### PR TITLE
[[ BuildBot ]] LC 6.7 did not understand BUILD_PLATFORM being set to …

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -98,7 +98,7 @@ bin_dir = ${top_src_dir}/$(BUILD_PLATFORM)-bin
 ifeq ($(BUILD_PLATFORM),mac)
   LIVECODE = $(bin_dir)/LiveCode-Community.app/Contents/MacOS/LiveCode-Community
   buildtool_platform = mac
-else ifeq ($(BUILD_PLATFORM),linux-x86)
+else ifeq ($(findstring linux,$(BUILD_PLATFORM)),linux)
   LIVECODE = $(bin_dir)/livecode-community
   buildtool_platform = linux
 endif


### PR DESCRIPTION
…linux-x86_64
