### PR TITLE
[[ Bug 11641 ]] Android touch ids are 0-based, but MCScreenDC::getmouse ...

### DIFF
--- a/docs/notes/bugfix-11641.md
+++ b/docs/notes/bugfix-11641.md
@@ -1,0 +1,2 @@
+# 'the mouse' doesn't work on Android (it always returns 'up').
+

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -1845,7 +1845,9 @@ JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doTouch(JNIEnv *env, jobje
 			return;
 	}
 
-	static_cast<MCScreenDC *>(MCscreen) -> handle_touch(t_phase, (void *)id, timestamp, x, y);
+	// MW-2014-01-06: [[ Bug 11641 ]] Make sure we use 'id + 1' for the id as it needs to be non-zero
+	//   (non-nil) for 'getmouse()'. (Android touch ids are 0 based).
+	static_cast<MCScreenDC *>(MCscreen) -> handle_touch(t_phase, (void *)(id + 1), timestamp, x, y);
 }
 
 JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doKeyPress(JNIEnv *env, jobject object, int modifiers, int char_code, int key_code)


### PR DESCRIPTION
...checks that the id (cast to a pointer) is non-nil.
