### PR TITLE
[Bug 15435] Refactor precedence levels in LiveCode Builder

### DIFF
--- a/docs/lcb/notes/feature-precedence.md
+++ b/docs/lcb/notes/feature-precedence.md
@@ -1,0 +1,21 @@
+# LiveCode Builder Language
+
+## Operator Precedence
+
+The precedence of LCB syntax operators has been reworked to use a
+defined set of 23 named precedence classes.  This is to ensure
+predictable and consistent interactions when multiple LCB operators
+are used in a single expression.
+
+There are two changes which are likely to significantly affect
+pre-existing LCB code:
+
+* "property", "subscript chunk", "function chunk" and "constructor
+  chunk" syntax classes now always have higher precedence than
+  arithmetic operators.  In particular, this change is likely to
+  require additional parentheses `(...)` around arithmetic operations
+  when using the LCB canvas API.
+
+* the precedence of the logical `not` operator has been reduced to
+  below that of comparison operators.  This may allow removal of
+  parentheses in the condition clauses of `if` statements.

--- a/docs/lcb/notes/feature-precedence.md
+++ b/docs/lcb/notes/feature-precedence.md
@@ -7,15 +7,7 @@ defined set of 23 named precedence classes.  This is to ensure
 predictable and consistent interactions when multiple LCB operators
 are used in a single expression.
 
-There are two changes which are likely to significantly affect
-pre-existing LCB code:
-
-* "property", "subscript chunk", "function chunk" and "constructor
-  chunk" syntax classes now always have higher precedence than
-  arithmetic operators.  In particular, this change is likely to
-  require additional parentheses `(...)` around arithmetic operations
-  when using the LCB canvas API.
-
-* the precedence of the logical `not` operator has been reduced to
-  below that of comparison operators.  This may allow removal of
-  parentheses in the condition clauses of `if` statements.
+There only change that is likely to significantly affect pre-existing
+LCB code is the reduction in precedence of the logical `not` operator
+to below that of comparison operators.  This may allow removal of
+parentheses in the condition clauses of `if` statements.

--- a/docs/specs/lcb-precedence.md
+++ b/docs/specs/lcb-precedence.md
@@ -31,9 +31,8 @@ Lower precedence numbers are more tightly-binding.
 |       | subscript         | `tList[1]`, `tArray["key"]`   |
 | 3     | property          | `the paint of this canvas`    |
 |       | subscript chunk   | `char 2 of tString`           |
-|       | function chunk    | `the length of tList`         |
-|       | constructor       | `rectangle tList`             |
 | 4     | conversion        | `tString parsed as number`    |
+|       | function chunk    | `the offset of "o" in "foo"`  |
 | 5     | modifier          | `-tNum`, `bitwise not`        |
 | 6     | exponentiation    | `^`                           |
 | 7     | multiplication    | `/`,`*`,`mod`, `div`          |
@@ -43,9 +42,10 @@ Lower precedence numbers are more tightly-binding.
 | 10    | bitwise and       | `7 bitwise and 1`             |
 | 11    | bitwise xor       | `7 bitwise xor 5`             |
 | 12    | bitwise or        | `2 bitwise or 4`              |
-| 13    | comparison        | `<=`, `<`, `is`               |
+| 13    | constructor       | `rectangle tList`             |
+| 14    | comparison        | `<=`, `<`, `is`               |
 |       | classification    | `is a`                        |
-| 14    | logical not       | `not tBoolean`                |
-| 15    | logical and       | `Foo() and Bar()`             |
-| 16    | logical or        | `Foo() or Bar()`              |
-| 17    | sequence          | `,`                           |
+| 15    | logical not       | `not tBoolean`                |
+| 16    | logical and       | `Foo() and Bar()`             |
+| 17    | logical or        | `Foo() or Bar()`              |
+| 18    | sequence          | `,`                           |

--- a/docs/specs/lcb-precedence.md
+++ b/docs/specs/lcb-precedence.md
@@ -32,7 +32,7 @@ Lower precedence numbers are more tightly-binding.
 | 3     | property          | `the paint of this canvas`    |
 |       | subscript chunk   | `char 2 of tString`           |
 |       | function chunk    | `the length of tList`         |
-|       | constructor chunk | `rectangle tList`             |
+|       | constructor       | `rectangle tList`             |
 | 4     | conversion        | `tString parsed as number`    |
 | 5     | modifier          | `-tNum`, `bitwise not`        |
 | 6     | exponentiation    | `^`                           |

--- a/docs/specs/lcb-precedence.md
+++ b/docs/specs/lcb-precedence.md
@@ -1,0 +1,51 @@
+# Operator Precedence in LiveCode builder
+Copyright © LiveCode Ltd.
+
+## Introduction
+
+The Builder standard library provides a large variety of syntax definitions.
+Syntax operators can be combined in a huge number of ways, and it's important
+that the interaction is sensible and consistent.
+
+Choosing appropriate precedence levels fulfils some important objectives:
+
+- The ordering of precedence is consistent with LiveCode Script
+- Complicated expressions can easily be written without needing many
+  parentheses `(…)`
+- The ordering of precedence is reasonably consistent with other programming
+  languages
+
+The precedence levels are named.  This makes it much clearer, when reading an
+operator syntax definition, why its assigned precedence level is appropriate.
+
+Multiple named precedence levels may share the same numeric priority.
+
+## Precedence levels
+
+Lower precedence numbers are more tightly-binding.
+
+| Level | Name              | Examples                      |
+|-------|-------------------|-------------------------------|
+| 1     | scope resolution  | `.`                           |
+| 2     | function call     | `MyHandler()`                 |
+|       | subscript         | `tList[1]`, `tArray["key"]`   |
+| 3     | property          | `the paint of this canvas`    |
+|       | subscript chunk   | `char 2 of tString`           |
+|       | function chunk    | `the length of tList`         |
+|       | constructor chunk | `rectangle tList`             |
+| 4     | conversion        | `tString parsed as number`    |
+| 5     | modifier          | `-tNum`, `bitwise not`        |
+| 6     | exponentiation    | `^`                           |
+| 7     | multiplication    | `/`,`*`,`mod`, `div`          |
+| 8     | addition          | `+`, `-`                      |
+|       | concatenation     | `&`, `&&`                     |
+| 9     | bitwise shift     | `1 shifted left by 3 bitwise` |
+| 10    | bitwise and       | `7 bitwise and 1`             |
+| 11    | bitwise xor       | `7 bitwise xor 5`             |
+| 12    | bitwise or        | `2 bitwise or 4`              |
+| 13    | comparison        | `<=`, `<`, `is`               |
+|       | classification    | `is a`                        |
+| 14    | logical not       | `not tBoolean`                |
+| 15    | logical and       | `Foo() and Bar()`             |
+| 16    | logical or        | `Foo() or Bar()`              |
+| 17    | sequence          | `,`                           |

--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -99,7 +99,7 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectangleMake is prefix operator with precedence 2
+syntax RectangleMake is prefix operator with constructor chunk precedence
 	"rectangle" <mRect: Expression>
 begin
     MCCanvasRectangleMakeWithList(mRect, output)
@@ -129,14 +129,14 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectanglePropertyLeft is prefix operator with precedence 2
+syntax RectanglePropertyLeft is prefix operator with property precedence
 	"the" "left" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetLeft(mRect, output)
 	MCCanvasRectangleSetLeft(input, mRect)
 end syntax
 
-syntax RectanglePropertyX is prefix operator with precedence 2
+syntax RectanglePropertyX is prefix operator with property precedence
 	"the" "x" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetLeft(mRect, output)
@@ -167,14 +167,14 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectanglePropertyTop is prefix operator with precedence 2
+syntax RectanglePropertyTop is prefix operator with property precedence
 	"the" "top" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetTop(mRect, output)
 	MCCanvasRectangleSetTop(input, mRect)
 end syntax
 
-syntax RectanglePropertyY is prefix operator with precedence 2
+syntax RectanglePropertyY is prefix operator with property precedence
 	"the" "y" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetTop(mRect, output)
@@ -205,7 +205,7 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectanglePropertyRight is prefix operator with precedence 2
+syntax RectanglePropertyRight is prefix operator with property precedence
 	"the" "right" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetRight(mRect, output)
@@ -236,7 +236,7 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectanglePropertyBottom is prefix operator with precedence 2
+syntax RectanglePropertyBottom is prefix operator with property precedence
 	"the" "bottom" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetBottom(mRect, output)
@@ -267,7 +267,7 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectanglePropertyWidth is prefix operator with precedence 2
+syntax RectanglePropertyWidth is prefix operator with property precedence
 	"the" "width" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetWidth(mRect, output)
@@ -298,7 +298,7 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectanglePropertyHeight is prefix operator with precedence 2
+syntax RectanglePropertyHeight is prefix operator with property precedence
 	"the" "height" "of" <mRect:Expression>
 begin
 	MCCanvasRectangleGetHeight(mRect, output)
@@ -331,7 +331,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax PointMake is prefix operator with precedence 2
+syntax PointMake is prefix operator with property precedence
 	"point" <mPoint: Expression>
 begin
 	MCCanvasPointMakeWithList(mPoint, output)
@@ -358,7 +358,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax PointPropertyX is prefix operator with precedence 2
+syntax PointPropertyX is prefix operator with property precedence
 	"the" "x" "of" <mPoint: Expression>
 begin
 	MCCanvasPointGetX(mPoint, output)
@@ -386,7 +386,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax PointPropertyY is prefix operator with precedence 2
+syntax PointPropertyY is prefix operator with property precedence
 	"the" "y" "of" <mPoint: Expression>
 begin
 	MCCanvasPointGetY(mPoint, output)
@@ -423,7 +423,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ColorMake is prefix operator with precedence 4
+syntax ColorMake is prefix operator with constructor chunk precedence
 	"color" <mColor: Expression>
 begin
 	MCCanvasColorMakeWithList(mColor, output)
@@ -466,7 +466,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ColorPropertyRed is prefix operator with precedence 4
+syntax ColorPropertyRed is prefix operator with property precedence
 	"the" "red" "of" <mColor: Expression>
 begin
 	MCCanvasColorGetRed(mColor, output)
@@ -497,7 +497,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ColorPropertyGreen is prefix operator with precedence 4
+syntax ColorPropertyGreen is prefix operator with property precedence
 	"the" "green" "of" <mColor: Expression>
 begin
 	MCCanvasColorGetGreen(mColor, output)
@@ -528,7 +528,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ColorPropertyBlue is prefix operator with precedence 4
+syntax ColorPropertyBlue is prefix operator with property precedence
 	"the" "blue" "of" <mColor: Expression>
 begin
 	MCCanvasColorGetBlue(mColor, output)
@@ -559,7 +559,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ColorPropertyAlpha is prefix operator with precedence 4
+syntax ColorPropertyAlpha is prefix operator with property precedence
 	"the" "alpha" "of" <mColor: Expression>
 begin
 	MCCanvasColorGetAlpha(mColor, output)
@@ -621,7 +621,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeScale is prefix operator with precedence 4
+syntax TransformMakeScale is prefix operator with constructor chunk precedence
 	"transform" "with" "scale" <mScale: Expression>
 begin
     MCCanvasTransformMakeScaleWithList(mScale, output)
@@ -642,7 +642,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeSkew is prefix operator with precedence 4
+syntax TransformMakeSkew is prefix operator with constructor chunk precedence
 	"transform" "with" "skew" <mSkew: Expression>
 begin
 	MCCanvasTransformMakeSkewWithList(mSkew, output)
@@ -663,7 +663,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeRotation is prefix operator with precedence 4
+syntax TransformMakeRotation is prefix operator with constructor chunk precedence
 	"transform" "with" "rotation" "by" <mRotation: Expression>
 begin
 	MCCanvasTransformMakeRotation(mRotation, output)
@@ -684,7 +684,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeTranslation is prefix operator with precedence 4
+syntax TransformMakeTranslation is prefix operator with constructor chunk precedence
 	"transform" "with" "translation" <mTranslation: Expression>
 begin
     MCCanvasTransformMakeTranslationWithList(mTranslation, output)
@@ -705,7 +705,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeWithMatrixAsList is prefix operator with precedence 4
+syntax TransformMakeWithMatrixAsList is prefix operator with constructor chunk precedence
 	"transform" "with" "matrix" <mMatrix: Expression>
 begin
 	MCCanvasTransformMakeWithMatrixAsList(mMatrix, output)
@@ -749,7 +749,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformPropertyScale is prefix operator with precedence 4
+syntax TransformPropertyScale is prefix operator with property precedence
 	"the" "scale" "of" <mTransform: Expression>
 begin
 	MCCanvasTransformGetScaleAsList(mTransform, output)
@@ -777,7 +777,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformPropertyRotation is prefix operator with precedence 4
+syntax TransformPropertyRotation is prefix operator with property precedence
 	"the" "rotation" "of" <mTransform: Expression>
 begin
 	MCCanvasTransformGetRotation(mTransform, output)
@@ -805,7 +805,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformPropertySkew is prefix operator with precedence 4
+syntax TransformPropertySkew is prefix operator with property precedence
 	"the" "skew" "of" <mTransform: Expression>
 begin
 	MCCanvasTransformGetSkewAsList(mTransform, output)
@@ -833,7 +833,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformPropertyTranslation is prefix operator with precedence 4
+syntax TransformPropertyTranslation is prefix operator with property precedence
 	"the" "translation" "of" <mTransform: Expression>
 begin
 	MCCanvasTransformGetTranslationAsList(mTransform, output)
@@ -867,7 +867,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformPropertyMatrixAsList is prefix operator with precedence 4
+syntax TransformPropertyMatrixAsList is prefix operator with property precedence
 	"the" "matrix" "of" <mTransform: Expression>
 begin
 	MCCanvasTransformGetMatrixAsList(mTransform, output)
@@ -898,7 +898,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformPropertyInverse is prefix operator with precedence 4
+syntax TransformPropertyInverse is prefix operator with property precedence
 	"the" "inverse" "of" <mTransform: Expression>
 begin
 	MCCanvasTransformGetInverse(mTransform, output)
@@ -1096,7 +1096,7 @@ Note:
 Tags: Canvas
 */
 
-syntax TransformOperationMultiply is left binary operator with precedence 3
+syntax TransformOperationMultiply is left binary operator with multiplication precedence
 	<Left: Expression> "*" <Right: Expression>
 begin
 	MCCanvasTransformMultiply(Left, Right, output)
@@ -1124,7 +1124,7 @@ Example:
 Tags: Canvas
 */
 
-syntax SolidPaintMake is prefix operator with precedence 4
+syntax SolidPaintMake is prefix operator with constructor chunk precedence
 	"solid" "paint" "with" <mColor: Expression>
 begin
 	MCCanvasSolidPaintMakeWithColor(mColor, output)
@@ -1159,7 +1159,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax SolidPaintPropertyColor is prefix operator with precedence 4
+syntax SolidPaintPropertyColor is prefix operator with property precedence
 	"the" "color" "of" <mSolid: Expression>
 begin
 	MCCanvasSolidPaintGetColor(mSolid, output)
@@ -1198,7 +1198,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMake is prefix operator with precedence 4
+syntax PatternMake is prefix operator with constructor chunk precedence
 	"pattern" "with" <mImage: Expression>
 begin
 	MCCanvasPatternMakeWithImage(mImage, output)
@@ -1228,7 +1228,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeTransformed is prefix operator with precedence 4
+syntax PatternMakeTransformed is prefix operator with constructor chunk precedence
 	"pattern" "with" <mImage: Expression> "transformed" "by" <mTransform: Expression>
 begin
     MCCanvasPatternMakeWithTransformedImage(mImage, mTransform, output)
@@ -1254,7 +1254,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeScaledBy is prefix operator with precedence 4
+syntax PatternMakeScaledBy is prefix operator with constructor chunk precedence
     "pattern" "with" <mImage: Expression> "scaled" "by" <mScale: Expression>
 begin
 	MCCanvasPatternMakeWithImageScaledWithList(mImage, mScale, output)
@@ -1282,7 +1282,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeTranslatedBy is prefix operator with precedence 4
+syntax PatternMakeTranslatedBy is prefix operator with constructor chunk precedence
     "pattern" "with" <mImage: Expression> "translated" "by" <mTranslation: Expression>
 begin
 	MCCanvasPatternMakeWithImageTranslatedWithList(mImage, mTranslation, output)
@@ -1308,7 +1308,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeRotatedBy is prefix operator with precedence 4
+syntax PatternMakeRotatedBy is prefix operator with constructor chunk precedence
     "pattern" "with" <mImage: Expression> "rotated" "by" <mRotation: Expression>
 begin
 	MCCanvasPatternMakeWithRotatedImage(mImage, mRotation, output)
@@ -1345,7 +1345,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax PatternPropertyImage is prefix operator with precedence 4
+syntax PatternPropertyImage is prefix operator with property precedence
 	"the" "image" "of" <mPattern: Expression>
 begin
 	MCCanvasPatternGetImage(mPattern, output)
@@ -1377,7 +1377,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax PatternPropertyTransform is prefix operator with precedence 4
+syntax PatternPropertyTransform is prefix operator with property precedence
 	"the" "transform" "of" <mPattern: Expression>
 begin
 	MCCanvasPatternGetTransform(mPattern, output)
@@ -1542,7 +1542,7 @@ Example:
 Tags: Canvas
 */
 
-syntax GradientStopMake is prefix operator with precedence 4
+syntax GradientStopMake is prefix operator with constructor chunk precedence
 	"gradient" "stop" "at" <mOffset: Expression> "with" <mColor: Expression>
 begin
 	MCCanvasGradientStopMake(mOffset, mColor, output)
@@ -1572,7 +1572,7 @@ Example:
 Tags: Canvas
 */
 
