### PR TITLE
lc-compile: Make autogenerated functions return void.

### DIFF
--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -353,7 +353,7 @@ void EmitFinish(void)
             if (__FindEmittedModule(s_ordered_modules[i], t_module))
             {
                 if (fprintf(s_output_code_file,
-                            "extern int %s_Finalize(void);\n",
+                            "extern void %s_Finalize(void);\n",
                             t_module -> modified_name) < 0)
                     goto error_cleanup;
             }


### PR DESCRIPTION
This removes a large number of compilation warnings for Emscripten
builds with `-s LINKABLE=1`.
