### PR TITLE
[Bug 14858] Crash when calling mobileStoreProductProperty

### DIFF
--- a/docs/notes/bugfix-14858.md
+++ b/docs/notes/bugfix-14858.md
@@ -1,0 +1,1 @@
+#   [In-app purchase] Calling mobileStoreProductProperty(prodID, "transactionIdentifier") when the purchase is still in progress crashes the app 

--- a/engine/src/mbliphonestore.mm
+++ b/engine/src/mbliphonestore.mm
@@ -231,7 +231,8 @@ Exec_stat MCPurchaseGet(MCPurchase *p_purchase, MCPurchaseProperty p_property, M
 			return ES_NORMAL;
 
 		case kMCPurchasePropertyTransactionIdentifier:
-			if (t_transaction == nil)
+            // PM-2015-03-10: [[ Bug 14858 ]] transactionIdentifier can be nil if the purchase is still in progress (i.e when purchaseStateUpdate msg is sent with state=sendingRequest)
+			if (t_transaction == nil || [t_transaction transactionIdentifier] == nil)
 				break;
 			
 			ep.copysvalue([[t_transaction transactionIdentifier] cStringUsingEncoding:NSMacOSRomanStringEncoding]);

--- a/engine/src/mblstore.cpp
+++ b/engine/src/mblstore.cpp
@@ -424,7 +424,11 @@ Exec_stat MCHandleGetPurchaseProperty(void *context, MCParameter *p_parameters)
     MCCStringFree(t_product_id);
     MCCStringFree(t_prop_name);
     
-    MCresult -> sets(t_prop_value);
+    // PM-2015-03-10: [[ Bug 14858 ]] t_prop_value can be nil if the property is not found
+    if (t_prop_value != nil)
+        MCresult -> sets(t_prop_value);
+    else
+        MCresult -> sets("");
     return ES_NORMAL;
 }
 


### PR DESCRIPTION
while the purchase is still in progress
