### PR TITLE
Bugfix accelerated rendering

### DIFF
--- a/engine/src/props.cpp
+++ b/engine/src/props.cpp
@@ -23,7 +23,8 @@ PropList;
 
 static PropList stackprops[] =
     {
-        {"altId", P_ALT_ID},
+  		{"acceleratedrendering", P_ACCELERATED_RENDERING},
+		{"altId", P_ALT_ID},
         {"alwaysBuffer", P_ALWAYS_BUFFER},
 		{"backColor", P_BACK_COLOR},
 		{"backPattern", P_BACK_PATTERN},

--- a/engine/src/props.cpp
+++ b/engine/src/props.cpp
@@ -23,6 +23,7 @@ PropList;
 
 static PropList stackprops[] =
     {
+    	// MDW-2013-12-15 [[ bugfix_acceleratedRendering ]] missing from stack properties
   		{"acceleratedrendering", P_ACCELERATED_RENDERING},
 		{"altId", P_ALT_ID},
         {"alwaysBuffer", P_ALWAYS_BUFFER},


### PR DESCRIPTION
Stack properties list was missing acceleratedRendering. Filed as bug 11599.
