### PR TITLE
[[ Bug 13917 ]] Make sure dontuseqt is taken into account when reopening...

### DIFF
--- a/docs/notes/bugfix-13917.md
+++ b/docs/notes/bugfix-13917.md
@@ -1,0 +1,1 @@
+#    dontuseqt value is ignored in player creation when reopening a recently closed stack that contains a player

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -996,6 +996,9 @@ void MCPlayer::close()
         MCPlatformDetachPlayer(m_platform_player);
         m_is_attached = false;
     }
+    // PM-2014-11-03: [[ Bug 13917 ]] m_platform_player should be recreated when reopening a recently closed stack, to take into account if the value of dontuseqt has changed in the meanwhile
+    if (m_platform_player != nil)
+        m_platform_player = nil;
 }
 
 Boolean MCPlayer::kdown(const char *string, KeySym key)


### PR DESCRIPTION
... a recently closed stack that contains a player
