### PR TITLE
[Bug 14593] com.livecode.arithmetic: Improve tests for mod operator

### DIFF
--- a/tests/lcb/stdlib/arithmetic.lcb
+++ b/tests/lcb/stdlib/arithmetic.lcb
@@ -110,7 +110,7 @@ public handler TestDivide()
 	test "divide (operator, int)" when 30 / tInt = 6
 
 	divide tInt by 2
-	test diagnostic "Expecting floor"
+	test diagnostic "Expecting trunc"
 	broken test "divide (syntax, int)" when tInt = 2 because "bug 14592"
 
 	variable tReal as Real
@@ -126,11 +126,46 @@ public handler TestDivide()
 	test "divide (operator, number)" when tNumber / 8 = 2.5
 end handler
 
-public handler TestMod()
-	test "mod (+ve, +ve)" when 10 mod 3 = 1
-	broken test "mod (-ve, +ve)" when -10 mod 3 = 2 because "bug 14593"
-	broken test "mod (+ve, -ve)" when 10 mod -3 = -2 because "bug 14593"
-	test "mod (-ve, -ve)" when -10 mod -3 = -1
+private handler ModInvariantDiagnostic(in pX, in pY, in pZ, in pR)
+	test diagnostic pX formatted as string && "mod" && pY formatted as string
+	test diagnostic pY formatted as string && "*" && \
+		pZ formatted as string && "+" && \
+		pR formatted as string && "=" && \
+		(pY * pZ + pR) formatted as string
+end handler
+
+private handler ModInvariantInteger(in pX as Integer, in pY as Integer) \
+		returns Boolean
+	variable tZ as Integer
+	variable tR as Integer
+	put (pX / pY) into tZ
+	put (pX mod pY) into tR
+
+	ModInvariantDiagnostic(pX, pY, tZ, tR)
+	return (pY * tZ + tR) is pX
+end handler
+
+private handler ModInvariantReal(in pX as Real, in pY as Real) \
+		returns Boolean
+	variable tZ as Real
+	variable tR as Real
+	put the trunc of (pX / pY) into tZ -- because there is no "div" operator
+	put (pX mod pY) into tR
+
+	ModInvariantDiagnostic(pX, pY, tZ, tR)
+	return (pY * tZ + tR) is pX
+end handler
+
+public handler TestModInteger()
+	broken test "mod int (+ve, +ve)" when ModInvariantInteger(10, 3) because "bug 14592"
+	broken test "mod (-ve, +ve)" when ModInvariantInteger(-10, 3) because "bug 14592"
+	broken test "mod int (+ve, -ve)" when ModInvariantInteger(10, -3) because "bug 14592"
+	broken test "mod int (-ve, -ve)" when ModInvariantInteger(-10, -3) because "bug 14592"
+
+	test "mod real (+ve, +ve)" when ModInvariantReal(16, 3.75)
+	test "mod real (-ve, +ve)" when ModInvariantReal(-16, 3.75) 
+	test "mod real (+ve, -ve)" when ModInvariantReal(16, -3.75)
+	test "mod real (-ve, -ve)" when ModInvariantReal(-16, -3.75)
 end handler
 
 public handler TestWrap()


### PR DESCRIPTION
Test the invariant that the "mod" operator is supposed to conform to
directly.  For an operation:

  x mod y

The following must hold:

  z = x div y = trunc(x / y)
  r = x mod y
  y*z + r = x
