### PR TITLE
[[ Bug 11866 ]] Properly port to 7.0 the bug fix for the bug 11866 - …

### DIFF
--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -1787,8 +1787,7 @@ Exec_stat MCHandleHeadingCalibrationTimeout(void *p_context, MCParameter *p_para
     int t_timeout;
     MCSensorGetLocationCalibrationTimeout(ctxt, t_timeout);
     MCresult->setnvalue(t_timeout);
-    
-    ctxt . SetTheResultToEmpty();
+
 	if (!ctxt . HasError())
 		return ES_NORMAL;
 


### PR DESCRIPTION
…setting the context to empty was not removed at the right place
