### PR TITLE
[[ Bug 11255 ]] Uninitialised parameter can cause crash in iPhonePickPho...

### DIFF
--- a/docs/notes/bugfix-11255.md
+++ b/docs/notes/bugfix-11255.md
@@ -1,0 +1,1 @@
+# Uninitialised parameter can cause crash in iPhonePickPhoto

--- a/engine/src/mbliphonecamera.mm
+++ b/engine/src/mbliphonecamera.mm
@@ -146,7 +146,8 @@ static MCIPhoneImagePickerDialog *s_image_picker = nil;
 	
 	// 19/10/2010 IM - fix crash in iOS4.0
 	// UIPopoverController only available on iPad but NSClassFromString returns non-nil in iOS4 phone/pod
-	id t_popover;
+    // AL-2013-10-04 [[ Bug 11255 ]] Uninitialised variable can cause crash in iPhonePickPhoto
+	id t_popover = nil;
 	if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
 		t_popover = NSClassFromString(@"UIPopoverController");
 	


### PR DESCRIPTION
...to
