### PR TITLE
Correct the detection of 32-bit Linux when running LCS tests

### DIFF
--- a/tests/lcs/Makefile
+++ b/tests/lcs/Makefile
@@ -8,7 +8,7 @@ TEST_DIR ?= $(top_srcdir)/_tests/lcb
 guess_linux_arch_script := \
 	case `uname -p` in \
 	    x86_64) echo x86_64 ;; \
-	    x86|i*85) echo x86 ;; \
+	    x86|i*86) echo x86 ;; \
 	esac
 guess_linux_arch := $(shell $(guess_linux_arch_script))
 


### PR DESCRIPTION
Simple typo in the case statement.
