### PR TITLE
[[ Bug 13454 ]] Delete created handler parameter variables before deleti...

### DIFF
--- a/docs/notes/bugfix-13454.md
+++ b/docs/notes/bugfix-13454.md
@@ -1,0 +1,1 @@
+# Memory leaks in handler parameter creation

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -367,7 +367,12 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 	if (err)
 	{
 		while (i--)
+        {
+            // AL-2014-09-16: [[ Bug 13454 ]] Delete created variables before deleting containers to prevent memory leak
+            if (i >= npnames || !pinfo[i].is_reference)
+				delete newparams[i] -> getvar();
             delete newparams[i];
+        }
 		delete newparams;
 		MCeerror->add(EE_HANDLER_BADPARAM, firstline - 1, 1, name);
 		return ES_ERROR;
@@ -495,7 +500,12 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
         // AL-2014-08-20: [[ ArrayElementRefParams ]] A container is always created for each parameter,
         //  so delete them all when the handler has finished executing
 		while (i--)
+        {
+            // AL-2014-09-16: [[ Bug 13454 ]] Delete created variables before deleting containers to prevent memory leak
+            if (i >= npnames || !pinfo[i].is_reference)
+				delete params[i] -> getvar();
             delete params[i];
+        }
 		delete params;
 	}
 	if (vars != NULL)


### PR DESCRIPTION
...ng their containers to prevent memory leak
