### PR TITLE
libfoundation: Add MCStringCreateWithSysString() for most platforms.

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1468,7 +1468,7 @@ bool MCStringCreateWithCFString(CFStringRef cf_string, MCStringRef& r_string);
 bool MCStringCreateWithCFStringAndRelease(CFStringRef cf_string, MCStringRef& r_string);
 #endif
 
-#ifdef __LINUX__
+#if !defined(__WINDOWS__)
 // Create a string from a C string in the system encoding
 bool MCStringCreateWithSysString(const char *sys_string, MCStringRef &r_string);
 #endif

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -5042,6 +5042,27 @@ bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, s
     r_byte_count = t_byte_count;
     return true;
 }
+
+bool
+MCStringCreateWithSysString(const char *p_sys_string,
+                            MCStringRef & r_string)
+{
+	/* Count the number of chars */
+	size_t p_byte_count;
+	for (p_byte_count = 0; p_sys_string[p_byte_count] != '\0'; ++p_byte_count);
+
+	if (0 == p_byte_count)
+	{
+		r_string = MCValueRetain(kMCEmptyString);
+		return true;
+	}
+
+	return MCStringCreateWithBytes((const byte_t *) p_sys_string,
+	                               p_byte_count,
+	                               kMCStringEncodingUTF8,
+	                               false, /* is_external_rep */
+	                               r_string);
+}
 #endif
 
 bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)


### PR DESCRIPTION
On OS X, iOS, and Android platforms, "system strings" are UTF-8.
