### PR TITLE
[[ Bug 13527 ]] Update docs for delimiters

### DIFF
--- a/docs/dictionary/command/split.xml
+++ b/docs/dictionary/command/split.xml
@@ -16,7 +16,7 @@
 
 	<examples>
 <example><p>put "one,two,three" into tData</p><p>split tData by comma</p><p>// RESULT</p><p>// tData[1] = "one"</p><p>// tData[2] = "two"</p><p>// tData[3] = "three"</p></example>
-<example><p>put "one,two,three" into line 1 of tData</p><p>put "ben,fraser,elanor" into line 2 of tData</p><p>put "apple,orange,grape" into line 3 of tData</p><p>set the rowdel to comma</p><p>split tData by column</p><p>// RESULT</p><p>// tData[1] = </p><p>// one</p><p>// two</p><p>// three</p><p>// tData[2] = </p><p>// ben</p><p>// fraser</p><p>// elanor</p><p>// tData[3] = </p><p>// apple</p><p>// orange</p><p>// grape</p></example>
+<example><p>put "one;;two;;three" into line 1 of tData</p><p>put "ben;;fraser;;elanor" into line 2 of tData</p><p>put "apple;;orange;;grape" into line 3 of tData</p><p>set the columndel to ";;"</p><p>split tData by column</p><p>// RESULT</p><p>// tData[1] = </p><p>// one</p><p>// two</p><p>// three</p><p>// tData[2] = </p><p>// ben</p><p>// fraser</p><p>// elanor</p><p>// tData[3] = </p><p>// apple</p><p>// orange</p><p>// grape</p></example>
 	</examples>
 
 	<history>
@@ -24,6 +24,7 @@
 		<deprecated version=""></deprecated>
 		<removed version=""></removed>
 		<changed version="2.8.1">2.8.1</changed>
+<changed version="7.0.0">7.0.0</changed>
 		<experimental version=""></experimental>
 		<nonexperimental version=""></nonexperimental>
 	</history>
@@ -72,23 +73,24 @@
 			<parameter>
 			<name>variable</name>
 			<description>Any variable that is not an array</description>
-			</parameter>  
+			</parameter>
 			
 			<parameter>
 			<name>primaryDelimiter</name>
-			<description>A character or an expression that evaluates to a character.</description>
-			</parameter>  
+			<description>A string of characters or an expression that evaluates to a string of characters.</description>
+			</parameter>
 			
 			<parameter>
 			<name>secondaryDelimiter</name>
-			<description>A character or an expression that evaluates to a character.</description>
-			</parameter>  
+			<description>A string of characters or an expression that evaluates to a string of characters.</description>
+			</parameter>
 		</parameters>
 
 	<value></value>
 	<comments>
 		<p>The <b>split</b> command separates the parts of the variable into elements of an array. After the command is finished executing, the variable specified is an array.</p>
 		<p></p>
+		<important>From LiveCode 7.0, <i>primaryDelimiter</i> and <i>secondaryDelimiter</i> can be a string of one or several <keyword tag="character">characters</keyword>, with no limit in length (see the example below).</important><p></p>
 		<p>If the first form of the <b>split</b> command is used, the parts that become elements are defined by the <i>primaryDelimiter</i>. For example, if the <i>primaryDelimiter</i> is <constant tag="return">return</constant>, each line of the variable becomes an element in the resulting array.</p>
 		<p></p>
 		<p>If you don't specify a <i>secondaryDelimiter</i>, then a simple numeric array is created, with each key being a number, starting with 1.</p>
@@ -99,18 +101,18 @@
 		<p></p>
 		<p>For example, the following statements create an array:</p>
 		<p></p>
-		<p>put "A apple,B bottle,C cradle" into myVariable</p>
-		<p>split myVariable by comma and space</p>
+		<p>put "A apple&lt;next /&gt;B bottle&lt;next /&gt;C cradle" into myVariable</p>
+		<p>split myVariable by "&lt;next /&gt;" and space</p>
 		<p></p>
 		<p>The resulting array looks like this:</p>
 		<p></p>
