### PR TITLE
[Bug 15821] Improve date syntax and clock timezone handling

### DIFF
--- a/docs/lcb/notes/feature-timezone.md
+++ b/docs/lcb/notes/feature-timezone.md
@@ -2,5 +2,6 @@
 
 ## Date and time
 
-* `the local time` now returns a list with an additional 7th element.
-  This is the local time zone's offset from UTC, in seconds.
+* `the local date` now returns a list with an additional 7th element.  This is the local time zone's offset from UTC, in seconds.
+
+* The new `the universal date` expression provides the date in the UTC+00:00 timezone.  It returns a list in the same format as `the local date`.

--- a/docs/lcb/notes/feature-timezone.md
+++ b/docs/lcb/notes/feature-timezone.md
@@ -1,0 +1,6 @@
+# LiveCode Builder Standard Library
+
+## Date and time
+
+* `the local time` now returns a list with an additional 7th element.
+  This is the local time zone's offset from UTC, in seconds.

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -197,7 +197,7 @@ end handler
 
 handler getTimeComponents() returns List
 	-- Fetch the local date.
-    -- This a list in the form [day, month, year, hours,minutes,seconds]
+    -- This a list in the form [day, month, year, hours, minutes, seconds, gmt_offset]
     variable tDate as List
     put the local date into tDate
 
@@ -205,9 +205,22 @@ handler getTimeComponents() returns List
     delete element 1 to 3 of tDate
 
     -- Adjust for the timezone.
+    --
+    -- N.b. we use the local date and translate the timezone because
+    -- the clock widget doesn't yet know how to account for timezones
+    -- with differing daylight savings time transitions.
 	variable tHour as Number
     put element 1 of tDate into tHour
-    put (tHour + mTimeZone) mod 24 into tHour
+
+	-- Estimate the correction needed to get to GMT.  This won't
+	-- work properly for timezones with a GMT offset that isn't a
+	-- whole number of hours (e.g. North Korea).
+	variable tGmtOffset as Number
+	put the last element of tDate into tGmtOffset
+	divide tGmtOffset by 3600
+	round tGmtOffset
+
+	put (tHour - tGmtOffset + mTimeZone) mod 24 into tHour
 
     -- Compute whether it is 'day' or 'night'
 	if tHour > kStartDay and tHour < kEndDay then

--- a/extensions/widgets/clock/notes/15821.md
+++ b/extensions/widgets/clock/notes/15821.md
@@ -1,0 +1,1 @@
+# Clock widget timezone wrong

--- a/libscript/src/date.mlc
+++ b/libscript/src/date.mlc
@@ -28,7 +28,7 @@ public foreign handler MCDateExecGetLocalDate(out rDateTime as List) returns not
 public foreign handler MCDateExecGetUniversalTime(out rSeconds as CDouble) returns nothing binds to "<builtin>"
 
 /*
-Summary:	The local gregorian date
+Summary:	The local Gregorian date
 
 Example:
 	variable tDateTime as List
@@ -38,7 +38,7 @@ Example:
 	put tDateTime[3] into tDayOfMonth
 
 Description:
-Returns the local date as a list of six numeric components.  The
+Returns the local date as a list of seven numeric components.  The
 elements of the list are:
 
 * The year
@@ -47,6 +47,7 @@ elements of the list are:
 * The hour (0-23)
 * The minute (0-59)
 * The second (0-59)
+* The offset from UTC in seconds
 
 Tags: Date and time
 */

--- a/libscript/src/date.mlc
+++ b/libscript/src/date.mlc
@@ -25,6 +25,7 @@ module com.livecode.date
 use com.livecode.foreign
 
 public foreign handler MCDateExecGetLocalDate(out rDateTime as List) returns nothing binds to "<builtin>"
