### PR TITLE
[Bug 16021] segmented: Correctly compute icon bounding box

### DIFF
--- a/extensions/widgets/segmented/notes/16021.md
+++ b/extensions/widgets/segmented/notes/16021.md
@@ -1,0 +1,3 @@
+# Segment widths
+
+# [16021] Segmented widget shrinks icons if you resize the widget

--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -544,7 +544,22 @@ private handler drawSegments() returns nothing
 
 		variable tIconPath as Path
 		variable tIconRect as Rectangle
-		put rectangle [mLeft + tWidth * kIconPaddingRatio, tWidth * kIconPaddingRatio, mLeft + tWidth * (1 - kIconPaddingRatio), my height - (tWidth * kIconPaddingRatio)] into tIconRect
+
+		-- Compute the size of icon that can be fitted into
+		-- widget given the padding ratio
+		variable tIconSize as Number
+		if tWidth > my height then
+			put my height * (1 - 2*kIconPaddingRatio) into tIconSize
+		else
+			put tWidth * (1 - 2*kIconPaddingRatio) into tIconSize
+		end if
+
+		-- Compute the corresponding icon bounding box
+		put rectangle [mLeft + (tWidth - tIconSize) / 2, \
+			(my height - tIconSize) / 2, \
+			mLeft + (tIconSize + tWidth) / 2, \
+			(my height + tIconSize) / 2] into tIconRect
+
 		if mSegmentDisplay is "icon" then
 			if tIsIn then
 				put path iconSVGPathFromName(element tX of mSelectedIcons) into tIconPath


### PR DESCRIPTION
The bounding box for the icons in the segmented widget were being
computed incorrectly in the case that the segment width was greater
than the segment height.  This caused weird things to happen as the
widget was resized.

This patch changes the code to first find the largest icon size that
will fit, and then compute the appropriate icon bounding box
accordingly.
