### PR TITLE
Bugfix 11300 (for 6.1) - flip on referenced images

### DIFF
--- a/docs/notes/bugfix-11300.md
+++ b/docs/notes/bugfix-11300.md
@@ -1,0 +1,3 @@
+# Flip does not work on referenced images.
+The flip command will now work on referenced images.
+Note that at the moment this behavior is the same as pre-6.0 where doing 'flip' on a referenced image would work, but would not be persistent and not interact well with other operations. This behavior will be improved in a subsequent release when image transformation abilities are improved.

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -1310,12 +1310,21 @@ Exec_stat MCFlip::exec(MCExecPoint &ep)
 			return ES_ERROR;
 		}
 		// MW-2013-07-01: [[ Bug 10999 ]] Throw an error if the image is not editable.
-		if (optr->gettype() != CT_IMAGE || optr->getflag(F_HAS_FILENAME))
+		if (optr->gettype() != CT_IMAGE)
 		{
 			MCeerror->add(EE_FLIP_NOTIMAGE, line, pos);
 			return ES_ERROR;
 		}
 		MCImage *iptr = (MCImage *)optr;
+		
+		// MW-2013-10-25: [[ Bug 11300 ]] If this is referenced set the flip flags
+		//   of the image appropriately.
+		if (optr->getflag(F_HAS_FILENAME))
+		{
+			iptr -> setflip(direction == FL_HORIZONTAL);
+			return ES_NORMAL;
+		}
+		
 		iptr->selimage();
 		t_created_selection = true;
 	}

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -87,6 +87,10 @@ MCImage::MCImage()
 	currentframe = 0;
 	repeatcount = 0;
 	resizequality = INTERPOLATION_BOX;
+	
+	// MW-2013-10-25: [[ Bug 11300 ]] Images are not flipped initially.
+	m_flip_x = false;
+	m_flip_y = false;
 }
 
 MCImage::MCImage(const MCImage &iref) : MCControl(iref)
@@ -127,6 +131,10 @@ MCImage::MCImage(const MCImage &iref) : MCControl(iref)
 	currentframe = 0;
 	repeatcount = iref.repeatcount;
 	resizequality = iref.resizequality;
+	
+	// MW-2013-10-25: [[ Bug 11300 ]] Images are not flipped initially.
+	m_flip_x = false;
+	m_flip_y = false;
 }
 
 MCImage::~MCImage()
@@ -2003,13 +2011,26 @@ MCSharedString *MCImage::getclipboardtext(void)
 
 ///////////////////////////////////////////////////////////////////////////////
 
