### PR TITLE
[[ CmdLineBuilder ]] Installers can now be built from the command-line.

### DIFF
--- a/builder/builder_tool.livecodescript
+++ b/builder/builder_tool.livecodescript
@@ -109,7 +109,12 @@ end startup
 command __loadExternal pExternal
    set the itemdelimiter to slash
    
-   set the externals of the templateStack to item 1 to -4 of specialFolderPath("engine") & slash & pExternal & ".bundle"
+   if the platform is "mac" then
+      set the externals of the templateStack to item 1 to -4 of specialFolderPath("engine") & slash & pExternal & ".bundle"
+   else if the platform is "linux" then
+      set the externals of the templateStack to specialFolderPath("engine") & slash & pExternal & ".so"
+   end if
+   
    create stack pExternal && "External"
    start using it
    if the externalCommands of it is empty then

--- a/builder/builder_tool.livecodescript
+++ b/builder/builder_tool.livecodescript
@@ -53,7 +53,7 @@ on startup
          end if
          put tArgs[tArgIndex + 1] into tBuild
          add 1 to tArgIndex
-      else if tArgs[tArgIndex] is "--engine-dir" then
+      else if tArgs[tArgIndex] is "--engine-dir" or tArgs[tArgIndex] is "--input-dir" then
          if tArgs[tArgIndex + 1] is empty then
             __builderLog "error", "No path specified for --engine-dir argument"
          end if

--- a/builder/builder_tool.livecodescript
+++ b/builder/builder_tool.livecodescript
@@ -36,7 +36,7 @@ on startup
          put true into tPlatforms[it]
          add 1 to tArgIndex
       else if tArgs[tArgIndex] is "--stage" then
-         if tArgs[tArgIndex + 1] is not among the items of "environment,tools,server,notes,docs" then
+         if tArgs[tArgIndex + 1] is not among the items of "environment,tools,server,notes,docs,disk" then
             __builderLog "error", "Unknown stage '" & tArgs[tArgIndex + 1] & "'"
          end if
          put tArgs[tArgIndex + 1] into tStage
@@ -91,6 +91,14 @@ on startup
    
    if tEngineDir is not empty then
       builderSetEngineDir tEngineDir
+   end if
+   
+   if tOutputDir is not empty then
+      builderSetOutputDir tOutputDir
+   end if
+   
+   if tWorkDir is not empty then
+      builderSetWorkDir tWorkDir
    end if
    
    builderBuild tStage, the keys of tPlatforms, tEdition, tBuild

--- a/builder/builder_tool.livecodescript
+++ b/builder/builder_tool.livecodescript
@@ -1,0 +1,129 @@
+﻿script "Command Line Builder"
+local sWarnAsError
+
+on startup
+   set the itemdelimiter to slash
+   start using stack (item 1 to -2 of the filename of me & slash & "builder_utilities.livecodescript")
+   set the itemDelimiter to comma
+   
+   __loadExternal "revzip"
+   __loadExternal "revxml"
+   
+   put false into sWarnAsError
+   
+   local tArgs, tArgIndex
+   repeat with tArgIndex = 1 to $# - 1
+      put value("$" & tArgIndex) into tArgs[tArgIndex]
+   end repeat
+   
+   local tPlatforms, tStage, tEdition, tBuild
+   put empty into tPlatforms
+   put "tools" into tStage
+   put "community" into tEdition
+   put "stable" into tBuild
+   
+   local tEngineDir, tOutputDir, tWorkDir
+   
+   put 1 into tArgIndex
+   repeat while tArgIndex is among the keys of tArgs
+      if tArgs[tArgIndex] is "--platform" then
+         get tArgs[tArgIndex + 1]
+         if it is not among the items of "windows,win,macosx,mac,linux" then
+            __builderLog "error", "Unknown platform '" & tArgs[tArgIndex + 1] & "'"
+         end if
+         if it is "win" then get "windows"
+         if it is "mac" then get "macosx"
+         put true into tPlatforms[it]
+         add 1 to tArgIndex
+      else if tArgs[tArgIndex] is "--stage" then
+         if tArgs[tArgIndex + 1] is not among the items of "environment,tools,server,notes,docs" then
+            __builderLog "error", "Unknown stage '" & tArgs[tArgIndex + 1] & "'"
+         end if
+         put tArgs[tArgIndex + 1] into tStage
+         add 1 to tArgIndex
+      else if tArgs[tArgIndex] is "--edition" then
+         if tArgs[tArgIndex + 1] is not among the items of "community,commercial" then
+            __builderLog "error", "Unknown edition '" & tArgs[tArgIndex + 1] & "'"
+         end if
+         put tArgs[tArgIndex + 1] into tEdition
+         add 1 to tArgIndex
+      else if tArgs[tArgIndex] is "--build" then
+         if tArgs[tArgIndex + 1] is not among the items of "stable,maintenance,development,beta" then
+            __builderLog "error", "Unknown build '" & tArgs[tArgIndex + 1] & "'"
+         end if
+         put tArgs[tArgIndex + 1] into tBuild
+         add 1 to tArgIndex
+      else if tArgs[tArgIndex] is "--engine-dir" then
+         if tArgs[tArgIndex + 1] is empty then
+            __builderLog "error", "No path specified for --engine-dir argument"
+         end if
+         put tArgs[tArgIndex + 1] into tEngineDir
+         add 1 to tArgIndex
+      else if tArgs[tArgIndex] is "--output-dir" then
+         if tArgs[tArgIndex + 1] is empty then
+            __builderLog "error", "No path specified for --output-dir argument"
+         end if
+         put tArgs[tArgIndex + 1] into tOutputDir
+         add 1 to tArgIndex
+      else if tArgs[tArgIndex] is "--work-dir" then
+         if tArgs[tArgIndex + 1] is empty then
+            __builderLog "error", "No path specified for --work-dir argument"
+         end if
+         put tArgs[tArgIndex + 1] into tWorkDir
+         add 1 to tArgIndex
+      else if tArgs[tArgIndex] is "--warn-as-error" then
+         put true into sWarnAsError
+      end if
+      add 1 to tArgIndex
+   end repeat
+   
+   if the keys of tPlatforms is empty and tStage is "tools" then
+      __builderLog "error", "No platforms specified"
+   end if
+   
+   if tStage is "environment" then
+      put empty into tPlatforms
+      put true into tPlatforms["environment"]
+      put "engine" into tStage
+   end if
+   
+   set the name of this stack to "Builder"
+   
+   if tEngineDir is not empty then
+      builderSetEngineDir tEngineDir
+   end if
+   
+   builderBuild tStage, the keys of tPlatforms, tEdition, tBuild
+   
+   quit 0
+end startup
+
+command __loadExternal pExternal
+   set the itemdelimiter to slash
+   
+   set the externals of the templateStack to item 1 to -4 of specialFolderPath("engine") & slash & pExternal & ".bundle"
+   create stack pExternal && "External"
+   start using it
+   if the externalCommands of it is empty then
+      __builderLog "error", "Cannot load external" && pExternal
+   end if
+end __loadExternal 
+
+command __builderLog pType, pMessage
+   local tLine
+   
+   put toUpper(char 1 of pType) into char 1 of pType
+   
+   repeat for each line tLine in pMessage
+      write ("[" && the internet date && "]" && ":" && pType && ":" && tLine & return) to stderr
+   end repeat
+   if pType is "warning" and sWarnAsError or \
+         pType is "error" then
+      quit 1
+   end if
+end __builderLog
+
+on errorDialog pBacktrace
+   write pBacktrace & return to stderr
+   quit 1
+end errorDialog

--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,5 +1,7 @@
 ﻿script "BuilderUtilities"
 local sEngineDir
+local sWorkDir
+local sOutputDir
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -22,6 +24,14 @@ end builderFinalize
 command builderSetEngineDir pDir
    put pDir into sEngineDir
 end builderSetEngineDir
+
+command builderSetWorkDir pDir
+   put pDir into sWorkDir
+end builderSetWorkDir
+
+command builderSetOutputDir pDir
+   put pDir into sOutputDir
+end builderSetOutputDir
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -60,6 +70,8 @@ on builderBuild pWhich, pPlatforms, pEdition, pType
       case "Docs"
          dispatch "docsBuilderRun" to stack builderDocsBuilderStack() with pEdition, tVersion
          break
+      case "Disk"
+         dispatch "toolsBuilderRunDisk" to stack builderToolsBuilderStack() with tPlatform, pEdition, tVersion
       case "Archive"
          local tBuildNumber
          put builderGetBuildNumber() into tBuildNumber
@@ -183,11 +195,17 @@ end builderSystemFolder
 
 -- Returns the folder where intermediate products should be placed
 function builderWorkFolder
+   if sWorkDir is not empty then
+      return sWorkDir
+   end if
    return builderRepoFolder() & slash & "_build/final/work"
 end builderWorkFolder
 
 -- Returns the folder where output products should be placed
 function builderOutputFolder
+   if sOutputDir is not empty then
+      return sOutputDir
+   end if
    return builderRepoFolder() & slash & "_build/final/output"
 end builderOutputFolder
 

--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -71,7 +71,10 @@ on builderBuild pWhich, pPlatforms, pEdition, pType
          dispatch "docsBuilderRun" to stack builderDocsBuilderStack() with pEdition, tVersion
          break
       case "Disk"
-         dispatch "toolsBuilderRunDisk" to stack builderToolsBuilderStack() with tPlatform, pEdition, tVersion
+         repeat for each line tPlatform in pPlatforms
+            dispatch "toolsBuilderRunDisk" to stack builderToolsBuilderStack() with tPlatform, pEdition, tVersion
+         end repeat
+         break
       case "Archive"
          local tBuildNumber
          put builderGetBuildNumber() into tBuildNumber
