### PR TITLE
[Bug 14664] Avoid cursor flickering when focussing a field

### DIFF
--- a/docs/notes/bugfix-14664.md
+++ b/docs/notes/bugfix-14664.md
@@ -1,0 +1,1 @@
+#    Mac OS too many screen updates when focussing field

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -422,7 +422,7 @@ void MCField::kfocus()
 			// MW-2011-08-18: [[ Layers ]] Invalidate the whole object, noting
 			//   possible change in transient.
 			layer_transientchangedandredrawall(t_old_trans);
-			replacecursor(False, False);
+			
 			MCscreen->addtimer(this, MCM_internal, MCblinkrate);
 			if (!(state & CS_MFOCUSED) && flags & F_AUTO_TAB)
 				seltext(0, getpgsize(paragraphs), True);
@@ -430,6 +430,9 @@ void MCField::kfocus()
 				message(MCM_open_field);
 			else
 				message(MCM_focus_in);
+                
+            // PM-2015-03-05: [[ Bug 14664 ]] Avoid flickering and draw cursor in the correct position after focussing the field
+            replacecursor(False, False);
 		}
 		if (!(flags & F_LOCK_TEXT))
 			MCModeActivateIme(getstack(), true);


### PR DESCRIPTION
Fixes cursor flickering in the following scenario:
1) Create a stack
2) Drag out a field
3) Switch to run mode and type in some text
4) Place the cursor at the start of the text
5) Unfocus the field
6) Click at the end of the text to focus the field
RESULT: Flicker as cursor draws at the start of the field, then in the correct position at the end of the field
