### PR TITLE
Fix compiler warning

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -487,7 +487,8 @@ public:
         if (m_bytes != nil)
         {
             free(m_bytes);
-            m_byte_count = nil;
+            m_bytes = nil;
+            m_byte_count = 0;
         }
     }
 


### PR DESCRIPTION
The warning

```
./../libfoundation/include/foundation-auto.h:490:26: warning: converting to non-pointer type ‘size_t {aka long unsigned int}’ from NULL [-Wconversion-null]
             m_byte_count = nil;
```

occured over 500 times and accounted for approx 30% of all compiler warnings on my system.
