### PR TITLE
[[ LCB ]] Detect too big integer literals.

### DIFF
--- a/docs/lcb/notes/14939.md
+++ b/docs/lcb/notes/14939.md
@@ -1,0 +1,7 @@
+# LiveCode Builder Tools
+
+## Compiler generates an error if integer literal too big
+
+The compiler will generate an error if an integer literal is too big to fit into the (current) unsigned 32-bit integer representation.
+
+# [14939] Compiler truncates integer literals if too big.

--- a/toolchain/lc-compile/src/INTEGER_LITERAL.t
+++ b/toolchain/lc-compile/src/INTEGER_LITERAL.t
@@ -1,6 +1,12 @@
 [0-9]+ {
-  MakeIntegerLiteral(yytext, &yylval.attr[1]);
-  yysetpos();
-   return INTEGER_LITERAL;
+    yysetpos();
+    if (MakeIntegerLiteral(yytext, &yylval.attr[1]) == 0)
+    {
+        long t_position;
+        GetCurrentPosition(&t_position);
+        Error_IntegerLiteralOutOfRange(t_position);
+        yylval.attr[1] = 0;
+    }
+    return INTEGER_LITERAL;
 }
 

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -130,6 +130,7 @@ extern "C" void EmitUndefinedConstant(long *idx);
 extern "C" void EmitTrueConstant(long *idx);
 extern "C" void EmitFalseConstant(long *idx);
 extern "C" void EmitIntegerConstant(long value, long *idx);
+extern "C" void EmitUnsignedIntegerConstant(unsigned long value, long *idx);
 extern "C" void EmitRealConstant(long value, long *idx);
 extern "C" void EmitStringConstant(long value, long *idx);
 extern "C" void EmitBeginListConstant(void);
@@ -1244,6 +1245,14 @@ void EmitIntegerConstant(long value, long *idx)
     MCNumberCreateWithInteger(value, &t_number);
     MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
     MCLog("[Emit] IntegerConstant(%ld -> %ld)", value, *idx);
+}
+
+void EmitUnsignedIntegerConstant(unsigned long value, long *idx)
+{
+    MCAutoNumberRef t_number;
+    MCNumberCreateWithUnsignedInteger(value, &t_number);
+    MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
+    MCLog("[Emit] UnsignedIntegerConstant(%lu -> %ld)", value, *idx);
 }
 
 void EmitRealConstant(long value, long *idx)

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1577,7 +1577,7 @@
         EmitAssignFalse(Output)
         
     'rule' GenerateExpressionInRegister(Result, Context, integer(_, Value), Output):
-        EmitAssignInteger(Output, Value)
+        EmitAssignUnsignedInteger(Output, Value)
         
     'rule' GenerateExpressionInRegister(Result, Context, real(_, Value), Output):
         EmitAssignReal(Output, Value)
@@ -1678,6 +1678,12 @@
         EmitIntegerConstant(Value -> Index)
         EmitAssignConstant(Reg, Index)
 
+'action' EmitAssignUnsignedInteger(INT, INT)
+
+    'rule' EmitAssignUnsignedInteger(Reg, Value):
+        EmitUnsignedIntegerConstant(Value -> Index)
+        EmitAssignConstant(Reg, Index)
+        
 'action' EmitAssignReal(INT, DOUBLE)
 
     'rule' EmitAssignReal(Reg, Value):

