### PR TITLE
[[libsystem]] Return a value from __MCSCommandLineInitialize().

### DIFF
--- a/libfoundation/src/system-commandline.cpp
+++ b/libfoundation/src/system-commandline.cpp
@@ -210,6 +210,7 @@ __MCSCommandLineInitialize (void)
 {
 	s_arguments = NULL;
 	s_name = NULL;
+	return true;
 }
 
 void


### PR DESCRIPTION
Fixes the IDE silently bombing on startup.

Reported-by: @runrevali 
