### PR TITLE
[[ Bug 15408 ]] Deleted controls can still be referenced by id.

### DIFF
--- a/docs/notes/bugfix-15408.md
+++ b/docs/notes/bugfix-15408.md
@@ -1,0 +1,1 @@
+# Deleted objects can still be accessed in some circumstances.

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -3196,3 +3196,28 @@ bool MCCard::recomputefonts(MCFontRef p_parent_font)
 	// to be provided to children).
 	return t_changed;
 }
+
+void MCCard::scheduledelete(bool p_is_child)
+{
+    MCObject::scheduledelete(p_is_child);
+    
+    if (objptrs != NULL)
+	{
+		MCObjptr *optr = objptrs;
+		do
+		{
+			// MW-2011-08-09: [[ Groups ]] Shared groups just get reparented, rather
+			//   than removed from the stack since they cannot be 'owned' by the card.
+			if (optr->getref()->gettype() == CT_GROUP && static_cast<MCGroup *>(optr->getref())->isshared())
+			{
+                // Do nothing for shared groups as they move to the stack.
+			}
+			else
+			{
+                optr -> getref() -> scheduledelete(true);
+			}
+			optr = optr->next();
+		}
+		while (optr != objptrs);
+	}
+}

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -92,6 +92,8 @@ public:
 	virtual void relayercontrol_remove(MCControl *control);
 	virtual void relayercontrol_insert(MCControl *control, MCControl *target);
 
+    virtual void scheduledelete(bool p_is_child);
+    
 	void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated);
 
 	MCObject *hittest(int32_t x, int32_t y);

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -3356,3 +3356,19 @@ void MCGroup::relayercontrol_insert(MCControl *p_control, MCControl *p_target)
 	if (!computeminrect(False))
 		p_control -> layer_redrawall();
 }
+
+void MCGroup::scheduledelete(bool p_is_child)
+{
+    MCControl::scheduledelete(p_is_child);
+    
+	if (controls != NULL)
+	{
+		MCControl *t_control;
+		t_control = controls;
+		do
+		{   t_control -> scheduledelete(true);
+			t_control = t_control -> next();
+		}
+		while(t_control != controls);
+	}
+}

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -122,6 +122,8 @@ public:
 	virtual void relayercontrol_remove(MCControl *control);
 	virtual void relayercontrol_insert(MCControl *control, MCControl *target);
 
+    virtual void scheduledelete(bool p_is_child);
+    
 	MCControl *findchildwithid(Chunk_term type, uint4 p_id);
 
 	// MCGroup functions

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4582,9 +4582,11 @@ void MCObject::relayercontrol_insert(MCControl *p_control, MCControl *p_target)
 {
 }
 
-void MCObject::scheduledelete(void)
+void MCObject::scheduledelete(bool p_is_child)
 {
-	appendto(MCtodelete);
+    if (!p_is_child)
+        appendto(MCtodelete);
+    
 	if (m_weak_handle != nil)
 	{
 		m_weak_handle -> Clear();

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -688,7 +688,7 @@ public:
 		return kMCPropertyChangedMessageTypeNone;
 	}	
 
-	void scheduledelete(void);
+	virtual void scheduledelete(bool p_is_child = false);
 	
 	// MW-2012-10-10: [[ IdCache ]]
 	void setinidcache(bool p_value)


### PR DESCRIPTION
When a control was deleted by script, only the id cache for that object was being flushed leaving any child objects in the id cache.

This has been fixed by making 'scheduledelete' virtual with a parameter to determine whether it is for a child, or direct. This then recurses to scheduledelete each child.
