### PR TITLE
[[ Bug 11349 ]] Make sure empty floating rects give empty integer rects.

### DIFF
--- a/docs/notes/bugfix-11349.md
+++ b/docs/notes/bugfix-11349.md
@@ -1,0 +1,1 @@
+# Content outside of card rect can be seen in show all fullscreenmode when acceleratedRendering is true.

--- a/engine/src/graphics_util.h
+++ b/engine/src/graphics_util.h
@@ -34,15 +34,27 @@ inline MCGRectangle MCRectangleToMCGRectangle(MCRectangle p_rect)
 }
 
 inline MCRectangle MCGRectangleGetIntegerBounds(MCGRectangle p_rect)
-{
+{	
 	int32_t t_left, t_right, t_top, t_bottom;
 	t_left = floor(p_rect.origin.x);
 	t_top = floor(p_rect.origin.y);
 	t_right = ceil(p_rect.origin.x + p_rect.size.width);
 	t_bottom = ceil(p_rect.origin.y + p_rect.size.height);
+
+	int32_t t_width, t_height;
+	t_width = t_right - t_left;
+	t_height = t_bottom - t_top;
+	
+	// [[ Bug 11349 ]] Out of bounds content displayed since getting integer
+	//   bounds of an empty rect is not empty.
+	if (p_rect . size . width == 0.0f || p_rect . size . height == 0.0f)
+	{
+		t_width = 0;
+		t_height = 0;
+	}
 	
 	MCRectangle t_rect;
-	t_rect = MCRectangleMake(t_left, t_top, t_right - t_left, t_bottom - t_top);
+	t_rect = MCRectangleMake(t_left, t_top, t_width, t_height);
 	
 	return t_rect;
 }

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -1170,6 +1170,10 @@ void MCCard::render(void)
 					t_layer . id = 0;
 				}
 
+				// MW-2013-10-29: [[ Bug 11349 ]] Scenery layers regions are clipped
+				//   by the clip directly.
+				t_layer . region = MCU_intersect_rect(t_layer . region, t_layer . clip);
+				
 				t_layer . callback = testtilecache_device_scenery_renderer;
 				MCTileCacheRenderScenery(t_tiler, t_layer);
 			}


### PR DESCRIPTION
[[ Bug 11349 ]] Make sure scenery layers are clipped before being processed by tilecache.
