### PR TITLE
[[ Bug 13680 ]] Ensure multichar delimiters are taken into account when ...

### DIFF
--- a/docs/notes/bugfix-13680.md
+++ b/docs/notes/bugfix-13680.md
@@ -1,0 +1,1 @@
+# item delimiter not deleted in target string if longer than 1 character

--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -285,10 +285,18 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
             
             if (p_whole_chunk && !p_further_chunks)
             {
+                // AL-2014-10-15: [[ Bug 13680 ]] Make sure the previously found delimiter's length is used to adjust the string offsets.
+                
+                // Wholechunk operations need additional processing of mark indices to preserve the presence or otherwise of trailing delimiters.
+                // If we found a trailing delimiter for this item or line, make sure it is included in the mark.
+                // e.g. mark item 3 of a,b,c, -> a,b,(c,) so that delete item 3 of a,b,c, -> a,b,
+                
                 if (r_end < t_length)
-                    r_end++;
+                    r_end += t_found_range . length;
+                // If we didn't, and this operation does not force additional delimiters, then include the previous delimiter in the mark.
+                // e.g. mark item 3 of a,b,c -> a,b(,c) so that delete item 3 of a,b,c -> a,b
                 else if (r_start > 0 && !r_add)
-                    r_start--;
+                    r_start -= t_found_range . length;
             }
         }
             break;


### PR DESCRIPTION
...marking item and line chunks for wholechunk operations
