### PR TITLE
[[ Bug 13695 ]] MCU_fix_path: Correctly handle '..' as 2nd relpath component

### DIFF
--- a/docs/notes/bugfix-13695.md
+++ b/docs/notes/bugfix-13695.md
@@ -1,0 +1,1 @@
+# Correctly handle '..' as 2nd path element when simplifying relative paths.

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -2271,15 +2271,24 @@ void MCU_fix_path(MCStringRef in, MCStringRef& r_out)
 		        && *(fptr + 2) == '.' && *(fptr + 3) == '/')
 		{//look for "/../" pattern
             if (fptr == t_unicode_str)
+				/* Delete "/.." component */
 				t_length -= strmove(fptr, fptr + 3, true);
 			else
 			{
 				unichar_t *bptr = fptr - 1;
 				while (True)
 				{ //search backword for '/'
-					if (*bptr == '/' || bptr == t_unicode_str)
+					if (*bptr == '/')
 					{
+						/* Delete "/xxx/.." component */
 						t_length -= strmove(bptr, fptr + 3, true);
+						fptr = bptr;
+						break;
+					}
+					else if (bptr == t_unicode_str)
+					{
+						/* Delete "xxx/../" component */
+						t_length -= strmove (bptr, fptr + 4, true);
 						fptr = bptr;
 						break;
 					}


### PR DESCRIPTION
MCU_fix_path() previously implemented the following transformations:

```
 /../suffix           --> /suffix       [correct]
 prefix/xxx/../suffix --> prefix/suffix [correct]
 xxx/../suffix        --> /suffix       [incorrect]
```

This problem only occurred when the path component cancelled by a '..'
path component occurred as the first element in a relative path.

This patch corrects the handling by ensuring that when a second path
separator cannot be located before the '..' component, one is removed
from after it instead.
