### PR TITLE
Move MC_DLLEXPORT attributes to function definitions.

### DIFF
--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -417,20 +417,20 @@ bool MCSolveQuadraticEqn(MCGFloat p_a, MCGFloat p_b, MCGFloat p_c, MCGFloat &r_x
 bool MCCanvasTypesInitialize();
 void MCCanvasTypesFinalize();
 
-MCTypeInfoRef kMCCanvasRectangleTypeInfo;
-MCTypeInfoRef kMCCanvasPointTypeInfo;
-MCTypeInfoRef kMCCanvasColorTypeInfo;
-MCTypeInfoRef kMCCanvasTransformTypeInfo;
-MCTypeInfoRef kMCCanvasImageTypeInfo;
-MCTypeInfoRef kMCCanvasPaintTypeInfo;
-MCTypeInfoRef kMCCanvasSolidPaintTypeInfo;
-MCTypeInfoRef kMCCanvasPatternTypeInfo;
-MCTypeInfoRef kMCCanvasGradientTypeInfo;
-MCTypeInfoRef kMCCanvasGradientStopTypeInfo;
-MCTypeInfoRef kMCCanvasPathTypeInfo;
-MCTypeInfoRef kMCCanvasEffectTypeInfo;
-MCTypeInfoRef kMCCanvasFontTypeInfo;
-MCTypeInfoRef kMCCanvasTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasRectangleTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasPointTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasColorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasTransformTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasPaintTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasSolidPaintTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasPatternTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientStopTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasPathTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasEffectTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasFontTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -439,30 +439,30 @@ MCTypeInfoRef kMCCanvasTypeInfo;
 bool MCCanvasErrorsInitialize();
 void MCCanvasErrorsFinalize();
 
-MCTypeInfoRef kMCCanvasRectangleListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasPointListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasColorListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasScaleListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasTranslationListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasSkewListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasRadiiListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageSizeListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasRectangleListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasPointListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasColorListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasScaleListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasTranslationListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasSkewListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasRadiiListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageSizeListFormatErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasTransformMatrixListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasTransformDecomposeErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasTransformMatrixListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasTransformDecomposeErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasGradientStopRangeErrorTypeInfo;
-MCTypeInfoRef kMCCanvasGradientStopOrderErrorTypeInfo;
-MCTypeInfoRef kMCCanvasGradientTypeErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientStopRangeErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientStopOrderErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientTypeErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasPathPointListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasSVGPathParseErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasPathPointListFormatErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCCanvasSVGPathParseErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -641,11 +641,13 @@ bool MCProperListToRectangle(MCProperListRef p_list, MCGRectangle &r_rectangle)
 
 // Constructors
 
+MC_DLLEXPORT
 void MCCanvasRectangleMakeWithLTRB(MCCanvasFloat p_left, MCCanvasFloat p_top, MCCanvasFloat p_right, MCCanvasFloat p_bottom, MCCanvasRectangleRef &r_rect)
 {
 	/* UNCHECKED */ MCCanvasRectangleCreateWithMCGRectangle(MCGRectangleMake(p_left, p_top, p_right - p_left, p_bottom - p_top), r_rect);
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleMakeWithList(MCProperListRef p_list, MCCanvasRectangleRef &r_rect)
 {
 	MCGRectangle t_rect;
@@ -667,6 +669,7 @@ void MCCanvasRectangleSetMCGRectangle(const MCGRectangle &p_rect, MCCanvasRectan
 	MCValueRelease(t_rect);
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleGetLeft(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_left)
 {
 	MCGRectangle t_rect;
@@ -674,6 +677,7 @@ void MCCanvasRectangleGetLeft(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_left
 	r_left = t_rect.origin.x;
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleSetLeft(MCCanvasFloat p_left, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -683,6 +687,7 @@ void MCCanvasRectangleSetLeft(MCCanvasFloat p_left, MCCanvasRectangleRef &x_rect
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleGetTop(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_top)
 {
 	MCGRectangle t_rect;
@@ -690,6 +695,7 @@ void MCCanvasRectangleGetTop(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_top)
 	r_top = t_rect.origin.y;
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleSetTop(MCCanvasFloat p_top, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -699,6 +705,7 @@ void MCCanvasRectangleSetTop(MCCanvasFloat p_top, MCCanvasRectangleRef &x_rect)
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleGetRight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_right)
 {
 	MCGRectangle t_rect;
@@ -706,6 +713,7 @@ void MCCanvasRectangleGetRight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_rig
 	r_right = t_rect.origin.x + t_rect.size.width;
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleSetRight(MCCanvasFloat p_right, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -715,6 +723,7 @@ void MCCanvasRectangleSetRight(MCCanvasFloat p_right, MCCanvasRectangleRef &x_re
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleGetBottom(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_bottom)
 {
 	MCGRectangle t_rect;
@@ -722,6 +731,7 @@ void MCCanvasRectangleGetBottom(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_bo
 	r_bottom = t_rect.origin.y + t_rect.size.height;
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleSetBottom(MCCanvasFloat p_bottom, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -731,6 +741,7 @@ void MCCanvasRectangleSetBottom(MCCanvasFloat p_bottom, MCCanvasRectangleRef &x_
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleGetWidth(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_width)
 {
 	MCGRectangle t_rect;
@@ -738,6 +749,7 @@ void MCCanvasRectangleGetWidth(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_wid
 	r_width = t_rect.size.width;
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleSetWidth(MCCanvasFloat p_width, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -747,6 +759,7 @@ void MCCanvasRectangleSetWidth(MCCanvasFloat p_width, MCCanvasRectangleRef &x_re
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleGetHeight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_height)
 {
 	MCGRectangle t_rect;
@@ -754,6 +767,7 @@ void MCCanvasRectangleGetHeight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_he
 	r_height = t_rect.size.height;
 }
 
+MC_DLLEXPORT
 void MCCanvasRectangleSetHeight(MCCanvasFloat p_height, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -862,11 +876,13 @@ bool MCProperListFromPoint(const MCGPoint &p_point, MCProperListRef &r_list)
 
 // Constructors
 
+MC_DLLEXPORT
 void MCCanvasPointMake(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPointRef &r_point)
 {
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(MCGPointMake(p_x, p_y), r_point);
 }
 
+MC_DLLEXPORT
 void MCCanvasPointMakeWithList(MCProperListRef p_list, MCCanvasPointRef &r_point)
 {
 	MCGPoint t_point;
@@ -887,6 +903,7 @@ void MCCanvasPointSetMCGPoint(const MCGPoint &p_point, MCCanvasPointRef &x_point
 	MCValueRelease(t_point);
 }
 
+MC_DLLEXPORT
 void MCCanvasPointGetX(MCCanvasPointRef p_point, MCCanvasFloat &r_x)
 {
 	MCGPoint t_point;
@@ -894,6 +911,7 @@ void MCCanvasPointGetX(MCCanvasPointRef p_point, MCCanvasFloat &r_x)
 	r_x = t_point.x;
 }
 
+MC_DLLEXPORT
 void MCCanvasPointSetX(MCCanvasFloat p_x, MCCanvasPointRef &x_point)
 {
 	MCGPoint t_point;
@@ -903,6 +921,7 @@ void MCCanvasPointSetX(MCCanvasFloat p_x, MCCanvasPointRef &x_point)
 	MCCanvasPointSetMCGPoint(t_point, x_point);
 }
 
+MC_DLLEXPORT
 void MCCanvasPointGetY(MCCanvasPointRef p_point, MCCanvasFloat &r_y)
 {
 	MCGPoint t_point;
@@ -910,6 +929,7 @@ void MCCanvasPointGetY(MCCanvasPointRef p_point, MCCanvasFloat &r_y)
 	r_y = t_point.y;
 }
 
+MC_DLLEXPORT
 void MCCanvasPointSetY(MCCanvasFloat p_y, MCCanvasPointRef &x_point)
 {
 	MCGPoint t_point;
@@ -1069,11 +1089,13 @@ bool MCProperListToRGBA(MCProperListRef p_list, MCCanvasFloat &r_red, MCCanvasFl
 
 // Constructors
 
+MC_DLLEXPORT
 void MCCanvasColorMakeRGBA(MCCanvasFloat p_red, MCCanvasFloat p_green, MCCanvasFloat p_blue, MCCanvasFloat p_alpha, MCCanvasColorRef &r_color)
 {
 	/* UNCHECKED */ MCCanvasColorCreate(MCCanvasColorImplMake(p_red, p_blue, p_green, p_alpha), r_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorMakeWithList(MCProperListRef p_color, MCCanvasColorRef &r_color)
 {
 	MCCanvasFloat t_red, t_green, t_blue, t_alpha;
@@ -1096,11 +1118,13 @@ void MCCanvasColorSet(const __MCCanvasColorImpl &p_color, MCCanvasColorRef &x_co
 	MCValueRelease(t_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorGetRed(MCCanvasColorRef p_color, MCCanvasFloat &r_red)
 {
 	r_red = MCCanvasColorGetRed(p_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorSetRed(MCCanvasFloat p_red, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1113,11 +1137,13 @@ void MCCanvasColorSetRed(MCCanvasFloat p_red, MCCanvasColorRef &x_color)
 	MCCanvasColorSet(t_color, x_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorGetGreen(MCCanvasColorRef p_color, MCCanvasFloat &r_green)
 {
 	r_green = MCCanvasColorGetGreen(p_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorSetGreen(MCCanvasFloat p_green, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1130,11 +1156,13 @@ void MCCanvasColorSetGreen(MCCanvasFloat p_green, MCCanvasColorRef &x_color)
 	MCCanvasColorSet(t_color, x_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorGetBlue(MCCanvasColorRef p_color, MCCanvasFloat &r_blue)
 {
 	r_blue = MCCanvasColorGetBlue(p_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorSetBlue(MCCanvasFloat p_blue, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1147,11 +1175,13 @@ void MCCanvasColorSetBlue(MCCanvasFloat p_blue, MCCanvasColorRef &x_color)
 	MCCanvasColorSet(t_color, x_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorGetAlpha(MCCanvasColorRef p_color, MCCanvasFloat &r_alpha)
 {
 	r_alpha = MCCanvasColorGetAlpha(p_color);
 }
 
+MC_DLLEXPORT
 void MCCanvasColorSetAlpha(MCCanvasFloat p_alpha, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1333,16 +1363,19 @@ void MCCanvasTransformMake(const MCGAffineTransform &p_transform, MCCanvasTransf
 	/* UNCHECKED */ MCCanvasTransformCreateWithMCGAffineTransform(p_transform, r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeIdentity(MCCanvasTransformRef &r_transform)
 {
 	r_transform = MCValueRetain(kMCCanvasIdentityTransform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeScale(MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeScale(p_xscale, p_yscale), r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeScaleWithList(MCProperListRef p_scale, MCCanvasTransformRef &r_transform)
 {
 	MCGPoint t_scale;
@@ -1352,16 +1385,19 @@ void MCCanvasTransformMakeScaleWithList(MCProperListRef p_scale, MCCanvasTransfo
 	MCCanvasTransformMakeScale(t_scale.x, t_scale.y, r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeRotation(MCCanvasFloat p_angle, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)), r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeTranslation(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeTranslation(p_x, p_y), r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeTranslationWithList(MCProperListRef p_translation, MCCanvasTransformRef &r_transform)
 {
 	MCGPoint t_translation;
@@ -1371,11 +1407,13 @@ void MCCanvasTransformMakeTranslationWithList(MCProperListRef p_translation, MCC
 	MCCanvasTransformMakeTranslation(t_translation.x, t_translation.y, r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeSkew(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeSkew(p_x, p_y), r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeSkewWithList(MCProperListRef p_skew, MCCanvasTransformRef &r_transform)
 {
 	MCGPoint t_skew;
@@ -1385,11 +1423,13 @@ void MCCanvasTransformMakeSkewWithList(MCProperListRef p_skew, MCCanvasTransform
 	MCCanvasTransformMakeSkew(t_skew.x, t_skew.y, r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeWithMatrixValues(MCCanvasFloat p_a, MCCanvasFloat p_b, MCCanvasFloat p_c, MCCanvasFloat p_d, MCCanvasFloat p_tx, MCCanvasFloat p_ty, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMake(p_a, p_b, p_c, p_d, p_tx, p_ty), r_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformMakeWithMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &r_transform)
 {
 	MCGAffineTransform t_transform;
@@ -1412,11 +1452,13 @@ void MCCanvasTransformSetMCGAffineTransform(const MCGAffineTransform &p_transfor
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformGetMatrixAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_matrix)
 {
 	/* UNCHECKED */ MCProperListFromTransform(*MCCanvasTransformGet(p_transform), r_matrix);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformSetMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &x_transform)
 {
 	bool t_success;
@@ -1429,6 +1471,7 @@ void MCCanvasTransformSetMatrixAsList(MCProperListRef p_matrix, MCCanvasTransfor
 	MCCanvasTransformSetMCGAffineTransform(t_transform, x_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformGetInverse(MCCanvasTransformRef p_transform, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformInvert(*MCCanvasTransformGet(p_transform)), r_transform);
@@ -1483,6 +1526,7 @@ bool MCCanvasTransformDecompose(const MCGAffineTransform &p_transform, MCGPoint 
 	return true;
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformGetScaleAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_scale)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1497,6 +1541,7 @@ void MCCanvasTransformGetScaleAsList(MCCanvasTransformRef p_transform, MCProperL
 	/* UNCHECKED */ MCProperListFromPoint(t_scale, r_scale);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformSetScaleAsList(MCProperListRef p_scale, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1514,6 +1559,7 @@ void MCCanvasTransformSetScaleAsList(MCProperListRef p_scale, MCCanvasTransformR
 	MCCanvasTransformSetMCGAffineTransform(MCCanvasTransformCompose(t_scale, t_rotation, t_skew, t_translation), x_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformGetRotation(MCCanvasTransformRef p_transform, MCCanvasFloat &r_rotation)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1527,6 +1573,7 @@ void MCCanvasTransformGetRotation(MCCanvasTransformRef p_transform, MCCanvasFloa
 	r_rotation = MCCanvasAngleFromRadians(t_rotation);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformSetRotation(MCCanvasFloat p_rotation, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1541,6 +1588,7 @@ void MCCanvasTransformSetRotation(MCCanvasFloat p_rotation, MCCanvasTransformRef
 	MCCanvasTransformSetMCGAffineTransform(MCCanvasTransformCompose(t_scale, MCCanvasAngleToRadians(p_rotation), t_skew, t_translation), x_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformGetSkewAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_skew)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1555,6 +1603,7 @@ void MCCanvasTransformGetSkewAsList(MCCanvasTransformRef p_transform, MCProperLi
 	/* UNCHECKED */ MCProperListFromPoint(t_skew, r_skew);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformSetSkewAsList(MCProperListRef p_skew, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1572,6 +1621,7 @@ void MCCanvasTransformSetSkewAsList(MCProperListRef p_skew, MCCanvasTransformRef
 	MCCanvasTransformSetMCGAffineTransform(MCCanvasTransformCompose(t_scale, t_rotation, t_skew, t_translation), x_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformGetTranslationAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_translation)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1586,6 +1636,7 @@ void MCCanvasTransformGetTranslationAsList(MCCanvasTransformRef p_transform, MCP
 	/* UNCHECKED */ MCProperListFromPoint(t_translation, r_translation);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformSetTranslationAsList(MCProperListRef p_translation, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1612,16 +1663,19 @@ void MCCanvasTransformConcat(MCCanvasTransformRef &x_transform, const MCGAffineT
 	MCCanvasTransformSetMCGAffineTransform(MCGAffineTransformConcat(*MCCanvasTransformGet(x_transform), p_transform), x_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformConcat(MCCanvasTransformRef &x_transform, MCCanvasTransformRef p_transform)
 {
 	MCCanvasTransformConcat(x_transform, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformScale(MCCanvasTransformRef &x_transform, MCCanvasFloat p_x_scale, MCCanvasFloat p_y_scale)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeScale(p_x_scale, p_y_scale));
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformScaleWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -1631,16 +1685,19 @@ void MCCanvasTransformScaleWithList(MCCanvasTransformRef &x_transform, MCProperL
 	MCCanvasTransformScale(x_transform, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformRotate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_rotation)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_rotation)));
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformTranslate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_dx, MCCanvasFloat p_dy)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeTranslation(p_dx, p_dy));
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformTranslateWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -1650,12 +1707,14 @@ void MCCanvasTransformTranslateWithList(MCCanvasTransformRef &x_transform, MCPro
 	MCCanvasTransformTranslate(x_transform, t_translation.x, t_translation.y);
 }
 
+MC_DLLEXPORT
 void MCCanvasTransformSkew(MCCanvasTransformRef &x_transform, MCCanvasFloat p_xskew, MCCanvasFloat p_yskew)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeSkew(p_xskew, p_yskew));
 }
 
-void MCCanvasTransformSkew(MCCanvasTransformRef &x_transform, MCProperListRef p_skew)
+MC_DLLEXPORT
+void MCCanvasTransformSkewWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_skew)
 {
 	MCGPoint t_skew;
 	if (!MCProperListToSkew(p_skew, t_skew))
@@ -1755,6 +1814,7 @@ void MCCanvasImageMake(MCImageRep *p_image, MCCanvasImageRef &r_image)
 	/* UNCHECKED */ MCCanvasImageCreateWithImageRep(p_image, r_image);
 }
 
+MC_DLLEXPORT
 void MCCanvasImageMakeWithPath(MCStringRef p_path, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1770,6 +1830,7 @@ void MCCanvasImageMakeWithPath(MCStringRef p_path, MCCanvasImageRef &r_image)
 	MCImageRepRelease(t_image_rep);
 }
 
+MC_DLLEXPORT
 void MCCanvasImageMakeWithResourceFile(MCStringRef p_resource, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1785,6 +1846,7 @@ void MCCanvasImageMakeWithResourceFile(MCStringRef p_resource, MCCanvasImageRef 
 	MCImageRepRelease(t_image_rep);
 }
 
+MC_DLLEXPORT
 void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1801,6 +1863,7 @@ void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &r_image)
 }
 
 // Input should be unpremultiplied ARGB pixels
+MC_DLLEXPORT
 void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1816,6 +1879,7 @@ void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRe
 	MCImageRepRelease(t_image_rep);
 }
 
+MC_DLLEXPORT
 void MCCanvasImageMakeWithPixelsWithSizeAsList(MCProperListRef p_size, MCDataRef p_pixels, MCCanvasImageRef &r_image)
 {
 	integer_t t_size[2];
@@ -1830,6 +1894,7 @@ void MCCanvasImageMakeWithPixelsWithSizeAsList(MCProperListRef p_size, MCDataRef
 
 // Properties
 
+MC_DLLEXPORT
 void MCCanvasImageGetWidth(MCCanvasImageRef p_image, uint32_t &r_width)
 {
 	uint32_t t_width, t_height;
@@ -1841,6 +1906,7 @@ void MCCanvasImageGetWidth(MCCanvasImageRef p_image, uint32_t &r_width)
 	r_width = t_width;
 }
 
+MC_DLLEXPORT
 void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height)
 {
 	uint32_t t_width, t_height;
@@ -1852,6 +1918,7 @@ void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height)
 	r_height = t_height;
 }
 
+MC_DLLEXPORT
 void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MCDataRef &r_pixels)
 {
 	MCImageRep *t_image_rep;
@@ -1977,6 +2044,7 @@ bool MCCanvasPaintIsSolidPaint(MCCanvasPaintRef p_paint)
 
 // Constructor
 
+MC_DLLEXPORT
 void MCCanvasSolidPaintMakeWithColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &r_paint)
 {
 	/* UNCHECKED */ MCCanvasSolidPaintCreateWithColor(p_color, r_paint);
@@ -1984,11 +2052,13 @@ void MCCanvasSolidPaintMakeWithColor(MCCanvasColorRef p_color, MCCanvasSolidPain
 
 // Properties
 
+MC_DLLEXPORT
 void MCCanvasSolidPaintGetColor(MCCanvasSolidPaintRef p_paint, MCCanvasColorRef &r_color)
 {
 	r_color = MCValueRetain(MCCanvasSolidPaintGet(p_paint)->color);
 }
 
+MC_DLLEXPORT
 void MCCanvasSolidPaintSetColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &x_paint)
 {
 	MCCanvasSolidPaintRef t_paint;
@@ -2086,6 +2156,7 @@ void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, MCCanvasT
 	/* UNCHECKED */ MCCanvasPatternCreateWithImage(p_image, p_transform, r_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, const MCGAffineTransform &p_transform, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasTransformRef t_transform;
@@ -2097,16 +2168,19 @@ void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, const MCG
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternMakeWithImage(MCCanvasImageRef p_image, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, kMCCanvasIdentityTransform, r_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternMakeWithScaledImage(MCCanvasImageRef p_image, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, MCGAffineTransformMakeScale(p_xscale, p_yscale), r_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternMakeWithImageScaledWithList(MCCanvasImageRef p_image, MCProperListRef p_scale, MCCanvasPatternRef &r_pattern)
 {
 	MCGPoint t_scale;
@@ -2116,16 +2190,19 @@ void MCCanvasPatternMakeWithImageScaledWithList(MCCanvasImageRef p_image, MCProp
 	MCCanvasPatternMakeWithScaledImage(p_image, t_scale.x, t_scale.y, r_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternMakeWithRotatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_angle, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)), r_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternMakeWithTranslatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, MCGAffineTransformMakeTranslation(p_x, p_y), r_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternMakeWithImageTranslatedWithList(MCCanvasImageRef p_image, MCProperListRef p_translation, MCCanvasPatternRef &r_pattern)
 {
 	MCGPoint t_translation;
@@ -2147,21 +2224,25 @@ void MCCanvasPatternSet(MCCanvasImageRef p_image, MCCanvasTransformRef p_transfo
 	MCValueRelease(t_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternGetImage(MCCanvasPatternRef p_pattern, MCCanvasImageRef &r_image)
 {
 	r_image = MCValueRetain(MCCanvasPatternGet(p_pattern)->image);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternSetImage(MCCanvasImageRef p_image, MCCanvasPatternRef &x_pattern)
 {
 	MCCanvasPatternSet(p_image, MCCanvasPatternGet(x_pattern)->transform, x_pattern);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternGetTransform(MCCanvasPatternRef p_pattern, MCCanvasTransformRef &r_transform)
 {
 	r_transform = MCValueRetain(MCCanvasPatternGet(p_pattern)->transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternSetTransform(MCCanvasTransformRef p_transform, MCCanvasPatternRef &x_pattern)
 {
 	MCCanvasPatternSet(MCCanvasPatternGet(x_pattern)->image, p_transform, x_pattern);
@@ -2182,16 +2263,19 @@ void MCCanvasPatternTransform(MCCanvasPatternRef &x_pattern, const MCGAffineTran
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternTransform(MCCanvasPatternRef &x_pattern, MCCanvasTransformRef p_transform)
 {
 	MCCanvasPatternTransform(x_pattern, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternScale(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale)
 {
 	MCCanvasPatternTransform(x_pattern, MCGAffineTransformMakeScale(p_xscale, p_yscale));
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternScaleWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -2201,16 +2285,19 @@ void MCCanvasPatternScaleWithList(MCCanvasPatternRef &x_pattern, MCProperListRef
 	MCCanvasPatternScale(x_pattern, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternRotate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_angle)
 {
 	MCCanvasPatternTransform(x_pattern, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternTranslate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasPatternTransform(x_pattern, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT
 void MCCanvasPatternTranslateWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -2297,6 +2384,7 @@ __MCCanvasGradientStopImpl *MCCanvasGradientStopGet(MCCanvasGradientStopRef p_st
 
 // Constructors
 
+MC_DLLEXPORT
 void MCCanvasGradientStopMake(MCCanvasFloat p_offset, MCCanvasColorRef p_color, MCCanvasGradientStopRef &r_stop)
 {
 	/* UNCHECKED */ MCCanvasGradientStopCreate(p_offset, p_color, r_stop);
@@ -2313,11 +2401,13 @@ void MCCanvasGradientStopSet(MCCanvasFloat p_offset, MCCanvasColorRef p_color, M
 	MCValueRelease(t_stop);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientStopGetOffset(MCCanvasGradientStopRef p_stop, MCCanvasFloat &r_offset)
 {
 	r_offset = MCCanvasGradientStopGet(p_stop)->offset;
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientStopSetOffset(MCCanvasFloat p_offset, MCCanvasGradientStopRef &x_stop)
 {
 	__MCCanvasGradientStopImpl *t_stop;
@@ -2326,11 +2416,13 @@ void MCCanvasGradientStopSetOffset(MCCanvasFloat p_offset, MCCanvasGradientStopR
 	MCCanvasGradientStopSet(p_offset, t_stop->color, x_stop);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientStopGetColor(MCCanvasGradientStopRef p_stop, MCCanvasColorRef &r_color)
 {
 	r_color = MCValueRetain(MCCanvasGradientStopGet(p_stop)->color);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientStopSetColor(MCCanvasColorRef p_color, MCCanvasGradientStopRef &x_stop)
 {
 	__MCCanvasGradientStopImpl *t_stop;
@@ -2486,6 +2578,7 @@ bool MCCanvasGradientCheckStopOrder(MCProperListRef p_ramp)
 
 //////////
 
+MC_DLLEXPORT
 void MCCanvasGradientEvaluateType(integer_t p_type, integer_t& r_type)
 {
     r_type = p_type;
@@ -2493,6 +2586,7 @@ void MCCanvasGradientEvaluateType(integer_t p_type, integer_t& r_type)
 
 // Constructor
 
+MC_DLLEXPORT
 void MCCanvasGradientMakeWithRamp(integer_t p_type, MCProperListRef p_ramp, MCCanvasGradientRef &r_gradient)
 {
 	MCCanvasGradientRef t_gradient;
@@ -2527,11 +2621,13 @@ void MCCanvasGradientSet(const __MCCanvasGradientImpl &p_gradient, MCCanvasGradi
 	MCValueRelease(t_gradient);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetRamp(MCCanvasGradientRef p_gradient, MCProperListRef &r_ramp)
 {
 	r_ramp = MCValueRetain(MCCanvasGradientGet(p_gradient)->ramp);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetRamp(MCProperListRef p_ramp, MCCanvasGradientRef &x_gradient)
 {
 	if (!MCCanvasGradientCheckStopOrder(p_ramp))
@@ -2545,11 +2641,13 @@ void MCCanvasGradientSetRamp(MCProperListRef p_ramp, MCCanvasGradientRef &x_grad
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetTypeAsString(MCCanvasGradientRef p_gradient, MCStringRef &r_string)
 {
 	/* UNCHECKED */ MCCanvasGradientTypeToString(MCCanvasGradientGet(p_gradient)->function, r_string);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetTypeAsString(MCStringRef p_string, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2564,11 +2662,13 @@ void MCCanvasGradientSetTypeAsString(MCStringRef p_string, MCCanvasGradientRef &
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetRepeat(MCCanvasGradientRef p_gradient, integer_t &r_repeat)
 {
 	r_repeat = MCCanvasGradientGet(p_gradient)->repeats;
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetRepeat(integer_t p_repeat, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2579,11 +2679,13 @@ void MCCanvasGradientSetRepeat(integer_t p_repeat, MCCanvasGradientRef &x_gradie
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetWrap(MCCanvasGradientRef p_gradient, bool &r_wrap)
 {
 	r_wrap = MCCanvasGradientGet(p_gradient)->wrap;
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetWrap(bool p_wrap, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2594,11 +2696,13 @@ void MCCanvasGradientSetWrap(bool p_wrap, MCCanvasGradientRef &x_gradient)
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetMirror(MCCanvasGradientRef p_gradient, bool &r_mirror)
 {
 	r_mirror = MCCanvasGradientGet(p_gradient)->mirror;
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetMirror(bool p_mirror, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2659,6 +2763,7 @@ void MCCanvasGradientSetPoints(MCCanvasGradientRef &x_gradient, const MCGPoint &
 	MCCanvasGradientSetTransform(x_gradient, t_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetFrom(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_from)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2667,6 +2772,7 @@ void MCCanvasGradientGetFrom(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(t_from, r_from);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetTo(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_to)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2675,6 +2781,7 @@ void MCCanvasGradientGetTo(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_t
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(t_to, r_to);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetVia(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_via)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2683,6 +2790,7 @@ void MCCanvasGradientGetVia(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(t_via, r_via);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetFrom(MCCanvasPointRef p_from, MCCanvasGradientRef &x_gradient)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2690,6 +2798,7 @@ void MCCanvasGradientSetFrom(MCCanvasPointRef p_from, MCCanvasGradientRef &x_gra
 	MCCanvasGradientSetPoints(x_gradient, *MCCanvasPointGet(p_from), t_to, t_via);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetTo(MCCanvasPointRef p_to, MCCanvasGradientRef &x_gradient)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2697,6 +2806,7 @@ void MCCanvasGradientSetTo(MCCanvasPointRef p_to, MCCanvasGradientRef &x_gradien
 	MCCanvasGradientSetPoints(x_gradient, t_from, *MCCanvasPointGet(p_to), t_via);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetVia(MCCanvasPointRef p_via, MCCanvasGradientRef &x_gradient)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2704,11 +2814,13 @@ void MCCanvasGradientSetVia(MCCanvasPointRef p_via, MCCanvasGradientRef &x_gradi
 	MCCanvasGradientSetPoints(x_gradient, t_from, t_to, *MCCanvasPointGet(p_via));
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientGetTransform(MCCanvasGradientRef p_gradient, MCCanvasTransformRef &r_transform)
 {
 	r_transform = MCValueRetain(MCCanvasGradientGet(p_gradient)->transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientSetTransform(MCCanvasTransformRef p_transform, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2745,6 +2857,7 @@ bool MCProperListGetGradientStopInsertionPoint(MCProperListRef p_list, MCCanvasG
 	return true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientAddStop(MCCanvasGradientStopRef p_stop, MCCanvasGradientRef &x_gradient)
 {
 	bool t_success;
@@ -2805,16 +2918,19 @@ void MCCanvasGradientTransform(MCCanvasGradientRef &x_gradient, const MCGAffineT
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientTransform(MCCanvasGradientRef &x_gradient, MCCanvasTransformRef p_transform)
 {
 	MCCanvasGradientTransform(x_gradient, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientScale(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale)
 {
 	MCCanvasGradientTransform(x_gradient, MCGAffineTransformMakeScale(p_xscale, p_yscale));
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientScaleWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -2824,16 +2940,19 @@ void MCCanvasGradientScaleWithList(MCCanvasGradientRef &x_gradient, MCProperList
 	MCCanvasGradientScale(x_gradient, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientRotate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_angle)
 {
 	MCCanvasGradientTransform(x_gradient, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientTranslate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasGradientTransform(x_gradient, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT
 void MCCanvasGradientTranslateWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -2983,6 +3102,7 @@ bool MCProperListToRadii(MCProperListRef p_list, MCGPoint &r_radii)
 
 // Constructors
 
+MC_DLLEXPORT
 void MCCanvasPathMakeEmpty(MCCanvasPathRef &r_path)
 {
 	r_path = MCValueRetain(kMCCanvasEmptyPath);
@@ -3152,6 +3272,7 @@ void MCCanvasPathMakeWithMCGPath(MCGPathRef p_path, MCCanvasPathRef &r_path)
 }
 
 // TODO - investigate error handling in libgraphics, libskia - don't think skia mem errors are tested for
+MC_DLLEXPORT
 void MCCanvasPathMakeWithInstructionsAsString(MCStringRef p_instructions, MCCanvasPathRef &r_path)
 {
 	bool t_success;
@@ -3177,6 +3298,7 @@ void MCCanvasPathMakeWithInstructionsAsString(MCStringRef p_instructions, MCCanv
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithRoundedRectangleWithRadii(MCCanvasRectangleRef p_rect, MCCanvasFloat p_x_radius, MCCanvasFloat p_y_radius, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3192,11 +3314,13 @@ void MCCanvasPathMakeWithRoundedRectangleWithRadii(MCCanvasRectangleRef p_rect, 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithRoundedRectangle(MCCanvasRectangleRef p_rect, MCCanvasFloat p_radius, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithRoundedRectangleWithRadii(p_rect, p_radius, p_radius, r_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(MCCanvasRectangleRef p_rect, MCProperListRef p_radii, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3206,6 +3330,7 @@ void MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(MCCanvasRectangleRef p_
 	MCCanvasPathMakeWithRoundedRectangleWithRadii(p_rect, t_radii.x, t_radii.y, r_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithRectangle(MCCanvasRectangleRef p_rect, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3221,6 +3346,7 @@ void MCCanvasPathMakeWithRectangle(MCCanvasRectangleRef p_rect, MCCanvasPathRef 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithEllipse(MCCanvasPointRef p_center, MCCanvasFloat p_radius_x, MCCanvasFloat p_radius_y, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3236,6 +3362,7 @@ void MCCanvasPathMakeWithEllipse(MCCanvasPointRef p_center, MCCanvasFloat p_radi
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithEllipseWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3245,11 +3372,13 @@ void MCCanvasPathMakeWithEllipseWithRadiiAsList(MCCanvasPointRef p_center, MCPro
 	MCCanvasPathMakeWithEllipse(p_center, t_radii.x, t_radii.y, r_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithCircle(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithEllipse(p_center, p_radius, p_radius, r_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithLine(MCCanvasPointRef p_start, MCCanvasPointRef p_end, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3303,6 +3432,7 @@ bool MCCanvasPointsListToMCGPoints(MCProperListRef p_points, MCGPoint *&r_points
 	return t_success;
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithPoints(bool p_close, MCProperListRef p_points, MCCanvasPathRef &r_path)
 {
 	bool t_success;
@@ -3352,11 +3482,13 @@ static void MCCanvasPathMakeWithArcWithRadii(const MCGPoint &p_center, MCGFloat 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithArcWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithArcWithRadii(*MCCanvasPointGet(p_center), p_radius, p_radius, p_start_angle, p_end_angle, r_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithArcWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3383,11 +3515,13 @@ static void MCCanvasPathMakeWithSectorWithRadii(const MCGPoint &p_center, MCGFlo
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithSectorWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithSectorWithRadii(*MCCanvasPointGet(p_center), p_radius, p_radius, p_start_angle, p_end_angle, r_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithSectorWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3413,11 +3547,13 @@ static void MCCanvasPathMakeWithSegmentWithRadii(const MCGPoint &p_center, MCGFl
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithSegmentWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithSegmentWithRadii(*MCCanvasPointGet(p_center), p_radius, p_radius, p_start_angle, p_end_angle, r_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMakeWithSegmentWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3438,6 +3574,7 @@ void MCCanvasPathSetMCGPath(MCGPathRef p_path, MCCanvasPathRef &x_path)
 	MCValueRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathGetSubpaths(integer_t p_start, integer_t p_end, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpaths)
 {
 	MCGPathRef t_path;
@@ -3450,11 +3587,13 @@ void MCCanvasPathGetSubpaths(integer_t p_start, integer_t p_end, MCCanvasPathRef
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathGetSubpath(integer_t p_index, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpath)
 {
 	MCCanvasPathGetSubpaths(p_index, p_index, p_path, r_subpath);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathGetBoundingBox(MCCanvasPathRef p_path, MCCanvasRectangleRef &r_bounds)
 {
 	MCGRectangle t_rect;
@@ -3463,6 +3602,7 @@ void MCCanvasPathGetBoundingBox(MCCanvasPathRef p_path, MCCanvasRectangleRef &r_
 	/* UNCHECKED */ MCCanvasRectangleCreateWithMCGRectangle(t_rect, r_bounds);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathGetInstructionsAsString(MCCanvasPathRef p_path, MCStringRef &r_instruction_string)
 {
 	MCAutoStringRef t_instruction_string;
@@ -3496,16 +3636,19 @@ void MCCanvasPathTransform(MCCanvasPathRef &x_path, const MCGAffineTransform &p_
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathTransform(MCCanvasPathRef &x_path, MCCanvasTransformRef p_transform)
 {
 	MCCanvasPathTransform(x_path, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT
 void MCCanvasPathScale(MCCanvasPathRef &x_path, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale)
 {
 	MCCanvasPathTransform(x_path, MCGAffineTransformMakeScale(p_xscale, p_yscale));
 }
 
+MC_DLLEXPORT
 void MCCanvasPathScaleWithList(MCCanvasPathRef &x_path, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -3515,16 +3658,19 @@ void MCCanvasPathScaleWithList(MCCanvasPathRef &x_path, MCProperListRef p_scale)
 	MCCanvasPathScale(x_path, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathRotate(MCCanvasPathRef &x_path, MCCanvasFloat p_angle)
 {
 	MCCanvasPathTransform(x_path, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT
 void MCCanvasPathTranslate(MCCanvasPathRef &x_path, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasPathTransform(x_path, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT
 void MCCanvasPathTranslateWithList(MCCanvasPathRef &x_path, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -3534,6 +3680,7 @@ void MCCanvasPathTranslateWithList(MCCanvasPathRef &x_path, MCProperListRef p_tr
 	MCCanvasPathTranslate(x_path, t_translation.x, t_translation.y);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathAddPath(MCCanvasPathRef p_source, MCCanvasPathRef &x_dest)
 {
 	bool t_success;
@@ -3560,6 +3707,7 @@ void MCCanvasPathAddPath(MCCanvasPathRef p_source, MCCanvasPathRef &x_dest)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathMoveTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3586,6 +3734,7 @@ void MCCanvasPathMoveTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathLineTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3612,6 +3761,7 @@ void MCCanvasPathLineTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3638,6 +3788,7 @@ void MCCanvasPathCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3664,6 +3815,7 @@ void MCCanvasPathCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointR
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathClosePath(MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3690,6 +3842,7 @@ void MCCanvasPathClosePath(MCCanvasPathRef &x_path)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathArcTo(MCCanvasPointRef p_tangent, MCCanvasPointRef p_to, MCCanvasFloat p_radius, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3716,6 +3869,7 @@ void MCCanvasPathArcTo(MCCanvasPointRef p_tangent, MCCanvasPointRef p_to, MCCanv
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathEllipticArcToWithFlagsWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, bool p_largest, bool p_clockwise, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3746,6 +3900,7 @@ void MCCanvasPathEllipticArcToWithFlagsWithRadiiAsList(MCCanvasPointRef p_to, MC
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT
 void MCCanvasPathEllipticArcToWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3899,6 +4054,7 @@ __MCCanvasEffectImpl *MCCanvasEffectGet(MCCanvasEffectRef p_effect)
 
 //////////
 
+MC_DLLEXPORT
 void MCCanvasEffectEvaluateType(integer_t p_type, integer_t& r_type)
 {
 	r_type = p_type;
@@ -3906,6 +4062,7 @@ void MCCanvasEffectEvaluateType(integer_t p_type, integer_t& r_type)
 
 // Constructors
 
+MC_DLLEXPORT
 void MCCanvasEffectMakeWithPropertyArray(integer_t p_type, MCArrayRef p_properties, MCCanvasEffectRef &r_effect)
 {
 	// TODO - defaults for missing properties?
@@ -4016,16 +4173,19 @@ bool MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectType p_type)
 	return p_type == kMCCanvasEffectTypeInnerShadow || p_type == kMCCanvasEffectTypeOuterShadow;
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetTypeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_type)
 {
 	/* UNCHECKED */ MCCanvasEffectTypeToString(MCCanvasEffectGet(p_effect)->type, r_type);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetColor(MCCanvasEffectRef p_effect, MCCanvasColorRef &r_color)
 {
 	r_color = MCValueRetain(MCCanvasEffectGet(p_effect)->color);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectSetColor(MCCanvasColorRef p_color, MCCanvasEffectRef &x_effect)
 {
 	__MCCanvasEffectImpl t_effect;
@@ -4034,11 +4194,13 @@ void MCCanvasEffectSetColor(MCCanvasColorRef p_color, MCCanvasEffectRef &x_effec
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetBlendModeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_blend_mode)
 {
 	/* UNCHECKED */ MCCanvasBlendModeToString(MCCanvasEffectGet(p_effect)->blend_mode, r_blend_mode);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasEffectRef &x_effect)
 {
 	__MCCanvasEffectImpl t_effect;
@@ -4051,11 +4213,13 @@ void MCCanvasEffectSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasEffect
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetOpacity(MCCanvasEffectRef p_effect, MCCanvasFloat &r_opacity)
 {
 	r_opacity = MCCanvasEffectGet(p_effect)->opacity;
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectSetOpacity(MCCanvasFloat p_opacity, MCCanvasEffectRef &x_effect)
 {
 	__MCCanvasEffectImpl t_effect;
@@ -4064,6 +4228,7 @@ void MCCanvasEffectSetOpacity(MCCanvasFloat p_opacity, MCCanvasEffectRef &x_effe
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetSize(MCCanvasEffectRef p_effect, MCCanvasFloat &r_size)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(p_effect)->type))
@@ -4075,6 +4240,7 @@ void MCCanvasEffectGetSize(MCCanvasEffectRef p_effect, MCCanvasFloat &r_size)
 	r_size = MCCanvasEffectGet(p_effect)->size;
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectSetSize(MCCanvasFloat p_size, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(x_effect)->type))
@@ -4089,6 +4255,7 @@ void MCCanvasEffectSetSize(MCCanvasFloat p_size, MCCanvasEffectRef &x_effect)
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetSpread(MCCanvasEffectRef p_effect, MCCanvasFloat &r_spread)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(p_effect)->type))
@@ -4100,6 +4267,7 @@ void MCCanvasEffectGetSpread(MCCanvasEffectRef p_effect, MCCanvasFloat &r_spread
 	r_spread = MCCanvasEffectGet(p_effect)->spread;
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectSetSpread(MCCanvasFloat p_spread, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(x_effect)->type))
@@ -4114,6 +4282,7 @@ void MCCanvasEffectSetSpread(MCCanvasFloat p_spread, MCCanvasEffectRef &x_effect
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetDistance(MCCanvasEffectRef p_effect, MCCanvasFloat &r_distance)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(p_effect)->type))
@@ -4125,6 +4294,7 @@ void MCCanvasEffectGetDistance(MCCanvasEffectRef p_effect, MCCanvasFloat &r_dist
 	r_distance = MCCanvasEffectGet(p_effect)->distance;
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectSetDistance(MCCanvasFloat p_distance, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(x_effect)->type))
@@ -4139,6 +4309,7 @@ void MCCanvasEffectSetDistance(MCCanvasFloat p_distance, MCCanvasEffectRef &x_ef
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectGetAngle(MCCanvasEffectRef p_effect, MCCanvasFloat &r_angle)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(p_effect)->type))
@@ -4150,6 +4321,7 @@ void MCCanvasEffectGetAngle(MCCanvasEffectRef p_effect, MCCanvasFloat &r_angle)
 	r_angle = MCCanvasEffectGet(p_effect)->angle;
 }
 
+MC_DLLEXPORT
 void MCCanvasEffectSetAngle(MCCanvasFloat p_angle, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(x_effect)->type))
@@ -4296,17 +4468,20 @@ bool MCCanvasFontGetDefault(MCCanvasFontRef &r_font)
 }
 
 // Constructors
+MC_DLLEXPORT
 void MCCanvasFontMakeWithSize(MCStringRef p_name, bool p_bold, bool p_italic, integer_t p_size, MCCanvasFontRef &r_font)
 {
 	/* UNCHECKED */ MCCanvasFontCreate(p_name, MCFontStyleMake(p_bold, p_italic), p_size, r_font);
 }
 
+MC_DLLEXPORT
 void MCCanvasFontMakeWithStyle(MCStringRef p_name, bool p_bold, bool p_italic, MCCanvasFontRef &r_font)
 {
 	// TODO - confirm default font size - make configurable?
 	/* UNCHECKED */ MCCanvasFontCreate(p_name, MCFontStyleMake(p_bold, p_italic), 12, r_font);
 }
 
+MC_DLLEXPORT
 void MCCanvasFontMake(MCStringRef p_name, MCCanvasFontRef &r_font)
 {
 	MCCanvasFontMakeWithStyle(p_name, false, false, r_font);
@@ -4334,11 +4509,13 @@ void MCCanvasFontSetProps(MCCanvasFontRef &x_font, MCStringRef p_name, MCFontSty
 	MCValueRelease(t_font);
 }
 
+MC_DLLEXPORT
 void MCCanvasFontGetName(MCCanvasFontRef p_font, MCStringRef &r_name)
 {
 	r_name = MCValueRetain(MCNameGetString(MCFontGetName(MCCanvasFontGetMCFont(p_font))));
 }
 
+MC_DLLEXPORT
 void MCCanvasFontSetName(MCStringRef p_name, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4349,11 +4526,13 @@ void MCCanvasFontSetName(MCStringRef p_name, MCCanvasFontRef &x_font)
 	MCCanvasFontSetProps(x_font, p_name, t_style, t_size);
 }
 
+MC_DLLEXPORT
 void MCCanvasFontGetBold(MCCanvasFontRef p_font, bool &r_bold)
 {
 	r_bold = MCFontStyleIsBold(MCFontGetStyle(MCCanvasFontGetMCFont(p_font)));
 }
 
+MC_DLLEXPORT
 void MCCanvasFontSetBold(bool p_bold, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4364,11 +4543,13 @@ void MCCanvasFontSetBold(bool p_bold, MCCanvasFontRef &x_font)
 	MCCanvasFontSetProps(x_font, t_name, MCFontStyleSetFlag(t_style, kMCFontStyleBold, p_bold), t_size);
 }
 
+MC_DLLEXPORT
 void MCCanvasFontGetItalic(MCCanvasFontRef p_font, bool &r_italic)
 {
 	r_italic = MCFontStyleIsItalic(MCFontGetStyle(MCCanvasFontGetMCFont(p_font)));
 }
 
+MC_DLLEXPORT
 void MCCanvasFontSetItalic(bool p_italic, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4379,11 +4560,13 @@ void MCCanvasFontSetItalic(bool p_italic, MCCanvasFontRef &x_font)
 	MCCanvasFontSetProps(x_font, t_name, MCFontStyleSetFlag(t_style, kMCFontStyleItalic, p_italic), t_size);
 }
 
+MC_DLLEXPORT
 void MCCanvasFontGetSize(MCCanvasFontRef p_font, uinteger_t &r_size)
 {
 	r_size = MCFontGetSize(MCCanvasFontGetMCFont(p_font));
 }
 
+MC_DLLEXPORT
 void MCCanvasFontSetSize(uinteger_t p_size, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4414,11 +4597,13 @@ MCCanvasRectangleRef MCCanvasFontMeasureTextTypographicBoundsWithTransform(MCStr
 	return t_rect;
 }
 
+MC_DLLEXPORT
 void MCCanvasFontMeasureTextTypographicBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect)
 {
 	r_rect = MCCanvasFontMeasureTextTypographicBoundsWithTransform(p_text, p_font, MCGAffineTransformMakeIdentity());
 }
 
+MC_DLLEXPORT
 void MCCanvasFontMeasureTextTypographicBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4446,11 +4631,13 @@ MCCanvasRectangleRef MCCanvasFontMeasureTextImageBoundsWithTransform(MCStringRef
 	return t_rect;
 }
 
+MC_DLLEXPORT
 void MCCanvasFontMeasureTextImageBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect)
 {
 	r_rect = MCCanvasFontMeasureTextImageBoundsWithTransform(p_text, p_font, MCGAffineTransformMakeIdentity());
 }
 
+MC_DLLEXPORT
 void MCCanvasFontMeasureTextImageBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4581,6 +4768,7 @@ bool MCCanvasPropertiesPop(__MCCanvasImpl &x_canvas)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCCanvasCreate(MCGContextRef p_context, MCCanvasRef &r_canvas)
 {
 	bool t_success;
@@ -4677,11 +4865,13 @@ static inline MCCanvasProperties &MCCanvasGetProps(MCCanvasRef p_canvas)
 	return MCCanvasGet(p_canvas)->props();
 }
 
+MC_DLLEXPORT
 void MCCanvasGetPaint(MCCanvasRef p_canvas, MCCanvasPaintRef &r_paint)
 {
 	r_paint = MCValueRetain(MCCanvasGetProps(p_canvas).paint);
 }
 
+MC_DLLEXPORT
 void MCCanvasSetPaint(MCCanvasPaintRef p_paint, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4690,6 +4880,7 @@ void MCCanvasSetPaint(MCCanvasPaintRef p_paint, MCCanvasRef p_canvas)
 	t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetFillRuleAsString(MCCanvasRef p_canvas, MCStringRef &r_string)
 {
 	if (!MCCanvasFillRuleToString(MCCanvasGetProps(p_canvas).fill_rule, r_string))
@@ -4698,6 +4889,7 @@ void MCCanvasGetFillRuleAsString(MCCanvasRef p_canvas, MCStringRef &r_string)
 	}
 }
 
+MC_DLLEXPORT
 void MCCanvasSetFillRuleAsString(MCStringRef p_string, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4712,11 +4904,13 @@ void MCCanvasSetFillRuleAsString(MCStringRef p_string, MCCanvasRef p_canvas)
 	t_canvas->fill_rule_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetAntialias(MCCanvasRef p_canvas, bool &r_antialias)
 {
 	r_antialias = MCCanvasGetProps(p_canvas).antialias;
 }
 
+MC_DLLEXPORT
 void MCCanvasSetAntialias(bool p_antialias, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4726,11 +4920,13 @@ void MCCanvasSetAntialias(bool p_antialias, MCCanvasRef p_canvas)
 	t_canvas->antialias_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetOpacity(MCCanvasRef p_canvas, MCCanvasFloat &r_opacity)
 {
 	r_opacity = MCCanvasGetProps(p_canvas).opacity;
 }
 
+MC_DLLEXPORT
 void MCCanvasSetOpacity(MCCanvasFloat p_opacity, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4740,11 +4936,13 @@ void MCCanvasSetOpacity(MCCanvasFloat p_opacity, MCCanvasRef p_canvas)
 	t_canvas->opacity_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetBlendModeAsString(MCCanvasRef p_canvas, MCStringRef &r_blend_mode)
 {
 	/* UNCHECKED */ MCCanvasBlendModeToString(MCCanvasGetProps(p_canvas).blend_mode, r_blend_mode);
 }
 
+MC_DLLEXPORT
 void MCCanvasSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4754,11 +4952,13 @@ void MCCanvasSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasRef p_canvas
 	t_canvas->blend_mode_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetStippled(MCCanvasRef p_canvas, bool &r_stippled)
 {
 	r_stippled = MCCanvasGetProps(p_canvas).stippled;
 }
 
+MC_DLLEXPORT
 void MCCanvasSetStippled(bool p_stippled, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4771,11 +4971,13 @@ void MCCanvasSetStippled(bool p_stippled, MCCanvasRef p_canvas)
 		t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetImageResizeQualityAsString(MCCanvasRef p_canvas, MCStringRef &r_quality)
 {
 	/* UNCHECKED */ MCCanvasImageFilterToString(MCCanvasGetProps(p_canvas).image_filter, r_quality);
 }
 
+MC_DLLEXPORT
 void MCCanvasSetImageResizeQualityAsString(MCStringRef p_quality, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4787,11 +4989,13 @@ void MCCanvasSetImageResizeQualityAsString(MCStringRef p_quality, MCCanvasRef p_
 		t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetStrokeWidth(MCCanvasRef p_canvas, MCGFloat& r_stroke_width)
 {
 	r_stroke_width = MCCanvasGetProps(p_canvas).stroke_width;
 }
 
+MC_DLLEXPORT
 void MCCanvasSetStrokeWidth(MCGFloat p_stroke_width, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4801,21 +5005,25 @@ void MCCanvasSetStrokeWidth(MCGFloat p_stroke_width, MCCanvasRef p_canvas)
 	t_canvas->stroke_width_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetFont(MCCanvasRef p_canvas, MCCanvasFontRef &r_font)
 {
 	r_font = MCValueRetain(MCCanvasGetProps(p_canvas).font);
 }
 
+MC_DLLEXPORT
 void MCCanvasSetFont(MCCanvasFontRef p_font, MCCanvasRef p_canvas)
 {
 	MCValueAssign(MCCanvasGetProps(p_canvas).font, p_font);
 }
 
+MC_DLLEXPORT
 void MCCanvasGetJoinStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_join_style)
 {
 	/* UNCHECKED */ MCCanvasJoinStyleToString(MCCanvasGetProps(p_canvas).join_style, r_join_style);
 }
 
+MC_DLLEXPORT
 void MCCanvasSetJoinStyleAsString(MCStringRef p_join_style, MCCanvasRef p_canvas)
 {
 	if (!MCCanvasJoinStyleFromString(p_join_style, MCCanvasGetProps(p_canvas).join_style))
@@ -4827,11 +5035,13 @@ void MCCanvasSetJoinStyleAsString(MCStringRef p_join_style, MCCanvasRef p_canvas
 	MCCanvasGet(p_canvas)->join_style_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetCapStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_cap_style)
 {
 	/* UNCHECKED */ MCCanvasCapStyleToString(MCCanvasGetProps(p_canvas).cap_style, r_cap_style);
 }
 
+MC_DLLEXPORT
 void MCCanvasSetCapStyleAsString(MCStringRef p_cap_style, MCCanvasRef p_canvas)
 {
 	if (!MCCanvasCapStyleFromString(p_cap_style, MCCanvasGetProps(p_canvas).cap_style))
@@ -4843,17 +5053,20 @@ void MCCanvasSetCapStyleAsString(MCStringRef p_cap_style, MCCanvasRef p_canvas)
 	MCCanvasGet(p_canvas)->cap_style_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetMiterLimit(MCCanvasRef p_canvas, MCCanvasFloat &r_limit)
 {
 	r_limit = MCCanvasGetProps(p_canvas).miter_limit;
 }
 
+MC_DLLEXPORT
 void MCCanvasSetMiterLimit(MCCanvasFloat p_limit, MCCanvasRef p_canvas)
 {
 	MCCanvasGetProps(p_canvas).miter_limit = p_limit;
 	MCCanvasGet(p_canvas)->miter_limit_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetDashes(MCCanvasRef p_canvas, MCProperListRef &r_dashes)
 {
 	r_dashes = MCValueRetain(MCCanvasGetProps(p_canvas).dash_lengths);
@@ -4873,6 +5086,7 @@ bool MCCanvasDashesCheckList(MCProperListRef p_list)
 	return true;
 }
 
+MC_DLLEXPORT
 void MCCanvasSetDashes(MCProperListRef p_dashes, MCCanvasRef p_canvas)
 {
 	if (!MCCanvasDashesCheckList(p_dashes))
@@ -4885,11 +5099,13 @@ void MCCanvasSetDashes(MCProperListRef p_dashes, MCCanvasRef p_canvas)
 	MCCanvasGet(p_canvas)->dashes_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasGetDashPhase(MCCanvasRef p_canvas, MCCanvasFloat &r_phase)
 {
 	r_phase = MCCanvasGetProps(p_canvas).dash_phase;
 }
 
+MC_DLLEXPORT
 void MCCanvasSetDashPhase(MCCanvasFloat p_phase, MCCanvasRef p_canvas)
 {
 	MCCanvasGetProps(p_canvas).dash_phase = p_phase;
@@ -5090,16 +5306,19 @@ void MCCanvasTransform(MCCanvasRef p_canvas, const MCGAffineTransform &p_transfo
 		t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT
 void MCCanvasTransform(MCCanvasRef p_canvas, MCCanvasTransformRef p_transform)
 {
 	MCCanvasTransform(p_canvas, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT
 void MCCanvasScale(MCCanvasRef p_canvas, MCCanvasFloat p_scale_x, MCCanvasFloat p_scale_y)
 {
 	MCCanvasTransform(p_canvas, MCGAffineTransformMakeScale(p_scale_x, p_scale_y));
 }
 
+MC_DLLEXPORT
 void MCCanvasScaleWithList(MCCanvasRef p_canvas, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -5109,16 +5328,19 @@ void MCCanvasScaleWithList(MCCanvasRef p_canvas, MCProperListRef p_scale)
 	MCCanvasScale(p_canvas, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT
 void MCCanvasRotate(MCCanvasRef p_canvas, MCCanvasFloat p_angle)
 {
 	MCCanvasTransform(p_canvas, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT
 void MCCanvasTranslate(MCCanvasRef p_canvas, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasTransform(p_canvas, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT
 void MCCanvasTranslateWithList(MCCanvasRef p_canvas, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -5130,6 +5352,7 @@ void MCCanvasTranslateWithList(MCCanvasRef p_canvas, MCProperListRef p_translati
 
 //////////
 
+MC_DLLEXPORT
 void MCCanvasSaveState(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5141,6 +5364,7 @@ void MCCanvasSaveState(MCCanvasRef p_canvas)
 	MCGContextSave(t_canvas->context);
 }
 
+MC_DLLEXPORT
 void MCCanvasRestoreState(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5152,6 +5376,7 @@ void MCCanvasRestoreState(MCCanvasRef p_canvas)
 	MCGContextRestore(t_canvas->context);
 }
 
+MC_DLLEXPORT
 void MCCanvasBeginLayer(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5170,7 +5395,7 @@ static void MCPolarCoordsToCartesian(MCGFloat p_distance, MCGFloat p_angle, MCGF
 	r_y = p_distance * sin(p_angle);
 }
 
-
+MC_DLLEXPORT
 void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5249,6 +5474,7 @@ void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canv
 	MCGContextBeginWithEffects(t_canvas->context, t_rect, t_effects);
 }
 
+MC_DLLEXPORT
 void MCCanvasEndLayer(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5260,6 +5486,7 @@ void MCCanvasEndLayer(MCCanvasRef p_canvas)
 	MCGContextEnd(t_canvas->context);
 }
 
+MC_DLLEXPORT
 void MCCanvasFill(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5271,6 +5498,7 @@ void MCCanvasFill(MCCanvasRef p_canvas)
 	MCGContextEnd(t_canvas->context);
 }
 
+MC_DLLEXPORT
 void MCCanvasStroke(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5282,6 +5510,7 @@ void MCCanvasStroke(MCCanvasRef p_canvas)
 	MCGContextEnd(t_canvas->context);
 }
 
+MC_DLLEXPORT
 void MCCanvasClipToRect(MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5290,6 +5519,7 @@ void MCCanvasClipToRect(MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas)
 	MCGContextClipToRect(t_canvas->context, *MCCanvasRectangleGet(p_rect));
 }
 
+MC_DLLEXPORT
 void MCCanvasAddPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5298,12 +5528,14 @@ void MCCanvasAddPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 	MCGContextAddPath(t_canvas->context, *MCCanvasPathGet(p_path));
 }
 
+MC_DLLEXPORT
 void MCCanvasFillPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 {
 	MCCanvasAddPath(p_path, p_canvas);
 	MCCanvasFill(p_canvas);
 }
 
+MC_DLLEXPORT
 void MCCanvasStrokePath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 {
 	MCCanvasAddPath(p_path, p_canvas);
@@ -5339,11 +5571,13 @@ void MCCanvasDrawRectOfImage(MCCanvasRef p_canvas, MCCanvasImageRef p_image, con
 	}
 }
 
+MC_DLLEXPORT
 void MCCanvasDrawRectOfImage(MCCanvasRectangleRef p_src_rect, MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas)
 {
 	MCCanvasDrawRectOfImage(p_canvas, p_image, *MCCanvasRectangleGet(p_src_rect), *MCCanvasRectangleGet(p_dst_rect));
 }
 
+MC_DLLEXPORT
 void MCCanvasDrawImage(MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas)
 {
 	MCGRectangle t_src_rect;
@@ -5354,6 +5588,7 @@ void MCCanvasDrawImage(MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect
 	MCCanvasDrawRectOfImage(p_canvas, p_image, t_src_rect, *MCCanvasRectangleGet(p_dst_rect));
 }
 
+MC_DLLEXPORT
 void MCCanvasMoveTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5362,6 +5597,7 @@ void MCCanvasMoveTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 	MCGContextMoveTo(t_canvas->context, *MCCanvasPointGet(p_point));
 }
 
+MC_DLLEXPORT
 void MCCanvasLineTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5370,6 +5606,7 @@ void MCCanvasLineTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 	MCGContextLineTo(t_canvas->context, *MCCanvasPointGet(p_point));
 }
 
+MC_DLLEXPORT
 void MCCanvasCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5378,6 +5615,7 @@ void MCCanvasCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to
 	MCGContextQuadraticTo(t_canvas->context, *MCCanvasPointGet(p_through), *MCCanvasPointGet(p_to));
 }
 
+MC_DLLEXPORT
 void MCCanvasCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5386,6 +5624,7 @@ void MCCanvasCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p
 	MCGContextCubicTo(t_canvas->context, *MCCanvasPointGet(p_through_a), *MCCanvasPointGet(p_through_b), *MCCanvasPointGet(p_to));
 }
 
+MC_DLLEXPORT
 void MCCanvasClosePath(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5394,6 +5633,7 @@ void MCCanvasClosePath(MCCanvasRef p_canvas)
 	MCGContextCloseSubpath(t_canvas->context);
 }
 
+MC_DLLEXPORT
 void MCCanvasFillText(MCStringRef p_text, MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 {
 	MCGPoint t_point;
@@ -5409,6 +5649,7 @@ void MCCanvasFillText(MCStringRef p_text, MCCanvasPointRef p_point, MCCanvasRef 
 	MCFontDrawText(t_context, t_point.x, t_point.y, p_text, t_font, false, false);
 }
 
+MC_DLLEXPORT
 void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_halign, integer_t p_valign, MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas)
 {
 	MCFontRef t_font;
@@ -5461,6 +5702,7 @@ void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_halign, integer_t p
 	MCFontDrawText(t_context, t_rect.origin.x + t_x, t_rect.origin.y + t_y, p_text, t_font, false, false);
 }
 
+MC_DLLEXPORT
 void MCCanvasAlignmentEvaluate(integer_t p_h_align, integer_t p_v_align, integer_t &r_align)
 {
 	// range of h/v align is -1, 0, 1 so shift to 0,1,2 and combine
@@ -5480,6 +5722,7 @@ void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_align, MCCanvasRect
 	MCCanvasFillTextAligned(p_text, t_h_aligh, t_v_align, p_rect, p_canvas);
 }
 
+MC_DLLEXPORT
 MCCanvasRectangleRef MCCanvasMeasureText(MCStringRef p_text, MCCanvasRef p_canvas)
 {
 	MCCanvasRectangleRef t_rect;

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -110,20 +110,20 @@ typedef struct __MCCanvasEffect *MCCanvasEffectRef;
 typedef struct __MCCanvasFont *MCCanvasFontRef;
 typedef struct __MCCanvas *MCCanvasRef;
 
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasRectangleTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasPointTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasColorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasTransformTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasPaintTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasSolidPaintTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasPatternTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientStopTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasPathTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasEffectTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasFontTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasTypeInfo;
+extern MCTypeInfoRef kMCCanvasRectangleTypeInfo;
+extern MCTypeInfoRef kMCCanvasPointTypeInfo;
+extern MCTypeInfoRef kMCCanvasColorTypeInfo;
+extern MCTypeInfoRef kMCCanvasTransformTypeInfo;
+extern MCTypeInfoRef kMCCanvasImageTypeInfo;
+extern MCTypeInfoRef kMCCanvasPaintTypeInfo;
+extern MCTypeInfoRef kMCCanvasSolidPaintTypeInfo;
+extern MCTypeInfoRef kMCCanvasPatternTypeInfo;
+extern MCTypeInfoRef kMCCanvasGradientTypeInfo;
+extern MCTypeInfoRef kMCCanvasGradientStopTypeInfo;
+extern MCTypeInfoRef kMCCanvasPathTypeInfo;
+extern MCTypeInfoRef kMCCanvasEffectTypeInfo;
+extern MCTypeInfoRef kMCCanvasFontTypeInfo;
+extern MCTypeInfoRef kMCCanvasTypeInfo;
 
 // Constant refs
 extern MCCanvasTransformRef kMCCanvasIdentityTransform;
@@ -134,30 +134,30 @@ extern MCCanvasPathRef kMCCanvasEmptyPath;
 ////////////////////////////////////////////////////////////////////////////////
 // Canvas Errors
 
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasRectangleListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasPointListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasColorListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasScaleListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasTranslationListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasSkewListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasRadiiListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageSizeListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasRectangleListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasPointListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasColorListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasScaleListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasTranslationListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasSkewListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasRadiiListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasImageSizeListFormatErrorTypeInfo;
 
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasTransformMatrixListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasTransformDecomposeErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasTransformMatrixListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasTransformDecomposeErrorTypeInfo;
 
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
 	
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientStopRangeErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientStopOrderErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientTypeErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasGradientStopRangeErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasGradientStopOrderErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasGradientTypeErrorTypeInfo;
 
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasPathPointListFormatErrorTypeInfo;
-extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasSVGPathParseErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasPathPointListFormatErrorTypeInfo;
+extern MCTypeInfoRef kMCCanvasSVGPathParseErrorTypeInfo;
 
 }
 
@@ -190,117 +190,117 @@ bool MCCanvasFontCreateWithMCFont(MCFontRef p_font, MCCanvasFontRef &r_font);
 MCFontRef MCCanvasFontGetMCFont(MCCanvasFontRef p_font);
 bool MCCanvasFontGetDefault(MCFontRef &r_font);
 
-extern "C" MC_DLLEXPORT bool MCCanvasCreate(MCGContextRef p_context, MCCanvasRef &r_canvas);
+extern "C" bool MCCanvasCreate(MCGContextRef p_context, MCCanvasRef &r_canvas);
 
 ////////////////////////////////////////////////////////////////////////////////
 
 // Rectangle
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasRectangleMakeWithLTRB(MCCanvasFloat p_left, MCCanvasFloat p_top, MCCanvasFloat p_right, MCCanvasFloat p_bottom, MCCanvasRectangleRef &r_rect);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleMakeWithList(MCProperListRef p_list, MCCanvasRectangleRef &r_point);
+extern "C" void MCCanvasRectangleMakeWithLTRB(MCCanvasFloat p_left, MCCanvasFloat p_top, MCCanvasFloat p_right, MCCanvasFloat p_bottom, MCCanvasRectangleRef &r_rect);
+extern "C" void MCCanvasRectangleMakeWithList(MCProperListRef p_list, MCCanvasRectangleRef &r_point);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasRectangleGetLeft(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_left);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleSetLeft(MCCanvasFloat p_left, MCCanvasRectangleRef &x_rect);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleGetTop(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_top);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleSetTop(MCCanvasFloat p_top, MCCanvasRectangleRef &x_rect);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleGetRight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_right);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleSetRight(MCCanvasFloat p_right, MCCanvasRectangleRef &x_rect);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleGetBottom(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_bottom);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleSetBottom(MCCanvasFloat p_bottom, MCCanvasRectangleRef &x_rect);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleGetWidth(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_width);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleSetWidth(MCCanvasFloat p_width, MCCanvasRectangleRef &x_rect);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleGetHeight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_height);
-extern "C" MC_DLLEXPORT void MCCanvasRectangleSetHeight(MCCanvasFloat p_height, MCCanvasRectangleRef &x_rect);
+extern "C" void MCCanvasRectangleGetLeft(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_left);
+extern "C" void MCCanvasRectangleSetLeft(MCCanvasFloat p_left, MCCanvasRectangleRef &x_rect);
+extern "C" void MCCanvasRectangleGetTop(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_top);
+extern "C" void MCCanvasRectangleSetTop(MCCanvasFloat p_top, MCCanvasRectangleRef &x_rect);
+extern "C" void MCCanvasRectangleGetRight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_right);
+extern "C" void MCCanvasRectangleSetRight(MCCanvasFloat p_right, MCCanvasRectangleRef &x_rect);
+extern "C" void MCCanvasRectangleGetBottom(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_bottom);
+extern "C" void MCCanvasRectangleSetBottom(MCCanvasFloat p_bottom, MCCanvasRectangleRef &x_rect);
+extern "C" void MCCanvasRectangleGetWidth(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_width);
+extern "C" void MCCanvasRectangleSetWidth(MCCanvasFloat p_width, MCCanvasRectangleRef &x_rect);
+extern "C" void MCCanvasRectangleGetHeight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_height);
+extern "C" void MCCanvasRectangleSetHeight(MCCanvasFloat p_height, MCCanvasRectangleRef &x_rect);
 
 //////////
 
 // Point
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasPointMake(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPointRef &r_point);
-extern "C" MC_DLLEXPORT void MCCanvasPointMakeWithList(MCProperListRef p_list, MCCanvasPointRef &r_list);
+extern "C" void MCCanvasPointMake(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPointRef &r_point);
+extern "C" void MCCanvasPointMakeWithList(MCProperListRef p_list, MCCanvasPointRef &r_list);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasPointGetX(MCCanvasPointRef p_point, MCCanvasFloat &r_x);
-extern "C" MC_DLLEXPORT void MCCanvasPointSetX(MCCanvasFloat p_x, MCCanvasPointRef &x_point);
-extern "C" MC_DLLEXPORT void MCCanvasPointGetY(MCCanvasPointRef p_point, MCCanvasFloat &r_y);
-extern "C" MC_DLLEXPORT void MCCanvasPointSetY(MCCanvasFloat p_y, MCCanvasPointRef &x_point);
+extern "C" void MCCanvasPointGetX(MCCanvasPointRef p_point, MCCanvasFloat &r_x);
+extern "C" void MCCanvasPointSetX(MCCanvasFloat p_x, MCCanvasPointRef &x_point);
+extern "C" void MCCanvasPointGetY(MCCanvasPointRef p_point, MCCanvasFloat &r_y);
+extern "C" void MCCanvasPointSetY(MCCanvasFloat p_y, MCCanvasPointRef &x_point);
 
 //////////
 
 // Color
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasColorMakeRGBA(MCCanvasFloat p_red, MCCanvasFloat p_green, MCCanvasFloat p_blue, MCCanvasFloat p_alpha, MCCanvasColorRef &r_color);
-extern "C" MC_DLLEXPORT void MCCanvasColorMakeWithList(MCProperListRef p_list, MCCanvasColorRef &r_color);
+extern "C" void MCCanvasColorMakeRGBA(MCCanvasFloat p_red, MCCanvasFloat p_green, MCCanvasFloat p_blue, MCCanvasFloat p_alpha, MCCanvasColorRef &r_color);
+extern "C" void MCCanvasColorMakeWithList(MCProperListRef p_list, MCCanvasColorRef &r_color);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasColorGetRed(MCCanvasColorRef p_color, MCCanvasFloat &r_red);
-extern "C" MC_DLLEXPORT void MCCanvasColorSetRed(MCCanvasFloat p_red, MCCanvasColorRef &x_color);
-extern "C" MC_DLLEXPORT void MCCanvasColorGetGreen(MCCanvasColorRef p_color, MCCanvasFloat &r_green);
-extern "C" MC_DLLEXPORT void MCCanvasColorSetGreen(MCCanvasFloat p_green, MCCanvasColorRef &x_color);
-extern "C" MC_DLLEXPORT void MCCanvasColorGetBlue(MCCanvasColorRef p_color, MCCanvasFloat &r_blue);
-extern "C" MC_DLLEXPORT void MCCanvasColorSetBlue(MCCanvasFloat p_blue, MCCanvasColorRef &x_color);
-extern "C" MC_DLLEXPORT void MCCanvasColorGetAlpha(MCCanvasColorRef p_color, MCCanvasFloat &r_alpha);
-extern "C" MC_DLLEXPORT void MCCanvasColorSetAlpha(MCCanvasFloat p_alpha, MCCanvasColorRef &x_color);
+extern "C" void MCCanvasColorGetRed(MCCanvasColorRef p_color, MCCanvasFloat &r_red);
+extern "C" void MCCanvasColorSetRed(MCCanvasFloat p_red, MCCanvasColorRef &x_color);
+extern "C" void MCCanvasColorGetGreen(MCCanvasColorRef p_color, MCCanvasFloat &r_green);
+extern "C" void MCCanvasColorSetGreen(MCCanvasFloat p_green, MCCanvasColorRef &x_color);
+extern "C" void MCCanvasColorGetBlue(MCCanvasColorRef p_color, MCCanvasFloat &r_blue);
+extern "C" void MCCanvasColorSetBlue(MCCanvasFloat p_blue, MCCanvasColorRef &x_color);
+extern "C" void MCCanvasColorGetAlpha(MCCanvasColorRef p_color, MCCanvasFloat &r_alpha);
+extern "C" void MCCanvasColorSetAlpha(MCCanvasFloat p_alpha, MCCanvasColorRef &x_color);
 
 //////////
 
 // Transform
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeIdentity(MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeScale(MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeScaleWithList(MCProperListRef p_list, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeRotation(MCCanvasFloat p_angle, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeTranslation(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeTranslationWithList(MCProperListRef p_list, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeSkew(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeSkewWithList(MCProperListRef p_list, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeWithMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformMakeWithMatrixValues(MCCanvasFloat p_a, MCCanvasFloat p_b, MCCanvasFloat p_c, MCCanvasFloat p_d, MCCanvasFloat p_tx, MCCanvasFloat p_ty, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeIdentity(MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeScale(MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeScaleWithList(MCProperListRef p_list, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeRotation(MCCanvasFloat p_angle, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeTranslation(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeTranslationWithList(MCProperListRef p_list, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeSkew(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeSkewWithList(MCProperListRef p_list, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeWithMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformMakeWithMatrixValues(MCCanvasFloat p_a, MCCanvasFloat p_b, MCCanvasFloat p_c, MCCanvasFloat p_d, MCCanvasFloat p_tx, MCCanvasFloat p_ty, MCCanvasTransformRef &r_transform);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasTransformGetMatrixAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_matrix);
-extern "C" MC_DLLEXPORT void MCCanvasTransformSetMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &x_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformGetInverse(MCCanvasTransformRef p_transform, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasTransformGetMatrixAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_matrix);
+extern "C" void MCCanvasTransformSetMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &x_transform);
+extern "C" void MCCanvasTransformGetInverse(MCCanvasTransformRef p_transform, MCCanvasTransformRef &r_transform);
 // T = Tscale * Trotate * Tskew * Ttranslate
-extern "C" MC_DLLEXPORT void MCCanvasTransformGetScaleAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_scale);
-extern "C" MC_DLLEXPORT void MCCanvasTransformSetScaleAsList(MCProperListRef p_scale, MCCanvasTransformRef &x_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformGetRotation(MCCanvasTransformRef p_transform, MCCanvasFloat &r_rotation);
-extern "C" MC_DLLEXPORT void MCCanvasTransformSetRotation(MCCanvasFloat p_rotation, MCCanvasTransformRef &x_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformGetSkewAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_skew);
-extern "C" MC_DLLEXPORT void MCCanvasTransformSetSkewAsList(MCProperListRef p_skew, MCCanvasTransformRef &x_transform);
-extern "C" MC_DLLEXPORT void MCCanvasTransformGetTranslationAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_translation);
-extern "C" MC_DLLEXPORT void MCCanvasTransformSetTranslationAsList(MCProperListRef p_translation, MCCanvasTransformRef &x_transform);
+extern "C" void MCCanvasTransformGetScaleAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_scale);
+extern "C" void MCCanvasTransformSetScaleAsList(MCProperListRef p_scale, MCCanvasTransformRef &x_transform);
+extern "C" void MCCanvasTransformGetRotation(MCCanvasTransformRef p_transform, MCCanvasFloat &r_rotation);
+extern "C" void MCCanvasTransformSetRotation(MCCanvasFloat p_rotation, MCCanvasTransformRef &x_transform);
+extern "C" void MCCanvasTransformGetSkewAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_skew);
+extern "C" void MCCanvasTransformSetSkewAsList(MCProperListRef p_skew, MCCanvasTransformRef &x_transform);
+extern "C" void MCCanvasTransformGetTranslationAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_translation);
+extern "C" void MCCanvasTransformSetTranslationAsList(MCProperListRef p_translation, MCCanvasTransformRef &x_transform);
 
 // Operations
-extern "C" MC_DLLEXPORT void MCCanvasTransformConcat(MCCanvasTransformRef &x_transform_a, MCCanvasTransformRef p_transform_b);
-extern "C" MC_DLLEXPORT void MCCanvasTransformScale(MCCanvasTransformRef &x_transform, MCCanvasFloat p_x_scale, MCCanvasFloat p_y_scale);
-extern "C" MC_DLLEXPORT void MCCanvasTransformScaleWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
-extern "C" MC_DLLEXPORT void MCCanvasTransformRotate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_rotation);
-extern "C" MC_DLLEXPORT void MCCanvasTransformTranslate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_dx, MCCanvasFloat p_dy);
-extern "C" MC_DLLEXPORT void MCCanvasTransformTranslateWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
-extern "C" MC_DLLEXPORT void MCCanvasTransformSkew(MCCanvasTransformRef &x_transform, MCCanvasFloat p_x_skew, MCCanvasFloat p_y_skew);
-extern "C" MC_DLLEXPORT void MCCanvasTransformSkewWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
+extern "C" void MCCanvasTransformConcat(MCCanvasTransformRef &x_transform_a, MCCanvasTransformRef p_transform_b);
+extern "C" void MCCanvasTransformScale(MCCanvasTransformRef &x_transform, MCCanvasFloat p_x_scale, MCCanvasFloat p_y_scale);
+extern "C" void MCCanvasTransformScaleWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
+extern "C" void MCCanvasTransformRotate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_rotation);
+extern "C" void MCCanvasTransformTranslate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_dx, MCCanvasFloat p_dy);
+extern "C" void MCCanvasTransformTranslateWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
+extern "C" void MCCanvasTransformSkew(MCCanvasTransformRef &x_transform, MCCanvasFloat p_x_skew, MCCanvasFloat p_y_skew);
+extern "C" void MCCanvasTransformSkewWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
 
 //////////
 
 // Image
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithPath(MCStringRef p_path, MCCanvasImageRef &x_image);
-extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &x_image);
-extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCCanvasImageRef &x_image);
-extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithPixelsWithSizeAsList(MCProperListRef p_size, MCDataRef p_pixels, MCCanvasImageRef &x_image);
-extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithResourceFile(MCStringRef p_resource, MCCanvasImageRef &r_image);
+extern "C" void MCCanvasImageMakeWithPath(MCStringRef p_path, MCCanvasImageRef &x_image);
+extern "C" void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &x_image);
+extern "C" void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCCanvasImageRef &x_image);
+extern "C" void MCCanvasImageMakeWithPixelsWithSizeAsList(MCProperListRef p_size, MCDataRef p_pixels, MCCanvasImageRef &x_image);
+extern "C" void MCCanvasImageMakeWithResourceFile(MCStringRef p_resource, MCCanvasImageRef &r_image);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasImageGetWidth(MCCanvasImageRef p_image, uint32_t &r_width);
-extern "C" MC_DLLEXPORT void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height);
-extern "C" MC_DLLEXPORT void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MCDataRef &r_pixels);
+extern "C" void MCCanvasImageGetWidth(MCCanvasImageRef p_image, uint32_t &r_width);
+extern "C" void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height);
+extern "C" void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MCDataRef &r_pixels);
 // TODO - Add support for image metadata
 //void MCCanvasImageGetMetadata(const MCCanvasImage &p_image, MCArrayRef &r_metadata);
 
@@ -315,38 +315,38 @@ extern "C" MC_DLLEXPORT void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MC
 // Solid Paint
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasSolidPaintMakeWithColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &r_paint);
+extern "C" void MCCanvasSolidPaintMakeWithColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &r_paint);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasSolidPaintGetColor(MCCanvasSolidPaintRef p_paint, MCCanvasColorRef &r_color);
-extern "C" MC_DLLEXPORT void MCCanvasSolidPaintSetColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &x_paint);
+extern "C" void MCCanvasSolidPaintGetColor(MCCanvasSolidPaintRef p_paint, MCCanvasColorRef &r_color);
+extern "C" void MCCanvasSolidPaintSetColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &x_paint);
 
 //////////
 
 // Pattern
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasPatternMakeWithImage(MCCanvasImageRef p_image, MCCanvasPatternRef &r_pattern);
-extern "C" MC_DLLEXPORT void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, MCCanvasTransformRef p_transform, MCCanvasPatternRef &r_pattern);
-extern "C" MC_DLLEXPORT void MCCanvasPatternMakeWithScaledImage(MCCanvasImageRef p_image, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasPatternRef &r_pattern);
-extern "C" MC_DLLEXPORT void MCCanvasPatternMakeWithImageScaledWithList(MCCanvasImageRef p_image, MCProperListRef p_list, MCCanvasPatternRef &r_pattern);
-extern "C" MC_DLLEXPORT void MCCanvasPatternMakeWithRotatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_angle, MCCanvasPatternRef &r_pattern);
-extern "C" MC_DLLEXPORT void MCCanvasPatternMakeWithTranslatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPatternRef &r_pattern);
-extern "C" MC_DLLEXPORT void MCCanvasPatternMakeWithImageTranslatedWithList(MCCanvasImageRef p_image, MCProperListRef p_list, MCCanvasPatternRef &r_pattern);
+extern "C" void MCCanvasPatternMakeWithImage(MCCanvasImageRef p_image, MCCanvasPatternRef &r_pattern);
+extern "C" void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, MCCanvasTransformRef p_transform, MCCanvasPatternRef &r_pattern);
+extern "C" void MCCanvasPatternMakeWithScaledImage(MCCanvasImageRef p_image, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasPatternRef &r_pattern);
+extern "C" void MCCanvasPatternMakeWithImageScaledWithList(MCCanvasImageRef p_image, MCProperListRef p_list, MCCanvasPatternRef &r_pattern);
+extern "C" void MCCanvasPatternMakeWithRotatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_angle, MCCanvasPatternRef &r_pattern);
+extern "C" void MCCanvasPatternMakeWithTranslatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPatternRef &r_pattern);
+extern "C" void MCCanvasPatternMakeWithImageTranslatedWithList(MCCanvasImageRef p_image, MCProperListRef p_list, MCCanvasPatternRef &r_pattern);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasPatternGetImage(MCCanvasPatternRef p_pattern, MCCanvasImageRef &r_image);
-extern "C" MC_DLLEXPORT void MCCanvasPatternSetImage(MCCanvasImageRef p_image, MCCanvasPatternRef &x_pattern);
-extern "C" MC_DLLEXPORT void MCCanvasPatternGetTransform(MCCanvasPatternRef p_pattern, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasPatternSetTransform(MCCanvasTransformRef p_transform, MCCanvasPatternRef &x_pattern);
+extern "C" void MCCanvasPatternGetImage(MCCanvasPatternRef p_pattern, MCCanvasImageRef &r_image);
+extern "C" void MCCanvasPatternSetImage(MCCanvasImageRef p_image, MCCanvasPatternRef &x_pattern);
+extern "C" void MCCanvasPatternGetTransform(MCCanvasPatternRef p_pattern, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasPatternSetTransform(MCCanvasTransformRef p_transform, MCCanvasPatternRef &x_pattern);
 
 // Operations
-extern "C" MC_DLLEXPORT void MCCanvasPatternTransform(MCCanvasPatternRef &x_pattern, MCCanvasTransformRef p_transform);
-extern "C" MC_DLLEXPORT void MCCanvasPatternScale(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale);
-extern "C" MC_DLLEXPORT void MCCanvasPatternScaleWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_scale);
-extern "C" MC_DLLEXPORT void MCCanvasPatternRotate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_angle);
-extern "C" MC_DLLEXPORT void MCCanvasPatternTranslate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_x, MCCanvasFloat p_y);
-extern "C" MC_DLLEXPORT void MCCanvasPatternTranslateWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_translation);
+extern "C" void MCCanvasPatternTransform(MCCanvasPatternRef &x_pattern, MCCanvasTransformRef p_transform);
+extern "C" void MCCanvasPatternScale(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale);
+extern "C" void MCCanvasPatternScaleWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_scale);
+extern "C" void MCCanvasPatternRotate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_angle);
+extern "C" void MCCanvasPatternTranslate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_x, MCCanvasFloat p_y);
+extern "C" void MCCanvasPatternTranslateWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_translation);
 // TODO - add skew?"
 
 //////////
@@ -354,217 +354,212 @@ extern "C" MC_DLLEXPORT void MCCanvasPatternTranslateWithList(MCCanvasPatternRef
 // Gradient Stop
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasGradientStopMake(MCCanvasFloat p_offset, MCCanvasColorRef p_color, MCCanvasGradientStopRef &r_stop);
+extern "C" void MCCanvasGradientStopMake(MCCanvasFloat p_offset, MCCanvasColorRef p_color, MCCanvasGradientStopRef &r_stop);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasGradientStopGetOffset(MCCanvasGradientStopRef p_stop, MCCanvasFloat &r_offset);
-extern "C" MC_DLLEXPORT void MCCanvasGradientStopSetOffset(MCCanvasFloat p_offset, MCCanvasGradientStopRef &x_stop);
-extern "C" MC_DLLEXPORT void MCCanvasGradientStopGetColor(MCCanvasGradientStopRef p_stop, MCCanvasColorRef &r_color);
-extern "C" MC_DLLEXPORT void MCCanvasGradientStopSetColor(MCCanvasColorRef p_color, MCCanvasGradientStopRef &x_stop);
+extern "C" void MCCanvasGradientStopGetOffset(MCCanvasGradientStopRef p_stop, MCCanvasFloat &r_offset);
+extern "C" void MCCanvasGradientStopSetOffset(MCCanvasFloat p_offset, MCCanvasGradientStopRef &x_stop);
+extern "C" void MCCanvasGradientStopGetColor(MCCanvasGradientStopRef p_stop, MCCanvasColorRef &r_color);
+extern "C" void MCCanvasGradientStopSetColor(MCCanvasColorRef p_color, MCCanvasGradientStopRef &x_stop);
 
 // Gradient
 
-extern "C" MC_DLLEXPORT void MCCanvasGradientEvaluateType(integer_t p_type, integer_t& r_type);
+extern "C" void MCCanvasGradientEvaluateType(integer_t p_type, integer_t& r_type);
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasGradientMakeWithRamp(integer_t p_type, MCProperListRef p_ramp, MCCanvasGradientRef &r_gradient);
+extern "C" void MCCanvasGradientMakeWithRamp(integer_t p_type, MCProperListRef p_ramp, MCCanvasGradientRef &r_gradient);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetRamp(MCCanvasGradientRef p_gradient, MCProperListRef &r_ramp);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetRamp(MCProperListRef p_ramp, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetTypeAsString(MCCanvasGradientRef p_gradient, MCStringRef &r_string);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetTypeAsString(MCStringRef p_string, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetRepeat(MCCanvasGradientRef p_gradient, integer_t &r_repeat);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetRepeat(integer_t p_repeat, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetWrap(MCCanvasGradientRef p_gradient, bool &r_wrap);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetWrap(bool p_wrap, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetMirror(MCCanvasGradientRef p_gradient, bool &r_mirror);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetMirror(bool p_mirror, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetFrom(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_from);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetFrom(MCCanvasPointRef p_from, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetTo(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_to);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetTo(MCCanvasPointRef p_to, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetVia(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_via);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetVia(MCCanvasPointRef p_via, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientGetTransform(MCCanvasGradientRef p_gradient, MCCanvasTransformRef &r_transform);
-extern "C" MC_DLLEXPORT void MCCanvasGradientSetTransform(MCCanvasTransformRef p_transform, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetRamp(MCCanvasGradientRef p_gradient, MCProperListRef &r_ramp);
+extern "C" void MCCanvasGradientSetRamp(MCProperListRef p_ramp, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetTypeAsString(MCCanvasGradientRef p_gradient, MCStringRef &r_string);
+extern "C" void MCCanvasGradientSetTypeAsString(MCStringRef p_string, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetRepeat(MCCanvasGradientRef p_gradient, integer_t &r_repeat);
+extern "C" void MCCanvasGradientSetRepeat(integer_t p_repeat, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetWrap(MCCanvasGradientRef p_gradient, bool &r_wrap);
+extern "C" void MCCanvasGradientSetWrap(bool p_wrap, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetMirror(MCCanvasGradientRef p_gradient, bool &r_mirror);
+extern "C" void MCCanvasGradientSetMirror(bool p_mirror, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetFrom(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_from);
+extern "C" void MCCanvasGradientSetFrom(MCCanvasPointRef p_from, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetTo(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_to);
+extern "C" void MCCanvasGradientSetTo(MCCanvasPointRef p_to, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetVia(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_via);
+extern "C" void MCCanvasGradientSetVia(MCCanvasPointRef p_via, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientGetTransform(MCCanvasGradientRef p_gradient, MCCanvasTransformRef &r_transform);
+extern "C" void MCCanvasGradientSetTransform(MCCanvasTransformRef p_transform, MCCanvasGradientRef &x_gradient);
 
 // Operators
-extern "C" MC_DLLEXPORT void MCCanvasGradientAddStop(MCCanvasGradientStopRef p_stop, MCCanvasGradientRef &x_gradient);
-extern "C" MC_DLLEXPORT void MCCanvasGradientTransform(MCCanvasGradientRef &x_gradient, MCCanvasTransformRef p_transform);
-extern "C" MC_DLLEXPORT void MCCanvasGradientScale(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale);
-extern "C" MC_DLLEXPORT void MCCanvasGradientScaleWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_scale);
-extern "C" MC_DLLEXPORT void MCCanvasGradientRotate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_angle);
-extern "C" MC_DLLEXPORT void MCCanvasGradientTranslate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_x, MCCanvasFloat p_y);
-extern "C" MC_DLLEXPORT void MCCanvasGradientTranslateWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_translation);
+extern "C" void MCCanvasGradientAddStop(MCCanvasGradientStopRef p_stop, MCCanvasGradientRef &x_gradient);
+extern "C" void MCCanvasGradientTransform(MCCanvasGradientRef &x_gradient, MCCanvasTransformRef p_transform);
+extern "C" void MCCanvasGradientScale(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale);
+extern "C" void MCCanvasGradientScaleWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_scale);
+extern "C" void MCCanvasGradientRotate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_angle);
+extern "C" void MCCanvasGradientTranslate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_x, MCCanvasFloat p_y);
+extern "C" void MCCanvasGradientTranslateWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_translation);
 
 //////////
 
 // Path
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeEmpty(MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithInstructionsAsString(MCStringRef p_instructions, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithRectangle(MCCanvasRectangleRef p_rect, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithRoundedRectangle(MCCanvasRectangleRef p_rect, MCCanvasFloat p_radius, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithRoundedRectangleWithRadii(MCCanvasRectangleRef p_rect, MCCanvasFloat p_x_radius, MCCanvasFloat p_y_radius, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(MCCanvasRectangleRef p_rect, MCProperListRef p_radii, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithRectangle(MCCanvasRectangleRef p_rect, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithEllipse(MCCanvasPointRef p_center, MCCanvasFloat p_radius_x, MCCanvasFloat p_radius_y, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithEllipseWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithCircle(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithLine(MCCanvasPointRef p_start, MCCanvasPointRef p_end, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithPoints(bool p_close, MCProperListRef p_points, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithArcWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithArcWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithSectorWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithSectorWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithSegmentWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathMakeWithSegmentWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeEmpty(MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithInstructionsAsString(MCStringRef p_instructions, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithRoundedRectangle(MCCanvasRectangleRef p_rect, MCCanvasFloat p_radius, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithRoundedRectangleWithRadii(MCCanvasRectangleRef p_rect, MCCanvasFloat p_x_radius, MCCanvasFloat p_y_radius, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(MCCanvasRectangleRef p_rect, MCProperListRef p_radii, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithRectangle(MCCanvasRectangleRef p_rect, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithEllipse(MCCanvasPointRef p_center, MCCanvasFloat p_radius_x, MCCanvasFloat p_radius_y, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithEllipseWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithCircle(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithLine(MCCanvasPointRef p_start, MCCanvasPointRef p_end, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithPoints(bool p_close, MCProperListRef p_points, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithArcWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithArcWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithSectorWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithSectorWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithSegmentWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
+extern "C" void MCCanvasPathMakeWithSegmentWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasPathGetSubpaths(integer_t p_start, integer_t p_end, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpaths);
-extern "C" MC_DLLEXPORT void MCCanvasPathGetSubpath(integer_t p_index, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpaths);
-extern "C" MC_DLLEXPORT void MCCanvasPathGetBoundingBox(MCCanvasPathRef p_path, MCCanvasRectangleRef &r_bounds);
-extern "C" MC_DLLEXPORT void MCCanvasPathGetInstructionsAsString(MCCanvasPathRef p_path, MCStringRef &r_instruction_string);
+extern "C" void MCCanvasPathGetSubpaths(integer_t p_start, integer_t p_end, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpaths);
+extern "C" void MCCanvasPathGetSubpath(integer_t p_index, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpaths);
+extern "C" void MCCanvasPathGetBoundingBox(MCCanvasPathRef p_path, MCCanvasRectangleRef &r_bounds);
+extern "C" void MCCanvasPathGetInstructionsAsString(MCCanvasPathRef p_path, MCStringRef &r_instruction_string);
 
 // Operations
-extern "C" MC_DLLEXPORT void MCCanvasPathTransform(MCCanvasPathRef &x_path, MCCanvasTransformRef p_transform);
-extern "C" MC_DLLEXPORT void MCCanvasPathScale(MCCanvasPathRef &x_path, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale);
-extern "C" MC_DLLEXPORT void MCCanvasPathScaleWithList(MCCanvasPathRef &x_path, MCProperListRef p_scale);
-extern "C" MC_DLLEXPORT void MCCanvasPathRotate(MCCanvasPathRef &x_path, MCCanvasFloat p_angle);
-extern "C" MC_DLLEXPORT void MCCanvasPathTranslate(MCCanvasPathRef &x_path, MCCanvasFloat p_x, MCCanvasFloat p_y);
-extern "C" MC_DLLEXPORT void MCCanvasPathTranslateWithList(MCCanvasPathRef &x_path, MCProperListRef p_translation);
-extern "C" MC_DLLEXPORT void MCCanvasPathAddPath(MCCanvasPathRef p_source, MCCanvasPathRef &x_dest);
-extern "C" MC_DLLEXPORT void MCCanvasPathMoveTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathLineTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasPathRef &x_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasPathRef &x_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathClosePath(MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathTransform(MCCanvasPathRef &x_path, MCCanvasTransformRef p_transform);
+extern "C" void MCCanvasPathScale(MCCanvasPathRef &x_path, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale);
+extern "C" void MCCanvasPathScaleWithList(MCCanvasPathRef &x_path, MCProperListRef p_scale);
+extern "C" void MCCanvasPathRotate(MCCanvasPathRef &x_path, MCCanvasFloat p_angle);
+extern "C" void MCCanvasPathTranslate(MCCanvasPathRef &x_path, MCCanvasFloat p_x, MCCanvasFloat p_y);
+extern "C" void MCCanvasPathTranslateWithList(MCCanvasPathRef &x_path, MCProperListRef p_translation);
+extern "C" void MCCanvasPathAddPath(MCCanvasPathRef p_source, MCCanvasPathRef &x_dest);
+extern "C" void MCCanvasPathMoveTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathLineTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathClosePath(MCCanvasPathRef &x_path);
 
-extern "C" MC_DLLEXPORT void MCCanvasPathArcTo(MCCanvasPointRef p_tangent, MCCanvasPointRef p_to, MCCanvasFloat p_radius, MCCanvasPathRef &x_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathEllipticArcToWithFlagsWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, bool p_largest, bool p_clockwise, MCCanvasPathRef &x_path);
-extern "C" MC_DLLEXPORT void MCCanvasPathEllipticArcToWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathArcTo(MCCanvasPointRef p_tangent, MCCanvasPointRef p_to, MCCanvasFloat p_radius, MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathEllipticArcToWithFlagsWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, bool p_largest, bool p_clockwise, MCCanvasPathRef &x_path);
+extern "C" void MCCanvasPathEllipticArcToWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, MCCanvasPathRef &x_path);
 
 //////////
 
 // Effect
 
-extern "C" MC_DLLEXPORT void MCCanvasEffectEvaluateType(integer_t p_type, integer_t &r_type);
+extern "C" void MCCanvasEffectEvaluateType(integer_t p_type, integer_t &r_type);
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasEffectMakeWithPropertyArray(integer_t p_type, MCArrayRef p_properties, MCCanvasEffectRef &r_effect);
+extern "C" void MCCanvasEffectMakeWithPropertyArray(integer_t p_type, MCArrayRef p_properties, MCCanvasEffectRef &r_effect);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetTypeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_type);
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetColor(MCCanvasEffectRef p_effect, MCCanvasColorRef &r_color);
-extern "C" MC_DLLEXPORT void MCCanvasEffectSetColor(MCCanvasColorRef p_color, MCCanvasEffectRef &x_effect);
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetBlendModeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_blend_mode);
-extern "C" MC_DLLEXPORT void MCCanvasEffectSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasEffectRef &x_effect);
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetOpacity(MCCanvasEffectRef p_effect, MCCanvasFloat &r_opacity);
-extern "C" MC_DLLEXPORT void MCCanvasEffectSetOpacity(MCCanvasFloat p_opacity, MCCanvasEffectRef &x_effect);
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetSize(MCCanvasEffectRef p_effect, MCCanvasFloat &r_size);
-extern "C" MC_DLLEXPORT void MCCanvasEffectSetSize(MCCanvasFloat p_size, MCCanvasEffectRef &x_effect);
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetSpread(MCCanvasEffectRef p_effect, MCCanvasFloat &r_spread);
-extern "C" MC_DLLEXPORT void MCCanvasEffectSetSpread(MCCanvasFloat p_spread, MCCanvasEffectRef &x_effect);
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetDistance(MCCanvasEffectRef p_effect, MCCanvasFloat &r_distance);
-extern "C" MC_DLLEXPORT void MCCanvasEffectSetDistance(MCCanvasFloat p_distance, MCCanvasEffectRef &x_effect);
-extern "C" MC_DLLEXPORT void MCCanvasEffectGetAngle(MCCanvasEffectRef p_effect, MCCanvasFloat &r_angle);
-extern "C" MC_DLLEXPORT void MCCanvasEffectSetAngle(MCCanvasFloat p_angle, MCCanvasEffectRef &x_effect);
+extern "C" void MCCanvasEffectGetTypeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_type);
+extern "C" void MCCanvasEffectGetColor(MCCanvasEffectRef p_effect, MCCanvasColorRef &r_color);
+extern "C" void MCCanvasEffectSetColor(MCCanvasColorRef p_color, MCCanvasEffectRef &x_effect);
+extern "C" void MCCanvasEffectGetBlendModeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_blend_mode);
+extern "C" void MCCanvasEffectSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasEffectRef &x_effect);
+extern "C" void MCCanvasEffectGetOpacity(MCCanvasEffectRef p_effect, MCCanvasFloat &r_opacity);
+extern "C" void MCCanvasEffectSetOpacity(MCCanvasFloat p_opacity, MCCanvasEffectRef &x_effect);
+extern "C" void MCCanvasEffectGetSize(MCCanvasEffectRef p_effect, MCCanvasFloat &r_size);
+extern "C" void MCCanvasEffectSetSize(MCCanvasFloat p_size, MCCanvasEffectRef &x_effect);
+extern "C" void MCCanvasEffectGetSpread(MCCanvasEffectRef p_effect, MCCanvasFloat &r_spread);
+extern "C" void MCCanvasEffectSetSpread(MCCanvasFloat p_spread, MCCanvasEffectRef &x_effect);
+extern "C" void MCCanvasEffectGetDistance(MCCanvasEffectRef p_effect, MCCanvasFloat &r_distance);
+extern "C" void MCCanvasEffectSetDistance(MCCanvasFloat p_distance, MCCanvasEffectRef &x_effect);
+extern "C" void MCCanvasEffectGetAngle(MCCanvasEffectRef p_effect, MCCanvasFloat &r_angle);
+extern "C" void MCCanvasEffectSetAngle(MCCanvasFloat p_angle, MCCanvasEffectRef &x_effect);
 
 //////////
 
 // Font
 
 // Constructors
-extern "C" MC_DLLEXPORT void MCCanvasFontMake(MCStringRef p_name, MCCanvasFontRef &r_font);
-extern "C" MC_DLLEXPORT void MCCanvasFontMakeWithStyle(MCStringRef p_name, bool p_bold, bool p_italic, MCCanvasFontRef &r_font);
-extern "C" MC_DLLEXPORT void MCCanvasFontMakeWithSize(MCStringRef p_name, bool p_bold, bool p_italic, integer_t p_size, MCCanvasFontRef &r_font);
+extern "C" void MCCanvasFontMake(MCStringRef p_name, MCCanvasFontRef &r_font);
+extern "C" void MCCanvasFontMakeWithStyle(MCStringRef p_name, bool p_bold, bool p_italic, MCCanvasFontRef &r_font);
+extern "C" void MCCanvasFontMakeWithSize(MCStringRef p_name, bool p_bold, bool p_italic, integer_t p_size, MCCanvasFontRef &r_font);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasFontGetName(MCCanvasFontRef p_font, MCStringRef &r_name);
-extern "C" MC_DLLEXPORT void MCCanvasFontSetName(MCStringRef p_name, MCCanvasFontRef &x_font);
-extern "C" MC_DLLEXPORT void MCCanvasFontGetBold(MCCanvasFontRef p_font, bool &r_bold);
-extern "C" MC_DLLEXPORT void MCCanvasFontSetBold(bool p_bold, MCCanvasFontRef &x_font);
-extern "C" MC_DLLEXPORT void MCCanvasFontGetItalic(MCCanvasFontRef p_font, bool &r_italic);
-extern "C" MC_DLLEXPORT void MCCanvasFontSetItalic(bool p_italic, MCCanvasFontRef &x_font);
-extern "C" MC_DLLEXPORT void MCCanvasFontGetSize(MCCanvasFontRef p_font, uinteger_t &r_size);
-extern "C" MC_DLLEXPORT void MCCanvasFontSetSize(uinteger_t p_size, MCCanvasFontRef &x_font);
+extern "C" void MCCanvasFontGetName(MCCanvasFontRef p_font, MCStringRef &r_name);
+extern "C" void MCCanvasFontSetName(MCStringRef p_name, MCCanvasFontRef &x_font);
+extern "C" void MCCanvasFontGetBold(MCCanvasFontRef p_font, bool &r_bold);
+extern "C" void MCCanvasFontSetBold(bool p_bold, MCCanvasFontRef &x_font);
+extern "C" void MCCanvasFontGetItalic(MCCanvasFontRef p_font, bool &r_italic);
+extern "C" void MCCanvasFontSetItalic(bool p_italic, MCCanvasFontRef &x_font);
+extern "C" void MCCanvasFontGetSize(MCCanvasFontRef p_font, uinteger_t &r_size);
+extern "C" void MCCanvasFontSetSize(uinteger_t p_size, MCCanvasFontRef &x_font);
 
 // Operations
-extern "C" MC_DLLEXPORT void MCCanvasFontMeasureTextTypographicBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect);
-extern "C" MC_DLLEXPORT void MCCanvasFontMeasureTextTypographicBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect);
-extern "C" MC_DLLEXPORT void MCCanvasFontMeasureTextImageBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect);
-extern "C" MC_DLLEXPORT void MCCanvasFontMeasureTextImageBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect);
+extern "C" void MCCanvasFontMeasureTextTypographicBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect);
+extern "C" void MCCanvasFontMeasureTextTypographicBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect);
+extern "C" void MCCanvasFontMeasureTextImageBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect);
+extern "C" void MCCanvasFontMeasureTextImageBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect);
 
 //////////
 
 // Canvas
 
-extern "C" MC_DLLEXPORT void MCCanvasAlignmentEvaluate(integer_t p_h_align, integer_t p_v_align, integer_t &r_align);
+extern "C" void MCCanvasAlignmentEvaluate(integer_t p_h_align, integer_t p_v_align, integer_t &r_align);
 
 // Properties
-extern "C" MC_DLLEXPORT void MCCanvasGetPaint(MCCanvasRef p_canvas, MCCanvasPaintRef &r_paint);
-extern "C" MC_DLLEXPORT void MCCanvasSetPaint(MCCanvasPaintRef p_paint, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetFillRuleAsString(MCCanvasRef p_canvas, MCStringRef &r_string);
-extern "C" MC_DLLEXPORT void MCCanvasSetFillRuleAsString(MCStringRef p_string, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetAntialias(MCCanvasRef p_canvas, bool &r_antialias);
-extern "C" MC_DLLEXPORT void MCCanvasSetAntialias(bool p_antialias, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetOpacity(MCCanvasRef p_canvas, MCCanvasFloat &r_opacity);
-extern "C" MC_DLLEXPORT void MCCanvasSetOpacity(MCCanvasFloat p_opacity, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetBlendModeAsString(MCCanvasRef p_canvas, MCStringRef &r_blend_mode);
-extern "C" MC_DLLEXPORT void MCCanvasSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetStippled(MCCanvasRef p_canvas, bool &r_stippled);
-extern "C" MC_DLLEXPORT void MCCanvasSetStippled(bool p_stippled, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetImageResizeQualityAsString(MCCanvasRef p_canvas, MCStringRef &r_quality);
-extern "C" MC_DLLEXPORT void MCCanvasSetImageResizeQualityAsString(MCStringRef p_quality, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetStrokeWidth(MCCanvasRef p_canvas, MCGFloat& r_stroke_width);
-extern "C" MC_DLLEXPORT void MCCanvasSetStrokeWidth(MCGFloat p_stroke_width, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetFont(MCCanvasRef p_canvas, MCCanvasFontRef &r_font);
-extern "C" MC_DLLEXPORT void MCCanvasSetFont(MCCanvasFontRef p_font, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetStrokeWidth(MCCanvasRef p_canvas, MCGFloat& r_stroke_width);
-extern "C" MC_DLLEXPORT void MCCanvasSetStrokeWidth(MCGFloat p_stroke_width, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetFont(MCCanvasRef p_canvas, MCCanvasFontRef &r_font);
-extern "C" MC_DLLEXPORT void MCCanvasSetFont(MCCanvasFontRef p_font, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetJoinStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_join_style);
-extern "C" MC_DLLEXPORT void MCCanvasSetJoinStyleAsString(MCStringRef p_join_style, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetCapStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_cap_style);
-extern "C" MC_DLLEXPORT void MCCanvasSetCapStyleAsString(MCStringRef p_cap_style, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetMiterLimit(MCCanvasRef p_canvas, MCCanvasFloat &r_limit);
-extern "C" MC_DLLEXPORT void MCCanvasSetMiterLimit(MCCanvasFloat p_limit, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetDashes(MCCanvasRef p_canvas, MCProperListRef &r_dashes);
-extern "C" MC_DLLEXPORT void MCCanvasSetDashes(MCProperListRef p_dashes, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasGetDashPhase(MCCanvasRef p_canvas, MCCanvasFloat &r_phase);
-extern "C" MC_DLLEXPORT void MCCanvasSetDashPhase(MCCanvasFloat p_phase, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetPaint(MCCanvasRef p_canvas, MCCanvasPaintRef &r_paint);
+extern "C" void MCCanvasSetPaint(MCCanvasPaintRef p_paint, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetFillRuleAsString(MCCanvasRef p_canvas, MCStringRef &r_string);
+extern "C" void MCCanvasSetFillRuleAsString(MCStringRef p_string, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetAntialias(MCCanvasRef p_canvas, bool &r_antialias);
+extern "C" void MCCanvasSetAntialias(bool p_antialias, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetOpacity(MCCanvasRef p_canvas, MCCanvasFloat &r_opacity);
+extern "C" void MCCanvasSetOpacity(MCCanvasFloat p_opacity, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetBlendModeAsString(MCCanvasRef p_canvas, MCStringRef &r_blend_mode);
+extern "C" void MCCanvasSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetStippled(MCCanvasRef p_canvas, bool &r_stippled);
+extern "C" void MCCanvasSetStippled(bool p_stippled, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetImageResizeQualityAsString(MCCanvasRef p_canvas, MCStringRef &r_quality);
+extern "C" void MCCanvasSetImageResizeQualityAsString(MCStringRef p_quality, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetStrokeWidth(MCCanvasRef p_canvas, MCGFloat& r_stroke_width);
+extern "C" void MCCanvasSetStrokeWidth(MCGFloat p_stroke_width, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetFont(MCCanvasRef p_canvas, MCCanvasFontRef &r_font);
+extern "C" void MCCanvasSetFont(MCCanvasFontRef p_font, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetJoinStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_join_style);
+extern "C" void MCCanvasSetJoinStyleAsString(MCStringRef p_join_style, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetCapStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_cap_style);
+extern "C" void MCCanvasSetCapStyleAsString(MCStringRef p_cap_style, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetMiterLimit(MCCanvasRef p_canvas, MCCanvasFloat &r_limit);
+extern "C" void MCCanvasSetMiterLimit(MCCanvasFloat p_limit, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetDashes(MCCanvasRef p_canvas, MCProperListRef &r_dashes);
+extern "C" void MCCanvasSetDashes(MCProperListRef p_dashes, MCCanvasRef p_canvas);
+extern "C" void MCCanvasGetDashPhase(MCCanvasRef p_canvas, MCCanvasFloat &r_phase);
+extern "C" void MCCanvasSetDashPhase(MCCanvasFloat p_phase, MCCanvasRef p_canvas);
 
 // Operations
-extern "C" MC_DLLEXPORT void MCCanvasTransform(MCCanvasRef p_canvas, MCCanvasTransformRef p_transform);
-extern "C" MC_DLLEXPORT void MCCanvasScale(MCCanvasRef p_canvas, MCCanvasFloat p_scale_x, MCCanvasFloat p_scale_y);
-extern "C" MC_DLLEXPORT void MCCanvasScaleWithList(MCCanvasRef p_canvas, MCProperListRef p_scale);
-extern "C" MC_DLLEXPORT void MCCanvasRotate(MCCanvasRef p_canvas, MCCanvasFloat p_angle);
-extern "C" MC_DLLEXPORT void MCCanvasTranslate(MCCanvasRef p_canvas, MCCanvasFloat p_x, MCCanvasFloat p_y);
-extern "C" MC_DLLEXPORT void MCCanvasTranslateWithList(MCCanvasRef p_canvas, MCProperListRef p_translation);
-extern "C" MC_DLLEXPORT void MCCanvasSaveState(MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasRestoreState(MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasBeginLayer(MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasEndLayer(MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasFill(MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasFillPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasStroke(MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasStrokePath(MCCanvasPathRef p_path, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasClipToRect(MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasAddPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasDrawImage(MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasDrawRectOfImage(MCCanvasRectangleRef p_src_rect, MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasMoveTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasLineTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasClosePath(MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_align, MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT void MCCanvasFillText(MCStringRef p_text, MCCanvasPointRef p_point, MCCanvasRef p_canvas);
-extern "C" MC_DLLEXPORT MCCanvasRectangleRef MCCanvasMeasureText(MCStringRef p_text, MCCanvasRef p_canvas);
+extern "C" void MCCanvasTransform(MCCanvasRef p_canvas, MCCanvasTransformRef p_transform);
+extern "C" void MCCanvasScale(MCCanvasRef p_canvas, MCCanvasFloat p_scale_x, MCCanvasFloat p_scale_y);
+extern "C" void MCCanvasScaleWithList(MCCanvasRef p_canvas, MCProperListRef p_scale);
+extern "C" void MCCanvasRotate(MCCanvasRef p_canvas, MCCanvasFloat p_angle);
+extern "C" void MCCanvasTranslate(MCCanvasRef p_canvas, MCCanvasFloat p_x, MCCanvasFloat p_y);
+extern "C" void MCCanvasTranslateWithList(MCCanvasRef p_canvas, MCProperListRef p_translation);
+extern "C" void MCCanvasSaveState(MCCanvasRef p_canvas);
+extern "C" void MCCanvasRestoreState(MCCanvasRef p_canvas);
+extern "C" void MCCanvasBeginLayer(MCCanvasRef p_canvas);
+extern "C" void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas);
+extern "C" void MCCanvasEndLayer(MCCanvasRef p_canvas);
+extern "C" void MCCanvasFill(MCCanvasRef p_canvas);
+extern "C" void MCCanvasFillPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas);
+extern "C" void MCCanvasStroke(MCCanvasRef p_canvas);
+extern "C" void MCCanvasStrokePath(MCCanvasPathRef p_path, MCCanvasRef p_canvas);
+extern "C" void MCCanvasClipToRect(MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas);
+extern "C" void MCCanvasAddPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas);
+extern "C" void MCCanvasDrawImage(MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas);
+extern "C" void MCCanvasDrawRectOfImage(MCCanvasRectangleRef p_src_rect, MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas);
+extern "C" void MCCanvasMoveTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas);
+extern "C" void MCCanvasLineTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas);
+extern "C" void MCCanvasCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasRef p_canvas);
+extern "C" void MCCanvasCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasRef p_canvas);
+extern "C" void MCCanvasClosePath(MCCanvasRef p_canvas);
+extern "C" void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_align, MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas);
+extern "C" void MCCanvasFillText(MCStringRef p_text, MCCanvasPointRef p_point, MCCanvasRef p_canvas);
+extern "C" MCCanvasRectangleRef MCCanvasMeasureText(MCStringRef p_text, MCCanvasRef p_canvas);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -50,7 +50,7 @@ struct __MCScriptObjectImpl
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCEngineScriptObjectTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCEngineScriptObjectTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -724,8 +724,8 @@ extern "C" MC_DLLEXPORT void MCEngineExecLogWithValues(MCStringRef p_message, MC
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCEngineScriptObjectDoesNotExistErrorTypeInfo = nil;
-MCTypeInfoRef kMCEngineScriptObjectNoContextErrorTypeInfo = nil;
+MC_DLLEXPORT MCTypeInfoRef kMCEngineScriptObjectDoesNotExistErrorTypeInfo = nil;
+MC_DLLEXPORT MCTypeInfoRef kMCEngineScriptObjectNoContextErrorTypeInfo = nil;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/module-engine.h
+++ b/engine/src/module-engine.h
@@ -25,10 +25,10 @@ typedef struct __MCScriptObject *MCScriptObjectRef;
 
 extern "C"
 {
-    extern MC_DLLEXPORT MCTypeInfoRef kMCEngineScriptObjectTypeInfo;
+    extern MCTypeInfoRef kMCEngineScriptObjectTypeInfo;
 
-	extern MC_DLLEXPORT MCTypeInfoRef kMCEngineScriptObjectDoesNotExistErrorTypeInfo;
-	extern MC_DLLEXPORT MCTypeInfoRef kMCEngineScriptObjectNoContextErrorTypeInfo;
+	extern MCTypeInfoRef kMCEngineScriptObjectDoesNotExistErrorTypeInfo;
+	extern MCTypeInfoRef kMCEngineScriptObjectNoContextErrorTypeInfo;
 }
 
 bool MCEngineScriptObjectCreate(MCObject *p_object, uint32_t p_part_id, MCScriptObjectRef& r_object);

--- a/engine/src/text-api.cpp
+++ b/engine/src/text-api.cpp
@@ -21,6 +21,7 @@
 #include "text-pane.h"
 
 
+MC_DLLEXPORT
 void MCTextCellSetMaxSize(MCTextCellRef p_cell, coord_t p_width, coord_t p_height)
 {
     p_cell->setMaxSize(p_width, p_height);
@@ -29,6 +30,7 @@ void MCTextCellSetMaxSize(MCTextCellRef p_cell, coord_t p_width, coord_t p_heigh
 // Creates a new, empty text pane. The specified stack is used for scaling and
 // theming only - the pane isn't a LiveCode control and isn't a child of the
 // stack.
+MC_DLLEXPORT
 bool MCTextPaneCreate(class MCStack* p_on_stack, MCTextPaneRef& r_pane)
 {
     r_pane = new MCTextPane;
@@ -36,6 +38,7 @@ bool MCTextPaneCreate(class MCStack* p_on_stack, MCTextPaneRef& r_pane)
 }
 
 // Deletes the given text pane
+MC_DLLEXPORT
 bool MCTextPaneDelete(MCTextPaneRef p_pane)
 {
     delete p_pane;
@@ -45,6 +48,7 @@ bool MCTextPaneDelete(MCTextPaneRef p_pane)
 // Sets the contents of the text pane to be the given string. Other than certain
 // inline control characters (tabs, newlines, BiDi controls, etc), the string
 // is unformatted.
+MC_DLLEXPORT
 bool MCTextPaneSetContentsPlain(MCTextPaneRef p_pane, MCStringRef p_contents)
 {
     p_pane->setContentsPlain(p_contents);
@@ -52,17 +56,22 @@ bool MCTextPaneSetContentsPlain(MCTextPaneRef p_pane, MCStringRef p_contents)
 }
 
 static MCTextPaneRef s_pane;
+
+MC_DLLEXPORT
 MCTextPaneRef MCTextPaneGet()
 {
     return s_pane;
 }
 
+MC_DLLEXPORT
 void MCTextPaneSet(MCTextPaneRef p_pane)
 {
     s_pane = p_pane;
 }
 
 extern MCDC* g_widget_paint_dc;
+
+MC_DLLEXPORT
 void MCTextPanePaintShim(MCTextPaneRef p_pane)
 {
     // AL-2015-07-08: Removed temporarily as it was causing build issues

--- a/engine/src/text-api.h
+++ b/engine/src/text-api.h
@@ -90,24 +90,24 @@ struct MCTextAttributes
 ////////////////////////////////////////////////////////////////////////////////
 
 // MCTextCell accessors
-MC_DLLEXPORT MCTextCellType              MCTextCellGetType(MCTextCellRef);
-MC_DLLEXPORT MCTextCellRef               MCTextCellGetParent(MCTextCellRef);
-MC_DLLEXPORT MCTextCellRef               MCTextCellGetChildren(MCTextCellRef);
-MC_DLLEXPORT coord_t                     MCTextCellGetX(MCTextCellRef);
-MC_DLLEXPORT coord_t                     MCTextCellGetY(MCTextCellRef);
-MC_DLLEXPORT coord_t                     MCTextCellGetWidth(MCTextCellRef);
-MC_DLLEXPORT coord_t                     MCTextCellGetHeight(MCTextCellRef);
-MC_DLLEXPORT coord_t                     MCTextCellGetMaxWidth(MCTextCellRef);
-MC_DLLEXPORT coord_t                     MCTextCellGetMaxHeight(MCTextCellRef);
-MC_DLLEXPORT MCTextCellAlignment         MCTextCellGetHorizontalAlignment(MCTextCellRef);
-MC_DLLEXPORT MCTextCellAlignment         MCTextCellGetVerticalAlignment(MCTextCellRef);
-MC_DLLEXPORT MCTextCellLayoutDirection   MCTextCellGetLayoutDirection(MCTextCellRef);
-MC_DLLEXPORT MCTextDirection             MCTextCellGetTextDirection(MCTextCellRef);
-MC_DLLEXPORT void                        MCTextCellSetPosition(MCTextCellRef, coord_t p_x, coord_t p_y);
-MC_DLLEXPORT void                        MCTextCellSetMaxSize(MCTextCellRef, coord_t p_width, coord_t p_height);
-MC_DLLEXPORT void                        MCTextCellSetAlignment(MCTextCellRef, MCTextCellAlignment p_horizontal, MCTextCellAlignment p_vertical);
-MC_DLLEXPORT void                        MCTextCellSetLayoutDirection(MCTextCellRef, MCTextCellLayoutDirection p_direction);
-MC_DLLEXPORT void                        MCTextCellSetTextDirection(MCTextCellRef, MCTextDirection p_direction);
+MCTextCellType              MCTextCellGetType(MCTextCellRef);
+MCTextCellRef               MCTextCellGetParent(MCTextCellRef);
+MCTextCellRef               MCTextCellGetChildren(MCTextCellRef);
+coord_t                     MCTextCellGetX(MCTextCellRef);
+coord_t                     MCTextCellGetY(MCTextCellRef);
+coord_t                     MCTextCellGetWidth(MCTextCellRef);
+coord_t                     MCTextCellGetHeight(MCTextCellRef);
+coord_t                     MCTextCellGetMaxWidth(MCTextCellRef);
+coord_t                     MCTextCellGetMaxHeight(MCTextCellRef);
+MCTextCellAlignment         MCTextCellGetHorizontalAlignment(MCTextCellRef);
+MCTextCellAlignment         MCTextCellGetVerticalAlignment(MCTextCellRef);
+MCTextCellLayoutDirection   MCTextCellGetLayoutDirection(MCTextCellRef);
+MCTextDirection             MCTextCellGetTextDirection(MCTextCellRef);
+void                        MCTextCellSetPosition(MCTextCellRef, coord_t p_x, coord_t p_y);
+void                        MCTextCellSetMaxSize(MCTextCellRef, coord_t p_width, coord_t p_height);
+void                        MCTextCellSetAlignment(MCTextCellRef, MCTextCellAlignment p_horizontal, MCTextCellAlignment p_vertical);
+void                        MCTextCellSetLayoutDirection(MCTextCellRef, MCTextCellLayoutDirection p_direction);
+void                        MCTextCellSetTextDirection(MCTextCellRef, MCTextDirection p_direction);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -115,19 +115,19 @@ MC_DLLEXPORT void                        MCTextCellSetTextDirection(MCTextCellRe
 // Creates a new, empty text pane. The specified stack is used for scaling and
 // theming only - the pane isn't a LiveCode control and isn't a child of the
 // stack.
-MC_DLLEXPORT bool MCTextPaneCreate(class MCStack* p_on_stack, MCTextPaneRef& r_pane);
+bool MCTextPaneCreate(class MCStack* p_on_stack, MCTextPaneRef& r_pane);
 
 // Deletes the given text pane
-MC_DLLEXPORT bool MCTextPaneDelete(MCTextPaneRef p_pane);
+bool MCTextPaneDelete(MCTextPaneRef p_pane);
 
 // Sets the contents of the text pane to be the given string. Other than certain
 // inline control characters (tabs, newlines, BiDi controls, etc), the string
 // is unformatted.
-MC_DLLEXPORT bool MCTextPaneSetContentsPlain(MCTextPaneRef p_pane, MCStringRef p_contents);
+bool MCTextPaneSetContentsPlain(MCTextPaneRef p_pane, MCStringRef p_contents);
     
-MC_DLLEXPORT MCTextPaneRef MCTextPaneGet();
-MC_DLLEXPORT void MCTextPaneSet(MCTextPaneRef p_pane);
-MC_DLLEXPORT void MCTextPanePaintShim(MCTextPaneRef p_pane);
+MCTextPaneRef MCTextPaneGet();
+void MCTextPaneSet(MCTextPaneRef p_pane);
+void MCTextPanePaintShim(MCTextPaneRef p_pane);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -2389,8 +2389,8 @@ bool MCErrorCreateNamedTypeInfo(MCNameRef p_domain, MCNameRef p_name, MCStringRe
 	return true;
 }
 
-MCTypeInfoRef kMCWidgetNoCurrentWidgetErrorTypeInfo = nil;
-MCTypeInfoRef kMCWidgetSizeFormatErrorTypeInfo = nil;
+MC_DLLEXPORT MCTypeInfoRef kMCWidgetNoCurrentWidgetErrorTypeInfo = nil;
+MC_DLLEXPORT MCTypeInfoRef kMCWidgetSizeFormatErrorTypeInfo = nil;
 
 bool MCWidgetModuleInitialize(void)
 {

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -239,8 +239,8 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT MCTypeInfoRef kMCWidgetNoCurrentWidgetErrorTypeInfo;
-extern "C" MC_DLLEXPORT MCTypeInfoRef kMCWidgetSizeFormatErrorTypeInfo;
+extern "C" MCTypeInfoRef kMCWidgetNoCurrentWidgetErrorTypeInfo;
+extern "C" MCTypeInfoRef kMCWidgetSizeFormatErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1001,22 +1001,22 @@ inline compare_t MCMemoryCompare(const void *left, const void *right, size_t siz
 
 // This method returns an unitialized block of memory of the given size in
 // block. An error is raised if allocation fails.
-MC_DLLEXPORT bool MCMemoryAllocate(size_t size, void*& r_block);
+bool MCMemoryAllocate(size_t size, void*& r_block);
 
 // This method returns an block of memory containing the same contents as the
 // provided one.
-MC_DLLEXPORT bool MCMemoryAllocateCopy(const void *block, size_t size, void*& r_new_block);
+bool MCMemoryAllocateCopy(const void *block, size_t size, void*& r_new_block);
 
 // This method reallocates a block of memory allocated using MCMemoryAllocate.
 // Any new space allocated is uninitialized. The new pointer to the block is
 // returned. Note that the block may move regardless of new size. If the input
 // block is nil, it is treated as an allocate call.
-MC_DLLEXPORT bool MCMemoryReallocate(void *block, size_t new_size, void*& r_new_block);
+bool MCMemoryReallocate(void *block, size_t new_size, void*& r_new_block);
 
 // This method deallocates a block of memory allocated using MCMemoryAllocate,
 // or subsequently reallocated using MCMemoryReallocate. The block passed in
 // may be nil.
-MC_DLLEXPORT void MCMemoryDeallocate(void *block);
+void MCMemoryDeallocate(void *block);
 
 //////////
 
@@ -1066,10 +1066,10 @@ extern "C" {
 // zero. An error is raised if allocation fails.
 //
 // Note that a block allocated with New must be freed with Delete.
-MC_DLLEXPORT bool MCMemoryNew(size_t size, void*& r_record);
+bool MCMemoryNew(size_t size, void*& r_record);
 
 // This method deletes a fixed size record that was allocated with MCMemoryNew.
-MC_DLLEXPORT void MCMemoryDelete(void *p_record);
+void MCMemoryDelete(void *p_record);
 
 //////////
 
@@ -1180,23 +1180,23 @@ extern "C" {
 //   value - recompute on unserialization of the object.
 
 // Return a hash for the given integer.
-MC_DLLEXPORT hash_t MCHashInteger(integer_t);
-MC_DLLEXPORT hash_t MCHashUInteger(uinteger_t);
-MC_DLLEXPORT hash_t MCHashUSize(size_t);
+hash_t MCHashInteger(integer_t);
+hash_t MCHashUInteger(uinteger_t);
+hash_t MCHashUSize(size_t);
 
 // Return a hash value for the given double - note that (hopefully!) hashing
 // an integer stored as a double will be the same as hashing the integer.
-MC_DLLEXPORT hash_t MCHashDouble(double d);
+hash_t MCHashDouble(double d);
 
 // Returns a hash value for the given pointer.
-MC_DLLEXPORT hash_t MCHashPointer(void *p);
+hash_t MCHashPointer(void *p);
 
 // Returns a hash value for the given sequence of bytes.
-MC_DLLEXPORT hash_t MCHashBytes(const void *bytes, size_t byte_count);
+hash_t MCHashBytes(const void *bytes, size_t byte_count);
 
 // Returns a hash value for the given sequence of bytes, continuing a previous
 // hashing sequence (byte_count should be a multiple of 4).
-MC_DLLEXPORT hash_t MCHashBytesStream(hash_t previous, const void *bytes, size_t byte_count);
+hash_t MCHashBytesStream(hash_t previous, const void *bytes, size_t byte_count);
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -1249,39 +1249,39 @@ struct MCValueCustomCallbacks
 };
 
 // Create a custom value with the given callbacks.
-MC_DLLEXPORT bool MCValueCreateCustom(MCTypeInfoRef typeinfo, size_t extra_bytes, MCValueRef& r_value);
+bool MCValueCreateCustom(MCTypeInfoRef typeinfo, size_t extra_bytes, MCValueRef& r_value);
 
 // Fetch the typecode of the given value.
-MC_DLLEXPORT MCValueTypeCode MCValueGetTypeCode(MCValueRef value);
+MCValueTypeCode MCValueGetTypeCode(MCValueRef value);
 
 // Fetch the typeinfo of the given value.
-MC_DLLEXPORT MCTypeInfoRef MCValueGetTypeInfo(MCValueRef value);
+MCTypeInfoRef MCValueGetTypeInfo(MCValueRef value);
 
 // Fetch the retain count.
-MC_DLLEXPORT uindex_t MCValueGetRetainCount(MCValueRef value);
+uindex_t MCValueGetRetainCount(MCValueRef value);
 
 // This only works for custom valuerefs at the moment!
-MC_DLLEXPORT bool MCValueIsMutable(MCValueRef value);
+bool MCValueIsMutable(MCValueRef value);
 
-MC_DLLEXPORT bool MCValueIsEmpty(MCValueRef value);
-MC_DLLEXPORT bool MCValueIsArray(MCValueRef value);
+bool MCValueIsEmpty(MCValueRef value);
+bool MCValueIsArray(MCValueRef value);
 
 // Reduce the reference count of the given value by one, destroying the value
 // if it reaches 0. Note that (for convience) 'value' can be nil, it which case
 // the call has no effect.
-MC_DLLEXPORT void MCValueRelease(MCValueRef value);
+void MCValueRelease(MCValueRef value);
 
 // Increment the reference count of the given value by one.
-MC_DLLEXPORT MCValueRef MCValueRetain(MCValueRef value);
+MCValueRef MCValueRetain(MCValueRef value);
 
 // Copies the given value ensuring the resulting value is immutable (which is
 // why it can fail).
-MC_DLLEXPORT bool MCValueCopy(MCValueRef value, MCValueRef& r_immutable_copy);
-MC_DLLEXPORT bool MCValueCopyAndRelease(MCValueRef value, MCValueRef& r_immutable_copy);
+bool MCValueCopy(MCValueRef value, MCValueRef& r_immutable_copy);
+bool MCValueCopyAndRelease(MCValueRef value, MCValueRef& r_immutable_copy);
 
 // Copies the given value as a mutable value - only works for custom valuerefs at the moment.
-MC_DLLEXPORT bool MCValueMutableCopy(MCValueRef value, MCValueRef& r_immutable_copy);
-MC_DLLEXPORT bool MCValueMutableCopyAndRelease(MCValueRef value, MCValueRef& r_immutable_copy);
+bool MCValueMutableCopy(MCValueRef value, MCValueRef& r_immutable_copy);
+bool MCValueMutableCopyAndRelease(MCValueRef value, MCValueRef& r_immutable_copy);
 
 // Compares the two values in an exact fashion and returns true if they are
 // equal. If the values are of different types, then they are not equal;
@@ -1297,22 +1297,22 @@ MC_DLLEXPORT bool MCValueMutableCopyAndRelease(MCValueRef value, MCValueRef& r_i
 //     comprise identical codepoint sequences (as unicode strings).
 //   - array: the two arrays are equal iff they have the same keys and the
 //     values of each corresponding keys are equal.
-MC_DLLEXPORT bool MCValueIsEqualTo(MCValueRef value, MCValueRef other_value);
+bool MCValueIsEqualTo(MCValueRef value, MCValueRef other_value);
 
 // Returns a hash value for the (exact) content of the value - in particular
 // no folding is done for strings or names. Note that if the hash of two values
 // is equal it does not mean the values are equal; although the converse is true
 // (by definition of IsEqualTo).
-MC_DLLEXPORT hash_t MCValueHash(MCValueRef value);
+hash_t MCValueHash(MCValueRef value);
 
 // Returns a string description of the given value suitable for display and
 // debugging (although not necessarily for general string formatting).
-MC_DLLEXPORT bool MCValueCopyDescription(MCValueRef value, MCStringRef& r_desc);
+bool MCValueCopyDescription(MCValueRef value, MCStringRef& r_desc);
 
 // Returns true if pointer comparison is for the value is enough to determine
 // equality. This is always true of booleans, nulls and names; other values
 // must be interred first.
-MC_DLLEXPORT bool MCValueIsUnique(MCValueRef value);
+bool MCValueIsUnique(MCValueRef value);
 
 // Inter the given value returning a new (immutable) value. Any two values that
 // are equal as defined by IsEqualTo will inter to the same object. i.e. For
@@ -1323,13 +1323,13 @@ MC_DLLEXPORT bool MCValueIsUnique(MCValueRef value);
 // bumps the reference count and returns the same value as they already satisfy
 //   x == y iff IsEqualTo(x, y)
 //
-MC_DLLEXPORT bool MCValueInter(MCValueRef value, MCValueRef& r_unique_value);
+bool MCValueInter(MCValueRef value, MCValueRef& r_unique_value);
 
 // As the 'Inter' method except that 'value' will be released. This allows
 // optimization in some cases as the original value can be (potentially) reused
 // to build the unique one (cutting down on copying).
 //
-MC_DLLEXPORT bool MCValueInterAndRelease(MCValueRef value, MCValueRef& r_unique_value);
+bool MCValueInterAndRelease(MCValueRef value, MCValueRef& r_unique_value);
 
 // Fetch the 'extra bytes' field for the given custom value.
 inline void *MCValueGetExtraBytesPtr(MCValueRef value) { return ((uint8_t *)value) + kMCValueCustomHeaderSize; }
@@ -1400,53 +1400,53 @@ extern "C" {
 // are equal iff their pointers are equal. (Note equal is not the same as conformance!)
 
 // The 'any' type is essentially a union of all typeinfos.
-MC_DLLEXPORT extern MCTypeInfoRef kMCAnyTypeInfo;
+extern MCTypeInfoRef kMCAnyTypeInfo;
 
 // These are typeinfos for all the 'builtin' valueref types.
-MC_DLLEXPORT extern MCTypeInfoRef kMCNullTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCBooleanTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCNumberTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCStringTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCNameTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCDataTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCArrayTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCSetTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCListTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCProperListTypeInfo;
+extern MCTypeInfoRef kMCNullTypeInfo;
+extern MCTypeInfoRef kMCBooleanTypeInfo;
+extern MCTypeInfoRef kMCNumberTypeInfo;
+extern MCTypeInfoRef kMCStringTypeInfo;
+extern MCTypeInfoRef kMCNameTypeInfo;
+extern MCTypeInfoRef kMCDataTypeInfo;
+extern MCTypeInfoRef kMCArrayTypeInfo;
+extern MCTypeInfoRef kMCSetTypeInfo;
+extern MCTypeInfoRef kMCListTypeInfo;
+extern MCTypeInfoRef kMCProperListTypeInfo;
 
-MC_DLLEXPORT extern MCTypeInfoRef kMCBoolTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCIntTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCUIntTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCFloatTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCDoubleTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCPointerTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCSizeTypeInfo;
+extern MCTypeInfoRef kMCBoolTypeInfo;
+extern MCTypeInfoRef kMCIntTypeInfo;
+extern MCTypeInfoRef kMCUIntTypeInfo;
+extern MCTypeInfoRef kMCFloatTypeInfo;
+extern MCTypeInfoRef kMCDoubleTypeInfo;
+extern MCTypeInfoRef kMCPointerTypeInfo;
+extern MCTypeInfoRef kMCSizeTypeInfo;
 
 //////////
 
 // Returns true if the typeinfo is an alias.
-MC_DLLEXPORT bool MCTypeInfoIsAlias(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsAlias(MCTypeInfoRef typeinfo);
 
 // Returns true if the typeinfo is a name.
-MC_DLLEXPORT bool MCTypeInfoIsNamed(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsNamed(MCTypeInfoRef typeinfo);
 
 // Returns true if the typeinfo is an optional typeinfo.
-MC_DLLEXPORT bool MCTypeInfoIsOptional(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsOptional(MCTypeInfoRef typeinfo);
 
 // Returns true if the typeinfo is of record type.
-MC_DLLEXPORT bool MCTypeInfoIsRecord(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsRecord(MCTypeInfoRef typeinfo);
 
 // Returns true if the typeinfo is of handler type.
-MC_DLLEXPORT bool MCTypeInfoIsHandler(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsHandler(MCTypeInfoRef typeinfo);
 
 // Returns true if the typeinfo is of error type.
-MC_DLLEXPORT bool MCTypeInfoIsError(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsError(MCTypeInfoRef typeinfo);
 
 // Returns true if the typeinfo is of foreign type.
-MC_DLLEXPORT bool MCTypeInfoIsForeign(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsForeign(MCTypeInfoRef typeinfo);
     
 // Returns true if the typeinfo is of custom type.
-MC_DLLEXPORT bool MCTypeInfoIsCustom(MCTypeInfoRef typeinfo);
+bool MCTypeInfoIsCustom(MCTypeInfoRef typeinfo);
 
 // Typeinfo's form a chain with elements in the chain potentially providing critical
 // information about the specified type. This structure describes the represented
@@ -1460,7 +1460,7 @@ struct MCResolvedTypeInfo
 
 // Resolves the given typeinfo to the base typeinfo (either a bound named typeinfo,
 // or an anonymous non-meta typeinfo) if possible, and indicates if it is optional.
-MC_DLLEXPORT bool MCTypeInfoResolve(MCTypeInfoRef typeinfo, MCResolvedTypeInfo& r_resolution);
+bool MCTypeInfoResolve(MCTypeInfoRef typeinfo, MCResolvedTypeInfo& r_resolution);
 
 // Returns true if the source typeinfo can be assigned to a slot with the target
 // typeinfo. It is assumed that 'source' is a concrete typeinfo (one which has
@@ -1476,14 +1476,14 @@ MC_DLLEXPORT bool MCTypeInfoResolve(MCTypeInfoRef typeinfo, MCResolvedTypeInfo& 
 //     supertypes.
 //   - if source is builtin then target must be the same builtin type.
 //
-MC_DLLEXPORT bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target);
+bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target);
 
-MC_DLLEXPORT bool MCResolvedTypeInfoConforms(const MCResolvedTypeInfo& source, const MCResolvedTypeInfo& target);
+bool MCResolvedTypeInfoConforms(const MCResolvedTypeInfo& source, const MCResolvedTypeInfo& target);
 
 //////////
 
 // Creates a typeinfo for one of the builtin typecodes.
-MC_DLLEXPORT bool MCBuiltinTypeInfoCreate(MCValueTypeCode typecode, MCTypeInfoRef& r_target);
+bool MCBuiltinTypeInfoCreate(MCValueTypeCode typecode, MCTypeInfoRef& r_target);
 
 //////////
 
@@ -1523,64 +1523,64 @@ struct MCForeignTypeDescriptor
 	bool (*describe)(void *contents, MCStringRef & r_desc);
 };
 
-MC_DLLEXPORT bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *descriptor, MCTypeInfoRef& r_typeinfo);
+bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *descriptor, MCTypeInfoRef& r_typeinfo);
 
-MC_DLLEXPORT const MCForeignTypeDescriptor *MCForeignTypeInfoGetDescriptor(MCTypeInfoRef typeinfo);
-MC_DLLEXPORT void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef typeinfo);
+const MCForeignTypeDescriptor *MCForeignTypeInfoGetDescriptor(MCTypeInfoRef typeinfo);
+void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef typeinfo);
 
 //////////
 
 // Creates a type which is alias for another type.
-MC_DLLEXPORT bool MCAliasTypeInfoCreate(MCNameRef name, MCTypeInfoRef target, MCTypeInfoRef& r_alias_typeinfo);
+bool MCAliasTypeInfoCreate(MCNameRef name, MCTypeInfoRef target, MCTypeInfoRef& r_alias_typeinfo);
 
 // Returnts the name of the alias.
-MC_DLLEXPORT MCNameRef MCAliasTypeInfoGetName(MCTypeInfoRef typeinfo);
+MCNameRef MCAliasTypeInfoGetName(MCTypeInfoRef typeinfo);
 
 // Returns the target typeinfo.
-MC_DLLEXPORT MCTypeInfoRef MCAliasTypeInfoGetTarget(MCTypeInfoRef typeinfo);
+MCTypeInfoRef MCAliasTypeInfoGetTarget(MCTypeInfoRef typeinfo);
 
 //////////
 
 // Creates a type which refers to a named type. Named types are resolved by binding
 // them to another type. It is an error to bind a bound named type, and an
 // error to attempt to resolve an unbound named type.
-MC_DLLEXPORT bool MCNamedTypeInfoCreate(MCNameRef name, MCTypeInfoRef& r_named_typeinfo);
+bool MCNamedTypeInfoCreate(MCNameRef name, MCTypeInfoRef& r_named_typeinfo);
 
 // Fetch the name of the named typeinfo.
-MC_DLLEXPORT MCNameRef MCNamedTypeInfoGetName(MCTypeInfoRef typeinfo);
+MCNameRef MCNamedTypeInfoGetName(MCTypeInfoRef typeinfo);
     
 // Returns true if the given named type is bound.
-MC_DLLEXPORT bool MCNamedTypeInfoIsBound(MCTypeInfoRef typeinfo);
+bool MCNamedTypeInfoIsBound(MCTypeInfoRef typeinfo);
 
 // Returns the bound typeinfo, or nil if the type is unbound.
-MC_DLLEXPORT MCTypeInfoRef MCNamedTypeInfoGetBoundTypeInfo(MCTypeInfoRef typeinfo);
+MCTypeInfoRef MCNamedTypeInfoGetBoundTypeInfo(MCTypeInfoRef typeinfo);
 
 // Bind the given named type to the target type. The bound_type cannot be a named
 // type.
-MC_DLLEXPORT bool MCNamedTypeInfoBind(MCTypeInfoRef typeinfo, MCTypeInfoRef bound_type);
+bool MCNamedTypeInfoBind(MCTypeInfoRef typeinfo, MCTypeInfoRef bound_type);
 
 // Unbind the given named type.
-MC_DLLEXPORT bool MCNamedTypeInfoUnbind(MCTypeInfoRef typeinfo);
+bool MCNamedTypeInfoUnbind(MCTypeInfoRef typeinfo);
 
 // Resolve the given named type to its underlying type.
-MC_DLLEXPORT bool MCNamedTypeInfoResolve(MCTypeInfoRef typeinfo, MCTypeInfoRef& r_bound_type);
+bool MCNamedTypeInfoResolve(MCTypeInfoRef typeinfo, MCTypeInfoRef& r_bound_type);
 
 //////////
 
 // Creates an optional type. It is not allowed to create an optional type of an
 // optional type. (Note optional named types are allowed, even if the named type
 // is optional).
-MC_DLLEXPORT bool MCOptionalTypeInfoCreate(MCTypeInfoRef base, MCTypeInfoRef& r_optional_typeinfo);
+bool MCOptionalTypeInfoCreate(MCTypeInfoRef base, MCTypeInfoRef& r_optional_typeinfo);
 
 // Returns the base type of the given optional type.
-MC_DLLEXPORT MCTypeInfoRef MCOptionalTypeInfoGetBaseTypeInfo(MCTypeInfoRef typeinfo);
+MCTypeInfoRef MCOptionalTypeInfoGetBaseTypeInfo(MCTypeInfoRef typeinfo);
 
 //////////
 
 // Create a typeinfo describing a custom typeinfo.
-MC_DLLEXPORT bool MCCustomTypeInfoCreate(MCTypeInfoRef base, const MCValueCustomCallbacks *callbacks, MCTypeInfoRef& r_typeinfo);
+bool MCCustomTypeInfoCreate(MCTypeInfoRef base, const MCValueCustomCallbacks *callbacks, MCTypeInfoRef& r_typeinfo);
 
-MC_DLLEXPORT const MCValueCustomCallbacks *MCCustomTypeInfoGetCallbacks(MCTypeInfoRef typeinfo);
+const MCValueCustomCallbacks *MCCustomTypeInfoGetCallbacks(MCTypeInfoRef typeinfo);
 
 //////////
 
@@ -1591,25 +1591,25 @@ struct MCRecordTypeFieldInfo
 };
 
 // Create a description of a record with the given fields.
-MC_DLLEXPORT bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef base_type, MCTypeInfoRef& r_typeinfo);
+bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef base_type, MCTypeInfoRef& r_typeinfo);
 
 // Return the base type of the record.
-MC_DLLEXPORT MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef typeinfo);
+MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef typeinfo);
 
 // Return the base type of the record.
-MC_DLLEXPORT MCTypeInfoRef MCRecordTypeGetBaseTypeInfo(MCTypeInfoRef typeinfo);
+MCTypeInfoRef MCRecordTypeGetBaseTypeInfo(MCTypeInfoRef typeinfo);
 
 // Return the number of fields in the record.
-MC_DLLEXPORT uindex_t MCRecordTypeInfoGetFieldCount(MCTypeInfoRef typeinfo);
+uindex_t MCRecordTypeInfoGetFieldCount(MCTypeInfoRef typeinfo);
 
 // Return the name of the field at the given index.
-MC_DLLEXPORT MCNameRef MCRecordTypeInfoGetFieldName(MCTypeInfoRef typeinfo, uindex_t index);
+MCNameRef MCRecordTypeInfoGetFieldName(MCTypeInfoRef typeinfo, uindex_t index);
 
 // Return the type of the field at the given index.
-MC_DLLEXPORT MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef typeinfo, uindex_t index);
+MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef typeinfo, uindex_t index);
 
 // Return true if typeinfo is derived from p_base_typeinfo.
-MC_DLLEXPORT bool MCRecordTypeInfoIsDerivedFrom(MCTypeInfoRef typeinfo, MCTypeInfoRef p_base_typeinfo);
+bool MCRecordTypeInfoIsDerivedFrom(MCTypeInfoRef typeinfo, MCTypeInfoRef p_base_typeinfo);
 
 //////////
 
@@ -1631,81 +1631,81 @@ struct MCHandlerTypeFieldInfo
 // Create a description of a handler with the given signature.
 // If field_count is negative, the fields array must be terminated by
 // an MCHandlerTypeFieldInfo where name is null.
-MC_DLLEXPORT bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef return_type, MCTypeInfoRef& r_typeinfo);
+bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef return_type, MCTypeInfoRef& r_typeinfo);
 
 // Get the return type of the handler. A return-type of kMCNullTypeInfo means no
 // value is returned.
-MC_DLLEXPORT MCTypeInfoRef MCHandlerTypeInfoGetReturnType(MCTypeInfoRef typeinfo);
+MCTypeInfoRef MCHandlerTypeInfoGetReturnType(MCTypeInfoRef typeinfo);
 
 // Get the number of parameters the handler takes.
-MC_DLLEXPORT uindex_t MCHandlerTypeInfoGetParameterCount(MCTypeInfoRef typeinfo);
+uindex_t MCHandlerTypeInfoGetParameterCount(MCTypeInfoRef typeinfo);
 
 // Return the mode of the index'th parameter.
-MC_DLLEXPORT MCHandlerTypeFieldMode MCHandlerTypeInfoGetParameterMode(MCTypeInfoRef typeinfo, uindex_t index);
+MCHandlerTypeFieldMode MCHandlerTypeInfoGetParameterMode(MCTypeInfoRef typeinfo, uindex_t index);
 
 // Return the type of the index'th parameter.
-MC_DLLEXPORT MCTypeInfoRef MCHandlerTypeInfoGetParameterType(MCTypeInfoRef typeinfo, uindex_t index);
+MCTypeInfoRef MCHandlerTypeInfoGetParameterType(MCTypeInfoRef typeinfo, uindex_t index);
 
 //////////
 
-MC_DLLEXPORT bool MCErrorTypeInfoCreate(MCNameRef domain, MCStringRef message, MCTypeInfoRef& r_typeinfo);
+bool MCErrorTypeInfoCreate(MCNameRef domain, MCStringRef message, MCTypeInfoRef& r_typeinfo);
 
-MC_DLLEXPORT MCNameRef MCErrorTypeInfoGetDomain(MCTypeInfoRef error);
-MC_DLLEXPORT MCStringRef MCErrorTypeInfoGetMessage(MCTypeInfoRef error);
+MCNameRef MCErrorTypeInfoGetDomain(MCTypeInfoRef error);
+MCStringRef MCErrorTypeInfoGetMessage(MCTypeInfoRef error);
 
 //////////
 
 // Create a named typeinfo bound to an error typeinfo.
-MC_DLLEXPORT bool MCNamedErrorTypeInfoCreate(MCNameRef p_name, MCNameRef p_domain, MCStringRef p_message, MCTypeInfoRef &r_typeinfo);
+bool MCNamedErrorTypeInfoCreate(MCNameRef p_name, MCNameRef p_domain, MCStringRef p_message, MCTypeInfoRef &r_typeinfo);
 
 // Create a named typeinfo bound to a custom typeinfo.
-MC_DLLEXPORT bool MCNamedCustomTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef base, const MCValueCustomCallbacks *callbacks, MCTypeInfoRef& r_typeinfo);
+bool MCNamedCustomTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef base, const MCValueCustomCallbacks *callbacks, MCTypeInfoRef& r_typeinfo);
 	
 // Create a named typeinfo bound to a foreign typeinfo.
-MC_DLLEXPORT bool MCNamedForeignTypeInfoCreate(MCNameRef p_name, const MCForeignTypeDescriptor *p_descriptor, MCTypeInfoRef& r_typeinfo);
+bool MCNamedForeignTypeInfoCreate(MCNameRef p_name, const MCForeignTypeDescriptor *p_descriptor, MCTypeInfoRef& r_typeinfo);
 	
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  BOOLEAN DEFINITIONS
 //
 
-MC_DLLEXPORT extern MCNullRef kMCNull;
+extern MCNullRef kMCNull;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  BOOLEAN DEFINITIONS
 //
 
-MC_DLLEXPORT extern MCBooleanRef kMCFalse;
-MC_DLLEXPORT extern MCBooleanRef kMCTrue;
+extern MCBooleanRef kMCFalse;
+extern MCBooleanRef kMCTrue;
 
-MC_DLLEXPORT bool MCBooleanCreateWithBool(bool value, MCBooleanRef& r_boolean);
+bool MCBooleanCreateWithBool(bool value, MCBooleanRef& r_boolean);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  NUMBER DEFINITIONS
 //
 
-MC_DLLEXPORT bool MCNumberCreateWithInteger(integer_t value, MCNumberRef& r_number);
-MC_DLLEXPORT bool MCNumberCreateWithUnsignedInteger(uinteger_t value, MCNumberRef& r_number);
-MC_DLLEXPORT bool MCNumberCreateWithReal(real64_t value, MCNumberRef& r_number);
+bool MCNumberCreateWithInteger(integer_t value, MCNumberRef& r_number);
+bool MCNumberCreateWithUnsignedInteger(uinteger_t value, MCNumberRef& r_number);
+bool MCNumberCreateWithReal(real64_t value, MCNumberRef& r_number);
 
-MC_DLLEXPORT bool MCNumberIsInteger(MCNumberRef number);
-MC_DLLEXPORT bool MCNumberIsReal(MCNumberRef number);
+bool MCNumberIsInteger(MCNumberRef number);
+bool MCNumberIsReal(MCNumberRef number);
 
-MC_DLLEXPORT integer_t MCNumberFetchAsInteger(MCNumberRef number);
-MC_DLLEXPORT uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef number);
-MC_DLLEXPORT real64_t MCNumberFetchAsReal(MCNumberRef number);
+integer_t MCNumberFetchAsInteger(MCNumberRef number);
+uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef number);
+real64_t MCNumberFetchAsReal(MCNumberRef number);
 
-MC_DLLEXPORT bool MCNumberParseOffsetPartial(MCStringRef p_string, uindex_t offset, uindex_t &r_chars_used, MCNumberRef &r_number);
+bool MCNumberParseOffsetPartial(MCStringRef p_string, uindex_t offset, uindex_t &r_chars_used, MCNumberRef &r_number);
 
-MC_DLLEXPORT bool MCNumberParseOffset(MCStringRef p_string, uindex_t offset, uindex_t char_count, MCNumberRef &r_number);
-MC_DLLEXPORT bool MCNumberParse(MCStringRef string, MCNumberRef& r_number);
-MC_DLLEXPORT bool MCNumberParseUnicodeChars(const unichar_t *chars, uindex_t char_count, MCNumberRef& r_number);
+bool MCNumberParseOffset(MCStringRef p_string, uindex_t offset, uindex_t char_count, MCNumberRef &r_number);
+bool MCNumberParse(MCStringRef string, MCNumberRef& r_number);
+bool MCNumberParseUnicodeChars(const unichar_t *chars, uindex_t char_count, MCNumberRef& r_number);
 
-MC_DLLEXPORT extern MCNumberRef kMCZero;
-MC_DLLEXPORT extern MCNumberRef kMCOne;
-MC_DLLEXPORT extern MCNumberRef kMCMinusOne;
+extern MCNumberRef kMCZero;
+extern MCNumberRef kMCOne;
+extern MCNumberRef kMCMinusOne;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -1713,30 +1713,30 @@ MC_DLLEXPORT extern MCNumberRef kMCMinusOne;
 //
 
 // Like MCSTR but for NameRefs
-MC_DLLEXPORT MCNameRef MCNAME(const char *);
+MCNameRef MCNAME(const char *);
 
 // Create a name using the given string.
-MC_DLLEXPORT bool MCNameCreate(MCStringRef string, MCNameRef& r_name);
+bool MCNameCreate(MCStringRef string, MCNameRef& r_name);
 // Create a name using chars.
-MC_DLLEXPORT bool MCNameCreateWithChars(const unichar_t *chars, uindex_t count, MCNameRef& r_name);
+bool MCNameCreateWithChars(const unichar_t *chars, uindex_t count, MCNameRef& r_name);
 // Create a name using native chars.
-MC_DLLEXPORT bool MCNameCreateWithNativeChars(const char_t *chars, uindex_t count, MCNameRef& r_name);
+bool MCNameCreateWithNativeChars(const char_t *chars, uindex_t count, MCNameRef& r_name);
 
 // Create a name using the given string, releasing the original.
-MC_DLLEXPORT bool MCNameCreateAndRelease(MCStringRef string, MCNameRef& r_name);
+bool MCNameCreateAndRelease(MCStringRef string, MCNameRef& r_name);
 
 // Looks for an existing name matching the given string.
-MC_DLLEXPORT MCNameRef MCNameLookup(MCStringRef string);
+MCNameRef MCNameLookup(MCStringRef string);
 
 // Returns a unsigned integer which can be used to order a table for a binary
 // search.
-MC_DLLEXPORT uintptr_t MCNameGetCaselessSearchKey(MCNameRef name);
+uintptr_t MCNameGetCaselessSearchKey(MCNameRef name);
 
 // Returns the string content of the name.
-MC_DLLEXPORT MCStringRef MCNameGetString(MCNameRef name);
+MCStringRef MCNameGetString(MCNameRef name);
 
 // Returns true if the given name is the empty name.
-MC_DLLEXPORT bool MCNameIsEmpty(MCNameRef name);
+bool MCNameIsEmpty(MCNameRef name);
 
 }
 
@@ -1749,10 +1749,10 @@ bool MCNameIsEqualTo(MCNameRef self, MCNameRef p_other_name, bool p_case_sensiti
 extern "C" {
 
 // The empty name object;
-MC_DLLEXPORT extern MCNameRef kMCEmptyName;
+extern MCNameRef kMCEmptyName;
 
-MC_DLLEXPORT extern MCNameRef kMCTrueName;
-MC_DLLEXPORT extern MCNameRef kMCFalseName;
+extern MCNameRef kMCTrueName;
+extern MCNameRef kMCFalseName;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -1814,141 +1814,141 @@ enum
 /////////
 
 // The empty string.
-MC_DLLEXPORT extern MCStringRef kMCEmptyString;
+extern MCStringRef kMCEmptyString;
 
 // The default string for the 'true' boolean value.
-MC_DLLEXPORT extern MCStringRef kMCTrueString;
+extern MCStringRef kMCTrueString;
 
 // The default string for the 'false' boolean value.
-MC_DLLEXPORT extern MCStringRef kMCFalseString;
+extern MCStringRef kMCFalseString;
 
 // The default string for the 'mixed' value of chunk properties.
-MC_DLLEXPORT extern MCStringRef kMCMixedString;
+extern MCStringRef kMCMixedString;
 
 // The default string for ','.
-MC_DLLEXPORT extern MCStringRef kMCCommaString;
+extern MCStringRef kMCCommaString;
 
 // The default string for '\n'.
-MC_DLLEXPORT extern MCStringRef kMCLineEndString;
+extern MCStringRef kMCLineEndString;
 
 // The default string for '\t'.
-MC_DLLEXPORT extern MCStringRef kMCTabString;
+extern MCStringRef kMCTabString;
 
 /////////
 
 // Creates an MCStringRef wrapping the given constant c-string. Note that
 // the c-string must be a C static string.
-MC_DLLEXPORT MCStringRef MCSTR(const char *string);
+MCStringRef MCSTR(const char *string);
 
-MC_DLLEXPORT const char *MCStringGetCString(MCStringRef p_string);
-MC_DLLEXPORT bool MCStringIsEqualToCString(MCStringRef string, const char *cstring, MCStringOptions options);
+const char *MCStringGetCString(MCStringRef p_string);
+bool MCStringIsEqualToCString(MCStringRef string, const char *cstring, MCStringOptions options);
 
 // Create an immutable string from the given bytes, interpreting them using
 // the specified encoding.
-MC_DLLEXPORT bool MCStringCreateWithBytes(const byte_t *bytes, uindex_t byte_count, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringCreateWithBytesAndRelease(byte_t *bytes, uindex_t byte_count, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
+bool MCStringCreateWithBytes(const byte_t *bytes, uindex_t byte_count, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
+bool MCStringCreateWithBytesAndRelease(byte_t *bytes, uindex_t byte_count, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
 
 // Create an immutable string from the given unicode char sequence.
-MC_DLLEXPORT bool MCStringCreateWithChars(const unichar_t *chars, uindex_t char_count, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringCreateWithCharsAndRelease(unichar_t *chars, uindex_t char_count, MCStringRef& r_string);
+bool MCStringCreateWithChars(const unichar_t *chars, uindex_t char_count, MCStringRef& r_string);
+bool MCStringCreateWithCharsAndRelease(unichar_t *chars, uindex_t char_count, MCStringRef& r_string);
 
 // Create an immutable string from the given NUL terminated unicode char sequence.
-MC_DLLEXPORT bool MCStringCreateWithWString(const unichar_t *wstring, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringCreateWithWStringAndRelease(unichar_t *wstring, MCStringRef& r_string);
+bool MCStringCreateWithWString(const unichar_t *wstring, MCStringRef& r_string);
+bool MCStringCreateWithWStringAndRelease(unichar_t *wstring, MCStringRef& r_string);
 
 // Create an immutable string from the given native char sequence.
-MC_DLLEXPORT bool MCStringCreateWithNativeChars(const char_t *chars, uindex_t char_count, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringCreateWithNativeCharsAndRelease(char_t *chars, uindex_t char_count, MCStringRef& r_string);
+bool MCStringCreateWithNativeChars(const char_t *chars, uindex_t char_count, MCStringRef& r_string);
+bool MCStringCreateWithNativeCharsAndRelease(char_t *chars, uindex_t char_count, MCStringRef& r_string);
 
 // Create an immutable string from the given (native) c-string.
-MC_DLLEXPORT bool MCStringCreateWithCString(const char *cstring, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringCreateWithCStringAndRelease(char *cstring, MCStringRef& r_string);
+bool MCStringCreateWithCString(const char *cstring, MCStringRef& r_string);
+bool MCStringCreateWithCStringAndRelease(char *cstring, MCStringRef& r_string);
 
 #ifdef __HAS_CORE_FOUNDATION__
 // Create a string from a CoreFoundation string object.
-MC_DLLEXPORT bool MCStringCreateWithCFString(CFStringRef cf_string, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringCreateWithCFStringAndRelease(CFStringRef cf_string, MCStringRef& r_string);
+bool MCStringCreateWithCFString(CFStringRef cf_string, MCStringRef& r_string);
+bool MCStringCreateWithCFStringAndRelease(CFStringRef cf_string, MCStringRef& r_string);
 #endif
 
 #if !defined(__WINDOWS__)
 // Create a string from a C string in the system encoding
-MC_DLLEXPORT bool MCStringCreateWithSysString(const char *sys_string, MCStringRef &r_string);
+bool MCStringCreateWithSysString(const char *sys_string, MCStringRef &r_string);
 #endif
 
 // Create a mutable string with the given initial capacity. Note that the
 // initial capacity is only treated as a hint, the string will extend itself
 // as necessary.
-MC_DLLEXPORT bool MCStringCreateMutable(uindex_t initial_capacity, MCStringRef& r_string);
+bool MCStringCreateMutable(uindex_t initial_capacity, MCStringRef& r_string);
 
 /////////
 
 // Encode the given string with the specified encoding. Characters which cannot
 // be represented in the target encoding are replaced by '?'.
-MC_DLLEXPORT bool MCStringEncode(MCStringRef string, MCStringEncoding encoding, bool is_external_rep, MCDataRef& r_data);
-MC_DLLEXPORT bool MCStringEncodeAndRelease(MCStringRef string, MCStringEncoding encoding, bool is_external_rep, MCDataRef& r_data);
+bool MCStringEncode(MCStringRef string, MCStringEncoding encoding, bool is_external_rep, MCDataRef& r_data);
+bool MCStringEncodeAndRelease(MCStringRef string, MCStringEncoding encoding, bool is_external_rep, MCDataRef& r_data);
 
 // Decode the given data, intepreting in the given encoding.
-MC_DLLEXPORT bool MCStringDecode(MCDataRef data, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringDecodeAndRelease(MCDataRef data, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
+bool MCStringDecode(MCDataRef data, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
+bool MCStringDecodeAndRelease(MCDataRef data, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
 
 /////////
 
 // Create an immutable string, built using the given format specification and
 // argument list.
-MC_DLLEXPORT bool MCStringFormat(MCStringRef& r_string, const char *format, ...);
-MC_DLLEXPORT bool MCStringFormatV(MCStringRef& r_string, const char *format, va_list args);
+bool MCStringFormat(MCStringRef& r_string, const char *format, ...);
+bool MCStringFormatV(MCStringRef& r_string, const char *format, va_list args);
 
 /////////
 
 // Copy the given string as immutable.
-MC_DLLEXPORT bool MCStringCopy(MCStringRef string, MCStringRef& r_new_string);
+bool MCStringCopy(MCStringRef string, MCStringRef& r_new_string);
 
 // Copy the given string as immutable, releasing the original.
-MC_DLLEXPORT bool MCStringCopyAndRelease(MCStringRef string, MCStringRef& r_new_string);
+bool MCStringCopyAndRelease(MCStringRef string, MCStringRef& r_new_string);
 
 // Copy the given string as mutable.
-MC_DLLEXPORT bool MCStringMutableCopy(MCStringRef string, MCStringRef& r_new_string);
+bool MCStringMutableCopy(MCStringRef string, MCStringRef& r_new_string);
 
 // Copy the given string as mutable, releasing the original.
-MC_DLLEXPORT bool MCStringMutableCopyAndRelease(MCStringRef string, MCStringRef& r_new_string);
+bool MCStringMutableCopyAndRelease(MCStringRef string, MCStringRef& r_new_string);
 
 /////////
 
 // Copy a substring of the given string as immutable.
-MC_DLLEXPORT bool MCStringCopySubstring(MCStringRef string, MCRange range, MCStringRef& r_substring);
+bool MCStringCopySubstring(MCStringRef string, MCRange range, MCStringRef& r_substring);
 
 // Copy a substring of the given string as immutable, releasing the original.
-MC_DLLEXPORT bool MCStringCopySubstringAndRelease(MCStringRef string, MCRange range, MCStringRef& r_substring);
+bool MCStringCopySubstringAndRelease(MCStringRef string, MCRange range, MCStringRef& r_substring);
 
 // Copy a substring of the given string as mutable.
-MC_DLLEXPORT bool MCStringMutableCopySubstring(MCStringRef string, MCRange range, MCStringRef& r_substring);
+bool MCStringMutableCopySubstring(MCStringRef string, MCRange range, MCStringRef& r_substring);
 
 // Copy a substring of the given string as mutable, releasing the original.
-MC_DLLEXPORT bool MCStringMutableCopySubstringAndRelease(MCStringRef string, MCRange range, MCStringRef& r_substring);
+bool MCStringMutableCopySubstringAndRelease(MCStringRef string, MCRange range, MCStringRef& r_substring);
 
 /////////
 
 // Returns true if the string is mutable
-MC_DLLEXPORT bool MCStringIsMutable(const MCStringRef string);
+bool MCStringIsMutable(const MCStringRef string);
 
 // Returns true if the string is the empty string.
-MC_DLLEXPORT bool MCStringIsEmpty(MCStringRef string);
+bool MCStringIsEmpty(MCStringRef string);
 
 // Returns true if the the string only requires native characters to represent.
-MC_DLLEXPORT bool MCStringCanBeNative(MCStringRef string);
+bool MCStringCanBeNative(MCStringRef string);
 
 // Returns true if under the given comparison conditions, string cannot be represented natively.
-MC_DLLEXPORT bool MCStringCantBeEqualToNative(MCStringRef string, MCStringOptions p_options);
+bool MCStringCantBeEqualToNative(MCStringRef string, MCStringOptions p_options);
 
 
 // Returns true if the string is stored as native chars.
-MC_DLLEXPORT bool MCStringIsNative(MCStringRef string);
+bool MCStringIsNative(MCStringRef string);
 
 // Returns true if the string only requires BMP characters to represent.
-MC_DLLEXPORT bool MCStringIsSimple(MCStringRef string);
+bool MCStringIsSimple(MCStringRef string);
 
 // Returns true if the string only comprises non-combining characters.
-MC_DLLEXPORT bool MCStringIsUncombined(MCStringRef string);
+bool MCStringIsUncombined(MCStringRef string);
 
 /////////
 
@@ -1958,80 +1958,80 @@ MC_DLLEXPORT bool MCStringIsUncombined(MCStringRef string);
 // natively encoded strings are at most the same length as their unicode encoded
 // counterparts (the subtleties being surrogate pairs map to '?', and things
 // like e,acute map to 'e-acute').
-MC_DLLEXPORT uindex_t MCStringGetLength(const MCStringRef string);
+uindex_t MCStringGetLength(const MCStringRef string);
 
 // Return a pointer to the char backing-store if possible. Note that if this
 // method returns nil, then GetChars() must be used to fetch the contents as
 // unicode codeunits.
-MC_DLLEXPORT const unichar_t *MCStringGetCharPtr(MCStringRef string);
+const unichar_t *MCStringGetCharPtr(MCStringRef string);
 
 // Return a pointer to the native char backing-store if possible. Note that if
 // the method returns nil, then GetNativeChars() must be used to fetch the contents
 // in native encoding.
-MC_DLLEXPORT const char_t *MCStringGetNativeCharPtr(MCStringRef string);
+const char_t *MCStringGetNativeCharPtr(MCStringRef string);
 // The native length may be different from the string char count.
-MC_DLLEXPORT const char_t *MCStringGetNativeCharPtrAndLength(MCStringRef self, uindex_t& r_native_length);
+const char_t *MCStringGetNativeCharPtrAndLength(MCStringRef self, uindex_t& r_native_length);
 
 // Returns the Unicode codepoint at the given codepoint index
-MC_DLLEXPORT codepoint_t MCStringGetCodepointAtIndex(MCStringRef string, uindex_t index);
+codepoint_t MCStringGetCodepointAtIndex(MCStringRef string, uindex_t index);
 
 // Returns the char at the given index.
-MC_DLLEXPORT unichar_t MCStringGetCharAtIndex(MCStringRef string, uindex_t index);
+unichar_t MCStringGetCharAtIndex(MCStringRef string, uindex_t index);
 
 // Returns the native char at the given index.
-MC_DLLEXPORT char_t MCStringGetNativeCharAtIndex(MCStringRef string, uindex_t index);
+char_t MCStringGetNativeCharAtIndex(MCStringRef string, uindex_t index);
 
 // Returns the Unicode codepoint (not UTF-16 char) at the given codepoint index
-MC_DLLEXPORT codepoint_t MCStringGetCodepointAtIndex(MCStringRef string, uindex_t index);
+codepoint_t MCStringGetCodepointAtIndex(MCStringRef string, uindex_t index);
 
 // Returns the sequence of chars making up the given range in 'chars' and returns
 // the number of chars generated. If 'chars' is nil, just the number of chars that
 // would be generated is returned.
-MC_DLLEXPORT uindex_t MCStringGetChars(MCStringRef string, MCRange range, unichar_t *chars);
+uindex_t MCStringGetChars(MCStringRef string, MCRange range, unichar_t *chars);
 
 // Returns the sequence of native chars making up the given range in 'chars' and
 // returns the number of chars generated. If 'chars' is nil, just the number of chars
 // that would be generated is returned. Any unmappable chars get generated as '?'.
-MC_DLLEXPORT uindex_t MCStringGetNativeChars(MCStringRef string, MCRange range, char_t *chars);
+uindex_t MCStringGetNativeChars(MCStringRef string, MCRange range, char_t *chars);
 
 // Nativize self
-MC_DLLEXPORT void MCStringNativize(MCStringRef string);
+void MCStringNativize(MCStringRef string);
 
 // Create a native copy of p_string
-MC_DLLEXPORT bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy);
+bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy);
 
 // Maps from a codepoint (character) range to a code unit (StringRef) range
-MC_DLLEXPORT bool MCStringMapCodepointIndices(MCStringRef, MCRange p_codepoint_range, MCRange& r_string_range);
+bool MCStringMapCodepointIndices(MCStringRef, MCRange p_codepoint_range, MCRange& r_string_range);
 
 // Maps from a code unit (StringRef) range to a codepoint (character) range
-MC_DLLEXPORT bool MCStringUnmapCodepointIndices(MCStringRef, MCRange p_string_range, MCRange &r_codepoint_range);
+bool MCStringUnmapCodepointIndices(MCStringRef, MCRange p_string_range, MCRange &r_codepoint_range);
 
 // Maps from a grapheme (visual character) range to a code unit (StringRef) range
-MC_DLLEXPORT bool MCStringMapGraphemeIndices(MCStringRef, MCLocaleRef, MCRange p_grapheme_range, MCRange& r_string_range);
+bool MCStringMapGraphemeIndices(MCStringRef, MCLocaleRef, MCRange p_grapheme_range, MCRange& r_string_range);
 
 // Maps from a code unit (StringRef) range to a grapheme (visual character) range
-MC_DLLEXPORT bool MCStringUnmapGraphemeIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange& r_grapheme_range);
+bool MCStringUnmapGraphemeIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange& r_grapheme_range);
 
 // Maps from a word range to a codeunit (StringRef) range
-MC_DLLEXPORT bool MCStringMapTrueWordIndices(MCStringRef, MCLocaleRef, MCRange p_word_range, MCRange& r_string_range);
+bool MCStringMapTrueWordIndices(MCStringRef, MCLocaleRef, MCRange p_word_range, MCRange& r_string_range);
 
 // Maps from a codeunit (StringRef) range to a word range
-MC_DLLEXPORT bool MCStringUnmapTrueWordIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange &r_word_range);
+bool MCStringUnmapTrueWordIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange &r_word_range);
 
 // Maps from a sentence range to a codeunit (StringRef) range
-MC_DLLEXPORT bool MCStringMapSentenceIndices(MCStringRef, MCLocaleRef, MCRange p_sentence_range, MCRange& r_string_range);
+bool MCStringMapSentenceIndices(MCStringRef, MCLocaleRef, MCRange p_sentence_range, MCRange& r_string_range);
 
 // Maps from a codeunit (StringRef) range to a sentence range
-MC_DLLEXPORT bool MCStringUnmapSentenceIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange &r_sentence_range);
+bool MCStringUnmapSentenceIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange &r_sentence_range);
 
 // Maps from a paragraph range to a codeunit (StringRef) range
-MC_DLLEXPORT bool MCStringMapParagraphIndices(MCStringRef, MCLocaleRef, MCRange p_paragraph_range, MCRange& r_string_range);
+bool MCStringMapParagraphIndices(MCStringRef, MCLocaleRef, MCRange p_paragraph_range, MCRange& r_string_range);
 
 // Maps from a codeunit (StringRef) range to a word range
-MC_DLLEXPORT bool MCStringUnmapParagraphIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange &r_paragraph_range);
+bool MCStringUnmapParagraphIndices(MCStringRef, MCLocaleRef, MCRange p_string_range, MCRange &r_paragraph_range);
 
 // Returns true if the codepoint is alphabetic or numeric.
-MC_DLLEXPORT bool MCStringCodepointIsWordPart(codepoint_t p_codepoint);
+bool MCStringCodepointIsWordPart(codepoint_t p_codepoint);
 
 // Flexible grapheme/codepoint/codeunit mapping used for "char" chunk expressions
 enum MCCharChunkType
@@ -2043,60 +2043,60 @@ enum MCCharChunkType
 
 const MCCharChunkType kMCDefaultCharChunkType = kMCCharChunkTypeGrapheme;
 
-MC_DLLEXPORT bool MCStringMapIndices(MCStringRef, MCCharChunkType, MCRange p_char_range, MCRange &r_codeunit_range);
-MC_DLLEXPORT bool MCStringUnmapIndices(MCStringRef, MCCharChunkType, MCRange p_codeunit_range, MCRange &r_char_range);
+bool MCStringMapIndices(MCStringRef, MCCharChunkType, MCRange p_char_range, MCRange &r_codeunit_range);
+bool MCStringUnmapIndices(MCStringRef, MCCharChunkType, MCRange p_codeunit_range, MCRange &r_char_range);
 
 /////////
 
 // Converts the contents of the string to bytes using the given encoding. The caller
 // takes ownership of the byte array. Note that the returned array is NUL terminated,
 // but this is not reflected in the byte count.
-MC_DLLEXPORT bool MCStringConvertToBytes(MCStringRef string, MCStringEncoding encoding, bool is_external_rep, byte_t*& r_bytes, uindex_t& r_byte_count);
+bool MCStringConvertToBytes(MCStringRef string, MCStringEncoding encoding, bool is_external_rep, byte_t*& r_bytes, uindex_t& r_byte_count);
 
 // [[ Bug 12204 ]] textEncode ASCII support is actually native
 // Converts the contents of the string to ASCII characters - excluding the characters from the extended range
-MC_DLLEXPORT bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char_count);
+bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char_count);
 
 // Converts the contents of the string to unicode. The caller takes ownership of the
 // char array. Note that the returned array is NUL terminated, but this is not
 // reflected in the char count.
-MC_DLLEXPORT bool MCStringConvertToUnicode(MCStringRef string, unichar_t*& r_chars, uindex_t& r_char_count);
+bool MCStringConvertToUnicode(MCStringRef string, unichar_t*& r_chars, uindex_t& r_char_count);
 
 // Converts the contents of the string to native - using '?' as the unmappable char.
 // The caller takes ownership of the char array. Note that the returned array is NUL
 // terminated, but this is not reflected in the char count.
-MC_DLLEXPORT bool MCStringConvertToNative(MCStringRef string, char_t*& r_chars, uindex_t& r_char_count);
+bool MCStringConvertToNative(MCStringRef string, char_t*& r_chars, uindex_t& r_char_count);
 
 // Normalizes and converts to native
-MC_DLLEXPORT bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, uindex_t& r_char_count);
+bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, uindex_t& r_char_count);
 
 // Converts the contents of the string to UTF-8. The caller takes ownership of the
 // char array. Note that the returned array is NUL terminated but this is not
 // reflected in the char count.
-MC_DLLEXPORT bool MCStringConvertToUTF8(MCStringRef string, char*& r_chars, uindex_t& r_char_count);
+bool MCStringConvertToUTF8(MCStringRef string, char*& r_chars, uindex_t& r_char_count);
 
 // Converts the contents of the string to UTF-32.
-MC_DLLEXPORT bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_t &r_char_count);
+bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_t &r_char_count);
 
 // Normalizes and converts to c-string
-MC_DLLEXPORT bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring);
+bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring);
 
 // Converts the content to char_t*
-MC_DLLEXPORT bool MCStringConvertToCString(MCStringRef string, char*& r_cstring);
+bool MCStringConvertToCString(MCStringRef string, char*& r_cstring);
 
 // Converts the content to wchar_t*
-MC_DLLEXPORT bool MCStringConvertToWString(MCStringRef string, unichar_t*& r_wstring);
+bool MCStringConvertToWString(MCStringRef string, unichar_t*& r_wstring);
 
 // Converts the content to unicode_t*
-MC_DLLEXPORT bool MCStringConvertToUTF8String(MCStringRef string, char*& r_utf8string);
+bool MCStringConvertToUTF8String(MCStringRef string, char*& r_utf8string);
 
 #if defined(__MAC__) || defined (__IOS__)
 // Converts the content to CFStringRef
-MC_DLLEXPORT bool MCStringConvertToCFStringRef(MCStringRef string, CFStringRef& r_cfstring);
+bool MCStringConvertToCFStringRef(MCStringRef string, CFStringRef& r_cfstring);
 #endif
 
 #ifdef __WINDOWS__
-MC_DLLEXPORT bool MCStringConvertToBSTR(MCStringRef string, BSTR& r_bstr);
+bool MCStringConvertToBSTR(MCStringRef string, BSTR& r_bstr);
 #endif
 
 // Converts the given string ref to a string in the system encoding.
@@ -2104,95 +2104,95 @@ MC_DLLEXPORT bool MCStringConvertToBSTR(MCStringRef string, BSTR& r_bstr);
 // as an opaque sequence of bytes with an 'unknowable' encoding.
 // Note that the output string is allocated with an implicit NUL byte, but this
 // is not included in the byte_count.
-MC_DLLEXPORT bool MCStringConvertToSysString(MCStringRef string, char*& r_bytes, size_t& r_byte_count);
+bool MCStringConvertToSysString(MCStringRef string, char*& r_bytes, size_t& r_byte_count);
 
 /////////
 
 // Returns the hash of the given string, processing as according to options.
-MC_DLLEXPORT hash_t MCStringHash(MCStringRef string, MCStringOptions options);
+hash_t MCStringHash(MCStringRef string, MCStringOptions options);
 
 // Returns true if the two strings are equal, processing as appropriate according
 // to options.
-MC_DLLEXPORT bool MCStringIsEqualTo(MCStringRef string, MCStringRef other, MCStringOptions options);
-MC_DLLEXPORT bool MCStringIsEqualToNativeChars(MCStringRef string, const char_t *chars, uindex_t char_count, MCStringOptions options);
+bool MCStringIsEqualTo(MCStringRef string, MCStringRef other, MCStringOptions options);
+bool MCStringIsEqualToNativeChars(MCStringRef string, const char_t *chars, uindex_t char_count, MCStringOptions options);
 
 // Returns true if the substring is equal to the other, according to options
-MC_DLLEXPORT bool MCStringSubstringIsEqualTo(MCStringRef string, MCRange range, MCStringRef p_other, MCStringOptions p_options);
-MC_DLLEXPORT bool MCStringSubstringIsEqualToSubstring(MCStringRef string, MCRange range, MCStringRef p_other, MCRange other_range, MCStringOptions p_options);
+bool MCStringSubstringIsEqualTo(MCStringRef string, MCRange range, MCStringRef p_other, MCStringOptions p_options);
+bool MCStringSubstringIsEqualToSubstring(MCStringRef string, MCRange range, MCStringRef p_other, MCRange other_range, MCStringOptions p_options);
 
 // Returns -1, 0, or 1, depending on whether left < 0, left == right or left > 0,
 // processing as appropriate according to options. The ordering used is codepoint-
 // wise lexicographic.
-MC_DLLEXPORT compare_t MCStringCompareTo(MCStringRef string, MCStringRef other, MCStringOptions options);
+compare_t MCStringCompareTo(MCStringRef string, MCStringRef other, MCStringOptions options);
 
 // Returns true if the string begins with the prefix string, processing as
 // appropriate according to options.
-MC_DLLEXPORT bool MCStringBeginsWith(MCStringRef string, MCStringRef prefix, MCStringOptions options);
-MC_DLLEXPORT bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefix, MCStringOptions p_options, uindex_t& r_self_match_length);
-MC_DLLEXPORT bool MCStringBeginsWithCString(MCStringRef string, const char_t *prefix_cstring, MCStringOptions options);
+bool MCStringBeginsWith(MCStringRef string, MCStringRef prefix, MCStringOptions options);
+bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefix, MCStringOptions p_options, uindex_t& r_self_match_length);
+bool MCStringBeginsWithCString(MCStringRef string, const char_t *prefix_cstring, MCStringOptions options);
 
 // Returns true if the string ends with the suffix string, processing as
 // appropriate according to options.
-MC_DLLEXPORT bool MCStringEndsWith(MCStringRef string, MCStringRef suffix, MCStringOptions options);
-MC_DLLEXPORT bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffix, MCStringOptions p_options, uindex_t& r_self_match_length);
-MC_DLLEXPORT bool MCStringEndsWithCString(MCStringRef string, const char_t *suffix_cstring, MCStringOptions options);
+bool MCStringEndsWith(MCStringRef string, MCStringRef suffix, MCStringOptions options);
+bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffix, MCStringOptions p_options, uindex_t& r_self_match_length);
+bool MCStringEndsWithCString(MCStringRef string, const char_t *suffix_cstring, MCStringOptions options);
 
 // Returns true if the string contains the given needle string, processing as
 // appropriate according to options.
-MC_DLLEXPORT bool MCStringContains(MCStringRef string, MCStringRef needle, MCStringOptions options);
+bool MCStringContains(MCStringRef string, MCStringRef needle, MCStringOptions options);
 
 // Returns true if the substring contains the given needle string, processing as
 // appropriate according to options.
-MC_DLLEXPORT bool MCStringSubstringContains(MCStringRef string, MCRange range, MCStringRef needle, MCStringOptions options);
+bool MCStringSubstringContains(MCStringRef string, MCRange range, MCStringRef needle, MCStringOptions options);
 
 //////////
 
 // Find the first offset of needle in string, on or after index 'after',
 // processing as appropriate according to options.
-MC_DLLEXPORT bool MCStringFirstIndexOf(MCStringRef string, MCStringRef needle, uindex_t after, MCStringOptions options, uindex_t& r_offset);
-MC_DLLEXPORT bool MCStringFirstIndexOfStringInRange(MCStringRef string, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset);
+bool MCStringFirstIndexOf(MCStringRef string, MCStringRef needle, uindex_t after, MCStringOptions options, uindex_t& r_offset);
+bool MCStringFirstIndexOfStringInRange(MCStringRef string, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset);
 
 // Find the first offset of needle in string - where needle is a Unicode character
 // (note it is a codepoint, not unichar - i.e. a 20-bit value).
-MC_DLLEXPORT bool MCStringFirstIndexOfChar(MCStringRef string, codepoint_t needle, uindex_t after, MCStringOptions options, uindex_t& r_offset);
+bool MCStringFirstIndexOfChar(MCStringRef string, codepoint_t needle, uindex_t after, MCStringOptions options, uindex_t& r_offset);
 // Find the first offset of needle in given range of string - where needle is a Unicode character
 // (note it is a codepoint, not unichar - i.e. a 20-bit value).
-MC_DLLEXPORT bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset);
+bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset);
 
 // Find the last offset of needle in string, on or before index 'before',
 // processing as appropriate according to options.
-MC_DLLEXPORT bool MCStringLastIndexOf(MCStringRef string, MCStringRef needle, uindex_t before, MCStringOptions options, uindex_t& r_offset);
-MC_DLLEXPORT bool MCStringLastIndexOfStringInRange(MCStringRef string, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset);
+bool MCStringLastIndexOf(MCStringRef string, MCStringRef needle, uindex_t before, MCStringOptions options, uindex_t& r_offset);
+bool MCStringLastIndexOfStringInRange(MCStringRef string, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset);
 
 // Find the last offset of needle in string - where needle is a Unicode character
 // (note it is a codepoint, not unichar - i.e. a 20-bit value).
-MC_DLLEXPORT bool MCStringLastIndexOfChar(MCStringRef string, codepoint_t needle, uindex_t before, MCStringOptions options, uindex_t& r_offset);
+bool MCStringLastIndexOfChar(MCStringRef string, codepoint_t needle, uindex_t before, MCStringOptions options, uindex_t& r_offset);
 
 // Search 'range' of 'string' for 'needle' processing as appropriate to optiosn
 // and returning any located string in 'result'. If the result is false, no range is
 // returned.
-MC_DLLEXPORT bool MCStringFind(MCStringRef string, MCRange range, MCStringRef needle, MCStringOptions options, MCRange* r_result);
+bool MCStringFind(MCStringRef string, MCRange range, MCStringRef needle, MCStringOptions options, MCRange* r_result);
 
 // Search 'range' of 'string' for 'needle' processing as appropriate to options
 // and returning the number of occurances found.
-MC_DLLEXPORT uindex_t MCStringCount(MCStringRef string, MCRange range, MCStringRef needle, MCStringOptions options);
-MC_DLLEXPORT uindex_t MCStringCountChar(MCStringRef string, MCRange range, codepoint_t needle, MCStringOptions options);
+uindex_t MCStringCount(MCStringRef string, MCRange range, MCStringRef needle, MCStringOptions options);
+uindex_t MCStringCountChar(MCStringRef string, MCRange range, codepoint_t needle, MCStringOptions options);
 
 //////////
 
 // Find the first index of separator in string processing as according to
 // options, then split the string into head and tail - the strings either side
 // of the needle.
-MC_DLLEXPORT bool MCStringDivide(MCStringRef string, MCStringRef separator, MCStringOptions options, MCStringRef& r_head, MCStringRef& r_tail);
-MC_DLLEXPORT bool MCStringDivideAtChar(MCStringRef string, codepoint_t separator, MCStringOptions options, MCStringRef& r_head, MCStringRef& r_tail);
-MC_DLLEXPORT bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_head, MCStringRef& r_tail);
+bool MCStringDivide(MCStringRef string, MCStringRef separator, MCStringOptions options, MCStringRef& r_head, MCStringRef& r_tail);
+bool MCStringDivideAtChar(MCStringRef string, codepoint_t separator, MCStringOptions options, MCStringRef& r_head, MCStringRef& r_tail);
+bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_head, MCStringRef& r_tail);
 
 //////////
 
 // Break the string into ranges inbetween the given delimiter char. A trailing
 // empty range is ignored. The caller is responsible for deleting the returned
 // array.
-MC_DLLEXPORT bool MCStringBreakIntoChunks(MCStringRef string, codepoint_t separator, MCStringOptions options, MCRange*& r_ranges, uindex_t& r_range_count);
+bool MCStringBreakIntoChunks(MCStringRef string, codepoint_t separator, MCStringOptions options, MCRange*& r_ranges, uindex_t& r_range_count);
 
 //////////
 
@@ -2200,130 +2200,130 @@ MC_DLLEXPORT bool MCStringBreakIntoChunks(MCStringRef string, codepoint_t separa
 // form of a string is that which is used to perform comparisons.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringFold(MCStringRef string, MCStringOptions options);
+bool MCStringFold(MCStringRef string, MCStringOptions options);
 
 // Lowercase the string.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringLowercase(MCStringRef string, MCLocaleRef p_in_locale);
+bool MCStringLowercase(MCStringRef string, MCLocaleRef p_in_locale);
 
 // Uppercase the string.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringUppercase(MCStringRef string, MCLocaleRef p_in_locale);
+bool MCStringUppercase(MCStringRef string, MCLocaleRef p_in_locale);
 
 /////////
 
 // Append suffix to string.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringAppend(MCStringRef string, MCStringRef suffix);
-MC_DLLEXPORT bool MCStringAppendSubstring(MCStringRef string, MCStringRef suffix, MCRange range);
-MC_DLLEXPORT bool MCStringAppendChars(MCStringRef string, const unichar_t *chars, uindex_t count);
-MC_DLLEXPORT bool MCStringAppendNativeChars(MCStringRef string, const char_t *chars, uindex_t count);
-MC_DLLEXPORT bool MCStringAppendChar(MCStringRef string, unichar_t p_char);
-MC_DLLEXPORT bool MCStringAppendNativeChar(MCStringRef string, char_t p_char);
-MC_DLLEXPORT bool MCStringAppendCodepoint(MCStringRef string, codepoint_t p_codepoint);
+bool MCStringAppend(MCStringRef string, MCStringRef suffix);
+bool MCStringAppendSubstring(MCStringRef string, MCStringRef suffix, MCRange range);
+bool MCStringAppendChars(MCStringRef string, const unichar_t *chars, uindex_t count);
+bool MCStringAppendNativeChars(MCStringRef string, const char_t *chars, uindex_t count);
+bool MCStringAppendChar(MCStringRef string, unichar_t p_char);
+bool MCStringAppendNativeChar(MCStringRef string, char_t p_char);
+bool MCStringAppendCodepoint(MCStringRef string, codepoint_t p_codepoint);
 
 // Prepend prefix to string.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringPrepend(MCStringRef string, MCStringRef prefix);
-MC_DLLEXPORT bool MCStringPrependSubstring(MCStringRef string, MCStringRef suffix, MCRange range);
-MC_DLLEXPORT bool MCStringPrependChars(MCStringRef string, const unichar_t *chars, uindex_t count);
-MC_DLLEXPORT bool MCStringPrependNativeChars(MCStringRef string, const char_t *chars, uindex_t count);
-MC_DLLEXPORT bool MCStringPrependChar(MCStringRef string, unichar_t p_char);
-MC_DLLEXPORT bool MCStringPrependNativeChar(MCStringRef string, char_t p_char);
-MC_DLLEXPORT bool MCStringPrependCodepoint(MCStringRef string, codepoint_t p_codepoint);
+bool MCStringPrepend(MCStringRef string, MCStringRef prefix);
+bool MCStringPrependSubstring(MCStringRef string, MCStringRef suffix, MCRange range);
+bool MCStringPrependChars(MCStringRef string, const unichar_t *chars, uindex_t count);
+bool MCStringPrependNativeChars(MCStringRef string, const char_t *chars, uindex_t count);
+bool MCStringPrependChar(MCStringRef string, unichar_t p_char);
+bool MCStringPrependNativeChar(MCStringRef string, char_t p_char);
+bool MCStringPrependCodepoint(MCStringRef string, codepoint_t p_codepoint);
 
 // Insert new_string into string at offset 'at'.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringInsert(MCStringRef string, uindex_t at, MCStringRef new_string);
-MC_DLLEXPORT bool MCStringInsertSubstring(MCStringRef string, uindex_t at, MCStringRef new_string, MCRange range);
-MC_DLLEXPORT bool MCStringInsertChars(MCStringRef string, uindex_t at, const unichar_t *chars, uindex_t count);
-MC_DLLEXPORT bool MCStringInsertNativeChars(MCStringRef string, uindex_t at, const char_t *chars, uindex_t count);
-MC_DLLEXPORT bool MCStringInsertChar(MCStringRef string, uindex_t at, unichar_t p_char);
-MC_DLLEXPORT bool MCStringInsertNativeChar(MCStringRef string, uindex_t at, char_t p_char);
-MC_DLLEXPORT bool MCStringInsertCodepoint (MCStringRef string, uindex_t p_at, codepoint_t p_codepoint);
+bool MCStringInsert(MCStringRef string, uindex_t at, MCStringRef new_string);
+bool MCStringInsertSubstring(MCStringRef string, uindex_t at, MCStringRef new_string, MCRange range);
+bool MCStringInsertChars(MCStringRef string, uindex_t at, const unichar_t *chars, uindex_t count);
+bool MCStringInsertNativeChars(MCStringRef string, uindex_t at, const char_t *chars, uindex_t count);
+bool MCStringInsertChar(MCStringRef string, uindex_t at, unichar_t p_char);
+bool MCStringInsertNativeChar(MCStringRef string, uindex_t at, char_t p_char);
+bool MCStringInsertCodepoint (MCStringRef string, uindex_t p_at, codepoint_t p_codepoint);
 
 // Remove 'range' characters from 'string'.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringRemove(MCStringRef string, MCRange range);
+bool MCStringRemove(MCStringRef string, MCRange range);
 
 // Retain only 'range' characters from 'string'.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringSubstring(MCStringRef string, MCRange range);
+bool MCStringSubstring(MCStringRef string, MCRange range);
 
 // Replace 'range' characters in 'string' with 'replacement'.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringReplace(MCStringRef string, MCRange range, MCStringRef replacement);
+bool MCStringReplace(MCStringRef string, MCRange range, MCStringRef replacement);
 
 // Pad the end of the string with count copies of value. If value is nil then count
 // uninitialized bytes will be inserted after at.
 //
 // Note that 'string' must be mutable.
-MC_DLLEXPORT bool MCStringPad(MCStringRef string, uindex_t at, uindex_t count, MCStringRef value);
+bool MCStringPad(MCStringRef string, uindex_t at, uindex_t count, MCStringRef value);
 
 // Resolves the directionality of the string and returns true if it is left to right.
 // (Uses MCBidiFirstStrongIsolate to determine directionality).
-MC_DLLEXPORT bool MCStringResolvesLeftToRight(MCStringRef p_string);
+bool MCStringResolvesLeftToRight(MCStringRef p_string);
 
 // Find and replace all instances of pattern in target with replacement.
 //
 // Note that 'string' must be mutable.
-MC_DLLEXPORT bool MCStringFindAndReplace(MCStringRef string, MCStringRef pattern, MCStringRef replacement, MCStringOptions options);
-MC_DLLEXPORT bool MCStringFindAndReplaceChar(MCStringRef string, codepoint_t pattern, codepoint_t replacement, MCStringOptions options);
+bool MCStringFindAndReplace(MCStringRef string, MCStringRef pattern, MCStringRef replacement, MCStringOptions options);
+bool MCStringFindAndReplaceChar(MCStringRef string, codepoint_t pattern, codepoint_t replacement, MCStringOptions options);
 
-MC_DLLEXPORT bool MCStringWildcardMatch(MCStringRef source, MCRange source_range, MCStringRef pattern, MCStringOptions p_options);
+bool MCStringWildcardMatch(MCStringRef source, MCRange source_range, MCStringRef pattern, MCStringOptions p_options);
 
 /////////
 
 // Append a formatted string to another string.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.
-MC_DLLEXPORT bool MCStringAppendFormat(MCStringRef string, const char *format, ...);
-MC_DLLEXPORT bool MCStringAppendFormatV(MCStringRef string, const char *format, va_list args);
+bool MCStringAppendFormat(MCStringRef string, const char *format, ...);
+bool MCStringAppendFormatV(MCStringRef string, const char *format, va_list args);
 
 //////////
 
-MC_DLLEXPORT bool MCStringSplit(MCStringRef string, MCStringRef element_del, MCStringRef key_del, MCStringOptions options, MCArrayRef& r_array);
-MC_DLLEXPORT bool MCStringSplitColumn(MCStringRef string, MCStringRef col_del, MCStringRef row_del, MCStringOptions options, MCArrayRef& r_array);
+bool MCStringSplit(MCStringRef string, MCStringRef element_del, MCStringRef key_del, MCStringOptions options, MCArrayRef& r_array);
+bool MCStringSplitColumn(MCStringRef string, MCStringRef col_del, MCStringRef row_del, MCStringOptions options, MCArrayRef& r_array);
 
 //////////
 
 // Proper list versions of string splitting
-MC_DLLEXPORT bool MCStringSplitByDelimiterNative(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list);
-MC_DLLEXPORT bool MCStringSplitByDelimiter(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list);
+bool MCStringSplitByDelimiterNative(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list);
+bool MCStringSplitByDelimiter(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list);
 
 //////////
 
 // Converts two surrogate pair code units into a codepoint
-MC_DLLEXPORT codepoint_t MCStringSurrogatesToCodepoint(unichar_t p_lead, unichar_t p_trail);
+codepoint_t MCStringSurrogatesToCodepoint(unichar_t p_lead, unichar_t p_trail);
 
 // Converts a codepoint to UTF-16 code units and returns the number of units
-MC_DLLEXPORT unsigned int MCStringCodepointToSurrogates(codepoint_t, unichar_t (&r_units)[2]);
+unsigned int MCStringCodepointToSurrogates(codepoint_t, unichar_t (&r_units)[2]);
 
 // Returns true if the code unit at the given index and the next code unit form
 // a valid surrogate pair. Lone lead or trail code units are not valid pairs.
-MC_DLLEXPORT bool MCStringIsValidSurrogatePair(MCStringRef, uindex_t);
+bool MCStringIsValidSurrogatePair(MCStringRef, uindex_t);
 
 //////////
 
 // Normalises a string into the requested form
-MC_DLLEXPORT bool MCStringNormalizedCopyNFC(MCStringRef, MCStringRef&);
-MC_DLLEXPORT bool MCStringNormalizedCopyNFD(MCStringRef, MCStringRef&);
-MC_DLLEXPORT bool MCStringNormalizedCopyNFKC(MCStringRef, MCStringRef&);
-MC_DLLEXPORT bool MCStringNormalizedCopyNFKD(MCStringRef, MCStringRef&);
+bool MCStringNormalizedCopyNFC(MCStringRef, MCStringRef&);
+bool MCStringNormalizedCopyNFD(MCStringRef, MCStringRef&);
+bool MCStringNormalizedCopyNFKC(MCStringRef, MCStringRef&);
+bool MCStringNormalizedCopyNFKD(MCStringRef, MCStringRef&);
 
 //////////
 
 // Utility to avoid multiple number conversion from a string when possible
-MC_DLLEXPORT bool MCStringSetNumericValue(MCStringRef self, double p_value);
-MC_DLLEXPORT bool MCStringGetNumericValue(MCStringRef self, double &r_value);
+bool MCStringSetNumericValue(MCStringRef self, double p_value);
+bool MCStringGetNumericValue(MCStringRef self, double &r_value);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -2331,68 +2331,68 @@ MC_DLLEXPORT bool MCStringGetNumericValue(MCStringRef self, double &r_value);
 //
 // Immutable data methods
 
-MC_DLLEXPORT extern MCDataRef kMCEmptyData;
+extern MCDataRef kMCEmptyData;
 
-MC_DLLEXPORT bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data);
-MC_DLLEXPORT bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data);
+bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data);
+bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data);
 
-MC_DLLEXPORT bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data);
+bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data);
 
-MC_DLLEXPORT bool MCDataIsEmpty(MCDataRef p_data);
+bool MCDataIsEmpty(MCDataRef p_data);
 
-MC_DLLEXPORT uindex_t MCDataGetLength(MCDataRef p_data);
-MC_DLLEXPORT const byte_t *MCDataGetBytePtr(MCDataRef p_data);
+uindex_t MCDataGetLength(MCDataRef p_data);
+const byte_t *MCDataGetBytePtr(MCDataRef p_data);
 
-MC_DLLEXPORT byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index);
+byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index);
 
-MC_DLLEXPORT hash_t MCDataHash(MCDataRef p_data);
-MC_DLLEXPORT bool MCDataIsEqualTo(MCDataRef p_left, MCDataRef p_right);
+hash_t MCDataHash(MCDataRef p_data);
+bool MCDataIsEqualTo(MCDataRef p_left, MCDataRef p_right);
 
-MC_DLLEXPORT compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right);
+compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right);
 
 // Mutable data methods
 
-MC_DLLEXPORT bool MCDataCreateMutable(uindex_t p_initial_capacity, MCDataRef& r_data);
+bool MCDataCreateMutable(uindex_t p_initial_capacity, MCDataRef& r_data);
 
-MC_DLLEXPORT bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data);
-MC_DLLEXPORT bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data);
-MC_DLLEXPORT bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data);
-MC_DLLEXPORT bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data);
+bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data);
+bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data);
+bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data);
+bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data);
 
-MC_DLLEXPORT bool MCDataCopyRange(MCDataRef data, MCRange range, MCDataRef& r_new_data);
-MC_DLLEXPORT bool MCDataCopyRangeAndRelease(MCDataRef data, MCRange range, MCDataRef& r_new_data);
-MC_DLLEXPORT bool MCDataMutableCopyRange(MCDataRef data, MCRange range, MCDataRef& r_new_data);
-MC_DLLEXPORT bool MCDataMutableCopyRangeAndRelease(MCDataRef data, MCRange range, MCDataRef& r_new_data);
+bool MCDataCopyRange(MCDataRef data, MCRange range, MCDataRef& r_new_data);
+bool MCDataCopyRangeAndRelease(MCDataRef data, MCRange range, MCDataRef& r_new_data);
+bool MCDataMutableCopyRange(MCDataRef data, MCRange range, MCDataRef& r_new_data);
+bool MCDataMutableCopyRangeAndRelease(MCDataRef data, MCRange range, MCDataRef& r_new_data);
 
-MC_DLLEXPORT bool MCDataIsMutable(const MCDataRef p_data);
+bool MCDataIsMutable(const MCDataRef p_data);
 
-MC_DLLEXPORT bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix);
-MC_DLLEXPORT bool MCDataAppendBytes(MCDataRef r_data, const byte_t *p_bytes, uindex_t p_byte_count);
-MC_DLLEXPORT bool MCDataAppendByte(MCDataRef r_data, byte_t p_byte);
+bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix);
+bool MCDataAppendBytes(MCDataRef r_data, const byte_t *p_bytes, uindex_t p_byte_count);
+bool MCDataAppendByte(MCDataRef r_data, byte_t p_byte);
 
-MC_DLLEXPORT bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix);
-MC_DLLEXPORT bool MCDataPrependBytes(MCDataRef r_data, const byte_t *p_bytes, uindex_t p_byte_count);
-MC_DLLEXPORT bool MCDataPrependByte(MCDataRef r_data, byte_t p_byte);
+bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix);
+bool MCDataPrependBytes(MCDataRef r_data, const byte_t *p_bytes, uindex_t p_byte_count);
+bool MCDataPrependByte(MCDataRef r_data, byte_t p_byte);
 
-MC_DLLEXPORT bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data);
-MC_DLLEXPORT bool MCDataInsertBytes(MCDataRef self, uindex_t p_at, const byte_t *p_bytes, uindex_t p_byte_count);
+bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data);
+bool MCDataInsertBytes(MCDataRef self, uindex_t p_at, const byte_t *p_bytes, uindex_t p_byte_count);
 
-MC_DLLEXPORT bool MCDataRemove(MCDataRef r_data, MCRange p_range);
-MC_DLLEXPORT bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data);
-MC_DLLEXPORT bool MCDataReplaceBytes(MCDataRef r_data, MCRange p_range, const byte_t *p_new_data, uindex_t p_byte_count);
+bool MCDataRemove(MCDataRef r_data, MCRange p_range);
+bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data);
+bool MCDataReplaceBytes(MCDataRef r_data, MCRange p_range, const byte_t *p_new_data, uindex_t p_byte_count);
 
-MC_DLLEXPORT bool MCDataPad(MCDataRef data, byte_t byte, uindex_t count);
+bool MCDataPad(MCDataRef data, byte_t byte, uindex_t count);
 
-MC_DLLEXPORT bool MCDataContains(MCDataRef p_data, MCDataRef p_needle);
-MC_DLLEXPORT bool MCDataBeginsWith(MCDataRef p_data, MCDataRef p_needle);
-MC_DLLEXPORT bool MCDataEndsWith(MCDataRef p_data, MCDataRef p_needle);
+bool MCDataContains(MCDataRef p_data, MCDataRef p_needle);
+bool MCDataBeginsWith(MCDataRef p_data, MCDataRef p_needle);
+bool MCDataEndsWith(MCDataRef p_data, MCDataRef p_needle);
 
-MC_DLLEXPORT bool MCDataFirstIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, uindex_t& r_index);
-MC_DLLEXPORT bool MCDataLastIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, uindex_t& r_index);
+bool MCDataFirstIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, uindex_t& r_index);
+bool MCDataLastIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, uindex_t& r_index);
 
 // convert the given data to CFDataRef
 #if defined(__MAC__) || defined (__IOS__)
-MC_DLLEXPORT bool MCDataConvertToCFDataRef(MCDataRef p_data, CFDataRef& r_cfdata);
+bool MCDataConvertToCFDataRef(MCDataRef p_data, CFDataRef& r_cfdata);
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2400,91 +2400,91 @@ MC_DLLEXPORT bool MCDataConvertToCFDataRef(MCDataRef p_data, CFDataRef& r_cfdata
 //  ARRAY DEFINITIONS
 //
 
-MC_DLLEXPORT extern MCArrayRef kMCEmptyArray;
+extern MCArrayRef kMCEmptyArray;
 
 // Create an immutable array containing the given keys and values.
-MC_DLLEXPORT bool MCArrayCreate(bool case_sensitive, const MCNameRef *keys, const MCValueRef *values, uindex_t length, MCArrayRef& r_array);
+bool MCArrayCreate(bool case_sensitive, const MCNameRef *keys, const MCValueRef *values, uindex_t length, MCArrayRef& r_array);
 // Create an immutable array containing the given keys and values with the requested string comparison options.
-MC_DLLEXPORT bool MCArrayCreateWithOptions(bool p_case_sensitive, bool p_form_sensitive, const MCNameRef *keys, const MCValueRef *values, uindex_t length, MCArrayRef& r_array);
+bool MCArrayCreateWithOptions(bool p_case_sensitive, bool p_form_sensitive, const MCNameRef *keys, const MCValueRef *values, uindex_t length, MCArrayRef& r_array);
 
 // Create an empty mutable array.
-MC_DLLEXPORT bool MCArrayCreateMutable(MCArrayRef& r_array);
+bool MCArrayCreateMutable(MCArrayRef& r_array);
 // Create an empty mutable array with the requested string comparison options.
-MC_DLLEXPORT bool MCArrayCreateMutableWithOptions(MCArrayRef& r_array, bool p_case_sensitive, bool p_form_sensitive);
+bool MCArrayCreateMutableWithOptions(MCArrayRef& r_array, bool p_case_sensitive, bool p_form_sensitive);
 
 // Make an immutable copy of the given array. If the 'copy and release' form is
 // used then the original array is released (has its reference count reduced by
 // one).
-MC_DLLEXPORT bool MCArrayCopy(MCArrayRef array, MCArrayRef& r_new_array);
-MC_DLLEXPORT bool MCArrayCopyAndRelease(MCArrayRef array, MCArrayRef& r_new_array);
+bool MCArrayCopy(MCArrayRef array, MCArrayRef& r_new_array);
+bool MCArrayCopyAndRelease(MCArrayRef array, MCArrayRef& r_new_array);
 
 // Make a mutable copy of the given array. If the 'copy and release' form is
 // used then the original array is released (has its reference count reduced by
 // one).
-MC_DLLEXPORT bool MCArrayMutableCopy(MCArrayRef array, MCArrayRef& r_new_array);
-MC_DLLEXPORT bool MCArrayMutableCopyAndRelease(MCArrayRef array, MCArrayRef& r_new_array);
+bool MCArrayMutableCopy(MCArrayRef array, MCArrayRef& r_new_array);
+bool MCArrayMutableCopyAndRelease(MCArrayRef array, MCArrayRef& r_new_array);
 
 // Returns 'true' if the given array is mutable.
-MC_DLLEXPORT bool MCArrayIsMutable(MCArrayRef array);
+bool MCArrayIsMutable(MCArrayRef array);
 
 // Returns the number of elements in the array.
-MC_DLLEXPORT uindex_t MCArrayGetCount(MCArrayRef array);
+uindex_t MCArrayGetCount(MCArrayRef array);
 
 // Returns whether the keys of the array have been predesignated case sensitive or not.
-MC_DLLEXPORT bool MCArrayIsCaseSensitive(MCArrayRef array);
+bool MCArrayIsCaseSensitive(MCArrayRef array);
 // Returns whether the keys of the array have been predesignated form sensitive or not.
-MC_DLLEXPORT bool MCArrayIsFormSensitive(MCArrayRef array);
+bool MCArrayIsFormSensitive(MCArrayRef array);
 
 // Fetch the value from the array with the given key. The returned value is
 // not retained. If being stored elsewhere ValueCopy should be used to make an
 // immutable copy first. If 'false' is returned it means the key was not found
 // (in this case r_value is undefined).
-MC_DLLEXPORT bool MCArrayFetchValue(MCArrayRef array, bool case_sensitive, MCNameRef key, MCValueRef& r_value);
+bool MCArrayFetchValue(MCArrayRef array, bool case_sensitive, MCNameRef key, MCValueRef& r_value);
 // Store the given value into the array. The value is copied appropriately so
 // that the original can still be modified without affecting the copy in the
 // array.
-MC_DLLEXPORT bool MCArrayStoreValue(MCArrayRef array, bool case_sensitive, MCNameRef key, MCValueRef value);
+bool MCArrayStoreValue(MCArrayRef array, bool case_sensitive, MCNameRef key, MCValueRef value);
 // Remove the given key from the array.
-MC_DLLEXPORT bool MCArrayRemoveValue(MCArrayRef array, bool case_sensitive, MCNameRef key);
+bool MCArrayRemoveValue(MCArrayRef array, bool case_sensitive, MCNameRef key);
 
 // Fetches index i in the given (sequence) array.
-MC_DLLEXPORT bool MCArrayFetchValueAtIndex(MCArrayRef array, index_t index, MCValueRef& r_value);
+bool MCArrayFetchValueAtIndex(MCArrayRef array, index_t index, MCValueRef& r_value);
 // Store index i in the given (sequence) array.
-MC_DLLEXPORT bool MCArrayStoreValueAtIndex(MCArrayRef array, index_t index, MCValueRef value);
+bool MCArrayStoreValueAtIndex(MCArrayRef array, index_t index, MCValueRef value);
 // Remove index i from the given (sequence) array.
-MC_DLLEXPORT bool MCArrayRemoveValueAtIndex(MCArrayRef array, index_t index);
+bool MCArrayRemoveValueAtIndex(MCArrayRef array, index_t index);
 
 // Fetch the value from the array on the given path. The returned value is
 // not retained. If being stored elsewhere ValueCopy should be used to make an
 // immutable copy first. If 'false' is returned it means the key was not found
 // (in this case r_value is undefined).
-MC_DLLEXPORT bool MCArrayFetchValueOnPath(MCArrayRef array, bool case_sensitive, const MCNameRef *path, uindex_t path_length, MCValueRef& r_value);
+bool MCArrayFetchValueOnPath(MCArrayRef array, bool case_sensitive, const MCNameRef *path, uindex_t path_length, MCValueRef& r_value);
 // Store the given value into the array on the given path. The value is retained
 // and not copied before being inserted.
-MC_DLLEXPORT bool MCArrayStoreValueOnPath(MCArrayRef array, bool case_sensitive, const MCNameRef *path, uindex_t path_length, MCValueRef value);
+bool MCArrayStoreValueOnPath(MCArrayRef array, bool case_sensitive, const MCNameRef *path, uindex_t path_length, MCValueRef value);
 // Remove the value on the given path in the array.
-MC_DLLEXPORT bool MCArrayRemoveValueOnPath(MCArrayRef array, bool case_sensitive, const MCNameRef *path, uindex_t path_length);
+bool MCArrayRemoveValueOnPath(MCArrayRef array, bool case_sensitive, const MCNameRef *path, uindex_t path_length);
 
 // Apply the callback function to each element of the array. Do not modify the
 // array within the callback as this will cause undefined behavior.
 typedef bool (*MCArrayApplyCallback)(void *context, MCArrayRef array, MCNameRef key, MCValueRef value);
-MC_DLLEXPORT bool MCArrayApply(MCArrayRef array, MCArrayApplyCallback callback, void *context);
+bool MCArrayApply(MCArrayRef array, MCArrayApplyCallback callback, void *context);
 
 // Iterate through the array. 'iterator' should be initialized to zero the first
 // time the method is called, and should then be called until it returns 'false'.
 // A return value of 'false' means no further elements. Do not modify the array
 // inbetween calls to Iterate as this will cause undefined behavior.
-MC_DLLEXPORT bool MCArrayIterate(MCArrayRef array, uintptr_t& iterator, MCNameRef& r_key, MCValueRef& r_value);
+bool MCArrayIterate(MCArrayRef array, uintptr_t& iterator, MCNameRef& r_key, MCValueRef& r_value);
 
 // Returns true if the given array is the empty array.
-MC_DLLEXPORT bool MCArrayIsEmpty(MCArrayRef self);
+bool MCArrayIsEmpty(MCArrayRef self);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  LIST DEFINITIONS
 //
 
-MC_DLLEXPORT extern MCListRef kMCEmptyList;
+extern MCListRef kMCEmptyList;
 
 // Create a list from a static list of values - NOT IMPLEMENTED YET.
 // bool MCListCreate(char delimiter, const MCValueRef *values, uindex_t value_count, MCListRef& r_list);
@@ -2498,31 +2498,31 @@ bool MCListCreateMutable(MCStringRef p_delimiter, MCListRef& r_list);
 extern "C" {
 
 // Eventually this will accept any value type, but for now - just strings, names, and booleans.
-MC_DLLEXPORT bool MCListAppend(MCListRef list, MCValueRef value);
+bool MCListAppend(MCListRef list, MCValueRef value);
 
 // Append a substring to the list.
-MC_DLLEXPORT bool MCListAppendSubstring(MCListRef list, MCStringRef value, MCRange range);
+bool MCListAppendSubstring(MCListRef list, MCStringRef value, MCRange range);
 
 // Append a sequence of native chars as an element.
-MC_DLLEXPORT bool MCListAppendNativeChars(MCListRef list, const char_t *chars, uindex_t char_count);
+bool MCListAppendNativeChars(MCListRef list, const char_t *chars, uindex_t char_count);
 
 // Append a formatted string as an element.
-MC_DLLEXPORT bool MCListAppendFormat(MCListRef list, const char *format, ...);
+bool MCListAppendFormat(MCListRef list, const char *format, ...);
 
 // Make an immutable copy of the list.
-MC_DLLEXPORT bool MCListCopy(MCListRef list, MCListRef& r_new_list);
+bool MCListCopy(MCListRef list, MCListRef& r_new_list);
 
 // Makes an immutable copy of the list and release the list
-MC_DLLEXPORT bool MCListCopyAndRelease(MCListRef list, MCListRef& r_new_list);
+bool MCListCopyAndRelease(MCListRef list, MCListRef& r_new_list);
 
 // Make a copy of the list as a string.
-MC_DLLEXPORT bool MCListCopyAsString(MCListRef list, MCStringRef& r_string);
+bool MCListCopyAsString(MCListRef list, MCStringRef& r_string);
 
 // Make an copy of the list as a string and release the list.
-MC_DLLEXPORT bool MCListCopyAsStringAndRelease(MCListRef list, MCStringRef& r_string);
+bool MCListCopyAsStringAndRelease(MCListRef list, MCStringRef& r_string);
 
 // Returns true if nothing has been added to the list
-MC_DLLEXPORT bool MCListIsEmpty(MCListRef list);
+bool MCListIsEmpty(MCListRef list);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -2531,68 +2531,68 @@ MC_DLLEXPORT bool MCListIsEmpty(MCListRef list);
 
 extern MCSetRef kMCEmptySet;
 
-MC_DLLEXPORT bool MCSetCreateSingleton(uindex_t element, MCSetRef& r_set);
-MC_DLLEXPORT bool MCSetCreateWithIndices(uindex_t *elements, uindex_t element_count, MCSetRef& r_set);
-MC_DLLEXPORT bool MCSetCreateWithLimbsAndRelease(uindex_t *limbs, uindex_t limb_count, MCSetRef& r_set);
+bool MCSetCreateSingleton(uindex_t element, MCSetRef& r_set);
+bool MCSetCreateWithIndices(uindex_t *elements, uindex_t element_count, MCSetRef& r_set);
+bool MCSetCreateWithLimbsAndRelease(uindex_t *limbs, uindex_t limb_count, MCSetRef& r_set);
 
-MC_DLLEXPORT bool MCSetCreateMutable(MCSetRef& r_set);
+bool MCSetCreateMutable(MCSetRef& r_set);
 
-MC_DLLEXPORT bool MCSetCopy(MCSetRef set, MCSetRef& r_new_set);
-MC_DLLEXPORT bool MCSetCopyAndRelease(MCSetRef set, MCSetRef& r_new_set);
+bool MCSetCopy(MCSetRef set, MCSetRef& r_new_set);
+bool MCSetCopyAndRelease(MCSetRef set, MCSetRef& r_new_set);
 
-MC_DLLEXPORT bool MCSetMutableCopy(MCSetRef set, MCSetRef& r_new_set);
-MC_DLLEXPORT bool MCSetMutableCopyAndRelease(MCSetRef set, MCSetRef& r_new_set);
+bool MCSetMutableCopy(MCSetRef set, MCSetRef& r_new_set);
+bool MCSetMutableCopyAndRelease(MCSetRef set, MCSetRef& r_new_set);
 
-MC_DLLEXPORT bool MCSetIsMutable(MCSetRef self);
+bool MCSetIsMutable(MCSetRef self);
 
-MC_DLLEXPORT bool MCSetIsEmpty(MCSetRef set);
-MC_DLLEXPORT bool MCSetIsEqualTo(MCSetRef set, MCSetRef other_set);
+bool MCSetIsEmpty(MCSetRef set);
+bool MCSetIsEqualTo(MCSetRef set, MCSetRef other_set);
 
-MC_DLLEXPORT bool MCSetContains(MCSetRef set, MCSetRef other_set);
-MC_DLLEXPORT bool MCSetIntersects(MCSetRef set, MCSetRef other_set);
+bool MCSetContains(MCSetRef set, MCSetRef other_set);
+bool MCSetIntersects(MCSetRef set, MCSetRef other_set);
 
-MC_DLLEXPORT bool MCSetContainsIndex(MCSetRef set, uindex_t index);
+bool MCSetContainsIndex(MCSetRef set, uindex_t index);
 
-MC_DLLEXPORT bool MCSetIncludeIndex(MCSetRef set, uindex_t index);
-MC_DLLEXPORT bool MCSetExcludeIndex(MCSetRef set, uindex_t index);
+bool MCSetIncludeIndex(MCSetRef set, uindex_t index);
+bool MCSetExcludeIndex(MCSetRef set, uindex_t index);
 
-MC_DLLEXPORT bool MCSetUnion(MCSetRef set, MCSetRef other_set);
-MC_DLLEXPORT bool MCSetDifference(MCSetRef set, MCSetRef other_set);
-MC_DLLEXPORT bool MCSetIntersect(MCSetRef set, MCSetRef other_set);
+bool MCSetUnion(MCSetRef set, MCSetRef other_set);
+bool MCSetDifference(MCSetRef set, MCSetRef other_set);
+bool MCSetIntersect(MCSetRef set, MCSetRef other_set);
 
-MC_DLLEXPORT bool MCSetIterate(MCSetRef set, uindex_t& x_iterator, uindex_t& r_element);
-MC_DLLEXPORT bool MCSetList(MCSetRef set, uindex_t*& r_element, uindex_t& r_element_count);
+bool MCSetIterate(MCSetRef set, uindex_t& x_iterator, uindex_t& r_element);
+bool MCSetList(MCSetRef set, uindex_t*& r_element, uindex_t& r_element_count);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  RECORD DEFINITIONS
 //
 
-MC_DLLEXPORT bool MCRecordCreate(MCTypeInfoRef typeinfo, const MCValueRef *values, uindex_t value_count, MCRecordRef& r_record);
+bool MCRecordCreate(MCTypeInfoRef typeinfo, const MCValueRef *values, uindex_t value_count, MCRecordRef& r_record);
 
-MC_DLLEXPORT bool MCRecordCreateMutable(MCTypeInfoRef p_typeinfo, MCRecordRef& r_record);
+bool MCRecordCreateMutable(MCTypeInfoRef p_typeinfo, MCRecordRef& r_record);
 
-MC_DLLEXPORT bool MCRecordCopy(MCRecordRef record, MCRecordRef& r_new_record);
-MC_DLLEXPORT bool MCRecordCopyAndRelease(MCRecordRef record, MCRecordRef& r_new_record);
+bool MCRecordCopy(MCRecordRef record, MCRecordRef& r_new_record);
+bool MCRecordCopyAndRelease(MCRecordRef record, MCRecordRef& r_new_record);
 
-MC_DLLEXPORT bool MCRecordMutableCopy(MCRecordRef record, MCRecordRef& r_new_record);
-MC_DLLEXPORT bool MCRecordMutableCopyAndRelease(MCRecordRef record, MCRecordRef& r_new_record);
+bool MCRecordMutableCopy(MCRecordRef record, MCRecordRef& r_new_record);
+bool MCRecordMutableCopyAndRelease(MCRecordRef record, MCRecordRef& r_new_record);
 
-MC_DLLEXPORT bool MCRecordCopyAsBaseType(MCRecordRef record, MCTypeInfoRef p_base_typeinfo, MCRecordRef & r_new_record);
-MC_DLLEXPORT bool MCRecordCopyAsBaseTypeAndRelease(MCRecordRef record, MCTypeInfoRef p_base_typeinfo, MCRecordRef & r_new_record);
+bool MCRecordCopyAsBaseType(MCRecordRef record, MCTypeInfoRef p_base_typeinfo, MCRecordRef & r_new_record);
+bool MCRecordCopyAsBaseTypeAndRelease(MCRecordRef record, MCTypeInfoRef p_base_typeinfo, MCRecordRef & r_new_record);
 
-MC_DLLEXPORT bool MCRecordCopyAsDerivedType(MCRecordRef record, MCTypeInfoRef p_derived_typeinfo, MCRecordRef & r_new_record);
-MC_DLLEXPORT bool MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef record, MCTypeInfoRef p_derived_typeinfo, MCRecordRef & r_new_record);
+bool MCRecordCopyAsDerivedType(MCRecordRef record, MCTypeInfoRef p_derived_typeinfo, MCRecordRef & r_new_record);
+bool MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef record, MCTypeInfoRef p_derived_typeinfo, MCRecordRef & r_new_record);
 
-MC_DLLEXPORT bool MCRecordIsMutable(MCRecordRef self);
+bool MCRecordIsMutable(MCRecordRef self);
 
-MC_DLLEXPORT bool MCRecordFetchValue(MCRecordRef record, MCNameRef field, MCValueRef& r_value);
-MC_DLLEXPORT bool MCRecordStoreValue(MCRecordRef record, MCNameRef field, MCValueRef value);
+bool MCRecordFetchValue(MCRecordRef record, MCNameRef field, MCValueRef& r_value);
+bool MCRecordStoreValue(MCRecordRef record, MCNameRef field, MCValueRef value);
 
-MC_DLLEXPORT bool MCRecordEncodeAsArray(MCRecordRef record, MCArrayRef & r_array);
-MC_DLLEXPORT bool MCRecordDecodeFromArray(MCArrayRef array, MCTypeInfoRef p_typeinfo, MCRecordRef & r_record);
+bool MCRecordEncodeAsArray(MCRecordRef record, MCArrayRef & r_array);
+bool MCRecordDecodeFromArray(MCArrayRef array, MCTypeInfoRef p_typeinfo, MCRecordRef & r_record);
 
-MC_DLLEXPORT bool MCRecordIterate(MCRecordRef record, uintptr_t& x_iterator, MCNameRef& r_field, MCValueRef& r_value);
+bool MCRecordIterate(MCRecordRef record, uintptr_t& x_iterator, MCNameRef& r_field, MCValueRef& r_value);
     
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -2607,77 +2607,77 @@ struct MCHandlerCallbacks
 	bool (*describe)(void *context, MCStringRef& r_desc);
 };
 
-MC_DLLEXPORT bool MCHandlerCreate(MCTypeInfoRef typeinfo, const MCHandlerCallbacks *callbacks, void *context, MCHandlerRef& r_handler);
+bool MCHandlerCreate(MCTypeInfoRef typeinfo, const MCHandlerCallbacks *callbacks, void *context, MCHandlerRef& r_handler);
 
-MC_DLLEXPORT void *MCHandlerGetContext(MCHandlerRef handler);
-MC_DLLEXPORT const MCHandlerCallbacks *MCHandlerGetCallbacks(MCHandlerRef handler);
+void *MCHandlerGetContext(MCHandlerRef handler);
+const MCHandlerCallbacks *MCHandlerGetCallbacks(MCHandlerRef handler);
     
-MC_DLLEXPORT bool MCHandlerInvoke(MCHandlerRef handler, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
-MC_DLLEXPORT /*copy*/ MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef handler, MCProperListRef& x_arguments, MCValueRef& r_value);
+bool MCHandlerInvoke(MCHandlerRef handler, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
+/*copy*/ MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef handler, MCProperListRef& x_arguments, MCValueRef& r_value);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  ERROR DEFINITIONS
 //
 
-MC_DLLEXPORT extern MCTypeInfoRef kMCOutOfMemoryErrorTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCGenericErrorTypeInfo;
+extern MCTypeInfoRef kMCOutOfMemoryErrorTypeInfo;
+extern MCTypeInfoRef kMCGenericErrorTypeInfo;
 
-MC_DLLEXPORT bool MCErrorCreate(MCTypeInfoRef typeinfo, MCArrayRef info, MCErrorRef& r_error);
+bool MCErrorCreate(MCTypeInfoRef typeinfo, MCArrayRef info, MCErrorRef& r_error);
 
-MC_DLLEXPORT bool MCErrorCreateWithMessage(MCTypeInfoRef typeinfo, MCStringRef message, MCArrayRef info, MCErrorRef & r_error);
+bool MCErrorCreateWithMessage(MCTypeInfoRef typeinfo, MCStringRef message, MCArrayRef info, MCErrorRef & r_error);
 
-MC_DLLEXPORT bool MCErrorUnwind(MCErrorRef error, MCValueRef target, uindex_t row, uindex_t column);
+bool MCErrorUnwind(MCErrorRef error, MCValueRef target, uindex_t row, uindex_t column);
 
-MC_DLLEXPORT MCNameRef MCErrorGetDomain(MCErrorRef error);
-MC_DLLEXPORT MCArrayRef MCErrorGetInfo(MCErrorRef error);
-MC_DLLEXPORT MCStringRef MCErrorGetMessage(MCErrorRef error);
+MCNameRef MCErrorGetDomain(MCErrorRef error);
+MCArrayRef MCErrorGetInfo(MCErrorRef error);
+MCStringRef MCErrorGetMessage(MCErrorRef error);
 
-MC_DLLEXPORT uindex_t MCErrorGetDepth(MCErrorRef error);
-MC_DLLEXPORT MCValueRef MCErrorGetTargetAtLevel(MCErrorRef error, uindex_t level);
-MC_DLLEXPORT uindex_t MCErrorGetRowAtLevel(MCErrorRef error, uindex_t row);
-MC_DLLEXPORT uindex_t MCErrorGetColumnAtLevel(MCErrorRef error, uindex_t column);
+uindex_t MCErrorGetDepth(MCErrorRef error);
+MCValueRef MCErrorGetTargetAtLevel(MCErrorRef error, uindex_t level);
+uindex_t MCErrorGetRowAtLevel(MCErrorRef error, uindex_t row);
+uindex_t MCErrorGetColumnAtLevel(MCErrorRef error, uindex_t column);
 
 // Create and throw an error. The arguments are used to build the info dictionary.
 // They should be a sequence of pairs (const char *key, MCValueRef value), and finish
 // with nil.
-MC_DLLEXPORT bool MCErrorCreateAndThrow(MCTypeInfoRef typeinfo, ...);
+bool MCErrorCreateAndThrow(MCTypeInfoRef typeinfo, ...);
 
-MC_DLLEXPORT bool MCErrorCreateAndThrowWithMessage(MCTypeInfoRef typeinfo, MCStringRef message_format, ...);
+bool MCErrorCreateAndThrowWithMessage(MCTypeInfoRef typeinfo, MCStringRef message_format, ...);
     
 // Throw the given error code (local to the current thread).
-MC_DLLEXPORT bool MCErrorThrow(MCErrorRef error);
+bool MCErrorThrow(MCErrorRef error);
 
 // Catch the current error code (on the current thread) if any and clear it.
-MC_DLLEXPORT bool MCErrorCatch(MCErrorRef& r_error);
+bool MCErrorCatch(MCErrorRef& r_error);
 
 // Returns true if there is an error pending on the current thread.
-MC_DLLEXPORT bool MCErrorIsPending(void);
+bool MCErrorIsPending(void);
 
 // Returns any pending error (on the current thread) without clearing it.
-MC_DLLEXPORT MCErrorRef MCErrorPeek(void);
+MCErrorRef MCErrorPeek(void);
 
 // Throw an out of memory error.
-MC_DLLEXPORT bool MCErrorThrowOutOfMemory(void);
+bool MCErrorThrowOutOfMemory(void);
 
 // Throw a generic runtime error (one that hasn't had a class made for it yet).
 // The message argument is optional (nil if no message).
-MC_DLLEXPORT bool MCErrorThrowGeneric(MCStringRef message);
+bool MCErrorThrowGeneric(MCStringRef message);
     
 // Throw a generic runtime error with formatted message.
-MC_DLLEXPORT bool MCErrorThrowGenericWithMessage(MCStringRef message, ...);
+bool MCErrorThrowGenericWithMessage(MCStringRef message, ...);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  FOREIGN DEFINITIONS
 //
 
-MC_DLLEXPORT bool MCForeignValueCreate(MCTypeInfoRef typeinfo, void *contents, MCForeignValueRef& r_value);
-MC_DLLEXPORT bool MCForeignValueCreateAndRelease(MCTypeInfoRef typeinfo, void *contents, MCForeignValueRef& r_value);
+bool MCForeignValueCreate(MCTypeInfoRef typeinfo, void *contents, MCForeignValueRef& r_value);
+bool MCForeignValueCreateAndRelease(MCTypeInfoRef typeinfo, void *contents, MCForeignValueRef& r_value);
 
-MC_DLLEXPORT void *MCForeignValueGetContentsPtr(MCValueRef value);
+void *MCForeignValueGetContentsPtr(MCValueRef value);
 
-MC_DLLEXPORT bool MCForeignValueExport(MCTypeInfoRef typeinfo, MCValueRef value, MCForeignValueRef& r_value);
+bool MCForeignValueExport(MCTypeInfoRef typeinfo, MCValueRef value, MCForeignValueRef& r_value);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -2727,11 +2727,11 @@ enum
 
 // Create a stream running using the giving callbacks. Note that the lifetime
 // of 'callbacks' must exceed that of the stream.
-MC_DLLEXPORT bool MCStreamCreate(const MCStreamCallbacks *callbacks, size_t extra_bytes, MCStreamRef& r_stream);
+bool MCStreamCreate(const MCStreamCallbacks *callbacks, size_t extra_bytes, MCStreamRef& r_stream);
 
 // Fetch the callback pointer attached to the stream - this can be used for type-
 // checking.
-MC_DLLEXPORT const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef stream);
+const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef stream);
 
 // Fetch the start of the 'extra bytes' for the stream.
 MC_DLLEXPORT inline void *MCStreamGetExtraBytesPtr(MCStreamRef stream) { return ((uint8_t *)MCValueGetExtraBytesPtr(stream)) + kMCStreamHeaderSize; }
@@ -2740,117 +2740,117 @@ MC_DLLEXPORT inline void *MCStreamGetExtraBytesPtr(MCStreamRef stream) { return 
 
 // Create a read-only stream targetting a memory block. The lifetime of the
 // memory block must exceed that of the stream.
-MC_DLLEXPORT bool MCMemoryInputStreamCreate(const void *block, size_t size, MCStreamRef& r_stream);
+bool MCMemoryInputStreamCreate(const void *block, size_t size, MCStreamRef& r_stream);
 
 // Memory-based output stream
 
 // Create a write-only stream that outputs to memory.
-MC_DLLEXPORT bool MCMemoryOutputStreamCreate(MCStreamRef& r_stream);
+bool MCMemoryOutputStreamCreate(MCStreamRef& r_stream);
 // Finish the memory output and return the buffer. The stream will continue
 // to work, but will be reset to empty and a new buffer accumulated.
-MC_DLLEXPORT bool MCMemoryOutputStreamFinish(MCStreamRef stream, void*& r_buffer, size_t& r_size);
+bool MCMemoryOutputStreamFinish(MCStreamRef stream, void*& r_buffer, size_t& r_size);
 
 // Capabilities
 
 // If a stream is readable it means that the 'Read' method work.
-MC_DLLEXPORT bool MCStreamIsReadable(MCStreamRef stream);
+bool MCStreamIsReadable(MCStreamRef stream);
 // If a stream is writable it means that the 'Write' method works.
-MC_DLLEXPORT bool MCStreamIsWritable(MCStreamRef stream);
+bool MCStreamIsWritable(MCStreamRef stream);
 // If a stream is markable it means that the stream supports the 'Mark' and
 // 'Reset' methods.
-MC_DLLEXPORT bool MCStreamIsMarkable(MCStreamRef stream);
+bool MCStreamIsMarkable(MCStreamRef stream);
 // If a stream is seekable it means that the stream supports the 'Tell' and
 // 'Seek' methods.
-MC_DLLEXPORT bool MCStreamIsSeekable(MCStreamRef stream);
+bool MCStreamIsSeekable(MCStreamRef stream);
 
 // Readable streams
 
 // Returns the number of bytes available on the stream without blocking (or
 // hitting eof).
-MC_DLLEXPORT bool MCStreamGetAvailableForRead(MCStreamRef stream, size_t& r_available);
+bool MCStreamGetAvailableForRead(MCStreamRef stream, size_t& r_available);
 // Attempt to read 'amount' bytes into the given buffer.
-MC_DLLEXPORT bool MCStreamRead(MCStreamRef stream, void *buffer, size_t amount);
+bool MCStreamRead(MCStreamRef stream, void *buffer, size_t amount);
 
 // Returns the number of bytes space available on the stream for writing
 // without blocking.
-MC_DLLEXPORT bool MCStreamGetAvailableForWrite(MCStreamRef stream, size_t& r_available);
+bool MCStreamGetAvailableForWrite(MCStreamRef stream, size_t& r_available);
 // Attempt to write 'amount' bytes to the output stream.
-MC_DLLEXPORT bool MCStreamWrite(MCStreamRef stream, const void *buffer, size_t amount);
+bool MCStreamWrite(MCStreamRef stream, const void *buffer, size_t amount);
 
 // Readable and writable streams.
 
 // If reading or writing a single byte would result in failure due to end of
 // file, 'finished' will contain true.
-MC_DLLEXPORT bool MCStreamIsFinished(MCStreamRef stream, bool& r_finished);
+bool MCStreamIsFinished(MCStreamRef stream, bool& r_finished);
 
 // Attempt to skip 'amount' bytes. This call only succeeds if the stream pointer
 // is 'amount' bytes away from eod.
-MC_DLLEXPORT bool MCStreamSkip(MCStreamRef stream, size_t amount);
+bool MCStreamSkip(MCStreamRef stream, size_t amount);
 
 // Markable streams only
 
 // Record the current location in the stream. If the stream head moves no further
 // than 'read_limit' bytes forward, then the 'Reset' method will allow a return to
 // the mark.
-MC_DLLEXPORT bool MCStreamMark(MCStreamRef stream, size_t read_limit);
+bool MCStreamMark(MCStreamRef stream, size_t read_limit);
 // Reset the stream to the last recorded mark.
-MC_DLLEXPORT bool MCStreamReset(MCStreamRef stream);
+bool MCStreamReset(MCStreamRef stream);
 
 // Seekable streams only
 
 // Fetch the current stream position.
-MC_DLLEXPORT bool MCStreamTell(MCStreamRef stream, filepos_t& r_position);
+bool MCStreamTell(MCStreamRef stream, filepos_t& r_position);
 // Set the current stream position.
-MC_DLLEXPORT bool MCStreamSeek(MCStreamRef stream, filepos_t position);
+bool MCStreamSeek(MCStreamRef stream, filepos_t position);
 
 // Simple byte-based serialization / unserialization functions. These are all
 // wrappers around read/write, and assume no higher-level structure.
 
 // Fixed-size unsigned and signed integer functions.
-MC_DLLEXPORT bool MCStreamReadUInt8(MCStreamRef stream, uint8_t& r_value);
-MC_DLLEXPORT bool MCStreamReadUInt16(MCStreamRef stream, uint16_t& r_value);
-MC_DLLEXPORT bool MCStreamReadUInt32(MCStreamRef stream, uint32_t& r_value);
-MC_DLLEXPORT bool MCStreamReadUInt64(MCStreamRef stream, uint64_t& r_value);
-MC_DLLEXPORT bool MCStreamReadInt8(MCStreamRef stream, int8_t& r_value);
-MC_DLLEXPORT bool MCStreamReadInt16(MCStreamRef stream, int16_t& r_value);
-MC_DLLEXPORT bool MCStreamReadInt32(MCStreamRef stream, int32_t& r_value);
-MC_DLLEXPORT bool MCStreamReadInt64(MCStreamRef stream, int64_t& r_value);
+bool MCStreamReadUInt8(MCStreamRef stream, uint8_t& r_value);
+bool MCStreamReadUInt16(MCStreamRef stream, uint16_t& r_value);
+bool MCStreamReadUInt32(MCStreamRef stream, uint32_t& r_value);
+bool MCStreamReadUInt64(MCStreamRef stream, uint64_t& r_value);
+bool MCStreamReadInt8(MCStreamRef stream, int8_t& r_value);
+bool MCStreamReadInt16(MCStreamRef stream, int16_t& r_value);
+bool MCStreamReadInt32(MCStreamRef stream, int32_t& r_value);
+bool MCStreamReadInt64(MCStreamRef stream, int64_t& r_value);
 
-MC_DLLEXPORT bool MCStreamWriteUInt8(MCStreamRef stream, uint8_t value);
-MC_DLLEXPORT bool MCStreamWriteUInt16(MCStreamRef stream, uint16_t value);
-MC_DLLEXPORT bool MCStreamWriteUInt32(MCStreamRef stream, uint32_t value);
-MC_DLLEXPORT bool MCStreamWriteUInt64(MCStreamRef stream, uint64_t value);
-MC_DLLEXPORT bool MCStreamWriteInt8(MCStreamRef stream, int8_t value);
-MC_DLLEXPORT bool MCStreamWriteInt16(MCStreamRef stream, int16_t value);
-MC_DLLEXPORT bool MCStreamWriteInt32(MCStreamRef stream, int32_t value);
-MC_DLLEXPORT bool MCStreamWriteInt64(MCStreamRef stream, int64_t value);
+bool MCStreamWriteUInt8(MCStreamRef stream, uint8_t value);
+bool MCStreamWriteUInt16(MCStreamRef stream, uint16_t value);
+bool MCStreamWriteUInt32(MCStreamRef stream, uint32_t value);
+bool MCStreamWriteUInt64(MCStreamRef stream, uint64_t value);
+bool MCStreamWriteInt8(MCStreamRef stream, int8_t value);
+bool MCStreamWriteInt16(MCStreamRef stream, int16_t value);
+bool MCStreamWriteInt32(MCStreamRef stream, int32_t value);
+bool MCStreamWriteInt64(MCStreamRef stream, int64_t value);
 
 // Variable-sized unsigned and signing integer functions. These methods use
 // the top-bit of successive bytes to indicate whether more bytes follow - each
 // byte encodes 7 bits of information.
-MC_DLLEXPORT bool MCStreamReadCompactUInt32(MCStreamRef stream, uint32_t& r_value);
-MC_DLLEXPORT bool MCStreamReadCompactUInt64(MCStreamRef stream, uint64_t& r_value);
-MC_DLLEXPORT bool MCStreamReadCompactSInt32(MCStreamRef stream, uint32_t& r_value);
-MC_DLLEXPORT bool MCStreamReadCompactSInt64(MCStreamRef stream, uint64_t& r_value);
+bool MCStreamReadCompactUInt32(MCStreamRef stream, uint32_t& r_value);
+bool MCStreamReadCompactUInt64(MCStreamRef stream, uint64_t& r_value);
+bool MCStreamReadCompactSInt32(MCStreamRef stream, uint32_t& r_value);
+bool MCStreamReadCompactSInt64(MCStreamRef stream, uint64_t& r_value);
 
 // Fixed-size binary-floating point functions.
-MC_DLLEXPORT bool MCStreamReadFloat(MCStreamRef stream, float& r_value);
-MC_DLLEXPORT bool MCStreamReadDouble(MCStreamRef stream, double& r_value);
+bool MCStreamReadFloat(MCStreamRef stream, float& r_value);
+bool MCStreamReadDouble(MCStreamRef stream, double& r_value);
 
-MC_DLLEXPORT bool MCStreamWriteFloat(MCStreamRef stream, float value);
-MC_DLLEXPORT bool MCStreamWriteDouble(MCStreamRef stream, double value);
+bool MCStreamWriteFloat(MCStreamRef stream, float value);
+bool MCStreamWriteDouble(MCStreamRef stream, double value);
 
 // Known valueref functions - these assume the given type is present.
-MC_DLLEXPORT bool MCStreamReadBoolean(MCStreamRef stream, MCBooleanRef& r_boolean);
-MC_DLLEXPORT bool MCStreamReadNumber(MCStreamRef stream, MCNumberRef& r_number);
-MC_DLLEXPORT bool MCStreamReadName(MCStreamRef stream, MCNameRef& r_name);
-MC_DLLEXPORT bool MCStreamReadString(MCStreamRef stream, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStreamReadArray(MCStreamRef stream, MCArrayRef& r_array);
-MC_DLLEXPORT bool MCStreamReadSet(MCStreamRef stream, MCSetRef& r_set);
+bool MCStreamReadBoolean(MCStreamRef stream, MCBooleanRef& r_boolean);
+bool MCStreamReadNumber(MCStreamRef stream, MCNumberRef& r_number);
+bool MCStreamReadName(MCStreamRef stream, MCNameRef& r_name);
+bool MCStreamReadString(MCStreamRef stream, MCStringRef& r_string);
+bool MCStreamReadArray(MCStreamRef stream, MCArrayRef& r_array);
+bool MCStreamReadSet(MCStreamRef stream, MCSetRef& r_set);
 
 // Variant valueref functions - these tag the data with the type, allowing
 // easy encoding/decoding of any value type (that supports serialization).
-MC_DLLEXPORT bool MCStreamReadValue(MCStreamRef stream, MCValueRef& r_value);
+bool MCStreamReadValue(MCStreamRef stream, MCValueRef& r_value);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -2875,13 +2875,13 @@ enum
 
 /////////
 
-MC_DLLEXPORT extern MCProperListRef kMCEmptyProperList;
+extern MCProperListRef kMCEmptyProperList;
 
 // Create an immutable list containing the given values.
-MC_DLLEXPORT bool MCProperListCreate(const MCValueRef *values, uindex_t length, MCProperListRef& r_list);
+bool MCProperListCreate(const MCValueRef *values, uindex_t length, MCProperListRef& r_list);
 
 // Create an empty mutable list.
-MC_DLLEXPORT bool MCProperListCreateMutable(MCProperListRef& r_list);
+bool MCProperListCreateMutable(MCProperListRef& r_list);
 
 // Create an immutable list taking ownership of the given array of
 // values.  Takes ownership of both the underlying MCValueRef
@@ -2891,87 +2891,87 @@ bool MCProperListCreateAndRelease(MCValueRef *p_values, uindex_t p_length, MCPro
 // Make an immutable copy of the given list. If the 'copy and release' form is
 // used then the original list is released (has its reference count reduced by
 // one).
-MC_DLLEXPORT bool MCProperListCopy(MCProperListRef list, MCProperListRef& r_new_list);
-MC_DLLEXPORT bool MCProperListCopyAndRelease(MCProperListRef list, MCProperListRef& r_new_list);
+bool MCProperListCopy(MCProperListRef list, MCProperListRef& r_new_list);
+bool MCProperListCopyAndRelease(MCProperListRef list, MCProperListRef& r_new_list);
 
 // Make a mutable copy of the given list. If the 'copy and release' form is
 // used then the original list is released (has its reference count reduced by
 // one).
-MC_DLLEXPORT bool MCProperListMutableCopy(MCProperListRef list, MCProperListRef& r_new_list);
-MC_DLLEXPORT bool MCProperListMutableCopyAndRelease(MCProperListRef list, MCProperListRef& r_new_list);
+bool MCProperListMutableCopy(MCProperListRef list, MCProperListRef& r_new_list);
+bool MCProperListMutableCopyAndRelease(MCProperListRef list, MCProperListRef& r_new_list);
 
 // Returns 'true' if the given list is mutable.
-MC_DLLEXPORT bool MCProperListIsMutable(MCProperListRef list);
+bool MCProperListIsMutable(MCProperListRef list);
 
 // Returns the number of elements in the list.
 uindex_t MCProperListGetLength(MCProperListRef list);
 
 // Returns true if the given list is the empty list.
-MC_DLLEXPORT bool MCProperListIsEmpty(MCProperListRef list);
+bool MCProperListIsEmpty(MCProperListRef list);
 
 // Iterate over the elements in the list.
-MC_DLLEXPORT bool MCProperListIterate(MCProperListRef list, uintptr_t& x_iterator, MCValueRef& r_element);
+bool MCProperListIterate(MCProperListRef list, uintptr_t& x_iterator, MCValueRef& r_element);
 
 // Apply the callback to each element of list. The contents should not be modified.
 typedef bool (*MCProperListApplyCallback)(void *context, MCValueRef element);
-MC_DLLEXPORT bool MCProperListApply(MCProperListRef list, MCProperListApplyCallback p_callback, void *context);
+bool MCProperListApply(MCProperListRef list, MCProperListApplyCallback p_callback, void *context);
 
 // Apply the callback to each element of list to create a new list.
 typedef bool (*MCProperListMapCallback)(void *context, MCValueRef element, MCValueRef& r_new_element);
-MC_DLLEXPORT bool MCProperListMap(MCProperListRef list, MCProperListMapCallback p_callback, MCProperListRef& r_new_list, void *context);
+bool MCProperListMap(MCProperListRef list, MCProperListMapCallback p_callback, MCProperListRef& r_new_list, void *context);
 
 // Sort list by comparing elements using the provided callback.
 typedef compare_t (*MCProperListQuickSortCallback)(const MCValueRef left, const MCValueRef right);
-MC_DLLEXPORT bool MCProperListSort(MCProperListRef list, bool p_reverse, MCProperListQuickSortCallback p_callback);
+bool MCProperListSort(MCProperListRef list, bool p_reverse, MCProperListQuickSortCallback p_callback);
 
 typedef compare_t (*MCProperListCompareElementCallback)(void *context, const MCValueRef left, const MCValueRef right);
-MC_DLLEXPORT bool MCProperListStableSort(MCProperListRef list, bool p_reverse, MCProperListCompareElementCallback p_callback, void *context);
+bool MCProperListStableSort(MCProperListRef list, bool p_reverse, MCProperListCompareElementCallback p_callback, void *context);
 
 // Fetch the first element of the list. The returned value is not retained.
-MC_DLLEXPORT MCValueRef MCProperListFetchHead(MCProperListRef list);
-MC_DLLEXPORT // Fetch the last element of the list. The returned value is not retained.
+MCValueRef MCProperListFetchHead(MCProperListRef list);
+// Fetch the last element of the list. The returned value is not retained.
 MCValueRef MCProperListFetchTail(MCProperListRef list);
 // Fetch the element of the list at the specified index. The returned value is not retained.
-MC_DLLEXPORT MCValueRef MCProperListFetchElementAtIndex(MCProperListRef list, uindex_t p_index);
+MCValueRef MCProperListFetchElementAtIndex(MCProperListRef list, uindex_t p_index);
 
 // Copy the elements at the specified range as a list.
-MC_DLLEXPORT bool MCProperListCopySublist(MCProperListRef list, MCRange p_range, MCProperListRef& r_elements);
+bool MCProperListCopySublist(MCProperListRef list, MCRange p_range, MCProperListRef& r_elements);
 
-MC_DLLEXPORT bool MCProperListPushElementOntoFront(MCProperListRef list, MCValueRef p_value);
-MC_DLLEXPORT bool MCProperListPushElementOntoBack(MCProperListRef list, MCValueRef p_value);
+bool MCProperListPushElementOntoFront(MCProperListRef list, MCValueRef p_value);
+bool MCProperListPushElementOntoBack(MCProperListRef list, MCValueRef p_value);
 // Pushes all of the values in p_values onto the end of the list
-MC_DLLEXPORT bool MCProperListPushElementsOntoFront(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length);
-MC_DLLEXPORT bool MCProperListPushElementsOntoBack(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length);
+bool MCProperListPushElementsOntoFront(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length);
+bool MCProperListPushElementsOntoBack(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length);
 
-MC_DLLEXPORT bool MCProperListAppendList(MCProperListRef list, MCProperListRef p_value);
+bool MCProperListAppendList(MCProperListRef list, MCProperListRef p_value);
 
 // The returned value is owned by the caller.
-MC_DLLEXPORT bool MCProperListPopFront(MCProperListRef list, MCValueRef& r_value);
-MC_DLLEXPORT bool MCProperListPopBack(MCProperListRef list, MCValueRef& r_value);
+bool MCProperListPopFront(MCProperListRef list, MCValueRef& r_value);
+bool MCProperListPopBack(MCProperListRef list, MCValueRef& r_value);
 
-MC_DLLEXPORT bool MCProperListInsertElement(MCProperListRef list, MCValueRef p_value, index_t p_index);
-MC_DLLEXPORT bool MCProperListInsertElements(MCProperListRef list, const MCValueRef *p_value, uindex_t p_length, index_t p_index);
-MC_DLLEXPORT bool MCProperListInsertList(MCProperListRef list, MCProperListRef p_value, index_t p_index);
+bool MCProperListInsertElement(MCProperListRef list, MCValueRef p_value, index_t p_index);
+bool MCProperListInsertElements(MCProperListRef list, const MCValueRef *p_value, uindex_t p_length, index_t p_index);
+bool MCProperListInsertList(MCProperListRef list, MCProperListRef p_value, index_t p_index);
 
-MC_DLLEXPORT bool MCProperListRemoveElement(MCProperListRef list, uindex_t p_index);
-MC_DLLEXPORT bool MCProperListRemoveElements(MCProperListRef list, uindex_t p_start, uindex_t p_finish);
+bool MCProperListRemoveElement(MCProperListRef list, uindex_t p_index);
+bool MCProperListRemoveElements(MCProperListRef list, uindex_t p_start, uindex_t p_finish);
 
-MC_DLLEXPORT bool MCProperListFirstIndexOfElement(MCProperListRef list, MCValueRef p_needle, uindex_t p_after, uindex_t& r_offset);
-MC_DLLEXPORT bool MCProperListFirstIndexOfElementInRange(MCProperListRef list, MCValueRef p_needle, MCRange p_range, uindex_t& r_offset);
+bool MCProperListFirstIndexOfElement(MCProperListRef list, MCValueRef p_needle, uindex_t p_after, uindex_t& r_offset);
+bool MCProperListFirstIndexOfElementInRange(MCProperListRef list, MCValueRef p_needle, MCRange p_range, uindex_t& r_offset);
 
-MC_DLLEXPORT bool MCProperListLastIndexOfElementInRange(MCProperListRef list, MCValueRef p_needle, MCRange p_range, uindex_t & r_offset);
+bool MCProperListLastIndexOfElementInRange(MCProperListRef list, MCValueRef p_needle, MCRange p_range, uindex_t & r_offset);
 
-MC_DLLEXPORT bool MCProperListFirstOffsetOfList(MCProperListRef list, MCProperListRef p_needle, uindex_t p_after, uindex_t& r_offset);
-MC_DLLEXPORT bool MCProperListFirstOffsetOfListInRange(MCProperListRef list, MCProperListRef p_needle, MCRange p_range, uindex_t & r_offset);
-MC_DLLEXPORT bool MCProperListLastOffsetOfListInRange(MCProperListRef list, MCProperListRef p_needle, MCRange p_range, uindex_t & r_offset);
+bool MCProperListFirstOffsetOfList(MCProperListRef list, MCProperListRef p_needle, uindex_t p_after, uindex_t& r_offset);
+bool MCProperListFirstOffsetOfListInRange(MCProperListRef list, MCProperListRef p_needle, MCRange p_range, uindex_t & r_offset);
+bool MCProperListLastOffsetOfListInRange(MCProperListRef list, MCProperListRef p_needle, MCRange p_range, uindex_t & r_offset);
 
-MC_DLLEXPORT bool MCProperListIsEqualTo(MCProperListRef list, MCProperListRef p_other);
+bool MCProperListIsEqualTo(MCProperListRef list, MCProperListRef p_other);
 
-MC_DLLEXPORT bool MCProperListBeginsWithList(MCProperListRef list, MCProperListRef p_prefix);
-MC_DLLEXPORT bool MCProperListEndsWithList(MCProperListRef list, MCProperListRef p_suffix);
+bool MCProperListBeginsWithList(MCProperListRef list, MCProperListRef p_prefix);
+bool MCProperListEndsWithList(MCProperListRef list, MCProperListRef p_suffix);
 
-MC_DLLEXPORT bool MCProperListIsListOfType(MCProperListRef list, MCValueTypeCode p_type);
-MC_DLLEXPORT bool MCProperListIsHomogeneous(MCProperListRef list, MCValueTypeCode& r_type);
+bool MCProperListIsListOfType(MCProperListRef list, MCValueTypeCode p_type);
+bool MCProperListIsHomogeneous(MCProperListRef list, MCValueTypeCode& r_type);
     
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -3079,23 +3079,23 @@ struct MCPickleVariantInfo
 #define MC_PICKLE_ARRAY_OF_VARIANT(Variant, Field, CountField) MC_PICKLE_FIELD_AUX(ArrayOfVariant, Field, CountField, k##Variant##PickleInfo)
 
 // Read in the stream in the format conforming to the specified pickle info.
-MC_DLLEXPORT bool MCPickleRead(MCStreamRef stream, MCPickleRecordInfo *info, void* r_record);
+bool MCPickleRead(MCStreamRef stream, MCPickleRecordInfo *info, void* r_record);
 
 // Write the given record to the stream in the format conforming to the specified
 // pickle info.
-MC_DLLEXPORT bool MCPickleWrite(MCStreamRef stream, MCPickleRecordInfo *info, void* record);
+bool MCPickleWrite(MCStreamRef stream, MCPickleRecordInfo *info, void* record);
 
 // Release a record read in using MCPickleRead.
-MC_DLLEXPORT void MCPickleRelease(MCPickleRecordInfo *info, void *record);
+void MCPickleRelease(MCPickleRecordInfo *info, void *record);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  TYPE CONVERSION
 //
 
-MC_DLLEXPORT bool MCTypeConvertStringToLongInteger(MCStringRef p_string, integer_t& r_converted);
-MC_DLLEXPORT bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool p_convert_octals = false);
-MC_DLLEXPORT bool MCTypeConvertStringToBool(MCStringRef p_string, bool& r_converted);
+bool MCTypeConvertStringToLongInteger(MCStringRef p_string, integer_t& r_converted);
+bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool p_convert_octals = false);
+bool MCTypeConvertStringToBool(MCStringRef p_string, bool& r_converted);
 
 }
     

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -369,7 +369,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #    define MC_DLLEXPORT __attribute__((dllexport))
 #  endif
 #else
-#  define MC_DLLEXPORT __attribute__((__visibility__("default")))
+#  define MC_DLLEXPORT __attribute__((__visibility__("default"), __used__))
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/system-commandline.h
+++ b/libfoundation/include/system-commandline.h
@@ -86,7 +86,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * ---------------------------------------------------------------- */
 
 /* Capture a C-style argument list. */
-MC_DLLEXPORT bool MCSCommandLineCapture (uindex_t p_arg_count, const char* p_arg_array[]);
+bool MCSCommandLineCapture (uindex_t p_arg_count, const char* p_arg_array[]);
 
 #if defined(__WINDOWS__)
 /* Capture an argument list using the Windows API.  You should use
@@ -94,7 +94,7 @@ MC_DLLEXPORT bool MCSCommandLineCapture (uindex_t p_arg_count, const char* p_arg
  * command line is passed to the C main() function using the system
  * codepage, which means that Unicode characters may be converted to
  * '?' by Windows. */
-MC_DLLEXPORT bool MCSCommandLineCaptureWindows (void);
+bool MCSCommandLineCaptureWindows (void);
 #endif /* __WINDOWS__ */
 
 /* ----------------------------------------------------------------
@@ -102,30 +102,30 @@ MC_DLLEXPORT bool MCSCommandLineCaptureWindows (void);
  * ---------------------------------------------------------------- */
 
 /* Set the argument list directly */
-MC_DLLEXPORT bool MCSCommandLineSetArguments (MCProperListRef p_arg_list);
+bool MCSCommandLineSetArguments (MCProperListRef p_arg_list);
 
 /* Get the argument list */
-MC_DLLEXPORT bool MCSCommandLineGetArguments (MCProperListRef & r_arg_list);
+bool MCSCommandLineGetArguments (MCProperListRef & r_arg_list);
 
 /* ----------------------------------------------------------------
  * Name
  * ---------------------------------------------------------------- */
 
 /* Set the command name directly */
-MC_DLLEXPORT bool MCSCommandLineSetName (MCStringRef p_name);
+bool MCSCommandLineSetName (MCStringRef p_name);
 
 /* Get the command name */
-MC_DLLEXPORT bool MCSCommandLineGetName (MCStringRef & r_name);
+bool MCSCommandLineGetName (MCStringRef & r_name);
 
 /* ----------------------------------------------------------------
  * Filename
  * ---------------------------------------------------------------- */
 
 /* Set the command filename directly */
-MC_DLLEXPORT bool MCSCommandLineSetFilename (MCStringRef p_filename);
+bool MCSCommandLineSetFilename (MCStringRef p_filename);
 
 /* Get the command filename */
-MC_DLLEXPORT bool MCSCommandLineGetFilename (MCStringRef & r_filename);
+bool MCSCommandLineGetFilename (MCStringRef & r_filename);
 
 /* ----------------------------------------------------------------
  * Initialization

--- a/libfoundation/include/system-file.h
+++ b/libfoundation/include/system-file.h
@@ -23,9 +23,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * Errors
  * ================================================================ */
 
-MC_DLLEXPORT extern MCTypeInfoRef kMCSFileIOErrorTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCSFileEndOfFileErrorTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCSFileInvalidPathErrorTypeInfo;
+extern MCTypeInfoRef kMCSFileIOErrorTypeInfo;
+extern MCTypeInfoRef kMCSFileEndOfFileErrorTypeInfo;
+extern MCTypeInfoRef kMCSFileInvalidPathErrorTypeInfo;
 
 #ifdef __MCS_INTERNAL_API__
 
@@ -53,7 +53,7 @@ bool __MCSFilePathFromNative (MCStringRef p_native_path, MCStringRef & r_path);
  * ================================================================ */
 
 /* Read an entire file into allocated memory, with good error checking. */
-MC_DLLEXPORT bool MCSFileGetContents(MCStringRef p_filename, MCDataRef & r_data);
+bool MCSFileGetContents(MCStringRef p_filename, MCDataRef & r_data);
 
 /* Write all of p_data to a file called p_filename, with good error
  * checking.  If a file called p_filename already exists it will be
@@ -77,7 +77,7 @@ MC_DLLEXPORT bool MCSFileGetContents(MCStringRef p_filename, MCDataRef & r_data)
  * 3) On Windows, this function will fail if p_filename already exists
  *    and is open.
  */
-MC_DLLEXPORT bool MCSFileSetContents(MCStringRef p_filename, MCDataRef p_data);
+bool MCSFileSetContents(MCStringRef p_filename, MCDataRef p_data);
 
 #ifdef __MCS_INTERNAL_API__
 
@@ -100,7 +100,7 @@ enum MCSFileOpenMode
 	kMCSFileOpenModeUpdate = (kMCSFileOpenModeRead | kMCSFileOpenModeWrite),
 };
 
-MC_DLLEXPORT bool MCSFileCreateStream(MCStringRef p_filename, intenum_t p_mode, MCStreamRef& r_stream);
+bool MCSFileCreateStream(MCStringRef p_filename, intenum_t p_mode, MCStreamRef& r_stream);
 
 #ifdef __MCS_INTERNAL_API__
 
@@ -113,18 +113,18 @@ bool __MCSFileCreateStream (MCStringRef p_native_path, intenum_t p_mode, MCStrea
  * ================================================================ */
 
 /* Delete the file at path. */
-MC_DLLEXPORT bool MCSFileDelete (MCStringRef p_path);
+bool MCSFileDelete (MCStringRef p_path);
 
 /* Create a directory at p_path.  Does not recursively create
  * directories. */
-MC_DLLEXPORT bool MCSFileCreateDirectory (MCStringRef p_path);
+bool MCSFileCreateDirectory (MCStringRef p_path);
 
 /* Delete a directory at p_path.  The directory must be empty. */
-MC_DLLEXPORT bool MCSFileDeleteDirectory (MCStringRef p_path);
+bool MCSFileDeleteDirectory (MCStringRef p_path);
 
 /* Return a list of the entries in the directory at p_path.  The
  * returned list never includes "." and "..". */
-MC_DLLEXPORT bool MCSFileGetDirectoryEntries (MCStringRef p_path, MCProperListRef & r_entries);
+bool MCSFileGetDirectoryEntries (MCStringRef p_path, MCProperListRef & r_entries);
 
 #ifdef __MCS_INTERNAL_API__
 

--- a/libfoundation/include/system-init.h
+++ b/libfoundation/include/system-init.h
@@ -24,8 +24,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * ================================================================ */
 
 /* Library setup. Call before any other functions in this library. */
-MC_DLLEXPORT bool MCSInitialize(void);
+bool MCSInitialize(void);
 
 /* Call when the library is no longer needed, in order to clear any
  * library state. */
-MC_DLLEXPORT void MCSFinalize(void);
+void MCSFinalize(void);

--- a/libfoundation/include/system-random.h
+++ b/libfoundation/include/system-random.h
@@ -24,11 +24,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * ================================================================ */
 
 /* Generate p_length bytes of random data. */
-MC_DLLEXPORT bool MCSRandomData (uindex_t p_length, MCDataRef & r_data);
+bool MCSRandomData (uindex_t p_length, MCDataRef & r_data);
 
 /* Generate a random real number on the interval [0,1).  If any random
  * number generation failure occurs, returns a quiet NaN. */
-MC_DLLEXPORT real64_t MCSRandomReal (void);
+real64_t MCSRandomReal (void);
 
 #ifdef __MCS_INTERNAL_API__
 

--- a/libfoundation/include/system-stream.h
+++ b/libfoundation/include/system-stream.h
@@ -26,9 +26,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <stdio.h>
 
 // Standard streams
-MC_DLLEXPORT bool MCSStreamGetStandardOutput(MCStreamRef & r_stdout);
-MC_DLLEXPORT bool MCSStreamGetStandardInput(MCStreamRef & r_stdin);
-MC_DLLEXPORT bool MCSStreamGetStandardError(MCStreamRef & r_stderr);
+bool MCSStreamGetStandardOutput(MCStreamRef & r_stdout);
+bool MCSStreamGetStandardInput(MCStreamRef & r_stdin);
+bool MCSStreamGetStandardError(MCStreamRef & r_stderr);
 
 #ifdef __MCS_INTERNAL_API__
 

--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -57,6 +57,7 @@ static bool __MCArrayFindKeyValueSlot(__MCArray *self, bool case_sensitive, MCNa
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCArrayCreate(bool p_case_sensitive, const MCNameRef *p_keys, const MCValueRef *p_values, uindex_t p_length, MCArrayRef& r_array)
 {
 	bool t_success;
@@ -78,6 +79,7 @@ bool MCArrayCreate(bool p_case_sensitive, const MCNameRef *p_keys, const MCValue
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCArrayCreateWithOptions(bool p_case_sensitive, bool p_form_sensitive, const MCNameRef *p_keys, const MCValueRef *p_values, uindex_t p_length, MCArrayRef& r_array)
 {
 	bool t_success;
@@ -99,6 +101,7 @@ bool MCArrayCreateWithOptions(bool p_case_sensitive, bool p_form_sensitive, cons
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCArrayCreateMutable(MCArrayRef& r_array)
 {
 	if (!__MCValueCreate(kMCValueTypeCodeArray, r_array))
@@ -109,6 +112,7 @@ bool MCArrayCreateMutable(MCArrayRef& r_array)
 	return true;
 }	
 
+MC_DLLEXPORT
 bool MCArrayCreateMutableWithOptions(MCArrayRef& r_array, bool p_case_sensitive, bool p_form_sensitive)
 {
 	if (!__MCValueCreate(kMCValueTypeCodeArray, r_array))
@@ -125,6 +129,7 @@ bool MCArrayCreateMutableWithOptions(MCArrayRef& r_array, bool p_case_sensitive,
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCArrayCopy(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	// If we aren't mutable, then we can just copy directly.
@@ -154,6 +159,7 @@ bool MCArrayCopy(MCArrayRef self, MCArrayRef& r_new_array)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCArrayCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	// If we aren't mutable, then new array is just us.
@@ -199,6 +205,7 @@ bool MCArrayCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCArrayMutableCopy(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	// If the array is immutable, then the new mutable array will be indirect
@@ -225,6 +232,7 @@ bool MCArrayMutableCopy(MCArrayRef self, MCArrayRef& r_new_array)
 	return __MCArrayCreateIndirect(self -> contents, r_new_array);
 }
 
+MC_DLLEXPORT
 bool MCArrayMutableCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	if (self -> references == 1)
@@ -243,6 +251,7 @@ bool MCArrayMutableCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCArrayApply(MCArrayRef self, MCArrayApplyCallback p_callback, void *p_context)
 {
 	// Make sure we are iterating over the correct contents.
@@ -271,6 +280,7 @@ bool MCArrayApply(MCArrayRef self, MCArrayApplyCallback p_callback, void *p_cont
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCArrayIterate(MCArrayRef self, uintptr_t& x_iterator, MCNameRef& r_key, MCValueRef& r_value)
 {
 	// Make sure we are iterating over the correct contents.
@@ -301,11 +311,13 @@ bool MCArrayIterate(MCArrayRef self, uintptr_t& x_iterator, MCNameRef& r_key, MC
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCArrayIsMutable(MCArrayRef self)
 {
 	return (self -> flags & kMCArrayFlagIsMutable) != 0;
 }
 
+MC_DLLEXPORT
 uindex_t MCArrayGetCount(MCArrayRef self)
 {
 	if (!__MCArrayIsIndirect(self))
@@ -313,11 +325,13 @@ uindex_t MCArrayGetCount(MCArrayRef self)
 	return self -> contents -> key_value_count;
 }
 
+MC_DLLEXPORT
 bool MCArrayIsCaseSensitive(MCArrayRef self)
 {
     return (self -> flags & kMCArrayFlagIsCaseSensitive) != 0;
 }
 
+MC_DLLEXPORT
 bool MCArrayIsFormSensitive(MCArrayRef self)
 {
     return (self -> flags & kMCArrayFlagIsFormSensitive) != 0;
@@ -325,11 +339,13 @@ bool MCArrayIsFormSensitive(MCArrayRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCArrayFetchValue(MCArrayRef self, bool p_case_sensitive, MCNameRef p_key, MCValueRef& r_value)
 {
 	return MCArrayFetchValueOnPath(self, p_case_sensitive, &p_key, 1, r_value);
 }
 
+MC_DLLEXPORT
 bool MCArrayFetchValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNameRef *p_path, uindex_t p_path_length, MCValueRef& r_value)
 {
 	// If the array is indirect, get the contents.
@@ -365,11 +381,13 @@ bool MCArrayFetchValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNam
 
 //////////////////////
 
+MC_DLLEXPORT
 bool MCArrayStoreValue(MCArrayRef self, bool p_case_sensitive, MCNameRef p_key, MCValueRef p_value)
 {
 	return MCArrayStoreValueOnPath(self, p_case_sensitive, &p_key, 1, p_value);
 }
 
+MC_DLLEXPORT
 bool MCArrayStoreValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNameRef *p_path, uindex_t p_path_length, MCValueRef p_new_value)
 {
 	// The array must be mutable.
@@ -464,11 +482,13 @@ bool MCArrayStoreValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNam
 
 //////////////////////
 
+MC_DLLEXPORT
 bool MCArrayRemoveValue(MCArrayRef self, bool p_case_sensitive, MCNameRef p_key)
 {
 	return MCArrayRemoveValueOnPath(self, p_case_sensitive, &p_key, 1);
 }
 
+MC_DLLEXPORT
 bool MCArrayRemoveValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNameRef *p_path, uindex_t p_path_length)
 {
 	// The array must be mutable.
@@ -528,6 +548,7 @@ bool MCArrayRemoveValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNa
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_value)
 {
 	char t_index_str[16];
@@ -540,6 +561,7 @@ bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_va
 	return MCArrayFetchValue(self, true, *t_key, r_value);
 }
 
+MC_DLLEXPORT
 bool MCArrayStoreValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef p_value)
 {
 	char t_index_str[16];
@@ -567,6 +589,7 @@ MCArrayRemoveValueAtIndex(MCArrayRef self, index_t p_index)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCArrayIsEmpty(MCArrayRef self)
 {
 	return MCArrayGetCount(self) == 0;
@@ -952,7 +975,7 @@ static bool __MCArrayRehash(__MCArray *self, index_t p_by)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCArrayRef kMCEmptyArray;
+MC_DLLEXPORT MCArrayRef kMCEmptyArray;
 
 bool __MCArrayInitialize(void)
 {

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -102,6 +102,7 @@ void MCFinalize(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCMemoryAllocate(size_t p_size, void*& r_block)
 {
 	void *t_block;
@@ -114,6 +115,7 @@ bool MCMemoryAllocate(size_t p_size, void*& r_block)
 	return MCErrorThrowOutOfMemory();
 }
 
+MC_DLLEXPORT
 bool MCMemoryAllocateCopy(const void *p_block, size_t p_block_size, void*& r_block)
 {
 	if (MCMemoryAllocate(p_block_size, r_block))
@@ -124,6 +126,7 @@ bool MCMemoryAllocateCopy(const void *p_block, size_t p_block_size, void*& r_blo
 	return MCErrorThrowOutOfMemory();
 }
 
+MC_DLLEXPORT
 bool MCMemoryReallocate(void *p_block, size_t p_new_size, void*& r_new_block)
 {
 	void *t_new_block;
@@ -136,6 +139,7 @@ bool MCMemoryReallocate(void *p_block, size_t p_new_size, void*& r_new_block)
 	return MCErrorThrowOutOfMemory();
 }
 
+MC_DLLEXPORT
 void MCMemoryDeallocate(void *p_block)
 {
 	free(p_block);
@@ -143,6 +147,7 @@ void MCMemoryDeallocate(void *p_block)
 
 //////////
 
+MC_DLLEXPORT
 bool MCMemoryNew(size_t p_size, void*& r_record)
 {
 	if (MCMemoryAllocate(p_size, r_record))
@@ -153,6 +158,7 @@ bool MCMemoryNew(size_t p_size, void*& r_record)
 	return false;
 }
 
+MC_DLLEXPORT
 void MCMemoryDelete(void *p_record)
 {
 	MCMemoryDeallocate(p_record);
@@ -223,28 +229,33 @@ MCHashInt(T i)
 	return MCHashUInt((i >= 0) ? i : (-i));
 }
 
+MC_DLLEXPORT
 hash_t MCHashInteger(integer_t i)
 {
 	return MCHashInt (i);
 }
 
+MC_DLLEXPORT
 hash_t
 MCHashUInteger (uinteger_t i)
 {
 	return MCHashUInt(i);
 }
 
+MC_DLLEXPORT
 hash_t
 MCHashUSize (size_t i)
 {
 	return MCHashUInt (i);
 }
 
+MC_DLLEXPORT
 hash_t MCHashPointer(void *p)
 {
 	return MCHashUInt((uintptr_t) p);
 }
 
+MC_DLLEXPORT
 hash_t MCHashDouble(double d)
 {
 	double i;
@@ -260,6 +271,7 @@ hash_t MCHashDouble(double d)
 
 #define ELF_STEP(B) T1 = (H << 4) + B; T2 = T1 & 0xF0000000; if (T2) T1 ^= (T2 >> 24); T1 &= (~T2); H = T1;
 
+MC_DLLEXPORT
 hash_t MCHashBytes(const void *p_bytes, size_t length)
 {
 	uint8_t *bytes = (uint8_t *)p_bytes;
@@ -288,6 +300,7 @@ hash_t MCHashBytes(const void *p_bytes, size_t length)
     return H;
 }
 
+MC_DLLEXPORT
 hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t length)
 {
     MCAssert((length % 4) == 0);

--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -52,6 +52,7 @@ static bool __MCDataCopyMutable(__MCData *self, __MCData*& r_new_data);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data)
 {
 	bool t_success;
@@ -82,6 +83,7 @@ bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataR
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data)
 {
     // AL-2014-11-17: Create with bytes and release should just take the bytes.
@@ -106,6 +108,7 @@ bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCD
     return t_success;
 }
 
+MC_DLLEXPORT
 bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data)
 {
     // AL-2014-12-12: [[ Bug 14208 ]] Implement MCDataConvertStringToData reduce the overhead in
@@ -156,6 +159,7 @@ bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data)
     return t_success;
 }
 
+MC_DLLEXPORT
 bool MCDataIsEmpty(MCDataRef p_data)
 {
     if (__MCDataIsIndirect(p_data))
@@ -164,6 +168,7 @@ bool MCDataIsEmpty(MCDataRef p_data)
 	return p_data -> byte_count == 0;
 }
 
+MC_DLLEXPORT
 uindex_t MCDataGetLength(MCDataRef p_data)
 {
     if (__MCDataIsIndirect(p_data))
@@ -172,6 +177,7 @@ uindex_t MCDataGetLength(MCDataRef p_data)
     return p_data->byte_count;
 }
 
+MC_DLLEXPORT
 const byte_t *MCDataGetBytePtr(MCDataRef p_data)
 {
     if (__MCDataIsIndirect(p_data))
@@ -180,6 +186,7 @@ const byte_t *MCDataGetBytePtr(MCDataRef p_data)
     return p_data->bytes;
 }
 
+MC_DLLEXPORT
 byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index)
 {
     if (__MCDataIsIndirect(p_data))
@@ -188,7 +195,7 @@ byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index)
     return p_data->bytes[p_index];
 }
 
-hash_t MCDataHash(MCDataRef p_data);
+MC_DLLEXPORT
 bool MCDataIsEqualTo(MCDataRef p_left, MCDataRef p_right)
 {
     if (__MCDataIsIndirect(p_left))
@@ -203,10 +210,9 @@ bool MCDataIsEqualTo(MCDataRef p_left, MCDataRef p_right)
     return MCMemoryCompare(p_left -> bytes, p_right -> bytes, p_left -> byte_count) == 0;
 }
 
-compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right);
-
 // Mutable data methods
 
+MC_DLLEXPORT
 bool MCDataCreateMutable(uindex_t p_initial_capacity, MCDataRef& r_data)
 {
 	bool t_success;
@@ -233,6 +239,7 @@ bool MCDataCreateMutable(uindex_t p_initial_capacity, MCDataRef& r_data)
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data)
 {
     if (!MCDataIsMutable(p_data))
@@ -254,6 +261,7 @@ bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data)
     return __MCDataCopyMutable(p_data, r_new_data);
 }
 
+MC_DLLEXPORT
 bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data)
 {
     // If the MCData is immutable we just pass it through (as we are releasing it).
@@ -290,6 +298,7 @@ bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data)
 {
     // If p_data is immutable, then the new mutable data ref will be indirect
@@ -309,6 +318,7 @@ bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data)
     return __MCDataCreateIndirect(p_data -> contents, r_mutable_data);
 }
 
+MC_DLLEXPORT
 bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data)
 {
     if (p_data -> references == 1)
@@ -327,6 +337,7 @@ bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCDataCopyRange(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
 {
     if (__MCDataIsIndirect(self))
@@ -337,6 +348,7 @@ bool MCDataCopyRange(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
     return MCDataCreateWithBytes(self -> bytes + p_range . offset, p_range . length, r_new_data);
 }
 
+MC_DLLEXPORT
 bool MCDataCopyRangeAndRelease(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
 {
     if (MCDataCopyRange(self, p_range, r_new_data))
@@ -348,11 +360,13 @@ bool MCDataCopyRangeAndRelease(MCDataRef self, MCRange p_range, MCDataRef& r_new
     return false;
 }
 
+MC_DLLEXPORT
 bool MCDataIsMutable(const MCDataRef p_data)
 {
     return (p_data->flags & kMCDataFlagIsMutable) != 0;
 }
 
+MC_DLLEXPORT
 bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix)
 {
     MCAssert(MCDataIsMutable(r_data));
@@ -374,6 +388,7 @@ bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix)
     return MCDataAppendBytes(r_data, p_suffix -> bytes, p_suffix -> byte_count);
 }
 
+MC_DLLEXPORT
 bool MCDataAppendBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -392,11 +407,13 @@ bool MCDataAppendBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_co
     return true;
 }
 
+MC_DLLEXPORT
 bool MCDataAppendByte(MCDataRef r_data, byte_t p_byte)
 {
     return MCDataAppendBytes(r_data, &p_byte, 1);
 }
 
+MC_DLLEXPORT
 bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix)
 {
     MCAssert(MCDataIsMutable(r_data));
@@ -418,6 +435,7 @@ bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix)
     return MCDataPrependBytes(r_data, p_prefix -> bytes, p_prefix -> byte_count);
 }
 
+MC_DLLEXPORT
 bool MCDataPrependBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -436,11 +454,13 @@ bool MCDataPrependBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_c
     return true;
 }
 
+MC_DLLEXPORT
 bool MCDataPrependByte(MCDataRef r_data, byte_t p_byte)
 {
     return MCDataPrependBytes(r_data, &p_byte, 1);
 }
 
+MC_DLLEXPORT
 bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data)
 {
     MCAssert(MCDataIsMutable(r_data));
@@ -462,6 +482,7 @@ bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data)
     return MCDataInsertBytes(r_data, p_at, p_new_data -> bytes, p_new_data -> byte_count);
 }
 
+MC_DLLEXPORT
 bool MCDataInsertBytes(MCDataRef self, uindex_t p_at, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -480,6 +501,7 @@ bool MCDataInsertBytes(MCDataRef self, uindex_t p_at, const byte_t *p_bytes, uin
     return true;
 }
 
+MC_DLLEXPORT
 bool MCDataRemove(MCDataRef self, MCRange p_range)
 {
 	MCAssert(MCDataIsMutable(self));
@@ -498,6 +520,7 @@ bool MCDataRemove(MCDataRef self, MCRange p_range)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data)
 {
 	MCAssert(MCDataIsMutable(r_data));
@@ -518,6 +541,7 @@ bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data)
     return MCDataReplaceBytes(r_data, p_range, p_new_data -> bytes, p_new_data -> byte_count);
 }
 
+MC_DLLEXPORT
 bool MCDataReplaceBytes(MCDataRef self, MCRange p_range, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -553,6 +577,7 @@ bool MCDataReplaceBytes(MCDataRef self, MCRange p_range, const byte_t *p_bytes, 
     return true;
 }
 
+MC_DLLEXPORT
 bool MCDataPad(MCDataRef self, byte_t p_byte, uindex_t p_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -569,6 +594,7 @@ bool MCDataPad(MCDataRef self, byte_t p_byte, uindex_t p_count)
 	return true;
 }
 
+MC_DLLEXPORT
 compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right)
 {
     if (__MCDataIsIndirect(p_left))
@@ -586,6 +612,7 @@ compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right)
     return p_left -> byte_count - p_right -> byte_count;
 }
 
+MC_DLLEXPORT
 bool MCDataContains(MCDataRef p_data, MCDataRef p_needle)
 {
     uindex_t t_needle_byte_count, t_byte_count;
@@ -609,6 +636,7 @@ bool MCDataContains(MCDataRef p_data, MCDataRef p_needle)
     return t_found;
 }
 
+MC_DLLEXPORT
 bool MCDataBeginsWith(MCDataRef p_data, MCDataRef p_needle)
 {
     uindex_t t_needle_byte_count, t_byte_count;
@@ -621,6 +649,7 @@ bool MCDataBeginsWith(MCDataRef p_data, MCDataRef p_needle)
     return MCMemoryCompare(p_data -> bytes, p_needle -> bytes, sizeof(byte_t) * t_needle_byte_count) == 0;
 }
 
+MC_DLLEXPORT
 bool MCDataEndsWith(MCDataRef p_data, MCDataRef p_needle)
 {
     uindex_t t_needle_byte_count, t_byte_count;
@@ -633,6 +662,7 @@ bool MCDataEndsWith(MCDataRef p_data, MCDataRef p_needle)
     return MCMemoryCompare(p_data -> bytes + t_byte_count - t_needle_byte_count, p_needle -> bytes, sizeof(byte_t) * t_needle_byte_count) == 0;
 }
 
+MC_DLLEXPORT
 bool MCDataFirstIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, uindex_t& r_index)
 {
     __MCDataClampRange(p_data, t_range);
@@ -662,7 +692,7 @@ bool MCDataFirstIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, ui
     return t_found;
 }
 
-bool
+MC_DLLEXPORT bool
 MCDataLastIndexOf (MCDataRef self,
                    MCDataRef p_needle,
                    MCRange p_range,
@@ -706,6 +736,7 @@ MCDataLastIndexOf (MCDataRef self,
 }
 
 #if defined(__MAC__) || defined (__IOS__)
+MC_DLLEXPORT
 bool MCDataConvertToCFDataRef(MCDataRef p_data, CFDataRef& r_cfdata)
 {
     if (__MCDataIsIndirect(p_data))
@@ -793,7 +824,7 @@ static bool __MCDataMakeImmutable(__MCData *self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCDataRef kMCEmptyData;
+MC_DLLEXPORT MCDataRef kMCEmptyData;
 
 bool __MCDataInitialize(void)
 {

--- a/libfoundation/src/foundation-error.cpp
+++ b/libfoundation/src/foundation-error.cpp
@@ -23,8 +23,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCOutOfMemoryErrorTypeInfo;
-MCTypeInfoRef kMCGenericErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCOutOfMemoryErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCGenericErrorTypeInfo;
 
 static MCErrorRef s_last_error = nil;
 
@@ -120,7 +120,7 @@ static bool MCErrorFormatMessage(MCStringRef p_format, MCArrayRef p_info, MCStri
     return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCErrorCreateWithMessage (MCTypeInfoRef p_typeinfo,
                           MCStringRef p_message,
                           MCArrayRef p_info,
@@ -147,6 +147,7 @@ MCErrorCreateWithMessage (MCTypeInfoRef p_typeinfo,
     return true;
 }
 
+MC_DLLEXPORT
 bool MCErrorCreate(MCTypeInfoRef p_typeinfo, MCArrayRef p_info, MCErrorRef& r_error)
 {
 	return MCErrorCreateWithMessage (p_typeinfo,
@@ -155,6 +156,7 @@ bool MCErrorCreate(MCTypeInfoRef p_typeinfo, MCArrayRef p_info, MCErrorRef& r_er
 	                                 r_error);
 }
 
+MC_DLLEXPORT
 bool MCErrorUnwind(MCErrorRef p_error, MCValueRef p_target, uindex_t p_row, uindex_t p_column)
 {
     MCErrorFrame *t_frame;
@@ -179,21 +181,25 @@ bool MCErrorUnwind(MCErrorRef p_error, MCValueRef p_target, uindex_t p_row, uind
     return true;
 }
 
+MC_DLLEXPORT
 MCNameRef MCErrorGetDomain(MCErrorRef self)
 {
     return MCErrorTypeInfoGetDomain(self -> typeinfo);
 }
 
+MC_DLLEXPORT
 MCArrayRef MCErrorGetInfo(MCErrorRef self)
 {
     return self -> info;
 }
 
+MC_DLLEXPORT
 MCStringRef MCErrorGetMessage(MCErrorRef self)
 {
     return self -> message;
 }
 
+MC_DLLEXPORT
 uindex_t MCErrorGetDepth(MCErrorRef self)
 {
     if (self -> backtrace == nil)
@@ -221,6 +227,7 @@ static MCErrorFrame *__MCErrorGetFrameAtLevel(MCErrorRef self, uindex_t p_level)
     return t_frame;
 }
 
+MC_DLLEXPORT
 MCValueRef MCErrorGetTargetAtLevel(MCErrorRef self, uindex_t p_level)
 {
     MCErrorFrame *t_frame;
@@ -231,6 +238,7 @@ MCValueRef MCErrorGetTargetAtLevel(MCErrorRef self, uindex_t p_level)
     return t_frame -> target;
 }
 
+MC_DLLEXPORT
 uindex_t MCErrorGetRowAtLevel(MCErrorRef self, uindex_t p_level)
 {
     MCErrorFrame *t_frame;
@@ -241,6 +249,7 @@ uindex_t MCErrorGetRowAtLevel(MCErrorRef self, uindex_t p_level)
     return t_frame -> row;
 }
 
+MC_DLLEXPORT
 uindex_t MCErrorGetColumnAtLevel(MCErrorRef self, uindex_t p_level)
 {
     MCErrorFrame *t_frame;
@@ -253,6 +262,7 @@ uindex_t MCErrorGetColumnAtLevel(MCErrorRef self, uindex_t p_level)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCErrorThrow(MCErrorRef p_error)
 {
     if (s_last_error != nil)
@@ -263,6 +273,7 @@ bool MCErrorThrow(MCErrorRef p_error)
     return false;
 }
 
+MC_DLLEXPORT
 bool MCErrorCatch(MCErrorRef& r_error)
 {
     if (s_last_error == nil)
@@ -274,11 +285,13 @@ bool MCErrorCatch(MCErrorRef& r_error)
     return true;
 }
 
+MC_DLLEXPORT
 MCErrorRef MCErrorPeek(void)
 {
     return s_last_error;
 }
 
+MC_DLLEXPORT
 bool MCErrorIsPending(void)
 {
     return s_last_error != nil;
@@ -324,7 +337,7 @@ MCErrorCreateAndThrowWithMessageV (MCTypeInfoRef p_error_type,
     return MCErrorThrow(*t_error);
 }
 
-bool
+MC_DLLEXPORT bool
 MCErrorCreateAndThrowWithMessage (MCTypeInfoRef p_error_type,
                                   MCStringRef p_message,
                                   ...)
@@ -341,7 +354,7 @@ MCErrorCreateAndThrowWithMessage (MCTypeInfoRef p_error_type,
 	return t_result;
 }
 
-bool
+MC_DLLEXPORT bool
 MCErrorCreateAndThrow (MCTypeInfoRef p_error_type, ...)
 {
 	va_list t_args;
@@ -358,6 +371,7 @@ MCErrorCreateAndThrow (MCTypeInfoRef p_error_type, ...)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCErrorThrowOutOfMemory(void)
 {
     if (s_out_of_memory_error == nil &&
@@ -374,11 +388,13 @@ bool MCErrorThrowOutOfMemory(void)
     return false;
 }
 
+MC_DLLEXPORT
 bool MCErrorThrowGeneric(MCStringRef p_reason)
 {
     return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", p_reason, nil);
 }
 
+MC_DLLEXPORT
 bool MCErrorThrowGenericWithMessage(MCStringRef p_message, ...)
 {
     va_list t_args;

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -21,19 +21,20 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCBoolTypeInfo;
-MCTypeInfoRef kMCUIntTypeInfo;
-MCTypeInfoRef kMCIntTypeInfo;
-MCTypeInfoRef kMCFloatTypeInfo;
-MCTypeInfoRef kMCDoubleTypeInfo;
-MCTypeInfoRef kMCPointerTypeInfo;
-MCTypeInfoRef kMCSizeTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCBoolTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCUIntTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCIntTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCFloatTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCDoubleTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCPointerTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCSizeTypeInfo;
 
 MCTypeInfoRef kMCForeignImportErrorTypeInfo;
 MCTypeInfoRef kMCForeignExportErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCForeignValueCreate(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignValueRef& r_value)
 {
     bool t_success;
@@ -59,6 +60,7 @@ bool MCForeignValueCreate(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignV
     return true;
 }
 
+MC_DLLEXPORT
 bool MCForeignValueCreateAndRelease(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignValueRef& r_value)
 {
     bool t_success;
@@ -84,6 +86,7 @@ bool MCForeignValueCreateAndRelease(MCTypeInfoRef p_typeinfo, void *p_contents, 
     return true;
 }
 
+MC_DLLEXPORT
 bool MCForeignValueExport(MCTypeInfoRef p_typeinfo, MCValueRef p_value, MCForeignValueRef& r_value)
 {
     bool t_success;
@@ -109,6 +112,7 @@ bool MCForeignValueExport(MCTypeInfoRef p_typeinfo, MCValueRef p_value, MCForeig
     return true;
 }
 
+MC_DLLEXPORT
 void *MCForeignValueGetContentsPtr(MCValueRef self)
 {
     return ((__MCForeignValue *)self) + 1;

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -21,6 +21,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCHandlerCreate(MCTypeInfoRef p_typeinfo, const MCHandlerCallbacks *p_callbacks, void *p_context, MCHandlerRef& r_handler)
 {
     // The context data for an MCHandler is stored after the common elements. The
@@ -40,11 +41,13 @@ bool MCHandlerCreate(MCTypeInfoRef p_typeinfo, const MCHandlerCallbacks *p_callb
     return true;
 }
 
+MC_DLLEXPORT
 bool MCHandlerInvoke(MCHandlerRef self, MCValueRef *p_arguments, uindex_t p_argument_count, MCValueRef& r_value)
 {
     return self -> callbacks -> invoke(MCHandlerGetContext(self), p_arguments, p_argument_count, r_value);
 }
 
+MC_DLLEXPORT
 MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef self, MCProperListRef& x_arguments, MCValueRef& r_value)
 {
     MCAutoValueRefArray t_args;
@@ -78,11 +81,13 @@ error_exit:
     return t_error;
 }
 
+MC_DLLEXPORT
 void *MCHandlerGetContext(MCHandlerRef self)
 {
     return (void *)self -> context;
 }
 
+MC_DLLEXPORT
 const MCHandlerCallbacks *MCHandlerGetCallbacks(MCHandlerRef self)
 {
     return self -> callbacks;

--- a/libfoundation/src/foundation-list.cpp
+++ b/libfoundation/src/foundation-list.cpp
@@ -47,6 +47,7 @@ bool MCListCreateMutable(MCStringRef p_delimiter, MCListRef& r_list)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCListAppend(MCListRef self, MCValueRef p_value)
 {
 	bool t_first = self->buffer == nil;
@@ -87,6 +88,7 @@ bool MCListAppend(MCListRef self, MCValueRef p_value)
 	return MCStringAppend(self -> buffer, t_string);
 }
 
+MC_DLLEXPORT
 bool MCListCopy(MCListRef self, MCListRef& r_list)
 {
 	MCAssert(self != nil);
@@ -121,6 +123,7 @@ bool MCListCopy(MCListRef self, MCListRef& r_list)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCListCopyAndRelease(MCListRef self, MCListRef& r_list)
 {
     // If there are no other references, just clear the mutable flag
@@ -138,6 +141,7 @@ bool MCListCopyAndRelease(MCListRef self, MCListRef& r_list)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCListCopyAsString(MCListRef self, MCStringRef& r_string)
 {
 	MCStringRef t_string;
@@ -152,6 +156,7 @@ bool MCListCopyAsString(MCListRef self, MCStringRef& r_string)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCListCopyAsStringAndRelease(MCListRef self, MCStringRef& r_string)
 {
 	if (!MCListCopyAsString(self, r_string))
@@ -162,6 +167,7 @@ bool MCListCopyAsStringAndRelease(MCListRef self, MCStringRef& r_string)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCListAppendFormat(MCListRef self, const char *p_format, ...)
 {
 	bool t_success;
@@ -184,6 +190,7 @@ bool MCListAppendFormat(MCListRef self, const char *p_format, ...)
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCListAppendNativeChars(MCListRef self, const char_t *p_chars, uindex_t p_char_count)
 {
 	bool t_first = self->buffer == nil;
@@ -197,11 +204,13 @@ bool MCListAppendNativeChars(MCListRef self, const char_t *p_chars, uindex_t p_c
 	return MCStringAppendNativeChars(self -> buffer, p_chars, p_char_count);
 }
 
+MC_DLLEXPORT
 bool MCListAppendSubstring(MCListRef self, MCStringRef p_string, MCRange p_range)
 {
 	return MCListAppendFormat(self, "%*@", &p_range, p_string);
 }
 
+MC_DLLEXPORT
 bool MCListIsEmpty(MCListRef self)
 {
 	return self -> buffer == nil;
@@ -209,7 +218,7 @@ bool MCListIsEmpty(MCListRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCListRef kMCEmptyList;
+MC_DLLEXPORT MCListRef kMCEmptyList;
 
 bool __MCListInitialize(void)
 {

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -20,9 +20,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCNameRef kMCEmptyName;
-MCNameRef kMCTrueName;
-MCNameRef kMCFalseName;
+MC_DLLEXPORT MCNameRef kMCEmptyName;
+MC_DLLEXPORT MCNameRef kMCTrueName;
+MC_DLLEXPORT MCNameRef kMCFalseName;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -37,6 +37,7 @@ static void __MCNameShrinkTable(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 MCNameRef MCNAME(const char *p_string)
 {
 	MCStringRef t_string;
@@ -55,6 +56,7 @@ MCNameRef MCNAME(const char *p_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCNameCreate(MCStringRef p_string, MCNameRef& r_name)
 {
 	MCAssert(p_string != nil);
@@ -168,6 +170,7 @@ bool MCNameCreate(MCStringRef p_string, MCNameRef& r_name)
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCNameCreateWithNativeChars(const char_t *p_chars, uindex_t p_count, MCNameRef& r_name)
 {
 	MCStringRef t_string;
@@ -181,6 +184,7 @@ bool MCNameCreateWithNativeChars(const char_t *p_chars, uindex_t p_count, MCName
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCNameCreateWithChars(const unichar_t *p_chars, uindex_t p_count, MCNameRef& r_name)
 {
 	MCStringRef t_string;
@@ -189,6 +193,7 @@ bool MCNameCreateWithChars(const unichar_t *p_chars, uindex_t p_count, MCNameRef
 	return MCNameCreateAndRelease(t_string, r_name);
 }
 
+MC_DLLEXPORT
 bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
 {
 	if (MCNameCreate(p_string, r_name))
@@ -200,6 +205,7 @@ bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
 	return false;
 }
 
+MC_DLLEXPORT
 MCNameRef MCNameLookup(MCStringRef p_string)
 {
 	// Compute the hash of the characters, up to case.
@@ -233,16 +239,19 @@ MCNameRef MCNameLookup(MCStringRef p_string)
 	return t_key_name;
 }
 
+MC_DLLEXPORT
 uintptr_t MCNameGetCaselessSearchKey(MCNameRef self)
 {
 	return (uintptr_t)self -> key;
 }
 
+MC_DLLEXPORT
 MCStringRef MCNameGetString(MCNameRef self)
 {
 	return self -> string;
 }
 
+MC_DLLEXPORT
 bool MCNameIsEmpty(MCNameRef self)
 {
 	return self == kMCEmptyName;

--- a/libfoundation/src/foundation-number.cpp
+++ b/libfoundation/src/foundation-number.cpp
@@ -23,6 +23,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCNumberCreateWithInteger(integer_t p_value, MCNumberRef& r_number)
 {
 	__MCNumber *self;
@@ -36,6 +37,7 @@ bool MCNumberCreateWithInteger(integer_t p_value, MCNumberRef& r_number)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCNumberCreateWithReal(real64_t p_value, MCNumberRef& r_number)
 {
 	__MCNumber *self;
@@ -50,7 +52,7 @@ bool MCNumberCreateWithReal(real64_t p_value, MCNumberRef& r_number)
 	return true;
 }
 
-
+MC_DLLEXPORT
 bool MCNumberCreateWithUnsignedInteger(uinteger_t p_value, MCNumberRef& r_number)
 {
     if (p_value <= INTEGER_MAX)
@@ -59,16 +61,19 @@ bool MCNumberCreateWithUnsignedInteger(uinteger_t p_value, MCNumberRef& r_number
     return MCNumberCreateWithReal((real64_t)p_value, r_number);
 }
 
+MC_DLLEXPORT
 bool MCNumberIsInteger(MCNumberRef self)
 {
 	return (self -> flags & kMCNumberFlagIsReal) == 0;
 }
 
+MC_DLLEXPORT
 bool MCNumberIsReal(MCNumberRef self)
 {
 	return (self -> flags & kMCNumberFlagIsReal) != 0;
 }
 
+MC_DLLEXPORT
 real64_t MCNumberFetchAsReal(MCNumberRef self)
 {
 	if (MCNumberIsReal(self))
@@ -76,6 +81,7 @@ real64_t MCNumberFetchAsReal(MCNumberRef self)
 	return (real64_t)self -> integer;
 }
 
+MC_DLLEXPORT
 integer_t MCNumberFetchAsInteger(MCNumberRef self)
 {
 	if (MCNumberIsInteger(self))
@@ -83,6 +89,7 @@ integer_t MCNumberFetchAsInteger(MCNumberRef self)
 	return self -> real < 0.0 ? (integer_t)(self -> real - 0.5) : (integer_t)(self -> real + 0.5);
 }
 
+MC_DLLEXPORT
 uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef self)
 {
 	if (MCNumberIsInteger(self))
@@ -183,6 +190,7 @@ bool __MCNumberParseNativeString(const char *p_string, uindex_t p_length, bool p
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCNumberParseOffset(MCStringRef p_string, uindex_t offset, uindex_t char_count, MCNumberRef &r_number)
 {
     uindex_t length = MCStringGetLength(p_string);
@@ -206,11 +214,13 @@ bool MCNumberParseOffset(MCStringRef p_string, uindex_t offset, uindex_t char_co
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCNumberParse(MCStringRef p_string, MCNumberRef &r_number)
 {
     return MCNumberParseOffset(p_string, 0, MCStringGetLength(p_string), r_number);
 }
 
+MC_DLLEXPORT
 bool MCNumberParseUnicodeChars(const unichar_t *p_chars, uindex_t p_char_count, MCNumberRef& r_number)
 {
 	char *t_native_chars;
@@ -233,6 +243,7 @@ bool MCNumberParseUnicodeChars(const unichar_t *p_chars, uindex_t p_char_count, 
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCNumberParseOffsetPartial(MCStringRef p_string, uindex_t offset, uindex_t &r_chars_used, MCNumberRef &r_number)
 {
 	bool t_success;
@@ -294,9 +305,9 @@ bool __MCNumberIsEqualTo(__MCNumber *self, __MCNumber *p_other_self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCNumberRef kMCZero;
-MCNumberRef kMCOne;
-MCNumberRef kMCMinusOne;
+MC_DLLEXPORT MCNumberRef kMCZero;
+MC_DLLEXPORT MCNumberRef kMCOne;
+MC_DLLEXPORT MCNumberRef kMCMinusOne;
 
 bool __MCNumberInitialize(void)
 {

--- a/libfoundation/src/foundation-pickle.cpp
+++ b/libfoundation/src/foundation-pickle.cpp
@@ -525,6 +525,7 @@ static bool MCPickleReadField(MCStreamRef stream, MCPickleFieldType p_kind, void
     return t_success;
 }
 
+MC_DLLEXPORT
 bool MCPickleRead(MCStreamRef stream, MCPickleRecordInfo *p_info, void* r_record)
 {
     bool t_success;
@@ -894,6 +895,7 @@ static bool MCPickleWriteField(MCStreamRef stream, MCPickleFieldType p_kind, voi
     return t_success;
 }
 
+MC_DLLEXPORT
 bool MCPickleWrite(MCStreamRef stream, MCPickleRecordInfo *p_info, void *p_record)
 {
     bool t_success;
@@ -991,6 +993,7 @@ static void MCPickleReleaseField(MCPickleFieldType p_kind, void *p_base_ptr, voi
     }
 }
 
+MC_DLLEXPORT
 void MCPickleRelease(MCPickleRecordInfo *p_info, void *p_record)
 {
     for(uindex_t i = 0; p_info -> fields[i] . kind != kMCPickleFieldTypeNone; i++)

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -48,6 +48,7 @@ static void __MCProperListClampRange(MCProperListRef self, MCRange& x_range);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCProperListCreate(const MCValueRef *p_values, uindex_t p_length, MCProperListRef& r_list)
 {
 	bool t_success;
@@ -68,6 +69,7 @@ bool MCProperListCreate(const MCValueRef *p_values, uindex_t p_length, MCProperL
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCProperListCreateMutable(MCProperListRef& r_list)
 {
 	if (!__MCValueCreate(kMCValueTypeCodeProperList, r_list))
@@ -94,6 +96,7 @@ MCProperListCreateAndRelease(MCValueRef *p_values,
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListCopy(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	// If we aren't mutable, then we can just copy directly.
@@ -123,6 +126,7 @@ bool MCProperListCopy(MCProperListRef self, MCProperListRef& r_new_list)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListCopyAndRelease(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	// If we aren't mutable, then new list is just us.
@@ -168,6 +172,7 @@ bool MCProperListCopyAndRelease(MCProperListRef self, MCProperListRef& r_new_lis
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListMutableCopy(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	// If the list is immutable, then the new mutable list will be indirect
@@ -194,6 +199,7 @@ bool MCProperListMutableCopy(MCProperListRef self, MCProperListRef& r_new_list)
 	return __MCProperListCreateIndirect(self -> contents, r_new_list);
 }
 
+MC_DLLEXPORT
 bool MCProperListMutableCopyAndRelease(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	if (self -> references == 1)
@@ -214,6 +220,7 @@ bool MCProperListMutableCopyAndRelease(MCProperListRef self, MCProperListRef& r_
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCProperListIsMutable(MCProperListRef self)
 {
 	return (self -> flags & kMCProperListFlagIsMutable) != 0;
@@ -224,6 +231,7 @@ bool MCProperListIsIndirect(MCProperListRef self)
 	return (self -> flags & kMCProperListFlagIsIndirect) != 0;
 }
 
+MC_DLLEXPORT
 uindex_t MCProperListGetLength(MCProperListRef self)
 {
 	if (!__MCProperListIsIndirect(self))
@@ -231,6 +239,7 @@ uindex_t MCProperListGetLength(MCProperListRef self)
 	return self -> contents -> length;
 }
 
+MC_DLLEXPORT
 bool MCProperListIsEmpty(MCProperListRef self)
 {
 	if (!__MCProperListIsIndirect(self))
@@ -241,26 +250,31 @@ bool MCProperListIsEmpty(MCProperListRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCProperListPushElementsOntoBack(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length)
 {
     return MCProperListInsertElements(self, p_values, p_length, MCProperListGetLength(self));
 }
 
+MC_DLLEXPORT
 bool MCProperListPushElementsOntoFront(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length)
 {
     return MCProperListInsertElements(self, p_values, p_length, 0);
 }
 
+MC_DLLEXPORT
 bool MCProperListPushElementOntoBack(MCProperListRef self, const MCValueRef p_value)
 {
     return MCProperListPushElementsOntoBack(self, &p_value, 1);
 }
 
+MC_DLLEXPORT
 bool MCProperListPushElementOntoFront(MCProperListRef self, const MCValueRef p_value)
 {
     return MCProperListPushElementsOntoFront(self, &p_value, 1);
 }
 
+MC_DLLEXPORT
 bool MCProperListAppendList(MCProperListRef self, MCProperListRef p_value)
 {
     if (MCProperListIsIndirect(p_value))
@@ -276,6 +290,7 @@ bool MCProperListAppendList(MCProperListRef self, MCProperListRef p_value)
     return MCProperListAppendList(self, *t_list);
 }
 
+MC_DLLEXPORT
 bool MCProperListInsertElements(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length, index_t p_index)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -293,11 +308,13 @@ bool MCProperListInsertElements(MCProperListRef self, const MCValueRef *p_values
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListInsertElement(MCProperListRef self, MCValueRef p_value, index_t p_index)
 {
     return MCProperListInsertElements(self, &p_value, 1, p_index);
 }
 
+MC_DLLEXPORT
 bool MCProperListInsertList(MCProperListRef self, MCProperListRef p_value, index_t p_index)
 {
     if (MCProperListIsIndirect(p_value))
@@ -313,6 +330,7 @@ bool MCProperListInsertList(MCProperListRef self, MCProperListRef p_value, index
     return MCProperListInsertList(self, *t_list, p_index);
 }
 
+MC_DLLEXPORT
 bool MCProperListRemoveElements(MCProperListRef self, uindex_t p_start, uindex_t p_count)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -337,6 +355,7 @@ bool MCProperListRemoveElements(MCProperListRef self, uindex_t p_start, uindex_t
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListRemoveElement(MCProperListRef self, uindex_t p_index)
 {
     return MCProperListRemoveElements(self, p_index, 1);
@@ -344,6 +363,7 @@ bool MCProperListRemoveElement(MCProperListRef self, uindex_t p_index)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 MCValueRef MCProperListFetchHead(MCProperListRef self)
 {
     if (MCProperListIsIndirect(self))
@@ -354,6 +374,7 @@ MCValueRef MCProperListFetchHead(MCProperListRef self)
     return self -> list[0];
 }
 
+MC_DLLEXPORT
 MCValueRef MCProperListFetchTail(MCProperListRef self)
 {
     if (MCProperListIsIndirect(self))
@@ -364,6 +385,7 @@ MCValueRef MCProperListFetchTail(MCProperListRef self)
     return self -> list[self -> length - 1];
 }
 
+MC_DLLEXPORT
 MCValueRef MCProperListFetchElementAtIndex(MCProperListRef self, uindex_t p_index)
 {
     if (MCProperListIsIndirect(self))
@@ -375,6 +397,7 @@ MCValueRef MCProperListFetchElementAtIndex(MCProperListRef self, uindex_t p_inde
     return self -> list[p_index];
 }
 
+MC_DLLEXPORT
 bool MCProperListPopBack(MCProperListRef self, MCValueRef& r_value)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -395,6 +418,7 @@ bool MCProperListPopBack(MCProperListRef self, MCValueRef& r_value)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListPopFront(MCProperListRef self, MCValueRef& r_value)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -415,6 +439,7 @@ bool MCProperListPopFront(MCProperListRef self, MCValueRef& r_value)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListCopySublist(MCProperListRef self, MCRange p_range, MCProperListRef& r_elements)
 {
     if (MCProperListIsIndirect(self))
@@ -426,13 +451,14 @@ bool MCProperListCopySublist(MCProperListRef self, MCRange p_range, MCProperList
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCProperListFirstIndexOfElement(MCProperListRef self, MCValueRef p_needle, uindex_t p_after, uindex_t& r_offset)
 {
 	return MCProperListFirstIndexOfElementInRange(self, p_needle,
 	            MCRangeMake(p_after, UINDEX_MAX), r_offset);
 }
 
-bool
+MC_DLLEXPORT bool
 MCProperListFirstIndexOfElementInRange (MCProperListRef self,
                                         MCValueRef p_needle,
                                         MCRange p_range,
@@ -458,7 +484,7 @@ MCProperListFirstIndexOfElementInRange (MCProperListRef self,
 	return false;
 }
 
-bool
+MC_DLLEXPORT bool
 MCProperListLastIndexOfElementInRange (MCProperListRef self,
                                        MCValueRef p_needle,
                                        MCRange p_range,
@@ -482,13 +508,14 @@ MCProperListLastIndexOfElementInRange (MCProperListRef self,
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCProperListFirstOffsetOfList(MCProperListRef self, MCProperListRef p_needle, uindex_t p_after, uindex_t& r_offset)
 {
 	return MCProperListFirstOffsetOfListInRange (self, p_needle,
 	            MCRangeMake (p_after, UINDEX_MAX), r_offset);
 }
 
-bool
+MC_DLLEXPORT bool
 MCProperListFirstOffsetOfListInRange (MCProperListRef self,
                                       MCProperListRef p_needle,
                                       MCRange p_range,
@@ -542,7 +569,7 @@ MCProperListFirstOffsetOfListInRange (MCProperListRef self,
 	return false;
 }
 
-bool
+MC_DLLEXPORT bool
 MCProperListLastOffsetOfListInRange (MCProperListRef self,
                                      MCProperListRef p_needle,
                                      MCRange p_range,
@@ -604,6 +631,7 @@ MCProperListLastOffsetOfListInRange (MCProperListRef self,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCProperListIterate(MCProperListRef self, uintptr_t& x_iterator, MCValueRef& r_element)
 {
     if (MCProperListIsIndirect(self))
@@ -619,6 +647,7 @@ bool MCProperListIterate(MCProperListRef self, uintptr_t& x_iterator, MCValueRef
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListApply(MCProperListRef self, MCProperListApplyCallback p_callback, void *context)
 {
     if (MCProperListIsIndirect(self))
@@ -631,6 +660,7 @@ bool MCProperListApply(MCProperListRef self, MCProperListApplyCallback p_callbac
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListMap(MCProperListRef self, MCProperListMapCallback p_callback, MCProperListRef& r_new_list, void *context)
 {
     if (MCProperListIsIndirect(self))
@@ -667,6 +697,7 @@ bool MCProperListMap(MCProperListRef self, MCProperListMapCallback p_callback, M
     return t_success;
 }
 
+MC_DLLEXPORT
 bool MCProperListSort(MCProperListRef self, bool p_reverse, MCProperListQuickSortCallback p_callback)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -727,6 +758,7 @@ static void MCProperListDoStableSort(MCValueRef*& list, uindex_t p_item_count, M
         list[i] = p_temp[i];
 }
 
+MC_DLLEXPORT
 bool MCProperListStableSort(MCProperListRef self, bool p_reverse, MCProperListCompareElementCallback p_callback, void *context)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -750,11 +782,13 @@ bool MCProperListStableSort(MCProperListRef self, bool p_reverse, MCProperListCo
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListIsEqualTo(MCProperListRef self, MCProperListRef p_other)
 {
     return __MCProperListIsEqualTo(self, p_other);
 }
 
+MC_DLLEXPORT
 bool MCProperListBeginsWithList(MCProperListRef self, MCProperListRef p_prefix)
 {
     // If the list is indirect, get the contents.
@@ -784,6 +818,7 @@ bool MCProperListBeginsWithList(MCProperListRef self, MCProperListRef p_prefix)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListEndsWithList(MCProperListRef self, MCProperListRef p_suffix)
 {
     // If the list is indirect, get the contents.
@@ -815,6 +850,7 @@ bool MCProperListEndsWithList(MCProperListRef self, MCProperListRef p_suffix)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCProperListIsListOfType(MCProperListRef self, MCValueTypeCode p_type)
 {
     // If the list is indirect, get the contents.
@@ -833,6 +869,7 @@ bool MCProperListIsListOfType(MCProperListRef self, MCValueTypeCode p_type)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCProperListIsHomogeneous(MCProperListRef self, MCValueTypeCode& r_type)
 {
     if (MCProperListIsEmpty(self))
@@ -1085,7 +1122,7 @@ static bool __MCProperListResolveIndirect(__MCProperList *self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCProperListRef kMCEmptyProperList;
+MC_DLLEXPORT MCProperListRef kMCEmptyProperList;
 
 bool __MCProperListInitialize(void)
 {

--- a/libfoundation/src/foundation-record.cpp
+++ b/libfoundation/src/foundation-record.cpp
@@ -40,6 +40,7 @@ static bool __check_conformance(MCTypeInfoRef p_typeinfo, const MCValueRef *p_va
     return true;
 }
 
+MC_DLLEXPORT
 bool MCRecordCreate(MCTypeInfoRef p_typeinfo, const MCValueRef *p_values, uindex_t p_value_count, MCRecordRef& r_record)
 {
     bool t_success;
@@ -80,6 +81,7 @@ bool MCRecordCreate(MCTypeInfoRef p_typeinfo, const MCValueRef *p_values, uindex
     
 }
 
+MC_DLLEXPORT
 bool MCRecordCreateMutable(MCTypeInfoRef p_typeinfo, MCRecordRef& r_record)
 {
     bool t_success;
@@ -118,6 +120,7 @@ bool MCRecordCreateMutable(MCTypeInfoRef p_typeinfo, MCRecordRef& r_record)
     return t_success;
 }
 
+MC_DLLEXPORT
 bool MCRecordCopy(MCRecordRef self, MCRecordRef& r_new_record)
 {
     if (!MCRecordIsMutable(self))
@@ -133,6 +136,7 @@ bool MCRecordCopy(MCRecordRef self, MCRecordRef& r_new_record)
     return MCRecordCreate(self -> typeinfo, self -> fields, __MCRecordTypeInfoGetFieldCount(t_resolved_typeinfo), r_new_record);
 }
 
+MC_DLLEXPORT
 bool MCRecordCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
 {
     // If the MCRecord is immutable we just pass it through (as we are releasing it).
@@ -161,6 +165,7 @@ bool MCRecordCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
     return t_success;
 }
 
+MC_DLLEXPORT
 bool MCRecordMutableCopy(MCRecordRef self, MCRecordRef& r_new_record)
 {
     MCTypeInfoRef t_resolved_typeinfo;
@@ -177,6 +182,7 @@ bool MCRecordMutableCopy(MCRecordRef self, MCRecordRef& r_new_record)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCRecordMutableCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
 {
     if (MCRecordMutableCopy(self, r_new_record))
@@ -188,6 +194,7 @@ bool MCRecordMutableCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
     return false;
 }
 
+MC_DLLEXPORT
 bool MCRecordIsMutable(MCRecordRef self)
 {
     return (self -> flags & kMCRecordFlagIsMutable) != 0;
@@ -211,6 +218,7 @@ static bool __fetch_value(MCTypeInfoRef p_typeinfo, MCRecordRef self, MCNameRef 
     return false;
 }
 
+MC_DLLEXPORT
 bool MCRecordFetchValue(MCRecordRef self, MCNameRef p_field, MCValueRef& r_value)
 {
     return __fetch_value(self -> typeinfo, self, p_field, r_value);
@@ -237,6 +245,7 @@ static bool __store_value(MCTypeInfoRef p_typeinfo, MCRecordRef self, MCNameRef 
     return false;
 }
 
+MC_DLLEXPORT
 bool MCRecordStoreValue(MCRecordRef self, MCNameRef p_field, MCValueRef p_value)
 {
     return __store_value(self -> typeinfo, self, p_field, p_value);
@@ -244,7 +253,7 @@ bool MCRecordStoreValue(MCRecordRef self, MCNameRef p_field, MCValueRef p_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool
+MC_DLLEXPORT bool
 MCRecordCopyAsBaseType(MCRecordRef self,
                        MCTypeInfoRef p_base_typeinfo,
                        MCRecordRef & r_new_record)
@@ -258,7 +267,7 @@ MCRecordCopyAsBaseType(MCRecordRef self,
 	return t_success;
 }
 
-bool
+MC_DLLEXPORT bool
 MCRecordCopyAsBaseTypeAndRelease(MCRecordRef self,
                                  MCTypeInfoRef p_base_typeinfo,
                                  MCRecordRef & r_new_record)
@@ -285,7 +294,7 @@ MCRecordCopyAsBaseTypeAndRelease(MCRecordRef self,
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCRecordCopyAsDerivedType(MCRecordRef self,
                           MCTypeInfoRef p_derived_typeinfo,
                           MCRecordRef & r_new_record)
@@ -299,7 +308,7 @@ MCRecordCopyAsDerivedType(MCRecordRef self,
 	return t_success;
 }
 
-bool
+MC_DLLEXPORT bool
 MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef self,
                                     MCTypeInfoRef p_derived_typeinfo,
                                     MCRecordRef & r_new_record)
@@ -344,7 +353,7 @@ MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef self,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool
+MC_DLLEXPORT bool
 MCRecordEncodeAsArray(MCRecordRef record,
                       MCArrayRef & r_array)
 {
@@ -377,7 +386,7 @@ MCRecordEncodeAsArray(MCRecordRef record,
 	return MCArrayCopyAndRelease (t_new_array, r_array);
 }
 
-bool
+MC_DLLEXPORT bool
 MCRecordDecodeFromArray(MCArrayRef array,
                         MCTypeInfoRef p_typeinfo,
                         MCRecordRef & r_record)
@@ -409,7 +418,7 @@ MCRecordDecodeFromArray(MCArrayRef array,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool
+MC_DLLEXPORT bool
 MCRecordIterate(MCRecordRef record,
                 uintptr_t& x_iterator,
                 MCNameRef& r_field_name,

--- a/libfoundation/src/foundation-set.cpp
+++ b/libfoundation/src/foundation-set.cpp
@@ -24,11 +24,13 @@ static bool __MCSetClone(MCSetRef self, bool as_mutable, MCSetRef& r_new_self);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCSetCreateSingleton(uindex_t p_element, MCSetRef& r_set)
 {
 	return MCSetCreateWithIndices(&p_element, 1, r_set);
 }
 
+MC_DLLEXPORT
 bool MCSetCreateWithIndices(uindex_t *p_elements, uindex_t p_element_count, MCSetRef& r_set)
 {
 	MCSetRef t_set;
@@ -41,6 +43,7 @@ bool MCSetCreateWithIndices(uindex_t *p_elements, uindex_t p_element_count, MCSe
 	return MCSetCopyAndRelease(t_set, r_set);
 }
 
+MC_DLLEXPORT
 bool MCSetCreateWithLimbsAndRelease(uindex_t *p_limbs, uindex_t p_limb_count, MCSetRef& r_set)
 {
 	__MCSet *self;
@@ -55,6 +58,7 @@ bool MCSetCreateWithLimbsAndRelease(uindex_t *p_limbs, uindex_t p_limb_count, MC
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetCreateMutable(MCSetRef& r_set)
 {
 	__MCSet *self;
@@ -70,6 +74,7 @@ bool MCSetCreateMutable(MCSetRef& r_set)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCSetCopy(MCSetRef self, MCSetRef& r_new_set)
 {
 	if (!MCSetIsMutable(self))
@@ -80,6 +85,7 @@ bool MCSetCopy(MCSetRef self, MCSetRef& r_new_set)
 	return __MCSetClone(self, false, r_new_set);
 }
 
+MC_DLLEXPORT
 bool MCSetCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 {
 	if (!MCSetIsMutable(self))
@@ -98,11 +104,13 @@ bool MCSetCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 	return __MCSetClone(self, false, r_new_set);
 }
 
+MC_DLLEXPORT
 bool MCSetMutableCopy(MCSetRef self, MCSetRef& r_new_set)
 {
 	return __MCSetClone(self, true, r_new_set);
 }
 
+MC_DLLEXPORT
 bool MCSetMutableCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 {
 	if (self -> references == 1)
@@ -117,6 +125,7 @@ bool MCSetMutableCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCSetIsMutable(MCSetRef self)
 {
 	return (self -> flags & kMCSetFlagIsMutable) != 0;
@@ -124,6 +133,7 @@ bool MCSetIsMutable(MCSetRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCSetIsEmpty(MCSetRef self)
 {
 	for(uindex_t i = 0; i < self -> limb_count; i++)
@@ -132,6 +142,7 @@ bool MCSetIsEmpty(MCSetRef self)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetIsEqualTo(MCSetRef self, MCSetRef other_self)
 {
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
@@ -146,6 +157,7 @@ bool MCSetIsEqualTo(MCSetRef self, MCSetRef other_self)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetContains(MCSetRef self, MCSetRef other_self)
 {
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
@@ -159,6 +171,7 @@ bool MCSetContains(MCSetRef self, MCSetRef other_self)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetIntersects(MCSetRef self, MCSetRef other_self)
 {
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
@@ -172,6 +185,7 @@ bool MCSetIntersects(MCSetRef self, MCSetRef other_self)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCSetContainsIndex(MCSetRef self, uindex_t p_element)
 {
 	if (p_element >= self -> limb_count * 32)
@@ -181,6 +195,7 @@ bool MCSetContainsIndex(MCSetRef self, uindex_t p_element)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCSetIncludeIndex(MCSetRef self, uindex_t p_index)
 {
 	if (!MCSetIsMutable(self))
@@ -195,6 +210,7 @@ bool MCSetIncludeIndex(MCSetRef self, uindex_t p_index)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetExcludeIndex(MCSetRef self, uindex_t p_index)
 {
 	if (!MCSetIsMutable(self))
@@ -208,6 +224,7 @@ bool MCSetExcludeIndex(MCSetRef self, uindex_t p_index)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetUnion(MCSetRef self, MCSetRef p_other_set)
 {
 	if (!MCSetIsMutable(self))
@@ -222,6 +239,7 @@ bool MCSetUnion(MCSetRef self, MCSetRef p_other_set)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetDifference(MCSetRef self, MCSetRef p_other_set)
 {
 	if (!MCSetIsMutable(self))
@@ -237,6 +255,7 @@ bool MCSetDifference(MCSetRef self, MCSetRef p_other_set)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetIntersect(MCSetRef self, MCSetRef p_other_set)
 {
 	if (!MCSetIsMutable(self))
@@ -251,6 +270,7 @@ bool MCSetIntersect(MCSetRef self, MCSetRef p_other_set)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCSetIterate(MCSetRef self, uindex_t& x_iterator, uindex_t& r_element)
 {
 	while(x_iterator < self -> limb_count * 32)

--- a/libfoundation/src/foundation-stream.cpp
+++ b/libfoundation/src/foundation-stream.cpp
@@ -140,6 +140,7 @@ static MCStreamCallbacks kMCMemoryInputStreamCallbacks =
 	__MCMemoryInputStreamSeek,
 };
 
+MC_DLLEXPORT
 bool MCMemoryInputStreamCreate(const void *p_block, size_t p_size, MCStreamRef& r_stream)
 {
 	MCStreamRef t_stream;
@@ -228,6 +229,7 @@ static MCStreamCallbacks kMCMemoryOutputStreamCallbacks =
 	nil,
 };
 
+MC_DLLEXPORT
 bool MCMemoryOutputStreamCreate(MCStreamRef& r_stream)
 {
 	MCStreamRef t_stream;
@@ -245,6 +247,7 @@ bool MCMemoryOutputStreamCreate(MCStreamRef& r_stream)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCMemoryOutputStreamFinish(MCStreamRef p_stream, void*& r_buffer, size_t& r_size)
 {
 	__MCMemoryOutputStream *self;
@@ -302,6 +305,7 @@ static MCValueCustomCallbacks kMCStreamCustomValueCallbacks =
 	nil,
 };
 
+MC_DLLEXPORT
 bool MCStreamCreate(const MCStreamCallbacks *p_callbacks, size_t p_extra_bytes, MCStreamRef& r_stream)
 {
 	MCStreamRef self;
@@ -315,6 +319,7 @@ bool MCStreamCreate(const MCStreamCallbacks *p_callbacks, size_t p_extra_bytes, 
 	return true;
 }
 
+MC_DLLEXPORT
 const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self);
@@ -322,21 +327,25 @@ const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStreamIsReadable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> read != nil;
 }
 
+MC_DLLEXPORT
 bool MCStreamIsWritable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> write != nil;
 }
 
+MC_DLLEXPORT
 bool MCStreamIsMarkable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> mark != nil;
 }
 
+MC_DLLEXPORT
 bool MCStreamIsSeekable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> seek != nil;
@@ -344,6 +353,7 @@ bool MCStreamIsSeekable(MCStreamRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStreamGetAvailableForRead(MCStreamRef self, size_t& r_available)
 {
 	if (__MCStreamCallbacks(self) -> get_available_for_read == nil)
@@ -351,6 +361,7 @@ bool MCStreamGetAvailableForRead(MCStreamRef self, size_t& r_available)
 	return __MCStreamCallbacks(self) -> get_available_for_read(self, r_available);
 }
 
+MC_DLLEXPORT
 bool MCStreamRead(MCStreamRef self, void *p_buffer, size_t p_amount)
 {
 	if (__MCStreamCallbacks(self) -> read == nil)
@@ -358,6 +369,7 @@ bool MCStreamRead(MCStreamRef self, void *p_buffer, size_t p_amount)
 	return __MCStreamCallbacks(self) -> read(self, p_buffer, p_amount);
 }
 
+MC_DLLEXPORT
 bool MCStreamGetAvailableForWrite(MCStreamRef self, size_t& r_available)
 {
 	if (__MCStreamCallbacks(self) -> get_available_for_write == nil)
@@ -365,6 +377,7 @@ bool MCStreamGetAvailableForWrite(MCStreamRef self, size_t& r_available)
 	return __MCStreamCallbacks(self) -> get_available_for_write(self, r_available);
 }
 
+MC_DLLEXPORT
 bool MCStreamWrite(MCStreamRef self, const void *p_buffer, size_t p_amount)
 {
 	if (__MCStreamCallbacks(self) -> write == nil)
@@ -372,6 +385,7 @@ bool MCStreamWrite(MCStreamRef self, const void *p_buffer, size_t p_amount)
 	return __MCStreamCallbacks(self) -> write(self, p_buffer, p_amount);
 }
 
+MC_DLLEXPORT
 bool MCStreamSkip(MCStreamRef self, size_t p_amount)
 {
 	if (__MCStreamCallbacks(self) -> skip != nil)
@@ -388,6 +402,7 @@ bool MCStreamSkip(MCStreamRef self, size_t p_amount)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStreamMark(MCStreamRef self, size_t p_read_limit)
 {
 	if (__MCStreamCallbacks(self) -> mark == nil)
@@ -395,6 +410,7 @@ bool MCStreamMark(MCStreamRef self, size_t p_read_limit)
 	return __MCStreamCallbacks(self) -> mark(self, p_read_limit);
 }
 
+MC_DLLEXPORT
 bool MCStreamReset(MCStreamRef self)
 {
 	if (__MCStreamCallbacks(self) -> reset == nil)
@@ -404,6 +420,7 @@ bool MCStreamReset(MCStreamRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStreamTell(MCStreamRef self, filepos_t& r_position)
 {
 	if (__MCStreamCallbacks(self) -> tell == nil)
@@ -411,6 +428,7 @@ bool MCStreamTell(MCStreamRef self, filepos_t& r_position)
 	return __MCStreamCallbacks(self) -> tell(self, r_position);
 }
 
+MC_DLLEXPORT
 bool MCStreamSeek(MCStreamRef self, filepos_t p_position)
 {
 	if (__MCStreamCallbacks(self) -> seek == nil)
@@ -420,11 +438,13 @@ bool MCStreamSeek(MCStreamRef self, filepos_t p_position)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStreamReadUInt8(MCStreamRef self, uint8_t& r_value)
 {
 	return MCStreamRead(self, &r_value, sizeof(uint8_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamReadUInt16(MCStreamRef self, uint16_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(uint16_t)))
@@ -435,6 +455,7 @@ bool MCStreamReadUInt16(MCStreamRef self, uint16_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStreamReadUInt32(MCStreamRef self, uint32_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(uint32_t)))
@@ -445,6 +466,7 @@ bool MCStreamReadUInt32(MCStreamRef self, uint32_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStreamReadUInt64(MCStreamRef self, uint64_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(uint64_t)))
@@ -455,11 +477,13 @@ bool MCStreamReadUInt64(MCStreamRef self, uint64_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStreamReadInt8(MCStreamRef self, int8_t& r_value)
 {
 	return MCStreamRead(self, &r_value, sizeof(int8_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamReadInt16(MCStreamRef self, int16_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(int16_t)))
@@ -470,6 +494,7 @@ bool MCStreamReadInt16(MCStreamRef self, int16_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStreamReadInt32(MCStreamRef self, int32_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(int32_t)))
@@ -480,6 +505,7 @@ bool MCStreamReadInt32(MCStreamRef self, int32_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStreamReadInt64(MCStreamRef self, int64_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(int64_t)))
@@ -490,13 +516,7 @@ bool MCStreamReadInt64(MCStreamRef self, int64_t& r_value)
 	return false;
 }
 
-bool MCStreamReadCompactUInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactUInt64(MCStreamRef stream, uint64_t& r_value);
-bool MCStreamReadCompactSInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactSInt64(MCStreamRef stream, uint64_t& r_value);
-
-bool MCStreamReadFloat(MCStreamRef stream, float& r_value);
-
+MC_DLLEXPORT
 bool MCStreamReadDouble(MCStreamRef stream, double& r_value)
 {
 	uint64_t t_bits;
@@ -510,11 +530,13 @@ bool MCStreamReadDouble(MCStreamRef stream, double& r_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStreamWriteUInt8(MCStreamRef self, uint8_t p_value)
 {
 	return MCStreamWrite(self, &p_value, sizeof(uint8_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamWriteUInt16(MCStreamRef self, uint16_t p_value)
 {
     uint16_t t_swapped_value;
@@ -522,6 +544,7 @@ bool MCStreamWriteUInt16(MCStreamRef self, uint16_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint16_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamWriteUInt32(MCStreamRef self, uint32_t p_value)
 {
     uint32_t t_swapped_value;
@@ -529,6 +552,7 @@ bool MCStreamWriteUInt32(MCStreamRef self, uint32_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint32_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamWriteUInt64(MCStreamRef self, uint64_t p_value)
 {
     uint64_t t_swapped_value;
@@ -536,11 +560,13 @@ bool MCStreamWriteUInt64(MCStreamRef self, uint64_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint64_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamWriteInt8(MCStreamRef self, int8_t p_value)
 {
 	return MCStreamWrite(self, &p_value, sizeof(int8_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamWriteInt16(MCStreamRef self, int16_t p_value)
 {
     uint16_t t_swapped_value;
@@ -548,6 +574,7 @@ bool MCStreamWriteInt16(MCStreamRef self, int16_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint16_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamWriteInt32(MCStreamRef self, int32_t p_value)
 {
     uint32_t t_swapped_value;
@@ -555,6 +582,7 @@ bool MCStreamWriteInt32(MCStreamRef self, int32_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint32_t));
 }
 
+MC_DLLEXPORT
 bool MCStreamWriteInt64(MCStreamRef self, int64_t p_value)
 {
     uint64_t t_swapped_value;
@@ -562,13 +590,7 @@ bool MCStreamWriteInt64(MCStreamRef self, int64_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint64_t));
 }
 
-bool MCStreamReadCompactUInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactUInt64(MCStreamRef stream, uint64_t& r_value);
-bool MCStreamReadCompactSInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactSInt64(MCStreamRef stream, uint64_t& r_value);
-
-bool MCStreamWriteFloat(MCStreamRef stream, float p_value);
-
+MC_DLLEXPORT
 bool MCStreamWriteDouble(MCStreamRef stream, double p_value)
 {
 	uint64_t t_bits;
@@ -578,6 +600,7 @@ bool MCStreamWriteDouble(MCStreamRef stream, double p_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStreamReadBoolean(MCStreamRef stream, MCBooleanRef& r_boolean)
 {
 	uint8_t t_value;
@@ -592,6 +615,7 @@ bool MCStreamReadBoolean(MCStreamRef stream, MCBooleanRef& r_boolean)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStreamReadNumber(MCStreamRef stream, MCNumberRef& r_number)
 {
 	uint8_t t_tag;
@@ -612,6 +636,7 @@ bool MCStreamReadNumber(MCStreamRef stream, MCNumberRef& r_number)
 	return MCNumberCreateWithReal(t_value, r_number);
 }
 
+MC_DLLEXPORT
 bool MCStreamReadName(MCStreamRef stream, MCNameRef& r_name)
 {
 	MCStringRef t_string;
@@ -621,6 +646,7 @@ bool MCStreamReadName(MCStreamRef stream, MCNameRef& r_name)
 	return MCNameCreateAndRelease(t_string, r_name);
 }
 
+MC_DLLEXPORT
 bool MCStreamReadString(MCStreamRef stream, MCStringRef& r_string)
 {
 	uint32_t t_length;
@@ -643,6 +669,7 @@ bool MCStreamReadString(MCStreamRef stream, MCStringRef& r_string)
 	return t_chars . CreateStringAndRelease(r_string);
 }
 
+MC_DLLEXPORT
 bool MCStreamReadArray(MCStreamRef stream, MCArrayRef& r_array)
 {
 	uint32_t t_count;
@@ -684,6 +711,7 @@ bool MCStreamReadArray(MCStreamRef stream, MCArrayRef& r_array)
 	return MCArrayCopyAndRelease(t_array, r_array);
 }
 
+MC_DLLEXPORT
 bool MCStreamReadSet(MCStreamRef stream, MCSetRef& r_set)
 {
 	uint32_t t_length;
@@ -710,6 +738,7 @@ bool MCStreamReadSet(MCStreamRef stream, MCSetRef& r_set)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStreamReadValue(MCStreamRef stream, MCValueRef& r_value)
 {
 	uint8_t t_tag;

--- a/libfoundation/src/foundation-string-cf.cpp
+++ b/libfoundation/src/foundation-string-cf.cpp
@@ -25,6 +25,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringCreateWithCFString(CFStringRef p_cf_string, MCStringRef& r_string)
 {
 	bool t_success;

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -222,6 +222,7 @@ static bool __MCStringIsEmpty(MCStringRef string)
 // This method creates a 'constant' MCStringRef from the given c-string. At some
 // point we'll make it work 'magically' at compile/build time. For now, uniquing
 // and returning that has a similar effect (if slightly slower).
+MC_DLLEXPORT
 MCStringRef MCSTR(const char *p_cstring)
 {
 	MCStringRef t_string;
@@ -237,11 +238,13 @@ MCStringRef MCSTR(const char *p_cstring)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringCreateWithCString(const char* p_cstring, MCStringRef& r_string)
 {
 	return MCStringCreateWithNativeChars((const char_t*)p_cstring, p_cstring == nil ? 0 : strlen(p_cstring), r_string);
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
 {
 	if (MCStringCreateWithNativeChars((const char_t *)p_cstring, p_cstring == nil ? 0 : strlen((const char*)p_cstring), r_string))
@@ -253,6 +256,7 @@ bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
     return false;
 }
 
+MC_DLLEXPORT
 const char *MCStringGetCString(MCStringRef p_string)
 {
     if (p_string == nil)
@@ -268,6 +272,7 @@ const char *MCStringGetCString(MCStringRef p_string)
 	return t_cstring;
 }
 
+MC_DLLEXPORT
 bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStringOptions p_options)
 {
 	return MCStringIsEqualToNativeChars(p_string, (const char_t *)p_cstring, strlen(p_cstring), p_options);
@@ -275,6 +280,7 @@ bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStr
 
 // Create an immutable string from the given bytes, interpreting them using
 // the specified encoding.
+MC_DLLEXPORT
 bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     MCAssert(!p_is_external_rep);
@@ -386,6 +392,7 @@ bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStr
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     MCStringRef t_string;
@@ -436,6 +443,7 @@ bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, M
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringCreateWithChars(const unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
     if (p_char_count == 0 && kMCEmptyString != nil)
@@ -498,6 +506,7 @@ bool MCStringCreateWithChars(const unichar_t *p_chars, uindex_t p_char_count, MC
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithCharsAndRelease(unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
     if (MCStringCreateWithChars(p_chars, p_char_count, r_string))
@@ -509,6 +518,7 @@ bool MCStringCreateWithCharsAndRelease(unichar_t *p_chars, uindex_t p_char_count
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithWString(const unichar_t *p_wstring, MCStringRef& r_string)
 {
 	uindex_t t_length;
@@ -518,6 +528,7 @@ bool MCStringCreateWithWString(const unichar_t *p_wstring, MCStringRef& r_string
 	return MCStringCreateWithChars(p_wstring, t_length, r_string);
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithWStringAndRelease(unichar_t* p_wstring, MCStringRef& r_string)
 {
 	if (MCStringCreateWithWString(p_wstring, r_string))
@@ -529,6 +540,7 @@ bool MCStringCreateWithWStringAndRelease(unichar_t* p_wstring, MCStringRef& r_st
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithNativeChars(const char_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
 	bool t_success;
@@ -566,6 +578,7 @@ bool MCStringCreateWithNativeChars(const char_t *p_chars, uindex_t p_char_count,
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithNativeCharsAndRelease(char_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
     bool t_success;
@@ -629,6 +642,7 @@ static bool MCStringCreateMutableUnicode(uindex_t p_initial_capacity, MCStringRe
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCStringCreateMutable(uindex_t p_initial_capacity, MCStringRef& r_string)
 {
 	bool t_success;
@@ -658,6 +672,7 @@ bool MCStringCreateMutable(uindex_t p_initial_capacity, MCStringRef& r_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringEncode(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is_external_rep, MCDataRef& r_data)
 {
     byte_t *t_bytes;
@@ -674,6 +689,7 @@ bool MCStringEncode(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringEncodeAndRelease(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is_external_rep, MCDataRef& r_data)
 {    
     MCDataRef t_data;
@@ -687,11 +703,13 @@ bool MCStringEncodeAndRelease(MCStringRef p_string, MCStringEncoding p_encoding,
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringDecode(MCDataRef p_data, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     return MCStringCreateWithBytes(MCDataGetBytePtr(p_data), MCDataGetLength(p_data), p_encoding, p_is_external_rep, r_string);
 }
 
+MC_DLLEXPORT
 bool MCStringDecodeAndRelease(MCDataRef p_data, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     MCStringRef t_string;
@@ -733,6 +751,7 @@ static bool __MCStringFormatSupportedForUnicode(const char *p_format)
 #define FORMAT_ARG_64_BIT 1
 #endif
 
+MC_DLLEXPORT
 bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args)
 {
 	MCStringRef t_buffer;
@@ -904,6 +923,7 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCStringFormat(MCStringRef& r_string, const char *p_format, ...)
 {
 	bool t_success;
@@ -945,6 +965,7 @@ static bool __MCStringCloneNativeBuffer(MCStringRef self, char_t*& chars, uindex
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringCopy(MCStringRef self, MCStringRef& r_new_string)
 {
 	// If the string is immutable we can just bump the reference count.
@@ -968,6 +989,7 @@ bool MCStringCopy(MCStringRef self, MCStringRef& r_new_string)
     return __MCStringCopyMutable(self, r_new_string);
 }
 
+MC_DLLEXPORT
 bool MCStringCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 {
 	// If the string is immutable we just pass it through (as we are releasing the string).
@@ -1007,6 +1029,7 @@ bool MCStringCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringMutableCopy(MCStringRef self, MCStringRef& r_new_string)
 {
 	// If self is immutable, then the new mutable string will be indirect
@@ -1026,6 +1049,7 @@ bool MCStringMutableCopy(MCStringRef self, MCStringRef& r_new_string)
     return __MCStringCreateIndirect(self -> string, r_new_string);
 }
 
+MC_DLLEXPORT
 bool MCStringMutableCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 {
 	if (self -> references == 1)
@@ -1049,6 +1073,7 @@ bool MCStringMutableCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_substring)
 {
     if (__MCStringIsIndirect(self))
@@ -1066,6 +1091,7 @@ bool MCStringCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_sub
 	return MCStringCreateWithChars(self -> chars + p_range . offset, p_range . length, r_substring);
 }
 
+MC_DLLEXPORT
 bool MCStringCopySubstringAndRelease(MCStringRef self, MCRange p_range, MCStringRef& r_substring)
 {
 	if (MCStringCopySubstring(self, p_range, r_substring))
@@ -1077,6 +1103,7 @@ bool MCStringCopySubstringAndRelease(MCStringRef self, MCRange p_range, MCString
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStringMutableCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_new_string)
 {
     if (__MCStringIsIndirect(self))
@@ -1117,6 +1144,7 @@ bool MCStringMutableCopySubstring(MCStringRef self, MCRange p_range, MCStringRef
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringMutableCopySubstringAndRelease(MCStringRef self, MCRange p_range, MCStringRef& r_new_string)
 {
 	if (MCStringMutableCopySubstring(self, p_range, r_new_string))
@@ -1130,6 +1158,7 @@ bool MCStringMutableCopySubstringAndRelease(MCStringRef self, MCRange p_range, M
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringIsMutable(const MCStringRef self)
 {
 	return (self -> flags & kMCStringFlagIsMutable) != 0;
@@ -1137,6 +1166,7 @@ bool MCStringIsMutable(const MCStringRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 uindex_t MCStringGetLength(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1145,6 +1175,7 @@ uindex_t MCStringGetLength(MCStringRef self)
     return __MCStringGetLength(self);
 }
 
+MC_DLLEXPORT
 const unichar_t *MCStringGetCharPtr(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1155,6 +1186,7 @@ const unichar_t *MCStringGetCharPtr(MCStringRef self)
 	return self -> chars;
 }
 
+MC_DLLEXPORT
 const char_t *MCStringGetNativeCharPtr(MCStringRef self)
 {
     if (MCStringIsNative(self))
@@ -1170,12 +1202,14 @@ const char_t *MCStringGetNativeCharPtr(MCStringRef self)
     return nil;
 }
 
+MC_DLLEXPORT
 const char_t *MCStringGetNativeCharPtrAndLength(MCStringRef self, uindex_t& r_char_count)
 {
     r_char_count = __MCStringNativize(self);
 	return self -> native_chars;
 }
 
+MC_DLLEXPORT
 unichar_t MCStringGetCharAtIndex(MCStringRef self, uindex_t p_index)
 {
     if (__MCStringIsIndirect(self))
@@ -1187,6 +1221,7 @@ unichar_t MCStringGetCharAtIndex(MCStringRef self, uindex_t p_index)
 	return self -> chars[p_index];
 }
 
+MC_DLLEXPORT
 char_t MCStringGetNativeCharAtIndex(MCStringRef self, uindex_t p_index)
 {
     if (__MCStringIsIndirect(self))
@@ -1201,6 +1236,7 @@ char_t MCStringGetNativeCharAtIndex(MCStringRef self, uindex_t p_index)
 	return '?';
 }
 
+MC_DLLEXPORT
 codepoint_t MCStringGetCodepointAtIndex(MCStringRef self, uindex_t p_index)
 {
 	// Calculate the code unit index for the given codepoint
@@ -1229,6 +1265,7 @@ codepoint_t MCStringGetCodepointAtIndex(MCStringRef self, uindex_t p_index)
     return MCStringSurrogatesToCodepoint(t_lead, t_trail);
 }
 
+MC_DLLEXPORT
 uindex_t MCStringGetChars(MCStringRef self, MCRange p_range, unichar_t *p_chars)
 {
     if (__MCStringIsIndirect(self))
@@ -1252,6 +1289,7 @@ uindex_t MCStringGetChars(MCStringRef self, MCRange p_range, unichar_t *p_chars)
 	return t_count;
 }
 
+MC_DLLEXPORT
 uindex_t MCStringGetNativeChars(MCStringRef self, MCRange p_range, char_t *p_chars)
 {
     if (__MCStringIsIndirect(self))
@@ -1276,11 +1314,13 @@ uindex_t MCStringGetNativeChars(MCStringRef self, MCRange p_range, char_t *p_cha
 	return t_count;
 }
 
+MC_DLLEXPORT
 void MCStringNativize(MCStringRef self)
 {
     __MCStringNativize(self);
 }
 
+MC_DLLEXPORT
 bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
 {
     // AL-2014-12-12: [[ Bug 14208 ]] Implement a native copy function to aid conversion to data
@@ -1302,6 +1342,7 @@ bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringIsNative(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1310,6 +1351,7 @@ bool MCStringIsNative(MCStringRef self)
     return __MCStringIsNative(self);
 }
 
+MC_DLLEXPORT
 bool MCStringCantBeEqualToNative(MCStringRef self, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -1318,6 +1360,7 @@ bool MCStringCantBeEqualToNative(MCStringRef self, MCStringOptions p_options)
     return __MCStringCantBeEqualToNative(self, p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringCanBeNative(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1327,6 +1370,7 @@ bool MCStringCanBeNative(MCStringRef self)
 }
 
 // AL-2015-02-06: [[ Bug 14504 ]] Ensure 'simple' flag is checked against the direct string.
+MC_DLLEXPORT
 bool MCStringIsSimple(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1336,6 +1380,7 @@ bool MCStringIsSimple(MCStringRef self)
 }
 
 // AL-2015-02-06: [[ Bug 14504 ]] Ensure 'uncombined' flag is checked against the direct string.
+MC_DLLEXPORT
 bool MCStringIsUncombined(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1344,6 +1389,7 @@ bool MCStringIsUncombined(MCStringRef self)
     return __MCStringIsUncombined(self);
 }
 
+MC_DLLEXPORT
 bool MCStringMapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &r_out_range)
 {
     if (__MCStringIsIndirect(self))
@@ -1429,6 +1475,7 @@ bool MCStringMapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringUnmapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &r_out_range)
 {    
     MCAssert(self != nil);
@@ -1533,6 +1580,7 @@ bool MCStringMapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocaleRe
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringMapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     if (__MCStringIsIndirect(self))
@@ -1559,11 +1607,13 @@ bool MCStringMapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange 
     return MCStringMapIndices(self, kMCBreakIteratorTypeCharacter, p_locale, p_in_range, r_out_range);
 }
 
+MC_DLLEXPORT
 bool MCStringCodepointIsWordPart(codepoint_t p_codepoint)
 {
     return MCUnicodeIsAlphabetic(p_codepoint) || MCUnicodeIsDigit(p_codepoint);
 }
 
+MC_DLLEXPORT
 bool MCStringMapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {    
     MCAssert(self != nil);
@@ -1613,6 +1663,7 @@ bool MCStringMapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange 
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringMapSentenceIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     return MCStringMapIndices(self, kMCBreakIteratorTypeSentence, p_locale, p_in_range, r_out_range);
@@ -1674,6 +1725,7 @@ bool MCStringUnmapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocale
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringUnmapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {    
     if (__MCStringIsIndirect(self))
@@ -1700,6 +1752,7 @@ bool MCStringUnmapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
     return MCStringUnmapIndices(self, kMCBreakIteratorTypeCharacter, p_locale, p_in_range, r_out_range);
 }
 
+MC_DLLEXPORT
 bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     MCAssert(self != nil);
@@ -1788,12 +1841,14 @@ bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringUnmapSentenceIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     return MCStringUnmapIndices(self, kMCBreakIteratorTypeSentence, p_locale, p_in_range, r_out_range);
 }
 
 extern MCLocaleRef kMCLocaleBasic;
+MC_DLLEXPORT
 bool MCStringMapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_char_range, MCRange &r_cu_range)
 {
     switch (p_type)
@@ -1813,6 +1868,7 @@ bool MCStringMapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_char
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringUnmapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_cu_range, MCRange &r_char_range)
 {
     switch (p_type)
@@ -1834,6 +1890,7 @@ bool MCStringUnmapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_cu
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringConvertToBytes(MCStringRef self, MCStringEncoding p_encoding, bool p_is_external_rep, byte_t*& r_bytes, uindex_t& r_byte_count)
 {
     MCAssert(!p_is_external_rep);
@@ -1933,6 +1990,7 @@ bool MCStringConvertToBytes(MCStringRef self, MCStringEncoding p_encoding, bool 
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char_count)
 {
     // Get the native chars, but excludes any char belonging to the extended part of the ASCII -
@@ -1954,6 +2012,7 @@ bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToUnicode(MCStringRef self, unichar_t*& r_chars, uindex_t& r_char_count)
 {
 	// Allocate an array of chars one bigger than needed. As the allocated array
@@ -1967,6 +2026,7 @@ bool MCStringConvertToUnicode(MCStringRef self, unichar_t*& r_chars, uindex_t& r
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, uindex_t& r_char_count)
 {
     MCAutoStringRef t_normalized;
@@ -1976,6 +2036,7 @@ bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, u
     return MCStringConvertToNative(*t_normalized, r_chars, r_char_count);
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToNative(MCStringRef self, char_t*& r_chars, uindex_t& r_char_count)
 {
 	// Allocate an array of chars one byte bigger than needed. As the allocated array
@@ -1989,6 +2050,7 @@ bool MCStringConvertToNative(MCStringRef self, char_t*& r_chars, uindex_t& r_cha
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring)
 {
     MCAutoStringRef t_normalized;
@@ -1998,6 +2060,7 @@ bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring)
     return MCStringConvertToCString(*t_normalized, r_cstring);
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToCString(MCStringRef p_string, char*& r_cstring)
 {
     uindex_t t_length;
@@ -2011,6 +2074,7 @@ bool MCStringConvertToCString(MCStringRef p_string, char*& r_cstring)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToWString(MCStringRef p_string, unichar_t*& r_wstring)
 {
     uindex_t t_length;
@@ -2024,12 +2088,14 @@ bool MCStringConvertToWString(MCStringRef p_string, unichar_t*& r_wstring)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToUTF8String(MCStringRef p_string, char*& r_utf8string)
 {
 	uindex_t length_is_ignored;
 	return MCStringConvertToUTF8(p_string, r_utf8string, length_is_ignored);
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToUTF8(MCStringRef p_string, char*& r_utf8string, uindex_t& r_utf8_chars)
 {
 	// Allocate an array of chars one byte bigger than needed. As the allocated array
@@ -2061,6 +2127,7 @@ bool MCStringConvertToUTF8(MCStringRef p_string, char*& r_utf8string, uindex_t& 
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_t &r_char_count)
 {
     if (MCStringIsNative(self))
@@ -2152,6 +2219,7 @@ bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_
 }
 
 #if defined(__MAC__) || defined (__IOS__)
+MC_DLLEXPORT
 bool MCStringConvertToCFStringRef(MCStringRef p_string, CFStringRef& r_cfstring)
 {
     uindex_t t_length;
@@ -2171,6 +2239,7 @@ bool MCStringConvertToCFStringRef(MCStringRef p_string, CFStringRef& r_cfstring)
 
 #if 0
 #ifdef __WINDOWS__
+MC_DLLEXPORT
 bool MCStringConvertToBSTR(MCStringRef p_string, BSTR& r_bstr)
 {
     uindex_t t_length;
@@ -2195,6 +2264,7 @@ bool MCStringConvertToBSTR(MCStringRef p_string, BSTR& r_bstr)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 hash_t MCStringHash(MCStringRef self, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2206,6 +2276,7 @@ hash_t MCStringHash(MCStringRef self, MCStringOptions p_options)
 	return MCUnicodeHash(self -> chars, self -> char_count, (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringIsEqualTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2241,11 +2312,13 @@ bool MCStringIsEqualTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_
     return MCUnicodeCompare(self -> chars, self -> char_count, self_native, p_other -> chars, p_other -> char_count, other_native, (MCUnicodeCompareOption)p_options) == 0;
 }
 
+MC_DLLEXPORT
 bool MCStringIsEmpty(MCStringRef string)
 {
 	return string == nil || MCStringGetLength(string) == 0;
 }
 
+MC_DLLEXPORT
 bool MCStringSubstringIsEqualTo(MCStringRef self, MCRange p_sub, MCStringRef p_other, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2278,6 +2351,7 @@ bool MCStringSubstringIsEqualTo(MCStringRef self, MCRange p_sub, MCStringRef p_o
     return MCUnicodeCompare(self_chars, p_sub . length, self_native, p_other -> chars, p_other -> char_count, __MCStringIsNative(p_other), (MCUnicodeCompareOption)p_options) == 0;
 }
 
+MC_DLLEXPORT
 bool MCStringSubstringIsEqualToSubstring(MCStringRef self, MCRange p_sub, MCStringRef p_other, MCRange p_other_sub, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2313,6 +2387,7 @@ bool MCStringSubstringIsEqualToSubstring(MCStringRef self, MCRange p_sub, MCStri
     return MCUnicodeCompare(self_chars, p_sub . length, self_native, other_chars, p_other_sub . length, other_native, (MCUnicodeCompareOption)p_options) == 0;
 }
 
+MC_DLLEXPORT
 bool MCStringIsEqualToNativeChars(MCStringRef self, const char_t *p_chars, uindex_t p_char_count, MCStringOptions p_options)
 {
     if (MCStringIsNative(self))
@@ -2334,6 +2409,7 @@ bool MCStringIsEqualToNativeChars(MCStringRef self, const char_t *p_chars, uinde
 	return MCStringIsEqualTo(self, *t_string, p_options);
 }
 
+MC_DLLEXPORT
 compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2345,6 +2421,7 @@ compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptio
     return MCUnicodeCompare(self -> chars, self -> char_count, __MCStringIsNative(self), p_other -> chars, p_other -> char_count, __MCStringIsNative(p_other), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringBeginsWith(MCStringRef self, MCStringRef p_prefix, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2373,6 +2450,7 @@ bool MCStringBeginsWith(MCStringRef self, MCStringRef p_prefix, MCStringOptions 
     return MCUnicodeBeginsWith(self -> chars, self -> char_count, __MCStringIsNative(self), p_prefix -> chars, p_prefix -> char_count, __MCStringIsNative(p_prefix), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefix, MCStringOptions p_options, uindex_t& r_self_match_length)
 {
     if (__MCStringIsIndirect(self))
@@ -2412,6 +2490,7 @@ bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefi
     return t_prefix_share == __MCStringGetLength(p_prefix);
 }
 
+MC_DLLEXPORT
 bool MCStringBeginsWithCString(MCStringRef self, const char_t *p_prefix_cstring, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2433,6 +2512,7 @@ bool MCStringBeginsWithCString(MCStringRef self, const char_t *p_prefix_cstring,
 	return MCStringBeginsWith(self, *t_string, p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringEndsWith(MCStringRef self, MCStringRef p_suffix, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2462,6 +2542,7 @@ bool MCStringEndsWith(MCStringRef self, MCStringRef p_suffix, MCStringOptions p_
     return MCUnicodeEndsWith(self -> chars, self -> char_count, __MCStringIsNative(self), p_suffix -> chars, p_suffix -> char_count, __MCStringIsNative(p_suffix), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffix, MCStringOptions p_options, uindex_t& r_self_match_length)
 {
     if (__MCStringIsIndirect(self))
@@ -2501,6 +2582,7 @@ bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffi
     return t_suffix_share == MCStringGetLength(p_suffix);
 }
 
+MC_DLLEXPORT
 bool MCStringEndsWithCString(MCStringRef self, const char_t *p_suffix_cstring, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2522,6 +2604,7 @@ bool MCStringEndsWithCString(MCStringRef self, const char_t *p_suffix_cstring, M
 	return MCStringEndsWith(self, *t_string, p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringContains(MCStringRef self, MCStringRef p_needle, MCStringOptions p_options)
 {
     if (MCStringIsEmpty(p_needle))
@@ -2561,6 +2644,7 @@ bool MCStringContains(MCStringRef self, MCStringRef p_needle, MCStringOptions p_
     return MCUnicodeContains(self -> chars, self -> char_count, __MCStringIsNative(self), p_needle -> chars, p_needle -> char_count, __MCStringIsNative(p_needle), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT
 bool MCStringSubstringContains(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(p_needle))
@@ -2612,12 +2696,13 @@ bool MCStringSubstringContains(MCStringRef self, MCRange p_range, MCStringRef p_
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringFirstIndexOf(MCStringRef self, MCStringRef p_needle, uindex_t p_after, MCStringOptions p_options, uindex_t& r_offset)
 {
     return MCStringFirstIndexOfStringInRange(self, p_needle, MCRangeMake(p_after, UINDEX_MAX), p_options, r_offset);
 }
 
-
+MC_DLLEXPORT
 bool MCStringFirstIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2672,11 +2757,13 @@ bool MCStringFirstIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, M
     return t_result;
 }
 
+MC_DLLEXPORT
 bool MCStringFirstIndexOfChar(MCStringRef self, codepoint_t p_needle, uindex_t p_after, MCStringOptions p_options, uindex_t& r_offset)
 {
     return MCStringFirstIndexOfCharInRange(self, p_needle, MCRangeMake(p_after, self -> char_count - p_after), p_options, r_offset);
 }
 
+MC_DLLEXPORT
 bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2720,11 +2807,13 @@ bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCR
     return t_result;
 }
 
+MC_DLLEXPORT
 bool MCStringLastIndexOf(MCStringRef self, MCStringRef p_needle, uindex_t p_before, MCStringOptions p_options, uindex_t& r_offset)
 {
     return MCStringLastIndexOfStringInRange(self, p_needle, MCRangeMake(0, p_before), p_options, r_offset);
 }
 
+MC_DLLEXPORT
 bool MCStringLastIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2798,6 +2887,7 @@ bool MCStringLastIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, MC
     return MCUnicodeLastIndexOf(self -> chars + p_range . offset, p_range . length, __MCStringIsNative(self), p_needle -> chars, p_needle -> char_count, __MCStringIsNative(p_needle), (MCUnicodeCompareOption)p_options, r_offset);
 }
 
+MC_DLLEXPORT
 bool MCStringLastIndexOfChar(MCStringRef self, codepoint_t p_needle, uindex_t p_before, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2888,6 +2978,7 @@ static bool MCStringFindNative(MCStringRef self, MCRange p_range, MCStringRef p_
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCStringFind(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options, MCRange *r_result)
 {
     if (__MCStringIsIndirect(self))
@@ -3018,6 +3109,7 @@ static uindex_t MCStringCountStrChars(MCStringRef self, MCRange p_range, const v
 	return t_count;
 }
 
+MC_DLLEXPORT
 uindex_t MCStringCount(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(p_needle))
@@ -3037,6 +3129,7 @@ uindex_t MCStringCount(MCStringRef self, MCRange p_range, MCStringRef p_needle, 
     return t_count;
 }
 
+MC_DLLEXPORT
 uindex_t MCStringCountChar(MCStringRef self, MCRange p_range, codepoint_t p_needle, MCStringOptions p_options)
 {
 	// We only support ASCII for now.
@@ -3058,6 +3151,7 @@ uindex_t MCStringCountChar(MCStringRef self, MCRange p_range, codepoint_t p_need
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringDivideAtChar(MCStringRef self, codepoint_t p_separator, MCStringOptions p_options, MCStringRef& r_head, MCStringRef& r_tail)
 {
 	uindex_t t_offset;
@@ -3074,6 +3168,7 @@ bool MCStringDivideAtChar(MCStringRef self, codepoint_t p_separator, MCStringOpt
 	return MCStringDivideAtIndex(self, t_offset, r_head, r_tail);
 }
 
+MC_DLLEXPORT
 bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_head, MCStringRef& r_tail)
 {
 	MCStringRef t_head;
@@ -3095,6 +3190,7 @@ bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_h
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringBreakIntoChunks(MCStringRef self, codepoint_t p_separator, MCStringOptions p_options, MCRange*& r_ranges, uindex_t& r_range_count)
 {
 	MCAssert(p_separator < 128);
@@ -3147,6 +3243,7 @@ bool MCStringBreakIntoChunks(MCStringRef self, codepoint_t p_separator, MCString
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringFold(MCStringRef self, MCStringOptions p_options)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3184,6 +3281,7 @@ bool MCStringFold(MCStringRef self, MCStringOptions p_options)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringLowercase(MCStringRef self, MCLocaleRef p_locale)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3216,6 +3314,7 @@ bool MCStringLowercase(MCStringRef self, MCLocaleRef p_locale)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringUppercase(MCStringRef self, MCLocaleRef p_locale)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3250,6 +3349,7 @@ bool MCStringUppercase(MCStringRef self, MCLocaleRef p_locale)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringAppend(MCStringRef self, MCStringRef p_suffix)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3272,6 +3372,7 @@ bool MCStringAppend(MCStringRef self, MCStringRef p_suffix)
 	return MCStringAppend(self, *t_suffix_copy);
 }
 
+MC_DLLEXPORT
 bool MCStringAppendSubstring(MCStringRef self, MCStringRef p_suffix, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3296,6 +3397,7 @@ bool MCStringAppendSubstring(MCStringRef self, MCStringRef p_suffix, MCRange p_r
     MCStringAppend(self, *t_suffix_substring);
 }
 
+MC_DLLEXPORT
 bool MCStringAppendNativeChars(MCStringRef self, const char_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3331,6 +3433,7 @@ bool MCStringAppendNativeChars(MCStringRef self, const char_t *p_chars, uindex_t
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringAppendChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3383,17 +3486,19 @@ bool MCStringAppendChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringAppendNativeChar(MCStringRef self, char_t p_char)
 {
 	return MCStringAppendNativeChars(self, &p_char, 1);
 }
 
+MC_DLLEXPORT
 bool MCStringAppendChar(MCStringRef self, unichar_t p_char)
 {
 	return MCStringAppendChars(self, &p_char, 1);
 }
 
-bool
+MC_DLLEXPORT bool
 MCStringAppendCodepoint (MCStringRef self, codepoint_t p_codepoint)
 {
 	uindex_t t_num_units;
@@ -3402,6 +3507,7 @@ MCStringAppendCodepoint (MCStringRef self, codepoint_t p_codepoint)
 	return MCStringAppendChars (self, t_units, t_num_units);
 }
 
+MC_DLLEXPORT
 bool MCStringPrepend(MCStringRef self, MCStringRef p_prefix)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3424,6 +3530,7 @@ bool MCStringPrepend(MCStringRef self, MCStringRef p_prefix)
 	return MCStringPrepend(self, *t_prefix_copy);
 }
 
+MC_DLLEXPORT
 bool MCStringPrependSubstring(MCStringRef self, MCStringRef p_prefix, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3448,6 +3555,7 @@ bool MCStringPrependSubstring(MCStringRef self, MCStringRef p_prefix, MCRange p_
     MCStringPrepend(self, *t_prefix_substring);
 }
 
+MC_DLLEXPORT
 bool MCStringPrependNativeChars(MCStringRef self, const char_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3479,6 +3587,7 @@ bool MCStringPrependNativeChars(MCStringRef self, const char_t *p_chars, uindex_
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringPrependChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3530,17 +3639,19 @@ bool MCStringPrependChars(MCStringRef self, const unichar_t *p_chars, uindex_t p
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringPrependNativeChar(MCStringRef self, char_t p_char)
 {
 	return MCStringPrependNativeChars(self, &p_char, 1);
 }
 
+MC_DLLEXPORT
 bool MCStringPrependChar(MCStringRef self, unichar_t p_char)
 {
 	return MCStringPrependChars(self, &p_char, 1);
 }
 
-bool
+MC_DLLEXPORT bool
 MCStringPrependCodepoint (MCStringRef self, codepoint_t p_codepoint)
 {
 	uindex_t t_num_units;
@@ -3549,6 +3660,7 @@ MCStringPrependCodepoint (MCStringRef self, codepoint_t p_codepoint)
 	return MCStringPrependChars (self, t_units, t_num_units);
 }
 
+MC_DLLEXPORT
 bool MCStringInsert(MCStringRef self, uindex_t p_at, MCStringRef p_substring)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3571,6 +3683,7 @@ bool MCStringInsert(MCStringRef self, uindex_t p_at, MCStringRef p_substring)
 	return MCStringInsert(self, p_at, *t_substring_copy);
 }
 
+MC_DLLEXPORT
 bool MCStringInsertSubstring(MCStringRef self, uindex_t p_at, MCStringRef p_substring, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3593,6 +3706,7 @@ bool MCStringInsertSubstring(MCStringRef self, uindex_t p_at, MCStringRef p_subs
     MCStringInsert(self, p_at, *t_substring_substring);
 }
 
+MC_DLLEXPORT
 bool MCStringInsertNativeChars(MCStringRef self, uindex_t p_at, const char_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3626,6 +3740,7 @@ bool MCStringInsertNativeChars(MCStringRef self, uindex_t p_at, const char_t *p_
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringInsertChars(MCStringRef self, uindex_t p_at, const unichar_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3678,17 +3793,19 @@ bool MCStringInsertChars(MCStringRef self, uindex_t p_at, const unichar_t *p_cha
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringInsertNativeChar(MCStringRef self, uindex_t p_at, char_t p_char)
 {
 	return MCStringInsertNativeChars(self, p_at, &p_char, 1);
 }
 
+MC_DLLEXPORT
 bool MCStringInsertChar(MCStringRef self, uindex_t p_at, unichar_t p_char)
 {
 	return MCStringInsertChars(self, p_at, &p_char, 1);
 }
 
-bool
+MC_DLLEXPORT bool
 MCStringInsertCodepoint (MCStringRef self, uindex_t p_at, codepoint_t p_codepoint)
 {
 	uindex_t t_num_units;
@@ -3697,6 +3814,7 @@ MCStringInsertCodepoint (MCStringRef self, uindex_t p_at, codepoint_t p_codepoin
 	return MCStringInsertChars (self, p_at, t_units, t_num_units);
 }
 
+MC_DLLEXPORT
 bool MCStringRemove(MCStringRef self, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3721,6 +3839,7 @@ bool MCStringRemove(MCStringRef self, MCRange p_range)
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringSubstring(MCStringRef self, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3868,6 +3987,7 @@ bool MCStringReplaceChars(MCStringRef self, MCRange p_range, const unichar_t *p_
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringReplace(MCStringRef self, MCRange p_range, MCStringRef p_replacement)
 {
     if (__MCStringIsIndirect(p_replacement))
@@ -3888,6 +4008,7 @@ bool MCStringReplace(MCStringRef self, MCRange p_range, MCStringRef p_replacemen
 	return MCStringReplace(self, p_range, *t_replacement_copy);
 }
 
+MC_DLLEXPORT
 bool MCStringPad(MCStringRef self, uindex_t p_at, uindex_t p_count, MCStringRef p_value)
 {
     // Ensure the string is not indirect.
@@ -3910,6 +4031,7 @@ bool MCStringPad(MCStringRef self, uindex_t p_at, uindex_t p_count, MCStringRef 
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringResolvesLeftToRight(MCStringRef self)
 {
     if (MCStringIsNative(self) || MCStringCanBeNative(self))
@@ -3920,6 +4042,7 @@ bool MCStringResolvesLeftToRight(MCStringRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCStringAppendFormat(MCStringRef self, const char *p_format, ...)
 {
 	bool t_success;
@@ -3930,6 +4053,7 @@ bool MCStringAppendFormat(MCStringRef self, const char *p_format, ...)
 	return t_success;
 }
 
+MC_DLLEXPORT
 bool MCStringAppendFormatV(MCStringRef self, const char *p_format, va_list p_args)
 {
 	MCAutoStringRef t_formatted_string;
@@ -4245,6 +4369,7 @@ static void split_find_end_of_element_and_key(const void *sptr, uindex_t length,
     split_find_end_of_element(sptr, length, native, p_del, p_del_length, p_del_native, p_options, r_element_end, r_del_found_length);
 }
 
+MC_DLLEXPORT
 bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_del, MCStringOptions p_options, MCArrayRef& r_array)
 {
     if (__MCStringIsIndirect(self))
@@ -4366,6 +4491,7 @@ bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_d
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringSplitByDelimiter(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list)
 {
     if (__MCStringIsIndirect(self))
@@ -4452,6 +4578,7 @@ bool MCStringSplitByDelimiter(MCStringRef self, MCStringRef p_elem_del, MCString
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringSplitByDelimiterNative(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list)
 {
     if (__MCStringIsIndirect(self))
@@ -4507,6 +4634,7 @@ bool MCStringSplitByDelimiterNative(MCStringRef self, MCStringRef p_elem_del, MC
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringFindAndReplaceChar(MCStringRef self, codepoint_t p_pattern, codepoint_t p_replacement, MCStringOptions p_options)
 {
     // Ensure the string is not indirect.
@@ -4560,6 +4688,7 @@ bool MCStringFindAndReplaceChar(MCStringRef self, codepoint_t p_pattern, codepoi
       return true;
 }
 
+MC_DLLEXPORT
 bool MCStringFindAndReplace(MCStringRef self, MCStringRef p_pattern, MCStringRef p_replacement, MCStringOptions p_options)
 {
     // Ensure the string is not indirect.
@@ -4667,6 +4796,7 @@ bool MCStringFindAndReplace(MCStringRef self, MCStringRef p_pattern, MCStringRef
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringWildcardMatch(MCStringRef source, MCRange source_range, MCStringRef pattern, MCStringOptions p_options)
 {
     bool source_native = MCStringIsNative(source);
@@ -4998,11 +5128,13 @@ static void __MCStringChanged(MCStringRef self, uindex_t simple, uindex_t uncomb
         self -> flags |= kMCStringFlagCanBeNative;
 }
 
+MC_DLLEXPORT
 codepoint_t MCStringSurrogatesToCodepoint(unichar_t p_lead, unichar_t p_trail)
 {
     return 0x10000 + ((p_lead & 0x3FF) << 10) + (p_trail & 0x3FF);
 }
 
+MC_DLLEXPORT
 unsigned int MCStringCodepointToSurrogates(codepoint_t p_codepoint, unichar_t (&r_units)[2])
 {
     if (p_codepoint > 0xFFFF)
@@ -5019,6 +5151,7 @@ unsigned int MCStringCodepointToSurrogates(codepoint_t p_codepoint, unichar_t (&
     }
 }
 
+MC_DLLEXPORT
 bool MCStringIsValidSurrogatePair(MCStringRef self, uindex_t p_index)
 {
     if (__MCStringIsIndirect(self))
@@ -5049,13 +5182,13 @@ bool MCStringIsValidSurrogatePair(MCStringRef self, uindex_t p_index)
 	
 ////////////////////////////////////////////////////////////////////////////////
 
-MCStringRef kMCEmptyString;
-MCStringRef kMCTrueString;
-MCStringRef kMCFalseString;
-MCStringRef kMCMixedString;
-MCStringRef kMCCommaString;
-MCStringRef kMCLineEndString;
-MCStringRef kMCTabString;
+MC_DLLEXPORT MCStringRef kMCEmptyString;
+MC_DLLEXPORT MCStringRef kMCTrueString;
+MC_DLLEXPORT MCStringRef kMCFalseString;
+MC_DLLEXPORT MCStringRef kMCMixedString;
+MC_DLLEXPORT MCStringRef kMCCommaString;
+MC_DLLEXPORT MCStringRef kMCLineEndString;
+MC_DLLEXPORT MCStringRef kMCTabString;
 
 bool __MCStringInitialize(void)
 {
@@ -5180,6 +5313,7 @@ static bool do_iconv(iconv_t fd, const char *in, size_t in_len, char * &out, siz
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringCreateWithSysString(const char *p_system_string, MCStringRef &r_string)
 {
     // Is the string empty?
@@ -5238,6 +5372,7 @@ bool MCStringCreateWithSysString(const char *p_system_string, MCStringRef &r_str
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
 {
     // Create the pseudo-FD that iconv uses for character conversion. For
@@ -5376,6 +5511,7 @@ MCStringCreateWithSysString(const char *p_sys_string,
 }
 #endif
 
+MC_DLLEXPORT
 bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)
 {
     if (MCStringIsNative(self))
@@ -5391,6 +5527,7 @@ bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringNormalizedCopyNFD(MCStringRef self, MCStringRef &r_string)
 {
     // AL-2014-06-24: [[ Bug 12656 ]] Native strings can be decomposed into non-native ones.
@@ -5403,6 +5540,7 @@ bool MCStringNormalizedCopyNFD(MCStringRef self, MCStringRef &r_string)
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringNormalizedCopyNFKC(MCStringRef self, MCStringRef &r_string)
 {
     // Native strings are already normalized
@@ -5419,6 +5557,7 @@ bool MCStringNormalizedCopyNFKC(MCStringRef self, MCStringRef &r_string)
     return false;
 }
 
+MC_DLLEXPORT
 bool MCStringNormalizedCopyNFKD(MCStringRef self, MCStringRef &r_string)
 {
     // AL-2014-06-24: [[ Bug 12656 ]] Native strings can be decomposed into non-native ones.
@@ -5434,6 +5573,7 @@ bool MCStringNormalizedCopyNFKD(MCStringRef self, MCStringRef &r_string)
 
 /////////
 
+MC_DLLEXPORT
 bool MCStringSetNumericValue(MCStringRef self, double p_value)
 {
     if (__MCStringIsIndirect(self))
@@ -5463,6 +5603,7 @@ bool MCStringSetNumericValue(MCStringRef self, double p_value)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCStringGetNumericValue(MCStringRef self, double &r_value)
 {
     if (__MCStringIsIndirect(self))

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -153,6 +153,7 @@ static integer_t MCU_strtol(const char *sptr, uindex_t &l, int8_t c, bool &done,
 	return value;
 }
 
+MC_DLLEXPORT
 bool MCTypeConvertStringToLongInteger(MCStringRef p_string, integer_t& r_converted)
 {
     if (!MCStringCanBeNative(p_string))
@@ -167,6 +168,7 @@ bool MCTypeConvertStringToLongInteger(MCStringRef p_string, integer_t& r_convert
 	return t_done;
 }
 
+MC_DLLEXPORT
 bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool p_convert_octals)
 {
     if (!MCStringCanBeNative(p_string))
@@ -207,6 +209,7 @@ bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCTypeConvertStringToBool(MCStringRef p_string, bool& r_converted)
 {
     if (MCStringIsEqualTo(p_string, kMCTrueString, kMCStringOptionCompareCaseless))

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -23,17 +23,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCAnyTypeInfo;
-MCTypeInfoRef kMCNullTypeInfo;
-MCTypeInfoRef kMCBooleanTypeInfo;
-MCTypeInfoRef kMCNumberTypeInfo;
-MCTypeInfoRef kMCStringTypeInfo;
-MCTypeInfoRef kMCNameTypeInfo;
-MCTypeInfoRef kMCDataTypeInfo;
-MCTypeInfoRef kMCArrayTypeInfo;
-MCTypeInfoRef kMCSetTypeInfo;
-MCTypeInfoRef kMCListTypeInfo;
-MCTypeInfoRef kMCProperListTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCAnyTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCNullTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCBooleanTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCNumberTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCStringTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCNameTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCDataTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCArrayTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCSetTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCListTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCProperListTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -49,46 +49,55 @@ static intenum_t __MCTypeInfoGetExtendedTypeCode(MCTypeInfoRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCTypeInfoIsAlias(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsAlias;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoIsNamed(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsNamed;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoIsOptional(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsOptional;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoIsHandler(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeHandler;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoIsRecord(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeRecord;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoIsError(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeError;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoIsForeign(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsForeign;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoIsCustom(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeCustom;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoResolve(MCTypeInfoRef self, MCResolvedTypeInfo& r_resolution)
 {
     intenum_t t_ext_typecode;
@@ -130,6 +139,7 @@ bool MCTypeInfoResolve(MCTypeInfoRef self, MCResolvedTypeInfo& r_resolution)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target)
 {
     // We require that source is concrete for all but handler types (as handlers
@@ -156,6 +166,7 @@ bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target)
     return MCResolvedTypeInfoConforms(t_resolved_source, t_resolved_target);
 }
 
+MC_DLLEXPORT
 bool MCResolvedTypeInfoConforms(const MCResolvedTypeInfo& source, const MCResolvedTypeInfo& target)
 {
     // If source and target are the same, we are done - as they are named types.
@@ -271,6 +282,7 @@ bool MCResolvedTypeInfoConforms(const MCResolvedTypeInfo& source, const MCResolv
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCBuiltinTypeInfoCreate(MCValueTypeCode p_code, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -289,6 +301,7 @@ bool MCBuiltinTypeInfoCreate(MCValueTypeCode p_code, MCTypeInfoRef& r_typeinfo)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCAliasTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef p_target, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -307,11 +320,13 @@ bool MCAliasTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef p_target, MCTypeInfoR
     return false;
 }
 
+MC_DLLEXPORT
 MCNameRef MCAliasTypeInfoGetName(MCTypeInfoRef self)
 {
     return self -> alias . name;
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCAliasTypeInfoGetTarget(MCTypeInfoRef self)
 {
     return self -> alias . typeinfo;
@@ -319,6 +334,7 @@ MCTypeInfoRef MCAliasTypeInfoGetTarget(MCTypeInfoRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCNamedTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -340,21 +356,25 @@ bool MCNamedTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef& r_typeinfo)
     return false;
 }
 
+MC_DLLEXPORT
 MCNameRef MCNamedTypeInfoGetName(MCTypeInfoRef self)
 {
     return self -> named . name;
 }
 
+MC_DLLEXPORT
 bool MCNamedTypeInfoIsBound(MCTypeInfoRef self)
 {
     return self -> named . typeinfo != nil;
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCNamedTypeInfoGetBoundTypeInfo(MCTypeInfoRef self)
 {
     return self -> named . typeinfo;
 }
 
+MC_DLLEXPORT
 bool MCNamedTypeInfoBind(MCTypeInfoRef self, MCTypeInfoRef p_target)
 {
     if (self -> named . typeinfo != nil)
@@ -365,6 +385,7 @@ bool MCNamedTypeInfoBind(MCTypeInfoRef self, MCTypeInfoRef p_target)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCNamedTypeInfoUnbind(MCTypeInfoRef self)
 {
     if (self -> named . typeinfo == nil)
@@ -376,6 +397,7 @@ bool MCNamedTypeInfoUnbind(MCTypeInfoRef self)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCNamedTypeInfoResolve(MCTypeInfoRef self, MCTypeInfoRef& r_bound_type)
 {
     if (self -> named . typeinfo == nil)
@@ -388,6 +410,7 @@ bool MCNamedTypeInfoResolve(MCTypeInfoRef self, MCTypeInfoRef& r_bound_type)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCOptionalTypeInfoCreate(MCTypeInfoRef p_base, MCTypeInfoRef& r_new_type)
 {
     if (__MCTypeInfoGetExtendedTypeCode(p_base) == kMCTypeInfoTypeIsOptional)
@@ -411,6 +434,7 @@ bool MCOptionalTypeInfoCreate(MCTypeInfoRef p_base, MCTypeInfoRef& r_new_type)
     return false;
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCOptionalTypeInfoGetBaseTypeInfo(MCTypeInfoRef p_base)
 {
     return p_base -> optional . basetype;
@@ -489,6 +513,7 @@ static bool __MCForeignTypeInfoComputeLayoutType(MCTypeInfoRef self)
     return true;
 }
 
+MC_DLLEXPORT
 bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -531,11 +556,13 @@ bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCType
     return false;
 }
 
+MC_DLLEXPORT
 const MCForeignTypeDescriptor *MCForeignTypeInfoGetDescriptor(MCTypeInfoRef self)
 {
     return &self -> foreign . descriptor;
 }
 
+MC_DLLEXPORT
 void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef self)
 {
     return self -> foreign . ffi_layout_type;
@@ -543,6 +570,7 @@ void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, index_t p_field_count, MCTypeInfoRef p_base, MCTypeInfoRef& r_typeinfo)
 	
 {
@@ -594,6 +622,7 @@ bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, index_t p_fie
     return false;
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef unresolved_self)
 {
 	MCTypeInfoRef self;
@@ -602,6 +631,7 @@ MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef unresolved_self)
     return self -> record . base;
 }
 
+MC_DLLEXPORT
 uindex_t MCRecordTypeInfoGetFieldCount(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -625,6 +655,7 @@ __MCRecordTypeInfoGetFieldCount(MCTypeInfoRef self)
     return t_field_count;
 }
 
+MC_DLLEXPORT
 MCNameRef MCRecordTypeInfoGetFieldName(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -640,6 +671,7 @@ MCNameRef MCRecordTypeInfoGetFieldName(MCTypeInfoRef unresolved_self, uindex_t p
 	return t_base_type -> record . fields[t_base_index] . name;
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -655,7 +687,7 @@ MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef unresolved_self, uindex
 	return t_base_type -> record . fields[t_base_index] . type;
 }
 
-bool
+MC_DLLEXPORT bool
 MCRecordTypeInfoIsDerivedFrom(MCTypeInfoRef self,
                               MCTypeInfoRef other)
 {
@@ -693,6 +725,7 @@ __MCRecordTypeInfoGetBaseTypeForField (__MCTypeInfo *self,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *p_fields, index_t p_field_count, MCTypeInfoRef p_return_type, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -729,6 +762,7 @@ bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *p_fields, index_t p_f
     return false;
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCHandlerTypeInfoGetReturnType(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -739,6 +773,7 @@ MCTypeInfoRef MCHandlerTypeInfoGetReturnType(MCTypeInfoRef unresolved_self)
     return self -> handler . return_type;
 }
 
+MC_DLLEXPORT
 uindex_t MCHandlerTypeInfoGetParameterCount(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -749,6 +784,7 @@ uindex_t MCHandlerTypeInfoGetParameterCount(MCTypeInfoRef unresolved_self)
     return self -> handler . field_count;
 }
 
+MC_DLLEXPORT
 MCHandlerTypeFieldMode MCHandlerTypeInfoGetParameterMode(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -760,6 +796,7 @@ MCHandlerTypeFieldMode MCHandlerTypeInfoGetParameterMode(MCTypeInfoRef unresolve
     return self -> handler . fields[p_index] . mode;
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCHandlerTypeInfoGetParameterType(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -773,6 +810,7 @@ MCTypeInfoRef MCHandlerTypeInfoGetParameterType(MCTypeInfoRef unresolved_self, u
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCErrorTypeInfoCreate(MCNameRef p_domain, MCStringRef p_message, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -794,6 +832,7 @@ bool MCErrorTypeInfoCreate(MCNameRef p_domain, MCStringRef p_message, MCTypeInfo
     return true;
 }
 
+MC_DLLEXPORT
 MCNameRef MCErrorTypeInfoGetDomain(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -802,6 +841,7 @@ MCNameRef MCErrorTypeInfoGetDomain(MCTypeInfoRef unresolved_self)
     return self -> error . domain;
 }
 
+MC_DLLEXPORT
 MCStringRef MCErrorTypeInfoGetMessage(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -812,6 +852,7 @@ MCStringRef MCErrorTypeInfoGetMessage(MCTypeInfoRef unresolved_self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCNamedErrorTypeInfoCreate(MCNameRef p_name, MCNameRef p_domain, MCStringRef p_message, MCTypeInfoRef &r_typeinfo)
 {
 	MCAutoTypeInfoRef t_type, t_named_type;
@@ -830,6 +871,7 @@ bool MCNamedErrorTypeInfoCreate(MCNameRef p_name, MCNameRef p_domain, MCStringRe
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCNamedCustomTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef base, const MCValueCustomCallbacks *callbacks, MCTypeInfoRef& r_typeinfo)
 {
 	MCAutoTypeInfoRef t_type, t_named_type;
@@ -848,6 +890,7 @@ bool MCNamedCustomTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef base, const MCV
 	return true;
 }
 
+MC_DLLEXPORT
 bool MCNamedForeignTypeInfoCreate(MCNameRef p_name, const MCForeignTypeDescriptor *p_descriptor, MCTypeInfoRef& r_typeinfo)
 {
 	MCAutoTypeInfoRef t_type, t_named_type;
@@ -868,6 +911,7 @@ bool MCNamedForeignTypeInfoCreate(MCNameRef p_name, const MCForeignTypeDescripto
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCCustomTypeInfoCreate(MCTypeInfoRef p_base, const MCValueCustomCallbacks *p_callbacks, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -893,6 +937,7 @@ MCTypeInfoRef MCCustomTypeInfoGetBaseType(MCTypeInfoRef unresolved_self)
     return self -> custom . base;
 }
 
+MC_DLLEXPORT
 const MCValueCustomCallbacks *MCCustomTypeInfoGetCallbacks(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -36,6 +36,7 @@ MCTypeInfoRef __MCCustomValueResolveTypeInfo(__MCValue *p_value)
     return __MCTypeInfoResolve(t_value -> typeinfo);
 }
 
+MC_DLLEXPORT
 bool MCValueCreateCustom(MCTypeInfoRef p_typeinfo, size_t p_extra_bytes, MCValueRef& r_value)
 {
 	__MCValue *t_value;
@@ -51,6 +52,7 @@ bool MCValueCreateCustom(MCTypeInfoRef p_typeinfo, size_t p_extra_bytes, MCValue
 	return true;
 }
 
+MC_DLLEXPORT
 MCValueTypeCode MCValueGetTypeCode(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -60,6 +62,7 @@ MCValueTypeCode MCValueGetTypeCode(MCValueRef p_value)
 	return __MCValueGetTypeCode(self);
 }
 
+MC_DLLEXPORT
 MCTypeInfoRef MCValueGetTypeInfo(MCValueRef p_value)
 {
     switch(MCValueGetTypeCode(p_value))
@@ -101,6 +104,7 @@ MCTypeInfoRef MCValueGetTypeInfo(MCValueRef p_value)
     MCUnreachable();
 }
 
+MC_DLLEXPORT
 uindex_t MCValueGetRetainCount(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -110,6 +114,7 @@ uindex_t MCValueGetRetainCount(MCValueRef p_value)
     return self -> references;
 }
 
+MC_DLLEXPORT
 MCValueRef MCValueRetain(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -121,6 +126,7 @@ MCValueRef MCValueRetain(MCValueRef p_value)
 	return self;
 }
 
+MC_DLLEXPORT
 void MCValueRelease(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -137,6 +143,7 @@ void MCValueRelease(MCValueRef p_value)
 	__MCValueDestroy(self);
 }
 
+MC_DLLEXPORT
 bool MCValueCopy(MCValueRef p_value, MCValueRef& r_immutable_copy)
 {
 	__MCValue *t_copy;
@@ -149,6 +156,7 @@ bool MCValueCopy(MCValueRef p_value, MCValueRef& r_immutable_copy)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCValueCopyAndRelease(MCValueRef p_value, MCValueRef& r_immutable_copy)
 {
 	__MCValue *t_copy;
@@ -161,6 +169,7 @@ bool MCValueCopyAndRelease(MCValueRef p_value, MCValueRef& r_immutable_copy)
 	return false;
 }
 
+MC_DLLEXPORT
 hash_t MCValueHash(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -216,6 +225,7 @@ hash_t MCValueHash(MCValueRef p_value)
 	return 0;
 }
 
+MC_DLLEXPORT
 bool MCValueIsEqualTo(MCValueRef p_value, MCValueRef p_other_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -297,6 +307,7 @@ bool MCValueIsEqualTo(MCValueRef p_value, MCValueRef p_other_value)
 	return false;
 }
 
+MC_DLLEXPORT
 bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -344,6 +355,7 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
 
 //////////
 
+MC_DLLEXPORT
 bool MCValueIsMutable(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -360,6 +372,7 @@ bool MCValueIsMutable(MCValueRef p_value)
 	        __MCCustomDefaultIsMutable (p_value));
 }
 
+MC_DLLEXPORT
 bool MCValueMutableCopy(MCValueRef p_value, MCValueRef& r_mutable_copy)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -376,6 +389,7 @@ bool MCValueMutableCopy(MCValueRef p_value, MCValueRef& r_mutable_copy)
 	        __MCCustomDefaultMutableCopy (p_value, false, r_mutable_copy));
 }
 
+MC_DLLEXPORT
 bool MCValueMutableCopyAndRelease(MCValueRef p_value, MCValueRef& r_mutable_copy)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -394,6 +408,7 @@ bool MCValueMutableCopyAndRelease(MCValueRef p_value, MCValueRef& r_mutable_copy
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCValueIsUnique(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -414,6 +429,7 @@ bool MCValueIsUnique(MCValueRef p_value)
 	return (self -> flags & kMCValueFlagIsInterred) != 0;
 }
 
+MC_DLLEXPORT
 bool MCValueInter(MCValueRef p_value, MCValueRef& r_unique_value)
 {
 	// If the value is already unique then this is just a copy.
@@ -427,6 +443,7 @@ bool MCValueInter(MCValueRef p_value, MCValueRef& r_unique_value)
 	return __MCValueInter((__MCValue *)p_value, false, r_unique_value);
 }
 
+MC_DLLEXPORT
 bool MCValueInterAndRelease(MCValueRef p_value, MCValueRef& r_unique_value)
 {
 	// If the value is already unique then this is just a copy but since
@@ -1035,6 +1052,7 @@ bool __MCValueImmutableCopy(__MCValue *self, bool p_release, __MCValue*& r_new_v
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT
 bool MCBooleanCreateWithBool(bool p_value, MCBooleanRef& r_boolean)
 {
     r_boolean = MCValueRetain(p_value ? kMCTrue : kMCFalse);
@@ -1043,9 +1061,9 @@ bool MCBooleanCreateWithBool(bool p_value, MCBooleanRef& r_boolean)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCNullRef kMCNull;
-MCBooleanRef kMCTrue;
-MCBooleanRef kMCFalse;
+MC_DLLEXPORT MCNullRef kMCNull;
+MC_DLLEXPORT MCBooleanRef kMCTrue;
+MC_DLLEXPORT MCBooleanRef kMCFalse;
 
 bool __MCValueInitialize(void)
 {

--- a/libfoundation/src/system-commandline.cpp
+++ b/libfoundation/src/system-commandline.cpp
@@ -47,7 +47,7 @@ static void __MCSWindowsCommandLineFree (uindex_t &, unichar_t **& );
  * Setters and getters
  * ================================================================ */
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineGetArguments (MCProperListRef & r_arg_list)
 {
 	if (NULL != s_arguments)
@@ -57,7 +57,7 @@ MCSCommandLineGetArguments (MCProperListRef & r_arg_list)
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineSetArguments (MCProperListRef p_arg_list)
 {
 	MCAssert (NULL != p_arg_list);
@@ -66,7 +66,7 @@ MCSCommandLineSetArguments (MCProperListRef p_arg_list)
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineGetName (MCStringRef & r_name)
 {
 	if (NULL != s_name)
@@ -76,7 +76,7 @@ MCSCommandLineGetName (MCStringRef & r_name)
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineSetName (MCStringRef p_name)
 {
 	MCAssert (NULL != p_name);
@@ -85,7 +85,7 @@ MCSCommandLineSetName (MCStringRef p_name)
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineGetFilename (MCStringRef & r_filename)
 {
 	if (NULL != s_filename)
@@ -95,7 +95,7 @@ MCSCommandLineGetFilename (MCStringRef & r_filename)
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineSetFilename (MCStringRef p_filename)
 {
 	MCAssert (NULL != p_filename);
@@ -194,7 +194,7 @@ __MCSCommandLineCaptureNameAndArguments (uindex_t p_arg_count,
  * Capture command information using C argument array
  * ---------------------------------------------------------------- */
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineCapture (uindex_t p_arg_count, const char *p_arg_array[])
 {
 	return
@@ -233,7 +233,7 @@ __MCSCommandLineFinalize (void)
  * Windows-specific functions
  * ================================================================ */
 
-bool
+MC_DLLEXPORT bool
 MCSCommandLineCaptureWindows (void)
 {
 	bool t_success = true;

--- a/libfoundation/src/system-file.cpp
+++ b/libfoundation/src/system-file.cpp
@@ -107,7 +107,7 @@ __MCSFileThrowInvalidPathError (MCStringRef p_path)
  * Whole-file IO
  * ================================================================ */
 
-bool
+MC_DLLEXPORT bool
 MCSFileGetContents (MCStringRef p_path,
                     MCDataRef & r_data)
 {
@@ -115,7 +115,7 @@ MCSFileGetContents (MCStringRef p_path,
 	return __MCSFileGetContents (t_native_path, r_data);
 }
 
-bool
+MC_DLLEXPORT bool
 MCSFileSetContents (MCStringRef p_path,
                     MCDataRef p_data)
 {
@@ -127,7 +127,7 @@ MCSFileSetContents (MCStringRef p_path,
  * File streams
  * ================================================================ */
 
-bool
+MC_DLLEXPORT bool
 MCSFileCreateStream (MCStringRef p_path,
                      intenum_t p_mode,
                      MCStreamRef & r_stream)
@@ -140,21 +140,21 @@ MCSFileCreateStream (MCStringRef p_path,
  * File system operations
  * ================================================================ */
 
-bool
+MC_DLLEXPORT bool
 MCSFileDelete (MCStringRef p_path)
 {
 	MCS_FILE_CONVERT_PATH(p_path, t_native_path);
 	return __MCSFileDelete (p_path);
 }
 
-bool
+MC_DLLEXPORT bool
 MCSFileCreateDirectory (MCStringRef p_path)
 {
 	MCS_FILE_CONVERT_PATH(p_path, t_native_path);
 	return __MCSFileCreateDirectory (t_native_path);
 }
 
-bool
+MC_DLLEXPORT bool
 MCSFileDeleteDirectory (MCStringRef p_path)
 {
 	MCS_FILE_CONVERT_PATH(p_path, t_native_path);
@@ -179,7 +179,7 @@ MCSFileGetDirectoryEntries_MapCallback (void *p_context,
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCSFileGetDirectoryEntries (MCStringRef p_path,
                             MCProperListRef & r_entries)
 {
@@ -201,9 +201,9 @@ MCSFileGetDirectoryEntries (MCStringRef p_path,
  * Initialization
  * ================================================================ */
 
-MCTypeInfoRef kMCSFileIOErrorTypeInfo;
-MCTypeInfoRef kMCSFileEndOfFileErrorTypeInfo;
-MCTypeInfoRef kMCSFileInvalidPathErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCSFileIOErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCSFileEndOfFileErrorTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef kMCSFileInvalidPathErrorTypeInfo;
 
 bool
 __MCSFileInitialize (void)

--- a/libfoundation/src/system-init.cpp
+++ b/libfoundation/src/system-init.cpp
@@ -17,7 +17,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "system-private.h"
 
-bool
+MC_DLLEXPORT bool
 MCSInitialize(void)
 {
 	return
@@ -26,7 +26,7 @@ MCSInitialize(void)
 		__MCSStreamInitialize();
 }
 
-void
+MC_DLLEXPORT void
 MCSFinalize(void)
 {
 	__MCSStreamFinalize();

--- a/libfoundation/src/system-random.cpp
+++ b/libfoundation/src/system-random.cpp
@@ -32,7 +32,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * Random value generation
  * ================================================================ */
 
-bool
+MC_DLLEXPORT bool
 MCSRandomData (uindex_t p_length, MCDataRef & r_data)
 {
 	MCDataRef t_mutable;
@@ -52,7 +52,7 @@ MCSRandomData (uindex_t p_length, MCDataRef & r_data)
 	return MCDataCopyAndRelease (t_mutable, r_data);
 }
 
-real64_t
+MC_DLLEXPORT real64_t
 MCSRandomReal (void)
 {
 	real64_t t_random_bytes;

--- a/libfoundation/src/system-stream.cpp
+++ b/libfoundation/src/system-stream.cpp
@@ -426,7 +426,7 @@ __MCSStreamGetStandardStream (FILE *p_cstream,
 	return true;
 }
 
-bool
+MC_DLLEXPORT bool
 MCSStreamGetStandardOutput (MCStreamRef & r_stream)
 {
 	return __MCSStreamGetStandardStream (stdout,
@@ -434,7 +434,7 @@ MCSStreamGetStandardOutput (MCStreamRef & r_stream)
 	                                     r_stream);
 }
 
-bool
+MC_DLLEXPORT bool
 MCSStreamGetStandardInput (MCStreamRef & r_stream)
 {
 	return __MCSStreamGetStandardStream (stdin,
@@ -442,7 +442,7 @@ MCSStreamGetStandardInput (MCStreamRef & r_stream)
 	                                     r_stream);
 }
 
-bool
+MC_DLLEXPORT bool
 MCSStreamGetStandardError (MCStreamRef & r_stream)
 {
 	return __MCSStreamGetStandardStream (stderr,


### PR DESCRIPTION
The `used` attribute is needed for Emscripten builds to ensure that functions accessed by name via dlsym() and/or from JavaScript keep their names and are not removed even when aggressive optimisation is used.  It therefore makes sense to add it to the `MC_DLLEXPORT` attribute macro.

However, the `visibility` attribute can be applied to declarations or definitions, but the `used` attribute can only be applied to definitions. It's therefore cleanest to move `MC_DLLEXPORT` from function declarations (in header files) to function definitions (in source files).
