### PR TITLE
Implement MCValueCopyDescription() for most types

### DIFF
--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -427,6 +427,11 @@ bool MCCanvasJoinStyleFromString(MCStringRef p_string, MCGJoinStyle &r_style);
 bool MCCanvasCapStyleToString(MCGCapStyle p_style, MCStringRef &r_string);
 bool MCCanvasCapStyleFromString(MCStringRef p_string, MCGCapStyle &r_style);
 
+MCCanvasFloat MCCanvasColorGetRed(MCCanvasColorRef color);
+MCCanvasFloat MCCanvasColorGetGreen(MCCanvasColorRef color);
+MCCanvasFloat MCCanvasColorGetBlue(MCCanvasColorRef color);
+MCCanvasFloat MCCanvasColorGetAlpha(MCCanvasColorRef color);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 static MCNameRef s_blend_mode_map[kMCGBlendModeCount];
@@ -880,8 +885,19 @@ static hash_t __MCCanvasColorHash(MCValueRef p_value)
 
 static bool __MCCanvasColorDescribe(MCValueRef p_value, MCStringRef &r_desc)
 {
-	// TODO - implement describe
-	return false;
+	MCCanvasColorRef t_color = static_cast<MCCanvasColorRef>(p_value);
+
+	if (1 < MCCanvasColorGetAlpha (t_color)) /* Opaque case */
+		return MCStringFormat (r_desc, "<color: %g, %g, %g>",
+		                       MCCanvasColorGetRed (t_color),
+		                       MCCanvasColorGetGreen (t_color),
+		                       MCCanvasColorGetBlue (t_color));
+	else
+		return MCStringFormat (r_desc, "<color: %g, %g, %g, %g>",
+		                       MCCanvasColorGetRed (t_color),
+		                       MCCanvasColorGetGreen (t_color),
+		                       MCCanvasColorGetBlue (t_color),
+		                       MCCanvasColorGetAlpha (t_color));
 }
 
 //////////

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -717,8 +717,10 @@ static hash_t __MCCanvasPointHash(MCValueRef p_value)
 
 static bool __MCCanvasPointDescribe(MCValueRef p_value, MCStringRef &r_desc)
 {
-	// TODO - implement describe point
-	return false;
+	MCGPoint t_point;
+	MCCanvasPointGetMCGPoint (static_cast<MCCanvasPointRef>(p_value), t_point);
+
+	return MCStringFormat (r_desc, "(%g, %g)", t_point.x, t_point.y);
 }
 
 bool MCCanvasPointCreateWithMCGPoint(const MCGPoint &p_point, MCCanvasPointRef &r_point)

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -504,8 +504,14 @@ static hash_t __MCCanvasRectangleHash(MCValueRef p_value)
 
 static bool __MCCanvasRectangleDescribe(MCValueRef p_value, MCStringRef &r_desc)
 {
-	// TODO - implement describe rectangle
-	return false;
+	MCGRectangle t_rectangle;
+	MCCanvasRectangleGetMCGRectangle (static_cast<MCCanvasRectangleRef>(p_value), t_rectangle);
+
+	return MCStringFormat (r_desc, "<rectangle (%g, %g) - (%g, %g)>",
+	                       t_rectangle.origin.x,
+	                       t_rectangle.origin.y,
+	                       t_rectangle.origin.x + t_rectangle.size.width,
+	                       t_rectangle.origin.y + t_rectangle.size.height);
 }
 
 bool MCCanvasRectangleCreateWithMCGRectangle(const MCGRectangle &p_rect, MCCanvasRectangleRef &r_rectangle)

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -1663,8 +1663,14 @@ static hash_t __MCCanvasImageHash(MCValueRef p_value)
 
 static bool __MCCanvasImageDescribe(MCValueRef p_value, MCStringRef &r_desc)
 {
-	// TODO - implement describe
-	return false;
+	MCCanvasImageRef t_image = static_cast<MCCanvasImageRef>(p_value);
+
+	uint32_t t_width, t_height;
+	if (!MCImageRepGetGeometry(MCCanvasImageGetImageRep (t_image),
+	                           t_width, t_height))
+		return MCStringCopy (MCSTR("<image>"), r_desc);
+
+	return MCStringFormat(r_desc, "<image %ux%u>", t_width, t_height);
 }
 
 bool MCCanvasImageCreateWithImageRep(MCImageRep *p_image, MCCanvasImageRef &r_image)

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -887,7 +887,7 @@ static bool __MCCanvasColorDescribe(MCValueRef p_value, MCStringRef &r_desc)
 {
 	MCCanvasColorRef t_color = static_cast<MCCanvasColorRef>(p_value);
 
-	if (1 < MCCanvasColorGetAlpha (t_color)) /* Opaque case */
+	if (1 <= MCCanvasColorGetAlpha (t_color)) /* Opaque case */
 		return MCStringFormat (r_desc, "<color: %g, %g, %g>",
 		                       MCCanvasColorGetRed (t_color),
 		                       MCCanvasColorGetGreen (t_color),

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1413,6 +1413,7 @@ struct MCForeignTypeDescriptor
     bool (*hash)(void *contents, hash_t& r_hash);
     bool (*doimport)(void *contents, bool release, MCValueRef& r_value);
     bool (*doexport)(MCValueRef value, bool release, void *contents);
+	bool (*describe)(void *contents, MCStringRef & r_desc);
 };
 
 MC_DLLEXPORT bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *descriptor, MCTypeInfoRef& r_typeinfo);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2479,6 +2479,7 @@ struct MCHandlerCallbacks
     size_t size;
     void (*release)(void *context);
     bool (*invoke)(void *context, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
+	bool (*describe)(void *context, MCStringRef& r_desc);
 };
 
 MC_DLLEXPORT bool MCHandlerCreate(MCTypeInfoRef typeinfo, const MCHandlerCallbacks *callbacks, void *context, MCHandlerRef& r_handler);

