### PR TITLE
[RFC] [[feature-filestreamio]] Add more complete file streams

### DIFF
--- a/libscript/src/file.mlc
+++ b/libscript/src/file.mlc
@@ -4,10 +4,18 @@ This module specifies the syntax definitions and bindings for file i/o operation
 
 module com.livecode.file
 
+use com.livecode.stream
+
 --
 
 public foreign handler MCFileExecGetContents(in File as string, out Contents as data) as undefined binds to "<builtin>"
 public foreign handler MCFileExecSetContents(in Contents as data, in File as string) as undefined binds to "<builtin>"
+
+public foreign handler MCFileExecOpenFileForRead(in File as string) as Stream binds to "<builtin>"
+public foreign handler MCFileExecOpenFileForWrite(in Create as bool, in File as string) as Stream binds to "<builtin>"
+public foreign handler MCFileExecOpenFileForUpdate(in Create as bool, in File as string) as Stream binds to "<builtin>"
+
+--
 
 /*
 Summary:	The data stored in a file.
@@ -24,6 +32,98 @@ Tags: IO
 */
 syntax FileContents is prefix operator with precedence 2
 	"the" "contents" "of" "file" <File: Expression>
+begin
+	MCFileExecGetContents(File, output)
+	MCFileExecSetContents(input, File)
+end syntax
+
+--
+
+/*
+Summary:	Open a read-only file stream
+
+File:		An expression that evaluates to a filename.
+
+Description:
+Open a stream for reading from a file.
+
+Example:
+	variable tStream
+	open read only stream for file "my_file.txt"
+	put the result into tStream
+
+Tags: IO
+*/
+syntax OpenFileForRead is statement
+    "open" "read" "only" "stream" "for" "file" <File: Expression>
+begin
+    MCFileExecOpenFileForRead(File)
+end syntax
+
+/*
+Summary:	Open a write-only file stream
+
+File:		An expression that evaluates to a filename.
+
+Description:
+Open a stream for writing to a file.
+
+There are two possible behaviours when the file already exists:
+
+* If a "new" file was requested, then no stream will be created, and
+  an error will be indicated.
+
+* Otherwise, the contents of the existing file will be deleted.
+
+If the file doesn't exist yet, then it will always be created.
+
+Example:
+	// 1. Open a stream to a file.  It might already exist.
+	variable tStream
+	open write only stream for file "my_file.txt"
+	put the result into tStream
+
+	// 2. Open a stream to a *new* file.  If it already exists,
+	// this will fail.
+	variable tStream
+	open write only stream for new file "my_file.txt"
+	put the result into tStream
+
+Tags: IO
+*/
+syntax OpenFileForWrite is statement
+    "open" "write" "only" "stream" "for" ("new" <Create=true> | <Create=false>) "file" <File: Expression>
+begin
+    MCFileExecOpenFileForWrite(Create, File)
+end syntax
+
+/*
+Summary:	Open a read/write file stream
+
+File:		An expression that evaluates to a filename.
+
+Description:
+Open a stream for reading from and writing to a file.
+
+There are two possible behaviours when the file already exists:
+
+* If a "new" file was requested, then no stream will be created, and
+  an error will be indicated.
+
+* Otherwise, the file will be opened as normal and the existing
+  contents will be preserved.
+
+If the file doesn't exist yet, then it will always be created.
+
+Example:
+	variable tStream
+	open read write stream for file "my_file.txt"
+	put the result into tStream
+
+Tags: IO
+*/
+syntax OpenFileForUpdate is statement
+    "open" "read" "write" "stream" "for" ("new" <Create=true> | <Create=false>) "file" <File: Expression>
 begin
 	MCFileExecGetContents(File, output)
 	MCFileExecSetContents(input, File)

--- a/libscript/src/module-file.cpp
+++ b/libscript/src/module-file.cpp
@@ -33,3 +33,32 @@ MCFileExecSetContents (MCDataRef p_contents, MCStringRef p_path)
 {
 	/* UNCHECKED */ MCFileSetContents (p_path, p_contents);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+extern "C" MC_DLLEXPORT MCStreamRef MCFileExecOpenFileForRead(MCStringRef p_filename)
+{
+    MCStreamRef t_stream;
+    if (!MCFileCreateStream(p_filename, kMCOpenFileModeRead, t_stream))
+        return nil;
+    
+    return t_stream;
+}
+
+extern "C" MC_DLLEXPORT MCStreamRef MCFileExecOpenFileForWrite(bool p_create, MCStringRef p_filename, MCStreamRef& r_stream)
+{
+    MCStreamRef t_stream;
+    if (!MCFileCreateStream(p_filename, p_create ? kMCOpenFileModeCreate : kMCOpenFileModeWrite, t_stream))
+        return nil;
+    
+    return t_stream;
+}
+
+extern "C" MC_DLLEXPORT MCStreamRef MCFileExecOpenFileForUpdate(bool p_create, MCStringRef p_filename, MCStreamRef& r_stream)
+{
+    MCStreamRef t_stream;
+    if (!MCFileCreateStream(p_filename, p_create ? kMCOpenFileModeCreate : kMCOpenFileModeUpdate, t_stream))
+        return nil;
+    
+    return t_stream;
+}

--- a/libscript/src/module-stream.cpp
+++ b/libscript/src/module-stream.cpp
@@ -37,6 +37,33 @@ MCStreamExecWriteToStream(MCDataRef p_data,
 	}
 }
 
