### PR TITLE
[[ Bug 13374 ]] LC hangs when setting the text of the field having a HGR...

### DIFF
--- a/docs/notes/bugfix-13374.md
+++ b/docs/notes/bugfix-13374.md
@@ -1,0 +1,1 @@
+LiveCode hangs when setting the text of a field with HGRID and a hidden last line

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -1021,14 +1021,18 @@ void MCField::drawrect(MCDC *dc, const MCRectangle &dirty)
 		{
 			setforeground(dc, DI_BORDER, False);
 			
-			int32_t cy;
-			cy = y + pgheight;
-			while(cy < grect . y + grect . height)
-			{
-				if (y >= grect . y)
-					dc -> drawline(grect . x, cy, grect . x + grect . width, cy);
-				cy += pgheight;
-			}
+            // SN-2014-09-10: [[ Bug 13374 ]] If the last line is hidden, the we take the field's lineheight.
+            if (pgheight == 0)
+                pgheight = fixedheight;
+            
+            int32_t cy;
+            cy = y + pgheight;
+            while(cy < grect . y + grect . height)
+            {
+                if (y >= grect . y)
+                    dc -> drawline(grect . x, cy, grect . x + grect . width, cy);
+                cy += pgheight;
+            }
 		}
 		
 		// MW-2012-03-15: [[ Bug 10069 ]] If we have vGrid set on the field, then render grid lines


### PR DESCRIPTION
...ID and a hidden last line.
