### PR TITLE
🍄 [[feature-objectuuids]] Add native support for object UUIDs to the engine.

### DIFF
--- a/engine/Makefile.kernel
+++ b/engine/Makefile.kernel
@@ -28,6 +28,7 @@ SOURCES=\
 	itransform.cpp keywords.cpp line.cpp literal.cpp magnify.cpp mcerror.cpp \
 	mcio.cpp mcstring.cpp mctheme.cpp newobj.cpp \
 	object.cpp objptr.cpp operator.cpp paragraf.cpp param.cpp \
+	objectid.cpp \
 	property.cpp pickle.cpp \
 	regex.cpp \
 	region.cpp \

--- a/engine/Makefile.kernel-server
+++ b/engine/Makefile.kernel-server
@@ -26,6 +26,7 @@ SOURCES=\
 	itransform.cpp keywords.cpp line.cpp literal.cpp magnify.cpp mcerror.cpp \
 	mcio.cpp mcstring.cpp mctheme.cpp newobj.cpp \
 	object.cpp objptr.cpp operator.cpp paragraf.cpp param.cpp \
+	objectid.cpp \
 	property.cpp pickle.cpp \
 	regex.cpp \
 	region.cpp \

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -2506,4 +2506,26 @@ void MCDispatch::GetDefaultPattern(MCExecContext& ctxt, uinteger_t*& r_pattern)
     r_pattern = nil;
 }
 
+////////////////////////////////////////////////////////////////
+// Finding things by UUID
+//
+
+MCObject *
+MCDispatch::GetObjectByUuid (const MCUuid & p_uuid)
+{
+	if (stacks == NULL) return NULL;
+
+	MCObject *t_obj = NULL;
+	MCStack *t_iter = stacks;
+	do
+	{
+		t_obj = t_iter->GetObjectByUuid (p_uuid);
+		if (t_obj) break;
+		t_iter = t_iter->next();
+	}
+	while (t_iter != stacks);
+
+	return t_obj;
+}
+
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -211,6 +211,9 @@ public:
 	
 	// IM-2014-07-23: [[ Bug 12930 ]] Replace findchildstack method with iterating method
 	bool foreachchildstack(MCStack *p_stack, MCStackForEachCallback p_callback, void *p_context);
