### PR TITLE
[[ Bugfix ]] Fix crash in MCObject::sendmessage()

### DIFF
--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2064,10 +2064,21 @@ void MCObject::senderror()
 
 void MCObject::sendmessage(Handler_type htype, MCNameRef m, Boolean h)
 {
-	static const char *htypes[] =
-	    {
-	        "undefined", "message", "function", "getprop", "setprop"
-	    };
+	static const char *htypes[] =	{
+		"undefined",
+		"message",
+		"function",
+		"getprop",
+		"setprop",
+		"before",
+		"after",
+		"private"
+	};
+	enum { max_htype = (sizeof(htypes)/sizeof(htypes[0])) - 1 };
+
+	MCAssert(htype <= max_htype);
+	MCStaticAssert(max_htype == HT_MAX);
+
     MCmessagemessages = False;
 
     MCExecContext ctxt(this, nil, nil);

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -585,7 +585,7 @@ enum Functions {
 };
 
 enum Handler_type {
-    HT_UNDEFINED,
+    HT_UNDEFINED = 0,
     HT_MESSAGE,
     HT_FUNCTION,
     HT_GETPROP,
@@ -596,7 +596,9 @@ enum Handler_type {
 	HT_BEFORE,
 	HT_AFTER,
 
-	HT_PRIVATE
+		HT_PRIVATE,
+
+		HT_MAX = HT_PRIVATE
 };
 
 enum If_format {

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -821,6 +821,20 @@ extern void __MCUnreachable(void) ATTRIBUTE_NORETURN;
 
 #endif
 
+
+#define MC_CONCAT(X,Y) MC_CONCAT_(X,Y)
+#define MC_CONCAT_(X,Y) X ## Y
+
+#if (__cplusplus >= 201103L)
+#define MCStaticAssert(expr) static_assert(expr, #expr)
+#else
+template<bool> struct __MCStaticAssert;
+template<> struct __MCStaticAssert<true> { };
+#define MCStaticAssert(expr)																						\
+	enum { MC_CONCAT(__MCSA_,__LINE__) = sizeof(__MCStaticAssert<expr>) }
+#endif
+
+
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
If you had a behaviour script containing a `before` message handler and opened the message watcher you would get a crash in `MCObject::sendmessage()`.  The problem was that it contained an array of strings used to convert a `Handler_type` enum value to a string, but this array didn't cover all possible values of the enum, so you'd end up dereferencing an invalid pointer.

I've added the missing strings to the array and added assertions that the enum is within the array.  I've also added a static assertion macro and use it to check the size of the array.
