### PR TITLE
Feature cefbrowser errormessage

### DIFF
--- a/docs/dictionary/message/browserDocumentFailed.xml
+++ b/docs/dictionary/message/browserDocumentFailed.xml
@@ -1,0 +1,40 @@
+<doc>
+  <legacy_id></legacy_id>
+  <name>browserDocumentFailed</name>
+  <type>message</type>
+  <syntax>
+    <example>browserDocumentFailed <i>instanceId, url, errorMessage</i></example>
+  </syntax>
+  <library>Browser Library</library>
+  <objects>
+    <card/>
+  </objects>
+  <synonyms>
+  </synonyms>
+  <classification>
+  </classification>
+  <references>
+    <message tag="browserDownloadRequest">browserDownloadRequest Message</message>
+    <function tag="revBrowserOpenCef">revBrowserOpenCef Function</function>
+  </references>
+  <history>
+    <introduced version="6.7.3">Added.</introduced>
+  </history>
+  <platforms>
+    <mac/>
+    <windows/>
+  </platforms>
+  <classes>
+    <desktop/>
+  </classes>
+  <security>
+    <network/>
+  </security>
+  <summary>Sent when a browser object has encountered an error when loading a url</summary>
+  <examples>
+    <example>on browserDocumentFailed pInstanceId, pUrl, pErrorMessage</p><p>  answer "Failed to load URL" && quote & pUrl & quote & return & "Error message: " && pErrorMessage</p><p>end browserDocumentFailed</example>
+  </examples>
+  <description>
+    <p>The <b>browserDocumentFailed</b> message is sent to the current card of a stack containing a browser object when the browser object has encountered an error while loading a url and all its dependent resources.</p><p/><p>If the target is the main frame of the browser (e.g. the html page with the "FRAMESET" declaration), then the <b>browserDocumentFailed</b> message is sent. Otherwise the <message tag="browserDocumentFailedFrame">browserDocumentFailedFrame message</message> is sent instead.</p><p/><p><b>Parameters:</b></p><p>The <i>url</i> is the url that has failed to load</p><p>The <i>instanceId</i> is the integer identifer of the browser object</p><p>The <i>errorMessage</i> is a message explaining why the url failed to load</p><p/><p><b>Note:</b> For general information on using the browser library, see the notes in the <function tag="revBrowserOpen">revBrowserOpen function</function> reference.</p>
+  </description>
+</doc>

--- a/docs/dictionary/message/browserDocumentFailedFrame.xml
+++ b/docs/dictionary/message/browserDocumentFailedFrame.xml
@@ -1,0 +1,40 @@
+<doc>
+  <legacy_id></legacy_id>
+  <name>browserDocumentFailedFrame</name>
+  <type>message</type>
+  <syntax>
+    <example>browserDocumentFailedFrame <i>instanceId, url, errorMessage</i></example>
+  </syntax>
+  <library>Browser Library</library>
+  <objects>
+    <card/>
+  </objects>
+  <synonyms>
+  </synonyms>
+  <classification>
+  </classification>
+  <references>
+    <message tag="browserDownloadRequest">browserDownloadRequest Message</message>
+    <function tag="revBrowserOpenCef">revBrowserOpenCef Function</function>
+  </references>
+  <history>
+    <introduced version="6.7.3">Added.</introduced>
+  </history>
+  <platforms>
+    <mac/>
+    <windows/>
+  </platforms>
+  <classes>
+    <desktop/>
+  </classes>
+  <security>
+    <network/>
+  </security>
+  <summary>Sent when a browser object has encountered an error when loading a url in a frame</summary>
+  <examples>
+    <example>on browserDocumentFailedFrame pInstanceId, pUrl, pErrorMessage</p><p>  answer "Failed to load frame URL" && quote & pUrl & quote & return & "Error message: " && pErrorMessage</p><p>end browserDocumentFailedFrame</example>
+  </examples>
+  <description>
+    <p>The <b>browserDocumentFailedFrame</b> message is sent to the current card of a stack containing a browser object when the browser object has encountered an error while loading a url and all its dependent resources in a frame.</p><p/><p>If the target is the main frame of the browser then the <message tag="browserDocumentFailed">browserDocumentFailed message</message> message is sent instead.</p><p/><p><b>Parameters:</b></p><p>The <i>url</i> is the url that has failed to load in a frame</p><p>The <i>instanceId</i> is the integer identifer of the browser object</p><p>The <i>errorMessage</i> is a message explaining why the url failed to load in the frame</p><p/><p><b>Note:</b> For general information on using the browser library, see the notes in the <function tag="revBrowserOpen">revBrowserOpen function</function> reference.</p>
+  </description>
+</doc>

