### PR TITLE
[Bug 16085] build: Documentation for building with Visual Studio 2010 Express

### DIFF
--- a/INSTALL-win.md
+++ b/INSTALL-win.md
@@ -1,0 +1,67 @@
+# Compiling LiveCode for Windows
+
+![LiveCode Community Logo](http://livecode.com/wp-content/uploads/2015/02/livecode-logo.png)
+
+Copyright © 2015 LiveCode Ltd., Edinburgh, UK
+
+## Dependencies
+
+The Windows build scripts currently don't have any ability to auto-discover tools, so you need to **install all of the build dependencies to their default locations**.
+
+### git
+
+You will need to install [git for Windows](https://git-scm.com/download/win) in order to obtain the LiveCode source code from GitHub.
+
+### Microsoft Visual Studio
+
+You will need to download & install [Microsoft Visual Studio 2010 Express](http://download.microsoft.com/download/1/E/5/1E5F1C0A-0D5B-426A-A603-1798B951DDAE/VS2010Express1.iso) (or Professional, if available).
+
+In addition, you should install:
+
+* [Microsoft Speech SDK 5.1](https://www.microsoft.com/en-gb/download/details.aspx?id=10121)
+* Microsoft Speech SDK 4.0 - this can be harder to find, but [this link](ftp://ftp.boulder.ibm.com/software/viavoicesdk/sapi4sdk.exe) may work
+
+### Cygwin
+
+The build currently requires the use of some tools from the Cygwin distribution of GNU and other open source tools.
+
+You need to [install Cygwin](https://cygwin.com/install.html), along with the following additional packages:
+
+* make
+* bash
+* bison
+* flex
+* curl
+* zip
+* unzip
+
+### Other tools
+
+The build process also requires:
+
+* [ActiveState Perl](https://www.activestate.com/activeperl/downloads) Community Edition
+* [Python 2.7](https://www.python.org/) (Python 3 isn't supported)
+* [QuickTime 7.3 SDK for Windows](https://developer.apple.com/downloads)
+
+## Configuring LiveCode
+
+Once you have checked out the source code from git, you can run:
+
+````
+cmd /C configure.bat
+````
+
+(Or just run `configure.bat` by double-clicking on it from Windows Explorer)
+
+This will generate a set of Visual Studio project files in the `build-win-x86/livecode` directory.
+
+## Compiling LiveCode
+
+To compile LiveCode, you can either open the `build-win-x86/livecode/livecode.sln` solution file in Visual Studio, or you can run:
+
+````
+cd build-win-x86
+cmd /C ..\make.cmd
+````
+
+Note that if you are using Visual Studio 2010 Express you won't be able to compile the revbrowser extension.

--- a/config/cpptest.gypi
+++ b/config/cpptest.gypi
@@ -2,7 +2,7 @@
 	'variables':
 	{
 		'module_test_dependencies%': '',
-		'module_test_additional_sources%': '',
+		'module_test_sources%': '',
 		'module_test_include_dirs%': '',
 		'module_test_defines%': '',
 	},
@@ -33,8 +33,7 @@
 
 			'sources':
 			[
-				'<!@(ls -1 test/*.cpp)',
-				'<@(module_test_additional_sources)',
+				'<@(module_test_sources)',
 			],
 
 			'include_dirs': [ '<@(module_test_include_dirs)', ],

--- a/config/version.gypi
+++ b/config/version.gypi
@@ -1,12 +1,11 @@
 {
 	'variables':
 	{
-		'version_major': "<!(perl -n -e '/^BUILD_MAJOR_VERSION[[:blank:]]*=[[:blank:]]*(.*)$/ && print $1' <(DEPTH)/version)",
-		'version_minor': "<!(perl -n -e '/^BUILD_MINOR_VERSION[[:blank:]]*=[[:blank:]]*(.*)$/ && print $1' <(DEPTH)/version)",
-		'version_point': "<!(perl -n -e '/^BUILD_POINT_VERSION[[:blank:]]*=[[:blank:]]*(.*)$/ && print $1' <(DEPTH)/version)",
-		'version_build': "<!(perl -n -e '/^BUILD_REVISION[[:blank:]]*=[[:blank:]]*(.*)$/ && print $1' <(DEPTH)/version)",
-	
-		'version_string': "<!(perl -n -e '/^BUILD_SHORT_VERSION[[:blank:]]*=[[:blank:]]*(.*)$/ && print $1' <(DEPTH)/version)",
+		'version_major': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_MAJOR_VERSION <(DEPTH)/version)",
+		'version_minor': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_MINOR_VERSION <(DEPTH)/version)",
+		'version_point': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_POINT_VERSION <(DEPTH)/version)",
+		'version_build': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_REVISION <(DEPTH)/version)",
+		'version_string': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_SHORT_VERSION <(DEPTH)/version)",
 
 		'git_revision': '<!(git rev-parse HEAD)',
 	},

--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -964,6 +964,13 @@
 		[
 			'src/browser.lcb',
 		],
+
+		# Engine cpptest source files
+		'engine_test_source_files':
+		[
+			'test/test_lextable.cpp',
+			'test/test_new.cpp',
+		],
 	},
 	
 	'target_defaults':

--- a/engine/kernel-development.gyp
+++ b/engine/kernel-development.gyp
@@ -9,8 +9,9 @@
 			'../libfoundation/libfoundation.gyp:libFoundation',
 			'../libgraphics/libgraphics.gyp:libGraphics',
 		],
-		'module_test_additional_sources':
+		'module_test_sources':
 		[
+			'<@(engine_test_source_files)',
 			'<(SHARED_INTERMEDIATE_DIR)/src/startupstack.cpp',
 		],
 		'module_test_include_dirs':

--- a/engine/kernel-installer.gyp
+++ b/engine/kernel-installer.gyp
@@ -15,6 +15,10 @@
 			'src',
 		],
 		'module_test_defines': [ 'MODE_INSTALLER', ],
+		'module_test_sources':
+		[
+			'<@(engine_test_source_files)',
+		],
 	},
 
 	'includes':

--- a/engine/kernel-server.gyp
+++ b/engine/kernel-server.gyp
@@ -8,9 +8,10 @@
 			'../libfoundation/libfoundation.gyp:libFoundation',
 			'../libgraphics/libgraphics.gyp:libGraphics',
 		],
