### PR TITLE
[[ Bug 15875 ]] Update Android minimum SDK for Android deployment

### DIFF
--- a/INSTALL-android.md
+++ b/INSTALL-android.md
@@ -37,7 +37,7 @@ Create a standalone toolchain (this simplifies setting up the build environment)
 ````bash
 android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
     --toolchain=arm-linux-androideabi-clang3.5 \
-    --platform=android-8 \
+    --platform=android-10 \
     --install-dir=${HOME}/android/toolchain/standalone
 ````
 
@@ -75,11 +75,11 @@ LINK="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -fuse-ld=bfd"
 AR="${BINDIR}/${TRIPLE}-ar"
 
 # Android platform information
-ANDROID_NDK_VERSION=r10d
-ANDROID_PLATFORM=android-8
-ANDROID_NDK=${TOOLCHAIN}/android-ndk-r10d
+ANDROID_NDK_VERSION=r10e
+ANDROID_PLATFORM=android-10
+ANDROID_NDK=${TOOLCHAIN}/android-ndk-r10e
 ANDROID_SDK=${TOOLCHAIN}/android-sdk-linux
-ANDROID_BUILD_TOOLS=22.0.1
+ANDROID_BUILD_TOOLS=23.0.1
 
 export JAVA_SDK
 export CC CXX LINK AR

--- a/config.sh
+++ b/config.sh
@@ -271,7 +271,7 @@ WIN_PERL=${WIN_PERL:-"C:/perl/bin/perl.exe"}
 # Android default settings and tools
 if test "${OS}" = "android" ; then
     ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION:-r10d}
-    ANDROID_PLATFORM=${ANDROID_PLATFORM:-android-8}
+    ANDROID_PLATFORM=${ANDROID_PLATFORM:-android-10}
 
     # Attempt to locate an Android NDK
     if [ -z "${ANDROID_NDK}" -a "${OS}" = "android" ] ; then

--- a/docs/notes/bugfix-15875.md
+++ b/docs/notes/bugfix-15875.md
@@ -1,0 +1,1 @@
+# Rotating Android causes app to restart if minimum version is set above 3.1 at deployment

--- a/engine/rsrc/android-manifest.xml
+++ b/engine/rsrc/android-manifest.xml
@@ -6,7 +6,7 @@
           ${INSTALL_LOCATION}>
 ${PUSH_PERMISSIONS}
 ${USES_PERMISSION}${USES_FEATURE}
-  <uses-sdk android:minSdkVersion="${MIN_SDK_VERSION}" />
+  <uses-sdk android:minSdkVersion="${MIN_SDK_VERSION}" android:targetSdkVersion="${MIN_SDK_VERSION}"/>
   <supports-screens
       android:largeScreens="true"
       android:normalScreens="true"
@@ -16,7 +16,7 @@ ${USES_PERMISSION}${USES_FEATURE}
     <activity android:name="${NAME}"
       android:theme="${THEME}"
       android:screenOrientation="${ORIENTATION}"
-      android:configChanges="keyboardHidden|orientation"
+      android:configChanges="${CONFIG_CHANGES}"
       android:windowSoftInputMode="stateHidden"
       android:launchMode="singleTask">
       <intent-filter>

--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -169,6 +169,10 @@ function deployIsValidJDK pPath
    return true
 end deployIsValidJDK
 
+function deployRequiredSDK
+   return "Android 4.0.3 (API 15)"
+end deployRequiredSDK
+
 function deployIsValidSDK pPath 
    if there is no folder (pPath & slash & "platforms") or \
          there is no folder (pPath & slash & "platform-tools") or \
@@ -177,7 +181,9 @@ function deployIsValidSDK pPath
       return false
    end if
    
-   if there is no folder (pPath & slash & "platforms/android-8") then
+   // We need API 15 in order to be able to give the value 'screenSize' to the manifest variable configChanges
+   // That was introduced in the API 13, but the SDK manager only have API 15 nowadays
+   if there is no folder (pPath & slash & "platforms/android-15") then
       --return "could not find install of SDK level 8, make sure it has been installed with the Android SDK Manager"
       return false
    end if
@@ -228,11 +234,11 @@ end deployGetJDK
 // SN-2015-05-13: [[ AndroidVersions ]] Make the available Android minimum versions
 //  something changeable from a script-only stack
 function deployGetVersionsList
-   return "2.3 - Gingerbread,2.3.3,3.0 - Honeycomb,3.1,3.2,4.0 - IceCream Sandwich,4.1 - Jelly Bean,4.2,4.3,4.4 - KitKat,5.0 - Lollipop,5.1"
+   return "2.3.3 - Gingerbread,3.0 - Honeycomb,3.1,3.2,4.0 - IceCream Sandwich,4.1 - Jelly Bean,4.2,4.3,4.4 - KitKat,5.0 - Lollipop,5.1"
 end deployGetVersionsList
 
 function deployGetAPIsList
-   return "9,10,11,12,13,14,16,17,18,19,21,22"
+   return "10,11,12,13,14,16,17,18,19,21,22"
 end deployGetAPIsList
 
 function deployGetApiFromVersion pVersion
@@ -303,7 +309,7 @@ function pathToRootClasses pRoot
    if pRoot is empty then
       put sAndroidRoot into pRoot
    end if
-   return pRoot & slash & "platforms/android-8/android.jar"
+   return pRoot & slash & "platforms/android-15/android.jar"
 end pathToRootClasses
 
 function pathToSDKClasses pRoot

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -448,6 +448,15 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget
       
       replace "${PROVIDER}" with tProvider in tManifest
       
+      // SN-2015-09-24: [[ Bug 15875 ]] Add the screenSize configChanges value for API > 12
+      //  Otherwise the app restarts on orientation change.
+      local tConfigChangesProp
+      put "keyboardHidden|orientation" into tConfigChangesProp
+      if tSettings["android,minimum version"] > 12 then
+         put "|screenSize" after tConfigChangesProp
+      end if
+      replace "${CONFIG_CHANGES}" with tConfigChangesProp in tManifest
+      
       #put tManifest into url ("binfile:c:/scratch/manifestdump.xml")
       put tManifest into url ("binfile:" & tManifestFile)
       if the result is not empty then


### PR DESCRIPTION
Several changes:
- manifest value `configChanges` also has `screenSize` set if min API >= 13
  (to avoid app restart on screen rotation)
- minimum Android SDK needed by users for Android deployment is now 15,
  in order to accomodate with the previous need
- minimum Android version been raised to 10 (as API 9 is not really relevant, since
  device running API 9 can update to use API 10)
- config.h has been updated to now use android-10 as a minimum version
- INSTALL-android.mk has been updated to reflect the android version change, and the
  update of the Platform tools to 23.0.1
- A function returning the required SDK for Android deployment has been added in the script-only stack
  revdeploylibraryandroid (see counterpart changes in the ide).
