### PR TITLE
libbrowser: Don't use aliased and never-defined structure types.

### DIFF
--- a/libbrowser/include/libbrowser.h
+++ b/libbrowser/include/libbrowser.h
@@ -36,7 +36,7 @@ private:
 };
 
 class MCBrowser;
-typedef struct __MCBrowserList *MCBrowserListRef;
+typedef class MCBrowserList *MCBrowserListRef;
 
 // Event handler interface
 class MCBrowserEventHandler : public MCBrowserRefCounted
@@ -152,8 +152,8 @@ MC_DLLEXPORT bool MCBrowserLibraryGetRunloopCallback(MCBrowserRunloopCallback &r
 
 //////////
 
-typedef struct __MCBrowserList *MCBrowserListRef;
-typedef struct __MCBrowserDictionary *MCBrowserDictionaryRef;
+typedef class MCBrowserList *MCBrowserListRef;
+typedef class MCBrowserDictionary *MCBrowserDictionaryRef;
 
 enum MCBrowserValueType
 {
@@ -223,8 +223,8 @@ MC_DLLEXPORT bool MCBrowserDictionaryGetDictionary(MCBrowserDictionaryRef p_dict
 	
 //////////
 
-typedef struct __MCBrowser *MCBrowserRef;
-typedef struct __MCBrowserFactory *MCBrowserFactoryRef;
+typedef class MCBrowser *MCBrowserRef;
+typedef class MCBrowserFactory *MCBrowserFactoryRef;
 
 MC_DLLEXPORT bool MCBrowserFactoryGet(const char *p_factory_id, MCBrowserFactoryRef &r_factory);
 MC_DLLEXPORT bool MCBrowserFactoryCreateBrowser(MCBrowserFactoryRef p_factory, void *p_display, void *p_parent_view, MCBrowserRef &r_browser);

--- a/libbrowser/src/libbrowser.cpp
+++ b/libbrowser/src/libbrowser.cpp
@@ -180,7 +180,7 @@ bool MCBrowserLibraryInitialize()
 void MCBrowserLibraryFinalize()
 {
 	if (s_browser_factory)
-		delete (MCBrowserFactory*)s_browser_factory;
+		delete s_browser_factory;
 }
 
 //////////
@@ -232,10 +232,10 @@ bool MCBrowserFactoryCreateBrowser(MCBrowserFactoryRef p_factory, void *p_displa
 		return false;
 	
 	MCBrowser *t_browser;
-	if (!((MCBrowserFactory*)p_factory)->CreateBrowser(p_display, p_parent_window, t_browser))
+	if (!p_factory->CreateBrowser(p_display, p_parent_window, t_browser))
 		return false;
 	
-	r_browser = (MCBrowserRef)t_browser;
+	r_browser = t_browser;
 	return true;
 }
 
@@ -246,7 +246,7 @@ MCBrowserRef MCBrowserRetain(MCBrowserRef p_browser)
 	if (p_browser == nil)
 		return nil;
 	
-	((MCBrowser*)p_browser)->Retain();
+	p_browser->Retain();
 	return p_browser;
 }
 
@@ -255,7 +255,7 @@ void MCBrowserRelease(MCBrowserRef p_browser)
 	if (p_browser == nil)
 		return;
 	
-	((MCBrowser*)p_browser)->Release();
+	p_browser->Release();
 }
 
 //////////
@@ -265,7 +265,7 @@ void *MCBrowserGetNativeLayer(MCBrowserRef p_browser)
 	if (p_browser == nil)
 		return nil;
 	
-	return ((MCBrowser*)p_browser)->GetNativeLayer();
+	return p_browser->GetNativeLayer();
 }
 
 bool MCBrowserGetRect(MCBrowserRef p_browser, MCBrowserRect &r_rect)
@@ -273,7 +273,7 @@ bool MCBrowserGetRect(MCBrowserRef p_browser, MCBrowserRect &r_rect)
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->GetRect(r_rect);
+	return p_browser->GetRect(r_rect);
 }
 
 bool MCBrowserSetRect(MCBrowserRef p_browser, const MCBrowserRect &p_rect)
@@ -281,7 +281,7 @@ bool MCBrowserSetRect(MCBrowserRef p_browser, const MCBrowserRect &p_rect)
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->SetRect(p_rect);
+	return p_browser->SetRect(p_rect);
 }
 
 bool MCBrowserGetBoolProperty(MCBrowserRef p_browser, MCBrowserProperty p_property, bool &r_value)