-		'module_test_additional_sources':
+		'module_test_sources':
 		[
-			'<@(engine_security_source_files)'
+			'<@(engine_test_source_files)',
+			'<@(engine_security_source_files)',
 		],
 		'module_test_include_dirs':
 		[

--- a/engine/kernel-standalone.gyp
+++ b/engine/kernel-standalone.gyp
@@ -15,6 +15,10 @@
 			'src',
 		],
 		'module_test_defines': [ 'MODE_STANDALONE', ],
+		'module_test_sources':
+		[
+			'<@(engine_test_source_files)',
+		],
 	},
 
 	'includes':

--- a/libbrowser/src/libbrowser_win.rc
+++ b/libbrowser/src/libbrowser_win.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
 
@@ -38,7 +38,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\0"
+    "#include ""windows.h""\0"
 END
 
 #endif    // APSTUDIO_INVOKED

--- a/libcpptest/libcpptest.gyp
+++ b/libcpptest/libcpptest.gyp
@@ -2,6 +2,10 @@
 	'variables':
 	{
 		'module_name': 'libcpptest',
+		'module_test_sources':
+		[
+			'test/trivial.cpp',
+		],
 	},
 
 	'includes':

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -6,6 +6,11 @@
 		[
 			'libFoundation',
 		],
+		'module_test_sources':
+		[
+			'test/environment.cpp',
+			'test/test_string.cpp',
+		],
 	},
 
 

--- a/make.cmd
+++ b/make.cmd
@@ -2,7 +2,7 @@
 @REM More-or-less the same effect as running vcvars32.bat
 @REM from the Visual Studio source tree.
 @REM @call vcvars32
-@set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VSTSDB\Deploy;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\IDE\;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\BIN;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Windows\Microsoft.NET\Framework\v3.5;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\VCPackages;%ProgramFiles(x86)%\HTML Help Workshop;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin\NETFX 4.0 Tools;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\system32\wbem"
+@set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VSTSDB\Deploy;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\IDE\;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\BIN;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Windows\Microsoft.NET\Framework\v3.5;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\VCPackages;%ProgramFiles(x86)%\HTML Help Workshop;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin\NETFX 4.0 Tools;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin;C:\Perl64\site\bin;C:\Perl64\bin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\system32\wbem"
 
 @REM Works around hangs when generating .pdb files
 @REM Needs to run in the background as never terminates

--- a/make.cmd
+++ b/make.cmd
@@ -2,15 +2,15 @@
 @REM More-or-less the same effect as running vcvars32.bat
 @REM from the Visual Studio source tree.
 @REM @call vcvars32
