### PR TITLE
[[ Build ]] browser widget clone and run on Linux & Windows

### DIFF
--- a/libbrowser/libbrowser.gyp
+++ b/libbrowser/libbrowser.gyp
@@ -349,14 +349,13 @@
 							{
 								'destination': '<(PRODUCT_DIR)',
 								'files': [
-									'../prebuilt/lib/linux/<(target_arch)/CEF/',
 									'../prebuilt/lib/linux/<(target_arch)/CEF/icudtl.dat',
 								],
 							},
 							{
-								'destination': '<(PRODUCT_DIR)/CEF',
+								'destination': '<(PRODUCT_DIR)/Externals/',
 								'files': [
-									'<(PRODUCT_DIR)/libbrowser-cefprocess',
+									'../prebuilt/lib/linux/<(target_arch)/CEF',
 								],
 							}
 						],

--- a/libbrowser/libbrowser.gyp
+++ b/libbrowser/libbrowser.gyp
@@ -15,6 +15,8 @@
 				# '../libcore/libcore.gyp:libCore',
 				'../thirdparty/libcef/libcef.gyp:libcef_library_wrapper',
 				'../thirdparty/libcef/libcef.gyp:libcef_stubs',
+				
+				'libbrowser-copy',
 			],
 			
 			'include_dirs':
@@ -167,18 +169,6 @@
 						'dependencies':
 						[
 							'libbrowser-cefprocess',
-						],
-					},
-				],
-				
-				[
-					# Copy libbrowser files into the necessary place to run when doing a
-					#    debug build.
-					'"<!(echo $BUILDTYPE)" == "Debug"',
-					{
-						'dependencies':
-						[
-							'libbrowser-copy',
 						],
 					},
 				],
@@ -358,6 +348,29 @@
 									'../prebuilt/lib/linux/<(target_arch)/CEF',
 								],
 							}
+						],
+					},
+				],
+				
+				[
+					'OS == "win"',
+					{
+						'copies':
+						[
+							{
+								'destination':'<(PRODUCT_DIR)/Externals/',
+								'files':
+								[
+									'../prebuilt/lib/win32/<(target_arch)/CEF/',
+								],
+							},
+							{
+								'destination':'<(PRODUCT_DIR)/Externals/CEF/',
+								'files':
+								[
+									'<(PRODUCT_DIR)/libbrowser-cefprocess.exe',
+								],
+							},
 						],
 					},
 				],


### PR DESCRIPTION
Ensure libcef libraries and resources are copied to the required place, so that the browser widget can be used within the IDE when launched from the build folder without having to manually copy files and folders.
