### PR TITLE
[[ Bug 15208 ]] Fix for the crash caused when using the character vie…

### DIFF
--- a/docs/notes/bugfix-15208.md
+++ b/docs/notes/bugfix-15208.md
@@ -1,0 +1,1 @@
+# LiveCode crashes when using System Character Viewer

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -935,7 +935,16 @@ void MCPlatformHandleTextInputInsertText(MCPlatformWindowRef p_window, unichar_t
         MCKeyMessageNext(s_pending_key_down);
     }
     else
+    {
+        // SN-2015-05-19: [[ Bug 15208 ]] This is only preventing the crash, does
+        //  not solved the situation detailed in the bug report
+        //  http://quality.runrev.com/show_bug.cgi?id=15208
+        MCField *t_activeField;
+        t_activeField = MCactivefield;
         MCactivefield -> finsertnew(FT_IMEINSERT, MCString((char *)p_chars, p_char_count * 2), True, true);
+        if (!MCactivefield)
+            MCactivefield = t_activeField;
+    }
 	
 	// And update the selection range.
 	int32_t t_s_si, t_s_ei;


### PR DESCRIPTION
…wer in a field with selected text
