### PR TITLE
Feature treeview overspill inspect action

### DIFF
--- a/extensions/widgets/treeview/notes/feature-double_click.md
+++ b/extensions/widgets/treeview/notes/feature-double_click.md
@@ -1,0 +1,3 @@
+# Double Click
+When a leaf node of the tree is double-clicked, an `actionDoubleClick` message is sent 
+to the widget's script object. It has one parameter: the path associated with the clicked row.

--- a/extensions/widgets/treeview/notes/feature-inspect_icon.md
+++ b/extensions/widgets/treeview/notes/feature-inspect_icon.md
@@ -4,5 +4,5 @@ When in read only mode, the tree widget will now display an 'open in new window'
 the value of the array at the specified path contains a newline character, or is too large
 to display in the widget. 
 
-If this icon is clicked, an `actionInspect` message is sent to the widget's script object
-with parameter the path associated with the clicked row.
+If this icon is clicked, an `actionInspect` message is sent to the widget's script object.
+It has one parameter: the path associated with the clicked row.

--- a/extensions/widgets/treeview/notes/feature-inspect_icon.md
+++ b/extensions/widgets/treeview/notes/feature-inspect_icon.md
@@ -1,0 +1,8 @@
+# Inspect Icon
+
+When in read only mode, the tree widget will now display an 'open in new window' icon if 
+the value of the array at the specified path contains a newline character, or is too large
+to display in the widget. 
+
+If this icon is clicked, an `actionInspect` message is sent to the widget's script object
+with parameter the path associated with the clicked row.

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -40,13 +40,26 @@ Syntax: actionInspect pPath
 Summary: Sent when an the inspect icon is clicked in read only mode
 
 Parameters:
-pPath: The path to the selected element
+pPath: The path to the clicked element
 
 Description:
 The actionInspect message is sent to the widget's script object when the inspect icon is clicked on.
 The inspect icon appears when the value string of a particular array element contains a newline character,
 or if it is too large to fit in the space provided. The <pPath> parameter contains the path to the 
 element whose icon was clicked.
+
+Name: actionDoubleClick
+Type: message
+Syntax: actionDoubleClick pPath
+
+Summary: Sent when a leaf node of the tree view is double-clicked.
+
+Parameters:
+pPath: The path to the clicked element
+
+Description:
+The actionDoubleClick message is sent to the widget's script object when a row of the widget
+is double-clicked. The <pPath> parameter contains the path to the element whose row was clicked.
 */
 
 widget com.livecode.widget.treeView
@@ -696,8 +709,10 @@ public handler OnClick() returns nothing
 		return
 	end if
 
-	if tData["leaf"] is not true then
-	   if the click count > 1 then
+	if the click count > 1 then
+		if tData["leaf"] then
+			post "actionDoubleClick" with tData["path"]
+		else
 		   if tData["folded"] is true then
 			   unfoldPath(tData["path"])
 		   else

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -32,6 +32,21 @@ The selectedElementChanged message is sent to the widget's script object when a 
 causing that row to be selected. The <pPath> parameter contains the path to the new <selectedElement>.
 
 References: selectedElement (property)
+
+Name: actionInspect
+Type: message
+Syntax: actionInspect pPath
+
+Summary: Sent when an the inspect icon is clicked in read only mode
+
+Parameters:
+pPath: The path to the selected element
+
+Description:
+The actionInspect message is sent to the widget's script object when the inspect icon is clicked on.
+The inspect icon appears when the value string of a particular array element contains a newline character,
+or if it is too large to fit in the space provided. The <pPath> parameter contains the path to the 
+element whose icon was clicked.
 */
 
 widget com.livecode.widget.treeView
@@ -236,6 +251,7 @@ private variable mFoldedArrowPath as Path
 private variable mUnfoldedArrowPath as Path
 private variable mDeleteItemPath as Path
 private variable mAddItemPath as Path