-		<p>KEY	VALUE</p>
-		<p>	A	apple</p>
-		<p>	B	bottle</p>
-		<p>	C	cradle</p>
+		<p>&#9;KEY&#9;VALUE</p>
+		<p>&#9;A&#9;apple</p>
+		<p>&#9;B&#9;bottle</p>
+		<p>&#9;C&#9;cradle</p>
 		<p></p>
-		<important>Using the <b>split</b> command can discard data if any of the keys in the original variable are duplicated. If more than one part of the variable delimited by the <i>primaryDelimiter</i> has the same first portion delimited by the <i>secondaryDelimiter</i>, only the element corresponding to the first part is created. (For example, if you are splitting a variable by <constant tag="return">return</constant> and <constant tag="space">space</constant>, and two lines happen to have the same first word, only one of the lines is retained in the array.) Only one element is created for each unique key.</important>
 		<p></p>
+		<important>Using the <b>split</b> command can discard data if any of the keys in the original variable are duplicated. If more than one part of the variable delimited by the <i>primaryDelimiter</i> has the same first portion delimited by the <i>secondaryDelimiter</i>, only the element corresponding to the first part is created. (For example, if you are splitting a variable by <constant tag="return">return</constant> and <constant tag="space">space</constant>, and two lines happen to have the same first word, only one of the lines is retained in the array.) Only one element is created for each unique key.</important><p></p>
 		<p>If the second form of the <b>split</b> command is used, the string is split into elements of an array where each element using the <property tag="rowDelimiter">rowDelimiter</property> or <property tag="columnDelimiter">columnDelimiter</property>, where each element of the resulting array is a row or column of the string respectively.</p>
 		<p></p>
 		<p>Splitting a string by row converts the string into an array where each element of the array corresponds to a row in the string separated by the <property tag="rowDelimiter">rowDelimiter</property>.</p>

--- a/docs/dictionary/property/columnDelimiter.xml
+++ b/docs/dictionary/property/columnDelimiter.xml
@@ -2,24 +2,32 @@
   <legacy_id>3063</legacy_id>
   <name>columnDelimiter</name>
   <type>property</type>
+
   <syntax>
-    <example>set the columnDelimiter to <i>character</i></example>
+    <example>set the columnDelimiter to <i>string</i></example>
     <example>the columnDelimiter</example>
   </syntax>
-  <library></library>
+
+  <synonyms>
+  </synonyms>
+
+  <summary>Specifies the character(s) used to separate columns in a string</summary>
+
+  <examples>
+<example>set the columnDelimiter to comma</example>
+<example>put the columnDelimiter into tColumnDelimiter</example>
+<example><p>set the columnDelimiter to "&lt;/col&gt;"</p></example>
+  </examples>
+
+  <history>
+    <introduced version="2.8.1">Added.</introduced>
+    <changed version="7.0.0">7.0.0</changed>
+  </history>
+
   <objects>
     <local/>
   </objects>
-  <synonyms>
-  </synonyms>
-  <classification>
-  </classification>
-  <references>
-    <command tag="split">split Command</command>
-  </references>
-  <history>
-    <introduced version="2.8.1">Added.</introduced>
-  </history>
+
   <platforms>
     <mac/>
     <windows/>
@@ -27,20 +35,24 @@
     <ios/>
     <android/>
   </platforms>
+
   <classes>
     <desktop/>
     <server/>
     <web/>
     <mobile/>
   </classes>
+
   <security>
   </security>
