### PR TITLE
[[ Bug 14737 ]] Ensure property changed message is sent when appropriate

### DIFF
--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -4226,8 +4226,10 @@ bool MCChunk::getsetprop(MCExecContext &ctxt, Properties which, MCNameRef index,
             t_success = t_obj_chunk . object -> getprop(ctxt, t_obj_chunk . part_id, which, index, effective, r_value);
         else
             t_success = t_obj_chunk . object -> setprop(ctxt, t_obj_chunk . part_id, which, index, effective, r_value);
-        MCValueRelease(t_obj_chunk . mark . text);
-        return t_success;
+        
+        // AL-2015-03-04: [[ Bug 14737 ]] Ensure property listener is signalled.
+        if (!t_success)
+            ctxt . Throw();
     }
     else
     {

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -2190,6 +2190,8 @@ void MCModeGetRevObjectListeners(MCExecContext& ctxt, uindex_t& r_count, MCStrin
 #ifdef FEATURE_PROPERTY_LISTENER
     // MM-2012-09-05: [[ Property Listener ]]
     MCInternalObjectListenerGetListeners(ctxt, r_listeners, r_count);
+    // AL-2015-03-04: [[ Bug 14737 ]] Don't reset the count of listeners to zero.
+    return;
 #endif			
     r_count = 0;
 }
@@ -2197,6 +2199,8 @@ void MCModeGetRevPropertyListenerThrottleTime(MCExecContext& ctxt, uinteger_t& r
 {
 #ifdef FEATURE_PROPERTY_LISTENER
     r_time = MCpropertylistenerthrottletime;
+    // AL-2015-03-04: [[ Bug 14737 ]] Don't reset the returned throttle time to 0.
+    return;
 #endif			
     r_time = 0;
 }


### PR DESCRIPTION
The non-chunk type object setting was returning rather than falling through to the property listener signalling below.
