### PR TITLE
[[ Bug 14401 ]] mobileStorePurchaseError no longer returns empty on LC 7...

### DIFF
--- a/docs/notes/bugfix-14401.md
+++ b/docs/notes/bugfix-14401.md
@@ -1,0 +1,1 @@
+#     [[ In-App Purchase ]] mobileStorePurchaseError returns empty in LC 7.0

--- a/engine/src/exec-store.cpp
+++ b/engine/src/exec-store.cpp
@@ -155,8 +155,9 @@ void MCStoreGetPurchaseError(MCExecContext& ctxt, int p_id, MCStringRef& r_error
     
     t_success = MCPurchaseFindById(p_id, t_purchase);
 	
+    // PM-2015-01-19: [[ Bug 14401 ]] Fixed mismerge issue that caused mobileStorePurchaseError to return empty 
     if (t_success)
-        t_success = (t_purchase == nil || t_purchase->state != kMCPurchaseStateError);
+        t_success = (t_purchase != nil && t_purchase->state == kMCPurchaseStateError);
     
 	if (t_success)
 		t_success = MCPurchaseGetError(t_purchase, &t_error);


### PR DESCRIPTION
....0
