### PR TITLE
[[ Profiling ]] A simple approach to low-level profiling.

### DIFF
--- a/benchmarks/lcs/Makefile
+++ b/benchmarks/lcs/Makefile
@@ -18,20 +18,12 @@ guess_platform_script := \
 	esac
 guess_platform := $(shell $(guess_platform_script))
 
-# When running on headless Linux, run tests in -ui mode.
-guess_flags_script := \
-	if echo $(guess_platform) | grep "^linux" >/dev/null 2>&1 && \
-	        ! xset -q >/dev/null 2>&1 ; then \
-	    echo "-ui"; \
-	fi
-guess_flags := $(shell $(guess_flags_script))
-
 bin_dir ?= $(top_srcdir)/_build/mac/Debug
 
 ENGINE ?= $(if $(filter mac,$(guess_platform)),$(bin_dir)/Standalone-Community.app/Contents/MacOS/Standalone-Community,$(bin_dir)/standalone-community)
-PROFILE_ENGINE ?= $(binder)/server-community
+PROFILE_ENGINE ?= $(bin_dir)/server-community
 
-ENGINE_FLAGS ?= $(guess_flags)
+ENGINE_FLAGS ?= -ui
 
 ################################################################
 

--- a/benchmarks/lcs/Makefile
+++ b/benchmarks/lcs/Makefile
@@ -1,0 +1,54 @@
+top_srcdir ?= ../..
+
+################################################################
+# Attempt to guess where the files we need are
+################################################################
+
+guess_linux_arch_script := \
+	case `uname -p` in \
+	    x86_64) echo x86_64 ;; \
+	    x86|i*86) echo x86 ;; \
+	esac
+guess_linux_arch := $(shell $(guess_linux_arch_script))
+
+guess_platform_script := \
+	case `uname -s` in \
+	    Linux) echo linux-$(guess_linux_arch) ;; \
+	    Darwin) echo mac ;; \
+	esac
+guess_platform := $(shell $(guess_platform_script))
+
+# When running on headless Linux, run tests in -ui mode.
+guess_flags_script := \
+	if echo $(guess_platform) | grep "^linux" >/dev/null 2>&1 && \
+	        ! xset -q >/dev/null 2>&1 ; then \
+	    echo "-ui"; \
+	fi
+guess_flags := $(shell $(guess_flags_script))
+
+bin_dir ?= $(top_srcdir)/_build/mac/Debug
+
+ENGINE ?= $(if $(filter mac,$(guess_platform)),$(bin_dir)/Standalone-Community.app/Contents/MacOS/Standalone-Community,$(bin_dir)/standalone-community)
+PROFILE_ENGINE ?= $(binder)/server-community
+
+ENGINE_FLAGS ?= $(guess_flags)
+
+################################################################
+
+.DEFAULT: bench
+
+bench: livecodescript-bench
+clean:
+	#-rm -rf $(TEST_DIR)
+
+.PHONY: check
+
+################################################################
+
+BENCH_LOG = _benchmark_suite.log
+
+BENCH_RUNNER_SCRIPT = _benchrunner.livecodescript
+
+livecodescript-bench: $(ENGINE) $(PROFILE_ENGINE)
+	@rm -f $(BENCH_LOG)
+	$(ENGINE) $(ENGINE_FLAGS) $(BENCH_RUNNER_SCRIPT) run

