### PR TITLE
[[Bug 14991]] lc-compile: Make "use" a definition.

### DIFF
--- a/docs/lcb/notes/14991.md
+++ b/docs/lcb/notes/14991.md
@@ -1,0 +1,7 @@
+# LiveCode Builder Language
+## Syntax
+
+* `use` declarations may now occur anywhere in a module's top-level
+context.
+
+# [14991] No 'use' clauses causes random parsing errors

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -31,18 +31,18 @@
 -- the defining id.
 'action' Bind(MODULE, MODULELIST)
 
-    'rule' Bind(Module:module(Position, Kind, Name, Imports, Definitions), ImportedModules):
+    'rule' Bind(Module:module(Position, Kind, Name, Definitions), ImportedModules):
         DefineModuleId(Name)
 
         -- Make sure all the imported modules are bound
-        BindImports(Imports, ImportedModules)
+        BindImports(Definitions, ImportedModules)
 
         -- Step 1: Ensure all id's referencing definitions point to the definition.
         --         and no duplicate definitions have been attempted.
         EnterScope
 
         -- Import all the used modules
-        DeclareImports(Imports, ImportedModules)
+        DeclareImports(Definitions, ImportedModules)
         
         EnterScope
 
@@ -62,7 +62,7 @@
         
         --DumpBindings(Module)
 
-'action' BindImports(IMPORT, MODULELIST)
+'action' BindImports(DEFINITION, MODULELIST)
 
     'rule' BindImports(sequence(Left, Right), Imports):
         BindImports(Left, Imports)
@@ -79,11 +79,11 @@
             Bind(Module, Imports)
         |)
         
-    'rule' BindImports(nil, _):
+    'rule' BindImports(_, _):
         -- do nothing
 --
 
-'action' DeclareImports(IMPORT, MODULELIST)
+'action' DeclareImports(DEFINITION, MODULELIST)
 
     'rule' DeclareImports(sequence(Left, Right), Imports):
         DeclareImports(Left, Imports)
@@ -95,7 +95,7 @@
         Module'Definitions -> Definitions
         DeclareImportedDefinitions(Definitions)
         
-    'rule' DeclareImports(nil, _):
+    'rule' DeclareImports(_, _):
         -- do nothing
         
 'action' DeclareImportedDefinitions(DEFINITION)
@@ -132,6 +132,9 @@
         DeclareId(Name)
 
     'rule' DeclareImportedDefinitions(metadata(_, _, _)):
+        -- do nothing
+
+    'rule' DeclareImportedDefinitions(import(_, _)):
         -- do nothing
 
     'rule' DeclareImportedDefinitions(nil):
@@ -194,6 +197,9 @@
         DeclareId(Name)
     
     'rule' Declare(metadata(_, _, _)):
+        -- do nothing
+
+    'rule' Declare(import(_, _)):
         -- do nothing
         
     'rule' Declare(nil):
@@ -270,6 +276,9 @@
         DefineSyntaxId(Name, ModuleId, Class, Syntax, Methods)
     
     'rule' Define(_, metadata(_, _, _)):
+        -- do nothing
+
+    'rule' Define(_, import(_, _)):
         -- do nothing
         
     'rule' Define(_, nil):
@@ -690,12 +699,11 @@
 
 'sweep' DumpBindings(ANY)
 
