### PR TITLE
[[ Build ]] Restore ability to fetch all platforms' prebuilts.

### DIFF
--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -67,9 +67,7 @@ else
     SELECTED_PLATFORMS="$@"
 fi
 
-echo "$SELECTED_PLATFORMS"
-
-for PLATFORM in "${SELECTED_PLATFORMS}" ; do
+for PLATFORM in ${SELECTED_PLATFORMS}; do
 	eval "ARCHS=( \${ARCHS_${PLATFORM}[@]} )"
 	eval "LIBS=( \${LIBS_${PLATFORM}[@]} )"
 	eval "SUBPLATFORMS=( \${SUBPLATFORMS_${PLATFORM}[@]} )"


### PR DESCRIPTION
Ensure that running `fetch-libraries.sh` with no arguments
downloads prebuilt libraries for all platforms.

Reported by @runrevmark.
