### PR TITLE
Feature unicode speech

### DIFF
--- a/docs/notes/bugfix-9941.md
+++ b/docs/notes/bugfix-9941.md
@@ -1,0 +1,1 @@
+# Accented characters in string passed to revSpeak cause nothing to be spoken.

--- a/docs/notes/feature-unicode_speech.md
+++ b/docs/notes/feature-unicode_speech.md
@@ -1,0 +1,2 @@
+# revSpeak updated to use Unicode
+You can now pass any string to revSpeak and it will pass it through to the OS preserving Unicode. For example, on newer Mac OSes if you select the 'Tarik' voice using revSetSpeechVoice, you can then pass Arabic text to revSpeak to have it spoken.

--- a/libexternal/include/revolution/external.h
+++ b/libexternal/include/revolution/external.h
@@ -610,6 +610,12 @@ template<ExternalHandler u_handler> void ExternalWrapper(char *p_arguments[], in
 #define EXTERNAL_DECLARE_FUNCTION(m_name, m_function) \
 		{ m_name, "F", 0, ExternalWrapper<m_function>, NULL },
 
+#define EXTERNAL_DECLARE_COMMAND_UTF8(m_name, m_function) \
+        { m_name, "c", 0, ExternalWrapper<m_function>, NULL },
+
+#define EXTERNAL_DECLARE_FUNCTION_UTF8(m_name, m_function) \
+        { m_name, "f", 0, ExternalWrapper<m_function>, NULL },
+
 
 #ifdef __OBJC__
 
@@ -662,7 +668,13 @@ template<ExternalHandler u_handler> void ExternalWrapperObjC(char *p_arguments[]
 
 #define EXTERNAL_DECLARE_FUNCTION_OBJC(m_name, m_function) \
 		{ m_name, "F", 0, ExternalWrapperObjC<m_function>, NULL },
-		
+
+#define EXTERNAL_DECLARE_COMMAND_OBJC(m_name, m_function) \
+        { m_name, "c", 0, ExternalWrapperObjC<m_function>, NULL },
+
+#define EXTERNAL_DECLARE_FUNCTION_OBJC(m_name, m_function) \
+        { m_name, "f", 0, ExternalWrapperObjC<m_function>, NULL },
+
 #else
 
 
@@ -671,6 +683,12 @@ template<ExternalHandler u_handler> void ExternalWrapperObjC(char *p_arguments[]
 
 #define EXTERNAL_DECLARE_FUNCTION_OBJC(m_name, m_function) \
 		{ m_name, "F", 0, ExternalWrapper<m_function>, NULL },
+
+#define EXTERNAL_DECLARE_COMMAND_OBJC_UTF8(m_name, m_function) \
+        { m_name, "c", 0, ExternalWrapper<m_function>, NULL },
+
+#define EXTERNAL_DECLARE_FUNCTION_OBJC_UTF8(m_name, m_function) \
+        { m_name, "f", 0, ExternalWrapper<m_function>, NULL },
 
 #endif
 
@@ -681,6 +699,12 @@ template<ExternalHandler u_handler> void ExternalWrapperObjC(char *p_arguments[]
 
 #define EXTERNAL_DECLARE_FUNCTION(m_name, m_function) \
 		{ m_name, "F", 0, m_function, 0 },
+
+#define EXTERNAL_DECLARE_COMMAND_UTF8(m_name, m_function) \
+        { m_name, "c", 0, m_function, 0 },
+
+#define EXTERNAL_DECLARE_FUNCTION_UTF8(m_name, m_function) \
+        { m_name, "f", 0, m_function, 0 },
 
 #endif
 

--- a/libexternal/src/external.c
+++ b/libexternal/src/external.c
@@ -37,39 +37,38 @@ enum
 	OPERATION_SET_ARRAY,
 
 	// IM-2014-03-06: [[ revBrowserCEF ]] Add externals extensions for V1
-	// V1
-	OPERATION_ADD_RUNLOOP_ACTION,
-	OPERATION_REMOVE_RUNLOOP_ACTION,
-	OPERATION_RUNLOOP_WAIT,
+	/* V1 */ OPERATION_ADD_RUNLOOP_ACTION,
+	/* V1 */ OPERATION_REMOVE_RUNLOOP_ACTION,
+	/* V1 */ OPERATION_RUNLOOP_WAIT,
+    
+	// IM-2014-07-09: [[ Bug 12225 ]] Add coordinate conversion functions
+	/* V1 */ OPERATION_STACK_TO_WINDOW_RECT,
+	/* V1 */ OPERATION_WINDOW_TO_STACK_RECT,
     
     // SN-2014-07-04: [[ UnicodeExternalsV0 ]] Add externals extensions to allow utf8-encoded arguments    
-	OPERATION_SEND_CARD_MESSAGE_UTF8,
-	OPERATION_EVAL_EXP_UTF8,
-	OPERATION_GET_GLOBAL_UTF8,
-	OPERATION_SET_GLOBAL_UTF8,
-	OPERATION_GET_FIELD_BY_NAME_UTF8,
-	OPERATION_GET_FIELD_BY_NUM_UTF8,
-	OPERATION_GET_FIELD_BY_ID_UTF8,
-	OPERATION_SET_FIELD_BY_NAME_UTF8,
-	OPERATION_SET_FIELD_BY_NUM_UTF8,
-	OPERATION_SET_FIELD_BY_ID_UTF8,
-	OPERATION_SHOW_IMAGE_BY_NAME_UTF8,
-	OPERATION_SHOW_IMAGE_BY_NUM_UTF8,
-	OPERATION_SHOW_IMAGE_BY_ID_UTF8,
-	OPERATION_GET_VARIABLE_UTF8,
-	OPERATION_SET_VARIABLE_UTF8,
-	OPERATION_GET_VARIABLE_EX_UTF8_TEXT,
-	OPERATION_GET_VARIABLE_EX_UTF8_BINARY,
-	OPERATION_SET_VARIABLE_EX_UTF8_TEXT,
-	OPERATION_SET_VARIABLE_EX_UTF8_BINARY,
-	OPERATION_GET_ARRAY_UTF8_TEXT,
-	OPERATION_GET_ARRAY_UTF8_BINARY,
-	OPERATION_SET_ARRAY_UTF8_TEXT,
-	OPERATION_SET_ARRAY_UTF8_BINARY,
-
-	// IM-2014-07-09: [[ Bug 12225 ]] Add coordinate conversion functions
-	OPERATION_STACK_TO_WINDOW_RECT,
-	OPERATION_WINDOW_TO_STACK_RECT,
+	/* V2 */ OPERATION_SEND_CARD_MESSAGE_UTF8,
+	/* V2 */ OPERATION_EVAL_EXP_UTF8,
+	/* V2 */ OPERATION_GET_GLOBAL_UTF8,
+	/* V2 */ OPERATION_SET_GLOBAL_UTF8,
+	/* V2 */ OPERATION_GET_FIELD_BY_NAME_UTF8,
+	/* V2 */ OPERATION_GET_FIELD_BY_NUM_UTF8,
+	/* V2 */ OPERATION_GET_FIELD_BY_ID_UTF8,
+	/* V2 */ OPERATION_SET_FIELD_BY_NAME_UTF8,
+	/* V2 */ OPERATION_SET_FIELD_BY_NUM_UTF8,
+	/* V2 */ OPERATION_SET_FIELD_BY_ID_UTF8,
+	/* V2 */ OPERATION_SHOW_IMAGE_BY_NAME_UTF8,
+	/* V2 */ OPERATION_SHOW_IMAGE_BY_NUM_UTF8,
+	/* V2 */ OPERATION_SHOW_IMAGE_BY_ID_UTF8,
+	/* V2 */ OPERATION_GET_VARIABLE_UTF8,
+	/* V2 */ OPERATION_SET_VARIABLE_UTF8,
+	/* V2 */ OPERATION_GET_VARIABLE_EX_UTF8_TEXT,
+	/* V2 */ OPERATION_GET_VARIABLE_EX_UTF8_BINARY,
+	/* V2 */ OPERATION_SET_VARIABLE_EX_UTF8_TEXT,
+	/* V2 */ OPERATION_SET_VARIABLE_EX_UTF8_BINARY,
+	/* V2 */ OPERATION_GET_ARRAY_UTF8_TEXT,
+	/* V2 */ OPERATION_GET_ARRAY_UTF8_BINARY,
+	/* V2 */ OPERATION_SET_ARRAY_UTF8_TEXT,
+	/* V2 */ OPERATION_SET_ARRAY_UTF8_BINARY,
 };
 
 enum
@@ -79,9 +78,9 @@ enum
 	SECURITY_CHECK_LIBRARY,
     
     // SN-2014-07-04: [[ UnicodeExternalsV0 ]] Add security checks with unicode parameters
-	SECURITY_CHECK_FILE_UTF8,
-	SECURITY_CHECK_HOST_UTF8,
-	SECURITY_CHECK_LIBRARY_UTF8    
+	/* V2 */ SECURITY_CHECK_FILE_UTF8,
+	/* V2 */ SECURITY_CHECK_HOST_UTF8,
+	/* V2 */ SECURITY_CHECK_LIBRARY_UTF8
 };
 
 typedef char *(*ExternalOperationCallback)(const char *p_arg_1, const char *p_arg_2, const char *p_arg_3, int *r_success);
@@ -399,6 +398,37 @@ void RunloopWait(int *r_success)
 	}
 
 	t_result = (s_operations[OPERATION_RUNLOOP_WAIT])(NULL, NULL, NULL, &r_success);
+	if (t_result != NULL)
+		s_delete(t_result);
+}
+
+// IM-2014-07-09: [[ Bug 12225 ]] Add coordinate conversion functions
+void StackToWindowRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success)
+{
+    char *t_result;
+    
+    if (s_external_interface_version < 1)
+	{
+		*r_success = EXTERNAL_FAILURE;
+		return;
+	}
+    
+	t_result = (s_operations[OPERATION_STACK_TO_WINDOW_RECT])(p_win_id, x_rect, NULL, &r_success);
+	if (t_result != NULL)
+		s_delete(t_result);
+}
+
+void WindowToStackRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success)
+{
+	char *t_result;
+    
+	if (s_external_interface_version < 1)
+	{
+		*r_success = EXTERNAL_FAILURE;
+		return;
+	}
+    
+	t_result = (s_operations[OPERATION_WINDOW_TO_STACK_RECT])(p_win_id, x_rect, NULL, &r_success);
 	if (t_result != NULL)
 		s_delete(t_result);
 }
