### PR TITLE
[Bug 14596] libfoundation: MCProperListFirstIndexOfList(): Overflow

### DIFF
--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -448,6 +448,13 @@ bool MCProperListFirstIndexOfList(MCProperListRef self, MCProperListRef p_needle
     while (!t_match && MCProperListFirstIndexOfElement(self, p_needle -> list[0], t_offset, t_new_offset))
     {
         t_match = true;
+
+		if (p_needle->length > self->length - t_new_offset)
+		{
+			t_match = false;
+			break;
+		}
+
         for (uindex_t i = 1; i < p_needle -> length; i++)
         {
             if (!MCValueIsEqualTo(p_needle -> list[i], self -> list[t_new_offset + i]))

--- a/tests/lcb/stdlib/list.lcb
+++ b/tests/lcb/stdlib/list.lcb
@@ -106,9 +106,8 @@ public handler TestContainsList()
 
 	test "contains (missing)" when not t contains [1, "x"]
 
-	-- Crash
-	skip test "contains (missing composite)" because "bug 14596"
-	--test "contains (missing composite)" when ["x", 1, true, []] contains [[], "x", 1]
+	-- Bug 14596
+	test "contains (missing, overlap)" when not ["x", 1, true, ""] contains ["", true]
 end handler
 
 public handler TestBeginsWith()


### PR DESCRIPTION
MCProperListFirstIndexOfList() segfaulted when called for two
lists (A, B) where B overlapped the end of A, e.g.:

  A = [1, 1, 1, 2]
  B = [2, 2]

This was due to overrunning the end of array A.

This patch adds a check to ensure that
MCProperListFirstIndexOfList() will not attempt to correlate A
and B if B does not fit fully within A at the computed offset.
