### PR TITLE
Fix build problems when building inside a Docker fedora container.

### DIFF
--- a/engine/Makefile.kernel-server
+++ b/engine/Makefile.kernel-server
@@ -63,6 +63,7 @@ SOURCES=\
 	fonttable.cpp fieldrtf.cpp fieldhtml.cpp fieldstyledtext.cpp paragrafattr.cpp \
     graphicscontext.cpp lnxflst.cpp lnxflstold.cpp lnxelevate.cpp \
 	linux-theme.cpp \
+	linuxstubs.cpp \
 	modules.cpp \
 	module-canvas.cpp \
 	module-engine.cpp \

--- a/rules/common.linux.makefile
+++ b/rules/common.linux.makefile
@@ -38,6 +38,7 @@ GLOBAL_INCLUDES=\
 	$(SOLUTION_DIR)/thirdparty/libskia/include/pathops \
 	$(SOLUTION_DIR)/thirdparty/libskia/include/ports \
 	$(SOLUTION_DIR)/thirdparty/libskia/include/utils \
+	$(SOLUTION_DIR)/thirdparty/libfreetype/include \
 	$(SOLUTION_DIR)/prebuilt/include \
 	$(SOLUTION_DIR)/thirdparty/libffi/linux/i686-pc-linux-gnu
 	


### PR DESCRIPTION
A couple of build issues when compiling livecode server in a Docker fedora 21 container:
- When you only build the `server` target the file `linuxstubs.cpp` wasn't being made.
- The thirdparty `libfreetype` headers were not being included.
