### PR TITLE
[[Bugfix 12105]] Livecode server no longer crashes if you call paramCoun...

### DIFF
--- a/docs/notes/bugfix-12105.md
+++ b/docs/notes/bugfix-12105.md
@@ -1,0 +1,1 @@
+# Livecode server crashed if you call paramCount() 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2452,6 +2452,10 @@ enum Exec_errors
 	// MM-2014-02-12: [[ SecureSocket ]]
 	// {EE-0805} secure: error in socket expression
 	EE_SECURE_BADNAME,
+    
+    // PM-2014-04-15: [[Bug 12105]]
+    // {EE-0806} paramCount: could not find handler
+    EE_PARAMCOUNT_NOHANDLER,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -4122,7 +4122,10 @@ Exec_stat MCParamCount::eval(MCExecPoint &ep)
 	uint2 count;
     // PM-2014-04-14: [[Bug 12105]] Do this check to prevent crash in LC server
     if (h == NULL)
+    {
+        MCeerror->add(EE_PARAMCOUNT_NOHANDLER, line, pos);
         return ES_ERROR;
+    }
 	h->getnparams(count);
 	ep.setnvalue(count);
 	return ES_NORMAL;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -4120,6 +4120,9 @@ Exec_stat MCParamCount::eval(MCExecPoint &ep)
 {
 #ifdef /* MCParamCount */ LEGACY_EXEC
 	uint2 count;
+    // PM-2014-04-14: [[Bug 12105]] Do this check to prevent crash in LC server
+    if (h == NULL)
+        return ES_ERROR;
 	h->getnparams(count);
 	ep.setnvalue(count);
 	return ES_NORMAL;


### PR DESCRIPTION
...t()
