### PR TITLE
[[Bugfix 12056]] IDE no longer crashes when clicking on a cell of a tabl...

### DIFF
--- a/docs/notes/bugfix-12056.md
+++ b/docs/notes/bugfix-12056.md
@@ -1,0 +1,1 @@
+# Clicking on a cell of a table field causes the IDE to crash

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -354,7 +354,9 @@ void MCCard::kunfocus()
 		oldkfocused = kfocused;
 		kfocused = NULL;
 		oldkfocused->getref()->kunfocus();
-		MCscreen -> controllostfocus(getstack(), oldkfocused -> getid());
+        // PM-2014-04-03: [[Bug 12056]] Make sure oldkfocused is not NULL, or else IDE crashes
+        if (oldkfocused != NULL)
+            MCscreen -> controllostfocus(getstack(), oldkfocused -> getid());
 	}
 	else
 	{


### PR DESCRIPTION
...e field
