### PR TITLE
[[ Bug 16220 ]] Fix segment boundaries in MCLine::GetCursorIndex

### DIFF
--- a/docs/notes/bugfix-16220.md
+++ b/docs/notes/bugfix-16220.md
@@ -1,0 +1,1 @@
+# ArrowKey left in tabbed field stuck if first column empty

--- a/engine/src/line.cpp
+++ b/engine/src/line.cpp
@@ -408,12 +408,13 @@ findex_t MCLine::GetCursorIndex(coord_t cx, Boolean chunk, bool moving_forward)
             
             // SN-2014-08-14: [[ Bug 13106 ]] We want the outside left edge
             coord_t origin = bptr->getorigin() + sgptr->GetLeft();
+
             // Different cases, according to the alignment:
             //  right-aligned: the origin belongs to the previous block
             //  others:        the origin belongs to the current block
             if ((sgptr -> GetHorizontalAlignment() == kMCSegmentTextHAlignRight
                         && cx > origin && cx <= (origin + bptr->getwidth()))
-                    || (cx >= origin && cx < (origin + bptr->getwidth())))
+                    || (cx >= origin && cx <= (origin + bptr->getwidth())))
             {
                 done = true;
                 break;


### PR DESCRIPTION
Coordinates [origin;origin + width] belong to a left / center-aligned segment.
This was [origin;origin + width[ beforehand (exluding a empty first block spanning over 0;0
