### PR TITLE
[[ Bug ]] Fix issue with signed integers coming from syntax bindings.

### DIFF
--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -288,6 +288,7 @@
     'rule' ComputeTypeOfConstantTermExpression(undefined(Position) -> undefined(Position)):
     'rule' ComputeTypeOfConstantTermExpression(true(Position) -> boolean(Position)):
     'rule' ComputeTypeOfConstantTermExpression(false(Position) -> boolean(Position)):
+    'rule' ComputeTypeOfConstantTermExpression(unsignedinteger(Position, _) -> integer(Position)):
     'rule' ComputeTypeOfConstantTermExpression(integer(Position, _) -> integer(Position)):
     'rule' ComputeTypeOfConstantTermExpression(real(Position, _) -> real(Position)):
     'rule' ComputeTypeOfConstantTermExpression(string(Position, _) -> string(Position)):

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -436,6 +436,7 @@
     'rule' IsExpressionSimpleConstant(undefined(_)):
     'rule' IsExpressionSimpleConstant(true(_)):
     'rule' IsExpressionSimpleConstant(false(_)):
+    'rule' IsExpressionSimpleConstant(unsignedinteger(_, _)):
     'rule' IsExpressionSimpleConstant(integer(_, _)):
     'rule' IsExpressionSimpleConstant(real(_, _)):
     'rule' IsExpressionSimpleConstant(string(_, _)):
@@ -1544,6 +1545,7 @@
     'rule' GetExpressionPosition(undefined(Position) -> Position):
     'rule' GetExpressionPosition(true(Position) -> Position):
     'rule' GetExpressionPosition(false(Position) -> Position):
+    'rule' GetExpressionPosition(unsignedinteger(Position, _) -> Position):
     'rule' GetExpressionPosition(integer(Position, _) -> Position):
     'rule' GetExpressionPosition(real(Position, _) -> Position):
     'rule' GetExpressionPosition(string(Position, _) -> Position):

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1576,8 +1576,11 @@
     'rule' GenerateExpressionInRegister(Result, Context, false(_), Output):
         EmitAssignFalse(Output)
         
-    'rule' GenerateExpressionInRegister(Result, Context, integer(_, Value), Output):
+    'rule' GenerateExpressionInRegister(Result, Context, unsignedinteger(_, Value), Output):
         EmitAssignUnsignedInteger(Output, Value)
+
+    'rule' GenerateExpressionInRegister(Result, Context, integer(_, Value), Output):
+        EmitAssignInteger(Output, Value)
         
     'rule' GenerateExpressionInRegister(Result, Context, real(_, Value), Output):
         EmitAssignReal(Output, Value)
@@ -1706,6 +1709,9 @@
 
     'rule' EmitConstant(false(_) -> Index):
         EmitFalseConstant(-> Index)
+
+    'rule' EmitConstant(unsignedinteger(_, IntValue) -> Index):
+        EmitUnsignedIntegerConstant(IntValue -> Index)
 
     'rule' EmitConstant(integer(_, IntValue) -> Index):
         EmitIntegerConstant(IntValue -> Index)

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -940,7 +940,7 @@
     'rule' ConstantTermExpression(-> false(Position)):
         "false" @(-> Position)
 
-    'rule' ConstantTermExpression(-> integer(Position, Value)):
+    'rule' ConstantTermExpression(-> unsignedinteger(Position, Value)):
         INTEGER_LITERAL(-> Value) @(-> Position)
 
     'rule' ConstantTermExpression(-> real(Position, Value)):

--- a/toolchain/lc-compile/src/syntax-gen.c
+++ b/toolchain/lc-compile/src/syntax-gen.c
@@ -1389,7 +1389,10 @@ static void GenerateSyntaxRuleExplicitAndUnusedMarks(SyntaxNodeRef p_node)
                     fprintf(s_output, "EXPRESSION'%s(UndefinedPosition)", p_node -> marks[i] . value -> boolean_mark . value == 0 ? "false" : "true");
                     break;
                 case kSyntaxNodeKindIntegerMark:
-                    fprintf(s_output, "EXPRESSION'integer(UndefinedPosition, %ld)", p_node -> marks[i] . value -> integer_mark . value);
+                    if (p_node -> marks[i] . value -> integer_mark . value < 0)
+                        fprintf(s_output, "EXPRESSION'integer(UndefinedPosition, %ld)", p_node -> marks[i] . value -> integer_mark . value);
+                    else
+                        fprintf(s_output, "EXPRESSION'unsignedinteger(UndefinedPosition, %lu)", (unsigned long)p_node -> marks[i] . value -> integer_mark . value);
                     break;
                 case kSyntaxNodeKindRealMark:
                     fprintf(s_output, "EXPRESSION'real(UndefinedPosition, Mark%ldValue)", p_node -> marks[i] . index);

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -160,6 +160,7 @@
     true(Position: POS)
     false(Position: POS)
     integer(Position: POS, Value: INT)
+    unsignedinteger(Position: POS, Value: INT)
     real(Position: POS, Value: DOUBLE)
     string(Position: POS, Value: STRING)
     slot(Position: POS, Name: ID)


### PR DESCRIPTION
The Canvas module uses an integer mark with a negative value. This wasn't generating the write syntax binding in the full grammar, causing an erroneous value to be passed through to MCCanvasFillTextAligned.
