### PR TITLE
[[ Bug 13619 ]] 'the files' and 'the folders' should return empty if an ...

### DIFF
--- a/docs/notes/bugfix-13619.md
+++ b/docs/notes/bugfix-13619.md
@@ -1,0 +1,1 @@
+# Setting a non-readable default folder makes 'the folders' fail

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -158,7 +158,8 @@ void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string)
 	if (MCS_getentries(false, false, &t_list) && MCListCopyAsString(*t_list, r_string))
 		return;
 
-	ctxt . Throw();
+    // SN-2014-10-07: [[ Bug 13619 ]] 'the folders' should return empty, in case of an error
+    r_string = MCValueRetain(kMCEmptyString);
 }
 
 void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string)
@@ -172,7 +173,8 @@ void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string)
 	if (MCS_getentries(true, false, &t_list) && MCListCopyAsString(*t_list, r_string))
 		return;
 
-	ctxt . Throw();
+    // SN-2014-10-07: [[ Bug 13619 ]] 'the files' should return empty, in case of an error
+    r_string = MCValueRetain(kMCEmptyString);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
...error occured
