### PR TITLE
[[ LCB ]] Unified the three char escapes to \u{FEDCBA}.

### DIFF
--- a/docs/specs/livecode_builder_language_reference.md
+++ b/docs/specs/livecode_builder_language_reference.md
@@ -30,7 +30,7 @@ Strings use backslash ('\') as an escape - the following are understood:
  - **\r**: CR (ASCII 13)
  - **\t**: TAB (ASCII 9)
  - **\q**: quote '"'
- - **\u{X…X}: character with unicode codepoint hex value 0xX...X - any number of nibbles may be specified, but the value will be clamped to 0x10FFFF.
+ - **\u{X...X}: character with unicode codepoint U+X...X - any number of nibbles may be specified, but any values greater than 0x10FFFF will be replaced by U+FFFD.
  - **\\**: backslash '\'
 
 > **Note:** The presence of '.' in identifiers are used as a namespace scope delimiter.

--- a/docs/specs/livecode_builder_language_reference.md
+++ b/docs/specs/livecode_builder_language_reference.md
@@ -30,9 +30,7 @@ Strings use backslash ('\') as an escape - the following are understood:
  - **\r**: CR (ASCII 13)
  - **\t**: TAB (ASCII 9)
  - **\q**: quote '"'
- - **\xXX**: character with unicode codepoint hex value 0xXX
- - **\uXXXX**: character with unicode codepoint hex value 0xXXXX
- - **\UXXXXXX**: character with unicode codepoint hex valu 0xXXXXXX
+ - **\u{FEDCBA}: character with unicode codepoint hex value 0xFEDCBA - BCDEF are optional.
  - **\\**: backslash '\'
 
 > **Note:** The presence of '.' in identifiers are used as a namespace scope delimiter.

--- a/docs/specs/livecode_builder_language_reference.md
+++ b/docs/specs/livecode_builder_language_reference.md
@@ -30,7 +30,7 @@ Strings use backslash ('\') as an escape - the following are understood:
  - **\r**: CR (ASCII 13)
  - **\t**: TAB (ASCII 9)
  - **\q**: quote '"'
- - **\u{FEDCBA}: character with unicode codepoint hex value 0xFEDCBA - BCDEF are optional.
+ - **\u{X…X}: character with unicode codepoint hex value 0xX...X - any number of nibbles may be specified, but the value will be clamped to 0x10FFFF.
  - **\\**: backslash '\'
 
 > **Note:** The presence of '.' in identifiers are used as a namespace scope delimiter.

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -1089,7 +1089,7 @@
     'rule' StringLiteral(-> Value):
         STRING_LITERAL(-> EscapedValue) @(-> Position)
         (|
-            UnescapeStringLiteral(EscapedValue -> Value)
+            UnescapeStringLiteral(Position, EscapedValue -> Value)
         ||
             Error_MalformedEscapedString(Position, EscapedValue)
             where(EscapedValue -> Value)

--- a/toolchain/lc-compile/src/literal.c
+++ b/toolchain/lc-compile/src/literal.c
@@ -163,9 +163,9 @@ int UnescapeStringLiteral(const char *p_string, long *r_unescaped_string)
                     t_ptr += 1;
                     if (t_ptr < t_limit && *t_ptr == '{')
                     {
-                        int t_char;
+                        int t_char, i;
                         t_char = 0;
-                        for(int i = 0; i < 6; i++)
+                        for(i = 0; i < 6; i++)
                         {
                             // Advance the input ptr - if we are at the end here
                             // it is an error.

--- a/toolchain/lc-compile/src/literal.c
+++ b/toolchain/lc-compile/src/literal.c
@@ -208,7 +208,7 @@ int UnescapeStringLiteral(long p_position, const char *p_string, long *r_unescap
                         if (t_overflow)
                         {
                             Warning_UnicodeEscapeTooBig(p_position + (t_escape - p_string));
-                            t_char = 0x10FFFF;
+                            t_char = 0xFFFD;
                         }
                         
                         append_utf8_char(t_value, &t_length, t_char);

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -185,6 +185,8 @@ DEFINE_ERROR(NonHandlerTypeVariablesCannotBeCalled, "Variables must have handler
     void Warning_##Name(long p_position) { _Warning(p_position, Message); }
 
 DEFINE_WARNING(MetadataClausesShouldComeAfterUseClauses, "Metadata clauses should come after use clauses")
+DEFINE_WARNING(EmptyUnicodeEscape, "Unicode escape sequence specified with no nibbles")
+DEFINE_WARNING(UnicodeEscapeTooBig, "Unicode escape sequence too big, character clamped to \\u{10FFFF}");
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -186,7 +186,7 @@ DEFINE_ERROR(NonHandlerTypeVariablesCannotBeCalled, "Variables must have handler
 
 DEFINE_WARNING(MetadataClausesShouldComeAfterUseClauses, "Metadata clauses should come after use clauses")
 DEFINE_WARNING(EmptyUnicodeEscape, "Unicode escape sequence specified with no nibbles")
-DEFINE_WARNING(UnicodeEscapeTooBig, "Unicode escape sequence too big, character clamped to \\u{10FFFF}");
+DEFINE_WARNING(UnicodeEscapeTooBig, "Unicode escape sequence too big, replaced with U+FFFD");
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -33,6 +33,9 @@ void Error_CouldNotOpenInputFile(const char *path);
 void Error_MalformedToken(long position, const char *token);
 void Error_MalformedSyntax(long position);
     
+void Warning_EmptyUnicodeEscape(long position);
+void Warning_UnicodeEscapeTooBig(long position);
+    
 #ifdef __cplusplus
 }
 #endif

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -314,7 +314,7 @@
 'action' MakeIntegerLiteral(Token: STRING -> Literal: INT)
 'action' MakeDoubleLiteral(Token: STRING -> Literal: DOUBLE)
 'action' MakeStringLiteral(Token: STRING -> Literal: STRING)
-'condition' UnescapeStringLiteral(String: STRING -> UnescapedString: STRING)
+'condition' UnescapeStringLiteral(Position:POS, String: STRING -> UnescapedString: STRING)
 'action' MakeNameLiteral(Token: STRING -> Literal: NAME)
 
 'action' GetStringOfNameLiteral(Name: NAME -> String: STRING)


### PR DESCRIPTION
The three escapes \x, \u, \U have been removed in favour of a general \u{FEDCBA} form.
