### PR TITLE
[[ Bug 12227 ]] Use same coordinate space when checking mouse location i...

### DIFF
--- a/docs/notes/bugfix-12227.md
+++ b/docs/notes/bugfix-12227.md
@@ -1,0 +1,1 @@
+# When Windows screen display is set to 125% popups sometimes break

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -1019,9 +1019,13 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 	case WM_APP:
 		if (MCmousestackptr != NULL && MCdispatcher->getmenu() == NULL)
 		{
+			// IM-2014-04-17: [[ Bug 12227 ]] Convert logical stack rect to screen coords when testing for mouse intersection
+			MCRectangle t_rect;
+			t_rect = pms->logicaltoscreenrect(MCmousestackptr->getrect());
+
 			POINT p;
 			if (!GetCursorPos(&p)
-			        || !MCU_point_in_rect(MCmousestackptr->getrect(),
+			        || !MCU_point_in_rect(t_rect,
 			                              (int2)p.x, (int2)p.y))
 			{
 				if (MCmousestackptr != MCtracestackptr)


### PR DESCRIPTION
...s still within stack window rect