-syntax GradientMakeWithRamp is prefix operator with precedence 4
+syntax GradientMakeWithRamp is prefix operator with constructor chunk precedence
 	<mType: GradientType> "gradient" "with" "ramp" <mRamp: Expression>
 begin
 	MCCanvasGradientMakeWithRamp(mType, mRamp, output)
@@ -1629,7 +1629,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientStopPropertyOffset is prefix operator with precedence 4
+syntax GradientStopPropertyOffset is prefix operator with property precedence
 	"the" "offset" "of" <mStop: Expression>
 begin
 	MCCanvasGradientStopGetOffset(mStop, output)
@@ -1657,7 +1657,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientStopPropertyColor is prefix operator with precedence 4
+syntax GradientStopPropertyColor is prefix operator with property precedence
 	"the" "color" "of" <mStop: Expression>
 begin
 	MCCanvasGradientStopGetColor(mStop, output)
@@ -1689,7 +1689,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyRamp is prefix operator with precedence 4
+syntax GradientPropertyRamp is prefix operator with property precedence
 	"the" "ramp" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetRamp(mGradient, output)
@@ -1718,7 +1718,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyType is prefix operator with precedence 4
+syntax GradientPropertyType is prefix operator with property precedence
 	"the" "type" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetTypeAsString(mGradient, output)
@@ -1747,7 +1747,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyRepeat is prefix operator with precedence 4
+syntax GradientPropertyRepeat is prefix operator with property precedence
 	"the" "repeat" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetRepeat(mGradient, output)
@@ -1774,7 +1774,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyWrap is prefix operator with precedence 4
+syntax GradientPropertyWrap is prefix operator with property precedence
 	"the" "wrap" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetWrap(mGradient, output)
@@ -1801,7 +1801,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyMirror is prefix operator with precedence 4
+syntax GradientPropertyMirror is prefix operator with property precedence
 	"the" "mirror" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetMirror(mGradient, output)
@@ -1829,7 +1829,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyFrom is prefix operator with precedence 4
+syntax GradientPropertyFrom is prefix operator with property precedence
 	"the" "from" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetFrom(mGradient, output)
@@ -1857,7 +1857,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyTo is prefix operator with precedence 4
+syntax GradientPropertyTo is prefix operator with property precedence
 	"the" "to" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetTo(mGradient, output)
@@ -1885,7 +1885,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyVia is prefix operator with precedence 4
+syntax GradientPropertyVia is prefix operator with property precedence
 	"the" "via" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetVia(mGradient, output)
@@ -1923,7 +1923,7 @@ Example:
 Tags:	Canvas
 */
 
-syntax GradientPropertyTransform is prefix operator with precedence 4
+syntax GradientPropertyTransform is prefix operator with property precedence
 	"the" "transform" "of" <mGradient: Expression>
 begin
 	MCCanvasGradientGetTransform(mGradient, output)
@@ -2098,7 +2098,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ImageMakeFromFile is prefix operator with precedence 4
+syntax ImageMakeFromFile is prefix operator with constructor chunk precedence
 	"image" "from" "file" <mPath: Expression>
 begin
 	MCCanvasImageMakeWithPath(mPath, output)
@@ -2120,7 +2120,7 @@ Example:
 
 Tags: Canvas
 */
-syntax ImageMakeFromResourceFile is prefix operator with precedence 4
+syntax ImageMakeFromResourceFile is prefix operator with constructor chunk precedence
 	"image" "from" "resource" "file" <mResource: Expression>
 begin
 	MCCanvasImageMakeWithResourceFile(mResource, output)
@@ -2145,7 +2145,7 @@ Example:
 
 Tags: Canvas
 */
-syntax ImageMakeFromData is prefix operator with precedence 4
+syntax ImageMakeFromData is prefix operator with constructor chunk precedence
 	"image" "from" "data" <mData: Expression>
 begin
 	MCCanvasImageMakeWithData(mData, output)
@@ -2172,7 +2172,7 @@ Example:
 
 Tags: Canvas
 */
-syntax ImageMakeWithPixels is prefix operator with precedence 4
+syntax ImageMakeWithPixels is prefix operator with constructor chunk precedence
 	"image" "of" "size" <mSize: Expression> "with" "pixels" <mPixels: Expression>
 begin
 //	MCCanvasImageMakeWithPixels(mSize[0], mSize[1], mPixels, output)
@@ -2210,7 +2210,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax ImagePropertyWidth is prefix operator with precedence 2
+syntax ImagePropertyWidth is prefix operator with property precedence
 	"the" "width" "of" <mImage: Expression>
 begin
 	MCCanvasImageGetWidth(mImage, output)
@@ -2236,7 +2236,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax ImagePropertyHeight is prefix operator with precedence 2
+syntax ImagePropertyHeight is prefix operator with property precedence
 	"the" "height" "of" <mImage: Expression>
 begin
 	MCCanvasImageGetHeight(mImage, output)
@@ -2244,7 +2244,7 @@ end syntax
 
 //////////
 
-//syntax ImageMetadataProperty is prefix operator with precedence 4
+//syntax ImageMetadataProperty is prefix operator with property precedence
 //	"the" "metadata" "of" <mImage: Expression>
 //begin
 //	MCCanvasImageGetMetadata(mImage, output)
@@ -2270,7 +2270,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax ImagePropertyPixels is prefix operator with precedence 4
+syntax ImagePropertyPixels is prefix operator with property precedence
 	"the" "pixels" "of" <mImage: Expression>
 begin
 	MCCanvasImageGetPixels(mImage, output)
@@ -2363,7 +2363,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMake is prefix operator with precedence 4
+syntax PathMake is prefix operator with constructor chunk precedence
 	"path" <mInstructions: Expression>
 begin
 	MCCanvasPathMakeWithInstructionsAsString(mInstructions, output)
@@ -2412,13 +2412,13 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithRoundedRectangleWithRadius is prefix operator with precedence 4
+syntax PathMakeWithRoundedRectangleWithRadius is prefix operator with constructor chunk precedence
 	"rounded" "rectangle" "path" "of" <mRect: Expression> "with" "radius" <mRadius: Expression>
 begin
 	MCCanvasPathMakeWithRoundedRectangle(mRect, mRadius, output)
 end syntax
 
-syntax PathMakeWithRoundedRectangleWithRadii is prefix operator with precedence 4
+syntax PathMakeWithRoundedRectangleWithRadii is prefix operator with constructor chunk precedence
 	"rounded" "rectangle" "path" "of" <mRect: Expression> "with" "radii" <mRadii: Expression>
 begin
 	MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(mRect, mRadii, output)
@@ -2440,7 +2440,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithRectangle is prefix operator with precedence 4
+syntax PathMakeWithRectangle is prefix operator with constructor chunk precedence
 	"rectangle" "path" "of" <mRect: Expression>
 begin
 	MCCanvasPathMakeWithRectangle(mRect, output)
@@ -2463,7 +2463,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithCircle is prefix operator with precedence 4
+syntax PathMakeWithCircle is prefix operator with constructor chunk precedence
 	"circle" "path" "centered" "at" <mCenter: Expression> "with" "radius" <mRadius: Expression>
 begin
 	MCCanvasPathMakeWithCircle(mCenter, mRadius, output)
@@ -2486,7 +2486,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithEllipse is prefix operator with precedence 4
+syntax PathMakeWithEllipse is prefix operator with constructor chunk precedence
 	"ellipse" "path" "centered" "at" <mPoint: Expression> "with" "radii" <mRadii: Expression>
 begin
 	MCCanvasPathMakeWithEllipseWithRadiiAsList(mPoint, mRadii, output)
@@ -2509,7 +2509,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithLine is prefix operator with precedence 4
+syntax PathMakeWithLine is prefix operator with constructor chunk precedence
 	"line" "path" "from" <mFrom: Expression> "to" <mTo: Expression>
 begin
 	MCCanvasPathMakeWithLine(mFrom, mTo, output)
@@ -2536,7 +2536,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithPoints is prefix operator with precedence 4
+syntax PathMakeWithPoints is prefix operator with constructor chunk precedence
 	( "polygon" <mClosed=true> | "polyline" <mClosed=false> ) "path" "with" "points" <mPoints: Expression>
 begin
 	MCCanvasPathMakeWithPoints(mClosed, mPoints, output)
@@ -2566,7 +2566,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithArc is prefix operator with precedence 4
+syntax PathMakeWithArc is prefix operator with constructor chunk precedence
 	"arc" "path" "centered" "at" <mCenter: Expression> "with" [ "radius" <mRadius: Expression> | "radii" <mRadii: Expression> ] "from" <mStartAngle: Expression> "to" <mEndAngle: Expression>
 begin
 	MCCanvasPathMakeWithArcWithRadius(mCenter, mRadius, mStartAngle, mEndAngle, output)
@@ -2597,7 +2597,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithSector is prefix operator with precedence 4
+syntax PathMakeWithSector is prefix operator with constructor chunk precedence
 	"sector" "path" "centered" "at" <mCenter: Expression> "with" [ "radius" <mRadius: Expression> | "radii" <mRadii: Expression> ] "from" <mStartAngle: Expression> "to" <mEndAngle: Expression>
 begin
 	MCCanvasPathMakeWithSectorWithRadius(mCenter, mRadius, mStartAngle, mEndAngle, output)
@@ -2628,7 +2628,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithSegment is prefix operator with precedence 4
+syntax PathMakeWithSegment is prefix operator with constructor chunk precedence
 	"segment" "path" "centered" "at" <mCenter: Expression> "with" [ "radius" <mRadius: Expression> | "radii" <mRadii: Expression> ] "from" <mStartAngle: Expression> "to" <mEndAngle: Expression>
 begin
 	MCCanvasPathMakeWithSegmentWithRadius(mCenter, mRadius, mStartAngle, mEndAngle, output)
@@ -2669,7 +2669,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax PathPropertySubpath is prefix operator with precedence 4
+syntax PathPropertySubpath is prefix operator with property precedence
 	"subpath" <mStart: Expression> [ "to" <mEnd: Expression> ] "of" <mPath: Expression>
 begin
 	MCCanvasPathGetSubpaths(mStart, mEnd, mPath, output)
@@ -2696,7 +2696,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax PathPropertyBoundingBox is prefix operator with precedence 4
+syntax PathPropertyBoundingBox is prefix operator with property precedence
 	"the" "bounding" "box" "of" <mPath: Expression>
 begin
 	MCCanvasPathGetBoundingBox(mPath, output)
@@ -2723,7 +2723,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax PathPropertyInstructions is prefix operator with precedence 4
+syntax PathPropertyInstructions is prefix operator with property precedence
 	"the" "instructions" "of" <mPath: Expression>
 begin
 	MCCanvasPathGetInstructionsAsString(mPath, output)
@@ -3198,7 +3198,7 @@ Example:
 
 Tags: Canvas
 */
-syntax EffectMakeWithProperties is prefix operator with precedence 4
+syntax EffectMakeWithProperties is prefix operator with constructor chunk precedence
 	<mType: EffectType> "effect" "with" "properties" <mProperties: Expression>
 begin
 	MCCanvasEffectMakeWithPropertyArray(mType, mProperties, output)
@@ -3250,7 +3250,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertyType is prefix operator with precedence 4
+syntax EffectPropertyType is prefix operator with property precedence
 	"the" "type" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetTypeAsString(mEffect, output)
@@ -3280,7 +3280,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertyColor is prefix operator with precedence 4
+syntax EffectPropertyColor is prefix operator with property precedence
 	"the" "color" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetColor(mEffect, output)
@@ -3312,7 +3312,7 @@ Example:
 Tags:	Canvas
 References: CanvasPropertyBlendMode(operator):
 */
-syntax EffectPropertyBlendMode is prefix operator with precedence 4
+syntax EffectPropertyBlendMode is prefix operator with property precedence
 	"the" "blend" "mode" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetBlendModeAsString(mEffect, output)
@@ -3343,7 +3343,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertySize is prefix operator with precedence 4
+syntax EffectPropertySize is prefix operator with property precedence
 	"the" "size" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetSize(mEffect, output)
@@ -3374,7 +3374,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertySpread is prefix operator with precedence 4
+syntax EffectPropertySpread is prefix operator with property precedence
 	"the" "spread" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetSpread(mEffect, output)
@@ -3405,7 +3405,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertyDistance is prefix operator with precedence 4
+syntax EffectPropertyDistance is prefix operator with property precedence
 	"the" "distance" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetDistance(mEffect, output)
@@ -3436,7 +3436,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertyAngle is prefix operator with precedence 4
+syntax EffectPropertyAngle is prefix operator with property precedence
 	"the" "angle" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetAngle(mEffect, output)
@@ -3467,7 +3467,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertyKnockOut is prefix operator with precedence 4
+syntax EffectPropertyKnockOut is prefix operator with property precedence
 	"the" "knockout" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetKnockOut(mEffect, output)
@@ -3498,7 +3498,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax EffectPropertySource is prefix operator with precedence 4
+syntax EffectPropertySource is prefix operator with property precedence
 	"the" "source" "of" <mEffect: Expression>
 begin
 	MCCanvasEffectGetSourceAsString(mEffect, output)
@@ -3531,7 +3531,7 @@ Example:
 
 Tags: Canvas
 */
-syntax FontMake is prefix operator with precedence 4
+syntax FontMake is prefix operator with constructor chunk precedence
 	"font" <mName: Expression>
 begin
 	MCCanvasFontMake(mName, output)
@@ -3554,7 +3554,7 @@ Example:
 
 Tags: Canvas
 */
-syntax FontMakeWithSize is prefix operator with precedence 4
+syntax FontMakeWithSize is prefix operator with constructor chunk precedence
 	"font" <mName: Expression> <mBold=false> <mItalic=false> "at" "size" <mSize: Expression>
 begin
 	MCCanvasFontMakeWithSize(mName, mBold, mItalic, mSize, output)
@@ -3599,7 +3599,7 @@ Example:
 
 Tags: Canvas
 */
-syntax FontMakeWithStyleAndSize is prefix operator with precedence 4
+syntax FontMakeWithStyleAndSize is prefix operator with constructor chunk precedence
 	"font" <mName: Expression> "with" ( "bold" <mBold=true> <mItalic=false> | "italic" <mBold=false> <mItalic=true> | "bold" "italic" <mBold=true> <mItalic=true> ) "style" "at" "size" <mSize: Expression>
 begin
 	MCCanvasFontMakeWithStyle(mName, mBold, mItalic, output)
@@ -3642,7 +3642,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax FontPropertyName is prefix operator with precedence 4
+syntax FontPropertyName is prefix operator with property precedence
 	"the" "name" "of" <mFont:Expression>
 begin
 	MCCanvasFontGetName(mFont, output)
@@ -3668,7 +3668,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax FontPropertyBold is prefix operator with precedence 4
+syntax FontPropertyBold is prefix operator with property precedence
 	"the" "bold" "of" <mFont:Expression>
 begin
 	MCCanvasFontGetBold(mFont, output)
@@ -3694,7 +3694,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax FontPropertyItalic is prefix operator with precedence 4
+syntax FontPropertyItalic is prefix operator with property precedence
 	"the" "italic" "of" <mFont:Expression>
 begin
 	MCCanvasFontGetItalic(mFont, output)
@@ -3720,7 +3720,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax FontPropertySize is prefix operator with precedence 4
+syntax FontPropertySize is prefix operator with property precedence
 	"the" "size" "of" <mFont:Expression>
 begin
 	MCCanvasFontGetSize(mFont, output)
@@ -3763,7 +3763,7 @@ Description:
 
 Tags:	Canvas
 */
-syntax FontOperationTextLayoutBounds is prefix operator with precedence 4
+syntax FontOperationTextLayoutBounds is prefix operator with function chunk precedence
 	"the" [ "layout" ] "bounds" "of" "text" <mText: Expression> "with" <mFont: Expression>
 begin
 	MCCanvasFontMeasureTextTypographicBounds(mText, mFont, output)
@@ -3792,7 +3792,7 @@ The layout bounds of the text, constructed from the ascent and descent values of
 
 Tags:	Canvas
 */
-syntax FontOperationTextLayoutBoundsOnCanvas is prefix operator with precedence 4
+syntax FontOperationTextLayoutBoundsOnCanvas is prefix operator with function chunk precedence
 	"the" [ "layout" ] "bounds" "of" "text" <mText: Expression> "on" <mCanvas: Expression>
 begin
 	MCCanvasFontMeasureTextTypographicBoundsOnCanvas(mText, mCanvas, output)
@@ -3823,7 +3823,7 @@ Description:
 
 Tags:	Canvas
 */
-syntax FontOperationTextImageBounds is prefix operator with precedence 4
+syntax FontOperationTextImageBounds is prefix operator with function chunk precedence
 	"the" "image" "bounds" "of" "text" <mText: Expression> "with" <mFont: Expression>
 begin
 	MCCanvasFontMeasureTextImageBounds(mText, mFont, output)
@@ -3852,7 +3852,7 @@ The exact bounds of the text, which will fully enclose each character.
 
 Tags:	Canvas
 */
-syntax FontOperationTextImageBoundsOnCanvas is prefix operator with precedence 4
+syntax FontOperationTextImageBoundsOnCanvas is prefix operator with function chunk precedence
 	"the" "image" "bounds" "of" "text" <mText: Expression> "on" <mCanvas: Expression>
 begin
 	MCCanvasFontMeasureTextImageBoundsOnCanvas(mText, mCanvas, output)
@@ -3916,7 +3916,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyPaint is prefix operator with precedence 4
+syntax CanvasPropertyPaint is prefix operator with property precedence
 	"the" "paint" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetPaint(mCanvas, output)
@@ -3938,7 +3938,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyFillRule is prefix operator with precedence 4
+syntax CanvasPropertyFillRule is prefix operator with property precedence
 	"the" "fill" "rule" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetFillRuleAsString(mCanvas, output)
@@ -3960,7 +3960,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyAntialias is prefix operator with precedence 4
+syntax CanvasPropertyAntialias is prefix operator with property precedence
 	"the" "antialias" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetAntialias(mCanvas, output)
