### PR TITLE
[[ Bugfix 15814 ]] Port to 7.0

### DIFF
--- a/docs/notes/bugfix-15814.md
+++ b/docs/notes/bugfix-15814.md
@@ -1,0 +1,1 @@
+# Can't read a file using UNC path in Windows

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -3650,13 +3650,67 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 		if (MCStringGetLength(p_path) == 0)
 			return MCS_getcurdir_native(r_resolved_path);
 
-        MCAutoStringRef t_native;
-        MCAutoStringRef t_native_resolved;
-        
-        MCS_pathtonative(p_path, &t_native);
-		MCU_fix_path(*t_native, &t_native_resolved);
-        MCS_pathfromnative(*t_native_resolved, r_resolved_path);
-		return true;
+		MCAutoStringRef t_canonised_path;
+		bool t_success;
+		t_success = true;
+		
+		// Taken from LiveCode 6.7's w32spec.cpp MCS_get_canonical_path
+		// The following rules are used to process paths on Windows:
+		// - an absolute UNIX path is mapped to an absolute windows path using the drive of the CWD:
+		// /foo/bar -> CWD-DRIVE:/foo/bar
+		// - an absolute windows path is left as is:
+		// //foo/bar -> //foo/bar
+		// C:/foo/bar -> C:/foo/bar
+		// - a relative path is prefixed by the CWD:
+		// foo/bar -> CWD/foo/bar
+		// Note: / and \ are treated the same, but not changed. 
+		// Note: When adding a path separator \ is used in LiveCode 7.0
+		// since we are suppose to have a native path as input for MCSystem functions
+
+		// We store the first chars in this static to make the if
+		// statements more readable
+		char_t t_first_chars[2];
+        t_first_chars[0] = MCStringGetNativeCharAtIndex(p_path, 0);
+		t_first_chars[1] = MCStringGetNativeCharAtIndex(p_path, 1);
+
+		if ((t_first_chars[0] == '/' && t_first_chars[1] != '/')
+				|| (t_first_chars[0] == '\\' && t_first_chars[1] != '\\'))
+		{
+			// path in root of current drive
+			MCAutoStringRef t_curdir;
+			if (t_success)
+				t_success = MCS_getcurdir_native(&t_curdir);
+		
+			if (t_success)
+			t_success = MCStringFormat(&t_canonised_path, 
+							"%c:%@", 
+							MCStringGetNativeCharAtIndex(*t_curdir, 0),
+							p_path);
+		}
+		else if ((is_legal_drive(t_first_chars[0]) && t_first_chars[1] == ':')
+				|| (t_first_chars[0] == '/' && t_first_chars[1] == '/')
+				|| (t_first_chars[0] == '\\' && t_first_chars[1] == '\\'))
+		{
+			// absolute path
+			t_canonised_path = p_path;
+		}
+		else
+		{
+			// relative to current folder
+			MCAutoStringRef t_curdir;
+			t_success = MCS_getcurdir_native(&t_curdir);
+
+			if (t_success)
+				t_success = MCStringFormat(&t_canonised_path,
+						   "%@\\%@",
+						   *t_curdir,
+						   p_path);
+		}
+
+		if (t_success)
+			r_resolved_path = MCValueRetain(*t_canonised_path);
+
+		return t_success;
 	}
 	
 	virtual bool LongFilePath(MCStringRef p_path, MCStringRef& r_long_path)

--- a/engine/src/w32spec.cpp
+++ b/engine/src/w32spec.cpp
@@ -459,8 +459,15 @@ char *MCS_get_canonical_path(const char *path)
 	if (path == NULL)
 		return NULL;
 
-	// SN-2015-09-07: [[ Bug 15814 ]] We consider backslashes and slashes the
-	//  same in this context.
+	// The following rules are used to process paths on Windows:
+	// - an absolute UNIX path is mapped to an absolute windows path using the drive of the CWD:
+	// /foo/bar -> CWD-DRIVE:/foo/bar
+	// - an absolute windows path is left as is:
+	// //foo/bar -> //foo/bar
+	// C:/foo/bar -> C:/foo/bar
+	// - a relative path is prefixed by the CWD:
+	// foo/bar -> CWD/foo/bar
+	// Note: / and \ are treated the same, but not changed. When adding a path separator / is used.
 	if ((path[0] == '/' && path[1] != '/')
 			|| (path[0] == '\\' && path[1] != '\\'))
 	{
@@ -475,8 +482,6 @@ char *MCS_get_canonical_path(const char *path)
 		t_path[0] = t_curdir[0]; t_path[1] = ':';
 		strcpy(t_path + 2, path);
 	}
