### PR TITLE
libfoundation: Check for bad MCValueRef casts

### DIFF
--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1985,34 +1985,56 @@ void MCModeSetRevLicenseLimits(MCExecContext& ctxt, MCArrayRef p_settings)
     }
     
     if (MCArrayFetchValue(p_settings, t_case_sensitive, MCNAME("multiplicity"), t_value))
-        MClicenseparameters . license_multiplicity = MCNumberFetchAsUnsignedInteger((MCNumberRef)t_value);
+    {
+	    MCAutoNumberRef t_number;
+	    if (ctxt.ConvertToNumber(t_value, &t_number))
+	    {
+		    MClicenseparameters . license_multiplicity = MCNumberFetchAsUnsignedInteger(*t_number);
+	    }
+    }
     
     if (MCArrayFetchValue(p_settings, t_case_sensitive, MCNAME("scriptlimit"), t_value))
     {
-        integer_t t_limit;
-        t_limit = MCNumberFetchAsInteger((MCNumberRef)t_value);
-        MClicenseparameters . script_limit = t_limit <= 0 ? 0 : t_limit;
+	    MCAutoNumberRef t_number;
+	    if (ctxt.ConvertToNumber(t_value, &t_number))
+	    {
+		    integer_t t_limit;
+		    t_limit = MCNumberFetchAsInteger(*t_number);
+		    MClicenseparameters . script_limit = t_limit <= 0 ? 0 : t_limit;
+	    }
     }
     
     if (MCArrayFetchValue(p_settings, t_case_sensitive, MCNAME("dolimit"), t_value))
     {
-        integer_t t_limit;
-        t_limit = MCNumberFetchAsInteger((MCNumberRef)t_value);
-        MClicenseparameters . do_limit = t_limit <= 0 ? 0 : t_limit;
+	    MCAutoNumberRef t_number;
+	    if (ctxt.ConvertToNumber(t_value, &t_number))
+	    {
+		    integer_t t_limit;
+		    t_limit = MCNumberFetchAsInteger(*t_number);
+		    MClicenseparameters . do_limit = t_limit <= 0 ? 0 : t_limit;
+	    }
     }
     
     if (MCArrayFetchValue(p_settings, t_case_sensitive, MCNAME("usinglimit"), t_value))
     {
-        integer_t t_limit;
-        t_limit = MCNumberFetchAsInteger((MCNumberRef)t_value);
-        MClicenseparameters . using_limit = t_limit <= 0 ? 0 : t_limit;
+	    MCAutoNumberRef t_number;
+	    if (ctxt.ConvertToNumber(t_value, &t_number))
+	    {
+		    integer_t t_limit;
+		    t_limit = MCNumberFetchAsInteger(*t_number);
+		    MClicenseparameters . using_limit = t_limit <= 0 ? 0 : t_limit;
+	    }
     }
     
     if (MCArrayFetchValue(p_settings, t_case_sensitive, MCNAME("insertlimit"), t_value))
     {
-        integer_t t_limit;
-        t_limit = MCNumberFetchAsInteger((MCNumberRef)t_value);
-        MClicenseparameters . insert_limit = t_limit <= 0 ? 0 : t_limit;
+	    MCAutoNumberRef t_number;
+	    if (ctxt.ConvertToNumber(t_value, &t_number))
+	    {
+		    integer_t t_limit;
+		    t_limit = MCNumberFetchAsInteger(*t_number);
+		    MClicenseparameters . insert_limit = t_limit <= 0 ? 0 : t_limit;
+	    }
     }
     
     if (MCArrayFetchValue(p_settings, t_case_sensitive, MCNAME("deploy"), t_value))

