### PR TITLE
[[ UnitTests ]] Fix log encoding issues.

### DIFF
--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -87,8 +87,14 @@ private command _TestOutput pIsOkay, pDescription, pDirective, pReason
       end if
    end if
    
-   write tMessage & return to stdout
+   _TestWriteOutput tMessage & return
 end _TestOutput
+
+private command _TestWriteOutput pMessage
+   -- As stdout is considered to be a 'native' stream, we encode to UTF-8 first
+   -- then will unencode in the test runner.
+   write textEncode(pMessage, "UTF8") to stdout
+end _TestWriteOutput
 
 ----------------------------------------------------------------
 -- Unit test library functions
@@ -97,7 +103,7 @@ end _TestOutput
 on TestDiagnostic pMessage
    local tLine
    repeat for each line tLine in pMessage
-      write "#" && tLine & return to stdout
+      _TestWriteOutput "#" && tLine & return
    end repeat
 end TestDiagnostic
 

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -112,12 +112,17 @@ private command doRun pInfo
    end if
 
    put the result into tAnalysis
-
-   -- Save the log to file
-   open file kLogFilename for "UTF-8" text write
-   write tAnalysis["log"] to file kLogFilename
-   close file kLogFilename
-
+   
+   -- Save the log to file.
+   -- We process to binary data ourselves to ensure encoding and
+   -- line endings are appropriate.
+   local tLogForWriting
+   put textEncode(tAnalysis["log"], "utf8") into tLogForWriting
+   if the platform is "win32" then
+      replace return with numToChar(13) & numToChar(10) in tLogForWriting
+   end if
+   put tLogForWriting into url ("binfile:" & kLogFilename)
+   
    if tapGetWorstResult(tAnalysis) is "FAIL" then
       quit 1
    end if
@@ -260,6 +265,9 @@ private command runTestCommand pInfo, pScriptFile, pCommand
    local tTestOutput, tTestExitStatus
    put shell(tCommandLine) into tTestOutput
    put the result into tTestExitStatus
+   
+   -- The output from the subprocesses will be native encoded utf-8.
+   put textDecode(tTestOutput, "utf8") into tTestOutput
 
    -- Check the exit status.  If it suggests failure, add a "not ok" stanza
    -- to the tail of the TAP output


### PR DESCRIPTION
This patch ensures that tests can output UTF-8 into the log file
and that line endings are more appropriate on Mac.

Code that writes the log from _testlib now encodes the text
explicitly as UTF-8 as 'stdout' is considered to be native encoded.
The testrunner then decodes the output from the subprocesses
appropriately.

The log file is now written with LF line endings on Mac and Linux,
with Windows remaining as CRLF.
