### PR TITLE
[[ Bug 5331 ]] Make liveResizing true for new stacks -- not suitable for maintenance release

### DIFF
--- a/docs/notes/bugfix-5331.md
+++ b/docs/notes/bugfix-5331.md
@@ -1,0 +1,2 @@
+# Mac live window resizing is off by default.
+The liveResizing property of stacks is now by default true for all newly created stacks. This is more inline with modern expectations on the platform.

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -106,7 +106,11 @@ MCStack::MCStack()
 	nneeds = 0;
 	needs = NULL;
 	mode = WM_CLOSED;
-	decorations = WD_CLEAR;
+	
+	// MW-2014-01-30: [[ Bug 5331 ]] Make liveResizing on by default
+	flags |= F_DECORATIONS;
+	decorations = WD_MENU | WD_TITLE | WD_MINIMIZE | WD_MAXIMIZE | WD_CLOSE | WD_LIVERESIZING;
+	
 	nstackfiles = 0;
 	stackfiles = NULL;
 	linkatts = NULL;


### PR DESCRIPTION
As this is a change in behavior, it is not suitable for a maintenance release. It should be merged into develop for the next major version.
