### PR TITLE
[[ Perf ]] Improve performance of 'repeat counted'.

### DIFF
--- a/benchmarks/lcs/control/repeat.livecodescript
+++ b/benchmarks/lcs/control/repeat.livecodescript
@@ -16,16 +16,29 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+on BenchmarkRepeatForever
+   local tCount
+   put 10000000 into tCount
+   BenchmarkStartTiming
+   repeat forever
+      subtract 1 from tCount
+      if tCount is 0 then
+         exit repeat
+      end if
+   end repeat
+   BenchmarkStopTiming
+end BenchmarkRepeatForever
+
 on BenchmarkRepeatCount
    BenchmarkStartTiming
-   repeat 100000000 times
+   repeat 100000000  times
    end repeat
    BenchmarkStopTiming
 end BenchmarkRepeatCount
 
 on BenchmarkRepeatWith
    BenchmarkStartTiming
-   repeat with i = 1 to 100000000
+   repeat with i = 1 to 10000000 
    end repeat
    BenchmarkStopTiming
 end BenchmarkRepeatWith

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1817,6 +1817,7 @@ private:
 
 void MCKeywordsExecSwitch(MCExecContext& ctxt, MCExpression *condition, MCExpression **cases, uindex_t case_count, int2 default_case, uint2 *case_offsets, MCStatement *statements, uint2 line, uint2 pos);
 void MCKeywordsExecIf(MCExecContext& ctxt, MCExpression *condition, MCStatement *thenstatements, MCStatement *elsestatements, uint2 line, uint2 pos);
+void MCKeywordsExecRepeatCount(MCExecContext& ctxt, MCStatement *statements, MCExpression *endcond, uint2 line, uint2 pos);
 void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExpression *endcond, MCVarref *loopvar, File_unit each, uint2 line, uint2 pos);
 void MCKeywordsExecRepeatWith(MCExecContext& ctxt, MCStatement *statements, MCExpression *step, MCExpression *startcond, MCExpression *endcond, MCVarref *loopvar, real8 stepval, uint2 line, uint2 pos);
 void MCKeywordsExecRepeatForever(MCExecContext& ctxt, MCStatement *statements, uint2 line, uint2 pos);

