### PR TITLE
[[ Build ]] Quieten non-Make build actions on Linux with 'make -s'

### DIFF
--- a/rules/environment.linux.makefile
+++ b/rules/environment.linux.makefile
@@ -49,3 +49,15 @@ ifeq ($(AR),)
 	AR=ar
 endif
 
+# Sometimes it's useful to print actions that a make rule is
+# performing as if they're being run by make.  In that case, use the
+# $(_PRINT_RULE) macro, e.g.
+#
+# mytarget:
+#         @for foo in $(LIST); do \
+#           echo "$(TOOL) $$foo" $(_PRINT_RULE); \
+#           $(TOOL) $$foo || exit $?; \
+#         done
+ifneq (,$(findstring s,$(MAKEFLAGS)))
+	_PRINT_RULE = > /dev/null
+endif

--- a/rules/mlc.linux.makefile
+++ b/rules/mlc.linux.makefile
@@ -12,7 +12,7 @@ MLC_SRC_DIR = $(SRC_DIR)/_mlc
 
 LC_COMPILE ?= $(shell PATH=$(BUILD_DIR):$(PATH) \
 	              which lc-compile 2>/dev/null || \
-	              echo "lc-compile" )
+	              echo "lc-compile")
 
 MLC_SOURCES = $(shell cat $(MLC_LIST) | grep -v '^\#')
 
@@ -25,6 +25,7 @@ $(MLC_STAMP): $(MLC_SOURCES) $(MLC_LIST) $(LC_COMPILE)
 	@for f in $(MLC_SOURCES); do \
 	    mlcfile=$(SRC_DIR)/$$f ; \
 	    cfile=$(MLC_SRC_DIR)/`echo $$f | sed -e's:mlc$$:c:'` ; \
+	    echo "$(LC_COMPILE) --modulepath $(MODULE_DIR) --outputc $$cfile $$mlcfile" $(_PRINT_RULE); \
 	    $(LC_COMPILE) --modulepath $(MODULE_DIR) --outputc $$cfile $$mlcfile \
 	        || exit $$? ; \
 	done

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -320,14 +320,14 @@ $(COMPILE_stagedir)/stamp-gentle: $(COMPILE_gentle_inputs)
 	for gfile in $(subst $(COMPILE_srcdir),.,$(COMPILE_gentle_inputs)); do \
 	    gbase=`basename $$gfile` && \
 	    if [ ! -f $(COMPILE_stagesubdir)/$$gbase ]; then \
-	        echo "cp $$gfile $(COMPILE_stagesubdir)"; \
+	        echo "cp $$gfile $(COMPILE_stagesubdir)" $(_PRINT_RULE); \
 	        cp $$gfile $(COMPILE_stagesubdir) || exit $$? ; \
 	    fi; \
 	done
 	@cd $(COMPILE_stagedir) && \
 	for gfile in $(COMPILE_gentle_inputs); do \
 	    gbase=`basename $$gfile` && \
-	    echo "$(GENTLE) $$gbase"; \
+	    echo "$(GENTLE) $$gbase" $(_PRINT_RULE); \
 	    $(GENTLE) $$gbase || exit $$?; \
 	done
 	touch $@
@@ -423,10 +423,10 @@ ifeq ($(STAGE),4)
 	fi
 	-for f in $(COMPILE_bootstrap_check_exes); do rm $$f-strip; done
 	@if ! cmp $< $@; then \
-	    echo "cp $< $@"; \
+	    echo "cp $< $@" $(_PRINT_RULE); \
 	    cp $< $@; \
 	else \
-	    echo "touch $@"; \
+	    echo "touch $@" $(_PRINT_RULE); \
 	    touch $@; \
 	fi
 endif
@@ -474,7 +474,7 @@ ALL_mlc = \
 $(COMPILE_stagedir)/stamp-lci: $(ALL_mlc) $(SCRIPT_mlc_list)
 	$(MKDIR_P) $(MODULE_DIR) $(dir $@)
 	@for mlcfile in $(ALL_mlc); do \
-	    echo $(LC_COMPILE) --modulepath $(MODULE_DIR) $$mlcfile ; \
+	    echo "$(LC_COMPILE) --modulepath $(MODULE_DIR) $$mlcfile" $(_PRINT_RULE); \
 	    $(LC_COMPILE) --modulepath $(MODULE_DIR) $$mlcfile || exit $$?; \
 	done
 	touch $@
@@ -621,7 +621,7 @@ $(MODULE_DIR)/%.lcm: %.mlc $(LC_COMPILE)
 
 lc-test-check: $(CHECK_lcm) $(LC_TEST)
 	for test_lcm in $(CHECK_lcm); do \
-	    echo "$(LC_TEST) $$test_lcm"; \
+	    echo "$(LC_TEST) $$test_lcm" $(_PRINT_RULE); \
 	    $(LC_TEST) $$test_lcm || exit $$? ; \
 	done
 


### PR DESCRIPTION
In some of the Linux Makefiles, there are rules that use a loop to
construct a bunch of commands to perform (for example, for compiling
MLC files).  These rules print the command that's being run for
debugging purposes, but it makes the make output unnecessarily noisy
when '-s' is specified.

This patch makes those rules obey 'make -s'.
