### PR TITLE
[[ CI ]] Don't do multithreaded Travis CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install: (cd prebuilt && ./fetch-libraries.sh linux)
 
 # Bootstrap the LCB compiler, build the default target set and run a
 # the default test suite.
-script: make -sj2 bootstrap && make -sj2 all && make -sj2 check
+script: make -s bootstrap && make -s all && make -s check
 
 # Configuration for Coverity Scan integration
 #
@@ -34,5 +34,5 @@ addons:
       description: "Build submitted via Travis CI"
     notification_email: peter@livecode.com
     build_command_prepend: "./configure; make clean"
-    build_command: "make -sj2 bootstrap && make -sj2 all"
+    build_command: "make -s bootstrap && make -s all"
     branch_pattern: coverity_scan


### PR DESCRIPTION
We've been having some intermittent race conditions on Travis where
make(1) tries to use a file before the rule that creates it has finished
running.

Remove `-j2` from make(1) invocation to prevent this problem from
occurring.  Builds will take a bit longer but will hopefully stop
randomly failing...
