### PR TITLE
[[ Bug 10689 ]] Make sure a button chunk is returned for 'the selectedCh...

### DIFF
--- a/docs/notes/bugfix-10689.md
+++ b/docs/notes/bugfix-10689.md
@@ -1,0 +1,1 @@
+# 'the selectedChunk' returns a field reference if the field is embedded in a combo-box.

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -4369,11 +4369,17 @@ Exec_stat MCSelectedChunk::eval(MCExecPoint &ep)
 			return ES_ERROR;
 		}
 	}
+	else if (MCactivefield == NULL)
+		ep.clear();
 	else
-		if (MCactivefield == NULL)
-			ep.clear();
+	{
+		// MW-2013-08-07: [[ Bug 10689 ]] If the parent of the field is a button
+		//   then return the chunk of the button, not the embedded field.
+		if (MCactivefield -> getparent() -> gettype() == CT_BUTTON)
+			static_cast<MCButton *>(MCactivefield -> getparent()) -> selectedchunk(ep);
 		else
 			MCactivefield->selectedchunk(ep);
+	}
 	return ES_NORMAL;
 }
 


### PR DESCRIPTION
...unk' if the active field is in a combo-box.
