### PR TITLE
[emscripten] Use correct deployment files on LiveCode Business

### DIFF
--- a/ide-support/revsaveasemscriptenstandalone.livecodescript
+++ b/ide-support/revsaveasemscriptenstandalone.livecodescript
@@ -512,10 +512,10 @@ private function getEngineFiles
    local tFiles
    
    -- Engine JavaScript
-   put mapBinPath("standalone-" & revLicenseType() & "-" & the version & ".js") into tFiles[1]
+   put mapBinPath("standalone-" & getEngineType() & "-" & the version & ".js") into tFiles[1]
    
    -- Memory initialisation file
-   put mapBinPath("standalone-" & revLicenseType() & "-" & the version & ".html.mem") into tFiles[2]
+   put mapBinPath("standalone-" & getEngineType() & "-" & the version & ".html.mem") into tFiles[2]
    
    return tFiles
 end getEngineFiles
@@ -539,7 +539,7 @@ end getStandaloneTemplateFiles
 -- This has some standalone-dependent JavaScript substituted into it
 -- to instantiate the engine.
 private function getHtmlTemplateFile
-   return mapBinPath("standalone-" & revLicenseType() & "-" & the version & ".html")
+   return mapBinPath("standalone-" & getEngineType() & "-" & the version & ".html")
 end getHtmlTemplateFile
 
 -- Get the filename of the Emscripten standalone startup script-only
@@ -602,3 +602,12 @@ private function isCommercialDeployment
       return true
    end if
 end isCommercialDeployment
+
+-- Get the engine type string ("commercial" or "community")
+private function getEngineType
+   if isCommercialDeployment() then
+      return "commercial"
+   else
+      return "community"
+   end if
+end getEngineType


### PR DESCRIPTION
In LiveCode Business, `revLicenseType()` returns "professional",
but we need to look for emscripten engine files that use the
"commercial" string.
