### PR TITLE
[[ Bug 10794 ]] Ensure block pointers for extremities of links are updat...

### DIFF
--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -755,12 +755,14 @@ void MCField::getlinkdata(MCRectangle &lrect, MCBlock *&sb, MCBlock *&eb)
 	
 	// MW-2011-02-26: [[ Bug 9416 ]] Make sure the linkrect and block extends to the
 	//   extremities of the link.
+	// MW-2013-05-21: [[ Bug 10794 ]] Make sure we update sb/eb with the actual blocks
+	//   the indices are within.
 	uint2 t_index;
 	t_index = (uint2)si;
-	sptr -> extendup(sb, t_index);
+	sb = sptr -> extendup(sb, t_index);
 	si = t_index;
 	t_index = (uint2)(ei - 1);
-	sptr -> extenddown(eb, t_index);
+	eb = sptr -> extenddown(eb, t_index);
 	ei = t_index;
 	
 	linksi += si;

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -3019,7 +3019,9 @@ void MCParagraph::getxextents(int4 &si, int4 &ei, int2 &minx, int2 &maxx)
 	ei -= gettextsizecr();
 }
 
-Boolean MCParagraph::extendup(MCBlock *bptr, uint2 &si)
+// MW-2013-05-21: [[ Bug 10794 ]] Changed signature to return the block the search
+//   ends up in.
+MCBlock *MCParagraph::extendup(MCBlock *bptr, uint2 &si)
 {
 	Boolean isgroup = True;
 	Boolean found = False;
@@ -3044,10 +3046,12 @@ Boolean MCParagraph::extendup(MCBlock *bptr, uint2 &si)
 		bptr = bptr->next();
 	uint2 l;
 	bptr->getindex(si, l);
-	return found;
+	return bptr;
 }
 
-Boolean MCParagraph::extenddown(MCBlock *bptr, uint2 &ei)
+// MW-2013-05-21: [[ Bug 10794 ]] Changed signature to return the block the search
+//   ends up in.
+MCBlock *MCParagraph::extenddown(MCBlock *bptr, uint2 &ei)
 {
 	Boolean isgroup = True;
 	Boolean found = False;
@@ -3073,7 +3077,7 @@ Boolean MCParagraph::extenddown(MCBlock *bptr, uint2 &ei)
 	uint2 l;
 	bptr->getindex(ei, l);
 	ei += l;
-	return found;
+	return bptr;
 }
 
 void MCParagraph::getclickindex(int2 x, int2 y,

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -739,13 +739,13 @@ private:
 
 	MCLine *indextoline(uint2 tindex);
 
-	// Returns true if the given block is part of a link, in which case si is
-	// the start index of the link.
-	Boolean extendup(MCBlock *bptr, uint2 &si);
-
-	// Returns true if the given block is part of a link, in which case ei is
-	// the end index of the link.
-	Boolean extenddown(MCBlock *bptr, uint2 &ei);
+	// Searches forward for the end of a link, returning the last index in si
+	// and returning the block containing it.
+	MCBlock *extendup(MCBlock *bptr, uint2 &si);
+	
+	// Searches backward for the start of a link, returning the first index in ei
+	// and returning the block containing it.
+	MCBlock *extenddown(MCBlock *bptr, uint2 &ei);
 
 	int2 getx(uint2 tindex, MCLine *lptr);
 


### PR DESCRIPTION
...ed correctly so full link hilites (when, for example, broken by flaggedRanges).
