### PR TITLE
[[ TemplateAppMetadata ]] Regression fix to TemplateManifest for android...

### DIFF
--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -199,26 +199,26 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget
       end if
       
       -------- Unpack all the files used by the externals
-      // MERG-2014-11-18: [[ TemplateManifest ]] Look for a template manifest provided by the developer in copy files
-      local tManifestFile
+      // MERG-2015-04-24: [[ TemplateAppMetadata ]] Look for a template manifest provided by the developer in copy files
+      local tManifest
       
       revStandaloneProgress "Integrating externals..."
       
       if tExternals is not empty then
          put return after tExternals
       end if
+      
+	  set the itemDelimiter to "."
       repeat for each line tFile in tFiles
          local tFilePath, tFileName
          computeAssetLocation tBaseFolder, tFile, tFilePath, tFileName
          
          -- Look for manifest template
-         set the itemDelimiter to slash
-         if the last item of tFilePath is "AndroidManifest.xml" then
-            put tFilePath into tManifestFile
+         if tFilePath ends with "AndroidManifest.xml" then
+		 	put url ("binfile:" & tFilePath) into tManifest
          end if
          
          -- Only look for lcext files.
-         set the itemDelimiter to "."
          if the last item of tFilePath is not "lcext" then
             next repeat
          end if
@@ -242,12 +242,12 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget
       -------- Create the Manifest
       revStandaloneProgress "Writing manifest..."
       
-      if tManifestFile is empty then
-         put tBuildFolder & slash & "AndroidManifest.xml" into tManifestFile
-      end if
+      local tManifestFile
+      put tBuildFolder & slash & "AndroidManifest.xml" into tManifestFile
       
-      local tManifest
-      put url ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "Manifest.xml")) into tManifest
+      if tManifest is empty then
+      	put url ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "Manifest.xml")) into tManifest
+	  end if
       // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occured
       if the result is not empty then
          throw "Cannot find the template Manifest"
@@ -850,6 +850,8 @@ private command addAssetsToArchive pFiles, pBaseFolder, pArchive
             put tFile & return after tFonts
          else if tFile ends with ".lcext" or tFile ends with ".dylib" then
             -- MW-2012-07-05: [[ Externals ]] If an 'lcext' file or dylib file is found then we ignore it.
+		 else if tFile ends with "AndroidManifest.xml" then
+		 	-- MW-2015-04-24: [[ TemplateAppMetadata ]] If an template manifest is found then we ignore it.
          else
             revZipAddUncompressedItemWithFile pArchive, "assets/" & tName, tFile
          end if

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -242,7 +242,9 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
       revCopyMobileNewSplash tSettings, tBaseFolder, pAppBundle
    end if
    
-   revCopyMobileFiles tFiles, tBaseFolder, pAppBundle, pTarget, tSDKs, tRedirects, tCopiedExternals, tCopiedFonts
+   -- MERG-2015-04-24: [[ TemplateAppMetadata ]] If a template plist is found then we use it instead of the default template.
+   local tPlist
+   revCopyMobileFiles tFiles, tBaseFolder, pAppBundle, pTarget, tSDKs, tRedirects, tCopiedExternals, tCopiedFonts, tPlist
    revCopyMobileStackFiles tStackFiles, tBaseFolder, pAppBundle
    
    -- Copy in the appropriate externals and drivers
@@ -250,7 +252,7 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
    revCopyMobileDrivers tDrivers, pAppBundle, pTarget, tSDKs, tCopiedExternals
    
    -- Generate the plist
-   revCreateMobilePlist tSettings, pAppBundle, pTarget, tCopiedFonts
+   revCreateMobilePlist tSettings, pAppBundle, pTarget, tCopiedFonts, tPlist
    
    -- Generate the PkgInfo file
    put "APPL????" into url ("binfile:" & pAppBundle & slash & "PkgInfo")
@@ -816,7 +818,7 @@ end revModifyMobileImageFile
 --   foobar/baz -> <base>/foobar/baz
 --   C:/foobar/baz -> <base>/baz
 --
-private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, pSDKs, @rRedirects, @rExternals, @rFonts
+private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, pSDKs, @rRedirects, @rExternals, @rFonts, @rPlist
    revStandaloneProgress "Copying files..."
    
    -- Only use redirects in simulator 4.x
@@ -949,10 +951,15 @@ private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, 
       
       -- If the file is a dylib, then see if there is a target specific version and record
       -- MM-2012-09-18: Ignore old style externals.
-      --
+	  --
       if tSource ends with ".lcext" or tSource ends with ".dylib" then         
          next repeat
       end if
+	  
+      -- MERG-2015-04-24: [[ TemplateAppMetadata ]] If a template plist is found then we use it instead of the default template.
+	  if tSource ends with "Info.plist" then
+	  	put url ("binfile:" & tSource) into rPlist
+	  end if
       
       -- Otherwise its just a file
       if not tUseRedirects then
