### PR TITLE
[Bug 7217] Send selectionChanged to the field when navigating using arrow keys

### DIFF
--- a/docs/notes/bugfix-7217.md
+++ b/docs/notes/bugfix-7217.md
@@ -1,0 +1,1 @@
+#  selectionChanged not sent on arrow navigation

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -2271,13 +2271,17 @@ void MCField::fmove(Field_translations function, const char *string, KeySym key)
 	drect.x += getcontentx();
 	setfocus(drect.x, drect.y);
 	replacecursor(True, function != FT_UP && function != FT_DOWN);
+	
+	// PM-2015-07-20: [[ Bug 7217 ]] Send selectionChanged on arrow navigation, regardless of whether Shift key is held down
 	if (state & CS_SELECTING)
 	{
 		state &= ~CS_SELECTING;
 		MCundos->freestate();
-		signallisteners(P_HILITED_LINES);
-		message(MCM_selection_changed);
 	}
+	
+	signallisteners(P_HILITED_LINES);
+	message(MCM_selection_changed);
+	
 	extend = extendwords = extendlines = False;
 	contiguous = True;
 }


### PR DESCRIPTION
..regardless of whether the Shift key is held down
