### PR TITLE
[[ Bug 12348 ]] Make sure we initialized the 'm_use_text_input' field of...

### DIFF
--- a/docs/notes/bugfix-12348.md
+++ b/docs/notes/bugfix-12348.md
@@ -1,0 +1,1 @@
+# Scrollbars don't get keyboard input when focused if no field is on the card on Mac.

--- a/engine/src/platform-window.cpp
+++ b/engine/src/platform-window.cpp
@@ -50,6 +50,9 @@ MCPlatformWindow::MCPlatformWindow(void)
 	m_use_live_resizing = false;
     m_hides_on_suspend = false;
 	
+    // MW-2014-05-02: [[ Bug 12348 ]] Make sure we initialize this value appropriately.
+    m_use_text_input = false;
+    
 	/* UNCHECKED */ MCRegionCreate(m_dirty_region);
 	m_is_visible = false;
 	m_is_focused = false;


### PR DESCRIPTION
... platform windows.
