### PR TITLE
[[ RecursiveConditionalMessages ]] visibilityChanged and controlMoved im...

### DIFF
--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -750,6 +750,9 @@ void MCGroup::setrect(const MCRectangle &nrect)
 		}
 		else
 		{
+            // MERG-13-11-12: [[ RecursiveConditionalMessages ]] Don't send moveControl when adjusting the scrollbars here
+            messagestate |= HH_MOVE_CONTROL;
+            
 			uint1 oldopen = opened;
 			opened = 0;  // suppress all updates and messages
 			int4 oldx = scrollx;
@@ -778,6 +781,10 @@ void MCGroup::setrect(const MCRectangle &nrect)
 			vscroll(oldy, False);
 			resetscrollbars(False);
 			opened = oldopen;
+            
+            // MERG-13-11-12: [[ RecursiveConditionalMessages ]] Don't send moveControl when adjusting the scrollbars here
+            messagestate &= ~HH_MOVE_CONTROL;
+            
 		}
 	else
 	{
@@ -787,9 +794,7 @@ void MCGroup::setrect(const MCRectangle &nrect)
 	
     // MERG-13-11-12: [[ ConditionalMessageRe-entry ]] Conditional message rentry handling is now in conditionalmessage
 	if (t_size_changed)
-	{
-		conditionalmessage(HH_RESIZE_CONTROL, MCM_resize_control);
-	}
+        conditionalmessage(HH_RESIZE_CONTROL, MCM_resize_control);
 }
 
 Exec_stat MCGroup::getprop(uint4 parid, Properties which, MCExecPoint &ep, Boolean effective)
@@ -1352,10 +1357,10 @@ void MCGroup::recursiveconditionalmessage(uint32_t p_flag, MCNameRef p_message)
             if ((p_flag == HH_HIDE_CONTROL || p_flag == HH_SHOW_CONTROL) && !t_object->getflag(F_VISIBLE))
                 continue;
             
+            t_object->conditionalmessage(p_flag, p_message);
+            
             if (t_object->gettype() == CT_GROUP)
                 (static_cast<MCGroup *>(t_object))->recursiveconditionalmessage(p_flag, p_message);
-            else
-                t_object->conditionalmessage(p_flag, p_message);
             
             t_object = t_object -> next();
             

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -147,6 +147,9 @@ public:
 	void computecrect();
 	Boolean computeminrect(Boolean scrolling);
 	void boundcontrols();
+    
+    // MERG-2013-11-10: [[ RecursiveConditionalMessages ]] recurse through the object heirarchy to send a conditional message
+    void recursiveconditionalmessage(uint32_t p_flag, MCNameRef p_message);
 	
 	Exec_stat opencontrols(bool p_is_preopen);
 	Exec_stat closecontrols(void);

--- a/engine/src/mcstring.cpp
+++ b/engine/src/mcstring.cpp
@@ -244,6 +244,7 @@ MCNameRef MCM_get_url_status;
 MCNameRef MCM_gradient_edit_ended;
 MCNameRef MCM_gradient_edit_started;
 MCNameRef MCM_help;
+MCNameRef MCM_hide_control;
 MCNameRef MCM_hot_spot_clicked;
 MCNameRef MCM_icon_menu_pick;
 MCNameRef MCM_icon_menu_opening;
@@ -342,6 +343,7 @@ MCNameRef MCM_scrollbar_page_inc;
 MCNameRef MCM_selected_object_changed;
 MCNameRef MCM_selection_changed;
 MCNameRef MCM_signal;
+MCNameRef MCM_show_control;
 MCNameRef MCM_shut_down;
 MCNameRef MCM_shut_down_request;
 MCNameRef MCM_socket_error;
@@ -362,7 +364,6 @@ MCNameRef MCM_uniconify_stack;
 MCNameRef MCM_unload_url;
 MCNameRef MCM_update_screen;
 MCNameRef MCM_update_var;
-MCNameRef MCM_visibility_changed;
 
 #ifdef _MOBILE
 MCNameRef MCN_firstname;
@@ -529,6 +530,7 @@ void MCU_initialize_names(void)
 	/* UNCHECKED */ MCNameCreateWithCString("gradientEditEnded", MCM_gradient_edit_ended);
 	/* UNCHECKED */ MCNameCreateWithCString("gradientEditStarted", MCM_gradient_edit_started);
 	/* UNCHECKED */ MCNameCreateWithCString("help", MCM_help);
