### PR TITLE
[[ Tests ]] Make the LCS testrunner output logs in all cases.

### DIFF
--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -34,15 +34,15 @@ end startup
 
 private function getCommandLineInfo
    local tRawArg, tSelfCommand, tSelfScript, tInArgs, tArgs
-   
+
    put false into tInArgs
-   
+
    -- Treat everything up to & including the first
    -- ".livecodescript" file as the command for running the test
    -- runner, and everything after it as test runner arguments
    put the commandName into tSelfCommand[1]
    repeat for each element tRawArg in the commandArguments
-      
+
       if tInArgs then
          put tRawArg into tArgs[1 + the number of elements in tArgs]
       else
@@ -52,14 +52,14 @@ private function getCommandLineInfo
             put true into tInArgs
          end if
       end if
-      
+
    end repeat
-   
+
    local tInfo
    put tSelfCommand into tInfo["self-command"]
    put tSelfScript into tInfo["self-script"]
    put tArgs into tInfo["args"]
-   
+
    return tInfo
 end getCommandLineInfo
 
@@ -71,7 +71,7 @@ command TestRunnerMain
    local tInfo
    put getCommandLineInfo() into tInfo
    logInit
-   
+
    switch tInfo["args"][1]
       case "invoke"
          doInvoke tInfo
@@ -94,7 +94,7 @@ end TestRunnerMain
 private command doInvoke pInfo
    put pInfo["args"][2] into pInfo["invoke"]["script"]
    put pInfo["args"][3] into pInfo["invoke"]["command"]
-   
+
    invokeLoadLibrary pInfo
    invokeTest pInfo
 end doInvoke
@@ -110,8 +110,14 @@ private command doRun pInfo
    else
       runTestCommand pInfo, tScript, tCommand
    end if
-   
+
    put the result into tAnalysis
+
+   -- Save the log to file
+   open file kLogFilename for "UTF-8" text write
+   write tAnalysis["log"] to file kLogFilename
+   close file kLogFilename
+
    if tapGetWorstResult(tAnalysis) is "FAIL" then
       quit 1
    end if
@@ -134,10 +140,10 @@ end ErrorDialog
 -- Execute a test
 private command invokeTest pInfo
    local tStackName
-   
+
    -- This should auto-load the test script
    put the name of stack pInfo["invoke"]["script"] into tStackName
-   
+
    -- Dispatch the test setup command, and the test command itself
    dispatch kSetupMessage to tStackName
    dispatch pInfo["invoke"]["command"] to tStackName
@@ -147,11 +153,11 @@ end invokeTest
 -- Add the unit test library stack to the backscripts
 private command invokeLoadLibrary pInfo
    local tStackName, tStackFile
-   
+
    -- This should auto-load the library
    put invokeGetLibraryStack(pInfo) into tStackFile
    put the name of stack tStackFile into tStackName
-   
+
    -- Add the library to the backscripts
    insert the script of stack tStackName into back
 end invokeLoadLibrary
@@ -160,10 +166,10 @@ end invokeLoadLibrary
 private function invokeGetLibraryStack pInfo
    local tFilename
    put pInfo["self-script"] into tFilename
-   
+
    set the itemDelimiter to slash
    put "_testlib.livecodescript" into item -1 of tFilename
-   
+
    return tFilename
 end invokeGetLibraryStack
 
@@ -180,12 +186,7 @@ private command runAllScripts pInfo
       put tapCombine(tAnalysis, the result) into tAnalysis
    end repeat
    runPrintSummary(tAnalysis)
-   
-   -- Save the log to file
-   open file kLogFilename for "UTF-8" text write
-   write tAnalysis["log"] to file kLogFilename
-   close file kLogFilename
-   
+
    return tAnalysis
 end runAllScripts
 
@@ -204,7 +205,7 @@ end runTestSkipAll
 private command runTestScript pInfo, pScriptFile
    local tCommand, tAnalysis, tMetadata
    put runGetTestMetadata(pScriptFile) into tMetadata
-   
+
    -- Only run tests that require UI if possible
    local tCanRunUITests
    put true into tCanRunUITests
@@ -214,12 +215,12 @@ private command runTestScript pInfo, pScriptFile
          exit repeat
       end if
    end repeat