@@ -769,38 +799,6 @@ Bool SecurityCanAccessLibraryUTF8(const char *p_library)
 		return s_security_handlers[SECURITY_CHECK_LIBRARY_UTF8](p_library);
 	return True;
 }
-    
-    
-// IM-2014-07-09: [[ Bug 12225 ]] Add coordinate conversion functions
-void StackToWindowRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success)
-{
-    char *t_result;
-    
-    if (s_external_interface_version < 1)
-	{
-		*r_success = EXTERNAL_FAILURE;
-		return;
-	}
-    
-	t_result = (s_operations[OPERATION_STACK_TO_WINDOW_RECT])(p_win_id, x_rect, NULL, &r_success);
-	if (t_result != NULL)
-		s_delete(t_result);
-}
-
-void WindowToStackRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success)
-{
-	char *t_result;
-    
-	if (s_external_interface_version < 1)
-	{
-		*r_success = EXTERNAL_FAILURE;
-		return;
-	}
-    
-	t_result = (s_operations[OPERATION_WINDOW_TO_STACK_RECT])(p_win_id, x_rect, NULL, &r_success);
-	if (t_result != NULL)
-		s_delete(t_result);
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -821,6 +819,7 @@ static struct LibExport __libexports[] =
 {
 	{ "getXtable", getXtable },
 	{ "configureSecurity", configureSecurity },
+    { "setExternalInterfaceVersion", setExternalInterfaceVersion },
 	{ 0, 0 }
 };
 

--- a/revspeech/revspeech.vcproj
+++ b/revspeech/revspeech.vcproj
@@ -207,6 +207,14 @@
 			<File
 				RelativePath=".\src\w32sapi4speech.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					ExcludedFromBuild="true"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath=".\src\w32sapi5speech.cpp"

--- a/revspeech/revspeech.xcodeproj/project.pbxproj
+++ b/revspeech/revspeech.xcodeproj/project.pbxproj
@@ -31,6 +31,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4D7113541991129F00C1710F /* w32sapi4speech.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = w32sapi4speech.cpp; path = src/w32sapi4speech.cpp; sourceTree = "<group>"; };
+		4D7113551991129F00C1710F /* w32sapi4speech.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = w32sapi4speech.h; path = src/w32sapi4speech.h; sourceTree = "<group>"; };
+		4D7113561991129F00C1710F /* w32sapi5speech.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = w32sapi5speech.cpp; path = src/w32sapi5speech.cpp; sourceTree = "<group>"; };
+		4D7113571991129F00C1710F /* w32sapi5speech.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = w32sapi5speech.h; path = src/w32sapi5speech.h; sourceTree = "<group>"; };
+		4D7113581991129F00C1710F /* w32speech.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = w32speech.cpp; path = src/w32speech.cpp; sourceTree = "<group>"; };
 		E82D44A11713199700A10289 /* revspeech.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = revspeech.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		E82D44B217131A4800A10289 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../rules/Debug.xcconfig; sourceTree = "<group>"; };
 		E82D44B317131A4800A10289 /* Global.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Global.xcconfig; path = ../rules/Global.xcconfig; sourceTree = "<group>"; };
@@ -106,6 +111,11 @@
 		E82D44B917131B3500A10289 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				4D7113541991129F00C1710F /* w32sapi4speech.cpp */,
+				4D7113551991129F00C1710F /* w32sapi4speech.h */,
+				4D7113561991129F00C1710F /* w32sapi5speech.cpp */,
+				4D7113571991129F00C1710F /* w32sapi5speech.h */,
+				4D7113581991129F00C1710F /* w32speech.cpp */,
 				E82D44BA17131B4700A10289 /* osxspeech.cpp */,
 				E82D44BB17131B4700A10289 /* osxspeech.h */,
 				E82D44BC17131B4700A10289 /* revspeech.cpp */,

--- a/revspeech/src/osxspeech.cpp
+++ b/revspeech/src/osxspeech.cpp
@@ -64,7 +64,7 @@ bool OSXSpeechNarrator::Finalize(void)
 	return false;
 }
 