-  <summary>Specifies the character used to separate columns in a string</summary>
-  <examples>
-    <example>set the columnDelimiter to comma</example>
-    <example>put the columnDelimiter into tColumnDelimiter</example>
-  </examples>
-  <description>
-    <p>Use the <b>columnDelimiter</b> property in conjunction with the <command tag="split">split command</command> to divide text into an array of columns or with the <command tag="combine">combine command</command> to combine an array of columns into a string.</p><p/><p><b>Value:</b></p><p>The <b>columnDelimiter</b> is a character</p><p/><p>By default, the <b>columnDelimiter</b> is set to tab</p><p/><p><b>Comments:</b></p><p>The <b>columnDelimiter</b> is a single character.</p><p/><p>Since the <b>columnDelimiter</b> is a local property, its value is reset to tab when the current handler finishes executing. It retains its value only for the current handler and setting it in one handler does not affect its value in other handlers called.</p>
-  </description>
+
+
+  <classification>
+  </classification>
+
+  <references>
+    <command tag="split">split Command</command>
+  </references>
+
+  <description>Use the <b>columnDelimiter</b> property in conjunction with the <command tag="split">split command</command> to divide text into an array of columns or with the <command tag="combine">combine command</command> to combine an array of columns into a string.<p></p><p><b>Value:</b></p><p>From LiveCode 7.0, <b>columnDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. </p><p></p><p>By default, the <b>columnDelimiter</b> is set to tab</p><p></p><p><b>Comments:</b></p><p>From LiveCode 7.0, <b>columnDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. </p><p></p><p>Since the <b>columnDelimiter</b> is a local property, its value is reset to tab when the current handler finishes executing. It retains its value only for the current handler and setting it in one handler does not affect its value in other handlers called.</p></description>
 </doc>

--- a/docs/dictionary/property/itemDelimiter.xml
+++ b/docs/dictionary/property/itemDelimiter.xml
@@ -2,29 +2,37 @@
   <legacy_id>1338</legacy_id>
   <name>itemDelimiter</name>
   <type>property</type>
+
   <syntax>
-    <example>set the itemDelimiter to <i>character</i></example>
+    <example>set the itemDelimiter to <i>string</i></example>
+    <example>the itemDelimiter</example>
   </syntax>
-  <library></library>
-  <objects>
-    <local/>
-  </objects>
+
   <synonyms>
     <synonym>itemDel</synonym>
   </synonyms>
-  <classification>
-    <category>Text and Data Processing</category>
-  </classification>
-  <references>
-    <constant tag="formfeed">formfeed Constant</constant>
-    <constant tag="colon">colon Constant</constant>
-    <constant tag="comma">comma Constant</constant>
-    <function tag="itemOffset">itemOffset Function</function>
-    <keyword tag="item">item Keyword</keyword>
-  </references>
+
+  <summary>Specifies the character(s) used to separate <keyword tag="items">items</keyword> in <glossary tag="chunk expression">chunk expressions</glossary>.</summary>
+
+  <examples>
+<example>set the itemDelimiter to numToCodepoint(202)</example>
+<example>set the itemDelimiter to tab</example>
+<example><p>set the itemDelimiter to "***delimiter***"</p></example>
+  </examples>
+
   <history>
     <introduced version="1.0">Added.</introduced>
+    <deprecated version=""></deprecated>
+    <removed version=""></removed>
+    <changed version="7.0.0">7.0.0</changed>
+    <experimental version=""></experimental>
+    <nonexperimental version=""></nonexperimental>
   </history>
+
+  <objects>
+    <local/>
+  </objects>
+
   <platforms>
     <mac/>
     <windows/>
@@ -32,20 +40,26 @@
     <ios/>
     <android/>
   </platforms>
+
   <classes>
     <desktop/>
     <server/>
     <web/>
     <mobile/>
   </classes>
+
   <security>
   </security>
