### PR TITLE
[[ Bug 12828 ]] RTL text is not automatically right-aligned in cell, so ...

### DIFF
--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -1142,12 +1142,10 @@ void MCParagraph::fillselect(MCDC *dc, MCLine *lptr, int2 x, int2 y, uint2 heigh
                 bex = bptr->GetCursorX(ei);
         
                 // AL-2014-07-17: [[ Bug 12823 ]] Include segment offset in the block coordinate calculation
-                // AL_2014-07-18: [[ Bug 12828 ]] RTL text is right-aligned in tabbed cell, so adjust the
-                //  x coordinate of the selection accordingly
                 // Re-ordering will be required if the block is RTL
                 if (bix > bex)
                 {
-                    srect.x = x + (sgptr -> GetRight() - bex - bptr -> getwidth());
+                    srect.x = x + sgptr -> GetCursorOffset() + bex;
                     srect.width = bix - bex;
                 }
                 else


### PR DESCRIPTION
...revert selection rect changes
