### PR TITLE
Send the URL related messages on all platforms, not just desktop

### DIFF
--- a/docs/notes/bugfix-13378.md
+++ b/docs/notes/bugfix-13378.md
@@ -1,0 +1,1 @@
+# 'get' causes a crash on server

--- a/engine/src/dskspec.cpp
+++ b/engine/src/dskspec.cpp
@@ -29,13 +29,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "osspec.h"
 
 void MCS_deleteurl(MCObject *p_target, MCStringRef p_url)
+// SJT-2014-09-10: [[ URLMessages ]] Send "deleteURL" messages on all platforms.
 {
-	Boolean oldlock = MClockmessages;
-	MClockmessages = False;
-	MCParameter p1;
-	p1 . setvalueref_argument(p_url);
-	p_target -> message(MCM_delete_url, &p1, False, True);
-	MClockmessages = oldlock;
+  // Should have been processed via the "deleteURL" message.
 }
 
 void MCS_loadurl(MCObject *p_target, MCStringRef p_url, MCNameRef p_message)
@@ -57,36 +53,21 @@ void MCS_unloadurl(MCObject *p_target, MCStringRef p_url)
 }
 
 void MCS_posttourl(MCObject *p_target, MCDataRef p_data, MCStringRef p_url)
+// SJT-2014-09-11: [[ URLMessages ]] Send "postURL" messages on all platforms.
 {
-	MCParameter p1;
-	p1 . setvalueref_argument(p_data);
-	MCParameter p2;
-	p2 . setvalueref_argument(p_url);
-	p1.setnext(&p2);
-	p_target -> message(MCM_post_url, &p1, False, True);
+  // Should have been processed via the "postURL" message.
 }
 
 void MCS_putintourl(MCObject *p_target, MCDataRef p_data, MCStringRef p_url)
+// SJT-2014-09-10: [[ URLMessages ]] Send "putURL" messages on all platforms.
 {
-	Boolean oldlock = MClockmessages;
-	MClockmessages = False;
-	MCParameter p1;
-	p1 . setvalueref_argument(p_data);
-	MCParameter p2;
-	p2 . setvalueref_argument(p_url);
-	p1.setnext(&p2);
-	p_target -> message(MCM_put_url, &p1, False, True);
-	MClockmessages = oldlock;
+  // Should have been processed via the "putURL" message.
 }
 
 void MCS_geturl(MCObject *p_target, MCStringRef p_url)
+// SJT-2014-09-10: [[ URLMessages ]] Send "getURL" messages on all platforms.
 {
-	Boolean oldlock = MClockmessages;
-	MClockmessages = False;
-	MCParameter p1;
-	p1 . setvalueref_argument(p_url);
-	p_target -> message(MCM_get_url, &p1, True, True);
-	MClockmessages = oldlock;
+  // Should have been processed via the "getURL" message.
 }
 
 void MCS_set_errormode(MCSErrorMode mode)

--- a/engine/src/dskspec.cpp
+++ b/engine/src/dskspec.cpp
@@ -35,21 +35,15 @@ void MCS_deleteurl(MCObject *p_target, MCStringRef p_url)
 }
 
 void MCS_loadurl(MCObject *p_target, MCStringRef p_url, MCNameRef p_message)
+// SJT-2014-09-11: [[ URLMessages ]] Send "loadURL" messages on all platforms.
 {
-	MCParameter p1;
-	p1 . setvalueref_argument(p_url);
-	MCParameter p2;
-	p2 . setvalueref_argument(p_message);
-	p1.setnext(&p2);
-	// MW-2006-03-03: I've changed this from False, True to True, True to ensure 'target' is returned correctly for libURL.
-	p_target -> message(MCM_load_url, &p1, True, True);
+  // Should have been processed via the "loadURL" message.
 }
 
 void MCS_unloadurl(MCObject *p_target, MCStringRef p_url)
