### PR TITLE
[[ Widgets ]] Bypass widgets for drag-drop related messages.

### DIFF
--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -589,9 +589,14 @@ Boolean MCCard::mfocus(int2 x, int2 y)
 					mfocused = tptr;
 
                 // The widget event manager handles enter/leave itself
-				if (newfocused && mfocused != NULL
-                    && mfocused -> getref() -> gettype() != CT_GROUP
-                    && mfocused -> getref() -> gettype() != CT_WIDGET)
+				if (newfocused && mfocused != NULL &&
+                    mfocused -> getref() -> gettype() != CT_GROUP &&
+#ifdef WIDGETS_HANDLE_DND
+                    mfocused -> getref() -> gettype() != CT_WIDGET)
+#else
+                    (MCdispatcher -> isdragtarget() ||
+                    mfocused -> getref() -> gettype() != CT_WIDGET))
+#endif
 				{
 					mfocused->getref()->enter();
 					

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -2220,9 +2220,12 @@ void MCDispatch::dodrop(bool p_source)
 	{
 		// We are only the source
 		m_drag_end_sent = true;
+        
+#ifdef WIDGETS_HANDLE_DND
         if (MCdragsource->gettype() == CT_WIDGET)
             MCwidgeteventmanager->event_dnd_end(reinterpret_cast<MCWidget*>(MCdragsource));
         else
+#endif
             MCdragsource -> message(MCM_drag_end);
 
 		// OK-2008-10-21 : [[Bug 7316]] - Cursor in script editor follows mouse after dragging to non-LiveCode target.
@@ -2343,12 +2346,14 @@ void MCDispatch::dodrop(bool p_source)
     t_auto_drop = MCdragdest != NULL;
     if (t_auto_drop)
     {
+#ifdef WIDGETS_HANDLE_DND
         if (MCdragdest->gettype() == CT_WIDGET)
         {
             MCwidgeteventmanager->event_dnd_drop(reinterpret_cast<MCWidget*>(MCdragdest));
             t_auto_drop = false;
         }
         else
+#endif
         {
             t_auto_drop = MCdragdest -> message(MCM_drag_drop) != ES_NORMAL;
         }
@@ -2393,12 +2398,14 @@ void MCDispatch::dodrop(bool p_source)
 	if (MCdragsource != NULL)
 	{
 		m_drag_end_sent = true;
+#ifdef WIDGETS_HANDLE_DND
         if (MCdragsource->gettype() == CT_WIDGET)
         {
             MCwidgeteventmanager->event_dnd_end(reinterpret_cast<MCWidget*>(MCdragsource));
             t_auto_end = false;
         }
         else
+#endif
         {
             t_auto_end = MCdragsource -> message(MCM_drag_end) != ES_NORMAL;
         }

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -274,7 +274,12 @@ Boolean MCWidget::mfocus(int2 p_x, int2 p_y)
 		(getflag(F_DISABLED) && (getstack() -> gettool(this) == T_BROWSE)))
 		return False;
 	
-	if (getstack() -> gettool(this) != T_BROWSE)
+	if (getstack() -> gettool(this) != T_BROWSE ||
+#ifdef WIDGETS_HANDLE_DND
+        false)
+#else
+        MCdispatcher -> isdragtarget())
+#endif
 		return MCControl::mfocus(p_x, p_y);
 	
 	// Update the mouse loc.
@@ -289,7 +294,12 @@ Boolean MCWidget::mfocus(int2 p_x, int2 p_y)
 
 void MCWidget::munfocus(void)
 {
-	if (getstack() -> gettool(this) != T_BROWSE)
+	if (getstack() -> gettool(this) != T_BROWSE ||
+#ifdef WIDGETS_HANDLE_DND
+        false)
+#else
+        MCdispatcher -> isdragtarget())
+#endif
 	{
 		MCControl::munfocus();
 		return;


### PR DESCRIPTION
As widgets cannot currently handle drag-drop, code which passes dnd
events through to MCwidgeteventmanager has been bypassed with a
define WIDGETS_HANDLE_DND.
