### PR TITLE
MLC: Add "the operating system" syntax.

### DIFF
--- a/libscript/Makefile.libscript
+++ b/libscript/Makefile.libscript
@@ -22,6 +22,7 @@ SOURCES += \
 	module-sort.cpp \
 	module-stream.cpp \
 	module-string.cpp \
+	module-system.cpp \
 	module-type_convert.cpp \
 	module-type.cpp \
 	module-url.cpp \

--- a/libscript/libstdscript-modules.list
+++ b/libscript/libstdscript-modules.list
@@ -14,5 +14,6 @@ math.mlc
 sort.mlc
 stream.mlc
 string.mlc
+system.mlc
 type.mlc
 type-convert.mlc

--- a/libscript/src/module-system.cpp
+++ b/libscript/src/module-system.cpp
@@ -1,0 +1,44 @@
+/*                                                                     -*-c++-*-
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include <foundation.h>
+
+/* ================================================================
+ * System identification
+ * ================================================================ */
+
+extern "C" MC_DLLEXPORT void
+MCSystemExecGetOperatingSystem (MCStringRef & r_string)
+{
+	const char t_os[] =
+#if defined(__IOS__)
+		"ios"
+#elif defined(__MAC__)
+		"mac"
+#elif defined(__WINDOWS__)
+		"windows"
+#elif defined(__ANDROID__)
+		"android"
+#elif defined(__LINUX__)
+		"linux"
+#else
+#  error "Unrecognized operating system"
+#endif
+		;
+
+	/* UNCHECKED */ MCStringCreateWithCString (t_os, r_string);
+}

--- a/libscript/src/system.mlc
+++ b/libscript/src/system.mlc
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/*
+This library provides low-level system functionality for modular
+LiveCode programs.
+*/
+
+module com.livecode.system
+
+----------------------------------------------------------------
+-- Platform identification
+----------------------------------------------------------------
+
+public foreign handler MCSystemExecGetOperatingSystem(out Platform as string) as undefined binds to "<builtin>"
+
+/*
+Summary:	The operating system
+
+Example:
+	if the operating system is "linux" then
+		- Platform specific-code
+	end if
+
+Description:
+Returns a string describing the operating system that LiveCode is
+running on.  The possible values are:
+
+* "windows" - 32-bit and 64-bit Windows
+* "mac" - Desktop OS X
+* "ios" - iOS (iPhone and iPad)
+* "android" - Android Linux devices
+* "linux" - All other Linux platforms
+
+Tags: System
+*/
+syntax OperatingSystem is expression
+	"the" "operating" "system"
+begin
+	MCSystemExecGetOperatingSystem(output)
+end syntax
+
+--
+
+end module

--- a/toolchain/lc-compile/src/module-helper.cpp
+++ b/toolchain/lc-compile/src/module-helper.cpp
@@ -42,6 +42,7 @@ extern builtin_module_descriptor __com_livecode_segmentchunk_module_info;
 extern builtin_module_descriptor __com_livecode_sort_module_info;
 extern builtin_module_descriptor __com_livecode_stream_module_info;
 extern builtin_module_descriptor __com_livecode_string_module_info;
+extern builtin_module_descriptor __com_livecode_system_module_info;
 extern builtin_module_descriptor __com_livecode_type_module_info;
 extern builtin_module_descriptor __com_livecode_typeconvert_module_info;
 
@@ -65,6 +66,7 @@ builtin_module_descriptor* g_builtin_modules[] =
     &__com_livecode_sort_module_info,
     &__com_livecode_stream_module_info,
     &__com_livecode_string_module_info,
+    &__com_livecode_system_module_info,
     &__com_livecode_type_module_info,
     &__com_livecode_typeconvert_module_info
 };
@@ -85,6 +87,7 @@ extern void (*MCMathFoundationExecRoundRealToNearest)();
 extern void (*MCSortExecSortListAscendingText)();
 extern void (*MCStreamExecWriteToStream)();
 extern void (*MCStringEvalConcatenate)();
+extern void (*MCSystemExecGetOperatingSystem)();
 extern void (*MCTypeEvalIsEmpty)();
 extern void (*MCTypeConvertExecSplitStringByDelimiter)();
 
@@ -105,6 +108,7 @@ void *g_builtin_ptrs[] =
     &MCSortExecSortListAscendingText,
     &MCStreamExecWriteToStream,
     &MCStringEvalConcatenate,
+    &MCSystemExecGetOperatingSystem,
     &MCTypeEvalIsEmpty,
     &MCTypeConvertExecSplitStringByDelimiter
 };

--- a/toolchain/lc-compile/test.mlc
+++ b/toolchain/lc-compile/test.mlc
@@ -3,6 +3,7 @@ module test
 use com.livecode.math
 use com.livecode.file
 use com.livecode.stream
+use com.livecode.system
 
 public handler test()
     variable tResults as list
@@ -68,6 +69,9 @@ public handler test()
 
 	--com.livecode.stream
 	testStream(tResults)
+
+	--com.livecode.system
+	testSystem(tResults)
 	
 	--com.livecode.binary
 	--com.livecode.byte
@@ -923,5 +927,8 @@ public handler testStream(inout xResults as list)
 
 end handler
 
+public handler testSystem(inout xResults as list)
+	testLog("System", "OperatingSystemNonEmpty", the operating system is not empty, xResults)
+end handler
 
 end module


### PR DESCRIPTION
Adds the "com.livecode.system" module and a new syntax for obtaining operating system information.

The new syntax resolves to one of the following strings:
- "windows" -- 32-bit and 64-bit Windows
- "mac" -- Desktop OS X
- "ios" -- iOS (iPhone and iPad)
- "android" -- Android Linux devices
- "linux" -- All other Linux platforms
