### PR TITLE
[[ Bug 10925 ]] Add/Subtract/Multiply/Divide now extract the varref from...

### DIFF
--- a/docs/notes/bugfix-10925.md
+++ b/docs/notes/bugfix-10925.md
@@ -1,0 +1,1 @@
+# Using add/subtract/multiply/divide on a variable that has not been declared causes subexpressions to be evaluated twice.

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -2729,6 +2729,21 @@ bool MCChunk::islinechunk(void) const
 	return false;
 }
 
+// MW-2013-08-01: [[ Bug 10925 ]] Returns true if the chunk is just a var or indexed var.
+bool MCChunk::isvarchunk(void) const
+{
+	if (source != nil)
+		return false;
+	
+	if (cline != nil || item != nil || token != nil || word != nil || character != nil)
+		return false;
+	
+	if (destvar != nil)
+		return true;
+	
+	return false;
+}
+
 // This method works out the start and end points of the text chunk in the
 // given field.
 //

--- a/engine/src/chunk.h
+++ b/engine/src/chunk.h
@@ -101,6 +101,9 @@ public:
 
 	// Returns true if this chunk is of text type and stops at line
 	bool islinechunk(void) const;
+	
+	// Returns true if this chunk is a var, or indexed var
+	bool isvarchunk(void) const;
 
 	// Returns the field, part and range of the text chunk
 	Exec_stat marktextchunk(MCExecPoint& ep, MCField*& r_field, uint4& r_part, uint4& r_start, uint4& r_end);

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -58,7 +58,10 @@ MCAdd::~MCAdd()
 {
 	delete source;
 	delete dest;
-	delete destvar;
+	// MW-2013-08-01: [[ Bug 10925 ]] Only delete the destvar varref if dest is NULL,
+	//   otherwise its owned by dest.
+	if (dest == NULL)
+		delete destvar;
 }
 
 Parse_stat MCAdd::parse(MCScriptPoint &sp)
@@ -89,6 +92,10 @@ Parse_stat MCAdd::parse(MCScriptPoint &sp)
 	}
 	else
 		destvar->parsearray(sp);
+	
+	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
+	if (dest != NULL && dest -> isvarchunk())
+		destvar = dest -> getrootvarref();
 
 	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
@@ -111,7 +118,7 @@ Exec_stat MCAdd::exec(MCExecPoint &ep)
 
 	if (overlap)
 		ep . grab();
-
+	
 	if (destvar != NULL && destvar -> evalcontainer(ep, t_dst_var, t_dst_ref) != ES_NORMAL)
 	{
 		MCeerror->add(EE_ADD_BADDEST, line, pos);
@@ -176,7 +183,10 @@ MCDivide::~MCDivide()
 {
 	delete source;
 	delete dest;
-	delete destvar;
+	// MW-2013-08-01: [[ Bug 10925 ]] Only delete the destvar varref if dest is NULL,
+	//   otherwise its owned by dest.
+	if (dest == NULL)
+		delete destvar;
 }
 
 Parse_stat MCDivide::parse(MCScriptPoint &sp)
@@ -208,7 +218,11 @@ Parse_stat MCDivide::parse(MCScriptPoint &sp)
 		MCperror->add(PE_DIVIDE_BADEXP, sp);
 		return PS_ERROR;
 	}
-
+	
+	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
+	if (dest != NULL && dest -> isvarchunk())
+		destvar = dest -> getrootvarref();
+	
 	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
 	return PS_NORMAL;
@@ -315,7 +329,10 @@ MCMultiply::~MCMultiply()
 {
 	delete source;
 	delete dest;
-	delete destvar;
+	// MW-2013-08-01: [[ Bug 10925 ]] Only delete the destvar varref if dest is NULL,
+	//   otherwise its owned by dest.
+	if (dest == NULL)
+		delete destvar;
 }
 
 Parse_stat MCMultiply::parse(MCScriptPoint &sp)
@@ -350,7 +367,11 @@ Parse_stat MCMultiply::parse(MCScriptPoint &sp)
 		(PE_MULTIPLY_BADEXP, sp);
 		return PS_ERROR;
 	}
-
+	
+	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
+	if (dest != NULL && dest -> isvarchunk())
+		destvar = dest -> getrootvarref();
+	
 	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
 	return PS_NORMAL;
@@ -451,7 +472,10 @@ MCSubtract::~MCSubtract()
 {
 	delete source;
 	delete dest;
-	delete destvar;
+	// MW-2013-08-01: [[ Bug 10925 ]] Only delete the destvar varref if dest is NULL,
+	//   otherwise its owned by dest.
+	if (dest == NULL)
+		delete destvar;
 }
 
 Parse_stat MCSubtract::parse(MCScriptPoint &sp)
@@ -486,7 +510,11 @@ Parse_stat MCSubtract::parse(MCScriptPoint &sp)
 	}
 	else
 		destvar->parsearray(sp);
-
+	
+	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
+	if (dest != NULL && dest -> isvarchunk())
+		destvar = dest -> getrootvarref();
+	
 	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
 	return PS_NORMAL;


### PR DESCRIPTION
... the dest chunk if the chunk is just an (indexed) var. This stops index subexpressions being evaluated twice.
