### PR TITLE
Add gyp file for server only builds

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -347,6 +347,10 @@ basic_args="${format_args} --depth ${DEPTH} --generator-output ${GENERATOR_OUTPU
 
 if [ "${BUILD_EDITION}" == "commercial" ] ; then
   basic_args="${basic_args} ../livecode-commercial.gyp"
+elif [ "${BUILD_EDITION}" == "server" ] ; then
+  basic_args="${basic_args} livecode-server.gyp -G default_target=binzip-copy"
+else
+  basic_args="${basic_args} livecode.gyp"
 fi
 
 case ${OS} in

--- a/livecode-server.gyp
+++ b/livecode-server.gyp
@@ -1,0 +1,140 @@
+{
+	'includes':
+	[
+		'common.gypi',
+	],
+	
+	'targets':
+	[
+		{
+			'target_name': 'LiveCode-server-all',
+			'type': 'none',
+			
+			'dependencies':
+			[
+				# LCB toolchain
+				'toolchain/toolchain.gyp:toolchain-all',
+				
+				# Engines
+				'engine/engine.gyp:server',
+
+				# Widgets and libraries
+				'extensions/extensions.gyp:extensions',
+			],
+			
+			'conditions':
+			[
+				[
+					# Server builds use special externals on OSX and Linux
+					'OS == "mac" or OS == "linux"',
+					{
+						'dependencies':
+						[
+							'revdb/revdb.gyp:dbmysql-server',
+							'revdb/revdb.gyp:dbodbc-server',
+							'revdb/revdb.gyp:dbpostgresql-server',
+							'revdb/revdb.gyp:dbsqlite-server',
+							'revxml/revxml.gyp:external-revxml-server',
+							'revzip/revzip.gyp:external-revzip-server',
+						],
+					},
+					{
+						'dependencies':
+						[
+							'revdb/revdb.gyp:dbmysql',
+							'revdb/revdb.gyp:dbodbc',
+							'revdb/revdb.gyp:dbpostgresql',
+							'revdb/revdb.gyp:dbsqlite',
+							'revxml/revxml.gyp:external-revxml',
+							'revzip/revzip.gyp:external-revzip',
+						]
+					},
+				],
+			],
+		},
+		
+		{
+			'target_name': 'debug-symbols',
+			'type': 'none',
+			
+			'dependencies':
+			[
+				'LiveCode-server-all',
+			],
+			
+			'variables':
+			{
+				'debug_syms_inputs%': [ '<@(debug_syms_inputs)' ],
+				'variables':
+				{
+					'debug_syms_inputs': [ '>@(dist_files)' ],
+				},
+			},
+			
+			'includes':
+			[
+				'config/debug_syms.gypi',
+			],
+			
+			'all_dependent_settings':
+			{
+				'variables':
+				{
+					'dist_aux_files': [ '<@(debug_syms_outputs)' ],
+					'variables':
+					{
+						'debug_syms_inputs%': [ '<@(debug_syms_inputs)' ],
+					},
+				},
+			},
+		},
+		
+		{
+			'target_name': 'binzip-copy',
+			'type': 'none',
+			
+			'variables':
+			{
+				'dist_files': [],
+				'dist_aux_files': [],
+			},
+			
+			'dependencies':
+			[
+				'LiveCode-server-all',
+				'debug-symbols',
+			],
+			
+			'copies':
+			[{
+				'destination': '<(output_dir)',
+				'files': [ '>@(dist_files)', '>@(dist_aux_files)', ],
+			}],
+		},
+
+		{
+			'target_name': 'install',
+			'type': 'none',
+
+			'variables':
+			{
+				'prefix': '/opt/livecode',
+			},
+
+			'dependencies':
+			[
+				'binzip-copy',
+			],
+
+			'actions':
+			[
+				{
+					'action_name': 'install',
+					'inputs': [ 'tools/install-server-linux.sh' ],
+					'outputs': [ '.installed' ],
+					'action': [ 'tools/install-server-linux.sh', '<(output_dir)', '<(prefix)' ],
+				},
+			],
+		},
+	],
+}

--- a/tools/install-server-linux.sh
+++ b/tools/install-server-linux.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+SOURCE=$1
+PREFIX=$2
+INSTALL_DIR=$PREFIX/server
+
+echo "Installing LiveCode server"
+echo "   Source: " $SOURCE
+echo "   Prefix: " $PREFIX
+
+invoke () {
+    if [ -n $V ]; then
+        echo "$@"
+    fi
+    "$@"
+}
+
+FILES=$(find $SOURCE -not -type d)
+for FILE in $FILES; do
+    case $FILE in
+        $SOURCE/server-community)
+            invoke install -D $FILE $INSTALL_DIR/livecode-server
+            ;;
+
+        $SOURCE/server-db*.so)
+            # DB drivers
+            invoke install -D $FILE $INSTALL_DIR/drivers/${FILE#$SOURCE/server-}
+            ;;
+
+        $SOURCE/server-*.so)
+            # Externals
+            invoke install -D $FILE $INSTALL_DIR/externals/${FILE#$SOURCE/server-}
+            ;;
+
+        *.dbg)
+            # debug symbols
+            # don't copy
+            ;;
+        
+        *)
+            if [ -x $FILE ]; then
+                # Other execuatables
+                invoke install -D $FILE $INSTALL_DIR/${FILE#$SOURCE/}
+            else
+                # non-executables
+                invoke install -m 0644 -D $FILE $INSTALL_DIR/${FILE#$SOURCE/}
+            fi
+            ;;
+    esac
+done


### PR DESCRIPTION
This adds the ability to just build server.  A server only build is performed by running `config.sh` with the BUILD_EDITION set to server, e.g.

```
    BUILD_EDITION=server ./config.sh
    make -C build-linux-x86_64/livecode 
```

(Running `make` on the root directory doesn't work as this re-runs `config.sh`.)

There is also an install rule that installs LiveCode server in `/opt/livecode/server`.

```
    sudo make -C build-linux-x86_64/livecode install
```

I haven't tested the install rule quite as much as I'd like -- I don't want to overwrite the current install on our server just now -- and I was having some problems where the install target was causing other files to be remade, but I think that this is problem with my computer and not with the build system. 
