### PR TITLE
Ensure pointer alignment for temporary storage in libscript FFI calls.

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -952,7 +952,11 @@ void MCFinalize(void);
 //  DEBUG HANDLING
 //
 
-#ifdef _DEBUG
+#if defined(_DEBUG)
+#	define DEBUG_LOG 1
+#endif
+
+#if defined(DEBUG_LOG)
 
 extern void __MCAssert(const char *file, uint32_t line, const char *message) ATTRIBUTE_NORETURN;
 #define MCAssert(m_expr) (void)( (!!(m_expr)) || (__MCAssert(__FILE__, __LINE__, #m_expr), 0) )

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -21,7 +21,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if defined(_DEBUG)
+#if defined(DEBUG_LOG)
 
 #if defined(_WINDOWS) || defined(_WINDOWS_SERVER)
 

--- a/libfoundation/src/foundation-ffi-js.cpp
+++ b/libfoundation/src/foundation-ffi-js.cpp
@@ -114,6 +114,17 @@ ffi_call(ffi_cif *p_cif,
 			// Get the actual JavaScript function
 			var func = Module.Runtime.functionPointers[index];
 
+			/*DEBUG // (no way to hide this behind an #ifdef, unfortunately)
+			// Get the function name
+			var DBG_func_name;
+			for (var key in Module) {
+				if (Module.hasOwnProperty(key) && Module[key] == func) {
+					DBG_func_name = key;
+				}
+			}
+			var DBG_func_args = [];
+			*/
+
 			// ---------- Marshal arguments
 			var func_args = [];
 			for (var i = 0; i < nargs; ++i) {
@@ -127,12 +138,21 @@ ffi_call(ffi_cif *p_cif,
 				var arg_val = getValue(getValue(arg_val_ptr, "*"), arg_type);
 
 				func_args.push(arg_val);
+
+				/*DEBUG
+				DBG_func_args.push('(' + arg_type + ')' + arg_val.toString(16));
+				*/
 			}
 
 			var ret_type = null;
 			if (rvalue_type_ptr != 0) {
 				ret_type = pointer_stringify(rvalue_type_ptr);
 			}
+
+			/*DEBUG
+			console.error('ffi_call: ' + fn.toString(16) + '=' + DBG_func_name +
+			              ' ' + DBG_func_args);
+			*/
 
 			// ---------- Invoke
 			stack = Module.Runtime.stackSave();

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -926,6 +926,8 @@ bool MCHandlerTypeInfoGetLayoutType(MCTypeInfoRef unresolved_self, int p_abi, vo
     MCHandlerTypeLayout *t_layout;
     if (!MCMemoryAllocate(sizeof(MCHandlerTypeLayout) + sizeof(ffi_cif), t_layout))
         return false;
+
+	t_layout -> abi = p_abi;
     
     if (ffi_prep_cif((ffi_cif *)&t_layout -> cif, (ffi_abi)p_abi, self -> handler . field_count, (ffi_type *)self -> handler . layout_args[0], (ffi_type **)(self -> handler . layout_args + 1)) != FFI_OK)
     {

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -1712,7 +1712,7 @@ static bool MCScriptPerformMultiInvoke(MCScriptFrame*& x_frame, byte_t*& x_next_
         MCScriptDefinition *t_definition;
         MCScriptResolveDefinitionInFrame(x_frame, t_group -> handlers[i], t_instance, t_definition);
         
-        uindex_t t_type_index;
+        uindex_t t_type_index = 0;
         if (t_definition -> kind == kMCScriptDefinitionKindHandler)
             t_type_index = static_cast<MCScriptHandlerDefinition *>(t_definition) -> type;
         else if (t_definition -> kind == kMCScriptDefinitionKindForeignHandler)
@@ -2215,11 +2215,13 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                     
                     // If we are a normal handler we use the current frame.
                     // If we are context handler, we use the caller's frame.
-                    MCScriptFrame *t_target_frame;
+                    MCScriptFrame *t_target_frame = nil;
                     if (t_frame -> handler -> scope == kMCScriptHandlerScopeNormal)
                         t_target_frame = t_frame;
                     else if (t_frame -> caller != nil)
                         t_target_frame = t_frame -> caller;
+                    else
+                        __MCScriptUnreachable__("cannot determine context variable target frame");
                     
                     // If there is no context table, or the value of the slot at the given
                     // index is nil then we use the default.
@@ -2296,11 +2298,13 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                     
                     // If we are a normal handler we use the current frame.
                     // If we are context handler, we use the caller's frame.
-                    MCScriptFrame *t_target_frame;
+                    MCScriptFrame *t_target_frame = nil;
                     if (t_frame -> handler -> scope == kMCScriptHandlerScopeNormal)
                         t_target_frame = t_frame;
                     else if (t_frame -> caller != nil)
                         t_target_frame = t_frame -> caller;
+                    else
+	                    __MCScriptUnreachable__("cannot determine context variable target frame");
                     
                     if (t_success &&
                         (t_target_frame -> context == nil ||

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -91,10 +91,10 @@ extern void __MCScriptAssertFailed__(const char *label, const char *expr, const 
 
 #else
 
-#define __MCScriptValidateObject__(obj)
-#define __MCScriptValidateObjectAndKind__(obj, kind)
-#define __MCScriptAssert__(expr, label)
-#define __MCScriptUnreachable__(label)
+#define __MCScriptValidateObject__(obj) do { } while (false)
+#define __MCScriptValidateObjectAndKind__(obj, kind) do { } while (false)
+#define __MCScriptAssert__(expr, label) do { } while (false)
+#define __MCScriptUnreachable__(label) do { } while (false)
 
 #endif
 

--- a/tests/lcb/Makefile
+++ b/tests/lcb/Makefile
@@ -24,6 +24,7 @@ bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
 LC_COMPILE ?= $(bin_dir)/lc-compile
 LC_RUN ?= $(bin_dir)/lc-run
 MODULE_DIR ?= $(bin_dir)/modules/lci
+VALGRIND ?=
 
 ################################################################
 
@@ -64,7 +65,7 @@ lcb-check: $(LC_RUN) $(LC_COMPILE)
 	@for lcmfile in $(TEST_LCM); do \
 	    logfile=`echo $$lcmfile | sed -e's:lcm$$:log:'` ; \
 	    $(LC_RUN) $(LC_RUN_FLAGS) --handler RunModuleTests -- \
-	        $(TEST_RUNNER_LCM) --lc-run "$(LC_RUN) $(LC_RUN_FLAGS)" \
+	        $(TEST_RUNNER_LCM) --lc-run "$(VALGRIND) $(LC_RUN) $(LC_RUN_FLAGS)" \
 	        $$lcmfile > $$logfile || exit $$? ; \
 	done
 	@$(LC_RUN) $(LC_RUN_FLAGS) --handler SummarizeTests -- \


### PR DESCRIPTION
This PR includes several changes related to enabling LiveCode Builder widgets in the HTML5 engine in "Release" builds.

The underlying issue was misaligned pointers being passed to `ffi_call()`.  This is fixed in commit fa07a85 by introducing a helper class that ensures alignment, reduces duplicated code, and checks for overruns.

In addition, this pull request:
- Allows `MCLog()` and `MCAssert()` calls to be preserved in release mode if `DEBUG_LOG` is defined.
- Fixes an uninitialised data error in libfoundation
- Fixes some `sometimes-uninitialised` warnings in "Release" builds of libscript
- Provides a mechanism for running the LiveCode Builder testsuite under valgrind.
