### PR TITLE
[[ Bug 15345 ]] Fix call to MCContext::setorigin in sprite renderer c…

### DIFF
--- a/docs/notes/bugfix-15345.md
+++ b/docs/notes/bugfix-15345.md
@@ -1,0 +1,1 @@
+# Rendering issues, layout mangled going from LC7 to LC8

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -979,7 +979,7 @@ static bool testtilecache_sprite_renderer(void *p_context, MCContext *p_target, 
 		return true;
 	
 	// IM-2014-07-03: [[ GraphicsPerformance ]] Context origin is the topleft of the sprite so adjust to card coords.
-	p_target -> setorigin(t_control_rect . x, t_control_rect . y);
+	p_target -> setorigin(-t_control_rect . x, -t_control_rect . y);
 	p_target -> cliprect(t_dirty_rect);
 	p_target -> setfunction(GXcopy);
 	p_target -> setopacity(255);


### PR DESCRIPTION
…allback to comply with changed behaviour.
