### PR TITLE
[[ LCB ]] Allow foreign handlers to bind to LCB handlers.

### DIFF
--- a/libscript/include/script.h
+++ b/libscript/include/script.h
@@ -277,6 +277,7 @@ void MCScriptAddDependencyToModule(MCScriptModuleBuilderRef builder, MCNameRef d
 
 void MCScriptAddExportToModule(MCScriptModuleBuilderRef builder, uindex_t index);
 void MCScriptAddImportToModule(MCScriptModuleBuilderRef builder, uindex_t module_index, MCNameRef definition, MCScriptDefinitionKind kind, uindex_t type, uindex_t& r_index);
+void MCScriptAddImportToModuleWithIndex(MCScriptModuleBuilderRef builder, uindex_t module_index, MCNameRef definition, MCScriptDefinitionKind kind, uindex_t type, uindex_t p_index);
 
 void MCScriptAddDefinedTypeToModule(MCScriptModuleBuilderRef builder, uindex_t index, uindex_t& r_type);
 void MCScriptAddForeignTypeToModule(MCScriptModuleBuilderRef builder, MCStringRef p_binding, uindex_t& r_type);

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -222,7 +222,6 @@ void MCScriptAddImportToModuleWithIndex(MCScriptModuleBuilderRef self, uindex_t 
     t_import -> module = p_module_index;
     t_import -> kind = p_kind;
     t_import -> name = MCValueRetain(p_name);
-    // t_import -> type = MCValueRetain(p_type);
     
     MCScriptExternalDefinition *t_definition;
     t_definition = static_cast<MCScriptExternalDefinition *>(self -> module . definitions[p_def_index]);

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -96,7 +96,6 @@ MC_PICKLE_BEGIN_RECORD(MCScriptImportedDefinition)
     MC_PICKLE_UINDEX(module)
     MC_PICKLE_INTENUM(MCScriptDefinitionKind, kind)
     MC_PICKLE_NAMEREF(name)
-    // MC_PICKLE_TYPEINFOREF(type)
 MC_PICKLE_END_RECORD()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptSyntaxMethod)

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -209,7 +209,6 @@ struct MCScriptImportedDefinition
     uindex_t module;
     MCScriptDefinitionKind kind;
     MCNameRef name;
-    //MCTypeInfoRef type;
     
     // The resolved definition - not pickled
     MCScriptDefinition *definition;

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -171,6 +171,17 @@ static MCStringRef to_mcstringref(long p_string)
     return t_uniq_string;
 }
 
+static NameRef nameref_from_mcstringref(MCStringRef p_string)
+{
+    MCAutoPointer<char> t_utf8_string;
+    MCStringConvertToUTF8String(p_string, &t_utf8_string);
+    
+    NameRef t_name;
+    MakeNameLiteral(*t_utf8_string, &t_name);
+    
+    return t_name;
+}
+
 //////////
 
 static MCScriptModuleBuilderRef s_builder;
