### PR TITLE
[[ Bug 12264 ]] Make sure we check correct setting of WD_MAXIMIZE decora...

### DIFF
--- a/docs/notes/bugfix-12264.md
+++ b/docs/notes/bugfix-12264.md
@@ -1,0 +1,1 @@
+# resizable and maximize decorations not honoured correctly on Mac.

--- a/engine/src/desktop-stack.cpp
+++ b/engine/src/desktop-stack.cpp
@@ -112,8 +112,9 @@ void MCStack::realize(void)
 			t_has_titlebox = (decorations & WD_TITLE) != 0;
 			t_has_closebox = (decorations & WD_CLOSE) != 0;
 			t_has_collapsebox = (decorations & WD_MINIMIZE) != 0;
-			t_has_zoombox = (decorations & WD_MAXIMIZE) == 0;
-			t_has_sizebox = getflag(F_RESIZABLE);
+            
+            // MW-2014-04-22: [[ Bug 12264 ]] Wrong test for maximize (was == 0!).
+			t_has_zoombox = (decorations & WD_MAXIMIZE) != 0;
 		}
 		else
 		{
@@ -137,6 +138,10 @@ void MCStack::realize(void)
 				t_has_titlebox = true;
 		}
 		
+        // MW-2014-04-22: [[ Bug 12264 ]] Make sure we use the resizable property in all cases, to be
+        //   switched off for certain window types.
+        t_has_sizebox = getflag(F_RESIZABLE);
+        
 		if (getflag(F_DECORATIONS) && ((decorations & (WD_TITLE | WD_MENU | WD_CLOSE | WD_MINIMIZE | WD_MAXIMIZE)) == 0))
 			t_has_sizebox = false;
 		


### PR DESCRIPTION
...tion, and use F_RESIZABLE flag at appropriate place when window created.