+// MW-2013-10-25: [[ Bug 11300 ]] Invert the appropriate flip flag and redraw.
+void MCImage::setflip(bool horz)
+{
+	if (horz)
+		m_flip_x = !m_flip_x;
+	else
+		m_flip_y = !m_flip_y;
+	
+	layer_redrawall();
+	notifyneeds(false);
+}
+
 void MCImage::apply_transform()
 {
 	uindex_t t_width = rect.width;
 	uindex_t t_height = rect.height;
 	if (m_rep != nil)
 		m_rep->GetGeometry(t_width, t_height);
-
+	
+	// MW-2013-10-25: [[ Bug 11300 ]] Make sure we apply flipping if necessary.
 	if (angle != 0)
 	{
 		rotate(angle);
@@ -2022,6 +2043,10 @@ void MCImage::apply_transform()
 		{
 			resize();
 		}
+	}
+	else if (m_flip_x || m_flip_y)
+	{
+		flip();
 	}
 	else
 	{

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -305,6 +305,11 @@ class MCImage : public MCControl
 	MCTransformedImageRep *m_transformed;
 	MCImageFrame *m_locked_frame;
 	uint32_t m_image_opened;
+	
+	// MW-2013-10-25: [[ Bug 11300 ]] If either is true, flips are done
+	//   appropriately in a transformed rep.
+	bool m_flip_x : 1;
+	bool m_flip_y : 1;
 
 	MCImageNeed *m_needs;
 	
@@ -403,6 +408,8 @@ public:
 	bool convert_to_mutable();
 
 	void resetimage();
+	
+	void setflip(bool horz);
 
 	void apply_transform();
 
@@ -460,6 +467,7 @@ public:
 	void crop(MCRectangle *newrect);
 	void rotate(uint32_t p_angle);
 	void resize();
+	void flip(void);
 	void createbrush(Properties which);
 
 	static MCbrushmask *getbrush(Tool p_which);

--- a/engine/src/image_rep.cpp
+++ b/engine/src/image_rep.cpp
@@ -355,11 +355,11 @@ bool MCImageRepGetCompressed(MCImageCompressedBitmap *p_compressed, MCImageRep *
 	return t_success;
 }
 
-bool MCImageRepGetTranformed(uindex_t p_width, uindex_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, MCImageRep *p_source, MCImageRep *&r_rep)
+bool MCImageRepGetTranformed(uindex_t p_width, uindex_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, bool p_flip_x, bool p_flip_y, MCImageRep *p_source, MCImageRep *&r_rep)
 {
 	bool t_success = true;
 	
-	MCCachedImageRep *t_rep = new MCTransformedImageRep(p_width, p_height, p_angle, p_lock_rect, p_quality, p_source);
+	MCCachedImageRep *t_rep = new MCTransformedImageRep(p_width, p_height, p_angle, p_lock_rect, p_quality, p_flip_x, p_flip_y, p_source);
 	
 	t_success = t_rep != nil;
 	if (t_success)

--- a/engine/src/image_rep.h
+++ b/engine/src/image_rep.h
@@ -276,7 +276,8 @@ protected:
 class MCTransformedImageRep : public MCCachedImageRep
 {
 public:
-	MCTransformedImageRep(uindex_t p_width, uindex_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, MCImageRep *p_source);
+	// MW-2013-10-25: [[ Bug 11300 ]] Update to take the flipped parameters.
+	MCTransformedImageRep(uindex_t p_width, uindex_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, bool p_flip_x, bool p_flip_y, MCImageRep *p_source);
 	~MCTransformedImageRep();
 	
 	MCImageRepType GetType() { return kMCImageRepTransformed; }
@@ -291,7 +292,8 @@ public:
 	
 	//////////
 	
-	bool Matches(uint32_t p_width, uint32_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, MCImageRep *p_source);
+	// MW-2013-10-25: [[ Bug 11300 ]] Update to take the flipped parameters.
+	bool Matches(uint32_t p_width, uint32_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, bool p_flip_x, bool p_flip_y, MCImageRep *p_source);
 	
 protected:
 	bool LoadImageFrames(MCImageFrame *&r_frames, uindex_t &r_frame_count);
@@ -302,8 +304,11 @@ protected:
 	MCImageRep *m_source;
 	uindex_t m_width, m_height;
 	int32_t m_angle;
-	bool m_lock_rect;
 	uint32_t m_quality;
+	bool m_lock_rect : 1;
+	// MW-2013-10-25: [[ Bug 11300 ]] These indicate whether the rep is flipped.
+	bool m_flip_x : 1;
+	bool m_flip_y : 1;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -312,7 +317,7 @@ bool MCImageRepGetReferenced(const char *p_filename, MCImageRep *&r_rep);
 bool MCImageRepGetResident(void *p_data, uindex_t p_size, MCImageRep *&r_rep);
 bool MCImageRepGetVector(void *p_data, uindex_t p_size, MCImageRep *&r_rep);
 bool MCImageRepGetCompressed(MCImageCompressedBitmap *p_compressed, MCImageRep *&r_rep);
-bool MCImageRepGetTranformed(uindex_t p_width, uindex_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, MCImageRep *p_source, MCImageRep *&r_rep);
+bool MCImageRepGetTranformed(uindex_t p_width, uindex_t p_height, int32_t p_angle, bool p_lock_rect, uint32_t p_quality, bool p_flip_x, bool p_flip_y, MCImageRep *p_source, MCImageRep *&r_rep);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/image_rep_mutable.cpp
+++ b/engine/src/image_rep_mutable.cpp
@@ -2277,6 +2277,47 @@ void MCMutableImageRep::rotatesel(int2 angle)
 	m_owner->sourcerectchanged(rect);
 }
 
+bool MCImageBitmapFlipVerticalInPlace(MCImageBitmap *self)
+{
+	uint32_t *t_row;
+	if (!MCMemoryNewArray(self -> width, t_row))
+		return false;
+	
+	for(uindex_t y = 0; y < self -> height / 2; y++)
+	{
+		uint32_t *t_top;
+		t_top = self -> data + y * (self -> stride >> 2);
+		uint32_t *t_bottom;
+		t_bottom = self -> data + (self -> height - y - 1) * (self -> stride >> 2);
+		
+		MCMemoryCopy(t_row, t_top, self -> width * sizeof(uint32_t));
+		MCMemoryCopy(t_top, t_bottom, self -> width * sizeof(uint32_t));
+		MCMemoryCopy(t_bottom, t_row, self -> width * sizeof(uint32_t));
+	}
+	
+	MCMemoryDeleteArray(t_row);
+	
+	return true;
+}
+
+bool MCImageBitmapFlipHorizontalInPlace(MCImageBitmap *self)
+{
+	for(uindex_t y = 0; y < self -> height; y++)
+	{
+		uint32_t *t_row;
+		t_row = self -> data + y * (self -> stride >> 2);
+		for(uindex_t x = 0; x < self -> width / 2; x++)
+		{
+			uint32_t t;
+			t = t_row[x];
+			t_row[x] = t_row[self -> width - x - 1];
+			t_row[self -> width - x - 1] = t;
+		}
+	}
+	
+	return true;
+}
+
 bool MCImageBitmapFlipVertical(MCImageBitmap *p_src, MCImageBitmap *&r_flipped)
 {
 	if (!MCImageBitmapCreate(p_src->width, p_src->height, r_flipped))

--- a/engine/src/imagebitmap.h
+++ b/engine/src/imagebitmap.h
@@ -68,6 +68,9 @@ void MCImageBitmapPremultiplyRegion(MCImageBitmap *p_bitmap, int32_t p_sx, int32
 void MCImageBitmapUnpremultiply(MCImageBitmap *p_bitmap);
 void MCImageBitmapUnpremultiplyChecking(MCImageBitmap *p_bitmap);
 
+bool MCImageBitmapFlipVerticalInPlace(MCImageBitmap *self);
+bool MCImageBitmapFlipHorizontalInPlace(MCImageBitmap *self);
+
 //////////
 
 bool MCImageCreateIndexedBitmap(uindex_t p_width, uindex_t p_height, MCImageIndexedBitmap *&r_indexed);

--- a/engine/src/iutil.cpp
+++ b/engine/src/iutil.cpp
@@ -499,12 +499,13 @@ void MCImage::rotate(uint32_t p_angle)
 	// IM-2013-08-02: [[ Bugfix 11087 ]] only get a transformed rep if there is an image rep to transform
 	if (m_rep != nil)
 	{
-		if (m_transformed != nil && m_transformed->Matches(rect.width, rect.height, p_angle, getflag(F_LOCK_LOCATION), resizequality, m_rep))
+		// MW-2013-10-25: [[ Bug 11300 ]] Pass in flip parameters.
+		if (m_transformed != nil && m_transformed->Matches(rect.width, rect.height, p_angle, getflag(F_LOCK_LOCATION), resizequality, m_flip_x, m_flip_y, m_rep))
 			t_rep = m_transformed->Retain();
 		// IM-2013-04-22: [[ BZ 10858 ]] A transformed rep is needed if the angle is non-zero,
 		// or the rect is locked and doesn't match the source dimensions.
 		else if ((p_angle != 0) || (getflag(F_LOCK_LOCATION) && m_rep->GetGeometry(width, height) && (width != rect.width || height != rect.height)))
-			/* UNCHECKED */ MCImageRepGetTranformed(rect.width, rect.height, p_angle, (flags & F_LOCK_LOCATION) != 0, resizequality, m_rep, t_rep);
+			/* UNCHECKED */ MCImageRepGetTranformed(rect.width, rect.height, p_angle, (flags & F_LOCK_LOCATION) != 0, resizequality, m_flip_x, m_flip_y, m_rep, t_rep);
 	}
 	
 	if (m_transformed != nil)
@@ -555,7 +556,8 @@ void MCImage::resize()
 		{
 			MCImageRep *t_rep = nil;
 			
-			/* UNCHECKED */ MCImageRepGetTranformed(rect.width, rect.height, 0, true, resizequality, m_rep, t_rep);
+			// MW-2013-10-25: [[ Bug 11300 ]] Pass in flip parameters.
+			/* UNCHECKED */ MCImageRepGetTranformed(rect.width, rect.height, 0, true, resizequality, m_flip_x, m_flip_y, m_rep, t_rep);
 			m_transformed = static_cast<MCTransformedImageRep*>(t_rep);
 		}
 	}
@@ -563,6 +565,32 @@ void MCImage::resize()
 	// MW-2011-09-20: [[ Bug 9739 ]] We've changed the content of the layer, so make sure
 	//   we mark it for redraw.
 	layer_redrawall();
+}
+
+// MW-2013-10-25: [[ Bug 11300 ]] Ensure we create a flipped rep if needed.
+void MCImage::flip(void)
+{
+	if (m_transformed != nil)
+	{
+		m_transformed->Release();
+		m_transformed = nil;
+	}
+	
+	if (m_rep != nil)
+	{
+		if (m_flip_x || m_flip_y)
+		{
+			MCImageRep *t_rep = nil;
+			
+			/* UNCHECKED */ MCImageRepGetTranformed(rect.width, rect.height, 0, true, resizequality, m_flip_x, m_flip_y, m_rep, t_rep);
+			m_transformed = static_cast<MCTransformedImageRep*>(t_rep);
+		}
+	}
+	
+	// MW-2011-09-20: [[ Bug 9739 ]] We've changed the content of the layer, so make sure
+	//   we mark it for redraw.
+	layer_redrawall();
+	
 }
 
 void MCImage::createbrush(Properties which)


### PR DESCRIPTION
This is for merging into release-6.1.3
