### PR TITLE
Oval fix

### DIFF
--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -840,7 +840,7 @@ bool MCGraphic::get_points_for_roundrect(MCPoint*& r_points, uint2& r_point_coun
 {
 	r_points = NULL;
 	r_point_count = 0;
-	MCU_roundrect(r_points, r_point_count, rect, roundradius, 0, 0);
+	MCU_roundrect(r_points, r_point_count, rect, roundradius, 0, 0, flags);
 	return (true);
 }
 
@@ -896,7 +896,7 @@ bool MCGraphic::get_points_for_oval(MCPoint*& r_points, uint2& r_point_count)
 		tRadius = rect.height;
 	else
 		tRadius = rect.width;
-	MCU_roundrect(r_points, r_point_count, rect, tRadius / 2, startangle, arcangle);
+	MCU_roundrect(r_points, r_point_count, rect, tRadius / 2, startangle, arcangle, flags);
 	return (true);
 }
 

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -1401,6 +1401,7 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 {
 	uint2 i, j, k, count;
 	uint2 x, y;
+	bool ignore = false;
 
 	if (points == NULL || npoints != 4 * QA_NPOINTS + 1)
 	{
@@ -1443,6 +1444,7 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 	// check for startAngle/arcAngle interaction
 	for (count = 0; count < (QA_NPOINTS*4); count++)
 	{
+		ignore = false;
 		// open wedge segment
 		if ((count < startAngle && arclength > 0 && count > arclength) || 
 			(arclength < 0 && count < startAngle) ||
@@ -1455,7 +1457,7 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 			}
 			else
 			{
-				break;
+				ignore = true;
 			}
 		}
 		else if (count < 90) // quadrant 1
@@ -1479,11 +1481,14 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 			y = tr . y + tr . height           - (qa_points[k] . y * rr_height / MAXINT2);
 		}
 
-		if (x != points[i-1] . x || y != points[i-1] . y)
+		if (ignore == false)
 		{
-			points[i] . x = x;
-			points[i] . y = y;
-			i++;
+			if (x != points[i-1] . x || y != points[i-1] . y)
+			{
+				points[i] . x = x;
+				points[i] . y = y;
+				i++;
+			}
 		}
 
 		j--;

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -1397,7 +1397,7 @@ void MCU_snap(int2 &p)
 // MDW-2014-07-09: [[ oval_points ]] need to factor in startAngle and arcAngle
 // this is now used for both roundrects and ovals
 void MCU_roundrect(MCPoint *&points, uint2 &npoints,
-                   const MCRectangle &rect, uint2 radius, uint2 startAngle, uint2 arcAngle)
+                   const MCRectangle &rect, uint2 radius, uint2 startAngle, uint2 arcAngle, uint2 flags)
 {
 	uint2 i, j, k, count;
 	uint2 x, y;
@@ -1448,8 +1448,15 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 			(arclength < 0 && count < startAngle) ||
 			(arclength < 0 && count > arcAngle+startAngle) )
 		{
-			x = origin_horiz;
-			y = origin_vert;
+			if (flags & F_OPAQUE)
+			{
+				x = origin_horiz;
+				y = origin_vert;
+			}
+			else
+			{
+				break;
+			}
 		}
 		else if (count < 90) // quadrant 1
 		{

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -145,7 +145,7 @@ extern void MCU_snap(int2 &p);
 
 // MDW-2014-07-06: [[ oval_points ]]
 extern void MCU_roundrect(MCPoint *&points, uint2 &npoints,
-                   const MCRectangle &rect, uint2 radius, uint2 startAngle, uint2 arcAngle);
+                   const MCRectangle &rect, uint2 radius, uint2 startAngle, uint2 arcAngle, uint2 flags);
 #ifdef LEGACY_EXEC
 extern void MCU_unparsepoints(MCPoint *points, uint2 npoints, MCExecPoint &);
 #endif

--- a/rules/common.linux.makefile
+++ b/rules/common.linux.makefile
@@ -53,7 +53,9 @@ DEFINES += __LITTLE_ENDIAN__
 
 PACKAGE_INCLUDES=$(shell pkg-config --silence-errors --cflags-only-I $(GLOBAL_PACKAGES))
 
-FALLBACK_INCLUDES=-I$(SOLUTION_DIR)/thirdparty/headers/linux/include -I$(SOLUTION_DIR)/thirdparty/headers/linux/include/cairo
+# MDW-2014-11-20 [[ fix_valgrind_path]]
+# avoids the libcairo compilation error
+FALLBACK_INCLUDES=-I$(SOLUTION_DIR)/thirdparty/headers/linux/include -I$(SOLUTION_DIR)/thirdparty/headers/linux/include/cairo -I$(SOLUTION_DIR)/thirdparty/headers/linux/include/valgrind
 
 INCLUDES=$(CUSTOM_INCLUDES) $(TYPE_INCLUDES) $(GLOBAL_INCLUDES)
 


### PR DESCRIPTION
Previously, non-opaque unclosed ovals would act the same as closed ovals. Thus rotating them would create a visible wedge. This fixes the problem by not creating extra points for the oval if it is not opaque and there is an open arc.

Note that this also includes the makefile patch so that it could be compiled on a 64-bit linux system.
