### PR TITLE
[[ Bug 13674 ]] Implement MCLinuxDesktop::GetFreeDiskSpace().

### DIFF
--- a/docs/notes/bugfix-13674.md
+++ b/docs/notes/bugfix-13674.md
@@ -1,0 +1,1 @@
+# Implement diskSpace function on Linux.


### PR DESCRIPTION
The documentation for "the diskSpace" says:

> Returns the amount of free space on the disk that holds the
> defaultFolder
> ...
> Use the diskSpace function to determine whether there is enough free
> space to complete an action (such as downloading data).

There are two different ways to interpret this when implementing using
statvfs(3):

1) statvfs.f_bfree gives the number of blocks that are free.  This
   matches the stated definition of the diskSpace function.

2) statvfs.f_bavail gives the number of blocks that are available to
   use by non-superuser users.  This is much more useful for the
   stated _application_ fo the diskSpace function.

This patch implements option (1).  Option (2) is commented out in the
source code.
