### PR TITLE
[[ LCB Compiler ]] Enable ability to specify unreserved keywords.

### DIFF
--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -948,6 +948,9 @@
         
     'rule' AtomicSyntax(-> keyword(Position, Value)):
         STRING_LITERAL(-> Value) @(-> Position)
+
+    'rule' AtomicSyntax(-> unreservedkeyword(Position, Value)):
+        STRING_LITERAL(-> Value) @(-> Position) "!"
         
     'rule' AtomicSyntax(-> rule(Position, Name)):
         "<" @(-> Position) Identifier(-> Name) ">"
@@ -1052,6 +1055,13 @@
         Id::ID
         Id'Position <- Position
         Id'Name <- Identifier
+        
+    'rule' Identifier(-> Id):
+        CustomKeywords(-> String) @(-> Position)
+        MakeNameLiteral(String -> Identifier)
+        Id::ID
+        Id'Position <- Position
+        Id'Name <- Identifier
 
 'nonterm' StringyIdentifier(-> ID)
 
@@ -1142,6 +1152,11 @@
 'nonterm' CustomIterators(-> EXPRESSION)
     'rule' CustomIterators(-> nil):
         "THISCANNEVERHAPPEN"
+'nonterm' CustomKeywords(-> STRING)
+    'rule' CustomKeywords(-> String):
+        "THISCANNEVERHAPPEN"
+        where("THISCANNEVERHAPPEN" -> String)
+
 
 
 

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -90,6 +90,7 @@
     RepeatSyntaxGrammar
     PushEmptySyntaxGrammar
     PushKeywordSyntaxGrammar
+    PushUnreservedKeywordSyntaxGrammar
     PushMarkedDescentSyntaxGrammar
     PushDescentSyntaxGrammar
     PushMarkedTrueSyntaxGrammar
@@ -381,6 +382,7 @@
 'action' RepeatSyntaxGrammar()
 'action' PushEmptySyntaxGrammar()
 'action' PushKeywordSyntaxGrammar(Token: STRING)
+'action' PushUnreservedKeywordSyntaxGrammar(Token: STRING)
 'action' PushMarkedDescentSyntaxGrammar(Index: INT, Rule: NAME, LMode: INT, RMode: INT)
 'action' PushDescentSyntaxGrammar(Rule: NAME)
 'action' PushMarkedTrueSyntaxGrammar(Index: INT)

--- a/toolchain/lc-compile/src/syntax.g
+++ b/toolchain/lc-compile/src/syntax.g
@@ -107,6 +107,9 @@
     'rule' GenerateSyntax(SYNTAX'keyword(_, Value)):
         PushKeywordSyntaxGrammar(Value)
 
+    'rule' GenerateSyntax(SYNTAX'unreservedkeyword(_, Value)):
+        PushUnreservedKeywordSyntaxGrammar(Value)
+
     'rule' GenerateSyntax(SYNTAX'markedrule(_, Variable, Id)):
         Id'Name -> Name
         Variable'Meaning -> syntaxmark(Info)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -192,6 +192,7 @@
     list(Position: POS, Element: SYNTAX, Delimiter: SYNTAX)
     optional(Position: POS, Operand: SYNTAX)
     keyword(Position: POS, Value: STRING)
+    unreservedkeyword(Position: POS, Value: STRING)
     markedrule(Position: POS, Variable: ID, Name: ID)
     rule(Position: POS, Name: ID)
     mark(Position: POS, Variable: ID, Value: SYNTAXCONSTANT)


### PR DESCRIPTION
By default any keywords specified in syntax clauses will be reserved by the compiler. This means that they cannot be used as identifiers.

So that we can choose to unreserve keywords which we know will not cause a problem you can now specify a keyword in the form "..."! - the postfix ! means that the keyword will be unreserved.

Note: At the moment only one instance of a keyword needs to be marked as unreserved for it to be so.
