### PR TITLE
lc-compile: Don't build target lc-compile for mobile platforms.

### DIFF
--- a/toolchain/lc-compile/lc-compile.gyp
+++ b/toolchain/lc-compile/lc-compile.gyp
@@ -47,6 +47,17 @@
 									[
 										'src/lc-compile-bootstrap.gyp:lc-compile-stage4#target',
 									],
+
+									'direct_dependent_settings':
+									{
+										'variables':
+										{
+											'dist_files':
+											[
+												'<(lc-compile_target)',
+											],
+										},
+									},
 								},
 							],
 							[
@@ -75,17 +86,6 @@
 					},
 				],
 			],
-			
-			'direct_dependent_settings':
-			{
-				'variables':
-				{
-					'dist_files':
-					[
-						'<(lc-compile_target)',
-					],
-				},
-			},
 		},
 	],
 }


### PR DESCRIPTION
It doesn't currently make sense to compile an Android or iOS version
of lc-compile.  At some point we might want to compile LCB source code
on mobile platforms; however, at that point we'll probably want the
compiler as a library, which will need a build system refactor anyway.
