### PR TITLE
Fix incorrect mouse position example

### DIFF
--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -623,7 +623,7 @@ Returns:		The location of the mouse pointer when it was clicked.
 
 Example:
 	variable tClick as Point
-	put the click position into tClick
+	put the mouse position into tClick
 	
 	variable tRect as Rectangle
 	put my bounds into tRect

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -617,23 +617,23 @@ begin
 end syntax
 
 /*
-Summary:		Determines the location of a mouse click.
+Summary:		Determines the location of a mouse position relative to the top left of the widget.
 
-Returns:		The location of the mouse pointer when it was clicked.
+Returns:		The current location of the mouse pointer.
 
 Example:
-	variable tClick as Point
-	put the mouse position into tClick
+	variable tLoc as Point
+	put the mouse position into tLoc
 	
 	variable tRect as Rectangle
 	put my bounds into tRect
 	
-	if tClick is within tRect then
-		// click was within widget bounds
+	if tLoc is within tRect then
+		// mouse is within widget bounds
 	end if
 	
 Description:
-Use the mouse location to obtain the location of the mouse pointer when it was last clicked. Use the 'current' form to obtain the asynchronous click position.
+Use the mouse location to obtain the location of the mouse pointer. Use the 'current' form to obtain the asynchronous mouse position.
 */
 
 syntax TheClickLocation is expression

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -591,19 +591,19 @@ public foreign handler MCWidgetGetClickCount(in pCurrent as CBool, out rCount as
 public foreign handler MCWidgetGetModifierKeys(in pCurrent as CBool, out rKeys as List) returns nothing binds to "<builtin>"
 
 /* 
-Summary:		Determines the location of the mouse pointer.
+Summary:		Determines the location of the mouse pointer relative to the widget.
 
 Returns:		The location of the mouse pointer.
 
 Example:
-	variable tClick as Point
-	put the click position into tClick
+	variable tPosition as Point
+	put the mouse position into tPosition
 	
 	variable tRect as Rectangle
 	put my bounds into tRect
 	
-	if tClick is within tRect then
-		// click was within widget bounds
+	if tPosition is within tRect then
+		// mouse position is within the widget bounds
 	end if
 	
 Description:
@@ -617,23 +617,23 @@ begin
 end syntax
 
 /*
-Summary:		Determines the location of a mouse position relative to the top left of the widget.
+Summary:		Determines the location of a mouse click.
 
-Returns:		The current location of the mouse pointer.
+Returns:		TheThe location of the mouse pointer when it was clicked.
 
 Example:
-	variable tLoc as Point
-	put the mouse position into tLoc
+	variable tClick as Point
+	put the click position into tClick
 	
 	variable tRect as Rectangle
 	put my bounds into tRect
 	
-	if tLoc is within tRect then
-		// mouse is within widget bounds
+	if tClick is within tRect then
+		// click was within widget bounds
 	end if
 	
 Description:
-Use the mouse location to obtain the location of the mouse pointer. Use the 'current' form to obtain the asynchronous mouse position.
+Use the mouse location to obtain the location of the mouse pointer when it was last clicked. Use the 'current' form to obtain the asynchronous click position.
 */
 
 syntax TheClickLocation is expression

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -619,7 +619,7 @@ end syntax
 /*
 Summary:		Determines the location of a mouse click.
 
-Returns:		TheThe location of the mouse pointer when it was clicked.
+Returns:		The location of the mouse pointer when it was clicked.
 
 Example:
 	variable tClick as Point


### PR DESCRIPTION
The <mouse position> example used <click position> instead of <mouse position>.
