### PR TITLE
[[ Bug 12042 ]] Object chunk evaluation should include new chunk types

### DIFF
--- a/docs/notes/bugfix-12042.md
+++ b/docs/notes/bugfix-12042.md
@@ -1,0 +1,1 @@
+# New chunk types (paragraph, trueWord, sentence) don't work with field property setting/getting

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -4971,9 +4971,11 @@ bool MCChunk::evalobjectchunk(MCExecContext &ctxt, bool p_whole_chunk, bool p_fo
         && function != F_DRAG_SOURCE && function != F_DRAG_DESTINATION)
         t_function = true;
 
-    if (!t_function && cline == nil && item == nil
-        && token == nil && word == nil && character == nil
-        && codepoint == nil && codeunit == nil && byte == nil)
+    // AL-2014-03-27: [[ Bug 12042 ]] Object chunk evaluation should include
+    //  paragraph, sentence, and trueword chunks.
+    if (!t_function && cline == nil && paragraph == nil && sentence == nil
+        && item == nil && word == nil && trueword == nil && token == nil
+        && character == nil && codepoint == nil && codeunit == nil && byte == nil)
     {
         MCMarkedText t_mark;
         t_mark . finish = INDEX_MAX;

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -3172,11 +3172,14 @@ void MCExecTypeRelease(MCExecValue &self)
 
 void MCExecResolveCharsOfField(MCField *p_field, uint32_t p_part, int32_t& x_start, int32_t& x_finish, uint32_t p_start, uint32_t p_count)
 {
+    x_start = p_start;
+    x_finish = p_start + p_count;
+    /*
     findex_t t_start = x_start;
     findex_t t_finish = x_finish;
     p_field -> resolvechars(p_part, t_start, t_finish, p_start, p_count);
     x_start = t_start;
-    x_finish = t_finish;
+    x_finish = t_finish; */
 }
 
 void MCExecParseSet(MCExecContext& ctxt, MCExecSetTypeInfo *p_info, MCExecValue p_value, intset_t& r_value)


### PR DESCRIPTION
Note this doesn't quite work at the moment due to the fact that the call to resolvechars expects to receive grapheme indices but chunk marking returns codeunit indices. I suspect that MCExecResolveCharsOfField can be safely made a no-op, but it needs a little testing lest the hangs of yesteryear resurface.
