### PR TITLE
libfoundation: __MCTypeInfoResolve(): Sanity check for unbound named types

### DIFF
--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -790,6 +790,7 @@ MCTypeInfoRef __MCTypeInfoResolve(__MCTypeInfo *self)
     if (__MCTypeInfoGetExtendedTypeCode(self) != kMCTypeInfoTypeIsNamed)
         return self;
     
+	MCAssert (self -> named . typeinfo != nil);
     return self -> named . typeinfo;
 }
 


### PR DESCRIPTION
Add a sanity check assertion to catch any attempt to resolve named
type infos that haven't been bound to a concrete type info
(i.e. programmer error).
