### PR TITLE
[[ Bug 16069 ]] Check if an item has been selected when a menu is closed

### DIFF
--- a/docs/notes/bugfix-16069.md
+++ b/docs/notes/bugfix-16069.md
@@ -1,0 +1,1 @@
+# Crash when closing button menu by clicking outside of it

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -418,8 +418,17 @@ void MCButton::macopenmenu(void)
                 // SN-2014-08-25: [[ Bug 13240 ]] We need to keep the actual popup_menustring,
                 //  in case some menus are nested
                 MCStringRef t_menupick;
-                t_menupick = s_popup_menupick;
-                s_popup_menupick = nil;
+                if (s_popup_menupick != NULL)
+                {
+                    t_menupick = s_popup_menupick;
+                    s_popup_menupick = nil;
+                }
+                else
+                {
+                    // SN-2015-10-05: [[ Bug 16069 ]] s_popup_menupick remains
+                    //  NULL if a menu is closed by clicking outside of it
+                    t_menupick = MCValueRetain(kMCEmptyString);
+                }
                 
 				Exec_stat es = message_with_valueref_args(MCM_menu_pick, t_menupick);
                 
@@ -444,8 +453,17 @@ void MCButton::macopenmenu(void)
                 // SN-2014-08-25: [[ Bug 13240 ]] We need to keep the actual popup_menustring,
                 //  in case some menus are nested
                 MCStringRef t_menupick;
-                t_menupick = s_popup_menupick;
-                s_popup_menupick = nil;
+                if (s_popup_menupick != NULL)
+                {
+                    t_menupick = s_popup_menupick;
+                    s_popup_menupick = nil;
+                }
+                else
+                {
+                    // SN-2015-10-05: [[ Bug 16069 ]] s_popup_menupick remains
+                    //  NULL if a menu is closed by clicking outside of it
+                    t_menupick = MCValueRetain(kMCEmptyString);
+                }
                 
 				Exec_stat es = message_with_valueref_args(MCM_menu_pick, t_menupick);
                 


### PR DESCRIPTION
If the menu was closed by clicking outside of it, then s_popup_menuclick remains NULL.
A check for this case has been added in MCButton::macopenmenu
