### PR TITLE
Refactor syntax unicode find

### DIFF
--- a/engine/engine.xcodeproj/project.pbxproj
+++ b/engine/engine.xcodeproj/project.pbxproj
@@ -1023,7 +1023,7 @@
 		4D587E2A0B8096E600200116 /* hc.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = hc.h; path = src/hc.h; sourceTree = "<group>"; };
 		4D587E2C0B8096E600200116 /* prefix.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = prefix.h; path = src/prefix.h; sourceTree = "<group>"; };
 		4D587E2F0B8096FD00200116 /* dispatch.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = dispatch.cpp; path = src/dispatch.cpp; sourceTree = "<group>"; };
-		4D587E300B8096FD00200116 /* fields.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = fields.cpp; path = src/fields.cpp; sourceTree = "<group>"; };
+		4D587E300B8096FD00200116 /* fields.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = fields.cpp; path = src/fields.cpp; sourceTree = "<group>"; usesTabs = 0; };
 		4D587E310B8096FD00200116 /* fieldh.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = fieldh.cpp; path = src/fieldh.cpp; sourceTree = "<group>"; };
 		4D587E330B8096FD00200116 /* ports.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = ports.cpp; path = src/ports.cpp; sourceTree = "<group>"; };
 		4D587E340B8096FD00200116 /* operator.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = operator.cpp; path = src/operator.cpp; sourceTree = "<group>"; };

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -2786,7 +2786,7 @@ Boolean MCCard::checkid(uint4 controlid)
 	return False;
 }
 
-Boolean MCCard::find(MCExecPoint &ep, Find_mode mode, const MCString &tofind,
+Boolean MCCard::find(MCExecPoint &ep, Find_mode mode, MCStringRef tofind,
                      Boolean firstcard, Boolean firstword)
 {
 	if (flags & F_C_DONT_SEARCH)

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -142,7 +142,7 @@ public:
 	MCObjptr *newcontrol(MCControl *cptr, Boolean needredraw);
 	void resetid(uint4 oldid, uint4 newid);
 	Boolean checkid(uint4 controlid);
-	Boolean find(MCExecPoint &ep, Find_mode mode, const MCString &,
+	Boolean find(MCExecPoint &ep, Find_mode mode, MCStringRef,
 	             Boolean firstcard, Boolean firstword);
 	MCObjptr *getrefs();
 	void clean();

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -1131,12 +1131,42 @@ Parse_stat MCMarking::parse(MCScriptPoint &sp)
 
 Exec_stat MCMarking::exec(MCExecPoint &ep)
 {
+#ifdef LEGACY_EXEC
 	if (card != NULL)
 	{
 		MCObject *optr;
 		uint4 parid;
 		if (card->getobj(ep, optr, parid, True) != ES_NORMAL
 		        || optr->gettype() != CT_CARD)
+		{
+			MCeerror->add
+			(EE_MARK_BADCARD, line, pos);
+			return ES_ERROR;
+		}
+		ep.setboolean(mark);
+		return optr->setprop(0, P_MARKED, ep, False);
+	}
+	if (tofind == NULL)
+		MCdefaultstackptr->mark(ep, where, mark);
+	else
+	{
+		if (tofind->eval(ep) != ES_NORMAL)
+		{
+			MCeerror->add
+			(EE_MARK_BADSTRING, line, pos);
+			return ES_ERROR;
+		}
+        
+		MCdefaultstackptr->markfind(ep, mode, ep.getsvalue(), field, mark);
+	}
+	return ES_NORMAL;
+#endif
+    if (card != NULL)
+	{
+		MCObject *optr;
+		uint4 parid;
+		if (card->getobj(ep, optr, parid, True) != ES_NORMAL
+            || optr->gettype() != CT_CARD)
 		{
 			MCeerror->add
 			(EE_MARK_BADCARD, line, pos);

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -1155,7 +1155,9 @@ Exec_stat MCMarking::exec(MCExecPoint &ep)
 			(EE_MARK_BADSTRING, line, pos);
 			return ES_ERROR;
 		}
-		MCdefaultstackptr->markfind(ep, mode, ep.getsvalue(), field, mark);
+        MCAutoStringRef t_value;
+        ep . copyasstringref(&t_value);
+		MCdefaultstackptr->markfind(ep, mode, *t_value, field, mark);
 	}
 	return ES_NORMAL;
 }

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3944,7 +3944,7 @@ void MCInterfaceExecFind(MCExecContext& ctxt, int p_mode, MCStringRef p_needle, 
 		ctxt .SetTheResultToCString(MCnotfoundstring);
 		return;
 	}
-	MCdefaultstackptr->find(ctxt . GetEP(), p_mode, p_needle, p_target);
+	MCdefaultstackptr->find(ctxt . GetEP(), (Find_mode)p_mode, p_needle, p_target);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -364,7 +364,7 @@ public:
 	void insertparagraph(MCParagraph *newtext);
 	// MCField selection functions in fields.cc
 	Boolean find(MCExecPoint &ep, uint4 cardid,
-	             Find_mode mode, const MCString &, Boolean first);
+	             Find_mode mode, MCStringRef, Boolean first);
 	Exec_stat sort(MCExecPoint &ep, uint4 parid, Chunk_term type,
 	               Sort_type dir, Sort_type form, MCExpression *by);
 	// MW-2012-02-08: [[ Field Indices ]] The 'index' parameter, if non-nil, will contain

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -190,7 +190,7 @@ Exec_stat MCField::sort(MCExecPoint &ep, uint4 parid, Chunk_term type,
 }
 
 Boolean MCField::find(MCExecPoint &ep, uint4 cardid, Find_mode mode,
-                      const MCString &tofind, Boolean first)
+                      MCStringRef tofind, Boolean first)
 {
 	if (fdata == NULL || flags & F_F_DONT_SEARCH)
 		return False;
@@ -205,7 +205,7 @@ Boolean MCField::find(MCExecPoint &ep, uint4 cardid, Find_mode mode,
 		{
 			MCParagraph *paragraphptr = tptr->getparagraphs();
 			MCParagraph *tpgptr = paragraphptr;
-			uint2 flength = tofind.getlength();
+			uint2 flength = MCStringGetLength(tofind);
 			int4 toffset, oldoffset;
 			if (first && foundlength != 0)
 			{
@@ -221,7 +221,7 @@ Boolean MCField::find(MCExecPoint &ep, uint4 cardid, Find_mode mode,
 				uint2 length = tpgptr->gettextsize();
 				uint4 offset;
 				MCString tosearch(&text[oldoffset], length - oldoffset);
-				while (MCU_offset(tofind, tosearch, offset, ep.getcasesensitive()))
+				while (MCU_offset(MCStringGetOldString(tofind), tosearch, offset, ep.getcasesensitive()))
 				{
 					offset += oldoffset;
 					switch (mode)
@@ -259,7 +259,7 @@ Boolean MCField::find(MCExecPoint &ep, uint4 cardid, Find_mode mode,
 								if (MCfoundfield != NULL && MCfoundfield != this)
 									MCfoundfield->clearfound();
 								foundoffset = toffset + offset;
-								foundlength = tofind.getlength();
+								foundlength = MCStringGetLength(tofind);
 								MCfoundfield = this;
 							}
 							return True;
@@ -273,7 +273,7 @@ Boolean MCField::find(MCExecPoint &ep, uint4 cardid, Find_mode mode,
 							if (MCfoundfield != NULL && MCfoundfield != this)
 								MCfoundfield->clearfound();
 							foundoffset = toffset + offset;
-							foundlength = tofind.getlength();
+							foundlength = MCStringGetLength(tofind);
 							MCfoundfield = this;
 						}
 					default:

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -434,13 +434,13 @@ public:
 	void flip(uint2 count);
 	Exec_stat sort(MCExecPoint &ep, Sort_type dir, Sort_type form,
 	               MCExpression *by, Boolean marked);
-	void breakstring(const MCString &, MCString **dest, uint2 &nstrings,
+	void breakstring(MCStringRef, MCStringRef*& dest, uint2 &nstrings,
 	                 Find_mode fmode);
-	Boolean findone(MCExecPoint &ep, Find_mode mode, const MCString *strings,
+	Boolean findone(MCExecPoint &ep, Find_mode mode, MCStringRef *strings,
 	                uint2 nstrings, MCChunk *field, Boolean firstcard);
 	void find(MCExecPoint &ep, int p_mode, MCStringRef p_needle, MCChunk *p_target);
-	void find(MCExecPoint &ep, Find_mode mode, const MCString &, MCChunk *field);
-	void markfind(MCExecPoint &ep, Find_mode mode, const MCString &,
+	void find(MCExecPoint &ep, Find_mode mode, MCStringRef, MCChunk *field);
+	void markfind(MCExecPoint &ep, Find_mode mode, MCStringRef,
 	              MCChunk *, Boolean mark);
 	void mark(MCExecPoint &ep, MCExpression *where, Boolean mark);
 	Linkatts *getlinkatts();

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1783,8 +1783,7 @@ Exec_stat MCStack::sort(MCExecPoint &ep, Sort_type dir, Sort_type form,
 
 void MCStack::breakstring(MCStringRef source, MCStringRef*& dest, uint2 &nstrings, Find_mode fmode)
 {
-    MCString *tdest = nil;
-	MCStringRef *tdest_str = nil;
+    MCStringRef *tdest_str = nil;
 	nstrings = 0;
 	switch (fmode)
 	{
@@ -1802,9 +1801,8 @@ void MCStack::breakstring(MCStringRef source, MCStringRef*& dest, uint2 &nstring
 				while(l != 0 && !isspace(*sptr))
 					sptr += 1, l -= 1;
 
-				MCU_realloc((char **)&tdest, nstrings, nstrings + 1, sizeof(MCString));
-				tdest[nstrings].set(startptr, sptr - startptr);
-                MCStringCreateWithOldString(tdest[nstrings], tdest_str[nstrings]);
+				MCU_realloc((char **)&tdest_str, nstrings, nstrings + 1, sizeof(MCStringRef));
+                /* UNCHECKED */ MCStringCreateWithNativeChars ((const char_t *) startptr, sptr - startptr, tdest_str[nstrings]);
 				nstrings++;
 				MCU_skip_spaces(sptr, l);
 				startptr = sptr;
