### PR TITLE
[[ Bug 15257 ]] Stdin shouldn't be non-blocking in LiveCode server

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -989,9 +989,12 @@ public:
     #endif
     #endif
 
-
+#ifndef _SERVER
+		// ST-2015-04-20: [[ Bug 15257 ]] Stdin shouldn't be set to
+		// non-blocking in server.
         if (!IsInteractiveConsole(0))
             MCS_lnx_nodelay(0);
+#endif
 
         // MW-2013-10-01: [[ Bug 11160 ]] At the moment NBSP is not considered a space.
         MCctypetable[160] &= ~(1 << 4);


### PR DESCRIPTION
Reading from $_POST_RAW would sometimes fail, this was because stdin was being set to non-blocking in dsklnx.cpp.
