### PR TITLE
[[ Bug 14599 ]] Use exact string comparison for text sort, for consistency with other string operations

### DIFF
--- a/docs/notes/bugfix-14599.md
+++ b/docs/notes/bugfix-14599.md
@@ -1,0 +1,1 @@
+# LCB: Text sort is inconsistent with string comparison

--- a/libscript/src/module-sort.cpp
+++ b/libscript/src/module-sort.cpp
@@ -57,9 +57,9 @@ extern "C" MC_DLLEXPORT void MCSortExecSortList(MCProperListRef& x_target, bool 
     switch (t_type)
     {
         case kMCValueTypeCodeString:
-            // For now, just compare caseless.
+            // AL-2015-02-13: [[ Bug 14599 ]] Use exact comparison here for consistency.
             MCStringOptions t_option;
-            t_option = kMCStringOptionCompareCaseless;
+            t_option = kMCStringOptionCompareExact;
             MCProperListStableSort(*t_mutable_list, p_descending, MCSortCompareText, &t_option);
             break;
         case kMCValueTypeCodeData:
@@ -102,9 +102,9 @@ extern "C" MC_DLLEXPORT void MCSortExecSortListText(MCProperListRef& x_target, b
     if (!MCProperListMutableCopy(x_target, &t_mutable_list))
         return;
     
-    // For now, just compare caseless.
+    // AL-2015-02-13: [[ Bug 14599 ]] Use exact comparison here for consistency.
     MCStringOptions t_option;
-    t_option = kMCStringOptionCompareCaseless;
+    t_option = kMCStringOptionCompareExact;
     MCProperListStableSort(*t_mutable_list, p_descending, MCSortCompareText, &t_option);
     
     MCAutoProperListRef t_sorted_list;

--- a/tests/lcb/stdlib/sort.lcb
+++ b/tests/lcb/stdlib/sort.lcb
@@ -162,11 +162,11 @@ public handler TestAscendingText() -- RANDOMIZED
 	-- Test sorting
 	put tRandom into tList
 	sort tList in ascending text order
-	broken test "sort ascending text" when IsSorted(tList, false) because "bug 14599"
+	test "sort ascending text" when IsSorted(tList, false)
 
 	put tRandom into tList
 	sort tList in ascending order
-	broken test "sort ascending generic (text)" when IsSorted(tList, false) because "bug 14599"
+	test "sort ascending generic (text)" when IsSorted(tList, false)
 
 	-- Test sorting stability
 	variable tStable
@@ -189,11 +189,11 @@ public handler TestDescendingText() -- RANDOMIZED
 	-- Test sorting
 	put tRandom into tList
 	sort tList in descending text order
-	broken test "sort descending text" when IsSorted(tList, true) because "bug 14599"
+	test "sort descending text" when IsSorted(tList, true)
 
 	put tRandom into tList
 	sort tList in descending order
-	broken test "sort descending generic (text)" when IsSorted(tList, true) because "bug 14599"
+	test "sort descending generic (text)" when IsSorted(tList, true)
 
 	-- Test sorting stability
 	variable tStable


### PR DESCRIPTION
Until we are using context variables for case and form sensitivity in string comparison, all comparison in LCB should be case sensitive.
