### PR TITLE
[[ Bug 13110 ]] Debugger triggers when using 'do'.

### DIFF
--- a/engine/src/debug.cpp
+++ b/engine/src/debug.cpp
@@ -269,8 +269,13 @@ void MCB_prepmessage(MCExecContext &ctxt, MCNameRef mess, uint2 line, uint2 pos,
 void MCB_trace(MCExecContext &ctxt, uint2 line, uint2 pos)
 {
 	uint2 i;
-
-	if (MCtrace && (MCtraceuntil == MAXUINT2 || MCnexecutioncontexts == MCtraceuntil))
+    
+    // MW-2015-03-03: [[ Bug 13110 ]] If this is an internal handler as a result of do
+    //   then *don't* debug it.
+    if (ctxt . GetHandler() -> getname() == MCM_message)
+        return;
+	
+    if (MCtrace && (MCtraceuntil == MAXUINT2 || MCnexecutioncontexts == MCtraceuntil))
 	{
 		MCtraceuntil = MAXUINT2;
 		MCB_prepmessage(ctxt, MCM_trace, line, pos, 0);
@@ -285,9 +290,9 @@ void MCB_trace(MCExecContext &ctxt, uint2 line, uint2 pos)
 			{
 				MCParentScriptUse *t_parentscript;
 				t_parentscript = ctxt . GetParentScript();
-				if (t_parentscript == NULL && MCbreakpoints[i].object == ctxt.GetObject() ||
-					t_parentscript != NULL && MCbreakpoints[i].object == t_parentscript -> GetParent() -> GetObject())
-				MCB_prepmessage(ctxt, MCM_trace_break, line, pos, 0, MCbreakpoints[i].info);
+				if ((t_parentscript == NULL && MCbreakpoints[i].object == ctxt.GetObject()) ||
+					(t_parentscript != NULL && MCbreakpoints[i].object == t_parentscript -> GetParent() -> GetObject()))
+                    MCB_prepmessage(ctxt, MCM_trace_break, line, pos, 0, MCbreakpoints[i].info);
 			}
 	}
 }


### PR DESCRIPTION
The debugger will trigger a breakpoint on the first few lines of a script when a do is executed in the context of the same object.

Essentially, the check for breakpoints gets confused in this case so if you do script has 3 lines, and you have a breakpoint in the first 3 lines of the objects script, you'll get a debug-break action.

This has been fixed by guarding MCB_trace against doing anything if within a handler called 'message' - which is what do uses for this purpose.
