### PR TITLE
Refactor syntax unicode remaining strings1 new

### DIFF
--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -78,7 +78,7 @@ struct MCarray
 };
 
 typedef char *(*XCB)(const char *arg1, const char *arg2, const char *arg3, int *retval);
-typedef int (*SECURITYHANDLER)(const char *);
+typedef int (*SECURITYHANDLER)(MCStringRef);
 typedef void (*DELETER)(void *data);
 typedef void (*GETXTABLE)(XCB *, DELETER, const char **, Xternal **, DELETER *);
 typedef void (*CONFIGURESECURITY)(SECURITYHANDLER *handlers);
@@ -784,21 +784,19 @@ XCB MCcbs[] =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static int can_access_file(const char *p_file)
+static int can_access_file(MCStringRef p_file)
 {
 	return MCSecureModeCanAccessDisk();
 }
 
-static int can_access_host(const char *p_host)
+static int can_access_host(MCStringRef p_host)
 {
 	if (MCSecureModeCanAccessNetwork())
 		return true;
-    MCAutoStringRef t_host;
-    /* UNCHECKED */ MCStringCreateWithCString(p_host, &t_host);
-	return MCModeCanAccessDomain(*t_host);
+	return MCModeCanAccessDomain(p_host);
 }
 
-static int can_access_library(const char *p_host)
+static int can_access_library(MCStringRef p_host)
 {
 	return true;
 }


### PR DESCRIPTION
This branch should replace the _remaining_strings1 branch. All the updates in _::load()/entendedload() (and wherever  function's signature taking a const char_ just compares it with a static C-string in its body) have been reverted.
