### PR TITLE
[[ Bug 14695 ]] Assertion failure in dynamic call.

### DIFF
--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -135,7 +135,7 @@ bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target)
     // We require that source is concrete for all but handler types (as handlers
     // have unnamed typeinfos which we need to compare with potentially named
     // handler type typeinfos).
-    MCAssert(MCTypeInfoIsNamed(source) || MCTypeInfoIsHandler(source));
+    MCAssert(MCTypeInfoIsNamed(source) || MCTypeInfoIsHandler(source) || MCTypeInfoIsOptional(source));
     
     // Resolve the source type.
     MCResolvedTypeInfo t_resolved_source;


### PR DESCRIPTION
The MCTypeInfoConforms() function was too strict - it also needs to handle the case
where source is an optional typeinfo (as well as handler and named).
