### PR TITLE
[[ Bug 15689 ]] Fix the media player callbacks parsing

### DIFF
--- a/docs/notes/bugfix-15689.md
+++ b/docs/notes/bugfix-15689.md
@@ -1,0 +1,1 @@
+# Media player callbacks are not called with the right defaultStack

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -2917,7 +2917,7 @@ void MCPlayer::SynchronizeUserCallbacks(void)
         }
         
         MCAutoStringRef t_message;
-        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_callback_index, t_space_index - t_callback_index), &t_message);
+        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_callback_index, t_space_index - 1 - t_callback_index), &t_message);
         /* UNCHECKED */ MCNameCreate(*t_message, m_callbacks[m_callback_count - 1] . message);
         
         // If no parameter is specified, use the time.


### PR DESCRIPTION
It used to include the space in the callback message, which was never matching any script handler when MCObject::message was called in MCObject::timer.
No error was trigered though, as the handler was found when MCObject::domess is called - but the former does not set MCdefaultstackptr, allowing some obscure issues to happen