@@ -1941,6 +1939,8 @@ void MCStack::markfind(MCExecPoint &ep, Find_mode fmode,
 		curcard = (MCCard *)curcard->next();
 	}
 	while (curcard != ocard);
+    for (uint i = 0 ; i < nstrings ; i++)
+        MCValueRelease(strings[i]);
 	delete strings;
 	if (MCfoundfield != NULL)
 		MCfoundfield->clearfound();

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1781,10 +1781,10 @@ Exec_stat MCStack::sort(MCExecPoint &ep, Sort_type dir, Sort_type form,
 	return ES_NORMAL;
 }
 
-void MCStack::breakstring(const MCString &source, MCString **dest,
-                          uint2 &nstrings, Find_mode fmode)
+void MCStack::breakstring(MCStringRef source, MCStringRef*& dest, uint2 &nstrings, Find_mode fmode)
 {
-	MCString *tdest = NULL;
+    MCString *tdest = nil;
+	MCStringRef *tdest_str = nil;
 	nstrings = 0;
 	switch (fmode)
 	{
@@ -1793,8 +1793,8 @@ void MCStack::breakstring(const MCString &source, MCString **dest,
 	case FM_WORD:
 		{
 			// MW-2007-07-05: [[ Bug 110 ]] - Break string only breaks at spaces, rather than space charaters
-			const char *sptr = source.getstring();
-			uint4 l = source.getlength();
+			const char *sptr = MCStringGetCString(source);
+			uint4 l = MCStringGetLength(source);
 			MCU_skip_spaces(sptr, l);
 			const char *startptr = sptr;
 			while(l != 0)
@@ -1804,6 +1804,7 @@ void MCStack::breakstring(const MCString &source, MCString **dest,
 
 				MCU_realloc((char **)&tdest, nstrings, nstrings + 1, sizeof(MCString));
 				tdest[nstrings].set(startptr, sptr - startptr);
+                MCStringCreateWithOldString(tdest[nstrings], tdest_str[nstrings]);
 				nstrings++;
 				MCU_skip_spaces(sptr, l);
 				startptr = sptr;
@@ -1817,15 +1818,14 @@ void MCStack::breakstring(const MCString &source, MCString **dest,
 	}
 	if (nstrings == 0)
 	{
-		tdest = new MCString;
-		tdest[0] = source;
+		tdest_str[0] = MCValueRetain(source);
 		nstrings = 1;
 	}
-	*dest = tdest;
+	dest = tdest_str;
 }
 
 Boolean MCStack::findone(MCExecPoint &ep, Find_mode fmode,
-                         const MCString *strings, uint2 nstrings,
+                         MCStringRef *strings, uint2 nstrings,
                          MCChunk *field, Boolean firstcard)
 {
 	Boolean firstword = True;
@@ -1873,18 +1873,13 @@ Boolean MCStack::findone(MCExecPoint &ep, Find_mode fmode,
 		return True;
 	}
 }
-/* WRAPPER */
-void MCStack::find(MCExecPoint &ep, int p_mode, MCStringRef p_needle, MCChunk *p_target)
-{
-	find(ep, (Find_mode)p_mode, MCStringGetOldString(p_needle), p_target);
-}
 
 void MCStack::find(MCExecPoint &ep, Find_mode fmode,
-                   const MCString &tofind, MCChunk *field)
+                   MCStringRef tofind, MCChunk *field)
 {
-	MCString *strings = NULL;
+	MCStringRef *strings = NULL;
 	uint2 nstrings;
-	breakstring(tofind, &strings, nstrings, fmode);
+	breakstring(tofind, strings, nstrings, fmode);
 	MCCard *ocard = curcard;
 	Boolean firstcard = MCfoundfield != NULL;
 	MCField *oldfound = MCfoundfield;
@@ -1921,18 +1916,20 @@ void MCStack::find(MCExecPoint &ep, Find_mode fmode,
 	curcard = ocard;
 	// MW-2011-08-17: [[ Redraw ]] Tell the stack to dirty all of itself.
 	dirtyall();
+    for (int i = 0 ; i < nstrings ; i++)
+        MCValueRelease(strings[i]);
 	delete strings;
 	MCresult->sets(MCnotfoundstring);
 }
 
 void MCStack::markfind(MCExecPoint &ep, Find_mode fmode,
-                       const MCString &tofind, MCChunk *field, Boolean mark)
+                       MCStringRef tofind, MCChunk *field, Boolean mark)
 {
 	if (MCfoundfield != NULL)
 		MCfoundfield->clearfound();
-	MCString *strings = NULL;
+	MCStringRef *strings = NULL;
 	uint2 nstrings;
-	breakstring(tofind, &strings, nstrings, fmode);
+	breakstring(tofind, strings, nstrings, fmode);
 	MCCard *ocard = curcard;
 	do
 	{


### PR DESCRIPTION
Updates on:

MCStack::markfind(MCExecPoint&, Find_mode, MCString const&, MCChunk_, Boolean)
MCStack::breakstring(MCString const&, MCString__, unsigned short&, Find_mode)
MCStack::findone(MCExecPoint&, Find_mode, MCString const_, unsigned short, MCChunk_, Boolean)
MCStack::find(MCExecPoint&, Find_mode, MCString const&, MCChunk_)
MCField::find(MCExecPoint&, unsigned int, Find_mode, MCString const&, Boolean)
MCCard::find(MCExecPoint&, Find_mode, MCString const&, Boolean, Boolean)
