### PR TITLE
[[ Script ]] Allow per-module native code libraries.

### DIFF
--- a/docs/lcb/notes/feature-module_native_code.md
+++ b/docs/lcb/notes/feature-module_native_code.md
@@ -14,15 +14,18 @@ archive. The engine derives the appropriate path from the requested library name
 current platform. The structure is as follows:
 
     <extension>/
-      code/
-        mac/
-          <library>.dylib
-        linux-x86/
-          <library>.so
-        linux-x86_64/
-          <library>.so
-        win-x86/
-          <library>.dll
+      resources/
+        code/
+          mac/
+            <library>.dylib
+          linux-x86/
+            <library>.so
+          linux-x86_64/
+            <library>.so
+          win-x86/
+            <library>.dll
 
 *Note:* At present, only the desktop platforms are supported.
 
+*Note:* The above structure is likely to change in a future release, in particular the 'code'
+folder will sit at the same level as resources rather than within it.

--- a/docs/lcb/notes/feature-module_native_code.md
+++ b/docs/lcb/notes/feature-module_native_code.md
@@ -1,0 +1,28 @@
+# LiveCode Builder Host Library
+
+## Native Code Access
+
+LiveCode extensions can now contain native code libraries which LCB will use to resolve
+foreign handler references.
+
+The foriegn handler binding string should be of the form "library>function" to use this
+feature. In this case, the engine will look for a library 'library' on a per-platform
+basis when the foreign handler needs to be resolved.
+
+Native code libraries should be present inside the 'resources' folder inside the extension
+archive. The engine derives the appropriate path from the requested library name and
+current platform. The structure is as follows:
+
+    <extension>/
+      code/
+        mac/
+          <library>.dylib
+        linux-x86/
+          <library>.so
+        linux-x86_64/
+          <library>.so
+        win-x86/
+          <library>.dll
+
+*Note:* At present, only the desktop platforms are supported.
+

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -194,6 +194,40 @@ void MCEngineLoadExtensionFromData(MCExecContext& ctxt, MCDataRef p_extension_da
     return;
 }
 
