### PR TITLE
Work around a CEF crash-on-shutdown bug for OSX

### DIFF
--- a/revbrowser/src/cefbrowser.cpp
+++ b/revbrowser/src/cefbrowser.cpp
@@ -228,7 +228,7 @@ void MCCefFinalise(void)
 	if (!s_cef_initialised)
 		return;
 
-	CefShutdown();
+    //CefShutdown();
 
 	s_cef_initialised = false;
 }


### PR DESCRIPTION
For now, we simply don't shut down CEF cleanly. This prevents it
from crashing due to an NSAutoReleasePool corruption bug.
