### PR TITLE
Refactor syntax unicode analysis cleanups0

### DIFF
--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -3322,7 +3322,7 @@ IO_stat MCCard::load(IO_handle stream, const char *version)
 
 IO_stat MCCard::loadobjects(IO_handle stream, const char *version)
 {
-	IO_stat stat;
+	IO_stat stat = IO_NORMAL;
 	
 	if (objptrs != NULL)
 	{

--- a/engine/src/debug.cpp
+++ b/engine/src/debug.cpp
@@ -463,7 +463,7 @@ void MCB_parsebreaks(MCExecContext& ctxt, MCStringRef p_input)
 			}
 		}
 
-		if (t_offset < t_length)
+		if (t_success && t_offset < t_length)
 		{
 			MCAutoStringRef t_head;
 			MCAutoStringRef t_tail;

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3320,7 +3320,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
         t_source_fork_opened = false;
         
         MCS_mac_openresourcefork_with_path(p_source, fsRdPerm, false, &t_source_ref, &t_error);
-        if (*t_error != nil)
+        if (*t_error == nil)
             t_source_fork_opened = true;
         
         SInt16 t_dest_ref;
@@ -3330,7 +3330,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
         if (t_source_fork_opened)
         {
             MCS_mac_openresourcefork_with_path(p_destination, fsWrPerm, true, &t_dest_ref, &t_error);
-            if (MCStringGetLength(*t_error))
+            if (*t_error == nil)
                 t_dest_fork_opened = true;
         }
         
@@ -3348,7 +3348,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
                     if (t_os_write_error != noErr || t_actual_write != t_actual_read)
 					/* UNCHECKED */ MCStringCreateWithCString("can't copy resource", &t_error);
                 }
-            } while(MCStringGetLength(*t_error) && t_os_read_error == noErr);
+            } while(*t_error == nil && t_os_read_error == noErr);
         }
         
         delete[] t_buffer;

