### PR TITLE
build: Make "tautological comparison" warnings into errors

### DIFF
--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -173,6 +173,7 @@
 							'-Wno-unused-parameter',
 							'-Werror=uninitialized',
 							'-Werror=return-type',
+							'-Werror=tautological-compare',
 						],
 					},
 				},

--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -121,6 +121,7 @@
 							'-Wno-unused-parameter',
 							'-Werror=uninitialized',
 							'-Werror=return-type',
+							'-Werror=tautological-compare',
 						],
 					},
 				},

--- a/engine/src/deploy_capsule.cpp
+++ b/engine/src/deploy_capsule.cpp
@@ -542,7 +542,7 @@ bool MCDeployCapsuleGenerate(MCDeployCapsuleRef self, MCDeployFileRef p_file, MC
 			
 			// This is a section for which data has been supplied so first write
 			// out the header.
-			if (t_section -> length >= 1 << 24 || t_section -> type >= 128)
+			if (t_section -> length >= 1 << 24 || (integer_t)t_section -> type >= 128)
 			{
 				// MW-2009-07-14: Probably best to make sure we fill the *right* indices in the
 				//   header array :o)

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -6106,8 +6106,8 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         
         FSRef t_defaultfolder_fsref;
         OSErr t_os_error;
-        if (t_defaultfolder != NULL)
-            t_os_error = FSPathMakeRef((const UInt8 *)t_defaultfolder, &t_defaultfolder_fsref, NULL);
+        
+        t_os_error = FSPathMakeRef((const UInt8 *)t_defaultfolder, &t_defaultfolder_fsref, NULL);
 		
         FSCatalogInfo t_catalog_info;
         if (t_os_error == noErr)

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1336,7 +1336,7 @@ uint4 MCFilesExecPerformReadCodeUnit(MCExecContext& ctxt, int4 p_index, intenum_
 			r_stat = MCS_readall(t_bytes.Bytes(), 2, p_stream, t_bytes_read);
 
 			if (t_bytes_read == 2 ||
-					(t_bytes_read == 1 && r_stat == EOF))
+					(t_bytes_read == 1 && r_stat == IO_EOF))
 			{
 				unichar_t t_codeunit;
 
@@ -1360,7 +1360,7 @@ uint4 MCFilesExecPerformReadCodeUnit(MCExecContext& ctxt, int4 p_index, intenum_
             t_bytes . New(4);
             r_stat = MCS_readall(t_bytes.Bytes(), 4, p_stream, t_bytes_read);
             
-            if (t_bytes_read == 4 || r_stat == EOF)
+            if (t_bytes_read == 4 || r_stat == IO_EOF)
             {
                 uint32_t t_codeunit;
                 MCAutoStringRef t_string;

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -1044,9 +1044,7 @@ MCExecEnumTypeInfo *kMCInterfaceGradientFillQualityTypeInfo = &_kMCInterfaceGrad
 void MCGraphic::SetForeColor(MCExecContext& ctxt, const MCInterfaceNamedColor& color)
 {
     // PM-2015-21-01: When the graphic has a strokegradient, make sure we can set a fore color of the form "rrr,ggg,bbb" (where color.name == nil)
-    bool t_has_color;
-    t_has_color = &color . color != NULL;
-    if (t_has_color && m_stroke_gradient != nil)
+    if (m_stroke_gradient != nil)
     {
         MCGradientFillFree(m_stroke_gradient);
         m_stroke_gradient = nil;
@@ -1058,9 +1056,7 @@ void MCGraphic::SetBackColor(MCExecContext& ctxt, const MCInterfaceNamedColor& c
 {
     // PM-2015-21-01: [[ Bug 14399 ]] Remove fillgradient when setting the bg color of a graphic
     // Also make sure we can set a bg color of the form "rrr,ggg,bbb" (where color.name == nil)
-    bool t_has_color;
-    t_has_color = &color . color != NULL;
-    if (t_has_color && m_fill_gradient != nil)
+    if (m_fill_gradient != nil)
     {
         MCGradientFillFree(m_fill_gradient);
         m_fill_gradient = nil;

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -2608,7 +2608,7 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
         {
             uinteger_t t_value;
             MCExecTypeConvertAndReleaseAlways(ctxt, p_value . type, &p_value, kMCExecValueTypeUInt, &t_value);
-            if (t_value < 0 || t_value > 65535)
+            if (t_value > 65535)
                 ctxt . LegacyThrow(EE_PROPERTY_NAN);
             if (!ctxt . HasError())
                 ((void(*)(MCExecContext&, void *, uinteger_t))prop -> setter)(ctxt, mark, t_value);
@@ -2855,7 +2855,7 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
             {
                 t_value_ptr = &t_value;
                 MCExecTypeConvertAndReleaseAlways(ctxt, p_value . type, &p_value, kMCExecValueTypeUInt, &t_value);
-                if (t_value < 0 || t_value > 255)
+                if (t_value > 255)
                     ctxt . LegacyThrow(EE_PROPERTY_NAN);
             }
             
@@ -2895,7 +2895,7 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
             {
                 t_value_ptr = &t_value;
                 MCExecTypeConvertAndReleaseAlways(ctxt, p_value . type, &p_value, kMCExecValueTypeUInt, &t_value);
-                if (t_value < 0 || t_value > 65535)
+                if (t_value > 65535)
                     ctxt . LegacyThrow(EE_PROPERTY_NAN);
             }
             

--- a/engine/src/ifile.cpp
+++ b/engine/src/ifile.cpp
@@ -324,7 +324,7 @@ bool MCImageExport(MCImageBitmap *p_bitmap, Export_format p_format, MCImagePalet
 	{
 		if (p_palette_settings != nil && p_palette_settings->type != kMCImagePaletteTypeEmpty)
 		{
-			t_success = MCImageQuantizeColors(p_bitmap, p_palette_settings, p_dither, p_format == F_GIF || p_format == F_PNG, t_indexed);
+			t_success = MCImageQuantizeColors(p_bitmap, p_palette_settings, p_dither, p_format == EX_GIF || p_format == EX_PNG, t_indexed);
 			if (t_success)
 				t_success = MCImageEncode(t_indexed, p_format, p_metadata, p_stream, t_size);
 		}

--- a/engine/src/osxprinter.cpp
+++ b/engine/src/osxprinter.cpp
@@ -440,10 +440,7 @@ bool MCMacOSXPrinter::Reset(MCStringRef p_name, PMPrintSettings p_settings, PMPa
 	if (t_success && t_printer != NULL)
 	{
 		OSErr t_err;
-		if (PMSessionSetCurrentPMPrinter != NULL)
-			t_err = PMSessionSetCurrentPMPrinter(t_session, t_printer);
-		else
-			t_err = PMSessionSetCurrentPrinter(t_session, PMPrinterGetName(t_printer));
+        t_err = PMSessionSetCurrentPrinter(t_session, PMPrinterGetName(t_printer));
 
 		if (t_err != noErr)
 			t_success = false;
@@ -471,7 +468,7 @@ bool MCMacOSXPrinter::Reset(MCStringRef p_name, PMPrintSettings p_settings, PMPa
 
 	PMPaper t_paper;
 	t_paper = NULL;
-	if (t_success && MCmajorosversion >= 0x1040 && PMGetPageFormatPaper != NULL)
+	if (t_success && MCmajorosversion >= 0x1040)
 	{
 		OSErr t_err;
 		t_err = PMGetPageFormatPaper(t_page_format, &t_paper);
@@ -570,7 +567,7 @@ void MCMacOSXPrinter::SetProperties(bool p_include_output)
 	PDEBUG(stderr, "SetProperties: PMGetPageFormatPaper\n");
 	PMRect t_pm_paper_rect;
 	PMPaper t_pm_paper;
-	if (PMGetPageFormatPaper != NULL && PMGetPageFormatPaper(m_page_format, &t_pm_paper) == noErr)
+	if (PMGetPageFormatPaper(m_page_format, &t_pm_paper) == noErr)
 	{
 		PDEBUG(stderr, "SetProperties: PMPaperGetWidth\n");
 		double t_width;
@@ -623,7 +620,7 @@ void MCMacOSXPrinter::SetProperties(bool p_include_output)
 
 	PDEBUG(stderr, "SetProperties: PMGetDuplex\n");
 	PMDuplexMode t_pm_duplex;
-	if (PMGetDuplex != NULL && PMGetDuplex(m_settings, &t_pm_duplex) == noErr)
+	if (PMGetDuplex(m_settings, &t_pm_duplex) == noErr)
 		t_job_duplex = t_pm_duplex == kPMDuplexNone ? PRINTER_DUPLEX_MODE_SIMPLEX : (t_pm_duplex == kPMDuplexNoTumble ? PRINTER_DUPLEX_MODE_LONG_EDGE : PRINTER_DUPLEX_MODE_SHORT_EDGE);
 	else
 		t_job_duplex = PRINTER_DEFAULT_JOB_DUPLEX;
@@ -969,10 +966,7 @@ void MCMacOSXPrinter::ResetSession(void)
 {
 	PMPrintSession t_session;
 	PMCreateSession(&t_session);
-	if (PMSessionSetCurrentPMPrinter != NULL)
-		PMSessionSetCurrentPMPrinter(t_session, m_printer);
-	else
-		PMSessionSetCurrentPrinter(t_session, PMPrinterGetName(m_printer));
+    PMSessionSetCurrentPMPrinter(t_session, m_printer);
 	
 	PMSessionValidatePrintSettings(t_session, m_settings, kPMDontWantBoolean);
 	PMSessionValidatePageFormat(t_session, m_page_format, kPMDontWantBoolean);

--- a/engine/src/path.cpp
+++ b/engine/src/path.cpp
@@ -145,9 +145,6 @@ static inline void __path_append_arc(uint1*& pr_commands, int4*& pr_data, int4 c
 
 void MCPath::release(void)
 {
-	if (this == NULL)
-		return;
-
 	f_references -= 1;
 	if (f_references == 0)
 		free(this);
@@ -155,9 +152,6 @@ void MCPath::release(void)
 
 void MCPath::retain(void)
 {
-	if (this == NULL)
-		return;
-
 	f_references += 1;
 }
 
@@ -600,17 +594,11 @@ MCPath *MCPath::create_empty(void)
 
 void MCPath::fill(MCCombiner *p_combiner, const MCRectangle& clip, bool p_even_odd)
 {
-	if (this == NULL)
-		return;
-
 	fill(f_commands, f_data, p_combiner, clip, p_even_odd);
 }
 
 void MCPath::stroke(MCCombiner *p_combiner, const MCRectangle& clip, MCStrokeStyle *p_stroke)
 {
-	if (this == NULL)
-		return;
-
 	uint2 t_width = p_stroke->width;
 	p_stroke->width *= 256;
 	stroke(f_commands, f_data, p_combiner, clip, p_stroke);

--- a/engine/src/stackcache.cpp
+++ b/engine/src/stackcache.cpp
@@ -303,11 +303,6 @@ bool MCStackIdCache::RehashBuckets(uindex_t p_new_item_count)
 	t_new_capacity_idx = m_capacity_idx;
 	if (p_new_item_count != 0)
 	{
-		// If we are shrinking we just shrink down to the level needed by the currently
-		// used buckets.
-		if (p_new_item_count < 0)
-			p_new_item_count = 0;
-
 		// Work out the smallest possible capacity greater than the requested capacity.
 		uindex_t t_new_capacity_req;
 		t_new_capacity_req = m_count + p_new_item_count;

--- a/engine/src/syscfdate.cpp
+++ b/engine/src/syscfdate.cpp
@@ -399,12 +399,6 @@ static bool osx_cf_cache_locale(MCDateTimeLocale *p_info)
 	bool t_success;
 	t_success = true;
 	
-	if (t_success)
-	{
-		if (CFDateFormatterCreate == NULL)
-			t_success = false;
-	}
-	
 	CFLocaleRef t_locale;
 	t_locale = NULL;
 	if (t_success)

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -802,7 +802,7 @@ bool __MCValueInitialize(void)
 
 void __MCValueFinalize(void)
 {
-    for(uindex_t i = 0; i < sizeof(s_value_pools) / sizeof(s_value_pools[0]); i++)
+    for(index_t i = 0; i < sizeof(s_value_pools) / sizeof(s_value_pools[0]); i++)
         while(s_value_pools[i] . count > 0)
         {
             __MCValue *t_value;

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -285,6 +285,9 @@ struct MCValuePool
 };
 static MCValuePool *s_value_pools;
 
+// Stores the number of pools that we have.
+uindex_t kMCValuePoolCount = kMCValueTypeCodeList + 1;
+
 bool __MCValueCreate(MCValueTypeCode p_type_code, size_t p_size, __MCValue*& r_value)
 {
 	void *t_value;
@@ -782,7 +785,7 @@ MCBooleanRef kMCFalse;
 
 bool __MCValueInitialize(void)
 {
-    if (!MCMemoryNewArray(kMCValueTypeCodeList + 1, s_value_pools))
+    if (!MCMemoryNewArray(kMCValuePoolCount, s_value_pools))
         return false;
     
 	if (!__MCValueCreate(kMCValueTypeCodeNull, kMCNull))
@@ -802,7 +805,7 @@ bool __MCValueInitialize(void)
 
 void __MCValueFinalize(void)
 {
-    for(index_t i = 0; i < sizeof(s_value_pools) / sizeof(s_value_pools[0]); i++)
+    for(uindex_t i = 0; i < kMCValuePoolCount; i++)
         while(s_value_pools[i] . count > 0)
         {
             __MCValue *t_value;


### PR DESCRIPTION
Sets compile flag `-Werror=tautological-compare` on Mac and iOS.

This might not really be wanted to keep it as an error, but few bugs have come to light (wrong type being compared for instance, with `EOF` and `IO_EOF`).
