### PR TITLE
[[Bugfix 12153]] Prevent crash when setting the cursor to an image that ...

### DIFF
--- a/engine/src/cgimageutil.cpp
+++ b/engine/src/cgimageutil.cpp
@@ -183,6 +183,8 @@ bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, bool p_copy, 
 
 bool MCImageBitmapToCGImage(MCImageBitmap *p_bitmap, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image)
 {
+    if (p_bitmap == nil)
+        return false;
 	bool t_mask;
 	t_mask = MCImageBitmapHasTransparency(p_bitmap);
 	

--- a/engine/src/imagebitmap.cpp
+++ b/engine/src/imagebitmap.cpp
@@ -92,7 +92,7 @@ void MCImageFreeBitmap(MCImageBitmap *p_bitmap)
 
 bool MCImageCopyBitmap(MCImageBitmap *p_bitmap, MCImageBitmap *&r_copy)
 {
-	if (!MCImageBitmapCreate(p_bitmap->width, p_bitmap->height, r_copy))
+	if (p_bitmap == nil || !MCImageBitmapCreate(p_bitmap->width, p_bitmap->height, r_copy))
 		return false;
 
 	r_copy->has_alpha = p_bitmap->has_alpha;
@@ -289,6 +289,8 @@ void MCImageBitmapCopyRegionFromBuffer(MCImageBitmap *p_bitmap, MCRectangle &p_r
 
 void MCImageBitmapCheckTransparency(MCImageBitmap *p_bitmap)
 {
+    if (p_bitmap == nil)
+        return;
 	uint8_t *t_row_ptr = (uint8_t*)p_bitmap->data;
 	p_bitmap->has_transparency = false;
 	p_bitmap->has_alpha = false;
@@ -316,11 +318,15 @@ void MCImageBitmapCheckTransparency(MCImageBitmap *p_bitmap)
 
 bool MCImageBitmapHasTransparency(MCImageBitmap *p_bitmap)
 {
+    if (p_bitmap == nil)
+        return false;
 	return p_bitmap->has_transparency;
 }
 
 bool MCImageBitmapHasTransparency(MCImageBitmap *p_bitmap, bool &r_has_alpha)
 {
+    if (p_bitmap == nil)
+        return false;
 	r_has_alpha = p_bitmap->has_alpha;
 	return p_bitmap->has_transparency;
 }

--- a/engine/src/osxcursor.mm
+++ b/engine/src/osxcursor.mm
@@ -151,6 +151,8 @@ void MCScreenDC::resetcursors(void)
 
 MCCursorRef MCScreenDC::createcursor(MCImageBitmap *p_image, int2 p_hotspot_x, int2 p_hotspot_y)
 {
+    if (p_image == nil)
+        return nil;
 	CGImageRef t_cg_image;
 	/* UNCHECKED */ MCImageBitmapToCGImage(p_image, false, false, t_cg_image);
 	


### PR DESCRIPTION
...references an image file that is not present
