### PR TITLE
[[ Bug 12458 ]] Fix crash when reading past the end of a data stream whe...

### DIFF
--- a/docs/notes/bugfix-12458.md
+++ b/docs/notes/bugfix-12458.md
@@ -1,0 +1,1 @@
+# Crash when reading invalid image data

--- a/engine/src/osxfiles.cpp
+++ b/engine/src/osxfiles.cpp
@@ -374,7 +374,8 @@ IO_stat MCS_read(void *ptr, uint4 size, uint4 &n, IO_handle stream)
 			nread = size * n;
 			if (nread > stream->len - (stream->ioptr - stream->buffer))
 			{
-				n = stream->len - (stream->ioptr - stream->buffer) / size;
+				// IM-2014-05-21: [[ Bug 12458 ]] Fix incorrect calculation of remaining blocks
+				n = (stream->len - (stream->ioptr - stream->buffer)) / size;
 				nread = size * n;
 				stat = IO_EOF;
 			}


### PR DESCRIPTION
...n size larger than 1 byte
