### PR TITLE
[[ Bug 14484 ]] Arrays not correctly marshalled between LCB and LCS.

### DIFF
--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -421,6 +421,63 @@ bool MCExtensionConvertToScriptType(MCExecContext& ctxt, MCValueRef& x_value)
         case kMCValueTypeCodeName:
         case kMCValueTypeCodeData:
             return true;
+        
+        case kMCValueTypeCodeArray:
+        {
+            // We start off with no new value - we only create a new array if one
+            // of the elements changes.
+            MCArrayRef t_mutated_value;
+            t_mutated_value = nil;
+            
+            MCNameRef t_key;
+            MCValueRef t_element;
+            uintptr_t t_iterator;
+            t_iterator = 0;
+            while(MCArrayIterate((MCArrayRef)x_value, t_iterator, t_key, t_element))
+            {
+                // 'Copy' the value (as we don't own it).
+                MCValueRef t_new_element;
+                t_new_element = MCValueRetain(t_element);
+                
+                // Attempt to convert it to a script type.
+                if (!MCExtensionConvertToScriptType(ctxt, t_new_element))
+                    goto array_error;
+                
+                // If the value has changed then we must ensure we have a new value.
+                if (t_new_element != t_element)
+                {
+                    if (!MCArrayMutableCopy((MCArrayRef)x_value, t_mutated_value))
+                        goto array_error;
+                
+                    if (!MCArrayStoreValue(t_mutated_value, true, t_key, t_new_element))
+                        goto array_error;
+                    
+                    MCValueRelease(t_new_element);
+                    
+                    continue;
+                }
+    
+                // If we get here then we haven't had to mutate the input array yet
+                // and this element has not changed through conversion so there is
+                // nothing to do!
+                
+                continue;
+
+            array_error:
+                MCValueRelease(t_new_element);
+                MCValueRelease(t_mutated_value);
+                return false;
+            }
+            
+            // If we get here then all is well - if we have a mutated value then
+            // we assign that to x_value, otherwise we leave well enough alone.
+            if (t_mutated_value != nil)
+            {
+                MCValueRelease(x_value);
+                x_value = t_mutated_value;
+            }
+        }
+        return true;
             
         // ProperLists map to sequences (arrays with numeric keys)
         case kMCValueTypeCodeProperList:
@@ -557,6 +614,85 @@ bool MCExtensionConvertFromScriptType(MCExecContext& ctxt, MCTypeInfoRef p_as_ty
         return true;
     
     return MCExtensionThrowTypeConversionError(p_as_type, x_value);
+}
+
+// Ensure that if the input value is a name it comes out as a string.
+// Ensure that if the input value is an array, all elements that are names (recursed)
+// come out as strings.
+// If r_output is not p_input on successful return then r_output must be released.
+static bool __script_ensure_names_are_strings(MCValueRef p_input, MCValueRef& r_output)
+{
+    if (MCValueGetTypeCode(p_input) == kMCValueTypeCodeName)
+    {
+        r_output = MCValueRetain(MCNameGetString((MCNameRef)p_input));
+        return true;
+    }
+    
+    if (MCValueGetTypeCode(p_input) == kMCValueTypeCodeArray)
+    {
+        MCArrayRef t_mutated_input;
+        t_mutated_input = nil;
+        
+        MCNameRef t_key;
+        MCValueRef t_element;
+        uintptr_t t_iterator;
+        t_iterator = 0;
+        while(MCArrayIterate((MCArrayRef)p_input, t_iterator, t_key, t_element))
+        {
+            // Ensure the element's names are all strings.
+            MCValueRef t_mutated_element;
+            if (!__script_ensure_names_are_strings(t_element, t_mutated_element))
+            {
+                MCValueRelease(t_mutated_input);
+                return false;
+            }
+            
+            // If something changed then we must replace the existing value.
+            if (t_element != t_mutated_element)
+            {
+                // First make sure we have a copy of the original to mutate.
+                if (t_mutated_input == nil)
+                {
+                    if (!MCArrayMutableCopy((MCArrayRef)p_input, t_mutated_input))
+                    {
+                        MCValueRelease(t_mutated_element);
+                        return false;
+                    }
+                }
+                
+                // Now store the value.
+                if (!MCArrayStoreValue((MCArrayRef)t_mutated_input, true, t_key, t_mutated_element))
+                {
+                    MCValueRelease(t_mutated_element);
+                    MCValueRelease(t_mutated_input);
+                    return false;
+                }
+                
+                // Storing the value retains the element, so we must free our
+                // copy here.
+                MCValueRelease(t_mutated_element);
+                
+                // We are done for this element.
+                continue;
+            }
+            
+            // If we get here then nothing has changed, so there's nothing to do.
+        }
+        
+        // Either return the original or the mutated version depending on whether
+        // any of its elements mutated.
+        if (t_mutated_input == nil)
+            r_output = p_input;
+        else
+            r_output = t_mutated_input;
+        
+        return true;
+    }
+    
+    // If no changes are made, don't change the ptr.
+    r_output = p_input;
+    
+    return true;
 }
 
 // Convert a script value to a boolean following standard lax-scripting rules.