+extern "C" MC_DLLEXPORT MCDataRef
+MCStreamExecReadFromStream (uindex_t p_amount,
+                            MCStreamRef p_stream)
+{
+	/* FIXME this should be handled by MCStreamRead */
+    if (!MCStreamIsReadable(p_stream))
+    {
+        MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("stream is not readable"), nil);
+        return MCValueRetain(kMCEmptyData);
+    }
+    
+    byte_t t_buffer[p_amount];
+    
+    if (!MCStreamRead(p_stream, t_buffer, p_amount))
+    {
+		/* Error information should already be set */
+        return MCValueRetain(kMCEmptyData);
+    }
+    
+    MCDataRef t_data;
+    if (!MCDataCreateWithBytes(t_buffer, p_amount, t_data))
+        return MCValueRetain(kMCEmptyData);
+    
+    return t_data;
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern "C" MC_DLLEXPORT void

--- a/libscript/src/module-stream.cpp
+++ b/libscript/src/module-stream.cpp
@@ -71,3 +71,14 @@ MCStreamExecGetStandardOutput (MCStreamRef & r_stream)
 {
 	MCStreamGetStandardOutput (r_stream);
 }
+
+extern "C" MC_DLLEXPORT void
+MCStreamExecGetStandardInput (MCStreamRef & r_stream)
+{
+	MCStreamGetStandardInput (r_stream);
+}
+extern "C" MC_DLLEXPORT void
+MCStreamExecGetStandardError (MCStreamRef & r_stream)
+{
+	MCStreamGetStandardError (r_stream);
+}

--- a/libscript/src/stream.mlc
+++ b/libscript/src/stream.mlc
@@ -33,6 +33,7 @@ end syntax
 --
 
 public foreign handler MCStreamExecWriteToStream(in Buffer as data, in Destination as Stream) as undefined binds to "<builtin>"
+public foreign handler MCStreamExecReadFromStream(in Amount as uint, in Source as Stream) as data binds to "<builtin>"
 
 /*
 Summary:	Write data to a stream.
@@ -55,6 +56,27 @@ syntax WriteToStream is statement
 	"write" <Buffer: Expression> "to" "stream" <Destination: Expression>
 begin
 	MCStreamExecWriteToStream(Buffer, Destination)
+end syntax
+
+/*
+Summary:	Read data from a stream.
+
+Amount:	An expression that evaluates to a number.
+Stream:	An expression that evaluates to a stream.
+
+Description:
+Read a specific amount of data from a stream.  If there is not enough
+data available in the stream, fails with an error.
+
+>*Warning:* Some streams will discard successfully-read data if there
+>wasn't enough data to fully satisfy the request.  This may cause loss
+>of data.
+
+*/
+syntax ReadFromStream is statement
+	"read" <Amount: Expression> "bytes" "from" "stream" <Source: Expression>
+begin
+    MCStreamExecReadFromStream(Amount, Source)
 end syntax
 
 --

--- a/libscript/src/stream.mlc
+++ b/libscript/src/stream.mlc
@@ -9,7 +9,29 @@ public foreign type Stream binds to "kMCStreamTypeInfo"
 
 --
 
+public foreign handler MCStreamExecGetStandardInput(out Stdin as Stream) as undefined binds to "<builtin>"
 public foreign handler MCStreamExecGetStandardOutput(out Stdout as Stream) as undefined binds to "<builtin>"
+public foreign handler MCStreamExecGetStandardError(out Stderr as Stream) as undefined binds to "<builtin>"
+
+/*
+Summary:	Default input stream.
+Returns:	The default input stream.
+
+Description:
+The default input stream for input to the program.
+
+In command-line programs, this is usually used to receive input from
+the user or from other applications.  In CGI programs running on
+servers, this is usually used to receive incoming data from the
+client.
+
+Tags: IO
+*/
+syntax DefaultInputStream is expression
+	"the" "input" "stream"
+begin
+	MCStreamExecGetStandardInput(output)
+end syntax
 
 /*
 Summary:	Default output stream.
@@ -28,6 +50,25 @@ syntax DefaultOutputStream is expression
 	"the" "output" "stream"
 begin
 	MCStreamExecGetStandardOutput(output)
+end syntax
+
+/*
+Summary:	Default error stream.
+Returns:	The default error stream.
+
+Description:
+The default error stream for diagnostic information.
+
+In command-line programs, this is usually used to display error
+messages.  In server programs, data output through this stream may be
+stored in the system log, depending on the server configuration.
+
+Tags: IO
+*/
+syntax DefaultErrorStream is expression
+	"the" "error" "stream"
+begin
+	MCStreamExecGetStandardError(output)
 end syntax
 
 --

--- a/toolchain/lc-compile/test.mlc
+++ b/toolchain/lc-compile/test.mlc
@@ -920,7 +920,15 @@ public handler testFile(inout xResults as list)
 end handler
 
 public handler testStream(inout xResults as list)
+	variable tStream as Stream
+	open read only stream for file "/dev/zero"
+	put the result into tStream
 
+	variable tData as data
+	read 7 bytes from stream tStream
+	put the result into tData
+
+	testLog("Stream", "ReadFileStreamLength", 7 is the number of bytes in tData, xResults)
 end handler
 
 


### PR DESCRIPTION
Add some additional syntax to MLC for working with files and streams:

```
-- stdin and stderr
the input stream
the output stream

-- stream reading
read tCount bytes from stream tStream

-- file streams
open read only stream for file tPath
open read write stream for file tPath
open write only stream for file tPath
```

N.b. this is based on #1667, but isn't ready to be merged yet because the stream API needs some work before it's useful (particularly error handling and partial reads).
