### PR TITLE
[[ iOS9.1 ]] Update for iOS 9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ WINE ?= wine
 
 # Some magic to control which versions of iOS we try to build.  N.b. you may
 # also need to modify the buildbot configuration
-IPHONEOS_VERSIONS ?= 8.2 8.4 9.0
-IPHONESIMULATOR_VERSIONS ?= 5.1 6.1 7.1 8.2 8.4 9.0
+IPHONEOS_VERSIONS ?= 8.2 8.4 9.1
+IPHONESIMULATOR_VERSIONS ?= 5.1 6.1 7.1 8.2 8.4 9.1
 
 IOS_SDKS ?= \
 	$(addprefix iphoneos,$(IPHONEOS_VERSIONS)) \

--- a/ide-support/revdeploylibraryios.livecodescript
+++ b/ide-support/revdeploylibraryios.livecodescript
@@ -19,7 +19,7 @@ local sDeviceSDKs
 --  SDKs and device relying on the engines we provide in the shipped version
 -- SN-2015-05-01: [[ Xcode 6.4 ]] Add iOS 8.4 amongst the uable iOS SDK
 function deployUsableIosSdk
-   return "5.1,6.1,7.1,8.2,8.4,9.0"
+   return "5.1,6.1,7.1,8.2,8.4,9.1"
 end deployUsableIosSdk
 
 // SN-2015-05-01: [[ Xcode 6.4 ]] Return the pair iOS SDK / Xcode for the current MacOS version
@@ -37,17 +37,17 @@ function deployGetIphoneOSes
       put "8.2,6.2" into tList[2]
       // Xcode 7.0 can be installed from Mac OSX 10.10.4 onwards
       if tMacVersion >= 101004 then
-         put "9.0,7.0" into tList[3]
+         put "9.1,7.1" into tList[3]
       end if
    else
-      put "9.0,7.0" into tList[1]
+      put "9.1,7.1" into tList[1]
    end if
    
    return tList
 end deployGetIphoneOSes
 
 function deployGetIosMinimumVersions
-   return "5.1.1,6.0,6.1,7.0,7.1,8.0,8.1,8.2,8.3,8.4,9.0"
+   return "5.1.1,6.0,6.1,7.0,7.1,8.0,8.1,8.2,8.3,8.4,9.0,9.1"
 end deployGetIosMinimumVersions
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tools/setup_xcode_sdks.sh
+++ b/tools/setup_xcode_sdks.sh
@@ -2,8 +2,8 @@
 
 # Update these lists if you need different SDK versions!
 
-iphoneos_versions="9.0 8.4 8.2"
-iphonesimulator_versions="9.0 8.4 8.2 7.1 6.1 5.1"
+iphoneos_versions="9.1 8.4 8.2"
+iphonesimulator_versions="9.1 8.4 8.2 7.1 6.1 5.1"
 macosx_versions="10.8 10.6"
 
 # This tool creates the symlinks required for Xcode builds of LiveCode.


### PR DESCRIPTION
Update the minimum iOS versions
Update the valid Xcode versions
Update tools/setup_xcode_sdk.sh
Update Makefile to build iOS9.1 instead of 9.0
