### PR TITLE
[[ ClipsToRect ]] A new property 'the clipsToRect' has been added to the...

### DIFF
--- a/docs/dictionary/property/clipsToRect.xml
+++ b/docs/dictionary/property/clipsToRect.xml
@@ -1,0 +1,43 @@
+<doc>
+  <name>clipsToRect</name>
+  <type>property</type>
+  <syntax>
+    <example>set the clipsToRect of <i>group</i> to {true | false}</example>
+  </syntax>
+  <library></library>
+  <objects>
+  </objects>
+  <classification>
+    <category>Appearance &amp; Positioning</category>
+  </classification>
+  <references>
+    <property tag="lockLocation">lockLocation Property</property>
+    <property tag="boundingRect">boundingRect Property</property>
+    <property tag="rectangle">rectangle Property</property>
+  </references>
+  <history>
+    <introduced version="6.2">Added.</introduced>
+  </history>
+  <platforms>
+    <mac/>
+    <windows/>
+    <linux/>
+    <ios/>
+    <android/>
+  </platforms>
+  <classes>
+    <desktop/>
+    <server/>
+    <web/>
+    <mobile/>
+  </classes>
+  <security>
+  </security>
+  <summary>Specfies whether the rectangle of the group or the union of the rectangles of the child controls of the group governs the groups displayed rectangle.</summary>
+  <examples>
+    <example>set the clipsToRect of group "ScrollingList" to true</example>
+  </examples>
+  <description>
+    <p>Use the <b>clipsToRect</b> <glossary tag="property">property</glossary> to make a <keyword tag="group">group</keyword> <property tag="rectangle">rectangle</property> <glossary tag="property">property</glossary> clip the objects within the <keyword tag="group">group</keyword> and prevent resizing of the <keyword tag="group">group</keyword> when its child objects are moved or resized. The behavior of the <keyword tag="group">group</keyword> when <b>clipsToRect</b> is true mirrors the behavior of a <keyword tag="group">group</keyword> with the <property tag="rectangle">lockLocation</property> <glossary tag="property">property</glossary> true with the exception that the selection handles can be freely moved.</p><p>By default, the <b>clipsToRect</b> <glossary tag="property">property</glossary> of a newly created <keyword tag="group">group</keyword> is set to false.</p>
+  </description>
+</doc>

--- a/docs/notes/feature-clips_to_rect.md
+++ b/docs/notes/feature-clips_to_rect.md
@@ -1,0 +1,2 @@
+# The clipsToRect of group
+A new property **the clipsToRect** has been added to the group object. If true this property will make a group clip its child controls in the same way that lockLocation does with the exception that the selection handles are unlocked.

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -960,6 +960,10 @@ Exec_stat MCGroup::getprop(uint4 parid, Properties which, MCExecPoint &ep, Boole
 	case P_LOCK_UPDATES:
 		ep.setboolean(m_updates_locked);
 		break;
+    // MERG-2013-08-12: [[ ClipsToRect ]] If true group clips to the set rect rather than the rect of children
+    case P_CLIPS_TO_RECT:
+        ep.setboolean(getflag(F_CLIPS_TO_RECT));
+        break;
 	default:
 		return MCControl::getprop(parid, which, ep, effective);
 	}
@@ -1321,7 +1325,23 @@ Exec_stat MCGroup::setprop(uint4 parid, Properties p, MCExecPoint &ep, Boolean e
 		return t_stat;
 	}
 	break;
-	default:
+    // MERG-2013-08-12: [[ ClipsToRect ]] If true group clips to the set rect rather than the rect of children
+    case P_CLIPS_TO_RECT:
+    {
+        Exec_stat t_stat;
+        Boolean t_clips_to_rect;
+        
+        t_stat = ep.getboolean(t_clips_to_rect, 0, 0, EE_PROPERTY_NAB);
+        if (t_stat == ES_NORMAL)
+            if (t_clips_to_rect != getflag(F_CLIPS_TO_RECT))
+            {
+                setflag(t_clips_to_rect, F_CLIPS_TO_RECT);
+                computeminrect(True);
+            }
+        return t_stat;
+    }
+        break;
+    default:
 		return MCControl::setprop(parid, p, ep, effective);
 	}
 	if (dirty && opened)
@@ -2300,7 +2320,8 @@ Boolean MCGroup::computeminrect(Boolean scrolling)
 		if (flags & F_SHOW_BORDER)
 			minrect = MCU_reduce_rect(minrect, -borderwidth);
 	}
-	if (flags & F_LOCK_LOCATION)
+	// MERG-2013-08-12: [[ ClipsToRect ]] If true group clips to the set rect rather than the rect of children
+    if (flags & F_LOCK_LOCATION || flags & F_CLIPS_TO_RECT)
 	{
 		boundcontrols();
 		if (scrolling && flags & F_BOUNDING_RECT)

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2321,7 +2321,7 @@ Boolean MCGroup::computeminrect(Boolean scrolling)
 			minrect = MCU_reduce_rect(minrect, -borderwidth);
 	}
 	// MERG-2013-08-12: [[ ClipsToRect ]] If true group clips to the set rect rather than the rect of children
-    if (flags & F_LOCK_LOCATION || flags & F_CLIPS_TO_RECT)
+    if (flags & (F_LOCK_LOCATION | F_CLIPS_TO_RECT))
 	{
 		boundcontrols();
 		if (scrolling && flags & F_BOUNDING_RECT)

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -641,6 +641,8 @@ LT factor_table[] =
         {"clickv", TT_FUNCTION, F_CLICK_V},
         {"clipboard", TT_FUNCTION, F_CLIPBOARD},
         {"clipboarddata", TT_PROPERTY, P_CLIPBOARD_DATA},
+        // MERG-2013-08-12: [[ ClipsToRect ]] If true group clips to the set rect rather than the rect of children
+        {"clipstorect", TT_PROPERTY, P_CLIPS_TO_RECT},
         {"closebox", TT_PROPERTY, P_CLOSE_BOX},
         {"cmdkey", TT_FUNCTION, F_COMMAND_KEY},
         {"collapsebox", TT_PROPERTY, P_COLLAPSE_BOX},

--- a/engine/src/objdefs.h
+++ b/engine/src/objdefs.h
@@ -262,6 +262,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 //   multiple cards, or is allowed to be placed on multiple cards.
 #define F_GROUP_SHARED			(1UL << 30)
 
+// MERG-2013-08-12: [[ ClipsToRect ]] This flag indicates that the group clips to the set
+//   rect rather than reseting to the bounds of it's children.
+#define F_CLIPS_TO_RECT         (1UL << 31)
+
 // MCStack attributes
 #define F_LINK_ATTS             (1UL << 5)
 #define F_S_CANT_DELETE         (1UL << 14)

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1579,7 +1579,10 @@ enum Properties {
     P_CONTROL_NAMES,
 	P_CHILD_CONTROL_IDS,
     P_CHILD_CONTROL_NAMES,
-	
+    
+    // MERG-2013-08-12: [[ ClipsToRect ]] If true group clips to the set rect rather than the rect of children
+    P_CLIPS_TO_RECT,
+    
 	// ARRAY STYLE PROPERTIES
 	P_FIRST_ARRAY_PROP,
     P_CUSTOM_KEYS = P_FIRST_ARRAY_PROP,


### PR DESCRIPTION
... group object. If true this property will make a group clip its child controls in the same way that lockLocation does with the exception that the selection handles are unlocked.
