### PR TITLE
[[ Bug 12230 ]] Make sure LockSystemContext returns a result, otherwise ...

### DIFF
--- a/docs/notes/bugfix-12230.md
+++ b/docs/notes/bugfix-12230.md
@@ -1,0 +1,1 @@
+# Accelerated rendering mode doesn't work correctly on Mac if using coregraphics mode.

--- a/engine/src/platform-surface.cpp
+++ b/engine/src/platform-surface.cpp
@@ -57,7 +57,8 @@ void MCPlatformSurfaceUnlockPixels(MCPlatformSurfaceRef p_surface)
 
 bool MCPlatformSurfaceLockSystemContext(MCPlatformSurfaceRef p_surface, void*& r_context)
 {
-	p_surface -> LockSystemContext(r_context);
+    // MW-2014-04-18: [[ Bug 12230 ]] Make sure we return the result.
+	return p_surface -> LockSystemContext(r_context);
 }
 
 void MCPlatformSurfaceUnlockSystemContext(MCPlatformSurfaceRef p_surface)


### PR DESCRIPTION
...CoreGraphics tilecache doesn't work.
