### PR TITLE
buildbot: Tweak rules for generating checksums for uploaded files

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -103,12 +103,15 @@ docs_build_dir = ${top_src_dir}/_build/docs-build
 ifeq ($(BUILD_PLATFORM),mac)
   LIVECODE = $(bin_dir)/LiveCode-Community.app/Contents/MacOS/LiveCode-Community
   buildtool_platform = mac
+  upload_checksum =
 else ifeq ($(BUILD_PLATFORM),linux-x86)
   LIVECODE = $(bin_dir)/LiveCode-Community
   buildtool_platform = linux
+  upload_checksum = sha1sum.txt
 else ifeq ($(BUILD_PLATFORM),linux-x86_64)
   LIVECODE = $(bin_dir)/LiveCode-Community
   buildtool_platform = linux
+  upload_checksum = sha1sum.txt
 endif
 
 # FIXME add --warn-as-error
@@ -119,6 +122,7 @@ buildtool_command = $(LIVECODE) -ui $(BUILDTOOL_STACK) \
 
 # Settings for upload
 RSYNC ?= rsync
+SHA1SUM ?= sha1sum
 UPLOAD_SERVER ?= meg.on-rev.com
 UPLOAD_PATH = staging/$(BUILD_LONG_VERSION)/$(GIT_VERSION)
 UPLOAD_MAX_RETRIES = 50
@@ -180,7 +184,9 @@ dist-tools-commercial:
 	  --built-docs-dir $(docs_build_dir)/cooked-commercial
 
 # Make a list of installers to be uploaded to the distribution server
-dist-upload-files.txt:
+# If a checksum file is needed, generate it with sha1sum
+dist-upload-files.txt $(upload_checksum):
+	set -e; \
 	find . -maxdepth 1 -name 'LiveCode*Installer-*-Mac.dmg' \
 	                -o -name 'LiveCode*Installer-*-Windows.exe' \
 	                -o -name 'LiveCode*Installer-*-Linux.*' \
@@ -188,11 +194,11 @@ dist-upload-files.txt:
 	                -o -name 'LiveCode*Server-*-Mac.zip' \
 	                -o -name 'LiveCode*Server-*-Windows.zip' \
 	                -o -name '*-bin.tar.xz' \
-	  > $@
-
-# Compute the SHA-1 sum of all the installers to be uploaded
-sha1sum.txt: dist-upload-files.txt
-	sha1sum < dist-upload-files.txt > $@
+	  > dist-upload-files.txt; \
+	if test -n "$(upload_checksum)"; then \
+	  $(SHA1SUM) < dist-upload-files.txt > $(upload_checksum); \
+	  echo "$(upload_checksum)" >> dist-upload-files.txt; \
+	fi
 
 # Perform the upload.  This is in two steps:
 # (1) Create the target directory
@@ -202,14 +208,14 @@ sha1sum.txt: dist-upload-files.txt
 # connection drops
 dist-upload-mkdir:
 	ssh $(UPLOAD_SERVER) "mkdir -p \"$(UPLOAD_PATH)\""
-dist-upload: dist-upload-files.txt sha1sum.txt dist-upload-mkdir
+dist-upload: dist-upload-files.txt dist-upload-mkdir
 	trap "echo Interrupted; exit;" SIGINT SIGTERM; \
 	i=0; \
 	false; \
 	while [ $$? -ne 0 -a $$i -lt $(UPLOAD_MAX_RETRIES) ] ; do \
 	  i=$$(($$i+1)); \
 	  rsync -v --progress --partial --chmod=ugo=rwX --executability \
-	    --files-from=dist-upload-files.txt sha1sum.txt . $(UPLOAD_SERVER):"\"$(UPLOAD_PATH)\""; \
+	    --files-from=dist-upload-files.txt . $(UPLOAD_SERVER):"\"$(UPLOAD_PATH)\""; \
 	done; \
 	rc=$$?; \
 	if [ $$i -eq $(UPLOAD_MAX_RETRIES) ]; then \


### PR DESCRIPTION
The new rules for generating and uploading a SHA-1 checksum of
uploaded installers were causing build failures due to (1) the lack of
a `sha1sum` program on Mac OS X, and (2) incorrect `rsync`
command-line syntax (you can't use both `--files-from` and filenames
as arguments).

This patch modifies the logic so that the checksum list isn't
generated when running the build on Mac, and generates the checksum
file and the list of files to upload in the same rule -- ensuring that
the list of files to upload includes the checksum file.