-  <summary>Specifies the <keyword tag="character">character</keyword> used to separate <keyword tag="items">items</keyword> in <glossary tag="chunk expression">chunk expressions</glossary>.</summary>
-  <examples>
-    <example>set the itemDelimiter to numToChar(202)</example>
-    <example>set the itemDelimiter to tab</example>
-  </examples>
-  <description>
-    <p>Use the <b>itemDelimiter</b> <glossary tag="property">property</glossary> to divide text into <glossary tag="chunk">chunks</glossary> based on a <glossary tag="delimit">delimiting</glossary> <keyword tag="character">character</keyword>.</p><p/><p><b>Value:</b></p><p>The <b>itemDelimiter</b> is a <keyword tag="character">character</keyword>.</p><p/><p>By default, the <b>itemDelimiter</b> <glossary tag="property">property</glossary> is set to <constant tag="comma">comma</constant>.</p><p/><p><b>Comments:</b></p><p>The <b>itemDelimiter</b> is a single <keyword tag="character">character</keyword>. <glossary tag="chunk expression">Chunk expressions</glossary> use the <b>itemDelimiter</b> to determine where one <keyword tag="item">item</keyword> ends and the next begins.</p><p/><p>Since the <b>itemDelimiter</b> is a <href tag="../dictionary/local_property.xml">local property</href>, its value is <command tag="reset">reset</command> to comma when the current <glossary tag="handler">handler</glossary> finishes <glossary tag="execute">executing</glossary>. It retains its <function tag="value">value</function> only for the current <glossary tag="handler">handler</glossary>, and setting it in one <glossary tag="handler">handler</glossary> does not affect its <function tag="value">value</function> in other <glossary tag="handler">handlers</glossary> it <glossary tag="call">calls</glossary>.</p>
-  </description>
+
+
+  <classification>
+    <category>Text and Data Processing</category>
+  </classification>
+
+  <references>
+    <function tag="itemOffset">itemOffset Function</function>
+    <keyword tag="item">item Keyword</keyword>
+  </references>
+
+  <description>Use the <b>itemDelimiter</b> <glossary tag="property">property</glossary> to divide text into <glossary tag="chunk">chunks</glossary> based on a <glossary tag="delimit">delimiting</glossary> string of<keyword tag="character">characters</keyword>.<p></p><p><b>Value:</b></p><p>From LiveCode 7.0, <b>itemDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. </p><p></p><p>By default, the <b>itemDelimiter</b> <glossary tag="property">property</glossary> is set to <constant tag="comma">comma</constant>.</p><p></p><p><b>Comments:</b></p><p>From LiveCode 7.0, <b>itemDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. <glossary tag="chunk expression">Chunk expressions</glossary> use the <b>itemDelimiter</b> to determine where one <keyword tag="item">item</keyword> ends and the next begins.</p><p></p><p>Since the <b>itemDelimiter</b> is a local property, its value is <command tag="reset">reset</command> to comma when the current <glossary tag="handler">handler</glossary> finishes <glossary tag="execute">executing</glossary>. It retains its <function tag="value">value</function> only for the current <glossary tag="handler">handler</glossary>, and setting it in one <glossary tag="handler">handler</glossary> does not affect its <function tag="value">value</function> in other <glossary tag="handler">handlers</glossary> it <glossary tag="call">calls</glossary>.</p></description>
 </doc>

--- a/docs/dictionary/property/lineDelimiter.xml
+++ b/docs/dictionary/property/lineDelimiter.xml
@@ -2,26 +2,37 @@
   <legacy_id>2496</legacy_id>
   <name>lineDelimiter</name>
   <type>property</type>
+
   <syntax>
-    <example>set the lineDelimiter to <i>character</i></example>
+    <example>set the lineDelimiter to <i>string</i></example>
+    <example>the lineDelimiter</example>
   </syntax>
-  <library></library>
-  <objects>
-    <local/>
-  </objects>
+
   <synonyms>
     <synonym>lineDel</synonym>
   </synonyms>
-  <classification>
-    <category>Text and Data Processing</category>
-  </classification>
-  <references>
-    <constant tag="formfeed">formfeed Constant</constant>
-    <keyword tag="lines">lines Keyword</keyword>
-  </references>
+
+  <summary>Specifies the character(s) used to separate <keyword tag="lines">lines</keyword> in <glossary tag="chunk expression">chunk expressions</glossary>.</summary>
+
+  <examples>
+<example>set the lineDelimiter to numToCodepoint(13)</example>
+<example>set the lineDelimiter to myRecordDelimiter</example>
+<example><p>set the lineDelimiter to "&lt;br /&gt;"</p></example>
+  </examples>
+
   <history>
     <introduced version="2.0">Added.</introduced>