--- a/engine/src/exec-dialog.cpp
+++ b/engine/src/exec-dialog.cpp
@@ -77,7 +77,7 @@ MC_EXEC_DEFINE_SET_METHOD(Dialog, ColorDialogColors, 2)
 void MCDialogExecAnswerColor(MCExecContext &ctxt, MCColor *p_initial_color, MCStringRef p_title, bool p_as_sheet)
 {
     MCAutoStringRef t_value;
-	bool t_chosen;
+	bool t_chosen = true;
 	if (MCsystemCS && MCscreen->hasfeature(PLATFORM_FEATURE_OS_COLOR_DIALOGS))
 	{
 		MCColor t_color;

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1579,6 +1579,8 @@ bool MCEngineEvalValueAsObject(MCValueRef p_value, bool p_strict, MCObjectPtr& r
     t_parse_error = tchunk->parse(sp, False) == PS_NORMAL;
     if (!t_parse_error && (!p_strict || sp.next(type) == PS_EOF))
         stat = ES_NORMAL;
+    else
+        stat = ES_ERROR;
     MCerrorlock--;
     if (stat == ES_NORMAL)
         stat = tchunk->getobj(ep, r_object, False);

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1785,6 +1785,7 @@ void MCFilesExecWriteToStream(MCExecContext& ctxt, IO_handle p_stream, MCStringR
 						r_stat = IO_write_uint4((uint4)n, p_stream);
 					break;
 				default:
+                    r_stat = IO_ERROR;
 					break;
 				}
 			}
@@ -1916,6 +1917,7 @@ void MCFilesExecWriteToProcess(MCExecContext& ctxt, MCNameRef p_process, MCStrin
 	uint4 t_offset;
 	Boolean haseof = False;
 	IO_stat t_stat;
+    t_stat = IO_NORMAL;
 
 	if (t_textmode)
 	{

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1215,7 +1215,7 @@ void MCObject::GetLayer(MCExecContext& ctxt, uint32_t part, MCInterfaceLayer& r_
 	// previous fix for crash when attempting to get the layer of an object outside
 	// the group being edited in edit group mode.
 	
-	uint2 num;
+	uint2 num = 0;
 	if (parent != nil)
 	{
 		MCCard *t_card;
@@ -1479,7 +1479,8 @@ void MCObject::SetParentScript(MCExecContext& ctxt, MCStringRef new_parent_scrip
 
             // MW-2013-05-30: [[ InheritedPscripts ]] Make sure we resolve the the
 			//   parent script as pointing to the object (so Inherit works correctly).
-			t_use -> GetParent() -> Resolve(t_object);
+            if (t_success)
+                t_use -> GetParent() -> Resolve(t_object);
             
             // MW-2013-05-30: [[ InheritedPscripts ]] Next we have to ensure the
 			//   inheritence hierarchy is in place (The inherit call will create

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3049,7 +3049,7 @@ void MCInterfaceExecClone(MCExecContext& ctxt, MCObject *p_target, MCStringRef p
 {
 	MCStack *odefaultstackptr = MCdefaultstackptr;
 
-	MCObject *t_object;
+	MCObject *t_object = nil;
 	switch (p_target->gettype())
 	{
 	case CT_STACK:

--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -182,6 +182,7 @@ void MCStringsGetExtentsByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_type, 
             break;
         default:
             fprintf(stderr, "MCChunk: ERROR bad extents\n");
+            abort();
 	}
     
     if (r_first < 0)

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -617,6 +617,7 @@ static bool MCPropertyParseUIntList(MCStringRef p_input, char_t p_delimiter, uin
     if (t_length == 0)
     {
         r_count = 0;
+        r_list = nil;
         return true;
     }
     
@@ -667,6 +668,7 @@ static bool MCPropertyParseStringList(MCStringRef p_input, char_t p_delimiter, u
     if (t_length == 0)
     {
         r_count = 0;
+        r_list = nil;
         return true;
     }
     
@@ -713,6 +715,7 @@ static bool MCPropertyParsePointList(MCStringRef p_input, char_t p_delimiter, ui
     if (t_length == 0)
     {
         r_count = 0;
+        r_list = nil;
         return true;
     }
     
@@ -1627,7 +1630,7 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
         case kMCPropertyTypeLinesOfString:
         {
             MCAutoStringRef t_input;
-            MCStringRef *t_value;
+            MCStringRef *t_value = nil;
             uindex_t t_count;
             
             if (!ep . copyasstringref(&t_input) || !MCPropertyParseStringList(*t_input, '\n', t_count, t_value))
@@ -1647,7 +1650,7 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
         case kMCPropertyTypeItemsOfUInt:
         {
             MCAutoStringRef t_input;
-            uinteger_t* t_value;
+            uinteger_t* t_value = nil;
             uindex_t t_count;
             
             char_t t_delimiter;
@@ -1666,7 +1669,7 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
         case kMCPropertyTypeLinesOfPoint:
         {
             MCAutoStringRef t_input;
-            MCPoint *t_value;
+            MCPoint *t_value = nil;
             uindex_t t_count;
             
             if (!ep . copyasstringref(&t_input) || !MCPropertyParsePointList(*t_input, '\n', t_count, t_value))

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -256,9 +256,9 @@ Exec_stat MCIdeScriptAction::eval_target_range(MCExecPoint& p_exec, MCExpression
 	Exec_stat t_status;
 	t_status = ES_NORMAL;
 
-	int4 t_start;
-	int4 t_end;
-	MCField *t_target;
+	int4 t_start = 0;
+	int4 t_end = 0;
+	MCField *t_target = nil;
 
 	if (t_status == ES_NORMAL)
 		t_status = p_start -> eval(p_exec);

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1164,7 +1164,7 @@ bool MCModeHandleMessageBoxChanged(MCExecContext& ctxt, MCStringRef p_string)
 			MCAutoNameRef t_msg_changed;
 			/* UNCHECKED */ t_msg_changed . CreateWithCString("msgchanged");
 			
-			bool t_added;
+			bool t_added = false;
 			if (MCnexecutioncontexts < MAX_CONTEXTS && ctxt.GetObject() != nil)
 			{
 				MCexecutioncontexts[MCnexecutioncontexts++] = &ctxt;

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -1498,7 +1498,7 @@ bool MCS_changeprocesstype(bool p_to_foreground)
     MCMacSystemServiceInterface *t_service;
     t_service = (MCMacSystemServiceInterface*) MCsystem -> QueryService(kMCServiceTypeMacSystem);
     
-    if (!t_service != nil)
+    if (t_service != nil)
         return t_service -> ChangeProcessType(p_to_foreground);
     
     MCresult -> sets("not supported");
@@ -1510,7 +1510,7 @@ bool MCS_processtypeisforeground(void)
     MCMacSystemServiceInterface *t_service;
     t_service = (MCMacSystemServiceInterface*) MCsystem -> QueryService(kMCServiceTypeMacSystem);
     
-    if (!t_service != nil)
+    if (t_service != nil)
         return t_service -> ProcessTypeIsForeground();
     
     MCresult -> sets("not supported");

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -768,7 +768,16 @@ void MCErrorSetHandler(MCErrorHandler handler);
 
 #ifdef _DEBUG
 
-extern void __MCAssert(const char *file, uint32_t line, const char *message);
+// If we are using GCC or Clang, we can give the compiler the hint that the
+// assertion functions do not return. This is particularly useful for Clang's
+// static analysis feature.
+#if defined(__GNUC__) || defined (__clang__) || defined (__llvm__)
+#define ATTRIBUTE_NORETURN  __attribute__((__noreturn__))
+#else
+#define ATTRIBUTE_NORETURN
+#endif
+
+extern void __MCAssert(const char *file, uint32_t line, const char *message) ATTRIBUTE_NORETURN;
 #define MCAssert(m_expr) (void)( (!!(m_expr)) || (__MCAssert(__FILE__, __LINE__, #m_expr), 0) )
 
 extern void __MCLog(const char *file, uint32_t line, const char *format, ...);
@@ -777,7 +786,7 @@ extern void __MCLog(const char *file, uint32_t line, const char *format, ...);
 extern void __MCLogWithTrace(const char *file, uint32_t line, const char *format, ...);
 #define MCLogWithTrace(m_format, ...) __MCLogWithTrace(__FILE__, __LINE__, m_format, __VA_ARGS__)
 
-extern void __MCUnreachable(void);
+extern void __MCUnreachable(void) ATTRIBUTE_NORETURN;
 #define MCUnreachable() __MCUnreachable();
 
 #else

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -140,6 +140,8 @@ void __MCUnreachable(void)
 
 void __MCAssert(const char *p_file, uint32_t p_line, const char *p_message)
 {
+    fprintf(stderr, "MCAssert failed: %s:%u \"%s\"", p_file, p_line, p_message);
+    abort();
 }
 
 void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)


### PR DESCRIPTION
Minor cleanups suggested by problem reports from the Clang static analyser.

These generally consist of un-initialised variables. Hopefully changing them won't cause subtle problems elsewhere. Plenty more issues from the analyser remain; these were just the low-hanging fruit.
