### PR TITLE
Bugfix 11285

### DIFF
--- a/docs/notes/bugfix-11285.md
+++ b/docs/notes/bugfix-11285.md
@@ -1,0 +1,2 @@
+# Fix font setting for multiline edit controls on iOS7
+

--- a/engine/src/mbliphoneinput.mm
+++ b/engine/src/mbliphoneinput.mm
@@ -347,10 +347,23 @@ Exec_stat MCNativeInputControl::Set(MCNativeControlProperty p_property, MCExecPo
 			return ES_NORMAL;
 			
 		case kMCNativeControlPropertyFontSize:
+        {
 			if (!ParseInteger(ep, t_integer))
 				return ES_ERROR;
-			[t_field setFont: [[t_field font] fontWithSize: t_integer]];
+            
+            // FG-2013-11-06 [[ Bugfix 11285 ]]
+            // On iOS7 devices, UITextView controls were having their font size
+            // properties ignored because [t_field font] was returning nil when
+            // no text had been added to the control yet.
+            UIFont* t_font = [t_field font];
+            if (t_font == nil)
+                t_font = [UIFont systemFontOfSize: t_integer];
+            else
+                t_font = [t_font fontWithSize: t_integer];
+            
+			[t_field setFont: t_font];
 			return ES_NORMAL;
+        }
 			
 		case kMCNativeControlPropertyTextAlign:
 			if (!ParseEnum(ep, s_textalign_enum, t_enum))


### PR DESCRIPTION
On iOS7 devices, the [UITextView font] method returned nil if no text had yet been added to the control so attempts to get font size were ignored. A check has now been added for this condition and the system font of the appropriate size is used if a custom font has not been set.