+    <deprecated version=""></deprecated>
+    <removed version=""></removed>
+    <changed version="7.0.0">7.0.0</changed>
+    <experimental version=""></experimental>
+    <nonexperimental version=""></nonexperimental>
   </history>
+
+  <objects>
+    <local/>
+  </objects>
+
   <platforms>
     <mac/>
     <windows/>
@@ -29,20 +40,25 @@
     <ios/>
     <android/>
   </platforms>
+
   <classes>
     <desktop/>
     <server/>
     <web/>
     <mobile/>
   </classes>
+
   <security>
   </security>
-  <summary>Specifies the <keyword tag="character">character</keyword> used to separate <keyword tag="lines">lines</keyword> in <glossary tag="chunk expression">chunk expressions</glossary>.</summary>
-  <examples>
-    <example>set the lineDelimiter to numToChar(13)</example>
-    <example>set the lineDelimiter to myRecordDelimiter</example>
-  </examples>
-  <description>
-    <p>Use the <b>lineDelimiter</b> <glossary tag="property">property</glossary> to divide text into <glossary tag="chunk">chunks</glossary> based on a <glossary tag="delimit">delimiting</glossary> <keyword tag="character">character</keyword>.</p><p/><p><b>Value:</b></p><p>The <b>lineDelimiter</b> is a <keyword tag="character">character</keyword>.</p><p/><p>By default, the <b>lineDelimiter</b> <glossary tag="property">property</glossary> is set to <constant tag="return">return</constant>.</p><p/><p><b>Comments:</b></p><p>The <b>lineDelimiter</b> is a single <keyword tag="character">character</keyword>. <glossary tag="chunk expression">Chunk expressions</glossary> use the <b>lineDelimiter</b> to determine where one <keyword tag="line">line</keyword> ends and the next begins.</p><p/><p>Since the <b>lineDelimiter</b> is a <href tag="../dictionary/local_property.xml">local property</href>, its value is <command tag="reset">reset</command> to <constant tag="return">return</constant> when the current <glossary tag="handler">handler</glossary> finishes <glossary tag="execute">executing</glossary>. It retains its <function tag="value">value</function> only for the current <glossary tag="handler">handler</glossary>, and setting it in one <glossary tag="handler">handler</glossary> does not affect its <function tag="value">value</function> in other <glossary tag="handler">handlers</glossary> it <glossary tag="call">calls</glossary>.</p>
-  </description>
+
+
+  <classification>
+    <category>Text and Data Processing</category>
+  </classification>
+
+  <references>
+    <keyword tag="lines">lines Keyword</keyword>
+  </references>
+
+  <description>Use the <b>lineDelimiter</b> <glossary tag="property">property</glossary> to divide text into <glossary tag="chunk">chunks</glossary> based on a <glossary tag="delimit">delimiting string of characters</glossary><p></p><p><b>Value:</b></p><p>From LiveCode 7.0, <b>lineDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. </p><p></p><p>By default, the <b>lineDelimiter</b> <glossary tag="property">property</glossary> is set to <constant tag="return">return</constant>.</p><p></p><p><b>Comments:</b></p><p>From LiveCode 7.0, <b>lineDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. <glossary tag="chunk expression">Chunk expressions</glossary> use the <b>lineDelimiter</b> to determine where one <keyword tag="line">line</keyword> ends and the next begins.</p><p></p><p>Since the <b>lineDelimiter</b> is a local property, its value is <command tag="reset">reset</command> to <constant tag="return">return</constant> when the current <glossary tag="handler">handler</glossary> finishes <glossary tag="execute">executing</glossary>. It retains its <function tag="value">value</function> only for the current <glossary tag="handler">handler</glossary>, and setting it in one <glossary tag="handler">handler</glossary> does not affect its <function tag="value">value</function> in other <glossary tag="handler">handlers</glossary> it <glossary tag="call">calls</glossary>.</p></description>
 </doc>

