### PR TITLE
[[ Bug 15189 ]] LCB constants cannot be negative

### DIFF
--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -434,15 +434,42 @@
 'condition' IsExpressionSimpleConstant(EXPRESSION)
 
     'rule' IsExpressionSimpleConstant(undefined(_)):
+
     'rule' IsExpressionSimpleConstant(true(_)):
+
     'rule' IsExpressionSimpleConstant(false(_)):
+
     'rule' IsExpressionSimpleConstant(unsignedinteger(_, _)):
+
     'rule' IsExpressionSimpleConstant(integer(_, _)):
+
     'rule' IsExpressionSimpleConstant(real(_, _)):
+
     'rule' IsExpressionSimpleConstant(string(_, _)):
+
     'rule' IsExpressionSimpleConstant(list(_, List)):
         IsExpressionListSimpleConstant(List)
-        
+
+    'rule' IsExpressionSimpleConstant(invoke(Position, invokelist(Info, nil), expressionlist(Operand, nil))):
+        Info'Name -> SyntaxName
+        (|
+            eq(SyntaxName, "PlusUnaryOperator")
+        ||
+            eq(SyntaxName, "MinusUnaryOperator")
+        |)
+        (|
+            where(Operand -> integer(_, _))
+        ||
+            where(Operand -> unsignedinteger(_, UIntValue))
+            (|
+                ge(UIntValue, 0)
+            ||
+                Error_IntegerLiteralOutOfRange(Position)
+            |)
+        ||
+            where(Operand -> real(_, _))
+        |)
+
 'condition' IsExpressionListSimpleConstant(EXPRESSIONLIST)
 
     'rule' IsExpressionListSimpleConstant(expressionlist(Head, Tail)):

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1734,6 +1734,27 @@
         EmitListConstant(Indicies)
         EmitEndListConstant(-> Index)
 
+    'rule' EmitConstant(invoke(_, invokelist(Info, nil), expressionlist(Operand, nil)) -> Index)
+        Info'Name -> SyntaxName
+        (|
+            eq(SyntaxName, "PlusUnaryOperator")
+            EmitConstant(Operand -> Index)
+        ||
+            eq(SyntaxName, "MinusUnaryOperator")
+            (|
+                where(Operand -> integer(_, IntValue))
+                EmitIntegerConstant(-IntValue -> Index)
+            ||
+                where(Operand -> unsignedinteger(_, UIntValue))
+                EmitIntegerConstant(-UIntValue -> Index)
+            ||
+                where(Operand -> real(_, RealValue))
+                NegateReal(RealValue -> MinusRealValue)
+                EmitRealConstant(MinusRealValue -> Index)
+            |)
+        |)
+
+
 'action' EmitListConstantElements(EXPRESSIONLIST -> INTLIST)
 
     'rule' EmitListConstantElements(expressionlist(Head, Tail) -> intlist(Index, Rest)):

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -301,6 +301,7 @@
     Error_HandlerNotSuitableForPropertyGetter
     Error_HandlerNotSuitableForPropertySetter
     Error_UnsuitableStringForKeyword
+    Error_IntegerLiteralOutOfRange
     Warning_DeprecatedTypeName
     Warning_UnsuitableNameForDefinition
     Warning_UsingAsForHandlerReturnTypeDeprecated
@@ -661,6 +662,8 @@
 'action' Error_HandlerNotSuitableForPropertySetter(Position: POS, Identifier: NAME)
 
 'action' Error_UnsuitableStringForKeyword(Position: POS, Token: STRING)
+
+'action' Error_IntegerLiteralOutOfRange(Position: POS)
 
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)
 'action' Warning_UnsuitableNameForDefinition(Position: POS, Identifier: NAME)


### PR DESCRIPTION
The check for 'simple constant expressions' now special cases Unary Plus/Minus Operator syntax so that clauses such as the following work:
    constant kFoo = -1234