@@ -3982,7 +3982,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyOpacity is prefix operator with precedence 4
+syntax CanvasPropertyOpacity is prefix operator with property precedence
 	"the" "opacity" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetOpacity(mCanvas, output)
@@ -4004,7 +4004,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyBlendMode is prefix operator with precedence 4
+syntax CanvasPropertyBlendMode is prefix operator with property precedence
 	"the" "blend" "mode" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetBlendModeAsString(mCanvas, output)
@@ -4027,7 +4027,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyStippled is prefix operator with precedence 4
+syntax CanvasPropertyStippled is prefix operator with property precedence
 	"the" "stippled" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetStippled(mCanvas, output)
@@ -4049,7 +4049,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyImageResizeQuality is prefix operator with precedence 4
+syntax CanvasPropertyImageResizeQuality is prefix operator with property precedence
 	"the" "image" "resize" "quality" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetImageResizeQualityAsString(mCanvas, output)
@@ -4071,7 +4071,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyStrokeWidth is prefix operator with precedence 4
+syntax CanvasPropertyStrokeWidth is prefix operator with property precedence
 	"the" "stroke" "width" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetStrokeWidth(mCanvas, output)
@@ -4093,7 +4093,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyFont is prefix operator with precedence 4
+syntax CanvasPropertyFont is prefix operator with property precedence
 	"the" "font" "of" <mCanvas:Expression>
 begin
 	MCCanvasGetFont(mCanvas, output)
@@ -4116,7 +4116,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyJoinStyle is prefix operator with precedence 4
+syntax CanvasPropertyJoinStyle is prefix operator with property precedence
 	"the" "join" "style" "of" <mCanvas:Expression>
 begin
 	MCCanvasGetJoinStyleAsString(mCanvas, output)
@@ -4139,7 +4139,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyCapStyle is prefix operator with precedence 4
+syntax CanvasPropertyCapStyle is prefix operator with property precedence
 	"the" "cap" "style" "of" <mCanvas:Expression>
 begin
 	MCCanvasGetCapStyleAsString(mCanvas, output)
@@ -4162,7 +4162,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyMiterLimit is prefix operator with precedence 4
+syntax CanvasPropertyMiterLimit is prefix operator with property precedence
 	"the" "miter" "limit" "of" <mCanvas:Expression>
 begin
 	MCCanvasGetMiterLimit(mCanvas, output)
@@ -4185,7 +4185,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyDashes is prefix operator with precedence 4
+syntax CanvasPropertyDashes is prefix operator with property precedence
 	"the" "dashes" "of" <mCanvas:Expression>
 begin
 	MCCanvasGetDashes(mCanvas, output)
@@ -4209,7 +4209,7 @@ Example:
 
 Tags:	Canvas
 */
-syntax CanvasPropertyDashPhase is prefix operator with precedence 4
+syntax CanvasPropertyDashPhase is prefix operator with property precedence
 	"the" "dash" "phase" "of" <mCanvas:Expression>
 begin
 	MCCanvasGetDashPhase(mCanvas, output)
@@ -4845,25 +4845,25 @@ end syntax
 
 //////////
 
-syntax NewCanvasWithSize is prefix operator with precedence 1
+syntax NewCanvasWithSize is prefix operator with constructor chunk precedence
   "a" "new" "canvas" "with" "size" <Size: Expression>
 begin
   MCCanvasNewCanvasWithSize(Size, output)
 end syntax
 
-syntax GetPixelDataOfCanvas is prefix operator with precedence 1
+syntax GetPixelDataOfCanvas is prefix operator with property precedence
   "the" "pixel" "data" "of" <Canvas: Expression>
 begin
   MCCanvasGetPixelDataOfCanvas(Canvas, output)
 end syntax
 
-syntax GetPixelWidthOfCanvas is prefix operator with precedence 1
+syntax GetPixelWidthOfCanvas is prefix operator with property precedence
   "the" "pixel" "width" "of" <Canvas: Expression>
 begin
   MCCanvasGetPixelWidthOfCanvas(Canvas, output)
 end syntax
 
-syntax GetPixelHeightOfCanvas is prefix operator with precedence 1
+syntax GetPixelHeightOfCanvas is prefix operator with property precedence
   "the" "pixel" "height" "of" <Canvas: Expression>
 begin
   MCCanvasGetPixelHeightOfCanvas(Canvas, output)

--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -99,7 +99,7 @@ Example:
 Tags:		Canvas
 */
 
-syntax RectangleMake is prefix operator with constructor chunk precedence
+syntax RectangleMake is prefix operator with constructor precedence
 	"rectangle" <mRect: Expression>
 begin
     MCCanvasRectangleMakeWithList(mRect, output)
@@ -423,7 +423,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ColorMake is prefix operator with constructor chunk precedence
+syntax ColorMake is prefix operator with constructor precedence
 	"color" <mColor: Expression>
 begin
 	MCCanvasColorMakeWithList(mColor, output)
@@ -621,7 +621,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeScale is prefix operator with constructor chunk precedence
+syntax TransformMakeScale is prefix operator with constructor precedence
 	"transform" "with" "scale" <mScale: Expression>
 begin
     MCCanvasTransformMakeScaleWithList(mScale, output)
@@ -642,7 +642,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeSkew is prefix operator with constructor chunk precedence
+syntax TransformMakeSkew is prefix operator with constructor precedence
 	"transform" "with" "skew" <mSkew: Expression>
 begin
 	MCCanvasTransformMakeSkewWithList(mSkew, output)
@@ -663,7 +663,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeRotation is prefix operator with constructor chunk precedence
+syntax TransformMakeRotation is prefix operator with constructor precedence
 	"transform" "with" "rotation" "by" <mRotation: Expression>
 begin
 	MCCanvasTransformMakeRotation(mRotation, output)
@@ -684,7 +684,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeTranslation is prefix operator with constructor chunk precedence
+syntax TransformMakeTranslation is prefix operator with constructor precedence
 	"transform" "with" "translation" <mTranslation: Expression>
 begin
     MCCanvasTransformMakeTranslationWithList(mTranslation, output)
@@ -705,7 +705,7 @@ Example:
 Tags: Canvas
 */
 
-syntax TransformMakeWithMatrixAsList is prefix operator with constructor chunk precedence
+syntax TransformMakeWithMatrixAsList is prefix operator with constructor precedence
 	"transform" "with" "matrix" <mMatrix: Expression>
 begin
 	MCCanvasTransformMakeWithMatrixAsList(mMatrix, output)
@@ -1124,7 +1124,7 @@ Example:
 Tags: Canvas
 */
 
-syntax SolidPaintMake is prefix operator with constructor chunk precedence
+syntax SolidPaintMake is prefix operator with constructor precedence
 	"solid" "paint" "with" <mColor: Expression>
 begin
 	MCCanvasSolidPaintMakeWithColor(mColor, output)
@@ -1198,7 +1198,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMake is prefix operator with constructor chunk precedence
+syntax PatternMake is prefix operator with constructor precedence
 	"pattern" "with" <mImage: Expression>
 begin
 	MCCanvasPatternMakeWithImage(mImage, output)
@@ -1228,7 +1228,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeTransformed is prefix operator with constructor chunk precedence
+syntax PatternMakeTransformed is prefix operator with constructor precedence
 	"pattern" "with" <mImage: Expression> "transformed" "by" <mTransform: Expression>
 begin
     MCCanvasPatternMakeWithTransformedImage(mImage, mTransform, output)
@@ -1254,7 +1254,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeScaledBy is prefix operator with constructor chunk precedence
+syntax PatternMakeScaledBy is prefix operator with constructor precedence
     "pattern" "with" <mImage: Expression> "scaled" "by" <mScale: Expression>
 begin
 	MCCanvasPatternMakeWithImageScaledWithList(mImage, mScale, output)
@@ -1282,7 +1282,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeTranslatedBy is prefix operator with constructor chunk precedence
+syntax PatternMakeTranslatedBy is prefix operator with constructor precedence
     "pattern" "with" <mImage: Expression> "translated" "by" <mTranslation: Expression>
 begin
 	MCCanvasPatternMakeWithImageTranslatedWithList(mImage, mTranslation, output)
@@ -1308,7 +1308,7 @@ Example:
 Tags: Canvas
 */
 
-syntax PatternMakeRotatedBy is prefix operator with constructor chunk precedence
+syntax PatternMakeRotatedBy is prefix operator with constructor precedence
     "pattern" "with" <mImage: Expression> "rotated" "by" <mRotation: Expression>
 begin
 	MCCanvasPatternMakeWithRotatedImage(mImage, mRotation, output)
@@ -1542,7 +1542,7 @@ Example:
 Tags: Canvas
 */
 
-syntax GradientStopMake is prefix operator with constructor chunk precedence
+syntax GradientStopMake is prefix operator with constructor precedence
 	"gradient" "stop" "at" <mOffset: Expression> "with" <mColor: Expression>
 begin
 	MCCanvasGradientStopMake(mOffset, mColor, output)
@@ -1572,7 +1572,7 @@ Example:
 Tags: Canvas
 */
 
-syntax GradientMakeWithRamp is prefix operator with constructor chunk precedence
+syntax GradientMakeWithRamp is prefix operator with constructor precedence
 	<mType: GradientType> "gradient" "with" "ramp" <mRamp: Expression>
 begin
 	MCCanvasGradientMakeWithRamp(mType, mRamp, output)
@@ -2098,7 +2098,7 @@ Example:
 Tags: Canvas
 */
 
-syntax ImageMakeFromFile is prefix operator with constructor chunk precedence
+syntax ImageMakeFromFile is prefix operator with constructor precedence
 	"image" "from" "file" <mPath: Expression>
 begin
 	MCCanvasImageMakeWithPath(mPath, output)
@@ -2120,7 +2120,7 @@ Example:
 
 Tags: Canvas
 */
-syntax ImageMakeFromResourceFile is prefix operator with constructor chunk precedence
+syntax ImageMakeFromResourceFile is prefix operator with constructor precedence
 	"image" "from" "resource" "file" <mResource: Expression>
 begin
 	MCCanvasImageMakeWithResourceFile(mResource, output)
@@ -2145,7 +2145,7 @@ Example:
 
 Tags: Canvas
 */
-syntax ImageMakeFromData is prefix operator with constructor chunk precedence
+syntax ImageMakeFromData is prefix operator with constructor precedence
 	"image" "from" "data" <mData: Expression>
 begin
 	MCCanvasImageMakeWithData(mData, output)
@@ -2172,7 +2172,7 @@ Example:
 
 Tags: Canvas
 */
-syntax ImageMakeWithPixels is prefix operator with constructor chunk precedence
+syntax ImageMakeWithPixels is prefix operator with constructor precedence
 	"image" "of" "size" <mSize: Expression> "with" "pixels" <mPixels: Expression>
 begin
 //	MCCanvasImageMakeWithPixels(mSize[0], mSize[1], mPixels, output)
@@ -2363,7 +2363,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMake is prefix operator with constructor chunk precedence
+syntax PathMake is prefix operator with constructor precedence
 	"path" <mInstructions: Expression>
 begin
 	MCCanvasPathMakeWithInstructionsAsString(mInstructions, output)
@@ -2412,13 +2412,13 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithRoundedRectangleWithRadius is prefix operator with constructor chunk precedence
+syntax PathMakeWithRoundedRectangleWithRadius is prefix operator with constructor precedence
 	"rounded" "rectangle" "path" "of" <mRect: Expression> "with" "radius" <mRadius: Expression>
 begin
 	MCCanvasPathMakeWithRoundedRectangle(mRect, mRadius, output)
 end syntax
 
-syntax PathMakeWithRoundedRectangleWithRadii is prefix operator with constructor chunk precedence
+syntax PathMakeWithRoundedRectangleWithRadii is prefix operator with constructor precedence
 	"rounded" "rectangle" "path" "of" <mRect: Expression> "with" "radii" <mRadii: Expression>
 begin
 	MCCanvasPathMakeWithRoundedRectangleWithRadiiAsList(mRect, mRadii, output)
@@ -2440,7 +2440,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithRectangle is prefix operator with constructor chunk precedence
+syntax PathMakeWithRectangle is prefix operator with constructor precedence
 	"rectangle" "path" "of" <mRect: Expression>
 begin
 	MCCanvasPathMakeWithRectangle(mRect, output)
@@ -2463,7 +2463,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithCircle is prefix operator with constructor chunk precedence
+syntax PathMakeWithCircle is prefix operator with constructor precedence
 	"circle" "path" "centered" "at" <mCenter: Expression> "with" "radius" <mRadius: Expression>
 begin
 	MCCanvasPathMakeWithCircle(mCenter, mRadius, output)
@@ -2486,7 +2486,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithEllipse is prefix operator with constructor chunk precedence
+syntax PathMakeWithEllipse is prefix operator with constructor precedence
 	"ellipse" "path" "centered" "at" <mPoint: Expression> "with" "radii" <mRadii: Expression>
 begin
 	MCCanvasPathMakeWithEllipseWithRadiiAsList(mPoint, mRadii, output)
@@ -2509,7 +2509,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithLine is prefix operator with constructor chunk precedence
+syntax PathMakeWithLine is prefix operator with constructor precedence
 	"line" "path" "from" <mFrom: Expression> "to" <mTo: Expression>
 begin
 	MCCanvasPathMakeWithLine(mFrom, mTo, output)
@@ -2536,7 +2536,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithPoints is prefix operator with constructor chunk precedence
+syntax PathMakeWithPoints is prefix operator with constructor precedence
 	( "polygon" <mClosed=true> | "polyline" <mClosed=false> ) "path" "with" "points" <mPoints: Expression>
 begin
 	MCCanvasPathMakeWithPoints(mClosed, mPoints, output)
@@ -2566,7 +2566,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithArc is prefix operator with constructor chunk precedence
+syntax PathMakeWithArc is prefix operator with constructor precedence
 	"arc" "path" "centered" "at" <mCenter: Expression> "with" [ "radius" <mRadius: Expression> | "radii" <mRadii: Expression> ] "from" <mStartAngle: Expression> "to" <mEndAngle: Expression>
 begin
 	MCCanvasPathMakeWithArcWithRadius(mCenter, mRadius, mStartAngle, mEndAngle, output)
@@ -2597,7 +2597,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithSector is prefix operator with constructor chunk precedence
+syntax PathMakeWithSector is prefix operator with constructor precedence
 	"sector" "path" "centered" "at" <mCenter: Expression> "with" [ "radius" <mRadius: Expression> | "radii" <mRadii: Expression> ] "from" <mStartAngle: Expression> "to" <mEndAngle: Expression>
 begin
 	MCCanvasPathMakeWithSectorWithRadius(mCenter, mRadius, mStartAngle, mEndAngle, output)
@@ -2628,7 +2628,7 @@ Example:
 
 Tags: Canvas
 */
-syntax PathMakeWithSegment is prefix operator with constructor chunk precedence
+syntax PathMakeWithSegment is prefix operator with constructor precedence
 	"segment" "path" "centered" "at" <mCenter: Expression> "with" [ "radius" <mRadius: Expression> | "radii" <mRadii: Expression> ] "from" <mStartAngle: Expression> "to" <mEndAngle: Expression>
 begin
 	MCCanvasPathMakeWithSegmentWithRadius(mCenter, mRadius, mStartAngle, mEndAngle, output)
@@ -3198,7 +3198,7 @@ Example:
 
 Tags: Canvas
 */
-syntax EffectMakeWithProperties is prefix operator with constructor chunk precedence
+syntax EffectMakeWithProperties is prefix operator with constructor precedence
 	<mType: EffectType> "effect" "with" "properties" <mProperties: Expression>
 begin
 	MCCanvasEffectMakeWithPropertyArray(mType, mProperties, output)
@@ -3531,7 +3531,7 @@ Example:
 
 Tags: Canvas
 */
-syntax FontMake is prefix operator with constructor chunk precedence
+syntax FontMake is prefix operator with constructor precedence
 	"font" <mName: Expression>
 begin
 	MCCanvasFontMake(mName, output)
@@ -3554,7 +3554,7 @@ Example:
 
 Tags: Canvas
 */
-syntax FontMakeWithSize is prefix operator with constructor chunk precedence
+syntax FontMakeWithSize is prefix operator with constructor precedence
 	"font" <mName: Expression> <mBold=false> <mItalic=false> "at" "size" <mSize: Expression>
 begin
 	MCCanvasFontMakeWithSize(mName, mBold, mItalic, mSize, output)
@@ -3599,7 +3599,7 @@ Example:
 
 Tags: Canvas
 */
-syntax FontMakeWithStyleAndSize is prefix operator with constructor chunk precedence
+syntax FontMakeWithStyleAndSize is prefix operator with constructor precedence
 	"font" <mName: Expression> "with" ( "bold" <mBold=true> <mItalic=false> | "italic" <mBold=false> <mItalic=true> | "bold" "italic" <mBold=true> <mItalic=true> ) "style" "at" "size" <mSize: Expression>
 begin
 	MCCanvasFontMakeWithStyle(mName, mBold, mItalic, output)
@@ -4845,7 +4845,7 @@ end syntax
 
 //////////
 
-syntax NewCanvasWithSize is prefix operator with constructor chunk precedence
+syntax NewCanvasWithSize is prefix operator with constructor precedence
   "a" "new" "canvas" "with" "size" <Size: Expression>
 begin
   MCCanvasNewCanvasWithSize(Size, output)

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -115,7 +115,7 @@ Use to test the existence or otherwise of a script object, for example after att
 References: ResolveScriptObject(statement)
 */
 
-syntax ScriptObjectExists is postfix operator with precedence 3
+syntax ScriptObjectExists is postfix operator with comparison precedence
     <Object: Expression> "exists"
 begin
     MCEngineEvalScriptObjectExists(Object, output)
