### PR TITLE
[Bug 16407] Prevent busy loop from splitting by empty.

### DIFF
--- a/docs/notes/bugfix-16407.md
+++ b/docs/notes/bugfix-16407.md
@@ -1,0 +1,1 @@
+# Splitting by empty causes a hang

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -4210,8 +4210,13 @@ bool MCStringSplitNative(MCStringRef self, MCStringRef p_elem_del, MCStringRef p
     
     if (__MCStringIsIndirect(p_elem_del))
         p_elem_del = p_elem_del -> string;
-    
-    
+
+	/* Splitting by empty isn't permitted */
+	if (0 == __MCStringGetLength(p_elem_del))
+	{
+		return false;
+	}
+
     const char_t *t_sptr;
     const char_t *t_eptr;
     t_sptr = self -> native_chars;
@@ -4246,7 +4251,12 @@ bool MCStringSplitNative(MCStringRef self, MCStringRef p_elem_del, MCStringRef p
 	{
         if (__MCStringIsIndirect(p_key_del))
             p_elem_del = p_key_del -> string;
-        
+
+		if (0 == __MCStringGetLength(p_key_del))
+		{
+			return false;
+		}
+
 		for(;;)
 		{
 			const char_t *t_element_end;
@@ -4475,7 +4485,7 @@ bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_d
     
     if (__MCStringIsIndirect(p_elem_del))
         p_elem_del = p_elem_del -> string;
-    
+
 	const void *t_echar, *t_kchar;
     bool del_native, key_native;
     del_native = __MCStringIsNative(p_elem_del);
@@ -4488,6 +4498,13 @@ bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_d
         
         key_native = __MCStringIsNative(p_key_del);
 		t_kchar = p_key_del -> chars;
+    }
+
+    /* Splitting by the empty string isn't permitted */
+    if (0 == __MCStringGetLength(p_elem_del) ||
+        (nil != p_key_del && 0 == __MCStringGetLength(p_key_del)))
+    {
+        return false;
     }
 
 	const void *t_sptr;

--- a/tests/lcs/core/array/split.livecodescript
+++ b/tests/lcs/core/array/split.livecodescript
@@ -1,0 +1,35 @@
+﻿script "CoreArraySplit"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+-- Attempting to split a string with an empty delimiter should throw an error
+private function IsSplitByEmptyError pString
+   local tVar
+   put pString into tVar
+   try
+      split tVar by ""
+      return false
+   catch tError
+      return true
+   end try
+end IsSplitByEmptyError
+
+on TestSplitByEmpty
+   -- Bug 16407
+   TestAssert "split native by empty", IsSplitByEmptyError("abc")
+   TestAssert "split unicode by empty", IsSplitByEmptyError("abc" & numToCodePoint(0x2192))
+end TestSplitByEmpty


### PR DESCRIPTION
Make `MCStringSplit()` fail when given an empty delimiter.
