### PR TITLE
[Bug 16092][emscripten] Set the canvas to use the "default" cursor

### DIFF
--- a/docs/notes/bugfix-16092.md
+++ b/docs/notes/bugfix-16092.md
@@ -1,0 +1,1 @@
+# HTML5 standalones always show the cursor as a "text insertion" cursor

--- a/engine/src/em-event.js
+++ b/engine/src/em-event.js
@@ -83,6 +83,10 @@ mergeInto(LibraryManager.library, {
 			// Make it a target for text input events
 			target.setAttribute('contentEditable', 'true');
 
+			// Force the canvas to use a normal mouse cursor by
+			// default
+			target.style.cursor = 'default';
+
 			LiveCodeEvents._initialised = false;
 		},
 


### PR DESCRIPTION
By default, the browser sets a contentEditable element to have the
"text insertion" cursor.  Because the canvas is set to be
contentEditable in order to receive text input events, it's necessary
to explicitly set the canvas back to using the default cursor.

A subsequent patch should connect up the cursor control syntax in
LiveCode to control the CSS cursor.