--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -656,7 +656,28 @@ bool __MCArrayIsEqualTo(__MCArray *self, __MCArray *other_self)
 
 bool __MCArrayCopyDescription(__MCArray *self, MCStringRef& r_string)
 {
-	return false;
+	/* Shortcut for empty arrays */
+	if (MCArrayIsEmpty (self))
+		return MCStringCopy (MCSTR("{}"), r_string);
+
+	MCAutoListRef t_contents_list;
+	if (!MCListCreateMutable (MCSTR(", "), &t_contents_list))
+		return false;
+
+	uintptr_t t_iter;
+	MCNameRef t_key;
+	MCValueRef t_value;
+	while (MCArrayIterate (self, t_iter, t_key, t_value))
+	{
+		if (!MCListAppendFormat (*t_contents_list, "%@: %@", t_key, t_value))
+			return false;
+	}
+
+	MCAutoStringRef t_contents_string;
+	if (!MCListCopyAsString (*t_contents_list, &t_contents_string))
+		return false;
+
+	return MCStringFormat(r_string, "{%@}", *t_contents_string);
 }
 
 bool __MCArrayImmutableCopy(__MCArray *self, bool p_release, __MCArray*& r_immutable_self)

--- a/libfoundation/src/foundation-custom.cpp
+++ b/libfoundation/src/foundation-custom.cpp
@@ -58,7 +58,7 @@ bool
 __MCCustomDefaultDescribe (MCValueRef self,
                            MCStringRef & r_desc)
 {
-	return false;
+	return MCStringFormat(r_desc, "<custom: %p>", self);
 }
 
 bool
@@ -73,4 +73,20 @@ __MCCustomDefaultMutableCopy (MCValueRef self,
                               MCValueRef & r_value)
 {
 	return false;
+}
+
+bool
+__MCCustomCopyDescription (MCValueRef self,
+                           MCStringRef & r_desc)
+{
+	MCTypeInfoRef t_typeinfo;
+	t_typeinfo = __MCCustomValueResolveTypeInfo((__MCValue *) self);
+
+	bool (*t_describe_func)(MCValueRef, MCStringRef &);
+	t_describe_func = t_typeinfo -> custom . callbacks . describe;
+
+	if (NULL == t_describe_func)
+		t_describe_func = __MCCustomDefaultDescribe;
+
+	return t_describe_func (self, r_desc);
 }

