### PR TITLE
[[ Bug 15034 ]] Fix non-64-bit clean uses of MCS_closetakingbuffer.

### DIFF
--- a/docs/notes/bugfix-15034.md
+++ b/docs/notes/bugfix-15034.md
@@ -1,0 +1,1 @@
+# import snapshot does not work correctly on 64-bit Linux.

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -4060,7 +4060,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 		uint32_t t_buf_size;
 		bool t_success;
 
-		t_success = MCS_closetakingbuffer(MCprocesses[index].ohandle, t_buffer, t_buf_size) == IO_NORMAL;
+		t_success = MCS_closetakingbuffer_uint32(MCprocesses[index].ohandle, t_buffer, t_buf_size) == IO_NORMAL;
         MCprocesses[index].ohandle = nil;
         
         IO_cleanprocesses();

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3648,23 +3648,31 @@ void MCInterfaceExportBitmap(MCExecContext &ctxt, MCImageBitmap *p_bitmap, int p
 	}
 	
 	IO_handle t_stream = nil;
-	/* UNCHECKED */ t_stream = MCS_fakeopenwrite();
-	t_success = MCImageExport(p_bitmap, (Export_format)p_format, t_ps_ptr, p_dither, p_metadata, t_stream, nil);
+	t_stream = MCS_fakeopenwrite();
+    if (t_stream == nil)
+        t_success = false;
+    if (t_success)
+        t_success = MCImageExport(p_bitmap, (Export_format)p_format, t_ps_ptr, p_dither, p_metadata, t_stream, nil);
 	
 	MCAutoByteArray t_autobuffer;
 	void *t_buffer = nil;
 	size_t t_size = 0;
-	MCS_closetakingbuffer(t_stream, t_buffer, t_size);
-	t_autobuffer.Give((char_t*)t_buffer, t_size);
+    if (t_success &&
+        MCS_closetakingbuffer(t_stream, t_buffer, t_size) != IO_NORMAL)
+        t_success = false;
+    
+    if (t_success)
+        t_autobuffer.Give((char_t*)t_buffer, t_size);
 
+    if (t_success)
+        t_success = t_autobuffer.CreateDataAndRelease(r_data);
+    
 	if (!t_success)
 	{
 		ctxt.LegacyThrow(EE_EXPORT_CANTWRITE);
 		
 		return;
 	}
-	
-	/* UNCHECKED */ t_autobuffer.CreateDataAndRelease(r_data);
 }
 
 void MCInterfaceExportBitmapToFile(MCExecContext& ctxt, MCImageBitmap *p_bitmap, int p_format, MCInterfaceImagePaletteSettings *p_palette, bool p_dither, MCImageMetadata* p_metadata, MCStringRef p_filename, MCStringRef p_mask_filename)

