### PR TITLE
[[ Bug 16228 ]] Do not list empty groups in 'the controlIDs'

### DIFF
--- a/docs/notes/bugfix-16228.md
+++ b/docs/notes/bugfix-16228.md
@@ -1,0 +1,1 @@
+# The controlIDs property reports empty lines after the id of an empty group.

--- a/engine/src/exec-interface-card.cpp
+++ b/engine/src/exec-interface-card.cpp
@@ -170,7 +170,10 @@ void MCCard::GetPropList(MCExecContext& ctxt, Properties which, uint32_t part_id
                     static_cast<MCGroup *>(t_object) -> GetControlIds(ctxt, part_id, &t_group_props);
                 else
                     static_cast<MCGroup *>(t_object) -> GetControlNames(ctxt, part_id, &t_group_props);
-                t_success = MCListAppend(*t_prop_list, *t_group_props);
+                
+                // MERG-2013-11-03: [[ ChildControlProps ]] Handle empty groups
+                if (!MCStringIsEmpty(*t_group_props))
+                    t_success = MCListAppend(*t_prop_list , *t_group_props);
             }
 
 		}

--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -733,7 +733,10 @@ void MCGroup::GetPropList(MCExecContext& ctxt, Properties which, uint32_t part_i
                     static_cast<MCGroup *>(t_object) -> GetControlIds(ctxt, part_id, &t_group_props);
                 else
                     static_cast<MCGroup *>(t_object) -> GetControlNames(ctxt, part_id, &t_group_props);
-                t_success = MCListAppend(*t_prop_list, *t_group_props);
+                
+                // MERG-2013-11-03: [[ ChildControlProps ]] Handle empty groups
+                if (!MCStringIsEmpty(*t_group_props))
+                    t_success = MCListAppend(*t_prop_list, *t_group_props);
             }
             
             t_object = t_object -> next();


### PR DESCRIPTION
This was fixed by Monte in the PR https://github.com/livecode/livecode/pull/348/files, but never made it in develop-7.0