+// This is the callback given to libscript so that it can resolve the absolute
+// path of native code libraries used by foreign handlers in the module. At
+// the moment we use the resources path of the module, however it will need to be
+// changed to a separate location at some point with explicit declaration so that
+// iOS linkage and Android placement issues can be resolved.
+//
+// Currently it expects:
+//   <resources>
+//     code/
+//       mac/<name>.dylib
+//       linux-x86/<name>.so
+//       linux-x86_64/<name>.so
+//       win-x86/<name>.dll
+//
+static bool MCEngineResolveSharedLibrary(MCScriptModuleRef p_module, MCStringRef p_name, MCStringRef& r_path)
+{
+    // If the module has no resource path, then it has no code.
+    MCAutoStringRef t_resource_path;
+    if (!MCEngineLookupResourcePathForModule(p_module, Out(t_resource_path)))
+        return false;
+    
+#if defined(_MACOSX)
+    return MCStringFormat(r_path, "%@/code/mac/%@.dylib", *t_resource_path, p_name);
+#elif defined(_LINUX) && defined(__32_BIT__)
+    return MCStringFormat(r_path, "%@/code/linux-x86/%@.so", *t_resource_path, p_name);
+#elif defined(_LINUX) && defined(__64_BIT__)
+    return MCStringFormat(r_path, "%@/code/linux-x86_64/%@.so", *t_resource_path, p_name);
+#elif defined(_WINDOWS)
+    return MCStringFormat(r_path, "%@/code/win-x86/%@.dll", *t_resource_path, p_name);
+#else
+    return false;
+#endif
+}
+
 void MCEngineExecLoadExtension(MCExecContext& ctxt, MCStringRef p_filename, MCStringRef p_resource_path)
 {
     ctxt . SetTheResultToEmpty();
@@ -205,6 +239,10 @@ void MCEngineExecLoadExtension(MCExecContext& ctxt, MCStringRef p_filename, MCSt
     MCAutoDataRef t_data;
     if (!MCS_loadbinaryfile(*t_resolved_filename, &t_data))
         return;
+    
+    // Make sure we set the shared library callback - this should be done in
+    // module init for 'extension' when we have such a mechanism.
+    MCScriptSetResolveSharedLibraryCallback(MCEngineResolveSharedLibrary);
     
     MCEngineLoadExtensionFromData(ctxt, *t_data, p_resource_path);
  }

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -215,6 +215,9 @@ static bool MCEngineResolveSharedLibrary(MCScriptModuleRef p_module, MCStringRef
     if (!MCEngineLookupResourcePathForModule(p_module, Out(t_resource_path)))
         return false;
     
+    if (MCStringIsEmpty(*t_resource_path))
+        return false;
+    
 #if defined(_MACOSX)
     return MCStringFormat(r_path, "%@/code/mac/%@.dylib", *t_resource_path, p_name);
 #elif defined(_LINUX) && defined(__32_BIT__)

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -35,8 +35,14 @@ typedef MCScriptInstance *MCScriptInstanceRef;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+typedef bool (*MCScriptResolveSharedLibraryCallback)(MCScriptModuleRef module, MCStringRef name, MCStringRef& r_path);
+
 bool MCScriptInitialize(void);
 void MCScriptFinalize(void);
+
+void MCScriptSetResolveSharedLibraryCallback(MCScriptResolveSharedLibraryCallback callback);
+
+bool MCScriptResolveSharedLibrary(MCScriptModuleRef module, MCStringRef name, MCStringRef& r_path);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -893,7 +893,7 @@ static bool MCScriptPerformScriptInvoke(MCScriptFrame*& x_frame, byte_t*& x_next
 }
 
 // This method resolves the binding string in the foreign function. The format is:
-//   [lang:][library@][class.]function[!calling]
+//   [lang:][library>][class.]function[!calling]
 //
 // lang - one of c, cpp, objc or java. If not present, it is taken to be c.
 // library - the library to load the symbol from. If not present, it is taken to be the

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -936,7 +936,82 @@ static bool __split_binding(MCStringRef& x_string, codepoint_t p_char, MCStringR
     return true;
 }
 
-static bool MCScriptResolveForeignFunctionBinding(MCScriptForeignHandlerDefinition *p_handler, ffi_abi& r_abi, bool p_throw, bool& r_bound)
+static bool MCScriptPlatformLoadSharedLibrary(MCStringRef p_path, void*& r_handle)
+{
+#if defined(_WIN32)
+    HMODULE t_module;
+    MCAutoStringRefAsWString t_library_wstr;
+    if (!t_library_wstr.Lock(p_path))
+        return false;
+    t_module = LoadLibraryW(*t_library_wstr);
+    if (t_module == NULL)
+        return false;
+    r_handle = (void *)t_module;
+#else
+    MCAutoStringRefAsUTF8String t_utf8_library;
+    if (!t_utf8_library.Lock(p_path))
+        return false;
+    void *t_module;
+    t_module = dlopen(*t_utf8_library, RTLD_LAZY);
+    if (t_module == NULL)
+        return false;
+    r_handle = (void *)t_module;
+#endif
+    return true;
+}
+
+static bool MCScriptPlatformLoadSharedLibraryFunction(void *p_module, MCStringRef p_function, void*& r_pointer)
+{
+    MCAutoStringRefAsCString t_function_name;
+    if (!t_function_name.Lock(p_function))
+        return false;
+    
+    void *t_pointer;
+#if defined(_WIN32)
+    t_pointer = GetProcAddress(p_module, *t_function_name);
+#else
+    t_pointer = dlsym(p_module, *t_function_name);
+#endif
+    
+    return true;
+}
+
+static bool MCScriptLoadSharedLibrary(MCScriptModuleRef p_module, MCStringRef p_library, void*& r_handle)
+{
+    // If there is no library name then we resolve to the executable module.
+    if (MCStringIsEmpty(p_library))
+    {
+#if defined(_WIN32)
+        r_handle = GetModuleHandle(NULL);
+#elif defined(TARGET_SUBPLATFORM_ANDROID)
+        r_handle = dlopen("librevandroid.so", 0);
+#else
+        r_handle = dlopen(NULL, 0);
+#endif
+        return true;
+    }
+
+    // If there is no slash in the name, we try to resolve based on the module.
+    uindex_t t_offset;
+    if (!MCStringFirstIndexOfChar(p_library, '/', 0, kMCStringOptionCompareExact, t_offset))
+    {
+        MCAutoStringRef t_mapped_library;
+        if (MCScriptResolveSharedLibrary(p_module, p_library, Out(t_mapped_library)))
+        {
+            if (MCScriptPlatformLoadSharedLibrary(*t_mapped_library, r_handle))
+                return true;
+        }
+    }
+    
+    // If the previous two things failed, then just try to load the library as written.
+    if (MCScriptPlatformLoadSharedLibrary(p_library, r_handle))
+        return true;
+    
+    // Oh dear - no native code library for us!
+    return false;
+}
+
+static bool MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance, MCScriptForeignHandlerDefinition *p_handler, ffi_abi& r_abi, bool p_throw, bool& r_bound)
 {
     MCStringRef t_rest;
     t_rest = MCValueRetain(p_handler -> binding);
@@ -979,62 +1054,21 @@ static bool MCScriptResolveForeignFunctionBinding(MCScriptForeignHandlerDefiniti
         if (!MCStringIsEmpty(*t_class))
             return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("class not allowed in c binding string"), nil);
         
+        void *t_module;
+        if (!MCScriptLoadSharedLibrary(MCScriptGetModuleOfInstance(p_instance), *t_library, t_module))
+        {
+            if (p_throw)
+                return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("unable to load foreign library"), nil);
+            
+            r_bound = false;
+            return true;
+        }
         
-#ifdef _WIN32
-        if (MCStringIsEmpty(*t_library))
-        {
-            p_handler -> function = GetProcAddress(GetModuleHandle(NULL), MCStringGetCString(*t_function));
-        }
-        else
-        {
-            HMODULE t_module;
-			MCAutoStringRefAsWString t_library_wstr;
-			if (!t_library_wstr.Lock(*t_library))
-                return false;
-            t_module = LoadLibraryW(*t_library_wstr);
-            if (t_module == nil)
-            {
-                if (p_throw)
-                    return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("unable to load foreign library"), nil);
-
-                r_bound = false;
-                return true;
-            }
-            p_handler -> function = GetProcAddress(t_module, MCStringGetCString(*t_function));
-        }
-#else
-        if (MCStringIsEmpty(*t_library))
-        {
-            void* t_self;
-#ifdef TARGET_SUBPLATFORM_ANDROID
-            t_self = dlopen("librevandroid.so", 0);
-            if (t_self == NULL)
-            {
-                return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("could not bind to engine"), nil);
-            }
-#else
-            t_self = dlopen(NULL, 0);
-#endif
-            p_handler -> function = dlsym(t_self, MCStringGetCString(*t_function));
-        }
-        else
-        {
-            MCAutoStringRefAsUTF8String t_utf8_library;
-            if (!t_utf8_library.Lock(*t_library))
-                return false;
-            void *t_module;
-            t_module = dlopen(*t_utf8_library, RTLD_LAZY);
-            if (t_module == nil)
-            {
-                if (p_throw)
-                    return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("unable to load foreign library"), nil);
-             
-                r_bound = false;
-                return true;
-            }
-            p_handler -> function = dlsym(t_module, MCStringGetCString(*t_function));
-        }
-#endif
+        void *t_pointer;
+        if (!MCScriptPlatformLoadSharedLibraryFunction(t_module, *t_function, t_pointer))
+            return false;
+        
+        p_handler -> function = t_pointer;
     }
     else if (MCStringIsEqualToCString(*t_language, "cpp", kMCStringOptionCompareExact))
     {
@@ -1083,7 +1117,7 @@ static bool MCScriptResolveForeignFunctionBinding(MCScriptForeignHandlerDefiniti
 static bool MCScriptPrepareForeignFunction(MCScriptFrame *p_frame, MCScriptInstanceRef p_instance, MCScriptForeignHandlerDefinition *p_handler, bool p_throw, bool& r_bound)
 {
     ffi_abi t_abi;
-    if (!MCScriptResolveForeignFunctionBinding(p_handler, t_abi, p_throw, r_bound))
+    if (!MCScriptResolveForeignFunctionBinding(p_instance, p_handler, t_abi, p_throw, r_bound))
         return false;
     
     if (!p_throw && !r_bound)

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -973,6 +973,8 @@ static bool MCScriptPlatformLoadSharedLibraryFunction(void *p_module, MCStringRe
     t_pointer = dlsym(p_module, *t_function_name);
 #endif
     
+    r_pointer = t_pointer;
+    
     return true;
 }
 

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -968,7 +968,7 @@ static bool MCScriptPlatformLoadSharedLibraryFunction(void *p_module, MCStringRe
     
     void *t_pointer;
 #if defined(_WIN32)
-    t_pointer = GetProcAddress(p_module, *t_function_name);
+    t_pointer = GetProcAddress((HMODULE)p_module, *t_function_name);
 #else
     t_pointer = dlsym(p_module, *t_function_name);
 #endif

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -52,6 +52,9 @@ struct MCBuiltinModule
 static MCScriptModuleRef s_builtin_module = nil;
 static MCScriptModuleRef *s_builtin_modules = nil;
 static uindex_t s_builtin_module_count = 0;
+
+static MCScriptResolveSharedLibraryCallback s_resolve_shared_library_callback = nil;
+
 static bool MCFetchBuiltinModuleSection(MCBuiltinModule**& r_modules, unsigned int& r_count);
 
 bool MCScriptInitialize(void)
@@ -277,6 +280,8 @@ bool MCScriptInitialize(void)
 			return false;
     }
 
+    s_resolve_shared_library_callback = nil;
+    
     return true;
 }
 
@@ -286,6 +291,19 @@ void MCScriptFinalize(void)
         MCScriptReleaseModule(s_builtin_modules[i]);
     MCMemoryDeleteArray(s_builtin_modules);
     MCValueRelease(s_builtin_module);
+}
+
+void MCScriptSetResolveSharedLibraryCallback(MCScriptResolveSharedLibraryCallback p_callback)
+{
+    s_resolve_shared_library_callback = p_callback;
+}
+
+bool MCScriptResolveSharedLibrary(MCScriptModuleRef p_module, MCStringRef p_name, MCStringRef& r_path)
+{
+    if (s_resolve_shared_library_callback == nil)
+        return false;
+    
+    return s_resolve_shared_library_callback(p_module, p_name, r_path);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The user of libscript can now set a callback to be used to resolve the path to
native code libraries on a per-module basis. This is used when binding foreign
handlers to libraries with no path, the callback is invoked with the module
context so that a mapping to an absolute path for the code module for the
current platform can be computed.
