### PR TITLE
Re-enable warnings for lc-compile

### DIFF
--- a/toolchain/lc-compile/src/lc-compile-bootstrap-common.gypi
+++ b/toolchain/lc-compile/src/lc-compile-bootstrap-common.gypi
@@ -14,6 +14,7 @@
 	
 	'sources':
 	[
+		# Some build systems require at least one input file
 		'dummy.cpp',
 	],
 	

--- a/toolchain/lc-compile/src/lc-compile-bootstrap-common.gypi
+++ b/toolchain/lc-compile/src/lc-compile-bootstrap-common.gypi
@@ -14,7 +14,7 @@
 	
 	'sources':
 	[
-		'>@(lc-compile_source_files)',
+		'dummy.cpp',
 	],
 	
 	'actions':

--- a/toolchain/lc-compile/src/lc-compile-bootstrap.gyp
+++ b/toolchain/lc-compile/src/lc-compile-bootstrap.gyp
@@ -191,6 +191,7 @@
 			
 			'sources':
 			[
+				# Some build systems require at least one input file
 				'dummy.cpp',
 			],
 			

--- a/toolchain/lc-compile/src/lc-compile-bootstrap.gyp
+++ b/toolchain/lc-compile/src/lc-compile-bootstrap.gyp
@@ -13,9 +13,8 @@
 
 		'dependencies':
 		[
-			'../../../libfoundation/libfoundation.gyp:libFoundation',
-			'../../../libscript/libscript.gyp:libScript',
 			'../../gentle/gentle/grts.gyp:grts',
+			'lc-compile-lib.gyp:lc-compile-lib',
 		],
 		
 		'include_dirs':
@@ -192,7 +191,7 @@
 			
 			'sources':
 			[
-				'>@(lc-compile_source_files)',
+				'dummy.cpp',
 			],
 			
 			'actions':

--- a/toolchain/lc-compile/src/lc-compile-lib.gyp
+++ b/toolchain/lc-compile/src/lc-compile-lib.gyp
@@ -1,0 +1,30 @@
+{
+	'includes':
+	[
+		'../../../common.gypi',
+		'lc-compile-sources.gypi'
+	],
+
+	'targets':
+	[
+		{
+			'target_name': 'lc-compile-lib',
+			'type': 'static_library',
+
+			'toolsets': ['host', 'target'],
+
+			'product_name': 'lc-compile-lib-<(_toolset)',
+
+			'dependencies':
+			[
+				'../../../libfoundation/libfoundation.gyp:libFoundation',
+				'../../../libscript/libscript.gyp:libScript',
+			],
+
+			'sources':
+			[
+					'<@(lc-compile_source_files)',
+			],
+		},
+	],
+}


### PR DESCRIPTION
This enables warnings for lc-compile while keeping them disabled for the machine-generated components. This is done by separating the hand-written files into a separate target that gets linked into the final executable.

Depends on #2616.
