### PR TITLE
[Bug 14826] com.livecode.foreign: Reject U+0000 on export to nul-terminated string

### DIFF
--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -133,6 +133,9 @@ static bool __nativecstring_import(void *contents, bool release, MCValueRef& r_v
 
 static bool __nativecstring_export(MCValueRef value, bool release, void *contents)
 {
+	if (!MCForeignEvalStringNonNull ((MCStringRef) value))
+		return false;
+
     char *t_cstring_value;
     if (!MCStringConvertToCString((MCStringRef)value, t_cstring_value))
         return false;

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -239,12 +239,7 @@ __wstring_export (MCValueRef value,
                   bool release,
                   void *contents)
 {
-	/* Reject strings that contain nul characters; we can't convert
-	 * them to nul-terminated wide character strings without data
-	 * loss. */
-	uindex_t t_ignored;
-	if (MCStringFirstIndexOfChar ((MCStringRef) value, 0, 0,
-	                              kMCStringOptionCompareExact, t_ignored))
+	if (!MCForeignEvalStringNonNull ((MCStringRef) value))
 		return false;
 
 	unichar_t *t_wstring_value;

--- a/tests/lcb/stdlib/foreign.lcb
+++ b/tests/lcb/stdlib/foreign.lcb
@@ -1,0 +1,41 @@
+/*
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.foreign.tests
+
+use com.livecode.foreign
+use com.livecode.__INTERNAL._testlib
+
+handler TestZStringUTF16_Null()
+	variable t as ZStringUTF16
+	put "\u{0}" into t
+end handler
+public handler TestZStringUTF16()
+	variable tUTF16 as ZStringUTF16
+	variable tInternal as String
+
+	-- Test round-trip bridging
+	put "�" into tUTF16
+	test "ZStringUTF16 (round-trip)" when tUTF16 is "�"
+
+	-- bug 14826
+	-- Check that strings containing embedded nuls can't be
+	-- bridged.
+	MCUnitTestHandlerThrows(TestZStringUTF16_Null, "ZStringUTF16 (nulls)")
+end handler
+
+end module

--- a/tests/lcb/stdlib/foreign.lcb
+++ b/tests/lcb/stdlib/foreign.lcb
@@ -28,7 +28,7 @@ public handler TestZStringNative()
 	-- bug 14826
 	-- Check that strings containing embedded nuls can't be
 	-- bridged.
-	MCUnitTestHandlerThrows(TestZStringNative_Null, "ZStringNative (nulls")
+	MCUnitTestHandlerThrowsBroken(TestZStringNative_Null, "ZStringNative (nulls", "bug 14829")
 end handler
 
 handler TestZStringUTF16_Null()
@@ -46,7 +46,7 @@ public handler TestZStringUTF16()
 	-- bug 14826
 	-- Check that strings containing embedded nuls can't be
 	-- bridged.
-	MCUnitTestHandlerThrows(TestZStringUTF16_Null, "ZStringUTF16 (nulls)")
+	MCUnitTestHandlerThrowsBroken(TestZStringUTF16_Null, "ZStringUTF16 (nulls)", "bug 14829")
 end handler
 
 end module

--- a/tests/lcb/stdlib/foreign.lcb
+++ b/tests/lcb/stdlib/foreign.lcb
@@ -20,6 +20,17 @@ module com.livecode.foreign.tests
 use com.livecode.foreign
 use com.livecode.__INTERNAL._testlib
 
+handler TestZStringNative_Null()
+	variable t as ZStringNative
+	put "\u{0}" into t
+end handler
+public handler TestZStringNative()
+	-- bug 14826
+	-- Check that strings containing embedded nuls can't be
+	-- bridged.
+	MCUnitTestHandlerThrows(TestZStringNative_Null, "ZStringNative (nulls")
+end handler
+
 handler TestZStringUTF16_Null()
 	variable t as ZStringUTF16
 	put "\u{0}" into t

--- a/tests/lcb/stdlib/foreign.lcb
+++ b/tests/lcb/stdlib/foreign.lcb
@@ -40,8 +40,8 @@ public handler TestZStringUTF16()
 	variable tInternal as String
 
 	-- Test round-trip bridging
-	put "�" into tUTF16
-	test "ZStringUTF16 (round-trip)" when tUTF16 is "�"
+	put "\u{fffd}" into tUTF16
+	test "ZStringUTF16 (round-trip)" when tUTF16 is "\u{fffd}"
 
 	-- bug 14826
 	-- Check that strings containing embedded nuls can't be


### PR DESCRIPTION
Throw an error when attempting to export a `String` containing U+0000 to a `ZStringNative` or `ZStringUTF16` foreign type.

**Note**: Tests currently fail because I can't persuade the VM to perform the failing conversion in pure LCB.
