### PR TITLE
[[ Bugfix 14638 ]] Restore the old stack rect when leaving fullscreen mode

### DIFF
--- a/docs/notes/bugfix-14638.md
+++ b/docs/notes/bugfix-14638.md
@@ -1,0 +1,2 @@
+# Ensure the old stack rect is restored when leaving fullscreen mode
+

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -344,6 +344,8 @@ void MCStack::SetFullscreen(MCExecContext& ctxt, bool setting)
         // IM-2014-01-16: [[ StackScale ]] Save the old rect here as view_setfullscreen() will update the stack rect
         if (setting)
             old_rect = rect;
+        else
+            rect = old_rect;
         
         // IM-2014-02-12: [[ Bug 11783 ]] We may also need to reset the fonts on Windows when
         //   fullscreen is changed


### PR DESCRIPTION
Because the old rect wasn't restored, leaving fullscreen mode on
Linux caused the window to be maximised (or partially offscreen,
depending on the window manager).