+	/* UNCHECKED */ MCNameCreateWithCString("hideControl", MCM_hide_control);
 	/* UNCHECKED */ MCNameCreateWithCString("hotSpotClicked", MCM_hot_spot_clicked);
 	/* UNCHECKED */ MCNameCreateWithCString("iconMenuPick", MCM_icon_menu_pick);
 	/* UNCHECKED */ MCNameCreateWithCString("iconMenuOpening", MCM_icon_menu_opening);
@@ -625,6 +627,7 @@ void MCU_initialize_names(void)
 	/* UNCHECKED */ MCNameCreateWithCString("selectedObjectChanged", MCM_selected_object_changed);
 	/* UNCHECKED */ MCNameCreateWithCString("selectionChanged", MCM_selection_changed);
 	/* UNCHECKED */ MCNameCreateWithCString("signal", MCM_signal);
+	/* UNCHECKED */ MCNameCreateWithCString("showControl", MCM_show_control);
 	/* UNCHECKED */ MCNameCreateWithCString("shutDown", MCM_shut_down);
 	/* UNCHECKED */ MCNameCreateWithCString("shutDownRequest", MCM_shut_down_request);
 	/* UNCHECKED */ MCNameCreateWithCString("socketError", MCM_socket_error);
@@ -645,7 +648,6 @@ void MCU_initialize_names(void)
 	/* UNCHECKED */ MCNameCreateWithCString("unloadURL", MCM_unload_url);
 	/* UNCHECKED */ MCNameCreateWithCString("updateScreen", MCM_update_screen);
 	/* UNCHECKED */ MCNameCreateWithCString("updateVariable", MCM_update_var);
-	/* UNCHECKED */ MCNameCreateWithCString("visibilityChanged", MCM_visibility_changed);
 
 #ifdef _MOBILE
 	/* UNCHECKED */ MCNameCreateWithCString("firstname", MCN_firstname);
@@ -816,6 +818,7 @@ void MCU_finalize_names(void)
 	MCNameDelete(MCM_gradient_edit_ended);
 	MCNameDelete(MCM_gradient_edit_started);
 	MCNameDelete(MCM_help);
+	MCNameDelete(MCM_hide_control);
 	MCNameDelete(MCM_hot_spot_clicked);
 	MCNameDelete(MCM_icon_menu_pick);
 	MCNameDelete(MCM_icon_menu_opening);
@@ -909,6 +912,7 @@ void MCU_finalize_names(void)
 	MCNameDelete(MCM_selected_object_changed);
 	MCNameDelete(MCM_selection_changed);
 	MCNameDelete(MCM_signal);
+	MCNameDelete(MCM_show_control);
 	MCNameDelete(MCM_shut_down);
 	MCNameDelete(MCM_shut_down_request);
 	MCNameDelete(MCM_socket_error);
@@ -929,7 +933,6 @@ void MCU_finalize_names(void)
 	MCNameDelete(MCM_unload_url);
 	MCNameDelete(MCM_update_screen);
 	MCNameDelete(MCM_update_var);
-	MCNameDelete(MCM_visibility_changed);
 
 #ifdef _MOBILE
 	MCNameDelete(MCN_firstname);

--- a/engine/src/mcstring.cpp
+++ b/engine/src/mcstring.cpp
@@ -202,6 +202,7 @@ MCNameRef MCM_close_stack_request;
 MCNameRef MCM_color_changed;
 MCNameRef MCM_command_key_down;
 MCNameRef MCM_control_key_down;
+MCNameRef MCM_control_moved;
 MCNameRef MCM_copy_key;
 MCNameRef MCM_current_time_changed;
 MCNameRef MCM_cut_key;
@@ -361,6 +362,7 @@ MCNameRef MCM_uniconify_stack;
 MCNameRef MCM_unload_url;
 MCNameRef MCM_update_screen;
 MCNameRef MCM_update_var;
+MCNameRef MCM_visibility_changed;
 
 #ifdef _MOBILE
 MCNameRef MCN_firstname;
@@ -485,6 +487,7 @@ void MCU_initialize_names(void)
 	/* UNCHECKED */ MCNameCreateWithCString("colorChanged", MCM_color_changed);
 	/* UNCHECKED */ MCNameCreateWithCString("commandKeyDown", MCM_command_key_down);
 	/* UNCHECKED */ MCNameCreateWithCString("controlKeyDown", MCM_control_key_down);
