### PR TITLE
[[ Bug 13847 ]] Make sure menuUpdate is only called once per accelerator...

### DIFF
--- a/docs/notes/bugfix-13847.md
+++ b/docs/notes/bugfix-13847.md
@@ -1,0 +1,1 @@
+# Cmd+, doesn't work in the IDE.


### PR DESCRIPTION
....

[[ Bug 13847 ]] Make sure default app menu shortcuts are honoured.
