### PR TITLE
[[ Bug 11720 ]] Ensure FTS is enabled on Mac / iOS

### DIFF
--- a/docs/notes/bugfix-11720.md
+++ b/docs/notes/bugfix-11720.md
@@ -1,0 +1,1 @@
+# SQLite FTS feature doesn't work on iOS or Mac.


### PR DESCRIPTION
This depends on an update to the thirdparty module - make sure livecode-thirdparty/bugfix-11720 is merged into a matching release branch in the thirdparty module and the submodule link from the livecode repo tracks it.
