### PR TITLE
[[ Bug 13836 ]] Unable to uncomment lines of code via keyboard shortcut

### DIFF
--- a/docs/notes/bugfix-13836.md
+++ b/docs/notes/bugfix-13836.md
@@ -1,0 +1,1 @@
+# Unable to uncomment lines of code via keyboard shortcut in OSX

--- a/engine/src/mac-menu.mm
+++ b/engine/src/mac-menu.mm
@@ -197,7 +197,10 @@ static uint32_t s_key_equivalent_depth = 0;
 - (BOOL)menuHasKeyEquivalent:(NSMenu *)menu forEvent:(NSEvent *)event target:(id *)target action:(SEL *)action
 {
     // MW-2014-10-22: [[ Bug 13510 ]] Make sure we update menus before searching for accelerators.
-    [[menu delegate] menuNeedsUpdate: menu];
+    // SN-2014-10-28: [[ Bug 13839 ]] This call to menuNeedsUpdate causes nesting call of performKeyEquivalent to
+    //  the menuDelegate. That eventually duplicate the call to keyDown, as well as preventing, in a way I did not define,
+    //  the expected execution (RawKeyDown end up to be never called).
+//    [[menu delegate] menuNeedsUpdate: menu];
 	return NO;
 }
 


### PR DESCRIPTION
Unsure about this bugfix: the call to menuNeedsUpdate might be needed, but it definitely is the cause of the bug 13836 (and maybe 13828 as well)
