### PR TITLE
[[ Bug ]] Allow 6.7 engine to build standalones with 8.0 standalone engine

### DIFF
--- a/engine/src/capsule.h
+++ b/engine/src/capsule.h
@@ -77,6 +77,9 @@ enum MCCapsuleSectionType
 	// An external section contains a external that should be loaded into the
 	// environment on startup;.
 	kMCCapsuleSectionTypeExternal,
+    
+    // Module to be loaded on startup.
+    kMCCapsuleSectionTypeModule,
 
     // Auxiliary stack sections contain other mainstacks that should be loaded
 	// alongside the mainstack (but not opened initially).
@@ -89,9 +92,6 @@ enum MCCapsuleSectionType
 	// Startup script to be executed after all stacks have loaded but before
 	// the main stack is opened.
 	kMCCapsuleSectionTypeStartupScript,
-
-	// Module to be loaded on startup.
-    kMCCapsuleSectionTypeModule,
     
     // Font mapping sections contain a mapping from a font name to another font
     // name (usually PostScript name). Whenever a font name is looked up it is


### PR DESCRIPTION
There is a mismatch between the <8.0 and 8.0 definitions of the capsule section enum, which means standalones built from 6.7 using the 8.0 standalone engine fail to run, as the 8.0 standalone engine then thinks that the fontmap section is a module section etc etc. This is a problem for running the test system against 8.0 from 6.7.
