### PR TITLE
LCB: "foreign type" declarations bind to functions, not variables.

### DIFF
--- a/engine/src/canvas.mlc
+++ b/engine/src/canvas.mlc
@@ -25,44 +25,44 @@ use com.livecode.foreign
 public type CanvasFloat is CFloat
 
 // Point
-public foreign type Point binds to "kMCCanvasPointTypeInfo"
+public foreign type Point binds to "MCCanvasPointTypeInfo"
 
 // Rectangle
-public foreign type Rectangle binds to "kMCCanvasRectangleTypeInfo"
+public foreign type Rectangle binds to "MCCanvasRectangleTypeInfo"
 
 // Transform
-public foreign type Transform binds to "kMCCanvasTransformTypeInfo"
+public foreign type Transform binds to "MCCanvasTransformTypeInfo"
 
 // Color
-public foreign type Color binds to "kMCCanvasColorTypeInfo"
+public foreign type Color binds to "MCCanvasColorTypeInfo"
 
 // Paint (supertype of pattern, gradient, solidpaint)
-public foreign type Paint binds to "kMCCanvasPaintTypeInfo"
+public foreign type Paint binds to "MCCanvasPaintTypeInfo"
 
 // Solid Paint
-public foreign type SolidPaint binds to "kMCCanvasSolidPaintTypeInfo"
+public foreign type SolidPaint binds to "MCCanvasSolidPaintTypeInfo"
 
 // Pattern
-public foreign type Pattern binds to "kMCCanvasPatternTypeInfo"
+public foreign type Pattern binds to "MCCanvasPatternTypeInfo"
 
 // Gradient
-public foreign type Gradient binds to "kMCCanvasGradientTypeInfo"
-public foreign type GradientStop binds to "kMCCanvasGradientStopTypeInfo"
+public foreign type Gradient binds to "MCCanvasGradientTypeInfo"
+public foreign type GradientStop binds to "MCCanvasGradientStopTypeInfo"
 
 // Image
-public foreign type Image binds to "kMCCanvasImageTypeInfo"
+public foreign type Image binds to "MCCanvasImageTypeInfo"
 
 // Path
-public foreign type Path binds to "kMCCanvasPathTypeInfo"
+public foreign type Path binds to "MCCanvasPathTypeInfo"
 
 // Effect
-public foreign type Effect binds to "kMCCanvasEffectTypeInfo"
+public foreign type Effect binds to "MCCanvasEffectTypeInfo"
 
 // Font
-public foreign type Font binds to "kMCCanvasFontTypeInfo"
+public foreign type Font binds to "MCCanvasFontTypeInfo"
 
 // Canvas
-public foreign type Canvas binds to "kMCCanvasTypeInfo"
+public foreign type Canvas binds to "MCCanvasTypeInfo"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Rectangle

--- a/engine/src/engine.mlc
+++ b/engine/src/engine.mlc
@@ -37,7 +37,7 @@ module com.livecode.engine
 
 use com.livecode.foreign
 
