### PR TITLE
[[ Bug 16239 ]] iOS Native Scrollers don't dispatch touches properly

### DIFF
--- a/docs/notes/bugfix-16239.md
+++ b/docs/notes/bugfix-16239.md
@@ -1,0 +1,1 @@
+# Touch interaction with iOS native scrollers doesn't work until after the scroller has been scrolled.

--- a/engine/src/mbliphonecontrol.h
+++ b/engine/src/mbliphonecontrol.h
@@ -42,7 +42,7 @@ public:
     virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
     virtual const MCNativeControlActionTable *getactiontable(void) const { return &kActionTable; }
     
-    void SetRect(MCExecContext& ctxt, MCRectangle p_rect);
+    virtual void SetRect(MCExecContext& ctxt, MCRectangle p_rect);
     void SetVisible(MCExecContext& ctxt, bool p_visible);
     void SetOpaque(MCExecContext& ctxt, bool p_opaque);
     void SetAlpha(MCExecContext& ctxt, uinteger_t p_alpha);


### PR DESCRIPTION
Due to an error in refactoring (virtual method in subclass not virtual
in superclass) the 'forwarder' was not having its bounds updated on
setting the rect property.
