### PR TITLE
[[ LCB ]] New '--deps' option for lc-compile.

### DIFF
--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -7,7 +7,7 @@ lc-compile(1) -- compile LiveCode Builder source code
 
 **lc-compile** [_OPTION_ ...] --outputc _OUTFILE_ [--] _LCBFILE_
 
-**lc-compile** [_OPTION_ ...] --deps [ DEPKIND ] [--] _LCBFILE_ ... _LCBFILE...
+**lc-compile** [_OPTION_ ...] --deps [DEPKIND] [--] _LCBFILE_ ... _LCBFILE_...
 
 ## DESCRIPTION
 
@@ -34,7 +34,7 @@ specified.
   _OUTFILE_, which should be the path to a `.c` file.  If _OUTFILE_ already
   exists, it will be overwritten.
   
-* --deps make:
+* --deps [make]:
   Generate lci file dependencies in make format for the input source files.
 
 * --deps order:

--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -7,7 +7,7 @@ lc-compile(1) -- compile LiveCode Builder source code
 
 **lc-compile** [_OPTION_ ...] --outputc _OUTFILE_ [--] _LCBFILE_
 
-**lc-compile** [_OPTION_ ...] --deps [DEPKIND] [--] _LCBFILE_ ... _LCBFILE_...
+**lc-compile** [_OPTION_ ...] --deps [make|order|changed-order] [--] _LCBFILE_ ... _LCBFILE_...
 
 ## DESCRIPTION
 

--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -7,6 +7,8 @@ lc-compile(1) -- compile LiveCode Builder source code
 
 **lc-compile** [_OPTION_ ...] --outputc _OUTFILE_ [--] _LCBFILE_
 
+**lc-compile** [_OPTION_ ...] --deps [ DEPKIND ] [--] _LCBFILE_ ... _LCBFILE...
+
 ## DESCRIPTION
 
 **lc-compile** compiles the named input _LCBFILE_ to bytecode, saving the
@@ -31,6 +33,18 @@ specified.
   Generate LiveCode bytecode as a static array embedded in C source code in
   _OUTFILE_, which should be the path to a `.c` file.  If _OUTFILE_ already
   exists, it will be overwritten.
+  
+* --deps make:
+  Generate lci file dependencies in make format for the input source files.
+
+* --deps order:
+  Output the input source files in dependency order, the one that needs to be
+  compiled first being first.
+
+* --deps changed-order:
+  Output the input source files in dependency order, the one that needs to be
+  compiled first being first. Any source files which don't need to be recompiled
+  (based on timestamp comparisons with the interface files) will be omitted.
 
 * --manifest _MANIFEST_:
   Generate a module manifest in _MANIFEST_.  This is used by the LiveCode IDE.

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1814,20 +1814,24 @@ static bool DependProcess(NameRef p_module)
     }
     
     // If any dependent module interfaces are more recent than our interface then
-    // we must recompile.
-    for(int i = 0; i < s_depend_dep_count; i++)
+    // we must recompile. However, if we already know this module needs recompiled,
+    // then we don't need to check.
+    if (!t_changed)
     {
-        if (s_depend_deps[i] . module == p_module)
+        for(int i = 0; i < s_depend_dep_count; i++)
         {
-            DependMapping *t_depend_mapping;
-            if (DependFindMapping(s_depend_deps[i] . dependency, &t_depend_mapping))
-                if (t_depend_mapping -> interface_time > t_mapping -> interface_time)
-                {
-                    const char *t_depend_name;
-                    GetStringOfNameLiteral(s_depend_deps[i] . dependency, &t_depend_name);
-                    Debug_Depend("Recompiling '%s' as dependency '%s' interface newer", t_module_name, t_depend_name);
-                    t_changed = true;
-                }
+            if (s_depend_deps[i] . module == p_module)
+            {
+                DependMapping *t_depend_mapping;
+                if (DependFindMapping(s_depend_deps[i] . dependency, &t_depend_mapping))
+                    if (t_depend_mapping -> interface_time > t_mapping -> interface_time)
+                    {
+                        const char *t_depend_name;
+                        GetStringOfNameLiteral(s_depend_deps[i] . dependency, &t_depend_name);
+                        Debug_Depend("Recompiling '%s' as dependency '%s' interface newer", t_module_name, t_depend_name);
+                        t_changed = true;
+                    }
+            }
         }
     }
     

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1750,7 +1750,7 @@ struct DependDependency
     NameRef dependency;
 };
 
