### PR TITLE
[emscripten] Include runtime in all editions.

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -66,14 +66,17 @@ installer LiveCode
 		include Mobile.MacOSX
 		include Runtime.iOS
 		include Runtime.Android
+		include Runtime.Emscripten
 	if TargetPlatform is Windows then
 		include Mobile.Windows
 		include Runtime.Android
+		include Runtime.Emscripten
 		shortcut "Desktop/[[ProductTitle]]" to "[[TargetFolder]]/[[ProductName]].exe"
 		shortcut "Programs/RunRev/[[ProductTitle]]" to "[[TargetFolder]]/[[ProductName]].exe"
 	if TargetPlatform is Linux then
 		include Mobile.Linux
 		include Runtime.Android
+		include Runtime.Emscripten
 		desktop application "repo:Installer/application.desktop" as "runrev-[[ProductTag]]"
 		if TargetEdition is Community then
 			desktop icon "repo:Installer/application.png" as "runrev-[[ProductTag]]"
@@ -88,8 +91,6 @@ installer LiveCode
 		include Commercial.IndyComponents
 	if TargetEdition is Business then
 		include Commercial.BusinessComponents
-	if TargetEdition is Community then
-		include Runtime.Emscripten
 
 component Runtime
 	include Runtime.[[TargetPlatform]]


### PR DESCRIPTION
Previously, the HTML5 runtime was only included in the Community
edition.
