### PR TITLE
[Cleanup] libfoundation: Remove two function declarations without definitions

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1665,9 +1665,6 @@ MC_DLLEXPORT bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *fields, in
 // Return the base type of the record.
 MC_DLLEXPORT MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef typeinfo);
 
-// Return the base type of the record.
-MC_DLLEXPORT MCTypeInfoRef MCRecordTypeGetBaseTypeInfo(MCTypeInfoRef typeinfo);
-
 // Return the number of fields in the record.
 MC_DLLEXPORT uindex_t MCRecordTypeInfoGetFieldCount(MCTypeInfoRef typeinfo);
 

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -49,10 +49,6 @@ MC_DLLEXPORT_DEF MCTypeInfoRef MCProperListTypeInfo() { return kMCProperListType
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static bool __MCTypeInfoIsNamed(MCTypeInfoRef self);
-
-////////////////////////////////////////////////////////////////////////////////
-
 
 static intenum_t __MCTypeInfoGetExtendedTypeCode(MCTypeInfoRef self)
 {


### PR DESCRIPTION
Both `MCRecordTypeGetBaseTypeInfo()` and `__MCTypeInfoIsNamed()` are declared but not defined in libfoundation (and both have similarly named functions that actually exist).
