### PR TITLE
[[ Bug 14466 ]] Enable MCscreendc::wait to be called when reading from a...

### DIFF
--- a/docs/notes/bugfix-14466.md
+++ b/docs/notes/bugfix-14466.md
@@ -1,0 +1,1 @@
+# read from socket x until empty returns nothing


### PR DESCRIPTION
... socket until empty
