### PR TITLE
libfoundation: Provide a better definition for `nil`.

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -600,7 +600,21 @@ typedef const struct __CFData *CFDataRef;
 //  POINTER TYPES
 //
 
-#define nil 0
+#if defined(__cplusplus) /* C++ */
+#	if defined(__GCC__)
+#		define nil __null
+#	else
+#		define nil uintptr_t(0)
+#	endif
+
+#else /* C */
+#	if defined(__GCC__)
+#		define nil __null
+#	else
+#		define nil ((void*)0)
+#	endif
+
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
`nil` is supposed to be an invalid pointer value.  Previously, it was defined to be 0.

When calling C-style variadic functions, `nil` was variously used a custodian for a pointer-sized slot.  A segfault was occurring on some platform/toolchain combinations because `nil` evaluated to `(int) 0`.

In variadic functions, arguments are packed with `sizeof(int)` alignment.  On platforms with `sizeof(void *) > sizeof(int)`, this meant that `nil` was being packed into 32 bits and unpacked into 64 bits, resulting in an invalid 32-bit read and possible segfault.

This patch makes **libfoundation** try harder to suitably define `nil`. First, it tries to use the compiler's "built-in" null value in order to enable compilation warnings about arithmetic using null.  Failing that, it makes sure that the 0 value has the same size as a pointer, ensuring that it gets packed into the right size slot in the stack for the variadic call.
