### PR TITLE
Fix incorrect characters

### DIFF
--- a/docs/dictionary/property/tabAlign.lcdoc
+++ b/docs/dictionary/property/tabAlign.lcdoc
@@ -15,14 +15,14 @@ OS: mac,windows,linux,ios,android
 Platforms: desktop,server,web,mobile
 
 Example:
-set¬†the tabAlign of field 1 to "left,left,right,center"
+set the tabAlign of field 1 to "left,left,right,center"
 
 Example:
-put¬†"A" & tab & "B" & tab & "C" & cr & "left" & tab & "center" & tab & "right" into field 1
-set¬†the tabStops of field 1 to "100"
-set¬†the tabAlign of field 1 to "left,center,right"
+put "A" & tab & "B" & tab & "C" & cr & "left" & tab & "center" & tab & "right" into field 1
+set the tabStops of field 1 to "100"
+set the tabAlign of field 1 to "left,center,right"
 
-Value (enum): The <tabAlign> of a field is a return delimited list of alignments, separated by commas. The alignments can be one of ‚Äòleft‚Äô, ‚Äòright‚Äô and ‚Äòcenter‚Äô.By default, the <tabAlign> property of newly created fields is set to empty
+Value (enum): The <tabAlign> of a field is a return delimited list of alignments, separated by commas. The alignments can be one of "left", "right" and "center".By default, the <tabAlign> property of newly created fields is set to empty
 
 Description:
 Use the <tabAlign> property to set the alignment of tab separated text.


### PR DESCRIPTION
Some characters in the document seem to have been encoded incorrectly when a conversion was made. This commit fixes those characters.
