### PR TITLE
[[ Bug 16395 ]] Fix bitNot documentation

### DIFF
--- a/docs/dictionary/operator/bitNot.xml
+++ b/docs/dictionary/operator/bitNot.xml
@@ -38,10 +38,10 @@
   </classes>
   <security>
   </security>
-  <summary>Performs a "bitwise not" <glossary tag="operation">operation</glossary> on the <glossary tag="binary">binary</glossary> representation of a number.</summary>
+  <summary>Performs a "bitwise not" <glossary tag="operation">operation</glossary> on the unsigned, 32-bit <glossary tag="binary">binary</glossary> representation of a number.</summary>
   <examples>
-    <example>bitNot 1 <code><i>-- evaluates to 0</i></code></example>
-    <example>bitNot 14 <code><i>-- in binary: bitNot 1110; evaluates to 0001; converted to 1</i></code></example>
+    <example>bitNot 1 <code><i>-- evaluates to 4294967294</i></code></example>
+    <example>bitNot 14 <code><i>-- in binary: bitNot 0000000000001110; evaluates to 1111111111110001; converted to 4294967281</i></code></example>
   </examples>
   <description>
     <p>Use the <b>bitNot</b> <glossary tag="operator">operator</glossary> to operate directly on the <glossary tag="bit">bits</glossary> of a number.</p><p/><p><b>Parameters:</b></p><p>The <i>number</i> is a number, or an <glossary tag="expression">expression</glossary> that <glossary tag="evaluate">evaluates</glossary> to a number, between zero and 4,294,967,295 (2^32 - 1).</p><p/><p><b>Comments:</b></p><p>To perform the <b>bitNot</b> <glossary tag="operation">operation</glossary>, LiveCode first converts the <glossary tag="operand">operand</glossary> to its <glossary tag="binary">binary</glossary> equivalent, a string of ones and zeroes. 1 is equivalent to true, and 0 is equivalent to false.</p><p/><p>For each bit of the <i>number</i>, LiveCode performs a <operator tag="not">not</operator> <glossary tag="operation">operation</glossary>. A <glossary tag="bit">bit</glossary> is 0 if the corresponding <glossary tag="bit">bit</glossary> of the <i>number</i> is 1, and 1 if the corresponding <glossary tag="bit">bit</glossary> of the <i>number</i> is 0.</p><p/><p>Finally, the binary number thus created is converted back to decimal.</p>

--- a/docs/notes/bugfix-16395.md
+++ b/docs/notes/bugfix-16395.md
@@ -1,0 +1,1 @@
+# bitNot dictionary example incorrect


### PR DESCRIPTION
bitNot takes its argument as an unsigned 32-bit int, not an 8-bit int
