### PR TITLE
[[ Load Extension From Data ]] Allow loading extensions from data in a variable

### DIFF
--- a/docs/notes/feature-load_extensions_from_data.md
+++ b/docs/notes/feature-load_extensions_from_data.md
@@ -1,0 +1,1 @@
+# Extensions can be loaded from raw data using 'load extension from data <data>' syntax

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -708,12 +708,14 @@ class MCLoad : public MCStatement
 	MCExpression *message;
     bool is_extension : 1;
 	bool has_resource_path : 1;
+    bool from_data : 1;
 public:
 	MCLoad()
 	{
 		url = message = NULL;
         is_extension = false;
 		has_resource_path = false;
+        from_data = false;
 	}
 	virtual ~MCLoad();
 	virtual Parse_stat parse(MCScriptPoint &);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3830,6 +3830,8 @@ void MCEngineExecReturnValue(MCExecContext& ctxt, MCValueRef value);
 void MCEngineExecLoadExtension(MCExecContext& ctxt, MCStringRef filename, MCStringRef resource_path);
 void MCEngineExecUnloadExtension(MCExecContext& ctxt, MCStringRef filename);
 
+void MCEngineLoadExtensionFromData(MCExecContext& ctxt, MCDataRef p_extension_data, MCStringRef p_resource_path);
+
 void MCEngineSetCaseSensitive(MCExecContext& ctxt, bool p_value);
 void MCEngineGetCaseSensitive(MCExecContext& ctxt, bool& r_value);
 void MCEngineSetFormSensitive(MCExecContext& ctxt, bool p_value);

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -2078,6 +2078,7 @@ static LT sugar_table[] =
         {"callback", TT_CHUNK, CT_UNDEFINED},
 		{"caller", TT_UNDEFINED, SG_CALLER},
 		{"closed", TT_UNDEFINED, SG_CLOSED},
+        {"data", TT_UNDEFINED, SG_DATA},
 		{"effects", TT_UNDEFINED, SG_EFFECTS},
 		{"elevated", TT_UNDEFINED, SG_ELEVATED},
         {"empty", TT_CHUNK, CT_UNDEFINED},

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -341,8 +341,8 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
             return false;
         }
         
-        extern bool MCEngineAddExtensionFromModule(MCStringRef name, MCScriptModuleRef module);
-        if (!MCEngineAddExtensionFromModule(MCNameGetString(MCScriptGetNameOfModule(t_module)), t_module))
+        extern bool MCEngineAddExtensionFromModule(MCScriptModuleRef module);
+        if (!MCEngineAddExtensionFromModule(t_module))
         {
             MCScriptReleaseModule(t_module);
             return false;

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1904,6 +1904,9 @@ enum Sugar_constants {
     SG_EXTENSION,
 	SG_RESOURCE,
 	SG_PATH,
+    
+    // AL-2015-06-11: [[ Load Extension From Var ]] Add 'data' syntactic sugar
+    SG_DATA,
 };
 
 enum Statements {


### PR DESCRIPTION
Added a 'from data' variant of load extension that takes a DataRef and loads extension directly. 

Removed unused filename variable in MCEngineAddExtensionFromModule (since filename will not generally be applicable).
