### PR TITLE
[[ BrowserWidget ]] Disable property load/save to fix crash

### DIFF
--- a/docs/notes/feature-browser_widget.md
+++ b/docs/notes/feature-browser_widget.md
@@ -23,3 +23,7 @@ To add a browser to your application, simply drag and drop the browser widget on
 * *browserNavigateBegin pUrl* - sent when the browser begins navigation to a new page.
 * *browserNavigateComplete pUrl* - sent when the browser successfully navigates to a new page.
 * *browserNavigateFailed pUrl, pError* - sent when the browser has failed to navigate to a new page.
+
+## Notes
+
+Browser widget properties are not currently saved, so will need to be set in a startup handler in order to initialize the browser as required. Property loading / saving will be implemented in a future release.

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -338,14 +338,17 @@ constant kPersistentProps is ["verticalScrollbarEnabled", "horizontalScrollbarEn
 --------------------------------------------------------------------------------
 
 public handler OnLoad(in pProperties as Array)
-	loadProperties(pProperties)
+	/* TODO - reinstate property load / save once cacheing is implemented */
+	// loadProperties(pProperties)
 end handler
 
 public handler OnSave(out rProperties as Array)
-	if mBrowser is not nothing then
-		put saveProperties() into mProperties
-	end if
-	put mProperties into rProperties
+	/* TODO - reinstate property load / save once cacheing is implemented */
+	// if mBrowser is not nothing then
+	// 	put saveProperties() into mProperties
+	// end if
+	// put mProperties into rProperties
+	put the empty array into rProperties
 end handler
 
 ----------


### PR DESCRIPTION
Certain browser properties require a runloop wait to fetch from the native browser control, which causes problems when saving. Temporarily disabling property saving to prevent this.