-   
+
    if tMetadata["ui"] is true and not tCanRunUITests then
       runTestSkipAll pInfo, pScriptFile, "test requires UI mode"
       return the result
    end if
-   
+
    repeat for each element tCommand in runGetTestCommandNames(pScriptFile)
       runTestCommand pInfo, pScriptFile, tCommand
       put tapCombine(tAnalysis, the result) into tAnalysis
@@ -233,13 +234,13 @@ private command runTestProcessOutput pScriptfile, pCommand, pOutput
    put "###" && runGetPrettyTestName(pScriptFile) && pCommand \
          & return & return into tTestLog
    put pOutput & return after tTestLog
-   
+
    -- Analyse the results and print a summary line
    local tTapResults
    put tapAnalyse(tTestLog) into tTapResults
 
    logSummaryLine tTapResults, (runGetPrettyTestName(pScriptFile) & ":" && pCommand)
-   
+
    return tTapResults
 end runTestProcessOutput
 
@@ -247,19 +248,19 @@ end runTestProcessOutput
 -- tScriptFile
 private command runTestCommand pInfo, pScriptFile, pCommand
    local tArg, tCommandLine
-   
+
    repeat for each element tArg in pInfo["self-command"]
       put tArg & " " after tCommandLine
    end repeat
-   
+
    put "invoke" && pScriptFile && pCommand after tCommandLine
-   
+
    -- Invoke the test in a subprocess.  This ensures that we can detect
    -- if a crash occurs
    local tTestOutput, tTestExitStatus
    put shell(tCommandLine) into tTestOutput
    put the result into tTestExitStatus
-   
+
    -- Check the exit status.  If it suggests failure, add a "not ok" stanza
    -- to the tail of the TAP output
    if tTestExitStatus is not empty then
@@ -267,7 +268,7 @@ private command runTestCommand pInfo, pScriptFile, pCommand
       put "not ok # Subprocess exited with status" && \
             tTestExitStatus & return after tTestOutput
    end if
-   
+
    runTestProcessOutput pScriptFile, pCommand, tTestOutput
    return the result
 end runTestCommand
@@ -276,12 +277,12 @@ end runTestCommand
 -- filenames starting with "." or "_"
 private function runGetTestFileNames
    local tFiles, tCount
-   
+
    put empty into tFiles
    put 0 into tCount
-   
+
    runGetTestFileNames_Recursive the defaultfolder, empty, tFiles, tCount
-   
+
    return tFiles
 end runGetTestFileNames
 
@@ -291,38 +292,38 @@ private command runGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCount
    local tSaveFolder
    put the defaultfolder into tSaveFolder
    set the defaultfolder to pPath
-   
+
    -- Process files in the current directory
    local tFile
    repeat for each line tFile in the files
       if tFile ends with ".livecodescript" and \
             not (tFile begins with "." or tFile begins with "_") then
-         
+
          if pRelPath is not empty then
             put pRelPath & slash before tFile
          end if
-         
+
          add 1 to xCount
          put tFile into xFiles[xCount]
       end if
    end repeat
-   
+
    -- Process subdirectories
    local tFolder, tFolderPath
    repeat for each line tFolder in the folders
       if tFolder begins with "." then
          next repeat
       end if
-      
+
       put pPath & slash & tFolder into tFolderPath
-      
+
       if pRelPath is not empty then
          put pRelPath & slash before tFolder
       end if
-      
+
       runGetTestFileNames_Recursive tFolderPath, tFolder, xFiles, xCount
    end repeat
-   
+
    -- Restore the CWD
    set the defaultfolder to tSaveFolder
 end runGetTestFileNames_Recursive
@@ -331,21 +332,21 @@ end runGetTestFileNames_Recursive
 -- commands in pFilename.
 private function runGetTestCommandNames pFilename
    local tScript
-   
+
    -- Get the contents of the file
    open file pFilename for "UTF-8" text read
    if the result is not empty then
       throw the result
    end if
-   
+
    read from file pFilename until end
    put it into tScript
-   
+
    close file pFilename
-   
+
    -- Scan the file for "on Test*" definitions
    local tCommandNames, tCount, tLine, tName