@@ -200,6 +203,11 @@ function builderWorkFolder
    end if
    return builderRepoFolder() & slash & "_build/final/work"
 end builderWorkFolder
+
+-- Returns the folder where input products are placed
+function builderInputFolder
+   return sEngineDir
+end builderInputFolder
 
 -- Returns the folder where output products should be placed
 function builderOutputFolder

--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,9 +1,11 @@
 ﻿script "BuilderUtilities"
+local sEngineDir
+
 ////////////////////////////////////////////////////////////////////////////////
 
 command builderLog  pType, pMessage
    if there is a stack "Builder" then
-      send "__builderLog pType, pMessage" to stack "Builder"
+      dispatch "__builderLog" to stack "Builder" with  pType, pMessage
    end if
 end builderLog
 
@@ -16,6 +18,10 @@ end builderInitialize
 command builderFinalize
    stop using stack (builderSystemFolder() & slash & "package_compiler.livecodescript")
 end builderFinalize
+
+command builderSetEngineDir pDir
+   put pDir into sEngineDir
+end builderSetEngineDir
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -65,6 +71,28 @@ on builderBuild pWhich, pPlatforms, pEdition, pType
 end builderBuild
 
 command builderFetchEngine pVersion, pPlatform
+   if sEngineDir is not empty then
+      switch pPlatform
+         case "windows"
+            return sEngineDir & slash & "build-win-x86.zip/build-win-x86/Release"
+         case "linux"
+            return sEngineDir & slash & "build-linux-x86.zip/build-linux-x86/out/Release"
+         case "linux-x64"
+            return sEngineDir & slash & "build-linux-x64.zip/build-linux-x64/out/Release"
+         case "linux-armv6hf"
+            return sEngineDir & slash & "build-linux-armv6hf.zip/build-linux-armv6hf/out/Release"
+         case "macosx"
+            return sEngineDir & slash & "build-mac-all.zip/build-mac-all/_build/mac/Release"
+         case "ios"
+            return sEngineDir & slash & "build-ios-all.zip/build-ios-all/_build/ios"
+         case "android"
+            return sEngineDir & slash & "build-android-armv6.zip/build-android-armv6/out/Release"
+         default
+            write the executionContexts to stderr
+            builderLog "error", "Unknown platform '" & pPlatform & "'"
+      end switch
+      return empty
+   end if
    local tPlatform
    switch pPlatform
       case "windows"
@@ -137,10 +165,15 @@ function builderRepoFolder
    return item 1 to -3 of the filename of me
 end builderRepoFolder
 
-function builderIDEFolder
-   set the itemDelimiter to slash
-   return (item 1 to -3 of the filename of me & slash & "ide")
-end builderIDEFolder
+-- Returns the folder of the private repository
+function builderPrivateRepoFolder
+   return builderRepoFolder() & slash & ".." & slash & "livecode-commercial"
+end builderPrivateRepoFolder
+
+-- Returns the folder of the IDE repository
+function builderIdeRepoFolder
+   return builderRepoFolder() & slash & "ide"
+end builderIdeRepoFolder
 
 -- Returns the folder of the builder system
 function builderSystemFolder
@@ -148,14 +181,23 @@ function builderSystemFolder
    return item 1 to -2 of the filename of me
 end builderSystemFolder
 
+-- Returns the folder where intermediate products should be placed
+function builderWorkFolder
+   return builderRepoFolder() & slash & "_build/final/work"
+end builderWorkFolder
+
+-- Returns the folder where output products should be placed
+function builderOutputFolder
+   return builderRepoFolder() & slash & "_build/final/output"
+end builderOutputFolder
+
 -- Returns the folder where all the work should be done
 function builderWorkspaceFolder
    return builderRepoFolder() & slash & "_build/final"
-   --return specialFolderPath("Desktop") & slash & "BuilderWorkspace"
 end builderWorkspaceFolder
 
 function builderIDEFolder
-   return builderRepoFolder() & slash & "ide"
+   return builderIdeRepoFolder()
 end builderIDEFolder
 
 function builderIDEDocsFolder
@@ -230,7 +272,6 @@ end builderModuleInterfaceFolder
 -- Returns the engine that should be used to build the installer
 function builderInstallerEngine pPlatform
    local tEngineFolder
-   --put builderWorkspaceFolder() & slash & "engine" & slash & pPlatform & "-" & item 1 of field "Version" of card 1 of me into tEngineFolder
    builderFetchEngine empty, pPlatform
    put the result into tEngineFolder
    
@@ -238,15 +279,25 @@ function builderInstallerEngine pPlatform
       case "windows"
          return tEngineFolder & slash & "installer.exe"
       case "linux"
-         return tEngineFolder & slash & "i386/release/installer"
+         return tEngineFolder & slash & "installer"
       case "linux-x64"
-         return tEngineFolder & slash & "x86_64/release/installer"
+         return tEngineFolder & slash & "installer"
       case "linux-armv6hf"
-         return tEngineFolder & slash & "armv6-hf/release/installer"
+         return tEngineFolder & slash & "installer"
       case "macosx"
          return tEngineFolder & slash & "installer.app"
    end switch
 end builderInstallerEngine
+
+function builderMakeTemporaryFile pTempFolder, pTag
+   local tIndex
+   put 1 into tIndex
+   repeat while there is a file (pTempFolder & slash & pTag & "-" & tIndex)
+      add 1 to tIndex
+   end repeat
+   
+   return pTempFolder & slash & pTag & "-" & tIndex
+end builderMakeTemporaryFile
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -33,6 +33,8 @@ command docsBuilderRun pEdition, pVersion
    put docsBuilderGetSourceDirectory() into tSourceDir
    put docsBuilderGetOutputDirectory() & "/packaged_xml" into tOutputDir
    
+   start using stack (builderIdeRepoFolder() & slash & "Toolset/palettes/revdocumentationlibrary.rev")
+   
    builderLog "report", "Building docs into" && tOutputDir
    buildDocumentation tSourceDir & "/dictionary", tSourceDir & "/glossary", tOutputDir & "/dictionary", tOutputDir & "/glossary", tOutputDir, "docsBuilderProgressUpdate", the long id of me
    builderLog "report", "Building docs into" && tOutputDir && "complete"   
@@ -2058,3 +2060,45 @@ command docsBuilderGenerateDistributedAPI
    
    put textEncode(tJSON, "utf-8") into url ("binfile:" & builderAPIFolder() & slash & "distributed_api.js")
 end docsBuilderGenerateDistributedAPI
+
+--- LEGACY
+
+function revDocumentationRetrieve pType, pTag, pFolder
+   -- We know how many files per clump cuz of kFilesPerClump
+   -- pType is either "dictionary/" or "glossary/"
+   local tClumpNumber, tFileNumber, tPropNumber, tPropName
+   local tClumpName, tDocData, tClumpPath, tType, tOpenClumps
+   ---------
+   
+   put pType into tType
+   if the last char of tType is not slash then put slash after tType
+   
+   if pFolder is empty then
+      put revEnvironmentDocumentationPath() & slash & "packaged_xml/" & tType into tClumpPath
+   else
+      put pFolder & slash & "packaged_xml/" & tType into tClumpPath
+   end if
+   
+   set the itemDelimiter to "."
+   put item 1 of pTag into tFileNumber
+   if tFileNumber is not a number then
+      return empty
+   end if
+   put ((tFileNumber - 1) div kFilesPerClump) + 1 into tClumpNumber
+   put ((tFileNumber - 1) mod kFilesPerClump) + 1 into tPropNumber
+   
+   put "c" & tPropNumber into tPropName
+   put the mainStacks into tOpenClumps
+   filter tOpenClumps with kClumpNamePrefix & "*"
+   
+   put kClumpNamePrefix & tClumpNumber into tClumpName
+   
+   put the tPropName of stack (tClumpPath & tClumpName & ".rev") into tDocData
+   if tDocData is empty then
+      return empty
+   end if
+   
+   -- We've got the doc's compressed data, uncompress and return
+   return the decompress of tDocData
+end revDocumentationRetrieve
+

--- a/builder/package_compiler.livecodescript
+++ b/builder/package_compiler.livecodescript
@@ -1239,6 +1239,11 @@ private function compilerProcessText @self, pText
 end compilerProcessText
 
 private function compilerProcessSlim @self, pInputFile, pTargetArchs
+   -- No need to slim or strip inputs any more.
+   if true then
+      return pInputFile
+   end if
+   
    local tDerivedFile
    put compilerMakeTemporaryFile(self, "slim")  into tDerivedFile
    

--- a/builder/package_compiler.livecodescript
+++ b/builder/package_compiler.livecodescript
@@ -1,6 +1,8 @@
 ﻿script "PackageCompiler"
 ################################################################################
 
+local sCurrentTempFolder
+
 -- Create a new compiler object, represented as an array
 command packageCompilerCreate @rCompiler
    put empty into rCompiler
@@ -28,7 +30,27 @@ end packageCompilerConfigure
 -- source, then any files present in the base source that are used from the new source will be
 -- derived via bsdiff.
 command packageCompilerConfigureSource @self, pTag, pFolder, pBasedOn
+   abstractCanonicalize pFolder
+   
    put pFolder into self["sources"][pTag]
+   
+   -- If the folder doesn't exist, but a prefix of the folder path is a file
+   -- then register that prefix as abstract.
+   if there is no folder pFolder then
+      set the itemDelimiter to slash
+      repeat with i = the number of items in pFolder - 1 down to 2
+         if there is a file (item 1 to i of pFolder) then
+            abstractAddPath item 1 to i of pFolder
+            exit repeat
+         end if
+      end repeat
+      set the itemDelimiter to comma
+   end if
+   
+   if pBasedOn is not empty then
+      throw "not implemented"
+   end if
+   
    if pBasedOn is not pTag then
       put pBasedOn into self["base_sources"][pTag]
    end if
