### PR TITLE
Fix compiler warning in external.h

### DIFF
--- a/libexternal/include/revolution/external.h
+++ b/libexternal/include/revolution/external.h
@@ -517,7 +517,7 @@ extern void GetXDisplayHandle(void **r_display, int *r_success);
 extern void GetXScreenHandle(void **r_screen, int *r_success);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Compiling with gcc and `-Wpedantic` you get a warning about an extra ';'
