### PR TITLE
[[ Bug 13527 ]] Update docs for LiveCode 8

### DIFF
--- a/docs/dictionary/command/split.lcdoc
+++ b/docs/dictionary/command/split.lcdoc
@@ -12,6 +12,8 @@ Summary: Transforms a list into an <array>.
 
 Introduced: 1.1
 
+Changed: 7.0.0
+
 OS: mac,windows,linux,ios,android
 
 Platforms: desktop,server,web,mobile
@@ -25,10 +27,10 @@ split tData by comma
 // tData[3] = "three"
 
 Example:
-put "one,two,three" into line 1 of tData
-put "ben,fraser,elanor" into line 2 of tData
-put "apple,orange,grape" into line 3 of tData
-set the rowdel to comma
+put "one;;two;;three" into line 1 of tData
+put "ben;;fraser;;elanor" into line 2 of tData
+put "apple;;orange;;grape" into line 3 of tData
+set the columndel to ";;"
 split tData by column
 // RESULT
 // tData[1] = 
@@ -46,12 +48,14 @@ split tData by column
 
 Parameters:
 variable: Any variable that is not an array
-primaryDelimiter: A character or an expression that evaluates to a character.
-secondaryDelimiter: A character or an expression that evaluates to a character.
+primaryDelimiter: A string of <character|characters> or an expression that evaluates to a string of <character|characters>.
+secondaryDelimiter: A string of <character|characters> or an expression that evaluates to a string of <character|characters>.
 
 The result: If the first form of the <split> command is used, the parts that become elements are defined by the <primaryDelimiter>. For example, if the <primaryDelimiter> is <return>, each line of the variable becomes an element in the resulting array.The resulting array looks like this:. If the second form of the <split> command is used, the string is split into elements of an array where each element using the <rowDelimiter> or <columnDelimiter>, where each element of the resulting array is a row or column of the string respectively.
 
 Description:
+From LiveCode 7.0, you can pass a string of <character|characters> as a column and row delimiter (it is no longer restricted to a single character).
+
 Use the <split> command to place a list in an array so you can easily address each part of the list.
 
 The <split> command separates the parts of the variable into elements of an array. After the command is finished executing, the variable specified is an array. 
@@ -64,10 +68,10 @@ If you use the as set form the <split> command converts the passed variable to a
  
 For example, the following statements create an array: 
  
-put "A apple,B bottle,C cradle" into myVariable 
-split myVariable by comma and space 
+put "A apple;;B bottle;;C cradle" into myVariable 
+split myVariable by ";;" and space 
  
-KEY	VALUE 
+	KEY	VALUE 
 	A	apple 
 	B	bottle 
 	C	cradle 

--- a/docs/dictionary/property/columnDelimiter.lcdoc
+++ b/docs/dictionary/property/columnDelimiter.lcdoc
@@ -2,13 +2,15 @@ Name: columnDelimiter
 
 Type: property
 
-Syntax: set the columnDelimiter to <character> 
+Syntax: set the columnDelimiter to <character|character(s)> 
 
 Syntax: the columnDelimiter
 
-Summary: Specifies the character used to separate columns in a string
+Summary: Specifies the <character|character(s)> used to separate columns in a string
 
 Introduced: 2.8.1
+
+Changed: 7.0.0
 
 OS: mac,windows,linux,ios,android
 
@@ -20,15 +22,18 @@ set the columnDelimiter to comma
 Example:
 put the columnDelimiter into tColumnDelimiter
 
+Example:
+set the columnDelimiter to ";;"
+
 Value:
-The <columnDelimiter> is a character
-By default, the <columnDelimiter> is set to tab.
+From LiveCode 7.0, <columnDelimiter> can be a string of one or several <character|characters>. 
+By default, the <columnDelimiter> is set to <tab>.
 
 Description:
 Use the <columnDelimiter> property in conjunction with the <split command> to divide text into an array of columns or with the <combine command> to combine an array of columns into a string.
 
-The <columnDelimiter> is a single character.
+From LiveCode 7.0, <columnDelimiter> can be a string of one or several <character|characters>.
 
-Since the <columnDelimiter> is a local property, its value is reset to tab when the current handler finishes executing. It retains its value only for the current handler and setting it in one handler does not affect its value in other handlers called.
+Since the <columnDelimiter> is a local property, its value is reset to <tab> when the current handler finishes executing. It retains its value only for the current handler and setting it in one handler does not affect its value in other handlers called.
 
 References: combine command (command), split (command), split command (command)

--- a/docs/dictionary/property/itemDelimiter.lcdoc
+++ b/docs/dictionary/property/itemDelimiter.lcdoc
@@ -2,13 +2,15 @@ Name: itemDelimiter
 
 Type: property
 
-Syntax: set the itemDelimiter to <character> 
+Syntax: set the itemDelimiter to <character|character(s)> 
 
-Summary: Specifies the <character> used to separate <items> in <chunk expression|chunk expressions>.
+Summary: Specifies the <character|character(s)> used to separate <items> in <chunk expression|chunk expressions>.
 
 Synonyms: itemDel
 
 Introduced: 1.0