@@ -1094,10 +1101,13 @@ private function revGetMinimumOSByArch pMinimumOS
    return tMinimumOSByArch
 end revGetMinimumOSByArch
 
-private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
+private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPlist
+   -- MERG-2015-04-24: [[ TemplateAppMetadata ]] If a pList was found then use that.
    local tTemplateFile
-   put mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "Settings.plist") into tTemplateFile
-   if there is no file tTemplateFile then
+   if pPlist is empty then
+      put url ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "Settings.plist")) into pPlist
+   end if
+   if there is no file pPlist then
       throw "could not find plist template for" && tolower(pTarget) && "target"
    end if
    
@@ -1218,22 +1228,20 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    
    ----------
    
-   local tPlist
-   put url ("file:" & tTemplateFile) into tPlist
    // SN-2014-10-27: [[ Bug 13827 ]] Strings in a Plist file should be UTF-8 encoded
-   replace "${EXECUTABLE_NAME}" with textEncode(tExeName, "utf-8") in tPlist
-   replace "${BUNDLE_IDENTIFIER}" with textEncode(tBundleId, "utf-8") in tPlist
-   replace "${BUNDLE_VERSION}" with tBundleVersion in tPlist
-   replace "${BUNDLE_DISPLAY_NAME_SUPPORT}" with "<string>" & tDisplayName & "</string>" in tPlist
+   replace "${EXECUTABLE_NAME}" with textEncode(tExeName, "utf-8") in pPlist
+   replace "${BUNDLE_IDENTIFIER}" with textEncode(tBundleId, "utf-8") in pPlist
+   replace "${BUNDLE_VERSION}" with tBundleVersion in pPlist
+   replace "${BUNDLE_DISPLAY_NAME_SUPPORT}" with "<string>" & tDisplayName & "</string>" in pPlist
    -- SN-2015-02-02: [[ Bug 14422 ]] We now have minimum version depending on the arch.
-   replace "${MINIMUM_OS_SUPPORT}" with "<string>" & tMinimumOSByArch["i386"] & "</string>" in tPlist
-   replace "${CUSTOM_FONTS}" with tCustomFonts in tPlist
+   replace "${MINIMUM_OS_SUPPORT}" with "<string>" & tMinimumOSByArch["i386"] & "</string>" in pPlist
+   replace "${CUSTOM_FONTS}" with tCustomFonts in pPlist
    
    get empty
    repeat for each item tItem in tDeviceFamily
       put "<integer>" & tItem & "</integer>" after it
    end repeat
-   replace "${DEVICE_SUPPORT}" with it in tPlist
+   replace "${DEVICE_SUPPORT}" with it in pPlist
    
    get empty
    repeat for each key tKey in tRequiredCapabilities
@@ -1250,36 +1258,36 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
       put "<key>armv7</key><true/>" after it
    end if
    
-   replace "${DEVICE_CAPABILITY}" with it in tPlist
+   replace "${DEVICE_CAPABILITY}" with it in pPlist
    
-   replace "${PERSISTENT_WIFI}" with "<" & tPersistentWifi & "/>" in tPlist
-   replace "${APPLICATION_EXITS_ON_SUSPEND}" with "<" & tExitsOnSuspend & "/>" in tPlist
-   replace "${FILE_SHARING}" with "<" & tFileSharing & "/>" in tPlist
-   replace "${PRE_RENDERED_ICON}" with "<" & tPrerenderedIcon & "/>" in tPlist
+   replace "${PERSISTENT_WIFI}" with "<" & tPersistentWifi & "/>" in pPlist
+   replace "${APPLICATION_EXITS_ON_SUSPEND}" with "<" & tExitsOnSuspend & "/>" in pPlist
+   replace "${FILE_SHARING}" with "<" & tFileSharing & "/>" in pPlist
+   replace "${PRE_RENDERED_ICON}" with "<" & tPrerenderedIcon & "/>" in pPlist
    
    -- MW-2010-11-30: We need to make sure the first item in the list is the
    --     initial orientation as otherwise we get odd behavior (in the simulator
    --     at least!)
    -- MM-2011-09-28: Updated oreintation handling to generate new plist values.
    --   
