### PR TITLE
[[ Tests ]] Add extension testing capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ check: check-$(guess_platform)
 check-common-%:
 	$(MAKE) -C tests bin_dir=../$*-bin
 	$(MAKE) -C ide/tests bin_dir=../../$*-bin
+	$(MAKE) -C extensions bin_dir=../$*-bin
 
 ################################################################
 # Linux rules

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,6 +48,7 @@ Before running each test command, the test framework inserts a test library stac
 * `TestAssertBroken pDescription, pExpectTrue, pReasonBroken`: The same as `TestAssert`, but marking the test as "expected to fail".  *pReasonBroken* should be a short explanation of why the test is currently expected to fail; it should almost always be a reference to a bug report, e.g. "bug 54321".
 * `TestGetEngineRepositoryPath`: A function that returns the path to the main LiveCode engine repository.
 * `TestGetIDERepositoryPath`: A function that returns the path to the LiveCode IDE repository.
+* `TestLoadExtension pName`: Attempt to load the extension with name `pName`, eg `TestLoadExtension "json"` will load the JSON library extension. 
 
 Tests can have additional setup requirements before running, for example loading custom libraries. If the script test contains a handler called `TestSetup`, this will be run prior to running each test command. For example:
 ````

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -1,0 +1,14 @@
+# This Makefile takes advantage of the fact that the engine's
+# "tests/Makefile" already does pretty much everything required for
+# running extension tests.  Rather than duplicating it, it can
+# just be included with a few tweaks to its configuration.
+
+# Only do livecodescript-based checks
+extensions-check: lcs-check
+.DEFAULT: extensions-check
+
+top_srcdir ?= ..
+
+# Things have now been setup enough that the engine's test Makefile
+# can perform the tests without any further configuration.
+include $(top_srcdir)/tests/Makefile

--- a/extensions/libraries/json/tests/basic.livecodescript
+++ b/extensions/libraries/json/tests/basic.livecodescript
@@ -1,0 +1,44 @@
+script "JSONLibrary"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSetup
+	TestLoadExtension "json"
+end TestSetup
+
+on TestExportArray
+   local tArray
+   put "value" into tArray["key"]
+   
+   local tExpected
+   put "{" & quote & "key" & quote & ":" & quote & "value" & quote & "}" into tExpected
+   
+   local tJson
+   put JsonExport(tArray) into tJson
+   # Ignore whitespace
+   replace " " with empty in tJson
+   
+   TestAssert "simple array export", tExpected is tJson
+end TestExportArray
+
+on TestImportArray
+   local tJson, tArray
+   put "{" & quote & "key" & quote & ":" & quote & "value" & quote & "}" into tJson
+   put JsonImport(tJson) into tArray
+   
+   TestAssert "simple array import", tArray["key"] is "value"
+end TestImportArray

--- a/extensions/libraries/json/tests/basic.livecodescript
+++ b/extensions/libraries/json/tests/basic.livecodescript
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestSetup
-	TestLoadExtension "json"
+	TestLoadExtension "com.livecode.library.json"
 end TestSetup
 
 on TestExportArray

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -128,10 +128,14 @@ function TestGetIDERepositoryPath
   return item 1 to -3 of the filename of me & slash & "ide"
 end TestGetIDERepositoryPath
 
-on TestLoadExtension pName
-   local tPath, tEnginePath
+on TestLoadExtension pName	
+   set the itemdelimiter to "."
+   local tExtensionUnzipFolder
+   put "com.livecode.extensions.livecode." & item -1 of pName into tExtensionUnzipFolder
+
+   local tPath, tRepoPath
    put specialfolderpath("engine") into tPath
-   put TestGetEngineRepositoryPath() into tEnginePath
+   put TestGetEngineRepositoryPath() into tRepoPath
    
    local tError
    put "extension" && pName && "not found" into tError
@@ -139,20 +143,24 @@ on TestLoadExtension pName
    # Find the built extensions folder
    local tExtensionsFolder
    set the itemdelimiter to slash
