### PR TITLE
Bugfix/lc interface query device scale

### DIFF
--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -1977,7 +1977,7 @@ static MCExternalError MCExternalInterfaceQuery(MCExternalInterfaceQueryTag op, 
 	{
 		case kMCExternalInterfaceQueryView:
 			// MERG-2013-11-07: [[ DeviceScale ]] Return the resolution scale on platforms where the view is measured in points
-            *(void **)r_value = MCIPhoneGetResolutionScale();
+            *(double *)r_value = MCIPhoneGetResolutionScale();
 			break;
 		case kMCExternalInterfaceQueryView:
 			*(void **)r_value = MCIPhoneGetView();

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -1971,15 +1971,14 @@ extern void *MCAndroidGetEngine(void);
 
 static MCExternalError MCExternalInterfaceQuery(MCExternalInterfaceQueryTag op, void *r_value)
 {
-    if (op == kMCExternalInterfaceQueryViewScale)
-    {
-        *(double *)r_value = MCResGetDeviceScale();
-    	return kMCExternalErrorNone;
-    }
     
 #if defined(TARGET_SUBPLATFORM_IPHONE)
 	switch(op)
 	{
+		case kMCExternalInterfaceQueryView:
+			// MERG-2013-11-07: [[ DeviceScale ]] Return the resolution scale on platforms where the view is measured in points
+            *(void **)r_value = MCIPhoneGetResolutionScale();
+			break;
 		case kMCExternalInterfaceQueryView:
 			*(void **)r_value = MCIPhoneGetView();
 			break;
@@ -1990,7 +1989,14 @@ static MCExternalError MCExternalInterfaceQuery(MCExternalInterfaceQueryTag op, 
 			return kMCExternalErrorInvalidInterfaceQuery;
 	}
 	return kMCExternalErrorNone;
-#elif defined(TARGET_SUBPLATFORM_ANDROID)
+#else
+    // MERG-2013-11-07: [[ DeviceScale ]] Return 1/the device scale on platforms where the view is measured in pixels
+    if (op == kMCExternalInterfaceQueryViewScale)
+    {
+        *(double *)r_value = 1/MCResGetDeviceScale();
+    	return kMCExternalErrorNone;
+    }
+#if defined(TARGET_SUBPLATFORM_ANDROID)
 	switch(op)
 	{
 		case kMCExternalInterfaceQueryActivity:
@@ -2019,6 +2025,7 @@ static MCExternalError MCExternalInterfaceQuery(MCExternalInterfaceQueryTag op, 
 			return kMCExternalErrorInvalidInterfaceQuery;
 	}
 	return kMCExternalErrorNone;
+#endif
 #endif
 
 	return kMCExternalErrorInvalidInterfaceQuery;


### PR DESCRIPTION
After reviewing my last pull request on this I realised it wasn't backwards compatible with use device resolution and would actually return 2 on iOS where in most instances we just want 1. It also I didn't like the difference between the results returned on iOS to other platforms. This pull request ensures the result of LCInterfaceQueryViewScale will always be the number of LC points in 1 view point/pixel depending on what the platform measures the view in. This means we can always divide our rects by LCInterfaceQueryViewScale no matter what platform.
