### PR TITLE
GTK themed checkboxes drawn incorrectly

### DIFF
--- a/docs/notes/bugfix-11854.md
+++ b/docs/notes/bugfix-11854.md
@@ -1,0 +1,1 @@
+# GTK-themed checkboxes drawn incorrectly

--- a/engine/src/button.h
+++ b/engine/src/button.h
@@ -501,5 +501,8 @@ protected:
     virtual MCPlatformControlType getcontroltype();
     virtual MCPlatformControlPart getcontrolsubpart();
     virtual MCPlatformControlState getcontrolstate();
+    
+    // Returns the size that check-marks should be drawn at
+    int16_t GetCheckSize() const;
 };
 #endif

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -703,6 +703,17 @@ void MCButton::drawcheck(MCDC *dc, MCRectangle &srect, Boolean white)
 	if (!(flags & F_AUTO_ARM) && MCcurtheme &&
 	        MCcurtheme->iswidgetsupported(WTHEME_TYPE_CHECKBOX))
 	{
+        if (IsNativeGTK())
+        {
+            int32_t t_size, t_spacing;
+            t_size = MCcurtheme -> getmetric(WTHEME_METRIC_CHECKBUTTON_INDICATORSIZE);
+            t_spacing = MCcurtheme -> getmetric(WTHEME_METRIC_CHECKBUTTON_INDICATORSPACING);
+            trect . x = srect . x + leftmargin - t_spacing;
+            trect . y = srect . y;
+            trect . width = t_size + 2*t_spacing;
+            trect . height = srect . height;
+        }
+        
 		MCWidgetInfo widgetinfo;
 		widgetinfo.type = WTHEME_TYPE_CHECKBOX;
 		getwidgetthemeinfo(widgetinfo);
@@ -859,9 +870,9 @@ void MCButton::drawradio(MCDC *dc, MCRectangle &srect, Boolean white)
 			int32_t t_size, t_spacing;
 			t_size = MCcurtheme -> getmetric(WTHEME_METRIC_RADIOBUTTON_INDICATORSIZE);
 			t_spacing = MCcurtheme -> getmetric(WTHEME_METRIC_RADIOBUTTON_INDICATORSPACING);
-			trect . x = srect . x + leftmargin - 2 + t_spacing;
+			trect . x = srect . x + leftmargin - t_spacing;
 			trect . y = srect . y;
-			trect . width = t_size;
+			trect . width = t_size + 2*t_spacing;
 			trect . height = srect . height;
 		}
 

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -496,7 +496,7 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 					{
 						if (indicator && !(flags & F_SHOW_ICON))
 						{
-							sx += CHECK_SIZE + leftmargin;
+							sx += GetCheckSize() + leftmargin;
 							if (MClook == LF_WIN95)
 							{
 								sy++;
@@ -2004,4 +2004,13 @@ void MCButton::unlockshape(MCObjectShape& p_shape)
 {
 	if (p_shape . type == kMCObjectShapeMask)
 		icons -> curicon -> unlockbitmap(p_shape . mask . bits);
+}
+
+int16_t MCButton::GetCheckSize() const
+{
+    // If we aren't using GTK at the theming engine, return the fixed size
+    if (!IsNativeGTK())
+        return CHECK_SIZE;
+    
+    return MCcurtheme -> getmetric(WTHEME_METRIC_CHECKBUTTON_INDICATORSIZE);
 }

--- a/engine/src/exec-interface-button.cpp
+++ b/engine/src/exec-interface-button.cpp
@@ -952,8 +952,12 @@ void MCButton::GetFormattedWidth(MCExecContext& ctxt, integer_t& r_width)
 				}
 			}
 			else
+            {
 				if (getstyleint(flags) == F_CHECK || getstyleint(flags) == F_RADIO)
-					fwidth += CHECK_SIZE + leftmargin;
+                {
+                    fwidth += leftmargin + GetCheckSize();
+                }
+            }
 			if (menumode == WM_OPTION)
 				fwidth += optionrect.width + (optionrect.width >> 1);
 			if (menumode == WM_CASCADE)
@@ -982,8 +986,8 @@ void MCButton::GetFormattedHeight(MCExecContext& ctxt, integer_t& r_height)
 					fheight = trect.height;
 			}
 		}
-		else if ((getstyleint(flags) == F_CHECK || getstyleint(flags) == F_RADIO) && CHECK_SIZE > fheight)
-			fheight = CHECK_SIZE;
+		else if ((getstyleint(flags) == F_CHECK || getstyleint(flags) == F_RADIO) && GetCheckSize() > fheight)
+			fheight = GetCheckSize();
 		else if (getstyleint(flags) == F_MENU && menumode == WM_TOP_LEVEL)
 			fheight += 8;
 		r_height = fheight;

--- a/engine/src/lnxgtkthemedrawing.cpp
+++ b/engine/src/lnxgtkthemedrawing.cpp
@@ -596,13 +596,13 @@ moz_gtk_checkbox_get_metrics(gint * indicator_size, gint * indicator_spacing)
 
 	if (indicator_size)
 	{
-		gtk_widget_style_get_ptr(gCheckboxWidget, "indicator_size",
+		gtk_widget_style_get_ptr(gCheckboxWidget, "indicator-size",
 		                       indicator_size, NULL);
 	}
 
 	if (indicator_spacing)
 	{
-		gtk_widget_style_get_ptr(gCheckboxWidget, "indicator_spacing",
+		gtk_widget_style_get_ptr(gCheckboxWidget, "indicator-spacing",
 		                       indicator_spacing, NULL);
 	}
 
@@ -616,13 +616,13 @@ gint moz_gtk_radiobutton_get_metrics(gint * indicator_size,
 
 	if (indicator_size)
 	{
-		gtk_widget_style_get_ptr(gRadiobuttonWidget, "indicator_size",
+		gtk_widget_style_get_ptr(gRadiobuttonWidget, "indicator-size",
 		                       indicator_size, NULL);
 	}
 
 	if (indicator_spacing)
 	{
-		gtk_widget_style_get_ptr(gRadiobuttonWidget, "indicator_spacing",
+		gtk_widget_style_get_ptr(gRadiobuttonWidget, "indicator-spacing",
 		                       indicator_spacing, NULL);
 	}
 
@@ -654,7 +654,7 @@ GtkStateType state_type = ConvertGtkState(state);
      * vertically center in the box, since XUL sometimes ignores our
      * GetMinimumWidgetSize in the vertical dimension
      */
-    x = rect->x;
+    x = rect->x + indicator_spacing;
     y = rect->y + (rect->height - indicator_size) / 2;
     width = indicator_size;
     height = indicator_size;


### PR DESCRIPTION
We were applying the various size and spacing properties of the
GTK widget incorrectly so checkboxes larger than 13x13 were having
their focus rectangles and even parts of the widget itself clipped.
