### PR TITLE
[[ Bug 11928 ]] Fix inclusion of CR when doing 'delete the selectedChunk...

### DIFF
--- a/docs/notes/bugfix-11928.md
+++ b/docs/notes/bugfix-11928.md
@@ -1,0 +1,7 @@
+# Inconsistencies in behavior when doing 'delete the selectedChunk'.
+The following should all operate the same way after selecting a line in a field by doing 'triple-click', or just selected the whole line without the paragraph break:
+* pressing backspace
+* executing 'delete the selectedChunk'
+* executing 'get the selectedChunk; delete it'
+Previously, 'delete the selectedChunk' would cause paragraph styles not to be set correctly on the resulting paragraph; or the paragraph break to be included when it should not be - this is no longer the case.
+Previously, 'get / delete it' would only work correctly the first time the command was executed - this is no longer the case.

--- a/engine/src/chunk.h
+++ b/engine/src/chunk.h
@@ -54,7 +54,11 @@ class MCChunk : public MCExpression
 	MCObject *destobj;
 	Dest_type desttype;
 	Functions function;
-	Boolean marked;
+	Boolean marked : 1;
+    
+    // MW-2014-05-28: [[ Bug 11928 ]] This is set to true after 'destvar' has been evaluated
+    //   as a chunk. This stops stale chunk information being used in MCChunk::del.
+    bool m_transient_text_chunk : 1;
 public:
 	MCChunk *next;
 	MCChunk(Boolean isdest);

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1861,7 +1861,7 @@ void MCDispatch::dodrop(bool p_source)
 		t_field = static_cast<MCField *>(MCdragsource);
 
 		int4 t_from_start_index, t_from_end_index;
-		t_field -> selectedmark(False, t_from_start_index, t_from_end_index, False, False);
+		t_field -> selectedmark(False, t_from_start_index, t_from_end_index, False);
 
 		// We are dropping in the target selection - so just send the messages and do nothing
 		if (t_start_index >= t_from_start_index && t_start_index < t_from_end_index)
@@ -1920,7 +1920,7 @@ void MCDispatch::dodrop(bool p_source)
 	int4 t_src_start, t_src_end;
 	t_src_start = t_src_end = 0;
 	if (t_auto_source)
-		static_cast<MCField *>(MCdragsource) -> selectedmark(False, t_src_start, t_src_end, False, False);
+		static_cast<MCField *>(MCdragsource) -> selectedmark(False, t_src_start, t_src_end, False);
 
 	bool t_auto_drop;
 	t_auto_drop = MCdragdest != NULL && MCdragdest -> message(MCM_drag_drop) != ES_NORMAL;

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -2103,7 +2103,7 @@ void MCField::undo(Ustruct *us)
 			if (us->ud.text.data != NULL)
 			{
 				insertparagraph(us->ud.text.data);
-				selectedmark(False, si, ei, False, False);
+				selectedmark(False, si, ei, False);
 				seltext(us->ud.text.index, si, True);
 				us->type = UT_REPLACE_TEXT;
 			}

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -420,8 +420,9 @@ public:
 	void selectedline(MCExecPoint &ep);
 	void selectedloc(MCExecPoint &ep);
 	void selectedtext(MCExecPoint &ep);
-	Boolean selectedmark(Boolean wholeline, int4 &si, int4 &ei,
-	                     Boolean force, Boolean inc_cr);
+    // MW-2014-05-28: [[ Bug 11928 ]] The 'inc_cr' parameter is unnecessary - it is determined
+    //   by 'wholeline'.
+	Boolean selectedmark(Boolean wholeline, int4 &si, int4 &ei, Boolean force);
 
 	void returnchunk(MCExecPoint &ep, int4 si, int4 ei);
 	void returnline(MCExecPoint &ep, int4 si, int4 ei);

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -326,7 +326,7 @@ void MCField::resetparagraphs()
 		//      in the future
 		if (flags & F_LIST_BEHAVIOR)
 			hilitedlines(oldhilitedlines);
-		selectedmark(False, si, ei, True, False);
+		selectedmark(False, si, ei, True);
 		if (flags & F_LIST_BEHAVIOR)
 			sethilitedlines(MCnullmcstring);
 		unselect(False, True);
