### PR TITLE
[[ LCB ]] Access to current LCB module ptr

### DIFF
--- a/libscript/include/script.h
+++ b/libscript/include/script.h
@@ -202,6 +202,9 @@ MCScriptModuleRef MCScriptRetainModule(MCScriptModuleRef module);
 // Release a module.
 void MCScriptReleaseModule(MCScriptModuleRef module);
 
+// Gets the module ptr for the most recent LCB stack frame on the current thread's stack.
+MCScriptModuleRef MCScriptGetCurrentModule(void);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // Create an instance of the given module. If the module is single-instance it


### PR DESCRIPTION
In order to implement private resources, the implementation various pieces of LCB syntax need to be able to access the MCScriptModuleRef of the LCB code which used the syntax. This allows the syntax to be able to map filenames appropriately to access the resources private to the module.

The MCScriptGetCurrentModule() API returns this 'current' module ptr, or nil if there is no LCB stack frame to reference.
