### PR TITLE
Fill selection color when alternate backgrounds is off

### DIFF
--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -536,9 +536,9 @@ private handler paintDataItem(in pDataItem as Array, in pTop as Real, in pRow as
 		
 	variable tPath as Path	
 	// Draw the alternating row backgrounds if applicable
-	if mAlternateRowBackgrounds is true then
+	if mAlternateRowBackgrounds is true or pDataItem["selected"] is true then
 		put rectangle path of rectangle [0,pTop,mViewWidth,pTop+mRowHeight] into tPath
-		if pRow mod 2 is 1 then
+		if pRow mod 2 is 1 or pDataItem["selected"] is true then
 			set the paint of this canvas to getPaint("row","fill" & tStyle)
 		else
 			set the paint of this canvas to getPaint("row","fill_alternate" & tStyle)


### PR DESCRIPTION
The selection color was only being filled when alternate backgrounds
were on which meant the line was going all white because the text was
still changing.
