### PR TITLE
Widget docs cleanup

### DIFF
--- a/extensions/widgets/header/header.lcb
+++ b/extensions/widgets/header/header.lcb
@@ -16,151 +16,7 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 /*
-
 This widget is a header bar.
-
-Name: headerTitle
-Type: property
-Summary: Sets the title of the header bar
-
-Syntax:
-set the headerTitle of <widget> to <pTitle>
-get the headerTitle of <widget>
-
-Parameters:
-pTitle (string): The text of the title of the header bar.
-
-Description:
-Sets the title of the header bar to any string.
-
-Name: headerSubtitle
-Type: property
-Summary: Sets the subtitle of the header bar
-
-Syntax:
-set the headerSubtitle of <widget> to <pSubtitle>
-get the headerSubtitle of <widget>
-
-Parameters:
-pSubtitle (string): The text of the subtitle of the header bar.
-
-Description:
-Sets the subtitle of the header bar to any string.
-
-Name: headerSubtitleIsOn
-Type: property
-Summary: Sets whether there is a subtitle in the header bar
-
-Syntax:
-set the headerSubtitleIsOn of <widget> to <pSubtitleIsOn>
-get the headerSubtitleIsOn of <widget>
-
-Parameters:
-pSubtitleIsOn (boolean): True or false
-
-Description:
-Controls whether there is a subtitle or not.
-
-Name: headerActions
-Type: property
-Summary: Sets the actions of the header bar
-
-Syntax:
-set the headerActions of <widget> to <pActions>
-get the headerActions of <widget>
-
-Parameters:
-pActions (list): The list of actions.
-
-Description:
-Sets the actions of the header bar from pActions, where pActions is a line delimited list of the actions, where each line is a comma delimited list
-of the different components of the action: name, label, icon
-
-Name: actionStyle
-Type: property
-Summary: Sets the header actions display style.
-
-Syntax:
-set the actionStyle of <widget> to <pActionStyle>
-get the actionStyle of <widget>
-
-Parameters:
-pActionStyle (enum): The style of the header actions display.
--"icons": Show the icons
--"names": Show the names
-
-Description:
-Sets the header actions display style of the control.
-
-Name: enableBackButton
-Type: property
-Summary: Controls whether the back button is enabled or not.
-
-Syntax:
-set the enableBackButton of <widget> to <pEnable>
-get the enableBackButton of <widget>
-
-Parameters:
-pEnable (boolean): True or false
-
-Description:
-Controls whether the back button is enabled or not.
-
-Name: showBackIcon
-Type: property
-Summary: Controls whether the back icon is displayed.
-
-Syntax:
-set the showBackIcon of <widget> to <pShow>
-get the showBackIcon of <widget>
-
-Parameters:
-pShow (boolean): True or false
-
-Description:
-Sets whether the back icon is showing or not.
-
-Name: backButtonLabel
-Type: property
-Summary: Sets the label of the back button.
-
-Syntax:
-set the backButtonLabel of <widget> to <pLabel>
-get the backButtonLabel of <widget>
-
-Parameters:
-pLabel (string): the label of the back button
-
-Description:
-Sets the label of the back button.
-
-Name: actionColor
-Type: property
-Summary: Sets the color of the actions and the back button.
-
-Syntax:
-set the actionColor of <widget> to <pColor>
-get the actionColor of <widget>
-
-Parameters:
-pColor (color): The color of the actions and back button
-
-Description:
-Sets the color of the actions and the back button.
-
-Name: showSearchIcon
-Type: property
-Summary: Sets whether there is a search icon in the header bar.
-
-Syntax:
-set the showSearchIcon of <widget> to <pShow>
-get the showSearchIcon of <widget>
-
-Parameters:
-pShow (boolean): True or false
-
-Description:
-Controls whether the search icon is displayed in the header bar.
 */
 
 -- declaring the extension as a widget, followed by identifier
@@ -179,51 +35,187 @@ metadata version is "1.0.0"
 metadata preferredSize is "320,64"
 
 -- property declarations
