### PR TITLE
[[ Bug 7474 ]] Issue deleting a grouped focused control.

### DIFF
--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2132,6 +2132,7 @@ void MCGroup::clearfocus(MCControl *cptr)
 	if (cptr == kfocused)
 	{
 		kfocused = NULL;
+        state &= ~CS_KFOCUSED;
 		if (parent -> gettype() == CT_CARD)
 			static_cast<MCCard *>(parent) -> erasefocus(this);
 		else


### PR DESCRIPTION
When the focusedObject is within a group, and is deleted the focused
state of the parent group(s) lingers meaning that an attempt to focus
another object in the same group(s) will fail.