-   replace "${IPHONE_INITIAL_ORIENTATION}" with "<string>UIInterfaceOrientation" & tIPhoneOrientation & "</string>" in tPlist
-   replace "${IPHONE_SUPPORTED_ORIENTATIONS}" with "<string>UIInterfaceOrientation" & tIPhoneOrientation & "</string>" in tPlist
-   replace "${IPAD_INITIAL_ORIENTATION}" with "<string>UIInterfaceOrientation" & item 1 of  tIPadOrientations & "</string>" in tPlist
+   replace "${IPHONE_INITIAL_ORIENTATION}" with "<string>UIInterfaceOrientation" & tIPhoneOrientation & "</string>" in pPlist
+   replace "${IPHONE_SUPPORTED_ORIENTATIONS}" with "<string>UIInterfaceOrientation" & tIPhoneOrientation & "</string>" in pPlist
+   replace "${IPAD_INITIAL_ORIENTATION}" with "<string>UIInterfaceOrientation" & item 1 of  tIPadOrientations & "</string>" in pPlist
    get empty
    repeat for each item tItem in tIPadOrientations
       put "<string>UIInterfaceOrientation" & tItem & "</string>" after it
    end repeat 
-   replace "${IPAD_SUPPORTED_ORIENTATIONS}" with it in tPlist
+   replace "${IPAD_SUPPORTED_ORIENTATIONS}" with it in pPlist
    
-   replace "${STATUS_BAR_STYLE}" with "<string>UIStatusBarStyle" & tStatusBarStyle & "</string>" in tPlist
-   replace "${STATUS_BAR_HIDDEN}" with "<" & tStatusBarHidden & "/>" in tPlist
-   replace "${IPAD_STATUS_BAR_HIDDEN}" with "<" & tIPadStatusBarHidden & "/>" in tPlist
+   replace "${STATUS_BAR_STYLE}" with "<string>UIStatusBarStyle" & tStatusBarStyle & "</string>" in pPlist
+   replace "${STATUS_BAR_HIDDEN}" with "<" & tStatusBarHidden & "/>" in pPlist
+   replace "${IPAD_STATUS_BAR_HIDDEN}" with "<" & tIPadStatusBarHidden & "/>" in pPlist
    
    -- PM-2015-02-17: [[ Bug 14482 ]] Added a new "solid" statusbarstyle
    if tStatusBarSolid is empty then
       put false into tStatusBarSolid
    end if
-   replace "${STATUS_BAR_SOLID}" with "<" & tStatusBarSolid & "/>" in tPlist
+   replace "${STATUS_BAR_SOLID}" with "<" & tStatusBarSolid & "/>" in pPlist
    
    
    -- MM-2013-10-08: [[ Bug 11257 ]] Make sure we include the new iOS 7 icons in the plist.
@@ -1289,7 +1297,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
          put "<string>" & "Icon" & tItem & ".png</string>" after it
       end if
    end repeat
-   replace "${BUNDLE_ICONS}" with it in tPlist
+   replace "${BUNDLE_ICONS}" with it in pPlist
    
    -- MM-2014-09-30: [[ iOS8 Support ]] Added new iOS 7 style entries for the splash screens
    -- MM-2014-10-06: [[ Bug 13512 ]] Splash screen sizes are in points and should omit the @2x @3x suffix, iOS is smart enough to figure that out.
@@ -1332,15 +1340,15 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    end repeat
    set the itemDel to comma
    
-   replace "${SPLASHSCREENS}" with tSplashData in tPlist
+   replace "${SPLASHSCREENS}" with tSplashData in pPlist
    
    ----------
    -- MM-2012-02-12: Added support for push notificaitons and custom URL schemes
    
    if pSettings["ios,push notifications"] then
-      replace "${REMOTE_NOTIFICATION_TYPES}" with URL ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "RemoteNotificationSettings.plist")) in tPlist      
+      replace "${REMOTE_NOTIFICATION_TYPES}" with URL ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "RemoteNotificationSettings.plist")) in pPlist      
    else
-      replace "${REMOTE_NOTIFICATION_TYPES}" with empty in tPlist
+      replace "${REMOTE_NOTIFICATION_TYPES}" with empty in pPlist
    end if
    
    local tUsesLocalNotifications
@@ -1350,15 +1358,15 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
       put "false" into tUsesLocalNotifications 
    end if
    
-   replace "${USES_LOCAL_NOTIFICATIONS}" with "<" & tUsesLocalNotifications & "/>" in tPlist
+   replace "${USES_LOCAL_NOTIFICATIONS}" with "<" & tUsesLocalNotifications & "/>" in pPlist
    
    if pSettings["ios,url name"] is not empty then
       get URL ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "URLSchemeSettings.plist"))
       replace "${BUNDLE_IDENTIFIER}" with tBundleId in it
       replace "${URL_NAME}" with pSettings["ios,url name"] in it
-      replace "${URL_TYPES}" with it in tPlist
+      replace "${URL_TYPES}" with it in pPlist
    else
-      replace "${URL_TYPES}" with empty in tPlist
+      replace "${URL_TYPES}" with empty in pPlist
    end if
    
    ----------
@@ -1378,11 +1386,11 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts
    else
       get empty
    end if
