### PR TITLE
[Bug 15581] libgraphics: Draw Pango layout texts into full-size buffer.

### DIFF
--- a/libgraphics/src/lnxtext.cpp
+++ b/libgraphics/src/lnxtext.cpp
@@ -192,14 +192,14 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 	void *t_data;
 	t_data = nil;
 	if (t_success)
-		t_success = MCMemoryNew(t_clipped_bounds . width * t_clipped_bounds . height, t_data);
+		t_success = MCMemoryNew(t_text_bounds . width * t_text_bounds . height, t_data);
 	
 	if (t_success)
 	{
 		FT_Bitmap t_ftbitmap;
-		t_ftbitmap . rows = t_clipped_bounds . height;
-		t_ftbitmap . width = t_clipped_bounds . width;
-		t_ftbitmap . pitch = t_clipped_bounds . width;
+		t_ftbitmap . rows = t_text_bounds . height;
+		t_ftbitmap . width = t_text_bounds . width;
+		t_ftbitmap . pitch = t_text_bounds . width;
 		t_ftbitmap . buffer = (unsigned char*) t_data;
 		t_ftbitmap . num_grays = 256;
 		t_ftbitmap . pixel_mode = FT_PIXEL_MODE_GRAY;
@@ -220,7 +220,7 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 			t_blend_mode -> unref();		
 		
 		SkBitmap t_bitmap;
-		t_bitmap . setConfig(SkBitmap::kA8_Config, t_clipped_bounds . width, t_clipped_bounds .  height);
+		t_bitmap . setConfig(SkBitmap::kA8_Config, t_clipped_bounds . width, t_clipped_bounds .  height, t_text_bounds . width);
         t_bitmap . setAlphaType(kPremul_SkAlphaType);
 		t_bitmap . setPixels(t_data);
 		self -> layer -> canvas -> drawSprite(t_bitmap, t_clipped_bounds . x + t_device_location . x, 


### PR DESCRIPTION
Newer versions of Pango appear to cope badly with drawing into buffers
that are smaller than the full extents of the layout to be drawn.
Specifically, a buffer overrun can be reliably triggered by attempting
to draw glyphs into a 1 px-wide FT_Bitmap pixel buffer.

This patch modifies text rendering on Linux to always allocate a
full-size buffer for Pango to render into, but only draw the clipped
area to the target surface.

@runrevmark Is this fix appropriate for 7.1.0-dp-1? It's a complete showstopper on Fedora 22.

Closes-Bug: [15581](http://quality.runrev.com/show_bug.cgi?id=15581)
