### PR TITLE
[Bug 16368] Make sure hiding an android player hides the controller, if any.

### DIFF
--- a/docs/notes/bugfix-16368.md
+++ b/docs/notes/bugfix-16368.md
@@ -1,0 +1,1 @@
+#   Hiding a mobile player does not automatically hide the controller on Android

--- a/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
@@ -308,6 +308,17 @@ public class ExtVideoView extends SurfaceView implements MediaPlayerControl {
             return;
         }
     }
+	
+	// PM-2015-11-05: [[ Bug 16368 ]] Toggling the visibility of the android player should show/hide the controller (if any)
+	public void setControllerVisible(boolean p_visible)
+	{
+		if (mMediaController != null ){
+			if (p_visible)
+				mMediaController.show(0);
+			else
+				mMediaController.hide();
+		}
+	}
 
     public void setMediaController(MediaController controller) {
         if (mMediaController != null) {

--- a/engine/src/java/com/runrev/android/nativecontrol/VideoControl.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/VideoControl.java
@@ -163,7 +163,15 @@ public class VideoControl extends NativeControl
         else
             m_video_view.setMediaController(null);
     }
-    
+	
+	// PM-2015-11-05: [[ Bug 16368 ]] Toggling the visibility of the android player should show/hide the controller (if any)
+	// Override setVisible() of NativeControl 
+	public void setVisible(boolean p_visible)
+	{
+		m_video_view.setControllerVisible(p_visible);
+		super.setVisible(p_visible);
+	}
+	
     public void setCurrentTime(int msec)
     {
         m_video_view.seekTo(msec);


### PR DESCRIPTION
Similarly, showing the player should show the controller, if showController==true
