### PR TITLE
[[ Bug 13356 ]] empty is among list of items with trailing comma should ...

### DIFF
--- a/docs/notes/bugfix-13356.md
+++ b/docs/notes/bugfix-13356.md
@@ -1,0 +1,1 @@
+# empty not among the items of a list with a trailing comma

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -5819,6 +5819,11 @@ bool MCTextChunkIterator::isamong(MCExecContext& ctxt, MCStringRef p_needle)
         if (MCStringSubstringIsEqualTo(text, range, p_needle, ctxt . GetStringComparisonType()))
             return true;
     
+    // AL-2014-09-10: [[ Bug 13356 ]] If we were not 'exhausted', then there was a trailing delimiter
+    //  which means empty is considered to be among the chunks.
+    if (MCStringIsEmpty(p_needle) && !exhausted)
+        return true;
+    
     return false;
 }
 


### PR DESCRIPTION
...return true
