### PR TITLE
[[ Bug 11039 ]] MCU_matchname tightened matching of names of the form '<...

### DIFF
--- a/docs/notes/bugfix-11039.md
+++ b/docs/notes/bugfix-11039.md
@@ -1,0 +1,11 @@
+# Resolving object chunks does not throw an error for long chunk references.
+When using named object chunks such as 'control <name>' or 'field <name>', the engine only accepts <name> of the form:
+* The short name of the object (e.g. 'foo')
+* The name of the object (e.g. 'field "foo"')
+Previously, in the case of matching a name, the engine would only match the prefix ignoring everything after it.
+This resulted in things like 'field the long id of field "foo"' potentially resolving incorrectly.
+This issue has now been fixed - when using named object chunks, <name>, must either be just a name, or a string of the form '<type> "<name>"'.
+To resolve long id/long name references, there is no need for a chunk and you should just use the variable directly:
+    put the long id of field "foo" into tFooRef
+    answer the short name of tFooRef
+

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -1189,16 +1189,25 @@ Boolean MCU_matchname(const MCString &test, Chunk_term type, MCNameRef name)
 	        MCepsstring, MCmagnifierstring,
 	        MCcolorstring, MCfieldstring
 	    };
+	
+	// MW-2013-07-29: [[ Bug 11068 ]] Make sure that we only match a reference
+	//   of the form 'field "..."', and throw an error if not.
 	const char *sptr = test.getstring();
 	uint4 l = test.getlength();
 	if (MCU_strchr(sptr, l, '"')
-	        && l > tname.getlength() + 1
+			&& l > tname.getlength() + 1
 	        && sptr[tname.getlength() + 1] == '"'
 	        && !MCU_strncasecmp(sptr + 1, tname.getstring(), tname.getlength())
 	        && sptr - test.getstring() >= (int)strlen(nametable[type - CT_STACK])
 	        && !MCU_strncasecmp(test.getstring(), nametable[type - CT_STACK],
 	                            strlen(nametable[type - CT_STACK])))
-		match = True;
+	{
+		if (l == tname.getlength() + 2)
+			match = True;
+		
+		if (!match)
+			MCLog("[[ Bug 11068 ]] match name '%s' to '%.*s' attempted and failed due to better checking", MCNameGetCString(name), test . getlength(), test . getstring());
+	}
 
 	return match;
 }


### PR DESCRIPTION
...chunk> "<name>"'.
