### PR TITLE
Fix crash caused by accessing an MCDataRef as an MCStringRef.

### DIFF
--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -1538,14 +1538,12 @@ void MCField::endselection()
 		{
 			MCAutoStringRef t_string;
 			selectedtext(&t_string);
-			
-			MCAutoDataRef t_data;
-            MCStringEncode(*t_string, kMCStringEncodingNative, false, &t_data);
-			if (*t_data != nil)
+
+			if (*t_string != nil)
             {
                 // SN-2014-12-08: [[ Bug 12784 ]] Only make this field the selectedfield
                 //  if it is Focusable
-                if (MCselectiondata -> Store(TRANSFER_TYPE_TEXT, *t_data)
+                if (MCselectiondata -> Store(TRANSFER_TYPE_TEXT, *t_string)
                         && flags & F_TRAVERSAL_ON)
 					MCactivefield = this;
 			}


### PR DESCRIPTION
On Linux, `MCField::endselection()` places the selected text into the
X11 selection.  It calls `MCPasteBoard::Store()`, which takes two
arguments: a constant denoting the type of data to place in the
selection, and an `MCValueRef` of the appropriate variety.

When the data type is `TRANSFER_TYPE_TEXT`, the value is expected to
be an `MCStringRef`.  However, the `endselection()` method was passing
an `MCDataRef`.

Until commit c1a1a2c5e19f, it turned out that the `MCStringRef` and
`MCDataRef` structures had the same alignment for their contents and
length fields.  This meant that, sometimes, you could get away with
treating an `MCDataRef` as an `MCStringRef` without the engine blowing
up.  However, the aforementioned commit changed the alignment, meaning
that any incorrect casts now cause dereferencing excitingly invalid
pointers and this crash.