--- a/docs/dictionary/property/rowDelimiter.xml
+++ b/docs/dictionary/property/rowDelimiter.xml
@@ -2,24 +2,36 @@
   <legacy_id>3062</legacy_id>
   <name>rowDelimiter</name>
   <type>property</type>
+
   <syntax>
-    <example>set the rowDelimiter to <i>character</i></example>
+    <example>set the rowDelimiter to <i>string</i></example>
     <example>get the rowDelimiter</example>
   </syntax>
-  <library></library>
+
+  <synonyms>
+  </synonyms>
+
+  <summary>Specifies the character(s) used to separate rows in a string.</summary>
+
+  <examples>
+<example>set the rowDelimiter to comma</example>
+<example>put the rowDelimiter into tRowDelimiter</example>
+<example><p>set the rowDelimiter to ";;"</p></example>
+  </examples>
+
+  <history>
+    <introduced version="2.8.1">Added.</introduced>
+    <deprecated version=""></deprecated>
+    <removed version=""></removed>
+    <changed version="7.0.0">7.0.0</changed>
+    <experimental version=""></experimental>
+    <nonexperimental version=""></nonexperimental>
+  </history>
+
   <objects>
     <local/>
   </objects>
-  <synonyms>
-  </synonyms>
-  <classification>
-  </classification>
-  <references>
-    <command tag="split">split Command</command>
-  </references>
-  <history>
-    <introduced version="2.8.1">Added.</introduced>
-  </history>
+
   <platforms>
     <mac/>
     <windows/>
@@ -27,20 +39,24 @@
     <ios/>
     <android/>
   </platforms>
+
   <classes>
     <desktop/>
     <server/>
     <web/>
     <mobile/>
   </classes>
+
   <security>
   </security>
-  <summary>Specifies the character used to separate rows in a string.</summary>
-  <examples>
-    <example>set the rowDelimiter to comma</example>
-    <example>put the rowDelimiter into tRowDelimiter</example>
-  </examples>
-  <description>
-    <p>Use the <b>rowDelimiter</b> property in conjunction with the <command tag="split">split command</command> to divide text into an array of rows or with the <command tag="combine">combine command</command> to combine an array of rows into a string.</p><p/><p><b>Value:</b></p><p>The <b>rowDelimiter</b> is a character</p><p/><p>By default, the rowDelimiter is set to return</p><p/><p><b>Comments:</b></p><p>The <b>rowDelimiter</b> is a single character. </p><p/><p>Since the <b>rowDelimiter</b> is a local property, its value is reset to return when the current handler finishes executing. It retains its value only for the current handler and setting it in one handler does not affect its value in other handlers called.</p><p/>
-  </description>
+
+
+  <classification>
+  </classification>
+
+  <references>
+    <command tag="split">split Command</command>
+  </references>
+
+  <description>Use the <b>rowDelimiter</b> property in conjunction with the <command tag="split">split command</command> to divide text into an array of rows or with the <command tag="combine">combine command</command> to combine an array of rows into a string.<p></p><p><b>Value:</b></p><p>From LiveCode 7.0, <b>rowDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. </p><p></p><p>By default, the rowDelimiter is set to return</p><p></p><p><b>Comments:</b></p><p>From LiveCode 7.0, <b>rowDelimiter</b> can be a string of one or several <keyword tag="character">characters</keyword>. </p><p></p><p>Since the <b>rowDelimiter</b> is a local property, its value is reset to return when the current handler finishes executing. It retains its value only for the current handler and setting it in one handler does not affect its value in other handlers called.</p></description>
 </doc>

--- a/docs/notes/bugfix-13527.md
+++ b/docs/notes/bugfix-13527.md
@@ -1,0 +1,1 @@
+# Outdated documentation for delimiters in LC 7.0


### PR DESCRIPTION
From 7.0, delimiters are now able to handle more that one character.
This pull request update the docs for
- columnDelimiter
- itemDelimiter
- lineDelimiter
- rowDelimiter
- split
