### PR TITLE
[[ Build ]] OS X: Fix libstdscript build rule for lc-compile args

### DIFF
--- a/libscript/libscript.xcodeproj/project.pbxproj
+++ b/libscript/libscript.xcodeproj/project.pbxproj
@@ -84,7 +84,7 @@
 			outputFiles = (
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_NAME).c",
 			);
-			script = "mkdir -p \"${BUILT_PRODUCTS_DIR}/modules\"\n\"${BUILT_PRODUCTS_DIR}/lc-compile\" -modulepath \"${BUILT_PRODUCTS_DIR}/modules\" -outputc \"${DERIVED_FILE_DIR}/${INPUT_FILE_NAME}.c\" \"${INPUT_FILE_PATH}\"";
+			script = "mkdir -p \"${BUILT_PRODUCTS_DIR}/modules\"\n\"${BUILT_PRODUCTS_DIR}/lc-compile\" --modulepath \"${BUILT_PRODUCTS_DIR}/modules\" --outputc \"${DERIVED_FILE_DIR}/${INPUT_FILE_NAME}.c\" \"${INPUT_FILE_PATH}\"";
 		};
 /* End PBXBuildRule section */
 


### PR DESCRIPTION
One place which used lc-compile was missed when updating the build
rules for the new double-dash style arguments (#1674).
