### PR TITLE
[[misc-customtypes]] libfoundation: Check custom type func pointers.

### DIFF
--- a/libfoundation/Makefile
+++ b/libfoundation/Makefile
@@ -7,6 +7,7 @@ SOURCES= \
 	foundation-array.cpp \
 	foundation-bidi.cpp \
 	foundation-core.cpp \
+	foundation-custom.cpp \
 	foundation-data.cpp \
 	foundation-debug.cpp \
 	foundation-error.cpp \

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1118,6 +1118,9 @@ enum
 	kMCValueCustomHeaderSize = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uintptr_t)
 };
 
+/* If you add a new function pointer to this structure, don't forget
+ * to add a default implementation of the function to
+ * foundation-custom.cpp */
 struct MCValueCustomCallbacks
 {
 	bool is_singleton : 1;

--- a/libfoundation/src/foundation-custom.cpp
+++ b/libfoundation/src/foundation-custom.cpp
@@ -1,0 +1,76 @@
+/*                                                                     -*-c++-*-
+Copyright (C) 2003-2013 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include <foundation.h>
+#include "foundation-private.h"
+
+/* ================================================================
+ * Default implementations of custom value operations
+ * ================================================================ */
+
+void
+__MCCustomDefaultDestroy (MCValueRef value)
+{
+}
+
+bool
+__MCCustomDefaultCopy (MCValueRef self,
+                       bool p_release,
+                       MCValueRef & r_value)
+{
+	/* This implementation doesn't handle mutable custom values. */
+	if (MCValueIsMutable (self)) return false;
+
+	r_value = MCValueRetain (self);
+	if (p_release)
+		MCValueRelease (self);
+	return true;
+}
+
+bool
+__MCCustomDefaultEqual (MCValueRef self,
+                        MCValueRef p_other)
+{
+	return (self == p_other);
+}
+
+hash_t
+__MCCustomDefaultHash (MCValueRef self)
+{
+	return MCHashPointer (self);
+}
+
+bool
+__MCCustomDefaultDescribe (MCValueRef self,
+                           MCStringRef & r_desc)
+{
+	return false;
+}
+
+bool
+__MCCustomDefaultIsMutable (MCValueRef self)
+{
+	return false;
+}
+
+bool
+__MCCustomDefaultMutableCopy (MCValueRef self,
+                              bool release,
+                              MCValueRef & r_value)
+{
+	return false;
+}

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -536,6 +536,15 @@ bool __MCForeignValueCopyDescription(__MCForeignValue *self, MCStringRef& r_desc
 bool __MCStreamInitialize(void);
 void __MCStreamFinalize(void);
 
+/* Default implementations of each of the function members of struct &
+ * MCValueCustomCallbacks */
+void __MCCustomDefaultDestroy(MCValueRef);
+bool __MCCustomDefaultCopy(MCValueRef, bool, MCValueRef &);
+bool __MCCustomDefaultEqual(MCValueRef, MCValueRef);
+hash_t __MCCustomDefaultHash(MCValueRef);
+bool __MCCustomDefaultDescribe(MCValueRef, MCStringRef &);
+bool __MCCustomDefaultIsMutable(MCValueRef);
+bool __MCCustomDefaultMutableCopy(MCValueRef, bool, MCValueRef &);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -185,7 +185,15 @@ hash_t MCValueHash(MCValueRef p_value)
     case kMCValueTypeCodeData:
         return __MCDataHash((__MCData*) self);
 	case kMCValueTypeCodeCustom:
-        return __MCCustomValueResolveTypeInfo(self) -> custom . callbacks . hash(p_value);
+		{
+			MCTypeInfoRef t_typeinfo;
+			hash_t (*t_hash_func)(MCValueRef);
+			t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+			t_hash_func = t_typeinfo -> custom . callbacks . hash;
+			return ((t_hash_func != NULL) ?
+			        t_hash_func (p_value) :
+			        __MCCustomDefaultHash (p_value));
+		}
     case kMCValueTypeCodeProperList:
         return __MCProperListHash((__MCProperList *)self);
     case kMCValueTypeCodeRecord:
@@ -253,7 +261,15 @@ bool MCValueIsEqualTo(MCValueRef p_value, MCValueRef p_other_value)
 	// the same.
 	case kMCValueTypeCodeCustom:
 		if (((__MCCustomValue *)self) -> typeinfo == ((__MCCustomValue *)other_self) -> typeinfo)
-			return __MCCustomValueResolveTypeInfo(self) -> custom . callbacks . equal(p_value, p_other_value);
+		{
+			MCTypeInfoRef t_typeinfo;
+			bool (*t_equal_func)(MCValueRef, MCValueRef);
+			t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+			t_equal_func = t_typeinfo -> custom . callbacks . equal;
+			return ((t_equal_func != NULL) ?
+			        t_equal_func (p_value, p_other_value) :
+			        __MCCustomDefaultEqual (p_value, p_other_value));
+		}
 		return false;
     case kMCValueTypeCodeProperList:
         return __MCProperListIsEqualTo((__MCProperList*)self, (__MCProperList*)other_self);
@@ -301,7 +317,15 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
     case kMCValueTypeCodeData:
         return __MCDataCopyDescription((__MCData*)p_value, r_desc);
 	case kMCValueTypeCodeCustom:
-		return __MCCustomValueResolveTypeInfo(self) -> custom . callbacks . describe(p_value, r_desc);
+		{
+			MCTypeInfoRef t_typeinfo;
+			bool (*t_describe_func)(MCValueRef, MCStringRef &);
+			t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+			t_describe_func = t_typeinfo -> custom . callbacks . describe;
+			return ((t_describe_func != NULL) ?
+			        t_describe_func (p_value, r_desc) :
+			        __MCCustomDefaultDescribe (p_value, r_desc));
+		}
     case kMCValueTypeCodeProperList:
         return __MCProperListCopyDescription((__MCProperList*)p_value, r_desc);
     case kMCValueTypeCodeRecord:
@@ -326,8 +350,14 @@ bool MCValueIsMutable(MCValueRef p_value)
     
     if (__MCValueGetTypeCode(self) != kMCValueTypeCodeCustom)
         return false;
-    
-    return __MCCustomValueResolveTypeInfo(self) -> custom . callbacks . is_mutable(p_value);
+
+	MCTypeInfoRef t_typeinfo;
+	bool (*t_is_mutable_func)(MCValueRef);
+	t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+	t_is_mutable_func = t_typeinfo -> custom . callbacks . is_mutable;
+	return ((t_is_mutable_func != NULL) ?
+	        t_is_mutable_func (p_value) :
+	        __MCCustomDefaultIsMutable (p_value));
 }
 
 bool MCValueMutableCopy(MCValueRef p_value, MCValueRef& r_mutable_copy)
@@ -337,7 +367,13 @@ bool MCValueMutableCopy(MCValueRef p_value, MCValueRef& r_mutable_copy)
     if (__MCValueGetTypeCode(self) != kMCValueTypeCodeCustom)
         return false;
     
-    return __MCCustomValueResolveTypeInfo(self) -> custom . callbacks . mutable_copy(p_value, false, r_mutable_copy);
+	MCTypeInfoRef t_typeinfo;
+	bool (*t_mutable_copy_func)(MCValueRef, bool, MCValueRef &);
+	t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+	t_mutable_copy_func = t_typeinfo -> custom . callbacks . mutable_copy;
+	return ((t_mutable_copy_func != NULL) ?
+	        t_mutable_copy_func (p_value, false, r_mutable_copy) :
+	        __MCCustomDefaultMutableCopy (p_value, false, r_mutable_copy));
 }
 
 bool MCValueMutableCopyAndRelease(MCValueRef p_value, MCValueRef& r_mutable_copy)
