### PR TITLE
[Bug 14665] Make sure the app actually uses in-app purchasing

### DIFF
--- a/docs/notes/bugfix-14665.md
+++ b/docs/notes/bugfix-14665.md
@@ -1,0 +1,1 @@
+#    fatal exception - Service not registered: com.runrev.android.billing.google.IabHelper

--- a/engine/src/java/com/runrev/android/billing/BillingModule.java
+++ b/engine/src/java/com/runrev/android/billing/BillingModule.java
@@ -31,6 +31,10 @@ public class BillingModule
     
     public BillingProvider getBillingProvider()
     {
+        // PM-2015-02-25: [[ Bug 14665 ]] Make sure the "In-app Purchase" checkbox is ticked in standalone settings
+        if (Engine.doGetCustomPropertyValue("cREVStandaloneSettings", "android,InAppPurchasing").equals("false"))
+            return null;
+        
         Log.d(TAG, "Fetching the billing provider...");
         String t_billing_provider = Engine.doGetCustomPropertyValue("cREVStandaloneSettings", "android,billingProvider");
         Log.d(TAG, "Provider is " + t_billing_provider);

--- a/engine/src/java/com/runrev/android/billing/google/IabHelper.java
+++ b/engine/src/java/com/runrev/android/billing/google/IabHelper.java
@@ -294,7 +294,14 @@ public class IabHelper {
         mSetupDone = false;
         if (mServiceConn != null) {
             logDebug("Unbinding from service.");
-            if (mContext != null) mContext.unbindService(mServiceConn);
+            
+            /** PM-2015-02-25: [[ Bug 14665 ]]
+             * mService is only set once the Service has been registered,
+             * so checking it for != null will guarantee that service is indeed registered, 
+             * before we try to unbind from it. The service will not be registered only in 
+             * devices with a very old version of Google Play app or with no Google Play app at all
+             */
+            if (mContext != null && mService != null) mContext.unbindService(mServiceConn);
         }
         mDisposed = true;
         mContext = null;


### PR DESCRIPTION
before initialising the billing provider. Also, prevent a crash on exit when the device does not support in-app purchase
