### PR TITLE
Refactor syntax unicode can access

### DIFF
--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -211,7 +211,7 @@ void MCNetworkEvalHostAddressToName(MCExecContext& ctxt, MCStringRef p_address, 
 
 	// We only allow an address to name lookup if the resulting is the secure domain
 	// unless we have network access.
-	if (!MCSecureModeCanAccessNetwork() && !MCModeCanAccessDomain(MCStringGetCString(r_name)))
+	if (!MCSecureModeCanAccessNetwork() && !MCModeCanAccessDomain(r_name))
 	{
 		MCValueRelease(r_name);
 		r_name = nil;
@@ -224,7 +224,7 @@ void MCNetworkEvalHostAddressToName(MCExecContext& ctxt, MCStringRef p_address, 
 void MCNetworkEvalHostNameToAddress(MCExecContext& ctxt, MCStringRef p_hostname, MCNameRef p_message, MCStringRef& r_string)
 {
 	// We only allow an name to address lookup to occur for the secure domain.
-	if (!MCSecureModeCanAccessNetwork() && !MCModeCanAccessDomain(MCStringGetCString(p_hostname)))
+	if (!MCSecureModeCanAccessNetwork() && !MCModeCanAccessDomain(p_hostname))
 	{
 		ctxt.LegacyThrow(EE_NETWORK_NOPERM);
 		return;
@@ -424,7 +424,7 @@ void MCNetworkExecDeleteUrl(MCExecContext& ctxt, MCStringRef p_target)
 
 void MCNetworkExecPerformOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, bool p_datagram, bool p_secure, bool p_ssl)
 {
-	if (!ctxt . EnsureNetworkAccessIsAllowed() && !MCModeCanAccessDomain(MCNameGetCString(p_name)))
+	if (!ctxt . EnsureNetworkAccessIsAllowed() && !MCModeCanAccessDomain(MCNameGetString(p_name)))
 		return;
 
 	uindex_t t_index;

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -78,7 +78,7 @@ struct MCarray
 };
 
 typedef char *(*XCB)(const char *arg1, const char *arg2, const char *arg3, int *retval);
-typedef int (*SECURITYHANDLER)(const char *);
+typedef int (*SECURITYHANDLER)(MCStringRef);
 typedef void (*DELETER)(void *data);
 typedef void (*GETXTABLE)(XCB *, DELETER, const char **, Xternal **, DELETER *);
 typedef void (*CONFIGURESECURITY)(SECURITYHANDLER *handlers);
@@ -780,19 +780,19 @@ XCB MCcbs[] =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static int can_access_file(const char *p_file)
+static int can_access_file(MCStringRef p_file)
 {
 	return MCSecureModeCanAccessDisk();
 }
 
-static int can_access_host(const char *p_host)
+static int can_access_host(MCStringRef p_host)
 {
 	if (MCSecureModeCanAccessNetwork())
 		return true;
 	return MCModeCanAccessDomain(p_host);
 }
 
-static int can_access_library(const char *p_host)
+static int can_access_library(MCStringRef p_host)
 {
 	return true;
 }
@@ -800,6 +800,6 @@ static int can_access_library(const char *p_host)
 SECURITYHANDLER MCsecuritycbs[] =
 {
 	can_access_file,
-	can_access_host,
+    can_access_host,
 	can_access_library
 };

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -78,7 +78,7 @@ struct MCarray
 };
 
 typedef char *(*XCB)(const char *arg1, const char *arg2, const char *arg3, int *retval);
-typedef int (*SECURITYHANDLER)(MCStringRef);
+typedef int (*SECURITYHANDLER)(const char *);
 typedef void (*DELETER)(void *data);
 typedef void (*GETXTABLE)(XCB *, DELETER, const char **, Xternal **, DELETER *);
 typedef void (*CONFIGURESECURITY)(SECURITYHANDLER *handlers);
@@ -780,19 +780,21 @@ XCB MCcbs[] =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static int can_access_file(MCStringRef p_file)
+static int can_access_file(const char *p_file)
 {
 	return MCSecureModeCanAccessDisk();
 }
 
-static int can_access_host(MCStringRef p_host)
+static int can_access_host(const char *p_host)
 {
 	if (MCSecureModeCanAccessNetwork())
 		return true;
-	return MCModeCanAccessDomain(p_host);
+    MCAutoStringRef t_host;
+    /* UNCHECKED */ MCStringCreateWithCString(p_host, &t_host);
+	return MCModeCanAccessDomain(*t_host);
 }
 
-static int can_access_library(MCStringRef p_host)
+static int can_access_library(const char *p_host)
 {
 	return true;
 }

--- a/engine/src/mode.h
+++ b/engine/src/mode.h
@@ -171,7 +171,7 @@ Window MCModeGetParentWindow(void);
 
 // This hook is used to determine whether a network resource can be accessed
 // while security limitations are in effect
-bool MCModeCanAccessDomain(const char *p_name);
+bool MCModeCanAccessDomain(MCStringRef p_name);
 
 #ifdef _LINUX
 void MCModePreSelectHook(int& maxfd, fd_set& rfds, fd_set& wfds, fd_set& efds);

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1290,7 +1290,7 @@ Window MCModeGetParentWindow(void)
 	return t_window;
 }
 
-bool MCModeCanAccessDomain(const char *p_name)
+bool MCModeCanAccessDomain(MCStringRef p_name)
 {
 	return false;
 }

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1641,7 +1641,7 @@ Window MCModeGetParentWindow(void)
 	return t_window;
 }
 
-bool MCModeCanAccessDomain(const char *p_name)
+bool MCModeCanAccessDomain(MCStringRef p_name)
 {
 	return false;
 }

--- a/engine/src/mode_server.cpp
+++ b/engine/src/mode_server.cpp
@@ -317,7 +317,7 @@ Window MCModeGetParentWindow(void)
 	return NULL;
 }
 
-bool MCModeCanAccessDomain(const char *p_name)
+bool MCModeCanAccessDomain(MCStringRef p_name)
 {
 	return false;
 }

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -822,7 +822,7 @@ Window MCModeGetParentWindow(void)
 	return t_window;
 }
 
-bool MCModeCanAccessDomain(const char *p_name)
+bool MCModeCanAccessDomain(MCStringRef p_name)
 {
 	return false;
 }


### PR DESCRIPTION
Updated methods:
can_access_host(char const_)
can_access_file(char const_)
can_access_library(char const_)
MCModeCanAccessDomain(char const_)
