### PR TITLE
[[ Bugfix 16363 ]] Reinstate dismissing menus by clicking outside

### DIFF
--- a/docs/notes/bugfix-16363.md
+++ b/docs/notes/bugfix-16363.md
@@ -1,0 +1,2 @@
+# Restore the ability to dismiss menus by clicking outside them
+

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -1370,8 +1370,37 @@ Boolean MCButton::mup(uint2 which, bool p_release)
                 // If the mouse release was handled, close the submenu. This
                 // takes care of backwards compatibility. Otherwise, ignore the
                 // mouse-up event.
+                //
+                // We also need to close the menu if the button release happened
+                // outside of the menu tree.
+                bool t_outside = true;
+                MCObject* t_menu = this;
+                while (t_outside && t_menu != NULL)
+                {
+                    // Check whether the click was inside the menu (the rect
+                    // that we need to check is the rect of the stack containing
+                    // the menu).
+                    MCRectangle t_rect = t_menu->getstack()->getrect();
+                    t_outside = (t_rect.x < MCmousex
+                                 || MCmousex >= (t_rect.x + t_rect.width)
+                                 || t_rect.y < MCmousey
+                                 || MCmousey >= (t_rect.y + t_rect.height));
+                    
+                    // Move to the parent menu, if it exists
+                    if (t_menu->getstack()->getparent()    // Stack's parent
+                        && t_menu->getstack()->getparent()->gettype() == CT_BUTTON)
+                    {
+                        // This is a submenu
+                        t_menu = t_menu->getstack()->getparent();
+                    }
+                    else
+                    {
+                        // We walked up to the top of the submenu tree
+                        t_menu = NULL;
+                    }
+                }
                 Exec_stat es = message_with_args(MCM_mouse_release, which);
-                if (es != ES_NOT_HANDLED && es != ES_PASS)
+                if (t_outside || (es != ES_NOT_HANDLED && es != ES_PASS))
                     closemenu(True, True);
             }
 		}


### PR DESCRIPTION
The fix that caused clicks on submenu anchors within a menu tree
to be ignored broke the ability to close menus by clicking outside
them. This patch allows both behaviours to co-exist.
