### PR TITLE
[[ Bug 11628 ]] Ensure that any spaces after a break boundary are skippe...

### DIFF
--- a/docs/notes/bugfix-11628.md
+++ b/docs/notes/bugfix-11628.md
@@ -1,0 +1,1 @@
+# Spaces after a style-run boundary are not skipped when wrapping text.

--- a/engine/src/line.cpp
+++ b/engine/src/line.cpp
@@ -167,6 +167,34 @@ MCBlock *MCLine::fitblocks(MCBlock* p_first, MCBlock* p_sentinal, uint2 p_max_wi
 		t_break_index = t_break_block -> getindex() + t_break_block -> getsize();
 	}
 	
+	// MW-2014-01-06: [[ Bug 11628 ]] We have a break block and index, so now extend the
+	//   break index through any space chars.
+	const char *t_text;
+	t_text = parent -> gettext();
+	for(;;)
+	{
+		// Consume all spaces after the break index.
+		while(t_break_index < (t_break_block -> getindex() + t_break_block -> getsize()) &&
+			  t_break_block -> textisspace(&t_text[t_break_index]))
+			t_break_index++;
+		
+		// Get the next block.
+		MCBlock *t_next_block;
+		t_next_block = t_break_block -> next();
+		
+		// If we are at the end of the list of blocks there is nothing more to do.
+		if (t_next_block == p_sentinal)
+			break;
+		
+		// If the first char of the next block is not a space, then there is nothing more
+		// to do.
+		if (!t_next_block -> textisspace(&t_text[t_next_block -> getindex()]))
+			break;
+		
+		// The next block starts with a space, so advance the break block.
+		t_break_block = t_next_block;
+	}
+	
 	// MW-2012-02-21: [[ LineBreak ]] Check to see if there is a vtab char before the
 	//   break index.
 	bool t_is_explicit_line_break;


### PR DESCRIPTION
...d.
