### PR TITLE
Add a dummy clipboard implementation for Emscripten

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -564,6 +564,7 @@
 			'src/socket_resolve.cpp',
 
 			'src/clipboard.h',
+			'src/em-clipboard.h',
 			'src/lnx-clipboard.h',
 			'src/mac-clipboard.h',
 			'src/mblandroid-clipboard.h',
@@ -571,6 +572,7 @@
 			'src/raw-clipboard.h',
 			'src/w32-clipboard.h',
 			'src/clipboard.cpp',
+			'src/em-clipboard.cpp',
 			'src/lnx-clipboard.cpp',
 			'src/mac-clipboard.mm',
 			'src/mblandroid-clipboard.cpp',

--- a/engine/src/em-clipboard.cpp
+++ b/engine/src/em-clipboard.cpp
@@ -1,0 +1,111 @@
+/* Copyright (C) 2015 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+
+#include "em-clipboard.h"
+
+
+MCRawClipboard* MCRawClipboard::CreateSystemClipboard()
+{
+    return new MCEmscriptenRawClipboard;
+}
+
+MCRawClipboard* MCRawClipboard::CreateSystemSelectionClipboard()
+{
+    return new MCEmscriptenRawClipboard;
+}
+
+MCRawClipboard* MCRawClipboard::CreateSystemDragboard()
+{
+    return new MCEmscriptenRawClipboard;
+}
+
+
+uindex_t MCEmscriptenRawClipboard::GetItemCount() const
+{
+    return 0;
+}
+
+const MCRawClipboardItem* MCEmscriptenRawClipboard::GetItemAtIndex(uindex_t p_index) const
+{
+    return NULL;
+}
+
+MCRawClipboardItem* MCEmscriptenRawClipboard::GetItemAtIndex(uindex_t p_index)
+{
+    return NULL;
+}
+
+void MCEmscriptenRawClipboard::Clear()
+{
+    ;
+}
+
+bool MCEmscriptenRawClipboard::IsOwned() const
+{
+    return false;
+}
+
+bool MCEmscriptenRawClipboard::IsExternalData() const
+{
+    return false;
+}
+
+MCRawClipboardItem* MCEmscriptenRawClipboard::CreateNewItem()
+{
+    return NULL;
+}
+
+bool MCEmscriptenRawClipboard::AddItem(MCRawClipboardItem* p_item)
+{
+    return false;
+}
+
+bool MCEmscriptenRawClipboard::PushUpdates()
+{
+    return false;
+}
+
+bool MCEmscriptenRawClipboard::PullUpdates()
+{
+    return false;
+}
+
+bool MCEmscriptenRawClipboard::FlushData()
+{
+    return false;
+}
+
+uindex_t MCEmscriptenRawClipboard::GetMaximumItemCount() const
+{
+    return 1;
+}
+
+MCStringRef MCEmscriptenRawClipboard::GetKnownTypeString(MCRawClipboardKnownType p_type) const
+{
+    return NULL;
+}
+
+MCDataRef MCEmscriptenRawClipboard::EncodeFileListForTransfer(MCStringRef p_file_list) const
+{
+    return NULL;
+}
+
+MCStringRef MCEmscriptenRawClipboard::DecodeTransferredFileList(MCDataRef p_data) const
+{
+    return NULL;
+}

--- a/engine/src/em-clipboard.h
+++ b/engine/src/em-clipboard.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2015 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+#ifndef EMSCRIPTEN_CLIPBOARD_H
+#define EMSCRIPTEN_CLIPBOARD_H
+
+
+#include "raw-clipboard.h"
+#include "foundation-auto.h"
+
+
+class MCEmscriptenRawClipboard :
+  public MCRawClipboard
+{
+public:
+    
+    // Inherited from MCRawClipboard
+    virtual uindex_t GetItemCount() const;
+    virtual const MCRawClipboardItem* GetItemAtIndex(uindex_t p_index) const;
+    virtual MCRawClipboardItem* GetItemAtIndex(uindex_t p_index);
+    virtual void Clear();
+    virtual bool IsOwned() const;
+    virtual bool IsExternalData() const;
+    virtual MCRawClipboardItem* CreateNewItem();
+    virtual bool AddItem(MCRawClipboardItem* p_item);
+    virtual bool PushUpdates();
+    virtual bool PullUpdates();
+    virtual bool FlushData();
+    virtual uindex_t GetMaximumItemCount() const;
+    virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
+    virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_list) const;
+    virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
+};
+
+
+#endif  /* ifndef EMSCRIPTEN_CLIPBOARD_H */


### PR DESCRIPTION
Adds a clipboard implementation for Emscripten that does nothing. This ensures that the required symbols are defined but doesn't provide any functionality.
