### PR TITLE
[[ Bug 12143 ]] The mousechunk end index is one larger than it ought to ...

### DIFF
--- a/docs/notes/bugfix-12143.md
+++ b/docs/notes/bugfix-12143.md
@@ -1,0 +1,1 @@
+# The mousechunk end index is one larger than it ought to be

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -4594,7 +4594,8 @@ void MCParagraph::getclickindex(int2 x, int2 y,
 		ei = findwordbreakafter(bptr, ei);
 
 		bptr = indextoblock(ei, False);
-		bptr -> AdvanceIndex(ei);
+		// AL-2014-04-07: [[ Bug 12143 ]] Advancing the index here causes the mouseChunk to report incorrect end index
+        // bptr -> AdvanceIndex(ei);
 		
 		return;
 	}


### PR DESCRIPTION
...be
