### PR TITLE
lc-compile: Don't dump all syntax rules on every compile.

### DIFF
--- a/toolchain/lc-compile/src/syntax-gen.c
+++ b/toolchain/lc-compile/src/syntax-gen.c
@@ -1855,9 +1855,6 @@ void GenerateSyntaxRules(void)
     
     GenerateInvokeLists();
     GenerateTokenList();
-
-    DumpSyntaxRules();
-    DumpSyntaxMethods();
 }
 
 void DumpSyntaxRules(void)


### PR DESCRIPTION
It's one of the things contributing to insanely huge build logs. :-(
