### PR TITLE
[[ Bug 14413 ]] revZip: add UTF-8 understanding of archive filename / archive item names on Windows

### DIFF
--- a/docs/notes/bugfix-14413.md
+++ b/docs/notes/bugfix-14413.md
@@ -1,0 +1,1 @@
+# revZipOpenArchive fails in 7.0.1 with Unicode characters

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -1737,6 +1737,8 @@ static char *convert_from_native_to_utf8(const char *arg1, const char *arg2,
     }
     
     *retval = xresSucc;
+	// Return a string owned by the engine, to avoid the release issue
+	MCExternalAddAllocatedString(MCexternalallocpool, t_utf8_string);
     return t_utf8_string;
 }
 
@@ -1755,6 +1757,8 @@ static char *convert_to_native_from_utf8(const char *arg1, const char *arg2,
     }
     
     *retval = xresSucc;
+	// Return a string owned by the engine, to avoid the release issue
+	MCExternalAddAllocatedString(MCexternalallocpool, t_native_string);
     return t_native_string;
 }
 

--- a/libexternal/include/revolution/external.h
+++ b/libexternal/include/revolution/external.h
@@ -511,6 +511,11 @@ extern Bool SecurityCanAccessLibrary(const char *p_library);
 extern Bool SecurityCanAccessFileUTF8(const char *p_file);
 extern Bool SecurityCanAccessHostUTF8(const char *p_host);
 extern Bool SecurityCanAccessLibraryUTF8(const char *p_library);
+    
+
+// SN-2015-03-12: [[ Bug 14413 ]] Added UTF-8 <-> native string conversion
+extern char *ConvertCStringFromNativeToUTF8(const char *p_native, int *r_success);
+extern char *ConvertCStringToNativeFromUTF8(const char *p_utf8, int *r_success);
 	
 #ifdef __cplusplus
 };

--- a/libexternal/include/revolution/external.h
+++ b/libexternal/include/revolution/external.h
@@ -514,8 +514,9 @@ extern Bool SecurityCanAccessLibraryUTF8(const char *p_library);
     
 
 // SN-2015-03-12: [[ Bug 14413 ]] Added UTF-8 <-> native string conversion
-extern char *ConvertCStringFromNativeToUTF8(const char *p_native, int *r_success);
-extern char *ConvertCStringToNativeFromUTF8(const char *p_utf8, int *r_success);
+// The string returned are owned by the engine, and must not be free'd
+extern const char *ConvertCStringFromNativeToUTF8(const char *p_native, int *r_success);
+extern const char *ConvertCStringToNativeFromUTF8(const char *p_utf8, int *r_success);
 	
 #ifdef __cplusplus
 };

--- a/libexternal/include/revolution/support.h
+++ b/libexternal/include/revolution/support.h
@@ -49,23 +49,4 @@ char *os_path_from_native(const char *p_native_path);
 //   Resolves a native path into an absolute path, e.g. by expanding "~" etc.
 char *os_path_resolve(const char *p_native_path);
 
-
-// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
-
-// Parameters:
-//  p_utf8_string : pointer to UTF-8 encoded string.
-// Returns:
-//  a pointer to the native-encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a UTF-8 encoded srting into a Native string
-char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success);
-
-// Parameters:
-//  p_native_string : pointer to native-encoded string.
-// Returns:
-//  a pointer to the UTF-8 encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a native srting into a UTF-8 encoded string
-char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success);
-
 #endif

--- a/libexternal/include/revolution/support.h
+++ b/libexternal/include/revolution/support.h
@@ -49,4 +49,23 @@ char *os_path_from_native(const char *p_native_path);
 //   Resolves a native path into an absolute path, e.g. by expanding "~" etc.
 char *os_path_resolve(const char *p_native_path);
 
+
+// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
+
+// Parameters:
+//  p_utf8_string : pointer to UTF-8 encoded string.
+// Returns:
+//  a pointer to the native-encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a UTF-8 encoded srting into a Native string
+char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success);
+
+// Parameters:
+//  p_native_string : pointer to native-encoded string.
+// Returns:
+//  a pointer to the UTF-8 encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a native srting into a UTF-8 encoded string
+char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success);
+
 #endif

