### PR TITLE
[[ Bug 16238 ]] Add DataGrid amongst the S/B script libraries

### DIFF
--- a/docs/notes/bugfix-16238.md
+++ b/docs/notes/bugfix-16238.md
@@ -1,0 +1,1 @@
+# Cannot choose to include DataGrid library in standalone settings

--- a/docs/notes/feature-datagrid_inclusion.md
+++ b/docs/notes/feature-datagrid_inclusion.md
@@ -1,0 +1,8 @@
+# DataGrid added to the Standalone Settings script libraries list
+
+Formerly, the DataGrid library was only included in a standalone application if the stack saved as a standalone was using a DataGrid.
+
+This have been causing issues, in case the stack saved does not use DataGrid, but loads a stack which uses it: the DataGrid library was not saved with the standalone, and the DataGrid would not work in the loaded stack.
+
+To tackle this issue, we have added 'DataGrid' in the list of Script Libraries in the Standalone Settings. You can now force the inclusion of the DataGrid library, to ensure that any stack loaded by the standalone can use DataGrids.
+ 

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -863,7 +863,10 @@ private command revCopyScriptLibraries pStack, pPlatform
    revAddLibrary "Common"
    
    -- data grid
-   if "data grid templates" is in the subStacks of stack pStack and there is a stack "revDataGridLibrary" then
+   // SN-2015-10-19: [[ Bug 16238 ]] DataGrid can be included on the wish of the user - in case the standalone stack
+   //  will load stacks using DataGrid, for instance.
+   if ("data grid templates" is in the subStacks of stack pStack or "DataGrid" is among the lines of sStandaloneSettingsA["scriptLibraries"]) \
+         and there is a stack "revDataGridLibrary" then
       set the mainStack of stack "revDataGridLibrary" to pStack
    end if
    

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -921,7 +921,8 @@ function revSBLibraryList
    local tPath,tSave,tLibrariesA,tBtn,tExternals
    -- rev script libraries
    # AL-2105-03-05: [[ Bug 14813 ]] Use static list of libs rather than generate from loaded libs list
-   repeat for each item tItem in "Animation,Geometry,Internet,Printing,Table,XMLRPC"
+   // SN-2015-10-19: [[ Bug 16238 ]] Add DataGrid library amongst the libraries
+   repeat for each item tItem in "Animation,DataGrid,Geometry,Internet,Printing,Table,XMLRPC"
       put empty into tLibrariesA[tItem]
    end repeat
    


### PR DESCRIPTION
Some users might want to force the inclusion of the DataGrid, for instance if the stack saved as a standalone
does not use a DataGrid, but some of the stack it loads does.
