### PR TITLE
Refactor syntax mc string get c string removal

### DIFF
--- a/engine/src/deploy_windows.cpp
+++ b/engine/src/deploy_windows.cpp
@@ -1111,7 +1111,11 @@ static bool add_version_info_entry(void *p_context, MCArrayRef p_array, MCNameRe
 		t_bytes[t_byte_count - 2] = '\0';
 		t_bytes[t_byte_count - 1] = '\0';	 
 	}
-	return MCWindowsVersionInfoAdd((MCWindowsVersionInfo *)p_context, MCNameGetCString(p_key), true, t_bytes, t_byte_count, t_string);
+
+	// SN-2015-05-14: [[ MCStringGetCString Removal ]] Use ConvertToCString
+	MCAutoStringRefAsCString t_key_as_cstring;
+	/* UNCHECKED */ t_key_as_cstring . Lock(MCNameGetString(p_key));
+	return MCWindowsVersionInfoAdd((MCWindowsVersionInfo *)p_context, *t_key_as_cstring, true, t_bytes, t_byte_count, t_string);
 }
 
 static bool MCWindowsResourcesAddVersionInfo(MCWindowsResources& self, MCArrayRef p_info)

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -6842,7 +6842,12 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         
         // SN-2014-12-09: [[ Bug 14001 ]] Update the module loading for Mac server
 #ifdef _SERVER
-        return (MCSysModuleHandle)dlsym(p_module, MCStringGetCString(p_symbol));
+        // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use AutoStringRefAsCString
+        MCAutoStringRefAsCString t_symbol_as_cstring;
+        if (t_symbol_as_cstring . Lock(p_symbol))
+            return (MCSysModuleHandle)dlsym(p_module, *t_symbol_as_cstring);
+        else
+            return NULL;
 #else
         CFStringRef t_cf_symbol;
        

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1968,13 +1968,19 @@ void MCEngineDoEvalUuid(MCExecContext& ctxt, MCStringRef p_namespace_id, MCStrin
         return;
     }
     
-    if (p_is_md5)
-        MCUuidGenerateMD5(t_namespace, MCStringGetOldString(p_name), t_uuid);
-    else
-        MCUuidGenerateSHA1(t_namespace, MCStringGetOldString(p_name), t_uuid);
+    // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use an AutoStringRefAsCString
+    MCAutoStringRefAsCString t_cstring_name;
     
-    if (MCEngineUuidToStringRef(t_uuid, r_uuid))
-        return;
+    if (t_cstring_name . Lock(p_name))
+    {
+        if (p_is_md5)
+            MCUuidGenerateMD5(t_namespace, *t_cstring_name, t_uuid);
+        else
+            MCUuidGenerateSHA1(t_namespace, *t_cstring_name, t_uuid);
+        
+        if (MCEngineUuidToStringRef(t_uuid, r_uuid))
+            return;
+    }
     
     ctxt . Throw();
 }

--- a/engine/src/exec-nativecontrol.cpp
+++ b/engine/src/exec-nativecontrol.cpp
@@ -50,13 +50,24 @@ MC_EXEC_DEFINE_GET_METHOD(NativeControl, ControlList, 1)
 
 //////////
 
