### PR TITLE
[[ Bug 15703 ]] Use x.y instead of x.y.z for the iOS minimum version …

### DIFF
--- a/docs/notes/bugfix-15703.md
+++ b/docs/notes/bugfix-15703.md
@@ -1,0 +1,1 @@
+# iOS app saved with minimum version 8.4 won't install on a device runnning iOS 8.4

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1113,7 +1113,7 @@ private function revGetMinimumOSByArch pMinimumOS
    if pMinimumOS is empty or pMinimumOS <= "5.1" then
       put "5.1.1" into tMinimumOSByArch["i386"]
    else
-      put pMinimumOS & ".0" after tMinimumOSByArch["i386"]
+      put pMinimumOS after tMinimumOSByArch["i386"]
    end if
    
    -- Assign the same value to the other architectures.


### PR DESCRIPTION
…saved in the standalones Plist
