### PR TITLE
[[ Bug 14450 ]] Remove an alert dialog in case of an in-app purchase err...

### DIFF
--- a/docs/notes/bugfix-14450.md
+++ b/docs/notes/bugfix-14450.md
@@ -1,0 +1,1 @@
+#     Google Play Store - Extra error message when an in-app purchase fails

--- a/engine/src/java/com/runrev/android/billing/google/GoogleBillingProvider.java
+++ b/engine/src/java/com/runrev/android/billing/google/GoogleBillingProvider.java
@@ -426,7 +426,7 @@ public class GoogleBillingProvider implements BillingProvider
     
             if (result.isFailure())
             {
-                complain("Error purchasing: " + result);
+				// PM-2015-01-27: [[ Bug 14450 ]] [Removed code] No need to display an alert with the error message, since this information is also contained in the purchaseStateUpdate message
                 mPurchaseObserver.onPurchaseStateChanged(pendingPurchaseSku, mapResponseCode(result.getResponse()));
                 pendingPurchaseSku = "";
                 return;


### PR DESCRIPTION
...or (Google Play Store), since this information is present in purchaseStateUpdate message
