### PR TITLE
[[ Bug 13590 ]] As of iOS 8, the presence of a NSLocationWhenInUseUsageD...

### DIFF
--- a/docs/notes/bugfix-13590.md
+++ b/docs/notes/bugfix-13590.md
@@ -1,1 +1,9 @@
 #     Location Services Disabled with LC 6.6.4 (rc1)
+
+A new function **mobileLocationAuthorizationStatus** (or **iphoneLocationAuthorizationStatus**) has been added. This returns the current location authorization status of the calling application. The status can be one of the following:
+
+- **notDetermined**: User has not yet made a choice with regards to this application
+- **restricted**: The application is not authorized to use location service
+- **denied**: User has explicitly denied authorization for this application, or location services are disabled in Settings.
+- **authorizedAlways**: User has granted authorization to use their location at any time, including monitoring for regions, visits, or significant location changes.
+- **authorizedWhenInUse**: User has granted authorization to use their location only when the app is visible to them (it will be made visible to them if you continue to receive location updates while in the background). Authorization to use launch APIs has not been granted.

--- a/docs/notes/bugfix-13590.md
+++ b/docs/notes/bugfix-13590.md
@@ -1,0 +1,1 @@
+#     Location Services Disabled with LC 6.6.4 (rc1)

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -84,6 +84,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This application requires access to Location Services when in use</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This application requires access to Location Services always</string>
 	<key>UIStatusBarHidden</key>
 		${STATUS_BAR_HIDDEN}
 	<key>UIStatusBarHidden~ipad</key>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -55,6 +55,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This application requires access to Location Services when in use</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This application requires access to Location Services always</string>
 	<key>UIStatusBarHidden</key>
 		${STATUS_BAR_HIDDEN}
 	<key>UIStatusBarHidden~ipad</key>

--- a/engine/rsrc/standalone-mobile-Info.plist
+++ b/engine/rsrc/standalone-mobile-Info.plist
@@ -72,7 +72,5 @@
 	<string>This application requires access to Location Services when in use</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>This application requires access to Location Services always</string>
-	<key>NSLocationUsageDescription</key>
-	<string>Requesting access to your location</string>
 </dict>
 </plist>

--- a/engine/rsrc/standalone-mobile-Info.plist
+++ b/engine/rsrc/standalone-mobile-Info.plist
@@ -68,5 +68,11 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This application requires access to Location Services when in use</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This application requires access to Location Services always</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Requesting access to your location</string>
 </dict>
 </plist>

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -170,6 +170,7 @@ bool MCParseParameters(MCParameter*& p_parameters, const char *p_format, ...)
 
 void MCIPhoneUseDeviceResolution(bool p_use_dev_res, bool p_use_control_device_res);
 float MCIPhoneGetDeviceScale(void);
+char* MCIPhoneGetLocationAuthorizationStatus(void);
 UIViewController *MCIPhoneGetViewController(void);
 UIView *MCIPhoneGetView(void);
 UITextView *MCIPhoneGetTextView(void);
@@ -720,6 +721,16 @@ static Exec_stat MCHandleDeviceScale(void *context, MCParameter *p_parameters)
 	return ES_NORMAL;
 #endif /* MCHandleDeviceScale */
 }
+
+static Exec_stat MCHandleLocationAuthorizationStatus(void *context, MCParameter *p_parameters)
+{
+#ifdef /* MCHandleLocationAuthorizationStatus */ LEGACY_EXEC
+    MCresult -> sets(MCIPhoneGetLocationAuthorizationStatus());
+    
+    return ES_NORMAL;
+#endif /* MCHandleLocationAuthorizationStatus */
+}
+
 
 #ifdef /* MCHandleDeviceOrientationIphone */ LEGACY_EXEC
 static Exec_stat MCHandleDeviceOrientation(void *context, MCParameter *p_parameters)
@@ -1605,6 +1616,9 @@ static MCPlatformMessageSpec s_platform_messages[] =
 	{false, "iphoneUseDeviceResolution", MCHandleUseDeviceResolution, nil},
 	{false, "iphoneDeviceScale", MCHandleDeviceScale, nil},
     {false, "mobilePixelDensity", MCHandleDeviceScale, nil},
