### PR TITLE
[[ LCB ]] Correct checking of property getter handler signature.

### DIFF
--- a/docs/lcb/notes/14938.md
+++ b/docs/lcb/notes/14938.md
@@ -1,0 +1,5 @@
+# LiveCode Tools
+
+# [14938] The compiler now checks a property get handler does not return nothing.
+
+

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -317,7 +317,15 @@
         Info'Kind -> handler
         Info'Type -> handler(_, Signature)
         (|
-            where(Signature -> signature(nil, _))
+            where(Signature -> signature(nil, ReturnType))
+            (|
+                where(ReturnType -> undefined(_))
+                Id'Name -> Name
+                Id'Position -> Position
+                Error_HandlerNotSuitableForPropertyGetter(Position, Name)
+            ||
+                -- all non-void return values are fine
+            |)
         ||
             Id'Name -> Name
             Id'Position -> Position


### PR DESCRIPTION
The compiler now correctly checks that a property getter returns a value.
