### PR TITLE
[[ Bug 13220 ]] Make sure we give Cairo a minimal path - if lineTo is fo...

### DIFF
--- a/docs/notes/bugfix-13220.md
+++ b/docs/notes/bugfix-13220.md
@@ -1,0 +1,1 @@
+# Polyline with same starting point as ending point draws as degenerate dot in PDF printing.


### PR DESCRIPTION
...llowed by close and lineTo target is original moveTo of subpath, then ignore the last lineTo.
