### PR TITLE
[[ Bug 15851 ]] Fix error returning swatchColor when it is empty

### DIFF
--- a/extensions/widgets/colorswatch/colorswatch.lcb
+++ b/extensions/widgets/colorswatch/colorswatch.lcb
@@ -168,7 +168,11 @@ public handler setColor(in tColor as optional String) returns nothing
 end handler
 
 public handler getColor() returns String
-	return colorToString(mColor)
+    if mColor is nothing then
+        return ""
+    else
+        return colorToString(mColor)
+    end if
 end handler
 ----------
 

--- a/extensions/widgets/colorswatch/notes/15851.md
+++ b/extensions/widgets/colorswatch/notes/15851.md
@@ -1,0 +1,1 @@
+# [15851] error getting swatchColor when it is empty


### PR DESCRIPTION
The swatchColor property should return empty when the instance variable mColor is nothing.
