### PR TITLE
[[ RTF Export ]] Fix broken RTF export on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+# Very basic Travis CI (http://travis-ci.org) control file that allows
+# some basic Linux-based continuous integration testing (for free).
+
+language: c++
+
+# Use container-based infrastructure
+sudo: false
+
+# Skip vulcan CI branches
+branches:
+  only:
+    - /^develop.*$/
+    - /^release.*$/
+    - coverity_scan
+
+# Environment variables
+env:
+  global:
+    - CXX_STD: "gnu++98"
+
+# Set up the source tree by fetching Linux-specific prebuilt objects
+install: (cd prebuilt && ./fetch-libraries.sh linux)
+
+# Build the default target set and run the test suite.
+script: make all-linux && make -C tests/lcs
+
+addons:
+  # Packages needed for building LiveCode
+  apt:
+    packages:
+      - libx11-dev
+      - libxext-dev
+      - libxrender-dev
+      - libxft-dev
+      - libxinerama-dev
+      - libxv-dev
+      - libxcursor-dev
+      - libfreetype6-dev
+      - libgtk2.0-dev
+      - libpopt-dev
+      - libesd0-dev
+      - liblcms-dev

--- a/docs/notes/bugfix-16450.md
+++ b/docs/notes/bugfix-16450.md
@@ -1,0 +1,1 @@
+# Setting RTF text adds invalid chars in the field on Linux

--- a/docs/notes/bugfix-16451,md
+++ b/docs/notes/bugfix-16451,md
@@ -1,0 +1,1 @@
+# Get the rtfText of field swaps blue and red colour values

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -349,8 +349,10 @@ static iconv_t fetch_converter(const char *p_encoding)
 
     if (t_current == NULL)
     {
+        // SN-2015-11-19: [[ Bug 16450 ]] Ask for UTF-16LE to avoid iconv to put
+        // a BOM char at the start of the stream
         iconv_t t_converter;
-        t_converter = iconv_open("UTF-16", p_encoding);
+        t_converter = iconv_open("UTF-16LE", p_encoding);
 
         ConverterRecord *t_record;
         t_record = new ConverterRecord;

--- a/engine/src/fieldrtf.cpp
+++ b/engine/src/fieldrtf.cpp
@@ -27,6 +27,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "osspec.h"
 //#include "execpt.h"
 #include "mcstring.h"
+#include "uidc.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -474,7 +475,14 @@ static bool export_rtf_emit_paragraphs(void *p_context, MCFieldExportEventType p
 		{
 			/* UNCHECKED */ MCStringAppendFormat(ctxt.m_text, "{\\colortbl;");
 			for(uint32_t i = 0; i < ctxt . colors . count(); i++)
-				/* UNCHECKED */ MCStringAppendFormat(ctxt.m_text, "\\red%d\\green%d\\blue%d;", (ctxt . colors[i] >> 16) & 0xff, (ctxt . colors[i] >> 8) & 0xff, (ctxt . colors[i] >> 0) & 0xff);
+            {
+                // SN-2015-11-19: [[ Bug 16451 ]] MCscreen knows better than
+                // us how to unpack a colour pixel.
+                MCColor t_color;
+                t_color . pixel = ctxt . colors[i];
+                MCscreen -> querycolor(t_color);
+                /* UNCHECKED */ MCStringAppendFormat(ctxt.m_text, "\\red%d\\green%d\\blue%d;", t_color . red, t_color . green, t_color . blue);
+            }
 			/* UNCHECKED */ MCStringAppendFormat(ctxt.m_text, "}\n");
 		}
 		


### PR DESCRIPTION
Fixes bugs [16450](http://quality.livecode.com/show_bug.cgi?id=16450) and [16451](http://quality.livecode.com/show_bug.cgi?id=16450), which are making the newly added RTF tests fail on Linux
