### PR TITLE
[[ Bug 15258 ]] Saving in < 7 format, do not nativise the Custom Propert...

### DIFF
--- a/docs/notes/bugfix-15258.md
+++ b/docs/notes/bugfix-15258.md
@@ -1,0 +1,1 @@
+# Custom properties lose unicode text when copied


### PR DESCRIPTION
...ies strings, but get a C-String copy
