### PR TITLE
[[ Bugfix 11208 ]] Incorrect behaviour of buttons in a mobile scroller c...

### DIFF
--- a/docs/notes/bugfix-11208.md
+++ b/docs/notes/bugfix-11208.md
@@ -1,0 +1,4 @@
+# Mouse release/touch cancel events incorrectly sending mouseUp message
+
+Previously, mouseUp was being sent when a touch action turned into a scroll (i.e a non-flick scroll). This was in addition to the normal mouseRelease message and only the latter should have been sent. The more responsive touches in iOS7 made this more apparent but it is present in all platforms where mouse release or touch cancel events are generated.
+

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -314,9 +314,20 @@ static void MCEventQueueDispatchEvent(MCEvent *p_event)
 			
 				// If the press was 'released' i.e. cancelled then we stop messages, mup then
 				// dispatch a mouseRelease message ourselves.
-				t_target -> setstate(True, CS_NO_MESSAGES);
-				t_target -> mup(t_event -> mouse . press . button + 1);
-				t_target -> setstate(False, CS_NO_MESSAGES);
+                
+                // FG-2013-10-09 [[ Bugfix 11208 ]]
+                // CS_NO_MESSAGES only applies to the target and not the controls it contains
+                // so the mouse up message (on mouseUp) sets sent when it isn't desired
+                // Hopefully nobody depends on the old behaviour...
+            
+                //t_target -> setstate(True, CS_NO_MESSAGES);
+				//t_target -> mup(t_event -> mouse . press . button + 1);
+				//t_target -> setstate(False, CS_NO_MESSAGES);
+                
+                bool old_lock = MClockmessages;
+                MClockmessages = true;
+                t_target -> mup(t_event -> mouse . press . button + 1);
+                MClockmessages = old_lock;
 				
 				t_target -> message_with_args(MCM_mouse_release, t_event -> mouse . press . button + 1);
 			}


### PR DESCRIPTION
...ontrol

An erroneous mouseUp event was being generated on touch cancel (and mouse release) in addition to the correct mouseRelease message.
