### PR TITLE
[[ Bug 14625 ]] Set appropriately the sim min version in build-extension...

### DIFF
--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -346,6 +346,9 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
          --put revGetMinimumOSByArch(tSettings["ios,minimum version"]) into tVersion
          --put "-miphoneos-version-min=" & tVersion["armv7"] & return after tLinkCommand
          
+         -- SN-2015-02-23: [[ Bug 14625 ]] Use a iOS 5.1/iOS 7.0 consistent stdlib
+         put "-stdlib=libc++" & return after tLinkCommand
+         
          -- MW-2013-06-26: [[ CloneAndRun ]] Only dead strip if an installed env.
          if revEnvironmentIsInstalled() then
             -- Strip any dead code and data from the engine
@@ -401,15 +404,12 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
             put tLinkCommand & "-o" && quote & tArchSpecificEngineFile & quote & return into url ("binfile:" & tLinkOptionsFile)
 
             local tiPhoneMinVersion
-            if tArch = "arm64" then
-               put "7.0.0" into tiPhoneMinVersion
-            else
-               put "5.1.1" into tiPhoneMinVersion
-            end if
+            put revGetMinimumOSByArch(tSettings["ios,minimum version"]) into tiPhoneMinVersion
+            
             -- MM-2013-09-23: [[ iOS7 Support ]] Use g++ instead of llvm-g++-4.2. XCode 5.0 uses llvm 5.0.
             -- g++ appears to be sym-linked to the appropriate compiler in all SDKS.
             -- SN-2015-02-19: [[ Bug 14625 ]] The minimum iOS version is bound to the architecture
-            get shell("g++ -arch " & tArch && "-miphoneos-version-min=" & tiPhoneMinVersion && quote & "@" & tLinkOptionsFile & quote)
+            get shell("g++ -arch " & tArch && "-miphoneos-version-min=" & tiPhoneMinVersion[tArch] && quote & "@" & tLinkOptionsFile & quote)
 
             put tArchSpecificEngineFile & space after tArchSpecificEngineList
             delete file tLinkOptionsFile

--- a/lcidlc/lclink.sh
+++ b/lcidlc/lclink.sh
@@ -19,11 +19,11 @@ DEPS="$DEPS -framework Foundation -framework UIKit"
 # The list of symbols exported by an iOS external is fixed
 SYMBOLS="_MCExternalDescribe _MCExternalInitialize _MCExternalFinalize"
 
-# Munge the passed in ARCHS environment variable into a form suitable for g++
-ARCHS="-arch ${ARCHS// / -arch }"
-
 # Munge the (computed) symbols list into a form suitable for g++
 SYMBOLS="-Wl,-exported_symbol -Wl,${SYMBOLS// / -Wl,-exported_symbol -Wl,}"
+
+# SN-2015-02019: [[ Bug 14625 ]] We build and link each arch separately, and lipo them
+#  togother once it's done.
 
 # In debug mode we definitely don't want do dead-strip and remove symbols, as then debugging is very
 # very hard!
@@ -33,21 +33,83 @@ else
 	SYMBOL_ARGS="-dead_strip -Wl,-x"
 fi
 
-# Build the 'dylib' form of the external - this is used by simulator builds, and as
-# a dependency check for device builds.
-"$PLATFORM_DEVELOPER_BIN_DIR/g++" -dynamiclib $ARCHS -isysroot "$SDKROOT" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" $SYMBOL_ARGS $SYMBOLS $DEPS
-if [ $? != 0 ]; then
-	echo "error: linking step of external dylib build failed, probably due to missing framework or library references - check the contents of the $PRODUCT_NAME.ios file"
-	exit $?
+# We still want to produce dylib for the simulator
+if [ "$EFFECTIVE_PLATFORM_NAME" = "-iphonesimulator" ]; then
+	BUILD_DYLIB=1
+else
+	BUILD_DYLIB=0
 fi
 
-# Build the 'object file' form of the external - this is used by device builds.
-"$PLATFORM_DEVELOPER_BIN_DIR/g++" -nodefaultlibs -Wl,-r -Wl,-x $ARCHS -isysroot "$SDKROOT" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$LIVECODE_DEP_FILE" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME
-if [ $? != 0 ]; then
-	echo "error: linking step of external object build failed"
-	exit $?
-fi
+# SN-2015-02-19: [[ Bug 14625 ]] Xcode only create FAT headers from iOS SDK 7.0
+FAT_INFO=$(otool -fv "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" | grep "Fat headers")
 
