### PR TITLE
Improve the errors when the shell command fails

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -2353,9 +2353,6 @@ public:
 					close(toparent[0]);
 					close(toparent[1]);
 
-                    if (MCprocesses[index].pid > 0)
-                        Kill(MCprocesses[index].pid, SIGKILL);
-
                     MCprocesses[index].pid = 0;
                     // SN-2015-01-29: [[ Bug 14462 ]] Should return false, not true
                     return false;

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -2347,7 +2347,9 @@ public:
                 }
                 if (MCprocesses[index].pid == -1)
                 {
-					MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
+					MCeerror->add(EE_SYSTEM_FUNCTION, 0, 0, "fork");
+					MCeerror->add(EE_SYSTEM_CODE, 0, 0, errno);
+					MCeerror->add(EE_SYSTEM_MESSAGE, 0, 0, strerror(errno));
 					close(tochild[0]);
 					close(tochild[1]);
 					close(toparent[0]);
@@ -2371,7 +2373,9 @@ public:
             }
             else
             {
-				MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
+                MCeerror->add(EE_SYSTEM_FUNCTION, 0, 0, "pipe");
+                MCeerror->add(EE_SYSTEM_CODE, 0, 0, errno);
+                MCeerror->add(EE_SYSTEM_MESSAGE, 0, 0, strerror(errno));
                 close(tochild[0]);
                 close(tochild[1]);
                 // SN-2015-01-29: [[ Bug 14462 ]] Should return false, not true
@@ -2380,7 +2384,9 @@ public:
         }
         else
         {
-			MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
+            MCeerror->add(EE_SYSTEM_FUNCTION, 0, 0, "pipe");
+            MCeerror->add(EE_SYSTEM_CODE, 0, 0, errno);
+            MCeerror->add(EE_SYSTEM_MESSAGE, 0, 0, strerror(errno));
             // SN-2015-01-29: [[ Bug 14462 ]] Should return false, not true
             return false;
         }

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -2345,6 +2345,21 @@ public:
                     execl(*t_shellcmd_sys, *t_shellcmd_sys, "-s", NULL);
                     _exit(-1);
                 }
+                if (MCprocesses[index].pid == -1)
+                {
+					MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
+					close(tochild[0]);
+					close(tochild[1]);
+					close(toparent[0]);
+					close(toparent[1]);
+
+                    if (MCprocesses[index].pid > 0)
+                        Kill(MCprocesses[index].pid, SIGKILL);
+
+                    MCprocesses[index].pid = 0;
+                    // SN-2015-01-29: [[ Bug 14462 ]] Should return false, not true
+                    return false;
+                }
                 CheckProcesses();
                 close(tochild[0]);
 
@@ -2356,32 +2371,19 @@ public:
                 close(tochild[1]);
                 close(toparent[1]);
                 MCS_lnx_nodelay(toparent[0]);
-                if (MCprocesses[index].pid == -1)
-                {
-                    if (MCprocesses[index].pid > 0)
-                        Kill(MCprocesses[index].pid, SIGKILL);
-
-                    MCprocesses[index].pid = 0;
-                    MCeerror->add
-                    (EE_SHELL_BADCOMMAND, 0, 0, p_filename);
-                    // SN-2015-01-29: [[ Bug 14462 ]] Should return false, not true
-                    return false;
-                }
             }
             else
             {
+				MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
                 close(tochild[0]);
                 close(tochild[1]);
-                MCeerror->add
-                (EE_SHELL_BADCOMMAND, 0, 0, p_filename);
                 // SN-2015-01-29: [[ Bug 14462 ]] Should return false, not true
                 return false;
             }
         }
         else
         {
-            MCeerror->add
-            (EE_SHELL_BADCOMMAND, 0, 0, p_filename);
+			MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
             // SN-2015-01-29: [[ Bug 14462 ]] Should return false, not true
             return false;
         }

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -29,6 +29,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "exec.h"
 #include "util.h"
 #include "uidc.h"
