### PR TITLE
[[ Bug 12647 ]] lock moves failed to synchronize movements

### DIFF
--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -1136,7 +1136,7 @@ Exec_stat MCLock::exec(MCExecPoint &ep)
 		MClockmessages = True;
 		break;
 	case LC_MOVES:
-		MClockmoves = True;
+		MCscreen->setlockmoves(True);
 		break;
 	case LC_RECENT:
 		MClockrecent = True;
@@ -2004,7 +2004,7 @@ Exec_stat MCUnlock::exec(MCExecPoint &ep)
 		MClockmessages = False;
 		break;
 	case LC_MOVES:
-		MClockmoves = False;
+		MCscreen->setlockmoves(False);
 		break;
 	case LC_RECENT:
 		MClockrecent = False;

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -402,7 +402,6 @@ Boolean MClockcolormap;
 Boolean MClockerrors;
 Boolean MClockmenus;
 Boolean MClockmessages;
-Boolean MClockmoves;
 Boolean MClockrecent;
 Boolean MCtwelvetime = True;
 Boolean MCuseprivatecmap;
@@ -758,7 +757,6 @@ void X_clear_globals(void)
 	MClockerrors = False;
 	MClockmenus = False;
 	MClockmessages = False;
-	MClockmoves = False;
 	MClockrecent = False;
 	MCtwelvetime = True;
 	MCuseprivatecmap = False;

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -315,7 +315,6 @@ extern Boolean MClockcolormap;
 extern Boolean MClockerrors;
 extern Boolean MClockmenus;
 extern Boolean MClockmessages;
-extern Boolean MClockmoves;
 extern Boolean MClockrecent;
 extern Boolean MCtwelvetime;
 extern Boolean MCuseprivatecmap;

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -2001,7 +2001,14 @@ Exec_stat MCProperty::set(MCExecPoint &ep)
 	case P_LOCK_MESSAGES:
 		return ep.getboolean(MClockmessages, line, pos, EE_PROPERTY_NAB);
 	case P_LOCK_MOVES:
-		return ep.getboolean(MClockmoves, line, pos, EE_PROPERTY_NAB);
+		{
+			Boolean t_new_value;
+			Exec_stat t_stat = ep.getboolean(t_new_value, line, pos, EE_PROPERTY_NAB);
+			if (t_stat == ES_NORMAL) {
+				MCscreen->setlockmoves(t_new_value);
+			}
+			return t_stat;
+		}
 	case P_LOCK_RECENT:
 		return ep.getboolean(MClockrecent, line, pos, EE_PROPERTY_NAB);
 	case P_PRIVATE_COLORS:
@@ -3433,7 +3440,7 @@ Exec_stat MCProperty::eval(MCExecPoint &ep)
 		ep.setboolean(MClockmessages);
 		break;
 	case P_LOCK_MOVES:
-		ep.setboolean(MClockmoves);
+		ep.setboolean(MCscreen->getlockmoves());
 		break;
 	case P_LOCK_RECENT:
 		ep.setboolean(MClockrecent);

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1185,6 +1185,9 @@ Boolean MCUIDC::getlockmoves() const
 
 void MCUIDC::setlockmoves(Boolean b)
 {
+	if (lockmoves == b)
+		return;
+
 	lockmoves = b;
 
 	if (lockmoves) {
@@ -1284,8 +1287,7 @@ void MCUIDC::stopmove(MCObject *optr, Boolean finish)
 		{
 			if (mptr->object == optr)
 			{
-				mptr->remove
-				(moving);
+				mptr->remove(moving);
 				if (finish)
 				{
 					MCRectangle rect = mptr->object->getrect();
@@ -1323,72 +1325,72 @@ void MCUIDC::handlemoves(real8 &curtime, real8 &eventtime)
 	Boolean done = False;
 	do
 	{
-			MCRectangle rect = mptr->object->getrect();
-			MCRectangle newrect = rect;
-			real8 dt = 0.0;
-			if (curtime >= mptr->starttime + mptr->duration
-			        || rect.x == mptr->donex && rect.y == mptr->doney)
+		MCRectangle rect = mptr->object->getrect();
+		MCRectangle newrect = rect;
+		real8 dt = 0.0;
+		if (curtime >= mptr->starttime + mptr->duration
+		        || rect.x == mptr->donex && rect.y == mptr->doney)
+		{
+			newrect.x = mptr->donex;
+			newrect.y = mptr->doney;
+			dt = curtime - (mptr->starttime + mptr->duration);
+			done = True;
+		}
+		else
+		{
+			newrect.x = mptr->pts[mptr->curpt].x - (rect.width >> 1)
+			            + (int2)(mptr->dx * (curtime - mptr->starttime) / mptr->duration);
+			newrect.y = mptr->pts[mptr->curpt].y - (rect.height >> 1)
+			            + (int2)(mptr->dy * (curtime - mptr->starttime) / mptr->duration);
+		}
+		if (newrect.x != rect.x || newrect.y != rect.y)
+		{
+			moved = True;
+		
+			// MW-2011-08-18: [[ Layers ]] Notify of position change.
+			if (mptr->object -> gettype() >= CT_GROUP)
+				static_cast<MCControl *>(mptr->object)->layer_setrect(newrect, false);
+			else
+				mptr->object->setrect(newrect);
+		}
+		if (done)
+		{
+			if (mptr->curpt < mptr->lastpt - 1)
 			{
-				newrect.x = mptr->donex;
-				newrect.y = mptr->doney;
-				dt = curtime - (mptr->starttime + mptr->duration);
-				done = True;
+				do
+				{
+					mptr->curpt++;
+					mptr->dx = mptr->pts[mptr->curpt + 1].x - mptr->pts[mptr->curpt].x;
+					mptr->dy = mptr->pts[mptr->curpt + 1].y - mptr->pts[mptr->curpt].y;
+					mptr->duration = sqrt((double)(mptr->dx * mptr->dx + mptr->dy
+					                               * mptr->dy)) / mptr->speed;
+					dt -= mptr->duration;
+				}
+				while (dt > 0.0 && mptr->curpt < mptr->lastpt - 1);
+				mptr->duration = -dt;
+				mptr->starttime = curtime;
+				mptr->donex = mptr->pts[mptr->curpt + 1].x - (rect.width >> 1);
+				mptr->doney = mptr->pts[mptr->curpt + 1].y - (rect.height >> 1);
 			}
 			else
 			{
-				newrect.x = mptr->pts[mptr->curpt].x - (rect.width >> 1)
-				            + (int2)(mptr->dx * (curtime - mptr->starttime) / mptr->duration);
-				newrect.y = mptr->pts[mptr->curpt].y - (rect.height >> 1)
-				            + (int2)(mptr->dy * (curtime - mptr->starttime) / mptr->duration);
-			}
-			if (newrect.x != rect.x || newrect.y != rect.y)
-			{
-				moved = True;
-			
-				// MW-2011-08-18: [[ Layers ]] Notify of position change.
-				if (mptr->object -> gettype() >= CT_GROUP)
-					static_cast<MCControl *>(mptr->object)->layer_setrect(newrect, false);
-				else
-					mptr->object->setrect(newrect);
-			}
-			if (done)
-			{
-				if (mptr->curpt < mptr->lastpt - 1)
-				{
-					do
-					{
-						mptr->curpt++;
-						mptr->dx = mptr->pts[mptr->curpt + 1].x - mptr->pts[mptr->curpt].x;
-						mptr->dy = mptr->pts[mptr->curpt + 1].y - mptr->pts[mptr->curpt].y;
-						mptr->duration = sqrt((double)(mptr->dx * mptr->dx + mptr->dy
-						                               * mptr->dy)) / mptr->speed;
-						dt -= mptr->duration;
-					}
-					while (dt > 0.0 && mptr->curpt < mptr->lastpt - 1);
-					mptr->duration = -dt;
-					mptr->starttime = curtime;
-					mptr->donex = mptr->pts[mptr->curpt + 1].x - (rect.width >> 1);
-					mptr->doney = mptr->pts[mptr->curpt + 1].y - (rect.height >> 1);
-				}
-				else
-				{
-					moving = mptr->prev();
-					mptr->remove(moving);
-					if (!mptr->waiting)
-						if (MClockmessages)
-							delaymessage(mptr->object, MCM_move_stopped);
-						else
-							mptr->object->message(MCM_move_stopped);
-					delete mptr;
-					if (moving == NULL)
-						mptr = NULL;
+				moving = mptr->prev();
+				mptr->remove(moving);
+				if (!mptr->waiting)
+					if (MClockmessages)
+						delaymessage(mptr->object, MCM_move_stopped);
 					else
-						mptr = moving->next();
-				}
-				done = False;
+						mptr->object->message(MCM_move_stopped);
+				delete mptr;
+				if (moving == NULL)
+					mptr = NULL;
+				else
+					mptr = moving->next();
 			}
-			else
-				mptr = mptr->next();
+			done = False;
+		}
+		else
+			mptr = mptr->next();
 	}
 	while (mptr != NULL && mptr != moving);
 		

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -254,6 +254,8 @@ class MCUIDC
 protected:
 	MCMessageList *messages;
 	MCMovingList *moving;
+	Boolean lockmoves;
+	real8 locktime;
 	uint4 messageid;
     // MW-2014-05-28: [[ Bug 12463 ]] Change these to 32-bit to stop wrap-around of messages.
 	uint32_t nmessages;
@@ -609,6 +611,8 @@ public:
     
 	void listmessages(MCExecPoint &ep);
 	Boolean handlepending(real8 &curtime, real8 &eventtime, Boolean dispatch);
+	Boolean getlockmoves() const;
+	void setlockmoves(Boolean b);
 	void addmove(MCObject *optr, MCPoint *pts, uint2 npts,
 	             real8 &duration, Boolean waiting);
 	void listmoves(MCExecPoint &ep);

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -149,7 +149,8 @@ void MCU_resetprops(Boolean update)
 		}
 	}
 	MCerrorlock = 0;
-	MClockerrors = MClockmessages = MClockmoves = MClockrecent = False;
+	MClockerrors = MClockmessages = MClockrecent = False;
+	MCscreen->setlockmoves(False);
 	MCerrorlockptr = NULL;
 	MCinterrupt = False;
 	MCdragspeed = 0;
@@ -168,7 +169,7 @@ void MCU_saveprops(MCSaveprops &sp)
 	sp.errorlockptr = MCerrorlockptr;
 	sp.lockerrors = MClockerrors;
 	sp.lockmessages = MClockmessages;
-	sp.lockmoves = MClockmoves;
+	sp.lockmoves = MCscreen->getlockmoves();
 	sp.lockrecent = MClockrecent;
 	sp.interrupt = MCinterrupt;
 	sp.dragspeed = MCdragspeed;
@@ -190,7 +191,7 @@ void MCU_restoreprops(MCSaveprops &sp)
 	MCerrorlockptr = sp.errorlockptr;
 	MClockerrors = sp.lockerrors;
 	MClockmessages = sp.lockmessages;
-	MClockmoves = sp.lockmoves;
+	MCscreen->setlockmoves(sp.lockmoves);
 	MClockrecent = sp.lockrecent;
 	MCinterrupt = sp.interrupt;
 	MCdragspeed = sp.dragspeed;


### PR DESCRIPTION
Multiple moves created whist `lock moves` was in effect failed to be synchronized. 

Previously when the movements were locked, every time `MCUIDC::handlemoves()` was called it would shift the start time of each movement forwards by an amount equal to the interval between the current and previous call.  This meant that the movements were essentially paused for the duration of the `lock moves`, but if there were multiple movements created during the lock any time difference between them would be preserved.  This becomes noticeable if there are a large number of movements created, or if, say, a 10 millisecond wait is added between two movements.

The solution here is to store the time that the lock was initiated, only apply the offset when the lock is released and, for movements created during a lock, use the start time of the current lock as the start time of the movement.
