### PR TITLE
[Bug 16465] libgraphics: Correct scaling for arcs.

### DIFF
--- a/docs/lcb/notes/16465.md
+++ b/docs/lcb/notes/16465.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Host Library
+
+# [16465] Arc radii treated as diameter

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -3380,7 +3380,7 @@ void MCCanvasPathMakeWithEllipse(MCCanvasPointRef p_center, MCCanvasFloat p_radi
 	if (!MCGPathCreateMutable(t_path))
 		return;
 	
-	MCGPathAddEllipse(t_path, *MCCanvasPointGet(p_center), MCGSizeMake(2*p_radius_x, 2*p_radius_y), 0);
+	MCGPathAddEllipse(t_path, *MCCanvasPointGet(p_center), MCGSizeMake(p_radius_x, p_radius_y), 0);
 	if (MCGPathIsValid(t_path))
 		MCCanvasPathMakeWithMCGPath(t_path, r_path);
 	

--- a/libgraphics/src/path.cpp
+++ b/libgraphics/src/path.cpp
@@ -457,8 +457,8 @@ void MCGPathAddEllipse(MCGPathRef self, MCGPoint p_center, MCGSize p_radii, MCGF
 		{
 			// Use Skia implementation
 			SkRect t_bounds;
-			t_bounds = SkRect::MakeXYWH(MCGCoordToSkCoord(p_center . x - (p_radii . width * 0.5f)), MCGCoordToSkCoord(p_center . y - (p_radii . height * 0.5f)),
-										MCGFloatToSkScalar(p_radii . width), MCGFloatToSkScalar(p_radii . height));
+			t_bounds = SkRect::MakeXYWH(MCGCoordToSkCoord(p_center . x - p_radii . width), MCGCoordToSkCoord(p_center . y - p_radii . height),
+										MCGFloatToSkScalar(p_radii . width * 2), MCGFloatToSkScalar(p_radii . height * 2));
 			self -> path -> addOval(t_bounds);
 		}
 	}

--- a/libgraphics/src/path.cpp
+++ b/libgraphics/src/path.cpp
@@ -488,8 +488,8 @@ void MCGPathAddArc(MCGPathRef self, MCGPoint p_center, MCGSize p_radii, MCGFloat
 		{
 			// Use Skia implementation
 			SkRect t_bounds;
-			t_bounds = SkRect::MakeXYWH(MCGCoordToSkCoord(p_center . x - (p_radii . width * 0.5f)), MCGCoordToSkCoord(p_center . y - (p_radii . height * 0.5f)),
-										MCGFloatToSkScalar(p_radii . width), MCGFloatToSkScalar(p_radii . height));
+			t_bounds = SkRect::MakeXYWH(MCGCoordToSkCoord(p_center . x - p_radii . width), MCGCoordToSkCoord(p_center . y - p_radii . height),
+			                            MCGFloatToSkScalar(p_radii . width * 2), MCGFloatToSkScalar(p_radii . height * 2));
 			self -> path -> addArc(t_bounds, MCGFloatToSkScalar(p_start_angle), MCGFloatToSkScalar(p_finish_angle - p_start_angle));
 		}
 	}


### PR DESCRIPTION
The radius argument was being treated as a diameter, causing arc,
segments and sector paths to be half the size they should be.