+	/* UNCHECKED */ MCNameCreateWithCString("controlMoved", MCM_control_moved);
 	/* UNCHECKED */ MCNameCreateWithCString("copyKey", MCM_copy_key);
 	/* UNCHECKED */ MCNameCreateWithCString("currentTimeChanged", MCM_current_time_changed);
 	/* UNCHECKED */ MCNameCreateWithCString("cutKey", MCM_cut_key);
@@ -642,6 +645,7 @@ void MCU_initialize_names(void)
 	/* UNCHECKED */ MCNameCreateWithCString("unloadURL", MCM_unload_url);
 	/* UNCHECKED */ MCNameCreateWithCString("updateScreen", MCM_update_screen);
 	/* UNCHECKED */ MCNameCreateWithCString("updateVariable", MCM_update_var);
+	/* UNCHECKED */ MCNameCreateWithCString("visibilityChanged", MCM_visibility_changed);
 
 #ifdef _MOBILE
 	/* UNCHECKED */ MCNameCreateWithCString("firstname", MCN_firstname);
@@ -770,6 +774,7 @@ void MCU_finalize_names(void)
 	MCNameDelete(MCM_color_changed);
 	MCNameDelete(MCM_command_key_down);
 	MCNameDelete(MCM_control_key_down);
+	MCNameDelete(MCM_control_moved);
 	MCNameDelete(MCM_copy_key);
 	MCNameDelete(MCM_current_time_changed);
 	MCNameDelete(MCM_cut_key);
@@ -924,6 +929,7 @@ void MCU_finalize_names(void)
 	MCNameDelete(MCM_unload_url);
 	MCNameDelete(MCM_update_screen);
 	MCNameDelete(MCM_update_var);
+	MCNameDelete(MCM_visibility_changed);
 
 #ifdef _MOBILE
 	MCNameDelete(MCN_firstname);

--- a/engine/src/mcstring.h
+++ b/engine/src/mcstring.h
@@ -148,9 +148,6 @@ extern MCNameRef MCM_color_changed;
 extern MCNameRef MCM_command_key_down;
 extern MCNameRef MCM_control_key_down;
 
-// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of movement to themselves or parent groups
-extern MCNameRef MCM_control_moved;
-
 extern MCNameRef MCM_copy_key;
 extern MCNameRef MCM_current_time_changed;
 extern MCNameRef MCM_cut_key;
@@ -196,6 +193,10 @@ extern MCNameRef MCM_gradient_edit_ended;
 extern MCNameRef MCM_gradient_edit_started;
 
 extern MCNameRef MCM_help;
+
+// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of visibility changes
+extern MCNameRef MCM_hide_control;
+
 extern MCNameRef MCM_hot_spot_clicked;
 extern MCNameRef MCM_icon_menu_pick;
 extern MCNameRef MCM_icon_menu_opening;
@@ -306,6 +307,10 @@ extern MCNameRef MCM_scrollbar_page_inc;
 extern MCNameRef MCM_selected_object_changed;
 extern MCNameRef MCM_selection_changed;
 extern MCNameRef MCM_signal;
+
+// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of visibility changes
+extern MCNameRef MCM_show_control;
+
 extern MCNameRef MCM_shut_down;
 extern MCNameRef MCM_shut_down_request;
 extern MCNameRef MCM_socket_error;
@@ -326,9 +331,6 @@ extern MCNameRef MCM_undo_key;
 extern MCNameRef MCM_uniconify_stack;
 extern MCNameRef MCM_unload_url;
 extern MCNameRef MCM_update_var;
-
-// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of visibility changes to themselves or parent groups
-extern MCNameRef MCM_visibility_changed;
 
 #ifdef _MOBILE
 extern MCNameRef MCN_firstname;

--- a/engine/src/mcstring.h
+++ b/engine/src/mcstring.h
@@ -147,6 +147,10 @@ extern MCNameRef MCM_close_stack_request;
 extern MCNameRef MCM_color_changed;
 extern MCNameRef MCM_command_key_down;
 extern MCNameRef MCM_control_key_down;
+
+// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of movement to themselves or parent groups
+extern MCNameRef MCM_control_moved;
+
 extern MCNameRef MCM_copy_key;
 extern MCNameRef MCM_current_time_changed;
 extern MCNameRef MCM_cut_key;
@@ -322,6 +326,9 @@ extern MCNameRef MCM_undo_key;
 extern MCNameRef MCM_uniconify_stack;
 extern MCNameRef MCM_unload_url;
 extern MCNameRef MCM_update_var;
+
+// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of visibility changes to themselves or parent groups
+extern MCNameRef MCM_visibility_changed;
 
 #ifdef _MOBILE
 extern MCNameRef MCN_firstname;