+    
+    {false, "iphoneLocationAuthorizationStatus", MCHandleLocationAuthorizationStatus, nil},
+    {false, "mobileLocationAuthorizationStatus", MCHandleLocationAuthorizationStatus, nil},
 	
     // PM-2014-10-07: [[ Bug 13590 ]] StartTrackingSensor and StopTrackingSensor must run on the script thread
     {true, "mobileStartTrackingSensor", MCHandleStartTrackingSensor, nil},

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -1606,19 +1606,25 @@ static MCPlatformMessageSpec s_platform_messages[] =
 	{false, "iphoneDeviceScale", MCHandleDeviceScale, nil},
     {false, "mobilePixelDensity", MCHandleDeviceScale, nil},
 	
-    {false, "mobileStartTrackingSensor", MCHandleStartTrackingSensor, nil},
-    {false, "mobileStopTrackingSensor", MCHandleStopTrackingSensor, nil},
+    // PM-2014-10-07: [[ Bug 13590 ]] StartTrackingSensor and StopTrackingSensor must run on the script thread
+    {true, "mobileStartTrackingSensor", MCHandleStartTrackingSensor, nil},
+    {true, "mobileStopTrackingSensor", MCHandleStopTrackingSensor, nil},
     {false, "mobileSensorReading", MCHandleSensorReading, nil},
     {false, "mobileSensorAvailable", MCHandleSensorAvailable, nil},	
     
     // MM-2012-02-11: Added support old style senseor syntax (iPhoneEnableAcceleromter etc)
 	/* DEPRECATED */ {false, "iphoneCanTrackLocation", MCHandleCanTrackLocation, nil},
-	/* DEPRECATED */ {false, "iphoneStartTrackingLocation", MCHandleLocationTrackingState, (void *)true},
-	/* DEPRECATED */ {false, "iphoneStopTrackingLocation", MCHandleLocationTrackingState, (void *)false},
+    
+    // PM-2014-10-07: [[ Bug 13590 ]] StartTrackingLocation and StopTrackingLocation must run on the script thread
+	/* DEPRECATED */ {true, "iphoneStartTrackingLocation", MCHandleLocationTrackingState, (void *)true},
+	/* DEPRECATED */ {true, "iphoneStopTrackingLocation", MCHandleLocationTrackingState, (void *)false},
+    
 	/* DEPRECATED */ {false, "iphoneCurrentLocation", MCHandleCurrentLocation, nil},
     /* DEPRECATED */ {false, "mobileCanTrackLocation", MCHandleCanTrackLocation, nil},
-    /* DEPRECATED */ {false, "mobileStartTrackingLocation", MCHandleLocationTrackingState, (void *)true},
-	/* DEPRECATED */ {false, "mobileStopTrackingLocation", MCHandleLocationTrackingState, (void *)false},
+    
+    // PM-2014-10-07: [[ Bug 13590 ]] StartTrackingLocation and StopTrackingLocation must run on the script thread
+    /* DEPRECATED */ {true, "mobileStartTrackingLocation", MCHandleLocationTrackingState, (void *)true},
+	/* DEPRECATED */ {true, "mobileStopTrackingLocation", MCHandleLocationTrackingState, (void *)false},
 	/* DEPRECATED */ {false, "mobileCurrentLocation", MCHandleCurrentLocation, nil},
 	
 	/* DEPRECATED */ {false, "iphoneCanTrackHeading", MCHandleCanTrackHeading, nil},

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -170,7 +170,7 @@ bool MCParseParameters(MCParameter*& p_parameters, const char *p_format, ...)
 
 void MCIPhoneUseDeviceResolution(bool p_use_dev_res, bool p_use_control_device_res);
 float MCIPhoneGetDeviceScale(void);
-char* MCIPhoneGetLocationAuthorizationStatus(void);
+const char* MCIPhoneGetLocationAuthorizationStatus(void);
 UIViewController *MCIPhoneGetViewController(void);
 UIView *MCIPhoneGetView(void);
 UITextView *MCIPhoneGetTextView(void);

