### PR TITLE
[[ Bug 15509 ]] Ensure that 'case', 'repeat until' and 'repeat while'…

### DIFF
--- a/docs/notes/bugfix-15509.md
+++ b/docs/notes/bugfix-15509.md
@@ -1,0 +1,1 @@
+Condition "<expr> in <expr>" does not throw parse error for 'case' or 'repeat until/while'

--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -580,14 +580,29 @@ Parse_stat MCRepeat::parse(MCScriptPoint &sp)
 							return PS_ERROR;
 						}
 					}
+
+                    // SN-2015-06-17: [[ Bug 15509 ]] This is separate from
+                    //  the RF_UNTIL / RF_WHILE behaviour
+                    if (sp.parseexp(False, True, &endcond) != PS_NORMAL)
+                    {
+                        MCperror->add
+                        (PE_REPEAT_BADCOND, sp);
+                        return PS_ERROR;
+                    }
+                    break;
 				case RF_UNTIL:
-				case RF_WHILE:
-					if (sp.parseexp(False, True, &endcond) != PS_NORMAL)
-					{
-						MCperror->add
-						(PE_REPEAT_BADCOND, sp);
-						return PS_ERROR;
-					}
+                case RF_WHILE:
+                    // SN-2015-06-17: [[ Bug 15509 ]] We should reach the end
+                    //  of the line after having parsed the expression.
+                    //  That mimics the behaviour of MCIf::parse, where a <then>
+                    //  is compulsary after the expression parsed (here, an EOL)
+                    if (sp.parseexp(False, True, &endcond) != PS_NORMAL
+                            || sp.next(type) != PS_EOL)
+                    {
+                        MCperror->add
+                        (PE_REPEAT_BADCOND, sp);
+                        return PS_ERROR;
+                    }
 					break;
 				case RF_WITH:
 					if ((stat = sp.next(type)) != PS_NORMAL)
@@ -1434,7 +1449,12 @@ Parse_stat MCSwitch::parse(MCScriptPoint &sp)
 				case TT_CASE:
 					MCU_realloc((char **)&cases, ncases, ncases + 1,
 					            sizeof(MCExpression *));
-					if (sp.parseexp(False, True, &cases[ncases]) != PS_NORMAL)
+                    // SN-2015-06-16: [[ Bug 15509 ]] We should reach the end
+                    //  of the line after having parsed the <case> expression.
+                    //  That mimics the behaviour of MCIf::parse, where a <then>
+                    //  is compulsary after the expression parsed (here, an EOL)
+                    if (sp.parseexp(False, True, &cases[ncases]) != PS_NORMAL
+                            || sp.next(type) != PS_EOL)
 					{
 						MCperror->add
 						(PE_SWITCH_BADCASECONDITION, sp);


### PR DESCRIPTION
… conditions are correctly parsed - and does not silently fail
