### PR TITLE
buildbot: Upload intermediates to build server

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -149,6 +149,7 @@ dist-upload-files.txt:
 	                -o -name 'LiveCode*Server-*-Linux*.zip' \
 	                -o -name 'LiveCode*Server-*-Mac.zip' \
 	                -o -name 'LiveCode*Server-*-Windows.zip' \
+	                -o -name '*-bin.tar.xz' \
 	  > $@
 
 # Perform the upload.  This is in two steps:


### PR DESCRIPTION
Upload the intermediate build result archives (e.g. mac-bin.tar.xz)
to the build server, as well as the final installers.  These are
very useful for debugging why distbuilds are failing.
