### PR TITLE
[[ Bug 12443 ]] import snapshot crashes livecode when empty rect is sele...

### DIFF
--- a/docs/notes/bugfix-12443.md
+++ b/docs/notes/bugfix-12443.md
@@ -1,0 +1,1 @@
+# import snapshot crashes LiveCode

--- a/engine/src/osxsnapshot.mm
+++ b/engine/src/osxsnapshot.mm
@@ -292,6 +292,16 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle& p_rect, uint32_t p_window, cons
 		
 		// Compute the selected rectangle.
 		t_screen_rect = mcrect_from_points(s_snapshot_start_point, s_snapshot_end_point);
+        
+        // AL-2014-05-23: [[ Bug 12443 ]] Import snapshot crashes when no rect is selected.
+        //  6.1 behaviour was to default to snapshot of the whole screen.
+        if (t_screen_rect . width == 0 || t_screen_rect . height == 0)
+        {
+            const MCDisplay *t_displays;
+            MCscreen -> getdisplays(t_displays, false);
+            
+            t_screen_rect = t_displays[0] . viewport;
+        }
 	}
 	else if (p_window == 0)
 	{


### PR DESCRIPTION
...cted with crosshair
