### PR TITLE
[[ Bug 15929 ]] Speed up 'read' command

### DIFF
--- a/docs/notes/bugfix-15929.md
+++ b/docs/notes/bugfix-15929.md
@@ -1,0 +1,1 @@
+# reading from Unicode files is extremely slow in LC 7

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1346,7 +1346,9 @@ uint4 MCFilesExecPerformReadCodeUnit(MCExecContext& ctxt, int4 p_index, intenum_
 				else
 					t_codeunit = *(unichar_t*)t_bytes . Bytes();
 
-				MCStringAppendChar(x_buffer, t_codeunit);
+                // Use fast appending, as we will always read UTF-16 in the
+                // buffer for the whole execution of this 'read' command.
+				MCStringFastAppendChar(x_buffer, t_codeunit);
 				t_codeunit_added = 1;
             }
             // SN-2014-12-02: [[ Bug 14135 ]] Do not wait if reading empty may occur
@@ -1366,7 +1368,10 @@ uint4 MCFilesExecPerformReadCodeUnit(MCExecContext& ctxt, int4 p_index, intenum_
                 MCAutoStringRef t_string;
                 
                 /* UNCHECKED */ MCStringCreateWithBytes((byte_t*)&t_codeunit, t_bytes_read, MCS_file_to_string_encoding((MCFileEncodingType)p_encoding), false, &t_string);
-                /* UNCHECKED */ MCStringAppend(x_buffer, *t_string);
+
+                // Use fast appending, as we will always read UTF-32 in the
+                // buffer for the whole execution of this 'read' command.
+                /* UNCHECKED */ MCStringFastAppend(x_buffer, *t_string);
                 
                 t_codeunit_added = MCStringGetLength(*t_string);
             }
@@ -1438,7 +1443,10 @@ uint4 MCFilesExecPerformReadCodeUnit(MCExecContext& ctxt, int4 p_index, intenum_
 					MCAutoStringRef t_codepoints;
 					MCStringCreateWithBytes(t_bytes . Bytes(), t_bytes_read, kMCStringEncodingUTF8, false, &t_codepoints);
 					t_codeunit_added = MCStringGetLength(*t_codepoints);
-					MCStringAppend(x_buffer, *t_codepoints);
+
+                    // Use fast appending, as we will always read UTF-8 in the
+                    // buffer for the whole execution of this 'read' command.
+					MCStringFastAppend(x_buffer, *t_codepoints);
 				}
 				else
 				{

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1837,6 +1837,17 @@ bool MCStringAppendNativeChars(MCStringRef string, const char_t *chars, uindex_t
 bool MCStringAppendChar(MCStringRef string, unichar_t p_char);
 bool MCStringAppendNativeChar(MCStringRef string, char_t p_char);
 
+// Fast-append suffix to string
+//
+// Note that for those functions, Unicode prevails over Nativeness
+// They are intended for tigh loops of small appending, to avoid repeatitive
+// nativeness (costly) checking.
+bool MCStringFastAppend(MCStringRef string, MCStringRef p_suffix);
+bool MCStringFastAppendChar(MCStringRef string, unichar_t p_char);
+bool MCStringFastAppendChars(MCStringRef string, const unichar_t *chars, uindex_t count);
+bool MCStringFastAppendNativeChar(MCStringRef string, char_t p_char);
+bool MCStringFastAppendNativeChars(MCStringRef string, const char_t *chars, uindex_t count);
+
 // Prepend prefix to string.
 //
 // Note that 'string' must be mutable, it is a fatal runtime error if it is not.

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -442,7 +442,9 @@ bool MCUnicodeCharsMapToNative(const unichar_t *uchars, uindex_t uchar_count, ch
 void MCUnicodeCharsMapFromNative(const char_t *chars, uindex_t char_count, unichar_t *uchars);
 
 uindex_t MCUnicodeCharsMapToUTF8(const unichar_t *wchars, uindex_t wchar_count, byte_t *utf8bytes, uindex_t utf8byte_count);
+
 uindex_t MCUnicodeCharsMapFromUTF8(const byte_t *utf8bytes, uindex_t utf8byte_count, unichar_t *wchars, uindex_t wchar_count);
+uindex_t MCUnicodeCharsMapFromUTF8WithNativeCheck(const byte_t *utf8bytes, uindex_t utf8byte_count, unichar_t *wchars, uindex_t wchar_count, bool &r_is_native);
 
 bool MCUnicodeCharMapToNative(unichar_t uchar, char_t& r_nchar);
 char_t MCUnicodeCharMapToNativeLossy(unichar_t nchar);


### PR DESCRIPTION
String Fast Appending

Fast appending a string consists of making Unicode prevail over nativeness
(which is the opposite of the usual behaviour).

The fast Append functions are mainly intended for tigh loops where small
chunks of text are appended, and where we don't need nor want to check the
nativeness of the string after each appending.

That is the case in MCFilesExecPerformReadCodeUnit, where the encoding is
fixed for the whole reading, and that we don't want to spend a huge amount
of time checking whether the string is native, as it is not the most likely.

Additionally, creating a string from UTF-8 bytes now checks whether the string
is not a native string (all chars < 128), and if it is, uses the bytes as native
chars.
