### PR TITLE
[[ Bug 16320 ]] Ensure correct params are passed to script in action messages

### DIFF
--- a/extensions/widgets/treeview/notes/16320.md
+++ b/extensions/widgets/treeview/notes/16320.md
@@ -1,0 +1,1 @@
+# [16320] actionInspect and actionDoubleClicked messages don't pass full path parameters

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -793,8 +793,10 @@ public handler OnClick() returns nothing
 		return
 	end if
 
+    variable tPathString as String
     if mHoverIcon is "inspect" then
-        post "actionInspect" with tData["path"]
+        combine tData["path"] with "," into tPathString
+        post "actionInspect" with [tPathString]
         return
     end if
 
@@ -830,7 +832,8 @@ public handler OnClick() returns nothing
 
 	if the click count > 1 then
 		if tData["leaf"] then
-			post "actionDoubleClick" with tData["path"]
+            combine tData["path"] with "," into tPathString
+			post "actionDoubleClick" with [tPathString]
 		else
 		   if tData["folded"] is true then
 			   unfoldPath(tData["path"])


### PR DESCRIPTION
This was causing the pop-out stack in variable viewer not to contain the sub-array values.
