### PR TITLE
[[ Bug 16299 ]] Add possibility to disable ATS in the S/B

### DIFF
--- a/docs/notes/bugfix-16299.md
+++ b/docs/notes/bugfix-16299.md
@@ -1,0 +1,1 @@
+# Unable to mobileControlSet URL with http:// URL on iOS 9.1 Simulators and Devices

--- a/docs/notes/feature-ats.md
+++ b/docs/notes/feature-ats.md
@@ -1,0 +1,9 @@
+# Application Transport Security (ATS)
+
+Apple introduced in iOS SDK 9.0 the Application Transport Security which 'enforces best practices in the secure connections between an app and its back end' (see [the technical notice](https://developer.apple.com/library/prerelease/ios/releasenotes/General/WhatsNewIniOS/Articles/iOS9.html#//apple_ref/doc/uid/TP40016198-SW14)).
+
+The most noticeable effect on applications created using Xcode 7.0 (and following versions) is that URLs using *HTTP* protocol are no longer considered valid, and the iOS engine will not process them; only URLs using *HTTPS* are deemed secure enough, and will be loaded.
+
+This means that `nativeBrowser` cannot load a webpage such as [http LiveCode](http://www.livecode.com), but will happily load [https LiveCode](https://www.livecode.com). The same applies to the LiveCode function *url*.
+
+To allow our users to create apps letting Web navigation accept unsecure webpages, we added a checkbox **Disable ATS** in the Standalone Settings for iOS, in the Requirements and Restrictions section. If you check this box, then *ATS* will be disabled, and the application can load Webpages using *HTTP* (as it used to do).

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -62,6 +62,7 @@
 	<array>
 		${DEVICE_SUPPORT}
 	</array>
+	${DISABLE_ATS}
 	<key>UIRequiredDeviceCapabilities</key>
 	<dict>
 		${DEVICE_CAPABILITY}

--- a/engine/rsrc/mobile-disable-ats-template.plist
+++ b/engine/rsrc/mobile-disable-ats-template.plist
@@ -1,0 +1,4 @@
+<key>NSAppTransportSecurity</key>
+         <dict>
+              <key>NSAllowsArbitraryLoads</key><true/>
+         </dict>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -21,6 +21,7 @@
 	<array>
 		${BUNDLE_ICONS}
 	</array>
+	${DISABLE_ATS}
 	<key>CFBundleDisplayName</key>
 		${BUNDLE_DISPLAY_NAME_SUPPORT}
 	<key>MinimumOSVersion</key>

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1197,6 +1197,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    ----------
    
    local tDisplayName, tMinimumOS, tDeviceFamily, tRequiredCapabilities, tPersistentWifi, tExitsOnSuspend
+   local tDisableATS
    local tFileSharing, tPrerenderedIcon, tBackGroundAudio
    put pSettings["ios,display name"] into tDisplayName
    put pSettings["ios,minimum version"] into tMinimumOS
@@ -1235,6 +1236,12 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    else -- false or empty
       put "true" into tExitsOnSuspend
    end if
+   
+   // SN-2015-02-11: [[ Bug 16299 ]] Add ${DISABLE_ATS} in the Plist template
+   if pSettings["ios,disable ATS"] then
+      put URL("binfile:" & mapFilePath("DisableATS.plist")) into tDisableATS
+   end if
+   
    
    ----------
    -- PM-2015-02-17: [[ Bug 14482 ]] Added a new "solid" statusbarstyle
@@ -1314,6 +1321,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    -- SN-2015-02-02: [[ Bug 14422 ]] We now have minimum version depending on the arch.
    replace "${MINIMUM_OS_SUPPORT}" with "<string>" & tMinimumOSByArch["i386"] & "</string>" in pPlist
    replace "${CUSTOM_FONTS}" with tCustomFonts in pPlist
+   replace "${DISABLE_ATS}" with tDisableATS in pPlist
    
    get empty
    repeat for each item tItem in tDeviceFamily
@@ -1634,6 +1642,9 @@ function mapFilePath pPath
          break
       case "BetaReportEntitlement.xcent"
          put tRepo & slash & "engine/rsrc/template-beta-report-entitlement.xcent" into tPath
+         break
+      case "DisableATS.plist"
+         put tRepo & slash & "engine/rsrc/mobile-disable-ats-template.plist" into tPath
          break
       case "RemoteNotificationSettings.plist"
          put tRepo & slash & "engine/rsrc/mobile-remote-notification-template.plist" into tPath


### PR DESCRIPTION
ATS (Application Transport Security), added in iOS SDK 9.0, won't let you load unsecure, HTTP URLs unless
specified in the Plist file.
A checkbox has been added in the S/B to let users choose whether that rules should be respected (the default
is to comply to the new Apple rule)
