### PR TITLE
[[ Bugfix 10846 ]] Warn if password-protected stack is opened in Communi...

### DIFF
--- a/docs/notes/bugfix-10846.md
+++ b/docs/notes/bugfix-10846.md
@@ -1,0 +1,1 @@
+# Warn if password-protected stack is opened in Community Edition

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -133,9 +133,15 @@ IO_stat MCStack::extendedload(MCObjectInputStream& p_stream, const char *p_versi
 IO_stat MCStack::load(IO_handle stream, const char *version, uint1 type)
 {
 	IO_stat stat;
-
+	
+	// FG-2013-09-20 [[ Bugfix 10846 ]]
+	// Community edition cannot read encrypted stacks
 	if (type != OT_STACK)
+	{
+		if (MCresult->isclear() && type == OT_ENCRYPT_STACK)
+			MCresult->sets("Encrypted stacks cannot be opened in Community Edition");
 		return IO_ERROR;
+	}
 	
 	uint32_t t_reserved = 0;
 	


### PR DESCRIPTION
...ty Edition

The error message when opening a password-protected stack on community edition has been changed to say just that instead of reporting a corrupt stack as it did previously. The result is updated to reflect this.
