### PR TITLE
[Bug 15639] Some tweaks to avoid incorrect results from MCMax() etc.

### DIFF
--- a/engine/src/graphics_util.h
+++ b/engine/src/graphics_util.h
@@ -107,8 +107,8 @@ inline MCGRectangle MCRectangle32ToMCGRectangle(const MCRectangle32 &p_rect)
 inline MCRectangle32 MCRectangle32FromMCGIntegerRectangle(const MCGIntegerRectangle &p_rect)
 {
 	return MCRectangle32Make(p_rect.origin.x, p_rect.origin.y,
-                             int32_t(MCMin(p_rect.size.width, INT32_MAX)),
-                             int32_t(MCMin(p_rect.size.height, INT32_MAX)));
+	                         int32_t(MCMin(p_rect.size.width, uint32_t(INT32_MAX))),
+	                         int32_t(MCMin(p_rect.size.height, uint32_t(INT32_MAX))));
 }
 
 inline MCGIntegerRectangle MCRectangle32ToMCGIntegerRectangle(const MCRectangle32 &p_rect)
@@ -129,8 +129,8 @@ inline MCRectangle MCRectangleFromMCGIntegerRectangle(const MCGIntegerRectangle 
 {
 	return MCRectangleMake(int16_t(MCClamp(p_rect.origin.x,     INT16_MIN, INT16_MAX)),
                            int16_t(MCClamp(p_rect.origin.y,     INT16_MIN, INT16_MAX)),
-                           uint16_t(MCClamp(p_rect.size.width,  0, UINT16_MAX)),
-                           uint16_t(MCClamp(p_rect.size.height, 0, UINT16_MAX)));
+	                       uint16_t(MCClamp(p_rect.size.width,  0U, uint32_t(UINT16_MAX))),
+	                       uint16_t(MCClamp(p_rect.size.height, 0U, uint32_t(UINT16_MAX))));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -705,6 +705,11 @@ typedef struct __MCLocale* MCLocaleRef;
 #include <foundation-stdlib.h>
 #include <math.h>
 
+// Ensure MCMin(), MCMax(), etc. can't return incorrect results due to
+// signed/unsigned comparisons.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wsign-compare"
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  MINIMUM FUNCTIONS
@@ -775,6 +780,9 @@ template <typename T, typename U, typename V>
 inline T MCClamp(T value, U min, V max) {
 	return MCMax(MCMin(value, max), min);
 }
+
+// Stop emitting -Wsign-compare errors
+#pragma GCC diagnostic pop
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -705,11 +705,6 @@ typedef struct __MCLocale* MCLocaleRef;
 #include <foundation-stdlib.h>
 #include <math.h>
 
-// Ensure MCMin(), MCMax(), etc. can't return incorrect results due to
-// signed/unsigned comparisons.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic error "-Wsign-compare"
-
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  MINIMUM FUNCTIONS
@@ -759,9 +754,6 @@ template <typename T, typename U, typename V>
 inline T MCClamp(T value, U min, V max) {
 	return MCMax(MCMin(value, max), min);
 }
-
-// Stop emitting -Wsign-compare errors
-#pragma GCC diagnostic pop
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -715,12 +715,6 @@ typedef struct __MCLocale* MCLocaleRef;
 //  MINIMUM FUNCTIONS
 //
 
-//inline uint32_t MCMin(uint32_t a, uint32_t b) { return a < b ? a : b; }
-//inline int32_t MCMin(int32_t a, int32_t b) { return a < b ? a : b; }
-//inline uint64_t MCMin(uint64_t a, uint64_t b) { return a < b ? a : b; }
-//inline int64_t MCMin(int64_t a, int64_t b) { return a < b ? a : b; }
-//inline double MCMin(double a, double b) { return a < b ? a : b; }
-//inline float MCMin(float a, float b) { return a < b ? a : b; }
 template <class T, class U> inline T MCMin(T a, U b) { return a < b ? a : b; }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -728,12 +722,6 @@ template <class T, class U> inline T MCMin(T a, U b) { return a < b ? a : b; }
 //  MAXIMUM FUNCTIONS
 //
 
-//inline uint32_t MCMax(uint32_t a, uint32_t b) { return a > b ? a : b; }
-//inline int32_t MCMax(int32_t a, int32_t b) { return a > b ? a : b; }
-//inline uint64_t MCMax(uint64_t a, uint64_t b) { return a > b ? a : b; }
-//inline int64_t MCMax(int64_t a, int64_t b) { return a > b ? a : b; }
-//inline double MCMax(double a, double b) { return a > b ? a : b; }
-//inline float MCMax(float a, float b) { return a > b ? a : b; }
 template <class T, class U> inline T MCMax(T a, U b) { return a > b ? a : b; }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -751,8 +739,6 @@ inline double MCAbs(double a) { return fabs(a); }
 //  SIGN FUNCTIONS
 //
 
-//inline compare_t MCSgn(int32_t a) { return a < 0 ? -1 : (a > 0 ? 1 : 0); }
-//inline compare_t MCSgn(int64_t a) { return a < 0 ? -1 : (a > 0 ? 1 : 0); }
 template <class T> inline compare_t MCSgn(T a) { return a < 0 ? -1 : (a > 0 ? 1 : 0); }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -746,14 +746,7 @@ template <class T> inline compare_t MCSgn(T a) { return a < 0 ? -1 : (a > 0 ? 1 
 //  COMPARE FUNCTIONS
 //
 
-// SN-2015-01-07: [[ iOS-64bit ]] Update the MCCompare functions
-inline compare_t MCCompare(int a, int b) { return a < b ? -1 : (a > b ? 1 : 0); }
-inline compare_t MCCompare(unsigned int a, unsigned int b) { return a < b ? -1 : (a > b ? 1 : 0); }
-inline compare_t MCCompare(long a, long b) { return a < b ? -1 : (a > b ? 1 : 0); }
-inline compare_t MCCompare(unsigned long a, unsigned long b) { return a < b ? -1 : (a > b ? 1 : 0); }
-inline compare_t MCCompare(long long a, long long b) { return a < b ? -1 : (a > b ? 1 : 0); }
-inline compare_t MCCompare(unsigned long long a, unsigned long long b) { return a < b ? -1 : (a > b ? 1 : 0); }
-
+template <typename T> inline compare_t MCCompare(T a, T b) { return ((a < b) ? -1 : ((a > b) ? 1 : 0)); }
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -753,7 +753,7 @@ template <typename T> inline compare_t MCCompare(T a, T b) { return ((a < b) ? -
 //  COMPARE FUNCTIONS
 //
 
-inline bool MCIsPowerOfTwo(uint32_t x) { return (x & (x - 1)) == 0; }
+template <typename T> inline bool MCIsPowerOfTwo(T x) { return (x & (x - 1)) == 0; }
 
 template <typename T, typename U, typename V>
 inline T MCClamp(T value, U min, V max) {

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1239,10 +1239,10 @@ void MCScriptEndHandlerInModule(MCScriptModuleBuilderRef self)
         
         __emit_position(self, t_pos_address_offset + t_address, self -> instructions[i] . file, self -> instructions[i] . line);
         
-        __emit_bytecode_byte(self, t_op | (MCMin(t_arity, 15) << 4));
+        __emit_bytecode_byte(self, t_op | (MCMin(t_arity, 15U) << 4));
         
-        if (t_arity >= 15)
-            __emit_bytecode_byte(self, t_arity - 15);
+        if (t_arity >= 15U)
+            __emit_bytecode_byte(self, t_arity - 15U);
         
         for(uindex_t j = 0; j < t_arity; j++)
             __emit_bytecode_uint(self, t_operands[j]);


### PR DESCRIPTION
The MCMax(), MCMin() and MCClamp() template functions can return incorrect results when one argument is signed and the other is unsigned.  For example:

```
MCMax(-1, 1U) -> -1
```

These changes ensure that compilers that understand GCC `#pragma diagnostic` macros fail to compile code which uses the templates incorrectly.  In addition, it corrects some places in the source code which would fail to compile with the changes.

These changes _don't_ correct this problem:

```
MCMax(uint16_t(UINT16_MAX), uint32_t(UINT16_MAX + 1)) -> 1
```

This can only be corrected by using `decltype` to determine the return value of `MCMax()` etc., which in turn requires compiling with C++11 compilers.

Yay happy fun times!
