### PR TITLE
[[ Bug 14098 ]] Use MacOS SDK 10.8-compliant function to set the color

### DIFF
--- a/engine/src/mac-dialog.mm
+++ b/engine/src/mac-dialog.mm
@@ -870,7 +870,11 @@ static MCColorPanelDelegate* s_color_dialog_delegate;
     {
         NSColor *t_color;
         
-        t_color = [[mColorPanel color] colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+        // Do not calibrate the colour. As stated in the doc for -colorUsingColorSpace
+        //   "The new NSColor object. This method converts the receiver's color to an equivalent
+        //    one in the new color space. Although the new color might have different component
+        //    values, it looks the same as the original."
+        t_color = [mColorPanel color];
         
         // Convert the value from to a colour component value.
         s_color_dialog_color . red   = (uint2) ([t_color redComponent] * UINT16_MAX);
@@ -929,10 +933,10 @@ void MCPlatformBeginColorDialog(const char *p_title, const MCColor& p_color)
     
     // SN-2014-11-28: [[ Bug 14098 ]] Make use of the initial colour
     CGFloat t_divider = UINT16_MAX;
-    NSColor* t_initial_color = [NSColor colorWithRed:(CGFloat)p_color.red / t_divider
-                                               green:(CGFloat)p_color.green / t_divider
-                                                blue:(CGFloat)p_color.blue / t_divider
-                                               alpha:1];
+    NSColor* t_initial_color = [NSColor colorWithSRGBRed:(CGFloat)p_color.red / t_divider
+                                                   green:(CGFloat)p_color.green / t_divider
+                                                    blue:(CGFloat)p_color.blue / t_divider
+                                                   alpha:1];
     [t_colorPicker setColor:t_initial_color];
     
     NSView* t_pickerView;


### PR DESCRIPTION
avoid color calibration
