### PR TITLE
lc-compile: Tweaks to bootstrap mode grammar generation.

### DIFF
--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -369,10 +369,16 @@ FILE *OpenOutputGrammarFile(const char **r_filename)
 {
     if (s_output_grammar_file == NULL)
         return NULL;
-    
+
 	if (NULL != r_filename)
 	{
 		*r_filename = s_output_grammar_file;
+	}
+
+	if (s_output_grammar_file[0] == '-' &&
+	    s_output_grammar_file[1] == '\0')
+	{
+		return stdout;
 	}
     
     return fopen(s_output_grammar_file, "w");

--- a/toolchain/lc-compile/src/syntax-gen.c
+++ b/toolchain/lc-compile/src/syntax-gen.c
@@ -1793,7 +1793,7 @@ void GenerateSyntaxRules(void)
     if (t_output != NULL)
         s_output = t_output;
     else
-        s_output = t_output = stderr;
+	    return;
     
     t_template = OpenTemplateFile();
     if (t_template != NULL)


### PR DESCRIPTION
It's handy not to have the entire grammar being dumped to the build log multiple times per build...
