### PR TITLE
[[ Bug ]] 'SysString' not used in places it should and not defined fo…

### DIFF
--- a/engine/src/lnxelevate.cpp
+++ b/engine/src/lnxelevate.cpp
@@ -196,7 +196,8 @@ bool MCSystemOpenElevatedProcess(MCStringRef p_command, int32_t& r_pid, int32_t&
 	// Convert the command string into the system encoding so that we can pass
 	// Unicode unscathed (hopefully)
 	MCAutoPointer<char> t_command;
-	/* UNCHECKED */ MCStringConvertToSysString(p_command, (const char*&)&t_command);
+    size_t t_command_len;
+	/* UNCHECKED */ MCStringConvertToSysString(p_command, &t_command, t_command_len);
 	
 	// First split the command args into the argc/argv array we need.
 	char **t_argv;
@@ -226,16 +227,13 @@ bool MCSystemOpenElevatedProcess(MCStringRef p_command, int32_t& r_pid, int32_t&
 	if (t_pid == 0)
 	{
 		// We must escape MCcmd to make gksu plays nice.
-        MCAutoPointer<const char> t_unescaped_cmd;
+        MCAutoPointer<char> t_unescaped_cmd;
         MCAutoArray<char> t_escaped_cmd;
-		uindex_t t_unescaped_len;
+		size_t t_unescaped_len;
 		uindex_t t_escaped_len = 0;
 		
 		if (t_success)
-			t_success = MCStringConvertToSysString(MCcmd, &t_unescaped_cmd);
-        
-        if (t_success)
-            t_unescaped_len = strlen(*t_unescaped_cmd);
+			t_success = MCStringConvertToSysString(MCcmd, &t_unescaped_cmd, t_unescaped_len);
 		
 		// The escaping can potentially double the length of the command
 		if (t_success)

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -465,10 +465,10 @@ static void IO_printf(IO_handle stream, const char *format, ...)
 	va_start(args, format);
     MCStringFormatV(&t_string, format, args);
 	va_end(args);
-    MCAutoStringRefAsUTF8String t_utf8_string;
-    t_utf8_string . Lock(*t_string);
     
-	MCS_write(*t_utf8_string, 1, t_utf8_string . Size(), stream);
+    MCAutoStringRefAsSysString t_sys_string;
+    t_sys_string . Lock(*t_string);
+	MCS_write(*t_sys_string, 1, t_sys_string . Size(), stream);
 }
 
 static bool load_extension_callback(void *p_context, const MCSystemFolderEntry *p_entry)

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -347,13 +347,13 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef __LINUX__
 class MCAutoStringRefAsSysString
 {
 public:
     MCAutoStringRefAsSysString()
     {
-        m_sysstring = nil;
+        m_bytes = nil;
+        m_byte_count = 0;
     }
 
     ~MCAutoStringRefAsSysString()
@@ -363,31 +363,39 @@ public:
 
     bool Lock(MCStringRef p_string)
     {
-        bool t_success =  MCStringConvertToSysString(p_string, m_sysstring);
-        if (!t_success)
-        {
-            int x = 42;
-        }
-        return t_success;
+        MCAssert(m_bytes == nil);
+        return MCStringConvertToSysString(p_string, m_bytes, m_byte_count);
     }
 
     void Unlock()
     {
-        if (m_sysstring != nil)
-            free((void*)m_sysstring);
-        m_sysstring = nil;
+        if (m_bytes != nil)
+        {
+            free(m_bytes);
+            m_byte_count = nil;
+        }
     }
 
-    const char * operator * () const
+    const char *operator * () const
     {
-        return m_sysstring;
+        return Ptr();
+    }
+    
+    const char *Ptr(void) const
+    {
+        MCAssert(m_bytes != nil);
+        return m_bytes;
+    }
+    
+    size_t Size(void) const
+    {
+        return m_byte_count;
     }
 
 private:
-    const char *m_sysstring;
+    char *m_bytes;
+    size_t m_byte_count;
 };
-
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1680,9 +1680,10 @@ bool MCStringConvertToCFStringRef(MCStringRef string, CFStringRef& r_cfstring);
 bool MCStringConvertToBSTR(MCStringRef string, BSTR& r_bstr);
 #endif
 
-#ifdef __LINUX__
-bool MCStringConvertToSysString(MCStringRef string, const char *&sys_string);
-#endif
+// Converts the given string ref to a string in the system encoding.
+// Note that the 'bytes' ptr is typed as 'char', however it should be considered
+// as an opaque sequence of bytes with an 'unknowable' encoding.
+bool MCStringConvertToSysString(MCStringRef string, char*& r_bytes, size_t& r_byte_count);
 
 /////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1683,6 +1683,8 @@ bool MCStringConvertToBSTR(MCStringRef string, BSTR& r_bstr);
 // Converts the given string ref to a string in the system encoding.
 // Note that the 'bytes' ptr is typed as 'char', however it should be considered
 // as an opaque sequence of bytes with an 'unknowable' encoding.
+// Note that the output string is allocated with an implicit NUL byte, but this
+// is not included in the byte_count.
 bool MCStringConvertToSysString(MCStringRef string, char*& r_bytes, size_t& r_byte_count);
 
 /////////

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -5026,7 +5026,9 @@ bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, s
     t_bytes . Take(t_size, t_ptr);
     
     r_system_string = t_ptr;
-    r_byte_count = t_size;
+    
+    // Account for the fact that array size includes the NUL byte.
+    r_byte_count = t_size - 1;
     
     return true;
 }

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -4991,17 +4991,6 @@ bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, s
     
 	return true;
 }
