### PR TITLE
[[ LCB ]] Implement simple constants.

### DIFF
--- a/libscript/include/script.h
+++ b/libscript/include/script.h
@@ -283,6 +283,9 @@ void MCScriptAddImportToModule(MCScriptModuleBuilderRef builder, uindex_t module
 void MCScriptAddImportToModuleWithIndex(MCScriptModuleBuilderRef builder, uindex_t module_index, MCNameRef definition, MCScriptDefinitionKind kind, uindex_t type, uindex_t p_index);
 
 void MCScriptAddValueToModule(MCScriptModuleBuilderRef builder, MCValueRef value, uindex_t& r_index);
+void MCScriptBeginListValueInModule(MCScriptModuleBuilderRef builder);
+void MCScriptContinueListValueInModule(MCScriptModuleBuilderRef builder, uindex_t index);
+void MCScriptEndListValueInModule(MCScriptModuleBuilderRef builder, uindex_t& r_index);
 
 void MCScriptAddDefinedTypeToModule(MCScriptModuleBuilderRef builder, uindex_t index, uindex_t& r_type);
 void MCScriptAddForeignTypeToModule(MCScriptModuleBuilderRef builder, MCStringRef p_binding, uindex_t& r_type);

--- a/libscript/include/script.h
+++ b/libscript/include/script.h
@@ -282,6 +282,8 @@ void MCScriptAddExportToModule(MCScriptModuleBuilderRef builder, uindex_t index)
 void MCScriptAddImportToModule(MCScriptModuleBuilderRef builder, uindex_t module_index, MCNameRef definition, MCScriptDefinitionKind kind, uindex_t type, uindex_t& r_index);
 void MCScriptAddImportToModuleWithIndex(MCScriptModuleBuilderRef builder, uindex_t module_index, MCNameRef definition, MCScriptDefinitionKind kind, uindex_t type, uindex_t p_index);
 
+void MCScriptAddValueToModule(MCScriptModuleBuilderRef builder, MCValueRef value, uindex_t& r_index);
+
 void MCScriptAddDefinedTypeToModule(MCScriptModuleBuilderRef builder, uindex_t index, uindex_t& r_type);
 void MCScriptAddForeignTypeToModule(MCScriptModuleBuilderRef builder, MCStringRef p_binding, uindex_t& r_type);
 void MCScriptAddOptionalTypeToModule(MCScriptModuleBuilderRef builder, uindex_t type, uindex_t& r_new_type);
@@ -295,7 +297,7 @@ void MCScriptEndRecordTypeInModule(MCScriptModuleBuilderRef builder, uindex_t& r
 void MCScriptAddDefinitionToModule(MCScriptModuleBuilderRef builder, uindex_t& r_index);
 
 void MCScriptAddTypeToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index);
-void MCScriptAddConstantToModule(MCScriptModuleBuilderRef builder, MCNameRef name, MCValueRef value, uindex_t index);
+void MCScriptAddConstantToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t const_idx, uindex_t index);
 void MCScriptAddVariableToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index);
 
 void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t signature, uindex_t index);
@@ -329,7 +331,7 @@ void MCScriptEmitJumpIfUndefinedInModule(MCScriptModuleBuilderRef builder, uinde
 void MCScriptEmitJumpIfDefinedInModule(MCScriptModuleBuilderRef builder, uindex_t value_reg, uindex_t target_label);
 void MCScriptEmitJumpIfFalseInModule(MCScriptModuleBuilderRef builder, uindex_t value_reg, uindex_t target_label);
 void MCScriptEmitJumpIfTrueInModule(MCScriptModuleBuilderRef builder, uindex_t value_reg, uindex_t target_label);
-void MCScriptEmitAssignConstantInModule(MCScriptModuleBuilderRef builder, uindex_t dst_reg, MCValueRef constant);
+void MCScriptEmitAssignConstantInModule(MCScriptModuleBuilderRef builder, uindex_t dst_reg, uindex_t const_idx);
 void MCScriptEmitAssignInModule(MCScriptModuleBuilderRef builder, uindex_t dst_reg, uindex_t src_reg);
 void MCScriptEmitBeginAssignListInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
 void MCScriptEmitContinueAssignListInModule(MCScriptModuleBuilderRef builder, uindex_t reg);

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -274,6 +274,14 @@ void MCScriptAddDefinitionToModule(MCScriptModuleBuilderRef self, uindex_t& r_in
     }
 }
 
