### PR TITLE
[[ Bug 13193 ]] Nil check in MCAVFoundationPlayer::SeekToTimeAndWait met...

### DIFF
--- a/docs/notes/bugfix-13193.md
+++ b/docs/notes/bugfix-13193.md
@@ -1,0 +1,1 @@
+#   [[ Player ]] LC hangs when you open a stack with a player with filename that does not exist

--- a/engine/src/mac-av-player.mm
+++ b/engine/src/mac-av-player.mm
@@ -408,6 +408,10 @@ void MCAVFoundationPlayer::Switch(bool p_new_offscreen)
 
 void MCAVFoundationPlayer::SeekToTimeAndWait(uint32_t p_time)
 {
+    // PM-2014-08-15: [[ Bug 13193 ]] Do this check to prevent LC hanging if filename is invalid the very first time you open a stack with a player object
+    if (m_player == nil || m_player.currentItem == nil)
+        return;
+    
     __block bool t_is_finished = false;
     [[m_player currentItem] seekToTime:CMTimeFromLCTime(p_time) toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero completionHandler:^(BOOL finished) {
         t_is_finished = true;


### PR DESCRIPTION
...hod to prevent LC hanging when playerItem is nil
