### PR TITLE
[[ Bug 15325 ]] Compiler crash with "exit repeat" outside "repeat"

### DIFF
--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -43,6 +43,9 @@
 
         -- Check that suitable identifiers are used in definitions
         CheckIdentifiers(Module)
+        
+        -- Check that repeat-specific commands are appropriate
+        CheckRepeats(Module, 0)
 
 --------------------------------------------------------------------------------
 
@@ -1700,6 +1703,42 @@
             IsNameSuitableForDefinition(Name)
         ||
             Warning_UnsuitableNameForDefinition(Position, Name)
+        |)
+
+--------------------------------------------------------------------------------
+
+'sweep' CheckRepeats(ANY, INT)
+
+    'rule' CheckRepeats(repeatforever(_, Body), Depth):
+        CheckRepeats(Body, Depth + 1)
+
+    'rule' CheckRepeats(repeatcounted(_, _, Body), Depth):
+        CheckRepeats(Body, Depth + 1)
+
+    'rule' CheckRepeats(repeatwhile(_, _, Body), Depth):
+        CheckRepeats(Body, Depth + 1)
+        
+    'rule' CheckRepeats(repeatuntil(_, _, Body), Depth):
+        CheckRepeats(Body, Depth + 1)
+
+    'rule' CheckRepeats(repeatupto(_, _, _, _, _, Body), Depth):
+        CheckRepeats(Body, Depth + 1)
+
+    'rule' CheckRepeats(repeatforeach(_, _, _, Body), Depth):
+        CheckRepeats(Body, Depth + 1)
+        
+    'rule' CheckRepeats(nextrepeat(Position), Depth):
+        (|
+            gt(Depth, 0)
+        ||
+            Error_NextRepeatOutOfContext(Position)
+        |)
+
+    'rule' CheckRepeats(exitrepeat(Position), Depth):
+        (|
+            gt(Depth, 0)
+        ||
+            Error_ExitRepeatOutOfContext(Position)
         |)
 
 --------------------------------------------------------------------------------

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -248,6 +248,9 @@ DEFINE_ERROR_I(HandlerNotSuitableForPropertySetter, "'%s' has inappropriate sign
 
 DEFINE_ERROR_S(UnsuitableStringForKeyword, "Keyword '%s' is ambiguous with identifiers")
 
+DEFINE_ERROR(NextRepeatOutOfContext, "'next repeat' must appear within a repeat")
+DEFINE_ERROR(ExitRepeatOutOfContext, "'exit repeat' must appear within a repeat")
+
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(long p_position) { _Warning(p_position, Message); }
 #define DEFINE_WARNING_I(Name, Message) \

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -301,6 +301,8 @@
     Error_HandlerNotSuitableForPropertyGetter
     Error_HandlerNotSuitableForPropertySetter
     Error_UnsuitableStringForKeyword
+    Error_NextRepeatOutOfContext
+    Error_ExitRepeatOutOfContext
     Warning_DeprecatedTypeName
     Warning_UnsuitableNameForDefinition
     Warning_UsingAsForHandlerReturnTypeDeprecated
@@ -661,6 +663,9 @@
 'action' Error_HandlerNotSuitableForPropertySetter(Position: POS, Identifier: NAME)
 
 'action' Error_UnsuitableStringForKeyword(Position: POS, Token: STRING)
+
+'action' Error_NextRepeatOutOfContext(Position: POS)
+'action' Error_ExitRepeatOutOfContext(Position: POS)
 
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)
 'action' Warning_UnsuitableNameForDefinition(Position: POS, Identifier: NAME)


### PR DESCRIPTION
The compiler now checks that the placement of next and exit repeat statements are appropriate during the check phase.
