### PR TITLE
Add thirdparty lib support to android externals

### DIFF
--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -1074,9 +1074,11 @@ private function addExternalFromFile pExternal, pClassesFolder, pLibsFolder
             throw "android external contains classes but no library for " & tArch
          end if
       end repeat
+      
+      return true
    end if
    
-   return there is a file tLibFile
+   return false
 end addExternalFromFile
 
 ################################################################################

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -2,6 +2,7 @@
 ################################################################################
 
 local sJavaRoot
+conatant kProcessors = "armeabi"
 
 ################################################################################
 
@@ -220,7 +221,9 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget
       
       put tBuildFolder & slash & "classes_app" into tClassesBuildFolder
       put tBuildFolder & slash & "libs" into tLibsBuildFolder
-      put tLibsBuildFolder & slash & "armeabi" into tArmLibsBuildFolder
+      
+      // MERG: TODO when support for other processors is added this needs work
+      put tLibsBuildFolder & slash & kProcessors into tArmLibsBuildFolder
       put tBuildFolder & slash & "res" into tResBuildFolder
       put tResBuildFolder & slash & "drawable" into tDrawableResBuildFolder
       put tResBuildFolder & slash & "layout" into tLayoutResBuildFolder
@@ -273,7 +276,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget
          -- MERG-2013-09-05: [[ Bug 11152 ]] Only list the external if it was successfully
          --   extracted.
          -- Now attempt to process the external
-         if addExternalFromFile(tFilePath, tClassesBuildFolder, tArmLibsBuildFolder) then
+         if addExternalFromFile(tFilePath, tClassesBuildFolder, tLibsBuildFolder) then
             -- Add the external to the list to load
             put char 1 to -7 of tFileName & return after tExternals
          end if
@@ -1015,27 +1018,62 @@ private function addExternalFromFile pExternal, pClassesFolder, pLibsFolder
    end if
    
    -- Get the name of the external.
+   local tExternalName
    set the itemDelimiter to slash
    get the last item of pExternal
    set the itemDelimiter to "."
-   get the first item of it
-   set the itemDelimiter to comma
+   put the first item of it into tExternalName
+   set the itemDelimiter to slash
    
    -- Compute the class / lib names.
-   local tClassesFile, tLibFile
-   put pClassesFolder & slash & "lib" & it & ".jar" into tClassesFile
-   put pLibsFolder & slash & "lib" & it & ".so" into tLibFile
+   local tClassesFile, tLibFileA
+   put pClassesFolder & slash & "lib" & tExternalName & ".jar" into tClassesFile
    
    -- Otherwise open the archive and check for appropriate android components
    revZipOpenArchive pExternal, "read"
    if the result is empty then
-      revZipExtractItemToFile pExternal, "Android/Classes", tClassesFile
-      revZipExtractItemToFile pExternal, "Android/External-armeabi", tLibFile
+      
+      -- MERG-2015-10-14: [[ ThirdpartyLibs ]] Add support for thirdparty librares
+      local tZipItems
+      put revZipEnumerateItems(pExternal) into tZipItems
+      filter tZipItems with "Android/*"
+      
+      local tZipItemsFiltered
+      filter tZipItems with regex pattern ".*(\.jar|Classes)$" into tZipItemsFiltered
+      repeat for each line tZipItem in tZipItemsFiltered
+         if tZipItem ends with ".jar" then
+            revZipExtractItemToFile pExternal, tZipItem, \
+                  pClassesFolder & slash & the last item of tZipItem 
+         else 
+            # will be Classes file
+            revZipExtractItemToFile pExternal, tZipItem, tClassesFile
+         end if
+      end repeat
+      
+      repeat for each word tProcessor in kProcessors
+         filter tZipItems with "*" & tProcessor & "*"
+         put pLibsFolder & slash & tProcessor & slash & "lib" & tExternalName & ".so" into tLibFileA[tProcessor]
+         
+         repeat for each line tZipItem in tZipItemsFiltered
+            if tZipItem ends with ".so" then
+               revZipExtractItemToFile pExternal, tZipItem, \
+                     pLibsFolder & slash & tProcessor & slash & the last item of tZipItem 
+            else 
+               # will be External-<processor> file
+               revZipExtractItemToFile pExternal, tZipItem, tLibFileA[tProcessor]
+            end if
+         end repeat
+      end repeat
+      
       revZipCloseArchive pExternal
    end if
    
