### PR TITLE
[[ Revert bugfix 14349 ]]

### DIFF
--- a/docs/notes/bugfix-14349.md
+++ b/docs/notes/bugfix-14349.md
@@ -1,1 +1,0 @@
-#    Can't use mouse events in QT players on a Mac

--- a/engine/engine.xcodeproj/project.pbxproj
+++ b/engine/engine.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		1D46D3021B038BE500681BE3 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDE08EA1945F10A000E3705 /* QTKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		1DC1249518FC422B00C2FEF3 /* quicktimestubs.mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1249418FC422300C2FEF3 /* quicktimestubs.mac.cpp */; };
 		1DC1249618FC423200C2FEF3 /* quicktimestubs.mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1249418FC422300C2FEF3 /* quicktimestubs.mac.cpp */; };
 		1DDE08D11945DD32000E3705 /* mac-qt-player.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1DDE08D01945DD31000E3705 /* mac-qt-player.mm */; };
@@ -1610,7 +1609,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D46D3021B038BE500681BE3 /* QTKit.framework in Frameworks */,
 				4C529CB11973CC4D007C5F7C /* AVFoundation.framework in Frameworks */,
 				4C529CB01973CC45007C5F7C /* CoreMedia.framework in Frameworks */,
 				4DEE2C7A0FDE52770009423C /* libkernel.a in Frameworks */,

--- a/engine/src/mac-qt-player.mm
+++ b/engine/src/mac-qt-player.mm
@@ -52,14 +52,7 @@
 - (NSArray*)loadedRanges;
 - (QTTime)maxTimeLoaded;
 @end
-
-// PM-2015-05-12: [[ Bug 14349 ]] Subclass QTMoviewView and override hitTest method to make mouse events respond to the superview
-@interface com_runrev_livecode_MCQTPlayerView : QTMovieView
-
-- (NSView *) hitTest: (NSPoint) aPoint;
-
-@end
-
+ 
 class MCQTKitPlayer: public MCPlatformPlayer
 {
 public:
@@ -103,7 +96,7 @@ private:
     static Boolean MovieActionFilter(MovieController mc, short action, void *params, long refcon);
     
     QTMovie *m_movie;
-    com_runrev_livecode_MCQTPlayerView *m_view;
+    QTMovieView *m_view;
     CVImageBufferRef m_current_frame;
     QTTime m_last_current_time;
     QTTime m_buffered_time;
@@ -152,16 +145,7 @@ private:
 }
 
 @end
-
-// PM-2015-05-12: [[ Bug 14349 ]] Override hitTest method to make mouse events respond to the superview
-@implementation com_runrev_livecode_MCQTPlayerView
-
-- (NSView *) hitTest: (NSPoint) aPoint
-{
-    return [self superview];
-}
-
-@end
+ 
 ////////////////////////////////////////////////////////////////////////////////
 
 
@@ -182,8 +166,8 @@ inline NSComparisonResult do_QTTimeCompare (QTTime time, QTTime otherTime)
 MCQTKitPlayer::MCQTKitPlayer(void)
 {
 	m_movie = [[NSClassFromString(@"QTMovie") movie] retain];
-    m_view = [[com_runrev_livecode_MCQTPlayerView alloc] initWithFrame: NSZeroRect];
-    m_observer = [[com_runrev_livecode_MCQTKitPlayerObserver alloc] initWithPlayer: this];
+	m_view = [[NSClassFromString(@"QTMovieView") alloc] initWithFrame: NSZeroRect];
+	m_observer = [[com_runrev_livecode_MCQTKitPlayerObserver alloc] initWithPlayer: this];
     
 	m_current_frame = nil;
 	

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1054,13 +1054,12 @@ Boolean MCPlayer::mdown(uint2 which)
             switch (getstack()->gettool(this))
 		{
             case T_BROWSE:
+                message_with_args(MCM_mouse_down, "1");
                 // PM-2014-07-16: [[ Bug 12817 ]] Create selection when click and drag on the well while shift key is pressed
                 if ((MCmodifierstate & MS_SHIFT) != 0)
                     handle_shift_mdown(which);
                 else
                     handle_mdown(which);
-                // Send mouseDown msg after mdown is passed to the controller, to prevent blocking if the mouseDown handler has an 'answer' command
-                message_with_args(MCM_mouse_down, "1");
                 MCscreen -> addtimer(this, MCM_internal, MCblinkrate);
                 break;
             case T_POINTER:


### PR DESCRIPTION
Reverts the merge of the pull request https://github.com/runrev/livecode/pull/2274, after it appeared that QTKit should not be linked to the engine.