+#include "mcerror.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -731,13 +732,13 @@ void MCFilesEvalShell(MCExecContext& ctxt, MCStringRef p_command, MCStringRef& r
 {
 	if (MCsecuremode & MC_SECUREMODE_PROCESS)
 	{
-		ctxt . LegacyThrow(EE_SHELL_NOPERM);
+		MCeerror->add(EE_SHELL_NOPERM, 0, 0, p_command);
 		return;
 	}
 
 	if (MCS_runcmd(p_command, r_output) != IO_NORMAL)
 	{
-		ctxt . LegacyThrow(EE_SHELL_BADCOMMAND);
+		MCeerror->add(EE_SHELL_BADCOMMAND, 0, 0, p_command);
 		return;
 	}
 }

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -733,12 +733,14 @@ void MCFilesEvalShell(MCExecContext& ctxt, MCStringRef p_command, MCStringRef& r
 	if (MCsecuremode & MC_SECUREMODE_PROCESS)
 	{
 		MCeerror->add(EE_SHELL_NOPERM, 0, 0, p_command);
+		ctxt . Throw();
 		return;
 	}
 
 	if (MCS_runcmd(p_command, r_output) != IO_NORMAL)
 	{
 		MCeerror->add(EE_SHELL_BADCOMMAND, 0, 0, p_command);
+		ctxt . Throw();
 		return;
 	}
 }

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2644,6 +2644,9 @@ enum Exec_errors
     
     // {EE-0866} MCInternalPayloadPatch: error in base item expression
     EE_INTERNAL_BASE_BADITEM,
+
+    // {EE-0867} System error
+    EE_SYSTEM,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2645,8 +2645,14 @@ enum Exec_errors
     // {EE-0866} MCInternalPayloadPatch: error in base item expression
     EE_INTERNAL_BASE_BADITEM,
 
-    // {EE-0867} System error
-    EE_SYSTEM,
+    // {EE-0867} System error: function
+    EE_SYSTEM_FUNCTION,
+
+    // {EE-0867} System error: code
+    EE_SYSTEM_CODE,
+
+    // {EE-0867} System error: message
+    EE_SYSTEM_MESSAGE,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/lnxspec.cpp
+++ b/engine/src/lnxspec.cpp
@@ -1023,7 +1023,9 @@ IO_stat MCS_runcmd(MCExecPoint &ep)
 			}
 			if (MCprocesses[index].pid == -1)
 			{
-				MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
+				MCeerror->add(EE_SYSTEM_FUNCTION, 0, 0, "fork");
+				MCeerror->add(EE_SYSTEM_CODE, 0, 0, errno);
+				MCeerror->add(EE_SYSTEM_MESSAGE, 0, 0, strerror(errno));
 				close(tochild[0]);
 				close(tochild[1]);
 				close(toparent[0]);
@@ -1043,7 +1045,9 @@ IO_stat MCS_runcmd(MCExecPoint &ep)
 		}
 		else
 		{
-			MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
+			MCeerror->add(EE_SYSTEM_FUNCTION, 0, 0, "pipe");
+			MCeerror->add(EE_SYSTEM_CODE, 0, 0, errno);
+			MCeerror->add(EE_SYSTEM_MESSAGE, 0, 0, strerror(errno));
 			close(tochild[0]);
 			close(tochild[1]);
 			return IO_ERROR;
@@ -1051,7 +1055,9 @@ IO_stat MCS_runcmd(MCExecPoint &ep)
 	}
 	else
 	{
-		MCeerror->add(EE_SYSTEM, 0, 0, strerror(errno));
+		MCeerror->add(EE_SYSTEM_FUNCTION, 0, 0, "pipe");
+		MCeerror->add(EE_SYSTEM_CODE, 0, 0, errno);
+		MCeerror->add(EE_SYSTEM_MESSAGE, 0, 0, strerror(errno));
 		return IO_ERROR;
 	}
 	char *buffer = ep.getbuffer(0);

--- a/engine/src/lnxspec.cpp
+++ b/engine/src/lnxspec.cpp
@@ -1029,9 +1029,6 @@ IO_stat MCS_runcmd(MCExecPoint &ep)
 				close(toparent[0]);
 				close(toparent[1]);
 
-				if (MCprocesses[index].pid > 0)
-					MCS_kill(MCprocesses[index].pid, SIGKILL);
-
 				MCprocesses[index].pid = 0;
 				return IO_ERROR;
 			}


### PR DESCRIPTION
When a `shell` command fails there are several system calls that could have failed and there's no indication in the error message which one actually failed, so I've added the system error to the error stack.

(There was also a leak of the `toparent[1]` file handle in the case of an error, which I've fixed.)
