### PR TITLE
[[ Bug 11129 ]] Make sure gettextatts() / settextatts() work with INT32_...

### DIFF
--- a/docs/notes/bugfix-11129.md
+++ b/docs/notes/bugfix-11129.md
@@ -1,0 +1,1 @@
+# Crash when fetching the encoding or the flaggedRanges property from the templateField.

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -1413,12 +1413,14 @@ Exec_stat MCField::getprop(uint4 parid, Properties which, MCExecPoint& ep, Boole
         }
         break;
     // MW-2012-02-08: [[ FlaggedRanges ]] Return the flaggedRanges of the whole field.
+	// MW-2013-08-27: [[ Bug 11129 ]] Use INT32_MAX as upper limit.
 	case P_FLAGGED_RANGES:
-		return gettextatts(parid, P_FLAGGED_RANGES, ep, nil, False, 0, getpgsize(nil), false);
+		return gettextatts(parid, P_FLAGGED_RANGES, ep, nil, False, 0, INT32_MAX, false);
 	// MW-2012-02-22: [[ IntrinsicUnicode ]] Fetch the encoding property of the field, this is
 	//   actually the encoding of the content.
 	case P_ENCODING:
-		return gettextatts(parid, P_ENCODING, ep, nil, False, 0, getpgsize(nil), false);
+		// MW-2013-08-27: [[ Bug 11129 ]] Use INT32_MAX as upper limit.
+		return gettextatts(parid, P_ENCODING, ep, nil, False, 0, INT32_MAX, false);
 	default:
 		return MCControl::getprop(parid, which, ep, effective);
 	}
@@ -1950,8 +1952,9 @@ Exec_stat MCField::setprop(uint4 parid, Properties p, MCExecPoint &ep, Boolean e
 		setsbrects();
 		break;
 	// MW-2012-02-08: [[ FlaggedField ]] Set the flaggedRanges of the whole field.
+	// MW-2013-08-27: [[ Bug 11129 ]] Use INT32_MAX as upper limit.
 	case P_FLAGGED_RANGES:
-		return settextatts(parid, P_FLAGGED_RANGES, ep, nil, 0, getpgsize(nil), false);
+		return settextatts(parid, P_FLAGGED_RANGES, ep, nil, 0, INT32_MAX, false);
 	default:
 		return MCControl::setprop(parid, p, ep, effective);
 	}

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -816,10 +816,10 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 		exportasstyledtext(parid, ep, si, ei, which == P_FORMATTED_STYLED_TEXT, effective == True);
 		return ES_NORMAL;
 	}
-
-	if (flags & F_SHARED_TEXT)
-		parid = 0;
-	MCParagraph *pgptr = getcarddata(fdata, parid, True)->getparagraphs();
+	
+	// MW-2013-08-27: [[ Bug 11129 ]] Use 'resolveparagraphs()' so we get the same
+	//   behavior as if exporting the content in various ways.
+	MCParagraph *pgptr = resolveparagraphs(parid);
 
 	// MW-2012-02-08: [[ Field Indices ]] If we pass a pointer to indextoparagraph
 	//   then it computes the index of the paragraph (1-based).
@@ -982,7 +982,13 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 
 				// Reduce ei until we get to zero, advancing through the paras.
 				ei -= sptr->gettextsizecr();
+				
 				sptr = sptr->next();
+				
+				// MW-2013-08-27: [[ Bug 11129 ]] If we reach the end of the paragraphs
+				//   then set ei to 0 as we are done.
+				if (sptr == pgptr)
+					ei = 0;
 			}
 			while(ei > 0);
 			
@@ -1024,6 +1030,11 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 				si = 0;
 				ei -= sptr -> gettextsizecr();
 				sptr = sptr -> next();
+				
+				// MW-2013-08-27: [[ Bug 11129 ]] If we reach the end of the paragraphs
+				//   then set ei to 0 as we are done.
+				if (sptr == pgptr)
+					ei = 0;
 			}
 			while(ei > 0);
 		}
@@ -1076,6 +1087,11 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 
 				ei -= sptr->gettextsizecr();
 				sptr = sptr->next();
+				
+				// MW-2013-08-27: [[ Bug 11129 ]] If we reach the end of the paragraphs
+				//   then set ei to 0 as we are done.
+				if (sptr == pgptr)
+					ei = 0;
 			}
 			while(ei > 0);
 			break;
@@ -1187,6 +1203,11 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 			ei -= sptr->gettextsizecr();
 			si = 0;
 			sptr = sptr->next();
+			
+			// MW-2013-08-27: [[ Bug 11129 ]] If we reach the end of the paragraphs
+			//   then set ei to 0 as we are done.
+			if (sptr == pgptr)
+				ei = 0;
 		}
 		while (ei > 0);
 
@@ -1423,7 +1444,9 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 		return ES_NORMAL;
 	}
 
-	MCParagraph *pgptr = getcarddata(fdata, parid, True)->getparagraphs();
+	// MW-2013-08-27: [[ Bug 11129 ]] Use 'resolveparagraphs()' so we get the same behavior
+	//   as elsewhere.
+	MCParagraph *pgptr = resolveparagraphs(parid);
 
 	// MW-2013-03-20: [[ Bug 10764 ]] We only need to layout if the paragraphs
 	//   are attached to the current card.
@@ -1655,6 +1678,11 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 		si = MCU_max(0, si - l);
 		ei -= l;
 		pgptr = pgptr->next();
+		
+		// MW-2013-08-27: [[ Bug 11129 ]] If we reach the end of the paragraphs
+		//   then set ei to 0 as we are done.
+		if (pgptr == t_first_pgptr)
+			ei = 0;
 	}
 	while(ei > 0 && t_stat == ES_NORMAL);
 	delete cname;


### PR DESCRIPTION
...MAX as upper limit.

[[ Bug 11129 ]] Make sure resolveparagraphs() is used rather than getcarddata().
