### PR TITLE
[[ Bug 15326 ]] Compiler fails with large dependency hierarchies.

### DIFF
--- a/toolchain/lc-compile/src/LEXFUNC.b
+++ b/toolchain/lc-compile/src/LEXFUNC.b
@@ -1,5 +1,12 @@
+static FILE *s_current_stream = NULL;
 void yynextfile(FILE *stream)
 {
     yy_delete_buffer(YY_CURRENT_BUFFER);
+
+    if (s_current_stream != NULL)
+        fclose(s_current_stream);
+        
+    s_current_stream = stream;
+
     yy_switch_to_buffer(yy_create_buffer(stream, YY_BUF_SIZE));
 }

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -196,12 +196,25 @@ void FinalizeFiles(void)
 {
 }
 
+int FileAlreadyAdded(const char *p_filename)
+{
+    FileRef t_file;
+    for(t_file = s_files; t_file != NULL; t_file = t_file -> next)
+        if (strcmp(t_file -> path, p_filename) == 0)
+            return 1;
+
+    return 0;
+}
+
 void AddFile(const char *p_filename)
 {	
 	FileRef t_new_file;
 	FileRef *t_last_file_ptr;
 	const char *t_name;
 
+    if (FileAlreadyAdded(p_filename))
+        return;
+    
     t_new_file = (FileRef)calloc(sizeof(struct File), 1);
     if (t_new_file == NULL)
         Fatal_OutOfMemory();


### PR DESCRIPTION
The lc-compile command now only loads a module interface file once per session.

The lc-compile command now closes file handles properly inbetween moving between source files.
