### PR TITLE
[[ Bug 11278 ]] Dismiss dialog before calling onListPickerDone to preven...

### DIFF
--- a/docs/notes/bugfix-11278.md
+++ b/docs/notes/bugfix-11278.md
@@ -1,0 +1,1 @@
+# Android mobilePick can only be called once, reliably

--- a/engine/src/java/com/runrev/android/DialogModule.java
+++ b/engine/src/java/com/runrev/android/DialogModule.java
@@ -242,8 +242,9 @@ class DialogModule
                 Log.i(TAG, "clicked:" + p_which);
 				if (m_list_close_on_selection)
                 {
-                    m_engine.onListPickerDone(p_which, true);
+                    // AL-2013-11-08 [[ Bug 11278 ]] Dismiss dialog before calling onListPickerDone to prevent premature continuation of script execution
                     m_list_dialog.dismiss();
+                    m_engine.onListPickerDone(p_which, true);
                 }
                 else
                     m_list_selection = p_which;


### PR DESCRIPTION
...t premature continuation of script execution
