### PR TITLE
changed super to sup in html tags

### DIFF
--- a/engine/src/fieldhtml.cpp
+++ b/engine/src/fieldhtml.cpp
@@ -114,7 +114,7 @@ static const char *s_export_html_tag_strings[] =
 	"b",
 	"strike",
 	"u",
-	"super",
+	"sup",
 	"sub",
 	"condensed",
 	"expanded",


### PR DESCRIPTION
This fixes bug 10905. getting htmltext is incorrectly using "super" instead of "sup" for superscript.
