### PR TITLE
[[ LCB ]] Reduce number of local variables in grammar_full.c

### DIFF
--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -1186,13 +1186,39 @@
 'token' END_OF_UNIT
 'token' NEXT_UNIT
 
+'action' DefineCustomInvokeList(INT, INVOKELIST)
+'action' LookupCustomInvokeList(INT -> INVOKELIST)
+
+'action' CustomInvokeLists(INT -> INVOKELIST)
+    'rule' CustomInvokeLists(Index -> List):
+        LookupCustomInvokeList(Index -> List)
+
+'action' MakeCustomInvokeMethodArgs1(MODE, INT -> INVOKESIGNATURE)
+    'rule' MakeCustomInvokeMethodArgs1(Mode, Index -> invokesignature(Mode, Index, nil)):
+    
+'action' MakeCustomInvokeMethodArgs2(MODE, INT, MODE, INT -> INVOKESIGNATURE)
+    'rule' MakeCustomInvokeMethodArgs2(Mode1, Index1, Mode2, Index2 -> invokesignature(Mode1, Index1, invokesignature(Mode2, Index2, nil))):
+
+'action' MakeCustomInvokeMethodArgs3(MODE, INT, MODE, INT, MODE, INT, -> INVOKESIGNATURE)
+    'rule' MakeCustomInvokeMethodArgs3(Mode1, Index1, Mode2, Index2, Mode3, Index3 -> invokesignature(Mode1, Index1, invokesignature(Mode2, Index2, invokesignature(Mode3, Index3, nil)))):
+
+'action' MakeCustomInvokeMethodList(STRING, INVOKEMETHODTYPE, INVOKESIGNATURE, INVOKEMETHODLIST -> INVOKEMETHODLIST)
+    'rule' MakeCustomInvokeMethodList(Name, Type, Signature, Previous -> methodlist(Name, Type, Signature, Previous))
+
+'action' MakeCustomInvokeList(STRING, STRING, INVOKEMETHODLIST, INVOKELIST -> INVOKELIST)
+    'rule' MakeCustomInvokeList(Name, ModuleName, Methods, Previous -> List)
+        Info::INVOKEINFO
+        Info'Index <- -1
+        Info'ModuleIndex <- -1
+        Info'Name <- Name
+        Info'ModuleName <- ModuleName
+        Info'Methods <- Methods
+        where(invokelist(Info, Previous) -> List)
+
 --*--*--*--*--*--*--*--
 
 'action' InitializeCustomInvokeLists()
     'rule' InitializeCustomInvokeLists():
-        -- nothing
-'action' CustomInvokeLists(INT -> INVOKELIST)
-    'rule' CustomInvokeLists(_ -> nil):
         -- nothing
 'nonterm' CustomStatements(-> STATEMENT)
     'rule' CustomStatements(-> nil):

--- a/toolchain/lc-compile/src/syntax-gen.c
+++ b/toolchain/lc-compile/src/syntax-gen.c
@@ -176,6 +176,9 @@ static SyntaxRuleRef s_rule = NULL;
 static SyntaxNodeRef s_stack[MAX_NODE_DEPTH];
 static unsigned int s_stack_index = 0;
 
+static long *s_invoke_lists = NULL;
+static long s_invoke_list_size = 0;
+
 static int IsSyntaxNodeEqualTo(SyntaxNodeRef p_left, SyntaxNodeRef p_right, int p_with_mark_values);
 
 static FILE* s_output;
@@ -1607,49 +1610,74 @@ static void GenerateUmbrellaSyntaxRule(const char *p_name, SyntaxRuleKind p_firs
     }
 }
 
