### PR TITLE
[[ Bug 15619 ]] Update LIBRARY_EXPORT definition for iOS database ext…

### DIFF
--- a/docs/notes/bugfix-15619.md
+++ b/docs/notes/bugfix-15619.md
@@ -1,0 +1,1 @@
+# Opening sqlite on iOS return "revdberror,invalid database type"

--- a/docs/notes/bugfix-15626.md
+++ b/docs/notes/bugfix-15626.md
@@ -1,0 +1,1 @@
+# Attempting to connect to Oracle database results in "revdberr,invalid database type"

--- a/revdb/src/dbdrivercommon.cpp
+++ b/revdb/src/dbdrivercommon.cpp
@@ -18,12 +18,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #if defined(_WINDOWS) || defined(_WINDOWS_SERVER)
 #define LIBRARY_EXPORT __declspec(dllexport)
-#elif defined(_MACOSX) || defined (_MAC_SERVER)
-#define LIBRARY_EXPORT
-#elif defined(_LINUX) || defined (_LINUX_SERVER)
-#define LIBRARY_EXPORT
-#elif defined(TARGET_SUBPLATFORM_IPHONE) || defined(TARGET_SUBPLATFORM_ANDROID)
-#define LIBRARY_EXPORT
+#else
+#define LIBRARY_EXPORT __attribute__((__visibility__("default")))
 #endif
 
 // Default implementations for DBField

--- a/revdb/src/dbmysqlapi.cpp
+++ b/revdb/src/dbmysqlapi.cpp
@@ -18,12 +18,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #if defined(_WINDOWS)
 #define LIBRARY_EXPORT __declspec(dllexport)
-#elif defined(_MACOSX)
-#define LIBRARY_EXPORT
-#elif defined(_LINUX)
-#define LIBRARY_EXPORT
-#elif defined(TARGET_SUBPLATFORM_IPHONE) || defined(TARGET_SUBPLATFORM_ANDROID)
-#define LIBRARY_EXPORT
+#else
+#define LIBRARY_EXPORT __attribute__((__visibility__("default")))
 #endif
 
 unsigned int *DBObject::idcounter = NULL;

--- a/revdb/src/dbodbcapi.cpp
+++ b/revdb/src/dbodbcapi.cpp
@@ -18,10 +18,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #if defined(_WINDOWS)
 #define LIBRARY_EXPORT __declspec(dllexport)
-#elif defined(_MACOSX)
-#define LIBRARY_EXPORT
-#elif defined(_LINUX)
-#define LIBRARY_EXPORT
+#else
+#define LIBRARY_EXPORT __attribute__((__visibility__("default")))
 #endif
 
 unsigned int *DBObject::idcounter = NULL;

--- a/revdb/src/dbpostgresqlapi.cpp
+++ b/revdb/src/dbpostgresqlapi.cpp
@@ -18,12 +18,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #if defined(_WINDOWS)
 #define LIBRARY_EXPORT __declspec(dllexport)
-#elif defined(_MACOSX)
-#define LIBRARY_EXPORT
-#elif defined(_LINUX)
-#define LIBRARY_EXPORT
-#elif defined(TARGET_PLATFORM_MOBILE) && defined(TARGET_SUBPLATFORM_IPHONE)
-#define LIBRARY_EXPORT
+#else
+#define LIBRARY_EXPORT __attribute__((__visibility__("default")))
 #endif
 
 unsigned int *DBObject::idcounter = NULL;

--- a/revdb/src/dbsqliteapi.cpp
+++ b/revdb/src/dbsqliteapi.cpp
@@ -18,12 +18,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #if defined(_WINDOWS)
 #define LIBRARY_EXPORT __declspec(dllexport)
-#elif defined(_MACOSX)
-#define LIBRARY_EXPORT
-#elif defined(_LINUX)
-#define LIBRARY_EXPORT
-#elif defined(TARGET_SUBPLATFORM_IPHONE) || defined(TARGET_SUBPLATFORM_ANDROID)
-#define LIBRARY_EXPORT
+#else
+#define LIBRARY_EXPORT __attribute__((__visibility__("default")))
 #endif
 
 unsigned int *DBObject::idcounter = NULL;


### PR DESCRIPTION
…ernals, so that their symbols are not hidden (which is the default in the Gypified build)
