### PR TITLE
[[ Bug 16500 ]] Arrays are not ascii strings

### DIFF
--- a/docs/notes/bugfix-16500.md
+++ b/docs/notes/bugfix-16500.md
@@ -1,0 +1,1 @@
+# Arrays are ASCII string

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -2129,6 +2129,14 @@ void MCStringsExecFilterRegexIntoIt(MCExecContext& ctxt, MCStringRef p_source, M
 
 void MCStringsEvalIsAscii(MCExecContext& ctxt, MCValueRef p_value, bool& r_result)
 {
+    // SN-2015-11-26: [[ Bug 16500 ]] Arrays will successfully convert to an
+    // empty string, which is a valid ASCII string. Cut short in this case
+    if (MCValueIsArray(p_value))
+    {
+        r_result = false;
+        return;
+    }
+
     MCAutoStringRef t_string;
 	if (!ctxt . ConvertToString(p_value, &t_string))
     {


### PR DESCRIPTION
This was caused by the fact array are converted into an empty string, internally - and an empty string is a valid C-string
