### PR TITLE
[[ Bug 11996 ]] NumToChar should return the char corresponding to the nu...

### DIFF
--- a/docs/notes/bugfix-11996.md
+++ b/docs/notes/bugfix-11996.md
@@ -1,0 +1,1 @@
+# numToByte works differently form numToChar in 6.6

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -149,7 +149,9 @@ void MCStringsEvalNumToChar(MCExecContext &ctxt, uinteger_t p_codepoint, MCValue
         r_character = MCValueRetain(*t_data);
     }
     else
-        MCStringsEvalNumToNativeChar(ctxt, p_codepoint, (MCStringRef&)r_character);
+        // AL-2014-03-26: [[ Bug 11996 ]] For backwards compatibility, we must
+        //  use codepoint % 256 here.
+        MCStringsEvalNumToNativeChar(ctxt, p_codepoint % 256, (MCStringRef&)r_character);
 }
 
 void MCStringsEvalNumToNativeChar(MCExecContext& ctxt, uinteger_t p_codepoint, MCStringRef& r_character)


### PR DESCRIPTION
...m mod 256, for backwards compatibility
