### PR TITLE
revXMLPutIntoNode crashed with empty replacement string

### DIFF
--- a/revxml/src/revxml.cpp
+++ b/revxml/src/revxml.cpp
@@ -1286,6 +1286,10 @@ void XML_SetElementContents(char *args[], int nargs, char **retstring, Bool *pas
 				// XML rather than as a raw string. Because of this we need to escape any special characters in the string.
 				xmlChar *t_encoded_string;
 				t_encoded_string = xmlEncodeSpecialChars(tdoc -> GetDocPtr(), (const xmlChar *)args[2]);
+				// MDW-2014-02-07 : [[ bugfix-11766 ]] handle empty string replacement argument.
+				// Should really be fixed in xmlStringGetNodeList in the libxml library, but this avoids the crash.
+				if (0 == strlen(args[2]))
+					t_encoded_string = (xmlChar *)"\n";
 
 				if (t_replace_text_only)
 				{


### PR DESCRIPTION
This is the fix for bug 11766, reported by Malte: revXMLPutIntoNode crashes the engine if you try to replace the contents of an existing node with an empty string. This should really be fixed in the thirdparty libxml library, and if I can figure out where to implement a fix I'll submit a pull request to the manager of that library, but this patch at least avoids the crash by replacing the existing string with a carriage return, thus providing a similar effect to eliminating the contents entirely.
