### PR TITLE
[[ Bug 14794 ]] Add the possibility to build 32-bit only iOS standalones...

### DIFF
--- a/docs/notes/bugfix-14794.md
+++ b/docs/notes/bugfix-14794.md
@@ -1,0 +1,1 @@
+# unable to test ios standalones on iPad 1 running ios 5.1.1

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -387,12 +387,15 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
          end if
          
          local tArchs
-         if tRawArchs contains "ARM64" then
+         -- SN-2015-03-30: [[ Bug 14794 ]] If the user specifies a 32-bit only build,
+         --  then we do not do the 64-bit build.
+         if tRawArchs contains "ARM64" and not tSettings["ios,32-bit only"] then
             put "arm64 " after tArchs
          end if
          if tRawArchs contains "V7" then
             put "armv7 " after tArchs
          end if
+         
          
          -- SN-2015-02-19: [[ Bug 14625 ]] Build each binary separately according
          -- to their architecture.


### PR DESCRIPTION
... (iPad 1 development)

Branch https://github.com/runrev/livecode-ide/pull/155 must be merged on counterpart.
