### PR TITLE
[[ Palette Actions ]] Remain in numeric order

### DIFF
--- a/extensions/widgets/paletteactions/notes/feature-sort_order.md
+++ b/extensions/widgets/paletteactions/notes/feature-sort_order.md
@@ -1,0 +1,4 @@
+# Palette actions order
+
+The palette actions widget now uses the sort using handler syntax to sort 
+the elements of its data array, in order to sort numerically.

--- a/extensions/widgets/paletteactions/paletteactions.lcb
+++ b/extensions/widgets/paletteactions/paletteactions.lcb
@@ -583,6 +583,42 @@ private handler listToArray(in pList as List) returns Array
 	return tArray
 end handler
 
+-- Sorts numerically, converting strings to numbers where possible
+private handler CompareKeysNumeric(in pLeft as any, in pRight as any) returns Integer
+	variable tLeft as optional Number
+	variable tRight as optional Number
+	
+	if pLeft is a number then
+		put pLeft into tLeft
+	else
+		put pLeft parsed as number into tLeft
+	end if
+	
+	if pRight is a number then
+		put pRight into tRight
+	else
+		put pRight parsed as number into tRight
+	end if
+
+	if tRight is tLeft then
+		return 0
+	end if
+		
+	if tRight is nothing then
+		return -1
+	end if
+	
+	if tLeft is nothing then
+		return 1
+	end if
+	
+	if tLeft < tRight then
+        return -1
+	end if
+
+    return 1
+end handler
+
 private handler setData(in pArray as Array, in pDefaultArray as Array, out rList as List)
 	variable tList as List
 	put the empty list into tList
@@ -590,7 +626,7 @@ private handler setData(in pArray as Array, in pDefaultArray as Array, out rList
 	if pArray is not empty then
 		variable tOrder as List
 		put the keys of pArray into tOrder
-		sort tOrder in ascending order
+		sort tOrder using handler CompareKeysNumeric
 
 		variable tKeys as List
 		put the keys of pDefaultArray into tKeys

--- a/extensions/widgets/paletteactions/tests/basic.livecodescript
+++ b/extensions/widgets/paletteactions/tests/basic.livecodescript
@@ -1,0 +1,41 @@
+script "PaletteActions"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSetup
+	TestLoadExtension "com.livecode.widget-utils"
+	TestLoadExtension "com.livecode.library.iconSVG"
+	TestLoadExtension "com.livecode.widget.paletteActions"
+end TestSetup
+
+on TestSortOrder
+	create widget "Actions" as "com.livecode.widget.paletteActions"
+	
+	local tArray
+	repeat with x = 1 to 10
+		put x into tArray[x]["name"]
+	end repeat
+	set the navData of widget "Actions" to tArray
+	
+	local tData
+	put the navData of widget "Actions" into tData
+	
+	get the keys of tData
+	repeat for each line tLine in it
+		TestAssert "palette nav items stay in numeric order", tData[tLine]["name"] + 0 is tLine + 0
+	end repeat
+end TestSortOrder


### PR DESCRIPTION
The palette actions previously sorted its keys in text order.

This patch forces the sort in numeric order. Since this widget
is currently reserved for IDE use, all of its uses should be passing
arrays with numeric keys as the navData.
