### PR TITLE
Fix our Android configure script so we don't need to replace the Andr…

### DIFF
--- a/INSTALL-android.md
+++ b/INSTALL-android.md
@@ -41,14 +41,6 @@ android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
     --install-dir=${HOME}/android/toolchain/standalone
 ````
 
-By default, the Android toolchain uses the `gold` linker.  However, this doesn't work for compiling LiveCode, so it's necessary to change the default linker to `ld.bfd` by replacing the `ld` symlink:
-
-````bash
-rm standalone/bin/arm-linux-androideabi-ld
-ln -s arm-linux-androideabi-ld.bfd \
-    standalone/bin/arm-linux-androideabi-ld
-````
-
 Add a couple of symlinks to allow the engine configuration script to find the Android toolchain:
 
 ````bash
@@ -79,7 +71,7 @@ COMMON_FLAGS="-target ${TRIPLE} -march=${ARCH}"
 
 CC="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -integrated-as"
 CXX="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -integrated-as"
-LINK="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS}"
+LINK="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -fuse-ld=bfd"
 AR="${BINDIR}/${TRIPLE}-ar"
 
 # Android platform information

--- a/config.sh
+++ b/config.sh
@@ -322,7 +322,7 @@ fi
 ANDROID_AR=${AR:-${ANDROID_TOOLCHAIN}ar}
 ANDROID_CC=${CC:-${ANDROID_TOOLCHAIN}clang -target arm-linux-androideabi -march=armv6 -integrated-as}
 ANDROID_CXX=${CXX:-${ANDROID_TOOLCHAIN}clang -target arm-linux-androideabi -march=armv6 -integrated-as}
-ANDROID_LINK=${LINK:-${ANDROID_TOOLCHAIN}clang -target arm-linux-androideabi -march=armv6 -integrated-as}
+ANDROID_LINK=${LINK:-${ANDROID_TOOLCHAIN}clang -target arm-linux-androideabi -march=armv6 -integrated-as -fuse-ld=bfd}
 ANDROID_OBJCOPY=${OBJCOPY:-${ANDROID_TOOLCHAIN}objcopy}
 ANDROID_OBJDUMP=${OBJDUMP:-${ANDROID_TOOLCHAIN}objdump}
 ANDROID_STRIP=${STRIP:-${ANDROID_TOOLCHAIN}strip}


### PR DESCRIPTION
…oid linker

We tell the compiler to link using the BFD version of ld rather than
the Gold linker so we no longer need to replace the ld symlink in the
Android toolchain.
