### PR TITLE
🍄 com.livecode.file: Add "command argument _ parsed as file"

### DIFF
--- a/engine/src/em-system.cpp
+++ b/engine/src/em-system.cpp
@@ -22,6 +22,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "osspec.h"
 
+#include <foundation-system.h>
+
 #include <fcntl.h>
 #include <dirent.h>
 #include <sys/stat.h>
@@ -351,6 +353,8 @@ MCEmscriptenSystem::ResolveAlias(MCStringRef p_target,
 bool
 MCEmscriptenSystem::GetCurrentFolder(MCStringRef & r_path)
 {
+	return MCSFileGetCurrentDirectory(r_path);
+
 	/* FIXME use get_current_dir_name() once it's available in Emscripten's
 	 * libc. */
 

--- a/libfoundation/include/system-file.h
+++ b/libfoundation/include/system-file.h
@@ -41,7 +41,12 @@ bool __MCSFileThrowInvalidPathError (MCStringRef p_path);
  * Path manipulation
  * ================================================================ */
 
+/* Get the current working directory */
+MC_DLLEXPORT bool MCSFileGetCurrentDirectory (MCStringRef & r_path);
+
 #ifdef __MCS_INTERNAL_API__
+
+bool __MCSFileGetCurrentDirectory (MCStringRef & r_native_path);
 
 bool __MCSFilePathToNative (MCStringRef p_path, MCStringRef & r_native_path);
 bool __MCSFilePathFromNative (MCStringRef p_native_path, MCStringRef & r_path);

--- a/libfoundation/src/system-file-posix.cpp
+++ b/libfoundation/src/system-file-posix.cpp
@@ -479,6 +479,24 @@ __MCSFilePathFromNative (MCStringRef p_native_path,
 	return MCStringCopy (p_native_path, r_path);
 }
 
+bool
+__MCSFileGetCurrentDirectory (MCStringRef & r_native_path)
+{
+	/* Assume that we have a C library that will allocate a buffer when getcwd(3)
+	 * is called with a NULL string buffer. */
+	char *t_cwd_sys;
+	errno = 0;
+	t_cwd_sys = getcwd (NULL, 0);
+
+	if (NULL == t_cwd_sys)
+	{
+		return __MCSFileThrowIOErrorWithErrno (kMCEmptyString, MCSTR("Failed to get current working directory: %{description}"), errno);
+	}
+
+	bool t_success = MCStringCreateWithSysString (t_cwd_sys, r_native_path);
+	free (t_cwd_sys);
+	return t_success;
+}
 
 /* ================================================================
  * File stream creation

--- a/libfoundation/src/system-file-w32.cpp
+++ b/libfoundation/src/system-file-w32.cpp
@@ -318,39 +318,148 @@ __MCSFileSetContents (MCStringRef p_native_path,
  * Path manipulation
  * ================================================================ */
 
+/* The essential reference material for working with these functions
+ * is the "Naming Files, Paths and Namespaces" page in the Windows API
+ * documentation on MSDN. */
+
+/* For use only when operating on *native* paths. */
+static inline bool
+__MCSFileCharIsSeparator (codepoint_t p_char)
+{
+	return (p_char == '/' || p_char == '\\');
+}
+
+/* For use only when operating on *native* paths.
+ *
+ * Tests whether p_path is a UNC path. */
+static inline bool
+__MCSFilePathIsUnc (MCStringRef p_native_path)
+{
+	if (2 > MCStringGetLength (p_native_path))
+	{
+		return false;
+	}
+
+	return (__MCSFileCharIsSeparator (MCStringGetCharAtIndex (p_native_path, 0)) &&
+	        __MCSFileCharIsSeparator (MCStringGetCharAtIndex (p_native_path, 1)));
+}
+
+/* For use only when operating on *native* paths.
+ *
+ * Tests whether p_path begins with "\\?\" or "\\.\" (or equivalent).
+ * N.b. that "\\?" and "\\." are treated as UNC paths rather than NT
+ * namespace paths. */
+static bool
+__MCSFilePathIsNamespace (MCStringRef p_native_path)
+{
+	if (4 > MCStringGetLength (p_native_path))
+	{
+		return false;
+	}
+
+	if (!__MCSFilePathIsUnc (p_native_path))
+	{
+		return false;
+	}
+
+	codepoint_t t_char = MCStringGetCharAtIndex (p_native_path, 2);
+	if ('.' != t_char && '?' != t_char)
+	{
+		return false;
+	}
+
+	if (!__MCSFileCharIsSeparator (MCStringGetCharAtIndex (p_native_path, 3)))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+/* For use only when operating on *native* paths.
+ *
+ * Tests whether p_path is a special Windows "device" path. */
+static inline bool
+__MCSFilePathIsDevice (MCStringRef p_native_path)
+{
+	static const char[][] kMCSDeviceBaseNames = {
+		'CON',
+		'PRN',
+		'AUX',
+		'NUL',
+		'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+		'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+		NULL,
+	};
+
+	/* UNC paths are safe! */
+	if (__MCSFilePathIsUnc (p_native_path))
+		return false;
+
+	uindex_t t_len = MCStringGetLength (p_native_path);
+
+	/* Find the last separator in the path */
+	/* FIXME there should be a "basename" function */
+	uindex_t t_basename_offset = t_len;
+	while (t_basename_offset > 0)
+	{
+		codepoint_t t_char = MCStringGetCharAtIndex (p_native_path,
+		                                             t_basename_offset - 1);
+		if (__MCSFileCharIsSeparator (t_char))
+			break;
+		--t_basename_offset;
+	}
+
+	/* Find the first '.' in the separator */
+	uindex_t t_basename_len = 0;
+	while (t_basename_len + t_basename_offset < t_len)
+	{
+		if ('.' == MCStringGetCharAtIndex (p_native_path,
+		                                   t_basename_offset + t_basename_len))
+		{
+			break;
+		}
+		++t_basename_len;
+	}
+
+	/* No basename -> not a device */
+	if (0 == t_basename_len)
+	{
+		return false;
+	}
+
+	MCAutoStringRef t_basename;
+	if (!MCStringCopySubstring (p_native_path,
+	                            MCRangeMake (t_basename_offset, t_basename_len),
+	                            &t_basename))
+	{
+		return false;
+	}
+
+	/* Check against static table of reserved device names */
+	for (int i = 0; NULL != kMCSDeviceBaseNames[i]; ++i)
+	{
+		if (MCStringIsEqualToCString (*t_basename, kMCSDeviceBaseNames[i],
+		                              kMCStringOptionCompareCaseless))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /* Convert a path in LiveCode representation (with '/' as the file
  * separator) to a Windows path (using '\').  This function also
  * performs some (very) limited validation, ensuring that the input
- * path does not contain any nul bytes or '\' characters.
+ * path does not contain any nul bytes or '\' characters, and is not a
+ * "special" device path (e.g. "NUL" or "COM1").
  *
  * FIXME Currently, this function -- and thus the files API on Windows
  * -- does not support the translation of long paths (i.e. longer than
  * 260 characters including the leading disk specifier and the
- * trailing nul).  There are a number of issues here:
- *
- * 1) Using __MCSFilePathToNative() followed by
- *    __MCSFilePathFromNative() is supposed to be a lossless operation,
- *    but supporting long file names means losing the relative
- *    filename information (because "\\?\" format supports absolute
- *    filenames only).
- *
- * 2) In some cases, users may be intentionally trying to open devices
- *    (to obtain an input stream for a serial port, for example).  It
- *    would be necessary to provide an alternative API for these
- *    users.
- *
- * 3) Since we may want to use the "\\?\" format for the native
- *    representation in the future, we need to forbid "/" in native
- *    paths returned by this function (because "\\?\" namespace treats
- *    them as normal characters rather than as path separators).
- *
- * It may be better to resolve these issues (and similar ones on other
- * platforms, e.g. Linux) by defining a 'filename' type and adding API
- * for obtaining the filename in various different forms.
- *
- * Initially, there's support for translating file namespace ("\\?\")
- * paths, but only if they're presented to the API already in that
- * format.
+ * trailing nul).  Excessively long paths are passed through to the
+ * underlying operating system APIs for them to error on.
  */
 bool
 __MCSFilePathToNative (MCStringRef p_path,
@@ -362,12 +471,6 @@ __MCSFilePathToNative (MCStringRef p_path,
 	if (0 == t_len)
 		return __MCSFileThrowInvalidPathError (p_path);
 
-	/* Check for '//?/' prefix.  If present, we handle some path
-	 * translations differently. */
-	bool t_file_namespace;
-	t_file_namespace = MCStringBeginsWithCString (p_path, (const char_t*)"//?/",
-	                                              kMCStringOptionCompareExact);
-
 	MCAutoArray<unichar_t> t_native_chars;
 	if (!t_native_chars.New (t_len))
 		return false;
@@ -376,22 +479,22 @@ __MCSFilePathToNative (MCStringRef p_path,
 	{
 		unichar_t t_char = MCStringGetCharAtIndex (p_path, i);
 
+		/* Explicitly reserved characters */
+		if (t_char < 32)
+		{
+			return __MCSFileThrowInvalidPathError (p_path);
+		}
+
 		switch (t_char)
 		{
-		case 0:
-			/* Path may not incorporate a nul */
-			return __MCSFileThrowInvalidPathError (p_path);
 		case '\\':
-			/* If the input path is a Win32 file namespace path,
-			 * translate '\\' to '/', since they'll be treated as
-			 * "normal" path characters.  Otherwise, fail (because we
-			 * may need to do translation to file namespace in future
-			 * versions of this API). */
-			if (t_file_namespace)
-				t_native_chars[i] = '/';
-			else
-				return __MCSFileThrowInvalidPathError (p_path);
-			break;
+			/* Backslashes in LiveCode internal paths are always
+			 * invalid on Windows, because they are ambiguous.  In
+			 * LiveCode internal paths, '\' is just another character,
+			 * but Windows doesn't distinguish.  It's better to
+			 * enforce that the only path separator used in internal
+			 * paths is '/'. */
+			return __MCSFileThrowInvalidPathError (p_path);
 		case '/':
 			t_native_chars[i] = '\\';
 			break;
@@ -401,14 +504,31 @@ __MCSFilePathToNative (MCStringRef p_path,
 		}
 	}
 
-	return MCStringCreateWithChars (t_native_chars.Ptr(),
-	                                t_native_chars.Size(),
-	                                r_native_path);
+	MCAutoStringRef t_native_path;
+	if (!MCStringCreateWithChars (t_native_chars.Ptr(),
+	                              t_native_chars.Size(),
+	                              &t_native_path))
+	{
+		return false;
+	}
+
+	/* Verify that the file is not a device path.  Assume that COM1 is a valid
+	 * filename when a UNC path is used. */
+	if (__MCSFilePathIsDevice (*t_native_path))
+	{
+		return __MCSFileThrowInvalidPathError (p_path);
+	}
+
+	return MCStringCopy (*t_native_path, r_native_path);
 }
 
+/* Convert a Windows path (using '\' as a separator) to LiveCode
+ * representation (using '/').  This function also performs some
+ * validation by truncating at nul bytes and ensuring that the path is
+ * not a device path. */
 bool
 __MCSFilePathFromNative (MCStringRef p_native_path,
-                        MCStringRef & r_path)
+                         MCStringRef & r_path)
 {
 	uindex_t t_len;
 	t_len = MCStringGetLength (p_native_path);
@@ -416,17 +536,16 @@ __MCSFilePathFromNative (MCStringRef p_native_path,
 	if (0 == t_len)
 		return MCStringCopy (p_native_path, r_path);
 
-	/* Check for '\\?\' prefix.  If present, we handle some path
-	 * translations differently. */
-	bool t_file_namespace;
-	t_file_namespace = MCStringBeginsWithCString (p_native_path, (const char_t*)"\\\\?\\",
-	                                              kMCStringOptionCompareExact);
+	if (__MCSFilePathIsDevice (p_native_path))
+	{
+		return __MCSFileThrowInvalidPathError (p_native_path);
+	}
 
 	MCAutoArray<unichar_t> t_internal_chars;
 	if (!t_internal_chars.New (t_len))
 		return false;
 
-	for (uindex_t i = 0; i < t_len; ++i)
+	for (uindex_t i = 0; i < t_len, ++i)
 	{
 		unichar_t t_char = MCStringGetCharAtIndex (p_native_path, i);
 
@@ -434,20 +553,13 @@ __MCSFilePathFromNative (MCStringRef p_native_path,
 		{
 		case 0:
 			/* If a nul is encountered, truncate the output path to
-			 * the number of preceding characters visited */
+			 * the number of preceding characters visited. */
+			t_len = i;
 			t_internal_chars.Shrink (i);
 			break;
 		case '/':
-			/* If the input path is a Win32 file namespace path,
-			 * translate '/' to '\\', since they're "normal" path
-			 * characters in this context.  Otherwise, fail (beacuse
-			 * we may need to do translation to/from file namespace in
-			 * future versions of this API). */
-			if (t_file_namespace)
-				t_internal_chars[i] = '\\';
-			else
-				return __MCSFileThrowInvalidPathError (p_native_path);
 		case '\\':
+			/* Always translate both '/' and '\' separators to '/'. */
 			t_internal_chars[i] = '/';
 			break;
 		default:

--- a/libfoundation/src/system-file-w32.cpp
+++ b/libfoundation/src/system-file-w32.cpp
@@ -461,6 +461,40 @@ __MCSFilePathFromNative (MCStringRef p_native_path,
 	                                r_path);
 }
 
+bool
+__MCSFileGetCurrentDirectory (MCStringRef & r_native_path)
+{
+
+	DWORD t_length = 0;
+	MCAutoArray<unichar_t> t_native_chars;
+	while (true)
+	{
+		t_length = GetCurrentDirectoryW (t_native_chars.Size(), t_native_chars.Ptr());
+
+		/* On error, GetCurrentDirectoryW() returns 0 */
+		if (0 == t_length)
+		{
+			return __MCSFileThrowIOErrorWithErrorCode (kMCEmptyString, MCSTR("Failed to get current working directory: %{description}"), p_error_code);
+		}
+
+		/* On success, it returns the number of characters read, not
+		 * including the trailing nul */
+		if (t_length + 1 < t_native_chars.Size())
+		{
+			break;
+		}
+
+		/* If the buffer isn't large enough, it returns the length of
+		 * buffer required. */
+		if (!t_native_chars.Resize (t_length))
+		{
+			return false;
+		}
+	}
+
+	return MCStringCreateWithWString (t_native_chars.Ptr(), r_native_path);
+}
+
 /* ================================================================
  * File stream creation
  * ================================================================ */

--- a/libfoundation/src/system-file.cpp
+++ b/libfoundation/src/system-file.cpp
@@ -104,6 +104,24 @@ __MCSFileThrowInvalidPathError (MCStringRef p_path)
 }
 
 /* ================================================================
+ * Path manipulation
+ * ================================================================ */
+
+MC_DLLEXPORT_DEF bool
+MCSFileGetCurrentDirectory (MCStringRef & r_path)
+{
+	MCAutoStringRef t_native_path;
+
+	if (!__MCSFileGetCurrentDirectory (&t_native_path))
+		return false;
+
+	if (!__MCSFilePathFromNative(*t_native_path, r_path))
+		return false;
+
+	return true;
+}
+
+/* ================================================================
  * Whole-file IO
  * ================================================================ */
 

--- a/libscript/src/file-impl.lcb
+++ b/libscript/src/file-impl.lcb
@@ -1,0 +1,223 @@
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.file.__IMPL
+-- DON'T USE THIS MODULE, USE com.livecode.unittest INSTEAD
+
+constant kSeparator is "/"
+
+-- We have to use this instead of "the current directory" in order to
+-- avoid a cyclic module dependency.
+private foreign handler MCFileEvalCurrentDirectory(out Directory as String) returns nothing binds to "<builtin>"
+
+----------------------------------------------------------------
+
+/* Return true if pPath is an absolute path */
+private handler IsAbsolutePath(in pPath as String) returns Boolean
+	if pPath is empty then
+		return false
+	end if
+
+	if the operating system is not "win" then
+		return pPath begins with kSeparator
+	end if
+
+	-- On Windows only, check whether the path starts with a drive
+	-- letter, e.g. "C:/".  Drive-relative paths, e.g. "C:foo", are not
+	-- supported.
+	variable tDriveLetter as String
+	put the upper of char 1 of pPath into tDriveLetter
+	if tDriveLetter >= "A" and tDriveLetter <= "Z" and \
+			char 2 of pPath is ":" then
+
+		if char 3 of pPath is kSeparator then
+			return true
+		else
+			throw "Unsupported drive-relative Windows path: '" & pPath & "'"
+		end if
+	end if
+
+	return false
+end handler
+
+/*
+Construct a path from a list of path components, <pElements>.  Empty
+path components are ignored.  At the boundary between any two
+components, any trailing path separators in the first component and
+any leading separators in the second component are removed, and
+exactly one separator is inserted.
+*/
+private handler BuildPath(in pElements as List) returns String
+	variable tComponent as String
+	variable tResult as String
+
+	put "" into tResult
+
+	repeat for each element tComponent in pElements
+
+		if tComponent is empty then
+			next repeat
+		end if
+
+		if tResult is empty then
+			put tComponent into tResult
+			next repeat
+		end if
+
+		-- Remove all leading separators from the component
+		repeat while the first char of tComponent is kSeparator
+			delete the first char of tComponent
+		end repeat
+
+		-- Remove all but 1 trailing separator from the accumulated
+		-- result
+		repeat while the last char of tComponent is kSeparator
+			delete the last char of tComponent
+		end repeat
+
+		put kSeparator & tComponent after tResult
+
+	end repeat
+
+	return tResult
+end handler
+
+private handler SplitPathRoot(in pPath as String, out rRoot as String, \
+		out rRelative as String) returns nothing
+
+	variable tLeadingSlashes as String
+
+	if not IsAbsolutePath(pPath) then
+		throw "No root part in relative path '" & pPath & "'"
+
+	else if the operating system is not "win" then
+		-- On POSIX systems, two slashes "//" at the start of a path is
+		-- special, but three or more aren't.
+		put pPath into rRelative
+		put "" into rRoot
+
+		repeat while rRelative begins with kSeparator
+			delete char 1 of rRelative
+			put kSeparator after rRoot
+		end repeat
+
+		if the number of chars in rRoot is not 2 then
+			put kSeparator into rRoot
+		end if
+
+	else
+		-- On Windows, things are slightly more complicated.
+
+		if pPath begins with kSeparator then
+
+			if the number of chars in pPath is 1 or \
+					char 2 of pPath is not kSeparator then
+				-- If the path begins with one separator, so it's relative
+				-- to the current drive letter.
+				put kSeparator into rRoot
+				put pPath into rRelative
+				delete char 1 of rRelative
+
+			else
+				-- The path begins with two or more separators, so it must be a
+				-- UNC path.
+				variable tRootEndOffset as Number
+				put the first index of kSeparator after 2 in pPath into tRootEndOffset
+				put char 1 to tRootEndOffset of pPath into rRoot
+				put pPath into rRelative
+				delete char 1 to tRootEndOffset of rRelative
+
+			end if
+
+		else
+			-- The path *doesn't* begin with a separator, so at this
+			-- point it presumably starts with a drive letter,
+			-- e.g. "C:/".
+			put char 1 to 3 of pPath into rRoot
+			put pPath into rRelative
+			delete char 1 to 3 of rRelative
+		end if
+	end if
+end handler
+
+private handler CanonicalizePath(in pPath as String) returns String
+
+	-- First, ensure that the path is absolute
+	variable tAbsolute
+	variable tCurrentDirectory
+	if IsAbsolutePath(pPath) then
+		put pPath into tAbsolute
+	else
+		MCFileEvalCurrentDirectory(tCurrentDirectory)
+		put BuildPath([tCurrentDirectory, pPath]) into tAbsolute
+	end if
+
+	-- Split the path into a leading root part and a relative part.
+	-- The idea is to perform canonicalisation on the relative part,
+	-- then stitch the path back together.
+	variable tRoot as String
+	variable tRelative as String
+	SplitPathRoot(tAbsolute, tRoot, tRelative)
+
+	variable tRawElements as List
+	split tRelative by kSeparator into tRawElements
+
+	variable tElements as List
+	put [] into tElements
+
+	variable tComponent as String
+	repeat for each element tComponent in tRawElements
+		if tComponent is empty or tComponent is "." then
+			-- Ignore
+		else if tComponent is ".." then
+			if tElements is not empty then
+				delete the last element of tElements
+			end if
+		else
+			push tComponent onto back of tElements
+		end if
+	end repeat
+
+	variable tCanonical
+	put tRoot & BuildPath(tElements) into tCanonical
+
+	if pPath ends with kSeparator and \
+			not tCanonical ends with kSeparator then
+		put kSeparator after pPath
+	end if
+
+	return tCanonical
+end handler
+
+-- FIXME there should be version of this function that takes a
+-- specific directory against which to resolve pArgument if it's a
+-- relative directory.
+public handler MCFileEvalCommandArgumentParsedAsFile(in pArgument as String, \
+		out rFile as String)
+
+	-- Translate separator characters on Windows
+	-- FIXME prune out illegal characters on all OSes
+	if the operating system is "win" then
+		-- Translate separators
+		replace "\\" with "/" in pArgument
+	end if
+
+	-- Make the path canonical
+	put CanonicalizePath(pArgument) into rFile
+end handler
+
+end module

--- a/libscript/src/file.lcb
+++ b/libscript/src/file.lcb
@@ -48,6 +48,24 @@ end syntax
 
 --
 
+public foreign handler MCFileEvalCurrentDirectory(out Directory as String) returns nothing binds to "<builtin>"
+
+/*
+Summary:	The current working directory.
+
+Description:
+The current working directory of the LiveCode process.
+
+Tags: System, Filesystem
+*/
+syntax CurrentDirectory is expression
+	"the" "current" "directory"
+begin
+	MCFileEvalCurrentDirectory(output)
+end syntax
+
+--
+
 public foreign handler MCFileExecDeleteFile(in File as String) returns nothing binds to "<builtin>"
 
 /*

--- a/libscript/src/file.lcb
+++ b/libscript/src/file.lcb
@@ -140,4 +140,44 @@ end syntax
 
 --
 
+public foreign handler MCFileEvalCommandArgumentParsedAsFile(in Argument as String, out File as String) returns nothing binds to "lcb:com.livecode.file.__IMPL.MCFileEvalCommandArgumentParsedAsFile"
+
+/**
+Summary:	Convert a command-line argument into a file path
+
+Argument:	A command-line argument
+
+Example:
+	-- Get a list of files to process from the command line
+	variable tFiles
+	variable tFile
+	variable tArgument
+	put [] into tFiles
+	repeat for each element tArgument in the command arguments
+		put command argument tArgument parsed as file into tFile
+		push tFile onto back of tFiles
+	end repeat
+
+Description:
+Converts the command-line <Argument> to an absolute filename in
+LiveCode's internal filename representation.
+
+This transformation is specifically designed for handling paths
+provided in the command-line arguments pased to the program.
+
+**Warning:** The processing performed by this expression assumes that
+the <CurrentDirectory | current working directory> has not changed
+since the program was started.  If the current directory has been
+changed, then the results may be incorrect.
+
+References: CommandArguments(expression), CurrentDirectory(expression)
+
+Tags: Filesystem, System
+*/
+syntax CommandArgumentParsedAsFile is expression
+	"command" "argument" <Argument: Expression> "parsed" "as" "file"
+begin
+	MCFileEvalCommandArgumentParsedAsFile(Argument, output)
+end syntax
+
 end module

--- a/libscript/src/module-file.cpp
+++ b/libscript/src/module-file.cpp
@@ -36,6 +36,14 @@ MCFileExecSetContents (MCDataRef p_contents, MCStringRef p_path)
 ////////////////////////////////////////////////////////////////////////////////
 
 extern "C" MC_DLLEXPORT_DEF void
+MCFileEvalCurrentDirectory (MCStringRef & r_path)
+{
+	/* UNCHECKED */ MCSFileGetCurrentDirectory (r_path);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+extern "C" MC_DLLEXPORT_DEF void
 MCFileExecDeleteFile (MCStringRef p_path)
 {
 	/* UNCHECKED */ MCSFileDelete (p_path);

--- a/libscript/src/module-file_IMPL.cpp
+++ b/libscript/src/module-file_IMPL.cpp
@@ -1,0 +1,29 @@
+/*                                                                     -*-c++-*-
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+////////////////////////////////////////////////////////////////////////////////
+
+extern "C" bool com_livecode_file___IMPL_Initialize (void)
+{
+	return true;
+}
+
+extern "C" void com_livecode_file___IMPL_Finalize (void)
+{
+}
+
+////////////////////////////////////////////////////////////////

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -557,7 +557,11 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
 	/* If the module is already marked as being checked for usability,
 	 * then there must be a cyclic module dependency. */
 	if (self -> is_in_usable_check)
-		return MCErrorThrowGeneric(MCSTR("cyclic module dependency"));
+	{
+		return MCErrorThrowGenericWithMessage(MCSTR("%{name} not usable - cyclic module dependency"),
+		                                      "name", self -> name,
+		                                      nil);
+	}
     
 	self -> is_in_usable_check = true;
     

--- a/libscript/src/system.lcb
+++ b/libscript/src/system.lcb
@@ -146,10 +146,11 @@ Some arguments may not be passed in if they are "used up" by the
 LiveCode run-time environment (for example, the LiveCode IDE will
 detect and "use" the `-mmap` argument).
 
-> **Note:** No filename conversion is performed on command line
-> arguments, so some processing may be required before using a command
-> line argument with any of the file handling syntax provided by the
-> `com.livecode.file` module.
+**Note:** No filename conversion is performed on command-line
+arguments.  Command-line arguments that should be interpreted as
+filenames should <CommandArguments | specially processed>.
+
+Tags: System
 */
 syntax CommandArguments is expression
 	"the" "command" "arguments"

--- a/libscript/src/system.lcb
+++ b/libscript/src/system.lcb
@@ -125,22 +125,20 @@ begin
 	MCSystemExecGetCommandName(output)
 end syntax
 
-/*
+/**
 Summary:	The command arguments
 
 Example:
-	-- Program that only succeeds if it's run as the "true"
-	-- command.
-	variable tCommand as String
-	put the command name into tCommand
-	if tCommand ends with "true" then
-		quit with status 0
-	else
-		quit with status 1
+
+	-- Program that only succeeds if the first argument is "--success"
+	if the command arguments is not empty then
+		if the first element of the command arguments is "--success" then
+			quit with status 0
+		end if
 	end if
+	quit with status 1
 
 Description:
-
 Evaluates to a list of command-line arguments passed to the program.
 Some arguments may not be passed in if they are "used up" by the
 LiveCode run-time environment (for example, the LiveCode IDE will

--- a/libscript/stdscript-sources.gypi
+++ b/libscript/stdscript-sources.gypi
@@ -35,6 +35,7 @@
 		
 		'stdscript_other_lcb_files':
 		[
+			'src/file-impl.lcb',
 			'src/unittest-impl.lcb',
 		],
 		
@@ -64,6 +65,7 @@
 			'src/module-type.cpp',
 			'src/module-unittest.cpp',
 			'src/module-unittest_IMPL.cpp',
+			'src/module-file_IMPL.cpp',
 			'src/module-url.cpp',
 		],
 	},

--- a/tests/lcb/stdlib/file.lcb
+++ b/tests/lcb/stdlib/file.lcb
@@ -1,0 +1,60 @@
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.file.tests
+
+use com.livecode.__INTERNAL._testlib
+
+public handler TestCommandArgumentParsedAsFile()
+
+	plan 5 tests
+
+	test "/./ removal" when command argument "/foo/./bar" parsed as file is "/foo/bar"
+	test "/../ removal" when command argument "/foo/../bar" parsed as file is "/bar"
+	test "// removal" when command argument "/foo//bar" parsed as file is "/foo/bar"
+
+	test "leading // preservation" when command argument "//foo/bar" parsed as file is "//foo/bar"
+
+	test "leading /../ removal" when command argument "/../foo/bar" parsed as file is "/foo/bar"
+
+	---------- Non-Windows tests
+	plan 2 tests
+
+	if the operating system is not "win" then
+		test "leading /// removal" when command argument "///foo/bar" parsed as file is "/foo/bar"
+		test "\\ preservation" when command argument "/foo\\bar" parsed as file is "/foo\\bar"
+	else
+		skip test "leading /// removal" because "non-Windows only"
+		skip test "\\ preservation" because "non-Windows only"
+	end if
+
+	---------- Windows tests
+	plan 3 tests
+
+	if the operating system is "win" then
+		test "\\ conversion" when command argument "\\foo\\bar" parsed as file is "/foo/bar"
+		test "UNC preservation" when command argument "\\\\foo\\bar" parsed as file is "//foo/bar"
+		test "UNC \\..\\ preservation" when command argument "\\\\foo\\..\\bar" parsed as file is "//foo/bar"
+	else
+		skip test "\\ conversion" because "Windows only"
+		skip test "UNC preservation" because "Windows only"
+		skip test "UNC \\..\\ preservation" because "Windows only"
+	end if
+
+end handler
+
+end module


### PR DESCRIPTION
When using lc-run on Windows, there's the problem of correctly converting a command argument string that should be a filename into a correct LiveCode-style file path, so that it can be passed to the com.livecode.file APIs.  At the moment, lc-run itself isn't quite right, because it only accepts LiveCode-style paths as arguments (and this is quite awkward for things like "getting the testsuite working").

This change set adds:
- `the current directory`, a statement that evaluates to the current working directory
- `command argument _ parsed as file`, which performs processing steps on its argument to convert it to a canonical LiveCode-style file path string

I've prototyped it in LCB, but once the behaviour is pinned down I want to translate it to C++ in libfoundation-system so that lc-run can use it during startup.

I'm not sure this is totally correct at the moment, because:
- `command argument element 1 of the command arguments parsed as file` is totally unambiguous, quite useful, and horrifically ugly
- arguably there should be an optional argument to the syntax that specifies the path to be treated as "current" for the purposes of parsing

Feedback very welcome!
