### PR TITLE
[[ Bug 13038 ]] Use platform-specific methods of obtaining random bytes,...

### DIFF
--- a/docs/notes/bugfix-13038.md
+++ b/docs/notes/bugfix-13038.md
@@ -1,0 +1,1 @@
+# uuid: not enough randomness available

--- a/engine/engine.xcodeproj/project.pbxproj
+++ b/engine/engine.xcodeproj/project.pbxproj
@@ -325,7 +325,6 @@
 		4DAB7D280FF3A0100009F91E /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DAB7D270FF3A0100009F91E /* md5.cpp */; };
 		4DADCD5B12392EAF003CD17C /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DADCD5912392EAF003CD17C /* sha1.cpp */; };
 		4DADCDFD12393F55003CD17C /* Installer.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4DADCDFC12393F26003CD17C /* Installer.icns */; };
-		4DB32401174BEE1400046FFE /* sysunxrandom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB3222E174BD06200046FFE /* sysunxrandom.cpp */; };
 		4DB32402174BEE1900046FFE /* uuid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D8589AA173A856600B20951 /* uuid.cpp */; };
 		4DB32404174BEE3300046FFE /* sysosxrandom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB32230174BD08E00046FFE /* sysosxrandom.cpp */; };
 		4DB382EE1714418A00D3F102 /* libz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D6C797917134897000BCF78 /* libz.a */; };
@@ -527,6 +526,7 @@
 		E8AE876C177B3F5C0041B7E0 /* cgimageutil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8AE876B177B3F5C0041B7E0 /* cgimageutil.cpp */; };
 		E8AF465B174CF247000B2F9E /* surface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D4F9DFA13CDE63000B9B15D /* surface.cpp */; };
 		E8B5BB1416DF77DF00CA02FB /* imagelist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8B5BB1216DF77DF00CA02FB /* imagelist.cpp */; };
+		E8D1ECDD1992395A00984EFE /* sysosxrandom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB32230174BD08E00046FFE /* sysosxrandom.cpp */; };
 		E8D7F8321785A88200EC051A /* imagelist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8B5BB1216DF77DF00CA02FB /* imagelist.cpp */; };
 		E8D7F8391785A8AC00EC051A /* graphicscontext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C10D76D16BF9BFA00D25197 /* graphicscontext.cpp */; };
 		E8D7F8471785A99900EC051A /* srvtheme.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8D7F8461785A99900EC051A /* srvtheme.cpp */; };
@@ -3183,6 +3183,7 @@
 				4D1F9D28171C682E0091C6CB /* button.cpp in Sources */,
 				4D1F9D29171C682E0091C6CB /* card.cpp in Sources */,
 				4D1F9D2A171C682E0091C6CB /* cardlst.cpp in Sources */,
+				E8D1ECDD1992395A00984EFE /* sysosxrandom.cpp in Sources */,
 				4D1F9D2B171C682E0091C6CB /* cdata.cpp in Sources */,
 				4D1F9D2C171C682E0091C6CB /* chunk.cpp in Sources */,
 				4D1F9D2D171C682E0091C6CB /* cmds.cpp in Sources */,
@@ -3318,7 +3319,6 @@
 				4D1F9DB2171C682E0091C6CB /* irle.cpp in Sources */,
 				4D1F9DB3171C682E0091C6CB /* stackcache.cpp in Sources */,
 				4D1F9DB4171C682E0091C6CB /* stacksecurity.cpp in Sources */,
-				4DB32401174BEE1400046FFE /* sysunxrandom.cpp in Sources */,
 				4DB32402174BEE1900046FFE /* uuid.cpp in Sources */,
 				E8D7F8321785A88200EC051A /* imagelist.cpp in Sources */,
 				E8D7F8391785A8AC00EC051A /* graphicscontext.cpp in Sources */,

--- a/engine/src/sysosxrandom.cpp
+++ b/engine/src/sysosxrandom.cpp
@@ -21,8 +21,16 @@
 #include "filedefs.h"
 #include "objdefs.h"
 #include "parsedef.h"
+#include "globals.h"
 
