### PR TITLE
[[ Bug 12459 ]] Setting graphic effects to non-array value should work t...

### DIFF
--- a/docs/notes/bugfix-12459.md
+++ b/docs/notes/bugfix-12459.md
@@ -1,0 +1,1 @@
+# Setting any graphic effects to "none" crashes LC 7 dp3 

--- a/engine/src/bitmapeffect.cpp
+++ b/engine/src/bitmapeffect.cpp
@@ -954,7 +954,11 @@ bool MCBitmapEffectsSetProperty(MCExecContext& ctxt, MCBitmapEffectsRef& self, M
     bool t_is_array;
     t_is_array = MCNameIsEmpty(p_index);
 
-    if (t_is_array && p_value . type == kMCExecValueTypeValueRef && MCValueIsEmpty(p_value . valueref_value))
+    // AL-2014-05-21: [[ Bug 12459 ]] Ensure setting bitmap effect to anything
+    //  that isn't an array does the same as setting it to 'empty'.
+    if (p_value . type == kMCExecValueTypeValueRef &&
+        (MCValueIsEmpty(p_value . valueref_value) ||
+         (MCValueGetTypeCode(p_value . valueref_value) != kMCValueTypeCodeArray)))
     {
         if (self == nil || (self -> mask & (1 << t_type)) == 0)
         {

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -953,7 +953,11 @@ bool MCGradientFillSetProperties(MCExecContext& ctxt, MCGradientFill*& x_gradien
     
 	uint4 tablesize = ELEMENTS(gradientprops);
 
-    if (p_value . type == kMCExecValueTypeValueRef && MCValueIsEmpty(p_value . valueref_value))
+    // AL-2014-05-21: [[ Bug 12459 ]] Ensure setting gradient property to anything
+    //  that isn't an array does the same as setting it to 'empty'.
+    if (p_value . type == kMCExecValueTypeValueRef &&
+        (MCValueIsEmpty(p_value . valueref_value) ||
+         (MCValueGetTypeCode(p_value . valueref_value) != kMCValueTypeCodeArray)))
     {
         delete t_gradient;
         t_gradient = nil;


### PR DESCRIPTION
...he same as setting them to 'empty'
