### PR TITLE
Fix fetching OSX raw clipboard items using Pboard or OSType types

### DIFF
--- a/docs/notes/bugfix-16458.md
+++ b/docs/notes/bugfix-16458.md
@@ -1,0 +1,2 @@
+# Fix fetching data from the OSX raw clipboard that is identified by a Pboard type or OSType
+

--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -630,6 +630,8 @@ MCDataRef MCMacRawClipboardItemRep::CopyData() const
         // Get the data for this type
         NSData* t_bytes = [m_item dataForType:(NSString*)t_type];
         CFRelease(t_type);
+        if (t_bytes == nil)
+            return NULL;
         
         // Convert the data to a DataRef
         MCDataRef t_data;

--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -295,7 +295,7 @@ MCStringRef MCMacRawClipboard::CopyAsUTI(MCStringRef p_key)
         CFRelease(t_class);
         return NULL;
     }
-    CFStringRef t_uti = UTTypeCreatePreferredIdentifierForTag(t_class, t_tag, NULL);
+    CFStringRef t_uti = UTTypeCreatePreferredIdentifierForTag(t_class, t_tag, kUTTypeData);
     CFRelease(t_class);
     CFRelease(t_tag);
     if (t_uti == NULL)

--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -618,9 +618,13 @@ MCDataRef MCMacRawClipboardItemRep::CopyData() const
         if (*t_type_string == NULL)
             return NULL;
         
+        // Convert the type string to a UTI
+        MCAutoStringRef t_uti;
+        t_uti.Give(MCMacRawClipboard::CopyAsUTI(*t_type_string));
+        
         // Convert from a StringRef to a CFString
         CFStringRef t_type;
-        if (!MCStringConvertToCFStringRef(*t_type_string, t_type))
+        if (!MCStringConvertToCFStringRef(*t_uti, t_type))
             return NULL;
         
         // Get the data for this type


### PR DESCRIPTION
There were a few small issues lurking here that combined into one larger one that failed silently.
