### PR TITLE
[[ Bug 12726 ]] Avoid to dereference a nil stack pointer on copying an o...

### DIFF
--- a/docs/notes/bugfix-12726.md
+++ b/docs/notes/bugfix-12726.md
@@ -1,0 +1,1 @@
+# Crash if you copy the tempate button

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -497,7 +497,11 @@ Exec_errors MCClipboardCmd::processtocontainer(MCObjectRef *p_objects, uint4 p_o
 
 				MCControl *t_new_control;
 				t_new_control = static_cast<MCControl *>(t_new_object);
-				if (p_dst -> getstack() != t_old_parent -> getstack())
+                // SN-2014-12-08: [[ Bug 12726 ]] Avoid to dereference a nil pointer (and fall back
+                //  to the default stack).
+                if (t_old_parent == NULL)
+                    t_new_control -> resetfontindex(MCdefaultstackptr);
+                else if (p_dst -> getstack() != t_old_parent -> getstack())
 					t_new_control -> resetfontindex(t_old_parent -> getstack());
 
 				// MW-2011-08-18: [[ Layers ]] Invalidate the whole object.


### PR DESCRIPTION
...bject
