### PR TITLE
[[ Bug 13348 ]] RawkeyUp and Key up are sent twice in LC7 RC1

### DIFF
--- a/docs/notes/bugfix-13348.md
+++ b/docs/notes/bugfix-13348.md
@@ -1,0 +1,1 @@
+RawKeyUp and KeyUp are sent twice in LC 7

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -614,7 +614,11 @@ Boolean MCObject::kup(MCStringRef p_string, KeySym key)
 	// OK-2010-04-01: [[Bug 6215]] - Need to also check for arrow keys here using the KeySym
 	//   as they don't have an ascii code.
 	// TODO: filter out the C1 control codes too
-	if (key >= 32 && key != 127 && key != XK_Left && key != XK_Right && key != XK_Up && key != XK_Down)
+	// SN-2014-09-10: [[ Bug 13348 ]] We need to take in consideration what is in the string, not the
+	// key typed
+	unichar_t t_char;
+	t_char = MCStringGetCharAtIndex(p_string, 0);
+	if (t_char >= 32 && t_char != 127 && key != XK_Left && key != XK_Right && key != XK_Up && key != XK_Down)
 		if (message_with_valueref_args(MCM_key_up, p_string) == ES_NORMAL)
 			return True;
 	return False;

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -144,9 +144,21 @@ void CALLBACK mouseproc(UINT id, UINT msg, DWORD user, DWORD dw1, DWORD dw2)
 	PostMessageA(pms->getinvisiblewindow(), WM_APP, 0, 0);
 }
 
+// SN-2014-09-10: [[ Bug 13348 ]] We need to know what was intended (key down or key up)
+// when WM_[SYS|IME_]CHAR is triggered (it seems like WM_KEYUP events are only translated 
+// to WM_CHAR when the key is kept pressed).
+enum KeyMove
+{
+	KM_KEY_DOWN,
+	KM_KEY_UP,
+	KM_NO_KEY_MOVE
+};
+
 typedef struct
 {
 	Boolean dispatch, abort, reset, handled, live;
+	// SN-2014-09-10: [[ Bug 13348 ]] KeyMove added to the stateinfo of the event
+	KeyMove keymove;
 	KeySym keysym;
 }
 stateinfo;
@@ -262,6 +274,8 @@ Boolean MCScreenDC::handle(real8 sleep, Boolean dispatch, Boolean anyevent,
 	curinfo->handled = False;
 	curinfo->keysym = 0;
 	curinfo->live = True;
+	// SN-2014-09-10: [[ Bug 13348 ]] No key move by default
+	curinfo->keymove = KM_NO_KEY_MOVE;
 	if (mousewheel == 0)
 		mousewheel = RegisterWindowMessageW(MSH_MOUSEWHEEL);
 	if (dispatch && pendingevents != NULL
@@ -293,7 +307,21 @@ Boolean MCScreenDC::handle(real8 sleep, Boolean dispatch, Boolean anyevent,
 				        || msg.message == WM_KEYUP || msg.message == WM_SYSKEYUP)
 					curinfo->keysym = getkeysym(msg.wParam, msg.lParam);
 				
+				// SN-2014-09-10: [[ Bug 13348 ]] Set the key move appropriately
+				if (msg.message == WM_KEYUP || msg.message == WM_SYSKEYUP)
+					curinfo->keymove = KM_KEY_UP;
+				else if (msg.message == WM_KEYDOWN || msg.message == WM_SYSKEYDOWN)
+					curinfo->keymove = KM_KEY_DOWN;
+
                 TranslateMessage(&msg);
+
+				// SN-2014-09-05: [[ Bug 13348 ]] Remove the WM_KEYDOWN, WM_SYSKEYDOWN messages
+				// in case TranslateMessage succeeded, and queued a WM_[SYS]CHAR message
+				bool t_cleaned_queue;
+				t_cleaned_queue = PeekMessageW(&msg, NULL, WM_CHAR, WM_DEADCHAR, PM_REMOVE);				
+				if (!t_cleaned_queue)
+					t_cleaned_queue = PeekMessageW(&msg, NULL, WM_SYSCHAR, WM_SYSDEADCHAR, PM_REMOVE);
+
 				DispatchMessageW(&msg);
 			}
 		}
@@ -313,8 +341,9 @@ static stateinfo dummycurinfo;
 static HWND capturehwnd;
 static uint2 lastdown;
 static Boolean doubledown;
-static char lastchar;
-static WPARAM lastwParam;
+// SN-2014-09-10: [[ Bug 13348 ]] We want to keep the last codepoint now, 
+// not the last char
+static uint32_t lastcodepoint;
 static KeySym lastkeysym;
 static Boolean doubleclick;
 Boolean tripleclick;
