### PR TITLE
[[ Broken Win Compilation ]] Fixes cefbrower issues on Windows:

### DIFF
--- a/engine/src/external.cpp
+++ b/engine/src/external.cpp
@@ -222,7 +222,7 @@ MCExternal *MCExternal::Load(const char *p_filename)
 	if (t_success)
 	{
         // AL-2015-02-10: [[ SB Inclusions ]] Load external using new module loading utility
-		t_module = MCU_loadmodule(p_filename);
+		t_module = (MCSysModuleHandle)MCU_loadmodule(p_filename);
 		if (t_module == NULL)
 			t_success = false;
 	}

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -817,7 +817,7 @@ static char *load_module(const char *arg1, const char *arg2,
     MCSysModuleHandle *t_result;
     t_result = (MCSysModuleHandle *)arg2;
     
-    *t_result = MCU_loadmodule(arg1);
+    *t_result = (MCSysModuleHandle)MCU_loadmodule(arg1);
     
     if (*t_result == nil)
         *retval = xresFail;

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -2930,7 +2930,9 @@ bool MCU_random_bytes(size_t p_count, void *p_buffer)
 // AL-2015-02-06: [[ SB Inclusions ]] Add utility functions for module loading where
 //  p_module can be a universal module name, where a mapping from module names to
 // relative paths has been provided.
-MCSysModuleHandle MCU_loadmodule(const char *p_module)
+// SN-2015-02-23: [[ Broken Win Compilation ]] Use void*, as the function is imported
+//  as extern in revbrowser/src/cefshared.h - where MCSysModuleHandle does not exist
+void* MCU_loadmodule(const char *p_module)
 {
     MCSysModuleHandle t_handle;
     t_handle = nil;
@@ -2998,12 +3000,16 @@ MCSysModuleHandle MCU_loadmodule(const char *p_module)
     return t_handle;
 }
 
-void MCU_unloadmodule(MCSysModuleHandle p_module)
+// SN-2015-02-23: [[ Broken Win Compilation ]] Use void*, as the function is imported
+//  as extern in revbrowser/src/cefshared.h - where MCSysModuleHandle does not exist
+void MCU_unloadmodule(void *p_module)
 {
-    MCS_unloadmodule(p_module);
+    MCS_unloadmodule((MCSysModuleHandle)p_module);
 }
 
-void *MCU_resolvemodulesymbol(MCSysModuleHandle p_module, const char *p_symbol)
+// SN-2015-02-23: [[ Broken Win Compilation ]] Use void*, as the function is imported
+//  as extern in revbrowser/src/cefshared.h - where MCSysModuleHandle does not exist
+void *MCU_resolvemodulesymbol(void* p_module, const char *p_symbol)
 {
 #if defined(_MACOSX) || defined(_MAC_SERVER)
     NSSymbol t_symbol;
@@ -3011,7 +3017,7 @@ void *MCU_resolvemodulesymbol(MCSysModuleHandle p_module, const char *p_symbol)
     if (t_symbol != NULL)
         return NSAddressOfSymbol(t_symbol);
 #endif
-    return MCS_resolvemodulesymbol(p_module, p_symbol);
+    return MCS_resolvemodulesymbol((MCSysModuleHandle)p_module, p_symbol);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -180,9 +180,11 @@ extern double MCU_squared_distance_from_line(int4 sx, int4 sy, int4 ex, int4 ey,
 extern bool MCU_random_bytes(size_t count, void *buffer);
 
 // AL-2015-02-06: [[ SB Inclusions ]] Add utility functions for module loading
-extern "C" MCSysModuleHandle MCU_loadmodule(const char *p_module);
-extern "C" void MCU_unloadmodule(MCSysModuleHandle p_module);
-extern "C" void *MCU_resolvemodulesymbol(MCSysModuleHandle p_module, const char *p_symbol);
+// SN-2015-02-23: [[ Broken Win Compilation ]] Use void*, as the function is imported
+//  as extern in revbrowser/src/cefshared.h - where MCSysModuleHandle does not exist
+extern "C" void* MCU_loadmodule(const char *p_module);
+extern "C" void MCU_unloadmodule(void* p_module);
+extern "C" void *MCU_resolvemodulesymbol(void* p_module, const char *p_symbol);
 
 // 
 

--- a/libexternal/include/revolution/external.h
+++ b/libexternal/include/revolution/external.h
@@ -451,7 +451,8 @@ extern void StackToWindowRect(unsigned int p_win_id, MCRectangle32 *x_rect, int 
 extern void WindowToStackRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success);
 
 // AL-2015-02-10: [[ SB Inclusions ]] Add wrappers for ExternalV0 module loading callbacks
-extern void LoadModule(const char *p_module, void **r_handle, int *r_success);
+// SN-2015-02-24: [[ Broken Win Compilation ]] LoadModule is a Win32 API function...
+extern void LoadModuleByName(const char *p_module, void **r_handle, int *r_success);
 extern void UnloadModule(void *p_handle, int *r_success);
 extern void ResolveSymbolInModule(void *p_handle, const char *p_symbol, void **r_resolved, int *r_success);
     

--- a/libexternal/src/external.c
+++ b/libexternal/src/external.c
@@ -413,15 +413,17 @@ void WindowToStackRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_succ
 ////////////////////////////////////////////////////////////////////////////////
 
 // AL-2015-02-10: [[ SB Inclusions ]] Add wrappers for ExternalV0 module loading callbacks
-void LoadModule(const char *p_module, void **r_handle, int *r_success)
+// SN-2015-02-24: [[ Broken Win Compilation ]] LoadModule is a Win32 API function...
+void LoadModuleByName(const char *p_module, void **r_handle, int *r_success)
 {
+    char *t_result;
+
     if (s_external_interface_version < 2)
     {
         *r_success = EXTERNAL_FAILURE;
         return;
     }
-    
-    char *t_result;
+
     t_result = (s_operations[OPERATION_LOAD_MODULE])(p_module, (const char *)r_handle, NULL, r_success);
     
     if (t_result != NULL)
@@ -430,13 +432,14 @@ void LoadModule(const char *p_module, void **r_handle, int *r_success)
 
 void UnloadModule(void *p_handle, int *r_success)
 {
+    char *t_result;
+
     if (s_external_interface_version < 2)
     {
         *r_success = EXTERNAL_FAILURE;
         return;
     }
-    
-    char *t_result;
+
     t_result = (s_operations[OPERATION_UNLOAD_MODULE])(p_handle, NULL, NULL, r_success);
     
     if (t_result != NULL)
@@ -445,13 +448,14 @@ void UnloadModule(void *p_handle, int *r_success)
 
 void ResolveSymbolInModule(void *p_handle, const char *p_symbol, void **r_resolved, int *r_success)
 {
+    char *t_result;
+
     if (s_external_interface_version < 2)
     {
         *r_success = EXTERNAL_FAILURE;
         return;
     }
-    
-    char *t_result;
+
     t_result = (s_operations[OPERATION_RESOLVE_SYMBOL_IN_MODULE])(p_handle, p_symbol, (const char *)r_resolved, r_success);
     
     if (t_result != NULL)

--- a/revbrowser/src/cefbrowser_w32.cpp
+++ b/revbrowser/src/cefbrowser_w32.cpp
@@ -533,5 +533,5 @@ void MCU_unloadmodule(void *p_module)
 
 void *MCU_resolvemodulesymbol(void *p_module, const char *p_name)
 {
-    return GetProcAddress(p_module, p_name);
+    return GetProcAddress((HMODULE)p_module, p_name);
 }

--- a/revdb/src/revdb.cpp
+++ b/revdb/src/revdb.cpp
@@ -139,7 +139,7 @@ static void *DBcallback_loadmodule(const char *p_path)
 {
     int t_success;
     void *t_handle;
-    LoadModule(p_path, &t_handle, &t_success);
+    LoadModuleByName(p_path, &t_handle, &t_success);
     if (t_success == EXTERNAL_FAILURE)
         return NULL;
     return t_handle;
@@ -271,7 +271,7 @@ DATABASEREC *LoadDatabaseDriverFromName(const char *p_type)
     int t_retvalue;
     void *t_handle;
     t_handle = NULL;
-    LoadModule(p_type, &t_handle, &t_retvalue);
+    LoadModuleByName(p_type, &t_handle, &t_retvalue);
     
     if (t_handle == NULL)
         return NULL;
@@ -280,8 +280,10 @@ DATABASEREC *LoadDatabaseDriverFromName(const char *p_type)
     t_result = new DATABASEREC;
 #if (defined _MACOSX && !defined _MAC_SERVER)
     t_result -> driverref = (CFBundleRef)t_handle;
+#elif (defined _WINDOWS)
+    t_result -> driverref = (HINSTANCE)t_handle;
 #else
-    t_result -> driverref = t_handle;
+	t_result -> driverref = t_handle;
 #endif
     
     void *id_counterref_ptr, *new_connectionref_ptr, *release_connectionref_ptr;


### PR DESCRIPTION
- rename LoadModule (which is a Windows API function)
- Change MCU_loadmodule, MCU_unloadmodule and MCU_resolvemodulesymbol prototype to use void\* instead of MCSysModuleHandle
