### PR TITLE
Faster field changes

### DIFF
--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -616,13 +616,6 @@ void MCParagraph::noflow(void)
 			MCLine *lptr = lines->remove(lines);
 			delete lptr;
 		}
-	MCBlock *bptr = blocks;
-	do
-	{
-		bptr->reset();
-		bptr = bptr->next();
-	}
-	while (bptr != blocks);
 	lines->appendall(blocks);
 
 	// MW-2012-02-10: [[ FixedTable ]] If there is a non-zero table width then

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -115,6 +115,7 @@ MCParagraph::MCParagraph()
 	opened = 0;
 	startindex = endindex = originalindex = MAXUINT2;
 	state = 0;
+	needs_layout = true;
 
 	// MW-2012-01-25: [[ ParaStyles ]] All attributes are unset to begin with.
 	attrs = nil;
@@ -155,6 +156,7 @@ MCParagraph::MCParagraph(const MCParagraph &pref) : MCDLlist(pref)
 	startindex = endindex = originalindex = MAXUINT2;
 	opened = 0;
 	state = 0;
+	needs_layout = true; // is this needed?
 }
 
 MCParagraph::~MCParagraph()
@@ -272,6 +274,8 @@ IO_stat MCParagraph::load(IO_handle stream, const char *version, bool is_ext)
 			return IO_NORMAL;
 		}
 	}
+
+	needs_layout = true;
 
 	return IO_NORMAL;
 }
@@ -415,6 +419,8 @@ bool MCParagraph::recomputefonts(MCFontRef p_parent_font)
 	}
 	while(t_block != blocks);
 
+	if (t_changed)
+		needs_layout = true;
 	return t_changed;
 }
 
@@ -461,6 +467,8 @@ void MCParagraph::deletelines()
 		MCLine *lptr = lines->remove(lines);
 		delete lptr;
 	}
+	
+	needs_layout = true;
 }
 
 // **** mutate blocks
@@ -473,6 +481,7 @@ void MCParagraph::deleteblocks()
 	}
 
 	state |= PS_LINES_NOT_SYNCHED;
+	needs_layout = true;
 }
 
 //clear blocks with the same attributes
@@ -513,6 +522,7 @@ void MCParagraph::defrag()
 	if (t_blocks_changed)
 	{
 		state |= PS_LINES_NOT_SYNCHED;
+		needs_layout = true;
 	}
 }
 
@@ -520,10 +530,15 @@ void MCParagraph::defrag()
 //   on the setting of 'dontWrap'.
 void MCParagraph::layout()
 {
+	if (!needs_layout)
+		return;
+
 	if (getdontwrap())
 		noflow();
 	else
 		flow();
+
+	needs_layout = False;
 }
 
 //reflow paragraph with wrapping
@@ -1253,6 +1268,8 @@ void MCParagraph::setatts(uint2 si, uint2 ei, Properties p, void *value, bool p_
 {
 	bool t_blocks_changed;
 	t_blocks_changed = false;
+	bool t_needs_layout;
+	t_needs_layout = false;
 
 	defrag();
 	MCBlock *bptr = indextoblock(si, False);
@@ -1294,10 +1311,12 @@ void MCParagraph::setatts(uint2 si, uint2 ei, Properties p, void *value, bool p_
 			break;
 		case P_TEXT_SHIFT:
 			bptr->setshift((uint4)(intptr_t)value);
+			t_needs_layout = true;
 			break;
 		case P_IMAGE_SOURCE:
 			{
 				bptr->setatts(p, value);
+				t_needs_layout = true;
 				
 				// MW-2008-04-03: [[ Bug ]] Only add an extra block if this is coming from
 				//   html parsing.
@@ -1317,6 +1336,7 @@ void MCParagraph::setatts(uint2 si, uint2 ei, Properties p, void *value, bool p_
 			break;
 		default:
 			bptr->setatts(p, value);
+			t_needs_layout = true;
 			break;
 		}
 		// MW-2012-02-14: [[ FontRefs ]] If the block is open, pass in the parent's
@@ -1330,6 +1350,10 @@ void MCParagraph::setatts(uint2 si, uint2 ei, Properties p, void *value, bool p_
 	if (t_blocks_changed)
 	{
 		state |= PS_LINES_NOT_SYNCHED;
+	}
+	if (t_needs_layout || t_blocks_changed)
+	{
+		needs_layout = true;
 	}
 }
 
@@ -1514,6 +1538,7 @@ void MCParagraph::join()
 	delete pgptr;
 	clearzeros();
 	deletelines();
+	needs_layout = true;
 }
 
 void MCParagraph::split() //split paragraphs on return
@@ -1567,6 +1592,7 @@ void MCParagraph::split() //split paragraphs on return
 		pgptr->open(parent -> getfontref());
 	append(pgptr);
 	deletelines();
+	needs_layout = true;
 }
 
 void MCParagraph::deletestring(uint2 si, uint2 ei)
@@ -1630,6 +1656,7 @@ void MCParagraph::deletestring(uint2 si, uint2 ei)
 	clearzeros();
 
 	state |= PS_LINES_NOT_SYNCHED;
+	needs_layout = true;
 }
 
 MCParagraph *MCParagraph::copystring(uint2 si, uint2 ei)
@@ -1791,6 +1818,7 @@ void MCParagraph::finsertnobreak(const MCString& p_text, bool p_is_unicode)
 	}
 
 	delete t_native_text;
+	needs_layout = true;
 }
 
 // MW-2012-02-13: [[ Block Unicode ]] New implementation of finsert which understands unicodeness.

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -137,6 +137,7 @@ class MCParagraph : public MCDLlist
 	uint2 startindex, endindex, originalindex;
 	uint2 opened;
 	uint1 state;
+	bool needs_layout : 1;
 	// MW-2012-01-25: [[ ParaStyles ]] This paragraphs collection of attrs.
 	MCParagraphAttrs *attrs;
 


### PR DESCRIPTION
This avoids unnecessary recomputation of the entire field any time anything changes. This affects all platforms, though most to a lesser degree than Linux. I have not personally seen any oddities with these changes, but more extensive testing is needed.
