### PR TITLE
[[ Bug 11925 ]] Make sure revBrowser is embedded in a 'framework' scaled...

### DIFF
--- a/docs/notes/bugfix-11925.md
+++ b/docs/notes/bugfix-11925.md
@@ -1,0 +1,1 @@
+# revBrowser does not use retina resolution on retina Macs.

--- a/revbrowser/src/osxbrowser.cpp
+++ b/revbrowser/src/osxbrowser.cpp
@@ -644,7 +644,7 @@ void TAltBrowser::init(unsigned int p_window)
 	GetWindowBounds(m_parent, kWindowContentRgn, &t_content_rect);
 	t_content_rect . right = t_content_rect . left + 32;
 	t_content_rect . bottom = t_content_rect . top + 32;
-	CreateNewWindow(kSheetWindowClass, kWindowStandardHandlerAttribute | kWindowCompositingAttribute | kWindowNoShadowAttribute, &t_content_rect, &m_container);
+	CreateNewWindow(kSheetWindowClass, kWindowStandardHandlerAttribute | kWindowCompositingAttribute | kWindowNoShadowAttribute | kWindowFrameworkScaledAttribute, &t_content_rect, &m_container);
 	
 	HIViewRef t_content_view;
 	HIViewFindByID(HIViewGetRoot(m_container), kHIViewWindowContentID, &t_content_view);


### PR DESCRIPTION
... window (so that it renders at Retina resolution).
