### PR TITLE
[[ Bug 14598 ]] Assertion failure when putting a handler value into a sl...

### DIFF
--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -132,9 +132,10 @@ bool MCTypeInfoResolve(MCTypeInfoRef self, MCResolvedTypeInfo& r_resolution)
 
 bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target)
 {
-    // We require that source is concrete - this means that it must be a named
-    // type.
-    MCAssert(MCTypeInfoIsNamed(source));
+    // We require that source is concrete for all but handler types (as handlers
+    // have unnamed typeinfos which we need to compare with potentially named
+    // handler type typeinfos).
+    MCAssert(MCTypeInfoIsNamed(source) || MCTypeInfoIsHandler(source));
     
     // Resolve the source type.
     MCResolvedTypeInfo t_resolved_source;


### PR DESCRIPTION
...ot.

Handler values are the only thing which can have 'unnamed' typeinfo and the MCTypeInfoConforms() assertion has been modified to take this into account.
