### PR TITLE
[Bug 14931] LCB: Check syntax definitions for method conflicts.

### DIFF
--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -63,7 +63,11 @@
             ErrorsDidOccur()
         ||
             GenerateSyntaxForModules(Modules)
-            GenerateSyntaxRules()
+            (|
+                ErrorsDidOccur()
+            ||
+                GenerateSyntaxRules()
+            |)
         |)
 
 'action' BindModules(MODULELIST, MODULELIST)

--- a/toolchain/lc-compile/src/literal.h
+++ b/toolchain/lc-compile/src/literal.h
@@ -31,7 +31,7 @@ void MakeDoubleLiteral(const char *token, long *r_literal);
 void MakeStringLiteral(const char *token, long *r_literal);
 void MakeNameLiteral(const char *token, NameRef *r_literal);
 void MakeNameLiteralN(const char *p_token, int p_token_length, NameRef *r_literal);
-
+    
 void GetStringOfNameLiteral(NameRef literal, const char** r_string);
 
 void InitializeScopes(void);

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -51,6 +52,19 @@ void Fatal_InternalInconsistency(const char *p_message)
 {
     fprintf(stderr, "*** INTERNAL INCONSISTENCY (%s) ***\n", p_message);
     exit(1);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void Error_Bootstrap(const char *p_format, ...)
+{
+    va_list t_args;
+    va_start(t_args, p_format);
+    fprintf(stderr, "error: ");
+    vfprintf(stderr, p_format, t_args);
+    fprintf(stderr, "\n");
+    va_end(t_args);
+    s_error_count += 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -39,6 +39,8 @@ void Error_MalformedSyntax(long position);
     
 void Warning_EmptyUnicodeEscape(long position);
 void Warning_UnicodeEscapeTooBig(long position);
+
+void Error_Bootstrap(const char *format, ...);
     
 #ifdef __cplusplus
 }

--- a/toolchain/lc-compile/src/syntax-gen.c
+++ b/toolchain/lc-compile/src/syntax-gen.c
@@ -175,7 +175,7 @@ static SyntaxRuleRef s_rule = NULL;
 static SyntaxNodeRef s_stack[MAX_NODE_DEPTH];
 static unsigned int s_stack_index = 0;
 
-static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right);
+static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right, int p_with_mark_values);
 
 static FILE* s_output;
 
@@ -270,10 +270,26 @@ void EndSyntaxRule(void)
     for(t_group = s_groups; t_group != NULL; t_group = t_group -> next)
     {
         if (s_rule -> kind != kSyntaxRuleKindPhrase &&
-            IsSyntaxNodeEqualTo(s_rule -> expr, t_group -> rules -> expr) &&
-            s_rule -> kind == t_group -> rules -> kind &&
-            s_rule -> precedence == t_group -> rules -> precedence)
+            IsSyntaxNodeEqualTo(s_rule -> expr, t_group -> rules -> expr, 0) &&
+            s_rule -> kind == t_group -> rules -> kind)
+        {
+            const char *t_rule_name, *t_other_rule_name;
+            GetStringOfNameLiteral(s_rule -> name, &t_rule_name);
+            GetStringOfNameLiteral(t_group -> rules -> name, &t_other_rule_name);
+            if (s_rule -> precedence != t_group -> rules -> precedence)
+            {
+                Error_Bootstrap("Rule '%s' and '%s' have conflicting precedence", t_rule_name, t_other_rule_name);
+                break;
+            }
+            
+            if (!IsSyntaxNodeEqualTo(s_rule -> expr, t_group -> rules -> expr, 1))
+            {
+                Error_Bootstrap("Rule '%s' and '%s' have conflicting methods", t_rule_name, t_other_rule_name);
+                break;
+            }
+            
             break;
+        }
     }
     
     if (t_group == NULL)
@@ -309,7 +325,41 @@ static int IsMarkSyntaxNode(SyntaxNodeRef p_node)
     return p_node -> kind >= kSyntaxNodeKindBooleanMark;
 }
 
-static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right)
+static int IsMarkSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right)
+{
+    if (p_left -> kind != p_right -> kind)
+        return 0;
+    
+    switch(p_left -> kind)
+    {
+        case kSyntaxNodeKindBooleanMark:
+            if (p_left -> boolean_mark  . value != p_right -> boolean_mark . value)
+                return 0;
+            break;
+            
+        case kSyntaxNodeKindIntegerMark:
+            if (p_left -> integer_mark  . value != p_right -> integer_mark . value)
+                return 0;
+            break;
+            
+        case kSyntaxNodeKindRealMark:
+            if (p_left -> real_mark  . value != p_right -> real_mark . value)
+                return 0;
+            break;
+            
+        case kSyntaxNodeKindStringMark:
+            if (p_left -> string_mark . value != p_right -> string_mark . value)
+                return 0;
+            break;
+            
+        default:
+            return 0;
+    }
+    
+    return 1;
+}
+
+static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right, int p_with_mark_values)
 {
     if (p_left -> kind != p_right -> kind)
         return 0;
@@ -335,6 +385,10 @@ static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right)
         case kSyntaxNodeKindStringMark:
             if (p_left -> boolean_mark . index != p_right -> boolean_mark . index)
                 return 0;
+            if (p_with_mark_values == 0)
+                return 1;
+            if (!IsMarkSyntaxNodeEqualTo(p_left, p_right))
+                return 0;
             break;
             
         case kSyntaxNodeKindConcatenate:
