### PR TITLE
[[ Bug 10981 ]] Allow the empty name for objects

### DIFF
--- a/docs/notes/bugfix-10981.md
+++ b/docs/notes/bugfix-10981.md
@@ -1,0 +1,3 @@
+# Getting 'the short name' of an object returns the abbrev id if the name property is empty
+
+Previously the empty name for objects was not allowed, and the abbreviated id was returned instead for both 'the name' and 'the short name' of an object. This change allows objects to have the empty name, and adjusts the properties accordingly: 'the name' of such an object returns '<object type> ""', and 'the short name' returns empty. 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2090,19 +2090,21 @@ Exec_stat MCObject::names(Properties which, MCExecPoint &ep, uint4 parid)
 			ep.appendmcstring(ep2.getsvalue());
 		}
 		break;
-	case P_NAME:
-	case P_ABBREV_NAME:
-		if (isunnamed())
-			stat = getprop(parid, P_ABBREV_ID, ep, False);
-		else
-			ep.setstringf("%s \"%s\"", itypestring, getname_cstring());
-		break;
-	case P_SHORT_NAME:
-		if (isunnamed())
-			stat = names(P_ABBREV_ID, ep, parid);
-		else
-			ep.setnameref_unsafe(getname());
-		break;
+    case P_NAME:
+    case P_ABBREV_NAME:
+        if (isunnamed())
+            // AL-2013-07-29: [[ Bug 10981 ]] Allow the empty name for objects.
+            ep.setstringf("%s \"\"", itypestring);
+        else
+            ep.setstringf("%s \"%s\"", itypestring, getname_cstring());
+        break;
+    case P_SHORT_NAME:
+        if (isunnamed())
+            // AL-2013-07-29: [[ Bug 10981 ]] Allow the empty name for objects.
+            ep . clear();
+        else
+            ep.setnameref_unsafe(getname());
+        break;
 	case P_LONG_NAME:
 		// MW-2013-01-15: [[ Bug 2629 ]] If this control is unnamed, use the abbrev id form
 		//   but *only* for this control (continue with names the rest of the way).

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -1169,8 +1169,12 @@ Boolean MCU_matchflags(const MCString &s, uint4 &flags, uint4 w, Boolean &c)
 
 Boolean MCU_matchname(const MCString &test, Chunk_term type, MCNameRef name)
 {
-	if (name == nil || MCNameIsEmpty(name) || test == MCnullmcstring)
-		return False;
+    if (name == nil)
+        return False;
+    
+    // AL-2013-07-29: [[ Bug 10981 ]] Allow the empty name for objects.
+	if (MCNameIsEmpty(name) && test == MCnullmcstring)
+		return True;
 
 	if (MCNameIsEqualToOldString(name, test, kMCCompareCaseless))
 		return True;


### PR DESCRIPTION
This is a change in functionality so should go into develop rather than a maintenance release.
