### PR TITLE
[[ Bug 15705 ]] Fix screen redrawing nesting, broken by 48d53efdcb1

### DIFF
--- a/docs/notes/bugfix-15705.md
+++ b/docs/notes/bugfix-15705.md
@@ -1,0 +1,1 @@
+# strange flash occurring under iOS with visual effect push left/right

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -1361,8 +1361,16 @@ void MCRedrawDoUpdateScreen(void)
 		if (sptr->getstate(CS_NEED_RESIZE))
 		{
 			sptr->setgeom();
-			sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE);
-			MCRedrawUpdateScreen();
+            sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE);
+
+            // SN-2015-08-31: [[ Bug 15705 ]] From 6.7.7, MCRedrawUpdateScreen
+            //  also removes kMCActionUpdateScreen from MCactionsrequired,
+            //  which was not the case beforehand - and the redrawing could nest
+            //  here, and eventually set s_screen_is_dirty to false (l.1383)
+            if (MClockscreen == 0 && s_screen_is_dirty && !s_screen_updates_disabled)
+                MCActionsSchedule(kMCActionsUpdateScreen);
+
+            MCRedrawUpdateScreen();
 			return;
 		}
 


### PR DESCRIPTION
Now that MCactionsrequired makes each action unrepeatable, no nesting was possible in MCRedrawDoUpdateScreen, and s_screen_is_dirty was left set to true
