### PR TITLE
[[ Mac64 ]] Use the Cocoa methods for showing/hiding the menubar

### DIFF
--- a/engine/src/mac-menu.mm
+++ b/engine/src/mac-menu.mm
@@ -1000,12 +1000,12 @@ static void MCPlatformStopUsingMenuAsMenubar(MCPlatformMenuRef p_menu)
 
 void MCPlatformShowMenubar(void)
 {
-	ShowMenuBar();
+    [NSMenu setMenuBarVisible:YES];
 }
 
 void MCPlatformHideMenubar(void)
 {
-	HideMenuBar();
+    [NSMenu setMenuBarVisible:NO];
 }
 
 void MCPlatformSetMenubar(MCPlatformMenuRef p_menu)


### PR DESCRIPTION
The Carbon APIs have been removed in 64-bit.
