### PR TITLE
Make RevBrowser compatible with 64-bit OSX

### DIFF
--- a/libexternal/include/revolution/external.h
+++ b/libexternal/include/revolution/external.h
@@ -1,6 +1,8 @@
 #ifndef __REVOLUTION_EXTERNAL__
 #define __REVOLUTION_EXTERNAL__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -492,9 +494,9 @@ extern void RemoveRunloopAction(MCRunloopActionRef p_action, int *r_success);
 extern void RunloopWait(int *r_success);
 
 // IM-2014-07-09: [[ Bug 12225 ]] Convert stack coords to logical window coords
-extern void StackToWindowRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success);
+extern void StackToWindowRect(uintptr_t p_win_id, MCRectangle32 *x_rect, int *r_success);
 // IM-2014-07-09: [[ Bug 12225 ]] Convert logical window coords to stack coords
-extern void WindowToStackRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success);
+extern void WindowToStackRect(uintptr_t p_win_id, MCRectangle32 *x_rect, int *r_success);
 
 // AL-2015-02-10: [[ SB Inclusions ]] Add wrappers for ExternalV0 module loading callbacks
 // SN-2015-02-24: [[ Broken Win Compilation ]] LoadModule is a Win32 API function...

--- a/libexternal/src/external.c
+++ b/libexternal/src/external.c
@@ -435,7 +435,7 @@ void RunloopWait(int *r_success)
 }
 
 // IM-2014-07-09: [[ Bug 12225 ]] Add coordinate conversion functions
-void StackToWindowRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success)
+void StackToWindowRect(uintptr_t p_win_id, MCRectangle32 *x_rect, int *r_success)
 {
     char *t_result;
     
@@ -445,12 +445,12 @@ void StackToWindowRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_succ
 		return;
 	}
     
-    t_result = (s_operations[OPERATION_STACK_TO_WINDOW_RECT])((const void*)(uintptr_t)p_win_id, x_rect, NULL, r_success);
+    t_result = (s_operations[OPERATION_STACK_TO_WINDOW_RECT])((const void*)p_win_id, x_rect, NULL, r_success);
 	if (t_result != NULL)
 		s_delete(t_result);
 }
 
-void WindowToStackRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_success)
+void WindowToStackRect(uintptr_t p_win_id, MCRectangle32 *x_rect, int *r_success)
 {
 	char *t_result;
     
@@ -460,7 +460,7 @@ void WindowToStackRect(unsigned int p_win_id, MCRectangle32 *x_rect, int *r_succ
 		return;
 	}
     
-	t_result = (s_operations[OPERATION_WINDOW_TO_STACK_RECT])((const void*)(uintptr_t)p_win_id, x_rect, NULL, r_success);
+	t_result = (s_operations[OPERATION_WINDOW_TO_STACK_RECT])((const void*)p_win_id, x_rect, NULL, r_success);
 	if (t_result != NULL)
 		s_delete(t_result);
 }

--- a/revbrowser/src/cefbrowser.cpp
+++ b/revbrowser/src/cefbrowser.cpp
@@ -1375,9 +1375,9 @@ void MCCefBrowserBase::SetHScroll(int p_hscroll_pixels)
 	MCCStringFree(t_scroll_script);
 }
 
-int MCCefBrowserBase::GetWindowId(void)
+uintptr_t MCCefBrowserBase::GetWindowId(void)
 {
-	int t_id;
+	uintptr_t t_id;
 	t_id = 0;
 
 	/* UNCHECKED */ PlatformGetWindowID(t_id);
@@ -1385,7 +1385,7 @@ int MCCefBrowserBase::GetWindowId(void)
 	return t_id;
 }
 
-void MCCefBrowserBase::SetWindowId(int p_new_id)
+void MCCefBrowserBase::SetWindowId(uintptr_t p_new_id)
 {
 	/* TODO - IMPLEMENT */
 }

--- a/revbrowser/src/cefbrowser.h
+++ b/revbrowser/src/cefbrowser.h
@@ -122,8 +122,8 @@ public:
 	virtual int GetHScroll(void);
 	virtual void SetHScroll(int p_hscroll_pixels);
 
