### PR TITLE
[[ Bug 12085 ]] Use Cocoa API when getting bounds for in OSX window snap...

### DIFF
--- a/docs/notes/bugfix-12085.md
+++ b/docs/notes/bugfix-12085.md
@@ -1,0 +1,1 @@
+# "export snapshot of window ..." locks up on OSX


### PR DESCRIPTION
...shot.
