### PR TITLE
[[ Bug 10979 ]] Made use of call 'registerForRemoteNotificationTypes:' d...

### DIFF
--- a/docs/notes/bugfix-10979.md
+++ b/docs/notes/bugfix-10979.md
@@ -1,0 +1,2 @@
+# App store submission warns about lack of push notification entitlement even for apps not using push notifications.
+

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -305,7 +305,10 @@ static UIDeviceOrientation patch_device_orientation(id self, SEL _cmd)
     if (t_allowed_notifications != UIRemoteNotificationTypeNone)
     {
         // Inform the device what kind of push notifications we can handle.
-        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:t_allowed_notifications];
+		
+		// MW-2013-07-29: [[ Bug 10979 ]] Dynamically call the 'registerForRemoteNotificationTypes' to
+		//   avoid app-store warnings.
+		objc_msgSend([[UIApplication sharedApplication], sel_getUid("registerForRemoteNotificationTypes:"), t_allowed_notifications);
     }
 }
 


### PR DESCRIPTION
...ynamic to (hopefully) stop app-store warnings.
