### PR TITLE
Bugfix object pools

### DIFF
--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1678,7 +1678,7 @@ MCFontStruct *MCDispatch::loadfont(MCNameRef fname, uint2 &size, uint2 style, Bo
 
 MCFontStruct *MCDispatch::loadfontwithhandle(MCSysFontHandle p_handle)
 {
-#if defined(_MACOSX)
+#if defined(_MACOSX) || defined(_MAC_SERVER)
     if (fonts == nil)
         fonts = new MCFontlist;
     return fonts->getfontbyhandle(p_handle);

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -319,6 +319,8 @@ void X_main_loop_iteration()
 
 	////
 
+    MCObjectPoolFrame t_object_pool_frame;
+    
 	if (MCiconicstacks == 0 && !MCscreen->hasmessages() && MCstacks->isempty() && MCnsockets == 0)
 	{
 		// MW-2005-11-01: We want to keep the result here so we call with send=True
@@ -337,16 +339,7 @@ void X_main_loop_iteration()
 		MCtracedobject->message(MCM_trace_done);
 		MCtracedobject = NULL;
 	}
-	if (!MCtodestroy->isempty() || MCtodelete != NULL)
-	{
-		MCtooltip->cleartip();
-		while (MCtodelete != NULL)
-		{
-			MCObject *optr = MCtodelete->remove(MCtodelete);
-			delete optr;
-		}
-		MCtodestroy->destroy();
-	}
+    MCtooltip->cleartip();
 	MCU_cleaninserted();
 	MCscreen->siguser();
 	MCdefaultstackptr = MCstaticdefaultstackptr;

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -318,8 +318,6 @@ void X_main_loop_iteration()
 	MCstackbottom = (char *)&i;
 
 	////
-
-    MCObjectPoolFrame t_object_pool_frame;
     
 	if (MCiconicstacks == 0 && !MCscreen->hasmessages() && MCstacks->isempty() && MCnsockets == 0)
 	{
@@ -340,6 +338,8 @@ void X_main_loop_iteration()
 		MCtracedobject = NULL;
 	}
     MCtooltip->cleartip();
+    extern MCObjectPoolFrame *MCrootobjectpoolframe;
+    MCrootobjectpoolframe -> drain();
 	MCU_cleaninserted();
 	MCscreen->siguser();
 	MCdefaultstackptr = MCstaticdefaultstackptr;

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1940,8 +1940,6 @@ void MCInterfaceExecRevert(MCExecContext& ctxt)
 	t_sptr->del();
 	MCerrorlock--;
 	MClockmessages = oldlock;
-	MCtodestroy->add
-	(t_sptr);
 	MCNewAutoNameRef t_name;
 	/* UNCHECKED */ MCNameCreate(*t_filename, &t_name);
 	t_sptr = MCdispatcher->findstackname(*t_name);
@@ -2189,8 +2187,6 @@ void MCInterfaceExecDeleteObjects(MCExecContext& ctxt, MCObjectPtr *p_objects, u
 			return;
 		}
 
-		if (p_objects[i] . object -> gettype() == CT_STACK)
-			MCtodestroy -> remove((MCStack *)p_objects[i] . object);
 		p_objects[i] . object -> scheduledelete();
 	}
 }

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -65,6 +65,7 @@ static Exec_stat MCKeywordsExecuteStatements(MCExecContext& ctxt, MCStatement *p
         ctxt . IgnoreLastError();
         // MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
         MCRedrawUpdateScreen();
+        MCObjectPoolFrameDrain();
         
         switch(stat)
         {
@@ -722,6 +723,7 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
         
 		// MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
 		MCRedrawUpdateScreen();
+        MCObjectPoolFrameDrain();
         
 		switch(stat)
 		{

--- a/engine/src/exec-pasteboard.cpp
+++ b/engine/src/exec-pasteboard.cpp
@@ -457,8 +457,6 @@ void MCPasteboardProcessToClipboard(MCExecContext& ctxt, MCObjectPtr *p_targets,
 			for(uint4 i = 0; i < p_object_count; ++i)
 			{
 				p_targets[i] . object -> del();
-				if (p_targets[i] . object -> gettype() == CT_STACK)
-					MCtodestroy -> remove(static_cast<MCStack *>(p_targets[i] . object));
 				p_targets[i] . object -> scheduledelete();
 			}
 		}

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -257,8 +257,6 @@ uint2 MCdragdelta = 4;
 MCUndolist *MCundos;
 MCSellist *MCselected;
 MCStacklist *MCstacks;
-MCStacklist *MCtodestroy;
-MCObject *MCtodelete;
 MCCardlist *MCrecent;
 MCCardlist *MCcstack;
 MCDispatch *MCdispatcher;
@@ -645,8 +643,6 @@ void X_clear_globals(void)
 	MCundos = nil;
 	MCselected = nil;
 	MCstacks = nil;
-	MCtodestroy = nil;
-	MCtodelete = nil;
 	MCrecent = nil;
 	MCcstack = nil;
 	MCdispatcher = nil;
@@ -979,7 +975,6 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 	MCundos = new MCUndolist;
 	MCselected = new MCSellist;
 	MCstacks = new MCStacklist;
-	MCtodestroy = new MCStacklist;
 	MCrecent = new MCCardlist;
 	MCcstack = new MCCardlist;
 
@@ -1132,12 +1127,6 @@ int X_close(void)
 
 	MCscreen -> flushclipboard();
 
-	while (MCtodelete != NULL)
-	{
-		MCObject *optr = MCtodelete->remove(MCtodelete);
-		delete optr;
-	}
-
     MCdispatcher -> remove_transient_stack(MCtooltip);
 	delete MCtooltip;
 	MCtooltip = NULL;
@@ -1191,7 +1180,6 @@ int X_close(void)
 	delete MCtemplateimage;
 	delete MCtemplatefield;
 	delete MCselected;
-	delete MCtodestroy;
 	delete MCstacks;
 	delete MCcstack;
 	delete MCrecent;
@@ -1294,8 +1282,6 @@ int X_close(void)
     MCValueRelease(MClicenseparameters . license_name);
     MCValueRelease(MClicenseparameters . license_organization);
 	MCValueRelease(MClicenseparameters . addons);
-
-
 
 	// Cleanup the startup stacks list
 	for(uint4 i = 0; i < MCnstacks; ++i)

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -500,6 +500,8 @@ MCThreadMutexRef MCfieldmutex = NULL;
 MCThreadMutexRef MCthememutex = NULL;
 MCThreadMutexRef MCgraphicmutex = NULL;
 
+MCObjectPoolFrame *MCrootobjectpoolframe = nil;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern MCUIDC *MCCreateScreenDC(void);
@@ -953,6 +955,8 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 		}
 #endif // _SERVER
 
+    MCrootobjectpoolframe = new MCObjectPoolFrame;
+    
 	/* UNCHECKED */ MCStackSecurityCreateStack(MCtemplatestack);
 	MCtemplateaudio = new MCAudioClip;
 	MCtemplateaudio->init();
@@ -1183,6 +1187,8 @@ int X_close(void)
 	delete MCstacks;
 	delete MCcstack;
 	delete MCrecent;
+    
+    delete MCrootobjectpoolframe;
 
 	// Temporary workaround for a crash
     //MCS_close(IO_stdin);
@@ -1272,7 +1278,7 @@ int X_close(void)
 	// VALGRIND: Still causing a single invalid memory
 	MCscreen->close(True);
 #endif
-
+    
 	delete MCscreen;
 
 	MCExternal::Cleanup();

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -163,8 +163,6 @@ extern Boolean MCownselection;
 extern MCUndolist *MCundos;
 extern MCSellist *MCselected;
 extern MCStacklist *MCstacks;
-extern MCStacklist *MCtodestroy;
-extern MCObject *MCtodelete;
 extern MCCardlist *MCrecent;
 extern MCCardlist *MCcstack;
 extern MCDispatch *MCdispatcher;

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -455,6 +455,7 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
         
 		// MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
 		MCRedrawUpdateScreen();
+        MCObjectPoolFrameDrain();
         
 		switch(stat)
 		{
@@ -675,6 +676,7 @@ Exec_stat MCHandler::exec(MCExecPoint &ep, MCParameter *plist)
 
 		// MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
 		MCRedrawUpdateScreen();
+        MCObjectPoolFrameDrain();
 
 		switch(stat)
 		{

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -425,6 +425,8 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 		}
 	}
     
+    MCObjectPoolFrame t_object_pool_frame;
+    
 	executing++;
 	ctxt . SetTheResultToEmpty();
 	Exec_stat stat = ES_NORMAL;
@@ -545,7 +547,8 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 	nvnames = oldnvnames;
 	nconstants = oldnconstants;
 	if (stat == ES_PASS)
-		gotpass = True;  // so MCObject::timer can distinguish pass from not handled
+		gotpass = True;  // so MCObject::timer can distinguish pass from not handle
+    
 	return stat;
 }
 

--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -492,6 +492,7 @@ Exec_stat MCIf::exec(MCExecPoint &ep)
 		
 		// MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
 		MCRedrawUpdateScreen();
+        MCObjectPoolFrameDrain();
 
 		switch(stat)
 		{
@@ -1146,6 +1147,7 @@ Exec_stat MCRepeat::exec(MCExecPoint &ep)
 
 			// MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
 			MCRedrawUpdateScreen();
+            MCObjectPoolFrameDrain();
 			
 			switch(stat)
 			{
@@ -1657,6 +1659,7 @@ Exec_stat MCSwitch::exec(MCExecPoint &ep)
 			
 			// MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
 			MCRedrawUpdateScreen();
+            MCObjectPoolFrameDrain();
 
 			switch(stat)
 			{
@@ -1905,6 +1908,7 @@ Exec_stat MCTry::exec(MCExecPoint &ep)
 
 		// MW-2011-08-17: [[ Redraw ]] Flush any screen updates.
 		MCRedrawUpdateScreen();
+        MCObjectPoolFrameDrain();
 
 		switch(stat)
 		{

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -2026,7 +2026,7 @@ int main(int argc, char *argv[], char *envp[])
 	
 	// Assign our delegate
 	[t_application setDelegate: t_delegate];
-	
+    
 	// Run the application - this never returns!
 	[t_application run];    
 	

--- a/engine/src/mblmain.cpp
+++ b/engine/src/mblmain.cpp
@@ -141,13 +141,13 @@ bool X_main_loop_iteration(void)
 		MCquit = True;
 		return false;
 	}
-    MCObjectPoolFrame t_object_pool_frame;
 	MCscreen->wait(MCmaxwait, True, True);
 	MCU_resetprops(True);
 	// MW-2011-08-26: [[ Redraw ]] Make sure we flush any updates.
 	MCRedrawUpdateScreen();
 	MCabortscript = False;
 	MCU_cleaninserted();
+    MCrootobjectpoolframe -> drain();
 	MCscreen->siguser();
 	MCdefaultstackptr = MCstaticdefaultstackptr;
 	MCS_alarm(0.0);

--- a/engine/src/mblmain.cpp
+++ b/engine/src/mblmain.cpp
@@ -141,21 +141,12 @@ bool X_main_loop_iteration(void)
 		MCquit = True;
 		return false;
 	}
+    MCObjectPoolFrame t_object_pool_frame;
 	MCscreen->wait(MCmaxwait, True, True);
 	MCU_resetprops(True);
 	// MW-2011-08-26: [[ Redraw ]] Make sure we flush any updates.
 	MCRedrawUpdateScreen();
 	MCabortscript = False;
-	if (!MCtodestroy->isempty() || MCtodelete != NULL)
-	{
-		MCtooltip->cleartip();
-		while (MCtodelete != NULL)
-		{
-			MCObject *optr = MCtodelete->remove(MCtodelete);
-			delete optr;
-		}
-		MCtodestroy->destroy();
-	}
 	MCU_cleaninserted();
 	MCscreen->siguser();
 	MCdefaultstackptr = MCstaticdefaultstackptr;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -5304,9 +5304,13 @@ void MCObjectPool::objectdestroyed(MCObjectPool*& x_pool, MCObject *p_object)
 {
     MCLog("DESTROY Object %p", p_object);
     if (x_pool == nil)
+    {
+        MCLog("  Object has no pool - doing nothing", 0);
         return;
+    }
     
     // Reduce the references to the pool.
+    MCLog("  Reducing references to pool %p (%d)", x_pool, x_pool -> references);
     x_pool -> references -= 1;
     
     // If the pool has reached reference count zero then clean up and is defunct.

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -225,9 +225,9 @@ struct MCObjectPool
     MCObjectPool *parent;
     MCObject *to_delete;
     
-    static void objectcreated(MCObjectPool*& r_pool, MCObject *object);
-    static void objectdestroyed(MCObjectPool*& p_pool, MCObject *object);
-    static void objectdeleted(MCObjectPool*& x_pool, MCObject *object);
+    static MCObjectPool *objectcreated(MCObject *object);
+    void objectdestroyed(MCObject *object);
+    void objectdeleted(MCObject *object);
 };
 
 struct MCObjectPoolFrame

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -233,7 +233,7 @@ struct MCObjectPool
 
 struct MCObjectPoolFrame
 {
-    MCObjectPool **parent_pool_ptr;
+    MCObjectPoolFrame *parent_frame;
     MCObjectPool *pool;
     
     MCObjectPoolFrame(void);
@@ -242,7 +242,17 @@ struct MCObjectPoolFrame
     void drain(void);
 };
 
-extern MCObjectPool **MCcurrentobjectpoolptr;
+extern MCObjectPoolFrame *MCcurrentobjectpoolframe;
+extern MCObjectPoolFrame *MCrootobjectpoolframe;
+
+inline void MCObjectPoolFrameDrain(void)
+{
+    if (MCcurrentobjectpoolframe -> pool == nil)
+        return;
+    if (MCcurrentobjectpoolframe -> pool -> to_delete == nil)
+        return;
+    MCcurrentobjectpoolframe -> drain();
+}
 
 class MCObject : public MCDLlist
 {

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -218,10 +218,34 @@ struct MCPatternInfo
 	MCPatternRef pattern;
 };
 
+struct MCObjectPool
+{
+    uindex_t references;
+    bool defunct : 1;
+    MCObjectPool *parent;
+    MCObject *to_delete;
+    
+    static void objectcreated(MCObjectPool*& r_pool, MCObject *object);
+    static void objectdestroyed(MCObjectPool*& p_pool, MCObject *object);
+    static void objectdeleted(MCObjectPool*& x_pool, MCObject *object);
+};
+
+struct MCObjectPoolFrame
+{
+    MCObjectPool **parent_pool_ptr;
+    MCObjectPool *pool;
+    
+    MCObjectPoolFrame(void);
+    ~MCObjectPoolFrame(void);
+};
+
+extern MCObjectPool **MCcurrentobjectpoolptr;
+
 class MCObject : public MCDLlist
 {
 protected:
 	uint4 obj_id;
+    MCObjectPool *pool;
 	MCObject *parent;
 	MCNameRef _name;
 	uint4 flags;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -226,8 +226,9 @@ struct MCObjectPool
     MCObject *to_delete;
     
     static MCObjectPool *objectcreated(MCObject *object);
-    void objectdestroyed(MCObject *object);
-    void objectdeleted(MCObject *object);
+    static MCObjectPool *objectdeleted(MCObjectPool *pool, MCObject *object);
+    
+    static void objectdestroyed(MCObjectPool *pool, MCObject *object);
 };
 
 struct MCObjectPoolFrame
@@ -237,6 +238,8 @@ struct MCObjectPoolFrame
     
     MCObjectPoolFrame(void);
     ~MCObjectPoolFrame(void);
+    
+    void drain(void);
 };
 
 extern MCObjectPool **MCcurrentobjectpoolptr;

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -423,11 +423,7 @@ bool MCSellist::clipboard(bool p_is_cut)
 					if (tptr -> ref -> getstack() -> iskeyed())
 					{
 						if (tptr -> ref -> del())
-						{
-							if (tptr -> ref -> gettype() == CT_STACK)
-								MCtodestroy -> remove(static_cast<MCStack *>(tptr -> ref));
 							tptr -> ref -> scheduledelete();
-						}
 					}
 
 					delete tptr;

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -554,6 +554,8 @@ void X_main_loop(void)
 		return;
 #endif
 	
+    MCObjectPoolFrame t_object_pool_frame;
+    
 	MCExecContext ctxt;
 	if (!MCserverscript -> Include(ctxt, MCserverinitialscript, false) &&
 		MCS_get_errormode() != kMCSErrorModeDebugger)

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -646,19 +646,23 @@ int main(int argc, char *argv[], char *envp[])
 	t_new_envp[i] = nil;
 // END MAC SPECIFIC	
 
-	if (!X_init(argc, t_new_argv, t_new_envp))
-		exit(-1);
+    MCObjectPoolFrame t_object_pool_frame;
+    
+    int t_exit_code;
+	if (X_init(argc, t_new_argv, t_new_envp))
+    {
+        X_main_loop();
 	
-	X_main_loop();
-	
-	int t_exit_code;
-	t_exit_code = X_close();
+        t_exit_code = X_close();
+    }
+    else
+        t_exit_code = -1;
 
     MCScriptFinalize();
     MCModulesFinalize();
 	MCFinalize();
 	
-	exit(t_exit_code);
+    return t_exit_code;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -553,8 +553,6 @@ void X_main_loop(void)
 	if (setrlimit(RLIMIT_RSS, &t_limits) < 0)
 		return;
 #endif
-	
-    MCObjectPoolFrame t_object_pool_frame;
     
 	MCExecContext ctxt;
 	if (!MCserverscript -> Include(ctxt, MCserverinitialscript, false) &&
@@ -644,9 +642,7 @@ int main(int argc, char *argv[], char *envp[])
 	
 	/* UNCHECKED */ MCMemoryResizeArray(i + 1, t_new_envp, t_envp_count);
 	t_new_envp[i] = nil;
-// END MAC SPECIFIC	
-
-    MCObjectPoolFrame t_object_pool_frame;
+// END MAC SPECIFIC
     
     int t_exit_code;
 	if (X_init(argc, t_new_argv, t_new_envp))

--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -33,6 +33,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "debug.h"
 #include "stack.h"
 #include "cmds.h"
+#include "object.h"
 
 
 #include "system.h"
@@ -551,7 +552,10 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 
 			t_statement = t_statement -> getnext();
 		}
-
+        
+        extern MCObjectPoolFrame *MCrootobjectpoolframe;
+        MCrootobjectpoolframe -> drain();
+        
 		t_statements -> deletestatements(t_statements);
 	}
 	

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -112,8 +112,7 @@ void MCStack::checkdestroy()
 					}
 					while (sptr != substacks);
 				}