-property headerTitle          get mHeaderTitle           set setHeaderTitle
-property headerSubtitle       get mHeaderSubtitle        set setHeaderSubtitle
-property leftLabel            get mLeftLabel             set setLeftLabel
-property headerActions        get getHeaderActions       set setHeaderActions
-property actionNames          get getActionNames         set setActionNames
-property actionLabels         get getActionLabels        set setActionLabels
-property actionIcons          get getActionIcons         set setActionIcons
-property actionStyle          get mActionStyle           set setActionStyle
-property showBackIcon         get mShowBackIcon          set setShowBackIcon
-property showSearchIcon       get mShowSearchIcon        set setShowSearchIcon
-property actionColor          get getActionColor         set setActionColor
+/*
+Summary: Sets the title of the header bar
 
--- property metadata
+Syntax: set the headerTitle of <widget> to <pTitle>
+Syntax: get the headerTitle of <widget>
+
+Parameters:
+pTitle (string): The text of the title of the header bar.
+
+Description:
+Sets the title of the header bar to any string.
+*/
+property headerTitle          get mHeaderTitle           set setHeaderTitle
 metadata headerTitle.default is "Title"
 metadata headerTitle.label is "Title"
 
+/*
+Summary: Sets the subtitle of the header bar
+
+Syntax: set the headerSubtitle of <widget> to <pSubtitle>
+Syntax: get the headerSubtitle of <widget>
+
+Parameters:
+pSubtitle (string): The text of the subtitle of the header bar.
+
+Description:
+Sets the subtitle of the header bar to any string.
+*/
+property headerSubtitle       get mHeaderSubtitle        set setHeaderSubtitle
 metadata headerSubtitle.default is "Subtitle"
 metadata headerSubtitle.label is "Subtitle"
 
+/*
+Summary: Sets the label at the left hand side of the header
+
+Syntax: set the leftLabel of <widget> to <pLabel>
+Syntax: get the leftLabel of <widget>
+
+Parameters:
+pLabel (string): the label at the left hand side of the header
+
+Description:
+Sets the label at the left hand side of the header.
+*/
+property leftLabel            get mLeftLabel             set setLeftLabel
+metadata leftLabel.default is "Back"
+metadata leftLabel.label is "Left Label"
+
+/*
+Summary: Sets the actions of the header bar
+
+Syntax: set the headerActions of <widget> to <pActions>
+Syntax: get the headerActions of <widget>
+
+Parameters:
+pActions (list): The list of actions.
+
+Description:
+Sets the actions of the header bar from pActions, where pActions is a line delimited list of the actions, where each line is a comma delimited list
+of the different components of the action: name, label, icon
+*/
+property headerActions        get getHeaderActions       set setHeaderActions
 metadata headerActions.editor is "com.livecode.pi.navbar"
 metadata headerActions.label is "Header Actions"
 
+/*
+Summary: Sets the action names of the header bar
+
+Syntax: set the actionNames of <widget> to <pNames>
+Syntax: get the actionNames of <widget>
+
+Parameters:
+pNames (list): The list of names.
+
+Description:
+Sets the names of the header bar actions, where <pNames> is a comma delimited list of the names.
+*/
+property actionNames          get getActionNames         set setActionNames
 metadata actionNames.user_visible is "false"
+
+/*
+Summary: Sets the action labels of the header bar
+
+Syntax: set the actionLabels of <widget> to <pLabels>
+Syntax: get the actionLabels of <widget>
+
+Parameters:
+pLabels (list): The list of labels.
+
+Description:
+Sets the labels of the header bar actions, where <pLabels> is a comma delimited list of the labels.
+*/
+property actionLabels         get getActionLabels        set setActionLabels
 metadata actionLabels.user_visible is "false"
+
+/*
+Summary: Sets the action icons of the header bar
+
+Syntax: set the actionIcons of <widget> to <pIcons>
+Syntax: get the actionIcons of <widget>
+
+Parameters:
+pIcons (list): The list of icons.
+
+Description:
+Sets the icons of the header bar actions, where <pIcons> is a comma delimited list of the icon names.
+*/
+property actionIcons          get getActionIcons         set setActionIcons
 metadata actionIcons.user_visible is "false"
 
+/*
+Summary: Sets the header actions display style.
+
+Syntax: set the actionStyle of <widget> to <pActionStyle>
+Syntax: get the actionStyle of <widget>
+
+Parameters:
+pActionStyle (enum): The style of the header actions display.
+-"icons": Show the icons
+-"names": Show the names
+
+Description:
+Sets the header actions display style of the control.
+*/
+property actionStyle          get mActionStyle           set setActionStyle
 metadata actionStyle.editor is "com.livecode.pi.enum"
 metadata actionStyle.options is "icons,names"
 metadata actionStyle.default is "icons"
 metadata actionStyle.label is "Action Display Style"
 
