### PR TITLE
libfoundation: Add new MC_DLLEXPORT_DEF macro.

### DIFF
--- a/engine/src/mbliphone.mm
+++ b/engine/src/mbliphone.mm
@@ -96,8 +96,8 @@ real8 curtime;
 
 ////////////////////////////////////////////////////////////////////////
 
-MC_DLLEXPORT extern "C" void *load_module(const char *);
-MC_DLLEXPORT extern "C" void *resolve_symbol(void *, const char *);
+extern "C" MC_DLLEXPORT_DEF void *load_module(const char *);
+extern "C" MC_DLLEXPORT_DEF void *resolve_symbol(void *, const char *);
 
 struct LibExport
 {
@@ -111,7 +111,8 @@ struct LibInfo
 	struct LibExport *exports;
 };
 
-void *load_module(const char *p_path) __attribute__((__visibility__("default")))
+MC_DLLEXPORT_DEF
+void *load_module(const char *p_path)
 {
 	const char *t_last_component;
 	t_last_component = strrchr(p_path, '/');

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -2028,7 +2028,7 @@ static char *my_strndup(const char * p, int n)
 
 extern "C" bool MCModulesInitialize();
 
-MC_DLLEXPORT int main(int argc, char *argv[], char *envp[])
+MC_DLLEXPORT_DEF int main(int argc, char *argv[], char *envp[])
 {
 #if defined(_DEBUG) && defined(_VALGRIND)
 	if (argc < 2 ||  (argc >= 2 && strcmp(argv[1], "-valgrind") != 0))

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -417,20 +417,20 @@ bool MCSolveQuadraticEqn(MCGFloat p_a, MCGFloat p_b, MCGFloat p_c, MCGFloat &r_x
 bool MCCanvasTypesInitialize();
 void MCCanvasTypesFinalize();
 
-MCTypeInfoRef kMCCanvasRectangleTypeInfo;
-MCTypeInfoRef kMCCanvasPointTypeInfo;
-MCTypeInfoRef kMCCanvasColorTypeInfo;
-MCTypeInfoRef kMCCanvasTransformTypeInfo;
-MCTypeInfoRef kMCCanvasImageTypeInfo;
-MCTypeInfoRef kMCCanvasPaintTypeInfo;
-MCTypeInfoRef kMCCanvasSolidPaintTypeInfo;
-MCTypeInfoRef kMCCanvasPatternTypeInfo;
-MCTypeInfoRef kMCCanvasGradientTypeInfo;
-MCTypeInfoRef kMCCanvasGradientStopTypeInfo;
-MCTypeInfoRef kMCCanvasPathTypeInfo;
-MCTypeInfoRef kMCCanvasEffectTypeInfo;
-MCTypeInfoRef kMCCanvasFontTypeInfo;
-MCTypeInfoRef kMCCanvasTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasRectangleTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasPointTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasColorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasTransformTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasPaintTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasSolidPaintTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasPatternTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasGradientTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasGradientStopTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasPathTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasEffectTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasFontTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -439,30 +439,30 @@ MCTypeInfoRef kMCCanvasTypeInfo;
 bool MCCanvasErrorsInitialize();
 void MCCanvasErrorsFinalize();
 
-MCTypeInfoRef kMCCanvasRectangleListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasPointListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasColorListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasScaleListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasTranslationListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasSkewListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasRadiiListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageSizeListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasRectangleListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasPointListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasColorListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasScaleListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasTranslationListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasSkewListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasRadiiListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageSizeListFormatErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasTransformMatrixListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasTransformDecomposeErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasTransformMatrixListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasTransformDecomposeErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
-MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasGradientStopRangeErrorTypeInfo;
-MCTypeInfoRef kMCCanvasGradientStopOrderErrorTypeInfo;
-MCTypeInfoRef kMCCanvasGradientTypeErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasGradientStopRangeErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasGradientStopOrderErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasGradientTypeErrorTypeInfo;
 
-MCTypeInfoRef kMCCanvasPathPointListFormatErrorTypeInfo;
-MCTypeInfoRef kMCCanvasSVGPathParseErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasPathPointListFormatErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasSVGPathParseErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -641,11 +641,13 @@ bool MCProperListToRectangle(MCProperListRef p_list, MCGRectangle &r_rectangle)
 
 // Constructors
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleMakeWithLTRB(MCCanvasFloat p_left, MCCanvasFloat p_top, MCCanvasFloat p_right, MCCanvasFloat p_bottom, MCCanvasRectangleRef &r_rect)
 {
 	/* UNCHECKED */ MCCanvasRectangleCreateWithMCGRectangle(MCGRectangleMake(p_left, p_top, p_right - p_left, p_bottom - p_top), r_rect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleMakeWithList(MCProperListRef p_list, MCCanvasRectangleRef &r_rect)
 {
 	MCGRectangle t_rect;
@@ -667,6 +669,7 @@ void MCCanvasRectangleSetMCGRectangle(const MCGRectangle &p_rect, MCCanvasRectan
 	MCValueRelease(t_rect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleGetLeft(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_left)
 {
 	MCGRectangle t_rect;
@@ -674,6 +677,7 @@ void MCCanvasRectangleGetLeft(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_left
 	r_left = t_rect.origin.x;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleSetLeft(MCCanvasFloat p_left, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -683,6 +687,7 @@ void MCCanvasRectangleSetLeft(MCCanvasFloat p_left, MCCanvasRectangleRef &x_rect
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleGetTop(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_top)
 {
 	MCGRectangle t_rect;
@@ -690,6 +695,7 @@ void MCCanvasRectangleGetTop(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_top)
 	r_top = t_rect.origin.y;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleSetTop(MCCanvasFloat p_top, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -699,6 +705,7 @@ void MCCanvasRectangleSetTop(MCCanvasFloat p_top, MCCanvasRectangleRef &x_rect)
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleGetRight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_right)
 {
 	MCGRectangle t_rect;
@@ -706,6 +713,7 @@ void MCCanvasRectangleGetRight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_rig
 	r_right = t_rect.origin.x + t_rect.size.width;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleSetRight(MCCanvasFloat p_right, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -715,6 +723,7 @@ void MCCanvasRectangleSetRight(MCCanvasFloat p_right, MCCanvasRectangleRef &x_re
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleGetBottom(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_bottom)
 {
 	MCGRectangle t_rect;
@@ -722,6 +731,7 @@ void MCCanvasRectangleGetBottom(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_bo
 	r_bottom = t_rect.origin.y + t_rect.size.height;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleSetBottom(MCCanvasFloat p_bottom, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -731,6 +741,7 @@ void MCCanvasRectangleSetBottom(MCCanvasFloat p_bottom, MCCanvasRectangleRef &x_
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleGetWidth(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_width)
 {
 	MCGRectangle t_rect;
@@ -738,6 +749,7 @@ void MCCanvasRectangleGetWidth(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_wid
 	r_width = t_rect.size.width;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleSetWidth(MCCanvasFloat p_width, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -747,6 +759,7 @@ void MCCanvasRectangleSetWidth(MCCanvasFloat p_width, MCCanvasRectangleRef &x_re
 	MCCanvasRectangleSetMCGRectangle(t_rect, x_rect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleGetHeight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_height)
 {
 	MCGRectangle t_rect;
@@ -754,6 +767,7 @@ void MCCanvasRectangleGetHeight(MCCanvasRectangleRef p_rect, MCCanvasFloat &r_he
 	r_height = t_rect.size.height;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRectangleSetHeight(MCCanvasFloat p_height, MCCanvasRectangleRef &x_rect)
 {
 	MCGRectangle t_rect;
@@ -862,11 +876,13 @@ bool MCProperListFromPoint(const MCGPoint &p_point, MCProperListRef &r_list)
 
 // Constructors
 
+MC_DLLEXPORT_DEF
 void MCCanvasPointMake(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPointRef &r_point)
 {
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(MCGPointMake(p_x, p_y), r_point);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPointMakeWithList(MCProperListRef p_list, MCCanvasPointRef &r_point)
 {
 	MCGPoint t_point;
@@ -887,6 +903,7 @@ void MCCanvasPointSetMCGPoint(const MCGPoint &p_point, MCCanvasPointRef &x_point
 	MCValueRelease(t_point);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPointGetX(MCCanvasPointRef p_point, MCCanvasFloat &r_x)
 {
 	MCGPoint t_point;
@@ -894,6 +911,7 @@ void MCCanvasPointGetX(MCCanvasPointRef p_point, MCCanvasFloat &r_x)
 	r_x = t_point.x;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPointSetX(MCCanvasFloat p_x, MCCanvasPointRef &x_point)
 {
 	MCGPoint t_point;
@@ -903,6 +921,7 @@ void MCCanvasPointSetX(MCCanvasFloat p_x, MCCanvasPointRef &x_point)
 	MCCanvasPointSetMCGPoint(t_point, x_point);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPointGetY(MCCanvasPointRef p_point, MCCanvasFloat &r_y)
 {
 	MCGPoint t_point;
@@ -910,6 +929,7 @@ void MCCanvasPointGetY(MCCanvasPointRef p_point, MCCanvasFloat &r_y)
 	r_y = t_point.y;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPointSetY(MCCanvasFloat p_y, MCCanvasPointRef &x_point)
 {
 	MCGPoint t_point;
@@ -1069,11 +1089,13 @@ bool MCProperListToRGBA(MCProperListRef p_list, MCCanvasFloat &r_red, MCCanvasFl
 
 // Constructors
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorMakeRGBA(MCCanvasFloat p_red, MCCanvasFloat p_green, MCCanvasFloat p_blue, MCCanvasFloat p_alpha, MCCanvasColorRef &r_color)
 {
 	/* UNCHECKED */ MCCanvasColorCreate(MCCanvasColorImplMake(p_red, p_blue, p_green, p_alpha), r_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorMakeWithList(MCProperListRef p_color, MCCanvasColorRef &r_color)
 {
 	MCCanvasFloat t_red, t_green, t_blue, t_alpha;
@@ -1096,11 +1118,13 @@ void MCCanvasColorSet(const __MCCanvasColorImpl &p_color, MCCanvasColorRef &x_co
 	MCValueRelease(t_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorGetRed(MCCanvasColorRef p_color, MCCanvasFloat &r_red)
 {
 	r_red = MCCanvasColorGetRed(p_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorSetRed(MCCanvasFloat p_red, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1113,11 +1137,13 @@ void MCCanvasColorSetRed(MCCanvasFloat p_red, MCCanvasColorRef &x_color)
 	MCCanvasColorSet(t_color, x_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorGetGreen(MCCanvasColorRef p_color, MCCanvasFloat &r_green)
 {
 	r_green = MCCanvasColorGetGreen(p_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorSetGreen(MCCanvasFloat p_green, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1130,11 +1156,13 @@ void MCCanvasColorSetGreen(MCCanvasFloat p_green, MCCanvasColorRef &x_color)
 	MCCanvasColorSet(t_color, x_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorGetBlue(MCCanvasColorRef p_color, MCCanvasFloat &r_blue)
 {
 	r_blue = MCCanvasColorGetBlue(p_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorSetBlue(MCCanvasFloat p_blue, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1147,11 +1175,13 @@ void MCCanvasColorSetBlue(MCCanvasFloat p_blue, MCCanvasColorRef &x_color)
 	MCCanvasColorSet(t_color, x_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorGetAlpha(MCCanvasColorRef p_color, MCCanvasFloat &r_alpha)
 {
 	r_alpha = MCCanvasColorGetAlpha(p_color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasColorSetAlpha(MCCanvasFloat p_alpha, MCCanvasColorRef &x_color)
 {
 	__MCCanvasColorImpl t_color;
@@ -1333,16 +1363,19 @@ void MCCanvasTransformMake(const MCGAffineTransform &p_transform, MCCanvasTransf
 	/* UNCHECKED */ MCCanvasTransformCreateWithMCGAffineTransform(p_transform, r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeIdentity(MCCanvasTransformRef &r_transform)
 {
 	r_transform = MCValueRetain(kMCCanvasIdentityTransform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeScale(MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeScale(p_xscale, p_yscale), r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeScaleWithList(MCProperListRef p_scale, MCCanvasTransformRef &r_transform)
 {
 	MCGPoint t_scale;
@@ -1352,16 +1385,19 @@ void MCCanvasTransformMakeScaleWithList(MCProperListRef p_scale, MCCanvasTransfo
 	MCCanvasTransformMakeScale(t_scale.x, t_scale.y, r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeRotation(MCCanvasFloat p_angle, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)), r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeTranslation(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeTranslation(p_x, p_y), r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeTranslationWithList(MCProperListRef p_translation, MCCanvasTransformRef &r_transform)
 {
 	MCGPoint t_translation;
@@ -1371,11 +1407,13 @@ void MCCanvasTransformMakeTranslationWithList(MCProperListRef p_translation, MCC
 	MCCanvasTransformMakeTranslation(t_translation.x, t_translation.y, r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeSkew(MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMakeSkew(p_x, p_y), r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeSkewWithList(MCProperListRef p_skew, MCCanvasTransformRef &r_transform)
 {
 	MCGPoint t_skew;
@@ -1385,11 +1423,13 @@ void MCCanvasTransformMakeSkewWithList(MCProperListRef p_skew, MCCanvasTransform
 	MCCanvasTransformMakeSkew(t_skew.x, t_skew.y, r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeWithMatrixValues(MCCanvasFloat p_a, MCCanvasFloat p_b, MCCanvasFloat p_c, MCCanvasFloat p_d, MCCanvasFloat p_tx, MCCanvasFloat p_ty, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformMake(p_a, p_b, p_c, p_d, p_tx, p_ty), r_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMakeWithMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &r_transform)
 {
 	MCGAffineTransform t_transform;
@@ -1412,11 +1452,13 @@ void MCCanvasTransformSetMCGAffineTransform(const MCGAffineTransform &p_transfor
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformGetMatrixAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_matrix)
 {
 	/* UNCHECKED */ MCProperListFromTransform(*MCCanvasTransformGet(p_transform), r_matrix);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformSetMatrixAsList(MCProperListRef p_matrix, MCCanvasTransformRef &x_transform)
 {
 	bool t_success;
@@ -1429,6 +1471,7 @@ void MCCanvasTransformSetMatrixAsList(MCProperListRef p_matrix, MCCanvasTransfor
 	MCCanvasTransformSetMCGAffineTransform(t_transform, x_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformGetInverse(MCCanvasTransformRef p_transform, MCCanvasTransformRef &r_transform)
 {
 	MCCanvasTransformMake(MCGAffineTransformInvert(*MCCanvasTransformGet(p_transform)), r_transform);
@@ -1483,6 +1526,7 @@ bool MCCanvasTransformDecompose(const MCGAffineTransform &p_transform, MCGPoint 
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformGetScaleAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_scale)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1497,6 +1541,7 @@ void MCCanvasTransformGetScaleAsList(MCCanvasTransformRef p_transform, MCProperL
 	/* UNCHECKED */ MCProperListFromPoint(t_scale, r_scale);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformSetScaleAsList(MCProperListRef p_scale, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1514,6 +1559,7 @@ void MCCanvasTransformSetScaleAsList(MCProperListRef p_scale, MCCanvasTransformR
 	MCCanvasTransformSetMCGAffineTransform(MCCanvasTransformCompose(t_scale, t_rotation, t_skew, t_translation), x_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformGetRotation(MCCanvasTransformRef p_transform, MCCanvasFloat &r_rotation)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1527,6 +1573,7 @@ void MCCanvasTransformGetRotation(MCCanvasTransformRef p_transform, MCCanvasFloa
 	r_rotation = MCCanvasAngleFromRadians(t_rotation);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformSetRotation(MCCanvasFloat p_rotation, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1541,6 +1588,7 @@ void MCCanvasTransformSetRotation(MCCanvasFloat p_rotation, MCCanvasTransformRef
 	MCCanvasTransformSetMCGAffineTransform(MCCanvasTransformCompose(t_scale, MCCanvasAngleToRadians(p_rotation), t_skew, t_translation), x_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformGetSkewAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_skew)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1555,6 +1603,7 @@ void MCCanvasTransformGetSkewAsList(MCCanvasTransformRef p_transform, MCProperLi
 	/* UNCHECKED */ MCProperListFromPoint(t_skew, r_skew);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformSetSkewAsList(MCProperListRef p_skew, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1572,6 +1621,7 @@ void MCCanvasTransformSetSkewAsList(MCProperListRef p_skew, MCCanvasTransformRef
 	MCCanvasTransformSetMCGAffineTransform(MCCanvasTransformCompose(t_scale, t_rotation, t_skew, t_translation), x_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformGetTranslationAsList(MCCanvasTransformRef p_transform, MCProperListRef &r_translation)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1586,6 +1636,7 @@ void MCCanvasTransformGetTranslationAsList(MCCanvasTransformRef p_transform, MCP
 	/* UNCHECKED */ MCProperListFromPoint(t_translation, r_translation);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformSetTranslationAsList(MCProperListRef p_translation, MCCanvasTransformRef &x_transform)
 {
 	MCGPoint t_scale, t_skew, t_translation;
@@ -1612,16 +1663,19 @@ void MCCanvasTransformConcat(MCCanvasTransformRef &x_transform, const MCGAffineT
 	MCCanvasTransformSetMCGAffineTransform(MCGAffineTransformConcat(*MCCanvasTransformGet(x_transform), p_transform), x_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformConcat(MCCanvasTransformRef &x_transform, MCCanvasTransformRef p_transform)
 {
 	MCCanvasTransformConcat(x_transform, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformScale(MCCanvasTransformRef &x_transform, MCCanvasFloat p_x_scale, MCCanvasFloat p_y_scale)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeScale(p_x_scale, p_y_scale));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformScaleWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -1631,16 +1685,19 @@ void MCCanvasTransformScaleWithList(MCCanvasTransformRef &x_transform, MCProperL
 	MCCanvasTransformScale(x_transform, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformRotate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_rotation)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_rotation)));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformTranslate(MCCanvasTransformRef &x_transform, MCCanvasFloat p_dx, MCCanvasFloat p_dy)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeTranslation(p_dx, p_dy));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformTranslateWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -1650,12 +1707,14 @@ void MCCanvasTransformTranslateWithList(MCCanvasTransformRef &x_transform, MCPro
 	MCCanvasTransformTranslate(x_transform, t_translation.x, t_translation.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformSkew(MCCanvasTransformRef &x_transform, MCCanvasFloat p_xskew, MCCanvasFloat p_yskew)
 {
 	MCCanvasTransformConcat(x_transform, MCGAffineTransformMakeSkew(p_xskew, p_yskew));
 }
 
-void MCCanvasTransformSkew(MCCanvasTransformRef &x_transform, MCProperListRef p_skew)
+MC_DLLEXPORT_DEF
+void MCCanvasTransformSkewWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_skew)
 {
 	MCGPoint t_skew;
 	if (!MCProperListToSkew(p_skew, t_skew))
@@ -1755,6 +1814,7 @@ void MCCanvasImageMake(MCImageRep *p_image, MCCanvasImageRef &r_image)
 	/* UNCHECKED */ MCCanvasImageCreateWithImageRep(p_image, r_image);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasImageMakeWithPath(MCStringRef p_path, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1770,6 +1830,7 @@ void MCCanvasImageMakeWithPath(MCStringRef p_path, MCCanvasImageRef &r_image)
 	MCImageRepRelease(t_image_rep);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasImageMakeWithResourceFile(MCStringRef p_resource, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1785,6 +1846,7 @@ void MCCanvasImageMakeWithResourceFile(MCStringRef p_resource, MCCanvasImageRef 
 	MCImageRepRelease(t_image_rep);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1801,6 +1863,7 @@ void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &r_image)
 }
 
 // Input should be unpremultiplied ARGB pixels
+MC_DLLEXPORT_DEF
 void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
@@ -1816,6 +1879,7 @@ void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRe
 	MCImageRepRelease(t_image_rep);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasImageMakeWithPixelsWithSizeAsList(MCProperListRef p_size, MCDataRef p_pixels, MCCanvasImageRef &r_image)
 {
 	integer_t t_size[2];
@@ -1830,6 +1894,7 @@ void MCCanvasImageMakeWithPixelsWithSizeAsList(MCProperListRef p_size, MCDataRef
 
 // Properties
 
+MC_DLLEXPORT_DEF
 void MCCanvasImageGetWidth(MCCanvasImageRef p_image, uint32_t &r_width)
 {
 	uint32_t t_width, t_height;
@@ -1841,6 +1906,7 @@ void MCCanvasImageGetWidth(MCCanvasImageRef p_image, uint32_t &r_width)
 	r_width = t_width;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height)
 {
 	uint32_t t_width, t_height;
@@ -1852,6 +1918,7 @@ void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height)
 	r_height = t_height;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MCDataRef &r_pixels)
 {
 	MCImageRep *t_image_rep;
@@ -1977,6 +2044,7 @@ bool MCCanvasPaintIsSolidPaint(MCCanvasPaintRef p_paint)
 
 // Constructor
 
+MC_DLLEXPORT_DEF
 void MCCanvasSolidPaintMakeWithColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &r_paint)
 {
 	/* UNCHECKED */ MCCanvasSolidPaintCreateWithColor(p_color, r_paint);
@@ -1984,11 +2052,13 @@ void MCCanvasSolidPaintMakeWithColor(MCCanvasColorRef p_color, MCCanvasSolidPain
 
 // Properties
 
+MC_DLLEXPORT_DEF
 void MCCanvasSolidPaintGetColor(MCCanvasSolidPaintRef p_paint, MCCanvasColorRef &r_color)
 {
 	r_color = MCValueRetain(MCCanvasSolidPaintGet(p_paint)->color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSolidPaintSetColor(MCCanvasColorRef p_color, MCCanvasSolidPaintRef &x_paint)
 {
 	MCCanvasSolidPaintRef t_paint;
@@ -2086,6 +2156,7 @@ void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, MCCanvasT
 	/* UNCHECKED */ MCCanvasPatternCreateWithImage(p_image, p_transform, r_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, const MCGAffineTransform &p_transform, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasTransformRef t_transform;
@@ -2097,16 +2168,19 @@ void MCCanvasPatternMakeWithTransformedImage(MCCanvasImageRef p_image, const MCG
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternMakeWithImage(MCCanvasImageRef p_image, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, kMCCanvasIdentityTransform, r_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternMakeWithScaledImage(MCCanvasImageRef p_image, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, MCGAffineTransformMakeScale(p_xscale, p_yscale), r_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternMakeWithImageScaledWithList(MCCanvasImageRef p_image, MCProperListRef p_scale, MCCanvasPatternRef &r_pattern)
 {
 	MCGPoint t_scale;
@@ -2116,16 +2190,19 @@ void MCCanvasPatternMakeWithImageScaledWithList(MCCanvasImageRef p_image, MCProp
 	MCCanvasPatternMakeWithScaledImage(p_image, t_scale.x, t_scale.y, r_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternMakeWithRotatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_angle, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)), r_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternMakeWithTranslatedImage(MCCanvasImageRef p_image, MCCanvasFloat p_x, MCCanvasFloat p_y, MCCanvasPatternRef &r_pattern)
 {
 	MCCanvasPatternMakeWithTransformedImage(p_image, MCGAffineTransformMakeTranslation(p_x, p_y), r_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternMakeWithImageTranslatedWithList(MCCanvasImageRef p_image, MCProperListRef p_translation, MCCanvasPatternRef &r_pattern)
 {
 	MCGPoint t_translation;
@@ -2147,21 +2224,25 @@ void MCCanvasPatternSet(MCCanvasImageRef p_image, MCCanvasTransformRef p_transfo
 	MCValueRelease(t_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternGetImage(MCCanvasPatternRef p_pattern, MCCanvasImageRef &r_image)
 {
 	r_image = MCValueRetain(MCCanvasPatternGet(p_pattern)->image);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternSetImage(MCCanvasImageRef p_image, MCCanvasPatternRef &x_pattern)
 {
 	MCCanvasPatternSet(p_image, MCCanvasPatternGet(x_pattern)->transform, x_pattern);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternGetTransform(MCCanvasPatternRef p_pattern, MCCanvasTransformRef &r_transform)
 {
 	r_transform = MCValueRetain(MCCanvasPatternGet(p_pattern)->transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternSetTransform(MCCanvasTransformRef p_transform, MCCanvasPatternRef &x_pattern)
 {
 	MCCanvasPatternSet(MCCanvasPatternGet(x_pattern)->image, p_transform, x_pattern);
@@ -2182,16 +2263,19 @@ void MCCanvasPatternTransform(MCCanvasPatternRef &x_pattern, const MCGAffineTran
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternTransform(MCCanvasPatternRef &x_pattern, MCCanvasTransformRef p_transform)
 {
 	MCCanvasPatternTransform(x_pattern, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternScale(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale)
 {
 	MCCanvasPatternTransform(x_pattern, MCGAffineTransformMakeScale(p_xscale, p_yscale));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternScaleWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -2201,16 +2285,19 @@ void MCCanvasPatternScaleWithList(MCCanvasPatternRef &x_pattern, MCProperListRef
 	MCCanvasPatternScale(x_pattern, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternRotate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_angle)
 {
 	MCCanvasPatternTransform(x_pattern, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternTranslate(MCCanvasPatternRef &x_pattern, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasPatternTransform(x_pattern, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPatternTranslateWithList(MCCanvasPatternRef &x_pattern, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -2297,6 +2384,7 @@ __MCCanvasGradientStopImpl *MCCanvasGradientStopGet(MCCanvasGradientStopRef p_st
 
 // Constructors
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientStopMake(MCCanvasFloat p_offset, MCCanvasColorRef p_color, MCCanvasGradientStopRef &r_stop)
 {
 	/* UNCHECKED */ MCCanvasGradientStopCreate(p_offset, p_color, r_stop);
@@ -2313,11 +2401,13 @@ void MCCanvasGradientStopSet(MCCanvasFloat p_offset, MCCanvasColorRef p_color, M
 	MCValueRelease(t_stop);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientStopGetOffset(MCCanvasGradientStopRef p_stop, MCCanvasFloat &r_offset)
 {
 	r_offset = MCCanvasGradientStopGet(p_stop)->offset;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientStopSetOffset(MCCanvasFloat p_offset, MCCanvasGradientStopRef &x_stop)
 {
 	__MCCanvasGradientStopImpl *t_stop;
@@ -2326,11 +2416,13 @@ void MCCanvasGradientStopSetOffset(MCCanvasFloat p_offset, MCCanvasGradientStopR
 	MCCanvasGradientStopSet(p_offset, t_stop->color, x_stop);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientStopGetColor(MCCanvasGradientStopRef p_stop, MCCanvasColorRef &r_color)
 {
 	r_color = MCValueRetain(MCCanvasGradientStopGet(p_stop)->color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientStopSetColor(MCCanvasColorRef p_color, MCCanvasGradientStopRef &x_stop)
 {
 	__MCCanvasGradientStopImpl *t_stop;
@@ -2486,6 +2578,7 @@ bool MCCanvasGradientCheckStopOrder(MCProperListRef p_ramp)
 
 //////////
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientEvaluateType(integer_t p_type, integer_t& r_type)
 {
     r_type = p_type;
@@ -2493,6 +2586,7 @@ void MCCanvasGradientEvaluateType(integer_t p_type, integer_t& r_type)
 
 // Constructor
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientMakeWithRamp(integer_t p_type, MCProperListRef p_ramp, MCCanvasGradientRef &r_gradient)
 {
 	MCCanvasGradientRef t_gradient;
@@ -2527,11 +2621,13 @@ void MCCanvasGradientSet(const __MCCanvasGradientImpl &p_gradient, MCCanvasGradi
 	MCValueRelease(t_gradient);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetRamp(MCCanvasGradientRef p_gradient, MCProperListRef &r_ramp)
 {
 	r_ramp = MCValueRetain(MCCanvasGradientGet(p_gradient)->ramp);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetRamp(MCProperListRef p_ramp, MCCanvasGradientRef &x_gradient)
 {
 	if (!MCCanvasGradientCheckStopOrder(p_ramp))
@@ -2545,11 +2641,13 @@ void MCCanvasGradientSetRamp(MCProperListRef p_ramp, MCCanvasGradientRef &x_grad
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetTypeAsString(MCCanvasGradientRef p_gradient, MCStringRef &r_string)
 {
 	/* UNCHECKED */ MCCanvasGradientTypeToString(MCCanvasGradientGet(p_gradient)->function, r_string);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetTypeAsString(MCStringRef p_string, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2564,11 +2662,13 @@ void MCCanvasGradientSetTypeAsString(MCStringRef p_string, MCCanvasGradientRef &
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetRepeat(MCCanvasGradientRef p_gradient, integer_t &r_repeat)
 {
 	r_repeat = MCCanvasGradientGet(p_gradient)->repeats;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetRepeat(integer_t p_repeat, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2579,11 +2679,13 @@ void MCCanvasGradientSetRepeat(integer_t p_repeat, MCCanvasGradientRef &x_gradie
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetWrap(MCCanvasGradientRef p_gradient, bool &r_wrap)
 {
 	r_wrap = MCCanvasGradientGet(p_gradient)->wrap;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetWrap(bool p_wrap, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2594,11 +2696,13 @@ void MCCanvasGradientSetWrap(bool p_wrap, MCCanvasGradientRef &x_gradient)
 	MCCanvasGradientSet(t_gradient, x_gradient);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetMirror(MCCanvasGradientRef p_gradient, bool &r_mirror)
 {
 	r_mirror = MCCanvasGradientGet(p_gradient)->mirror;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetMirror(bool p_mirror, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2659,6 +2763,7 @@ void MCCanvasGradientSetPoints(MCCanvasGradientRef &x_gradient, const MCGPoint &
 	MCCanvasGradientSetTransform(x_gradient, t_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetFrom(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_from)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2667,6 +2772,7 @@ void MCCanvasGradientGetFrom(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(t_from, r_from);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetTo(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_to)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2675,6 +2781,7 @@ void MCCanvasGradientGetTo(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_t
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(t_to, r_to);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetVia(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_via)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2683,6 +2790,7 @@ void MCCanvasGradientGetVia(MCCanvasGradientRef p_gradient, MCCanvasPointRef &r_
 	/* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(t_via, r_via);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetFrom(MCCanvasPointRef p_from, MCCanvasGradientRef &x_gradient)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2690,6 +2798,7 @@ void MCCanvasGradientSetFrom(MCCanvasPointRef p_from, MCCanvasGradientRef &x_gra
 	MCCanvasGradientSetPoints(x_gradient, *MCCanvasPointGet(p_from), t_to, t_via);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetTo(MCCanvasPointRef p_to, MCCanvasGradientRef &x_gradient)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2697,6 +2806,7 @@ void MCCanvasGradientSetTo(MCCanvasPointRef p_to, MCCanvasGradientRef &x_gradien
 	MCCanvasGradientSetPoints(x_gradient, t_from, *MCCanvasPointGet(p_to), t_via);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetVia(MCCanvasPointRef p_via, MCCanvasGradientRef &x_gradient)
 {
 	MCGPoint t_from, t_to, t_via;
@@ -2704,11 +2814,13 @@ void MCCanvasGradientSetVia(MCCanvasPointRef p_via, MCCanvasGradientRef &x_gradi
 	MCCanvasGradientSetPoints(x_gradient, t_from, t_to, *MCCanvasPointGet(p_via));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientGetTransform(MCCanvasGradientRef p_gradient, MCCanvasTransformRef &r_transform)
 {
 	r_transform = MCValueRetain(MCCanvasGradientGet(p_gradient)->transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientSetTransform(MCCanvasTransformRef p_transform, MCCanvasGradientRef &x_gradient)
 {
 	__MCCanvasGradientImpl t_gradient;
@@ -2745,6 +2857,7 @@ bool MCProperListGetGradientStopInsertionPoint(MCProperListRef p_list, MCCanvasG
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientAddStop(MCCanvasGradientStopRef p_stop, MCCanvasGradientRef &x_gradient)
 {
 	bool t_success;
@@ -2805,16 +2918,19 @@ void MCCanvasGradientTransform(MCCanvasGradientRef &x_gradient, const MCGAffineT
 	MCValueRelease(t_transform);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientTransform(MCCanvasGradientRef &x_gradient, MCCanvasTransformRef p_transform)
 {
 	MCCanvasGradientTransform(x_gradient, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientScale(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale)
 {
 	MCCanvasGradientTransform(x_gradient, MCGAffineTransformMakeScale(p_xscale, p_yscale));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientScaleWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -2824,16 +2940,19 @@ void MCCanvasGradientScaleWithList(MCCanvasGradientRef &x_gradient, MCProperList
 	MCCanvasGradientScale(x_gradient, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientRotate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_angle)
 {
 	MCCanvasGradientTransform(x_gradient, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientTranslate(MCCanvasGradientRef &x_gradient, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasGradientTransform(x_gradient, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGradientTranslateWithList(MCCanvasGradientRef &x_gradient, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -2983,6 +3102,7 @@ bool MCProperListToRadii(MCProperListRef p_list, MCGPoint &r_radii)
 
 // Constructors
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeEmpty(MCCanvasPathRef &r_path)
 {
 	r_path = MCValueRetain(kMCCanvasEmptyPath);
@@ -3152,6 +3272,7 @@ void MCCanvasPathMakeWithMCGPath(MCGPathRef p_path, MCCanvasPathRef &r_path)
 }
 
 // TODO - investigate error handling in libgraphics, libskia - don't think skia mem errors are tested for
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithInstructionsAsString(MCStringRef p_instructions, MCCanvasPathRef &r_path)
 {
 	bool t_success;
@@ -3177,6 +3298,7 @@ void MCCanvasPathMakeWithInstructionsAsString(MCStringRef p_instructions, MCCanv
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithRoundedRectangleWithRadii(MCCanvasRectangleRef p_rect, MCCanvasFloat p_x_radius, MCCanvasFloat p_y_radius, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3192,11 +3314,13 @@ void MCCanvasPathMakeWithRoundedRectangleWithRadii(MCCanvasRectangleRef p_rect, 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithRoundedRectangle(MCCanvasRectangleRef p_rect, MCCanvasFloat p_radius, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithRoundedRectangleWithRadii(p_rect, p_radius, p_radius, r_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(MCCanvasRectangleRef p_rect, MCProperListRef p_radii, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3206,6 +3330,7 @@ void MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(MCCanvasRectangleRef p_
 	MCCanvasPathMakeWithRoundedRectangleWithRadii(p_rect, t_radii.x, t_radii.y, r_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithRectangle(MCCanvasRectangleRef p_rect, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3221,6 +3346,7 @@ void MCCanvasPathMakeWithRectangle(MCCanvasRectangleRef p_rect, MCCanvasPathRef 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithEllipse(MCCanvasPointRef p_center, MCCanvasFloat p_radius_x, MCCanvasFloat p_radius_y, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3236,6 +3362,7 @@ void MCCanvasPathMakeWithEllipse(MCCanvasPointRef p_center, MCCanvasFloat p_radi
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithEllipseWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3245,11 +3372,13 @@ void MCCanvasPathMakeWithEllipseWithRadiiAsList(MCCanvasPointRef p_center, MCPro
 	MCCanvasPathMakeWithEllipse(p_center, t_radii.x, t_radii.y, r_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithCircle(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithEllipse(p_center, p_radius, p_radius, r_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithLine(MCCanvasPointRef p_start, MCCanvasPointRef p_end, MCCanvasPathRef &r_path)
 {
 	MCGPathRef t_path;
@@ -3303,6 +3432,7 @@ bool MCCanvasPointsListToMCGPoints(MCProperListRef p_points, MCGPoint *&r_points
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithPoints(bool p_close, MCProperListRef p_points, MCCanvasPathRef &r_path)
 {
 	bool t_success;
@@ -3352,11 +3482,13 @@ static void MCCanvasPathMakeWithArcWithRadii(const MCGPoint &p_center, MCGFloat 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithArcWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithArcWithRadii(*MCCanvasPointGet(p_center), p_radius, p_radius, p_start_angle, p_end_angle, r_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithArcWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3383,11 +3515,13 @@ static void MCCanvasPathMakeWithSectorWithRadii(const MCGPoint &p_center, MCGFlo
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithSectorWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithSectorWithRadii(*MCCanvasPointGet(p_center), p_radius, p_radius, p_start_angle, p_end_angle, r_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithSectorWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3413,11 +3547,13 @@ static void MCCanvasPathMakeWithSegmentWithRadii(const MCGPoint &p_center, MCGFl
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithSegmentWithRadius(MCCanvasPointRef p_center, MCCanvasFloat p_radius, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCCanvasPathMakeWithSegmentWithRadii(*MCCanvasPointGet(p_center), p_radius, p_radius, p_start_angle, p_end_angle, r_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMakeWithSegmentWithRadiiAsList(MCCanvasPointRef p_center, MCProperListRef p_radii, MCCanvasFloat p_start_angle, MCCanvasFloat p_end_angle, MCCanvasPathRef &r_path)
 {
 	MCGPoint t_radii;
@@ -3438,6 +3574,7 @@ void MCCanvasPathSetMCGPath(MCGPathRef p_path, MCCanvasPathRef &x_path)
 	MCValueRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathGetSubpaths(integer_t p_start, integer_t p_end, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpaths)
 {
 	MCGPathRef t_path;
@@ -3450,11 +3587,13 @@ void MCCanvasPathGetSubpaths(integer_t p_start, integer_t p_end, MCCanvasPathRef
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathGetSubpath(integer_t p_index, MCCanvasPathRef p_path, MCCanvasPathRef &r_subpath)
 {
 	MCCanvasPathGetSubpaths(p_index, p_index, p_path, r_subpath);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathGetBoundingBox(MCCanvasPathRef p_path, MCCanvasRectangleRef &r_bounds)
 {
 	MCGRectangle t_rect;
@@ -3463,6 +3602,7 @@ void MCCanvasPathGetBoundingBox(MCCanvasPathRef p_path, MCCanvasRectangleRef &r_
 	/* UNCHECKED */ MCCanvasRectangleCreateWithMCGRectangle(t_rect, r_bounds);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathGetInstructionsAsString(MCCanvasPathRef p_path, MCStringRef &r_instruction_string)
 {
 	MCAutoStringRef t_instruction_string;
@@ -3496,16 +3636,19 @@ void MCCanvasPathTransform(MCCanvasPathRef &x_path, const MCGAffineTransform &p_
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathTransform(MCCanvasPathRef &x_path, MCCanvasTransformRef p_transform)
 {
 	MCCanvasPathTransform(x_path, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathScale(MCCanvasPathRef &x_path, MCCanvasFloat p_xscale, MCCanvasFloat p_yscale)
 {
 	MCCanvasPathTransform(x_path, MCGAffineTransformMakeScale(p_xscale, p_yscale));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathScaleWithList(MCCanvasPathRef &x_path, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -3515,16 +3658,19 @@ void MCCanvasPathScaleWithList(MCCanvasPathRef &x_path, MCProperListRef p_scale)
 	MCCanvasPathScale(x_path, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathRotate(MCCanvasPathRef &x_path, MCCanvasFloat p_angle)
 {
 	MCCanvasPathTransform(x_path, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathTranslate(MCCanvasPathRef &x_path, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasPathTransform(x_path, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathTranslateWithList(MCCanvasPathRef &x_path, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -3534,6 +3680,7 @@ void MCCanvasPathTranslateWithList(MCCanvasPathRef &x_path, MCProperListRef p_tr
 	MCCanvasPathTranslate(x_path, t_translation.x, t_translation.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathAddPath(MCCanvasPathRef p_source, MCCanvasPathRef &x_dest)
 {
 	bool t_success;
@@ -3560,6 +3707,7 @@ void MCCanvasPathAddPath(MCCanvasPathRef p_source, MCCanvasPathRef &x_dest)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathMoveTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3586,6 +3734,7 @@ void MCCanvasPathMoveTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathLineTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3612,6 +3761,7 @@ void MCCanvasPathLineTo(MCCanvasPointRef p_point, MCCanvasPathRef &x_path)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3638,6 +3788,7 @@ void MCCanvasPathCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef 
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3664,6 +3815,7 @@ void MCCanvasPathCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointR
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathClosePath(MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3690,6 +3842,7 @@ void MCCanvasPathClosePath(MCCanvasPathRef &x_path)
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathArcTo(MCCanvasPointRef p_tangent, MCCanvasPointRef p_to, MCCanvasFloat p_radius, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3716,6 +3869,7 @@ void MCCanvasPathArcTo(MCCanvasPointRef p_tangent, MCCanvasPointRef p_to, MCCanv
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathEllipticArcToWithFlagsWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, bool p_largest, bool p_clockwise, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3746,6 +3900,7 @@ void MCCanvasPathEllipticArcToWithFlagsWithRadiiAsList(MCCanvasPointRef p_to, MC
 	MCGPathRelease(t_path);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasPathEllipticArcToWithRadiiAsList(MCCanvasPointRef p_to, MCProperListRef p_radii, MCCanvasFloat p_rotation, MCCanvasPathRef &x_path)
 {
 	bool t_success;
@@ -3899,6 +4054,7 @@ __MCCanvasEffectImpl *MCCanvasEffectGet(MCCanvasEffectRef p_effect)
 
 //////////
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectEvaluateType(integer_t p_type, integer_t& r_type)
 {
 	r_type = p_type;
@@ -3906,6 +4062,7 @@ void MCCanvasEffectEvaluateType(integer_t p_type, integer_t& r_type)
 
 // Constructors
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectMakeWithPropertyArray(integer_t p_type, MCArrayRef p_properties, MCCanvasEffectRef &r_effect)
 {
 	// TODO - defaults for missing properties?
@@ -4016,16 +4173,19 @@ bool MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectType p_type)
 	return p_type == kMCCanvasEffectTypeInnerShadow || p_type == kMCCanvasEffectTypeOuterShadow;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetTypeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_type)
 {
 	/* UNCHECKED */ MCCanvasEffectTypeToString(MCCanvasEffectGet(p_effect)->type, r_type);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetColor(MCCanvasEffectRef p_effect, MCCanvasColorRef &r_color)
 {
 	r_color = MCValueRetain(MCCanvasEffectGet(p_effect)->color);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectSetColor(MCCanvasColorRef p_color, MCCanvasEffectRef &x_effect)
 {
 	__MCCanvasEffectImpl t_effect;
@@ -4034,11 +4194,13 @@ void MCCanvasEffectSetColor(MCCanvasColorRef p_color, MCCanvasEffectRef &x_effec
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetBlendModeAsString(MCCanvasEffectRef p_effect, MCStringRef &r_blend_mode)
 {
 	/* UNCHECKED */ MCCanvasBlendModeToString(MCCanvasEffectGet(p_effect)->blend_mode, r_blend_mode);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasEffectRef &x_effect)
 {
 	__MCCanvasEffectImpl t_effect;
@@ -4051,11 +4213,13 @@ void MCCanvasEffectSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasEffect
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetOpacity(MCCanvasEffectRef p_effect, MCCanvasFloat &r_opacity)
 {
 	r_opacity = MCCanvasEffectGet(p_effect)->opacity;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectSetOpacity(MCCanvasFloat p_opacity, MCCanvasEffectRef &x_effect)
 {
 	__MCCanvasEffectImpl t_effect;
@@ -4064,6 +4228,7 @@ void MCCanvasEffectSetOpacity(MCCanvasFloat p_opacity, MCCanvasEffectRef &x_effe
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetSize(MCCanvasEffectRef p_effect, MCCanvasFloat &r_size)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(p_effect)->type))
@@ -4075,6 +4240,7 @@ void MCCanvasEffectGetSize(MCCanvasEffectRef p_effect, MCCanvasFloat &r_size)
 	r_size = MCCanvasEffectGet(p_effect)->size;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectSetSize(MCCanvasFloat p_size, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(x_effect)->type))
@@ -4089,6 +4255,7 @@ void MCCanvasEffectSetSize(MCCanvasFloat p_size, MCCanvasEffectRef &x_effect)
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetSpread(MCCanvasEffectRef p_effect, MCCanvasFloat &r_spread)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(p_effect)->type))
@@ -4100,6 +4267,7 @@ void MCCanvasEffectGetSpread(MCCanvasEffectRef p_effect, MCCanvasFloat &r_spread
 	r_spread = MCCanvasEffectGet(p_effect)->spread;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectSetSpread(MCCanvasFloat p_spread, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasSizeAndSpread(MCCanvasEffectGet(x_effect)->type))
@@ -4114,6 +4282,7 @@ void MCCanvasEffectSetSpread(MCCanvasFloat p_spread, MCCanvasEffectRef &x_effect
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetDistance(MCCanvasEffectRef p_effect, MCCanvasFloat &r_distance)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(p_effect)->type))
@@ -4125,6 +4294,7 @@ void MCCanvasEffectGetDistance(MCCanvasEffectRef p_effect, MCCanvasFloat &r_dist
 	r_distance = MCCanvasEffectGet(p_effect)->distance;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectSetDistance(MCCanvasFloat p_distance, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(x_effect)->type))
@@ -4139,6 +4309,7 @@ void MCCanvasEffectSetDistance(MCCanvasFloat p_distance, MCCanvasEffectRef &x_ef
 	MCCanvasEffectSet(t_effect, x_effect);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectGetAngle(MCCanvasEffectRef p_effect, MCCanvasFloat &r_angle)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(p_effect)->type))
@@ -4150,6 +4321,7 @@ void MCCanvasEffectGetAngle(MCCanvasEffectRef p_effect, MCCanvasFloat &r_angle)
 	r_angle = MCCanvasEffectGet(p_effect)->angle;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEffectSetAngle(MCCanvasFloat p_angle, MCCanvasEffectRef &x_effect)
 {
 	if (!MCCanvasEffectHasDistanceAndAngle(MCCanvasEffectGet(x_effect)->type))
@@ -4296,17 +4468,20 @@ bool MCCanvasFontGetDefault(MCCanvasFontRef &r_font)
 }
 
 // Constructors
+MC_DLLEXPORT_DEF
 void MCCanvasFontMakeWithSize(MCStringRef p_name, bool p_bold, bool p_italic, integer_t p_size, MCCanvasFontRef &r_font)
 {
 	/* UNCHECKED */ MCCanvasFontCreate(p_name, MCFontStyleMake(p_bold, p_italic), p_size, r_font);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontMakeWithStyle(MCStringRef p_name, bool p_bold, bool p_italic, MCCanvasFontRef &r_font)
 {
 	// TODO - confirm default font size - make configurable?
 	/* UNCHECKED */ MCCanvasFontCreate(p_name, MCFontStyleMake(p_bold, p_italic), 12, r_font);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontMake(MCStringRef p_name, MCCanvasFontRef &r_font)
 {
 	MCCanvasFontMakeWithStyle(p_name, false, false, r_font);
@@ -4334,11 +4509,13 @@ void MCCanvasFontSetProps(MCCanvasFontRef &x_font, MCStringRef p_name, MCFontSty
 	MCValueRelease(t_font);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontGetName(MCCanvasFontRef p_font, MCStringRef &r_name)
 {
 	r_name = MCValueRetain(MCNameGetString(MCFontGetName(MCCanvasFontGetMCFont(p_font))));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontSetName(MCStringRef p_name, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4349,11 +4526,13 @@ void MCCanvasFontSetName(MCStringRef p_name, MCCanvasFontRef &x_font)
 	MCCanvasFontSetProps(x_font, p_name, t_style, t_size);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontGetBold(MCCanvasFontRef p_font, bool &r_bold)
 {
 	r_bold = MCFontStyleIsBold(MCFontGetStyle(MCCanvasFontGetMCFont(p_font)));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontSetBold(bool p_bold, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4364,11 +4543,13 @@ void MCCanvasFontSetBold(bool p_bold, MCCanvasFontRef &x_font)
 	MCCanvasFontSetProps(x_font, t_name, MCFontStyleSetFlag(t_style, kMCFontStyleBold, p_bold), t_size);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontGetItalic(MCCanvasFontRef p_font, bool &r_italic)
 {
 	r_italic = MCFontStyleIsItalic(MCFontGetStyle(MCCanvasFontGetMCFont(p_font)));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontSetItalic(bool p_italic, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4379,11 +4560,13 @@ void MCCanvasFontSetItalic(bool p_italic, MCCanvasFontRef &x_font)
 	MCCanvasFontSetProps(x_font, t_name, MCFontStyleSetFlag(t_style, kMCFontStyleItalic, p_italic), t_size);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontGetSize(MCCanvasFontRef p_font, uinteger_t &r_size)
 {
 	r_size = MCFontGetSize(MCCanvasFontGetMCFont(p_font));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontSetSize(uinteger_t p_size, MCCanvasFontRef &x_font)
 {
 	MCStringRef t_name;
@@ -4414,11 +4597,13 @@ MCCanvasRectangleRef MCCanvasFontMeasureTextTypographicBoundsWithTransform(MCStr
 	return t_rect;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontMeasureTextTypographicBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect)
 {
 	r_rect = MCCanvasFontMeasureTextTypographicBoundsWithTransform(p_text, p_font, MCGAffineTransformMakeIdentity());
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontMeasureTextTypographicBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4446,11 +4631,13 @@ MCCanvasRectangleRef MCCanvasFontMeasureTextImageBoundsWithTransform(MCStringRef
 	return t_rect;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontMeasureTextImageBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect)
 {
 	r_rect = MCCanvasFontMeasureTextImageBoundsWithTransform(p_text, p_font, MCGAffineTransformMakeIdentity());
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFontMeasureTextImageBoundsOnCanvas(MCStringRef p_text, MCCanvasRef p_canvas, MCCanvasRectangleRef& r_rect)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4581,6 +4768,7 @@ bool MCCanvasPropertiesPop(__MCCanvasImpl &x_canvas)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCCanvasCreate(MCGContextRef p_context, MCCanvasRef &r_canvas)
 {
 	bool t_success;
@@ -4677,11 +4865,13 @@ static inline MCCanvasProperties &MCCanvasGetProps(MCCanvasRef p_canvas)
 	return MCCanvasGet(p_canvas)->props();
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetPaint(MCCanvasRef p_canvas, MCCanvasPaintRef &r_paint)
 {
 	r_paint = MCValueRetain(MCCanvasGetProps(p_canvas).paint);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetPaint(MCCanvasPaintRef p_paint, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4690,6 +4880,7 @@ void MCCanvasSetPaint(MCCanvasPaintRef p_paint, MCCanvasRef p_canvas)
 	t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetFillRuleAsString(MCCanvasRef p_canvas, MCStringRef &r_string)
 {
 	if (!MCCanvasFillRuleToString(MCCanvasGetProps(p_canvas).fill_rule, r_string))
@@ -4698,6 +4889,7 @@ void MCCanvasGetFillRuleAsString(MCCanvasRef p_canvas, MCStringRef &r_string)
 	}
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetFillRuleAsString(MCStringRef p_string, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4712,11 +4904,13 @@ void MCCanvasSetFillRuleAsString(MCStringRef p_string, MCCanvasRef p_canvas)
 	t_canvas->fill_rule_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetAntialias(MCCanvasRef p_canvas, bool &r_antialias)
 {
 	r_antialias = MCCanvasGetProps(p_canvas).antialias;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetAntialias(bool p_antialias, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4726,11 +4920,13 @@ void MCCanvasSetAntialias(bool p_antialias, MCCanvasRef p_canvas)
 	t_canvas->antialias_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetOpacity(MCCanvasRef p_canvas, MCCanvasFloat &r_opacity)
 {
 	r_opacity = MCCanvasGetProps(p_canvas).opacity;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetOpacity(MCCanvasFloat p_opacity, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4740,11 +4936,13 @@ void MCCanvasSetOpacity(MCCanvasFloat p_opacity, MCCanvasRef p_canvas)
 	t_canvas->opacity_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetBlendModeAsString(MCCanvasRef p_canvas, MCStringRef &r_blend_mode)
 {
 	/* UNCHECKED */ MCCanvasBlendModeToString(MCCanvasGetProps(p_canvas).blend_mode, r_blend_mode);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4754,11 +4952,13 @@ void MCCanvasSetBlendModeAsString(MCStringRef p_blend_mode, MCCanvasRef p_canvas
 	t_canvas->blend_mode_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetStippled(MCCanvasRef p_canvas, bool &r_stippled)
 {
 	r_stippled = MCCanvasGetProps(p_canvas).stippled;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetStippled(bool p_stippled, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4771,11 +4971,13 @@ void MCCanvasSetStippled(bool p_stippled, MCCanvasRef p_canvas)
 		t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetImageResizeQualityAsString(MCCanvasRef p_canvas, MCStringRef &r_quality)
 {
 	/* UNCHECKED */ MCCanvasImageFilterToString(MCCanvasGetProps(p_canvas).image_filter, r_quality);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetImageResizeQualityAsString(MCStringRef p_quality, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4787,11 +4989,13 @@ void MCCanvasSetImageResizeQualityAsString(MCStringRef p_quality, MCCanvasRef p_
 		t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetStrokeWidth(MCCanvasRef p_canvas, MCGFloat& r_stroke_width)
 {
 	r_stroke_width = MCCanvasGetProps(p_canvas).stroke_width;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetStrokeWidth(MCGFloat p_stroke_width, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -4801,21 +5005,25 @@ void MCCanvasSetStrokeWidth(MCGFloat p_stroke_width, MCCanvasRef p_canvas)
 	t_canvas->stroke_width_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetFont(MCCanvasRef p_canvas, MCCanvasFontRef &r_font)
 {
 	r_font = MCValueRetain(MCCanvasGetProps(p_canvas).font);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetFont(MCCanvasFontRef p_font, MCCanvasRef p_canvas)
 {
 	MCValueAssign(MCCanvasGetProps(p_canvas).font, p_font);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetJoinStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_join_style)
 {
 	/* UNCHECKED */ MCCanvasJoinStyleToString(MCCanvasGetProps(p_canvas).join_style, r_join_style);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetJoinStyleAsString(MCStringRef p_join_style, MCCanvasRef p_canvas)
 {
 	if (!MCCanvasJoinStyleFromString(p_join_style, MCCanvasGetProps(p_canvas).join_style))
@@ -4827,11 +5035,13 @@ void MCCanvasSetJoinStyleAsString(MCStringRef p_join_style, MCCanvasRef p_canvas
 	MCCanvasGet(p_canvas)->join_style_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetCapStyleAsString(MCCanvasRef p_canvas, MCStringRef &r_cap_style)
 {
 	/* UNCHECKED */ MCCanvasCapStyleToString(MCCanvasGetProps(p_canvas).cap_style, r_cap_style);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetCapStyleAsString(MCStringRef p_cap_style, MCCanvasRef p_canvas)
 {
 	if (!MCCanvasCapStyleFromString(p_cap_style, MCCanvasGetProps(p_canvas).cap_style))
@@ -4843,17 +5053,20 @@ void MCCanvasSetCapStyleAsString(MCStringRef p_cap_style, MCCanvasRef p_canvas)
 	MCCanvasGet(p_canvas)->cap_style_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetMiterLimit(MCCanvasRef p_canvas, MCCanvasFloat &r_limit)
 {
 	r_limit = MCCanvasGetProps(p_canvas).miter_limit;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetMiterLimit(MCCanvasFloat p_limit, MCCanvasRef p_canvas)
 {
 	MCCanvasGetProps(p_canvas).miter_limit = p_limit;
 	MCCanvasGet(p_canvas)->miter_limit_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetDashes(MCCanvasRef p_canvas, MCProperListRef &r_dashes)
 {
 	r_dashes = MCValueRetain(MCCanvasGetProps(p_canvas).dash_lengths);
@@ -4873,6 +5086,7 @@ bool MCCanvasDashesCheckList(MCProperListRef p_list)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetDashes(MCProperListRef p_dashes, MCCanvasRef p_canvas)
 {
 	if (!MCCanvasDashesCheckList(p_dashes))
@@ -4885,11 +5099,13 @@ void MCCanvasSetDashes(MCProperListRef p_dashes, MCCanvasRef p_canvas)
 	MCCanvasGet(p_canvas)->dashes_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasGetDashPhase(MCCanvasRef p_canvas, MCCanvasFloat &r_phase)
 {
 	r_phase = MCCanvasGetProps(p_canvas).dash_phase;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasSetDashPhase(MCCanvasFloat p_phase, MCCanvasRef p_canvas)
 {
 	MCCanvasGetProps(p_canvas).dash_phase = p_phase;
@@ -5090,16 +5306,19 @@ void MCCanvasTransform(MCCanvasRef p_canvas, const MCGAffineTransform &p_transfo
 		t_canvas->paint_changed = true;
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransform(MCCanvasRef p_canvas, MCCanvasTransformRef p_transform)
 {
 	MCCanvasTransform(p_canvas, *MCCanvasTransformGet(p_transform));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasScale(MCCanvasRef p_canvas, MCCanvasFloat p_scale_x, MCCanvasFloat p_scale_y)
 {
 	MCCanvasTransform(p_canvas, MCGAffineTransformMakeScale(p_scale_x, p_scale_y));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasScaleWithList(MCCanvasRef p_canvas, MCProperListRef p_scale)
 {
 	MCGPoint t_scale;
@@ -5109,16 +5328,19 @@ void MCCanvasScaleWithList(MCCanvasRef p_canvas, MCProperListRef p_scale)
 	MCCanvasScale(p_canvas, t_scale.x, t_scale.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRotate(MCCanvasRef p_canvas, MCCanvasFloat p_angle)
 {
 	MCCanvasTransform(p_canvas, MCGAffineTransformMakeRotation(MCCanvasAngleToDegrees(p_angle)));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTranslate(MCCanvasRef p_canvas, MCCanvasFloat p_x, MCCanvasFloat p_y)
 {
 	MCCanvasTransform(p_canvas, MCGAffineTransformMakeTranslation(p_x, p_y));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTranslateWithList(MCCanvasRef p_canvas, MCProperListRef p_translation)
 {
 	MCGPoint t_translation;
@@ -5130,6 +5352,7 @@ void MCCanvasTranslateWithList(MCCanvasRef p_canvas, MCProperListRef p_translati
 
 //////////
 
+MC_DLLEXPORT_DEF
 void MCCanvasSaveState(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5141,6 +5364,7 @@ void MCCanvasSaveState(MCCanvasRef p_canvas)
 	MCGContextSave(t_canvas->context);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasRestoreState(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5152,6 +5376,7 @@ void MCCanvasRestoreState(MCCanvasRef p_canvas)
 	MCGContextRestore(t_canvas->context);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasBeginLayer(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5170,7 +5395,7 @@ static void MCPolarCoordsToCartesian(MCGFloat p_distance, MCGFloat p_angle, MCGF
 	r_y = p_distance * sin(p_angle);
 }
 
-
+MC_DLLEXPORT_DEF
 void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5249,6 +5474,7 @@ void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canv
 	MCGContextBeginWithEffects(t_canvas->context, t_rect, t_effects);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasEndLayer(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5260,6 +5486,7 @@ void MCCanvasEndLayer(MCCanvasRef p_canvas)
 	MCGContextEnd(t_canvas->context);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFill(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5271,6 +5498,7 @@ void MCCanvasFill(MCCanvasRef p_canvas)
 	MCGContextEnd(t_canvas->context);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasStroke(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5282,6 +5510,7 @@ void MCCanvasStroke(MCCanvasRef p_canvas)
 	MCGContextEnd(t_canvas->context);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasClipToRect(MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5290,6 +5519,7 @@ void MCCanvasClipToRect(MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas)
 	MCGContextClipToRect(t_canvas->context, *MCCanvasRectangleGet(p_rect));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasAddPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5298,12 +5528,14 @@ void MCCanvasAddPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 	MCGContextAddPath(t_canvas->context, *MCCanvasPathGet(p_path));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFillPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 {
 	MCCanvasAddPath(p_path, p_canvas);
 	MCCanvasFill(p_canvas);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasStrokePath(MCCanvasPathRef p_path, MCCanvasRef p_canvas)
 {
 	MCCanvasAddPath(p_path, p_canvas);
@@ -5339,11 +5571,13 @@ void MCCanvasDrawRectOfImage(MCCanvasRef p_canvas, MCCanvasImageRef p_image, con
 	}
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasDrawRectOfImage(MCCanvasRectangleRef p_src_rect, MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas)
 {
 	MCCanvasDrawRectOfImage(p_canvas, p_image, *MCCanvasRectangleGet(p_src_rect), *MCCanvasRectangleGet(p_dst_rect));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasDrawImage(MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect, MCCanvasRef p_canvas)
 {
 	MCGRectangle t_src_rect;
@@ -5354,6 +5588,7 @@ void MCCanvasDrawImage(MCCanvasImageRef p_image, MCCanvasRectangleRef p_dst_rect
 	MCCanvasDrawRectOfImage(p_canvas, p_image, t_src_rect, *MCCanvasRectangleGet(p_dst_rect));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasMoveTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5362,6 +5597,7 @@ void MCCanvasMoveTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 	MCGContextMoveTo(t_canvas->context, *MCCanvasPointGet(p_point));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasLineTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5370,6 +5606,7 @@ void MCCanvasLineTo(MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 	MCGContextLineTo(t_canvas->context, *MCCanvasPointGet(p_point));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5378,6 +5615,7 @@ void MCCanvasCurveThroughPoint(MCCanvasPointRef p_through, MCCanvasPointRef p_to
 	MCGContextQuadraticTo(t_canvas->context, *MCCanvasPointGet(p_through), *MCCanvasPointGet(p_to));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p_through_b, MCCanvasPointRef p_to, MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5386,6 +5624,7 @@ void MCCanvasCurveThroughPoints(MCCanvasPointRef p_through_a, MCCanvasPointRef p
 	MCGContextCubicTo(t_canvas->context, *MCCanvasPointGet(p_through_a), *MCCanvasPointGet(p_through_b), *MCCanvasPointGet(p_to));
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasClosePath(MCCanvasRef p_canvas)
 {
 	__MCCanvasImpl *t_canvas;
@@ -5394,6 +5633,7 @@ void MCCanvasClosePath(MCCanvasRef p_canvas)
 	MCGContextCloseSubpath(t_canvas->context);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFillText(MCStringRef p_text, MCCanvasPointRef p_point, MCCanvasRef p_canvas)
 {
 	MCGPoint t_point;
@@ -5409,6 +5649,7 @@ void MCCanvasFillText(MCStringRef p_text, MCCanvasPointRef p_point, MCCanvasRef 
 	MCFontDrawText(t_context, t_point.x, t_point.y, p_text, t_font, false, false);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_halign, integer_t p_valign, MCCanvasRectangleRef p_rect, MCCanvasRef p_canvas)
 {
 	MCFontRef t_font;
@@ -5461,6 +5702,7 @@ void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_halign, integer_t p
 	MCFontDrawText(t_context, t_rect.origin.x + t_x, t_rect.origin.y + t_y, p_text, t_font, false, false);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasAlignmentEvaluate(integer_t p_h_align, integer_t p_v_align, integer_t &r_align)
 {
 	// range of h/v align is -1, 0, 1 so shift to 0,1,2 and combine
@@ -5480,6 +5722,7 @@ void MCCanvasFillTextAligned(MCStringRef p_text, integer_t p_align, MCCanvasRect
 	MCCanvasFillTextAligned(p_text, t_h_aligh, t_v_align, p_rect, p_canvas);
 }
 
+MC_DLLEXPORT_DEF
 MCCanvasRectangleRef MCCanvasMeasureText(MCStringRef p_text, MCCanvasRef p_canvas)
 {
 	MCCanvasRectangleRef t_rect;
@@ -5510,7 +5753,7 @@ void MCCanvasPop(uintptr_t p_cookie)
     MCValueRelease(t_canvas);
 }
 
-extern "C" MC_DLLEXPORT void MCCanvasThisCanvas(MCCanvasRef& r_canvas)
+extern "C" MC_DLLEXPORT_DEF void MCCanvasThisCanvas(MCCanvasRef& r_canvas)
 {
     if (s_current_canvas == nil)
     {
@@ -5521,11 +5764,11 @@ extern "C" MC_DLLEXPORT void MCCanvasThisCanvas(MCCanvasRef& r_canvas)
     r_canvas = MCValueRetain(s_current_canvas);
 }
 
-extern "C" MC_DLLEXPORT void MCCanvasPretendToAssignToThisCanvas(MCCanvasRef p_canvas)
+extern "C" MC_DLLEXPORT_DEF void MCCanvasPretendToAssignToThisCanvas(MCCanvasRef p_canvas)
 {
 }
 
-extern "C" MC_DLLEXPORT void MCCanvasNewCanvasWithSize(MCProperListRef p_list, MCCanvasRef& r_canvas)
+extern "C" MC_DLLEXPORT_DEF void MCCanvasNewCanvasWithSize(MCProperListRef p_list, MCCanvasRef& r_canvas)
 {
 	MCGPoint t_scale;
 	if (!MCProperListToScale(p_list, t_scale))
@@ -5550,7 +5793,7 @@ extern "C" MC_DLLEXPORT void MCCanvasNewCanvasWithSize(MCProperListRef p_list, M
     r_canvas = t_canvas;
 }
 
-extern "C" MC_DLLEXPORT void MCCanvasGetPixelDataOfCanvas(MCCanvasRef p_canvas, MCDataRef& r_data)
+extern "C" MC_DLLEXPORT_DEF void MCCanvasGetPixelDataOfCanvas(MCCanvasRef p_canvas, MCDataRef& r_data)
 {
 	__MCCanvasImpl *t_canvas;
 	t_canvas = MCCanvasGet(p_canvas);
@@ -5583,14 +5826,14 @@ extern "C" MC_DLLEXPORT void MCCanvasGetPixelDataOfCanvas(MCCanvasRef p_canvas, 
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCCanvasGetPixelWidthOfCanvas(MCCanvasRef p_canvas, uinteger_t& r_width)
+extern "C" MC_DLLEXPORT_DEF void MCCanvasGetPixelWidthOfCanvas(MCCanvasRef p_canvas, uinteger_t& r_width)
 {
 	__MCCanvasImpl *t_canvas;
 	t_canvas = MCCanvasGet(p_canvas);
     r_width = MCGContextGetWidth(t_canvas -> context);
 }
 
-extern "C" MC_DLLEXPORT void MCCanvasGetPixelHeightOfCanvas(MCCanvasRef p_canvas, uinteger_t& r_height)
+extern "C" MC_DLLEXPORT_DEF void MCCanvasGetPixelHeightOfCanvas(MCCanvasRef p_canvas, uinteger_t& r_height)
 {
 	__MCCanvasImpl *t_canvas;
 	t_canvas = MCCanvasGet(p_canvas);

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -50,7 +50,7 @@ struct __MCScriptObjectImpl
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCEngineScriptObjectTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCEngineScriptObjectTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -116,7 +116,7 @@ void MCEngineScriptObjectAllowAccess(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT MCScriptObjectRef MCEngineExecResolveScriptObject(MCStringRef p_object_id)
+extern "C" MC_DLLEXPORT_DEF MCScriptObjectRef MCEngineExecResolveScriptObject(MCStringRef p_object_id)
 {
     if (!MCEngineScriptObjectAccessIsAllowed())
         return nil;
@@ -164,7 +164,7 @@ extern "C" MC_DLLEXPORT MCScriptObjectRef MCEngineExecResolveScriptObject(MCStri
     return t_script_object;
 }
 
-extern "C" MC_DLLEXPORT void MCEngineEvalScriptObjectExists(MCScriptObjectRef p_object, bool& r_exists)
+extern "C" MC_DLLEXPORT_DEF void MCEngineEvalScriptObjectExists(MCScriptObjectRef p_object, bool& r_exists)
 {
     // This method does't require any script interaction so it always allowed.
     
@@ -177,7 +177,7 @@ extern "C" MC_DLLEXPORT void MCEngineEvalScriptObjectExists(MCScriptObjectRef p_
         r_exists = false;
 }
 
-extern "C" MC_DLLEXPORT void MCEngineEvalScriptObjectDoesNotExist(MCScriptObjectRef p_object, bool& r_not_exists)
+extern "C" MC_DLLEXPORT_DEF void MCEngineEvalScriptObjectDoesNotExist(MCScriptObjectRef p_object, bool& r_not_exists)
 {
     // This method does't require any script interaction so it always allowed.
     
@@ -254,7 +254,7 @@ MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_proper
 	return t_value_ref;
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCEngineExecGetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecGetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object)
 {
     if (!MCEngineScriptObjectAccessIsAllowed())
         return nil;
@@ -311,7 +311,7 @@ void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MC
     }
 }
 
-extern "C" MC_DLLEXPORT void MCEngineExecSetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object, MCValueRef p_value)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object, MCValueRef p_value)
 {
 	MCObject *t_object;
 	uint32_t t_part_id;
@@ -323,7 +323,7 @@ extern "C" MC_DLLEXPORT void MCEngineExecSetPropertyOfScriptObject(MCStringRef p
 	MCEngineSetPropertyOfObject(ctxt, p_property, t_object, t_part_id, p_value);
 }
 
-extern "C" MC_DLLEXPORT void MCEngineEvalOwnerOfScriptObject(MCScriptObjectRef p_object, MCScriptObjectRef &r_owner)
+extern "C" MC_DLLEXPORT_DEF void MCEngineEvalOwnerOfScriptObject(MCScriptObjectRef p_object, MCScriptObjectRef &r_owner)
 {
     // This method does't require any script interaction so it always allowed.
     
@@ -364,7 +364,7 @@ struct MCScriptObjectChildControlsVisitor : public MCObjectVisitor
 	MCProperListRef m_list;
 };
 
-extern "C" MC_DLLEXPORT void MCEngineEvalChildrenOfScriptObject(MCScriptObjectRef p_object, MCProperListRef &r_controls)
+extern "C" MC_DLLEXPORT_DEF void MCEngineEvalChildrenOfScriptObject(MCScriptObjectRef p_object, MCProperListRef &r_controls)
 {
     // This method does't require any script interaction so it always allowed.
     
@@ -465,7 +465,7 @@ cleanup:
     return t_result;
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCEngineExecSendToScriptObjectWithArguments(bool p_is_function, MCStringRef p_message, MCScriptObjectRef p_object, MCProperListRef p_arguments)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecSendToScriptObjectWithArguments(bool p_is_function, MCStringRef p_message, MCScriptObjectRef p_object, MCProperListRef p_arguments)
 {
     if (!MCEngineScriptObjectAccessIsAllowed())
         return nil;
@@ -478,7 +478,7 @@ extern "C" MC_DLLEXPORT MCValueRef MCEngineExecSendToScriptObjectWithArguments(b
     return MCEngineDoSendToObjectWithArguments(p_is_function, p_message, t_object, p_arguments);
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCEngineExecSendToScriptObject(bool p_is_function, MCStringRef p_message, MCScriptObjectRef p_object)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecSendToScriptObject(bool p_is_function, MCStringRef p_message, MCScriptObjectRef p_object)
 {
     return MCEngineExecSendToScriptObjectWithArguments(p_is_function, p_message, p_object, kMCEmptyProperList);
 }
@@ -501,7 +501,7 @@ void MCEngineDoPostToObjectWithArguments(MCStringRef p_message, MCObject *p_obje
     MCscreen -> addmessage(p_object, *t_message_as_name, 0.0f, t_params);
 }
 
-extern "C" MC_DLLEXPORT void MCEngineExecPostToScriptObjectWithArguments(MCStringRef p_message, MCScriptObjectRef p_object, MCProperListRef p_arguments)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecPostToScriptObjectWithArguments(MCStringRef p_message, MCScriptObjectRef p_object, MCProperListRef p_arguments)
 {
     if (!MCEngineScriptObjectAccessIsAllowed())
         return;
@@ -514,17 +514,17 @@ extern "C" MC_DLLEXPORT void MCEngineExecPostToScriptObjectWithArguments(MCStrin
     MCEngineDoPostToObjectWithArguments(p_message, t_object, p_arguments);
 }
 
-extern "C" MC_DLLEXPORT void MCEngineExecPostToScriptObject(MCStringRef p_message, MCScriptObjectRef p_object)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecPostToScriptObject(MCStringRef p_message, MCScriptObjectRef p_object)
 {
     MCEngineExecPostToScriptObjectWithArguments(p_message, p_object, kMCEmptyProperList);
 }
 
-extern "C" MC_DLLEXPORT void MCEngineEvalMessageWasHandled(bool& r_handled)
+extern "C" MC_DLLEXPORT_DEF void MCEngineEvalMessageWasHandled(bool& r_handled)
 {
     r_handled = s_last_message_was_handled;
 }
 
-extern "C" MC_DLLEXPORT void MCEngineEvalMessageWasNotHandled(bool& r_not_handled)
+extern "C" MC_DLLEXPORT_DEF void MCEngineEvalMessageWasNotHandled(bool& r_not_handled)
 {
     bool t_handled;
     MCEngineEvalMessageWasHandled(t_handled);
@@ -533,7 +533,7 @@ extern "C" MC_DLLEXPORT void MCEngineEvalMessageWasNotHandled(bool& r_not_handle
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT MCValueRef MCEngineExecExecuteScript(MCStringRef p_script)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecExecuteScript(MCStringRef p_script)
 {
     if (!MCEngineScriptObjectAccessIsAllowed())
         return nil;
@@ -636,7 +636,7 @@ public:
     }
 };
 
-extern "C" MC_DLLEXPORT void MCEngineExecLog(MCValueRef p_message)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecLog(MCValueRef p_message)
 {
 	if (p_message == nil)
 		p_message = kMCNull;
@@ -673,7 +673,7 @@ extern "C" MC_DLLEXPORT void MCEngineExecLog(MCValueRef p_message)
 #endif
 }
 
-extern "C" MC_DLLEXPORT void MCEngineExecLogWithValues(MCStringRef p_message, MCProperListRef p_values)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecLogWithValues(MCStringRef p_message, MCProperListRef p_values)
 {
     MCAutoStringRef t_formatted_message;
     if (!MCStringCreateMutable(0, &t_formatted_message))
@@ -724,8 +724,8 @@ extern "C" MC_DLLEXPORT void MCEngineExecLogWithValues(MCStringRef p_message, MC
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCEngineScriptObjectDoesNotExistErrorTypeInfo = nil;
-MCTypeInfoRef kMCEngineScriptObjectNoContextErrorTypeInfo = nil;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCEngineScriptObjectDoesNotExistErrorTypeInfo = nil;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCEngineScriptObjectNoContextErrorTypeInfo = nil;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/text-api.cpp
+++ b/engine/src/text-api.cpp
@@ -21,6 +21,7 @@
 #include "text-pane.h"
 
 
+MC_DLLEXPORT_DEF
 void MCTextCellSetMaxSize(MCTextCellRef p_cell, coord_t p_width, coord_t p_height)
 {
     p_cell->setMaxSize(p_width, p_height);
@@ -29,6 +30,7 @@ void MCTextCellSetMaxSize(MCTextCellRef p_cell, coord_t p_width, coord_t p_heigh
 // Creates a new, empty text pane. The specified stack is used for scaling and
 // theming only - the pane isn't a LiveCode control and isn't a child of the
 // stack.
+MC_DLLEXPORT_DEF
 bool MCTextPaneCreate(class MCStack* p_on_stack, MCTextPaneRef& r_pane)
 {
     r_pane = new MCTextPane;
@@ -36,6 +38,7 @@ bool MCTextPaneCreate(class MCStack* p_on_stack, MCTextPaneRef& r_pane)
 }
 
 // Deletes the given text pane
+MC_DLLEXPORT_DEF
 bool MCTextPaneDelete(MCTextPaneRef p_pane)
 {
     delete p_pane;
@@ -45,6 +48,7 @@ bool MCTextPaneDelete(MCTextPaneRef p_pane)
 // Sets the contents of the text pane to be the given string. Other than certain
 // inline control characters (tabs, newlines, BiDi controls, etc), the string
 // is unformatted.
+MC_DLLEXPORT_DEF
 bool MCTextPaneSetContentsPlain(MCTextPaneRef p_pane, MCStringRef p_contents)
 {
     p_pane->setContentsPlain(p_contents);
@@ -52,17 +56,22 @@ bool MCTextPaneSetContentsPlain(MCTextPaneRef p_pane, MCStringRef p_contents)
 }
 
 static MCTextPaneRef s_pane;
+
+MC_DLLEXPORT_DEF
 MCTextPaneRef MCTextPaneGet()
 {
     return s_pane;
 }
 
+MC_DLLEXPORT_DEF
 void MCTextPaneSet(MCTextPaneRef p_pane)
 {
     s_pane = p_pane;
 }
 
 extern MCDC* g_widget_paint_dc;
+
+MC_DLLEXPORT_DEF
 void MCTextPanePaintShim(MCTextPaneRef p_pane)
 {
     // AL-2015-07-08: Removed temporarily as it was causing build issues

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -1792,7 +1792,7 @@ static bool MCWidgetThrowNoCurrentWidgetError(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCWidgetExecRedrawAll(void)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecRedrawAll(void)
 {
     if (MCwidgetobject == nil)
     {
@@ -1803,7 +1803,7 @@ extern "C" MC_DLLEXPORT void MCWidgetExecRedrawAll(void)
     MCwidgetobject -> layer_redrawall();
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetExecScheduleTimerIn(double p_after)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecScheduleTimerIn(double p_after)
 {
     if (MCwidgetobject == nil)
     {
@@ -1815,7 +1815,7 @@ extern "C" MC_DLLEXPORT void MCWidgetExecScheduleTimerIn(double p_after)
     MCscreen -> addtimer(MCwidgetobject, MCM_internal, (uint4)(p_after * 1000));
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetExecCancelTimer(void)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecCancelTimer(void)
 {
     if (MCwidgetobject == nil)
     {
@@ -1826,7 +1826,7 @@ extern "C" MC_DLLEXPORT void MCWidgetExecCancelTimer(void)
     MCscreen -> cancelmessageobject(MCwidgetobject, MCM_internal);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetEvalInEditMode(bool& r_in_edit_mode)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetEvalInEditMode(bool& r_in_edit_mode)
 {
     r_in_edit_mode = MCcurtool != T_BROWSE;
 }
@@ -1836,7 +1836,7 @@ extern "C" MC_DLLEXPORT void MCWidgetEvalInEditMode(bool& r_in_edit_mode)
 extern MCValueRef MCEngineDoSendToObjectWithArguments(bool p_is_function, MCStringRef p_message, MCObject *p_object, MCProperListRef p_arguments);
 extern void MCEngineDoPostToObjectWithArguments(MCStringRef p_message, MCObject *p_object, MCProperListRef p_arguments);
 
-extern "C" MC_DLLEXPORT void MCWidgetGetScriptObject(MCScriptObjectRef& r_script_object)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetScriptObject(MCScriptObjectRef& r_script_object)
 {
     if (MCwidgetobject == nil)
     {
@@ -1848,7 +1848,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetScriptObject(MCScriptObjectRef& r_script
         return;
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCWidgetExecSend(bool p_is_function, MCStringRef p_message)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCWidgetExecSend(bool p_is_function, MCStringRef p_message)
 {
     if (MCwidgetobject == nil)
     {
@@ -1859,7 +1859,7 @@ extern "C" MC_DLLEXPORT MCValueRef MCWidgetExecSend(bool p_is_function, MCString
     return MCEngineDoSendToObjectWithArguments(p_is_function, p_message, MCwidgetobject, kMCEmptyProperList);
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCWidgetExecSendWithArguments(bool p_is_function, MCStringRef p_message, MCProperListRef p_arguments)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCWidgetExecSendWithArguments(bool p_is_function, MCStringRef p_message, MCProperListRef p_arguments)
 {
     if (MCwidgetobject == nil)
     {
@@ -1870,7 +1870,7 @@ extern "C" MC_DLLEXPORT MCValueRef MCWidgetExecSendWithArguments(bool p_is_funct
     return MCEngineDoSendToObjectWithArguments(p_is_function, p_message, MCwidgetobject, p_arguments);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetExecPost(MCStringRef p_message)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecPost(MCStringRef p_message)
 {
     if (MCwidgetobject == nil)
     {
@@ -1881,7 +1881,7 @@ extern "C" MC_DLLEXPORT void MCWidgetExecPost(MCStringRef p_message)
     MCEngineDoPostToObjectWithArguments(p_message, MCwidgetobject, kMCEmptyProperList);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetExecPostWithArguments(MCStringRef p_message, MCProperListRef p_arguments)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecPostWithArguments(MCStringRef p_message, MCProperListRef p_arguments)
 {
     if (MCwidgetobject == nil)
     {
@@ -1894,7 +1894,7 @@ extern "C" MC_DLLEXPORT void MCWidgetExecPostWithArguments(MCStringRef p_message
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCWidgetGetRectangle(MCCanvasRectangleRef& r_rect)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetRectangle(MCCanvasRectangleRef& r_rect)
 {
     if (MCwidgetobject == nil)
     {
@@ -1911,7 +1911,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetRectangle(MCCanvasRectangleRef& r_rect)
     MCCanvasRectangleCreateWithMCGRectangle(t_grect, r_rect);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetFrame(MCCanvasRectangleRef& r_rect)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetFrame(MCCanvasRectangleRef& r_rect)
 {
     if (MCwidgetobject == nil)
     {
@@ -1933,7 +1933,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetFrame(MCCanvasRectangleRef& r_rect)
     MCCanvasRectangleCreateWithMCGRectangle(t_grect, r_rect);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetBounds(MCCanvasRectangleRef& r_rect)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetBounds(MCCanvasRectangleRef& r_rect)
 {
     if (MCwidgetobject == nil)
     {
@@ -1950,7 +1950,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetBounds(MCCanvasRectangleRef& r_rect)
     MCCanvasRectangleCreateWithMCGRectangle(t_grect, r_rect);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetWidth(MCNumberRef& r_width)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetWidth(MCNumberRef& r_width)
 {
     if (MCwidgetobject == nil)
     {
@@ -1961,7 +1961,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetWidth(MCNumberRef& r_width)
     MCNumberCreateWithReal(MCwidgetobject->getrect().width, r_width);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetHeight(MCNumberRef& r_height)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetHeight(MCNumberRef& r_height)
 {
     if (MCwidgetobject == nil)
     {
@@ -1972,7 +1972,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetHeight(MCNumberRef& r_height)
     MCNumberCreateWithReal(MCwidgetobject->getrect().height, r_height);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetSetWidth(MCNumberRef p_width)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetSetWidth(MCNumberRef p_width)
 {
     if (MCwidgetobject == nil)
     {
@@ -1985,7 +1985,7 @@ extern "C" MC_DLLEXPORT void MCWidgetSetWidth(MCNumberRef p_width)
     MCwidgetobject->setrect(t_rect);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetSetHeight(MCNumberRef p_height)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetSetHeight(MCNumberRef p_height)
 {
     if (MCwidgetobject == nil)
     {
@@ -1998,7 +1998,7 @@ extern "C" MC_DLLEXPORT void MCWidgetSetHeight(MCNumberRef p_height)
     MCwidgetobject->setrect(t_rect);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetFont(MCCanvasFontRef& r_canvas_font)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetFont(MCCanvasFontRef& r_canvas_font)
 {
     if (MCwidgetobject == nil)
     {
@@ -2014,7 +2014,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetFont(MCCanvasFontRef& r_canvas_font)
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetEnabled(bool& r_enabled)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetEnabled(bool& r_enabled)
 {
     if (MCwidgetobject == nil)
     {
@@ -2025,7 +2025,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetEnabled(bool& r_enabled)
     r_enabled = !MCwidgetobject -> getflag(F_DISABLED);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetDisabled(bool& r_disabled)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetDisabled(bool& r_disabled)
 {
     if (MCwidgetobject == nil)
     {
@@ -2036,7 +2036,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetDisabled(bool& r_disabled)
     r_disabled = MCwidgetobject -> getflag(F_DISABLED);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetMousePosition(bool p_current, MCCanvasPointRef& r_point)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMousePosition(bool p_current, MCCanvasPointRef& r_point)
 {
     if (MCwidgetobject == nil)
     {
@@ -2063,7 +2063,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetMousePosition(bool p_current, MCCanvasPo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCWidgetGetClickPosition(bool p_current, MCCanvasPointRef& r_point)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetClickPosition(bool p_current, MCCanvasPointRef& r_point)
 {
     if (MCwidgetobject == nil)
     {
@@ -2088,7 +2088,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetClickPosition(bool p_current, MCCanvasPo
     /* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(t_gpoint, r_point);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetClickButton(bool p_current, unsigned int& r_button)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetClickButton(bool p_current, unsigned int& r_button)
 {
     if (MCwidgetobject == nil)
     {
@@ -2103,7 +2103,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetClickButton(bool p_current, unsigned int
         MCErrorThrowGeneric(MCSTR("'the current click button' is not implemented yet"));
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetGetClickCount(bool p_current, unsigned int& r_count)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetClickCount(bool p_current, unsigned int& r_count)
 {
     if (MCwidgetobject == nil)
     {
@@ -2123,7 +2123,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetClickCount(bool p_current, unsigned int&
 typedef struct __MCPressedState* MCPressedStateRef;
 MCTypeInfoRef kMCPressedState;
 
-extern "C" MC_DLLEXPORT void MCWidgetGetMouseButtonState(uinteger_t p_index, MCPressedStateRef r_state)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMouseButtonState(uinteger_t p_index, MCPressedStateRef r_state)
 {
     if (MCwidgetobject == nil)
     {
@@ -2137,7 +2137,7 @@ extern "C" MC_DLLEXPORT void MCWidgetGetMouseButtonState(uinteger_t p_index, MCP
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCWidgetEvalIsPointWithinRect(MCCanvasPointRef p_point, MCCanvasRectangleRef p_rect, bool& r_within)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetEvalIsPointWithinRect(MCCanvasPointRef p_point, MCCanvasRectangleRef p_rect, bool& r_within)
 {
     MCGPoint t_p;
     MCGRectangle t_r;
@@ -2148,7 +2148,7 @@ extern "C" MC_DLLEXPORT void MCWidgetEvalIsPointWithinRect(MCCanvasPointRef p_po
         && (t_r.origin.y <= t_p.y && t_p.y < t_r.origin.y+t_r.size.height);
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetEvalIsPointNotWithinRect(MCCanvasPointRef p_point, MCCanvasRectangleRef p_rect, bool& r_not_within)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetEvalIsPointNotWithinRect(MCCanvasPointRef p_point, MCCanvasRectangleRef p_rect, bool& r_not_within)
 {
     bool t_within;
     MCWidgetEvalIsPointWithinRect(p_point, p_rect, t_within);
@@ -2192,7 +2192,7 @@ private:
 	MCValueRef m_pick;
 };
 
-extern "C" MC_DLLEXPORT MCStringRef MCWidgetExecPopupMenuAtLocation(MCStringRef p_menu, MCCanvasPointRef p_at)
+extern "C" MC_DLLEXPORT_DEF MCStringRef MCWidgetExecPopupMenuAtLocation(MCStringRef p_menu, MCCanvasPointRef p_at)
 {
 	if (MCwidgetobject == nil)
 	{
@@ -2303,7 +2303,7 @@ MCValueRef MCWidgetPopupAtLocationWithProperties(MCNameRef p_kind, const MCPoint
 	return t_result;
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCWidgetExecPopupAtLocationWithProperties(MCStringRef p_kind, MCCanvasPointRef p_at, MCArrayRef p_properties)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCWidgetExecPopupAtLocationWithProperties(MCStringRef p_kind, MCCanvasPointRef p_at, MCArrayRef p_properties)
 {
 	if (MCwidgetobject == nil)
 	{
@@ -2326,14 +2326,14 @@ extern "C" MC_DLLEXPORT MCValueRef MCWidgetExecPopupAtLocationWithProperties(MCS
 	return MCWidgetPopupAtLocationWithProperties(*t_kind, t_at, p_properties);
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCWidgetExecPopupAtLocation(MCStringRef p_kind, MCCanvasPointRef p_at)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCWidgetExecPopupAtLocation(MCStringRef p_kind, MCCanvasPointRef p_at)
 {
 	return MCWidgetExecPopupAtLocationWithProperties(p_kind, p_at, kMCEmptyArray);
 }
 
 
 
-extern "C" MC_DLLEXPORT void MCWidgetEvalIsPopup(bool &r_popup)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetEvalIsPopup(bool &r_popup)
 {
 	if (MCwidgetobject == nil)
 	{
@@ -2344,7 +2344,7 @@ extern "C" MC_DLLEXPORT void MCWidgetEvalIsPopup(bool &r_popup)
 	r_popup = s_widget_popup != nil && MCwidgetobject == s_widget_popup->getpopupwidget();
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetExecClosePopupWithResult(MCValueRef p_result)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecClosePopupWithResult(MCValueRef p_result)
 {
 	if (MCwidgetobject == nil)
 	{
@@ -2365,7 +2365,7 @@ extern "C" MC_DLLEXPORT void MCWidgetExecClosePopupWithResult(MCValueRef p_resul
 	s_widget_popup->close();
 }
 
-extern "C" MC_DLLEXPORT void MCWidgetExecClosePopup(MCValueRef p_result)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecClosePopup(MCValueRef p_result)
 {
 	MCWidgetExecClosePopupWithResult(kMCNull);
 }
@@ -2389,8 +2389,8 @@ bool MCErrorCreateNamedTypeInfo(MCNameRef p_domain, MCNameRef p_name, MCStringRe
 	return true;
 }
 
-MCTypeInfoRef kMCWidgetNoCurrentWidgetErrorTypeInfo = nil;
-MCTypeInfoRef kMCWidgetSizeFormatErrorTypeInfo = nil;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCWidgetNoCurrentWidgetErrorTypeInfo = nil;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCWidgetSizeFormatErrorTypeInfo = nil;
 
 bool MCWidgetModuleInitialize(void)
 {

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -362,14 +362,26 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 //
 //  SYMBOL EXPORTS
 //
+
+/* MC_DLLEXPORT should be applied to declarations.  MC_DLLEXPORT_DEF
+ * should be applied to definitions. */
 #ifdef _WIN32
+/* On Windows, declaring something as having "dllexport" storage
+ * modifies the naming of the corresponding symbol, so the export
+ * attribute must be attached to declarations (and possibly to the
+ * definition *as well* if no separate declaration appears) */
 #  ifdef _MSC_VER
 #    define MC_DLLEXPORT __declspec(dllexport)
 #  else
 #    define MC_DLLEXPORT __attribute__((dllexport))
 #  endif
+#  define MC_DLLEXPORT_DEF MC_DLLEXPORT
 #else
-#  define MC_DLLEXPORT __attribute__((__visibility__("default")))
+/* On non-Windows platforms, the external visibility of a symbol is
+ * simply a property of its definition (i.e. whether or not it should
+ * appear in the list of exported symbols). */
+#  define MC_DLLEXPORT
+#  define MC_DLLEXPORT_DEF __attribute__((__visibility__("default"), __used__))
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2916,7 +2916,7 @@ MC_DLLEXPORT bool MCProperListMutableCopyAndRelease(MCProperListRef list, MCProp
 MC_DLLEXPORT bool MCProperListIsMutable(MCProperListRef list);
 
 // Returns the number of elements in the list.
-uindex_t MCProperListGetLength(MCProperListRef list);
+MC_DLLEXPORT uindex_t MCProperListGetLength(MCProperListRef list);
 
 // Returns true if the given list is the empty list.
 MC_DLLEXPORT bool MCProperListIsEmpty(MCProperListRef list);

--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -57,6 +57,7 @@ static bool __MCArrayFindKeyValueSlot(__MCArray *self, bool case_sensitive, MCNa
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCArrayCreate(bool p_case_sensitive, const MCNameRef *p_keys, const MCValueRef *p_values, uindex_t p_length, MCArrayRef& r_array)
 {
 	bool t_success;
@@ -78,6 +79,7 @@ bool MCArrayCreate(bool p_case_sensitive, const MCNameRef *p_keys, const MCValue
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayCreateWithOptions(bool p_case_sensitive, bool p_form_sensitive, const MCNameRef *p_keys, const MCValueRef *p_values, uindex_t p_length, MCArrayRef& r_array)
 {
 	bool t_success;
@@ -99,6 +101,7 @@ bool MCArrayCreateWithOptions(bool p_case_sensitive, bool p_form_sensitive, cons
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayCreateMutable(MCArrayRef& r_array)
 {
 	if (!__MCValueCreate(kMCValueTypeCodeArray, r_array))
@@ -109,6 +112,7 @@ bool MCArrayCreateMutable(MCArrayRef& r_array)
 	return true;
 }	
 
+MC_DLLEXPORT_DEF
 bool MCArrayCreateMutableWithOptions(MCArrayRef& r_array, bool p_case_sensitive, bool p_form_sensitive)
 {
 	if (!__MCValueCreate(kMCValueTypeCodeArray, r_array))
@@ -125,6 +129,7 @@ bool MCArrayCreateMutableWithOptions(MCArrayRef& r_array, bool p_case_sensitive,
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayCopy(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	// If we aren't mutable, then we can just copy directly.
@@ -154,6 +159,7 @@ bool MCArrayCopy(MCArrayRef self, MCArrayRef& r_new_array)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	// If we aren't mutable, then new array is just us.
@@ -199,6 +205,7 @@ bool MCArrayCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayMutableCopy(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	// If the array is immutable, then the new mutable array will be indirect
@@ -225,6 +232,7 @@ bool MCArrayMutableCopy(MCArrayRef self, MCArrayRef& r_new_array)
 	return __MCArrayCreateIndirect(self -> contents, r_new_array);
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayMutableCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 {
 	if (self -> references == 1)
@@ -243,6 +251,7 @@ bool MCArrayMutableCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayApply(MCArrayRef self, MCArrayApplyCallback p_callback, void *p_context)
 {
 	// Make sure we are iterating over the correct contents.
@@ -271,6 +280,7 @@ bool MCArrayApply(MCArrayRef self, MCArrayApplyCallback p_callback, void *p_cont
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayIterate(MCArrayRef self, uintptr_t& x_iterator, MCNameRef& r_key, MCValueRef& r_value)
 {
 	// Make sure we are iterating over the correct contents.
@@ -301,11 +311,13 @@ bool MCArrayIterate(MCArrayRef self, uintptr_t& x_iterator, MCNameRef& r_key, MC
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCArrayIsMutable(MCArrayRef self)
 {
 	return (self -> flags & kMCArrayFlagIsMutable) != 0;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCArrayGetCount(MCArrayRef self)
 {
 	if (!__MCArrayIsIndirect(self))
@@ -313,11 +325,13 @@ uindex_t MCArrayGetCount(MCArrayRef self)
 	return self -> contents -> key_value_count;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayIsCaseSensitive(MCArrayRef self)
 {
     return (self -> flags & kMCArrayFlagIsCaseSensitive) != 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayIsFormSensitive(MCArrayRef self)
 {
     return (self -> flags & kMCArrayFlagIsFormSensitive) != 0;
@@ -325,11 +339,13 @@ bool MCArrayIsFormSensitive(MCArrayRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCArrayFetchValue(MCArrayRef self, bool p_case_sensitive, MCNameRef p_key, MCValueRef& r_value)
 {
 	return MCArrayFetchValueOnPath(self, p_case_sensitive, &p_key, 1, r_value);
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayFetchValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNameRef *p_path, uindex_t p_path_length, MCValueRef& r_value)
 {
 	// If the array is indirect, get the contents.
@@ -365,11 +381,13 @@ bool MCArrayFetchValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNam
 
 //////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCArrayStoreValue(MCArrayRef self, bool p_case_sensitive, MCNameRef p_key, MCValueRef p_value)
 {
 	return MCArrayStoreValueOnPath(self, p_case_sensitive, &p_key, 1, p_value);
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayStoreValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNameRef *p_path, uindex_t p_path_length, MCValueRef p_new_value)
 {
 	// The array must be mutable.
@@ -464,11 +482,13 @@ bool MCArrayStoreValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNam
 
 //////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCArrayRemoveValue(MCArrayRef self, bool p_case_sensitive, MCNameRef p_key)
 {
 	return MCArrayRemoveValueOnPath(self, p_case_sensitive, &p_key, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayRemoveValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNameRef *p_path, uindex_t p_path_length)
 {
 	// The array must be mutable.
@@ -528,6 +548,7 @@ bool MCArrayRemoveValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNa
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_value)
 {
 	char t_index_str[16];
@@ -540,6 +561,7 @@ bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_va
 	return MCArrayFetchValue(self, true, *t_key, r_value);
 }
 
+MC_DLLEXPORT_DEF
 bool MCArrayStoreValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef p_value)
 {
 	char t_index_str[16];
@@ -567,6 +589,7 @@ MCArrayRemoveValueAtIndex(MCArrayRef self, index_t p_index)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCArrayIsEmpty(MCArrayRef self)
 {
 	return MCArrayGetCount(self) == 0;
@@ -952,7 +975,7 @@ static bool __MCArrayRehash(__MCArray *self, index_t p_by)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCArrayRef kMCEmptyArray;
+MC_DLLEXPORT_DEF MCArrayRef kMCEmptyArray;
 
 bool __MCArrayInitialize(void)
 {

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -102,6 +102,7 @@ void MCFinalize(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCMemoryAllocate(size_t p_size, void*& r_block)
 {
 	void *t_block;
@@ -114,6 +115,7 @@ bool MCMemoryAllocate(size_t p_size, void*& r_block)
 	return MCErrorThrowOutOfMemory();
 }
 
+MC_DLLEXPORT_DEF
 bool MCMemoryAllocateCopy(const void *p_block, size_t p_block_size, void*& r_block)
 {
 	if (MCMemoryAllocate(p_block_size, r_block))
@@ -124,6 +126,7 @@ bool MCMemoryAllocateCopy(const void *p_block, size_t p_block_size, void*& r_blo
 	return MCErrorThrowOutOfMemory();
 }
 
+MC_DLLEXPORT_DEF
 bool MCMemoryReallocate(void *p_block, size_t p_new_size, void*& r_new_block)
 {
 	void *t_new_block;
@@ -136,6 +139,7 @@ bool MCMemoryReallocate(void *p_block, size_t p_new_size, void*& r_new_block)
 	return MCErrorThrowOutOfMemory();
 }
 
+MC_DLLEXPORT_DEF
 void MCMemoryDeallocate(void *p_block)
 {
 	free(p_block);
@@ -143,6 +147,7 @@ void MCMemoryDeallocate(void *p_block)
 
 //////////
 
+MC_DLLEXPORT_DEF
 bool MCMemoryNew(size_t p_size, void*& r_record)
 {
 	if (MCMemoryAllocate(p_size, r_record))
@@ -153,6 +158,7 @@ bool MCMemoryNew(size_t p_size, void*& r_record)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 void MCMemoryDelete(void *p_record)
 {
 	MCMemoryDeallocate(p_record);
@@ -223,28 +229,33 @@ MCHashInt(T i)
 	return MCHashUInt((i >= 0) ? i : (-i));
 }
 
+MC_DLLEXPORT_DEF
 hash_t MCHashInteger(integer_t i)
 {
 	return MCHashInt (i);
 }
 
+MC_DLLEXPORT_DEF
 hash_t
 MCHashUInteger (uinteger_t i)
 {
 	return MCHashUInt(i);
 }
 
+MC_DLLEXPORT_DEF
 hash_t
 MCHashUSize (size_t i)
 {
 	return MCHashUInt (i);
 }
 
+MC_DLLEXPORT_DEF
 hash_t MCHashPointer(void *p)
 {
 	return MCHashUInt((uintptr_t) p);
 }
 
+MC_DLLEXPORT_DEF
 hash_t MCHashDouble(double d)
 {
 	double i;
@@ -260,6 +271,7 @@ hash_t MCHashDouble(double d)
 
 #define ELF_STEP(B) T1 = (H << 4) + B; T2 = T1 & 0xF0000000; if (T2) T1 ^= (T2 >> 24); T1 &= (~T2); H = T1;
 
+MC_DLLEXPORT_DEF
 hash_t MCHashBytes(const void *p_bytes, size_t length)
 {
 	uint8_t *bytes = (uint8_t *)p_bytes;
@@ -288,6 +300,7 @@ hash_t MCHashBytes(const void *p_bytes, size_t length)
     return H;
 }
 
+MC_DLLEXPORT_DEF
 hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t length)
 {
     MCAssert((length % 4) == 0);

--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -52,6 +52,7 @@ static bool __MCDataCopyMutable(__MCData *self, __MCData*& r_new_data);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data)
 {
 	bool t_success;
@@ -82,6 +83,7 @@ bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataR
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data)
 {
     // AL-2014-11-17: Create with bytes and release should just take the bytes.
@@ -106,6 +108,7 @@ bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCD
     return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data)
 {
     // AL-2014-12-12: [[ Bug 14208 ]] Implement MCDataConvertStringToData reduce the overhead in
@@ -156,6 +159,7 @@ bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data)
     return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataIsEmpty(MCDataRef p_data)
 {
     if (__MCDataIsIndirect(p_data))
@@ -164,6 +168,7 @@ bool MCDataIsEmpty(MCDataRef p_data)
 	return p_data -> byte_count == 0;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCDataGetLength(MCDataRef p_data)
 {
     if (__MCDataIsIndirect(p_data))
@@ -172,6 +177,7 @@ uindex_t MCDataGetLength(MCDataRef p_data)
     return p_data->byte_count;
 }
 
+MC_DLLEXPORT_DEF
 const byte_t *MCDataGetBytePtr(MCDataRef p_data)
 {
     if (__MCDataIsIndirect(p_data))
@@ -180,6 +186,7 @@ const byte_t *MCDataGetBytePtr(MCDataRef p_data)
     return p_data->bytes;
 }
 
+MC_DLLEXPORT_DEF
 byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index)
 {
     if (__MCDataIsIndirect(p_data))
@@ -188,7 +195,7 @@ byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index)
     return p_data->bytes[p_index];
 }
 
-hash_t MCDataHash(MCDataRef p_data);
+MC_DLLEXPORT_DEF
 bool MCDataIsEqualTo(MCDataRef p_left, MCDataRef p_right)
 {
     if (__MCDataIsIndirect(p_left))
@@ -203,10 +210,9 @@ bool MCDataIsEqualTo(MCDataRef p_left, MCDataRef p_right)
     return MCMemoryCompare(p_left -> bytes, p_right -> bytes, p_left -> byte_count) == 0;
 }
 
-compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right);
-
 // Mutable data methods
 
+MC_DLLEXPORT_DEF
 bool MCDataCreateMutable(uindex_t p_initial_capacity, MCDataRef& r_data)
 {
 	bool t_success;
@@ -233,6 +239,7 @@ bool MCDataCreateMutable(uindex_t p_initial_capacity, MCDataRef& r_data)
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data)
 {
     if (!MCDataIsMutable(p_data))
@@ -254,6 +261,7 @@ bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data)
     return __MCDataCopyMutable(p_data, r_new_data);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data)
 {
     // If the MCData is immutable we just pass it through (as we are releasing it).
@@ -290,6 +298,7 @@ bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data)
 {
     // If p_data is immutable, then the new mutable data ref will be indirect
@@ -309,6 +318,7 @@ bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data)
     return __MCDataCreateIndirect(p_data -> contents, r_mutable_data);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data)
 {
     if (p_data -> references == 1)
@@ -327,6 +337,7 @@ bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataCopyRange(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
 {
     if (__MCDataIsIndirect(self))
@@ -337,6 +348,7 @@ bool MCDataCopyRange(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
     return MCDataCreateWithBytes(self -> bytes + p_range . offset, p_range . length, r_new_data);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataCopyRangeAndRelease(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
 {
     if (MCDataCopyRange(self, p_range, r_new_data))
@@ -348,11 +360,13 @@ bool MCDataCopyRangeAndRelease(MCDataRef self, MCRange p_range, MCDataRef& r_new
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataIsMutable(const MCDataRef p_data)
 {
     return (p_data->flags & kMCDataFlagIsMutable) != 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix)
 {
     MCAssert(MCDataIsMutable(r_data));
@@ -374,6 +388,7 @@ bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix)
     return MCDataAppendBytes(r_data, p_suffix -> bytes, p_suffix -> byte_count);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataAppendBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -392,11 +407,13 @@ bool MCDataAppendBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_co
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataAppendByte(MCDataRef r_data, byte_t p_byte)
 {
     return MCDataAppendBytes(r_data, &p_byte, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix)
 {
     MCAssert(MCDataIsMutable(r_data));
@@ -418,6 +435,7 @@ bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix)
     return MCDataPrependBytes(r_data, p_prefix -> bytes, p_prefix -> byte_count);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataPrependBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -436,11 +454,13 @@ bool MCDataPrependBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_c
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataPrependByte(MCDataRef r_data, byte_t p_byte)
 {
     return MCDataPrependBytes(r_data, &p_byte, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data)
 {
     MCAssert(MCDataIsMutable(r_data));
@@ -462,6 +482,7 @@ bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data)
     return MCDataInsertBytes(r_data, p_at, p_new_data -> bytes, p_new_data -> byte_count);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataInsertBytes(MCDataRef self, uindex_t p_at, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -480,6 +501,7 @@ bool MCDataInsertBytes(MCDataRef self, uindex_t p_at, const byte_t *p_bytes, uin
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataRemove(MCDataRef self, MCRange p_range)
 {
 	MCAssert(MCDataIsMutable(self));
@@ -498,6 +520,7 @@ bool MCDataRemove(MCDataRef self, MCRange p_range)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data)
 {
 	MCAssert(MCDataIsMutable(r_data));
@@ -518,6 +541,7 @@ bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data)
     return MCDataReplaceBytes(r_data, p_range, p_new_data -> bytes, p_new_data -> byte_count);
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataReplaceBytes(MCDataRef self, MCRange p_range, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -553,6 +577,7 @@ bool MCDataReplaceBytes(MCDataRef self, MCRange p_range, const byte_t *p_bytes, 
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataPad(MCDataRef self, byte_t p_byte, uindex_t p_count)
 {
     MCAssert(MCDataIsMutable(self));
@@ -569,6 +594,7 @@ bool MCDataPad(MCDataRef self, byte_t p_byte, uindex_t p_count)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right)
 {
     if (__MCDataIsIndirect(p_left))
@@ -586,6 +612,7 @@ compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right)
     return p_left -> byte_count - p_right -> byte_count;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataContains(MCDataRef p_data, MCDataRef p_needle)
 {
     uindex_t t_needle_byte_count, t_byte_count;
@@ -609,6 +636,7 @@ bool MCDataContains(MCDataRef p_data, MCDataRef p_needle)
     return t_found;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataBeginsWith(MCDataRef p_data, MCDataRef p_needle)
 {
     uindex_t t_needle_byte_count, t_byte_count;
@@ -621,6 +649,7 @@ bool MCDataBeginsWith(MCDataRef p_data, MCDataRef p_needle)
     return MCMemoryCompare(p_data -> bytes, p_needle -> bytes, sizeof(byte_t) * t_needle_byte_count) == 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataEndsWith(MCDataRef p_data, MCDataRef p_needle)
 {
     uindex_t t_needle_byte_count, t_byte_count;
@@ -633,6 +662,7 @@ bool MCDataEndsWith(MCDataRef p_data, MCDataRef p_needle)
     return MCMemoryCompare(p_data -> bytes + t_byte_count - t_needle_byte_count, p_needle -> bytes, sizeof(byte_t) * t_needle_byte_count) == 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCDataFirstIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, uindex_t& r_index)
 {
     __MCDataClampRange(p_data, t_range);
@@ -662,7 +692,7 @@ bool MCDataFirstIndexOf(MCDataRef p_data, MCDataRef p_chunk, MCRange t_range, ui
     return t_found;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCDataLastIndexOf (MCDataRef self,
                    MCDataRef p_needle,
                    MCRange p_range,
@@ -706,6 +736,7 @@ MCDataLastIndexOf (MCDataRef self,
 }
 
 #if defined(__MAC__) || defined (__IOS__)
+MC_DLLEXPORT_DEF
 bool MCDataConvertToCFDataRef(MCDataRef p_data, CFDataRef& r_cfdata)
 {
     if (__MCDataIsIndirect(p_data))
@@ -793,7 +824,7 @@ static bool __MCDataMakeImmutable(__MCData *self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCDataRef kMCEmptyData;
+MC_DLLEXPORT_DEF MCDataRef kMCEmptyData;
 
 bool __MCDataInitialize(void)
 {

--- a/libfoundation/src/foundation-error.cpp
+++ b/libfoundation/src/foundation-error.cpp
@@ -23,8 +23,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCOutOfMemoryErrorTypeInfo;
-MCTypeInfoRef kMCGenericErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCOutOfMemoryErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCGenericErrorTypeInfo;
 
 static MCErrorRef s_last_error = nil;
 
@@ -120,7 +120,7 @@ static bool MCErrorFormatMessage(MCStringRef p_format, MCArrayRef p_info, MCStri
     return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCErrorCreateWithMessage (MCTypeInfoRef p_typeinfo,
                           MCStringRef p_message,
                           MCArrayRef p_info,
@@ -147,6 +147,7 @@ MCErrorCreateWithMessage (MCTypeInfoRef p_typeinfo,
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCErrorCreate(MCTypeInfoRef p_typeinfo, MCArrayRef p_info, MCErrorRef& r_error)
 {
 	return MCErrorCreateWithMessage (p_typeinfo,
@@ -155,6 +156,7 @@ bool MCErrorCreate(MCTypeInfoRef p_typeinfo, MCArrayRef p_info, MCErrorRef& r_er
 	                                 r_error);
 }
 
+MC_DLLEXPORT_DEF
 bool MCErrorUnwind(MCErrorRef p_error, MCValueRef p_target, uindex_t p_row, uindex_t p_column)
 {
     MCErrorFrame *t_frame;
@@ -179,21 +181,25 @@ bool MCErrorUnwind(MCErrorRef p_error, MCValueRef p_target, uindex_t p_row, uind
     return true;
 }
 
+MC_DLLEXPORT_DEF
 MCNameRef MCErrorGetDomain(MCErrorRef self)
 {
     return MCErrorTypeInfoGetDomain(self -> typeinfo);
 }
 
+MC_DLLEXPORT_DEF
 MCArrayRef MCErrorGetInfo(MCErrorRef self)
 {
     return self -> info;
 }
 
+MC_DLLEXPORT_DEF
 MCStringRef MCErrorGetMessage(MCErrorRef self)
 {
     return self -> message;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCErrorGetDepth(MCErrorRef self)
 {
     if (self -> backtrace == nil)
@@ -221,6 +227,7 @@ static MCErrorFrame *__MCErrorGetFrameAtLevel(MCErrorRef self, uindex_t p_level)
     return t_frame;
 }
 
+MC_DLLEXPORT_DEF
 MCValueRef MCErrorGetTargetAtLevel(MCErrorRef self, uindex_t p_level)
 {
     MCErrorFrame *t_frame;
@@ -231,6 +238,7 @@ MCValueRef MCErrorGetTargetAtLevel(MCErrorRef self, uindex_t p_level)
     return t_frame -> target;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCErrorGetRowAtLevel(MCErrorRef self, uindex_t p_level)
 {
     MCErrorFrame *t_frame;
@@ -241,6 +249,7 @@ uindex_t MCErrorGetRowAtLevel(MCErrorRef self, uindex_t p_level)
     return t_frame -> row;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCErrorGetColumnAtLevel(MCErrorRef self, uindex_t p_level)
 {
     MCErrorFrame *t_frame;
@@ -253,6 +262,7 @@ uindex_t MCErrorGetColumnAtLevel(MCErrorRef self, uindex_t p_level)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCErrorThrow(MCErrorRef p_error)
 {
     if (s_last_error != nil)
@@ -263,6 +273,7 @@ bool MCErrorThrow(MCErrorRef p_error)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCErrorCatch(MCErrorRef& r_error)
 {
     if (s_last_error == nil)
@@ -274,11 +285,13 @@ bool MCErrorCatch(MCErrorRef& r_error)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 MCErrorRef MCErrorPeek(void)
 {
     return s_last_error;
 }
 
+MC_DLLEXPORT_DEF
 bool MCErrorIsPending(void)
 {
     return s_last_error != nil;
@@ -324,7 +337,7 @@ MCErrorCreateAndThrowWithMessageV (MCTypeInfoRef p_error_type,
     return MCErrorThrow(*t_error);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCErrorCreateAndThrowWithMessage (MCTypeInfoRef p_error_type,
                                   MCStringRef p_message,
                                   ...)
@@ -341,7 +354,7 @@ MCErrorCreateAndThrowWithMessage (MCTypeInfoRef p_error_type,
 	return t_result;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCErrorCreateAndThrow (MCTypeInfoRef p_error_type, ...)
 {
 	va_list t_args;
@@ -358,6 +371,7 @@ MCErrorCreateAndThrow (MCTypeInfoRef p_error_type, ...)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCErrorThrowOutOfMemory(void)
 {
     if (s_out_of_memory_error == nil &&
@@ -374,11 +388,13 @@ bool MCErrorThrowOutOfMemory(void)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCErrorThrowGeneric(MCStringRef p_reason)
 {
     return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", p_reason, nil);
 }
 
+MC_DLLEXPORT_DEF
 bool MCErrorThrowGenericWithMessage(MCStringRef p_message, ...)
 {
     va_list t_args;

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -21,19 +21,20 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCBoolTypeInfo;
-MCTypeInfoRef kMCUIntTypeInfo;
-MCTypeInfoRef kMCIntTypeInfo;
-MCTypeInfoRef kMCFloatTypeInfo;
-MCTypeInfoRef kMCDoubleTypeInfo;
-MCTypeInfoRef kMCPointerTypeInfo;
-MCTypeInfoRef kMCSizeTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCBoolTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUIntTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCIntTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCFloatTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCDoubleTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCPointerTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSizeTypeInfo;
 
 MCTypeInfoRef kMCForeignImportErrorTypeInfo;
 MCTypeInfoRef kMCForeignExportErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCForeignValueCreate(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignValueRef& r_value)
 {
     bool t_success;
@@ -59,6 +60,7 @@ bool MCForeignValueCreate(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignV
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCForeignValueCreateAndRelease(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignValueRef& r_value)
 {
     bool t_success;
@@ -84,6 +86,7 @@ bool MCForeignValueCreateAndRelease(MCTypeInfoRef p_typeinfo, void *p_contents, 
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCForeignValueExport(MCTypeInfoRef p_typeinfo, MCValueRef p_value, MCForeignValueRef& r_value)
 {
     bool t_success;
@@ -109,6 +112,7 @@ bool MCForeignValueExport(MCTypeInfoRef p_typeinfo, MCValueRef p_value, MCForeig
     return true;
 }
 
+MC_DLLEXPORT_DEF
 void *MCForeignValueGetContentsPtr(MCValueRef self)
 {
     return ((__MCForeignValue *)self) + 1;

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -21,6 +21,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCHandlerCreate(MCTypeInfoRef p_typeinfo, const MCHandlerCallbacks *p_callbacks, void *p_context, MCHandlerRef& r_handler)
 {
     // The context data for an MCHandler is stored after the common elements. The
@@ -40,11 +41,13 @@ bool MCHandlerCreate(MCTypeInfoRef p_typeinfo, const MCHandlerCallbacks *p_callb
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCHandlerInvoke(MCHandlerRef self, MCValueRef *p_arguments, uindex_t p_argument_count, MCValueRef& r_value)
 {
     return self -> callbacks -> invoke(MCHandlerGetContext(self), p_arguments, p_argument_count, r_value);
 }
 
+MC_DLLEXPORT_DEF
 MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef self, MCProperListRef& x_arguments, MCValueRef& r_value)
 {
     MCAutoValueRefArray t_args;
@@ -78,11 +81,13 @@ error_exit:
     return t_error;
 }
 
+MC_DLLEXPORT_DEF
 void *MCHandlerGetContext(MCHandlerRef self)
 {
     return (void *)self -> context;
 }
 
+MC_DLLEXPORT_DEF
 const MCHandlerCallbacks *MCHandlerGetCallbacks(MCHandlerRef self)
 {
     return self -> callbacks;

--- a/libfoundation/src/foundation-list.cpp
+++ b/libfoundation/src/foundation-list.cpp
@@ -47,6 +47,7 @@ bool MCListCreateMutable(MCStringRef p_delimiter, MCListRef& r_list)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCListAppend(MCListRef self, MCValueRef p_value)
 {
 	bool t_first = self->buffer == nil;
@@ -87,6 +88,7 @@ bool MCListAppend(MCListRef self, MCValueRef p_value)
 	return MCStringAppend(self -> buffer, t_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCListCopy(MCListRef self, MCListRef& r_list)
 {
 	MCAssert(self != nil);
@@ -121,6 +123,7 @@ bool MCListCopy(MCListRef self, MCListRef& r_list)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCListCopyAndRelease(MCListRef self, MCListRef& r_list)
 {
     // If there are no other references, just clear the mutable flag
@@ -138,6 +141,7 @@ bool MCListCopyAndRelease(MCListRef self, MCListRef& r_list)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCListCopyAsString(MCListRef self, MCStringRef& r_string)
 {
 	MCStringRef t_string;
@@ -152,6 +156,7 @@ bool MCListCopyAsString(MCListRef self, MCStringRef& r_string)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCListCopyAsStringAndRelease(MCListRef self, MCStringRef& r_string)
 {
 	if (!MCListCopyAsString(self, r_string))
@@ -162,6 +167,7 @@ bool MCListCopyAsStringAndRelease(MCListRef self, MCStringRef& r_string)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCListAppendFormat(MCListRef self, const char *p_format, ...)
 {
 	bool t_success;
@@ -184,6 +190,7 @@ bool MCListAppendFormat(MCListRef self, const char *p_format, ...)
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCListAppendNativeChars(MCListRef self, const char_t *p_chars, uindex_t p_char_count)
 {
 	bool t_first = self->buffer == nil;
@@ -197,11 +204,13 @@ bool MCListAppendNativeChars(MCListRef self, const char_t *p_chars, uindex_t p_c
 	return MCStringAppendNativeChars(self -> buffer, p_chars, p_char_count);
 }
 
+MC_DLLEXPORT_DEF
 bool MCListAppendSubstring(MCListRef self, MCStringRef p_string, MCRange p_range)
 {
 	return MCListAppendFormat(self, "%*@", &p_range, p_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCListIsEmpty(MCListRef self)
 {
 	return self -> buffer == nil;
@@ -209,7 +218,7 @@ bool MCListIsEmpty(MCListRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCListRef kMCEmptyList;
+MC_DLLEXPORT_DEF MCListRef kMCEmptyList;
 
 bool __MCListInitialize(void)
 {

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -20,9 +20,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCNameRef kMCEmptyName;
-MCNameRef kMCTrueName;
-MCNameRef kMCFalseName;
+MC_DLLEXPORT_DEF MCNameRef kMCEmptyName;
+MC_DLLEXPORT_DEF MCNameRef kMCTrueName;
+MC_DLLEXPORT_DEF MCNameRef kMCFalseName;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -37,6 +37,7 @@ static void __MCNameShrinkTable(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 MCNameRef MCNAME(const char *p_string)
 {
 	MCStringRef t_string;
@@ -55,6 +56,7 @@ MCNameRef MCNAME(const char *p_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCNameCreate(MCStringRef p_string, MCNameRef& r_name)
 {
 	MCAssert(p_string != nil);
@@ -168,6 +170,7 @@ bool MCNameCreate(MCStringRef p_string, MCNameRef& r_name)
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNameCreateWithNativeChars(const char_t *p_chars, uindex_t p_count, MCNameRef& r_name)
 {
 	MCStringRef t_string;
@@ -181,6 +184,7 @@ bool MCNameCreateWithNativeChars(const char_t *p_chars, uindex_t p_count, MCName
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNameCreateWithChars(const unichar_t *p_chars, uindex_t p_count, MCNameRef& r_name)
 {
 	MCStringRef t_string;
@@ -189,6 +193,7 @@ bool MCNameCreateWithChars(const unichar_t *p_chars, uindex_t p_count, MCNameRef
 	return MCNameCreateAndRelease(t_string, r_name);
 }
 
+MC_DLLEXPORT_DEF
 bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
 {
 	if (MCNameCreate(p_string, r_name))
@@ -200,6 +205,7 @@ bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 MCNameRef MCNameLookup(MCStringRef p_string)
 {
 	// Compute the hash of the characters, up to case.
@@ -233,16 +239,19 @@ MCNameRef MCNameLookup(MCStringRef p_string)
 	return t_key_name;
 }
 
+MC_DLLEXPORT_DEF
 uintptr_t MCNameGetCaselessSearchKey(MCNameRef self)
 {
 	return (uintptr_t)self -> key;
 }
 
+MC_DLLEXPORT_DEF
 MCStringRef MCNameGetString(MCNameRef self)
 {
 	return self -> string;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNameIsEmpty(MCNameRef self)
 {
 	return self == kMCEmptyName;

--- a/libfoundation/src/foundation-number.cpp
+++ b/libfoundation/src/foundation-number.cpp
@@ -23,6 +23,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCNumberCreateWithInteger(integer_t p_value, MCNumberRef& r_number)
 {
 	__MCNumber *self;
@@ -36,6 +37,7 @@ bool MCNumberCreateWithInteger(integer_t p_value, MCNumberRef& r_number)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNumberCreateWithReal(real64_t p_value, MCNumberRef& r_number)
 {
 	__MCNumber *self;
@@ -50,7 +52,7 @@ bool MCNumberCreateWithReal(real64_t p_value, MCNumberRef& r_number)
 	return true;
 }
 
-
+MC_DLLEXPORT_DEF
 bool MCNumberCreateWithUnsignedInteger(uinteger_t p_value, MCNumberRef& r_number)
 {
     if (p_value <= INTEGER_MAX)
@@ -59,16 +61,19 @@ bool MCNumberCreateWithUnsignedInteger(uinteger_t p_value, MCNumberRef& r_number
     return MCNumberCreateWithReal((real64_t)p_value, r_number);
 }
 
+MC_DLLEXPORT_DEF
 bool MCNumberIsInteger(MCNumberRef self)
 {
 	return (self -> flags & kMCNumberFlagIsReal) == 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNumberIsReal(MCNumberRef self)
 {
 	return (self -> flags & kMCNumberFlagIsReal) != 0;
 }
 
+MC_DLLEXPORT_DEF
 real64_t MCNumberFetchAsReal(MCNumberRef self)
 {
 	if (MCNumberIsReal(self))
@@ -76,6 +81,7 @@ real64_t MCNumberFetchAsReal(MCNumberRef self)
 	return (real64_t)self -> integer;
 }
 
+MC_DLLEXPORT_DEF
 integer_t MCNumberFetchAsInteger(MCNumberRef self)
 {
 	if (MCNumberIsInteger(self))
@@ -83,6 +89,7 @@ integer_t MCNumberFetchAsInteger(MCNumberRef self)
 	return self -> real < 0.0 ? (integer_t)(self -> real - 0.5) : (integer_t)(self -> real + 0.5);
 }
 
+MC_DLLEXPORT_DEF
 uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef self)
 {
 	if (MCNumberIsInteger(self))
@@ -183,6 +190,7 @@ bool __MCNumberParseNativeString(const char *p_string, uindex_t p_length, bool p
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNumberParseOffset(MCStringRef p_string, uindex_t offset, uindex_t char_count, MCNumberRef &r_number)
 {
     uindex_t length = MCStringGetLength(p_string);
@@ -206,11 +214,13 @@ bool MCNumberParseOffset(MCStringRef p_string, uindex_t offset, uindex_t char_co
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNumberParse(MCStringRef p_string, MCNumberRef &r_number)
 {
     return MCNumberParseOffset(p_string, 0, MCStringGetLength(p_string), r_number);
 }
 
+MC_DLLEXPORT_DEF
 bool MCNumberParseUnicodeChars(const unichar_t *p_chars, uindex_t p_char_count, MCNumberRef& r_number)
 {
 	char *t_native_chars;
@@ -233,6 +243,7 @@ bool MCNumberParseUnicodeChars(const unichar_t *p_chars, uindex_t p_char_count, 
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNumberParseOffsetPartial(MCStringRef p_string, uindex_t offset, uindex_t &r_chars_used, MCNumberRef &r_number)
 {
 	bool t_success;
@@ -294,9 +305,9 @@ bool __MCNumberIsEqualTo(__MCNumber *self, __MCNumber *p_other_self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCNumberRef kMCZero;
-MCNumberRef kMCOne;
-MCNumberRef kMCMinusOne;
+MC_DLLEXPORT_DEF MCNumberRef kMCZero;
+MC_DLLEXPORT_DEF MCNumberRef kMCOne;
+MC_DLLEXPORT_DEF MCNumberRef kMCMinusOne;
 
 bool __MCNumberInitialize(void)
 {

--- a/libfoundation/src/foundation-pickle.cpp
+++ b/libfoundation/src/foundation-pickle.cpp
@@ -525,6 +525,7 @@ static bool MCPickleReadField(MCStreamRef stream, MCPickleFieldType p_kind, void
     return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCPickleRead(MCStreamRef stream, MCPickleRecordInfo *p_info, void* r_record)
 {
     bool t_success;
@@ -894,6 +895,7 @@ static bool MCPickleWriteField(MCStreamRef stream, MCPickleFieldType p_kind, voi
     return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCPickleWrite(MCStreamRef stream, MCPickleRecordInfo *p_info, void *p_record)
 {
     bool t_success;
@@ -991,6 +993,7 @@ static void MCPickleReleaseField(MCPickleFieldType p_kind, void *p_base_ptr, voi
     }
 }
 
+MC_DLLEXPORT_DEF
 void MCPickleRelease(MCPickleRecordInfo *p_info, void *p_record)
 {
     for(uindex_t i = 0; p_info -> fields[i] . kind != kMCPickleFieldTypeNone; i++)

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -48,6 +48,7 @@ static void __MCProperListClampRange(MCProperListRef self, MCRange& x_range);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCProperListCreate(const MCValueRef *p_values, uindex_t p_length, MCProperListRef& r_list)
 {
 	bool t_success;
@@ -68,6 +69,7 @@ bool MCProperListCreate(const MCValueRef *p_values, uindex_t p_length, MCProperL
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListCreateMutable(MCProperListRef& r_list)
 {
 	if (!__MCValueCreate(kMCValueTypeCodeProperList, r_list))
@@ -94,6 +96,7 @@ MCProperListCreateAndRelease(MCValueRef *p_values,
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListCopy(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	// If we aren't mutable, then we can just copy directly.
@@ -123,6 +126,7 @@ bool MCProperListCopy(MCProperListRef self, MCProperListRef& r_new_list)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListCopyAndRelease(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	// If we aren't mutable, then new list is just us.
@@ -168,6 +172,7 @@ bool MCProperListCopyAndRelease(MCProperListRef self, MCProperListRef& r_new_lis
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListMutableCopy(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	// If the list is immutable, then the new mutable list will be indirect
@@ -194,6 +199,7 @@ bool MCProperListMutableCopy(MCProperListRef self, MCProperListRef& r_new_list)
 	return __MCProperListCreateIndirect(self -> contents, r_new_list);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListMutableCopyAndRelease(MCProperListRef self, MCProperListRef& r_new_list)
 {
 	if (self -> references == 1)
@@ -214,6 +220,7 @@ bool MCProperListMutableCopyAndRelease(MCProperListRef self, MCProperListRef& r_
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCProperListIsMutable(MCProperListRef self)
 {
 	return (self -> flags & kMCProperListFlagIsMutable) != 0;
@@ -224,6 +231,7 @@ bool MCProperListIsIndirect(MCProperListRef self)
 	return (self -> flags & kMCProperListFlagIsIndirect) != 0;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCProperListGetLength(MCProperListRef self)
 {
 	if (!__MCProperListIsIndirect(self))
@@ -231,6 +239,7 @@ uindex_t MCProperListGetLength(MCProperListRef self)
 	return self -> contents -> length;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListIsEmpty(MCProperListRef self)
 {
 	if (!__MCProperListIsIndirect(self))
@@ -241,26 +250,31 @@ bool MCProperListIsEmpty(MCProperListRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCProperListPushElementsOntoBack(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length)
 {
     return MCProperListInsertElements(self, p_values, p_length, MCProperListGetLength(self));
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListPushElementsOntoFront(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length)
 {
     return MCProperListInsertElements(self, p_values, p_length, 0);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListPushElementOntoBack(MCProperListRef self, const MCValueRef p_value)
 {
     return MCProperListPushElementsOntoBack(self, &p_value, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListPushElementOntoFront(MCProperListRef self, const MCValueRef p_value)
 {
     return MCProperListPushElementsOntoFront(self, &p_value, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListAppendList(MCProperListRef self, MCProperListRef p_value)
 {
     if (MCProperListIsIndirect(p_value))
@@ -276,6 +290,7 @@ bool MCProperListAppendList(MCProperListRef self, MCProperListRef p_value)
     return MCProperListAppendList(self, *t_list);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListInsertElements(MCProperListRef self, const MCValueRef *p_values, uindex_t p_length, index_t p_index)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -293,11 +308,13 @@ bool MCProperListInsertElements(MCProperListRef self, const MCValueRef *p_values
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListInsertElement(MCProperListRef self, MCValueRef p_value, index_t p_index)
 {
     return MCProperListInsertElements(self, &p_value, 1, p_index);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListInsertList(MCProperListRef self, MCProperListRef p_value, index_t p_index)
 {
     if (MCProperListIsIndirect(p_value))
@@ -313,6 +330,7 @@ bool MCProperListInsertList(MCProperListRef self, MCProperListRef p_value, index
     return MCProperListInsertList(self, *t_list, p_index);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListRemoveElements(MCProperListRef self, uindex_t p_start, uindex_t p_count)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -337,6 +355,7 @@ bool MCProperListRemoveElements(MCProperListRef self, uindex_t p_start, uindex_t
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListRemoveElement(MCProperListRef self, uindex_t p_index)
 {
     return MCProperListRemoveElements(self, p_index, 1);
@@ -344,6 +363,7 @@ bool MCProperListRemoveElement(MCProperListRef self, uindex_t p_index)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 MCValueRef MCProperListFetchHead(MCProperListRef self)
 {
     if (MCProperListIsIndirect(self))
@@ -354,6 +374,7 @@ MCValueRef MCProperListFetchHead(MCProperListRef self)
     return self -> list[0];
 }
 
+MC_DLLEXPORT_DEF
 MCValueRef MCProperListFetchTail(MCProperListRef self)
 {
     if (MCProperListIsIndirect(self))
@@ -364,6 +385,7 @@ MCValueRef MCProperListFetchTail(MCProperListRef self)
     return self -> list[self -> length - 1];
 }
 
+MC_DLLEXPORT_DEF
 MCValueRef MCProperListFetchElementAtIndex(MCProperListRef self, uindex_t p_index)
 {
     if (MCProperListIsIndirect(self))
@@ -375,6 +397,7 @@ MCValueRef MCProperListFetchElementAtIndex(MCProperListRef self, uindex_t p_inde
     return self -> list[p_index];
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListPopBack(MCProperListRef self, MCValueRef& r_value)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -395,6 +418,7 @@ bool MCProperListPopBack(MCProperListRef self, MCValueRef& r_value)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListPopFront(MCProperListRef self, MCValueRef& r_value)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -415,6 +439,7 @@ bool MCProperListPopFront(MCProperListRef self, MCValueRef& r_value)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListCopySublist(MCProperListRef self, MCRange p_range, MCProperListRef& r_elements)
 {
     if (MCProperListIsIndirect(self))
@@ -426,13 +451,14 @@ bool MCProperListCopySublist(MCProperListRef self, MCRange p_range, MCProperList
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCProperListFirstIndexOfElement(MCProperListRef self, MCValueRef p_needle, uindex_t p_after, uindex_t& r_offset)
 {
 	return MCProperListFirstIndexOfElementInRange(self, p_needle,
 	            MCRangeMake(p_after, UINDEX_MAX), r_offset);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCProperListFirstIndexOfElementInRange (MCProperListRef self,
                                         MCValueRef p_needle,
                                         MCRange p_range,
@@ -458,7 +484,7 @@ MCProperListFirstIndexOfElementInRange (MCProperListRef self,
 	return false;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCProperListLastIndexOfElementInRange (MCProperListRef self,
                                        MCValueRef p_needle,
                                        MCRange p_range,
@@ -482,13 +508,14 @@ MCProperListLastIndexOfElementInRange (MCProperListRef self,
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListFirstOffsetOfList(MCProperListRef self, MCProperListRef p_needle, uindex_t p_after, uindex_t& r_offset)
 {
 	return MCProperListFirstOffsetOfListInRange (self, p_needle,
 	            MCRangeMake (p_after, UINDEX_MAX), r_offset);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCProperListFirstOffsetOfListInRange (MCProperListRef self,
                                       MCProperListRef p_needle,
                                       MCRange p_range,
@@ -542,7 +569,7 @@ MCProperListFirstOffsetOfListInRange (MCProperListRef self,
 	return false;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCProperListLastOffsetOfListInRange (MCProperListRef self,
                                      MCProperListRef p_needle,
                                      MCRange p_range,
@@ -604,6 +631,7 @@ MCProperListLastOffsetOfListInRange (MCProperListRef self,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCProperListIterate(MCProperListRef self, uintptr_t& x_iterator, MCValueRef& r_element)
 {
     if (MCProperListIsIndirect(self))
@@ -619,6 +647,7 @@ bool MCProperListIterate(MCProperListRef self, uintptr_t& x_iterator, MCValueRef
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListApply(MCProperListRef self, MCProperListApplyCallback p_callback, void *context)
 {
     if (MCProperListIsIndirect(self))
@@ -631,6 +660,7 @@ bool MCProperListApply(MCProperListRef self, MCProperListApplyCallback p_callbac
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListMap(MCProperListRef self, MCProperListMapCallback p_callback, MCProperListRef& r_new_list, void *context)
 {
     if (MCProperListIsIndirect(self))
@@ -667,6 +697,7 @@ bool MCProperListMap(MCProperListRef self, MCProperListMapCallback p_callback, M
     return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListSort(MCProperListRef self, bool p_reverse, MCProperListQuickSortCallback p_callback)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -727,6 +758,7 @@ static void MCProperListDoStableSort(MCValueRef*& list, uindex_t p_item_count, M
         list[i] = p_temp[i];
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListStableSort(MCProperListRef self, bool p_reverse, MCProperListCompareElementCallback p_callback, void *context)
 {
     MCAssert(MCProperListIsMutable(self));
@@ -750,11 +782,13 @@ bool MCProperListStableSort(MCProperListRef self, bool p_reverse, MCProperListCo
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListIsEqualTo(MCProperListRef self, MCProperListRef p_other)
 {
     return __MCProperListIsEqualTo(self, p_other);
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListBeginsWithList(MCProperListRef self, MCProperListRef p_prefix)
 {
     // If the list is indirect, get the contents.
@@ -784,6 +818,7 @@ bool MCProperListBeginsWithList(MCProperListRef self, MCProperListRef p_prefix)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListEndsWithList(MCProperListRef self, MCProperListRef p_suffix)
 {
     // If the list is indirect, get the contents.
@@ -815,6 +850,7 @@ bool MCProperListEndsWithList(MCProperListRef self, MCProperListRef p_suffix)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCProperListIsListOfType(MCProperListRef self, MCValueTypeCode p_type)
 {
     // If the list is indirect, get the contents.
@@ -833,6 +869,7 @@ bool MCProperListIsListOfType(MCProperListRef self, MCValueTypeCode p_type)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCProperListIsHomogeneous(MCProperListRef self, MCValueTypeCode& r_type)
 {
     if (MCProperListIsEmpty(self))
@@ -1085,7 +1122,7 @@ static bool __MCProperListResolveIndirect(__MCProperList *self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCProperListRef kMCEmptyProperList;
+MC_DLLEXPORT_DEF MCProperListRef kMCEmptyProperList;
 
 bool __MCProperListInitialize(void)
 {

--- a/libfoundation/src/foundation-record.cpp
+++ b/libfoundation/src/foundation-record.cpp
@@ -40,6 +40,7 @@ static bool __check_conformance(MCTypeInfoRef p_typeinfo, const MCValueRef *p_va
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordCreate(MCTypeInfoRef p_typeinfo, const MCValueRef *p_values, uindex_t p_value_count, MCRecordRef& r_record)
 {
     bool t_success;
@@ -80,6 +81,7 @@ bool MCRecordCreate(MCTypeInfoRef p_typeinfo, const MCValueRef *p_values, uindex
     
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordCreateMutable(MCTypeInfoRef p_typeinfo, MCRecordRef& r_record)
 {
     bool t_success;
@@ -118,6 +120,7 @@ bool MCRecordCreateMutable(MCTypeInfoRef p_typeinfo, MCRecordRef& r_record)
     return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordCopy(MCRecordRef self, MCRecordRef& r_new_record)
 {
     if (!MCRecordIsMutable(self))
@@ -133,6 +136,7 @@ bool MCRecordCopy(MCRecordRef self, MCRecordRef& r_new_record)
     return MCRecordCreate(self -> typeinfo, self -> fields, __MCRecordTypeInfoGetFieldCount(t_resolved_typeinfo), r_new_record);
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
 {
     // If the MCRecord is immutable we just pass it through (as we are releasing it).
@@ -161,6 +165,7 @@ bool MCRecordCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
     return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordMutableCopy(MCRecordRef self, MCRecordRef& r_new_record)
 {
     MCTypeInfoRef t_resolved_typeinfo;
@@ -177,6 +182,7 @@ bool MCRecordMutableCopy(MCRecordRef self, MCRecordRef& r_new_record)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordMutableCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
 {
     if (MCRecordMutableCopy(self, r_new_record))
@@ -188,6 +194,7 @@ bool MCRecordMutableCopyAndRelease(MCRecordRef self, MCRecordRef& r_new_record)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordIsMutable(MCRecordRef self)
 {
     return (self -> flags & kMCRecordFlagIsMutable) != 0;
@@ -211,6 +218,7 @@ static bool __fetch_value(MCTypeInfoRef p_typeinfo, MCRecordRef self, MCNameRef 
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordFetchValue(MCRecordRef self, MCNameRef p_field, MCValueRef& r_value)
 {
     return __fetch_value(self -> typeinfo, self, p_field, r_value);
@@ -237,6 +245,7 @@ static bool __store_value(MCTypeInfoRef p_typeinfo, MCRecordRef self, MCNameRef 
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCRecordStoreValue(MCRecordRef self, MCNameRef p_field, MCValueRef p_value)
 {
     return __store_value(self -> typeinfo, self, p_field, p_value);
@@ -244,7 +253,7 @@ bool MCRecordStoreValue(MCRecordRef self, MCNameRef p_field, MCValueRef p_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordCopyAsBaseType(MCRecordRef self,
                        MCTypeInfoRef p_base_typeinfo,
                        MCRecordRef & r_new_record)
@@ -258,7 +267,7 @@ MCRecordCopyAsBaseType(MCRecordRef self,
 	return t_success;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordCopyAsBaseTypeAndRelease(MCRecordRef self,
                                  MCTypeInfoRef p_base_typeinfo,
                                  MCRecordRef & r_new_record)
@@ -285,7 +294,7 @@ MCRecordCopyAsBaseTypeAndRelease(MCRecordRef self,
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordCopyAsDerivedType(MCRecordRef self,
                           MCTypeInfoRef p_derived_typeinfo,
                           MCRecordRef & r_new_record)
@@ -299,7 +308,7 @@ MCRecordCopyAsDerivedType(MCRecordRef self,
 	return t_success;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef self,
                                     MCTypeInfoRef p_derived_typeinfo,
                                     MCRecordRef & r_new_record)
@@ -344,7 +353,7 @@ MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef self,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordEncodeAsArray(MCRecordRef record,
                       MCArrayRef & r_array)
 {
@@ -377,7 +386,7 @@ MCRecordEncodeAsArray(MCRecordRef record,
 	return MCArrayCopyAndRelease (t_new_array, r_array);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordDecodeFromArray(MCArrayRef array,
                         MCTypeInfoRef p_typeinfo,
                         MCRecordRef & r_record)
@@ -409,7 +418,7 @@ MCRecordDecodeFromArray(MCArrayRef array,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordIterate(MCRecordRef record,
                 uintptr_t& x_iterator,
                 MCNameRef& r_field_name,

--- a/libfoundation/src/foundation-set.cpp
+++ b/libfoundation/src/foundation-set.cpp
@@ -24,11 +24,13 @@ static bool __MCSetClone(MCSetRef self, bool as_mutable, MCSetRef& r_new_self);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCSetCreateSingleton(uindex_t p_element, MCSetRef& r_set)
 {
 	return MCSetCreateWithIndices(&p_element, 1, r_set);
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetCreateWithIndices(uindex_t *p_elements, uindex_t p_element_count, MCSetRef& r_set)
 {
 	MCSetRef t_set;
@@ -41,6 +43,7 @@ bool MCSetCreateWithIndices(uindex_t *p_elements, uindex_t p_element_count, MCSe
 	return MCSetCopyAndRelease(t_set, r_set);
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetCreateWithLimbsAndRelease(uindex_t *p_limbs, uindex_t p_limb_count, MCSetRef& r_set)
 {
 	__MCSet *self;
@@ -55,6 +58,7 @@ bool MCSetCreateWithLimbsAndRelease(uindex_t *p_limbs, uindex_t p_limb_count, MC
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetCreateMutable(MCSetRef& r_set)
 {
 	__MCSet *self;
@@ -70,6 +74,7 @@ bool MCSetCreateMutable(MCSetRef& r_set)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCSetCopy(MCSetRef self, MCSetRef& r_new_set)
 {
 	if (!MCSetIsMutable(self))
@@ -80,6 +85,7 @@ bool MCSetCopy(MCSetRef self, MCSetRef& r_new_set)
 	return __MCSetClone(self, false, r_new_set);
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 {
 	if (!MCSetIsMutable(self))
@@ -98,11 +104,13 @@ bool MCSetCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 	return __MCSetClone(self, false, r_new_set);
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetMutableCopy(MCSetRef self, MCSetRef& r_new_set)
 {
 	return __MCSetClone(self, true, r_new_set);
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetMutableCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 {
 	if (self -> references == 1)
@@ -117,6 +125,7 @@ bool MCSetMutableCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCSetIsMutable(MCSetRef self)
 {
 	return (self -> flags & kMCSetFlagIsMutable) != 0;
@@ -124,6 +133,7 @@ bool MCSetIsMutable(MCSetRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCSetIsEmpty(MCSetRef self)
 {
 	for(uindex_t i = 0; i < self -> limb_count; i++)
@@ -132,6 +142,7 @@ bool MCSetIsEmpty(MCSetRef self)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetIsEqualTo(MCSetRef self, MCSetRef other_self)
 {
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
@@ -146,6 +157,7 @@ bool MCSetIsEqualTo(MCSetRef self, MCSetRef other_self)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetContains(MCSetRef self, MCSetRef other_self)
 {
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
@@ -159,6 +171,7 @@ bool MCSetContains(MCSetRef self, MCSetRef other_self)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetIntersects(MCSetRef self, MCSetRef other_self)
 {
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
@@ -172,6 +185,7 @@ bool MCSetIntersects(MCSetRef self, MCSetRef other_self)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetContainsIndex(MCSetRef self, uindex_t p_element)
 {
 	if (p_element >= self -> limb_count * 32)
@@ -181,6 +195,7 @@ bool MCSetContainsIndex(MCSetRef self, uindex_t p_element)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCSetIncludeIndex(MCSetRef self, uindex_t p_index)
 {
 	if (!MCSetIsMutable(self))
@@ -195,6 +210,7 @@ bool MCSetIncludeIndex(MCSetRef self, uindex_t p_index)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetExcludeIndex(MCSetRef self, uindex_t p_index)
 {
 	if (!MCSetIsMutable(self))
@@ -208,6 +224,7 @@ bool MCSetExcludeIndex(MCSetRef self, uindex_t p_index)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetUnion(MCSetRef self, MCSetRef p_other_set)
 {
 	if (!MCSetIsMutable(self))
@@ -222,6 +239,7 @@ bool MCSetUnion(MCSetRef self, MCSetRef p_other_set)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetDifference(MCSetRef self, MCSetRef p_other_set)
 {
 	if (!MCSetIsMutable(self))
@@ -237,6 +255,7 @@ bool MCSetDifference(MCSetRef self, MCSetRef p_other_set)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetIntersect(MCSetRef self, MCSetRef p_other_set)
 {
 	if (!MCSetIsMutable(self))
@@ -251,6 +270,7 @@ bool MCSetIntersect(MCSetRef self, MCSetRef p_other_set)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCSetIterate(MCSetRef self, uindex_t& x_iterator, uindex_t& r_element)
 {
 	while(x_iterator < self -> limb_count * 32)

--- a/libfoundation/src/foundation-stream.cpp
+++ b/libfoundation/src/foundation-stream.cpp
@@ -26,7 +26,7 @@ struct __MCStreamImpl
 	const MCStreamCallbacks *callbacks;
 };
 
-MC_DLLEXPORT MCTypeInfoRef kMCStreamTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCStreamTypeInfo;
 
 static inline __MCStreamImpl &__MCStreamGet(MCStreamRef p_stream)
 {
@@ -140,6 +140,7 @@ static MCStreamCallbacks kMCMemoryInputStreamCallbacks =
 	__MCMemoryInputStreamSeek,
 };
 
+MC_DLLEXPORT_DEF
 bool MCMemoryInputStreamCreate(const void *p_block, size_t p_size, MCStreamRef& r_stream)
 {
 	MCStreamRef t_stream;
@@ -228,6 +229,7 @@ static MCStreamCallbacks kMCMemoryOutputStreamCallbacks =
 	nil,
 };
 
+MC_DLLEXPORT_DEF
 bool MCMemoryOutputStreamCreate(MCStreamRef& r_stream)
 {
 	MCStreamRef t_stream;
@@ -245,6 +247,7 @@ bool MCMemoryOutputStreamCreate(MCStreamRef& r_stream)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCMemoryOutputStreamFinish(MCStreamRef p_stream, void*& r_buffer, size_t& r_size)
 {
 	__MCMemoryOutputStream *self;
@@ -302,6 +305,7 @@ static MCValueCustomCallbacks kMCStreamCustomValueCallbacks =
 	nil,
 };
 
+MC_DLLEXPORT_DEF
 bool MCStreamCreate(const MCStreamCallbacks *p_callbacks, size_t p_extra_bytes, MCStreamRef& r_stream)
 {
 	MCStreamRef self;
@@ -315,6 +319,7 @@ bool MCStreamCreate(const MCStreamCallbacks *p_callbacks, size_t p_extra_bytes, 
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self);
@@ -322,21 +327,25 @@ const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStreamIsReadable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> read != nil;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamIsWritable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> write != nil;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamIsMarkable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> mark != nil;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamIsSeekable(MCStreamRef self)
 {
 	return __MCStreamCallbacks(self) -> seek != nil;
@@ -344,6 +353,7 @@ bool MCStreamIsSeekable(MCStreamRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStreamGetAvailableForRead(MCStreamRef self, size_t& r_available)
 {
 	if (__MCStreamCallbacks(self) -> get_available_for_read == nil)
@@ -351,6 +361,7 @@ bool MCStreamGetAvailableForRead(MCStreamRef self, size_t& r_available)
 	return __MCStreamCallbacks(self) -> get_available_for_read(self, r_available);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamRead(MCStreamRef self, void *p_buffer, size_t p_amount)
 {
 	if (__MCStreamCallbacks(self) -> read == nil)
@@ -358,6 +369,7 @@ bool MCStreamRead(MCStreamRef self, void *p_buffer, size_t p_amount)
 	return __MCStreamCallbacks(self) -> read(self, p_buffer, p_amount);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamGetAvailableForWrite(MCStreamRef self, size_t& r_available)
 {
 	if (__MCStreamCallbacks(self) -> get_available_for_write == nil)
@@ -365,6 +377,7 @@ bool MCStreamGetAvailableForWrite(MCStreamRef self, size_t& r_available)
 	return __MCStreamCallbacks(self) -> get_available_for_write(self, r_available);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWrite(MCStreamRef self, const void *p_buffer, size_t p_amount)
 {
 	if (__MCStreamCallbacks(self) -> write == nil)
@@ -372,6 +385,7 @@ bool MCStreamWrite(MCStreamRef self, const void *p_buffer, size_t p_amount)
 	return __MCStreamCallbacks(self) -> write(self, p_buffer, p_amount);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamSkip(MCStreamRef self, size_t p_amount)
 {
 	if (__MCStreamCallbacks(self) -> skip != nil)
@@ -388,6 +402,7 @@ bool MCStreamSkip(MCStreamRef self, size_t p_amount)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStreamMark(MCStreamRef self, size_t p_read_limit)
 {
 	if (__MCStreamCallbacks(self) -> mark == nil)
@@ -395,6 +410,7 @@ bool MCStreamMark(MCStreamRef self, size_t p_read_limit)
 	return __MCStreamCallbacks(self) -> mark(self, p_read_limit);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReset(MCStreamRef self)
 {
 	if (__MCStreamCallbacks(self) -> reset == nil)
@@ -404,6 +420,7 @@ bool MCStreamReset(MCStreamRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStreamTell(MCStreamRef self, filepos_t& r_position)
 {
 	if (__MCStreamCallbacks(self) -> tell == nil)
@@ -411,6 +428,7 @@ bool MCStreamTell(MCStreamRef self, filepos_t& r_position)
 	return __MCStreamCallbacks(self) -> tell(self, r_position);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamSeek(MCStreamRef self, filepos_t p_position)
 {
 	if (__MCStreamCallbacks(self) -> seek == nil)
@@ -420,11 +438,13 @@ bool MCStreamSeek(MCStreamRef self, filepos_t p_position)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadUInt8(MCStreamRef self, uint8_t& r_value)
 {
 	return MCStreamRead(self, &r_value, sizeof(uint8_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadUInt16(MCStreamRef self, uint16_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(uint16_t)))
@@ -435,6 +455,7 @@ bool MCStreamReadUInt16(MCStreamRef self, uint16_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadUInt32(MCStreamRef self, uint32_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(uint32_t)))
@@ -445,6 +466,7 @@ bool MCStreamReadUInt32(MCStreamRef self, uint32_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadUInt64(MCStreamRef self, uint64_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(uint64_t)))
@@ -455,11 +477,13 @@ bool MCStreamReadUInt64(MCStreamRef self, uint64_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadInt8(MCStreamRef self, int8_t& r_value)
 {
 	return MCStreamRead(self, &r_value, sizeof(int8_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadInt16(MCStreamRef self, int16_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(int16_t)))
@@ -470,6 +494,7 @@ bool MCStreamReadInt16(MCStreamRef self, int16_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadInt32(MCStreamRef self, int32_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(int32_t)))
@@ -480,6 +505,7 @@ bool MCStreamReadInt32(MCStreamRef self, int32_t& r_value)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadInt64(MCStreamRef self, int64_t& r_value)
 {
 	if (MCStreamRead(self, &r_value, sizeof(int64_t)))
@@ -490,13 +516,7 @@ bool MCStreamReadInt64(MCStreamRef self, int64_t& r_value)
 	return false;
 }
 
-bool MCStreamReadCompactUInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactUInt64(MCStreamRef stream, uint64_t& r_value);
-bool MCStreamReadCompactSInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactSInt64(MCStreamRef stream, uint64_t& r_value);
-
-bool MCStreamReadFloat(MCStreamRef stream, float& r_value);
-
+MC_DLLEXPORT_DEF
 bool MCStreamReadDouble(MCStreamRef stream, double& r_value)
 {
 	uint64_t t_bits;
@@ -510,11 +530,13 @@ bool MCStreamReadDouble(MCStreamRef stream, double& r_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteUInt8(MCStreamRef self, uint8_t p_value)
 {
 	return MCStreamWrite(self, &p_value, sizeof(uint8_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteUInt16(MCStreamRef self, uint16_t p_value)
 {
     uint16_t t_swapped_value;
@@ -522,6 +544,7 @@ bool MCStreamWriteUInt16(MCStreamRef self, uint16_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint16_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteUInt32(MCStreamRef self, uint32_t p_value)
 {
     uint32_t t_swapped_value;
@@ -529,6 +552,7 @@ bool MCStreamWriteUInt32(MCStreamRef self, uint32_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint32_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteUInt64(MCStreamRef self, uint64_t p_value)
 {
     uint64_t t_swapped_value;
@@ -536,11 +560,13 @@ bool MCStreamWriteUInt64(MCStreamRef self, uint64_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint64_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteInt8(MCStreamRef self, int8_t p_value)
 {
 	return MCStreamWrite(self, &p_value, sizeof(int8_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteInt16(MCStreamRef self, int16_t p_value)
 {
     uint16_t t_swapped_value;
@@ -548,6 +574,7 @@ bool MCStreamWriteInt16(MCStreamRef self, int16_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint16_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteInt32(MCStreamRef self, int32_t p_value)
 {
     uint32_t t_swapped_value;
@@ -555,6 +582,7 @@ bool MCStreamWriteInt32(MCStreamRef self, int32_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint32_t));
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamWriteInt64(MCStreamRef self, int64_t p_value)
 {
     uint64_t t_swapped_value;
@@ -562,13 +590,7 @@ bool MCStreamWriteInt64(MCStreamRef self, int64_t p_value)
 	return MCStreamWrite(self, &t_swapped_value, sizeof(uint64_t));
 }
 
-bool MCStreamReadCompactUInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactUInt64(MCStreamRef stream, uint64_t& r_value);
-bool MCStreamReadCompactSInt32(MCStreamRef stream, uint32_t& r_value);
-bool MCStreamReadCompactSInt64(MCStreamRef stream, uint64_t& r_value);
-
-bool MCStreamWriteFloat(MCStreamRef stream, float p_value);
-
+MC_DLLEXPORT_DEF
 bool MCStreamWriteDouble(MCStreamRef stream, double p_value)
 {
 	uint64_t t_bits;
@@ -578,6 +600,7 @@ bool MCStreamWriteDouble(MCStreamRef stream, double p_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadBoolean(MCStreamRef stream, MCBooleanRef& r_boolean)
 {
 	uint8_t t_value;
@@ -592,6 +615,7 @@ bool MCStreamReadBoolean(MCStreamRef stream, MCBooleanRef& r_boolean)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadNumber(MCStreamRef stream, MCNumberRef& r_number)
 {
 	uint8_t t_tag;
@@ -612,6 +636,7 @@ bool MCStreamReadNumber(MCStreamRef stream, MCNumberRef& r_number)
 	return MCNumberCreateWithReal(t_value, r_number);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadName(MCStreamRef stream, MCNameRef& r_name)
 {
 	MCStringRef t_string;
@@ -621,6 +646,7 @@ bool MCStreamReadName(MCStreamRef stream, MCNameRef& r_name)
 	return MCNameCreateAndRelease(t_string, r_name);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadString(MCStreamRef stream, MCStringRef& r_string)
 {
 	uint32_t t_length;
@@ -643,6 +669,7 @@ bool MCStreamReadString(MCStreamRef stream, MCStringRef& r_string)
 	return t_chars . CreateStringAndRelease(r_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadArray(MCStreamRef stream, MCArrayRef& r_array)
 {
 	uint32_t t_count;
@@ -684,6 +711,7 @@ bool MCStreamReadArray(MCStreamRef stream, MCArrayRef& r_array)
 	return MCArrayCopyAndRelease(t_array, r_array);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadSet(MCStreamRef stream, MCSetRef& r_set)
 {
 	uint32_t t_length;
@@ -710,6 +738,7 @@ bool MCStreamReadSet(MCStreamRef stream, MCSetRef& r_set)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStreamReadValue(MCStreamRef stream, MCValueRef& r_value)
 {
 	uint8_t t_tag;

--- a/libfoundation/src/foundation-string-cf.cpp
+++ b/libfoundation/src/foundation-string-cf.cpp
@@ -25,6 +25,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithCFString(CFStringRef p_cf_string, MCStringRef& r_string)
 {
 	bool t_success;

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -222,6 +222,7 @@ static bool __MCStringIsEmpty(MCStringRef string)
 // This method creates a 'constant' MCStringRef from the given c-string. At some
 // point we'll make it work 'magically' at compile/build time. For now, uniquing
 // and returning that has a similar effect (if slightly slower).
+MC_DLLEXPORT_DEF
 MCStringRef MCSTR(const char *p_cstring)
 {
 	MCStringRef t_string;
@@ -237,11 +238,13 @@ MCStringRef MCSTR(const char *p_cstring)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithCString(const char* p_cstring, MCStringRef& r_string)
 {
 	return MCStringCreateWithNativeChars((const char_t*)p_cstring, p_cstring == nil ? 0 : strlen(p_cstring), r_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
 {
 	if (MCStringCreateWithNativeChars((const char_t *)p_cstring, p_cstring == nil ? 0 : strlen((const char*)p_cstring), r_string))
@@ -253,6 +256,7 @@ bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 const char *MCStringGetCString(MCStringRef p_string)
 {
     if (p_string == nil)
@@ -268,6 +272,7 @@ const char *MCStringGetCString(MCStringRef p_string)
 	return t_cstring;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStringOptions p_options)
 {
 	return MCStringIsEqualToNativeChars(p_string, (const char_t *)p_cstring, strlen(p_cstring), p_options);
@@ -275,6 +280,7 @@ bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStr
 
 // Create an immutable string from the given bytes, interpreting them using
 // the specified encoding.
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     MCAssert(!p_is_external_rep);
@@ -386,6 +392,7 @@ bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStr
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     MCStringRef t_string;
@@ -436,6 +443,7 @@ bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, M
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithChars(const unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
     if (p_char_count == 0 && kMCEmptyString != nil)
@@ -498,6 +506,7 @@ bool MCStringCreateWithChars(const unichar_t *p_chars, uindex_t p_char_count, MC
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithCharsAndRelease(unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
     if (MCStringCreateWithChars(p_chars, p_char_count, r_string))
@@ -509,6 +518,7 @@ bool MCStringCreateWithCharsAndRelease(unichar_t *p_chars, uindex_t p_char_count
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithWString(const unichar_t *p_wstring, MCStringRef& r_string)
 {
 	uindex_t t_length;
@@ -518,6 +528,7 @@ bool MCStringCreateWithWString(const unichar_t *p_wstring, MCStringRef& r_string
 	return MCStringCreateWithChars(p_wstring, t_length, r_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithWStringAndRelease(unichar_t* p_wstring, MCStringRef& r_string)
 {
 	if (MCStringCreateWithWString(p_wstring, r_string))
@@ -529,6 +540,7 @@ bool MCStringCreateWithWStringAndRelease(unichar_t* p_wstring, MCStringRef& r_st
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithNativeChars(const char_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
 	bool t_success;
@@ -566,6 +578,7 @@ bool MCStringCreateWithNativeChars(const char_t *p_chars, uindex_t p_char_count,
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithNativeCharsAndRelease(char_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
     bool t_success;
@@ -629,6 +642,7 @@ static bool MCStringCreateMutableUnicode(uindex_t p_initial_capacity, MCStringRe
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateMutable(uindex_t p_initial_capacity, MCStringRef& r_string)
 {
 	bool t_success;
@@ -658,6 +672,7 @@ bool MCStringCreateMutable(uindex_t p_initial_capacity, MCStringRef& r_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringEncode(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is_external_rep, MCDataRef& r_data)
 {
     byte_t *t_bytes;
@@ -674,6 +689,7 @@ bool MCStringEncode(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringEncodeAndRelease(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is_external_rep, MCDataRef& r_data)
 {    
     MCDataRef t_data;
@@ -687,11 +703,13 @@ bool MCStringEncodeAndRelease(MCStringRef p_string, MCStringEncoding p_encoding,
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringDecode(MCDataRef p_data, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     return MCStringCreateWithBytes(MCDataGetBytePtr(p_data), MCDataGetLength(p_data), p_encoding, p_is_external_rep, r_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringDecodeAndRelease(MCDataRef p_data, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
     MCStringRef t_string;
@@ -733,6 +751,7 @@ static bool __MCStringFormatSupportedForUnicode(const char *p_format)
 #define FORMAT_ARG_64_BIT 1
 #endif
 
+MC_DLLEXPORT_DEF
 bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args)
 {
 	MCStringRef t_buffer;
@@ -904,6 +923,7 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringFormat(MCStringRef& r_string, const char *p_format, ...)
 {
 	bool t_success;
@@ -945,6 +965,7 @@ static bool __MCStringCloneNativeBuffer(MCStringRef self, char_t*& chars, uindex
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCopy(MCStringRef self, MCStringRef& r_new_string)
 {
 	// If the string is immutable we can just bump the reference count.
@@ -968,6 +989,7 @@ bool MCStringCopy(MCStringRef self, MCStringRef& r_new_string)
     return __MCStringCopyMutable(self, r_new_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 {
 	// If the string is immutable we just pass it through (as we are releasing the string).
@@ -1007,6 +1029,7 @@ bool MCStringCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMutableCopy(MCStringRef self, MCStringRef& r_new_string)
 {
 	// If self is immutable, then the new mutable string will be indirect
@@ -1026,6 +1049,7 @@ bool MCStringMutableCopy(MCStringRef self, MCStringRef& r_new_string)
     return __MCStringCreateIndirect(self -> string, r_new_string);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMutableCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 {
 	if (self -> references == 1)
@@ -1049,6 +1073,7 @@ bool MCStringMutableCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_substring)
 {
     if (__MCStringIsIndirect(self))
@@ -1066,6 +1091,7 @@ bool MCStringCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_sub
 	return MCStringCreateWithChars(self -> chars + p_range . offset, p_range . length, r_substring);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCopySubstringAndRelease(MCStringRef self, MCRange p_range, MCStringRef& r_substring)
 {
 	if (MCStringCopySubstring(self, p_range, r_substring))
@@ -1077,6 +1103,7 @@ bool MCStringCopySubstringAndRelease(MCStringRef self, MCRange p_range, MCString
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMutableCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_new_string)
 {
     if (__MCStringIsIndirect(self))
@@ -1117,6 +1144,7 @@ bool MCStringMutableCopySubstring(MCStringRef self, MCRange p_range, MCStringRef
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMutableCopySubstringAndRelease(MCStringRef self, MCRange p_range, MCStringRef& r_new_string)
 {
 	if (MCStringMutableCopySubstring(self, p_range, r_new_string))
@@ -1130,6 +1158,7 @@ bool MCStringMutableCopySubstringAndRelease(MCStringRef self, MCRange p_range, M
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringIsMutable(const MCStringRef self)
 {
 	return (self -> flags & kMCStringFlagIsMutable) != 0;
@@ -1137,6 +1166,7 @@ bool MCStringIsMutable(const MCStringRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 uindex_t MCStringGetLength(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1145,6 +1175,7 @@ uindex_t MCStringGetLength(MCStringRef self)
     return __MCStringGetLength(self);
 }
 
+MC_DLLEXPORT_DEF
 const unichar_t *MCStringGetCharPtr(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1155,6 +1186,7 @@ const unichar_t *MCStringGetCharPtr(MCStringRef self)
 	return self -> chars;
 }
 
+MC_DLLEXPORT_DEF
 const char_t *MCStringGetNativeCharPtr(MCStringRef self)
 {
     if (MCStringIsNative(self))
@@ -1170,12 +1202,14 @@ const char_t *MCStringGetNativeCharPtr(MCStringRef self)
     return nil;
 }
 
+MC_DLLEXPORT_DEF
 const char_t *MCStringGetNativeCharPtrAndLength(MCStringRef self, uindex_t& r_char_count)
 {
     r_char_count = __MCStringNativize(self);
 	return self -> native_chars;
 }
 
+MC_DLLEXPORT_DEF
 unichar_t MCStringGetCharAtIndex(MCStringRef self, uindex_t p_index)
 {
     if (__MCStringIsIndirect(self))
@@ -1187,6 +1221,7 @@ unichar_t MCStringGetCharAtIndex(MCStringRef self, uindex_t p_index)
 	return self -> chars[p_index];
 }
 
+MC_DLLEXPORT_DEF
 char_t MCStringGetNativeCharAtIndex(MCStringRef self, uindex_t p_index)
 {
     if (__MCStringIsIndirect(self))
@@ -1201,6 +1236,7 @@ char_t MCStringGetNativeCharAtIndex(MCStringRef self, uindex_t p_index)
 	return '?';
 }
 
+MC_DLLEXPORT_DEF
 codepoint_t MCStringGetCodepointAtIndex(MCStringRef self, uindex_t p_index)
 {
 	// Calculate the code unit index for the given codepoint
@@ -1229,6 +1265,7 @@ codepoint_t MCStringGetCodepointAtIndex(MCStringRef self, uindex_t p_index)
     return MCStringSurrogatesToCodepoint(t_lead, t_trail);
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCStringGetChars(MCStringRef self, MCRange p_range, unichar_t *p_chars)
 {
     if (__MCStringIsIndirect(self))
@@ -1252,6 +1289,7 @@ uindex_t MCStringGetChars(MCStringRef self, MCRange p_range, unichar_t *p_chars)
 	return t_count;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCStringGetNativeChars(MCStringRef self, MCRange p_range, char_t *p_chars)
 {
     if (__MCStringIsIndirect(self))
@@ -1276,11 +1314,13 @@ uindex_t MCStringGetNativeChars(MCStringRef self, MCRange p_range, char_t *p_cha
 	return t_count;
 }
 
+MC_DLLEXPORT_DEF
 void MCStringNativize(MCStringRef self)
 {
     __MCStringNativize(self);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
 {
     // AL-2014-12-12: [[ Bug 14208 ]] Implement a native copy function to aid conversion to data
@@ -1302,6 +1342,7 @@ bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringIsNative(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1310,6 +1351,7 @@ bool MCStringIsNative(MCStringRef self)
     return __MCStringIsNative(self);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCantBeEqualToNative(MCStringRef self, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -1318,6 +1360,7 @@ bool MCStringCantBeEqualToNative(MCStringRef self, MCStringOptions p_options)
     return __MCStringCantBeEqualToNative(self, p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCanBeNative(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1327,6 +1370,7 @@ bool MCStringCanBeNative(MCStringRef self)
 }
 
 // AL-2015-02-06: [[ Bug 14504 ]] Ensure 'simple' flag is checked against the direct string.
+MC_DLLEXPORT_DEF
 bool MCStringIsSimple(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1336,6 +1380,7 @@ bool MCStringIsSimple(MCStringRef self)
 }
 
 // AL-2015-02-06: [[ Bug 14504 ]] Ensure 'uncombined' flag is checked against the direct string.
+MC_DLLEXPORT_DEF
 bool MCStringIsUncombined(MCStringRef self)
 {
     if (__MCStringIsIndirect(self))
@@ -1344,6 +1389,7 @@ bool MCStringIsUncombined(MCStringRef self)
     return __MCStringIsUncombined(self);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &r_out_range)
 {
     if (__MCStringIsIndirect(self))
@@ -1429,6 +1475,7 @@ bool MCStringMapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringUnmapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &r_out_range)
 {    
     MCAssert(self != nil);
@@ -1533,6 +1580,7 @@ bool MCStringMapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocaleRe
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     if (__MCStringIsIndirect(self))
@@ -1559,11 +1607,13 @@ bool MCStringMapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange 
     return MCStringMapIndices(self, kMCBreakIteratorTypeCharacter, p_locale, p_in_range, r_out_range);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCodepointIsWordPart(codepoint_t p_codepoint)
 {
     return MCUnicodeIsAlphabetic(p_codepoint) || MCUnicodeIsDigit(p_codepoint);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {    
     MCAssert(self != nil);
@@ -1613,6 +1663,7 @@ bool MCStringMapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange 
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringMapSentenceIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     return MCStringMapIndices(self, kMCBreakIteratorTypeSentence, p_locale, p_in_range, r_out_range);
@@ -1674,6 +1725,7 @@ bool MCStringUnmapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocale
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringUnmapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {    
     if (__MCStringIsIndirect(self))
@@ -1700,6 +1752,7 @@ bool MCStringUnmapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
     return MCStringUnmapIndices(self, kMCBreakIteratorTypeCharacter, p_locale, p_in_range, r_out_range);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     MCAssert(self != nil);
@@ -1788,12 +1841,14 @@ bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringUnmapSentenceIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
     return MCStringUnmapIndices(self, kMCBreakIteratorTypeSentence, p_locale, p_in_range, r_out_range);
 }
 
 extern MCLocaleRef kMCLocaleBasic;
+MC_DLLEXPORT_DEF
 bool MCStringMapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_char_range, MCRange &r_cu_range)
 {
     switch (p_type)
@@ -1813,6 +1868,7 @@ bool MCStringMapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_char
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringUnmapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_cu_range, MCRange &r_char_range)
 {
     switch (p_type)
@@ -1834,6 +1890,7 @@ bool MCStringUnmapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_cu
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToBytes(MCStringRef self, MCStringEncoding p_encoding, bool p_is_external_rep, byte_t*& r_bytes, uindex_t& r_byte_count)
 {
     MCAssert(!p_is_external_rep);
@@ -1933,6 +1990,7 @@ bool MCStringConvertToBytes(MCStringRef self, MCStringEncoding p_encoding, bool 
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char_count)
 {
     // Get the native chars, but excludes any char belonging to the extended part of the ASCII -
@@ -1954,6 +2012,7 @@ bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToUnicode(MCStringRef self, unichar_t*& r_chars, uindex_t& r_char_count)
 {
 	// Allocate an array of chars one bigger than needed. As the allocated array
@@ -1967,6 +2026,7 @@ bool MCStringConvertToUnicode(MCStringRef self, unichar_t*& r_chars, uindex_t& r
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, uindex_t& r_char_count)
 {
     MCAutoStringRef t_normalized;
@@ -1976,6 +2036,7 @@ bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, u
     return MCStringConvertToNative(*t_normalized, r_chars, r_char_count);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToNative(MCStringRef self, char_t*& r_chars, uindex_t& r_char_count)
 {
 	// Allocate an array of chars one byte bigger than needed. As the allocated array
@@ -1989,6 +2050,7 @@ bool MCStringConvertToNative(MCStringRef self, char_t*& r_chars, uindex_t& r_cha
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring)
 {
     MCAutoStringRef t_normalized;
@@ -1998,6 +2060,7 @@ bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring)
     return MCStringConvertToCString(*t_normalized, r_cstring);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToCString(MCStringRef p_string, char*& r_cstring)
 {
     uindex_t t_length;
@@ -2011,6 +2074,7 @@ bool MCStringConvertToCString(MCStringRef p_string, char*& r_cstring)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToWString(MCStringRef p_string, unichar_t*& r_wstring)
 {
     uindex_t t_length;
@@ -2024,12 +2088,14 @@ bool MCStringConvertToWString(MCStringRef p_string, unichar_t*& r_wstring)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToUTF8String(MCStringRef p_string, char*& r_utf8string)
 {
 	uindex_t length_is_ignored;
 	return MCStringConvertToUTF8(p_string, r_utf8string, length_is_ignored);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToUTF8(MCStringRef p_string, char*& r_utf8string, uindex_t& r_utf8_chars)
 {
 	// Allocate an array of chars one byte bigger than needed. As the allocated array
@@ -2061,6 +2127,7 @@ bool MCStringConvertToUTF8(MCStringRef p_string, char*& r_utf8string, uindex_t& 
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_t &r_char_count)
 {
     if (MCStringIsNative(self))
@@ -2152,6 +2219,7 @@ bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_
 }
 
 #if defined(__MAC__) || defined (__IOS__)
+MC_DLLEXPORT_DEF
 bool MCStringConvertToCFStringRef(MCStringRef p_string, CFStringRef& r_cfstring)
 {
     uindex_t t_length;
@@ -2171,6 +2239,7 @@ bool MCStringConvertToCFStringRef(MCStringRef p_string, CFStringRef& r_cfstring)
 
 #if 0
 #ifdef __WINDOWS__
+MC_DLLEXPORT_DEF
 bool MCStringConvertToBSTR(MCStringRef p_string, BSTR& r_bstr)
 {
     uindex_t t_length;
@@ -2195,6 +2264,7 @@ bool MCStringConvertToBSTR(MCStringRef p_string, BSTR& r_bstr)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 hash_t MCStringHash(MCStringRef self, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2206,6 +2276,7 @@ hash_t MCStringHash(MCStringRef self, MCStringOptions p_options)
 	return MCUnicodeHash(self -> chars, self -> char_count, (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringIsEqualTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2241,11 +2312,13 @@ bool MCStringIsEqualTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_
     return MCUnicodeCompare(self -> chars, self -> char_count, self_native, p_other -> chars, p_other -> char_count, other_native, (MCUnicodeCompareOption)p_options) == 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringIsEmpty(MCStringRef string)
 {
 	return string == nil || MCStringGetLength(string) == 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSubstringIsEqualTo(MCStringRef self, MCRange p_sub, MCStringRef p_other, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2278,6 +2351,7 @@ bool MCStringSubstringIsEqualTo(MCStringRef self, MCRange p_sub, MCStringRef p_o
     return MCUnicodeCompare(self_chars, p_sub . length, self_native, p_other -> chars, p_other -> char_count, __MCStringIsNative(p_other), (MCUnicodeCompareOption)p_options) == 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSubstringIsEqualToSubstring(MCStringRef self, MCRange p_sub, MCStringRef p_other, MCRange p_other_sub, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2313,6 +2387,7 @@ bool MCStringSubstringIsEqualToSubstring(MCStringRef self, MCRange p_sub, MCStri
     return MCUnicodeCompare(self_chars, p_sub . length, self_native, other_chars, p_other_sub . length, other_native, (MCUnicodeCompareOption)p_options) == 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringIsEqualToNativeChars(MCStringRef self, const char_t *p_chars, uindex_t p_char_count, MCStringOptions p_options)
 {
     if (MCStringIsNative(self))
@@ -2334,6 +2409,7 @@ bool MCStringIsEqualToNativeChars(MCStringRef self, const char_t *p_chars, uinde
 	return MCStringIsEqualTo(self, *t_string, p_options);
 }
 
+MC_DLLEXPORT_DEF
 compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2345,6 +2421,7 @@ compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptio
     return MCUnicodeCompare(self -> chars, self -> char_count, __MCStringIsNative(self), p_other -> chars, p_other -> char_count, __MCStringIsNative(p_other), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringBeginsWith(MCStringRef self, MCStringRef p_prefix, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2373,6 +2450,7 @@ bool MCStringBeginsWith(MCStringRef self, MCStringRef p_prefix, MCStringOptions 
     return MCUnicodeBeginsWith(self -> chars, self -> char_count, __MCStringIsNative(self), p_prefix -> chars, p_prefix -> char_count, __MCStringIsNative(p_prefix), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefix, MCStringOptions p_options, uindex_t& r_self_match_length)
 {
     if (__MCStringIsIndirect(self))
@@ -2412,6 +2490,7 @@ bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefi
     return t_prefix_share == __MCStringGetLength(p_prefix);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringBeginsWithCString(MCStringRef self, const char_t *p_prefix_cstring, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2433,6 +2512,7 @@ bool MCStringBeginsWithCString(MCStringRef self, const char_t *p_prefix_cstring,
 	return MCStringBeginsWith(self, *t_string, p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringEndsWith(MCStringRef self, MCStringRef p_suffix, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2462,6 +2542,7 @@ bool MCStringEndsWith(MCStringRef self, MCStringRef p_suffix, MCStringOptions p_
     return MCUnicodeEndsWith(self -> chars, self -> char_count, __MCStringIsNative(self), p_suffix -> chars, p_suffix -> char_count, __MCStringIsNative(p_suffix), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffix, MCStringOptions p_options, uindex_t& r_self_match_length)
 {
     if (__MCStringIsIndirect(self))
@@ -2501,6 +2582,7 @@ bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffi
     return t_suffix_share == MCStringGetLength(p_suffix);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringEndsWithCString(MCStringRef self, const char_t *p_suffix_cstring, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(self))
@@ -2522,6 +2604,7 @@ bool MCStringEndsWithCString(MCStringRef self, const char_t *p_suffix_cstring, M
 	return MCStringEndsWith(self, *t_string, p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringContains(MCStringRef self, MCStringRef p_needle, MCStringOptions p_options)
 {
     if (MCStringIsEmpty(p_needle))
@@ -2561,6 +2644,7 @@ bool MCStringContains(MCStringRef self, MCStringRef p_needle, MCStringOptions p_
     return MCUnicodeContains(self -> chars, self -> char_count, __MCStringIsNative(self), p_needle -> chars, p_needle -> char_count, __MCStringIsNative(p_needle), (MCUnicodeCompareOption)p_options);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSubstringContains(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(p_needle))
@@ -2612,12 +2696,13 @@ bool MCStringSubstringContains(MCStringRef self, MCRange p_range, MCStringRef p_
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringFirstIndexOf(MCStringRef self, MCStringRef p_needle, uindex_t p_after, MCStringOptions p_options, uindex_t& r_offset)
 {
     return MCStringFirstIndexOfStringInRange(self, p_needle, MCRangeMake(p_after, UINDEX_MAX), p_options, r_offset);
 }
 
-
+MC_DLLEXPORT_DEF
 bool MCStringFirstIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2672,11 +2757,13 @@ bool MCStringFirstIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, M
     return t_result;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringFirstIndexOfChar(MCStringRef self, codepoint_t p_needle, uindex_t p_after, MCStringOptions p_options, uindex_t& r_offset)
 {
     return MCStringFirstIndexOfCharInRange(self, p_needle, MCRangeMake(p_after, self -> char_count - p_after), p_options, r_offset);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2720,11 +2807,13 @@ bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCR
     return t_result;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringLastIndexOf(MCStringRef self, MCStringRef p_needle, uindex_t p_before, MCStringOptions p_options, uindex_t& r_offset)
 {
     return MCStringLastIndexOfStringInRange(self, p_needle, MCRangeMake(0, p_before), p_options, r_offset);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringLastIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2798,6 +2887,7 @@ bool MCStringLastIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, MC
     return MCUnicodeLastIndexOf(self -> chars + p_range . offset, p_range . length, __MCStringIsNative(self), p_needle -> chars, p_needle -> char_count, __MCStringIsNative(p_needle), (MCUnicodeCompareOption)p_options, r_offset);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringLastIndexOfChar(MCStringRef self, codepoint_t p_needle, uindex_t p_before, MCStringOptions p_options, uindex_t& r_offset)
 {
     if (__MCStringIsIndirect(self))
@@ -2888,6 +2978,7 @@ static bool MCStringFindNative(MCStringRef self, MCRange p_range, MCStringRef p_
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringFind(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options, MCRange *r_result)
 {
     if (__MCStringIsIndirect(self))
@@ -3018,6 +3109,7 @@ static uindex_t MCStringCountStrChars(MCStringRef self, MCRange p_range, const v
 	return t_count;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCStringCount(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options)
 {
     if (__MCStringIsIndirect(p_needle))
@@ -3037,6 +3129,7 @@ uindex_t MCStringCount(MCStringRef self, MCRange p_range, MCStringRef p_needle, 
     return t_count;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCStringCountChar(MCStringRef self, MCRange p_range, codepoint_t p_needle, MCStringOptions p_options)
 {
 	// We only support ASCII for now.
@@ -3058,6 +3151,7 @@ uindex_t MCStringCountChar(MCStringRef self, MCRange p_range, codepoint_t p_need
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringDivideAtChar(MCStringRef self, codepoint_t p_separator, MCStringOptions p_options, MCStringRef& r_head, MCStringRef& r_tail)
 {
 	uindex_t t_offset;
@@ -3074,6 +3168,7 @@ bool MCStringDivideAtChar(MCStringRef self, codepoint_t p_separator, MCStringOpt
 	return MCStringDivideAtIndex(self, t_offset, r_head, r_tail);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_head, MCStringRef& r_tail)
 {
 	MCStringRef t_head;
@@ -3095,6 +3190,7 @@ bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_h
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringBreakIntoChunks(MCStringRef self, codepoint_t p_separator, MCStringOptions p_options, MCRange*& r_ranges, uindex_t& r_range_count)
 {
 	MCAssert(p_separator < 128);
@@ -3147,6 +3243,7 @@ bool MCStringBreakIntoChunks(MCStringRef self, codepoint_t p_separator, MCString
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringFold(MCStringRef self, MCStringOptions p_options)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3184,6 +3281,7 @@ bool MCStringFold(MCStringRef self, MCStringOptions p_options)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringLowercase(MCStringRef self, MCLocaleRef p_locale)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3216,6 +3314,7 @@ bool MCStringLowercase(MCStringRef self, MCLocaleRef p_locale)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringUppercase(MCStringRef self, MCLocaleRef p_locale)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3250,6 +3349,7 @@ bool MCStringUppercase(MCStringRef self, MCLocaleRef p_locale)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringAppend(MCStringRef self, MCStringRef p_suffix)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3272,6 +3372,7 @@ bool MCStringAppend(MCStringRef self, MCStringRef p_suffix)
 	return MCStringAppend(self, *t_suffix_copy);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringAppendSubstring(MCStringRef self, MCStringRef p_suffix, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3296,6 +3397,7 @@ bool MCStringAppendSubstring(MCStringRef self, MCStringRef p_suffix, MCRange p_r
     MCStringAppend(self, *t_suffix_substring);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringAppendNativeChars(MCStringRef self, const char_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3331,6 +3433,7 @@ bool MCStringAppendNativeChars(MCStringRef self, const char_t *p_chars, uindex_t
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringAppendChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3383,17 +3486,19 @@ bool MCStringAppendChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringAppendNativeChar(MCStringRef self, char_t p_char)
 {
 	return MCStringAppendNativeChars(self, &p_char, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringAppendChar(MCStringRef self, unichar_t p_char)
 {
 	return MCStringAppendChars(self, &p_char, 1);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCStringAppendCodepoint (MCStringRef self, codepoint_t p_codepoint)
 {
 	uindex_t t_num_units;
@@ -3402,6 +3507,7 @@ MCStringAppendCodepoint (MCStringRef self, codepoint_t p_codepoint)
 	return MCStringAppendChars (self, t_units, t_num_units);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringPrepend(MCStringRef self, MCStringRef p_prefix)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3424,6 +3530,7 @@ bool MCStringPrepend(MCStringRef self, MCStringRef p_prefix)
 	return MCStringPrepend(self, *t_prefix_copy);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringPrependSubstring(MCStringRef self, MCStringRef p_prefix, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3448,6 +3555,7 @@ bool MCStringPrependSubstring(MCStringRef self, MCStringRef p_prefix, MCRange p_
     MCStringPrepend(self, *t_prefix_substring);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringPrependNativeChars(MCStringRef self, const char_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3479,6 +3587,7 @@ bool MCStringPrependNativeChars(MCStringRef self, const char_t *p_chars, uindex_
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringPrependChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3530,17 +3639,19 @@ bool MCStringPrependChars(MCStringRef self, const unichar_t *p_chars, uindex_t p
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringPrependNativeChar(MCStringRef self, char_t p_char)
 {
 	return MCStringPrependNativeChars(self, &p_char, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringPrependChar(MCStringRef self, unichar_t p_char)
 {
 	return MCStringPrependChars(self, &p_char, 1);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCStringPrependCodepoint (MCStringRef self, codepoint_t p_codepoint)
 {
 	uindex_t t_num_units;
@@ -3549,6 +3660,7 @@ MCStringPrependCodepoint (MCStringRef self, codepoint_t p_codepoint)
 	return MCStringPrependChars (self, t_units, t_num_units);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringInsert(MCStringRef self, uindex_t p_at, MCStringRef p_substring)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3571,6 +3683,7 @@ bool MCStringInsert(MCStringRef self, uindex_t p_at, MCStringRef p_substring)
 	return MCStringInsert(self, p_at, *t_substring_copy);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringInsertSubstring(MCStringRef self, uindex_t p_at, MCStringRef p_substring, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3593,6 +3706,7 @@ bool MCStringInsertSubstring(MCStringRef self, uindex_t p_at, MCStringRef p_subs
     MCStringInsert(self, p_at, *t_substring_substring);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringInsertNativeChars(MCStringRef self, uindex_t p_at, const char_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3626,6 +3740,7 @@ bool MCStringInsertNativeChars(MCStringRef self, uindex_t p_at, const char_t *p_
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringInsertChars(MCStringRef self, uindex_t p_at, const unichar_t *p_chars, uindex_t p_char_count)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3678,17 +3793,19 @@ bool MCStringInsertChars(MCStringRef self, uindex_t p_at, const unichar_t *p_cha
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringInsertNativeChar(MCStringRef self, uindex_t p_at, char_t p_char)
 {
 	return MCStringInsertNativeChars(self, p_at, &p_char, 1);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringInsertChar(MCStringRef self, uindex_t p_at, unichar_t p_char)
 {
 	return MCStringInsertChars(self, p_at, &p_char, 1);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCStringInsertCodepoint (MCStringRef self, uindex_t p_at, codepoint_t p_codepoint)
 {
 	uindex_t t_num_units;
@@ -3697,6 +3814,7 @@ MCStringInsertCodepoint (MCStringRef self, uindex_t p_at, codepoint_t p_codepoin
 	return MCStringInsertChars (self, p_at, t_units, t_num_units);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringRemove(MCStringRef self, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3721,6 +3839,7 @@ bool MCStringRemove(MCStringRef self, MCRange p_range)
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSubstring(MCStringRef self, MCRange p_range)
 {
 	MCAssert(MCStringIsMutable(self));
@@ -3868,6 +3987,7 @@ bool MCStringReplaceChars(MCStringRef self, MCRange p_range, const unichar_t *p_
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringReplace(MCStringRef self, MCRange p_range, MCStringRef p_replacement)
 {
     if (__MCStringIsIndirect(p_replacement))
@@ -3888,6 +4008,7 @@ bool MCStringReplace(MCStringRef self, MCRange p_range, MCStringRef p_replacemen
 	return MCStringReplace(self, p_range, *t_replacement_copy);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringPad(MCStringRef self, uindex_t p_at, uindex_t p_count, MCStringRef p_value)
 {
     // Ensure the string is not indirect.
@@ -3910,6 +4031,7 @@ bool MCStringPad(MCStringRef self, uindex_t p_at, uindex_t p_count, MCStringRef 
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringResolvesLeftToRight(MCStringRef self)
 {
     if (MCStringIsNative(self) || MCStringCanBeNative(self))
@@ -3920,6 +4042,7 @@ bool MCStringResolvesLeftToRight(MCStringRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCStringAppendFormat(MCStringRef self, const char *p_format, ...)
 {
 	bool t_success;
@@ -3930,6 +4053,7 @@ bool MCStringAppendFormat(MCStringRef self, const char *p_format, ...)
 	return t_success;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringAppendFormatV(MCStringRef self, const char *p_format, va_list p_args)
 {
 	MCAutoStringRef t_formatted_string;
@@ -4245,6 +4369,7 @@ static void split_find_end_of_element_and_key(const void *sptr, uindex_t length,
     split_find_end_of_element(sptr, length, native, p_del, p_del_length, p_del_native, p_options, r_element_end, r_del_found_length);
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_del, MCStringOptions p_options, MCArrayRef& r_array)
 {
     if (__MCStringIsIndirect(self))
@@ -4366,6 +4491,7 @@ bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_d
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSplitByDelimiter(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list)
 {
     if (__MCStringIsIndirect(self))
@@ -4452,6 +4578,7 @@ bool MCStringSplitByDelimiter(MCStringRef self, MCStringRef p_elem_del, MCString
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringSplitByDelimiterNative(MCStringRef self, MCStringRef p_elem_del, MCStringOptions p_options, MCProperListRef& r_list)
 {
     if (__MCStringIsIndirect(self))
@@ -4507,6 +4634,7 @@ bool MCStringSplitByDelimiterNative(MCStringRef self, MCStringRef p_elem_del, MC
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringFindAndReplaceChar(MCStringRef self, codepoint_t p_pattern, codepoint_t p_replacement, MCStringOptions p_options)
 {
     // Ensure the string is not indirect.
@@ -4560,6 +4688,7 @@ bool MCStringFindAndReplaceChar(MCStringRef self, codepoint_t p_pattern, codepoi
       return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringFindAndReplace(MCStringRef self, MCStringRef p_pattern, MCStringRef p_replacement, MCStringOptions p_options)
 {
     // Ensure the string is not indirect.
@@ -4667,6 +4796,7 @@ bool MCStringFindAndReplace(MCStringRef self, MCStringRef p_pattern, MCStringRef
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringWildcardMatch(MCStringRef source, MCRange source_range, MCStringRef pattern, MCStringOptions p_options)
 {
     bool source_native = MCStringIsNative(source);
@@ -4998,11 +5128,13 @@ static void __MCStringChanged(MCStringRef self, uindex_t simple, uindex_t uncomb
         self -> flags |= kMCStringFlagCanBeNative;
 }
 
+MC_DLLEXPORT_DEF
 codepoint_t MCStringSurrogatesToCodepoint(unichar_t p_lead, unichar_t p_trail)
 {
     return 0x10000 + ((p_lead & 0x3FF) << 10) + (p_trail & 0x3FF);
 }
 
+MC_DLLEXPORT_DEF
 unsigned int MCStringCodepointToSurrogates(codepoint_t p_codepoint, unichar_t (&r_units)[2])
 {
     if (p_codepoint > 0xFFFF)
@@ -5019,6 +5151,7 @@ unsigned int MCStringCodepointToSurrogates(codepoint_t p_codepoint, unichar_t (&
     }
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringIsValidSurrogatePair(MCStringRef self, uindex_t p_index)
 {
     if (__MCStringIsIndirect(self))
@@ -5049,13 +5182,13 @@ bool MCStringIsValidSurrogatePair(MCStringRef self, uindex_t p_index)
 	
 ////////////////////////////////////////////////////////////////////////////////
 
-MCStringRef kMCEmptyString;
-MCStringRef kMCTrueString;
-MCStringRef kMCFalseString;
-MCStringRef kMCMixedString;
-MCStringRef kMCCommaString;
-MCStringRef kMCLineEndString;
-MCStringRef kMCTabString;
+MC_DLLEXPORT_DEF MCStringRef kMCEmptyString;
+MC_DLLEXPORT_DEF MCStringRef kMCTrueString;
+MC_DLLEXPORT_DEF MCStringRef kMCFalseString;
+MC_DLLEXPORT_DEF MCStringRef kMCMixedString;
+MC_DLLEXPORT_DEF MCStringRef kMCCommaString;
+MC_DLLEXPORT_DEF MCStringRef kMCLineEndString;
+MC_DLLEXPORT_DEF MCStringRef kMCTabString;
 
 bool __MCStringInitialize(void)
 {
@@ -5180,6 +5313,7 @@ static bool do_iconv(iconv_t fd, const char *in, size_t in_len, char * &out, siz
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithSysString(const char *p_system_string, MCStringRef &r_string)
 {
     // Is the string empty?
@@ -5238,6 +5372,7 @@ bool MCStringCreateWithSysString(const char *p_system_string, MCStringRef &r_str
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
 {
     // Create the pseudo-FD that iconv uses for character conversion. For
@@ -5376,6 +5511,7 @@ MCStringCreateWithSysString(const char *p_sys_string,
 }
 #endif
 
+MC_DLLEXPORT_DEF
 bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)
 {
     if (MCStringIsNative(self))
@@ -5391,6 +5527,7 @@ bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringNormalizedCopyNFD(MCStringRef self, MCStringRef &r_string)
 {
     // AL-2014-06-24: [[ Bug 12656 ]] Native strings can be decomposed into non-native ones.
@@ -5403,6 +5540,7 @@ bool MCStringNormalizedCopyNFD(MCStringRef self, MCStringRef &r_string)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringNormalizedCopyNFKC(MCStringRef self, MCStringRef &r_string)
 {
     // Native strings are already normalized
@@ -5419,6 +5557,7 @@ bool MCStringNormalizedCopyNFKC(MCStringRef self, MCStringRef &r_string)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringNormalizedCopyNFKD(MCStringRef self, MCStringRef &r_string)
 {
     // AL-2014-06-24: [[ Bug 12656 ]] Native strings can be decomposed into non-native ones.
@@ -5434,6 +5573,7 @@ bool MCStringNormalizedCopyNFKD(MCStringRef self, MCStringRef &r_string)
 
 /////////
 
+MC_DLLEXPORT_DEF
 bool MCStringSetNumericValue(MCStringRef self, double p_value)
 {
     if (__MCStringIsIndirect(self))
@@ -5463,6 +5603,7 @@ bool MCStringSetNumericValue(MCStringRef self, double p_value)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCStringGetNumericValue(MCStringRef self, double &r_value)
 {
     if (__MCStringIsIndirect(self))

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -153,6 +153,7 @@ static integer_t MCU_strtol(const char *sptr, uindex_t &l, int8_t c, bool &done,
 	return value;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeConvertStringToLongInteger(MCStringRef p_string, integer_t& r_converted)
 {
     if (!MCStringCanBeNative(p_string))
@@ -167,6 +168,7 @@ bool MCTypeConvertStringToLongInteger(MCStringRef p_string, integer_t& r_convert
 	return t_done;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool p_convert_octals)
 {
     if (!MCStringCanBeNative(p_string))
@@ -207,6 +209,7 @@ bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeConvertStringToBool(MCStringRef p_string, bool& r_converted)
 {
     if (MCStringIsEqualTo(p_string, kMCTrueString, kMCStringOptionCompareCaseless))

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -23,17 +23,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCTypeInfoRef kMCAnyTypeInfo;
-MCTypeInfoRef kMCNullTypeInfo;
-MCTypeInfoRef kMCBooleanTypeInfo;
-MCTypeInfoRef kMCNumberTypeInfo;
-MCTypeInfoRef kMCStringTypeInfo;
-MCTypeInfoRef kMCNameTypeInfo;
-MCTypeInfoRef kMCDataTypeInfo;
-MCTypeInfoRef kMCArrayTypeInfo;
-MCTypeInfoRef kMCSetTypeInfo;
-MCTypeInfoRef kMCListTypeInfo;
-MCTypeInfoRef kMCProperListTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCAnyTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCNullTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCBooleanTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCNumberTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCStringTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCNameTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCDataTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCArrayTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSetTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCListTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCProperListTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -49,46 +49,55 @@ static intenum_t __MCTypeInfoGetExtendedTypeCode(MCTypeInfoRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsAlias(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsAlias;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsNamed(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsNamed;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsOptional(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsOptional;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsHandler(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeHandler;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsRecord(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeRecord;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsError(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeError;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsForeign(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCTypeInfoTypeIsForeign;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoIsCustom(MCTypeInfoRef self)
 {
     return __MCTypeInfoGetExtendedTypeCode(self) == kMCValueTypeCodeCustom;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoResolve(MCTypeInfoRef self, MCResolvedTypeInfo& r_resolution)
 {
     intenum_t t_ext_typecode;
@@ -130,6 +139,7 @@ bool MCTypeInfoResolve(MCTypeInfoRef self, MCResolvedTypeInfo& r_resolution)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target)
 {
     // We require that source is concrete for all but handler types (as handlers
@@ -156,6 +166,7 @@ bool MCTypeInfoConforms(MCTypeInfoRef source, MCTypeInfoRef target)
     return MCResolvedTypeInfoConforms(t_resolved_source, t_resolved_target);
 }
 
+MC_DLLEXPORT_DEF
 bool MCResolvedTypeInfoConforms(const MCResolvedTypeInfo& source, const MCResolvedTypeInfo& target)
 {
     // If source and target are the same, we are done - as they are named types.
@@ -271,6 +282,7 @@ bool MCResolvedTypeInfoConforms(const MCResolvedTypeInfo& source, const MCResolv
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCBuiltinTypeInfoCreate(MCValueTypeCode p_code, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -289,6 +301,7 @@ bool MCBuiltinTypeInfoCreate(MCValueTypeCode p_code, MCTypeInfoRef& r_typeinfo)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCAliasTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef p_target, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -307,11 +320,13 @@ bool MCAliasTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef p_target, MCTypeInfoR
     return false;
 }
 
+MC_DLLEXPORT_DEF
 MCNameRef MCAliasTypeInfoGetName(MCTypeInfoRef self)
 {
     return self -> alias . name;
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCAliasTypeInfoGetTarget(MCTypeInfoRef self)
 {
     return self -> alias . typeinfo;
@@ -319,6 +334,7 @@ MCTypeInfoRef MCAliasTypeInfoGetTarget(MCTypeInfoRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCNamedTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -340,21 +356,25 @@ bool MCNamedTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef& r_typeinfo)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 MCNameRef MCNamedTypeInfoGetName(MCTypeInfoRef self)
 {
     return self -> named . name;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNamedTypeInfoIsBound(MCTypeInfoRef self)
 {
     return self -> named . typeinfo != nil;
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCNamedTypeInfoGetBoundTypeInfo(MCTypeInfoRef self)
 {
     return self -> named . typeinfo;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNamedTypeInfoBind(MCTypeInfoRef self, MCTypeInfoRef p_target)
 {
     if (self -> named . typeinfo != nil)
@@ -365,6 +385,7 @@ bool MCNamedTypeInfoBind(MCTypeInfoRef self, MCTypeInfoRef p_target)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNamedTypeInfoUnbind(MCTypeInfoRef self)
 {
     if (self -> named . typeinfo == nil)
@@ -376,6 +397,7 @@ bool MCNamedTypeInfoUnbind(MCTypeInfoRef self)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNamedTypeInfoResolve(MCTypeInfoRef self, MCTypeInfoRef& r_bound_type)
 {
     if (self -> named . typeinfo == nil)
@@ -388,6 +410,7 @@ bool MCNamedTypeInfoResolve(MCTypeInfoRef self, MCTypeInfoRef& r_bound_type)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCOptionalTypeInfoCreate(MCTypeInfoRef p_base, MCTypeInfoRef& r_new_type)
 {
     if (__MCTypeInfoGetExtendedTypeCode(p_base) == kMCTypeInfoTypeIsOptional)
@@ -411,6 +434,7 @@ bool MCOptionalTypeInfoCreate(MCTypeInfoRef p_base, MCTypeInfoRef& r_new_type)
     return false;
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCOptionalTypeInfoGetBaseTypeInfo(MCTypeInfoRef p_base)
 {
     return p_base -> optional . basetype;
@@ -489,6 +513,7 @@ static bool __MCForeignTypeInfoComputeLayoutType(MCTypeInfoRef self)
     return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -531,11 +556,13 @@ bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCType
     return false;
 }
 
+MC_DLLEXPORT_DEF
 const MCForeignTypeDescriptor *MCForeignTypeInfoGetDescriptor(MCTypeInfoRef self)
 {
     return &self -> foreign . descriptor;
 }
 
+MC_DLLEXPORT_DEF
 void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef self)
 {
     return self -> foreign . ffi_layout_type;
@@ -543,6 +570,7 @@ void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, index_t p_field_count, MCTypeInfoRef p_base, MCTypeInfoRef& r_typeinfo)
 	
 {
@@ -594,6 +622,7 @@ bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *p_fields, index_t p_fie
     return false;
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef unresolved_self)
 {
 	MCTypeInfoRef self;
@@ -602,6 +631,7 @@ MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef unresolved_self)
     return self -> record . base;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCRecordTypeInfoGetFieldCount(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -625,6 +655,7 @@ __MCRecordTypeInfoGetFieldCount(MCTypeInfoRef self)
     return t_field_count;
 }
 
+MC_DLLEXPORT_DEF
 MCNameRef MCRecordTypeInfoGetFieldName(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -640,6 +671,7 @@ MCNameRef MCRecordTypeInfoGetFieldName(MCTypeInfoRef unresolved_self, uindex_t p
 	return t_base_type -> record . fields[t_base_index] . name;
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -655,7 +687,7 @@ MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef unresolved_self, uindex
 	return t_base_type -> record . fields[t_base_index] . type;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCRecordTypeInfoIsDerivedFrom(MCTypeInfoRef self,
                               MCTypeInfoRef other)
 {
@@ -693,6 +725,7 @@ __MCRecordTypeInfoGetBaseTypeForField (__MCTypeInfo *self,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *p_fields, index_t p_field_count, MCTypeInfoRef p_return_type, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -729,6 +762,7 @@ bool MCHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *p_fields, index_t p_f
     return false;
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCHandlerTypeInfoGetReturnType(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -739,6 +773,7 @@ MCTypeInfoRef MCHandlerTypeInfoGetReturnType(MCTypeInfoRef unresolved_self)
     return self -> handler . return_type;
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCHandlerTypeInfoGetParameterCount(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -749,6 +784,7 @@ uindex_t MCHandlerTypeInfoGetParameterCount(MCTypeInfoRef unresolved_self)
     return self -> handler . field_count;
 }
 
+MC_DLLEXPORT_DEF
 MCHandlerTypeFieldMode MCHandlerTypeInfoGetParameterMode(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -760,6 +796,7 @@ MCHandlerTypeFieldMode MCHandlerTypeInfoGetParameterMode(MCTypeInfoRef unresolve
     return self -> handler . fields[p_index] . mode;
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCHandlerTypeInfoGetParameterType(MCTypeInfoRef unresolved_self, uindex_t p_index)
 {
     MCTypeInfoRef self;
@@ -773,6 +810,7 @@ MCTypeInfoRef MCHandlerTypeInfoGetParameterType(MCTypeInfoRef unresolved_self, u
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCErrorTypeInfoCreate(MCNameRef p_domain, MCStringRef p_message, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -794,6 +832,7 @@ bool MCErrorTypeInfoCreate(MCNameRef p_domain, MCStringRef p_message, MCTypeInfo
     return true;
 }
 
+MC_DLLEXPORT_DEF
 MCNameRef MCErrorTypeInfoGetDomain(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -802,6 +841,7 @@ MCNameRef MCErrorTypeInfoGetDomain(MCTypeInfoRef unresolved_self)
     return self -> error . domain;
 }
 
+MC_DLLEXPORT_DEF
 MCStringRef MCErrorTypeInfoGetMessage(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;
@@ -812,6 +852,7 @@ MCStringRef MCErrorTypeInfoGetMessage(MCTypeInfoRef unresolved_self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCNamedErrorTypeInfoCreate(MCNameRef p_name, MCNameRef p_domain, MCStringRef p_message, MCTypeInfoRef &r_typeinfo)
 {
 	MCAutoTypeInfoRef t_type, t_named_type;
@@ -830,6 +871,7 @@ bool MCNamedErrorTypeInfoCreate(MCNameRef p_name, MCNameRef p_domain, MCStringRe
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNamedCustomTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef base, const MCValueCustomCallbacks *callbacks, MCTypeInfoRef& r_typeinfo)
 {
 	MCAutoTypeInfoRef t_type, t_named_type;
@@ -848,6 +890,7 @@ bool MCNamedCustomTypeInfoCreate(MCNameRef p_name, MCTypeInfoRef base, const MCV
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 bool MCNamedForeignTypeInfoCreate(MCNameRef p_name, const MCForeignTypeDescriptor *p_descriptor, MCTypeInfoRef& r_typeinfo)
 {
 	MCAutoTypeInfoRef t_type, t_named_type;
@@ -868,6 +911,7 @@ bool MCNamedForeignTypeInfoCreate(MCNameRef p_name, const MCForeignTypeDescripto
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCCustomTypeInfoCreate(MCTypeInfoRef p_base, const MCValueCustomCallbacks *p_callbacks, MCTypeInfoRef& r_typeinfo)
 {
     __MCTypeInfo *self;
@@ -893,6 +937,7 @@ MCTypeInfoRef MCCustomTypeInfoGetBaseType(MCTypeInfoRef unresolved_self)
     return self -> custom . base;
 }
 
+MC_DLLEXPORT_DEF
 const MCValueCustomCallbacks *MCCustomTypeInfoGetCallbacks(MCTypeInfoRef unresolved_self)
 {
     MCTypeInfoRef self;

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -36,6 +36,7 @@ MCTypeInfoRef __MCCustomValueResolveTypeInfo(__MCValue *p_value)
     return __MCTypeInfoResolve(t_value -> typeinfo);
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueCreateCustom(MCTypeInfoRef p_typeinfo, size_t p_extra_bytes, MCValueRef& r_value)
 {
 	__MCValue *t_value;
@@ -51,6 +52,7 @@ bool MCValueCreateCustom(MCTypeInfoRef p_typeinfo, size_t p_extra_bytes, MCValue
 	return true;
 }
 
+MC_DLLEXPORT_DEF
 MCValueTypeCode MCValueGetTypeCode(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -60,6 +62,7 @@ MCValueTypeCode MCValueGetTypeCode(MCValueRef p_value)
 	return __MCValueGetTypeCode(self);
 }
 
+MC_DLLEXPORT_DEF
 MCTypeInfoRef MCValueGetTypeInfo(MCValueRef p_value)
 {
     switch(MCValueGetTypeCode(p_value))
@@ -101,6 +104,7 @@ MCTypeInfoRef MCValueGetTypeInfo(MCValueRef p_value)
     MCUnreachable();
 }
 
+MC_DLLEXPORT_DEF
 uindex_t MCValueGetRetainCount(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -110,6 +114,7 @@ uindex_t MCValueGetRetainCount(MCValueRef p_value)
     return self -> references;
 }
 
+MC_DLLEXPORT_DEF
 MCValueRef MCValueRetain(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -121,6 +126,7 @@ MCValueRef MCValueRetain(MCValueRef p_value)
 	return self;
 }
 
+MC_DLLEXPORT_DEF
 void MCValueRelease(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -137,6 +143,7 @@ void MCValueRelease(MCValueRef p_value)
 	__MCValueDestroy(self);
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueCopy(MCValueRef p_value, MCValueRef& r_immutable_copy)
 {
 	__MCValue *t_copy;
@@ -149,6 +156,7 @@ bool MCValueCopy(MCValueRef p_value, MCValueRef& r_immutable_copy)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueCopyAndRelease(MCValueRef p_value, MCValueRef& r_immutable_copy)
 {
 	__MCValue *t_copy;
@@ -161,6 +169,7 @@ bool MCValueCopyAndRelease(MCValueRef p_value, MCValueRef& r_immutable_copy)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 hash_t MCValueHash(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -216,6 +225,7 @@ hash_t MCValueHash(MCValueRef p_value)
 	return 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueIsEqualTo(MCValueRef p_value, MCValueRef p_other_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -297,6 +307,7 @@ bool MCValueIsEqualTo(MCValueRef p_value, MCValueRef p_other_value)
 	return false;
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -344,6 +355,7 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
 
 //////////
 
+MC_DLLEXPORT_DEF
 bool MCValueIsMutable(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -360,6 +372,7 @@ bool MCValueIsMutable(MCValueRef p_value)
 	        __MCCustomDefaultIsMutable (p_value));
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueMutableCopy(MCValueRef p_value, MCValueRef& r_mutable_copy)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -376,6 +389,7 @@ bool MCValueMutableCopy(MCValueRef p_value, MCValueRef& r_mutable_copy)
 	        __MCCustomDefaultMutableCopy (p_value, false, r_mutable_copy));
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueMutableCopyAndRelease(MCValueRef p_value, MCValueRef& r_mutable_copy)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -394,6 +408,7 @@ bool MCValueMutableCopyAndRelease(MCValueRef p_value, MCValueRef& r_mutable_copy
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCValueIsUnique(MCValueRef p_value)
 {
 	__MCValue *self = (__MCValue *)p_value;
@@ -414,6 +429,7 @@ bool MCValueIsUnique(MCValueRef p_value)
 	return (self -> flags & kMCValueFlagIsInterred) != 0;
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueInter(MCValueRef p_value, MCValueRef& r_unique_value)
 {
 	// If the value is already unique then this is just a copy.
@@ -427,6 +443,7 @@ bool MCValueInter(MCValueRef p_value, MCValueRef& r_unique_value)
 	return __MCValueInter((__MCValue *)p_value, false, r_unique_value);
 }
 
+MC_DLLEXPORT_DEF
 bool MCValueInterAndRelease(MCValueRef p_value, MCValueRef& r_unique_value)
 {
 	// If the value is already unique then this is just a copy but since
@@ -1035,6 +1052,7 @@ bool __MCValueImmutableCopy(__MCValue *self, bool p_release, __MCValue*& r_new_v
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF
 bool MCBooleanCreateWithBool(bool p_value, MCBooleanRef& r_boolean)
 {
     r_boolean = MCValueRetain(p_value ? kMCTrue : kMCFalse);
@@ -1043,9 +1061,9 @@ bool MCBooleanCreateWithBool(bool p_value, MCBooleanRef& r_boolean)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCNullRef kMCNull;
-MCBooleanRef kMCTrue;
-MCBooleanRef kMCFalse;
+MC_DLLEXPORT_DEF MCNullRef kMCNull;
+MC_DLLEXPORT_DEF MCBooleanRef kMCTrue;
+MC_DLLEXPORT_DEF MCBooleanRef kMCFalse;
 
 bool __MCValueInitialize(void)
 {

--- a/libfoundation/src/system-commandline.cpp
+++ b/libfoundation/src/system-commandline.cpp
@@ -47,7 +47,7 @@ static void __MCSWindowsCommandLineFree (uindex_t &, unichar_t **& );
  * Setters and getters
  * ================================================================ */
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineGetArguments (MCProperListRef & r_arg_list)
 {
 	if (NULL != s_arguments)
@@ -57,7 +57,7 @@ MCSCommandLineGetArguments (MCProperListRef & r_arg_list)
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineSetArguments (MCProperListRef p_arg_list)
 {
 	MCAssert (NULL != p_arg_list);
@@ -66,7 +66,7 @@ MCSCommandLineSetArguments (MCProperListRef p_arg_list)
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineGetName (MCStringRef & r_name)
 {
 	if (NULL != s_name)
@@ -76,7 +76,7 @@ MCSCommandLineGetName (MCStringRef & r_name)
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineSetName (MCStringRef p_name)
 {
 	MCAssert (NULL != p_name);
@@ -85,7 +85,7 @@ MCSCommandLineSetName (MCStringRef p_name)
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineGetFilename (MCStringRef & r_filename)
 {
 	if (NULL != s_filename)
@@ -95,7 +95,7 @@ MCSCommandLineGetFilename (MCStringRef & r_filename)
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineSetFilename (MCStringRef p_filename)
 {
 	MCAssert (NULL != p_filename);
@@ -194,7 +194,7 @@ __MCSCommandLineCaptureNameAndArguments (uindex_t p_arg_count,
  * Capture command information using C argument array
  * ---------------------------------------------------------------- */
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineCapture (uindex_t p_arg_count, const char *p_arg_array[])
 {
 	return
@@ -233,7 +233,7 @@ __MCSCommandLineFinalize (void)
  * Windows-specific functions
  * ================================================================ */
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSCommandLineCaptureWindows (void)
 {
 	bool t_success = true;

--- a/libfoundation/src/system-file.cpp
+++ b/libfoundation/src/system-file.cpp
@@ -107,7 +107,7 @@ __MCSFileThrowInvalidPathError (MCStringRef p_path)
  * Whole-file IO
  * ================================================================ */
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSFileGetContents (MCStringRef p_path,
                     MCDataRef & r_data)
 {
@@ -115,7 +115,7 @@ MCSFileGetContents (MCStringRef p_path,
 	return __MCSFileGetContents (t_native_path, r_data);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSFileSetContents (MCStringRef p_path,
                     MCDataRef p_data)
 {
@@ -127,7 +127,7 @@ MCSFileSetContents (MCStringRef p_path,
  * File streams
  * ================================================================ */
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSFileCreateStream (MCStringRef p_path,
                      intenum_t p_mode,
                      MCStreamRef & r_stream)
@@ -140,21 +140,21 @@ MCSFileCreateStream (MCStringRef p_path,
  * File system operations
  * ================================================================ */
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSFileDelete (MCStringRef p_path)
 {
 	MCS_FILE_CONVERT_PATH(p_path, t_native_path);
 	return __MCSFileDelete (p_path);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSFileCreateDirectory (MCStringRef p_path)
 {
 	MCS_FILE_CONVERT_PATH(p_path, t_native_path);
 	return __MCSFileCreateDirectory (t_native_path);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSFileDeleteDirectory (MCStringRef p_path)
 {
 	MCS_FILE_CONVERT_PATH(p_path, t_native_path);
@@ -179,7 +179,7 @@ MCSFileGetDirectoryEntries_MapCallback (void *p_context,
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSFileGetDirectoryEntries (MCStringRef p_path,
                             MCProperListRef & r_entries)
 {
@@ -201,9 +201,9 @@ MCSFileGetDirectoryEntries (MCStringRef p_path,
  * Initialization
  * ================================================================ */
 
-MCTypeInfoRef kMCSFileIOErrorTypeInfo;
-MCTypeInfoRef kMCSFileEndOfFileErrorTypeInfo;
-MCTypeInfoRef kMCSFileInvalidPathErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSFileIOErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSFileEndOfFileErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSFileInvalidPathErrorTypeInfo;
 
 bool
 __MCSFileInitialize (void)

--- a/libfoundation/src/system-init.cpp
+++ b/libfoundation/src/system-init.cpp
@@ -17,7 +17,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "system-private.h"
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSInitialize(void)
 {
 	return
@@ -26,7 +26,7 @@ MCSInitialize(void)
 		__MCSStreamInitialize();
 }
 
-void
+MC_DLLEXPORT_DEF void
 MCSFinalize(void)
 {
 	__MCSStreamFinalize();

--- a/libfoundation/src/system-random.cpp
+++ b/libfoundation/src/system-random.cpp
@@ -32,7 +32,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * Random value generation
  * ================================================================ */
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSRandomData (uindex_t p_length, MCDataRef & r_data)
 {
 	MCDataRef t_mutable;
@@ -52,7 +52,7 @@ MCSRandomData (uindex_t p_length, MCDataRef & r_data)
 	return MCDataCopyAndRelease (t_mutable, r_data);
 }
 
-real64_t
+MC_DLLEXPORT_DEF real64_t
 MCSRandomReal (void)
 {
 	real64_t t_random_bytes;

--- a/libfoundation/src/system-stream.cpp
+++ b/libfoundation/src/system-stream.cpp
@@ -426,7 +426,7 @@ __MCSStreamGetStandardStream (FILE *p_cstream,
 	return true;
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSStreamGetStandardOutput (MCStreamRef & r_stream)
 {
 	return __MCSStreamGetStandardStream (stdout,
@@ -434,7 +434,7 @@ MCSStreamGetStandardOutput (MCStreamRef & r_stream)
 	                                     r_stream);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSStreamGetStandardInput (MCStreamRef & r_stream)
 {
 	return __MCSStreamGetStandardStream (stdin,
@@ -442,7 +442,7 @@ MCSStreamGetStandardInput (MCStreamRef & r_stream)
 	                                     r_stream);
 }
 
-bool
+MC_DLLEXPORT_DEF bool
 MCSStreamGetStandardError (MCStreamRef & r_stream)
 {
 	return __MCSStreamGetStandardStream (stderr,

--- a/libscript/src/module-arithmetic.cpp
+++ b/libscript/src/module-arithmetic.cpp
@@ -19,7 +19,7 @@
 
 #include <float.h>
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecAddIntegerToInteger(integer_t p_number, integer_t& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecAddIntegerToInteger(integer_t p_number, integer_t& x_target)
 {
     if (p_number > 0 && INTEGER_MAX - p_number < x_target)
         // overflow
@@ -31,12 +31,12 @@ extern "C" MC_DLLEXPORT void MCArithmeticExecAddIntegerToInteger(integer_t p_num
         x_target += p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecAddRealToReal(double p_number, double& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecAddRealToReal(double p_number, double& x_target)
 {
     x_target += p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecAddNumberToNumber(MCNumberRef p_number, MCNumberRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecAddNumberToNumber(MCNumberRef p_number, MCNumberRef& x_target)
 {    
     double t_target, t_number;
     t_target = MCNumberFetchAsReal(x_target);
@@ -50,7 +50,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticExecAddNumberToNumber(MCNumberRef p_num
     MCValueAssign(x_target, *t_new_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecSubtractIntegerFromInteger(integer_t p_number, integer_t& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecSubtractIntegerFromInteger(integer_t p_number, integer_t& x_target)
 {
     if (p_number > 0 && INTEGER_MIN + p_number > x_target)
         // overflow
@@ -62,12 +62,12 @@ extern "C" MC_DLLEXPORT void MCArithmeticExecSubtractIntegerFromInteger(integer_
         x_target -= p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecSubtractRealFromReal(double p_number, double& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecSubtractRealFromReal(double p_number, double& x_target)
 {
     x_target -= p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecSubtractNumberFromNumber(MCNumberRef p_number, MCNumberRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecSubtractNumberFromNumber(MCNumberRef p_number, MCNumberRef& x_target)
 {
     double t_target, t_number;
     t_target = MCNumberFetchAsReal(x_target);
@@ -81,7 +81,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticExecSubtractNumberFromNumber(MCNumberRe
     MCValueAssign(x_target, *t_new_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecMultiplyIntegerByInteger(integer_t& x_target, integer_t p_number)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecMultiplyIntegerByInteger(integer_t& x_target, integer_t p_number)
 {
     if (p_number > 0 && INTEGER_MAX / p_number < x_target)
         // overflow
@@ -93,12 +93,12 @@ extern "C" MC_DLLEXPORT void MCArithmeticExecMultiplyIntegerByInteger(integer_t&
         x_target *= p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecMultiplyRealByReal(double& x_target, double p_number)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecMultiplyRealByReal(double& x_target, double p_number)
 {
     x_target *= p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecMultiplyNumberByNumber(MCNumberRef& x_target, MCNumberRef p_number)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecMultiplyNumberByNumber(MCNumberRef& x_target, MCNumberRef p_number)
 {
     double t_target, t_number;
     t_target = MCNumberFetchAsReal(x_target);
@@ -112,17 +112,17 @@ extern "C" MC_DLLEXPORT void MCArithmeticExecMultiplyNumberByNumber(MCNumberRef&
     MCValueAssign(x_target, *t_new_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecDivideIntegerByInteger(integer_t& x_target, integer_t p_number)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecDivideIntegerByInteger(integer_t& x_target, integer_t p_number)
 {
     x_target /= p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecDivideRealByReal(double& x_target, double p_number)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecDivideRealByReal(double& x_target, double p_number)
 {
     x_target /= p_number;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticExecDivideNumberByNumber(MCNumberRef& x_target, MCNumberRef p_number)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticExecDivideNumberByNumber(MCNumberRef& x_target, MCNumberRef p_number)
 {
     double t_target, t_number;
     t_target = MCNumberFetchAsReal(x_target);
@@ -136,7 +136,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticExecDivideNumberByNumber(MCNumberRef& x
     MCValueAssign(x_target, *t_new_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerPlusInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerPlusInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     MCArithmeticExecAddIntegerToInteger(p_left, p_right);
     
@@ -144,7 +144,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerPlusInteger(integer_t p_left
     r_output = p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealPlusReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealPlusReal(double p_left, double p_right, double& r_output)
 {
     MCArithmeticExecAddRealToReal(p_left, p_right);
     
@@ -152,7 +152,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalRealPlusReal(double p_left, double 
     r_output = p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberPlusNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberPlusNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     MCNumberRef t_number;
     MCNumberCreateWithReal(MCNumberFetchAsReal(p_right), t_number);
@@ -166,7 +166,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberPlusNumber(MCNumberRef p_left
     MCValueRelease(t_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerMinusInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerMinusInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     MCArithmeticExecSubtractIntegerFromInteger(p_right, p_left);
     
@@ -174,7 +174,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerMinusInteger(integer_t p_lef
     r_output = p_left;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealMinusReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealMinusReal(double p_left, double p_right, double& r_output)
 {
     MCArithmeticExecSubtractRealFromReal(p_right, p_left);
     
@@ -182,7 +182,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalRealMinusReal(double p_left, double
     r_output = p_left;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberMinusNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberMinusNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     MCNumberRef t_number;
     MCNumberCreateWithReal(MCNumberFetchAsReal(p_left), t_number);
@@ -196,7 +196,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberMinusNumber(MCNumberRef p_lef
     MCValueRelease(t_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerTimesInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerTimesInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     MCArithmeticExecMultiplyIntegerByInteger(p_left, p_right);
     
@@ -204,7 +204,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerTimesInteger(integer_t p_lef
     r_output = p_left;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealTimesReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealTimesReal(double p_left, double p_right, double& r_output)
 {
     MCArithmeticExecMultiplyRealByReal(p_left, p_right);
     
@@ -212,7 +212,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalRealTimesReal(double p_left, double
     r_output = p_left;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberTimesNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberTimesNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     MCNumberRef t_number;
     MCNumberCreateWithReal(MCNumberFetchAsReal(p_right), t_number);
@@ -226,7 +226,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberTimesNumber(MCNumberRef p_lef
     MCValueRelease(t_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerOverInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerOverInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     MCArithmeticExecDivideIntegerByInteger(p_left, p_right);
     
@@ -234,7 +234,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerOverInteger(integer_t p_left
     r_output = p_left;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealOverReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealOverReal(double p_left, double p_right, double& r_output)
 {
     MCArithmeticExecDivideRealByReal(p_left, p_right);
     
@@ -242,7 +242,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalRealOverReal(double p_left, double 
     r_output = p_left;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberOverNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberOverNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     MCNumberRef t_number;
     MCNumberCreateWithReal(MCNumberFetchAsReal(p_left), t_number);
@@ -256,7 +256,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberOverNumber(MCNumberRef p_left
     MCValueRelease(t_number);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerModInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerModInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     if (p_right == 0)
         return;
@@ -264,7 +264,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerModInteger(integer_t p_left,
     r_output = fmod(double(p_left), double(p_right));
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealModReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealModReal(double p_left, double p_right, double& r_output)
 {
     double n = 0.0;
     n = p_left / p_right;
@@ -273,7 +273,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalRealModReal(double p_left, double p
     r_output = fmod(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberModNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberModNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     double t_left, t_right;
     t_left = MCNumberFetchAsReal(p_left);
@@ -285,7 +285,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberModNumber(MCNumberRef p_left,
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerWrapInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerWrapInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     if (p_right == 0)
         return;
@@ -298,7 +298,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerWrapInteger(integer_t p_left
 		r_output = -(fmod(double(-p_left - 1), double(t_y)) + 1);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealWrapReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealWrapReal(double p_left, double p_right, double& r_output)
 {
     double n = 0.0;
     n = p_left / p_right;
@@ -312,7 +312,7 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalRealWrapReal(double p_left, double 
 		r_output = -(fmod(-p_left - 1, t_y) + 1);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberWrapNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberWrapNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     double t_left, t_right;
     t_left = MCNumberFetchAsReal(p_left);
@@ -324,92 +324,92 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberWrapNumber(MCNumberRef p_left
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerIsGreaterThanInteger(integer_t p_left, integer_t p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerIsGreaterThanInteger(integer_t p_left, integer_t p_right, bool& r_output)
 {
     r_output = (p_left > p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealIsGreaterThanReal(double p_left, double p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealIsGreaterThanReal(double p_left, double p_right, bool& r_output)
 {
     r_output = (p_left > p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberIsGreaterThanNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberIsGreaterThanNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
 {
     r_output = (MCNumberFetchAsReal(p_left) > MCNumberFetchAsReal(p_right));
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerIsGreaterThanOrEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerIsGreaterThanOrEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
 {
     r_output = (p_left >= p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealIsGreaterThanOrEqualToReal(double p_left, double p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealIsGreaterThanOrEqualToReal(double p_left, double p_right, bool& r_output)
 {
     r_output = (p_left >= p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberIsGreaterThanOrEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberIsGreaterThanOrEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
 {
     r_output = (MCNumberFetchAsReal(p_left) >= MCNumberFetchAsReal(p_right));
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerIsLessThanInteger(integer_t p_left, integer_t p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerIsLessThanInteger(integer_t p_left, integer_t p_right, bool& r_output)
 {
     r_output = (p_left < p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealIsLessThanReal(double p_left, double p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealIsLessThanReal(double p_left, double p_right, bool& r_output)
 {
     r_output = (p_left < p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberIsLessThanNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberIsLessThanNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
 {
     r_output = (MCNumberFetchAsReal(p_left) < MCNumberFetchAsReal(p_right));
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalIntegerIsLessThanOrEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalIntegerIsLessThanOrEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
 {
     r_output = (p_left <= p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalRealIsLessThanOrEqualToReal(double p_left, double p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalRealIsLessThanOrEqualToReal(double p_left, double p_right, bool& r_output)
 {
     r_output = (p_left <= p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberIsLessThanOrEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberIsLessThanOrEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
 {
     r_output = (MCNumberFetchAsReal(p_left) <= MCNumberFetchAsReal(p_right));
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalPlusInteger(integer_t p_operand, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalPlusInteger(integer_t p_operand, integer_t& r_output)
 {
     r_output = p_operand;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalPlusReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalPlusReal(double p_operand, double& r_output)
 {
     r_output = p_operand;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalPlusNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalPlusNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     r_output = MCValueRetain(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalMinusInteger(integer_t p_operand, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalMinusInteger(integer_t p_operand, integer_t& r_output)
 {
     r_output = -p_operand;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalMinusReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalMinusReal(double p_operand, double& r_output)
 {
     r_output = -p_operand;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalMinusNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalMinusNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     if (MCNumberIsInteger(p_operand))
         MCNumberCreateWithInteger(-MCNumberFetchAsInteger(p_operand), r_output);
@@ -417,46 +417,46 @@ extern "C" MC_DLLEXPORT void MCArithmeticEvalMinusNumber(MCNumberRef p_operand, 
         MCNumberCreateWithReal(-MCNumberFetchAsReal(p_operand), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
 {
     r_output = p_left == p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalEqualToReal(double p_left, double p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalEqualToReal(double p_left, double p_right, bool& r_output)
 {
     r_output = p_left == p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
 {
     r_output = MCNumberFetchAsReal(p_left) == MCNumberFetchAsReal(p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNotEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNotEqualToInteger(integer_t p_left, integer_t p_right, bool& r_output)
 {
     r_output = p_left != p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNotEqualToReal(double p_left, double p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNotEqualToReal(double p_left, double p_right, bool& r_output)
 {
     r_output = p_left != p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNotEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNotEqualToNumber(MCNumberRef p_left, MCNumberRef p_right, bool& r_output)
 {
     r_output = MCNumberFetchAsReal(p_left) != MCNumberFetchAsReal(p_right);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT MCStringRef MCArithmeticExecFormatNumberAsString(MCNumberRef p_operand)
+extern "C" MC_DLLEXPORT_DEF MCStringRef MCArithmeticExecFormatNumberAsString(MCNumberRef p_operand)
 {
     MCAutoStringRef t_output;
     MCStringFormat(&t_output, "%f", MCNumberFetchAsReal(p_operand));
     return MCValueRetain(*t_output);
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCArithmeticExecParseStringAsNumber(MCStringRef p_operand)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCArithmeticExecParseStringAsNumber(MCStringRef p_operand)
 {
     double t_converted;
     if (!MCTypeConvertStringToReal(p_operand, t_converted))
@@ -469,7 +469,7 @@ extern "C" MC_DLLEXPORT MCValueRef MCArithmeticExecParseStringAsNumber(MCStringR
     return MCValueRetain(*t_number);
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCArithmeticExecParseListOfStringAsListOfNumber(MCProperListRef p_list_of_string)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCArithmeticExecParseListOfStringAsListOfNumber(MCProperListRef p_list_of_string)
 {
     MCAutoProperListRef t_output;
     if (!MCProperListCreateMutable(&t_output))
@@ -496,17 +496,17 @@ extern "C" MC_DLLEXPORT MCValueRef MCArithmeticExecParseListOfStringAsListOfNumb
     return MCValueRetain(*t_list);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalNumberFormattedAsString(MCNumberRef p_operand, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNumberFormattedAsString(MCNumberRef p_operand, MCStringRef& r_output)
 {
     r_output = MCArithmeticExecFormatNumberAsString(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalStringParsedAsNumber(MCStringRef p_operand, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalStringParsedAsNumber(MCStringRef p_operand, MCValueRef& r_output)
 {
     r_output = MCArithmeticExecParseStringAsNumber(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCArithmeticEvalListOfStringParsedAsListOfNumber(MCProperListRef p_list_of_string, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalListOfStringParsedAsListOfNumber(MCProperListRef p_list_of_string, MCValueRef& r_output)
 {
     r_output = MCArithmeticExecParseListOfStringAsListOfNumber(p_list_of_string);
 }

--- a/libscript/src/module-array.cpp
+++ b/libscript/src/module-array.cpp
@@ -58,7 +58,7 @@ static bool list_array_elements(void *context, MCArrayRef p_target, MCNameRef p_
     return MCProperListPushElementOntoBack(t_list, p_value);
 }
 
-extern "C" MC_DLLEXPORT void MCArrayEvalKeysOf(MCArrayRef p_target, MCProperListRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArrayEvalKeysOf(MCArrayRef p_target, MCProperListRef& r_output)
 {
     MCProperListRef t_list;
     if (MCProperListCreateMutable(t_list) &&
@@ -67,7 +67,7 @@ extern "C" MC_DLLEXPORT void MCArrayEvalKeysOf(MCArrayRef p_target, MCProperList
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCArrayEvalElementsOf(MCArrayRef p_target, MCProperListRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArrayEvalElementsOf(MCArrayRef p_target, MCProperListRef& r_output)
 {
     MCProperListRef t_list;
     if (MCProperListCreateMutable(t_list) &&
@@ -76,19 +76,19 @@ extern "C" MC_DLLEXPORT void MCArrayEvalElementsOf(MCArrayRef p_target, MCProper
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCArrayEvalNumberOfElementsIn(MCArrayRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArrayEvalNumberOfElementsIn(MCArrayRef p_target, uindex_t& r_output)
 {
     r_output = MCArrayGetCount(p_target);
 }
 
-extern "C" MC_DLLEXPORT void MCArrayEvalIsAmongTheElementsOf(MCValueRef p_needle, bool p_is_not, MCArrayRef p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArrayEvalIsAmongTheElementsOf(MCValueRef p_needle, bool p_is_not, MCArrayRef p_target, bool& r_output)
 {
     MCValueRef t_value;
     t_value = p_needle != nil ? p_needle : kMCNull;
     r_output = !MCArrayApply(p_target, is_not_among_the_elements_of, t_value);
 }
 
-extern "C" MC_DLLEXPORT void MCArrayEvalIsAmongTheKeysOfCaseless(MCStringRef p_needle, bool p_is_not, MCArrayRef p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArrayEvalIsAmongTheKeysOfCaseless(MCStringRef p_needle, bool p_is_not, MCArrayRef p_target, bool& r_output)
 {
     MCNewAutoNameRef t_key;
     if (!create_key_for_array(p_needle, p_target, &t_key))
@@ -103,7 +103,7 @@ extern "C" MC_DLLEXPORT void MCArrayEvalIsAmongTheKeysOfCaseless(MCStringRef p_n
         r_output = !r_output;
 }
 
-extern "C" MC_DLLEXPORT void MCArrayFetchElementOfCaseless(MCArrayRef p_target, MCStringRef p_key, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArrayFetchElementOfCaseless(MCArrayRef p_target, MCStringRef p_key, MCValueRef& r_output)
 {
     MCNewAutoNameRef t_key;
     
@@ -121,7 +121,7 @@ extern "C" MC_DLLEXPORT void MCArrayFetchElementOfCaseless(MCArrayRef p_target, 
     r_output = MCValueRetain(t_value);
 }
 
-extern "C" MC_DLLEXPORT void MCArrayStoreElementOfCaseless(MCValueRef p_value, MCArrayRef& x_target, MCStringRef p_key)
+extern "C" MC_DLLEXPORT_DEF void MCArrayStoreElementOfCaseless(MCValueRef p_value, MCArrayRef& x_target, MCStringRef p_key)
 {
     MCNewAutoNameRef t_key;
     MCAutoArrayRef t_array;
@@ -141,7 +141,7 @@ extern "C" MC_DLLEXPORT void MCArrayStoreElementOfCaseless(MCValueRef p_value, M
     MCValueAssign(x_target, *t_new_array);
 }
 
-extern "C" MC_DLLEXPORT void MCArrayDeleteElementOfCaseless(MCArrayRef& x_target, MCStringRef p_key)
+extern "C" MC_DLLEXPORT_DEF void MCArrayDeleteElementOfCaseless(MCArrayRef& x_target, MCStringRef p_key)
 {
     MCNewAutoNameRef t_key;
     MCAutoArrayRef t_array;
@@ -158,12 +158,12 @@ extern "C" MC_DLLEXPORT void MCArrayDeleteElementOfCaseless(MCArrayRef& x_target
     MCValueAssign(x_target, *t_new_array);
 }
 
-extern "C" MC_DLLEXPORT void MCArrayEvalEmpty(MCArrayRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCArrayEvalEmpty(MCArrayRef& r_output)
 {
     r_output = MCValueRetain(kMCEmptyArray);
 }
 
-extern "C" bool MC_DLLEXPORT MCArrayRepeatForEachElement(void*& x_iterator, MCValueRef& r_iterand, MCArrayRef p_array)
+extern "C" bool MC_DLLEXPORT_DEF MCArrayRepeatForEachElement(void*& x_iterator, MCValueRef& r_iterand, MCArrayRef p_array)
 {
     MCValueRef t_value;
     // If this is a numerical array, do it in order
@@ -195,7 +195,7 @@ extern "C" bool MC_DLLEXPORT MCArrayRepeatForEachElement(void*& x_iterator, MCVa
     return true;
 }
 
-extern "C" bool MC_DLLEXPORT MCArrayRepeatForEachKey(void*& x_iterator, MCStringRef& r_iterand, MCArrayRef p_array)
+extern "C" bool MC_DLLEXPORT_DEF MCArrayRepeatForEachKey(void*& x_iterator, MCStringRef& r_iterand, MCArrayRef p_array)
 {
     MCNameRef t_key;
     MCValueRef t_value;

--- a/libscript/src/module-binary.cpp
+++ b/libscript/src/module-binary.cpp
@@ -18,7 +18,7 @@
 #include <foundation-auto.h>
 #include <foundation-chunk.h>
 
-extern "C" MC_DLLEXPORT void MCBinaryEvalConcatenateBytes(MCDataRef p_left, MCDataRef p_right, MCDataRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCBinaryEvalConcatenateBytes(MCDataRef p_left, MCDataRef p_right, MCDataRef& r_output)
 {
     MCAutoDataRef t_data;
     if (!MCDataMutableCopy(p_left, &t_data))
@@ -31,7 +31,7 @@ extern "C" MC_DLLEXPORT void MCBinaryEvalConcatenateBytes(MCDataRef p_left, MCDa
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCBinaryExecPutBytesBefore(MCDataRef p_source, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCBinaryExecPutBytesBefore(MCDataRef p_source, MCDataRef& x_target)
 {
     MCAutoDataRef t_data;
     MCBinaryEvalConcatenateBytes(p_source, x_target == (MCDataRef)kMCNull ? kMCEmptyData : x_target, &t_data);
@@ -42,7 +42,7 @@ extern "C" MC_DLLEXPORT void MCBinaryExecPutBytesBefore(MCDataRef p_source, MCDa
     MCValueAssign(x_target, *t_data);
 }
 
-extern "C" MC_DLLEXPORT void MCBinaryExecPutBytesAfter(MCDataRef p_source, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCBinaryExecPutBytesAfter(MCDataRef p_source, MCDataRef& x_target)
 {
     MCAutoDataRef t_data;
     MCBinaryEvalConcatenateBytes(x_target == (MCDataRef)kMCNull ? kMCEmptyData : x_target, p_source, &t_data);
@@ -53,27 +53,27 @@ extern "C" MC_DLLEXPORT void MCBinaryExecPutBytesAfter(MCDataRef p_source, MCDat
     MCValueAssign(x_target, *t_data);
 }
 
-extern "C" MC_DLLEXPORT void MCBinaryEvalIsEqualTo(MCDataRef p_left, MCDataRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCBinaryEvalIsEqualTo(MCDataRef p_left, MCDataRef p_right, bool& r_result)
 {
     r_result = MCDataIsEqualTo(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCBinaryEvalIsNotEqualTo(MCDataRef p_left, MCDataRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCBinaryEvalIsNotEqualTo(MCDataRef p_left, MCDataRef p_right, bool& r_result)
 {
     r_result = !MCDataIsEqualTo(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCBinaryEvalIsLessThan(MCDataRef p_left, MCDataRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCBinaryEvalIsLessThan(MCDataRef p_left, MCDataRef p_right, bool& r_result)
 {
     r_result = MCDataCompareTo(p_left, p_right) < 0;
 }
 
-extern "C" MC_DLLEXPORT void MCBinaryEvalIsGreaterThan(MCDataRef p_left, MCDataRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCBinaryEvalIsGreaterThan(MCDataRef p_left, MCDataRef p_right, bool& r_result)
 {
     r_result = MCDataCompareTo(p_left, p_right) > 0;
 }
 
-extern "C" MC_DLLEXPORT void MCDataEvalEmpty(MCDataRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCDataEvalEmpty(MCDataRef& r_output)
 {
     r_output = MCValueRetain(kMCEmptyData);
 }

--- a/libscript/src/module-bitwise.cpp
+++ b/libscript/src/module-bitwise.cpp
@@ -16,22 +16,22 @@
 
 #include <foundation.h>
 
-extern "C" MC_DLLEXPORT void MCBitwiseEvalBitwiseAnd(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCBitwiseEvalBitwiseAnd(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     r_output = p_left & p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCBitwiseEvalBitwiseOr(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCBitwiseEvalBitwiseOr(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     r_output = p_left | p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCBitwiseEvalBitwiseXor(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCBitwiseEvalBitwiseXor(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     r_output = p_left ^ p_right;
 }
 
-extern "C" MC_DLLEXPORT void MCBitwiseEvalBitwiseNot(integer_t p_operand, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCBitwiseEvalBitwiseNot(integer_t p_operand, integer_t& r_output)
 {
     r_output = ~p_operand;
 }
@@ -46,7 +46,7 @@ MCBitwiseEvalBitwiseShiftCount (T p_operand, uinteger_t & p_shift)
 	p_shift = MCMin (p_shift, t_max_shift);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCBitwiseEvalBitwiseShiftRight (integer_t p_operand,
                                 uinteger_t p_shift,
                                 integer_t & r_output)
@@ -55,7 +55,7 @@ MCBitwiseEvalBitwiseShiftRight (integer_t p_operand,
 	r_output = p_operand >> p_shift;
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCBitwiseEvalBitwiseShiftLeft (integer_t p_operand,
                                uinteger_t p_shift,
                                integer_t& r_output)

--- a/libscript/src/module-byte.cpp
+++ b/libscript/src/module-byte.cpp
@@ -19,12 +19,12 @@
 #include <foundation-auto.h>
 #include <foundation-chunk.h>
 
-extern "C" MC_DLLEXPORT void MCByteEvalNumberOfBytesIn(MCDataRef p_source, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalNumberOfBytesIn(MCDataRef p_source, uindex_t& r_output)
 {
     r_output = MCDataGetLength(p_source);
 }
 
-extern "C" MC_DLLEXPORT void MCByteEvalIsAmongTheBytesOf(MCDataRef p_needle, MCDataRef p_target, bool p_is_not, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalIsAmongTheBytesOf(MCDataRef p_needle, MCDataRef p_target, bool p_is_not, bool& r_output)
 {
     // Error if there is more than one byte.
     if (MCDataGetLength(p_needle) != 1)
@@ -41,22 +41,22 @@ extern "C" MC_DLLEXPORT void MCByteEvalIsAmongTheBytesOf(MCDataRef p_needle, MCD
     r_output = t_found;
 }
 
-extern "C" MC_DLLEXPORT void MCByteEvalContainsBytes(MCDataRef p_target, MCDataRef p_needle, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalContainsBytes(MCDataRef p_target, MCDataRef p_needle, bool& r_output)
 {
     r_output = MCDataContains(p_target, p_needle);
 }
  
-extern "C" MC_DLLEXPORT void MCByteEvalBeginsWithBytes(MCDataRef p_target, MCDataRef p_needle, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalBeginsWithBytes(MCDataRef p_target, MCDataRef p_needle, bool& r_output)
 {
     r_output = MCDataBeginsWith(p_target, p_needle);
 }
 
-extern "C" MC_DLLEXPORT void MCByteEvalEndsWithBytes(MCDataRef p_target, MCDataRef p_needle, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalEndsWithBytes(MCDataRef p_target, MCDataRef p_needle, bool& r_output)
 {
     r_output = MCDataEndsWith(p_target, p_needle);
 }
 
-extern "C" MC_DLLEXPORT void MCByteEvalOffsetOfBytesInRange(MCDataRef p_needle, MCDataRef p_target, bool p_is_last, MCRange p_range, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalOffsetOfBytesInRange(MCDataRef p_needle, MCDataRef p_target, bool p_is_last, MCRange p_range, uindex_t& r_output)
 {
     // Incoming range must be 0-based.
     uindex_t t_offset;
@@ -78,12 +78,12 @@ extern "C" MC_DLLEXPORT void MCByteEvalOffsetOfBytesInRange(MCDataRef p_needle, 
     r_output = t_offset;
 }
 
-extern "C" MC_DLLEXPORT void MCByteEvalOffsetOfBytes(bool p_is_last, MCDataRef p_needle, MCDataRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalOffsetOfBytes(bool p_is_last, MCDataRef p_needle, MCDataRef p_target, uindex_t& r_output)
 {
     return MCByteEvalOffsetOfBytesInRange(p_needle, p_target, p_is_last, MCRangeMake(0, UINDEX_MAX), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCByteEvalOffsetOfBytesAfter(bool p_is_last, MCDataRef p_needle, index_t p_after, MCDataRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalOffsetOfBytesAfter(bool p_is_last, MCDataRef p_needle, index_t p_after, MCDataRef p_target, uindex_t& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfByteChunkByExpressionInRange(p_target, nil, p_after, true, true, false, t_start, t_count))
@@ -95,7 +95,7 @@ extern "C" MC_DLLEXPORT void MCByteEvalOffsetOfBytesAfter(bool p_is_last, MCData
     return MCByteEvalOffsetOfBytesInRange(p_needle, p_target, p_is_last, MCRangeMake(t_start + t_count, UINDEX_MAX), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCByteEvalOffsetOfBytesBefore(bool p_is_first, MCDataRef p_needle, index_t p_before, MCDataRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteEvalOffsetOfBytesBefore(bool p_is_first, MCDataRef p_needle, index_t p_before, MCDataRef p_target, uindex_t& r_output)
 {
     uindex_t t_start, t_count;
 	if (0 == p_before)
@@ -111,7 +111,7 @@ extern "C" MC_DLLEXPORT void MCByteEvalOffsetOfBytesBefore(bool p_is_first, MCDa
     return MCByteEvalOffsetOfBytesInRange(p_needle, p_target, !p_is_first, MCRangeMake(0, t_start), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCByteFetchByteRangeOf(index_t p_start, index_t p_finish, MCDataRef p_target, MCDataRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteFetchByteRangeOf(index_t p_start, index_t p_finish, MCDataRef p_target, MCDataRef& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfByteChunkByRangeInRange(p_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -124,7 +124,7 @@ extern "C" MC_DLLEXPORT void MCByteFetchByteRangeOf(index_t p_start, index_t p_f
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCByteStoreByteRangeOf(MCDataRef p_value, index_t p_start, index_t p_finish, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteStoreByteRangeOf(MCDataRef p_value, index_t p_start, index_t p_finish, MCDataRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfByteChunkByRangeInRange(x_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -147,57 +147,57 @@ extern "C" MC_DLLEXPORT void MCByteStoreByteRangeOf(MCDataRef p_value, index_t p
     MCValueAssign(x_target, *t_new_data);
 }
 
-extern "C" MC_DLLEXPORT void MCByteFetchByteOf(index_t p_index, MCDataRef p_target, MCDataRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteFetchByteOf(index_t p_index, MCDataRef p_target, MCDataRef& r_output)
 {
     MCByteFetchByteRangeOf(p_index, p_index, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCByteStoreByteOf(MCDataRef p_value, index_t p_index, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteStoreByteOf(MCDataRef p_value, index_t p_index, MCDataRef& x_target)
 {
     MCByteStoreByteRangeOf(p_value, p_index, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCByteFetchFirstByteOf(MCDataRef p_target, MCDataRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteFetchFirstByteOf(MCDataRef p_target, MCDataRef& r_output)
 {
     MCByteFetchByteOf(1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCByteStoreFirstByteOf(MCDataRef p_value, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteStoreFirstByteOf(MCDataRef p_value, MCDataRef& x_target)
 {
     MCByteStoreByteOf(p_value, 1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCByteFetchLastByteOf(MCDataRef p_target, MCDataRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCByteFetchLastByteOf(MCDataRef p_target, MCDataRef& r_output)
 {
     MCByteFetchByteOf(-1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCByteStoreLastByteOf(MCDataRef p_value, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteStoreLastByteOf(MCDataRef p_value, MCDataRef& x_target)
 {
     MCByteStoreByteOf(p_value, -1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCByteExecDeleteByteRangeOf(index_t p_start, index_t p_finish, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteExecDeleteByteRangeOf(index_t p_start, index_t p_finish, MCDataRef& x_target)
 {
     MCByteStoreByteRangeOf(kMCEmptyData, p_start, p_finish, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCByteExecDeleteByteOf(index_t p_index, MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteExecDeleteByteOf(index_t p_index, MCDataRef& x_target)
 {
     MCByteStoreByteOf(kMCEmptyData, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCByteExecDeleteFirstByteOf(MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteExecDeleteFirstByteOf(MCDataRef& x_target)
 {
     MCByteExecDeleteByteOf(1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCByteExecDeleteLastByteOf(MCDataRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCByteExecDeleteLastByteOf(MCDataRef& x_target)
 {
     MCByteExecDeleteByteOf(-1, x_target);
 }
 
-extern "C" MC_DLLEXPORT bool MCByteRepeatForEachByte(void*& x_iterator, MCDataRef& r_iterand, MCDataRef p_data)
+extern "C" MC_DLLEXPORT_DEF bool MCByteRepeatForEachByte(void*& x_iterator, MCDataRef& r_iterand, MCDataRef p_data)
 {
     uintptr_t t_offset;
     t_offset = (uintptr_t)x_iterator;
@@ -215,7 +215,7 @@ extern "C" MC_DLLEXPORT bool MCByteRepeatForEachByte(void*& x_iterator, MCDataRe
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCDataExecRandomBytes (uindex_t p_count, MCDataRef & r_data)
 {
 	/* UNCHECKED */ MCSRandomData (p_count, r_data);
@@ -223,7 +223,7 @@ MCDataExecRandomBytes (uindex_t p_count, MCDataRef & r_data)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCByteEvalByteWithCode (uinteger_t p_value,
                         MCDataRef & r_data)
 {
@@ -240,7 +240,7 @@ MCByteEvalByteWithCode (uinteger_t p_value,
 	MCDataCreateWithBytes (&t_byte, 1, r_data);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCByteEvalCodeOfByte (MCDataRef p_data,
                       uinteger_t & r_value)
 {

--- a/libscript/src/module-char.cpp
+++ b/libscript/src/module-char.cpp
@@ -47,14 +47,14 @@ bool MCCharStoreChunk(MCStringRef &x_target, MCStringRef p_value, MCRange p_grap
     return true;
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalNumberOfCharsIn(MCStringRef p_target, index_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalNumberOfCharsIn(MCStringRef p_target, index_t& r_output)
 {
     MCTextChunkIterator *tci;
     tci = MCChunkCreateTextChunkIterator(p_target, nil, kMCChunkTypeCharacter, nil, kMCStringOptionCompareExact);
     r_output = tci -> CountChunks();
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalIsAmongTheCharsOf(MCStringRef p_needle, MCStringRef p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalIsAmongTheCharsOf(MCStringRef p_needle, MCStringRef p_target, bool& r_output)
 {
     // Error if there is more than one char in needle.
     MCRange t_range;
@@ -71,7 +71,7 @@ extern "C" MC_DLLEXPORT void MCCharEvalIsAmongTheCharsOf(MCStringRef p_needle, M
     r_output = tci -> IsAmong(p_needle);
 }
 
-extern "C" MC_DLLEXPORT void MCCharFetchCharRangeOf(index_t p_start, index_t p_finish, MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharFetchCharRangeOf(index_t p_start, index_t p_finish, MCStringRef p_target, MCStringRef& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfGraphemeChunkByRangeInRange(p_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -83,7 +83,7 @@ extern "C" MC_DLLEXPORT void MCCharFetchCharRangeOf(index_t p_start, index_t p_f
     MCCharEvaluateChunk(p_target, MCRangeMake(t_start, t_count), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCharStoreCharRangeOf(MCStringRef p_value, index_t p_start, index_t p_finish, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharStoreCharRangeOf(MCStringRef p_value, index_t p_start, index_t p_finish, MCStringRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfGraphemeChunkByRangeInRange(x_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -95,17 +95,17 @@ extern "C" MC_DLLEXPORT void MCCharStoreCharRangeOf(MCStringRef p_value, index_t
     MCCharStoreChunk(x_target, p_value, MCRangeMake(t_start, t_count), p_value);
 }
 
-extern "C" MC_DLLEXPORT void MCCharFetchCharOf(index_t p_index, MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharFetchCharOf(index_t p_index, MCStringRef p_target, MCStringRef& r_output)
 {
     MCCharFetchCharRangeOf(p_index, p_index, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCharStoreCharOf(MCStringRef p_value, index_t p_index, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharStoreCharOf(MCStringRef p_value, index_t p_index, MCStringRef& x_target)
 {
     MCCharStoreCharRangeOf(p_value, p_index, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalOffsetOfCharsInRange(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, MCRange p_range, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalOffsetOfCharsInRange(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, MCRange p_range, uindex_t& r_output)
 {
     uindex_t t_offset;
     t_offset = 0;
@@ -146,12 +146,12 @@ extern "C" MC_DLLEXPORT void MCCharEvalOffsetOfCharsInRange(bool p_is_last, MCSt
 	r_output = t_output_range . offset + p_range . offset;
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalOffsetOfChars(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalOffsetOfChars(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, uindex_t& r_output)
 {
     MCCharEvalOffsetOfCharsInRange(p_is_last, p_needle, p_target, MCRangeMake(0, UINDEX_MAX), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalOffsetOfCharsAfter(bool p_is_last, MCStringRef p_needle, index_t p_after, MCStringRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalOffsetOfCharsAfter(bool p_is_last, MCStringRef p_needle, index_t p_after, MCStringRef p_target, uindex_t& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfGraphemeChunkByExpressionInRange(p_target, nil, p_after, true, true, false, t_start, t_count) && p_after != 0)
@@ -163,7 +163,7 @@ extern "C" MC_DLLEXPORT void MCCharEvalOffsetOfCharsAfter(bool p_is_last, MCStri
     MCCharEvalOffsetOfCharsInRange(p_is_last, p_needle, p_target, MCRangeMake(t_start + t_count, UINDEX_MAX), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalOffsetOfCharsBefore(bool p_is_first, MCStringRef p_needle, index_t p_before, MCStringRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalOffsetOfCharsBefore(bool p_is_first, MCStringRef p_needle, index_t p_before, MCStringRef p_target, uindex_t& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfGraphemeChunkByExpressionInRange(p_target, nil, p_before, true, false, true, t_start, t_count))
@@ -175,62 +175,62 @@ extern "C" MC_DLLEXPORT void MCCharEvalOffsetOfCharsBefore(bool p_is_first, MCSt
     MCCharEvalOffsetOfCharsInRange(!p_is_first, p_needle, p_target, MCRangeMake(0, t_start), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalContains(MCStringRef p_source, MCStringRef p_needle, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalContains(MCStringRef p_source, MCStringRef p_needle, bool& r_result)
 {
     r_result = MCStringContains(p_source, p_needle, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalBeginsWith(MCStringRef p_source, MCStringRef p_prefix, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalBeginsWith(MCStringRef p_source, MCStringRef p_prefix, bool& r_result)
 {
     r_result = MCStringBeginsWith(p_source, p_prefix, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalEndsWith(MCStringRef p_source, MCStringRef p_suffix, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalEndsWith(MCStringRef p_source, MCStringRef p_suffix, bool& r_result)
 {
     r_result = MCStringEndsWith(p_source, p_suffix, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCCharEvalNewlineCharacter(MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharEvalNewlineCharacter(MCStringRef& r_output)
 {
     MCStringFormat(r_output, "\n");
 }
 
-extern "C" MC_DLLEXPORT void MCCharFetchFirstCharOf(MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharFetchFirstCharOf(MCStringRef p_target, MCStringRef& r_output)
 {
     MCCharFetchCharOf(1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCharStoreFirstCharOf(MCStringRef p_value, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharStoreFirstCharOf(MCStringRef p_value, MCStringRef& x_target)
 {
     MCCharStoreCharOf(p_value, 1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCharFetchLastCharOf(MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCharFetchLastCharOf(MCStringRef p_target, MCStringRef& r_output)
 {
     MCCharFetchCharOf(-1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCharStoreLastCharOf(MCStringRef p_value, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharStoreLastCharOf(MCStringRef p_value, MCStringRef& x_target)
 {
     MCCharStoreCharOf(p_value, -1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCharExecDeleteCharRangeOf(index_t p_start, index_t p_finish, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharExecDeleteCharRangeOf(index_t p_start, index_t p_finish, MCStringRef& x_target)
 {
     MCCharStoreCharRangeOf(kMCEmptyString, p_start, p_finish, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCharExecDeleteCharOf(index_t p_index, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharExecDeleteCharOf(index_t p_index, MCStringRef& x_target)
 {
     MCCharStoreCharOf(kMCEmptyString, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCharExecDeleteFirstCharOf(MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharExecDeleteFirstCharOf(MCStringRef& x_target)
 {
     MCCharExecDeleteCharOf(1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCharExecDeleteLastCharOf(MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCharExecDeleteLastCharOf(MCStringRef& x_target)
 {
     MCCharExecDeleteCharOf(-1, x_target);
 }
@@ -246,7 +246,7 @@ extern "C" MC_DLLEXPORT void MCCharExecDeleteLastCharOf(MCStringRef& x_target)
 //   repeat for each char tChar in tVar
 //   end repeat
 // Will result in tChar containing the value it had at the point of end repeat.
-extern "C" MC_DLLEXPORT bool MCCharRepeatForEachChar(void*& x_iterator, MCStringRef& r_iterand, MCStringRef p_string)
+extern "C" MC_DLLEXPORT_DEF bool MCCharRepeatForEachChar(void*& x_iterator, MCStringRef& r_iterand, MCStringRef p_string)
 {
     MCTextChunkIterator *t_iterator;
     bool t_first;
@@ -275,7 +275,7 @@ extern "C" MC_DLLEXPORT bool MCCharRepeatForEachChar(void*& x_iterator, MCString
 
 ////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCStringEvalCodeOfChar(MCStringRef p_string, uinteger_t& r_code)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalCodeOfChar(MCStringRef p_string, uinteger_t& r_code)
 {
     uindex_t t_length;
     t_length = MCStringGetLength(p_string);
@@ -296,7 +296,7 @@ notacodepoint_exit:
     MCErrorThrowGeneric(MCSTR("not a single code character"));
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalCharWithCode(uinteger_t p_code, MCStringRef& r_string)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalCharWithCode(uinteger_t p_code, MCStringRef& r_string)
 {
     if (p_code >= 1 << 21)
     {

--- a/libscript/src/module-codeunit.cpp
+++ b/libscript/src/module-codeunit.cpp
@@ -18,12 +18,12 @@
 #include <foundation-auto.h>
 #include <foundation-chunk.h>
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalNumberOfCodeunitsIn(MCStringRef p_target, index_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalNumberOfCodeunitsIn(MCStringRef p_target, index_t& r_output)
 {
     r_output = MCStringGetLength(p_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalIsAmongTheCodeunitsOf(MCStringRef p_needle, MCStringRef p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalIsAmongTheCodeunitsOf(MCStringRef p_needle, MCStringRef p_target, bool& r_output)
 {
     // Error if there is more than one char in needle.
     if (MCStringGetLength(p_needle) != 1)
@@ -36,7 +36,7 @@ extern "C" MC_DLLEXPORT void MCCodeunitEvalIsAmongTheCodeunitsOf(MCStringRef p_n
     r_output = MCStringFirstIndexOfChar(p_target, MCStringGetCodepointAtIndex(p_needle, 0), 0, kMCStringOptionCompareExact, t_dummy);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitFetchCodeunitRangeOf(index_t p_start, index_t p_finish, MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitFetchCodeunitRangeOf(index_t p_start, index_t p_finish, MCStringRef p_target, MCStringRef& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfCodeunitChunkByRangeInRange(p_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -49,7 +49,7 @@ extern "C" MC_DLLEXPORT void MCCodeunitFetchCodeunitRangeOf(index_t p_start, ind
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitStoreCodeunitRangeOf(MCStringRef p_value, index_t p_start, index_t p_finish, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitStoreCodeunitRangeOf(MCStringRef p_value, index_t p_start, index_t p_finish, MCStringRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfCodeunitChunkByRangeInRange(x_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -72,17 +72,17 @@ extern "C" MC_DLLEXPORT void MCCodeunitStoreCodeunitRangeOf(MCStringRef p_value,
     MCValueAssign(x_target, *t_new_string);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitFetchCodeunitOf(index_t p_index, MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitFetchCodeunitOf(index_t p_index, MCStringRef p_target, MCStringRef& r_output)
 {
     MCCodeunitFetchCodeunitRangeOf(p_index, p_index, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitStoreCodeunitOf(MCStringRef p_value, index_t p_index, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitStoreCodeunitOf(MCStringRef p_value, index_t p_index, MCStringRef& x_target)
 {
     MCCodeunitStoreCodeunitRangeOf(p_value, p_index, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalOffsetOfCodeunitsInRange(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, MCRange p_range, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalOffsetOfCodeunitsInRange(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, MCRange p_range, uindex_t& r_output)
 {
     uindex_t t_offset;
     t_offset = 0;
@@ -104,12 +104,12 @@ extern "C" MC_DLLEXPORT void MCCodeunitEvalOffsetOfCodeunitsInRange(bool p_is_la
     r_output = t_offset;
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalOffsetOfCodeunits(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalOffsetOfCodeunits(bool p_is_last, MCStringRef p_needle, MCStringRef p_target, uindex_t& r_output)
 {
     MCCodeunitEvalOffsetOfCodeunitsInRange(p_is_last, p_needle, p_target, MCRangeMake(0, UINDEX_MAX), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalOffsetOfCodeunitsAfter(bool p_is_last, MCStringRef p_needle, index_t p_after, MCStringRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalOffsetOfCodeunitsAfter(bool p_is_last, MCStringRef p_needle, index_t p_after, MCStringRef p_target, uindex_t& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfCodeunitChunkByExpressionInRange(p_target, nil, p_after, true, true, false, t_start, t_count))
@@ -121,7 +121,7 @@ extern "C" MC_DLLEXPORT void MCCodeunitEvalOffsetOfCodeunitsAfter(bool p_is_last
     MCCodeunitEvalOffsetOfCodeunitsInRange(p_is_last, p_needle, p_target, MCRangeMake(t_start + t_count, UINDEX_MAX), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalOffsetOfCodeunitsBefore(bool p_is_first, MCStringRef p_needle, index_t p_before, MCStringRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalOffsetOfCodeunitsBefore(bool p_is_first, MCStringRef p_needle, index_t p_before, MCStringRef p_target, uindex_t& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfCodeunitChunkByExpressionInRange(p_target, nil, p_before, true, false, true, t_start, t_count))
@@ -133,57 +133,57 @@ extern "C" MC_DLLEXPORT void MCCodeunitEvalOffsetOfCodeunitsBefore(bool p_is_fir
     MCCodeunitEvalOffsetOfCodeunitsInRange(!p_is_first, p_needle, p_target, MCRangeMake(0, t_start), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalContains(MCStringRef p_source, MCStringRef p_needle, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalContains(MCStringRef p_source, MCStringRef p_needle, bool& r_result)
 {
     r_result = MCStringContains(p_source, p_needle, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalBeginsWith(MCStringRef p_source, MCStringRef p_prefix, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalBeginsWith(MCStringRef p_source, MCStringRef p_prefix, bool& r_result)
 {
     r_result = MCStringBeginsWith(p_source, p_prefix, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitEvalEndsWith(MCStringRef p_source, MCStringRef p_suffix, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitEvalEndsWith(MCStringRef p_source, MCStringRef p_suffix, bool& r_result)
 {
     r_result = MCStringEndsWith(p_source, p_suffix, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitFetchFirstCodeunitOf(MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitFetchFirstCodeunitOf(MCStringRef p_target, MCStringRef& r_output)
 {
     MCCodeunitFetchCodeunitOf(1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitStoreFirstCodeunitOf(MCStringRef p_value, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitStoreFirstCodeunitOf(MCStringRef p_value, MCStringRef& x_target)
 {
     MCCodeunitStoreCodeunitOf(p_value, 1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitFetchLastCodeunitOf(MCStringRef p_target, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitFetchLastCodeunitOf(MCStringRef p_target, MCStringRef& r_output)
 {
     MCCodeunitFetchCodeunitOf(-1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitStoreLastCodeunitOf(MCStringRef p_value, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitStoreLastCodeunitOf(MCStringRef p_value, MCStringRef& x_target)
 {
     MCCodeunitStoreCodeunitOf(p_value, -1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitExecDeleteCodeunitRangeOf(index_t p_start, index_t p_finish, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitExecDeleteCodeunitRangeOf(index_t p_start, index_t p_finish, MCStringRef& x_target)
 {
     MCCodeunitStoreCodeunitRangeOf(kMCEmptyString, p_start, p_finish, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitExecDeleteCodeunitOf(index_t p_index, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitExecDeleteCodeunitOf(index_t p_index, MCStringRef& x_target)
 {
     MCCodeunitStoreCodeunitOf(kMCEmptyString, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitExecDeleteFirstCodeunitOf(MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitExecDeleteFirstCodeunitOf(MCStringRef& x_target)
 {
     MCCodeunitExecDeleteCodeunitOf(1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCCodeunitExecDeleteLastCodeunitOf(MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCCodeunitExecDeleteLastCodeunitOf(MCStringRef& x_target)
 {
     MCCodeunitExecDeleteCodeunitOf(-1, x_target);
 }
@@ -199,7 +199,7 @@ extern "C" MC_DLLEXPORT void MCCodeunitExecDeleteLastCodeunitOf(MCStringRef& x_t
 //   repeat for each char tCodeunit in tVar
 //   end repeat
 // Will result in tCodeunit containing the value it had at the point of end repeat.
-extern "C" MC_DLLEXPORT bool MCCodeunitRepeatForEachCodeunit(void*& x_iterator, MCStringRef& r_iterand, MCStringRef p_string)
+extern "C" MC_DLLEXPORT_DEF bool MCCodeunitRepeatForEachCodeunit(void*& x_iterator, MCStringRef& r_iterand, MCStringRef p_string)
 {
     uintptr_t t_offset;
     t_offset = (uintptr_t)x_iterator;

--- a/libscript/src/module-date.cpp
+++ b/libscript/src/module-date.cpp
@@ -32,7 +32,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #  define localtime_r(s,t) (localtime_s(t,s))
 #endif
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCDateExecGetLocalDate (MCProperListRef & r_datetime)
 {
 	struct tm t_timeinfo;
@@ -58,7 +58,7 @@ MCDateExecGetLocalDate (MCProperListRef & r_datetime)
         return;
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCDateExecGetUniversalTime (double& r_time)
 {
 #ifndef _WINDOWS

--- a/libscript/src/module-file.cpp
+++ b/libscript/src/module-file.cpp
@@ -21,13 +21,13 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCFileExecGetContents (MCStringRef p_path, MCDataRef & r_data)
 {
 	/* UNCHECKED */ MCSFileGetContents (p_path, r_data);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCFileExecSetContents (MCDataRef p_contents, MCStringRef p_path)
 {
 	/* UNCHECKED */ MCSFileSetContents (p_path, p_contents);
@@ -35,25 +35,25 @@ MCFileExecSetContents (MCDataRef p_contents, MCStringRef p_path)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCFileExecDeleteFile (MCStringRef p_path)
 {
 	/* UNCHECKED */ MCSFileDelete (p_path);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCFileExecCreateDirectory (MCStringRef p_path)
 {
 	/* UNCHECKED */ MCSFileCreateDirectory (p_path);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCFileExecDeleteDirectory (MCStringRef p_path)
 {
 	/* UNCHECKED */ MCSFileDeleteDirectory (p_path);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCFileExecGetDirectoryEntries (MCStringRef p_path,
                                MCProperListRef & r_entries)
 {

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -24,8 +24,8 @@
 
 extern "C"
 {
-    MC_DLLEXPORT MCTypeInfoRef kMCNativeCStringTypeInfo;
-	MC_DLLEXPORT MCTypeInfoRef kMCWStringTypeInfo;
+    MC_DLLEXPORT_DEF MCTypeInfoRef kMCNativeCStringTypeInfo;
+	MC_DLLEXPORT_DEF MCTypeInfoRef kMCWStringTypeInfo;
 }
 
 MCTypeInfoRef kMCForeignZStringNullErrorTypeInfo;

--- a/libscript/src/module-list.cpp
+++ b/libscript/src/module-list.cpp
@@ -18,7 +18,7 @@
 #include <foundation-auto.h>
 #include <foundation-chunk.h>
 
-extern "C" MC_DLLEXPORT void MCListEvalHeadOf(MCProperListRef p_target, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalHeadOf(MCProperListRef p_target, MCValueRef& r_output)
 {
 	if (MCProperListIsEmpty (p_target))
 	{
@@ -29,7 +29,7 @@ extern "C" MC_DLLEXPORT void MCListEvalHeadOf(MCProperListRef p_target, MCValueR
     r_output = MCValueRetain(MCProperListFetchHead(p_target));
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalTailOf(MCProperListRef p_target, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalTailOf(MCProperListRef p_target, MCValueRef& r_output)
 {
 	if (MCProperListIsEmpty (p_target))
 	{
@@ -40,7 +40,7 @@ extern "C" MC_DLLEXPORT void MCListEvalTailOf(MCProperListRef p_target, MCValueR
     r_output = MCValueRetain(MCProperListFetchTail(p_target));
 }
 
-extern "C" MC_DLLEXPORT void MCListExecPushSingleElementOnto(MCValueRef p_value, bool p_is_front, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListExecPushSingleElementOnto(MCValueRef p_value, bool p_is_front, MCProperListRef& x_target)
 {
     MCAutoProperListRef t_mutable_list;
     if (!MCProperListMutableCopy(x_target, &t_mutable_list))
@@ -67,7 +67,7 @@ extern "C" MC_DLLEXPORT void MCListExecPushSingleElementOnto(MCValueRef p_value,
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCListExecPopElement(bool p_is_front, MCProperListRef& x_source)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCListExecPopElement(bool p_is_front, MCProperListRef& x_source)
 {
     MCAutoProperListRef t_mutable_list;
     MCAutoValueRef t_result;
@@ -101,12 +101,12 @@ extern "C" MC_DLLEXPORT MCValueRef MCListExecPopElement(bool p_is_front, MCPrope
     return t_result.Take();
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalNumberOfElementsIn(MCProperListRef p_target, uindex_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalNumberOfElementsIn(MCProperListRef p_target, uindex_t& r_output)
 {
     r_output = MCProperListGetLength(p_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalIsAmongTheElementsOf(MCValueRef p_needle, MCProperListRef p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalIsAmongTheElementsOf(MCValueRef p_needle, MCProperListRef p_target, bool& r_output)
 {
     MCValueRef t_value;
     t_value = p_needle != nil ? p_needle : kMCNull;
@@ -115,13 +115,13 @@ extern "C" MC_DLLEXPORT void MCListEvalIsAmongTheElementsOf(MCValueRef p_needle,
     r_output = MCProperListFirstIndexOfElement(p_target, t_value, 0, t_dummy);
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalContainsElements(MCProperListRef p_target, MCProperListRef p_needle, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalContainsElements(MCProperListRef p_target, MCProperListRef p_needle, bool& r_output)
 {
     uindex_t t_dummy;
     r_output = MCProperListFirstOffsetOfList(p_target, p_needle, 0, t_dummy);
 }
 
-extern "C" MC_DLLEXPORT void MCListFetchElementOf(index_t p_index, MCProperListRef p_target, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListFetchElementOf(index_t p_index, MCProperListRef p_target, MCValueRef& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByExpressionInRange(p_target, nil, p_index, true, false, false, t_start, t_count))
@@ -133,7 +133,7 @@ extern "C" MC_DLLEXPORT void MCListFetchElementOf(index_t p_index, MCProperListR
     r_output = MCValueRetain(MCProperListFetchElementAtIndex(p_target, t_start));
 }
 
-extern "C" MC_DLLEXPORT void MCListStoreElementOf(MCValueRef p_value, index_t p_index, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListStoreElementOf(MCValueRef p_value, index_t p_index, MCProperListRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByExpressionInRange(x_target, nil, p_index, true, false, false, t_start, t_count))
@@ -159,7 +159,7 @@ extern "C" MC_DLLEXPORT void MCListStoreElementOf(MCValueRef p_value, index_t p_
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT void MCListFetchElementRangeOf(index_t p_start, index_t p_finish, MCProperListRef p_target, MCProperListRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListFetchElementRangeOf(index_t p_start, index_t p_finish, MCProperListRef p_target, MCProperListRef& r_output)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByRangeInRange(p_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -171,7 +171,7 @@ extern "C" MC_DLLEXPORT void MCListFetchElementRangeOf(index_t p_start, index_t 
     MCProperListCopySublist(p_target, MCRangeMake(t_start, t_count), r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCListStoreElementRangeOf(MCValueRef p_value, index_t p_start, index_t p_finish, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListStoreElementRangeOf(MCValueRef p_value, index_t p_start, index_t p_finish, MCProperListRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByRangeInRange(x_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -197,19 +197,19 @@ extern "C" MC_DLLEXPORT void MCListStoreElementRangeOf(MCValueRef p_value, index
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT void MCListFetchIndexOf(MCProperListRef p_target, index_t p_index, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListFetchIndexOf(MCProperListRef p_target, index_t p_index, MCValueRef& r_output)
 {
     MCListFetchElementOf(p_index, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCListStoreIndexOf(MCValueRef p_value, MCProperListRef& x_target, index_t p_index)
+extern "C" MC_DLLEXPORT_DEF void MCListStoreIndexOf(MCValueRef p_value, MCProperListRef& x_target, index_t p_index)
 {
     MCValueRef t_value;
     t_value = p_value != nil ? p_value : kMCNull;
     MCListStoreElementOf(t_value, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListStoreAfterElementOf(MCValueRef p_value, index_t p_index, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListStoreAfterElementOf(MCValueRef p_value, index_t p_index, MCProperListRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByExpressionInRange(x_target, nil, p_index, true, true, false, t_start, t_count))
@@ -236,7 +236,7 @@ extern "C" MC_DLLEXPORT void MCListStoreAfterElementOf(MCValueRef p_value, index
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT void MCListStoreBeforeElementOf(MCValueRef p_value, index_t p_index, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListStoreBeforeElementOf(MCValueRef p_value, index_t p_index, MCProperListRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByExpressionInRange(x_target, nil, p_index, true, false, true, t_start, t_count))
@@ -261,24 +261,24 @@ extern "C" MC_DLLEXPORT void MCListStoreBeforeElementOf(MCValueRef p_value, inde
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT void MCListFetchFirstElementOf(MCProperListRef p_target, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListFetchFirstElementOf(MCProperListRef p_target, MCValueRef& r_output)
 {
     MCListFetchElementOf(1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCListStoreFirstElementOf(MCValueRef p_value, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListStoreFirstElementOf(MCValueRef p_value, MCProperListRef& x_target)
 {
     MCValueRef t_value;
     t_value = p_value != nil ? p_value : kMCNull;
     MCListStoreElementOf(t_value, 1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListFetchLastElementOf(MCProperListRef p_target, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListFetchLastElementOf(MCProperListRef p_target, MCValueRef& r_output)
 {
     MCListFetchElementOf(-1, p_target, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCListStoreLastElementOf(MCValueRef p_value, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListStoreLastElementOf(MCValueRef p_value, MCProperListRef& x_target)
 {
     MCValueRef t_value;
     t_value = p_value != nil ? p_value : kMCNull;
@@ -287,7 +287,7 @@ extern "C" MC_DLLEXPORT void MCListStoreLastElementOf(MCValueRef p_value, MCProp
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCListSpliceIntoElementRangeOf(MCProperListRef p_list, index_t p_start, index_t p_finish, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceIntoElementRangeOf(MCProperListRef p_list, index_t p_start, index_t p_finish, MCProperListRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByRangeInRange(x_target, nil, p_start, p_finish, true, false, false, t_start, t_count))
@@ -310,12 +310,12 @@ extern "C" MC_DLLEXPORT void MCListSpliceIntoElementRangeOf(MCProperListRef p_li
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT void MCListSpliceIntoElementOf(MCProperListRef p_list, index_t p_index, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceIntoElementOf(MCProperListRef p_list, index_t p_index, MCProperListRef& x_target)
 {
     MCListSpliceIntoElementRangeOf(p_list, p_index, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListSpliceBeforeElementOf(MCProperListRef p_list, index_t p_index, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceBeforeElementOf(MCProperListRef p_list, index_t p_index, MCProperListRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByExpressionInRange(x_target, nil, p_index, true, false, true, t_start, t_count))
@@ -337,7 +337,7 @@ extern "C" MC_DLLEXPORT void MCListSpliceBeforeElementOf(MCProperListRef p_list,
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT void MCListSpliceAfterElementOf(MCProperListRef p_list, index_t p_index, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceAfterElementOf(MCProperListRef p_list, index_t p_index, MCProperListRef& x_target)
 {
     uindex_t t_start, t_count;
     if (!MCChunkGetExtentsOfElementChunkByExpressionInRange(x_target, nil, p_index, true, true, false, t_start, t_count))
@@ -361,52 +361,52 @@ extern "C" MC_DLLEXPORT void MCListSpliceAfterElementOf(MCProperListRef p_list, 
     MCValueAssign(x_target, *t_immutable);
 }
 
-extern "C" MC_DLLEXPORT void MCListSpliceBefore(MCProperListRef p_list, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceBefore(MCProperListRef p_list, MCProperListRef& x_target)
 {
     MCListSpliceBeforeElementOf(p_list, 1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListSpliceAfter(MCProperListRef p_list, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceAfter(MCProperListRef p_list, MCProperListRef& x_target)
 {
     MCListSpliceAfterElementOf(p_list, -1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListSpliceIntoFirstElementOf(MCProperListRef p_list, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceIntoFirstElementOf(MCProperListRef p_list, MCProperListRef& x_target)
 {
     MCListSpliceIntoElementOf(p_list, 1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListSpliceIntoLastElementOf(MCProperListRef p_list, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListSpliceIntoLastElementOf(MCProperListRef p_list, MCProperListRef& x_target)
 {
     MCListSpliceIntoElementOf(p_list, -1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListExecDeleteElementRangeOf(index_t p_start, index_t p_finish, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListExecDeleteElementRangeOf(index_t p_start, index_t p_finish, MCProperListRef& x_target)
 {
     MCListSpliceIntoElementRangeOf(kMCEmptyProperList, p_start, p_finish, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListExecDeleteElementOf(index_t p_index, MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListExecDeleteElementOf(index_t p_index, MCProperListRef& x_target)
 {
     MCListSpliceIntoElementOf(kMCEmptyProperList, p_index, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListExecDeleteFirstElementOf(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListExecDeleteFirstElementOf(MCProperListRef& x_target)
 {
     MCListExecDeleteElementOf(1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListExecDeleteLastElementOf(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCListExecDeleteLastElementOf(MCProperListRef& x_target)
 {
     MCListExecDeleteElementOf(-1, x_target);
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalEmpty(MCProperListRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalEmpty(MCProperListRef& r_output)
 {
     r_output = MCValueRetain(kMCEmptyProperList);
 }
 
-extern "C" MC_DLLEXPORT bool MCListRepeatForEachElement(void*& x_iterator, MCValueRef& r_iterand, MCProperListRef p_list)
+extern "C" MC_DLLEXPORT_DEF bool MCListRepeatForEachElement(void*& x_iterator, MCValueRef& r_iterand, MCProperListRef p_list)
 {
     uintptr_t t_offset;
     t_offset = (uintptr_t)x_iterator;
@@ -421,22 +421,22 @@ extern "C" MC_DLLEXPORT bool MCListRepeatForEachElement(void*& x_iterator, MCVal
     return true;
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalBeginsWith(MCProperListRef p_list, MCProperListRef p_prefix, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalBeginsWith(MCProperListRef p_list, MCProperListRef p_prefix, bool& r_output)
 {
     r_output = MCProperListBeginsWithList(p_list, p_prefix);
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalEndsWith(MCProperListRef p_list, MCProperListRef p_suffix, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalEndsWith(MCProperListRef p_list, MCProperListRef p_suffix, bool& r_output)
 {
     r_output = MCProperListEndsWithList(p_list, p_suffix);
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalIsEqualTo(MCProperListRef p_left, MCProperListRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalIsEqualTo(MCProperListRef p_left, MCProperListRef p_right, bool& r_output)
 {
     r_output = MCProperListIsEqualTo(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCListEvalIsNotEqualTo(MCProperListRef p_left, MCProperListRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCListEvalIsNotEqualTo(MCProperListRef p_left, MCProperListRef p_right, bool& r_output)
 {
     r_output = !MCProperListIsEqualTo(p_left, p_right);
 }
@@ -471,7 +471,7 @@ MCListEvalIndexOfElementInRange (bool p_is_last,
 		r_output = 0;
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCListEvalIndexOfElement (bool p_is_last,
                           MCValueRef p_needle,
                           MCProperListRef p_haystack,
@@ -481,7 +481,7 @@ MCListEvalIndexOfElement (bool p_is_last,
 	MCListEvalIndexOfElementInRange (p_is_last, p_needle, p_haystack, t_range, r_output);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCListEvalIndexOfElementAfter (bool p_is_last,
                                MCValueRef p_needle,
                                index_t p_after,
@@ -503,7 +503,7 @@ MCListEvalIndexOfElementAfter (bool p_is_last,
 	                                 r_output);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCListEvalIndexOfElementBefore (bool p_is_first,
                                MCValueRef p_needle,
                                index_t p_before,
@@ -557,7 +557,7 @@ MCListEvalOffsetOfListInRange (bool p_is_last,
 		r_output = 0;
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCListEvalOffsetOfList (bool p_is_last,
                         MCProperListRef p_needle,
                         MCProperListRef p_haystack,
@@ -567,7 +567,7 @@ MCListEvalOffsetOfList (bool p_is_last,
 	MCListEvalOffsetOfListInRange (p_is_last, p_needle, p_haystack, t_range, r_output);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCListEvalOffsetOfListAfter (bool p_is_last,
                              MCProperListRef p_needle,
                              index_t p_after,
@@ -589,7 +589,7 @@ MCListEvalOffsetOfListAfter (bool p_is_last,
 	                               r_output);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCListEvalOffsetOfListBefore (bool p_is_first,
                               MCProperListRef p_needle,
                               index_t p_before,

--- a/libscript/src/module-logic.cpp
+++ b/libscript/src/module-logic.cpp
@@ -16,28 +16,28 @@
 
 #include "foundation.h"
 
-extern "C" MC_DLLEXPORT void MCLogicEvalNot(bool p_bool, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCLogicEvalNot(bool p_bool, bool& r_result)
 {
     r_result = !p_bool;
 }
 
-extern "C" MC_DLLEXPORT void MCLogicEvalIsEqualTo(bool p_left, bool p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCLogicEvalIsEqualTo(bool p_left, bool p_right, bool& r_result)
 {
     r_result = (p_left == p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCLogicEvalIsNotEqualTo(bool p_left, bool p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCLogicEvalIsNotEqualTo(bool p_left, bool p_right, bool& r_result)
 {
     r_result = (p_left != p_right);
 }
 
 // AL-2015-02-10: [[ Bug 14538 ]] Native function named incorrectly
-extern "C" MC_DLLEXPORT MCStringRef MCLogicExecFormatBoolAsString(bool p_operand)
+extern "C" MC_DLLEXPORT_DEF MCStringRef MCLogicExecFormatBoolAsString(bool p_operand)
 {
     return MCValueRetain(p_operand ? kMCTrueString : kMCFalseString);
 }
 
-extern "C" MC_DLLEXPORT MCValueRef MCLogicExecParseStringAsBool(MCStringRef p_operand)
+extern "C" MC_DLLEXPORT_DEF MCValueRef MCLogicExecParseStringAsBool(MCStringRef p_operand)
 {
     if (MCStringIsEqualTo(p_operand, kMCTrueString, kMCStringOptionCompareCaseless))
         return MCValueRetain(kMCTrue);
@@ -48,12 +48,12 @@ extern "C" MC_DLLEXPORT MCValueRef MCLogicExecParseStringAsBool(MCStringRef p_op
 }
 
 // AL-2015-02-10: [[ Bug 14538 ]] Native function named incorrectly
-extern "C" MC_DLLEXPORT void MCLogicEvalBoolFormattedAsString(bool p_operand, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCLogicEvalBoolFormattedAsString(bool p_operand, MCStringRef& r_output)
 {
     r_output = MCLogicExecFormatBoolAsString(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCLogicEvalStringParsedAsBool(MCStringRef p_operand, MCValueRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCLogicEvalStringParsedAsBool(MCStringRef p_operand, MCValueRef& r_output)
 {
     r_output = MCLogicExecParseStringAsBool(p_operand);
 }

--- a/libscript/src/module-math.cpp
+++ b/libscript/src/module-math.cpp
@@ -55,7 +55,7 @@ __MCMathPropagateNanBinary (double p_left, double p_right, double p_out)
 
 ////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCMathEvalRealToPowerOfReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalRealToPowerOfReal(double p_left, double p_right, double& r_output)
 {
     r_output = pow(p_left, p_right);
 
@@ -65,7 +65,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalRealToPowerOfReal(double p_left, double p
     MCErrorCreateAndThrow (kMCMathDomainErrorTypeInfo, nil);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalNumberToPowerOfNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalNumberToPowerOfNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     double t_left, t_right;
     t_left = MCNumberFetchAsReal(p_left);
@@ -78,7 +78,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalNumberToPowerOfNumber(MCNumberRef p_left,
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalBase10LogReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalBase10LogReal(double p_operand, double& r_output)
 {
     r_output = log10(p_operand);
 
@@ -88,7 +88,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalBase10LogReal(double p_operand, double& r
     MCErrorCreateAndThrow (kMCMathDomainErrorTypeInfo, nil);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalBase10LogNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalBase10LogNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -100,7 +100,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalBase10LogNumber(MCNumberRef p_operand, MC
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalNaturalLogReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalNaturalLogReal(double p_operand, double& r_output)
 {
     r_output = log(p_operand);
 
@@ -110,7 +110,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalNaturalLogReal(double p_operand, double& 
     MCErrorCreateAndThrow (kMCMathDomainErrorTypeInfo, nil);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalNaturalLogNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalNaturalLogNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -122,12 +122,12 @@ extern "C" MC_DLLEXPORT void MCMathEvalNaturalLogNumber(MCNumberRef p_operand, M
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalExpReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalExpReal(double p_operand, double& r_output)
 {
     r_output = exp(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalExpNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalExpNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -139,12 +139,12 @@ extern "C" MC_DLLEXPORT void MCMathEvalExpNumber(MCNumberRef p_operand, MCNumber
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalSinReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalSinReal(double p_operand, double& r_output)
 {
     r_output = sin(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalSinNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalSinNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -156,12 +156,12 @@ extern "C" MC_DLLEXPORT void MCMathEvalSinNumber(MCNumberRef p_operand, MCNumber
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalCosReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalCosReal(double p_operand, double& r_output)
 {
     r_output = cos(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalCosNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalCosNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -173,12 +173,12 @@ extern "C" MC_DLLEXPORT void MCMathEvalCosNumber(MCNumberRef p_operand, MCNumber
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalTanReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalTanReal(double p_operand, double& r_output)
 {
     r_output = tan(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalTanNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalTanNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -190,7 +190,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalTanNumber(MCNumberRef p_operand, MCNumber
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAsinReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAsinReal(double p_operand, double& r_output)
 {
     r_output = asin(p_operand);
 
@@ -200,7 +200,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalAsinReal(double p_operand, double& r_outp
     MCErrorCreateAndThrow (kMCMathDomainErrorTypeInfo, nil);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAsinNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAsinNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -212,7 +212,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalAsinNumber(MCNumberRef p_operand, MCNumbe
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAcosReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAcosReal(double p_operand, double& r_output)
 {
     r_output = acos(p_operand);
 
@@ -222,7 +222,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalAcosReal(double p_operand, double& r_outp
     MCErrorCreateAndThrow (kMCMathDomainErrorTypeInfo, nil);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAcosNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAcosNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -234,12 +234,12 @@ extern "C" MC_DLLEXPORT void MCMathEvalAcosNumber(MCNumberRef p_operand, MCNumbe
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAtanReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAtanReal(double p_operand, double& r_output)
 {
     r_output = atan(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAtanNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAtanNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     double t_operand;
     t_operand = MCNumberFetchAsReal(p_operand);
@@ -251,12 +251,12 @@ extern "C" MC_DLLEXPORT void MCMathEvalAtanNumber(MCNumberRef p_operand, MCNumbe
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAtan2Real(double p_first, double p_second, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAtan2Real(double p_first, double p_second, double& r_output)
 {
     r_output = atan2(p_first, p_second);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAtan2Number(MCNumberRef p_first, MCNumberRef p_second, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAtan2Number(MCNumberRef p_first, MCNumberRef p_second, MCNumberRef& r_output)
 {
     double t_first, t_second;
     t_first = MCNumberFetchAsReal(p_first);
@@ -269,17 +269,17 @@ extern "C" MC_DLLEXPORT void MCMathEvalAtan2Number(MCNumberRef p_first, MCNumber
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAbsInteger(integer_t p_operand, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAbsInteger(integer_t p_operand, integer_t& r_output)
 {
     r_output = MCAbs(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAbsReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAbsReal(double p_operand, double& r_output)
 {
     r_output = MCAbs(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalAbsNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalAbsNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     if (MCNumberIsInteger(p_operand))
     {
@@ -294,17 +294,17 @@ extern "C" MC_DLLEXPORT void MCMathEvalAbsNumber(MCNumberRef p_operand, MCNumber
     MCNumberCreateWithReal(t_abs_real, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalTruncInteger(integer_t p_operand, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalTruncInteger(integer_t p_operand, integer_t& r_output)
 {
     r_output = p_operand;
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalTruncReal(double p_operand, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalTruncReal(double p_operand, double& r_output)
 {
     r_output = trunc(p_operand);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalTruncNumber(MCNumberRef p_operand, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalTruncNumber(MCNumberRef p_operand, MCNumberRef& r_output)
 {
     if (MCNumberIsInteger(p_operand))
     {
@@ -319,17 +319,17 @@ extern "C" MC_DLLEXPORT void MCMathEvalTruncNumber(MCNumberRef p_operand, MCNumb
     MCNumberCreateWithReal(t_abs_real, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMinInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMinInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     r_output = MCMin(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMinReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMinReal(double p_left, double p_right, double& r_output)
 {
     r_output = MCMin(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMinNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMinNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     double t_left, t_right, t_result;
     t_left = MCNumberFetchAsReal(p_left);
@@ -365,27 +365,27 @@ static void MCMathEvalMinMaxList(MCProperListRef p_list, bool p_is_min, MCNumber
     MCNumberCreateWithReal(t_minmax, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMinList(MCProperListRef p_list, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMinList(MCProperListRef p_list, MCNumberRef& r_output)
 {
     MCMathEvalMinMaxList(p_list, true, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMaxList(MCProperListRef p_list, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMaxList(MCProperListRef p_list, MCNumberRef& r_output)
 {
     MCMathEvalMinMaxList(p_list, false, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMaxInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMaxInteger(integer_t p_left, integer_t p_right, integer_t& r_output)
 {
     r_output = MCMax(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMaxReal(double p_left, double p_right, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMaxReal(double p_left, double p_right, double& r_output)
 {
     r_output = MCMax(p_left, p_right);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalMaxNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalMaxNumber(MCNumberRef p_left, MCNumberRef p_right, MCNumberRef& r_output)
 {
     double t_left, t_right, t_result;
     t_left = MCNumberFetchAsReal(p_left);
@@ -396,14 +396,14 @@ extern "C" MC_DLLEXPORT void MCMathEvalMaxNumber(MCNumberRef p_left, MCNumberRef
     MCNumberCreateWithReal(t_result, r_output);
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalRandomReal(double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalRandomReal(double& r_output)
 {
     r_output = MCSRandomReal();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void MCMathEvalConvertToBase10(MCStringRef p_operand, integer_t p_source_base, integer_t& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalConvertToBase10(MCStringRef p_operand, integer_t p_source_base, integer_t& r_output)
 {
     if (p_source_base < 2 || p_source_base > 32)
         MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("source base must be between 2 and 32"), nil);
@@ -424,7 +424,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalConvertToBase10(MCStringRef p_operand, in
 	}
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalConvertFromBase10(integer_t p_operand, integer_t p_dest_base, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalConvertFromBase10(integer_t p_operand, integer_t p_dest_base, MCStringRef& r_output)
 {
     if (p_dest_base < 2 || p_dest_base > 32)
         MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("destination base must be between 2 and 32"), nil);
@@ -443,7 +443,7 @@ extern "C" MC_DLLEXPORT void MCMathEvalConvertFromBase10(integer_t p_operand, in
 //    ctxt . Throw();
 }
 
-extern "C" MC_DLLEXPORT void MCMathEvalConvertBase(MCStringRef p_operand, integer_t p_source_base, integer_t p_dest_base, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathEvalConvertBase(MCStringRef p_operand, integer_t p_source_base, integer_t p_dest_base, MCStringRef& r_output)
 {
     
     if (p_source_base < 2 || p_source_base > 32)

--- a/libscript/src/module-math_foundation.cpp
+++ b/libscript/src/module-math_foundation.cpp
@@ -17,7 +17,7 @@
 #include <foundation.h>
 #include <foundation-auto.h>
 
-extern "C" MC_DLLEXPORT void MCMathFoundationExecRoundRealToNearest(double& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationExecRoundRealToNearest(double& x_target)
 {
 	if (x_target < 0.0)
         x_target = ceil(x_target - 0.5);
@@ -25,7 +25,7 @@ extern "C" MC_DLLEXPORT void MCMathFoundationExecRoundRealToNearest(double& x_ta
         x_target = floor(x_target + 0.5);
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationExecRoundNumberToNearest(MCNumberRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationExecRoundNumberToNearest(MCNumberRef& x_target)
 {
     double t_target = MCNumberFetchAsReal(x_target);
     MCMathFoundationExecRoundRealToNearest(t_target);
@@ -37,13 +37,13 @@ extern "C" MC_DLLEXPORT void MCMathFoundationExecRoundNumberToNearest(MCNumberRe
     MCValueAssign(x_target, *t_new_number);
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationEvalRoundedRealToNearest(double p_target, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationEvalRoundedRealToNearest(double p_target, double& r_output)
 {
     MCMathFoundationExecRoundRealToNearest(p_target);
     r_output = p_target;
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationEvalRoundedNumberToNearest(MCNumberRef p_target, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationEvalRoundedNumberToNearest(MCNumberRef p_target, MCNumberRef& r_output)
 {
     double t_target = MCNumberFetchAsReal(p_target);
     MCMathFoundationExecRoundRealToNearest(t_target);
@@ -52,17 +52,17 @@ extern "C" MC_DLLEXPORT void MCMathFoundationEvalRoundedNumberToNearest(MCNumber
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationEvalFloorReal(double p_target, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationEvalFloorReal(double p_target, double& r_output)
 {
     r_output = floor(p_target);
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationEvalCeilingReal(double p_target, double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationEvalCeilingReal(double p_target, double& r_output)
 {
     r_output = ceil(p_target);
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationEvalFloorNumber(MCNumberRef p_target, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationEvalFloorNumber(MCNumberRef p_target, MCNumberRef& r_output)
 {
     double t_target = MCNumberFetchAsReal(p_target);
     MCMathFoundationEvalFloorReal(t_target, t_target);
@@ -71,7 +71,7 @@ extern "C" MC_DLLEXPORT void MCMathFoundationEvalFloorNumber(MCNumberRef p_targe
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationEvalCeilingNumber(MCNumberRef p_target, MCNumberRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationEvalCeilingNumber(MCNumberRef p_target, MCNumberRef& r_output)
 {
     double t_target = MCNumberFetchAsReal(p_target);
     MCMathFoundationEvalCeilingReal(t_target, t_target);
@@ -80,7 +80,7 @@ extern "C" MC_DLLEXPORT void MCMathFoundationEvalCeilingNumber(MCNumberRef p_tar
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCMathFoundationEvalPi(double& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCMathFoundationEvalPi(double& r_output)
 {
     r_output = 3.141592653589793238462643;
 }

--- a/libscript/src/module-sort.cpp
+++ b/libscript/src/module-sort.cpp
@@ -41,7 +41,7 @@ static compare_t MCSortCompareDateTime(void *context, MCValueRef p_left, MCValue
     return 0;
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortList(MCProperListRef& x_target, bool p_descending)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortList(MCProperListRef& x_target, bool p_descending)
 {
     MCValueTypeCode t_type;
     if (!MCProperListIsHomogeneous(x_target, t_type))
@@ -80,17 +80,17 @@ extern "C" MC_DLLEXPORT void MCSortExecSortList(MCProperListRef& x_target, bool 
     MCValueAssign(x_target, *t_sorted_list);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListAscending(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListAscending(MCProperListRef& x_target)
 {
     MCSortExecSortList(x_target, false);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListDescending(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListDescending(MCProperListRef& x_target)
 {
     MCSortExecSortList(x_target, true);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListText(MCProperListRef& x_target, bool p_descending)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListText(MCProperListRef& x_target, bool p_descending)
 {
     if (!MCProperListIsListOfType(x_target, kMCValueTypeCodeString))
     {
@@ -114,17 +114,17 @@ extern "C" MC_DLLEXPORT void MCSortExecSortListText(MCProperListRef& x_target, b
     MCValueAssign(x_target, *t_sorted_list);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListAscendingText(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListAscendingText(MCProperListRef& x_target)
 {
     MCSortExecSortListText(x_target, false);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListDescendingText(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListDescendingText(MCProperListRef& x_target)
 {
     MCSortExecSortListText(x_target, true);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListBinary(MCProperListRef& x_target, bool p_descending)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListBinary(MCProperListRef& x_target, bool p_descending)
 {
     if (!MCProperListIsListOfType(x_target, kMCValueTypeCodeData))
     {
@@ -145,17 +145,17 @@ extern "C" MC_DLLEXPORT void MCSortExecSortListBinary(MCProperListRef& x_target,
     MCValueAssign(x_target, *t_sorted_list);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListAscendingBinary(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListAscendingBinary(MCProperListRef& x_target)
 {
     MCSortExecSortListBinary(x_target, false);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListDescendingBinary(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListDescendingBinary(MCProperListRef& x_target)
 {
     MCSortExecSortListBinary(x_target, true);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListNumeric(MCProperListRef& x_target, bool p_descending)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListNumeric(MCProperListRef& x_target, bool p_descending)
 {
     if (!MCProperListIsListOfType(x_target, kMCValueTypeCodeNumber))
     {
@@ -176,12 +176,12 @@ extern "C" MC_DLLEXPORT void MCSortExecSortListNumeric(MCProperListRef& x_target
     MCValueAssign(x_target, *t_sorted_list);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListAscendingNumeric(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListAscendingNumeric(MCProperListRef& x_target)
 {
     MCSortExecSortListNumeric(x_target, false);
 }
 
-extern "C" MC_DLLEXPORT void MCSortExecSortListDescendingNumeric(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListDescendingNumeric(MCProperListRef& x_target)
 {
     MCSortExecSortListNumeric(x_target, true);
 }

--- a/libscript/src/module-stream.cpp
+++ b/libscript/src/module-stream.cpp
@@ -20,7 +20,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCStreamExecWriteToStream(MCDataRef p_data,
                         MCStreamRef p_stream)
 {
@@ -40,13 +40,13 @@ MCStreamExecWriteToStream(MCDataRef p_data,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCStreamExecGetStandardOutput (MCStreamRef & r_stream)
 {
 	MCSStreamGetStandardOutput (r_stream);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCStreamExecGetStandardError (MCStreamRef & r_stream)
 {
 	MCSStreamGetStandardError (r_stream);

--- a/libscript/src/module-string.cpp
+++ b/libscript/src/module-string.cpp
@@ -19,13 +19,13 @@
 
 #include <foundation-locale.h>
 
-extern "C" MC_DLLEXPORT void MCStringEvalConcatenate(MCStringRef p_left, MCStringRef p_right, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalConcatenate(MCStringRef p_left, MCStringRef p_right, MCStringRef& r_output)
 {
     if (!MCStringFormat(r_output, "%@%@", p_left, p_right))
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCStringExecPutStringBefore(MCStringRef p_source, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCStringExecPutStringBefore(MCStringRef p_source, MCStringRef& x_target)
 {
     MCAutoStringRef t_string;
     MCStringEvalConcatenate(p_source, x_target == (MCStringRef)kMCNull ? kMCEmptyString : x_target, &t_string);
@@ -36,7 +36,7 @@ extern "C" MC_DLLEXPORT void MCStringExecPutStringBefore(MCStringRef p_source, M
     MCValueAssign(x_target, *t_string);
 }
 
-extern "C" MC_DLLEXPORT void MCStringExecPutStringAfter(MCStringRef p_source, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCStringExecPutStringAfter(MCStringRef p_source, MCStringRef& x_target)
 {
     MCAutoStringRef t_string;
     MCStringEvalConcatenate(x_target == (MCStringRef)kMCNull ? kMCEmptyString : x_target, p_source, &t_string);
@@ -47,7 +47,7 @@ extern "C" MC_DLLEXPORT void MCStringExecPutStringAfter(MCStringRef p_source, MC
     MCValueAssign(x_target, *t_string);
 }
 
-extern "C" MC_DLLEXPORT void MCStringExecReplace(MCStringRef p_pattern, MCStringRef p_replacement, MCStringRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCStringExecReplace(MCStringRef p_pattern, MCStringRef p_replacement, MCStringRef& x_target)
 {
     MCAutoStringRef t_string;
     if (!MCStringMutableCopy(x_target, &t_string))
@@ -62,13 +62,13 @@ extern "C" MC_DLLEXPORT void MCStringExecReplace(MCStringRef p_pattern, MCString
     MCValueAssign(x_target, *t_new_string);
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalConcatenateWithSpace(MCStringRef p_left, MCStringRef p_right, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalConcatenateWithSpace(MCStringRef p_left, MCStringRef p_right, MCStringRef& r_output)
 {
     if (!MCStringFormat(r_output, "%@ %@", p_left, p_right))
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalLowercaseOf(MCStringRef p_source, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalLowercaseOf(MCStringRef p_source, MCStringRef& r_output)
 {
     MCAutoStringRef t_string;
     if (!MCStringMutableCopy(p_source, &t_string))
@@ -81,7 +81,7 @@ extern "C" MC_DLLEXPORT void MCStringEvalLowercaseOf(MCStringRef p_source, MCStr
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalUppercaseOf(MCStringRef p_source, MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalUppercaseOf(MCStringRef p_source, MCStringRef& r_output)
 {
     MCAutoStringRef t_string;
     if (!MCStringMutableCopy(p_source, &t_string))
@@ -94,27 +94,27 @@ extern "C" MC_DLLEXPORT void MCStringEvalUppercaseOf(MCStringRef p_source, MCStr
         return;
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalIsEqualTo(MCStringRef p_left, MCStringRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalIsEqualTo(MCStringRef p_left, MCStringRef p_right, bool& r_result)
 {
     r_result = MCStringIsEqualTo(p_left, p_right, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalIsNotEqualTo(MCStringRef p_left, MCStringRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalIsNotEqualTo(MCStringRef p_left, MCStringRef p_right, bool& r_result)
 {
     r_result = !MCStringIsEqualTo(p_left, p_right, kMCStringOptionCompareExact);
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalIsLessThan(MCStringRef p_left, MCStringRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalIsLessThan(MCStringRef p_left, MCStringRef p_right, bool& r_result)
 {
     r_result = MCStringCompareTo(p_left, p_right, kMCStringOptionCompareExact) < 0;
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalIsGreaterThan(MCStringRef p_left, MCStringRef p_right, bool& r_result)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalIsGreaterThan(MCStringRef p_left, MCStringRef p_right, bool& r_result)
 {
     r_result = MCStringCompareTo(p_left, p_right, kMCStringOptionCompareExact) > 0;
 }
 
-extern "C" MC_DLLEXPORT void MCStringEvalEmpty(MCStringRef& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCStringEvalEmpty(MCStringRef& r_output)
 {
     r_output = MCValueRetain(kMCEmptyString);
 }

--- a/libscript/src/module-system.cpp
+++ b/libscript/src/module-system.cpp
@@ -22,7 +22,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * System identification
  * ================================================================ */
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCSystemExecGetOperatingSystem (MCStringRef & r_string)
 {
 	const char t_os[] =
@@ -48,13 +48,13 @@ MCSystemExecGetOperatingSystem (MCStringRef & r_string)
  * Command-line information
  * ================================================================ */
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCSystemExecGetCommandName (MCStringRef & r_string)
 {
 	/* UNCHECKED */ MCSCommandLineGetName (r_string);
 }
 
-extern "C" MC_DLLEXPORT void
+extern "C" MC_DLLEXPORT_DEF void
 MCSystemExecGetCommandArguments (MCProperListRef & r_list)
 {
 	/* UNCHECKED */ MCSCommandLineGetArguments (r_list);

--- a/libscript/src/module-type.cpp
+++ b/libscript/src/module-type.cpp
@@ -13,12 +13,12 @@ static bool MCTypeValueIsEmpty(MCValueRef p_value)
     (MCValueGetTypeCode(p_value) == kMCValueTypeCodeProperList && MCProperListIsEmpty((MCProperListRef)p_value)));
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsEmpty(MCValueRef p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsEmpty(MCValueRef p_target, bool& r_output)
 {
     r_output = MCTypeValueIsEmpty(p_target);
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsNotEmpty(MCValueRef p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsNotEmpty(MCValueRef p_target, bool& r_output)
 {
     bool t_empty;
     MCTypeEvalIsEmpty(p_target, t_empty);
@@ -26,12 +26,12 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsNotEmpty(MCValueRef p_target, bool& r_o
     r_output = !t_empty;
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsDefined(MCValueRef *p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsDefined(MCValueRef *p_target, bool& r_output)
 {
     r_output = (p_target != nil && *p_target != kMCNull);
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsNotDefined(MCValueRef *p_target, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsNotDefined(MCValueRef *p_target, bool& r_output)
 {
     bool t_defined;
     MCTypeEvalIsDefined(p_target, t_defined);
@@ -39,7 +39,7 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsNotDefined(MCValueRef *p_target, bool& 
     r_output = !t_defined;
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsABoolean(MCValueRef p_value, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsABoolean(MCValueRef p_value, bool& r_output)
 {
     if (p_value != nil)
         r_output = MCValueGetTypeCode(p_value) == kMCValueTypeCodeBoolean;
@@ -47,7 +47,7 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsABoolean(MCValueRef p_value, bool& r_ou
         r_output = false;
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsANumber(MCValueRef p_value, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsANumber(MCValueRef p_value, bool& r_output)
 {
     if (p_value != nil)
         r_output = MCValueGetTypeCode(p_value) == kMCValueTypeCodeNumber;
@@ -55,7 +55,7 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsANumber(MCValueRef p_value, bool& r_out
         r_output = false;
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsAString(MCValueRef p_value, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsAString(MCValueRef p_value, bool& r_output)
 {
     if (p_value != nil)
         r_output = MCValueGetTypeCode(p_value) == kMCValueTypeCodeString;
@@ -63,7 +63,7 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsAString(MCValueRef p_value, bool& r_out
         r_output = false;
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsAData(MCValueRef p_value, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsAData(MCValueRef p_value, bool& r_output)
 {
     if (p_value != nil)
         r_output = MCValueGetTypeCode(p_value) == kMCValueTypeCodeData;
@@ -71,7 +71,7 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsAData(MCValueRef p_value, bool& r_outpu
         r_output = false;
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsAnArray(MCValueRef p_value, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsAnArray(MCValueRef p_value, bool& r_output)
 {
     if (p_value != nil)
         r_output = MCValueGetTypeCode(p_value) == kMCValueTypeCodeArray;
@@ -79,7 +79,7 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsAnArray(MCValueRef p_value, bool& r_out
         r_output = false;
 }
 
-extern "C" MC_DLLEXPORT void MCTypeEvalIsAList(MCValueRef p_value, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCTypeEvalIsAList(MCValueRef p_value, bool& r_output)
 {
     if (p_value != nil)
         r_output = MCValueGetTypeCode(p_value) == kMCValueTypeCodeProperList;
@@ -87,22 +87,22 @@ extern "C" MC_DLLEXPORT void MCTypeEvalIsAList(MCValueRef p_value, bool& r_outpu
         r_output = false;
 }
 
-extern "C" MC_DLLEXPORT void MCNothingEvalIsNothingEqualTo(MCNullRef p_left, MCValueRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCNothingEvalIsNothingEqualTo(MCNullRef p_left, MCValueRef p_right, bool& r_output)
 {
     r_output = p_right == nil;
 }
 
-extern "C" MC_DLLEXPORT void MCNothingEvalIsEqualToNothing(MCValueRef p_left, MCNullRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCNothingEvalIsEqualToNothing(MCValueRef p_left, MCNullRef p_right, bool& r_output)
 {
     r_output = p_left == nil;
 }
 
-extern "C" MC_DLLEXPORT void MCNothingEvalIsNothingNotEqualTo(MCNullRef p_left, MCValueRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCNothingEvalIsNothingNotEqualTo(MCNullRef p_left, MCValueRef p_right, bool& r_output)
 {
     r_output = p_right != nil;
 }
 
-extern "C" MC_DLLEXPORT void MCNothingEvalIsNotEqualToNothing(MCValueRef p_left, MCNullRef p_right, bool& r_output)
+extern "C" MC_DLLEXPORT_DEF void MCNothingEvalIsNotEqualToNothing(MCValueRef p_left, MCNullRef p_right, bool& r_output)
 {
     r_output = p_left != nil;
 }

--- a/libscript/src/module-type_convert.cpp
+++ b/libscript/src/module-type_convert.cpp
@@ -30,7 +30,7 @@ static bool MCProperListCombine(void *context, MCValueRef p_value)
     return MCListAppend(t_list, p_value);
 }
 
-extern "C" MC_DLLEXPORT MCProperListRef MCTypeConvertExecSplitStringByDelimiter(MCStringRef p_target, MCStringRef p_delimiter)
+extern "C" MC_DLLEXPORT_DEF MCProperListRef MCTypeConvertExecSplitStringByDelimiter(MCStringRef p_target, MCStringRef p_delimiter)
 {
     MCAutoProperListRef t_list;
     if (!MCStringSplitByDelimiter(p_target, p_delimiter, kMCStringOptionCompareExact, &t_list))
@@ -39,7 +39,7 @@ extern "C" MC_DLLEXPORT MCProperListRef MCTypeConvertExecSplitStringByDelimiter(
     return MCValueRetain(*t_list);
 }
 
-extern "C" MC_DLLEXPORT MCStringRef MCTypeConvertExecCombineListWithDelimiter(MCProperListRef p_target, MCStringRef p_delimiter)
+extern "C" MC_DLLEXPORT_DEF MCStringRef MCTypeConvertExecCombineListWithDelimiter(MCProperListRef p_target, MCStringRef p_delimiter)
 {
     MCListRef t_list;
     if (!MCListCreateMutable(p_delimiter, t_list))

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -2482,7 +2482,7 @@ __MCScriptHandlerDescribe (void *p_context,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" bool MC_DLLEXPORT MCScriptBuiltinRepeatCounted(uinteger_t *x_count)
+extern "C" bool MC_DLLEXPORT_DEF MCScriptBuiltinRepeatCounted(uinteger_t *x_count)
 {
     if (*x_count == 0)
         return false;
@@ -2491,27 +2491,27 @@ extern "C" bool MC_DLLEXPORT MCScriptBuiltinRepeatCounted(uinteger_t *x_count)
     return true;
 }
 
-extern "C" bool MC_DLLEXPORT MCScriptBuiltinRepeatUpToCondition(double p_counter, double p_limit)
+extern "C" bool MC_DLLEXPORT_DEF MCScriptBuiltinRepeatUpToCondition(double p_counter, double p_limit)
 {
     return p_counter <= p_limit;
 }
 
-extern "C" double MC_DLLEXPORT MCScriptBuiltinRepeatUpToIterate(double p_counter, double p_step)
+extern "C" double MC_DLLEXPORT_DEF MCScriptBuiltinRepeatUpToIterate(double p_counter, double p_step)
 {
     return p_counter + p_step;
 }
 
-extern "C" bool MC_DLLEXPORT MCScriptBuiltinRepeatDownToCondition(double p_counter, double p_limit)
+extern "C" bool MC_DLLEXPORT_DEF MCScriptBuiltinRepeatDownToCondition(double p_counter, double p_limit)
 {
     return p_counter >= p_limit;
 }
 
-extern "C" double MC_DLLEXPORT MCScriptBuiltinRepeatDownToIterate(double p_counter, double p_step)
+extern "C" double MC_DLLEXPORT_DEF MCScriptBuiltinRepeatDownToIterate(double p_counter, double p_step)
 {
     return p_counter + p_step;
 }
 
-extern "C" void MC_DLLEXPORT MCScriptBuiltinThrow(MCStringRef p_reason)
+extern "C" void MC_DLLEXPORT_DEF MCScriptBuiltinThrow(MCStringRef p_reason)
 {
     MCErrorThrowGeneric(p_reason);
 }


### PR DESCRIPTION
The `used` attribute is needed for Emscripten builds to ensure that
native functions accessed by name via dlsym() and/or from JavaScript
keep their names and are not removed even when aggressive optimisation
is used.

`used` can only be attached to definitions, so it cannot be added to
`MC_DLLEXPORT`, because that is attached to declarations.  It is also
not possible to move `MC_DLLEXPORT` from declarations to definitions,
because on Windows, the `dllexport` attribute must be attached to
declarations (it changes the storage type of the symbol to which it is
attached).

This patch therefore adds a new `MC_DLLEXPORT_DEF` macro that must be
attached to the definitions of exported functions or variables, while
`MC_DLLEXPORT` is reserved for advance declarations (e.g. in header
files).

All symbols that are declared `MC_DLLEXPORT` are now defined with
`MC_DLLEXPORT_DEF`, and all uses of `MC_DLLEXPORT` on definitions are
replaced with `MC_DLLEXPORT_DEF`.

Supercedes #2579.
