### PR TITLE
Feature/edit script at

### DIFF
--- a/docs/dictionary/command/edit.xml
+++ b/docs/dictionary/command/edit.xml
@@ -3,7 +3,7 @@
   <name>edit</name>
   <type>command</type>
   <syntax>
-    <example>edit [the] script of <i>object</i></example>
+    <example>edit [the] script of <i>object</i> [at line,column]</example>
   </syntax>
   <library></library>
   <objects>
@@ -23,6 +23,7 @@
   </references>
   <history>
     <introduced version="1.0">Added.</introduced>
+    <introduced version="6.5">Added optional at syntax.</introduced>
   </history>
   <platforms>
     <mac/>
@@ -40,9 +41,9 @@
   <examples>
     <example>edit the script of the mouseStack</example>
     <example>edit the script of this card</example>
-    <example>edit the script of player "Show Me"</example>
+    <example>edit the script of player "Show Me" at 100,0</example>
   </examples>
   <description>
-    <p>Use the <b>edit</b> <glossary tag="command">command</glossary> in the <glossary tag="development environment">development environment</glossary> to open the LiveCode <glossary tag="script editor">script editor</glossary> with the <property tag="script">script</property> of the specified <glossary tag="object">object</glossary>.</p><p/><p><b>Parameters:</b></p><p>The <i>object</i> is any <href tag="reference/object_reference.rev">object reference</href>.</p><p/><p><b>Comments:</b></p><p>The <b>edit</b> <glossary tag="command">command</glossary> is equivalent to selecting the object and choosing Object menu<img src="202656"/>Object Script<important/>. If the script ed is not open, the <b>edit</b> command opens a window that shows the <a/>script.</p>
+    <p>Use the <b>edit</b> <glossary tag="command">command</glossary> in the <glossary tag="development environment">development environment</glossary> to open the LiveCode <glossary tag="script editor">script editor</glossary> with the <property tag="script">script</property> of the specified <glossary tag="object">object</glossary>.</p><p/><p><b>Parameters:</b></p><p>The <i>object</i> is any <href tag="reference/object_reference.rev">object reference</href>.</p><p>Usint the optional at syntax will pass the subsequent items to the editScript handler as a second parameter. By convention the first two parameters should be a line number and a column character offset from the start of the line.</p><p/><p><b>Comments:</b></p><p>The <b>edit</b> <glossary tag="command">command</glossary> is equivalent to selecting the object and choosing Object menu<img src="202656"/>Object Script<important/>. If the script ed is not open, the <b>edit</b> command opens a window that shows the <a/>script.</p>
   </description>
 </doc>

--- a/docs/dictionary/message/editScript.xml
+++ b/docs/dictionary/message/editScript.xml
@@ -3,7 +3,7 @@
   <name>editScript</name>
   <type>message</type>
   <syntax>
-    <example>editScript <i>objectID</i></example>
+    <example>editScript <i>objectID</i>,<i>atItems</i></example>
   </syntax>
   <library></library>
   <objects>
@@ -19,6 +19,7 @@
   </references>
   <history>
     <introduced version="1.0">Added.</introduced>
+    <introduced version="6.5">Added atItems.</introduced>
   </history>
   <platforms>
     <mac/>
@@ -37,6 +38,6 @@
     <example>on editScript theObject <code><i>-- save current script before editing</i></code></p><p>  set the oldScript of theObject to the script of theObject</p><p>  pass editScript</p><p>end editScript</example>
   </examples>
   <description>
-    <p>Handle the <b>editScript</b> <keyword tag="message box">message</keyword> if you want to intercept attempts to edit a <property tag="script">script</property> via the <keyword tag="message box">message box</keyword> or a <glossary tag="handler">handler</glossary>.</p><p/><p><b>Parameters:</b></p><p>The <i>objectID</i> is the long <property tag="ID">ID</property> <glossary tag="property">property</glossary> of the <glossary tag="object">object</glossary> whose <property tag="script">script</property> is about to be opened.</p><p/><p><b>Comments:</b></p><p>The <b>editScript</b> <keyword tag="message box">message</keyword> is sent when you use the <command tag="edit">edit</command> command in a <glossary tag="handler">handler</glossary>. However, it is not sent when the <glossary tag="development environment">development environment</glossary> is active.</p>
+    <p>Handle the <b>editScript</b> <keyword tag="message box">message</keyword> if you want to intercept attempts to edit a <property tag="script">script</property> via the <keyword tag="message box">message box</keyword> or a <glossary tag="handler">handler</glossary>.</p><p/><p><b>Parameters:</b></p><p>The <i>objectID</i> is the long <property tag="ID">ID</property> <glossary tag="property">property</glossary> of the <glossary tag="object">object</glossary> whose <property tag="script">script</property> is about to be opened.</p><p>The <i>atItems</i> parameter may be sent if the optional edit script of object at syntax is used. By convention the atItems are used to provide a line and column that a script editor should be opened at.<p/><p><b>Comments:</b></p><p>The <b>editScript</b> <keyword tag="message box">message</keyword> is sent when you use the <command tag="edit">edit</command> command in a <glossary tag="handler">handler</glossary>. However, it is not sent when the <glossary tag="development environment">development environment</glossary> is active.</p>
   </description>
 </doc>

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -574,7 +574,7 @@ Parse_stat MCEdit::parse(MCScriptPoint &sp)
 	{
 		if (sp.parseexp(False, True, &m_at) != PS_NORMAL)
         {
-            MCperror->add(PE_EDIT_NOTARGET, sp);
+            MCperror->add(PE_EDIT_NOAT, sp);
             return PS_ERROR;
         }
 	}