-   replace "${LOCATION_AUTH_TYPE}" with it in tPlist
+   replace "${LOCATION_AUTH_TYPE}" with it in pPlist
    
    ----------   
    
-   put tPlist into url ("binfile:" & pAppBundle & slash & "Info.plist")   
+   put pPlist into url ("binfile:" & pAppBundle & slash & "Info.plist")   
 end revCreateMobilePlist
 
 ################################################################################

--- a/revbrowser/revbrowser.xcodeproj/project.pbxproj
+++ b/revbrowser/revbrowser.xcodeproj/project.pbxproj
@@ -388,6 +388,8 @@
 /* Begin PBXProject section */
 		4DF42A990B0488B2003F2D95 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 4DF42A9A0B0488B2003F2D95 /* Build configuration list for PBXProject "revbrowser" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;

--- a/revmobile/reviphone.xcodeproj/project.pbxproj
+++ b/revmobile/reviphone.xcodeproj/project.pbxproj
@@ -200,6 +200,8 @@
 /* Begin PBXProject section */
 		4D8F6A0C113D13140056ED41 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 4D8F6A0F113D13140056ED41 /* Build configuration list for PBXProject "reviphone" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;

--- a/revpdfprinter/revpdfprinter.xcodeproj/project.pbxproj
+++ b/revpdfprinter/revpdfprinter.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		4D9D1D5217142A7800BE4F14 /* libz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D9D1D3E17142A1000BE4F14 /* libz.a */; };
 		4D9D1D5317142A7B00BE4F14 /* libcairo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D9D1D4817142A1C00BE4F14 /* libcairo.a */; };
 		4DA9C01B10E20D0500055232 /* revpdfprinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DA9C01A10E20D0500055232 /* revpdfprinter.cpp */; };
-		4DA9C05E10E20E2E00055232 /* revpdfprinter_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DA9C05D10E20E2E00055232 /* revpdfprinter_osx.cpp */; };
 		72CC350318A946E900BEC655 /* libcore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 72CC350218A946E900BEC655 /* libcore.a */; };
 /* End PBXBuildFile section */
 

--- a/revvideograbber/revvideograbber.xcodeproj/project.pbxproj
+++ b/revvideograbber/revvideograbber.xcodeproj/project.pbxproj
@@ -86,6 +86,20 @@
 			remoteGlobalIDString = 4DB846B4192B53E800771914;
 			remoteInfo = "Server-Community";
 		};
+		B22F25081ACCF42C002C862A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4D51518C0BCF96B700F73C6E /* engine.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7699BD601A1CD51A00636397;
+			remoteInfo = "Test-Community";
+		};
+		B22F250A1ACCF42C002C862A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4D51518C0BCF96B700F73C6E /* engine.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7699BE791A1CD51E00636397;
+			remoteInfo = "kernel-test";
+		};
 		B55AFA1D0BCE905300E1F7F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B55AFA190BCE905300E1F7F0 /* libexternal.xcodeproj */;
@@ -163,6 +177,8 @@
 				4D5151A00BCF96B700F73C6E /* Standalone-Community.app */,
 				4D41477E120431AE0088006F /* Installer.app */,
 				729039DA197985C6007E0FF3 /* Server-Community */,
+				B22F25091ACCF42C002C862A /* Test-Community.app */,
+				B22F250B1ACCF42C002C862A /* libkernel-test.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -275,6 +291,8 @@
 /* Begin PBXProject section */
 		4D6758CF0A79F96300FA96D2 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 4D6758D00A79F96300FA96D2 /* Build configuration list for PBXProject "revvideograbber" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -367,6 +385,20 @@
 			fileType = "compiled.mach-o.executable";
 			path = "Server-Community";
 			remoteRef = 729039D9197985C6007E0FF3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B22F25091ACCF42C002C862A /* Test-Community.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = "Test-Community.app";
+			remoteRef = B22F25081ACCF42C002C862A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B22F250B1ACCF42C002C862A /* libkernel-test.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libkernel-test.a";
+			remoteRef = B22F250A1ACCF42C002C862A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		B55AFA1E0BCE905300E1F7F0 /* libexternal.a */ = {

--- a/rules/Global.xcconfig
+++ b/rules/Global.xcconfig
@@ -1,6 +1,6 @@
 #include "../version"
 
-SDKROOT = macosx10.8
+SDKROOT = macosx10.9
 
 OWNER = .
 SOLUTION_DIR = $(PROJECT_DIR)/../$(OWNER)


### PR DESCRIPTION
... manifests and implementation of template plists for iOS

It looks like I got mixed up at some point between the tManifestFile variable and the tManifest one... sorry. Should be fixed now and also implemented for iOS if you have your own Info.plist in copy files it will use that instead of the default plist.