-int DependencyMode = 0;
+DependencyModeType DependencyMode = kDependencyModeNone;
 
 static DependMapping *s_depend_mappings;
 static int s_depend_mapping_count;
@@ -1853,33 +1853,13 @@ void DependStart(void)
 
 void DependFinish(void)
 {
-#if 0
-    for(int i = 0; i < s_depend_mapping_count; i++)
-    {
-        const char *t_module_name_string;
-        GetStringOfNameLiteral(s_depend_mappings[i] . module, &t_module_name_string);
-        fprintf(stdout, "%s>%s\n", t_module_name_string, s_depend_mappings[i] . source);
-        fprintf(stdout, "  is_interface = %d\n", s_depend_mappings[i] . is_interface);
-        fprintf(stdout, "  source_time = %ld\n", s_depend_mappings[i] . source_time);
-        fprintf(stdout, "  interface_time = %ld\n", s_depend_mappings[i] . interface_time);
-    }
-    
-    for(int i = 0; i < s_depend_dep_count; i++)
-    {
-        const char *t_module_name_string;
-        const char *t_dependency_name_string;
-        GetStringOfNameLiteral(s_depend_deps[i] . module, &t_module_name_string);
-        GetStringOfNameLiteral(s_depend_deps[i] . dependency, &t_dependency_name_string);
-        fprintf(stdout, "%s:%s\n", t_module_name_string, t_dependency_name_string);
-    }
-#endif
-    
-    if (DependencyMode < 3)
+    if (DependencyMode == kDependencyModeOrder ||
+        DependencyMode == kDependencyModeChangedOrder)
     {
         for(int i = 0; i < s_depend_mapping_count; i++)
             DependProcess(s_depend_mappings[i] . module);
     }
-    else if (DependencyMode == 3)
+    else if (DependencyMode == kDependencyModeMake)
     {
         const char *t_output_file;
         GetOutputFile(&t_output_file);

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1835,7 +1835,7 @@ static bool DependProcess(NameRef p_module)
         }
     }
     
-    if (DependencyMode == 1)
+    if (DependencyMode == kDependencyModeOrder)
         t_changed = true;
     
     // If we have changed, then emit the source file.

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -29,7 +29,7 @@ extern void InitializeCustomInvokeLists(void);
 
 static int s_is_bootstrap = 0;
 
-extern int DependencyMode;
+extern enum DependencyModeType DependencyMode;
 extern int OutputFileAsC;
 extern int OutputFileAsBytecode;
 
@@ -151,11 +151,11 @@ static void full_main(int argc, char *argv[])
                     t_option = "make";
                 
                 if (0 == strcmp(t_option, "make"))
-                    DependencyMode = 3;
+                    DependencyMode = kDependencyModeMake;
                 else if (0 == strcmp(t_option, "order"))
-                    DependencyMode = 1;
+                    DependencyMode = kDependencyModeOrder;
                 else if (0 == strcmp(t_option, "changed-order"))