@@ -85,6 +107,7 @@ command packageCompilerBuild @self, pInstaller, pOutput
    put self["default context"] into self["context"]
    put pOutput into self["output"]
    try
+      put self["options"]["temporary"] into sCurrentTempFolder
       compilerRun self, pInstaller
    catch tException
    end try
@@ -117,7 +140,7 @@ command packageCompilerBuild @self, pInstaller, pOutput
    set the itemDelimiter to  tab
    repeat for each line tLine in self["manifest"]
       if item 1 of tLine is among the words of "file executable" and \
-             item 4 of tLine is not empty then
+            item 4 of tLine is not empty then
          if not tUsedFiles[item 4 of tLine] then
             delete item 4 of tLine
          end if
@@ -180,7 +203,7 @@ command packageCompilerBuild @self, pInstaller, pOutput
          put compilerMakeTemporaryFile(self, "diff") into tDerivedFile
          put tDerivedFile & return after tTmpFiles
          compilerProgress self, "Diffing '" & tItemFiles[tBaseItem] &"' and '" & tItemFiles[tItem] & "'"
-         _internal bsdiff tItemFiles[tBaseItem] to tItemFiles[tItem] into tDerivedFile
+         _internal bsdiff abstractPinFile(tItemFiles[tBaseItem]) to abstractPinFile(tItemFiles[tItem]) into tDerivedFile
          archiveAddItemWithFile tArchive, self["files"][tItem], tDerivedFile
       end if
    end repeat
@@ -199,9 +222,11 @@ command packageCompilerBuild @self, pInstaller, pOutput
    end if
    
    -- Remove any temporary files generated in the above process
-   repeat for each line tFile in tTmpFiles
-      delete file tFile
-   end repeat
+   if self["options"]["temporary"] is empty then
+      repeat for each line tFile in tTmpFiles
+         delete file tFile
+      end repeat
+   end if
    
    -- Return the error, if any
    return tError
@@ -735,30 +760,27 @@ private command compilerExecuteCopy @self, pCommand
    -- case of a file will be one item long, but in the case of the bundle
    -- will be determined by its manifest file.
    local tItemManifest
-   if there is a folder tSourcePath then
+   if abstractThereIsAFolder(tSourcePath) then
       if pCommand["class"] is not among the items of "folder,executable,rfolder" then
          compilerBuildWarning self, "Item '" & tSourcePath & "' is a folder, but not of executable or folder type", pCommand["line"]
          exit compilerExecuteCopy