--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -828,7 +828,8 @@ hash_t __MCDataHash(__MCData *self)
 
 bool __MCDataCopyDescription(__MCData *self, MCStringRef &r_description)
 {
-    return false;
+	return MCStringFormat (r_description, "<data: %u B>",
+	                       MCDataGetLength (self));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-error.cpp
+++ b/libfoundation/src/foundation-error.cpp
@@ -354,7 +354,7 @@ bool __MCErrorIsEqualTo(__MCError *self, __MCError *other_error)
 
 bool __MCErrorCopyDescription(__MCError *self, MCStringRef& r_string)
 {
-    return false;
+	return MCStringCopy (MCErrorGetMessage (self), r_string);
 }
 
 bool __MCErrorInitialize(void)

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -74,7 +74,13 @@ bool __MCHandlerIsEqualTo(__MCHandler *self, __MCHandler *other_self)
 
 bool __MCHandlerCopyDescription(__MCHandler *self, MCStringRef& r_desc)
 {
-    return false;
+	if (NULL != self->callbacks->describe)
+		return self->callbacks->describe(MCHandlerGetContext (self), r_desc);
+
+	/* Default implementation. */
+	/* FIXME Should include information about arguments and return
+	 * values, extracted from the handler's typeinfo. */
+	return MCStringCopy(MCSTR("<handler>"), r_desc);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-list.cpp
+++ b/libfoundation/src/foundation-list.cpp
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <foundation.h>
+#include <foundation-auto.h>
 
 #include "foundation-private.h"
 
@@ -241,7 +242,10 @@ bool __MCListIsEqualTo(__MCList *list, __MCList *other_list)
 
 bool __MCListCopyDescription(__MCList *self, MCStringRef& r_string)
 {
-	return false;
+	MCAutoStringRef t_self_string;
+	if (!MCListCopyAsString (self, &t_self_string))
+		return false;
+	return MCValueCopyDescription(*t_self_string, r_string);
 }
 
 bool __MCListImmutableCopy(__MCList *self, bool p_release, __MCList*& r_immutable_value)

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -556,6 +556,9 @@ void __MCStreamFinalize(void);
 
 /* Default implementations of each of the function members of struct &
  * MCValueCustomCallbacks */
+MCTypeInfoRef __MCCustomValueResolveTypeInfo(__MCValue *p_value);
+bool __MCCustomCopyDescription (MCValueRef self, MCStringRef & r_desc);
+
 void __MCCustomDefaultDestroy(MCValueRef);
 bool __MCCustomDefaultCopy(MCValueRef, bool, MCValueRef &);
 bool __MCCustomDefaultEqual(MCValueRef, MCValueRef);

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -774,7 +774,27 @@ bool __MCProperListIsEqualTo(__MCProperList *self, __MCProperList *other_self)
 
 bool __MCProperListCopyDescription(__MCProperList *self, MCStringRef& r_string)
 {
-	return false;
+	/* Shortcut for empty lists */
+	if (MCProperListIsEmpty (self))
+		return MCStringCopy (MCSTR("[]"), r_string);
+
+	MCAutoListRef t_contents_list;
+	if (!MCListCreateMutable (MCSTR(", "), &t_contents_list))
+		return false;
+
+	uintptr_t t_iter;
+	MCValueRef t_value;
+	while (MCProperListIterate (self, t_iter, t_value))
+	{
+		if (!MCListAppend (*t_contents_list, t_value))
+			return false;
+	}
+
+	MCAutoStringRef t_contents_string;
+	if (!MCListCopyAsString (*t_contents_list, &t_contents_string))
+		return false;
+
+	return MCStringFormat(r_string, "[%@]", *t_contents_string);
 }
 
 bool __MCProperListImmutableCopy(__MCProperList *self, bool p_release, __MCProperList*& r_immutable_self)

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -755,8 +755,6 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 					/* UNCHECKED */ MCStringFormat(&t_string, "%f", MCNumberFetchAsReal((MCNumberRef)t_value));
 			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeBoolean)
                 /* UNCHECKED */ MCStringFormat(&t_string, t_value == kMCTrue ? "<true>" : "<false>");
-			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeNull)
-                /* UNCHECKED */ MCStringFormat(&t_string, "<null>");
             else
 				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);
 

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -757,8 +757,6 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
                 /* UNCHECKED */ MCStringFormat(&t_string, t_value == kMCTrue ? "<true>" : "<false>");
 			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeNull)
                 /* UNCHECKED */ MCStringFormat(&t_string, "<null>");
-            else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeHandler)
-                /* UNCHECKED */ MCStringFormat(&t_string, "<handler>");
             else
 				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);
 

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -746,8 +746,6 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 			MCAutoStringRef t_string;
 			if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeString)
 				t_string = (MCStringRef)t_value;
