### PR TITLE
[[ Bugfix ]] Fix crash in MCObject::sendmessage()

### DIFF
--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2020,10 +2020,21 @@ void MCObject::senderror()
 
 void MCObject::sendmessage(Handler_type htype, MCNameRef m, Boolean h)
 {
-	static const char *htypes[] =
-	    {
-	        "undefined", "message", "function", "getprop", "setprop"
-	    };
+	static const char *htypes[] =	{
+		"undefined",
+		"message",
+		"function",
+		"getprop",
+		"setprop",
+		"before",
+		"after",
+		"private"
+	};
+	enum { max_htype = (sizeof(htypes)/sizeof(htypes[0])) - 1 };
+
+	MCAssert(htype <= max_htype);
+	MCStaticAssert(max_htype == HT_MAX);
+
 	MCmessagemessages = False;
 	MCExecPoint ep(this, NULL, NULL);
 	MCresult->fetch(ep);

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -628,7 +628,7 @@ enum Functions {
 };
 
 enum Handler_type {
-    HT_UNDEFINED,
+    HT_UNDEFINED = 0,
     HT_MESSAGE,
     HT_FUNCTION,
     HT_GETPROP,
@@ -639,7 +639,9 @@ enum Handler_type {
 	HT_BEFORE,
 	HT_AFTER,
 
-	HT_PRIVATE
+		HT_PRIVATE,
+
+		HT_MAX = HT_PRIVATE
 };
 
 enum If_format {

--- a/libcore/include/core.h
+++ b/libcore/include/core.h
@@ -140,6 +140,19 @@ extern void __MCLogWithTrace(const char *file, uint32_t line, const char *format
 #define MCLogWithTrace(m_format, ...)
 #endif
 
+#define MC_CONCAT(X,Y) MC_CONCAT_(X,Y)
+#define MC_CONCAT_(X,Y) X ## Y
+
+#if (__cplusplus >= 201103L)
+#define MCStaticAssert(expr) static_assert(expr, #expr)
+#else
+template<bool> struct __MCStaticAssert;
+template<> struct __MCStaticAssert<true> { };
+#define MCStaticAssert(expr)																						\
+	enum { MC_CONCAT(__MCSA_,__LINE__) = sizeof(__MCStaticAssert<expr>) }
+#endif
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // IM. 2011-01-18 blocked out currently unused error codes which conflict with libexternal


### PR DESCRIPTION
If you had a behaviour script containing a `before` message handler and opened the message watcher you would get a crash in `MCObject::sendmessage()`.  The problem was that it contained an array of strings used to convert a `Handler_type` enum value to a string, but this array didn't cover all possible values of the enum, so you'd end up dereferencing an invalid pointer.

I've added the missing strings to the array and added assertions that the enum is within the array.  I've also added a static assertion macro and use it to check the size of the array.
