### PR TITLE
[Coverity] Add Unreachable annotations to the blend-mode switch statements

### DIFF
--- a/engine/src/combiners.cpp
+++ b/engine/src/combiners.cpp
@@ -418,6 +418,9 @@ template<BitwiseOperation x_combiner, bool x_dst_alpha, bool x_src_alpha> INLINE
 	case OPERATION_SET:
 		r = 0x00ffffff;
 	break;
+    default:
+        MCUnreachable();
+    break;
 	}
 
 	if (x_src_alpha && x_dst_alpha)
@@ -548,6 +551,9 @@ template<ArithmeticOperation x_combiner, bool x_dst_alpha, bool x_src_alpha> INL
 		r = rr | rg | rb;
 	}
 	break;
+    default:
+        MCUnreachable();
+    break;
 	}
 
 	if (x_src_alpha && x_dst_alpha)
@@ -660,6 +666,9 @@ template<BasicImagingOperation x_combiner, bool x_dst_alpha, bool x_src_alpha> I
 	case OPERATION_BLEND_SCREEN:
 		r = packed_multiply_bounded(src, packed_inverse(dst)) + dst;
 	break;
+    default:
+        MCUnreachable();
+    break;
 	}
 
 	return r;
@@ -884,6 +893,9 @@ template<AdvancedImagingOperation x_combiner, bool x_dst_alpha, bool x_src_alpha
 		t_blue = downscale(t_src_blue * (t_dst_alpha - t_dst_blue) + t_dst_blue * (t_src_alpha - t_src_blue) + t_inv_dst_alpha_src_blue + t_inv_src_alpha_dst_blue);
 		t_alpha = t_src_alpha + t_dst_alpha - downscale(t_src_alpha_dst_alpha);
 	break;
+    default:
+        MCUnreachable();
+    break;
 	}
 
 	if (x_dst_alpha)

--- a/libgraphics/src/legacyblendmodes.cpp
+++ b/libgraphics/src/legacyblendmodes.cpp
@@ -493,6 +493,9 @@ template<BitwiseOperation x_combiner, bool x_dst_alpha, bool x_src_alpha> INLINE
 		case OPERATION_SET:
 			r = 0x00ffffff;
 			break;
+        default:
+            MCUnreachable();
+            break;
 	}
 	
 	if (x_src_alpha && x_dst_alpha)
@@ -622,6 +625,10 @@ template<ArithmeticOperation x_combiner, bool x_dst_alpha, bool x_src_alpha> INL
 			r = rr | rg | rb;
 		}
 			break;
+        
+        default:
+            MCUnreachable();
+            break;
 	}
 	
 	if (x_src_alpha && x_dst_alpha)
@@ -734,6 +741,9 @@ template<BasicImagingOperation x_combiner, bool x_dst_alpha, bool x_src_alpha> I
 		case OPERATION_BLEND_SCREEN:
 			r = packed_multiply_bounded(src, packed_inverse(dst)) + dst;
 			break;
+        default:
+            MCUnreachable();
+            break;
 	}
 	
 	return r;
@@ -958,6 +968,9 @@ template<AdvancedImagingOperation x_combiner, bool x_dst_alpha, bool x_src_alpha
 			t_blue = downscale(t_src_blue * (t_dst_alpha - t_dst_blue) + t_dst_blue * (t_src_alpha - t_src_blue) + t_inv_dst_alpha_src_blue + t_inv_src_alpha_dst_blue);
 			t_alpha = t_src_alpha + t_dst_alpha - downscale(t_src_alpha_dst_alpha);
 			break;
+        default:
+            MCUnreachable();
+            break;
 	}
 	
 	if (x_dst_alpha)


### PR DESCRIPTION
All switch statements are exhaustive over the valid input parameters, but this cannot be proven by static analysers like Coverity. Add default statements with an MCUnreachable() annotation.

Fixes Coverity defects 15998 16125 16265 16375 16481 16499 16586.
