### PR TITLE
[[ Bug 11781 ]] Make sure co-ordinates are scaled correctly in effectrec...

### DIFF
--- a/docs/notes/bugfix-11781.md
+++ b/docs/notes/bugfix-11781.md
@@ -1,0 +1,1 @@
+# Visual effects can display in the wrong place on iOS on Retina devices.

--- a/engine/src/mbliphonestack.mm
+++ b/engine/src/mbliphonestack.mm
@@ -338,8 +338,10 @@ static void effectrect_phase_2(void *p_context)
 	[ctxt -> updated_image release];
 	
     // MM-2013-01-10: [[ Bug 11653 ]] As above, our rects are also in device pixels, so use the device scale when working out x and y of bounds.
+    // MW-2014-02-11: [[ Bug 11781 ]] Make sure we compute the correct scale - what units iOS will expect
+    //   depends on both the physical device scale, and what pixel scale is set.
 	float t_scale;
-    t_scale = MCIPhoneGetDeviceScale();
+    t_scale = MCIPhoneGetDeviceScale() / MCResGetPixelScale();
 	
 	// MW-2011-09-27: [[ iOSApp ]] Adjust for content origin.
 	// IM-2013-07-18: [[ ResIndependence ]] use width / height from the UIImage
@@ -648,8 +650,9 @@ bool MCStack::snapshottilecache(MCRectangle p_area, MCGImageRef& r_image)
 		return false;
 	
 	__block bool t_result;
+    __block MCGImageRef *t_image = &r_image;
 	MCIPhoneRunBlockOnMainFiber(^(void) {
-		t_result = view_snapshottilecache(p_area, r_image);
+		t_result = view_snapshottilecache(p_area, *t_image);
 	});
 	
 	return t_result;


### PR DESCRIPTION
...t() when passing them to iOS.
