### PR TITLE
[[ Bug 16232 ]] Do not overwrite existing files when copying at stand…

### DIFF
--- a/docs/notes/bugfix-16232.md
+++ b/docs/notes/bugfix-16232.md
@@ -1,0 +1,1 @@
+# Externals in the Copy Files of a standalone causes the app to crash in the iOS simulator

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1678,6 +1678,11 @@ end mapFilePath
 ################################################################################
 
 private command symlinkRedirect pSource, pTarget
+   if there is a file pTarget then
+      // We don't want to erase files that have possibly be already copied ith the same name
+      // such as externals, fonts or plist files.
+      exit symlinkRedirect
+   end if
    if there is a file pSource then
       // Hardlink, since iOS simulator 9.0 does not seem able to handle symlinks
       get shell(merge("ln '[[pSource]]' '[[pTarget]]' || cp '[[pSource]]' '[[pTarget]]'"))


### PR DESCRIPTION
…alone saving

Files such as externals can be copied before the Copy Files content, in which case they should not be overwritten
