### PR TITLE
[[ LCB ]] Tighten integer literal pattern.

### DIFF
--- a/docs/lcb/notes/14950.md
+++ b/docs/lcb/notes/14950.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Tools
+
+# [14950] Integer literal pattern is too general.

--- a/toolchain/lc-compile/src/INTEGER_LITERAL.t
+++ b/toolchain/lc-compile/src/INTEGER_LITERAL.t
@@ -1,4 +1,4 @@
-[0-9]+ {
+0|([1-9][0-9]*) {
   MakeIntegerLiteral(yytext, &yylval.attr[1]);
   yysetpos();
    return INTEGER_LITERAL;


### PR DESCRIPTION
An integer literal now uses the regex 0|[1-9][0-9]*.
