### PR TITLE
[[ Bug 12558 ]] Ensure 7.0 stackfiles report as new versions not corrupt

### DIFF
--- a/docs/notes/bugfix-12558.md
+++ b/docs/notes/bugfix-12558.md
@@ -1,0 +1,1 @@
+# Older versions of LiveCode report a corrupt stack when opening a file from newer version

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -76,6 +76,8 @@ static char header[HEADERSIZE] = "#!/bin/sh\n# MetaCard 2.4 stack\n# The followi
 #define NEWHEADERSIZE 8
 static const char *newheader = "REVO2700";
 static const char *newheader5500 = "REVO5500";
+// AL-2014-10-27: [[ Bug 12558 ]] REVO7000 is a valid stackfile header
+static const char *newheader7000 = "REVO7000";
 
 MCDispatch::MCDispatch()
 {
@@ -424,7 +426,9 @@ IO_stat readheader(IO_handle& stream, char *version)
 	{
 		// MW-2012-03-04: [[ StackFile5500 ]] Check for either the 2.7 or 5.5 header.
 		if (strncmp(tnewheader, newheader, NEWHEADERSIZE) == 0 ||
-			strncmp(tnewheader, newheader5500, NEWHEADERSIZE) == 0)
+			strncmp(tnewheader, newheader5500, NEWHEADERSIZE) == 0 ||
+            // AL-2014-10-27: [[ Bug 12558 ]] REVO7000 is a valid stackfile header
+            strncmp(tnewheader, newheader7000, NEWHEADERSIZE) == 0)
 		{
 			sprintf(version, "%c.%c.%c.%c", tnewheader[4], tnewheader[5], tnewheader[6], tnewheader[7]);
 			if (tnewheader[7] == '0')

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -74,10 +74,9 @@ MCImage *MCDispatch::imagecache;
 static char header[HEADERSIZE] = "#!/bin/sh\n# MetaCard 2.4 stack\n# The following is not ASCII text,\n# so now would be a good time to q out of more\f\nexec mc $0 \"$@\"\n";
 
 #define NEWHEADERSIZE 8
+#define HEADERPREFIXSIZE 4
 static const char *newheader = "REVO2700";
 static const char *newheader5500 = "REVO5500";
-// AL-2014-10-27: [[ Bug 12558 ]] REVO7000 is a valid stackfile header
-static const char *newheader7000 = "REVO7000";
 
 MCDispatch::MCDispatch()
 {
@@ -424,19 +423,32 @@ IO_stat readheader(IO_handle& stream, char *version)
 
 	if (IO_read(tnewheader, sizeof(char), size, stream) == IO_NORMAL)
 	{
-		// MW-2012-03-04: [[ StackFile5500 ]] Check for either the 2.7 or 5.5 header.
-		if (strncmp(tnewheader, newheader, NEWHEADERSIZE) == 0 ||
-			strncmp(tnewheader, newheader5500, NEWHEADERSIZE) == 0 ||
-            // AL-2014-10-27: [[ Bug 12558 ]] REVO7000 is a valid stackfile header
-            strncmp(tnewheader, newheader7000, NEWHEADERSIZE) == 0)
+		// AL-2014-10-27: [[ Bug 12558 ]] Check for valid header prefix
+		if (strncmp(tnewheader, "REVO", HEADERPREFIXSIZE) == 0)
 		{
-			sprintf(version, "%c.%c.%c.%c", tnewheader[4], tnewheader[5], tnewheader[6], tnewheader[7]);
-			if (tnewheader[7] == '0')
-			{
-				version[5] = '\0';
-				if (tnewheader[6] == '0')
-					version[3] = '\0';
-			}
+            // The version is valid if it consists of 4 alphanumeric values.
+            // Later versions will always strcmp greater than 6.7 version strings
+            // so we just check to see if it is valid.
+            for (uint1 i = 0; i < 4; i++)
+            {
+                char t_char = tnewheader[i + 4];
+                if ('0' <= t_char && t_char <= '9')
+                    continue;
+                else if ('A' <= t_char && t_char <= 'Z')
+                    continue;
+                else if ('a' <= t_char && t_char <= 'z')
+                    continue;
+                else
+                    return IO_ERROR;
+            }
+            
+            sprintf(version, "%c.%c.%c.%c", tnewheader[4], tnewheader[5], tnewheader[6], tnewheader[7]);
+            if (tnewheader[7] == '0')
+            {
+                version[5] = '\0';
+                if (tnewheader[6] == '0')
+                    version[3] = '\0';
+            }
 		}
 		else
 		{
@@ -561,12 +573,12 @@ IO_stat MCDispatch::doreadfile(const char *openpath, const char *inname, IO_hand
     // MW-2014-09-30: [[ ScriptOnlyStack ]] First see if it is a binary stack.
 	if (readheader(stream, version) == IO_NORMAL)
 	{
-		if (strcmp(version, MCversionstring) > 0)
-		{
-			MCresult->sets("stack was produced by a newer version");
-			return IO_ERROR;
-		}
-
+        if (strcmp(version, MCversionstring) > 0)
+        {
+            MCresult->sets("stack was produced by a newer version");
+            return IO_ERROR;
+        }
+        
 		// MW-2008-10-20: [[ ParentScripts ]] Set the boolean flag that tells us whether
 		//   parentscript resolution is required to false.
 		s_loaded_parent_script_reference = false;


### PR DESCRIPTION
Note this required a change in the IDE too for stacks opened by dragging onto the app icon in the dock.
