### PR TITLE
Precisely preserve the timestamps when stripping debugging symbols

### DIFF
--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -16,16 +16,23 @@ function extract_linux_or_android {
 for input in $@ ; do
 	output="${input}${suffix}"	
 
+  # The --preserver-dates flag for strip and objcopy only has whole
+  # second resolution, so copy the timestamps to a separate file instead
+  cp --attributes-only --preserve=timestamps "$input" "$input.timestamps"
+
 	# Extract a copy of the debugging information
 	$OBJCOPY --only-keep-debug "$input" "$output" 
 	
 	# Because we export symbols from the engine, only debug symbols
 	# should be stripped.
-	$STRIP -x --preserve-dates --strip-debug "$input"
+	$STRIP -x --strip-debug "$input"
 	
 	# Add a hint for the debugger so it can find the debug info
-	$OBJCOPY --preserve-dates --remove-section=.gnu_debuglink "$input"
-	$OBJCOPY --preserve-dates --add-gnu-debuglink="$output" "$input"
+	$OBJCOPY --remove-section=.gnu_debuglink "$input"
+	$OBJCOPY --add-gnu-debuglink="$output" "$input"
+
+  cp --attributes-only --preserve=timestamps "$input.timestamps" "$input"
+  rm "$input.attributes"
 done
 
 }

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -18,7 +18,7 @@ for input in $@ ; do
 
   # The --preserver-dates flag for strip and objcopy only has whole
   # second resolution, so copy the timestamps to a separate file instead
-  cp --attributes-only --preserve=timestamps "$input" "$input.timestamps"
+  cp --attributes-only --preserve=timestamps "$input" "$input.timestamps" 2>&1 || true
 
 	# Extract a copy of the debugging information
 	$OBJCOPY --only-keep-debug "$input" "$output" 
@@ -31,8 +31,8 @@ for input in $@ ; do
 	$OBJCOPY --remove-section=.gnu_debuglink "$input"
 	$OBJCOPY --add-gnu-debuglink="$output" "$input"
 
-  cp --attributes-only --preserve=timestamps "$input.timestamps" "$input"
-  rm "$input.timestamps"
+  cp --attributes-only --preserve=timestamps "$input.timestamps" "$input" 2>&1 || true
+  rm "$input.timestamps" 2>&1 || true
 done
 
 }

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -32,7 +32,7 @@ for input in $@ ; do
 	$OBJCOPY --add-gnu-debuglink="$output" "$input"
 
   cp --attributes-only --preserve=timestamps "$input.timestamps" "$input"
-  rm "$input.attributes"
+  rm "$input.timestamps"
 done
 
 }

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -16,11 +16,10 @@ function extract_linux_or_android {
 for input in "$@" ; do
 	output="${input}${suffix}"
 
-	# The --preserve-dates flag for strip and objcopy only has
-	# whole second resolution, so move to a new file and copy to
-	# preserve the timestamps
-	mv "$input" "$input.timestamps"
-	cp "$input.timestamps" "$input"
+	# The --preserve-dates flag for strip and objcopy only has whole
+	# second resolution, so save the timestamps in a separate file
+	# instead.
+	touch -m -r "$input" "$input.timestamps"
 
 	# Extract a copy of the debugging information
 	$OBJCOPY --only-keep-debug "$input" "$output" 

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -13,12 +13,14 @@ STRIP="${STRIP:-strip}"
 
 function extract_linux_or_android {
 
-for input in $@ ; do
-	output="${input}${suffix}"	
+for input in "$@" ; do
+	output="${input}${suffix}"
 
-  # The --preserver-dates flag for strip and objcopy only has whole
-  # second resolution, so copy the timestamps to a separate file instead
-  cp --attributes-only --preserve=timestamps "$input" "$input.timestamps" 2>&1 || true
+	# The --preserve-dates flag for strip and objcopy only has
+	# whole second resolution, so move to a new file and copy to
+	# preserve the timestamps
+	mv "$input" "$input.timestamps"
+	cp "$input.timestamps" "$input"
 
 	# Extract a copy of the debugging information
 	$OBJCOPY --only-keep-debug "$input" "$output" 
@@ -31,15 +33,16 @@ for input in $@ ; do
 	$OBJCOPY --remove-section=.gnu_debuglink "$input"
 	$OBJCOPY --add-gnu-debuglink="$output" "$input"
 
-  cp --attributes-only --preserve=timestamps "$input.timestamps" "$input" 2>&1 || true
-  rm "$input.timestamps" 2>&1 || true
+	# Restore the original modification time
+	touch -m -r "$input.timestamps" "$input"
+	rm "$input.timestamps" 2>&1
 done
 
 }
 
 function extract_emscripten {
 
-for input in $@ ; do
+for input in "$@" ; do
 	touch "${input}${suffix}"
 done
 
@@ -47,7 +50,7 @@ done
 
 function extract_mac_or_ios {
 
-for input in $@ ; do
+for input in "$@" ; do
 	output="${input}${suffix}"
 
 	# If this is an app bundle, find the executable name

--- a/util/build-extensions.sh
+++ b/util/build-extensions.sh
@@ -44,9 +44,5 @@ build_order=$(${lc_compile} --modulepath ${module_dir} --deps changed-order -- $
 
 # Loop over the extensions that need to be (re-)built
 for ext in ${build_order} ; do
-	# Create the output directory
-	mkdir -p "${destination_dir}"/com.livecode.extensions.livecode.$(basename -s .lcb "${ext}")
-	
-	# Build this extension
 	build_widget $(dirname "${ext}") "${destination_dir}" "${module_dir}" "${lc_compile}"
 done


### PR DESCRIPTION
This is an update to #2642.

On Debian Wheezy the `cp --attributes-only --preserve=timestamps` command was emptying the contents of the destination.  I've changed it to using `mv` and `touch` instead.  This should now work on Squeeze, so it no longer has to ignore any failures.

I also removed an unnecessary `mkdir` from `util/build-extensions.sh`.  This line was causing an error as `basename` doesn't have an `-s` flag on Debian Wheezy.
