### PR TITLE
[Bug 14483] Fiddling with alphaData no longer crashes/hangs LC 7.0.1

### DIFF
--- a/docs/notes/bugfix-14483.md
+++ b/docs/notes/bugfix-14483.md
@@ -1,0 +1,1 @@
+#     fiddling with alphaData crashes/hangs LC 7.0.2 

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -1243,8 +1243,8 @@ Exec_stat MCImage::setprop(uint4 parid, Properties p, MCExecPoint &ep, Boolean e
 			MCImageBitmap *t_copy = nil;
 			if (m_rep != nil)
 			{
-                // PM-2014-11-05: [[ Bug 13938 ]] Make sure new alphaData does not add to previous one
-				t_success = lockbitmap(t_copy, false);
+                // PM-2015-02-09: [[ Bug 14483 ]] Reverted patch for bugfix 13938
+                t_success = copybitmap(false, t_copy);
 			}
 			else
 			{
@@ -1256,8 +1256,7 @@ Exec_stat MCImage::setprop(uint4 parid, Properties p, MCExecPoint &ep, Boolean e
 			if (t_success)
 			{
 				MCImageSetMask(t_copy, (uint8_t*)data.getstring(), data.getlength(), true);
-                // PM-2015-01-15: [[ Bug 14347 ]] Unlock bitmap to prevent a crash
-                unlockbitmap(t_copy);
+                // PM-2015-02-09: [[ Bug 14483 ]] Reverted patch for bugfix 14347
 				setbitmap(t_copy, 1.0);
             }
 
@@ -2701,7 +2700,8 @@ bool MCImage::copybitmap(bool p_premultiplied, MCImageBitmap *&r_bitmap)
 	MCImageBitmap *t_bitmap;
 	t_bitmap = nil;
 
-	t_success = lockbitmap(t_bitmap, true);
+    // PM-2014-11-05: [[ Bug 13938 ]] Make sure new alphaData does not add to previous one
+	t_success = lockbitmap(t_bitmap, p_premultiplied);
 
 	if (t_success)
 	{


### PR DESCRIPTION
Note: This pull request includes:
1. Reverting of patches for bugs 13938 and 14347
2. Better patch for bug 13938, which fixes all bugs 13938, 14347 and 14483
