### PR TITLE
[[ Bug 15756 ]] Put cmdname token in the correct place in lextable.cpp

### DIFF
--- a/docs/notes/bugfix-15756.md
+++ b/docs/notes/bugfix-15756.md
@@ -1,0 +1,1 @@
+# various codepoint and codeunit functionality broken in standalones

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -726,6 +726,7 @@ LT factor_table[] =
         {"closebox", TT_PROPERTY, P_CLOSE_BOX},
         {"cmdargs", TT_FUNCTION, F_COMMAND_ARGUMENTS},
         {"cmdkey", TT_FUNCTION, F_COMMAND_KEY},
+        {"cmdname", TT_FUNCTION, F_COMMAND_NAME},
         {"codepoint", TT_CHUNK, CT_CODEPOINT},
         {"codepointoffset", TT_FUNCTION, F_CODEPOINT_OFFSET},
         {"codepointproperty", TT_FUNCTION, F_CODEPOINT_PROPERTY},
@@ -734,7 +735,6 @@ LT factor_table[] =
         {"codeunit", TT_CHUNK, CT_CODEUNIT},
         {"codeunitoffset", TT_FUNCTION, F_CODEUNIT_OFFSET},
         {"codeunits", TT_CLASS, CT_CODEUNIT},
-        {"cmdname", TT_FUNCTION, F_COMMAND_NAME},
         {"collapsebox", TT_PROPERTY, P_COLLAPSE_BOX},
 		// MERG-2013-08-17: [[ ColorDialogColors ]] Custom color management for the windows color dialog
 		{"colordialogcolors", TT_PROPERTY, P_COLOR_DIALOG_COLORS},


### PR DESCRIPTION
I suspect this happened because it was originally based against develop-6.7 where none of those codepoint or codeunit tokens were present.
