### PR TITLE
[[ Bug ]] Syntax bindings not working correctly in lc-compile.

### DIFF
--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1543,9 +1543,9 @@
 'condition' ComputeInvokeSignature(INVOKEMETHODTYPE, INVOKELIST, EXPRESSIONLIST -> INVOKESIGNATURE)
 
     'rule' ComputeInvokeSignature(Type, invokelist(Head, Tail), Arguments -> Signature)
-        IsInvokeModuleAllowed(Head)
-        Head'Methods -> Methods
         (|
+            IsInvokeModuleAllowed(Head)
+            Head'Methods -> Methods
             ComputeInvokeSignatureForMethods(Type, Methods, Arguments -> Signature)
         ||
             ComputeInvokeSignature(Type, Tail, Arguments -> Signature)


### PR DESCRIPTION
When choosing the list of possible methods to bind to for a particular statement, lc-compile
will cut out all canvas and widget possibilities unless those modules are explicitly used.

However, rather than check this for each possible binding, it was only checking whether the
first binding was in canvas or widget thus making an implicit (incorrect) dependency on the
order of modules passed to the syntax compiler.
