### PR TITLE
Remove a debugging line that was accidentally added to bugfix-16460

### DIFF
--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -630,8 +630,6 @@ MCDataRef MCMacRawClipboardItemRep::CopyData() const
         // Get the data for this type
         NSData* t_bytes = [m_item dataForType:(NSString*)t_type];
         CFRelease(t_type);
-        if (t_bytes == nil)
-            return NULL;
         
         // Convert the data to a DataRef
         MCDataRef t_data;


### PR DESCRIPTION
Line was an extra-paranoid check to make it easy to break into the
debugger when an error occurred.