@@ -141,7 +141,7 @@ Use to test the non-existence or otherwise of a script object, for example after
 References: ResolveScriptObject(statement)
 */
 
-syntax ScriptObjectDoesNotExist is postfix operator with precedence 3
+syntax ScriptObjectDoesNotExist is postfix operator with comparison precedence
     <Object: Expression> "does" "not" "exist"
 begin
     MCEngineEvalScriptObjectDoesNotExists(Object, output)
@@ -172,7 +172,7 @@ Use to manipulate properties of a script object.
 to script objects is not allowed.
 */
 
-syntax PropertyOfScriptObject is prefix operator with precedence 3
+syntax PropertyOfScriptObject is prefix operator with property precedence
     "property" <Property: Expression> "of" <Object: Expression>
 begin
     MCEngineExecGetPropertyOfScriptObject(Property, Object, output)
@@ -201,7 +201,7 @@ Description:
 >*Note:* An error is thrown if the script object does not exist.
 */
 
-syntax OwnerOfScriptObject is prefix operator with precedence 4
+syntax OwnerOfScriptObject is prefix operator with property precedence
 	"the" "owner" "of" <Object: Expression>
 begin
 	MCEngineEvalOwnerOfScriptObject(Object, output)
@@ -232,7 +232,7 @@ Description:
 >*Note:* An error is thrown if the script object does not exist.
 */
 
-syntax ChildrenOfScriptObject is prefix operator with precedence 4
+syntax ChildrenOfScriptObject is prefix operator with property precedence
 	"the" "children" "of" <Object: Expression>
 begin
 	MCEngineEvalChildrenOfScriptObject(Object, output)

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -1106,7 +1106,7 @@ Create a new widget object of the specified kind. The widget can then be placed 
 References: PlaceWidget (statement)
 */
 
-syntax ANewWidget is prefix operator with constructor chunk precedence
+syntax ANewWidget is prefix operator with constructor precedence
     "a" "new" "widget" <mKind: Expression>
 begin
     MCWidgetEvalANewWidget(mKind, output)

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -707,13 +707,13 @@ end syntax
 //public foreign handler MCWidgetEvalStateIsPressed(in pState /*as PressedState*/, in pCurrently as CBool, out rPressed as CBool) returns nothing binds to "<builtin>"
 //public foreign handler MCWidgetEvalStateIsNotPressed(in pState /*as PressedState*/, in pCurrently as CBool, out rNotPressed as CBool) returns nothing binds to "<builtin>"
 
-/*syntax IsPressed is postfix operator with precedence 5
+/*syntax IsPressed is postfix operator with function chunk precedence
   <mState: Expression> "is" ( "currently" <Currently=true> | <Currently=false> ) "pressed"
 begin
     MCWidgetEvalStateIsPressed(mState, Currently, output)
 end syntax
 
-syntax IsNotPressed is postfix operator with precedence 5
+syntax IsNotPressed is postfix operator with function chunk precedence
   <mState: Expression> "is not" ( "currently" <Currently=true> | <Currently=false> ) "pressed"
 begin
     MCWidgetEvalStateIsNotPressed(mState, Currently, output)
@@ -742,7 +742,7 @@ Example:
 	end if
 */
 	
-syntax IsPointWithinRect is neutral binary operator with precedence 5
+syntax IsPointWithinRect is neutral binary operator with comparison precedence
   <Point: Expression> "is" "within" <Rect: Expression>
 begin
     MCWidgetEvalIsPointWithinRect(Point, Rect, output)
@@ -765,7 +765,7 @@ Example:
 	end if
 */
 	
-syntax IsPointNotWithinRect is neutral binary operator with precedence 5
+syntax IsPointNotWithinRect is neutral binary operator with comparison precedence
   <Point: Expression> "is not" "within" <Rect: Expression>
 begin
     MCWidgetEvalIsPointNotWithinRect(Point, Rect, output)
@@ -1106,7 +1106,7 @@ Create a new widget object of the specified kind. The widget can then be placed 
 References: PlaceWidget (statement)
 */
 
-syntax ANewWidget is prefix operator with precedence 1
+syntax ANewWidget is prefix operator with constructor chunk precedence
     "a" "new" "widget" <mKind: Expression>
 begin
     MCWidgetEvalANewWidget(mKind, output)
@@ -1238,7 +1238,7 @@ widget properties.
 
 */
 
-syntax PropertyOfWidget is prefix operator with precedence 3
+syntax PropertyOfWidget is prefix operator with property precedence
 	"property" <mName: Expression> "of" <mWidget: Expression>
 begin
 	MCWidgetGetPropertyOfWidget(mName, mWidget, output)
@@ -1269,7 +1269,7 @@ Use the rectangle property to set the rectangle of a child widget.
 
 */
 
-syntax WidgetRectangleProperty is prefix operator with precedence 2
+syntax WidgetRectangleProperty is prefix operator with property precedence
 	"the" "rectangle" "of" <mWidget: Expression>
 begin
 	MCWidgetGetRectangleOfWidget(mWidget, output)
@@ -1300,7 +1300,7 @@ Use the width property to set the width of a child widget.
 
 */
 
-syntax WidgetWidthProperty is prefix operator with precedence 2
+syntax WidgetWidthProperty is prefix operator with property precedence
 	"the" "width" "of" <mWidget: Expression>
 begin
 	MCWidgetGetWidthOfWidget(mWidget, output)
@@ -1331,7 +1331,7 @@ Use the height property to set the height of a child widget.
 
 */
 
-syntax WidgetHeightProperty is prefix operator with precedence 2
+syntax WidgetHeightProperty is prefix operator with property precedence
 	"the" "height" "of" <mWidget: Expression>
 begin
 	MCWidgetGetHeightOfWidget(mWidget, output)
@@ -1362,7 +1362,7 @@ The location property is of type com.livecode.canvas.Point.
 
 */
 
-syntax WidgetLocationProperty is prefix operator with precedence 2
+syntax WidgetLocationProperty is prefix operator with property precedence
 	"the" "location" "of" <mWidget: Expression>
 begin
 	MCWidgetGetLocationOfWidget(mWidget, output)
@@ -1393,7 +1393,7 @@ References: MyDisabled (expression)
 
 */
 
-syntax WidgetEnabledProperty is prefix operator with precedence 2
+syntax WidgetEnabledProperty is prefix operator with property precedence
 	"the" "enabled" "of" <mWidget: Expression>
 begin
 	MCWidgetGetEnabledOfWidget(mWidget, output)
@@ -1424,14 +1424,14 @@ References: MyDisabled (expression)
 
 */
 
-syntax WidgetDisabledProperty is prefix operator with precedence 2
+syntax WidgetDisabledProperty is prefix operator with property precedence
 	"the" "disabled" "of" <mWidget: Expression>
 begin
 	MCWidgetGetDisabledOfWidget(mWidget, output)
 	MCWidgetSetDisabledOfWidget(input, mWidget)
 end syntax
 
-syntax WidgetFontProperty is prefix operator with precedence 4
+syntax WidgetFontProperty is prefix operator with property precedence
 	"the" "font" "of" <mWidget: Expression>
 begin
 	MCWidgetGetFontOfWidget(mWidget, output)
@@ -1471,7 +1471,7 @@ to be used to disambiguate widget objects returned from operators such as <TheTa
 References: TheTarget (operator), MyChildren (operator)
 */
 
-syntax AnnotationOfWidget is prefix operator with precedence 3
+syntax AnnotationOfWidget is prefix operator with property precedence
 	"annotation" <mName: Expression> "of" <mWidget: Expression>
 begin
 	MCWidgetGetAnnotationOfWidget(mName, mWidget, output)
