### PR TITLE
[[ Bug 13750 ]] When in iPhone 4, make sure that the native picker view ...

### DIFF
--- a/docs/notes/bugfix-13750.md
+++ b/docs/notes/bugfix-13750.md
@@ -1,0 +1,1 @@
+#     Picker broken on iPhone 4 iOS 7.1

--- a/engine/src/mbliphoneapp.h
+++ b/engine/src/mbliphoneapp.h
@@ -371,6 +371,7 @@ void MCIPhoneHandlePerformRedraw(void);
 ////////////////////////////////////////////////////////////////////////////////
 
 MCIPhoneApplication *MCIPhoneGetApplication(void);
+NSString* MCIPhoneGetDeviceModelName(void);
 
 UIViewController *MCIPhoneGetViewController(void);
 UIView *MCIPhoneGetView(void);

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -28,6 +28,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "mbliphoneview.h"
 
 #include "mblnotification.h"
+#import <sys/utsname.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1767,6 +1768,75 @@ void MCiOSFilePostProtectedDataUnavailableEvent();
 @end
 
 ////////////////////////////////////////////////////////////////////////////////
+
+// PM-2014-10-22: [[ Bug 13750 ]] Utility method to determine the exact device model. If on simulator, it returns "i386" or "x86_64"
+NSString* MCIPhoneGetDeviceModelName(void)
+{
+    struct utsname t_system_info;
+    uname(&t_system_info);
+    
+    NSString *t_machine_name = [NSString stringWithCString:t_system_info.machine encoding:NSUTF8StringEncoding];
+    
+    // MARK: We can just return t_machine_name. Following is for convenience
+    // Full list at http://theiphonewiki.com/wiki/Models
+    
+    NSDictionary *commonNamesDictionary =
+    @{
+      @"iPhone1,1":    @"iPhone",
+      @"iPhone1,2":    @"iPhone 3G",
+      @"iPhone2,1":    @"iPhone 3GS",
+      @"iPhone3,1":    @"iPhone 4",
+      @"iPhone3,2":    @"iPhone 4(Rev A)",
+      @"iPhone3,3":    @"iPhone 4(CDMA)",
+      @"iPhone4,1":    @"iPhone 4S",
+      @"iPhone5,1":    @"iPhone 5(GSM)",
+      @"iPhone5,2":    @"iPhone 5(GSM+CDMA)",
+      @"iPhone5,3":    @"iPhone 5c(GSM)",
+      @"iPhone5,4":    @"iPhone 5c(GSM+CDMA)",
+      @"iPhone6,1":    @"iPhone 5s(GSM)",
+      @"iPhone6,2":    @"iPhone 5s(GSM+CDMA)",
+      
+      @"iPhone7,1":    @"iPhone 6+ (GSM+CDMA)",
+      @"iPhone7,2":    @"iPhone 6 (GSM+CDMA)",
+      
+      @"iPad1,1":  @"iPad",
+      @"iPad2,1":  @"iPad 2(WiFi)",
+      @"iPad2,2":  @"iPad 2(GSM)",
+      @"iPad2,3":  @"iPad 2(CDMA)",
+      @"iPad2,4":  @"iPad 2(WiFi Rev A)",
+      @"iPad2,5":  @"iPad Mini 1G (WiFi)",
+      @"iPad2,6":  @"iPad Mini 1G (GSM)",
+      @"iPad2,7":  @"iPad Mini 1G (GSM+CDMA)",
+      @"iPad3,1":  @"iPad 3(WiFi)",
+      @"iPad3,2":  @"iPad 3(GSM+CDMA)",
+      @"iPad3,3":  @"iPad 3(GSM)",
+      @"iPad3,4":  @"iPad 4(WiFi)",
+      @"iPad3,5":  @"iPad 4(GSM)",
+      @"iPad3,6":  @"iPad 4(GSM+CDMA)",
+      
+      @"iPad4,1":  @"iPad Air(WiFi)",
+      @"iPad4,2":  @"iPad Air(GSM)",
+      @"iPad4,3":  @"iPad Air(GSM+CDMA)",
+      
+      @"iPad4,4":  @"iPad Mini 2G (WiFi)",
+      @"iPad4,5":  @"iPad Mini 2G (GSM)",
+      @"iPad4,6":  @"iPad Mini 2G (GSM+CDMA)",
+      
+      @"iPod1,1":  @"iPod 1st Gen",
+      @"iPod2,1":  @"iPod 2nd Gen",
+      @"iPod3,1":  @"iPod 3rd Gen",
+      @"iPod4,1":  @"iPod 4th Gen",
+      @"iPod5,1":  @"iPod 5th Gen",
+      
+      };
+    
+    NSString *t_device_name = commonNamesDictionary[t_machine_name];
+    
+    if (t_device_name == nil)
+        t_device_name = t_machine_name;
+    
+    return t_device_name;
+}
 
 MCIPhoneApplication *MCIPhoneGetApplication(void)
 {

--- a/engine/src/mbliphonepick.mm
+++ b/engine/src/mbliphonepick.mm
@@ -483,6 +483,11 @@ return 1;
 			m_bar_visible = true;
 		}
 		
+        // PM-2014-10-22: [[ Bug 13750 ]] Make sure the view under the pickerView is not visible (iphone 4 only)
+        NSString *t_device_model_name = MCIPhoneGetDeviceModelName();
+        if ([t_device_model_name isEqualToString:@"iPhone 4"] || [t_device_model_name isEqualToString:@"iPhone 4(Rev A)"] || [t_device_model_name isEqualToString:@"iPhone 4(CDMA)"])
+            pickerView.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.90];
+        
 		// set the label item
 		for (t_i = 0; t_i < [m_selected_index count]; t_i++)
 			[pickerView selectRow:[[m_selected_index objectAtIndex:t_i] integerValue] inComponent:t_i animated:NO];

--- a/engine/src/mbliphonepickdate.mm
+++ b/engine/src/mbliphonepickdate.mm
@@ -240,6 +240,11 @@ UIViewController *MCIPhoneGetViewController(void);
 		[datePicker setLocale:t_locale];
 		[datePicker setCalendar:[t_locale objectForKey:NSLocaleCalendar]];
 		[datePicker setTimeZone:[NSTimeZone localTimeZone]];
+        
+        // PM-2014-10-22: [[ Bug 13750 ]] Make sure the view under the pickerView is not visible (iphone 4 only)
+        NSString *t_device_model_name = MCIPhoneGetDeviceModelName();
+        if ([t_device_model_name isEqualToString:@"iPhone 4"] || [t_device_model_name isEqualToString:@"iPhone 4(Rev A)"] || [t_device_model_name isEqualToString:@"iPhone 4(CDMA)"])
+            datePicker.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.90];
 		
 		// set up the style and parameters for the date picker
 		if (p_style == nil || MCCStringEqual([p_style cStringUsingEncoding:NSMacOSRomanStringEncoding], "dateTime"))


### PR DESCRIPTION
...is opaque enough to hide what is below
