### PR TITLE
libfoundation: Allow MCStringCreateWithCString() to accept NULL.

### DIFF
--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -245,8 +245,6 @@ MCStringRef MCSTR(const char *p_cstring)
 MC_DLLEXPORT_DEF
 bool MCStringCreateWithCString(const char* p_cstring, MCStringRef& r_string)
 {
-	MCAssert(nil != p_cstring);
-
 	return MCStringCreateWithNativeChars((const char_t*)p_cstring, p_cstring == nil ? 0 : strlen(p_cstring), r_string);
 }
 


### PR DESCRIPTION
Technically, `NULL` isn't a valid C string, but consider it equivalent
to the empty string for the purposes of backwards compatibility.
