### PR TITLE
[emscripten] Look for engine in the correct place when installed.

### DIFF
--- a/ide-support/revsaveasemscriptenstandalone.livecodescript
+++ b/ide-support/revsaveasemscriptenstandalone.livecodescript
@@ -264,7 +264,7 @@ private function getRuntimeFolder
    
    local tRelFolder, tOverridePath, tUserPath
    
-   put slash & "Emscripten" into tRelFolder
+   put slash & "Emscripten" & slash & "js" into tRelFolder
    
    put revOverrideRuntimePath() into tOverridePath
    if tOverridePath is not empty then


### PR DESCRIPTION
The standalone builder was looking in the `Emscripten` runtime
resource directory for the JavaScript engine, but it should be looking
in `Emscripten/js`.