-    'rule' DumpBindings(MODULE'module(_, Kind, Name, Imports, Definitions)):
+    'rule' DumpBindings(MODULE'module(_, Kind, Name, Definitions)):
         DumpId("module", Name)
-        DumpBindings(Imports)
         DumpBindings(Definitions)
         
-    'rule' DumpBindings(IMPORT'import(_, Name)):
+    'rule' DumpBindings(DEFINITION'import(_, Name)):
         DumpId("import", Name)
         
     'rule' DumpBindings(DEFINITION'type(_, _, Name, Type)):

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1287,15 +1287,15 @@
 
 'var' IgnoredModulesList : NAMELIST
 
-'condition' ImportContainsCanvas(IMPORT)
+'condition' ImportContainsCanvas(DEFINITION)
 
 'sweep' CheckInvokes(ANY)
 
-    'rule' CheckInvokes(MODULE'module(_, Kind, Name, Imports, Definitions)):
+    'rule' CheckInvokes(MODULE'module(_, Kind, Name, Definitions)):
         (|
             ne(Kind, widget)
             (|
-                ImportContainsCanvas(Imports)
+                ImportContainsCanvas(Definitions)
                 MakeNameLiteral("com.livecode.widget" -> WidgetModuleName)
                 IgnoredModulesList <- namelist(WidgetModuleName, nil)
             ||
@@ -1669,9 +1669,8 @@
 
 'sweep' CheckIdentifiers(ANY)
 
-    'rule' CheckIdentifiers(MODULE'module(_, _, Id, Imports, Definitions)):
+    'rule' CheckIdentifiers(MODULE'module(_, _, Id, Definitions)):
         CheckIdIsSuitableForDefinition(Id)
-        CheckIdentifiers(Imports)
         CheckIdentifiers(Definitions)
 
     --

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -31,7 +31,7 @@
 
 'action' Generate(MODULE)
 
-    'rule' Generate(Module:module(_, Kind, Id, Imports, Definitions)):
+    'rule' Generate(Module:module(_, Kind, Id, Definitions)):
         ModuleDependencyList <- nil
         
         QueryModuleId(Id -> Info)
@@ -52,7 +52,7 @@
         (|
             ne(Kind, widget)
             (|
-                ImportContainsCanvas(Imports)
+                ImportContainsCanvas(Definitions)
                 MakeNameLiteral("com.livecode.widget" -> WidgetModuleName)
                 IgnoredModuleList <- namelist(WidgetModuleName, nil)
             ||
@@ -81,7 +81,7 @@
         
         GenerateManifest(Module)
 
-'condition' ImportContainsCanvas(IMPORT)
+'condition' ImportContainsCanvas(DEFINITION)
 
     'rule' ImportContainsCanvas(sequence(Left, _)):
         ImportContainsCanvas(Left)
@@ -98,7 +98,7 @@
 
 'action' GenerateManifest(MODULE)
 
-    'rule' GenerateManifest(module(_, Kind, Id, Imports, Definitions)):
+    'rule' GenerateManifest(module(_, Kind, Id, Definitions)):
         OutputBeginManifest()
         Id'Name -> Name
         OutputWrite("<package version=\"0.0\">\n")
@@ -708,6 +708,9 @@
         EmitEndSyntaxDefinition()
         
     'rule' GenerateDefinitions(metadata(_, _, _)):
+        -- do nothing
+
+    'rule' GenerateDefinitions(import(_, _)):
         -- do nothing
 
     'rule' GenerateDefinitions(nil):

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -136,36 +136,30 @@
 
 'nonterm' Module(-> MODULE)
 
-    'rule' Module(-> module(Position, module, Name, Imports, Definitions)):
+    'rule' Module(-> module(Position, module, Name, Definitions)):
         OptionalSeparator
         "module" @(-> Position) Identifier(-> Name) Separator
-        Imports(-> Imports)
         Definitions(-> Definitions)
         "end" "module" OptionalSeparator
         END_OF_UNIT
 
-    'rule' Module(-> module(Position, widget, Name, Imports, sequence(PreImportDefs, Definitions))):
+    'rule' Module(-> module(Position, widget, Name, Definitions)):
         OptionalSeparator
         "widget" @(-> Position) Identifier(-> Name) Separator
-        PreImportMetadata(-> PreImportDefs)
-        Imports(-> Imports)
         Definitions(-> Definitions)
         "end" "widget" OptionalSeparator
         END_OF_UNIT
 
-    'rule' Module(-> module(Position, library, Name, Imports, sequence(PreImportDefs, Definitions))):
+    'rule' Module(-> module(Position, library, Name, Definitions)):
         OptionalSeparator
         "library" @(-> Position) Identifier(-> Name) Separator
-        PreImportMetadata(-> PreImportDefs)
-        Imports(-> Imports)
         Definitions(-> Definitions)
         "end" "library" OptionalSeparator
         END_OF_UNIT
 
-    'rule' Module(-> module(Position, import, Name, Imports, Definitions)):
+    'rule' Module(-> module(Position, import, Name, Definitions)):
         OptionalSeparator
         "import" "module" @(-> Position) Identifier(-> Name) Separator
-        Imports(-> Imports)
         ImportDefinitions(-> Definitions)
         "end" "module" OptionalSeparator
         END_OF_UNIT
@@ -180,6 +174,9 @@
         -- done!
         
 'nonterm' ImportDefinition(-> DEFINITION)
+
+    'rule' ImportDefinition(-> Import):
+        Import(-> Import)
 
     'rule' ImportDefinition(-> type(Position, public, Id, foreign(Position, ""))):
         "foreign" @(-> Position) "type" Identifier(-> Id)
@@ -206,15 +203,6 @@
 -- Metadata Syntax
 --------------------------------------------------------------------------------
 
-'nonterm' PreImportMetadata(-> DEFINITION)
-
-    'rule' PreImportMetadata(-> sequence(Left, Right)):
-        Metadata(-> Left) Separator
-        PreImportMetadata(-> Right)
-
-    'rule' PreImportMetadata(-> nil):
-        -- do nothing
-
 'nonterm' Metadata(-> DEFINITION)
 
     'rule' Metadata(-> metadata(Position, Key, Value)):
@@ -224,22 +212,12 @@
 -- Import Syntax
 --------------------------------------------------------------------------------
 
-'nonterm' Imports(-> IMPORT)
-
-    'rule' Imports(-> sequence(Head, Tail)):
-        Import(-> Head) Separator
-        Imports(-> Tail)
-        
-    'rule' Imports(-> nil):
-        -- empty
-        
-'nonterm' Import(-> IMPORT)
-
+'nonterm' Import(-> DEFINITION)
     'rule' Import(-> ImportList):
         "use" @(-> Position) IdentifierList(-> Identifiers)
         ExpandImports(Position, Identifiers -> ImportList)
 
-'action' ExpandImports(POS, IDLIST -> IMPORT)
+'action' ExpandImports(POS, IDLIST -> DEFINITION)
 
     'rule' ExpandImports(Position, idlist(Id, nil) -> import(Position, Id)):
         Id'Name -> Name
@@ -270,6 +248,9 @@
 
     'rule' Definition(-> Metadata):
         Metadata(-> Metadata)
+
+    'rule' Definition(-> Import):
+        Import(-> Import)
         
     'rule' Definition(-> Constant):
         ConstantDefinition(-> Constant)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -21,7 +21,6 @@
 
 'export'
     MODULE MODULELIST MODULEKIND
-    IMPORT
     DEFINITION SIGNATURE ACCESS SCOPE
     TYPE FIELD FIELDLIST
     PARAMETER MODE PARAMETERLIST
@@ -53,12 +52,7 @@
     application
 
 'type' MODULE
-    module(Position: POS, Kind: MODULEKIND, Name: ID, Imports: IMPORT, Definitions: DEFINITION)
-
-'type' IMPORT
-    sequence(Left: IMPORT, Right: IMPORT)
-    import(Position: POS, Name: ID)
-    nil
+    module(Position: POS, Kind: MODULEKIND, Name: ID, Definitions: DEFINITION)
 
 'type' SCOPE
     normal
@@ -67,6 +61,7 @@
 'type' DEFINITION
     sequence(Left: DEFINITION, Right: DEFINITION)
     metadata(Position: POS, Key: STRING, Value: STRING)
+    import(Position: POS, Name: ID)
     type(Position: POS, Access: ACCESS, Name: ID, Type: TYPE)
     constant(Position: POS, Access: ACCESS, Name: ID, Value: EXPRESSION)
     variable(Position: POS, Access: ACCESS, Name: ID, Type: TYPE)


### PR DESCRIPTION
This removes the distinction between pre-import and post-import
metadata, and allows "use" declarations to appear anywhere in a source
file.
