### PR TITLE
[[ Bug 15979 ]]  Call close() instead of orderOut() to ensure the correct closure of iconified windows on OS X.

### DIFF
--- a/docs/notes/buxfix-15979.md
+++ b/docs/notes/buxfix-15979.md
@@ -1,0 +1,1 @@
+# Can't properly close a stack that is minimised on OS X

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -2051,7 +2051,10 @@ void MCMacPlatformWindow::DoHide(void)
 		if ([m_window_handle parentWindow] != nil)
 			[[m_window_handle parentWindow] removeChildWindow: m_window_handle];
 	
-		[m_window_handle orderOut: nil];
+		// CW-2015-09-21: [[ Bug 15979 ]] Call close instead of orderOut here to properly close
+		// windows that have been iconified.
+		[m_window_handle setReleasedWhenClosed: NO];
+		[m_window_handle close];
 	}
 	
 	MCMacPlatformHandleMouseAfterWindowHidden();

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -2053,7 +2053,6 @@ void MCMacPlatformWindow::DoHide(void)
 	
 		// CW-2015-09-21: [[ Bug 15979 ]] Call close instead of orderOut here to properly close
 		// windows that have been iconified.
-		[m_window_handle setReleasedWhenClosed: NO];
 		[m_window_handle close];
 	}
 	

--- a/engine/src/platform-window.cpp
+++ b/engine/src/platform-window.cpp
@@ -170,6 +170,9 @@ void MCPlatformWindow::Hide(void)
 	
 	// Update the state.
 	m_is_visible = false;
+    
+	// CW-2015-19-22: [[ Bug 15979 ]] Reset m_is_iconified, otherwise if the window is reopened, it cannot be iconified.
+	m_is_iconified = false;
 	
 	// Hide the window.
 	DoHide();


### PR DESCRIPTION
Reset m_is_iconified on window close to ensure that re-opened windows can be minimised.
