### PR TITLE
gyp: Split minizip source files from installer source files.

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -756,14 +756,19 @@
 			'src/internal_development.cpp',
 			'src/mode_development.cpp',
 		],
-		
+
+		# Sources for minizip
+		'engine_minizip_source_files':
+		[
+			'src/minizip.h',
+			'src/minizip.cpp',
+		],
+
 		# Sources for the installer engine
 		'engine_installer_mode_source_files':
 		[
-			'src/minizip.h',
 			'src/bsdiff_apply.cpp',
 			'src/internal.cpp',
-			'src/minizip.cpp',
 			'src/mode_installer.cpp',
 			'src/mode_installer_lnx.cpp',
 			'src/mode_installer_osx.cpp',

--- a/engine/kernel-installer.gypi
+++ b/engine/kernel-installer.gypi
@@ -24,6 +24,7 @@
 			
 			'sources':
 			[
+				'<@(engine_minizip_source_files)',
 				'<@(engine_installer_mode_source_files)',
 			],
 			


### PR DESCRIPTION
On some platforms, we need to manipulate zip files before being able
to load externals.  To support them, we need to compile zip into
non-installer engines.

This patch tweaks the gyp configuration to make that easier.