+/*
+Summary: Controls whether the back icon is displayed.
+
+Syntax: set the showBackIcon of <widget> to <pShow>
+Syntax: get the showBackIcon of <widget>
+
+Parameters:
+pShow (boolean): True or false
+
+Description:
+Sets whether the back icon is showing or not.
+*/
+property showBackIcon         get mShowBackIcon          set setShowBackIcon
 metadata showBackIcon.editor is "com.livecode.pi.boolean"
 metadata showBackIcon.default is "true"
 metadata showBackIcon.label is "Show Back Icon"
 
-metadata leftLabel.default is "Back"
-metadata leftLabel.label is "Left Label"
+/*
+Summary: Sets whether there is a search icon in the header bar.
 
+Syntax: set the showSearchIcon of <widget> to <pShow>
+Syntax: get the showSearchIcon of <widget>
+
+Parameters:
+pShow (boolean): True or false
+
+Description:
+Controls whether the search icon is displayed in the header bar.
+*/
+property showSearchIcon       get mShowSearchIcon        set setShowSearchIcon
+metadata showSearchIcon.editor is "com.livecode.pi.boolean"
+metadata showSearchIcon.default is "false"
+metadata showSearchIcon.label is "Show Search Icon"
+
+/*
+Summary: Sets the color of the actions and the back button.
+
+Syntax: set the actionColor of <widget> to <pColor>
+Syntax: get the actionColor of <widget>
+
+Parameters:
+pColor (color): The color of the actions and back button
+
+Description:
+Sets the color of the actions and the back button.
+*/
+property actionColor          get getActionColor         set setActionColor
 metadata actionColor.editor is "com.livecode.pi.color"
 metadata actionColor.default is "0,121,255"
 metadata actionColor.label is "Action Color"
 
-metadata showSearchIcon.editor is "com.livecode.pi.boolean"
-metadata showSearchIcon.default is "false"
-metadata showSearchIcon.label is "Show Search Icon"
 
 -- private instance variables
 private variable mHeaderTitle as String

--- a/extensions/widgets/navbar/navbar.lcb
+++ b/extensions/widgets/navbar/navbar.lcb
@@ -33,109 +33,8 @@ end navigate
 
 Description:
 Handle the navigate message in the widget's object script to respond to a selection made by the user.
-
-Name: navNames
-Type: property
-Syntax: set the navNames of <widget> to <pNavNames>
-Syntax: get the navNames of <widget>
-Summary: Sets the list of names of navigation items
-
-Parameters:
-pNavNames(string): A comma delimited list of the navigation item names.
-
-Description:
-Sets the names of the navigation items of the widget. Adding an item to the navNames of a navbar widget causes a
-new navigation item to be created with the default icon and label. Removing an item from the navNames causes the
-corresponding item to be removed from the navigation items.
-
-Name: navLabels
-Type: property
-Syntax: set the navLabels of <widget> to <pNavLabels>
-Syntax: get the navLabels of <widget>
-Summary: Sets the list of labels of navigation items
-
-Parameters:
-pNavLabels(string): A comma delimited list of the navigation item labels.
-
-Description:
-Sets the labels of the navigation items of the widget. Adding an item to the navLabels of a navbar widget causes a
-new navigation item to be created with the default icon and name.
-
->*Note:* Removing an item from the navLabels does not cause the corresponding item to be removed from the navigation items,
-but merely resets it to the default label.
-
-Name: navIcons
-Type: property
-Syntax: set the navIcons of <widget> to <pNavIcons>
-Syntax: get the navIcons of <widget>
-Summary: Sets the list of icons of navigation items
-
-Parameters:
-pNavIcons(string): A comma delimited list of the navigation item icons.
-
-Description:
-Sets the icons of the navigation items of the widget. Adding an item to the navIcons of a navbar widget causes a
-new navigation item to be created with the default label and name.
-
-The name of an icon must be one of the names returned by the iconNames() function of the com.livecode.library.iconSVG library.
-
->*Note:* Removing an item from the navIcons does not cause the corresponding item to be removed from the navigation items,
-but merely resets it to the default icon.
-
-Name: selectedItem
-Type: property
-Syntax: set the selectedItem of <widget> to <pSelectedItem>
-Syntax: get the selectedItem of <widget>
-
-Summary: Sets the selected navigation item
-
-Parameters:
-pSelectedItem(integer): The number of a nav item.
-
-Description:
-Selects a navigation item.
-
-Name: itemStyle
-Type: property
-Syntax: set the itemStyle of <widget> to <pItemStyle>
-Syntax: get the itemStyle of <widget>
-
-Summary: The display style of the widget
-
-Parameters:
-pItemStyle(enum): The display style
--"icons": display icons only
--"names": display names only
--"icons and names": display icons and names
-
-Description:
-Use the <itemStyle> property to control which elements of the navigation items are displayed.
-
-Name: editMode
-Type: property
-Syntax: set the editMode of <widget> to (true | false)
-Syntax: get the editMode of <widget>
-
-Summary: Whether the widget is in edit mode or not
-
-Description:
-This is currently an experimental feature of the navigation bar, and allows the icons to
-be changed by clicking on the outlined regions, and new items to be added with the add button.
-
-Name: desiredHeight
-Type: property
-Syntax: get the desiredHeight of <widget>
-
-Summary: The height that the widget ought to be displayed at
-
-Example:
-create widget as "com.livecode.widget.navbar"
-set the height of it to the desiredHeight of it
-
-Description:
-Returns the height that the widget ought to be displayed at
-
 */
