### PR TITLE
[[ Valgrind ]] Use Memcheck macros to mark pooled MCValue buffers.

### DIFF
--- a/rules/common.linux.makefile
+++ b/rules/common.linux.makefile
@@ -44,7 +44,7 @@ GLOBAL_LIBS=\
 	$(SOLUTION_DIR)/prebuilt/lib/linux-$(ARCH)
 
 ifeq ($(MODE),debug)
-	DEFINES+=_DEBUG
+	DEFINES+=_DEBUG HAVE_VALGRIND
 else
 	DEFINES+=_RELEASE NDEBUG
 endif


### PR DESCRIPTION
By default, Linux builds are made with Valgrind integration.  Also requires runrev/livecode-thirdparty#14 (in order to make sure that the relevant headers are always available).

If LiveCode isn't running under Valgrind, the special macros are no-ops (they cost approx. 7 processor instructions each).
