### PR TITLE
🍄 [RFC][LCB stdlib] Add logging syntax

### DIFF
--- a/libscript/src/log.mlc
+++ b/libscript/src/log.mlc
@@ -1,0 +1,20 @@
+/*
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.logging
+
+end module


### PR DESCRIPTION
It would be really useful to have a basic logging API in the LCB stdlib.  The basic syntax could be something like:

```
log message "foo"
-- Log at "info" level by default
-- Outputs "(myprogram:pid) Message **: foo"

log warning message "foo"
-- Outputs "(myprogram:pid) WARNING **: foo"
```
### Initial implementation
- Support for log levels "error", "warning", "message", and "debug" (corresponding roughly to syslog(3) levels `LOG_CRIT`, `LOG_WARNING`, `LOG_NOTICE` and `LOG_DEBUG`).
- Log output always goes to stderr with the formatting as above
- "log error" always quits
### Later

Later on we could add additional features, like
- Support for the default output to be to syslog(3) instead of to stderr, if appropriate
- More log levels, like "critical" (like an error, but doesn't quit)
- Ability to turn off debugging log messages
- String formatting
### Practical considerations

This would be initially implemented by in pure LCB by binding to any necessary libfoundation functions and encoding all strings passed to ASCII.  It would also frob stderr by using cstdio functions directly.  I.e. quick dirty hack.
