### PR TITLE
[[ Bug 13671 ]] Keep track of delimiter length when iterating over line ...

### DIFF
--- a/docs/notes/bugfix-13671.md
+++ b/docs/notes/bugfix-13671.md
@@ -1,0 +1,1 @@
+# repeat for each item or line does not use multichar delimiter 

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -5730,8 +5730,8 @@ bool MCTextChunkIterator::next(MCExecContext& ctxt)
             else
             {
                 range . length = t_found_range . offset - range . offset;
-                // keep track of matched delimiter length.
-                //delimiter_length = t_found_range . length;
+                // AL-2014-10-15: [[ Bug 13671 ]] Keep track of matched delimiter length to increment offset correctly
+                delimiter_length = t_found_range . length;
             }
             
         }


### PR DESCRIPTION
...or item chunks
