### PR TITLE
String optimisation

### DIFF
--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3386,10 +3386,11 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
                     MCresult->sets("error reading file");
                 else
                 {
-                    /* UNCHECKED */ MCStringCreateWithNativeCharsAndRelease((char_t*)buffer, toread, r_data);
+                    /* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)buffer, toread, r_data);
                     MCresult->clear(False);
                 }
             }
+            delete[] buffer;
         }
         
         FSCloseFork(fRefNum);
@@ -3965,7 +3966,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
                 {
                     errno = getAddressFromDesc(senderDesc, sender);
                     AEDisposeDesc(&senderDesc);
-                    /* UNCHECKED */ MCStringCreateWithCStringAndRelease((char_t*)sender, r_value);
+                    /* UNCHECKED */ MCStringCreateWithCStringAndRelease(sender, r_value);
                     return;
                 }
                 delete[] sender;
@@ -8233,21 +8234,26 @@ static OSErr getAEAttributes(const AppleEvent *ae, AEKeyword key, MCStringRef &r
             {
                 byte_t *result = new byte_t[s + 1];
                 AEGetAttributePtr(ae, key, dt, &rType, result, s, &rSize);
-                /* UNCHECKED */ MCStringCreateWithBytesAndRelease(result, s, kMCStringEncodingUTF8, false, r_result);
+                /* UNCHECKED */ MCStringCreateWithBytes(result, s, kMCStringEncodingUTF8, false, r_result);
+                delete[] result;
                 break;
             }
             case typeChar:
             {
                 char_t *result = new char_t[s + 1];
                 AEGetAttributePtr(ae, key, dt, &rType, result, s, &rSize);
-                /* UNCHECKED */ MCStringCreateWithNativeCharsAndRelease(result, s, r_result);
+                /* UNCHECKED */ MCStringCreateWithNativeChars(result, s, r_result);
+                delete[] result;
                 break;
             }
             case typeType:
             {
                 FourCharCode t_type;
                 AEGetAttributePtr(ae, key, dt, &rType, &t_type, s, &rSize);
-                /* UNCHECKED */ MCStringCreateWithNativeCharsAndRelease((char_t*)FourCharCodeToString(t_type), 4, r_result);
+                char *result;
+                result = FourCharCodeToString(t_type);
+                /* UNCHECKED */ MCStringCreateWithNativeChars((char_t*)result, 4, r_result);
+                delete[] result;
 			}
                 break;
             case typeShortInteger:
@@ -8339,14 +8345,18 @@ static OSErr getAEParams(const AppleEvent *ae, AEKeyword key, MCStringRef &r_res
             {
                 char_t *result = new char_t[s + 1];
                 AEGetParamPtr(ae, key, dt, &rType, result, s, &rSize);
-                /* UNCHECKED */ MCStringCreateWithNativeCharsAndRelease(result, s, r_result);
+                /* UNCHECKED */ MCStringCreateWithNativeChars(result, s, r_result);
+                delete[] result;
                 break;
             }
             case typeType:
             {
                 FourCharCode t_type;
                 AEGetParamPtr(ae, key, dt, &rType, &t_type, s, &rSize);
-                /* UNCHECKED */ MCStringCreateWithNativeCharsAndRelease((char_t*)FourCharCodeToString(t_type), 4, r_result);
+                char *result;
+                result = FourCharCodeToString(t_type);
+                /* UNCHECKED */ MCStringCreateWithNativeChars((char_t*)result, 4, r_result);
+                delete[] result;
 			}
                 break;
             case typeShortInteger:

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -93,9 +93,10 @@ bool MCExecContext::ConvertToString(MCValueRef p_value, MCStringRef& r_string)
         t_length = MCU_r8tos(t_buffer, t_buffer_size, MCNumberFetchAsReal((MCNumberRef)p_value), m_nffw, m_nftrailing, m_nfforce);
 
         bool t_success;
-        t_success = MCStringCreateWithNativeCharsAndRelease((char_t *)t_buffer, t_length, r_string) &&
+        t_success = MCStringCreateWithNativeChars((char_t *)t_buffer, t_length, r_string) &&
                 MCStringSetNumericValue(r_string, MCNumberFetchAsReal((MCNumberRef)p_value));
 
+        delete[] t_buffer;
         return t_success;
     }
     break;

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -672,7 +672,8 @@ bool MCValueConvertToStringForSave(MCValueRef self, MCStringRef& r_string)
 			uint32_t t_length;
 			t_length = MCU_r8tos(t_buffer, t_buffer_length, MCNumberFetchAsReal((MCNumberRef)self), 8, 6, 0);
 
-			t_success = MCStringCreateWithNativeCharsAndRelease((char_t *)t_buffer, t_length, r_string);
+			t_success = MCStringCreateWithNativeChars((char_t *)t_buffer, t_length, r_string);
+            delete[] t_buffer;
 		}
 		break;
 	case kMCValueTypeCodeString:

--- a/engine/src/objectstream.cpp
+++ b/engine/src/objectstream.cpp
@@ -290,22 +290,23 @@ IO_stat MCObjectInputStream::ReadTranslatedStringRef(MCStringRef &r_value)
     // If the string needs to be converted, do so
     if (MCtranslatechars)
     {
-        MCAutoStringRefAsCString t_string;
-        t_string . Lock(t_read);
-        char *t_cstring;
-        t_cstring = strclone(*t_string);
+        char_t *t_chars;
+        uindex_t t_char_count;
+        
+        MCStringConvertToNative(t_read, t_chars, t_char_count);
+
 #ifdef __MACROMAN__
-        IO_iso_to_mac(t_cstring, strlen(t_cstring));
+        IO_iso_to_mac((char *)t_chars, t_char_count);
 #else
-        IO_mac_to_iso(t_cstring, strlen(t_cstring));
+        IO_mac_to_iso((char *)t_chars, t_char_count);
 #endif
         
         // Conversion complete
         uindex_t t_length = MCStringGetLength(t_read);
         MCValueRelease(t_read);
-        if (!MCStringCreateWithNativeCharsAndRelease((char_t*)t_cstring, t_length, t_read))
+        if (!MCStringCreateWithNativeCharsAndRelease(t_chars, t_char_count, t_read))
         {
-            free(t_cstring);
+            MCMemoryDeleteArray(t_chars);
             return IO_ERROR;
         }
     }

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -605,7 +605,7 @@ bool MCU_r8tos(real8 n, uint2 fw, uint2 trailing, uint2 force, MCStringRef &r_st
 	}
 	
 	MCStringRef t_string;
-	if (!MCStringCreateWithCStringAndRelease((char_t *)t_str, t_string))
+	if (!MCStringCreateWithCStringAndRelease(t_str, t_string))
 	{
 		delete[] t_str;
 		return false;

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -846,8 +846,9 @@ public:
 
 	bool CreateStringAndRelease(MCStringRef& r_string)
 	{
-		if (MCStringCreateWithNativeCharsAndRelease(m_chars, m_char_count, r_string))
+		if (MCStringCreateWithNativeChars(m_chars, m_char_count, r_string))
 		{
+            MCMemoryDeleteArray(m_chars);
 			m_chars = nil;
 			m_char_count = 0;
 			return true;

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1404,7 +1404,7 @@ bool MCStringCreateWithNativeCharsAndRelease(char_t *chars, uindex_t char_count,
 
 // Create an immutable string from the given (native) c-string.
 bool MCStringCreateWithCString(const char *cstring, MCStringRef& r_string);
-bool MCStringCreateWithCStringAndRelease(char_t *cstring, MCStringRef& r_string);
+bool MCStringCreateWithCStringAndRelease(char *cstring, MCStringRef& r_string);
 
 #ifdef __HAS_CORE_FOUNDATION__
 // Create a string from a CoreFoundation string object.

--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -84,13 +84,26 @@ bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataR
 
 bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data)
 {
-    if (MCDataCreateWithBytes(p_bytes, p_byte_count, r_data))
-    {
-        MCMemoryDeallocate(p_bytes);
-        return true;
-    }
+    // AL-2014-11-17: Create with bytes and release should just take the bytes.
     
-    return false;
+    bool t_success;
+    t_success = true;
+    
+    __MCData *self;
+    self = nil;
+    if (t_success)
+        t_success = __MCValueCreate(kMCValueTypeCodeData, self);
+    
+    if (t_success)
+    {
+        self -> bytes = p_bytes;
+        self -> byte_count = p_byte_count;
+        r_data = self;
+    }
+    else
+        MCMemoryDelete(self);
+    
+    return t_success;
 }
 
 bool MCDataIsEmpty(MCDataRef p_data)


### PR DESCRIPTION
Some optimisations to MCStringRef and MCDataRef creation.

The following now just assimilate the passed buffer:
MCStringCreateWithNativeCharsAndRelease
MCStringCreateWithBytesAndRelease (for native / ascii chars)
MCDataCreateWithBytesAndRelease
