### PR TITLE
[RFC] Refactor MCSTR & MCNAME to use MCAutoStringRef & MCNewAutoNameRef.

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -61,17 +61,70 @@ private:
     MCAutoValueRefBase<T>& operator = (MCAutoValueRefBase<T>& x);
 };
 
+class MCAutoStringRef : public MCAutoValueRefBase<MCStringRef>
+{
+public:
+	MCAutoStringRef(void) : MCAutoValueRefBase<MCStringRef>() {};
+	~MCAutoStringRef(void) {};
+
+	MCAutoStringRef(const char * p_cstring) : MCAutoValueRefBase()
+	{
+		MCAutoStringRef t_string;
+		uindex_t t_len;
+
+		t_len = strlen (p_cstring);
+
+		/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *) p_cstring, t_len, &t_string);
+
+		MCValueRef t_unique_value;
+		MCValueInter(*t_string, t_unique_value);
+		&(*this) = (MCStringRef) MCValueRetain(t_unique_value);
+	}
+
+	MCStringRef operator = (MCStringRef value)
+	{
+		return MCAutoValueRefBase<MCStringRef>::operator=(value);
+	}
+};
+
+class MCNewAutoNameRef : public MCAutoValueRefBase<MCNameRef>
+{
+public:
+	MCNewAutoNameRef(void) : MCAutoValueRefBase<MCNameRef>() {};
+	~MCNewAutoNameRef(void) {};
+
+	MCNewAutoNameRef(const char * p_cstring) : MCAutoValueRefBase()
+	{
+		MCAutoStringRef t_string(p_cstring);
+		MCNewAutoNameRef t_name;
+		/* UNCHECKED */ MCNameCreate(*t_string, &t_name);
+
+		MCValueRef t_unique_value;
+		MCValueInter(*t_name, t_unique_value);
+		&(*this) = (MCNameRef) MCValueRetain(t_unique_value);
+	}
+
+	MCNameRef operator = (MCNameRef value)
+	{
+		return MCAutoValueRefBase<MCNameRef>::operator=(value);
+	}
+};
+
+/* Creates an MCStringRef wrapping the given constant c-string. Note
+ * that the c-string should usually be a C literal string. */
+#define MCSTR(x) *MCAutoStringRef((x))
+/* Creates an MCNameRef wrapping the given constant c-string. Note
+ * that the c-string should usually be a C literal string. */
+#define MCNAME(x) *MCNewAutoNameRef((x))
+
 typedef MCAutoValueRefBase<MCValueRef> MCAutoValueRef;
 typedef MCAutoValueRefBase<MCNumberRef> MCAutoNumberRef;
-typedef MCAutoValueRefBase<MCStringRef> MCAutoStringRef;
 typedef MCAutoValueRefBase<MCArrayRef> MCAutoArrayRef;
 typedef MCAutoValueRefBase<MCListRef> MCAutoListRef;
 typedef MCAutoValueRefBase<MCBooleanRef> MCAutoBooleanRef;
 typedef MCAutoValueRefBase<MCSetRef> MCAutoSetRef;
 
-typedef MCAutoValueRefBase<MCNameRef> MCNewAutoNameRef;
 typedef MCAutoValueRefBase<MCDataRef> MCAutoDataRef;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1262,9 +1262,6 @@ extern MCNumberRef kMCMinusOne;
 //  NAME DEFINITIONS
 //
 
-// Like MCSTR but for NameRefs
-MCNameRef MCNAME(const char *);
-
 // Create a name using the given string.
 bool MCNameCreate(MCStringRef string, MCNameRef& r_name);
 // Create a name using chars.
@@ -1377,10 +1374,6 @@ extern MCStringRef kMCLineEndString;
 extern MCStringRef kMCTabString;
 
 /////////
-
-// Creates an MCStringRef wrapping the given constant c-string. Note that
-// the c-string must be a C static string.
-MCStringRef MCSTR(const char *string);
 
 const char *MCStringGetCString(MCStringRef p_string);
 bool MCStringIsEqualToCString(MCStringRef string, const char *cstring, MCStringOptions options);

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <foundation.h>
+#include <foundation-auto.h>
 
 #include "foundation-private.h"
 
@@ -32,24 +33,6 @@ static uindex_t s_name_table_capacity;
 
 static void __MCNameGrowTable(void);
 static void __MCNameShrinkTable(void);
-
-////////////////////////////////////////////////////////////////////////////////
-
-MCNameRef MCNAME(const char *p_string)
-{
-	MCStringRef t_string;
-	t_string = MCSTR(p_string);
-	
-	MCNameRef t_name;
-	/* UNCHECKED */ MCNameCreate(t_string, t_name);
-	
-	MCValueRef t_name_unique;
-	/* UNCHECKED */ MCValueInter(t_name, t_name_unique);
-	
-	MCValueRelease(t_name);
-	
-	return (MCNameRef)t_name_unique;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -87,24 +87,6 @@ static bool __MCStringCopyMutable(__MCString *self, __MCString*& r_new_string);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// This method creates a 'constant' MCStringRef from the given c-string. At some
-// point we'll make it work 'magically' at compile/build time. For now, uniquing
-// and returning that has a similar effect (if slightly slower).
-MCStringRef MCSTR(const char *p_cstring)
-{
-	MCStringRef t_string;
-	/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)p_cstring, strlen(p_cstring), t_string);
-	
-	MCValueRef t_unique_string;
-	/* UNCHECKED */ MCValueInter(t_string, t_unique_string);
-	
-	MCValueRelease(t_string);
-	
-	return (MCStringRef)t_unique_string;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 bool MCStringCreateWithCString(const char* p_cstring, MCStringRef& r_string)
 {
 	return MCStringCreateWithNativeChars((const char_t*)p_cstring, p_cstring == nil ? 0 : strlen(p_cstring), r_string);


### PR DESCRIPTION
This has two advantages:
1. MCStringRefs and MCNameRefs created using the MCSTR and MCNAME
   macros are automatically cleaned up when they're no longer needed.
2. There is a more convenient syntax for creating an MCAutoStringRef
   from a C literal string:
   
      MCAutoStringRef t_literal("My literal string here");