-      end if
-      if pCommand["class"] is among the items "executable,rfolder" then
-         compilerProgress self, "Creating manifest for item '" & tSourcePath & "'"
-         put createManifest(tSourcePath) into URL ("file:" & tSourcePath & slash & "Manifest")
-         --compilerBuildWarning self, "Item '" & tSourcePath & "' is referenced as a bundle but has no manifest", pCommand["line"]
-         --exit compilerExecuteCopy
       end if
       
       -- Simply take the manifest file from within the bundle (one assumes
       -- this will be automagically processed so shouldn't be any problems).
       -- The expected syntax is:
       --    <class>,/<relativefile>
-      --
-      if there is a file (tSourcePath & slash & "Manifest") then
+      -- (If rfolder then we generate one)
+      if pCommand["class"] is among the items "executable,rfolder" then
+         compilerProgress self, "Creating manifest for item '" & tSourcePath & "'"
+         put createManifest(tSourcePath) into tItemManifest
+      else if abstractThereIsAFile(tSourcePath & slash & "Manifest") then
          put url ("file:" & tSourcePath & slash & "Manifest") into tItemManifest
       else
          put pCommand["class"], empty into tItemManifest
       end if
    else
-      if there is no file tSourcePath then
+      if not abstractThereIsAFile(tSourcePath) then
          compilerBuildWarning self, "Item '" & tSourcePath & "' could not be found", pCommand["line"]
          exit compilerExecuteCopy
       end if
@@ -785,7 +807,7 @@ private command compilerExecuteCopy @self, pCommand
          put tBaseSourcePath & item 2 of tItem into tBaseItemSourcePath
       end if
       
-      if tItemClass is not "folder" and there is no file tItemSourcePath then
+      if tItemClass is not "folder" and not abstractThereIsAFile(tItemSourcePath) then
          compilerBuildWarning self, "Bundle item '" & tItemSourcePath & "' could not be found", pCommand["line"]
       end if
       
@@ -794,7 +816,7 @@ private command compilerExecuteCopy @self, pCommand
       switch tItemClass
          case "executable"
             local tExeType
-            put sniffExecutable(tItemSourcePath) into tExeType
+            put sniffExecutable(abstractPinFile(tItemSourcePath)) into tExeType
             if tExeType is "macosx" and tSourceType is not "ios" then
                get self["context"]["TargetArchitectures"]
                sort items of it ascending
@@ -997,37 +1019,37 @@ private command compilerExecuteRegister @self, pCommand
    -- registry values are escaped:
    --   \q -> "
    --   \\ -> \
-   if pCommand["value"] is not empty then
-      put compilerEvaluate(self, pCommand["value"], pCommand["line"]) into tValue
-      replace "\q" with quote in tValue
-      replace "\\" with "\" in tValue
+         if pCommand["value"] is not empty then
+   put compilerEvaluate(self, pCommand["value"], pCommand["line"]) into tValue
+   replace "\q" with quote in tValue
+   replace "\\" with "\" in tValue
+end if
+
+local tRoot
+put compilerEvaluateOptVar(self, "RegistryRoot") into tRoot
+if pCommand["class"] is "key" then
+   -- If the 'RegistryRoot' var is not empty, then we prefix the target key with that
+   if tRoot is not empty then
+      if tTarget is not empty then
+         put slash before tTarget
+      end if
+      put tRoot before tTarget
    end if
-   
-   local tRoot
-   put compilerEvaluateOptVar(self, "RegistryRoot") into tRoot
-   if pCommand["class"] is "key" then
-      -- If the 'RegistryRoot' var is not empty, then we prefix the target key with that
-      if tRoot is not empty then
-         if tTarget is not empty then
-            put slash before tTarget
-         end if
-         put tRoot before tTarget
-      end if
-      put "registry key" & tab & tTarget & tab & tValue & tab & pCommand["value_type"] & return after self["manifest"]
-   else
-      -- In this case we have a 'parent' key
-      local tParent
-      if pCommand["parent"] is not empty then
-         put compilerEvaluate(self, pCommand["parent"], pCommand["line"]) into tParent
-      end if
-      if tRoot is not empty then
-         if tParent is not empty then
-            put slash before tParent
-         end if
-         put tRoot before tParent
-      end if
-      put "registry value" & tab & tParent & "//" & tTarget & tab & tValue & tab & pCommand["value_type"] & return after self["manifest"]
+   put "registry key" & tab & tTarget & tab & tValue & tab & pCommand["value_type"] & return after self["manifest"]
+else
+   -- In this case we have a 'parent' key
+   local tParent
+   if pCommand["parent"] is not empty then
+      put compilerEvaluate(self, pCommand["parent"], pCommand["line"]) into tParent
    end if
+   if tRoot is not empty then
+      if tParent is not empty then
+         put slash before tParent
+      end if
+      put tRoot before tParent
+   end if
+   put "registry value" & tab & tParent & "//" & tTarget & tab & tValue & tab & pCommand["value_type"] & return after self["manifest"]
+end if
 end compilerExecuteRegister
 
 private command compilerExecuteRename @self, pCommand
@@ -1059,7 +1081,7 @@ private command compilerExecuteDesktop @self, pCommand
    -- Compute the source path, and if it doesn't exist append a warning
    local tSourcePath
    put self["sources"][tSourceType] & slash & tSourceFile into tSourcePath
-   if there is no file tSourcePath then
+   if not abstractThereIsAFile(tSourcePath) then
       compilerBuildWarning self, "Item '" & tSourcePath & "' could not be found", pCommand["line"]
       exit compilerExecuteDesktop
    end if
@@ -1073,7 +1095,7 @@ private command compilerExecuteDesktop @self, pCommand
       
       -- And process the data
       local tData
-      repeat for each line tLine in url ("file:" & tSourcePath)
+      repeat for each line tLine in abstractContentsOfTextFile(tSourcePath)
          put compilerEvaluate(self, tLine, pCommand["line"]) & return after tData
       end repeat
       delete the last char of tData
@@ -1117,7 +1139,7 @@ private function compilerEvaluateOptVar @self, pVar, pLineNumber
    end if
    return self["context"][pVar]
 end compilerEvaluateOptVar
-   
+
 ################################################################################
 
 -- Normalization analyses the list of actions ensuring that folder creation actions are added as
@@ -1183,7 +1205,7 @@ private function compilerProcessItem @self, pProcess, pFile
    
    if pProcess is "text" then
       put compilerMakeTemporaryFile(self, pProcess) into tDerivedFile
-      put compilerProcessText(self, url ("binfile:" & pFile)) into url ("binfile:" & tDerivedFile)
+      put compilerProcessText(self, abstractContentsOfBinaryFile(pFile)) into url ("binfile:" & tDerivedFile)
    else if pProcess is "sign" then
       put compilerProcessSign(self, pFile) into tDerivedFile
    else if pProcess begins with "slim-" then
@@ -1222,7 +1244,7 @@ private function compilerProcessSlim @self, pInputFile, pTargetArchs
    
    -- Use the 'diet' internal command to perform the appropriate lipo/strip operation
    local tDietParams
-   put pInputFile into tDietParams["input"]
+   put abstractPinFile(pInputFile) into tDietParams["input"]
    put tDerivedFile into tDietParams["output"]
    
    -- Note that we use 'i386' in the arch's list here, but the diet command uses 'x86'
@@ -1236,7 +1258,7 @@ private function compilerProcessSlim @self, pInputFile, pTargetArchs
    -- Now run the diet command
    compilerProgress self, "Stripping/dieting '" & pInputFile & "' to" && pTargetArchs
    --_internal diet macosx tDietParams
-   dietAndStrip pTargetArchs, pInputFile, tDerivedFile
+   dietAndStrip pTargetArchs, tDietParams["input"], tDietParams["output"]
    
    if the result is "no architectures left" then
       compilerBuildWarning self, "Executable '" & pInputFile & "' does not contain requested architecture(s) " & pTargetArchs
@@ -1253,7 +1275,7 @@ end compilerProcessSlim
 
 private function compilerProcessSign @self, pFile
    local tSignParams
-   put pFile into tSignParams["input"]
+   put abstractPinFile(pFile) into tSignParams["input"]
    put compilerMakeTemporaryFile(self, "sign") into tSignParams["output"]
    put self["options"]["sign.certificate"] into tSignParams["certificate"]
    put self["options"]["sign.privatekey"] into tSignParams["privatekey"]
@@ -1344,12 +1366,259 @@ private command archiveAddItemWithFile @self, pItemName, pFile
    end if
    
    if self["type"] is "zip" then
-      revZipAddItemWithFile self["output"], pItemName, pFile
+      if abstractFileIsPinned(pFile) then
+         revZipAddItemWithFile self["output"], pItemName, abstractPinFile(pFile)
+      else
+         local tData
+         put abstractContentsOfBinaryFile(pFile) into tData
+         revZipAddItemWithData self["output"], pItemName, "tData"
+      end if
       if the result is not empty then
          put "on add item '" & pItemName & "' with file '" & pFile & "':" && item 2 to -1 of the result into self["error"]
       end if
    end if
 end archiveAddItemWithFile
+
+################################################################################
+
+local sAbstractFolders
+local sAbstractPathCache
+
+private command abstractAddPath pAbstractPath
+   put "closed" into sAbstractFolders[pAbstractPath]["state"]
+end abstractAddPath
+
+private command abstractEnsureFolderIsReady pFolder
+   if sAbstractFolders[pFolder]["state"] is "open" then
+      exit abstractEnsureFolderIsReady
+   end if
+   
+   revZipOpenArchive pFolder, "read"
+   if the result is not empty then
+      throw ",Cannot open source zip '" & pFolder & "'"
+   end if
+   
+   put "open" into sAbstractFolders[pFolder]["state"]
+   
+   set the itemDelimiter to slash
+   
+   repeat for each line tItem in revZipEnumerateItems(pFolder)
+      put "file" into sAbstractFolders[pFolder]["items"][tItem]["type"]
+      repeat with i = 1 to the number of items in tItem - 1
+         put "folder" into sAbstractFolders[pFolder]["items"][item 1 to i of tItem]["type"]
+      end repeat
+   end repeat
+end abstractEnsureFolderIsReady
+
+private function abstractPathIsRegular pPath
+   -- If we've computed this before then use the cached result
+   if pPath is among the keys of sAbstractPathCache then
+      return sAbstractPathCache[pPath]["is_regular"]
+   end if
+   
+   -- If the path is prefixed by <folder>/ for an abstract folder
+   -- then it is not regular.
+   -- If the path is one of the abstract folders then it is not
+   -- regular.
+   local tIsRegular, tAbstractFolder
+   put true into tIsRegular
+   repeat for each key tAbstractFolder in sAbstractFolders
+      if pPath begins with (tAbstractFolder & slash) or \
+            pPath is tAbstractFolder then
+         put false into tIsRegular
+         exit repeat
+      end if
+   end repeat
+   
+   -- Cache the result
+   put tIsRegular into sAbstractPathCache[pPath]["is_regular"]
+   if not tIsRegular then
+      put tAbstractFolder into sAbstractPathCache[pPath]["branch"]
+      put char (the length of tAbstractFolder + 2) to -1 of pPath into sAbstractPathCache[pPath]["leaf"]
+      
+      -- Ensure the abstract folder is open
+      abstractEnsureFolderIsReady tAbstractFolder
+   end if
+   
+   return tIsRegular
+end abstractPathIsRegular
+
+private command abstractPathDecompose pFile, @rBranch, @rLeaf
+   put sAbstractPathCache[pFile]["branch"] into rBranch
+   put sAbstractPathCache[pFile]["leaf"] into rLeaf
+end abstractPathDecompose
+
+private function abstractThereIsAFile pFile
+   abstractCanonicalize pFile
+   
+   if abstractPathIsRegular(pFile) then
+      return there is a file pFile
+   end if
+   
+   local tBranch, tLeaf
+   abstractPathDecompose pFile, tBranch, tLeaf
+   
+   return sAbstractFolders[tBranch]["items"][tLeaf]["type"] is "file"
+end abstractThereIsAFile
+
+private function abstractThereIsAFolder pFolder
+   abstractCanonicalize pFolder
+   
+   if abstractPathIsRegular(pFolder) then
+      return there is a folder pFolder
+   end if
+   
+   local tBranch, tLeaf
+   abstractPathDecompose pFolder, tBranch, tLeaf
+   
+   return sAbstractFolders[tBranch]["items"][tLeaf]["type"] is "folder"
+end abstractThereIsAFolder
+
+private function abstractContentsOfTextFile pFile
+   abstractCanonicalize pFile
+   
+   if abstractPathIsRegular(pFile) then
+      return url ("file:" & pFile)
+   end if
+   
+   get abstractContentsOfBinaryFile(pFile)
+   replace numToChar(13) & numToChar(10) with numToChar(10) in it
+   replace numToChar(13) with numToChar(10) in it
+   
+   return it
+end abstractContentsOfTextFile
+
+private function abstractContentsOfBinaryFile pFile
+   abstractCanonicalize pFile
+   
+   if abstractPathIsRegular(pFile) then
+      return url ("binfile:" & pFile)
+   end if
+   
+   local tBranch, tLeaf
+   abstractPathDecompose pFile, tBranch, tLeaf
+   
+   local tData
+   if not sAbstractFolders[tBranch]["items"][tLeaf]["has_data"] then
+      if not sAbstractFolders[tBranch]["items"][tLeaf]["has_pin"] then
+         revZipExtractItemToVariable tBranch, tLeaf, "tData"
+         if the result is not empty then
+            throw "Could not extract item '" & tLeaf & "' from archive '" & tBranch & "'"
+         end if
+      else
+         put url ("binfile:" & sAbstractFolders[tBranch]["items"][tLeaf]["pin"]) into tData
+         if the result is not empty then
+            throw "Could read data for item '" & tLeaf & "' from archive '" & tBranch & "'"
+         end if
+      end if
+      
+      put true into sAbstractFolders[tBranch]["items"][tLeaf]["has_data"]
+      put tData into sAbstractFolders[tBranch]["items"][tLeaf]["data"]
+   else
+      put sAbstractFolders[tBranch]["items"][tLeaf]["data"] into tData
+   end if
+   
+   return tData
+end abstractContentsOfBinaryFile
+
+function abstractPinFile pFile
+   abstractCanonicalize pFile
+   
+   if abstractPathIsRegular(pFile) then
+      return pFile
+   end if
+   
+   local tBranch, tLeaf
+   abstractPathDecompose pFile, tBranch, tLeaf
+   
+   local tPinnedFile
+   if not sAbstractFolders[tBranch]["items"][tLeaf]["has_pin"] then
+      put builderMakeTemporaryFile(sCurrentTempFolder, "pin") into tPinnedFile
+      if not sAbstractFolders[tBranch]["items"][tLeaf]["has_data"] then
+         revZipExtractItemToFile tBranch, tLeaf, tPinnedFile
+         if the result is not empty then
+            throw "Could not extract item '" & tLeaf & "' from archive '" & tBranch & "'"
+         end if
+      else
+         put sAbstractFolders[tBranch]["items"][tLeaf]["data"] into url ("binfile:" & tPinnedFile)
+         if the result is not empty then
+            throw "Could write data for item '" & tLeaf & "' from archive '" & tBranch & "'"
+         end if
+      end if
+      
+      put true into sAbstractFolders[tBranch]["items"][tLeaf]["has_pin"]
+      put tPinnedFile into sAbstractFolders[tBranch]["items"][tLeaf]["pin"]
+   else
+      put sAbstractFolders[tBranch]["items"][tLeaf]["pin"] into tPinnedFile
+   end if
+   
+   return tPinnedFile
+end abstractPinFile
+
+private function abstractFileIsPinned pFile
+   abstractCanonicalize pFile
+   
+   if abstractPathIsRegular(pFile) then
+      return true
+   end if
+   
+   local tBranch, tLeaf
+   abstractPathDecompose pFile, tBranch, tLeaf
+   
+   return sAbstractFolders[tBranch]["items"][tLeaf]["has_pin"]
+end abstractFileIsPinned
+
+private function abstractTheItemsOf pPath, pType
+   abstractCanonicalize pPath
+   
+   if abstractPathIsRegular(pPath) then
+      local tOldFolder
+      put the folder into tOldFolder
+      set the folder to pPath
+      if pType is "folder" then
+         get the folders
+      else
+         get the files
+      end if
+      set the folder to tOldFolder
+      return it
+   end if
+   
+   local tBranch, tLeaf
+   abstractPathDecompose pPath, tBranch, tLeaf
+   
+   local tItem, tItems
+   set the itemDelimiter to slash
+   repeat for each key tItem in sAbstractFolders[tBranch]["items"]
+      if item 1 to -2 of tItem is not tLeaf then
+         next repeat
+      end if
+      if sAbstractFolders[tBranch]["items"][tItem]["type"] is not pType then
+         next repeat
+      end if
+      put item -1 of tItem & return after tItems
+   end repeat
+   delete the last char of tItems
+   
+   return tItems
+end abstractTheItemsOf
+
+private function abstractTheFoldersOf pPath
+   return abstractTheItemsOf(pPath, "folder")
+end abstractTheFoldersOf
+
+private function abstractTheFilesOf pPath
+   return abstractTheItemsOf(pPath, "file")
+end abstractTheFilesOf
+
+command abstractCanonicalize @xPath
+   if char 1 of xPath is not "/" and char 2 of xPath is not ":" then
+      put the folder & slash before xPath
+   end if
+   if the last char of xPath is "/" and xPath is not "/" then
+      delete the last char of xPath
+   end if
+end abstractCanonicalize
 
 ################################################################################
 
@@ -1374,14 +1643,11 @@ private command compilerDump @self
 end compilerDump
 
 private command compilerExecutionError @self, pError, pLine
-   if pLine is not empty then
-      throw "error, line" && pLine && ":" && pError
-   end if
-   throw "error:" && pError
+   throw pLine, pError
 end compilerExecutionError
 
 private command compilerSyntaxError @self, pError, pLine
-   throw "error, line" && pLine && ":" && pError
+   throw pLine, pError
 end compilerSyntaxError
 
 private command compilerBuildWarning @self, pError, pLine
@@ -1393,8 +1659,8 @@ private command compilerBuildWarning @self, pError, pLine
       put "warning:" && pError & return after self["warnings"]
    end if
    
-   if self["report.target"] is  not empty then
-      dispatch self["report.handler"] to self["report.target"] with "error", the last line of self["warnings"]
+   if self["report.target"] is not empty then
+      dispatch self["report.handler"] to self["report.target"] with "warning", pError, pLine
    end if
 end compilerBuildWarning
 
@@ -1450,13 +1716,9 @@ private function readBytesFromFile pPath, pCount
 end readBytesFromFile
 
 private function createManifest pBase, pPath, pPrefix
-   local tOldFolder
-   put the folder into tOldFolder
-   
    local tManifest, tFolders, tFiles   
-   set the folder to pBase & slash & pPath
-   put the folders into tFolders
-   put the files into tFiles
+   put abstractTheFoldersOf(pBase & slash & pPath) into tFolders
+   put abstractTheFilesOf(pBase & slash & pPath) into tFiles
    filter tFolders without ".*"
    filter tFiles without ".*"
    
@@ -1464,7 +1726,11 @@ private function createManifest pBase, pPath, pPrefix
       put "folder," & pPath into tManifest
    else
       repeat for each line tFolder in tFolders
-         get createManifest(pBase, pPath & slash & tFolder)
+         if pPath is empty then
+            get createManifest(pBase, tFolder)
+         else
+            get createManifest(pBase, pPath & slash & tFolder)
+         end if
          if it is not empty then
             if tManifest is not empty then
                put return after tManifest
@@ -1483,10 +1749,9 @@ private function createManifest pBase, pPath, pPrefix
             get "file"
          end if
          set the itemDel to comma
-         put it & comma & pPath & slash & tFile after tManifest
+         put it & comma & slash & pPath & slash & tFile after tManifest
       end repeat
    end if
    
-   set the folder to tOldFolder
    return tManifest
 end createManifest

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -397,19 +397,23 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
          end if
          
          -- Get us an installer by dieting the source installer
-         put abstractPinFile(builderInstallerEngine("macosx") & slash & "Contents/MacOS/installer") into tDietParams["input"]
-         put tTempFolder & slash & "macosx-installer-x86" into tDietParams["output"]
-         put true into tDietParams["keep_x86"]
-         put false into tDietParams["keep_ppc"]
-         builderLog "message", "Dieting input installer down to x86"
-         --_internal diet macosx tDietParams
-         dietAndStrip "x86", tDietParams["input"], tDietParams["output"]
-         if the result is not empty then
-            builderLog "error", "Dieting input installer to x86 failed -" && the result
-            throw "failure"
+         if false then
+            put abstractPinFile(builderInstallerEngine("macosx") & slash & "Contents/MacOS/installer") into tDietParams["input"]
+            put tTempFolder & slash & "macosx-installer-x86" into tDietParams["output"]
+            put true into tDietParams["keep_x86"]
+            put false into tDietParams["keep_ppc"]
+            builderLog "message", "Dieting input installer down to x86"
+            --_internal diet macosx tDietParams
+            dietAndStrip "x86", tDietParams["input"], tDietParams["output"]
+            if the result is not empty then
+               builderLog "error", "Dieting input installer to x86 failed -" && the result
+               throw "failure"
+            end if
+            
+            put tTempFolder & slash & "macosx-installer-x86" into tParams["engine_x86"]
          end if
          
-         put tTempFolder & slash & "macosx-installer-x86" into tParams["engine_x86"]
+         put abstractPinFile(builderInstallerEngine("macosx") & slash & "Contents/MacOS/installer") into tParams["engine_x86"]
          put tInstallerStackFile into tParams["stackfile"]
          put tOutputFileStub & ".app" & slash & "Contents/MacOS/installer" into tParams["output"]
          

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -42,9 +42,28 @@ command toolsBuilderRun pPlatform, pEdition, pVersion
    local tPrivateFolder
    put builderPrivateRepoFolder() into tPrivateFolder
    
-   -- Finally build an installer
+   -- Now build the installer
    toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, tIdeFolder, tPrivateFolder, tPackageFile
 end toolsBuilderRun
+
+command toolsBuilderRunDisk pPlatform, pEdition, pVersion
+   if pPlatform is not "macosx" then
+      exit toolsBuilderRunDisk
+   end if
+   
+   if the platform is not "macos" then
+      builderLog "error", "Cannot sign and build disk image for Mac on this platform"
+      exit toolsBuilderRunDisk
+   end if
+   
+   local tInputFolder
+   put builderInputFolder() into tInputFolder
+   
+   local tInputFile
+   put tInputFolder & slash & "installer-mac.zip" into tInputFile
+   
+   toolsBuilderMakeDisk pVersion, pEdition, pPlatform, tInputFile
+end toolsBuilderRunDisk
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -404,57 +423,73 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
          end if
          
          builderLog "report", "Deployed macosx installer to '" && tOutputFileStub & ".app" & "'"
-         
-         get shell("/usr/bin/security -q find-identity -v")
-         filter it with "*Developer ID Application: Runtime Revolution Ltd*"
-         if it is not empty then
-            builderLog "message", "Signing macosx installer'" && tOutputFileStub & ".app" & "'"
-            wait 1 second
-            get shell("/usr/bin/codesign -s" && word 2 of it && "'" & tOutputFileStub & ".app'")
-            if it is not empty then
-               builderLog "error", "Could not macosx sign installer:" && it
-               throw "failure"
-            end if
-            builderLog "report", "Successfully signed macosx installer'" && tOutputFileStub & ".app" & "'"
-         end if
-         
-         local tDmgFile, tDmgName, tDmgAppFolder
-         put tOutputFileStub & ".dmg" into tDmgFile
-         if pEdition is "Community" then
-            put "LiveCode Community" && getReadableVersion(pVersion) && "Installer" into tDmgName
-            put (tOutputFileFolder & slash & "Install LiveCode Community" && getReadableVersion(pVersion) & ".app") into tDmgAppFolder
-         else
-            put "LiveCode" && getReadableVersion(pVersion) && "Installer" into tDmgName
-            put (tOutputFileFolder & slash & "Install LiveCode" && getReadableVersion(pVersion) & ".app") into tDmgAppFolder
-         end if
-         builderLog "message", "Building Mac DMG to '" & tDmgFile & "'"
-         if there is a file tDmgFile then
-            delete file tDmgFile
-            if there is a file tDmgFile then
-               builderLog "error", "Could not remove existing dmg - make sure it is not mounted"
-               throw "failure"
-            end if
-         end if
-         
-         --local tTrashFile
-         --put builderWorkspaceFolder() & "/deploy/.Trash" into tTrashFile
-         --put empty into URL ("file:" & tTrashFile)
-         
-         -- Do the DMG build
-         rename (tOutputFileStub & ".app") to tDmgAppFolder
-         -- SN-2015-03-09: [[ DMG creation failure ]] Ensure that hdiutil will allocate enough
-         --  memory if the installer end up being over a gigabyte large.
-         get shell("hdiutil create -fs HFS+ -size 1G -volname" && quote & tDmgName & quote && "-srcfolder" && quote & tDmgAppFolder & quote && quote & tDmgFile & quote)
-         rename tDmgAppFolder to (tOutputFileStub & ".app")
-         if "created:" is not in it then
-            builderLog "error", "Dmg creation failed -" && the last line of it
-            throw "failure"
-         end if
-         
-         builderLog "report", "Deployed macosx dmg to '" & tDmgFile & "'"
          break
    end switch
 end toolsBuilderMakeInstaller
+
+command toolsBuilderMakeDisk pVersion, pEdition, pPlatform, tInputZip
+   -- Compute the output file
+   local tOutputFileStub, tOutputFileFolder
+   put builderOutputFolder() into tOutputFileFolder
+   put tOutputFileFolder & slash & getInstallerFilenameStub(pVersion, pPlatform, pEdition) into tOutputFileStub
+   builderEnsureFolderForFile tOutputFileStub
+   
+   -- Unzip the input zip
+   builderLog "message", "Unzipping macosx instaler to " && tOutputFileStub & ".app" & "'"
+   get shell("unzip -qq -o -d" && quote & tOutputFileFolder & quote && quote & tInputZip & quote)
+   if it is not empty then
+      builderLog "error", "Could not extract macosx app from zip:" && it
+      throw "failure"
+   end if
+   
+   get shell("/usr/bin/security -q find-identity -v")
+   filter it with "*Developer ID Application: Runtime Revolution Ltd*"
+   if it is not empty then
+      builderLog "message", "Signing macosx installer'" && tOutputFileStub & ".app" & "'"
+      wait 1 second
+      get shell("/usr/bin/codesign -s" && word 2 of it && "'" & tOutputFileStub & ".app'")
+      if it is not empty then
+         builderLog "error", "Could not macosx sign installer:" && it
+         throw "failure"
+      end if
+      builderLog "report", "Successfully signed macosx installer'" && tOutputFileStub & ".app" & "'"
+   end if
+   
+   local tDmgFile, tDmgName, tDmgAppFolder
+   put tOutputFileStub & ".dmg" into tDmgFile
+   if pEdition is "Community" then
+      put "LiveCode Community" && getReadableVersion(pVersion) && "Installer" into tDmgName
+      put (tOutputFileFolder & slash & "Install LiveCode Community" && getReadableVersion(pVersion) & ".app") into tDmgAppFolder
+   else
+      put "LiveCode" && getReadableVersion(pVersion) && "Installer" into tDmgName
+      put (tOutputFileFolder & slash & "Install LiveCode" && getReadableVersion(pVersion) & ".app") into tDmgAppFolder
+   end if
+   builderLog "message", "Building Mac DMG to '" & tDmgFile & "'"
+   if there is a file tDmgFile then
+      delete file tDmgFile
+      if there is a file tDmgFile then
+         builderLog "error", "Could not remove existing dmg - make sure it is not mounted"
+         throw "failure"
+      end if
+   end if
+   
+   --local tTrashFile
+   --put builderWorkspaceFolder() & "/deploy/.Trash" into tTrashFile
+   --put empty into URL ("file:" & tTrashFile)
+   
+   -- Do the DMG build
+   rename (tOutputFileStub & ".app") to tDmgAppFolder
+   -- SN-2015-03-09: [[ DMG creation failure ]] Ensure that hdiutil will allocate enough
+   --  memory if the installer end up being over a gigabyte large.
+   get shell("hdiutil create -fs HFS+ -size 1G -volname" && quote & tDmgName & quote && "-srcfolder" && quote & tDmgAppFolder & quote && quote & tDmgFile & quote)
+   rename tDmgAppFolder to (tOutputFileStub & ".app")
+   if "created:" is not in it then
+      builderLog "error", "Dmg creation failed -" && the last line of it
+      throw "failure"
+   end if
+   
+   builderLog "report", "Deployed macosx dmg to '" & tDmgFile & "'"
+end toolsBuilderMakeDisk
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -27,13 +27,11 @@ command toolsBuilderRun pPlatform, pEdition, pVersion
    
    -- Next make sure our IDE is up to date
    local tIdeFolder
-   toolsBuilderFetchIde pVersion
-   put the result into tIdeFolder
+   put builderIdeRepoFolder() into tIdeFolder
    
    -- Fetch the documentation
    local tDocsFolder
-   toolsBuilderFetchDocs  tIdeFolder
-   put the result into tDocsFolder
+   put builderBuiltDocsFolder() into tDocsFolder
    
    -- Now build the package
    local tPackageFile
@@ -42,23 +40,11 @@ command toolsBuilderRun pPlatform, pEdition, pVersion
    
    -- Compute the private folder
    local tPrivateFolder
-   put builderRepoFolder() & slash & ".." & slash & "livecode-commercial" into tPrivateFolder
+   put builderPrivateRepoFolder() into tPrivateFolder
    
    -- Finally build an installer
    toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, tIdeFolder, tPrivateFolder, tPackageFile
 end toolsBuilderRun
-
-////////////////////////////////////////////////////////////////////////////////
-
-private command toolsBuilderFetchIde pVersion
-   return builderIDEFolder()
-end toolsBuilderFetchIde
-
-////////////////////////////////////////////////////////////////////////////////
-
-private command toolsBuilderFetchDocs pIdeFolder
-   return builderBuiltDocsFolder()
-end toolsBuilderFetchDocs
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -68,23 +54,24 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    local tEditionType
    put pEdition into tEditionType
    
-   -- Remove any edition suffix from mac standalones
-   builderLog "report", "Removing edition suffixes from mac standalone '" & pEngineFolders["macosx"] & "/Standalone-" &  pEdition & ".app" & "'"
-   removeStandaloneEdiitonSuffix pEngineFolders["macosx"] & "/Standalone-" &  pEdition & ".app", pEdition
-   
    -- Compute the package temp folder
    local tTempFolder
-   put builderWorkspaceFolder() & "/temp/tools-" & pPlatform & "-" & pVersion into tTempFolder
+   put builderWorkFolder() & slash & "tools-" & pPlatform & "-" & pVersion & ".tmp" into tTempFolder
    builderEnsureFolder tTempFolder
    
    -- Compute the package output file
-   put builderWorkspaceFolder() & slash & "package/tools-" & pPlatform & "-" & pVersion & ".zip" into tPackageFile
+   put builderWorkFolder() & slash & "tools-" & pPlatform & "-" & pVersion & ".zip" into tPackageFile
    builderEnsureFolderForFile tPackageFile
+   
+   --return tPackageFile
    
    -- Configure the package compiler appropriately
    local tPackager
    packageCompilerCreate tPackager
    packageCompilerSetReportCallback tPackager, the long id of me, "toolsBuilderPackageReport"
+   
+   -- Setup the temporary dir
+   packageCompilerConfigure tPackager, "temporary", tTempFolder
    
    -- Configure the sources: ide, docs, macosx, windows, linux
    packageCompilerConfigureSource tPackager, "ide", pIdeFolder
@@ -92,13 +79,15 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    packageCompilerConfigureSource tPackager, "docs", pDocsFolder
    packageCompilerConfigureSource tPackager, "engine", pEngineFolders[pPlatform]
    packageCompilerConfigureSource tPackager, "macosx", pEngineFolders["macosx"]
-   packageCompilerConfigureSource tPackager, "linux", pEngineFolders["linux"]
+   packageCompilerConfigureSource tPackager, "linux-i386", pEngineFolders["linux"]
+   packageCompilerConfigureSource tPackager, "linux-x86_64", pEngineFolders["linux-x64"]
+   packageCompilerConfigureSource tPackager, "linux-armv6-hf", pEngineFolders["linux-armv6hf"]
    packageCompilerConfigureSource tPackager, "windows", pEngineFolders["windows"]
    packageCompilerConfigureSource tPackager, "ios", pEngineFolders["ios"]
    packageCompilerConfigureSource tPackager, "android", pEngineFolders["android"]
    packageCompilerConfigureSource tPackager, "prebuilt", builderRepoFolder() & slash & "prebuilt"
    if tEditionType is "Commercial" then
-      packageCompilerConfigureSource tPackager, "private", builderRepoFolder() & slash & ".." & slash & "livecode-commercial"
+      packageCompilerConfigureSource tPackager, "private", builderPrivateRepoFolder()
    end if
    
    -- Now set up variables used by the description: TargetFolder, SupportFolder, ToolsFolder, TargetPlatform, TargetEdition
@@ -118,7 +107,6 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    end if
    packageCompilerConfigureVariable tPackager, "TodaysDate", "[[todaysDate]]"
    packageCompilerConfigureVariable tPackager, "VersionTag", pVersion
-   --packageCompilerConfigureVariable tPackager, "TargetArchitectures", "i386,ppc"
    packageCompilerConfigureVariable tPackager, "TargetArchitectures", "i386"
    if pPlatform is "linux" then
       packageCompilerConfigureVariable tPackager, "TargetArchitecture", "i386"
@@ -159,9 +147,9 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    builderLog "message", "Parsing description file '" & tDescFile & "'"
    packageCompilerParse tPackager, url ("file:" & tDescFile)
    if the result is empty then
-      builderLog "report", "Parsed description file '" & tDescFile & "'"
+      toolsBuilderPackageReport "report", "Parsed description file '" & tDescFile & "'"
    else
-      builderLog "error", the result
+      toolsBuilderPackageReport "error", item 2 to -1 of the result, item 1 of the result
       put false into tSuccess
    end if
    
@@ -175,7 +163,7 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
       if the result is empty then
          builderLog "report", "Built package '" & tPackageFile & "'"
       else
-         builderLog "error", the result
+         toolsBuilderPackageReport "error", item 2 to -1 of the result, item 1 of the result
          put false into tSuccess
       end if
    end if
@@ -189,8 +177,11 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    return tPackageFile
 end toolsBuilderMakePackage
 
-on toolsBuilderPackageReport pType, pMessage
-   builderLog "message", pMessage
+on toolsBuilderPackageReport pType, pMessage, pLine
+   if pLine is not empty then
+      put "Line" && pLine && ":" && pMessage into pMessage
+   end if
+   builderLog pType, pMessage
 end toolsBuilderPackageReport
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -201,13 +192,13 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
    
    -- Compute the deploy temp folder
    local tTempFolder
-   put builderWorkspaceFolder() & "/temp/tools-" & pPlatform & "-" & pVersion into tTempFolder
+   put builderWorkFolder() & slash & "tools-" & pPlatform & "-" & pVersion & ".tmp" into tTempFolder
    builderEnsureFolder tTempFolder
    
    -- Compute the output file
    local tOutputFileStub, tOutputFileFolder
-   put builderWorkspaceFolder() & "/deploy" into tOutputFileFolder
-   put builderWorkspaceFolder() & "/deploy/" & getInstallerFilenameStub(pVersion, pPlatform, pEdition) into tOutputFileStub
+   put builderOutputFolder() into tOutputFileFolder
+   put tOutputFileFolder & slash & getInstallerFilenameStub(pVersion, pPlatform, pEdition) into tOutputFileStub
    builderEnsureFolderForFile tOutputFileStub
    
    local tInstaller
@@ -271,16 +262,16 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
    # AL-2015-03-14: Use deploy parameters to include libURL scriptified stack in installer standalone
    local tAuxStackfiles
    if there is a stack "revLibUrl" then
-   		put the effective filename of stack "revLibUrl" into tAuxStackfiles
+      put the effective filename of stack "revLibUrl" into tAuxStackfiles
    else
-	   put builderRepoFolder() & slash & "ide-support" & slash & "revliburl.livecodescript" into tAuxStackfiles
+      put builderRepoFolder() & slash & "ide-support" & slash & "revliburl.livecodescript" into tAuxStackfiles
    end if	
    put return & builderSystemFolder() & slash & "installer_utilities.livecodescript" after tAuxStackfiles
    
-   start using stack "revSBLibrary"
+   start using stack (builderRepoFolder() & slash & "ide-support" & slash & "revsblibrary.livecodescript")
    repeat for each line tStackFile in tAuxStackfiles
       local tTempStackFile
-      put the tempname into tTempStackFile
+      put builderMakeTemporaryFile(tTempFolder, "stack") into tTempStackFile
       revSBResaveScriptOnlyStackAsProperStackFile the short name of stack tStackFile, tStackFile, tTempStackFile
       put tTempStackFile & return after tParams["auxiliary_stackfiles"]
    end repeat
@@ -301,7 +292,7 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
          put tManifestFile into tParams["manifest"]
          
          -- First we deploy the installer unsigned
-         put builderInstallerEngine("windows") into tParams["engine"]
+         put abstractPinFile(builderInstallerEngine("windows")) into tParams["engine"]
          put tInstallerStackfile into tParams["stackfile"] 
          put pPackageFile into tParams["payload"]
          put tOutputFileStub & ".unsigned.exe" into tParams["output"]
@@ -348,7 +339,7 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
       case "linux"
       case "linux-x64"
       case "linux-armv6hf"
-         put builderInstallerEngine(pPlatform) into tParams["engine"]
+         put abstractPinFile(builderInstallerEngine(pPlatform)) into tParams["engine"]
          put tInstallerStackFile into tParams["stackfile"]
          put pPackageFile into tParams["payload"]
          if pPlatform is "linux" then
@@ -387,7 +378,7 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
          end if
          
          -- Get us an installer by dieting the source installer
-         put builderInstallerEngine("macosx") & slash & "Contents/MacOS/installer" into tDietParams["input"]
+         put abstractPinFile(builderInstallerEngine("macosx") & slash & "Contents/MacOS/installer") into tDietParams["input"]
          put tTempFolder & slash & "macosx-installer-x86" into tDietParams["output"]
          put true into tDietParams["keep_x86"]
          put false into tDietParams["keep_ppc"]
@@ -399,20 +390,7 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
             throw "failure"
          end if
          
-         --         put builderInstallerEngine("macosx") & slash & "Contents/MacOS/installer" into tDietParams["input"]
-         --         put tTempFolder & slash & "macosx-installer-ppc" into tDietParams["output"]
-         --         put false into tDietParams["keep_x86"]
-         --         put true into tDietParams["keep_ppc"]
-         --         builderLog "message", "Dieting input installer down to ppc"
-         --         --_internal diet macosx tDietParams
-         --         dietAndStrip "ppc", tDietParams["input"], tDietParams["output"]
-         --         if the result is not empty then
-         --            builderLog "error", "Dieting input installer to ppc failed -" && the result
-         --            throw "failure"
-         --         end if
-         
          put tTempFolder & slash & "macosx-installer-x86" into tParams["engine_x86"]
-         --put tTempFolder & slash & "macosx-installer-ppc" into tParams["engine_ppc"]
          put tInstallerStackFile into tParams["stackfile"]
          put tOutputFileStub & ".app" & slash & "Contents/MacOS/installer" into tParams["output"]
          
@@ -458,15 +436,15 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
             end if
          end if
          
-         local tTrashFile
-         put builderWorkspaceFolder() & "/deploy/.Trash" into tTrashFile
-         put empty into URL ("file:" & tTrashFile)
+         --local tTrashFile
+         --put builderWorkspaceFolder() & "/deploy/.Trash" into tTrashFile
+         --put empty into URL ("file:" & tTrashFile)
          
          -- Do the DMG build
          rename (tOutputFileStub & ".app") to tDmgAppFolder
          -- SN-2015-03-09: [[ DMG creation failure ]] Ensure that hdiutil will allocate enough
          --  memory if the installer end up being over a gigabyte large.
-         get shell("hdiutil create -fs HFS+ -size 1G -volname" && quote & tDmgName & quote && "-srcfolder" && quote & tDmgAppFolder & quote && "-srcfolder" && quote & tTrashFile & quote && quote & tDmgFile & quote)
+         get shell("hdiutil create -fs HFS+ -size 1G -volname" && quote & tDmgName & quote && "-srcfolder" && quote & tDmgAppFolder & quote && quote & tDmgFile & quote)
          rename tDmgAppFolder to (tOutputFileStub & ".app")
          if "created:" is not in it then
             builderLog "error", "Dmg creation failed -" && the last line of it
@@ -540,13 +518,3 @@ function loadTextFile pFile
    return it
 end loadTextFile
 
-private command removeStandaloneEdiitonSuffix pStandalone, pEdition
-   local tOldStandalone, tNewStandalone
-   put pStandalone & "/Contents/MacOS/Standalone-" & pEdition into tOldStandalone
-   put pStandalone & "/Contents/MacOS/Standalone" into tNewStandalone   
-   if there is a file tNewStandalone and there is a file tOldStandalone then
-      delete file tNewStandalone
-   end if
-   rename tOldStandalone to tNewStandalone
-   return the result
-end removeStandaloneEdiitonSuffix

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -663,7 +663,9 @@ Exec_stat MCIdeDeploy::exec(MCExecPoint& ep)
 	// Now, if we are not licensed for a target, then its an error.
 	bool t_is_licensed;
 	t_is_licensed = false;
-	if (m_platform == PLATFORM_WINDOWS)
+    if (MCnoui && MClicenseparameters . license_class == kMCLicenseClassCommunity)
+        t_is_licensed = true;
+	else if (m_platform == PLATFORM_WINDOWS)
 		t_is_licensed = (MClicenseparameters . deploy_targets & kMCLicenseDeployToWindows) != 0;
 	else if (m_platform == PLATFORM_MACOSX)
 		t_is_licensed = (MClicenseparameters . deploy_targets & kMCLicenseDeployToMacOSX) != 0;

--- a/engine/src/desktop-stack.cpp
+++ b/engine/src/desktop-stack.cpp
@@ -230,9 +230,6 @@ MCRectangle MCStack::view_platform_getwindowrect() const
 // IM-2013-09-23: [[ FullscreenMode ]] Factor out device-specific window sizing
 MCRectangle MCStack::view_platform_setgeom(const MCRectangle &p_rect)
 {
-    if (window == NULL)
-        return p_rect;
-    
 	MCPlatformSetWindowContentRect(window, p_rect);
 	return p_rect;
 }

--- a/engine/src/desktop-stack.cpp
+++ b/engine/src/desktop-stack.cpp
@@ -230,6 +230,9 @@ MCRectangle MCStack::view_platform_getwindowrect() const
 // IM-2013-09-23: [[ FullscreenMode ]] Factor out device-specific window sizing
 MCRectangle MCStack::view_platform_setgeom(const MCRectangle &p_rect)
 {
+    if (window == NULL)
+        return p_rect;
+    
 	MCPlatformSetWindowContentRect(window, p_rect);
 	return p_rect;
 }

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -837,7 +837,8 @@ IO_stat MCDispatch::doreadfile(const char *openpath, const char *inname, IO_hand
     {
         MCnoui = True;
         MCscreen = new MCUIDC;
-        /* UNCHECKED */ MCStackSecurityCreateStack(stacks);
+        /* UNCHECKED */ MCStackSecurityCreateStack(sptr);
+        stacks = sptr;
         MCdefaultstackptr = MCstaticdefaultstackptr = stacks;
         stacks->setparent(this);
         stacks->setname_cstring("revScript");

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -80,14 +80,10 @@ MCScreenDC::MCScreenDC()
 	
 	backdrop_hard = false;
 	backdrop_active = false;
-
-	MCNotifyInitialize();
 }
 
 MCScreenDC::~MCScreenDC()
 {
-	MCNotifyFinalize();
-
 	if (opened)
 		close(True);
 	if (ncolors != 0)

--- a/engine/src/mbldc.cpp
+++ b/engine/src/mbldc.cpp
@@ -111,9 +111,6 @@ MCScreenDC::MCScreenDC(void)
 	
 	// Initialize the list of active touches.
 	m_active_touches = nil;
-	
-	// MW-2013-06-18: [[ XPlatNotify ]] Initialize the notify module.
-	MCNotifyInitialize();
 }
 
 MCScreenDC::~MCScreenDC(void)
@@ -123,9 +120,6 @@ MCScreenDC::~MCScreenDC(void)
 	
 	// Delete the main windows stack.
 	delete m_main_windows;
-	
-	// MW-2013-06-18: [[ XPlatNotify ]] Finalize the notify module.
-	MCNotifyFinalize();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/notify.cpp
+++ b/engine/src/notify.cpp
@@ -31,6 +31,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <pthread.h>
 #endif
 
+extern Boolean MCnoui;
+
 struct MCNotifySyncEvent
 {
 	MCNotifySyncEvent *next;
@@ -80,6 +82,7 @@ static DWORD s_main_thread_id = 0;
 static bool s_notify_sent = false;
 static pthread_mutex_t s_notify_lock;
 static pthread_t s_main_thread;
+int g_notify_pipe[2] = {-1, -1};
 #elif defined(_LINUX)
 static bool s_notify_sent = false;
 int g_notify_pipe[2] = {-1, -1};
@@ -225,6 +228,8 @@ bool MCNotifyInitialize(void)
 #elif defined(_MACOSX)
 	pthread_mutex_init(&s_notify_lock, NULL);
 	s_main_thread = pthread_self();
+    if (MCnoui)
+        pipe(g_notify_pipe);
 #elif defined(_LINUX)
 	pthread_mutex_init(&s_notify_lock, NULL);
 	pipe(g_notify_pipe);
@@ -294,7 +299,14 @@ void MCNotifyFinalize(void)
 #if defined(_WINDOWS)
 	DeleteCriticalSection(&s_notify_lock);
 	CloseHandle(g_notify_wakeup);
-#elif defined(_MACOSX) || defined(_IOS_MOBILE) || defined(_ANDROID_MOBILE)
+#elif defined(_MACOSX)
+    if (MCnoui)
+    {
+        close(g_notify_pipe[0]);
+        close(g_notify_pipe[1]);
+    }
+	pthread_mutex_destroy(&s_notify_lock);
+#elif defined(_IOS_MOBILE) || defined(_ANDROID_MOBILE)
 	pthread_mutex_destroy(&s_notify_lock);
 #elif defined(_LINUX)
 	pthread_mutex_destroy(&s_notify_lock);
@@ -466,8 +478,16 @@ void MCNotifyPing(bool p_high_priority)
 	if (!s_notify_sent)
 	{
 		s_notify_sent = true;
-		extern void MCMacBreakWait(void);
-		MCMacBreakWait();
+		if (!MCnoui)
+        {
+            extern void MCMacBreakWait(void);
+            MCMacBreakWait();
+        }
+        else
+        {
+            char t_notify_char = 1;
+            write(g_notify_pipe[1], &t_notify_char, 1);
+        }
 	}
 #elif defined(_LINUX)
 	if (!s_notify_sent)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -1911,16 +1911,8 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
 
 	if (stat == ES_ERROR && MCerrorlock == 0 && !MCtrylock)
 	{
-		if (MCnoui)
-		{
-			uint2 line, pos;
-			MCeerror->geterrorloc(line, pos);
-			fprintf(stderr, "%s: Script execution error at line %d, column %d\n",
-			        MCcmd, line, pos);
-		}
-		else
-			if (!send)
-				senderror();
+        if (!send)
+            senderror();
 		return ES_ERROR;
 	}
 	if (!send)

--- a/engine/src/osxspec.cpp
+++ b/engine/src/osxspec.cpp
@@ -1599,7 +1599,15 @@ Boolean MCS_poll(real8 delay, int fd)
 			handled = True;
 		}
 	}
-
+    
+	extern int g_notify_pipe[2];
+	if (g_notify_pipe[0] != -1)
+	{
+		FD_SET(g_notify_pipe[0], &rmaskfd);
+		if (g_notify_pipe[0] > maxfd)
+			maxfd = g_notify_pipe[0];
+	}
+    
 	struct timeval timeoutval;
 	timeoutval.tv_sec = (long)delay;
 	timeoutval.tv_usec = (long)((delay - floor(delay)) * 1000000.0);
@@ -1639,7 +1647,13 @@ Boolean MCS_poll(real8 delay, int fd)
 		}
 		MCsockets[i]->setselect();
 	}
