### PR TITLE
lc-compile: Add -Werror option and use it everywhere.

### DIFF
--- a/docs/lcb/notes/feature-warning_error.md
+++ b/docs/lcb/notes/feature-warning_error.md
@@ -1,0 +1,5 @@
+# LiveCode Builder Tools
+## lc-compile
+### Warnings
+
+* The `-Werror` option converts all compilation warnings into errors.

--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -174,63 +174,63 @@ public handler browserListToLCBList(in pBrowserList as MCBrowserListRef, out rLi
 		return false
 	end if
 	
-	variable i
-	repeat with i from 0 up to tCount - 1
+	variable tIndex
+	repeat with tIndex from 0 up to tCount - 1
 		variable tType as MCBrowserValueType
-		if not MCBrowserListGetType(pBrowserList, i, tType) then
-			log "couldn't get type of %@" with [i]
+		if not MCBrowserListGetType(pBrowserList, tIndex, tType) then
+			log "couldn't get type of %@" with [tIndex]
 			return false
 		end if
 		
 		if tType is kMCBrowserValueTypeBoolean then
 			variable tBoolean as CBool
-			if not MCBrowserListGetBoolean(pBrowserList, i, tBoolean) then
-				log "couldn't get boolean %@" with [i]
+			if not MCBrowserListGetBoolean(pBrowserList, tIndex, tBoolean) then
+				log "couldn't get boolean %@" with [tIndex]
 				return false
 			end if
 			push tBoolean onto tList
 		else if tType is kMCBrowserValueTypeInteger then
 			variable tInteger as CInt
-			if not MCBrowserListGetInteger(pBrowserList, i, tInteger) then
-				log "couldn't get integer %@" with [i]
+			if not MCBrowserListGetInteger(pBrowserList, tIndex, tInteger) then
+				log "couldn't get integer %@" with [tIndex]
 				return false
 			end if
 			push tInteger onto tList
 		else if tType is kMCBrowserValueTypeDouble then
 			variable tDouble as CDouble
-			if not MCBrowserListGetDouble(pBrowserList, i, tDouble) then
-				log "couldn't get double %@" with [i]
+			if not MCBrowserListGetDouble(pBrowserList, tIndex, tDouble) then
+				log "couldn't get double %@" with [tIndex]
 				return false
 			end if
 			push tDouble onto tList
 		else if tType is kMCBrowserValueTypeUTF8String then
 			variable tUTF8String as ZStringNative
-			if not MCBrowserListGetUTF8String(pBrowserList, i, tUTF8String) then
-				log "couldn't get string %@" with [i]
+			if not MCBrowserListGetUTF8String(pBrowserList, tIndex, tUTF8String) then
+				log "couldn't get string %@" with [tIndex]
 				return false
 			end if
 			push tUTF8String onto tList
 		else if tType is kMCBrowserValueTypeList then
 			variable tBrowserList as MCBrowserListRef
-			if not MCBrowserListGetList(pBrowserList, i, tBrowserList) then
-				log "couldn't get list %@" with [i]
+			if not MCBrowserListGetList(pBrowserList, tIndex, tBrowserList) then
+				log "couldn't get list %@" with [tIndex]
 				return false
 			end if
 			variable tConvertedList as List
 			if not browserListToLCBList(tBrowserList, tConvertedList) then
-				log "couldn't convert list %@" with [i]
+				log "couldn't convert list %@" with [tIndex]
 				return false
 			end if
 			push tConvertedList onto tList
 		else if tType is kMCBrowserValueTypeDictionary then
 			variable tBrowserDict as MCBrowserDictionaryRef
-			if not MCBrowserListGetDictionary(pBrowserList, i, tBrowserDict) then
-				log "couldn't get dictionary %@" with [i]
+			if not MCBrowserListGetDictionary(pBrowserList, tIndex, tBrowserDict) then
+				log "couldn't get dictionary %@" with [tIndex]
 				return false
 			end if
 			variable tConvertedDict as Array
 			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then 
-				log "couldn't convert dictionary %@" with [i]
+				log "couldn't convert dictionary %@" with [tIndex]
 				return false
 			end if
 			push tConvertedDict onto tList
@@ -255,69 +255,69 @@ public handler browserDictionaryToLCBArray(in pBrowserDict as MCBrowserDictionar
 		return false
 	end if
 	
-	variable i
-	repeat with i from 0 up to tCount - 1
+	variable tIndex
+	repeat with tIndex from 0 up to tCount - 1
 		variable tKey as String
-		if not MCBrowserDictionaryGetKey(pBrowserDict, i, tKey) then
-			log "couldn't get key of %@" with [i]
+		if not MCBrowserDictionaryGetKey(pBrowserDict, tIndex, tKey) then
+			log "couldn't get key of %@" with [tIndex]
 			return false
 		end if
 		
 		variable tType as MCBrowserValueType
 		if not MCBrowserDictionaryGetType(pBrowserDict, tKey, tType) then
-			log "couldn't get type of %@" with [i]
+			log "couldn't get type of %@" with [tIndex]
 			return false
 		end if
 		
 		if tType is kMCBrowserValueTypeBoolean then
 			variable tBoolean as CBool
 			if not MCBrowserDictionaryGetBoolean(pBrowserDict, tKey, tBoolean) then
-				log "couldn't get boolean %@" with [i]
+				log "couldn't get boolean %@" with [tIndex]
 				return false
 			end if
 			put tBoolean into tArray[tKey]
 		else if tType is kMCBrowserValueTypeInteger then
 			variable tInteger as CInt
 			if not MCBrowserDictionaryGetInteger(pBrowserDict, tKey, tInteger) then
-				log "couldn't get integer %@" with [i]
+				log "couldn't get integer %@" with [tIndex]
 				return false
 			end if
 			put tInteger into tArray[tKey]
 		else if tType is kMCBrowserValueTypeDouble then
 			variable tDouble as CDouble
 			if not MCBrowserDictionaryGetDouble(pBrowserDict, tKey, tDouble) then
-				log "couldn't get double %@" with [i]
+				log "couldn't get double %@" with [tIndex]
 				return false
 			end if
 			put tDouble into tArray[tKey]
 		else if tType is kMCBrowserValueTypeUTF8String then
 			variable tUTF8String as ZStringNative
 			if not MCBrowserDictionaryGetUTF8String(pBrowserDict, tKey, tUTF8String) then
-				log "couldn't get string %@" with [i]
+				log "couldn't get string %@" with [tIndex]
 				return false
 			end if
 			put tUTF8String into tArray[tKey]
 		else if tType is kMCBrowserValueTypeList then
 			variable tBrowserList as MCBrowserListRef
 			if not MCBrowserDictionaryGetList(pBrowserDict, tKey, tBrowserList) then
-				log "couldn't get list %@" with [i]
+				log "couldn't get list %@" with [tIndex]
 				return false
 			end if
 			variable tConvertedList as List
 			if not browserListToLCBList(tBrowserList, tConvertedList) then
-				log "couldn't convert list %@" with [i]
+				log "couldn't convert list %@" with [tIndex]
 				return false
 			end if
 			put tConvertedList into tArray[tKey]
 		else if tType is kMCBrowserValueTypeDictionary then
 			variable tBrowserDict as MCBrowserDictionaryRef
 			if not MCBrowserDictionaryGetDictionary(pBrowserDict, tKey, tBrowserDict) then
-				log "couldn't get dictionary %@" with [i]
+				log "couldn't get dictionary %@" with [tIndex]
 				return false
 			end if
 			variable tConvertedDict as Array
 			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then 
-				log "couldn't convert dictionary %@" with [i]
+				log "couldn't convert dictionary %@" with [tIndex]
 				return false
 			end if
 			put tConvertedDict into tArray[tKey]

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -24,14 +24,14 @@ Licensed under the terms of the Creative Commons Attribution 3.0 Unported Licens
 /*
 This widget displays web content within a native web browser view.
 
-Name: url
+Name: URL
 Type: property
 
 Syntax:
-set the url of <widget> to <pUrl>
-get the url of <widget>
+set the URL of <widget> to <pUrl>
+get the URL of <widget>
 
-Summary: The url displayed by the browser.
+Summary: The URL displayed by the browser.
 
 Parameters:
 pUrl(string): A string specifying a URL.
@@ -40,19 +40,19 @@ Example:
 	// Navigate to livecode.com by setting the url property, keeping a copy of the
 	//    previous URL
 	local tOldUrl
-	put the url of widget "myBrowser" into tOldUrl
-	set the url of widget "myBrowser" to "http://livecode.com"
+	put the URL of widget "myBrowser" into tOldUrl
+	set the URL of widget "myBrowser" to "http://livecode.com"
 
 Description:
-The <url> is the URL of the content be displayed in the browser.
+The <URL> is the URL of the content be displayed in the browser.
 
 
-Name: htmltext
+Name: htmlText
 Type: property
 
 Syntax:
-set the htmltext of <widget> to <pHtmlText>
-get the htmltext of <widget>
+set the htmlText of <widget> to <pHtmlText>
+get the htmlText of <widget>
 
 Summary: The HTML text of the content displayed by the browser.
 
@@ -63,18 +63,18 @@ Example:
 	// Render a web page in the browser by specifying custom HTML content
 	local tHTML
 	put "<html><head><title>My Page Title</title></head><body>My Page Contents</body></html>" into tHTML
-	set the htmltext of widget "myBrowser" to tHTML
+	set the htmlText of widget "myBrowser" to tHTML
 
 Description:
-The <htmltext> is the HTML representation of the content displayed in the browser.
+The <htmlText> is the HTML representation of the content displayed in the browser.
 
 
-Name: vscrollbar
+Name: vScrollbar
 Type: property
 
 Syntax:
-set the vscrollbar of <widget> to <pEnabled>
-get the vscrollbar of <widget>
+set the vScrollbar of <widget> to <pEnabled>
+get the vScrollbar of <widget>
 
 Summary: Controls whether the vertical scrollbar is visible and enabled within the browser.
 
@@ -85,12 +85,12 @@ Description:
 Controls whether the vertical scrollbar is visible and enabled within the browser.
 
 
-Name: hscrollbar
+Name: hScrollbar
 Type: property
 
 Syntax:
-set the hscrollbar of <widget> to <pEnabled>
-get the hscrollbar of <widget>
+set the hScrollbar of <widget> to <pEnabled>
+get the hScrollbar of <widget>
 
 Summary: Controls whether the horizontal scrollbar is visible and enabled within the browser.
 
@@ -101,12 +101,12 @@ Description:
 Controls whether the horizontal scrollbar is visible and enabled within the browser.
 
 
-Name: useragent
+Name: userAgent
 Type: property
 
 Syntax:
-set the useragent of <widget> to <pUserAgent>
-get the useragent of <widget>
+set the userAgent of <widget> to <pUserAgent>
+get the userAgent of <widget>
 
 Summary: The identifier sent by the browser when fetching content from remote URLs.
 
@@ -115,19 +115,19 @@ pUserAgent(string): A string conforming to the http specifications at http://www
 
 Example:
 	// Set custom User-Agent header. The remote web server may be configured to deliver custom content for browsers using this User-Agent.
-	set the useragent of widget "myBrowser" to "myAppEmbeddedBrowser"
+	set the userAgent of widget "myBrowser" to "myAppEmbeddedBrowser"
 	launch url "http://myexampleserver.com/content.html" in widget "myBrowser"
 
 Description:
-The <useragent> is the identifier sent by the browser when fetching content from remote URLs.
+The <userAgent> is the identifier sent by the browser when fetching content from remote URLs.
 
 
-Name: javascripthandlers
+Name: javascriptHandlers
 Type: property
 
 Syntax:
-set the javascripthandlers of <widget> to <pHanderList>
-get the javascripthandlers of <widget>
+set the javascriptHandlers of <widget> to <pHanderList>
+get the javascriptHandlers of <widget>
 
 Summary: A list of LiveCode handlers that are made available to JavaScript calls within the browser.
 
@@ -144,7 +144,7 @@ Example:
 	...
 	
 	// Set up the browser javascript handler list
-	set the javascripthandlers to "myJSHandler" & return & "myOtherJSHandler"
+	set the javascriptHandlers to "myJSHandler" & return & "myOtherJSHandler"
 
 	...
 	
@@ -152,9 +152,9 @@ Example:
 	liveCode.myJSHandler("myMessage", 12345);
 	
 Description:
-The <javascripthandlers> is a list of LiveCode handlers that are made available to JavaScript calls within the browser. The handlers will appear as methods attached to a global "liveCode" object. You can call these methods as you would any other JavaScript function and pass whatever parameters you require.
+The <javascriptHandlers> is a list of LiveCode handlers that are made available to JavaScript calls within the browser. The handlers will appear as methods attached to a global "liveCode" object. You can call these methods as you would any other JavaScript function and pass whatever parameters you require.
 
->*Warning:* Setting the javascriptHandlers property gives JavaScript running within the Web browser permission to execute parts of your application through the handlers you choose to expose. If using this feature, make sure that you have complete control over the webpages which you load into the browser widget, and consider using https to ensure that third-parties cannot inject malicious code into them.
+>*Warning:* Setting the <javascriptHandlers> property gives JavaScript running within the Web browser permission to execute parts of your application through the handlers you choose to expose. If using this feature, make sure that you have complete control over the webpages which you load into the browser widget, and consider using https to ensure that third-parties cannot inject malicious code into them.
 
 
 Name: browserDocumentLoadBegin
@@ -298,22 +298,22 @@ metadata svgicon is "M21.7,12c0,5.4-4.4,9.7-9.7,9.7S2.3,17.4,2.3,12S6.6,2.3,12,2
 --
 
 -- property declarations
-property url get getUrl set setUrl
-metadata url.editor is "com.livecode.pi.text"
+property URL get getUrl set setUrl
+metadata URL.editor is "com.livecode.pi.text"
 
-property htmltext get getHtmlText set setHtmlText
+property htmlText get getHtmlText set setHtmlText
 
-property vscrollbar get getVScrollbar set setVScrollbar
-metadata vscrollbar.editor is "com.livecode.pi.boolean"
+property vScrollbar get getVScrollbar set setVScrollbar
+metadata vScrollbar.editor is "com.livecode.pi.boolean"
 
-property hscrollbar get getHScrollbar set setHScrollbar
-metadata hscrollbar.editor is "com.livecode.pi.boolean"
+property hScrollbar get getHScrollbar set setHScrollbar
+metadata hScrollbar.editor is "com.livecode.pi.boolean"
 
-property useragent get getUserAgent set setUserAgent
-metadata useragent.editor is "com.livecode.pi.text"
+property userAgent get getUserAgent set setUserAgent
+metadata userAgent.editor is "com.livecode.pi.text"
 
-property javascripthandlers get getJavaScriptHandlers set setJavaScriptHandlers
-metadata javascripthandlers.editor is "com.livecode.pi.text"
+property javascriptHandlers get getJavaScriptHandlers set setJavaScriptHandlers
+metadata javascriptHandlers.editor is "com.livecode.pi.text"
 
 --------------------------------------------------------------------------------
 

--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -43,6 +43,9 @@ specified.
 * --manifest _MANIFEST_:
   Generate a module manifest in _MANIFEST_.  This is used by the LiveCode IDE.
 
+* -Werror:
+  Turn all warnings into errors.
+
 * -h, --help:
   Print some basic usage information.
 

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -55,6 +55,9 @@ void bootstrap_main(int argc, char *argv[])
     }
     
     s_is_bootstrap = 1;
+
+    /* Treat all warnings as errors in bootstrap mode */
+    s_is_werror_enabled = 1;
     
     for(i = 0; i < argc; i++)
     {

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -104,6 +104,7 @@ usage(int status)
 "      --deps changed-order Generate the order the input source files should be\n"
 "                           compiled in, but only if they need recompiling.\n"
 "      --manifest MANIFEST  Filename for generated manifest.\n"
+"      -Werror              Turn all warnings into errors.\n"
 "  -v, --verbose            Output extra debugging information.\n"
 "  -h, --help               Print this message.\n"
 "  --                       Treat all remaining arguments as filenames.\n"
@@ -178,6 +179,15 @@ static void full_main(int argc, char *argv[])
             if (0 == strcmp(opt, "--manifest") && optarg)
             {
                 SetManifestOutputFile(argv[++argi]);
+                continue;
+            }
+            /* FIXME This should be expanded to support "-W error",
+             * "--warn error", "--warn=error", etc.  Also options for
+             * enabling/disabling/errorifying particular warning
+             * types. */
+            if (0 == strcmp(opt, "-Werror"))
+            {
+                s_is_werror_enabled = 1;
                 continue;
             }
             if (0 == strcmp(opt, "-v") || 0 == strcmp(opt, "--verbose"))

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -28,6 +28,7 @@ extern int IsDependencyCompile(void);
 
 static int s_error_count;
 int s_verbose_level;
+int s_is_werror_enabled;
 
 void InitializeReports(void)
 {
@@ -162,9 +163,16 @@ static void _Warning(long p_position, const char *p_message)
 {
     if (IsDependencyCompile())
         return;
-    
-    _PrintPosition(p_position);
-    fprintf(stderr, "warning: %s\n", p_message);
+
+    if (s_is_werror_enabled)
+    {
+        _Error(p_position, p_message);
+    }
+    else
+    {
+        _PrintPosition(p_position);
+        fprintf(stderr, "warning: %s\n", p_message);
+    }
 }
 
 static void _ErrorS(long p_position, const char *p_message, const char *p_string)
@@ -173,6 +181,7 @@ static void _ErrorS(long p_position, const char *p_message, const char *p_string
     GetColumnOfPosition(p_position, &t_column);
     GetRowOfPosition(p_position, &t_row);
     _PrintPosition(p_position);
+    fprintf(stderr, "error: ");
     fprintf(stderr, p_message, p_string);
     fprintf(stderr, "\n");
     s_error_count += 1;
@@ -184,13 +193,20 @@ static void _WarningS(long p_position, const char *p_message, const char *p_stri
     
     if (IsDependencyCompile())
         return;
-    
-    GetColumnOfPosition(p_position, &t_column);
-    GetRowOfPosition(p_position, &t_row);
-    _PrintPosition(p_position);
-    fprintf(stderr, "warning: ");
-    fprintf(stderr, p_message, p_string);
-    fprintf(stderr, "\n");
+
+    if (s_is_werror_enabled)
+    {
+       _ErrorS(p_position, p_message, p_string);
+    }
+    else
+    {
+        GetColumnOfPosition(p_position, &t_column);
+        GetRowOfPosition(p_position, &t_row);
+        _PrintPosition(p_position);
+        fprintf(stderr, "warning: ");
+        fprintf(stderr, p_message, p_string);
+        fprintf(stderr, "\n");
+    }
 }
 
 static void _ErrorI(long p_position, const char *p_message, NameRef p_name)

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+extern int s_is_werror_enabled;
 extern int s_verbose_level;
 
 void InitializeReports(void);

--- a/util/build-extensions.sh
+++ b/util/build-extensions.sh
@@ -13,6 +13,7 @@ function build_widget {
 	LC_COMPILE=$4
 	
 	"${LC_COMPILE}" \
+		-Werror \
 		--modulepath "${MODULE_DIR}" \
 		--manifest "${WIDGET_DIR}/manifest.xml" \
 		--output "${WIDGET_DIR}/module.lcm" \


### PR DESCRIPTION
Add a `-Werror` option to the LCB compiler, which turns all warnings into errors.  Use it whenever compiling LCB source code that's part of LiveCode.
