### PR TITLE
[[ Bugfix 13099 ]] Make sure redrawcontroller() is called before current...

### DIFF
--- a/docs/notes/bugfix-13099.md
+++ b/docs/notes/bugfix-13099.md
@@ -1,0 +1,1 @@
+#   [Player] Playback is locked when alwaysBuffer is true and video is playing

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -2143,12 +2143,15 @@ void MCPlayer::currenttimechanged(void)
         setselection(true);
     }
     
+    // FG-2014-08-14: [[ Bug 13099 ]] redrawcontroller () should be called before currenttimechanged message is sent, or else player becomes unresponsive if alwaysbuffer is true
+    redrawcontroller();
+    
     // PM-2014-05-26: [[Bug 12512]] Make sure we pass the param to the currenttimechanged message
     MCParameter t_param;
     t_param . setn_argument(getmoviecurtime());
     timer(MCM_current_time_changed, &t_param);
     
-    redrawcontroller();
+
 }
 
 void MCPlayer::moviefinished(void)


### PR DESCRIPTION
...timechanged message is sent,

 or else player becomes unresponsive if alwaysbuffer is true
