### PR TITLE
libscript: Refactor and extend MCScript auto ptr types

### DIFF
--- a/libscript/include/script-auto.h
+++ b/libscript/include/script-auto.h
@@ -22,79 +22,44 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 /* ================================================================ */
 
-class MCAutoScriptModuleRef
+template <typename T, T (*REF)(T), void (*UNREF)(T)>
+class MCAutoScriptObjectRefBase
 {
 public:
-	MCAutoScriptModuleRef (void)
+	MCAutoScriptObjectRefBase (void)
+		: m_value(nil)
+	{}
+
+	~MCAutoScriptObjectRefBase (void)
 	{
-		m_value = nil;
+		UNREF (m_value);
 	}
 
-	~MCAutoScriptModuleRef (void)
-	{
-		MCScriptReleaseModule (m_value);
-	}
-
-	MCScriptModuleRef operator = (MCScriptModuleRef value)
+	MCAutoScriptObjectRefBase operator = (T value)
 	{
 		MCAssert (nil == m_value);
-		m_value = MCScriptRetainModule (value);
+		m_value = REF (value);
 		return value;
 	}
 
-	MCScriptModuleRef& operator & (void)
+	T & operator & (void)
 	{
 		MCAssert (nil == m_value);
 		return m_value;
 	}
 
-	MCScriptModuleRef operator * (void) const
+	T operator * (void) const
 	{
 		return m_value;
 	}
 
 private:
-	MCScriptModuleRef m_value;
-
-	MCAutoScriptModuleRef & operator = (MCAutoScriptModuleRef & x);
+	T m_value;
+	MCAutoScriptObjectRefBase<T,REF,UNREF> & operator = (MCAutoScriptObjectRefBase<T,REF,UNREF> & x);
 };
 
-class MCAutoScriptInstanceRef
-{
-public:
-	MCAutoScriptInstanceRef (void)
-	{
-		m_value = nil;
-	}
-
-	~MCAutoScriptInstanceRef (void)
-	{
-		MCScriptReleaseInstance (m_value);
-	}
-
-	MCScriptInstanceRef operator = (MCScriptInstanceRef value)
-	{
-		MCAssert (nil == m_value);
-		m_value = MCScriptRetainInstance (value);
-		return value;
-	}
-
-	MCScriptInstanceRef& operator & (void)
-	{
-		MCAssert (nil == m_value);
-		return m_value;
-	}
-
-	MCScriptInstanceRef operator * (void) const
-	{
-		return m_value;
-	}
-
-private:
-	MCScriptInstanceRef m_value;
-
-	MCAutoScriptInstanceRef & operator = (MCAutoScriptInstanceRef & x);
-};
+typedef MCAutoScriptObjectRefBase<MCScriptModuleRef, MCScriptRetainModule, MCScriptReleaseModule> MCAutoScriptModuleRef;
+typedef MCAutoScriptObjectRefBase<MCScriptInstanceRef, MCScriptRetainInstance, MCScriptReleaseInstance> MCAutoScriptInstanceRef;
 
 /* ================================================================ */
 

--- a/libscript/include/script-auto.h
+++ b/libscript/include/script-auto.h
@@ -63,4 +63,62 @@ typedef MCAutoScriptObjectRefBase<MCScriptInstanceRef, MCScriptRetainInstance, M
 
 /* ================================================================ */
 
+template <typename T, T (*REF)(T), void (*UNREF)(T)>
+class MCAutoScriptObjectRefArrayBase
+{
+public:
+	MCAutoScriptObjectRefArrayBase (void)
+		: m_values(nil), m_count(0)
+	{}
+
+	~MCAutoScriptObjectRefArrayBase (void)
+	{
+		if (nil == m_values) return;
+		for (size_t i = 0; i < m_count; ++i)
+		{
+			UNREF(m_values[i]);
+		}
+		MCMemoryDeleteArray (m_values);
+		m_values = 0;
+		m_count = 0;
+	}
+
+	bool New (uindex_t p_size)
+	{
+		MCAssert (nil == m_values);
+		return MCMemoryNewArray (p_size, m_values, m_count);
+	}
+
+	T* Ptr ()
+	{
+		return m_values;
+	}
+
+	uindex_t Size() const
+	{
+		return m_count;
+	}
+
+	bool Resize(uindex_t p_new_count)
+	{
+		return MCMemoryResizeArray (p_new_count, m_values, m_count);
+	}
+
+	T & operator [] (const int p_index)
+	{
+		MCAssert (nil != m_values);
+		MCAssert (p_index >= 0);
+		return m_values[p_index];
+	}
+
+private:
+	T *m_values;
+	uindex_t m_count;
+};
+
+typedef MCAutoScriptObjectRefArrayBase<MCScriptModuleRef, MCScriptRetainModule, MCScriptReleaseModule> MCAutoScriptModuleRefArray;
+typedef MCAutoScriptObjectRefArrayBase<MCScriptInstanceRef, MCScriptRetainInstance, MCScriptReleaseInstance> MCAutoScriptInstanceRefArray;
+
+/* ================================================================ */
+
 #endif /* !__MC_SCRIPT_AUTO__ */


### PR DESCRIPTION
- Refactor libscript's auto pointer types to reduce code duplication and improve naming clarity.
- Add array auto pointer types.
