### PR TITLE
[[ Bug 15718 ]] Fix the symbol list generated for revsecurity

### DIFF
--- a/docs/notes/bugfix-15718.md
+++ b/docs/notes/bugfix-15718.md
@@ -1,0 +1,1 @@
+# 'SSL library not found' error thrown on iOS when using SSL & Encryption library

--- a/util/build_libinfo.pl
+++ b/util/build_libinfo.pl
@@ -79,10 +79,11 @@ foreach my $line (@spec)
 	$symbol =~ s/:$// ;
 
 	$symbolExterns .= "extern \"C\" void *$symbol;\n";
-	$symbolEntries .= "    { \"$symbol\", $symbol },\n";
+	$symbolEntries .= "    { \"$symbol\", &$symbol },\n";
 }
 
 print OUTPUT $symbolExterns;
+output "extern \"C\" {";
 output "struct LibExport { const char *name; void *address; };";
 output "struct LibInfo { const char **name; struct LibExport *exports; };";
 output "static const char *__libexternalname = \"$name\";";
@@ -96,7 +97,8 @@ output "{";
 output "    &__libexternalname,";
 output "    __libexports";
 output "};";
-output "LibInfo *__libinfoptr_$name __attribute__((__visibility__(\"default\"))) = &__libinfo;";
+output "__attribute((__visibility__(\"default\"),section(\"__DATA,__libs\"))) volatile struct LibInfo *__libinfoptr_$name = &__libinfo;";
+output "};";
 
 sub output
 {


### PR DESCRIPTION
The issue came back after gypification of libopenssl project (was fixed in a5fd9a818)
