### PR TITLE
[[ Bugfix 12812 ]]  Make sure we loop within start and finish time when ...

### DIFF
--- a/docs/notes/bugfix-12812.md
+++ b/docs/notes/bugfix-12812.md
@@ -1,0 +1,1 @@
+# [[Player]] loop goes to beginning of movie not selection start time when playSelection is true

--- a/engine/src/mac-av-player.mm
+++ b/engine/src/mac-av-player.mm
@@ -310,7 +310,11 @@ void MCAVFoundationPlayer::MovieFinished(void)
     }
     else
     {
-        [[m_player currentItem] seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+        // PM-2014-07-15: [[ Bug 12812 ]] Make sure we loop within start and finish time when playSelection is true 
+        if (m_play_selection_only)
+            [[m_player currentItem] seekToTime:CMTimeMake(m_selection_start, 1000) toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+        else
+            [[m_player currentItem] seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
         
         if (m_offscreen)
             CVDisplayLinkStart(m_display_link);


### PR DESCRIPTION
...playSelection is true
