### PR TITLE
[[feature-localtime]] MLC: Add "the local time" syntax.

### DIFF
--- a/libscript/Makefile.libscript
+++ b/libscript/Makefile.libscript
@@ -12,6 +12,7 @@ SOURCES += \
 	module-bitwise.cpp \
 	module-byte.cpp \
 	module-char.cpp \
+	module-date.cpp \
 	module-encoding.cpp \
 	module-file.cpp \
 	module-list.cpp \

--- a/libscript/libstdscript-modules.list
+++ b/libscript/libstdscript-modules.list
@@ -6,6 +6,7 @@ binary.mlc
 bitwise.mlc
 byte.mlc
 char.mlc
+date.mlc
 file.mlc
 list.mlc
 logic.mlc

--- a/libscript/src/date.mlc
+++ b/libscript/src/date.mlc
@@ -1,0 +1,58 @@
+/*
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/*
+This library provides low-level system functionality for modular
+LiveCode programs.
+*/
+
+module com.livecode.date
+
+public foreign handler MCDateExecGetLocalTime(out DateTime as list) as undefined binds to "<builtin>"
+
+/*
+Summary:	The local time
+
+Example:
+	variable tDateTime as list
+	put the local time into tDateTime
+
+	variable tDayOfMonth as number
+	put tDateTime[3] into tDayOfMonth
+
+Description:
+Returns the local time as a list of six numeric components.  The
+elements of the list are:
+
+* The year
+* The month (1-12)
+* The day of the month (1-31, depending on the month)
+* The hour (0-23)
+* The minute (0-59)
+* The second (0-59)
+
+Tags: Date and time
+*/
+syntax LocalTime is expression
+	"the" "local" "time"
+begin
+	MCDateExecGetLocalTime(output)
+end syntax
+
+--
+
+end module

--- a/libscript/src/module-date.cpp
+++ b/libscript/src/module-date.cpp
@@ -1,0 +1,52 @@
+/*                                                                     -*-c++-*-
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include <foundation.h>
+#include <foundation-auto.h>
+
+#include <time.h>
+
+/* Windows doesn't have localtime_r(), but it does have an equivalent
+ * function with the arguments in the opposite order! */
+#if defined(__WINDOWS__)
+#  define localtime_r(s,t) (_localtime_s(t,s))
+#endif
+
+extern "C" MC_DLLEXPORT void
+MCDateExecGetLocalTime (MCProperListRef & r_datetime)
+{
+	struct tm t_timeinfo;
+	time_t t_now;
+
+	time (&t_now);
+	if (NULL == localtime_r (&t_now, &t_timeinfo))
+		return;
+
+	MCAutoNumberRef t_year, t_month, t_day, t_hour, t_minute, t_second;
+	if (!(MCNumberCreateWithInteger (t_timeinfo.tm_year, &t_year) &&
+	      MCNumberCreateWithInteger (t_timeinfo.tm_mon, &t_month) &&
+	      MCNumberCreateWithInteger (t_timeinfo.tm_mday, &t_day) &&
+	      MCNumberCreateWithInteger (t_timeinfo.tm_hour, &t_hour) &&
+	      MCNumberCreateWithInteger (t_timeinfo.tm_min, &t_minute) &&
+	      MCNumberCreateWithInteger (t_timeinfo.tm_sec, &t_second)))
+		return;
+
+	const MCValueRef t_elements[] = {*t_year, *t_month, *t_day,
+	                                 *t_hour, *t_minute, *t_second};
+
+	/* UNCHECKED */ MCProperListCreate (t_elements, 6, r_datetime);
+}

--- a/toolchain/lc-compile/src/module-helper.cpp
+++ b/toolchain/lc-compile/src/module-helper.cpp
@@ -30,6 +30,7 @@ extern builtin_module_descriptor __com_livecode_binary_module_info;
 extern builtin_module_descriptor __com_livecode_bitwise_module_info;
 extern builtin_module_descriptor __com_livecode_byte_module_info;
 extern builtin_module_descriptor __com_livecode_char_module_info;
+extern builtin_module_descriptor __com_livecode_date_module_info;
 extern builtin_module_descriptor __com_livecode_encoding_module_info;
 extern builtin_module_descriptor __com_livecode_file_module_info;
 extern builtin_module_descriptor __com_livecode_item_module_info;
@@ -54,6 +55,7 @@ builtin_module_descriptor* g_builtin_modules[] =
     &__com_livecode_bitwise_module_info,
     &__com_livecode_byte_module_info,
     &__com_livecode_char_module_info,
+    &__com_livecode_date_module_info,
     //&__com_livecode_encoding_module_info,
     &__com_livecode_file_module_info,
     //&__com_livecode_item_module_info,
@@ -79,6 +81,7 @@ extern void (*MCBinaryEvalConcatenateBytes)();
 extern void (*MCBitwiseEvalBitwiseAnd)();
 extern void (*MCByteEvalNumberOfBytesIn)();
 extern void (*MCCharEvalNumberOfCharsIn)();
+extern void (*MCDateExecGetLocalTime)();
 extern void (*MCFileExecGetContents)();
 extern void (*MCListEvalHeadOf)();
 extern void (*MCLogicEvalNot)();
@@ -100,6 +103,7 @@ void *g_builtin_ptrs[] =
     &MCBitwiseEvalBitwiseAnd,
     &MCByteEvalNumberOfBytesIn,
     &MCCharEvalNumberOfCharsIn,
+    &MCDateExecGetLocalTime,
     &MCFileExecGetContents,
     &MCListEvalHeadOf,
     &MCLogicEvalNot,

--- a/toolchain/lc-compile/test.mlc
+++ b/toolchain/lc-compile/test.mlc
@@ -4,6 +4,7 @@ use com.livecode.math
 use com.livecode.file
 use com.livecode.stream
 use com.livecode.system
+use com.livecode.date
 
 public handler test()
     variable tResults as list
@@ -72,6 +73,9 @@ public handler test()
 
 	--com.livecode.system
 	testSystem(tResults)
+
+	--com.livecode.date
+	testDate(tResults)
 	
 	--com.livecode.binary
 	--com.livecode.byte
@@ -929,6 +933,10 @@ end handler
 
 public handler testSystem(inout xResults as list)
 	testLog("System", "OperatingSystemNonEmpty", the operating system is not empty, xResults)
+end handler
+
+public handler testDate(inout xResults as list)
+testLog("Date", "LocalTimeListLength", the number of elements in the local time is 6, xResults)
 end handler
 
 end module


### PR DESCRIPTION
Add a new "com.livecode.date" module with a single syntax definition:

```
the local time
```

This evaluates to a list containing the numerical components of the
local time, except for the UTC offset.  The precision of the time is
in seconds.  For example, if the current local time was:

```
2015-01-16 14:45:55 +0100
```

then "the local time" would evaluate to:

```
[ 2015, 1, 16, 14, 45, 55 ]
```

In the future, this syntax will return a date/time object that is
UTC-offset-aware and that can be formatted, converted, compared, etc.
