### PR TITLE
[[ Bug 13626 ]] Prevent crash caused by static variable not being set to...

### DIFF
--- a/docs/notes/bugfix-13626.md
+++ b/docs/notes/bugfix-13626.md
@@ -1,0 +1,1 @@
+# Android app crashes when back button pressed for a second time

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -2305,7 +2305,9 @@ void MCAndroidFinalizeBuildInfo()
             MCValueRelease(s_build_info[i]);
         }
         MCMemoryDeleteArray(s_build_info);
-    }        
+        // AL-2014-10-08: [[ Bug 13626 ]] Set s_build_info back to NULL when finalizing
+        s_build_info = NULL;
+    }
 }
 
 bool MCAndroidSignatureMatch(const char *p_signature)


### PR DESCRIPTION
... nil before exit
