### PR TITLE
[[ Cleanup ]] lc-compile: Remove unused format argument.

### DIFF
--- a/toolchain/lc-compile/src/syntax-gen.c
+++ b/toolchain/lc-compile/src/syntax-gen.c
@@ -1817,7 +1817,7 @@ void DumpSyntaxRules(void)
         {
             const char *t_name;
             GetStringOfNameLiteral(t_rule -> name, &t_name);
-            printf("[%d] ", t_gindex, t_name);
+            printf("[%d] ", t_gindex);
             PrintSyntaxNode(t_rule -> expr);
             printf("\n");
         }


### PR DESCRIPTION
Trivial correctness patch.
