### PR TITLE
[[ Bug 12255 ]] Don't handle the 'system' mouseEntered message, instead ...

### DIFF
--- a/docs/notes/bugfix-12255.md
+++ b/docs/notes/bugfix-12255.md
@@ -1,0 +1,1 @@
+# dragDrop sometimes doesn't work when dropping from other applications (on Mac).

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -602,7 +602,10 @@ static CGEventRef mouse_event_callback(CGEventTapProxy p_proxy, CGEventType p_ty
 
 - (void)mouseEntered: (NSEvent *)event
 {
-	[self handleMouseMove: event];
+    // MW-2014-04-22: [[ Bug 12255 ]] mouseEntered can get sent before dragEntered and when it is
+    //   it isn't possible to tell if a dragging operation is going to start. Thus we don't handle
+    //   this message, and rely on the first mouseMove instead.
+	//[self handleMouseMove: event];
 }
 
 - (void)mouseExited: (NSEvent *)event


### PR DESCRIPTION
...rely on mouseMove (mouseEntered can get sent before dragEntered).
