### PR TITLE
[Bug 14677] Rework "last offset" string operation for native strings.

### DIFF
--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -2646,30 +2646,57 @@ bool MCStringLastIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, MC
     {
         if (__MCStringIsNative(p_needle))
         {
-            uindex_t t_limit;
-            t_limit = p_range . offset + p_range . length;
-            while (t_limit--)
-            {
-				if (t_limit < p_range.offset)
+			const char_t *t_needle = p_needle->native_chars;
+			uindex_t t_needle_len = p_needle->char_count;
+
+			/* If needle is longer than range, can't possibly be found. */
+			if (p_range.length < t_needle_len)
+				return false;
+
+			/* Start search at first possible offset of needle within range */
+			uindex_t t_offset; /* Relative to start of range */
+			t_offset = p_range.length - t_needle_len;
+
+			while (true)
+			{
+				const char_t *t_haystack;
+				uindex_t t_haystack_len;
+
+				t_haystack = self->native_chars + p_range.offset + t_offset;
+				t_haystack_len = p_range.length - t_offset;
+
+				uindex_t t_prefix_length;
+				if (p_options == kMCStringOptionCompareCaseless ||
+				    p_options == kMCStringOptionCompareFolded)
+				{
+					t_prefix_length ==
+						MCNativeCharsSharedPrefixCaseless (t_haystack,
+						                                   t_haystack_len,
+						                                   t_needle,
+						                                   t_needle_len);
+				}
+				else
+				{
+					t_prefix_length =
+						MCNativeCharsSharedPrefixExact (t_haystack,
+						                                t_haystack_len,
+						                                t_needle,
+						                                t_needle_len);
+				}
+				if (t_prefix_length == t_needle_len)
+				{
+					r_offset = p_range.offset + t_offset;
+					return true;
+				}
+
+				/* No match at start of range */
+				if (0 == t_offset)
 					break;
 
-                // Compute the length of the shared prefix *before* offset - this means
-                // we adjust offset down by one before comparing.
-                uindex_t t_prefix_length;
-                if (p_options == kMCStringOptionCompareCaseless || p_options == kMCStringOptionCompareFolded)
-                    t_prefix_length = MCNativeCharsSharedPrefixCaseless(self -> native_chars + (t_limit - 1), self -> char_count - (t_limit - 1), p_needle -> native_chars, p_needle -> char_count);
-                else
-                    t_prefix_length = MCNativeCharsSharedPrefixExact(self -> native_chars + (t_limit - 1), self -> char_count - (t_limit - 1), p_needle -> native_chars, p_needle -> char_count);
-                
-                // If the prefix length is the same as the needle then we are done.
-                if (t_prefix_length == p_needle -> char_count)
-                {
-                    r_offset = t_limit - 1;
-                    return true;
-                }
-            }
-            return false;
-        }
+				--t_offset;
+			}
+			return false;
+		}
         
         if (__MCStringCantBeNative(p_needle, p_options))
             return false;

--- a/tests/lcb/stdlib/char.lcb
+++ b/tests/lcb/stdlib/char.lcb
@@ -292,8 +292,8 @@ public handler TestOffset()
 
 	test "offset (single, same)" when the offset of "x" in "x" is 1
 	test "first offset (single, same)" when the first offset of "x" in "x" is 1
-	skip test "last offset (single, same)" because "bug 14677"
-	--test "last offset (single, same)" when the last offset of "x" in "x" is 1
+	-- bug 14677
+	test "last offset (single, same)" when the last offset of "x" in "x" is 1
 
 	-- "chars" variant
 	test "offset chars (single)" when the first offset of chars "x" in ".xx." is 2
@@ -333,8 +333,8 @@ public handler TestOffsetAfter()
 	test "first offset after (single, invalid +ve)" when the first offset of "x" after 3 in "x" is 0
 	test "first offset after (single, invalid -ve)" when the first offset of "x" after -3 in "x" is 1
 	test "last offset after (single, invalid +ve)" when the last offset of "x" after 3 in "x" is 0
-	skip test "last offset after (single, invalid -ve)" because "bug 14677"
-	--test "last offset after (single, invalid -ve)" when the last offset of "x" after -3 in "x" is 1
+	-- bug 14677
+	test "last offset after (single, invalid -ve)" when the last offset of "x" after -3 in "x" is 1
 
 	-- "chars" variants
 	test "offset after chars (single, +ve)" when the offset of chars "x" after 1 in "x.xx." is 2
@@ -354,9 +354,9 @@ public handler TestOffsetAfterZero()
 	put the last offset of "x" in ".x." into tNoAfter
 	test "last offset after (single, 0)" when the last offset of "x" after 0 in ".x." is tNoAfter
 
-	skip test "last offset after (single, 0, same)" because "bug 14677"
-	--put the last offset of "x" in "x" into tNoAfter
-	--test "the last offset after (single, 0, same)" when the last offset of "x" after 0 in "x" is tNoAfter
+	-- bug 14677
+	put the last offset of "x" in "x" into tNoAfter
+	test "the last offset after (single, 0, same)" when the last offset of "x" after 0 in "x" is tNoAfter
 end handler
 
 public handler TestBeginsWith()


### PR DESCRIPTION
Rework "the last offset" syntax implementation for native strings, fixing a number of issues.
- Avoid `uindex_t` underflow errors when searching for 1 character string in 1 character string.
- Start searching at the last position at which the needle will fit into the range, rather than at the end of the haystack.  For example, when searching for "xxxx" in the string "xxxx.", start searching at offset 2 rather than offset 5.
- Limit the underlying "shared prefix" operation to looking at characters in the specified range of the haystack string, rather than allowing the needle to be matched against characters beyond the end of the range.
