### PR TITLE
[[ Bug 15276 ]] Check the 'type' field when mapping property indicies to...

### DIFF
--- a/docs/lcb/notes/15276.md
+++ b/docs/lcb/notes/15276.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Host Library
+
+# [15276] Keywords don't map to the correct property name.

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -365,7 +365,7 @@ static void lookup_name_for_prop(Properties p_which, MCNameRef& r_name)
     extern LT factor_table[];
     extern const uint4 factor_table_size;
     for(uindex_t i = 0; i < factor_table_size; i++)
-        if (factor_table[i] . which == p_which)
+        if (factor_table[i] . type == TT_PROPERTY && factor_table[i] . which == p_which)
         {
             /* UNCHECKED */ MCNameCreateWithCString(factor_table[i] . token, r_name);
             return;


### PR DESCRIPTION
... strings.
