### PR TITLE
[[ Bug 16284 ]] Fix warning filtering when linking with Xcode for iOS

### DIFF
--- a/docs/notes/bugfix-16284.md
+++ b/docs/notes/bugfix-16284.md
@@ -1,0 +1,1 @@
+# First iOS standalone build with Xcode 7.0/7.1 causes "linking for arm" error

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -72,7 +72,8 @@ private function linkingIsValid pLinkingOutput
    repeat for each line tLine in pLinkingOutput
       // Discard Xcode 7 new warnings like:
       // ld: warning: object file (<path_to_exe) was built for newer iOS version (9.0) than being linked (7.0)
-      if not matchtext(tLine, "ld: warning: object file \(.*\) was built for newer iOS version \(.*\) than being linked \(.*\)") then
+      // On the first use of Xcode 7.0 for deployment, 'ld: warning: ' is duplicated...
+      if not matchtext(tLine, "(ld: warning: )+object file \(.*\) was built for newer iOS version \(.*\) than being linked \(.*\)") then
          return false
       end if
    end repeat


### PR DESCRIPTION
(cherry picked from commit cda73ec0c1debdfd166774c2ef866b1d1bffab5f)