--- a/benchmarks/lcs/_benchrunner.livecodescript
+++ b/benchmarks/lcs/_benchrunner.livecodescript
@@ -1,0 +1,320 @@
+﻿script "TestRunner"
+/*
+Copyright (C) 2015 Runtime Revolution Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+-- FIXME provide this on the command line
+constant kLogFilename = "_benchmark_suite.log"
+
+on startup
+   send "BenchRunnerMain" to me in 0
+end startup
+
+----------------------------------------------------------------
+-- Command-line processing
+----------------------------------------------------------------
+
+private function getCommandLineInfo
+   local tRawArg, tSelfCommand, tSelfScript, tInArgs, tArgs
+   
+   put false into tInArgs
+   
+   -- Treat everything up to & including the first
+   -- ".livecodescript" file as the command for running the bench
+   -- runner, and everything after it as bench runner arguments
+   put the commandName into tSelfCommand[1]
+   repeat for each element tRawArg in the commandArguments
+      
+      if tInArgs then
+         put tRawArg into tArgs[1 + the number of elements in tArgs]
+      else
+         put tRawArg into tSelfCommand[1 + the number of elements in tSelfCommand]
+         if tRawArg ends with ".livecodescript" then
+            put tRawArg into tSelfScript
+            put true into tInArgs
+         end if
+      end if
+      
+   end repeat
+   
+   local tInfo
+   put tSelfCommand into tInfo["self-command"]
+   put tSelfScript into tInfo["self-script"]
+   put tArgs into tInfo["args"]
+   
+   return tInfo
+end getCommandLineInfo
+
+----------------------------------------------------------------
+-- Top-level actions
+----------------------------------------------------------------
+
+command BenchRunnerMain
+   local tInfo
+   put getCommandLineInfo() into tInfo
+   logInit
+   
+   switch tInfo["args"][1]
+      case "invoke"
+         doInvoke tInfo
+         break
+      case "run"
+         doRun tInfo
+         break
+      case "--help"
+      case "-h"
+      case "help"
+         doUsage 0
+         break
+      default
+         doUsage 1
+         break
+   end switch
+   quit 0
+end BenchRunnerMain
+
+private command doInvoke pInfo
+   put pInfo["args"][2] into pInfo["invoke"]["script"]
+   put pInfo["args"][3] into pInfo["invoke"]["command"]
+   
+   invokeLoadLibrary pInfo
+   invokeTest pInfo
+end doInvoke
+
+private command doRun pInfo
+   local tScript, tCommand, tAnalysis
+   put pInfo["args"][2] into tScript
+   put pInfo["args"][3] into tCommand
+   if tScript is empty then
+      runAllScripts pInfo
+   else if tCommand is empty then
+      runBenchScript pInfo, tScript
+   end if
+   
+   put the result into tAnalysis
+   if tapGetWorstResult(tAnalysis) is "FAIL" then
+      quit 1
+   end if
+end doRun
+
+private command doUsage pStatus
+   write "Usage: _benchrunner.livecodescript run [SCRIPT]" & return to stderr
+   quit pStatus
+end doUsage
+
+on ErrorDialog pExecutionError
+   write "ERROR:" && pExecutionError & return to stderr
+   quit 1
+end ErrorDialog
+
+----------------------------------------------------------------
+-- Support for invoking test commands
+----------------------------------------------------------------
+
+-- Execute a test
+private command invokeTest pInfo
+   local tStackName
+   
+   -- This should auto-load the test script
+   put the name of stack pInfo["invoke"]["script"] into tStackName
+   
+   -- Dispatch the test command
+   dispatch pInfo["invoke"]["command"] to tStackName
+end invokeTest
+
+----------------------------------------------------------------
+-- Support for running tests
+----------------------------------------------------------------
+
+-- Run all the test scripts that can be found below the current
+-- directory
+private command runAllScripts pInfo
+   local tFile, tAnalysis
+   repeat for each element tFile in runGetBenchFileNames()
+      runBenchScript pInfo, tFile
+      put benchCombine(tAnalysis, the result) into tAnalysis
+   end repeat
+   runPrintSummary tAnalysis
+   
+   -- Save the log to file
+   open file kLogFilename for "UTF-8" text write
+   write tAnalysis["log"] to file kLogFilename
+   close file kLogFilename
+   
+   return tAnalysis
+end runAllScripts
+
+-- Run the benchmark found in one specific script file
+private command runBenchScript pInfo, pScriptFile
+   local tArtCommandLine
+   
+   repeat for each element tArg in pInfo["self-command"]
+      put tArg & " " after tCommandLine
+   end repeat
+   
+   --put "invoke" && pScriptFile && pCommand after tCommandLine
+   
+   -- Invoke the test in a subprocess.  This ensures that we can detect
+   -- if a crash occurs
+   local tTestOutput, tTestExitStatus
+   put shell(tCommandLine) into tTestOutput
+   put the result into tTestExitStatus
+   
+   -- Check the exit status.  If it suggests failure, add a "not ok" stanza
+   -- to the tail of the TAP output
+   if tTestExitStatus is not empty then
+      put return after tTestOutput
+      put "not ok # Subprocess exited with status" && \
+            tTestExitStatus & return after tTestOutput
+   end if
+   
+   runTestProcessOutput pScriptFile, pCommand, tTestOutput
+   return the result*/
+end runBenchScript
+
+-- Get all livecode script files beneath the CWD, apart from
+-- filenames starting with "." or "_"
+private function runGetBenchFileNames
+   local tFiles, tCount
+   
+   put empty into tFiles
+   put 0 into tCount
+   
+   runGetBenchFileNames_Recursive the defaultfolder, empty, tFiles, tCount
+   
+   return tFiles
+end runGetBenchFileNames
+
+-- Helper command used by runGetBenchFileNames
+private command runGetBenchFileNames_Recursive pPath, pRelPath, @xFiles, @xCount
+   -- Save the CWD
+   local tSaveFolder
+   put the defaultfolder into tSaveFolder
+   set the defaultfolder to pPath
+   
+   -- Process files in the current directory
+   local tFile
+   repeat for each line tFile in the files
+      if tFile ends with ".livecodescript" and \
+            not (tFile begins with "." or tFile begins with "_") then
+         
+         if pRelPath is not empty then
+            put pRelPath & slash before tFile
+         end if
+         
+         add 1 to xCount
+         put tFile into xFiles[xCount]
+      end if
+   end repeat
+   
+   -- Process subdirectories
+   local tFolder, tFolderPath
+   repeat for each line tFolder in the folders
+      if tFolder begins with "." then
+         next repeat
+      end if
+      
+      put pPath & slash & tFolder into tFolderPath
+      
+      if pRelPath is not empty then
+         put pRelPath & slash before tFolder
+      end if
+      
+      runGetBenchFileNames_Recursive tFolderPath, tFolder, xFiles, xCount
+   end repeat
+   
+   -- Restore the CWD
+   set the defaultfolder to tSaveFolder
+end runGetBenchFileNames_Recursive
+
+-- Prettify a test name by removing a ".livecodescript" suffix
+private function runGetPrettyBenchName pFilename
+   if pFilename ends with ".livecodescript" then
+      set the itemDelimiter to "."
+      return item 1 to -2 of pFileName
+   end if
+end runGetPrettyBenchName
+
+-- Print out a table of statistics
+private command runPrintSummary pAnalysis
+   --write tSummaryString to stdout
+end runPrintSummary
+
+----------------------------------------------------------------
+-- Logging helpers
+----------------------------------------------------------------
+
+local sLogInfo
+
+-- Figure out what the highlighting escape codes are for the terminal
+--
+-- FIXME this really doesn't work properly if LiveCode's stdout
+-- *isn't* a TTY.
+private command logInit
+   -- We can only do colour on Linux and OS X
+   if the platform is not "Linux" and the platform is not "MacOS" then
+      put false into sLogInfo
+   end if
+
+   -- Check if colouring is possible
+   local tTput
+   put shell("tput colors") into tTput
+   if the result is not empty or tTput <= 8 then
+      put false into sLogInfo
+   end if
+
+   -- Get colours
+   put shell("tput sgr0") into sLogInfo["normal"]
+   put shell("tput bold") into sLogInfo["bold"]
+   put shell("tput setaf 1") into sLogInfo["red"]
+   put shell("tput setaf 2") into sLogInfo["green"]
+   put shell("tput setaf 3") into sLogInfo["yellow"]
+   put shell("tput setaf 6") into sLogInfo["cyan"]
+end logInit
+
+private function logHighlight pString
+  if pString is "fail" then
+     return sLogInfo["red"] & sLogInfo["bold"] & pString & sLogInfo["normal"]
+  else if pString is "xfail" or pString is "xpass" then
+     return sLogInfo["yellow"] & pString & sLogInfo["normal"]
+  else if pString is "pass" then
+     return sLogInfo["green"] & pString & sLogInfo["normal"]
+  else if pString is "skip" then
+     return sLogInfo["cyan"] & pString & sLogInfo["normal"]
+  else
+     return pString
+  end if
+end logHighlight
+
+private command logSummaryLine pTapResults, pTestName
+   local tTotal, tPassed, tWorst, tMessage
+
+   put pTapResults["xpass"] + pTapResults["pass"] + pTapResults["skip"] into tPassed
+   put tapGetTestCount(pTapResults) into tTotal
+
+   put tapGetWorstResult(pTapResults) into tWorst
+   put logHighLight(the toUpper of tWorst) into tMessage
+   put ":" after tMessage
+   if the number of chars in tWorst < 5 then
+      put space after tMessage
+   end if
+
+   put space & pTestName after tMessage
+
+   put space & "[" & tPassed & "/" & tTotal & "]" after tMessage
+   write tMessage & return to stdout
+end logSummaryLine
+

