### PR TITLE
lc-run: Fix bug and add basic functionality tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ xcuserdata/
 _build/
 _cache/
 build/
+/_tests/
 
 # SDKs          #
 #################

--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,11 @@ lc-test: libstdscript libfoundation
 	$(MAKE) -C ./toolchain lc-test
 
 ########## Tests
-lc-test-check: lc-test
+lc-run-check: lc-compile lc-run
+	$(MAKE) -C ./tests/lc-run check
+lc-test-check: lc-compile lc-test
 	$(MAKE) -C ./toolchain lc-test-check
-.PHONY: mlc-check
+.PHONY: lc-run-check lc-test-check
 
 ###############################################################################
 # All Targets
@@ -239,7 +241,7 @@ thirdparty: libffi libz libjpeg libpcre libpng libgif libopenssl libskia
 thirdparty: libcairopdf libpq libmysql libsqlite libiodbc libxml libxslt
 thirdparty: libzip
 
-check: lc-test-check
+check: lc-run-check lc-test-check
 
 clean:
 	-rm -rf _build/linux _cache/linux

--- a/tests/lc-run/Makefile
+++ b/tests/lc-run/Makefile
@@ -1,0 +1,25 @@
+top_srcdir=../..
+
+include $(top_srcdir)/rules/environment.linux.makefile
+
+SOLUTION_DIR = $(top_srcdir)
+
+LC_COMPILE ?= $(shell PATH=$(BUILD_DIR):$(PATH) \
+	              which lc-compile 2>/dev/null || \
+	              echo "lc-compile")
+LC_RUN ?= $(shell PATH=$(BUILD_DIR):$(PATH) \
+	              which lc-run 2>/dev/null || \
+	              echo "lc-run")
+
+TEST_DIR = $(SOLUTION_DIR)/_tests/lc-run
+
+# Basic functionality tests for lc-run
+#
+# 1) Does lc-run run a trivial program?
+# 2) Does lc-run list the handlers of a trivial program?
+check:
+	mkdir -p $(TEST_DIR)
+	$(LC_COMPILE) --modulepath $(TEST_DIR) --modulepath $(MODULE_DIR) \
+	    lc-run-test.mlc --output $(TEST_DIR)/lc-run-test.lcm
+	$(LC_RUN) $(TEST_DIR)/lc-run-test.lcm
+	test "`$(LC_RUN) --list-handlers $(TEST_DIR)/lc-run-test.lcm`" = "main"

--- a/tests/lc-run/lc-run-test.mlc
+++ b/tests/lc-run/lc-run-test.mlc
@@ -1,0 +1,7 @@
+module com.livecode.lc_run_test
+
+public handler main()
+	-- nothing
+end handler
+
+end module

--- a/toolchain/lc-compile/lc-compile.xcodeproj/project.pbxproj
+++ b/toolchain/lc-compile/lc-compile.xcodeproj/project.pbxproj
@@ -54,6 +54,12 @@
 		4DEB640B19E6822E009DF2EA /* syntax-gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DEB640919E6822E009DF2EA /* syntax-gen.c */; };
 		4DEB642819E81D95009DF2EA /* operator.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DEB642719E81D95009DF2EA /* operator.c */; };
 		4DEB642919E81D95009DF2EA /* operator.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DEB642719E81D95009DF2EA /* operator.c */; };
+		C72BED811A838B5A009B3CEB /* lc-run.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C72BED801A838B5A009B3CEB /* lc-run.cpp */; };
+		C72BED821A838B65009B3CEB /* module-helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D79B9101A3767E000DD750C /* module-helper.cpp */; };
+		C72BED831A838BA4009B3CEB /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D79B64B1A27381400DD750C /* CoreFoundation.framework */; };
+		C72BED841A838BBA009B3CEB /* libscript.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D0391201A27369800CB9E06 /* libscript.a */; };
+		C72BED851A838BC9009B3CEB /* libfoundation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D03910D1A27366200CB9E06 /* libfoundation.a */; };
+		C72BED861A838BCF009B3CEB /* libstdscript.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D79B6E81A27407900DD750C /* libstdscript.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -197,6 +203,20 @@
 			remoteGlobalIDString = 4D21B65619E43BE100B64BEF;
 			remoteInfo = "lc-bootstrap-compile";
 		};
+		C72BED871A838BD7009B3CEB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4D6F070119CC36B700DDC6E0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4D6F070A19CC36DD00DDC6E0;
+			remoteInfo = "lc-compile";
+		};
+		C72BED891A838C07009B3CEB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4D0391191A27369800CB9E06 /* libscript.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 4D79B6531A273B6900DD750C;
+			remoteInfo = stdscript;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -219,6 +239,15 @@
 			runOnlyForDeploymentPostprocessing = 1;
 		};
 		4D6F070919CC36DD00DDC6E0 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		C72BED761A838B0D009B3CEB /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = /usr/share/man/man1/;
@@ -304,6 +333,8 @@
 		4DEB640919E6822E009DF2EA /* syntax-gen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "syntax-gen.c"; path = "src/syntax-gen.c"; sourceTree = SOURCE_ROOT; };
 		4DEB640E19E69E50009DF2EA /* COMMENTS.b */ = {isa = PBXFileReference; lastKnownFileType = text; name = COMMENTS.b; path = src/COMMENTS.b; sourceTree = SOURCE_ROOT; };
 		4DEB642719E81D95009DF2EA /* operator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = operator.c; path = src/operator.c; sourceTree = SOURCE_ROOT; };
+		C72BED781A838B0D009B3CEB /* lc-run */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "lc-run"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C72BED801A838B5A009B3CEB /* lc-run.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "lc-run.cpp"; path = "src/lc-run.cpp"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -337,6 +368,17 @@
 				4D0391281A2736D300CB9E06 /* libscript.a in Frameworks */,
 				4D0391131A27367E00CB9E06 /* libfoundation.a in Frameworks */,
 				4D0391141A27367E00CB9E06 /* libgrts.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C72BED751A838B0D009B3CEB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C72BED831A838BA4009B3CEB /* CoreFoundation.framework in Frameworks */,
