### PR TITLE
[[ Bug 16032 ]]  gradientrampeditor widget does not catch mouse relea…

### DIFF
--- a/docs/notes/bugfix-16032.md
+++ b/docs/notes/bugfix-16032.md
@@ -1,0 +1,1 @@
+# catch OnMouseCancel in gradientrampeditor

--- a/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
+++ b/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
@@ -287,6 +287,9 @@ end handler
 
 public handler onMouseCancel() returns nothing
    put false into mIsDraggingStop
+   put xCoordToStopNumber(the x of the mouse position) into mCurrentlySelectedStopIndex
+   redraw all
+   gradientStopsChanged()
 end handler
 
 public handler OnKeyPress(in pKey as String) returns nothing

--- a/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
+++ b/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
@@ -285,6 +285,10 @@ public handler OnMouseDoubleUp() returns nothing
    gradientStopsChanged()
 end handler
 
+public handler onMouseCancel() returns nothing
+   put false into mIsDraggingStop
+end handler
+
 public handler OnKeyPress(in pKey as String) returns nothing
    if not mIsDraggingStop and mCurrentlySelectedStopIndex is not 0 then
       delete element mCurrentlySelectedStopIndex of mGradientRamp


### PR DESCRIPTION
…se outside card bounds

gradientrampeditor does not catch mouseUp when it occurs outside of card bounds. Added OnMouseCancel handler.