-
+    
+	if (g_notify_pipe[0] != -1 && FD_ISSET(g_notify_pipe[0], &rmaskfd))
+	{
+		char t_notify_char;
+		read(g_notify_pipe[0], &t_notify_char, 1);
+	}
+    
 	return True;
 }
 

--- a/engine/src/stackview.cpp
+++ b/engine/src/stackview.cpp
@@ -960,7 +960,8 @@ MCRectangle MCStack::view_setgeom(const MCRectangle &p_rect)
 
 void MCStack::view_update_geometry()
 {
-	if (m_view_need_resize)
+	if (m_view_need_resize &&
+        window != NULL)
 		view_platform_setgeom(m_view_rect);
 	
 	m_view_need_resize = false;

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -43,6 +43,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "redraw.h"
 #include "notify.h"
 #include "dispatch.h"
+#include "notify.h"
+#include "mode.h"
+#include "eventqueue.h"
 
 #include "graphicscontext.h"
 
@@ -191,6 +194,8 @@ MCMovingList::~MCMovingList()
 
 MCUIDC::MCUIDC()
 {
+	MCNotifyInitialize();
+    
 	messageid = 0;
 	nmessages = maxmessages = 0;
 	messages = NULL;
@@ -214,6 +219,8 @@ MCUIDC::~MCUIDC()
 	while (nmessages != 0)
 		cancelmessageindex(0, True);
 	delete messages;
+    
+	MCNotifyFinalize();
 }
 
 
@@ -803,10 +810,13 @@ Boolean MCUIDC::getmouseclick(uint2 button, Boolean& r_abort)
 
 Boolean MCUIDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 {
+	MCwaitdepth++;
+    
 	real8 curtime = MCS_time();
 	if (duration < 0.0)
 		duration = 0.0;
 	real8 exittime = curtime + duration;
+    Boolean abort = False;
 	Boolean done = False;
 	Boolean donepending = False;
 	do
@@ -817,8 +827,17 @@ Boolean MCUIDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 		real8 eventtime = exittime;
 		donepending = handlepending(curtime, eventtime, dispatch);
 		siguser();
+        
+		MCModeQueueEvents();
+        
+        if ((MCNotifyDispatch(dispatch == True) ||
+             donepending) && anyevent ||
+            abort)
+            break;
+        
 		if (MCquit)
-			return True;
+            break;
+        
 		if (curtime < eventtime)
 		{
 			done = MCS_poll(donepending ? 0 : eventtime - curtime, 0);
@@ -826,7 +845,11 @@ Boolean MCUIDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 		}
 	}
 	while (curtime < exittime  && !(anyevent && (done || donepending)));
-	return False;
+    if (MCquit)
+        abort = True;
+    MCwaitdepth--;
+    
+	return abort;
 }
 
 void MCUIDC::pingwait(void)