@@ -289,7 +289,7 @@ bool MCBrowserGetBoolProperty(MCBrowserRef p_browser, MCBrowserProperty p_proper
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->GetBoolProperty(p_property, r_value);
+	return p_browser->GetBoolProperty(p_property, r_value);
 }
 
 bool MCBrowserSetBoolProperty(MCBrowserRef p_browser, MCBrowserProperty p_property, bool p_value)
@@ -297,7 +297,7 @@ bool MCBrowserSetBoolProperty(MCBrowserRef p_browser, MCBrowserProperty p_proper
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->SetBoolProperty(p_property, p_value);
+	return p_browser->SetBoolProperty(p_property, p_value);
 }
 
 bool MCBrowserGetStringProperty(MCBrowserRef p_browser, MCBrowserProperty p_property, char *&r_value)
@@ -305,7 +305,7 @@ bool MCBrowserGetStringProperty(MCBrowserRef p_browser, MCBrowserProperty p_prop
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->GetStringProperty(p_property, r_value);
+	return p_browser->GetStringProperty(p_property, r_value);
 }
 
 bool MCBrowserSetStringProperty(MCBrowserRef p_browser, MCBrowserProperty p_property, const char *p_value)
@@ -313,7 +313,7 @@ bool MCBrowserSetStringProperty(MCBrowserRef p_browser, MCBrowserProperty p_prop
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->SetStringProperty(p_property, p_value);
+	return p_browser->SetStringProperty(p_property, p_value);
 }
 
 bool MCBrowserGoBack(MCBrowserRef p_browser)
@@ -321,7 +321,7 @@ bool MCBrowserGoBack(MCBrowserRef p_browser)
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->GoBack();
+	return p_browser->GoBack();
 }
 
 bool MCBrowserGoForward(MCBrowserRef p_browser)
@@ -329,7 +329,7 @@ bool MCBrowserGoForward(MCBrowserRef p_browser)
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->GoForward();
+	return p_browser->GoForward();
 }
 
 bool MCBrowserGoToURL(MCBrowserRef p_browser, const char *p_url)
@@ -337,7 +337,7 @@ bool MCBrowserGoToURL(MCBrowserRef p_browser, const char *p_url)
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->GoToURL(p_url);
+	return p_browser->GoToURL(p_url);
 }
 
 bool MCBrowserEvaluateJavaScript(MCBrowserRef p_browser, const char *p_script, char *&r_result)
@@ -345,7 +345,7 @@ bool MCBrowserEvaluateJavaScript(MCBrowserRef p_browser, const char *p_script, c
 	if (p_browser == nil)
 		return false;
 	
-	return ((MCBrowser*)p_browser)->EvaluateJavaScript(p_script, r_result);
+	return p_browser->EvaluateJavaScript(p_script, r_result);
 }
 
 //////////
