### PR TITLE
[[ Bug 14700 ]] revZipOpenArchive can fail in 64-bit mode.

### DIFF
--- a/docs/notes/bugfix-14700.md
+++ b/docs/notes/bugfix-14700.md
@@ -1,0 +1,2 @@
+# revZipOpenArchive can fail on 64-bit Linux
+The revZipOpenArchive command can fail to open a valid zip archive on 64-bit versions of Linux. This was due to a 64-bit cleanliness problem in the libzip library which has now been fixed.


### PR DESCRIPTION
This pull request contains the release note.

Please note there is a corresponding pull-request against thirdparty which needs to be merged - https://github.com/runrev/livecode-thirdparty/pull/22
