### PR TITLE
[CVE-2015-0235] Only use gethostbyname(3) if inet_aton(3) failed. (6.7)

### DIFF
--- a/engine/src/srvposix.cpp
+++ b/engine/src/srvposix.cpp
@@ -767,6 +767,15 @@ struct MCPosixSystem: public MCSystemInterface
 	
 	bool HostNameToAddress(const char *p_hostname, MCSystemHostResolveCallback p_callback, void *p_context)
 	{
+		/* Use inet_aton to check whether p_hostname is
+		 * already an IP address; if so, don't bother calling
+		 * gethostbyname(). */
+		struct in_addr t_inaddr;
+		if (inet_aton (p_hostname, &t_inaddr))
+		{
+			return p_callback (p_context, inet_ntoa (t_inaddr));
+		}
+
 		struct hostent *he;
 		he = gethostbyname(p_hostname);
 		if (he == NULL)


### PR DESCRIPTION
Protects against exploitable buffer overflow in glibc's gethostbyname(3).

http://www.openwall.com/lists/oss-security/2015/01/27/9
