### PR TITLE
[[ Bug 3537 ]] Make rawKeyDown and rawKeyUp send the same message, an…

### DIFF
--- a/docs/notes/bugfix-3536-2.md
+++ b/docs/notes/bugfix-3536-2.md
@@ -1,0 +1,1 @@
+# Make rawKeyUp and rawKeyDown consistent on non-Latin chars

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -549,11 +549,14 @@ void MCPlatformHandleDragDrop(MCPlatformWindowRef p_window, bool& r_accepted)
 ////////////////////////////////////////////////////////////////////////////////
 
 // SN-2014-09-15: [[ Bug 13423 ]] Added new static variable to keep the last keys pressed
+// SN-2015-06-23: [[ Bug 3537 ]] Sometimes a keyUp key message can be already
+//  mapped (when nativised).
 struct MCKeyMessage
 {
     MCPlatformKeyCode key_code;
     codepoint_t mapped_codepoint;
     codepoint_t unmapped_codepoint;
+    bool needs_mapping;
     struct MCKeyMessage* next;
 };
 
@@ -578,7 +581,9 @@ void MCKeyMessageClear(MCKeyMessage *&p_message_queue)
 }
 
 // SN-2014-11-03: [[ Bug 13832 ]] Added a message queue parameter
-void MCKeyMessageAppend(MCKeyMessage *&p_message_queue, MCPlatformKeyCode p_key_code, codepoint_t p_mapped_codepoint, codepoint_t p_unmapped_codepoint)
+// SN-2015-06-23: [[ Bug 3537 ]] If the input has already been nativised, then
+//  we don't want to map it with map_key_to_engine.
+void MCKeyMessageAppend(MCKeyMessage *&p_message_queue, MCPlatformKeyCode p_key_code, codepoint_t p_mapped_codepoint, codepoint_t p_unmapped_codepoint, bool p_needs_mapping = true)
 {
     MCKeyMessage *t_new;
     t_new = new MCKeyMessage;
@@ -586,6 +591,7 @@ void MCKeyMessageAppend(MCKeyMessage *&p_message_queue, MCPlatformKeyCode p_key_
     t_new -> key_code = p_key_code;
     t_new -> mapped_codepoint = p_mapped_codepoint;
     t_new -> unmapped_codepoint = p_unmapped_codepoint;
+    t_new -> needs_mapping = p_needs_mapping;
     t_new -> next = nil;
     
     if (p_message_queue != nil)
@@ -690,19 +696,27 @@ void MCPlatformHandleKeyDown(MCPlatformWindowRef p_window, MCPlatformKeyCode p_k
 
 void MCPlatformHandleKeyUp(MCPlatformWindowRef p_window, MCPlatformKeyCode p_key_code, codepoint_t p_mapped_codepoint, codepoint_t p_unmapped_codepoint)
 {
-    MCPlatformKeyCode t_mapped_key_code;
-    uint8_t t_mapped_char[2];
-    map_key_to_engine(p_key_code, p_mapped_codepoint, p_unmapped_codepoint, t_mapped_key_code, t_mapped_char);
-    
     // SN-2014-10-31: [[ Bug 13832 ]] We now output all the key messages that have been queued
     //  (by either MCPlatformHandleKeyDown, or MCPlatformHandleTextInputInsertText)
     while (s_pending_key_up != nil)
     {
         MCPlatformKeyCode t_mapped_key_code;
         uint8_t t_mapped_char[2];
-        map_key_to_engine(s_pending_key_up -> key_code, s_pending_key_up -> mapped_codepoint, s_pending_key_up -> unmapped_codepoint, t_mapped_key_code, t_mapped_char);
+        t_mapped_char[1] = '\0';
         
-        MCdispatcher -> wkup(p_window, (const char *)t_mapped_char, t_mapped_key_code);
+        // SN-2015-06-23: [[ Bug 3537 ]] We don't want to map a nativised char -
+        //  but we want to map key strokes like F1 and such
+        //  This is intended to mimic the behaviour of the key down process,
+        //  in which MCDispatcher::wkdown is called with the nativised char
+        if (s_pending_key_up -> needs_mapping)
+            map_key_to_engine(s_pending_key_up -> key_code, s_pending_key_up -> mapped_codepoint, s_pending_key_up -> unmapped_codepoint, t_mapped_key_code, t_mapped_char);
+        else
+        {
+            t_mapped_char[0] = s_pending_key_up -> mapped_codepoint;
+            t_mapped_key_code = s_pending_key_up -> key_code;
+        }
+
+        MCdispatcher -> wkup(p_window, (const char*)t_mapped_char, t_mapped_key_code);
         MCKeyMessageNext(s_pending_key_up);
     }
 }
@@ -905,15 +919,24 @@ void MCPlatformHandleTextInputInsertText(MCPlatformWindowRef p_window, unichar_t
     //    this wrong key is replaced by the dead-key char
     // SN-2015-04-10: [[ Bug 14205 ]] When using the dictation, there is no
     //  pending key down, but the composition was still on though.
-    if (t_was_compositing && s_pending_key_down)
+    // SN-2015-06-23: [[ Bug 3537 ]] We should not cast p_char as a uint1 if it
+    //  is not a native char.
+    uint1 t_char[2];
+    bool t_is_native_char;
+    t_is_native_char = MCUnicodeMapToNative(p_chars, 1, t_char[0]);
+    t_char[1] = 0;
+    
+    if (t_was_compositing && s_pending_key_down && t_is_native_char)
     {
-        s_pending_key_down -> key_code = (uint1)*p_chars;
-        s_pending_key_down -> mapped_codepoint = (uint1)*p_chars;
-        s_pending_key_down -> unmapped_codepoint = (uint1)*p_chars;
+        s_pending_key_down -> key_code = (uint1)*t_char;
+        s_pending_key_down -> mapped_codepoint = (uint1)*t_char;
+        s_pending_key_down -> unmapped_codepoint = (uint1)*t_char;
         
         // SN-2015-05-18: [[ Bug 15385 ]] Enqueue the first char in the sequence
         //  here - that will be the same as keyDown.
-        MCKeyMessageAppend(s_pending_key_up, (uint1)*p_chars, (uint1)*p_chars, (uint1)*p_chars);
+        // SN-2015-06-23: [[ Bug 3537 ]] In this only case, we don't want this
+        //  nativised char to be mapped again in MCPlatformHandleKeyUp.
+        MCKeyMessageAppend(s_pending_key_up, (uint1)*t_char, (uint1)*t_char, (uint1)*t_char, false);
     }
     
 	// Set the text.	
@@ -926,14 +949,12 @@ void MCPlatformHandleTextInputInsertText(MCPlatformWindowRef p_window, unichar_t
     // [Raw]KeyDown/Up and remove the first character from the sequence of keys typed.
     // If the character successfully combined with the dead char before it in a native char, we don't use finsert
     // Otherwise, we have the dead char in p_chars, we need to remove the one stored first in the sequence
-    uint1 t_char[2];
-    t_char[1] = 0;
     // SN-2015-01-20: [[ Bug 14406 ]] If we have a series of pending keys, we have two possibilities:
     //   - typing IME characters: the characters are native, so we use the finsertnew
     //   - typing dead characters: the character, if we arrive here,    is > 127
     // SN-2015-04-13: [[ Bug 14205 ]] Ensure that s_pending_key_down is not nil
     if (*p_chars > 127 && s_pending_key_down && s_pending_key_down -> next
-            && MCUnicodeMapToNative(p_chars, 1, t_char[0]))
+            && t_is_native_char)
     {
         MCdispatcher -> wkdown(p_window, (const char *)t_char, *t_char);
         


### PR DESCRIPTION
…d ensure char nativising when needed
