### PR TITLE
[[ Bug 13871 ]] Do not specify AI_ADDRCONFIG flag to getaddrinfo(3).

### DIFF
--- a/docs/notes/bugfix-13871.md
+++ b/docs/notes/bugfix-13871.md
@@ -1,0 +1,1 @@
+# Allow hostname to IP address resolution when only loopback interfaces are configured.

--- a/engine/src/socket_resolve.cpp
+++ b/engine/src/socket_resolve.cpp
@@ -66,7 +66,7 @@ bool addrinfo_lookup(const char *p_name, const char *p_port, int p_socktype, str
 	t_hints.ai_socktype = p_socktype;
 	// specify IPv4 addresses only
 	t_hints.ai_family = AF_INET;
-	t_hints.ai_flags = AI_ADDRCONFIG;
+	t_hints.ai_flags = 0;
 
 	int t_status;
 


### PR DESCRIPTION
The AI_ADDRCONFIG flag allows getaddrinfo to return much faster in
some circumstances, but it will ignore any IP addresses configured on
the loopback interface.  This can be an issue when attempting to
connect to servers on the local machine without any network
interfaces configured.

See also https://bugzilla.redhat.com/show_bug.cgi?id=721350.
