### PR TITLE
[emscripten] Only define MCEmscriptenNotImplemented() in debug mode.

### DIFF
--- a/engine/src/em-util.h
+++ b/engine/src/em-util.h
@@ -33,6 +33,10 @@ __MCEmscriptenNotImplemented(const char *p_file,
 	__MCLog(p_file, p_line, "not implemented: %s", p_function);
 }
 
-#define MCEmscriptenNotImplemented() __MCEmscriptenNotImplemented(__FILE__, __LINE__, __PRETTY_FUNCTION__)
+#if defined(_DEBUG)
+#	define MCEmscriptenNotImplemented() __MCEmscriptenNotImplemented(__FILE__, __LINE__, __PRETTY_FUNCTION__)
+#else
+#   define MCEmscriptenNotImplemented()
+#endif /* _DEBUG */
 
 #endif /* ! __MC_EMSCRIPTEN_UTIL_H__ */


### PR DESCRIPTION
In other modes, make it a no-op.
