### PR TITLE
[[ Mac64 ]] Convert an OSX-specific routine to use CGFloat instead of float

### DIFF
--- a/engine/src/color.h
+++ b/engine/src/color.h
@@ -51,19 +51,6 @@ inline MCColorVector3 MCColorVector3Make(MCGFloat x, MCGFloat y, MCGFloat z)
 	return t_vector;
 }
 
-inline void MCColorMatrix3x3GetElements(const MCColorMatrix3x3 &p_matrix, MCGFloat r_values[9])
-{
-	r_values[0] = p_matrix.m[0][0];
-	r_values[1] = p_matrix.m[1][0];
-	r_values[2] = p_matrix.m[2][0];
-	r_values[3] = p_matrix.m[0][1];
-	r_values[4] = p_matrix.m[1][1];
-	r_values[5] = p_matrix.m[2][1];
-	r_values[6] = p_matrix.m[0][2];
-	r_values[7] = p_matrix.m[1][2];
-	r_values[8] = p_matrix.m[2][2];
-}
-
 //////////
 
 bool MCColorTransformLinearRGBToXYZ(const MCColorVector2 &p_white, const MCColorVector2 &p_red, const MCColorVector2 &p_green, const MCColorVector2 &p_blue,

--- a/engine/src/mac-color.mm
+++ b/engine/src/mac-color.mm
@@ -40,6 +40,21 @@ struct MCPlatformColorTransform
 
 ////////////////////////////////////////////////////////////////////////////////
 
+inline void MCColorMatrix3x3GetElements(const MCColorMatrix3x3 &p_matrix, CGFloat r_values[9])
+{
+    r_values[0] = p_matrix.m[0][0];
+    r_values[1] = p_matrix.m[1][0];
+    r_values[2] = p_matrix.m[2][0];
+    r_values[3] = p_matrix.m[0][1];
+    r_values[4] = p_matrix.m[1][1];
+    r_values[5] = p_matrix.m[2][1];
+    r_values[6] = p_matrix.m[0][2];
+    r_values[7] = p_matrix.m[1][2];
+    r_values[8] = p_matrix.m[2][2];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void MCPlatformCreateColorTransform(const MCColorSpaceInfo& p_info, MCPlatformColorTransformRef& r_transform)
 {
 	bool t_success;


### PR DESCRIPTION
They are different types in the 64-bit world.
