### PR TITLE
[[ Bug 15128 ]] Fix OnMouseMove invocation in widgets.

### DIFF
--- a/docs/lcb/notes/15128.md
+++ b/docs/lcb/notes/15128.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Host Library
+
+# [15128] OnMouseMove doesn't fire if there is more than one widget on a card.

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -172,10 +172,6 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
     bool t_pos_changed;
     t_pos_changed = !(p_x == m_mouse_x && p_y == m_mouse_y);
     
-    // Update the mouse position
-    m_mouse_x = p_x;
-    m_mouse_y = p_y;
-    
     // Do a quick bounds test on the targeted widget. If this fails, the widget
     // wasn't the target of the mouse focus event.
     MCRectangle p_rect;
@@ -197,6 +193,10 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
         
         if (m_mouse_grab == p_widget)
         {
+            // Update the mouse position
+            m_mouse_x = p_x;
+            m_mouse_y = p_y;
+            
             mouseMove(p_widget, p_x, p_y);
             return true;
         }
@@ -214,6 +214,10 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
     }
     else if (t_pos_changed)
     {
+        // Update the mouse position
+        m_mouse_x = p_x;
+        m_mouse_y = p_y;
+        
         // Mouse has moved within this widget
         mouseMove(p_widget, p_x, p_y);
     }

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -193,10 +193,6 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
         
         if (m_mouse_grab == p_widget)
         {
-            // Update the mouse position
-            m_mouse_x = p_x;
-            m_mouse_y = p_y;
-            
             mouseMove(p_widget, p_x, p_y);
             return true;
         }
@@ -214,10 +210,6 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
     }
     else if (t_pos_changed)
     {
-        // Update the mouse position
-        m_mouse_x = p_x;
-        m_mouse_y = p_y;
-        
         // Mouse has moved within this widget
         mouseMove(p_widget, p_x, p_y);
     }


### PR DESCRIPTION
We now only update the event managers mouse x and y variables on sending a mouse move event. This ensures that the correct widget handles the mouse move.
