### PR TITLE
[[ Bug 13186 ]] Ensure strings don't get permanently converted to UTF-16...

### DIFF
--- a/docs/notes/bugfix-13186.md
+++ b/docs/notes/bugfix-13186.md
@@ -1,0 +1,1 @@
+# Name comparison failure when using menuPick from tab panel

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -452,7 +452,13 @@ void MCFontDrawTextSubstring(MCGContextRef p_gcontext, coord_t x, int32_t y, MCS
     if (p_can_break)
         MCFontBreakText(p_font, p_text, p_range, (MCFontBreakTextCallback)MCFontDrawTextCallback, &ctxt, p_rtl);
     else
-        MCFontDrawTextCallback(p_font, p_text, p_range, &ctxt);
+    {
+        // AL-2014-08-20: [[ Bug 13186 ]] Ensure strings which skip go through the breaking algorithm
+        //  don't get permanently converted to UTF-16 when drawn
+        MCAutoStringRef t_temp;
+        /* UNCHECKED */ MCStringMutableCopy(p_text, &t_temp);
+        MCFontDrawTextCallback(p_font, *t_temp, p_range, &ctxt);
+    }
 }
 
 MCFontStyle MCFontStyleFromTextStyle(uint2 p_text_style)

--- a/engine/src/regex.cpp
+++ b/engine/src/regex.cpp
@@ -217,8 +217,12 @@ int regcomp(regex_t *preg, MCStringRef pattern, int cflags)
     if ((cflags & REG_NEWLINE) != 0)
 		options |= PCRE_MULTILINE;
 
+    // AL-2014-08-20: [[ Bug 13186 ]] Ensure pattern string doesn't get permanently converted to UTF-16
+    MCAutoStringRef t_temp;
+    /* UNCHECKED */ MCStringMutableCopy(pattern, &t_temp);
+    
     // SN-2014-01-14: [[ libpcre update ]]
-    preg->re_pcre = pcre16_compile((PCRE_SPTR16)MCStringGetCharPtr(pattern), options, &errorptr, &erroffset, NULL);
+    preg->re_pcre = pcre16_compile((PCRE_SPTR16)MCStringGetCharPtr(*t_temp), options, &errorptr, &erroffset, NULL);
 	preg->re_erroffset = erroffset;
 
 	if (preg->re_pcre == NULL)


### PR DESCRIPTION
... when char ptr is required
