### PR TITLE
[[ Bugfix 11081 ]] translate local -> global coords when taking snapshot...

### DIFF
--- a/docs/notes/bugfix-11081.md
+++ b/docs/notes/bugfix-11081.md
@@ -1,0 +1,1 @@
+# Dropper dool does not work on OSX

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -537,7 +537,7 @@ public:
 	void handlemoves(real8 &curtime, real8 &eventtime);
 	void siguser();
 	Boolean lookupcolor(const MCString &s, MCColor *color);
-	void dropper(Drawable d, int2 mx, int2 my, MCColor *cptr);
+	void dropper(Window w, int2 mx, int2 my, MCColor *cptr);
 	Boolean parsecolor(const MCString &s, MCColor *color, char **cname);
 	Boolean parsecolors(const MCString &values, MCColor *colors,
 	                    char *cnames[], uint2 ncolors);


### PR DESCRIPTION
... for dropper on OSX
