### PR TITLE
libfoundation: Add accessors to add codepoints into strings.

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1754,6 +1754,7 @@ bool MCStringAppendChars(MCStringRef string, const unichar_t *chars, uindex_t co
 bool MCStringAppendNativeChars(MCStringRef string, const char_t *chars, uindex_t count);
 bool MCStringAppendChar(MCStringRef string, unichar_t p_char);
 bool MCStringAppendNativeChar(MCStringRef string, char_t p_char);
+bool MCStringAppendCodepoint(MCStringRef string, codepoint_t p_codepoint);
 
 // Prepend prefix to string.
 //
@@ -1764,6 +1765,7 @@ bool MCStringPrependChars(MCStringRef string, const unichar_t *chars, uindex_t c
 bool MCStringPrependNativeChars(MCStringRef string, const char_t *chars, uindex_t count);
 bool MCStringPrependChar(MCStringRef string, unichar_t p_char);
 bool MCStringPrependNativeChar(MCStringRef string, char_t p_char);
+bool MCStringPrependCodepoint(MCStringRef string, codepoint_t p_codepoint);
 
 // Insert new_string into string at offset 'at'.
 //
@@ -1774,6 +1776,7 @@ bool MCStringInsertChars(MCStringRef string, uindex_t at, const unichar_t *chars
 bool MCStringInsertNativeChars(MCStringRef string, uindex_t at, const char_t *chars, uindex_t count);
 bool MCStringInsertChar(MCStringRef string, uindex_t at, unichar_t p_char);
 bool MCStringInsertNativeChar(MCStringRef string, uindex_t at, char_t p_char);
+bool MCStringInsertCodepoint (MCStringRef string, uindex_t p_at, codepoint_t p_codepoint);
 
 // Remove 'range' characters from 'string'.
 //

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -3067,6 +3067,15 @@ bool MCStringAppendChar(MCStringRef self, unichar_t p_char)
 	return MCStringAppendChars(self, &p_char, 1);
 }
 
+bool
+MCStringAppendCodepoint (MCStringRef self, codepoint_t p_codepoint)
+{
+	uindex_t t_num_units;
+	unichar_t t_units[2];
+	t_num_units = MCStringCodepointToSurrogates (p_codepoint, t_units);
+	return MCStringAppendChars (self, t_units, t_num_units);
+}
+
 bool MCStringPrepend(MCStringRef self, MCStringRef p_prefix)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3200,6 +3209,15 @@ bool MCStringPrependNativeChar(MCStringRef self, char_t p_char)
 bool MCStringPrependChar(MCStringRef self, unichar_t p_char)
 {
 	return MCStringPrependChars(self, &p_char, 1);
+}
+
+bool
+MCStringPrependCodepoint (MCStringRef self, codepoint_t p_codepoint)
+{
+	uindex_t t_num_units;
+	unichar_t t_units[2];
+	t_num_units = MCStringCodepointToSurrogates (p_codepoint, t_units);
+	return MCStringPrependChars (self, t_units, t_num_units);
 }
 
 bool MCStringInsert(MCStringRef self, uindex_t p_at, MCStringRef p_substring)
@@ -3337,6 +3355,15 @@ bool MCStringInsertNativeChar(MCStringRef self, uindex_t p_at, char_t p_char)
 bool MCStringInsertChar(MCStringRef self, uindex_t p_at, unichar_t p_char)
 {
 	return MCStringInsertChars(self, p_at, &p_char, 1);
+}
+
+bool
+MCStringInsertCodepoint (MCStringRef self, uindex_t p_at, codepoint_t p_codepoint)
+{
+	uindex_t t_num_units;
+	unichar_t t_units[2];
+	t_num_units = MCStringCodepointToSurrogates (p_codepoint, t_units);
+	return MCStringInsertChars (self, p_at, t_units, t_num_units);
 }
 
 bool MCStringRemove(MCStringRef self, MCRange p_range)


### PR DESCRIPTION
It's sometimes useful to build a string by Unicode codepoint (for example when assembling a string with the output of an `MCTextFilter`).