-public foreign type ScriptObject binds to "kMCEngineScriptObjectTypeInfo"
+public foreign type ScriptObject binds to "MCEngineScriptObjectTypeInfo"
 
 public foreign handler MCEngineExecResolveScriptObject(in pObjectId as String) returns ScriptObject binds to "<builtin>"
 public foreign handler MCEngineEvalScriptObjectExists(in pObject as ScriptObject, out rExists as CBool) returns nothing binds to "<builtin>"

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -432,6 +432,22 @@ MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasEffectTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasFontTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasTypeInfo;
 
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasRectangleTypeInfo(void) { return kMCCanvasRectangleTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasPointTypeInfo(void) { return kMCCanvasPointTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasColorTypeInfo(void) { return kMCCanvasColorTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasTransformTypeInfo(void) { return kMCCanvasTransformTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasImageTypeInfo(void) { return kMCCanvasImageTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasPaintTypeInfo(void) { return kMCCanvasPaintTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasSolidPaintTypeInfo(void) { return kMCCanvasSolidPaintTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasPatternTypeInfo(void) { return kMCCanvasPatternTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasGradientTypeInfo(void) { return kMCCanvasGradientTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasGradientStopTypeInfo(void) { return kMCCanvasGradientStopTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasPathTypeInfo(void) { return kMCCanvasPathTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasEffectTypeInfo(void) { return kMCCanvasEffectTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasFontTypeInfo(void) { return kMCCanvasFontTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCCanvasTypeInfo(void) { return kMCCanvasTypeInfo; }
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // Error types

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -52,6 +52,9 @@ struct __MCScriptObjectImpl
 
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCEngineScriptObjectTypeInfo;
 
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCEngineScriptObjectTypeInfo()
+{ return kMCEngineScriptObjectTypeInfo; }
+
 ////////////////////////////////////////////////////////////////////////////////
 
 static bool s_last_message_was_handled = false;

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -690,6 +690,9 @@ MC_DLLEXPORT_DEF MCTypeInfoRef kMCWidgetNoCurrentWidgetErrorTypeInfo = nil;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCWidgetSizeFormatErrorTypeInfo = nil;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCWidgetTypeInfo = nil;
 
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCWidgetTypeInfo()
+{ return kMCWidgetTypeInfo; }
+
 bool com_livecode_widget_InitializePopups(void);
 void com_livecode_widget_FinalizePopups(void);
 

--- a/engine/src/widget.mlc
+++ b/engine/src/widget.mlc
@@ -586,7 +586,7 @@ end syntax
 
 // ---------- Synchronous and asynchronous ("current") event information ---------- //
 
-//foreign type PressedState binds to "kMCPressedState"
+//foreign type PressedState binds to "MCPressedState"
 
 public foreign handler MCWidgetGetMousePosition(in pCurrent as CBool, out rLocation as Point) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetClickPosition(in pCurrent as CBool, out rLocation as Point) returns nothing binds to "<builtin>"
@@ -969,7 +969,7 @@ end syntax
 
 // annotation <name> of <widget>
 
-public foreign type Widget binds to "kMCWidgetTypeInfo"
+public foreign type Widget binds to "MCWidgetTypeInfo"
 
 public foreign handler MCWidgetEvalTheTarget(out rTarget as optional Widget) returns nothing binds to "<builtin>"
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -380,9 +380,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #if defined(__GNUC__) || defined (__clang__) || defined (__llvm__)
 #  define ATTRIBUTE_NORETURN  __attribute__((__noreturn__))
 #  define ATTRIBUTE_UNUSED __attribute__((__unused__))
+#  define ATTRIBUTE_PURE __attribute__((__pure__))
 #else
 #  define ATTRIBUTE_NORETURN
 #  define ATTRIBUTE_UNUSED
+#  define ATTRIBUTE_PURE
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1440,6 +1442,8 @@ extern "C" {
 // The 'any' type is essentially a union of all typeinfos.
 MC_DLLEXPORT extern MCTypeInfoRef kMCAnyTypeInfo;
 
+MC_DLLEXPORT MCTypeInfoRef MCAnyTypeInfo(void) ATTRIBUTE_PURE;
+
 // These are typeinfos for all the 'builtin' valueref types.
 MC_DLLEXPORT extern MCTypeInfoRef kMCNullTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCBooleanTypeInfo;
@@ -1452,6 +1456,17 @@ MC_DLLEXPORT extern MCTypeInfoRef kMCSetTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCListTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCProperListTypeInfo;
 
+MC_DLLEXPORT MCTypeInfoRef MCNullTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCBooleanTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCNumberTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCStringTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCNameTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCDataTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCArrayTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCSetTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCListTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCProperListTypeInfo(void) ATTRIBUTE_PURE;
+
 MC_DLLEXPORT extern MCTypeInfoRef kMCBoolTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCIntTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCUIntTypeInfo;
@@ -1459,8 +1474,18 @@ MC_DLLEXPORT extern MCTypeInfoRef kMCFloatTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCDoubleTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCPointerTypeInfo;
 
+MC_DLLEXPORT MCTypeInfoRef MCForeignBoolTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUIntTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignIntTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignFloatTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignDoubleTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignPointerTypeInfo(void) ATTRIBUTE_PURE;
+
 MC_DLLEXPORT extern MCTypeInfoRef kMCSizeTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCSSizeTypeInfo;
+
+MC_DLLEXPORT MCTypeInfoRef MCForeignSizeTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSSizeTypeInfo(void) ATTRIBUTE_PURE;
 
 //////////
 

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -35,6 +35,17 @@ MCTypeInfoRef kMCForeignExportErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignBoolTypeInfo() { return kMCBoolTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUIntTypeInfo() { return kMCUIntTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignIntTypeInfo() { return kMCIntTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignFloatTypeInfo() { return kMCFloatTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignDoubleTypeInfo() { return kMCDoubleTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignPointerTypeInfo() { return kMCPointerTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSizeTypeInfo() { return kMCSizeTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSSizeTypeInfo() { return kMCSSizeTypeInfo; }
+
+////////////////////////////////////////////////////////////////////////////////
+
 MC_DLLEXPORT_DEF
 bool MCForeignValueCreate(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignValueRef& r_value)
 {

--- a/libfoundation/src/foundation-stream.cpp
+++ b/libfoundation/src/foundation-stream.cpp
@@ -28,6 +28,8 @@ struct __MCStreamImpl
 
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCStreamTypeInfo;
 
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCStreamTypeInfo() { return kMCStreamTypeInfo; }
+
 static inline __MCStreamImpl &__MCStreamGet(MCStreamRef p_stream)
 {
 	return *(__MCStreamImpl*)MCValueGetExtraBytesPtr(p_stream);

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -35,6 +35,18 @@ MC_DLLEXPORT_DEF MCTypeInfoRef kMCSetTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCListTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCProperListTypeInfo;
 
+MC_DLLEXPORT_DEF MCTypeInfoRef MCAnyTypeInfo() { return kMCAnyTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCNullTypeInfo() { return kMCNullTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCBooleanTypeInfo() { return kMCBooleanTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCNumberTypeInfo() { return kMCNumberTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCStringTypeInfo() { return kMCStringTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCNameTypeInfo() { return kMCNameTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCDataTypeInfo() { return kMCDataTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCArrayTypeInfo() { return kMCArrayTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCSetTypeInfo() { return kMCSetTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCListTypeInfo() { return kMCListTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCProperListTypeInfo() { return kMCProperListTypeInfo; }
+
 ////////////////////////////////////////////////////////////////////////////////
 
 static bool __MCTypeInfoIsNamed(MCTypeInfoRef self);

--- a/libscript/src/foreign.mlc
+++ b/libscript/src/foreign.mlc
@@ -20,22 +20,22 @@ module com.livecode.foreign
 -- Universal types
 ----------------------------------------------------------------
 
-public foreign type Pointer binds to "kMCPointerTypeInfo"
+public foreign type Pointer binds to "MCForeignPointerTypeInfo"
 
-public foreign type UInt32 binds to "kMCUIntTypeInfo"
-public foreign type Int32 binds to "kMCIntTypeInfo"
+public foreign type UInt32 binds to "MCForeignUIntTypeInfo"
+public foreign type Int32 binds to "MCForeignIntTypeInfo"
 
-public foreign type UIntSize binds to "kMCSizeTypeInfo"
-public foreign type IntSize binds to "kMCSSizeTypeInfo"
+public foreign type UIntSize binds to "MCForeignSizeTypeInfo"
+public foreign type IntSize binds to "MCForeignSSizeTypeInfo"
 
-public foreign type Float32 binds to "kMCFloatTypeInfo"
-public foreign type Float64 binds to "kMCDoubleTypeInfo"
+public foreign type Float32 binds to "MCForeignFloatTypeInfo"
+public foreign type Float64 binds to "MCForeignDoubleTypeInfo"
 
 ----------------------------------------------------------------
 -- C types
 ----------------------------------------------------------------
 
-public foreign type CBool binds to "kMCBoolTypeInfo"
+public foreign type CBool binds to "MCForeignBoolTypeInfo"
 public type CInt is Int32
 public type CUInt is UInt32
 public type CFloat is Float32
@@ -54,7 +54,7 @@ public type LCUIndex is UInt32
 -- Nul-terminated string pointer types
 ----------------------------------------------------------------
 
-public foreign type ZStringNative binds to "kMCNativeCStringTypeInfo"
-public foreign type ZStringUTF16 binds to "kMCWStringTypeInfo"
+public foreign type ZStringNative binds to "MCNativeCStringTypeInfo"
+public foreign type ZStringUTF16 binds to "MCWStringTypeInfo"
 
 end module

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -22,11 +22,11 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C"
-{
-    MC_DLLEXPORT_DEF MCTypeInfoRef kMCNativeCStringTypeInfo;
-	MC_DLLEXPORT_DEF MCTypeInfoRef kMCWStringTypeInfo;
-}
+MCTypeInfoRef kMCNativeCStringTypeInfo;
+MCTypeInfoRef kMCWStringTypeInfo;
+
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCNativeCStringTypeInfo(void) { return kMCNativeCStringTypeInfo; }
+extern "C" MC_DLLEXPORT_DEF MCTypeInfoRef MCWStringTypeInfo(void) { return kMCWStringTypeInfo; }
 
 MCTypeInfoRef kMCForeignZStringNullErrorTypeInfo;
 

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -752,8 +752,10 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                                                    nil);
 					goto error_cleanup;
                 }
-                
-                t_typeinfo = MCValueRetain(*(MCTypeInfoRef *)t_symbol);
+
+                /* The symbol is a function that returns a type info reference. */
+                MCTypeInfoRef (*t_type_func)(void) = (MCTypeInfoRef (*)(void)) t_symbol;
+                t_typeinfo = MCValueRetain(t_type_func());
             }
             break;
             case kMCScriptTypeKindRecord:

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -91,44 +91,44 @@ bool MCScriptInitialize(void)
         uindex_t t_def_index, t_type_index;
             
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCAnyTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCAnyTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("any"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_null_type_index;
         MCScriptAddDefinitionToModule(t_builder, t_null_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCNullTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCNullTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("undefined"), t_type_index, t_null_type_index);
         MCScriptAddExportToModule(t_builder, t_null_type_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCBooleanTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCBooleanTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("boolean"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCNumberTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCNumberTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("number"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_string_type_index;
         MCScriptAddDefinitionToModule(t_builder, t_string_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCStringTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCStringTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("string"), t_type_index, t_string_type_index);
         MCScriptAddExportToModule(t_builder, t_string_type_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCDataTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCDataTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("data"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCArrayTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCArrayTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("array"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCProperListTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCProperListTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("list"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
@@ -136,34 +136,34 @@ bool MCScriptInitialize(void)
         
         uindex_t t_bool_type_index;
         MCScriptAddDefinitionToModule(t_builder, t_bool_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCBoolTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignBoolTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("bool"), t_type_index, t_bool_type_index);
         MCScriptAddExportToModule(t_builder, t_bool_type_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCIntTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignIntTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("int"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_uint_type_index;
         MCScriptAddDefinitionToModule(t_builder, t_uint_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCUIntTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignUIntTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("uint"), t_type_index, t_uint_type_index);
         MCScriptAddExportToModule(t_builder, t_uint_type_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCFloatTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignFloatTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("float"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_double_type_index;
         MCScriptAddDefinitionToModule(t_builder, t_double_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCDoubleTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignDoubleTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("double"), t_type_index, t_double_type_index);
         MCScriptAddExportToModule(t_builder, t_double_type_index);
         
         MCScriptAddDefinitionToModule(t_builder, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("kMCPointerTypeInfo"), t_type_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignPointerTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("pointer"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         

--- a/libscript/src/stream.mlc
+++ b/libscript/src/stream.mlc
@@ -22,7 +22,7 @@ stream input and output operations in modular LiveCode.
 
 module com.livecode.stream
 
-public foreign type Stream binds to "kMCStreamTypeInfo"
+public foreign type Stream binds to "MCStreamTypeInfo"
 
 --
 


### PR DESCRIPTION
Change the meaning of the `foreign type <Name> binds to "<Symbol>"`
syntax.  `<Symbol>` is now expected to refer to a function with the
signature `MCTypeInfoRef (*)(void)`, which returns a type info
pointer.

This is required for platforms which can only dynamically resolve symbols
referring to functions, such as Emscripten.