-				MCtodestroy->remove(this); // prevent duplicates
-				MCtodestroy->add(this);
+                scheduledelete();
 			}
 	}
 	else if (!MCdispatcher -> is_transient_stack(this))
@@ -2116,7 +2115,6 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
 	if (state & (CS_IGNORE_CLOSE | CS_NO_FOCUS | CS_DELETE_STACK))
 		return ES_NORMAL;
 
-	MCtodestroy->remove(this); // prevent delete
 	if (wm == WM_LAST)
 		if (opened)
 			wm = mode;

--- a/engine/src/stackcache.cpp
+++ b/engine/src/stackcache.cpp
@@ -115,7 +115,7 @@ void MCStackIdCache::CacheObject(MCObject *p_object)
 {
 	if (p_object -> getinidcache())
 		return;
-	
+    
 	uint32_t t_id;
 	t_id = p_object -> getid();
 	
@@ -135,7 +135,7 @@ void MCStackIdCache::CacheObject(MCObject *p_object)
 	
 	if (t_target_slot == UINDEX_MAX)
 		return;
-
+    
 	p_object -> setinidcache(true);
 	m_buckets[t_target_slot] = (uintptr_t)p_object;
 	m_count += 1;
@@ -374,6 +374,9 @@ bool MCStackIdCache::RehashBuckets(index_t p_new_item_count_delta)
 
 void MCStack::cacheobjectbyid(MCObject *p_object)
 {
+    // Disable for now
+    return;
+    
     MCThreadMutexLock(m_id_cache_lock);
 	if (m_id_cache == nil)
 	{
@@ -392,6 +395,9 @@ void MCStack::cacheobjectbyid(MCObject *p_object)
 
 void MCStack::uncacheobjectbyid(MCObject *p_object)
 {
+    // Disable for now
+    return;
+    
 	if (m_id_cache == nil)
 		return;
 		


### PR DESCRIPTION
WIP for trying to make objects get flushed at more granular intervals.

It seems to work - although the word cloud stack on Desktop still seems to cause a climb in memory.

Also there is a potential 'crash on exit' when using widgets as OnDestroy() can occur when there is no script-context, but the handler call code is still assuming there is.

Another tweak that is needed is to consolidate the 'post statement' processing steps into a general action rather than having to check both for redraw and for object deletion.

(Note this has idcache disabled due to a defect found in that mechanism whilst implementing object pools).

(Note this branch will get completely reconstructed before final PR is issued - so don't merge it into anything you can't revert it in!)