@@ -363,37 +363,37 @@ public:
 	virtual void OnNavigationBegin(MCBrowser *p_browser, bool p_in_frame, const char *p_url)
 	{
 		if (m_callback)
-			m_callback(m_context, (MCBrowserRef)p_browser, kMCBrowserRequestTypeNavigate, kMCBrowserRequestStateBegin, p_in_frame, p_url, nil);
+			m_callback(m_context, p_browser, kMCBrowserRequestTypeNavigate, kMCBrowserRequestStateBegin, p_in_frame, p_url, nil);
 	}
 	
 	virtual void OnNavigationComplete(MCBrowser *p_browser, bool p_in_frame, const char *p_url)
 	{
 		if (m_callback)
-			m_callback(m_context, (MCBrowserRef)p_browser, kMCBrowserRequestTypeNavigate, kMCBrowserRequestStateComplete, p_in_frame, p_url, nil);
+			m_callback(m_context, p_browser, kMCBrowserRequestTypeNavigate, kMCBrowserRequestStateComplete, p_in_frame, p_url, nil);
 	}
 	
 	virtual void OnNavigationFailed(MCBrowser *p_browser, bool p_in_frame, const char *p_url, const char *p_error)
 	{
 		if (m_callback)
-			m_callback(m_context, (MCBrowserRef)p_browser, kMCBrowserRequestTypeNavigate, kMCBrowserRequestStateFailed, p_in_frame, p_url, p_error);
+			m_callback(m_context, p_browser, kMCBrowserRequestTypeNavigate, kMCBrowserRequestStateFailed, p_in_frame, p_url, p_error);
 	}
 	
 	virtual void OnDocumentLoadBegin(MCBrowser *p_browser, bool p_in_frame, const char *p_url)
 	{
 		if (m_callback)
-			m_callback(m_context, (MCBrowserRef)p_browser, kMCBrowserRequestTypeDocumentLoad, kMCBrowserRequestStateBegin, p_in_frame, p_url, nil);
+			m_callback(m_context, p_browser, kMCBrowserRequestTypeDocumentLoad, kMCBrowserRequestStateBegin, p_in_frame, p_url, nil);
 	}
 	
 	virtual void OnDocumentLoadComplete(MCBrowser *p_browser, bool p_in_frame, const char *p_url)
 	{
 		if (m_callback)
-			m_callback(m_context, (MCBrowserRef)p_browser, kMCBrowserRequestTypeDocumentLoad, kMCBrowserRequestStateComplete, p_in_frame, p_url, nil);
+			m_callback(m_context, p_browser, kMCBrowserRequestTypeDocumentLoad, kMCBrowserRequestStateComplete, p_in_frame, p_url, nil);
 	}
 	
 	virtual void OnDocumentLoadFailed(MCBrowser *p_browser, bool p_in_frame, const char *p_url, const char *p_error)
 	{
 		if (m_callback)
-			m_callback(m_context, (MCBrowserRef)p_browser, kMCBrowserRequestTypeDocumentLoad, kMCBrowserRequestStateFailed, p_in_frame, p_url, p_error);
+			m_callback(m_context, p_browser, kMCBrowserRequestTypeDocumentLoad, kMCBrowserRequestStateFailed, p_in_frame, p_url, p_error);
 	}
 	
 private:
@@ -408,7 +408,7 @@ bool MCBrowserSetRequestHandler(MCBrowserRef p_browser, MCBrowserRequestCallback
 	
 	if (p_callback == nil)
 	{
-		((MCBrowser*)p_browser)->SetEventHandler(nil);
+		p_browser->SetEventHandler(nil);
 		return true;
 	}
 	
@@ -418,7 +418,7 @@ bool MCBrowserSetRequestHandler(MCBrowserRef p_browser, MCBrowserRequestCallback
 	if (t_wrapper == nil)
 		return false;
 	
-	((MCBrowser*)p_browser)->SetEventHandler(t_wrapper);
+	p_browser->SetEventHandler(t_wrapper);
 	return true;
 }
 
@@ -437,7 +437,7 @@ public:
 	virtual void OnJavaScriptCall(MCBrowser *p_browser, const char *p_handler, MCBrowserListRef p_params)
 	{
 		if (m_callback)
-			m_callback(m_context, (MCBrowserRef)p_browser, p_handler, p_params);
+			m_callback(m_context, p_browser, p_handler, p_params);
 	}
 	
 private:
@@ -452,7 +452,7 @@ bool MCBrowserSetJavaScriptHandler(MCBrowserRef p_browser, MCBrowserJavaScriptCa
 	
 	if (p_callback == nil)
 	{
-		((MCBrowser*)p_browser)->SetJavaScriptHandler(nil);
+		p_browser->SetJavaScriptHandler(nil);
 		return true;
 	}
 	
@@ -462,7 +462,7 @@ bool MCBrowserSetJavaScriptHandler(MCBrowserRef p_browser, MCBrowserJavaScriptCa
 	if (t_wrapper == nil)
 		return false;
 	
-	((MCBrowser*)p_browser)->SetJavaScriptHandler(t_wrapper);
+	p_browser->SetJavaScriptHandler(t_wrapper);
 	return true;
 }
 

--- a/libbrowser/src/libbrowser_android.cpp
+++ b/libbrowser/src/libbrowser_android.cpp
@@ -1005,7 +1005,7 @@ bool MCAndroidWebViewBrowserFactoryCreate(MCBrowserFactoryRef &r_factory)
 	if (t_factory == nil)
 		return false;
 		
-	r_factory = (MCBrowserFactoryRef)t_factory;
+	r_factory = t_factory;
 	return true;
 }
 

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -1709,6 +1709,6 @@ bool MCCefBrowserFactoryCreate(MCBrowserFactoryRef &r_factory)
 		return false;
 	}
 	
-	r_factory = (MCBrowserFactoryRef)t_factory;
+	r_factory = t_factory;
 	return true;
 }

