### PR TITLE
[emscripten] Fix "mismatched-tags" error in commercial engine

### DIFF
--- a/engine/src/platform.h
+++ b/engine/src/platform.h
@@ -1111,7 +1111,7 @@ void MCPlatformSoundGetProperty(MCPlatformSoundRef sound, MCPlatformSoundPropert
 // what is currently required).
 //
 
-typedef struct MCPlatformSoundRecorder *MCPlatformSoundRecorderRef;
+typedef class MCPlatformSoundRecorder *MCPlatformSoundRecorderRef;
 
 enum MCPlatformSoundRecorderProperty
 {


### PR DESCRIPTION
Some code which generated a "mismatched-tags" warning isn't built in
the community engine, which meant it wasn't fixed up in pull
request #3199.
