### PR TITLE
[[ Bug 13442 ]] Make sure rawKeyDown for arrowKey up and down does not f...

### DIFF
--- a/docs/notes/bugfix-13442.md
+++ b/docs/notes/bugfix-13442.md
@@ -1,0 +1,1 @@
+#     rawKeyDown for arrowKey up and down fires twice when holding altKey down

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -868,6 +868,8 @@ static void map_key_event(NSEvent *event, MCPlatformKeyCode& r_key_code, codepoi
 	{
 		[self handleKeyPress: m_input_method_event isDown: YES];
 		[self handleKeyPress: m_input_method_event isDown: NO];
+        // PM-2014-09-15: [[ Bug 13442 ]] Set m_input_method_event to nil to prevent rawKeyDown from firing twice when altKey is down
+        m_input_method_event = nil;
 	}
 	else
 	{


### PR DESCRIPTION
...ire twice when holding altKey down