+
+if [ -z "$FAT_INFO" -o $BUILD_DYLIB -eq 1 ]; then
+	# No arch-specific compilation for simulators.
+
+	# We set the minimum iOS or simulator version
+    if [ $BUILD_DYLIB -eq 1 ]; then
+        MIN_OS_VERSION="-mios-simulator-version-min=5.1.1"
+    else
+        MIN_OS_VERSION="-miphoneos-version-min=5.1.1"
+    fi
+
+    ARCHS="-arch ${ARCHS// / -arch }"
+
+	if [ $BUILD_DYLIB -eq 1 ]; then
+		$BIN_DIR/g++ -stdlib=libc++ -dynamiclib ${ARCHS} $MIN_OS_VERSION -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
+	fi
+
+	if [ $? -ne 0 ]; then
+		exit $?
+	fi
+
+	$BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS ${ARCHS} $MIN_OS_VERSION -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME $STATIC_DEPS
+else
+	# Only executed if the binaries have a FAT header, and we need an architecture-specific
+	# linking
+	LCEXT_FILE_LIST=""
+	DYLIB_FILE_LIST=""
+
+	# Link architecture-specifically the libraries
+	for ARCH in $(echo $ARCHS | tr " " "\n")
+	do
+		LCEXT_FILE="$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext_${ARCH}"
+		DYLIB_FILE="$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib_${ARCH}"
+
+		if [ $ARCH = "arm64" -o $ARCH = "x86_64" ]; then
+			MIN_VERSION="7.0.0"
+		else
+			MIN_VERSION="5.1.1"
+		fi
+
+		# Build the 'dylib' form of the external - this is used by simulator builds, and as
+		# a dependency check for device builds.
+		"$PLATFORM_DEVELOPER_BIN_DIR/g++" -stdlib=libc++ -dynamiclib -arch $ARCH -miphoneos-version-min=${MIN_VERSION} -isysroot "$SDKROOT" -o "$DYLIB_FILE" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" $SYMBOL_ARGS $SYMBOLS $DEPS
+		if [ $? != 0 ]; then
+			echo "error: linking step of external dylib build failed, probably due to missing framework or library references - check the contents of the $PRODUCT_NAME.ios file"
+			exit $?
+		fi
+
+		# Build the 'object file' form of the external - this is used by device builds.
+		"$PLATFORM_DEVELOPER_BIN_DIR/g++" -stdlib=libc++ -nodefaultlibs -Wl,-r -Wl,-x -arch $ARCH -miphoneos-version-min=${MIN_VERSION} -isysroot "$SDKROOT" -o "$LCEXT_FILE" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$LIVECODE_DEP_FILE" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME
+		if [ $? != 0 ]; then
+			echo "error: linking step of external object build failed"
+			exit $?
+		fi
+
+		LCEXT_FILE_LIST+=" ${LCEXT_FILE}"
+		DYLIB_FILE_LIST+=" ${DYLIB_FILE}"
+	done
+
+	# Lipo together the arch-specific binaries and cleanup
+	lipo -create ${LCEXT_FILE_LIST} -output "$BUILD_PRODUCTS_DIR/$PRODUCT_NAME.lcext"
+	lipo -create ${DYLIB_FILE_LIST} -output "$BUILD_PRODUCTS_DIR/$PRODUCT_NAME.dylib"
+
+	rm -r ${DYLIB_FILE_LIST}
+	rm -r ${LCEXT_FILE_LIST}
+fi
+		
 # Now copy the products into the 'binaries' folder - the dylibs are used for simulator/testing on device
 # through XCode; the lcext file is for standalone (device) builds from the IDE.
 mkdir -p "$SRCROOT/binaries"

--- a/tools/build-extension-ios.sh
+++ b/tools/build-extension-ios.sh
@@ -32,23 +32,42 @@ fi
 # SN-2015-02019: [[ Bug 14625 ]] We build and link each arch separately, and lipo them
 #  togother once it's done.
 
-# We still want to produce revsecurity.dylib for the simulator
-if [ "${SDK_NAME:0:8}" != "iphoneos" -a "${EXECUTABLE_NAME}" = "librevsecurity.a" ]; then
+# We still want to produce dylibs for the simulator
+if [ "$EFFECTIVE_PLATFORM_NAME" = "-iphonesimulator" ]; then
 	BUILD_DYLIB=1
 else
 	BUILD_DYLIB=0
 fi
 
 # SN-2015-02-19: [[ Bug 14625 ]] Xcode only create FAT headers from iOS SDK 7.0
