### PR TITLE
[Bug 16407] libfoundation: Change MCStringSplit by empty

### DIFF
--- a/docs/notes/bugfix-16407.md
+++ b/docs/notes/bugfix-16407.md
@@ -1,0 +1,1 @@
+# Splitting by empty causes a hang

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -4142,6 +4142,13 @@ bool MCStringAppendFormatV(MCStringRef self, const char *p_format, va_list p_arg
 
 static void split_find_end_of_element_native(const char_t *sptr, const char_t *eptr, const char_t *del, uindex_t p_del_length, const char_t*& r_end_ptr, MCStringOptions p_options)
 {
+	/* Empty delimiters are never found */
+	if (0 == p_del_length)
+	{
+		r_end_ptr = eptr;
+		return;
+	}
+
 	while(sptr < eptr - p_del_length + 1)
 	{
         // Compute the length of the shared prefix at the current offset.
@@ -4163,6 +4170,15 @@ static void split_find_end_of_element_native(const char_t *sptr, const char_t *e
 
 static void split_find_end_of_element_and_key_native(const char_t *sptr, const char_t *eptr, const char_t *del, uindex_t p_del_length, const char_t *key, uindex_t p_key_length, const char_t*& r_key_ptr, const char_t *& r_end_ptr, MCStringOptions p_options)
 {
+	/* Empty delimiters are never found */
+	if (0 == p_key_length)
+	{
+		split_find_end_of_element_native(sptr, eptr, del, p_del_length,
+		                                 r_end_ptr, p_options);
+		r_key_ptr = r_end_ptr;
+		return;
+	}
+
     while(sptr < eptr - p_key_length + 1)
     {
         // Compute the length of the shared prefix at the current offset.
@@ -4177,7 +4193,8 @@ static void split_find_end_of_element_and_key_native(const char_t *sptr, const c
 			break;
         }
         
-        if (sptr < eptr - p_del_length + 1)
+        if (0 < p_del_length &&
+            sptr < eptr - p_del_length + 1)
         {
             if (p_options == kMCStringOptionCompareCaseless || p_options == kMCStringOptionCompareFolded)
                 t_prefix_length = MCNativeCharsSharedPrefixCaseless(sptr, eptr - sptr, del, p_del_length);
@@ -4426,23 +4443,30 @@ static void split_find_end_of_element_and_key(const void *sptr, uindex_t length,
     t_del_found = MCUnicodeFind(sptr, length, native, p_del, p_del_length, p_del_native, (MCUnicodeCompareOption)p_options, t_del_found_range);
     // SN-2014-07-29: [[ Bug 13018 ]] Use t_key_found_range for the key, not t_del_found_range
     t_key_found = MCUnicodeFind(sptr, length, native, p_key, p_key_length, p_key_native, (MCUnicodeCompareOption)p_options, t_key_found_range);
-    
-    if (!t_key_found)
-        r_key_end = length;
-    
-    if (!t_del_found)
-        r_element_end = length;
-    
-    if (t_key_found_range . offset > t_del_found_range . offset)
-    {
-        // Delimiter came before the key
-        r_key_end = r_element_end = length;
-        return;
-    }
-    
-    r_key_end = t_key_found_range . offset;
-    r_key_found_length = t_key_found_range . length;
-    split_find_end_of_element(sptr, length, native, p_del, p_del_length, p_del_native, p_options, r_element_end, r_del_found_length);
+
+	if (!t_del_found)
+	{
+		r_element_end = length;
+		r_del_found_length = 0;
+	}
+	else
+	{
+		r_element_end = t_del_found_range.offset;
+		r_del_found_length = t_del_found_range.length;
+	}
+
+	/* Deal with the possibility that the delimiter was found before the key */
+	if (!t_key_found ||
+	    r_element_end < t_key_found_range.offset)
+	{
+		r_key_end = r_element_end;
+		r_key_found_length = 0;
+	}
+	else
+	{
+		r_key_end = t_key_found_range.offset;
+		r_key_found_length = t_key_found_range.length;
+	}
 }
 
 bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_del, MCStringOptions p_options, MCArrayRef& r_array)

--- a/tests/lcs/core/array/split.livecodescript
+++ b/tests/lcs/core/array/split.livecodescript
@@ -1,0 +1,152 @@
+﻿script "CoreArraySplit"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSplit
+   local tResult, tExpected, tRArrow, tLArrow
+   put numToCodePoint(0x2192) into tRArrow
+   put numToCodePoint(0x2190) into tLArrow
+
+   -- Split by single char
+   put "a,b" into tResult
+   put empty into tExpected
+   put "a" into tExpected[1]
+   put "b" into tExpected[2]
+   split tResult by ","
+   TestAssert "split (native, native)", tResult is tExpected
+
+   put "a," & tRArrow into tResult
+   put empty into tExpected
+   put "a" into tExpected[1]
+   put tRArrow into tExpected[2]
+   split tResult by ","
+   TestAssert "split (unicode, native)", tResult is tExpected
+
+   put "a" & tRArrow & "b" into tResult
+   put empty into tExpected
+   put "a" into tExpected[1]
+   put "b" into tExpected[2]
+   split tResult by tRArrow
+   TestAssert "split (unicode, unicode)", tResult is tExpected
+
+   ----------
+
+   put "a:,b" into tResult
+   split tResult by ":,"
+   TestAssert "split multi (native, native)", tResult is tExpected
+
+   put "a" & tRArrow & tLArrow & "b" into tResult
+   split tResult by (tRArrow & tLArrow)
+   TestAssert "split multi (unicode, unicode)", tResult is tExpected
+
+   ----------
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put "b" into tExpected["a"]
+   put "d" into tExpected["c"]
+   split tResult by "," and ":"
+   TestAssert "split key (native, native)", (tResult is tExpected)
+
+   put "a:b" & tRArrow & "c:d" into tResult
+   split tResult by tRArrow and ":"
+   TestAssert "split key (unicode, unicode, native)", (tResult is tExpected)
+
+   put "a" & tRArrow & "b,c" & tRArrow & "d" into tResult
+   split tResult by "," and tRArrow
+   TestAssert "split key (unicode, native, unicode)", (tResult is tExpected)
+
+   ----------
+
+   put "a,b" into tResult
+   put empty into tExpected
+   put empty into tExpected["a"]
+   put empty into tExpected["b"]
+   split tResult by "," and ":"
+   TestAssert "split key missing (native, native, native)", tResult is tExpected
+
+   put tRArrow & comma & tLArrow into tResult
+   put empty into tExpected
+   put empty into tExpected[tRArrow]
+   put empty into tExpected[tLArrow]
+   split tResult by "," and ":"
+   TestAssert "split key missing (unicode, native, native)", tResult is tExpected
+end TestSplit
+
+
+
+on TestSplitByEmpty
+   local tResult, tExpected, tRArrow
+   put numToCodePoint(0x2192) into tRArrow
+
+   put "a,b" into tResult
+   put empty into tExpected
+   put tResult into tExpected[1]
+   split tResult by empty
+   TestAssert "split (native, empty)", tResult is tExpected
+
+   put "a" & tRArrow & "b" into tResult
+   put empty into tExpected
+   put tResult into tExpected[1]
+   split tResult by empty
+   TestAssert "split (unicode, empty)", tResult is tExpected
+
+   ----------
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put "b,c:d" into tExpected["a"]
+   split tResult by empty and ":"
+   TestAssert "split key (native, empty, native)", tResult is tExpected
+
+   put "a:b,c:" & tRArrow into tResult
+   put empty into tExpected
+   put char 3 to -1 of tResult into tExpected["a"]
+   split tResult by empty and ":"
+   TestAssert "split key (unicode, empty, native)", tResult is tExpected
+
+   ----------
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put empty into tExpected["a:b"]
+   put empty into tExpected["c:d"]
+   split tResult by "," and empty
+   TestAssert "split key (native, native, empty)", tResult is tExpected
+
+   put tRArrow & ":b,c:" & tRArrow into tResult
+   put empty into tExpected
+   put empty into tExpected[tRArrow & ":b"]
+   put empty into tExpected["c:" & tRArrow]
+   split tResult by "," and empty
+   TestAssert "split key (unicode, native, empty)", tResult is tExpected
+
+   ----------
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put empty into tExpected[tResult]
+   split tResult by empty and empty
+   TestAssert "split key (native, empty, empty)", tResult is tExpected
+
+   put "a:b,c:" & tRArrow into tResult
+   put empty into tExpected
+   put empty into tExpected[tResult]
+   split tResult by empty and empty
+   TestAssert "split key (unicode, empty, empty)", tResult is tExpected
+
+end TestSplitByEmpty


### PR DESCRIPTION
`MCStringSplit()` misbehaves when it receives an empty delimiter
string, entering an infinite loop.

This patch alters the behaviour of `MCStringSplit()` to treat empty
delimiters as never existing in the target string.  This is consistent
with the behaviour of the `contains` operator:
`"abc" contains empty -> false`
