### PR TITLE
[[ Bug 16234 ]] Ensure that iOS Multiline view observer is deregistered

### DIFF
--- a/docs/notes/bugfix-16234.md
+++ b/docs/notes/bugfix-16234.md
@@ -1,0 +1,1 @@
+# MobileControlDelete crashes app in LC 6.7.8 (RC 1) on iOS sim 9.0

--- a/engine/src/mbliphoneinput.mm
+++ b/engine/src/mbliphoneinput.mm
@@ -77,6 +77,7 @@ class MCNativeInputControl;
 
 @interface MCNativeMultiLineDelegate : MCNativeInputDelegate <UIScrollViewDelegate>
 {
+    UIView* m_view;
 	int32_t m_verticaltextalign;
 }
 
@@ -1146,6 +1147,10 @@ private:
 		return nil;
 	
 	m_verticaltextalign = kMCTextVerticalAlignTop;
+    
+    // SN-2015-10-19: [[ Bug 16234 ]] We need to keep track of our view, as we
+    //  will be deallocated after m_instance has cleared up its view.
+    m_view = view;
 
 	[view addObserver:self forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
 	
@@ -1156,7 +1161,7 @@ private:
 //   can be removed that reference this object.
 - (void)dealloc
 {
-	[m_instance -> GetView() removeObserver: self forKeyPath:@"contentSize"];
+    [m_view removeObserver: self forKeyPath:@"contentSize"];
 	[super dealloc];
 }
    


### PR DESCRIPTION
The MCNativeControlInput stored in MCNativeMultilineDelegate is cleared before the delegate is deallocated - the delegate
needs to store the view associated with the native control, in order to remove the observers
