### PR TITLE
[[ ServerActivation ]] Make again MCString and MCData alignment identical

### DIFF
--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -174,7 +174,6 @@ struct __MCString: public __MCValue
         MCStringRef string;
         struct
         {
-            double numeric_value;
             uindex_t char_count;
             union
             {
@@ -182,6 +181,7 @@ struct __MCString: public __MCValue
                 char_t *native_chars;
             };
             uindex_t capacity;
+            double numeric_value;
         };
     };
 };


### PR DESCRIPTION
The different alignment was causing issues for the server to make the activation.
This is a temporary fix, and the underlying issues needs to be fixed.