--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -1296,7 +1296,10 @@ void MCRepeat::exec_ctxt(MCExecContext& ctxt)
     switch (form)
 	{
         case RF_FOR:
-            MCKeywordsExecRepeatFor(ctxt, statements, endcond, loopvar, each, line, pos);
+            if (loopvar != nil)
+                MCKeywordsExecRepeatFor(ctxt, statements, endcond, loopvar, each, line, pos);
+            else
+                MCKeywordsExecRepeatCount(ctxt, statements, endcond, line, pos);
             break;
         case RF_WITH:
             MCKeywordsExecRepeatWith(ctxt, statements, step, startcond, endcond, loopvar, stepval, line, pos);

--- a/tests/lcs/core/control/repeat.livecodescript
+++ b/tests/lcs/core/control/repeat.livecodescript
@@ -1,0 +1,217 @@
+﻿script "CoreControlRepeat"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestRepeatForever
+  local tCounter
+  put 0 into tCounter
+  repeat forever
+    add 1 to tCounter
+    if tCounter is 1000 then
+      exit repeat
+    end if
+  end repeat
+  TestAssert "repeat forever runs 1000 times", tCounter is 1000
+end TestRepeatForever
+
+on TestRepeatCount
+  local tCounter
+  put 1000 into tCounter
+  repeat 1000 times
+    subtract 1 from tCounter
+  end repeat
+  TestAssert "repeat 1000 times runs 1000 times", tCounter is 0
+end TestRepeatCount
+
+on TestRepeatForEachKeyInArray
+  local tArray
+  put 1 into tArray["foo"]
+  put 2 into tArray["bar"]
+  put 3 into tArray["baz"]
+
+  local tTotal
+  repeat for each key tKey in tArray
+    add tArray[tKey] to tTotal
+  end repeat
+
+  TestAssert "repeat for each key in array", tTotal is 6
+end TestRepeatForEachKeyInArray
+
+on TestRepeatForEachKeyInSequence
+   local tArray, tExpectedString
+   repeat with i = 1 to 10000
+      put i into tArray[i]
+      put i & comma after tExpectedString
+   end repeat
+   
+   local tComputedString
+   repeat for each key tKey in tArray
+      put tArray[tKey] & comma after tComputedString
+   end repeat
+   
+   TestAssertBroken "repeat for each key in sequence", tComputedString is tExpectedString, "anomaly 16449"
+end TestRepeatForEachKeyInSequence
+
+on TestRepeatForEachElementInArray
+  local tArray
+  put 1 into tArray["foo"]
+  put 2 into tArray["bar"]
+  put 3 into tArray["baz"]
+
+  local tTotal
+  repeat for each element tElement in tArray
+    add tElement to tTotal
+  end repeat
+
+  TestAssert "repeat for each element in array", tTotal is 6
+end TestRepeatForEachElementInArray
+
+on TestRepeatForEachElementInSequence
+   local tArray, tExpectedString
+   repeat with i = 1 to 10000
+      put i into tArray[i]
+      put i & comma after tExpectedString
+   end repeat
+   
+   local tComputedString
+   repeat for each element tElement in tArray
+      put tElement & comma after tComputedString
+   end repeat
+   
+   TestAssert "repeat for each element in sequence", tComputedString is tExpectedString
+end TestRepeatForEachElementInSequence
+
+on TestRepeatForEachByte
+   local tBytes, tExpectedString
+   repeat with i = 0 to 255
+      put numToByte(i) after tBytes
+      put i & comma after tExpectedString
+   end repeat
+   
+   local tComputedString
+   repeat for each byte tByte in tBytes
+      put byteToNum(tByte) & comma after tComputedString
+   end repeat
+   
+   TestAssert "repeat for each byte", tComputedString is tExpectedString
+end TestRepeatForEachByte
+
+on TestRepeatForEachChar
+   local tString, tExpectedCharString, tExpectedCodepointString, tExpectedCodeunitString, tComputedString
+   
+   repeat for each word tType in "native simple combining surrogates"
+      switch tType
+         case "native"
+            -- native boundaries are the same for char, codepoint and codeunit
+            put "foo" into tString
+            put "f,o,o," into tExpectedCharString
+            put "f,o,o," into tExpectedCodepointString
+            put "f,o,o," into tExpectedCodeunitString
+            break
+            
+         case "simple"
+            -- unicode characters which are 1-1-1 (char,unit,point)
+            -- we use greek alpha, beta and gamma
+            put numToCodepoint(0x0391) & numToCodepoint(0x392) & numToCodepoint(0x393) into tString
+            put numToCodepoint(0x0391) , numToCodepoint(0x392) , numToCodepoint(0x393) , empty into tExpectedCharString
+            put tExpectedCharString into tExpectedCodepointString
+            put tExpectedCharString into tExpectedCodeunitString
+            break
+            
+         case "combining"
+            -- unicode characters which give 2-1-1 (char,unit,point)
+            put "fo" & numToCodepoint(0x301) & "o" into tString
+            put "f", "o" & numToCodepoint(0x301) , "o" , empty into tExpectedCharString
+            put "f", "o", numToCodepoint(0x301) , "o" , empty into tExpectedCodepointString
+            put tExpectedCodepointString into tExpectedCodeunitString
+            break
+      end switch
+      
+      put empty into tComputedString
+      repeat for each character tChar in tString
+         put tChar & comma after tComputedString
+      end repeat
+      TestAssert "repeat for each character -" && tType, tComputedString is tExpectedCharString
+      
+      put empty into tComputedString
+      repeat for each codepoint tChar in tString
+         put tChar & comma after tComputedString
+      end repeat
+      TestAssert "repeat for each codepoint -" && tType, tComputedString is tExpectedCodepointString
+      
+      put empty into tComputedString
+      repeat for each codeunit tChar in tString
+         put tChar & comma after tComputedString
+      end repeat
+      TestAssert "repeat for each codeunit -" && tType, tComputedString is tExpectedCodeunitString
+   end repeat
+end TestRepeatForEachChar
+
+on TestRepeatForEachDelimitedChunk
+   local tChunks, tComputedChunks
+   put "foo,bar,baz,foobar,foobaz,barbaz" into tChunks
+   
+   put empty into tComputedChunks
+   repeat for each item tChunk in tChunks
+      put tChunk & comma after tComputedChunks
+   end repeat
+   TestAssert "repeat for each item", tComputedChunks is (tChunks & comma)
+   
+   put empty into tComputedChunks
+   repeat for each item tChunk in (tChunks & comma)
+      put tChunk & comma after tComputedChunks
+   end repeat
+   TestAssert "repeat for each item trailing delimiter", tComputedChunks is (tChunks & comma)
+   
+   replace comma with return in tChunks
+   
+   put empty into tComputedChunks
+   repeat for each line tChunk in tChunks
+      put tChunk & return after tComputedChunks
+   end repeat
+   TestAssert "repeat for each line", tComputedChunks is (tChunks & return)
+   
+   put empty into tComputedChunks
+   repeat for each line tChunk in (tChunks & return)
+      put tChunk & return after tComputedChunks
+   end repeat
+   TestAssert "repeat for each item trailing delimiter", tComputedChunks is (tChunks & return)
+end TestRepeatForEachDelimitedChunk
+
+on TestRepeatForEachSegment
+   local tSegments, tExpectedString
+   put "  the    " & quote & "quick brown" & quote & " fox" into tSegments
+   put "the," & quote & "quick brown" & quote & ",fox," into tExpectedString
+   
+   local tComputedString
+   repeat for each segment tSegment in tSegments
+      put tSegment & comma after tComputedString
+   end repeat
+   TestAssert "repeat for each segment", tComputedString is tExpectedString
+end TestRepeatForEachSegment
+
+on TestRepeatForEachTrueWord
+   local tTrueWords, tExpectedString
+   put "  the    " & quote & "quick brown" & quote & " fox" into tTrueWords
+   put "the,quick,brown,fox," into tExpectedString
+   
+   local tComputedString
+   repeat for each trueWord tTrueWord in tTrueWords
+      put tTrueWord & comma after tComputedString
+   end repeat
+   TestAssert "repeat for each true word", tComputedString is tExpectedString
+end TestRepeatForEachTrueWord


### PR DESCRIPTION
The 'repeat for' and 'repeat ... times' execution methods have been
split into two resulting in a significant speed boost to the 'n times'
form.
