### PR TITLE
MCNotify: Allow compilation on non-thread platforms, and minor cleanup

### DIFF
--- a/engine/src/notify.cpp
+++ b/engine/src/notify.cpp
@@ -18,6 +18,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "notify.h"
 
+#if !defined(FEATURE_NOTIFY)
+#	error MCNotify API not supported on this platform
+#endif
+
 #if defined(_MAC_DESKTOP)
 #include "osxprefix.h"
 #include <pthread.h>

--- a/engine/src/osxdc-cocoa.mm
+++ b/engine/src/osxdc-cocoa.mm
@@ -61,8 +61,6 @@ MCScreenDC::MCScreenDC(void)
 	m_current_scrap_data = NULL;
 	
 	m_dst_profile = nil;
-	
-	MCNotifyInitialize();
 }
 
 MCScreenDC::~MCScreenDC(void)

--- a/engine/src/osxdc.cpp
+++ b/engine/src/osxdc.cpp
@@ -95,8 +95,6 @@ MCScreenDC::MCScreenDC()
 	m_in_resize = false;
 
 	m_dst_profile = nil;
-	
-	MCNotifyInitialize();
 }
 
 MCScreenDC::~MCScreenDC()

--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -62,6 +62,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define PLATFORM_STRING "Win32"
 
 #define MCSSL
+#define FEATURE_NOTIFY 1
 
 #elif defined(_MAC_SERVER)
 

--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -35,6 +35,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define FEATURE_RELAUNCH_SUPPORT
 #define FEATURE_QUICKTIME
 #define FEATURE_QUICKTIME_EFFECTS
+#define FEATURE_NOTIFY 1
 
 #elif defined(_MAC_DESKTOP)
 
@@ -46,6 +47,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define FEATURE_PLATFORM_PLAYER
 #define FEATURE_PLATFORM_RECORDER
 #define FEATURE_PLATFORM_AUDIO
+#define FEATURE_NOTIFY 1
 
 #elif defined(_LINUX_DESKTOP)
 
@@ -53,6 +55,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #define MCSSL
 #define FEATURE_MPLAYER
+#define FEATURE_NOTIFY 1
 
 #elif defined(_WINDOWS_SERVER)
 
@@ -65,12 +68,14 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define PLATFORM_STRING "MacOS"
 
 #define MCSSL
+#define FEATURE_NOTIFY 1
 
 #elif defined(_LINUX_SERVER) || defined(_DARWIN_SERVER)
 
 #define PLATFORM_STRING "Linux"
 
 #define MCSSL
+#define FEATURE_NOTIFY 1
 
 #elif defined(_IOS_MOBILE)
 
@@ -80,6 +85,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define PLATFORM_STRING "iphone"
 
 #define FEATURE_PLATFORM_URL 1
+#define FEATURE_NOTIFY 1
 
 #elif defined(_ANDROID_MOBILE)
 
@@ -89,6 +95,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define PLATFORM_STRING "android"
 
 #define FEATURE_PLATFORM_URL 1
+#define FEATURE_NOTIFY 1
 
 #endif
 

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -16,6 +16,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "prefix.h"
 
+#include "sysdefs.h"
 #include "globdefs.h"
 #include "filedefs.h"
 #include "objdefs.h"
@@ -204,7 +205,9 @@ MCMovingList::~MCMovingList()
 
 MCUIDC::MCUIDC()
 {
+#if defined(FEATURE_NOTIFY)
 	MCNotifyInitialize();
+#endif
     
 	messageid = 0;
 	nmessages = maxmessages = 0;


### PR DESCRIPTION
On some platforms, such as emscripten, no threading API is available (and threads aren't needed anyway).  In that case, there's also no need for the `MCNotify` API.

These changes gate use of the `MCNotify` API using the `FEATURE_NOTIFY` macro, and ensures that the API implementation won't compile on platforms that don't define `FEATURE_NOTIFY`.

It also removes some redundant calls to `MCNotifyInitialize()`.
