### PR TITLE
build: Tweak upload checksum rules (attempt 2)

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -103,15 +103,15 @@ docs_build_dir = ${top_src_dir}/_build/docs-build
 ifeq ($(BUILD_PLATFORM),mac)
   LIVECODE = $(bin_dir)/LiveCode-Community.app/Contents/MacOS/LiveCode-Community
   buildtool_platform = mac
-  upload_checksum =
+  UPLOAD_ENABLE_CHECKSUM ?= no
 else ifeq ($(BUILD_PLATFORM),linux-x86)
   LIVECODE = $(bin_dir)/LiveCode-Community
   buildtool_platform = linux
-  upload_checksum = sha1sum.txt
+  UPLOAD_ENABLE_CHECKSUM ?= yes
 else ifeq ($(BUILD_PLATFORM),linux-x86_64)
   LIVECODE = $(bin_dir)/LiveCode-Community
   buildtool_platform = linux
-  upload_checksum = sha1sum.txt
+  UPLOAD_ENABLE_CHECKSUM ?= yes
 endif
 
 # FIXME add --warn-as-error
@@ -185,7 +185,7 @@ dist-tools-commercial:
 
 # Make a list of installers to be uploaded to the distribution server
 # If a checksum file is needed, generate it with sha1sum
-dist-upload-files.txt $(upload_checksum):
+dist-upload-files.txt sha1sum.txt:
 	set -e; \
 	find . -maxdepth 1 -name 'LiveCode*Installer-*-Mac.dmg' \
 	                -o -name 'LiveCode*Installer-*-Windows.exe' \
@@ -195,9 +195,11 @@ dist-upload-files.txt $(upload_checksum):
 	                -o -name 'LiveCode*Server-*-Windows.zip' \
 	                -o -name '*-bin.tar.xz' \
 	  > dist-upload-files.txt; \
-	if test -n "$(upload_checksum)"; then \
-	  $(SHA1SUM) < dist-upload-files.txt > $(upload_checksum); \
-	  echo "$(upload_checksum)" >> dist-upload-files.txt; \
+	if test "$(UPLOAD_ENABLE_CHECKSUM)" = "yes"; then \
+	  $(SHA1SUM) < dist-upload-files.txt > sha1sum.txt; \
+	  echo sha1sum.txt >> dist-upload-files.txt; \
+	else \
+	  touch sha1sum.txt; \
 	fi
 
 # Perform the upload.  This is in two steps:


### PR DESCRIPTION
Commit 9036b0d generated invalid shell script in the upload file list
rule if the checksum filename was empty.  This commit fixes that by
making whether the checksum file should be generated explicit by
putting a flag value into `$(UPLOAD_ENABLE_CHECKSUM)` and always
specifying checksum filename.
