### PR TITLE
Fix to oval rendering.

### DIFF
--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -840,7 +840,7 @@ bool MCGraphic::get_points_for_roundrect(MCPoint*& r_points, uint2& r_point_coun
 {
 	r_points = NULL;
 	r_point_count = 0;
-	MCU_roundrect(r_points, r_point_count, rect, roundradius, 0, 0);
+	MCU_roundrect(r_points, r_point_count, rect, roundradius, 0, 0, flags);
 	return (true);
 }
 
@@ -896,7 +896,7 @@ bool MCGraphic::get_points_for_oval(MCPoint*& r_points, uint2& r_point_count)
 		tRadius = rect.height;
 	else
 		tRadius = rect.width;
-	MCU_roundrect(r_points, r_point_count, rect, tRadius / 2, startangle, arcangle);
+	MCU_roundrect(r_points, r_point_count, rect, tRadius / 2, startangle, arcangle, flags);
 	return (true);
 }
 

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -145,7 +145,7 @@ extern void MCU_snap(int2 &p);
 
 // MDW-2014-07-06: [[ oval_points ]]
 extern void MCU_roundrect(MCPoint *&points, uint2 &npoints,
-                   const MCRectangle &rect, uint2 radius, uint2 startAngle, uint2 arcAngle);
+                   const MCRectangle &rect, uint2 radius, uint2 startAngle, uint2 arcAngle, uint2 flags);
 #ifdef LEGACY_EXEC
 extern void MCU_unparsepoints(MCPoint *points, uint2 npoints, MCExecPoint &);
 #endif


### PR DESCRIPTION
Previously, non-opaque unclosed ovals would act the same as closed
ovals.  Thus rotating them would create a visible wedge. This fixes
the problem by not creating extra points for the oval if it is not
opaque and there is an open arc.

(Originally submitted as #1521 by @mwieder; I've rebased it against develop-7.0 branch).
