### PR TITLE
[[ CppTests ]] Do not process the tests for new() allocation on Mac

### DIFF
--- a/engine/test/test_new.cpp
+++ b/engine/test/test_new.cpp
@@ -64,7 +64,7 @@ struct VeryBig {
 };
 
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || defined(__MAC__)
 TEST(new, DISABLED_new)
 #else
 TEST(new, new)
@@ -91,7 +91,7 @@ TEST(new, new)
 }
 
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) || defined(__MAC__)
 TEST(new, DISABLED_array)
 #else
 TEST(new, array)


### PR DESCRIPTION
new does not return NULL if the memory asked for is too big to be allocated.
But it will crash when this memory block is accessed.
