### PR TITLE
[[ Bug 12303 ]] Make sure paragraph styles of an empty initial line are ...

### DIFF
--- a/docs/notes/bugfix-12303.md
+++ b/docs/notes/bugfix-12303.md
@@ -1,0 +1,1 @@
+# Setting the text of a field chunk should not clear the paragraph styles of an empty line.

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -1391,6 +1391,12 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 		MCCdata *fptr = getcarddata(fdata, parid, True);
 		MCParagraph *oldparagraphs = fptr->getparagraphs();
 		fptr->setset(0);
+        
+        // MW-2014-05-28: [[ Bug 12303 ]] If we are setting 'text' then we don't want to touch the paragraph
+        //   styles of the first paragraph it is being put into. (In the other cases they are styled formats
+        //   so if the first paragraph is empty, we replace styles - this is what you'd expect).
+        bool t_preserve_zero_length_styles;
+        t_preserve_zero_length_styles = false;
 		switch (which)
 		{
 		case P_HTML_TEXT:
@@ -1404,9 +1410,10 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 			setstyledtext(parid, ep);
 			break;
 		case P_UNICODE_TEXT:
-		case P_TEXT:
-			setpartialtext(parid, s, which == P_UNICODE_TEXT);
-			break;
+        case P_TEXT:
+            t_preserve_zero_length_styles = true;
+            setpartialtext(parid, s, which == P_UNICODE_TEXT);
+            break;
 		default:
 			break;
 		}
@@ -1418,7 +1425,7 @@ Exec_stat MCField::settextatts(uint4 parid, Properties which, MCExecPoint& ep, M
 		pgptr->setselectionindex(si, si, False, False);
 		pgptr->split();
 		pgptr->append(newpgptr);
-		pgptr->join();
+		pgptr->join(t_preserve_zero_length_styles);
 		if (lastpgptr == NULL)
 			lastpgptr = pgptr;
 		else

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -1511,7 +1511,11 @@ MCLine *MCParagraph::indextoline(uint2 tindex)
 	return lines->prev();
 }
 
-void MCParagraph::join()
+// MW-2014-05-28: [[ Bug 12303 ]] Special-case added for when setting 'text' of field chunks. If
+//   'preserve_if_zero' is true, then 'this' paragraph's styles are preserved even if it has no
+//   text. This is used in the case of 'set the text of <chunk>' to ensure that paragraph properties
+//   of the first paragraph the text is set in do not get clobbered.
+void MCParagraph::join(bool p_preserve_zero_length_styles_if_zero)
 {
 	if (blocks == NULL)
 		inittext();
@@ -1522,7 +1526,9 @@ void MCParagraph::join()
 	//   the next paragraphs attrs.
 	// MW-2012-08-31: [[ Bug 10344 ]] If the textsize is 0 then always take the next
 	//   paragraphs attrs.
-	if (textsize == 0)
+	// MW-2014-05-28: [[ Bug 12303 ]] If the textsize is 0 and we don't want to preserve the style
+    //   changes, then copy the next paragraph's.
+	if (!p_preserve_zero_length_styles_if_zero && textsize == 0)
 		copyattrs(*pgptr);
 
 	// MW-2006-04-13: If the total new text size is greater than 65536 - 34 we just delete the next paragraph

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -221,8 +221,10 @@ public:
 	//   MCField::gettextatts (to fetch partial parts of a paragraph)
 	//   MCField::settextatts (to insert partial parts of a paragraph)
 	//   MCField::insertparagraph
-	//   
-	void join();
+	//
+	// MW-2014-05-28: [[ Bug 12303 ]] If 'preserve' is true, then the paragraph styles
+    //   of 'this' paragraph are never changed (used when setting 'text' of a chunk).
+	void join(bool p_preserve_styles_if_zero_length = false);
 	void split();
 
 	// Delete the text from si to ei in the paragraph.


### PR DESCRIPTION
...preserved when replacing via 'set the text of ...'.
