### PR TITLE
[[ Bug 11144 ]] Make sure we advance through the lines when exporting te...

### DIFF
--- a/docs/notes/bugfix-11144.md
+++ b/docs/notes/bugfix-11144.md
@@ -1,0 +1,1 @@
+# Hang when trying to get chunk of formattedText of a field beyond the first (formatted) line.

--- a/engine/src/fieldh.cpp
+++ b/engine/src/fieldh.cpp
@@ -281,6 +281,10 @@ bool MCField::doexport(MCFieldExportFlags p_flags, MCParagraph *p_paragraphs, in
 						// must be the line.
 						if (t_last -> getindex() + t_last -> getsize() > t_first_offset)
 							break;
+							
+						// MW-2013-09-02: [[ Bug 11144 ]] Make sure we advance to the next line,
+						//   otherwise we just get an infinite loop.
+						t_line = t_line -> next();
 					}
 			}
 		}


### PR DESCRIPTION
...xt of a subrange of the field.
