### PR TITLE
libscript: Silence "Loading builtin module" message.

### DIFF
--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -80,8 +80,6 @@ bool MCScriptInitialize(void)
     
     for(uindex_t i = 0; i < t_module_count; i++)
     {
-        MCLog("Loading builtin module - %s", t_modules[i] -> name);
-        
         MCStreamRef t_stream;
         if (!MCMemoryInputStreamCreate(t_modules[i] -> data, t_modules[i] -> size, t_stream))
             return false;


### PR DESCRIPTION
Now that builtin modules are working quite well, the messages are more
noisy than useful.
