### PR TITLE
[[ Bug 15799 ]] Make sure empty arrays are encoded as the empty string in <7.0 format.

### DIFF
--- a/docs/notes/bugfix-15799.md
+++ b/docs/notes/bugfix-15799.md
@@ -1,0 +1,6 @@
+# Some arrays encoded in 6.7 format from 7.0 won't load into 6.7.
+
+It was possible for an array in 7.0 to have a key that contained the empty array. When encoded in 6.7 format using arrayEncode,
+the resulting data would not decode correctly in 6.7 - producing a truncated result.
+
+This has been fixed - 6.7 will now successfully load such arrays when generated from 7.0.

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -1786,8 +1786,16 @@ static bool save_array_to_stream(void *p_context, MCArrayRef p_array, MCNameRef 
 		t_str_value = nil;
 		break;
 	case kMCValueTypeCodeArray:
-		t_type = VF_ARRAY;
-		t_str_value = nil;
+        if (MCArrayGetCount((MCArrayRef)p_value) != 0)
+        {
+            t_type = VF_ARRAY;
+            t_str_value = nil;
+        }
+        else
+        {
+            t_type = VF_STRING;
+            t_str_value = kMCEmptyString;
+        }
 		break;
 	default:
 		MCAssert(false);

--- a/engine/src/variablearray.cpp
+++ b/engine/src/variablearray.cpp
@@ -1793,6 +1793,13 @@ IO_stat MCVariableArray::load(MCObjectInputStream& p_stream, bool p_merge)
 	if (t_nfilled == 0 && !p_merge)
 	{
 		nfilled = 0;
+        
+        uint8_t t_terminator;
+        t_stat = p_stream . ReadU8(t_terminator);
+        if (t_stat == IO_ERROR &&
+            t_terminator != 0)
+            t_stat = IO_ERROR;
+        
 		return t_stat;
 	}
 


### PR DESCRIPTION
When encoding an array in legacy format, the engine must ensure that empty arrays
are encoded as empty strings. Without this, older engines choke on the encoded array
data.
