### PR TITLE
[[ Bug 13664 ]] Interpret numeric initial segment of string as sort key for numeric sort

### DIFF
--- a/docs/notes/bugfix-13664.md
+++ b/docs/notes/bugfix-13664.md
@@ -1,0 +1,1 @@
+# Livecode 7.0 rc 2 does not sort certain strings correctly when the numeric form is used


### PR DESCRIPTION
In the original source code for adding an item to the list to sort, there is a comment:

// REVIEW - at the moment the numeric prefix of the string is used to
//   derive the sort key e.g. 1000abc would get processed as 1000.

This fix is redundant if indeed we do not wish to retain the behaviour for LC 7 onwards.
