### PR TITLE
[[ Bug 15385 ]] Enqueue the same message for keyDown/keyUp when dead …

### DIFF
--- a/docs/notes/bugfix-15385.md
+++ b/docs/notes/bugfix-15385.md
@@ -1,0 +1,1 @@
+# keyUp on MacOS is sent with wrong value, after a failed dead char combination

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -906,6 +906,10 @@ void MCPlatformHandleTextInputInsertText(MCPlatformWindowRef p_window, unichar_t
         s_pending_key_down -> key_code = (uint1)*p_chars;
         s_pending_key_down -> mapped_codepoint = (uint1)*p_chars;
         s_pending_key_down -> unmapped_codepoint = (uint1)*p_chars;
+        
+        // SN-2015-05-18: [[ Bug 15385 ]] Enqueue the first char in the sequence
+        //  here - that will be the same as keyDown.
+        MCKeyMessageAppend(s_pending_key_up, (uint1)*p_chars, (uint1)*p_chars, (uint1)*p_chars);
     }
     
 	// Set the text.	
@@ -928,9 +932,6 @@ void MCPlatformHandleTextInputInsertText(MCPlatformWindowRef p_window, unichar_t
             && MCUnicodeMapToNative(p_chars, 1, t_char[0]))
     {
         MCdispatcher -> wkdown(p_window, (const char *)t_char, *t_char);
-        // SN-2014-11-03: [[ Bug 13832 ]] Enqueue the event, instead of firing it now (we are still in NSApplication's keyDown).
-        //  We use the mapped codepoint of the message to send, instead of t_char.
-        MCKeyMessageAppend(s_pending_key_up, (MCPlatformKeyCode)*t_char, s_pending_key_down -> next -> mapped_codepoint, (codepoint_t)*t_char);
         
         MCKeyMessageNext(s_pending_key_down);
     }


### PR DESCRIPTION
…chars fail to combine
