### PR TITLE
Precisely preserve the timestamps when stripping debugging symbols

### DIFF
--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -16,16 +16,23 @@ function extract_linux_or_android {
 for input in $@ ; do
 	output="${input}${suffix}"	
 
+  # The --preserver-dates flag for strip and objcopy only has whole
+  # second resolution, so copy the timestamps to a separate file instead
+  cp --attributes-only --preserve=timestamps "$input" "$input.timestamps"
+
 	# Extract a copy of the debugging information
 	$OBJCOPY --only-keep-debug "$input" "$output" 
 	
 	# Because we export symbols from the engine, only debug symbols
 	# should be stripped.
-	$STRIP -x --preserve-dates --strip-debug "$input"
+	$STRIP -x --strip-debug "$input"
 	
 	# Add a hint for the debugger so it can find the debug info
-	$OBJCOPY --preserve-dates --remove-section=.gnu_debuglink "$input"
-	$OBJCOPY --preserve-dates --add-gnu-debuglink="$output" "$input"
+	$OBJCOPY --remove-section=.gnu_debuglink "$input"
+	$OBJCOPY --add-gnu-debuglink="$output" "$input"
+
+  cp --attributes-only --preserve=timestamps "$input.timestamps" "$input"
+  rm "$input.attributes"
 done
 
 }

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -18,7 +18,7 @@ for input in $@ ; do
 
   # The --preserver-dates flag for strip and objcopy only has whole
   # second resolution, so copy the timestamps to a separate file instead
-  cp --attributes-only --preserve=timestamps "$input" "$input.timestamps"
+  cp --attributes-only --preserve=timestamps "$input" "$input.timestamps" 2>&1 || true
 
 	# Extract a copy of the debugging information
 	$OBJCOPY --only-keep-debug "$input" "$output" 
@@ -31,8 +31,8 @@ for input in $@ ; do
 	$OBJCOPY --remove-section=.gnu_debuglink "$input"
 	$OBJCOPY --add-gnu-debuglink="$output" "$input"
 
-  cp --attributes-only --preserve=timestamps "$input.timestamps" "$input"
-  rm "$input.timestamps"
+  cp --attributes-only --preserve=timestamps "$input.timestamps" "$input" 2>&1 || true
+  rm "$input.timestamps" 2>&1 || true
 done
 
 }

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -32,7 +32,7 @@ for input in $@ ; do
 	$OBJCOPY --add-gnu-debuglink="$output" "$input"
 
   cp --attributes-only --preserve=timestamps "$input.timestamps" "$input"
-  rm "$input.attributes"
+  rm "$input.timestamps"
 done
 
 }


### PR DESCRIPTION
The `--preserve-dates` flag for `strip` and `objcopy` only has whole
second resolution.  This meant that the modification time was being
truncated to an integer number of seconds.  Consequently, when
stripping a file, some of the dependencies of that file would appear
to be newer, and hence the file would be unnecessarily remade during a
second call to make.

Simple solution: copy the timestamps to a separate file before we
strip and copy them back after.
