### PR TITLE
[[ Bug 15799 ]] Array containing empty array encoded in 7.0 won't load in 6.7

### DIFF
--- a/docs/notes/bugfix-15799.md
+++ b/docs/notes/bugfix-15799.md
@@ -1,0 +1,6 @@
+# Some arrays encoded in 6.7 format from 7.0 won't load into 6.7.
+
+It was possible for an array in 7.0 to have a key that contained the empty array. When encoded in 6.7 format using arrayEncode,
+the resulting data would not decode correctly in 6.7 - producing a truncated result.
+
+This has been fixed - 6.7 will now successfully load such arrays when generated from 7.0.

--- a/engine/src/variablearray.cpp
+++ b/engine/src/variablearray.cpp
@@ -1793,6 +1793,13 @@ IO_stat MCVariableArray::load(MCObjectInputStream& p_stream, bool p_merge)
 	if (t_nfilled == 0 && !p_merge)
 	{
 		nfilled = 0;
+        
+        uint8_t t_terminator;
+        t_stat = p_stream . ReadU8(t_terminator);
+        if (t_stat == IO_ERROR &&
+            t_terminator != 0)
+            t_stat = IO_ERROR;
+        
 		return t_stat;
 	}
 


### PR DESCRIPTION
The 7.x engines are currently (in some cases) encoding empty arrays as an array with 0 elements
when encoding the array in 6.7 format. Unfortunately, this is not quite compatible with the
previous method 6.7 uses to decode - where it assumes that empty arrays will not appear at all
and be empty strings instead (which is consistent with the 6.7 execution model).

This has been fixed by making sure the 6.7 engine looks for the terminating byte of the array
if it has 0 elements.
