### PR TITLE
Fix incorrect reinterpret cast

### DIFF
--- a/engine/src/ifile.cpp
+++ b/engine/src/ifile.cpp
@@ -93,8 +93,15 @@ bool MCImageCompress(MCImageBitmap *p_bitmap, bool p_dither, MCImageCompressedBi
 			 }
 		}
 
-		if (t_stream != nil)
-			t_success = MCS_closetakingbuffer(t_stream, reinterpret_cast<void*&>(t_buffer), reinterpret_cast<size_t&>(t_size)) == IO_NORMAL;
+		if (t_stream != nil) {
+			size_t t_size_t;
+			t_success = MCS_closetakingbuffer(
+				t_stream,
+				reinterpret_cast<void*&>(t_buffer),
+				t_size_t
+			) == IO_NORMAL;
+			t_size = t_size_t;
+		}
 
 		if (t_success)
 			t_success = MCImageCreateCompressedBitmap(t_compression, r_compressed);


### PR DESCRIPTION
I was getting a crash when deleting and image.  This was caused by an incorrect reinterpret cast from a `uindex_t` to a `size_t&`, as a `uindex_t` is 4 bytes and a `size_t` is 8 bytes when a value was written into it it was clobbering the value of a different variable.

I've added a local `size_t` variable which is then later assigned to the original `uindex_t` variable.  There's actually no possibility of an overflow here as the `size_t` is actually set from a `uint32_t`.  A better solution might be to convert to use `size_t` throughout these functions, but that would be a bigger code change.
