### PR TITLE
[[ StacksAsBehaviors ]] Behavior property expanded to allow stacks.

### DIFF
--- a/engine/src/aclip.cpp
+++ b/engine/src/aclip.cpp
@@ -244,7 +244,10 @@ Exec_stat MCAudioClip::setprop(uint4 parid, Properties p, MCExecPoint &ep, Boole
 Boolean MCAudioClip::del()
 {
 	getstack()->removeaclip(this);
-	return True;
+    
+    // MCObject now does things on del(), so we must make sure we finish by
+    // calling its implementation.
+	return MCObject::del();
 }
 
 void MCAudioClip::paste(void)

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -365,11 +365,6 @@ MCButton::~MCButton()
 	// particuarly if the button had icons.
 	while (opened)
 		close();
-	
-	// MW-2008-10-28: [[ ParentScripts ]] Flush the parent scripts table if
-	//   tsub has the state flag marked.
-	if (getstate(CS_IS_PARENTSCRIPT))
-		MCParentScript::FlushObject(this);
 
 	delete icons;
 	freemenu(True);
@@ -425,15 +420,7 @@ bool MCButton::visit(MCVisitStyle p_style, uint32_t p_part, MCObjectVisitor* p_v
 
 void MCButton::open()
 {
-	// MW-2008-10-28: [[ ParentScripts ]] We have to preserve the setting of the
-	//   CS_IS_PARENTSCRIPT state.
-	if (!getstate(CS_IS_PARENTSCRIPT))
-		MCControl::open();
-	else
-	{
-		MCControl::open();
-		setstate(True, CS_IS_PARENTSCRIPT);
-	}
+    MCControl::open();
 
 	// MW-2011-02-08: [[ Bug 9382 ]] Make sure we reset icons when opening and the state
 	//   has changed (i.e. background transition has occured).

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1253,7 +1253,10 @@ Boolean MCCard::del()
 		}
 		while (optr != objptrs);
 	}
-	return True;
+    
+    // MCObject now does things on del(), so we must make sure we finish by
+    // calling its implementation.
+    return MCObject::del();
 }
 
 struct UpdateDataIdsVisitor: public MCObjectVisitor

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -96,6 +96,7 @@ MCControl::~MCControl()
 {
 	if (focused == this)
 		focused = NULL;
+    
 	MCscreen->stopmove(this, False);
 
 	// MW-2009-06-11: [[ Bitmap Effects ]] Destroy the bitmap effects
@@ -112,6 +113,7 @@ void MCControl::open()
 		if (!getstate(CS_KEEP_LAYER))
 			layer_resetattrs();
 		
+        // Make sure we keep state which should be preserved across open.
 		state = (state & (CS_NO_MESSAGES | CS_NO_FILE | CS_SELECTED)) | (state & CS_KEEP_LAYER);
 	}
 	
@@ -756,15 +758,6 @@ Boolean MCControl::del()
 		}
 	}
 
-	// MW-2008-10-28: [[ ParentScripts ]] If the object is marked as being used
-	//   as a parentScript, flush the parentScript table so we don't get any
-	//   dangling pointers.
-	if (getstate(CS_IS_PARENTSCRIPT) && gettype() == CT_BUTTON)
-	{
-		MCParentScript::FlushObject(this);
-		setstate(False, CS_IS_PARENTSCRIPT);
-	}
-
     // IM-2012-05-16 [[ BZ 10212 ]] deleting the dragtarget control in response
     // to a 'dragdrop' message would leave these globals pointing to the deleted
     // object, leading to an infinite loop if the target was a field
@@ -777,7 +770,9 @@ Boolean MCControl::del()
     if (MCdragsource == this)
         MCdragsource = nil;
     
-	return True;
+    // MCObject now does things on del(), so we must make sure we finish by
+    // calling its implementation.
+    return MCObject::del();
 }
 
 void MCControl::paste(void)

--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -401,7 +401,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, const char *script)
 	//   (for example 'getdefaultprinter()' on Linux) so don't indirect in this case.
 	bool t_is_parent_script;
 	if (objptr != NULL)
-		t_is_parent_script = objptr -> getstate(CS_IS_PARENTSCRIPT) && objptr -> gettype() == CT_BUTTON;
+		t_is_parent_script = objptr -> getisparentscript();
 	else
 		t_is_parent_script = false;
 

--- a/engine/src/objdefs.h
+++ b/engine/src/objdefs.h
@@ -402,10 +402,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define CS_MOUSE_UP_MENU        (1UL << 21)
 #define CS_VISITED              (1UL << 22)
 
