### PR TITLE
Rename MCField::settext to settext_oldstring

### DIFF
--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -752,7 +752,7 @@ Boolean MCButton::kdown(const char *string, KeySym key)
 					labelsize = pick.getlength();
 					flags |= F_LABEL;
 					if (entry != NULL)
-						entry->settext(0, pick, False, hasunicode());
+						entry->settext_oldstring(0, pick, False, hasunicode());
 					Exec_stat es = message_with_args(MCM_menu_pick, pick);
 					if (es == ES_NOT_HANDLED || es == ES_PASS)
 						message_with_args(MCM_mouse_up, menubutton);
@@ -1344,7 +1344,7 @@ Boolean MCButton::mup(uint2 which)
 					labelsize = pick.getlength();
 					flags |= F_LABEL;
 					if (entry != NULL)
-						entry->settext(0, pick, False, hasunicode());
+						entry->settext_oldstring(0, pick, False, hasunicode());
 				}
 				docascade(pick);
 			}
@@ -3839,7 +3839,7 @@ bool MCButton::resetlabel()
 			label = NULL;
 			labelsize = 0;
 			if (entry != NULL)
-				entry->settext(0, MCnullmcstring, False, hasunicode());
+				entry->settext_oldstring(0, MCnullmcstring, False, hasunicode());
 
 			flags &= ~F_LABEL;
 
@@ -3863,7 +3863,7 @@ bool MCButton::resetlabel()
 				memcpy(label, sptr, labelsize);
 			}
 			if (entry != NULL)
-				entry->settext(0, MCString(label, labelsize), False, hasunicode());
+				entry->settext_oldstring(0, MCString(label, labelsize), False, hasunicode());
 
 			flags |= F_LABEL;
 

--- a/engine/src/debug.cpp
+++ b/engine/src/debug.cpp
@@ -146,7 +146,7 @@ void MCB_setmsg(MCExecPoint &ep)
 			MCCard *cptr = MCmbstackptr->getchild(CT_THIS, kMCEmptyString, CT_CARD);
 			MCField *fptr = (MCField *)cptr->getchild(CT_FIRST, kMCEmptyString, CT_FIELD, CT_CARD);
 			if (fptr != NULL)
-				fptr->settext(0, ep.getsvalue(), False);
+				fptr->settext_oldstring(0, ep.getsvalue(), False);
 		}
 	}
 }

--- a/engine/src/exec-interface-button.cpp
+++ b/engine/src/exec-interface-button.cpp
@@ -609,9 +609,9 @@ void MCButton::DoSetLabel(MCExecContext& ctxt, MCStringRef p_label)
 
 		if (entry != NULL)
 			if (label == NULL)
-				entry->settext(0, MCnullmcstring, False, False);
+				entry->settext_oldstring(0, MCnullmcstring, False, False);
 			else
-				entry->settext(0, MCString(label, labelsize), False, hasunicode());
+				entry->settext_oldstring(0, MCString(label, labelsize), False, hasunicode());
 
 		clearmnemonic();
 		setupmnemonic();

--- a/engine/src/exec-interface-field.cpp
+++ b/engine/src/exec-interface-field.cpp
@@ -523,7 +523,7 @@ void MCField::GetText(MCExecContext& ctxt, uint32_t part, MCStringRef& r_text)
 
 void MCField::SetText(MCExecContext& ctxt, uint32_t part, MCStringRef p_text)
 {
-	settext(part, MCStringGetOldString(p_text), False);
+	settext(part, p_text, False);
 }
 
 void MCField::GetUnicodeText(MCExecContext& ctxt, uint32_t part, MCStringRef& r_text)
