### PR TITLE
[[ SB Inclusions ]] Mac server should use MCS_loadmodule to load the ext...

### DIFF
--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -42,7 +42,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "globals.h"
 #include "dispatch.h"
 
-#if defined(_MACOSX) || defined(_MAC_SERVER)
+#if defined(_MACOSX)
 #include <mach-o/dyld.h>
 #endif
 
@@ -2936,7 +2936,7 @@ void* MCU_loadmodule(const char *p_module)
 {
     MCSysModuleHandle t_handle;
     t_handle = nil;
-#if defined(_MACOSX) || defined(_MAC_SERVER)
+#if defined(_MACOSX)
     t_handle = (MCSysModuleHandle)NSAddImage(p_module, NSADDIMAGE_OPTION_RETURN_ON_ERROR | NSADDIMAGE_OPTION_WITH_SEARCHING);
     if (t_handle != nil)
         return t_handle;
@@ -3007,7 +3007,7 @@ void MCU_unloadmodule(void *p_module)
     // SN-2015-03-04: [[ Broken module unloading ]] NSAddImage, used on Mac in
     //  MCU_loadmodule, does not need any unloading of the module -
     //  but the other platforms do.
-#if !defined(_MACOSX) && !defined(_MAC_SERVER)
+#if !defined(_MACOSX)
     MCS_unloadmodule((MCSysModuleHandle)p_module);
 #endif
 }
@@ -3016,7 +3016,7 @@ void MCU_unloadmodule(void *p_module)
 //  as extern in revbrowser/src/cefshared.h - where MCSysModuleHandle does not exist
 void *MCU_resolvemodulesymbol(void* p_module, const char *p_symbol)
 {
-#if defined(_MACOSX) || defined(_MAC_SERVER)
+#if defined(_MACOSX)
     NSSymbol t_symbol;
     t_symbol = NSLookupSymbolInImage((mach_header *)p_module, p_symbol, NSLOOKUPSYMBOLINIMAGE_OPTION_BIND_NOW);
     if (t_symbol != NULL)


### PR DESCRIPTION
...ernals, not the Mac desktop specific MCU_loadmodule path
