### PR TITLE
[[ Bug 13537 ]] Strict compilation issue with global variables

### DIFF
--- a/docs/notes/bugfix-13537.md
+++ b/docs/notes/bugfix-13537.md
@@ -1,0 +1,1 @@
+# Global variables should not trigger a strict compilation error if a local variable has the same name in another object script

--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -125,15 +125,6 @@ Parse_stat MCLocaltoken::parse(MCScriptPoint &sp)
 			return PS_ERROR;
 		}
 
-		MCVariable *tmp;
-		for (tmp = MCglobals ; tmp != NULL ; tmp = tmp->getnext())
-			if (tmp -> hasname(t_token_name))
-				if (MCexplicitvariables)
-				{
-					MCperror->add(PE_LOCAL_SHADOW, sp);
-					return PS_ERROR;
-				}
-
 		MCVarref *tvar = NULL;
 		MCString init;
 		bool initialised = false;


### PR DESCRIPTION
With Strict Compilation turned on, local variable creation should only check for
the existence of global variables declared in that handler and in this script only.
