### PR TITLE
[[ BrowserWidget ]] Android browser bugfixes

### DIFF
--- a/libbrowser/libbrowser.gyp
+++ b/libbrowser/libbrowser.gyp
@@ -317,13 +317,19 @@
 			'target_name': 'libbrowser-copy',
 			'type': 'none',
 			
-			'dependencies':
-			[
-				'libbrowser-cefprocess',
-			],
-			
 			'conditions':
 			[
+				[
+					# Only the CEF platforms need libbrowser-cefprocess
+					'OS == "mac" or OS == "win" or OS == "linux"',
+					{
+						'dependencies':
+						[
+							'libbrowser-cefprocess',
+						],
+					},
+				],
+
 				[
 					'OS == "mac"',
 					{

--- a/libbrowser/libbrowser.gyp
+++ b/libbrowser/libbrowser.gyp
@@ -250,15 +250,6 @@
 			
 			'conditions':
 			[
-				# OSX, Windows, and Linux only
-				[
-					'OS != "mac" and OS != "win" and OS != "linux"',
-					{
-						'type': 'none',
-						'mac_bundle': 0,
-					},
-				],
-				
 				## Exclusions
 				[
 					'OS != "mac"',

--- a/libbrowser/src/libbrowser_android.cpp
+++ b/libbrowser/src/libbrowser_android.cpp
@@ -748,7 +748,7 @@ private:
 		
 		MCAndroidObjectRemoteCall(m_view, "getUrl", "s", &t_url);
 		if (t_url == nil)
-			return false;
+			return MCCStringClone("", r_utf8_string);
 			
 		r_utf8_string = t_url;
 		return true;


### PR DESCRIPTION
Fixes a compile error when building the Android standalone, and an error when returning an empty url property value.
