### PR TITLE
Miscellaneous libfoundation fixes

### DIFF
--- a/libfoundation/Makefile
+++ b/libfoundation/Makefile
@@ -3,12 +3,28 @@ TYPE=archive
 
 include ../rules/environment.linux.makefile
 
-SOURCES=foundation-array.cpp foundation-core.cpp foundation-debug.cpp \
-	foundation-list.cpp foundation-name.cpp foundation-nativechars.cpp \
-        foundation-data.cpp foundation-number.cpp foundation-set.cpp \
-        foundation-stream.cpp foundation-string.cpp foundation-unicodechars.cpp \
-        foundation-value.cpp foundation-error.cpp foundation-unicode.cpp \
-	foundation-locale.cpp foundation-bidi.cpp foundation-text.cpp
+SOURCES= \
+	foundation-array.cpp \
+	foundation-bidi.cpp \
+	foundation-core.cpp \
+	foundation-data.cpp \
+	foundation-debug.cpp \
+	foundation-error.cpp \
+	foundation-handler.cpp \
+	foundation-list.cpp \
+	foundation-locale.cpp \
+	foundation-name.cpp \
+	foundation-nativechars.cpp \
+	foundation-number.cpp \
+	foundation-record.cpp \
+	foundation-set.cpp \
+	foundation-stream.cpp \
+	foundation-string.cpp \
+	foundation-text.cpp \
+	foundation-typeinfo.cpp \
+	foundation-unicodechars.cpp \
+	foundation-unicode.cpp \
+	foundation-value.cpp
 
 CUSTOM_DEFINES=
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1265,7 +1265,7 @@ struct MCRecordTypeFieldInfo
 };
 
 // Create a description of a record with the given fields.
-bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *fields, uindex_t field_count, MCTypeInfoRef base_type, MCTypeInfoRef& r_typeinfo);
+bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef base_type, MCTypeInfoRef& r_typeinfo);
 
 // Return the number of fields in the record.
 uindex_t MCRecordTypeInfoGetFieldCount(MCTypeInfoRef typeinfo);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -290,7 +290,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define __64_BIT__
 #define __LITTLE_ENDIAN__
 #define __X86_64__
-#define __HUGE__
+#define __MEDIUM__
 #elif defined(__arm__)
 #define __32_BIT__
 #define __LITTLE_ENDIAN__

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1295,7 +1295,9 @@ struct MCHandlerTypeFieldInfo
 };
 
 // Create a description of a handler with the given signature.
-bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *fields, uindex_t field_count, MCTypeInfoRef return_type, MCTypeInfoRef& r_typeinfo);
+// If field_count is negative, the fields array must be terminated by
+// an MCHandlerTypeFieldInfo where name is null.
+bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef return_type, MCTypeInfoRef& r_typeinfo);
 
 // Get the return type of the handler. A return-type of kMCNullTypeInfo means no
 // value is returned.

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -202,7 +202,7 @@ hash_t MCHashInteger(integer_t i)
 
 hash_t MCHashPointer(void *p)
 {
-    return MCHashInteger((integer_t)p);
+    return MCHashInteger((intptr_t)p);
 }
 
 hash_t MCHashDouble(double d)

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -87,7 +87,7 @@ bool MCTypeInfoBindAndRelease(MCNameRef p_name, MCTypeInfoRef p_typeinfo, MCType
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, uindex_t p_field_count, MCTypeInfoRef p_base, MCTypeInfoRef& r_typeinfo)
+bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, index_t p_field_count, MCTypeInfoRef p_base, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
     if (!__MCValueCreate(kMCValueTypeCodeTypeInfo, self))
@@ -100,11 +100,16 @@ bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, uindex_t p_fi
     }
     
     self -> flags |= kMCValueTypeCodeRecord;
-    
-    for(uindex_t i = 0; i < p_field_count; i++)
-    {
+
+	/* If the p_field_count < 0 then the p_fields are expected to be
+	 * terminated by a custodian with name = nil. */
+	uindex_t i;
+	i = 0;
+	while ((p_field_count >= 0) ? (i < p_field_count) : (p_fields[i].name != nil))
+	{
         self -> record . fields[i] . name = MCValueRetain(p_fields[i] . name);
         self -> record . fields[i] . type = MCValueRetain(p_fields[i] . type);
+		++i;
     }
     self -> record . field_count = p_field_count;
     self -> record . base = MCValueRetain(p_base != nil ? p_base : kMCNullTypeInfo);

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -156,7 +156,7 @@ MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef unresolved_self, uindex
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *p_fields, uindex_t p_field_count, MCTypeInfoRef p_return_type, MCTypeInfoRef& r_typeinfo)
+bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *p_fields, index_t p_field_count, MCTypeInfoRef p_return_type, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
     if (!__MCValueCreate(kMCValueTypeCodeTypeInfo, self))
@@ -169,12 +169,17 @@ bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *p_fields, uindex_t p_
     }
     
     self -> flags |= kMCValueTypeCodeHandler;
-    
-    for(uindex_t i = 0; i < p_field_count; i++)
+
+	uindex_t i;
+	i = 0;
+	/* If the p_field_count < 0 then the p_fields are expected to be
+	 * terminated by a custodian with name = nil. */
+	while ((p_field_count >= 0) ? (i < p_field_count) : p_fields[i].name != nil)
     {
         self -> handler . fields[i] . name = MCValueRetain(p_fields[i] . name);
         self -> handler . fields[i] . type = MCValueRetain(p_fields[i] . type);
         self -> handler . fields[i] . mode = p_fields[i] . mode;
+		++i;
     }
     self -> handler . field_count = p_field_count;
     


### PR DESCRIPTION
This gets libfoundation building cleanly on Linux again, and also changes a bit of TypeInfo API to make working with static initialisers more convenient.
