### PR TITLE
build: Automatically choose "default iOS version"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,9 +167,9 @@ check-ios-iphonesimulator5.1:
 	@echo "Skipping iOS simulator 5.1 (no longer supported)"
 
 # Provide some synonyms for "latest iOS SDK"
-$(addsuffix -ios-iphoneos,all config compile check): %: %8.4
+$(addsuffix -ios-iphoneos,all config compile check): %: %$(lastword $(IPHONEOS_VERSIONS))
 	@true
-$(addsuffix -ios-iphonesimulator,all config compile check): %: %8.4
+$(addsuffix -ios-iphonesimulator,all config compile check): %: %$(lastword ($IPHONESIMULATOR_VERSIONS))
 	@true
 
 all_ios_subplatforms = iphoneos iphonesimulator $(IOS_SDKS)


### PR DESCRIPTION
Update the top-level Makefile so that `make all-ios-iphoneos` uses the
last version listed in the `IPHONEOS_VERSIONS` variable.  (And
etc. for simulator builds).