@@ -827,7 +827,7 @@ void MCField::computedrag()
 {
 	int4 ti, si, ei;
 	locmark(False, False, False, False, True, ti, ei);
-	selectedmark(False, si, ei, False, False);
+	selectedmark(False, si, ei, False);
 	uint2 c = ti >= si && ti < ei ? PI_ARROW : PI_IBEAM;
 
 	getstack()->setcursor(MCcursors[c], False);
@@ -1208,7 +1208,7 @@ void MCField::setfocus(int2 x, int2 y)
 	if (!(flags & F_LOCK_TEXT))
 	{
 		int4 si,ei;
-		selectedmark(False, si, ei, False, False);
+		selectedmark(False, si, ei, False);
 		if (composing)
 			if (!(si >= composeoffset && ei <= composeoffset + composelength))
 				stopcomposition(False, True);
@@ -1331,7 +1331,7 @@ void MCField::startselection(int2 x, int2 y, Boolean words)
 					int4 ti, si, ei;
 					if (locmark(False, False, False, True, True, ti, ei))
 					{
-						selectedmark(False, si, ei, False, False);
+						selectedmark(False, si, ei, False);
 						if (ti >= si && ti < ei && si != ei)
 						{
 							// Here we mark the fact a mouse-down has occured in
@@ -1425,7 +1425,7 @@ void MCField::endselection()
 		{
 			int4 ti, si, ei;
 			locmark(False, False, False, False, True, ti, ei);
-			selectedmark(False, si, ei, False, False);
+			selectedmark(False, si, ei, False);
 			uint2 c = ti >= si && ti <= ei ? PI_ARROW : PI_IBEAM;
 			getstack()->setcursor(MCcursors[c], False);
 		}
@@ -1506,7 +1506,7 @@ Boolean MCField::deleteselection(Boolean force)
 		focusedparagraph->clearzeros();
 
 		int4 si, ei;
-		selectedmark(False, si, ei, False, False);
+		selectedmark(False, si, ei, False);
 		Ustruct *us = new Ustruct;
 		us->type = UT_DELETE_TEXT;
 		us->ud.text.index = si;
@@ -1682,14 +1682,14 @@ void MCField::finsertnew(Field_translations function, const MCString& p_string, 
 	
 	// Compute the start and end point of the selection.
 	int4 si,ei;
-	selectedmark(False, si, ei, False, False);
+	selectedmark(False, si, ei, False);
 
 	// Defer to the paragraph method to insert the text.
 	focusedparagraph -> finsertnew(p_string, p_is_unicode);
 
 	// Compute the end of the selection.
 	int4 ti;
-	selectedmark(False, ei, ti, False, False);
+	selectedmark(False, ei, ti, False);
 	if (composing)
 	{
 		composeoffset = si;
@@ -1816,7 +1816,7 @@ void MCField::fdel(Field_translations function, const char *string, KeySym key)
 		}
 		int4 si, ei;
 		us->type = UT_DELETE_TEXT;
-		selectedmark(False, si, ei, False, False);
+		selectedmark(False, si, ei, False);
 		us->ud.text.index = si;
 		MCundos->freestate();
 		MCundos->savestate(this, us);
@@ -2106,7 +2106,7 @@ void MCField::fmove(Field_translations function, const char *string, KeySym key)
 				&& focusedparagraph->isselection())
 	{
 		int4 si, ei;
-		selectedmark(False, si, ei, False, False);
+		selectedmark(False, si, ei, False);
 		unselect(False, True);
 		if (function == FT_LEFTCHAR)
 			seltext(si, si, False);

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -667,27 +667,37 @@ Exec_stat MCField::settextindex(uint4 parid, int4 si, int4 ei, const MCString &s
 	
 	if (si != ei)
 	{
-		int4 tei;
-		if (ei >= pgptr->gettextsizecr())
-		{
-			tei = pgptr->gettextsize();
-			ei--;
-			if (ei == tei && pgptr->next() != toppgptr)
-			{
-				pgptr->join();
-				
-				// MW-2013-10-24: [[ FasterField ]] Join affects multiple paragraphs.
-				t_affect_many = true;
-			}
-		}
-		else
-			tei = ei;
-		ei -= tei;
+        
+        // MW-2014-05-28: [[ Bug 11928 ]] Reworked code here so that it is the same as
+        //   MCField::deleteselection (makes sure paragraph styles work the same way
+        //   when deleting a paragraph break).
 		MCParagraph *saveparagraph = pgptr;
 		int4 savey = 0;
 		if (opened && pgptr == paragraphs)
 			savey = paragraphtoy(saveparagraph);
+        
+        // First delete the portion of the first paragraph in the range.
+        int4 tei;
+        tei = MCMin(ei, pgptr -> gettextsize());
+        
 		pgptr->deletestring(si, tei);
+        
+        // If the end range is after the end of paragraph, then join with
+        // the next.
+        if (ei > tei && pgptr -> next() != toppgptr)
+        {
+            // Account for the CR.
+            tei += 1;
+            // Join the paragraphs.
+            pgptr -> join();
+            // We've affected more than one.
+            t_affect_many = true;
+        }
+        
+        // si / ei are relative to pgptr, so at this point 'si' maps to 0 in
+        // pgptr, so we must adjust ei.
+        ei -= tei;
+        
 		if (ei > 0)
 		{
 			pgptr = pgptr->next();
@@ -1692,7 +1702,7 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 		{
 			if (MCactivefield == this)
 			{
-				selectedmark(False, ssi, sei, False, False);
+				selectedmark(False, ssi, sei, False);
 				unselect(False, True);
 			}
 			curparagraph = focusedparagraph = paragraphs;
@@ -2184,7 +2194,7 @@ Boolean MCField::foundmark(Boolean wholeline, Boolean inc_cr, int4 &si, int4 &ei
 void MCField::selectedchunk(MCExecPoint &ep)
 {
 	int4 si, ei;
-	if (selectedmark(False, si, ei, False, False))
+	if (selectedmark(False, si, ei, False))
 		returnchunk(ep, si, ei);
 	else
 		ep.clear();
@@ -2193,7 +2203,7 @@ void MCField::selectedchunk(MCExecPoint &ep)
 void MCField::selectedline(MCExecPoint &ep)
 {
 	int4 si, ei;
-	if (selectedmark(False, si, ei, False, False))
+	if (selectedmark(False, si, ei, False))
 		returnline(ep, si, ei);
 	else
 		ep.clear();
@@ -2202,7 +2212,7 @@ void MCField::selectedline(MCExecPoint &ep)
 void MCField::selectedloc(MCExecPoint &ep)
 {
 	int4 si, ei;
-	if (selectedmark(False, si, ei, False, False))
+	if (selectedmark(False, si, ei, False))
 		returnloc(ep, si);
 	else
 		ep.clear();
@@ -2231,13 +2241,14 @@ void MCField::selectedtext(MCExecPoint &ep)
 	else
 	{
 		int4 si, ei;
-		if (selectedmark(False, si, ei, False, False))
+		if (selectedmark(False, si, ei, False))
 			returntext(ep, si, ei);
 	}
 }
 
-Boolean MCField::selectedmark(Boolean whole, int4 &si, int4 &ei,
-                              Boolean force, Boolean include_cr)
+// MW-2014-05-28: [[ Bug 11928 ]] The 'inc_cr' parameter is not necessary - this is determined
+//   by 'whole' - i.e. if 'whole' is true then select the whole paragraph inc CR.
+Boolean MCField::selectedmark(Boolean whole, int4 &si, int4 &ei, Boolean force)
 {
 	MCParagraph *pgptr = paragraphs;
 	si = ei = 0;
@@ -2320,8 +2331,6 @@ Boolean MCField::selectedmark(Boolean whole, int4 &si, int4 &ei,
 				ei += e;
 			}
 		}
-		if (include_cr && pgptr != NULL && e == pgptr->gettextsize() && pgptr->next() != paragraphs)
-			ei++;
 	}
 	return True;
 }
@@ -2598,7 +2607,7 @@ void MCField::pastetext(MCParagraph *newtext, Boolean dodel)
 		{
 			us = new Ustruct;
 			int4 si, ei;
-			selectedmark(False, si, ei, False, False);
+			selectedmark(False, si, ei, False);
 			us->ud.text.index = si;
 			us->ud.text.newline = False;
 			us->ud.text.data = NULL;
@@ -2635,7 +2644,7 @@ void MCField::movetext(MCParagraph *newtext, int4 p_to_index)
 	if ((flags & F_LOCK_TEXT) == 0 && !getstack()->islocked() && opened)
 	{
 		int4 si, ei;
-		selectedmark(False, si, ei, False, False);
+		selectedmark(False, si, ei, False);
 		if (si < p_to_index)
 			p_to_index -= ei - si;
 


### PR DESCRIPTION
...'.

[[ Bug 11928 ]] Fix paragraph style merging when doing 'delete the selectedChunk' and the selectedChunk contains a whole paragraph and trailing CR.
[[ Bug 11928 ]] Fix 'get the selectedChunk; delete it' - it now works correctly every time and not just the first.