--- a/libbrowser/src/libbrowser_value.cpp
+++ b/libbrowser/src/libbrowser_value.cpp
@@ -423,14 +423,14 @@ bool MCBrowserListCreate(MCBrowserListRef &r_browser, uint32_t p_size)
 		return false;
 	}
 	
-	r_browser = (MCBrowserListRef)t_browser;
+	r_browser = t_browser;
 	return true;
 }
 
 MCBrowserListRef MCBrowserListRetain(MCBrowserListRef p_list)
 {
 	if (p_list != nil)
-		((MCBrowserList*)p_list)->Retain();
+		p_list->Retain();
 	
 	return p_list;
 }
@@ -438,7 +438,7 @@ MCBrowserListRef MCBrowserListRetain(MCBrowserListRef p_list)
 void MCBrowserListRelease(MCBrowserListRef p_list)
 {
 	if (p_list != nil)
-		((MCBrowserList*)p_list)->Release();
+		p_list->Release();
 }
 
 bool MCBrowserListGetSize(MCBrowserListRef p_list, uint32_t &r_size)
@@ -446,7 +446,7 @@ bool MCBrowserListGetSize(MCBrowserListRef p_list, uint32_t &r_size)
 	if (p_list == nil)
 		return false;
 	
-	r_size = ((MCBrowserList*)p_list)->GetSize();
+	r_size = p_list->GetSize();
 	return true;
 }
 
@@ -455,7 +455,7 @@ bool MCBrowserListGetType(MCBrowserListRef p_list, uint32_t p_index, MCBrowserVa
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetType(p_index, r_type);
+	return p_list->GetType(p_index, r_type);
 }
 
 bool MCBrowserListSetValue(MCBrowserListRef p_list, uint32_t p_index, const MCBrowserValue &p_value)
@@ -463,7 +463,7 @@ bool MCBrowserListSetValue(MCBrowserListRef p_list, uint32_t p_index, const MCBr
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->SetValue(p_index, p_value);
+	return p_list->SetValue(p_index, p_value);
 }
 
 bool MCBrowserListSetBoolean(MCBrowserListRef p_list, uint32_t p_index, bool p_value)
@@ -471,7 +471,7 @@ bool MCBrowserListSetBoolean(MCBrowserListRef p_list, uint32_t p_index, bool p_v
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->SetBoolean(p_index, p_value);
+	return p_list->SetBoolean(p_index, p_value);
 }
 
 bool MCBrowserListSetInteger(MCBrowserListRef p_list, uint32_t p_index, int32_t p_value)
@@ -479,7 +479,7 @@ bool MCBrowserListSetInteger(MCBrowserListRef p_list, uint32_t p_index, int32_t 
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->SetInteger(p_index, p_value);
+	return p_list->SetInteger(p_index, p_value);
 }
 
 bool MCBrowserListSetDouble(MCBrowserListRef p_list, uint32_t p_index, double p_value)
@@ -487,7 +487,7 @@ bool MCBrowserListSetDouble(MCBrowserListRef p_list, uint32_t p_index, double p_
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->SetDouble(p_index, p_value);
+	return p_list->SetDouble(p_index, p_value);
 }
 
 bool MCBrowserListSetUTF8String(MCBrowserListRef p_list, uint32_t p_index, const char *p_value)
@@ -495,7 +495,7 @@ bool MCBrowserListSetUTF8String(MCBrowserListRef p_list, uint32_t p_index, const
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->SetUTF8String(p_index, p_value);
+	return p_list->SetUTF8String(p_index, p_value);
 }
 
 bool MCBrowserListSetList(MCBrowserListRef p_list, uint32_t p_index, MCBrowserListRef p_value)
@@ -503,7 +503,7 @@ bool MCBrowserListSetList(MCBrowserListRef p_list, uint32_t p_index, MCBrowserLi
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->SetList(p_index, p_value);
+	return p_list->SetList(p_index, p_value);
 }
 
 bool MCBrowserListSetDictionary(MCBrowserListRef p_list, uint32_t p_index, MCBrowserDictionaryRef p_value)
@@ -511,7 +511,7 @@ bool MCBrowserListSetDictionary(MCBrowserListRef p_list, uint32_t p_index, MCBro
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->SetDictionary(p_index, p_value);
+	return p_list->SetDictionary(p_index, p_value);
 }
 
 bool MCBrowserListAppendValue(MCBrowserListRef p_list, const MCBrowserValue &p_value)
