### PR TITLE
[[ Bug 15457 ]] <repeat for each element> should use numeric order fo…

### DIFF
--- a/docs/notes/bugfix-15457.md
+++ b/docs/notes/bugfix-15457.md
@@ -1,0 +1,1 @@
+# Repeat for each element subtly different in 7.0

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -385,6 +385,8 @@ void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExp
 	MCNameRef t_key;
 	MCValueRef t_value;
 	uintptr_t t_iterator;
+    // SN2015-06-15: [[ Bug 15457 ]] The index can be a negative index.
+    index_t t_sequenced_iterator;
     const byte_t *t_data_ptr, *t_data_end;
     Parse_stat ps;
     MCScriptPoint *sp = nil;
@@ -405,12 +407,12 @@ void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExp
             if (!ctxt . ConvertToArray(*t_condition, &t_array))
                 return;
             
-            // If this is a numerical array, do it in order
-            if (each == FU_ELEMENT && MCArrayIsSequence(*t_array))
+            // SN-2015-06-15: [[ Bug 15457 ]] If this is a numerical array, do
+            //  it in order - even if it does not start at 1
+            if (each == FU_ELEMENT && MCArrayIsNumericSequence(*t_array, t_sequenced_iterator))
             {
                 t_sequence_array = true;
-                t_iterator = 1;
-                if (!MCArrayFetchValueAtIndex(*t_array, t_iterator, t_value))
+                if (!MCArrayFetchValueAtIndex(*t_array, t_sequenced_iterator, t_value))
                     return;
             }
             else
@@ -513,9 +515,11 @@ void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExp
                 case FU_ELEMENT:
                 {
                     loopvar -> set(ctxt, t_value);
+                    // SN-2015-06-15: [[ Bug 15457 ]] Sequenced, numeric arrays
+                    //  have their own iterator
                     if (t_sequence_array)
                     {
-                        if (!MCArrayFetchValueAtIndex(*t_array, ++t_iterator, t_value))
+                        if (!MCArrayFetchValueAtIndex(*t_array, ++t_sequenced_iterator, t_value))
                             endnext = true;
                     }
                     else

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -115,6 +115,10 @@ class MCObjectOutputStream;
 // with no holes).
 bool MCArrayIsSequence(MCArrayRef array);
 
+// SN-2015-06-15: [[ Bug 15457 ]] Returns true if the array a dense, numeric
+//  sequence - but does not have to start with 1.
+bool MCArrayIsNumericSequence(MCArrayRef self, index_t &r_start_index);
+
 // Constructs a string containing the list of all keys in the array separated by
 // the given delimiter.
 bool MCArrayListKeys(MCArrayRef array, char delimiter, MCStringRef& r_list);


### PR DESCRIPTION
…r any numeric sequence, start it with 1 or not
