### PR TITLE
[[ Bug 12648 ]] Shell command does not accept spaces despite being quote...

### DIFF
--- a/docs/notes/bugfix-12648.md
+++ b/docs/notes/bugfix-12648.md
@@ -1,0 +1,1 @@
+# Shell command does not accept spaces despite being quoted (Windows)

--- a/engine/src/w32spec.cpp
+++ b/engine/src/w32spec.cpp
@@ -1009,6 +1009,10 @@ IO_stat MCS_runcmd(MCExecPoint &ep)
 	siStartInfo.hStdInput = hChildStdinRd;
 	siStartInfo.hStdOutput = hChildStdoutWr;
 
+	// SN-2014-06-16 [[ Bug 12648 ]] Shell command does not accept spaces despite being quoted (Windows)
+	// Quotes surrounding the command call are needed to preserve the quotes of the command and command arguments
+	ep.insert("\"", 0, 0);
+	ep.appendchar('\"');
 	ep.insert(" /C ", 0, 0);
 	ep.insert(MCshellcmd, 0, 0);
 	char *pname = ep.getsvalue().clone();


### PR DESCRIPTION
...d (Windows)