-                    DependencyMode = 2;
+                    DependencyMode = kDependencyModeChangedOrder;
                 else
                 {
                     fprintf(stderr, "ERROR: Invalid --deps option '%s'.\n\n",

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -29,12 +29,18 @@ extern void InitializeCustomInvokeLists(void);
 
 static int s_is_bootstrap = 0;
 
+extern int DependencyMode;
 extern int OutputFileAsC;
 extern int OutputFileAsBytecode;
 
 int IsBootstrapCompile(void)
 {
     return s_is_bootstrap;
+}
+
+int IsDependencyCompile(void)
+{
+    return DependencyMode != 0;
 }
 
 void bootstrap_main(int argc, char *argv[])
@@ -83,6 +89,7 @@ usage(int status)
     fprintf(stderr,
 "Usage: lc-compile [OPTION ...] --output OUTFILE [--] LCBFILE\n"
 "       lc-compile [OPTION ...] --outputc OUTFILE [--] LCBFILE\n"
+"       lc-compile [OPTION ...] --deps DEPTYPE [--] LCBFILE ... LCBFILE\n"
 "\n"
 "Compile a LiveCode Builder source file.\n"
 "\n"
@@ -90,6 +97,12 @@ usage(int status)
 "      --modulepath PATH    Search PATH for module interface files.\n"
 "      --output OUTFILE     Filename for bytecode output.\n"
 "      --outputc OUTFILE    Filename for C source code output.\n"
+"      --deps make          Generate lci file dependencies in make format for\n"
+"                           the input source files.\n"
+"      --deps order         Generate the order the input source files should be\n"
+"                           compiled in.\n"
+"      --deps changed-order Generate the order the input source files should be\n"
+"                           compiled in, but only if they need recompiling.\n"
 "      --manifest MANIFEST  Filename for generated manifest.\n"
 "  -v, --verbose            Output extra debugging information.\n"
 "  -h, --help               Print this message.\n"
@@ -108,6 +121,7 @@ static void full_main(int argc, char *argv[])
 {
     /* Process options. */
     int have_input_file = 0;
+    int have_output_file = 0;
     int end_of_args = 0;
     int argi;
 
@@ -115,9 +129,41 @@ static void full_main(int argc, char *argv[])
     for (argi = 0; argi < argc; ++argi)
     {
         const char *opt = argv[argi];
-        const char *optarg = (argi + 1 < argc) ? argv[argi+1] : NULL;
+        const char *optarg = (argi + 1 < argc) && 0 != strncmp(argv[argi+1], "--", 2) ? argv[argi+1] : NULL;
         if (!end_of_args)
         {
+            if (0 == strcmp(opt, "--order"))
+            {
+                DependencyMode = 1;
+                continue;
+            }
+            if (0 == strcmp(opt, "--changed-order"))
+            {
+                DependencyMode = 2;
+                continue;
+            }
+            if (0 == strcmp(opt, "--deps"))
+            {
+                const char *t_option;
+                if (optarg)
+                    t_option = argv[++argi];
+                else
+                    t_option = "make";
+                
+                if (0 == strcmp(t_option, "make"))
+                    DependencyMode = 3;
+                else if (0 == strcmp(t_option, "order"))
+                    DependencyMode = 1;
+                else if (0 == strcmp(t_option, "changed-order"))
+                    DependencyMode = 2;
+                else
+                {
+                    fprintf(stderr, "ERROR: Invalid --deps option '%s'.\n\n",
+                            t_option);
+                    usage(1);
+                }
+                continue;
+            }
             if (0 == strcmp(opt, "--modulepath") && optarg)
             {
                 AddImportedModuleDir(argv[++argi]);
@@ -128,6 +174,7 @@ static void full_main(int argc, char *argv[])
                 SetOutputBytecodeFile(argv[++argi]);
                 OutputFileAsBytecode = 1;
                 OutputFileAsC = 0;
+                have_output_file = 1;
                 continue;
             }
             if (0 == strcmp(opt, "--outputc") && optarg)
@@ -135,6 +182,7 @@ static void full_main(int argc, char *argv[])
                 SetOutputCodeFile(argv[++argi]);
                 OutputFileAsC = 1;
                 OutputFileAsBytecode = 0;
+                have_output_file = 1;
                 continue;
             }
             if (0 == strcmp(opt, "--manifest") && optarg)
@@ -168,19 +216,27 @@ static void full_main(int argc, char *argv[])
         }
 
         /* Accept only one input file */
-        if (!have_input_file)
+        if (DependencyMode == 0 || have_output_file)
         {
-            AddFile(opt);
-            have_input_file = 1;
-            continue;
+            if (!have_input_file)
+            {
+                AddFile(opt);
+                have_input_file = 1;
+                continue;
+            }
+            else
+            {
+                fprintf(stderr, "WARNING: Ignoring multiple input filenames.\n");
+                continue;
+            }
+            
+            break; /* Doesn't match any option */
         }
         else
         {
-            fprintf(stderr, "WARNING: Ignoring multiple input filenames.\n");
-            continue;
+            AddFile(opt);
+            have_input_file = 1;
         }
-
-        break; /* Doesn't match any option */
     }
 
 	// If there is no filename, error.

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -40,7 +40,7 @@ int IsBootstrapCompile(void)
 
 int IsDependencyCompile(void)
 {
-    return DependencyMode != 0;
+    return DependencyMode != kDependencyModeNone;
 }
 
 void bootstrap_main(int argc, char *argv[])

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -132,16 +132,6 @@ static void full_main(int argc, char *argv[])
         const char *optarg = (argi + 1 < argc) && 0 != strncmp(argv[argi+1], "--", 2) ? argv[argi+1] : NULL;
         if (!end_of_args)
         {
-            if (0 == strcmp(opt, "--order"))
-            {
-                DependencyMode = 1;
-                continue;
-            }
-            if (0 == strcmp(opt, "--changed-order"))
-            {
-                DependencyMode = 2;
-                continue;
-            }
             if (0 == strcmp(opt, "--deps"))
             {
                 const char *t_option;

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -83,6 +83,13 @@ void GetFileOfPosition(long p_position, FileRef *r_file)
         Fatal_InternalInconsistency("Position encoded with invalid file index");
 }
 
+void GetFilenameOfPosition(long p_position, const char **r_filename)
+{
+    FileRef t_file;
+    GetFileOfPosition(p_position, &t_file);
+    GetFilePath(t_file, r_filename);
+}
+
 void GetCurrentPosition(long *r_result)
 {
     *r_result = s_current_position;
@@ -142,6 +149,40 @@ int AddImportedModuleFile(const char *p_name)
     AddFile(t_path);
     
     return 1;
+}
+
+void FindImportedModuleFile(const char *p_name, char** r_module_file)
+{
+    char t_path[4096];
+	FILE *t_file;
+    
+    t_file = NULL;
+    if (ImportedModuleDirCount > 0)
+    {
+		int i;
+        for(i = 0; i < ImportedModuleDirCount; i++)
+        {
+            sprintf(t_path, "%s/%s.lci", ImportedModuleDir[i], p_name);
+            t_file = fopen(t_path, "r");
+            if (t_file != NULL)
+                break;
+        }
+    }
+    else
+    {
+        sprintf(t_path, "%s.lci", p_name);
+        t_file = fopen(t_path, "r");
+    }
+    
+    if (t_file == NULL)
+    {
+        if (ImportedModuleDirCount > 0)
+            sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
+    }
+    else
+        fclose(t_file);
+    
+    *r_module_file = strdup(t_path);
 }
 
 FILE *
@@ -209,7 +250,7 @@ int FileAlreadyAdded(const char *p_filename)
 }
 
 void AddFile(const char *p_filename)
-{	
+{
 	FileRef t_new_file;
 	FileRef *t_last_file_ptr;
 	const char *t_name;
@@ -337,6 +378,14 @@ void SetManifestOutputFile(const char *p_output)
 void SetTemplateFile(const char *p_output)
 {
     s_template_file = p_output;
+}
+
+void GetOutputFile(const char **r_output)
+{
+    if (s_output_bytecode_file != NULL)
+        *r_output = s_output_bytecode_file;
+    else
+        *r_output = s_output_code_file;
 }
 
 FILE *OpenOutputBytecodeFile(const char **r_filename)

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -131,7 +131,7 @@ int AddImportedModuleFile(const char *p_name)
 		int i;
         for(i = 0; i < ImportedModuleDirCount; i++)
         {
-            sprintf(t_path, "%s/%s.lci", ImportedModuleDir[i], p_name);
+            /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[i], p_name);
             t_file = fopen(t_path, "r");
             if (t_file != NULL)
                 break;
@@ -139,7 +139,7 @@ int AddImportedModuleFile(const char *p_name)
     }
     else
     {
-        sprintf(t_path, "%s.lci", p_name);
+        /* OVERFLOW */ sprintf(t_path, "%s.lci", p_name);
         t_file = fopen(t_path, "r");
     }
     
@@ -164,7 +164,7 @@ void FindImportedModuleFile(const char *p_name, char** r_module_file)
 		int i;
         for(i = 0; i < ImportedModuleDirCount; i++)
         {
-            sprintf(t_path, "%s/%s.lci", ImportedModuleDir[i], p_name);
+            /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[i], p_name);
             t_file = fopen(t_path, "r");
             if (t_file != NULL)
                 break;
@@ -172,14 +172,14 @@ void FindImportedModuleFile(const char *p_name, char** r_module_file)
     }
     else
     {
-        sprintf(t_path, "%s.lci", p_name);
+        /* OVERFLOW */ sprintf(t_path, "%s.lci", p_name);
         t_file = fopen(t_path, "r");
     }
     
     if (t_file == NULL)
     {
         if (ImportedModuleDirCount > 0)
-            sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
+            /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
     }
     else
         fclose(t_file);
@@ -198,7 +198,7 @@ OpenImportedModuleFile (const char *p_name,
         return NULL;
 
     // Use the first modulepath to write the interface file into.
-    sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
+    /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
 
 	if (NULL != r_filename)
 	{

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -27,6 +27,8 @@
 #define ROWS_PER_FILE 10000
 #define COLUMNS_PER_FILE (COLUMNS_PER_ROW * ROWS_PER_FILE)
 
+#define MAXPATHLEN 4096
+
 static long s_current_position;
 
 void InitializePosition(void)
@@ -120,7 +122,7 @@ void AddImportedModuleDir(const char *p_dir)
 
 int AddImportedModuleFile(const char *p_name)
 {
-    char t_path[4096];
+    char t_path[MAXPATHLEN];
 	FILE *t_file;
     
     t_file = NULL;
@@ -153,7 +155,7 @@ int AddImportedModuleFile(const char *p_name)
 
 void FindImportedModuleFile(const char *p_name, char** r_module_file)
 {
-    char t_path[4096];
+    char t_path[MAXPATHLEN];
 	FILE *t_file;
     
     t_file = NULL;
@@ -189,7 +191,7 @@ FILE *
 OpenImportedModuleFile (const char *p_name,
                         char **r_filename)
 {
-    char t_path[4096];
+    char t_path[MAXPATHLEN];
     FILE *t_file;
 
     if (ImportedModuleDirCount == 0)

--- a/toolchain/lc-compile/src/position.h
+++ b/toolchain/lc-compile/src/position.h
@@ -36,6 +36,7 @@ void AdvanceCurrentPositionToFile(FileRef file);
 void GetColumnOfPosition(PositionRef position, long *r_column);
 void GetRowOfPosition(PositionRef position, long *r_row);
 void GetFileOfPosition(PositionRef position, FileRef *r_file);
+void GetFilenameOfPosition(PositionRef position, const char **r_filename);
 
 void GetCurrentPosition(PositionRef *r_result);
 void yyGetPos(PositionRef *r_result);
@@ -59,12 +60,15 @@ void SetOutputCodeFile(const char *filename);
 void SetOutputGrammarFile(const char *filename);
 void SetManifestOutputFile(const char *filename);
 void SetTemplateFile(const char *filename);
+void GetOutputFile(const char **r_filename);
+    
 FILE *OpenOutputBytecodeFile(const char **r_filename);
 FILE *OpenOutputGrammarFile(const char **r_filename);
 FILE *OpenOutputCodeFile(const char **r_filename);
 FILE *OpenManifestOutputFile(void);
 FILE *OpenTemplateFile(void);
 FILE *OpenImportedModuleFile(const char *module, char **r_filename);
+    void FindImportedModuleFile(const char *p_name, char** r_module_file);
 
 #ifdef __cplusplus
 }

--- a/toolchain/lc-compile/src/position.h
+++ b/toolchain/lc-compile/src/position.h
@@ -26,6 +26,14 @@ extern "C" {
 typedef long PositionRef;
 typedef struct File *FileRef;
 
+enum DependencyModeType
+{
+    kDependencyModeNone,
+    kDependencyModeOrder,
+    kDependencyModeChangedOrder,
+    kDependencyModeMake
+};
+    
 void InitializePosition(void);
 void FinalizePosition(void);
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -75,6 +75,23 @@ Debug_Emit(const char *p_format, ...)
 	va_end(t_args);
 }
 
+void
+Debug_Depend(const char *p_format, ...)
+{
+	va_list t_args;
+	
+	if (s_verbose_level < 1)
+		return;
+    
+	va_start(t_args, p_format);
+    
+	fprintf(stderr, "debug: [Depend] ");
+	vfprintf(stderr, p_format, t_args);
+	fprintf(stderr, "\n");
+    
+	va_end(t_args);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void Error_Bootstrap(const char *p_format, ...)
@@ -141,6 +158,9 @@ static void _Error(long p_position, const char *p_message)
 
 static void _Warning(long p_position, const char *p_message)
 {
+    if (IsDependencyCompile())
+        return;
+    
     _PrintPosition(p_position);
     fprintf(stderr, "warning: %s\n", p_message);
 }
@@ -159,6 +179,10 @@ static void _ErrorS(long p_position, const char *p_message, const char *p_string
 static void _WarningS(long p_position, const char *p_message, const char *p_string)
 {
     long t_row, t_column;
+    
+    if (IsDependencyCompile())
+        return;
+    
     GetColumnOfPosition(p_position, &t_column);
     GetRowOfPosition(p_position, &t_row);
     _PrintPosition(p_position);

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -46,6 +46,7 @@ void Warning_UnicodeEscapeTooBig(long position);
 void Error_Bootstrap(const char *format, ...);
 
 void Debug_Emit(const char *p_format, ...);
+void Debug_Depend(const char *p_format, ...);
 
 #ifdef __cplusplus
 }

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -31,6 +31,7 @@
     GetColumnOfCurrentPosition
     GetUndefinedPosition
     AddImportedModuleFile
+    GetFilenameOfPosition
 
     InitializeLiterals
     FinalizeLiterals
@@ -121,6 +122,12 @@
     PushInMarkArgumentSyntaxMapping
     PushOutMarkArgumentSyntaxMapping
     PushInOutMarkArgumentSyntaxMapping
+
+    IsDependencyCompile
+    DependStart
+    DependFinish
+    DependDefineMapping
+    DependDefineDependency
 
     EmitStart
     EmitFinish
@@ -337,6 +344,8 @@
 
 'condition' AddImportedModuleFile(Name: STRING)
 
+'action' GetFilenameOfPosition(Position: POS -> Filename: STRING)
+
 --------------------------------------------------------------------------------
 
 'action' InitializeLiterals()
@@ -458,6 +467,14 @@
 'action' PushRealArgumentSyntaxMapping(Value: DOUBLE)
 'action' PushStringArgumentSyntaxMapping(Value: STRING)
 'action' PushIndexedMarkArgumentSyntaxMapping(MarkIndex: INT, Index: INT)
+
+--------------------------------------------------------------------------------
+
+'condition' IsDependencyCompile()
+'action' DependStart()
+'action' DependFinish()
+'action' DependDefineMapping(ModuleName: NAME, SourceFile: STRING)
+'action' DependDefineDependency(ModuleName: NAME, RequiredModuleName: NAME)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The lc-compile command now has a '--deps' option to generate dependency information.

The first form is to specify either '--deps order' or '--deps changed-order'. In this mode
lc-compile will read in all input files specified and then output them in an ordered list
which is needed to compile them appropriately based on dependencies between them. If
'changed-order' is used then only files which need to recompiled based on timestamps
(comparing with the interface files). Note that you need to specify a --modulepath for
these modes to work, and lc-compile will not generate errors if it cannot find specific
interface files.

The second form is to specify '--deps make'. In this mode if you specify an --output option
it will generate makefile compatible dependency rules. In this case you must only specify
a single input file.

The third form is to specify '--deps make' without an output option. In this case, a Makefile
compatible list of dependencies will be generated specifying the dependencies between the
input source files and the interface files.
