### PR TITLE
[[ Bug 16035 ]] Initialise properly libURL at installer startup

### DIFF
--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -296,7 +296,8 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
    end repeat
    delete the last char of tParams["auxiliary_stackfiles"]
    
-   put "insert script of stack" && quote & "revLibUrl" & quote && "into back" into tParams["startup_script"]
+   // revLibURL needs to initialise its custom props, and revLoadLibrary must therefore be called.
+   put merge("send [[quote]]revLoadLibrary[[quote]] to stack [[quote]]revLibUrl[[quote]]") into tParams["startup_script"]
    put return & "insert script of stack" && quote & "InstallerUtilities" & quote && "into back" after tParams["startup_script"]
    
    switch pPlatform

--- a/docs/notes/bugfix-16035.md
+++ b/docs/notes/bugfix-16035.md
@@ -1,0 +1,1 @@
+# Check for update does not work


### PR DESCRIPTION
revLibURL, now scriptified, needs to be loaded using its 'revLoadLibrary' function.
Simply putting its script in the backscripts when the installer stack was starting up
was not making revLibURL initialise its custom properties, and fail to check for the updates.
