### PR TITLE
[[ Bug 13461 ]] Ensure that sorting the lines of a field preserve their ...

### DIFF
--- a/docs/notes/bugfix-13461.md
+++ b/docs/notes/bugfix-13461.md
@@ -1,0 +1,1 @@
+# sort removes textColor in 7.0 RC1

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -62,8 +62,14 @@ Exec_stat MCField::sort(MCExecContext &ctxt, uint4 parid, Chunk_term type,
 {
 	if (flags & F_SHARED_TEXT)
 		parid = 0;
+    
+    // SN-2014-09-17: [[ Bug 13461 ]] We might get CT_FIELD as a chunk type.
+    if (type == CT_FIELD)
+        type = CT_PARAGRAPH;
 
-	if (type != CT_PARAGRAPH)
+    // SN-2014-09-17: [[ Bug 13461 ]] CT_LINE and CT_PARAGRAPH are equivalent in
+    // the way they don't modify the content of the paragraphs
+	if (type != CT_PARAGRAPH && type != CT_LINE)
 	{
         
         extern bool MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef p_data, int p_type, Sort_type p_direction, int p_form, MCExpression *p_by, MCStringRef &r_output);


### PR DESCRIPTION
...properties
