### PR TITLE
[[ Bug 16120 ]] Do not use symlink for apps for iOS Simulator >= 9.0

### DIFF
--- a/docs/notes/bugfix-16120.md
+++ b/docs/notes/bugfix-16120.md
@@ -1,0 +1,1 @@
+# [Global Jam] Can't deploy to iOS 9 Simulator when using referenced images

--- a/docs/notes/bugfix-16120.md
+++ b/docs/notes/bugfix-16120.md
@@ -1,1 +1,5 @@
 # [Global Jam] Can't deploy to iOS 9 Simulator when using referenced images
+
+To improve deployment speed on iOS simulator, the files referenced in the Standalone Settings 'Copy Files' pane are not actually copied, but symlinked.
+Unfortunately, it seems that iOS Simulator 9.0 does not handle this the way the previous simulators do, and when deploying to iOS Simulator 9.0, the files have to be copied.
+Therefore, expect a longer deployment building to iOS simulator 9.0 if you have big files attached to your application.

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -900,7 +900,8 @@ private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, 
    -- MM-2012-09-18: Since we now no longer support sims before 4.3, we always use redirects for sim builds.
    --
    local tUseRedirects
-   if pAppTarget is not "Device" then
+   // We only use symlinks for iOS simulator < 9.0 (from 9.0, the app won't start with symlinks)
+   if pAppTarget is not "Device" and word 2 of pAppTarget < 9.0 then
       put true into tUseRedirects
    end if 
    


### PR DESCRIPTION
It seems that iOS Simulator 9.0 can't handle symlinks, and the app will never start with our iPhoneProxy if any is used
