### PR TITLE
libfoundation: Correct implementation of isinf() on Windows.

### DIFF
--- a/libfoundation/include/foundation-math.h
+++ b/libfoundation/include/foundation-math.h
@@ -30,7 +30,9 @@
 #    define NAN ((float)(INFINITY*0.));
 #  endif
 #  include <float.h>
-#  define isinf(x) (!_finite(x))
+/* C++: isinf(x) should return non-zero if is an infinity.
+ * C99: isinf(x) should return 1 if x is +Inf, -1 if x is -Inf, 0 otherwise. */
+#  define isinf(x) ((_fpclass(x) == _FPCLASS_PINF) ? 1 : ((_fpclass(x) == _FPCLASS_NINF) ? -1 : 0))
 #  define copysign _copysign
 #endif
 


### PR DESCRIPTION
Previously, the fallback implementation of isinf(3) on Windows platforms
would return:
- 1 if the argument is an infinity or NaN.
- 0 otherwise

This conformed to neither C++, C99 nor POSIX specification:
- C++ requires `isinf(x) == 0` when `x` is NaN.
- C99 and POSIX require `isinf(x) == 0` when `x` is NaN and `isinf(x) == -1`
  when `x` is negative infinity.

This patch alters the behaviour of the fallback implementation of isinf(3) to
match POSIX behaviour (and thus also conform to C++ and C99).
