### PR TITLE
[[ Bug 15939 ]] Tweak MCScreenDC::wait loop on iOS (socket handling)

### DIFF
--- a/docs/notes/bugfix-15939.md
+++ b/docs/notes/bugfix-15939.md
@@ -1,0 +1,1 @@
+# MouseUp, MouseDown msgs not rx on iOS device when using sockets

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -724,12 +724,7 @@ Boolean MCScreenDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 		
         // MM-2015-08-11: [[ Bug 15700 ]] Poll the sockets. Code pulled over from OS X wait.
         extern Boolean MCS_handle_sockets();
-        if (MCS_handle_sockets())
-        {
-            if (anyevent)
-                done = True;
-            t_sleep = 0.0;
-        }
+        MCS_handle_sockets();
         
 		// Switch to the main fiber and wait for at most t_sleep seconds. This
 		// returns 'true' if the wait was broken rather than timed out.


### PR DESCRIPTION
The loop should not be exited after a successful socket read, like it does on Mac (from where the code was pulled
when mobile sockets were implemented).
