### PR TITLE
[[ Bug 14532 ]] Prevent excessive substring copying when resolving text chunks.

### DIFF
--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -5673,6 +5673,89 @@ MCTextChunkIterator::MCTextChunkIterator(Chunk_term p_chunk_type, MCStringRef p_
         MCLocaleBreakIteratorRelease(break_iterator);
 }
 
+// AL-2015-02-10: [[ Bug 14532 ]] Add text chunk iterator constructor for restricted range chunk operations.
+MCTextChunkIterator::MCTextChunkIterator(Chunk_term p_chunk_type, MCStringRef p_text, MCRange p_restriction)
+{
+    /* UNCHECKED */ MCStringCopy(p_text, text);
+    type = p_chunk_type;
+    
+    if (type == CT_CHARACTER && (MCStringIsNative(text) || (MCStringIsSimple(text) && MCStringIsUncombined(text))))
+        type = CT_CODEUNIT;
+    
+    MCBreakIteratorRef break_iterator;
+    
+    break_iterator = nil;
+    sp = nil;
+    range = MCRangeMake(p_restriction . offset, 0);
+    length = p_restriction . length == UINDEX_MAX ? MCStringGetLength(text) : p_restriction . offset + p_restriction . length;
+    // AL-2014-10-24: [[ Bug 13783 ]] Set exhausted to true if the string is immediately exhausted
+    exhausted = (p_restriction . length == 0 || p_restriction . offset>= MCStringGetLength(text));
+    first_chunk = true;
+    break_position = 0;
+    delimiter_length = 0;
+    
+    switch (type)
+    {
+        case CT_TOKEN:
+        {
+            MCAutoStringRef t_substring;
+            MCStringCopySubstring(text, p_restriction, &t_substring);
+            MCValueAssign(text, *t_substring);
+            sp = new MCScriptPoint(text);
+        }
+            break;
+        case CT_CHARACTER:
+        case CT_SENTENCE:
+        {
+            MCAutoStringRef t_substring;
+            MCStringCopySubstring(text, p_restriction, &t_substring);
+            MCRange t_range;
+            uindex_t t_end;
+            /* UNCHECKED */ MCLocaleBreakIteratorCreate(kMCBasicLocale, p_chunk_type == CT_SENTENCE ? kMCBreakIteratorTypeSentence : kMCBreakIteratorTypeCharacter, break_iterator);
+            /* UNCHECKED */ MCLocaleBreakIteratorSetText(break_iterator, *t_substring);
+            t_range . length = p_restriction . length;
+            t_range . offset = p_restriction . offset;
+            
+            while ((t_end = MCLocaleBreakIteratorAdvance(break_iterator)) != kMCLocaleBreakIteratorDone)
+            {
+                t_range . offset += t_range . length;
+                t_range . length = t_end - t_range . offset;
+                breaks . Push(t_range);
+            }
+        }
+            break;
+        case CT_TRUEWORD:
+        {
+            MCAutoStringRef t_substring;
+            MCStringCopySubstring(text, p_restriction, &t_substring);
+            MCAutoArray<uindex_t> t_breaks;
+            /* UNCHECKED */ MCLocaleBreakIteratorCreate(kMCBasicLocale, kMCBreakIteratorTypeWord, break_iterator);
+            /* UNCHECKED */ MCLocaleBreakIteratorSetText(break_iterator, *t_substring);
+            MCRange t_range;
+            t_range . length = p_restriction . length;
+            t_range . offset = p_restriction . offset;
+            
+            while (MCLocaleWordBreakIteratorAdvance(*t_substring, break_iterator, t_range)
+                   && t_range . offset + t_range . length != kMCLocaleBreakIteratorDone)
+            {
+                breaks . Push(t_range);
+            }
+        }
+            break;
+        case CT_LINE:
+        case CT_ITEM:
+        case CT_PARAGRAPH:
+            // delimiter length may vary for line and item.
+            delimiter_length = 1;
+        default:
+            break;
+    }
+    
+    if (break_iterator != nil)
+        MCLocaleBreakIteratorRelease(break_iterator);
+}
+
+
 MCTextChunkIterator::~MCTextChunkIterator()
 {    
     MCValueRelease(text);
@@ -5739,7 +5822,8 @@ bool MCTextChunkIterator::next(MCExecContext& ctxt)
             
             MCRange t_found_range;
             // calculate the length of the line / item
-            if (!MCStringFind(text, MCRangeMake(t_offset, UINDEX_MAX), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
+            // AL-2015-02-10: [[ Bug 14532 ]] Use restricted range for delimiter search
+            if (!MCStringFind(text, MCRangeMake(t_offset, length - t_offset), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
             {
                 range . length = length - range . offset;
                 exhausted = true;
@@ -5759,8 +5843,9 @@ bool MCTextChunkIterator::next(MCExecContext& ctxt)
             uindex_t t_pg_offset;
             bool t_newline_found, t_pg_found;
             
+            // AL-2015-02-10: [[ Bug 14532 ]] Use restricted range for delimiter search
             t_pg_offset = t_offset;
-            t_newline_found = MCStringFirstIndexOfChar(text, '\n', t_offset, kMCCompareExact, t_offset);
+            t_newline_found = MCStringFirstIndexOfCharInRange(text, '\n', MCRangeMake(t_offset, length - t_offset), kMCCompareExact, t_offset);
             // AL-2014-07-21: [[ Bug 12162 ]] Ignore PS when calculating paragraph chunk.
             t_pg_found = false; /*MCStringFirstIndexOfChar(text, 0x2029, t_pg_offset, kMCCompareExact, t_pg_offset);*/
             
@@ -5791,7 +5876,8 @@ bool MCTextChunkIterator::next(MCExecContext& ctxt)
             
             MCStringsSkipWord(ctxt, text, false, t_offset);
             
-            if (t_offset == length)
+            // AL-2015-02-10: [[ Bug 14532 ]] Use restricted range for exhaustion check
+            if (t_offset >= length)
                 exhausted = true;
             
             range . length = t_offset - range . offset;
@@ -5847,11 +5933,11 @@ bool MCTextChunkIterator::isamong(MCExecContext& ctxt, MCStringRef p_needle)
             // Otherwise we need to find p_needle and check to see if there is a delimiter either side.
             // This is because of the case where the delimiter is within p_needle - e.g.
             // "a,b" is among the items of "a,b,c,d" should return true.
-            
+            // AL-2015-02-10: [[ Bug 14532 ]] Use restricted range for isamong search
             if (type == CT_PARAGRAPH)
-                return MCStringsIsAmongTheParagraphsOfRange(ctxt, p_needle, text, ctxt . GetStringComparisonType(), MCRangeMake(0, length));
+                return MCStringsIsAmongTheParagraphsOfRange(ctxt, p_needle, text, ctxt . GetStringComparisonType(), MCRangeMake(range . offset, length));
             
-            return MCStringsIsAmongTheChunksOfRange(ctxt, p_needle, text, type, ctxt . GetStringComparisonType(), MCRangeMake(0, length));
+            return MCStringsIsAmongTheChunksOfRange(ctxt, p_needle, text, type, ctxt . GetStringComparisonType(), MCRangeMake(range . offset, length));
         }
         default:
             if (MCStringIsEmpty(p_needle))

--- a/engine/src/chunk.h
+++ b/engine/src/chunk.h
@@ -250,6 +250,8 @@ class MCTextChunkIterator
     
     public:
     MCTextChunkIterator(Chunk_term p_chunk_type, MCStringRef p_text);
+    // AL-2015-02-10: [[ Bug 14532 ]] Add text chunk iterator constructor for restricted range chunk operations.
+    MCTextChunkIterator(Chunk_term p_chunk_type, MCStringRef p_text, MCRange p_restriction);
     ~MCTextChunkIterator();
     
     MCRange getrange()

--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -85,9 +85,10 @@ void MCStringsSkipWord(MCExecContext& ctxt, MCStringRef p_string, bool p_skip_sp
     }
 }
 
-void MCStringsCountChunks(MCExecContext& ctxt, Chunk_term p_chunk_type, MCStringRef p_string, uinteger_t& r_count)
+// AL-2015-02-10: [[ Bug 14532 ]] Allow chunks to be counted in a given range, to prevent substring copying in text chunk resolution.
+void MCStringsCountChunksInRange(MCExecContext& ctxt, Chunk_term p_chunk_type, MCStringRef p_string, MCRange p_range, uinteger_t& r_count)
 {
-    if (MCStringGetLength(p_string) == 0)
+    if (p_range . length == 0 || p_range . offset > MCStringGetLength(p_string))
     {
         r_count = 0;
         return;
@@ -100,18 +101,24 @@ void MCStringsCountChunks(MCExecContext& ctxt, Chunk_term p_chunk_type, MCString
     
     if (p_chunk_type == CT_CODEUNIT)
     {
-        r_count = MCStringGetLength(p_string);
+        r_count = MCU_min(MCStringGetLength(p_string), p_range . length) - p_range . offset;
         return;
     }
     
     MCTextChunkIterator *tci;
-    tci = new MCTextChunkIterator(p_chunk_type, p_string);
+    tci = new MCTextChunkIterator(p_chunk_type, p_string, p_range);
     r_count = tci -> countchunks(ctxt);
     delete tci;
     return;
- }
+}
 
-void MCStringsGetExtentsByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_type, Chunk_term p_ordinal_type, MCValueRef p_string, integer_t& r_first, integer_t& r_chunk_count)
+void MCStringsCountChunks(MCExecContext& ctxt, Chunk_term p_chunk_type, MCStringRef p_string, uinteger_t& r_count)
+{
+    MCStringsCountChunksInRange(ctxt, p_chunk_type, p_string, MCRangeMake(0, MCStringGetLength(p_string)), r_count);
+}
+
+// AL-2015-02-10: [[ Bug 14532 ]] Allow chunk extents to be counted in a given range, to prevent substring copying in text chunk resolution.
+void MCStringsGetExtentsByOrdinalInRange(MCExecContext& ctxt, Chunk_term p_chunk_type, Chunk_term p_ordinal_type, MCValueRef p_string, MCRange p_range, integer_t& r_first, integer_t& r_chunk_count)
 {
     uinteger_t t_count = 0;
     switch (p_ordinal_type)
@@ -120,17 +127,17 @@ void MCStringsGetExtentsByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_type, 
         case CT_LAST:
         case CT_MIDDLE:
             if (MCValueGetTypeCode(p_string) == kMCValueTypeCodeData)
-                t_count = MCDataGetLength((MCDataRef)p_string);
+                t_count = p_range . length;
             else
-                MCStringsCountChunks(ctxt, p_chunk_type, (MCStringRef)p_string, t_count);
+                MCStringsCountChunksInRange(ctxt, p_chunk_type, (MCStringRef)p_string, p_range, t_count);
             
             if (p_ordinal_type == CT_ANY)
                 r_first = MCU_any(t_count);
             else if (p_ordinal_type == CT_LAST)
                 r_first = t_count - 1;
             else
-                r_first = t_count / 2;                
-            break; 
+                r_first = t_count / 2;
+            break;
         case CT_FIRST:
         case CT_SECOND:
         case CT_THIRD:
@@ -161,7 +168,16 @@ void MCStringsGetExtentsByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_type, 
         r_chunk_count = 1;
 }
 
-void MCStringsGetExtentsByRange(MCExecContext& ctxt, Chunk_term p_chunk_type, integer_t p_first, integer_t p_last, MCValueRef p_string, integer_t& r_first, integer_t& r_chunk_count)
+void MCStringsGetExtentsByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_type, Chunk_term p_ordinal_type, MCValueRef p_string, integer_t& r_first, integer_t& r_chunk_count)
+{
+    if (MCValueGetTypeCode(p_string) == kMCValueTypeCodeString)
+        return MCStringsGetExtentsByOrdinalInRange(ctxt, p_chunk_type, p_ordinal_type, p_string, MCRangeMake(0, MCStringGetLength((MCStringRef)p_string)), r_first, r_chunk_count);
+    
+    return MCStringsGetExtentsByOrdinalInRange(ctxt, p_chunk_type, p_ordinal_type, p_string, MCRangeMake(0, MCDataGetLength((MCDataRef)p_string)), r_first, r_chunk_count);
+}
+
+// AL-2015-02-10: [[ Bug 14532 ]] Allow chunk extents to be counted in a given range, to prevent substring copying in text chunk resolution.
+void MCStringsGetExtentsByRangeInRange(MCExecContext& ctxt, Chunk_term p_chunk_type, integer_t p_first, integer_t p_last, MCValueRef p_string, MCRange p_range, integer_t& r_first, integer_t& r_chunk_count)
 {
     int4 t_chunk_count;
     
@@ -169,9 +185,9 @@ void MCStringsGetExtentsByRange(MCExecContext& ctxt, Chunk_term p_chunk_type, in
     {
         uinteger_t t_count;
         if (MCValueGetTypeCode(p_string) == kMCValueTypeCodeData)
-            t_count = MCDataGetLength((MCDataRef)p_string);
+            t_count = p_range . length;
         else
-            MCStringsCountChunks(ctxt, p_chunk_type, (MCStringRef)p_string, t_count);
+            MCStringsCountChunksInRange(ctxt, p_chunk_type, (MCStringRef)p_string, p_range, t_count);
         
         if (p_first < 0)
             p_first += t_count;
@@ -199,14 +215,23 @@ void MCStringsGetExtentsByRange(MCExecContext& ctxt, Chunk_term p_chunk_type, in
     r_first = p_first;
 }
 
-void MCStringsGetExtentsByExpression(MCExecContext& ctxt, Chunk_term p_chunk_type, integer_t p_first, MCStringRef p_string, integer_t& r_first, integer_t& r_chunk_count)
+void MCStringsGetExtentsByRange(MCExecContext& ctxt, Chunk_term p_chunk_type, integer_t p_first, integer_t p_last, MCValueRef p_string, integer_t& r_first, integer_t& r_chunk_count)
+{
+    if (MCValueGetTypeCode(p_string) == kMCValueTypeCodeString)
+        return MCStringsGetExtentsByRangeInRange(ctxt, p_chunk_type, p_first, p_last, p_string, MCRangeMake(0, MCStringGetLength((MCStringRef)p_string)), r_first, r_chunk_count);
+    
+    return MCStringsGetExtentsByRangeInRange(ctxt, p_chunk_type, p_first, p_last, p_string, MCRangeMake(0, MCDataGetLength((MCDataRef)p_string)), r_first, r_chunk_count);
+}
+
+// AL-2015-02-10: [[ Bug 14532 ]] Allow chunk extents to be counted in a given range, to prevent substring copying in text chunk resolution.
+void MCStringsGetExtentsByExpressionInRange(MCExecContext& ctxt, Chunk_term p_chunk_type, integer_t p_first, MCStringRef p_string, MCRange p_range, integer_t& r_first, integer_t& r_chunk_count)
 {
     r_chunk_count = 1;
     
     if (p_first < 0)
     {
         uinteger_t t_count;
-        MCStringsCountChunks(ctxt, p_chunk_type, p_string, t_count);
+        MCStringsCountChunksInRange(ctxt, p_chunk_type, p_string, p_range, t_count);
         p_first += t_count;
     }
     else
@@ -221,7 +246,16 @@ void MCStringsGetExtentsByExpression(MCExecContext& ctxt, Chunk_term p_chunk_typ
     r_first = p_first;
 }
 
-void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_term p_chunk_type, integer_t p_first, integer_t p_count, integer_t& r_start, integer_t& r_end, bool p_whole_chunk, bool p_further_chunks, bool p_include_chars, integer_t& r_add)
+void MCStringsGetExtentsByExpression(MCExecContext& ctxt, Chunk_term p_chunk_type, integer_t p_first, MCStringRef p_string, integer_t& r_first, integer_t& r_chunk_count)
+{
+    if (MCValueGetTypeCode(p_string) == kMCValueTypeCodeString)
+        return MCStringsGetExtentsByExpressionInRange(ctxt, p_chunk_type, p_first, p_string, MCRangeMake(0, MCStringGetLength((MCStringRef)p_string)), r_first, r_chunk_count);
+    
+    return MCStringsGetExtentsByExpressionInRange(ctxt, p_chunk_type, p_first, p_string, MCRangeMake(0, MCDataGetLength((MCDataRef)p_string)), r_first, r_chunk_count);
+}
+
+// AL-2015-02-10: [[ Bug 14532 ]] Allow chunk marking in a given range, to prevent substring copying in text chunk resolution.
+void MCStringsMarkTextChunkInRange(MCExecContext& ctxt, MCStringRef p_string, MCRange p_range, Chunk_term p_chunk_type, integer_t p_first, integer_t p_count, integer_t& r_start, integer_t& r_end, bool p_whole_chunk, bool p_further_chunks, bool p_include_chars, integer_t& r_add)
 {
     r_add = 0;
     if (p_count == 0 && p_chunk_type != CT_CHARACTER && p_chunk_type != CT_WORD)
@@ -231,7 +265,9 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
         return;
     }
     
-    uindex_t t_length = MCStringGetLength(p_string);
+    uindex_t t_string_length;
+    t_string_length = MCStringGetLength(p_string);
+    uindex_t t_length = p_range . offset + p_range . length > t_string_length ? t_string_length : p_range . offset + p_range . length;
     
     if (t_length == 0)
     {
@@ -242,7 +278,7 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
     }
     
     uindex_t t_end_index = t_length - 1;
-    uindex_t t_offset = 0;
+    uindex_t t_offset = p_range . offset;
     
     switch (p_chunk_type)
     {
@@ -256,7 +292,7 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
             MCRange t_found_range;
             
             // calculate the start of the (p_first)th line or item
-            while (p_first && MCStringFind(p_string, MCRangeMake(t_offset, UINDEX_MAX), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
+            while (p_first && MCStringFind(p_string, MCRangeMake(t_offset, t_length - t_offset), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
             {
                 p_first--;
                 t_offset = t_found_range . offset + t_found_range . length;
@@ -275,7 +311,7 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
             // calculate the length of the next p_count lines / items
             while (p_count--)
             {
-                if (t_offset > t_end_index || !MCStringFind(p_string, MCRangeMake(t_offset, UINDEX_MAX), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
+                if (t_offset > t_end_index || !MCStringFind(p_string, MCRangeMake(t_offset, t_length - t_offset), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
                 {
                     r_end = t_length;
                     break;
@@ -313,7 +349,7 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
             while (p_first)
             {
                 t_pg_offset = t_offset;
-                t_newline_found = MCStringFirstIndexOfChar(p_string, '\n', t_offset, kMCCompareExact, t_offset);
+                t_newline_found = MCStringFirstIndexOfCharInRange(p_string, '\n', MCRangeMake(t_offset, t_length - t_offset), kMCCompareExact, t_offset);
                 // AL-2014-07-21: [[ Bug 12162 ]] Ignore PS when calculating paragraph chunk.                
                 t_pg_found = false; /*MCStringFirstIndexOfChar(p_string, 0x2029, t_pg_offset, kMCCompareExact, t_pg_offset);*/
                 
@@ -341,8 +377,8 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
                 // AL-2014-05-26: [[ Bug 12527 ]] Make sure both newline and pg char are found if both present
                 if (t_offset <= t_end_index)
                 {
-                    t_newline_found = MCStringFirstIndexOfChar(p_string, '\n', t_offset, kMCCompareExact, t_offset);
-                    t_pg_found = MCStringFirstIndexOfChar(p_string, 0x2029, t_pg_offset, kMCCompareExact, t_pg_offset);
+                    t_newline_found = MCStringFirstIndexOfCharInRange(p_string, '\n', MCRangeMake(t_offset, t_length - t_offset), kMCCompareExact, t_offset);
+                    t_pg_found = MCStringFirstIndexOfCharInRange(p_string, 0x2029, MCRangeMake(t_pg_offset, t_length - t_pg_offset), kMCCompareExact, t_pg_offset);
                 }
                 else
                 {
@@ -377,16 +413,22 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
         case CT_SENTENCE:
         case CT_TRUEWORD:
         {
+            MCAutoStringRef t_string;
+            if (t_offset > 0 || t_length < MCStringGetLength(p_string))
+                /* UNCHECKED */ MCStringCopySubstring(p_string, p_range, &t_string);
+            else
+                t_string = p_string;
+            
             // Resolve the indices
             MCRange t_range, t_cu_range;
             t_range = MCRangeMake(p_first, p_count);
             if (p_chunk_type == CT_SENTENCE)
-                /* UNCHECKED */ MCStringMapSentenceIndices(p_string, kMCBasicLocale, t_range, t_cu_range);
+                /* UNCHECKED */ MCStringMapSentenceIndices(*t_string, kMCBasicLocale, t_range, t_cu_range);
             else
-                /* UNCHECKED */ MCStringMapTrueWordIndices(p_string, kMCBasicLocale, t_range, t_cu_range);
+                /* UNCHECKED */ MCStringMapTrueWordIndices(*t_string, kMCBasicLocale, t_range, t_cu_range);
                 
-            r_start = t_cu_range.offset;
-            r_end = t_cu_range.offset + t_cu_range.length;
+            r_start = t_offset + t_cu_range.offset;
+            r_end = MCU_min(t_offset + t_cu_range.offset + t_cu_range.length, t_length);
             //r_start = p_first;
             //r_end = p_first + p_count;
         }
@@ -394,6 +436,7 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
             
         case CT_WORD:
         {
+
             uindex_t t_space_offset;
             
             // if there are consecutive spaces at the beginning, skip them
@@ -412,6 +455,9 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
             {
                 MCStringsSkipWord(ctxt, p_string, p_count != 0, t_offset);
             }
+            
+            if (t_offset > t_length)
+                t_offset = t_length;
             
             r_end = t_offset;
             
@@ -437,7 +483,13 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
             
         case CT_TOKEN:
         {
-            MCScriptPoint sp(p_string);
+            MCAutoStringRef t_string;
+            if (t_offset > 0 || t_length < MCStringGetLength(p_string))
+            /* UNCHECKED */ MCStringCopySubstring(p_string, p_range, &t_string);
+            else
+                t_string = p_string;
+            
+            MCScriptPoint sp(*t_string);
             MCerrorlock++;
             
             uint2 t_pos;
@@ -459,13 +511,19 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
         case CT_CODEPOINT:
             if (p_include_chars)
             {
+                MCAutoStringRef t_string;
+                if (t_offset > 0 || t_length < MCStringGetLength(p_string))
+                /* UNCHECKED */ MCStringCopySubstring(p_string, p_range, &t_string);
+                else
+                    t_string = p_string;
+                
                 // Resolve the indices
                 MCRange t_cp_range, t_cu_range;
                 t_cp_range = MCRangeMake(p_first, p_count);
-                MCStringMapIndices(p_string, p_chunk_type == CT_CHARACTER ? kMCCharChunkTypeGrapheme : kMCCharChunkTypeCodepoint, t_cp_range, t_cu_range);
+                MCStringMapIndices(*t_string, p_chunk_type == CT_CHARACTER ? kMCCharChunkTypeGrapheme : kMCCharChunkTypeCodepoint, t_cp_range, t_cu_range);
         
-                r_start = t_cu_range.offset;
-                r_end = t_cu_range.offset + t_cu_range.length;
+                r_start = t_offset + t_cu_range.offset;
+                r_end = t_offset + t_cu_range.offset + t_cu_range.length;
                 //r_start = p_first;
                 //r_end = p_first + p_count;
             }
@@ -474,8 +532,8 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
         case CT_BYTE:
             if (p_include_chars)
             {
-                r_start = p_first;
-                r_end = p_first + p_count;
+                r_start = p_first + t_offset;
+                r_end = MCU_min(p_first + t_offset + p_count, t_offset + t_length);
             }
             break;
         default:
@@ -490,6 +548,11 @@ void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_ter
 //    MCStringMapIndices(p_string, kMCCharChunkTypeCodepoint, t_cp_range, t_cu_range);
 //    r_start = t_cu_range . offset;
 //    r_end = t_cu_range . offset + t_cu_range . length;
+}
+
+void MCStringsMarkTextChunk(MCExecContext& ctxt, MCStringRef p_string, Chunk_term p_chunk_type, integer_t p_first, integer_t p_count, integer_t& r_start, integer_t& r_end, bool p_whole_chunk, bool p_further_chunks, bool p_include_chars, integer_t& r_add)
+{
+    MCStringsMarkTextChunkInRange(ctxt, p_string, MCRangeMake(0, MCStringGetLength(p_string)), p_chunk_type, p_first, p_count, r_start, r_end, p_whole_chunk, p_further_chunks, p_include_chars, r_add);
 }
 
 void MCStringsGetTextChunk(MCExecContext& ctxt, MCStringRef p_source, Chunk_term p_chunk_type, integer_t p_first, integer_t p_count, bool p_eval_mutable, MCStringRef& r_result)
@@ -929,24 +992,17 @@ void MCStringsMarkTextChunkByRange(MCExecContext& ctxt, Chunk_term p_chunk_type,
     MCRange t_cu_range;
     t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
     
-    MCAutoStringRef t_string;
-    MCStringCopySubstring((MCStringRef)x_mark . text, t_cu_range, &t_string);
-    
     int4 t_first;
     int4 t_chunk_count;
-    MCStringsGetExtentsByRange(ctxt, p_chunk_type, p_first, p_last, *t_string, t_first, t_chunk_count);
+    MCStringsGetExtentsByRangeInRange(ctxt, p_chunk_type, p_first, p_last, x_mark . text, t_cu_range, t_first, t_chunk_count);
     
     int4 t_add;
     int4 t_start, t_end;
-    MCStringsMarkTextChunk(ctxt, *t_string, p_chunk_type, t_first, t_chunk_count, t_start, t_end, p_whole_chunk, p_further_chunks, true, t_add);
+    MCStringsMarkTextChunkInRange(ctxt, (MCStringRef)x_mark . text, t_cu_range, p_chunk_type, t_first, t_chunk_count, t_start, t_end, p_whole_chunk, p_further_chunks, true, t_add);
     
-    // The indices returned by MarkTextChunk are code unit indices
-    t_cu_range.offset += t_start;
-    t_cu_range.length = t_end - t_start;
-    
-    x_mark . start = t_cu_range.offset;
-    x_mark . finish = t_cu_range.offset + t_cu_range.length;
-    
+    x_mark . start = t_start;
+    x_mark . finish = t_end;
+
     if (p_force)
         MCStringsAddChunks(ctxt, p_chunk_type, t_add, x_mark);
 }
@@ -957,12 +1013,9 @@ void MCStringsMarkTextChunkByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_typ
     MCRange t_cu_range;
     t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
     
-    MCAutoStringRef t_string;
-    MCStringCopySubstring((MCStringRef)x_mark . text, t_cu_range, &t_string);
-    
     int4 t_first;
     int4 t_chunk_count;
-    MCStringsGetExtentsByOrdinal(ctxt, p_chunk_type, p_ordinal_type, *t_string, t_first, t_chunk_count);
+    MCStringsGetExtentsByOrdinalInRange(ctxt, p_chunk_type, p_ordinal_type, x_mark . text, t_cu_range, t_first, t_chunk_count);
     
     // SN-2014-12-15: [[ Bug 14211 ]] MCStringsGetExtensByOrdinal may throw an error.
     // The release of x_mark.text will be done in MCChunk::evalobjectchunk
@@ -971,7 +1024,7 @@ void MCStringsMarkTextChunkByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_typ
     
     int4 t_add;
     int4 t_start, t_end;
-    MCStringsMarkTextChunk(ctxt, *t_string, p_chunk_type, t_first, t_chunk_count, t_start, t_end, p_whole_chunk, p_further_chunks, true, t_add);
+    MCStringsMarkTextChunkInRange(ctxt, (MCStringRef)x_mark . text, t_cu_range, p_chunk_type, t_first, t_chunk_count, t_start, t_end, p_whole_chunk, p_further_chunks, true, t_add);
     
     // The indices returned by MarkTextChunk are code unit indices
     t_cu_range.offset += t_start;
@@ -1086,19 +1139,16 @@ void MCStringsMarkCodeunitsOfTextByOrdinal(MCExecContext& ctxt, Chunk_term p_ord
 
 void MCStringsMarkBytesOfTextByRange(MCExecContext& ctxt, integer_t p_first, integer_t p_last, MCMarkedText& x_mark)
 {
+    // The incoming indices are for codeunits
+    MCRange t_cu_range;
+    t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
+    
     // AL-2014-09-10: [[ Bug 13400 ]] Keep marked strings the correct type where possible
-    // Cut the string down, and then convert to data if it is not already data
     if (MCValueGetTypeCode(x_mark . text) != kMCValueTypeCodeData)
     {
-        // The incoming indices are for codeunits
-        MCRange t_cu_range;
-        t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
-        
-        MCAutoStringRef t_string;
-        MCStringCopySubstring((MCStringRef)x_mark . text, t_cu_range, &t_string);
-        
+        // Convert to data if it is not already data
         MCAutoDataRef t_data;
-        ctxt . ConvertToData(*t_string, &t_data);
+        ctxt . ConvertToData((MCStringRef)x_mark . text, &t_data);
         
         MCValueRelease(x_mark . text);
         x_mark . text = MCValueRetain(*t_data);
@@ -1106,36 +1156,33 @@ void MCStringsMarkBytesOfTextByRange(MCExecContext& ctxt, integer_t p_first, int
     
     int4 t_first;
     int4 t_chunk_count;
-    MCStringsGetExtentsByRange(ctxt, CT_BYTE, p_first, p_last, x_mark . text, t_first, t_chunk_count);
+    MCStringsGetExtentsByRangeInRange(ctxt, CT_BYTE, p_first, p_last, x_mark . text, t_cu_range, t_first, t_chunk_count);
     
-    // convert codeunit indices to byte indices
-    x_mark . start = x_mark . start + t_first;
+    // adjust the byte indices
+    x_mark . start = t_cu_range . offset + t_first;
     x_mark . finish = x_mark . start + t_chunk_count;
 }
 
 void MCStringsMarkBytesOfTextByOrdinal(MCExecContext& ctxt, Chunk_term p_ordinal_type, MCMarkedText& x_mark)
 {
+    // The incoming indices are for codeunits
+    MCRange t_cu_range;
+    t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
+    
     // AL-2014-09-10: [[ Bug 13400 ]] Keep marked strings the correct type where possible
-    // Cut the string down, and then convert to data if it is not already data
     if (MCValueGetTypeCode(x_mark . text) != kMCValueTypeCodeData)
     {
-        // The incoming indices are for codeunits
-        MCRange t_cu_range;
-        t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
-        
-        MCAutoStringRef t_string;
-        MCStringCopySubstring((MCStringRef)x_mark . text, t_cu_range, &t_string);
-        
         MCAutoDataRef t_data;
-        ctxt . ConvertToData(*t_string, &t_data);
+        ctxt . ConvertToData((MCStringRef)x_mark . text, &t_data);
         
         MCValueRelease(x_mark . text);
         x_mark . text = MCValueRetain(*t_data);
     }
     int4 t_first;
     int4 t_chunk_count;
-    MCStringsGetExtentsByOrdinal(ctxt, CT_BYTE, p_ordinal_type, x_mark . text, t_first, t_chunk_count);
+    MCStringsGetExtentsByOrdinalInRange(ctxt, CT_BYTE, p_ordinal_type, x_mark . text, t_cu_range, t_first, t_chunk_count);
     
-    x_mark . start = x_mark . start + t_first;
+    // adjust the byte indices
+    x_mark . start = t_cu_range . offset + t_first;
     x_mark . finish = x_mark . start + t_chunk_count;
 }


### PR DESCRIPTION
Every time part of a text chunk expression is resolved, the previously calculated code unit indices were used to create a substring. This also happened at the beginning of text chunk resolution. Therefore every text chunk resolution involved at least one unnecessary copy.

Now parts of text chunk expressions modify the range accordingly, thereby preventing any copying of substrings of the underlying string until the final evaluation (or potentially not at all if this is a 'put into').
