### PR TITLE
[emscripten] Avoid calling `fsync()` in order to prevent crash.

### DIFF
--- a/engine/src/em-filehandle.cpp
+++ b/engine/src/em-filehandle.cpp
@@ -274,8 +274,9 @@ MCEmscriptenFileHandle::Truncate()
 bool
 MCEmscriptenFileHandle::Sync()
 {
-	errno = 0;
-	return (0 == fsync(m_fd));
+	/* Assume that the filesystem is fully in-memory and therefore fsync()
+	 * is meaningless! */
+	return true;
 }
 
 bool


### PR DESCRIPTION
`fsync(2)` may pause when running under Emterpreter.  This causes a
crash because `MCEmscriptenFileHandle::Sync()` isn't compiled with
Emterpreter.

It's also probably unnecessary to call `fsync(2)` anyway; the
Emscripten filesystem is fully in-memory.
