### PR TITLE
Refactor syntax unicode get ep2 new

### DIFF
--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1155,8 +1155,9 @@ static void MCEngineSplitScriptIntoMessageAndParameters(MCExecContext& ctxt, MCS
 
 			// MW-2011-08-11: [[ Bug 9668 ]] Make sure we copy 'pdata' if we use it, since
 			//   mptr (into which it points) only lasts as long as this method call.
-			if (ctxt . GetEP() . gethandler() -> eval(ctxt . GetEP()) == ES_NORMAL)
-				newparam->set_argument(ctxt . GetEP());
+			MCAutoValueRef t_value;
+			if (ctxt . GetHandler() -> eval_ctxt(ctxt, &t_value)  == ES_NORMAL)
+				newparam->setvalueref_argument(*t_value);
 			else
 				newparam->copysvalue_argument(pdata);
 

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1836,7 +1836,7 @@ void MCFilesExecWriteToStderr(MCExecContext& ctxt, MCStringRef p_data, int p_uni
 		ctxt . SetTheResultToEmpty();
 }
 
-//This method causes the program to crash (the call to MCFilesExecWriteToStream(ctxt, t_stream, *t_text_data, p_unit_type, t_stat))
+
 void MCFilesExecWriteToFileOrDriver(MCExecContext& ctxt, MCNameRef p_file, MCStringRef p_data, bool p_is_end, int p_unit_type, int64_t p_at)
 {
 	
@@ -1918,15 +1918,18 @@ void MCFilesExecWriteToProcess(MCExecContext& ctxt, MCNameRef p_process, MCStrin
 
 	if (t_textmode)
 	{
-		MCAutoStringRef t_text_data;
-		MCStringConvertLineEndingsFromLiveCode(p_data, &t_text_data);
+		MCStringRef t_text_data;
+		/* UNCHECKED */ MCStringConvertLineEndingsFromLiveCode(p_data, t_text_data);
 		// MW-2004-11-17: EOD should only happen when writing to processes in text-mode
-		if (MCU_offset("\004", MCStringGetOldString(*t_text_data), offset, True))
+		if (MCU_offset("\004", MCStringGetOldString(t_text_data), offset, True))
 		{
-			ctxt.GetEP().substring(0, offset);
+			MCAutoStringRef t_substring;
+			MCStringCopySubstring(t_text_data, MCRangeMake(0, offset), &t_substring);
+			MCValueAssign(t_text_data, *t_substring);
 			haseof = True;
 		}
-		MCFilesExecWriteToStream(ctxt, t_stream, *t_text_data, p_unit_type, t_stat);
+		MCFilesExecWriteToStream(ctxt, t_stream, t_text_data, p_unit_type, t_stat);
+		MCValueRelease(t_text_data);
 	}
 	else
 		MCFilesExecWriteToStream(ctxt, t_stream, p_data, p_unit_type, t_stat);

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1912,7 +1912,7 @@ void MCFilesExecWriteToProcess(MCExecContext& ctxt, MCNameRef p_process, MCStrin
 
 	IO_handle t_stream = MCprocesses[t_index].ohandle;
 	Boolean t_textmode = MCprocesses[t_index].textmode;
-	uint4 offset;
+	uint4 t_offset;
 	Boolean haseof = False;
 	IO_stat t_stat;
 
@@ -1921,10 +1921,11 @@ void MCFilesExecWriteToProcess(MCExecContext& ctxt, MCNameRef p_process, MCStrin
 		MCStringRef t_text_data;
 		/* UNCHECKED */ MCStringConvertLineEndingsFromLiveCode(p_data, t_text_data);
 		// MW-2004-11-17: EOD should only happen when writing to processes in text-mode
-		if (MCU_offset("\004", MCStringGetOldString(t_text_data), offset, True))
+		//if (MCU_offset("\004", MCStringGetOldString(t_text_data), offset, True))
+		if (MCStringFirstIndexOf(t_text_data, MCSTR("\004"), 0, kMCCompareExact, t_offset))
 		{
 			MCAutoStringRef t_substring;
-			MCStringCopySubstring(t_text_data, MCRangeMake(0, offset), &t_substring);
+			MCStringCopySubstring(t_text_data, MCRangeMake(0, t_offset), &t_substring);
 			MCValueAssign(t_text_data, *t_substring);
 			haseof = True;
 		}

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1921,8 +1921,7 @@ void MCFilesExecWriteToProcess(MCExecContext& ctxt, MCNameRef p_process, MCStrin
 		MCStringRef t_text_data;
 		/* UNCHECKED */ MCStringConvertLineEndingsFromLiveCode(p_data, t_text_data);
 		// MW-2004-11-17: EOD should only happen when writing to processes in text-mode
-		//if (MCU_offset("\004", MCStringGetOldString(t_text_data), offset, True))
-		if (MCStringFirstIndexOf(t_text_data, MCSTR("\004"), 0, kMCCompareExact, t_offset))
+		if (MCStringFirstIndexOfChar(t_text_data, '\004', 0, kMCCompareExact, t_offset))
 		{
 			MCAutoStringRef t_substring;
 			MCStringCopySubstring(t_text_data, MCRangeMake(0, t_offset), &t_substring);

--- a/engine/src/exec-store.cpp
+++ b/engine/src/exec-store.cpp
@@ -105,12 +105,8 @@ void MCStoreExecRestorePurchases(MCExecContext& ctxt)
 
 void MCStoreGetPurchaseList(MCExecContext& ctxt, MCStringRef& r_list)
 {
-    if (!MCPurchaseList(ctxt.GetEP()))
+    if (!MCPurchaseList(r_list))
         ctxt.Throw();
-    else
-    {
-        /* UNCHECKED */ ctxt.GetEP().copyasstringref(r_list);
-    }
 }
 
 void MCStoreExecCreatePurchase(MCExecContext& ctxt, MCStringRef p_product_id, uint32_t& r_id)

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -316,105 +316,37 @@ bool MCCStringFromUnicode(const unichar_t *p_unicode_string, char*& r_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCStringConvertLineEndingsFromLiveCode(MCStringRef input, MCStringRef& r_output)
+bool MCStringConvertLineEndingsFromLiveCode(MCStringRef p_input, MCStringRef& r_output)
 {
 	
 #ifdef __CRLF__
-	MCAutoStringRef t_input_mutable;
-	MCStringMutableCopy(input, &t_input_mutable);
-	
-	char *sptr;
-	uint32_t l;
-	sptr = (char*)MCStringGetCString(*t_input_mutable);
-	l = MCStringGetLength(*t_input_mutable);
-
-	uint32_t pad;
-	pad = 0;
-	for(uint32_t i = 0; i < l; i++)
-		if (*sptr++ == '\n')
-			pad++;
-
-	if (pad != 0)
-	{
-		uint4 newsize;
-		MCStringPad(*t_input_mutable, MCStringGetLength(*t_input_mutable), pad, nil);
-		newsize = MCStringGetLength(*t_input_mutable);
-
-		char *newbuffer = sptr;
-		sptr += l;
-		char *dptr = newbuffer + newsize;
-		while (dptr > sptr)
-		{
-			*--dptr = *--sptr;
-			if (*sptr == '\n')
-				*--dptr = '\r';
-		}
-	}
-	r_output = MCValueRetain(*t_input_mutable);
-
+	MCStringRef t_mutable_input;
+	/* UNCHECKED */ MCStringMutableCopy(p_input, t_mutable_input);
+	/* UNCHECKED */ MCStringFindAndReplace(t_mutable_input, MCSTR("\n"), MCSTR("\r\n"), kMCStringOptionCompareExact);
+	/* UNCHECKED */ MCStringCopyAndRelease(t_mutable_input, r_output);
 #elif defined(__CR__)
-	MCAutoStringRef t_input_mutable;
-	MCStringMutableCopy(input, &t_input_mutable);
-	
-	char *sptr;
-	uint32_t l;
-	sptr = (char*)MCStringGetCString(*t_input_mutable);
-	l = MCStringGetLength(*t_input_mutable);
-	for (uint32_t i = 0 ; i < l ; i++)
-	{
-		if (*sptr == '\n')
-			*sptr = '\r';
-		sptr++;
-	}
-	r_output = MCValueRetain(*t_input_mutable);
-	
+	MCStringRef t_mutable_input;
+	/* UNCHECKED */ MCStringMutableCopy(p_input, t_mutable_input);
+	/* UNCHECKED */ MCStringFindAndReplaceChar(t_mutable_input, '\n', '\r', kMCStringOptionCompareExact);
+	/* UNCHECKED */ MCStringCopyAndRelease(t_mutable_input, r_output);
+#else
+	r_output = MCValueRetain(p_input);
 #endif
-	
-	return true;
+
+return true;
 }
 
 
-bool MCStringConvertLineEndingsToLiveCode(MCStringRef input, MCStringRef& r_output)
+bool MCStringConvertLineEndingsToLiveCode(MCStringRef p_input, MCStringRef& r_output)
 {
-	
-	MCAutoStringRef t_input_mutable;
-	MCStringMutableCopy(input, &t_input_mutable);
-	
-	char *s;
-	uint32_t l;
-	s = (char*)MCStringGetCString(*t_input_mutable);
-	l = MCStringGetLength(*t_input_mutable);
-
-	char *sptr, *dptr, *eptr;
-	sptr = s;
-	dptr = s;
-	eptr = s + l;
-
-	while (sptr < eptr)
-	{
-		if (*sptr == '\r')
-		{
-			if (sptr < eptr - 1 &&  *(sptr + 1) == '\n')
-				l--;
-			else
-				*dptr++ = '\n';
-			sptr++;
-		}
-		else
-			if (!*sptr)
-			{
-				*dptr++ = ' ';
-				sptr++;
-			}
-			else
-				*dptr++ = *sptr++;
-	}
-
-	MCStringRemove(*t_input_mutable, MCRangeMake(l, UINDEX_MAX));
-	r_output = MCValueRetain(*t_input_mutable);
-	
+	MCStringRef t_mutable_input;
+	/* UNCHECKED */ MCStringMutableCopy(p_input, t_mutable_input);
+	/* UNCHECKED */ MCStringFindAndReplace(t_mutable_input, MCSTR("\r\n"), MCSTR("\n\r"), kMCStringOptionCompareExact);
+	/* UNCHECKED */ MCStringFindAndReplaceChar(t_mutable_input, '\r', '\n', kMCStringOptionCompareExact);
+	/* UNCHECKED */ MCStringCopyAndRelease(t_mutable_input, r_output);
 	return true;
 }
+	
 ////////////////////////////////////////////////////////////////////////////////
 
 // Convert the given UTF-8 string to Unicode. Both counts are in bytes.

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -155,6 +155,10 @@ int UnicodeToUTF8(const uint16_t *lpSrcStr, int cchSrc, char *lpDestStr, int cch
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool MCStringConvertLineEndingsFromLiveCode(MCStringRef input, MCStringRef& r_output);
+bool MCStringConvertLineEndingsToLiveCode(MCStringRef input, MCStringRef& r_output);
+
+////////////////////////////////////////////////////////////////////////////////
 bool MCCStringClone(const char *s, char*& r_s);
 bool MCCStringCloneSubstring(const char *p_string, uint32_t p_length, char*& r_new_string);
 bool MCCStringAppend(char *& x_string, const char *p_suffix);

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -731,6 +731,15 @@ Exec_stat MCHandler::eval(MCExecPoint &ep)
 	return stat;
 }
 
+/* WRAPPER */ Exec_stat MCHandler::eval_ctxt(MCExecContext& ctxt, MCValueRef& r_value)
+{
+	Exec_stat t_stat;
+	t_stat = eval(ctxt . GetEP());
+	if (t_stat == ES_NORMAL)
+		/* UNCHECKED */ ctxt . GetEP() . copyasvalueref(r_value);
+	return t_stat;
+}
+
 /*WRAPPER */ void MCHandler::eval(MCExecContext& ctxt, MCStringRef p_expression, MCValueRef& r_value)
 {
 	MCExecPoint ep(ctxt.GetEP());

--- a/engine/src/handler.h
+++ b/engine/src/handler.h
@@ -105,7 +105,7 @@ public:
 	bool getglobalnames(MCListRef& r_list);
 	bool getvarnames(bool p_all, MCListRef& r_list);
 	Exec_stat getvarnames(MCExecPoint &, Boolean all);
-	Exec_stat MCHandler::eval_ctxt(MCExecContext& ctxt, MCValueRef& r_value);
+	Exec_stat eval_ctxt(MCExecContext& ctxt, MCValueRef& r_value);
 	void eval(MCExecContext& ctxt, MCStringRef p_expression, MCValueRef& r_value);
 	Exec_stat eval(MCExecPoint &);
 	uint4 linecount();

--- a/engine/src/handler.h
+++ b/engine/src/handler.h
@@ -105,6 +105,7 @@ public:
 	bool getglobalnames(MCListRef& r_list);
 	bool getvarnames(bool p_all, MCListRef& r_list);
 	Exec_stat getvarnames(MCExecPoint &, Boolean all);
+	Exec_stat MCHandler::eval_ctxt(MCExecContext& ctxt, MCValueRef& r_value);
 	void eval(MCExecContext& ctxt, MCStringRef p_expression, MCValueRef& r_value);
 	Exec_stat eval(MCExecPoint &);
 	uint4 linecount();

--- a/engine/src/mblstore.cpp
+++ b/engine/src/mblstore.cpp
@@ -115,6 +115,21 @@ bool MCPurchaseStateToString(MCPurchaseState p_state, const char *&r_string)
 	return false;
 }
 
+bool MCPurchaseList(MCStringRef& r_string)
+{   
+	MCAutoStringRef t_string;
+	MCStringCreateMutable(0, &t_string);
+	for (MCPurchase *t_purchase = MCStoreGetPurchases(); t_purchase != NULL; t_purchase = t_purchase->next)
+		MCStringAppendFormat(*t_string, "%u\n", t_purchase -> id);
+	//remove the last \n character
+    /* UNCHECKED */ MCStringRemove(*t_string, MCRangeMake(MCStringGetLength(*t_string) - 1, 1)); 
+
+	r_string = MCValueRetain(*t_string);
+	
+	return true;
+}
+
+/*
 bool MCPurchaseList(MCExecPoint& ep)
 {    
 	for (MCPurchase *t_purchase = MCStoreGetPurchases(); t_purchase != NULL; t_purchase = t_purchase->next)
@@ -122,6 +137,7 @@ bool MCPurchaseList(MCExecPoint& ep)
 	
 	return true;
 }
+*/
 
 bool MCPurchaseInit(MCPurchase *p_purchase, MCStringRef p_product_id, void *p_context);
 bool MCPurchaseCreate(MCStringRef p_product_id, void *p_context, MCPurchase *&r_purchase)

--- a/engine/src/mblstore.cpp
+++ b/engine/src/mblstore.cpp
@@ -117,16 +117,13 @@ bool MCPurchaseStateToString(MCPurchaseState p_state, const char *&r_string)
 
 bool MCPurchaseList(MCStringRef& r_string)
 {   
-	MCAutoStringRef t_string;
-	MCStringCreateMutable(0, &t_string);
+	MCAutoListRef t_list;
+	if (!MCListCreateMutable('\n', &t_list))
+		return false;
 	for (MCPurchase *t_purchase = MCStoreGetPurchases(); t_purchase != NULL; t_purchase = t_purchase->next)
-		MCStringAppendFormat(*t_string, "%u\n", t_purchase -> id);
-	//remove the last \n character
-    /* UNCHECKED */ MCStringRemove(*t_string, MCRangeMake(MCStringGetLength(*t_string) - 1, 1)); 
-
-	r_string = MCValueRetain(*t_string);
+		MCListAppendInteger(*t_list, t_purchase -> id);
 	
-	return true;
+	return MCListCopyAsString(*t_list, r_string);	
 }
 
 /*

--- a/engine/src/mblstore.cpp
+++ b/engine/src/mblstore.cpp
@@ -126,16 +126,6 @@ bool MCPurchaseList(MCStringRef& r_string)
 	return MCListCopyAsString(*t_list, r_string);	
 }
 
-/*
-bool MCPurchaseList(MCExecPoint& ep)
-{    
-	for (MCPurchase *t_purchase = MCStoreGetPurchases(); t_purchase != NULL; t_purchase = t_purchase->next)
-        ep.concatuint(t_purchase -> id, EC_RETURN, ep.isempty());
-	
-	return true;
-}
-*/
-
 bool MCPurchaseInit(MCPurchase *p_purchase, MCStringRef p_product_id, void *p_context);
 bool MCPurchaseCreate(MCStringRef p_product_id, void *p_context, MCPurchase *&r_purchase)
 {

--- a/engine/src/mblstore.h
+++ b/engine/src/mblstore.h
@@ -174,6 +174,7 @@ bool MCPurchaseLookupProperty(MCStringRef p_property, MCPurchaseProperty &r_prop
 
 bool MCPurchaseFindById(uint32_t p_id, MCPurchase *&r_purchase);
 bool MCPurchaseList(MCExecPoint& ep);
+bool MCPurchaseList(MCStringRef& r_string);
 
 bool MCPurchaseCreate(MCStringRef p_product_id, void *p_context, MCPurchase *&r_purchase);
 

--- a/engine/src/mblstore.h
+++ b/engine/src/mblstore.h
@@ -173,7 +173,6 @@ void MCStoreExecSet(MCExecContext& ctxt, integer_t p_id, MCStringRef p_prop_name
 bool MCPurchaseLookupProperty(MCStringRef p_property, MCPurchaseProperty &r_property);
 
 bool MCPurchaseFindById(uint32_t p_id, MCPurchase *&r_purchase);
-bool MCPurchaseList(MCExecPoint& ep);
 bool MCPurchaseList(MCStringRef& r_string);
 
 bool MCPurchaseCreate(MCStringRef p_product_id, void *p_context, MCPurchase *&r_purchase);


### PR DESCRIPTION
Updates on

```
MCEngineSplitScriptIntoMessageAndParameters(), 
MCFilesExecReadComplete(), 
MCFilesExecWriteToFileOrDriver(), 
MCFilesExecWriteToProcess(), 
MCStoreGetPurchaseList(). 
```

Program crashes because of `MCFilesExecWriteToFileOrDriver()` method.