-	virtual int GetWindowId(void);
-	virtual void SetWindowId(int p_new_id);
+	virtual uintptr_t GetWindowId(void);
+	virtual void SetWindowId(uintptr_t p_new_id);
 
 	virtual char *GetUserAgent(void);
 	virtual void SetUserAgent(const char *p_user_agent);
@@ -166,7 +166,7 @@ public:
 	virtual bool PlatformGetRect(int32_t &t_left, int32_t &t_top, int32_t &t_right, int32_t &t_bottom) = 0;
 	virtual bool PlatformSetRect(int32_t t_left, int32_t t_top, int32_t t_right, int32_t t_bottom) = 0;
 
-	virtual bool PlatformGetWindowID(int32_t &r_id) = 0;
+	virtual bool PlatformGetWindowID(uintptr_t &r_id) = 0;
 	
 	virtual bool PlatformGetAuthCredentials(bool p_is_proxy, const CefString &p_url, const CefString &p_realm, MCCefAuthScheme p_auth_scheme, CefString &r_user, CefString &r_password) = 0;
 

--- a/revbrowser/src/cefbrowser_lnx.cpp
+++ b/revbrowser/src/cefbrowser_lnx.cpp
@@ -41,7 +41,7 @@ public:
 
 	virtual bool PlatformGetRect(int32_t &r_left, int32_t &r_top, int32_t &r_right, int32_t &r_bottom);
 	virtual bool PlatformSetRect(int32_t p_left, int32_t p_top, int32_t p_right, int32_t p_bottom);
-	virtual bool PlatformGetWindowID(int32_t &r_id);
+	virtual bool PlatformGetWindowID(uintptr_t &r_id);
 
 	virtual bool PlatformGetAuthCredentials(bool p_is_proxy, const CefString &p_url, const CefString &p_realm, MCCefAuthScheme p_auth_scheme, CefString &r_user, CefString &r_password);
 
@@ -179,9 +179,9 @@ bool MCCefLinuxBrowser::PlatformSetVisible(bool p_visible)
 	return true;
 }
 
-bool MCCefLinuxBrowser::PlatformGetWindowID(int32_t &r_id)
+bool MCCefLinuxBrowser::PlatformGetWindowID(uintptr_t &r_id)
 {
-	r_id = (int32_t) m_parent_window;
+	r_id = uintptr_t(m_parent_window);
 	return true;
 }
 

--- a/revbrowser/src/cefbrowser_osx.mm
+++ b/revbrowser/src/cefbrowser_osx.mm
@@ -94,7 +94,7 @@ public:
 	
 	virtual bool PlatformGetRect(int32_t &r_left, int32_t &r_top, int32_t &r_right, int32_t &r_bottom);
 	virtual bool PlatformSetRect(int32_t p_left, int32_t p_top, int32_t p_right, int32_t p_bottom);
-	virtual bool PlatformGetWindowID(int32_t &r_id);
+	virtual bool PlatformGetWindowID(uintptr_t &r_id);
 	
 	virtual bool PlatformGetAuthCredentials(bool p_is_proxy, const CefString &p_url, const CefString &p_realm, MCCefAuthScheme p_auth_scheme, CefString &r_user, CefString &r_password);
 	
@@ -365,13 +365,13 @@ bool MCCefBrowserOSX::PlatformSetVisible(bool p_visible)
 	return true;
 }
 
-bool MCCefBrowserOSX::PlatformGetWindowID(int32_t &r_id)
+bool MCCefBrowserOSX::PlatformGetWindowID(uintptr_t &r_id)
 {
 	// IM-2014-09-16: [[ Bug 13286 ]] If we have no parent window then the browser has already closed
 	if (m_parent_window == nil)
 		return false;
 	
-	r_id = (int32_t) [[m_parent_window window] windowNumber];
+	r_id = uintptr_t([[m_parent_window window] windowNumber]);
 	
 	return true;
 }

