### PR TITLE
[Bug 15549] MCParagraph::fmovefocus(): Allow any field translation.

### DIFF
--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -2840,6 +2840,9 @@ uint1 MCParagraph::fmovefocus(Field_translations type, bool p_force_logical)
             type = FT_FORWARDWORD;
             break;
 
+		case FT_UNDEFINED:
+			break;
+
 		default:
 			MCUnreachable();
 			break;

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -2840,11 +2840,8 @@ uint1 MCParagraph::fmovefocus(Field_translations type, bool p_force_logical)
             type = FT_FORWARDWORD;
             break;
 
-		case FT_UNDEFINED:
-			break;
-
 		default:
-			MCUnreachable();
+			/* Field translations that don't require RTL fix-ups */
 			break;
     }
 


### PR DESCRIPTION
Regression introduced in commit 0280749eb6bb.
