### PR TITLE
[[ Foundation ]] Make single byte fetching more efficient (7.x)

### DIFF
--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -20,6 +20,10 @@
 #include "foundation-private.h"
 
 
+////////////////////////////////////////////////////////////////////////////////
+
+// An array of all possible (256) single byte DataRefs.
+static MCDataRef *__kMCSingleBytes;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -368,6 +372,14 @@ bool MCDataCopyRange(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
     
     __MCDataClampRange(self, p_range);
     
+    // We special-case when the length of the range to be copied is 1. Rather
+    // than create a brand new DataRef, we use one of the pre-allocated ones.
+    if (p_range . length == 1)
+    {
+        r_new_data = MCValueRetain(__kMCSingleBytes[self -> bytes[p_range . offset]]);
+        return true;
+    }
+    
     return MCDataCreateWithBytes(self -> bytes + p_range . offset, p_range . length, r_new_data);
 }
 
@@ -715,11 +727,29 @@ bool __MCDataInitialize(void)
     if (!MCDataCreateWithBytes(nil, 0, kMCEmptyData))
         return false;
     
+    // Allocate the array for the 256 single byte DataRefs.
+    if (!MCMemoryNewArray(256, __kMCSingleBytes))
+        return false;
+    
+    // Create each single byte DataRef.
+    for(uindex_t i = 0; i < 256; i++)
+    {
+        byte_t t_byte;
+        t_byte = (byte_t)i;
+        if (!MCDataCreateWithBytes(&t_byte, 1, __kMCSingleBytes[i]))
+            return false;
+    }
+    
     return true;
 }
 
 void __MCDataFinalize(void)
 {
+    // Deallocate all the single byte DataRefs and their holding array.
+    for(uindex_t i = 0; i < 256; i++)
+        MCValueRelease(__kMCSingleBytes[i]);
+    MCMemoryDeleteArray(__kMCSingleBytes);
+    
     MCValueRelease(kMCEmptyData);
 }
 


### PR DESCRIPTION
When copying a data range which is of length 1, libfoundation will now use
a pre-allocated, immutable MCDataRef.

A vector of 256 MCDataRefs, corresponding to each single byte value is
created on startup.

(cherry picked from commit 215f5939243a9ba0368cca428118c2b5cc56b062)
