### PR TITLE
Improve engine lock debugging infrastructure

### DIFF
--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -388,8 +388,8 @@ uint2 MClook;
 MCStringRef MCttbgcolor;
 MCStringRef MCttfont;
 uint2 MCttsize;
-uint2 MCtrylock;
-uint2 MCerrorlock;
+MCSemaphore MCtrylock;
+MCSemaphore MCerrorlock;
 Boolean MCwatchcursor;
 Boolean MClockcursor;
 MCCursorRef MCcursor;
@@ -769,8 +769,8 @@ void X_clear_globals(void)
     MCttfont = MCSTR(DEFAULT_TEXT_FONT);
     MCttsize = 12;
 
-	MCtrylock = 0;
-	MCerrorlock = 0;
+    MCtrylock = MCSemaphore("try");
+    MCerrorlock = MCSemaphore("error");
 	MCwatchcursor = False;
 	MClockcursor = False;
 	MCcursor = nil;

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -22,6 +22,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "mcstring.h"
 #include "imagelist.h"
+#include "mcsemaphore.h"
 
 #include "foundation-locale.h"
 
@@ -302,8 +303,8 @@ extern uint2 MClook;
 extern MCStringRef MCttbgcolor;
 extern MCStringRef MCttfont;
 extern uint2 MCttsize;
-extern uint2 MCtrylock;
-extern uint2 MCerrorlock;
+extern MCSemaphore MCtrylock;
+extern MCSemaphore MCerrorlock;
 extern Boolean MCwatchcursor;
 extern Boolean MClockcursor;
 extern MCCursorRef MCcursor;

--- a/engine/src/mcerror.cpp
+++ b/engine/src/mcerror.cpp
@@ -53,7 +53,7 @@ void MCError::add(uint2 id, uint2 line, uint2 pos, uint32_t v)
 
 void MCError::add(uint2 id, uint2 line, uint2 pos, MCValueRef n)
 {
-    if (MCerrorlock != 0 || thrown)
+    if (MCerrorlock || thrown)
 		return;
     
     if (n != nil)
@@ -71,7 +71,7 @@ void MCError::add(uint2 id, uint2 line, uint2 pos, MCValueRef n)
 #ifdef LLEGACY_EXEC
 void MCError::add(uint2 id, uint2 line, uint2 pos, const MCString &token)
 {
-	if (MCerrorlock != 0 || thrown)
+	if (MCerrorlock || thrown)
 		return;
 	doadd(id, line, pos, token);
 }

--- a/engine/src/mcsemaphore.h
+++ b/engine/src/mcsemaphore.h
@@ -1,0 +1,125 @@
+/*                                                                     -*-c++-*-
+
+Copyright (C) 2003-2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef __MC_SEMAPHORE_H__
+#define __MC_SEMAPHORE_H__
+
+/* This is a semaphore with an internal lock count.  It's a drop-in
+ * replacement for a lock counter integer. */
+
+class MCSemaphore
+{
+ public:
+
+	/* Default constructor starts with 0 count */
+	MCSemaphore(const char *p_desc = nil) : m_counter(0)
+	{
+#if defined(DEBUG_LOCKS)
+		m_desc = p_desc;
+#endif /* DEBUG_LOCKS */
+	}
+
+	/* We need a copy constructor to make postfix increment/decrement work
+	 * correctly. */
+	MCSemaphore(const MCSemaphore &p_copy) : m_counter(p_copy.m_counter)
+	{
+#if defined(DEBUG_LOCKS)
+		m_desc = p_copy.m_desc;
+#endif /* DEBUG_LOCKS */
+	}
+
+	~MCSemaphore() {}
+
+	/* ---------- Reset */
+	void Reset()
+	{
+		m_counter = 0;
+	}
+
+	/* ---------- Testing */
+	bool IsLocked() const
+	{
+		return (m_counter > 0);
+	}
+
+	/* Allow use in "if" statements; returns true if locked */
+	/* FIXME mark as explicit */
+	operator bool() const
+	{
+		return IsLocked();
+	}
+
+	/* ---------- Locking ops */
+	void Lock()
+	{
+		MCAssert(m_counter < INT_MAX);
+		++m_counter;
+
+#if defined(DEBUG_LOCKS)
+		MCLog("LOCK %p -> %i (%s)", this, m_counter,
+		      m_desc ? m_desc : "unnamed");
+#endif /* DEBUG_LOCKS */
+	}
+
+	MCSemaphore & /*prefix*/ operator++()
+	{
+		Lock();
+		return *this;
+	}
+
+	MCSemaphore /*postfix*/ operator++(int)
+	{
+		MCSemaphore tmp(*this); /* copy */
+		Lock();
+		return tmp;             /* return old value */
+	}
+
+	/* ---------- Unlocking ops */
+	void Unlock()
+	{
+		MCAssert(m_counter > 0);
+		--m_counter;
+
+#if defined(DEBUG_LOCKS)
+		MCLog("UNLOCK %p -> %i (%s)", this, m_counter,
+		      m_desc ? m_desc : "unnamed");
+#endif /* DEBUG_LOCKS */
+	}
+
+	MCSemaphore & /*prefix*/ operator--()
+	{
+		Unlock();
+		return *this;
+	}
+
+	MCSemaphore /*postfix*/ operator--(int)
+	{
+		MCSemaphore tmp(*this); /* copy */
+		Unlock();
+		return tmp;             /* return old value */
+	}
+
+ private:
+	int m_counter;
+
+#if defined(DEBUG_LOCKS)
+	const char *m_desc;
+#endif /* DEBUG_LOCKS */
+};
+
+#endif /* !__MC_SEMAPHORE_H__ */

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2125,7 +2125,7 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
 	MCtargetptr = oldtargetptr;
 	MCdynamicpath = olddynamic;
 
-	if (stat == ES_ERROR && MCerrorlock == 0 && !MCtrylock)
+	if (stat == ES_ERROR && !MCerrorlock && !MCtrylock)
 	{
 		if (MCnoui)
 		{

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -169,7 +169,7 @@ void MCU_resetprops(Boolean update)
 			MCselected->redraw();
 		}
 	}
-	MCerrorlock = 0;
+	MCerrorlock.Reset();
 	MClockerrors = MClockmessages = MClockrecent = False;
 	MCscreen->setlockmoves(False);
 	MCerrorlockptr = NULL;

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -21,10 +21,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef UTIL_H
 #define UTIL_H
 
+#include "mcsemaphore.h"
+
 typedef struct
 {
 	uint2 lockscreen;
-	uint2 errorlock;
+	MCSemaphore errorlock;
 	Boolean watchcursor;
 	Boolean lockerrors;
 	Boolean lockmessages;


### PR DESCRIPTION
Recently we had an issue where the error lock wasn't getting decremented correctly, and turned out to be quite hard to debug.

This patch adds a new `mcsemaphore` header-only library which provides an `MCSemaphore` class.  This class is a drop-in replacement for any uses of an `int` as a lock counter.  When `DEBUG_LOCKS` is defined during compilation, it prints log messages whenever each lock is acquired or relinquished.

The "try" and "error" locks are modified to use `MCSemaphore`.
