### PR TITLE
[[ Widgets ]] Remove opacity setting from outer shadow props array

### DIFF
--- a/extensions/widgets/header/header.lcb
+++ b/extensions/widgets/header/header.lcb
@@ -715,7 +715,6 @@ private handler drawDropShadow() returns Effect
 
    put color [153/255, 153/255, 153/255, 1] into tProps["color"]
    put "source over" into tProps["blend mode"]
-   put 255 into tProps["opacity"]
    put 0.75 into tProps["spread"]
    put 5 into tProps["size"]
    put 1 into tProps["distance"]

--- a/extensions/widgets/pushbutton/pushbutton.lcb
+++ b/extensions/widgets/pushbutton/pushbutton.lcb
@@ -445,7 +445,6 @@ private handler drawDropShadow() returns Effect
 
    put color [39/255, 39/255, 39/255, 0.2] into tProps["color"]
    put "source over" into tProps["blend mode"]
-   put 255 into tProps["opacity"]
 
    if mWidgetTheme is kWidgetThemeAndroidFloatingAction then
       put 0.5 into tProps["spread"]


### PR DESCRIPTION
This setting was removed because it is specified by the alpha component of the color.
