### PR TITLE
Refactor syntax unicode mcf

### DIFF
--- a/engine/src/bitmapeffect.cpp
+++ b/engine/src/bitmapeffect.cpp
@@ -617,11 +617,11 @@ Exec_stat MCBitmapEffectSetProperty(MCBitmapEffect *self, MCBitmapEffectProperty
 		case kMCBitmapEffectPropertyBlendMode:
 		{
 			MCBitmapEffectBlendMode t_new_mode;
-			if (MCStringIsEqualToCString(*t_data, "normal", kMCCompareExact))
+			if (MCStringIsEqualToCString(*t_data, "normal", kMCCompareCaseless))
 				t_new_mode = kMCBitmapEffectBlendModeNormal;
-			else if (MCStringIsEqualToCString(*t_data, "multiply", kMCCompareExact))
+			else if (MCStringIsEqualToCString(*t_data, "multiply", kMCCompareCaseless))
 				t_new_mode = kMCBitmapEffectBlendModeMultiply;
-			else if (MCStringIsEqualToCString(*t_data, "colordodge", kMCCompareExact))
+			else if (MCStringIsEqualToCString(*t_data, "colordodge", kMCCompareCaseless))
 				t_new_mode = kMCBitmapEffectBlendModeColorDodge;
 			else
 			{
@@ -652,13 +652,13 @@ Exec_stat MCBitmapEffectSetProperty(MCBitmapEffect *self, MCBitmapEffectProperty
 		case kMCBitmapEffectPropertyFilter:
 		{
 			MCBitmapEffectFilter t_new_filter;
-			if (MCStringIsEqualToCString(*t_data, "gaussian", kMCCompareExact))
+			if (MCStringIsEqualToCString(*t_data, "gaussian", kMCCompareCaseless))
 				t_new_filter = kMCBitmapEffectFilterFastGaussian;
-			else if (MCStringIsEqualToCString(*t_data, "box1pass", kMCCompareExact))
+			else if (MCStringIsEqualToCString(*t_data, "box1pass", kMCCompareCaseless))
 				t_new_filter = kMCBitmapEffectFilterOnePassBox;
-			else if (MCStringIsEqualToCString(*t_data, "box2pass", kMCCompareExact))
+			else if (MCStringIsEqualToCString(*t_data, "box2pass", kMCCompareCaseless))
 				t_new_filter = kMCBitmapEffectFilterTwoPassBox;
-			else if (MCStringIsEqualToCString(*t_data, "box3pass", kMCCompareExact))
+			else if (MCStringIsEqualToCString(*t_data, "box3pass", kMCCompareCaseless))
 				t_new_filter = kMCBitmapEffectFilterThreePassBox;
 			else
 			{

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -3704,7 +3704,7 @@ void MCObject::GetTextStyleElement(MCExecContext& ctxt, MCNameRef p_index, bool&
         t_style_set = gettextstyle();
     
     Font_textstyle t_style;
-    if (MCF_parsetextstyle(MCNameGetOldString(p_index), t_style) == ES_NORMAL)
+    if (MCF_parsetextstyle(MCNameGetString(p_index), t_style) == ES_NORMAL)
     {
         r_setting = MCF_istextstyleset(t_style_set, t_style);
         return;
@@ -3716,7 +3716,7 @@ void MCObject::GetTextStyleElement(MCExecContext& ctxt, MCNameRef p_index, bool&
 void MCObject::SetTextStyleElement(MCExecContext& ctxt, MCNameRef p_index, bool p_setting)
 {
     Font_textstyle t_style;
-    if (MCF_parsetextstyle(MCNameGetOldString(p_index), t_style) == ES_NORMAL)
+    if (MCF_parsetextstyle(MCNameGetString(p_index), t_style) == ES_NORMAL)
     {
         uint2 t_style_set;
 		if ((m_font_flags & FF_HAS_TEXTSTYLE) == 0)

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -620,9 +620,9 @@ static void MCInterfaceTextStyleParse(MCExecContext& ctxt, MCStringRef p_input, 
 		{
 			t_old_offset = t_new_offset + 1;
 
-			if (MCF_setweightstring(style, MCStringGetOldString(*t_text_style)))
+			if (MCF_setweightstring(style, *t_text_style))
 				continue;
-			if (MCF_setexpandstring(style, MCStringGetOldString(*t_text_style)))
+			if (MCF_setexpandstring(style, *t_text_style))
 				continue;
 			if (MCStringIsEqualToCString(*t_text_style, "oblique", kMCCompareCaseless))
 			{

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -475,7 +475,7 @@ public:
 	MCParagraph *texttoparagraphs(const MCString &data, Boolean isunicode);
 	
 	MCParagraph *parsestyledtextappendparagraph(MCArrayRef p_style, MCNameRef metadata, bool p_split, MCParagraph*& x_paragraphs);
-	void parsestyledtextappendblock(MCParagraph *p_paragraph, MCArrayRef p_style, const char *p_initial, const char *p_final, MCStringRef p_metadata, bool p_is_unicode);
+	void parsestyledtextappendblock(MCParagraph *p_paragraph, MCArrayRef p_style, MCStringRef p_initial, MCStringRef p_final, MCStringRef p_metadata, bool p_is_unicode);
 	void parsestyledtextblockarray(MCArrayRef p_block_value, MCParagraph*& x_paragraphs);
 	void parsestyledtextarray(MCArrayRef p_styled_text, bool p_paragraph_break, MCParagraph*& x_paragraphs);
 	

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -475,7 +475,7 @@ public:
 	MCParagraph *texttoparagraphs(const MCString &data, Boolean isunicode);
 	
 	MCParagraph *parsestyledtextappendparagraph(MCArrayRef p_style, MCNameRef metadata, bool p_split, MCParagraph*& x_paragraphs);
-	void parsestyledtextappendblock(MCParagraph *p_paragraph, MCArrayRef p_style, MCStringRef p_initial, MCStringRef p_final, MCStringRef p_metadata, bool p_is_unicode);
+	void parsestyledtextappendblock(MCParagraph *p_paragraph, MCArrayRef p_style, const char *p_initial, const char *p_final, MCStringRef p_metadata, bool p_is_unicode);
 	void parsestyledtextblockarray(MCArrayRef p_block_value, MCParagraph*& x_paragraphs);
 	void parsestyledtextarray(MCArrayRef p_styled_text, bool p_paragraph_break, MCParagraph*& x_paragraphs);
 	

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -1113,7 +1113,7 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 		//   an index, then decode which specific style is being manipulated.
 		if (which == P_TEXT_STYLE && !MCNameIsEmpty(index))
 		{
-			if (MCF_parsetextstyle(MCNameGetOldString(index), t_text_style) != ES_NORMAL)
+			if (MCF_parsetextstyle(MCNameGetString(index), t_text_style) != ES_NORMAL)
 				return ES_ERROR;
 
 			pspecstyle = MCF_istextstyleset(pstyle, t_text_style);
@@ -1197,6 +1197,8 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 		}
 		while (ei > 0);
 
+        MCAutoStringRef t_fname;
+        /* UNCHECKED */ MCStringCreateWithCString(fname, &t_fname);
 		if (!has)
 		{
 			if (effective)
@@ -1234,13 +1236,13 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 			if (mixed & MIXED_NAMES)
 				ep.setstaticcstring(MCmixedstring);
 			else
-				stat = MCF_unparsetextatts(which, ep, flags, fname, height, size, style);
+				stat = MCF_unparsetextatts(which, ep, flags, *t_fname, height, size, style);
 			break;
 		case P_TEXT_SIZE:
 			if (mixed & MIXED_SIZES)
 				ep.setstaticcstring(MCmixedstring);
 			else
-				stat = MCF_unparsetextatts(which, ep, flags, fname, height, size, style);
+				stat = MCF_unparsetextatts(which, ep, flags, *t_fname, height, size, style);
 			break;
 		case P_TEXT_STYLE:
 			// MW-2011-11-23: [[ Array TextStyle ]] If no textStyle has been specified
@@ -1250,7 +1252,7 @@ Exec_stat MCField::gettextatts(uint4 parid, Properties which, MCExecPoint &ep, M
 				if (mixed & MIXED_STYLES)
 					ep.setstaticcstring(MCmixedstring);
 				else
-					stat = MCF_unparsetextatts(which, ep, flags, fname, height, size, style);
+					stat = MCF_unparsetextatts(which, ep, flags, *t_fname, height, size, style);
 			}
 			else
 			{
@@ -1452,7 +1454,7 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 	verifyindex(pgptr, ei, true);
 
 	pgptr = indextoparagraph(pgptr, si, ei);
-	char *fname = NULL;
+	MCStringRef fname = NULL;
 	uint2 size = 0;
 	uint2 style = FA_DEFAULT_STYLE;
 	MCColor tcolor;
@@ -1493,7 +1495,7 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 		{
 			Font_textstyle t_text_style;
 
-			if (MCF_parsetextstyle(MCNameGetOldString(index), t_text_style) != ES_NORMAL)
+			if (MCF_parsetextstyle(MCNameGetString(index), t_text_style) != ES_NORMAL)
 				return ES_ERROR;
 
 			Boolean t_new_state;
@@ -1514,7 +1516,7 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 		// Fall through for default (non-array) handling.
 	case P_TEXT_FONT:
 	case P_TEXT_SIZE:
-		if (MCF_parsetextatts(which, MCStringGetOldString(*s), flags, fname, fontheight, size, style) != ES_NORMAL)
+		if (MCF_parsetextatts(which, *s, flags, fname, fontheight, size, style) != ES_NORMAL)
 			return ES_ERROR;
 		all = True;
 		if (which == P_TEXT_FONT)

--- a/engine/src/fieldstyledtext.cpp
+++ b/engine/src/fieldstyledtext.cpp
@@ -459,11 +459,11 @@ MCParagraph *MCField::parsestyledtextappendparagraph(MCArrayRef p_style, MCNameR
 	return t_new_paragraph;
 }
 
-void MCField::parsestyledtextappendblock(MCParagraph *p_paragraph, MCArrayRef p_style, MCStringRef p_initial, MCStringRef p_final, MCStringRef p_metadata, bool p_is_unicode)
+void MCField::parsestyledtextappendblock(MCParagraph *p_paragraph, MCArrayRef p_style, const char *p_initial, const char *p_final, MCStringRef p_metadata, bool p_is_unicode)
 {
 	// Make sure we don't try and append any more than 64K worth of bytes.
 	uint32_t t_text_length;
-	t_text_length = MCMin(MCStringGetCString(p_final) - MCStringGetCString(p_initial), 65534 - p_paragraph -> textsize);
+	t_text_length = MCMin(p_final - p_initial, 65534 - p_paragraph -> textsize);
 	
 	// If we are unicode and the text length is odd, chop off the last char.
 	if (p_is_unicode && (t_text_length & 1) != 0)
@@ -500,7 +500,7 @@ void MCField::parsestyledtextappendblock(MCParagraph *p_paragraph, MCArrayRef p_
 	t_block -> size = t_text_length;
 	
 	// Copy across the bytes of the text.
-	memcpy(p_paragraph -> text + t_block -> index, MCStringGetCString(p_initial), t_block -> size);
+	memcpy(p_paragraph -> text + t_block -> index, p_initial, t_block -> size);
 	p_paragraph -> textsize += t_block -> size;
 	
 	// Now set the block styles.
@@ -685,10 +685,7 @@ void MCField::parsestyledtextblockarray(MCArrayRef p_block_value, MCParagraph*& 
 		}
 
 		// We now add the range initial...final as a block.
-        MCAutoStringRef t_initial_str, t_final_str;
-        /* UNCHECKED */ MCStringCreateWithCString(t_text_initial_ptr, &t_initial_str);
-        /* UNCHECKED */ MCStringCreateWithCString(t_text_final_ptr, &t_final_str);
-		parsestyledtextappendblock(t_paragraph, *t_style_entry, *t_initial_str, *t_final_str, *t_metadata, t_is_unicode);
+		parsestyledtextappendblock(t_paragraph, *t_style_entry, t_text_initial_ptr, t_text_final_ptr, *t_metadata, t_is_unicode);
 		
 		// And, if we need a new paragraph, add it.
 		if (t_add_paragraph)

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -322,8 +322,8 @@ Boolean MCF_setslantlongstring(uint2 &style, const MCString &data)
 	return False;
 }
 
-Exec_stat MCF_parsetextatts(Properties which, const MCString &data,
-                            uint4 &flags, char *&fname, uint2 &height,
+Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
+                            uint4 &flags, MCStringRef &fname, uint2 &height,
                             uint2 &size, uint2 &style)
 {
 	int2 i1;
@@ -331,16 +331,16 @@ Exec_stat MCF_parsetextatts(Properties which, const MCString &data,
 	{
 	case P_TEXT_ALIGN:
 		flags &= ~F_ALIGNMENT;
-		if (data == MCleftstring || data.getlength() == 0)
+		if (MCStringIsEqualToCString(data, MCleftstring, kMCCompareExact) || MCStringIsEmpty(data))
 			flags |= F_ALIGN_LEFT;
 		else
-			if (data == MCcenterstring)
+			if (MCStringIsEqualToCString(data, MCcenterstring, kMCCompareExact))
 				flags |= F_ALIGN_CENTER;
 			else
-				if (data == MCrightstring)
+				if (MCStringIsEqualToCString(data, MCrightstring, kMCCompareExact))
 					flags |= F_ALIGN_RIGHT;
 				else
-					if (data == MCjustifystring)
+					if (MCStringIsEqualToCString(data, MCjustifystring, kMCCompareExact))
 						flags |= F_ALIGN_JUSTIFY;
 					else
 					{
@@ -350,12 +350,12 @@ Exec_stat MCF_parsetextatts(Properties which, const MCString &data,
 		break;
 	case P_TEXT_FONT:
 		{
-			fname = data.clone();
+			fname = MCValueRetain(data);
 			
 			// MW-2012-02-17: [[ IntrinsicUnicode ]] Strip any lang tag from the
 			//   fontname.
 			char *t_tag;
-			t_tag = strchr(fname, ',');
+			t_tag = strchr(MCStringGetCString(fname), ',');
 			if (t_tag != nil)
 				t_tag[0] = '\0';
 		}
@@ -370,7 +370,7 @@ Exec_stat MCF_parsetextatts(Properties which, const MCString &data,
 		height = i1;
 		break;
 	case P_TEXT_SIZE:
-		if (data.getlength() == 0)
+		if (MCStringIsEmpty(data))
 			i1 = 0;
 		else
 			if (!MCU_stoi2(data, i1))
@@ -385,8 +385,8 @@ Exec_stat MCF_parsetextatts(Properties which, const MCString &data,
 		{
 			// MW-2012-02-17: [[ SplitTextAttrs ]] If the string is empty, then
 			//   return 0 for the style - indicating to unset the property.
-			uint4 l = data.getlength();
-			const char *sptr = data.getstring();
+			uint4 l = MCStringGetLength(data);
+			const char *sptr = MCStringGetCString(data);
 			if (l == 0)
 				style = 0;
 			else
@@ -459,7 +459,7 @@ Exec_stat MCF_parsetextatts(Properties which, const MCString &data,
 }
 
 Exec_stat MCF_unparsetextatts(Properties which, MCExecPoint &ep, uint4 flags,
-                              const char *name, uint2 height, uint2 size,
+                              MCStringRef name, uint2 height, uint2 size,
                               uint2 style)
 {
 	switch (which)
@@ -482,7 +482,7 @@ Exec_stat MCF_unparsetextatts(Properties which, MCExecPoint &ep, uint4 flags,
 		}
 		break;
 	case P_TEXT_FONT:
-		ep.setsvalue(name);
+		ep.setsvalue(MCStringGetOldString(name));
 		break;
 	case P_TEXT_HEIGHT:
 		ep.setint(height);
@@ -527,27 +527,27 @@ Exec_stat MCF_unparsetextatts(Properties which, MCExecPoint &ep, uint4 flags,
 }
 
 // MW-2011-11-23: [[ Array TextStyle ]] Convert a textStyle name into the enum.
-Exec_stat MCF_parsetextstyle(const MCString &data, Font_textstyle &style)
+Exec_stat MCF_parsetextstyle(MCStringRef data, Font_textstyle &style)
 {
-	if (data == "bold")
+	if (MCStringIsEqualToCString(data, "bold", kMCCompareExact))
 		style = FTS_BOLD;
-	else if (data == "condensed")
+	else if (MCStringIsEqualToCString(data, "condensed", kMCCompareExact))
 		style = FTS_CONDENSED;
-	else if (data == "expanded")
+	else if (MCStringIsEqualToCString(data, "expanded", kMCCompareExact))
 		style = FTS_EXPANDED;
-	else if (data == "italic")
+	else if (MCStringIsEqualToCString(data, "italic", kMCCompareExact))
 		style = FTS_ITALIC;
-	else if (data == "oblique")
+	else if (MCStringIsEqualToCString(data, "oblique", kMCCompareExact))
 		style = FTS_OBLIQUE;
-	else if (data == MCboxstring)
+	else if (MCStringIsEqualToCString(data, MCboxstring, kMCCompareExact))
 		style = FTS_BOX;
-	else if (data == MCthreedboxstring)
+	else if (MCStringIsEqualToCString(data, MCthreedboxstring, kMCCompareExact))
 		style = FTS_3D_BOX;
-	else if (data == MCunderlinestring)
+	else if (MCStringIsEqualToCString(data, MCunderlinestring, kMCCompareExact))
 		style = FTS_UNDERLINE;
-	else if (data == MCstrikeoutstring)
+	else if (MCStringIsEqualToCString(data, MCstrikeoutstring, kMCCompareExact))
 		style = FTS_STRIKEOUT;
-	else if (data == MCgroupstring || data == MClinkstring)
+	else if (MCStringIsEqualToCString(data, MCgroupstring, kMCCompareExact) || MCStringIsEqualToCString(data, MClinkstring, kMCCompareExact))
 		style = FTS_LINK;
 	else
 	{

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -353,7 +353,7 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 			// MW-2012-02-17: [[ IntrinsicUnicode ]] Strip any lang tag from the
 			//   fontname.
 			char *t_tag;
-			t_tag = strchr(MCStringGetCString(fname), ',');
+			t_tag = strchr(strdup(MCStringGetCString(fname)), ',');
 			if (t_tag != nil)
 				t_tag[0] = '\0';
 		}

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -250,7 +250,7 @@ Boolean MCF_setweightstring(uint2 &style, MCStringRef data)
 {
 	uint2 w;
 	for (w = MCFW_UNDEFINED ; w <= MCFW_ULTRABOLD ; w++)
-		if (MCStringIsEqualToCString(data, weightstrings[w], kMCCompareExact))
+		if (MCStringIsEqualToCString(data, weightstrings[w], kMCCompareCaseless))
 			break;
 	if (w <= MCFW_ULTRABOLD)
 	{
@@ -278,7 +278,7 @@ Boolean MCF_setexpandstring(uint2 &style, MCStringRef data)
 {
 	uint2 w;
 	for (w = FE_UNDEFINED ; w <= FE_ULTRAEXPANDED ; w++)
-		if (MCStringIsEqualToCString(data, expandstrings[w], kMCCompareExact))
+		if (MCStringIsEqualToCString(data, expandstrings[w], kMCCompareCaseless))
 			break;
 	if (w <= FE_ULTRAEXPANDED)
 	{
@@ -309,12 +309,12 @@ const char *MCF_getslantlongstring(uint2 style)
 
 Boolean MCF_setslantlongstring(uint2 &style, MCStringRef data)
 {
-	if (MCStringIsEqualToCString(data, "oblique", kMCCompareExact))
+	if (MCStringIsEqualToCString(data, "oblique", kMCCompareCaseless))
 	{
 		style |= FA_OBLIQUE;
 		return True;
 	}
-	if (MCStringIsEqualToCString(data, "italic", kMCCompareExact))
+	if (MCStringIsEqualToCString(data, "italic", kMCCompareCaseless))
 	{
 		style |= FA_ITALIC;
 		return True;
@@ -331,16 +331,16 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 	{
 	case P_TEXT_ALIGN:
 		flags &= ~F_ALIGNMENT;
-		if (MCStringIsEqualToCString(data, MCleftstring, kMCCompareExact) || MCStringIsEmpty(data))
+		if (MCStringIsEqualToCString(data, MCleftstring, kMCCompareCaseless) || MCStringIsEmpty(data))
 			flags |= F_ALIGN_LEFT;
 		else
-			if (MCStringIsEqualToCString(data, MCcenterstring, kMCCompareExact))
+			if (MCStringIsEqualToCString(data, MCcenterstring, kMCCompareCaseless))
 				flags |= F_ALIGN_CENTER;
 			else
-				if (MCStringIsEqualToCString(data, MCrightstring, kMCCompareExact))
+				if (MCStringIsEqualToCString(data, MCrightstring, kMCCompareCaseless))
 					flags |= F_ALIGN_RIGHT;
 				else
-					if (MCStringIsEqualToCString(data, MCjustifystring, kMCCompareExact))
+					if (MCStringIsEqualToCString(data, MCjustifystring, kMCCompareCaseless))
 						flags |= F_ALIGN_JUSTIFY;
 					else
 					{
@@ -410,40 +410,40 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 						continue;
 					if (MCF_setslantlongstring(style, *tdata))
 						continue;
-					if (MCStringIsEqualToCString(*tdata, MCplainstring, kMCCompareExact))
+					if (MCStringIsEqualToCString(*tdata, MCplainstring, kMCCompareCaseless))
 					{
 						style = FA_DEFAULT_STYLE;
 						continue;
 					}
-					if (MCStringIsEqualToCString(*tdata, MCmixedstring, kMCCompareExact))
+					if (MCStringIsEqualToCString(*tdata, MCmixedstring, kMCCompareCaseless))
 					{
 						style = FA_DEFAULT_STYLE;
 						continue;
 					}
-					if (MCStringIsEqualToCString(*tdata, MCboxstring, kMCCompareExact))
+					if (MCStringIsEqualToCString(*tdata, MCboxstring, kMCCompareCaseless))
 					{
 						style &= ~FA_3D_BOX;
 						style |= FA_BOX;
 						continue;
                     }
                 
-					if (MCStringIsEqualToCString(*tdata, MCthreedboxstring, kMCCompareExact))
+					if (MCStringIsEqualToCString(*tdata, MCthreedboxstring, kMCCompareCaseless))
 					{
 						style &= ~FA_BOX;
 						style |= FA_3D_BOX;
 						continue;
 					}
-					if (MCStringIsEqualToCString(*tdata, MCunderlinestring, kMCCompareExact))
+					if (MCStringIsEqualToCString(*tdata, MCunderlinestring, kMCCompareCaseless))
 					{
 						style |= FA_UNDERLINE;
 						continue;
 					}
-					if (MCStringIsEqualToCString(*tdata, MCstrikeoutstring, kMCCompareExact))
+					if (MCStringIsEqualToCString(*tdata, MCstrikeoutstring, kMCCompareCaseless))
 					{
 						style |= FA_STRIKEOUT;
 						continue;
 					}
-					if (MCStringIsEqualToCString(*tdata, MCgroupstring, kMCCompareExact) || MCStringIsEqualToCString(*tdata, MClinkstring, kMCCompareExact))
+					if (MCStringIsEqualToCString(*tdata, MCgroupstring, kMCCompareCaseless) || MCStringIsEqualToCString(*tdata, MClinkstring, kMCCompareCaseless))
 					{
 						style |= FA_LINK;
 						continue;
@@ -530,25 +530,25 @@ Exec_stat MCF_unparsetextatts(Properties which, MCExecPoint &ep, uint4 flags, MC
 // MW-2011-11-23: [[ Array TextStyle ]] Convert a textStyle name into the enum.
 Exec_stat MCF_parsetextstyle(MCStringRef data, Font_textstyle &style)
 {
-	if (MCStringIsEqualToCString(data, "bold", kMCCompareExact))
+	if (MCStringIsEqualToCString(data, "bold", kMCCompareCaseless))
 		style = FTS_BOLD;
-	else if (MCStringIsEqualToCString(data, "condensed", kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, "condensed", kMCCompareCaseless))
 		style = FTS_CONDENSED;
-	else if (MCStringIsEqualToCString(data, "expanded", kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, "expanded", kMCCompareCaseless))
 		style = FTS_EXPANDED;
-	else if (MCStringIsEqualToCString(data, "italic", kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, "italic", kMCCompareCaseless))
 		style = FTS_ITALIC;
-	else if (MCStringIsEqualToCString(data, "oblique", kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, "oblique", kMCCompareCaseless))
 		style = FTS_OBLIQUE;
-	else if (MCStringIsEqualToCString(data, MCboxstring, kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, MCboxstring, kMCCompareCaseless))
 		style = FTS_BOX;
-	else if (MCStringIsEqualToCString(data, MCthreedboxstring, kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, MCthreedboxstring, kMCCompareCaseless))
 		style = FTS_3D_BOX;
-	else if (MCStringIsEqualToCString(data, MCunderlinestring, kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, MCunderlinestring, kMCCompareCaseless))
 		style = FTS_UNDERLINE;
-	else if (MCStringIsEqualToCString(data, MCstrikeoutstring, kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, MCstrikeoutstring, kMCCompareCaseless))
 		style = FTS_STRIKEOUT;
-	else if (MCStringIsEqualToCString(data, MCgroupstring, kMCCompareExact) || MCStringIsEqualToCString(data, MClinkstring, kMCCompareExact))
+	else if (MCStringIsEqualToCString(data, MCgroupstring, kMCCompareCaseless) || MCStringIsEqualToCString(data, MClinkstring, kMCCompareCaseless))
 		style = FTS_LINK;
 	else
 	{

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -347,15 +347,13 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 					}
 		break;
 	case P_TEXT_FONT:
-		{
-			fname = MCValueRetain(data);
-			
-			// MW-2012-02-17: [[ IntrinsicUnicode ]] Strip any lang tag from the
+		{// MW-2012-02-17: [[ IntrinsicUnicode ]] Strip any lang tag from the
 			//   fontname.
-			char *t_tag;
-			t_tag = strchr(strdup(MCStringGetCString(fname)), ',');
-			if (t_tag != nil)
-				t_tag[0] = '\0';
+			uindex_t t_offset;
+			if (MCStringFirstIndexOfChar(data, ',', 0, kMCCompareExact, t_offset))
+				/* UNCHECKED */ MCStringCopySubstring(data, MCRangeMake(t_offset + 1, MCStringGetLength(data) - (t_offset + 1)), fname);
+			else
+				fname = MCValueRetain(data);
 		}
 		break;
 	case P_TEXT_HEIGHT:

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -246,11 +246,11 @@ const char *MCF_getweightstring(uint2 style)
 	return weightstrings[weight];
 }
 
-Boolean MCF_setweightstring(uint2 &style, const MCString &data)
+Boolean MCF_setweightstring(uint2 &style, MCStringRef data)
 {
 	uint2 w;
 	for (w = MCFW_UNDEFINED ; w <= MCFW_ULTRABOLD ; w++)
-		if (data == weightstrings[w])
+		if (MCStringIsEqualToCString(data, weightstrings[w], kMCCompareExact))
 			break;
 	if (w <= MCFW_ULTRABOLD)
 	{
@@ -274,11 +274,11 @@ const char *MCF_getexpandstring(uint2 style)
 	return expandstrings[expand];
 }
 
-Boolean MCF_setexpandstring(uint2 &style, const MCString &data)
+Boolean MCF_setexpandstring(uint2 &style, MCStringRef data)
 {
 	uint2 w;
 	for (w = FE_UNDEFINED ; w <= FE_ULTRAEXPANDED ; w++)
-		if (data == expandstrings[w])
+		if (MCStringIsEqualToCString(data, expandstrings[w], kMCCompareExact))
 			break;
 	if (w <= FE_ULTRAEXPANDED)
 	{
@@ -307,14 +307,14 @@ const char *MCF_getslantlongstring(uint2 style)
 	return "";
 }
 
-Boolean MCF_setslantlongstring(uint2 &style, const MCString &data)
+Boolean MCF_setslantlongstring(uint2 &style, MCStringRef data)
 {
-	if (data == "oblique")
+	if (MCStringIsEqualToCString(data, "oblique", kMCCompareExact))
 	{
 		style |= FA_OBLIQUE;
 		return True;
 	}
-	if (data == "italic")
+	if (MCStringIsEqualToCString(data, "italic", kMCCompareExact))
 	{
 		style |= FA_ITALIC;
 		return True;
@@ -400,48 +400,50 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 						sptr += l;
 						l = 0;
 					}
-					MCString tdata(startptr, sptr - startptr);
+                    MCAutoStringRef tdata;
+					/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)startptr, sptr - startptr, &tdata);
 					MCU_skip_char(sptr, l);
 					MCU_skip_spaces(sptr, l);
-					if (MCF_setweightstring(style, tdata))
+					if (MCF_setweightstring(style, *tdata))
 						continue;
-					if (MCF_setexpandstring(style, tdata))
+					if (MCF_setexpandstring(style, *tdata))
 						continue;
-					if (MCF_setslantlongstring(style, tdata))
+					if (MCF_setslantlongstring(style, *tdata))
 						continue;
-					if (tdata == MCplainstring)
+					if (MCStringIsEqualToCString(*tdata, MCplainstring, kMCCompareExact))
 					{
 						style = FA_DEFAULT_STYLE;
 						continue;
 					}
-					if (tdata == MCmixedstring)
+					if (MCStringIsEqualToCString(*tdata, MCmixedstring, kMCCompareExact))
 					{
 						style = FA_DEFAULT_STYLE;
 						continue;
 					}
-					if (tdata == MCboxstring)
+					if (MCStringIsEqualToCString(*tdata, MCboxstring, kMCCompareExact))
 					{
 						style &= ~FA_3D_BOX;
 						style |= FA_BOX;
 						continue;
-					}
-					if (tdata == MCthreedboxstring)
+                    }
+                
+					if (MCStringIsEqualToCString(*tdata, MCthreedboxstring, kMCCompareExact))
 					{
 						style &= ~FA_BOX;
 						style |= FA_3D_BOX;
 						continue;
 					}
-					if (tdata == MCunderlinestring)
+					if (MCStringIsEqualToCString(*tdata, MCunderlinestring, kMCCompareExact))
 					{
 						style |= FA_UNDERLINE;
 						continue;
 					}
-					if (tdata == MCstrikeoutstring)
+					if (MCStringIsEqualToCString(*tdata, MCstrikeoutstring, kMCCompareExact))
 					{
 						style |= FA_STRIKEOUT;
 						continue;
 					}
-					if (tdata == MCgroupstring || tdata == MClinkstring)
+					if (MCStringIsEqualToCString(*tdata, MCgroupstring, kMCCompareExact) || MCStringIsEqualToCString(*tdata, MClinkstring, kMCCompareExact))
 					{
 						style |= FA_LINK;
 						continue;
@@ -458,9 +460,8 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 	return ES_NORMAL;
 }
 
-Exec_stat MCF_unparsetextatts(Properties which, MCExecPoint &ep, uint4 flags,
-                              MCStringRef name, uint2 height, uint2 size,
-                              uint2 style)
+    
+Exec_stat MCF_unparsetextatts(Properties which, MCExecPoint &ep, uint4 flags, MCStringRef name, uint2 height, uint2 size, uint2 style)
 {
 	switch (which)
 	{
@@ -610,13 +611,13 @@ void MCF_changetextstyle(uint2& x_style_set, Font_textstyle p_style, bool p_new_
 	switch(p_style)
 	{
 	case FTS_BOLD:
-		MCF_setweightstring(x_style_set, p_new_state ? "bold" : "medium");
+		MCF_setweightstring(x_style_set, p_new_state ? MCSTR("bold") : MCSTR("medium"));
 		return;
 	case FTS_CONDENSED:
-		MCF_setexpandstring(x_style_set, p_new_state ? "condensed" : "normal");
+		MCF_setexpandstring(x_style_set, p_new_state ? MCSTR("condensed") : MCSTR("normal"));
 		return;
 	case FTS_EXPANDED:
-		MCF_setexpandstring(x_style_set, p_new_state ? "expanded" : "normal");
+		MCF_setexpandstring(x_style_set, p_new_state ? MCSTR("expanded") : MCSTR("normal"));
 		return;
 	case FTS_ITALIC:
 		t_flag = FA_ITALIC;

--- a/engine/src/font.h
+++ b/engine/src/font.h
@@ -130,13 +130,13 @@ enum Font_textstyle {
 
 extern uint2 MCF_getweightint(uint2 style);
 extern const char *MCF_getweightstring(uint2 style);
-extern Boolean MCF_setweightstring(uint2 &style, const MCString &data);
+extern Boolean MCF_setweightstring(uint2 &style, MCStringRef data);
 extern uint2 MCF_getexpandint(uint2 style);
 extern const char *MCF_getexpandstring(uint2 style);
-extern Boolean MCF_setexpandstring(uint2 &style, const MCString &data);
+extern Boolean MCF_setexpandstring(uint2 &style, MCStringRef data);
 extern const char *MCF_getslantshortstring(uint2 style);
 extern const char *MCF_getslantlongstring(uint2 style);
-extern Boolean MCF_setslantlongstring(uint2 &style, const MCString &data);
+extern Boolean MCF_setslantlongstring(uint2 &style, MCStringRef data);
 extern Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 	                                   uint4 &flags, MCStringRef &fname,
 	                                   uint2 &height, uint2 &size, uint2 &style);

--- a/engine/src/font.h
+++ b/engine/src/font.h
@@ -137,14 +137,14 @@ extern Boolean MCF_setexpandstring(uint2 &style, const MCString &data);
 extern const char *MCF_getslantshortstring(uint2 style);
 extern const char *MCF_getslantlongstring(uint2 style);
 extern Boolean MCF_setslantlongstring(uint2 &style, const MCString &data);
-extern Exec_stat MCF_parsetextatts(Properties which, const MCString &data,
-	                                   uint4 &flags, char *&fname,
+extern Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
+	                                   uint4 &flags, MCStringRef &fname,
 	                                   uint2 &height, uint2 &size, uint2 &style);
 extern Exec_stat MCF_unparsetextatts(Properties which, MCExecPoint &ep,
-	                                     uint4 flags, const char *name,
+	                                     uint4 flags, MCStringRef name,
 	                                     uint2 height, uint2 size, uint2 style);
 
-extern Exec_stat MCF_parsetextstyle(const MCString &data, Font_textstyle &style);
+extern Exec_stat MCF_parsetextstyle(MCStringRef data, Font_textstyle &style);
 extern const char *MCF_unparsetextstyle(Font_textstyle style);
 extern void MCF_changetextstyle(uint2& x_style_set, Font_textstyle p_style, bool p_new_state);
 extern bool MCF_istextstyleset(uint2 styleset, Font_textstyle style);

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -786,7 +786,7 @@ Exec_stat MCObject::getarrayprop(uint4 parid, Properties which, MCExecPoint& ep,
 
 		// Parse the requested text style.
 		Font_textstyle t_style;
-		if (MCF_parsetextstyle(MCNameGetOldString(key), t_style) != ES_NORMAL)
+		if (MCF_parsetextstyle(MCNameGetString(key), t_style) != ES_NORMAL)
 			return ES_ERROR;
 
 		// Check the textstyle string is within the object's textstyle set.
@@ -1854,7 +1854,7 @@ Exec_stat MCObject::setarrayprop(uint4 parid, Properties which, MCExecPoint& ep,
 
 		// Parse the requested text style.
 		Font_textstyle t_style;
-		if (MCF_parsetextstyle(MCNameGetOldString(key), t_style) != ES_NORMAL)
+		if (MCF_parsetextstyle(MCNameGetString(key), t_style) != ES_NORMAL)
 			return ES_ERROR;
 
 		// MW-2012-02-19: [[ SplitTextAttrs ]] If we have no textStyle set then

--- a/engine/src/paragrafattr.cpp
+++ b/engine/src/paragrafattr.cpp
@@ -438,8 +438,10 @@ Exec_stat MCParagraph::setparagraphattr(Properties which, MCExecPoint& ep)
 			
 			uint4 myflags;
 			uint2 fontheight, size, style;
-			char *fname;
-			if (MCF_parsetextatts(which, ep . getsvalue(), myflags, fname, fontheight, size, style) != ES_NORMAL)
+			MCAutoStringRef fname;
+            MCAutoStringRef t_value;
+            ep . copyasstringref(&t_value);
+			if (MCF_parsetextatts(which, *t_value, myflags, &fname, fontheight, size, style) != ES_NORMAL)
 				return ES_ERROR;
 
 			if (attrs == nil)


### PR DESCRIPTION
Updates on: 
MCF_parsetextstyle(MCString const&, Font_textstyle&)
MCF_unparsetextatts(Properties, MCExecPoint&, unsigned int, char const_, unsigned short, unsigned short, unsigned short)
MCField::parsestyledtextappendblock(MCParagraph_, __MCArray_, char const_, char const_, __MCString_, bool)
MCF_parsetextatts(Properties, MCString const&, unsigned int&, char*&, unsigned short&, unsigned short&, unsigned short&)
MCF_setweightstring(unsigned short&, MCString const&)
MCF_setexpandstring(unsigned short&, MCString const&)
MCF_setslantlongstring(unsigned short&, MCString const&)