-   if there is a file tClassesFile and there is no file tLibFile then
-      throw "android external contains classes but no library"
+   if there is a file tClassesFile then
+      repeat for each word tProcessor in kProcessors
+         if there is no file tLibFileA[tProcessor] then
+            throw "android external contains classes but no library for " & tProcessor
+         end if
+      end repeat
    end if
    
    return there is a file tLibFile

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -2,7 +2,7 @@
 ################################################################################
 
 local sJavaRoot
-conatant kProcessors = "armeabi"
+conatant kArchs = "armeabi"
 
 ################################################################################
 
@@ -222,8 +222,8 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget
       put tBuildFolder & slash & "classes_app" into tClassesBuildFolder
       put tBuildFolder & slash & "libs" into tLibsBuildFolder
       
-      // MERG: TODO when support for other processors is added this needs work
-      put tLibsBuildFolder & slash & kProcessors into tArmLibsBuildFolder
+      // MERG: TODO when support for other Archs is added this needs work
+      put tLibsBuildFolder & slash & kArchs into tArmLibsBuildFolder
       put tBuildFolder & slash & "res" into tResBuildFolder
       put tResBuildFolder & slash & "drawable" into tDrawableResBuildFolder
       put tResBuildFolder & slash & "layout" into tLayoutResBuildFolder
@@ -1050,17 +1050,17 @@ private function addExternalFromFile pExternal, pClassesFolder, pLibsFolder
          end if
       end repeat
       
-      repeat for each word tProcessor in kProcessors
-         filter tZipItems with "*" & tProcessor & "*"
-         put pLibsFolder & slash & tProcessor & slash & "lib" & tExternalName & ".so" into tLibFileA[tProcessor]
+      repeat for each word tArch in kArchs
+         filter tZipItems with "*" & tArch & "*"
+         put pLibsFolder & slash & tArch & slash & "lib" & tExternalName & ".so" into tLibFileA[tArch]
          
          repeat for each line tZipItem in tZipItemsFiltered
             if tZipItem ends with ".so" then
                revZipExtractItemToFile pExternal, tZipItem, \
-                     pLibsFolder & slash & tProcessor & slash & the last item of tZipItem 
+                     pLibsFolder & slash & tArch & slash & the last item of tZipItem 
             else 
-               # will be External-<processor> file
-               revZipExtractItemToFile pExternal, tZipItem, tLibFileA[tProcessor]
+               # will be External-<Arch> file
+               revZipExtractItemToFile pExternal, tZipItem, tLibFileA[tArch]
             end if
          end repeat
       end repeat
@@ -1069,9 +1069,9 @@ private function addExternalFromFile pExternal, pClassesFolder, pLibsFolder
    end if
    
    if there is a file tClassesFile then
-      repeat for each word tProcessor in kProcessors
-         if there is no file tLibFileA[tProcessor] then
-            throw "android external contains classes but no library for " & tProcessor
+      repeat for each word tArch in kArchs
+         if there is no file tLibFileA[tArch] then
+            throw "android external contains classes but no library for " & tArch
          end if
       end repeat
    end if


### PR DESCRIPTION
This PR is just a request for comment at this stage. It's untested but looks like it will work fine to me. The main thing I want comment on is the future proofing I've done to support multiple architectures. See my use of the kArchs constant which is intended to be a list of words. I'm wondering if perhaps this would be a user selection like on iOS and therefore the list would be better passed as a parameter to addExternalFromFile?
