### PR TITLE
[[Bug 15527]] libfoundation: Fix build on __LP32__ platforms. (7.0.6)

### DIFF
--- a/libfoundation/src/foundation-number.cpp
+++ b/libfoundation/src/foundation-number.cpp
@@ -143,13 +143,13 @@ bool MCNumberParseOffset(MCStringRef p_string, uindex_t offset, uindex_t char_co
         char *t_end;
         // SN-2014-10-06: [[ Bug 13594 ]] We want an unsigned integer if possible
         uinteger_t t_uinteger;
-#ifdef __LP64__
+#if defined(__LP64__)
         unsigned long t_ulong;
         t_ulong = strtoul(t_chars, &t_end, 10);
         if (t_ulong > UINTEGER_MAX)
             errno = ERANGE;
         t_uinteger = (uinteger_t) t_ulong;
-#elif __LP32__ || __LLP64__
+#elif defined(__LP32__) || defined(__LLP64__)
         t_uinteger = strtoul(t_chars, &t_end, 10);
 #endif
         


### PR DESCRIPTION
Correctly test whether preprocessor macros are defined.  Build failure
introduced in commit e107048b.
