### PR TITLE
libfoundation: MCStringCreateMutable(): Set length of string to zero.

### DIFF
--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -405,6 +405,7 @@ static bool MCStringCreateMutableUnicode(uindex_t p_initial_capacity, MCStringRe
 	if (t_success)
 	{
 		self -> flags |= kMCStringFlagIsMutable;
+		self->char_count = 0;
 		r_string = self;
 	}
     
@@ -427,6 +428,7 @@ bool MCStringCreateMutable(uindex_t p_initial_capacity, MCStringRef& r_string)
 	if (t_success)
 	{
 		self -> flags |= kMCStringFlagIsMutable;
+		self->char_count = 0;
 		r_string = self;
 	}
 


### PR DESCRIPTION
When `MCStringCreateMutable()` is called with a non-zero
`p_initial_capacity`, `__MCStringExpandAt()` provides a buffer of the
requested length for the `__MCString`.  However, it also sets the
char_count of the `__MCString` to the same length.  This can cause the
resulting `__MCString` to contain arbitrary data.
