### PR TITLE
libfoundation: MCAssert(): Add a newline to message output.

### DIFF
--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -143,7 +143,7 @@ void __MCUnreachable(void)
 
 void __MCAssert(const char *p_file, uint32_t p_line, const char *p_message)
 {
-    fprintf(stderr, "MCAssert failed: %s:%u \"%s\"", p_file, p_line, p_message);
+    fprintf(stderr, "MCAssert failed: %s:%u \"%s\"\n", p_file, p_line, p_message);
     abort();
 }
 


### PR DESCRIPTION
Makes assertion crashes slightly more ergonomic on platforms where
libc prints a message on assertion failure.
