### PR TITLE
[[Bugfix 12106]] In livecode server the $n arguments are no longer of by...

### DIFF
--- a/docs/notes/bugfix-12106.md
+++ b/docs/notes/bugfix-12106.md
@@ -1,0 +1,1 @@
+# $0 is the first argument, not the script name (LC server)

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -408,7 +408,8 @@ bool X_init(int argc, char *argv[], char *envp[])
 			MCserverinitialscript = NULL;
 		
 		// Create the $<n> variables.
-		for(int i = 2; i < argc; ++i)
+        // PM-2014-04-14: [[Bug 12106]] Make sure $0 is the script name, and $n is the n-th argument
+		for(int i = 1; i < argc; ++i)
 			if (argv[i] != nil)
 			create_var(argv[i]);
 		create_var(nvars);


### PR DESCRIPTION
... one. So $0 is the script name, $1 is the first argument, and so on.
