### PR TITLE
[emscripten] Include startup template stack in installer.

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -688,6 +688,7 @@ component Runtime.Emscripten
 		file emscripten:standalone[[BaseEditionTagLower]]-[[VersionTag]].html
 		file emscripten:standalone[[BaseEditionTagLower]]-[[VersionTag]].html.mem
 		file emscripten:standalone[[BaseEditionTagLower]]-[[VersionTag]].js
+		file emscripten:emscripten-startup-template.livecodescript
 		rfolder emscripten:emscripten-standalone-template
 
 //////////


### PR DESCRIPTION
The startup script-only stack template was added to the
emscripten-bin archive generation, but not to the installer
manifest.
