### PR TITLE
[[ Perf ]] Improve get speed

### DIFF
--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -920,11 +920,11 @@ void MCGet::exec_ctxt(MCExecContext& ctxt)
 	return ES_NORMAL;
 #endif /* MCGet */
 
-    MCAutoValueRef t_value;
-    if (!ctxt . EvalExprAsValueRef(value, EE_GET_BADEXP, &t_value))
+    MCExecValue t_value;
+    if (!ctxt . EvaluateExpression(value, EE_GET_BADEXP, t_value))
         return;
 
-    MCEngineExecGet(ctxt, *t_value);
+    MCEngineExecGet(ctxt, t_value);
 }
 
 void MCGet::compile(MCSyntaxFactoryRef ctxt)

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -692,9 +692,9 @@ void MCEngineExecSet(MCExecContext& ctxt, MCProperty *p_target, MCValueRef p_val
 	}
 }
 
-void MCEngineExecGet(MCExecContext& ctxt, MCValueRef p_value)
+void MCEngineExecGet(MCExecContext& ctxt, /* take */ MCExecValue& p_value)
 {
-	ctxt . SetItToValue(p_value);
+	ctxt . GetIt() -> give_value(ctxt, p_value);
 }
 
 void MCEngineExecPutOutput(MCExecContext& ctxt, MCStringRef p_value)

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -694,7 +694,7 @@ void MCEngineExecSet(MCExecContext& ctxt, MCProperty *p_target, MCValueRef p_val
 
 void MCEngineExecGet(MCExecContext& ctxt, /* take */ MCExecValue& p_value)
 {
-	ctxt . GetIt() -> give_value(ctxt, p_value);
+    ctxt . GiveValueToIt(p_value);
 }
 
 void MCEngineExecPutOutput(MCExecContext& ctxt, MCStringRef p_value)

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1170,6 +1170,11 @@ void MCExecContext::SetItToValue(MCValueRef p_value)
     GetIt() -> set(*this, p_value);
 }
 
+void MCExecContext::GiveValueToIt(/* take */ MCExecValue& p_value)
+{
+    GetIt() -> give_value(*this, p_value);
+}
+
 void MCExecContext::SetItToEmpty(void)
 {
 	SetItToValue(kMCEmptyString);

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1167,9 +1167,7 @@ MCVarref* MCExecContext::GetIt() const
 
 void MCExecContext::SetItToValue(MCValueRef p_value)
 {
-    MCAutoPointer<MCContainer> t_container;
-    GetIt() -> evalcontainer(*this, &t_container);
-	t_container -> set_valueref(p_value);
+    GetIt() -> set(*this, p_value);
 }
 
 void MCExecContext::SetItToEmpty(void)

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3803,7 +3803,7 @@ void MCEngineEvalMenuObjectAsObject(MCExecContext& ctxt, MCObjectPtr& r_object);
 void MCEngineEvalTargetAsObject(MCExecContext& ctxt, MCObjectPtr& r_object);
 void MCEngineEvalErrorObjectAsObject(MCExecContext& ctxt, MCObjectPtr& r_object);
 
-void MCEngineExecGet(MCExecContext& ctxt, MCValueRef value);
+void MCEngineExecGet(MCExecContext& ctxt, /* take */ MCExecValue& value);
 void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCValueRef value, int where, MCVariableChunkPtr t_target);
 void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCExecValue value, int where, MCVariableChunkPtr t_target);
 void MCEngineExecPutOutput(MCExecContext& ctxt, MCStringRef value);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1613,6 +1613,9 @@ public:
     MCVarref *GetIt() const;
 	void SetItToEmpty(void);
 	void SetItToValue(MCValueRef p_value);
+    
+    // Assign the given ExecValue to it, the 'it' variable takes ownership.
+	void GiveValueToIt(/* take */ MCExecValue& p_value);
 	
 	//////////    
 


### PR DESCRIPTION
The setting of it has been sped up by not indirecting through an MCContainer.

The speed of 'get' has been improved by vectoring through an MCExecValue rather than an MCValueRef.