-
-#elif defined(__MAC__)
-bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
-{
-    bool t_success;
-    uindex_t t_byte_count;
-    if (!MCStringConvertToUTF8(p_string, r_system_string, t_byte_count))
-        return false;
-    r_byte_count = t_byte_count;
-    return true;
-}
 #elif defined(__WINDOWS__)
 bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
 {
@@ -5039,6 +5028,16 @@ bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, s
     r_system_string = t_ptr;
     r_byte_count = t_size;
     
+    return true;
+}
+#else
+bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
+{
+    bool t_success;
+    uindex_t t_byte_count;
+    if (!MCStringConvertToUTF8(p_string, r_system_string, t_byte_count))
+        return false;
+    r_byte_count = t_byte_count;
     return true;
 }
 #endif

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -28,6 +28,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <locale.h>
 #endif
 
+#ifdef __WINDOWS__
+#include <windows.h>
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // CAVEAT!
@@ -4923,7 +4927,7 @@ bool MCStringCreateWithSysString(const char *p_system_string, MCStringRef &r_str
 	return true;
 }
 
-bool MCStringConvertToSysString(MCStringRef p_string, const char * &r_system_string)
+bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
 {
     // Create the pseudo-FD that iconv uses for character conversion. For
     // efficiency, convert straight from the internal format.
@@ -4983,9 +4987,60 @@ bool MCStringConvertToSysString(MCStringRef p_string, const char * &r_system_str
     t_sys_string[t_sys_len] = '\0';
 
 	r_system_string = t_sys_string;
+    r_byte_count = t_sys_len;
+    
 	return true;
 }
 
+#elif defined(__MAC__)
+bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
+{
+    bool t_success;
+    uindex_t t_byte_count;
+    if (!MCStringConvertToUTF8(p_string, r_system_string, t_byte_count))
+        return false;
+    r_byte_count = t_byte_count;
+    return true;
+}
+#elif defined(__WINDOWS__)
+bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
+{
+    UINT t_codepage;
+    t_codepage = GetConsoleOutputCP();
+    
+    int t_needed;
+    t_needed = WideCharToMultibyte(t_codepage,
+                                   WC_COMPOSITECHECK | WC_NO_BEST_FIT_CHARS,
+                                   MCStringGetCharPtr(p_string),
+                                   -1,
+                                   NULL,
+                                   0,
+                                   NULL,
+                                   NULL);
+    
+    MCAutoArray<char> t_bytes;
+    if (!t_bytes . New(t_needed))
+        return false;
+    
+    if (WideCharToMultibyte(t_codepage,
+                            WC_COMPOSITECHECK | WC_NO_BEST_FIT_CHARS,
+                            MCStringGetCharPtr(p_string),
+                            -1,
+                            t_bytes . Ptr(),
+                            t_needed,
+                            NULL,
+                            NULL) == 0)
+        return false;
+    
+    uindex_t t_size;
+    char *t_ptr;
+    t_bytes . Take(t_size, t_ptr);
+    
+    r_system_string = t_ptr;
+    r_byte_count = t_size;
+    
+    return true;
+}
 #endif
 
 bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)


### PR DESCRIPTION
…r all platforms.

The 'SysString' notion and auto-lock class has been made cross-platform.

On Linux it uses the environment defined encoding.

On Mac it uses UTF-8.

On Windows it uses the current console output codepage.
