### PR TITLE
MCEngineAddExtensionFromModule: More informative error message

### DIFF
--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -99,7 +99,15 @@ bool MCEngineAddExtensionFromModule(MCStringRef p_filename, MCScriptModuleRef p_
 {
     if (!MCScriptEnsureModuleIsUsable(p_module))
     {
-        MCresult -> sets("module is not usable");
+        MCAutoErrorRef t_error;
+        if (MCErrorCatch(&t_error))
+        {
+            MCresult -> setvalueref(MCErrorGetMessage(*t_error));
+        }
+        else
+        {
+            MCresult -> sets("module is not usable");
+        }
         return false;
     }
     


### PR DESCRIPTION
The LCB virtual machine now provides better errors when a module
can't be loaded.  These are passed to as `the result` when `load
extension` fails.
