### PR TITLE
[C++11] Add explicit cast to intenum_t from MCExternalValueOptions.

### DIFF
--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -2181,7 +2181,7 @@ static MCExternalError MCExternalVariableIterateKeys(MCExternalVariableRef var, 
 
 static bool MCExternalIsCaseSensitive(MCExternalValueOptions p_options)
 {
-    switch(p_options & kMCExternalValueOptionCaseSensitiveMask)
+	switch(intenum_t(p_options) & kMCExternalValueOptionCaseSensitiveMask)
     {
         case kMCExternalValueOptionDefaultCaseSensitive:
             return MCECptr -> GetCaseSensitive();


### PR DESCRIPTION
This avoids a narrowing conversion that is invalid in C++11.
