### PR TITLE
[[ Bug 12948 ]] Crash when opening custom property inspector having a pr...

### DIFF
--- a/docs/notes/bugfix-12948.md
+++ b/docs/notes/bugfix-12948.md
@@ -1,0 +1,1 @@
+#Crash when opening custom property inspector having a property with more than 65535 bytes

--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -1799,7 +1799,8 @@ coord_t MCBlock::getsubwidth(MCDC *dc, coord_t x /* IGNORED */, findex_t i, find
 			l--;
         
         // AL-2014-07-18: [[ Bug 12828 ]] If the last char is a tab character then ignore it.
-        if (parent->GetCodepointAtIndex(sptr + l - 1) == '\t')
+        // SN-2014-07-24: [[ Bug 12948 ]] Fix for the crash (negative length possible)
+        if (l && parent->GetCodepointAtIndex(sptr + l - 1) == '\t')
 			l--;
 
 		// MW-2012-08-29: [[ Bug 10325 ]] Use 32-bit int to compute the width, then clamp

--- a/engine/src/exec-interface-field.cpp
+++ b/engine/src/exec-interface-field.cpp
@@ -806,21 +806,9 @@ void MCField::GetText(MCExecContext& ctxt, uint32_t part, MCStringRef& r_text)
 
 void MCField::SetText(MCExecContext& ctxt, uint32_t part, MCStringRef p_text)
 {
-    MCString t_text;
-    bool t_is_unicode;
-    
-    if (MCStringIsNative(p_text))
-    {
-        t_text . set((const char*)MCStringGetNativeCharPtr(p_text), MCStringGetLength(p_text));
-        t_is_unicode = false;
-    }
-    else
-    {
-        t_text . set((const char*)MCStringGetCharPtr(p_text), MCStringGetLength(p_text) * 2);
-        t_is_unicode = true;
-    }
-    
-    setpartialtext(part, t_text, t_is_unicode);
+    // SN-2014-07-24: [[ Bug 12948 ]]  Fix for the horrendous slow-down:
+    //  P_TEXT property for a field should call settext, not setpartialtext (avoid text formatting)
+    settext(part, p_text, False);
 }
 
 void MCField::GetUnicodeText(MCExecContext& ctxt, uint32_t part, MCDataRef& r_text)


### PR DESCRIPTION
...operty with more than 65535 bytes