--- a/engine/src/objdefs.h
+++ b/engine/src/objdefs.h
@@ -512,6 +512,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define HH_RESIZE_CONTROL		(1UL << 6)
 #define HH_CLOSE_CONTROL		(1UL << 7)
 
+// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of visibility changes to themseves or parent groups
+#define HH_VISIBILITY_CHANGED	(1UL << 8)
+// MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of location changes to themseves or parent groups
+#define HH_CONTROL_MOVED        (1UL << 9)
+
 // MCParagraph state
 #define PS_FRONT                (1UL << 0)
 #define PS_BACK                 (1UL << 1)

--- a/engine/src/objdefs.h
+++ b/engine/src/objdefs.h
@@ -389,6 +389,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #define CS_GRAB                 (1UL << 30)
 #define CS_MENU_ATTACHED        (1UL << 31)
+
 // MCButton state
 #define CS_ARMED                (1UL << 13)
 #define CS_SUBMENU              (1UL << 14)
@@ -451,7 +452,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define CS_NEED_UPDATE          (1UL << 13)
 // Uses CS_HSCROLL 14
 // Uses CS_VSCROLL 15
-#define CS_SENDING_RESIZE		(1UL << 16)
+//#define CS_SENDING_RESIZE		(1UL << 16)
 // MCCard state
 #define CS_OWN_CONTROLS         (1UL << 14)
 #define CS_INSIDE               (1UL << 15)
@@ -513,15 +514,16 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define HH_CLOSE_CONTROL		(1UL << 7)
 
 // MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of visibility changes to themseves or parent groups
-#define HH_VISIBILITY_CHANGED	(1UL << 8)
+#define HH_SHOW_CONTROL         (1UL << 8)
+#define HH_HIDE_CONTROL         (1UL << 9)
 // MERG-2013-11-10: [[ RecursiveConditionalMessages ]] notify controls of location changes to themseves or parent groups
-#define HH_CONTROL_MOVED        (1UL << 9)
+#define HH_MOVE_CONTROL         (1UL << 10)
 
 // MCParagraph state
 #define PS_FRONT                (1UL << 0)
 #define PS_BACK                 (1UL << 1)
 #define PS_HILITED              (PS_FRONT | PS_BACK)
-#define PS_LINES_NOT_SYNCHED		(1UL << 2)
+#define PS_LINES_NOT_SYNCHED	(1UL << 2)
 
 // MCStack decorations
 #define DECORATION_LENGTH     64

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2213,6 +2213,10 @@ Boolean MCObject::parsescript(Boolean report, Boolean force)
 					hashandlers |= HH_CLOSE_CONTROL;
 				if (should_send_message(hlist, MCM_resize_control))
 					hashandlers |= HH_RESIZE_CONTROL;
+                if (should_send_message(hlist, MCM_visibility_changed))
+                    hashandlers |= HH_VISIBILITY_CHANGED;
+                if (should_send_message(hlist, MCM_control_moved))
+                    hashandlers |= HH_CONTROL_MOVED;
 			}
 		}
 	return True;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -186,6 +186,7 @@ protected:
 	uint2 npixmaps;
 	uint2 altid;
 	uint16_t hashandlers;
+    uint16_t messagestate;
 	uint1 scriptdepth;
 	uint1 borderwidth;
 	int1 shadowoffset;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -185,7 +185,7 @@ protected:
 	uint2 ncolors;
 	uint2 npixmaps;
 	uint2 altid;
