### PR TITLE
[Bug 15844] mobilePickDate "time",,,,10 does not work in LC 7

### DIFF
--- a/docs/notes/bugfix-15844.md
+++ b/docs/notes/bugfix-15844.md
@@ -1,0 +1,1 @@
+#    mobilePickDate "time",,,,10 does not work in LC 7

--- a/engine/src/exec-pick.cpp
+++ b/engine/src/exec-pick.cpp
@@ -175,8 +175,10 @@ void MCPickDoPickDateTime(MCExecContext& ctxt, MCStringRef p_current, MCStringRe
     MCDateTime t_current;
     MCDateTime *t_current_ptr;
     t_current_ptr = nil;
-    
-    if (p_current != nil)
+	
+	// PM-2015-09-01: [[ Bug 15844 ]] Allow calling mobilePickDate with empty [, current] [, start] [, end] parameters
+	// i.e. mobilePickDate "time",,,,10
+    if (!MCStringIsEmpty(p_current))
     {
         if (!MCD_convert_to_datetime(ctxt, p_current, CF_UNDEFINED, CF_UNDEFINED, t_current))
             return;
@@ -187,7 +189,7 @@ void MCPickDoPickDateTime(MCExecContext& ctxt, MCStringRef p_current, MCStringRe
     MCDateTime *t_start_ptr;
     t_start_ptr = nil;
     
-    if (p_start != nil)
+    if (!MCStringIsEmpty(p_start))
     {
         if (!MCD_convert_to_datetime(ctxt, p_start, CF_UNDEFINED, CF_UNDEFINED, t_start))
             return;
@@ -198,7 +200,7 @@ void MCPickDoPickDateTime(MCExecContext& ctxt, MCStringRef p_current, MCStringRe
     MCDateTime *t_end_ptr;
     t_end_ptr = nil;
     
-    if (p_end != nil)
+    if (!MCStringIsEmpty(p_end))
     {
         if (!MCD_convert_to_datetime(ctxt, p_end, CF_UNDEFINED, CF_UNDEFINED, t_end))
             return;


### PR DESCRIPTION
i.e. Allow calling mobilePickDate with empty [, current] [, start] [, end] parameters, such as mobilePickDate "time",,,,10
