### PR TITLE
MCObject::load() shouldn't be called for MCStack instances

### DIFF
--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -743,6 +743,7 @@ public:
 	void getstackfile(MCStringRef p_name, MCStringRef &r_name);
 	void setfilename(MCStringRef f);
 
+	virtual IO_stat load(IO_handle stream, uint32_t version); /* Don't use this */
 	virtual IO_stat load(IO_handle stream, uint32_t version, uint1 type);
 	IO_stat load_stack(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -136,6 +136,11 @@ IO_stat MCStack::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 	return t_stat;
 }
 
+IO_stat MCStack::load(IO_handle stream, uint32_t version)
+{
+	MCUnreachableReturn(IO_ERROR);
+}
+
 IO_stat MCStack::load(IO_handle stream, uint32_t version, uint1 type)
 {
 	IO_stat stat;


### PR DESCRIPTION
When loading a stack, the type byte needs to be passed to
`MCStack::load()` in order to allow the correct stack loading mode to
be selected.  All other objects can be fully loaded without the type
byte.

Previously, only a 3-argument variant of `load()` was defined in
`MCStack`, which meant that it was possible to (incorrectly) call the
base class (2-argument) implementation of `MCObject::load()` by
upcasting an `MCStack` pointer.  This was flagged up by the emscripten
C++ compiler with a "overloaded-virtual" warning.

This patch explicitly overrides `MCObject::load()` in `MCStack` with
an implementation that indicates a programming error.