-   repeat while tPath is not tEnginePath and tPath is not empty
+   repeat while tPath is not tRepoPath and tPath is not empty
       if there is a folder (tPath & slash & "packaged_extensions") then
          put (tPath & slash & "packaged_extensions") into tExtensionsFolder
          exit repeat
       end if
       delete item -1 of tPath
    end repeat
+   
+   TestDiagnostic tExtensionsFolder
 
    local tExtensionFolder
    if tExtensionsFolder is not empty then
-      if there is a folder (tExtensionsFolder & slash & "com.livecode.extensions.livecode." & pName) then
-        put (tExtensionsFolder & slash & "com.livecode.extensions.livecode." & pName) into tExtensionFolder
+      if there is a folder (tExtensionsFolder & slash & tExtensionUnzipFolder) then
+        put (tExtensionsFolder & slash & tExtensionUnzipFolder) into tExtensionFolder
       end if
    end if
+   
+    TestDiagnostic tExtensionFolder
    
    local tExtensionFile
    if tExtensionFolder is not empty then

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -140,11 +140,11 @@ on TestLoadExtension pName
    local tExtensionsFolder
    set the itemdelimiter to slash
    repeat while tPath is not tEnginePath and tPath is not empty
-      delete item -1 of tPath
       if there is a folder (tPath & slash & "packaged_extensions") then
          put (tPath & slash & "packaged_extensions") into tExtensionsFolder
          exit repeat
       end if
+      delete item -1 of tPath
    end repeat
 
    local tExtensionFolder

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -127,3 +127,53 @@ function TestGetIDERepositoryPath
   set the itemdelimiter to "/"
   return item 1 to -3 of the filename of me & slash & "ide"
 end TestGetIDERepositoryPath
+
+on TestLoadExtension pName
+   local tPath, tEnginePath
+   put specialfolderpath("engine") into tPath
+   put TestGetEngineRepositoryPath() into tEnginePath
+   
+   local tError
+   put "extension" && pName && "not found" into tError
+   
+   # Find the built extensions folder
+   local tExtensionsFolder
+   set the itemdelimiter to slash
+   repeat while tPath is not tEnginePath and tPath is not empty
+      delete item -1 of tPath
+      if there is a folder (tPath & slash & "packaged_extensions") then
+         put (tPath & slash & "packaged_extensions") into tExtensionsFolder
+         exit repeat
+      end if
+   end repeat
+
+   local tExtensionFolder
+   if tExtensionsFolder is not empty then
+      if there is a folder (tExtensionsFolder & slash & "com.livecode.extensions.livecode." & pName) then
+        put (tExtensionsFolder & slash & "com.livecode.extensions.livecode." & pName) into tExtensionFolder
+      end if
+   end if
+   
+   local tExtensionFile
+   if tExtensionFolder is not empty then
+      if there is a file (tExtensionFolder & slash & "module.lcm") then
+         put (tExtensionFolder & slash & "module.lcm") into tExtensionFile
+      end if
+   end if
+   
+   if tExtensionFile is not empty then
+      if there is a folder (tExtensionFolder & slash & "resources") then
+         load extension from file tExtensionFile with resource path (tExtensionFolder & slash & "resources")
+      else
+         load extension from file tExtensionFile
+      end if
+      
+      put the result into tError
+   end if
+   
+   if tError is not empty then
+      write tError & return to stderr
+      quit 1
+   end if
+   
+end TestLoadExtension


### PR DESCRIPTION
This patch adds extension testing to our continuous integration, by adding a further check target in the
extensions directory. At some point the tests/Makefile will need tweaking to make sure that only
<extension>/tests/ directories are searched for suitable test handlers.

Also TestLoadExtension has been added to the test library to facilitate loading of extensions in the
TestSetup handler. At some point it might make sense for extension tests to automatically load themselves
but for now it seems fine to have them do it explicitly.

Note this does no dependency analysis, so it is currently not possible to test extensions that rely on modules
other than those built in to the engine.
