### PR TITLE
[[ Bugfix 13742 ]] Export "the styledText" runs as "text" rather than "u...

### DIFF
--- a/docs/notes/bugfix-13742.md
+++ b/docs/notes/bugfix-13742.md
@@ -1,0 +1,2 @@
+# Export "the styledText" runs as "text" rather than "unicodeText"
+

--- a/engine/src/fieldstyledtext.cpp
+++ b/engine/src/fieldstyledtext.cpp
@@ -396,9 +396,10 @@ static bool export_styled_text(void *p_context, MCFieldExportEventType p_event_t
 
 		// Set the block's 'text' or 'unicodeText' entry in the block's run array.
 		// Depending on whether its unicode or not.
+        // FG-2014-10-21: [[ Bugfix 13742 ]] Only export as "text" in 7.0+
 		MCAutoStringRef t_string;
 		/* UNCHECKED */ MCStringCopySubstring(p_event_data.m_text, p_event_data.m_range, &t_string);
-        /* UNCHECKED */ MCArrayStoreValue(ctxt . last_run, true, p_event_type == kMCFieldExportEventUnicodeRun ? MCNAME("unicodeText") : MCNAME("text"), *t_string);
+        /* UNCHECKED */ MCArrayStoreValue(ctxt . last_run, true, MCNAME("text"), *t_string);
 
 		// Set the block's 'metadata' entry in the block's run array.
 		if (p_event_data . character_style . has_metadata)


### PR DESCRIPTION
...nicodeText"
