### PR TITLE
[Bug 16456] com.livecode.arithmetic: Improve number->string format

### DIFF
--- a/docs/lcb/notes/14546.md
+++ b/docs/lcb/notes/14546.md
@@ -1,0 +1,5 @@
+# LiveCode Builder Standard Library
+
+## Mathematical functions
+
+# [14546] Improve formatting integers as string

--- a/libscript/src/module-arithmetic.cpp
+++ b/libscript/src/module-arithmetic.cpp
@@ -452,7 +452,21 @@ extern "C" MC_DLLEXPORT_DEF void MCArithmeticEvalNotEqualToNumber(MCNumberRef p_
 extern "C" MC_DLLEXPORT_DEF MCStringRef MCArithmeticExecFormatNumberAsString(MCNumberRef p_operand)
 {
     MCAutoStringRef t_output;
-    MCStringFormat(&t_output, "%f", MCNumberFetchAsReal(p_operand));
+	if (MCNumberIsInteger(p_operand))
+	{
+		if (!MCStringFormat(&t_output, "%i", MCNumberFetchAsInteger(p_operand)))
+		{
+			return nil;
+		}
+	}
+	else
+	{
+		if (!MCStringFormat(&t_output, "%g", MCNumberFetchAsReal(p_operand)))
+		{
+			return nil;
+		}
+	}
+
     return MCValueRetain(*t_output);
 }
 

--- a/tests/lcb/stdlib/arithmetic.lcb
+++ b/tests/lcb/stdlib/arithmetic.lcb
@@ -173,14 +173,9 @@ public handler TestLessThanEqual()
 end handler
 
 public handler TestFormatString()
-	test diagnostic "TODO -1 formatted as string (bug 14594)"
-	broken test "format as string (int)" when (-1) formatted as string is "-1" because "bug 14546"
+	test "format as string (int)" when (-1) formatted as string is "-1"
 
-	variable tNum
-	put (-1.0) formatted as string into tNum
-	test diagnostic "TODO test full string, not just prefix"
-	test diagnostic tNum
-	test "format as string (real)" when tNum begins with "-1."
+	test "format as string (real)" when (-1.1) formatted as string is "-1.1"
 end handler
 
 public handler TestParseString()


### PR DESCRIPTION
Improve the `_ formatted as string` format for number types, by using
the `%i` format operation when the number _can_ be an integer and the
`%g` operator otherwise.
