### PR TITLE
[[ Bug 12786 ]] Treat XK_ISO_Left_Tab the same as XK_Tab.

### DIFF
--- a/docs/notes/bugfix-12786.md
+++ b/docs/notes/bugfix-12786.md
@@ -1,0 +1,1 @@
+# \<Shift>+\<Tab> key combination now works on Linux desktop.

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -127,6 +127,7 @@ KeySym MCScreenDC::translatekeysym(KeySym sym, uint4 keycode)
 	case XK_osfDelete:
 	case XK_hpDeleteChar:
 		return XK_Delete;
+	case XK_ISO_Left_Tab: /* X11 shift-tab keysym */
 	case 0x1000FF74: // HP shift-tab keysysm
 		return XK_Tab;
 	}


### PR DESCRIPTION
On Xorg systems, a <Tab> keystroke has keysym XK_Tab, but a
<Shift>+<Tab> keystroke has keysym XK_ISO_Left_Tab (with the shift
modifier bit set).

Modifying the translatekeysym() function to translate XK_ISO_Left_Tab
into XK_Tab ensures that <Shift>+<Tab> key combinations are handled
correctly.