--- a/revbrowser/src/cefbrowser_w32.cpp
+++ b/revbrowser/src/cefbrowser_w32.cpp
@@ -49,7 +49,7 @@ public:
 
 	virtual bool PlatformGetRect(int32_t &r_left, int32_t &r_top, int32_t &r_right, int32_t &r_bottom);
 	virtual bool PlatformSetRect(int32_t p_left, int32_t p_top, int32_t p_right, int32_t p_bottom);
-	virtual bool PlatformGetWindowID(int32_t &r_id);
+	virtual bool PlatformGetWindowID(uintptr_t &r_id);
 
 	virtual bool PlatformGetAuthCredentials(bool p_is_proxy, const CefString &p_url, const CefString &p_realm, MCCefAuthScheme p_auth_scheme, CefString &r_user, CefString &r_password);
 
@@ -274,7 +274,7 @@ bool MCCefWin32Browser::PlatformSetVisible(bool p_visible)
 	return true;
 }
 
-bool MCCefWin32Browser::PlatformGetWindowID(int32_t &r_id)
+bool MCCefWin32Browser::PlatformGetWindowID(uintptr_t &r_id)
 {
 	r_id = (int32_t) m_parent_window;
 

--- a/revbrowser/src/osxbrowser.h
+++ b/revbrowser/src/osxbrowser.h
@@ -35,7 +35,7 @@ public:
 	TAltBrowser(void);
 	virtual ~TAltBrowser(void);
 	
-	void init(unsigned int p_window_id);
+	void init(uintptr_t p_window_id);
  
  	virtual void SetVisible(bool p_visible);
 	virtual void SetBrowser(const char *p_type);
@@ -52,7 +52,7 @@ public:
 	virtual void SetInst(int p_id);
 	virtual void SetVScroll(int p_vscroll_pixels);
 	virtual void SetHScroll(int p_hscroll_pixels);
-	virtual void SetWindowId(int p_new_id);
+	virtual void SetWindowId(uintptr_t p_new_id);
 	virtual void SetUserAgent(const char *p_user_agent);
 
 	virtual bool GetBusy(void);
@@ -77,7 +77,7 @@ public:
 	virtual int GetFormattedHeight(void);
 	virtual int GetFormattedWidth(void);
 	virtual void GetFormattedRect(int& r_left, int& r_top, int& r_right, int& r_bottom);
-	virtual int GetWindowId(void);
+	virtual uintptr_t GetWindowId(void);
 	virtual char *GetUserAgent(void);
 
 	virtual char *ExecuteScript(const char *p_javascript_string);

--- a/revbrowser/src/osxbrowser.mm
+++ b/revbrowser/src/osxbrowser.mm
@@ -85,8 +85,8 @@ OpenDialogEventProc( const NavEventCallbackMessage callbackSelector,
 	DOMHTMLElement *m_previous_element;
 }
 
-- init;
-- dealloc;
+- (id)init;
+- (void)dealloc;
 
 - (void)setBrowser: (TAltBrowser *)inBrowser;
 - (HIObjectRef)hiobject;
@@ -95,7 +95,7 @@ OpenDialogEventProc( const NavEventCallbackMessage callbackSelector,
 
 @implementation WebBrowserAdapter
 
-- init
+- (id)init
 {
     self = [super init];
 	if ( self )
@@ -105,7 +105,7 @@ OpenDialogEventProc( const NavEventCallbackMessage callbackSelector,
     return self;
 }
 
-- dealloc
+- (void)dealloc
 {
 	if (m_previous_element != NULL)
 		[m_previous_element release];

--- a/revbrowser/src/osxbrowser.mm
+++ b/revbrowser/src/osxbrowser.mm
@@ -1273,12 +1273,12 @@ bool TAltBrowser::GetImage(void*& r_data, int& r_length)
 	return t_success;
 }
 
-int TAltBrowser::GetWindowId(void)
+uintptr_t TAltBrowser::GetWindowId(void)
 {
-	return (int)m_parent;
+	return uintptr_t(m_parent);
 }
 
-void TAltBrowser::SetWindowId(int p_new_id)
+void TAltBrowser::SetWindowId(uintptr_t p_new_id)
 {
 	NSWindow *t_window;
 	t_window = [NSApp windowWithWindowNumber: p_new_id];

--- a/revbrowser/src/osxbrowser.mm
+++ b/revbrowser/src/osxbrowser.mm
@@ -904,8 +904,8 @@ void TAltBrowser::SetRect(int p_left, int p_top, int p_right, int p_bottom)
 char * TAltBrowser::GetSelectedText()
 {
 	WebView*            nativeView;
-	long				SystemMinorVersion;
-	long				SystemBugFixVersion;
+	SInt32              SystemMinorVersion;
+	SInt32              SystemBugFixVersion;
 	
 	//Domranges only showed up in 10.3.9 and later
 	Gestalt( gestaltSystemVersionMinor, &SystemMinorVersion);
@@ -1011,7 +1011,7 @@ void TAltBrowser::Print()
 	NSView *			  pView;
 	WebFrameView *     pFrame;
 	WebPreferences *   thePrefs;
-	long				 SystemMinorVersion;
+	SInt32				 SystemMinorVersion;
 	
 	
 	nativeView = m_web_browser;

--- a/revbrowser/src/osxbrowser.mm
+++ b/revbrowser/src/osxbrowser.mm
@@ -16,6 +16,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "osxbrowser.h"
 
+#import <AppKit/AppKit.h>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 enum
@@ -73,11 +75,6 @@ static NSRect RectToNSRect(NSWindow *p_window, Rect p_rect)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
-void
-OpenDialogEventProc( const NavEventCallbackMessage callbackSelector, 
-									   NavCBRecPtr callbackParms, 
-									   NavCallBackUserData callbackUD );
 
 @interface WebBrowserAdapter : NSObject
 {
@@ -278,135 +275,59 @@ OpenDialogEventProc( const NavEventCallbackMessage callbackSelector,
 
 - (void)webView:(WebView *)sender runJavaScriptAlertPanelWithMessage:(NSString *)message
 {
-	AlertStdCFStringAlertParamRec		param;
-	DialogRef							alert;
-	DialogItemIndex						itemHit;
-
-	param.version 		= kStdCFStringAlertVersionOne;
-	param.movable 		= true;
-	param.helpButton 	= false;
-	param.defaultText 	= (CFStringRef)kAlertDefaultOKText;
-	param.cancelText 	= NULL;
-	param.otherText 	= NULL;
-	param.defaultButton = kAlertStdAlertOKButton;
-	param.cancelButton 	= 0;
-	param.position 		= kWindowDefaultPosition;
-	param.flags 		= 0;
-	
-	CreateStandardAlert( 0, (CFStringRef)message, NULL, NULL, &alert );
-        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-	RunStandardAlert( alert, NULL, &itemHit );
-        [pool release];
+    // Create and display an alert panel
+    NSAutoreleasePool* t_pool = [[NSAutoreleasePool alloc] init];
+    NSAlert* t_alert = [[[NSAlert alloc] init] autorelease];
+    [t_alert setMessageText:message];
+    [t_alert runModal];
+    [t_pool release];
 }
 
 - (BOOL)webView:(WebView *)sender runJavaScriptConfirmPanelWithMessage:(NSString *)message
 {
-	AlertStdCFStringAlertParamRec		param;
-	DialogRef							alert;
-	DialogItemIndex						itemHit;
-
-	param.version 		= kStdCFStringAlertVersionOne;
-	param.movable 		= true;
-	param.helpButton 	= false;
-	param.defaultText 	= (CFStringRef)kAlertDefaultOKText;
-	param.cancelText 	= (CFStringRef)kAlertDefaultCancelText;
-	param.otherText 	= NULL;
-	param.defaultButton = kAlertStdAlertOKButton;
-	param.cancelButton 	= kAlertStdAlertCancelButton;
-	param.position 		= kWindowDefaultPosition;
-	param.flags 		= 0;
-	
-	CreateStandardAlert( 0, (CFStringRef)message, NULL, &param, &alert );
-        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-	RunStandardAlert( alert, NULL, &itemHit );
-        [pool release];
-	
-	return (itemHit == kAlertStdAlertOKButton );
+    // Create and display an alert panel with OK/Cancel buttons
+    NSAutoreleasePool* t_pool = [[NSAutoreleasePool alloc] init];
+    NSAlert* t_alert = [[[NSAlert alloc] init] autorelease];
+    NSInteger t_response;
+    [t_alert setMessageText:message];
+    [t_alert addButtonWithTitle:@"Cancel"];
+    t_response = [t_alert runModal];
+    [t_pool release];
+    return (t_response == NSAlertFirstButtonReturn);
 }
 
 - (void)webView:(WebView *)sender runOpenPanelForFileButtonWithResultListener:(id<WebOpenPanelResultListener>)resultListener
 {
-	NavDialogCreationOptions	dialogOptions;
-	NavDialogRef				dialog;
-	OSStatus 					theErr = noErr;
-
-	NavGetDefaultDialogCreationOptions( &dialogOptions );
-
-	dialogOptions.modality = kWindowModalityAppModal;
-	dialogOptions.clientName = CFStringCreateWithPascalString( NULL, LMGetCurApName(), GetApplicationTextEncoding());
-	dialogOptions.optionFlags &= ~kNavAllowMultipleFiles;
-
-	theErr = NavCreateChooseFileDialog( &dialogOptions, NULL, OpenDialogEventProc, NULL, NULL, resultListener, &dialog );
-	if ( theErr == noErr )
-	{
-		theErr = NavDialogRun( dialog );
-	}
-	
-	if ( theErr != noErr )
-	{
-		NavDialogDispose( dialog );
-		[resultListener cancel];
-	}
+    // Create an open-file panel that allows a single file to be chosen
+    NSOpenPanel* t_dialog = [NSOpenPanel openPanel];
+    [t_dialog setCanChooseDirectories:NO];
+    [t_dialog setCanChooseFiles:YES];
+    [t_dialog setAllowsMultipleSelection:NO];
+    
+    // Run the dialogue
+    NSInteger t_result = [t_dialog runModal];
+    
+    // If the user didn't cancel it, get the selection
+    if (t_result == NSFileHandlingPanelOKButton)
+    {
+        // Get the URL that was selected and convert to a file path
+        NSURL* t_url = [[t_dialog URL] filePathURL];
+        NSString* t_path = [t_url path];
+        
+        // Send it to the listener
+        [resultListener chooseFilename:t_path];
+    }
+    else
+    {
+        // The dialogue was cancelled and no selection was made
+        [resultListener cancel];
+    }
+    
+    [t_dialog release];
 }
 
 @end
 
-void
-OpenDialogEventProc( const NavEventCallbackMessage callbackSelector, 
-									   NavCBRecPtr callbackParms, 
-									   NavCallBackUserData callbackUD )
-{
-	id<WebOpenPanelResultListener> 	resultListener = (id<WebOpenPanelResultListener>)callbackUD;
-
-	switch ( callbackSelector )
-	{	
-		case kNavCBUserAction:
-			if ( callbackParms->userAction == kNavUserActionChoose )
-			{
-				NavReplyRecord	reply;
-				OSStatus		status;
-				
-				status = NavDialogGetReply( callbackParms->context, &reply );
-				if ( status == noErr )
-				{
-					OSStatus		anErr;
-					AEKeyword		keywd;
-					DescType		returnedType;
-					Size			actualSize;
-					FSRef 			fileRef;
-					FSCatalogInfo	theCatInfo;
-					UInt8			path[1024];
-					CFStringRef		filename;
-					
-					anErr = AEGetNthPtr( &reply.selection, 1, typeFSRef, &keywd, &returnedType,
-									(Ptr)(&fileRef), sizeof( fileRef ), &actualSize );
-					require_noerr(anErr, AEGetNthPtr);
-			
-					anErr = FSGetCatalogInfo( &fileRef, kFSCatInfoFinderInfo, &theCatInfo, NULL, NULL, NULL );
-					require_noerr(anErr, FSGetCatalogInfo);
-					
-					FSRefMakePath( &fileRef, path, sizeof( path ) );
-					filename = CFStringCreateWithCString( NULL, (char *)path, kCFStringEncodingUTF8 );
-					[resultListener chooseFilename:(NSString*)filename];
-					CFRelease( filename );
-
-				AEGetNthPtr:
-				FSGetCatalogInfo:
-
-					NavDisposeReply( &reply );
-				}
-			}
-			else if ( callbackParms->userAction == kNavUserActionCancel )
-			{
-				[resultListener cancel];
-			}
-			break;
-
-		case kNavCBTerminate:
-			NavDialogDispose( callbackParms->context );
-			break;
-	}
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -487,10 +408,8 @@ TAltBrowser::~TAltBrowser()
 
 @end
 
-void TAltBrowser::init(unsigned int p_window)
+void TAltBrowser::init(uintptr_t p_window)
 {
-	WebInitForCarbon();
-	
 	m_parent = p_window;
 	
 	NSWindow *t_window;

--- a/revbrowser/src/revbrowser.h
+++ b/revbrowser/src/revbrowser.h
@@ -39,7 +39,7 @@ public:
 	virtual void SetInst(int p_id) = 0;
 	virtual void SetVScroll(int p_vscroll_pixels) = 0;
 	virtual void SetHScroll(int p_hscroll_pixels) = 0;
-	virtual void SetWindowId(int p_new_id) = 0;
+	virtual void SetWindowId(uintptr_t p_new_id) = 0;
 	virtual void SetUserAgent(const char *p_user_agent) = 0;
 
 	virtual bool GetBusy(void) = 0;
@@ -64,7 +64,7 @@ public:
 	virtual int GetFormattedHeight(void) = 0;
 	virtual int GetFormattedWidth(void) = 0;
 	virtual void GetFormattedRect(int& r_left, int& r_top, int& r_right, int& r_bottom) = 0;
-	virtual int GetWindowId(void) = 0;
+	virtual uintptr_t GetWindowId(void) = 0;
 	virtual char *GetUserAgent(void) = 0;
 
 	virtual char *ExecuteScript(const char *p_javascript_string) = 0;

--- a/revbrowser/src/w32browser.cpp
+++ b/revbrowser/src/w32browser.cpp
@@ -1342,12 +1342,12 @@ bool CWebBrowser::GetImage(void*& r_data, int& r_length)
 	return t_success;
 }
 
-int CWebBrowser::GetWindowId(void)
+uintptr_t CWebBrowser::GetWindowId(void)
 {
-	return (int)hostwindow;
+	return uintptr_t(hostwindow);
 }
 
-void CWebBrowser::SetWindowId(int p_new_id)
+void CWebBrowser::SetWindowId(uintptr_t p_new_id)
 {
 	HWND t_new_window;
 	t_new_window = (HWND)p_new_id;

--- a/revbrowser/src/w32browser.h
+++ b/revbrowser/src/w32browser.h
@@ -125,7 +125,7 @@ public:
 	int GetFormattedHeight(void);
 	int GetFormattedWidth(void);
 	void GetFormattedRect(int &r_left, int &t_top, int &r_right, int &r_bottom);
-	int GetWindowId(void);
+	uintptr_t GetWindowId(void);
 	char *GetUserAgent(void);
 
 	void SetScale(bool willscale);
@@ -143,7 +143,7 @@ public:
 	void SetInst(int linst);
 	void SetVScroll(int p_vscroll_pixels);
 	void SetHScroll(int p_hscroll_pixels);
-	void SetWindowId(int id);
+	void SetWindowId(uintptr_t id);
 	void SetUserAgent(const char *p_user_agent);
 
 	virtual void AddJavaScriptHandler(const char *p_handler);

--- a/revvideograbber/src/qtvideograbber.h
+++ b/revvideograbber/src/qtvideograbber.h
@@ -19,6 +19,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define QTVIDEO_H
 #include "videograbber.h"
 #ifdef WIN32
+// This is really nasty but required to avoid breaking revvideograbber for Windows:
+//    The QuickTime SDK includes a bundled stdint.h header that conflicts with the
+//    version supplied with VS2010 and later, so we need to prevent its inclusion.
+#define _STDINT_H
 #include <windows.h>
 #include <QTML.h>
 #include <QuickTimeComponents.h>


### PR DESCRIPTION
The CEF component of RevBrowser does not yet work in 64-bit builds as we don't currently have a 64-bit libCEF prebuilt.
