### PR TITLE
Make sure the BillingProvider is not initialised on first launch, if IAP is not used

### DIFF
--- a/engine/src/java/com/runrev/android/billing/BillingModule.java
+++ b/engine/src/java/com/runrev/android/billing/BillingModule.java
@@ -32,7 +32,7 @@ public class BillingModule
     public BillingProvider getBillingProvider()
     {
         // PM-2015-02-25: [[ Bug 14665 ]] Make sure the "In-app Purchase" checkbox is ticked in standalone settings
-        if (Engine.doGetCustomPropertyValue("cREVStandaloneSettings", "android,InAppPurchasing").equals("false"))
+        if (!Engine.doGetCustomPropertyValue("cREVStandaloneSettings", "android,InAppPurchasing").equals("true"))
             return null;
         
         Log.d(TAG, "Fetching the billing provider...");


### PR DESCRIPTION
Previously, the BillingProvider was not initialised if Engine.doGetCustomPropertyValue("cREVStandaloneSettings", "android,InAppPurchasing") == "false".
On the first launch, if in-app purchase checkbox was not ticked, this value was " "(empty) rather than "false". Thus, the BillingProvider was initialised, although it shouldn't.