+private variable mInspectItemPath as Path
 
 private variable mIconRect as Rectangle
 private variable mIconWidth as Real
@@ -260,6 +276,7 @@ public handler OnCreate() returns nothing
 	put path "M0.221,0l7.565,0c0.177,0,0.281,0.188,0.183,0.327L4.186,5.679c-0.087,0.124-0.278,0.124-0.366,0L0.038,0.327 C-0.061,0.188,0.044,0,0.221,0z" into mUnfoldedArrowPath
 	put path "M512 736L512 1312Q512 1326 503 1335 494 1344 480 1344L416 1344Q402 1344 393 1335 384 1326 384 1312L384 736Q384 722 393 713 402 704 416 704L480 704Q494 704 503 713 512 722 512 736ZM768 736L768 1312Q768 1326 759 1335 750 1344 736 1344L672 1344Q658 1344 649 1335 640 1326 640 1312L640 736Q640 722 649 713 658 704 672 704L736 704Q750 704 759 713 768 722 768 736ZM1024 736L1024 1312Q1024 1326 1015 1335 1006 1344 992 1344L928 1344Q914 1344 905 1335 896 1326 896 1312L896 736Q896 722 905 713 914 704 928 704L992 704Q1006 704 1015 713 1024 722 1024 736ZM1152 1460L1152 512 256 512 256 1460Q256 1482 263 1500.5 270 1519 277.5 1527.5 285 1536 288 1536L1120 1536Q1123 1536 1130.5 1527.5 1138 1519 1145 1500.5 1152 1482 1152 1460ZM480 384L928 384 880 267Q873 258 863 256L546 256Q536 258 529 267ZM1408 416L1408 480Q1408 494 1399 503 1390 512 1376 512L1280 512 1280 1460Q1280 1543 1233 1603.5 1186 1664 1120 1664L288 1664Q222 1664 175 1605.5 128 1547 128 1464L128 512 32 512Q18 512 9 503 0 494 0 480L0 416Q0 402 9 393 18 384 32 384L341 384 411 217Q426 180 465 154 504 128 544 128L864 128Q904 128 943 154 982 180 997 217L1067 384 1376 384Q1390 384 1399 393 1408 402 1408 416Z" into mDeleteItemPath
 	put path "M1408 608L1408 800Q1408 840 1380 868 1352 896 1312 896L896 896 896 1312Q896 1352 868 1380 840 1408 800 1408L608 1408Q568 1408 540 1380 512 1352 512 1312L512 896 96 896Q56 896 28 868 0 840 0 800L0 608Q0 568 28 540 56 512 96 512L512 512 512 96Q512 56 540 28 568 0 608 0L800 0Q840 0 868 28 896 56 896 96L896 512 1312 512Q1352 512 1380 540 1408 568 1408 608Z" into mAddItemPath
+    put path "M1408 928L1408 1248Q1408 1367 1323.5 1451.5 1239 1536 1120 1536L288 1536Q169 1536 84.5 1451.5 0 1367 0 1248L0 416Q0 297 84.5 212.5 169 128 288 128L992 128Q1006 128 1015 137 1024 146 1024 160L1024 224Q1024 238 1015 247 1006 256 992 256L288 256Q222 256 175 303 128 350 128 416L128 1248Q128 1314 175 1361 222 1408 288 1408L1120 1408Q1186 1408 1233 1361 1280 1314 1280 1248L1280 928Q1280 914 1289 905 1298 896 1312 896L1376 896Q1390 896 1399 905 1408 914 1408 928ZM1792 64L1792 576Q1792 602 1773 621 1754 640 1728 640 1702 640 1683 621L1507 445 855 1097Q845 1107 832 1107 819 1107 809 1097L695 983Q685 973 685 960 685 947 695 937L1347 285 1171 109Q1152 90 1152 64 1152 38 1171 19 1190 0 1216 0L1728 0Q1754 0 1773 19 1792 38 1792 64Z" into mInspectItemPath
 
 	// Make sure all the icons paths are 10 x 10, with centered at the origin
 	put rectangle [-5,-5,5,5] into mIconRect