-EXECUTABLE_INFO=$(otool -fv "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" | grep "Fat headers")
-if [ -z "$EXECUTABLE_INFO" ]; then
-	if [ $BUILD_DYLIB -eq 1 ]; then
-		$BIN_DIR/g++ -stdlib=libc++ -dynamiclib -arch ${ARCHS} -miphoneos-version-min=5.1.1 -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
-	fi
-	$BIN_DIR/g++ -stdlib=libc++ -dynamiclib -arch ${ARCHS} -miphoneos-version-min=5.1.1 -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
+FAT_INFO=$(otool -fv "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" | grep "Fat headers")
 
-	# Success
-	exit 0
+if [ -z "$FAT_INFO" -o $BUILD_DYLIB -eq 1 ]; then
+	# We set the minimum iOS or simulator version
+    if [ $BUILD_DYLIB -eq 1 ]; then
+        MIN_OS_VERSION="-mios-simulator-version-min=5.1.1"
+    else
+        MIN_OS_VERSION="-miphoneos-version-min=5.1.1"
+    fi
+
+    ARCHS="-arch ${ARCHS// / -arch }"
+
+	if [ $BUILD_DYLIB -eq 1 ]; then
+		$BIN_DIR/g++ -stdlib=libc++ -dynamiclib ${ARCHS} $MIN_OS_VERSION -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS
+	fi
+
+	if [ $? -ne 0 ]; then
+		exit $?
+	fi
+
+	$BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS ${ARCHS} $MIN_OS_VERSION -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME $STATIC_DEPS
+
+	if [ $? -ne 0 ]; then
+		exit $?
+	else
+		# Success
+		exit 0
+	fi
 fi
 
 # Only executed if the binaries have a FAT header, and we need an architecture-specific
@@ -71,19 +90,19 @@ do
 
 	if [ $BUILD_DYLIB -eq 1 ]; then
 		OUTPUT=$($BIN_DIR/g++ -stdlib=libc++ -dynamiclib -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${DYLIB_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -dead_strip -Wl,-x $SYMBOLS $DEPS)
-		if [ -n "$OUTPUT" ]; then
+		if [ $? -ne 0 ]; then
 			echo "Linking ""${DYLIB_FILE}""failed:"
 			echo $OUTPUT
-			exit -1
+			exit $?
 		fi
 	fi
 
     OUTPUT=$($BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${LCEXT_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME $STATIC_DEPS)
 
-	if [ -n "$OUTPUT" ]; then
+	if [ $? -ne 0 ]; then
 		echo "Linking ""${LCEXT_FILE}""failed:"
 		echo $OUTPUT
-		exit -1
+		exit $?
 	fi
 
     LCEXT_FILE_LIST+=" ${LCEXT_FILE}"

--- a/tools/build-ios.osx
+++ b/tools/build-ios.osx
@@ -1,8 +1,8 @@
 BASEDIR=$(dirname $0)
 cd $BASEDIR/..
 
-./sdks/Xcode_4_2/usr/bin/xcodebuild -project stage-mobile.xcodeproj -configuration Release -sdk iphonesimulator5.1 ARCHS=i386
-./sdks/Xcode_4_6/usr/bin/xcodebuild -project stage-mobile.xcodeproj -configuration Release -sdk iphonesimulator6.1 ARCHS=i386
+./sdks/Xcode_5_1/usr/bin/xcodebuild -project stage-mobile.xcodeproj -configuration Release -sdk iphonesimulator5.1 ARCHS=i386
+./sdks/Xcode_5_1/usr/bin/xcodebuild -project stage-mobile.xcodeproj -configuration Release -sdk iphonesimulator6.1 ARCHS=i386
 ./sdks/Xcode_5_1/usr/bin/xcodebuild -project stage-mobile.xcodeproj -configuration Release -sdk iphonesimulator7.1 ARCHS="i386"
 ./sdks/Xcode_6_1/usr/bin/xcodebuild -project stage-mobile.xcodeproj -configuration Release -sdk iphonesimulator8.1 ARCHS="i386 x86_64"
 


### PR DESCRIPTION
...-ios.sh

Re-instate the use of the minimum version in iOS standalone application saving
Use Xcode 5.1 for all the pre-iOS simulator 7.1 compilations