--- a/docs/notes/feature-cefbrowser_error_message.md
+++ b/docs/notes/feature-cefbrowser_error_message.md
@@ -1,0 +1,10 @@
+# Add revBrowser error callback messages.
+
+Added two new callbacks sent by revBrowser.
+Note that these messages are only sent from browsers opened with revBrowserOpenCEF.
+
+## Callback messages:
+* browserDocumentFailed
+*	sent to the current card when the browser has encountered an error while loading a URL.
+* browserDocumentFailedFrame
+*	sent to the current card when the browser has encountered an error while loading a URL into a frame.

--- a/revbrowser/src/revbrowser.cpp
+++ b/revbrowser/src/revbrowser.cpp
@@ -285,7 +285,7 @@ bool is_escape_char(char p_char)
 bool MCCStringQuote(const char *p_string, char *&r_quoted)
 {
 	if (p_string == nil || p_string[0] == '\0')
-		return MCCStringClone("", r_quoted);
+		return MCCStringClone("\"\"", r_quoted);
 
 	bool t_success;
 	t_success = true;
@@ -771,6 +771,21 @@ void CB_DocumentComplete(int p_instance_id, const char *p_url)
 }
 
 // Callback:
+//   browserDocumentFailed pInstanceId, pURL, pErrorMessage
+// Description:
+//   The browser sends this message when a given URL has failed to load.
+//
+void CB_DocumentFailed(int p_instance_id, const char *p_url, const char *p_error)
+{
+	const char *t_params[2];
+	t_params[0] = p_url;
+	t_params[1] = p_error;
+	
+	bool t_pass;
+	s_browsers . Callback(p_instance_id, "browserDocumentFailed", (char**)t_params, 2, t_pass);
+}
+
+// Callback:
 //   XBrowser_DocumentCompleteFrame pURL, pInstanceId
 // Description:
 //   The browser sends this message when a given URL has finished
@@ -779,6 +794,21 @@ void CB_DocumentComplete(int p_instance_id, const char *p_url)
 void CB_DocumentFrameComplete(int p_instance_id, const char *p_url)
 {
 	s_browsers . Callback(p_instance_id, "DocumentCompleteFrame", p_url);
+}
+
+// Callback:
+//   browserDocumentFailedFrame pInstanceId, pURL, pErrorMessage
+// Description:
+//   The browser sends this message when a given URL has failed to load into a frame.
+//
+void CB_DocumentFrameFailed(int p_instance_id, const char *p_url, const char *p_error)
+{
+	const char *t_params[2];
+	t_params[0] = p_url;
+	t_params[1] = p_error;
+	
+	bool t_pass;
+	s_browsers . Callback(p_instance_id, "browserDocumentFailedFrame", (char**)t_params, 2, t_pass);
 }
 
 // Callback:

--- a/revbrowser/src/revbrowser.h
+++ b/revbrowser/src/revbrowser.h
@@ -107,6 +107,9 @@ void CB_NavigateFrameComplete(int p_instance_id, const char *p_url);
 void CB_DocumentComplete(int p_instance_id, const char *p_url);
 void CB_DocumentFrameComplete(int p_instance_id, const char *p_url);
 
+void CB_DocumentFailed(int p_instance_id, const char *p_url, const char *p_error);
+void CB_DocumentFrameFailed(int p_instance_id, const char *p_url, const char *p_error);
+
 void CB_CreateInstance(int p_instance_id);
 void CB_DestroyInstance(int p_instance_id);
 


### PR DESCRIPTION
added the following callback messages to revBrowserCef, sent when a document / frame fails to load:

browserDocumentFailed pBrowser, pUrl, pErrorMsg
browserDocumentFailedFrame pBrowser, pUrl, pErrorMsg
