### PR TITLE
libfoundation: Allow MCStringCreateWithCString() to accept NULL.

### DIFF
--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -240,8 +240,6 @@ MCStringRef MCSTR(const char *p_cstring)
 
 bool MCStringCreateWithCString(const char* p_cstring, MCStringRef& r_string)
 {
-	MCAssert(nil != p_cstring);
-
 	return MCStringCreateWithNativeChars((const char_t*)p_cstring, p_cstring == nil ? 0 : strlen(p_cstring), r_string);
 }
 


### PR DESCRIPTION
Technically, `NULL` isn't a valid C string, but consider it equivalent
to the empty string for the purposes of backwards compatibility.

See also #3070.

(cherry picked from commit 81ae88d0c446756a90c134e018e169c14cc326c8)
