### PR TITLE
[[ BrowserWidget ]] Simplify browser property names

### DIFF
--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -124,15 +124,16 @@ public constant kMCBrowserValueTypeDictionary is 6
 
 --
 
-public constant kMCBrowserPropertyScrollbars is 0
-public constant kMCBrowserPropertyAllowNewWindows is 1
-public constant kMCBrowserPropertyEnableContextMenu is 2
-public constant kMCBrowserPropertyUrl is 3
-public constant kMCBrowserPropertyHtmlText is 4
-public constant kMCBrowserPropertyUserAgent is 5
-public constant kMCBrowserPropertyJavaScriptHandlers is 6
+public constant kMCBrowserPropertyVerticalScrollbarEnabled is 0
+public constant kMCBrowserPropertyHorizontalScrollbarEnabled is 1
+public constant kMCBrowserPropertyAllowNewWindows is 2
+public constant kMCBrowserPropertyEnableContextMenu is 3
+public constant kMCBrowserPropertyUrl is 4
+public constant kMCBrowserPropertyHtmlText is 5
+public constant kMCBrowserPropertyUserAgent is 6
+public constant kMCBrowserPropertyJavaScriptHandlers is 7
 
-public constant kMCBrowserPropertyMap is ["scrollbars", "allowNewWindows", "enableContextMenu", "url", "htmlText", "userAgent", "javaScriptHandlers"]
+public constant kMCBrowserPropertyMap is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu", "url", "htmlText", "userAgent", "javaScriptHandlers"]
 
 --
 
@@ -153,11 +154,11 @@ public constant kMCBrowserRequestStateMap is ["begin", "complete", "failed"]
 
 -- constant kStringProps is ["url", "htmlText", "userAgent", "javaScriptHandlers"]
 -- TODO - replace literal values with constants when possible
-constant kStringProps is [3, 4, 5, 6]
+constant kStringProps is [4, 5, 6, 7]
 
--- constant kBoolProps is ["scrollbars", "allowNewWindows", "enableContextMenu"]
+-- constant kBoolProps is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu"]
 -- TODO - replace literal values with constants when possible
-constant kBoolProps is [0, 1, 2]
+constant kBoolProps is [0, 1, 2, 3]
 
 --------------------------------------------------------------------------------
 