--- a/engine/src/w32dc.cpp
+++ b/engine/src/w32dc.cpp
@@ -89,14 +89,10 @@ MCScreenDC::MCScreenDC()
 	m_printer_dc_changed = false;
 
 	m_clipboard = NULL;
-
-	MCNotifyInitialize();
 }
 
 MCScreenDC::~MCScreenDC()
 {
-	MCNotifyFinalize();
-
 	showtaskbar();
 	while (opened)
 		close(True);

--- a/engine/src/w32spec.cpp
+++ b/engine/src/w32spec.cpp
@@ -1465,6 +1465,7 @@ void MCS_fakewriteat(IO_handle stream, uint4 p_pos, const void *p_buffer, uint4 
 // MW-2005-02-22: Make these global for opensslsocket.cpp
 static Boolean wsainited = False;
 HWND sockethwnd;
+HANDLE g_socket_wakeup;
 
 Boolean wsainit()
 {
@@ -1483,6 +1484,8 @@ Boolean wsainit()
 			if (!MCnoui)
 				sockethwnd = CreateWindowA(MC_WIN_CLASS_NAME, "MCsocket", WS_POPUP, 0, 0,
 				                          8, 8, NULL, NULL, MChInst, NULL);
+			else
+				g_socket_wakeup = CreateEvent(NULL, FALSE, FALSE, NULL);
 		}
 	}
 	MCS_seterrno(0);
@@ -1634,6 +1637,12 @@ void MCS_saveresfile(const MCString &s, const MCString data)
 
 Boolean MCS_poll(real8 delay, int fd)
 {
+	extern HANDLE g_notify_wakeup;
+	HANDLE t_handles[2];
+	t_handles[0] = g_notify_wakeup;
+	t_handles[1] = g_socket_wakeup;
+	MsgWaitForMultipleObjects(2, t_handles, FALSE, delay * 1000.0, 0);
+
 	Boolean handled = False;
 	int4 n;
 	uint2 i;
@@ -1672,9 +1681,7 @@ Boolean MCS_poll(real8 delay, int fd)
 			handled = True;
 		}
 	}