-// MW-2008-10-28: [[ ParentScripts ]] If this state flag is set it means that
-//   the button is referenced as a parentScript.
-#define CS_IS_PARENTSCRIPT		(1UL << 21)
-
 // MCImage state
 #define CS_BEEN_MOVED           (1UL << 13)
 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -149,9 +149,12 @@ MCObject::MCObject()
 	
 	// MW-2012-10-10: [[ IdCache ]]
 	m_in_id_cache = false;
-	
+    
 	// IM-2013-04-16: Initialize to false;
 	m_script_encrypted = false;
+    
+    // Object's do not begin in the parentScript table.
+    m_is_parent_script = false;
 }
 
 MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
@@ -240,6 +243,10 @@ MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
 	
 	// MW-2012-10-10: [[ IdCache ]]
 	m_in_id_cache = false;
+    
+    // Cloned objects have a different identifier so are not in the parentScript
+    // table at the start.
+    m_is_parent_script = false;
 }
 
 MCObject::~MCObject()
@@ -290,6 +297,10 @@ MCObject::~MCObject()
 	//   all deletions vector through 'scheduledelete'.
 	if (m_in_id_cache)
 		getstack() -> uncacheobjectbyid(this);
+    
+    // If this object is a parent-script make sure we flush it from the table.
+	if (m_is_parent_script)
+		MCParentScript::FlushObject(this);
 }
 
 Chunk_term MCObject::gettype() const
@@ -805,8 +816,15 @@ void MCObject::deselect()
 
 Boolean MCObject::del()
 {
-	fprintf(stderr, "Object: ERROR tried to delete %s\n", getname_cstring());
-	return False;
+    // If the object is marked as being used as a parentScript, flush the parentScript
+    // table so we don't get any dangling pointers.
+	if (m_is_parent_script)
+	{
+		MCParentScript::FlushObject(this);
+        m_is_parent_script = false;
+	}
+    
+	return True;
 }
 
 void MCObject::paste(void)
@@ -3610,20 +3628,26 @@ bool MCObject::resolveparentscript(void)
 	t_stack = getstack() -> findstackname(MCNameGetOldString(t_script -> GetObjectStack()));
 
 	// Next search for the control we need.
-	MCControl *t_control;
-	t_control = NULL;
+	MCObject *t_object;
+	t_object = NULL;
 	if (t_stack != NULL)
-		t_control = t_stack -> getcontrolid(CT_BUTTON, t_script -> GetObjectId(), true);
+    {
+        if (t_script -> GetObjectId() != 0)
+            t_object = t_stack -> getcontrolid(CT_BUTTON, t_script -> GetObjectId(), true);
+        else
+            t_object = t_stack;
+    }
 
 	// If we found a control, resolve the parent script. Otherwise block it.
-	if (t_control != NULL)
+	if (t_object != NULL &&
+        t_object != this)
 	{
-		t_script -> Resolve(t_control);
+		t_script -> Resolve(t_object);
 
 		// MW-2015-05-30: [[ InheritedPscripts ]] Next we must ensure the
 		//   existence of the inheritence hierarchy, so resolve the parentScript's
 		//   parentScript.
-		if (!t_control -> resolveparentscript())
+		if (!t_object -> resolveparentscript())
 			return false;
 
 		// MW-2015-05-30: [[ InheritedPscripts ]] And then make sure it creates its

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -216,6 +216,9 @@ protected:
 	
 	// IM-2013-04-16: [[ BZ 10848 ]] // flag to record encrypted state of object script
 	bool m_script_encrypted : 1;
+    
+    // If this is true, then this object is in the parentScript resolution table.
+    bool m_is_parent_script : 1;
 	
 	char *tooltip;
 	
@@ -697,6 +700,16 @@ public:
 	{
 		return m_in_id_cache;
 	}
+    
+    void setisparentscript(bool p_value)
+    {
+        m_is_parent_script = p_value;
+    }
+    
+    bool getisparentscript(void)
+    {
+        return m_is_parent_script;
+    }
 
 	// IM-2013-02-11 image change notification (used by button icons, field images, etc.)
 	// returns true if the referenced image is still in use by this object

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -1019,7 +1019,11 @@ Exec_stat MCObject::setparentscriptprop(MCExecPoint& ep)
 			//
 			uint32_t t_id;
 			t_id = t_object -> getid();
-
+            
+            // If the object is a stack, then the id should be 0.
+            if (t_object -> gettype() == CT_STACK)
+                t_id = 0;
+                
 			MCNameRef t_stack;
 			t_stack = t_object -> getstack() -> getname();
 

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -326,9 +326,13 @@ Exec_stat MCObject::getprop(uint4 parid, Properties which, MCExecPoint &ep, Bool
 			MCParentScript *t_parent;
 			t_parent = parent_script -> GetParent();
  
-			ep . setstringf("button id %d of stack \"%s\"",
-								t_parent -> GetObjectId(),
-								MCNameGetCString(t_parent -> GetObjectStack()));
+            if (t_parent -> GetObjectId() != 0)
+                ep . setstringf("button id %d of stack \"%s\"",
+                                    t_parent -> GetObjectId(),
+                                    MCNameGetCString(t_parent -> GetObjectStack()));
+            else
+                ep . setstringf("stack \"%s\"",
+                                    MCNameGetCString(t_parent -> GetObjectStack()));
 		}
 	}
 	break;