-static bool MCParseRGBA(const MCString &p_data, bool p_require_alpha, uint1 &r_red, uint1 &r_green, uint1 &r_blue, uint1 &r_alpha)
+// SN-2015-05-18: [[ MCStringGetCString Removal ]] Update MCParseRGBA signature
+static bool MCParseRGBA(MCStringRef p_data, bool p_require_alpha, uint1 &r_red, uint1 &r_green, uint1 &r_blue, uint1 &r_alpha)
 {
 	bool t_success = true;
 	Boolean t_parsed;
 	uint2 r, g, b, a;
-	const char *t_data = p_data.getstring();
-	uint32_t l = p_data.getlength();
+    // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use AutoStringRefAsCString
+    MCAutoStringRefAsCString t_data_as_cstring;
+    t_success = t_data_as_cstring . Lock(p_data);
+    const char *t_data;
+    uint32_t l;
+    
+    if (t_success)
+    {
+        t_data = *t_data_as_cstring;
+        l = (uint32_t)strlen(*t_data_as_cstring);
+    }
+    
 	if (t_success)
 	{
 		r = MCU_max(0, MCU_min(255, MCU_strtol(t_data, l, ',', t_parsed)));
@@ -98,7 +109,8 @@ void MCNativeControlColorParse(MCExecContext& ctxt, MCStringRef p_input, MCNativ
 {
     uint8_t t_r8, t_g8, t_b8, t_a8;
     MCColor t_color;
-    if (MCParseRGBA(MCStringGetOldString(p_input), false, t_r8, t_g8, t_b8, t_a8))
+    // SN-2015-05-18: [[ MCStringGetCString Removal ]] Update MCParseRGBA signature
+    if (MCParseRGBA(p_input, false, t_r8, t_g8, t_b8, t_a8))
     {
         r_output . r = (t_r8 << 8) | t_r8;
         r_output . g = (t_g8 << 8) | t_g8;

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -442,7 +442,7 @@ void MCNetworkExecUnloadUrl(MCExecContext& ctxt, MCStringRef p_url)
 void MCNetworkExecPostToUrl(MCExecContext& ctxt, MCValueRef p_data, MCStringRef p_url)
 // SJT-2014-09-11: [[ URLMessages ]] Send "postURL" messages on all platforms.
 {
-	if (MCU_couldbeurl(MCStringGetOldString(p_url)))
+	if (MCU_couldbeurl(p_url))
 	{
 		MCAutoDataRef t_data;
 
@@ -511,7 +511,7 @@ void MCNetworkExecDeleteUrl(MCExecContext& ctxt, MCStringRef p_target)
 		MCStringCopySubstring(p_target, MCRangeMake(8, MCStringGetLength(p_target)-8), &t_filename);
 		MCS_saveresfile(*t_filename, kMCEmptyData);
 	}
-	else if (MCU_couldbeurl(MCStringGetOldString(p_target)))
+	else if (MCU_couldbeurl(p_target))
 	{
 		// Send "deleteURL" message
 		Boolean oldlock = MClockmessages;

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -558,9 +558,17 @@ static char *eval_expr(const char *arg1, const char *arg2,
 	}
 	
 	MCAutoStringRef t_return;
-	/* UNCHECKED */ MCECptr->ConvertToString(*t_result, &t_return);
-	*retval = xresSucc;
-	return MCStringGetOldString(*t_return).clone();
+    char *t_cstring_return;
+    t_cstring_return = NULL;
+    
+    // SN-2015-05-18: [[ MCStringGetCString Removal ]] Convert to CString
+    if (MCECptr->ConvertToString(*t_result, &t_return)
+            && MCStringConvertToCString(*t_return, t_cstring_return))
+        *retval = xresSucc;
+    else
+        *retval = xresFail;
+    
+	return t_cstring_return;
 }
 
 static char *get_global(const char *arg1, const char *arg2,

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -737,9 +737,14 @@ bool MCStringToInteger(MCStringRef p_string, integer_t& r_integer)
 	t_end = nil;
 	
 	integer_t t_value;
-	t_value = strtol(MCStringGetCString(p_string), &t_end, 10);
+	// SN-2015-05-14: [[ MCStringGetCString Removal ]] Use ConvertToCString
+	MCAutoPointer<char> t_cstring;
+	if (!MCStringConvertToCString(p_string, &t_cstring))
+		return false;
+
+	t_value = strtol(*t_cstring, &t_end, 10);
 	
-	if (t_end != MCStringGetCString(p_string) + strlen(MCStringGetCString(p_string)))
+	if (t_end != *t_cstring + strlen(*t_cstring))
 		return false;
 	
 	r_integer = t_value;
@@ -1158,10 +1163,11 @@ bool MCNameClone(MCNameRef p_name, MCNameRef& r_new_name)
 	return true;
 }
 
-const char *MCNameGetCString(MCNameRef p_name)
-{
-	return MCStringGetCString(MCNameGetString(p_name));
-}
+// SN-2015-05-14: [[ MCStringGetCString Removal ]] End of the super-evil function
+//const char *MCNameGetCString(MCNameRef p_name)
+//{
+//	return MCStringGetCString(MCNameGetString(p_name));
+//}
 
 MCString MCNameGetOldString(MCNameRef p_name)
 {
@@ -1310,8 +1316,13 @@ static uint32_t measure_array_entry(MCNameRef p_key, MCValueRef p_value)
 	//   4 bytes - length not including identifier byte
 	//   * bytes - C string of key
 
+	// SN-2015-05-14: [[ MCStringGetCString ]] Use ConvertToCString
+	MCAutoPointer<char> t_key_as_cstring;
 	uint32_t t_size;
-	t_size = 1 + 4 + MCCStringLength(MCStringGetCString(MCNameGetString(p_key))) + 1;
+
+	/* UNCHECKED */ MCStringConvertToCString(MCNameGetString(p_key), &t_key_as_cstring);
+	t_size = 1 + 4 + strlen(*t_key_as_cstring) + 1;
+
 	switch(MCValueGetTypeCode(p_value))
 	{
 	case kMCValueTypeCodeNull:

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -1298,10 +1298,10 @@ static uint32_t measure_array_entry(MCNameRef p_key, MCValueRef p_value)
 	//   * bytes - C string of key
 
 	// SN-2015-05-14: [[ MCStringGetCString ]] Use ConvertToCString
-	MCAutoPointer<char> t_key_as_cstring;
+	MCAutoStringRefAsCString t_key_as_cstring;
 	uint32_t t_size;
 
-	/* UNCHECKED */ MCStringConvertToCString(MCNameGetString(p_key), &t_key_as_cstring);
+	/* UNCHECKED */t_key_as_cstring . Lock(MCNameGetString(p_key));
 	t_size = 1 + 4 + strlen(*t_key_as_cstring) + 1;
 
 	switch(MCValueGetTypeCode(p_value))

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -718,14 +718,6 @@ bool MCStringCreateWithOldString(const MCString& p_old_string, MCStringRef& r_st
 	return MCStringCreateWithNativeChars((const char_t *)p_old_string . getstring(), p_old_string . getlength(), r_string);
 }
 
-MCString MCStringGetOldString(MCStringRef p_string)
-{
-    if (!MCStringIsNative(p_string))
-        MCStringNativize(p_string);
-    
-    return MCString((const char *)MCStringGetNativeCharPtr(p_string), MCStringGetLength(p_string));
-}
-
 bool MCStringIsEqualToOldString(MCStringRef p_string, const MCString& p_oldstring, MCCompareOptions p_options)
 {
 	return MCStringIsEqualToNativeChars(p_string, (const char_t *)p_oldstring . getstring(), p_oldstring . getlength(), p_options);
@@ -738,8 +730,8 @@ bool MCStringToInteger(MCStringRef p_string, integer_t& r_integer)
 	
 	integer_t t_value;
 	// SN-2015-05-14: [[ MCStringGetCString Removal ]] Use ConvertToCString
-	MCAutoPointer<char> t_cstring;
-	if (!MCStringConvertToCString(p_string, &t_cstring))
+	MCAutoStringRefAsCString t_cstring;
+    if (!t_cstring . Lock(p_string))
 		return false;
 
 	t_value = strtol(*t_cstring, &t_end, 10);
@@ -1161,17 +1153,6 @@ bool MCNameClone(MCNameRef p_name, MCNameRef& r_new_name)
 	r_new_name = p_name;
 	MCValueRetain(p_name);
 	return true;
-}
-
-// SN-2015-05-14: [[ MCStringGetCString Removal ]] End of the super-evil function
-//const char *MCNameGetCString(MCNameRef p_name)
-//{
-//	return MCStringGetCString(MCNameGetString(p_name));
-//}
-
-MCString MCNameGetOldString(MCNameRef p_name)
-{
-	return MCStringGetOldString(MCNameGetString(p_name));
 }
 
 bool MCNameGetAsIndex(MCNameRef p_name, index_t& r_index)

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -84,7 +84,8 @@ bool MCNameClone(MCNameRef name, MCNameRef& r_new_name);
 
 bool MCNameGetAsIndex(MCNameRef name, index_t& r_index);
 
-const char *MCNameGetCString(MCNameRef name);
+// SN-2015-05-14: [[ MCStringGetCString Removal ]] End of the super-evil function
+//const char *MCNameGetCString(MCNameRef name);
 MCString MCNameGetOldString(MCNameRef name);
 char MCNameGetCharAtIndex(MCNameRef name, uindex_t at);
 

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -38,7 +38,6 @@ bool MCValueConvertToStringForSave(MCValueRef value, MCStringRef& r_string);
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCStringCreateWithOldString(const MCString&, MCStringRef &r_string);
-MCString MCStringGetOldString(MCStringRef p_string);
 bool MCStringIsEqualToOldString(MCStringRef string, const MCString& oldstring, MCCompareOptions options);
 
 // Attempt to interpret the given string as a base-10 integer. It returns false
@@ -84,9 +83,6 @@ bool MCNameClone(MCNameRef name, MCNameRef& r_new_name);
 
 bool MCNameGetAsIndex(MCNameRef name, index_t& r_index);
 
-// SN-2015-05-14: [[ MCStringGetCString Removal ]] End of the super-evil function
-//const char *MCNameGetCString(MCNameRef name);
-MCString MCNameGetOldString(MCNameRef name);
 char MCNameGetCharAtIndex(MCNameRef name, uindex_t at);
 
 bool MCNameIsEqualTo(MCNameRef left, MCNameRef right, MCCompareOptions options);

--- a/engine/src/mac-qt-recorder.mm
+++ b/engine/src/mac-qt-recorder.mm
@@ -192,16 +192,17 @@ static SampleDescriptionHandle scanSoundTracks(Movie tmovie)
 static bool path_to_dataref(MCStringRef p_path, DataReferenceRecord& r_rec)
 {
 	bool t_success = true;
-	CFStringRef t_cf_path = NULL;
-	t_cf_path = CFStringCreateWithCString(NULL, MCStringGetCString(p_path), kCFStringEncodingWindowsLatin1);
-	t_success = (t_cf_path != NULL);
+    // SN-2015-05-15: [[ MCStringGetCString Removal ]] Use AutoStringRefAsCFStringRef
+    MCAutoStringRefAsCFString t_cf_path;
+    t_success = t_cf_path . Lock(p_path);
+    
 	if (t_success)
 	{
 		OSErr t_error;
-		t_error = QTNewDataReferenceFromFullPathCFString(t_cf_path, kQTNativeDefaultPathStyle, 0, &r_rec . dataRef, &r_rec . dataRefType);
+		t_error = QTNewDataReferenceFromFullPathCFString(*t_cf_path, kQTNativeDefaultPathStyle, 0, &r_rec . dataRef, &r_rec . dataRefType);
 		t_success = noErr == t_error;
 	}
-	CFRelease(t_cf_path);
+
 	return t_success;
 }
 

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -2323,8 +2323,9 @@ Exec_stat MCHandleAdCreate(void *context, MCParameter *p_parameters)
     
     if (t_success)
     {
+        // SN-2015-05-18: [[ MCStringGetCtring Removal ]] Use MCU_stoui4x2
         if (MCParseParameters(p_parameters, "x", &(&t_topleft_string)))
-            /* UNCHECKED */ sscanf(MCStringGetCString(*t_topleft_string), "%u,%u", &t_topleft.x, &t_topleft.y);
+            t_success = MCU_stoui4x2(*t_topleft_string, t_topleft.x, t_topleft.y);
     }
     
     MCAutoArrayRef t_metadata;

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -1216,7 +1216,8 @@ static void MCIPhoneDoDidBecomeActive(void *)
 		
 		if (MCValueGetTypeCode(MCresult -> getvalueref()) == kMCValueTypeCodeString)
 		{
-			NSLog(@"Startup error: %s\n", MCStringGetCString((MCStringRef)MCresult -> getvalueref()));
+            // SN0-2015-05-18: [[ MCStringGetCString Removal ]] Use %@ format
+			NSLog(@"Startup error: %@\n", ((MCStringRef)MCresult -> getvalueref()));
 			abort();
 			return;
 		}

--- a/engine/src/mblspec.cpp
+++ b/engine/src/mblspec.cpp
@@ -508,8 +508,10 @@ static bool MCS_posturl_callback(void *p_context, MCSystemUrlStatus p_status, co
 	if (p_status == kMCSystemUrlStatusError)
     {
         MCAutoDataRef t_err;
-        MCDataCreateWithBytes((const byte_t *)MCStringGetCString((MCStringRef)p_data), MCStringGetLength((MCStringRef)p_data), &t_err);
-		MCValueAssign(context -> data, *t_err);
+        // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use string <-> data
+        //  conversion function.
+        if (MCStringEncode((MCStringRef)p_data, kMCStringEncodingASCII, false, &t_err))
+            MCValueAssign(context -> data, *t_err);
     }
 	else if (p_status == kMCSystemUrlStatusLoading)
     {

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1495,17 +1495,17 @@ LONG WINAPI unhandled_exception_filter(struct _EXCEPTION_POINTERS *p_exception_i
 		t_write_minidump = (MiniDumpWriteDumpPtr)GetProcAddress(t_dbg_help_module, "MiniDumpWriteDump");
 
 	// SN-2015-05-14: [[ MCStringGetCString Removal ]] Update to WCHAR
-	WCHAR *t_path = NULL;
+	MCAutoStringRefAsWString t_path;
 	MCAutoStringRef t_resolved_path;
 	if (t_write_minidump != NULL)
 		// SN-2015-05-14: [[ MCStringGetCString Removal ]] We don't want to
 		//  change the value in MCcrashreportfilename.
 		if (MCS_resolvepath(MCcrashreportfilename, &t_resolved_path))
-			MCStringConvertToWString(*t_resolved_path, t_path);
+			/* UNCHECKED */ t_path . Lock(*t_resolved_path);
 
 	HANDLE t_file = NULL;
-	if (t_path != NULL)
-		t_file = CreateFileW(t_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
+	if (*t_path != NULL)
+		t_file = CreateFileW(*t_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
 
 	BOOL t_minidump_written = FALSE;
 	if (t_file != NULL)
@@ -1519,9 +1519,6 @@ LONG WINAPI unhandled_exception_filter(struct _EXCEPTION_POINTERS *p_exception_i
 
 	if (t_file != NULL)
 		CloseHandle(t_file);
-
-	if (t_path != NULL)
-		delete t_path;
 	
 	if (t_dbg_help_module != NULL)
 		FreeLibrary(t_dbg_help_module);

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1494,13 +1494,18 @@ LONG WINAPI unhandled_exception_filter(struct _EXCEPTION_POINTERS *p_exception_i
 	if (t_dbg_help_module != NULL)
 		t_write_minidump = (MiniDumpWriteDumpPtr)GetProcAddress(t_dbg_help_module, "MiniDumpWriteDump");
 
-	char *t_path = NULL;
+	// SN-2015-05-14: [[ MCStringGetCString Removal ]] Update to WCHAR
+	WCHAR *t_path = NULL;
+	MCAutoStringRef t_resolved_path;
 	if (t_write_minidump != NULL)
-		t_path = MCS_resolvepath(MCStringGetCString(MCcrashreportfilename));
+		// SN-2015-05-14: [[ MCStringGetCString Removal ]] We don't want to
+		//  change the value in MCcrashreportfilename.
+		if (MCS_resolvepath(MCcrashreportfilename, &t_resolved_path))
+			MCStringConvertToWString(*t_resolved_path, t_path);
 
 	HANDLE t_file = NULL;
 	if (t_path != NULL)
-		t_file = CreateFileA(t_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
+		t_file = CreateFileW(t_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
 
 	BOOL t_minidump_written = FALSE;
 	if (t_file != NULL)

--- a/engine/src/quicktime.cpp
+++ b/engine/src/quicktime.cpp
@@ -219,8 +219,17 @@ static bool path_to_dataref(MCStringRef p_path, DataReferenceRecord& r_rec)
 {
 	bool t_success = true;
 	CFStringRef t_cf_path = NULL;
-	t_cf_path = CFStringCreateWithCString(NULL, MCStringGetCString(p_path), kCFStringEncodingWindowsLatin1);
-	t_success = (t_cf_path != NULL);
+
+	// SN-2015-05-14: [[ MCStringGetCString Removal ]] Use a UTF-8 string
+	MCAutoStringRefAsUTF8String t_cstring_path;	
+	t_success = t_cstring_path . Lock(p_path);
+
+	if (t_success)
+	{
+		t_cf_path = CFStringCreateWithCString(NULL, *t_cstring_path, kCFStringEncodingUTF8);
+		t_success = (t_cf_path != NULL);
+	}
+
 	if (t_success)
 	{
 		OSErr t_error;

--- a/engine/src/srvcgi.cpp
+++ b/engine/src/srvcgi.cpp
@@ -1527,7 +1527,8 @@ static bool cgi_send_cookies(void)
 	
 	for (uint32_t i = 0; t_success && i < MCservercgicookiecount; i++)
 	{
-		t_success = MCCStringFormat(t_cookie_header, "Set-Cookie: %s=%s", MCservercgicookies[i].name, MCservercgicookies[i].value);
+		// SN-2015-05-18: [[ MCservercgicookies Refactor ]] Now stores StringRefs
+		t_success = MCCStringFormat(t_cookie_header, "Set-Cookie: %@=%@", MCservercgicookies[i].name, MCservercgicookies[i].value);
 		
 		if (t_success && MCservercgicookies[i].expires != 0)
 		{
@@ -1542,11 +1543,12 @@ static bool cgi_send_cookies(void)
 			}
 		}
 		
-		if (t_success && MCservercgicookies[i].path != NULL)
-			t_success = MCCStringAppendFormat(t_cookie_header, "; Path=%s", MCservercgicookies[i].path);
+		// SN-2015-05-18: [[ MCservercgicookies Refactor ]] Now stores StringRefs
+		if (t_success && !MCStringIsEmpty(MCservercgicookies[i].path))
+			t_success = MCCStringAppendFormat(t_cookie_header, "; Path=%@", MCservercgicookies[i].path);
 		
-		if (t_success && MCservercgicookies[i].domain != NULL)
-			t_success = MCCStringAppendFormat(t_cookie_header, "; Domain=%s", MCservercgicookies[i].domain);
+		if (t_success && !MCStringIsEmpty(MCservercgicookies[i].domain))
+			t_success = MCCStringAppendFormat(t_cookie_header, "; Domain=%@", MCservercgicookies[i].domain);
 
 		if (t_success && MCservercgicookies[i].secure)
 			t_success = MCCStringAppend(t_cookie_header, "; Secure");

--- a/engine/src/srvmain.h
+++ b/engine/src/srvmain.h
@@ -37,12 +37,14 @@ extern uint32_t MCsessionlifetime;
 extern char **MCservercgiheaders;
 extern uint32_t MCservercgiheadercount;
 
+// SN-2015-05-18: [[ MCservercgicookies Refactor ]] Update MCServerCookie
+//  to hold StringRefs
 typedef struct mcservercookie_t
 {
-	char *name;
-	char *value;
-	char *path;
-	char *domain;
+	MCStringRef name;
+	MCStringRef value;
+	MCStringRef path;
+	MCStringRef domain;
 	uint32_t expires;
 	bool secure;
 	bool http_only;

--- a/engine/src/srvoutput.cpp
+++ b/engine/src/srvoutput.cpp
@@ -518,10 +518,12 @@ bool MCServerSetCookie(MCStringRef p_name, MCStringRef p_value, uint32_t p_expir
 	if (t_success)
 	{
 		// SN-2015-05-14: [[ MCservercgicookies Refactor ]] Now stores StringRefs
-		MCservercgicookies[t_index].name = MCValueRetain(p_name);
-		MCservercgicookies[t_index].value = MCValueRetain(*t_encoded);
-		MCservercgicookies[t_index].path = MCValueRetain(p_path);
-		MCservercgicookies[t_index].domain = MCValueRetain(p_domain);
+        //  Use MCValueAssign since we can overwrite another value - otherwise,
+        //  will be initialised to NULL by MCMemoryResizeArray
+		MCValueAssign(MCservercgicookies[t_index].name, p_name);
+		MCValueAssign(MCservercgicookies[t_index].value, *t_encoded);
+		MCValueAssign(MCservercgicookies[t_index].path, p_path);
+		MCValueAssign(MCservercgicookies[t_index].domain, p_domain);
 		MCservercgicookies[t_index].expires = p_expires;
 		MCservercgicookies[t_index].secure = p_secure;
 		MCservercgicookies[t_index].http_only = p_http_only;

--- a/engine/src/srvoutput.cpp
+++ b/engine/src/srvoutput.cpp
@@ -432,11 +432,18 @@ void MCServerPutOutput(MCStringRef s)
 
 void MCServerPutHeader(MCStringRef s, bool p_new)
 {
+    // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use AutoStringRefAsCString
+    MCAutoStringRefAsCString t_input_as_cstring;
 	// Find where the ':' is
-	const char *t_loc;
-	t_loc = MCStringGetCString(s);
-	uint4 t_loc_len;
-	t_loc_len = MCStringGetLength(s);
+    const char *t_loc;
+    uint4 t_loc_len;
+    
+    if (!t_input_as_cstring . Lock(s))
+        return;
+
+    t_loc = *t_input_as_cstring;
+    t_loc_len = strlen(*t_input_as_cstring);
+    
 	if (!MCU_strchr(t_loc, t_loc_len, ':', False))
 		return;
 	
@@ -447,7 +454,7 @@ void MCServerPutHeader(MCStringRef s, bool p_new)
 	else
 		for(i = MCservercgiheadercount; i > 0; i--)
 		{
-			if (MCU_strncasecmp(MCStringGetCString(s), MCservercgiheaders[i - 1], t_loc - MCStringGetCString(s)) == 0)
+			if (MCU_strncasecmp(*t_input_as_cstring, MCservercgiheaders[i - 1], t_loc - *t_input_as_cstring) == 0)
 				break;
 		}
 	
@@ -460,7 +467,7 @@ void MCServerPutHeader(MCStringRef s, bool p_new)
 	else
 		free(MCservercgiheaders[i - 1]);
 	
-	MCservercgiheaders[i - 1] = strdup(MCStringGetCString(s));
+	MCservercgiheaders[i - 1] = strdup(*t_input_as_cstring);
 }
 
 void MCServerPutContent(MCStringRef s)
@@ -513,7 +520,7 @@ bool MCServerSetCookie(MCStringRef p_name, MCStringRef p_value, uint32_t p_expir
 		t_success = MCStringConvertToCString(p_name, MCservercgicookies[t_index].name)
 				&& MCStringConvertToCString(*t_encoded, MCservercgicookies[t_index].value)
 				&& MCStringConvertToCString(p_path, MCservercgicookies[t_index].path)
-				&& MCStringConvertToCString(p_domain, MCservercgicookies[t_index].domain;
+				&& MCStringConvertToCString(p_domain, MCservercgicookies[t_index].domain);
 	}
 
 	if (t_success)

--- a/engine/src/srvoutput.cpp
+++ b/engine/src/srvoutput.cpp
@@ -509,11 +509,15 @@ bool MCServerSetCookie(MCStringRef p_name, MCStringRef p_value, uint32_t p_expir
 	
 	if (t_success)
 	{
-        MCservercgicookies[t_index].name = MCStringIsEmpty(p_name) ? strdup("") : strdup(MCStringGetCString(p_name));
-		MCservercgicookies[t_index].value = strdup(MCStringGetCString(*t_encoded));
-        MCservercgicookies[t_index].path = MCStringIsEmpty(p_domain) ? strdup("") : strdup(MCStringGetCString(p_path));
-        MCservercgicookies[t_index].domain = MCStringIsEmpty(p_domain) ? strdup("") : strdup(MCStringGetCString(p_domain));
+		// SN-2015-05-14: [[ MCStringGetCString Removal ]] Use ConvertToCString
+		t_success = MCStringConvertToCString(p_name, MCservercgicookies[t_index].name)
+				&& MCStringConvertToCString(*t_encoded, MCservercgicookies[t_index].value)
+				&& MCStringConvertToCString(p_path, MCservercgicookies[t_index].path)
+				&& MCStringConvertToCString(p_domain, MCservercgicookies[t_index].domain;
+	}
 
+	if (t_success)
+	{
 		MCservercgicookies[t_index].expires = p_expires;
 		MCservercgicookies[t_index].secure = p_secure;
 		MCservercgicookies[t_index].http_only = p_http_only;

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1490,6 +1490,8 @@ Boolean MCUIDC::lookupcolor(MCStringRef s, MCColor *color)
     
     // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use AutoStringRefAsCString
     MCAutoStringRefAsCString t_cstring;
+    if (!t_cstring . Lock(s))
+        return False;
 	MCU_lower(sptr, *t_cstring);
     
 	sptr[slength] = '\0';

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1486,8 +1486,12 @@ Boolean MCUIDC::lookupcolor(MCStringRef s, MCColor *color)
 	uint4 slength = MCStringGetLength(s);
 	MCAutoPointer<char> startptr;
     startptr = new char[slength + 1];
-	char *sptr = *startptr;
-	MCU_lower(sptr, MCStringGetOldString(s));
+    char *sptr = *startptr;
+    
+    // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use AutoStringRefAsCString
+    MCAutoStringRefAsCString t_cstring;
+	MCU_lower(sptr, *t_cstring);
+    
 	sptr[slength] = '\0';
 	if (*sptr == '#')
 	{

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -207,7 +207,7 @@ extern void MCU_dofunc(Functions func, uint4 nparams, real8 &n,
 	                       real8 tn, real8 oldn, MCSortnode *titems);
 // MW-2013-07-01: [[ Bug 10975 ]] This method returns true if the given string could be a url
 //   (as used by MCU_geturl, to determine whether to try and fetch via libUrl).
-extern bool MCU_couldbeurl(const MCString& potential_url);
+extern bool MCU_couldbeurl(MCStringRef potential_url);
 #ifdef LEGACY_EXEC
 extern void MCU_geturl(MCExecPoint &ep);
 #endif

--- a/engine/src/w32printer.cpp
+++ b/engine/src/w32printer.cpp
@@ -2125,7 +2125,11 @@ void MCWindowsPrinter::EncodeSettings(MCStringRef p_name, DEVMODEW* p_devmode, M
 
 	void *t_temp;
 	uint4 t_len;
-	t_dictionary . Set('NMEA', MCStringGetOldString(p_name));
+    // SN-2015-05-18: [[ MCStringGetCString Removal ]] Use AutoStringRefAsCString
+    MCAutoStringRefAsCString t_cstring_name;
+    if (!t_cstring_name . Lock (p_name))
+        return;
+	t_dictionary . Set('NMEA', *t_cstring_name);
 	t_dictionary . Set('W32A', MCString((char *)p_devmode, p_devmode -> dmSize + p_devmode -> dmDriverExtra));
 	t_dictionary . Pickle(t_temp, t_len);
 

--- a/engine/src/w32script.cpp
+++ b/engine/src/w32script.cpp
@@ -595,14 +595,9 @@ void MCWindowsActiveScriptEnvironment::Finalize(void)
 
 void MCWindowsActiveScriptEnvironment::Run(MCStringRef p_script, MCStringRef& r_out)
 {
-	LPOLESTR t_ole_script;
-
 	// SN-2015-05-14: [[ MCStringGetCString ]] Make use of UTF-8 automatic conversion
-	MCAutoStringRefAsUTF8String t_utf8_script;
-	/* UNCHECKED */ t_utf8_script . Lock(p_script);
-	t_ole_script = ConvertUTF8ToOLESTR(*t_utf8_script);
-
-	if (t_ole_script == NULL)
+	MCAutoStringRefAsWString t_script_as_wstring;
+	if (!t_script_as_wstring . Lock(p_script))
 		return;
 
 	EXCEPINFO t_exception = { 0 };
@@ -611,7 +606,7 @@ void MCWindowsActiveScriptEnvironment::Run(MCStringRef p_script, MCStringRef& r_
 	t_result = S_OK;
 
 	if (t_result == S_OK)
-		t_result = m_parser -> ParseScriptText(t_ole_script, NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISVISIBLE, NULL, &t_exception);
+		t_result = m_parser -> ParseScriptText((LPOLESTR)*t_script_as_wstring, NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISVISIBLE, NULL, &t_exception);
 
 	IDispatch *t_lang_dispatch;
 	t_lang_dispatch = NULL;
@@ -670,9 +665,6 @@ void MCWindowsActiveScriptEnvironment::Run(MCStringRef p_script, MCStringRef& r_
 
 	if (t_lang_dispatch != NULL)
 		t_lang_dispatch -> Release();
-
-	if (t_ole_script != NULL)
-		delete t_ole_script;
 
 	// SN-2015-05-14: [[ MCStringGetCString Removal ]] Use appropriately
 	//  UTF-8 encoding - we leave r_out NULL in case of failure

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1422,8 +1422,6 @@ extern MCStringRef kMCTabString;
 // the c-string must be a C static string.
 MCStringRef MCSTR(const char *string);
 
-// SN-2015-05-014: [[ MCStringGetCString Removal ]] End of the evil function.
-//const char *MCStringGetCString(MCStringRef p_string);
 bool MCStringIsEqualToCString(MCStringRef string, const char *cstring, MCStringOptions options);
 
 // Create an immutable string from the given bytes, interpreting them using

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1422,7 +1422,8 @@ extern MCStringRef kMCTabString;
 // the c-string must be a C static string.
 MCStringRef MCSTR(const char *string);
 
-const char *MCStringGetCString(MCStringRef p_string);
+// SN-2015-05-014: [[ MCStringGetCString Removal ]] End of the evil function.
+//const char *MCStringGetCString(MCStringRef p_string);
 bool MCStringIsEqualToCString(MCStringRef string, const char *cstring, MCStringOptions options);
 
 // Create an immutable string from the given bytes, interpreting them using

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1219,6 +1219,10 @@ bool MCValueInterAndRelease(MCValueRef value, MCValueRef& r_unique_value);
 // Fetch the 'extra bytes' field for the given custom value.
 inline void *MCValueGetExtraBytesPtr(MCValueRef value) { return ((uint8_t *)value) + kMCValueCustomHeaderSize; }
 
+// SN-2015-05-26: [[ MCStringGetCString Removal ]] Add new function to debug the
+//  ValueRefs, since MCStringGetCString is gone.
+void MCValueShow(MCValueRef p_value);
+
 //////////
 
 template<typename T> inline T MCValueRetain(T value)

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -178,20 +178,21 @@ bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
     return false;
 }
 
-const char *MCStringGetCString(MCStringRef p_string)
-{
-    if (p_string == nil)
-        return nil;
-    
-    MCStringNativize(p_string);
-    
-	const char *t_cstring;
-	t_cstring = (const char *)MCStringGetNativeCharPtr(p_string);
-	
-	MCAssert(t_cstring != nil);
-    
-	return t_cstring;
-}
+// SN-2015-05-014: [[ MCStringGetCString Removal ]] End of the evil function.
+//const char *MCStringGetCString(MCStringRef p_string)
+//{
+//    if (p_string == nil)
+//        return nil;
+//    
+//    MCStringNativize(p_string);
+//    
+//	const char *t_cstring;
+//	t_cstring = (const char *)MCStringGetNativeCharPtr(p_string);
+//	
+//	MCAssert(t_cstring != nil);
+//    
+//	return t_cstring;
+//}
 
 bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStringOptions p_options)
 {

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -178,22 +178,6 @@ bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
     return false;
 }
 
-// SN-2015-05-014: [[ MCStringGetCString Removal ]] End of the evil function.
-//const char *MCStringGetCString(MCStringRef p_string)
-//{
-//    if (p_string == nil)
-//        return nil;
-//    
-//    MCStringNativize(p_string);
-//    
-//	const char *t_cstring;
-//	t_cstring = (const char *)MCStringGetNativeCharPtr(p_string);
-//	
-//	MCAssert(t_cstring != nil);
-//    
-//	return t_cstring;
-//}
-
 bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStringOptions p_options)
 {
 	return MCStringIsEqualToNativeChars(p_string, (const char_t *)p_cstring, strlen(p_cstring), p_options);

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -272,6 +272,20 @@ bool MCValueInterAndRelease(MCValueRef p_value, MCValueRef& r_unique_value)
 	return __MCValueInter((__MCValue *)p_value, true, r_unique_value);
 }
 
+// SN-2015-05-26: [[ MCStringGetCString Removal ]] Add new function to debug the
+//  ValueRefs, since MCStringGetCString is gone.
+void MCValueShow(MCValueRef p_value)
+{
+    MCStringRef t_description;
+    
+    if (MCValueCopyDescription(p_value, t_description))
+    {
+        MCLog("%@", t_description);
+        MCValueRelease(t_description);
+    }
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // MW-2014-03-21: [[ Faster ]] Memory allocation is relatively slow, therefore


### PR DESCRIPTION
This pull request makes removes MCStringGetCString, the function that causes the parameter string to be nativised.

That comes after a check of its call, and finding out that some calls to `MCStringGetCString(MCNameGetString)` were still present, and we certainly do not want to leave this happening.

That unfortunately does not fix the bug http://quality.runrev.com/show_bug.cgi?id=14635 as I first hoped.

There is no harm to merge this "enhancement" in I suppose though.
