### PR TITLE
[Bug 14828] Add "the byte with code _" and "the code of _"

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -571,6 +571,7 @@ typedef unsigned char char_t;
 
 // The 'byte_t' type is used to hold a char in a binary string (native).
 typedef uint8_t byte_t;
+#define BYTE_MAX UINT8_MAX
 
 // The 'codepoint_t' type is used to hold a single Unicode codepoint (20-bit
 // value).

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -310,7 +310,7 @@ __size_import (void *contents,
 	{
 		MCErrorCreateAndThrow (kMCForeignImportErrorTypeInfo,
 		                       "type", kMCSizeTypeInfo,
-		                       "reason", "too large for Number representation",
+		                       "reason", MCSTR("too large for Number representation"),
 		                       nil);
 		return false;
 	}

--- a/libscript/src/byte.mlc
+++ b/libscript/src/byte.mlc
@@ -56,6 +56,8 @@ public foreign handler MCByteExecDeleteFirstByteOf(inout Target as Data) as unde
 
 public foreign handler MCDataExecRandomBytes(in Count as LCUIndex, out Value as Data) as undefined binds to "<builtin>"
 
+public foreign handler MCByteEvalByteWithCode(in Value as LCUInt, out Result as Data) as undefined binds to "<builtin>"
+
 --
 
 /*
@@ -427,6 +429,25 @@ begin
 	MCDataExecRandomBytes(Count, output)
 end syntax
 
---
+----------------------------------------------------------------
+-- Conversion between bytes and numbers
+----------------------------------------------------------------
+
+/*
+Summary:	Create a 1-byte data value from a number
+
+Value:		The value for the new data value
+
+Description:
+Returns a byte of binary data, created using the given value.  The
+<Value> must be between 0 and 255 (inclusive).
+
+Tags: Binary
+*/
+syntax ByteWithCode is prefix operator with precedence 2
+      "the" "byte" "with" "code" <Value: Expression>
+begin
+	MCByteEvalByteWithCode(Value, output)
+end syntax
 
 end module

--- a/libscript/src/byte.mlc
+++ b/libscript/src/byte.mlc
@@ -57,6 +57,7 @@ public foreign handler MCByteExecDeleteFirstByteOf(inout Target as Data) as unde
 public foreign handler MCDataExecRandomBytes(in Count as LCUIndex, out Value as Data) as undefined binds to "<builtin>"
 
 public foreign handler MCByteEvalByteWithCode(in Value as LCUInt, out Result as Data) as undefined binds to "<builtin>"
+public foreign handler MCByteEvalCodeOfByte(in Target as Data, out Result as LCUInt) as undefined binds to "<builtin>"
 
 --
 
@@ -445,9 +446,25 @@ Returns a byte of binary data, created using the given value.  The
 Tags: Binary
 */
 syntax ByteWithCode is prefix operator with precedence 2
-      "the" "byte" "with" "code" <Value: Expression>
+	"the" "byte" "with" "code" <Value: Expression>
 begin
 	MCByteEvalByteWithCode(Value, output)
+end syntax
+
+/*
+Summary:	Get the numeric value of a single byte.
+
+Target:	A 1-byte binary data value.
+
+Description:
+Returns the numeric representation of a single byte of binary data.
+
+Tags: Binary
+*/
+syntax CodeOfByte is prefix operator with precedence 2
+	"the" "code" "of" <Target: Expression>
+begin
+	MCByteEvalCodeOfByte(Target, output)
 end syntax
 
 end module

--- a/libscript/src/module-byte.cpp
+++ b/libscript/src/module-byte.cpp
@@ -236,6 +236,19 @@ MCByteEvalByteWithCode (uinteger_t p_value,
 	MCDataCreateWithBytes (&t_byte, 1, r_data);
 }
 
+extern "C" MC_DLLEXPORT void
+MCByteEvalCodeOfByte (MCDataRef p_data,
+                      uinteger_t & r_value)
+{
+	if (1 != MCDataGetLength (p_data))
+	{
+		MCErrorThrowGeneric(MCSTR("not a single byte"));
+		return;
+	}
+
+	r_value = MCDataGetByteAtIndex (p_data, 0);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef _TEST

--- a/libscript/src/module-byte.cpp
+++ b/libscript/src/module-byte.cpp
@@ -217,6 +217,25 @@ MCDataExecRandomBytes (uindex_t p_count, MCDataRef & r_data)
 	/* UNCHECKED */ MCSRandomData (p_count, r_data);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+extern "C" MC_DLLEXPORT void
+MCByteEvalByteWithCode (uinteger_t p_value,
+                        MCDataRef & r_data)
+{
+	if (p_value > BYTE_MAX)
+	{
+		MCErrorCreateAndThrow (kMCGenericErrorTypeInfo,
+		                       "reason", MCSTR("overflow in byte operation"),
+		                       nil);
+		return;
+	}
+
+	const byte_t t_byte = p_value;
+
+	MCDataCreateWithBytes (&t_byte, 1, r_data);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef _TEST

--- a/tests/lcb/stdlib/byte.lcb
+++ b/tests/lcb/stdlib/byte.lcb
@@ -35,4 +35,22 @@ public handler TestByteWithCode()
 	MCUnitTestHandlerThrows(TestByteWithCode_Overflow, "code->byte (overflow)")
 end handler
 
+handler TestCodeOfByte_Long()
+	variable t
+	put the byte with code 0 into t
+	put t after t
+	return the code of t
+end handler
+handler TestCodeOfByte_Empty()
+	variable t
+	put the empty data into t
+	return the code of t
+end handler
+public handler TestCodeOfByte()
+	test "byte->code" when the code of (the byte with code 1) is 1
+
+	MCUnitTestHandlerThrows(TestCodeOfByte_Long, "byte->code (multibyte)")
+	MCUnitTestHandlerThrows(TestCodeOfByte_Empty, "byte->code (empty)")
+end handler
+
 end module

--- a/tests/lcb/stdlib/byte.lcb
+++ b/tests/lcb/stdlib/byte.lcb
@@ -1,0 +1,38 @@
+/*
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.foreign.tests
+
+use com.livecode.__INTERNAL._testlib
+
+handler TestByteWithCode_Negative()
+	return the byte with code -1
+end handler
+handler TestByteWithCode_Overflow()
+	return the byte with code 256
+end handler
+public handler TestByteWithCode()
+	variable t
+	put the byte with code 0 into t
+
+	test "code->byte" when the number of bytes in t is 1
+
+	MCUnitTestHandlerThrows(TestByteWithCode_Negative, "code->byte (negative)")
+	MCUnitTestHandlerThrows(TestByteWithCode_Overflow, "code->byte (overflow)")
+end handler
+
+end module


### PR DESCRIPTION
In order to make this work properly, also fix exporting `Number` to foreign unsigned integer types.
