### PR TITLE
Ignore .lci dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ extensions/*/*/*.xml
 extensions/*/*/*.lci
 extensions/*/*/*.lcm
 extensions/*/*/*.lce
+.lci/
 
 # Compiled source and intermediates #
 ###################


### PR DESCRIPTION
The linter for LCB in the LiveCode package for Atom outputs *.lci files
into a .lci directory.