+public foreign handler MCDateExecGetUniversalDate(out rDateTime as List) returns nothing binds to "<builtin>"
 public foreign handler MCDateExecGetUniversalTime(out rSeconds as CDouble) returns nothing binds to "<builtin>"
 
 /*
@@ -49,12 +50,39 @@ elements of the list are:
 * The second (0-59)
 * The offset from UTC in seconds
 
+References: UniversalDate (expression)
+
 Tags: Date and time
 */
 syntax LocalDate is expression
 	"the" "local" "date"
 begin
 	MCDateExecGetLocalDate(output)
+end syntax
+
+/*
+Summary:	The UTC Gregorian date
+
+Example:
+	variable tDateTime as List
+	put the universal date into tDateTime
+
+	variable tMinuteOfHour as Number
+	put tDateTime[5] into tMinuteOfHour
+
+Description:
+Returns the universal date (i.e. the current date in the UTC+00:00
+time zone) as a list of seven numeric components.  The elements of the
+list are the same as for <LocalDate>.
+
+References: LocalDate (expression)
+
+Tags: Date and time
+*/
+syntax UniversalDate is expression
+	"the" "universal" "date"
+begin
+	MCDateExecGetUniversalDate(output)
 end syntax
 
 /*Summary:	The seconds

--- a/libscript/src/module-date.cpp
+++ b/libscript/src/module-date.cpp
@@ -47,8 +47,8 @@ MCDateGetTimeInfo(bool t_is_local,
 	/* Windows doesn't have localtime_r(), but it does have an equivalent
 	 * function with the arguments in the opposite order! */
 	if (0 != (t_is_local
-	          ? localtime_s(&r_timeinfo, &t_time)
-	          : gmtime_s(&r_timeinfo, &t_time)))
+	          ? localtime_s(&r_timeinfo, &t_now)
+	          : gmtime_s(&r_timeinfo, &t_now)))
 	{
 		return false;
 	}

--- a/tests/lcb/stdlib/date.lcb
+++ b/tests/lcb/stdlib/date.lcb
@@ -1,0 +1,31 @@
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.date.tests
+
+public handler TestLocalDate()
+	variable tDate
+	put the local date into tDate
+	test "local date element count" when the number of elements in tDate is 7
+	test "local date month range" when tDate[2] >= 1 and tDate[2] <= 12
+	test "local date day range" when tDate[3] >= 1 and tDate[3] <= 31
+	test "local date hour range" when tDate[4] >= 0 and tDate[4] <= 23
+	test "local date minute range" when tDate[5] >= 0 and tDate[5] <= 59
+	test "local date second range" when tDate[6] >= 0 and tDate[6] <= 59
+end handler
+
+end module

--- a/tests/lcb/stdlib/date.lcb
+++ b/tests/lcb/stdlib/date.lcb
@@ -28,4 +28,16 @@ public handler TestLocalDate()
 	test "local date second range" when tDate[6] >= 0 and tDate[6] <= 59
 end handler
 
+public handler TestUniversalDate()
+	variable tDate
+	put the universal date into tDate
+	test "utc date element count" when the number of elements in tDate is 7
+	test "utc date month range" when tDate[2] >= 1 and tDate[2] <= 12
+	test "utc date day range" when tDate[3] >= 1 and tDate[3] <= 31
+	test "utc date hour range" when tDate[4] >= 0 and tDate[4] <= 23
+	test "utc date minute range" when tDate[5] >= 0 and tDate[5] <= 59
+	test "utc date second range" when tDate[6] >= 0 and tDate[6] <= 59
+	test "utc date no gmt offset" when tDate[7] is 0
+end handler
+
 end module


### PR DESCRIPTION
Try a bit harder to handle timezones correctly in the clock widget.

This change set does a number of things:
- Adds the UTC offset as a 7th element in the list returned by `the local date`
- Adds a `the universal date` which returns the UTC+0 date
- Makes the clock widget subtract the timezone offset from the local time before applying the hour offset from its `timezone` property.

This isn't ideal because it doesn't seem to take into account the fact that summer time changeovers happen differently depending on where you are, but it's hard to deal with that without access to the tzdata database.

There are tests.
