### PR TITLE
[[ Bug 10655 ]] Make sure the field CS_DRAG_TEXT state is always reset i...

### DIFF
--- a/docs/notes/bugfix-10655.md
+++ b/docs/notes/bugfix-10655.md
@@ -1,0 +1,1 @@
+# Dragging a file over a script without dropping causes the caret to continue to move in field after drag has ended.

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -1574,9 +1574,11 @@ void MCControl::leave()
 	MCControl *oldfocused = focused;
 	if (MCdispatcher -> isdragtarget())
 	{
-		//fprintf(stderr, "In MCControl::leave() : this = %x\n", this);
+		// MW-2013-08-08: [[ Bug 10655 ]] If oldfocused is a field and has dragText set,
+		//   then make sure we unset it (otherwise the caret will continue moving around
+		//   on mouseMove).
 		if (oldfocused->gettype() == CT_FIELD
-		        && !(flags & F_LOCK_TEXT) && MCdragdata -> HasText())
+		        && oldfocused -> getstate(CS_DRAG_TEXT))
 		{
 			MCField *fptr = (MCField *)oldfocused;
 			fptr->removecursor();


### PR DESCRIPTION
...n MCControl::leave if it was the focused field.
