### PR TITLE
[[ Bug 16081 ]] Crash when fetching the shadow property.

### DIFF
--- a/docs/notes/bugfix-16081.md
+++ b/docs/notes/bugfix-16081.md
@@ -1,0 +1,1 @@
+# Crash when fetching 'the shadow' property of an object.

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1009,10 +1009,15 @@ static void MCInterfaceShadowParse(MCExecContext& ctxt, MCStringRef p_input, MCI
 
 static void MCInterfaceShadowFormat(MCExecContext& ctxt, const MCInterfaceShadow& p_input, MCStringRef& r_output)
 {
-	if (p_input . flag)
-		r_output = (MCStringRef)MCValueRetain(kMCTrue);
-	else
-		r_output = (MCStringRef)MCValueRetain(kMCFalse);
+    if (p_input . is_flag)
+    {
+        if (p_input . flag)
+            r_output = MCValueRetain(kMCTrueString);
+        else
+            r_output = MCValueRetain(kMCFalseString);
+    }
+    else
+        ctxt . FormatInteger(p_input . shadow, r_output);
 }
 
 static void MCInterfaceShadowFree(MCExecContext& ctxt, MCInterfaceShadow& p_input)
@@ -3026,6 +3031,7 @@ void MCObject::SetOpaque(MCExecContext& ctxt, bool setting)
 }
 void MCObject::GetShadow(MCExecContext& ctxt, MCInterfaceShadow& r_shadow)
 {
+    r_shadow . is_flag = true;
 	r_shadow . flag = getflag(F_SHADOW);
 }
 

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -452,6 +452,11 @@ bool MCExecContext::FormatReal(real64_t p_real, MCStringRef& r_value)
 	return MCU_r8tos(p_real, GetNumberFormatWidth(), GetNumberFormatTrailing(), GetNumberFormatForce(), r_value);
 }
 
+bool MCExecContext::FormatInteger(integer_t p_integer, MCStringRef& r_value)
+{
+	return MCStringFormat(r_value, "%d", p_integer);
+}
+
 bool MCExecContext::FormatUnsignedInteger(uinteger_t p_integer, MCStringRef& r_value)
 {
 	return MCStringFormat(r_value, "%u", p_integer);


### PR DESCRIPTION
The shadow property of object's uses a custom type MCInterfaceShadow. The formatting method of this, however, was unfinished and using boolean values rather than the string boolean values. This has been corrected. In addition, the GetShadow method was incorrectly initialising the MCInterfaceShadow structure.
