### PR TITLE
[[ Bug 15946 ]] Reinstate array building of CGI control value (POST a…

### DIFF
--- a/docs/notes/bugfix-15946.md
+++ b/docs/notes/bugfix-15946.md
@@ -1,0 +1,1 @@
+# $_POST_RAW key value pairs used for form checkboxes are not converted to arrays in $_POST


### PR DESCRIPTION
…nd GET)

The arrays can contain subkeys, and taking this into consideration got removed during the refactoring.
