### PR TITLE
[[ Bug 14879 ]] Use glGetError() after calling glTexSubImage2D, to get t...

### DIFF
--- a/docs/notes/bugfix-14879.md
+++ b/docs/notes/bugfix-14879.md
@@ -1,0 +1,1 @@
+#  android mobile app launch hangs up while processing the opencard handler

--- a/engine/src/tilecachegl.cpp
+++ b/engine/src/tilecachegl.cpp
@@ -354,7 +354,14 @@ bool MCTileCacheOpenGLCompositor_AllocateTile(void *p_context, int32_t p_size, c
 		
 		// Fill the texture.
 		// IM_2013-08-21: [[ RefactorGraphics ]] set iOS pixel format to RGBA
-		glTexSubImage2D(GL_TEXTURE_2D, 0, t_x * self -> tile_size, t_y * self -> tile_size, self -> tile_size, self -> tile_size, GL_RGBA, GL_UNSIGNED_BYTE, t_data);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, t_x * self -> tile_size, t_y * self -> tile_size, self -> tile_size, self -> tile_size, GL_RGBA, GL_UNSIGNED_BYTE, t_data);
+        // SN-2015-04-13: [[ Bug 14879 ]] This function seems to fail sometimes,
+        //  and we want to get the error here, not in
+        //  MCTileCacheOpenGLCompositorFlushSuperTiles as it happens in the
+        //  stack attached to the bug report.
+        GLenum t_error = glGetError();
+        if (t_error != GL_NO_ERROR)
+            MCLog("glTextSubImage2D(x,x,%d,%d,%d,%d,...) returned error 0x%X", t_x * self -> tile_size, t_y * self -> tile_size, self -> tile_size, self -> tile_size, t_error);
 
 		// Set the tile id.
 		t_tile = (void *)t_tile_id;


### PR DESCRIPTION
...he error at the right location
