### PR TITLE
Regression caused by PR 2384:

### DIFF
--- a/engine/src/dskspec.cpp
+++ b/engine/src/dskspec.cpp
@@ -95,9 +95,9 @@ bool MCS_put(MCExecPoint& ep, MCSPutKind p_kind, const MCString& p_data)
 
 	switch(p_kind)
 	{
-	case kMCSPutOutput:
 	case kMCSPutBeforeMessage:
         return MCmb -> prepend(ep, False) == ES_NORMAL;
+	case kMCSPutOutput:
 	case kMCSPutIntoMessage:
 		return MCmb -> store(ep, False) == ES_NORMAL;
 	case kMCSPutAfterMessage:


### PR DESCRIPTION
'put foo' prepended foo in the contents of msg box instead of replacing them
