### PR TITLE
libfoundation: MCErrorCreateAndThrowWithMessage(): Use correct message text

### DIFF
--- a/libfoundation/src/foundation-error.cpp
+++ b/libfoundation/src/foundation-error.cpp
@@ -271,7 +271,7 @@ MCErrorCreateAndThrowWithMessageV (MCTypeInfoRef p_error_type,
     }
     
     MCAutoErrorRef t_error;
-    if (!MCErrorCreate(p_error_type, *t_info, &t_error))
+    if (!MCErrorCreateWithMessage(p_error_type, p_message, *t_info, &t_error))
         return false;
     
     return MCErrorThrow(*t_error);


### PR DESCRIPTION
Make sure that MCErrorCreateAndThrowWithMessage() correctly
constructs the thrown error with the message text it was passed,
rather than using the generic message text from the error type.
