### PR TITLE
[emscripten] Add dummy rules for Emscripten builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,3 +165,17 @@ all-win-%:
 	$(MAKE) compile-win-$*
 
 $(addsuffix -win,all config compile): %: %-x86
+
+################################################################
+# Emscripten rules
+################################################################
+
+config-emscripten:
+	mkdir -p build-emscripten
+
+compile-emscripten:
+	mkdir -p emscripten-bin
+
+all-emscripten:
+	$(MAKE) config-emscripten
+	$(MAKE) compile-emscripten


### PR DESCRIPTION
We need to be able to run the build system against branches that don't
support emscripten.  This patch works around the lack of support for
running builds conditionally by branch by adding dummy build rules for
emscripten.