-			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeName)
-				t_string = MCNameGetString((MCNameRef)t_value);
             else
 				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);
 

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -762,7 +762,7 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
             else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeTypeInfo)
                 /* UNCHECKED */ MCStringFormat(&t_string, "<type>");
             else
-                /* UNCHECKED */ MCStringFormat(&t_string, "<unknown>");
+				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);
 
 			if (t_range == nil)
 				t_success = MCStringAppend(t_buffer, *t_string);

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -748,11 +748,6 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 				t_string = (MCStringRef)t_value;
 			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeName)
 				t_string = MCNameGetString((MCNameRef)t_value);
-			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeNumber)
-				if (MCNumberIsInteger((MCNumberRef)t_value))
-					/* UNCHECKED */ MCStringFormat(&t_string, "%d", MCNumberFetchAsInteger((MCNumberRef)t_value));
-				else
-					/* UNCHECKED */ MCStringFormat(&t_string, "%f", MCNumberFetchAsReal((MCNumberRef)t_value));
 			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeBoolean)
                 /* UNCHECKED */ MCStringFormat(&t_string, t_value == kMCTrue ? "<true>" : "<false>");
             else

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -759,8 +759,6 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
                 /* UNCHECKED */ MCStringFormat(&t_string, "<null>");
             else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeHandler)
                 /* UNCHECKED */ MCStringFormat(&t_string, "<handler>");
-            else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeTypeInfo)
-                /* UNCHECKED */ MCStringFormat(&t_string, "<type>");
             else
 				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);
 

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -748,8 +748,6 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 				t_string = (MCStringRef)t_value;
 			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeName)
 				t_string = MCNameGetString((MCNameRef)t_value);
-			else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeBoolean)
-                /* UNCHECKED */ MCStringFormat(&t_string, t_value == kMCTrue ? "<true>" : "<false>");
             else
 				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);
 

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -1037,7 +1037,25 @@ bool __MCTypeInfoIsEqualTo(__MCTypeInfo *self, __MCTypeInfo *other_self)
 
 bool __MCTypeInfoCopyDescription(__MCTypeInfo *self, MCStringRef& r_description)
 {
-    return false;
+	MCAutoStringRef tOptionalPart;
+	if (MCTypeInfoIsOptional (self))
+		tOptionalPart = MCSTR("optional ");
+	else
+		tOptionalPart = kMCEmptyString;
+
+	MCAutoStringRef tNamePart;
+	if (MCTypeInfoIsNamed (self))
+	{
+		tNamePart = MCNameGetString (MCNamedTypeInfoGetName (self));
+	}
+	else
+	{
+		if (!MCStringFormat (&tNamePart, "unnamed[%p]", self))
+			return false;
+	}
+
+	return MCStringFormat (r_description, "<type: %@%@>",
+	                       *tOptionalPart, *tNamePart);
 }
 
 static bool __create_named_builtin(MCNameRef p_name, MCValueTypeCode p_code, MCTypeInfoRef& r_typeinfo)

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -29,7 +29,7 @@ static void __MCValueUninter(__MCValue *value);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static MCTypeInfoRef __MCCustomValueResolveTypeInfo(__MCValue *p_value)
+MCTypeInfoRef __MCCustomValueResolveTypeInfo(__MCValue *p_value)
 {
     __MCCustomValue *t_value;
     t_value = (__MCCustomValue*)p_value;
@@ -322,15 +322,7 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
     case kMCValueTypeCodeData:
         return __MCDataCopyDescription((__MCData*)p_value, r_desc);
 	case kMCValueTypeCodeCustom:
-		{
-			MCTypeInfoRef t_typeinfo;
-			bool (*t_describe_func)(MCValueRef, MCStringRef &);
-			t_typeinfo = __MCCustomValueResolveTypeInfo(self);
-			t_describe_func = t_typeinfo -> custom . callbacks . describe;
-			return ((t_describe_func != NULL) ?
-			        t_describe_func (p_value, r_desc) :
-			        __MCCustomDefaultDescribe (p_value, r_desc));
-		}
+		return __MCCustomCopyDescription((__MCCustomValue *) p_value, r_desc);
     case kMCValueTypeCodeProperList:
         return __MCProperListCopyDescription((__MCProperList*)p_value, r_desc);
     case kMCValueTypeCodeRecord:

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -306,7 +306,7 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
 	case kMCValueTypeCodeNull:
 		return MCStringCopy (MCSTR("<null>"), r_desc);
 	case kMCValueTypeCodeBoolean:
-		return MCStringFormat(r_desc, "<%s>", p_value == kMCTrue ? "true" : "false");
+		return MCStringCopy (MCSTR(p_value == kMCTrue ? "true" : "false"), r_desc);
 	case kMCValueTypeCodeNumber:
 		return __MCNumberCopyDescription((__MCNumber *)p_value, r_desc);
 	case kMCValueTypeCodeString:

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -344,8 +344,9 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
     case kMCValueTypeCodeForeignValue:
         return __MCForeignValueCopyDescription((__MCForeignValue *)p_value, r_desc);
 	default:
-		break;
+		return MCStringCopy (MCSTR("<unknown>"), r_desc);
 	}
