### PR TITLE
[[ Bug 14013 ]] Iterate over the keys of the RHS not the LHS in MCMathAr...

### DIFF
--- a/engine/src/exec-math.cpp
+++ b/engine/src/exec-math.cpp
@@ -833,10 +833,10 @@ void MCMathArrayApplyOperationWithArray(MCExecContext& ctxt, MCArrayRef p_left, 
 	uintptr_t t_index = 0;
 
 	MCS_seterrno(0);
-	while (MCArrayIterate(p_left, t_index, t_key, t_value_left))
+	while (MCArrayIterate(p_right, t_index, t_key, t_value_right))
 	{
 		real64_t t_double_left, t_double_right;
-		if (!MCArrayFetchValue(p_right, ctxt.GetCaseSensitive(), t_key, t_value_right) ||
+		if (!MCArrayFetchValue(p_left, ctxt.GetCaseSensitive(), t_key, t_value_left) ||
 			!ctxt.ConvertToReal(t_value_left, t_double_left) ||
 			!ctxt.ConvertToReal(t_value_right, t_double_right))
 		{


### PR DESCRIPTION
...rayApplyOperationWithArray()

If you have two arrays `A` and `B`and do

```
multiply A by B
```

then in 6.7 `A` can contain keys that are not present in `B`, they are just left unchanged, but in 7.0 this was raising an error.  The problem was that `MCMathArrayApplyOperationWithArray()` was iterating over the keys of the left hand argument, eg `A`, and not the keys of the right hand side.
