### PR TITLE
[[ Bug 12265 ]] Rounded rects are drawn incorrectly when using the image...

### DIFF
--- a/docs/notes/bugfix-12265.md
+++ b/docs/notes/bugfix-12265.md
@@ -1,0 +1,1 @@
+# Rounded rects are drawn incorrectly when using the image editing tools with a linesize 1

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -2122,7 +2122,7 @@ static bool MCGContextSetupStrokePaint(MCGContextRef self, SkPaint &r_paint)
 		
 		// MM-2014-04-08: [[ Bug 11370 ]] Fudge 1 pixel line widths. This prevents Skia from treating them as hairlines,
 		//  which was causing inconstancies with anti-aliasing.
-		if (self -> state -> stroke_attr . width == 1.0)
+		if (self -> state -> stroke_attr . width == 1.0 && self -> state -> should_antialias)
 			r_paint . setStrokeWidth(SkFloatToScalar(1.01f));
 		else
 			r_paint . setStrokeWidth(MCGFloatToSkScalar(self -> state -> stroke_attr . width));


### PR DESCRIPTION
... editing tools with a linesize 1.
