### PR TITLE
Remove iOS Simulator 5.1 from the installer manifest

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -703,58 +703,43 @@ component Runtime.Android
 //////////
 
 component Runtime.iOS
-	into "[[ToolsFolder]]/Runtime/iOS/Simulator-5_1" place
-		executable ios:iphonesimulator5.1/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone
-		executable ios:iphonesimulator5.1/revsecurity.ios-extension as RevSecurity
-		executable ios:iphonesimulator5.1/revpdfprinter.ios-extension as RevPdfPrinter
-		executable ios:iphonesimulator5.1/revzip.ios-extension as RevZip
-		executable ios:iphonesimulator5.1/revxml.ios-extension as RevXml
-		executable ios:iphonesimulator5.1/revdb.ios-extension as RevDb
-		executable ios:iphonesimulator5.1/dbsqlite.ios-extension as DbSqlite
-		executable ios:iphonesimulator5.1/dbmysql.ios-extension as DbMysql
-		file ios:iphonesimulator5.1/mobile-template.plist as "Settings.plist"
-		file ios:iphonesimulator5.1/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
-		file ios:iphonesimulator5.1/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"
-		file ios:iphonesimulator5.1/mobile-splashscreen-template.plist as "SplashscreenSettings.plist"
-		file ios:iphonesimulator5.1/Default-568h@2x.png as "Default4InchSplash.png" base ios:Default-568h@2x.png
-		file ios:iphonesimulator5.1/fontmap as "fontmap"
 	into "[[ToolsFolder]]/Runtime/iOS/Simulator-6_1" place
-		executable ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator5.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
-		executable ios:iphonesimulator6.1/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator5.1/revsecurity.dylib
-		executable ios:iphonesimulator6.1/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator5.1/revpdfprinter.dylib
-		executable ios:iphonesimulator6.1/revzip.ios-extension as RevZip base ios:iphonesimulator5.1/revzip.dylib
-		executable ios:iphonesimulator6.1/revxml.ios-extension as RevXml base ios:iphonesimulator5.1/revxml.dylib
-		executable ios:iphonesimulator6.1/revdb.ios-extension as RevDb base ios:iphonesimulator5.1/revdb.dylib
-		executable ios:iphonesimulator6.1/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator5.1/dbsqlite.dylib
-		executable ios:iphonesimulator6.1/dbmysql.ios-extension as DbMysql base ios:iphonesimulator5.1/dbmysql.dylib
+		executable ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone
+		executable ios:iphonesimulator6.1/revsecurity.ios-extension as RevSecurity
+		executable ios:iphonesimulator6.1/revpdfprinter.ios-extension as RevPdfPrinter
+		executable ios:iphonesimulator6.1/revzip.ios-extension as RevZip
+		executable ios:iphonesimulator6.1/revxml.ios-extension as RevXml
+		executable ios:iphonesimulator6.1/revdb.ios-extension as RevDb
+		executable ios:iphonesimulator6.1/dbsqlite.ios-extension as DbSqlite
+		executable ios:iphonesimulator6.1/dbmysql.ios-extension as DbMysql
 		file ios:iphonesimulator6.1/mobile-template.plist as "Settings.plist"
 		file ios:iphonesimulator6.1/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
 		file ios:iphonesimulator6.1/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"
 		file ios:iphonesimulator6.1/Default-568h@2x.png as "Default4InchSplash.png" base ios:Default-568h@2x.png
 		file ios:iphonesimulator6.1/fontmap as "fontmap"
 	into "[[ToolsFolder]]/Runtime/iOS/Simulator-7_1" place
-		executable ios:iphonesimulator7.1/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator5.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
-		executable ios:iphonesimulator7.1/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator5.1/revsecurity.dylib
-		executable ios:iphonesimulator7.1/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator5.1/revpdfprinter.dylib
-		executable ios:iphonesimulator7.1/revzip.ios-extension as RevZip base ios:iphonesimulator5.1/revzip.dylib
-		executable ios:iphonesimulator7.1/revxml.ios-extension as RevXml base ios:iphonesimulator5.1/revxml.dylib
-		executable ios:iphonesimulator7.1/revdb.ios-extension as RevDb base ios:iphonesimulator5.1/revdb.dylib
-		executable ios:iphonesimulator7.1/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator5.1/dbsqlite.dylib
-		executable ios:iphonesimulator7.1/dbmysql.ios-extension as DbMysql base ios:iphonesimulator5.1/dbmysql.dylib
+		executable ios:iphonesimulator7.1/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
+		executable ios:iphonesimulator7.1/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator6.1/revsecurity.dylib
+		executable ios:iphonesimulator7.1/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator6.1/revpdfprinter.dylib
+		executable ios:iphonesimulator7.1/revzip.ios-extension as RevZip base ios:iphonesimulator6.1/revzip.dylib
+		executable ios:iphonesimulator7.1/revxml.ios-extension as RevXml base ios:iphonesimulator6.1/revxml.dylib
+		executable ios:iphonesimulator7.1/revdb.ios-extension as RevDb base ios:iphonesimulator6.1/revdb.dylib
+		executable ios:iphonesimulator7.1/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator6.1/dbsqlite.dylib
+		executable ios:iphonesimulator7.1/dbmysql.ios-extension as DbMysql base ios:iphonesimulator6.1/dbmysql.dylib
 		file ios:iphonesimulator7.1/mobile-template.plist as "Settings.plist"
 		file ios:iphonesimulator7.1/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
 		file ios:iphonesimulator7.1/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"
 		file ios:iphonesimulator7.1/Default-568h@2x.png as "Default4InchSplash.png" base ios:Default-568h@2x.png
 		file ios:iphonesimulator7.1/fontmap as "fontmap"
 	into "[[ToolsFolder]]/Runtime/iOS/Simulator-8_2" place