--- a/libexternal/src/external.c
+++ b/libexternal/src/external.c
@@ -911,7 +911,7 @@ void ResolveSymbolInModule(void *p_handle, const char *p_symbol, void **r_resolv
 ////////////////////////////////////////////////////////////////////////////////
 // V4: UTF-8 <-> native string conversion
 
-char *ConvertCStringFromNativeToUTF8(const char *p_native, int *r_success)
+const char *ConvertCStringFromNativeToUTF8(const char *p_native, int *r_success)
 {
     char *t_result;
     
@@ -926,7 +926,7 @@ char *ConvertCStringFromNativeToUTF8(const char *p_native, int *r_success)
     return t_result;
 }
 
-char *ConvertCStringToNativeFromUTF8(const char *p_utf8, int *r_success)
+const char *ConvertCStringToNativeFromUTF8(const char *p_utf8, int *r_success)
 {
     char *t_result;
     

--- a/libexternal/src/external.c
+++ b/libexternal/src/external.c
@@ -74,6 +74,10 @@ enum
     /* V3 */ OPERATION_LOAD_MODULE,
     /* V3 */ OPERATION_UNLOAD_MODULE,
     /* V3 */ OPERATION_RESOLVE_SYMBOL_IN_MODULE,
+    
+    // SN-2015-03-12: [[ Bug 14413 ]] Add new UTF-8 <-> native conversion functions
+    /* V4 */ OPERATION_CONVERT_FROM_NATIVE_TO_UTF8,
+    /* V4 */ OPERATION_CONVERT_TO_NATIVE_FROM_UTF8,
 };
 
 enum
@@ -905,6 +909,37 @@ void ResolveSymbolInModule(void *p_handle, const char *p_symbol, void **r_resolv
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// V4: UTF-8 <-> native string conversion
+
+char *ConvertCStringFromNativeToUTF8(const char *p_native, int *r_success)
+{
+    char *t_result;
+    
+    if (s_external_interface_version < 4)
+    {
+        *r_success = EXTERNAL_FAILURE;
+        return;
+    }
+    
+    t_result = (s_operations[OPERATION_CONVERT_FROM_NATIVE_TO_UTF8])(p_native, NULL, NULL, r_success);
+    
+    return t_result;
+}
+
+char *ConvertCStringToNativeFromUTF8(const char *p_utf8, int *r_success)
+{
+    char *t_result;
+    
+    if (s_external_interface_version < 4)
+    {
+        *r_success = EXTERNAL_FAILURE;
+        return;
+    }
+    
+    t_result = (s_operations[OPERATION_CONVERT_TO_NATIVE_FROM_UTF8])(p_utf8, NULL, NULL, r_success);
+    
+    return t_result;
+}
 
 #ifdef TARGET_SUBPLATFORM_IPHONE
 struct LibExport

--- a/libexternal/src/osxsupport.cpp
+++ b/libexternal/src/osxsupport.cpp
@@ -237,3 +237,35 @@ char *os_path_resolve(const char *p_native_path)
 	}
 	return newname;
 }
+
+// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
+
+// Parameters:
+//  p_utf8_string : pointer to UTF-8 encoded string.
+// Returns:
+//  a pointer to the native-encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a UTF-8 encoded srting into a Native string
+char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success)
+{
+	char *t_native_string;
+	t_native_string = string_from_utf8(p_utf8_path);
+
+	*r_success = t_native_string != NULL;
+	return t_native_string;
+}
+
+// Parameters:
+//  p_native_string : pointer to native-encoded string.
+// Returns:
+//  a pointer to the UTF-8 encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a native srting into a UTF-8 encoded string
+char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success)
+{
+	char *t_utf8_string;
+	t_utf8_string = string_to_utf8(p_native_string);
+
+	*r_success = t_utf8_string != NULL;
+	return t_utf8_string;
+}

--- a/libexternal/src/osxsupport.cpp
+++ b/libexternal/src/osxsupport.cpp
@@ -237,35 +237,3 @@ char *os_path_resolve(const char *p_native_path)
 	}
 	return newname;
 }
-
-// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
-
-// Parameters:
-//  p_utf8_string : pointer to UTF-8 encoded string.
-// Returns:
-//  a pointer to the native-encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a UTF-8 encoded srting into a Native string
-char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success)
-{
-	char *t_native_string;
-	t_native_string = string_from_utf8(p_utf8_path);
-
-	*r_success = t_native_string != NULL;
-	return t_native_string;
-}
-
-// Parameters:
-//  p_native_string : pointer to native-encoded string.
-// Returns:
-//  a pointer to the UTF-8 encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a native srting into a UTF-8 encoded string
-char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success)
-{
-	char *t_utf8_string;
-	t_utf8_string = string_to_utf8(p_native_string);
-
-	*r_success = t_utf8_string != NULL;
-	return t_utf8_string;
-}

