### PR TITLE
[[ Bug 15897 ]] Ensure LCB widget object is not nil before fetching save state

### DIFF
--- a/docs/notes/bugfix-15897.md
+++ b/docs/notes/bugfix-15897.md
@@ -1,0 +1,1 @@
+# LiveCode crashes when trying to clone a group containing a widget object whose kind is not installed

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -1262,6 +1262,7 @@ bool MCChildWidgetSetDisabled(MCWidgetRef p_widget, bool p_disabled)
 
 MCWidgetBase *MCWidgetAsBase(MCWidgetRef self)
 {
+    MCAssert(self != nil);
     return (MCWidgetBase *)MCValueGetExtraBytesPtr(self);
 }
 

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -737,7 +737,9 @@ MCControl *MCWidget::clone(Boolean p_attach, Object_pos p_position, bool invisib
 		t_new_widget -> attach(p_position, invisible);
     
     MCAutoValueRef t_rep;
-    MCWidgetOnSave(m_widget, &t_rep);
+    // AL-2015-09-08: [[ Bug 15897 ]] Ensure m_widget is not nil before fetching save state
+    if (m_widget != nil)
+        MCWidgetOnSave(m_widget, &t_rep);
     if (*t_rep == nil)
         t_rep = kMCNull;
     


### PR DESCRIPTION
Also add an assert to MCWidgetAsBase.
