### PR TITLE
[Bug 14972] Init setcallbacksptr to prevent a crash in LoadDatabaseDriver

### DIFF
--- a/docs/notes/bugfix-14972.md
+++ b/docs/notes/bugfix-14972.md
@@ -1,0 +1,1 @@
+#    Hard crash on iOS during startup

--- a/revdb/src/iossupport.cpp
+++ b/revdb/src/iossupport.cpp
@@ -203,6 +203,8 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)dlsym(t_driver_handle, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)dlsym(t_driver_handle, "newdbconnectionref");
 	t_result -> releaseconnectionptr = (release_connectionrefptr)dlsym(t_driver_handle, "releasedbconnectionref");
+    // PM-2015-04-09: [[ Bug 14972 ]] Init setcallbacksptr to prevent a crash when LoadDatabaseDriver is called
+    t_result -> setcallbacksptr = (set_callbacksrefptr)nil;
 	free(t_filename);
 	return t_result;
 #else
@@ -223,6 +225,8 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)resolve_symbol(t_driver_handle, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)resolve_symbol(t_driver_handle, "newdbconnectionref");
 	t_result -> releaseconnectionptr = (release_connectionrefptr)resolve_symbol(t_driver_handle, "releasedbconnectionref");
+    // PM-2015-04-09: [[ Bug 14972 ]] Init setcallbacksptr to prevent a crash when LoadDatabaseDriver is called
+    t_result -> setcallbacksptr = (set_callbacksrefptr)nil;
 	free(t_filename);
 	return t_result;
 #endif


### PR DESCRIPTION
Note:  There were two issues in bug report 14972
1. A crash on startup when running on 64-bit devices
2. A crash later on, when trying to load a database

Issue (1) is addressed in pull request for bug 15090:
https://github.com/runrev/livecode/pull/2133

Issue (2) is addressed in this pull request
