### PR TITLE
[[ Bugfix 11087 ]] don't try to create transformed image rep if there is...

### DIFF
--- a/docs/notes/bugfix-11087.md
+++ b/docs/notes/bugfix-11087.md
@@ -1,0 +1,2 @@
+# Crash setting location of image with filename set to empty
+

--- a/engine/src/iutil.cpp
+++ b/engine/src/iutil.cpp
@@ -496,12 +496,16 @@ void MCImage::rotate(uint32_t p_angle)
 
 	MCImageRep *t_rep = nil;
 
-	if (m_transformed != nil && m_transformed->Matches(rect.width, rect.height, p_angle, getflag(F_LOCK_LOCATION), resizequality, m_rep))
-		t_rep = m_transformed->Retain();
-	// IM-2013-04-22: [[ BZ 10858 ]] A transformed rep is needed if the angle is non-zero,
-	// or the rect is locked and doesn't match the source dimensions.
-	else if ((p_angle != 0) || (getflag(F_LOCK_LOCATION) && m_rep != nil && m_rep->GetGeometry(width, height) && (width != rect.width || height != rect.height)))
-		/* UNCHECKED */ MCImageRepGetTranformed(rect.width, rect.height, p_angle, (flags & F_LOCK_LOCATION) != 0, resizequality, m_rep, t_rep);
+	// IM-2013-08-02: [[ Bugfix 11087 ]] only get a transformed rep if there is an image rep to transform
+	if (m_rep != nil)
+	{
+		if (m_transformed != nil && m_transformed->Matches(rect.width, rect.height, p_angle, getflag(F_LOCK_LOCATION), resizequality, m_rep))
+			t_rep = m_transformed->Retain();
+		// IM-2013-04-22: [[ BZ 10858 ]] A transformed rep is needed if the angle is non-zero,
+		// or the rect is locked and doesn't match the source dimensions.
+		else if ((p_angle != 0) || (getflag(F_LOCK_LOCATION) && m_rep->GetGeometry(width, height) && (width != rect.width || height != rect.height)))
+			/* UNCHECKED */ MCImageRepGetTranformed(rect.width, rect.height, p_angle, (flags & F_LOCK_LOCATION) != 0, resizequality, m_rep, t_rep);
+	}
 	
 	if (m_transformed != nil)
 	{


### PR DESCRIPTION
... no source rep
