### PR TITLE
Fix bug 11162

### DIFF
--- a/docs/notes/bugfix-11162.md
+++ b/docs/notes/bugfix-11162.md
@@ -1,0 +1,3 @@
+# Spaces required between numeric and non-numeric components of a date to parse correctly
+
+Date format string parsing has been made less strict in its processing, now collapsing one or more spaces together to allow a ' ' in a format string to match one or more input spaces. Additionally, spaces in the input after a formatting specifier was successfully matched are ignored. With these changes, both "10:41 PM" and "10:41PM" are accepted as valid times; previously, only the former was acceptable.

--- a/engine/src/date.cpp
+++ b/engine/src/date.cpp
@@ -445,6 +445,16 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 				t_valid = true;
 			break;
 			}
+			
+			// FG-2013-09-10 [[ Bug 11162 ]]
+			// Trailing spaces after an accepted format specifier should be squashed
+			if (t_valid && !t_skip)
+			{
+				while (p_format[1] != '\0' && isspace(p_format[1]))
+					p_format++;
+				while (t_input_length > 1 && isspace(t_input[1]))
+					t_input++, t_input_length--;
+			}
 
 		}
 		else if (*p_format != *t_input)
@@ -474,6 +484,13 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 		}
 		else
 		{
+			// FG-2013-09-10 [[ Bug 11162 ]]
+			// One or more spaces in the format string should accept any number of input spaces
+			while (t_input_length > 0 && isspace(*t_input))
+				t_input += 1, t_input_length -= 1;
+			while (*p_format != '\0' && isspace(*p_format))
+				p_format++;
+			
 			if (t_input_length > 0)
 			{
 				t_input += 1;


### PR DESCRIPTION
Date format string parsing has been made less strict in its processing, now collapsing one or more spaces together to allow a ' ' in a format string to match one or more input spaces. Additionally, spaces in the input after a formatting specifier was successfully matched are ignored. With these changes, both "10:41 PM" and "10:41PM" are accepted as valid times; previously, only the former was acceptable.
