### PR TITLE
[[ Bug 15592 ]] Do not leave the buffer allocated for MCMacDesktop::S…

### DIFF
--- a/docs/notes/bugfix-15592.md
+++ b/docs/notes/bugfix-15592.md
@@ -1,0 +1,1 @@
+# memory leak in shell() on Mac

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -7419,10 +7419,19 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
             close(toparent[0]);
             if (MCprocesses[index].pid != 0)
                 Kill(MCprocesses[index].pid, SIGKILL);
-            /* UNCHECKED */ MCDataCreateWithBytes((char_t*)buffer, size, r_data);
+            
+            // SN-2015-07-15: [[ Bug 15592 ]] Do not copy the buffer as we want
+            //  to take ownership of it - and ensure to free it in any case.
+            if (!MCDataCreateWithBytesAndRelease((char_t*)buffer, size, r_data))
+                free(buffer);
+
             return false;
         }
-        /* UNCHECKED */ MCDataCreateWithBytes((char_t*)buffer, size, r_data);
+        // SN-2015-07-15: [[ Bug 15592 ]] Do not copy the buffer as we want
+        //  to take ownership of it - and ensure to free it in any case.
+        if (!MCDataCreateWithBytesAndRelease((char_t*)buffer, size, r_data))
+            free(buffer);
+
         close(toparent[0]);
         CheckProcesses();
         if (MCprocesses[index].pid != 0)


### PR DESCRIPTION
…hell unfree'd
