### PR TITLE
[[ Bug 14422 ]] Allow specification of min_os_version fields when buildi...

### DIFF
--- a/docs/notes/bugfix-14422.md
+++ b/docs/notes/bugfix-14422.md
@@ -1,0 +1,1 @@
+# Binary submitted to App Store rejected due to minimum version mismatch

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -56,8 +56,13 @@
 	<string>6A1052c</string>
 	<key>CFBundleDisplayName</key>
 		${BUNDLE_DISPLAY_NAME_SUPPORT}
-	<key>MinimumOSVersion</key>
-		${MINIMUM_OS_SUPPORT}
+	<key>LSMinimumOSVersionByArchitecture</key>
+	<dict>
+		<key>i386</key>
+		${MINIMUM_OS_i386_SUPPORT}
+		<key>x86_64</key>
+		${MINIMUM_OS_x86_64_SUPPORT}
+	</dict>
 	<key>UIDeviceFamily</key>
 	<array>
 		${DEVICE_SUPPORT}

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -56,13 +56,8 @@
 	<string>6A1052c</string>
 	<key>CFBundleDisplayName</key>
 		${BUNDLE_DISPLAY_NAME_SUPPORT}
-	<key>LSMinimumOSVersionByArchitecture</key>
-	<dict>
-		<key>i386</key>
-		${MINIMUM_OS_i386_SUPPORT}
-		<key>x86_64</key>
-		${MINIMUM_OS_x86_64_SUPPORT}
-	</dict>
+	<key>LSMinimumOSVersion</key>
+	<string>${MINIMUM_OS_SUPPORT}</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		${DEVICE_SUPPORT}

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -56,7 +56,7 @@
 	<string>6A1052c</string>
 	<key>CFBundleDisplayName</key>
 		${BUNDLE_DISPLAY_NAME_SUPPORT}