@@ -967,11 +971,13 @@ Exec_stat MCObject::setparentscriptprop(MCExecPoint& ep)
 	uint32_t t_part_id;
 	if (t_stat == ES_NORMAL)
 		t_stat = t_chunk -> getobj(ep2, t_object, t_part_id, False);
-
-	// Check that the object is a button
-	if (t_stat == ES_NORMAL && t_object -> gettype() != CT_BUTTON)
-		t_stat = ES_ERROR;
 	
+	// Check that the object is a button or a stack.
+	if (t_stat == ES_NORMAL &&
+        t_object -> gettype() != CT_BUTTON &&
+        t_object -> gettype() != CT_STACK)
+		t_stat = ES_ERROR;
+    
 	// MW-2013-07-18: [[ Bug 11037 ]] Make sure the object isn't in the hierarchy
 	//   of the parentScript.
 	bool t_is_cyclic;
@@ -1048,7 +1054,7 @@ Exec_stat MCObject::setparentscriptprop(MCExecPoint& ep)
 			//   is because the inheritence hierarchy has been updated and so the
 			//   super_use chains need to be remade.
 			MCParentScript *t_this_parent;
-			if (getstate(CS_IS_PARENTSCRIPT))
+			if (m_is_parent_script)
 			{
 				t_this_parent = MCParentScript::Lookup(this);
 				if (t_this_parent != nil)

--- a/engine/src/parentscript.cpp
+++ b/engine/src/parentscript.cpp
@@ -366,9 +366,8 @@ void MCParentScript::Resolve(MCObject *p_object)
 	// Unblock this
 	m_blocked = false;
 
-	// Mark the object as being used as a parent script - note that this is a
-	// button state flag since we currently restrict parentScripts to buttons.
-	m_object -> setstate(True, CS_IS_PARENTSCRIPT);
+	// Mark the object as being used as a parent script.
+	m_object -> setisparentscript(true);
 
 	// Mark the object's stack as having an object which is a parent script.
 	MCStack *t_stack;
@@ -621,7 +620,7 @@ void MCParentScript::Detach(MCParentScriptUse *p_use)
 		// Unset the object's IS_PARENTSCRIPT state as it is no longer being used as
 		// one.
 		if (m_object != NULL)
-			m_object -> setstate(False, CS_IS_PARENTSCRIPT);
+			m_object -> setisparentscript(false);
 
 		// Now delete our state
 		delete this;

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -2733,8 +2733,10 @@ Boolean MCStack::del()
 	//   flag set, flush the parentscripts table.
 	if (getextendedstate(ECS_HAS_PARENTSCRIPTS))
 		MCParentScript::FlushStack(this);
-
-	return True;
+    
+    // MCObject now does things on del(), so we must make sure we finish by
+    // calling its implementation.
+    return MCObject::del();
 }
 
 void MCStack::paste(void)

--- a/engine/src/vclip.cpp
+++ b/engine/src/vclip.cpp
@@ -159,7 +159,10 @@ Exec_stat MCVideoClip::setprop(uint4 parid, Properties p, MCExecPoint &ep, Boole
 Boolean MCVideoClip::del()
 {
 	getstack()->removevclip(this);
-	return True;
+    
+    // MCObject now does things on del(), so we must make sure we finish by
+    // calling its implementation.
+    return MCObject::del();
 }
 
 void MCVideoClip::paste(void)


### PR DESCRIPTION
The behavior property can now be set to use either the script of a button, or the script of a stack.

This is file-format-backwards-compatible change - referencing a stack will cause the behavior reference to be written out to the stackfile with id 0 which an accessible runtime object can never have an id of.

When fetching the behavior property it might now either be a string of the form:

```
button id <id> of stack <stack>
```

or

```
stack <stack>
```

This might have implications on scripts which process the behavior property directly, rather than relying on chunk parsing.

To extend behaviors to be able to reference any object we will need to extend the chunk syntax to allow

```
object id <id> of stack <stack>
```

This is because ids can uniquely identify cards, audio clips, video clips as well as controls.
