### PR TITLE
[Build] [CI] Coverity: Don't scan third party source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ addons:
       name: "runrev/livecode"
       description: "Build submitted via Travis CI"
     notification_email: peter@livecode.com
-    # build_command_prepend: "true"
+    build_command_prepend: "make -s thirdparty"
     build_command: "make -s bootstrap all"
     branch_pattern: coverity_scan

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ lc-test-check: lc-test
 ###############################################################################
 # All Targets
 
-.PHONY: all bootstrap clean
+.PHONY: all bootstrap thirdparty clean
 .DEFAULT_GOAL := all
 
 all: revzip server-revzip
@@ -234,6 +234,10 @@ all: revpdfprinter revandroid
 all: lc-run lc-test
 
 bootstrap: lc-bootstrap-compile
+
+thirdparty: libffi libz libjpeg libpcre libpng libgif libopenssl libskia
+thirdparty: libcairopdf libpq libmysql libsqlite libiodbc libxml libxslt
+thirdparty: libzip
 
 check: lc-test-check
 


### PR DESCRIPTION
There's no point in submitting the third party libs that we keep as
source to Coverity Scan, so try to build them in an early build step.

Add an additional "thirdparty" target to the top-level Makefile to
facilitate this.