@@ -636,7 +636,7 @@ void MCField::GetFormattedText(MCExecContext& ctxt, uint32_t part, MCStringRef& 
 
 void MCField::SetFormattedText(MCExecContext& ctxt, uint32_t part, MCStringRef p_string)
 {
-	settext(part, MCStringGetOldString(p_string), True);
+	settext(part, p_string, True);
 	Redraw(true);
 }
 
@@ -650,7 +650,7 @@ void MCField::GetUnicodeFormattedText(MCExecContext& ctxt, uint32_t part, MCStri
 
 void MCField::SetUnicodeFormattedText(MCExecContext& ctxt, uint32_t part, MCStringRef p_string)
 {
-	settext(part, MCStringGetOldString(p_string), True, True);
+	settext(part, p_string, True);
 	Redraw(true);
 }
 

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -422,7 +422,7 @@ static char *set_field_by_name(const char *arg1, const char *arg2,
 		*retval = xresFail;
 	else
 	{
-		fptr->settext(fptr->getcard()->getid(), arg3, False);
+		fptr->settext_oldstring(fptr->getcard()->getid(), arg3, False);
 		*retval = xresSucc;
 	}
 	return NULL;
@@ -436,7 +436,7 @@ static char *set_field_by_num(const char *arg1, const char *arg2,
 		*retval = xresFail;
 	else
 	{
-		fptr->settext(fptr->getcard()->getid(), arg3, False);
+		fptr->settext_oldstring(fptr->getcard()->getid(), arg3, False);
 		*retval = xresSucc;
 	}
 	return NULL;
@@ -450,7 +450,7 @@ static char *set_field_by_id(const char *arg1, const char *arg2,
 		*retval = xresFail;
 	else
 	{
-		fptr->settext(fptr->getcard()->getid(), arg3, False);
+		fptr->settext_oldstring(fptr->getcard()->getid(), arg3, False);
 		*retval = xresSucc;
 	}
 	return NULL;

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -380,7 +380,8 @@ public:
 	MCParagraph *resolveparagraphs(uint4 parid);
 
 	void setparagraphs(MCParagraph *newpgptr, uint4 parid);
-	Exec_stat settext(uint4 parid, const MCString &newtext, Boolean formatted, Boolean asunicode = False);
+	Exec_stat settext(uint4 parid, MCStringRef p_text, Boolean p_formatted);
+	Exec_stat settext_oldstring(uint4 parid, const MCString &newtext, Boolean formatted, Boolean asunicode = False);
 	// MW-2012-02-23: [[ PutUnicode ]] Added parameter to specify whether 'is' is unicode or native.
 	Exec_stat settextindex(uint4 parid, int4 si, int4 ei, const MCString &s, Boolean undoing, bool asunicode = false);
 	void getlinkdata(MCRectangle &r, MCBlock *&sb, MCBlock *&eb);

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -2249,7 +2249,7 @@ void MCField::setupmenu(const MCString &s, uint2 fheight,
 	fontheight = fheight;
 	topmargin = bottommargin = 6;
 	borderwidth = 0;
-	settext(0, s, False, isunicode);
+	settext_oldstring(0, s, False, isunicode);
 
 	// MW-2008-03-14: [[ Bug 5750 ]] Fix to focus border problem in fields used as menu lists in
 	//   (for example) option menus. Set this as a menufield.
@@ -2274,7 +2274,7 @@ void MCField::setupentry(MCButton *bptr, const MCString &s, Boolean isunicode)
 		topmargin = 6;
 	flags = F_VISIBLE | F_SHOW_BORDER | F_3D | F_OPAQUE | F_FIXED_HEIGHT
 		| F_TRAVERSAL_ON | F_AUTO_TAB | F_DONT_WRAP | F_SHARED_TEXT;
-	settext(0, s, False, isunicode);
+	settext_oldstring(0, s, False, isunicode);
 }
 
 void MCField::typetext(const MCString &newtext)

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -156,7 +156,7 @@ Exec_stat MCField::sort(MCExecPoint &ep, uint4 parid, Chunk_term type,
 			newtext[tlength] = '\0';
 		}
 		delete itemtext;
-		settext(parid, newtext, False);
+		settext_oldstring(parid, newtext, False);
 		delete newtext;
 	}
 	else if (nitems > 0)
@@ -504,7 +504,17 @@ void MCField::setparagraphs(MCParagraph *newpgptr, uint4 parid)
 		fptr->setparagraphs(newpgptr);
 }
 
-Exec_stat MCField::settext(uint4 parid, const MCString &s, Boolean formatted, Boolean isunicode)
+Exec_stat MCField::settext(uint4 parid, MCStringRef p_text, Boolean p_formatted)
+{
+	const char *t_bytes = (const char*)MCStringGetNativeCharPtr(p_text);
+	uindex_t t_length = MCStringGetLength(p_text);
+	if (t_bytes != nil)
+		return settext_oldstring(parid, MCString(t_bytes, t_length), p_formatted, false);
+	else
+		return settext_oldstring(parid, MCString((const char*)MCStringGetCharPtr(p_text), t_length * sizeof(unichar_t)), p_formatted, true);
+}
+
+Exec_stat MCField::settext_oldstring(uint4 parid, const MCString &s, Boolean formatted, Boolean isunicode)
 {
 	state &= ~CS_CHANGED;
 	if (opened)

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -205,7 +205,7 @@ Exec_stat MCRevRelicense::exec(MCExecPoint& ep)
     MCAutoStringRef t_command_path;
     MCS_resolvepath(MCcmd, &t_command_path);
 	
-	s_command_path = MCValueRetain(*t_command_path));
+	s_command_path = MCValueRetain(*t_command_path);
 
 	atexit(restart_revolution);
 	
@@ -1208,7 +1208,7 @@ bool MCModeHandleMessageBoxChanged(MCExecPoint& ep)
 			else
 				t_msg_stack -> raise();
 
-			((MCField *)MCmessageboxredirect) -> settext(0, ep . getsvalue(), False);
+			((MCField *)MCmessageboxredirect) -> settext_oldstring(0, ep . getsvalue(), False);
 		}
 		else
 		{


### PR DESCRIPTION
The MCString variant of MCField::settext has been renamed to MCField::settext_oldstring. In its place, the new MCField::settext takes a StringRef.
