### PR TITLE
[[ Bug 15612 ]] Reinstate MCtodestroy stack list.

### DIFF
--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -2854,6 +2854,8 @@ Exec_stat MCChunk::del(MCExecPoint &ep)
 				MCeerror->add(EE_CHUNK_CANTDELETEOBJECT, line, pos);
 				return ES_ERROR;
 			}
+            if (objptr->gettype() == CT_STACK)
+                MCtodestroy->remove((MCStack *)objptr);
 			objptr->scheduledelete();
 		}
 		else

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -592,7 +592,11 @@ Exec_errors MCClipboardCmd::processtoclipboard(MCObjectRef *p_objects, uint4 p_o
 			for(uint4 i = 0; i < p_object_count; ++i)
 			{
 				if (p_objects[i] . object -> del())
+                {
+                    if (p_objects[i] . object -> gettype() == CT_STACK)
+                        MCtodestroy -> remove(static_cast<MCStack *>(p_objects[i] . object));
                     p_objects[i] . object -> scheduledelete();
+                }
 			}
 		}
 	}

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -336,6 +336,11 @@ void X_main_loop_iteration()
 		MCtracedobject->message(MCM_trace_done);
 		MCtracedobject = NULL;
 	}
+    if (!MCtodestroy -> isempty())
+    {
+        MCtooltip -> settip(NULL);
+        MCtodestroy -> destroy();
+    }
 	MCU_cleaninserted();
 	MCscreen->siguser();
 	MCdefaultstackptr = MCstaticdefaultstackptr;

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -247,6 +247,7 @@ uint2 MCdragdelta = 4;
 MCUndolist *MCundos;
 MCSellist *MCselected;
 MCStacklist *MCstacks;
+MCStacklist *MCtodestroy;
 MCCardlist *MCrecent;
 MCCardlist *MCcstack;
 MCDispatch *MCdispatcher;
@@ -632,6 +633,7 @@ void X_clear_globals(void)
 	MCundos = nil;
 	MCselected = nil;
 	MCstacks = nil;
+    MCtodestroy = nil;
 	MCrecent = nil;
 	MCcstack = nil;
 	MCdispatcher = nil;
@@ -927,6 +929,7 @@ bool X_open(int argc, char *argv[], char *envp[])
 	MCundos = new MCUndolist;
 	MCselected = new MCSellist;
 	MCstacks = new MCStacklist;
+    MCtodestroy = new MCStacklist;
 	MCrecent = new MCCardlist;
 	MCcstack = new MCCardlist;
 
@@ -1120,6 +1123,7 @@ int X_close(void)
 	delete MCtemplateimage;
 	delete MCtemplatefield;
 	delete MCselected;
+    delete MCtodestroy;
 	delete MCstacks;
 	delete MCcstack;
 	delete MCrecent;

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -161,6 +161,7 @@ extern Boolean MCownselection;
 extern MCUndolist *MCundos;
 extern MCSellist *MCselected;
 extern MCStacklist *MCstacks;
+extern MCStacklist *MCtodestroy;
 extern MCCardlist *MCrecent;
 extern MCCardlist *MCcstack;
 extern MCDispatch *MCdispatcher;

--- a/engine/src/mblmain.cpp
+++ b/engine/src/mblmain.cpp
@@ -141,6 +141,11 @@ bool X_main_loop_iteration(void)
 	// MW-2011-08-26: [[ Redraw ]] Make sure we flush any updates.
 	MCRedrawUpdateScreen();
 	MCabortscript = False;
+    if (!MCtodestroy -> isempty())
+    {
+        MCtooltip -> settip(NULL);
+        MCtodestroy -> destroy();
+    }
 	MCU_cleaninserted();
 	MCscreen->siguser();
 	MCdefaultstackptr = MCstaticdefaultstackptr;

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -425,7 +425,11 @@ bool MCSellist::clipboard(bool p_is_cut)
 					if (tptr -> ref -> getstack() -> iskeyed())
 					{
 						if (tptr -> ref -> del())
+                        {
+                            if (tptr -> ref -> gettype() == CT_STACK)
+                                MCtodestroy -> remove(static_cast<MCStack *>(tptr -> ref));
 							tptr -> ref -> scheduledelete();
+                        }
 					}
 
 					delete tptr;

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -112,8 +112,8 @@ void MCStack::checkdestroy()
 					}
 					while (sptr != substacks);
 				}
-                del();
-                scheduledelete();
+                MCtodestroy -> remove(this);
+                MCtodestroy -> add(this);
 			}
 	}
 	else if (!MCdispatcher -> is_transient_stack(this))
@@ -1690,6 +1690,7 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
 	if (state & (CS_IGNORE_CLOSE | CS_NO_FOCUS | CS_DELETE_STACK))
 		return ES_NORMAL;
     
+    MCtodestroy -> remove(this);
 	if (wm == WM_LAST)
 		if (opened)
 			wm = mode;


### PR DESCRIPTION
When reworking object deletion to be more prompty, the pending destroyed stack list was replaced by the same
object deletion process. However, this was incorrect. MCtodestroy is a list of stacks which are pending
deletion due to the 'destroyStack' requirement being satisfied. These are always deleted at the next main
loop iteration, rather than immediately. (This ensures destroyStack works even if handlers in the stack are
currently executing).

(This requires porting forward to 7.0 to fix the problem in the 7 branch also).
