### PR TITLE
[[ Bug 12789 ]] Relayout after property setting when defragging causes b...

### DIFF
--- a/docs/notes/bugfix-12789.md
+++ b/docs/notes/bugfix-12789.md
@@ -1,0 +1,1 @@
+# Clicking on stack listed in Application Browser causes crash

--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -1031,7 +1031,9 @@ template<typename T> void SetCharPropOfCharChunk(MCExecContext& ctxt, MCField *p
             }
             // end of MCParagraph scope
 
-            if (t_need_layout && !all && pgptr->getopened())
+            // AL-2014-07-14: [[ Bug 12789 ]] Defragging can cause paragraph to need layout, do make sure we relayout
+            //  if it did. Otherwise setting properties that avoid relayout can cause crashes.
+            if (pgptr -> getneedslayout() && !all && pgptr->getopened())
             {
                 // MW-2012-01-25: [[ ParaStyles ]] Ask the paragraph to reflow itself.
                 pgptr -> layout(false);

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -883,6 +883,7 @@ public:
     void setDirty() { state |= PS_LINES_NOT_SYNCHED; }
 
     void layoutchanged() { needs_layout = true; }
+    bool getneedslayout() { return needs_layout; }
     
     //////////
 


### PR DESCRIPTION
...lock changes