+				C72BED841A838BBA009B3CEB /* libscript.a in Frameworks */,
+				C72BED851A838BC9009B3CEB /* libfoundation.a in Frameworks */,
+				C72BED861A838BCF009B3CEB /* libstdscript.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -411,6 +453,7 @@
 				4D6F070B19CC36DD00DDC6E0 /* lc-compile */,
 				4D21B66B19E43BE100B64BEF /* lc-bootstrap-compile */,
 				4D44E4E01A24D6610073FFA2 /* lc-test */,
+				C72BED781A838B0D009B3CEB /* lc-run */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -454,6 +497,7 @@
 				4DEB642719E81D95009DF2EA /* operator.c */,
 				4D44E3AA1A1632160073FFA2 /* emit.cpp */,
 				4D44E4E91A24D6910073FFA2 /* test.cpp */,
+				C72BED801A838B5A009B3CEB /* lc-run.cpp */,
 			);
 			name = Sources;
 			path = "lc-compile";
@@ -589,6 +633,25 @@
 			productReference = 4D6F070B19CC36DD00DDC6E0 /* lc-compile */;
 			productType = "com.apple.product-type.tool";
 		};
+		C72BED771A838B0D009B3CEB /* lc-run */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C72BED7F1A838B0D009B3CEB /* Build configuration list for PBXNativeTarget "lc-run" */;
+			buildPhases = (
+				C72BED741A838B0D009B3CEB /* Sources */,
+				C72BED751A838B0D009B3CEB /* Frameworks */,
+				C72BED761A838B0D009B3CEB /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C72BED8A1A838C07009B3CEB /* PBXTargetDependency */,
+				C72BED881A838BD7009B3CEB /* PBXTargetDependency */,
+			);
+			name = "lc-run";
+			productName = "lc-run";
+			productReference = C72BED781A838B0D009B3CEB /* lc-run */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -596,6 +659,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0510;
+				TargetAttributes = {
+					C72BED771A838B0D009B3CEB = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
 			};
 			buildConfigurationList = 4D6F070419CC36B700DDC6E0 /* Build configuration list for PBXProject "lc-compile" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -626,6 +694,7 @@
 				4D6F070A19CC36DD00DDC6E0 /* lc-compile */,
 				4D21B65619E43BE100B64BEF /* lc-bootstrap-compile */,
 				4D44E4DF1A24D6610073FFA2 /* lc-test */,
+				C72BED771A838B0D009B3CEB /* lc-run */,
 			);
 		};
 /* End PBXProject section */
@@ -922,6 +991,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C72BED741A838B0D009B3CEB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C72BED811A838B5A009B3CEB /* lc-run.cpp in Sources */,
+				C72BED821A838B65009B3CEB /* module-helper.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -989,6 +1067,16 @@
 			isa = PBXTargetDependency;
 			target = 4D21B65619E43BE100B64BEF /* lc-bootstrap-compile */;
 			targetProxy = 4DA53A1C19E43CC60089FBDC /* PBXContainerItemProxy */;
+		};
+		C72BED881A838BD7009B3CEB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4D6F070A19CC36DD00DDC6E0 /* lc-compile */;
+			targetProxy = C72BED871A838BD7009B3CEB /* PBXContainerItemProxy */;
+		};
+		C72BED8A1A838C07009B3CEB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = stdscript;
+			targetProxy = C72BED891A838C07009B3CEB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1243,6 +1331,82 @@
 			};
 			name = Release;
 		};
+		C72BED7C1A838B0D009B3CEB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		C72BED7D1A838B0D009B3CEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1281,6 +1445,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		C72BED7F1A838B0D009B3CEB /* Build configuration list for PBXNativeTarget "lc-run" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C72BED7C1A838B0D009B3CEB /* Debug */,
+				C72BED7D1A838B0D009B3CEB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/toolchain/lc-compile/src/lc-run.cpp
+++ b/toolchain/lc-compile/src/lc-run.cpp
@@ -326,7 +326,7 @@ MCRunLoadModule (MCStringRef p_filename,
 	if (!MCScriptEnsureModuleIsUsable (*t_module))
 		return false;
 
-	r_module = MCValueRetain(*t_module);
+	r_module = MCScriptRetainModule (*t_module);
 	return true;
 }
 


### PR DESCRIPTION
Commit 46ccf1ae6ff introduced a bug where an `MCScriptModuleRef` was referenced using `MCValueRetain()` instead of `MCScriptRetainModule()`.  This wasn't picked up because the lc-run tool isn't used very much yet.  Fix the bug and also add basic functionality tests for lc-run to `make check`.
