### PR TITLE
[Bug 14963] lc-compile: Add missing rule for position of "the result"

### DIFF
--- a/docs/lcb/notes/14963.md
+++ b/docs/lcb/notes/14963.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+# lc-compile
+
+# [14963] Unclear error message when targetting the result

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1586,6 +1586,7 @@
     'rule' GetExpressionPosition(list(Position, _) -> Position):
     'rule' GetExpressionPosition(call(Position, _, _) -> Position):
     'rule' GetExpressionPosition(invoke(Position, _, _) -> Position):
+    'rule' GetExpressionPosition(result(Position) -> Position):
     'rule' GetExpressionPosition(nil -> Position)
         GetUndefinedPosition(-> Position)
 


### PR DESCRIPTION
Enables correct generation of an error message when "the result" is
used as an lvalue.