--- a/libexternal/src/unxsupport.cpp
+++ b/libexternal/src/unxsupport.cpp
@@ -50,42 +50,6 @@ char *string_to_utf8(const char *p_string)
 	return t_utf8_string;
 }
 
-char *string_from_utf8(const char* p_utf8_string)
-{
-	char *t_iso_string;
-	t_iso_string = (char*)malloc(strlen(p_utf8_string) + 1);
-
-	int i, j, t_error;
-	t_error = 0;
-
-    for (i = 0, j = 0; p_utf8_string[i] != '\0' && !t_error;)
-	{
-		unsigned char t_first_char;
-        t_first_char = ((unsigned char *)p_utf8_string)[i++];
-
-		if (t_first_char < 128)
-			t_iso_string[j++] = t_first_char;
-        else if (p_utf8_string[i] != '\0')
-		{
-            unsigned char t_second_char;
-			t_second_char = p_utf8_string[i++];
-
-            // SN-2015-03-11: [[ Bug 14413 ]] Take the 6 right bit of the first char.
-            t_iso_string[j++] = ((t_first_char & 0x3F) << 6)
-                                | (t_second_char & 0x63);
-		}
-		else
-			t_error = true;
-	}
-
-	if (t_error)
-		return NULL;
-	else
-	{
-		t_iso_string[j] = '\0';
-		return t_iso_string;
-	}
-}
 // LINUX implimentation of externals.
 char *os_path_to_native(const char *p_path)
 {
@@ -189,37 +153,3 @@ char *os_path_resolve(const char *p_native_path)
 	}
 	return newname;
 }
-
-
-// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
-
-// Parameters:
-//  p_utf8_string : pointer to UTF-8 encoded string.
-// Returns:
-//  a pointer to the native-encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a UTF-8 encoded srting into a Native string
-char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success)
-{
-	char *t_native_string;
-	t_native_string = string_from_utf8(p_utf8_path);
-
-	*r_success = t_native_string != NULL;
-	return t_native_string;
-}
-
-// Parameters:
-//  p_native_string : pointer to native-encoded string.
-// Returns:
-//  a pointer to the UTF-8 encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a native srting into a UTF-8 encoded string
-char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success)
-{
-	char *t_utf8_string;
-	t_utf8_string = string_to_utf8(p_native_string);
-
-	*r_success = t_utf8_string != NULL;
-	return t_utf8_string;
-}
-

--- a/libexternal/src/unxsupport.cpp
+++ b/libexternal/src/unxsupport.cpp
@@ -49,6 +49,41 @@ char *string_to_utf8(const char *p_string)
 	return t_utf8_string;
 }
 
+char *string_from_utf8(const char* p_utf8_string)
+{
+	char *t_iso_string;
+	t_iso_string = (char*)malloc(strlen(p_utf8_string) + 1);
+
+	int i, j, t_error;
+	t_error = 0;
+
+	for (i = 0, j = 0; p_string[i] != '\0' && !t_error;)
+	{
+		unsigned char t_first_char;
+		t_first_char = ((unsigned char *)p_utf8_string)[i++];
+
+		if (t_first_char < 128)
+			t_iso_string[j++] = t_first_char;
+		else if (p_string[i] != '\0')
+		{
+			unsigned char t_second_char;
+			t_second_char = p_utf8_string[i++];
+
+			t_iso_string[j++] = ((t_first_char & 0xBF) << 5)
+								| ((t_second_char & 0x63); 
+		}
+		else
+			t_error = true;
+	}
+
+	if (t_error)
+		return NULL;
+	else
+	{
+		t_iso_string[j] = '\0';
+		return t_iso_string;
+	}
+}
 // LINUX implimentation of externals.
 char *os_path_to_native(const char *p_path)
 {
@@ -152,3 +187,37 @@ char *os_path_resolve(const char *p_native_path)
 	}
 	return newname;
 }
