### PR TITLE
libfoundation: The "unspecified" record base type is kMCNullTypeInfo not...

### DIFF
--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -91,7 +91,7 @@ bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, index_t p_fie
 {
 	MCTypeInfoRef t_resolved_base;
 	t_resolved_base = nil;
-	if (p_base != nil)
+	if (p_base != kMCNullTypeInfo)
 	{
 		t_resolved_base = __MCTypeInfoResolve(p_base);
 		MCAssert((t_resolved_base -> flags & kMCTypeInfoTypeCodeMask) == kMCValueTypeCodeRecord);


### PR DESCRIPTION
... nil.

Fixes bug introduced (by me) in commit e50f93921882.
