### PR TITLE
[[ Bug 14815 ]] Correct mouseRelease.

### DIFF
--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -539,7 +539,7 @@ bool MCWidgetEventManager::mouseRelease(MCWidget* p_widget, uinteger_t p_which)
     // Send a mouse release event if the widget handles it
     bool t_accepted;
     t_accepted = false;
-    if (p_widget->handlesMouseRelease())
+    if (p_widget->handlesMouseCancel())
     {
         p_widget->OnMouseCancel(p_which);
         t_accepted = true;

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -73,6 +73,7 @@ MCWidgetEventManager::MCWidgetEventManager() :
   m_modifiers(0),
   m_keystring(nil),
   m_mouse_focus(nil),
+  m_mouse_grab(nil),
   m_keyboard_focus(nil),
   m_doubleclick_time(MCdoubletime),
   m_doubleclick_distance(MCdoubledelta),
@@ -194,8 +195,14 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
             mouseLeave(p_widget);
         }
         
+        if (m_mouse_grab == p_widget)
+        {
+            mouseMove(p_widget, p_x, p_y);
+            return true;
+        }
+            
         // This is not the widget you were looking for
-        return False;
+        return false;
     }
     
     // Has the focus state for this widget changed?
@@ -418,6 +425,9 @@ void MCWidgetEventManager::mouseLeave(MCWidget* p_widget)
 
 bool MCWidgetEventManager::mouseDown(MCWidget* p_widget, uinteger_t p_which)
 {
+    if (m_mouse_buttons == 0)
+        m_mouse_grab = p_widget;
+    
     // Mouse button is down
     m_mouse_buttons |= (1 << p_which);
     
@@ -452,6 +462,9 @@ bool MCWidgetEventManager::mouseUp(MCWidget* p_widget, uinteger_t p_which)
 {
     // Mouse button is no longer down
     m_mouse_buttons &= ~(1 << p_which);
+    
+    if (m_mouse_buttons == 0)
+        m_mouse_grab = nil;
     
     if (!widgetIsInRunMode(p_widget))
         return false;

--- a/engine/src/widget-events.h
+++ b/engine/src/widget-events.h
@@ -89,6 +89,7 @@ private:
     uinteger_t  m_modifiers;
     MCStringRef m_keystring;
     MCWidget*   m_mouse_focus;
+    MCWidget*   m_mouse_grab;
     MCWidget*   m_keyboard_focus;
     
     // Parameters for controlling double-click time and position deltas

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -807,13 +807,13 @@ bool MCWidget::handlesMouseUp() const
     return MCScriptQueryHandlerOfModule(MCScriptGetModuleOfInstance(m_instance), MCNAME("OnMouseUp"), t_signature);
 }
 
-bool MCWidget::handlesMouseRelease() const
+bool MCWidget::handlesMouseCancel() const
 {
     if (m_instance == nil)
         return false;
     
     MCTypeInfoRef t_signature;
-    return MCScriptQueryHandlerOfModule(MCScriptGetModuleOfInstance(m_instance), MCNAME("OnMouseRelease"), t_signature);
+    return MCScriptQueryHandlerOfModule(MCScriptGetModuleOfInstance(m_instance), MCNAME("OnMouseCancel"), t_signature);
 }
 
 bool MCWidget::handlesKeyPress() const

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -89,7 +89,7 @@ public:
     ////////// Functions used by the event manager for event processing
     bool handlesMouseDown() const;
     bool handlesMouseUp() const;
-    bool handlesMouseRelease() const;
+    bool handlesMouseCancel() const;
     bool handlesKeyPress() const;
     bool handlesActionKeyPress() const;
     bool handlesTouches() const;

--- a/engine/src/widget.mlc
+++ b/engine/src/widget.mlc
@@ -220,10 +220,11 @@ Syntax: OnMouseMove
 Summary: Sent when the mouse pointer moves within the widget's rect.
 
 
-Name: OnMouseRelease
+Name: OnMouseCancel
 Type: message
-Syntax: OnMouseRelease
-Summary: Sent when the mouse button is released outside of the widget's rect.
+Syntax: OnMouseCancel
+Summary: Sent when something happens which should cause the previous mouse down
+action to be considered cancelled. For example, opening a popup during OnMouseDown.
 
 
 Name: OnMouseDown
@@ -235,7 +236,8 @@ Summary: Sent when the mouse button is pushed within the widget's rect.
 Name: OnMouseUp
 Type: message
 Syntax: OnMouseUp
-Summary: Sent when the mouse button is released within the widget's rect.
+Summary: Sent when the mouse button is released regardless of whether the pointer
+is within the widget's rect or not.
 
 
 Name: OnMouseScroll


### PR DESCRIPTION
The docs and implementation have been corrected so that 'OnMouseCancel' is sent in response to a cancellation of a mouse down sequence.