@@ -661,18 +690,20 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 			pms->appendevent(tptr);
 			break;
 		}
+
+		// SN-2014-09-10: [[ Bug 13348 ]] The keysym is got as for the WM_KEYDOWN case
+		if (curinfo->keysym == 0) // event came from some other dispatch
+			keysym = pms->getkeysym(wParam, lParam);
+		else
+			keysym = curinfo->keysym;
+
+		lastkeysym = keysym;
 		
 		// UTF-16 or ANSI character has been received
 		WCHAR t_char;
 		t_char = LOWORD(wParam);
 
-		lastchar = wParam;
-
 		MCAutoStringRef t_input;
-
-		// No need to send control characters as text
-		if (iswcntrl(t_char))
-			break;
 
 		// MW-2010-11-17: [[ Bug 3892 ]] Ctrl+Alt can be the same as AltGr.
 		//   If we have Ctrl+Alt set, we discard the modifiers
@@ -710,8 +741,18 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		// Translate the input character into its corresponding keysym
 		// TODO: surrogate pairs?
 		codepoint_t t_codepoint = MCStringGetCodepointAtIndex(*t_input, 0);
+		// SN-2014-09-10: [[ Bug 13348 ]] Only add the codepoint if it is not a control char
+		if (iswcntrl(t_codepoint))
+			lastcodepoint = 0;
+		else	
+			lastcodepoint = t_codepoint;
+
 		KeySym t_keysym;
-		if (t_codepoint > 0x7F)
+
+		// No need to send control characters as text
+		if (iswcntrl(t_char))
+			t_keysym = keysym;
+		else if (t_codepoint > 0x7F)
 		{
 			// This is a non-ASCII codepoint
 			t_keysym = t_codepoint | XK_Class_codepoint;
@@ -726,11 +767,14 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		{
 			// Submit the character as both text and a key stroke
 			uint16_t count = LOWORD(lParam);
+
 			while (count--)
 			{
-				// Key down and key up
-				MCdispatcher->wkdown(dw, *t_input, t_keysym);
-				MCdispatcher->wkup(dw, *t_input, t_keysym);
+				// SN-2014-09-05: [[ Bug 13348 ]] Call the appropriate message
+				if (curinfo->keymove == KM_KEY_DOWN)
+					MCdispatcher->wkdown(dw, *t_input, t_keysym);
+				else // curinfo->eventtype == ET_KEY_UP
+  					MCdispatcher->wkup(dw, *t_input, t_keysym);
 			}
 
 			curinfo->handled = curinfo->reset = true;
@@ -760,9 +804,6 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 				else
 					MCinterrupt = True;
 			}
-			else
-				if (msg == WM_KEYDOWN)
-					buffer[0] = lastchar = wParam;
 
 		if (curinfo->dispatch)
 		{
@@ -801,6 +842,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		}
 	}
 	break;
+
 	case WM_KEYUP:
 	case WM_SYSKEYUP:
 	{	
@@ -809,13 +851,34 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		else
 			keysym = curinfo->keysym;
 
+		// SN-2014-09-10: [[ Bug 13348 ]] We want to get the last codepoint translated, if any,
+		// since the KEYUP events are not translated (but when keeping pressed a key)
+		MCAutoStringRef t_string;
+
+		if (lastkeysym == keysym)
+		{
+			unichar_t t_pair[2];
+			uindex_t t_char_count;
+			
+			t_char_count = MCStringCodepointToSurrogates(lastcodepoint, t_pair);
+			/* UNCHECKED */ MCStringCreateWithChars(t_pair, t_char_count, &t_string);
+		}
+		else
+		{
+			lastkeysym = keysym;
+			lastcodepoint = 0;
+			t_string = kMCEmptyString;
+		}
+
 		if (curinfo->dispatch)
 		{
 			if (MCtracewindow == DNULL || hwnd != (HWND)MCtracewindow->handle.window)
 			{
 				// Character messages handle the text keyup themselves
 				MCeventtime = GetMessageTime(); //krevent->time;
-				MCdispatcher->wkup(dw, kMCEmptyString, keysym);
+				// SN-2014-09-10: [[ Bug 13348 ]] Send the string we could build from the last
+				// codepoint.
+				MCdispatcher->wkup(dw, *t_string, keysym);
 				curinfo->handled = curinfo->reset = True;
 			}
 		}


### PR DESCRIPTION
The bugfix also fixes the fact [Raw]KeyUp is sent continuously when a key is kept pressed (that's something going on Windows on the 6.x engine)