@@ -1487,7 +1487,7 @@ public foreign handler MCWidgetGetStackNativeDisplayOfWidget(in pWidget as Widge
 /*
 TODO - docs
 */
-syntax NativeLayerOfWidget is prefix operator with precedence 3
+syntax NativeLayerOfWidget is prefix operator with property precedence
 	"native" "layer" "of" <mWidget: Expression>
 begin
 	MCWidgetGetNativeLayerOfWidget(mWidget, output)

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -272,7 +272,7 @@ private handler getPath(in pString as String) returns Path
 
 	if pString is "clock face" then
 		put (my width)/10 into mFontSize
-		return circle path centered at point [(my width)/2, (my height)/2] with radius (my width)/2
+		return circle path centered at point [(my width)/2, (my height)/2] with radius (my width/2)
 
 	else if pString is "second hand" or pString is "minute hand" then
 		return line path from point [0, 0] to point [0, -0.7*(my width)/2]
@@ -281,10 +281,10 @@ private handler getPath(in pString as String) returns Path
 		return line path from point [0,0] to point [0, -0.45*(my width/2)]
 
 	else if pString is "outer nub" then
-		return circle path centered at point [(my width)/2, (my height)/2] with radius 0.06*(my width/2)
+		return circle path centered at point [(my width)/2, (my height)/2] with radius (0.06*my width/2)
 
 	else if pString is "inner nub" then
-		return circle path centered at point [(my width)/2, (my height)/2] with radius 0.02*(my width/2)
+		return circle path centered at point [(my width)/2, (my height)/2] with radius (0.02*my width/2)
 
 	end if
 end handler

--- a/extensions/widgets/selector/selector.lcb
+++ b/extensions/widgets/selector/selector.lcb
@@ -95,7 +95,7 @@ public handler OnPaint()
 		set the paint of this canvas to getPaint("background",tCount)
 		fill getPath("circle",tCount) on this canvas
 			
-		set the font of this canvas to font getFontName() at size (my width)/(3*mNumSelections)
+		set the font of this canvas to font getFontName() at size (my width/(3*mNumSelections))
 		set the paint of this canvas to getPaint("labels",0)
 		fill text getLabel(tCount) at center of getRect("label", tCount) on this canvas
 		
@@ -144,7 +144,7 @@ private handler getPath(in pShape as String, in pSelection as Integer) returns P
 	put (my width)/(2*mNumSelections) + (pSelection-1)*(my width)/mNumSelections into tCenterX
 	
 	if pShape is "circle" then
-		return circle path centered at point [tCenterX, (my height)/2] with radius (my width)/(3*mNumSelections)
+		return circle path centered at point [tCenterX, (my height)/2] with radius (my width/(3*mNumSelections))
 	end if
 
 end handler

--- a/extensions/widgets/switchbutton/switchbutton.lcb
+++ b/extensions/widgets/switchbutton/switchbutton.lcb
@@ -407,18 +407,18 @@ private handler fetchPath(in pObject as String) returns Path
 	-- iOS paths
 	if mWidgetTheme is "iOS" then
 		if pObject is "track" then
-			return rounded rectangle path of rectangle [mWidth/2 - 3*mHeight/8, mHeight/4, mWidth/2 + 3*mHeight/8, 3*mHeight/4] with radius mHeight/4
+			return rounded rectangle path of rectangle [mWidth/2 - 3*mHeight/8, mHeight/4, mWidth/2 + 3*mHeight/8, 3*mHeight/4] with radius (mHeight/4)
 		else if pObject is "thumb" then
 			if mSwitchIsInOnPosition then
-				return circle path centered at point [mWidth/2 + 3*mHeight/16, mHeight/2] with radius mHeight/4
+				return circle path centered at point [mWidth/2 + 3*mHeight/16, mHeight/2] with radius (mHeight/4)
 			else
-				return circle path centered at point [mWidth/2 - 3*mHeight/16, mHeight/2] with radius mHeight/4
+				return circle path centered at point [mWidth/2 - 3*mHeight/16, mHeight/2] with radius (mHeight/4)
 			end if
 		else if pObject is "thumbExtensionCircle" then
 			if mSwitchIsInOnPosition then
-				return circle path centered at point [mWidth/2 + mHeight/16, mHeight/2] with radius mHeight/4
+				return circle path centered at point [mWidth/2 + mHeight/16, mHeight/2] with radius (mHeight/4)
 			else
-				return circle path centered at point [mWidth/2 - mHeight/16, mHeight/2] with radius mHeight/4
+				return circle path centered at point [mWidth/2 - mHeight/16, mHeight/2] with radius (mHeight/4)
 			end if
 		else if pObject is "thumbExtensionRect" then
 			if mSwitchIsInOnPosition then
@@ -437,12 +437,12 @@ private handler fetchPath(in pObject as String) returns Path
 				return circle path centered at point [3*mRadius, mHeight/2] with radius mRadius
 			end if
 		else if pObject is "track" then
-			return rounded rectangle path of rectangle [2.5*mRadius, mHeight/2 - 2*mRadius/3, 5.5*mRadius, mHeight/2 + 2*mRadius/3] with radius 2*mRadius/3
+			return rounded rectangle path of rectangle [2.5*mRadius, mHeight/2 - 2*mRadius/3, 5.5*mRadius, mHeight/2 + 2*mRadius/3] with radius (2*mRadius/3)
 		else if pObject is "pressedHilite" then
 			if mSwitchIsInOnPosition then
-				return circle path centered at point [5*mRadius, mHeight/2] with radius 2.5*mRadius
+				return circle path centered at point [5*mRadius, mHeight/2] with radius (2.5*mRadius)
 			else
-				return circle path centered at point [3*mRadius, mHeight/2] with radius 2.5*mRadius
+				return circle path centered at point [3*mRadius, mHeight/2] with radius (2.5*mRadius)
 			end if
 		end if
 

--- a/libscript/src/arithmetic.lcb
+++ b/libscript/src/arithmetic.lcb
@@ -209,7 +209,7 @@ The unary plus operator is a no-op on the predefined numeric types.
 Tags: Math
 */
 
-syntax PlusUnaryOperator is prefix operator with precedence 0
+syntax PlusUnaryOperator is prefix operator with modifier precedence
     "+" <Operand: Expression>
 begin
     MCArithmeticEvalPlusNumber(Operand, output)
@@ -228,7 +228,7 @@ Example:
 Tags: Math
 */
 
-syntax MinusUnaryOperator is prefix operator with precedence 0
+syntax MinusUnaryOperator is prefix operator with modifier precedence
     "-" <Operand: Expression>
 begin
     MCArithmeticEvalMinusNumber(Operand, output)
@@ -250,7 +250,7 @@ Example:
 Tags: Math
 */
 
-syntax PlusOperator is left binary operator with precedence 4
+syntax PlusOperator is left binary operator with addition precedence
     <Left: Expression> "+" <Right: Expression>
 begin
     MCArithmeticEvalNumberPlusNumber(Left, Right, output)
@@ -270,7 +270,7 @@ Example:
 Tags: Math
 */
 
-syntax MinusOperator is left binary operator with precedence 4
+syntax MinusOperator is left binary operator with addition precedence
     <Left: Expression> "-" <Right: Expression>
 begin
     MCArithmeticEvalNumberMinusNumber(Left, Right, output)
@@ -291,7 +291,7 @@ Tags: Math
 
 */
 
-syntax TimesOperator is left binary operator with precedence 3
+syntax TimesOperator is left binary operator with multiplication precedence
     <Left: Expression> "*" <Right: Expression>
 begin
     MCArithmeticEvalNumberTimesNumber(Left, Right, output)
@@ -311,7 +311,7 @@ Example:
 Tags: Math
 */
 
-syntax OverOperator is left binary operator with precedence 3
+syntax OverOperator is left binary operator with multiplication precedence
     <Left: Expression> "/" <Right: Expression>
 begin
     MCArithmeticEvalNumberOverNumber(Left, Right, output)
@@ -335,7 +335,7 @@ Returns the remainder on dividing <Left> by <Right>
 
 */
 
-syntax ModOperator is neutral binary operator with precedence 3
+syntax ModOperator is neutral binary operator with multiplication precedence
     <Left: Expression> "mod" <Right: Expression>
 begin
     MCArithmeticEvalNumberModNumber(Left, Right, output)
@@ -363,7 +363,7 @@ successive values of x wrap y cycle through the sequence 1, 2, ..., y.
 
 */
 
-syntax WrapOperator is neutral binary operator with precedence 3
+syntax WrapOperator is neutral binary operator with multiplication precedence
     <Left: Expression> "wrap" <Right: Expression>
 begin
     MCArithmeticEvalNumberWrapNumber(Left, Right, output)
@@ -379,7 +379,7 @@ Right:      An expression that evaluates to a number.
 Returns: 	True if <Left> is greater than <Right>, and false otherwise.
 */
 
-syntax NumberIsGreaterThanNumber is neutral binary operator with precedence 5
+syntax NumberIsGreaterThanNumber is neutral binary operator with comparison precedence
     <Left: Expression> ">" <Right: Expression>
 begin
     MCArithmeticEvalNumberIsGreaterThanNumber(Left, Right, output)
@@ -393,7 +393,7 @@ Right:      An expression that evaluates to a number.
 Returns: 	True if <Left> is greater than or equal to <Right>, and false otherwise.
 */
 
-syntax NumberIsGreaterThanOrEqualToNumber is neutral binary operator with precedence 5
+syntax NumberIsGreaterThanOrEqualToNumber is neutral binary operator with comparison precedence
     <Left: Expression> ">=" <Right: Expression>
 begin
     MCArithmeticEvalNumberIsGreaterThanOrEqualToNumber(Left, Right, output)
@@ -411,7 +411,7 @@ Description:
 Tags: Math
 */
 
-syntax NumberIsLessThanNumber is neutral binary operator with precedence 5
+syntax NumberIsLessThanNumber is neutral binary operator with comparison precedence
     <Left: Expression> "<" <Right: Expression>
 begin
     MCArithmeticEvalNumberIsLessThanNumber(Left, Right, output)
@@ -430,7 +430,7 @@ Tags: Math
 */
 
 
-syntax NumberIsLessThanOrEqualToNumber is neutral binary operator with precedence 5
+syntax NumberIsLessThanOrEqualToNumber is neutral binary operator with comparison precedence
     <Left: Expression> "<=" <Right: Expression>
 begin
     MCArithmeticEvalNumberIsLessThanOrEqualToNumber(Left, Right, output)
@@ -450,7 +450,7 @@ Description:
 Tags: Math
 */
 
-syntax NumberIsEqualToNumber is neutral binary operator with precedence 6
+syntax NumberIsEqualToNumber is neutral binary operator with comparison precedence
     <Left: Expression> "=" <Right: Expression>
 begin
     MCArithmeticEvalEqualToNumber(Left, Right, output)
@@ -471,7 +471,7 @@ References: NumberIsEqualToNumber (operator)
 Tags: Math
 */
 
-syntax NumberIsNumber is neutral binary operator with precedence 7
+syntax NumberIsNumber is neutral binary operator with comparison precedence
     <Left: Expression> "is" <Right: Expression>
 begin
     MCArithmeticEvalEqualToNumber(Left, Right, output)
@@ -493,7 +493,7 @@ Tags: Math
 */
 
 
-syntax NumberIsNotNumber is neutral binary operator with precedence 7
+syntax NumberIsNotNumber is neutral binary operator with comparison precedence
     <Left: Expression> "is not" <Right: Expression>
 begin
     MCArithmeticEvalNotEqualToNumber(Left, Right, output)
@@ -517,7 +517,7 @@ Description:
 Use <NumberFormattedAsString> when you want to manipulate a numeric value as text.
 */
 
-syntax NumberFormattedAsString is postfix operator with precedence 1
+syntax NumberFormattedAsString is postfix operator with conversion precedence
     <Operand: Expression> "formatted" "as" "string"
 begin
     MCArithmeticEvalNumberFormattedAsString(Operand, output)
@@ -572,7 +572,7 @@ Description:
 Use <StringParsedAsNumber> when you want to interpret text numerically. nothing is returned if parsing was not possible.
 */
 
-syntax StringParsedAsNumber is postfix operator with precedence 1
+syntax StringParsedAsNumber is postfix operator with conversion precedence
     <Operand: Expression> "parsed" "as" "number"
 begin
     MCArithmeticEvalStringParsedAsNumber(Operand, output)
@@ -641,7 +641,7 @@ Use <ListOfStringParsedAsListOfNumber> when you want to interpret pieces of text
 *Note:* It is an error if any element of <Operand> is not a string.
 */
 
-syntax ListOfStringParsedAsListOfNumber is postfix operator with precedence 1
+syntax ListOfStringParsedAsListOfNumber is postfix operator with conversion precedence
     <Operand: Expression> "parsed" "as" "list" "of" "number"
 begin
     MCArithmeticEvalListOfStringParsedAsListOfNumber(Operand, output)

--- a/libscript/src/array.lcb
+++ b/libscript/src/array.lcb
@@ -73,7 +73,7 @@ References: com.livecode.sort(library)
 Tags: Arrays
 */
 
-syntax KeysOfArray is prefix operator with precedence 2
+syntax KeysOfArray is prefix operator with property precedence
     "the" "keys" "of" <Target: Expression>
 begin
     MCArrayEvalKeysOf(Target, output)
@@ -106,7 +106,7 @@ References: com.livecode.sort(library)
 Tags: Arrays
 */
 
-syntax ElementsOfArray is prefix operator with precedence 2
+syntax ElementsOfArray is prefix operator with property precedence
     "the" "elements" "of" <Target: Expression>
 begin
     MCArrayEvalElementsOf(Target, output)
@@ -134,7 +134,7 @@ The number of elements in tArray returns the number of key-value pairs stored in
 Tags: Arrays
 */
 
-syntax CountElementsOfArray is prefix operator with precedence 1
+syntax CountElementsOfArray is prefix operator with property precedence
     "the" "number" "of" "elements" "in" <Target: Expression>
 begin
     MCArrayEvalNumberOfElementsIn(Target, output)
@@ -168,7 +168,7 @@ References: IsInList (operator)
 Tags: Arrays
 */
                 
-syntax AmongKeysOfArray is neutral binary operator with precedence 1
+syntax AmongKeysOfArray is neutral binary operator with comparison precedence
     <Needle: Expression> ( "is not" <IsNot=true> | "is" <IsNot=false> | <IsNot=false> ) "among" "the" "keys" "of" <Target: Expression>
 begin
 //  EvalIsAmongTheKeysOfCaseSensitive(Needle, IsNot, Target, output)
@@ -200,7 +200,7 @@ Tags: Arrays
 
 */
                 
-syntax AmongElementsOfArray is neutral binary operator with precedence 1
+syntax AmongElementsOfArray is neutral binary operator with comparison precedence
     <Needle: Expression> ( "is not" <IsNot=true> | "is" <IsNot=false> | <IsNot=false> ) "among" "the" "elements" "of" <Target: Expression>
 begin
     MCArrayEvalIsAmongTheElementsOf(Needle, IsNot, Target, output)
@@ -228,7 +228,7 @@ Either locates the element container with the given key for use as the target co
 Tags: Arrays
 */
 
-syntax SingletonElementOfArray is postfix operator with precedence 1
+syntax SingletonElementOfArray is postfix operator with subscript precedence
 	<Target: Expression> "[" <Key: Expression> "]"
 begin
     MCArrayFetchElementOfCaseless(Target, Key, output)

--- a/libscript/src/binary.lcb
+++ b/libscript/src/binary.lcb
@@ -91,7 +91,7 @@ The result consists of the bytes of <Left> followed by those of <Right>.
 Tags: Binary
 */
 
-syntax ConcatenateBytes is left binary operator with precedence 2
+syntax ConcatenateBytes is left binary operator with concatenation precedence
     <Left: Expression> "&" <Right: Expression>
 begin
     MCBinaryEvalConcatenateBytes(Left, Right, output)
@@ -113,7 +113,7 @@ Performs a byte by byte comparison of <Left> and <Right>, returning false if the
 Tags: Binary
 */
 
-syntax DataIsData is neutral binary operator with precedence 7
+syntax DataIsData is neutral binary operator with comparison precedence
     <Left: Expression> "is" <Right: Expression>
 begin
     MCBinaryEvalIsEqualTo(Left, Right, output)
@@ -133,7 +133,7 @@ Performs a byte by byte comparison of <Left> and <Right>, returning true if ther
 Tags: Binary
 */
 
-syntax DataIsNotData is neutral binary operator with precedence 7
+syntax DataIsNotData is neutral binary operator with comparison precedence
     <Left: Expression> "is not" <Right: Expression>
 begin
     MCBinaryEvalIsNotEqualTo(Left, Right, output)
@@ -154,7 +154,7 @@ Description:
 Tags: Binary
 */
 
-syntax DataIsLessThanData is neutral binary operator with precedence 5
+syntax DataIsLessThanData is neutral binary operator with comparison precedence
     <Left: Expression> "<" <Right: Expression>
 begin
     MCBinaryEvalIsLessThan(Left, Right, output)
@@ -175,7 +175,7 @@ Description:
 Tags: Binary
 */
 
-syntax DataIsGreaterThanData is neutral binary operator with precedence 5
+syntax DataIsGreaterThanData is neutral binary operator with comparison precedence
     <Left: Expression> ">" <Right: Expression>
 begin
     MCBinaryEvalIsGreaterThan(Left, Right, output)

--- a/libscript/src/bitwise.lcb
+++ b/libscript/src/bitwise.lcb
@@ -51,7 +51,7 @@ Tags: Bitwise operations
 
 */
 
-syntax BitwiseAnd is left binary operator with precedence 2
+syntax BitwiseAnd is left binary operator with bitwise and precedence
     <Left: Expression> "bitwise and" <Right: Expression>
 begin
     MCBitwiseEvalBitwiseAnd(Left, Right, output)
@@ -76,7 +76,7 @@ Each bit of <Left> bitwise or <Right> is 0 if and only if both the corresponding
 Tags: Bitwise operations
 */
 
-syntax BitwiseOr is left binary operator with precedence 4
+syntax BitwiseOr is left binary operator with bitwise or precedence
     <Left: Expression> "bitwise or" <Right: Expression>
 begin
     MCBitwiseEvalBitwiseOr(Left, Right, output)
@@ -100,7 +100,7 @@ Each bit of <Left> bitwise xor <Right> is 1 if and only if exactly one of the co
 Tags: Bitwise operations
 */
 
-syntax BitwiseXor is left binary operator with precedence 3
+syntax BitwiseXor is left binary operator with bitwise xor precedence
     <Left: Expression> "bitwise xor" <Right: Expression>
 begin
     MCBitwiseEvalBitwiseXor(Left, Right, output)
@@ -124,7 +124,7 @@ complement integer, i.e. equivalent to -(x + 1).
 Tags: Bitwise operations
 */
 
-syntax BitwiseNot is prefix operator with precedence 1
+syntax BitwiseNot is prefix operator with modifier precedence
     "bitwise" "not" <Operand: Expression>
 begin
     MCBitwiseEvalBitwiseNot(Operand, output)
@@ -151,7 +151,7 @@ by x is equivalent to multiplying by 2^x.
 Tags: Bitwise operations
 */
 
-syntax BitwiseShiftLeft is postfix operator with precedence 1
+syntax BitwiseShiftLeft is postfix operator with bitwise shift precedence
     <Operand: Expression> "shifted" "left" "by" <Shift: Expression> "bitwise"
 begin
     MCBitwiseEvalBitwiseShiftLeft(Operand, Shift, output)
@@ -176,7 +176,7 @@ right by x is equivalent to dividing by 2^x (rounding down)
 Tags: Bitwise operations
 */
 
-syntax BitwiseShiftRight is postfix operator with precedence 1
+syntax BitwiseShiftRight is postfix operator with bitwise shift precedence
     <Operand: Expression> "shifted" "right" "by" <Shift: Expression> "bitwise"
 begin
     MCBitwiseEvalBitwiseShiftRight(Operand, Shift, output)
@@ -184,7 +184,7 @@ end syntax
 
 --
 
-//syntax BitwiseRotate is postfix operator with precedence 1
+//syntax BitwiseRotate is postfix operator with bitwise shift precedence
 //    <Operand: Expression> "rotated" "by" <Shift: Expression> "bitwise"
 //begin
 //    EvalBitwiseRotate(Operand, Shift, output)

--- a/libscript/src/byte.lcb
+++ b/libscript/src/byte.lcb
@@ -73,7 +73,7 @@ Description:
 Tags: Binary
 */
 
-syntax CountBytesOf is prefix operator with precedence 1
+syntax CountBytesOf is prefix operator with property precedence
 	"the" "number" "of" "bytes" "in" <Target: Expression>
 begin
 	MCByteEvalNumberOfBytesIn(Target, output)
@@ -96,12 +96,12 @@ The first (respectively last) offset of <Needle> in <Target> is number of bytes 
 Tags: Binary
 */
 
-syntax ByteOffset is prefix operator with precedence 1
+syntax ByteOffset is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" <Needle: Expression> "in" <Target: Expression>
 begin
     MCByteEvalOffsetOfBytes(IsLast, Needle, Target, output)
 end syntax
-syntax ByteIndex is prefix operator with precedence 1
+syntax ByteIndex is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "index" "of" <Needle: Expression> "in" <Target: Expression>
 begin
     MCByteEvalOffsetOfBytes(IsLast, Needle, Target, output)
@@ -122,12 +122,12 @@ The first (respectively last) offset of <Needle> in <Target> is number of bytes 
 
 Tags: Binary
 */
-syntax ByteOffsetAfter is prefix operator with precedence 1
+syntax ByteOffsetAfter is prefix operator with function chunk precedence
 	"the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" <Needle: Expression> "after" <After: Expression> "in" <Target: Expression>
 begin
 	MCByteEvalOffsetOfBytesAfter(IsLast, Needle, After, Target, output)
 end syntax
-syntax ByteIndexAfter is prefix operator with precedence 1
+syntax ByteIndexAfter is prefix operator with function chunk precedence
 	"the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "index" "of" <Needle: Expression> "after" <After: Expression> "in" <Target: Expression>
 begin
 	MCByteEvalOffsetOfBytesAfter(IsLast, Needle, After, Target, output)
@@ -148,12 +148,12 @@ The first (respectively last) offset of <Needle> in <Target> is number of bytes 
 
 Tags: Binary
 */
-syntax ByteOffsetBefore is prefix operator with precedence 1
+syntax ByteOffsetBefore is prefix operator with function chunk precedence
     "the" ( "first" <IsFirst=true> | "last" <IsFirst=false> | <IsFirst=false> ) "offset" "of" <Needle: Expression> "before" <Before: Expression> "in" <Target: Expression>
 begin
     MCByteEvalOffsetOfBytesBefore(IsFirst, Needle, Before, Target, output)
 end syntax
-syntax ByteIndexBefore is prefix operator with precedence 1
+syntax ByteIndexBefore is prefix operator with function chunk precedence
     "the" ( "first" <IsFirst=true> | "last" <IsFirst=false> | <IsFirst=false> ) "index" "of" <Needle: Expression> "before" <Before: Expression> "in" <Target: Expression>
 begin
     MCByteEvalOffsetOfBytesBefore(IsFirst, Needle, Before, Target, output)
@@ -172,7 +172,7 @@ Description:
 Tags: Binary
 */
 
-syntax ByteIsInData is neutral binary operator with precedence 1
+syntax ByteIsInData is neutral binary operator with comparison precedence
     <Needle: Expression> "is" "in" <Target: Expression>
 begin
     MCByteEvalIsInBytes(Needle, Target, output)
@@ -193,7 +193,7 @@ Description:
 Tags: Binary
 */
 
-syntax ContainsBytes is neutral binary operator with precedence 1
+syntax ContainsBytes is neutral binary operator with comparison precedence
     <Target: Expression> "contains" <Needle: Expression>
 begin
     MCByteEvalContainsBytes(Target, Needle, output)
@@ -212,7 +212,7 @@ Description:
 Tags: Binary
 */
 
-syntax BeginsWithBytes is neutral binary operator with precedence 1
+syntax BeginsWithBytes is neutral binary operator with comparison precedence
     <Target: Expression> "begins" "with" <Needle: Expression>
 begin
     MCByteEvalBeginsWithBytes(Target, Needle, output)
@@ -231,7 +231,7 @@ Description:
 Tags: Binary
 */
 
-syntax EndsWithBytes is neutral binary operator with precedence 1
+syntax EndsWithBytes is neutral binary operator with comparison precedence
     <Target: Expression> "ends" "with" <Needle: Expression>
 begin
     MCByteEvalEndsWithBytes(Target, Needle, output)
@@ -253,7 +253,7 @@ Either locates the byte at the given index for use as the target container of an
 Tags: Binary
 */
 
-syntax SingletonByteOf is prefix operator with precedence 1
+syntax SingletonByteOf is prefix operator with subscript chunk precedence
 	"byte" <Index: Expression> "of" <Target: Expression>
 begin
 	MCByteFetchByteOf(Index, Target, output)
@@ -276,7 +276,7 @@ Either locates the bytes between the given indices for use as the target contain
 Tags: Binary
 */
 
-syntax RangeByteOf is prefix operator with precedence 1
+syntax RangeByteOf is prefix operator with subscript chunk precedence
 	"byte" <Start: Expression> "to" <Finish: Expression> "of" <Target: Expression>
 begin
 	MCByteFetchByteRangeOf(Start, Finish, Target, output)
@@ -296,7 +296,7 @@ Either locates the first byte for use as the target container of another operati
 Tags: Binary
 */
 
-syntax FirstByteOf is prefix operator with precedence 1
+syntax FirstByteOf is prefix operator with subscript chunk precedence
 	"the" "first" "byte" "of" <Target: Expression>
 begin
 	MCByteFetchFirstByteOf(Target, output)
@@ -316,7 +316,7 @@ Either locates the first byte for use as the target container of another operati
 Tags: Binary
 */
 
-syntax LastByteOf is prefix operator with precedence 1
+syntax LastByteOf is prefix operator with subscript chunk precedence
 	"the" "last" "byte" "of" <Target: Expression>
 begin
 	MCByteFetchLastByteOf(Target, output)
@@ -437,7 +437,7 @@ random data.
 Tags: Binary, Random
 
 */
-syntax RandomBytes is postfix operator with precedence 5
+syntax RandomBytes is postfix operator with constructor chunk precedence
 	<Count : Expression> "random" "bytes"
 begin
 	MCDataExecRandomBytes(Count, output)
@@ -458,7 +458,7 @@ Returns a byte of binary data, created using the given value.  The
 
 Tags: Binary
 */
-syntax ByteWithCode is prefix operator with precedence 2
+syntax ByteWithCode is prefix operator with function chunk precedence
 	"the" "byte" "with" "code" <Value: Expression>
 begin
 	MCByteEvalByteWithCode(Value, output)
@@ -474,7 +474,7 @@ Returns the numeric representation of a single byte of binary data.
 
 Tags: Binary
 */
-syntax CodeOfByte is prefix operator with precedence 2
+syntax CodeOfByte is prefix operator with function chunk precedence
 	"the" "code" "of" <Target: Expression>
 begin
 	MCByteEvalCodeOfByte(Target, output)

--- a/libscript/src/byte.lcb
+++ b/libscript/src/byte.lcb
@@ -437,7 +437,7 @@ random data.
 Tags: Binary, Random
 
 */
-syntax RandomBytes is postfix operator with constructor chunk precedence
+syntax RandomBytes is postfix operator with constructor precedence
 	<Count : Expression> "random" "bytes"
 begin
 	MCDataExecRandomBytes(Count, output)

--- a/libscript/src/char.lcb
+++ b/libscript/src/char.lcb
@@ -91,7 +91,7 @@ Description:
 Tags: Strings
 */
 
-syntax CountCharsOf is prefix operator with precedence 1
+syntax CountCharsOf is prefix operator with function chunk precedence
 	"the" "number" "of" "chars" "in" <Target: Expression>
 begin
 	MCCharEvalNumberOfCharsIn(Target, output)
@@ -116,7 +116,7 @@ Either locates the char at the given index for use as the target container of an
 Tags: Strings
 */
 
-syntax SingletonCharOf is prefix operator with precedence 3
+syntax SingletonCharOf is prefix operator with subscript chunk precedence
 	"char" <Index: Expression> "of" <Target: Expression>
 begin
 	MCCharFetchCharOf(Index, Target, output)
@@ -142,7 +142,7 @@ Either locates the chars between the given indices for use as the target contain
 Tags: Strings
 */
 
-syntax RangeCharOf is prefix operator with precedence 3
+syntax RangeCharOf is prefix operator with subscript chunk precedence
 	"char" <Start: Expression> "to" <Finish: Expression> "of" <Target: Expression>
 begin
 	MCCharFetchCharRangeOf(Start, Finish, Target, output)
@@ -169,7 +169,7 @@ Either locates the first char for use as the target container of another operati
 Tags: Strings
 */
 
-syntax FirstCharOf is prefix operator with precedence 1
+syntax FirstCharOf is prefix operator with subscript chunk precedence
 	"the" "first" "char" "of" <Target: Expression>
 begin
 	MCCharFetchFirstCharOf(Target, output)
@@ -196,7 +196,7 @@ Either locates the last char for use as the target container of another operatio
 Tags: Strings
 */
 
-syntax LastCharOf is prefix operator with precedence 1
+syntax LastCharOf is prefix operator with subscript chunk precedence
 	"the" "last" "char" "of" <Target: Expression>
 begin
 	MCCharFetchLastCharOf(Target, output)
@@ -320,7 +320,7 @@ Description:
 Tags: Strings
 */
 
-syntax CharIsInString is neutral binary operator with precedence 1
+syntax CharIsInString is neutral binary operator with comparison precedence
     <Needle: Expression> "is" "in" <Source: Expression>
 begin
     MCCharEvalIsAmongTheCharsOf(Needle, Source, output)
@@ -356,12 +356,12 @@ The first (respectively last) offset of <Needle> in <Target> is number of chars 
 Tags: Strings
 */
 
-syntax CharOffset is prefix operator with precedence 1
+syntax CharOffset is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" <Needle: Expression> "in" <Target: Expression>
 begin
     MCCharEvalOffsetOfChars(IsLast, Needle, Target, output)
 end syntax
-syntax CharIndex is prefix operator with precedence 1
+syntax CharIndex is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "index" "of" <Needle: Expression> "in" <Target: Expression>
 begin
     MCCharEvalOffsetOfChars(IsLast, Needle, Target, output)
@@ -386,12 +386,12 @@ The first (respectively last) offset of <Needle> in <Target> is number of chars 
 
 Tags: Strings
 */
-syntax CharOffsetAfter is prefix operator with precedence 1
+syntax CharOffsetAfter is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" <Needle: Expression> "after" <After: Expression> "in" <Target: Expression>
 begin
     MCCharEvalOffsetOfCharsAfter(IsLast, Needle, After, Target, output)
 end syntax
-syntax CharIndexAfter is prefix operator with precedence 1
+syntax CharIndexAfter is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "index" "of" <Needle: Expression> "after" <After: Expression> "in" <Target: Expression>
 begin
     MCCharEvalOffsetOfCharsAfter(IsLast, Needle, After, Target, output)
@@ -423,12 +423,12 @@ The first (respectively last) offset of <Needle> in <Target> is number of chars 
 Tags: Strings
 */
 
-syntax CharOffsetBefore is prefix operator with precedence 1
+syntax CharOffsetBefore is prefix operator with function chunk precedence
     "the" ( "first" <IsFirst=true> | "last" <IsFirst=false> | <IsFirst=false> ) "offset" "of" <Needle: Expression> "before" <Before: Expression> "in" <Target: Expression>
 begin
     MCCharEvalOffsetOfCharsBefore(IsFirst, Needle, Before, Target, output)
 end syntax
-syntax CharIndexBefore is prefix operator with precedence 1
+syntax CharIndexBefore is prefix operator with function chunk precedence
     "the" ( "first" <IsFirst=true> | "last" <IsFirst=false> | <IsFirst=false> ) "index" "of" <Needle: Expression> "before" <Before: Expression> "in" <Target: Expression>
 begin
     MCCharEvalOffsetOfCharsBefore(IsFirst, Needle, Before, Target, output)
@@ -449,7 +449,7 @@ Description:
 Tags: Strings
 */
 
-syntax ContainsChars is neutral binary operator with precedence 1
+syntax ContainsChars is neutral binary operator with comparison precedence
     <Source: Expression> "contains" <Needle: Expression>
 begin
     MCCharEvalContains(Source, Needle, output)
@@ -480,7 +480,7 @@ Description:
 Tags: Strings
 */
 
-syntax StringBeginsWithString is neutral binary operator with precedence 1
+syntax StringBeginsWithString is neutral binary operator with comparison precedence
     <Source: Expression> "begins" "with" <Prefix: Expression>
 begin
     MCCharEvalBeginsWith(Source, Prefix, output)
@@ -509,7 +509,7 @@ Description:
 Tags: Strings
 */
 
-syntax StringEndsWithString is neutral binary operator with precedence 1
+syntax StringEndsWithString is neutral binary operator with comparison precedence
     <Source: Expression> "ends" "with" <Suffix: Expression>
 begin
     MCCharEvalEndsWith(Source, Suffix, output)
@@ -583,7 +583,7 @@ Returns the Unicode codepoint index of a single character.
 Tags: Strings
 */
 
-syntax CodeOfChar is prefix operator with precedence 2
+syntax CodeOfChar is prefix operator with function chunk precedence
     "the" "code" "of" <Target: Expression>
 begin
     MCStringEvalCodeOfChar(Target, output)
@@ -601,7 +601,7 @@ given value.
 Tags: Strings
 */
 
-syntax CharWithCode is prefix operator with precedence 2
+syntax CharWithCode is prefix operator with function chunk precedence
     "the" "char" "with" "code" <Index: Expression>
 begin
     MCStringEvalCharWithCode(Index, output)

--- a/libscript/src/codeunit.lcb
+++ b/libscript/src/codeunit.lcb
@@ -86,7 +86,7 @@ Description:
 Tags: Strings
 */
 
-syntax CountCodeunitsOf is prefix operator with precedence 1
+syntax CountCodeunitsOf is prefix operator with function chunk precedence
 	"the" "number" "of" "codeunits" "in" <Target: Expression>
 begin
 	MCCodeunitEvalNumberOfCodeunitsIn(Target, output)
@@ -111,7 +111,7 @@ Either locates the codeunit at the given index for use as the target container o
 Tags: Strings
 */
 
-syntax SingletonCodeunitOf is prefix operator with precedence 3
+syntax SingletonCodeunitOf is prefix operator with subscript chunk precedence
 	"codeunit" <Index: Expression> "of" <Target: Expression>
 begin
 	MCCodeunitFetchCodeunitOf(Index, Target, output)
@@ -137,7 +137,7 @@ Either locates the codeunits between the given indices for use as the target con
 Tags: Strings
 */
 
-syntax RangeCodeunitOf is prefix operator with precedence 3
+syntax RangeCodeunitOf is prefix operator with subscript chunk precedence
 	"codeunit" <Start: Expression> "to" <Finish: Expression> "of" <Target: Expression>
 begin
 	MCCodeunitFetchCodeunitRangeOf(Start, Finish, Target, output)
@@ -164,7 +164,7 @@ Either locates the first codeunit for use as the target container of another ope
 Tags: Strings
 */
 
-syntax FirstCodeunitOf is prefix operator with precedence 1
+syntax FirstCodeunitOf is prefix operator with subscript chunk precedence
 	"the" "first" "codeunit" "of" <Target: Expression>
 begin
 	MCCodeunitFetchFirstCodeunitOf(Target, output)
@@ -191,7 +191,7 @@ Either locates the last codeunit for use as the target container of another oper
 Tags: Strings
 */
 
-syntax LastCodeunitOf is prefix operator with precedence 1
+syntax LastCodeunitOf is prefix operator with subscript chunk precedence
 	"the" "last" "codeunit" "of" <Target: Expression>
 begin
 	MCCodeunitFetchLastCodeunitOf(Target, output)
@@ -315,7 +315,7 @@ Description:
 Tags: Strings
 */
 
-syntax CodeunitIsInString is neutral binary operator with precedence 1
+syntax CodeunitIsInString is neutral binary operator with comparison precedence
     <Needle: Expression> "is" "in" <Source: Expression>
 begin
     MCCodeunitEvalIsAmongTheCodeunitsOf(Needle, Source, output)
@@ -351,7 +351,7 @@ The first (respectively last) offset of <Needle> in <Target> is number of codeun
 Tags: Strings
 */
 
-syntax CodeunitOffset is prefix operator with precedence 1
+syntax CodeunitOffset is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" "codeunits" <Needle: Expression> "in" <Target: Expression>
 begin
     MCCodeunitEvalOffsetOfCodeunits(IsLast, Needle, Target, output)
@@ -377,7 +377,7 @@ The first (respectively last) offset of <Needle> in <Target> is number of codeun
 Tags: Strings
 */
 
-syntax CodeunitOffsetAfter is prefix operator with precedence 1
+syntax CodeunitOffsetAfter is prefix operator with function chunk precedence
     "the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" "codeunits" <Needle: Expression> "after" <After: Expression> "in" <Target: Expression>
 begin
     MCCodeunitEvalOffsetOfCodeunitsAfter(IsLast, Needle, After, Target, output)
@@ -409,7 +409,7 @@ The first (respectively last) offset of <Needle> in <Target> is number of codeun
 Tags: Strings
 */
 
-syntax CodeunitOffsetBefore is prefix operator with precedence 1
+syntax CodeunitOffsetBefore is prefix operator with function chunk precedence
     "the" ( "first" <IsFirst=true> | "last" <IsFirst=false> | <IsFirst=false> ) "offset" "of" "codeunits" <Needle: Expression> "before" <Before: Expression> "in" <Target: Expression>
 begin
     MCCodeunitEvalOffsetOfCodeunitsBefore(IsFirst, Needle, Before, Target, output)

--- a/libscript/src/file.lcb
+++ b/libscript/src/file.lcb
@@ -39,7 +39,7 @@ The raw data stored in a file.
 
 Tags: IO, Filesystem
 */
-syntax FileContents is prefix operator with precedence 2
+syntax FileContents is prefix operator with function chunk precedence
 	"the" "contents" "of" "file" <File: Expression>
 begin
 	MCFileExecGetContents(File, output)
@@ -114,7 +114,7 @@ Creates a new, empty directory.
 
 Tags: IO, Filesystem
 */
-syntax GetDirectoryEntries is prefix operator with precedence 5
+syntax GetDirectoryEntries is prefix operator with function chunk precedence
 	"the" "entries" "of" "directory" <Directory: Expression>
 begin
 	MCFileExecGetDirectoryEntries(Directory, output)

--- a/libscript/src/list.lcb
+++ b/libscript/src/list.lcb
@@ -111,7 +111,7 @@ References: IndexedElementOfList(operator)
 Tags: Lists
 */
 
-syntax HeadOfList is prefix operator with precedence 1
+syntax HeadOfList is prefix operator with subscript chunk precedence
     "the" "head" "of" <Target: Expression>
 begin
     MCListEvalHeadOf(Target, output)
@@ -145,7 +145,7 @@ References: IndexedElementOfList(operator)
 Tags: Lists
 */
 
-syntax TailOfList is prefix operator with precedence 1
+syntax TailOfList is prefix operator with subscript chunk precedence
     "the" "tail" "of" <Target: Expression>
 begin
     MCListEvalTailOf(Target, output)
@@ -235,7 +235,7 @@ Returns the number of elements in the list.
 Tags: Lists
 */
 
-syntax CountElementsOfList is prefix operator with precedence 1
+syntax CountElementsOfList is prefix operator with property precedence
     "the" "number" "of" "elements" "in" <Target: Expression>
 begin
     MCListEvalNumberOfElementsIn(Target, output)
@@ -263,7 +263,7 @@ Description:
 Tags: Lists
 */
                 
-syntax ElementIsInList is neutral binary operator with precedence 1
+syntax ElementIsInList is neutral binary operator with comparison precedence
     <Needle: Expression> "is" "in" <Target: Expression>
 begin
     MCListEvalIsAmongTheElementsOf(Needle, Target, output)
@@ -294,7 +294,7 @@ Description:
 Tags: Lists
 */
                 
-syntax ListContainsElements is neutral binary operator with precedence 1
+syntax ListContainsElements is neutral binary operator with comparison precedence
     <Target: Expression> "contains" <Needle: Expression>
 begin
     MCListEvalContainsElements(Target, Needle, output)
@@ -326,7 +326,7 @@ Description:
 Tags: Lists
 */
 
-syntax ListBeginsWithList is neutral binary operator with precedence 1
+syntax ListBeginsWithList is neutral binary operator with comparison precedence
     <Source: Expression> "begins" "with" <Prefix: Expression>
 begin
     MCListEvalBeginsWith(Source, Prefix, output)
@@ -356,7 +356,7 @@ Description:
 Tags: Lists
 */
 
-syntax ListEndsWithList is neutral binary operator with precedence 1
+syntax ListEndsWithList is neutral binary operator with comparison precedence
     <Source: Expression> "ends" "with" <Suffix: Expression>
 begin
     MCListEvalEndsWith(Source, Suffix, output)
@@ -388,7 +388,7 @@ In particular, this means that comparison between string elements is case sensit
 Tags: Lists
 */
 
-syntax ListIsList is neutral binary operator with precedence 7
+syntax ListIsList is neutral binary operator with comparison precedence
     <Left: Expression> "is" <Right: Expression>
 begin
     MCListEvalIsEqualTo(Left, Right, output)
@@ -417,7 +417,7 @@ In particular, this means that comparison between string elements is case sensit
 Tags: Lists
 */
 
-syntax ListIsNotList is neutral binary operator with precedence 7
+syntax ListIsNotList is neutral binary operator with comparison precedence
     <Left: Expression> "is not" <Right: Expression>
 begin
     MCListEvalIsNotEqualTo(Left, Right, output)
@@ -447,7 +447,7 @@ Either locates the element container at the given index for use as the target co
 Tags: Lists
 */
 
-syntax SingletonElementOfList is prefix operator with precedence 1
+syntax SingletonElementOfList is prefix operator with subscript chunk precedence
 	"element" <Index: Expression> "of" <Target: Expression>
 begin
     MCListFetchElementOf(Index, Target, output)
@@ -477,7 +477,7 @@ Either locates the element container at the given index for use as the target co
 Tags: Lists
 */
 
-syntax IndexedElementOfList is postfix operator with precedence 1
+syntax IndexedElementOfList is postfix operator with subscript precedence
     <Target: Expression> "[" <Index: Expression> "]"
 begin
     MCListFetchIndexOf(Target, Index, output)
@@ -508,7 +508,7 @@ Either locates the element containers between the given indices for use as a lis
 Tags: Lists
 */
 
-syntax RangeElementsOfList is prefix operator with precedence 1
+syntax RangeElementsOfList is prefix operator with subscript chunk precedence
 	"element" <Start: Expression> "to" <Finish: Expression> "of" <Target: Expression>
 begin
     MCListFetchElementRangeOf(Start, Finish, Target, output)
@@ -528,7 +528,7 @@ Either locates the first element for use as the target container of another oper
 Tags: Lists
 */
 
-syntax FirstElementOf is prefix operator with precedence 1
+syntax FirstElementOf is prefix operator with subscript chunk precedence
 	"the" "first" "element" "of" <Target: Expression>
 begin
 	MCListFetchFirstElementOf(Target, output)
@@ -548,7 +548,7 @@ Either locates the first element for use as the target container of another oper
 Tags: Lists
 */
 
-syntax LastElementOf is prefix operator with precedence 1
+syntax LastElementOf is prefix operator with subscript chunk precedence
 	"the" "last" "element" "of" <Target: Expression>
 begin
 	MCListFetchLastElementOf(Target, output)
@@ -893,7 +893,7 @@ element found is returned.  If no element of <Haystack> is equal to
 
 Tags: Lists
 */
-syntax ListIndex is prefix operator with precedence 1
+syntax ListIndex is prefix operator with function chunk precedence
 	"the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "index" "of" <Needle: Expression> "in" <Haystack: Expression>
 begin
 	MCListEvalIndexOfElement(IsLast, Needle, Haystack, output)
@@ -927,7 +927,7 @@ the position of the element found is returned.  If no element of
 
 Tags: Lists
 */
-syntax ListIndexAfter is prefix operator with precedence 1
+syntax ListIndexAfter is prefix operator with function chunk precedence
 	"the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "index" "of" <Needle: Expression> "after" <After: Expression> "in" <Haystack: Expression>
 begin
 	MCListEvalIndexOfElementAfter(IsLast, Needle, After, Haystack, output)
@@ -962,7 +962,7 @@ specified, the last matching element is found.
 
 Tags: Lists
 */
-syntax ListIndexBefore is prefix operator with precedence 1
+syntax ListIndexBefore is prefix operator with function chunk precedence
 	"the" ( "first" <IsFirst=true> | "last" <IsFirst=false> | <IsFirst=false> ) "index" "of" <Needle: Expression> "before" <Before: Expression> "in" <Haystack: Expression>
 begin
 	MCListEvalIndexOfElementBefore(IsFirst, Needle, Before, Haystack, output)
@@ -999,7 +999,7 @@ the return value is 0.
 
 Tags: Lists
 */
-syntax ListOffset is prefix operator with precedence 1
+syntax ListOffset is prefix operator with function chunk precedence
 	"the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" <Needle: Expression> "in" <Haystack: Expression>
 begin
 	MCListEvalOffsetOfList(IsLast, Needle, Haystack, output)
@@ -1037,7 +1037,7 @@ position <After> is equal to <Needle>, the return value is 0.
 
 Tags: Lists
 */
-syntax ListOffsetAfter is prefix operator with precedence 1
+syntax ListOffsetAfter is prefix operator with function chunk precedence
 	"the" ( "first" <IsLast=false> | "last" <IsLast=true> | <IsLast=false> ) "offset" "of" <Needle: Expression> "after" <After: Expression> "in" <Haystack: Expression>
 begin
 	MCListEvalOffsetOfListAfter(IsLast, Needle, After, Haystack, output)
@@ -1074,7 +1074,7 @@ is equal to <Needle>, the return value is 0.  If neither "first" nor
 
 Tags: Lists
 */
-syntax ListOffsetBefore is prefix operator with precedence 1
+syntax ListOffsetBefore is prefix operator with function chunk precedence
 	"the" ( "first" <IsFirst=true> | "last" <IsFirst=false> | <IsFirst=false> ) "offset" "of" <Needle: Expression> "before" <Before: Expression> "in" <Haystack: Expression>
 begin
 	MCListEvalOffsetOfListBefore(IsFirst, Needle, Before, Haystack, output)

--- a/libscript/src/logic.lcb
+++ b/libscript/src/logic.lcb
@@ -46,7 +46,7 @@ Returns: 	If the left hand expression evaluates to false, the value of the expre
             Note that the right hand expression is only evaluated if the left hand expression is true.
 */
 
-//syntax LogicOr is left binary operator of precedence 4
+//syntax LogicOr is left binary operator with logical or precedence
 //    <Left: Expression> "or" <Right: Expression>
 //begin
 //    EvalOr(Left, Right, output)
@@ -63,7 +63,7 @@ Returns: 	If the left hand expression evaluates to true, the value of the expres
             Note that the right hand expression is only evaluated if the left hand expression is false.
 */
 
-//syntax LogicAnd is left binary operator of precedence 3
+//syntax LogicAnd is left binary operator with logical or precedence
 //    <Left: Expression> "and" <Right: Expression>
 //begin
 //    EvalAnd(Left, Right, output)
@@ -85,7 +85,7 @@ Tags: Logic
 	
 */
 
-syntax LogicNot is prefix operator with precedence 6
+syntax LogicNot is prefix operator with logical not precedence
     "not" <Operand: Expression>
 begin
     MCLogicEvalNot(Operand, output)
@@ -109,7 +109,7 @@ Example:
 Tags: Logic
 */
 
-syntax BooleanIsEqualToBoolean is neutral binary operator with precedence 7
+syntax BooleanIsEqualToBoolean is neutral binary operator with comparison precedence
     <Left: Expression> "is" <Right: Expression>
 begin
     MCLogicEvalIsEqualTo(Left, Right, output)
@@ -131,7 +131,7 @@ Example:
 Tags: Logic
 */
 
-syntax BooleanIsNotEqualToBoolean is neutral binary operator with precedence 7
+syntax BooleanIsNotEqualToBoolean is neutral binary operator with comparison precedence
     <Left: Expression> "is not" <Right: Expression>
 begin
     MCLogicEvalIsNotEqualTo(Left, Right, output)
@@ -154,7 +154,7 @@ Description:
 Use <BooleanFormattedAsString> when you want to manipulate a boolean value as text.
 */
 
-syntax BooleanFormattedAsString is postfix operator with precedence 1
+syntax BooleanFormattedAsString is postfix operator with conversion precedence
     <Operand: Expression> "formatted" "as" "string"
 begin
     MCLogicEvalBoolFormattedAsString(Operand, output)
@@ -204,7 +204,7 @@ Use <StringParsedAsBoolean> when you want to determine if a string contains "tru
 
 >*Note:* Only the strings "true" and "false" will parse to give a boolean value. Any other input will cause an error to be thrown.
 */
-syntax StringParsedAsBoolean is postfix operator with precedence 1
+syntax StringParsedAsBoolean is postfix operator with conversion precedence
     <Operand: Expression> "parsed" "as" "boolean"
 begin
     MCLogicEvalStringParsedAsBool(Operand, output)

--- a/libscript/src/math-foundation.lcb
+++ b/libscript/src/math-foundation.lcb
@@ -98,7 +98,7 @@ Return the greatest integer less than or equal to <Target>, or the least integer
 Tags: Math
 */
 
-syntax RoundedToNearest is prefix operator with precedence 1
+syntax RoundedToNearest is prefix operator with function chunk precedence
     "the" "rounded" "of" <Target: Expression>
 begin
     MCMathFoundationEvalRoundedNumberToNearest(Target, output)
@@ -125,7 +125,7 @@ Tags: Math
 */
 
 
-syntax FloorOperator is prefix operator with precedence 1
+syntax FloorOperator is prefix operator with function chunk precedence
     "the" "floor" "of" <Target: Expression>
 begin
     MCMathFoundationEvalFloorNumber(Target, output)
@@ -150,7 +150,7 @@ Tags: Math
 
 */
 
-syntax CeilOperator is prefix operator with precedence 1
+syntax CeilOperator is prefix operator with function chunk precedence
     "the" "ceiling" "of" <Target: Expression>
 begin
     MCMathFoundationEvalCeilingNumber(Target, output)

--- a/libscript/src/math.lcb
+++ b/libscript/src/math.lcb
@@ -96,7 +96,7 @@ Example:
 Tags: Math
 */
 
-syntax PowOperator is left binary operator with precedence 1
+syntax PowOperator is left binary operator with exponentiation precedence
     <Left: Expression> "^" <Right: Expression>
 begin
     MCMathEvalNumberToPowerOfNumber(Left, Right, output)
@@ -120,7 +120,7 @@ Example:
 Tags: Math
 */
 
-syntax SinOperator is prefix operator with precedence 1
+syntax SinOperator is prefix operator with function chunk precedence
     "the" "sine" "of" <Operand: Expression>
 begin
     MCMathEvalSinNumber(Operand, output)
@@ -144,7 +144,7 @@ Example:
 Tags: Math
 */
 
-syntax CosOperator is prefix operator with precedence 1
+syntax CosOperator is prefix operator with function chunk precedence
     "the" "cosine" "of" <Operand: Expression>
 begin
     MCMathEvalCosNumber(Operand, output)
@@ -172,7 +172,7 @@ Example:
 Tags: Math
 */
 
-syntax TanOperator is prefix operator with precedence 1
+syntax TanOperator is prefix operator with function chunk precedence
     "the" "tangent" "of" <Operand: Expression>
 begin
     MCMathEvalTanNumber(Operand, output)
@@ -203,7 +203,7 @@ The inverse of the sin operator.
 Tags: Math
 */
 
-syntax ArcsinOperator is prefix operator with precedence 1
+syntax ArcsinOperator is prefix operator with function chunk precedence
     "the" "arcsine" "of" <Operand: Expression>
 begin
     MCMathEvalAsinNumber(Operand, output)
@@ -234,7 +234,7 @@ The inverse of the cos operator.
 Tags: Math
 */
 
-syntax ArccosOperator is prefix operator with precedence 1
+syntax ArccosOperator is prefix operator with function chunk precedence
     "the" "arccosine" "of" <Operand: Expression>
 begin
     MCMathEvalAcosNumber(Operand, output)
@@ -265,7 +265,7 @@ The inverse of the tan operator.
 Tags: Math
 */
 
-syntax ArctanOperator is prefix operator with precedence 1
+syntax ArctanOperator is prefix operator with function chunk precedence
     "the" "arctangent" "of" <Operand: Expression>
 begin
     MCMathEvalAtanNumber(Operand, output)
@@ -298,7 +298,7 @@ The angle returned has absolute value less than pi: −π < arctan2(y, x) ≤ π
 Tags: Math
 */
 
-syntax BinaryArctanOperator is prefix operator with precedence 1
+syntax BinaryArctanOperator is prefix operator with function chunk precedence
     "the" "binary" "arctangent" "of" <yCoord: Expression> "and" <xCoord: Expression>
 begin
     MCMathEvalAtan2Number(yCoord, xCoord, output)
@@ -324,7 +324,7 @@ Example:
 Tags: Math
 */
 
-syntax Base10LogOperator is prefix operator with precedence 1
+syntax Base10LogOperator is prefix operator with function chunk precedence
     "the" "log" "of" <Operand: Expression>
 begin
     MCMathEvalBase10LogNumber(Operand, output)
@@ -351,7 +351,7 @@ Tags: Math
 
 */
 
-syntax BaseELogOperator is prefix operator with precedence 1
+syntax BaseELogOperator is prefix operator with function chunk precedence
     "the" "natural" "log" "of" <Operand: Expression>
 begin
     MCMathEvalNaturalLogNumber(Operand, output)
@@ -377,7 +377,7 @@ Example:
 Tags: Math
 */
 
-syntax ExpOperator is prefix operator with precedence 1
+syntax ExpOperator is prefix operator with function chunk precedence
     "the" "exponential" "of" <Operand: Expression>
 begin
     MCMathEvalExpNumber(Operand, output)
@@ -408,7 +408,7 @@ Tags: Math
 
 */
 
-syntax TruncOperator is prefix operator with precedence 1
+syntax TruncOperator is prefix operator with function chunk precedence
     "the" "trunc" "of" <Operand: Expression>
 begin
     MCMathEvalTruncNumber(Operand, output)
@@ -430,7 +430,7 @@ The absolute value of <Operand> is the value of <Operand> if it is greater than 
 Tags: Math
 */
 
-syntax AbsOperator is prefix operator with precedence 1
+syntax AbsOperator is prefix operator with function chunk precedence
     "the" "abs" "of" <Operand: Expression>
 begin
     MCMathEvalAbsNumber(Operand, output)
@@ -469,7 +469,7 @@ Returns: 	The value of <Left>, if it is less than the value of <Right>, and the 
 Tags: Math
 */
 
-syntax MinOperator is prefix operator with precedence 5
+syntax MinOperator is prefix operator with function chunk precedence
     "the" "minimum" "of" <Left: Expression> "and" <Right: Expression>
 begin
     MCMathEvalMinNumber(Left, Right, output)
@@ -491,7 +491,7 @@ Returns: 	The value of <Left>, if it is greater than the value of <Right>, and t
 Tags: Math
 */
 
-syntax MaxOperator is prefix operator with precedence 5
+syntax MaxOperator is prefix operator with function chunk precedence
     "the" "maximum" "of" <Left: Expression> "and" <Right: Expression>
 begin
     MCMathEvalMaxNumber(Left, Right, output)
@@ -515,7 +515,7 @@ Description:
 Tags: Math
 */
 
-syntax MinListOperator is prefix operator with precedence 5
+syntax MinListOperator is prefix operator with function chunk precedence
     "the" "minimum" "value" "of" <ValueList: Expression>
 begin
     MCMathEvalMinList(ValueList, output)
@@ -533,7 +533,7 @@ Description:
 Tags: Math
 */
 
-syntax MaxListOperator is prefix operator with precedence 5
+syntax MaxListOperator is prefix operator with function chunk precedence
     "the" "maximum" "value" "of" <ValueList: Expression>
 begin
     MCMathEvalMaxList(ValueList, output)
@@ -556,7 +556,7 @@ Interprets a string in the desired base and converts it to decimal.
 Tags: Math
 */
 
-syntax BaseConvertFrom is left binary operator with precedence 1
+syntax BaseConvertFrom is left binary operator with conversion precedence
     <Operand: Expression> "converted" "from" "base" <Source: Expression>
 begin
     MCMathEvalConvertToBase10(Operand, Source, output)
@@ -577,7 +577,7 @@ Converts a decimal into the desired base, and returns a string representation.
 Tags: Math
 */
 
-syntax BaseConvertTo is left binary operator with precedence 1
+syntax BaseConvertTo is left binary operator with conversion precedence
     <Operand: Expression> "converted" "to" "base" <Target: Expression>
 begin
     MCMathEvalConvertFromBase10(Operand, Target, output)
@@ -599,7 +599,7 @@ Interprets a string in the desired source base and converts it to the desired ta
 Tags: Math
 */
 
-syntax BaseConvert is left binary operator with precedence 1
+syntax BaseConvert is left binary operator with conversion precedence
     <Operand: Expression> "converted" "from" "base" <Source: Expression> "to" "base" <Target: Expression>
 begin
     MCMathEvalConvertBase(Operand, Source, Target, output)

--- a/libscript/src/string.lcb
+++ b/libscript/src/string.lcb
@@ -150,7 +150,7 @@ The result consists of the chars of <Left> followed by those of <Right>.
 Tags: Strings
 */
 
-syntax ConcatenateStrings is left binary operator with precedence 2
+syntax ConcatenateStrings is left binary operator with concatenation precedence
     <Left: Expression> "&" <Right: Expression>
 begin
     MCStringEvalConcatenate(Left, Right, output)
@@ -174,7 +174,7 @@ The result consists of the chars of <Left> followed by a space, and then the cha
 Tags: Strings
 */
 
-syntax ConcatenateStringsWithSpace is left binary operator with precedence 2
+syntax ConcatenateStringsWithSpace is left binary operator with concatenation precedence
     <Left: Expression> "&&" <Right: Expression>
 begin
     MCStringEvalConcatenateWithSpace(Left, Right, output)
@@ -195,7 +195,7 @@ Tags: Strings
 */
 
 
-syntax UppercaseString is prefix operator with precedence 1
+syntax UppercaseString is prefix operator with function chunk precedence
     "the" "upper" "of" <Source: Expression>
 begin
     MCStringEvalUppercaseOf(Source, output)
@@ -214,7 +214,7 @@ Tags: Strings
 */
 
 
-syntax LowercaseString is prefix operator with precedence 1
+syntax LowercaseString is prefix operator with function chunk precedence
     "the" "lower" "of" <Source: Expression>
 begin
     MCStringEvalLowercaseOf(Source, output)
@@ -237,7 +237,7 @@ The ```is``` operator is case sensitive.
 Tags: Strings
 */
 
-syntax StringIsString is neutral binary operator with precedence 7
+syntax StringIsString is neutral binary operator with comparison precedence
     <Left: Expression> "is" <Right: Expression>
 begin
     MCStringEvalIsEqualTo(Left, Right, output)
@@ -258,7 +258,7 @@ The ```is not``` operator is case sensitive.
 Tags: Strings
 */
 
-syntax StringIsNotString is neutral binary operator with precedence 7
+syntax StringIsNotString is neutral binary operator with comparison precedence
     <Left: Expression> "is not" <Right: Expression>
 begin
     MCStringEvalIsNotEqualTo(Left, Right, output)
@@ -279,7 +279,7 @@ Description:
 Tags: Strings
 */
 
-syntax StringIsLessThanString is neutral binary operator with precedence 5
+syntax StringIsLessThanString is neutral binary operator with comparison precedence
     <Left: Expression> "<" <Right: Expression>
 begin
     MCStringEvalIsLessThan(Left, Right, output)
@@ -299,7 +299,7 @@ Description:
 Tags: Strings
 */
 
-syntax StringIsGreaterThanString is neutral binary operator with precedence 5
+syntax StringIsGreaterThanString is neutral binary operator with comparison precedence
     <Left: Expression> ">" <Right: Expression>
 begin
     MCStringEvalIsGreaterThan(Left, Right, output)

--- a/libscript/src/type.lcb
+++ b/libscript/src/type.lcb
@@ -46,7 +46,7 @@ output:     Returns true if the given expression <Target> evaluates to the empty
 
 */
 
-syntax IsEmpty is postfix operator with precedence 7
+syntax IsEmpty is postfix operator with comparison precedence
     <Target: Expression> "is" "empty"
 begin
     MCTypeEvalIsEmpty(Target, output)
@@ -60,7 +60,7 @@ output:     Returns false if the given expression <Target> evaluates to the empt
 
 */
 
-syntax IsNotEmpty is postfix operator with precedence 7
+syntax IsNotEmpty is postfix operator with comparison precedence
 	<Target: Expression> "is not" "empty"
 begin
 	MCTypeEvalIsNotEmpty(Target, output)
@@ -80,7 +80,7 @@ Description:
 References: IsNotNothing (operator)
 */
 
-syntax IsDefined is postfix operator with precedence 7
+syntax IsDefined is postfix operator with comparison precedence
     deprecate with message "Use 'is not nothing' instead"
 	<Target: Expression> "is" "defined"
 begin
@@ -100,7 +100,7 @@ References: IsNothing (operator)
 
 */
 
-syntax IsNotDefined is postfix operator with precedence 7
+syntax IsNotDefined is postfix operator with comparison precedence
     deprecate with message "Use 'is nothing' instead"
 	<Target: Expression> "is not" "defined"
 begin
@@ -119,7 +119,7 @@ Description:
 References: IsNothing (operator)
 
 */
-syntax IsUndefined is postfix operator with precedence 7
+syntax IsUndefined is postfix operator with comparison precedence
     deprecate with message "Use 'is nothing' instead"
 	<Target: Expression> "is undefined"
 begin
@@ -137,7 +137,7 @@ Description:
 References: IsNotNothing (operator)
 
 */
-syntax IsNotUndefined is postfix operator with precedence 7
+syntax IsNotUndefined is postfix operator with comparison precedence
     deprecate with message "Use 'is not nothing' instead"
 	<Target: Expression> "is not undefined"
 begin
@@ -159,7 +159,7 @@ Use the <IsNothing> operator to test if operators or handlers have returned anyt
 
 */
 
-syntax NothingIsNothing is neutral binary operator with precedence 7
+syntax NothingIsNothing is neutral binary operator with comparison precedence
     <Left: Expression> "is" <Right: Expression>
 begin
     MCNothingEvalIsEqualToNothing(Left, Right, output)
@@ -185,7 +185,7 @@ Description:
 Use the <IsNotNothing> operator to test if operators or handlers have returned anything.
 */
 
-syntax NothingIsNotNothing is neutral binary operator with precedence 7
+syntax NothingIsNotNothing is neutral binary operator with comparison precedence
     <Left: Expression> "is not" <Right: Expression>
 begin
     MCNothingEvalIsNotEqualToNothing(Left, Right, output)
@@ -202,7 +202,7 @@ output:     Returns true if the given expression <Target> is a boolean, and fals
 
 */
 
-syntax IsABoolean is postfix operator with precedence 7
+syntax IsABoolean is postfix operator with classification precedence
 	<Target: Expression> "is" "a" "boolean"
 begin
 	MCTypeEvalIsABoolean(Target, output)
@@ -216,7 +216,7 @@ output:     Returns true if the given expression <Target> is a number, and false
 
 */
 
-syntax IsANumber is postfix operator with precedence 7
+syntax IsANumber is postfix operator with classification precedence
 	<Target: Expression> "is" "a" "number"
 begin
 	MCTypeEvalIsANumber(Target, output)
@@ -230,7 +230,7 @@ output:     Returns true if the given expression <Target> is a string, and false
 
 */
 
-syntax IsAString is postfix operator with precedence 7
+syntax IsAString is postfix operator with classification precedence
 	<Target: Expression> "is" "a" "string"
 begin
 	MCTypeEvalIsAString(Target, output)
@@ -244,7 +244,7 @@ output:     Returns true if the given expression <Target> is data, and false if 
 
 */
 
-syntax IsAData is postfix operator with precedence 7
+syntax IsAData is postfix operator with classification precedence
 	<Target: Expression> "is" "a" "data"
 begin
 	MCTypeEvalIsAData(Target, output)
@@ -258,7 +258,7 @@ output:     Returns true if the given expression <Target> is an array, and false
 
 */
 
-syntax IsAnArray is postfix operator with precedence 7
+syntax IsAnArray is postfix operator with classification precedence
 	<Target: Expression> "is" "an" "array"
 begin
 	MCTypeEvalIsAnArray(Target, output)
@@ -272,7 +272,7 @@ output:     Returns true if the given expression <Target> is a list, and false i
 
 */
 
-syntax IsAList is postfix operator with precedence 7
+syntax IsAList is postfix operator with classification precedence
 	<Target: Expression> "is" "a" "list"
 begin
 	MCTypeEvalIsAList(Target, output)

--- a/tests/lcb/stdlib/array.lcb
+++ b/tests/lcb/stdlib/array.lcb
@@ -1,0 +1,29 @@
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.array.tests
+
+public handler TestSubscriptPrecedence()
+	variable tArray as Array
+
+	-- Bug 15435
+	put the empty array into tArray
+	put "foo" into tArray["bar"]
+	test "subscript (_ ends with)" when tArray["bar"] ends with "o"
+end handler
+
+end module

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -618,8 +618,8 @@
     'rule' SyntaxPrecedence(-> functionchunk):
         "function chunk"
 
-    'rule' SyntaxPrecedence(-> constructorchunk):
-        "constructor chunk"
+    'rule' SyntaxPrecedence(-> constructor):
+        "constructor"
 
     'rule' SyntaxPrecedence(-> conversion):
         "conversion"

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -576,13 +576,13 @@
         "is" "iterator"
 
     'rule' SyntaxClass(-> prefix(Precedence)):
-        "is" "prefix" "operator" "with" "precedence" INTEGER_LITERAL(-> Precedence)
+        "is" "prefix" "operator" "with" SyntaxPrecedence(-> Precedence) "precedence"
 
     'rule' SyntaxClass(-> postfix(Precedence)):
-        "is" "postfix" "operator" "with" "precedence" INTEGER_LITERAL(-> Precedence)
+        "is" "postfix" "operator" "with" SyntaxPrecedence(-> Precedence) "precedence"
 
     'rule' SyntaxClass(-> binary(Assoc, Precedence)):
-        "is" SyntaxAssoc(-> Assoc) "binary" "operator" "with" "precedence" INTEGER_LITERAL(-> Precedence)
+        "is" SyntaxAssoc(-> Assoc) "binary" "operator" "with" SyntaxPrecedence(-> Precedence) "precedence"
 
     'rule' SyntaxClass(-> phrase):
         "is" "phrase"
@@ -597,6 +597,77 @@
         
     'rule' SyntaxAssoc(-> right):
         "right"
+
+'nonterm' SyntaxPrecedence(-> SYNTAXPRECEDENCE)
+
+    'rule' SyntaxPrecedence(-> scoperesolution):
+        "scope" "resolution"
+
+    'rule' SyntaxPrecedence(-> functioncall):
+        "function" "call"
+
+    'rule' SyntaxPrecedence(-> subscript):
+        "subscript"
+
+    'rule' SyntaxPrecedence(-> property):
+        "property"
+
+    'rule' SyntaxPrecedence(-> subscriptchunk):
+        "subscript chunk"
+
+    'rule' SyntaxPrecedence(-> functionchunk):
+        "function chunk"
+
+    'rule' SyntaxPrecedence(-> constructorchunk):
+        "constructor chunk"
+
+    'rule' SyntaxPrecedence(-> conversion):
+        "conversion"
+
+    'rule' SyntaxPrecedence(-> exponentiation):
+        "exponentiation"
+
+    'rule' SyntaxPrecedence(-> modifier):
+        "modifier"
+
+    'rule' SyntaxPrecedence(-> multiplication):
+        "multiplication"
+
+    'rule' SyntaxPrecedence(-> addition):
+        "addition"
+
+    'rule' SyntaxPrecedence(-> bitwiseshift):
+        "bitwise shift"
+
+    'rule' SyntaxPrecedence(-> concatenation):
+        "concatenation"
+
+    'rule' SyntaxPrecedence(-> comparison):
+        "comparison"
+
+    'rule' SyntaxPrecedence(-> classification):
+        "classification"
+
+    'rule' SyntaxPrecedence(-> bitwiseand):
+        "bitwise and"
+
+    'rule' SyntaxPrecedence(-> bitwisexor):
+        "bitwise xor"
+
+    'rule' SyntaxPrecedence(-> bitwiseor):
+        "bitwise or"
+
+    'rule' SyntaxPrecedence(-> logicalnot):
+        "logical not"
+
+    'rule' SyntaxPrecedence(-> logicaland):
+        "logical and"
+
+    'rule' SyntaxPrecedence(-> logicalor):
+        "logical or"
+
+    'rule' SyntaxPrecedence(-> sequence):
+        "sequence"
 
 'nonterm' SyntaxMethods(-> SYNTAXMETHODLIST)
 

--- a/toolchain/lc-compile/src/syntax.g
+++ b/toolchain/lc-compile/src/syntax.g
@@ -53,19 +53,24 @@
             BeginIteratorSyntaxRule(ModuleName, Name)
         ||
             where(Class -> prefix(Precedence))
-            BeginPrefixOperatorSyntaxRule(ModuleName, Name, Precedence)
+            MapSyntaxPrecedence(Precedence -> Level)
+            BeginPrefixOperatorSyntaxRule(ModuleName, Name, Level)
         ||
             where(Class -> postfix(Precedence))
-            BeginPostfixOperatorSyntaxRule(ModuleName, Name, Precedence)
+            MapSyntaxPrecedence(Precedence -> Level)
+            BeginPostfixOperatorSyntaxRule(ModuleName, Name, Level)
         ||
             where(Class -> binary(left, Precedence))
-            BeginLeftBinaryOperatorSyntaxRule(ModuleName, Name, Precedence)
+            MapSyntaxPrecedence(Precedence -> Level)
+            BeginLeftBinaryOperatorSyntaxRule(ModuleName, Name, Level)
         ||
             where(Class -> binary(right, Precedence))
-            BeginRightBinaryOperatorSyntaxRule(ModuleName, Name, Precedence)
+            MapSyntaxPrecedence(Precedence -> Level)
+            BeginRightBinaryOperatorSyntaxRule(ModuleName, Name, Level)
         ||
             where(Class -> binary(neutral, Precedence))
-            BeginNeutralBinaryOperatorSyntaxRule(ModuleName, Name, Precedence)
+            MapSyntaxPrecedence(Precedence -> Level)
+            BeginNeutralBinaryOperatorSyntaxRule(ModuleName, Name, Level)
         |)
         
         [|
@@ -262,3 +267,49 @@
         SetRModeOfMarkToInOut(Index)*/
 
 --------------------------------------------------------------------------------
+
+-- Decode SYNTAXPRECEDENCE named operator classes into numeric
+-- precedence levels.
+--
+-- See also /docs/specs/lcb-precedence.md
+
+'action' MapSyntaxPrecedence(SYNTAXPRECEDENCE -> INT)
+    'rule' MapSyntaxPrecedence(scoperesolution -> 1)
+
+    'rule' MapSyntaxPrecedence(functioncall -> 2)
+    'rule' MapSyntaxPrecedence(subscript -> 2)
+
+    'rule' MapSyntaxPrecedence(property -> 3)
+    'rule' MapSyntaxPrecedence(subscriptchunk -> 3)
+    'rule' MapSyntaxPrecedence(functionchunk -> 3)
+    'rule' MapSyntaxPrecedence(constructorchunk -> 3)
+
+    'rule' MapSyntaxPrecedence(conversion -> 4)
+
+    'rule' MapSyntaxPrecedence(modifier -> 5)
+
+    'rule' MapSyntaxPrecedence(exponentiation -> 6)
+
+    'rule' MapSyntaxPrecedence(multiplication -> 7)
+
+    'rule' MapSyntaxPrecedence(addition -> 8)
+
+    'rule' MapSyntaxPrecedence(bitwiseshift -> 9)
+    'rule' MapSyntaxPrecedence(concatenation -> 9)
+
+    'rule' MapSyntaxPrecedence(bitwiseand -> 10)
+
+    'rule' MapSyntaxPrecedence(bitwisexor -> 11)
+
+    'rule' MapSyntaxPrecedence(bitwiseor -> 12)
+
+    'rule' MapSyntaxPrecedence(comparison -> 13)
+    'rule' MapSyntaxPrecedence(classification -> 13)
+
+    'rule' MapSyntaxPrecedence(logicalnot -> 14)
+
+    'rule' MapSyntaxPrecedence(logicaland -> 15)
+
+    'rule' MapSyntaxPrecedence(logicalor -> 16)
+
+    'rule' MapSyntaxPrecedence(sequence -> 17)

--- a/toolchain/lc-compile/src/syntax.g
+++ b/toolchain/lc-compile/src/syntax.g
@@ -281,10 +281,9 @@
 
     'rule' MapSyntaxPrecedence(property -> 3)
     'rule' MapSyntaxPrecedence(subscriptchunk -> 3)
-    'rule' MapSyntaxPrecedence(functionchunk -> 3)
-    'rule' MapSyntaxPrecedence(constructor -> 3)
 
     'rule' MapSyntaxPrecedence(conversion -> 4)
+    'rule' MapSyntaxPrecedence(functionchunk -> 3)
 
     'rule' MapSyntaxPrecedence(modifier -> 5)
 
@@ -303,13 +302,15 @@
 
     'rule' MapSyntaxPrecedence(bitwiseor -> 12)
 
-    'rule' MapSyntaxPrecedence(comparison -> 13)
-    'rule' MapSyntaxPrecedence(classification -> 13)
+    'rule' MapSyntaxPrecedence(constructor -> 13)
 
-    'rule' MapSyntaxPrecedence(logicalnot -> 14)
+    'rule' MapSyntaxPrecedence(comparison -> 14)
+    'rule' MapSyntaxPrecedence(classification -> 14)
 
-    'rule' MapSyntaxPrecedence(logicaland -> 15)
+    'rule' MapSyntaxPrecedence(logicalnot -> 15)
 
-    'rule' MapSyntaxPrecedence(logicalor -> 16)
+    'rule' MapSyntaxPrecedence(logicaland -> 16)
 
-    'rule' MapSyntaxPrecedence(sequence -> 17)
+    'rule' MapSyntaxPrecedence(logicalor -> 17)
+
+    'rule' MapSyntaxPrecedence(sequence -> 18)

--- a/toolchain/lc-compile/src/syntax.g
+++ b/toolchain/lc-compile/src/syntax.g
@@ -282,7 +282,7 @@
     'rule' MapSyntaxPrecedence(property -> 3)
     'rule' MapSyntaxPrecedence(subscriptchunk -> 3)
     'rule' MapSyntaxPrecedence(functionchunk -> 3)
-    'rule' MapSyntaxPrecedence(constructorchunk -> 3)
+    'rule' MapSyntaxPrecedence(constructor -> 3)
 
     'rule' MapSyntaxPrecedence(conversion -> 4)
 

--- a/toolchain/lc-compile/src/syntax.g
+++ b/toolchain/lc-compile/src/syntax.g
@@ -293,9 +293,9 @@
     'rule' MapSyntaxPrecedence(multiplication -> 7)
 
     'rule' MapSyntaxPrecedence(addition -> 8)
+    'rule' MapSyntaxPrecedence(concatenation -> 8)
 
     'rule' MapSyntaxPrecedence(bitwiseshift -> 9)
-    'rule' MapSyntaxPrecedence(concatenation -> 9)
 
     'rule' MapSyntaxPrecedence(bitwiseand -> 10)
 

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -37,6 +37,7 @@
     SYNTAXINFO
     SYNTAXMARKINFO SYNTAXMARKTYPE
     NAME DOUBLE
+    SYNTAXPRECEDENCE
 
 --------------------------------------------------------------------------------
 
@@ -202,9 +203,9 @@
     statement
     iterator
     expression
-    prefix(Precedence: INT)
-    postfix(Precedence: INT)
-    binary(Assoc: SYNTAXASSOC, Precedence: INT)
+    prefix(Precedence: SYNTAXPRECEDENCE)
+    postfix(Precedence: SYNTAXPRECEDENCE)
+    binary(Assoc: SYNTAXASSOC, Precedence: SYNTAXPRECEDENCE)
     expressionphrase
     expressionlistphrase
 
@@ -314,6 +315,48 @@
 'table' INVOKEINFO(Index: INT, ModuleIndex: INT, Name: STRING, ModuleName: STRING, Methods: INVOKEMETHODLIST)
 
 'table' TYPEINFO(Position: POS)
+
+--------------------------------------------------------------------------------
+
+-- All operators are classified as particular types representing their syntactic
+-- structure. These patterns have fixed precedence when used in expressions to
+-- ensure consistent interpretation.
+--
+-- These classifications easy syntactic description and ensure consistency. The
+-- parser maps them to concrete operator type and precedence level before
+-- building the AST.
+--
+-- Some classifications have the same underlying syntactic pattern but distinction
+-- is made to make it clear what the intent of the syntax is. Generally, if two
+-- classifications share a syntax pattern, then they must share the same precedence
+-- and operator type to ensure the principal of least surprise is enforced.
+--
+-- See also /docs/specs/lcb-precedence.md
+--
+'type' SYNTAXPRECEDENCE
+    scoperesolution,  -- com.livecode.module.Identifier
+    functioncall,     -- Handler()
+    subscript,        -- tList[5]
+    property,         -- the paint of tCanvas
+    subscriptchunk,   -- char 5 of tString
+    conversion,       -- tString parsed as number
+    modifier,         -- -tNumber, bitwise not tNumber
+    exponentiation,   -- 2 ^ 10
+    multiplication,   -- /, *, div, mod
+    addition,         -- +, -
+    bitwiseshift,     -- 1 shifted left by 3 bitwise
+    concatenation,    -- &, &&
+    bitwiseand,       -- 5 bitwise and 1
+    bitwisexor,       -- 5 bitwise xor 1
+    bitwiseor,        -- 5 bitwise or 1
+    functionchunk,    -- the length of tList
+    constructorchunk, -- rectangle tList
+    comparison,       -- <=, <, is, =
+    classification,   -- 5 is a number
+    logicalnot,       -- not tBoolean
+    logicaland,       -- tLeft and tRight
+    logicalor,        -- tLeft or tRight
+    sequence          -- ,
 
 --------------------------------------------------------------------------------
 

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -350,7 +350,7 @@
     bitwisexor,       -- 5 bitwise xor 1
     bitwiseor,        -- 5 bitwise or 1
     functionchunk,    -- the length of tList
-    constructorchunk, -- rectangle tList
+    constructor,      -- rectangle tList
     comparison,       -- <=, <, is, =
     classification,   -- 5 is a number
     logicalnot,       -- not tBoolean

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -340,6 +340,7 @@
     property,         -- the paint of tCanvas
     subscriptchunk,   -- char 5 of tString
     conversion,       -- tString parsed as number
+    functionchunk,    -- the length of tList
     modifier,         -- -tNumber, bitwise not tNumber
     exponentiation,   -- 2 ^ 10
     multiplication,   -- /, *, div, mod
@@ -349,7 +350,6 @@
     bitwiseand,       -- 5 bitwise and 1
     bitwisexor,       -- 5 bitwise xor 1
     bitwiseor,        -- 5 bitwise or 1
-    functionchunk,    -- the length of tList
     constructor,      -- rectangle tList
     comparison,       -- <=, <, is, =
     classification,   -- 5 is a number

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -344,8 +344,8 @@
     exponentiation,   -- 2 ^ 10
     multiplication,   -- /, *, div, mod
     addition,         -- +, -
-    bitwiseshift,     -- 1 shifted left by 3 bitwise
     concatenation,    -- &, &&
+    bitwiseshift,     -- 1 shifted left by 3 bitwise
     bitwiseand,       -- 5 bitwise and 1
     bitwisexor,       -- 5 bitwise xor 1
     bitwiseor,        -- 5 bitwise or 1


### PR DESCRIPTION
This pull request refactors the way precedence levels work in LCB, to increase consistency.  Numbered precedence levels have been replaced by named precedence levels that describe the type of operator being used. There is [a specification](https://github.com/peter-b/livecode/blob/lcb/precedence/docs/specs/lcb-precedence.md).

**Note:** The precedence of logical `not` has been reduced to below that of comparison, to make syntax like `if not tObject exists` work as expected.

Overall, most LCB code should continue to work as before.
