### PR TITLE
libfoundation: Tweak string to/from bytes for ISO-8869-1 platforms.

### DIFF
--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -292,7 +292,7 @@ bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStr
 			return MCStringCreateWithChars(t_buffer.Ptr(), t_out_offset, r_string);
 		}
             break;
-#if !defined(__LINUX__) && !defined(__ANDROID__)
+#if !defined(__ISO_8859_1__)
         case kMCStringEncodingISO8859_1:
             break;
 #endif
@@ -1836,7 +1836,7 @@ bool MCStringConvertToBytes(MCStringRef self, MCStringEncoding p_encoding, bool 
             }
         }
         break;
-#if !defined(__LINUX__) && !defined(__ANDROID__)
+#if !defined(__ISO_8859_1__)
     case kMCStringEncodingISO8859_1:
         break;
 #endif


### PR DESCRIPTION
It's better to identify platforms with ISO 8859-1 native text by using
the `__ISO_8859_1__` macro than by enumerating them.
