### PR TITLE
Refactor syntax unicode analysis cleanups2

### DIFF
--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1734,14 +1734,14 @@ void MCEngineMarkVariable(MCExecContext& ctxt, MCVarref *p_variable, MCMarkedTex
 		return;
 	}
     
-    MCValueRef t_value;
-    if (!p_variable -> eval(ctxt, t_value))
+    MCAutoValueRef t_value;
+    if (!p_variable -> eval(ctxt, &t_value))
     {
         ctxt . LegacyThrow(EE_CHUNK_SETCANTGETDEST);
         return;
     }
     
-    if (!ctxt . ConvertToString(t_value, r_mark . text))
+    if (!ctxt . ConvertToString(*t_value, r_mark . text))
     {
         ctxt . LegacyThrow(EE_CHUNK_SETCANTGETDEST);
         return;

--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -477,3 +477,9 @@ void __MCDataFinalize(void)
 {
     MCValueRelease(kMCEmptyData);
 }
+
+void __MCDataDestroy(__MCData *self)
+{
+    if (self -> bytes != nil)
+        MCMemoryDeleteArray(self -> bytes);
+}

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -308,6 +308,7 @@ bool __MCSetImmutableCopy(__MCSet *set, bool release, __MCSet*& r_immutable_valu
 
 bool __MCDataInitialize(void);
 void __MCDataFinalize(void);
+void __MCDataDestroy(__MCData *data);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -294,7 +294,6 @@ void __MCValueDestroy(__MCValue *self)
 	case kMCValueTypeCodeNull:
 	case kMCValueTypeCodeBoolean:
 	case kMCValueTypeCodeNumber:
-	default:
 		break;
 	case kMCValueTypeCodeString:
 		__MCStringDestroy((__MCString *)self);
@@ -311,8 +310,14 @@ void __MCValueDestroy(__MCValue *self)
 	case kMCValueTypeCodeSet:
 		__MCSetDestroy((__MCSet *)self);
 		break;
+    case kMCValueTypeCodeData:
+        __MCDataDestroy((__MCData *)self);
+        break;
 	case kMCValueTypeCodeCustom:
 		return ((__MCCustomValue *)self) -> callbacks -> destroy(self);
+    default:
+        // Shouldn't get here
+        MCAssert(false);
 	}
 
 	MCMemoryDelete(self);


### PR DESCRIPTION
In addition to the cleanups1 fixes, removes a couple of sources of major memory leaks.
