### PR TITLE
[Bug 14689] Cast the last nil sentinel to prevent EXC_BAD_ACCESS

### DIFF
--- a/docs/notes/bugfix-14689.md
+++ b/docs/notes/bugfix-14689.md
@@ -1,0 +1,1 @@
+#    Option menu crashes app in Simulator 8.0

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -1866,7 +1866,8 @@ NSString* MCIPhoneGetDeviceModelName(void)
                                            @"iPod 3rd Gen",         @"iPod3,1",
 										   @"iPod 4th Gen",         @"iPod4,1",
                                            @"iPod 5th Gen",         @"iPod5,1",
-                                           nil];
+                                           // PM-2015-03-03: [[ Bug 14689 ]] Cast to NSString* to prevent EXC_BAD_ACCESS when in release mode and run in 64bit device/sim
+                                           (NSString *)nil];
 										   
 	
 	NSString *t_device_name = [commonNamesDictionary objectForKey: t_machine_name];


### PR DESCRIPTION
The crash (because of EXC_BAD_ACCESS) happened only in release mode, and only when tested against 64 bit iOS devices (physical or simulated)
