### PR TITLE
[[ WinServerCrash ]] MCS_tmpnam and MCWindowsSystem::GetTemporaryFile…

### DIFF
--- a/engine/src/srvwindows.cpp
+++ b/engine/src/srvwindows.cpp
@@ -682,6 +682,8 @@ struct MCWindowsSystem: public MCSystemInterface
 			ep . setsvalue(fname);
 		else
 			ep . setsvalue(t_long_fname);
+        
+        ep . grabsvalue();
 		
 		if (t_ptr != NULL)
 			ep.appendstringf("/%s", ++t_ptr);

--- a/engine/src/srvwindows.cpp
+++ b/engine/src/srvwindows.cpp
@@ -663,9 +663,9 @@ struct MCWindowsSystem: public MCSystemInterface
 
 		// MW-2008-06-19: Make sure fname is stored in a static to keep the (rather
 		//   unpleasant) current semantics of the call.
-		static char *fname;
-		if (fname != NULL)
-			delete fname;
+		// SN-2015-07-15: [[ ServerCrash ]] t_file in MCS_tmpnam will delete fname
+		//  outside of this function - we don't keep it as static here.
+		char *fname = NULL;
 
 		// TS-2008-06-18: [[ Bug 6403 ]] - specialFolderPath() returns 8.3 paths
 		fname = _tempnam("\\tmp", "tmp");
@@ -681,11 +681,7 @@ struct MCWindowsSystem: public MCSystemInterface
 		if (t_long_fname == nil)
 			ep . setsvalue(fname);
 		else
-		{
-			delete fname;
-			fname = t_long_fname;
-			ep . setsvalue(fname);
-		}
+			ep . setsvalue(t_long_fname);
 		
 		if (t_ptr != NULL)
 			ep.appendstringf("/%s", ++t_ptr);
@@ -693,6 +689,7 @@ struct MCWindowsSystem: public MCSystemInterface
 		// MW-2008-06-19: Make sure we delete this version of fname, since we don't
 		//   need it anymore.
 		delete fname;
+		delete t_long_fname;
 
 		// MW-2008-06-19: Use ep . getsvalue() . clone() to make sure we get a copy
 		//   of the ExecPoint's string as a NUL-terminated (C-string) string.


### PR DESCRIPTION
…name have a static char\* which ends up pointing to the same memory. They should not over-release it.

```
The temp name returned by MCWindowsSystem:GetTemporaryFilename was wrong for the fact it released fname string, inside which t_ptr points the filename leaf.
```
