### PR TITLE
[[ Bug 14994 ]] Ensure that the activefield is not NULL before starting ...

### DIFF
--- a/docs/notes/bugfix-14994.md
+++ b/docs/notes/bugfix-14994.md
@@ -1,0 +1,1 @@
+# Clicking in field with listBehavior true and lockText false crashes

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -1085,7 +1085,9 @@ void MCScreenDC::activateIME(Boolean activate)
     if (!m_has_gtk)
         return;
     
-    if (activate)
+    // SN-2015-04-22: [[ Bug 14994 ]] Ensure that there is an activeField
+    //  before starting the IME in it.
+    if (activate && MCactivefield)
     {
         gtk_im_context_set_client_window(m_im_context, MCactivefield->getstack()->getwindow());
         gtk_im_context_focus_in(m_im_context);


### PR DESCRIPTION
...the IME in it

As expected by this fix, this causes the IME to stop working in the window containing the faulty field (see the bug report http://quality.runrev.com/show_bug.cgi?id=14994 ).
That said, it now matches the (buggy) behaviour occuring as well on the other platforms - and no longer crashes.