--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -59,6 +59,20 @@ static bool __MCArrayFindKeyValueSlot(__MCArray *self, bool case_sensitive, MCNa
 
 bool MCArrayCreate(bool p_case_sensitive, const MCNameRef *p_keys, const MCValueRef *p_values, uindex_t p_length, MCArrayRef& r_array)
 {
+	if (p_length == 0)
+	{
+		if (nil != kMCEmptyArray)
+		{
+			r_array = MCValueRetain(kMCEmptyArray);
+			return true;
+		}
+	}
+	else
+	{
+		MCAssert(nil != p_keys);
+		MCAssert(nil != p_values);
+	}
+
 	bool t_success;
 	t_success = true;
 
@@ -93,6 +107,8 @@ bool MCArrayCreateMutable(MCArrayRef& r_array)
 
 bool MCArrayCopy(MCArrayRef self, MCArrayRef& r_new_array)
 {
+	__MCAssertIsArray(self);
+
 	// If we aren't mutable, then we can just copy directly.
 	if (!MCArrayIsMutable(self))
 	{
@@ -122,6 +138,8 @@ bool MCArrayCopy(MCArrayRef self, MCArrayRef& r_new_array)
 
 bool MCArrayCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 {
+	__MCAssertIsArray(self);
+
 	// If we aren't mutable, then new array is just us.
 	if (!MCArrayIsMutable(self))
 	{
@@ -167,6 +185,8 @@ bool MCArrayCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 
 bool MCArrayMutableCopy(MCArrayRef self, MCArrayRef& r_new_array)
 {
+	__MCAssertIsArray(self);
+
 	// If the array is immutable, then the new mutable array will be indirect
 	// referencing it. [ non-mutable arrays cannot be indirect so self does not
 	// need resolving ].
@@ -193,6 +213,8 @@ bool MCArrayMutableCopy(MCArrayRef self, MCArrayRef& r_new_array)
 
 bool MCArrayMutableCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 {
+	__MCAssertIsArray(self);
+
 	if (self -> references == 1)
 	{
 		if (!MCArrayIsMutable(self))
@@ -211,6 +233,9 @@ bool MCArrayMutableCopyAndRelease(MCArrayRef self, MCArrayRef& r_new_array)
 
 bool MCArrayApply(MCArrayRef self, MCArrayApplyCallback p_callback, void *p_context)
 {
+	__MCAssertIsArray(self);
+	MCAssert(nil != p_callback);
+
 	// Make sure we are iterating over the correct contents.
 	MCArrayRef t_contents;
 	if (!__MCArrayIsIndirect(self))
@@ -239,6 +264,8 @@ bool MCArrayApply(MCArrayRef self, MCArrayApplyCallback p_callback, void *p_cont
 
 bool MCArrayIterate(MCArrayRef self, uintptr_t& x_iterator, MCNameRef& r_key, MCValueRef& r_value)
 {
+	__MCAssertIsArray(self);
+
 	// Make sure we are iterating over the correct contents.
 	MCArrayRef t_contents;
 	if (!__MCArrayIsIndirect(self))
@@ -269,11 +296,15 @@ bool MCArrayIterate(MCArrayRef self, uintptr_t& x_iterator, MCNameRef& r_key, MC
 
 bool MCArrayIsMutable(MCArrayRef self)
 {
+	__MCAssertIsArray(self);
+
 	return (self -> flags & kMCArrayFlagIsMutable) != 0;
 }
 
 uindex_t MCArrayGetCount(MCArrayRef self)
 {
+	__MCAssertIsArray(self);
+
 	if (!__MCArrayIsIndirect(self))
 		return self -> key_value_count;
 	return self -> contents -> key_value_count;
@@ -288,6 +319,11 @@ bool MCArrayFetchValue(MCArrayRef self, bool p_case_sensitive, MCNameRef p_key, 
 
 bool MCArrayFetchValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNameRef *p_path, uindex_t p_path_length, MCValueRef& r_value)
 {
+	__MCAssertIsArray(self);
+	MCAssert(nil != p_path);
+	MCAssert(0 < p_path_length);
+	__MCAssertIsName(p_path[0]);
+
 	// If the array is indirect, get the contents.
 	MCArrayRef t_contents;
 	if (!__MCArrayIsIndirect(self))
@@ -330,6 +366,9 @@ bool MCArrayStoreValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNam
 {
 	// The array must be mutable.
 	MCAssert(MCArrayIsMutable(self));
+	MCAssert(nil != p_path);
+	MCAssert(0 < p_path_length);
+	__MCAssertIsName(p_path[0]);
 
 	// Ensure it is not indirect.
 	if (__MCArrayIsIndirect(self))
@@ -429,6 +468,8 @@ bool MCArrayRemoveValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNa
 {
 	// The array must be mutable.
 	MCAssert(MCArrayIsMutable(self));
+	MCAssert(nil != p_path);
+	MCAssert(0 < p_path_length);
 
 	// Ensure it is not indirect.
 	if (__MCArrayIsIndirect(self))
@@ -486,6 +527,8 @@ bool MCArrayRemoveValueOnPath(MCArrayRef self, bool p_case_sensitive, const MCNa
 
 bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_value)
 {
+	__MCAssertIsArray(self);
+
 	char t_index_str[16];
 	sprintf(t_index_str, "%d", p_index);
 
@@ -498,6 +541,8 @@ bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_va
 
 bool MCArrayStoreValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef p_value)
 {
+	__MCAssertIsArray(self);
+
 	char t_index_str[16];
 	sprintf(t_index_str, "%d", p_index);
 

--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -58,6 +58,16 @@ static bool __MCDataCopyMutable(__MCData *self, __MCData*& r_new_data);
 
 bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data)
 {
+	/* Special case for empty data */
+	if ((p_byte_count == 0 || nil == p_bytes) && nil != kMCEmptyData)
+	{
+		r_data = MCValueRetain(kMCEmptyData);
+		return true;
+	}
+
+	/* Check that if the byte count is non-zero, the source pointer is valid */
+	MCAssert(p_byte_count == 0 || nil != p_bytes);
+
 	bool t_success;
 	t_success = true;
     
@@ -71,7 +81,10 @@ bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataR
     
 	if (t_success)
 	{
-        MCMemoryCopy(self -> bytes, p_bytes, p_byte_count);
+		if (nil != p_bytes)
+		{
+			MCMemoryCopy(self -> bytes, p_bytes, p_byte_count);
+		}
         self -> byte_count = p_byte_count;
 		r_data = self;
 	}
@@ -88,6 +101,8 @@ bool MCDataCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCDataR
 
 bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCDataRef& r_data)
 {
+	MCAssert(nil != p_bytes);
+
     // AL-2014-11-17: Create with bytes and release should just take the bytes.
     
     bool t_success;
@@ -113,6 +128,9 @@ bool MCDataCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCD
 bool
 MCDataCreateWithData(MCDataRef& r_data, MCDataRef p_one, MCDataRef p_two)
 {
+	__MCAssertIsData(p_one);
+	__MCAssertIsData(p_two);
+
     // Resolve any indirection
     if (__MCDataIsIndirect(p_one))
         p_one = p_one->contents;
@@ -148,6 +166,8 @@ MCDataCreateWithData(MCDataRef& r_data, MCDataRef p_one, MCDataRef p_two)
 
 bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data)
 {
+	__MCAssertIsString(string);
+
     // AL-2014-12-12: [[ Bug 14208 ]] Implement MCDataConvertStringToData reduce the overhead in
     //  converting from non-native string to data.
     
@@ -200,6 +220,8 @@ bool MCDataConvertStringToData(MCStringRef string, MCDataRef& r_data)
 
 bool MCDataIsEmpty(MCDataRef p_data)
 {
+	__MCAssertIsData(p_data);
+
     if (__MCDataIsIndirect(p_data))
         p_data = p_data -> contents;
     
@@ -208,6 +230,8 @@ bool MCDataIsEmpty(MCDataRef p_data)
 
 uindex_t MCDataGetLength(MCDataRef p_data)
 {
+	__MCAssertIsData(p_data);
+
     if (__MCDataIsIndirect(p_data))
         p_data = p_data -> contents;
     
@@ -216,6 +240,8 @@ uindex_t MCDataGetLength(MCDataRef p_data)
 
 const byte_t *MCDataGetBytePtr(MCDataRef p_data)
 {
+	__MCAssertIsData(p_data);
+
     if (__MCDataIsIndirect(p_data))
         p_data = p_data -> contents;
     
@@ -224,6 +250,8 @@ const byte_t *MCDataGetBytePtr(MCDataRef p_data)
 
 byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index)
 {
+	__MCAssertIsData(p_data);
+
     if (__MCDataIsIndirect(p_data))
         p_data = p_data -> contents;
     
@@ -233,6 +261,9 @@ byte_t MCDataGetByteAtIndex(MCDataRef p_data, uindex_t p_index)
 hash_t MCDataHash(MCDataRef p_data);
 bool MCDataIsEqualTo(MCDataRef p_left, MCDataRef p_right)
 {
+	__MCAssertIsData(p_left);
+	__MCAssertIsData(p_right);
+
     if (__MCDataIsIndirect(p_left))
         p_left = p_left -> contents;
 
@@ -273,6 +304,8 @@ bool MCDataCreateMutable(uindex_t p_initial_capacity, MCDataRef& r_data)
 
 bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data)
 {
+	__MCAssertIsData(p_data);
+
     if (!MCDataIsMutable(p_data))
     {
         MCValueRetain(p_data);
@@ -294,6 +327,8 @@ bool MCDataCopy(MCDataRef p_data, MCDataRef& r_new_data)
 
 bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data)
 {
+	__MCAssertIsData(p_data);
+
     // If the MCData is immutable we just pass it through (as we are releasing it).
     if (!MCDataIsMutable(p_data))
     {
@@ -330,6 +365,8 @@ bool MCDataCopyAndRelease(MCDataRef p_data, MCDataRef& r_new_data)
 
 bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data)
 {
+	__MCAssertIsData(p_data);
+
     // If p_data is immutable, then the new mutable data ref will be indirect
     // referencing it.
     if (!MCDataIsMutable(p_data))
@@ -349,6 +386,8 @@ bool MCDataMutableCopy(MCDataRef p_data, MCDataRef& r_mutable_data)
 
 bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data)
 {
+	__MCAssertIsData(p_data);
+
     if (p_data -> references == 1)
     {
         if (!MCDataIsMutable(p_data))
@@ -367,6 +406,8 @@ bool MCDataMutableCopyAndRelease(MCDataRef p_data, MCDataRef& r_mutable_data)
 
 bool MCDataCopyRange(MCDataRef self, MCRange p_range, MCDataRef& r_new_data)
 {
+	__MCAssertIsData(self);
+
     if (__MCDataIsIndirect(self))
         self = self -> contents;
     
@@ -396,12 +437,15 @@ bool MCDataCopyRangeAndRelease(MCDataRef self, MCRange p_range, MCDataRef& r_new
 
 bool MCDataIsMutable(const MCDataRef p_data)
 {
+	__MCAssertIsData(p_data);
+
     return (p_data->flags & kMCDataFlagIsMutable) != 0;
 }
 
 bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix)
 {
     MCAssert(MCDataIsMutable(r_data));
+    __MCAssertIsData(p_suffix);
     
     if (__MCDataIsIndirect(p_suffix))
         p_suffix = p_suffix -> contents;
@@ -423,6 +467,7 @@ bool MCDataAppend(MCDataRef r_data, MCDataRef p_suffix)
 bool MCDataAppendBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
+    MCAssert(nil != p_bytes);
     
     // Ensure the data ref is not indirect.
     if (__MCDataIsIndirect(self))
@@ -446,6 +491,7 @@ bool MCDataAppendByte(MCDataRef r_data, byte_t p_byte)
 bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix)
 {
     MCAssert(MCDataIsMutable(r_data));
+    __MCAssertIsData(p_prefix);
     
     if (__MCDataIsIndirect(p_prefix))
         p_prefix = p_prefix -> contents;
@@ -467,6 +513,7 @@ bool MCDataPrepend(MCDataRef r_data, MCDataRef p_prefix)
 bool MCDataPrependBytes(MCDataRef self, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
+    MCAssert(nil != p_bytes);
     
     // Ensure the data ref is not indirect.
     if (__MCDataIsIndirect(self))
@@ -490,6 +537,7 @@ bool MCDataPrependByte(MCDataRef r_data, byte_t p_byte)
 bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data)
 {
     MCAssert(MCDataIsMutable(r_data));
+    __MCAssertIsData(p_new_data);
     
     if (__MCDataIsIndirect(p_new_data))
         p_new_data = p_new_data -> contents;
@@ -511,6 +559,7 @@ bool MCDataInsert(MCDataRef r_data, uindex_t p_at, MCDataRef p_new_data)
 bool MCDataInsertBytes(MCDataRef self, uindex_t p_at, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
+    MCAssert(nil != p_bytes);
     
     // Ensure the data ref is not indirect.
     if (__MCDataIsIndirect(self))
@@ -547,6 +596,7 @@ bool MCDataRemove(MCDataRef self, MCRange p_range)
 bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data)
 {
 	MCAssert(MCDataIsMutable(r_data));
+	__MCAssertIsData(p_new_data);
     
     if (__MCDataIsIndirect(p_new_data))
         p_new_data = p_new_data -> contents;
@@ -567,6 +617,7 @@ bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data)
 bool MCDataReplaceBytes(MCDataRef self, MCRange p_range, const byte_t *p_bytes, uindex_t p_byte_count)
 {
     MCAssert(MCDataIsMutable(self));
+    MCAssert(nil != p_bytes);
     
     // Ensure the data ref is not indirect.
     if (__MCDataIsIndirect(self))
@@ -617,6 +668,9 @@ bool MCDataPad(MCDataRef self, byte_t p_byte, uindex_t p_count)
 
 compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right)
 {
+	__MCAssertIsData(p_left);
+	__MCAssertIsData(p_right);
+
     if (__MCDataIsIndirect(p_left))
         p_left = p_left -> contents;
     
@@ -635,6 +689,8 @@ compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right)
 #if defined(__MAC__) || defined (__IOS__)
 bool MCDataConvertToCFDataRef(MCDataRef p_data, CFDataRef& r_cfdata)
 {
+	__MCAssertIsData(p_data);
+
     if (__MCDataIsIndirect(p_data))
         p_data = p_data -> contents;
     

--- a/libfoundation/src/foundation-list.cpp
+++ b/libfoundation/src/foundation-list.cpp
@@ -48,6 +48,9 @@ bool MCListCreateMutable(MCStringRef p_delimiter, MCListRef& r_list)
 
 bool MCListAppend(MCListRef self, MCValueRef p_value)
 {
+	__MCAssertIsList(self);
+	MCAssert(nil != p_value);
+
 	bool t_first = self->buffer == nil;
 	if (t_first)
 		if (!MCStringCreateMutable(0, self -> buffer))
@@ -88,7 +91,7 @@ bool MCListAppend(MCListRef self, MCValueRef p_value)
 
 bool MCListCopy(MCListRef self, MCListRef& r_list)
 {
-	MCAssert(self != nil);
+	__MCAssertIsList(self);
     
     // If we are immutable, just bump the reference count
     if (!self -> flags & kMCListFlagIsMutable)
@@ -122,6 +125,8 @@ bool MCListCopy(MCListRef self, MCListRef& r_list)
 
 bool MCListCopyAndRelease(MCListRef self, MCListRef& r_list)
 {
+	__MCAssertIsList(self);
+
     // If there are no other references, just clear the mutable flag
     if (self -> references == 1)
     {
@@ -139,6 +144,8 @@ bool MCListCopyAndRelease(MCListRef self, MCListRef& r_list)
 
 bool MCListCopyAsString(MCListRef self, MCStringRef& r_string)
 {
+	__MCAssertIsList(self);
+
 	MCStringRef t_string;
 	if (self -> buffer != nil)
 		t_string = self -> buffer;
@@ -163,6 +170,9 @@ bool MCListCopyAsStringAndRelease(MCListRef self, MCStringRef& r_string)
 
 bool MCListAppendFormat(MCListRef self, const char *p_format, ...)
 {
+	__MCAssertIsList(self);
+	MCAssert(nil != p_format);
+
 	bool t_success;
 	t_success = true;
 
@@ -185,6 +195,9 @@ bool MCListAppendFormat(MCListRef self, const char *p_format, ...)
 
 bool MCListAppendNativeChars(MCListRef self, const char_t *p_chars, uindex_t p_char_count)
 {
+	__MCAssertIsList(self);
+	MCAssert(p_chars != nil);
+
 	bool t_first = self->buffer == nil;
 	if (t_first)
 		if (!MCStringCreateMutable(0, self -> buffer))
@@ -203,6 +216,7 @@ bool MCListAppendSubstring(MCListRef self, MCStringRef p_string, MCRange p_range
 
 bool MCListIsEmpty(MCListRef self)
 {
+	__MCAssertIsList(self);
 	return self -> buffer == nil;
 }
 

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -55,7 +55,7 @@ MCNameRef MCNAME(const char *p_string)
 
 bool MCNameCreate(MCStringRef p_string, MCNameRef& r_name)
 {
-	MCAssert(p_string != nil);
+	__MCAssertIsString(p_string);
 
 	if (p_string -> char_count == 0 && kMCEmptyName != nil)
 	{
@@ -233,11 +233,13 @@ MCNameRef MCNameLookup(MCStringRef p_string)
 
 uintptr_t MCNameGetCaselessSearchKey(MCNameRef self)
 {
+	__MCAssertIsName(self);
 	return (uintptr_t)self -> key;
 }
 
 MCStringRef MCNameGetString(MCNameRef self)
 {
+	__MCAssertIsName(self);
 	return self -> string;
 }
 
@@ -248,6 +250,9 @@ bool MCNameIsEmpty(MCNameRef self)
 
 bool MCNameIsEqualTo(MCNameRef self, MCNameRef p_other_name)
 {
+	__MCAssertIsName(self);
+	__MCAssertIsName(p_other_name);
+
 	return self == p_other_name ||
 			self -> key == p_other_name -> key;
 }

--- a/libfoundation/src/foundation-number.cpp
+++ b/libfoundation/src/foundation-number.cpp
@@ -61,11 +61,13 @@ bool MCNumberCreateWithUnsignedInteger(uinteger_t p_value, MCNumberRef& r_number
 
 bool MCNumberIsInteger(MCNumberRef self)
 {
+	__MCAssertIsNumber(self);
 	return (self -> flags & kMCNumberFlagIsReal) == 0;
 }
 
 bool MCNumberIsReal(MCNumberRef self)
 {
+	__MCAssertIsNumber(self);
 	return (self -> flags & kMCNumberFlagIsReal) != 0;
 }
 

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -456,5 +456,24 @@ unichar_t MCUnicodeCharMapFromNative(char_t nchar);
 //unichar_t MCUnicodeCharUppercase(unichar_t);
 
 ////////////////////////////////////////////////////////////////////////////////
+// INTERNAL MCVALUE TYPE ASSERTIONS
+//
+
+#define __MCAssertValueType(x,T) MCAssert(MCValueGetTypeCode(x) == kMCValueTypeCode##T)
+
+#define __MCAssertIsNumber(x)   __MCAssertValueType(x,Number)
+#define __MCAssertIsName(x)     __MCAssertValueType(x,Name)
+#define __MCAssertIsString(x)   __MCAssertValueType(x,String)
+#define __MCAssertIsData(x)     __MCAssertValueType(x,Data)
+#define __MCAssertIsArray(x)    __MCAssertValueType(x,Array)
+#define __MCAssertIsList(x)     __MCAssertValueType(x,List)
+#define __MCAssertIsSet(x)      __MCAssertValueType(x,Set)
+
+#define __MCAssertIsLocale(x)   MCAssert(nil != (x)) /* FIXME */
+
+#define __MCAssertIsMutableString(x) MCAssert(MCStringIsMutable(x))
+#define __MCAssertIsMutableData(x)   MCAssert(MCDataIsMutable(x))
+
+////////////////////////////////////////////////////////////////////////////////
 
 #endif

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -301,6 +301,12 @@ inline MCValueTypeCode __MCValueGetTypeCode(__MCValue *self)
 	return (self -> flags >> 28);
 }
 
+inline const MCValueCustomCallbacks *
+__MCValueGetCustomCallbacks(__MCValue *self)
+{
+	return reinterpret_cast<__MCCustomValue *>(self)->callbacks;
+}
+
 template<class T> inline bool __MCValueCreate(MCValueTypeCode p_type_code, T*& r_value)
 {
 	__MCValue *t_value;

--- a/libfoundation/src/foundation-set.cpp
+++ b/libfoundation/src/foundation-set.cpp
@@ -31,6 +31,19 @@ bool MCSetCreateSingleton(uindex_t p_element, MCSetRef& r_set)
 
 bool MCSetCreateWithIndices(uindex_t *p_elements, uindex_t p_element_count, MCSetRef& r_set)
 {
+	if (p_element_count == 0)
+	{
+		if (nil != kMCEmptySet)
+		{
+			r_set = MCValueRetain(kMCEmptySet);
+			return true;
+		}
+	}
+	else
+	{
+		MCAssert(nil != p_elements);
+	}
+
 	MCSetRef t_set;
 	if (!MCSetCreateMutable(t_set))
 		return false;
@@ -43,6 +56,8 @@ bool MCSetCreateWithIndices(uindex_t *p_elements, uindex_t p_element_count, MCSe
 
 bool MCSetCreateWithLimbsAndRelease(uindex_t *p_limbs, uindex_t p_limb_count, MCSetRef& r_set)
 {
+	MCAssert(nil != p_limbs);
+
 	__MCSet *self;
 	if (!__MCValueCreate(kMCValueTypeCodeSet, self))
 		return false;
@@ -72,6 +87,8 @@ bool MCSetCreateMutable(MCSetRef& r_set)
 
 bool MCSetCopy(MCSetRef self, MCSetRef& r_new_set)
 {
+	__MCAssertIsSet(self);
+
 	if (!MCSetIsMutable(self))
 	{
 		r_new_set = MCValueRetain(self);
@@ -82,6 +99,8 @@ bool MCSetCopy(MCSetRef self, MCSetRef& r_new_set)
 
 bool MCSetCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 {
+	__MCAssertIsSet(self);
+
 	if (!MCSetIsMutable(self))
 	{
 		r_new_set = self;
@@ -100,11 +119,14 @@ bool MCSetCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 
 bool MCSetMutableCopy(MCSetRef self, MCSetRef& r_new_set)
 {
+	__MCAssertIsSet(self);
 	return __MCSetClone(self, true, r_new_set);
 }
 
 bool MCSetMutableCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 {
+	__MCAssertIsSet(self);
+
 	if (self -> references == 1)
 	{
 		self -> flags |= kMCSetFlagIsMutable;
@@ -119,6 +141,8 @@ bool MCSetMutableCopyAndRelease(MCSetRef self, MCSetRef& r_new_set)
 
 bool MCSetIsMutable(MCSetRef self)
 {
+	__MCAssertIsSet(self);
+
 	return (self -> flags & kMCSetFlagIsMutable) != 0;
 }
 
@@ -126,6 +150,8 @@ bool MCSetIsMutable(MCSetRef self)
 
 bool MCSetIsEmpty(MCSetRef self)
 {
+	__MCAssertIsSet(self);
+
 	for(uindex_t i = 0; i < self -> limb_count; i++)
 		if (self -> limbs[i] != 0)
 			return false;
@@ -134,6 +160,9 @@ bool MCSetIsEmpty(MCSetRef self)
 
 bool MCSetIsEqualTo(MCSetRef self, MCSetRef other_self)
 {
+	__MCAssertIsSet(self);
+	__MCAssertIsSet(other_self);
+
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
 	{
 		uindex_t t_left_limb, t_right_limb;
@@ -148,6 +177,9 @@ bool MCSetIsEqualTo(MCSetRef self, MCSetRef other_self)
 
 bool MCSetContains(MCSetRef self, MCSetRef other_self)
 {
+	__MCAssertIsSet(self);
+	__MCAssertIsSet(other_self);
+
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
 	{
 		uindex_t t_left_limb, t_right_limb;
@@ -161,6 +193,9 @@ bool MCSetContains(MCSetRef self, MCSetRef other_self)
 
 bool MCSetIntersects(MCSetRef self, MCSetRef other_self)
 {
+	__MCAssertIsSet(self);
+	__MCAssertIsSet(other_self);
+
 	for(uindex_t i = 0; i < MCMax(self -> limb_count, other_self -> limb_count); i++)
 	{
 		uindex_t t_left_limb, t_right_limb;
@@ -174,6 +209,8 @@ bool MCSetIntersects(MCSetRef self, MCSetRef other_self)
 
 bool MCSetContainsIndex(MCSetRef self, uindex_t p_element)
 {
+	__MCAssertIsSet(self);
+
 	if (p_element >= self -> limb_count * 32)
 		return false;
 	return (self -> limbs[p_element / 32] & (1 << (p_element % 32))) != 0;
@@ -253,6 +290,8 @@ bool MCSetIntersect(MCSetRef self, MCSetRef p_other_set)
 
 bool MCSetIterate(MCSetRef self, uindex_t& x_iterator, uindex_t& r_element)
 {
+	__MCAssertIsSet(self);
+
 	while(x_iterator < self -> limb_count * 32)
 	{
 		x_iterator++;

--- a/libfoundation/src/foundation-stream.cpp
+++ b/libfoundation/src/foundation-stream.cpp
@@ -130,6 +130,8 @@ static MCStreamCallbacks kMCMemoryInputStreamCallbacks =
 
 bool MCMemoryInputStreamCreate(const void *p_block, size_t p_size, MCStreamRef& r_stream)
 {
+	MCAssert(nil != p_block);
+
 	MCStreamRef t_stream;
 	if (!MCStreamCreate(&kMCMemoryInputStreamCallbacks, sizeof(__MCMemoryInputStream), t_stream))
 		return false;
@@ -200,6 +202,14 @@ static MCValueCustomCallbacks kMCStreamCustomValueCallbacks =
 	__MCStreamDescribe,
 };
 
+static inline void __MCAssertIsStream(MCStreamRef ref)
+{
+	__MCValue *val = reinterpret_cast<__MCValue *>(ref);
+	MCAssert(nil != val &&
+	         __MCValueGetTypeCode(val) == kMCValueTypeCodeCustom &&
+	         __MCValueGetCustomCallbacks(val) == &kMCStreamCustomValueCallbacks);
+}
+
 bool MCStreamCreate(const MCStreamCallbacks *p_callbacks, size_t p_extra_bytes, MCStreamRef& r_stream)
 {
 	__MCStream *self;
@@ -215,6 +225,8 @@ bool MCStreamCreate(const MCStreamCallbacks *p_callbacks, size_t p_extra_bytes, 
 
 const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef self)
 {
+	__MCAssertIsStream(self);
+
 	return self -> callbacks;
 }
 
@@ -222,21 +234,29 @@ const MCStreamCallbacks *MCStreamGetCallbacks(MCStreamRef self)
 
 bool MCStreamIsReadable(MCStreamRef self)
 {
+	__MCAssertIsStream(self);
+
 	return self -> callbacks -> read != nil;
 }
 
 bool MCStreamIsWritable(MCStreamRef self)
 {
+	__MCAssertIsStream(self);
+
 	return self -> callbacks -> write != nil;
 }
 
 bool MCStreamIsMarkable(MCStreamRef self)
 {
+	__MCAssertIsStream(self);
+
 	return self -> callbacks -> mark != nil;
 }
 
 bool MCStreamIsSeekable(MCStreamRef self)
 {
+	__MCAssertIsStream(self);
+
 	return self -> callbacks -> seek != nil;
 }
 
@@ -244,6 +264,8 @@ bool MCStreamIsSeekable(MCStreamRef self)
 
 bool MCStreamGetAvailableForRead(MCStreamRef self, size_t& r_available)
 {
+	__MCAssertIsStream(self);
+
 	if (self -> callbacks -> get_available_for_read == nil)
 		return false;
 	return self -> callbacks -> get_available_for_read(self, r_available);
@@ -251,6 +273,9 @@ bool MCStreamGetAvailableForRead(MCStreamRef self, size_t& r_available)
 
 bool MCStreamRead(MCStreamRef self, void *p_buffer, size_t p_amount)
 {
+	__MCAssertIsStream(self);
+	MCAssert(nil != p_buffer);
+
 	if (self -> callbacks -> read == nil)
 		return false;
 	return self -> callbacks -> read(self, p_buffer, p_amount);
@@ -258,6 +283,8 @@ bool MCStreamRead(MCStreamRef self, void *p_buffer, size_t p_amount)
 
 bool MCStreamGetAvailableForWrite(MCStreamRef self, size_t& r_available)
 {
+	__MCAssertIsStream(self);
+
 	if (self -> callbacks -> get_available_for_write == nil)
 		return false;
 	return self -> callbacks -> get_available_for_write(self, r_available);
@@ -265,6 +292,9 @@ bool MCStreamGetAvailableForWrite(MCStreamRef self, size_t& r_available)
 
 bool MCStreamWrite(MCStreamRef self, const void *p_buffer, size_t p_amount)
 {
+	__MCAssertIsStream(self);
+	MCAssert(nil != p_buffer);
+
 	if (self -> callbacks -> write == nil)
 		return false;
 	return self -> callbacks -> write(self, p_buffer, p_amount);
@@ -272,6 +302,8 @@ bool MCStreamWrite(MCStreamRef self, const void *p_buffer, size_t p_amount)
 
 bool MCStreamSkip(MCStreamRef self, size_t p_amount)
 {
+	__MCAssertIsStream(self);
+
 	if (self -> callbacks -> skip != nil)
 		return self -> callbacks -> skip(self, p_amount);
 	if (self -> callbacks -> seek != nil)
@@ -288,6 +320,8 @@ bool MCStreamSkip(MCStreamRef self, size_t p_amount)
 
 bool MCStreamMark(MCStreamRef self, size_t p_read_limit)
 {
+	__MCAssertIsStream(self);
+
 	if (self -> callbacks -> mark == nil)
 		return false;
 	return self -> callbacks -> mark(self, p_read_limit);
@@ -295,6 +329,8 @@ bool MCStreamMark(MCStreamRef self, size_t p_read_limit)
 
 bool MCStreamReset(MCStreamRef self)
 {
+	__MCAssertIsStream(self);
+
 	if (self -> callbacks -> reset == nil)
 		return false;
 	return self -> callbacks -> reset(self);
@@ -304,6 +340,8 @@ bool MCStreamReset(MCStreamRef self)
 
 bool MCStreamTell(MCStreamRef self, filepos_t& r_position)
 {
+	__MCAssertIsStream(self);
+
 	if (self -> callbacks -> tell == nil)
 		return false;
 	return self -> callbacks -> tell(self, r_position);
@@ -311,6 +349,8 @@ bool MCStreamTell(MCStreamRef self, filepos_t& r_position)
 
 bool MCStreamSeek(MCStreamRef self, filepos_t p_position)
 {
+	__MCAssertIsStream(self);
+
 	if (self -> callbacks -> seek == nil)
 		return false;
 	return self -> callbacks -> seek(self, p_position);

--- a/libfoundation/src/foundation-stream.cpp
+++ b/libfoundation/src/foundation-stream.cpp
@@ -274,7 +274,7 @@ bool MCStreamGetAvailableForRead(MCStreamRef self, size_t& r_available)
 bool MCStreamRead(MCStreamRef self, void *p_buffer, size_t p_amount)
 {
 	__MCAssertIsStream(self);
-	MCAssert(nil != p_buffer);
+	MCAssert(nil != p_buffer || 0 == p_amount);
 
 	if (self -> callbacks -> read == nil)
 		return false;
@@ -293,7 +293,7 @@ bool MCStreamGetAvailableForWrite(MCStreamRef self, size_t& r_available)
 bool MCStreamWrite(MCStreamRef self, const void *p_buffer, size_t p_amount)
 {
 	__MCAssertIsStream(self);
-	MCAssert(nil != p_buffer);
+	MCAssert(nil != p_buffer || 0 == p_amount);
 
 	if (self -> callbacks -> write == nil)
 		return false;

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1883,7 +1883,7 @@ bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
 		self = self->string;
     
     // Check that the input range is valid
-    if (p_in_range.offset + p_in_range.length > self -> char_count)
+	if (p_in_range.offset + p_in_range.length > __MCStringGetLength(self))
         return false;
     
     // Create a break iterator of the appropriate type
@@ -1922,7 +1922,7 @@ bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
             t_left_break = t_right_break;
         }
 
-        if (t_right_break >= MCStringGetLength(self))
+        if (t_right_break >= __MCStringGetLength(self))
         {
             r_out_range = MCRangeMake(t_right_break, 0);
             return true;
@@ -1951,7 +1951,7 @@ bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
             t_left_break = t_right_break;
         }
         
-        if (t_right_break >= MCStringGetLength(self))
+        if (t_right_break >= __MCStringGetLength(self))
             break;
     }
     

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -287,7 +287,19 @@ bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStr
 // the specified encoding.
 bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
-	MCAssert(nil != p_bytes);
+	if (0 == p_byte_count)
+	{
+		if (nil != kMCEmptyString)
+		{
+			r_string = MCValueRetain(kMCEmptyString);
+			return true;
+		}
+	}
+	else
+	{
+		MCAssert(nil != p_bytes);
+	}
+
     MCAssert(!p_is_external_rep);
     
     switch (p_encoding)
@@ -399,14 +411,19 @@ bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStr
 
 bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
-	if ((p_bytes == nil || p_byte_count == 0) && kMCEmptyString != nil)
-    {
-        r_string = MCValueRetain(kMCEmptyString);
-        free(p_bytes);
-        return true;
-    }
-
-	MCAssert(nil != p_bytes);
+	if (p_byte_count == 0)
+	{
+		if (kMCEmptyString != nil)
+		{
+			r_string = MCValueRetain(kMCEmptyString);
+			free(p_bytes);
+			return true;
+		}
+	}
+	else
+	{
+		MCAssert(nil != p_bytes);
+	}
 
     MCStringRef t_string;
     t_string = nil;
@@ -451,12 +468,17 @@ bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, M
 
 bool MCStringCreateWithChars(const unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
-	MCAssert(nil != p_chars);
-
-    if (p_char_count == 0 && kMCEmptyString != nil)
+	if (p_char_count == 0)
 	{
-		r_string = MCValueRetain(kMCEmptyString);
-		return true;
+		if (kMCEmptyString != nil)
+		{
+			r_string = MCValueRetain(kMCEmptyString);
+			return true;
+		}
+	}
+	else
+	{
+		MCAssert(nil != p_chars);
 	}
     
 	bool t_success;

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -5449,11 +5449,11 @@ MCStringCreateWithSysString(const char *p_sys_string,
 	}
 
 	/* Count the number of chars */
-	size_t p_byte_count;
-	for (p_byte_count = 0; p_sys_string[p_byte_count] != '\0'; ++p_byte_count);
+	size_t t_byte_count;
+	for (t_byte_count = 0; p_sys_string[p_byte_count] != '\0'; ++t_byte_count);
 
 	return MCStringCreateWithBytes((const byte_t *) p_sys_string,
-	                               p_byte_count,
+	                               t_byte_count,
 	                               kMCStringEncodingUTF8,
 	                               false, /* is_external_rep */
 	                               r_string);

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -224,6 +224,8 @@ static bool __MCStringIsEmpty(MCStringRef string)
 // and returning that has a similar effect (if slightly slower).
 MCStringRef MCSTR(const char *p_cstring)
 {
+	MCAssert(nil != p_cstring);
+
 	MCStringRef t_string;
 	/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)p_cstring, strlen(p_cstring), t_string);
 	
@@ -239,11 +241,15 @@ MCStringRef MCSTR(const char *p_cstring)
 
 bool MCStringCreateWithCString(const char* p_cstring, MCStringRef& r_string)
 {
+	MCAssert(nil != p_cstring);
+
 	return MCStringCreateWithNativeChars((const char_t*)p_cstring, p_cstring == nil ? 0 : strlen(p_cstring), r_string);
 }
 
 bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
 {
+	MCAssert(nil != p_cstring);
+
 	if (MCStringCreateWithNativeChars((const char_t *)p_cstring, p_cstring == nil ? 0 : strlen((const char*)p_cstring), r_string))
     {
         delete p_cstring;
@@ -257,6 +263,8 @@ const char *MCStringGetCString(MCStringRef p_string)
 {
     if (p_string == nil)
         return nil;
+
+    __MCAssertIsString(p_string);
     
     MCStringNativize(p_string);
     
@@ -270,6 +278,8 @@ const char *MCStringGetCString(MCStringRef p_string)
 
 bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStringOptions p_options)
 {
+	__MCAssertIsString(p_string);
+
 	return MCStringIsEqualToNativeChars(p_string, (const char_t *)p_cstring, strlen(p_cstring), p_options);
 }
 
@@ -277,6 +287,7 @@ bool MCStringIsEqualToCString(MCStringRef p_string, const char *p_cstring, MCStr
 // the specified encoding.
 bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
+	MCAssert(nil != p_bytes);
     MCAssert(!p_is_external_rep);
     
     switch (p_encoding)
@@ -388,6 +399,15 @@ bool MCStringCreateWithBytes(const byte_t *p_bytes, uindex_t p_byte_count, MCStr
 
 bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
+	if ((p_bytes == nil || p_byte_count == 0) && kMCEmptyString != nil)
+    {
+        r_string = MCValueRetain(kMCEmptyString);
+        free(p_bytes);
+        return true;
+    }
+
+	MCAssert(nil != p_bytes);
+
     MCStringRef t_string;
     t_string = nil;
     
@@ -407,13 +427,6 @@ bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, M
     
     bool t_success;
     t_success = true;
-    
-    if (p_byte_count == 0 && kMCEmptyString != nil)
-    {
-        r_string = MCValueRetain(kMCEmptyString);
-        free(p_bytes);
-        return true;
-    }
     
     if (t_success)
         t_success = __MCValueCreate(kMCValueTypeCodeString, t_string);
@@ -438,6 +451,8 @@ bool MCStringCreateWithBytesAndRelease(byte_t *p_bytes, uindex_t p_byte_count, M
 
 bool MCStringCreateWithChars(const unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
+	MCAssert(nil != p_chars);
+
     if (p_char_count == 0 && kMCEmptyString != nil)
 	{
 		r_string = MCValueRetain(kMCEmptyString);
@@ -500,6 +515,8 @@ bool MCStringCreateWithChars(const unichar_t *p_chars, uindex_t p_char_count, MC
 
 bool MCStringCreateWithCharsAndRelease(unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
 {
+	MCAssert(nil != p_chars);
+
     if (MCStringCreateWithChars(p_chars, p_char_count, r_string))
     {
         free(p_chars);
@@ -511,6 +528,8 @@ bool MCStringCreateWithCharsAndRelease(unichar_t *p_chars, uindex_t p_char_count
 
 bool MCStringCreateWithWString(const unichar_t *p_wstring, MCStringRef& r_string)
 {
+	MCAssert(nil != p_wstring);
+
 	uindex_t t_length;
 	for(t_length = 0; p_wstring[t_length] != 0; t_length++)
 		;
@@ -520,6 +539,8 @@ bool MCStringCreateWithWString(const unichar_t *p_wstring, MCStringRef& r_string
 
 bool MCStringCreateWithWStringAndRelease(unichar_t* p_wstring, MCStringRef& r_string)
 {
+	MCAssert(nil != p_wstring);
+
 	if (MCStringCreateWithWString(p_wstring, r_string))
 	{
 		free(p_wstring);
@@ -534,11 +555,13 @@ bool MCStringCreateWithNativeChars(const char_t *p_chars, uindex_t p_char_count,
 	bool t_success;
 	t_success = true;
 
-	if (p_char_count == 0 && kMCEmptyString != nil)
+	if ((p_chars == nil || p_char_count == 0) && kMCEmptyString != nil)
 	{
 		r_string = MCValueRetain(kMCEmptyString);
 		return true;
 	}
+
+	MCAssert(nil != p_chars);
 
 	__MCString *self;
 	self = nil;
@@ -573,6 +596,8 @@ bool MCStringCreateWithNativeCharsAndRelease(char_t *p_chars, uindex_t p_char_co
 
 bool MCStringCreateWithNativeCharBufferAndRelease(char_t* p_chars, uindex_t p_char_count, uindex_t p_buffer_length, MCStringRef& r_string)
 {
+	MCAssert(nil != p_chars);
+
     bool t_success;
     t_success = true;
     
@@ -662,6 +687,8 @@ bool MCStringCreateMutable(uindex_t p_initial_capacity, MCStringRef& r_string)
 
 bool MCStringEncode(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is_external_rep, MCDataRef& r_data)
 {
+	__MCAssertIsString(p_string);
+
     byte_t *t_bytes;
     uindex_t t_byte_count;
     if (!MCStringConvertToBytes(p_string, p_encoding, p_is_external_rep, t_bytes, t_byte_count))
@@ -677,7 +704,9 @@ bool MCStringEncode(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is
 }
 
 bool MCStringEncodeAndRelease(MCStringRef p_string, MCStringEncoding p_encoding, bool p_is_external_rep, MCDataRef& r_data)
-{    
+{
+	__MCAssertIsString(p_string);
+
     MCDataRef t_data;
     
     if (!MCStringEncode(p_string, p_encoding, p_is_external_rep, t_data))
@@ -696,6 +725,8 @@ bool MCStringDecode(MCDataRef p_data, MCStringEncoding p_encoding, bool p_is_ext
 
 bool MCStringDecodeAndRelease(MCDataRef p_data, MCStringEncoding p_encoding, bool p_is_external_rep, MCStringRef& r_string)
 {
+	__MCAssertIsData(p_data);
+
     MCStringRef t_string;
     
     if (!MCStringDecode(p_data, p_encoding, p_is_external_rep, t_string))
@@ -713,6 +744,7 @@ bool MCStringDecodeAndRelease(MCDataRef p_data, MCStringEncoding p_encoding, boo
 //  Unicode string that the engine function takes (in MCR_exec for instance)
 bool MCStringCreateUnicodeStringFromData(MCDataRef p_data, bool p_is_external_rep, MCStringRef& r_string)
 {
+	__MCAssertIsData(p_data);
     MCAssert(!p_is_external_rep);
     
     if (MCDataIsEmpty(p_data))
@@ -792,6 +824,8 @@ static bool __MCStringFormatSupportedForUnicode(const char *p_format)
 
 bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args)
 {
+	MCAssert(nil != p_format);
+
 	MCStringRef t_buffer;
 	if (!MCStringCreateMutable(0, t_buffer))
 		return false;
@@ -1010,6 +1044,8 @@ static bool __MCStringCloneNativeBuffer(MCStringRef self, char_t*& chars, uindex
 
 bool MCStringCopy(MCStringRef self, MCStringRef& r_new_string)
 {
+	__MCAssertIsString(self);
+
 	// If the string is immutable we can just bump the reference count.
 	if (!MCStringIsMutable(self))
 	{
@@ -1033,6 +1069,8 @@ bool MCStringCopy(MCStringRef self, MCStringRef& r_new_string)
 
 bool MCStringCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 {
+	__MCAssertIsString(self);
+
 	// If the string is immutable we just pass it through (as we are releasing the string).
 	if (!MCStringIsMutable(self))
 	{
@@ -1072,6 +1110,8 @@ bool MCStringCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 
 bool MCStringMutableCopy(MCStringRef self, MCStringRef& r_new_string)
 {
+	__MCAssertIsString(self);
+
 	// If self is immutable, then the new mutable string will be indirect
 	// referencing it.
     if (!MCStringIsMutable(self))
@@ -1091,6 +1131,8 @@ bool MCStringMutableCopy(MCStringRef self, MCStringRef& r_new_string)
 
 bool MCStringMutableCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 {
+	__MCAssertIsString(self);
+
 	if (self -> references == 1)
 	{
 		if (!MCStringIsMutable(self))
@@ -1114,6 +1156,8 @@ bool MCStringMutableCopyAndRelease(MCStringRef self, MCStringRef& r_new_string)
 
 bool MCStringCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_substring)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1142,6 +1186,8 @@ bool MCStringCopySubstringAndRelease(MCStringRef self, MCRange p_range, MCString
 
 bool MCStringMutableCopySubstring(MCStringRef self, MCRange p_range, MCStringRef& r_new_string)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1195,6 +1241,8 @@ bool MCStringMutableCopySubstringAndRelease(MCStringRef self, MCRange p_range, M
 
 bool MCStringIsMutable(const MCStringRef self)
 {
+	__MCAssertIsString(self);
+
 	return (self -> flags & kMCStringFlagIsMutable) != 0;
 }
 
@@ -1202,6 +1250,8 @@ bool MCStringIsMutable(const MCStringRef self)
 
 uindex_t MCStringGetLength(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1210,6 +1260,8 @@ uindex_t MCStringGetLength(MCStringRef self)
 
 const unichar_t *MCStringGetCharPtr(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         __MCStringResolveIndirect(self);
     
@@ -1219,6 +1271,8 @@ const unichar_t *MCStringGetCharPtr(MCStringRef self)
 
 const char_t *MCStringGetNativeCharPtr(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (MCStringIsNative(self))
     {
         // AL-2014-07-25: [[ Bug 12672 ]] Ensure possibly indirect string is resolved before returning char ptr
@@ -1233,12 +1287,16 @@ const char_t *MCStringGetNativeCharPtr(MCStringRef self)
 
 const char_t *MCStringGetNativeCharPtrAndLength(MCStringRef self, uindex_t& r_char_count)
 {
+	__MCAssertIsString(self);
+
     r_char_count = __MCStringNativize(self);
 	return self -> native_chars;
 }
 
 unichar_t MCStringGetCharAtIndex(MCStringRef self, uindex_t p_index)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1250,6 +1308,8 @@ unichar_t MCStringGetCharAtIndex(MCStringRef self, uindex_t p_index)
 
 char_t MCStringGetNativeCharAtIndex(MCStringRef self, uindex_t p_index)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1264,6 +1324,8 @@ char_t MCStringGetNativeCharAtIndex(MCStringRef self, uindex_t p_index)
 
 codepoint_t MCStringGetCodepointAtIndex(MCStringRef self, uindex_t p_index)
 {
+	__MCAssertIsString(self);
+
 	// Calculate the code unit index for the given codepoint
 	MCRange t_codepoint_idx, t_codeunit_idx;
     t_codepoint_idx = MCRangeMake(p_index, 1);
@@ -1292,6 +1354,8 @@ codepoint_t MCStringGetCodepointAtIndex(MCStringRef self, uindex_t p_index)
 
 uindex_t MCStringGetChars(MCStringRef self, MCRange p_range, unichar_t *p_chars)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1315,6 +1379,8 @@ uindex_t MCStringGetChars(MCStringRef self, MCRange p_range, unichar_t *p_chars)
 
 uindex_t MCStringGetNativeChars(MCStringRef self, MCRange p_range, char_t *p_chars)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1339,11 +1405,15 @@ uindex_t MCStringGetNativeChars(MCStringRef self, MCRange p_range, char_t *p_cha
 
 void MCStringNativize(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     __MCStringNativize(self);
 }
 
 bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
 {
+	__MCAssertIsString(p_string);
+
     // AL-2014-12-12: [[ Bug 14208 ]] Implement a native copy function to aid conversion to data
     if (MCStringIsNative(p_string))
         return MCStringCopy(p_string, r_copy);
@@ -1365,6 +1435,8 @@ bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
 
 bool MCStringIsNative(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1373,6 +1445,8 @@ bool MCStringIsNative(MCStringRef self)
 
 bool MCStringCantBeEqualToNative(MCStringRef self, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1381,6 +1455,8 @@ bool MCStringCantBeEqualToNative(MCStringRef self, MCStringOptions p_options)
 
 bool MCStringCanBeNative(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1390,6 +1466,8 @@ bool MCStringCanBeNative(MCStringRef self)
 // AL-2015-02-06: [[ Bug 14504 ]] Ensure 'simple' flag is checked against the direct string.
 bool MCStringIsSimple(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1399,6 +1477,8 @@ bool MCStringIsSimple(MCStringRef self)
 // AL-2015-02-06: [[ Bug 14504 ]] Ensure 'uncombined' flag is checked against the direct string.
 bool MCStringIsUncombined(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1407,6 +1487,8 @@ bool MCStringIsUncombined(MCStringRef self)
 
 bool MCStringMapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &r_out_range)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1492,7 +1574,7 @@ bool MCStringMapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &
 
 bool MCStringUnmapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange &r_out_range)
 {    
-    MCAssert(self != nil);
+	__MCAssertIsString(self);
     
     // AL-2015-02-06: [[ Bug 14504 ]] Use direct string for checks here, as the flags are not set on the indirect string.
     if (__MCStringIsIndirect(self))
@@ -1556,8 +1638,8 @@ bool MCStringUnmapCodepointIndices(MCStringRef self, MCRange p_in_range, MCRange
 
 bool MCStringMapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
-    MCAssert(self != nil);
-    MCAssert(p_locale != nil);
+	__MCAssertIsString(self);
+	__MCAssertIsLocale(p_locale);
     
     // Create the appropriate break iterator
     MCBreakIteratorRef t_iter;
@@ -1598,6 +1680,9 @@ bool MCStringMapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocaleRe
 
 bool MCStringMapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsLocale(p_locale);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1628,9 +1713,9 @@ bool MCStringCodepointIsWordPart(codepoint_t p_codepoint)
 }
 
 bool MCStringMapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
-{    
-    MCAssert(self != nil);
-    MCAssert(p_locale != nil);
+{
+	__MCAssertIsString(self);
+	__MCAssertIsLocale(p_locale);
     
     // Create the appropriate break iterator
     MCBreakIteratorRef t_iter;
@@ -1682,8 +1767,8 @@ bool MCStringMapSentenceIndices(MCStringRef self, MCLocaleRef p_locale, MCRange 
 
 bool MCStringUnmapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
-    MCAssert(self != nil);
-    MCAssert(p_locale != nil);
+	__MCAssertIsString(self);
+	__MCAssertIsLocale(p_locale);
     
     // Check that the input range is valid
     if (p_in_range.offset + p_in_range.length > MCStringGetLength(self))
@@ -1740,6 +1825,9 @@ bool MCStringUnmapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocale
 
 bool MCStringUnmapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {    
+	__MCAssertIsString(self);
+	__MCAssertIsLocale(p_locale);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -1766,8 +1854,11 @@ bool MCStringUnmapGraphemeIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
 
 bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange p_in_range, MCRange &r_out_range)
 {
-    MCAssert(self != nil);
-    MCAssert(p_locale != nil);
+	__MCAssertIsString(self);
+	__MCAssertIsLocale(p_locale);
+
+	if (__MCStringIsIndirect(self))
+		self = self->string;
     
     // Check that the input range is valid
     if (p_in_range.offset + p_in_range.length > self -> char_count)
@@ -1859,6 +1950,8 @@ bool MCStringUnmapSentenceIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
 extern MCLocaleRef kMCBasicLocale;
 bool MCStringMapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_char_range, MCRange &r_cu_range)
 {
+	__MCAssertIsString(self);
+
     switch (p_type)
     {
         case kMCCharChunkTypeCodeunit:
@@ -1878,6 +1971,8 @@ bool MCStringMapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_char
 
 bool MCStringUnmapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_cu_range, MCRange &r_char_range)
 {
+	__MCAssertIsString(self);
+
     switch (p_type)
     {
         case kMCCharChunkTypeCodeunit:
@@ -1899,6 +1994,7 @@ bool MCStringUnmapIndices(MCStringRef self, MCCharChunkType p_type, MCRange p_cu
 
 bool MCStringConvertToBytes(MCStringRef self, MCStringEncoding p_encoding, bool p_is_external_rep, byte_t*& r_bytes, uindex_t& r_byte_count)
 {
+	__MCAssertIsString(self);
     MCAssert(!p_is_external_rep);
     
     switch(p_encoding)
@@ -1997,6 +2093,8 @@ bool MCStringConvertToBytes(MCStringRef self, MCStringEncoding p_encoding, bool 
 
 bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char_count)
 {
+	__MCAssertIsString(self);
+
     // Get the native chars, but excludes any char belonging to the extended part of the ASCII -
     char_t *t_chars;
     uindex_t t_char_count = MCStringGetLength(self);
@@ -2018,6 +2116,8 @@ bool MCStringConvertToAscii(MCStringRef self, char_t *&r_chars, uindex_t& r_char
 
 bool MCStringConvertToUnicode(MCStringRef self, unichar_t*& r_chars, uindex_t& r_char_count)
 {
+	__MCAssertIsString(self);
+
 	// Allocate an array of chars one bigger than needed. As the allocated array
 	// is filled with zeros, this will naturally NUL terminate the string.
 	unichar_t *t_chars;
@@ -2031,6 +2131,8 @@ bool MCStringConvertToUnicode(MCStringRef self, unichar_t*& r_chars, uindex_t& r
 
 bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, uindex_t& r_char_count)
 {
+	__MCAssertIsString(string);
+
     MCAutoStringRef t_normalized;
     if (!MCStringNormalizedCopyNFC(string, &t_normalized))
         return false;
@@ -2040,6 +2142,8 @@ bool MCStringNormalizeAndConvertToNative(MCStringRef string, char_t*& r_chars, u
 
 bool MCStringConvertToNative(MCStringRef self, char_t*& r_chars, uindex_t& r_char_count)
 {
+	__MCAssertIsString(self);
+
 	// Allocate an array of chars one byte bigger than needed. As the allocated array
 	// is filled with zeros, this will naturally NUL terminate the string.
 	char_t *t_chars;
@@ -2053,6 +2157,8 @@ bool MCStringConvertToNative(MCStringRef self, char_t*& r_chars, uindex_t& r_cha
 
 bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring)
 {
+	__MCAssertIsString(string);
+
     MCAutoStringRef t_normalized;
     if (!MCStringNormalizedCopyNFC(string, &t_normalized))
         return false;
@@ -2062,6 +2168,8 @@ bool MCStringNormalizeAndConvertToCString(MCStringRef string, char*& r_cstring)
 
 bool MCStringConvertToCString(MCStringRef p_string, char*& r_cstring)
 {
+	__MCAssertIsString(p_string);
+
     uindex_t t_length;
     t_length = MCStringGetLength(p_string);
     if (!MCMemoryNewArray(t_length + 1, r_cstring))
@@ -2075,6 +2183,8 @@ bool MCStringConvertToCString(MCStringRef p_string, char*& r_cstring)
 
 bool MCStringConvertToWString(MCStringRef p_string, unichar_t*& r_wstring)
 {
+	__MCAssertIsString(p_string);
+
     uindex_t t_length;
     t_length = MCStringGetLength(p_string);
     if (!MCMemoryNewArray(t_length + 1, r_wstring))
@@ -2088,12 +2198,16 @@ bool MCStringConvertToWString(MCStringRef p_string, unichar_t*& r_wstring)
 
 bool MCStringConvertToUTF8String(MCStringRef p_string, char*& r_utf8string)
 {
+	__MCAssertIsString(p_string);
+
 	uindex_t length_is_ignored;
 	return MCStringConvertToUTF8(p_string, r_utf8string, length_is_ignored);
 }
 
 bool MCStringConvertToUTF8(MCStringRef p_string, char*& r_utf8string, uindex_t& r_utf8_chars)
 {
+	__MCAssertIsString(p_string);
+
 	// Allocate an array of chars one byte bigger than needed. As the allocated array
 	// is filled with zeros, this will naturally NUL terminate the string.
     uindex_t t_length;
@@ -2122,6 +2236,8 @@ bool MCStringConvertToUTF8(MCStringRef p_string, char*& r_utf8string, uindex_t& 
 
 bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_t &r_char_count)
 {
+	__MCAssertIsString(self);
+
     if (MCStringIsNative(self))
     {
         // Shortcut for native string - no surrogate pair checking
@@ -2213,6 +2329,8 @@ bool MCStringConvertToUTF32(MCStringRef self, uint32_t *&r_codepoints, uinteger_
 #if defined(__MAC__) || defined (__IOS__)
 bool MCStringConvertToCFStringRef(MCStringRef p_string, CFStringRef& r_cfstring)
 {
+	__MCAssertIsString(p_string);
+
     uindex_t t_length;
     unichar_t* t_chars;
     
@@ -2256,6 +2374,8 @@ bool MCStringConvertToBSTR(MCStringRef p_string, BSTR& r_bstr)
 
 hash_t MCStringHash(MCStringRef self, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2267,6 +2387,9 @@ hash_t MCStringHash(MCStringRef self, MCStringOptions p_options)
 
 bool MCStringIsEqualTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_other);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2307,6 +2430,9 @@ bool MCStringIsEmpty(MCStringRef string)
 
 bool MCStringSubstringIsEqualTo(MCStringRef self, MCRange p_sub, MCStringRef p_other, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_other);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2339,6 +2465,9 @@ bool MCStringSubstringIsEqualTo(MCStringRef self, MCRange p_sub, MCStringRef p_o
 
 bool MCStringSubstringIsEqualToSubstring(MCStringRef self, MCRange p_sub, MCStringRef p_other, MCRange p_other_sub, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_other);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2374,6 +2503,9 @@ bool MCStringSubstringIsEqualToSubstring(MCStringRef self, MCRange p_sub, MCStri
 
 bool MCStringIsEqualToNativeChars(MCStringRef self, const char_t *p_chars, uindex_t p_char_count, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	MCAssert(nil != p_chars);
+
     if (MCStringIsNative(self))
     {
         if (__MCStringIsIndirect(self))
@@ -2395,6 +2527,9 @@ bool MCStringIsEqualToNativeChars(MCStringRef self, const char_t *p_chars, uinde
 
 compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_other);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2406,6 +2541,9 @@ compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptio
 
 bool MCStringBeginsWith(MCStringRef self, MCStringRef p_prefix, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_prefix);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2434,6 +2572,9 @@ bool MCStringBeginsWith(MCStringRef self, MCStringRef p_prefix, MCStringOptions 
 
 bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefix, MCStringOptions p_options, uindex_t& r_self_match_length)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_prefix);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2473,6 +2614,9 @@ bool MCStringSharedPrefix(MCStringRef self, MCRange p_range, MCStringRef p_prefi
 
 bool MCStringBeginsWithCString(MCStringRef self, const char_t *p_prefix_cstring, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	MCAssert(nil != p_prefix_cstring);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2494,6 +2638,9 @@ bool MCStringBeginsWithCString(MCStringRef self, const char_t *p_prefix_cstring,
 
 bool MCStringEndsWith(MCStringRef self, MCStringRef p_suffix, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_suffix);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2523,6 +2670,9 @@ bool MCStringEndsWith(MCStringRef self, MCStringRef p_suffix, MCStringOptions p_
 
 bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffix, MCStringOptions p_options, uindex_t& r_self_match_length)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_suffix);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2562,6 +2712,9 @@ bool MCStringSharedSuffix(MCStringRef self, MCRange p_range, MCStringRef p_suffi
 
 bool MCStringEndsWithCString(MCStringRef self, const char_t *p_suffix_cstring, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	MCAssert(nil != p_suffix_cstring);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2583,6 +2736,9 @@ bool MCStringEndsWithCString(MCStringRef self, const char_t *p_suffix_cstring, M
 
 bool MCStringContains(MCStringRef self, MCStringRef p_needle, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_needle);
+
     if (MCStringIsEmpty(p_needle))
         return false;
     
@@ -2622,6 +2778,9 @@ bool MCStringContains(MCStringRef self, MCStringRef p_needle, MCStringOptions p_
 
 bool MCStringSubstringContains(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_needle);
+
     if (__MCStringIsIndirect(p_needle))
         p_needle = p_needle -> string;
     
@@ -2673,6 +2832,9 @@ bool MCStringSubstringContains(MCStringRef self, MCRange p_range, MCStringRef p_
 
 bool MCStringFirstIndexOf(MCStringRef self, MCStringRef p_needle, uindex_t p_after, MCStringOptions p_options, uindex_t& r_offset)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_needle);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2735,6 +2897,8 @@ bool MCStringFirstIndexOfChar(MCStringRef self, codepoint_t p_needle, uindex_t p
 
 bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCRange p_range, MCStringOptions p_options, uindex_t& r_offset)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2778,6 +2942,9 @@ bool MCStringFirstIndexOfCharInRange(MCStringRef self, codepoint_t p_needle, MCR
 
 bool MCStringLastIndexOf(MCStringRef self, MCStringRef p_needle, uindex_t p_before, MCStringOptions p_options, uindex_t& r_offset)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_needle);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2820,6 +2987,8 @@ bool MCStringLastIndexOf(MCStringRef self, MCStringRef p_needle, uindex_t p_befo
 
 bool MCStringLastIndexOfChar(MCStringRef self, codepoint_t p_needle, uindex_t p_before, MCStringOptions p_options, uindex_t& r_offset)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -2910,6 +3079,9 @@ static bool MCStringFindNative(MCStringRef self, MCRange p_range, MCStringRef p_
 
 bool MCStringFind(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options, MCRange *r_result)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_needle);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -3040,6 +3212,9 @@ static uindex_t MCStringCountStrChars(MCStringRef self, MCRange p_range, const v
 
 uindex_t MCStringCount(MCStringRef self, MCRange p_range, MCStringRef p_needle, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_needle);
+
     if (__MCStringIsIndirect(p_needle))
         p_needle = p_needle -> string;
     
@@ -3059,9 +3234,8 @@ uindex_t MCStringCount(MCStringRef self, MCRange p_range, MCStringRef p_needle, 
 
 uindex_t MCStringCountChar(MCStringRef self, MCRange p_range, codepoint_t p_needle, MCStringOptions p_options)
 {
-	// We only support ASCII for now.
-	//MCAssert(p_needle < 128);
-	
+	__MCAssertIsString(self);
+
 	strchar_t t_native_needle;
 	t_native_needle = (strchar_t)p_needle;
 	
@@ -3080,6 +3254,8 @@ uindex_t MCStringCountChar(MCStringRef self, MCRange p_range, codepoint_t p_need
 
 bool MCStringDivideAtChar(MCStringRef self, codepoint_t p_separator, MCStringOptions p_options, MCStringRef& r_head, MCStringRef& r_tail)
 {
+	__MCAssertIsString(self);
+
 	uindex_t t_offset;
 	if (!MCStringFirstIndexOfChar(self, p_separator, 0, p_options, t_offset))
 	{
@@ -3096,6 +3272,8 @@ bool MCStringDivideAtChar(MCStringRef self, codepoint_t p_separator, MCStringOpt
 
 bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_head, MCStringRef& r_tail)
 {
+	__MCAssertIsString(self);
+
 	MCStringRef t_head;
 	if (!MCStringCopySubstring(self, MCRangeMake(0, p_offset), t_head))
 		return false;
@@ -3117,6 +3295,7 @@ bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_h
 
 bool MCStringBreakIntoChunks(MCStringRef self, codepoint_t p_separator, MCStringOptions p_options, MCRange*& r_ranges, uindex_t& r_range_count)
 {
+	__MCAssertIsString(self);
 	MCAssert(p_separator < 128);
 	
 	uindex_t t_length;
@@ -3863,6 +4042,8 @@ bool MCStringReplaceChars(MCStringRef self, MCRange p_range, const unichar_t *p_
 
 bool MCStringReplace(MCStringRef self, MCRange p_range, MCStringRef p_replacement)
 {
+	__MCAssertIsMutableString(self);
+
     if (__MCStringIsIndirect(p_replacement))
         p_replacement = p_replacement -> string;
     
@@ -3883,6 +4064,8 @@ bool MCStringReplace(MCStringRef self, MCRange p_range, MCStringRef p_replacemen
 
 bool MCStringPad(MCStringRef self, uindex_t p_at, uindex_t p_count, MCStringRef p_value)
 {
+	__MCAssertIsMutableString(self);
+
     // Ensure the string is not indirect.
     if (__MCStringIsIndirect(self))
         if (!__MCStringResolveIndirect(self))
@@ -3905,6 +4088,8 @@ bool MCStringPad(MCStringRef self, uindex_t p_at, uindex_t p_count, MCStringRef 
 
 bool MCStringResolvesLeftToRight(MCStringRef self)
 {
+	__MCAssertIsString(self);
+
     if (MCStringIsNative(self) || MCStringCanBeNative(self))
         return true;
     
@@ -3925,6 +4110,8 @@ bool MCStringAppendFormat(MCStringRef self, const char *p_format, ...)
 
 bool MCStringAppendFormatV(MCStringRef self, const char *p_format, va_list p_args)
 {
+	__MCAssertIsMutableString(self);
+
 	MCAutoStringRef t_formatted_string;
 	if (!MCStringFormatV(&t_formatted_string, p_format, p_args))
 		return false;
@@ -4077,6 +4264,8 @@ bool MCStringSplitNative(MCStringRef self, MCStringRef p_elem_del, MCStringRef p
 
 bool MCStringFindAndReplaceChar(MCStringRef self, char_t p_pattern, char_t p_replacement, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+
 	if (p_options == kMCStringOptionCompareExact || p_options == kMCStringOptionCompareNonliteral)
 	{
 		// Simplest case, just substitute pattern for replacement.
@@ -4239,6 +4428,12 @@ static void split_find_end_of_element_and_key(const void *sptr, uindex_t length,
 
 bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_del, MCStringOptions p_options, MCArrayRef& r_array)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_elem_del);
+	if (nil != p_key_del)
+		__MCAssertIsString(p_key_del);
+
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -4360,6 +4555,8 @@ bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_d
 
 bool MCStringFindAndReplaceChar(MCStringRef self, codepoint_t p_pattern, codepoint_t p_replacement, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+
     // Ensure the string is not indirect.
     if (__MCStringIsIndirect(self))
         if (!__MCStringResolveIndirect(self))
@@ -4413,6 +4610,10 @@ bool MCStringFindAndReplaceChar(MCStringRef self, codepoint_t p_pattern, codepoi
 
 bool MCStringFindAndReplace(MCStringRef self, MCStringRef p_pattern, MCStringRef p_replacement, MCStringOptions p_options)
 {
+	__MCAssertIsString(self);
+	__MCAssertIsString(p_pattern);
+	__MCAssertIsString(p_replacement);
+
     // Ensure the string is not indirect.
     if (__MCStringIsIndirect(self))
         if (!__MCStringResolveIndirect(self))
@@ -4520,6 +4721,9 @@ bool MCStringFindAndReplace(MCStringRef self, MCStringRef p_pattern, MCStringRef
 
 bool MCStringWildcardMatch(MCStringRef source, MCRange source_range, MCStringRef pattern, MCStringOptions p_options)
 {
+	__MCAssertIsString(source);
+	__MCAssertIsString(pattern);
+
     bool source_native = MCStringIsNative(source);
     
     const void *source_chars;
@@ -4872,6 +5076,8 @@ unsigned int MCStringCodepointToSurrogates(codepoint_t p_codepoint, unichar_t (&
 
 bool MCStringIsValidSurrogatePair(MCStringRef self, uindex_t p_index)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -5034,7 +5240,7 @@ static bool do_iconv(iconv_t fd, const char *in, size_t in_len, char * &out, siz
 bool MCStringCreateWithSysString(const char *p_system_string, MCStringRef &r_string)
 {
     // Is the string empty?
-    if (p_system_string == nil)
+    if (p_system_string == nil || *p_system_string == 0)
     {
         r_string = MCValueRetain(kMCEmptyString);
         return true;
@@ -5156,6 +5362,8 @@ bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, s
 #elif defined(__WINDOWS__)
 bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
 {
+	__MCAssertIsString(p_string);
+
     UINT t_codepage;
     t_codepage = GetConsoleOutputCP();
     
@@ -5197,6 +5405,8 @@ bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, s
 #else
 bool MCStringConvertToSysString(MCStringRef p_string, char *& r_system_string, size_t& r_byte_count)
 {
+	__MCAssertIsString(p_string);
+
     bool t_success;
     uindex_t t_byte_count;
     if (!MCStringConvertToUTF8(p_string, r_system_string, t_byte_count))
@@ -5209,15 +5419,16 @@ bool
 MCStringCreateWithSysString(const char *p_sys_string,
                             MCStringRef & r_string)
 {
-	/* Count the number of chars */
-	size_t p_byte_count;
-	for (p_byte_count = 0; p_sys_string[p_byte_count] != '\0'; ++p_byte_count);
-
-	if (0 == p_byte_count)
+	/* Fast path for empty string */
+	if (nil == p_sys_string || 0 == *p_sys_string)
 	{
 		r_string = MCValueRetain(kMCEmptyString);
 		return true;
 	}
+
+	/* Count the number of chars */
+	size_t p_byte_count;
+	for (p_byte_count = 0; p_sys_string[p_byte_count] != '\0'; ++p_byte_count);
 
 	return MCStringCreateWithBytes((const byte_t *) p_sys_string,
 	                               p_byte_count,
@@ -5346,17 +5557,25 @@ __MCStringCreateWithStrings(MCStringRef& r_string, bool p_has_separator, unichar
 bool
 MCStringCreateWithStrings(MCStringRef& r_string, MCStringRef p_one, MCStringRef p_two)
 {
+	__MCAssertIsString(p_one);
+	__MCAssertIsString(p_two);
+
     return __MCStringCreateWithStrings(r_string, false, 0, p_one, p_two);
 }
 
 bool
 MCStringCreateWithStringsAndSeparator(MCStringRef& r_string, unichar_t p_separator, MCStringRef p_one, MCStringRef p_two)
 {
+	__MCAssertIsString(p_one);
+	__MCAssertIsString(p_two);
+
     return __MCStringCreateWithStrings(r_string, true, p_separator, p_one, p_two);
 }
 
 bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)
 {
+	__MCAssertIsString(self);
+
     if (MCStringIsNative(self))
         return MCStringCopy(self, r_string);
     
@@ -5372,6 +5591,8 @@ bool MCStringNormalizedCopyNFC(MCStringRef self, MCStringRef &r_string)
 
 bool MCStringNormalizedCopyNFD(MCStringRef self, MCStringRef &r_string)
 {
+	__MCAssertIsString(self);
+
     // AL-2014-06-24: [[ Bug 12656 ]] Native strings can be decomposed into non-native ones.
     unichar_t *t_norm = nil;
     uindex_t t_norm_length;
@@ -5384,6 +5605,8 @@ bool MCStringNormalizedCopyNFD(MCStringRef self, MCStringRef &r_string)
 
 bool MCStringNormalizedCopyNFKC(MCStringRef self, MCStringRef &r_string)
 {
+	__MCAssertIsString(self);
+
     // Native strings are already normalized
     if (MCStringIsNative(self))
         return MCStringCopy(self, r_string);
@@ -5400,6 +5623,8 @@ bool MCStringNormalizedCopyNFKC(MCStringRef self, MCStringRef &r_string)
 
 bool MCStringNormalizedCopyNFKD(MCStringRef self, MCStringRef &r_string)
 {
+	__MCAssertIsString(self);
+
     // AL-2014-06-24: [[ Bug 12656 ]] Native strings can be decomposed into non-native ones.
     // Normalise
     unichar_t *t_norm = nil;
@@ -5415,6 +5640,8 @@ bool MCStringNormalizedCopyNFKD(MCStringRef self, MCStringRef &r_string)
 
 bool MCStringSetNumericValue(MCStringRef self, double p_value)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     
@@ -5429,6 +5656,8 @@ bool MCStringSetNumericValue(MCStringRef self, double p_value)
 
 bool MCStringGetNumericValue(MCStringRef self, double &r_value)
 {
+	__MCAssertIsString(self);
+
     if (__MCStringIsIndirect(self))
         self = self -> string;
     

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -5450,7 +5450,7 @@ MCStringCreateWithSysString(const char *p_sys_string,
 
 	/* Count the number of chars */
 	size_t t_byte_count;
-	for (t_byte_count = 0; p_sys_string[p_byte_count] != '\0'; ++t_byte_count);
+	for (t_byte_count = 0; p_sys_string[t_byte_count] != '\0'; ++t_byte_count);
 
 	return MCStringCreateWithBytes((const byte_t *) p_sys_string,
 	                               t_byte_count,


### PR DESCRIPTION
Add assertions to every public libfoundation function that accepts arguments of `MCValueRef` type, ensuring that the values are of the expected type.  The new checks add about 2.5% overhead to the engine, as measured using `perf` on Linux.