@@ -600,7 +600,7 @@ Exec_stat MCEdit::exec(MCExecPoint &ep)
         if (m_at->eval(ep) != ES_NORMAL)
         {
             MCeerror->add
-            (EE_FIND_BADSTRING, line, pos);
+            (EE_EDIT_BADAT, line, pos);
             return ES_ERROR;
         }
         t_at = ep.getsvalue();

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -546,6 +546,7 @@ Exec_stat MCDoMenu::exec(MCExecPoint &ep)
 MCEdit::~MCEdit()
 {
 	delete target;
+    delete m_at;
 }
 
 Parse_stat MCEdit::parse(MCScriptPoint &sp)
@@ -568,6 +569,15 @@ Parse_stat MCEdit::parse(MCScriptPoint &sp)
 		MCperror->add(PE_EDIT_NOTARGET, sp);
 		return PS_ERROR;
 	}
+    // MERG 2013-9-13: [[ EditScriptChunk ]] Added line and column
+    if (sp.skip_token(SP_FACTOR, TT_PREP, PT_AT) == PS_NORMAL)
+	{
+		if (sp.parseexp(False, True, &m_at) != PS_NORMAL)
+        {
+            MCperror->add(PE_EDIT_NOTARGET, sp);
+            return PS_ERROR;
+        }
+	}
 	return PS_NORMAL;
 }
 
@@ -581,12 +591,27 @@ Exec_stat MCEdit::exec(MCExecPoint &ep)
 		return ES_ERROR;
 	}
 
-	// MW-2010-10-13: [[ Bug 7476 ]] Make sure we temporarily turn off lock messages
+    // MERG 2013-9-13: [[ EditScriptChunk ]] Added at expression that's passed through as a second parameter to editScript
+    MCString t_at;
+    t_at = NULL;
+    
+    if (m_at != NULL)
+    {
+        if (m_at->eval(ep) != ES_NORMAL)
+        {
+            MCeerror->add
+            (EE_FIND_BADSTRING, line, pos);
+            return ES_ERROR;
+        }
+        t_at = ep.getsvalue();
+    }
+    
+    // MW-2010-10-13: [[ Bug 7476 ]] Make sure we temporarily turn off lock messages
 	//   before invoking the method - since it requires message sending to work!
 	Boolean t_old_lock;
 	t_old_lock = MClockmessages;
 	MClockmessages = False;
-	optr->editscript();
+	optr->editscript(t_at);
 	MClockmessages = t_old_lock;
 
 	return ES_NORMAL;

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -125,11 +125,14 @@ public:
 class MCEdit : public MCStatement
 {
 	MCChunk *target;
+    // MERG 2013-9-13: [[ EditScriptChunk ]] Added at expression that's passed through as a second parameter to editScript
+    MCExpression *m_at;
 public:
 	MCEdit()
 	{
 		target = NULL;
-	}
+        m_at = NULL;
+    }
 	virtual ~MCEdit();
 	virtual Parse_stat parse(MCScriptPoint &);
 	virtual Exec_stat exec(MCExecPoint &);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2416,6 +2416,10 @@ enum Exec_errors
 	
 	// {EE-0796} group: object cannot be grouped
 	EE_GROUP_NOTGROUPABLE,
+    
+    // {EE-0797} edit script: bad at expression
+	EE_EDIT_BADAT,
+    
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2523,11 +2523,15 @@ Exec_stat MCObject::eval(const char *sptr, MCExecPoint &ep)
 	return stat;
 }
 
-void MCObject::editscript()
+// MERG 2013-9-13: [[ EditScriptChunk ]] Added at expression that's passed through as a second parameter to editScript
+void MCObject::editscript(MCString p_at)
 {
 	MCExecPoint ep(this, NULL, NULL);
 	getprop(0, P_LONG_ID, ep, False);
-	getcard()->message_with_args(MCM_edit_script, ep.getsvalue());
+    if (p_at != NULL)
+        getcard()->message_with_args(MCM_edit_script, ep.getsvalue(), p_at);
+    else
+        getcard()->message_with_args(MCM_edit_script, ep.getsvalue());
 }
 
 void MCObject::removefrom(MCObjectList *l)

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -548,7 +548,8 @@ public:
 	void positionrel(const MCRectangle &dptr, Object_pos xpos, Object_pos ypos);
 	Exec_stat domess(const char *sptr);
 	Exec_stat eval(const char *sptr, MCExecPoint &ep);
-	void editscript();
+	// MERG 2013-9-13: [[ EditScriptChunk ]] Added at expression that's passed through as a second parameter to editScript
+    void editscript(MCString p_at = NULL);
 	void removefrom(MCObjectList *l);
 	Boolean attachmenu(MCStack *sptr);
 	void alloccolors();

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1618,6 +1618,10 @@ enum Parse_errors
 
 	// {PE-0530} variance: bad parameters
 	PE_VARIANCE_BADPARAM,
+    
+    // {EE-0531} edit script: no at expression
+	PE_EDIT_NOAT,
+
 };
 
 extern const char *MCparsingerrors;


### PR DESCRIPTION
Added optional at parameter passed to the editScript message. Currently the content of the parameter is unchecked so it could be used by an IDE team for other purposes. I've documented line,column as convention but the implementation allows for extra parameters... such as inNewWindow or some other feature that an IDE team might want to expose.