@@ -519,7 +519,7 @@ bool MCBrowserListAppendValue(MCBrowserListRef p_list, const MCBrowserValue &p_v
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->AppendValue(p_value);
+	return p_list->AppendValue(p_value);
 }
 
 bool MCBrowserListAppendBoolean(MCBrowserListRef p_list, bool p_value)
@@ -527,7 +527,7 @@ bool MCBrowserListAppendBoolean(MCBrowserListRef p_list, bool p_value)
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->AppendBoolean(p_value);
+	return p_list->AppendBoolean(p_value);
 }
 
 bool MCBrowserListAppendInteger(MCBrowserListRef p_list, int32_t p_value)
@@ -535,7 +535,7 @@ bool MCBrowserListAppendInteger(MCBrowserListRef p_list, int32_t p_value)
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->AppendInteger(p_value);
+	return p_list->AppendInteger(p_value);
 }
 
 bool MCBrowserListAppendDouble(MCBrowserListRef p_list, double p_value)
@@ -543,7 +543,7 @@ bool MCBrowserListAppendDouble(MCBrowserListRef p_list, double p_value)
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->AppendDouble(p_value);
+	return p_list->AppendDouble(p_value);
 }
 
 bool MCBrowserListAppendUTF8String(MCBrowserListRef p_list, const char *p_value)
@@ -551,7 +551,7 @@ bool MCBrowserListAppendUTF8String(MCBrowserListRef p_list, const char *p_value)
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->AppendUTF8String(p_value);
+	return p_list->AppendUTF8String(p_value);
 }
 
 bool MCBrowserListAppendList(MCBrowserListRef p_list, MCBrowserListRef p_value)
@@ -559,7 +559,7 @@ bool MCBrowserListAppendList(MCBrowserListRef p_list, MCBrowserListRef p_value)
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->AppendList(p_value);
+	return p_list->AppendList(p_value);
 }
 
 bool MCBrowserListAppendDictionary(MCBrowserListRef p_list, MCBrowserDictionaryRef p_value)
@@ -567,7 +567,7 @@ bool MCBrowserListAppendDictionary(MCBrowserListRef p_list, MCBrowserDictionaryR
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->AppendDictionary(p_value);
+	return p_list->AppendDictionary(p_value);
 }
 
 bool MCBrowserListGetValue(MCBrowserListRef p_list, uint32_t p_index, MCBrowserValue &r_value)
@@ -575,7 +575,7 @@ bool MCBrowserListGetValue(MCBrowserListRef p_list, uint32_t p_index, MCBrowserV
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetValue(p_index, r_value);
+	return p_list->GetValue(p_index, r_value);
 }
 
 bool MCBrowserListGetBoolean(MCBrowserListRef p_list, uint32_t p_index, bool &r_value)
@@ -583,7 +583,7 @@ bool MCBrowserListGetBoolean(MCBrowserListRef p_list, uint32_t p_index, bool &r_
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetBoolean(p_index, r_value);
+	return p_list->GetBoolean(p_index, r_value);
 }
 
 bool MCBrowserListGetInteger(MCBrowserListRef p_list, uint32_t p_index, int32_t &r_value)
@@ -591,7 +591,7 @@ bool MCBrowserListGetInteger(MCBrowserListRef p_list, uint32_t p_index, int32_t 
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetInteger(p_index, r_value);
+	return p_list->GetInteger(p_index, r_value);
 }
 
 bool MCBrowserListGetDouble(MCBrowserListRef p_list, uint32_t p_index, double &r_value)
@@ -599,7 +599,7 @@ bool MCBrowserListGetDouble(MCBrowserListRef p_list, uint32_t p_index, double &r
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetDouble(p_index, r_value);
+	return p_list->GetDouble(p_index, r_value);
 }
 
 bool MCBrowserListGetUTF8String(MCBrowserListRef p_list, uint32_t p_index, char *&r_value)
@@ -607,7 +607,7 @@ bool MCBrowserListGetUTF8String(MCBrowserListRef p_list, uint32_t p_index, char 
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetUTF8String(p_index, r_value);
+	return p_list->GetUTF8String(p_index, r_value);
 }
 
 bool MCBrowserListGetList(MCBrowserListRef p_list, uint32_t p_index, MCBrowserListRef &r_value)
