### PR TITLE
[[ Bug 16162 ]] infinity is not always infinity

### DIFF
--- a/docs/notes/bugfix-16162.md
+++ b/docs/notes/bugfix-16162.md
@@ -1,0 +1,1 @@
+# "infinity" is not always equal to "infinity"

--- a/engine/src/exec-logic.cpp
+++ b/engine/src/exec-logic.cpp
@@ -126,6 +126,12 @@ static bool MCLogicIsEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef 
     
     if (t_left_converted && t_right_converted)
     {
+        if (t_left_num == t_right_num)
+        {
+            r_result = true;
+            return true;
+        }
+        
         real64_t t_dleft, t_dright;
         t_dleft = fabs(t_left_num);
         t_dright = fabs(t_right_num);
@@ -180,6 +186,12 @@ static bool MCLogicCompareTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef 
 		
 	if (t_left_converted && t_right_converted)
 	{
+        if (t_left_num == t_right_num)
+        {
+            r_result = 0;
+            return true;
+        }
+        
 		real64_t t_dleft, t_dright;
 		t_dleft = fabs(t_left_num);
 		t_dright = fabs(t_right_num);

--- a/tests/lcs/core/logic/infinity.livecodescript
+++ b/tests/lcs/core/logic/infinity.livecodescript
@@ -1,0 +1,49 @@
+script "CoreLogicInfinity"
+/*
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestInfinityComparisons
+	TestAssert "strconst(infinity) is strconst(infinity)", "infinity" is "infinity"
+	TestAssert "string(infinity) is strconst(infinity)", ("infinity" & empty) is "infinity"
+	TestAssert "strconst(infinity) is string(infinity)", "infinity" is ("infinity" & empty)
+	TestAssert "strconst(Infinity) is strconst(infinity)", "Infinity" is "infinity"
+	TestAssert "string(Infinity) is strconst(infinity)", ("Infinity" & empty) is "infinity"
+	TestAssert "strconst(Infinity) is string(infinity)", "Infinity" is ("infinity" & empty)
+	TestAssert "strconst(infinity) is strconst(Infinity)", "infinity" is "Infinity"
+	TestAssert "string(infinity) is strconst(Infinity)", ("infinity" & empty) is "Infinity"
+	TestAssert "strconst(infinity) is string(Infinity)", "infinity" is ("Infinity" & empty)
+
+	TestAssert "strconst(infinity) <= strconst(infinity)", "infinity" <= "infinity"
+	TestAssert "string(infinity) <= strconst(infinity)", ("infinity" & empty) <= "infinity"
+	TestAssert "strconst(infinity) <= string(infinity)", "infinity" <= ("infinity" & empty)
+	TestAssert "strconst(Infinity) <= strconst(infinity)", "Infinity" <= "infinity"
+	TestAssert "string(Infinity) <= strconst(infinity)", ("Infinity" & empty) <= "infinity"
+	TestAssert "strconst(Infinity) <= string(infinity)", "Infinity" <= ("infinity" & empty)
+	TestAssert "strconst(infinity) <= strconst(Infinity)", "infinity" <= "Infinity"
+	TestAssert "string(infinity) <= strconst(Infinity)", ("infinity" & empty) <= "Infinity"
+	TestAssert "strconst(infinity) <= string(Infinity)", "infinity" <= ("Infinity" & empty)
+
+	TestAssert "strconst(infinity) >= strconst(infinity)", "infinity" >= "infinity"
+	TestAssert "string(infinity) >= strconst(infinity)", ("infinity" & empty) >= "infinity"
+	TestAssert "strconst(infinity) >= string(infinity)", "infinity" >= ("infinity" & empty)
+	TestAssert "strconst(Infinity) >= strconst(infinity)", "Infinity" >= "infinity"
+	TestAssert "string(Infinity) >= strconst(infinity)", ("Infinity" & empty) >= "infinity"
+	TestAssert "strconst(Infinity) >= string(infinity)", "Infinity" >= ("infinity" & empty)
+	TestAssert "strconst(infinity) >= strconst(Infinity)", "infinity" >= "Infinity"
+	TestAssert "string(infinity) >= strconst(Infinity)", ("infinity" & empty) >= "Infinity"
+	TestAssert "strconst(infinity) >= string(Infinity)", "infinity" >= ("Infinity" & empty)
+end TestInfinityComparisons

--- a/tests/lcs/core/logic/infinity.livecodescript
+++ b/tests/lcs/core/logic/infinity.livecodescript
@@ -1,6 +1,6 @@
 script "CoreLogicInfinity"
 /*
-Copyright (C) 2015 Runtime Revolution Ltd.
+Copyright (C) 2015 LiveCode Ltd.
 
 This file is part of LiveCode.
 


### PR DESCRIPTION
The engine will convert "infinity" to +inf (the actual number representing
infinity). However, the CompareTo and EqualTo operators do the comparisons in
a way which means +inf will not compare as expected with +inf. To fix this
a direct check for equality has been put into both operators.
