### PR TITLE
[emscripten] Tweak overlay foreground colour.

### DIFF
--- a/engine/src/em-preamble-overlay.js
+++ b/engine/src/em-preamble-overlay.js
@@ -100,6 +100,7 @@ Module['preRun'].push(function() {
 	overlay.style.position = 'absolute';
 	overlay.style.right = '1px';
 	overlay.style.bottom = '1px';
+	overlay.style.color = '#000000';
 	overlay.style.backgroundColor = '#FFFFFF';
 	overlay.style.border = '1px solid #AED036';
 	overlay.style.borderRadius = '5px';


### PR DESCRIPTION
Ensure that the overlay text is visible even if the page's foreground
colour is set to white.
