### PR TITLE
[[ Bug 16033 ]] Ensure conversion from empty to 0 is consistent between 6.7 and 7.0

### DIFF
--- a/docs/notes/bugfix-16033.md
+++ b/docs/notes/bugfix-16033.md
@@ -1,0 +1,1 @@
+# Empty converted to 0 in object id chunk expression

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -1060,7 +1060,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
             case CT_ID:
             {
                 uint4 t_id;
-                if (!ctxt . EvalExprAsUInt(stack -> startpos, EE_CHUNK_BADSTACKEXP, t_id))
+                if (!ctxt . EvalExprAsStrictUInt(stack -> startpos, EE_CHUNK_BADSTACKEXP, t_id))
                     return;
 
                 MCInterfaceEvalStackOfStackById(ctxt, t_object, t_id, t_object);
@@ -1089,7 +1089,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
                 case CT_ID:
                 {
                     uint4 t_id;
-                    if (!ctxt . EvalExprAsUInt(stack -> next -> startpos, EE_CHUNK_BADSTACKEXP, t_id))
+                    if (!ctxt . EvalExprAsStrictUInt(stack -> next -> startpos, EE_CHUNK_BADSTACKEXP, t_id))
                         return;
 
                     MCInterfaceEvalSubstackOfStackById(ctxt, t_object, t_id, t_object);
@@ -1118,7 +1118,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
             case CT_ID:
             {
                 uint4 t_id;
-                if (!ctxt . EvalExprAsUInt(object -> startpos, EE_CHUNK_BADOBJECTEXP, t_id))
+                if (!ctxt . EvalExprAsStrictUInt(object -> startpos, EE_CHUNK_BADOBJECTEXP, t_id))
                     return;
 
                 if (object -> otype == CT_AUDIO_CLIP)
@@ -1166,7 +1166,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
             case CT_ID:
             {
                 uint4 t_id;
-                if (!ctxt . EvalExprAsUInt(background -> startpos, EE_CHUNK_BADBACKGROUNDEXP, t_id))
+                if (!ctxt . EvalExprAsStrictUInt(background -> startpos, EE_CHUNK_BADBACKGROUNDEXP, t_id))
                     return;
 
                 if (card == nil)
@@ -1210,7 +1210,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
             case CT_ID:
             {
                 uint4 t_id;
-                if (!ctxt . EvalExprAsUInt(card -> startpos, EE_CHUNK_BADCARDEXP, t_id))
+                if (!ctxt . EvalExprAsStrictUInt(card -> startpos, EE_CHUNK_BADCARDEXP, t_id))
                     return;
 
                 if (background != nil)
@@ -1264,7 +1264,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
             case CT_ID:
             {
                 uint4 t_id;
-                if (!ctxt . EvalExprAsUInt(tgptr -> startpos, EE_CHUNK_BADBACKGROUNDEXP, t_id))
+                if (!ctxt . EvalExprAsStrictUInt(tgptr -> startpos, EE_CHUNK_BADBACKGROUNDEXP, t_id))
                     return;
 
                 // MW-2011-08-09: [[ Groups ]] If there was an explicit stack reference,
@@ -1338,7 +1338,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
                 case CT_ID:
                 {
                     uint4 t_id;
-                    if (!ctxt . EvalExprAsUInt(toptr -> startpos, EE_CHUNK_BADOBJECTEXP, t_id))
+                    if (!ctxt . EvalExprAsStrictUInt(toptr -> startpos, EE_CHUNK_BADOBJECTEXP, t_id))
                         return;
                     
                     // If we are in stack override mode, then search the stack *after*

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -1013,7 +1013,7 @@ void MCGo::exec_ctxt(MCExecContext &ctxt)
             else if (stack -> etype == CT_ID)
             {
                 uinteger_t t_stack_id;
-                if (!ctxt . EvalExprAsUInt(stack -> startpos, EE_GO_BADSTACKEXP, t_stack_id))
+                if (!ctxt . EvalExprAsStrictUInt(stack -> startpos, EE_GO_BADSTACKEXP, t_stack_id))
                     return;
 
                 sptr = MCdefaultstackptr->findstackid(t_stack_id);
@@ -1034,7 +1034,7 @@ void MCGo::exec_ctxt(MCExecContext &ctxt)
 				case CT_ID:
                 {
                     uinteger_t t_stack_id;
-                    if (!ctxt . EvalExprAsUInt(stack -> next -> startpos, EE_CHUNK_BADSTACKEXP, t_stack_id))
+                    if (!ctxt . EvalExprAsStrictUInt(stack -> next -> startpos, EE_CHUNK_BADSTACKEXP, t_stack_id))
                         return;
 
                     sptr = sptr -> findsubstackid(t_stack_id);

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -923,6 +923,42 @@ static bool EvalExprAs(MCExecContext* self, MCExpression *p_expr, Exec_errors p_
 }
 
 template <typename T>
+static bool EvalExprAsStrictNumber(MCExecContext* self, MCExpression *p_expr, Exec_errors p_error, MCExecValueType p_type, T& r_value)
+{
+	MCAssert(p_expr != nil);
+	
+    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
+    MCExecValue t_value;
+    Boolean t_number_expected = self -> GetNumberExpected();
+    self -> SetNumberExpected(True);
+    
+	p_expr -> eval_ctxt(*self, t_value);
+    
+    if (MCExecTypeIsValueRef(t_value . type) && MCValueIsEmpty(t_value . valueref_value))
+    {
+        self -> LegacyThrow(p_error);
+        
+        return false;
+    }
+    
+    self -> SetNumberExpected(t_number_expected);
+    
+    if (!self -> HasError())
+        MCExecTypeConvertAndReleaseAlways(*self, t_value . type, &t_value, p_type, &r_value);
+	
+	if (!self -> HasError())
+		return true;
+	
+	self -> LegacyThrow(p_error);
+	
+	return false;
+}
+
+bool MCExecContext::EvalExprAsStrictUInt(MCExpression *p_expr, Exec_errors p_error, uinteger_t& r_value) { return EvalExprAsStrictNumber(this, p_expr, p_error, kMCExecValueTypeUInt, r_value); }
+
+bool MCExecContext::EvalExprAsStrictInt(MCExpression *p_expr, Exec_errors p_error, integer_t& r_value) { return EvalExprAsStrictNumber(this, p_expr, p_error, kMCExecValueTypeInt, r_value); }
+
+template <typename T>
 static bool EvalExprAsNumber(MCExecContext* self, MCExpression *p_expr, Exec_errors p_error, MCExecValueType p_type, T& r_value)
 {
 	MCAssert(p_expr != nil);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1754,6 +1754,10 @@ public:
 	void TryToEvalExprAsArrayRef(MCExpression *p_expr, Exec_errors p_error, MCArrayRef& r_value);
     void TryToEvalOptionalExprAsColor(MCExpression *p_expr, MCColor *p_default, Exec_errors p_error, MCColor *&r_value);
     
+    bool EvalExprAsStrictUInt(MCExpression *p_expr, Exec_errors p_error, uinteger_t& r_value);
+    
+    bool EvalExprAsStrictInt(MCExpression *p_expr, Exec_errors p_error, integer_t& r_value);
+    
 private:
 #ifdef LEGACY_EXEC
     MCExecPoint& m_ep;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -2246,7 +2246,7 @@ void MCFontStyles::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
     if (!ctxt . EvalExprAsStringRef(fontname, EE_FONTSTYLES_BADFONTNAME, &t_fontname))
         return;
     uinteger_t fsize;
-    if (!ctxt . EvalExprAsUInt(fontsize, EE_FONTSTYLES_BADFONTSIZE, fsize))
+    if (!ctxt . EvalExprAsStrictUInt(fontsize, EE_FONTSTYLES_BADFONTSIZE, fsize))
         return;
     
 	MCTextEvalFontStyles(ctxt, *t_fontname, fsize, r_value . stringref_value);

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -319,10 +319,10 @@ bool MCIdeScriptAction::eval_target_range(MCExecContext& ctxt, MCExpression *p_s
     int4 t_end = 0;
     MCField *t_target = nil;
 
-    t_success = ctxt . EvalExprAsInt(p_start, EE_OBJECT_NAN, t_start);
+    t_success = ctxt . EvalExprAsStrictInt(p_start, EE_OBJECT_NAN, t_start);
 
     if (t_success)
-        t_success = ctxt . EvalExprAsInt(p_end, EE_OBJECT_NAN, t_end);
+        t_success = ctxt . EvalExprAsStrictInt(p_end, EE_OBJECT_NAN, t_end);
 
     if (t_success)
         t_success = eval_target(ctxt, p_target, t_target);


### PR DESCRIPTION
In 6.7, the empty string was converted to 0 in numeric context iff `ep.ton()` was called before `ep.getuint()` or similar. Our `EvalExprAsNumber` function doesn't check for empty, and therefore empty is always converted to 0 in these contexts. 

This patch adds `EvalExprAsStrictNumber` to cover the cases where empty should not convert.