+
 -- declaring extension as widget, followed by identifier
 widget com.livecode.widget.navbar
 --
@@ -154,22 +53,87 @@ metadata title is "Navigation Bar"
 metadata preferredSize is "320,49"
 --
 
--- property declarations
+/*
+Syntax: set the navData of <widget> to <pNavArray>
+Syntax: get the navData of <widget>
+
+Summary:  The <navData> is all the collective data of the icons and labels of the navbar
+
+Parameters:
+pNavArray(array): An array containing all the navigation data:
+{ key (integer): The index of the navigation item
+	value (array): The array containing the data for the item at this index
+	{ key : "label"
+		value (string): The label of this item
+		key : "icon_name"
+		value (string) : The name of the icon to display when the item is not selected
+		key : "selected_icon_name"
+		value (string) : The name of the icon to display when the item is not selected
+	}
+}
+
+Description:
+The <navData> is a numerically keyed array, each element of which contains and array describing the label and icons of the
+navigation item at that index. Any individual keys ("label", "icon_name", "selected_icon_name") missing when setting the <navData>
+will be added, and set to their defaults - "circle" for the icons, and "New Item" for the label.
+
+>*Note:* Setting the <navData> to a non-numerically keyed array will cause an error to be thrown
+
+*/
 property navData get getNavData set setNavData
 metadata navData.editor is "com.livecode.pi.navbar"
 metadata navData.label is "Navigation Data"
 
+/*
+Syntax: set the itemStyle of <widget> to <pItemStyle>
+Syntax: get the itemStyle of <widget>
+
+Summary: The display style of the widget
+
+Parameters:
+pItemStyle(enum): The display style
+-"icons": display icons only
+-"names": display names only
+-"icons and names": display icons and names
+
+Description:
+Use the <itemStyle> property to control which elements of the navigation items are displayed.
+*/
 property itemStyle	get mItemStyle	set setItemStyle
 metadata itemStyle.editor is "com.livecode.pi.enum"
 metadata itemStyle.options is "icons,names,icons and names"
 metadata itemStyle.default is "icons and names"
 metadata itemStyle.label is "Display Style"
 
+/*
+Syntax: set the navHiliteColor of <widget> to <pColor>
+Syntax: get the navHiliteColor of <widget>
+
+Summary: The hilite color of the widget
+
+Parameters:
+pColor (color): The color of the navBar hilite
+
+Description:
+The color of the icon and text displayed when the navigation icon is selected.
+*/
 property navHiliteColor	get getHiliteColor set setHiliteColor
 metadata navHiliteColor.editor is "com.livecode.pi.color"
 metadata navHiliteColor.label is "Selected Item Color"
 metadata navHiliteColor.default is "0,121,255"
 
+/*
+Syntax: set the selectedItem of <widget> to <pSelectedItem>
+Syntax: get the selectedItem of <widget>
+
+Summary: Manipulates the value of the selected navigation item
+
+Parameters:
+pSelectedItem(integer): The number of a nav item.
+
+Description:
+Selects a navigation item.
+*/
 property selectedItem	get mSelectedItem 	set setNavSelectedItem
 metadata selectedItem.editor is "com.livecode.pi.integer"
 metadata selectedItem.default is "1"
@@ -177,18 +141,107 @@ metadata selectedItem.label is "Selected Item Index"
 metadata selectedItem.step is "1"
 metadata selectedItem.min is "1"
 
+/*
+Syntax: set the editMode of <widget> to (true | false)
+Syntax: get the editMode of <widget>
+
+Summary: Whether the widget is in edit mode or not
+
+Description:
+This is currently an experimental feature of the navigation bar, and allows the icons to
+be changed by clicking on the outlined regions, and new items to be added with the add button.
+*/
 property editMode get mEditMode set setEditMode
 metadata editMode.user_visible is "false"
 
