### PR TITLE
[[ Bug 13222 ]] Use layer_setrect() to ensure old effective rect is inva...

### DIFF
--- a/docs/notes/bugfix-13222.md
+++ b/docs/notes/bugfix-13222.md
@@ -1,0 +1,1 @@
+# Moving graphic while editing gradient causes artifacts

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -539,11 +539,12 @@ void MCSellist::continuemove(int2 x, int2 y)
 		}
 		if (cptr->moveable())
 		{
-			MCRectangle t_old_rect;
-			t_old_rect = cptr -> getrect();
-			cptr->setrect(trect);
-			if (!cptr->resizeparent())
-				cptr -> layer_rectchanged(t_old_rect, false);
+			// IM-2014-09-09: [[ Bug 13222 ]] Use the layer_setrect method to ensure the old
+			// effectiverect is appropriately dirtied when edittools are displayed for a graphic
+			if (cptr->resizeparent())
+				cptr->setrect(trect);
+			else
+				cptr->layer_setrect(trect, false);
 		}
 		tptr = tptr->next();
 	}


### PR DESCRIPTION
...lidated when moving controls
