### PR TITLE
[[ Bug 15719 ]] Reinstate mobile handlers return value: either ES_NOR…

### DIFF
--- a/docs/notes/bugfix-15719.md
+++ b/docs/notes/bugfix-15719.md
@@ -1,0 +1,1 @@
+# An error in a preOpenStack script aborted openStack, pre- and OpenCard messages on Mobile platforms

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -178,10 +178,15 @@ void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, bool resolved, MCHandl
     
     if (global_handler)
     {
-        // AL-2014-03-14: Currently no mobile handler's execution is halted when ES_ERROR
-        //  is returned. Error info is returned via the result. 
         if (!MCRunGlobalHandler(name, params, stat))
             stat = ES_NOT_HANDLED;
+		
+		// AL-2014-03-14: Currently no mobile handler's execution is halted when ES_ERROR
+		//  is returned. Error info is returned via the result.
+#ifdef _MOBILE
+		if (stat != ES_NOT_HANDLED)
+			stat = ES_NORMAL;
+#endif
     }
 	else if (handler != nil)
 	{


### PR DESCRIPTION
…MAL or ES_NOT_HANDLED

That behaviour was removed in 85759f5e
