### PR TITLE
[[ Bug 14269 ]] Play audioclip no longer loops when followed by wait unt...

### DIFF
--- a/docs/notes/bugfix-14269.md
+++ b/docs/notes/bugfix-14269.md
@@ -1,0 +1,1 @@
+#     Play audioclip loops when followed by wait until the sound is done

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -1303,6 +1303,8 @@ void MCPlatformHandleSoundFinished(MCPlatformSoundRef p_sound)
         MCscreen -> addtimer(MCacptr, MCM_internal, 0);
         // PM-2014-12-09: [[ Bug 14176 ]] Release and nullify the sound once it is done
         MCacptr->stop(True);
+        // PM-2014-12-22: [[ Bug 14269 ]] Nullify MCacptr to prevent looping when play audioclip is followed by wait until the sound is done
+        MCacptr = NULL;
     }
 }
 

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -54,13 +54,14 @@ static void MCU_play_message()
 {
 	MCAudioClip *acptr = MCacptr;
 	MCacptr = NULL;
-	MCStack *sptr = acptr->getmessagestack();
+    // PM-2014-12-22: [[ Bug 14269 ]] Nil checks to prevent a crash
+	MCStack *sptr = (acptr != NULL ? acptr->getmessagestack() : NULL);
 	if (sptr != NULL)
 	{
 		acptr->setmessagestack(NULL);
 		sptr->getcurcard()->message_with_args(MCM_play_stopped, acptr->getname());
 	}
-	if (acptr->isdisposable())
+	if (acptr != NULL && acptr->isdisposable())
 		delete acptr;
 }
 


### PR DESCRIPTION
...il the sound is done