+
+
+// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
+
+// Parameters:
+//  p_utf8_string : pointer to UTF-8 encoded string.
+// Returns:
+//  a pointer to the native-encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a UTF-8 encoded srting into a Native string
+char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success)
+{
+	char *t_native_string;
+	t_native_string = string_from_utf8(p_utf8_path);
+
+	*r_success = t_native_string != NULL;
+	return t_native_string;
+}
+
+// Parameters:
+//  p_native_string : pointer to native-encoded string.
+// Returns:
+//  a pointer to the UTF-8 encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a native srting into a UTF-8 encoded string
+char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success)
+{
+	char *t_utf8_string;
+	t_utf8_string = string_to_utf8(p_native_string);
+
+	*r_success = t_utf8_string != NULL;
+	return t_utf8_string;
+}
+

--- a/libexternal/src/unxsupport.cpp
+++ b/libexternal/src/unxsupport.cpp
@@ -35,14 +35,15 @@ char *string_to_utf8(const char *p_string)
 		unsigned int v;
 		v = ((unsigned char *)p_string)[i];
 
-		if (v < 128)
+        if (v < 128)
 			t_utf8_string[j++] = v;
 		else
 		{
-			t_utf8_string[j++] = 0xC0 | (v >> 5);
-			t_utf8_string[j++] = 0x80 | (v & 63);
+            // SN-2015-03-11: [[ Bug 14413 ]] Do the expected shift
+            t_utf8_string[j++] = (0xC0 | (v >> 6));
+            t_utf8_string[j++] = (0x80 | (v & 63));
 		}
-	}
+    }
 
 	t_utf8_string[j] = '\0';
 
@@ -57,20 +58,21 @@ char *string_from_utf8(const char* p_utf8_string)
 	int i, j, t_error;
 	t_error = 0;
 
-	for (i = 0, j = 0; p_string[i] != '\0' && !t_error;)
+    for (i = 0, j = 0; p_utf8_string[i] != '\0' && !t_error;)
 	{
 		unsigned char t_first_char;
-		t_first_char = ((unsigned char *)p_utf8_string)[i++];
+        t_first_char = ((unsigned char *)p_utf8_string)[i++];
 
 		if (t_first_char < 128)
 			t_iso_string[j++] = t_first_char;
-		else if (p_string[i] != '\0')
+        else if (p_utf8_string[i] != '\0')
 		{
-			unsigned char t_second_char;
+            unsigned char t_second_char;
 			t_second_char = p_utf8_string[i++];
 
-			t_iso_string[j++] = ((t_first_char & 0xBF) << 5)
-								| ((t_second_char & 0x63); 
+            // SN-2015-03-11: [[ Bug 14413 ]] Take the 6 right bit of the first char.
+            t_iso_string[j++] = ((t_first_char & 0x3F) << 6)
+                                | (t_second_char & 0x63);
 		}
 		else
 			t_error = true;

--- a/libexternal/src/w32support.cpp
+++ b/libexternal/src/w32support.cpp
@@ -36,6 +36,29 @@ char *string_to_utf8(const char *p_native_path)
 	return t_utf8_path;
 }
 
+char *string_from_utf8(const char *p_utf8_string)
+{
+	int t_length;
+	// Make sure that the length includes the NULL terminating char
+	t_length = strlen(p_utf8_string) + 1;
+
+	WCHAR *t_utf16_path;
+	t_utf16_path = (WCHAR *)malloc(sizeof(WCHAR) * t_length);
+	MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, p_utf8_string, t_length, t_utf16_path, t_length);
+
+	int t_native_length;
+	t_native_length = WideCharToMultiByte(CP_ACP, 0, t_utf16_path, t_length, NULL, 0, NULL, NULL);
+
+	char *t_native_string;
+	t_native_string = (char *)malloc(t_native_length);
+
+	WideCharToMultiByte(CP_ACP, 0, t_utf16_path, t_length, t_native_string, t_native_length, NULL, NULL);
+
+	free(t_utf16_path);
+
+	return t_native_string;
+}
+
 char *os_path_to_native_utf8(const char *p_path)
 {
 	char *t_native_path;
@@ -118,4 +141,37 @@ char *os_path_resolve(const char *p_native_path)
 	char *cstr = strclone(p_native_path);
 	cstr = os_path_to_native(cstr);
 	return cstr;
+}
+
+
+// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
+
+// Parameters:
+//  p_utf8_string : pointer to UTF-8 encoded string.
+// Returns:
+//  a pointer to the native-encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a UTF-8 encoded srting into a Native string
+char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success)
+{
+	char *t_native_string;
+	t_native_string = string_from_utf8(p_utf8_path);
+
+	*r_success = t_native_string != NULL;
+	return t_native_string;
+}
+
+// Parameters:
+//  p_native_string : pointer to native-encoded string.
+// Returns:
+//  a pointer to the UTF-8 encoded string. Must be freed by the caller
+// Semantics:
+//  Converts a native srting into a UTF-8 encoded string
+char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success)
+{
+	char *t_utf8_string;
+	t_utf8_string = string_to_utf8(p_native_string);
+
+	*r_success = t_utf8_string != NULL;
+	return t_utf8_string;
 }

