### PR TITLE
[[ Bug 11018 ]] prevent crash when opening a rotated referenced image wi...

### DIFF
--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -67,6 +67,8 @@ MCImage::MCImage()
 	m_transformed = nil;
 	m_image_opened = false;
 
+	m_locked_frame = nil;
+
 	m_have_control_colors = false;
 	m_control_colors = nil;
 	m_control_color_names = nil;
@@ -87,6 +89,8 @@ MCImage::MCImage(const MCImage &iref) : MCControl(iref)
 	m_rep = nil;
 	m_transformed = nil;
 	m_image_opened = false;
+
+	m_locked_frame = nil;
 
 	m_have_control_colors = false;
 	m_control_colors = nil;

--- a/engine/src/image_rep.cpp
+++ b/engine/src/image_rep.cpp
@@ -85,7 +85,7 @@ uindex_t MCCachedImageRep::GetFrameCount()
 	if (!m_have_geometry)
 	{
 		if (!EnsureImageFrames())
-			return false;
+			return 0;
 	}
 
 	return m_frame_count;
@@ -157,7 +157,7 @@ void MCCachedImageRep::UnlockImageFrame(uindex_t p_index, MCImageFrame *p_frame)
 
 uint32_t MCCachedImageRep::GetFrameByteCount()
 {
-	if (m_frames == nil)
+	if (m_frames == nil || m_frame_count == 0)
 		return 0;
 
 	return (m_frames[0].image->height * m_frames[0].image->stride + sizeof(MCImageBitmap) + sizeof(MCImageFrame)) * m_frame_count;

--- a/engine/src/image_rep_transformed.cpp
+++ b/engine/src/image_rep_transformed.cpp
@@ -84,7 +84,11 @@ bool MCTransformedImageRep::LoadImageFrames(MCImageFrame *&r_frames, uindex_t &r
 	
 	t_frame_count = m_source->GetFrameCount();
 	
-	t_success = MCMemoryNewArray(t_frame_count, t_frames);
+	// IM-2013-07-03: [[ Bug 11018 ]] fail here if the source has no frames
+	t_success = t_frame_count != 0;
+
+	if (t_success)
+		t_success = MCMemoryNewArray(t_frame_count, t_frames);
 	
 	for (uindex_t i = 0; t_success && i < t_frame_count; i++)
 	{


### PR DESCRIPTION
...th an invalid filename