+void MCScriptAddValueToModule(MCScriptModuleBuilderRef self, MCValueRef p_value, uindex_t& r_index)
+{
+    if (self == nil || !self -> valid)
+        return;
+    
+    __emit_constant(self, p_value, r_index);
+}
+
 void MCScriptAddTypeToModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, uindex_t p_index)
 {
     if (self == nil || !self -> valid)
@@ -296,7 +304,7 @@ void MCScriptAddTypeToModule(MCScriptModuleBuilderRef self, MCNameRef p_name, ui
     t_definition -> type = p_type;
 }
 
-void MCScriptAddConstantToModule(MCScriptModuleBuilderRef self, MCNameRef p_name, MCValueRef p_value, uindex_t p_index)
+void MCScriptAddConstantToModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_const_idx, uindex_t p_index)
 {
     if (self == nil || !self -> valid)
         return;
@@ -315,7 +323,7 @@ void MCScriptAddConstantToModule(MCScriptModuleBuilderRef self, MCNameRef p_name
     t_definition = static_cast<MCScriptConstantDefinition *>(self -> module . definitions[p_index]);
     
     t_definition -> kind = kMCScriptDefinitionKindConstant;
-    t_definition -> value = MCValueRetain(p_value);
+    t_definition -> value = p_const_idx;
 }
 
 void MCScriptAddVariableToModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, uindex_t p_index)
@@ -988,7 +996,7 @@ static void __emit_constant(MCScriptModuleBuilderRef self, MCValueRef p_constant
     for(uindex_t i = 0; i < self -> module . value_count; i++)
         if (MCValueIsEqualTo(p_constant, self -> module . values[i]))
         {
-            r_index = i + 1;
+            r_index = i;
             return;
         }
     
@@ -998,7 +1006,7 @@ static void __emit_constant(MCScriptModuleBuilderRef self, MCValueRef p_constant
     
     self -> module . values[t_vindex] = MCValueRetain(p_constant);
     
-    r_index = t_vindex + 1;
+    r_index = t_vindex;
 }
 
 static void __begin_instruction(MCScriptModuleBuilderRef self, MCScriptBytecodeOp p_operation)
@@ -1277,15 +1285,12 @@ void MCScriptEmitJumpIfTrueInModule(MCScriptModuleBuilderRef self, uindex_t p_va
     __emit_instruction(self, kMCScriptBytecodeOpJumpIfTrue, 2, p_value_reg, p_target_label);
 }
 
-void MCScriptEmitAssignConstantInModule(MCScriptModuleBuilderRef self, uindex_t p_reg, MCValueRef p_constant)
+void MCScriptEmitAssignConstantInModule(MCScriptModuleBuilderRef self, uindex_t p_reg, uindex_t p_const_idx)
 {
     if (self == nil || !self -> valid)
         return;
     
-    uindex_t t_constant_index;
-    __emit_constant(self, p_constant, t_constant_index);
-    
-    __emit_instruction(self, kMCScriptBytecodeOpAssignConstant, 2, p_reg, t_constant_index - 1);
+    __emit_instruction(self, kMCScriptBytecodeOpAssignConstant, 2, p_reg, p_const_idx);
 }
 
 void MCScriptEmitBeginAssignListInModule(MCScriptModuleBuilderRef self, uindex_t p_reg)

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -2122,8 +2122,10 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                 MCScriptDefinition *t_definition;
                 MCScriptResolveDefinitionInFrame(t_frame, t_index, t_instance, t_definition);
                 
-                // Fetch the value - if it is a variable fetch from the slot; if
-                // it is a handler construct a handler value.
+                // Fetch the value:
+                //   - variables get fetched from the slot
+                //   - constants from the constant pool
+                //   - handlers have a value constructed
                 if (t_definition -> kind == kMCScriptDefinitionKindVariable)
                 {
                     MCScriptVariableDefinition *t_var_definition;
@@ -2138,6 +2140,18 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                     
                     if (t_success)
                         t_success = MCScriptCheckedStoreToRegisterInFrame(t_frame, t_dst, t_value);
+                }
+                else if (t_definition -> kind == kMCScriptDefinitionKindConstant)
+                {
+                    MCScriptConstantDefinition *t_constant_definition;
+                    t_constant_definition = static_cast<MCScriptConstantDefinition *>(t_definition);
+                    
+                    MCValueRef t_value;
+                    t_value = t_instance -> module -> values[t_constant_definition -> value];
+                    
+                    if (t_success)
+                        t_success = MCScriptCheckedStoreToRegisterInFrame(t_frame, t_dst, t_value);
+                    
                 }
                 else if (t_definition -> kind == kMCScriptDefinitionKindHandler)
                 {

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -118,7 +118,7 @@ MC_PICKLE_BEGIN_RECORD(MCScriptTypeDefinition)
 MC_PICKLE_END_RECORD()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptConstantDefinition)
-    MC_PICKLE_VALUEREF(value)
+    MC_PICKLE_UINDEX(value)
 MC_PICKLE_END_RECORD()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptVariableDefinition)