@@ -425,43 +436,33 @@ void EmitForeignHandlerDefinition(long p_index, PositionRef p_position, NameRef 
     else
         t_binding_str = to_mcstringref(p_binding);
     
-    if (strncmp((const char *)p_binding, "lcb:", 4) != 0)
+    if (!MCStringBeginsWithCString(*t_binding_str, (const char_t *)"lcb:", kMCStringOptionCompareExact))
         MCScriptAddForeignHandlerToModule(s_builder, to_mcnameref(p_name), p_type_index, *t_binding_str, p_index);
     else
     {
         // The string should be of the form:
         //   lcb:<module>.<handler>
         
-        const char *t_separator;
-        t_separator = strrchr((const char *)p_binding, '.');
+        MCAutoStringRef t_module_dot_handler;
+        MCStringCopySubstring(*t_binding_str, MCRangeMake(4, UINDEX_MAX), &t_module_dot_handler);
         
-        const char *t_handler;
-        const char *t_module;
-        if (t_separator != nil)
-        {
-            t_module = (const char *)p_binding + 4;
-            t_handler = t_separator + 1;
-        }
+        MCAutoStringRef t_module, t_handler;
+        uindex_t t_offset;
+        if (MCStringLastIndexOfChar(*t_module_dot_handler, '.', UINDEX_MAX, kMCStringOptionCompareExact, t_offset))
+            MCStringDivideAtIndex(*t_module_dot_handler, t_offset, &t_module, &t_handler);
         else
-        {
-            t_module = nil;
-            t_handler = (const char *)p_binding + 4;
-        }
-        
+            t_handler = *t_module_dot_handler;
+
         long t_module_dep;
-        if (t_module == nil)
+        if (*t_module == nil)
             EmitModuleDependency(s_module_name, t_module_dep);
         else
-        {
-            NameRef t_mod_name;
-            MakeNameLiteralN(t_module, t_separator - t_module, &t_mod_name);
-            EmitModuleDependency(t_mod_name, t_module_dep);
-        }
+            EmitModuleDependency(nameref_from_mcstringref(*t_module), t_module_dep);
         
-        NameRef t_hand_name;
-        MakeNameLiteral(t_handler, &t_hand_name);
+        MCNewAutoNameRef t_hand_name;
+        MCNameCreate(*t_handler, &t_hand_name);
         
-        MCScriptAddImportToModuleWithIndex(s_builder, t_module_dep - 1, to_mcnameref(t_hand_name), kMCScriptDefinitionKindHandler, p_type_index, p_index);
+        MCScriptAddImportToModuleWithIndex(s_builder, t_module_dep - 1, *t_hand_name, kMCScriptDefinitionKindHandler, p_type_index, p_index);
     }
     
     MCLog("[Emit] ForeignHandlerDefinition(%ld, %@, %ld, %@)", p_index, to_mcnameref(p_name), p_type_index, to_mcstringref(p_binding));

--- a/toolchain/lc-compile/src/literal.c
+++ b/toolchain/lc-compile/src/literal.c
@@ -260,8 +260,7 @@ void MakeStringLiteral(const char *p_token, long *r_literal)
     *r_literal = (long)t_value;
 }
 
-                    
-void MakeNameLiteral(const char *p_token, NameRef *r_literal)
+void MakeNameLiteralN(const char *p_token, int p_token_length, NameRef *r_literal)
 {
     NameRef t_name;
     for(t_name = s_names; t_name != NULL; t_name = t_name -> next)
@@ -274,7 +273,7 @@ void MakeNameLiteral(const char *p_token, NameRef *r_literal)
         if (t_name == NULL)
             Fatal_OutOfMemory();
         
-        t_name -> token = strdup(p_token);
+        t_name -> token = strndup(p_token, p_token_length);
         if (t_name -> token == NULL)
             Fatal_OutOfMemory();
         
@@ -283,6 +282,11 @@ void MakeNameLiteral(const char *p_token, NameRef *r_literal)
     }
     
     *r_literal = t_name;
+}
+
+void MakeNameLiteral(const char *p_token, NameRef *r_literal)
+{
+    MakeNameLiteralN(p_token, strlen(p_token), r_literal);
 }
 
 void GetStringOfNameLiteral(NameRef p_literal, const char **r_string)

--- a/toolchain/lc-compile/src/literal.h
+++ b/toolchain/lc-compile/src/literal.h
@@ -30,6 +30,7 @@ void MakeIntegerLiteral(const char *token, long *r_literal);
 void MakeDoubleLiteral(const char *token, long *r_literal);
 void MakeStringLiteral(const char *token, long *r_literal);
 void MakeNameLiteral(const char *token, NameRef *r_literal);
+void MakeNameLiteralN(const char *p_token, int p_token_length, NameRef *r_literal);
 
 void GetStringOfNameLiteral(NameRef literal, const char** r_string);
 


### PR DESCRIPTION
In order to provide a means of implementing LCB syntax in LCB, the ability to bind to LCB handlers in foreign handler clauses has been implemented.

To use this feature the binding string should be 'lcb:module.handler'. This is compiled as an import of the handler from the module (not weakly - the module will currently fail to load if the import isn't there).

This feature is only temporary until the infrastructure is in place to allow modules defining syntax which use syntax to be compilable.

An example usage is this:

```
foreign handler mysin(in Value as number) as number binds to "lcb:com.livecode.math.sin"
```

This binds mysin() in the current module to com.livecode.math.sin but in a way that means it is resolved at module load time, rather than at compile-time.
