### PR TITLE
[[ Bug 15675 ]] Crash when 'DataTree' is in Plugins

### DIFF
--- a/docs/notes/bugfix-15675.md
+++ b/docs/notes/bugfix-15675.md
@@ -1,0 +1,2 @@
+# IDE crashes on startup if DataTree is installed
+

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -331,7 +331,7 @@ void X_main_loop_iteration()
 	}
     if (!MCtodestroy -> isempty())
     {
-        MCtooltip -> settip(NULL);
+        MCtooltip -> cleartip();
         MCtodestroy -> destroy();
     }
 	MCU_cleaninserted();

--- a/engine/src/mblmain.cpp
+++ b/engine/src/mblmain.cpp
@@ -148,7 +148,7 @@ bool X_main_loop_iteration(void)
 	MCabortscript = False;
     if (!MCtodestroy -> isempty())
     {
-        MCtooltip -> settip(NULL);
+        MCtooltip -> cleartip();
         MCtodestroy -> destroy();
     }
 	MCU_cleaninserted();


### PR DESCRIPTION
The IDE crashes shortly after startup if DataTree is in the plugins. This appears to be
because at some point DataTree uses a stack with 'destroyStack' true, which causes
the current tooltip to be set to NULL. However, the 'settip()' method used expects a
valid stringref and not NULL. This call has been replaced with 'cleartip()' which fixes
the problem.
