### PR TITLE
[[Bugfix 12116]] No longer NullPointerException when app is launched and...

### DIFF
--- a/docs/notes/bugfix-12116.md
+++ b/docs/notes/bugfix-12116.md
@@ -1,0 +1,1 @@
+# NullPointerException on device logcat when app was launched and closed if in-app purchasing box is not ticked

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -2038,6 +2038,9 @@ public class Engine extends View implements EngineApi
             return;
         
         mBillingProvider = mBillingModule.getBillingProvider();
+        // PM-2014-04-03: [[Bug 12116]] Avoid a NullPointerException is in-app purchasing is not used
+        if (mBillingProvider == null)
+            return;
         mBillingProvider.setActivity(getActivity());
         mPurchaseObserver = new EnginePurchaseObserver((Activity)getContext());
         mBillingProvider.setPurchaseObserver(mPurchaseObserver);
@@ -2697,7 +2700,9 @@ public class Engine extends View implements EngineApi
 	public void onDestroy()
 	{
 		doDestroy();
-        mBillingProvider.onDestroy();
+        // PM-2014-04-03: [[Bug 12116]] Avoid a NullPointerException is in-app purchasing is not used
+        if (mBillingProvider != null)
+            mBillingProvider.onDestroy();
         s_engine_instance = null;
 	}
 


### PR DESCRIPTION
... closed if in-app purchasing is not used
