### PR TITLE
Enhanced filter command as discussed on forum

### DIFF
--- a/docs/dictionary/command/filter.xml
+++ b/docs/dictionary/command/filter.xml
@@ -3,7 +3,7 @@
   <name>filter</name>
   <type>command</type>
   <syntax>
-    <example>filter <i>container</i> {with | without} <i>filterPattern</i></example>
+    <example>filter [{lines | items} of] <i>containerOrExpression</i> {with | without | [not] matching} [{wildcard | regex} [pattern] <i>filterPattern</i>< [into <i>targetConteiner</i>]/example>
   </syntax>
   <library></library>
   <objects>
@@ -17,13 +17,14 @@
     <property tag="caseSensitive">caseSensitive Property</property>
     <function tag="matchChunk">matchChunk Function</function>
     <function tag="matchText">matchText Function</function>
+    <function tag="replaceText">replaceText Function</function>
     <command tag="replace">replace Command</command>
     <command tag="sort">sort Command</command>
-    <function tag="replaceText">replaceText Function</function>
   </references>
   <history>
     <introduced version="1.0">Added.</introduced>
     <changed version="2.1.1"></changed>
+    <changed version="6.1"></changed>
   </history>
   <platforms>
     <mac/>
@@ -40,14 +41,18 @@
   </classes>
   <security>
   </security>
-  <summary>Filters each <keyword tag="line">line</keyword> in a <glossary tag="container">container</glossary>, removing the <keyword tag="lines">lines</keyword> that do or don't match a pattern.</summary>
+  <summary>Filters each <keyword tag="line">line</keyword> or <keyword tag="item">item</keyword> in a source <glossary tag="container">container</glossary> or <glossary tag="expression">expression</glossary>, removing the <keyword tag="lines">lines</keyword> or <keyword tag="lines">items</keyword> that do or don't match a pattern.</summary>
   <examples>
     <example>filter myVariable with "A?2"</example>
     <example>filter me without "*[a-zA-Z]*"</example>
     <example>filter field 22 with "[0-9]*"</example>
     <example>filter field "Sorted Lines" with "[" &amp; mySelection &amp; "]"</example>
+    <example>filter items of theList matching regex pattern "b.*"</example>
+    <example>filter items of theList with wildcard pattern "b*" into theFilteredList</example>
+    <example>filter lines of (theFirstList & return & theSecondList) not matching "b*"</example>
+    <example>
   </examples>
   <description>
-    <p>Use the <b>filter</b> command to pick specific <keyword tag="lines">lines</keyword> in a <glossary tag="container">container</glossary>.</p><p/><p><b>Parameters:</b></p><p>The <i>container</i> is any <glossary tag="expression">expression</glossary> that <glossary tag="evaluate">evaluates</glossary> to a <glossary tag="container">container</glossary>.</p><p/><p>The <i>filterPattern</i> is an expression used to match certain <keyword tag="lines">lines</keyword>.</p><p/><p><b>Comments:</b></p><p>The filter...with form places the lines that contain a match for the specified <i>filterPattern</i> in the <i>container</i>, replacing the previous contents.</p><p/><p>The filter...without form places the lines that do not contain a match for the specified <i>filterPattern</i> in the <i>container</i>, replacing the previous contents.</p><p/><p>A <i>filterPattern</i> consists of a string of characters to match which may be combined with any number of the following special characters:</p><p/><p><b>*</b></p><p>Matches zero or more of any character. The <i>filterPattern</i> A*C matches "AC", "ABC", or "ADZXC".</p><p/><p><b>?</b></p><p>Matches exactly one character. The <i>filterPattern</i> A?C matches "ABC", but not "AC" or "ADZXC".</p><p/><p><b>[<i>chars</i>]</b></p><p>Matches any one of the characters inside the brackets. The <i>filterPattern</i> A[BC]D matches "ABD" or "ACD", but not "AD" or "ABCD".</p><p/><p><b>[<i>char</i>-<i>char</i>]</b></p><p>Matches any character whose ASCII value is between the first character and the second character.</p><p/><p><b>Changes:</b></p><p>The filter...without form was added in version 2.1.1. In previous versions, the <b>filter</b> <glossary tag="command">command</glossary> could be used only to retrieve <keyword tag="lines">lines</keyword> that matched a <glossary tag="wildcard">wildcard expression</glossary>.</p>
+    <p>Use the <b>filter</b> command to pick specific <keyword tag="lines">lines</keyword> or <keyword tag="items">items</keyword> in a <glossary tag="container">container</glossary> or <glossary tag="expression">expression</glossary>.</p><p/><p><b>Parameters:</b></p><p>The <i>container</i> is any <glossary tag="expression">expression</glossary> that <glossary tag="evaluate">evaluates</glossary> to a <glossary tag="container">container</glossary>.</p><p/><p>The <i>filterPattern</i> is an expression used to match certain <keyword tag="lines">lines</keyword> or <keyword tag="items">items</keyword>.</p><p/><p><b>Comments:</b></p><p>The filter...with form and the filter...matching form retain the lines or items that contain a match for the specified <i>filterPattern</i>.</p><p/><p>The filter...without form and the filter...not matching form discard the lines or items that do not contain a match for the specified <i>filterPattern</i>.</p><p/><p>A <glossary tag="wildcard">wildcard</glossary> <i>filterPattern</i> consists of a string of characters to match which may be combined with any number of the following special characters:</p><p/><p><b>*</b></p><p>Matches zero or more of any character. The <i>filterPattern</i> A*C matches "AC", "ABC", or "ADZXC".</p><p/><p><b>?</b></p><p>Matches exactly one character. The <i>filterPattern</i> A?C matches "ABC", but not "AC" or "ADZXC".</p><p/><p><b>[<i>chars</i>]</b></p><p>Matches any one of the characters inside the brackets. The <i>filterPattern</i> A[BC]D matches "ABD" or "ACD", but not "AD" or "ABCD".</p><p/><p><b>[<i>char</i>-<i>char</i>]</b></p><p>Matches any character whose ASCII value is between the first character and the second character.</p><p/><p><b>Changes:</b></p><p>The filter...without form was added in version 2.1.1. In previous versions, the <b>filter</b> <glossary tag="command">command</glossary> could be used only to retrieve <keyword tag="lines">lines</keyword> that matched a <glossary tag="wildcard">wildcard expression</glossary>.</p><p>The filter items... form was added in version 6.1. In previous versions, the <b>filter</b> <glossary tag="command">command</glossary> could be used only to retrieve <keyword tag="lines">lines</keyword>.</p><p>The ability to filter using a <glossary tag="regular expression">regular expression</glossary> was added in version 6.1. In previous versions, the <b>filter</b> <glossary tag="command">command</glossary> only supported <glossary tag="wildcard">wildcard expressions</glossary>.</p><p>The ability to filter an <glossary tag="expression">expression</glossary> was added in version 6.1. In previous versions, the <b>filter</b> <glossary tag="command">command</glossary> could be used only for a <glossary tag="container">container</glossary>.</p><p>The filter...[not] matching form was added in version 6.1 to clarify the pattern handling.</p><p>The filter...into form was added in version 6.1. In previous versions, the <b>filter</b> <glossary tag="command">command</glossary> always replaced the contents of the original <glossary tag="container">container</glossary>.</p>
   </description>
 </doc>

--- a/docs/notes/feature-enhanced_filter.md
+++ b/docs/notes/feature-enhanced_filter.md
@@ -1,0 +1,70 @@
+# Enhanced 'filter' command
+The **filter** command was enhanced to support:
+- filtering items in addition to lines
+- matching a regular expression in addition to wildcard patterns
+- storing the output in another container using an optional 'into' clause
+- as well as the adoption of 'convert' semantics.
+
+The new syntax is:
+`filter [ { lines | items } of ] <source_container_or_expr> { with | without | [ not ] matching } [ { wildcard | regex } [ pattern ] ] <pattern> [ into <target_container> ]`
+
+Note that the implementation is backward compatible as:
+- the default chunk type is 'lines'
+- and the default pattern type is 'wildcard'.
+
+## Filtering items
+In previous versions, the 'filter' command only supported the filtering of lines. Now you can also filter items in a source.
+For example, for a variable 'theList' containing a comma-separated list of strings:
+`foo,bar,baz,qux,quux,corge,grault,garply,waldo,fred,plugh,xyzzy,thud`
+The script line:
+`filter items of theList with "b*"`
+Would result in the variable 'theList' containing:
+`bar,baz`
+
+## Matching regular expressions
+In previous versions, the 'filter' command only supported matching a 'wildcard' pattern. Now you can use regular expression pattern matching as well.
+For example, for a variable 'theList' containing a comma-separated list of strings:
+`foo,bar,baz,qux,quux,corge,grault,garply,waldo,fred,plugh,xyzzy,thud`
+The script line:
+`filter items of theList with regex pattern "b.*"`
+Would result in the variable 'theList' containing:
+`bar,baz`
+Note that the keyword 'pattern' is optional syntactic sugar to clarify the intent of the script.
+
+## Storing the output in another container
+In previous versions, the 'filter' command always replaced the contents of the original container. Now you can opt to store the output in a separate container, allowing you to easily retain both the original and filtered data in separate variables.
+For example, for a variable 'theList' containing a comma-separated list of strings:
+`foo,bar,baz,qux,quux,corge,grault,garply,waldo,fred,plugh,xyzzy,thud`
+The script line:
+`filter items of theList with "b*" into theFilteredList`
+Would result in the variable 'theFilteredList' containing:
+`bar,baz`
+While the variable 'theList' still contains the original unfiltered data.
+
+## Adoption of 'convert' semantics
+In previous versions, the 'filter' command only supported containers as input, not expressions. Now you can use any expression as input, and the output is stored in a separate container (if the 'into' clause is used) or in the special 'it' variable.
+For example, for a variable 'theFirstList' containing a comma-separated list of strings:
+`foo,bar,baz,qux,quux,corge,grault`
+And a second variable 'theSecondList' containing another comma-separated list of strings:
+`garply,waldo,fred,plugh,xyzzy,thud`
+The script line:
+`filter items of theFirstList & comma & theSecondList with "b*" into theFilteredList`
+Would result in the variable 'theFilteredList' containing:
+`bar,baz`
+On the other hand, the script line:
+`filter items of theFirstList & comma & theSecondList with "b*"`
+Would result in the variable 'it' containing:
+`bar,baz`
+
+## Backward compatibility
+As stated above, the implementation is backward compatible.
+This means that the script line:
+`filter theList with "b*"`
+Is equivalent to the following, more explicit variants:
+`filter lines of theList with wildcard "b*"`
+`filter lines of theList matching wildcard pattern "b*"`
+Likewise, the script line:
+`filter theList without "b*"`
+Is equivalent to the following, more explicit variants:
+`filter lines of theList without wildcard "b*"`
+`filter lines of theList not matching wildcard pattern "b*"`

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1354,7 +1354,6 @@ public:
 	{
 		compiled = NULL;
 	}
-	virtual ~MCRegexMatcher();
 	virtual Exec_stat compile(uint2 line, uint2 pos);
 	virtual Boolean match(char *s);
 };

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1335,10 +1335,12 @@ class MCPatternMatcher
 {
 protected:
 	char *pattern;
+	Boolean casesensitive;
 public:
-	MCPatternMatcher(char *p)
+	MCPatternMatcher(char *p, Boolean cs)
 	{
 		pattern = strdup(p);
+		casesensitive = cs;
 	}
 	virtual ~MCPatternMatcher();
 	virtual Exec_stat compile(uint2 line, uint2 pos) = 0;
@@ -1350,7 +1352,7 @@ class MCRegexMatcher : public MCPatternMatcher
 protected:
 	regexp *compiled;
 public:
-	MCRegexMatcher(char *p) : MCPatternMatcher(p)
+	MCRegexMatcher(char *p, Boolean cs) : MCPatternMatcher(p, cs)
 	{
 		compiled = NULL;
 	}
@@ -1360,12 +1362,9 @@ public:
 
 class MCWildcardMatcher : public MCPatternMatcher
 {
-protected:
-	Boolean casesensitive;
 public:
-	MCWildcardMatcher(char *p, Boolean cs) : MCPatternMatcher(p)
+	MCWildcardMatcher(char *p, Boolean cs) : MCPatternMatcher(p, cs)
 	{
-		casesensitive = cs;
 	}
 	virtual Exec_stat compile(uint2 line, uint2 pos);
 	virtual Boolean match(char *s);

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1338,7 +1338,7 @@ protected:
 public:
 	MCPatternMatcher(char *p)
 	{
-		pattern = p;
+		pattern = strdup(p);
 	}
 	virtual ~MCPatternMatcher();
 	virtual Exec_stat compile(uint2 line, uint2 pos) = 0;
@@ -1354,6 +1354,7 @@ public:
 	{
 		compiled = NULL;
 	}
+	virtual ~MCRegexMatcher();
 	virtual Exec_stat compile(uint2 line, uint2 pos);
 	virtual Boolean match(char *s);
 };
@@ -1382,7 +1383,6 @@ class MCFilter : public MCStatement
 	MCExpression *source;
 	MCExpression *pattern;
 	Match_mode matchmode;
-	MCPatternMatcher *matcher;
 	Boolean discardmatches;
 public:
 	MCFilter()
@@ -1394,11 +1394,10 @@ public:
 		source = NULL;
 		pattern = NULL;
 		matchmode = MA_UNDEFINED;
-		matcher = NULL;
 		discardmatches = False;
 	}
 	virtual ~MCFilter();
