### PR TITLE
[[ SB Inclusions ]] Abstract module loading functions.

### DIFF
--- a/revdb/dbsqlite.exports
+++ b/revdb/dbsqlite.exports
@@ -1,3 +1,4 @@
 _newdbconnectionref
 _releasedbconnectionref
 _setidcounterref
+_setcallbacksref

--- a/revdb/src/dbdriver.h
+++ b/revdb/src/dbdriver.h
@@ -290,6 +290,20 @@ inline void DBString::Set(char *p_string, int p_length, Bool p_binary)
 
 ///////////////////////////////////////////////////////////////////////////////
 
+#define DBcallbacks_version 0
+
+struct DBcallbacks
+{
+    unsigned int version;
+
+    // V0 callbacks
+    void *(*load_module)(const char *module);
+    void (*unload_module)(void *module);
+    void *(*resolve_symbol_in_module)(void *module, const char *symbol);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
 // These are the standard exported functions for all db-drivers. We predeclare
 // them here with appropriate visibility so we don't have to do this in all
 // driver files.
@@ -298,6 +312,7 @@ inline void DBString::Set(char *p_string, int p_length, Bool p_binary)
 extern "C" DBConnection *newdbconnectionref() __attribute__((visibility("default")));
 extern "C" void releasedbconnectionref(DBConnection *dbref) __attribute__((visibility("default")));
 extern "C" void setidcounterref(unsigned int *tidcounter) __attribute__((visibility("default")));
+extern "C" void setcallbacksref(DBcallbacks *callbacks) __attribute__((visibility("default")));
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/revdb/src/dbdrivercommon.cpp
+++ b/revdb/src/dbdrivercommon.cpp
@@ -16,6 +16,16 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "dbdrivercommon.h"
 
+#if defined(_WINDOWS)
+#define LIBRARY_EXPORT __declspec(dllexport)
+#elif defined(_MACOSX)
+#define LIBRARY_EXPORT
+#elif defined(_LINUX)
+#define LIBRARY_EXPORT
+#elif defined(TARGET_SUBPLATFORM_IPHONE) || defined(TARGET_SUBPLATFORM_ANDROID)
+#define LIBRARY_EXPORT
+#endif
+
 // Default implementations for DBField
 DBField::DBField()
 {
@@ -452,3 +462,34 @@ void CDBCursor::FreeFields()
 	fields = NULL;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+static DBcallbacks *dbcallbacks = NULL;
+
+extern "C" LIBRARY_EXPORT void setcallbacksref(DBcallbacks *callbacks)
+{
+    dbcallbacks = callbacks;
+}
+
+extern "C" void *MCU_loadmodule(const char *p_path)
+{
+    if (dbcallbacks == NULL)
+        return NULL;
+    return dbcallbacks -> load_module(p_path);
+}
+
+extern "C" void MCU_unloadmodule(void *p_handle)
+{
+    if (dbcallbacks == NULL)
+        return;
+    dbcallbacks -> unload_module(p_handle);
+}
+
+extern "C" void *MCU_resolvemodulesymbol(void *p_handle, const char *p_symbol)
+{
+    if (dbcallbacks == NULL)
+        return NULL;
+    return dbcallbacks -> resolve_symbol_in_module(p_handle, p_symbol);
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/revdb/src/osxsupport.cpp
+++ b/revdb/src/osxsupport.cpp
@@ -137,6 +137,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)CFBundleGetFunctionPointerForName(t_bundle, CFSTR("setidcounterref"));
 	t_result -> newconnectionptr = (new_connectionrefptr)CFBundleGetFunctionPointerForName(t_bundle, CFSTR("newdbconnectionref"));
 	t_result -> releaseconnectionptr = (release_connectionrefptr)CFBundleGetFunctionPointerForName(t_bundle, CFSTR("releasedbconnectionref"));
+    t_result -> setcallbacksptr = (set_callbacksrefptr)CFBundleGetFunctionPointerForName(t_bundle, CFSTR("setcallbacksref"));
 	
 	return t_result;
 }
@@ -176,6 +177,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)dlsym(t_driver_handle, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)dlsym(t_driver_handle, "newdbconnectionref");
 	t_result -> releaseconnectionptr = (release_connectionrefptr)dlsym(t_driver_handle, "releasedbconnectionref");
+    t_result -> setcallbacksptr = (set_callbacksrefptr)dlsym(t_driver_handle, "setcallbacksref");
 	free(t_filename);
 	return t_result;
 	

--- a/revdb/src/osxsupport.h
+++ b/revdb/src/osxsupport.h
@@ -32,6 +32,7 @@ struct DATABASEREC
 	idcounterrefptr idcounterptr;
 	new_connectionrefptr  newconnectionptr;
 	release_connectionrefptr releaseconnectionptr;
+    set_callbacksrefptr setcallbacksptr;
 #ifndef _MAC_SERVER
 	CFBundleRef driverref;
 #else

--- a/revdb/src/revdb.h
+++ b/revdb/src/revdb.h
@@ -19,6 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 typedef DBConnection *(*new_connectionrefptr) ();
 typedef void (*release_connectionrefptr) (DBConnection *dbref);
 typedef void (*idcounterrefptr) (unsigned int *tidcounter);
+typedef void (*set_callbacksrefptr)(const DBcallbacks *callbacks);
 
 struct DATABASEREC;
 

--- a/revdb/src/unxsupport.cpp
+++ b/revdb/src/unxsupport.cpp
@@ -203,6 +203,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)dlsym(t_driver_handle, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)dlsym(t_driver_handle, "newdbconnectionref");
 	t_result -> releaseconnectionptr = (release_connectionrefptr)dlsym(t_driver_handle, "releasedbconnectionref");
+    t_result -> setcallbacksptr = (set_callbacksrefptr)dlsym(t_driver_handle, "setcallbacksref");
 	free(t_filename);
 	return t_result;
 

--- a/revdb/src/w32support.cpp
+++ b/revdb/src/w32support.cpp
@@ -81,6 +81,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)GetProcAddress(t_module, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)GetProcAddress(t_module, "newdbconnectionref");
 	t_result -> releaseconnectionptr = (release_connectionrefptr)GetProcAddress(t_module, "releasedbconnectionref");
+    t_result -> setcallbacksptr = (set_callbacksrefptr)GetProcAddress(t_module, "setcallbacksref");
 	return t_result;
 }
 


### PR DESCRIPTION
The DB drivers can now be passed a DBcallbacks ptr through a exported 'set_callbacksref' function.

The callbacks contain module access functions which use the ones provided by the external interface. This allows dbmysql to use the the engine module loader to find revsecurity (which it weakly links to).
