### PR TITLE
[[ Bug 14211 ]] Throw an execution error when using 'next line of ...'

### DIFF
--- a/docs/notes/bugfix-14211.md
+++ b/docs/notes/bugfix-14211.md
@@ -1,0 +1,1 @@
+# referencing the next line causes the IDE to crash

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -1372,7 +1372,12 @@ Exec_stat MCChunk::extents(MCCRef *ref, int4 &start, int4 &number,
 			start--;
 		break;
 	default:
+        // SN-2014-12-15: [[ Bug 14211 ]] Fix for using next with a text chunk.
+        //  That was causing the extents to return an uninitialised value.
 		fprintf(stderr, "MCChunk: ERROR bad extents\n");
+        MCeerror->add(EE_CHUNK_BADEXTENTS, line, pos);
+        return ES_ERROR;
+
 	}
 	if (start < 0)
 	{

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2467,7 +2467,11 @@ enum Exec_errors
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] New variant open socket <socket> with verification for host <host>
 	// {EE-0809} open: error in host name expression
-	EE_OPEN_BADHOST,	
+	EE_OPEN_BADHOST,
+    
+    // SN-2014-12-15: [[ Bug 14211 ]] put ... into the next line of ... should return an error
+    // {EE-0810} Chunk: bad extents provided
+    EE_CHUNK_BADEXTENTS,
 };
 
 extern const char *MCexecutionerrors;


### PR DESCRIPTION
Bug fix for 142111 ported to 6.7, to avoid having 6.7 accepting a script that does not execute on 7.0 (that was a long-lasting bug, only putting a random line random when accessing the 'next line of').
