### PR TITLE
[[ Bug 15948 ]] Iterate through a copy of the destination array in MCArraysDoIntersect()

### DIFF
--- a/docs/notes/bugfix-15948.md
+++ b/docs/notes/bugfix-15948.md
@@ -1,0 +1,1 @@
+# Array intersect is completely wrong in LC 7

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -606,7 +606,7 @@ void MCArraysDoIntersect(MCExecContext& ctxt, MCArrayRef p_dst_array, MCArrayRef
 	MCNameRef t_key;
 	MCValueRef t_src_value;
     MCValueRef t_dst_value;
-    MCArrayRef p_orig_array;
+    MCArrayRef t_orig_dst_array;
 	uintptr_t t_iterator;
 	t_iterator = 0;
     
@@ -616,13 +616,13 @@ void MCArraysDoIntersect(MCExecContext& ctxt, MCArrayRef p_dst_array, MCArrayRef
     // the copy so that we are not removing values from the same array.  Otherwise
     // the array may be rehashed during the MCArrayRemoveValue() call and break the
     // iteration sequence.
-    if (!MCArrayMutableCopy(p_dst_array, p_orig_array)) {
+    if (!MCArrayCopy(p_dst_array, t_orig_dst_array)) {
         return;
     }
     
     // Loop through the copy of the array, not the one that we will be removing entries
     // from.
-    while(MCArrayIterate(p_orig_array, t_iterator, t_key, t_dst_value))
+    while(MCArrayIterate(t_orig_dst_array, t_iterator, t_key, t_dst_value))
 	{
 		if (MCArrayFetchValue(p_src_array, ctxt . GetCaseSensitive(), t_key, t_src_value))
         {

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -606,12 +606,23 @@ void MCArraysDoIntersect(MCExecContext& ctxt, MCArrayRef p_dst_array, MCArrayRef
 	MCNameRef t_key;
 	MCValueRef t_src_value;
     MCValueRef t_dst_value;
+    MCArrayRef p_orig_array;
 	uintptr_t t_iterator;
 	t_iterator = 0;
     
     bool t_is_array;
     
-	while(MCArrayIterate(p_dst_array, t_iterator, t_key, t_dst_value))
+    // TS-2015-19-18: [[ Bug 15948 ]] Take a copy of p_dst_array and iterate through
+    // the copy so that we are not removing values from the same array.  Otherwise
+    // the array may be rehashed during the MCArrayRemoveValue() call and break the
+    // iteration sequence.
+    if (!MCArrayMutableCopy(p_dst_array, p_orig_array)) {
+        return;
+    }
+    
+    // Loop through the copy of the array, not the one that we will be removing entries
+    // from.
+    while(MCArrayIterate(p_orig_array, t_iterator, t_key, t_dst_value))
 	{
 		if (MCArrayFetchValue(p_src_array, ctxt . GetCaseSensitive(), t_key, t_src_value))
         {

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -606,7 +606,7 @@ void MCArraysDoIntersect(MCExecContext& ctxt, MCArrayRef p_dst_array, MCArrayRef
 	MCNameRef t_key;
 	MCValueRef t_src_value;
     MCValueRef t_dst_value;
-    MCArrayRef t_orig_dst_array;
+    MCAutoArrayRef t_orig_dst_array;
 	uintptr_t t_iterator;
 	t_iterator = 0;
     
@@ -616,13 +616,13 @@ void MCArraysDoIntersect(MCExecContext& ctxt, MCArrayRef p_dst_array, MCArrayRef
     // the copy so that we are not removing values from the same array.  Otherwise
     // the array may be rehashed during the MCArrayRemoveValue() call and break the
     // iteration sequence.
-    if (!MCArrayCopy(p_dst_array, t_orig_dst_array)) {
+    if (!MCArrayCopy(p_dst_array, &t_orig_dst_array)) {
         return;
     }
     
     // Loop through the copy of the array, not the one that we will be removing entries
     // from.
-    while(MCArrayIterate(t_orig_dst_array, t_iterator, t_key, t_dst_value))
+    while(MCArrayIterate(*t_orig_dst_array, t_iterator, t_key, t_dst_value))
 	{
 		if (MCArrayFetchValue(p_src_array, ctxt . GetCaseSensitive(), t_key, t_src_value))
         {


### PR DESCRIPTION
Iterate through a copy of the destination array as removing values from an array can caused it to be rehashed during key deletion, breaking the iteration loop.
