### PR TITLE
Revert "[[Bugfix 12106]] In livecode server the $n arguments are no long...

### DIFF
--- a/docs/notes/bugfix-12106.md
+++ b/docs/notes/bugfix-12106.md
@@ -1,1 +1,0 @@
-# $0 is the first argument, not the script name (LC server)

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -408,8 +408,7 @@ bool X_init(int argc, char *argv[], char *envp[])
 			MCserverinitialscript = NULL;
 		
 		// Create the $<n> variables.
-        // PM-2014-04-14: [[Bug 12106]] Make sure $0 is the script name, and $n is the n-th argument
-		for(int i = 1; i < argc; ++i)
+		for(int i = 2; i < argc; ++i)
 			if (argv[i] != nil)
 			create_var(argv[i]);
 		create_var(nvars);


### PR DESCRIPTION
Reverts runrev/livecode#1405
