### PR TITLE
[[ Bug 11993 ]] "save stack" corrupt password protected stacks

### DIFF
--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -629,7 +629,7 @@ void MCArraysEvalArrayDecode(MCExecContext& ctxt, MCDataRef p_encoding, MCArrayR
 	t_stream = nil;
 	if (t_success)
 	{
-		t_stream = new MCObjectInputStream(t_stream_handle, MCDataGetLength(p_encoding));
+		t_stream = new MCObjectInputStream(t_stream_handle, MCDataGetLength(p_encoding), false);
 		if (t_stream == nil)
 			t_success = false;
 	}

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -3032,7 +3032,9 @@ IO_stat MCObject::load(IO_handle stream, uint32_t version)
 			// we pass t_length - 1 to extendedload (after adjusting for script). We
 			// then verify we've read a nice NUL byte at the end.
 			MCObjectInputStream *t_stream = nil;
-			/* UNCHECKED */ MCStackSecurityCreateObjectInputStream(stream, t_length, t_stream);
+            // SN-2014-03-27 [[ Bug 11993 ]] 7.0 file format doesn't put the nil byte needed for decryption
+            // We need to provide the information to the ObjectInputStream
+			/* UNCHECKED */ MCStackSecurityCreateObjectInputStream(stream, t_length, version >= 7000, t_stream);
 			if (version < 7000)
 			{
 				t_length -= 1;

--- a/engine/src/objectstream.cpp
+++ b/engine/src/objectstream.cpp
@@ -26,7 +26,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "object.h"
 #include "objectstream.h"
 
-MCObjectInputStream::MCObjectInputStream(IO_handle p_stream, uint32_t p_remaining)
+MCObjectInputStream::MCObjectInputStream(IO_handle p_stream, uint32_t p_remaining, bool p_new_format)
 {
 	m_stream = p_stream;
 	m_buffer = NULL;
@@ -35,6 +35,7 @@ MCObjectInputStream::MCObjectInputStream(IO_handle p_stream, uint32_t p_remainin
 	m_bound = 0;
 	m_remaining = p_remaining;
 	m_mark = 0;
+    m_new_format = p_new_format;
 }
 
 MCObjectInputStream::~MCObjectInputStream(void)
@@ -81,7 +82,7 @@ IO_stat MCObjectInputStream::Skip(uint32_t p_length)
 	// offset by length.
 
 	return t_stat;
-}
+}    
 
 IO_stat MCObjectInputStream::ReadTag(uint32_t& r_flags, uint32_t& r_length, uint32_t& r_header_length)
 {

--- a/engine/src/objectstream.h
+++ b/engine/src/objectstream.h
@@ -22,7 +22,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 class MCObjectInputStream
 {
 public:
-	MCObjectInputStream(IO_handle p_stream, uint32_t p_remaining);
+	MCObjectInputStream(IO_handle p_stream, uint32_t p_remaining, bool p_new_format);
 	virtual ~MCObjectInputStream(void);
 
 	IO_stat ReadTag(uint32_t& r_flags, uint32_t& r_length, uint32_t& r_header_length);
@@ -68,6 +68,10 @@ protected:
 
 	// The amount of data remaining in the input file for this stream
 	uint32_t m_remaining;
+    
+    // SN-2014-03-27 [[ Bug 11993 ]] We need to know whether we are reading from a 7.0 file
+    // in order to add the missing nil byte in the end before decrypting.  
+    bool m_new_format;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/stacksecurity.cpp
+++ b/engine/src/stacksecurity.cpp
@@ -54,9 +54,9 @@ bool MCStackSecurityCopyStack(const MCStack *p_stack, MCStack *&r_copy)
 
 ///////////
 
-bool MCStackSecurityCreateObjectInputStream(IO_handle p_stream, uint32_t p_length, MCObjectInputStream *&r_object_stream)
+bool MCStackSecurityCreateObjectInputStream(IO_handle p_stream, uint32_t p_length, bool p_new_format, MCObjectInputStream *&r_object_stream)
 {
-	r_object_stream = new MCObjectInputStream(p_stream, p_length);
+	r_object_stream = new MCObjectInputStream(p_stream, p_length, p_new_format);
 	return r_object_stream != nil;
 }
 

--- a/engine/src/stacksecurity.h
+++ b/engine/src/stacksecurity.h
@@ -32,7 +32,7 @@ bool MCStackSecurityEncryptString(MCStringRef p_string, MCStringRef &r_enc);
 bool MCStackSecurityCreateStack(MCStack *&r_stack);
 bool MCStackSecurityCopyStack(const MCStack *p_stack, MCStack *&r_copy);
 
-bool MCStackSecurityCreateObjectInputStream(IO_handle p_stream, uint32_t p_length, MCObjectInputStream *&r_object_stream);
+bool MCStackSecurityCreateObjectInputStream(IO_handle p_stream, uint32_t p_length, bool p_new_format, MCObjectInputStream *&r_object_stream);
 bool MCStackSecurityCreateObjectOutputStream(IO_handle p_stream, MCObjectOutputStream *&r_object_stream);
 
 //////////


### PR DESCRIPTION
The issue was coming from the fact a nil byte is needed after an extended save, as the MCX decryption is wrong without it