@@ -1088,6 +1088,11 @@ bool MCScriptWriteInterfaceOfModule(MCScriptModuleRef self, MCStreamRef stream)
                         __writeln(stream, "foreign type %@", t_def_name);
                         break;
                 }
+            }
+            break;
+            case kMCScriptDefinitionKindConstant:
+            {
+                __writeln(stream, "constant %@", t_def_name);
             }
             break;
             case kMCScriptDefinitionKindVariable:

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -240,7 +240,7 @@ struct MCScriptTypeDefinition: public MCScriptDefinition
 
 struct MCScriptConstantDefinition: public MCScriptDefinition
 {
-	MCValueRef value;
+	uindex_t value;
 };
 
 struct MCScriptVariableDefinition: public MCScriptDefinition

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -236,8 +236,8 @@
         |]
     
     'rule' Define(ModuleId, constant(Position, Access, Name, Value)):
-        ComputeTypeOfConstantTermExpression(Value -> Type)
-        DefineSymbolId(Name, ModuleId, Access, constant, Type)
+        --ComputeTypeOfConstantTermExpression(Value -> Type)
+        DefineSymbolId(Name, ModuleId, Access, constant, undefined(Position))
     
     'rule' Define(ModuleId, variable(Position, Access, Name, Type)):
         DefineSymbolId(Name, ModuleId, Access, variable, Type)

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -73,7 +73,12 @@
     --
 
     'rule' CheckBindings(DEFINITION'constant(Position, _, _, Value)):
-        /* BD1 */ CheckBindingsOfConstantExpression(Value)
+        --/* BD1 */ CheckBindingsOfConstantExpression(Value)
+        (|
+            IsExpressionSimpleConstant(Value)
+        ||
+            Error_ConstantsMustBeSimple(Position)
+        |)
 
     'rule' CheckBindings(DEFINITION'property(Position, _, _, Getter, OptionalSetter)):
         /* BD2 */ CheckBindingIsVariableOrHandlerId(Getter)
@@ -372,6 +377,26 @@
         Error_NotBoundToASyntaxMark(Position, Name)
         -- Mark this id as being in error.
         Id'Meaning <- error
+
+'condition' IsExpressionSimpleConstant(EXPRESSION)
+
+    'rule' IsExpressionSimpleConstant(undefined(_)):
+    'rule' IsExpressionSimpleConstant(true(_)):
+    'rule' IsExpressionSimpleConstant(false(_)):
+    'rule' IsExpressionSimpleConstant(integer(_, _)):
+    'rule' IsExpressionSimpleConstant(real(_, _)):
+    'rule' IsExpressionSimpleConstant(string(_, _)):
+    'rule' IsExpressionSimpleConstant(list(_, List)):
+        IsExpressionListSimpleConstant(List)
+        
+'condition' IsExpressionListSimpleConstant(EXPRESSIONLIST)
+
+    'rule' IsExpressionListSimpleConstant(expressionlist(Head, Tail)):
+        IsExpressionSimpleConstant(Head)
+        IsExpressionListSimpleConstant(Tail)
+
+    'rule' IsExpressionListSimpleConstant(nil):
+        -- nothing
 
 --------------------------------------------------------------------------------
 

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -127,6 +127,9 @@ extern "C" void EmitFalseConstant(long *idx);
 extern "C" void EmitIntegerConstant(long value, long *idx);
 extern "C" void EmitRealConstant(long value, long *idx);
 extern "C" void EmitStringConstant(long value, long *idx);
+extern "C" void EmitBeginListConstant(void);
+extern "C" void EmitContinueListConstant(long idx);
+extern "C" void EmitEndListConstant(long *idx);
 extern "C" void EmitBeginAssignList(long reg);
 extern "C" void EmitContinueAssignList(long reg);
 extern "C" void EmitEndAssignList(void);
@@ -1117,6 +1120,24 @@ void EmitStringConstant(long value, long *idx)
     MCStringCreateWithBytes((const byte_t *)value, strlen((const char *)value), kMCStringEncodingUTF8, false, &t_string);
     MCScriptAddValueToModule(s_builder, *t_string, (uindex_t&)*idx);
     MCLog("[Emit] StringConstant(\"%s\" -> %ld)", (const char *)value, *idx);
+}
+
+void EmitBeginListConstant(void)
+{
+    MCScriptBeginListValueInModule(s_builder);
+    MCLog("[Emit] BeginListConstant()", 0);
+}
+
+void EmitContinueListConstant(long idx)
+{
+    MCScriptContinueListValueInModule(s_builder, idx);
+    MCLog("[Emit] ContinueListConstant(%ld)", idx);
+}
+
+void EmitEndListConstant(long *idx)
+{
+    MCScriptEndListValueInModule(s_builder, (uindex_t&)*idx);
+    MCLog("[Emit] EndListConstant(-> %ld)", *idx);
 }
 
 void EmitBeginAssignList(long reg)

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -477,7 +477,7 @@
         GenerateDefinitionIndex(Name)
     
     'rule' GenerateDefinitionIndexes(constant(_, _, Name, _)):
-        -- GenerateDefinitionIndex(Name)
+        GenerateDefinitionIndex(Name)
     
     'rule' GenerateDefinitionIndexes(variable(_, _, Name, _)):
         GenerateDefinitionIndex(Name)
@@ -611,7 +611,28 @@
         
     'rule' GenerateDefinitions(constant(Position, _, Id, Value)):
         QuerySymbolId(Id -> Info)
-        -- Do something
+        Id'Name -> Name
+        Info'Index -> DefIndex
+        (|
+            where(Value -> undefined(_))
+            EmitUndefinedConstant(-> Index)
+        ||
+            where(Value -> true(_))
+            EmitTrueConstant(-> Index)
+        ||
+            where(Value -> false(_))
+            EmitFalseConstant(-> Index)
+        ||
+            where(Value -> integer(_, IntValue))
+            EmitIntegerConstant(IntValue -> Index)
+        ||
+            where(Value -> real(_, RealValue))
+            EmitRealConstant(RealValue -> Index)
+        ||
+            where(Value -> string(_, StringValue))
+            EmitStringConstant(StringValue -> Index)
+        |)
+        EmitConstantDefinition(DefIndex, Position, Name, Index)
         
     'rule' GenerateDefinitions(variable(Position, _, Id, Type)):
         GenerateType(Type -> TypeIndex)
@@ -1594,6 +1615,42 @@
 
     'rule' GenerateAssignList(nil):
         -- finished
+
+'action' EmitAssignUndefined(INT)
+
+    'rule' EmitAssignUndefined(Reg):
+        EmitUndefinedConstant(-> Index)
+        EmitAssignConstant(Reg, Index)
+
+'action' EmitAssignTrue(INT)
+
+    'rule' EmitAssignTrue(Reg):
+        EmitTrueConstant(-> Index)
+        EmitAssignConstant(Reg, Index)
+
+'action' EmitAssignFalse(INT)
+
+    'rule' EmitAssignFalse(Reg):
+        EmitFalseConstant(-> Index)
+        EmitAssignConstant(Reg, Index)
+
+'action' EmitAssignInteger(INT, INT)
+
+    'rule' EmitAssignInteger(Reg, Value):
+        EmitIntegerConstant(Value -> Index)
+        EmitAssignConstant(Reg, Index)
+
+'action' EmitAssignReal(INT, DOUBLE)
+
+    'rule' EmitAssignReal(Reg, Value):
+        EmitRealConstant(Value -> Index)
+        EmitAssignConstant(Reg, Index)
+        
+'action' EmitAssignString(INT, STRING)
+
+    'rule' EmitAssignString(Reg, Value):
+        EmitStringConstant(Value -> Index)
+        EmitAssignConstant(Reg, Index)
 
 'action' EmitStoreVar(SYMBOLKIND, INT, INT)
 

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1567,7 +1567,7 @@
         (|
             IsExpressionSimpleConstant(List)
             EmitConstant(List -> Index)
-            EmitAssignConstant(Result, Index)
+            EmitAssignConstant(Output, Index)
         ||
             GenerateExpressionList(Result, Context, Elements -> ListRegs)
             EmitBeginAssignList(Output)

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -180,6 +180,12 @@
     'rule' ImportDefinition(-> type(Position, public, Id, foreign(Position, ""))):
         "foreign" @(-> Position) "type" Identifier(-> Id)
     
+    'rule' ImportDefinition(-> constant(Position, public, Id, nil)):
+        "constant" @(-> Position) Identifier(-> Id)
+
+    'rule' ImportDefinition(-> variable(Position, public, Id, Type)):
+        "variable" @(-> Position) Identifier(-> Id) "as" Type(-> Type)
+
     'rule' ImportDefinition(-> handler(Position, public, Id, Signature, nil, nil)):
         "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
 

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -289,7 +289,7 @@
 'nonterm' ConstantDefinition(-> DEFINITION)
 
     'rule' ConstantDefinition(-> constant(Position, Access, Name, Value)):
-        Access(-> Access) "constant" @(-> Position) Identifier(-> Name) "is" ConstantTermExpression(-> Value)
+        Access(-> Access) "constant" @(-> Position) Identifier(-> Name) "is" Expression(-> Value)
 
 'nonterm' Access(-> ACCESS)
 
@@ -852,6 +852,14 @@
     'rule' TermExpression(-> Expression):
         "(" Expression(-> Expression) ")"
 
+/*'nonterm' ConstantTermExpressionList(-> EXPRESSIONLIST)
+
+    'rule' ConstantTermExpressionList(-> expressionlist(Head, Tail)):
+        ConstantTermExpression(-> Head) "," ConstantTermExpressionList(-> Tail)
+        
+    'rule' ConstantTermExpressionList(-> expressionlist(Tail, nil)):
+        ConstantTermExpression(-> Tail)*/
+
 'nonterm' ConstantTermExpression(-> EXPRESSION)
 
     'rule' ConstantTermExpression(-> undefined(Position)):
@@ -871,6 +879,12 @@
 
     'rule' ConstantTermExpression(-> string(Position, Value)):
         StringLiteral(-> Value) @(-> Position)
+        
+/*    'rule' ConstantTermExpression(-> list(Position, Value)):
+        "[" @(-> Position) ConstantTermExpressionList(-> Value) "]"
+        
+    'rule' ConstantTermExpression(-> list(Position, nil)):
+        "[" @(-> Position) "]"*/
 
 ----------
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -183,6 +183,8 @@ DEFINE_ERROR_I(CannotAssignToConstantId, "'%s' is a constant id and cannot be as
 
 DEFINE_ERROR(NonHandlerTypeVariablesCannotBeCalled, "Variables must have handler type to be called")
 
+DEFINE_ERROR(ConstantsMustBeSimple, "Constant definitions must be a simple expression (i.e. a direct constant or list of direct constants)")
+
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(long p_position) { _Warning(p_position, Message); }
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -141,6 +141,7 @@ DEFINE_ERROR_I(SyntaxMarkVariableAlreadyDefinedWithDifferentType, "Mark variable
 DEFINE_ERROR_I(NotBoundToAHandler, "'%s' is not a handler")
 DEFINE_ERROR_I(NotBoundToAVariable, "'%s' is not a variable")
 DEFINE_ERROR_I(NotBoundToAVariableOrHandler, "'%s' is not a variable or handler")
+DEFINE_ERROR_I(NotBoundToAConstantOrVariableOrHandler, "'%s' is not a constant, a variable nor a handler")
 DEFINE_ERROR_I(NotBoundToAPhrase, "'%s' is not a syntax phrase")
 DEFINE_ERROR_I(NotBoundToASyntaxMark, "'%s' is not a mark variable")
 DEFINE_ERROR_I(NotBoundToASyntaxRule, "'%s' is not a syntax rule")
@@ -178,6 +179,7 @@ DEFINE_ERROR(VariableMustHaveHighLevelType, "Inappropriate type for variable")
 DEFINE_ERROR(ParameterMustHaveHighLevelType, "Inappropriate type for parameter")
 
 DEFINE_ERROR_I(CannotAssignToHandlerId, "'%s' is a handler id and cannot be assigned to")
+DEFINE_ERROR_I(CannotAssignToConstantId, "'%s' is a constant id and cannot be assigned to")
 
 DEFINE_ERROR(NonHandlerTypeVariablesCannotBeCalled, "Variables must have handler type to be called")
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -183,7 +183,7 @@ DEFINE_ERROR_I(CannotAssignToConstantId, "'%s' is a constant id and cannot be as
 
 DEFINE_ERROR(NonHandlerTypeVariablesCannotBeCalled, "Variables must have handler type to be called")
 
-DEFINE_ERROR(ConstantsMustBeSimple, "Constant definitions must be a simple expression (i.e. a direct constant or list of direct constants)")
+DEFINE_ERROR(ConstantsMustBeSimple, "Constant definitions must be a literal expression")
 
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(long p_position) { _Warning(p_position, Message); }

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -207,6 +207,9 @@
     EmitIntegerConstant
     EmitRealConstant
     EmitStringConstant
+    EmitBeginListConstant
+    EmitContinueListConstant
+    EmitEndListConstant
     EmitBeginAssignList
     EmitContinueAssignList
     EmitEndAssignList
@@ -284,6 +287,7 @@
     Error_VariableMustHaveHighLevelType
     Error_CannotAssignToHandlerId
     Error_CannotAssignToConstantId
+    Error_ConstantsMustBeSimple
     Error_NonHandlerTypeVariablesCannotBeCalled
     Warning_MetadataClausesShouldComeAfterUseClauses
 
@@ -531,6 +535,9 @@
 'action' EmitIntegerConstant(Value: INT -> ConstIndex: INT)
 'action' EmitRealConstant(Value: DOUBLE -> ConstIndex: INT)
 'action' EmitStringConstant(Value: STRING -> ConstIndex: INT)
+'action' EmitBeginListConstant()
+'action' EmitContinueListConstant(ConstIndex: INT)
+'action' EmitEndListConstant(-> ConstIndex: INT)
 'action' EmitBeginAssignList(Register: INT)
 'action' EmitContinueAssignList(Register: INT)
 'action' EmitEndAssignList()
@@ -622,6 +629,8 @@
 'action' Error_CannotAssignToHandlerId(Position: POS, Identifier: NAME)
 'action' Error_CannotAssignToConstantId(Position: POS, Identifier: NAME)
 'action' Error_NonHandlerTypeVariablesCannotBeCalled(Position: POS)
+
+'action' Error_ConstantsMustBeSimple(Position: POS)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)
 

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -129,6 +129,7 @@
     EmitImportedHandler
     EmitImportedSyntax
     EmitTypeDefinition
+    EmitConstantDefinition
     EmitVariableDefinition
     EmitBeginHandlerDefinition
     EmitEndHandlerDefinition
@@ -199,12 +200,13 @@
     EmitContinueInvoke
     EmitEndInvoke
     EmitAssign
-    EmitAssignUndefined
-    EmitAssignTrue
-    EmitAssignFalse
-    EmitAssignInteger
-    EmitAssignReal
-    EmitAssignString
+    EmitAssignConstant
+    EmitUndefinedConstant
+    EmitTrueConstant
+    EmitFalseConstant
+    EmitIntegerConstant
+    EmitRealConstant
+    EmitStringConstant
     EmitBeginAssignList
     EmitContinueAssignList
     EmitEndAssignList
@@ -254,6 +256,7 @@
     Error_NotBoundToAVariable
     Error_NotBoundToAConstantSyntaxValue
     Error_NotBoundToAVariableOrHandler
+    Error_NotBoundToAConstantOrVariableOrHandler
     Error_TooManyArgumentsPassedToHandler
     Error_TooFewArgumentsPassedToHandler
     Error_HandlersBoundToSyntaxMustNotReturnAValue
@@ -280,6 +283,7 @@
     Error_ParameterMustHaveHighLevelType
     Error_VariableMustHaveHighLevelType
     Error_CannotAssignToHandlerId
+    Error_CannotAssignToConstantId
     Error_NonHandlerTypeVariablesCannotBeCalled
     Warning_MetadataClausesShouldComeAfterUseClauses
 
@@ -441,6 +445,7 @@
 'action' EmitDefinitionIndex(-> Index: INT)
 
 'action' EmitTypeDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
+'action' EmitConstantDefinition(Index: INT, Position: POS, Name: NAME, ConstIndex: INT)
 'action' EmitVariableDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitBeginHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitEndHandlerDefinition()
@@ -518,16 +523,17 @@
 'action' EmitBeginInvoke(Index: INT, ContextRegister: INT, ResultRegister: INT)
 'action' EmitContinueInvoke(Register: INT)
 'action' EmitEndInvoke()
-'action' EmitAssignUndefined(Register: INT)
-'action' EmitAssignTrue(Register: INT)
-'action' EmitAssignFalse(Register: INT)
-'action' EmitAssignInteger(Register: INT, Value: INT)
-'action' EmitAssignReal(Register: INT, Value: DOUBLE)
-'action' EmitAssignString(Register: INT, Value: STRING)
+'action' EmitAssign(Dst: INT, Src: INT)
+'action' EmitAssignConstant(Register: INT, ConstIndex: INT)
+'action' EmitUndefinedConstant(-> ConstIndex: INT)
+'action' EmitTrueConstant(-> ConstIndex: INT)
+'action' EmitFalseConstant(-> ConstIndex: INT)
+'action' EmitIntegerConstant(Value: INT -> ConstIndex: INT)
+'action' EmitRealConstant(Value: DOUBLE -> ConstIndex: INT)
+'action' EmitStringConstant(Value: STRING -> ConstIndex: INT)
 'action' EmitBeginAssignList(Register: INT)
 'action' EmitContinueAssignList(Register: INT)
 'action' EmitEndAssignList()
-'action' EmitAssign(Dst: INT, Src: INT)
 'action' EmitFetch(Register: INT, Var: INT, Level: INT)
 'action' EmitStore(Register: INT, Var: INT, Level: INT)
 'action' EmitReturn(Register: INT)
@@ -582,6 +588,7 @@
 'action' Error_NotBoundToAHandler(Position: POS, Name: NAME)
 'action' Error_NotBoundToAVariable(Position: POS, Name: NAME)
 'action' Error_NotBoundToAVariableOrHandler(Position: POS, Name: NAME)
+'action' Error_NotBoundToAConstantOrVariableOrHandler(Position: POS, Name: NAME)
 
 'action' Error_NonAssignableExpressionUsedForOutContext(Position: POS)
 'action' Error_NonEvaluatableExpressionUsedForInContext(Position: POS)
@@ -613,6 +620,7 @@
 'action' Error_VariableMustHaveHighLevelType(Position: POS)
 
 'action' Error_CannotAssignToHandlerId(Position: POS, Identifier: NAME)
+'action' Error_CannotAssignToConstantId(Position: POS, Identifier: NAME)
 'action' Error_NonHandlerTypeVariablesCannotBeCalled(Position: POS)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)


### PR DESCRIPTION
Simple constant definitions of the form 'constant ID is VALUE' now work where VALUE is a constant value (undefined, true, false, an integer, a real or a string).

Constants can be public, in which case they will be accessible from other modules.