@@ -354,7 +408,7 @@ static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right)
                 
                 if (t_left_child != NULL && t_right_child != NULL)
                 {
-                    if (!IsSyntaxNodeEqualTo(t_left_child, t_right_child))
+                    if (!IsSyntaxNodeEqualTo(t_left_child, t_right_child, p_with_mark_values))
                         return 0;
                 }
                 else if (t_left_child != NULL)
@@ -374,30 +428,30 @@ static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right)
 		}
         case kSyntaxNodeKindAlternate:
 		{
-			int i;
+			int i, t_found;
             if (p_left -> alternate . operand_count != p_right -> alternate . operand_count)
                 return 0;
             if (p_left -> alternate . is_nullable != p_right -> alternate . is_nullable)
                 return 0;
+            t_found = 0;
             for(i = 0; i < p_left -> alternate . operand_count; i++)
             {
-                int j, t_found;
-                t_found = 0;
+                int j;
                 for(j = 0; j < p_right -> alternate . operand_count; j++)
-                    if (IsSyntaxNodeEqualTo(p_left -> alternate . operands[i], p_right -> alternate . operands[j]))
+                    if (IsSyntaxNodeEqualTo(p_left -> alternate . operands[i], p_right -> alternate . operands[j], p_with_mark_values))
                     {
-                        t_found = 1;
+                        t_found += 1;
                         break;
                     }
-                if (!t_found)
-                    return 0;
             }
+            if (t_found != p_left -> alternate . operand_count)
+                return 0;
             break;
 		}
         case kSyntaxNodeKindRepeat:
-            if (!IsSyntaxNodeEqualTo(p_left -> repeat . element, p_right -> repeat . element))
+            if (!IsSyntaxNodeEqualTo(p_left -> repeat . element, p_right -> repeat . element, p_with_mark_values))
                 return 0;
-            if (!IsSyntaxNodeEqualTo(p_left -> repeat . delimiter, p_right -> repeat . delimiter))
+            if (!IsSyntaxNodeEqualTo(p_left -> repeat . delimiter, p_right -> repeat . delimiter, p_with_mark_values))
                 return 0;
             break;
     }
@@ -1101,7 +1155,7 @@ static void MergeSyntaxNodes(SyntaxNodeRef p_node, SyntaxNodeRef p_other_node, l
         {
             int j;
 			for(j = 0; j < p_other_node -> alternate . operand_count; j++)
-                if (IsSyntaxNodeEqualTo(p_node -> alternate . operands[i], p_other_node -> alternate . operands[j]))
+                if (IsSyntaxNodeEqualTo(p_node -> alternate . operands[i], p_other_node -> alternate . operands[j], 0))
                     MergeSyntaxNodes(p_node -> alternate . operands[i], p_other_node -> alternate . operands[j], x_next_mark, x_mapping);
         }
     }
@@ -1730,6 +1784,7 @@ static void GenerateTokenList(void)
 }
 
 extern void DumpSyntaxRules(void);
+extern void DumpSyntaxMethods(void);
 void GenerateSyntaxRules(void)
 {
     FILE *t_template;
@@ -1804,6 +1859,7 @@ void GenerateSyntaxRules(void)
     GenerateTokenList();
 
     DumpSyntaxRules();
+    DumpSyntaxMethods();
 }
 
 void DumpSyntaxRules(void)
@@ -1823,6 +1879,54 @@ void DumpSyntaxRules(void)
             printf("[%d] ", t_gindex);
             PrintSyntaxNode(t_rule -> expr);
             printf("\n");
+        }
+        t_gindex += 1;
+    }
+}
+
+void PrintSyntaxMethod(SyntaxMethodRef self)
+{
+    const char *t_name;
+    struct SyntaxArgument *t_arg;
+    GetStringOfNameLiteral(self -> name, &t_name);
+    printf("%s(", t_name);
+    for(t_arg = self -> arguments; t_arg != NULL; t_arg = t_arg -> next)
+    {
+        if (t_arg != self -> arguments)
+            printf(", ");
+        printf("%s %ld", t_arg -> mode == 0 ? "in" : t_arg -> mode == 1 ? "out" : "inout", t_arg -> index);
+        
+        {
+            printf(" {");
+        
+            printf("}");
+        }
+    }
+    printf(")");
+}
+
+void DumpSyntaxMethods(void)
+{
+    int t_gindex;
+	SyntaxRuleGroupRef t_group;
+    
+    t_gindex = 0;
+    for (t_group = s_groups; t_group != NULL; t_group = t_group -> next)
+    {
+        SyntaxRuleRef t_rule;
+		
+		for (t_rule = t_group -> rules; t_rule != NULL; t_rule = t_rule -> next)
+        {
+            const char *t_name;
+            SyntaxMethodRef t_method;
+            
+            GetStringOfNameLiteral(t_rule -> name, &t_name);
+            for(t_method = t_rule -> methods; t_method != NULL; t_method = t_method -> next)
+            {
+                printf("[%d] [%s] ", t_gindex, t_name);
+                PrintSyntaxMethod(t_method);
+                printf("\n");
+            }
         }
         t_gindex += 1;
     }


### PR DESCRIPTION
The syntax processor will now flag an error if two identical syntax rules have method lists which are incompatible.

This can happen (for example), if different mark values are specified for the same placement in rules which otherwise match.
