### PR TITLE
[[ Bug 13787 ]] Compute the range correctly in EndsWith before checking ...

### DIFF
--- a/docs/notes/bugfix-13787.md
+++ b/docs/notes/bugfix-13787.md
@@ -1,0 +1,1 @@
+# 'ends with' can return the wrong result if a string contains surrogates or combining sequences.

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -1523,8 +1523,9 @@ void MCStringsEvalEndsWith(MCExecContext& ctxt, MCStringRef p_whole, MCStringRef
         return;
     }
     
+    // MW-2014-10-24: [[ Bug 13787 ]] Make sure we calculate the correct range.
     MCRange t_range;
-    t_range = MCRangeMake(0, t_self_length);
+    t_range = MCRangeMake(MCStringGetLength(p_whole) - t_self_length, t_self_length);
     
     r_result = MCStringsCheckGraphemeBoundaries(p_whole, t_range);
 }


### PR DESCRIPTION
...grapheme boundaries.
