### PR TITLE
[Bug 14514] Minor bugs with LCB symbol imports

### DIFF
--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -657,8 +657,8 @@ static inline void MCScriptResolveDefinitionInFrame(MCScriptFrame *p_frame, uind
         MCScriptImportedDefinition *t_import_def;
         t_import_def = &t_instance -> module -> imported_definitions[t_ext_def -> index];
         
-        t_instance = t_instance -> module -> dependencies[t_import_def -> module] . instance;
-        t_definition = t_import_def -> definition;
+        t_instance = t_import_def -> resolved_module -> shared_instance;
+        t_definition = t_import_def -> resolved_definition;
     }
 
     r_instance = t_instance;

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -461,6 +461,11 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
         if (t_module -> module_kind == kMCScriptModuleKindWidget)
             return false;
         
+        // A used module must be usable - do this before resolving imports so
+        // chained imports work.
+        if (!MCScriptEnsureModuleIsUsable(t_module))
+            return false;
+        
         // Check all the imported definitions from the module, and compute indicies.
         for(uindex_t t_import = 0; t_import < self -> imported_definition_count; t_import++)
         {
@@ -473,6 +478,17 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
             if (!MCScriptLookupDefinitionInModule(t_module, t_import_def -> name, t_def))
                 return false;
             
+            MCScriptModuleRef t_mod;
+            if (t_def -> kind == kMCScriptDefinitionKindExternal)
+            {
+                MCScriptExternalDefinition *t_ext_def;
+                t_ext_def = static_cast<MCScriptExternalDefinition *>(t_def);
+                t_mod = t_module -> imported_definitions[t_ext_def -> index] . resolved_module;
+                t_def = t_module -> imported_definitions[t_ext_def -> index] . resolved_definition;
+            }
+            else
+                t_mod = t_module;
+            
             if (t_def -> kind != t_import_def -> kind)
             {
                 if (t_import_def -> kind != kMCScriptDefinitionKindHandler ||
@@ -482,12 +498,9 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
             
             // Check that signatures match.
             
-            t_import_def -> definition = t_def;
+            t_import_def -> resolved_definition = t_def;
+            t_import_def -> resolved_module = t_mod;
         }
-        
-        // A used module must be usable.
-        if (!MCScriptEnsureModuleIsUsable(t_module))
-            return false;
         
         // Now create the instance we need.
         if (!MCScriptCreateInstanceOfModule(t_module, self -> dependencies[i] . instance))
@@ -567,8 +580,8 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                     t_import = &self -> imported_definitions[t_ext_def -> index];
                     
                     MCScriptModuleRef t_module;
-                    t_module = self -> dependencies[t_import -> module] . instance -> module;
-                    t_typeinfo = t_module -> types[static_cast<MCScriptTypeDefinition *>(t_import -> definition) -> type] -> typeinfo;
+                    t_module = t_import -> resolved_module;
+                    t_typeinfo = t_module -> types[static_cast<MCScriptTypeDefinition *>(t_import -> resolved_definition) -> type] -> typeinfo;
                 }
                 else
                     return false;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -210,8 +210,10 @@ struct MCScriptImportedDefinition
     MCScriptDefinitionKind kind;
     MCNameRef name;
     
+    // The module the definition resides in.
+    MCScriptModuleRef resolved_module;
     // The resolved definition - not pickled
-    MCScriptDefinition *definition;
+    MCScriptDefinition *resolved_definition;
 };
 
 struct MCScriptPosition

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -40,14 +40,21 @@
         -- Step 1: Ensure all id's referencing definitions point to the definition.
         --         and no duplicate definitions have been attempted.
         EnterScope
+
         -- Import all the used modules
         DeclareImports(Imports, ImportedModules)
+        
+        EnterScope
+
         -- Declare the predefined ids
         DeclarePredefinedIds
         -- Assign the defining id to all top-level names.
         Declare(Definitions)
         -- Resolve all references to id's.
         Apply(Definitions)
+        
+        LeaveScope
+
         LeaveScope
         
         -- Step 2: Ensure all definitions have their appropriate meaning


### PR DESCRIPTION
Fixes two issues:

1) LCB compiler doesn't use correct scoping when importing modules meaning that a module cannot override an imported definition from another module.

2) LCB machine doesn't resolve imported definitions which point to an imported definition in a used module.
