### PR TITLE
[[ Bug 12874 ]] revBrowser (both original and CEF) crashes LiveCode 7.0 ...

### DIFF
--- a/docs/notes/bugfix-12874.md
+++ b/docs/notes/bugfix-12874.md
@@ -1,0 +1,1 @@
+#revBrowser (both original and CEF) crashes LiveCode 7.0 DP7

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -1662,16 +1662,21 @@ XCB MCcbs[] =
 	runloop_wait,
     
     // Externals interface unicode functions
+    // SN-2014-07-22: [[ Bug 12874 ]] revBrowser (both original and CEF) crashes LiveCode 7.0 DP7
+    //  added *_by_id_* in the MCcbs...
 	card_message_utf8,
 	eval_expr_utf8,
 	get_global_utf8,
 	set_global_utf8,
 	get_field_by_name_utf8,
 	get_field_by_num_utf8,
+    get_field_by_id_utf8,
 	set_field_by_name_utf8,
 	set_field_by_num_utf8,
+    set_field_by_id_utf8,
 	show_image_by_name_utf8,
 	show_image_by_num_utf8,
+    show_image_by_id_utf8,
 	get_variable_utf8,
 	set_variable_utf8,
 	get_variable_ex_utf8_text,


### PR DESCRIPTION
...DP7
