### PR TITLE
[Bug 15495] Progress bar not updated when playing audio files

### DIFF
--- a/docs/notes/bugfix-15495.md
+++ b/docs/notes/bugfix-15495.md
@@ -1,0 +1,1 @@
+#     [Player] Progress Bar does not update when playing audio files and alwaysBuffer is true

--- a/engine/src/mac-av-player.mm
+++ b/engine/src/mac-av-player.mm
@@ -513,7 +513,17 @@ CVReturn MCAVFoundationPlayer::MyDisplayLinkCallback (CVDisplayLinkRef displayLi
                                 void *displayLinkContext)
 {
     MCAVFoundationPlayer *t_self = (MCAVFoundationPlayer *)displayLinkContext;
-        
+    
+    // PM-2015-06-12: [[ Bug 15495 ]] If the file has no video component, then just update the currentTime (no need to updateCurrentFrame, since there are no frames)
+    bool t_has_video;
+    t_has_video = ( [[[[t_self -> m_player currentItem] asset] tracksWithMediaType:AVMediaTypeVideo] count] != 0);
+    
+    if (!t_has_video)
+    {
+        t_self -> HandleCurrentTimeChanged();
+        return kCVReturnSuccess;
+    }
+    
     CMTime t_output_item_time = [t_self -> m_player_item_video_output itemTimeForCVTimeStamp:*inOutputTime];
     
     if (![t_self -> m_player_item_video_output hasNewPixelBufferForItemTime:t_output_item_time])


### PR DESCRIPTION
and alwaysBuffer is true
