### PR TITLE
[[ Bug 13137 ]] Make currentTimeChanged messages 'pending' and only have...

### DIFF
--- a/docs/notes/bugfix-13137.md
+++ b/docs/notes/bugfix-13137.md
@@ -1,0 +1,1 @@
+# Setting currentTime of a player in response to a currentTimeChanged message can cause a hang.

--- a/engine/src/objdefs.h
+++ b/engine/src/objdefs.h
@@ -448,6 +448,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define CS_PAUSED               (1UL << 15)
 #define CS_CLOSING              (1UL << 16)
 #define CS_EXTERNAL_CONTROLLER	(1UL << 17)
+#define CS_CTC_PENDING          (1UL << 18)
 // MCGroup state
 #define CS_NEED_UPDATE          (1UL << 13)
 // Uses CS_HSCROLL 14

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -886,7 +886,14 @@ void MCPlayer::timer(MCNameRef mptr, MCParameter *params)
     }
     else if (MCNameIsEqualTo(mptr, MCM_current_time_changed, kMCCompareCaseless))
     {
-        state &= ~CS_CTC_PENDING;
+        // If params is nil then this did not originate from the player!
+        if (params != nil)
+        {
+            // Update the current time in the parameter and make sure we allow another
+            // currentTimeChanged message to be posted.
+            state &= ~CS_CTC_PENDING;
+            params -> setn_argument(getmoviecurtime());
+        }
     }
     else if (MCNameIsEqualTo(mptr, MCM_internal, kMCCompareCaseless))
     {


### PR DESCRIPTION
... one pending at any one time for a given player.
