### PR TITLE
[[ Bug 15379 ]] Data input given to MCR_exec should remain data, to a…

### DIFF
--- a/docs/notes/bugfix-15379.md
+++ b/docs/notes/bugfix-15379.md
@@ -1,0 +1,1 @@
+# Regular Expression with binary input fails in LC 7, works in LC 6

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1497,6 +1497,10 @@ bool MCStringEncodeAndRelease(MCStringRef string, MCStringEncoding encoding, boo
 bool MCStringDecode(MCDataRef data, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
 bool MCStringDecodeAndRelease(MCDataRef data, MCStringEncoding encoding, bool is_external_rep, MCStringRef& r_string);
 
+// SN-2015-07-27: [[ Bug 15379 ]] We can need to build a string from data,
+//  without any ASCII value conversion.
+bool MCStringCreateUnicodeStringFromData(MCDataRef p_data, bool p_is_external_rep, MCStringRef& r_string);
+
 /////////
 
 // Create an immutable string, built using the given format specification and

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -697,6 +697,61 @@ bool MCStringDecodeAndRelease(MCDataRef p_data, MCStringEncoding p_encoding, boo
     return true;
 }
 
+// SN-2015-07-27: [[ Bug 15379 ]] This function is only used for internal
+//  purposes, when a LiveCode function parameter can be data - in which case
+//  no char translation must occur between the bytes in the DataRef and the
+//  Unicode string that the engine function takes (in MCR_exec for instance)
+bool MCStringCreateUnicodeStringFromData(MCDataRef p_data, bool p_is_external_rep, MCStringRef& r_string)
+{
+    MCAssert(!p_is_external_rep);
+    
+    if (MCDataIsEmpty(p_data))
+    {
+        r_string = MCValueRetain(kMCEmptyString);
+        return true;
+    }
+    
+    bool t_success;
+    t_success = true;
+    
+    __MCString *self;
+    self = nil;
+    if (t_success)
+        t_success = __MCValueCreate(kMCValueTypeCodeString, self);
+    
+    uint32_t t_byte_count;
+    t_byte_count = MCDataGetLength(p_data);
+    
+    const byte_t* t_bytes = MCDataGetBytePtr(p_data);
+    
+    if (t_success)
+        t_success = MCMemoryNewArray(t_byte_count + 1, self -> chars);
+    
+    if (t_success)
+    {
+        uindex_t i;
+        for(i = 0; i < t_byte_count; i++)
+            self -> chars[i] = t_bytes[i];
+    }
+    
+    if (t_success)
+    {
+        self -> flags |= kMCStringFlagIsNotNative;
+        self -> char_count = t_byte_count;
+        
+        r_string = self;
+    }
+    else
+    {
+        if (self != nil)
+            MCMemoryDeleteArray(self -> chars);
+        
+        MCMemoryDelete(self);
+    }
+    
+    return t_success;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 static bool __MCStringFormatSupportedForUnicode(const char *p_format)


### PR DESCRIPTION
…void a native-char to Unicode char conversion of its bytes
