### PR TITLE
[[ CI ]] Unbreak Travis CI build control file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install: (cd prebuilt && ./fetch-libraries.sh linux)
 # Bootstrap the LCB compiler, build the default target set and run a
 # the default test suite.
 script: >
-  if [ ${COVERITY_SCAN_BRANCH} != "1" ]; then
+  if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then
       make -s bootstrap && make -s all && make -s check;
   fi
 


### PR DESCRIPTION
In commit 5446228e91d9 (#1717), I broke the CI build because I am a
numpty.

Specifically, `COVERITY_SCAN_BRANCH` is empty if not on the Coverity build branch, and because its shell expansion wasn't protected by quotes, a very classic shell programming error occurred.

The real WTF is why the shell didn't error out on encountering the syntax error...
