### PR TITLE
perfect: Compile without -Wstrict-prototypes

### DIFF
--- a/util/perfect/perfect.gyp
+++ b/util/perfect/perfect.gyp
@@ -19,6 +19,11 @@
 				'perfect.c',
 			],
 
+			'cflags_c!':
+			[
+				'-Wstrict-prototypes',
+			],
+
 			'msvs_settings':
 			{
 				'VCLinkerTool':


### PR DESCRIPTION
The source code to perfect isn't written according to strict C
standards, and we don't care.
