### PR TITLE
[[ Bug 12286 ]] Make sure we use the frame rect to work out zoom locatio...

### DIFF
--- a/docs/notes/bugfix-12286.md
+++ b/docs/notes/bugfix-12286.md
@@ -1,0 +1,1 @@
+# Maximizing a window where only the title-bar is on-screen causes a crash on Mac.

--- a/engine/src/osxdcmac.cpp
+++ b/engine/src/osxdcmac.cpp
@@ -250,6 +250,12 @@ static void dozoomwindow(WindowPtr win, short zoomInOrOut)
 		GetRegionBounds(r, &tbRect);
 		DisposeRgn(r);
 		int2 wTitleHeight = tbRect.bottom - tbRect.top;
+        
+        // MW-2014-04-24: [[ Bug 12286 ]] Use the combined content and titlebar rect
+        //   to make sure there will be some overlap (if the user can click the zoom
+        //   box, then it must be visible!).
+        UnionRect(&windRect, &tbRect, &windRect);
+        
 		/*-------------------------------------------------------------------------*/
 		long  sectArea = 0;
 		long greatestArea = 0;


### PR DESCRIPTION
...n, rather than the content rect.
