### PR TITLE
[[ Bug 12010 ]] Fix Windows engine hang due to resource leak - unrelease...

### DIFF
--- a/docs/notes/bugfix-12010.md
+++ b/docs/notes/bugfix-12010.md
@@ -1,0 +1,1 @@
+# Windows engine hangs after multiple stack redraws.

--- a/engine/src/w32stack.cpp
+++ b/engine/src/w32stack.cpp
@@ -1193,6 +1193,9 @@ void MCStack::view_platform_updatewindow(MCRegionRef p_region)
 			composite();
 		}
 	}
+
+	// IM-2014-03-27: [[ Bug 12010 ]] Free the created surface region once the update is done.
+	MCRegionDestroy(t_surface_region);
 }
 
 void MCStack::view_platform_updatewindowwithcallback(MCRegionRef p_region, MCStackUpdateCallback p_callback, void *p_context)


### PR DESCRIPTION
...d MCRegionRefs in window update code
