### PR TITLE
[[ Debugging ]] Added a helper 'checkloadstat()' for fileformat problems

### DIFF
--- a/engine/src/aclip.cpp
+++ b/engine/src/aclip.cpp
@@ -965,26 +965,26 @@ IO_stat MCAudioClip::load(IO_handle stream, uint32_t version)
 	IO_stat stat;
 
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint4(&size, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if (size != 0)
 	{
 		samples = new int1[size];
 		if ((stat = IO_read(samples, size, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 	}
 	if ((stat = IO_read_uint2(&format, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint2(&nchannels, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint2(&swidth, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint2(&rate, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if (flags & F_LOUDNESS)
 		if ((stat = IO_read_uint2(&loudness, stream)) != IO_NORMAL)
-            return stat;
+            return checkloadstat(stat);
 	return loadpropsets(stream, version);
 }
 

--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -163,7 +163,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	}
 
 	if ((stat = IO_read_uint4(&flags, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 
 	// MW-2012-03-04: [[ StackFile5500 ]] If this isn't an extended block, then strip the
 	//   metadata flag.
@@ -184,7 +184,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 		{
 			uint2 t_font_index;
 			if ((stat = IO_read_uint2(&t_font_index, stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 
 			// MW-2012-02-17: [[ LogFonts ]] Map the font index we have to the font attrs.
 			//   Note that we ignore the 'unicode' tag since that is encoded in flags.
@@ -208,11 +208,11 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 			// MW-2013-11-19: [[ UnicodeFileFormat ]] This path only happens sfv < 1300
 			//   so is legacy.
 			if ((stat = IO_read_nameref_legacy(atts->fontname, stream, false)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			if ((stat = IO_read_uint2(&atts->fontsize, stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			if ((stat = IO_read_uint2(&atts->fontstyle, stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 
 			// MW-2012-02-17; [[ SplitTextAttrs ]] All the font attrs are set.
 			flags |= F_FATTR_MASK;
@@ -222,7 +222,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	{
 		atts->color = new MCColor;
 		if ((stat = IO_read_mccolor(*atts->color, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (flags & F_HAS_COLOR_NAME)
 		{
 			// MW-2012-01-06: [[ Block Changes ]] We no longer use the color name
@@ -231,7 +231,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 			//   so is legacy,
 			char *colorname;
 			if ((stat = IO_read_cstring_legacy(colorname, stream, 2)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			delete colorname;
 			flags &= ~F_HAS_COLOR_NAME;
 		}
@@ -240,7 +240,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	{
 		atts->backcolor = new MCColor;
 		if ((stat = IO_read_mccolor(*atts->backcolor, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (version < 2000 || flags & F_HAS_BACK_COLOR_NAME)
 		{
 			// MW-2012-01-06: [[ Block Changes ]] We no longer use the backcolor name
@@ -249,14 +249,14 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 			//   so is legacy,
 			char *backcolorname;
 			if ((stat = IO_read_cstring_legacy(backcolorname, stream, 2)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			delete backcolorname;
 			flags &= ~F_HAS_BACK_COLOR_NAME;
 		}
 	}
 	if (flags & F_HAS_SHIFT)
 		if ((stat = IO_read_int2(&atts->shift, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 
 	// MW-2012-05-04: [[ Values ]] linkText / imageSource / metaData are now uniqued
 	//   strings.
@@ -264,7 +264,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	{
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 		if ((stat = IO_read_stringref_new(atts->linktext, stream, version >= 7000)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		/* UNCHECKED */ MCValueInterAndRelease(atts -> linktext, atts -> linktext);
 	}
 
@@ -272,7 +272,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	{
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 		if ((stat = IO_read_stringref_new(atts->imagesource, stream, version >= 7000)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		/* UNCHECKED */ MCValueInterAndRelease(atts -> imagesource, atts -> imagesource);
 	}
 
@@ -282,7 +282,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	{
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 		if ((stat = IO_read_stringref_new(atts->metadata, stream, version >= 7000)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		/* UNCHECKED */ MCValueInterAndRelease(atts -> metadata, atts -> metadata);
 	}
 
@@ -290,7 +290,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	//   to the end of the attrs record.
 	if (is_ext)
 		if ((stat = MCS_seek_set(stream, t_attr_end)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 	
 	// ***** IMPORTANT *****
 	// The "index" and "size" values loaded below are byte indices into the
@@ -304,9 +304,9 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	// the block of the correct offsets as soon as it knows them.
 	uint2 index, size;
 	if ((stat = IO_read_uint2(&index, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint2(&size, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	m_index = index;
 	m_size = size;
 

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -3373,7 +3373,7 @@ IO_stat MCCard::load(IO_handle stream, uint32_t version)
 	IO_stat stat;
 
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 
 //---- 2.7+:
 //  . F_OPAQUE is now valid - default true
@@ -3387,19 +3387,19 @@ IO_stat MCCard::load(IO_handle stream, uint32_t version)
 
 	rect.y = 0; // in case saved on mac with editMenus false
 	if ((stat = loadpropsets(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	while (True)
 	{
 		uint1 type;
 		if ((stat = IO_read_uint1(&type, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (type == OT_PTR)
 		{
 			MCObjptr *newptr = new MCObjptr;
 			if ((stat = newptr->load(stream)) != IO_NORMAL)
 			{
 				delete newptr;
-				return stat;
+				return checkloadstat(stat);
 			}
 			newptr->setparent(this);
 			newptr->appendto(objptrs);
@@ -3425,7 +3425,7 @@ IO_stat MCCard::loadobjects(IO_handle stream, uint32_t version)
 		{
 			uint1 t_object_type;
 			if ((stat = IO_read_uint1(&t_object_type, stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 
 			MCControl *t_control;
 			switch(t_object_type)
@@ -3464,14 +3464,14 @@ IO_stat MCCard::loadobjects(IO_handle stream, uint32_t version)
 				t_control = new MCColors;
 			break;
 			default:
-				return IO_ERROR;
+				return checkloadstat(IO_ERROR);
 			break;
 			}
 
 			if ((stat = t_control -> load(stream, version)) != IO_NORMAL)
 			{
 				delete t_control;
-				return stat;
+				return checkloadstat(stat);
 			}
 
 			t_objptr -> setref(t_control);
@@ -3481,7 +3481,7 @@ IO_stat MCCard::loadobjects(IO_handle stream, uint32_t version)
 		while(t_objptr != objptrs);
 	}
 
-	return stat;
+	return checkloadstat(stat);
 }
 
 IO_stat MCCard::save(IO_handle stream, uint4 p_part, bool p_force_ext)

--- a/engine/src/cdata.cpp
+++ b/engine/src/cdata.cpp
@@ -88,13 +88,13 @@ IO_stat MCCdata::load(IO_handle stream, MCObject *parent, uint32_t version)
 	IO_stat stat;
 
 	if ((stat = IO_read_uint4(&id, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if (parent->gettype() == CT_BUTTON)
 	{
 		uint1 set;
 		stat = IO_read_uint1(&set, stream);
 		data = reinterpret_cast<void *>(set ? 1 : 0);
-		return stat;
+		return checkloadstat(stat);
 	}
 	else
 	{
@@ -104,7 +104,7 @@ IO_stat MCCdata::load(IO_handle stream, MCObject *parent, uint32_t version)
 			//   so is just legacy.
 			char *string;
 			if ((stat = IO_read_cstring_legacy(string, stream, sizeof(uint1))) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			data = string;
 		}
 		else
@@ -114,7 +114,7 @@ IO_stat MCCdata::load(IO_handle stream, MCObject *parent, uint32_t version)
 			{
 				uint1 type;
 				if ((stat = IO_read_uint1(&type, stream)) != IO_NORMAL)
-					return stat;
+					return checkloadstat(stat);
 				switch (type)
 				{
 				// MW-2012-03-04: [[ StackFile5500 ]] Handle either the paragraph or extended
@@ -130,7 +130,7 @@ IO_stat MCCdata::load(IO_handle stream, MCObject *parent, uint32_t version)
 						if ((stat = newpar->load(stream, version, type == OT_PARAGRAPH_EXT)) != IO_NORMAL)
 						{
 							delete newpar;
-							return stat;
+							return checkloadstat(stat);
 						}
 						newpar->appendto(paragraphs);
 					}

--- a/engine/src/cpalette.cpp
+++ b/engine/src/cpalette.cpp
@@ -316,6 +316,6 @@ IO_stat MCColors::load(IO_handle stream, uint32_t version)
 {
 	IO_stat stat;
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	return loadpropsets(stream, version);
 }

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -672,7 +672,7 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
 		if (version > MAX_STACKFILE_VERSION)
 		{
 			MCresult->sets("stack was produced by a newer version");
-			return IO_ERROR;
+			return checkloadstat(IO_ERROR);
 		}
         
 		// MW-2008-10-20: [[ ParentScripts ]] Set the boolean flag that tells us whether
@@ -687,7 +687,7 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
 		        || IO_read_cstring_legacy(newsf, stream, 2) != IO_NORMAL)
 		{
 			MCresult->sets("stack is corrupted, check for ~ backup file");
-			return IO_ERROR;
+			return checkloadstat(IO_ERROR);
 		}
 		delete newsf; // stackfiles is obsolete
 		MCtranslatechars = charset != CHARSET;
@@ -722,7 +722,7 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
 				MCresult->sets("stack is corrupted, check for ~ backup file");
 			destroystack(sptr, False);
 			sptr = NULL;
-			return IO_ERROR;
+			return checkloadstat(IO_ERROR);
 		}
 		
 		// MW-2011-08-09: [[ Groups ]] Make sure F_GROUP_SHARED is set
@@ -737,7 +737,7 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
 				MCresult->sets("stack is corrupted, check for ~ backup file");
 			destroystack(sptr, False);
 			sptr = NULL;
-			return IO_ERROR;
+			return checkloadstat(IO_ERROR);
 		}
     }
     
@@ -762,7 +762,7 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
         if (IO_read(t_script, t_size, stream) == IO_ERROR)
         {
             MCresult -> sets("unable to read file");
-            return IO_ERROR;
+            return checkloadstat(IO_ERROR);
         }
 
         // SN-2014-10-16: [[ Merge-6.7.0-rc-3 ]] Update to StringRef

--- a/engine/src/dllst.h
+++ b/engine/src/dllst.h
@@ -62,6 +62,18 @@ public:
 	void append(MCDLlist *node);
 	void splitat(MCDLlist *node);
 	MCDLlist *remove(MCDLlist *&list);
+    
+    // This function is called on all 'IO_stat' return in load methods. It
+    // provides an easy hook for a breakpoint to work out why a particular file
+    // failed to load.
+    inline static IO_stat checkloadstat(IO_stat stat)
+    {
+        if (stat != IO_NORMAL)
+        {
+            return stat;
+        }
+        return stat;
+    }
 
 #ifdef  _DEBUG_MALLOC_INC
 	void verify(char *where);

--- a/engine/src/eps.cpp
+++ b/engine/src/eps.cpp
@@ -574,59 +574,59 @@ IO_stat MCEPS::load(IO_handle stream, uint32_t version)
 	IO_stat stat;
 
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	delete postscript;
 	delete prolog;
 	if ((stat = IO_read_uint4(&size, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	postscript = new char[size + 1];
 	if ((stat = IO_read(postscript, size, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	postscript[size] = '\0';
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] EPS is always ASCII so legacy.
 	if ((stat = IO_read_cstring_legacy(prolog, stream, 2)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	int4 i;
 	if ((stat = IO_read_int4(&i, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	xscale = MCU_i4tor8(i);
 	if (flags & F_SCALE_INDEPENDENTLY)
 	{
 		if ((stat = IO_read_int4(&i, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		yscale = MCU_i4tor8(i);
 	}
 	else
 		yscale = xscale;
 	if ((stat = IO_read_int2(&angle, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_int2(&tx, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_int2(&ty, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint2(&ex, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint2(&ey, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if (flags & F_RETAIN_IMAGE)
 	{
 		image = new MCImage;
 		image->setparent(this);
 		if ((stat = image->load(stream, version)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 	}
 	if (version > 1300)
 	{
 		if ((stat = IO_read_uint2(&curpage, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_uint2(&pagecount, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (pagecount > 0)
 		{
 			pageIndex = new uint4[pagecount];
 			for (i = 0 ; i < pagecount ; i++)
 				if ((stat = IO_read_uint4(&pageIndex[i], stream)) != IO_NORMAL)
-					return stat;
+					return checkloadstat(stat);
 		}
 	}
 	return loadpropsets(stream, version);

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -3245,16 +3245,16 @@ IO_stat MCField::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
     if (p_length > 0)
     {
 		uint4 t_flags, t_length, t_header_length;
-		t_stat = p_stream . ReadTag(t_flags, t_length, t_header_length);
+		t_stat = checkloadstat(p_stream . ReadTag(t_flags, t_length, t_header_length));
         
 		if (t_stat == IO_NORMAL)
-			t_stat = p_stream . Mark();
+			t_stat = checkloadstat(p_stream . Mark());
         
         // MW-2014-06-20: [[ 13315 ]] Load the textDirection of the field.
         if (t_stat == IO_NORMAL && (t_flags & FIELD_EXTRA_TEXTDIRECTION) != 0)
         {
             uint8_t t_value;
-            t_stat = p_stream . ReadU8(t_value);
+            t_stat = checkloadstat(p_stream . ReadU8(t_value));
             if (t_stat == IO_NORMAL)
                 text_direction = (MCTextDirection)t_value;
         }
@@ -3266,17 +3266,17 @@ IO_stat MCField::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
             intenum_t *t_alignments;
             t_alignments = NULL;
 
-            t_stat = p_stream . ReadU16(t_nalign);
+            t_stat = checkloadstat(p_stream . ReadU16(t_nalign));
 
             if (t_stat == IO_NORMAL && t_nalign != 0)
             {
                 if (!MCMemoryAllocate(sizeof(intenum_t) * t_nalign, t_alignments))
-                    t_stat = IO_ERROR;
+                    t_stat = checkloadstat(IO_ERROR);
 
                 for (uint2 i = 0; i < t_nalign && t_stat == IO_NORMAL; ++i)
                 {
                     int8_t t_align;
-                    if ((t_stat = p_stream . ReadS8(t_align)) == IO_NORMAL)
+                    if ((t_stat = checkloadstat(p_stream . ReadS8(t_align))) == IO_NORMAL)
                         t_alignments[i] = t_align;
                 }
 
@@ -3291,7 +3291,7 @@ IO_stat MCField::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
         }
         
         if (t_stat == IO_NORMAL)
-            t_stat = p_stream . Skip(t_length);
+            t_stat = checkloadstat(p_stream . Skip(t_length));
         
         if (t_stat == IO_NORMAL)
             p_length -= t_length + t_header_length;
@@ -3399,26 +3399,26 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 	IO_stat stat;
 
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_int2(&leftmargin, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_int2(&rightmargin, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_int2(&topmargin, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_int2(&bottommargin, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_int2(&indent, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if (flags & F_TABS)
 	{
 		if ((stat = IO_read_uint2(&ntabs, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		tabs = new uint2[ntabs];
 		uint2 i;
 		for (i = 0 ; i < ntabs ; i++)
 			if ((stat = IO_read_uint2(&tabs[i], stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 	}
 	if (version <= 2000)
 	{
@@ -3429,19 +3429,19 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 	if (flags & F_VGRID)
 		flags |= F_DONT_WRAP;
 	if ((stat = loadpropsets(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	while (True)
 	{
 		uint1 type;
 		if ((stat = IO_read_uint1(&type, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (type == OT_FDATA)
 		{
 			MCCdata *newfdata = new MCCdata;
 			if ((stat = newfdata->load(stream, this, version)) != IO_NORMAL)
 			{
 				delete newfdata;
-				return stat;
+				return checkloadstat(stat);
 			}
 			newfdata->appendto(fdata);
 		}
@@ -3453,7 +3453,7 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 					vscrollbar = new MCScrollbar;
 					vscrollbar->setparent(this);
 					if ((stat = vscrollbar->load(stream, version)) != IO_NORMAL)
-						return stat;
+						return checkloadstat(stat);
 					vscrollbar->setflag(getflag(F_DISABLED), F_DISABLED);
 					vscrollbar->allowmessages(False);
 					vscrollbar->setembedded();
@@ -3465,7 +3465,7 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 						hscrollbar = new MCScrollbar;
 						hscrollbar->setparent(this);
 						if ((stat = hscrollbar->load(stream, version)) != IO_NORMAL)
-							return stat;
+							return checkloadstat(stat);
 						hscrollbar->setflag(getflag(F_DISABLED), F_DISABLED);
 						hscrollbar->allowmessages(False);
 						hscrollbar->setembedded();

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -2566,16 +2566,16 @@ IO_stat MCGraphic::extendedload(MCObjectInputStream& p_stream, uint32_t p_versio
 	if (p_remaining > 0)
 	{
 		uint4 t_flags, t_length, t_header_size;
-		t_stat = p_stream . ReadTag(t_flags, t_length, t_header_size);
+		t_stat = checkloadstat(p_stream . ReadTag(t_flags, t_length, t_header_size));
 		if (t_stat == IO_NORMAL)
-			t_stat = p_stream . Mark();
+			t_stat = checkloadstat(p_stream . Mark());
 
 		uint4 t_corrected_length;
 		t_corrected_length = 0;
 
 		if (t_stat == IO_NORMAL && (t_flags & GRAPHIC_EXTRA_MITERLIMIT) != 0)
 		{
-			t_stat = p_stream . ReadFloat32(m_stroke_miter_limit);
+			t_stat = checkloadstat(p_stream . ReadFloat32(m_stroke_miter_limit));
 			if (t_length == 0)
 				t_corrected_length += 4;
 		}
@@ -2583,7 +2583,7 @@ IO_stat MCGraphic::extendedload(MCObjectInputStream& p_stream, uint32_t p_versio
 		if (t_stat == IO_NORMAL && (t_flags & GRAPHIC_EXTRA_FILLGRADIENT) != 0)
 		{
 			MCGradientFillInit(m_fill_gradient, rect);
-			t_stat = MCGradientFillUnserialize(m_fill_gradient, p_stream);
+			t_stat = checkloadstat(MCGradientFillUnserialize(m_fill_gradient, p_stream));
 			if (t_length == 0)
 				t_corrected_length += MCGradientFillMeasure(m_fill_gradient);
 		}
@@ -2591,7 +2591,7 @@ IO_stat MCGraphic::extendedload(MCObjectInputStream& p_stream, uint32_t p_versio
 		if (t_stat == IO_NORMAL && (t_flags & GRAPHIC_EXTRA_STROKEGRADIENT) != 0)
 		{
 			MCGradientFillInit(m_stroke_gradient, rect);
-			t_stat = MCGradientFillUnserialize(m_stroke_gradient, p_stream);
+			t_stat = checkloadstat(MCGradientFillUnserialize(m_stroke_gradient, p_stream));
 			if (t_length == 0)
 				t_corrected_length += MCGradientFillMeasure(m_stroke_gradient);
 		}
@@ -2599,13 +2599,13 @@ IO_stat MCGraphic::extendedload(MCObjectInputStream& p_stream, uint32_t p_versio
 		// MW-2008-08-12: [[ Bug 2849 ]] Make sure margins are saved with the graphic object
 		if (t_stat == IO_NORMAL && (t_flags & GRAPHIC_EXTRA_MARGINS) != 0)
 		{
-			t_stat = p_stream . ReadS16(leftmargin);
+			t_stat = checkloadstat(p_stream . ReadS16(leftmargin));
 			if (t_stat == IO_NORMAL)
-				t_stat = p_stream . ReadS16(topmargin);
+				t_stat = checkloadstat(p_stream . ReadS16(topmargin));
 			if (t_stat == IO_NORMAL)
-				t_stat = p_stream . ReadS16(rightmargin);
+				t_stat = checkloadstat(p_stream . ReadS16(rightmargin));
 			if (t_stat == IO_NORMAL)
-				t_stat = p_stream . ReadS16(bottommargin);
+				t_stat = checkloadstat(p_stream . ReadS16(bottommargin));
 		}
 
 		// During the 3.0.0 development cycle, the graphic extended data area was different since it
@@ -2613,7 +2613,7 @@ IO_stat MCGraphic::extendedload(MCObjectInputStream& p_stream, uint32_t p_versio
 		// be non-zero, and length to be zero. In this case, we rely on the file pointer not needing
 		// updating so we only do the following for non-zero length.
 		if (t_stat == IO_NORMAL && t_length != 0)
-			t_stat = p_stream . Skip(t_length);
+			t_stat = checkloadstat(p_stream . Skip(t_length));
 
 		if (t_stat == IO_NORMAL)
 		{
@@ -2757,7 +2757,7 @@ IO_stat MCGraphic::load(IO_handle stream, uint32_t version)
 	Boolean loaddashes = False;
 
 	if ((stat = MCControl::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 
 //---- 2.7+:
 //  . F_G_ANTI_ALIASED now defined
@@ -2770,58 +2770,58 @@ IO_stat MCGraphic::load(IO_handle stream, uint32_t version)
 		m_font_flags |= FF_HAS_UNICODE;
 
 	if ((stat = IO_read_uint2(&angle, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint2(&linesize, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	switch (flags & F_STYLE)
 	{
 	case F_G_RECTANGLE:
 		break;
 	case F_ROUNDRECT:
 		if ((stat = IO_read_uint2(&roundradius, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		break;
 	case F_REGULAR:
 		if ((stat = IO_read_uint2(&nsides, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		break;
 	case F_OVAL:
 		if ((stat = IO_read_uint2(&startangle, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_uint2(&arcangle, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		break;
 	case F_POLYGON:
 		if ((stat = IO_read_uint2(&markerlsize, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_uint2(&nmarkerpoints, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (nmarkerpoints != 0)
 		{
 			markerpoints = new MCPoint[nmarkerpoints];
 			for (i = 0 ; i < nmarkerpoints ; i++)
 			{
 				if ((stat = IO_read_int2(&markerpoints[i].x, stream)) != IO_NORMAL)
-					return stat;
+					return checkloadstat(stat);
 				if ((stat = IO_read_int2(&markerpoints[i].y, stream)) != IO_NORMAL)
-					return stat;
+					return checkloadstat(stat);
 			}
 		}
 	case F_LINE:
 	case F_CURVE:
 		if ((stat = IO_read_uint2(&arrowsize, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_uint2(&nrealpoints, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (nrealpoints != 0)
 		{
 			realpoints = new MCPoint[nrealpoints];
 			for (i = 0 ; i < nrealpoints ; i++)
 			{
 				if ((stat = IO_read_int2(&realpoints[i].x, stream)) != IO_NORMAL)
-					return stat;
+					return checkloadstat(stat);
 				if ((stat = IO_read_int2(&realpoints[i].y, stream)) != IO_NORMAL)
-					return stat;
+					return checkloadstat(stat);
 			}
 		}
 		if (version < 1400)
@@ -2833,14 +2833,14 @@ IO_stat MCGraphic::load(IO_handle stream, uint32_t version)
 	if (loaddashes || flags & F_DASHES)
 	{
 		if ((stat = IO_read_uint2(&ndashes, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (ndashes != 0)
 		{
 			flags |= F_DASHES;
 			dashes = new uint1[ndashes];
 			for (i = 0 ; i < ndashes ; i++)
 				if ((stat = IO_read_uint1(&dashes[i], stream)) != IO_NORMAL)
-					return stat;
+					return checkloadstat(stat);
 			// sanity check: ensure dashes are not all 0
 			bool t_allzero = true;
 			for (i=0; i<ndashes && t_allzero; i++)
@@ -2862,12 +2862,12 @@ IO_stat MCGraphic::load(IO_handle stream, uint32_t version)
 		if (version < 7000)
 		{
 			if ((stat = IO_read_stringref_legacy(label, stream, hasunicode())) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 		}
 		else
 		{
 			if ((stat = IO_read_stringref_new(label, stream, true)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 		}
     }
 	

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -3147,10 +3147,10 @@ IO_stat MCGroup::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 	if (p_remaining > 0)
 	{
 		uint4 t_flags, t_length, t_header_length;
-		t_stat = p_stream . ReadTag(t_flags, t_length, t_header_length);
+		t_stat = checkloadstat(p_stream . ReadTag(t_flags, t_length, t_header_length));
         
 		if (t_stat == IO_NORMAL)
-			t_stat = p_stream . Mark();
+			t_stat = checkloadstat(p_stream . Mark());
         
         // MW-2014-06-20: [[ ClipsToRect ]] ClipsToRect doesn't require any storage
         //   as if the flag is present its true, otherwise false.
@@ -3158,7 +3158,7 @@ IO_stat MCGroup::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
             m_clips_to_rect = true;
         
 		if (t_stat == IO_NORMAL)
-			t_stat = p_stream . Skip(t_length);
+			t_stat = checkloadstat(p_stream . Skip(t_length));
         
 		if (t_stat == IO_NORMAL)
 			p_remaining -= t_length + t_header_length;
@@ -3269,7 +3269,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 {
 	IO_stat stat;
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 
 	// MW-2011-08-10: [[ Groups ]] Make sure the group has F_GROUP_SHARED set
 	//   if it is a background.
@@ -3287,25 +3287,25 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 		if (version < 7000)
 		{
 			if ((stat = IO_read_stringref_legacy(label, stream, hasunicode())) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 		}
 		else
 		{
 			if ((stat = IO_read_stringref_new(label, stream, true)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 		}
 	}
 	
 	if (flags & F_MARGINS)
 	{
 		if ((stat = IO_read_int2(&leftmargin, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_int2(&rightmargin, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_int2(&topmargin, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_int2(&bottommargin, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (leftmargin == defaultmargin
 		        && leftmargin == rightmargin
 		        && leftmargin == topmargin
@@ -3315,21 +3315,21 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 	if (flags & F_BOUNDING_RECT)
 	{
 		if ((stat = IO_read_int2(&minrect.x, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_int2(&minrect.y, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_uint2(&minrect.width, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if ((stat = IO_read_uint2(&minrect.height, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 	}
 	if ((stat = loadpropsets(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	while (True)
 	{
 		uint1 type;
 		if ((stat = IO_read_uint1(&type, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		switch (type)
 		{
 		case OT_GROUP:
@@ -3339,7 +3339,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newgroup->load(stream, version)) != IO_NORMAL)
 				{
 					delete newgroup;
-					return stat;
+					return checkloadstat(stat);
 				}
 				MCControl *newcontrol = newgroup;
 				
@@ -3358,7 +3358,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newbutton->load(stream, version)) != IO_NORMAL)
 				{
 					delete newbutton;
-					return stat;
+					return checkloadstat(stat);
 				}
 				MCControl *cptr = (MCControl *)newbutton;
 				cptr->appendto(controls);
@@ -3371,7 +3371,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newfield->load(stream, version)) != IO_NORMAL)
 				{
 					delete newfield;
-					return stat;
+					return checkloadstat(stat);
 				}
 				newfield->appendto(controls);
 			}
@@ -3383,7 +3383,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newimage->load(stream, version)) != IO_NORMAL)
 				{
 					delete newimage;
-					return stat;
+					return checkloadstat(stat);
 				}
 				MCControl *cptr = (MCControl *)newimage;
 				cptr->appendto(controls);
@@ -3396,7 +3396,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newscrollbar->load(stream, version)) != IO_NORMAL)
 				{
 					delete newscrollbar;
-					return stat;
+					return checkloadstat(stat);
 				}
 				if (flags & F_VSCROLLBAR && vscrollbar == NULL)
 				{
@@ -3422,7 +3422,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newgraphic->load(stream, version)) != IO_NORMAL)
 				{
 					delete newgraphic;
-					return stat;
+					return checkloadstat(stat);
 				}
 				newgraphic->appendto(controls);
 			}
@@ -3434,7 +3434,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = neweps->load(stream, version)) != IO_NORMAL)
 				{
 					delete neweps;
-					return stat;
+					return checkloadstat(stat);
 				}
 				neweps->appendto(controls);
 			}
@@ -3446,7 +3446,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
             if ((stat = neweps->load(stream, version)) != IO_NORMAL)
             {
                 delete neweps;
-                return stat;
+                return checkloadstat(stat);
             }
             neweps->appendto(controls);
         }
@@ -3458,7 +3458,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newmag->load(stream, version)) != IO_NORMAL)
 				{
 					delete newmag;
-					return stat;
+					return checkloadstat(stat);
 				}
 				newmag->appendto(controls);
 			}
@@ -3470,7 +3470,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newcolors->load(stream, version)) != IO_NORMAL)
 				{
 					delete newcolors;
-					return stat;
+					return checkloadstat(stat);
 				}
 				newcolors->appendto(controls);
 			}
@@ -3482,7 +3482,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 				if ((stat = newplayer->load(stream, version)) != IO_NORMAL)
 				{
 					delete newplayer;
-					return stat;
+					return checkloadstat(stat);
 				}
 				newplayer->appendto(controls);
 			}

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -1757,7 +1757,7 @@ IO_stat MCImage::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
     
 	if (p_remaining >= 1)
 	{
-		t_stat = p_stream . ReadU8(resizequality);
+		t_stat = checkloadstat(p_stream . ReadU8(resizequality));
 		
 		if (t_stat == IO_NORMAL)
 			p_remaining -= 1;
@@ -1766,18 +1766,18 @@ IO_stat MCImage::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 	if (p_remaining > 0)
 	{
 		uint4 t_flags, t_length, t_header_length;
-		t_stat = p_stream . ReadTag(t_flags, t_length, t_header_length);
+		t_stat = checkloadstat(p_stream . ReadTag(t_flags, t_length, t_header_length));
         
 		if (t_stat == IO_NORMAL)
-			t_stat = p_stream . Mark();
+			t_stat = checkloadstat(p_stream . Mark());
 		
 		// MW-2013-09-05: [[ Bug 11127 ]] If we have control colors then read them in
 		//   (first do colors, then pixmapids - if any).
 		if (t_stat == IO_NORMAL && (t_flags & IMAGE_EXTRA_CONTROLCOLORS) != 0)
 		{
 			s_have_control_colors = true;
-			t_stat = p_stream . ReadU16(s_control_color_count);
-			t_stat = p_stream . ReadU16(s_control_color_flags);
+			t_stat = checkloadstat(p_stream . ReadU16(s_control_color_count));
+			t_stat = checkloadstat(p_stream . ReadU16(s_control_color_flags));
 
             if (t_stat == IO_NORMAL)
 			{
@@ -1786,11 +1786,11 @@ IO_stat MCImage::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 			}
 
 			for (uint32_t i = 0; t_stat == IO_NORMAL && i < s_control_color_count; i++)
-				t_stat = p_stream . ReadColor(s_control_colors[i]);
+				t_stat = checkloadstat(p_stream . ReadColor(s_control_colors[i]));
 			for (uint32_t i = 0; t_stat == IO_NORMAL && i < s_control_color_count; i++)
 			{
 				// MW-2013-12-05: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-				t_stat = p_stream . ReadStringRefNew(s_control_color_names[i], p_version >= 7000);
+				t_stat = checkloadstat(p_stream . ReadStringRefNew(s_control_color_names[i], p_version >= 7000));
 				if (t_stat == IO_NORMAL && MCStringIsEmpty(s_control_color_names[i]))
 				{
 					MCValueRelease(s_control_color_names[i]);
@@ -1798,28 +1798,28 @@ IO_stat MCImage::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 				}
 			}
             if (t_stat == IO_NORMAL)
-				t_stat = p_stream . ReadU16(s_control_pixmap_count);
+				t_stat = checkloadstat(p_stream . ReadU16(s_control_pixmap_count));
 			
 			if (t_stat == IO_NORMAL && 
 				!MCMemoryNewArray(s_control_pixmap_count, s_control_pixmapids))
-				t_stat = IO_ERROR;
+				t_stat = checkloadstat(IO_ERROR);
 			for(uint32_t i = 0; t_stat == IO_NORMAL && i < s_control_pixmap_count; i++)
-				t_stat = p_stream . ReadU32(s_control_pixmapids[i] . id);
+				t_stat = checkloadstat(p_stream . ReadU32(s_control_pixmapids[i] . id));
 		}
         
         if (t_stat == IO_NORMAL && (t_flags & IMAGE_EXTRA_CENTERRECT) != 0)
         {
-            t_stat = p_stream . ReadS16(m_center_rect . x);
+            t_stat = checkloadstat(p_stream . ReadS16(m_center_rect . x));
             if (t_stat == IO_NORMAL)
-                t_stat = p_stream . ReadS16(m_center_rect . y);
+                t_stat = checkloadstat(p_stream . ReadS16(m_center_rect . y));
             if (t_stat == IO_NORMAL)
-                t_stat = p_stream . ReadU16(m_center_rect . width);
+                t_stat = checkloadstat(p_stream . ReadU16(m_center_rect . width));
             if (t_stat == IO_NORMAL)
-                t_stat = p_stream . ReadU16(m_center_rect . height);
+                t_stat = checkloadstat(p_stream . ReadU16(m_center_rect . height));
         }
 
 		if (t_stat == IO_NORMAL)
-			t_stat = p_stream . Skip(t_length);
+			t_stat = checkloadstat(p_stream . Skip(t_length));
 
 		if (t_stat == IO_NORMAL)
 			p_remaining -= t_length + t_header_length;

--- a/engine/src/objectpropsets.cpp
+++ b/engine/src/objectpropsets.cpp
@@ -480,12 +480,12 @@ IO_stat MCObject::loadpropsets(IO_handle stream, uint32_t version)
 	{
 		uint1 type;
 		if ((stat = IO_read_uint1(&type, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (type == OT_CUSTOM)
 		{
 			MCNameRef pname;
 			if ((stat = IO_read_nameref_new(pname, stream, true)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			
 			MCObjectPropertySet *v;
 			/* UNCHECKED */ MCObjectPropertySet::createwithname_nocopy(pname, v);
@@ -498,7 +498,7 @@ IO_stat MCObject::loadpropsets(IO_handle stream, uint32_t version)
 				props = p = v;
 
 			if ((stat = p->loadprops_new(stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 		}
 		else
 		{
@@ -563,12 +563,12 @@ IO_stat MCObject::loadpropsets_legacy(IO_handle stream)
 	{
 		uint1 type;
 		if ((stat = IO_read_uint1(&type, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		if (type == OT_CUSTOM)
 		{
 			MCNameRef pname;
 			if ((stat = IO_read_nameref_new(pname, stream, false)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 
 			// If there is already a next pset, then it means its had array values loaded.
 			// Thus we just advance and update the name.
@@ -586,7 +586,7 @@ IO_stat MCObject::loadpropsets_legacy(IO_handle stream)
 			}
 
 			if ((stat = p->loadprops_legacy(stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 		}
 		else
 		{
@@ -644,7 +644,7 @@ IO_stat MCObject::loadarraypropsets_legacy(MCObjectInputStream& p_stream)
 		}
 	}
 
-	return t_stat;
+	return checkloadstat(t_stat);
 }
 
 IO_stat MCObject::saveunnamedpropset_legacy(IO_handle stream)

--- a/engine/src/objptr.cpp
+++ b/engine/src/objptr.cpp
@@ -47,7 +47,7 @@ bool MCObjptr::visit(MCObjectVisitorOptions p_options, uint32_t p_part, MCObject
 
 IO_stat MCObjptr::load(IO_handle stream)
 {
-	return IO_read_uint4(&id, stream);
+	return checkloadstat(IO_read_uint4(&id, stream));
 }
 
 IO_stat MCObjptr::save(IO_handle stream, uint4 p_part)

--- a/engine/src/paragrafattr.cpp
+++ b/engine/src/paragrafattr.cpp
@@ -207,7 +207,7 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 	// Read in the size of the attrs.
 	uint32_t t_size;
 	if (t_stat == IO_NORMAL)
-		t_stat = IO_read_uint2or4(&t_size, stream);
+		t_stat = checkloadstat(IO_read_uint2or4(&t_size, stream));
 	
 	// Fetch the stream position at this point and use it to compute
 	// the end of the record.
@@ -218,7 +218,7 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 	// Read the (first) flags word
 	uint2 t_flags;
 	if (t_stat == IO_NORMAL)
-		t_stat = IO_read_uint2(&t_flags, stream);
+		t_stat = checkloadstat(IO_read_uint2(&t_flags, stream));
 		
 	// Initialize the paragraph attrs to default values.
 	attrs = new MCParagraphAttrs;
@@ -228,7 +228,7 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 	if (t_stat == IO_NORMAL && (attrs -> flags & (PA_HAS_TEXT_ALIGN | PA_HAS_LIST_STYLE | PA_HAS_VGRID | PA_HAS_HGRID | PA_HAS_DONT_WRAP)) != 0)
 	{
 		uint2 t_value;
-		t_stat = IO_read_uint2(&t_value, stream);
+		t_stat = checkloadstat(IO_read_uint2(&t_value, stream));
 		if (t_stat == IO_NORMAL)
 		{
 			attrs -> text_align = (t_value & 0x03);
@@ -240,36 +240,36 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 		}
 	}
 	if (t_stat == IO_NORMAL && (attrs -> flags & (PA_HAS_BORDER_WIDTH)) != 0)
-		t_stat = IO_read_uint1(&attrs -> border_width, stream);
+		t_stat = checkloadstat(IO_read_uint1(&attrs -> border_width, stream));
 	// MW-2012-02-29: [[ Bug ]] Read the first indent field if either has first
 	//   or has list indent.
 	if (t_stat == IO_NORMAL && ((attrs -> flags & PA_HAS_FIRST_INDENT) != 0 || (attrs -> flags & PA_HAS_LIST_INDENT) != 0))
-		t_stat = IO_read_int2(&attrs -> first_indent, stream);
+		t_stat = checkloadstat(IO_read_int2(&attrs -> first_indent, stream));
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_LEFT_INDENT) != 0)
-		t_stat = IO_read_int2(&attrs -> left_indent, stream);
+		t_stat = checkloadstat(IO_read_int2(&attrs -> left_indent, stream));
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_RIGHT_INDENT) != 0)
-		t_stat = IO_read_int2(&attrs -> right_indent, stream);
+		t_stat = checkloadstat(IO_read_int2(&attrs -> right_indent, stream));
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_SPACE_ABOVE) != 0)
-		t_stat = IO_read_int2(&attrs -> space_above, stream);
+		t_stat = checkloadstat(IO_read_int2(&attrs -> space_above, stream));
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_SPACE_BELOW) != 0)
-		t_stat = IO_read_int2(&attrs -> space_below, stream);
+		t_stat = checkloadstat(IO_read_int2(&attrs -> space_below, stream));
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_TABS) != 0)
 	{
-		t_stat = IO_read_uint2(&attrs -> tab_count, stream);
+		t_stat = checkloadstat(IO_read_uint2(&attrs -> tab_count, stream));
 		if (t_stat == IO_NORMAL)
 		{
 			attrs -> tabs = new uint16_t[attrs -> tab_count];
 			for(uint32_t i = 0; i < attrs -> tab_count && t_stat == IO_NORMAL; i++)
-				t_stat = IO_read_uint2(&attrs -> tabs[i], stream);
+				t_stat = checkloadstat(IO_read_uint2(&attrs -> tabs[i], stream));
 		}
 	}
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_BACKGROUND_COLOR) != 0)
-		t_stat = IO_read_uint4(&attrs -> background_color, stream);
+		t_stat = checkloadstat(IO_read_uint4(&attrs -> background_color, stream));
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_BORDER_COLOR) != 0)
-		t_stat = IO_read_uint4(&attrs -> border_color, stream);
+		t_stat = checkloadstat(IO_read_uint4(&attrs -> border_color, stream));
 	// MW-2012-02-22: [[ Bug ]] Load the padding setting from the stream.
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_PADDING) != 0)
-		t_stat = IO_read_uint1(&attrs -> padding, stream);
+		t_stat = checkloadstat(IO_read_uint1(&attrs -> padding, stream));
 
 	// MW-2012-03-19: [[ HiddenText ]] If there is still more to read, we must have
 	//   a second flags word.
@@ -277,7 +277,7 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 	{
 		uint2 t_flags_2;
 		if (t_stat == IO_NORMAL)
-			t_stat = IO_read_uint2(&t_flags_2, stream);
+			t_stat = checkloadstat(IO_read_uint2(&t_flags_2, stream));
 		if (t_stat == IO_NORMAL)
 		{
 				attrs -> flags |= t_flags_2 << 16;
@@ -289,10 +289,10 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 		
 		// MW-2013-11-20: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 		if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_METADATA) != 0)
-            t_stat = IO_read_stringref_new(attrs -> metadata, stream, version >= 7000);
+            t_stat = checkloadstat(IO_read_stringref_new(attrs -> metadata, stream, version >= 7000));
 
 		if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_LIST_INDEX) != 0)
-			t_stat = IO_read_uint2(&attrs -> list_index, stream);
+			t_stat = checkloadstat(IO_read_uint2(&attrs -> list_index, stream));
         
         // SN-2015-05-01: [[ Bug 15175 ]] Load the paragraph's tab alignments
         if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_TAB_ALIGNMENTS) != 0)
@@ -301,12 +301,12 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
             uint16_t t_nalignments;
             t_alignments = NULL;
             
-            t_stat = IO_read_uint2(&t_nalignments, stream);
+            t_stat = checkloadstat(IO_read_uint2(&t_nalignments, stream));
             
             if (t_stat == IO_NORMAL)
             {
                 if (!MCMemoryAllocate(sizeof(intenum_t) * t_nalignments, t_alignments))
-                    t_stat = IO_ERROR;
+                    t_stat = checkloadstat(IO_ERROR);
                 
                 for (uint16_t i = 0; i < t_nalignments && t_stat == IO_NORMAL; ++i)
                 {
@@ -328,9 +328,9 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 	
 	// Finally skip to the end of the record for future modifications.
 	if (t_stat == IO_NORMAL)
-		t_stat = MCS_seek_set(stream, t_attr_end);
+		t_stat = checkloadstat(MCS_seek_set(stream, t_attr_end));
 
-	return t_stat;
+	return checkloadstat(t_stat);
 }
 
 IO_stat MCParagraph::saveattrs(IO_handle stream)

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1795,23 +1795,23 @@ IO_stat MCPlayer::load(IO_handle stream, uint32_t version)
 	IO_stat stat;
     
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_stringref_new(filename, stream, version >= 7000)) != IO_NORMAL)
         
         // MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint4(&starttime, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint4(&endtime, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	int4 trate;
 	if ((stat = IO_read_int4(&trate, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	rate = (real8)trate * 10.0 / MAXINT4;
 	
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 	if ((stat = IO_read_stringref_new(userCallbackStr, stream, version >= 7000)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	return loadpropsets(stream, version);
 }
 

--- a/engine/src/scrolbar.cpp
+++ b/engine/src/scrolbar.cpp
@@ -1344,35 +1344,35 @@ IO_stat MCScrollbar::load(IO_handle stream, uint32_t version)
 	IO_stat stat;
 
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if (flags & F_SAVE_ATTS)
 	{
 		uint2 i2;
 		if ((stat = IO_read_uint2(&i2, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		thumbpos = (real8)i2;
 		if ((stat = IO_read_uint2(&i2, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		thumbsize = (real8)i2;
 		if ((stat = IO_read_uint2(&i2, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		lineinc = (real8)i2;
 		if ((stat = IO_read_uint2(&i2, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		pageinc = (real8)i2;
 		if (flags & F_HAS_VALUES)
 		{
 			// MW-2013-08-27: [[ UnicodifyScrollbar ]] Update to use stringref primitives.
 			// MW-2013-11-20: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 			if ((stat = IO_read_stringref_new(startstring, stream, version >= 7000)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			if (!MCStringToDouble(startstring, startvalue))
 				startvalue = 0.0;
 			
 			// MW-2013-08-27: [[ UnicodifyScrollbar ]] Update to use stringref primitives.
 			// MW-2013-11-20: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 			if ((stat = IO_read_stringref_new(endstring, stream, version >= 7000)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			if (!MCStringToDouble(endstring, endvalue))
 				endvalue = 0.0;
 			
@@ -1382,11 +1382,11 @@ IO_stat MCScrollbar::load(IO_handle stream, uint32_t version)
 			lineinc *= range;
 			pageinc *= range;
 			if ((stat = IO_read_uint2(&nffw, stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			if ((stat = IO_read_uint2(&nftrailing, stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 			if ((stat = IO_read_uint2(&nfforce, stream)) != IO_NORMAL)
-				return stat;
+				return checkloadstat(stat);
 		}
 	}
 	if (version <= 2000)

--- a/engine/src/styledtext.cpp
+++ b/engine/src/styledtext.cpp
@@ -128,7 +128,7 @@ IO_stat MCStyledText::load(IO_handle p_stream, uint32_t p_version)
 	{
 		uint1 type;
 		if ((stat = IO_read_uint1(&type, p_stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		switch (type)
 		{
 		// MW-2012-03-04: [[ StackFile5500 ]] Handle both the paragraph and extended
@@ -144,7 +144,7 @@ IO_stat MCStyledText::load(IO_handle p_stream, uint32_t p_version)
 				if ((stat = newpar->load(p_stream, p_version, type == OT_PARAGRAPH_EXT)) != IO_NORMAL)
 				{
 					delete newpar;
-					return stat;
+					return checkloadstat(stat);
 				}
 
 				newpar->appendto(paragraphs);

--- a/engine/src/vclip.cpp
+++ b/engine/src/vclip.cpp
@@ -279,23 +279,23 @@ IO_stat MCVideoClip::load(IO_handle stream, uint32_t version)
 	IO_stat stat;
 
 	if ((stat = MCObject::load(stream, version)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if ((stat = IO_read_uint4(&size, stream)) != IO_NORMAL)
-		return stat;
+		return checkloadstat(stat);
 	if (size != 0)
 	{
 		frames = new uint1[size];
 		if ((stat = IO_read(frames, size, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 	}
 	if (flags & F_FRAME_RATE)
 		if ((stat = IO_read_uint2(&framerate, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 	if (flags & F_SCALE_FACTOR)
 	{
 		int4 i;
 		if ((stat = IO_read_int4(&i, stream)) != IO_NORMAL)
-			return stat;
+			return checkloadstat(stat);
 		scale = MCU_i4tor8(i);
 	}
 	return loadpropsets(stream, version);

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -672,15 +672,15 @@ IO_stat MCWidget::load(IO_handle p_stream, uint32_t p_version)
 	IO_stat t_stat;
     
 	if ((t_stat = MCObject::load(p_stream, p_version)) != IO_NORMAL)
-		return t_stat;
+		return checkloadstat(t_stat);
     
     MCNewAutoNameRef t_kind;
     if ((t_stat = IO_read_nameref_new(&t_kind, p_stream, true)) != IO_NORMAL)
-        return t_stat;
+        return checkloadstat(t_stat);
     
     MCAutoValueRef t_rep;
     if ((t_stat = IO_read_valueref_new(&t_rep, p_stream)) != IO_NORMAL)
-        return t_stat;
+        return checkloadstat(t_stat);
     
     if (t_stat == IO_NORMAL)
     {
@@ -694,9 +694,9 @@ IO_stat MCWidget::load(IO_handle p_stream, uint32_t p_version)
     }
     
 	if ((t_stat = loadpropsets(p_stream, p_version)) != IO_NORMAL)
-		return t_stat;
+		return checkloadstat(t_stat);
     
-    return t_stat;
+    return checkloadstat(t_stat);
 }
 
 IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext)


### PR DESCRIPTION
A (static inline) method 'checkloadstat()' has been added to MCDLlist to provide
a suitable place to add a breakpoint to help debug stackfile problems.

Each place a 'load()' method returns in the case of an error has been augmented
with this call.