--- a/benchmarks/lcs/_benchrunner.livecodescript
+++ b/benchmarks/lcs/_benchrunner.livecodescript
@@ -1,4 +1,4 @@
-﻿script "TestRunner"
+﻿script "BenchRunner"
 /*
 Copyright (C) 2015 Runtime Revolution Ltd.
 
@@ -105,9 +105,6 @@ private command doRun pInfo
    end if
    
    put the result into tAnalysis
-   if tapGetWorstResult(tAnalysis) is "FAIL" then
-      quit 1
-   end if
 end doRun
 
 private command doUsage pStatus
@@ -145,7 +142,7 @@ private command runAllScripts pInfo
    local tFile, tAnalysis
    repeat for each element tFile in runGetBenchFileNames()
       runBenchScript pInfo, tFile
-      put benchCombine(tAnalysis, the result) into tAnalysis
+      put the result after tAnalysis
    end repeat
    runPrintSummary tAnalysis
    
@@ -157,32 +154,48 @@ private command runAllScripts pInfo
    return tAnalysis
 end runAllScripts
 
+private command runBenchProcessOutput pScriptfile, pOutput
+   -- Create test log
+   local tTestLog
+   put "###" && runGetPrettyBenchName(pScriptFile) \
+         & return & return into tTestLog
+   put pOutput & return after tTestLog
+   
+   return tTestLog
+end runBenchProcessOutput
+
 -- Run the benchmark found in one specific script file
 private command runBenchScript pInfo, pScriptFile
-   local tArtCommandLine
+   local tCommandLine
    
-   repeat for each element tArg in pInfo["self-command"]
-      put tArg & " " after tCommandLine
-   end repeat
+   -- Get the path to this engine
+   put pInfo["self-command"][1] into tCommandLine
    
-   --put "invoke" && pScriptFile && pCommand after tCommandLine
+   -- Modify it so that it points to server-community instead
+   set the itemDelimiter to slash
+   if the platform is "macos" then
+      put "server-community" into item -4 to -1 of tCommandLine
+   else
+      put "server-community" into item -1 of tCommandLine
+   end if
+   
+   put " " & pScriptFile after tCommandLine
    
    -- Invoke the test in a subprocess.  This ensures that we can detect
    -- if a crash occurs
-   local tTestOutput, tTestExitStatus
-   put shell(tCommandLine) into tTestOutput
-   put the result into tTestExitStatus
+   local tBenchOutput, tBenchExitStatus
+   put shell(tCommandLine) into tBenchOutput
    
-   -- Check the exit status.  If it suggests failure, add a "not ok" stanza
-   -- to the tail of the TAP output
-   if tTestExitStatus is not empty then
-      put return after tTestOutput
-      put "not ok # Subprocess exited with status" && \
-            tTestExitStatus & return after tTestOutput
+   put the result into tBenchExitStatus
+   write tBenchOutput to stdout
+   -- Check the exit status.
+   if tBenchExitStatus is not empty then
+      put return after tBenchOutput
+      put "FAILED" after tBenchOutput
    end if
    
-   runTestProcessOutput pScriptFile, pCommand, tTestOutput
-   return the result*/
+   runBenchProcessOutput pScriptFile, tBenchOutput
+   return the result
 end runBenchScript
 
 -- Get all livecode script files beneath the CWD, apart from