+/*
+Name: navNames
+Type: property
+Syntax: set the navNames of <widget> to <pNavNames>
+Syntax: get the navNames of <widget>
+Summary: Sets the list of names of navigation items
+
+Parameters:
+pNavNames(string): A comma delimited list of the navigation item names.
+
+Description:
+Sets the names of the navigation items of the widget. Adding an item to the navNames of a navbar widget causes a
+new navigation item to be created with the default icon and label. Removing an item from the navNames causes the
+corresponding item to be removed from the navigation items.
+*/
 property navNames		get getNavNames			set setNavNames
 metadata navNames.user_visible is "false"
+
+/*
+Syntax: set the navIcons of <widget> to <pNavIcons>
+Syntax: get the navIcons of <widget>
+Summary: Sets the list of icons of navigation items
+
+Parameters:
+pNavIcons(string): A comma delimited list of the navigation item icons.
+
+Description:
+Sets the icons of the navigation items of the widget. Adding an item to the navIcons of a navbar widget causes a
+new navigation item to be created with the default label and name.
+
+The name of an icon must be one of the names returned by the iconNames() function of the com.livecode.library.iconSVG library.
+
+>*Note:* Removing an item from the navIcons does not cause the corresponding item to be removed from the navigation items,
+but merely resets it to the default icon.
+*/
 property navIcons		get getNavIcons			set setNavIcons
 metadata navIcons.user_visible is "false"
+
+/*
+Syntax: set the navSelectedIcons of <widget> to <pNavSelectedIcons>
+Syntax: get the navSelectedIcons of <widget>
+Summary: Sets the list of icons of navigation items
+
+Parameters:
+pNavSelectedIcons(string): A comma delimited list of the navigation item selected icons.
+
+Description:
+Sets the selected icons of the navigation items of the widget. Adding an item to the <navSelectedIcons> of a navbar widget causes a
+new navigation item to be created with the default label and name.
+
+The name of an icon must be one of the names returned by the iconNames() function of the com.livecode.library.iconSVG library.
+
+>*Note:* Removing an item from the navSelectedIcons does not cause the corresponding item to be removed from the navigation items,
+but merely resets it to the default icon.
+*/
 property navSelectedIcons		get getNavSelectedIcons			set setNavSelectedIcons
 metadata navSelectedIcons.user_visible is "false"
+
+/*
+Syntax: set the navLabels of <widget> to <pNavLabels>
+Syntax: get the navLabels of <widget>
+Summary: Sets the list of labels of navigation items
+
+Parameters:
+pNavLabels(string): A comma delimited list of the navigation item labels.
+
+Description:
+Sets the labels of the navigation items of the widget. Adding an item to the navLabels of a navbar widget causes a
+new navigation item to be created with the default icon and name.
+
+>*Note:* Removing an item from the navLabels does not cause the corresponding item to be removed from the navigation items,
+but merely resets it to the default label.
+*/
 property navLabels		get getNavLabels		set setNavLabels
 metadata navLabels.user_visible is "false"
 
+/*
+Syntax: get the desiredHeight of <widget>
+
+Summary: The height that the widget ought to be displayed at
+
+Example:
+create widget as "com.livecode.widget.navbar"
+set the height of it to the desiredHeight of it
+
+Description:
+Returns the height that the widget ought to be displayed at
+*/
 property desiredHeight	get getDesiredHeight
 metadata desiredHeight.user_visible is "false"
 
@@ -711,9 +764,7 @@ public handler OnGeometryChanged()
 	put true into mRecalculate
 end handler
 
-/*
-Callback when an icon is selected from the icon picker widget
-*/
+--Callback when an icon is selected from the icon picker widget
 public handler iconSelected(in pSelectedIcon as optional any, in pType as String, in pNumber as Number)
 	if pSelectedIcon is not nothing then
 		if pType is "selectedIcon" then
@@ -759,9 +810,7 @@ private handler yPosToLine(in pY as Number) returns Integer
 	return the floor of (pY / tLineHeight) + 1
 end handler
 
-/*
-Translate and scale xPath so that it fits within pTargetRect
-*/
+--Translate and scale xPath so that it fits within pTargetRect
 private handler setIconPath(in pTargetRect as Rectangle, inout xPath as Path)
 
 	// Scale the icon


### PR DESCRIPTION
Moved all the docs for widget properties to directly above the property declarations.
See also: https://github.com/runrev/livecode/pull/2484
