### PR TITLE
[[ Foundation ]] Fix MCStringCantBeNative

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1544,7 +1544,7 @@ bool MCStringIsEmpty(MCStringRef string);
 bool MCStringCanBeNative(MCStringRef string);
 
 // Returns true if under the given comparison conditions, string cannot be represented natively.
-bool MCStringCantBeNative(MCStringRef string, MCStringOptions p_options);
+bool MCStringCantBeEqualToNative(MCStringRef string, MCStringOptions p_options);
 
 // Returns true if the string is stored as native chars.
 bool MCStringIsNative(MCStringRef string);

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1109,9 +1109,6 @@ const unichar_t *MCStringGetCharPtr(MCStringRef self)
     if (__MCStringIsIndirect(self))
         __MCStringResolveIndirect(self);
     
-    if (self -> char_count == 0)
-        return (unichar_t *)"\0\0";
-    
     __MCStringUnnativize(self);
 	return self -> chars;
 }
@@ -1126,9 +1123,6 @@ const char_t *MCStringGetNativeCharPtr(MCStringRef self)
         
         return self -> native_chars;
     }
-    
-    if (self -> char_count == 0)
-        return (char_t *)"";
     
     return nil;
 }


### PR DESCRIPTION
The MCStringCantBeNative function has been renamed MCStringCantBeEqualToNative to make it
clearer what it is computing.

The implementation has been replaced by a much clearer version - it now definitely only
returns true if there is absolutely no way the given string could be equal to a native
string given the specified comparison options.