@@ -268,6 +285,7 @@ public handler OnCreate() returns nothing
 	setIconPath(mIconRect, mUnfoldedArrowPath)
 	setIconPath(mIconRect, mDeleteItemPath)
 	setIconPath(mIconRect, mAddItemPath)
+	setIconPath(mIconRect, mInspectItemPath)
 
 	variable tWidth as Real
 	put the width of mIconRect into mIconWidth
@@ -476,37 +494,39 @@ private handler paintDataItem(in pDataItem as Array, in pTop as Real, in pRow as
 	put tTextBounds into pDataItem["keyRect"]
 
 	add the width of tTextBounds + mMargin to tLeft
-		
+
+    variable tIconStyle
+    put "fill" into tIconStyle
+    if pDataItem["selected"] then
+        put "_selected" after tIconStyle
+    end if
+
+    // Variable to store the icon style in
+    variable tThisIconStyle as String
+
 	// Draw the value if it is a 'leaf' (i.e. if it does not contain a sub-array)
 	if pDataItem["leaf"] then
-        // AL-2015-07-26: [[ Bug 15752 ]] Only draw specified amount of value string
-        variable tValueLength as Number
-        variable tValueDisplay as String
-        put the number of chars in pDataItem["string_value"] into tValueLength
-        if tValueLength <= kMaxValueDisplayChars then
-            put pDataItem["string_value"] into tValueDisplay
-        else
-            put (char 1 to kMaxValueDisplayChars of pDataItem["string_value"]) & "..." into tValueDisplay
-        end if
-
 		set the paint of this canvas to getPaint("text","fill" & tStyle)
-		fill text tValueDisplay at left of rectangle [tLeft, pTop, mViewWidth - 3 * mMargin - 2 * mIconWidth, pTop + mRowHeight] on this canvas
+		fill text pDataItem["display_value"] at left of rectangle [tLeft, pTop, mViewWidth - 3 * mMargin - 2 * mIconWidth, pTop + mRowHeight] on this canvas
+
+        if mReadOnly and pDataItem["need_inspect"] then
+            put tIconStyle into tThisIconStyle
+            if pRow is mHoverRow and mHoverIcon is "inspect" then
+                put "_hover" after tThisIconStyle
+            end if
+            put mInspectItemPath into tPath
+            translate tPath by [mViewWidth - scrollbarWidth() - mMargin - mIconWidth / 2, pTop + mRowHeight / 2]
+            set the paint of this canvas to getPaint("icon", tThisIconStyle)
+            fill tPath on this canvas
+        end if
 	end if
-	
-	// Draw the action icons 
+
+	// Draw the action icons
 	if mReadOnly is false and (pDataItem["selected"] is true or pRow is mHoverRow) then
-		put "fill" into tStyle
-		if pDataItem["selected"] then
-			put "_selected" after tStyle
-		end if
-		
 		variable tRight as Real
 		put mViewWidth - scrollbarWidth() - mMargin into tRight
-		
-		variable tThisIconStyle as String
-		variable tMouseX as Real
-		put the x of the mouse position into tMouseX		
-		put tStyle into tThisIconStyle
+
+		put tIconStyle into tThisIconStyle
 		put mDeleteItemPath into tPath
 		translate tPath by [tRight - mIconWidth / 2, pTop + mRowHeight / 2]
 		if pRow is mHoverRow and mHoverIcon is "delete" then
@@ -517,7 +537,7 @@ private handler paintDataItem(in pDataItem as Array, in pTop as Real, in pRow as
 		
 		subtract mMargin + mIconWidth from tRight
 		
-		put tStyle into tThisIconStyle
+		put tIconStyle into tThisIconStyle
 		put mAddItemPath into tPath
 		translate tPath by [tRight - mIconWidth / 2, pTop + mRowHeight / 2]
 		if pRow is mHoverRow and mHoverIcon is "add" then
@@ -559,7 +579,7 @@ public handler OnMouseMove() returns nothing
         	put "" into mHoverIcon
         else
             variable tHoverIcon as String
-            put xPosToIconString(the x of the mouse position) into tHoverIcon
+            put xPosToIconString(the x of the mouse position, mHoverRow) into tHoverIcon
             if mHoverIcon is not tHoverIcon then
                 put tHoverIcon into mHoverIcon
                 put true into tRedraw
@@ -643,7 +663,12 @@ public handler OnClick() returns nothing
 		addUnderPath(tData["path"])
 		return
 	end if
-	
+
+    if mHoverIcon is "inspect" then
+        post "actionInspect" with tData["path"]
+        return
+    end if
+
 	// Check if the arrow was clicked
 	if not tData["leaf"] then
 		variable tLeft as Real
@@ -692,7 +717,7 @@ private handler yPosToRowNumber(in pYPos as Number) returns Integer
     return tRow
 end handler
 
-private handler xPosToIconString(in pXPos as Number) returns String
+private handler xPosToIconString(in pXPos as Number, in pRow as Number) returns String
     variable tLeft as Real
     variable tRight as Real
     put mViewWidth - scrollbarWidth() into tRight
@@ -701,17 +726,36 @@ private handler xPosToIconString(in pXPos as Number) returns String
     	return ""
     end if
     
-    put tRight - 2 * mMargin - 2 * mIconWidth into tLeft
+    if mReadOnly then
+	    put tRight - mMargin - mIconWidth into tLeft
+	else
+		put tRight - 2 * mMargin - 2 * mIconWidth into tLeft
+	end if
     
     if pXPos <= tLeft then
     	return ""
     end if
 
-    if pXPos > tLeft and pXPos <= tLeft + mIconWidth then
-        return "add"
-    end if
-    
-    return "delete"
+	if not mReadOnly then
+	    if pXPos > tLeft and pXPos <= tLeft + mIconWidth then
+    	    return "add"
+	    end if
+
+		return "delete"
+	end if
+	
+	if pRow is 0 or pRow > mDataCount then
+		return ""
+	end if
+
+	variable tElement as Array
+	put element pRow of mDataList into tElement
+
+	if tElement["leaf"] and tElement["need_inspect"] then
+		return "inspect"
+	end if
+	
+    return ""
 end handler
 
 public handler OnGeometryChanged()
@@ -1059,6 +1103,25 @@ private handler convertArrayToList(in pArray as Array, in pLevel as Integer, in 
 				put "Can't display value" into tString
 			end if	
 			put tString into tElement["string_value"]
+
+            variable tNeedInspect as Boolean
+            put false into tNeedInspect
+            if newline is in tElement["string_value"] then
+                put true into tNeedInspect
+            end if
+
+            // AL-2015-07-26: [[ Bug 15752 ]] Only draw specified amount of value string
+            variable tValueLength as Number
+            put the number of chars in tElement["string_value"] into tValueLength
+            if tValueLength <= kMaxValueDisplayChars then
+                put tElement["string_value"] into tElement["display_value"]
+            else
+                put (char 1 to kMaxValueDisplayChars of tElement["string_value"]) & "..." into tElement["display_value"]
+                put true into tNeedInspect
+            end if
+
+            put tNeedInspect into tElement["need_inspect"]
+
 			push tElement onto tList
 		end if	
 	end repeat


### PR DESCRIPTION
Add an icon to the tree view when the display value is too long, or is multiline.
Post actionInspect message when it is clicked.
Also post actionDoubleClick message when any line is double-clicked.

Marked enhancement, but required along with https://github.com/runrev/livecode-ide/pull/482 to fix but 15884 .
