### PR TITLE
[[ Bug 14466 ]] 'read from socket until empty' doesn't necessarily re…

### DIFF
--- a/engine/src/w32dce.cpp
+++ b/engine/src/w32dce.cpp
@@ -577,6 +577,13 @@ Boolean MCScreenDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 			abort = True;
 			break;
 		}
+        
+        if (MCS_handle_sockets())
+        {
+            if (anyevent)
+                done = True;
+            waittime = 0.0;
+        }
 
 		if ((dispatch && MCEventQueueDispatch() ||
 			handle(waittime, dispatch, anyevent, abort, reset) ||


### PR DESCRIPTION
…turn pending data

The MCS_read_socket() primitive will now MCS_handle_sockets() before it processes socket data to ensure that the socket state is in sync with the system socket state.

On Windows, MCS_handle_sockets() forces all WM_USER events sent to sockethwnd to be dispatched; whilst on other platforms it forces a 0ms select on all the socket handles.
