### PR TITLE
Revert "[[ Bug 15743 ]] binzip-copy target cannot copy dSYM files in …

### DIFF
--- a/config/debug_syms.gypi
+++ b/config/debug_syms.gypi
@@ -1,122 +1,65 @@
 {
-	'targets':
+	'conditions':
 	[
-		{
-			'target_name': 'debug-symbols',
-			'type': 'none',
-
-			'dependencies':
-			[
-				'LiveCode-all',
-			],
-
-			'variables':
+		[
+			'OS != "win"',
 			{
-				'debug_syms_inputs%': [ '<@(debug_syms_inputs)' ],
 				'variables':
 				{
-					'debug_syms_inputs': [ '>@(dist_files)' ],
+					'debug_syms_outputs':
+					[
+						'>!@(["sh", "-c", "echo $@ | xargs -n1 | sed -e \\\"s/$/>(debug_info_suffix)/g\\\"", "echo", \'>@(debug_syms_inputs)\'])',
+					],
+					
+					'extract-debug-symbols_path': '../tools/extract-debug-symbols.sh',
+					
+					# These tools are only used for Linux and Android targets
+					'objcopy%': '',
+					'objdump%': '',
+					'strip%': '',
 				},
-			},
-			
-			'conditions':
-			[
-				[
-					'OS != "win"',
-					{
-						'variables':
-						{
-							'debug_syms_outputs':
-							[
-								'>!@(["sh", "-c", "echo $@ | xargs -n1 | sed -e \\\"s/$/>(debug_info_suffix)/g\\\"", "echo", \'>@(debug_syms_inputs)\'])',
-							],
-					
-							'extract-debug-symbols_path': '../tools/extract-debug-symbols.sh',
-					
-							# These tools are only used for Linux and Android targets
-							'objcopy%': '',
-							'objdump%': '',
-							'strip%': '',
-						},
 
-						'actions':
+				'actions':
+				[
+					{
+						'action_name': 'extract-debug-symbols',
+						'message': 'Extracting debug symbols',
+			
+						'inputs':
 						[
-							{
-								'action_name': 'extract-debug-symbols',
-								'message': 'Extracting debug symbols',
-			
-								'inputs':
-								[
-									'>@(debug_syms_inputs)',
-									'<(extract-debug-symbols_path)',
-								],
-			
-								'outputs':
-								[
-									'>@(debug_syms_outputs)',
-								],
-			
-								'action':
-								[
-									'env',
-									'OBJCOPY=<(objcopy)',
-									'OBJDUMP=<(objdump)',
-									'STRIP=<(strip)',
-									'<(extract-debug-symbols_path)',
-									'<(OS)',
-									'>(debug_info_suffix)',
-									'>@(debug_syms_inputs)',
-								],
-							},
+							'>@(debug_syms_inputs)',
+							'<(extract-debug-symbols_path)',
 						],
-					}
-				],
-				[
-					'OS == "win"',
-					{
-						# Not yet implemented...
-						'variables':
-						{
-							'debug_syms_outputs': [],
-						},
+			
+						'outputs':
+						[
+							'>@(debug_syms_outputs)',
+						],
+			
+						'action':
+						[
+							'env',
+							'OBJCOPY=<(objcopy)',
+							'OBJDUMP=<(objdump)',
+							'STRIP=<(strip)',
+							'<(extract-debug-symbols_path)',
+							'<(OS)',
+							'>(debug_info_suffix)',
+							'>@(debug_syms_inputs)',
+						],
 					},
 				],
-			],
-
-
-			'all_dependent_settings':
+			}
+		],
+		[
+			'OS == "win"',
 			{
+				# Not yet implemented...
 				'variables':
 				{
-					'dist_aux_files': [ '<@(debug_syms_outputs)' ],
-					'variables':
-					{
-						'debug_syms_inputs%': [ '<@(debug_syms_inputs)' ],
-					},
+					'debug_syms_outputs': [],
 				},
 			},
-		},
-		{
-			'target_name': 'binzip-copy',
-			'type': 'none',
-	
-			'variables':
-			{
-				'dist_files': [],
-				'dist_aux_files': [],
-			},
-	
-			'dependencies':
-			[
-				'LiveCode-all',
-				'debug-symbols',
-			],
-	
-			'copies':
-			[{
-				'destination': '<(output_dir)',
-				'files': [ '>@(dist_files)', '>@(dist_aux_files)', ],
-			}],
-		},
+		],
 	],
 }

--- a/docs/notes/bugfix-15743.md
+++ b/docs/notes/bugfix-15743.md
@@ -1,0 +1,1 @@
+# iOS standalone engine do not build anymore in Debug mode

--- a/docs/notes/bugfix-15743.md
+++ b/docs/notes/bugfix-15743.md
@@ -1,1 +1,0 @@
-# iOS standalone engine do not build anymore in Debug mode

--- a/livecode.gyp
+++ b/livecode.gyp
@@ -98,60 +98,64 @@
 				],
 			],
 		},