-bool OSXSpeechNarrator::Start(const char* p_string)
+bool OSXSpeechNarrator::Start(const char* p_string, bool p_is_utf8)
 {
 	if (SpeechStart(true) == false)
 	{
@@ -73,7 +73,7 @@ bool OSXSpeechNarrator::Start(const char* p_string)
     
     if (speechtext != nil)
         CFRelease(speechtext);
-    speechtext = CFStringCreateWithCString(kCFAllocatorDefault, p_string, kCFStringEncodingMacRoman);
+    speechtext = CFStringCreateWithCString(kCFAllocatorDefault, p_string, p_is_utf8 ? kCFStringEncodingUTF8 : kCFStringEncodingMacRoman);
 	SpeakCFString(spchannel, speechtext, nil);
 	return true;
 }

--- a/revspeech/src/osxspeech.cpp
+++ b/revspeech/src/osxspeech.cpp
@@ -39,7 +39,7 @@ OSXSpeechNarrator::OSXSpeechNarrator(void)
 {
 	spchannel = NULL;
 	strcpy(speechvoice, "empty");
-	speechbuffer = NULL;
+	speechtext = NULL;
 	speechspeed = 0;
 	speechpitch = 0;
 }
@@ -70,18 +70,11 @@ bool OSXSpeechNarrator::Start(const char* p_string)
 	{
 		return false;
 	}
-        
-	if (speechbuffer != nil)
-	{
-		if (spchannel != nil)
-			StopSpeech(spchannel);
-			
-		free(speechbuffer);
-        speechbuffer = nil;
-    }
-	
-	speechbuffer = strdup(p_string);
-	SpeakText(spchannel, speechbuffer, strlen(speechbuffer) + 1);
+    
+    if (speechtext != nil)
+        CFRelease(speechtext);
+    speechtext = CFStringCreateWithCString(kCFAllocatorDefault, p_string, kCFStringEncodingMacRoman);
+	SpeakCFString(spchannel, speechtext, nil);
 	return true;
 }
 
