### PR TITLE
Various Gyp tweaks to make engine rebuilds faster

### DIFF
--- a/config/cpptest.gypi
+++ b/config/cpptest.gypi
@@ -111,7 +111,7 @@
 						'../util/run-tests.pl',
 						'<(exec_wrapper)',
 						'<(PRODUCT_DIR)/test-<(module_name)<(test_suffix)',
-						'test-<(module_name).log',
+						'<(PRODUCT_DIR)/test-<(module_name).log',
 					],
 
 				},

--- a/engine/lcb-modules.gyp
+++ b/engine/lcb-modules.gyp
@@ -43,7 +43,6 @@
 						'<@(engine_other_lcb_files)',
 						'<@(stdscript_syntax_lcb_files)',
 						'<@(stdscript_other_lcb_files)',
-						'>(lc-compile_host)',
 					],
 					
 					'outputs':

--- a/engine/lcb-modules.gyp
+++ b/engine/lcb-modules.gyp
@@ -49,7 +49,11 @@
 					'outputs':
 					[
 						'<(INTERMEDIATE_DIR)/engine_lcb_modules.c',
-						'<(PRODUCT_DIR)/modules/lci/dummy.file',
+                        
+  						# A specific output file is required here to ensure that
+  						# all build systems create the output directory while
+  						# also preventing spurious rebuilds.
+  						'<(PRODUCT_DIR)/modules/lci/com.livecode.type.lci',
 					],
 					
 					'action':
@@ -59,7 +63,6 @@
 						'--bootstrap',
 						'--inputg', '../toolchain/lc-compile/src/grammar.g',
 						'--outputi', '<(PRODUCT_DIR)/modules/lci',
-						#'--outputg', '<(INTERMEDIATE_DIR)/>(stage)/grammar_full.g',
 						'--outputc', '<(INTERMEDIATE_DIR)/engine_lcb_modules.c',
 						'<@(_inputs)',
 					],

--- a/gyp/pylib/gyp/generator/xcode.py
+++ b/gyp/pylib/gyp/generator/xcode.py
@@ -888,6 +888,9 @@ def GenerateOutput(target_list, target_dicts, data, params):
       # (rule_sources) that apply to it.
       concrete_outputs_all = []
 
+      # All rule prerequisites
+      prerequisites_all = []
+
       # messages & actions are keyed by the same indices as rule['rule_sources']
       # and concrete_outputs_by_rule_source.  They contain the message and
       # action to perform after resolving input-dependent variables.  The
@@ -1016,6 +1019,9 @@ def GenerateOutput(target_list, target_dicts, data, params):
           prerequisites.extend(rule.get('inputs', []))
           for prerequisite_index in xrange(0, len(prerequisites)):
             prerequisite = prerequisites[prerequisite_index]
+            # Add the prerequisite to the list if not already there
+            if prerequisite not in prerequisites_all:
+              prerequisites_all.append(prerequisite)
             if prerequisite_index == len(prerequisites) - 1:
               eol = ''
             else:
@@ -1071,6 +1077,8 @@ exit 1
               'name': 'Rule "' + rule['rule_name'] + '"',
               'shellScript': script,
               'showEnvVarsInLog': 0,
+              'outputPaths': concrete_outputs_all,
+              'inputPaths': prerequisites_all,
             })
 
         if support_xct:

--- a/revmobile/revmobile.gyp
+++ b/revmobile/revmobile.gyp
@@ -31,7 +31,7 @@
 			'conditions':
 			[
 				[
-					'OS == "linux" or OS =="mac"',
+					'OS == "linux"',
 					{
 						'libraries':
 						[

--- a/toolchain/lc-compile/lc-run.gyp
+++ b/toolchain/lc-compile/lc-run.gyp
@@ -77,7 +77,6 @@
 					[
 						'<@(stdscript_syntax_lcb_files)',
 						'<@(stdscript_other_lcb_files)',
-						'>(lc-compile_host)',
 					],
 					
 					'outputs':

--- a/toolchain/lc-compile/lc-run.gyp
+++ b/toolchain/lc-compile/lc-run.gyp
@@ -83,7 +83,11 @@
 					'outputs':
 					[
 						'<(INTERMEDIATE_DIR)/lc-run_lcb_modules.c',
-						'<(INTERMEDIATE_DIR)/modules/lci/dummy.file',
+
+						# A specific output file is required here to ensure that
+						# all build systems create the output directory while
+                        			# also preventing spurious rebuilds.
+						'<(INTERMEDIATE_DIR)/lc-run-modules/lci/com.livecode.type.lci',
 					],
 					
 					'action':
@@ -92,8 +96,7 @@
 						'>(lc-compile_host)',
 						'--bootstrap',
 						'--inputg', 'src/grammar.g',
-						'--outputi', '<(INTERMEDIATE_DIR)/modules/lci',
-						#'--outputg', '<(INTERMEDIATE_DIR)/>(stage)/grammar_full.g',
+						'--outputi', '<(INTERMEDIATE_DIR)/lc-run-modules/lci',
 						'--outputc', '<(INTERMEDIATE_DIR)/lc-run_lcb_modules.c',
 						'<@(_inputs)',
 					],

--- a/toolchain/lc-compile/src/lc-compile-bootstrap-common.gypi
+++ b/toolchain/lc-compile/src/lc-compile-bootstrap-common.gypi
@@ -33,8 +33,11 @@
 			'outputs':
 			[
 				'<(INTERMEDIATE_DIR)/>(stage)/grammar_full.g',
-				'<(INTERMEDIATE_DIR)/>(stage)/builtin-modules.c',
-				'<(INTERMEDIATE_DIR)/>(stage)/modules/lci/dummy.file',
+                
+                # A specific output file is required here to ensure that all
+                # build systems create the output directory while also
+                # also preventing spurious rebuilds.
+                '<(INTERMEDIATE_DIR)/>(stage)/modules/lci/com.livecode.type.lci',
 			],
 			
 			'action':
@@ -44,7 +47,6 @@
 				'--inputg', '>(template_grammar_file)',
 				'--outputi', '<(INTERMEDIATE_DIR)/>(stage)/modules/lci',
 				'--outputg', '<(INTERMEDIATE_DIR)/>(stage)/grammar_full.g',
-				#'--outputc', '<(INTERMEDIATE_DIR)/>(stage)/builtin-modules.c',
 				'>@(all_syntax_files)',
 			],
 		},


### PR DESCRIPTION
Our dependencies are a bit off, causing Xcode and Visual Studio to rebuild too aggressively - this branch fixes these issues, making iterating on a fix easier, without breaking any actual dependencies (hopefully...).
