### PR TITLE
[[ Bug 12170 ]] Make sure BOTH(0,"") is treated as empty in MCVariableVa...

### DIFF
--- a/docs/notes/bugfix-12170.md
+++ b/docs/notes/bugfix-12170.md
@@ -1,0 +1,1 @@
+# Non-existant command line parameter variables ($<n>) behave strangely with split.

--- a/engine/src/variable_impl.h
+++ b/engine/src/variable_impl.h
@@ -165,11 +165,12 @@ inline bool MCVariableValue::is_undefined(void) const
 	return is_clear();
 }
 
+// MW-2014-04-10: [[ Bug 12170 ]] A 'both' var with empty string is empty.
 inline bool MCVariableValue::is_empty(void) const
 {
 	Value_format t_type;
 	t_type = get_type();
-	return t_type == VF_UNDEFINED || (t_type == VF_STRING && strnum . svalue . length == 0);
+	return t_type == VF_UNDEFINED || ((t_type == VF_STRING || t_type == VF_BOTH) && strnum . svalue . length == 0);
 }
 
 inline bool MCVariableValue::is_string(void) const


### PR DESCRIPTION
...lue::is_empty().