--- a/toolchain/lc-compile/src/literal.c
+++ b/toolchain/lc-compile/src/literal.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <errno.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -63,9 +64,22 @@ void FinalizeLiterals(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MakeIntegerLiteral(const char *p_token, long *r_literal)
+// Integer literals are actually unsigned, even though they pass through as
+// longs. Indeed, a -ve integer literal is not possible since it is prevented
+// by the token's regex.
+int MakeIntegerLiteral(const char *p_token, long *r_literal)
 {
-    *r_literal = atoi(p_token);
+    errno = 0;
+    
+    unsigned long t_value;
+    t_value = strtoul(p_token, NULL, 10);
+    
+    if (errno == ERANGE || t_value > 0xFFFFFFFFU)
+        return 0;
+    
+    *r_literal = (long)t_value;
+    
+    return 1;
 }
 
 void MakeDoubleLiteral(const char *p_token, long *r_literal)

--- a/toolchain/lc-compile/src/literal.h
+++ b/toolchain/lc-compile/src/literal.h
@@ -26,7 +26,7 @@ typedef struct Name *NameRef;
 void InitializeLiterals(void);
 void FinalizeLiterals(void);
 
-void MakeIntegerLiteral(const char *token, long *r_literal);
+int MakeIntegerLiteral(const char *token, long *r_literal);
 void MakeDoubleLiteral(const char *token, long *r_literal);
 void MakeStringLiteral(const char *token, long *r_literal);
 void MakeNameLiteral(const char *token, NameRef *r_literal);

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -174,6 +174,8 @@ DEFINE_ERROR_I(UnableToFindImportedModule, "Unable to find imported module '%s'"
 DEFINE_ERROR_S(MalformedToken, "Illegal token '%s'");
 DEFINE_ERROR_S(MalformedEscapedString, "Illegal escape in string '%s'");
 DEFINE_ERROR(MalformedSyntax, "Syntax error");
+DEFINE_ERROR(IntegerLiteralOutOfRange, "Integer literal too big");
+
 DEFINE_ERROR_I(IdentifierPreviouslyDeclared, "Identifier '%s' already declared");
 DEFINE_ERROR_I(IdentifierNotDeclared, "Identifier '%s' not declared");
 DEFINE_ERROR_I(InvalidNameForSyntaxMarkVariable, "'%s' is not a valid name for a mark variable");

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -36,6 +36,7 @@ void Error_CouldNotWriteOutputFile(const char *path);
 void Error_CouldNotWriteInterfaceFile(const char *path);
 void Error_MalformedToken(long position, const char *token);
 void Error_MalformedSyntax(long position);
+void Error_IntegerLiteralOutOfRange(long position);
     
 void Warning_EmptyUnicodeEscape(long position);
 void Warning_UnicodeEscapeTooBig(long position);

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -210,6 +210,7 @@
     EmitTrueConstant
     EmitFalseConstant
     EmitIntegerConstant
+    EmitUnsignedIntegerConstant
     EmitRealConstant
     EmitStringConstant
     EmitBeginListConstant
@@ -331,7 +332,7 @@
 'action' InitializeLiterals()
 'action' FinalizeLiterals()
 
-'action' MakeIntegerLiteral(Token: STRING -> Literal: INT)
+'condition' MakeIntegerLiteral(Token: STRING -> Literal: INT)
 'action' MakeDoubleLiteral(Token: STRING -> Literal: DOUBLE)
 'action' MakeStringLiteral(Token: STRING -> Literal: STRING)
 'condition' UnescapeStringLiteral(Position:POS, String: STRING -> UnescapedString: STRING)
@@ -550,6 +551,7 @@
 'action' EmitTrueConstant(-> ConstIndex: INT)
 'action' EmitFalseConstant(-> ConstIndex: INT)
 'action' EmitIntegerConstant(Value: INT -> ConstIndex: INT)
+'action' EmitUnsignedIntegerConstant(Value: INT -> ConstIndex: INT)
 'action' EmitRealConstant(Value: DOUBLE -> ConstIndex: INT)
 'action' EmitStringConstant(Value: STRING -> ConstIndex: INT)
 'action' EmitBeginListConstant()


### PR DESCRIPTION
The compiler will now detect and report an error if an integer literal is too big to fit into an unsigned 32-bit integer.

The internal literal representation has been changed to unsigned so that the full range of values can be achieved (literals are never -ve).

Note: The standard gentle value type is 'long', but integer literals only enter at MakeIntegerLiteral, and leave at EmitUnsignedIntegerConstant.