+static const char *s_invoke_modes[] = { "In_Mode", "Out_Mode", "InOut_Mode" };
 static void GenerateInvokeMethodArg(SyntaxArgumentRef p_arg)
 {
-    static const char *s_modes[] = { "in", "out", "inout" };
-	
 	if (p_arg == NULL)
     {
-        fprintf(s_output, "nil");
+        fprintf(s_output, "Signature_Nil");
         return;
     }
     
-    fprintf(s_output, "invokesignature(%s, %ld, ", s_modes[p_arg -> mode], p_arg -> index);
+    fprintf(s_output, "invokesignature(%s, %ld, ", s_invoke_modes[p_arg -> mode], p_arg -> index);
     GenerateInvokeMethodArg(p_arg -> next);
     fprintf(s_output, ")");
 }
 
 static void GenerateInvokeMethodList(int p_index, int p_method_index, SyntaxMethodRef p_method)
 {
-    static const char *s_method_types[] = { "execute", "evaluate", "assign", "iterate" };
+    static const char *s_method_types[] = { "Execute_Type", "Evaluate_Type", "Assign_Type", "Iterate_Type" };
     const char *t_name;
-	
+	int t_arity;
+    SyntaxArgumentRef t_arg;
+    
 	if (p_method == NULL)
     {
-        fprintf(s_output, "    where(INVOKEMETHODLIST'nil -> MethodList_%d_%d)\n", p_index, p_method_index);
+        fprintf(s_output, "    where(MethodList_Nil -> MethodList_%d_%d)\n", p_index, p_method_index);
         return;
     }
-
-    GenerateInvokeMethodList(p_index, p_method_index + 1, p_method -> next);
+    
+    if (p_method -> next != NULL)
+        GenerateInvokeMethodList(p_index, p_method_index + 1, p_method -> next);
+    
+    for(t_arity = 0, t_arg = p_method -> arguments; t_arg != NULL; t_arity += 1, t_arg = t_arg -> next)
+        ;
+    
+    if (t_arity > 0 && t_arity <= 3)
+    {
+        fprintf(s_output, "    MakeCustomInvokeMethodArgs%d(", t_arity);
+        for(t_arg = p_method -> arguments; t_arg != NULL; t_arg = t_arg -> next)
+        {
+            fprintf(s_output, "%s, %ld", s_invoke_modes[t_arg -> mode], t_arg -> index);
+            if (t_arg -> next != NULL)
+                fprintf(s_output, ", ");
+        }
+        fprintf(s_output, " -> MethodListArgs_%d_%d)\n", p_index, p_method_index);
+    }
     
     GetStringOfNameLiteral(p_method -> name, &t_name);
-    fprintf(s_output, "    where(INVOKEMETHODLIST'methodlist(\"%s\", %s, ", t_name, s_method_types[p_method -> type]);
-    
-    GenerateInvokeMethodArg(p_method -> arguments);
-    
-    fprintf(s_output, ", MethodList_%d_%d) -> MethodList_%d_%d)\n", p_index, p_method_index + 1, p_index, p_method_index);
+    fprintf(s_output, "    MakeCustomInvokeMethodList(\"%s\", %s, ", t_name, s_method_types[p_method -> type]);
+    if (t_arity == 0)
+    {
+        fprintf(s_output, " Signature_Nil");
+    }
+    else if (t_arity < 3)
+        fprintf(s_output, "  MethodListArgs_%d_%d", p_index, p_method_index);
+    else
+        GenerateInvokeMethodArg(p_method -> arguments);
+    if (p_method -> next != NULL)
+        fprintf(s_output, ", MethodList_%d_%d -> MethodList_%d_%d)\n", p_index, p_method_index + 1, p_index, p_method_index);
+    else
+        fprintf(s_output, ", MethodList_Nil -> MethodList_%d_%d)\n", p_index, p_method_index);
 }
 
 static void GenerateInvokeLists(void)
 {
     int t_method_index = 1;
 	SyntaxRuleGroupRef t_group;
-	
-	for (t_group = s_groups; t_group != NULL; t_group = t_group -> next)
-        fprintf(s_output, "'var' CustomInvokeList%d: INVOKELIST\n", t_group -> index);
+    
+    int t_entry_count;
+    t_entry_count = 0;
     
     fprintf(s_output, "'action' InitializeCustomInvokeLists()\n");
     fprintf(s_output, "  'rule' InitializeCustomInvokeLists():\n");
@@ -1658,7 +1686,23 @@ static void GenerateInvokeLists(void)
         int t_index = 1;
 		SyntaxRuleRef t_rule;
         
-        fprintf(s_output, "    where(INVOKELIST'nil -> List_%d_0)\n", t_group -> index);
+        if ((t_entry_count % 10) == 0)
+        {
+            fprintf(s_output, "    InitializeCustomInvokeLists_%d\n\n", t_entry_count);
+            fprintf(s_output, "'action' InitializeCustomInvokeLists_%d\n", t_entry_count);
+            fprintf(s_output, "  'rule' InitializeCustomInvokeLists_%d\n", t_entry_count);
+            fprintf(s_output, "    where(INVOKELIST'nil -> List_Nil)\n");
+            fprintf(s_output, "    where(INVOKEMETHODLIST'nil -> MethodList_Nil)\n");
+            fprintf(s_output, "    where(INVOKESIGNATURE'nil -> Signature_Nil)\n");
+            fprintf(s_output, "    where(MODE'in -> In_Mode)\n");
+            fprintf(s_output, "    where(MODE'out -> Out_Mode)\n");
+            fprintf(s_output, "    where(MODE'inout -> InOut_Mode)\n");
+            fprintf(s_output, "    where(INVOKEMETHODTYPE'execute -> Execute_Type)\n");
+            fprintf(s_output, "    where(INVOKEMETHODTYPE'evaluate -> Evaluate_Type)\n");
+            fprintf(s_output, "    where(INVOKEMETHODTYPE'assign -> Assign_Type)\n");
+            fprintf(s_output, "    where(INVOKEMETHODTYPE'iterate -> Iterate_Type)\n");
+        }
+        
         for (t_rule = t_group -> rules; t_rule != NULL; t_rule = t_rule -> next)
         {
             const char *t_module, *t_name;
@@ -1667,100 +1711,21 @@ static void GenerateInvokeLists(void)
             
             GetStringOfNameLiteral(t_rule -> module, &t_module);
             GetStringOfNameLiteral(t_rule -> name, &t_name);
-            fprintf(s_output, "    Info_%d_%d::INVOKEINFO\n", t_group -> index, t_index);
-            fprintf(s_output, "    Info_%d_%d'Index <- -1\n", t_group -> index, t_index);
-            fprintf(s_output, "    Info_%d_%d'ModuleIndex <- -1\n", t_group -> index, t_index);
-            fprintf(s_output, "    Info_%d_%d'Name <- \"%s\"\n", t_group -> index, t_index, t_name);
-            fprintf(s_output, "    Info_%d_%d'ModuleName <- \"%s\"\n", t_group -> index, t_index, t_module);
-            fprintf(s_output, "    Info_%d_%d'Methods <- MethodList_%d_%d\n", t_group -> index, t_index, t_method_index, 0);
+            if (t_index - 1 > 0)
+                fprintf(s_output, "    MakeCustomInvokeList(\"%s\", \"%s\", MethodList_%d_%d, List_%d_%d -> List_%d_%d)\n",
+                    t_name, t_module, t_method_index, 0, t_group -> index, t_index - 1, t_group -> index, t_index);
+            else
+                fprintf(s_output, "    MakeCustomInvokeList(\"%s\", \"%s\", MethodList_%d_%d, List_Nil -> List_%d_%d)\n",
+                        t_name, t_module, t_method_index, 0, t_group -> index, t_index);
             
-            fprintf(s_output, "    where(invokelist(Info_%d_%d, List_%d_%d) -> List_%d_%d)\n", t_group -> index, t_index, t_group -> index, t_index - 1, t_group -> index, t_index);
             t_index += 1;
             t_method_index += 1;
         }
-        fprintf(s_output, "    CustomInvokeList%d <- List_%d_%d\n", t_group -> index, t_group -> index, t_index - 1);
-    }
-    
-    fprintf(s_output, "'action' CustomInvokeLists(INT -> INVOKELIST)\n");
-    for(t_group = s_groups; t_group != NULL; t_group = t_group -> next)
-    {
-        fprintf(s_output, "  'rule' CustomInvokeLists(Index -> List):\n");
-        fprintf(s_output, "    eq(Index, %d)\n", t_group -> index);
-        fprintf(s_output, "    CustomInvokeList%d -> List\n", t_group -> index);
+        fprintf(s_output, "    DefineCustomInvokeList(%d, List_%d_%d)\n", t_group -> index, t_group -> index, t_index - 1);
+        
+        t_entry_count += 1;
     }
 }
