### PR TITLE
[[ Bug 11732 ]] Make sure '<>' is identical to 'is not' -- not suitable for maintenance release

### DIFF
--- a/docs/notes/bugfix-11732.md
+++ b/docs/notes/bugfix-11732.md
@@ -1,0 +1,11 @@
+# <> operator is different from 'is not' operator for arrays
+The <> operator will now work identically to 'is not' when comparing with an array. Previously, the <> operator would convert arrays to the empty string before comparing.
+
+More specifically:
+   put 100 into tLeft[1]
+   put tLeft is empty -- false
+   put tLeft = empty -- false (same as is)
+   put tLeft is not empty -- true
+   put tLeft <> empty -- true (previously this was false)
+   
+Note: This is a subtle change which could impact existing scripts. However, since '<>' and 'is not' should be synonyms it is considered that it is more likely that it will fix unnoticed bugs in existing scripts rather than cause them.

--- a/engine/src/operator.cpp
+++ b/engine/src/operator.cpp
@@ -852,8 +852,10 @@ Exec_stat MCLessThanEqual::eval(MCExecPoint &ep)
 
 Exec_stat MCNotEqual::eval(MCExecPoint &ep)
 {
+	// MW-2014-01-30: [[ Bug 11732 ]] Enable array comparison mode - this stops
+	//   auto-conversion of arrays to empty.
 	int2 i;
-	if (compare(ep, i) != ES_NORMAL)
+	if (compare(ep, i, true) != ES_NORMAL)
 	{
 		MCeerror->add
 		(EE_NOTEQUAL_OPS, line, pos);


### PR DESCRIPTION
This is a subtle change in semantics of <> (albeit how things should be) therefore it is not suitable for inclusion in a maintenance release and should go into the next major release.
