### PR TITLE
[[ Bug 12365 ]] After "putting" return into a Field, a visible residue i...

### DIFF
--- a/docs/notes/bugfix-12365.md
+++ b/docs/notes/bugfix-12365.md
@@ -1,0 +1,1 @@
+# After "putting" return into a Field, a visible residue is left from the cursor

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -639,6 +639,9 @@ Exec_stat MCField::settextindex(uint4 parid, int4 si, int4 ei, const MCString &s
 	{
 		clearfound();
 		unselect(False, True);
+        // SN-2014-05-12 [[ Bug 12365 ]]
+        // There might be several paragraph to be inserted, the cursor must be removed
+        removecursor();
 		focusedparagraph->setselectionindex(MAXUINT2, MAXUINT2, False, False);
 	}
 	int4 oldsi = si;
@@ -779,6 +782,10 @@ Exec_stat MCField::settextindex(uint4 parid, int4 si, int4 ei, const MCString &s
 		layer_redrawrect(drect);
 		
 		focusedy = paragraphtoy(focusedparagraph);
+        
+        // SN-2014-05-12 [[ Bug 12365 ]]
+        // Redraw the cursor after the update
+        replacecursor(True, True);
 	}
 
 	return ES_NORMAL;


### PR DESCRIPTION
...s left from the cursor
