### PR TITLE
new can't return nil

### DIFF
--- a/revpdfprinter/src/revpdfprinter.cpp
+++ b/revpdfprinter/src/revpdfprinter.cpp
@@ -1368,8 +1368,8 @@ void * operator new (size_t p_amount)
 #endif
 {
 	void *t_result;
-	if (!MCMemoryAllocate(p_amount, t_result))
-		return nil;
+	// MDW-2015-02-06: [[ feature_reduce_warnings ]] This will return nil on error anyway
+	MCMemoryAllocate(p_amount, t_result);
 	return t_result;
 }
 


### PR DESCRIPTION
The C++ new operator can't return a value, so attempting to return a nil on memory allocation failure will give a warning. Simply returning the allocated value should do the right thing, since if MCMemoryAllocate fails the pointer value should be nil in any event. To be pedantic about it, I'd rather have t_result initialized to nil, but the compiler should do this anyway. And to be really pedantic about it, I think MCMemoryAllocate should set the return pointer to nil in core.h even on failure, where it now only sets the pointer on success.
