### PR TITLE
[[ Bug 11632 ]] Added MCOffscreenGraphicsContext derived MCGraphicsConte...

### DIFF
--- a/docs/notes/bugfix-11632.md
+++ b/docs/notes/bugfix-11632.md
@@ -1,0 +1,1 @@
+# Taking a snapshot of a non-buffered player doesn't work.

--- a/engine/src/graphicscontext.h
+++ b/engine/src/graphicscontext.h
@@ -112,5 +112,15 @@ private:
 	uint32_t m_dash_count;
 };
 
+// MW-2014-01-07: [[ Bug 11632 ]] The player object distinguishes between 'screen' and 'offscreen' - in the
+//   latter case it caches the bitmap and blits it rather than relying on the OS to overlay it. This derived
+//   class handles this case by changing the 'type' appropriately.
+class MCOffscreenGraphicsContext: public MCGraphicsContext
+{
+public:
+	MCOffscreenGraphicsContext(MCGContextRef ctxt): MCGraphicsContext(ctxt) {}
+
+	virtual MCContextType gettype(void) const { return CONTEXT_TYPE_OFFSCREEN; }
+};
 
 #endif

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2671,7 +2671,9 @@ MCImageBitmap *MCObject::snapshot(const MCRectangle *p_clip, const MCPoint *p_si
 
 	MCGContextConcatCTM(t_gcontext, t_transform);
 	
-	MCContext *t_context = new MCGraphicsContext(t_gcontext);
+	// MW-2014-01-07: [[ bug 11632 ]] Use the offscreen variant of the context so its
+	//   type field is appropriate for use by the player.
+	MCContext *t_context = new MCOffscreenGraphicsContext(t_gcontext);
 	t_context -> setclip(r);
 
 	// MW-2011-01-29: [[ Bug 9355 ]] Make sure we only open a control if it needs it!


### PR DESCRIPTION
...xt class which returns CONTEXT_TYPE_OFFSCREEN - used by the player to ensure it is buffering when being snapshot.
