### PR TITLE
[[ Bug 16474 ]] Make odd numbers of dashes work properly

### DIFF
--- a/docs/notes/bugfix-16474.md
+++ b/docs/notes/bugfix-16474.md
@@ -1,0 +1,4 @@
+# Make odd numbers of dashes work properly.
+
+If the dashes property of a graphic was set to an odd number
+of items, then the pattern would not replicate correctly.

--- a/libgraphics/src/utils.cpp
+++ b/libgraphics/src/utils.cpp
@@ -291,7 +291,7 @@ bool MCGDashesToSkDashPathEffect(MCGDashesRef self, SkDashPathEffect*& r_path_ef
         
 	SkScalar *t_dashes;
 	if (t_success)
-		t_success = MCMemoryNewArray(self -> count, t_dashes);
+		t_success = MCMemoryNewArray(t_dash_count, t_dashes);
 	
 	SkDashPathEffect *t_dash_effect;
 	t_dash_effect = NULL;

--- a/libgraphics/src/utils.cpp
+++ b/libgraphics/src/utils.cpp
@@ -284,6 +284,11 @@ bool MCGDashesToSkDashPathEffect(MCGDashesRef self, SkDashPathEffect*& r_path_ef
 	bool t_success;
 	t_success = true;
 	
+    // Skia won't except odd numbers of dashes, so we must replicate in that case.
+    uint32_t t_dash_count;
+    if (t_success)
+        t_dash_count = (self -> count % 2) == 0 ? self -> count : self -> count * 2;
+        
 	SkScalar *t_dashes;
 	if (t_success)
 		t_success = MCMemoryNewArray(self -> count, t_dashes);
@@ -292,10 +297,10 @@ bool MCGDashesToSkDashPathEffect(MCGDashesRef self, SkDashPathEffect*& r_path_ef
 	t_dash_effect = NULL;
 	if (t_success)
 	{
-		for (uint32_t i = 0; i < self -> count; i++)
-			t_dashes[i] = MCGFloatToSkScalar(self -> lengths[i]);	
+		for (uint32_t i = 0; i < t_dash_count; i++)
+			t_dashes[i] = MCGFloatToSkScalar(self -> lengths[i % self -> count]);
 	
-		t_dash_effect = new SkDashPathEffect(t_dashes, self -> count, MCGFloatToSkScalar(self -> phase));
+		t_dash_effect = new SkDashPathEffect(t_dashes, (int)t_dash_count, MCGFloatToSkScalar(self -> phase));
 		t_success = t_dash_effect != NULL;
 	}
 	


### PR DESCRIPTION
Skia does not accept odd numbers of dashes in its path effects and
causes an assertion failure in debug mode in that case.

This has been fixed by ensuring that odd numbers of dashes set a
repeated pattern. i.e. 1,2,3 => 1,2,3,1,2,3.