-	<key>LSMinimumOSVersion</key>
+	<key>MinimumOSVersion</key>
 	<string>${MINIMUM_OS_SUPPORT}</string>
 	<key>UIDeviceFamily</key>
 	<array>

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -120,6 +120,9 @@ static bool MCDeployMapArchitectureString(const MCString& p_string, MCDeployArch
 
 static Exec_stat MCDeployPushMinOSVersion(MCDeployParameters& p_params, MCDeployArchitecture p_arch, const char *p_vers_string)
 {
+    // Use sscanf to parse out the version string. We don't check the return value of
+    // sscanf as we don't care - any malformed / missing components will come out as
+    // 0.
     int t_major, t_minor, t_inc;
     t_major = t_minor = t_inc = 0;
     sscanf(p_vers_string, "%d.%d.%d", &t_major, &t_minor, &t_inc);

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -89,6 +89,57 @@ extern Boolean InitSSLCrypt(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static const char *kMCDeployArchitectureStrings[] =
+{
+    "",
+    "i386",
+    "x86-64",
+    "armv6",
+    "armv7",
+    "armv7s",
+    "arm64",
+    "ppc",
+    "ppc64",
+    nil,
+};
+
+static bool MCDeployMapArchitectureString(const MCString& p_string, MCDeployArchitecture& r_architecture)
+{
+    for(uindex_t i = 0; kMCDeployArchitectureStrings[i] != nil; i++)
+    {
+        // As 'p_string' is an MCString the '==' operator does a caseless comparison.
+        if (p_string == kMCDeployArchitectureStrings[i])
+        {
+            r_architecture = (MCDeployArchitecture)i;
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+static Exec_stat MCDeployPushMinOSVersion(MCDeployParameters& p_params, MCDeployArchitecture p_arch, const char *p_vers_string)
+{
+    int t_major, t_minor, t_inc;
+    t_major = t_minor = t_inc = 0;
+    sscanf(p_vers_string, "%d.%d.%d", &t_major, &t_minor, &t_inc);
+    
+    if (!MCMemoryResizeArray(p_params . min_os_version_count + 1, p_params . min_os_versions, p_params . min_os_version_count))
+        return ES_ERROR;
+    
+    uint32_t t_version;
+    t_version = (t_major & 0xFFFF) << 16;
+    t_version |= (t_minor & 0xFF) << 8;
+    t_version |= (t_inc & 0xFF) << 0;
+    
+    p_params . min_os_versions[p_params . min_os_version_count - 1] . architecture = p_arch;
+    p_params . min_os_versions[p_params . min_os_version_count - 1] . version = t_version;
+    
+    return ES_NORMAL;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 static bool MCDeployWriteDefinePrologueSection(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
 {
 	MCCapsulePrologueSection t_prologue;
@@ -531,6 +582,51 @@ Exec_stat MCIdeDeploy::exec(MCExecPoint& ep)
 		if (t_stat == ES_NORMAL && ep2 . getarray() != NULL)
 			t_params . version_info = new MCVariableValue(*ep2 . getarray());
 	}
+    
+    // The 'min_os_version' is either a string or an array. If it is a string then
+    // it encodes the version against the 'Unknown' architecture which is interpreted
+    // by the deploy command to mean all architectures. Otherwise, the keys in the
+    // array are assumed to be architecture names and each is pushed on the array.
+    // If multiple entries are present, then the 'unknown' mapping is used for any
+    // architecture not explicitly specified. The current architecture strings that are
+    // known are:
+    //   i386, x86_64, armv6, armv7, armv7s, arm64, ppc, ppc64
+    // The empty string is taken to be 'unknown'.
+    if (t_stat == ES_NORMAL)
+    {
+        t_stat = t_array -> fetch_element(ep2, "min_os_version");
+        if (t_stat == ES_NORMAL)
+        {
+            if (ep2 . getformat() == VF_ARRAY)
+            {
+                MCExecPoint ep3(ep2);
+                MCHashentry *t_entry;
+                uindex_t t_index;
+                t_entry = nil;
+                t_index = 0;
+                for(;;)
+                {
+                    if (t_stat == ES_ERROR)
+                        break;
+                    
+                    t_entry = ep2 . getarray() -> get_array() -> getnextelement(t_index, t_entry, False, ep);
+                    if (t_entry == nil)
+                        break;
+                    
+                    MCDeployArchitecture t_arch;
+                    if (!MCDeployMapArchitectureString(t_entry -> string, t_arch))
+                        continue;
+                    
+                    t_stat = t_entry -> value . fetch(ep3);
+                    
+                    if (t_stat == ES_NORMAL)
+                        t_stat = MCDeployPushMinOSVersion(t_params, t_arch, ep3 . getcstring());
+                }
+            }
+            else
+                t_stat = MCDeployPushMinOSVersion(t_params, kMCDeployArchitecture_Unknown, ep2 . getcstring());
+        }
+    }
 	
 	// If platform is iOS and we are not Mac then error
 #ifndef _MACOSX
@@ -605,6 +701,7 @@ Exec_stat MCIdeDeploy::exec(MCExecPoint& ep)
 	delete t_params . engine_ppc;
 	delete t_params . engine_x86;
 	delete t_params . version_info;
+    MCMemoryDeleteArray(t_params . min_os_versions);
 
 	if (t_stat == ES_ERROR && t_soft_error)
 		return ES_NORMAL;

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -593,7 +593,7 @@ Exec_stat MCIdeDeploy::exec(MCExecPoint& ep)
     // If multiple entries are present, then the 'unknown' mapping is used for any
     // architecture not explicitly specified. The current architecture strings that are
     // known are:
-    //   i386, x86_64, armv6, armv7, armv7s, arm64, ppc, ppc64
+    //   i386, x86-64, armv6, armv7, armv7s, arm64, ppc, ppc64
     // The empty string is taken to be 'unknown'.
     if (t_stat == ES_NORMAL)
     {

--- a/engine/src/deploy.h
+++ b/engine/src/deploy.h
@@ -56,7 +56,7 @@ struct MCDeployParameters
     // When building for Mac/iOS, you can specify a min os version per arch
     // slice.
     MCDeployMinOSVersion *min_os_versions;
-    uint32_t min_os_version_count;
+    uindex_t min_os_version_count;
     
 	// The root stackfile to be included in the standalone.
 	char *stackfile;

--- a/engine/src/deploy.h
+++ b/engine/src/deploy.h
@@ -19,6 +19,27 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum MCDeployArchitecture
+{
+    kMCDeployArchitecture_Unknown,
+    kMCDeployArchitecture_I386,
+    kMCDeployArchitecture_X86_64,
+    kMCDeployArchitecture_ARMV6,
+    kMCDeployArchitecture_ARMV7,
+    kMCDeployArchitecture_ARMV7S,
+    kMCDeployArchitecture_ARM64,
+    kMCDeployArchitecture_PPC,
+    kMCDeployArchitecture_PPC64,
+};
+
+struct MCDeployMinOSVersion
+{
+    // The architecture this version applies to.
+    MCDeployArchitecture architecture;
+    // The version word encoded as nibbles XXXX.YY.ZZ for X.Y.Z.
+    uint32_t version;
+};
+
 struct MCDeployParameters
 {
 	// The path to the engine binaries to use. On Windows and Linux this should
@@ -32,6 +53,11 @@ struct MCDeployParameters
 	// fields.
 	MCVariableValue *version_info;
 
+    // When building for Mac/iOS, you can specify a min os version per arch
+    // slice.
+    MCDeployMinOSVersion *min_os_versions;
+    uint32_t min_os_version_count;
+    
 	// The root stackfile to be included in the standalone.
 	char *stackfile;
 	// The array of auxillary stackfiles to be included in the standalone.

--- a/engine/src/deploy_macosx.cpp
+++ b/engine/src/deploy_macosx.cpp
@@ -1155,6 +1155,8 @@ static bool MCDeployToMacOSXFetchMinOSVersion(const MCDeployParameters& p_params
         t_arch = kMCDeployArchitecture_PPC;
     else if (p_header . cputype == CPU_TYPE_POWERPC64)
         t_arch = kMCDeployArchitecture_PPC64;
+    else
+        t_arch = kMCDeployArchitecture_Unknown;
     
     // Search for both the architecture in the mach header and for the 'unknown'
     // architecture. If the real arch is found, then we use that version; otherwise
@@ -1165,16 +1167,16 @@ static bool MCDeployToMacOSXFetchMinOSVersion(const MCDeployParameters& p_params
     t_found_index = -1;
     for(uindex_t i = 0; i < p_params . min_os_version_count; i++)
         if (p_params . min_os_versions[i] . architecture == t_arch &&
-            t_found_index == -1)
+            t_found_index < 0)
             t_found_index = (signed)i;
         else if (p_params . min_os_versions[i] . architecture == kMCDeployArchitecture_Unknown &&
-                 t_unknown_index == -1)
+                 t_unknown_index < 0)
             t_unknown_index = -1;
     
-    if (t_found_index == -1 && t_unknown_index == -1)
+    if (t_found_index < 0 && t_unknown_index < 0)
         return false;
     
-    if (t_found_index == -1)
+    if (t_found_index >= 0)
     {
         r_version = p_params . min_os_versions[t_unknown_index] . version;
         return true;

--- a/engine/src/deploy_macosx.cpp
+++ b/engine/src/deploy_macosx.cpp
@@ -1171,18 +1171,18 @@ static bool MCDeployToMacOSXFetchMinOSVersion(const MCDeployParameters& p_params
             t_found_index = (signed)i;
         else if (p_params . min_os_versions[i] . architecture == kMCDeployArchitecture_Unknown &&
                  t_unknown_index < 0)
-            t_unknown_index = -1;
+            t_unknown_index = (signed)i;
     
     if (t_found_index < 0 && t_unknown_index < 0)
         return false;
     
     if (t_found_index >= 0)
     {
-        r_version = p_params . min_os_versions[t_unknown_index] . version;
+        r_version = p_params . min_os_versions[t_found_index] . version;
         return true;
     }
     
-    r_version = p_params . min_os_versions[t_found_index] . version;
+    r_version = p_params . min_os_versions[t_unknown_index] . version;
     return true;
 }
 

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1062,27 +1062,23 @@ end revCopyMobileStackFiles
 private function revGetMinimumOSByArch pMinimumOS 
    local tMinimumOSByArch  
    -- MM-2013-09-23: We only support iOS 4.3 and later
-   -- SN-2015-02-02: [[ Bug 14422 ]] Minimum OS version
-   -- depends on the arch - and we only support version >= 5.0
+   -- SN-2015-02-02: [[ Bug 14422 ]] Minimum OS version is the
+   --  same for all archs, and we only support version >= 5.1
    --
-   if pMinimumOS is empty or pMinimumOS < "5.0" then
-      put "5.0.0" into tMinimumOSByArch["i386"]
+   if pMinimumOS is empty or pMinimumOS < "5.1" then
+      put "5.1.0" into tMinimumOSByArch["i386"]
    else
       put pMinimumOS & ".0" after tMinimumOSByArch["i386"]
    end if
-   if pMinimumOS is empty or pMinimumOS < "7.0" then
-      put "7.0.0" into tMinimumOSByArch["x86_64"]
-   else
-      put pMinimumOS & ".0" after tMinimumOSByArch["x86_64"]
-   end if
    
-   -- Assign the correct value to the other architectures
-   -- i386, x86_64, armv6, armv7, armv7s, arm64, ppc, ppc64
-   -- is the list of the possible architectures.
+   -- Assign the same value to the other architectures.
+   -- Possible architectures:
+   --   i386, x86-64, armv6, armv7, armv7s, arm64, ppc, ppc64
    put tMinimumOSByArch["i386"] into tMinimumOSByArch["armv6"]
    put tMinimumOSByArch["i386"] into tMinimumOSByArch["armv7"]
    put tMinimumOSByArch["i386"] into tMinimumOSByArch["armv7s"]
-   put tMinimumOSByArch["x86_64"] into tMinimumOSByArch["arm64"]
+   put tMinimumOSByArch["i386"] into tMinimumOSByArch["arm64"]
+   put tMinimumOSByArch["i386"] into tMinimumOSByArch["x86-64"]
    return tMinimumOSByArch
 end revGetMinimumOSByArch
 
@@ -1211,8 +1207,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    replace "${BUNDLE_VERSION}" with tBundleVersion in tPlist
    replace "${BUNDLE_DISPLAY_NAME_SUPPORT}" with "<string>" & tDisplayName & "</string>" in tPlist
    -- SN-2015-02-02: [[ Bug 14422 ]] We now have minimum version depending on the arch.
-   replace "${MINIMUM_OS_i386_SUPPORT}" with "<string>" & tMinimumOSByArch["i386"] & "</string>" in tPlist
-   replace "${MINIMUM_OS_x86_64_SUPPORT}" with "<string>" & tMinimumOSByArch["x86_64"] & "</string>" in tPlist
+   replace "${MINIMUM_OS_SUPPORT}" with tMinimumOSByArch["i386"] in tPlist
    replace "${CUSTOM_FONTS}" with tCustomFonts in tPlist
    
    get empty

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1063,10 +1063,10 @@ private function revGetMinimumOSByArch pMinimumOS
    local tMinimumOSByArch  
    -- MM-2013-09-23: We only support iOS 4.3 and later
    -- SN-2015-02-02: [[ Bug 14422 ]] Minimum OS version is the
-   --  same for all archs, and we only support version >= 5.1
+   --  same for all archs, and we only support version >= 5.1.1
    --
-   if pMinimumOS is empty or pMinimumOS < "5.1" then
-      put "5.1.0" into tMinimumOSByArch["i386"]
+   if pMinimumOS is empty or pMinimumOS <= "5.1" then
+      put "5.1.1" into tMinimumOSByArch["i386"]
    else
       put pMinimumOS & ".0" after tMinimumOSByArch["i386"]
    end if

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -484,6 +484,8 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
    -- Output file to create
    put pAppBundle & slash & tName into tDeploy["output"]
    
+   put revGetMinimumOSByArch(tSettings["ios,minimum os"]) into tDeploy["min_os_version"]
+   
    -- Splash to use (if non-commercial)
    if line 3 of the revLicenseInfo is among the words of "Educational Personal" then
       -- MM-2011-09-28: Descend through possible spash settings until a splash is found.
@@ -1057,6 +1059,33 @@ end revCopyMobileStackFiles
 
 ################################################################################
 
+private function revGetMinimumOSByArch pMinimumOS 
+   local tMinimumOSByArch  
+   -- MM-2013-09-23: We only support iOS 4.3 and later
+   -- SN-2015-02-02: [[ Bug 14422 ]] Minimum OS version
+   -- depends on the arch - and we only support version >= 5.0
+   --
+   if pMinimumOS is empty or pMinimumOS < "5.0" then
+      put "5.0.0" into tMinimumOSByArch["i386"]
+   else
+      put pMinimumOS & ".0" after tMinimumOSByArch["i386"]
+   end if
+   if pMinimumOS is empty or pMinimumOS < "7.0" then
+      put "7.0.0" into tMinimumOSByArch["x86_64"]
+   else
+      put pMinimumOS & ".0" after tMinimumOSByArch["x86_64"]
+   end if
+   
+   -- Assign the correct value to the other architectures
+   -- i386, x86_64, armv6, armv7, armv7s, arm64, ppc, ppc64
+   -- is the list of the possible architectures.
+   put tMinimumOSByArch["i386"] into tMinimumOSByArch["armv6"]
+   put tMinimumOSByArch["i386"] into tMinimumOSByArch["armv7"]
+   put tMinimumOSByArch["i386"] into tMinimumOSByArch["armv7s"]
+   put tMinimumOSByArch["x86_64"] into tMinimumOSByArch["arm64"]
+   return tMinimumOSByArch
+end revGetMinimumOSByArch
+
 private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    local tTemplateFile
    put mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "Settings.plist") into tTemplateFile
@@ -1066,7 +1095,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    
    ----------
    
-   local tExeName, tBundleId, tBundleVersion
+   local tExeName, tBundleId, tBundleVersion,tMinimumOSByArch
    put pSettings["name"] into tExeName
    put pSettings["ios,bundle id"] into tBundleId
    put pSettings["ios,bundle version"] into tBundleVersion
@@ -1094,11 +1123,8 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    if tDisplayName is empty then
       put tExeName into tDisplayName
    end if
-   -- MM-2013-09-23: We only support iOS 4.3 and later
-   --
-   if tMinimumOS is empty or tMinimumOS < "4.3" then
-      put "4.3" into tMinimumOS
-   end if
+   
+   put revGetMinimumOSByArch(tMinimumOS) into tMinimumOSByArch
    if tDeviceFamily is empty then
       put "1" into tDeviceFamily
    end if
@@ -1184,7 +1210,9 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    replace "${BUNDLE_IDENTIFIER}" with tBundleId in tPlist
    replace "${BUNDLE_VERSION}" with tBundleVersion in tPlist
    replace "${BUNDLE_DISPLAY_NAME_SUPPORT}" with "<string>" & tDisplayName & "</string>" in tPlist
-   replace "${MINIMUM_OS_SUPPORT}" with "<string>" & tMinimumOS & "</string>" in tPlist
+   -- SN-2015-02-02: [[ Bug 14422 ]] We now have minimum version depending on the arch.
+   replace "${MINIMUM_OS_i386_SUPPORT}" with "<string>" & tMinimumOSByArch["i386"] & "</string>" in tPlist
+   replace "${MINIMUM_OS_x86_64_SUPPORT}" with "<string>" & tMinimumOSByArch["x86_64"] & "</string>" in tPlist
    replace "${CUSTOM_FONTS}" with tCustomFonts in tPlist
    
    get empty


### PR DESCRIPTION
...ng mach-o standalones.

The plist in an app bundle must have a MinOsVersion field which matches the mach-o load command inside the executable.

This patch adds a 'min_os_version' key to the deploy array used when using the deploy command. The key's value can either be a string or an array.

In the former case, the string is taken to be a version to apply to all architectures in the (fat) binary.

In the latter case, the array is expected to be a mapping from architecture string (key) to version (value). The architecture string can be one of:
  i386, x86_64, armv6, armv7, armv7s, arm64, ppc, ppc64
If the architecture string is empty it is taken to be 'unknown'.

The version (value) must be in the X.Y.Z where X, Y, Z are integers.

For example:
   put "6.1.0" into tDeploy["min_os_version"]["i386"]
   put "8.1.0" into tDeploy["min_os_version"]["armv7"]
   put "7.1.0" into tDeploy["min_os_version"]["arm64"]

When building a standalone, the deploy command will rewrite the min os version load command in each slice based on the architecture of the slice. If a given architecture is not present in the min_os_version array, then it will take the value specified for the 'unknown' (empty key). If neither a given architecture is present nor an 'unknown' entry then the deploy command will not touch the min_os_version load command.

NOTE: This pull request should be augmented with the changes to the standalone builder to ensure that the min-os-version that is written in the plist matches that which is written into the binary.
