### PR TITLE
[[ Bug 11915 ]] Make sure view (fullscreenmode) related parameters are c...

### DIFF
--- a/docs/notes/bugfix-11915.md
+++ b/docs/notes/bugfix-11915.md
@@ -1,0 +1,1 @@
+# Fullscreen mode not preserved when using 'go in window'.

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -560,6 +560,10 @@ Boolean MCStack::takewindow(MCStack *sptr)
 	// MW-2011-01-10: [[ Effects ]] Take the snapshot.
 	takewindowsnapshot(sptr);
 	
+    // MW-2014-03-14: [[ Bug 11915 ]] Make sure we copy the view (fullscreenmode related)
+    //   props to this stack.
+    view_copy(*sptr);
+    
 	mode_takewindow(sptr);
 	
 	if (MCmousestackptr == sptr)


### PR DESCRIPTION
...opied when a stack take's another's window.
