### PR TITLE
[[ Bug 14744 ]] Fix incorrect codeunit count calculation

### DIFF
--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -76,7 +76,8 @@ void MCStringsCountChunksInRange(MCExecContext& ctxt, Chunk_term p_chunk_type, M
     
     if (p_chunk_type == CT_CODEUNIT)
     {
-        r_count = MCU_min(MCStringGetLength(p_string), p_range . length) - p_range . offset;
+        // AL-2015-03-03: [[ Bug 14744 ]] Fix incorrect codeunit count calculation
+        r_count = MCU_min(MCStringGetLength(p_string) - p_range . offset, p_range . length);
         return;
     }
     


### PR DESCRIPTION
If the incoming range length exceeds the string length, clamp the codeunit count.
