### PR TITLE
[[ LCB ]] Postfix 'into' syntax.

### DIFF
--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1102,6 +1102,23 @@
         EmitDestroyRegister(Reg)
         EmitAssignUndefined(Result)
         
+    'rule' GenerateBody(Result, Context, postfixinto(Position, Command, slot(_, Id))):
+        QuerySymbolId(Id -> Info)
+        Info'Kind -> Kind
+        Info'Index -> Index
+        IsVariableInRegister(Kind)
+        GenerateBody(Index, Context, Command)
+        EmitAssignUndefined(Result)
+
+    'rule' GenerateBody(Result, Context, postfixinto(Position, Command, Target)):
+        EmitPosition(Position)
+        GenerateInvoke_EvaluateArgumentForOut(Result, Context, Target)
+        EmitGetRegisterAttachedToExpression(Target -> DstReg)
+        GenerateBody(DstReg, Context, Command)
+        GenerateInvoke_AssignArgument(Result, Context, Target)
+        GenerateInvoke_FreeArgument(Target)
+        EmitAssignUndefined(Result)
+
     'rule' GenerateBody(Result, Context, nil):
         -- nothing
 
@@ -1595,20 +1612,26 @@
     'rule' GenerateAssignList(nil):
         -- finished
 
-'action' EmitStoreVar(SYMBOLKIND, INT, INT)
+'condition' IsVariableInRegister(SYMBOLKIND)
 
-    'rule' EmitStoreVar(variable, Reg, Var):
-        EmitStore(Reg, Var, 0)
+    'rule' IsVariableInRegister(local):
+    'rule' IsVariableInRegister(parameter):
+
+
+'action' EmitStoreVar(SYMBOLKIND, INT, INT)
         
-    'rule' EmitStoreVar(_, Reg, Var):
+    'rule' EmitStoreVar(Kind, Reg, Var):
+        IsVariableInRegister(Kind)
         EmitAssign(Var, Reg)
+
+    -- This catches all module-scope things, including variables and handler references.
+    'rule' EmitStoreVar(_, Reg, Var):
+        EmitStore(Reg, Var, 0)
 
 'action' EmitFetchVar(SYMBOLKIND, INT, INT)
 
-    'rule' EmitFetchVar(local, Reg, Var):
-        EmitAssign(Reg, Var)
-
-    'rule' EmitFetchVar(parameter, Reg, Var):
+    'rule' EmitFetchVar(Kind, Reg, Var):
+        IsVariableInRegister(Kind)
         EmitAssign(Reg, Var)
 
     -- This catches all module-scope things, including variables and handler references.

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -601,7 +601,7 @@
         
     'rule' Statements(-> nil):
         -- empty
-        
+
 'nonterm' Statement(-> STATEMENT)
 
     'rule' Statement(-> variable(Position, Name, Type)):
@@ -681,6 +681,9 @@
 
     'rule' Statement(-> call(Position, Handler, Arguments)):
         Identifier(-> Handler) @(-> Position) "(" OptionalExpressionList(-> Arguments) ")"
+
+    'rule' Statement(-> postfixinto(Position, Statement, Target)):
+        CustomStatements(-> Statement) "into" @(-> Position) Expression(-> Target)
 
     'rule' Statement(-> Statement):
         CustomStatements(-> Statement)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -143,6 +143,7 @@
     call(Position: POS, Handler: ID, Arguments: EXPRESSIONLIST)
     invoke(Position: POS, Info: INVOKELIST, Arguments: EXPRESSIONLIST)
     throw(Position: POS, Error: EXPRESSION)
+    postfixinto(Position: POS, Command: STATEMENT, Target: EXPRESSION)
     nil
     
 'type' EXPRESSIONLIST


### PR DESCRIPTION
A general postfix 'into' clause has been added for all commands. The action of the 'into' clause is to replace the return value of the command into the target variable, as opposed to 'the result'. If postfix 'into' is used 'the result' will be undefined.
