### PR TITLE
[Coverity] Coverity project has been renamed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ addons:
   # 'coverity_scan' branch.
   coverity_scan:
     project:
-      name: "runrev/livecode"
+      name: "livecode/livecode"
       description: "Build submitted via Travis CI"
     notification_email: engineteam@livecode.com
     build_command: "make all-linux"


### PR DESCRIPTION
The Coverity Scan project has been renamed from runrev/livecode to
livecode/livecode.
