### PR TITLE
[[ Mac64 ]] Use the Cocoa API for enabling/disabling screen updates

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -691,7 +691,7 @@
 			'src/osxfield.cpp',
 			'src/osxfiles.cpp',
 			'src/osximage.cpp',
-			'src/osxmisc.cpp',
+			'src/osxmisc.mm',
 			'src/osxprinter.cpp',
 			'src/osxstack.cpp',
 			'src/osxtextlayout.cpp',

--- a/engine/src/osxmisc.mm
+++ b/engine/src/osxmisc.mm
@@ -35,6 +35,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "resolution.h"
 
+#import <AppKit/AppKit.h>
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  REFACTORED FROM TEXT.CPP
@@ -159,12 +161,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 void MCMacDisableScreenUpdates(void)
 {
-	DisableScreenUpdates();
+    NSDisableScreenUpdates();
 }
 
 void MCMacEnableScreenUpdates(void)
 {
-	EnableScreenUpdates();
+	NSEnableScreenUpdates();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/osxstack.cpp
+++ b/engine/src/osxstack.cpp
@@ -77,6 +77,9 @@ void MCStack::sethints(void)
 {
 }
 
+extern void MCMacDisableScreenUpdates();
+extern void MCMacEnableScreenUpdates();
+
 void MCStack::setgeom()
 {
 	//set stack(window) size or position from script
@@ -109,7 +112,7 @@ void MCStack::setgeom()
 	//   just disabling screen updates and enabling them between setting the frame and resizing
 	//   should be enough...
 	
-	DisableScreenUpdates();
+	MCMacDisableScreenUpdates();
 	
 	rect = view_setstackviewport(rect);
 	
@@ -120,7 +123,7 @@ void MCStack::setgeom()
 	if (t_old_rect.x != rect.x || t_old_rect.y != rect.y || t_old_rect.width != rect.width || t_old_rect.height != rect.height)
 		resize(t_old_rect.width, t_old_rect.height);
 	
-	EnableScreenUpdates();
+	MCMacEnableScreenUpdates();
 }
 
 // MW-2011-09-12: [[ MacScroll ]] This is called to apply the Mac menu scroll. It


### PR DESCRIPTION
The Carbon API has been removed in 64-bit.