+
+	/* Get an object by UUID, searching all stacks */
+	MCObject *GetObjectByUuid (const MCUuid &);
 	
 	MCObject *getobjid(Chunk_term type, uint4 inid);
 	MCObject *getobjname(Chunk_term type, MCNameRef);

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -99,6 +99,7 @@ MCObject::MCObject()
 {
 	parent = NULL;
 	obj_id = 0;
+	have_uuid = false;
 	/* UNCHECKED */ MCNameClone(kMCEmptyName, _name);
 	flags = F_VISIBLE | F_SHOW_BORDER | F_3D | F_OPAQUE;
 	fontheight = 0;
@@ -164,6 +165,7 @@ MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
 	/* UNCHECKED */ MCNameClone(oref . getname(), _name);
 	
 	obj_id = 0;
+	have_uuid = false; /* The copy isn't the same object; require new UUID */
 	rect = oref.rect;
 	flags = oref.flags;
 	fontheight = oref.fontheight;
@@ -4819,6 +4821,31 @@ MCRectangle MCObject::measuretext(MCStringRef p_text, bool p_is_unicode)
 bool MCObject::visit(MCVisitStyle p_style, uint32_t p_part, MCObjectVisitor *p_visitor)
 {
 	return p_visitor -> OnObject(this);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+bool
+MCObject::GetUuid (MCUuid & r_uuid)
+{
+	/* Only generate a UUID the first time that one is requested. */
+	if (!have_uuid)
+	{
+		if (!MCUuidGenerateRandom(uuid))
+			return false;
+		have_uuid = true;
+	}
+
+	r_uuid = uuid;
+	return true;
+}
+
+bool
+MCObject::SetUuid (MCUuid p_uuid)
+{
+	uuid = p_uuid;
+	have_uuid = true;
+	return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4857,6 +4857,10 @@ MCObject::GetUuid (MCUuid & r_uuid)
 bool
 MCObject::SetUuid (const MCUuid & p_uuid)
 {
+	/* If the object is in the ID cache, uncache it since its ID is changing. */
+	if (getinidcache() && have_uuid)
+		getstack()->uncacheobjectbyid(this);
+
 	uuid = p_uuid;
 	have_uuid = true;
 	return true;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -96,6 +96,7 @@ MCColor MCObject::maccolors[MAC_NCOLORS] = {
         };
 
 MCObject::MCObject()
+	: _id(*this)
 {
 	parent = NULL;
 	obj_id = 0;
@@ -155,7 +156,8 @@ MCObject::MCObject()
 	m_script_encrypted = false;
 }
 
-MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
+MCObject::MCObject(const MCObject &oref)
+	: MCDLlist(oref), _id(*this)
 {
 	if (oref.parent == NULL)
 		parent = MCdefaultstackptr;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4826,13 +4826,27 @@ bool MCObject::visit(MCVisitStyle p_style, uint32_t p_part, MCObjectVisitor *p_v
 ///////////////////////////////////////////////////////////////////////////////
 
 bool
+MCObject::HasUuid (const MCUuid & p_uuid) const
+{
+	if (!have_uuid) return false;
+	return (0 == MCUuidCompare (p_uuid, uuid));
+}
+
+bool
+MCObject::GetUuid (MCUuid & r_uuid) const
+{
+	if (!have_uuid) return false;
+	r_uuid = uuid;
+	return true;
+}
+
+bool
 MCObject::GetUuid (MCUuid & r_uuid)
 {
 	/* Only generate a UUID the first time that one is requested. */
 	if (!have_uuid)
 	{
-		if (!MCUuidGenerateRandom(uuid))
-			return false;
+		if (!MCUuidGenerateRandom (uuid)) return false;
 		have_uuid = true;
 	}
 
@@ -4841,7 +4855,7 @@ MCObject::GetUuid (MCUuid & r_uuid)
 }
 
 bool
-MCObject::SetUuid (MCUuid p_uuid)
+MCObject::SetUuid (const MCUuid & p_uuid)
 {
 	uuid = p_uuid;
 	have_uuid = true;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -413,8 +413,25 @@ public:
 	Exec_stat changeid(uint32_t new_id);
 #endif
 
+	////////// UUIDS
+
+	/* Returns false until the object has had a UUID allocated to it. */
+	bool HasUuid(void) const { return have_uuid; }
+	/* Returns false unless the object has a UUID and it matches the specified
+	 * p_uuid. */
+	bool HasUuid(const MCUuid &) const;
+	/* Obtain the object's UUID.  If it does not yet have one,
+	 * attempts to allocate a pseudorandomly-generated UUID.  Returns
+	 * false on failure. */
 	bool GetUuid(MCUuid &);
-	bool SetUuid(MCUuid);
+	/* Obtain the object's UUID, if it has one.  If not, returns
+	 * false.  Note: this can be interpreted as failing to allocate a
+	 * UUID because the object is const. */
+	bool GetUuid(MCUuid &) const;
+	/* Set the UUID of the object to a specific value. */
+	bool SetUuid(const MCUuid &);
+
+	//////////
 
 	uint4 getid() const
 	{

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -29,6 +29,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #endif
 
 #include "globals.h"
+#include "uuid.h"
 
 enum {
     MAC_SHADOW,
@@ -191,6 +192,8 @@ class MCObject : public MCDLlist
 {
 protected:
 	uint4 obj_id;
+	MCUuid uuid;
+	bool have_uuid;
 	MCObject *parent;
 	MCNameRef _name;
 	uint4 flags;
@@ -409,6 +412,9 @@ public:
 	Exec_stat setprops(uint32_t parid, MCExecPoint& ep);
 	Exec_stat changeid(uint32_t new_id);
 #endif
+
+	bool GetUuid(MCUuid &);
+	bool SetUuid(MCUuid);
 
 	uint4 getid() const
 	{

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -29,7 +29,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #endif
 
 #include "globals.h"
-#include "uuid.h"
+#include "objectid.h"
 
 enum {
     MAC_SHADOW,
@@ -1215,6 +1215,57 @@ private:
 	void mapfont(void);
 	void unmapfont(void);
 
+	////////// OBJECT ID MANAGEMENT
+protected:
+	/* MCConcreteObjectId is an MCObjectId that's permanently and directly
+	 * associated with a particular MCObject instance.  The accessors
+	 * operate directly on the associated MCObject.  The lifetime of an
+	 * MCConcreteObjectId instance is tied to its associated MCObject. */
+	class MCConcreteObjectId: public MCObjectId
+	{
+	public:
+		virtual MCObject *Get (void) const
+		{ return &m_owner; }
+
+		virtual void SetUuid (const MCUuid & p_uuid)
+		{ m_owner.SetUuid (p_uuid); }
+		virtual bool HasUuid (void) const
+		{ return m_owner.HasUuid (); }
+		virtual bool GetUuid (MCUuid & r_uuid) const
+		{ return m_owner.GetUuid (r_uuid); }
+
+		virtual void SetId (id_t p_id);
+		virtual bool HasId (void) const
+		{ return (0 != m_owner.getid ()); }
+		virtual id_t GetId (void) const
+		{ return m_owner.getid (); }
+
+		virtual void SetName (MCNameRef p_name)
+		{ m_owner.setname (p_name); }
+		virtual bool HasName (void) const
+		{ return !m_owner.hasname (kMCEmptyName); }
+		virtual MCNameRef GetName (void) const
+		{ return m_owner.getname (); }
+
+	protected:
+		MCConcreteObjectId (MCObject & p_owner)
+			: m_owner (p_owner)
+		{}
+
+		MCObject & m_owner;
+
+		friend class MCObject;
+	};
+
+private:
+	MCConcreteObjectId _id;
+
+public:
+	/* Get the MCObject's concrete object ID instance */
+	virtual const MCObjectId & GetObjectId (void) const { return _id; };
+
+	//////////
+
 	friend class MCObjectHandle;
 	friend class MCEncryptedStack;
 };
@@ -1263,4 +1314,7 @@ public:
 		return (MCObjectList *)MCDLlist::remove((MCDLlist *&)list);
 	}
 };
+
+////////////////////////////////////////////////////////////////
+
 #endif

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -422,6 +422,10 @@ public:
 	{
 		obj_id = inid;
 	}
+	void setaltid(uint4 p_id)
+	{
+		altid = p_id;
+	}
 
 	// Returns true if the object has not been named.
 	bool isunnamed(void) const

--- a/engine/src/objectid.cpp
+++ b/engine/src/objectid.cpp
@@ -205,6 +205,11 @@ MCDelayedObjectId::SetName (MCNameRef p_name)
 const MCObjectId *
 MCDelayedObjectId::Resolve (void) const
 {
+	MCObject *t_obj = Get();
+
+	if (!t_obj)
+		return NULL;
+
 	return &(Get()->GetObjectId());
 }
 

--- a/engine/src/objectid.cpp
+++ b/engine/src/objectid.cpp
@@ -46,27 +46,27 @@ MCDelayedObjectId::MCDelayedObjectId ()
 	  m_name (NULL)
 {}
 
-MCDelayedObjectId::MCDelayedObjectId (const MCObjectId & id)
+MCDelayedObjectId::MCDelayedObjectId (const MCObjectId * id)
 	: m_context (NULL)
 {
-	m_have_uuid = id.HasUuid();
+	m_have_uuid = id->HasUuid();
 	if (m_have_uuid)
-		id.GetUuid (m_uuid);
+		id->GetUuid (m_uuid);
 
-	m_have_id = id.HasId();
+	m_have_id = id->HasId();
 	if (m_have_id)
-		m_id = id.GetId();
+		m_id = id->GetId();
 
-	m_name = id.HasName() ? MCValueRetain (id.GetName()) : NULL;
+	m_name = id->HasName() ? MCValueRetain (id->GetName()) : NULL;
 }
 
-MCDelayedObjectId::MCDelayedObjectId (const MCDelayedObjectId & id)
-	: m_context (id.m_context),
-	  m_uuid (id.m_uuid),
-	  m_have_uuid (id.m_have_uuid),
-	  m_id (id.m_id),
-	  m_have_id (id.m_have_id),
-	  m_name (MCValueRetain (id.m_name))
+MCDelayedObjectId::MCDelayedObjectId (const MCDelayedObjectId * id)
+	: m_context (id->m_context),
+	  m_uuid (id->m_uuid),
+	  m_have_uuid (id->m_have_uuid),
+	  m_id (id->m_id),
+	  m_have_id (id->m_have_id),
+	  m_name (MCValueRetain (id->m_name))
 {
 }
 

--- a/engine/src/objectid.cpp
+++ b/engine/src/objectid.cpp
@@ -1,0 +1,305 @@
+/*                                                                   -*- c++ -*-
+Copyright (C) 2003-2014 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "prefix.h"
+
+#include "objdefs.h"
+#include "parsedef.h"
+
+#include "object.h"
+#include "dispatch.h"
+#include "stack.h"
+#include "exec.h"
+
+#include "objectid.h"
+
+/* ================================================================
+ * MCDelayedObjectId
+ * ================================================================ */
+
+/* The delayed object ID is a reference to an MCObject instance that
+ * may not exist yet. */
+
+/* ----------------------------------------------------------------
+ * Construction
+ * ---------------------------------------------------------------- */
+
+MCDelayedObjectId::MCDelayedObjectId ()
+	: m_context (NULL),
+	  m_have_uuid (false),
+	  m_id (0),
+	  m_have_id (false),
+	  m_name (NULL)
+{}
+
+MCDelayedObjectId::MCDelayedObjectId (const MCObjectId & id)
+	: m_context (NULL)
+{
+	m_have_uuid = id.HasUuid();
+	if (m_have_uuid)
+		id.GetUuid (m_uuid);
+
+	m_have_id = id.HasId();
+	if (m_have_id)
+		m_id = id.GetId();
+
+	m_name = id.HasName() ? MCValueRetain (id.GetName()) : NULL;
+}
+
+MCDelayedObjectId::MCDelayedObjectId (const MCDelayedObjectId & id)
+	: m_context (id.m_context),
+	  m_uuid (id.m_uuid),
+	  m_have_uuid (id.m_have_uuid),
+	  m_id (id.m_id),
+	  m_have_id (id.m_have_id),
+	  m_name (MCValueRetain (id.m_name))
+{
+}
+
+MCDelayedObjectId::MCDelayedObjectId (MCUuid p_uuid,
+                                      const MCObject *p_context)
+	: m_id (0),
+	  m_have_id (false),
+	  m_name (NULL)
+{
+	SetUuid (p_uuid);
+	SetContext (p_context);
+}
+
+MCDelayedObjectId::MCDelayedObjectId (MCUuid p_uuid,
+                                      const MCObjectId *p_context)
+	: m_id (0),
+	  m_have_id (false),
+	  m_name (NULL)
+{
+	SetUuid (p_uuid);
+	SetContext (p_context);
+}
+
+MCDelayedObjectId::MCDelayedObjectId (MCObjectId::id_t p_id,
+                                      const MCObject *p_context)
+	: m_have_uuid (false),
+	  m_name (NULL)
+{
+	SetId (p_id);
+	SetContext (p_context);
+}
+
+MCDelayedObjectId::MCDelayedObjectId (MCObjectId::id_t p_id,
+                                      const MCObjectId *p_context)
+	: m_have_uuid (false),
+	  m_name (NULL)
+{
+	SetId (p_id);
+	SetContext (p_context);
+}
+
+MCDelayedObjectId::MCDelayedObjectId (MCNameRef p_name,
+                                      const MCObject *p_context)
+	: m_have_uuid (false),
+	  m_id (0),
+	  m_have_id (false),
+	  m_name (NULL)
+{
+	SetName (p_name);
+	SetContext (p_context);
+}
+
+MCDelayedObjectId::MCDelayedObjectId (MCNameRef p_name,
+                                      const MCObjectId *p_context)
+	: m_have_uuid (false),
+	  m_id (0),
+	  m_have_id (false),
+	  m_name (NULL)
+{
+	SetName (p_name);
+	SetContext (p_context);
+}
+
+/* ----------------------------------------------------------------
+ * Destruction
+ * ---------------------------------------------------------------- */
+
+MCDelayedObjectId::~MCDelayedObjectId (void)
+{
+	MCValueRelease (m_name);
+}
+
+/* ----------------------------------------------------------------
+ * UUIDs
+ * ---------------------------------------------------------------- */
+
+void
+MCDelayedObjectId::SetUuid (const MCUuid & p_uuid)
+{
+	m_uuid = p_uuid;
+	m_have_uuid = true;
+}
+
+bool
+MCDelayedObjectId::GetUuid (MCUuid & r_uuid) const
+{
+	if (!m_have_uuid) return false;
+	r_uuid = m_uuid;
+	return true;
+}
+
+/* ----------------------------------------------------------------
+ * ID & name resolution contexts
+ * ---------------------------------------------------------------- */
+
+void
+MCDelayedObjectId::SetContext (const MCObject *p_context)
+{
+	MCAssert (p_context);
+	SetContext(&p_context->GetObjectId ());
+}
+
+void
+MCDelayedObjectId::SetContext (const MCObjectId *p_context)
+{
+	m_context = p_context;
+}
+
+/* ----------------------------------------------------------------
+ * IDs
+ * ---------------------------------------------------------------- */
+
+void
+MCDelayedObjectId::SetId (MCObjectId::id_t p_id)
+{
+	m_id = p_id;
+	m_have_id = true;
+}
+
+/* ----------------------------------------------------------------
+ * Names
+ * ---------------------------------------------------------------- */
+
+void
+MCDelayedObjectId::SetName (MCNameRef p_name)
+{
+	MCAssert (p_name);
+	MCValueRelease (m_name);
+	m_name = MCValueRetain (p_name);
+}
+
+/* ----------------------------------------------------------------
+ * Resolution
+ * ---------------------------------------------------------------- */
+
+const MCObjectId *
+MCDelayedObjectId::Resolve (void) const
+{
+	return &(Get()->GetObjectId());
+}
+
+MCObject *
+MCDelayedObjectId::Get (void) const
+{
+	MCObject *t_obj = NULL;
+
+	/* Resolve context object and acquire context stack */
+	MCStack *t_context_stack;
+	if (HasContext ())
+	{
+		MCObject *t_context_obj;
+		t_context_obj = GetContext () -> Get ();
+		t_context_stack = t_context_obj ? t_context_obj->getstack () : NULL;
+	}
+	else
+		t_context_stack = NULL;
+
+	if (HasUuid ())
+	{
+		MCUuid t_uuid;
+		GetUuid (t_uuid);
+		if (!t_obj && t_context_stack)
+			t_obj = t_context_stack->GetObjectByUuid (t_uuid);
+		else if (!t_obj)
+			t_obj = MCdispatcher->GetObjectByUuid (t_uuid);
+	}
+
+	if (HasId ())
+	{
+		if (t_context_stack)
+		{
+			if (!t_obj) /* Stacks (& substacks) */
+				t_obj = t_context_stack->findstackid (GetId ());
+			if (!t_obj) /* Controls */
+				t_obj = t_context_stack->getobjid (CT_ANY, GetId ());
+			if (!t_obj) /* Audio */
+				t_obj = t_context_stack->getobjid (CT_AUDIO_CLIP, GetId ());
+			if (!t_obj) /* Video */
+				t_obj = t_context_stack->getobjid (CT_VIDEO_CLIP, GetId ());
+		}
+		else
+		{
+			if (!t_obj) /* Stacks (& substacks) */
+				t_obj = MCdispatcher->findstackid (GetId ());
+			if (!t_obj) /* Controls */
+				t_obj = MCdispatcher->getobjid (CT_ANY, GetId ());
+			if (!t_obj) /* Audio */
+				t_obj = MCdispatcher->getobjid (CT_AUDIO_CLIP, GetId ());
+			if (!t_obj) /* Video */
+				t_obj = MCdispatcher->getobjid (CT_VIDEO_CLIP, GetId ());
+		}
+	}
+
+	if (HasName ())
+	{
+		t_obj = NULL;
+		if (t_context_stack)
+		{
+			if (!t_obj) /* Stacks (& substacks) */
+				t_obj = t_context_stack->findstackname (GetName ());
+			if (!t_obj) /* Controls */
+				t_obj = t_context_stack->getobjname (CT_ANY, GetName ());
+			if (!t_obj) /* Audio */
+				t_obj = t_context_stack->getobjname (CT_AUDIO_CLIP, GetName ());
+			if (!t_obj) /* Video */
+				t_obj = t_context_stack->getobjname (CT_VIDEO_CLIP, GetName ());
+		}
+		else
+		{
+			if (!t_obj) /* Stacks (& substacks) */
+				t_obj = MCdispatcher->findstackname (GetName ());
+			if (!t_obj) /* Controls */
+				t_obj = MCdispatcher->getobjname (CT_ANY, GetName ());
+			if (!t_obj) /* Audio */
+				t_obj = MCdispatcher->getobjname (CT_AUDIO_CLIP, GetName ());
+			if (!t_obj) /* Video */
+				t_obj = MCdispatcher->getobjname (CT_VIDEO_CLIP, GetName ());
+		}
+	}
+
+	return t_obj;
+}
+
+/* ================================================================
+ * MCObject::MCConcreteObjectId
+ * ================================================================ */
+
+void
+MCObject::MCConcreteObjectId::SetId (MCObjectId::id_t p_id)
+{
+	/* It's better to use the exec function because it ensures that
+	 * everything that depends on the ID is correctly updated (e.g. ID
+	 * lookup caches) */
+	MCExecContext t_ctxt;
+	Get()->SetId (t_ctxt, p_id);
+}

--- a/engine/src/objectid.h
+++ b/engine/src/objectid.h
@@ -1,0 +1,131 @@
+/*                                                                   -*- c++ -*-
+Copyright (C) 2003-2014 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef _MC_OBJECTID_H_
+#define _MC_OBJECTID_H_
+
+#include "uuid.h"
+
+/* ----------------------------------------------------------------
+ * MCObjectId (abstract)
+ * ---------------------------------------------------------------- */
+
+/* An MCObjectId contains the information about how to reference an
+ * MCObject instance.  Each MCObject encapsulates exactly one
+ * MCObjectId that references it and contains all of its identifying
+ * information. */
+
+class MCObject;
+
+/* Abstract base class */
+class MCObjectId
+{
+public:
+	typedef uint32_t id_t;
+
+	/* Return the object instance referenced by this object id, or
+	 * NULL if the referenced object cannot be found. */
+	virtual MCObject *Get (void) const = 0;
+
+	virtual void SetUuid (const MCUuid &) = 0;
+	virtual bool HasUuid (void) const = 0;
+	virtual bool GetUuid (MCUuid & r_uuid) const = 0;
+
+	virtual void SetId (id_t) = 0;
+	virtual bool HasId (void) const = 0;
+	virtual id_t GetId (void) const = 0;
+
+	virtual void SetName (MCNameRef) = 0;
+	virtual bool HasName (void) const = 0;
+	virtual MCNameRef GetName (void) const = 0;
+};
+
+/* ----------------------------------------------------------------
+ * MCDelayedObjectId
+ * ---------------------------------------------------------------- */
+
+/* MCDelayedObjectId is an MCObjectId that encapsulates identifying
+ * information without being tied to a specific MCObject instance.  At
+ * any time, its MCDelayedObjectId::Resolve() method may be used to
+ * attempt to obtain an MCConcreteObjectId. */
+class MCDelayedObjectId : public MCObjectId
+{
+public:
+	/* There are several different combinations of information that can be
+	 * used to create a delayed object ID. */
+	MCDelayedObjectId ();
+
+	/* Create a delayed object ID with the same identifying information as
+	 * in another object ID */
+	MCDelayedObjectId (const MCObjectId &);
+	MCDelayedObjectId (const MCDelayedObjectId &);
+
+	/* An object can only be uniquely identified by id or name if
+	 * these are resolved relative to a stack.  A context must be
+	 * provided in the form of an object instance or object ID, and
+	 * must be a stack or an object that is part of a stack. */
+	MCDelayedObjectId (id_t, const MCObject *);
+	MCDelayedObjectId (MCNameRef, const MCObject *);
+	MCDelayedObjectId (id_t, const MCObjectId *);
+	MCDelayedObjectId (MCNameRef, const MCObjectId *);
+
+	/* UUIDs may be resolved relative to a stack. */
+	MCDelayedObjectId (MCUuid p_uuid, const MCObject *p_context);
+	MCDelayedObjectId (MCUuid p_uuid, const MCObjectId *p_context=NULL);
+
+	/* Attempt to obtain a concrete object ID for the object instance
+	 * referenced by this delayed object ID.  Analogous to "ending the
+	 * delay".  Returns NULL if the object ID can't be resolved
+	 * yet. */
+	virtual const MCObjectId *Resolve (void) const;
+
+	/* Resolves this object ID and obtains the underlying object from
+	 * the resulting concrete object ID.  Returns NULL if the object
+	 * ID can't be resolved yet. */
+	virtual MCObject *Get (void) const;
+
+	virtual void SetUuid (const MCUuid &);
+	virtual bool HasUuid (void) const { return m_have_uuid; }
+	/* If no UUID is set, returns false */
+	virtual bool GetUuid (MCUuid &) const;
+
+	virtual void SetId (id_t p_id);
+	virtual bool HasId (void) const { return m_have_id; }
+	/* If no ID is set, returns 0 */
+	virtual id_t GetId (void) const { return m_have_id ? m_id : 0; }
+
+	virtual void SetName (MCNameRef p_name);
+	virtual bool HasName (void) const { return (m_name != NULL); }
+	virtual MCNameRef GetName (void) const { return m_name; }
+
+	virtual void SetContext (const MCObjectId *);
+	virtual void SetContext (const MCObject *);
+	virtual bool HasContext (void) const { return (m_context != NULL); }
+	virtual const MCObjectId *GetContext (void) const {return m_context; }
+
+	~MCDelayedObjectId (void);
+
+protected:
+	const MCObjectId *m_context;
+	MCUuid m_uuid;
+	bool m_have_uuid;
+	id_t m_id;
+	bool m_have_id;
+	MCNameRef m_name;
+};
+
+#endif /* !_MC_OBJECTID_H_ */

--- a/engine/src/objectid.h
+++ b/engine/src/objectid.h
@@ -117,7 +117,7 @@ public:
 	virtual bool HasContext (void) const { return (m_context != NULL); }
 	virtual const MCObjectId *GetContext (void) const {return m_context; }
 
-	~MCDelayedObjectId (void);
+	virtual ~MCDelayedObjectId (void);
 
 protected:
 	const MCObjectId *m_context;

--- a/engine/src/objectid.h
+++ b/engine/src/objectid.h
@@ -71,8 +71,8 @@ public:
 
 	/* Create a delayed object ID with the same identifying information as
 	 * in another object ID */
-	MCDelayedObjectId (const MCObjectId &);
-	MCDelayedObjectId (const MCDelayedObjectId &);
+	MCDelayedObjectId (const MCObjectId *);
+	MCDelayedObjectId (const MCDelayedObjectId *);
 
 	/* An object can only be uniquely identified by id or name if
 	 * these are resolved relative to a stack.  A context must be

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -277,6 +277,7 @@ MCStack::MCStack()
 
 	// MW-2012-10-10: [[ IdCache ]]
 	m_id_cache = nil;
+	m_uuid_cache = nil;
     
     // MM-2014-07-31: [[ ThreadedRendering ]] Used to ensure only a single thread mutates the ID cache at a time.
     /* UNCHECKED */ MCThreadMutexCreate(m_id_cache_lock);
@@ -357,6 +358,7 @@ MCStack::MCStack(const MCStack &sref) : MCObject(sref)
 	
 	// MW-2012-10-10: [[ IdCache ]]
 	m_id_cache = nil;
+	m_uuid_cache = nil;
 	
     // MM-2014-07-31: [[ ThreadedRendering ]] Used to ensure only a single thread mutates the ID cache at a time.
     /* UNCHECKED */ MCThreadMutexCreate(m_id_cache_lock);

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -207,6 +207,7 @@ MCObjectPropertyTable MCStack::kPropertyTable =
 ////////////////////////////////////////////////////////////////////////////////
 
 MCStack::MCStack()
+	: _id(*this)
 {
 	obj_id = START_ID;
 	flags = F_VISIBLE | F_RESIZABLE | F_OPAQUE;
@@ -300,7 +301,8 @@ MCStack::MCStack()
 	view_init();
 }
 
-MCStack::MCStack(const MCStack &sref) : MCObject(sref)
+MCStack::MCStack(const MCStack &sref)
+	: MCObject(sref), _id(*this)
 {
 	obj_id = sref.obj_id;
 

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -738,6 +738,10 @@ public:
 	void removecontrol(MCControl *cptr);
 	void appendcard(MCCard *cptr);
 	void removecard(MCCard *cptr);
+
+	/* Get an object by UUID, searching relative to this stack. */
+	MCObject *GetObjectByUuid(const MCUuid &);
+
 	MCObject *getsubstackobjid(Chunk_term type, uint4 inid);
 	MCObject *getobjid(Chunk_term type, uint4 inid);
 	MCObject *getsubstackobjname(Chunk_term type, MCNameRef);

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -56,6 +56,7 @@ typedef struct _Mnemonic Mnemonic;
 struct MCStackModeData;
 
 class MCStackIdCache;
+class MCStackUuidCache;
 
 // MCStackSurface is an interim abstraction that should be rolled into the Window
 // abstraction at some point - it represents a display rendering target.
@@ -213,6 +214,7 @@ protected:
 	
 	// MW-2012-10-10: [[ IdCache ]]
 	MCStackIdCache *m_id_cache;
+	MCStackUuidCache *m_uuid_cache;
     
     // MM-2014-07-31: [[ ThreadedRendering ]] Used to ensure only a single thread mutates the ID cache at a time.
     MCThreadMutexRef m_id_cache_lock;
@@ -866,6 +868,8 @@ public:
 	void cacheobjectbyid(MCObject *object);
 	void uncacheobjectbyid(MCObject *object);
 	MCObject *findobjectbyid(uint32_t object);
+	/* Find an object by UUID */
+	MCObject *findobjectbyuuid(const MCUuid &);
 	void freeobjectidcache(void);
 
 	// MW-2013-11-07: [[ Bug 11393 ]] This returns true if the stack should use device-independent

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -1227,5 +1227,37 @@ private:
 	
 	bool mode_openasdialog(void);
 	void mode_closeasdialog(void);
+
+	////////// OBJECT ID MANAGEMENT
+protected:
+	/* MCConcreteStackId is a special version of MCConcreteObjectId
+	 * that's needed because stacks are identified by altid rather
+	 * than by id. */
+	class MCConcreteStackId: public MCObject::MCConcreteObjectId
+	{
+	public:
+		virtual void SetId (id_t p_id)
+		{ m_owner.setaltid (p_id); }
+		virtual bool HasId (void) const
+		{ return (0 != m_owner.getaltid ()); }
+		virtual id_t GetId (void) const
+		{ return m_owner.getaltid (); }
+
+	private:
+		MCConcreteStackId (MCObject & p_owner)
+			: MCConcreteObjectId(p_owner)
+		{}
+
+		friend class MCStack;
+	};
+
+private:
+	MCConcreteStackId _id;
+
+public:
+	/* Get the stack's concrete object ID instance */
+	virtual const MCObjectId & GetObjectId (void) const { return _id; };
+
+	//////////
 };
 #endif

--- a/engine/src/stackcache.cpp
+++ b/engine/src/stackcache.cpp
@@ -27,340 +27,355 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#define UINDEX_MAX UINT32_MAX
-#define UINDEX_MIN UINT32_MIN
-#define UINTPTR_MAX UINT32_MAX
-#define UINTPTR_MIN UINT32_MIN
-
-class MCStackIdCache
+template<typename K>
+class MCStackCache
 {
 public:
-	MCStackIdCache(void);
-	~MCStackIdCache(void);
-	
-	void CacheObject(MCObject *object);
-	void UncacheObject(MCObject *object);
-	MCObject *FindObject(uint32_t id);
-	
-	bool RehashBuckets(uindex_t p_new_count);
+	MCStackCache (void);
+	virtual ~MCStackCache (void);
+
+	virtual bool CacheObject (MCObject *object);
+	virtual void UncacheObject (MCObject *object);
+	MCObject *FindObject (const K & key) const;
+
+	bool RehashBuckets (uindex_t p_new_count);
+
+protected:
+	virtual hash_t KeyHash (const K & key) const = 0;
+	virtual compare_t KeyCompare (const K &, const K &) const = 0;
+	virtual void ObjectGetKey (MCObject *object, K & key) const = 0;
 
 private:
-	static hash_t HashId(uint32_t id);
+	uindex_t FindBucket (const K & key, hash_t hash) const;
+	uindex_t FindBucketIfExists (const K & key, hash_t hash) const;
+	uindex_t FindBucketAfterRehash (const K & key, hash_t hash) const;
 
-	uindex_t FindBucket(uint32_t id, hash_t hash);
-	uindex_t FindBucketIfExists(uint32_t id, hash_t hash);
-	uindex_t FindBucketAfterRehash(uint32_t id, hash_t hash);
-	
 	uindex_t m_capacity_idx;
 	uindex_t m_count;
 	uintptr_t *m_buckets;
+
+	static const uindex_t kNOTFOUND = UINDEX_MAX;
+	static const uintptr_t kUNUSED = UINTPTR_MIN;
+	static const uintptr_t kDELETED = UINTPTR_MAX;
 };
 
 // Prime numbers. Values above 100 have been adjusted up so that the
 // malloced block size will be just below a multiple of 512; values
 // above 1200 have been adjusted up to just below a multiple of 4096.
- const uindex_t __kMCValueHashTableSizes[] = {
-    0, 3, 7, 13, 23, 41, 71, 127, 191, 251, 383, 631, 1087, 1723,
-    2803, 4523, 7351, 11959, 19447, 31231, 50683, 81919, 132607,
-    214519, 346607, 561109, 907759, 1468927, 2376191, 3845119,
-    6221311, 10066421, 16287743, 26354171, 42641881, 68996069,
-    111638519, 180634607, 292272623, 472907251,
+
+const uindex_t __kMCValueHashTableSizes[] = {
+	0, 3, 7, 13, 23, 41, 71, 127, 191, 251, 383, 631, 1087, 1723,
+	2803, 4523, 7351, 11959, 19447, 31231, 50683, 81919, 132607,
+	214519, 346607, 561109, 907759, 1468927, 2376191, 3845119,
+	6221311, 10066421, 16287743, 26354171, 42641881, 68996069,
+	111638519, 180634607, 292272623, 472907251,
 #ifdef __HUGE__
-    765180413UL, 1238087663UL, 2003267557UL, 3241355263UL, 5244622819UL,
+	765180413UL, 1238087663UL, 2003267557UL, 3241355263UL, 5244622819UL,
 #if 0
-    8485977589UL, 13730600407UL, 22216578047UL, 35947178479UL,
-    58163756537UL, 94110934997UL, 152274691561UL, 246385626107UL,
-    398660317687UL, 645045943807UL, 1043706260983UL, 1688752204787UL,
-    2732458465769UL, 4421210670577UL, 7153669136377UL,
-    11574879807461UL, 18728548943849UL, 30303428750843UL
+	8485977589UL, 13730600407UL, 22216578047UL, 35947178479UL,
+	58163756537UL, 94110934997UL, 152274691561UL, 246385626107UL,
+	398660317687UL, 645045943807UL, 1043706260983UL, 1688752204787UL,
+	2732458465769UL, 4421210670577UL, 7153669136377UL,
+	11574879807461UL, 18728548943849UL, 30303428750843UL
 #endif
 #endif
 };
 
 const uindex_t __kMCValueHashTableCapacities[] = {
-    0, 3, 6, 11, 19, 32, 52, 85, 118, 155, 237, 390, 672, 1065,
-    1732, 2795, 4543, 7391, 12019, 19302, 31324, 50629, 81956,
-    132580, 214215, 346784, 561026, 907847, 1468567, 2376414,
-    3844982, 6221390, 10066379, 16287773, 26354132, 42641916,
-    68996399, 111638327, 180634415, 292272755,
+	0, 3, 6, 11, 19, 32, 52, 85, 118, 155, 237, 390, 672, 1065,
+	1732, 2795, 4543, 7391, 12019, 19302, 31324, 50629, 81956,
+	132580, 214215, 346784, 561026, 907847, 1468567, 2376414,
+	3844982, 6221390, 10066379, 16287773, 26354132, 42641916,
+	68996399, 111638327, 180634415, 292272755,
 #ifdef __HUGE__
-    472907503UL, 765180257UL, 1238087439UL, 2003267722UL, 3241355160UL,
+	472907503UL, 765180257UL, 1238087439UL, 2003267722UL, 3241355160UL,
 #if 0
-    5244622578UL, 8485977737UL, 13730600347UL, 22216578100UL,
-    35947178453UL, 58163756541UL, 94110935011UL, 152274691274UL,
-    246385626296UL, 398660317578UL, 645045943559UL, 1043706261135UL,
-    1688752204693UL, 2732458465840UL, 4421210670552UL,
-    7153669136706UL, 11574879807265UL, 18728548943682UL
+	5244622578UL, 8485977737UL, 13730600347UL, 22216578100UL,
+	35947178453UL, 58163756541UL, 94110935011UL, 152274691274UL,
+	246385626296UL, 398660317578UL, 645045943559UL, 1043706261135UL,
+	1688752204693UL, 2732458465840UL, 4421210670552UL,
+	7153669136706UL, 11574879807265UL, 18728548943682UL
 #endif
 #endif
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
-MCStackIdCache::MCStackIdCache(void)
+template <typename K>
+MCStackCache<K>::MCStackCache (void)
+	: m_capacity_idx (0), m_count (0), m_buckets (NULL)
 {
-	m_capacity_idx = 0;
-	m_count = 0;
-	m_buckets = nil;
 }
 
-MCStackIdCache::~MCStackIdCache(void)
+template <typename K>
+MCStackCache<K>::~MCStackCache (void)
 {
-	MCMemoryDeleteArray(m_buckets);
+	MCMemoryDeleteArray (m_buckets);
 }
 
-void MCStackIdCache::CacheObject(MCObject *p_object)
+template <typename K>
+bool
+MCStackCache<K>::CacheObject (MCObject *p_object)
 {
-	if (p_object -> getinidcache())
-		return;
-	
-	uint32_t t_id;
-	t_id = p_object -> getid();
-	
+	MCAssert (p_object != NULL);
+
+	K t_key;
 	hash_t t_hash;
-	t_hash = HashId(t_id);
-	
 	uindex_t t_target_slot;
-	t_target_slot = FindBucket(t_id, t_hash);
-	
-	if (t_target_slot == UINDEX_MAX)
+
+	ObjectGetKey (p_object, t_key);
+	t_hash = KeyHash (t_key);
+	t_target_slot = FindBucket (t_key, t_hash);
+
+	if (t_target_slot == kNOTFOUND) /* Grow hashtable */
 	{
-		if (!RehashBuckets(1))
-			return;
-		
-		t_target_slot = FindBucketAfterRehash(t_id, t_hash);
+		if (!RehashBuckets (1)) return false;
+		t_target_slot = FindBucketAfterRehash (t_key, t_hash);
 	}
-	
-	if (t_target_slot == UINDEX_MAX)
+
+	if (t_target_slot == kNOTFOUND) /* No room in hashtable */
+		return false;
+
+	m_buckets[t_target_slot] = reinterpret_cast<uintptr_t>(p_object);
+	++m_count;
+
+	return true;
+}
+
+template <typename K>
+void
+MCStackCache<K>::UncacheObject (MCObject *p_object)
+{
+	MCAssert (p_object != NULL);
+
+	K t_key;
+	hash_t t_hash;
+	uindex_t t_target_slot;
+
+	ObjectGetKey (p_object, t_key);
+	t_hash = KeyHash (t_key);
+	t_target_slot = FindBucketIfExists (t_key, t_hash);
+
+	if (t_target_slot == kNOTFOUND) /* Not found in hashtable */
 		return;
 
-	p_object -> setinidcache(true);
-	m_buckets[t_target_slot] = (uintptr_t)p_object;
-	m_count += 1;
+	m_buckets[t_target_slot] = kDELETED;
 }
 
-void MCStackIdCache::UncacheObject(MCObject *p_object)
-{
-	if (!p_object -> getinidcache())
-		return;
-	
-	uint32_t t_id;
-	t_id = p_object -> getid();
-	
-	hash_t t_hash;
-	t_hash = HashId(t_id);
-	
-	uindex_t t_target_slot;
-	t_target_slot = FindBucketIfExists(t_id, t_hash);
-	
-	if (t_target_slot != UINDEX_MAX)
-	{
-		p_object -> setinidcache(false);
-		m_buckets[t_target_slot] = UINTPTR_MAX;
-		m_count -= 1;
-	}
-}
-
-MCObject *MCStackIdCache::FindObject(uint32_t p_id)
+template <typename K>
+MCObject *
+MCStackCache<K>::FindObject (const K & t_key) const
 {
 	hash_t t_hash;
-	t_hash = HashId(p_id);
-	
 	uindex_t t_target_slot;
-	t_target_slot = FindBucketIfExists(p_id, t_hash);
-	
-	if (t_target_slot != UINDEX_MAX)
-		return (MCObject *)m_buckets[t_target_slot];
-	
-	return nil;
+
+	t_hash = KeyHash (t_key);
+	t_target_slot = FindBucketIfExists (t_key, t_hash);
+
+	if (t_target_slot == kNOTFOUND) /* Not found in hashtable */
+		return NULL;
+
+	return reinterpret_cast<MCObject *>(m_buckets[t_target_slot]);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
-hash_t MCStackIdCache::HashId(uint32_t h)
+template <typename K>
+uindex_t
+MCStackCache<K>::FindBucket (const K & p_key,
+                               hash_t p_hash) const
 {
-	h ^= (h >> 20) ^ (h >> 12);
-    return h ^ (h >> 7) ^ (h >> 4);
-}
+	uindex_t t_capacity, t_h1, t_target_slot;
 
-uindex_t MCStackIdCache::FindBucket(uint32_t p_id, hash_t p_hash)
-{
-	uindex_t t_capacity;
 	t_capacity = __kMCValueHashTableSizes[m_capacity_idx];
-	
-	uindex_t t_h1;
-#if defined(__ARM__) && 0 // TODO
-	t_h1 = __MCHashFold(p_hash, m_capacity_idx);
-#else
+	if (t_capacity == 0) return kNOTFOUND;
+
+	/* FIXME do something sensible on ARM ?? */
 	t_h1 = p_hash % t_capacity;
-#endif
-	
-	uindex_t t_probe;
-	t_probe = t_h1;
 
-	uindex_t t_target_slot;
-	t_target_slot = UINDEX_MAX;
+	t_target_slot = kNOTFOUND;
 
-	for(uindex_t i = 0; i < t_capacity; i++)
+	for (uindex_t i = 0; i < t_capacity; ++i)
 	{
+		/* Compute the trial insertion position, wrapping around */
+		uindex_t t_probe;
+		t_probe = (t_h1 + i) % t_capacity;
+
 		uintptr_t t_bucket;
 		t_bucket = m_buckets[t_probe];
-		if (t_bucket == UINTPTR_MIN)
-		{
-			if (t_target_slot == UINDEX_MAX)
+
+		if (t_bucket == kDELETED)
+		{ /* Previously deleted entry. Still need to check that key not present */
+			if (t_target_slot == kNOTFOUND)
+				t_target_slot = t_probe;
+		}
+		else if (t_bucket == kUNUSED)
+		{ /* Bucket has not yet been filled. */
+			if (t_target_slot == kNOTFOUND)
 				t_target_slot = t_probe;
 			break;
 		}
-		else if (t_bucket == UINTPTR_MAX)
-		{
-			if (t_target_slot == UINDEX_MAX)
-				t_target_slot = t_probe;
-		}
 		else
-		{
-			if (p_id == ((MCObject *)t_bucket) -> getid())
+		{ /* Bucket is full. Check the key */
+			K t_key;
+			ObjectGetKey (reinterpret_cast<MCObject *>(t_bucket), t_key);
+			if (0 == KeyCompare (t_key, p_key))
 				return t_probe;
 		}
-
-		t_probe += 1;
-
-		if (t_capacity <= t_probe)
-			t_probe -= t_capacity;
 	}
 
 	return t_target_slot;
 }
 
-uindex_t MCStackIdCache::FindBucketIfExists(uint32_t p_id, hash_t p_hash)
+template <typename K>
+uindex_t
+MCStackCache<K>::FindBucketIfExists (const K & p_key,
+                                       hash_t p_hash) const
 {
-	uindex_t t_capacity;
-	t_capacity = __kMCValueHashTableSizes[m_capacity_idx];
+	uindex_t t_bucket = FindBucket (p_key, p_hash);
 
-	uindex_t t_h1;
-#if defined(__ARM__) && 0 // TODO
-	t_h1 = __MCHashFold(p_hash, m_capacity_idx);
-#else
-	t_h1 = p_hash % t_capacity;
-#endif
+	if (t_bucket == kNOTFOUND) return kNOTFOUND;
 
-	uindex_t t_probe;
-	t_probe = t_h1;
+	/* Requested key is not currently in the hash table */
+	if (m_buckets[t_bucket] == kUNUSED ||
+	    m_buckets[t_bucket] == kDELETED)
+		return kNOTFOUND;
 
-	for(uindex_t i = 0; i < t_capacity; i++)
-	{
-		uintptr_t t_bucket;
-		t_bucket = m_buckets[t_probe];
-
-		if (t_bucket == UINTPTR_MIN)
-			return UINDEX_MAX;
-
-		if (t_bucket != UINTPTR_MAX &&
-			((MCObject *)t_bucket) -> getid() == p_id)
-			return t_probe;
-
-		t_probe += 1;
-
-		if (t_capacity <= t_probe)
-			t_probe -= t_capacity;
-	}
-
-	return UINDEX_MAX;
+	return t_bucket;
 }
 
-uindex_t MCStackIdCache::FindBucketAfterRehash(uint32_t p_id, hash_t p_hash)
+template <typename K>
+uindex_t
+MCStackCache<K>::FindBucketAfterRehash (const K & p_key,
+                                          hash_t p_hash) const
 {
-	uindex_t t_capacity;
-	t_capacity = __kMCValueHashTableSizes[m_capacity_idx];
-
-	uindex_t t_h1;
-#if defined(__ARM__) && 0 // TODO
-	t_h1 = __MCHashFold(p_hash, m_capacity_idx);
-#else
-	t_h1 = p_hash % t_capacity;
-#endif
-
-	uindex_t t_probe;
-	t_probe = t_h1;
-
-	for(uindex_t i = 0; i < t_capacity; i++)
-	{
-		uintptr_t t_bucket;
-		t_bucket = m_buckets[t_probe];
-
-		if (t_bucket == UINTPTR_MIN)
-			return t_probe;
-
-		t_probe += 1;
-
-		if (t_capacity <= t_probe)
-			t_probe -= t_capacity;
-	}
-
-	return UINDEX_MAX;
+	return FindBucket (p_key, p_hash);
 }
 
-bool MCStackIdCache::RehashBuckets(uindex_t p_new_item_count)
+template <typename K>
+bool
+MCStackCache<K>::RehashBuckets (uindex_t p_new_item_count)
 {
-	uindex_t t_new_capacity_idx;
-	t_new_capacity_idx = m_capacity_idx;
-	if (p_new_item_count != 0)
-	{
-		// If we are shrinking we just shrink down to the level needed by the currently
-		// used buckets.
-		if (p_new_item_count < 0)
-			p_new_item_count = 0;
-
-		// Work out the smallest possible capacity greater than the requested capacity.
-		uindex_t t_new_capacity_req;
-		t_new_capacity_req = m_count + p_new_item_count;
-		for(t_new_capacity_idx = 0; t_new_capacity_idx < 64; t_new_capacity_idx++)
-			if (t_new_capacity_req <= __kMCValueHashTableCapacities[t_new_capacity_idx])
-				break;
-	}
-
-	// Fetch the old capacity and table.
+	/* Keep the old capacity and table */
 	uindex_t t_old_capacity;
 	uintptr_t *t_old_buckets;
 	t_old_capacity = __kMCValueHashTableSizes[m_capacity_idx];
 	t_old_buckets = m_buckets;
 
-	// Create the new table.
+	/* Compute the new capacity and create the new table */
+	uindex_t t_new_capacity_idx;
 	uindex_t t_new_capacity;
 	uintptr_t *t_new_buckets;
+
+	t_new_capacity_idx = m_capacity_idx;
+	if (p_new_item_count != 0)
+	{
+		uindex_t t_required_capacity;
+
+		/* If shrinking, always shrink to the level needed by the
+		 * current contents. */
+		if (p_new_item_count < 0)
+			t_required_capacity = m_count;
+		else
+			t_required_capacity = m_count + p_new_item_count;
+
+		/* Work out the smallest possible capacity greater than the
+		 * requested capacity */
+		for (t_new_capacity_idx = 0;
+		     (t_new_capacity_idx < 64 &&
+		      t_required_capacity <= __kMCValueHashTableCapacities[t_new_capacity_idx]);
+		     ++t_new_capacity_idx);
+	}
+
 	t_new_capacity = __kMCValueHashTableSizes[t_new_capacity_idx];
-	if (!MCMemoryNewArray(t_new_capacity, t_new_buckets))
+	if (!MCMemoryNewArray (t_new_capacity, t_new_buckets))
 		return false;
 
-	// Update the vars.
+	/* Update the variables */
 	m_capacity_idx = t_new_capacity_idx;
 	m_buckets = t_new_buckets;
 
-	// Now rehash the values from the old table.
-	for(uindex_t i = 0; i < t_old_capacity; i++)
+	/* Rehash values from old table */
+	for (uindex_t i = 0; i < t_old_capacity; ++i)
 	{
-		if (t_old_buckets[i] != UINTPTR_MIN && t_old_buckets[i] != UINTPTR_MAX)
-		{
-			uint32_t t_id;
-			t_id = ((MCObject *)t_old_buckets[i]) -> getid();
-			
-			hash_t t_hash;
-			t_hash = HashId(t_id);
-			
-			uindex_t t_target_slot;
-			t_target_slot = FindBucketAfterRehash(t_id, t_hash);
+		/* Skip empty or deleted buckets */
+		if (t_old_buckets[i] == kUNUSED || t_old_buckets[i] == kDELETED)
+			continue;
 
-			// This assertion should never trigger - something is very wrong if it does!
-			MCAssert(t_target_slot != UINDEX_MAX);
+		K t_key;
+		hash_t t_hash;
+		uindex_t t_target_slot;
 
-			m_buckets[t_target_slot] = t_old_buckets[i];
-		}
+		ObjectGetKey (reinterpret_cast<MCObject *>(t_old_buckets[i]), t_key);
+		t_hash = KeyHash (t_key);
+		t_target_slot = FindBucketAfterRehash (t_key, t_hash);
+
+		/* There should always be enough space for a new entry at this point! */
+		MCAssert (t_target_slot != kNOTFOUND);
+
+		m_buckets[t_target_slot] = t_old_buckets[i];
 	}
 
-	// Delete the old table.
-	MCMemoryDeleteArray(t_old_buckets);
+	/* Delete the old table */
+	MCMemoryDeleteArray (t_old_buckets);
 
-	// We are done!
 	return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class MCStackIdCache : public MCStackCache<uint32_t>
+{
+public:
+	virtual bool CacheObject (MCObject *object);
+	virtual void UncacheObject (MCObject *object);
+protected:
+	virtual hash_t KeyHash (const uint32_t & key) const;
+	virtual compare_t KeyCompare (const uint32_t &, const uint32_t &) const;
+	virtual void ObjectGetKey (MCObject *object, uint32_t & key) const;
+};
+
+bool
+MCStackIdCache::CacheObject (MCObject *object)
+{
+	if (object->getinidcache ())
+		return true;
+
+	if (!MCStackCache<uint32_t>::CacheObject (object)) return false;
+
+	object->setinidcache (true);
+	return true;
+}
+
+void
+MCStackIdCache::UncacheObject (MCObject *object)
+{
+	if (!object->getinidcache ())
+		return;
+
+	MCStackCache<uint32_t>::UncacheObject (object);
+
+	object->setinidcache (false);
+}
+
+hash_t
+MCStackIdCache::KeyHash (const uint32_t & key) const
+{
+	uint32_t h;
+	h = key;
+	h ^= (h >> 20) ^ (h >> 12);
+	h ^= (h >> 7) ^ (h >> 4);
+	return h;
+}
+
+compare_t
+MCStackIdCache::KeyCompare (const uint32_t & a,
+                            const uint32_t & b) const
+{
+	return (a - b);
+}
+
+void
+MCStackIdCache::ObjectGetKey (MCObject *object,
+                              uint32_t & key) const
+{
+	key = object->getid ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/uuid.cpp
+++ b/engine/src/uuid.cpp
@@ -256,7 +256,7 @@ MCUuidCompare (const MCUuid & a,
 
 	if (t_diff != 0) return t_diff;
 
-	for (uindex_t i = 0; t_diff != 0 && i < 6; ++i)
+	for (uindex_t i = 0; t_diff == 0 && i < 6; ++i)
 	{
 		t_diff = a.node[i] - b.node[i];
 	}

--- a/engine/src/uuid.cpp
+++ b/engine/src/uuid.cpp
@@ -241,3 +241,27 @@ void MCUuidFromBytes(uint8_t p_bytes[16], MCUuid& r_uuid)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+compare_t
+MCUuidCompare (const MCUuid & a,
+               const MCUuid & b)
+{
+	compare_t t_diff;
+	t_diff =
+		(a.time_low - b.time_low) ||
+		(a.time_mid - b.time_mid) ||
+		(a.time_hi_and_version - b.time_hi_and_version) ||
+		(a.clock_seq_hi_and_reserved - b.clock_seq_hi_and_reserved) ||
+		(a.clock_seq_low - b.clock_seq_low);
+
+	if (t_diff != 0) return t_diff;
+
+	for (uindex_t i = 0; t_diff != 0 && i < 6; ++i)
+	{
+		t_diff = a.node[i] - b.node[i];
+	}
+
+	return t_diff;
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/uuid.h
+++ b/engine/src/uuid.h
@@ -66,4 +66,9 @@ void MCUuidToBytes(const MCUuid& uuid, uint8_t r_bytes[16]);
 // Decode a UUID from an endian-invariant sequence of bytes.
 void MCUuidFromBytes(uint8_t bytes[16], MCUuid& r_uuid);
 
+/* Compare two UUIDs. Returns an integer less than, equal to, or
+ * greater than zero if p_uuid_a is considered to be respectively less
+ * than, equal to or greater than p_uuid_b. */
+compare_t MCUuidCompare (const MCUuid & p_uuid_a, const MCUuid & p_uuid_b);
+
 #endif


### PR DESCRIPTION
This branch has four main parts:
1. e01edf2, 49736d0, 3cf5f8e, 17326ea: These add a UUID field and accessors to `MCObject`, and some convenience functions for working with UUIDs and altids.
2. 39dc486, 1211602, 798826d, 3fd1c1c: These give stacks the capability to cache object UUIDs in a hashtable for quick lookup.
3. 8232a11: Add searching for objects by UUID.
4. 563c8dc: This adds an `ObjectID` class that represents various different ways of identifying classes. They can be concrete (permanently associated with one specific `MCObject` instance) or delayed (they contain the identifying information, and go and find the appropriate object on request).

There were also a couple of bugs found by @runrevfraser during code review.
