### PR TITLE
[[ Docs ]] Don't unnecessarily call function unavailable outside of IDE

### DIFF
--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -2011,11 +2011,6 @@ end builderGetDocsGuideData
 
 on docsBuilderGenerateBuiltGuide pExtensions
    local tData
-   
-   # Get the location of the distributed guide
-   local tGuidePath
-   put revIDESpecialFolderPath("guide") into tGuidePath
-   
    put "var tUserGuideData =" & CR & "{" & CR & tab & quote & "guides" & quote & ":[" into tData
    
    # Add the guide data from each of the packaged extensions
@@ -2028,11 +2023,6 @@ end docsBuilderGenerateBuiltGuide
 
 on docsBuilderGenerateBuiltAPI pExtensions
    local tData
-   
-   # Get the location of the distributed API
-   local tAPIPath
-   put revIDESpecialFolderPath("API") into tAPIPath
-   
    put "var dictionary_data =" & CR & "{" & CR & tab & quote & "docs" & quote & ":[" after tData
    
    # Add the api data from each of the packaged extensions


### PR DESCRIPTION
The builder uses a separate utility function for the location of the docs, so doesn't need to call revIDESpecialFolderPath("API") or "Guide" (and indeed will fail to find such a function when building the installers)