@@ -250,7 +263,6 @@ end runGetPrettyBenchName
 
 -- Print out a table of statistics
 private command runPrintSummary pAnalysis
-   --write tSummaryString to stdout
 end runPrintSummary
 
 ----------------------------------------------------------------
@@ -265,13 +277,14 @@ local sLogInfo
 -- *isn't* a TTY.
 private command logInit
    -- We can only do colour on Linux and OS X
-   if the platform is not "Linux" and the platform is not "MacOS" then
+   /*if the platform is not "Linux" and the platform is not "MacOS" then
       put false into sLogInfo
    end if
 
    -- Check if colouring is possible
    local tTput
    put shell("tput colors") into tTput
+   put the result
    if the result is not empty or tTput <= 8 then
       put false into sLogInfo
    end if
@@ -282,7 +295,7 @@ private command logInit
    put shell("tput setaf 1") into sLogInfo["red"]
    put shell("tput setaf 2") into sLogInfo["green"]
    put shell("tput setaf 3") into sLogInfo["yellow"]
-   put shell("tput setaf 6") into sLogInfo["cyan"]
+   put shell("tput setaf 6") into sLogInfo["cyan"]*/
 end logInit
 
 private function logHighlight pString

--- a/engine/kernel-server.gypi
+++ b/engine/kernel-server.gypi
@@ -16,6 +16,11 @@
 				'mode_macro': 'MODE_SERVER',
 			},
 			
