### PR TITLE
[[ Bug 14330 ]] Don't loop through the open stacks (and crash) if there ...

### DIFF
--- a/docs/notes/bugfix-14330.md
+++ b/docs/notes/bugfix-14330.md
@@ -1,0 +1,1 @@
+openstacks() crashes when called in the shutdown handler

--- a/engine/src/stacklst.cpp
+++ b/engine/src/stacklst.cpp
@@ -264,6 +264,14 @@ MCStack *MCStacklist::getstack(uint2 n)
 bool MCStacklist::stackprops(MCExecContext& ctxt, Properties p_property, MCListRef& r_list)
 {
 	MCAutoListRef t_list;
+    
+    // SN-2015-01-05: [[ Bug 14330 ]] Return if there is no open stacks
+    if (stacks == NULL)
+    {
+        r_list = MCValueRetain(kMCEmptyList);
+        return true;
+    }
+    
 	if (!MCListCreateMutable('\n', &t_list))
 		return false;
 


### PR DESCRIPTION
...is none
