### PR TITLE
[[ Bug 6720 ]] Return scrollbar properties in correct format

### DIFF
--- a/docs/notes/bugfix-6720.md
+++ b/docs/notes/bugfix-6720.md
@@ -1,1 +1,3 @@
 # Scrollbar properties not returned in correct format.
+
+Previously these properties returned different values when obtained as numbers and string - as strings they returned the value rounded. Now they return the same value - rounded to a precision specified by the numberFormat of the scrollbar.

--- a/docs/notes/bugfix-6720.md
+++ b/docs/notes/bugfix-6720.md
@@ -1,0 +1,1 @@
+# Scrollbar properties not returned in correct format.

--- a/engine/src/scrolbar.cpp
+++ b/engine/src/scrolbar.cpp
@@ -660,18 +660,26 @@ Exec_stat MCScrollbar::getprop(uint4 parid, Properties which, MCExecPoint& ep, B
 		else
 			ep.setstaticcstring(MCscrollbarstring);
 		break;
-	case P_THUMB_SIZE:
-		ep.setr8(thumbsize, nffw, nftrailing, nfforce);
-		break;
-	case P_THUMB_POS:
-		ep.setr8(thumbpos, nffw, nftrailing, nfforce);
-		break;
-	case P_LINE_INC:
-		ep.setr8(lineinc, nffw, nftrailing, nfforce);
-		break;
-	case P_PAGE_INC:
-		ep.setr8(pageinc, nffw, nftrailing, nfforce);
-		break;
+    case P_THUMB_SIZE:
+        ep.setr8(thumbsize, nffw, nftrailing, nfforce);
+        // AL-2013-07-26: [[ Bug 6720 ]] Scrollbar properties not returned in correct format.
+        ep.setsvalue(ep.getsvalue());
+        break;
+    case P_THUMB_POS:
+        ep.setr8(thumbpos, nffw, nftrailing, nfforce);
+        // AL-2013-07-26: [[ Bug 6720 ]] Scrollbar properties not returned in correct format.
+        ep.setsvalue(ep.getsvalue());
+        break;
+    case P_LINE_INC:
+        ep.setr8(lineinc, nffw, nftrailing, nfforce);
+        // AL-2013-07-26: [[ Bug 6720 ]] Scrollbar properties not returned in correct format.
+        ep.setsvalue(ep.getsvalue());
+        break;
+    case P_PAGE_INC:
+        ep.setr8(pageinc, nffw, nftrailing, nfforce);
+        // AL-2013-07-26: [[ Bug 6720 ]] Scrollbar properties not returned in correct format.
+        ep.setsvalue(ep.getsvalue());
+        break;
 	case P_ORIENTATION:
 		ep.setstaticcstring(getstyleint(flags) == F_VERTICAL ? "vertical" : "horizontal");
 		break;


### PR DESCRIPTION
Since this fix includes a slight change in functionality, it should be merged into the develop branch.
