### PR TITLE
[Bug 15264] Crash when selecting "Tracks" in player property inspector

### DIFF
--- a/docs/notes/bugfix-15264.md
+++ b/docs/notes/bugfix-15264.md
@@ -1,0 +1,1 @@
+#   Crash in Stack with Player Object when selecting "Tracks" in the player property inspector

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -2711,6 +2711,9 @@ void MCPlayer::gettracks(MCStringRef &r_tracks)
         }
         /* UNCHECKED */ MCListCopyAsString(*t_tracks_list, r_tracks);
     }
+    // PM-2015-04-22: [[ Bug 15264 ]] In case of invalid/non-existent file, return empty (as in LC 6.7.x)
+    else
+        r_tracks = MCValueRetain(kMCEmptyString);
 }
 
 uinteger_t MCPlayer::gettrackcount()


### PR DESCRIPTION
and the player filename is invalid/non-existent
