### PR TITLE
[[ Bug 16111 ]] Fix default location for 'Save' and 'Save As'

### DIFF
--- a/docs/notes/bugfix-16111.md
+++ b/docs/notes/bugfix-16111.md
@@ -1,0 +1,1 @@
+# Save As dialog always opens in a folder deep in LiveCode's app bundle

--- a/engine/src/ask.cpp
+++ b/engine/src/ask.cpp
@@ -373,10 +373,20 @@ Exec_errors MCAsk::exec_file(MCExecPoint& ep, const char *p_title)
 
 	if (!t_error && t_initial != nil)
 	{
-		// IM-2014-08-06: [[ Bug 13096 ]] Allow file dialogs to work with relative paths by resolving to absolute
-		t_initial_resolved = MCS_get_canonical_path(t_initial);
-		if (nil == t_initial_resolved)
-			t_error == EE_NO_MEMORY;
+        // We only want to resolve the path if the path is relative (otherwise
+        // it will be created at the current folder - which is /Applications)
+        if (strchr(t_initial, '/'))
+        {
+            // IM-2014-08-06: [[ Bug 13096 ]] Allow file dialogs to work with relative paths by resolving to absolute
+            t_initial_resolved = MCS_get_canonical_path(t_initial);
+            if (nil == t_initial_resolved)
+                t_error = EE_NO_MEMORY;
+        }
+        else
+        {
+            // Simply copy the file path
+            t_initial_resolved = strclone(*t_initial);
+        }
 	}
 
 	if (!t_error)


### PR DESCRIPTION
The issue was caused by always resolving the initial path - if that initial path is not relative, then the current folder was used
Resolving the path should only be done if a relative path is given (that was introducing by implementing the enhancement request 13096
