### PR TITLE
[[ Bug 15097 ]] Make 'the effective rect of stack' more reliable on L…

### DIFF
--- a/docs/notes/bugfix-15097.md
+++ b/docs/notes/bugfix-15097.md
@@ -1,0 +1,3 @@
+# Ensure 'the effective rect of stack' is more accurate on Linux
+
+With the move to GDK since 7.0 there is a better method for computing the effective rect of a window. The engine has been updated to use this method, rather than the heuristic which was there before.

--- a/engine/src/linux.stubs
+++ b/engine/src/linux.stubs
@@ -299,6 +299,7 @@ gdk libgdk-x11-2.0.so.0
 	gdk_window_set_skip_pager_hint: (pointer, integer) -> ()
 	gdk_window_constrain_size: (pointer, integer, integer, integer, pointer, pointer) -> ()
 	gdk_window_unmaximize: (pointer) -> ()
+	gdk_window_get_frame_extents: (pointer, pointer) -> ()
 
 gdk_pixbuf libgdk_pixbuf-2.0.so.0
 	gdk_pixbuf_get_pixels: (pointer) -> (pointer)

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -449,37 +449,9 @@ MCRectangle MCStack::view_platform_getwindowrect(void) const
 
 MCRectangle MCStack::view_device_getwindowrect(void) const
 {
-    x11::Window t_root, t_child, t_parent;
-    x11::Window *t_children;
-	int32_t t_win_x, t_win_y, t_x_offset, t_y_offset;
-	uint32_t t_width, t_height, t_border_width, t_depth, t_child_count;
-
-    x11::Window t_window = x11::gdk_x11_drawable_get_xid(window);
-    
-    x11::Display *t_display = x11::gdk_x11_display_get_xdisplay(MCdpy);
-
-    // We query for the top-level parent using the X11 functions because the GDK
-    // equivalents do not account for re-parenting window managers and will not
-    // return the re-parented parent.
-    x11::XQueryTree(t_display, t_window, &t_root, &t_parent, &t_children, &t_child_count);
-    x11::XFree(t_children);
-	while (t_parent != t_root)
-	{
-		t_window = t_parent;
-        x11::XQueryTree(t_display, t_window, &t_root, &t_parent, &t_children, &t_child_count);
-        x11::XFree(t_children);
-	}
-
-    x11::XGetGeometry(t_display, t_window, &t_root, &t_win_x, &t_win_y, &t_width, &t_height, &t_border_width, &t_depth);
-    x11::XTranslateCoordinates(t_display, t_window, t_root, 0, 0, &t_win_x, &t_win_y, &t_child);
-
-	MCRectangle t_rect;
-	t_rect.x = t_win_x - t_border_width;
-	t_rect.y = t_win_y - t_border_width;
-	t_rect.width = t_width + t_border_width * 2;
-	t_rect.height = t_height + t_border_width * 2;
-
-	return t_rect;
+    GdkRectangle t_frame;
+    gdk_window_get_frame_extents(window, &t_frame);
+    return MCRectangleMake(t_frame . x, t_frame . y, t_frame . width, t_frame . height);
 }
 
 // IM-2014-01-29: [[ HiDPI ]] Placeholder method for Linux HiDPI support


### PR DESCRIPTION
…inux

Before the port to GDK, the Linux engine used its own heuristic for computing
the frame rect of a window - this was not entirely reliable.

The appropriate method has now been updated to use gdk_window_get_frame_extents
which uses a couple of methods to try and ensure accuracy. Indeed, as long as
the window manager is compliant with EWMH (and isn't broken) it should be
correct.
