### PR TITLE
LCS: Script Only Stack Specification

### DIFF
--- a/docs/specs/lcs-script_only_stacks.md
+++ b/docs/specs/lcs-script_only_stacks.md
@@ -1,0 +1,3 @@
+# LiveCode Script - Script Only Stacks
+Copyright 2015 LiveCode Ltd.
+


### PR DESCRIPTION
This is a place-holder for the spec which is to be written for script-only-stacks.

The remit of script-only-stacks is to be able to create a stack in a special mode where its content can be entirely serialized as a text-file. The use-case is for (mostly?) pure script bearing stacks. The textfile format must be readable by a human and easily editable in a text editor. It should be resilient as far as possible to merge conflicts when used correctly by the developer.

We have an initial implementation which exists in 6.7 onwards for script only stacks and it shown to be really quite useful for a number of projects so far.

However, it has a number of deficiencies which need some thought to resolve - hence a new spec.

Things to consider:
- you can't use script-onlys in server (as they conflict with PHP-style interpolated scripts)
- they only store the stack script
- all non-script data is lost even though some things (like simple string-like custom properties) could be preserved

Please comment below if there is anything else you think should be taken into consideration in an updated version of 'script only stacks', or if you have any ideas about them that might be useful.
