### PR TITLE
[[ Bugfix 11511 ]] Fix for crash when retrieving contact

### DIFF
--- a/docs/notes/bugfix-11511.md
+++ b/docs/notes/bugfix-11511.md
@@ -1,0 +1,2 @@
+# Fix a crash when retrieving contacts imported from Outlook into the iOS address book
+

--- a/engine/src/mbliphonecontact.mm
+++ b/engine/src/mbliphonecontact.mm
@@ -276,7 +276,10 @@ bool MCCreatePersonData(MCExecPoint& ep, ABRecordRef p_person, MCVariableValue *
 					
 					t_label = ABMultiValueCopyLabelAtIndex(t_values, j);
 					
-					if (label_to_name(t_label, t_label_name))
+                    // FG-2013-11-26 [[ Bugfix 11511 ]]
+                    // ABMultiValueCopyLabelAtIndex returns a null pointer if
+                    // there is no label for the given index.
+					if (t_label != nil && label_to_name(t_label, t_label_name))
 					{
 						CFTypeRef t_multi_value;
 						t_multi_value = ABMultiValueCopyValueAtIndex(t_values, j);


### PR DESCRIPTION
Contacts imported from Outlook into the iOS address book may contain fields with a nil label. The engine didn't check for this before attempting to compare the label to the list of known labels.