--- a/engine/src/ifile.cpp
+++ b/engine/src/ifile.cpp
@@ -69,7 +69,7 @@ bool MCImageCompress(MCImageBitmap *p_bitmap, bool p_dither, MCImageCompressedBi
 	else
 	{
 		uint32_t t_compression;
-		char *t_buffer = nil;
+		void *t_buffer = nil;
 		uindex_t t_size = 0;
 
 		IO_handle t_stream = nil;
@@ -94,7 +94,7 @@ bool MCImageCompress(MCImageBitmap *p_bitmap, bool p_dither, MCImageCompressedBi
 		}
 
 		if (t_stream != nil)
-			t_success = MCS_closetakingbuffer(t_stream, reinterpret_cast<void*&>(t_buffer), reinterpret_cast<size_t&>(t_size)) == IO_NORMAL;
+			t_success = MCS_closetakingbuffer_uint32(t_stream, t_buffer, t_size) == IO_NORMAL;
 
 		if (t_success)
 			t_success = MCImageCreateCompressedBitmap(t_compression, r_compressed);

--- a/engine/src/iutil.cpp
+++ b/engine/src/iutil.cpp
@@ -1236,7 +1236,7 @@ bool MCImageCreateClipboardData(MCImageBitmap *p_bitmap, MCDataRef &r_data)
 	MCImageBitmap *t_bitmap = nil;
 	IO_handle t_stream = nil;
 	
-	char *t_bytes = nil;
+	void *t_bytes = nil;
 	uindex_t t_byte_count = 0;
 	
 	t_success = nil != (t_stream = MCS_fakeopenwrite());
@@ -1244,7 +1244,7 @@ bool MCImageCreateClipboardData(MCImageBitmap *p_bitmap, MCDataRef &r_data)
 	if (t_success)
 		t_success = MCImageEncodePNG(p_bitmap, nil, t_stream, t_byte_count);
 	
-	if (t_stream != nil && IO_NORMAL != MCS_closetakingbuffer(t_stream, reinterpret_cast<void*&>(t_bytes), reinterpret_cast<size_t&>(t_byte_count)))
+	if (t_stream != nil && IO_NORMAL != MCS_closetakingbuffer_uint32(t_stream, t_bytes, t_byte_count))
 		t_success = false;
 	
 	if (t_success)

--- a/engine/src/mcio.h
+++ b/engine/src/mcio.h
@@ -182,6 +182,7 @@ extern IO_handle MCS_fakeopen(const void *p_data, uindex_t p_size);
 extern IO_handle MCS_fakeopenwrite(void);
 ///* LEGACY */ extern IO_stat MCS_fakeclosewrite(IO_handle &stream, char*& r_buffer, uint4& r_length);
 extern IO_stat MCS_closetakingbuffer(IO_handle& p_stream, void*& r_buffer, size_t& r_length);
+extern IO_stat MCS_closetakingbuffer_uint32(IO_handle& p_stream, void*& r_buffer, uint32_t& r_length);
 
 extern IO_handle MCS_deploy_open(MCStringRef path, intenum_t p_mode);
 /* LEGACY */ extern IO_handle MCS_open(const char *path, const char *mode, Boolean map, Boolean driver, uint4 offset);

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -1092,6 +1092,25 @@ IO_stat MCS_closetakingbuffer(IO_handle& p_stream, void*& r_buffer, size_t& r_le
 	return IO_NORMAL;
 }
 
+IO_stat MCS_closetakingbuffer_uint32(IO_handle& p_stream, void*& r_buffer, uint32_t& r_length)
+{
+    size_t t_size;
+    void *t_buffer;
+    if (MCS_closetakingbuffer(p_stream, t_buffer, t_size) != IO_NORMAL)
+        return IO_ERROR;
+    
+    if (t_size > UINT32_MAX)
+    {
+        free(t_buffer);
+        return IO_ERROR;
+    }
+    
+    r_buffer = t_buffer;
+    r_length = (uint32_t)t_size;
+    
+	return IO_NORMAL;
+}
+
 IO_stat MCS_writeat(const void *p_buffer, uint32_t p_size, uint32_t p_pos, IO_handle p_stream)
 {
     uint64_t t_old_pos;

--- a/engine/src/w32transfer.cpp
+++ b/engine/src/w32transfer.cpp
@@ -1254,7 +1254,7 @@ bool MCWindowsPasteboard::Fetch(MCTransferType p_type, MCDataRef& r_data)
 			t_success = MCImageEncodePNG(t_bitmap, NULL, t_stream, t_byte_count);
 
 		if (t_success)
-			t_success = IO_NORMAL == MCS_closetakingbuffer(t_stream, *(void**)(&t_buffer), t_length);
+			t_success = IO_NORMAL == MCS_closetakingbuffer_uint32(t_stream, *(void**)(&t_buffer), t_length);
 
 		if (t_success)
 			t_success = MCDataCreateWithBytesAndRelease((char_t*)t_buffer, t_length, &t_out_data);


### PR DESCRIPTION
Incorrect reinterpret casts were being applied to the buffer length variable.

This has been resolved by adding an MCS_closetakingbuffer_uint32 variant, which wraps MCS_closetakingbuffer and size checks the buffer size before returning.
