### PR TITLE
[[ Bug 11948 ]] Export snaphot crashes LiveCode when it should return em...

### DIFF
--- a/docs/notes/bugfix-11948.md
+++ b/docs/notes/bugfix-11948.md
@@ -1,0 +1,1 @@
+# Export snaphot crashes LiveCode when it should return empty rect error 

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3732,7 +3732,9 @@ void MCInterfaceExecExportSnapshotOfObjectToFile(MCExecContext& ctxt, MCObject *
 	MCImageBitmap *t_bitmap;
 	t_bitmap = MCInterfaceGetSnapshotOfObjectBitmap(ctxt, p_target, p_region, p_with_effects, p_at_size);
     
-	MCInterfaceExportBitmapToFile(ctxt, t_bitmap, p_format, p_palette, MCInterfaceGetDitherImage(nil), p_filename, p_mask_filename);
+    // AL-2014-03-20: [[ Bug 11948 ]] t_bitmap nil here causes a crash.
+    if (t_bitmap != nil)
+        MCInterfaceExportBitmapToFile(ctxt, t_bitmap, p_format, p_palette, MCInterfaceGetDitherImage(nil), p_filename, p_mask_filename);
 }
 
 MCImage* MCInterfaceExecExportSelectImage(MCExecContext& ctxt)


### PR DESCRIPTION
...pty rect error
