### PR TITLE
[[ Builder ]] Output the release notes in the working folder

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -168,7 +168,7 @@ dist-upload-files.txt sha1sum.txt:
 	                -o -name '*-bin.tar.xz' \
 	  > dist-upload-files.txt; \
 	if test "${UPLOAD_RELEASE_NOTES}" = "yes"; then \
-		find "_build/notes" -name 'LiveCodeNotes*.pdf' >> dist-upload-files.txt; \
+		find . -maxdepth 1 -name 'LiveCodeNotes*.pdf' >> dist-upload-files.txt; \
 	fi; \
 	if test "$(UPLOAD_ENABLE_CHECKSUM)" = "yes"; then \
 	  $(SHA1SUM) < dist-upload-files.txt > sha1sum.txt; \

--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -70,7 +70,7 @@ on builderBuild pWhich, pPlatforms, pEdition, pType
          end repeat
          break
       case "Notes"
-         dispatch "releaseNotesBuilderRun" to stack builderNotesBuilderStack() with pEdition, tVersion
+         dispatch "releaseNotesBuilderRun" to stack builderNotesBuilderStack() with pEdition, tVersion, pType, builderOutputFolder()
          break
       case "Docs"
          dispatch "docsBuilderRun" to stack builderDocsBuilderStack() with pEdition, tVersion

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -50,7 +50,7 @@ command releaseNotesBuilderFinalize
    stop using stack (builderSystemFolder() & slash & "markdown_compiler.livecodescript")
 end releaseNotesBuilderFinalize
 
-command releaseNotesBuilderRun pEdition, pVersion, pReleaseType
+command releaseNotesBuilderRun pEdition, pVersion, pReleaseType, pOutputDir
    builderLog "report", "Building release notes for version" && pVersion
    
    releaseNotesBuilderInitialize
@@ -138,8 +138,14 @@ command releaseNotesBuilderRun pEdition, pVersion, pReleaseType
    
    local tNotesFileURL
    local tNotesFile
-   builderEnsureFolder  builderRepoFolder() & slash & targetPath()
-   put builderRepoFolder() & slash & targetPath() & slash & "LiveCodeNotes-" & replaceText(pVersion, "[-,\.]", "_") into tNotesFile
+   local tOutputDir
+   if pOutputDir is empty then
+      put builderRepoFolder() & slash & targetPath() into tOutputDir
+   else
+      put pOutputDir into tOutputDir
+   end if
+   builderEnsureFolder tOutputDir
+   put tOutputDir & slash & "LiveCodeNotes-" & replaceText(pVersion, "[-,\.]", "_") into tNotesFile
    put "file:" & tNotesFile & ".html" into tNotesFileURL
    
    local tNotesPrefix


### PR DESCRIPTION
So that the release notes will be uploaded at the same level as the installers on the server, not
in a _build/notes folder
