### PR TITLE
[env-vars] Make environment variable handling more robust

### DIFF
--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -908,9 +908,10 @@ X_open_environment_variables_store(MCArrayRef x_array,
 	// the environment variables on server, as they have been copied
 	// to $_SERVER
 #ifndef _SERVER
-	/* Create a global variable for the environment variable, but
-	 * only if the variable name is a valid token beginning with a
-	 * capital letter. */
+	/* Create a global variable for the environment variable, but only
+	 * if the variable name is a valid token that doesn't start with
+	 * "#" or "0".  These rules are to match the way MCVariable
+	 * detects whether a variable proxies an environment variable. */
 	unichar_t t_first = MCStringGetCharAtIndex(p_name_str, 0);
 	if (p_make_global &&
 	    '#' != t_first &&
@@ -939,8 +940,7 @@ X_open_environment_variables_store(MCArrayRef x_array,
 /* Parse environment variables.  All environment variables are placed
  * into the MCenvironmentvariables global array.  Some environment
  * variables are turned into special "$<name>" global LiveCode
- * variables, but only if they begin with a capital letter, and are
- * valid LiveCode language tokens, and are well-formed (i.e. in the
+ * variables, but only if they are well-formed (i.e. in the
  * format "name=value"). */
 static bool
 X_open_environment_variables(MCStringRef envp[])

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -989,7 +989,7 @@ X_open_environment_variables(MCStringRef envp[])
 			}
 
 			if (!MCStringCopySubstring(t_env_var,
-			                           MCRangeMake(t_equal + 1, UINT32_MAX),
+			                           MCRangeMake(t_equal + 1, UINDEX_MAX),
 			                           &t_env_value))
 			{
 				return false;

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -912,7 +912,8 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 		for (uint32_t i = 0 ; envp[i] != nil ; i++)
 		{
 			MCStringRef t_env_var = envp[i];
-			if (isupper(MCStringGetCharAtIndex(t_env_var, 0)))
+			if (isupper(MCStringGetCharAtIndex(t_env_var, 0)) &&
+			    MCU_is_token(t_env_var))
 			{
 				uindex_t t_equal;
 				/* UNCHECKED */ MCStringFirstIndexOfChar(t_env_var, '=', 0, kMCStringOptionCompareExact, t_equal);

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -92,6 +92,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #endif
 
 #include "exec.h"
+#include "chunk.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -493,6 +494,8 @@ MCLocaleRef kMCSystemLocale = nil;
 
 uint32_t MCactionsrequired = 0;
 
+MCArrayRef MCenvironmentvariables;
+
 // SN-2015-07-17: [[ CommandArguments ]] Add global array for the arguments.
 MCStringRef MCcommandname;
 MCArrayRef MCcommandarguments;
@@ -841,7 +844,9 @@ void X_clear_globals(void)
     MChooks = nil;
 
     MCSocketsInitialize();
-    
+
+    MCenvironmentvariables = nil;
+
     MCcommandarguments = NULL;
     MCcommandname = NULL;
 
@@ -863,6 +868,172 @@ void X_clear_globals(void)
 	
 	MCDateTimeInitialize();
 }
+
+/* ---------------------------------------------------------------- */
+
+/* Helper function for X_open_environment_variables() */
+static bool
+X_open_environment_variables_store(MCArrayRef x_array,
+                                   MCStringRef p_name_str,
+                                   MCStringRef p_value,
+                                   bool p_make_global)
+{
+	MCNewAutoNameRef t_name;
+	if (!MCNameCreate(p_name_str, &t_name))
+	{
+		return false;
+	}
+
+	/* Store the environment variable in the array of
+	 * environment variables.  Note that if there are
+	 * duplicates, we always use the *first* value found in
+	 * the environment.  This matches the behaviour of most
+	 * shells. See also bug 13622.
+	 *
+	 * The global array of environment variables is *case
+	 * sensitive*, because "path" and "PATH" are distinct.
+	 */
+	MCValueRef t_current_value;
+	if (MCArrayFetchValue(x_array, true, *t_name, t_current_value))
+	{
+		return true; /* We already have a value for this variable */
+	}
+
+	if (!MCArrayStoreValue(x_array, true, *t_name, p_value))
+	{
+		return false;
+	}
+
+	// SN-2014-06-12 [[ RefactorServer ]] We don't want to duplicate
+	// the environment variables on server, as they have been copied
+	// to $_SERVER
+#ifndef _SERVER
+	/* Create a global variable for the environment variable, but
+	 * only if the variable name is a valid token beginning with a
+	 * capital letter. */
+	if (p_make_global &&
+	    isupper(MCStringGetCharAtIndex(p_name_str, 0)) &&
+	    MCU_is_token(p_name_str))
+	{
+		MCAutoStringRef t_global_str;
+		MCNewAutoNameRef t_global;
+		if (!MCStringFormat(&t_global_str, "$%@", p_name_str))
+		{
+			return false;
+		}
+		if (!MCNameCreate(*t_global_str, &t_global))
+		{
+			return false;
+		}
+
+		MCVariable *t_var;
+		MCVariable::ensureglobal(*t_global, t_var);
+		t_var->setvalueref(p_value);
+	}
+#endif
+	return true;
+}
+
+/* Parse environment variables.  All environment variables are placed
+ * into the MCenvironmentvariables global array.  Some environment
+ * variables are turned into special "$<name>" global LiveCode
+ * variables, but only if they begin with a capital letter, and are
+ * valid LiveCode language tokens, and are well-formed (i.e. in the
+ * format "name=value"). */
+static bool
+X_open_environment_variables(MCStringRef envp[])
+{
+	if (nil == envp || !MCModeHasEnvironmentVariables())
+	{
+		MCenvironmentvariables = nil;
+		return true;
+	}
+
+	/* Create the array of raw environment variables */
+	MCAutoArrayRef t_env_array;
+	if (!MCArrayCreateMutable(&t_env_array))
+	{
+		return false;
+	}
+
+	/* Create an list for degenerate environment variables (ones which
+	 * are not in the "name=value" format.  These are considered after
+	 * all other variables have been processed. */
+	/* FIXME use MCProperListRef */
+	MCAutoArrayRef t_degenerate;
+	if (!MCArrayCreateMutable(&t_degenerate))
+	{
+		return false;
+	}
+
+	for (uint32_t i = 0 ; envp[i] != nil ; i++)
+	{
+		MCStringRef t_env_var = envp[i];
+		MCAutoStringRef t_env_namestr;
+		MCNewAutoNameRef t_env_name;
+		MCAutoStringRef t_env_value;
+		uindex_t t_equal;
+
+		/* Split the environment variable into name and value.  If the
+		 * environment string doesn't contain an '=' character, treat
+		 * the whole string as a name, and delay processing. */
+		if (MCStringFirstIndexOfChar(t_env_var, '=', 0,
+		                             kMCStringOptionCompareExact, t_equal))
+		{
+			if (!MCStringCopySubstring(t_env_var, MCRangeMake(0, t_equal),
+			                           &t_env_namestr))
+			{
+				return false;
+			}
+
+			if (!MCStringCopySubstring(t_env_var,
+			                           MCRangeMake(t_equal + 1, UINT32_MAX),
+			                           &t_env_value))
+			{
+				return false;
+			}
+
+			if (!X_open_environment_variables_store(*t_env_array,
+			                                        *t_env_namestr,
+			                                        *t_env_value,
+			                                        true))
+			{
+				return false;
+			}
+		}
+		else
+		{
+			/* Delay for processing later. */
+			if (!MCArrayStoreValueAtIndex(*t_degenerate,
+			                              MCArrayGetCount(*t_degenerate) + 1,
+			                              t_env_var))
+			{
+				return false;
+			}
+		}
+	}
+
+	/* Process degenerate environment variables */
+	for (uindex_t i = 1; i <= MCArrayGetCount(*t_degenerate); ++i)
+	{
+		MCValueRef t_env_var;
+		if (!MCArrayFetchValueAtIndex(*t_degenerate, i, t_env_var))
+		{
+			return false;
+		}
+
+		if (!X_open_environment_variables_store(*t_env_array,
+		                                        static_cast<MCStringRef>(t_env_var),
+		                                        kMCEmptyString, false))
+		{
+			return false;
+		}
+	}
+
+	return MCArrayCopy(*t_env_array, MCenvironmentvariables);
+}
+
+/* ---------------------------------------------------------------- */
 
 bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 {
@@ -905,45 +1076,23 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 
 	/* UNCHECKED */ MCVariable::ensureglobal(MCN_each, MCeach);
 
-    // SN-2014-06-12 [[ RefactorServer ]] We don't want to duplicate the environment variables
-    // on server, as they have been copied to $_SERVER
-#ifndef _SERVER
-	if (envp != nil)
-		for (uint32_t i = 0 ; envp[i] != nil ; i++)
+	/* Environment variables */
+	if (!X_open_environment_variables(envp))
+	{
+		return false;
+	}
+
+	/* Handle special "MCNOFILES" environment variable */
+	if (nil != MCenvironmentvariables)
+	{
+		MCValueRef t_env_value;
+		if (MCArrayFetchValue(MCenvironmentvariables, true, MCNAME("MCNOFILES"), t_env_value) &&
+		    MCStringGetCharAtIndex(static_cast<MCStringRef>(t_env_value), 0) != '0')
 		{
-			MCStringRef t_env_var = envp[i];
-			if (isupper(MCStringGetCharAtIndex(t_env_var, 0)) &&
-			    MCU_is_token(t_env_var))
-			{
-				uindex_t t_equal;
-				/* UNCHECKED */ MCStringFirstIndexOfChar(t_env_var, '=', 0, kMCStringOptionCompareExact, t_equal);
-
-				MCAutoStringRef t_vname;
-				/* UNCHECKED */ MCStringCreateMutable(0, &t_vname);
-				/* UNCHECKED */ MCStringAppendChar(*t_vname, '$');
-				/* UNCHECKED */ MCStringAppendSubstring(*t_vname, t_env_var, MCRangeMake(0, t_equal));
-
-				MCNewAutoNameRef t_name;
-				/* UNCHECKED */ MCNameCreate(*t_vname, &t_name);
-
-				MCVariable *tvar;
-				/* UNCHECKED */ MCVariable::ensureglobal(*t_name, tvar);
-				if (MCStringIsEqualToCString(*t_vname, "$MCNOFILES", kMCCompareExact) 
-					&& MCStringGetCharAtIndex(t_env_var, t_equal + 1) != '0')
-				{
-					MCnofiles = True;
-					MCsecuremode = MC_SECUREMODE_ALL;
-				}
-				
-				MCAutoStringRef t_value;
-				/* UNCHECKED */ MCStringCopySubstring(t_env_var, 
-													  MCRangeMake(t_equal + 1, MCStringGetLength(t_env_var) - t_equal - 1),
-													  &t_value);
-				
-				tvar->setvalueref(*t_value);
-			}
-        }
-#endif // _SERVER
+			MCnofiles = True;
+			MCsecuremode = MC_SECUREMODE_ALL;
+		}
+	}
 
     // SN-2015-07-17: [[ CommandArguments ]] Initialise the commandName and
     //  commandArguments properties.
@@ -1269,6 +1418,9 @@ int X_close(void)
 	if (MCcurtheme != NULL)
 		MCcurtheme -> unload();
 	delete MCcurtheme;
+
+	MCValueRelease(MCenvironmentvariables);
+	MCenvironmentvariables = nil;
 
     // SN-2015-07-17: [[ CommandArguments ]] Clean up the memory
     MCValueRelease(MCcommandname);

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -911,8 +911,10 @@ X_open_environment_variables_store(MCArrayRef x_array,
 	/* Create a global variable for the environment variable, but
 	 * only if the variable name is a valid token beginning with a
 	 * capital letter. */
+	unichar_t t_first = MCStringGetCharAtIndex(p_name_str, 0);
 	if (p_make_global &&
-	    isupper(MCStringGetCharAtIndex(p_name_str, 0)) &&
+	    '#' != t_first &&
+	    !isdigit(t_first) &&
 	    MCU_is_token(p_name_str))
 	{
 		MCAutoStringRef t_global_str;

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -366,6 +366,8 @@ extern uint4 MCqtidlerate;
 extern MCStringRef MCcommandname;
 extern MCArrayRef MCcommandarguments;
 
+extern MCArrayRef MCenvironmentvariables;
+
 #ifdef _LINUX_DESKTOP
 extern Window MCgtkthemewindow;
 #endif

--- a/engine/src/mode.h
+++ b/engine/src/mode.h
@@ -84,6 +84,13 @@ bool MCModeIsExecutableFirstArgument(void);
 //
 bool MCModeHasCommandLineArguments(void);
 
+// This hook is used to determine if we populate the environment
+// variables at startup.
+//
+// This hook is called by X_open.
+//
+bool MCModeHasEnvironmentVariables(void);
+
 // This hook is used to determine if any stacks on the command-line
 // should be opened on startup.
 //

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1230,6 +1230,13 @@ bool MCModeHasCommandLineArguments(void)
     return false;
 }
 
+// In development mode, we process environment variables
+bool
+MCModeHasEnvironmentVariables()
+{
+	return true;
+}
+
 // In development mode, we always automatically open stacks.
 bool MCModeShouldLoadStacksOnStartup(void)
 {

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1569,6 +1569,13 @@ bool MCModeHasCommandLineArguments(void)
     return true;
 }
 
+// In installer mode, we have environment variables
+bool
+MCModeHasEnvironmentVariables()
+{
+	return true;
+}
+
 // In standalone mode, we only automatically open stacks if there isn't an
 // embedded stack.
 bool MCModeShouldLoadStacksOnStartup(void)

--- a/engine/src/mode_server.cpp
+++ b/engine/src/mode_server.cpp
@@ -286,6 +286,13 @@ bool MCModeHasCommandLineArguments(void)
     return true;
 }
 
+// In server mode, we have environment variables
+bool
+MCModeHasEnvironmentVariables()
+{
+	return true;
+}
+
 // In standalone mode, we only automatically open stacks if there isn't an
 // embedded stack.
 bool MCModeShouldLoadStacksOnStartup(void)

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -805,6 +805,13 @@ bool MCModeHasCommandLineArguments(void)
 #endif
 }
 
+// Standalones have environment variables
+bool
+MCModeHasEnvironmentVariables()
+{
+	return true;
+}
+
 // In standalone mode, we only automatically open stacks if there isn't an
 // embedded stack.
 bool MCModeShouldLoadStacksOnStartup(void)

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -3354,9 +3354,11 @@ MCU_is_token(MCStringRef p_string)
 {
 	MCScriptPoint sp(p_string);
 
-	MCerrorlock++;
+	++MCerrorlock;
 
 	Parse_stat ps = sp.nexttoken();
+
+	--MCerrorlock;
 
 	if (ps == PS_ERROR || ps == PS_EOF)
 	{

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -46,6 +46,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "exec.h"
 #include "system.h"
 #include "dispatch.h"
+#include "scriptpt.h"
 
 #if defined(_MACOSX)
 #include <mach-o/dyld.h>
@@ -3344,6 +3345,37 @@ void *MCU_resolvemodulesymbol(void* p_module, const char *p_symbol)
         return nil;
 
     return MCS_resolvemodulesymbol((MCSysModuleHandle)p_module, *t_symbol_str);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+bool
+MCU_is_token(MCStringRef p_string)
+{
+	MCScriptPoint sp(p_string);
+
+	MCerrorlock++;
+
+	Parse_stat ps = sp.nexttoken();
+
+	if (ps == PS_ERROR || ps == PS_EOF)
+	{
+		return false;
+	}
+
+	/* Check that token is located at start of query string */
+	if (sp.getindex() != 0)
+	{
+		return false;
+	}
+
+	/* Check that token spans full length of query string */
+	if (MCStringGetLength(p_string) != MCStringGetLength(sp.gettoken_stringref()))
+	{
+		return false;
+	}
+
+	return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -288,4 +288,7 @@ inline MCRectangle MCU_make_rect(int2 x, int2 y, uint2 w, uint2 h)
 	return r;
 }
 
+// Test whether p_string is a valid LiveCode script token
+extern bool MCU_is_token(MCStringRef p_string);
+
 #endif


### PR DESCRIPTION
These are the changes that avoid subtle engine breakage when LiveCode is started with a weird environment array.  It fixes several IDE bugs on my Linux machines/VMs.
- Always use the _first_ definition of each variable in the environment (to match bash)
- Don't import variables that aren't valid LiveCode tokens as `$<name>` variables
- Be more consistent about what's considered a valid `$<name>` variable
- Handle degenerate environment variables that aren't in `name=value` format

These changes **do not** (because I don't have time):
- Synchronise `setenv()` changes back to `MCenvironmentvariables`
- Provide syntax to inspect/modify environment variables that weren't imported
- Ensure that only environment variables visible to LiveCode scripts get passed to subprocesses.