-	],
-	
-	'configurations':
-	{
-		'Debug':
+		
 		{
-			'targets':
-			[
-				{
-					'target_name': 'binzip-copy',
-					'type': 'none',
+			'target_name': 'debug-symbols',
+			'type': 'none',
 			
+			'dependencies':
+			[
+				'LiveCode-all',
+			],
+			
+			'variables':
+			{
+				'debug_syms_inputs%': [ '<@(debug_syms_inputs)' ],
+				'variables':
+				{
+					'debug_syms_inputs': [ '>@(dist_files)' ],
+				},
+			},
+			
+			'includes':
+			[
+				'config/debug_syms.gypi',
+			],
+			
+			'all_dependent_settings':
+			{
+				'variables':
+				{
+					'dist_aux_files': [ '<@(debug_syms_outputs)' ],
 					'variables':
 					{
-						'dist_files': [],
-						'dist_aux_files': [],
+						'debug_syms_inputs%': [ '<@(debug_syms_inputs)' ],
 					},
-			
-					'dependencies':
-					[
-						'LiveCode-all',
-					],
-			
-					'copies':
-					[{
-						'destination': '<(output_dir)',
-						'files': [ '>@(dist_files)', '>@(dist_aux_files)', ],
-					}],
 				},
-			],
+			},
 		},
-		'Release':
+		
 		{
-			'targets':
+			'target_name': 'binzip-copy',
+			'type': 'none',
+			
+			'variables':
+			{
+				'dist_files': [],
+				'dist_aux_files': [],
+			},
+			
+			'dependencies':
 			[
-				{
-					'includes':
-					[
-						'config/debug_syms.gypi',
-					],
-				},
+				'LiveCode-all',
+				'debug-symbols',
 			],
+			
+			'copies':
+			[{
+				'destination': '<(output_dir)',
+				'files': [ '>@(dist_files)', '>@(dist_aux_files)', ],
+			}],
 		},
-		'Fast':
-		{
-			'targets':
-			[
-				{
-					'includes':
-					[
-						'config/debug_syms.gypi',
-					],
-				},
-			],
-		},
-	}
+	],
 }

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -52,20 +52,22 @@ for input in $@ ; do
 		real_input="${input}"
 	fi
 
-	# Extract a copy of the debugging information
-	echo Extracting debug symbols for ${input}
-	dsymutil --out "${output}" "${real_input}"
 
-	# Strip the executable
-	$STRIP -x -S "$real_input"
+	# If the OS is iOS and this is a debug build, do nothing
+	if [ "$os" == "ios" -a "$BUILDTYPE" == "Debug" ] ; then
+		echo Creating empty debug symbols file for ${input}
+		touch "${output}"
+	else
+		# Extract a copy of the debugging information
+		echo Extracting debug symbols for ${input}
+		dsymutil --out "${output}" "${real_input}"
+
+		# Strip the executable
+		$STRIP -x -S "$real_input"
+	fi
 done
 
 }
-
-# If the OS is iOS and this is a debug build, do nothing
-if [ "$os" == "ios" -a "$BUILDTYPE" == "Debug" ] ; then
-	exit 0
-fi
 
 case $os in
 	linux|android)


### PR DESCRIPTION
…Debug mode, since the debug symbols are not extracted."

This reverts commit b07d02fe1f29c0e9a82e4d748199c434c22b8813, which breaks commercial compilation - and does not fix the issue
in the best way