-#include "mcssl.h"
+#include <Carbon/Carbon.h>
+
+typedef const struct __SecRandom * SecRandomRef;
+#define kSecRandomDefault (NULL)
+
+typedef int (*SecRandomCopyBytesPtr)(SecRandomRef p_rnd, size_t p_count, uint8_t *p_bytes);
+
+static SecRandomCopyBytesPtr s_sec_random_copy_bytes = nil;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -30,17 +38,9 @@
 //   Mac (Desktop and Server).
 bool MCS_random_bytes(size_t p_count, void *p_buffer)
 {
-	// On Mac (both Server and Desktop) OpenSSL is always available so we will
-	// never get here.
-	return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-// This is alternative code which doesn't rely on OpenSSL (not needed now, but
-// maybe in the future).
-#if 0
-{
+	// IM-2014-08-06: [[ Bug 13038 ]] Enable this implementation on OSX + server
+	// so we can remove the reliance on SSL from MCU_random_bytes
+	
 	// Now, on Lion and above SecRandomCopyBytes is available, so use that if
 	// possible. ( Note that as we can't link against the 10.7 SDK, we have to
 	// weak-link manually :( ).
@@ -49,17 +49,18 @@ bool MCS_random_bytes(size_t p_count, void *p_buffer)
 		if (s_sec_random_copy_bytes == nil)
 		{
 			CFBundleRef t_security_bundle;
-			t_security_bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.Security"));
+			t_security_bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.security"));
 			if (t_security_bundle != nil)
 			{
-				s_sec_random_copy_bytes = (SecRandomCopyBytesPtr)CFBundleGetFunctionPointerForName(t_security_bundle, CFSTR("SetRandomCopyBytes"));
+				s_sec_random_copy_bytes = (SecRandomCopyBytesPtr)CFBundleGetFunctionPointerForName(t_security_bundle, CFSTR("SecRandomCopyBytes"));
 				CFRelease(t_security_bundle);
 			}
 		}
 		
 		if (s_sec_random_copy_bytes != nil)
-			return s_sec_random_copy_bytes(NULL, p_count, (uint8_t *)p_buffer);
-			}
+			// IM-2014-04-16: [[ Bug 11860 ]] SecRandomCopyBytes returns 0 on success
+			return 0 == s_sec_random_copy_bytes(NULL, p_count, (uint8_t *)p_buffer);
+	}
 	
 	// Otherwise attempt to use /dev/urandom
 	int t_fd;
@@ -96,6 +97,5 @@ bool MCS_random_bytes(size_t p_count, void *p_buffer)
 	// If we read the correct number of bytes, then we are done.
 	return t_bytes_read == p_count;
 }
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -40,10 +40,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "globals.h"
 
-#ifdef MCSSL
-#include <openssl/rand.h>
-#endif
-
 #define QA_NPOINTS 10
 
 static MCPoint qa_points[QA_NPOINTS];
@@ -2868,22 +2864,11 @@ bool MCU_compare_strings_native(const char *p_a, bool p_a_isunicode, const char 
 
 ///////////////////////////////////////////////////////////////////////////////
 
-// MW-2013-05-21: [[ RandomBytes ]] Utility function for generating random bytes
-//   which uses OpenSSL if available, otherwise falls back on system support.
+// MW-2013-05-21: [[ RandomBytes ]] Utility function for generating random bytes.
 bool MCU_random_bytes(size_t p_count, void *p_buffer)
 {
-#ifdef MCSSL
-	// If SSL is available, then use that.
-	static bool s_donotuse_ssl = false;
-	if (!s_donotuse_ssl)
-	{
-		if (InitSSLCrypt())
-			return RAND_bytes((unsigned char *)p_buffer, p_count) == 1;
-		
-		s_donotuse_ssl = true;
-	}
-#endif
-
-	// Otherwise use the system provided CPRNG.
+	// IM-2014-08-06: [[ Bug 13038 ]] Use system implementation directly instead of SSL
 	return MCS_random_bytes(p_count, p_buffer);
 }
+
+///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
... rather than rely on SSL