-	// SN-2015-09-03: [[ Bug 15814 ]] UNC paths (such as //servername/path)
-	//  should not be changed, as they are already valid.
 	else if ((is_legal_drive(path[0]) && path[1] == ':')
 			|| (path[0] == '/' && path[1] == '/')
 			|| (path[0] == '\\' && path[1] == '\\'))

--- a/engine/src/w32spec.cpp
+++ b/engine/src/w32spec.cpp
@@ -475,15 +475,16 @@ char *MCS_get_canonical_path(const char *path)
 		t_path[0] = t_curdir[0]; t_path[1] = ':';
 		strcpy(t_path + 2, path);
 	}
-	else if (is_legal_drive(path[0]) && path[1] == ':')
+	// SN-2015-09-03: [[ Bug 15814 ]] UNC paths (such as //servername/path)
+	//  should not be changed, as they are already valid.
+	else if ((is_legal_drive(path[0]) && path[1] == ':')
+			|| (path[0] == '/' && path[1] == '/')
+			|| (path[0] == '\\' && path[1] == '\\'))
 	{
 		// absolute path
 		t_path = strclone(path);
 	}
-	// SN-2015-09-03: [[ Bug 15814 ]] UNC paths (such as //servername/path)
-	//  should not be changed, as they are already valid.
-	else if ((path[0] != '/' && path[1] != '/')
-			|| (path[0] != '\\' && path[1] != '\\'))
+	else
 	{
 		// relative to current folder
 		t_curdir = MCS_getcurdir();
@@ -501,8 +502,6 @@ char *MCS_get_canonical_path(const char *path)
 		t_path[t_curdir_len] = '/';
 		memcpy(t_path + t_curdir_len + 1, path, t_path_len + 1);
 	}
-	else
-		t_path = strclone(t_path);
 
 	MCU_fix_path(t_path);
 	return t_path;

--- a/engine/src/w32spec.cpp
+++ b/engine/src/w32spec.cpp
@@ -98,59 +98,10 @@ void MCS_loadfile(MCExecPoint &ep, Boolean binary)
 #ifdef /* MCS_savefile_dsk_w32 */ LEGACY_SYSTEM
 void MCS_savefile(const MCString &fname, MCExecPoint &data, Boolean binary)
 {
-	char *t_path = NULL;
-	char *t_curdir = NULL;
-
-	if (path == NULL)
-		return NULL;
-
-	// The following rules are used to process paths on Windows:
-	// - an absolute UNIX path is mapped to an absolute windows path using the drive of the CWD:
-	// /foo/bar -> CWD-DRIVE:/foo/bar
-	// - an absolute windows path is left as is:
-	// //foo/bar -> //foo/bar
-	// C:/foo/bar -> C:/foo/bar
-	// - a relative path is prefixed by the CWD:
-	// foo/bar -> CWD/foo/bar
-	// Note: / and \ are treated the same, but not changed. When adding a path separator / is used.
-	if ((path[0] == '/' && path[1] != '/')
-			|| (path[0] == '\\' && path[1] != '\\'))
+	if (!MCSecureModeCanAccessDisk())
 	{
-		// path in root of current drive
-		t_curdir = MCS_getcurdir();
-
-		int t_path_len;
-		t_path_len = strlen(path);
-		
-		// We append CWD and a colon to the path: length + 2
-		t_path = (char*)malloc(2 + t_path_len + 1);
-		t_path[0] = t_curdir[0]; t_path[1] = ':';
-		strcpy(t_path + 2, path);
-	}
-	else if ((is_legal_drive(path[0]) && path[1] == ':')
-			|| (path[0] == '/' && path[1] == '/')
-			|| (path[0] == '\\' && path[1] == '\\'))
-	{
-		// absolute path
-		t_path = strclone(path);
-	}
-	else
-	{
-		// relative to current folder
-		t_curdir = MCS_getcurdir();
-		int t_curdir_len;
-		t_curdir_len = strlen(t_curdir);
-
-		while (t_curdir_len > 0 && t_curdir[t_curdir_len - 1] == '/')
-			t_curdir_len--;
-
-		int t_path_len;
-		t_path_len = strlen(path);
-
-		t_path = (char*)malloc(t_curdir_len + 1 + t_path_len + 1);
-		memcpy(t_path, t_curdir, t_curdir_len);
-		t_path[t_curdir_len] = '/';
-		memcpy(t_path + t_curdir_len + 1, path, t_path_len + 1);
+		MCresult->sets("can't open file");
+		return;
 	}
 
 	char *tpath = fname.clone();

--- a/engine/src/w32spec.cpp
+++ b/engine/src/w32spec.cpp
@@ -481,7 +481,9 @@ char *MCS_get_canonical_path(const char *path)
 		// absolute path
 		t_path = strclone(path);
 	}
