### PR TITLE
[[ Bug 15569 ]] Fix image loading and crash in case of failure in MCJPEGImageLoader::LoadFrames

### DIFF
--- a/docs/notes/bugfix-15569.md
+++ b/docs/notes/bugfix-15569.md
@@ -1,0 +1,1 @@
+# Referenced jpg crashes application on Linux

--- a/engine/src/ijpg.cpp
+++ b/engine/src/ijpg.cpp
@@ -808,7 +808,9 @@ bool MCJPEGImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 	if (t_row_buffer != nil)
 		MCMemoryDeallocate(t_row_buffer);
 
-	if (m_orientation != 0)
+    // SN-2015-07-07: [[ Bug 15569 ]] Ensure that we do not touch the image if
+    //  an error occured on decompression.
+    if (t_success && m_orientation != 0)
 		apply_exif_orientation(m_orientation, t_frame->image);
 
 	if (t_success)

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -1584,8 +1584,16 @@ IO_stat MCS_readall(void *p_ptr, uint32_t p_byte_count, IO_handle p_stream, uint
 	if (MCabortscript || p_ptr == NULL || p_stream == NULL)
 		return IO_ERROR;
     
+    // SN-2015-07-07: [[ Bug 15569 ]] Reading referenced images on Linux was
+    //  always failing, since it was reading a input buffer of 4096 bytes.
+    //  We should return IO_EOF in case the stream is exhausted, not an error.
     if (!p_stream -> Read(p_ptr, p_byte_count, r_bytes_read))
-        return IO_ERROR;
+    {
+        if (p_stream -> IsExhausted())
+            return IO_EOF;
+        else
+            return IO_ERROR;
+    }
     
     if (p_stream -> IsExhausted())
         return IO_EOF;


### PR DESCRIPTION
Image loading was broken by MCS_readall, which returned IO_ERROR on EOF
Crash was occurring when accessing the invalid, unloaded data on file reading failure.
