### PR TITLE
[[ Bug 13328 ]] Setting menuhistory crashes in 7.0, and send menuPick wi...

### DIFF
--- a/docs/notes/bugfix-13328.md
+++ b/docs/notes/bugfix-13328.md
@@ -1,0 +1,1 @@
+# Setting menuhistory with a stack panel sends invalid menuPick second parameter

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -4128,7 +4128,12 @@ void MCButton::setmenuhistory(int2 newline)
 			MCU_break_string(MCString(menustring, menusize), tabs, ntabs, hasunicode());
 		uint2 oldline = menuhistory;
 		setmenuhistoryprop(MCU_max(MCU_min(newline, ntabs), 1));
-		if (menuhistory != oldline && !(state & CS_MFOCUSED) && tabs != NULL)
+        
+        // SN-2014-09-03: [[ Bug 13328 ]] menupick should no be sent if there is a
+        // menuname: the oldline belongs to the panel stack, and certainly doesn't match
+        // the menustring of this button. At least, it would set a bad label, at worst,
+        // it gives garbage (and crashes in 7.0)
+		if (menuname == NULL && menuhistory != oldline && !(state & CS_MFOCUSED) && tabs != NULL)
 			message_with_args(MCM_menu_pick, tabs[menuhistory - 1], tabs[oldline - 1]);
 		resetlabel();
 		if (!(getstyleint(flags) == F_MENU && menumode == WM_TOP_LEVEL) || !opened)


### PR DESCRIPTION
...th garbage as second parameter
