### PR TITLE
[[ Bug 10957 ]] Pass in paragraph byte offset rather than char offset to...

### DIFF
--- a/docs/notes/bugfix-10957.md
+++ b/docs/notes/bugfix-10957.md
@@ -1,0 +1,1 @@
+# The 'flaggedRanges' property can sometimes report the wrong values in a field containing mixed unicode and non-unicode text.

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -1004,25 +1004,25 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 			// Start with an empty result.
 			ep . clear();
 
-			// The ranges are adjusted by the index of the first char (i.e. they are
-			// relative to the start of the range.
-			int32_t t_index_offset;
-			t_index_offset = -countchars(parid, 0, si);
-
+			// MW-2013-07-31: [[ Bug 10957 ]] Keep track of the byte index of the start
+			//   of the paragraph.
+			int32_t t_paragraph_offset;
+			t_paragraph_offset = 0;
+			
 			// Loop through the paragraphs until the range is exhausted.
 			do
 			{
 				// Fetch the flagged ranges into ep between si and ei (sptr relative)
 				// making sure the ranges are adjusted to the start of the range.
-				sptr -> getflaggedranges(parid, ep, si, ei, t_index_offset);
-
-				// MW-2013-05-22: [[ Bug 10908 ]] Increment the offset by the size of the
-				//   paragraph in codepoints not bytes.
-				t_index_offset += sptr -> gettextlength() + 1;
-
+				sptr -> getflaggedranges(parid, ep, si, ei, t_paragraph_offset);
+				
+				// MW-2013-07-31: [[ Bug 10957 ]] Update the paragraph (byte) offset.
+				t_paragraph_offset += sptr -> gettextsizecr();
+				
 				// Reduce ei until we get to zero, advancing through the paras.
 				si = 0;
 				ei -= sptr -> gettextsizecr();
+				
 				sptr = sptr -> next();
 			}
 			while(ei > 0);

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -3316,7 +3316,7 @@ bool MCParagraph::getflagstate(uint32_t flag, uint2 si, uint2 ei, bool& r_state)
 // This method accumulates the ranges of the paragraph that have 'flagged' set
 // to true. The output is placed in ep as a return-delimited list, with indices
 // adjusted by the 'delta'.
-void MCParagraph::getflaggedranges(uint32_t p_part_id, MCExecPoint& ep, uint2 si, uint2 ei, int32_t p_delta)
+void MCParagraph::getflaggedranges(uint32_t p_part_id, MCExecPoint& ep, uint2 si, uint2 ei, int32_t p_paragraph_start)
 {
 	// If the paragraph is empty, there is nothing to do.
 	if (textsize == 0)
@@ -3365,10 +3365,10 @@ void MCParagraph::getflaggedranges(uint32_t p_part_id, MCExecPoint& ep, uint2 si
 				
 				// MW-2012-02-24: [[ FieldChars ]] Map the field indices back to char indices.
 				int32_t t_start, t_end;
-				t_start = t_flagged_start;
-				t_end = t_flagged_end;
+				t_start = p_paragraph_start + t_flagged_start;
+				t_end = p_paragraph_start + t_flagged_end;
 				parent -> unresolvechars(p_part_id, t_start, t_end);
-				ep.appendstringf("%d,%d", t_start + p_delta + 1, t_end + p_delta);
+				ep.appendstringf("%d,%d", t_start + 1, t_end);
 
 				t_flagged_start = t_flagged_end = -1;
 			}

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -448,8 +448,10 @@ public:
 	//   flagged status set to true - these are then adjusted by delta.
 	// MW-2012-02-24: [[ FieldChars ]] Pass in the part_id so the paragraph can map
 	//   field indices to char indices.
-	void getflaggedranges(uint32_t p_part_id, MCExecPoint& ep, uint2 si, uint2 ei, int32_t p_delta);
-    
+	// MW-2013-07-31: [[ Bug 10957 ]] Pass in the start of the paragraph as a byte
+	//   offset so that the correct char offset can be calculated.
+	void getflaggedranges(uint32_t p_part_id, MCExecPoint& ep, uint2 si, uint2 ei, int32_t p_paragraph_start);
+
 	// Return true if the paragraph completely fits in theight. Otherwise, return
 	// false and set lastline to the line that would be clipped.
 	// Called by:


### PR DESCRIPTION
... MCParagraph::getflaggedranges() to ensure returned values are correct.
