### PR TITLE
[[ Bug 16120 ]] Hardlink iOS simulator copied files rather than symlink

### DIFF
--- a/docs/notes/bugfix-16120.md
+++ b/docs/notes/bugfix-16120.md
@@ -1,0 +1,1 @@
+# [Global Jam] Can't deploy to iOS 9 Simulator when using referenced images

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -483,12 +483,10 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
             local tSource, tTarget
             put char (it + 2) to -1 of tRedirect into tSource
             put pAppBundle into tTarget
-            if there is a file tSource then
-               put slash & char 1 to (it - 1) of tRedirect after tTarget
-            else if there is a folder (tTarget & slash & char 1 to (it - 1) of tRedirect) then
-               revDeleteFolder tTarget & slash & char 1 to (it - 1) of tRedirect
-            end if
-            get shell("ln -s" && quote & tSource & quote && quote & tTarget & quote)
+            
+            put slash & char 1 to (it - 1) of tRedirect after tTarget
+            
+            symlinkRedirect tSource, tTarget
          end if
       end repeat
    end if
@@ -1667,7 +1665,8 @@ end mapFilePath
 
 private command symlinkRedirect pSource, pTarget
    if there is a file pSource then
-      get shell("ln -s" && quote & pSource & quote && quote & pTarget & quote)
+      // Hardlink, since iOS simulator 9.0 does not seem able to handle symlinks
+      get shell("ln" && quote & pSource & quote && quote & pTarget & quote)
    else if there is a folder pSource then
       local tOldFolder
       put the folder into tOldFolder

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1667,6 +1667,15 @@ private command symlinkRedirect pSource, pTarget
    if there is a file pSource then
       // Hardlink, since iOS simulator 9.0 does not seem able to handle symlinks
       get shell("ln" && quote & pSource & quote && quote & pTarget & quote)
+      
+      if it is not empty then
+         // Hard linking failed, we copy the file instead
+         get shell("cp" && quote & pSource & quote && quote & pTarget & quote)
+         
+         if it is not empty then
+            throw "Cannot copy" && pSource
+         end if
+      end if
    else if there is a folder pSource then
       local tOldFolder
       put the folder into tOldFolder

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1666,15 +1666,11 @@ end mapFilePath
 private command symlinkRedirect pSource, pTarget
    if there is a file pSource then
       // Hardlink, since iOS simulator 9.0 does not seem able to handle symlinks
-      get shell("ln" && quote & pSource & quote && quote & pTarget & quote)
+      get shell(merge("ln '[[pSource]]' '[[pTarget]]' || cp '[[pSource]]' '[[pTarget]]'"))
       
-      if it is not empty then
-         // Hard linking failed, we copy the file instead
-         get shell("cp" && quote & pSource & quote && quote & pTarget & quote)
-         
-         if it is not empty then
-            throw "Cannot copy" && pSource
-         end if
+      if the result is not empty then
+         // Both 'ln' and 'cp' failedn
+         throw "Cannot copy" && pSource
       end if
    else if there is a folder pSource then
       local tOldFolder


### PR DESCRIPTION
iOS Simulator 9.0 make iPhoneProxy hang if symlinks are used in the app bundle.
Using hardlinks instead fixes the issue, and the application can be started after deployment
