### PR TITLE
[[ Bug 12210 ]] Update revBrowser on Windows to use a different snapshot...

### DIFF
--- a/docs/notes/bugfix-12210.md
+++ b/docs/notes/bugfix-12210.md
@@ -1,0 +1,1 @@
+# revBrowserSnapshot not working on Windows with IE9+

--- a/revbrowser/src/w32browser.cpp
+++ b/revbrowser/src/w32browser.cpp
@@ -1315,7 +1315,9 @@ bool CWebBrowser::GetImage(void*& r_data, int& r_length)
 		desthdc = CreateCompatibleDC(desktophdc);
 		ReleaseDC(NULL, desktophdc);
 		HBITMAP odbm = (HBITMAP)SelectObject(desthdc, browserimage->bm);
-		BOOL res = Draw(desthdc);
+		// MW-2014-04-30: [[ Bug 12210 ]] Use IViewObject to render rather than DrawToDC as the latter
+		//   has been deprecated in IE9+.
+		BOOL res = Draw(twidth, theight, desthdc);
 		SelectObject(desthdc, odbm);
 		DeleteDC(desthdc);
 		if (res)


### PR DESCRIPTION
... method from before (old one doesn't work in IE9+).