-
-#if 0
-static void GenerateInvokeLists(void)
-{
-    for(SyntaxRuleGroupRef t_group = s_groups; t_group != NULL; t_group = t_group -> next)
-        fprintf(s_output, "'var' CustomInvokeList%d: INVOKELIST\n", t_group -> index);
-    
-    fprintf(s_output, "'action' InitializeCustomInvokeLists()\n");
-    fprintf(s_output, "  'rule' InitializeCustomInvokeLists():\n");
-    for(SyntaxRuleGroupRef t_group = s_groups; t_group != NULL; t_group = t_group -> next)
-    {
-        static const char *s_modes[] = { "in", "out", "inout" };
-        
-        int t_index;
-        t_index = 1;
-        fprintf(s_output, "    where(INVOKESIGNATURE'nil -> LSig_%d_%d)\n", t_group -> index, 0);
-        fprintf(s_output, "    where(INVOKESIGNATURE'nil -> RSig_%d_%d)\n", t_group -> index, 0);
-        
-        SyntaxNodeRef t_node;
-        t_node = t_group -> rules -> expr;
-        
-        if (t_node -> right_trimmed)
-        {
-            fprintf(s_output, "    where(invokesignature(%s, LSig_%d_%d) -> LSig_%d_%d)\n", s_modes[t_node -> right_lmode], t_group -> index, t_index - 1, t_group -> index, t_index);
-            fprintf(s_output, "    where(invokesignature(%s, RSig_%d_%d) -> RSig_%d_%d)\n", s_modes[t_node -> right_rmode], t_group -> index, t_index - 1, t_group -> index, t_index);
-            t_index += 1;
-        }
-        for(int i = t_group -> rules -> expr -> mark_count; i > 0; i--)
-        {
-            fprintf(s_output, "    where(invokesignature(%s, LSig_%d_%d) -> LSig_%d_%d)\n", s_modes[t_group -> rules -> expr -> marks[i - 1] . lmode], t_group -> index, t_index - 1, t_group -> index, t_index);
-            fprintf(s_output, "    where(invokesignature(%s, RSig_%d_%d) -> RSig_%d_%d)\n", s_modes[t_group -> rules -> expr -> marks[i - 1] . rmode], t_group -> index, t_index - 1, t_group -> index, t_index);
-            t_index += 1;
-        }
-        if (t_node -> left_trimmed)
-        {
-            fprintf(s_output, "    where(invokesignature(%s, LSig_%d_%d) -> LSig_%d_%d)\n", s_modes[t_node -> left_lmode], t_group -> index, t_index - 1, t_group -> index, t_index);
-            fprintf(s_output, "    where(invokesignature(%s, RSig_%d_%d) -> RSig_%d_%d)\n", s_modes[t_node -> left_rmode], t_group -> index, t_index - 1, t_group -> index, t_index);
-            t_index += 1;
-        }
-        fprintf(s_output, "    where(LSig_%d_%d -> LSig_%d)\n", t_group -> index, t_index - 1, t_group -> index);
-        fprintf(s_output, "    where(RSig_%d_%d -> RSig_%d)\n", t_group -> index, t_index - 1, t_group -> index);
-        
-        t_index = 1;
-        fprintf(s_output, "    where(INVOKELIST'nil -> List_%d_0)\n", t_group -> index);
-        for(SyntaxRuleRef t_rule = t_group -> rules; t_rule != NULL; t_rule = t_rule -> next)
-        {
-            const char *t_module, *t_name;
-            GetStringOfNameLiteral(t_rule -> module, &t_module);
-            GetStringOfNameLiteral(t_rule -> name, &t_name);
-            fprintf(s_output, "    Info_%d_%d::INVOKEINFO\n", t_group -> index, t_index);
-            fprintf(s_output, "    Info_%d_%d'Index <- -1\n", t_group -> index, t_index);
-            fprintf(s_output, "    Info_%d_%d'ModuleIndex <- -1\n", t_group -> index, t_index);
-            fprintf(s_output, "    Info_%d_%d'Name <- \"%s\"\n", t_group -> index, t_index, t_name);
-            fprintf(s_output, "    Info_%d_%d'ModuleName <- \"%s\"\n", t_group -> index, t_index, t_module);
-            fprintf(s_output, "    Info_%d_%d'RSignature <- RSig_%d\n", t_group -> index, t_index, t_group -> index);
-            fprintf(s_output, "    Info_%d_%d'LSignature <- LSig_%d\n", t_group -> index, t_index, t_group -> index);
-            
-            fprintf(s_output, "    where(invokelist(Info_%d_%d, List_%d_%d) -> List_%d_%d)\n", t_group -> index, t_index, t_group -> index, t_index - 1, t_group -> index, t_index);
-            t_index += 1;
-        }
-        fprintf(s_output, "    CustomInvokeList%d <- List_%d_%d\n", t_group -> index, t_group -> index, t_index - 1);
-    }
-    
-    fprintf(s_output, "'action' CustomInvokeLists(INT -> INVOKELIST)\n");
-    for(SyntaxRuleGroupRef t_group = s_groups; t_group != NULL; t_group = t_group -> next)
-    {
-        fprintf(s_output, "  'rule' CustomInvokeLists(Index -> List):\n");
-        fprintf(s_output, "    eq(Index, %d)\n", t_group -> index);
-        fprintf(s_output, "    CustomInvokeList%d -> List\n", t_group -> index);
-    }
-}
-#endif
 
 static void GenerateTokenList(void)
 {
@@ -1791,6 +1756,27 @@ static void GenerateTokenList(void)
         fprintf(s_output, "    \"THISCANNEVERHAPPENORATLEASTWEHOPESO\"\n");
         fprintf(s_output, "    where(\"THISCANNEVERHAPPENORATLEASTWEHOPESO\" -> String)\n");
     }
+}
+
+void DefineCustomInvokeList(long index, long ptr)
+{
+    if (index >= s_invoke_list_size)
+    {
+        while(index >= s_invoke_list_size)
+        {
+            if (s_invoke_list_size == 0)
+                s_invoke_list_size = 1;
+            s_invoke_list_size *= 2;
+        }
+    
+        s_invoke_lists = (long *)Reallocate(s_invoke_lists, s_invoke_list_size * sizeof(long));
+    }
+    s_invoke_lists[index] = ptr;
+}
+
+void LookupCustomInvokeList(long index, long *r_ptr)
+{
+    *r_ptr = s_invoke_lists[index];
 }
 
 extern void DumpSyntaxRules(void);


### PR DESCRIPTION
The generation of the invoke info used by the compiler has been changed so that
it splits it into many functions with fewer local variables. This is to ensure
it doesn't break the C compilers optimization phases.
