### PR TITLE
[[ Bug 12160 ]] Put after/before on an uninitialised, by-reference param...

### DIFF
--- a/docs/notes/bugfix-12160.md
+++ b/docs/notes/bugfix-12160.md
@@ -1,0 +1,1 @@
+# Put after/before on an uninitialised, by-reference parameter inserts the variable's name in it

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -123,9 +123,15 @@ bool MCVariable::isuql(void) const
 }
 
 void MCVariable::clearuql(void)
-{
+{    
 	if (!is_uql)
 		return;
+    
+    // SN-2014-04-09 [[ Bug 12160 ]] Put after/before on an uninitialised, by-reference parameter inserts the variable's name in it
+    // The content of a UQL value was not cleared when needed
+    if (value . type == kMCExecValueTypeNameRef && MCNameIsEqualTo(value . nameref_value, name))
+        clear();
+    
 	is_uql = false;
 }
 


### PR DESCRIPTION
...eter inserts the variable's name in it
