### PR TITLE
com.livecode.math: Don't find min/max if error is detected

### DIFF
--- a/libscript/src/module-math.cpp
+++ b/libscript/src/module-math.cpp
@@ -343,10 +343,16 @@ extern "C" MC_DLLEXPORT_DEF void MCMathEvalMinNumber(MCNumberRef p_left, MCNumbe
 static void MCMathEvalMinMaxList(MCProperListRef p_list, bool p_is_min, MCNumberRef& r_output)
 {
     if (MCProperListIsEmpty(p_list))
+    {
         MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("list must be non-empty"), nil);
+        return;
+    }
     
     if (!MCProperListIsListOfType(p_list, kMCValueTypeCodeNumber))
+    {
         MCErrorCreateAndThrow(kMCGenericErrorTypeInfo, "reason", MCSTR("list must be numeric"), nil);
+        return;
+    }
 
     double t_minmax, t_cur_real;
     t_cur_real = MCNumberFetchAsReal((MCNumberRef)MCProperListFetchElementAtIndex(p_list, 0));


### PR DESCRIPTION
If the list passed to `MCMathEvalMinMaxList()` is empty or contains
non-Number elements, return rather than creating an error and carrying
on.

This fixes a bug where `kMCNull` was being cast to an `MCNumberRef`
and passed to `MCNumberFetchAsReal()`.
