### PR TITLE
[[ Bug 14437 ]] Make sure setting the player filename to empty does not ...

### DIFF
--- a/docs/notes/bugfix-14437.md
+++ b/docs/notes/bugfix-14437.md
@@ -1,0 +1,1 @@
+#    Clearing a Player filename causes LC to crash.

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -3091,7 +3091,11 @@ void MCStack::unloadexternals(void)
 bool MCStack::resolve_relative_path(MCStringRef p_path, MCStringRef& r_resolved)
 {
     if (MCStringIsEmpty(p_path))
+    {
+        // PM-2015-01-26: [[ Bug 14437 ]] If we clear the player filename in the property inspector or by script, make sure we resolve empty, to prevent a crash
+        r_resolved = MCValueRetain(kMCEmptyString);
 		return false;
+    }
 
 	MCStringRef t_stack_filename;
 	t_stack_filename = getfilename();


### PR DESCRIPTION
...crash LC