+// SJT-2014-09-11: [[ URLMessages ]] Send "unloadURL" messages on all platforms.
 {
-	MCParameter p1;
-	p1 . setvalueref_argument(p_url);
-	p_target -> message(MCM_unload_url, &p1, False, True);
+  // Should have been processed via the "unloadURL" message.
 }
 
 void MCS_posttourl(MCObject *p_target, MCDataRef p_data, MCStringRef p_url)

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -373,13 +373,59 @@ void MCNetworkEvalHTTPProxyForURLWithPAC(MCExecContext& ctxt, MCStringRef p_url,
 ////////////////////////////////////////////////////////////////////////////////
 
 void MCNetworkExecLoadUrl(MCExecContext& ctxt, MCStringRef p_url, MCNameRef p_message)
+// SJT-2014-09-11: [[ URLMessages ]] Send "loadURL" messages on all platforms.
 {
-	MCS_loadurl(ctxt . GetObject(), p_url, p_message);
+  // Send "loadURL" message.
+	MCParameter p1;
+	p1 . setvalueref_argument(p_url);
+	MCParameter p2;
+	p2 . setvalueref_argument(p_message);
+	p1.setnext(&p2);
+	// MW-2006-03-03: I've changed this from False, True to True, True to ensure 'target' is returned correctly for libURL.
+  Exec_stat t_stat = ctxt . GetObject() -> message(MCM_load_url, &p1, True, True);
+	
+	switch (t_stat)
+	{
+  case ES_NOT_HANDLED:
+  case ES_PASS:
+    // Either there was no message handler, or the handler passed the message,
+    // so process the URL in the engine.
+    MCS_loadurl(ctxt . GetObject(), p_url, p_message);
+    break;
+
+  case ES_ERROR:
+    ctxt . Throw();
+    break;
+    
+  default:
+    break;
+  }
 }
 
 void MCNetworkExecUnloadUrl(MCExecContext& ctxt, MCStringRef p_url)
+// SJT-2014-09-11: [[ URLMessages ]] Send "unloadURL" messages on all platforms.
 {
-	MCS_unloadurl(ctxt . GetObject(), p_url);
+  // Send "unloadURL" message.
+	MCParameter p1;
+	p1 . setvalueref_argument(p_url);
+  Exec_stat t_stat = ctxt . GetObject() -> message(MCM_unload_url, &p1, False, True);
+	
+	switch (t_stat)
+	{
+  case ES_NOT_HANDLED:
+  case ES_PASS:
+    // Either there was no message handler, or the handler passed the message,
+    // so process the URL in the engine.
+    MCS_unloadurl(ctxt . GetObject(), p_url);
+    break;
+
+  case ES_ERROR:
+    ctxt . Throw();
+    break;
+    
+  default:
+    break;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -38,6 +38,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "debug.h"
 #include "param.h"
 
+// SN-2014-09-05: [[ Bug 13378 ]] Include the definition of MCServerScript
+#ifdef _SERVER
+#include "srvscript.h"
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCExecContext::ForceToString(MCValueRef p_value, MCStringRef& r_string)
@@ -1089,10 +1094,11 @@ MCVarref* MCExecContext::GetIt() const
     if (m_curhandler != nil)
         return m_curhandler -> getit();
 
-#ifdef MODE_SERVER
+    // SN-2014-09-05: [[ Bug 13378 ]] Changed the #ifdef to be _SERVER, and updated the member name
+#ifdef _SERVER
     // If we are here it means we must be in global scope, executing in a
     // MCServerScript object.
-    return static_cast<MCServerScript *>(m_curobj) -> getit();
+    return static_cast<MCServerScript *>(m_object) -> GetIt();
 #else
     // We should never get here as execution only occurs within handlers unless
     // in server mode.

--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -124,6 +124,12 @@ uint4 MCServerScript::FindFileIndex(MCStringRef p_filename, bool p_add)
 	return t_file -> index;
 }
 
+// SN-2014-09-05: [[ Bug 13378 ]] Added forgotten function GetIt
+MCVarref* MCServerScript::GetIt()
+{
+    return m_it;
+}
+
 MCServerScript::File *MCServerScript::FindFile(MCStringRef p_filename, bool p_add)
 {
 	// First resolve the filename.

--- a/engine/src/srvscript.h
+++ b/engine/src/srvscript.h
@@ -45,6 +45,9 @@ public:
 	// Lookup the file index for the given filename. If <p_add> is true then
 	// add new entry and return its index.
 	uint4 FindFileIndex(MCStringRef p_filename, bool p_add);
+    
+    // SN-2014-09-05: [[ Bug 13378 ]] Added forgotten function GetIt
+    MCVarref* GetIt();
 	
 private:
 	// A File record stores information about an included file.


### PR DESCRIPTION
Send the `getURL`, `putURL`, `deleteURL`, `postURL`, `loadURL` and `unloadURL` messages on all platforms, not just desktop.

Merge after runrev/livecode#1132, as that was required to fix a crash when doing a post.
