### PR TITLE
[Bug 14779] Receive a purchaseStateUpdate msg with state=complete

### DIFF
--- a/docs/notes/bugfix-14779.md
+++ b/docs/notes/bugfix-14779.md
@@ -1,0 +1,1 @@
+#   [in-app purchase] Android: Receive a purchaseStateUpdate message with state=complete after calling mobileStoreConfirmPurchase 

--- a/engine/src/mblandroidstore.cpp
+++ b/engine/src/mblandroidstore.cpp
@@ -354,7 +354,13 @@ static bool purchase_confirm(MCPurchase *p_purchase)
     MCAndroidEngineRemoteCall("purchaseConfirmDelivery", "bis", &t_result, p_purchase->id, t_android_data->notification_id);
     
     if (t_result)
+    {
+        // PM-2015-03-04: [[ Bug 14779 ]] Send a purchaseStateUpdate msg with state=complete
+        p_purchase->state = kMCPurchaseStateComplete;
         MCPurchaseCompleteListUpdate(p_purchase);
+        MCPurchaseNotifyUpdate(p_purchase);
+        MCPurchaseRelease(p_purchase);
+    }
     
     return t_result;
 }
@@ -365,7 +371,7 @@ bool MCPurchaseConfirmDelivery(MCPurchase *p_purchase)
     if (!(p_purchase->state == kMCPurchaseStatePaymentReceived || p_purchase->state == kMCPurchaseStateRefunded || p_purchase->state == kMCPurchaseStateRestored))
         return false;
     
-    purchase_confirm(p_purchase);
+    return purchase_confirm(p_purchase);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
after calling mobileStoreConfirmPurchase on android. This is the current flow on iOS.
