### PR TITLE
[[ Bug 11214 ]] Make sure there is enough room for the NUL terminator wh...

### DIFF
--- a/docs/notes/bugfix-11214.md
+++ b/docs/notes/bugfix-11214.md
@@ -1,0 +1,2 @@
+# Crash when getting htmlText of certain fields.
+

--- a/engine/src/textbuffer.h
+++ b/engine/src/textbuffer.h
@@ -134,7 +134,9 @@ public:
 #error text_buffer_t::appendtextf not implemented
 #endif
 
-		if (!ensure(t_count))
+		// MW-2013-09-30: [[ Bug 11214 ]] Make sure we take into account room for
+		//   the NUL terminator.
+		if (!ensure(t_count + 1))
 			return false;
 	
 		va_start(t_args, p_format);


### PR DESCRIPTION
...en using textbuffer::appendtextf.
