### PR TITLE
[[ Bug 11647 ]] Prevent a crash on android when hardware key is pressed ...

### DIFF
--- a/docs/notes/bugfix-11647.md
+++ b/docs/notes/bugfix-11647.md
@@ -1,0 +1,1 @@
+#     After Android hardware backKey is pressed, relaunch crashes

--- a/engine/src/regex.cpp
+++ b/engine/src/regex.cpp
@@ -396,5 +396,7 @@ void MCR_clearcache()
 	for (i = 0 ; i < PATTERN_CACHE_SIZE ; i++)
 	{
 		MCR_free(MCregexcache[i]);
+        // PM-2014-10-02: [[ Bug 11647 ]] Make sure we clear old data to prevent a crash when restarting the app
+        MCregexcache[i] = nil;
 	}
 }


### PR DESCRIPTION
...and then the app is relaunched
