### PR TITLE
[[ Bug 15314 ]] Initialise to empty the secure socket hostname verificat...

### DIFF
--- a/docs/notes/bugfix-15314.md
+++ b/docs/notes/bugfix-15314.md
@@ -1,0 +1,1 @@
+# "secure socket" crashes livecode

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -5404,8 +5404,9 @@ void MCSecure::exec_ctxt(MCExecContext& ctxt)
         return;
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added passing through the host name to verify against.
+    // SN-2015-05-05: [[ Bug 15314 ]] The host name should be initialised.
 	MCNewAutoNameRef t_host_name;
-    if (!ctxt . EvalOptionalExprAsNullableNameRef(m_verify_host_name, EE_SECURE_BADHOST, &t_host_name))
+    if (!ctxt . EvalOptionalExprAsNameRef(m_verify_host_name, kMCEmptyName, EE_SECURE_BADHOST, &t_host_name))
         return;
 
     MCSecurityExecSecureSocket(ctxt, *t_name, secureverify == True, *t_host_name);


### PR DESCRIPTION
...ion, if none provided
