### PR TITLE
avoid libcairo missing header problem

### DIFF
--- a/rules/common.linux.makefile
+++ b/rules/common.linux.makefile
@@ -53,7 +53,9 @@ DEFINES += __LITTLE_ENDIAN__
 
 PACKAGE_INCLUDES=$(shell pkg-config --silence-errors --cflags-only-I $(GLOBAL_PACKAGES))
 
-FALLBACK_INCLUDES=-I$(SOLUTION_DIR)/thirdparty/headers/linux/include -I$(SOLUTION_DIR)/thirdparty/headers/linux/include/cairo
+# MDW-2014-11-20 [[ fix_valgrind_path]]
+# avoids the libcairo compilation error
+FALLBACK_INCLUDES=-I$(SOLUTION_DIR)/thirdparty/headers/linux/include -I$(SOLUTION_DIR)/thirdparty/headers/linux/include/cairo -I$(SOLUTION_DIR)/thirdparty/headers/linux/include/valgrind
 
 INCLUDES=$(CUSTOM_INCLUDES) $(TYPE_INCLUDES) $(GLOBAL_INCLUDES)
 


### PR DESCRIPTION
Avoids the missing header error when compiling libcairo

In file included from ./src/cairo-analysis-surface.c:37:0:
./src/cairoint.h:2827:22: fatal error: memcheck.h: No such file or directory
# include <memcheck.h>
