### PR TITLE
fix building of revbuild.h header when $MODE not set

### DIFF
--- a/engine/Makefile.kernel
+++ b/engine/Makefile.kernel
@@ -51,6 +51,8 @@ linuxstubs.cpp: src/linux.stubs
 include/revbuild.h: include/revbuild.h.in ../version
 	../prebuilt/bin/Revolution.lnx "./encode_version.rev" "./"
 
-../_cache/linux/$(MODE)/$(NAME)/mcstring.o: include/revbuild.h
+include ../rules/environment.linux.makefile
+
+$(CACHE_DIR)/mcstring.o: include/revbuild.h
 
 include Makefile.kernel-common

--- a/engine/Makefile.kernel-server
+++ b/engine/Makefile.kernel-server
@@ -61,6 +61,8 @@ linuxstubs.cpp: src/linux.stubs
 encodederrors.cpp: src/executionerrors.h src/parseerrors.h
 	../prebuilt/bin/Revolution.lnx "./encode_errors.rev"  "./src" "./src/encodederrors.cpp"
 
-../_cache/linux/$(MODE)/$(NAME)/mcstring.o: include/revbuild.h
+include ../rules/environment.linux.makefile
+
+$(CACHE_DIR)/mcstring.o: include/revbuild.h
 
 include ../rules/archive.linux.makefile

--- a/rules/common.linux.makefile
+++ b/rules/common.linux.makefile
@@ -1,18 +1,6 @@
 # Common template Makefile for all types
 
-ifeq ($(MODE),)
-	MODE=debug
-endif
-
-ifeq ($(EDITION),)
-	SOLUTION_DIR=$(shell cat ../owner)/..
-else
-	SOLUTION_DIR=../livecode
-endif
-
-BUILD_DIR=$(SOLUTION_DIR)/_build/linux/$(MODE)
-CACHE_DIR=$(SOLUTION_DIR)/_cache/linux/$(MODE)/$(NAME)
-PRODUCT_DIR=$(BUILD_DIR)
+include $(dir $(lastword $(MAKEFILE_LIST)))/environment.linux.makefile
 
 DEFINES=$(CUSTOM_DEFINES) $(TYPE_DEFINES) _LINUX TARGET_PLATFORM_POSIX
 

--- a/rules/environment.linux.makefile
+++ b/rules/environment.linux.makefile
@@ -1,0 +1,15 @@
+# Common environment variables
+
+ifeq ($(MODE),)
+	MODE=debug
+endif
+
+ifeq ($(EDITION),)
+	SOLUTION_DIR=$(shell cat ../owner)/..
+else
+	SOLUTION_DIR=../livecode
+endif
+
+BUILD_DIR=$(SOLUTION_DIR)/_build/linux/$(MODE)
+CACHE_DIR=$(SOLUTION_DIR)/_cache/linux/$(MODE)/$(NAME)
+PRODUCT_DIR=$(BUILD_DIR)


### PR DESCRIPTION
factor out useful environment variables into environment.linux.makefile - update kernel makefiles to use this so we always have the correct path to the cache folder ($CACHE_DIR)
