### PR TITLE
[[ Bug 16118 ]] Fix some mismatched MCerrorlock increments

### DIFF
--- a/docs/notes/bugfix-16118.md
+++ b/docs/notes/bugfix-16118.md
@@ -1,0 +1,1 @@
+# Error dialog doesn't open correctly in some circumstances

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -2919,7 +2919,6 @@ void MCSubwindow::exec_ctxt(MCExecContext &ctxt)
 		case WM_SHEET:
 		case WM_DRAWER:
 			{
-				MCerrorlock++;
 				MCNewAutoNameRef t_parent_name;
                 if (!ctxt . EvalOptionalExprAsNullableNameRef(parent, EE_SUBWINDOW_BADEXP, &t_parent_name))
                     return;
@@ -2989,7 +2988,6 @@ void MCSubwindow::exec_ctxt(MCExecContext &ctxt)
 					else
 						MCInterfaceExecDrawerStack(ctxt, (MCStack *)optr, *t_parent_name, thisstack == True, t_pos, t_align);
 				}
-                MCerrorlock--;
 				break;
 			}
 		case WM_PULLDOWN:

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -2989,6 +2989,7 @@ void MCSubwindow::exec_ctxt(MCExecContext &ctxt)
 					else
 						MCInterfaceExecDrawerStack(ctxt, (MCStack *)optr, *t_parent_name, thisstack == True, t_pos, t_align);
 				}
+                MCerrorlock--;
 				break;
 			}
 		case WM_PULLDOWN:

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -2545,6 +2545,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
             if (MCValueGetTypeCode(t_temp_items[i]) != kMCValueTypeCodeString)
                 t_all_strings = false;
         }
+        MCerrorlock--;
         t_items = t_temp_items;
     }
     else

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -448,10 +448,10 @@ bool MCGradientFillGetProperties(MCExecContext& ctxt, MCGradientFill* p_gradient
             t_success = MCArrayStoreValue(*v, kMCCompareExact, *t_key, t_prop_value);
     }
     
+    MCerrorlock--;
+    
     if (t_success)
     {
-        MCerrorlock--;
-        
         r_value . arrayref_value = MCValueRetain(*v);
         r_value . type = kMCExecValueTypeArrayRef;
         return true;


### PR DESCRIPTION
This is not quite right yet - the MCerrorlock++ in MCSubwindow doesn't seem to have an obvious purpose.