-   
+
    repeat for each line tLine in tScript
       if token 1 of tLine is not "on" then
          next repeat
@@ -365,7 +366,7 @@ private function runGetTestCommandNames pFilename
       add 1 to tCount
       put tName into tCommandNames[tCount]
    end repeat
-   
+
    return tCommandNames
 end runGetTestCommandNames
 
@@ -380,22 +381,22 @@ end runGetPrettyTestName
 -- Print out a table of statistics
 private command runPrintSummary pAnalysis
    local tSummaryString, tTotal, tDecoration
-   
+
    put tapGetTestCount(pAnalysis) into tTotal
-   
+
    -- Format basic summary information
    if pAnalysis["xfail"] is 0 and pAnalysis["fail"] is 0 then
       put "All" && tTotal && "tests passed" into tSummaryString
-      
+
    else if pAnalysis["fail"] is 0 then
       put "All" && tTotal && "tests behaved as expected" into tSummaryString
-      
+
    else
       put pAnalysis["fail"] && "OF" && tTotal && "TESTS FAILED" into tSummaryString
    end if
-   
+
    put return after tSummaryString
-   
+
    -- Add extra summary info from expected failure & skip directives
    if pAnalysis["xpass"] > 0 then
       put tab & pAnalysis["xpass"] && "unexpected passes" & return after tSummaryString
@@ -406,56 +407,56 @@ private command runPrintSummary pAnalysis
    if pAnalysis["skip"] > 0 then
       put tab & pAnalysis["skip"] && "skipped" & return after tSummaryString
    end if
-   
+
    put "================================================================" into tDecoration
    put tDecoration & return before tSummaryString
    put tDecoration & return after tSummaryString
-   
+
    write tSummaryString to stdout
 end runPrintSummary
 
 -- Get all the metadata keys and values in the stack file
 private function runGetTestMetadata pFilename
    local tScript
-   
+
    -- Get the contents of the file
    open file pFilename for "UTF-8" text read
    if the result is not empty then
       throw the result
    end if
-   
+
    read from file pFilename until end
    put it into tScript
-   
+
    close file pFilename
-   
-   -- Scan the file for metadata - 
+
+   -- Scan the file for metadata -
    -- Metadata is given in the form ### <key> : <value>
-   
+
    local tKey, tValue, tMetadata
    repeat for each line tLine in tScript
       -- save some time by only looking at commented out lines
       if token 1 of tLine is not empty then
          next repeat
       end if
-      
+
       -- remove whitespace
       put word 1 to -1 of tLine into tLine
-      
+
       if not (tLine begins with "###") then
          next repeat
       end if
-      
+
       -- remove hashes
       put char 4 to -1 of tLine into tLine
-      
+
       set the itemdelimiter to ":"
       put word 1 to -1 of (item 1 of tLine) into tKey
       put word 1 to -1 of (item 2 of tLine) into tValue
-      
+
       put tValue into tMetadata[tKey]
    end repeat
-   
+
    return tMetadata
 end runGetTestMetadata
 
@@ -537,7 +538,7 @@ private function tapAnalyse pTapData
    put 0 into tStats["fail"]
    put 0 into tStats["skip"]
    put pTapData into tStats["log"]
-   
+
    local tLine, tIsOkay, tIsTodo, tIsSkip
    local tTail, tDirective
    repeat for each line tLine in pTapData
@@ -549,9 +550,9 @@ private function tapAnalyse pTapData
          put false into tIsOkay
       else
          -- No test result on this line
-         next repeat          
+         next repeat
       end if
-      
+
       -- Check if the test on this line was skipped or was expected to fail
       put false into tIsTodo
       put false into tIsSkip
@@ -564,7 +565,7 @@ private function tapAnalyse pTapData
             put true into tIsSkip
             break
       end switch
-      
+
       if tIsOkay then
          if tIsTodo then
             add 1 to tStats["xpass"]
@@ -580,9 +581,9 @@ private function tapAnalyse pTapData
             add 1 to tStats["fail"]
          end if
       end if
-      
+
    end repeat
-   
+
    return tStats
 end tapAnalyse
 


### PR DESCRIPTION
Previously the LCS testrunner would only output a log if it ran all
tests. The log output code has been moved so that it now outputs a log
for all cases.
