### PR TITLE
[[ Bug 16257 ]] Windows do not unfocus correctly.

### DIFF
--- a/docs/notes/bugfix-15208.md
+++ b/docs/notes/bugfix-15208.md
@@ -1,1 +1,0 @@
-# LiveCode crashes when using System Character Viewer

--- a/docs/notes/bugfix-16257.md
+++ b/docs/notes/bugfix-16257.md
@@ -1,0 +1,1 @@
+# When switching between windows on Mac, the unfocused window can still appear to be focused.

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -469,9 +469,8 @@ public:
 	void ProcessWillMiniaturize(void);
 	void ProcessDidMiniaturize(void);
 	void ProcessDidDeminiaturize(void);
-    // SN-2015-05-20: [[ Bug 15208 ]] Renamed to better reflect the functions action
-	void ProcessGainedMainFocus(void);
-	void ProcessLostMainFocus(void);
+	void ProcessDidBecomeKey(void);
+	void ProcessDidResignKey(void);
 	
 	void ProcessMouseMove(NSPoint location);
 	void ProcessMousePress(NSInteger button, bool is_down);
@@ -542,7 +541,7 @@ private:
 		bool m_has_sheet : 1;
 		
 		// When the frame is locked, any changes to the window rect will be prevented.
-        bool m_frame_locked : 1;
+		bool m_frame_locked : 1;
 	};
 	
 	// A window might map to one of several different classes, so we use a

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -469,7 +469,7 @@ static bool s_lock_responder_change = false;
 - (void)windowDidResignKey:(NSNotification *)notification
 {
     if (s_inside_focus_event)
-        m_window -> ProcessDidBecomeKey();
+        m_window -> ProcessDidResignKey();
     else
     {
         s_inside_focus_event = true;

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -453,42 +453,29 @@ static bool s_lock_responder_change = false;
 }
 
 // MW-2014-07-22: [[ Bug 12720 ]] Mark the period we are inside a focus event handler.
-// SN-2015-05-20: [[ Bug 15208 ]] Renamed to better reflect the functions action
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
     if (s_inside_focus_event)
-        m_window -> ProcessGainedMainFocus();
+        m_window -> ProcessDidBecomeKey();
     else
     {
         s_inside_focus_event = true;
-        m_window -> ProcessGainedMainFocus();
+        m_window -> ProcessDidBecomeKey();
         s_inside_focus_event = false;
     }
 }
 
 // MW-2014-07-22: [[ Bug 12720 ]] Mark the period we are inside a focus event handler.
-// SN-2015-05-20: [[ Bug 15208 ]] If we are not the KeyWindow, we can still be
-//  the MainWindow, and in that case we keep the focus.
 - (void)windowDidResignKey:(NSNotification *)notification
 {
-}
-
-// SN-2015-05-20: [[ Bug 15208 ]] A main window is not necessarily the key window
-// (see https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html)
-//  We do no want to unfocus the active field if a utility window (such as Color
-//  Picker or Character Viewer) is opened, or that can lead to a crash since we
-//  might want to insert text in this field (it is not properly speaking unfocusing).
-//  That leads to a not-so-nice blinking cursor on the message box when using
-//     answer color
-//  but there might not be any other option to avoid the Character Viewer crash.
-- (void)windowDidBecomeMain:(NSNotification *)notification
-{
-    m_window -> ProcessGainedMainFocus();
-}
-
-- (void)windowDidResignMain:(NSNotification *)notification
-{
-    m_window -> ProcessLostMainFocus();
+    if (s_inside_focus_event)
+        m_window -> ProcessDidBecomeKey();
+    else
+    {
+        s_inside_focus_event = true;
+        m_window -> ProcessDidResignKey();
+        s_inside_focus_event = false;
+    }
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification
@@ -1749,13 +1736,12 @@ void MCMacPlatformWindow::ProcessDidDeminiaturize(void)
 	HandleUniconify();
 }
 
-// SN-2015-05-20: [[ Bug 15208 ]] Renamed to better reflect the functions action
-void MCMacPlatformWindow::ProcessGainedMainFocus(void)
+void MCMacPlatformWindow::ProcessDidBecomeKey(void)
 {
-    HandleFocus();
+	HandleFocus();
 }
 
-void MCMacPlatformWindow::ProcessLostMainFocus(void)
+void MCMacPlatformWindow::ProcessDidResignKey(void)
 {
     HandleUnfocus();
 }


### PR DESCRIPTION
A problem with window focus switching was introduced with a fix to
Bug 15208. This fix essentially stopped windows receiving 'unfocus'
events.

Reversion of that patch uncovered a typo in 'windowDidResignKey'
which would cause ProcessDidBecomeKey to be sent instead of
ProcessDidResignKey in some instances.

It is likely that this error would occasionally cause other focusing
related issues.