--- a/libexternal/src/w32support.cpp
+++ b/libexternal/src/w32support.cpp
@@ -36,29 +36,6 @@ char *string_to_utf8(const char *p_native_path)
 	return t_utf8_path;
 }
 
-char *string_from_utf8(const char *p_utf8_string)
-{
-	int t_length;
-	// Make sure that the length includes the NULL terminating char
-	t_length = strlen(p_utf8_string) + 1;
-
-	WCHAR *t_utf16_path;
-	t_utf16_path = (WCHAR *)malloc(sizeof(WCHAR) * t_length);
-	MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, p_utf8_string, t_length, t_utf16_path, t_length);
-
-	int t_native_length;
-	t_native_length = WideCharToMultiByte(CP_ACP, 0, t_utf16_path, t_length, NULL, 0, NULL, NULL);
-
-	char *t_native_string;
-	t_native_string = (char *)malloc(t_native_length);
-
-	WideCharToMultiByte(CP_ACP, 0, t_utf16_path, t_length, t_native_string, t_native_length, NULL, NULL);
-
-	free(t_utf16_path);
-
-	return t_native_string;
-}
-
 char *os_path_to_native_utf8(const char *p_path)
 {
 	char *t_native_path;
@@ -141,37 +118,4 @@ char *os_path_resolve(const char *p_native_path)
 	char *cstr = strclone(p_native_path);
 	cstr = os_path_to_native(cstr);
 	return cstr;
-}
-
-
-// SN-2015-03-10:[[ Bug 14413 ]] Added UTF-8 conversion functions
-
-// Parameters:
-//  p_utf8_string : pointer to UTF-8 encoded string.
-// Returns:
-//  a pointer to the native-encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a UTF-8 encoded srting into a Native string
-char *ConvertCStringFromUTF8ToNative(const char* p_utf8_path, int *r_success)
-{
-	char *t_native_string;
-	t_native_string = string_from_utf8(p_utf8_path);
-
-	*r_success = t_native_string != NULL;
-	return t_native_string;
-}
-
-// Parameters:
-//  p_native_string : pointer to native-encoded string.
-// Returns:
-//  a pointer to the UTF-8 encoded string. Must be freed by the caller
-// Semantics:
-//  Converts a native srting into a UTF-8 encoded string
-char *ConvertCStringFromNativeToUTF8(const char* p_native_string, int *r_success)
-{
-	char *t_utf8_string;
-	t_utf8_string = string_to_utf8(p_native_string);
-
-	*r_success = t_utf8_string != NULL;
-	return t_utf8_string;
 }

