### PR TITLE
Fixed bug 10945 where the extra reference count during input control foc...

### DIFF
--- a/engine/src/mblcontrol.cpp
+++ b/engine/src/mblcontrol.cpp
@@ -378,8 +378,9 @@ void MCNativeControl::Finalize(void)
 bool MCNativeControl::List(MCNativeControlListCallback p_callback, void *p_context)
 {
 	for(MCNativeControl *t_control = s_native_controls; t_control != nil; t_control = t_control -> m_next)
-		if (!p_callback(p_context, t_control))
-			return false;
+		if (!t_control -> m_deleted)
+            if (!p_callback(p_context, t_control))
+                return false;
 	
 	return true;
 }


### PR DESCRIPTION
...us meant deleted mobile controls would appear in mobileControls()
