### PR TITLE
[[ Bugfix 13105 ]] Player: Make sure currenttimechanged message is sent ...

### DIFF
--- a/docs/notes/bugfix-13105.md
+++ b/docs/notes/bugfix-13105.md
@@ -1,0 +1,1 @@
+#  [[Player]] CurrentTimeChanged message not sent by 'step forward' or 'step backward' buttons 


### PR DESCRIPTION
...when stepping forward/backward