--- a/revzip/src/revzip.cpp
+++ b/revzip/src/revzip.cpp
@@ -1287,7 +1287,7 @@ void revZipEnumerateItems(char *p_arguments[], int p_argument_count, char **r_re
 				//  meant to return a UTF-8 encoded string.
 				if (t_stat.bitflags && ZIP_UTF8_FLAG)
 				{
-					t_success = 1;
+                    t_success = EXTERNAL_SUCCESS;
 					t_converted_name = strdup(t_stat.name);
 				}
 				else

--- a/revzip/src/revzip.cpp
+++ b/revzip/src/revzip.cpp
@@ -1280,7 +1280,7 @@ void revZipEnumerateItems(char *p_arguments[], int p_argument_count, char **r_re
 			else
 			{
 				char *t_converted_name;
-				int t_success;
+                int t_success;
 
 				// SN-2015-03-10: [[ Bug 14413 ]] We convert the string to UTF-8
 				//  in case it was natively encoded, as revZipEnumerateItems is
@@ -1291,9 +1291,9 @@ void revZipEnumerateItems(char *p_arguments[], int p_argument_count, char **r_re
 					t_converted_name = strdup(t_stat.name);
 				}
 				else
-					t_converted_name = ConvertCStringFromNativeToUTF8(t_stat.name, &t_success);
+                    t_converted_name = ConvertCStringFromNativeToUTF8(t_stat.name, &t_success);
 
-				if (t_success)
+                if (t_success == EXTERNAL_SUCCESS)
 				{
 					t_str_names += std::string(t_converted_name);
 					t_str_names += "\n";

--- a/revzip/src/revzip.cpp
+++ b/revzip/src/revzip.cpp
@@ -1285,7 +1285,7 @@ void revZipEnumerateItems(char *p_arguments[], int p_argument_count, char **r_re
 				const char *t_converted_name;
                 int t_success;
 
-				if (t_stat.bitflags && ZIP_UTF8_FLAG)
+				if (t_stat.bitflags & ZIP_UTF8_FLAG)
 				{
                     t_success = EXTERNAL_SUCCESS;
 					t_converted_name = t_stat.name;

--- a/revzip/src/revzip.cpp
+++ b/revzip/src/revzip.cpp
@@ -1267,15 +1267,50 @@ void revZipEnumerateItems(char *p_arguments[], int p_argument_count, char **r_re
 		for( int i = 0; i < t_num_files; ++i )
 		{
 			const char* t_line = NULL;
-			t_line = zip_get_name(t_archive, i, 0);
-			if( t_line )
+			struct zip_stat t_stat;
+
+			// SN-2015-03-11: [[ Bug 14413 ]] We want to get the bitflags
+			//  alongside the name: zip_stat_index provides this.
+			if (zip_stat_index(t_archive, i, 0, &t_stat) != 0)
 			{
-				t_str_names += std::string(t_line);
-				t_str_names += "\n";
+				std::string t_outerr = "ziperr," + std::string((zip_strerror(t_archive)));
+				t_result = strdup(t_outerr.c_str());
+				t_error = False;
+			}
+			else
+			{
+				char *t_converted_name;
+				int t_success;
+
+				// SN-2015-03-10: [[ Bug 14413 ]] We convert the string to UTF-8
+				//  in case it was natively encoded, as revZipEnumerateItems is
+				//  meant to return a UTF-8 encoded string.
+				if (t_stat.bitflags && ZIP_UTF8_FLAG)
+				{
+					t_success = 1;
+					t_converted_name = strdup(t_stat.name);
+				}
+				else
+					t_converted_name = ConvertCStringFromNativeToUTF8(t_stat.name, &t_success);
+
+				if (t_success)
+				{
+					t_str_names += std::string(t_converted_name);
+					t_str_names += "\n";
+				}
+				else
+				{
+					t_result = strdup("");
+					t_error  = True;
+					break;
+				}
+
+				// Free the allocated memory.
+				free(t_converted_name);
 			}
 		}
 		
-		if( !t_str_names.empty() )
+		if( !t_str_names.empty() && t_error == False)
 		{
 			t_result = strdup(t_str_names.c_str());
 			t_error = False;

--- a/revzip/src/revzip.cpp
+++ b/revzip/src/revzip.cpp
@@ -1279,19 +1279,19 @@ void revZipEnumerateItems(char *p_arguments[], int p_argument_count, char **r_re
 			}
 			else
 			{
-				char *t_converted_name;
-                int t_success;
-
 				// SN-2015-03-10: [[ Bug 14413 ]] We convert the string to UTF-8
 				//  in case it was natively encoded, as revZipEnumerateItems is
 				//  meant to return a UTF-8 encoded string.
+				const char *t_converted_name;
+                int t_success;
+
 				if (t_stat.bitflags && ZIP_UTF8_FLAG)
 				{
                     t_success = EXTERNAL_SUCCESS;
-					t_converted_name = strdup(t_stat.name);
+					t_converted_name = t_stat.name;
 				}
 				else
-                    t_converted_name = ConvertCStringFromNativeToUTF8(t_stat.name, &t_success);
+					t_converted_name = ConvertCStringFromNativeToUTF8(t_stat.name, &t_success);
 
                 if (t_success == EXTERNAL_SUCCESS)
 				{
@@ -1304,9 +1304,6 @@ void revZipEnumerateItems(char *p_arguments[], int p_argument_count, char **r_re
 					t_error  = True;
 					break;
 				}
-
-				// Free the allocated memory.
-				free(t_converted_name);
 			}
 		}
 		


### PR DESCRIPTION
This pull request only contains the bugfix note.

The bugfix is on the pull request https://github.com/runrev/livecode-thirdparty/pull/23.
