### PR TITLE
[Bug 14613] prebuilt: Over-quoted variable in shell loop.

### DIFF
--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -67,9 +67,7 @@ else
     SELECTED_PLATFORMS="$@"
 fi
 
-echo "$SELECTED_PLATFORMS"
-
-for PLATFORM in "${SELECTED_PLATFORMS}" ; do
+for PLATFORM in ${SELECTED_PLATFORMS} ; do
 	eval "ARCHS=( \${ARCHS_${PLATFORM}[@]} )"
 	eval "LIBS=( \${LIBS_${PLATFORM}[@]} )"
 	eval "SUBPLATFORMS=( \${SUBPLATFORMS_${PLATFORM}[@]} )"


### PR DESCRIPTION
When multiple platforms are selected (i.e. `$SELECTED_PLATFORMS` contains multiple words) the quoting of `$SELECTED_PLATFORMS` in the `for` loop iterator clause was preventing the words from being split and operated on separately.
