### PR TITLE
Fixed bug 10844 - incorrect evaluation of threshold parameter, should us...

### DIFF
--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -2787,7 +2787,9 @@ Exec_stat MCIntersect::eval(MCExecPoint &ep)
 			return ES_ERROR;
 		}
 		
-		if (ep . ston() == ES_NORMAL)
+		// MW-2013-04-12: [[ Bug 10844 ]] Make sure we use ton(), otherwise it assumes
+		//   input is a string.
+		if (ep . ton() == ES_NORMAL)
 			t_threshold = ep . getuint4();
 		else
 		{

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4038,7 +4038,6 @@ bool MCObject::intersects(MCObject *p_other, uint32_t p_threshold)
 			memset(t_other_scanline, 0xff, t_scanline_width * 4);
 		
 		// Now check for overlap!
-		bool t_intersects;
 		t_intersects = false;
 		for(int32_t y = 0; y < t_rect . height; y++)
 		{


### PR DESCRIPTION
...e ton() rather than ston().
