### PR TITLE
Revert "[[ emscripten ]] Disable our Harfbuzz typeface cache"

### DIFF
--- a/libgraphics/src/harfbuzztext.cpp
+++ b/libgraphics/src/harfbuzztext.cpp
@@ -214,7 +214,7 @@ MCHarfbuzzSkiaFace *MCHarfbuzzGetFaceForSkiaTypeface(SkTypeface *p_typeface, uin
         t_hb_sk_face -> skia_face = t_face;
         p_typeface -> ref();
         
-        //MCGCacheTableSet(s_hb_face_cache, t_key, sizeof(t_id), &t_hb_sk_face, sizeof(MCHarfbuzzSkiaFace*));
+		MCGCacheTableSet(s_hb_face_cache, t_key, sizeof(t_id), t_hb_sk_face, sizeof(MCHarfbuzzSkiaFace));
         return t_hb_sk_face;
 	}
 	


### PR DESCRIPTION
This reverts commit 1a28bdb6192056d13881b7573e9ad60027ba0510.

@livecodeian reports that the underlying issue has been solved so this commit can be reverted. 

Related bug: http://quality.runrev.com/show_bug.cgi?id=14786
Fixed in: https://github.com/livecode/livecode/pull/2973