-	uint1 hashandlers;
+	uint16_t hashandlers;
 	uint1 scriptdepth;
 	uint1 borderwidth;
 	int1 shadowoffset;

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -827,9 +827,9 @@ Exec_stat MCObject::setrectprop(Properties p_which, MCExecPoint& ep, Boolean p_e
         
         if (t_moved)
         {
-            conditionalmessage(HH_CONTROL_MOVED, MCM_control_moved);
+            conditionalmessage(HH_MOVE_CONTROL, MCM_move_control);
             if (gettype() == CT_GROUP)
-                static_cast<MCGroup *>(this)->recursiveconditionalmessage(HH_CONTROL_MOVED, MCM_control_moved);
+                static_cast<MCGroup *>(this)->recursiveconditionalmessage(HH_MOVE_CONTROL, MCM_move_control);
         
         }
         
@@ -1112,6 +1112,10 @@ Exec_stat MCObject::setvisibleprop(uint4 parid, Properties which, MCExecPoint& e
 {
 	Boolean dirty;
 	dirty = True;
+    
+    Boolean was_visible;
+    // Was the control visible before the change
+    was_visible = isvisible();
 
 	MCString data;
 	data = ep . getsvalue();
@@ -1126,7 +1130,7 @@ Exec_stat MCObject::setvisibleprop(uint4 parid, Properties which, MCExecPoint& e
 		flags ^= F_VISIBLE;
 		dirty = !dirty;
 	}
-
+    
 	// MW-2011-10-17: [[ Bug 9813 ]] Record the current effective rect of the object.
 	MCRectangle t_old_effective_rect;
 	if (dirty && opened && gettype() >= CT_GROUP)
@@ -1174,10 +1178,20 @@ Exec_stat MCObject::setvisibleprop(uint4 parid, Properties which, MCExecPoint& e
 			dirty = False;
         
         // MERG-2013-11-10: [[ RecursiveConditionalMessages ]] Notify objects of visbility change
-        conditionalmessage(HH_VISIBILITY_CHANGED, MCM_visibility_changed);
-        if (gettype() == CT_GROUP)
-            static_cast<MCGroup *>(this)->recursiveconditionalmessage(HH_VISIBILITY_CHANGED, MCM_visibility_changed);
-           
+        // Is the control invisible after the change
+        if (was_visible && !(flags & F_VISIBLE)) 
+        {
+            conditionalmessage(HH_HIDE_CONTROL, MCM_hide_control);
+            if (gettype() == CT_GROUP)
+                static_cast<MCGroup *>(this)->recursiveconditionalmessage(HH_HIDE_CONTROL, MCM_hide_control);
+        }
+        else if (isvisible()) // we are dirty so we know there's been a change
+        {
+            conditionalmessage(HH_SHOW_CONTROL, MCM_show_control);
+            if (gettype() == CT_GROUP)
+                static_cast<MCGroup *>(this)->recursiveconditionalmessage(HH_SHOW_CONTROL, MCM_show_control);
+        }
+        
     }
 
 	if (dirty)

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -811,20 +811,33 @@ Exec_stat MCObject::setrectprop(Properties p_which, MCExecPoint& ep, Boolean p_e
 				if (MCU_point_in_rect(t_rect, MCmousex, MCmousey) && this != mfocused)
 					needmfocus = True;
 		}
-
+        
+        // MERG-2013-11-10: [[ RecursiveConditionalMessages ]] Notify objects of movement
+        bool t_moved = t_rect.width == rect.width && t_rect.height == rect.height;
+        
 		if (gettype() >= CT_GROUP)
 		{
 			// MW-2011-08-18: [[ Layers ]] Notify of change of rect.
 			static_cast<MCControl *>(this) -> layer_setrect(t_rect, false);
 			// Notify the parent of the resize.
 			resizeparent();
-		}
+  		}
 		else
 			setrect(t_rect);
+        
+        if (t_moved)
+        {
+            conditionalmessage(HH_CONTROL_MOVED, MCM_control_moved);
+            if (gettype() == CT_GROUP)
+                static_cast<MCGroup *>(this)->recursiveconditionalmessage(HH_CONTROL_MOVED, MCM_control_moved);
+        
+        }
+        
 
 		if (needmfocus)
 			MCmousestackptr->getcard()->mfocus(MCmousex, MCmousey);
-	}
+    
+    }
 	
 	return ES_NORMAL;
 }
@@ -1159,7 +1172,13 @@ Exec_stat MCObject::setvisibleprop(uint4 parid, Properties which, MCExecPoint& e
 
 		if (resizeparent())
 			dirty = False;
-	}
+        
+        // MERG-2013-11-10: [[ RecursiveConditionalMessages ]] Notify objects of visbility change
+        conditionalmessage(HH_VISIBILITY_CHANGED, MCM_visibility_changed);
+        if (gettype() == CT_GROUP)
+            static_cast<MCGroup *>(this)->recursiveconditionalmessage(HH_VISIBILITY_CHANGED, MCM_visibility_changed);
+           
+    }
 
 	if (dirty)
 		signallisteners(P_VISIBLE);


### PR DESCRIPTION
...plemented to allow custom controls presenting native views to respond to changes to the control or one of it's parents

Currently undocumented and submitting for feedback on:
- requiring controls state to guard against recursion
- only sending the messages if the control is open

Note that visibilityChanged doesn't compare changes in effective visible of an object before sending the message. The intention is just to notify that there may be a change in the effective visible because of a change to the object or one of it's parents.
