### PR TITLE
[Bug 16407] Splitting by empty should be an error

### DIFF
--- a/docs/notes/bugfix-16407.md
+++ b/docs/notes/bugfix-16407.md
@@ -1,0 +1,1 @@
+# Splitting by empty causes a hang

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -1327,6 +1327,14 @@ void MCArrayOp::exec_ctxt(MCExecContext &ctxt)
 	}
 	else
 	{
+		/* Delimiters cannot be empty for split */
+		if (MCStringIsEmpty(*t_element_del) ||
+		    (nil != *t_key_del && MCStringIsEmpty(*t_key_del)))
+		{
+			ctxt.LegacyThrow(EE_ARRAYOP_BADEXP);
+			return;
+		}
+
 		MCAutoStringRef t_string;
         if (!ctxt . ConvertToString(*t_container_value, &t_string))
             return;

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -1327,14 +1327,6 @@ void MCArrayOp::exec_ctxt(MCExecContext &ctxt)
 	}
 	else
 	{
-		/* Delimiters cannot be empty for split */
-		if (MCStringIsEmpty(*t_element_del) ||
-		    (nil != *t_key_del && MCStringIsEmpty(*t_key_del)))
-		{
-			ctxt.LegacyThrow(EE_ARRAYOP_BADEXP);
-			return;
-		}
-
 		MCAutoStringRef t_string;
         if (!ctxt . ConvertToString(*t_container_value, &t_string))
             return;

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -404,6 +404,14 @@ void MCArraysExecCombineAsSet(MCExecContext& ctxt, MCArrayRef p_array, MCStringR
 
 void MCArraysExecSplit(MCExecContext& ctxt, MCStringRef p_string, MCStringRef p_element_delimiter, MCStringRef p_key_delimiter, MCArrayRef& r_array)
 {
+	/* Cannot split by empty delimiters */
+	if (MCStringIsEmpty(p_element_delimiter) ||
+	    (nil != p_key_delimiter && MCStringIsEmpty(p_key_delimiter)))
+	{
+		ctxt.LegacyThrow(EE_ARRAYOP_BADEXP);
+		return;
+	}
+
 	if (MCStringSplit(p_string, p_element_delimiter, p_key_delimiter, ctxt . GetStringComparisonType(), r_array))
 		return;
 
@@ -415,7 +423,14 @@ void MCArraysExecSplitByColumn(MCExecContext& ctxt, MCStringRef p_string, MCArra
     MCStringRef t_row_delim, t_column_delim;
     t_row_delim = ctxt . GetRowDelimiter();
     t_column_delim = ctxt . GetColumnDelimiter();
-    
+
+	/* Cannot split by empty delimiters */
+	if (MCStringIsEmpty(t_row_delim) || MCStringIsEmpty(t_column_delim))
+	{
+		ctxt.LegacyThrow(EE_ARRAYOP_BADEXP);
+		return;
+	}
+
     // Output array
     MCAutoArrayRef t_array;
     if (!MCArrayCreateMutable(&t_array))
@@ -523,6 +538,13 @@ void MCArraysExecSplitByColumn(MCExecContext& ctxt, MCStringRef p_string, MCArra
 
 void MCArraysExecSplitAsSet(MCExecContext& ctxt, MCStringRef p_string, MCStringRef p_element_delimiter, MCArrayRef& r_array)
 {
+	/* Cannot split by empty delimiters */
+	if (MCStringIsEmpty(p_element_delimiter))
+	{
+		ctxt.LegacyThrow(EE_ARRAYOP_BADEXP);
+		return;
+	}
+
 	// Split the incoming string into its components
     MCAutoArrayRef t_keys;
     if (!MCStringSplit(p_string, p_element_delimiter, nil, ctxt . GetStringComparisonType(), &t_keys))

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -4426,23 +4426,30 @@ static void split_find_end_of_element_and_key(const void *sptr, uindex_t length,
     t_del_found = MCUnicodeFind(sptr, length, native, p_del, p_del_length, p_del_native, (MCUnicodeCompareOption)p_options, t_del_found_range);
     // SN-2014-07-29: [[ Bug 13018 ]] Use t_key_found_range for the key, not t_del_found_range
     t_key_found = MCUnicodeFind(sptr, length, native, p_key, p_key_length, p_key_native, (MCUnicodeCompareOption)p_options, t_key_found_range);
-    
-    if (!t_key_found)
-        r_key_end = length;
-    
-    if (!t_del_found)
-        r_element_end = length;
-    
-    if (t_key_found_range . offset > t_del_found_range . offset)
-    {
-        // Delimiter came before the key
-        r_key_end = r_element_end = length;
-        return;
-    }
-    
-    r_key_end = t_key_found_range . offset;
-    r_key_found_length = t_key_found_range . length;
-    split_find_end_of_element(sptr, length, native, p_del, p_del_length, p_del_native, p_options, r_element_end, r_del_found_length);
+
+	if (!t_del_found)
+	{
+		r_element_end = length;
+		r_del_found_length = 0;
+	}
+	else
+	{
+		r_element_end = t_del_found_range.offset;
+		r_del_found_length = t_del_found_range.length;
+	}
+
+	/* Deal with the possibility that the delimiter was found before the key */
+	if (!t_key_found ||
+	    r_element_end < t_key_found_range.offset)
+	{
+		r_key_end = r_element_end;
+		r_key_found_length = 0;
+	}
+	else
+	{
+		r_key_end = t_key_found_range.offset;
+		r_key_found_length = t_key_found_range.length;
+	}
 }
 
 bool MCStringSplit(MCStringRef self, MCStringRef p_elem_del, MCStringRef p_key_del, MCStringOptions p_options, MCArrayRef& r_array)

--- a/tests/lcs/core/array/split.livecodescript
+++ b/tests/lcs/core/array/split.livecodescript
@@ -1,0 +1,136 @@
+﻿script "CoreArraySplit"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSplit
+   local tResult, tExpected, tRArrow, tLArrow
+   put numToCodePoint(0x2192) into tRArrow
+   put numToCodePoint(0x2190) into tLArrow
+
+   -- Split by single char
+   put "a,b" into tResult
+   put empty into tExpected
+   put "a" into tExpected[1]
+   put "b" into tExpected[2]
+   split tResult by ","
+   TestAssert "split (native, native)", tResult is tExpected
+
+   put "a," & tRArrow into tResult
+   put empty into tExpected
+   put "a" into tExpected[1]
+   put tRArrow into tExpected[2]
+   split tResult by ","
+   TestAssert "split (unicode, native)", tResult is tExpected
+
+   put "a" & tRArrow & "b" into tResult
+   put empty into tExpected
+   put "a" into tExpected[1]
+   put "b" into tExpected[2]
+   split tResult by tRArrow
+   TestAssert "split (unicode, unicode)", tResult is tExpected
+
+   ----------
+
+   put "a:,b" into tResult
+   split tResult by ":,"
+   TestAssert "split multi (native, native)", tResult is tExpected
+
+   put "a" & tRArrow & tLArrow & "b" into tResult
+   split tResult by (tRArrow & tLArrow)
+   TestAssert "split multi (unicode, unicode)", tResult is tExpected
+
+   ----------
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put "b" into tExpected["a"]
+   put "d" into tExpected["c"]
+   split tResult by "," and ":"
+   TestAssert "split key (native, native)", (tResult is tExpected)
+
+   put "a:b" & tRArrow & "c:d" into tResult
+   split tResult by tRArrow and ":"
+   TestAssert "split key (unicode, unicode, native)", (tResult is tExpected)
+
+   put "a" & tRArrow & "b,c" & tRArrow & "d" into tResult
+   split tResult by "," and tRArrow
+   TestAssert "split key (unicode, native, unicode)", (tResult is tExpected)
+
+   ----------
+
+   put "a,b" into tResult
+   put empty into tExpected
+   put empty into tExpected["a"]
+   put empty into tExpected["b"]
+   split tResult by "," and ":"
+   TestAssert "split key missing (native, native, native)", tResult is tExpected
+
+   put tRArrow & comma & tLArrow into tResult
+   put empty into tExpected
+   put empty into tExpected[tRArrow]
+   put empty into tExpected[tLArrow]
+   split tResult by "," and ":"
+   TestAssertBroken "split key missing (unicode, native, native)", tResult is tExpected
+end TestSplit
+
+
+
+on TestSplitByEmpty
+   local tResult, tExpected, tError
+
+   put "a,b" into tResult
+   put empty into tExpected
+   put tResult into tExpected[1]
+   try
+      split tResult by empty
+      TestAssert "split (native, empty)", false
+   catch tError
+      TestAssert "split (native, empty)", true
+   end try
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put "b,c:d" into tExpected["a"]
+   try
+      split tResult by empty and ":"
+      TestAssert "split key (native, empty, native)", false
+   catch tError
+      TestAssert "split key (native, empty, native)", true
+   end try
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put empty into tExpected["a:b"]
+   put empty into tExpected["c:d"]
+   try
+      split tResult by "," and empty
+      TestAssert "split key (native, native, empty)", false
+   catch tError
+      TestAssert "split key (native, native, empty)", true
+   end try
+
+   put "a:b,c:d" into tResult
+   put empty into tExpected
+   put empty into tExpected[tResult]
+   try
+      split tResult by empty and empty
+      TestAssert "split key (native, empty, empty)", false
+   catch tError
+      TestAssert "split key (native, empty, empty)", true
+   end try
+
+end TestSplitByEmpty

--- a/tests/lcs/core/array/split.livecodescript
+++ b/tests/lcs/core/array/split.livecodescript
@@ -134,3 +134,98 @@ on TestSplitByEmpty
    end try
 
 end TestSplitByEmpty
+
+
+
+on TestSplitByColumn
+   local tResult, tExpected
+
+   put "a,b:c,d" into tResult
+   put empty into tExpected
+   put "a:c" into tExpected[1]
+   put "b:d" into tExpected[2]
+   set the columnDel to ","
+   set the rowDel to ":"
+   split tResult by column
+
+   TestAssert "split column (native, native, native)", tResult is tExpected
+
+   ----------
+
+   put "a,b:c,d" into tResult
+   set the columnDel to empty
+   set the rowDel to ":"
+   try
+      split tResult by column
+      TestAssert "split column (native, empty, native)", false
+   catch tError
+      TestAssert "split column (native, empty, native)", true
+   end try
+
+   put "a,b:c,d" into tResult
+   set the columnDel to ","
+   set the rowDel to empty
+   try
+      split tResult by column
+      TestAssert "split column (native, native, empty)", false
+   catch tError
+      TestAssert "split column (native, native, empty)", true
+   end try
+end TestSplitByColumn
+
+
+
+on TestSplitByRow
+   local tResult, tExpected
+
+   put "a,b:c,d" into tResult
+   put empty into tExpected
+   put "a,b" into tExpected[1]
+   put "c,d" into tExpected[2]
+   set the columnDel to ","
+   set the rowDel to ":"
+   split tResult by row
+   TestAssert "split row (native, native, native)", tResult is tExpected
+
+   -- The column delimiter isn't actually used when splitting by row.
+   put "a,b:c,d" into tResult
+   set the columnDel to empty
+   set the rowDel to ":"
+   split tResult by row
+   TestAssert "split row (native, empty, native)", tResult is tExpected
+
+   ----------
+
+   put "a,b:c,d" into tResult
+   set the columnDel to ","
+   set the rowDel to empty
+   try
+      split tResult by row
+      TestAssert "split row (native, native, empty)", false
+   catch tError
+      TestAssert "split row (native, native, empty)", true
+   end try
+end TestSplitByRow
+
+
+
+on TestSplitAsSet
+   local tResult, tExpected, tError
+
+   put "a:b" into tResult
+   put empty into tExpected
+   put true into tExpected["a"]
+   put true into tExpected["b"]
+   split tResult with ":" as set
+   TestAssert "split set (native, native)", tResult is tExpected
+
+   ----------
+
+   put "a:b" into tResult
+   try
+      split tResult with empty as set
+      TestAssert "split set (native, empty)", false
+   catch tError
+      TestAssert "split set (native, empty)", true
+   end try
+end TestSplitAsSet

--- a/tests/lcs/core/array/split.livecodescript
+++ b/tests/lcs/core/array/split.livecodescript
@@ -84,7 +84,7 @@ on TestSplit
    put empty into tExpected[tRArrow]
    put empty into tExpected[tLArrow]
    split tResult by "," and ":"
-   TestAssertBroken "split key missing (unicode, native, native)", tResult is tExpected
+   TestAssert "split key missing (unicode, native, native)", tResult is tExpected
 end TestSplit
 
 


### PR DESCRIPTION
`MCStringSplit()` misbehaves when it receives an empty delimiter
string, entering an infinite loop.

~~This patch alters the behaviour of `MCStringSplit()` to treat empty
delimiters as never existing in the target string.  This is consistent
with the behaviour of the `contains` operator:
`"abc" contains empty -> false`~~

This patch turns splitting by an empty delimiter into an error, for consistency with LiveCode 6.7.  It also fixes an inconsistency between the Unicode and native character implementations of splitting.
