### PR TITLE
[[ Bug 11860 ]] MCS_random_bytes() function wrongly indicates failure on...

### DIFF
--- a/docs/notes/bugfix-11860.md
+++ b/docs/notes/bugfix-11860.md
@@ -1,0 +1,1 @@
+# uuid and randomBytes functions don't work on iOS when Encryption support is not included

--- a/engine/src/mbliphone.mm
+++ b/engine/src/mbliphone.mm
@@ -936,7 +936,8 @@ MCSystemInterface *MCMobileCreateSystem(void)
 // MW-2013-05-21: [[ RandomBytes ]] System function for random bytes on iOS.
 bool MCS_random_bytes(size_t p_count, void* p_buffer)
 {
-	return SecRandomCopyBytes(kSecRandomDefault, p_count, (uint8_t *)p_buffer) != 0;
+	// IM-2014-04-16: [[ Bug 11860 ]] SecRandomCopyBytes returns 0 on success
+	return SecRandomCopyBytes(kSecRandomDefault, p_count, (uint8_t *)p_buffer) == 0;
 }
 
 //////////////////


### PR DESCRIPTION
... iOS
