### PR TITLE
[[ Bug 11507 ]] Prevent crash in revBrowser on OSX when there is no data...

### DIFF
--- a/docs/notes/bugfix-11507.md
+++ b/docs/notes/bugfix-11507.md
@@ -1,0 +1,1 @@
+# Prevent crash in revBrowser on OSX when there is no data source

--- a/revbrowser/src/osxbrowser.cpp
+++ b/revbrowser/src/osxbrowser.cpp
@@ -1181,7 +1181,8 @@ char *TAltBrowser::GetSource()
 	if (datasource != nil)
 		t_repn = [datasource representation];
 
-	NSString *t_source;
+    // AL-2013-12-03 [[ Bug 11507 ]] Initialise t_source to nil to prevent crash.
+	NSString *t_source = nil;
 	if (t_repn != nil)
 		t_source = [t_repn documentSource];
 


### PR DESCRIPTION
... source
