### PR TITLE
[[ Bug 11844 ]] Don't constrain rect of non-fullscreen stack to the widt...

### DIFF
--- a/docs/notes/bugfix-11844.md
+++ b/docs/notes/bugfix-11844.md
@@ -1,0 +1,1 @@
+# Stack height limited to screen height

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -470,9 +470,6 @@ public:
 	
 	// IM-2013-10-08: [[ FullscreenMode ]] Ensure rect of resizable stacks is within min/max width & height
 	MCRectangle constrainstackrect(const MCRectangle &p_rect);
-	// IM-2013-10-08: [[ FullscreenMode ]] Ensure rect of resizable stacks is within screen bounds
-	// IM-2014-02-13: [[ StackScale ]] Update to work with MCGRectangles. Rename to reflect use of view coordinates.
-	MCGRectangle view_constrainrecttoscreen(const MCGRectangle &p_rect);
 	
     // IM-2012-05-15: [[ Effective Rect ]] get the rect of the window (including decorations)
     MCRectangle getwindowrect() const;

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -2654,26 +2654,6 @@ MCRectangle MCStack::constrainstackrect(const MCRectangle &p_rect)
 	return MCRectangleMake(p_rect.x, p_rect.y, t_width, t_height);
 }
 
-// IM-2013-10-08: [[ FullscreenMode ]] Ensure rect of resizable stacks is within screen bounds
-// IM-2014-02-13: [[ StackScale ]] Update to work with MCGRectangles
-MCGRectangle MCStack::view_constrainrecttoscreen(const MCGRectangle &p_rect)
-{
-	if (!getflag(F_RESIZABLE))
-		return p_rect;
-	
-	MCGFloat t_width, t_height;
-	const MCDisplay *t_display;
-	t_display = MCscreen->getnearestdisplay(MCGRectangleGetIntegerInterior(p_rect));
-	
-	MCRectangle t_screenrect;
-	t_screenrect = MCscreen->fullscreenrect(t_display);
-	
-	t_width = MCMin(p_rect.size.width, (MCGFloat)t_screenrect.width);
-	t_height = MCMin(p_rect.size.height, (MCGFloat)t_screenrect.height);
-	
-	return MCGRectangleMake(p_rect.origin.x, p_rect.origin.y, t_width, t_height);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 MCPoint MCStack::windowtostackloc(const MCPoint &p_windowloc) const

--- a/engine/src/stackview.cpp
+++ b/engine/src/stackview.cpp
@@ -292,7 +292,10 @@ MCGRectangle MCStack::view_constrainstackviewport(const MCGRectangle &p_rect)
 		}
 	}
 	else
-		t_new_rect = view_constrainrecttoscreen(t_stackrect);
+	{
+		// IM-2014-02-28: [[ Bug 11844 ]] Don't constrain stack rect here unless fullscreen
+		t_new_rect = t_stackrect;
+	}
 	
 	return t_new_rect;
 }


### PR DESCRIPTION
...h/height of the screen

Remove unnecessary MCStack::view_constrainrecttoscreen method
