### PR TITLE
lc-run: Print backtrace from uncaught errors.

### DIFF
--- a/toolchain/lc-compile/src/lc-run.cpp
+++ b/toolchain/lc-compile/src/lc-run.cpp
@@ -108,9 +108,27 @@ MCRunHandlerError (void)
 	MCErrorRef t_error;
 
 	if (MCErrorCatch (t_error))
+	{
 		t_reason = MCErrorGetMessage (t_error);
+
+		/* Print stack trace */
+		uindex_t t_num_frames = MCErrorGetDepth (t_error);
+		for (uindex_t t_depth = 0; t_depth < t_num_frames; ++t_depth)
+		{
+			MCAutoStringRef t_frame;
+			/* UNCHECKED */ MCStringFormat (&t_frame,
+			                                "#%u\tat %@:%u:%u\n",
+			                                t_depth,
+			                                MCErrorGetTargetAtLevel (t_error, t_depth),
+			                                MCErrorGetRowAtLevel (t_error, t_depth),
+			                                MCErrorGetColumnAtLevel (t_error, t_depth));
+			MCRunPrintMessage (stderr, *t_frame);
+		}
+	}
 	else
+	{
 		/* UNCHECKED */ MCStringCopy (MCSTR("Unknown error"), &t_reason);
+	}
 
 	/* UNCHECKED */ MCStringFormat (&t_message,
 	                                "ERROR: Uncaught error: %@\n",


### PR DESCRIPTION
Output looks something like:

```
#0  at json.lcb:135:1
#1  at github.lcb:266:1
#2  at github.lcb:364:1
#3  at pullrequest.lcb:247:1
#4  at pullrequest.lcb:255:1
#5  at pullrequest.lcb:347:1
#6  at vulcan-comment.lcb:112:1
#7  at vulcan-comment.lcb:168:1
#8  at vulcan-review.lcb:234:1
#9  at vulcan-review.lcb:330:1
#10 at vulcan-review.lcb:385:1
#11 at vulcan.lcb:551:1
#12 at vulcan.lcb:58:1
ERROR: Uncaught error: needle must be a single char
```

Needless to say, this makes debugging large pure-LCB applications a lot easier.
