### PR TITLE
[[ Bug 13103 ]] Menu items starting with '-', with more content, should ...

### DIFF
--- a/docs/notes/bugfix-13103.md
+++ b/docs/notes/bugfix-13103.md
@@ -1,0 +1,1 @@
+#option, pulldown and popUp menus don't accept negative numbers

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -266,7 +266,9 @@ public:
         if (!t_utf_title . Lock(p_menuitem -> label))
             return false;
 		
-		if (MCStringGetCharAtIndex(p_menuitem -> label, 0) == '-')
+        // SN-2014-08-05: [[ Bug 13103 ]] The item label must be "-" to be a menu separator,
+        //  not only start with '-'
+		if (MCStringIsEqualToCString(p_menuitem -> label, "-", kMCStringOptionCompareExact))
 			MCPlatformAddMenuSeparatorItem(TopMenu(), UINDEX_MAX);
 		else
 		{


### PR DESCRIPTION
...not generate a menu separator
