### PR TITLE
[[ Bug 7414 ]] Focusing a listBehavior field doesn't set the active field

### DIFF
--- a/docs/notes/bugfix-7414.md
+++ b/docs/notes/bugfix-7414.md
@@ -1,0 +1,1 @@
+# listBehavior fields don't become the selectedField if focused by any means other than clicking.

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -395,7 +395,12 @@ void MCField::kfocus()
 		uint2 t_old_trans;
 		t_old_trans = gettransient();
 		state |= CS_KFOCUSED;
-
+        
+        if (MCactivefield != NULL && MCactivefield != this)
+            MCactivefield->unselect(True, True);
+        MCactivefield = this;
+        clearfound();
+        
 		if (flags & F_LIST_BEHAVIOR)
 		{
 			if (!(flags & F_TOGGLE_HILITE))
@@ -414,10 +419,6 @@ void MCField::kfocus()
 		}
 		else
 		{
-			if (MCactivefield != NULL && MCactivefield != this)
-				MCactivefield->unselect(True, True);
-			MCactivefield = this;
-			clearfound();
 			// MW-2011-08-18: [[ Layers ]] Invalidate the whole object, noting
 			//   possible change in transient.
 			layer_transientchangedandredrawall(t_old_trans);


### PR DESCRIPTION
It would appear that when listBehavior was added to the field, the code
which sets the 'active field' to the focused field ended up being in the
wrong place.

The result was that focusing a list field by any other means than clicking
on it would result in the focusedObject being the field, but the
selectedField not being the same.
