### PR TITLE
[Build] Linux: Compare stripped compilers for bootstrap verification.

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -414,7 +414,7 @@ ifeq ($(STAGE),4)
 	for f in $(COMPILE_bootstrap_check_exes); \
 	    do strip -s -o $$f-strip $$f ; \
 	done
-	@if ! cmp $(COMPILE_bootstrap_check_exes); then \
+	@if ! cmp $(addsuffix -strip,$(COMPILE_bootstrap_check_exes)); then \
 	    echo; \
 	    echo "ERROR: Stage 4 output does not match stage 3."; \
 	    echo "ERROR: There may be a bootstrapping problem."; \


### PR DESCRIPTION
After going to the the trouble of stripping the stage 3 and stage 4
compilers for comparison, it might make sense to actually compare the
stripped binaries rather than the unstripped ones.
