### PR TITLE
[emscripten] Update top-level build instructions.

### DIFF
--- a/INSTALL-emscripten.md
+++ b/INSTALL-emscripten.md
@@ -29,16 +29,6 @@ an Emscripten engine.
 
    This will take a really long time and use an insane amount of RAM.
 
-### Prebuild libicu
-
-The LiveCode downloads server doesn't currently include prebuilt libraries for Emscripten.  You need to build **libicu** manually.  First you need to build a host library, and then use the host library to cross compile **libicu** for Emscripten.
-
-    cd prebuilt
-    ./build-libraries.sh linux x86_64 icu
-
-    ( source /opt/emsdk_portable/emsdk_env.sh &&
-      ./build-libraries.sh emscripten js icu )
-
 ## Build environment
 
 Before building for Emscripten, source the Emscripten SDK script that sets up the environment correctly.  You need to source it with the `.` or `source` command rather than just running it.
@@ -57,21 +47,19 @@ This will generate make control files in the `build-emscripten` directory.  You 
 
 LiveCode currently requires some special setup steps to enable building on Emscripten.
 
-You need to construct a root filesystem for the standalone engine in the `engine/boot` directory.  This is a temporary setup step until a standalone builder is implemented for Emscripten engines. You need to provide two files there:
-
-* `engine/boot/boot.livecode` is a stack to be loaded when the standalone engine starts.
-
-* `engine/boot/fonts/basefont.ttf` is the default (currently only) font for text rendering
-
 To compile LiveCode, run:
 
     make compile-emscripten
 
+This will generate outputs in the `emscripten-bin` directory.
+
 ## Running LiveCode
 
-Emscripten builds currently don't put all of the output files in the `emscripten-js-bin` directory.  To run the engine, load `build-emscripten/livecode/out/Debug/standalone-community.html` in a web browser.
+Once you've created a standalone, you can open the HTML file in a web browser to try out the engine.
 
 Some web browsers (including Google Chrome) have JavaScript security policies that won't allow you to run the engine from a local filesystem.  For these browsers, you will need to run a local web server.  You can use the following steps to launch a local-only webserver listening on port 8080:
 
-    cd build-emscripten/livecode/out
+    cd /path/to/my/standalone
     python -m SimpleHTTPServer 8080
+
+You can then load http://localhost:8080/ in a web browser to view your standalone HTML5 engine.

--- a/INSTALL-emscripten.md
+++ b/INSTALL-emscripten.md
@@ -4,7 +4,7 @@
 
 Copyright © 2015 LiveCode Ltd., Edinburgh, UK
 
-**Warning**: Emscripten (HTML5) platform support for LiveCode is still under development.  This document is almost certainly already out of date.
+**Warning**: Emscripten (HTML5) platform support for LiveCode is experimental and not recommended for production use.
 
 ## Dependencies
 
@@ -55,6 +55,10 @@ This will generate outputs in the `emscripten-bin` directory.
 
 ## Running LiveCode
 
+**Note**: See also the "HTML5 Deployment" guide, available in the in-IDE dictionary.
+
+Use the desktop build of the LiveCode IDE to run the standalone builder and create an "HTML5" standalone.
+
 Once you've created a standalone, you can open the HTML file in a web browser to try out the engine.
 
 Some web browsers (including Google Chrome) have JavaScript security policies that won't allow you to run the engine from a local filesystem.  For these browsers, you will need to run a local web server.  You can use the following steps to launch a local-only webserver listening on port 8080:
@@ -63,3 +67,4 @@ Some web browsers (including Google Chrome) have JavaScript security policies th
     python -m SimpleHTTPServer 8080
 
 You can then load http://localhost:8080/ in a web browser to view your standalone HTML5 engine.
+


### PR DESCRIPTION
- prebuilt libicu is now available on the server
- no longer necessary to manually create a root filesystem image
- built products are now put in the right place
- can now generate HTML5 standalones
