### PR TITLE
[[ Bug 15392 ]] Make sure we ignore any trailing returns when setting…

### DIFF
--- a/docs/notes/bugfix-15392.md
+++ b/docs/notes/bugfix-15392.md
@@ -1,0 +1,1 @@
+# Setting the points of a graphic to a string with trailing returns causes erroneous points to be added.

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -1369,7 +1369,7 @@ Boolean MCU_parsepoints(MCPoint *&points, uint2 &noldpoints,
 			MCU_realloc((char **)&points, npoints, npoints + 1, sizeof(MCPoint));
 		points[npoints].x = i1;
 		points[npoints++].y = i2;
-		if (data.getlength() - l > 2 && *(sptr - 1) == '\n'
+		if (l > 0 && sptr - data . getstring() > 2 && *(sptr - 1) == '\n'
 		        && *(sptr - 2) == '\n')
 		{
 			if (npoints + 1 > noldpoints)


### PR DESCRIPTION
… the points of a graphic.
