### PR TITLE
build: Refactor openssl stub library generation.

### DIFF
--- a/engine/engine-common.gyp
+++ b/engine/engine-common.gyp
@@ -80,8 +80,8 @@
 			
 			'dependencies':
 			[
-				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl',
-				
+				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
+
 				# Because our headers are so messed up...
 				'../libfoundation/libfoundation.gyp:libFoundation',
 				'../libgraphics/libgraphics.gyp:libGraphics',

--- a/engine/kernel-development.gyp
+++ b/engine/kernel-development.gyp
@@ -47,8 +47,8 @@
 			'dependencies':
 			[
 				'kernel.gyp:kernel',
-				
-				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl',
+
+				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 				'../thirdparty/libz/libz.gyp:libz',
 			],
 			

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -22,7 +22,7 @@
 
 				'../thirdparty/libgif/libgif.gyp:libgif',
 				'../thirdparty/libjpeg/libjpeg.gyp:libjpeg',
-				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl',
+				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 				'../thirdparty/libpcre/libpcre.gyp:libpcre',
 				'../thirdparty/libpng/libpng.gyp:libpng',
 				'../thirdparty/libz/libz.gyp:libz',

--- a/revdb/revdb.gyp
+++ b/revdb/revdb.gyp
@@ -84,7 +84,7 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
 				'../thirdparty/libmysql/libmysql.gyp:libmysql',
-				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl',
+				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
@@ -142,7 +142,7 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
 				'../thirdparty/libmysql/libmysql.gyp:libmysql',
-				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl',
+				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
@@ -321,7 +321,7 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
 				'../thirdparty/libpq/libpq.gyp:libpq',
-				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl',
+				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 			],
 			
 			'include_dirs':
@@ -367,7 +367,7 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
 				'../thirdparty/libpq/libpq.gyp:libpq',
-				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl',
+				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 			],
 			
 			'include_dirs':


### PR DESCRIPTION
Replace uses of the the thirdparty "openssl" target with
"openssl_stubs".  This fixes a problem when compiling with
MS Visual Studio 2010 Express Edition due to having two
projects named "openssl" in the solution.
