### PR TITLE
[[ Bug 15509 ]] Ensure that 'case', 'repeat while' and 'repeat until'…

### DIFF
--- a/docs/notes/bugfix-15509.md
+++ b/docs/notes/bugfix-15509.md
@@ -1,0 +1,1 @@
+# Condition "<expr> in <expr>" does not throw parse error for 'case' or 'repeat until/while'

--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -604,6 +604,16 @@ Parse_stat MCRepeat::parse(MCScriptPoint &sp)
 				case RF_FOREVER:
 					break;
 				case RF_FOR:
+                {
+                    // SN-2015-06-18: [[ Bug 15509 ]] repeat for <n> times
+                    //  should get the whole line parsed, not only the <n> expr
+                    //  Otherwise,
+                    //      repeat for 4 garbage words that are not parsed
+                    //          put "a"
+                    //      end repeat
+                    //  is parsed with no issue
+                    bool t_is_for_each;
+                    t_is_for_each = false;
 					if (sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_EACH) == PS_NORMAL)
 					{
 						if (sp.next(type) != PS_NORMAL
@@ -625,17 +635,37 @@ Parse_stat MCRepeat::parse(MCScriptPoint &sp)
 						{
 							MCperror->add(PE_REPEAT_NOOF, sp);
 							return PS_ERROR;
-						}
+                        }
+                        
+                        t_is_for_each = true;
 					}
-
-                    // SN-2015-06-17: [[ Bug 15509 ]] This is separate from
-                    //  the RF_UNTIL / RF_WHILE behaviour
+                    
+                    // SN-2015-06-18: [[ Bug 15509 ]] Both 'repeat for each' and
+                    //  'repeat for <expr> times' need an expression
                     if (sp.parseexp(False, True, &endcond) != PS_NORMAL)
                     {
                         MCperror->add
                         (PE_REPEAT_BADCOND, sp);
                         return PS_ERROR;
                     }
+                    
+                    //  SN-2015-06-18: [[ Bug 15509 ]] In case we have not
+                    //  reached the end of the line after parsing the expression
+                    //  we have two possibilies:
+                    //    - in a 'repeat for each' loop, error
+                    //    - in a 'repeat for x times', error only if the line
+                    //      does not finish with 'times'
+                    if (sp.next(type) != PS_EOL
+                            && !(!t_is_for_each
+                                 && sp.lookup(SP_REPEAT, te) == PS_NORMAL
+                                 && te -> which == RF_TIMES
+                                 && sp.next(type) == PS_EOL))
+                    {
+                        MCperror->add
+                        (PE_REPEAT_BADCOND, sp);
+                        return PS_ERROR;
+                    }
+                }
                     break;
 				case RF_UNTIL:
                 case RF_WHILE:

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -1978,6 +1978,8 @@ static LT repeat_table[] =
         {"for", TT_UNDEFINED, RF_FOR},
         {"forever", TT_UNDEFINED, RF_FOREVER},
         {"step", TT_UNDEFINED, RF_STEP},
+        // SN-2015-06-18: [[ Bug 15509 ]] Parse 'times' in 'repeat for x times'
+        {"times", TT_UNDEFINED, RF_TIMES},
         {"until", TT_UNDEFINED, RF_UNTIL},
         {"while", TT_UNDEFINED, RF_WHILE},
         {"with", TT_UNDEFINED, RF_WITH}

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1715,7 +1715,9 @@ enum Repeat_form {
     RF_STEP,
     RF_UNTIL,
     RF_WHILE,
-    RF_WITH
+    RF_WITH,
+    // SN-2015-06-18: [[ Bug 15509 ]] Parse 'times' in 'repeat for x times'
+    RF_TIMES
 };
 
 enum Reset_type {


### PR DESCRIPTION
… condition is correctly parser - and does not silently fail
