### PR TITLE
[Bug 16021] segmented: Fit non-square icons correctly.

### DIFF
--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -545,20 +545,20 @@ private handler drawSegments() returns nothing
 		variable tIconPath as Path
 		variable tIconRect as Rectangle
 
-		-- Compute the size of icon that can be fitted into
-		-- widget given the padding ratio
-		variable tIconSize as Number
+		-- Compute the minimum margin required to provide the correct
+		-- padding ratio.
+		variable tIconMargin as Number
 		if tWidth > my height then
-			put my height * (1 - 2*kIconPaddingRatio) into tIconSize
+			put my height * kIconPaddingRatio into tIconMargin
 		else
-			put tWidth * (1 - 2*kIconPaddingRatio) into tIconSize
+			put tWidth * kIconPaddingRatio into tIconMargin
 		end if
 
 		-- Compute the corresponding icon bounding box
-		put rectangle [mLeft + (tWidth - tIconSize) / 2, \
-			(my height - tIconSize) / 2, \
-			mLeft + (tIconSize + tWidth) / 2, \
-			(my height + tIconSize) / 2] into tIconRect
+		put rectangle [mLeft + tIconMargin, \
+			tIconMargin, \
+			mLeft + tWidth - tIconMargin, \
+			my height - tIconMargin] into tIconRect
 
 		if mSegmentDisplay is "icon" then
 			if tIsIn then


### PR DESCRIPTION
The fix in commit 205e7fc70c2c was correct for square icons, but would
result in pessimistic fitting for non-square icons.  This patch
changes the logic to compute the minimum necessary padding within the
segment, and then the maximum icon bounding rectangle that provides
that padding.  This gives the same result as before for square icons,
but allows non-square icons to be as large as possible.