--- a/engine/src/java/com/runrev/android/libraries/LibBrowser.java
+++ b/engine/src/java/com/runrev/android/libraries/LibBrowser.java
@@ -150,8 +150,6 @@ class LibBrowserWebView extends WebView
 {
 	public static final String TAG = "revandroid.LibBrowserWebView";
 	
-	private boolean m_scrolling_enabled;
-
 	private VideoView m_custom_video_view;
 	private FrameLayout m_custom_view_container;
 	private WebChromeClient.CustomViewCallback m_custom_view_callback;
@@ -164,8 +162,6 @@ class LibBrowserWebView extends WebView
 	{
 		super(p_context);
 		
-		m_scrolling_enabled = true;
-
 		setWebViewClient(new WebViewClient() {
 			public boolean shouldOverrideUrlLoading(WebView p_view, String p_url)
 			{
@@ -427,30 +423,24 @@ class LibBrowserWebView extends WebView
 	//	return toAPKPath(super.getUrl());
 	//}
 
-	public boolean getScrollingEnabled()
+	public boolean getVerticalScrollbarEnabled()
 	{
-		return m_scrolling_enabled;
+		return isVerticalScrollBarEnabled();
 	}
 	
-	public void setScrollingEnabled(boolean p_enabled)
+	public void setVerticalScrollbarEnabled(boolean p_enabled)
 	{
-		if (m_scrolling_enabled == p_enabled)
-			return;
-		m_scrolling_enabled = p_enabled;
-		setHorizontalScrollBarEnabled(p_enabled);
 		setVerticalScrollBarEnabled(p_enabled);
-		getSettings().setBuiltInZoomControls(p_enabled);
-		if (!m_scrolling_enabled)
-		{
-			setOnTouchListener(new View.OnTouchListener() {
-				@Override
-				public boolean onTouch(View v, MotionEvent event) {
-					return (event.getAction() == MotionEvent.ACTION_MOVE);
-				}
-			});
-		}
-		else
-			setOnTouchListener(null);
+	}
+	
+	public boolean getHorizontalScrollbarEnabled()
+	{
+		return isHorizontalScrollBarEnabled();
+	}
+	
+	public void setHorizontalScrollbarEnabled(boolean p_enabled)
+	{
+		setHorizontalScrollBarEnabled(p_enabled);
 	}
 	
 	public String getUserAgent()

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1616,9 +1616,12 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 		default:
 			if (lookup(SP_FACTOR, te) == PS_NORMAL)
 			{
+				extern bool lookup_property_override(const LT&p_lt, Properties &r_property);
+				Properties t_property;
+				
 				Token_type t_type;
 				t_type = te->type;
-				if (doingthe && t_type == TT_CHUNK && te->which == CT_URL)
+				if (doingthe && lookup_property_override(*te, t_property))
 				{
 					t_type = TT_PROPERTY;
 				}

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1616,7 +1616,13 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 		default:
 			if (lookup(SP_FACTOR, te) == PS_NORMAL)
 			{
-				switch (te->type)
+				Token_type t_type;
+				t_type = te->type;
+				if (doingthe && t_type == TT_CHUNK && te->which == CT_URL)
+				{
+					t_type = TT_PROPERTY;
+				}
+				switch (t_type)
 				{
 				case TT_THE:
 					doingthe = True;

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -378,7 +378,11 @@ static void lookup_name_for_prop(Properties p_which, MCNameRef& r_name)
             /* UNCHECKED */ MCNameCreateWithCString(factor_table[i] . token, r_name);
             return;
         }
-    
+	
+	extern bool lookup_property_override_name(uint16_t p_property, MCNameRef &r_name);
+	if (lookup_property_override_name(p_which, r_name))
+		return;
+
     assert(false);
 }
 

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -63,20 +63,36 @@ Description:
 The <browserHtmltext> is the HTML representation of the content displayed in the browser.
 
 
-Name: browserScrollbars
+Name: vscrollbar
 Type: property
 
 Syntax:
-set the browserScrollbars of <widget> to <pEnabled>
-get the browserScrollbars of <widget>
+set the vscrollbar of <widget> to <pEnabled>
+get the vscrollbar of <widget>
 
-Summary: Controls whether scrollbars are visible and enabled within the browser.
+Summary: Controls whether the vertical scrollbar is visible and enabled within the browser.
 
 Parameters:
 pEnabled(boolean): True or false.
 
 Description:
-Controls whether scrollbars are visible and enabled within the browser.
+Controls whether the vertical scrollbar is visible and enabled within the browser.
+
+
+Name: hscrollbar
+Type: property
+
+Syntax:
+set the hscrollbar of <widget> to <pEnabled>
+get the hscrollbar of <widget>
+
+Summary: Controls whether the horizontal scrollbar is visible and enabled within the browser.
+
+Parameters:
+pEnabled(boolean): True or false.
+
+Description:
+Controls whether the horizontal scrollbar is visible and enabled within the browser.
 
 
 Name: browserUseragent
@@ -277,8 +293,11 @@ metadata browserUrl.editor is "com.livecode.pi.text"
 
 property browserHtmltext get getHtmlText set setHtmlText
 
-property browserScrollbars get getScrollbars set setScrollbars
-metadata browserScrollbars.editor is "com.livecode.pi.boolean"
+property vscrollbar get getVScrollbar set setVScrollbar
+metadata vscrollbar.editor is "com.livecode.pi.boolean"
+
+property hscrollbar get getHScrollbar set setHScrollbar
+metadata hscrollbar.editor is "com.livecode.pi.boolean"
 
 property browserUseragent get getUserAgent set setUserAgent
 metadata browserUseragent.editor is "com.livecode.pi.text"
@@ -304,7 +323,7 @@ variable mScriptObject as ScriptObject
 
 --------------------------------------------------------------------------------
 
-constant kPersistentProps is ["scrollbars", "allowNewWindows", "enableContextMenu", "userAgent", "javaScriptHandlers"]
+constant kPersistentProps is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu", "userAgent", "javaScriptHandlers"]
 
 --------------------------------------------------------------------------------
 
@@ -501,12 +520,22 @@ end handler
 
 --
 
-private handler getScrollbars() returns Boolean
-	return getProperty("scrollbars")
+private handler getVScrollbar() returns Boolean
+	return getProperty("verticalScrollbarEnabled")
 end handler
 
-private handler setScrollbars(in pScrollbars as Boolean)
-	setProperty("scrollbars", pScrollbars)
+private handler setVScrollbar(in pVScrollbar as Boolean)
+	setProperty("verticalScrollbarEnabled", pVScrollbar)
+end handler
+
+--
+
+private handler getHScrollbar() returns Boolean
+	return getProperty("horizontalScrollbarEnabled")
+end handler
+
+private handler setHScrollbar(in pHScrollbar as Boolean)
+	setProperty("horizontalScrollbarEnabled", pHScrollbar)
 end handler
 
 ----------

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -18,12 +18,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 /*
 This widget displays web content within a native web browser view.
 
-Name: browserUrl
+Name: url
 Type: property
 
 Syntax:
-set the browserUrl of <widget> to <pUrl>
-get the browserUrl of <widget>
+set the url of <widget> to <pUrl>
+get the url of <widget>
 
 Summary: The url displayed by the browser.
 
@@ -31,22 +31,22 @@ Parameters:
 pUrl(string): A string specifying a URL.
 
 Example:
-	// Navigate to livecode.com by setting the browserUrl property, keeping a copy of the
+	// Navigate to livecode.com by setting the url property, keeping a copy of the
 	//    previous URL
 	local tOldUrl
-	put the browserUrl of widget "myBrowser" into tOldUrl
-	set the browserUrl of widget "myBrowser" to "http://livecode.com"
+	put the url of widget "myBrowser" into tOldUrl
+	set the url of widget "myBrowser" to "http://livecode.com"
 
 Description:
-The <browserUrl> is the URL of the content be displayed in the browser.
+The <url> is the URL of the content be displayed in the browser.
 
 
-Name: browserHtmltext
+Name: htmltext
 Type: property
 
 Syntax:
-set the browserHtmltext of <widget> to <pHtmlText>
-get the browserHtmltext of <widget>
+set the htmltext of <widget> to <pHtmlText>
+get the htmltext of <widget>
 
 Summary: The HTML text of the content displayed by the browser.
 
@@ -57,10 +57,10 @@ Example:
 	// Render a web page in the browser by specifying custom HTML content
 	local tHTML
 	put "<html><head><title>My Page Title</title></head><body>My Page Contents</body></html>" into tHTML
-	set the browserHtmltext of widget "myBrowser" to tHTML
+	set the htmltext of widget "myBrowser" to tHTML
 
 Description:
-The <browserHtmltext> is the HTML representation of the content displayed in the browser.
+The <htmltext> is the HTML representation of the content displayed in the browser.
 
 
 Name: vscrollbar
@@ -95,12 +95,12 @@ Description:
 Controls whether the horizontal scrollbar is visible and enabled within the browser.
 
 
-Name: browserUseragent
+Name: useragent
 Type: property
 
 Syntax:
-set the browserUseragent of <widget> to <pUserAgent>
-get the browserUseragent of <widget>
+set the useragent of <widget> to <pUserAgent>
+get the useragent of <widget>
 
 Summary: The identifier sent by the browser when fetching content from remote URLs.
 
@@ -109,19 +109,19 @@ pUserAgent(string): A string conforming to the http specifications at http://www
 
 Example:
 	// Set custom User-Agent header. The remote web server may be configured to deliver custom content for browsers using this User-Agent.
-	set the browserUseragent of widget "myBrowser" to "myAppEmbeddedBrowser"
+	set the useragent of widget "myBrowser" to "myAppEmbeddedBrowser"
 	launch url "http://myexampleserver.com/content.html" in widget "myBrowser"
 
 Description:
-The <browserUseragent> is the identifier sent by the browser when fetching content from remote URLs.
+The <useragent> is the identifier sent by the browser when fetching content from remote URLs.
 
 
-Name: browserJavascripthandlers
+Name: javascripthandlers
 Type: property
 
 Syntax:
-set the browserJavascripthandlers of <widget> to <pHanderList>
-get the browserJavascripthandlers of <widget>
+set the javascripthandlers of <widget> to <pHanderList>
+get the javascripthandlers of <widget>
 
 Summary: A list of LiveCode handlers that are made available to JavaScript calls within the browser.
 
@@ -138,7 +138,7 @@ Example:
 	...
 	
 	// Set up the browser javascript handler list
-	set the browserJavascripthandlers to "myJSHandler" & return & "myOtherJSHandler"
+	set the javascripthandlers to "myJSHandler" & return & "myOtherJSHandler"
 
 	...
 	
@@ -146,7 +146,7 @@ Example:
 	liveCode.myJSHandler("myMessage", 12345);
 	
 Description:
-The <browserJavascripthandlers> is a list of LiveCode handlers that are made available to JavaScript calls within the browser. The handlers will appear as methods attached to a global "liveCode" object. You can call these methods as you would any other JavaScript function and pass whatever parameters you require.
+The <javascripthandlers> is a list of LiveCode handlers that are made available to JavaScript calls within the browser. The handlers will appear as methods attached to a global "liveCode" object. You can call these methods as you would any other JavaScript function and pass whatever parameters you require.
 
 
 
@@ -288,10 +288,10 @@ metadata version is "1.0.0"
 --
 
 -- property declarations
-property browserUrl get getUrl set setUrl
-metadata browserUrl.editor is "com.livecode.pi.text"
+property url get getUrl set setUrl
+metadata url.editor is "com.livecode.pi.text"
 
-property browserHtmltext get getHtmlText set setHtmlText
+property htmltext get getHtmlText set setHtmlText
 
 property vscrollbar get getVScrollbar set setVScrollbar
 metadata vscrollbar.editor is "com.livecode.pi.boolean"
@@ -299,11 +299,11 @@ metadata vscrollbar.editor is "com.livecode.pi.boolean"
 property hscrollbar get getHScrollbar set setHScrollbar
 metadata hscrollbar.editor is "com.livecode.pi.boolean"
 
-property browserUseragent get getUserAgent set setUserAgent
-metadata browserUseragent.editor is "com.livecode.pi.text"
+property useragent get getUserAgent set setUserAgent
+metadata useragent.editor is "com.livecode.pi.text"
 
-property browserJavascripthandlers get getJavaScriptHandlers set setJavaScriptHandlers
-metadata browserJavascripthandlers.editor is "com.livecode.pi.text"
+property javascripthandlers get getJavaScriptHandlers set setJavaScriptHandlers
+metadata javascripthandlers.editor is "com.livecode.pi.text"
 
 --------------------------------------------------------------------------------
 

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -148,6 +148,7 @@ Example:
 Description:
 The <javascripthandlers> is a list of LiveCode handlers that are made available to JavaScript calls within the browser. The handlers will appear as methods attached to a global "liveCode" object. You can call these methods as you would any other JavaScript function and pass whatever parameters you require.
 
+>*Warning:* Setting the javascriptHandlers property gives JavaScript running within the Web browser permission to execute parts of your application through the handlers you choose to expose. If using this feature, make sure that you have complete control over the webpages which you load into the browser widget, and consider using https to ensure that third-parties cannot inject malicious code into them.
 
 
 Name: browserDocumentLoadBegin

--- a/libbrowser/include/libbrowser.h
+++ b/libbrowser/include/libbrowser.h
@@ -62,7 +62,8 @@ enum MCBrowserProperty
 {
 //	kMCBrowserRect,
 	// Boolean properties
-	kMCBrowserScrollbars,
+	kMCBrowserVerticalScrollbarEnabled,
+	kMCBrowserHorizontalScrollbarEnabled,
 	kMCBrowserAllowNewWindows,
 	kMCBrowserEnableContextMenu,
 	

--- a/libbrowser/src/libbrowser_android.cpp
+++ b/libbrowser/src/libbrowser_android.cpp
@@ -606,8 +606,11 @@ public:
 	{
 		switch (p_property)
 		{
-			case kMCBrowserScrollbars:
-				return GetScrollbarsEnabled(r_value);
+			case kMCBrowserVerticalScrollbarEnabled:
+				return GetVerticalScrollbarEnabled(r_value);
+				
+			case kMCBrowserHorizontalScrollbarEnabled:
+				return GetHorizontalScrollbarEnabled(r_value);
 			
 			default:
 				break;
@@ -620,9 +623,12 @@ public:
 	{
 		switch (p_property)
 		{
-			case kMCBrowserScrollbars:
-				return SetScrollbarsEnabled(p_value);
+			case kMCBrowserVerticalScrollbarEnabled:
+				return SetVerticalScrollbarEnabled(p_value);
 			
+			case kMCBrowserHorizontalScrollbarEnabled:
+				return SetHorizontalScrollbarEnabled(p_value);
+				
 			default:
 				break;
 		}
@@ -729,15 +735,27 @@ public:
 	//////////
 	
 private:
-	bool GetScrollbarsEnabled(bool &r_value)
+	bool GetVerticalScrollbarEnabled(bool &r_value)
 	{
-		MCAndroidObjectRemoteCall(m_view, "getScrollingEnabled", "b", &r_value);
+		MCAndroidObjectRemoteCall(m_view, "getVerticalScrollbarEnabled", "b", &r_value);
 		return true;
 	}
 	
-	bool SetScrollbarsEnabled(bool p_value)
+	bool SetVerticalScrollbarEnabled(bool p_value)
 	{
-		MCAndroidObjectRemoteCall(m_view, "setScrollingEnabled", "vb", nil, p_value);
+		MCAndroidObjectRemoteCall(m_view, "setVerticalScrollbarEnabled", "vb", nil, p_value);
+		return true;
+	}
+	
+	bool GetHorizontalScrollbarEnabled(bool &r_value)
+	{
+		MCAndroidObjectRemoteCall(m_view, "getHorizontalScrollbarEnabled", "b", &r_value);
+		return true;
+	}
+	
+	bool SetHorizontalScrollbarEnabled(bool p_value)
+	{
+		MCAndroidObjectRemoteCall(m_view, "setHorizontalScrollbarEnabled", "vb", nil, p_value);
 		return true;
 	}
 	

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -1284,8 +1284,15 @@ void MCCefBrowserBase::SetSource(const char *p_source)
 	m_browser->GetMainFrame()->LoadString(t_source, t_url);
 }
 
+#define MCCEF_VERTICAL_OVERFLOW_PROPERTY "document.body.style.overflowY"
+#define MCCEF_HORIZONTAL_OVERFLOW_PROPERTY "document.body.style.overflowX"
+inline const char *scrollbar_property(MCCefScrollbarDirection p_direction)
+{
+	return p_direction == kMCCefScrollbarVertical ? MCCEF_VERTICAL_OVERFLOW_PROPERTY : MCCEF_HORIZONTAL_OVERFLOW_PROPERTY;
+}
+
 // IM-2014-08-25: [[ Bug 13272 ]] Implement CEF browser scrollbar property.
-bool MCCefBrowserBase::GetOverflowHidden()
+bool MCCefBrowserBase::GetOverflowHidden(MCCefScrollbarDirection p_direction)
 {
 	// property available through JavaScript
 	bool t_success;
@@ -1293,7 +1300,7 @@ bool MCCefBrowserBase::GetOverflowHidden()
 	
 	CefString t_value;
 	
-	t_success = EvalJavaScript("document.body.style.overflow", t_value);
+	t_success = EvalJavaScript(scrollbar_property(p_direction), t_value);
 	
 	// assume scrollbars are visible if property fetch fails
 	if (!t_success)
@@ -1303,7 +1310,7 @@ bool MCCefBrowserBase::GetOverflowHidden()
 }
 
 // IM-2014-08-25: [[ Bug 13272 ]] Implement CEF browser scrollbar property.
-void MCCefBrowserBase::SetOverflowHidden(bool p_hidden)
+void MCCefBrowserBase::SetOverflowHidden(MCCefScrollbarDirection p_direction, bool p_hidden)
 {
 	// property available through JavaScript
 	
@@ -1313,7 +1320,7 @@ void MCCefBrowserBase::SetOverflowHidden(bool p_hidden)
 	char *t_overflow_script;
 	t_overflow_script = nil;
 	
-	t_success = MCCStringFormat(t_overflow_script, "document.body.style.overflow = \"%s\"", p_hidden ? "hidden" : "");
+	t_success = MCCStringFormat(t_overflow_script, "%s = \"%s\"", scrollbar_property(p_direction), p_hidden ? "hidden" : "");
 	
 	CefString t_return_value;
 	
@@ -1323,16 +1330,28 @@ void MCCefBrowserBase::SetOverflowHidden(bool p_hidden)
 	MCCStringFree(t_overflow_script);
 }
 
-bool MCCefBrowserBase::GetScrollbars(void)
+bool MCCefBrowserBase::GetVerticalScrollbarEnabled(void)
 {
 	// IM-2014-08-25: [[ Bug 13272 ]] Show / hide scrollbars by setting the overflow style to empty / "hidden".
-	return !GetOverflowHidden();
+	return !GetOverflowHidden(kMCCefScrollbarVertical);
 }
 
-void MCCefBrowserBase::SetScrollbars(bool p_scrollbars)
+void MCCefBrowserBase::SetVerticalScrollbarEnabled(bool p_scrollbars)
 {
 	// IM-2014-08-25: [[ Bug 13272 ]] Show / hide scrollbars by setting the overflow style to empty / "hidden".
-	/* UNCHECKED */ SetOverflowHidden(!p_scrollbars);
+	/* UNCHECKED */ SetOverflowHidden(kMCCefScrollbarVertical, !p_scrollbars);
+}
+
+bool MCCefBrowserBase::GetHorizontalScrollbarEnabled(void)
+{
+	// IM-2014-08-25: [[ Bug 13272 ]] Show / hide scrollbars by setting the overflow style to empty / "hidden".
+	return !GetOverflowHidden(kMCCefScrollbarHorizontal);
+}
+
+void MCCefBrowserBase::SetHorizontalScrollbarEnabled(bool p_scrollbars)
+{
+	// IM-2014-08-25: [[ Bug 13272 ]] Show / hide scrollbars by setting the overflow style to empty / "hidden".
+	/* UNCHECKED */ SetOverflowHidden(kMCCefScrollbarHorizontal, !p_scrollbars);
 }
 
 bool MCCefBrowserBase::GetRect(MCBrowserRect &r_rect)
@@ -1551,8 +1570,12 @@ bool MCCefBrowserBase::GetBoolProperty(MCBrowserProperty p_property, bool &r_val
 			r_value = GetEnableContextMenu();
 			return true;
 			
-		case kMCBrowserScrollbars:
-			r_value = GetScrollbars();
+		case kMCBrowserVerticalScrollbarEnabled:
+			r_value = GetVerticalScrollbarEnabled();
+			return true;
+			
+		case kMCBrowserHorizontalScrollbarEnabled:
+			r_value = GetHorizontalScrollbarEnabled();
 			return true;
 			
 		default:
@@ -1574,8 +1597,12 @@ bool MCCefBrowserBase::SetBoolProperty(MCBrowserProperty p_property, bool p_valu
 			SetEnableContextMenu(p_value);
 			return true;
 			
-		case kMCBrowserScrollbars:
-			SetScrollbars(p_value);
+		case kMCBrowserVerticalScrollbarEnabled:
+			SetVerticalScrollbarEnabled(p_value);
+			return true;
+			
+		case kMCBrowserHorizontalScrollbarEnabled:
+			SetHorizontalScrollbarEnabled(p_value);
 			return true;
 			
 		default:

--- a/libbrowser/src/libbrowser_cef.h
+++ b/libbrowser/src/libbrowser_cef.h
@@ -35,6 +35,12 @@ enum MCCefAuthScheme
 	kMCCefAuthSPDYProxy,
 };
 
+enum MCCefScrollbarDirection
+{
+	kMCCefScrollbarVertical = 1<<0,
+	kMCCefScrollbarHorizontal = 1<<1,
+};
+
 class MCCefBrowserBase : public MCBrowserBase
 {
 public:
@@ -82,8 +88,8 @@ private:
 	bool WaitOnResultString(CefString &r_result);
 	bool GetMessageResultString(CefProcessId p_target, CefRefPtr<CefProcessMessage> p_message, CefString &r_result);
 	
-	bool GetOverflowHidden();
-	void SetOverflowHidden(bool p_hidden);
+	bool GetOverflowHidden(MCCefScrollbarDirection);
+	void SetOverflowHidden(MCCefScrollbarDirection, bool p_hidden);
 	
 public:
 	bool GetUserAgent(CefString &r_user_agent);
@@ -101,8 +107,11 @@ public:
 	virtual char *GetSource(void);
 	virtual void SetSource(const char *p_source);
 	
-	virtual bool GetScrollbars(void);
-	virtual void SetScrollbars(bool p_scrollbars);
+	virtual bool GetVerticalScrollbarEnabled(void);
+	virtual void SetVerticalScrollbarEnabled(bool p_scrollbars);
+	
+	virtual bool GetHorizontalScrollbarEnabled(void);
+	virtual void SetHorizontalScrollbarEnabled(bool p_scrollbars);
 	
 	virtual char *GetUserAgent(void);
 	virtual void SetUserAgent(const char *p_user_agent);

--- a/libbrowser/src/libbrowser_uiwebview.h
+++ b/libbrowser/src/libbrowser_uiwebview.h
@@ -51,8 +51,10 @@ protected:
 	bool GetHTMLText(char *&r_htmltext);
 	bool SetHTMLText(const char *p_htmltext);
 	
-	bool GetScrollingEnabled(bool& r_value);
-	bool SetScrollingEnabled(bool p_value);
+	bool GetVerticalScrollbarEnabled(bool& r_value);
+	bool SetVerticalScrollbarEnabled(bool p_value);
+	bool GetHorizontalScrollbarEnabled(bool& r_value);
+	bool SetHorizontalScrollbarEnabled(bool p_value);
 	
 	bool GetJavaScriptHandlers(char *&r_handlers);
 	bool SetJavaScriptHandlers(const char *p_handlers);

--- a/libbrowser/src/libbrowser_uiwebview.mm
+++ b/libbrowser/src/libbrowser_uiwebview.mm
@@ -247,19 +247,6 @@ bool MCUIWebViewBrowser::GoToURL(const char *p_url)
 	return true;
 }
 
-bool MCUIWebViewBrowser::SetScrollingEnabled(bool p_value)
-{
-	UIWebView *t_view;
-	if (!GetView(t_view))
-		return false;
-	
-	MCBrowserRunBlockOnMainFiber(^{
-		[GetScrollView() setScrollEnabled: p_value ? YES : NO];
-	});
-	
-	return true;
-}
-
 bool MCUIWebViewBrowser::GetUrl(char *&r_url)
 {
 	UIWebView *t_view;
@@ -270,18 +257,57 @@ bool MCUIWebViewBrowser::GetUrl(char *&r_url)
 	MCBrowserRunBlockOnMainFiber(^{
 		t_success = MCCStringClone([[[[t_view request] URL] absoluteString] cStringUsingEncoding: NSUTF8StringEncoding], r_url);
 	});
-
+	
 	return t_success;
 }
 
-bool MCUIWebViewBrowser::GetScrollingEnabled(bool& r_value)
+bool MCUIWebViewBrowser::SetVerticalScrollbarEnabled(bool p_value)
 {
 	UIWebView *t_view;
 	if (!GetView(t_view))
 		return false;
 	
 	MCBrowserRunBlockOnMainFiber(^{
-		r_value = [GetScrollView() isScrollEnabled];
+		GetScrollView().showsVerticalScrollIndicator = p_value ? YES : NO;
+	});
+	
+	return true;
+}
+
+bool MCUIWebViewBrowser::GetVerticalScrollbarEnabled(bool& r_value)
+{
+	UIWebView *t_view;
+	if (!GetView(t_view))
+		return false;
+	
+	MCBrowserRunBlockOnMainFiber(^{
+		r_value = GetScrollView().showsVerticalScrollIndicator;
+	});
+	
+	return true;
+}
+
+bool MCUIWebViewBrowser::SetHorizontalScrollbarEnabled(bool p_value)
+{
+	UIWebView *t_view;
+	if (!GetView(t_view))
+		return false;
+	
+	MCBrowserRunBlockOnMainFiber(^{
+		GetScrollView().showsHorizontalScrollIndicator = p_value ? YES : NO;
+	});
+	
+	return true;
+}
+
+bool MCUIWebViewBrowser::GetHorizontalScrollbarEnabled(bool& r_value)
+{
+	UIWebView *t_view;
+	if (!GetView(t_view))
+		return false;
+	
+	MCBrowserRunBlockOnMainFiber(^{
+		r_value = GetScrollView().showsHorizontalScrollIndicator;
 	});
 	
 	return true;
@@ -385,8 +411,11 @@ bool MCUIWebViewBrowser::SetBoolProperty(MCBrowserProperty p_property, bool p_va
 {
 	switch (p_property)
 	{
-		case kMCBrowserScrollbars:
-			return SetScrollingEnabled(p_value);
+		case kMCBrowserVerticalScrollbarEnabled:
+			return SetVerticalScrollbarEnabled(p_value);
+			
+		case kMCBrowserHorizontalScrollbarEnabled:
+			return SetHorizontalScrollbarEnabled(p_value);
 			
 		default:
 			break;
@@ -399,8 +428,11 @@ bool MCUIWebViewBrowser::GetBoolProperty(MCBrowserProperty p_property, bool &r_v
 {
 	switch (p_property)
 	{
-		case kMCBrowserScrollbars:
-			return GetScrollingEnabled(r_value);
+		case kMCBrowserVerticalScrollbarEnabled:
+			return GetVerticalScrollbarEnabled(r_value);
+			
+		case kMCBrowserHorizontalScrollbarEnabled:
+			return GetHorizontalScrollbarEnabled(r_value);
 			
 		default:
 			break;


### PR DESCRIPTION
Removes the "browser" prefix from property names, which requires some engine parser changes to allow "url" to be recognised as a property name.
