### PR TITLE
[[ Valgrind ]] MCUuidFromCString(): Properly nul-terminate C string.

### DIFF
--- a/engine/src/uuid.cpp
+++ b/engine/src/uuid.cpp
@@ -171,6 +171,7 @@ bool MCUuidFromCString(const char *p_string, MCUuid& r_uuid)
 		char t_hex_byte[3];
 		t_hex_byte[0] = p_string[24 + i * 2];
 		t_hex_byte[1] = p_string[24 + i * 2 + 1];
+		t_hex_byte[2] = 0;
 		r_uuid . node[i] = (uint8_t)strtoul(t_hex_byte, NULL, 16);
 	}
 	


### PR DESCRIPTION
Prevents potential buffer overrun by strtoul(3).
