### PR TITLE
[[ Bug ]] Initialise script frame mapping to nil

### DIFF
--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -616,6 +616,7 @@ static bool MCScriptCreateFrame(MCScriptFrame *p_caller, MCScriptInstanceRef p_i
     self -> instance = MCScriptRetainInstance(p_instance);
     self -> handler = p_handler;
     self -> address = p_handler -> start_address;
+    self -> mapping = nil;
     
     r_frame = self;
     


### PR DESCRIPTION
Had a couple of crashes because of this, but I can't find a recipe to reproduce it. May have been present in DP 2 too.
