### PR TITLE
[[ CI ]] Add basic continuous integration with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# Very basic Travis CI (http://travis-ci.org) control file that allows
+# some basic Linux-based continuous integration testing (for free).
+
+language: c++
+
+# Before setting up the source tree, install necessary development
+# headers
+before_install:
+- sudo apt-get install -y libx11-dev libxext-dev libxrender-dev libxft-dev libxinerama-dev libxv-dev libxcursor-dev libfreetype6-dev libgtk2.0-dev libpopt-dev libesd0-dev liblcms-dev
+
+# Set up the source tree by fetching Linux-specific prebuilt objects
+install: (cd prebuilt && ./fetch-libraries.sh linux)
+
+# Bootstrap the LCB compiler, build the default target set and run a
+# the default test suite.
+script: make -sj2 bootstrap && make -sj2 all && make -sj2 check

--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -61,7 +61,15 @@ function fetchLibrary {
 	fi
 }
 
-for PLATFORM in "${PLATFORMS[@]}" ; do
+if [ 0 -eq "$#" ]; then
+    SELECTED_PLATFORMS="${PLATFORMS[@]}"
+else
+    SELECTED_PLATFORMS="$@"
+fi
+
+echo "$SELECTED_PLATFORMS"
+
+for PLATFORM in "${SELECTED_PLATFORMS}" ; do
 	eval "ARCHS=( \${ARCHS_${PLATFORM}[@]} )"
 	eval "LIBS=( \${LIBS_${PLATFORM}[@]} )"
 	eval "SUBPLATFORMS=( \${SUBPLATFORMS_${PLATFORM}[@]} )"


### PR DESCRIPTION
These changes add a top-level `.travis.yml` which contains build control information for use with [Travis CI](https://travis-ci.org).  Travis is a free service for open-source software projects that watches Github for new commits, pull requests and branches, and attempts to build and run integration tests.  As you can see below, it integrates with Github to show the status of the integration tests directly in the Github UI.
