### PR TITLE
Update the LCS tests makefile so it can run on OSX

### DIFF
--- a/tests/lcs/Makefile
+++ b/tests/lcs/Makefile
@@ -29,7 +29,7 @@ guess_flags := $(shell $(guess_flags_script))
 
 bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
 
-ENGINE ?= $(bin_dir)/standalone-community
+ENGINE ?= $(if $(filter mac,$(guess_platform)),$(bin_dir)/Standalone-Community.app/Contents/MacOS/Standalone-Community,$(bin_dir)/standalone-community)
 
 ENGINE_FLAGS ?= $(guess_flags)
 


### PR DESCRIPTION
It currently uses an incorrect path for the OSX standalone engine.
