### PR TITLE
[Tests] Add support for running IDE tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ check: check-$(guess_platform)
 
 check-common-%:
 	$(MAKE) -C tests bin_dir=../$*-bin
+	$(MAKE) -C ide/tests bin_dir=../../$*-bin
 
 ################################################################
 # Linux rules

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,6 +57,8 @@ on TestSetup
 end TestSetup
 ````
 
+Tests may need to clean up temporary files or other resources after running.  If a script test contains a handler called `TestTeardown`, this will be run after running each test command -- even if the test failed.  N.b. `TestTeardown` won't be run if running the test command causes an engine crash.
+
 Crashes or uncaught errors from a test command cause the test to immediately fail.
 
 ### LiveCode Builder

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,12 +40,22 @@ on TestMyFeature
 end TestMyFeature
 ````
 
-Before running each test command, the test framework inserts a test library stack, called `TestLibrary`, into the backscripts.  This provides a set of useful utility commands that can be used when writing test commands.  Currently, the following commands are available:
+Before running each test command, the test framework inserts a test library stack, called `TestLibrary`, into the backscripts.  This provides a set of useful utility handlers that can be used when writing test commands.  Currently, the following are available:
 
 * `TestDiagnostic pMessage`: Write *pMessage* to the test log as a message.
 * `TestAssert pDescription, pExpectTrue`: Make a test assertion.  The test is recorded as a failure if *pExpectTrue* is false.  *pDescription* should be a short string that describes the test (e.g. "clipboard is clear").
 * `TestSkip pDescription, pReasonSkipped`: Record a test as having been skipped.  *pReasonSkipped* should be a short explanation of why the test was skipped (e.g. "not supported on Windows").
 * `TestAssertBroken pDescription, pExpectTrue, pReasonBroken`: The same as `TestAssert`, but marking the test as "expected to fail".  *pReasonBroken* should be a short explanation of why the test is currently expected to fail; it should almost always be a reference to a bug report, e.g. "bug 54321".
+* `TestGetEngineRepositoryPath`: A function that returns the path to the main LiveCode engine repository.
+* `TestGetIDERepositoryPath`: A function that returns the path to the LiveCode IDE repository.
+
+Tests can have additional setup requirements before running, for example loading custom libraries. If the script test contains a handler called `TestSetup`, this will be run prior to running each test command. For example:
+````
+on TestSetup
+   -- All the tests in this script require access to the docs parser
+   start using stack (TestGetEngineRepositoryPath() & slash & "ide-support" & slash & "revdocsparser.livecodescript")
+end TestSetup
+````
 
 Crashes or uncaught errors from a test command cause the test to immediately fail.
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -44,7 +44,7 @@ LCS_ENGINE ?= $(guess_engine)
 LCS_ENGINE_FLAGS ?= $(guess_engine_flags)
 
 LCS_LOG = _lcs_test_suite.log
-LCS_TESTRUNNER = _testrunner.livecodescript
+LCS_TESTRUNNER = $(top_srcdir)/tests/_testrunner.livecodescript
 
 ########## LiveCode Builder test parameters
 
@@ -86,7 +86,9 @@ LCM_TEST_MODULES = $(patsubst %.lcb,$(LCM_DIR)/%.lcm,$(LCM_TEST_SOURCES))
 
 ########## Build dependencies rules
 
-include $(LCM_DIR)/deps.mk
+ifneq ($(LCM_SOURCES),)
+	include $(LCM_DIR)/deps.mk
+endif
 
 $(LCM_DIR):
 	mkdir -p $(LCM_DIR)

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -117,3 +117,13 @@ on ErrorDialog executionError, parseError
    write executionError & return to stderr
    quit 1
 end ErrorDialog
+
+function TestGetEngineRepositoryPath
+  set the itemdelimiter to "/"
+  return item 1 to -3 of the filename of me
+end TestGetEngineRepositoryPath
+
+function TestGetIDERepositoryPath
+  set the itemdelimiter to "/"
+  return item 1 to -3 of the filename of me & slash & "ide"
+end TestGetIDERepositoryPath

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -19,6 +19,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 -- FIXME provide this on the command line
 constant kLogFilename = "_test_suite.log"
 
+-- This is the message dispatched before invoking each test command
+constant kSetupMessage = "TestSetup"
+-- And this message is dispatched *after* each test command
+constant kTeardownMessage = "TestTearDown"
+
 on startup
    send "TestRunnerMain" to me in 0
 end startup
@@ -133,8 +138,10 @@ private command invokeTest pInfo
    -- This should auto-load the test script
    put the name of stack pInfo["invoke"]["script"] into tStackName
    
-   -- Dispatch the test command
+   -- Dispatch the test setup command, and the test command itself
+   dispatch kSetupMessage to tStackName
    dispatch pInfo["invoke"]["command"] to tStackName
+   dispatch kTeardownMessage to tStackName
 end invokeTest
 
 -- Add the unit test library stack to the backscripts
@@ -337,13 +344,26 @@ private function runGetTestCommandNames pFilename
    close file pFilename
    
    -- Scan the file for "on Test*" definitions
-   local tCommandNames, tCount, tLine
+   local tCommandNames, tCount, tLine, tName
    
    repeat for each line tLine in tScript
-      if token 1 of tLine is "on" and token 2 of tLine begins with "Test" then
-         add 1 to tCount
-         put token 2 of tLine into tCommandNames[tCount]
+      if token 1 of tLine is not "on" then
+         next repeat
       end if
+
+      put token 2 of tLine into tName
+
+      if not (tName begins with "Test") then
+         next repeat
+      end if
+
+      -- Exclude the test setup message
+      if tName is kSetupMessage or tName is kTeardownMessage then
+         next repeat
+      end if
+
+      add 1 to tCount
+      put tName into tCommandNames[tCount]
    end repeat
    
    return tCommandNames


### PR DESCRIPTION
- Add `TestSetup` and `TestTeardown` steps for each test
- Add test library handlers for getting useful paths
- Run tests from `ide/tests` in `make check`
- Update documentation
