### PR TITLE
[[ Bug 14423 ]] Ensure that the codec names can be converted to MacRoman...

### DIFF
--- a/docs/notes/bugfix-14423.md
+++ b/docs/notes/bugfix-14423.md
@@ -1,0 +1,1 @@
+# revCapture - revCaptureListVideoCodecs() results in crash

--- a/docs/notes/bugfix-14423.md
+++ b/docs/notes/bugfix-14423.md
@@ -1,1 +1,29 @@
 # revCapture - revCaptureListVideoCodecs() results in crash
+
+To palliate this problem, some getters in the library revCapture must return possibly UTF-8 encoded names (such as the codecs) to allow the script writer to set them.
+In the same idea, some setters can be given UTF-8 encoded strings.
+
+Affected getters:
+- revCaptureListAudioInputs
+- revCaptureListVideoInputs
+- revCaptureGetAudioInput
+- revCaptureGetVideoInput
+- revCaptureGetPreviewImage
+- revCapturePreviewState
+- revCaptureListAudioCodecs
+- revCaptureListVideoCodecs
+- revCaptureGetAudioCodec
+- revCaptureGetVideoCodec
+- revCaptureGetRecordOutput
+- revCaptureStartRecording
+- revCaptureStopRecording
+- revCaptureGetRecordFrameSize
+- revCaptureRecordState
+
+Affected setters:
+- revCaptureSetAudioInput
+- revCaptureSetVideoInput
+- revCaptureSetPreviewImage
+- revCaptureSetAudioCodec
+- revCaptureSetVideoCodec
+- revCaptureSetRecordOutput

--- a/docs/notes/bugfix-14423.md
+++ b/docs/notes/bugfix-14423.md
@@ -9,16 +9,11 @@ Affected getters:
 - revCaptureGetAudioInput
 - revCaptureGetVideoInput
 - revCaptureGetPreviewImage
-- revCapturePreviewState
 - revCaptureListAudioCodecs
 - revCaptureListVideoCodecs
 - revCaptureGetAudioCodec
 - revCaptureGetVideoCodec
 - revCaptureGetRecordOutput
-- revCaptureStartRecording
-- revCaptureStopRecording
-- revCaptureGetRecordFrameSize
-- revCaptureRecordState
 
 Affected setters:
 - revCaptureSetAudioInput

--- a/revvideograbber/src/revcapture.mm
+++ b/revvideograbber/src/revcapture.mm
@@ -445,28 +445,23 @@ static void CallObjCStringMethod(ObjCStringMethodPtr p_method, char *p_argc[], i
 		t_method_result = p_method();
 		if (!CatchException(r_result, r_error))
         {
-            // SN-2015-01-22: [[ Bug 14423 ]] Check first that the conversion can
-            //   be processed (cStringUsingEncoding returns nil otherwise).
-            if (![t_method_result canBeConvertedToEncoding:NSMacOSRomanStringEncoding])
-            {
-                char *t_string;
-                NSData* t_data;
-                t_data = [t_method_result dataUsingEncoding: NSMacOSRomanStringEncoding
-                                       allowLossyConversion:True];
-                
-                t_string = new char[[t_data length] + 1];
-                
-                if (t_string == NULL)
-                    *r_result = NULL;
-                else
-                {
-                    memcpy((void*)t_string, (const void*)[t_data bytes], [t_data length]);
-                    t_string [[t_data length]] = '\0';
-                    *r_result = t_string;
-                }
-            }
+            // SN-2015-01-22: [[ Bug 14423 ]] Convert to UTF-8 by default, because we
+            //  want to return the actual codec names, nothing with '?'
+            char *t_string;
+            NSData* t_data;
+            t_data = [t_method_result dataUsingEncoding: NSUTF8StringEncoding
+                                   allowLossyConversion:True];
+            
+            t_string = new char[[t_data length] + 1];
+            
+            if (t_string == NULL)
+                *r_result = NULL;
             else
-                *r_result = strdup([t_method_result cStringUsingEncoding: NSMacOSRomanStringEncoding]);
+            {
+                memcpy((void*)t_string, (const void*)[t_data bytes], [t_data length]);
+                t_string [[t_data length]] = '\0';
+                *r_result = t_string;
+            }
         }
 	}
 	@catch(id t_error)
@@ -533,7 +528,7 @@ static void CallVoidMethodWithObjCString(VoidMethodWithObjCStringPtr p_method, c
 	{
 		ClearException();
 		
-		p_method([NSString stringWithCString: p_argc[0] encoding: NSMacOSRomanStringEncoding]);
+		p_method([NSString stringWithCString: p_argc[0] encoding: NSUTF8StringEncoding]);
 		
 		CatchException(r_result, r_error);
 	}


### PR DESCRIPTION
... before duplicating the converted result
