### PR TITLE
[[ Bug 15436 ]] Problems calling foreign handlers / types from LCS.

### DIFF
--- a/docs/lcb/15436.md
+++ b/docs/lcb/15436.md
@@ -1,0 +1,5 @@
+# LiveCode Builder Host Library
+
+# [15436] Attempting to call a foreign handler directly from LCS will no longer crash, but throw an error.
+# [15436] An appropriate error message will be returned if a type conversion fails when calling a library handler.
+# [15436] Calling library handlers with foreign typed arguments now works from LCS.

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -331,7 +331,8 @@ Exec_stat MCEngineHandleLibraryMessage(MCNameRef p_message, MCParameter *p_param
     
     MCValueRef t_result;
     t_result = nil;
-    if (MCScriptCallHandlerOfInstance(t_ext -> instance, p_message, t_arguments . Ptr(), t_arguments . Size(), t_result))
+    if (t_success &&
+        MCScriptCallHandlerOfInstance(t_ext -> instance, p_message, t_arguments . Ptr(), t_arguments . Size(), t_result))
     {
         MCParameter *t_param;
         t_param = p_parameters;
@@ -644,12 +645,12 @@ bool MCExtensionTryToConvertFromScriptType(MCExecContext& ctxt, MCTypeInfoRef p_
         if (!__script_try_to_convert_to_list(ctxt, x_value, r_converted))
             return false;
     }
-    else if (MCTypeInfoIsRecord(t_resolved_type . named_type))
+    else if (MCTypeInfoIsRecord(t_resolved_type . type))
     {
         if (!__script_try_to_convert_to_record(ctxt, t_resolved_type . named_type, x_value, r_converted))
             return false;
     }
-    else if (MCTypeInfoIsForeign(t_resolved_type . named_type))
+    else if (MCTypeInfoIsForeign(t_resolved_type . type))
     {
         if (!__script_try_to_convert_to_foreign(ctxt, t_resolved_type . named_type, x_value, r_converted))
             return false;

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -557,14 +557,18 @@ bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCType
 }
 
 MC_DLLEXPORT_DEF
-const MCForeignTypeDescriptor *MCForeignTypeInfoGetDescriptor(MCTypeInfoRef self)
+const MCForeignTypeDescriptor *MCForeignTypeInfoGetDescriptor(MCTypeInfoRef unresolved_self)
 {
+	MCTypeInfoRef self;
+	self = __MCTypeInfoResolve(unresolved_self);
     return &self -> foreign . descriptor;
 }
 
 MC_DLLEXPORT_DEF
-void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef self)
+void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef unresolved_self)
 {
+	MCTypeInfoRef self;
+	self = __MCTypeInfoResolve(unresolved_self);
     return self -> foreign . ffi_layout_type;
 }
 

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -909,8 +909,7 @@ bool MCScriptCopyHandlersOfModule(MCScriptModuleRef self, /* copy */ MCProperLis
         return false;
     
     for(uindex_t i = 0; i < self -> exported_definition_count; i++)
-        if (self -> definitions[self -> exported_definitions[i] . index] -> kind == kMCScriptDefinitionKindHandler ||
-            self -> definitions[self -> exported_definitions[i] . index] -> kind == kMCScriptDefinitionKindForeignHandler)
+        if (self -> definitions[self -> exported_definitions[i] . index] -> kind == kMCScriptDefinitionKindHandler)
             if (!MCProperListPushElementOntoBack(*t_handlers, self -> exported_definitions[i] . name))
                 return false;
     
@@ -998,7 +997,8 @@ bool MCScriptLookupHandlerDefinitionInModule(MCScriptModuleRef self, MCNameRef p
     
     for(uindex_t i = 0; i < self -> exported_definition_count; i++)
     {
-        if (self -> definitions[self -> exported_definitions[i] . index] -> kind != kMCScriptDefinitionKindHandler)
+        if (self -> definitions[self -> exported_definitions[i] . index] -> kind != kMCScriptDefinitionKindHandler &&
+            self -> definitions[self -> exported_definitions[i] . index] -> kind != kMCScriptDefinitionKindForeignHandler)
             continue;
         
         if (!MCNameIsEqualTo(p_handler, self -> exported_definitions[i] . name))


### PR DESCRIPTION
Foreign handlers cannot be called directly from LCS, and trying to do this no longer crashes.

A failing type conversion when calling an library handler from LCS will now present an appropriate error message.

Calling a library handler with a foreign type argument will now works from LCS.
