### PR TITLE
[[ LibC++ ]] Update to the Standard C++ Library used to build iOS.

### DIFF
--- a/rules/Global Mobile.xcconfig
+++ b/rules/Global Mobile.xcconfig
@@ -21,5 +21,4 @@ ALWAYS_SEARCH_USER_PATHS = NO
 DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
 SDKROOT=iphoneos
 ARCHS_STANDARD=armv7 arm64
-CLANG_CXX_LIBRARY[arch=armv7] = libc++
-CLANG_CXX_LIBRARY[arch=arm64] = libc++
+CLANG_CXX_LIBRARY = libc++

--- a/rules/Global Mobile.xcconfig
+++ b/rules/Global Mobile.xcconfig
@@ -21,3 +21,5 @@ ALWAYS_SEARCH_USER_PATHS = NO
 DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
 SDKROOT=iphoneos
 ARCHS_STANDARD=armv7 arm64
+CLANG_CXX_LIBRARY[arch=armv7] = libc++
+CLANG_CXX_LIBRARY[arch=arm64] = libc++

--- a/tools/build-extension-ios.sh
+++ b/tools/build-extension-ios.sh
@@ -43,9 +43,9 @@ fi
 EXECUTABLE_INFO=$(otool -fv "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" | grep "Fat headers")
 if [ -z "$EXECUTABLE_INFO" ]; then
 	if [ $BUILD_DYLIB -eq 1 ]; then
-		$BIN_DIR/g++ -dynamiclib -arch ${ARCHS} -miphoneos-version-min=5.1.1 -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
+		$BIN_DIR/g++ -stdlib=libc++ -dynamiclib -arch ${ARCHS} -miphoneos-version-min=5.1.1 -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
 	fi
-	$BIN_DIR/g++ -dynamiclib -arch ${ARCHS} -miphoneos-version-min=5.1.1 -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
+	$BIN_DIR/g++ -stdlib=libc++ -dynamiclib -arch ${ARCHS} -miphoneos-version-min=5.1.1 -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
 
 	# Success
 	exit 0
@@ -70,7 +70,7 @@ do
     fi
 
 	if [ $BUILD_DYLIB -eq 1 ]; then
-		OUTPUT=$($BIN_DIR/g++ -dynamiclib -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${DYLIB_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS)
+		OUTPUT=$($BIN_DIR/g++ -stdlib=libc++ -dynamiclib -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${DYLIB_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS)
 		if [ -n "$OUTPUT" ]; then
 			echo "Linking ""${DYLIB_FILE}""failed:"
 			echo $OUTPUT
@@ -78,7 +78,7 @@ do
 		fi
 	fi
 
-    OUTPUT=$($BIN_DIR/g++ -nodefaultlibs $STRIP_OPTIONS -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${LCEXT_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME $STATIC_DEPS)
+    OUTPUT=$($BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${LCEXT_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME $STATIC_DEPS)
 
 	if [ -n "$OUTPUT" ]; then
 		echo "Linking ""${LCEXT_FILE}""failed:"


### PR DESCRIPTION
The Standard C++ Library has been updated to use libc++ rather than libstdc++.

This means that all binary components built for iOS which use any C++ features must also have their settings updated.

The global rules file and the extension building shell script has been update to reflect this.
