### PR TITLE
[[ cleanup ]] Remove some common build warnings.

### DIFF
--- a/engine/src/cdata.h
+++ b/engine/src/cdata.h
@@ -41,13 +41,13 @@ public:
 	void setparagraphs(MCParagraph *&newpar);
 	Boolean getset();
 	void setset(Boolean newdata);
-	void setdata(int4 newdata)
+	void setdata(uintptr_t newdata)
 	{
 		data = (void *)newdata;
 	}
-	int4 getdata()
+	uintptr_t getdata()
 	{
-		return (int4)(intptr_t)data;
+		return (uintptr_t)data;
 	}
 	MCCdata *next()
 	{

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -61,7 +61,7 @@ inline bool MCStringToUInt16(MCStringRef string, uint16_t& r_integer)
 	integer_t t_integer;
 	if (!MCStringToInteger(string, t_integer))
 		return false;
-	if (t_integer < UINT16_MIN || t_integer > UINT16_MAX)
+	if (t_integer < (integer_t) UINT16_MIN || t_integer > (integer_t) UINT16_MAX)
 		return false;
 	r_integer = (uint16_t)t_integer;
 	return true;

--- a/engine/src/mcio.h
+++ b/engine/src/mcio.h
@@ -21,7 +21,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #if defined(_WINDOWS_DESKTOP) || defined(_WINDOWS_SERVER)
 #define PATH_MAX 260
-#elif !defined(_ANDROID_MOBILE)
+#elif !defined(PATH_MAX)
 #define PATH_MAX 1024
 #endif
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -355,7 +355,7 @@ typedef signed long int int64_t;
 #define UINT16_MIN (0U)
 #define UINT16_MAX (65535U)
 #define INT16_MIN (-32768)
-#define INT16_MAX (32767U)
+#define INT16_MAX (32767)
 
 #define UINT32_MIN (0U)
 #define UINT32_MAX (4294967295U)


### PR DESCRIPTION
Nuke a bunch of commonly-occurring warnings, especially in Linux builds.
