### PR TITLE
[[ Bug 15386 ]] Do not over-release the stack filename as ~MCStack ta…

### DIFF
--- a/docs/notes/bugfix-15386.md
+++ b/docs/notes/bugfix-15386.md
@@ -1,0 +1,1 @@
+# Failure to incorporate code with 'include' on 7.0 servers

--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -66,8 +66,6 @@ MCServerScript::~MCServerScript(void)
         else
             delete t_file -> script;
 
-        MCValueRelease(filename);
-
 		delete t_file;
 	}
 	


### PR DESCRIPTION
…kes care of it
