### PR TITLE
LCB-Widget: Add 'the click button' syntax

### DIFF
--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -361,6 +361,11 @@ void MCWidgetEventManager::GetSynchronousClickPosition(coord_t& r_x, coord_t& r_
     r_y = m_click_y;
 }
 
+void MCWidgetEventManager::GetSynchronousClickButton(unsigned int& r_button) const
+{
+    r_button = m_click_button;
+}
+
 void MCWidgetEventManager::GetAsynchronousMousePosition(coord_t& r_x, coord_t& r_y) const
 {
     r_x = MCmousex;

--- a/engine/src/widget-events.h
+++ b/engine/src/widget-events.h
@@ -71,6 +71,7 @@ public:
     // Returns the synchronous mouse/click coordinates
     void GetSynchronousMousePosition(coord_t& r_x, coord_t& r_y) const;
     void GetSynchronousClickPosition(coord_t& r_x, coord_t& r_y) const;
+    void GetSynchronousClickButton(unsigned int& r_button) const;
     
     // Returns the asynchronous ("current") mouse/click coordinates
     void GetAsynchronousMousePosition(coord_t& r_x, coord_t& r_y) const;

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -1753,6 +1753,23 @@ extern "C" MC_DLLEXPORT void MCWidgetGetClickPosition(bool p_current, MCCanvasPo
 
 ////////////////////////////////////////////////////////////////////////////////
 
+extern "C" MC_DLLEXPORT void MCWidgetGetClickButton(bool p_current, unsigned int& r_button)
+{
+    if (MCwidgetobject == nil)
+    {
+        MCWidgetThrowNoCurrentWidgetError();
+        return;
+    }
+    
+    // TODO: Implement asynchronous version.
+    if (!p_current)
+        MCwidgeteventmanager -> GetSynchronousClickButton(r_button);
+    else
+        MCErrorThrowGeneric(MCSTR("'the current click button' is not implemented yet"));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 typedef struct __MCPressedState* MCPressedStateRef;
 MCTypeInfoRef kMCPressedState;
 

--- a/engine/src/widget.mlc
+++ b/engine/src/widget.mlc
@@ -572,6 +572,8 @@ end syntax
 
 public foreign handler MCWidgetGetMousePosition(in pCurrent as CBool, out rLocation as Point) as undefined binds to "<builtin>"
 public foreign handler MCWidgetGetClickPosition(in pCurrent as CBool, out rLocation as Point) as undefined binds to "<builtin>"
+public foreign handler MCWidgetGetClickButton(in pCurrent as CBool, out rButton as CUInt) as undefined binds to "<builtin>"
+
 public foreign handler MCWidgetGetMouseButtonState(in pIndex as LCUInt, out rPressed /*as PressedState*/) as undefined binds to "<builtin>"
 public foreign handler MCWidgetGetModifierKeys(in pCurrent as CBool, out rKeys as List) as undefined binds to "<builtin>"
 
@@ -625,6 +627,27 @@ syntax TheClickLocation is expression
   "the" ( "current" <IsCurrent=true> | <IsCurrent=false> ) "click" "position"
 begin
     MCWidgetGetClickPosition(IsCurrent, output)
+end syntax
+
+/*
+Summary:        Determines the mouse button which started the mouse click.
+
+Returns:        The index of the mouse button which started the mouse click.
+
+Example:
+    variable tButton as integer
+    put the click button into tButton
+    
+    if tButton is 1 then
+        // do primary button action
+    else
+        // do secondary button action
+    end if
+*/
+syntax TheClickButton is expression
+    "the" ( "current" <IsCurrent=true> | <IsCurrent=false> ) "click" "button"
+begin
+    MCWidgetGetClickButton(IsCurrent, output)
 end syntax
 
 syntax MouseButtonName is phrase

--- a/libscript/src/foreign.mlc
+++ b/libscript/src/foreign.mlc
@@ -34,7 +34,7 @@ public foreign type Float64 binds to "kMCDoubleTypeInfo"
 
 public foreign type CBool binds to "kMCBoolTypeInfo"
 public type CInt is Int32
-public type CUint is UInt32
+public type CUInt is UInt32
 public type CFloat is Float32
 public type CDouble is Float64
 


### PR DESCRIPTION
The new syntax returns the mouse button index of the button which started the mouse\* event sequence.