+            'defines':
+            [
+                'FEATURE_PROFILE',
+            ],
+            
 			'dependencies':
 			[
 				'../libfoundation/libfoundation.gyp:libFoundation',

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -3338,7 +3338,7 @@ void MCOpen::exec_ctxt(MCExecContext &ctxt)
 #endif /* MCOpen */
 
 	if (go != NULL)
-        return go->exec_ctxt(ctxt);
+        return go->execute(ctxt);
 
     ctxt . SetTheResultToEmpty();
 

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -448,7 +448,7 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 		}
 		ctxt.SetLineAndPos(tspr->getline(), tspr->getpos());
         
-        tspr->exec_ctxt(ctxt);
+        tspr->execute(ctxt);
 		stat = ctxt . GetExecStat();
         
         MCActionsRunAll();
@@ -469,7 +469,7 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
                     {
                         MCB_error(ctxt, tspr->getline(), tspr->getpos(), EE_HANDLER_BADSTATEMENT);
                         ctxt . IgnoreLastError();
-                        tspr->exec_ctxt(ctxt);
+                        tspr->execute(ctxt);
                     }
 				while (MCtrace && (stat = ctxt . GetExecStat()) != ES_NORMAL);
                 if (stat != ES_NORMAL)
@@ -1038,5 +1038,19 @@ void MCHandler::compile(MCSyntaxFactoryRef ctxt)
 	
 	MCSyntaxFactoryEndHandler(ctxt);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+#ifdef FEATURE_PROFILE
+void MCHandler::reporttiming(MCProfilingReportCallback report)
+{
+	MCStatement *stmp = statements;
+	while (stmp != NULL)
+	{
+        stmp -> reporttiming(report);
+		stmp = stmp->getnext();
+	}
+}
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/handler.h
+++ b/engine/src/handler.h
@@ -17,6 +17,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef __MC_HANDLER__
 #define	__MC_HANDLER__
 
+#ifndef __MC_STATEMENT__
+#include "statemnt.h"
+#endif
+
 struct MCExecValue;
 
 // A single variable definition. If 'init' is nil then it means the var should
@@ -191,6 +195,10 @@ public:
 	{
 		return globals[p_index];
 	}
+    
+#ifdef FEATURE_PROFILE
+    void reporttiming(MCProfilingReportCallback report);
+#endif
 
 private:
 	Parse_stat newparam(MCScriptPoint& sp);

--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -799,3 +799,18 @@ void MCHandlerlist::compile(MCSyntaxFactoryRef ctxt)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+#ifdef FEATURE_PROFILE
+void MCHandlerlist::reporttiming(MCProfilingReportCallback report)
+{
+    for(int i = 0; i < 6; i++)
+    {
+        for(int j = 0; j < handlers[i] . count(); j++)
+        {
+            handlers[i] . get()[j] -> reporttiming(report);
+        }
+    }
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/hndlrlst.h
+++ b/engine/src/hndlrlst.h
@@ -161,5 +161,9 @@ public:
 		return vars != NULL;
 	}
 	uint4 linecount();
+    
+#ifdef FEATURE_PROFILE
+    void reporttiming(MCProfilingReportCallback report);
+#endif
 };
 #endif