-	char *filterdelimited(char *sstring, char delimiter);
+	char *filterdelimited(char *sstring, char delimiter, MCPatternMatcher *matcher);
 	virtual Parse_stat parse(MCScriptPoint &);
 	virtual Exec_stat exec(MCExecPoint &);
 };

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -19,6 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "statemnt.h"
 #include "objdefs.h"
+#include "regex.h"
 #include "util.h"
 #include "uidc.h"
 

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -1150,7 +1150,7 @@ Exec_stat MCRegexMatcher::compile(uint2 line, uint2 pos)
 			MCregexpatterns[i] = MCregexpatterns[i - 1];
 		}
 		MCregexpatterns[0] = pstring;
-		MCregexcache[0] = MCR_compile(MCregexpatterns[0]);
+		MCregexcache[0] = MCR_compile(MCregexpatterns[0], casesensitive);
 		compiled = MCregexcache[0];
 	}
 	else
@@ -1497,7 +1497,7 @@ Exec_stat MCFilter::exec(MCExecPoint &ep)
 	// Create the pattern matcher
 	MCPatternMatcher *matcher;
 	if (matchmode == MA_REGEX)
-        matcher = new MCRegexMatcher(pptr);
+        matcher = new MCRegexMatcher(pptr, ep.getcasesensitive());
     else
 		matcher = new MCWildcardMatcher(pptr, ep.getcasesensitive());
 	stat = matcher->compile(line, pos);

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -1130,31 +1130,7 @@ MCPatternMatcher::~MCPatternMatcher()
 
 Exec_stat MCRegexMatcher::compile(uint2 line, uint2 pos)
 {
-	char *pstring = strdup(pattern);
-	uint2 i;
-	for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
-	{
-		if (strequal(pstring, MCregexpatterns[i]))
-		{
-			compiled = MCregexcache[i];
-			break;
-		}
-	}
-	if (compiled == NULL)
-	{
-		delete MCregexpatterns[PATTERN_CACHE_SIZE - 1];
-		MCR_free(MCregexcache[PATTERN_CACHE_SIZE - 1]);
-		for (i = PATTERN_CACHE_SIZE - 1 ; i ; i--)
-		{
-			MCregexcache[i] = MCregexcache[i - 1];
-			MCregexpatterns[i] = MCregexpatterns[i - 1];
-		}
-		MCregexpatterns[0] = pstring;
-		MCregexcache[0] = MCR_compile(MCregexpatterns[0], casesensitive);
-		compiled = MCregexcache[0];
-	}
-	else
-		delete pstring;
+	compiled = MCR_compile(pattern, True /* usecache */, casesensitive);
 	if (compiled == NULL)
 	{
 		MCeerror->add
@@ -1178,7 +1154,7 @@ Exec_stat MCWildcardMatcher::compile(uint2 line, uint2 pos)
 #define OPEN_BRACKET '['
 #define CLOSE_BRACKET ']'
 
-Boolean MCWildcardMatcher::match(char *s, char *p, Boolean casesensitive)
+/* static */ Boolean MCWildcardMatcher::match(char *s, char *p, Boolean casesensitive)
 {
 	uint1 scc, c;
     

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -1128,18 +1128,13 @@ MCPatternMatcher::~MCPatternMatcher()
 	delete pattern;
 }
 
-MCRegexMatcher::~MCRegexMatcher()
-{
-	// do not delete, but nullify as MCregexcache owns the reference
-	compiled = NULL;
-}
-
 Exec_stat MCRegexMatcher::compile(uint2 line, uint2 pos)
 {
+	char *pstring = strdup(pattern);
 	uint2 i;
 	for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
 	{
-		if (strequal(pattern, MCregexpatterns[i]))
+		if (strequal(pstring, MCregexpatterns[i]))
 		{
 			compiled = MCregexcache[i];
 			break;
@@ -1154,10 +1149,12 @@ Exec_stat MCRegexMatcher::compile(uint2 line, uint2 pos)
 			MCregexcache[i] = MCregexcache[i - 1];
 			MCregexpatterns[i] = MCregexpatterns[i - 1];
 		}
-		MCregexpatterns[0] = pattern;
+		MCregexpatterns[0] = pstring;
 		MCregexcache[0] = MCR_compile(MCregexpatterns[0]);
 		compiled = MCregexcache[0];
 	}
+	else
+		delete pstring;
 	if (compiled == NULL)
 	{
 		MCeerror->add

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -61,9 +61,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "core.h"
 
-char *MCregexpatterns[PATTERN_CACHE_SIZE];
-regexp *MCregexcache[PATTERN_CACHE_SIZE];
-
 #define GZIP_HEAD_CRC     0x02 /* bit 1 set: header CRC present */
 #define GZIP_EXTRA_FIELD  0x04 /* bit 2 set: extra field present */
 #define GZIP_ORIG_NAME    0x08 /* bit 3 set: original file name present */
@@ -3200,29 +3197,9 @@ Exec_stat MCMatch::eval(MCExecPoint &ep)
 		return ES_ERROR;
 	}
 	char *pstring = ep.getsvalue().clone();
-	regexp *compiled = NULL;
-	uint2 i;
-	for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
-		if (strequal(pstring, MCregexpatterns[i]))
-		{
-			compiled = MCregexcache[i];
-			break;
-		}
-	if (compiled == NULL)
-	{
-		delete MCregexpatterns[PATTERN_CACHE_SIZE - 1];
-		MCR_free(MCregexcache[PATTERN_CACHE_SIZE - 1]);
-		for (i = PATTERN_CACHE_SIZE - 1 ; i ; i--)
-		{
-			MCregexcache[i] = MCregexcache[i - 1];
-			MCregexpatterns[i] = MCregexpatterns[i - 1];
-		}
-		MCregexpatterns[0] = pstring;
-		MCregexcache[0] = MCR_compile(MCregexpatterns[0]);
-		compiled = MCregexcache[0];
-	}
-	else
-		delete pstring;
+    // JS-2013-06-21: [[ EnhancedFilter ]] refactored regex caching mechanism and case sentitivity
+	regexp *compiled = MCR_compile(pstring, True /* usecache */, True /* casesensitive */);
+    delete pstring;
 	if (compiled == NULL)
 	{
 		MCeerror->add
@@ -3243,7 +3220,7 @@ Exec_stat MCMatch::eval(MCExecPoint &ep)
 	match = MCR_exec(compiled, ep.getsvalue().getstring(), ep.getsvalue().getlength());
 
 	MCParameter *p = params->getnext()->getnext();
-	i = 1;
+	uint2 i = 1;
 	if (chunk)
 	{
 		while (p != NULL && p->getnext() != NULL)
@@ -4041,33 +4018,12 @@ Exec_stat MCReplaceText::eval(MCExecPoint &ep)
 		return ES_NORMAL;
 	}
 	char *pstring = ep.getsvalue().clone();
-
-	regexp *compiled = NULL;
-	const char *pattern = NULL;
-	uint2 i;
-	for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
-		if (strequal(pstring, MCregexpatterns[i]))
-		{
-			compiled = MCregexcache[i];
-			pattern = MCregexpatterns[i];
-			break;
-		}
-	if (compiled == NULL)
-	{
-		delete MCregexpatterns[PATTERN_CACHE_SIZE - 1];
-		MCR_free(MCregexcache[PATTERN_CACHE_SIZE - 1]);
-		uint2 i;
-		for (i = PATTERN_CACHE_SIZE - 1 ; i ; i--)
-		{
-			MCregexcache[i] = MCregexcache[i - 1];
-			MCregexpatterns[i] = MCregexpatterns[i - 1];
-		}
-		pattern = MCregexpatterns[0] = pstring;
-		MCregexcache[0] = MCR_compile(MCregexpatterns[0]);
-		compiled = MCregexcache[0];
-	}
-	else
-		delete pstring;
+    const char *pattern = NULL;
+    // JS-2013-06-21: [[ EnhancedFilter ]] refactored regex caching mechanism and case sentitivity
+	regexp *compiled = MCR_compile(pstring, True /*usecache*/, True /*casesensitive*/);
+    delete pstring;
+    if (compiled != NULL)
+        pattern = compiled->pattern;
 	if (compiled == NULL)
 	{
 		delete rstring;

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -810,11 +810,7 @@ void X_clear_globals(void)
 	MCnullmcstring = NULL;
 
 	// MW-2013-03-11: [[ Bug 10713 ]] Make sure we reset the regex cache globals to nil.
-	for(uindex_t i = 0; i < PATTERN_CACHE_SIZE; i++)
-	{
-		MCregexpatterns[i] = nil;
-		MCregexcache[i] = nil;
-	}
+	MCR_clearcache();
 
 	for(uint32_t i = 0; i < PI_NCURSORS; i++)
 		MCcursors[i] = nil;
@@ -1091,12 +1087,8 @@ int X_close(void)
 		MCglobals = MCglobals->getnext();
 		delete tvar;
 	}
-	uint2 i;
-	for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
-	{
-		delete MCregexpatterns[i];
-		MCR_free(MCregexcache[i]);
-	}
+	// JS-2013-06-21: [[ EnhancedFilter ]] refactored regex caching mechanism
+    MCR_clearcache();
 	delete MCperror;
 	delete MCeerror;
 

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -1907,15 +1907,19 @@ static LT sugar_table[] =
 		// MM-2012-09-05: [[ Property Listener ]] Syntax: cancel listener for [object]
 		{"listener", TT_UNDEFINED, SG_LISTENER},
 #endif
+        {"matching", TT_PREP, PT_MATCHING},
         {"message", TT_CHUNK, CT_UNDEFINED},
         {"new", TT_CHUNK, CT_UNDEFINED},
 		{"nothing", TT_UNDEFINED, SG_NOTHING},
 		{"open", TT_UNDEFINED, SG_OPEN},
 		{"optimized", TT_UNDEFINED, SG_OPTIMIZED},
 		{"options", TT_UNDEFINED, SG_OPTIONS},
+		{"pattern", TT_UNDEFINED, SG_PATTERN},
+		{"regex", TT_UNDEFINED, SG_REGEX},
 		{"standard", TT_UNDEFINED, SG_STANDARD},
 		{"unicode", TT_UNDEFINED, SG_UNICODE},
 		{"url", TT_UNDEFINED, SG_URL},
+		{"wildcard", TT_UNDEFINED, SG_WILDCARD},
 		{"without", TT_PREP, PT_WITHOUT},
     };
 

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -20,14 +20,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef	PARSEDEFS_H
 #define	PARSEDEFS_H
 
-// for regex
-#define PATTERN_CACHE_SIZE 20
-extern char *MCregexpatterns[];
-
-#define NSUBEXP  50
-typedef struct _regexp regexp;
-extern regexp *MCregexcache[];
-
 typedef struct _constant
 {
 	MCString name;

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -705,6 +705,12 @@ enum Mark_constants {
     MC_WHERE
 };
 
+enum Match_mode {
+    MA_UNDEFINED,
+    MA_WILDCARD,
+    MA_REGEX
+};
+
 enum Move_mode {
     MM_UNDEFINED,
     MM_MESSAGES,
@@ -850,7 +856,8 @@ enum Preposition_type {
 	PT_CONTENT,
 	PT_MARKUP,
 	PT_BINARY,
-	PT_COOKIE
+	PT_COOKIE,
+    PT_MATCHING
 };
 
 enum Print_mode {
@@ -1751,6 +1758,9 @@ enum Sugar_constants {
 	SG_OPEN,
 	SG_CLOSED,
 	SG_CALLER,
+    SG_PATTERN,
+    SG_REGEX,
+    SG_WILDCARD
 };
 
 enum Statements {

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -2167,7 +2167,7 @@ Exec_stat MCProperty::set(MCExecPoint &ep)
 			else
 			{
 				regexp *t_net_int_regex;
-				t_net_int_regex = MCR_compile("\\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b");
+				t_net_int_regex = MCR_compile("\\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b", False /* usecache */, True /* casesensitive */);
 				int t_net_int_valid;
 				t_net_int_valid = MCR_exec(t_net_int_regex, ep.getsvalue().getstring(), ep.getsvalue().getlength());
 				MCR_free(t_net_int_regex);			

--- a/engine/src/regex.cpp
+++ b/engine/src/regex.cpp
@@ -296,31 +296,60 @@ int regexec(regex_t *preg, const char *string, int len, size_t nmatch,
 
 static char regexperror[100];
 
+regexp *MCregexcache[PATTERN_CACHE_SIZE];
+
 const char *MCR_geterror()
 {
 	return regexperror;
 }
 
-regexp *MCR_compile(char *exp)
+regexp *MCR_compile(char *exp, Boolean usecache, Boolean casesensitive)
 {
-    // JS-2013-06-21: [[ EnhancedFilter ]] case sensitive regex matching
-    return MCR_compile(exp, True);
-}
-
-// JS-2013-06-21: [[ EnhancedFilter ]] case sensitive regex matching
-regexp *MCR_compile(char *exp, Boolean casesensitive)
-{
-	regexp *re = new regexp;
-	int status;
+	Boolean found = False;
+	regexp *re = NULL;
 	int flags = REG_EXTENDED;
     if (!casesensitive)
         flags |= REG_ICASE;
-	status = regcomp(&re->rexp, exp, flags);
-	if (status != REG_OKAY)
+
+	if (usecache)
 	{
-		regerror(status, NULL, regexperror, sizeof(regexperror));
-		delete re;
-		return(NULL);
+		uint2 i;
+		for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
+		{
+			if (MCregexcache[i]
+				&& strequal(exp, MCregexcache[i]->pattern)
+				&& flags == MCregexcache[i]->flags)
+			{
+				found = True;
+				re = MCregexcache[i];
+				break;
+			}
+		}
+	}
+	if (re == NULL)
+	{
+		re = new regexp;
+		re->pattern = strdup(exp);
+		re->flags = flags;
+		int status;
+		status = regcomp(&re->rexp, exp, flags);
+		if (status != REG_OKAY)
+		{
+			regerror(status, NULL, regexperror, sizeof(regexperror));
+			delete re->pattern;
+			delete re;
+			return(NULL);
+		}
+	}
+	if (usecache && !found)
+	{
+		uint2 i;
+		MCR_free(MCregexcache[PATTERN_CACHE_SIZE - 1]);
+		for (i = PATTERN_CACHE_SIZE - 1 ; i ; i--)
+		{
+			MCregexcache[i] = MCregexcache[i - 1];
+		}
+		MCregexcache[0] = re;
 	}
 	return re;
 }
@@ -348,5 +377,14 @@ void MCR_free(regexp *prog)
 	{
 		regfree(&prog->rexp);
 		delete prog;
+	}
+}
+
+void MCR_clearcache()
+{
+	uint2 i;
+	for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
+	{
+		MCR_free(MCregexcache[i]);
 	}
 }

--- a/engine/src/regex.cpp
+++ b/engine/src/regex.cpp
@@ -303,9 +303,18 @@ const char *MCR_geterror()
 
 regexp *MCR_compile(char *exp)
 {
+    // JS-2013-06-21: [[ EnhancedFilter ]] case sensitive regex matching
+    return MCR_compile(exp, True);
+}
+
+// JS-2013-06-21: [[ EnhancedFilter ]] case sensitive regex matching
+regexp *MCR_compile(char *exp, Boolean casesensitive)
+{
 	regexp *re = new regexp;
 	int status;
 	int flags = REG_EXTENDED;
+    if (!casesensitive)
+        flags |= REG_ICASE;
 	status = regcomp(&re->rexp, exp, flags);
 	if (status != REG_OKAY)
 	{

--- a/engine/src/regex.h
+++ b/engine/src/regex.h
@@ -58,6 +58,8 @@ regexp;
 
 const char *MCR_geterror();
 regexp *MCR_compile(char *exp);
+// JS-2013-06-21: [[ EnhancedFilter ]] case sensitive regex matching
+regexp *MCR_compile(char *exp, Boolean casesensitive);
 int MCR_exec(regexp *prog, const char *string, uint4 len);
 void MCR_free(regexp *prog);
 

--- a/engine/src/regex.h
+++ b/engine/src/regex.h
@@ -24,7 +24,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define REG_OKAY 0
 
 #define PATTERN_CACHE_SIZE 20
-extern char *MCregexpatterns[];
 
 //regex structure
 typedef struct
@@ -51,17 +50,17 @@ regmatch_t;
 typedef struct _regexp
 {
 	regex_t rexp;
+    char *pattern;
+    int flags;
 	uint2 nsubs;
 	regmatch_t matchinfo[NSUBEXP];
 }
 regexp;
 
 const char *MCR_geterror();
-regexp *MCR_compile(char *exp);
-// JS-2013-06-21: [[ EnhancedFilter ]] case sensitive regex matching
-regexp *MCR_compile(char *exp, Boolean casesensitive);
+regexp *MCR_compile(char *exp, Boolean usecache, Boolean casesensitive);
 int MCR_exec(regexp *prog, const char *string, uint4 len);
 void MCR_free(regexp *prog);
+void MCR_clearcache();
 
-extern regexp *MCregexcache[];
 #endif


### PR DESCRIPTION
Enhanced filter command with chunk support, regex support, into clause and convert semantics, as discussed on the engine forum.
New syntax:
    filter [ ( lines | items ) of ] <container_or_exp>
           ( with | without | [ not ] matching )
           [ { wildcard | regex } [ pattern ] ] <pattern>
           [ into <container> ]
The implementation is compatible with existing scripts.
