### PR TITLE
[Bug 15570] Do not run "after" handlers if error occurs.

### DIFF
--- a/docs/notes/bugfix-15570.md
+++ b/docs/notes/bugfix-15570.md
@@ -1,0 +1,1 @@
+# Do not run "after" handlers if an error occurs.

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -1066,7 +1066,7 @@ Exec_stat MCObject::handleself(Handler_type p_handler_type, MCNameRef p_message,
 				t_main_stat = exechandler(t_handler, p_parameters);
 
 				// If there was an error we are done.
-				if (t_stat == ES_ERROR)
+				if (t_main_stat == ES_ERROR)
 					return t_main_stat;
 			}
 		}


### PR DESCRIPTION
Incorrect variable in test.