@@ -347,7 +383,13 @@ bool MCValueMutableCopyAndRelease(MCValueRef p_value, MCValueRef& r_mutable_copy
     if (__MCValueGetTypeCode(self) != kMCValueTypeCodeCustom)
         return false;
     
-    return __MCCustomValueResolveTypeInfo(self) -> custom . callbacks . mutable_copy(p_value, true, r_mutable_copy);
+	MCTypeInfoRef t_typeinfo;
+	bool (*t_mutable_copy_func)(MCValueRef, bool, MCValueRef &);
+	t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+	t_mutable_copy_func = t_typeinfo -> custom . callbacks . mutable_copy;
+	return ((t_mutable_copy_func != NULL) ?
+	        t_mutable_copy_func (p_value, true, r_mutable_copy) :
+	        __MCCustomDefaultMutableCopy (p_value, true, r_mutable_copy));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -487,7 +529,16 @@ void __MCValueDestroy(__MCValue *self)
         __MCProperListDestroy((__MCProperList *)self);
         break;
 	case kMCValueTypeCodeCustom:
-        __MCCustomValueResolveTypeInfo(self) -> custom . callbacks . destroy(self);
+		{
+			MCTypeInfoRef t_typeinfo;
+			void (*t_destroy_func)(MCValueRef);
+			t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+			t_destroy_func = t_typeinfo -> custom . callbacks . destroy;
+			if (t_destroy_func != NULL)
+				t_destroy_func (self);
+			else
+				__MCCustomDefaultDestroy (self);
+		}
         break;
     case kMCValueTypeCodeRecord:
         __MCRecordDestroy((__MCRecord *)self);
@@ -946,8 +997,14 @@ bool __MCValueImmutableCopy(__MCValue *self, bool p_release, __MCValue*& r_new_v
 	case kMCValueTypeCodeCustom:
 	{
 		MCValueRef t_new_value;
-		if (__MCCustomValueResolveTypeInfo(self) -> custom . callbacks . copy(self, p_release, t_new_value))
-			return r_new_value = (__MCValue *)t_new_value, true;
+		MCTypeInfoRef t_typeinfo;
+		bool (*t_copy_func)(MCValueRef, bool, MCValueRef &);
+		t_typeinfo = __MCCustomValueResolveTypeInfo(self);
+		t_copy_func = t_typeinfo -> custom . callbacks . copy;
+		if ((t_copy_func != NULL) ?
+		    t_copy_func (self, p_release, t_new_value) :
+		    __MCCustomDefaultCopy (self, p_release, t_new_value))
+			return r_new_value = (__MCValue *) t_new_value, true;
 	}
 	return false;
             


### PR DESCRIPTION
Some custom types may not wish to implement all function pointers in
the corresponding `MCValueCustomCallbacks` structure -- for example,
some custom types may not support mutability and thus may not
implement a `mutable_copy` function.  Furthermore, additional members
may be added to `struct MCValueCustomCallbacks` over time, requiring
every custom type to be adjusted unless the custom value support code
can cope with NULL function pointers.

This patch adds default implementations of all the functions defined
in `struct MCValueCustomCallbacks`, and calls them for any type that
leaves the corresponding function pointer as NULL.
