### PR TITLE
[[ Bug 15190 ]] 'repeat down to' doesn't execute body

### DIFF
--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -199,7 +199,7 @@ bool MCScriptInitialize(void)
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("limit"), t_double_type_def);
         MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
-        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatDownToCondition"), t_type_index, MCSTR("MCScriptBuiltinRepeatUpToCondition"), t_def_index);
+        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatDownToCondition"), t_type_index, MCSTR("MCScriptBuiltinRepeatDownToCondition"), t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);


### PR DESCRIPTION
The 'RepeatDownToCondition' builtin primitive was incorrectly mapped to 'RepeatUpToCondition'.
