### PR TITLE
[[ Bug 12364 ]] Prevent crash when runloop action is removed by its own ...

### DIFF
--- a/docs/notes/bugfix-12364.md
+++ b/docs/notes/bugfix-12364.md
@@ -1,0 +1,1 @@
+# Crash when calling revBrowserClose on revCEFBrowser

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -873,8 +873,12 @@ void MCUIDC::DoRunloopActions(void)
 
 	while (t_action != nil)
 	{
+		// IM-2014-05-06: [[ Bug 12364 ]] Guard against runloop action deletion within callback
+		MCRunloopAction *t_next;
+		t_next = t_action->next;
+
 		t_action->callback(t_action->context);
-		t_action = t_action->next;
+		t_action = t_next;
 	}
 }
 


### PR DESCRIPTION
...callback
