### PR TITLE
[[ Bug 14505 ]] ProperListRefs are not serialized.

### DIFF
--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -935,7 +935,7 @@ IO_stat IO_write_valueref_new(MCValueRef p_value, IO_handle p_stream)
 			}
 		}	
 		break;
-        case kMCValueTypeCodeList:
+        case kMCValueTypeCodeProperList:
         {
             if (MCProperListIsEmpty((MCProperListRef)p_value))
                 t_stat = IO_write_uint1(IO_VALUEREF_LIST_EMPTY, p_stream);


### PR DESCRIPTION
Due to a typo in the MCS_write_valueref_new function, MCProperListRef values ('list' in LCB) were not being serialized and instead causing an error.
