### PR TITLE
[[ Bug 16354 ]] Fix crash when relayering widgets

### DIFF
--- a/docs/notes/bugfix-16354.md
+++ b/docs/notes/bugfix-16354.md
@@ -1,0 +1,1 @@
+# Crash when adding browser widget on second card 

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -2858,10 +2858,7 @@ void MCCard::erasefocus(MCObject *p_object)
 MCObjptr *MCCard::newcontrol(MCControl *cptr, Boolean needredraw)
 {
 	if (opened)
-	{
 		cptr->setparent(this);
-		cptr->open();
-	}
 
 	MCObjptr *newptr = new MCObjptr;
 	newptr->setparent(this);
@@ -2871,6 +2868,9 @@ MCObjptr *MCCard::newcontrol(MCControl *cptr, Boolean needredraw)
 	// MW-2011-08-19: [[ Layers ]] Notify the stack that a layer may have ben inserted.
 	layer_added(cptr, objptrs != newptr ? newptr -> prev() : nil, nil);
 
+	if (opened)
+		cptr->open();
+	
 	return newptr;
 }
 

--- a/engine/src/native-layer.cpp
+++ b/engine/src/native-layer.cpp
@@ -70,48 +70,54 @@ bool MCNativeLayer::ShouldShowWidget(MCWidget *p_widget)
 
 MCWidget* MCNativeLayer::findNextLayerAbove(MCWidget* p_widget)
 {
-    MCWidget *t_before;
-    MCControl *t_control;
-    t_before = NULL;
-    t_control = p_widget->next();
-    while (t_control != p_widget && t_control != p_widget->getcard()->getobjptrs()->getref())
-    {
-        // We are only looking for widgets with a native layer
-        if (t_control->gettype() == CT_WIDGET && reinterpret_cast<MCWidget*>(t_control)->getNativeLayer() != nil)
-        {
-            // Found what we are looking for
-            t_before = reinterpret_cast<MCWidget*>(t_control);
-            break;
-        }
-        
-        // Next control
-        t_control = t_control->next();
-    }
-    
-    return t_before;
+	MCObjptr *t_first_object;
+	t_first_object = p_widget->getcard()->getobjptrs();
+	
+	MCObjptr *t_object;
+	t_object = p_widget->getcard()->getobjptrforcontrol(p_widget)->next();
+	
+	while (t_object != t_first_object)
+	{
+		MCControl *t_control;
+		t_control = t_object->getref();
+		// We are only looking for widgets with a native layer
+		if (t_control->gettype() == CT_WIDGET && reinterpret_cast<MCWidget*>(t_control)->getNativeLayer() != nil)
+		{
+			// Found what we are looking for
+			return reinterpret_cast<MCWidget*>(t_control);
+		}
+		
+		// Next control
+		t_object = t_object->next();
+	}
+	
+	return nil;
 }
 
 MCWidget* MCNativeLayer::findNextLayerBelow(MCWidget* p_widget)
 {
-    MCWidget *t_after;
-    MCControl *t_control;
-    t_after = NULL;
-    t_control = p_widget->prev();
-    while (t_control != p_widget && t_control != p_widget->getcard()->getobjptrs()->getref()->prev())
-    {
-        // We are only looking for widgets with a native layer
-        if (t_control->gettype() == CT_WIDGET && reinterpret_cast<MCWidget*>(t_control)->getNativeLayer() != nil)
-        {
-            // Found what we are looking for
-            t_after = reinterpret_cast<MCWidget*>(t_control);
-            break;
-        }
-        
-        // Next control
-        t_control = t_control->next();
-    }
-    
-    return t_after;
+	MCObjptr *t_last_object;
+	t_last_object = p_widget->getcard()->getobjptrs()->prev();
+	
+	MCObjptr *t_object;
+	t_object = p_widget->getcard()->getobjptrforcontrol(p_widget)->prev();
+	
+	while (t_object != t_last_object)
+	{
+		MCControl *t_control;
+		t_control = t_object->getref();
+		// We are only looking for widgets with a native layer
+		if (t_control->gettype() == CT_WIDGET && reinterpret_cast<MCWidget*>(t_control)->getNativeLayer() != nil)
+		{
+			// Found what we are looking for
+			return reinterpret_cast<MCWidget*>(t_control);
+		}
+		
+		// Previous control
+		t_object = t_object->prev();
+	}
+	
+	return nil;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
[[ Bug 16354 ]] Redo widget relayering to only look at objects on the same card.
