### PR TITLE
[[ Bug ]] Output the generated lcdoc files when building installer

### DIFF
--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -1970,6 +1970,9 @@ private function builderGetDocsAPIData pExtensions
       local tLcdoc
       put revDocsGenerateDocsFileFromModularFile(tFolder & slash & tSource) into tLcdoc
       
+      # Output the lcdoc file
+      put textEncode(tLcdoc, "utf-8") into url ("binfile:" & tFolder & slash & "api.lcdoc")
+      
       # Convert to JSON
       put revDocsFormatDocTextAsJSON(tLcdoc,"", "LiveCode") into tExtensionAPI
       


### PR DESCRIPTION
If the lcdoc files are not output to a file at this stage, they are skipped when the IDE builds them on startup resulting in an incomplete dictionary.
