### PR TITLE
libfoundation: Fix finding single-character needle in string.

### DIFF
--- a/tests/lcb/stdlib/char.lcb
+++ b/tests/lcb/stdlib/char.lcb
@@ -304,6 +304,11 @@ public handler TestOffset()
 	test "index" when the index of "x" in ".xx." is 2
 end handler
 
+public handler TestOffsetUnicode()
+	test "offset (native, BMP)" when the index of " " in "\u{2192} right" is 2
+	test "offset (BMP, BMP)" when the index of "\u{2192}" in "\u{2192} right" is 1
+end handler
+
 public handler TestOffsetAfter()
 	-- Only test single-character needles for now
 	test "offset after (single, +ve)" when the offset of "x" after 1 in "x.xx." is 3


### PR DESCRIPTION
In the single-character needle case, `MCUnicodeFirstIndexOf()` was
dereferencing 1-element `char_t` or `unichar_t` array as a
`codepoint_t`, resulting in a 2- or 3-byte buffer overrun.

In addition, the single character codepath is only valid if the the
needle is (1) a native ASCII character or (2) a BMP Unicode character.
This wasn't being tested correctly.