--- a/engine/src/mbliphonesensor.mm
+++ b/engine/src/mbliphonesensor.mm
@@ -122,6 +122,7 @@ static int32_t s_location_calibration_timeout = 0;
 {
     return m_ready;
 }
+
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
 {
     if (status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorized)
@@ -206,7 +207,6 @@ static void requestAlwaysAuthorization(void)
                                                handler:^(UIAlertAction *action) {
                                                    // do nothing
                                                    t_in_modal = false;
-                                                   MCscreen -> pingwait();
                                                    [t_alert_controller dismissViewControllerAnimated:YES completion:nil];
                                                }];
         t_go_to_settings_action = [UIAlertAction actionWithTitle:@"Settings"
@@ -214,7 +214,6 @@ static void requestAlwaysAuthorization(void)
                                              handler:^(UIAlertAction *action) {
                                                  // go to settings
                                                  t_in_modal = false;
-                                                 MCscreen -> pingwait();
                                                  NSURL *t_settings_url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
                                                  [[UIApplication sharedApplication] openURL:t_settings_url];
                                              }];
@@ -231,6 +230,7 @@ static void requestAlwaysAuthorization(void)
     else if (t_status == kCLAuthorizationStatusNotDetermined)
     {
         [s_location_manager requestAlwaysAuthorization];
+        
         while (![s_location_delegate isReady])
             MCscreen -> wait(1.0, False, True);
     }
@@ -243,7 +243,8 @@ static void initialize_core_location(void)
 	if (s_location_manager != nil)
 		return;
 	
-	s_location_manager = [[CLLocationManager alloc] init];
+    // PM-2014-10-07: [[ Bug 13590 ]] Configuration of the location manager object must always occur on a thread with an active run loop
+    MCIPhoneRunBlockOnMainFiber(^(void) {s_location_manager = [[CLLocationManager alloc] init];});
 	s_location_delegate = [[MCIPhoneLocationDelegate alloc] init];
     [s_location_delegate setReady: False];
 	[s_location_manager setDelegate: s_location_delegate];

--- a/engine/src/mbliphonesensor.mm
+++ b/engine/src/mbliphonesensor.mm
@@ -304,6 +304,52 @@ double MCSystemGetSensorDispatchThreshold(MCSensorType p_sensor)
     return 0.0;
 }
 
+const char* MCIPhoneGetLocationAuthorizationStatus(void)
+{
+    CLAuthorizationStatus t_status = [CLLocationManager authorizationStatus];
+    
+    const char *t_status_string;
+    t_status_string = "";
+    switch (t_status)
+    {
+        case kCLAuthorizationStatusNotDetermined:
+            t_status_string = "notDetermined";
+            break;
+            
+            // This application is not authorized to use location services.  Due
+            // to active restrictions on location services, the user cannot change
+            // this status, and may not have personally denied authorization
+        case kCLAuthorizationStatusRestricted:
+            t_status_string = "restricted";
+            break;
+            
+            // User has explicitly denied authorization for this application, or
+            // location services are disabled in Settings.
+        case kCLAuthorizationStatusDenied:
+            t_status_string = "denied";
+            break;
+            
+            // User has granted authorization to use their location at any time,
+            // including monitoring for regions, visits, or significant location changes.
+        case kCLAuthorizationStatusAuthorizedAlways:
+            t_status_string = "authorizedAlways";
+            break;
+            
+            // User has granted authorization to use their location only when your app
+            // is visible to them (it will be made visible to them if you continue to
+            // receive location updates while in the background).  Authorization to use
+            // launch APIs has not been granted.
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
+            t_status_string = "authorizedWhenInUse";
+            break;
+            
+        default:
+            break;
+    }
+    
+    return t_status_string;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // LOCATION SENSEOR
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
...escription or a NSLocationAlwaysUsageDescription key value in the app's Info.plist

 file is required. It's then also necessary to request permission from the user prior to registering for location updates, either by calling
 [self.myLocationManager requestWhenInUseAuthorization] or [self.myLocationManager requestAlwaysAuthorization] depending on our need. The string we entered
 into the Info.plist will then be displayed in the ensuing dialog.