@@ -615,7 +615,7 @@ bool MCBrowserListGetList(MCBrowserListRef p_list, uint32_t p_index, MCBrowserLi
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetList(p_index, r_value);
+	return p_list->GetList(p_index, r_value);
 }
 
 bool MCBrowserListGetDictionary(MCBrowserListRef p_list, uint32_t p_index, MCBrowserDictionaryRef &r_value)
@@ -623,7 +623,7 @@ bool MCBrowserListGetDictionary(MCBrowserListRef p_list, uint32_t p_index, MCBro
 	if (p_list == nil)
 		return false;
 	
-	return ((MCBrowserList*)p_list)->GetDictionary(p_index, r_value);
+	return p_list->GetDictionary(p_index, r_value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -864,14 +864,14 @@ bool MCBrowserDictionaryCreate(MCBrowserDictionaryRef &r_dict, uint32_t p_size)
 		return false;
 	}
 	
-	r_dict = (MCBrowserDictionaryRef)t_dict;
+	r_dict = t_dict;
 	return true;
 }
 
 MCBrowserDictionaryRef MCBrowserDictionaryRetain(MCBrowserDictionaryRef p_dictionary)
 {
 	if (p_dictionary != nil)
-		((MCBrowserDictionary*)p_dictionary)->Retain();
+		p_dictionary->Retain();
 	
 	return p_dictionary;
 }
