### PR TITLE
[[ Bug 11330 ]] Fixed issue with snapshot being created at the wrong siz...

### DIFF
--- a/docs/notes/bugfix-11330.md
+++ b/docs/notes/bugfix-11330.md
@@ -1,0 +1,2 @@
+# Visual effects not displayed correctly on iOS when fullscreenmode is 'no border', and stack extends outside of the visible screen.
+

--- a/engine/src/mbliphonestack.mm
+++ b/engine/src/mbliphonestack.mm
@@ -559,6 +559,10 @@ void MCStack::effectrect(const MCRectangle& p_rect, Boolean& r_abort)
 		t_effect_area = MCU_intersect_rect(t_effect_area, p_rect);
 		
 		ctxt . effect_area = MCRectangleGetTransformedBounds(t_effect_area, view_getviewtransform());
+        
+        // MW-2013-10-29: [[ Bug 11330 ]] Make sure the effect area is cropped to the visible
+        //   area.
+        ctxt . effect_area = MCU_intersect_rect(ctxt . effect_area, MCU_make_rect(0, 0, view_getrect() . width, view_getrect() . height));
 		
 		// MW-2011-09-24: [[ Effects ]] Get the current snapshot as a UIImage
 		// MW-2011-11-18: [[ Bug ]] Make sure we grab a UIImage copy of the snapshot

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -2523,8 +2523,13 @@ void MCStack::snapshotwindow(const MCRectangle& p_area)
 		// IM-2013-09-30: [[ FullscreenMode ]] Use stack transform to get device coords
 		MCGAffineTransform t_transform = getdevicetransform();
 		
+		// MW-2013-10-29: [[ Bug 11330 ]] Make sure the effect area is cropped to the visible
+		//   area.
+		t_effect_area = MCRectangleGetTransformedBounds(t_effect_area, getviewtransform());
+		t_effect_area = MCU_intersect_rect(t_effect_area, MCU_make_rect(0, 0, view_getrect() . width, view_getrect() . height));
+		
 		MCRectangle t_device_rect, t_user_rect;
-		t_device_rect = MCRectangleGetTransformedBounds(t_effect_area, t_transform);
+		t_device_rect = MCRectangleGetTransformedBounds(t_effect_area, MCResGetDeviceTransform());		
 		t_user_rect = MCRectangleGetTransformedBounds(t_device_rect, MCGAffineTransformInvert(t_transform));
 		
 		if (t_success)

--- a/engine/src/stacke.cpp
+++ b/engine/src/stacke.cpp
@@ -220,8 +220,13 @@ void MCStack::effectrect(const MCRectangle& p_area, Boolean& r_abort)
 	MCGAffineTransform t_transform;
 	t_transform = getdevicetransform();
 	
-	MCRectangle t_device_rect, t_user_rect;
-	t_device_rect = MCRectangleGetTransformedBounds(t_effect_area, t_transform);
+    // MW-2013-10-29: [[ Bug 11330 ]] Make sure the effect area is cropped to the visible
+    //   area.
+    t_effect_area = MCRectangleGetTransformedBounds(t_effect_area, getviewtransform());
+    t_effect_area = MCU_intersect_rect(t_effect_area, MCU_make_rect(0, 0, view_getrect() . width, view_getrect() . height));
+	
+    MCRectangle t_device_rect, t_user_rect;
+	t_device_rect = MCRectangleGetTransformedBounds(t_effect_area, MCResGetDeviceTransform());
 	t_user_rect = MCRectangleGetTransformedBounds(t_device_rect, MCGAffineTransformInvert(t_transform));
 	
 	MCGFloat t_scale;

--- a/engine/src/stackview.cpp
+++ b/engine/src/stackview.cpp
@@ -726,10 +726,15 @@ bool MCStack::view_snapshottilecache(const MCRectangle &p_stack_rect, MCGImageRe
 	if (m_view_tilecache == nil)
 		return false;
 	
+	// MW-2013-10-29: [[ Bug 11330 ]] Transform stack to (local) view co-ords.
+	MCRectangle t_view_rect;
+	t_view_rect = MCRectangleGetTransformedBounds(p_stack_rect, getviewtransform());
+	t_view_rect = MCU_intersect_rect(t_view_rect, MCU_make_rect(0, 0, view_getrect() . width, view_getrect() . height));
+	
 	// IM-2013-08-21: [[ ResIndependence ]] Use device coords for tilecache operation
 	// IM-2013-09-30: [[ FullscreenMode ]] Use stack transform to get device coords
 	MCRectangle t_device_rect;
-	t_device_rect = MCRectangleGetTransformedBounds(p_stack_rect, getdevicetransform());
+	t_device_rect = MCRectangleGetTransformedBounds(t_view_rect, MCResGetDeviceTransform());
 	return MCTileCacheSnapshot(m_view_tilecache, t_device_rect, r_image);
 }
 

--- a/engine/src/tilecache.cpp
+++ b/engine/src/tilecache.cpp
@@ -2495,7 +2495,7 @@ bool MCTileCacheSnapshot(MCTileCacheRef self, MCRectangle p_area, MCGImageRef& r
 	
 	bool t_success;
 	t_success = true;
-	
+    
 	MCGRaster t_raster;
 	t_raster.width = p_area.width;
 	t_raster.height = p_area.height;
@@ -2507,13 +2507,7 @@ bool MCTileCacheSnapshot(MCTileCacheRef self, MCRectangle p_area, MCGImageRef& r
 		t_success = MCMemoryAllocate(t_raster.stride * t_raster.height, t_raster.pixels);
 	
 	if (t_success)
-	{
-		// IM-2013-10-14: [[ FullscreenMode ]] Snapshot region may extend outside the tilecache viewport,
-		// so clear the raster to leave the clipped-out area transparent
-		MCMemoryClear(t_raster.pixels, t_raster.stride * t_raster.height);
-		p_area = MCU_intersect_rect(p_area, MCTileCacheGetViewport(self));
 		t_success = self -> compositor . begin_snapshot(self -> compositor . context, p_area, t_raster);
-	}
 	
 	if (t_success)
 		t_success = MCTileCacheDoComposite(self);


### PR DESCRIPTION
...e and thus causing corruption in iOS visual effects in no border mode.

[[ Bug 11330 ]] Ensured effect area is always clipped to the viewrect on all platforms and in all modes.
