### PR TITLE
Potential fix for Linux startup hangs

### DIFF
--- a/docs/notes/bugfix-15617.md
+++ b/docs/notes/bugfix-15617.md
@@ -1,0 +1,2 @@
+# Don't wait forever for the Linux clipboard to respond
+

--- a/engine/src/linux.stubs
+++ b/engine/src/linux.stubs
@@ -628,6 +628,8 @@ glib libglib-2.0.so.0
 	g_main_context_query: (pointer, integer, pointer, pointer, integer) -> (integer)
 	g_main_context_check: (pointer, integer, pointer, integer) -> (integer)
 	g_main_context_dispatch: (pointer) -> ()
+	g_main_context_find_source_by_id: (pointer, integer) -> (pointer)
+	g_source_destroy: (pointer) -> ()
 
 esd libesd.so.0
 	esd_close: (integer) -> (integer)

--- a/engine/src/lnx-clipboard.cpp
+++ b/engine/src/lnx-clipboard.cpp
@@ -721,7 +721,7 @@ static bool WaitForSelectionNotify()
     // Loop until a selection notify event is received
     MCScreenDC *dc = (MCScreenDC*)MCscreen;
     GdkEvent *t_notify;
-    while (!dc->GetFilteredEvent(SelectionNotifyFilter, t_notify, NULL))
+    while (!dc->GetFilteredEvent(SelectionNotifyFilter, t_notify, NULL, true))
     {
         // TODO: timeout
     }

--- a/engine/src/lnx-clipboard.cpp
+++ b/engine/src/lnx-clipboard.cpp
@@ -716,17 +716,42 @@ static bool SelectionNotifyFilter(GdkEvent *t_event, void *)
     return (t_event->type == GDK_SELECTION_NOTIFY);
 }
 
+// Timeout function that is triggered if we don't receive a reply from the
+// current seelction owner. If this timeout triggers, the selection is regarded
+// as being empty.
+static bool s_selection_timeout;
+static gboolean SelectionNotifyTimeout(gpointer)
+{
+    // If we didn't receive the selection notification by now, we have timed out
+    s_selection_timeout = true;
+    
+    // Remove this timer
+    return FALSE;
+}
+
 static bool WaitForSelectionNotify()
 {
+    // Add a timeout that will be triggered if there is no reply. We will wait
+    // for a maximum of 1 second.
+    guint t_timeout_event;
+    s_selection_timeout = false;
+    t_timeout_event = g_timeout_add(1000, &SelectionNotifyTimeout, NULL);
+    
     // Loop until a selection notify event is received
     MCScreenDC *dc = (MCScreenDC*)MCscreen;
     GdkEvent *t_notify;
     while (!dc->GetFilteredEvent(SelectionNotifyFilter, t_notify, NULL, true))
     {
-        // TODO: timeout
+        // If we timed out, stop waiting
+        if (s_selection_timeout)
+            break;
     }
     
-    return true;
+    // If the timeout didn't trigger, remove it manually
+    if (!s_selection_timeout)
+        g_source_destroy(g_main_context_find_source_by_id(NULL, t_timeout_event));
+    
+    return !s_selection_timeout;
 }
 #endif
 
@@ -775,14 +800,17 @@ void MCLinuxRawClipboardItem::FetchExternalRepresentations(GdkDragContext* p_dra
                               GDK_CURRENT_TIME);
         
         // Wait for a SelectionNotify event that tells us the data is ready
-        WaitForSelectionNotify();
+        bool t_timed_out = !WaitForSelectionNotify();
         
         // Get the data for this property
-        guchar* t_data;
         GdkAtom t_type;
         gint t_format;
-        gint t_data_length = gdk_selection_property_get(m_clipboard->GetClipboardWindow(),
-                                                        &t_data, &t_type, &t_format);
+        guchar* t_data = NULL;
+        gint t_data_length = 0;
+        if (!t_timed_out)
+        {
+            t_data_length = gdk_selection_property_get(m_clipboard->GetClipboardWindow(), &t_data, &t_type, &t_format);
+        }
         
         // Was the property received successfully?
         if (t_data == NULL || t_type != GDK_SELECTION_TYPE_ATOM)
@@ -852,14 +880,17 @@ MCLinuxRawClipboardItemRep::MCLinuxRawClipboardItemRep(MCLinuxRawClipboard* p_cl
                           p_selection, p_atom, GDK_CURRENT_TIME);
     
     // Wait for a SelectionNotify event that tells us the data is ready
-    WaitForSelectionNotify();
+    bool t_timed_out = !WaitForSelectionNotify();
     
     // Get the data for this property
-    guchar* t_data;
     GdkAtom t_type;
     gint t_format;
-    gint t_data_length = gdk_selection_property_get(p_clipboard->GetClipboardWindow(),
-                                                    &t_data, &t_type, &t_format);
+    guchar* t_data = NULL;
+    gint t_data_length = 0;
+    if (!t_timed_out)
+    {
+        t_data_length = gdk_selection_property_get(p_clipboard->GetClipboardWindow(), &t_data, &t_type, &t_format);
+    }
     
     // Copy the data for this property
     MCDataCreateWithBytes(t_data, t_data_length, &m_bytes);

--- a/engine/src/lnxdc.h
+++ b/engine/src/lnxdc.h
@@ -333,11 +333,11 @@ public:
 #endif
     
     // Processes all outstanding GDK events and adds them to the event queue
-    void EnqueueGdkEvents();
+    void EnqueueGdkEvents(bool p_may_block = false);
     
     // Searches the event queue for an event that passes the given filter
     typedef bool (*event_filter)(GdkEvent*, void *);
-    bool GetFilteredEvent(event_filter, GdkEvent* &r_event, void *);
+    bool GetFilteredEvent(event_filter, GdkEvent* &r_event, void *, bool p_may_block = false);
     
     // Utility function - maps an X drawing operation to the GDK equivalent
     static GdkFunction XOpToGdkOp(int op);


### PR DESCRIPTION
Logging reveals that the potential cause of Linux startup hangs that have been reported is waiting for the X11 clipboard to respond. This PR adds a 1-second timeout to the wait, after which the engine assumes that the clipboard is empty. It also ensures that during that interval, the engine will poll rather than busy-waiting.

Unfortunately, I haven't been able to reproduce the issue locally so it isn't possible to be certain that this fixes the issue. Even if it doesn't, it fixes some problematic clipboard interactions.
