### PR TITLE
[[ Bug 12697 ]] Setting tabStop less than the preceding one on a field c...

### DIFF
--- a/docs/notes/bugfix-12697.md
+++ b/docs/notes/bugfix-12697.md
@@ -1,0 +1,1 @@
+# Setting tabStop less than the preceding one on a field causes text to overlap

--- a/engine/src/exec-interface-field.cpp
+++ b/engine/src/exec-interface-field.cpp
@@ -1145,13 +1145,17 @@ void MCField::DoSetTabStops(MCExecContext& ctxt, bool is_relative, uindex_t p_co
             return;
         }
 
-        if (is_relative)
+        // AL-2014-06-25: [[ Bug 12697]] If a tabStop is smaller than the preceding one,
+        //  then calculate as relative distance.
+        if (is_relative || p_tabs[i] < t_previous_tab_stop)
         {
             t_new_tabs . Push(p_tabs[i] + t_previous_tab_stop);
             t_previous_tab_stop = t_new_tabs[i];
         }
         else
             t_new_tabs . Push(p_tabs[i]);
+        
+        t_previous_tab_stop = p_tabs[i];
     }
     
     t_new_tabs . Take(t_new, t_new_count);


### PR DESCRIPTION
...auses text to overlap