-	struct timeval timeoutval;
-	timeoutval.tv_sec = (long)delay;
-	timeoutval.tv_usec = (long)((delay - floor(delay)) * 1000000.0);
+	struct timeval timeoutval = {0, 0};
 	n = select(maxfd + 1, &rmaskfd, &wmaskfd, &emaskfd, &timeoutval);
 	if (n <= 0)
 		return handled;


### PR DESCRIPTION
This patch contains minor changes to the engine to allow the community IDE engine to run in -ui along with various changes to the builder system to enable installers to be built from the command line.

Specifically, there is a new stack 'builder_tool.livecodescript' which gives a command-line interface to the installer builder system:

`<ide-engine>` -ui builder/builder_tool.livecodescript

This takes the following arguments:

  . --platform `<plat>` : `<plat>` is one of win, mac, linux (multiple --platform arguments are allowed)
  . --stage `<stage>` : `<stage>` is one of environment, tools, server, notes, docs
  . --edition `<edition>` : `<edition>` is one of community, commercial
  . --build `<build>` : `<build>` is one of stable, maintenance, development, beta
  . --engine-dir `<dir>` : `<dir>` is a folder containing zipped binary components
  . --output-dir `<dir>` : `<dir>` is the folder where the final built installers should be placed
  . --work-dir `<dir>` : `<dir>` is the folder where intermediate files should be placed
  . --warn-as-error : if specified, the build will stop at the first warning

The environment stage will generate a suitable public/private key.

The docs stage will generate the documentation.

The notes stage will generate the release notes.

The tools stage will generate the installers themselves.

Note: This also requires a patch to the installer package.txt - on branch feature-cmd_line_builder in the ide repository.
