### PR TITLE
[[ Bug 13591 ]] Initialise the "shellCommand" on OS X server.

### DIFF
--- a/docs/notes/bugfix-13591.md
+++ b/docs/notes/bugfix-13591.md
@@ -1,0 +1,1 @@
+# Set default value for the "shellCommand" on LiveCode Mac OS X server.

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -4435,6 +4435,8 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         sigaction(SIGILL, &action, NULL);
         sigaction(SIGBUS, &action, NULL);
         
+        MCValueAssign(MCshellcmd, MCSTR("/bin/sh"));
+        
 #ifndef _MAC_SERVER
         // MW-2010-05-11: Make sure if stdin is not a tty, then we set non-blocking.
         //   Without this you can't poll read when a slave process.
@@ -4462,10 +4464,6 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         for(uint4 i = 0; i < 256; ++i)
             MClowercasingtable[i] = (uint1)i;
         LowercaseText((char *)MClowercasingtable, 256, smRoman);
-        
-        // MW-2013-03-22: [[ Bug 10772 ]] Make sure we initialize the shellCommand
-        //   property here (otherwise it is nil in -ui mode).
-        MCValueAssign(MCshellcmd, MCSTR("/bin/sh"));
         
         //
         

--- a/engine/src/srvcgi.cpp
+++ b/engine/src/srvcgi.cpp
@@ -1068,21 +1068,21 @@ static bool cgi_multipart_header_callback(void *p_context, MCMultiPartHeader *p_
 				if (MCCStringEqualCaseless(p_header->param_name[i], "name"))
                 {
                     MCAutoStringRef t_name;
-                    MCStringCreateWithCStringAndRelease((char_t*)p_header->param_value[i], &t_name);
+                    MCStringCreateWithCStringAndRelease(p_header->param_value[i], &t_name);
                     MCNameCreate(*t_name, t_context->name);
                 }
 				else if (MCCStringEqualCaseless(p_header->param_name[i], "filename"))
-                    MCStringCreateWithCStringAndRelease((char_t*)p_header->param_value[i], t_context->file_name);
+                    MCStringCreateWithCStringAndRelease(p_header->param_value[i], t_context->file_name);
 			}
 		}
 		else if (MCCStringEqualCaseless(p_header->name, "Content-Type"))
 		{
-            MCStringCreateWithCStringAndRelease((char_t*)p_header->value, t_context->type);
+            MCStringCreateWithCStringAndRelease(p_header->value, t_context->type);
 			
 			for (uint32_t i = 0; i < p_header->param_count; i++)
 			{
 				if (MCCStringEqualCaseless(p_header->param_name[i], "boundary"))
-                    MCStringCreateWithCStringAndRelease((char_t*)p_header->param_value[i], t_context->boundary);
+                    MCStringCreateWithCStringAndRelease(p_header->param_value[i], t_context->boundary);
 			}
 		}
 	}


### PR DESCRIPTION
Previously it was only initialised for OS X in desktop mode.

Requires #1556.