+
+Changed: 7.0.0
 
 OS: mac,windows,linux,ios,android
 
@@ -20,14 +22,17 @@ set the itemDelimiter to numToChar(202)
 Example:
 set the itemDelimiter to tab
 
+Example:
+set the itemDelimiter to ";;"
+
 Value:
-The <itemDelimiter> is a <character>.
+From LiveCode 7.0, <itemDelimiter> can be a string of one or several <character|characters>. 
 By default, the <itemDelimiter> <property> is set to <comma>.
 
 Description:
-Use the <itemDelimiter> <property> to divide text into <chunk|chunks> based on a <delimit|delimiting> <character>.
+Use the <itemDelimiter> <property> to divide text into <chunk|chunks> based on a <delimit|delimiting> <character|character(s)>.
 
-The <itemDelimiter> is a single <character>. <chunk expression|Chunk expressions> use the <itemDelimiter> to determine where one <item> ends and the next begins.
+From LiveCode 7.0, <itemDelimiter> can be a string of one or several <character|characters>.  <chunk expression|Chunk expressions> use the <itemDelimiter> to determine where one <item> ends and the next begins.
 
 Since the <itemDelimiter> is a <local property>, its value is <reset> to comma when the current <handler> finishes <execute|executing>. It retains its <value> only for the current <handler>, and setting it in one <handler> does not affect its <value> in other <handler|handlers> it <call|calls>.
 

--- a/docs/dictionary/property/lineDelimiter.lcdoc
+++ b/docs/dictionary/property/lineDelimiter.lcdoc
@@ -2,13 +2,15 @@ Name: lineDelimiter
 
 Type: property
 
-Syntax: set the lineDelimiter to <character> 
+Syntax: set the lineDelimiter to <character|character(s)>
 
-Summary: Specifies the <character> used to separate <lines> in <chunk expression|chunk expressions>.
+Summary: Specifies the <character|character(s)> used to separate <lines> in <chunk expression|chunk expressions>.
 
 Synonyms: lineDel
 
 Introduced: 2.0
+
+Changed: 7.0.0
 
 OS: mac,windows,linux,ios,android
 
@@ -20,14 +22,17 @@ set the lineDelimiter to numToChar(13)
 Example:
 set the lineDelimiter to myRecordDelimiter
 
+Example:
+set the itemDelimiter to ";;"
+
 Value:
-The <lineDelimiter> is a <character>.
+From LiveCode 7.0, <lineDelimiter> can be a string of one or several <character|characters>.
 By default, the <lineDelimiter> <property> is set to <return>.
 
 Description:
 Use the <lineDelimiter> <property> to divide text into <chunk|chunks> based on a <delimit|delimiting> <character>.
 
-The <lineDelimiter> is a single <character>. <chunk expression|Chunk expressions> use the <lineDelimiter> to determine where one <line> ends and the next begins.
+From LiveCode 7.0, <lineDelimiter> can be a string of one or several <character|characters>. <chunk expression|Chunk expressions> use the <lineDelimiter> to determine where one <line> ends and the next begins.
 
 Since the <lineDelimiter> is a <local property>, its value is <reset> to <return> when the current <handler> finishes <execute|executing>. It retains its <value> only for the current <handler>, and setting it in one <handler> does not affect its <value> in other <handler|handlers> it <call|calls>.
 

--- a/docs/dictionary/property/rowDelimiter.lcdoc
+++ b/docs/dictionary/property/rowDelimiter.lcdoc
@@ -2,13 +2,15 @@ Name: rowDelimiter
 
 Type: property
 
-Syntax: set the rowDelimiter to <character> 
+Syntax: set the rowDelimiter to <character|character(s)>
 
 Syntax: get the rowDelimiter
 
-Summary: Specifies the character used to separate rows in a string.
+Summary: Specifies the <character|character(s)> used to separate rows in a string.
 
 Introduced: 2.8.1
+
+Changed: 7.0.0
 
 OS: mac,windows,linux,ios,android
 
@@ -20,14 +22,17 @@ set the rowDelimiter to comma
 Example:
 put the rowDelimiter into tRowDelimiter
 
+Example:
+set the rowDelimiter to ";;"
+
 Value:
-The <rowDelimiter> is a character
+From LiveCode 7.0, <rowDelimiter> can be a string of one or several <character|characters>. 
 By default, the rowDelimiter is set to return.
 
 Description:
 Use the <rowDelimiter> property in conjunction with the <split command> to divide text into an array of rows or with the <combine command> to combine an array of rows into a string.
 
-The <rowDelimiter> is a single character. 
+From LiveCode 7.0, <rowDelimiter> can be a string of one or several <character|characters>.
 
 Since the <rowDelimiter> is a local property, its value is reset to return when the current handler finishes executing. It retains its value only for the current handler and setting it in one handler does not affect its value in other handlers called.
 


### PR DESCRIPTION
columnDelimiter, itemDelimiter, lineDelimiter, rowDelimiter and split `lcdoc` files
have been updated to reflect the fact that delimiters can have several characters.

This is ports the docs update for 7 to 8.
