### PR TITLE
[[ Bug 16258 ]] Standalone dependence on QTKit.

### DIFF
--- a/docs/notes/bugfix-16258.md
+++ b/docs/notes/bugfix-16258.md
@@ -1,0 +1,1 @@
+# Remove unneeded load-time dependence on QTKit.

--- a/engine/kernel.gypi
+++ b/engine/kernel.gypi
@@ -119,7 +119,6 @@
 								'$(SDKROOT)/System/Library/Frameworks/ApplicationServices.framework',
 								'$(SDKROOT)/System/Library/Frameworks/Carbon.framework',
 								'$(SDKROOT)/System/Library/Frameworks/Cocoa.framework',
-								'$(SDKROOT)/System/Library/Frameworks/QTKit.framework',
 								'$(SDKROOT)/System/Library/Frameworks/Quartz.framework',
 							],
 						},


### PR DESCRIPTION
The unneeded reference to QTKit.framework in kernel.gypi has been removed.
