### PR TITLE
[[ Bug 14964 ]] LCB: Fix script mapping to 'any'.

### DIFF
--- a/docs/lcb/notes/14964.md
+++ b/docs/lcb/notes/14964.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Host Library
+
+# [14964] Crash when calling a handler with 'any' type parameter form LCS.


### PR DESCRIPTION
The mapping to the LCB 'any' type is now present.

If there is no mapping from an LCS value to an LCB type then an error will be thrown (rather than an assertion hit!)