+	MCUnreachable();
 	return false;
 }
 

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -304,7 +304,7 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
 	switch(__MCValueGetTypeCode(self))
 	{
 	case kMCValueTypeCodeNull:
-		return MCStringFormat(r_desc, "<null>");
+		return MCStringCopy (MCSTR("<null>"), r_desc);
 	case kMCValueTypeCodeBoolean:
 		return MCStringFormat(r_desc, "<%s>", p_value == kMCTrue ? "true" : "false");
 	case kMCValueTypeCodeNumber:

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -43,6 +43,7 @@ struct __MCScriptHandlerContext
 extern MCHandlerCallbacks __kMCScriptHandlerCallbacks;
 bool __MCScriptHandlerInvoke(void *context, MCValueRef *p_arguments, uindex_t p_argument_count, MCValueRef& r_value);
 void __MCScriptHandlerRelease(void *context);
+bool __MCScriptHandlerDescribe(void *context, MCStringRef &r_desc);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2342,6 +2343,7 @@ MCHandlerCallbacks __kMCScriptHandlerCallbacks =
     sizeof(__MCScriptHandlerContext),
     __MCScriptHandlerRelease,
     __MCScriptHandlerInvoke,
+	__MCScriptHandlerDescribe,
 };
 
 bool __MCScriptHandlerInvoke(void *p_context, MCValueRef *p_arguments, uindex_t p_argument_count, MCValueRef& r_result)
@@ -2360,6 +2362,26 @@ void __MCScriptHandlerRelease(void *p_context)
     __MCScriptHandlerContext *context;
     context = (__MCScriptHandlerContext *)p_context;
     MCScriptReleaseInstance(context -> instance);
+}
+
+bool
+__MCScriptHandlerDescribe (void *p_context,
+                           MCStringRef & r_desc)
+{
+	__MCScriptHandlerContext *context;
+	context = (__MCScriptHandlerContext *)p_context;
+
+	MCScriptModuleRef t_module;
+	t_module = MCScriptGetModuleOfInstance (context->instance);
+
+	MCNameRef t_module_name;
+	t_module_name = MCScriptGetNameOfModule (t_module);
+
+	MCNameRef t_handler_name;
+	t_handler_name = MCScriptGetNameOfDefinitionInModule(t_module,
+	                                                     context->definition);
+
+	return MCStringFormat(r_desc, "%@.%@()", t_module_name, t_handler_name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
All types other than MCString now use MCValueCopyDescription() for formatting with MCStringFormat().

New formats:

```
"<type: %{name}>"             -- Named type infos
"<type: unnamed(%{pointer})>" -- Unnamed type infos
"<handler>"                   -- Handlers that don't override describe() callback
"module.Handler()"            -- LCB handlers
"{k1: v1, k2: v2}"            -- Arrays
"[v1, v2]"                    -- Proper lists
"v1, v2"                      -- Legacy lists
"<data: 1024 B>"              -- Binary data
"<custom: %{pointer}>" -- Custom values that don't have an overridden describe() callback
"%{message}"                  -- Errors just format as the error message
"<foreign: %{pointer}>" -- Foreign values that don't have an overridden describe() callback
"<foreign %{type} %{value}>"  -- Most builtin foreign types, e.g. "<foreign integer 21>"
"(x, y)"                      -- Canvas points
"<rectangle (x1, y1) - (x2, y2)>" -- Canvas rectangles
"<image %{width}x%{height}>"  -- Canvas images
"<color %{r}, %{g}, %{b}>"    -- Canvas colors (opaque)
"<color %{r}, %{g}, %{b}, %{a}>" -- Canvas colors (non-opaque)
```