-@set "PATH=C:\Program Files\Microsoft Visual Studio 10.0\VSTSDB\Deploy;C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\;C:\Program Files\Microsoft Visual Studio 10.0\VC\BIN;C:\Program Files\Microsoft Visual Studio 10.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Windows\Microsoft.NET\Framework\v3.5;C:\Program Files\Microsoft Visual Studio 10.0\VC\VCPackages;C:\Program Files\HTML Help Workshop;C:\Program Files\Microsoft SDKs\Windows\7.0A\bin\NETFX 4.0 Tools;C:\Program Files\Microsoft SDKs\Windows\7.0A\bin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\system32\wbem"
- 
+@set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VSTSDB\Deploy;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\IDE\;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\BIN;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Windows\Microsoft.NET\Framework\v3.5;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\VCPackages;%ProgramFiles(x86)%\HTML Help Workshop;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin\NETFX 4.0 Tools;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\system32\wbem"
+
 @REM Works around hangs when generating .pdb files
 @REM Needs to run in the background as never terminates
 @REM
 @start /min /b mspdbsrv -start -spawn -shutdowntime -1
 
 @REM Select the correct build mode.
-@REM 
+@REM
 @IF NOT DEFINED BUILDTYPE SET BUILDTYPE=Debug
 
 @REM Select the correct build project file
@@ -29,6 +29,5 @@ IF -%1-==-- (
 )
 
 @msbuild %BUILD_PROJECT% /fl /flp:Verbosity=normal /nologo /p:Configuration=%BUILDTYPE% /m:1 /t:%TARGET%
- 
-@exit %ERRORLEVEL%
 
+@exit %ERRORLEVEL%

--- a/make.cmd
+++ b/make.cmd
@@ -1,8 +1,16 @@
+@REM Make sure ProgramFiles(x86) variable is defined
+@SET "ProgramFilesBase=%ProgramFiles% (x86)"
+@IF NOT EXIST "%ProgramFilesBase%" (
+  SET "ProgramFilesBase=%ProgramFiles%"
+)
+
+ECHO %ProgramFilesBase%
+
 @REM Set up environment so that we can run Visual Studio.
 @REM More-or-less the same effect as running vcvars32.bat
 @REM from the Visual Studio source tree.
 @REM @call vcvars32
-@set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VSTSDB\Deploy;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\IDE\;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\BIN;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Windows\Microsoft.NET\Framework\v3.5;%ProgramFiles(x86)%\Microsoft Visual Studio 10.0\VC\VCPackages;%ProgramFiles(x86)%\HTML Help Workshop;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin\NETFX 4.0 Tools;%ProgramFiles(x86)%\Microsoft SDKs\Windows\7.0A\bin;C:\Perl64\site\bin;C:\Perl64\bin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\system32\wbem"
+@set "PATH=%ProgramFilesBase%\Microsoft Visual Studio 10.0\VSTSDB\Deploy;%ProgramFilesBase%\Microsoft Visual Studio 10.0\Common7\IDE\;%ProgramFilesBase%\Microsoft Visual Studio 10.0\VC\BIN;%ProgramFilesBase%\Microsoft Visual Studio 10.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Windows\Microsoft.NET\Framework\v3.5;%ProgramFilesBase%\Microsoft Visual Studio 10.0\VC\VCPackages;%ProgramFilesBase%\HTML Help Workshop;%ProgramFilesBase%\Microsoft SDKs\Windows\7.0A\bin\NETFX 4.0 Tools;%ProgramFilesBase%\Microsoft SDKs\Windows\7.0A\bin;C:\Perl64\site\bin;C:\Perl64\bin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\system32\wbem"
 
 @REM Works around hangs when generating .pdb files
 @REM Needs to run in the background as never terminates

--- a/util/decode_version.pl
+++ b/util/decode_version.pl
@@ -1,0 +1,9 @@
+#!/usr/bin/env perl
+
+open(FILE, $ARGV[1]) || die "Can't open input file";
+
+my $expr = "^${ARGV[0]}[[:blank:]]*=[[:blank:]]*(.*)\$";
+
+while (<FILE>) {
+	if (/$expr/) { print $1 }
+}


### PR DESCRIPTION
This pull request fixes some issues with Windows native builds, and provides the long-missing `INSTALL-win.md` documentation.

The main (possibly controversial) change here is to require cpptest test source files to be listed explicitly in the gyp files, rather than automatically scanning for them.
