### PR TITLE
libfoundation: MCListAppend(): Fall back to copy description

### DIFF
--- a/libfoundation/src/foundation-list.cpp
+++ b/libfoundation/src/foundation-list.cpp
@@ -78,9 +78,11 @@ bool MCListAppend(MCListRef self, MCValueRef p_value)
 		break;
 
 	default:
-		// value type conversion not implemented
-		MCAssert(false);
-		return false;
+		if (!MCStringFormat(t_string, "%@", p_value))
+		{
+			return false;
+		}
+		break;
 	}
 	if (!t_first && !MCStringAppend(self -> buffer, self -> delimiter))
 		return false;


### PR DESCRIPTION
When printing error messages from some LiveCode Builder programs it
was possible to hit the default path in `MCListAppend()`'s type switch
statement, causing an immediate (and uninformative) abort.

This patch makes `MCListAppend()` use `MCStringFormat()` to
format values that it can't handle directly.
