### PR TITLE
[[ Bug 15700 ]] iOS sockets only accept a single connection.

### DIFF
--- a/docs/notes/bugfix-15700.md
+++ b/docs/notes/bugfix-15700.md
@@ -1,0 +1,1 @@
+# iOS sockets only accept a single connection

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -722,6 +722,7 @@ Boolean MCScreenDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 		else if (!done && eventtime > curtime)
 			t_sleep = MCMin(eventtime - curtime, exittime - curtime);
 		
+        // MM-2015-08-11: [[ Bug 15700 ]] Poll the sockets. Code pulled over from OS X wait.
         extern Boolean MCS_handle_sockets();
         if (MCS_handle_sockets())
         {

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -722,6 +722,14 @@ Boolean MCScreenDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 		else if (!done && eventtime > curtime)
 			t_sleep = MCMin(eventtime - curtime, exittime - curtime);
 		
+        extern Boolean MCS_handle_sockets();
+        if (MCS_handle_sockets())
+        {
+            if (anyevent)
+                done = True;
+            t_sleep = 0.0;
+        }
+        
 		// Switch to the main fiber and wait for at most t_sleep seconds. This
 		// returns 'true' if the wait was broken rather than timed out.
 		if (MCIPhoneWait(t_sleep) && anyevent)


### PR DESCRIPTION
Make sure we poll sockets during a wait otherwise we miss connections.
