### PR TITLE
[[ DynamicFonts ]] Enable dynamic font loading on Linux

### DIFF
--- a/engine/src/linux.stubs
+++ b/engine/src/linux.stubs
@@ -626,3 +626,12 @@ esd libesd.so.0
 	esd_close: (integer) -> (integer)
 	esd_play_stream: (integer, integer, pointer, pointer) -> (integer)
 	esd_open_sound: (pointer) -> (integer)
+
+fontconfig libfontconfig.so.1
+	FcInit: () -> (integer)
+	FcInitLoadConfigAndFonts: () -> (pointer)
+	FcConfigAppFontAddFile: (pointer, pointer) -> (integer)
+	FcConfigAppFontClear: (pointer) -> ()
+	FcConfigBuildFonts: (pointer) -> (integer)
+	FcConfigSetCurrent: (pointer) -> (integer)
+    

--- a/engine/src/lnxdc.h
+++ b/engine/src/lnxdc.h
@@ -368,5 +368,8 @@ public:
     virtual void configureIME(int32_t x, int32_t y);
 	virtual void activateIME(Boolean activate);
 	//virtual void closeIME();
+    
+    virtual bool loadfont(MCStringRef p_path, bool p_globally, void*& r_loaded_font_handle);
+    virtual bool unloadfont(MCStringRef p_path, bool p_globally, void *r_loaded_font_handle);
 };
 #endif


### PR DESCRIPTION
A minimal implementation using the fontconfig library to get font loading working on Linux.

It cannot currently
- load fonts globally
- unload fonts efficiently

We might want to consider back-porting this to 7, although I'm not sure anyone has asked for it. 
