### PR TITLE
[[ Bug 14591 ]] LCB: Make precedence of unary minus higher than that of exponentiation

### DIFF
--- a/libscript/src/arithmetic.mlc
+++ b/libscript/src/arithmetic.mlc
@@ -209,7 +209,7 @@ The unary plus operator is a no-op on the predefined numeric types.
 Tags: Math
 */
 
-syntax PlusUnaryOperator is prefix operator with precedence 1
+syntax PlusUnaryOperator is prefix operator with precedence 0
     "+" <Operand: Expression>
 begin
     MCArithmeticEvalPlusNumber(Operand, output)
@@ -228,7 +228,7 @@ Example:
 Tags: Math
 */
 
-syntax MinusUnaryOperator is prefix operator with precedence 1
+syntax MinusUnaryOperator is prefix operator with precedence 0
     "-" <Operand: Expression>
 begin
     MCArithmeticEvalMinusNumber(Operand, output)

--- a/tests/lcb/stdlib/math.lcb
+++ b/tests/lcb/stdlib/math.lcb
@@ -46,7 +46,7 @@ public handler TestRound()
 end handler
 
 public handler TestPow()
-	test "pow (-ve, -ve)" when -2 ^ -2 is -0.25
+	test "pow (-ve, -ve)" when -2 ^ -2 is 0.25
 	test "pow (-ve, +ve)" when (-2) ^ 2 is 4
 	test "pow (-ve, +ve)" when -2 ^ 3 is -8
 	test "pow (+ve, -ve)" when 2 ^ -2 is 0.25
@@ -65,8 +65,8 @@ public handler TestPowDomain()
 end handler
 
 public handler TestPowPrecedence()
-	broken test "pow vs. unary−" when -2 ^ 2 is 4 because "bug 14591"
-	broken test "pow vs. unary−" when -2 ^ 0 is 1 because "bug 14591"
+	test "pow vs. unary−" when -2 ^ 2 is 4
+	test "pow vs. unary−" when -2 ^ 0 is 1
 end handler
 
 public handler TestLog10()


### PR DESCRIPTION
This change makes the relative precedence of unary - and ^ consistent with that of LiveCode script.
