### PR TITLE
[[Cleanup]] More type conversion warnings in graphics headers.

### DIFF
--- a/engine/src/graphics_util.h
+++ b/engine/src/graphics_util.h
@@ -30,7 +30,7 @@ inline MCRectangle MCRectangleMake(int16_t x, int16_t y, uint16_t width, uint16_
 	return t_rect;
 }
 
-inline MCRectangle MCRectangleOffset(const MCRectangle &p_rect, int32_t p_dx, int32_t p_dy)
+inline MCRectangle MCRectangleOffset(const MCRectangle &p_rect, int16_t p_dx, int16_t p_dy)
 {
 	return MCRectangleMake(p_rect.x + p_dx, p_rect.y + p_dy, p_rect.width, p_rect.height);
 }
@@ -67,7 +67,7 @@ inline MCRectangle32 MCRectangle32Intersect(const MCRectangle32 &a, const MCRect
 	t_right = MCMin(a.x + a.width, b.x + b.width);
 	t_bottom = MCMin(a.y + a.height, b.y + b.height);
 	
-	uint32_t t_width, t_height;
+	int32_t t_width, t_height;
 	t_width = MCMax(0, t_right - t_left);
 	t_height = MCMax(0, t_bottom - t_top);
 	
@@ -84,7 +84,10 @@ inline MCRectangle32 MCRectangle32FromMCRectangle(const MCRectangle &p_rect)
 
 inline MCRectangle MCRectangle32ToMCRectangle(const MCRectangle32 &p_rect)
 {
-	return MCRectangleMake(p_rect.x, p_rect.y, p_rect.width, p_rect.height);
+	return MCRectangleMake(int16_t(MCClamp(p_rect.x, INT16_MIN, INT16_MAX)),
+                           int16_t(MCClamp(p_rect.y, INT16_MIN, INT16_MAX)),
+                           uint16_t(MCClamp(p_rect.width, 0, UINT16_MAX)),
+                           uint16_t(MCClamp(p_rect.height, 0, UINT16_MAX)));
 }
 
 inline MCGRectangle MCRectangleToMCGRectangle(const MCRectangle &p_rect)
@@ -103,12 +106,16 @@ inline MCGRectangle MCRectangle32ToMCGRectangle(const MCRectangle32 &p_rect)
 
 inline MCRectangle32 MCRectangle32FromMCGIntegerRectangle(const MCGIntegerRectangle &p_rect)
 {
-	return MCRectangle32Make(p_rect.origin.x, p_rect.origin.y, p_rect.size.width, p_rect.size.height);
+	return MCRectangle32Make(p_rect.origin.x, p_rect.origin.y,
+                             int32_t(MCMin(p_rect.size.width, INT32_MAX)),
+                             int32_t(MCMin(p_rect.size.height, INT32_MAX)));
 }
 
 inline MCGIntegerRectangle MCRectangle32ToMCGIntegerRectangle(const MCRectangle32 &p_rect)
 {
-	return MCGIntegerRectangleMake(p_rect.x, p_rect.y, p_rect.width, p_rect.height);
+	return MCGIntegerRectangleMake(p_rect.x, p_rect.y,
+                                   uint32_t(MCMax(p_rect.width, 0)),
+                                   uint32_t(MCMax(p_rect.height, 0)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -120,7 +127,10 @@ inline MCGIntegerRectangle MCRectangleToMCGIntegerRectangle(const MCRectangle &p
 
 inline MCRectangle MCRectangleFromMCGIntegerRectangle(const MCGIntegerRectangle &p_rect)
 {
-	return MCRectangleMake(p_rect.origin.x, p_rect.origin.y, p_rect.size.width, p_rect.size.height);
+	return MCRectangleMake(int16_t(MCClamp(p_rect.origin.x,     INT16_MIN, INT16_MAX)),
+                           int16_t(MCClamp(p_rect.origin.y,     INT16_MIN, INT16_MAX)),
+                           uint16_t(MCClamp(p_rect.size.width,  0, UINT16_MAX)),
+                           uint16_t(MCClamp(p_rect.size.height, 0, UINT16_MAX)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -533,50 +533,54 @@ inline bool MCGSizeIsEqual(const MCGSize &p_a, const MCGSize &p_b)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-inline void MCGColorSetRed(MCGColor& x_color, MCGFloat p_red) {
-    x_color = (x_color & 0xFF00FFFF) |
-              (MCGColor(MCClamp(p_red * 0xFF, 0, UINT8_MAX)) << 16);
+inline MCGColor MCGColorComponentFromFloat(MCGFloat p_component)
+{
+    return MCGColor(MCClamp(p_component, 0, UINT8_MAX));
 }
 
-inline void MCGColorSetGreen(MCGColor& x_color, MCGFloat p_green) {
-	x_color = (x_color & 0xFFFF00FF) |
-              (MCGColor(MCClamp(p_green * 0xFF, 0, UINT8_MAX)) << 8);
-}
-
-inline void MCGColorSetBlue(MCGColor& x_color, MCGFloat p_blue) {
-	x_color = (x_color & 0xFFFFFF00) |
-              (MCGColor(MCClamp(p_blue * 0xFF, 0, UINT8_MAX)) << 0);
-}
-
-inline void MCGColorSetAlpha(MCGColor& x_color, MCGFloat p_alpha) {
-	x_color = (x_color & 0x00FFFFFF) |
-              (MCGColor(MCClamp(p_alpha * 0xFF, 0, UINT8_MAX)) << 24);
+inline MCGFloat MCGColorComponentToFloat(MCGColor p_component)
+{
+    return (p_component & UINT8_MAX) / MCGFloat(UINT8_MAX);
 }
 
 inline MCGColor MCGColorMakeRGBA(MCGFloat p_red, MCGFloat p_green, MCGFloat p_blue, MCGFloat p_alpha)
 {
-    MCGColor result = 0;
-    MCGColorSetRed  (result, p_red  );
-    MCGColorSetGreen(result, p_green);
-    MCGColorSetBlue (result, p_blue );
-    MCGColorSetAlpha(result, p_alpha);
-    return result;
+    return ((MCGColorComponentFromFloat(p_alpha) << 24) |
+            (MCGColorComponentFromFloat(p_red)   << 16) |
+            (MCGColorComponentFromFloat(p_green) <<  8) |
+            (MCGColorComponentFromFloat(p_blue)  <<  0));
+}
+
+inline void MCGColorSetRed(MCGColor& x_color, MCGFloat p_red) {
+    x_color = (x_color & 0xFF00FFFF) | (MCGColorComponentFromFloat(p_red) << 16);
+}
+
+inline void MCGColorSetGreen(MCGColor& x_color, MCGFloat p_green) {
+    x_color = (x_color & 0xFFFF00FF) | (MCGColorComponentFromFloat(p_green) << 8);
+}
+
+inline void MCGColorSetBlue(MCGColor& x_color, MCGFloat p_blue) {
+    x_color = (x_color & 0xFFFFFF00) | (MCGColorComponentFromFloat(p_blue) << 0);
+}
+
+inline void MCGColorSetAlpha(MCGColor& x_color, MCGFloat p_alpha) {
+    x_color = (x_color & 0x00FFFFFF) | (MCGColorComponentFromFloat(p_alpha) << 24);
 }
 
 inline MCGFloat MCGColorGetRed(MCGColor p_color) {
-	return ((p_color >> 16) & 0xFF) / 255.0f;
+    return MCGColorComponentToFloat(p_color >> 16);
 }
 
 inline MCGFloat MCGColorGetGreen(MCGColor p_color) {
-	return ((p_color >> 8) & 0xFF) / 255.0f;
+    return MCGColorComponentToFloat(p_color >> 8);
 }
 
 inline MCGFloat MCGColorGetBlue(MCGColor p_color) {
-	return ((p_color >> 0) & 0xFF) / 255.0f;
+    return MCGColorComponentToFloat(p_color >> 0);
 }
 
 inline MCGFloat MCGColorGetAlpha(MCGColor p_color) {
-	return ((p_color >> 24) & 0xFF) / 255.0f;
+    return MCGColorComponentToFloat(p_color >> 24);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -61,9 +61,9 @@ typedef uint32_t MCGPixelFormat;
 static inline uint32_t __MCGPixelPackComponents(uint8_t p_1, uint8_t p_2, uint8_t p_3, uint8_t p_4)
 {
 #ifdef __LITTLE_ENDIAN__
-	return p_1 | (p_2 << 8) | (p_3 << 16) | (p_4 << 24);
+	return p_1 | (uint32_t(p_2) << 8) | (uint32_t(p_3) << 16) | (uint32_t(p_4) << 24);
 #else
-	return (p_1 << 24) | (p_2 << 16) | (p_3 << 8) | p_4;
+	return (uint32_t(p_1) << 24) | (uint32_t(p_2) << 16) | (uint32_t(p_3) << 8) | uint32_t(p_4);
 #endif
 }
 
@@ -158,12 +158,12 @@ static inline uint32_t MCGPixelSetAlpha(MCGPixelFormat p_format, uint32_t p_pixe
 	if (p_format & kMCGPixelAlphaPositionFirst)
 		return (p_pixel & 0xFFFFFF00) | p_new_alpha;
 	else
-		return (p_pixel & 0x00FFFFFF) | (p_new_alpha << 24);
+		return (p_pixel & 0x00FFFFFF) | (uint32_t(p_new_alpha) << 24);
 #else
 	if ((p_format & kMCGPixelAlphaPositionFirst) == 0)
 		return (p_pixel & 0xFFFFFF00) | p_new_alpha;
 	else
-		return (p_pixel & 0x00FFFFFF) | (p_new_alpha << 24);
+		return (p_pixel & 0x00FFFFFF) | (uint32_t(p_new_alpha) << 24);
 #endif
 }
 
@@ -191,13 +191,13 @@ static inline uint32_t MCGPixelSetNativeAlpha(uint32_t p_pixel, uint8_t p_new_al
 	#if kMCGPixelFormatNative & kMCGPixelAlphaPositionFirst
 		return (p_pixel & 0xFFFFFF00) | p_new_alpha;
 	#else
-		return (p_pixel & 0x00FFFFFF) | (p_new_alpha << 24);
+		return (p_pixel & 0x00FFFFFF) | (uint32_t(p_new_alpha) << 24);
 	#endif
 #else
 	#if (kMCGPixelFormatNative & kMCGPixelAlphaPositionFirst) == 0
 		return (p_pixel & 0xFFFFFF00) | p_new_alpha;
 	#else
-		return (p_pixel & 0x00FFFFFF) | (p_new_alpha << 24);
+		return (p_pixel & 0x00FFFFFF) | (uint32_t(p_new_alpha) << 24);
 	#endif
 #endif
 }
@@ -533,25 +533,34 @@ inline bool MCGSizeIsEqual(const MCGSize &p_a, const MCGSize &p_b)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-inline MCGColor MCGColorMakeRGBA(MCGFloat p_red, MCGFloat p_green, MCGFloat p_blue, MCGFloat p_alpha)
-{
-	return ((uint8_t)(p_red * 255) << 16) | ((uint8_t)(p_green * 255) << 8) | ((uint8_t)(p_blue * 255) << 0) | ((uint8_t)(p_alpha * 255) << 24);
-}
-
 inline void MCGColorSetRed(MCGColor& x_color, MCGFloat p_red) {
-	x_color = (x_color & 0xFF00FFFF) | ((uint8_t)(p_red * 255) << 16);
+    x_color = (x_color & 0xFF00FFFF) |
+              (MCGColor(MCClamp(p_red * 0xFF, 0, UINT8_MAX)) << 16);
 }
 
 inline void MCGColorSetGreen(MCGColor& x_color, MCGFloat p_green) {
-	x_color = (x_color & 0xFFFF00FF) | ((uint8_t)(p_green * 255) << 8);
+	x_color = (x_color & 0xFFFF00FF) |
+              (MCGColor(MCClamp(p_green * 0xFF, 0, UINT8_MAX)) << 8);
 }
 
 inline void MCGColorSetBlue(MCGColor& x_color, MCGFloat p_blue) {
-	x_color = (x_color & 0xFFFFFF00) | ((uint8_t)(p_blue * 255) << 0);
+	x_color = (x_color & 0xFFFFFF00) |
+              (MCGColor(MCClamp(p_blue * 0xFF, 0, UINT8_MAX)) << 0);
 }
 
 inline void MCGColorSetAlpha(MCGColor& x_color, MCGFloat p_alpha) {
-	x_color = (x_color & 0x00FFFFFF) | ((uint8_t)(p_alpha * 255) << 24);
+	x_color = (x_color & 0x00FFFFFF) |
+              (MCGColor(MCClamp(p_alpha * 0xFF, 0, UINT8_MAX)) << 24);
+}
+
+inline MCGColor MCGColorMakeRGBA(MCGFloat p_red, MCGFloat p_green, MCGFloat p_blue, MCGFloat p_alpha)
+{
+    MCGColor result = 0;
+    MCGColorSetRed  (result, p_red  );
+    MCGColorSetGreen(result, p_green);
+    MCGColorSetBlue (result, p_blue );
+    MCGColorSetAlpha(result, p_alpha);
+    return result;
 }
 
 inline MCGFloat MCGColorGetRed(MCGColor p_color) {
@@ -685,7 +694,7 @@ inline MCGIntegerRectangle MCGIntegerRectangleMake(int32_t x, int32_t y, uint32_
 // IM-2014-10-22: [[ Bug 13746 ]] Add convenience function to construct rectangle from left, top, right, bottom coords
 inline MCGIntegerRectangle MCGIntegerRectangleMakeLTRB(int32_t l, int32_t t, int32_t r, int32_t b)
 {
-	return MCGIntegerRectangleMake(l, t, r - l, b - t);
+	return MCGIntegerRectangleMake(l, t, uint32_t(r - l), uint32_t(b - t));
 }
 
 inline bool MCGIntegerRectangleIsEmpty(const MCGIntegerRectangle &p_rect)

--- a/libgraphics/libgraphics.gyp
+++ b/libgraphics/libgraphics.gyp
@@ -24,6 +24,8 @@
 			
 			'sources':
 			[
+				'include/graphics.h',
+
 				'src/graphics-internal.h',
 				
 				'src/blur.cpp',


### PR DESCRIPTION
Fixes some possible issues with truncation rather than saturation.
