### PR TITLE
MCRedrawUnlockScreen() is now called prior to triggering the menu associ...

### DIFF
--- a/engine/src/stacklst.cpp
+++ b/engine/src/stacklst.cpp
@@ -329,8 +329,10 @@ Boolean MCStacklist::doaccelerator(KeySym key)
 					if (key == (KeySym)accelerators[i] . key && (MCmodifierstate & t_mod_mask) == (accelerators[i].mods & t_mod_mask) && accelerators[i] . button -> getparent() == t_menubar)
 					{
 						MCmodifierstate &= t_mod_mask;
-						accelerators[i] . button -> activate(True, (uint2)key);
+                        // TKD-2014-09-26 : Unlock the screen prior to triggering menu item. If code outside of
+                        // the engine updates the window size the window isn't redrawn (e.g. [NSWindow toggleFullScreen:nil]).
                         MCRedrawUnlockScreen();
+						accelerators[i] . button -> activate(True, (uint2)key);
 						return True;
 					}
 				}


### PR DESCRIPTION
...ated with an accelerator key. If the menu item triggered by the accelerator updates the window using an external the window will now update appropriately.

I have an external that calls NSWindow toggleFullScreen. When using accelerator keys to trigger the menu option that calls toggleFullScreen, the window would go full screen but LiveCode would not send the resizeStack message. In my code if I call unlock screen prior to call toggleFullScreen then everything works as it should.

By moving MCRedrawUnlockScreen() before the acceleratorKey trigger, everything works as it should. I don't think this affects the speed improvement that MCRedrawLockScreen brings to the table as the screen is still locked during the mousedown event.
