### PR TITLE
lc-compile: Add short options (-o and -I)

### DIFF
--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -3,7 +3,7 @@ lc-compile(1) -- compile LiveCode Builder source code
 
 ## SYNOPSIS
 
-**lc-compile** [_OPTION_ ...] --output _OUTFILE_ [--] _LCBFILE_
+**lc-compile** [_OPTION_ ...] -o _OUTFILE_ [--] _LCBFILE_
 
 **lc-compile** [_OPTION_ ...] --outputc _OUTFILE_ [--] _LCBFILE_
 
@@ -18,12 +18,12 @@ specified.
 
 ## OPTIONS
 
-* --modulepath _PATH_:
+* -I, --modulepath _PATH_:
   Search for interface (`.lci`) files in _PATH_, which should be a directory.
   The first `--modulepath` option specified determines the directory in which
   an interface file may be created for _LCBFILE_.
 
-* --output _OUTFILE_:
+* -o, --output _OUTFILE_:
   Generate LiveCode bytecode in _OUTFILE_, which should be the path to a `.lcm`
   file.  If _OUTFILE_ already exists, it will be overwritten.
 

--- a/toolchain/lc-compile/src/lc-run.cpp
+++ b/toolchain/lc-compile/src/lc-run.cpp
@@ -62,11 +62,11 @@ MCRunUsage (int p_exit_status)
 	fprintf (stderr,
 "Usage: lc-run [OPTIONS] [--] LCMFILE [ARGS ...]\n"
 "\n"
-"Run a compiled Modular Livecode bytecode file.\n"
+"Run a compiled Livecode Builder bytecode file.\n"
 "\n"
 "Options:\n"
 "  -H, --handler NAME   Specify name of handler to run.\n"
-"  --list-handlers      List possible entry points in LCMFILE and exit.\n"
+"      --list-handlers  List possible entry points in LCMFILE and exit.\n"
 "  -h, --help           Print this message.\n"
 "  --                   Treat next argument as bytecode filename.\n"
 "\n"

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -107,22 +107,22 @@ static void
 usage(int status)
 {
     fprintf(stderr,
-"Usage: lc-compile {--modulepath PATH} --output OUTFILE [--manifest MANIFEST] [--] MLCFILE\n"
-"       lc-compile {--modulepath PATH} --outputc OUTFILE [--manifest MANIFEST] [--] MLCFILE\n"
+"Usage: lc-compile [OPTION ...] -o OUTFILE [--] LCBFILE\n"
+"       lc-compile [OPTION ...] --outputc OUTFILE [--] LCBFILE\n"
 "\n"
-"Compile a Modular LiveCode source file.\n"
+"Compile a LiveCode Builder source file.\n"
 "\n"
 "Options:\n"
-"  --modulepath PATH    Path to directory containing module interface files.\n"
-"  --output  OUTFILE    Filename for bytecode output.\n"
-"  --outputc OUTFILE    Filename for C source code output.\n"
-"  --manifest MANIFEST  Filename for generated manifest.\n"
-"  -h, --help           Print this message.\n"
-"  --                   Treat all remaining arguments as filenames.\n"
+"  -I, --modulepath PATH    Search PATH for module interface files.\n"
+"  -o, --output OUTFILE     Filename for bytecode output.\n"
+"      --outputc OUTFILE    Filename for C source code output.\n"
+"      --manifest MANIFEST  Filename for generated manifest.\n"
+"  -h, --help               Print this message.\n"
+"  --                       Treat all remaining arguments as filenames.\n"
 "\n"
-"More than one `--modulepath' option may be specified. They are searched in\n"
-"the order specified.  The first modulepath is used to output the interface\n"
-"file."
+"More than one `--modulepath' option may be specified.  The PATHs are\n"
+"searched in the order they appear.  An interface file may be generated in\n"
+"the first PATH specified.\n"
 "\n"
 "Report bugs to <http://quality.runrev.com/>\n"
             );
@@ -143,12 +143,14 @@ static void full_main(int argc, char *argv[])
         const char *optarg = (argi + 1 < argc) ? argv[argi+1] : NULL;
         if (!end_of_args)
         {
-            if (0 == strcmp(opt, "--modulepath") && optarg)
+	        if ((0 == strcmp(opt, "--modulepath") || 0 == strcmp(opt, "-I")) &&
+	            optarg)
             {
                 AddImportedModuleDir(argv[++argi]);
                 continue;
             }
-            if (0 == strcmp(opt, "--output") && optarg)
+            if ((0 == strcmp(opt, "--output") || 0 == strcmp(opt, "-o")) &&
+                optarg)
             {
                 SetOutputFile(argv[++argi]);
                 continue;


### PR DESCRIPTION
Add `-o` (same as `--output`) and `-I` (same as `--modulepath`).

Other minor updates to lc-run and lc-compile usage messages.
