### PR TITLE
[[ Bugfix 16272 ]] Ignore clicks to menu items that anchor submenus

### DIFF
--- a/docs/notes/bugfix-16272.md
+++ b/docs/notes/bugfix-16272.md
@@ -1,2 +1,18 @@
 # Ignore clicks to menu items that open submenus
 
+Previously, clicks to menu items that open submenus would dismiss
+the menu and send a 'mouseRelease' message. Unfortunately, this
+did not match the conventions of modern user interfaces where
+these clicks are ignored. This can be seen on OSX where the
+system's menus are used instead of being emulated by LiveCode.
+
+Now, clicking on the item that anchors a submenu will send the
+'mouseRelease' message as before but, if that message is not
+handled or is passed, the click will be ignored and the menu
+will remain on-screen.
+
+To restore the old behaviour, handle the 'mouseRelease' message
+without passing. To add the new behaviour to existing code that
+handles the 'mouseRelease' message, add a 'pass' command to the
+end of the handler.
+

--- a/docs/notes/bugfix-16272.md
+++ b/docs/notes/bugfix-16272.md
@@ -1,0 +1,2 @@
+# Ignore clicks to menu items that open submenus
+

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -1370,7 +1370,8 @@ Boolean MCButton::mup(uint2 which, bool p_release)
                 // If the mouse release was handled, close the submenu. This
                 // takes care of backwards compatibility. Otherwise, ignore the
                 // mouse-up event.
-                if (message_with_args(MCM_mouse_release, which) != ES_NOT_HANDLED)
+                Exec_stat es = message_with_args(MCM_mouse_release, which);
+                if (es != ES_NOT_HANDLED && es != ES_PASS)
                     closemenu(True, True);
             }
 		}


### PR DESCRIPTION
This brings the LiveCode behaviour more in line with the behaviour of modern UIs.

The existing behaviour (closing the menu when a submenu anchor is clicked on) is retained in the case that there is an "on mouseRelease" handler for the menu in order to avoid breaking existing code that captures clicks to the anchor.

For full UI compliance, clicks to the submenu anchor should open and close the submenu. However, the current menu code cannot handle this case without a larger rework of the code.

I'm marking this as a WIP as I'm not sure checking for ES_NOT_HANDLED is the right way of going about this; in particular, should ES_PASS also do the same? @runrevmark is sure to have an opinion ;)