--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -1248,6 +1248,10 @@ Exec_stat MCRepeat::exec(MCExecPoint &ep)
 
 void MCRepeat::exec_ctxt(MCExecContext& ctxt)
 {
+#ifdef FEATURE_PROFILE
+    extern MCStatement *MCprofilingkeyword;
+    MCprofilingkeyword = this;
+#endif
     switch (form)
 	{
         case RF_FOR:
@@ -2007,5 +2011,77 @@ uint4 MCTry::linecount()
 	return countlines(trystatements) + countlines(catchstatements)
 	       + countlines(finallystatements);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+#ifdef FEATURE_PROFILE
+static void reportstatements(MCStatement *stmts, MCProfilingReportCallback report)
+{
+    while(stmts != nil)
+    {
+        stmts -> reporttiming(report);
+        stmts = stmts -> getnext();
+    }
+}
+
+void MCIf::starttiming(void)
+{
+}
+
+void MCIf::finishtiming(void)
+{
+}
+
+void MCIf::reporttiming(MCProfilingReportCallback report)
+{
+    MCStatement::reporttiming(report);
+    reportstatements(thenstatements, report);
+    reportstatements(elsestatements, report);
+}
+
+void MCRepeat::starttiming(void)
+{
+}
+
+void MCRepeat::finishtiming(void)
+{
+}
+
+void MCRepeat::reporttiming(MCProfilingReportCallback report)
+{
+    MCStatement::reporttiming(report);
+    reportstatements(statements, report);
+}
+
+void MCSwitch::starttiming(void)
+{
+}
+
+void MCSwitch::finishtiming(void)
+{
+}
+
+void MCSwitch::reporttiming(MCProfilingReportCallback report)
+{
+    MCStatement::reporttiming(report);
+    reportstatements(statements, report);
+}
+
+void MCTry::starttiming(void)
+{
+}
+
+void MCTry::finishtiming(void)
+{
+}
+
+void MCTry::reporttiming(MCProfilingReportCallback report)
+{
+    MCStatement::reporttiming(report);
+    reportstatements(trystatements, report);
+    reportstatements(catchstatements, report);
+    reportstatements(finallystatements, report);
+}
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/keywords.h
+++ b/engine/src/keywords.h
@@ -87,6 +87,12 @@ public:
 	virtual Parse_stat parse(MCScriptPoint &);
 	virtual void exec_ctxt(MCExecContext &ctxt);
 	virtual uint4 linecount();
+    
+#ifdef FEATURE_PROFILE
+    virtual void starttiming(void);
+    virtual void finishtiming(void);
+    virtual void reporttiming(MCProfilingReportCallback report);
+#endif
 };
 
 class MCRepeat : public MCStatement
@@ -105,6 +111,12 @@ public:
 	virtual Parse_stat parse(MCScriptPoint &);
 	virtual void exec_ctxt(MCExecContext&);
 	virtual uint4 linecount();
+    
+#ifdef FEATURE_PROFILE
+    virtual void starttiming(void);
+    virtual void finishtiming(void);
+    virtual void reporttiming(MCProfilingReportCallback report);
+#endif
 };
 
 class MCExit : public MCStatement
@@ -166,6 +178,12 @@ public:
 	virtual Parse_stat parse(MCScriptPoint &sp);
 	virtual void exec_ctxt(MCExecContext &);
 	virtual uint4 linecount();
+    
+#ifdef FEATURE_PROFILE
+    virtual void starttiming(void);
+    virtual void finishtiming(void);
+    virtual void reporttiming(MCProfilingReportCallback report);
+#endif
 };
 
 class MCThrowKeyword : public MCStatement
@@ -198,6 +216,12 @@ public:
 	virtual Parse_stat parse(MCScriptPoint &);
 	virtual void exec_ctxt(MCExecContext&);
 	virtual uint4 linecount();
+    
+#ifdef FEATURE_PROFILE
+    virtual void starttiming(void);
+    virtual void finishtiming(void);
+    virtual void reporttiming(MCProfilingReportCallback report);
+#endif
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -561,6 +561,13 @@ void X_main_loop(void)
 		return;
 #endif
 	
+#ifdef FEATURE_PROFILE
+    double t_profile_start_time;
+    MCProfilingTimer t_profile_timer;
+    t_profile_start_time = MCS_time();
+    t_profile_timer . Start();
+#endif
+    
 	MCExecContext ctxt;
 	if (!MCserverscript -> Include(ctxt, MCserverinitialscript, false) &&
 		MCS_get_errormode() != kMCSErrorModeDebugger)
@@ -603,7 +610,12 @@ void X_main_loop(void)
 	}
 	
 #ifdef FEATURE_PROFILE
+    double t_profile_finish_time;
+    t_profile_timer . Stop();
+    t_profile_finish_time = MCS_time();
+    
     MCserverscript -> gethandlers() -> reporttiming(X_report_timing);
