### PR TITLE
[[ Bug 14724 ]] Fix seg fault in MCArraysExecCombineAsSet()

### DIFF
--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -393,8 +393,11 @@ void MCArraysExecCombineAsSet(MCExecContext& ctxt, MCArrayRef p_array, MCStringR
             return;
         }
     }
-    
-    MCStringCopy(*t_string, r_string);
+
+    if (*t_string == nil)
+        r_string = MCValueRetain(kMCEmptyString);
+    else
+        MCStringCopy(*t_string, r_string);
 }
 
 //////////


### PR DESCRIPTION
Fixes a seg fault that would occur when evaluating

```
combine X using RETURN as set
```

with `X` empty.  The seg fault was happening when a null pointer was passed to `MCStringCopy()`.

[Bug 14724](http://quality.runrev.com/show_bug.cgi?id=14724)
