### PR TITLE
[[ Xcode 7 ]] reviphoneproxy won't compile using Xcode 7 with MacOSX …

### DIFF
--- a/revmobile/revmobile.gyp
+++ b/revmobile/revmobile.gyp
@@ -142,6 +142,7 @@
 						'xcode_settings':
 						{
 							'ARCHS': 'x86_64',
+							'SDKROOT': 'macosx',
 						},
 					},
 				],


### PR DESCRIPTION
…10.8 or 10.9 SDK, but 10.10 or 10.11 work.

```
 We take the latest SDK installed, to let people running Mavericks able to compile.
```
