### PR TITLE
[[ Bug 16270 ]] Crash when mouse scrolling a composed widget.

### DIFF
--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -521,6 +521,33 @@ void MCWidgetEventManager::event_dnd_end(MCWidget* p_widget)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void MCWidgetEventManager::widget_appearing(MCWidgetRef p_widget)
+{
+    if (m_mouse_focus != nil &&
+        MCWidgetIsAncestorOf(m_mouse_focus, p_widget))
+        event_mfocus(MCWidgetGetHost(p_widget), (int2)m_mouse_x, (int2)m_mouse_y);
+    
+}
+
+void MCWidgetEventManager::widget_disappearing(MCWidgetRef p_widget)
+{
+    if (m_mouse_focus != nil &&
+        MCWidgetIsAncestorOf(p_widget, m_mouse_focus))
+        event_mfocus(MCWidgetGetHost(p_widget), (int2)m_mouse_x, (int2)m_mouse_y);
+    
+    if (m_mouse_grab != nil &&
+        MCWidgetIsAncestorOf(p_widget, m_mouse_grab))
+        mouseCancel(p_widget, 0);
+}
+
+void MCWidgetEventManager::widget_sync(void)
+{
+    if (!m_check_mouse_focus)
+        return;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 MCWidgetRef MCWidgetEventManager::GetGrabbedWidget(void) const
 {
     return m_mouse_grab;
@@ -645,8 +672,17 @@ void MCWidgetEventManager::mouseLeave(MCWidgetRef p_widget)
 
 bool MCWidgetEventManager::mouseDown(MCWidgetRef p_widget, uinteger_t p_which)
 {
+    // If the button is already down, do nothing.
+    if ((m_mouse_buttons & (1 << p_which)) != 0)
+        return true;
+    
+    // If the mouse buttons is currently 0 then this is a transition from no
+    // click button to a click button.
     if (m_mouse_buttons == 0)
+    {
         MCValueAssign(m_mouse_grab, p_widget);
+        m_click_button = p_which;
+    }
     
     // Mouse button is down
     m_mouse_buttons |= (1 << p_which);
@@ -655,6 +691,10 @@ bool MCWidgetEventManager::mouseDown(MCWidgetRef p_widget, uinteger_t p_which)
     
     if (!widgetIsInRunMode(MCWidgetGetHost(p_widget)))
         return false;
+    
+    // If the button is not the click button, do nothing.
+    if (p_which != m_click_button)
+        return true;
     
     // Do the position change and time since the last click make this a double
     // (or triple or more...) click?
@@ -679,28 +719,39 @@ bool MCWidgetEventManager::mouseDown(MCWidgetRef p_widget, uinteger_t p_which)
     
     bubbleEvent(p_widget, MCWidgetOnMouseDown);
     
-    return True;
+    return true;
 }
 
 bool MCWidgetEventManager::mouseUp(MCWidgetRef p_widget, uinteger_t p_which)
 {
+    // If the given button isn't actually down, do nothing.
+    if ((m_mouse_buttons & (1 << p_which)) == 0)
+        return true;
+    
     // Mouse button is no longer down
     m_mouse_buttons &= ~(1 << p_which);
     
+    // We only do anything about mouseUps if transitioning to no buttons being
+    // pressed.
     if (m_mouse_buttons == 0)
     {
         MCValueRelease(m_mouse_grab);
         m_mouse_grab = nil;
+        
+        MCWidgetGetHost(p_widget) -> setstate(False, CS_MFOCUSED);
+        
+        if (!widgetIsInRunMode(MCWidgetGetHost(p_widget)))
+            return false;
+    
+        // When we get the final mouseUp, the actual button press is tied to
+        // the click button.
+        mouseClick(p_widget, m_click_button);
+        
+        // Reset the click button.
+        m_click_button = 0;
     }
     
-    MCWidgetGetHost(p_widget) -> setstate(False, CS_MFOCUSED);
-    
-    if (!widgetIsInRunMode(MCWidgetGetHost(p_widget)))
-        return false;
-    
-    mouseClick(p_widget, p_which);
-    
-    return True;
+    return true;
 }
 
 void MCWidgetEventManager::mouseClick(MCWidgetRef p_widget, uinteger_t p_which)
@@ -713,22 +764,23 @@ void MCWidgetEventManager::mouseClick(MCWidgetRef p_widget, uinteger_t p_which)
 
 bool MCWidgetEventManager::mouseCancel(MCWidgetRef p_widget, uinteger_t p_which)
 {
-    // Mouse button is no longer down
-    m_mouse_buttons &= ~(1 << p_which);
+    // When we get a mouseCancel we completely cancel the current click which
+    // means resetting mouse buttons and click button to 0.
     
-    if (m_mouse_buttons == 0)
-    {
-        MCValueRelease(m_mouse_grab);
-        m_mouse_grab = nil;
-    }
-	
+    m_click_button = 0;
+    
+    m_mouse_buttons = 0;
+    
+    MCValueRelease(m_mouse_grab);
+    m_mouse_grab = nil;
+    
     if (!widgetIsInRunMode(MCWidgetGetHost(p_widget)))
         return false;
     
     // Send a mouse release event if the widget handles it
     bubbleEvent(p_widget, MCWidgetOnMouseCancel);
     
-    return True;
+    return true;
 }
 
 struct bubble_mouse_scroll_state

--- a/engine/src/widget-events.h
+++ b/engine/src/widget-events.h
@@ -74,6 +74,14 @@ public:
     void event_dnd_end(MCWidget*);
     void event_dnd_drop(MCWidget*);
     
+    // (Child) Widget appear / disappear notifications (used to ensure the widget
+    // event manager syncs events and internal state appropriately).
+    void widget_appearing(MCWidgetRef widget);
+    void widget_disappearing(MCWidgetRef widget);
+    
+    // Tell the event manager to sync widget state.
+    void widget_sync(void);
+    
     MCWidgetRef GetGrabbedWidget(void) const;
     MCWidgetRef GetTargetWidget(void) const;
     MCWidgetRef SetTargetWidget(MCWidgetRef target);
@@ -113,6 +121,10 @@ private:
     // Parameters for controlling double-click time and position deltas
     uint32_t    m_doubleclick_time;
     coord_t     m_doubleclick_distance;
+    
+    // When set to true, widget-bound state (mouse focus etc.) will be recomputed
+    // after the current event has finished.
+    bool        m_check_mouse_focus : 1;
     
     // State for touch events
     struct MCWidgetTouchEvent;

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -973,10 +973,7 @@ void MCWidgetChild::SetOwner(MCWidgetRef p_owner)
     if (p_owner == m_owner)
         return;
     
-    MCValueRelease(m_owner);
     m_owner = p_owner;
-    if (m_owner != nil)
-        MCValueRetain(m_owner);
 }
 
 bool MCWidgetChild::SetFrame(MCGRectangle p_frame)

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -45,6 +45,9 @@ bool MCWidgetIsRoot(MCWidgetRef widget);
 MCWidget *MCWidgetGetHost(MCWidgetRef widget);
 MCWidgetRef MCWidgetGetOwner(MCWidgetRef widget);
 
+// Returns true if p_widget is p_child, or an ancestor of it.
+bool MCWidgetIsAncestorOf(MCWidgetRef p_widget, MCWidgetRef p_child);
+
 MCGRectangle MCWidgetGetFrame(MCWidgetRef widget);
 bool MCWidgetGetDisabled(MCWidgetRef widget);
 bool MCWidgetCopyFont(MCWidgetRef widget, MCFontRef& r_font);


### PR DESCRIPTION
When mouse scrolling over a composed widget which recreates its children,
it was possible for MCwidgeteventmanager to still hold references to an
unplaced child in mouse focus, or mouse grab.

This patch cleans up synchronization of state after unplace / place,
ensuring that the event manager holds the correct focused, or grabbed
control after placement or unplacement. At the moment this is done
immediately, however it might be better that it work via a deferral
mechanism at some point to improve efficiency.

Additionally, it also ensures that OnOpen and OnClose are called when
widgets are placed or unplaced into open widgets.

It now also fixes a reference counting cycle with widgets and their children.
