### PR TITLE
Fixed bugs:

### DIFF
--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -1181,6 +1181,7 @@ void MCPlatformHandlePlayerStopped(MCPlatformPlayerRef p_player)
     if (t_player == nil)
         return;
     
+    t_player -> layer_redrawall();
     t_player -> timer(MCM_play_stopped, nil);
 }
 

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1414,10 +1414,8 @@ void MCPlayer::syncbuffering(MCContext *p_dc)
 //   currently in use.
 void MCPlayer::getversion(MCExecPoint &ep)
 {
-#if 0
     extern void MCQTGetVersion(MCExecPoint& ep);
     MCQTGetVersion(ep);
-#endif
 }
 
 void MCPlayer::freetmp()
@@ -2313,6 +2311,7 @@ void MCPlayer::drawControllerWellButton(MCGContextRef p_gcontext)
     // Adjust to look prettier. The same settings for y and height should apply to kMCPlayerControllerPartSelectedArea and kMCPlayerControllerPartPlayedArea
     t_drawn_well_rect . y = t_drawn_well_rect . y + 2 * CONTROLLER_HEIGHT / 5;
     t_drawn_well_rect . height = CONTROLLER_HEIGHT / 5;
+    t_drawn_well_rect . width -= 4;
     
     MCGBitmapEffects t_effects;
 	t_effects . has_drop_shadow = false;
@@ -2684,6 +2683,9 @@ MCRectangle MCPlayer::getcontrollerpartrect(const MCRectangle& p_rect, int p_par
             MCPlatformGetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyCurrentTime, kMCPlatformPropertyTypeUInt32, &t_current_time);
             MCPlatformGetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyDuration, kMCPlatformPropertyTypeUInt32, &t_duration);
             
+            if (t_current_time >= t_duration)
+                t_current_time = t_duration;
+            
             MCRectangle t_well_rect;
             t_well_rect = getcontrollerpartrect(p_rect, kMCPlayerControllerPartWell);
             
@@ -2902,6 +2904,7 @@ void MCPlayer::handle_mdown(int p_which)
             else
                 playstart(nil);
             layer_redrawrect(getcontrollerpartrect(getcontrollerrect(), kMCPlayerControllerPartPlay));
+    
             
             break;
         case kMCPlayerControllerPartVolume:

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -402,7 +402,7 @@ public:
         return True;
     }
     
-    Boolean mup(uint2 which)
+    Boolean mup(uint2 which, bool release)
     {
         m_grabbed_part = kMCPlayerControllerPartUnknown;
         return True;
@@ -1582,9 +1582,15 @@ Boolean MCPlayer::prepare(const char *options)
 {
 	Boolean ok = False;
     
-	if (state & CS_PREPARED || filename == NULL)
+	if (state & CS_PREPARED)
 		return True;
-	
+    
+	if (filename == NULL)
+    {
+        if (m_platform_player != nil)
+            MCPlatformSetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyFilename, kMCPlatformPropertyTypeNativeCString, &filename);
+        return True;
+    }
 	if (!opened)
 		return False;
     

--- a/engine/src/quicktime.cpp
+++ b/engine/src/quicktime.cpp
@@ -1093,7 +1093,7 @@ void MCQTEffectEnd(void)
 
 void MCQTEffectsList(MCExecPoint& ep)
 {
-	ep . clear();
+	ep.clear();
 }
 
 Boolean MCQTEffectsDialog(MCExecPoint& ep, const char *p_title, Boolean p_sheet)
@@ -1109,7 +1109,8 @@ void MCQTRecordSound(char *file)
 
 void MCQTGetRecordLoudness(MCExecPoint& ep)
 {
-	MCresult -> sets("not supported");
+    uint2 rloudness = 0;
+    ep.setint(rloudness);
 }
 
 void MCQTGetRecordCompressionList(MCExecPoint& ep)
@@ -1125,5 +1126,13 @@ void MCQTRecordDialog(MCExecPoint& ep, const char *p_title, Boolean sheet)
 {
 }
 
+void MCQTGetVersion(MCExecPoint& ep)
+{
+    long attrs;
+    if (Gestalt(gestaltQuickTimeVersion, &attrs) == noErr)
+        ep.setstringf("%ld.%ld.%ld", attrs >> 24, (attrs >> 20) & 0xF, (attrs >> 16) & 0xF);
+    else
+        ep.setstaticcstring("0.0");  //indicates that no QT installed
+}
 #endif
 


### PR DESCRIPTION
1. Setting video source to empty now resets the player
2. Adding a new source now loads the first frame of the video instantly
3. Fixed scrubbing issue in volume controller and playback controller
4. Clicking anywhere in the well now takes you to that part of the video
5. Clicking anywhere on the volume well now sets the volume correctly