@@ -757,6 +893,16 @@ static bool __script_try_to_convert_to_array(MCExecContext& ctxt, MCValueRef& x_
     // If it is already an array, we are done.
     if (MCValueGetTypeCode(x_value) == kMCValueTypeCodeArray)
     {
+        MCValueRef t_mutated_value;
+        if (!__script_ensure_names_are_strings(x_value, t_mutated_value))
+            return false;
+        
+        if (t_mutated_value != x_value)
+        {
+            MCValueRelease(x_value);
+            x_value = t_mutated_value;
+        }
+        
         r_converted = true;
         return true;
     }
@@ -808,12 +954,27 @@ static bool __script_try_to_convert_to_list(MCExecContext& ctxt, MCValueRef& x_v
             // We know this will succeed as we have a sequence.
             MCValueRef t_element;
             MCArrayFetchValueAtIndex((MCArrayRef)x_value, i + 1, t_element);
-            if (!MCProperListPushElementOntoBack(t_proper_list, t_element))
+            
+            // Deal with the name/string issue.
+            MCValueRef t_revised_element;
+            if (!__script_ensure_names_are_strings(t_element, t_revised_element))
             {
                 MCValueRelease(t_proper_list);
                 return false;
             }
+                
+            if (!MCProperListPushElementOntoBack(t_proper_list, t_revised_element))
+            {
+                if (t_element != t_revised_element)
+                    MCValueRelease(t_revised_element);
+                MCValueRelease(t_proper_list);
+                return false;
+            }
+            
+            if (t_element != t_revised_element)
+                MCValueRelease(t_revised_element);
         }
+        
         if (!MCProperListCopyAndRelease(t_proper_list, t_proper_list))
         {
             MCValueRelease(t_proper_list);

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -440,7 +440,7 @@ bool MCExtensionConvertToScriptType(MCExecContext& ctxt, MCValueRef& x_value)
                 t_new_element = t_element;
                 
                 // Attempt to convert it to a script type.
-                if (!MCExtensionConvertToScriptType(ctxt, t_new_element . InOut()))
+                if (!MCExtensionConvertToScriptType(ctxt, InOut(t_new_element)))
                     return false;
                 
                 // If the value has changed then we must do a store.
@@ -450,12 +450,12 @@ bool MCExtensionConvertToScriptType(MCExecContext& ctxt, MCValueRef& x_value)
                     // array.
                     if (*t_mutated_value == nil)
                     {
-                        if (!MCArrayMutableCopy((MCArrayRef)x_value, t_mutated_value . Out()))
+                        if (!MCArrayMutableCopy((MCArrayRef)x_value, Out(t_mutated_value)))
                             return false;
                     }
                     
                     // Store the element in the array.
-                    if (!MCArrayStoreValue(t_mutated_value . In(), true, t_key, t_new_element . In()))
+                    if (!MCArrayStoreValue(In(t_mutated_value), true, t_key, In(t_new_element)))
                         return false;
                     
                     continue;
@@ -638,7 +638,7 @@ static bool __script_ensure_names_are_strings(MCValueRef p_input, MCValueRef& r_
         {
             // Ensure the element's names are all strings.
             MCAutoValueRef t_mutated_element;
-            if (!__script_ensure_names_are_strings(t_element, t_mutated_element . Out()))
+            if (!__script_ensure_names_are_strings(t_element, Out(t_mutated_element)))
                 return false;
             
             // If something changed then we must replace the existing value.
@@ -647,12 +647,12 @@ static bool __script_ensure_names_are_strings(MCValueRef p_input, MCValueRef& r_
                 // First make sure we have a copy of the original to mutate.
                 if (*t_mutated_input == nil)
                 {
-                    if (!MCArrayMutableCopy((MCArrayRef)p_input, t_mutated_input . Out()))
+                    if (!MCArrayMutableCopy((MCArrayRef)p_input, Out(t_mutated_input)))
                         return false;
                 }
                 
                 // Now store the value.
-                if (!MCArrayStoreValue(t_mutated_input . In(), true, t_key, t_mutated_element . In()))
+                if (!MCArrayStoreValue(In(t_mutated_input), true, t_key, In(t_mutated_element)))
                     return false;
                 
                 // We are done for this element.
@@ -927,7 +927,7 @@ static bool __script_try_to_convert_to_list(MCExecContext& ctxt, MCValueRef& x_v
     if (t_is_array && MCArrayIsSequence((MCArrayRef)x_value))
     {
         MCAutoProperListRef t_proper_list;
-        if (!MCProperListCreateMutable(t_proper_list . Out()))
+        if (!MCProperListCreateMutable(Out(t_proper_list)))
             return false;
         
         for(uindex_t i = 0; i < MCArrayGetCount((MCArrayRef)x_value); i++)
@@ -941,7 +941,7 @@ static bool __script_try_to_convert_to_list(MCExecContext& ctxt, MCValueRef& x_v
             if (!__script_ensure_names_are_strings(t_element, &t_revised_element))
                 return false;
                 
-            if (!MCProperListPushElementOntoBack(t_proper_list . In(), *t_revised_element == nil ? t_element : *t_revised_element))
+            if (!MCProperListPushElementOntoBack(In(t_proper_list), *t_revised_element == nil ? t_element : In(t_revised_element)))
                 return false;
         }
         

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -5557,7 +5557,7 @@ bool MCCanvasCreateNamedErrorType(MCNameRef p_name, MCStringRef p_message, MCTyp
 
 bool MCCanvasThrowError(MCTypeInfoRef p_error_type)
 {
-	MCAutoValueRefBase<MCErrorRef> t_error;
+	MCAutoErrorRef t_error;
 	if (!MCErrorCreate(p_error_type, nil, &t_error))
 		return false;
 	

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -97,9 +97,15 @@ private:
     
     MCAutoValueRefBase<T>& operator = (MCAutoValueRefBase<T>& x);
 };
+
 template<typename T, bool (*MutableCopyAndRelease)(T, T&), bool (*ImmutableCopyAndRelease)(T, T&)> class MCAutoMutableValueRefBase: public MCAutoValueRefBase<T>
 {
 public:
+	T operator = (T value)
+	{
+        return MCAutoValueRefBase<T>::operator =(value);
+	}
+    
     bool MakeMutable(void)
     {
         return MutableCopyAndRelease((T)m_value, (T&)m_value);

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -26,7 +26,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 template<typename T> class MCAutoValueRefBase
 {
 public:
-
 	MCAutoValueRefBase(void)
 	{
 		m_value = nil;
@@ -92,9 +91,10 @@ public:
         return t_value;
     }
     
-private:
+protected:
 	T m_value;
-    
+
+private:
     MCAutoValueRefBase<T>& operator = (MCAutoValueRefBase<T>& x);
 };
 
@@ -108,17 +108,15 @@ public:
     
     bool MakeMutable(void)
     {
-        return MutableCopyAndRelease((T)m_value, (T&)m_value);
+        return MutableCopyAndRelease(MCAutoValueRefBase<T>::m_value, MCAutoValueRefBase<T>::m_value);
     }
     
     bool MakeImmutable(void)
     {
-        return ImmutableCopyAndRelease((T)m_value, (T&)m_value);
+        return ImmutableCopyAndRelease(MCAutoValueRefBase<T>::m_value, MCAutoValueRefBase<T>::m_value);
     }
     
 private:
-	T m_value;
-    
     MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& operator = (MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& x);
 };
 

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -23,6 +23,23 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+template<typename T> class MCAutoValueRefBase;
+
+template<typename T> inline T In(const MCAutoValueRefBase<T>& p_auto)
+{
+    return p_auto . In();
+}
+
+template<typename T> inline T& Out(MCAutoValueRefBase<T>& p_auto)
+{
+    return p_auto . Out();
+}
+
+template<typename T> inline T& InOut(MCAutoValueRefBase<T>& p_auto)
+{
+    return p_auto . InOut();
+}
+
 template<typename T> class MCAutoValueRefBase
 {
 public:
@@ -77,9 +94,9 @@ public:
         return t_value;
     }
     
-    friend T In(const MCAutoValueRefBase<T>&);
-    friend T& Out(MCAutoValueRefBase<T>&);
-    friend T& InOut(MCAutoValueRefBase<T>&);
+    friend T In<>(const MCAutoValueRefBase<T>&);
+    friend T& Out<>(MCAutoValueRefBase<T>&);
+    friend T& InOut<>(MCAutoValueRefBase<T>&);
     
 protected:
 	T m_value;
@@ -129,21 +146,6 @@ private:
     MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& operator = (MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& x);
 };
 
-template<typename T> inline T In(const MCAutoValueRefBase<T>& p_auto)
-{
-    return p_auto . In();
-}
-
-template<typename T> inline T& Out(MCAutoValueRefBase<T>& p_auto)
-{
-    return p_auto . Out();
-}
-
-template<typename T> inline T& InOut(MCAutoValueRefBase<T>& p_auto)
-{
-    return p_auto . InOut();
-}
-
 typedef MCAutoValueRefBase<MCValueRef> MCAutoValueRef;
 typedef MCAutoValueRefBase<MCNumberRef> MCAutoNumberRef;
 typedef MCAutoMutableValueRefBase<MCStringRef, MCStringMutableCopyAndRelease, MCStringCopyAndRelease> MCAutoStringRef;
@@ -157,7 +159,6 @@ typedef MCAutoValueRefBase<MCTypeInfoRef> MCAutoTypeInfoRef;
 typedef MCAutoMutableValueRefBase<MCRecordRef, MCRecordMutableCopyAndRelease, MCRecordCopyAndRelease> MCAutoRecordRef;
 typedef MCAutoValueRefBase<MCErrorRef> MCAutoErrorRef;
 typedef MCAutoMutableValueRefBase<MCProperListRef, MCProperListMutableCopyAndRelease, MCProperListCopyAndRelease> MCAutoProperListRef;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -23,7 +23,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, bool (*MutableCopyAndRelease)(T, T&), bool (*ImmutableCopyAndRelease)(T, T&)> class MCAutoValueRefBase
+template<typename T> class MCAutoValueRefBase
 {
 public:
 
@@ -92,6 +92,14 @@ public:
         return t_value;
     }
     
+private:
+	T m_value;
+    
+    MCAutoValueRefBase<T>& operator = (MCAutoValueRefBase<T>& x);
+};
+template<typename T, bool (*MutableCopyAndRelease)(T, T&), bool (*ImmutableCopyAndRelease)(T, T&)> class MCAutoMutableValueRefBase: public MCAutoValueRefBase<T>
+{
+public:
     bool MakeMutable(void)
     {
         return MutableCopyAndRelease((T)m_value, (T&)m_value);
@@ -105,95 +113,22 @@ public:
 private:
 	T m_value;
     
-    MCAutoValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& operator = (MCAutoValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& x);
-};
-template<typename T> class MCAutoImmutableValueRefBase
-{
-public:
-	MCAutoImmutableValueRefBase(void)
-	{
-		m_value = nil;
-	}
-    
-	~MCAutoImmutableValueRefBase(void)
-	{
-		MCValueRelease(m_value);
-	}
-    
-	T operator = (T value)
-	{
-		MCAssert(m_value == nil);
-		m_value = (T)MCValueRetain(value);
-		return value;
-	}
-    
-	T& operator & (void)
-	{
-		MCAssert(m_value == nil);
-		return m_value;
-	}
-    
-	T operator * (void) const
-	{
-		return m_value;
-	}
-    
-    // Return the contents of the auto pointer in a form for an in parameter.
-    T In(void) const
-    {
-        return m_value;
-    }
-    
-    // Return the contents of the auto pointer in a form for an out parameter.
-    T& Out(void)
-    {
-		MCAssert(m_value == nil);
-		return m_value;
-    }
-    
-    // Return the contents of the auto pointer in a form for an inout parameter.
-    T& InOut(void)
-    {
-        return m_value;
-    }
-    
-    // The give method places the given value into the container without
-    // retaining it - the auto container is considered to now own the value.
-    void Give(T value)
-    {
-        MCAssert(m_value == nil);
-        m_value = value;
-    }
-    
-    // The take method removes the value from the container passing ownership
-    // to the caller.
-    T Take(void)
-    {
-        T t_value;
-        t_value = m_value;
-        m_value = nil;
-        return t_value;
-    }
-    
-private:
-	T m_value;
-    
-    MCAutoImmutableValueRefBase<T>& operator = (MCAutoImmutableValueRefBase<T>& x);
+    MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& operator = (MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& x);
 };
 
-typedef MCAutoValueRefBase<MCValueRef, MCValueMutableCopyAndRelease, MCValueCopyAndRelease> MCAutoValueRef;
-typedef MCAutoImmutableValueRefBase<MCNumberRef> MCAutoNumberRef;
-typedef MCAutoValueRefBase<MCStringRef, MCStringMutableCopyAndRelease, MCStringCopyAndRelease> MCAutoStringRef;
-typedef MCAutoValueRefBase<MCArrayRef, MCArrayMutableCopyAndRelease, MCArrayCopyAndRelease> MCAutoArrayRef;
-typedef MCAutoImmutableValueRefBase<MCListRef> MCAutoListRef;
-typedef MCAutoImmutableValueRefBase<MCBooleanRef> MCAutoBooleanRef;
-typedef MCAutoValueRefBase<MCSetRef, MCSetMutableCopyAndRelease, MCSetCopyAndRelease> MCAutoSetRef;
-typedef MCAutoImmutableValueRefBase<MCNameRef> MCNewAutoNameRef;
-typedef MCAutoValueRefBase<MCDataRef, MCDataMutableCopyAndRelease, MCDataCopyAndRelease> MCAutoDataRef;
-typedef MCAutoImmutableValueRefBase<MCTypeInfoRef> MCAutoTypeInfoRef;
-typedef MCAutoValueRefBase<MCRecordRef, MCRecordMutableCopyAndRelease, MCRecordCopyAndRelease> MCAutoRecordRef;
-typedef MCAutoImmutableValueRefBase<MCErrorRef> MCAutoErrorRef;
-typedef MCAutoValueRefBase<MCProperListRef, MCProperListMutableCopyAndRelease, MCProperListCopyAndRelease> MCAutoProperListRef;
+typedef MCAutoValueRefBase<MCValueRef> MCAutoValueRef;
+typedef MCAutoValueRefBase<MCNumberRef> MCAutoNumberRef;
+typedef MCAutoMutableValueRefBase<MCStringRef, MCStringMutableCopyAndRelease, MCStringCopyAndRelease> MCAutoStringRef;
+typedef MCAutoMutableValueRefBase<MCArrayRef, MCArrayMutableCopyAndRelease, MCArrayCopyAndRelease> MCAutoArrayRef;
+typedef MCAutoValueRefBase<MCListRef> MCAutoListRef;
+typedef MCAutoValueRefBase<MCBooleanRef> MCAutoBooleanRef;
+typedef MCAutoMutableValueRefBase<MCSetRef, MCSetMutableCopyAndRelease, MCSetCopyAndRelease> MCAutoSetRef;
+typedef MCAutoValueRefBase<MCNameRef> MCNewAutoNameRef;
+typedef MCAutoMutableValueRefBase<MCDataRef, MCDataMutableCopyAndRelease, MCDataCopyAndRelease> MCAutoDataRef;
+typedef MCAutoValueRefBase<MCTypeInfoRef> MCAutoTypeInfoRef;
+typedef MCAutoMutableValueRefBase<MCRecordRef, MCRecordMutableCopyAndRelease, MCRecordCopyAndRelease> MCAutoRecordRef;
+typedef MCAutoValueRefBase<MCErrorRef> MCAutoErrorRef;
+typedef MCAutoMutableValueRefBase<MCProperListRef, MCProperListMutableCopyAndRelease, MCProperListCopyAndRelease> MCAutoProperListRef;
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -26,56 +26,42 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 template<typename T> class MCAutoValueRefBase
 {
 public:
-	MCAutoValueRefBase(void)
+	inline MCAutoValueRefBase(void)
 	{
 		m_value = nil;
 	}
 
-	~MCAutoValueRefBase(void)
+	inline ~MCAutoValueRefBase(void)
 	{
 		MCValueRelease(m_value);
 	}
 
-	T operator = (T value)
+	inline T operator = (T value)
 	{
 		MCAssert(m_value == nil);
 		m_value = (T)MCValueRetain(value);
 		return value;
 	}
 
-	T& operator & (void)
+	inline T& operator & (void)
 	{
 		MCAssert(m_value == nil);
 		return m_value;
 	}
 
-	T operator * (void) const
+	inline T operator * (void) const
 	{
 		return m_value;
 	}
     
-    // Return the contents of the auto pointer in a form for an in parameter.
-    T In(void) const
+    inline T& operator ! (void)
     {
-        return m_value;
-    }
-    
-    // Return the contents of the auto pointer in a form for an out parameter.
-    T& Out(void)
-    {
-		MCAssert(m_value == nil);
 		return m_value;
-    }
-    
-    // Return the contents of the auto pointer in a form for an inout parameter.
-    T& InOut(void)
-    {
-        return m_value;
     }
     
     // The give method places the given value into the container without
     // retaining it - the auto container is considered to now own the value.
-    void Give(T value)
+    inline void Give(T value)
     {
         MCAssert(m_value == nil);
         m_value = value;
@@ -83,7 +69,7 @@ public:
     
     // The take method removes the value from the container passing ownership
     // to the caller.
-    T Take(void)
+    inline T Take(void)
     {
         T t_value;
         t_value = m_value;
@@ -91,8 +77,31 @@ public:
         return t_value;
     }
     
+    friend T In(const MCAutoValueRefBase<T>&);
+    friend T& Out(MCAutoValueRefBase<T>&);
+    friend T& InOut(MCAutoValueRefBase<T>&);
+    
 protected:
 	T m_value;
+    
+    // Return the contents of the auto pointer in a form for an in parameter.
+    inline T In(void) const
+    {
+        return m_value;
+    }
+    
+    // Return the contents of the auto pointer in a form for an out parameter.
+    inline T& Out(void)
+    {
+		MCAssert(m_value == nil);
+		return m_value;
+    }
+    
+    // Return the contents of the auto pointer in a form for an inout parameter.
+    inline T& InOut(void)
+    {
+        return m_value;
+    }
 
 private:
     MCAutoValueRefBase<T>& operator = (MCAutoValueRefBase<T>& x);
@@ -101,17 +110,17 @@ private:
 template<typename T, bool (*MutableCopyAndRelease)(T, T&), bool (*ImmutableCopyAndRelease)(T, T&)> class MCAutoMutableValueRefBase: public MCAutoValueRefBase<T>
 {
 public:
-	T operator = (T value)
+	inline T operator = (T value)
 	{
         return MCAutoValueRefBase<T>::operator =(value);
 	}
     
-    bool MakeMutable(void)
+    inline bool MakeMutable(void)
     {
         return MutableCopyAndRelease(MCAutoValueRefBase<T>::m_value, MCAutoValueRefBase<T>::m_value);
     }
     
-    bool MakeImmutable(void)
+    inline bool MakeImmutable(void)
     {
         return ImmutableCopyAndRelease(MCAutoValueRefBase<T>::m_value, MCAutoValueRefBase<T>::m_value);
     }
@@ -119,6 +128,21 @@ public:
 private:
     MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& operator = (MCAutoMutableValueRefBase<T, MutableCopyAndRelease, ImmutableCopyAndRelease>& x);
 };
+
+template<typename T> inline T In(const MCAutoValueRefBase<T>& p_auto)
+{
+    return p_auto . In();
+}
+
+template<typename T> inline T& Out(MCAutoValueRefBase<T>& p_auto)
+{
+    return p_auto . Out();
+}
+
+template<typename T> inline T& InOut(MCAutoValueRefBase<T>& p_auto)
+{
+    return p_auto . InOut();
+}
 
 typedef MCAutoValueRefBase<MCValueRef> MCAutoValueRef;
 typedef MCAutoValueRefBase<MCNumberRef> MCAutoNumberRef;

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1240,7 +1240,20 @@ template<typename T> inline T MCValueRetain(T value)
 // Utility function for assigning to MCValueRef vars.
 template<typename T> inline void MCValueAssign(T& dst, T src)
 {
+    if (src == dst)
+        return;
+    
 	MCValueRetain(src);
+	MCValueRelease(dst);
+	dst = src;
+}
+
+// Utility function for assigning to MCValueRef vars.
+template<typename T> inline void MCValueAssignAndRelease(T& dst, T src)
+{
+    if (src == dst)
+        return;
+    
 	MCValueRelease(dst);
 	dst = src;
 }

--- a/libfoundation/src/system-commandline.cpp
+++ b/libfoundation/src/system-commandline.cpp
@@ -152,7 +152,7 @@ __MCSCommandLineCaptureNameAndArguments (uindex_t p_arg_count,
 	}
 	else
 	{
-		t_name = MCValueRetain (kMCEmptyString);
+		t_name = kMCEmptyString;
 	}
 
 	if (!MCSCommandLineSetName (*t_name))
@@ -181,7 +181,7 @@ __MCSCommandLineCaptureNameAndArguments (uindex_t p_arg_count,
 	}
 	else
 	{
-		t_arg_list = MCValueRetain (kMCEmptyProperList);
+		t_arg_list = kMCEmptyProperList;
 	}
 
 	if (!MCSCommandLineSetArguments (*t_arg_list))


### PR DESCRIPTION
Arrays are now passed correctly between LCB and LCS. Elements are marshalled recursively.

When going from LCB to LCS, all LCB-specific types are mapped to their (looser) LCS types.

When going from LCS to LCB, names are marshalled to strings.
