### PR TITLE
[[ Bug 15062 ]] _NSGetExecutablePath returns UTF-8 encoded string, not a...

### DIFF
--- a/docs/notes/bugfix-15062.md
+++ b/docs/notes/bugfix-15062.md
@@ -1,0 +1,1 @@
+# Standalones saved in a folder with Unicode char will not launch on Mac

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -6290,8 +6290,10 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 		}
 
 		MCAutoStringRef t_path;
-		MCStringCreateWithCStringAndRelease(buf, &t_path);
-		return ResolvePath(*t_path, r_path);
+        // [[ Bug 15062 ]] The path returned by _NSGetExecutablePath is UTF-8
+        //  encoded. We should decode it this way.
+        return MCStringCreateWithBytesAndRelease((byte_t*)buf, bufsize, kMCStringEncodingUTF8, false, &t_path)
+            && ResolvePath(*t_path, r_path);
 	}
 
 


### PR DESCRIPTION
... C-string
