### PR TITLE
[[ Bug 16047 ]] Make MCS_startprocess give the right args to execvp

### DIFF
--- a/docs/notes/bugfix-16047.md
+++ b/docs/notes/bugfix-16047.md
@@ -1,0 +1,1 @@
+# open process / launch does not word with quotes around the executable name

--- a/engine/src/lnxspec.cpp
+++ b/engine/src/lnxspec.cpp
@@ -403,7 +403,8 @@ void MCS_startprocess(char *name, char *doc, Open_mode mode, Boolean elevated)
 				}
 				else
 					close(0);
-				execvp(name, argv);
+                // The executable name should be argv[0].
+                execvp(argv[0], argv);
 				_exit(-1);
 			}
 			MCS_checkprocesses();


### PR DESCRIPTION
The variable `name` was modified and no longer had the final quote of the executable name, once the `argv` list had been build.
Change the parameteres given to `execvp` to `argv[0], argv`.

This is needed to fix the post-install launch of LiveCode.
