### PR TITLE
[[ WinServer crash ]] Initialise t_max_distance_display in getnearest…

### DIFF
--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -505,6 +505,7 @@ const MCDisplay *MCUIDC::getnearestdisplay(const MCRectangle& p_rectangle)
 
 	t_max_area = 0;
 	t_max_distance = MAXUINT4;
+    t_max_distance_index = 0;
 	for(uint4 t_display = 0; t_display < t_display_count; ++t_display)
 	{
 		MCRectangle t_workarea;


### PR DESCRIPTION
…display

This was causing crashes on server (which do not have display)
