### PR TITLE
[[ Bug 14424 ]] Prevent overrelease of path strings when evaluating the ...

### DIFF
--- a/docs/notes/bugfix-14424.md
+++ b/docs/notes/bugfix-14424.md
@@ -1,0 +1,1 @@
+# Getting 'the fontfilesinuse' can cause a crash.

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -595,28 +595,20 @@ bool MCFontUnload(MCStringRef p_path)
 
 bool MCFontListLoaded(uindex_t& r_count, MCStringRef*& r_list)
 {
-    MCAutoArray<MCStringRef> t_list;
+    MCAutoStringRefArray t_list;
     
     bool t_success;
     t_success = true;
  
     // AL-2015-01-22: [[ Bug 14424 ]] 'the fontfilesinuse' can cause a crash, due to overreleasing MCStringRefs.
-    //  Property getters always release afterwards, so we have to increment the ref count of each font path.
+    //  Property getters always release afterwards, use an MCAutoStringRefArray which increses the refcount.
     for(MCLoadedFont *t_font = s_loaded_fonts; t_success && t_font != nil; t_font = t_font -> next)
-        t_success = t_list . Push(MCValueRetain(t_font -> path));
-
-    // Ensure all strings with increased refcount are released on failure.
-    if (!t_success)
-    {
-        for (uindex_t i = 0;i < t_list . Size() ; i++)
-            MCValueRelease(t_list[i]);
-        
-        return false;
-    }
+        t_success = t_list . Push(t_font -> path);
     
-    t_list . Take(r_list, r_count);
+    if (t_success)
+        t_list . Take(r_list, r_count);
 
-    return true;
+    return t_success;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -166,6 +166,14 @@ public:
 
 		return true;
 	}
+    
+    bool Push(T p_value)
+    {
+        if (!Extend(m_value_count + 1))
+            return false;
+        m_values[m_value_count - 1] = MCValueRetain(p_value);
+        return true;
+    }
 
 	//////////
 


### PR DESCRIPTION
...font files in use
