### PR TITLE
[[ Bug 11867 ]] Make sure MCExecPoint::getarray() returns nil if format ...

### DIFF
--- a/docs/notes/bugfix-11867.md
+++ b/docs/notes/bugfix-11867.md
@@ -1,0 +1,1 @@
+# Union and intersect commands can give erroneous results if source array is empty or not an array.

--- a/engine/src/execpt.h
+++ b/engine/src/execpt.h
@@ -119,7 +119,12 @@ public:
 	// Return a pointer to the array value contained in the exec-point
 	MCVariableValue *getarray(void)
 	{
-		return array;
+		// MW-2014-03-12: [[ Bug 11867 ]] If the format is array return the array
+		//   pointer. Otherwise return nil (since array is not necessarily set to
+		//   nil if it changes format).
+		if (format == VF_ARRAY) 
+			return array;
+		return nil;
 	}
 
 	Boolean getdeletearray()


### PR DESCRIPTION
...is not VF_ARRAY.
