### PR TITLE
lc-run: Add new -l, --load option for loading additional module files.

### DIFF
--- a/tests/lc-run/Makefile
+++ b/tests/lc-run/Makefile
@@ -20,6 +20,8 @@ TEST_DIR = $(SOLUTION_DIR)/_tests/lc-run
 check:
 	mkdir -p $(TEST_DIR)
 	$(LC_COMPILE) --modulepath $(TEST_DIR) --modulepath $(MODULE_DIR) \
+	    lc-run-lib.mlc --output $(TEST_DIR)/lc-run-lib.lcm
+	$(LC_COMPILE) --modulepath $(TEST_DIR) --modulepath $(MODULE_DIR) \
 	    lc-run-test.mlc --output $(TEST_DIR)/lc-run-test.lcm
-	$(LC_RUN) $(TEST_DIR)/lc-run-test.lcm
-	test "`$(LC_RUN) --list-handlers $(TEST_DIR)/lc-run-test.lcm`" = "main"
+	$(LC_RUN) -l $(TEST_DIR)/lc-run-lib.lcm $(TEST_DIR)/lc-run-test.lcm
+	test "`$(LC_RUN) -l $(TEST_DIR)/lc-run-lib.lcm --list-handlers $(TEST_DIR)/lc-run-test.lcm`" = "main"

--- a/tests/lc-run/lc-run-lib.mlc
+++ b/tests/lc-run/lc-run-lib.mlc
@@ -1,0 +1,7 @@
+module com.livecode.lc_run_lib
+
+public handler lib_main()
+	-- Do nothing
+end handler
+
+end module

--- a/tests/lc-run/lc-run-test.mlc
+++ b/tests/lc-run/lc-run-test.mlc
@@ -1,7 +1,9 @@
 module com.livecode.lc_run_test
 
+use com.livecode.lc_run_lib
+
 public handler main()
-	-- nothing
+	lib_main()
 end handler
 
 end module

--- a/toolchain/lc-compile/src/lc-run.cpp
+++ b/toolchain/lc-compile/src/lc-run.cpp
@@ -40,6 +40,7 @@ struct MCRunConfiguration
 {
 	MCStringRef m_filename;
 	MCNameRef m_handler;
+	MCProperListRef m_load_filenames;
 	bool m_list_handlers;
 };
 
@@ -65,6 +66,7 @@ MCRunUsage (int p_exit_status)
 "Run a compiled Livecode Builder bytecode file.\n"
 "\n"
 "Options:\n"
+"  -l, --load LCMLIB    Load an additional bytecode file.\n"
 "  -H, --handler NAME   Specify name of handler to run.\n"
 "      --list-handlers  List possible entry points in LCMFILE and exit.\n"
 "  -h, --help           Print this message.\n"
@@ -248,6 +250,21 @@ MCRunParseCommandLine (int argc,
 				continue;
 			}
 
+			if (MC_RUN_STRING_EQUAL (t_arg, "--load") ||
+			    MC_RUN_STRING_EQUAL (t_arg, "-l"))
+			{
+				if (NULL == t_argopt)
+					MCRunBadOptionArgError (t_arg, t_argopt);
+
+				++t_arg_idx; /* Consume option argument */
+
+				/* Add to load list */
+				if (!MCProperListPushElementOntoFront (x_config.m_load_filenames,
+				                                       t_argopt))
+					return false;
+				continue;
+			}
+
 			if (MC_RUN_STRING_EQUAL (t_arg, "--list-handlers"))
 			{
 				x_config.m_list_handlers = true;
@@ -327,6 +344,36 @@ MCRunLoadModule (MCStringRef p_filename,
 	if (!MCScriptCreateModuleFromStream (*t_stream, &t_module))
 		return false;
 
+	r_module = MCScriptRetainModule (*t_module);
+	return true;
+}
+
+static bool
+MCRunLoadModules (MCStringRef p_filename,
+                  MCProperListRef p_load_filenames,
+                  MCScriptModuleRef & r_module)
+{
+	/* Load main module */
+	MCAutoScriptModuleRef t_module;
+	if (!MCRunLoadModule (p_filename, &t_module))
+		return false;
+
+	/* Load other modules */
+	MCAutoScriptModuleRefArray t_load_modules;
+	uindex_t t_num_load = MCProperListGetLength (p_load_filenames);
+
+	if (!t_load_modules.New(t_num_load))
+		return false;
+
+	for (uindex_t i = 0; i < t_num_load; ++i)
+	{
+		MCValueRef t_element;
+		t_element = MCProperListFetchElementAtIndex (p_load_filenames, i);
+		if (!MCRunLoadModule ((MCStringRef) t_element, t_load_modules[i]))
+			return false;
+	}
+
+	/* Check main module is usable */
 	if (!MCScriptEnsureModuleIsUsable (*t_module))
 		return false;
 
@@ -394,6 +441,8 @@ main (int argc,
 	t_config.m_filename = MCValueRetain (kMCEmptyString);
 	t_config.m_handler = MCValueRetain (MCNAME("main"));
 	t_config.m_list_handlers = false;
+	if (!MCProperListCreateMutable (t_config.m_load_filenames))
+		MCRunStartupError(MCSTR("Initialization"));
 
 	/* ---------- Process command-line arguments */
 	if (!MCRunParseCommandLine (argc, argv, t_config))
@@ -404,8 +453,10 @@ main (int argc,
 	MCAutoScriptInstanceRef t_instance;
 	MCAutoValueRef t_ignored_retval;
 
-	if (!MCRunLoadModule (t_config.m_filename, &t_module))
-		MCRunStartupError(MCSTR("Load Module"));
+	if (!MCRunLoadModules (t_config.m_filename,
+	                       t_config.m_load_filenames,
+	                       &t_module))
+		MCRunStartupError (MCSTR("Load Modules"));
 
 	if (t_config.m_list_handlers)
 	{

--- a/toolchain/lc-run.1.md
+++ b/toolchain/lc-run.1.md
@@ -25,6 +25,12 @@ the value of `the command arguments`.
 
 ## OPTIONS
 
+* -l, --load _LCMLIB_:
+  In addition to loading the _LCMFILE_, load a module from the
+  bytecode file _LCMLIB_.  Any number of `--preload` options may be
+  provided.  _LCMFILE_ is loaded first, followed by the _LCMLIB_s in
+  reverse order.
+
 * -H, --handler _NAME_:
   Call the handler with the specified _NAME_ as the entry point of the program.
   _NAME_ must have public visibility and accept no arguments.  The default value


### PR DESCRIPTION
This solves the problem of "program that needs a couple of library modules" for the specific case of a small number of library modules, which is good enough for solving the test library problem without invasive libscript changes.
