### PR TITLE
[[ Bug 14386 ]] Make sure the implicit NUL byte is preserved in strings ...

### DIFF
--- a/docs/notes/bugfix-14386.md
+++ b/docs/notes/bugfix-14386.md
@@ -1,0 +1,1 @@
+# Evaluating 1.884956+0 and then using in string context can make it not convert back to a number.


### PR DESCRIPTION
...when setting the numeric value.