@@ -268,13 +261,14 @@ bool OSXSpeechNarrator::SpeechStop(bool ReleaseInit)
 	}
 	while(SpeechBusy() > 0);
 	
-       DisposeSpeechChannel(spchannel);
-       spchannel = nil;
-       if (speechbuffer != nil)
-	{
-           free(speechbuffer);
-           speechbuffer = nil;
-	}
+    DisposeSpeechChannel(spchannel);
+    spchannel = nil;
+    if (speechtext != nil)
+    {
+        CFRelease(speechtext);
+        speechtext = nil;
+    }
+    
    	return true;
 }
 

--- a/revspeech/src/osxspeech.h
+++ b/revspeech/src/osxspeech.h
@@ -32,7 +32,7 @@ public:
 	bool Initialize(void);
 	bool Finalize(void);
 	
-	bool Start(const char* p_string);
+	bool Start(const char* p_string, bool p_is_utf8);
 	bool Stop(void);
 	bool Busy(void);
 

--- a/revspeech/src/osxspeech.h
+++ b/revspeech/src/osxspeech.h
@@ -51,7 +51,7 @@ public:
 private:
 	SpeechChannel spchannel;
 	char speechvoice[255];
-	char *speechbuffer;
+    CFStringRef speechtext;
 	Fixed speechspeed, speechpitch;
 	
 	bool SpeechStart(bool StartInit);