-	else
+	// SN-2015-09-03: [[ Bug 15814 ]] UNC paths (such as //servername/path)
+	//  should not be changed, as they are already valid.
+	else if (path[0] != '/' && path[1] != '/')
 	{
 		// relative to current folder
 		t_curdir = MCS_getcurdir();

--- a/engine/src/w32spec.cpp
+++ b/engine/src/w32spec.cpp
@@ -455,35 +455,52 @@ char *MCS_get_canonical_path(const char *path)
 {
 	char *t_path = NULL;
 	char *t_curdir = NULL;
+	char *t_livecode_path = NULL;
+	char *t_livecode_path_start;
 
 	if (path == NULL)
 		return NULL;
+	
+	// SN-2015-09-04: [[ Bug 15814 ]] Backslashes are not valid filename chars
+	//  on Windows, so we can accept Windows paths using backslashes (for the 
+	//  people who are still using them in LiveCode scripts).
+	bool t_use_backslashes;
+	t_use_backslashes = false;
+	uint4 i = 0;
+	while (path[i] != NULL && !t_use_backslashes)
+		t_use_backslashes = path[i++] == '\\';
+	
+	t_livecode_path = strclone(path);
+	t_livecode_path_start = t_livecode_path;
 
-	if (path[0] == '/' && path[1] != '/')
+	if (t_use_backslashes)
+		MCU_path2native(t_livecode_path);
+
+	if (t_livecode_path[0] == '/' && t_livecode_path[1] != '/')
 	{
 		// path in root of current drive
 		t_curdir = MCS_getcurdir();
 
 		int t_path_len;
 		t_path_len = strlen(path);
-		while (path[0] == '/')
+		while (t_livecode_path[0] == '/')
 		{
-			path ++;
+			t_livecode_path ++;
 			t_path_len --;
 		}
 		
 		t_path = (char*)malloc(3 + t_path_len + 1);
 		t_path[0] = t_curdir[0]; t_path[1] = ':'; t_path[2] = '/';
-		strcpy(t_path + 3, path);
+		strcpy(t_path + 3, t_livecode_path);
 	}
-	else if (is_legal_drive(path[0]) && path[1] == ':')
+	else if (is_legal_drive(t_livecode_path[0]) && t_livecode_path[1] == ':')
 	{
 		// absolute path
-		t_path = strclone(path);
+		t_path = strclone(t_livecode_path);
 	}
 	// SN-2015-09-03: [[ Bug 15814 ]] UNC paths (such as //servername/path)
 	//  should not be changed, as they are already valid.
-	else if (path[0] != '/' && path[1] != '/')
+	else if (t_livecode_path[0] != '/' && t_livecode_path[1] != '/')
 	{
 		// relative to current folder
 		t_curdir = MCS_getcurdir();
@@ -496,9 +513,9 @@ char *MCS_get_canonical_path(const char *path)
 		int t_path_len;
 		t_path_len = strlen(path);
 
-		while (t_path_len > 0 && path[0] == '/')
+		while (t_path_len > 0 && t_livecode_path[0] == '/')
 		{
-			path ++;
+			t_livecode_path ++;
 			t_path_len --;
 		}
 
@@ -507,8 +524,17 @@ char *MCS_get_canonical_path(const char *path)
 		t_path[t_curdir_len] = '/';
 		memcpy(t_path + t_curdir_len + 1, path, t_path_len + 1);
 	}
+	else
+		t_path = strclone(t_livecode_path);
 
 	MCU_fix_path(t_path);
+
+	// SN-2015-09-04: [[ Bug 15814]] Reinstate the backslashes if needed
+	if (t_use_backslashes)
+		MCU_path2std(t_path);
+
+	delete t_livecode_path_start;
+
 	return t_path;
 }
 


### PR DESCRIPTION
Now, `MCWindowsDesktop::ResolvePath` also returns an absolute path, as `MCLinuxDesktop` and `MCMacDesktop` do.
One change only from the fix in 6.7: in 7.0, the paths given to `MCSystemInterface` functions are
always native, so when needed, `ResolvePath` will add `\`, not `/` as it does in 6.7
