### PR TITLE
[[ Bug 11108 ]] Make sure the paragraph attrs structure is not accessed ...

### DIFF
--- a/docs/notes/bugfix-11108.md
+++ b/docs/notes/bugfix-11108.md
@@ -1,0 +1,1 @@
+# Crash in some circumstances when setting the hidden of a paragraph to false.

--- a/engine/src/paragrafattr.cpp
+++ b/engine/src/paragrafattr.cpp
@@ -1017,7 +1017,9 @@ void MCParagraph::copysingleattr(Properties which, MCParagraph *other)
 				attrs -> hidden = other -> attrs -> hidden;
 			else if (attrs != nil)
 				attrs -> hidden = false;
-			if (!attrs -> hidden)
+			// MW-2013-08-20: [[ Bug 11108 ]] If we don't have attributes, then don't tweak
+			//   the flags.
+			if (attrs != nil && !attrs -> hidden)
 				attrs -> flags &= ~PA_HAS_HIDDEN;
 		}
 		break;


### PR DESCRIPTION
...if it is not there (when setting hidden).