-		executable ios:iphonesimulator8.2/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator5.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
-		executable ios:iphonesimulator8.2/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator5.1/revsecurity.dylib
-		executable ios:iphonesimulator8.2/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator5.1/revpdfprinter.dylib
-		executable ios:iphonesimulator8.2/revzip.ios-extension as RevZip base ios:iphonesimulator5.1/revzip.dylib
-		executable ios:iphonesimulator8.2/revxml.ios-extension as RevXml base ios:iphonesimulator5.1/revxml.dylib
-		executable ios:iphonesimulator8.2/revdb.ios-extension as RevDb base ios:iphonesimulator5.1/revdb.dylib
-		executable ios:iphonesimulator8.2/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator5.1/dbsqlite.dylib
-		executable ios:iphonesimulator8.2/dbmysql.ios-extension as DbMysql base ios:iphonesimulator5.1/dbmysql.dylib
+		executable ios:iphonesimulator8.2/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
+		executable ios:iphonesimulator8.2/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator6.1/revsecurity.dylib
+		executable ios:iphonesimulator8.2/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator6.1/revpdfprinter.dylib
+		executable ios:iphonesimulator8.2/revzip.ios-extension as RevZip base ios:iphonesimulator6.1/revzip.dylib
+		executable ios:iphonesimulator8.2/revxml.ios-extension as RevXml base ios:iphonesimulator6.1/revxml.dylib
+		executable ios:iphonesimulator8.2/revdb.ios-extension as RevDb base ios:iphonesimulator6.1/revdb.dylib
+		executable ios:iphonesimulator8.2/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator6.1/dbsqlite.dylib
+		executable ios:iphonesimulator8.2/dbmysql.ios-extension as DbMysql base ios:iphonesimulator6.1/dbmysql.dylib
 		file ios:iphonesimulator8.2/mobile-template.plist as "Settings.plist"
 		file ios:iphonesimulator8.2/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
 		file ios:iphonesimulator8.2/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"
@@ -762,14 +747,14 @@ component Runtime.iOS
 		file ios:iphonesimulator8.2/Default-568h@2x.png as "Default4InchSplash.png" base ios:Default-568h@2x.png
 		file ios:iphonesimulator8.2/fontmap as "fontmap"
 	into "[[ToolsFolder]]/Runtime/iOS/Simulator-8_4" place
-		executable ios:iphonesimulator8.4/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator5.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
-		executable ios:iphonesimulator8.4/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator5.1/revsecurity.dylib
-		executable ios:iphonesimulator8.4/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator5.1/revpdfprinter.dylib
-		executable ios:iphonesimulator8.4/revzip.ios-extension as RevZip base ios:iphonesimulator5.1/revzip.dylib
-		executable ios:iphonesimulator8.4/revxml.ios-extension as RevXml base ios:iphonesimulator5.1/revxml.dylib
-		executable ios:iphonesimulator8.4/revdb.ios-extension as RevDb base ios:iphonesimulator5.1/revdb.dylib
-		executable ios:iphonesimulator8.4/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator5.1/dbsqlite.dylib
-		executable ios:iphonesimulator8.4/dbmysql.ios-extension as DbMysql base ios:iphonesimulator5.1/dbmysql.dylib
+		executable ios:iphonesimulator8.4/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
+		executable ios:iphonesimulator8.4/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator6.1/revsecurity.dylib
+		executable ios:iphonesimulator8.4/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator6.1/revpdfprinter.dylib
+		executable ios:iphonesimulator8.4/revzip.ios-extension as RevZip base ios:iphonesimulator6.1/revzip.dylib
+		executable ios:iphonesimulator8.4/revxml.ios-extension as RevXml base ios:iphonesimulator6.1/revxml.dylib
+		executable ios:iphonesimulator8.4/revdb.ios-extension as RevDb base ios:iphonesimulator6.1/revdb.dylib
+		executable ios:iphonesimulator8.4/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator6.1/dbsqlite.dylib
+		executable ios:iphonesimulator8.4/dbmysql.ios-extension as DbMysql base ios:iphonesimulator6.1/dbmysql.dylib
 		file ios:iphonesimulator8.4/mobile-template.plist as "Settings.plist"
 		file ios:iphonesimulator8.4/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
 		file ios:iphonesimulator8.4/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"


### PR DESCRIPTION
The engine isn't built as of 8.0 so the inclusion in the installer
manifest is just causing missing file warnings.
