### PR TITLE
[[ Community Docs ]] Tweak description of accept command

### DIFF
--- a/docs/dictionary/command/accept.lcdoc
+++ b/docs/dictionary/command/accept.lcdoc
@@ -34,18 +34,27 @@ callbackMessage: The name of a message to be sent when a connection is made or a
 portNumber: The TCP port number on which to accept connections.
 
 Description:
-Use the <accept> <command> when running a <server>, to accept <TCP> connections or <UDP> <datagram|datagrams> from other systems (or other <process|processes> on the same system).
-Use the datagram option if you want to accept UDP datagrams.
+Use the <accept> <command> when running a <server>, to accept <TCP> connections or <UDP> <datagram|datagrams> 
+from other systems (or other <process|processes> on the same system). Use the datagram option if you want to 
+accept UDP datagrams.
 
-When a connection is made or a datagram is received, the <accept> <command> creates a new <socket> that can be used to communicate with the other system (or <process>). When using the <close socket>, <read from socket>, or <write to socket> <command|commands>, you can refer to this <socket> with a socket identifier that looks like this:
-host:port[|connectionID]
-where the connectionID is a number assigned by the <accept> <command>. (You only need to specify the connection number if there is more than one <socket> connected to a particular <port> and <host>.)
+When a connection is made or a datagram is received, the <accept> <command> creates a new <socket> that can be 
+used to communicate with the other system (or <process>). When using the <close socket>, <read from socket>, or 
+<write to socket> <command|commands>, you can refer to this <socket> with a socket identifier that looks like this:
 
-The <callbackMessage> is sent to the <object> whose <script> contains the <accept> <command>. Either one or two <parameter|parameters> are sent with this <message>. The first <parameter> is the <IP address> of the system or <process> making the connection. If a <datagram> is being accepted, the second <parameter> is the contents of the <datagram>.
+`host:port[|connectionID]`
 
-For technical information about sockets, see RFC 147 at http://www.ietf.org/rfc/rfc147.txt.
-For technical information about UDP datagrams, see RFC 768 at http://www.ietf.org/rfc/rfc0768.txt.
-For technical information about the numbers used to designate standard ports, see the list of port numbers at http://www.iana.org/assignments/port-numbers, in particular the section entitled "Well Known Port Numbers".
+where the connectionID is a number assigned by the <accept> <command>. (You only need to specify the connection 
+number if there is more than one <socket> connected to a particular <port> and <host>.)
+
+The <callbackMessage> is sent to the <object> whose <script> contains the <accept> <command>. Either one or two 
+<parameter|parameters> are sent with this <message>. The first <parameter> is the <IP address> of the system or 
+<process> making the connection. If a <datagram> is being accepted, the second <parameter> is the contents of the 
+<datagram>.
+
+- For technical information about sockets, see RFC 147 at http://www.ietf.org/rfc/rfc147.txt.
+- For technical information about UDP datagrams, see RFC 768 at http://www.ietf.org/rfc/rfc0768.txt.
+- For technical information about the numbers used to designate standard ports, see the list of port numbers at http://www.iana.org/assignments/port-numbers, in particular the section entitled "Well Known Port Numbers".
 
 References: HTTPProxy (property), script (property), read from socket (command), write to socket (command), close socket (command), open socket (command), openSockets (function), hostAddressToName (function), hostName (function), hostAddress (function), peerAddress (function), hostNameToAddress (function), datagram (glossary), IP address (glossary), TCP (glossary), port (glossary), command (glossary), socket (glossary), UDP (glossary), host (glossary), server (glossary), message (glossary), parameter (glossary), process (glossary), object (object)
 

--- a/docs/notes/bugfix-99999.md
+++ b/docs/notes/bugfix-99999.md
@@ -1,0 +1,1 @@
+# Accept command has some formatting issues


### PR DESCRIPTION
Single line breaks are ignored in the dictionary, so I've tweaked the formatting of the entry for the accept command to make it fit within Git's Edit file window. Also, the technical information section would have been several lines run together, so I've made it a list instead using Markdown's list syntax.
