### PR TITLE
[[ Mac64 ]] -[NSWindow backingScaleFactor] sometimes returns NaN

### DIFF
--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -106,6 +106,18 @@
 						],
 					},
 				],
+				[
+					'OS == "mac"',
+					{
+						'defines':
+						[
+							# We want to use the new prototypes for the Objective-C
+							# dispatch methods as it helps catch certain errors at
+							# compile time rather than run time.
+							'OBJC_OLD_DISPATCH_PROTOTYPES=0',
+						],
+					},
+				],
 			],
 			
 			'link_settings':

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -1167,7 +1167,7 @@ void MCPlatformGetScreenPixelScale(uindex_t p_index, MCGFloat& r_scale)
 	NSScreen *t_screen;
 	t_screen = [[NSScreen screens] objectAtIndex: p_index];
 	if ([t_screen respondsToSelector: @selector(backingScaleFactor)])
-		r_scale = objc_msgSend_fpret(t_screen, @selector(backingScaleFactor));
+		r_scale = objc_msgSend_fpret_type<CGFloat>(t_screen, @selector(backingScaleFactor));
 	else
 		r_scale = 1.0f;
 }

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -665,4 +665,20 @@ bool MCMacPlatformIsEventCheckingEnabled(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// The function pointer for objc_msgSend_fpret needs to be cast in order
+// to get the correct return type, otherwise we can get strange results
+// on x86_64 because "long double" return values are returned in
+// different registers to "float" or "double".
+extern "C" void objc_msgSend_fpret(void);
+template <class R, class... Types> R objc_msgSend_fpret_type(id p_id, SEL p_sel, Types... p_params)
+{
+    // Cast the obj_msgSend_fpret function to the correct type
+    R (*t_send)(id, SEL, ...) = reinterpret_cast<R (*)(id, SEL, ...)> (&objc_msgSend_fpret);
+    
+    // Perform the call
+    return t_send(p_id, p_sel, p_params...);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 #endif

--- a/engine/src/mac-surface.mm
+++ b/engine/src/mac-surface.mm
@@ -328,11 +328,7 @@ MCGFloat MCMacPlatformSurface::GetBackingScaleFactor(void)
 {
 	if ([m_window -> GetHandle() respondsToSelector: @selector(backingScaleFactor)])
     {
-        // This property seems to sometimes return NaN on 64-bit
-        double t_value = objc_msgSend_fpret(m_window -> GetHandle(), @selector(backingScaleFactor));
-        if (t_value != t_value)
-            t_value = 1.0;
-        return t_value;
+        return objc_msgSend_fpret_type<CGFloat>(m_window -> GetHandle(), @selector(backingScaleFactor));
     }
 	return 1.0f;
 }

--- a/engine/src/mac-surface.mm
+++ b/engine/src/mac-surface.mm
@@ -327,7 +327,13 @@ void MCMacPlatformSurface::Unlock(void)
 MCGFloat MCMacPlatformSurface::GetBackingScaleFactor(void)
 {
 	if ([m_window -> GetHandle() respondsToSelector: @selector(backingScaleFactor)])
-		return objc_msgSend_fpret(m_window -> GetHandle(), @selector(backingScaleFactor));
+    {
+        // This property seems to sometimes return NaN on 64-bit
+        double t_value = objc_msgSend_fpret(m_window -> GetHandle(), @selector(backingScaleFactor));
+        if (t_value != t_value)
+            t_value = 1.0;
+        return t_value;
+    }
 	return 1.0f;
 }
 


### PR DESCRIPTION
I'm not entirely happy with having to do this as I'm surprised that NaN can ever be returned. Maybe we're doing something strange?