--- a/revspeech/src/revspeech.cpp
+++ b/revspeech/src/revspeech.cpp
@@ -225,11 +225,31 @@ void revSpeechSpeak(char *args[], int nargs, char **retstring,
 	{
 		NarratorLoad();
 
-		s_narrator -> Start(args[0]);
+		s_narrator -> Start(args[0], false);
 	}
 	else
 		*error = True;
 
+	*retstring = result != NULL ? result : strdup("");
+}
+
+void revSpeechSpeakUTF8(char *args[], int nargs, char **retstring,
+                    Bool *pass, Bool *error)
+{
+	char *result = NULL;
+    
+	*pass = False;
+	*error = False;
+    
+	if (nargs == 1)
+	{
+		NarratorLoad();
+        
+		s_narrator -> Start(args[0], true);
+	}
+	else
+		*error = True;
+    
 	*retstring = result != NULL ? result : strdup("");
 }
 
@@ -465,7 +485,8 @@ EXTERNAL_BEGIN_DECLARATIONS("revSpeech")
 	EXTERNAL_DECLARE_COMMAND("revSetSpeechPitch", revSpeechPitch)
 	EXTERNAL_DECLARE_COMMAND("revSetSpeechVolume", revSpeechSetVolume)
 	EXTERNAL_DECLARE_FUNCTION("revGetSpeechVolume", revSpeechGetVolume)
-	EXTERNAL_DECLARE_COMMAND("revSpeak", revSpeechSpeak)
+    EXTERNAL_DECLARE_COMMAND("revSpeak", revSpeechSpeak)
+    EXTERNAL_DECLARE_COMMAND_UTF8("revSpeak", revSpeechSpeakUTF8)
 	EXTERNAL_DECLARE_COMMAND("revStopSpeech", revSpeechStop)
 	EXTERNAL_DECLARE_FUNCTION("revIsSpeaking", revSpeechBusy)
 	EXTERNAL_DECLARE_FUNCTION("revSpeechVoices", revSpeechVoices)

--- a/revspeech/src/revspeech.h
+++ b/revspeech/src/revspeech.h
@@ -43,7 +43,7 @@ public:
 	virtual bool Initialize(void) = 0;
 	virtual bool Finalize(void) = 0;
 
-	virtual bool Start(const char* p_string) = 0;
+	virtual bool Start(const char* p_string, bool p_is_utf8) = 0;
 
 #ifdef FEATURE_REVSPEAKTOFILE	
 	virtual bool SpeakToFile(const char* p_string, const char* p_file) = 0;

--- a/revspeech/src/w32sapi5speech.h
+++ b/revspeech/src/w32sapi5speech.h
@@ -40,7 +40,7 @@ public:
 	bool Finalize(void);
 	bool IsInited() {return bInited;}
 
-	bool Start(const char* p_string);
+	bool Start(const char* p_string, bool p_is_utf8);
 	bool SpeakToFile(const char* p_string, const char* p_file);
 	bool Stop(void);
 	bool Busy(void);

--- a/revspeech/src/w32speech.cpp
+++ b/revspeech/src/w32speech.cpp
@@ -23,6 +23,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 INarrator *InstantiateNarrator(NarratorProvider p_provider)
 {
+#ifdef OLD_SAPI
 	if (p_provider == kNarratorProviderDefault)
 	{
 		INarrator *t_narrator;
@@ -43,7 +44,8 @@ INarrator *InstantiateNarrator(NarratorProvider p_provider)
 	}
 	else if (p_provider == kNarratorProviderSAPI4)
 		return new WindowsSAPI4Narrator();
-	
+#endif
+
 	return new WindowsSAPI5Narrator();
 }
 


### PR DESCRIPTION
Externals API update to allow declarations of UTF8 compliant handlers in old-style externals (hopefully in a backward-compatible way!).
Updated Mac revSpeech by adding a UTF8 variant of revSpeak meaning that in 7.0 using 'revSpeak' will allow unicode text to pass through.
Updated Windows revSpeech to accept unicode.
