### PR TITLE
[[ Bug 12200 ]] If a file has file type 'rhaplcmt' then mark as a direct...

### DIFF
--- a/docs/notes/bugfix-12200.md
+++ b/docs/notes/bugfix-12200.md
@@ -1,0 +1,3 @@
+# Some filesystem entries in the root of a volume on Mac report as files when they are really folders.
+The 'net', 'home' and 'dev' folders do not report as folders in when using 'the folders' - they appear as files instead.
+


### PR DESCRIPTION
...ory. (This occurs for /home /net /dev on Mac).
