### PR TITLE
[Bug 14755] Implement WString foreign type; fix minor NativeCString bugs

### DIFF
--- a/libscript/src/foreign.mlc
+++ b/libscript/src/foreign.mlc
@@ -27,5 +27,6 @@ public foreign type index binds to "kMCIntTypeInfo"
 public foreign type uindex binds to "kMCUIntTypeInfo"
 
 public foreign type NativeCString binds to "kMCNativeCStringTypeInfo"
+public foreign type WString binds to "kMCWStringTypeInfo"
 
 end module

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -58,15 +58,17 @@ static bool __cstring_copy(void *from, void *to)
         *(void **)to = nil;
         return true;
     }
+
+    const char *t_old_string = *(char **) from;
     
     size_t t_length;
-    t_length = strlen(*(char **)from) + 1;
+    t_length = strlen(t_old_string) + 1;
     
     char *t_new_string;
     if (!MCMemoryNewArray(t_length, t_new_string))
         return false;
     
-    MCMemoryCopy(t_new_string, from, t_length);
+    MCMemoryCopy(t_new_string, t_old_string, t_length);
     
     *(char **)to = t_new_string;
     

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -76,9 +76,10 @@ static bool __cstring_copy(void *from, void *to)
 static bool __cstring_equal(void *left, void *right, bool& r_equal)
 {
     if (*(void **)left == nil || *(void **)right == nil)
-        return left == right;
-    
-    return strcmp(*(char **)left, *(char **)right) == 0;
+		r_equal = (left == right);
+	else
+		r_equal = strcmp(*(char **)left, *(char **)right) == 0;
+	return true;
 }
 
 static bool __cstring_hash(void *value, hash_t& r_hash)


### PR DESCRIPTION
Provide a `WString` type in the `com.livecode.foreign` module.  Also, fix a couple of minor bugs in the `NativeCString` type's equality and copying methods.
