### PR TITLE
Feature lcb dynamic calls

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2464,8 +2464,19 @@ MC_DLLEXPORT bool MCRecordIterate(MCRecordRef record, uintptr_t& x_iterator, MCN
 //  HANDLER DEFINITIONS
 //
 
-MC_DLLEXPORT void *MCHandlerGetDefinition(MCHandlerRef handler);
-MC_DLLEXPORT void *MCHandlerGetInstance(MCHandlerRef handler);
+struct MCHandlerCallbacks
+{
+    size_t size;
+    void (*release)(void *context);
+    bool (*invoke)(void *context, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
+};
+
+MC_DLLEXPORT bool MCHandlerCreate(MCTypeInfoRef typeinfo, const MCHandlerCallbacks *callbacks, void *context, MCHandlerRef& r_handler);
+
+MC_DLLEXPORT void *MCHandlerGetContext(MCHandlerRef handler);
+MC_DLLEXPORT const MCHandlerCallbacks *MCHandlerGetCallbacks(MCHandlerRef handler);
+    
+MC_DLLEXPORT bool MCHandlerInvoke(MCHandlerRef handler, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -41,6 +41,16 @@ bool MCHandlerInvoke(MCHandlerRef self, MCValueRef *p_arguments, uindex_t p_argu
     return self -> callbacks -> invoke(self + 1, p_arguments, p_argument_count, r_value);
 }
 
+void *MCHandlerGetContext(MCHandlerRef self)
+{
+    return self + 1;
+}
+
+const MCHandlerCallbacks *MCHandlerGetCallbacks(MCHandlerRef self)
+{
+    return self -> callbacks;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void __MCHandlerDestroy(__MCHandler *self)

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -20,14 +20,48 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void *MCHandlerGetDefinition(MCHandlerRef self)
+bool MCHandlerCreate(MCTypeInfoRef p_typeinfo, const MCHandlerCallbacks *p_callbacks, void *p_context, MCHandlerRef& r_handler)
 {
-    return nil;
+    __MCHandler *self;
+    if (!__MCValueCreate(kMCValueTypeCodeHandler, sizeof(__MCHandler) + p_callbacks -> size, (__MCValue*&)self))
+        return false;
+    
+    MCMemoryCopy(self + 1, p_context, p_callbacks -> size);
+    
+    self -> typeinfo = MCValueRetain(p_typeinfo);
+    self -> callbacks = p_callbacks;
+    
+    r_handler = self;
+    
+    return true;
 }
 
-void *MCHandlerGetInstance(MCHandlerRef self)
+bool MCHandlerInvoke(MCHandlerRef self, MCValueRef *p_arguments, uindex_t p_argument_count, MCValueRef& r_value)
 {
-    return nil;
+    return self -> callbacks -> invoke(self + 1, p_arguments, p_argument_count, r_value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void __MCHandlerDestroy(__MCHandler *self)
+{
+    if (self -> callbacks -> release != nil)
+        self -> callbacks -> release(self + 1);
+}
+
+hash_t __MCHandlerHash(__MCHandler *self)
+{
+    return MCHashPointer(self);
+}
+
+bool __MCHandlerIsEqualTo(__MCHandler *self, __MCHandler *other_self)
+{
+    return self == other_self;
+}
+
+bool __MCHandlerCopyDescription(__MCHandler *self, MCStringRef& r_desc)
+{
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -410,6 +410,14 @@ struct __MCForeignValue: public __MCValue
     MCTypeInfoRef typeinfo;
 };
 
+////////
+
+struct __MCHandler: public __MCValue
+{
+    MCTypeInfoRef typeinfo;
+    const MCHandlerCallbacks *callbacks;
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern const uindex_t __kMCValueHashTableSizes[];
@@ -536,6 +544,11 @@ void __MCForeignValueDestroy(__MCForeignValue *self);
 hash_t __MCForeignValueHash(__MCForeignValue *self);
 bool __MCForeignValueIsEqualTo(__MCForeignValue *self, __MCForeignValue *other_self);
 bool __MCForeignValueCopyDescription(__MCForeignValue *self, MCStringRef& r_description);
+
+void __MCHandlerDestroy(__MCHandler *self);
+hash_t __MCHandlerHash(__MCHandler *self);
+bool __MCHandlerIsEqualTo(__MCHandler *self, __MCHandler *other_self);
+bool __MCHandlerCopyDescription(__MCHandler *self, MCStringRef& r_description);
 
 bool __MCStreamInitialize(void);
 void __MCStreamFinalize(void);

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -416,6 +416,7 @@ struct __MCHandler: public __MCValue
 {
     MCTypeInfoRef typeinfo;
     const MCHandlerCallbacks *callbacks;
+    char context[1];
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -749,8 +749,12 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
                 /* UNCHECKED */ MCStringFormat(&t_string, t_value == kMCTrue ? "<true>" : "<false>");
 			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeNull)
                 /* UNCHECKED */ MCStringFormat(&t_string, "<null>");
+            else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeHandler)
+                /* UNCHECKED */ MCStringFormat(&t_string, "<handler>");
+            else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeTypeInfo)
+                /* UNCHECKED */ MCStringFormat(&t_string, "<type>");
             else
-				MCAssert(false);
+                /* UNCHECKED */ MCStringFormat(&t_string, "<unknown>");
 
 			if (t_range == nil)
 				t_success = MCStringAppend(t_buffer, *t_string);

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -89,8 +89,7 @@ MCTypeInfoRef MCValueGetTypeInfo(MCValueRef p_value)
         case kMCValueTypeCodeRecord:
             return ((__MCRecord *)p_value) -> typeinfo;
         case kMCValueTypeCodeHandler:
-            MCAssert(false); // TODO
-            return nil;
+            return ((__MCHandler *)p_value) -> typeinfo;
         case kMCValueTypeCodeError:
             return ((__MCError *)p_value) -> typeinfo;
         case kMCValueTypeCodeForeignValue:
@@ -200,6 +199,8 @@ hash_t MCValueHash(MCValueRef p_value)
         return __MCProperListHash((__MCProperList *)self);
     case kMCValueTypeCodeRecord:
         return __MCRecordHash((__MCRecord*) self);
+    case kMCValueTypeCodeHandler:
+        return __MCHandlerHash((__MCHandler*) self);    
     case kMCValueTypeCodeTypeInfo:
         return __MCTypeInfoHash((__MCTypeInfo*) self);
     case kMCValueTypeCodeError:
@@ -277,6 +278,8 @@ bool MCValueIsEqualTo(MCValueRef p_value, MCValueRef p_other_value)
         return __MCProperListIsEqualTo((__MCProperList*)self, (__MCProperList*)other_self);
     case kMCValueTypeCodeRecord:
         return __MCRecordIsEqualTo((__MCRecord*)self, (__MCRecord*)other_self);
+    case kMCValueTypeCodeHandler:
+        return __MCHandlerIsEqualTo((__MCHandler*)self, (__MCHandler*)other_self);    
     case kMCValueTypeCodeTypeInfo:
         return __MCTypeInfoIsEqualTo((__MCTypeInfo *)self, (__MCTypeInfo *)other_self);
     case kMCValueTypeCodeError:
@@ -332,6 +335,8 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
         return __MCProperListCopyDescription((__MCProperList*)p_value, r_desc);
     case kMCValueTypeCodeRecord:
         return __MCRecordCopyDescription((__MCRecord*)p_value, r_desc);
+    case kMCValueTypeCodeHandler:
+        return __MCHandlerCopyDescription((__MCHandler*)p_value, r_desc);
     case kMCValueTypeCodeTypeInfo:
         return __MCTypeInfoCopyDescription((__MCTypeInfo*)p_value, r_desc);
     case kMCValueTypeCodeError:
@@ -544,6 +549,9 @@ void __MCValueDestroy(__MCValue *self)
         break;
     case kMCValueTypeCodeRecord:
         __MCRecordDestroy((__MCRecord *)self);
+        break;
+    case kMCValueTypeCodeHandler:
+        __MCHandlerDestroy((__MCHandler *)self);
         break;
     case kMCValueTypeCodeTypeInfo:
         __MCTypeInfoDestroy((__MCTypeInfo *)self);

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1368,7 +1368,7 @@ void MCScriptBeginInvokeEvaluateInModule(MCScriptModuleBuilderRef self, uindex_t
 }
 #endif
 
-void MCScriptBeginIndirectInvokeInModule(MCScriptModuleBuilderRef self, uindex_t p_handler_reg, uindex_t p_result_reg)
+void MCScriptBeginInvokeIndirectInModule(MCScriptModuleBuilderRef self, uindex_t p_handler_reg, uindex_t p_result_reg)
 {
     if (self == nil || !self -> valid)
         return;

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -307,7 +307,7 @@ bool MCScriptValidateModule(MCScriptModuleRef self)
                     case kMCScriptBytecodeOpStoreGlobal:
                         // check arity is 2
                         // check glob index is in definition range
-                        // check definition[index] is variable
+                        // check definition[index] is variable or handler
                         t_temporary_count = MCMax(t_temporary_count, t_operands[0] + 1);
                         break;
                 }

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -35,6 +35,7 @@ MCTypeInfoRef kMCScriptTypeBindingErrorTypeInfo;
 MCTypeInfoRef kMCScriptNoMatchingHandlerErrorTypeInfo;
 MCTypeInfoRef kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo;
 MCTypeInfoRef kMCScriptInvalidPropertyValueErrorTypeInfo;
+MCTypeInfoRef kMCScriptNotAHandlerValueErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -268,6 +269,7 @@ bool MCScriptInitialize(void)
         MCScriptCreateNamedErrorType(MCNAME("livecode.lang.NoMatchingHandlerError"), MCSTR("No matching handler for arguments with types (%{types}) - possible handlers (%{handlers})"), kMCScriptNoMatchingHandlerErrorTypeInfo);
         MCScriptCreateNamedErrorType(MCNAME("livecode.lang.CannotSetReadOnlyPropertyError"), MCSTR("Cannot set read-only property %{module}.%{property}"), kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo);
         MCScriptCreateNamedErrorType(MCNAME("livecode.lang.PropertyValueTypeError"), MCSTR("Value is not of correct type for setting property - expected type %{type} for setting property %{module}.%{property}"), kMCScriptInvalidPropertyValueErrorTypeInfo);
+        MCScriptCreateNamedErrorType(MCNAME("livecode.lang.NotAHandlerValueError"), MCSTR("Value is not a handler"), kMCScriptNotAHandlerValueErrorTypeInfo);
     }
 
     return true;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -40,6 +40,7 @@ extern MCTypeInfoRef kMCScriptTypeBindingErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptNoMatchingHandlerErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptInvalidPropertyValueErrorTypeInfo;
+extern MCTypeInfoRef kMCScriptNotAHandlerValueErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -249,10 +250,13 @@ struct MCScriptVariableDefinition: public MCScriptDefinition
 	uindex_t slot_index;
 };
 
-struct MCScriptHandlerDefinition: public MCScriptDefinition
+struct MCScriptCommonHandlerDefinition: public MCScriptDefinition
 {
-	uindex_t type;
-    
+    uindex_t type;
+};
+
+struct MCScriptHandlerDefinition: public MCScriptCommonHandlerDefinition
+{
     uindex_t *locals;
     uindex_t local_count;
     
@@ -287,9 +291,8 @@ struct MCScriptSyntaxDefinition: public MCScriptDefinition
     uindex_t method_count;
 };
 
-struct MCScriptForeignHandlerDefinition: public MCScriptDefinition
+struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
 {
-    uindex_t type;
     MCStringRef binding;
     
     // Bound function information - not pickled.

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -237,7 +237,8 @@
 
 'action' FullyResolveType(TYPE -> TYPE)
 
-    'rule' FullyResolveType(optional(_, Base) -> Base):
+    'rule' FullyResolveType(optional(_, Type) -> Base):
+        FullyResolveType(Type -> Base)
     
     'rule' FullyResolveType(named(_, Id) -> Base):
         QuerySymbolId(Id -> Named)

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -259,11 +259,6 @@
             FullyResolveType(Type -> BaseType)
             (|
                 where(BaseType -> handler(_, Signature))
-                [|
-                    where(Signature -> deferred)
-                    Id'Position -> Position
-                    Error_UniversalHandlerTypeVariablesCannotBeCalled(Position)
-                |]
             ||
                 Id'Position -> Position
                 Error_NonHandlerTypeVariablesCannotBeCalled(Position)

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -114,8 +114,7 @@
         CheckBindings(Body)
 
     'rule' CheckBindings(STATEMENT'call(_, Handler, Arguments)):
-        -- TODO: Implement indirect calls
-        /* B4 */ CheckBindingIsHandlerId(Handler)
+        /* B4 */ CheckBindingIsCallableVariableOrHandlerId(Handler)
         CheckBindings(Arguments)
 
     --
@@ -124,8 +123,7 @@
         /* BE1 */ CheckBindingIsVariableOrHandlerId(Name)
 
     'rule' CheckBindings(EXPRESSION'call(_, Handler, Arguments)):
-        -- TODO: Implement indirect calls
-        /* BE2 */ CheckBindingIsHandlerId(Handler)
+        /* BE2 */ CheckBindingIsCallableVariableOrHandlerId(Handler)
         CheckBindings(Arguments)
         
     --
@@ -236,6 +234,42 @@
         Error_NotBoundToAVariableOrHandler(Position, Name)
         -- Mark this id as being in error.
         Id'Meaning <- error
+
+'action' FullyResolveType(TYPE -> TYPE)
+
+    'rule' FullyResolveType(optional(_, Base) -> Base):
+    
+    'rule' FullyResolveType(named(_, Id) -> Base):
+        QuerySymbolId(Id -> Named)
+        Named'Type -> Type
+        FullyResolveType(Type -> Base)
+        
+    'rule' FullyResolveType(Type -> Type):
+
+'action' CheckBindingIsCallableVariableOrHandlerId(ID)
+
+    'rule' CheckBindingIsCallableVariableOrHandlerId(Id):
+        CheckBindingIsVariableOrHandlerId(Id)
+        [|
+            QuerySymbolId(Id -> Info)
+            Info'Kind -> Kind
+            -- If we get here the symbol is either a handler or variable (local or global)
+            ne(Kind, handler)
+            Info'Type -> Type
+            FullyResolveType(Type -> BaseType)
+            (|
+                where(BaseType -> handler(_, Signature))
+                [|
+                    where(Signature -> deferred)
+                    Id'Position -> Position
+                    Error_UniversalHandlerTypeVariablesCannotBeCalled(Position)
+                |]
+            ||
+                Id'Position -> Position
+                Error_NonHandlerTypeVariablesCannotBeCalled(Position)
+            |)
+        |]
+            
 
 'action' CheckBindingIsSyntaxRuleOfExpressionType(ID)
 
@@ -1122,9 +1156,12 @@
         CheckInvokes(Definitions)
 
     'rule' CheckInvokes(STATEMENT'call(Position, Handler, Arguments)):
-        QueryHandlerIdSignature(Handler -> signature(Parameters, ReturnType))
-        CheckCallArguments(Position, Parameters, Arguments)
-        CheckInvokes(Arguments)
+        [|
+            -- This call will fail if Handler is an untyped or generic handler type variable
+            QueryHandlerIdSignature(Handler -> signature(Parameters, ReturnType))
+            CheckCallArguments(Position, Parameters, Arguments)
+            CheckInvokes(Arguments)
+        |]
 
     'rule' CheckInvokes(STATEMENT'invoke(Position, Info, Arguments)):
         (|
@@ -1209,9 +1246,12 @@
         CheckInvokes(Error)
 
     'rule' CheckInvokes(EXPRESSION'call(Position, Handler, Arguments)):
-        QueryHandlerIdSignature(Handler -> signature(Parameters, ReturnType))
-        CheckCallArguments(Position, Parameters, Arguments)
-        CheckInvokes(Arguments)
+        [|
+            -- This call will fail if Handler is an untyped or generic handler type variable
+            QueryHandlerIdSignature(Handler -> signature(Parameters, ReturnType))
+            CheckCallArguments(Position, Parameters, Arguments)
+            CheckInvokes(Arguments)
+        |]
     
     'rule' CheckInvokes(EXPRESSION'invoke(Position, Info, Arguments)):
         (|
@@ -1316,8 +1356,12 @@
             Error_SyntaxNotAllowedInThisContext(Position)
         |)
         
-    'rule' CheckExpressionIsAssignable(slot(_, _)):
-        -- variables are assignable
+    'rule' CheckExpressionIsAssignable(slot(Position, Id)):
+        [|
+            QueryKindOfSymbolId(Id -> handler)
+            Id'Name -> Name
+            Error_CannotAssignToHandlerId(Position, Name)
+        |]
         
     'rule' CheckExpressionIsAssignable(Expr):
         -- everything else is not
@@ -1431,6 +1475,7 @@
         |)
     'rule' IsHighLevelType(optional(_, Type)):
         IsHighLevelType(Type)
+    'rule' IsHighLevelType(handler(_, _)):
     'rule' IsHighLevelType(record(_, _, _)):
     'rule' IsHighLevelType(pointer(_)):
     'rule' IsHighLevelType(boolean(_)):
@@ -1450,6 +1495,12 @@
         QueryId(Id -> symbol(Info))
         Info'Kind -> handler
         Info'Type -> handler(_, Signature)
+        
+    'rule' QueryHandlerIdSignature(Id -> Signature)
+        QueryId(Id -> symbol(Info))
+        Info'Kind -> variable
+        Info'Type -> Type
+        FullyResolveType(Type -> handler(_, Signature))
 
 'condition' QueryKindOfSymbolId(ID -> SYMBOLKIND)
 

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -115,6 +115,7 @@ extern "C" void EmitBeginIndirectCall(long reg, long resultreg);
 extern "C" void EmitContinueCall(long reg);
 extern "C" void EmitEndCall(void);
 extern "C" void EmitBeginInvoke(long index, long contextreg, long resultreg);
+extern "C" void EmitBeginIndirectInvoke(long handlerreg, long contextreg, long resultreg);
 extern "C" void EmitContinueInvoke(long reg);
 extern "C" void EmitEndInvoke(void);
 extern "C" void EmitAssign(long dst, long src);
@@ -979,6 +980,12 @@ void EmitBeginInvoke(long index, long contextreg, long resultreg)
 {
     MCScriptBeginInvokeInModule(s_builder, index, resultreg);
     MCLog("[Emit] BeginExecuteInvoke(%ld, %ld, %ld)", index, contextreg, resultreg);
+}
+
+void EmitBeginIndirectInvoke(long handlerreg, long contextreg, long resultreg)
+{
+    MCScriptBeginInvokeInModule(s_builder, handlerreg, resultreg);
+    MCLog("[Emit] BeginExecuteIndirectInvoke(%ld, %ld, %ld)", handlerreg, contextreg, resultreg);
 }
 
 void EmitContinueInvoke(long reg)

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -984,7 +984,7 @@ void EmitBeginInvoke(long index, long contextreg, long resultreg)
 
 void EmitBeginIndirectInvoke(long handlerreg, long contextreg, long resultreg)
 {
-    MCScriptBeginInvokeInModule(s_builder, handlerreg, resultreg);
+    MCScriptBeginInvokeIndirectInModule(s_builder, handlerreg, resultreg);
     MCLog("[Emit] BeginExecuteIndirectInvoke(%ld, %ld, %ld)", handlerreg, contextreg, resultreg);
 }
 

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1369,7 +1369,7 @@
             -- If the Id is not a handler it must be a variable
             ne(Kind, handler)
             EmitCreateRegister(-> HandlerReg)
-            EmitFetchVar(Kind, Index, HandlerReg)
+            EmitFetchVar(Kind, HandlerReg, Index)
         ||
             where(-1 -> HandlerReg)
         |)
@@ -1501,12 +1501,13 @@
 
 'action' EmitFetchVar(SYMBOLKIND, INT, INT)
 
-    'rule' EmitFetchVar(variable, Reg, Var):
-        EmitFetchGlobal(Reg, Var)
-        
-    'rule' EmitFetchVar(_, Reg, Var):
+    'rule' EmitFetchVar(local, Reg, Var):
         EmitFetchLocal(Reg, Var)
 
+    -- This catches all module-scope things, including variables and handler references.
+    'rule' EmitFetchVar(_, Reg, Var):
+        EmitFetchGlobal(Reg, Var)
+        
 'action' EmitInvokeRegisterList(INTLIST)
 
     'rule' EmitInvokeRegisterList(intlist(Head, Tail)):

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -173,7 +173,6 @@ DEFINE_ERROR(ParameterMustHaveHighLevelType, "Inappropriate type for parameter")
 
 DEFINE_ERROR_I(CannotAssignToHandlerId, "'%s' is a handler id and cannot be assigned to")
 
-DEFINE_ERROR(UniversalHandlerTypeVariablesCannotBeCalled, "Variables must have specific handler type to be called")
 DEFINE_ERROR(NonHandlerTypeVariablesCannotBeCalled, "Variables must have handler type to be called")
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -171,6 +171,11 @@ DEFINE_ERROR(SyntaxNotAllowedInThisContext, "This syntax is not allowed for this
 DEFINE_ERROR(VariableMustHaveHighLevelType, "Inappropriate type for variable")
 DEFINE_ERROR(ParameterMustHaveHighLevelType, "Inappropriate type for parameter")
 
+DEFINE_ERROR_I(CannotAssignToHandlerId, "'%s' is a handler id and cannot be assigned to")
+
+DEFINE_ERROR(UniversalHandlerTypeVariablesCannotBeCalled, "Variables must have specific handler type to be called")
+DEFINE_ERROR(NonHandlerTypeVariablesCannotBeCalled, "Variables must have handler type to be called")
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void yyerror(const char *p_text)

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -279,6 +279,10 @@
     Error_SyntaxNotAllowedInThisContext
     Error_ParameterMustHaveHighLevelType
     Error_VariableMustHaveHighLevelType
+    Error_CannotAssignToHandlerId
+    Error_UniversalHandlerTypeVariablesCannotBeCalled
+    Error_NonHandlerTypeVariablesCannotBeCalled
+
 
 --------------------------------------------------------------------------------
 
@@ -607,5 +611,9 @@
 
 'action' Error_ParameterMustHaveHighLevelType(Position: POS)
 'action' Error_VariableMustHaveHighLevelType(Position: POS)
+
+'action' Error_CannotAssignToHandlerId(Position: POS, Identifier: NAME)
+'action' Error_UniversalHandlerTypeVariablesCannotBeCalled(Position: POS)
+'action' Error_NonHandlerTypeVariablesCannotBeCalled(Position: POS)
 
 --------------------------------------------------------------------------------

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -280,7 +280,6 @@
     Error_ParameterMustHaveHighLevelType
     Error_VariableMustHaveHighLevelType
     Error_CannotAssignToHandlerId
-    Error_UniversalHandlerTypeVariablesCannotBeCalled
     Error_NonHandlerTypeVariablesCannotBeCalled
 
 
@@ -613,7 +612,6 @@
 'action' Error_VariableMustHaveHighLevelType(Position: POS)
 
 'action' Error_CannotAssignToHandlerId(Position: POS, Identifier: NAME)
-'action' Error_UniversalHandlerTypeVariablesCannotBeCalled(Position: POS)
 'action' Error_NonHandlerTypeVariablesCannotBeCalled(Position: POS)
 
 --------------------------------------------------------------------------------

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -79,6 +79,7 @@
 
 'type' SIGNATURE
     signature(Parameters: PARAMETERLIST, ReturnType: TYPE)
+    deferred -- a deferred signature indicates 'any handler type'
 
 'type' ACCESS
     inferred

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -79,7 +79,6 @@
 
 'type' SIGNATURE
     signature(Parameters: PARAMETERLIST, ReturnType: TYPE)
-    deferred -- a deferred signature indicates 'any handler type'
 
 'type' ACCESS
     inferred


### PR DESCRIPTION
This is the implementation of dynamic handler calls in LCB.

It allows you to treat handler identifiers as (constant) values. If a handler is bound, then evaluating the handler identifier creates an MCHandler valueref (which is essentially a closure - instance + handler reference).

Variables which are explicitly typed as a handler type can then be used in call syntax '<variable>(...)'. This causes the assigned handler to be executed (in the context of the instance it was evaluated in). (Note that you can assign a handler value to a type of 'any', but you cannot invoke it from such a variable - it needs to be placed into an explicitly typed variable as otherwise the compiler doesn't know how to compile the call).

One handler type conforms to another if the parameter count is the same, the modes of all arguments match and parameter types conform in an appropriate way. In particular, for in parameters (and the result) the type of the parameter in the target type must conform to that of the concrete parameter, for out parameters the type of concrete parameter must conform to that of the parameter in the type. (inout parameters require both).

When a foreign handler identifier is evaluated binding will be attempted with undefined being the value if this fails. Note that any binding errors not related to not finding the library / function will still cause an exception as these are considered programmatic errors (e.g. ill formatted binding string).
