### PR TITLE
Replace references to quality.runrev.com (6.7)

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -80,7 +80,7 @@ Once your changes have been reviewed and tested, they will be merged in time for
 
 Finding and fixing bugs in LiveCode is a particularly valuable contribution.
 
-If you've found a bug, please add a ticket to the [LiveCode issue tracking system](http://quality.runrev.com/).  This will give you a bug number which can be used whenever discussing the issue, and included in git commit log messages and in GitHub pull request descriptions.  This will help other contributors keep track of who's working on what.
+If you've found a bug, please add a ticket to the [LiveCode issue tracking system](http://quality.livecode.com/).  This will give you a bug number which can be used whenever discussing the issue, and included in git commit log messages and in GitHub pull request descriptions.  This will help other contributors keep track of who's working on what.
 
 When you submit a pull request that fixes a bug, the status of the bug should be set to "AWAITING_MERGE" -- please also add a comment to the bug with a link to the pull request's page.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ There are several ways to get help with installing and using LiveCode:
 
 * Visit the [LiveCode open source forums](http://forums.livecode.com/viewforum.php?f=65).  In particular, you may wish to post your question in the [Engine Contributors](http://forums.livecode.com/viewforum.php?f=66) forum.
 
-* If you have discovered a bug, have a feature request, or have written a patch to improve LiveCode, please create an ticket in the [LiveCode issue tracking system](http://quality.runrev.com/).
+* If you have discovered a bug, have a feature request, or have written a patch to improve LiveCode, please create an ticket in the [LiveCode issue tracking system](http://quality.livecode.com/).
 
 ## Contributing to LiveCode
 

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -258,7 +258,7 @@ function makeBugTable pBugs, pBold
             put tNoID & "<td>" & item 2 of tLine & "</td></tr>" into tNoID
          end if
       else
-         put "http://quality.runrev.com/show_bug.cgi?id=" & item 1 of tLine into tBugUrl
+         put "http://quality.livecode.com/show_bug.cgi?id=" & item 1 of tLine into tBugUrl
          if pBold then
             put tBugs & CR & "<tr><td><strong>" & item 1 of tLine & "</strong></td>" & CR into tBugs
             put tBugs & "<td><a href=" & quote & tBugUrl & quote & "><strong>" & item 2 of tLine & "</strong></a></td></tr>" into tBugs


### PR DESCRIPTION
BugZilla is now at http://quality.livecode.com/.