@@ -879,7 +879,7 @@ MCBrowserDictionaryRef MCBrowserDictionaryRetain(MCBrowserDictionaryRef p_dictio
 void MCBrowserDictionaryRelease(MCBrowserDictionaryRef p_dictionary)
 {
 	if (p_dictionary != nil)
-		((MCBrowserDictionary*)p_dictionary)->Release();
+		p_dictionary->Release();
 }
 
 bool MCBrowserDictionaryGetKeys(MCBrowserDictionaryRef p_dictionary, char **&r_keys, uint32_t &r_count)
@@ -887,7 +887,7 @@ bool MCBrowserDictionaryGetKeys(MCBrowserDictionaryRef p_dictionary, char **&r_k
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetKeys(r_keys, r_count);
+	return p_dictionary->GetKeys(r_keys, r_count);
 }
 
 /* WORKAROUND - Lack of Pointer dereferencing or C Array abstraction in LCB */
@@ -917,7 +917,7 @@ bool MCBrowserDictionaryGetType(MCBrowserDictionaryRef p_dictionary, const char 
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetType(p_key, r_type);
+	return p_dictionary->GetType(p_key, r_type);
 }
 
 bool MCBrowserDictionarySetValue(MCBrowserDictionaryRef p_dictionary, const char *p_key, const MCBrowserValue &p_value)
@@ -925,7 +925,7 @@ bool MCBrowserDictionarySetValue(MCBrowserDictionaryRef p_dictionary, const char
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->SetValue(p_key, p_value);
+	return p_dictionary->SetValue(p_key, p_value);
 }
 
 bool MCBrowserDictionaryGetValue(MCBrowserDictionaryRef p_dictionary, const char *p_key, MCBrowserValue &r_value)
@@ -933,7 +933,7 @@ bool MCBrowserDictionaryGetValue(MCBrowserDictionaryRef p_dictionary, const char
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetValue(p_key, r_value);
+	return p_dictionary->GetValue(p_key, r_value);
 }
 
 bool MCBrowserDictionarySetBoolean(MCBrowserDictionaryRef p_dictionary, const char *p_key, bool p_value)
@@ -941,7 +941,7 @@ bool MCBrowserDictionarySetBoolean(MCBrowserDictionaryRef p_dictionary, const ch
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->SetBoolean(p_key, p_value);
+	return p_dictionary->SetBoolean(p_key, p_value);
 }
 
 bool MCBrowserDictionarySetInteger(MCBrowserDictionaryRef p_dictionary, const char *p_key, int32_t p_value)
@@ -949,7 +949,7 @@ bool MCBrowserDictionarySetInteger(MCBrowserDictionaryRef p_dictionary, const ch
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->SetInteger(p_key, p_value);
+	return p_dictionary->SetInteger(p_key, p_value);
 }
 
 bool MCBrowserDictionarySetDouble(MCBrowserDictionaryRef p_dictionary, const char *p_key, double p_value)
@@ -957,7 +957,7 @@ bool MCBrowserDictionarySetDouble(MCBrowserDictionaryRef p_dictionary, const cha
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->SetDouble(p_key, p_value);
+	return p_dictionary->SetDouble(p_key, p_value);
 }
 
 bool MCBrowserDictionarySetUTF8String(MCBrowserDictionaryRef p_dictionary, const char *p_key, const char *p_value)
@@ -965,7 +965,7 @@ bool MCBrowserDictionarySetUTF8String(MCBrowserDictionaryRef p_dictionary, const
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->SetUTF8String(p_key, p_value);
+	return p_dictionary->SetUTF8String(p_key, p_value);
 }
 
 bool MCBrowserDictionarySetList(MCBrowserDictionaryRef p_dictionary, const char *p_key, MCBrowserListRef p_value)
@@ -973,7 +973,7 @@ bool MCBrowserDictionarySetList(MCBrowserDictionaryRef p_dictionary, const char 
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->SetList(p_key, p_value);
+	return p_dictionary->SetList(p_key, p_value);
 }
 
 bool MCBrowserDictionarySetDictionary(MCBrowserDictionaryRef p_dictionary, const char *p_key, MCBrowserDictionaryRef p_value)
@@ -981,7 +981,7 @@ bool MCBrowserDictionarySetDictionary(MCBrowserDictionaryRef p_dictionary, const
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->SetDictionary(p_key, p_value);
+	return p_dictionary->SetDictionary(p_key, p_value);
 }
 
 bool MCBrowserDictionaryGetBoolean(MCBrowserDictionaryRef p_dictionary, const char *p_key, bool &r_value)
@@ -989,7 +989,7 @@ bool MCBrowserDictionaryGetBoolean(MCBrowserDictionaryRef p_dictionary, const ch
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetBoolean(p_key, r_value);
+	return p_dictionary->GetBoolean(p_key, r_value);
 }
 
 bool MCBrowserDictionaryGetInteger(MCBrowserDictionaryRef p_dictionary, const char *p_key, int32_t &r_value)
@@ -997,7 +997,7 @@ bool MCBrowserDictionaryGetInteger(MCBrowserDictionaryRef p_dictionary, const ch
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetInteger(p_key, r_value);
+	return p_dictionary->GetInteger(p_key, r_value);
 }
 
 bool MCBrowserDictionaryGetDouble(MCBrowserDictionaryRef p_dictionary, const char *p_key, double &r_value)
@@ -1005,7 +1005,7 @@ bool MCBrowserDictionaryGetDouble(MCBrowserDictionaryRef p_dictionary, const cha
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetDouble(p_key, r_value);
+	return p_dictionary->GetDouble(p_key, r_value);
 }
 
 bool MCBrowserDictionaryGetUTF8String(MCBrowserDictionaryRef p_dictionary, const char *p_key, char *&r_value)
@@ -1013,7 +1013,7 @@ bool MCBrowserDictionaryGetUTF8String(MCBrowserDictionaryRef p_dictionary, const
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetUTF8String(p_key, r_value);
+	return p_dictionary->GetUTF8String(p_key, r_value);
 }
 
 bool MCBrowserDictionaryGetList(MCBrowserDictionaryRef p_dictionary, const char *p_key, MCBrowserListRef &r_value)
@@ -1021,7 +1021,7 @@ bool MCBrowserDictionaryGetList(MCBrowserDictionaryRef p_dictionary, const char 
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetList(p_key, r_value);
+	return p_dictionary->GetList(p_key, r_value);
 }
 
 bool MCBrowserDictionaryGetDictionary(MCBrowserDictionaryRef p_dictionary, const char *p_key, MCBrowserDictionaryRef &r_value)
@@ -1029,7 +1029,7 @@ bool MCBrowserDictionaryGetDictionary(MCBrowserDictionaryRef p_dictionary, const
 	if (p_dictionary == nil)
 		return false;
 	
-	return ((MCBrowserDictionary*)p_dictionary)->GetDictionary(p_key, r_value);
+	return p_dictionary->GetDictionary(p_key, r_value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously, `MCBrowserListRef` was defined as a pointer to a `struct
__MCBrowserList` that was never defined anywhere.  Instead, every use
of `MCBrowserListRef` was aliased to a complete `class MCBrowserList`
type.  There were several other types used in a similar way by
libbrowser.  This highly confused static analysis tools!

This patch defines each `MCBrowser*Ref` type to be a pointer to the
corresponding class type, and removes as many unnecessary aliasing
casts as possible from libbrowser method functions.
