### PR TITLE
[Bug 14011] Updated dictionary entry of 'printMargins' property

### DIFF
--- a/docs/dictionary/property/printMargins.xml
+++ b/docs/dictionary/property/printMargins.xml
@@ -1,49 +1,1 @@
-<doc>
-  <legacy_id>2421</legacy_id>
-  <name>printMargins</name>
-  <type>property</type>
-  <syntax>
-    <example>set the printMargins to <i>left</i>,<i>top</i>,<i>right</i>,<i>bottom</i></example>
-  </syntax>
-  <library></library>
-  <objects>
-    <global/>
-  </objects>
-  <synonyms>
-  </synonyms>
-  <classification>
-    <category>Printing</category>
-  </classification>
-  <references>
-    <command tag="answer printer">answer printer Command</command>
-    <command tag="answer page setup">answer page setup Command</command>
-    <property tag="printCardBorders">printCardBorders Property</property>
-    <property tag="printRowsFirst">printRowsFirst Property</property>
-    <property tag="printGutters">printGutters Property</property>
-  </references>
-  <history>
-    <introduced version="1.0">Added.</introduced>
-  </history>
-  <platforms>
-    <mac/>
-    <windows/>
-    <linux/>
-    <ios/>
-  </platforms>
-  <classes>
-    <desktop/>
-    <server/>
-    <web/>
-    <mobile/>
-  </classes>
-  <security>
-    <printing/>
-  </security>
-  <summary>Specifies the width of the page margins when printing <glossary tag="card">cards</glossary>.</summary>
-  <examples>
-    <example>set the printMargins to 72,144,72,144 </example>
-  </examples>
-  <description>
-    <p>Use the <b>printMargins</b> <glossary tag="property">property</glossary> to control how much blank space is left at each edge of the page when printing.</p><p/><p><b>Value:</b></p><p>The <b>printMargins</b> consists of four <href tag="../glossary/nondashnegative.xml">non-negative</href> <glossary tag="integer">integers</glossary>, separated by commas.</p><p/><p>By default, the <b>printMargins</b> is set to 72,72,72,72 (a one-inch margin on each side).</p><p/><p><b>Comments:</b></p><p>The <i>left</i> is the width in <property tag="points">points</property> of blank space between the left edge of the page and the leftmost edge of the printed <glossary tag="card">cards</glossary>. (There are 72 <property tag="points">points</property> to an inch.)</p><p/><p>The <i>top</i> is the height in <property tag="points">points</property> of blank space between the top edge of the page and the topmost edge of the printed <glossary tag="card">cards</glossary>.</p><p/><p>The <i>right</i> is the width in <property tag="points">points</property> of blank space between the right edge of the page and the rightmost edge of the printed <glossary tag="card">cards</glossary>.</p><p/><p>The <i>bottom</i> is the height in <property tag="points">points</property> of blank space between the bottom edge of the page and the bottommost edge of the printed <glossary tag="card">cards</glossary>.</p>
-  </description>
-</doc>
+<doc>	<legacy_id>2421</legacy_id>	<name>printMargins</name>	<type>property</type>	<syntax>		<example>set the printMargins to <i>left</i>,<i>top</i>,<i>right</i>,<i>bottom</i></example>	</syntax>	<synonyms>	</synonyms>	<summary>Specifies the width of the page margins when printing <glossary tag="card">cards</glossary>.</summary>	<examples><example>set the printMargins to 72,144,72,144 </example>	</examples>	<history>		<introduced version="1.0">Added.</introduced>		<deprecated version=""></deprecated>		<removed version=""></removed>				<experimental version=""></experimental>		<nonexperimental version=""></nonexperimental>	</history>	<objects>		<global/>	</objects>	<platforms>		<mac/>		<windows/>		<linux/>		<ios/>	</platforms>	<classes>		<desktop/>		<server/>		<web/>		<mobile/>	</classes>	<security>		<printing/>	</security>	<classification>		<category>Printing</category>	</classification>	<references>		<command tag="answer printer">answer printer Command</command>		<command tag="answer page setup">answer page setup Command</command>		<property tag="printCardBorders">printCardBorders Property</property>		<property tag="printRowsFirst">printRowsFirst Property</property>		<property tag="printGutters">printGutters Property</property>	</references>	<description>Use the <b>printMargins</b> <glossary tag="property">property</glossary> to control how much blank space is left at each edge of the page when printing.<p></p><p><b>Value:</b></p><p>The <b>printMargins</b> consists of four non-negative <glossary tag="integer">integers</glossary>, separated by commas.</p><p></p><p>By default, the <b>printMargins</b> is set to 72,72,72,72 (a one-inch margin on each side).</p><p></p><p><b>Comments:</b></p><p>The <i>left</i> is the width in <property tag="points">points</property> of blank space between the left edge of the page and the leftmost edge of the printed <glossary tag="card">cards</glossary>. (There are 72 <property tag="points">points</property> to an inch.)</p><p></p><p>The <i>top</i> is the height in <property tag="points">points</property> of blank space between the top edge of the page and the topmost edge of the printed <glossary tag="card">cards</glossary>.</p><p></p><p>The <i>right</i> is the width in <property tag="points">points</property> of blank space between the right edge of the page and the rightmost edge of the printed <glossary tag="card">cards</glossary>.</p><p></p><p>The <i>bottom</i> is the height in <property tag="points">points</property> of blank space between the bottom edge of the page and the bottommost edge of the printed <glossary tag="card">cards</glossary>.</p><p></p><p>Set this property before calling the "open printing" or "open printing to pdf" command, to apply the new value to the current print run.</p></description></doc>

--- a/docs/notes/bugfix-14011.md
+++ b/docs/notes/bugfix-14011.md
@@ -1,0 +1,1 @@
+#     Printing is inconsistent


### PR DESCRIPTION
To illustrate that this property should be set before calling the "open printing" or "open printing to pdf" command, so as to apply the new value to the current print run
