### PR TITLE
[[ Bug 12044 ]] Fix incomplete rendering of opaque group background when...

### DIFF
--- a/docs/notes/bugfix-12044.md
+++ b/docs/notes/bugfix-12044.md
@@ -1,0 +1,1 @@
+# Opaque groups do not completely draw their backgrounds when acceleratedRendering is enabled

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2520,7 +2520,11 @@ void MCGroup::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 				!MCcurtheme -> drawmetalbackground(dc, dirty, rect, this))
 			{
 				setforeground(dc, DI_BACK, False);
-				dc->fillrect(rect);
+				// IM-2014-04-16: [[ Bug 12044 ]] The sprite background should fill the whole redraw area. 
+				if (!p_sprite)
+					dc->fillrect(rect);
+				else
+					dc->fillrect(p_dirty);
 			}
 
 			// MW-2009-06-14: Non-themed, opaque backgrounds are (unsurprisingly!) opaque.

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -251,7 +251,11 @@ MCRectangle MCControl::layer_getcontentrect(void)
 {
 	// As getcontentrect is only called if 'isscrolling' is true, this unchecked
 	// cast is safe.
-	return static_cast<MCGroup *>(this) -> getminrect();
+	MCRectangle t_content_rect = static_cast<MCGroup *>(this) -> getminrect();
+	// IM-2014-04-16: [[ Bug 12044 ]] Include rect when computing the coverage of opaque groups
+	if (flags & F_OPAQUE)
+		t_content_rect = MCU_union_rect(t_content_rect, rect);
+	return t_content_rect;
 }
 
 void MCControl::layer_redrawall(void)


### PR DESCRIPTION
... acceleratedRendering is enabled
