### PR TITLE
[[ Gentle ]] Tame Gentle command-line

### DIFF
--- a/toolchain/gentle/gentle-97/gentle/input.c
+++ b/toolchain/gentle/gentle-97/gentle/input.c
@@ -121,14 +121,19 @@ static open_next_file ()
 define_file (path)
    char * path;
 {
-/* --PATCH-- */    char cwd[4096];
 /* --PATCH-- */    char fullpath[4096];
-/* --PATCH-- */    getcwd(cwd, 4096);
+/* --PATCH-- */    if (path[0] != '/' && path[1] != ':')
+/* --PATCH-- */    {
+/* --PATCH-- */         char cwd[4096];
+/* --PATCH-- */         getcwd(cwd, 4096);
 #ifndef _WIN32
-/* --PATCH-- */    sprintf(fullpath, "%s/%s", cwd, path);
+/* --PATCH-- */         sprintf(fullpath, "%s/%s", cwd, path);
 #else
-/* --PATCH-- */    sprintf(fullpath, "%s\\%s", cwd, path);
+/* --PATCH-- */         sprintf(fullpath, "%s\\%s", cwd, path);
 #endif
+/* --PATCH-- */    }
+/* --PATCH-- */    else
+/* --PATCH-- */         sprintf(fullpath, "%s", path);
     
 /* --PATCH-- */   if (! is_defined(fullpath)) {
       filecount++;

--- a/toolchain/gentle/gentle-97/gentle/input.c
+++ b/toolchain/gentle/gentle-97/gentle/input.c
@@ -28,9 +28,11 @@ static FillBuf ();
 
 #define MAXPATH            500
 
+#define PATHLENGTH          4096
+
 static FILE   *InFile;
-/* --PATCH-- */ static char   InFileName[1024];
-/* --PATCH-- */ static char   CurFileName[1024];
+/* --PATCH-- */ static char   InFileName[PATHLENGTH];
+/* --PATCH-- */ static char   CurFileName[PATHLENGTH];
 static long   filecount = 0;
 static long   CurFile = 0;
 static char * PATH[MAXPATH];
@@ -81,7 +83,7 @@ GetSourceName (str)
 static FILE * open_file (unit)
    char * unit;
 {
-   char buf[1000];
+   char buf[PATHLENGTH];
    FILE * InFile;
       
    sprintf (buf, "%s.g", unit);
@@ -121,11 +123,11 @@ static open_next_file ()
 define_file (path)
    char * path;
 {
-/* --PATCH-- */    char fullpath[4096];
+/* --PATCH-- */    char fullpath[PATHLENGTH];
 /* --PATCH-- */    if (path[0] != '/' && path[1] != ':')
 /* --PATCH-- */    {
-/* --PATCH-- */         char cwd[4096];
-/* --PATCH-- */         getcwd(cwd, 4096);
+/* --PATCH-- */         char cwd[PATHLENGTH];
+/* --PATCH-- */         getcwd(cwd, PATHLENGTH);
 #ifndef _WIN32
 /* --PATCH-- */         sprintf(fullpath, "%s/%s", cwd, path);
 #else

--- a/toolchain/gentle/gentle-97/gentle/input.c
+++ b/toolchain/gentle/gentle-97/gentle/input.c
@@ -10,6 +10,7 @@
    gentle-97-v-4-1-0
 */
 
+extern const char *MapFile(const char *);
 
 static long is_defined();
 static open_next_file ();

--- a/toolchain/gentle/gentle-97/gentle/input.c
+++ b/toolchain/gentle/gentle-97/gentle/input.c
@@ -84,7 +84,7 @@ static FILE * open_file (unit)
    FILE * InFile;
       
    sprintf (buf, "%s.g", unit);
-   InFile = fopen (buf, "r");
+   InFile = fopen (MapFile(buf), "r");
    if (InFile == NULL) {
       char msg[200];
       sprintf(msg, "Cannot open file '%s'\n", buf);

--- a/toolchain/gentle/gentle-97/gentle/main.c
+++ b/toolchain/gentle/gentle-97/gentle/main.c
@@ -47,44 +47,89 @@ int SymbolFileOption ()
    return SymbolFileFlag;
 }
 
+/* --BEGIN-PATCH-- */
+struct FileMapping
+{
+    struct FileMapping *next;
+    char *name;
+    char *replacement;
+    int used;
+};
+
+static struct FileMapping *FileMappings;
+
+void DefFileMapping(const char *p_map_str)
+{
+    struct FileMapping *t_mapping;
+    t_mapping = (struct FileMapping *)malloc(sizeof(struct FileMapping));
+    t_mapping -> next = FileMappings;
+    t_mapping -> name = strndup(p_map_str, strchr(p_map_str, '=') - p_map_str);
+    t_mapping -> replacement = strdup(strchr(p_map_str, '=') + 1);
+    t_mapping -> used = 0;
+    FileMappings = t_mapping;
+}
+
+const char *MapFile(const char *p_input)
+{
+    struct FileMapping *t_mapping;
+    for(t_mapping = FileMappings; t_mapping != NULL; t_mapping = t_mapping -> next)
+        if (strcmp(t_mapping -> name, p_input) == 0)
+            return t_mapping -> replacement;
+    
+    return p_input;
+}
+
+/* --END-PATCH-- */
+
 /*----------------------------------------------------------------------------*/
 
 static scanargs (argc, argv)
-   int argc;
-   char ** argv;
+int argc;
+char ** argv;
 {
-   int i;
-   int source_defined = 0;
-
-   i = 1;
-   while (i < argc) {
-      /* -- PATCH -- */ if (strcmp (argv[i], "-subdir") == 0) { if (argv[i+1] == NULL) { printf("Invalid option: parameter expected for -subdir"); exit(1); } SetOption_SUBDIR(argv[++i]); }
-      else if (strcmp (argv[i], "-alert") == 0) SetOption_ALERT();
-      else if (strcmp (argv[i], "-if") == 0) SymbolFileFlag = 1;
-      else if (strcmp (argv[i], "-trace") == 0) TraceFlag = 1;
-      else {
-	 int len;
-
-	 len = strlen(argv[i]);
-
-         if (len > 0 && argv[i][0] == '-') {
-            printf ("Invalid option: %s\n", argv[i]);
-            exit(1);
-         }
-	 if (len <= 2 || argv[i][len-2] != '.' || argv[i][len-1] != 'g') {
-	    printf ("Invalid filename: %s\n", argv[i]);
-	    exit(1);
-	 }
-
-	 DefSourceName (argv[i]);
-	 source_defined = 1;
-      }
-      i++;
-   }
-   if (! source_defined) {
-      printf("Missing file name\n");
-      exit(1);
-   }
+    int i;
+    int source_defined = 0;
+    
+    i = 1;
+    while (i < argc) {
+        /* -- PATCH -- */ if (strcmp (argv[i], "-subdir") == 0) { if (argv[i+1] == NULL) { printf("Invalid option: parameter expected for -subdir"); exit(1); } SetOption_SUBDIR(argv[++i]); }
+        else if (strcmp (argv[i], "-alert") == 0) SetOption_ALERT();
+        else if (strcmp (argv[i], "-if") == 0) SymbolFileFlag = 1;
+        else if (strcmp (argv[i], "-trace") == 0) TraceFlag = 1;
+        else {
+            int len;
+            
+            len = strlen(argv[i]);
+            
+            if (len > 0 && argv[i][0] == '-') {
+                printf ("Invalid option: %s\n", argv[i]);
+                exit(1);
+            }
+            
+            /* --BEGIN-PATCH-- */
+            if (strchr(argv[i], '=') != NULL)
+            {
+                DefFileMapping(argv[i]);
+                goto continue_args;
+            }
+            /* --END-PATCH-- */
+            
+            if (len <= 2 || argv[i][len-2] != '.' || argv[i][len-1] != 'g') {
+                printf ("Invalid filename: %s\n", argv[i]);
+                exit(1);
+            }
+            
+            DefSourceName (argv[i]);
+            source_defined = 1;
+        }
+        
+    continue_args:
+        i++;
+    }
+    if (! source_defined) {
+        printf("Missing file name\n");
+        exit(1);
+    }
 }
 
 /*----------------------------------------------------------------------------*/

--- a/toolchain/gentle/gentle-97/gentle/main.c
+++ b/toolchain/gentle/gentle-97/gentle/main.c
@@ -87,10 +87,23 @@ void DefFileMapping(const char *p_map_str)
 
 const char *MapFile(const char *p_input)
 {
+    const char* t_input;
     struct FileMapping *t_mapping;
+    
+    // Only map on the basename component
+#ifndef _WIN32
+    t_input = strrchr(p_input, '/');
+#else
+    t_input = strrchr(p_input, '\\');
+#endif
+    if (t_input == NULL)
+        t_input = p_input;
+    else
+        t_input = t_input + 1;
+    
     for(t_mapping = FileMappings; t_mapping != NULL; t_mapping = t_mapping -> next)
     {
-        if (strcmp(t_mapping -> name, p_input) == 0)
+        if (strcmp(t_mapping -> name, t_input) == 0)
             return t_mapping -> replacement;
     }
     return p_input;

--- a/toolchain/gentle/gentle-97/gentle/main.c
+++ b/toolchain/gentle/gentle-97/gentle/main.c
@@ -63,8 +63,24 @@ void DefFileMapping(const char *p_map_str)
     struct FileMapping *t_mapping;
     t_mapping = (struct FileMapping *)malloc(sizeof(struct FileMapping));
     t_mapping -> next = FileMappings;
-    t_mapping -> name = strndup(p_map_str, strchr(p_map_str, '=') - p_map_str);
-    t_mapping -> replacement = strdup(strchr(p_map_str, '=') + 1);
+    
+    const char *t_equal;
+    t_equal = strchr(p_map_str, '=');
+    
+    t_mapping -> name = strndup(p_map_str, t_equal - p_map_str);
+    
+    t_equal++;
+    if (t_equal[0] == '\"')
+        t_equal++;
+    
+    t_mapping -> replacement = strdup(t_equal);
+    
+    size_t t_length;
+    t_length = strlen(t_mapping -> replacement);
+    if (t_length > 0)
+        if (t_mapping -> replacement[t_length - 1] == '\"')
+            t_mapping -> replacement[t_length - 1] = '\0';
+    
     t_mapping -> used = 0;
     FileMappings = t_mapping;
 }
@@ -73,9 +89,10 @@ const char *MapFile(const char *p_input)
 {
     struct FileMapping *t_mapping;
     for(t_mapping = FileMappings; t_mapping != NULL; t_mapping = t_mapping -> next)
+    {
         if (strcmp(t_mapping -> name, p_input) == 0)
             return t_mapping -> replacement;
-    
+    }
     return p_input;
 }
 

--- a/toolchain/gentle/gentle-97/gentle/output.c
+++ b/toolchain/gentle/gentle-97/gentle/output.c
@@ -147,7 +147,7 @@ nl()
 TellFile(Name)
    char *Name;
 {
-   char buf[200];
+   char buf[4096];
 
 /* --PATCH-- */   if (SUBDIR != NULL)
 /* --PATCH-- */      sprintf(buf, "%s/%s", SUBDIR, Name);
@@ -160,7 +160,7 @@ TellFile(Name)
 
 TellClauseFile()
 {
-   char name[100];
+   char name[4096];
    extern char *SourceName();
    
    sprintf(name, "%s.c", SourceName());
@@ -172,7 +172,7 @@ TellClauseFile()
 
 TellSymbolFile()
 {
-   char name[100];
+   char name[4096];
    extern char *SourceName();
    
    sprintf(name, "%s.if", SourceName());
@@ -184,7 +184,7 @@ TellSymbolFile()
 
 TellXRefFile()
 {
-   char name[100];
+   char name[4096];
    extern char *SourceName();
    
    sprintf(name, "%s.nst", SourceName());

--- a/toolchain/gentle/gentle-97/gentle/output.c
+++ b/toolchain/gentle/gentle-97/gentle/output.c
@@ -16,6 +16,8 @@
 #define FlushPos 5000
 
 
+extern const char *MapFile(const char *);
+
 static char OutBuf[OutBufSize];
 static char *OutBufPtr;
 static FILE *OutFile;

--- a/toolchain/gentle/gentle-97/gentle/output.c
+++ b/toolchain/gentle/gentle-97/gentle/output.c
@@ -31,8 +31,7 @@ Tell(Name)
    Told();
    OutFile = fopen(MapFile(Name), "w");
    if (OutFile == NULL) {
-      char msg[200];
-      sprintf(msg, "cannot open %s\n", Name);
+      fprintf(stderr, "cannot open %s\n", Name);
       exit(1);
    }
    OutBufPtr = &OutBuf[0];

--- a/toolchain/gentle/gentle-97/gentle/output.c
+++ b/toolchain/gentle/gentle-97/gentle/output.c
@@ -27,7 +27,7 @@ Tell(Name)
    char *Name;
 {
    Told();
-   OutFile = fopen(Name, "w");
+   OutFile = fopen(MapFile(Name), "w");
    if (OutFile == NULL) {
       char msg[200];
       sprintf(msg, "cannot open %s\n", Name);
@@ -152,7 +152,7 @@ TellFile(Name)
 /* --PATCH-- */      sprintf(buf, "%s/%s", SUBDIR, Name);
    else
       sprintf(buf, "%s", Name);
-   Tell(buf);
+   Tell(MapFile(buf));
 }
 
 /*----------------------------------------------------------------------------*/
@@ -164,7 +164,7 @@ TellClauseFile()
    
    sprintf(name, "%s.c", SourceName());
 
-   TellFile(name);
+   TellFile(MapFile(name));
 }
 
 /*----------------------------------------------------------------------------*/
@@ -176,7 +176,7 @@ TellSymbolFile()
    
    sprintf(name, "%s.if", SourceName());
 
-   TellFile(name);
+   TellFile(MapFile(name));
 }
 
 /*----------------------------------------------------------------------------*/
@@ -188,7 +188,7 @@ TellXRefFile()
    
    sprintf(name, "%s.nst", SourceName());
 
-   TellFile(name);
+   TellFile(MapFile(name));
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
The 'reflex' command will now take arguments of the form:
  `<filename>`
  `<input>=<filename>`

The `<filename>` form is equivalent to `<leaf of filename>=<filename>`.

The resulting X=Y mappings are used whenever reflex looks up a file. For example:

`reflex gen.lit=../../foo.lit gen.tkn=$(DERIVED_SRC_DIR)/foo.gen ../COMMENTS.b gen.l=$(DERIVED_SRC_DIR)/foo.l`

This will cause:
- gen.lit to be taken from '../../foo.lit'
- gen.tkn to be taken from '../../foo.tkn'
- COMMENTS.b to be taken from ../COMMENTS.b
- the output file gen.l to be placed into '$(DERIVED_SRC_DIR)/foo.l'

---

The 'gentle' command can now accept extra input parameters of the form `x=y`.

These parameters are used to remap the short name of a file 'x' to a file path 'y'.

For example:

```
  gentle support.c=$(DERIVED)/my_support.c support.g
```

Would compile support.g but generate the clause (C) file my_support.c in $(DERIVED).

This also works for the auxillary files generated by a gentle grammar file - gen.lit, gen.tkn, gen.h and gen.y can all be remapped to different files.

Additionally, resolution of input modules (i.e. other .g files which are used by the 'use' clause) can also be remapped using this formalism. e.g. `othermod.g=$(OTHER_FOLDER)/somemod.g`.