+    fprintf(stderr, "XXXXXXXX %llu %lf\n", t_profile_timer . Total(), t_profile_finish_time - t_profile_start_time);
 #endif
     
 	if (s_server_cgi)

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -501,6 +501,11 @@ static void X_load_extensions(MCServerScript *p_script)
 	
 }
 
+void X_report_timing(uint2 line, uint64_t count)
+{
+    fprintf(stderr, "%08d %llu\n", line, count);
+}
+
 void X_main_loop(void)
 {
 	int i;
@@ -597,6 +602,10 @@ void X_main_loop(void)
 		}
 	}
 	
+#ifdef FEATURE_PROFILE
+    MCserverscript -> gethandlers() -> reporttiming(X_report_timing);
+#endif
+    
 	if (s_server_cgi)
 		cgi_finalize();
 #ifdef _IREVIAM

--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -526,7 +526,7 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 				m_ctxt -> SetLineAndPos(t_statement -> getline(), t_statement -> getpos());
 				
 				Exec_stat t_exec_stat;
-				t_statement -> exec_ctxt(*m_ctxt);
+				t_statement -> execute(*m_ctxt);
 				t_exec_stat = m_ctxt -> GetExecStat();
 				m_ctxt -> IgnoreLastError();
 				
@@ -539,7 +539,7 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 							if (!MCB_error(*m_ctxt, t_statement->getline(), t_statement->getpos(), EE_HANDLER_BADSTATEMENT))
 								break;
 							m_ctxt -> IgnoreLastError();
-							t_statement -> exec_ctxt(*m_ctxt);
+							t_statement -> execute(*m_ctxt);
 						}
 						while (MCtrace && (t_exec_stat = m_ctxt -> GetExecStat()) != ES_NORMAL);
 
@@ -552,7 +552,20 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 
 			t_statement = t_statement -> getnext();
 		}
-
+        
+#ifdef FEATURE_PROFILE
+        if (t_stat == ES_NORMAL)
+        {
+            extern void X_report_timing(uint2 line, uint64_t count);
+            t_statement = t_statements;
+            while(t_statement != nil)
+            {
+                t_statement -> reporttiming(X_report_timing);
+                t_statement = t_statement -> getnext();
+            }
+        }
+#endif
+        
 		t_statements -> deletestatements(t_statements);
 	}
 	

--- a/engine/src/statemnt.cpp
+++ b/engine/src/statemnt.cpp
@@ -350,6 +350,22 @@ void MCStatement::compile(MCSyntaxFactoryRef ctxt)
 	MCSyntaxFactoryEndStatement(ctxt);
 };
 
+#ifdef FEATURE_PROFILE
+void MCStatement::starttiming(void)
+{
+    timer . Start();
+}
+
+void MCStatement::finishtiming(void)
+{
+    timer . Stop();
+}
+
+void MCStatement::reporttiming(MCProfilingReportCallback report)
+{
+    report(line, timer . Total());
+}
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/livecode-minimal.gyp
+++ b/livecode-minimal.gyp
@@ -23,7 +23,8 @@
 						'dependencies':
 						[
 							# Engines
-							'engine/engine.gyp:server',
+                            'engine/engine.gyp:server',
+                            'engine/engine.gyp:profiling-server',
 						],
 					},
 				],

--- a/livecode-minimal.gyp
+++ b/livecode-minimal.gyp
@@ -1,0 +1,33 @@
+{
+	'includes':
+	[
+		'common.gypi',
+	],
+	
+	'targets':
+	[
+		{
+			'target_name': 'LiveCode-minimal',
+			'type': 'none',
+			
+			'dependencies':
+			[
+				# Engines
+			],
+			
+			'conditions':
+			[
+				[
+					'mobile == 0',
+					{
+						'dependencies':
+						[
+							# Engines
+							'engine/engine.gyp:server',
+						],
+					},
+				],
+			],
+		},
+    ],
+}


### PR DESCRIPTION
This patch allows the server engine to be be built with 'FEATURE_PROFILE'.

This augments the core exec methods for statements so that they measure
the amount of 'time' spent executing each one.

It instruments the root server script, and outputs a list of (line, count) pairs at
the end which can easily be processed by a simple script.

Note 'time' here is the low-level CPU cycle counter.
