### PR TITLE
libfoundation: __MCRandomBytes(): Only use arc4random() if available.

### DIFF
--- a/libfoundation/src/foundation-random.cpp
+++ b/libfoundation/src/foundation-random.cpp
@@ -75,48 +75,68 @@ __MCRandomBytes (void *x_buffer,
 	return false;
 }
 
-#elif defined(__MAC__) || defined(__IOS__)
+#else /* !__WINDOWS__ */
 /* ----------------------------------------------------------------
- * Darwin libc random numbers
- * ---------------------------------------------------------------- */
-
-bool
-__MCRandomBytes (void *x_buffer,
-				 size_t p_buffer_length)
-{
-	/* arc4random(3) is a source of cryptographic-quality random data.
-	 * It self-seeds from the kernel entropy source when necessary. */
-	arc4random_buf (x_buffer, p_buffer_length);
-
-	return true;
-}
-
-#else
-/* ----------------------------------------------------------------
- * POSIX random number device
+ * Non-Windows random numbers
  * ---------------------------------------------------------------- */
 
 bool
 __MCRandomBytes (void *x_buffer,
                  size_t p_buffer_length)
 {
-	/* On Linux, we use /dev/urandom because it's guaranteed not to
-	 * block. */
-	static const char k_random_device[] = "/dev/urandom";
 
-	MCStreamRef t_stream;
+#	if defined(__MAC__) || defined(__IOS__)
+	/* ---------- arc4random(3) library function
+	 *
+	 * On OSX >= 10.7 and on most versions of iOS, there's an
+	 * arc4random(3) function in the standard library.  It's a source
+	 * of cryptographic-quality random data.  It self-seeds from the
+	 * kernel entropy source when necessary.
+	 *
+	 * Since we don't know whether arc4random_buf(3) is available at
+	 * compile time, check for it using dlsym(3).
+	 */
+	{
+		void (*t_arc4random_buf_func)(void *, size_t);
+		void *t_self;
 
-	if (!MCFileCreateStream (MCSTR(k_random_device), kMCOpenFileModeRead,
-	                         t_stream))
-		return false;
+		t_self = dlopen(NULL, 0);
+		t_arc4random_buf_func = dlsym (t_self, "arc4random_buf");
 
-	bool t_success = true;
-	if (t_success)
-		t_success = MCStreamRead (t_stream, x_buffer, p_buffer_length);
+		if (NULL != t_arc4random_buf_func)
+		{
+			t_arc4random_buf_func (x_buffer, p_buffer_length);
+			return true;
+		}
+	}
+#	endif /* __MAC__ || __IOS__ */
 
-	MCValueRelease (t_stream);
+	/* ---------- POSIX random number device
+	 *
+	 * Both Linux and OSX/iOS have /dev/random and /dev/urandom.  On
+	 * OSX/iOS, they both behave identically, but on Linux, only
+	 * /dev/urandom is guaranteed not to block waiting for entropy.
+	 */
+	{
+		static const char k_random_device[] = "/dev/urandom";
+		bool t_success = true;
+		MCStreamRef t_stream = NULL;
 
-	return t_success;
+		if (t_success)
+			t_success = MCFileCreateStream (MCSTR(k_random_device),
+			                                kMCOpenFileModeRead,
+			                                t_stream);
+
+		if (t_success)
+			t_success = MCStreamRead (t_stream, x_buffer,
+			                          p_buffer_length);
+
+		MCValueRelease (t_stream);
+
+		if (t_success)
+			return true;
+	}
+	return false;
 }
 
-#endif
+#endif /* !__WINDOWS__ */


### PR DESCRIPTION
We should use arc4random(3) if it's available on OS X and iOS, and if its unavailable, fall back to reading from /dev/urandom. arc4random(3) is only available on OS X >= 10.7.

Reported by @runrevmark.
