### PR TITLE
[[ no-UI Crash ]] bugfix 16017 causes a crash when LiveCode is run in…

### DIFF
--- a/engine/src/stackview.cpp
+++ b/engine/src/stackview.cpp
@@ -448,11 +448,18 @@ void MCStack::view_update_transform(void)
 	
 	// PM-2015-07-17: [[ Bug 13754 ]] Make sure stack does not disappear off screen when changing the scalefactor
     MCRectangle t_bounded_rect, t_screen_rect;
-	
-	// AL-2015-10-01: [[ Bug 16017 ]] Remember location of stacks on a second monitor
-    t_screen_rect = MCscreen -> getnearestdisplay(t_view_rect) -> viewport;
-	
-    t_bounded_rect = MCU_bound_rect(t_view_rect, t_screen_rect . x, t_screen_rect . y, t_screen_rect . width, t_screen_rect . height);
+    
+    const MCDisplay* t_nearest_display = MCscreen -> getnearestdisplay(t_view_rect);
+    if (t_nearest_display != NULL)
+    {
+        t_screen_rect = t_nearest_display -> viewport;
+        t_bounded_rect = MCU_bound_rect(t_view_rect, t_screen_rect . x, t_screen_rect . y, t_screen_rect . width, t_screen_rect . height);
+    }
+    else
+    {
+        // In noUI mode, we don't have a nearest display.
+        t_bounded_rect = MCU_bound_rect(t_view_rect, 0, 0, MCscreen -> getwidth(), MCscreen -> getheight());
+    }
 	
     // IM-2014-01-16: [[ StackScale ]] Update view rect if needed
     view_setrect(t_bounded_rect);


### PR DESCRIPTION
… no-UI mode

should check whether a display has been returned before accessing its rectangle view
