### PR TITLE
[[ Bug 14141 ]] Delay playStopped message when in AVFoundation, to avoid...

### DIFF
--- a/docs/notes/bugfix-14141.md
+++ b/docs/notes/bugfix-14141.md
@@ -1,0 +1,1 @@
+#      IDE Unresponsive after setting the fileName of a player object during a playStopped message 

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -2613,7 +2613,8 @@ void MCPlayer::moviefinished(void)
 {
     // PM-2014-08-06: [[ Bug 13104 ]] Set rate to zero when movie finish
     rate = 0.0;
-    timer(MCM_play_stopped, nil);
+    // PM-2014-12-02: [[ Bug 14141 ]] Delay the playStopped message to prevent IDE hang in case where the player's filename is set in the playStopped message (AVFoundation does not like nested callbacks)
+    MCscreen -> delaymessage(this, MCM_play_stopped);
 }
 
 void MCPlayer::SynchronizeUserCallbacks(void)


### PR DESCRIPTION
... unresponsiveness due to nested callbacks
