### PR TITLE
[Bug 15970] Change mechanism for saving in specific stack file formats

### DIFF
--- a/docs/dictionary/command/save.lcdoc
+++ b/docs/dictionary/command/save.lcdoc
@@ -2,20 +2,20 @@ Name: save
 
 Type: command
 
-Syntax: save <stack> [as <filePath>]
+Syntax: save <stack> [as <filePath>] [with format <stackFormat> | with newest format]
 
 Summary: Saves a <stack file> on the user's system.
 
 Introduced: 1.0
 
-OS: mac,windows,linux,ios,android
+OS: mac,windows,linux,ios,android,html5
 
 Platforms: desktop,web,mobile
 
 Security: disk
 
 Example:
-save stack "project1"
+save stack "project1" with newest format
 
 Example:
 save this stack as "Backup"
@@ -23,21 +23,35 @@ save this stack as "Backup"
 Example:
 save stack "project1" as "/Disk/Folder/File"
 
+Example:
+save stack "MyOldApp" with format 7.0
+
 Parameters:
 stack: Any open stack.
-filePath: The filePath specifies the name and location of the file you want to save to. If you specify a name but not a location, LiveCode assumes the file is in the defaultFolder. If the file does not exist, LiveCode creates it.
 
-The result: If the stack cannot be saved (for example, if you try to save it to a nonexistent drive or to a CD-ROM), the result <function> is set to "Can't open stack file".
+filePath: The <filePath> specifies the name and location of the file you want to save to. If you specify a name but not a location, LiveCode assumes the file is in the <defaultFolder>. If the file does not exist, LiveCode creates it.
+
+stackFormat: The <stack version|stack file format version> to use when saving.
+
+The result: If the stack cannot be saved (for example, if you try to save it to a nonexistent drive or to a CD-ROM), the <result> will contain an error message.  Otherwise, the <result> will be empty.
 
 Description:
 Use the <save> <command> to save changes to a <stack> or to save a copy of a <stack> into another <file>.
 
 The <save> <command> saves all <stacks> stored in the same <file> as the specified <stack>. That is, if you save a <main stack>, all <substacks> of that stack are also saved in the same <file>, and if you save a <substack>, its <main stack> and any other <substacks> are also saved.
 
-If the stack has not yet been saved and doesn't have a filename, you must use theform.
+If the stack has not yet been saved and doesn't have a filename, you must use the `as` form.
 
 You cannot save to a standalone application's file; <standalone application|standalones> are read-only.
 
-References: stackFileVersion (property), substacks (property), stack (object), as (keyword), file (keyword), substack (glossary), stack file (glossary), command (glossary), standalone application (glossary), main stack (glossary), stacks (function), create stack (command), function (control_st)
+The <save> command can save the <stack> in several different versions of the LiveCode stack file format.
+
+* If you use the `with newest format` form of the <save> command, the <stack> is saved using the newest <stack version>
+* If you use the `with format` form of the <save> command, the <stackFormat> should be the particular <stack version> you want the stack to be saved as.
+* If you do not specify a format to use, the current value of the <stackFileFormat> property is used.
+
+**Warning:** If you save in an older <stack version> that doesn't support all of the features used in the stack, then some of contents of the stack may be lost.  In general, you are recommended to use the `with newest format` form of the <save> command.
+
+References: substacks (property), stack (object), as (keyword), file (keyword), substack (glossary), stack file (glossary), command (glossary), standalone application (glossary), main stack (glossary), stacks (function), create stack (command), function (control_st), stack version (glossary), defaultFolder (property), stackFileFormat (property)
 
 Tags: file system

--- a/docs/dictionary/object/stack.lcdoc
+++ b/docs/dictionary/object/stack.lcdoc
@@ -31,6 +31,6 @@ Stacks contain one or more cards, and may optionally contain backgrounds.
 
 The stack object has a number of properties and messages associated with it. To see a list of messages that can be sent to a stack as a result of user actions or internal LiveCode events, open the "LiveCode Language Dictionary" page of the main Documentation window, ensure that the stack column is visible and use sort and filter to bring the relevant entries to the top
 
-References: templateStack (keyword), mode (property), stackFileVersion (property), defaultStack (property), style (property), topLevel (command), go (command), modal (command), palette (command), modeless (command), revLoadedStacks (function), mouseStack (function), stack (object), object (object), property (glossary), dialog box (glossary), command (glossary), object type (glossary)
+References: templateStack (keyword), mode (property), stack version (glossary), defaultStack (property), style (property), topLevel (command), go (command), modal (command), palette (command), modeless (command), revLoadedStacks (function), mouseStack (function), stack (object), object (object), property (glossary), dialog box (glossary), command (glossary), object type (glossary)
 
 Tags: objects

--- a/docs/dictionary/property/stackFileVersion.lcdoc
+++ b/docs/dictionary/property/stackFileVersion.lcdoc
@@ -6,74 +6,29 @@ Syntax: set the stackFileVersion to <version>
 
 Syntax: the stackFileVersion
 
-Summary: Reports the version of the stack file format to use.
+Summary: The version of the stack file format to use when saving stacks
 
 Introduced: 2.7
 
-OS: mac,windows,linux,ios,android
+OS: mac,windows,linux,ios,android,html5
 
 Platforms: desktop,server,web,mobile
 
-Example:
-command legacySave pStack
-  local
-tOldStackFileVersion
-  put the stackFileVersion into
-tOldStackFileVersion
-  set the stackFileVersion to 2.4
-  save
-stack pStack
-  set the stackFileVersion to
-OldStackFileVersion
-end legacySave
-
 Value:
-The <stackFileVersion> currently has two possible values:
-  - "2.4" - This stack file version is used by LiveCode 2.6.1 and arlier
-  - "2.7" - This stack file version is used by versions of LiveCode after 2.6.1 and before 5.5.0.
-  - "5.5" - This stack file version is used by versions of LiveCode after 5.5.0 and before .0.
-  - "7.0" - This stack file version is used by versions of LiveCode 7.0. and after.
+The name of a <stack version>.
 
 Description:
-Use the <stackFileVersion> to obtain or change which version of the stack file format LiveCode will use when saving stacks.
+**Note**: The <stackFileVersion> is deprecated.  Instead, please specify the <stack version> directly, as an optional parameter of the <save> <command>.
 
-The <stackFileVersion> is useful when stacks need to be saved in legacy formats for backwards compatibility but it should be used with caution.
+Use the <stackFileVersion> to obtain or change the default stack file format version LiveCode uses when saving stacks.
 
-Setting the <stackFileVersion> to something less than the current version could result in data being lost when stacks are saved, in particular any features that are not present in the target version. For example setting the <stackFileVersion> to 2.4 will cause any blendLevel or ink properties to be lost.
+Setting the <stackFileVersion> to something less than the newest <stack version> could result in data being lost when stacks are saved.  For example, setting the <stackFileVersion> to 7.0 will cause any widgets in the stack to be lost, along with their scripts and properties.
 
 Remember to set the <stackFileVersion> back to its previous value after changing it, otherwise LiveCode may save your stacks in unexpected formats.
 
-There is no need to use the <stackFileVersion> to save a stack compatible with version 2.6.1 and earlier in the IDE. Instead, open the stack in the current version of LiveCode and select "Save As" from the "File" menu, then choose "Legacy LiveCode Stack" from the drop down box for the file type. If you do not wish to do this every time, there is a setting in the "Files  Memory" section of the preferences that causes LiveCode to preserve the stack file version of legacy stacks.
+There is no need to use the <stackFileVersion> when saving a stack using the IDE.  Instead, open the stack in the current version of LiveCode and select "Save As" from the "File" menu, then choose "Legacy LiveCode Stack" from the drop down box for the file type.  If you do not wish to do this every time, there is a setting in the "Files  Memory" section of the preferences that causes LiveCode to preserve the stack file version of legacy stacks.
 
-The following properties are not supported in the 2.4 stack file format and will be lost or altered when saving in 2.4 format:
+References: save (command), stack version (glossary)
 
-antialiased property - lost
-ink property - lost for cards, reverted to GXcopy for controls if not supported
-opaque property - lost for cards
-blendLevel property - lost
-
-The following properties are not supported in the 2.7 stack file format and will be lost or altered when saving in 2.7 format:
-
-textFont property - separation lost
-textStyle property - separation lost
-textSize property - separation lost
-textFont property - separation lost
-unicodeToolTip property - lost
-all paragraph level properties - lost
-separation of Unicode attribute of chars - lost
-character level metadata property - lost
-
-The following properties are not supported in the 2.7 stack file format and will be lost or altered when saving in 2.7 format:
-
-textFont property - separation lost
-textStyle property - separation lost
-textSize property - separation lost
-textFont property - separation lost
-unicodeToolTip property - lost
-all paragraph level properties - lost
-separation of Unicode attribute of chars - lost
-character level metadata property - lost
-
-When saving in the 5.5 format all Unicode text that does not have a Unicode variant in 5.5 will be lost, so field text and button labels etc will be saved but any Unicode text in scripts or custom properties will be lost.
-
-References: save (command)
+Changes:
+Deprecated from version 8.0.0.

--- a/docs/glossary/s/stack-version.lcdoc
+++ b/docs/glossary/s/stack-version.lcdoc
@@ -1,0 +1,42 @@
+Name: stack version
+
+Synonyms: stack format,stack file format,stack file version
+
+Type: glossary
+
+Description:
+
+When saving a <stack> using the <save> <command>, it is possible to save with a specific version of LiveCode's stack <file> format.  This is useful when saving a stack so that it can be saved in an older <version|version of LiveCode>, but it should be used with caution.
+
+**Warning:** Using a non-default <stack version> could result in data being lost when stacks are saved.  In particular, any features that are not present in the target version may be lost.  For example, using a <stack version> of "2.4" will cause any <blendLevel> or <ink> properties to be lost.
+
+These are the <stack version|stack file format versions> that can be used with the <save> command, and the versions of LiveCode that they are compatible with:
+
+* "8.0": (Default) LiveCode 8.0.0 and later
+* "7.0": LiveCode 7.0.0 up to LiveCode 8.0.0
+* "5.5": LiveCode 5.5.0 up to LiveCode 7.0
+* "2.7": LiveCode 2.6.1 up to LiveCode 5.5.0
+* "2.4": LiveCode older than 2.6.1
+
+When saving in the **7.0 format**, all <widget|widgets> will be lost.
+
+When saving in the **5.5 format**, all <Unicode> text will be lost unless it is stored in a container that has a Unicode variant.  For example, this means that Unicode text in <field|fields> and <button> labels will be saved, but any Unicode text in <script|scripts> or <custom properties> will be lost.
+
+When saving in the **2.7 format**, the following properties or property aspects will also be lost:
+
+* <textFont> property: separation lost
+* <textStyle> property: separation lost
+* <textSize> property: separation lost
+* <unicodeToolTip> property: lost
+* all paragraph level properties: lost
+* separation of Unicode attribute of chars: lost
+* character level metadata property: lost
+
+When saving in the **2.4 format**, the following properties will also be lost or altered:
+
+* <antialiased> property: lost
+* <ink> property: lost for <card|cards>, reverted to "GXcopy" for controls if not supported
+* <opaque> property: lost for cards
+* <blendLevel> property: lost
+
+References: stack file (glossary), stack (object), save (command), blendLevel (property), ink (property), Unicode (glossary), field (object), button (object), script (glossary), custom property (glossary), textFont (property), textStyle (property), textSize (property), unicodeToolTip (property), antialiased (property), opaque (property), card (object), widget (object), version (function)

--- a/docs/notes/bugfix-15970.md
+++ b/docs/notes/bugfix-15970.md
@@ -1,0 +1,11 @@
+# Improvements for saving in old stack file formats
+
+It is now possible to specify a version of the stack file format to be
+used when saving directly with the `save` command, by using the `save
+STACK with format VERSION` form of the command.
+
+You can request the latest supported file format using the `save STACK
+with newest format` form.
+
+The `stackFileVersion` global property is now deprecated, and should not be
+used in new stacks.

--- a/engine/src/MCBlock.h
+++ b/engine/src/MCBlock.h
@@ -88,7 +88,7 @@ public:
 	// MW-2012-03-04: [[ StackFile5500 ]] If 'is_ext' is true then this block has
 	//   an extension style attribute section.
 	IO_stat load(IO_handle stream, uint32_t version, bool is_ext);
-	IO_stat save(IO_handle stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, uint32_t p_version);
 
 	// MW-2012-02-14: [[ FontRefs ]] To open a block, we need the parent's fontref.
 	void open(MCFontRef parent_font);
@@ -146,7 +146,7 @@ public:
 	void importattrs(const MCFieldCharacterStyle& x_style);
 	
 	// MW-2012-03-04: [[ StackFile5500 ]] Measure the size of the serialized attributes.
-	uint32_t measureattrs(void);
+	uint32_t measureattrs(uint32_t p_version);
 
 #ifdef LEGACY_EXEC
 	void setatts(Properties which, void *value);

--- a/engine/src/aclip.cpp
+++ b/engine/src/aclip.cpp
@@ -913,9 +913,9 @@ bool MCAudioClip::isPlaying()
 //  SAVING AND LOADING
 //
 
-IO_stat MCAudioClip::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCAudioClip::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCAudioClip::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, uint4 p_length)
@@ -923,13 +923,13 @@ IO_stat MCAudioClip::extendedload(MCObjectInputStream& p_stream, uint32_t p_vers
 	return defaultextendedload(p_stream, p_version, p_length);
 }
 
-IO_stat MCAudioClip::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCAudioClip::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
 	if ((stat = IO_write_uint1(OT_AUDIO_CLIP, stream)) != IO_NORMAL)
 		return stat;
-	if ((stat = MCObject::save(stream, p_part, false)) != IO_NORMAL)
+	if ((stat = MCObject::save(stream, p_part, false, p_version)) != IO_NORMAL)
 		return stat;
 	if (osamples != NULL)
 	{
@@ -957,7 +957,7 @@ IO_stat MCAudioClip::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	if (flags & F_LOUDNESS)
 		if ((stat = IO_write_uint2(loudness, stream)) != IO_NORMAL)
 			return stat;
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 IO_stat MCAudioClip::load(IO_handle stream, uint32_t version)

--- a/engine/src/aclip.h
+++ b/engine/src/aclip.h
@@ -110,8 +110,8 @@ public:
     void stop(Boolean abort);
     bool isPlaying();
 
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+    IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+    IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
 

--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -332,14 +332,14 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	return IO_NORMAL;
 }
 
-IO_stat MCBlock::save(IO_handle stream, uint4 p_part)
+IO_stat MCBlock::save(IO_handle stream, uint4 p_part, uint32_t p_version)
 {
 	IO_stat stat;
 
 	// MW-2012-03-04: [[ StackFile5500 ]] If the block has metadata and 5.5 stackfile
 	//   format has been requested then this is an extended block.
 	bool t_is_ext;
-	if (MCstackfileversion >= 5500 && getflag(F_HAS_METADATA))
+	if (p_version >= 5500 && getflag(F_HAS_METADATA))
 		t_is_ext = true;
 	else
 		t_is_ext = false;
@@ -352,7 +352,7 @@ IO_stat MCBlock::save(IO_handle stream, uint4 p_part)
 	// MW-2012-03-04: [[ StackFile5500 ]] If this is an extended block then write out
 	//   the length of the attrs.
 	if (t_is_ext)
-		if ((stat = IO_write_uint2or4(measureattrs(), stream)) != IO_NORMAL)
+		if ((stat = IO_write_uint2or4(measureattrs(p_version), stream)) != IO_NORMAL)
 			return stat;
 
 	uint4 oldflags = flags;
@@ -368,7 +368,7 @@ IO_stat MCBlock::save(IO_handle stream, uint4 p_part)
 	
     // The "has unicode" flag depends on whether the paragraph is native
 	bool t_is_unicode;
-    if (MCstackfileversion < 7000 && MCStringIsNative(parent->GetInternalStringRef()))
+    if (p_version < 7000 && MCStringIsNative(parent->GetInternalStringRef()))
 	{
 		t_is_unicode = false;
         flags &= ~F_HAS_UNICODE;
@@ -380,7 +380,7 @@ IO_stat MCBlock::save(IO_handle stream, uint4 p_part)
 	}
 
     // SN-2014-12-04: [[ Bug 14149 ]] Add the F_HAS_TAB flag, for legacy saving
-    if (MCstackfileversion < 7000)
+    if (p_version < 7000)
     {
         if (segment && segment != segment -> next())
             flags |= F_HAS_TAB;
@@ -437,11 +437,11 @@ IO_stat MCBlock::save(IO_handle stream, uint4 p_part)
 	//   strings.
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
     if (flags & F_HAS_LINK)
-        if ((stat = IO_write_stringref_new(atts->linktext, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+        if ((stat = IO_write_stringref_new(atts->linktext, stream, p_version >= 7000)) != IO_NORMAL)
 			return stat;
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
     if (flags & F_HAS_IMAGE)
-        if ((stat = IO_write_stringref_new(atts->imagesource, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+        if ((stat = IO_write_stringref_new(atts->imagesource, stream, p_version >= 7000)) != IO_NORMAL)
 			return stat;
 	
 	// MW-2012-03-04: [[ StackFile5500 ]] If this is an extended block then emit the
@@ -450,7 +450,7 @@ IO_stat MCBlock::save(IO_handle stream, uint4 p_part)
 	{
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
         if (flags & F_HAS_METADATA)
-            if ((stat = IO_write_stringref_new(atts -> metadata, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+            if ((stat = IO_write_stringref_new(atts -> metadata, stream, p_version >= 7000)) != IO_NORMAL)
 				return stat;
 	}
 	
@@ -2245,13 +2245,13 @@ void MCBlock::importattrs(const MCFieldCharacterStyle& p_style)
 }
 
 // SN-2014-10-31: [[ Bug 13879 ]] Update the way the string is measured.
-uint32_t measure_stringref(MCStringRef p_string)
+uint32_t measure_stringref(MCStringRef p_string, uint32_t p_version)
 {
     MCStringEncoding t_encoding;
     uint32_t t_additional_bytes = 0;
     
 
-    if (MCstackfileversion < 7000)
+    if (p_version < 7000)
         t_encoding = kMCStringEncodingNative;
     else
         t_encoding = kMCStringEncodingUTF8;
@@ -2262,7 +2262,7 @@ uint32_t measure_stringref(MCStringRef p_string)
     uint32_t t_length;
     t_length = MCDataGetLength(*t_data);
     
-    if (MCstackfileversion < 7000)
+    if (p_version < 7000)
     {
         // Full string is written in 5.5 format:
         //  - length is written as a uint2
@@ -2283,14 +2283,14 @@ uint32_t measure_stringref(MCStringRef p_string)
 
 // MW-2012-03-04: [[ StackFile5500 ]] Utility routine for computing the length of
 //   a nameref when serialized to disk.
-uint32_t measure_nameref(MCNameRef p_name)
+uint32_t measure_nameref(MCNameRef p_name, uint32_t p_version)
 {
-	return measure_stringref(MCNameGetString(p_name));
+	return measure_stringref(MCNameGetString(p_name), p_version);
 }
 
 // MW-2012-03-04: [[ StackFile5500 ]] Compute the number of bytes the attributes will
 //   take up when serialized.
-uint32_t MCBlock::measureattrs(void)
+uint32_t MCBlock::measureattrs(uint32_t p_version)
 {
 	// If there are no attrs, then the size is 0.
 	if (!hasatts())
@@ -2315,11 +2315,11 @@ uint32_t MCBlock::measureattrs(void)
 	// MW-2012-05-04: [[ Values ]] linkText / imageSource / metaData are now uniqued
 	//   strings.
 	if ((flags & F_HAS_LINK) != 0)
-		t_size += measure_stringref(atts -> linktext);
+		t_size += measure_stringref(atts -> linktext, p_version);
 	if ((flags & F_HAS_IMAGE) != 0)
-		t_size += measure_stringref(atts -> imagesource);
+		t_size += measure_stringref(atts -> imagesource, p_version);
 	if ((flags & F_HAS_METADATA) != 0)
-		t_size += measure_stringref((MCStringRef)atts -> metadata);
+		t_size += measure_stringref((MCStringRef)atts -> metadata, p_version);
 
 	return t_size;
 }

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -4406,7 +4406,7 @@ void MCButton::trytochangetonative(void)
 
 #define BUTTON_EXTRA_ICONGRAVITY (1 << 0)
 
-IO_stat MCButton::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCButton::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
 	// Extended data area for a button consists of:
 	//   uint4 hover_icon;
@@ -4439,7 +4439,7 @@ IO_stat MCButton::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
         t_stat = p_stream . WriteU32(m_icon_gravity);
     
 	if (t_stat == IO_NORMAL)
-		t_stat = MCObject::extendedsave(p_stream, p_part);
+		t_stat = MCObject::extendedsave(p_stream, p_part, p_version);
 
 	return t_stat;
 }
@@ -4494,7 +4494,7 @@ IO_stat MCButton::extendedload(MCObjectInputStream& p_stream, uint32_t p_version
 	return t_stat;
 }
 
-IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 	
@@ -4519,7 +4519,8 @@ IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext)
     if (m_icon_gravity != kMCGravityNone)
         t_has_extension = true;
     
-	if ((stat = MCObject::save(stream, p_part, t_has_extension || p_force_ext)) != IO_NORMAL)
+	if ((stat = MCObject::save(stream, p_part, t_has_extension || p_force_ext,
+	                           p_version)) != IO_NORMAL)
 		return stat;
 
 	if (flags & F_HAS_ICONS)
@@ -4535,7 +4536,7 @@ IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext)
     //  we need to rely on the F_LABEL flag
     if (flags & F_LABEL)
 	{
-		if (MCstackfileversion < 7000)
+		if (p_version < 7000)
 		{
 			if ((stat = IO_write_stringref_legacy(label, stream, hasunicode())) != IO_NORMAL)
 				return stat;
@@ -4561,13 +4562,13 @@ IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 			return stat;
 	}
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-	if ((stat = IO_write_nameref_new(menuname, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+	if ((stat = IO_write_nameref_new(menuname, stream, p_version >= 7000)) != IO_NORMAL)
 		return stat;
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode; otherwise use
 	//   legacy unicode output.
     if (flags & F_MENU_STRING)
 	{
-		if (MCstackfileversion < 7000)
+		if (p_version < 7000)
 		{
 			if ((stat = IO_write_stringref_legacy(menustring, stream, hasunicode())) != IO_NORMAL)
 				return stat;
@@ -4596,7 +4597,7 @@ IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode; otherwise use
 	//   legacy unicode output.
-	if (MCstackfileversion < 7000)
+	if (p_version < 7000)
 	{
 		if ((stat = IO_write_stringref_legacy(acceltext, stream, hasunicode())) != IO_NORMAL)
 			return stat;
@@ -4614,7 +4615,7 @@ IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	if ((stat = IO_write_uint1(mnemonic, stream)) != IO_NORMAL)
 		return stat;
 
-	if ((stat = savepropsets(stream)) != IO_NORMAL)
+	if ((stat = savepropsets(stream, p_version)) != IO_NORMAL)
 		return stat;
 
 	MCCdata *tptr = bdata;
@@ -4622,7 +4623,7 @@ IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	{
 		do
 		{
-			if ((stat = tptr->save(stream, OT_BDATA, p_part)) != IO_NORMAL)
+			if ((stat = tptr->save(stream, OT_BDATA, p_part, p_version)) != IO_NORMAL)
 				return stat;
 			tptr = (MCCdata *)tptr->next();
 		}

--- a/engine/src/button.h
+++ b/engine/src/button.h
@@ -204,8 +204,8 @@ public:
 	virtual void unlockshape(MCObjectShape& shape);
 
 	// virtual functions from MCControl
-	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	virtual IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	virtual IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 	virtual IO_stat load(IO_handle stream, uint32_t version);
 	virtual IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
 

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -3368,9 +3368,9 @@ IO_stat MCCard::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, 
 	return defaultextendedload(p_stream, p_version, p_length);
 }
 
-IO_stat MCCard::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCCard::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCCard::load(IO_handle stream, uint32_t version)
@@ -3489,7 +3489,7 @@ IO_stat MCCard::loadobjects(IO_handle stream, uint32_t version)
 	return checkloadstat(stat);
 }
 
-IO_stat MCCard::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCCard::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
@@ -3501,7 +3501,7 @@ IO_stat MCCard::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 //---- 2.7+: 
 //  . F_OPAQUE valid - must be true in older versions
 //  . ink valid - must be GXcopy in older versions
-	if (MCstackfileversion < 2700)
+	if (p_version < 2700)
 	{
 		t_old_flags = flags;
 		t_old_ink = GXcopy;
@@ -3509,18 +3509,18 @@ IO_stat MCCard::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	}
 //---- 2.7+
 
-	if ((stat = MCObject::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+	if ((stat = MCObject::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 
 //---- 2.7+
-	if (MCstackfileversion < 2700)
+	if (p_version < 2700)
 	{
 		flags = t_old_flags;
 		ink = t_old_ink;
 	}
 //---- 2.7+
 
-	if ((stat = savepropsets(stream)) != IO_NORMAL)
+	if ((stat = savepropsets(stream, p_version)) != IO_NORMAL)
 		return stat;
 	if (objptrs != NULL)
 	{
@@ -3536,7 +3536,7 @@ IO_stat MCCard::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	return IO_NORMAL;
 }
 
-IO_stat MCCard::saveobjects(IO_handle p_stream, uint4 p_part)
+IO_stat MCCard::saveobjects(IO_handle p_stream, uint4 p_part, uint32_t p_version)
 {
 	IO_stat t_stat;
 
@@ -3546,7 +3546,7 @@ IO_stat MCCard::saveobjects(IO_handle p_stream, uint4 p_part)
 		t_objptr = objptrs;
 		do
 		{
-			if ((t_stat = t_objptr -> getref() -> save(p_stream, p_part, false)) != IO_NORMAL)
+			if ((t_stat = t_objptr -> getref() -> save(p_stream, p_part, false, p_version)) != IO_NORMAL)
 				return t_stat;
 			t_objptr = t_objptr -> next();
 		}

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -117,10 +117,10 @@ public:
 	// MCCard functions
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
-	IO_stat saveobjects(IO_handle stream, uint4 p_part);
+	IO_stat saveobjects(IO_handle stream, uint4 p_part, uint32_t p_version);
 	IO_stat loadobjects(IO_handle stream, uint32_t version);
 
 	void kfocusset(MCControl *target);

--- a/engine/src/cdata.cpp
+++ b/engine/src/cdata.cpp
@@ -146,7 +146,7 @@ IO_stat MCCdata::load(IO_handle stream, MCObject *parent, uint32_t version)
 	return IO_NORMAL;
 }
 
-IO_stat MCCdata::save(IO_handle stream, Object_type type, uint4 p_part)
+IO_stat MCCdata::save(IO_handle stream, Object_type type, uint4 p_part, uint32_t p_version)
 {
 	IO_stat stat;
 
@@ -177,7 +177,7 @@ IO_stat MCCdata::save(IO_handle stream, Object_type type, uint4 p_part)
 			if (tptr != NULL)
 				do
 				{
-					if ((stat = tptr->save(stream, p_part)) != IO_NORMAL)
+					if ((stat = tptr->save(stream, p_part, p_version)) != IO_NORMAL)
 						return stat;
 					tptr = (MCParagraph *)tptr->next();
 				}

--- a/engine/src/cdata.h
+++ b/engine/src/cdata.h
@@ -34,7 +34,7 @@ public:
 	MCCdata(const MCCdata &fref);
 	~MCCdata();
 	IO_stat load(IO_handle stream, MCObject *parent, uint32_t version);
-	IO_stat save(IO_handle stream, Object_type type, uint4 p_part);
+	IO_stat save(IO_handle stream, Object_type type, uint4 p_part, uint32_t p_version);
 	uint4 getid();
 	void setid(uint4 newid);
 	MCParagraph *getparagraphs();

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1919,12 +1919,9 @@ class MCSave : public MCStatement
 {
 	MCChunk *target;
 	MCExpression *filename;
+	MCExpression *format;
 public:
-	MCSave()
-	{
-		target = NULL;
-		filename = NULL;
-	}
+	MCSave() : target(NULL), filename(NULL), format(NULL) {}
 	virtual ~MCSave();
 	virtual Parse_stat parse(MCScriptPoint &);
     virtual void exec_ctxt(MCExecContext &ctxt);

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1920,8 +1920,9 @@ class MCSave : public MCStatement
 	MCChunk *target;
 	MCExpression *filename;
 	MCExpression *format;
+	bool newest_format;
 public:
-	MCSave() : target(NULL), filename(NULL), format(NULL) {}
+	MCSave() : target(NULL), filename(NULL), format(NULL), newest_format(false) {}
 	virtual ~MCSave();
 	virtual Parse_stat parse(MCScriptPoint &);
     virtual void exec_ctxt(MCExecContext &ctxt);

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -2124,9 +2124,6 @@ MCSave::~MCSave()
 
 Parse_stat MCSave::parse(MCScriptPoint &sp)
 {
-	Symbol_type type;
-	const LT *te;
-
 	initpoint(sp);
 	target = new MCChunk(False);
 	if (target->parse(sp, False) != PS_NORMAL)

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -889,9 +889,9 @@ void MCControl::draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p
 	fprintf(stderr, "Control: ERROR tried to draw control id %d\n", obj_id);
 }
 
-IO_stat MCControl::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCControl::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
-	return MCObject::save(stream, p_part, p_force_ext);
+	return MCObject::save(stream, p_part, p_force_ext, p_version);
 }
 
 Boolean MCControl::kfocusset(MCControl *target)

--- a/engine/src/cpalette.cpp
+++ b/engine/src/cpalette.cpp
@@ -291,9 +291,9 @@ void MCColors::draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_
 //  SAVING AND LOADING
 //
 
-IO_stat MCColors::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCColors::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return MCObject::defaultextendedsave(p_stream, p_part);
+	return MCObject::defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCColors::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, uint4 p_length)
@@ -301,15 +301,15 @@ IO_stat MCColors::extendedload(MCObjectInputStream& p_stream, uint32_t p_version
 	return MCObject::defaultextendedload(p_stream, p_version, p_length);
 }
 
-IO_stat MCColors::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCColors::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
 	if ((stat = IO_write_uint1(OT_COLORS, stream)) != IO_NORMAL)
 		return stat;
-	if ((stat = MCObject::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+	if ((stat = MCObject::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 IO_stat MCColors::load(IO_handle stream, uint32_t version)

--- a/engine/src/cpalette.h
+++ b/engine/src/cpalette.h
@@ -45,8 +45,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1066,20 +1066,22 @@ IO_stat MCDispatch::savestack(MCStack *sptr, const MCStringRef p_fname, uint32_t
     }
     else
     {
-        // MW-2014-12-17: [[ Widgets ]] Force writing out as 8.0 version stack if it
-        //   contains widgets, and only write out as 8.0 if it contains widgets.
-        uint32_t t_old_stackfileversion;
-        t_old_stackfileversion = MCstackfileversion;
-        if (sptr -> haswidgets() || sptr -> substackhaswidgets())
-            MCstackfileversion = 8000;
-        else if (MCstackfileversion == 8000)
-            MCstackfileversion = 7000;
-        
-        stat = dosavestack(sptr, p_fname, MCstackfileversion);
+		/* If no version was specified, assume that 8.0 format was requested */
+		if (UINT32_MAX == p_version)
+		{
+			p_version = 8000;
+		}
+
+		/* If the stack doesn't contain widgets, and 8.0 format was requested,
+		 * use 7.0 format. */
+		if (8000 == p_version && !sptr->haswidgets())
+		{
+			p_version = 7000;
+		}
+
+        stat = dosavestack(sptr, p_fname, p_version);
         
         MCLogicalFontTableFinish();
-        
-        MCstackfileversion = t_old_stackfileversion;
     }
     
 	return stat;

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1054,7 +1054,7 @@ void MCDispatch::cleanup(IO_handle stream, MCStringRef linkname, MCStringRef bna
 		MCS_unbackup(bname, linkname);
 }
 
-IO_stat MCDispatch::savestack(MCStack *sptr, const MCStringRef p_fname)
+IO_stat MCDispatch::savestack(MCStack *sptr, const MCStringRef p_fname, uint32_t p_version)
 {
     IO_stat stat;
     
@@ -1075,7 +1075,7 @@ IO_stat MCDispatch::savestack(MCStack *sptr, const MCStringRef p_fname)
         else if (MCstackfileversion == 8000)
             MCstackfileversion = 7000;
         
-        stat = dosavestack(sptr, p_fname);
+        stat = dosavestack(sptr, p_fname, MCstackfileversion);
         
         MCLogicalFontTableFinish();
         
@@ -1164,7 +1164,7 @@ IO_stat MCDispatch::dosavescriptonlystack(MCStack *sptr, const MCStringRef p_fna
     return IO_NORMAL;
 }
 
-IO_stat MCDispatch::dosavestack(MCStack *sptr, const MCStringRef p_fname)
+IO_stat MCDispatch::dosavestack(MCStack *sptr, const MCStringRef p_fname, uint32_t p_version)
 {
 	if (MCModeCheckSaveStack(sptr, p_fname) != IO_NORMAL)
 		return IO_ERROR;
@@ -1217,13 +1217,13 @@ IO_stat MCDispatch::dosavestack(MCStack *sptr, const MCStringRef p_fname)
 	// MW-2012-03-04: [[ StackFile5500 ]] Work out what header to emit, and the size.
 	const char *t_header;
 	uint32_t t_header_size;
-    if (MCstackfileversion >= 8000)
+    if (p_version >= 8000)
 		t_header = newheader8000, t_header_size = 8;
-	else if (MCstackfileversion >= 7000)
+	else if (p_version >= 7000)
 		t_header = newheader7000, t_header_size = 8;
-	else if (MCstackfileversion >= 5500)
+	else if (p_version >= 5500)
 		t_header = newheader5500, t_header_size = 8;
-	else if (MCstackfileversion >= 2700)
+	else if (p_version >= 2700)
 		t_header = newheader, t_header_size = 8;
 	else
 		t_header = header, t_header_size = HEADERSIZE;
@@ -1251,7 +1251,7 @@ IO_stat MCDispatch::dosavestack(MCStack *sptr, const MCStringRef p_fname)
 	MCgroupedobjectoffset . y = 0;
 	
 	MCresult -> clear();
-	if (sptr->save(stream, 0, false) != IO_NORMAL
+	if (sptr->save(stream, 0, false, p_version) != IO_NORMAL
 	        || IO_write_uint1(OT_END, stream) != IO_NORMAL)
 	{
 		if (MCresult -> isclear())

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -101,7 +101,7 @@ public:
 	bool loadexternal(MCStringRef p_external);
 
 	void cleanup(IO_handle stream, MCStringRef lname, MCStringRef bname);
-	IO_stat savestack(MCStack *sptr, const MCStringRef);
+	IO_stat savestack(MCStack *sptr, const MCStringRef, uint32_t p_version = UINT32_MAX);
 	IO_stat startup(void);
 	
 	void wreshape(Window w);
@@ -270,7 +270,7 @@ private:
 	IO_stat doreadfile(MCStringRef openpath, MCStringRef inname, IO_handle &stream, MCStack *&sptr);
 	// MW-2012-02-17: [[ LogFonts ]] Actual method which performs a save stack. This
     //   is wrapped by savestack to handle logical font table.
-    IO_stat dosavestack(MCStack *sptr, const MCStringRef);
+	IO_stat dosavestack(MCStack *sptr, const MCStringRef, uint32_t p_version);
     // MW-2014-09-30: [[ ScriptOnlyStack ]] Save a stack if it is marked as script-only.
     IO_stat dosavescriptonlystack(MCStack *sptr, const MCStringRef);
 };

--- a/engine/src/eps.cpp
+++ b/engine/src/eps.cpp
@@ -433,9 +433,9 @@ Exec_stat MCEPS::setprop_legacy(uint4 parid, Properties p, MCExecPoint &ep, Bool
 }
 #endif
 
-IO_stat MCEPS::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCEPS::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCEPS::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, uint4 p_length)
@@ -443,13 +443,13 @@ IO_stat MCEPS::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, u
 	return defaultextendedload(p_stream, p_version, p_length);
 }
 
-IO_stat MCEPS::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCEPS::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
 	if ((stat = IO_write_uint1(OT_MCEPS, stream)) != IO_NORMAL)
 		return stat;
-	if ((stat = MCObject::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+	if ((stat = MCObject::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 	if ((stat = IO_write_uint4(size, stream)) != IO_NORMAL)
 		return stat;
@@ -474,7 +474,7 @@ IO_stat MCEPS::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	if ((stat = IO_write_uint2(ey, stream)) != IO_NORMAL)
 		return stat;
 	if (flags & F_RETAIN_IMAGE)
-		if ((stat = image->save(stream, p_part, p_force_ext)) != IO_NORMAL)
+		if ((stat = image->save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 			return stat;
 	if ((stat = IO_write_uint2(curpage, stream)) != IO_NORMAL)
 		return stat;
@@ -484,7 +484,7 @@ IO_stat MCEPS::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	for (i = 0 ; i < pagecount ; i++)
 		if ((stat = IO_write_uint4(pageIndex[i], stream)) != IO_NORMAL)
 			return stat;
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 MCControl *MCEPS::clone(Boolean attach, Object_pos p, bool invisible)

--- a/engine/src/eps.h
+++ b/engine/src/eps.h
@@ -60,8 +60,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2501,6 +2501,14 @@ void MCInterfaceExecSaveStack(MCExecContext& ctxt, MCStack *p_target)
 	MCInterfaceExecSaveStackAs(ctxt, p_target, kMCEmptyString);
 }
 
+void
+MCInterfaceExecSaveStackWithVersion(MCExecContext & ctxt,
+                                    MCStack *p_target,
+                                    MCStringRef p_version)
+{
+	MCInterfaceExecSaveStackAsWithVersion(ctxt, p_target, kMCEmptyString, p_version);
+}
+
 void MCInterfaceExecSaveStackAs(MCExecContext& ctxt, MCStack *p_target, MCStringRef p_new_filename)
 {
 	ctxt . SetTheResultToEmpty();
@@ -2508,6 +2516,24 @@ void MCInterfaceExecSaveStackAs(MCExecContext& ctxt, MCStack *p_target, MCString
 		return;
 	
 	p_target -> saveas(p_new_filename, MCstackfileversion);
+}
+
+void
+MCInterfaceExecSaveStackAsWithVersion(MCExecContext & ctxt,
+                                      MCStack *p_target,
+                                      MCStringRef p_new_filename,
+                                      MCStringRef p_version)
+{
+	ctxt.SetTheResultToEmpty();
+	if (!ctxt.EnsureDiskAccessIsAllowed())
+		return;
+
+	MCInterfaceStackFileVersion t_version;
+	MCInterfaceStackFileVersionParse(ctxt, p_version, t_version);
+	if (ctxt.HasError())
+		return;
+
+	p_target->saveas(p_new_filename, t_version.version);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2509,6 +2509,13 @@ MCInterfaceExecSaveStackWithVersion(MCExecContext & ctxt,
 	MCInterfaceExecSaveStackAsWithVersion(ctxt, p_target, kMCEmptyString, p_version);
 }
 
+void
+MCInterfaceExecSaveStackWithNewestVersion(MCExecContext & ctxt,
+                                          MCStack *p_target)
+{
+	MCInterfaceExecSaveStackAsWithNewestVersion(ctxt, p_target, kMCEmptyString);
+}
+
 void MCInterfaceExecSaveStackAs(MCExecContext& ctxt, MCStack *p_target, MCStringRef p_new_filename)
 {
 	ctxt . SetTheResultToEmpty();
@@ -2534,6 +2541,18 @@ MCInterfaceExecSaveStackAsWithVersion(MCExecContext & ctxt,
 		return;
 
 	p_target->saveas(p_new_filename, t_version.version);
+}
+
+void
+MCInterfaceExecSaveStackAsWithNewestVersion(MCExecContext & ctxt,
+                                            MCStack * p_target,
+                                            MCStringRef p_new_filename)
+{
+	ctxt.SetTheResultToEmpty();
+	if (!ctxt.EnsureDiskAccessIsAllowed())
+		return;
+
+	p_target->saveas(p_new_filename);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2507,7 +2507,7 @@ void MCInterfaceExecSaveStackAs(MCExecContext& ctxt, MCStack *p_target, MCString
 	if (!ctxt . EnsureDiskAccessIsAllowed())
 		return;
 	
-	p_target -> saveas(p_new_filename);
+	p_target -> saveas(p_new_filename, MCstackfileversion);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3049,7 +3049,9 @@ void MCInterfaceExecUnhiliteObject(MCExecContext& ctxt, MCObjectPtr p_targets);
 void MCInterfaceExecHiliteObject(MCExecContext& ctxt, MCObjectPtr p_targets);
 
 void MCInterfaceExecSaveStack(MCExecContext& ctxt, MCStack *p_target);
+void MCInterfaceExecSaveStackWithVersion(MCExecContext & ctxt, MCStack *p_target, MCStringRef p_version);
 void MCInterfaceExecSaveStackAs(MCExecContext& ctxt, MCStack *p_target, MCStringRef p_new_filename);
+void MCInterfaceExecSaveStackAsWithVersion(MCExecContext& ctxt, MCStack *p_target, MCStringRef p_new_filename, MCStringRef p_version);
 
 void MCInterfaceExecMoveObjectBetween(MCExecContext& ctxt, MCObject *p_target, MCPoint p_from, MCPoint p_to, double p_duration, int p_units, bool p_wait, bool p_dispatch);
 void MCInterfaceExecMoveObjectAlong(MCExecContext& ctxt, MCObject *p_target, MCPoint *p_motion, uindex_t p_motion_count, bool p_is_relative, double p_duration, int p_units, bool p_wait, bool p_dispatch);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3050,8 +3050,10 @@ void MCInterfaceExecHiliteObject(MCExecContext& ctxt, MCObjectPtr p_targets);
 
 void MCInterfaceExecSaveStack(MCExecContext& ctxt, MCStack *p_target);
 void MCInterfaceExecSaveStackWithVersion(MCExecContext & ctxt, MCStack *p_target, MCStringRef p_version);
+void MCInterfaceExecSaveStackWithNewestVersion(MCExecContext & ctxt, MCStack *p_target);
 void MCInterfaceExecSaveStackAs(MCExecContext& ctxt, MCStack *p_target, MCStringRef p_new_filename);
 void MCInterfaceExecSaveStackAsWithVersion(MCExecContext& ctxt, MCStack *p_target, MCStringRef p_new_filename, MCStringRef p_version);
+void MCInterfaceExecSaveStackAsWithNewestVersion(MCExecContext& ctxt, MCStack *p_target, MCStringRef p_new_filename);
 
 void MCInterfaceExecMoveObjectBetween(MCExecContext& ctxt, MCObject *p_target, MCPoint p_from, MCPoint p_to, double p_duration, int p_units, bool p_wait, bool p_dispatch);
 void MCInterfaceExecMoveObjectAlong(MCExecContext& ctxt, MCObject *p_target, MCPoint *p_motion, uindex_t p_motion_count, bool p_is_relative, double p_duration, int p_units, bool p_wait, bool p_dispatch);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2691,7 +2691,10 @@ enum Exec_errors
 	EE_DO_BADWIDGETEXP,
 
     // {EE-0881} documentFilename: bad filename
-    EE_DOCUMENTFILENAME_BADFILENAME,    
+    EE_DOCUMENTFILENAME_BADFILENAME, 
+
+	// {EE-0882} save: error in file format expression
+	EE_SAVE_BADNOFORMATEXP,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -3229,7 +3229,7 @@ void MCField::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 // SN-2015-04-30: [[ Bug 15175 ]] TabAlignment flag added
 #define FIELD_EXTRA_TABALIGN        (1 << 1)
 
-IO_stat MCField::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCField::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
 	uint32_t t_size, t_flags;
 	t_size = 0;
@@ -3266,7 +3266,7 @@ IO_stat MCField::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
     }
     
 	if (t_stat == IO_NORMAL)
-		t_stat = MCObject::extendedsave(p_stream, p_part);
+		t_stat = MCObject::extendedsave(p_stream, p_part, p_version);
     
 	return t_stat;
 }
@@ -3337,7 +3337,7 @@ IO_stat MCField::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 	return t_stat;
 }
 
-IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 	int4 savex = textx;
@@ -3351,7 +3351,7 @@ IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext)
     bool t_has_extension;
     t_has_extension = text_direction != kMCTextDirectionAuto || nalignments != 0;
     
-	if ((stat = MCObject::save(stream, p_part, t_has_extension || p_force_ext)) != IO_NORMAL)
+    if ((stat = MCObject::save(stream, p_part, t_has_extension || p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 
 	if ((stat = IO_write_int2(leftmargin, stream)) != IO_NORMAL)
@@ -3373,7 +3373,7 @@ IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 			if ((stat = IO_write_uint2(tabs[i], stream)) != IO_NORMAL)
 				return stat;
 	}
-	if ((stat = savepropsets(stream)) != IO_NORMAL)
+	if ((stat = savepropsets(stream, p_version)) != IO_NORMAL)
 		return stat;
 	if (fdata != NULL)
 	{
@@ -3389,7 +3389,7 @@ IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 			MCCdata *tptr;
 			tptr = getcarddata(fdata, 0, False);
 			if (tptr != NULL)
-				if ((stat = tptr -> save(stream, OT_FDATA, 0)) != IO_NORMAL)
+				if ((stat = tptr -> save(stream, OT_FDATA, 0, p_version)) != IO_NORMAL)
 					return stat;
 		}
 		else
@@ -3397,7 +3397,7 @@ IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 			MCCdata *tptr = fdata;
 			do
 			{
-				if ((stat = tptr->save(stream, OT_FDATA, p_part)) != IO_NORMAL)
+				if ((stat = tptr->save(stream, OT_FDATA, p_part, p_version)) != IO_NORMAL)
 					return stat;
 				tptr = tptr->next();
 			}
@@ -3405,10 +3405,10 @@ IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 		}
 	}
 	if (vscrollbar != NULL)
-		if ((stat = vscrollbar->save(stream, p_part, p_force_ext)) != IO_NORMAL)
+		if ((stat = vscrollbar->save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 			return stat;
 	if (hscrollbar != NULL)
-		if ((stat = hscrollbar->save(stream, p_part, p_force_ext)) != IO_NORMAL)
+		if ((stat = hscrollbar->save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 			return stat;
 	if (opened)
 	{

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -299,8 +299,8 @@ public:
 	// virtual functions from MCControl
 	virtual IO_stat load(IO_handle stream, uint32_t version);
 	virtual IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	virtual IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	virtual IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -384,7 +384,7 @@ MCPlatformSoundRecorderRef MCrecorder;
 #endif
 
 // AL-2014-18-02: [[ UnicodeFileFormat ]] Make stackfile version 7.0 the default.
-uint4 MCstackfileversion = 7000;
+uint4 MCstackfileversion = 8000;
 uint2 MClook;
 MCStringRef MCttbgcolor;
 MCStringRef MCttfont;
@@ -764,7 +764,7 @@ void X_clear_globals(void)
 #endif
     
 	// AL-2014-18-02: [[ UnicodeFileFormat ]] Make 7.0 stackfile version the default.
-	MCstackfileversion = 7000;
+	MCstackfileversion = 8000;
 
     MClook = LF_MOTIF;
     MCttbgcolor = MCSTR("255,255,207");

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -2478,7 +2478,7 @@ void MCGraphic::setfillrule(uint2 p_rule)
 //  SAVING AND LOADING
 //
 
-IO_stat MCGraphic::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCGraphic::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
 	// Extended data area for a graphic consists of:
 	//   tag graphic_extensions
@@ -2553,7 +2553,7 @@ IO_stat MCGraphic::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
 	}
 
 	if (t_stat == IO_NORMAL)
-		t_stat = MCObject::extendedsave(p_stream, p_part);
+		t_stat = MCObject::extendedsave(p_stream, p_part, p_version);
 
 	return t_stat;
 }
@@ -2632,7 +2632,7 @@ IO_stat MCGraphic::extendedload(MCObjectInputStream& p_stream, uint32_t p_versio
 	return t_stat;
 }
 
-IO_stat MCGraphic::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCGraphic::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	uint2 i;
 	IO_stat stat;
@@ -2655,7 +2655,7 @@ IO_stat MCGraphic::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 //---- 2.7+:
 //  . F_G_ANTI_ALIASED now defined, default false
 	uint4 t_old_flags;
-	if (MCstackfileversion < 2700)
+	if (p_version < 2700)
 	{
 		t_old_flags = flags;
 		flags &= ~F_G_ANTI_ALIASED;
@@ -2665,11 +2665,11 @@ IO_stat MCGraphic::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	bool t_has_extensions;
 	t_has_extensions = m_stroke_gradient != NULL || m_fill_gradient != NULL || m_stroke_miter_limit != 10.0 ||
 		leftmargin != defaultmargin || topmargin != defaultmargin || rightmargin != defaultmargin || bottommargin != defaultmargin;
-	if ((stat = MCControl::save(stream, p_part, t_has_extensions || p_force_ext)) != IO_NORMAL)
+	if ((stat = MCControl::save(stream, p_part, t_has_extensions || p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 
 //---- 2.7+:
-	if (MCstackfileversion < 2700)
+	if (p_version < 2700)
 		flags = t_old_flags;
 //----
 
@@ -2735,7 +2735,7 @@ IO_stat MCGraphic::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	//   legacy unicode output.
     if (flags & F_G_LABEL)
 	{
-		if (MCstackfileversion < 7000)
+		if (p_version < 7000)
 		{
 			if ((stat = IO_write_stringref_legacy(label, stream, hasunicode())) != IO_NORMAL)
 				return stat;
@@ -2747,7 +2747,7 @@ IO_stat MCGraphic::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 		}
 	}
 
-	return savepropsets(stream);
+    return savepropsets(stream, p_version);
 }
 
 IO_stat MCGraphic::load(IO_handle stream, uint32_t version)

--- a/engine/src/graphic.h
+++ b/engine/src/graphic.h
@@ -103,8 +103,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -3120,7 +3120,7 @@ void MCGroup::drawbord(MCDC *dc, const MCRectangle &dirty)
 
 #define GROUP_EXTRA_CLIPSTORECT (1 << 0UL)
 
-IO_stat MCGroup::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCGroup::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
 	uint32_t t_size, t_flags;
 	t_size = 0;
@@ -3134,7 +3134,7 @@ IO_stat MCGroup::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
 	IO_stat t_stat;
 	t_stat = p_stream . WriteTag(t_flags, t_size);
 	if (t_stat == IO_NORMAL)
-		t_stat = MCObject::extendedsave(p_stream, p_part);
+		t_stat = MCObject::extendedsave(p_stream, p_part, p_version);
     
 	return t_stat;
 }
@@ -3170,7 +3170,7 @@ IO_stat MCGroup::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 	return t_stat;
 }
 
-IO_stat MCGroup::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCGroup::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 	
@@ -3184,14 +3184,14 @@ IO_stat MCGroup::save(IO_handle stream, uint4 p_part, bool p_force_ext)
     if (m_clips_to_rect)
         t_has_extensions = true;
 
-	if ((stat = MCObject::save(stream, p_part, t_has_extensions || p_force_ext)) != IO_NORMAL)
+    if ((stat = MCObject::save(stream, p_part, t_has_extensions || p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 	
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode; otherwise use
 	//   legacy unicode output.
     if (flags & F_LABEL)
 	{
-		if (MCstackfileversion < 7000)
+		if (p_version < 7000)
 		{
 			if ((stat = IO_write_stringref_legacy(label, stream, hasunicode())) != IO_NORMAL)
 				return stat;
@@ -3233,16 +3233,16 @@ IO_stat MCGroup::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 		if ((stat = IO_write_uint2(minrect.height, stream)) != IO_NORMAL)
 			return stat;
 	}
-	if ((stat = savepropsets(stream)) != IO_NORMAL)
+	if ((stat = savepropsets(stream, p_version)) != IO_NORMAL)
 		return stat;
 	if (vscrollbar != NULL)
 	{
-		if ((stat = vscrollbar->save(stream, p_part, p_force_ext)) != IO_NORMAL)
+		if ((stat = vscrollbar->save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 			return stat;
 	}
 	if (hscrollbar != NULL)
 	{
-		if ((stat = hscrollbar->save(stream, p_part, p_force_ext)) != IO_NORMAL)
+		if ((stat = hscrollbar->save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 			return stat;
 	}
 	if (controls != NULL)
@@ -3250,7 +3250,7 @@ IO_stat MCGroup::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 		MCControl *cptr = controls;
 		do
 		{
-			if ((stat = cptr->save(stream, p_part, p_force_ext)) != IO_NORMAL)
+			if ((stat = cptr->save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 				return stat;
 			cptr = cptr->next();
 		}

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -97,8 +97,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual Boolean kfocusset(MCControl *target);
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -1656,7 +1656,7 @@ void MCImage::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 //  SAVING AND LOADING
 //
 
-IO_stat MCImage::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCImage::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
 	// Extended data area for an image consists of:
 	//   uint1 resize_quality;
@@ -1694,11 +1694,11 @@ IO_stat MCImage::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
                 // FG-2014-10-17: [[ Bugfix 13706 ]]
                 // Calculate the correct size for 7.0+ style strings
                 // SN-2014-10-27: [[ Bug 13554 ]] String length calculation refactored
-                t_length += p_stream . MeasureStringRefNew(s_control_color_names[i], MCstackfileversion >= 7000);
+                t_length += p_stream . MeasureStringRefNew(s_control_color_names[i], p_version >= 7000);
             }
 			else
                 // AL-2014-11-07: [[ Bug 13851 ]] Measure empty string if the color name is nil
-                t_length += p_stream . MeasureStringRefNew(kMCEmptyString, MCstackfileversion >= 7000);
+                t_length += p_stream . MeasureStringRefNew(kMCEmptyString, p_version >= 7000);
 	
 		t_length += sizeof(uint16_t);
 		t_length += s_control_pixmap_count * sizeof(uint4);
@@ -1723,7 +1723,7 @@ IO_stat MCImage::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
 			t_stat = p_stream . WriteColor(s_control_colors[i]);
 		// MW-2013-12-05: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 		for (uint16_t i = 0; t_stat == IO_NORMAL && i < s_control_color_count; i++)
-			t_stat = p_stream . WriteStringRefNew(s_control_color_names[i] != nil ? s_control_color_names[i] : kMCEmptyString, MCstackfileversion >= 7000);
+			t_stat = p_stream . WriteStringRefNew(s_control_color_names[i] != nil ? s_control_color_names[i] : kMCEmptyString, p_version >= 7000);
 		
 		if (t_stat == IO_NORMAL)
 			t_stat = p_stream . WriteU16(s_control_pixmap_count);
@@ -1745,7 +1745,7 @@ IO_stat MCImage::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
     }
     
 	if (t_stat == IO_NORMAL)
-		t_stat = MCObject::extendedsave(p_stream, p_part);
+		t_stat = MCObject::extendedsave(p_stream, p_part, p_version);
 
 	return t_stat;
 }
@@ -1831,7 +1831,7 @@ IO_stat MCImage::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 	return t_stat;
 }
 
-IO_stat MCImage::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCImage::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
@@ -1894,7 +1894,7 @@ IO_stat MCImage::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	uint1 t_old_ink = ink;
 
 //--- pre-2.7 Conversion
-	if (MCstackfileversion < 2700)
+	if (p_version < 2700)
 	{
 		if (ink == GXblendSrcOver)
 		{
@@ -1917,7 +1917,7 @@ IO_stat MCImage::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	uint4 oldflags = flags;
 	if (flags & F_HAS_FILENAME)
 		flags &= ~(F_TRUE_COLOR | F_COMPRESSION | F_NEED_FIXING);
-	stat = MCControl::save(stream, p_part, t_has_extension || p_force_ext);
+	stat = MCControl::save(stream, p_part, t_has_extension || p_force_ext, p_version);
 
 	flags = oldflags;
 
@@ -1952,7 +1952,7 @@ IO_stat MCImage::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	if (flags & F_HAS_FILENAME)
     {
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-        if ((stat = IO_write_stringref_new(filename, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+        if ((stat = IO_write_stringref_new(filename, stream, p_version >= 7000)) != IO_NORMAL)
 			return stat;
 	}
 	else
@@ -2030,7 +2030,7 @@ IO_stat MCImage::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	if (flags & F_ANGLE)
 		if ((stat = IO_write_uint2(angle, stream)) != IO_NORMAL)
 			return stat;
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 IO_stat MCImage::load(IO_handle stream, uint32_t version)

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -433,8 +433,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 	virtual Boolean maskrect(const MCRectangle &srect);

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -1258,6 +1258,7 @@ LT factor_table[] =
         {"nativechartonum", TT_FUNCTION, F_NATIVE_CHAR_TO_NUM},
         {"navigationarrows", TT_PROPERTY, P_NAVIGATION_ARROWS},
 		{"networkinterfaces", TT_PROPERTY, P_NETWORK_INTERFACES},
+        {"newest", TT_PREP, PT_NEWEST},
         {"next", TT_CHUNK, CT_NEXT},
         {"ninth", TT_CHUNK, CT_NINTH},
         {"no", TT_UNOP, O_NOT},

--- a/engine/src/magnify.cpp
+++ b/engine/src/magnify.cpp
@@ -117,13 +117,13 @@ Boolean MCMagnify::doubleup(uint2 which)
 	return False;
 }
 
-IO_stat MCMagnify::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCMagnify::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
 	if ((stat = IO_write_uint1(OT_MAGNIFY, stream)) != IO_NORMAL)
 		return stat;
-	if ((stat = MCObject::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+	if ((stat = MCObject::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 
 	return IO_NORMAL;
@@ -154,7 +154,7 @@ IO_stat MCMagnify::extendedload(MCObjectInputStream& p_stream, uint32_t p_versio
 	return defaultextendedload(p_stream, p_version, p_length);
 }
 
-IO_stat MCMagnify::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCMagnify::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }

--- a/engine/src/magnify.h
+++ b/engine/src/magnify.h
@@ -45,8 +45,8 @@ public:
 	// virtual functions from control
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -132,7 +132,7 @@ public:
 	// MW-2011-09-06: [[ Redraw ]] Added 'sprite' option - if true, ink and opacity are not set.
 	virtual void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite) = 0;
 
-	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
+	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
 	virtual Boolean kfocusset(MCControl *target);
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 	virtual MCControl *findnum(Chunk_term type, uint2 &num);

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -335,8 +335,8 @@ public:
 	virtual bool visit_self(MCObjectVisitor *p_visitor);
 	virtual bool visit_children(MCObjectVisitorOptions p_options, uint32_t p_part, MCObjectVisitor *p_visitor);
 
-	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	virtual IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	virtual IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual IO_stat load(IO_handle stream, uint32_t version);
 	virtual IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
@@ -1185,13 +1185,13 @@ public:
     void setdeletedobjectpool(MCDeletedObjectPool *pool) { m_pool = pool; }
 
 protected:
-	IO_stat defaultextendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+    IO_stat defaultextendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 	IO_stat defaultextendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_remaining);
 	
 	// MW-2013-12-05: [[ UnicodeFileFormat ]] These are the new propset pickle routines. If
 	//   sfv < 7000 then the legacy ones are used; otherwise new ones are.
 	IO_stat loadpropsets(IO_handle stream, uint32_t version);
-	IO_stat savepropsets(IO_handle stream);
+	IO_stat savepropsets(IO_handle stream, uint32_t p_version);
 	
 	// MW-2012-02-16: [[ LogFonts ]] Load the font attrs with the given index.
 	//   This method is protected as MCStack needs to call it to resolve its

--- a/engine/src/objectpropsets.cpp
+++ b/engine/src/objectpropsets.cpp
@@ -443,9 +443,9 @@ void MCObject::deletepropsets(void)
 	}
 }
 
-IO_stat MCObject::savepropsets(IO_handle stream)
+IO_stat MCObject::savepropsets(IO_handle stream, uint32_t p_version)
 {
-	if (MCstackfileversion < 7000)
+	if (p_version < 7000)
 		return savepropsets_legacy(stream);
 	
 	// MW-2013-12-05: [[ UnicodeFileFormat ]] Emit all the propsets in

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -713,7 +713,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 }
 
 // **** require blocks
-IO_stat MCParagraph::save(IO_handle stream, uint4 p_part)
+IO_stat MCParagraph::save(IO_handle stream, uint4 p_part, uint32_t p_version)
 {
 	IO_stat stat;
 	defrag();
@@ -721,7 +721,7 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part)
 	// MW-2012-03-04: [[ StackFile5500 ]] If the paragraph has attributes and 5.5
 	//   stackfile format has been requested, then output an extended paragraph.
 	bool t_is_ext;
-	if (MCstackfileversion >= 5500 && attrs != nil)
+	if (p_version >= 5500 && attrs != nil)
 		t_is_ext = true;
 	else
 		t_is_ext = false;
@@ -729,7 +729,7 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part)
 	if ((stat = IO_write_uint1(t_is_ext ? OT_PARAGRAPH_EXT : OT_PARAGRAPH, stream)) != IO_NORMAL)
 		return stat;
 	
-	if (MCstackfileversion < 7000)
+	if (p_version < 7000)
 	{
 		// The string data that will get written out. It can't be just done as a
 		// StringRef without breaking file format compatibility.
@@ -785,7 +785,7 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part)
 	// MW-2012-03-04: [[ StackFile5500 ]] If this is an extended paragraph then
 	//   write out the attribtues.
 	if (t_is_ext)
-		if ((stat = saveattrs(stream)) != IO_NORMAL)
+		if ((stat = saveattrs(stream, p_version)) != IO_NORMAL)
 			return IO_ERROR;
  
 	// Write out the blocks
@@ -794,7 +794,7 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part)
 		MCBlock *tptr = blocks;
 		do
 		{
-			if ((stat = tptr->save(stream, p_part)) != IO_NORMAL)
+			if ((stat = tptr->save(stream, p_part, p_version)) != IO_NORMAL)
 				return stat;
 
 			tptr = tptr->next();

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -279,7 +279,7 @@ public:
 	// MW-2012-03-04: [[ StackFile5500 ]] If 'is_ext' is true then this paragraph
 	//   has an attribute extension.
 	IO_stat load(IO_handle stream, uint32_t version, bool is_ext);
-	IO_stat save(IO_handle stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, uint32_t p_version);
 	
 	// MW-2012-02-14: [[ FontRefs ]] Now takes the parent fontref so it can compute
 	//   block's fontrefs.
@@ -643,7 +643,7 @@ public:
 	// Unserializes the paragraph attributes from stream.
 	IO_stat loadattrs(IO_handle stream, uint32_t version);
 	// Serializes the paragraph attributes into stream.
-	IO_stat saveattrs(IO_handle stream);
+	IO_stat saveattrs(IO_handle stream, uint32_t p_version);
 	// MW-2012-02-21: [[ FieldExport ]] Fills in the appropriate members of the
 	//   field export struct.
 	void exportattrs(MCFieldParagraphStyle& x_style);
@@ -651,7 +651,7 @@ public:
 	//  by the style.
 	void importattrs(const MCFieldParagraphStyle& x_style);
 	// MW-2012-03-03: [[ StackFile5500 ]] Computes the size of the attrs when serialized.
-	uint32_t measureattrs(void);
+	uint32_t measureattrs(uint32_t p_version);
     // SN-2015-05-01: [[ Bug 15175 ]] Make easier to find out whether we need an extra flag
     bool hasextraflag(void);
 

--- a/engine/src/paragrafattr.cpp
+++ b/engine/src/paragrafattr.cpp
@@ -338,14 +338,14 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 	return checkloadstat(t_stat);
 }
 
-IO_stat MCParagraph::saveattrs(IO_handle stream)
+IO_stat MCParagraph::saveattrs(IO_handle stream, uint32_t p_version)
 {
 	IO_stat t_stat;
 	t_stat = IO_NORMAL;
 
 	// First we work out the size of the attrs.
 	uint32_t t_attr_size;
-	t_attr_size = measureattrs();
+	t_attr_size = measureattrs(p_version);
 	
 	// Write out the size as either a 2 byte or 4 byte size.
 	if (t_stat == IO_NORMAL)
@@ -399,7 +399,7 @@ IO_stat MCParagraph::saveattrs(IO_handle stream)
 	// MW-2012-11-13: [[ ParaMetadata ]] Write out the metadata, if any.
 	// MW-2013-11-20: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_METADATA) != 0)
-        t_stat = IO_write_stringref_new(attrs -> metadata, stream, MCstackfileversion >= 7000);
+        t_stat = IO_write_stringref_new(attrs -> metadata, stream, p_version >= 7000);
 
 	// MW-2012-11-13: [[ ParaListIndex ]] Write out the list index, if any.
 	if (t_stat == IO_NORMAL && (attrs -> flags & PA_HAS_LIST_INDEX) != 0)
@@ -424,7 +424,7 @@ bool MCParagraph::hasextraflag(void)
     return (attrs -> flags > UINT16_MAX);
 }
 
-uint32_t MCParagraph::measureattrs(void)
+uint32_t MCParagraph::measureattrs(uint32_t p_version)
 {
 	// If there are no attrs, then the size is 0.
 	if (attrs == nil)
@@ -475,9 +475,9 @@ uint32_t MCParagraph::measureattrs(void)
 		t_size += 2;
 	
 	// MW-2012-11-13: [[ ParaMetadata ]] If the paragraph has metadata then add that on.
-    extern uint32_t measure_stringref(MCStringRef string);
+	extern uint32_t measure_stringref(MCStringRef string, uint32_t p_version);
 	if ((attrs -> flags & PA_HAS_METADATA) != 0)
-        t_size += measure_stringref(attrs -> metadata);
+		t_size += measure_stringref(attrs -> metadata, p_version);
 
 	// MW-2012-11-13: [[ ParaListIndex ]] If the paragraph has a list index, then add that on.
 	if ((attrs -> flags & PA_HAS_LIST_INDEX) != 0)

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -861,6 +861,7 @@ enum Preposition_type {
 	PT_MARKUP,
 	PT_BINARY,
 	PT_COOKIE,
+	PT_NEWEST,
 };
 
 enum Print_mode {

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1750,6 +1750,10 @@ enum Parse_errors
 	
 	// {PE-0568} launch: error in widget expression
 	PE_LAUNCH_BADWIDGETEXP,
+
+	// {PE-0568} save: error in format expression
+	PE_SAVE_BADFORMATEXP,
+	
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/pickle.cpp
+++ b/engine/src/pickle.cpp
@@ -155,9 +155,6 @@ void MCObject::stoppickling(MCPickleContext *p_context, MCDataRef& r_string)
 // AL-2014-02-14: [[ UnicodeFileFormat ]] Write an object to the given stream
 static IO_stat pickle_object_to_stream(IO_handle p_stream, uint32_t p_version, MCObject* p_object, uint4 p_part)
 {
-    uint32_t t_old_version = MCstackfileversion;
-    MCstackfileversion = p_version;
-    
     IO_stat t_stat;
     t_stat = IO_NORMAL;
     
@@ -173,22 +170,21 @@ static IO_stat pickle_object_to_stream(IO_handle p_stream, uint32_t p_version, M
 		MCLogicalFontTableBuild(p_object, p_part);
         
 		// Write out the font table to the stream.
-		MCLogicalFontTableSave(p_stream, MCstackfileversion);
+		MCLogicalFontTableSave(p_stream, p_version);
 	}
     
 	// Write the object
 	if (t_stat == IO_NORMAL)
-		t_stat = p_object -> save(p_stream, p_part, false);
+		t_stat = p_object -> save(p_stream, p_part, false, p_version);
     
 	// If the object is a card, pickle all the objects it references
 	// immediately after the main object.
 	if (t_stat == IO_NORMAL && p_object -> gettype() == CT_CARD)
-		t_stat = static_cast<MCCard *>(p_object) -> saveobjects(p_stream, p_part);
+		t_stat = static_cast<MCCard *>(p_object) -> saveobjects(p_stream, p_part, p_version);
     
 	if (t_stat == IO_NORMAL)
 		t_stat = IO_write_uint1(OT_END, p_stream);
     
-    MCstackfileversion = t_old_version;
     return t_stat;
 }
 

--- a/engine/src/player-legacy.cpp
+++ b/engine/src/player-legacy.cpp
@@ -1144,9 +1144,9 @@ MCControl *MCPlayer::clone(Boolean attach, Object_pos p, bool invisible)
 	return newplayer;
 }
 
-IO_stat MCPlayer::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCPlayer::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCPlayer::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, uint4 p_remaining)
@@ -1154,18 +1154,18 @@ IO_stat MCPlayer::extendedload(MCObjectInputStream& p_stream, uint32_t p_version
 	return defaultextendedload(p_stream, p_version, p_remaining);
 }
 
-IO_stat MCPlayer::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCPlayer::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 	if (!disposable)
 	{
 		if ((stat = IO_write_uint1(OT_PLAYER, stream)) != IO_NORMAL)
 			return stat;
-		if ((stat = MCControl::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+		if ((stat = MCControl::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 			return stat;
 		
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-        if ((stat = IO_write_stringref_new(filename, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+        if ((stat = IO_write_stringref_new(filename, stream, p_version >= 7000)) != IO_NORMAL)
 			return stat;
 		if ((stat = IO_write_uint4(starttime, stream)) != IO_NORMAL)
 			return stat;
@@ -1176,10 +1176,10 @@ IO_stat MCPlayer::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 			return stat;
 		
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-        if ((stat = IO_write_stringref_new(userCallbackStr, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+        if ((stat = IO_write_stringref_new(userCallbackStr, stream, p_version >= 7000)) != IO_NORMAL)
 			return stat;
 	}
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 IO_stat MCPlayer::load(IO_handle stream, uint32_t version)

--- a/engine/src/player-legacy.h
+++ b/engine/src/player-legacy.h
@@ -129,8 +129,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
     
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
     

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1754,9 +1754,9 @@ MCControl *MCPlayer::clone(Boolean attach, Object_pos p, bool invisible)
 	return newplayer;
 }
 
-IO_stat MCPlayer::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCPlayer::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCPlayer::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, uint4 p_remaining)
@@ -1764,18 +1764,18 @@ IO_stat MCPlayer::extendedload(MCObjectInputStream& p_stream, uint32_t p_version
 	return defaultextendedload(p_stream, p_version, p_remaining);
 }
 
-IO_stat MCPlayer::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCPlayer::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 	if (!disposable)
 	{
 		if ((stat = IO_write_uint1(OT_PLAYER, stream)) != IO_NORMAL)
 			return stat;
-		if ((stat = MCControl::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+		if ((stat = MCControl::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 			return stat;
         
         // MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-        if ((stat = IO_write_stringref_new(filename, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+        if ((stat = IO_write_stringref_new(filename, stream, p_version >= 7000)) != IO_NORMAL)
 			return stat;
 		if ((stat = IO_write_uint4(starttime, stream)) != IO_NORMAL)
 			return stat;
@@ -1786,10 +1786,10 @@ IO_stat MCPlayer::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 			return stat;
         
         // MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-        if ((stat = IO_write_stringref_new(userCallbackStr, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+        if ((stat = IO_write_stringref_new(userCallbackStr, stream, p_version >= 7000)) != IO_NORMAL)
 			return stat;
 	}
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 IO_stat MCPlayer::load(IO_handle stream, uint32_t version)

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -130,8 +130,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
     
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
     

--- a/engine/src/scrolbar.cpp
+++ b/engine/src/scrolbar.cpp
@@ -1284,9 +1284,9 @@ void MCScrollbar::setembedded(void)
 //  SAVING AND LOADING
 //
 
-IO_stat MCScrollbar::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCScrollbar::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCScrollbar::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, uint4 p_length)
@@ -1294,13 +1294,13 @@ IO_stat MCScrollbar::extendedload(MCObjectInputStream& p_stream, uint32_t p_vers
 	return defaultextendedload(p_stream, p_version, p_length);
 }
 
-IO_stat MCScrollbar::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCScrollbar::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
 	if ((stat = IO_write_uint1(OT_SCROLLBAR, stream)) != IO_NORMAL)
 		return stat;
-	if ((stat = MCControl::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+	if ((stat = MCControl::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 	if (flags & F_SAVE_ATTS)
 	{
@@ -1323,10 +1323,10 @@ IO_stat MCScrollbar::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 		{
             // MW-2013-08-27: [[ UnicodifyScrollbar ]] Update to use stringref primitives.
 			// MW-2013-11-20: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-			if ((stat = IO_write_stringref_new(startstring, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+			if ((stat = IO_write_stringref_new(startstring, stream, p_version >= 7000)) != IO_NORMAL)
 				return stat;
 			// MW-2013-11-20: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-            if ((stat = IO_write_stringref_new(endstring, stream, MCstackfileversion >= 7000)) != IO_NORMAL)
+            if ((stat = IO_write_stringref_new(endstring, stream, p_version >= 7000)) != IO_NORMAL)
 				return stat;
 			if ((stat = IO_write_uint2(nffw, stream)) != IO_NORMAL)
 				return stat;
@@ -1336,7 +1336,7 @@ IO_stat MCScrollbar::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 				return stat;
 		}
 	}
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 IO_stat MCScrollbar::load(IO_handle stream, uint32_t version)

--- a/engine/src/scrolbar.h
+++ b/engine/src/scrolbar.h
@@ -98,8 +98,8 @@ public:
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean attach, Object_pos p, bool invisible);
 	virtual void getwidgetthemeinfo(MCWidgetInfo &widgetinfo);

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -674,7 +674,7 @@ public:
 	MCStack *clone();
 	void compact();
 	Boolean checkid(uint4 cardid, uint4 controlid);
-	IO_stat saveas(const MCStringRef);
+	IO_stat saveas(const MCStringRef, uint32_t p_version = UINT32_MAX);
 	MCStack *findname(Chunk_term type, MCNameRef);
 	MCStack *findid(Chunk_term type, uint4 inid, Boolean alt);
 	void setmark();
@@ -749,9 +749,9 @@ public:
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
 	virtual IO_stat load_substacks(IO_handle stream, uint32_t version);
 	
-	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat save_stack(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat save_stack(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	Exec_stat resubstack(MCStringRef p_data);
 	MCCard *getcardid(uint4 inid);

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -706,7 +706,7 @@ Boolean MCStack::checkid(uint4 cardid, uint4 controlid)
 	return False;
 }
 
-IO_stat MCStack::saveas(const MCStringRef p_fname)
+IO_stat MCStack::saveas(const MCStringRef p_fname, uint32_t p_version)
 {
 	Exec_stat stat = curcard->message(MCM_save_stack_request);
 	if (stat == ES_NOT_HANDLED || stat == ES_PASS)
@@ -714,7 +714,7 @@ IO_stat MCStack::saveas(const MCStringRef p_fname)
 		MCStack *sptr = this;
 		if (!MCdispatcher->ismainstack(sptr))
 			sptr = (MCStack *)sptr->parent;
-		return MCdispatcher->savestack(sptr, p_fname);
+		return MCdispatcher->savestack(sptr, p_fname, p_version);
 	}
 	return IO_NORMAL;
 }

--- a/engine/src/styledtext.cpp
+++ b/engine/src/styledtext.cpp
@@ -99,7 +99,7 @@ bool MCStyledText::visit_children(MCObjectVisitorOptions p_options, uint32_t p_p
 
 // MW-2011-01-13: As styledtext is an internal (not published in anyway) format
 //   we can change it to include the paragraph style for now.
-IO_stat MCStyledText::save(IO_handle p_stream, uint4 p_part, bool p_force_ext)
+IO_stat MCStyledText::save(IO_handle p_stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
@@ -110,7 +110,7 @@ IO_stat MCStyledText::save(IO_handle p_stream, uint4 p_part, bool p_force_ext)
 	if (tptr != NULL)
 		do
 		{
-			if ((stat = tptr->save(p_stream, p_part)) != IO_NORMAL)
+			if ((stat = tptr->save(p_stream, p_part, p_version)) != IO_NORMAL)
 				return stat;
 
 			tptr = (MCParagraph *)tptr->next();

--- a/engine/src/styledtext.h
+++ b/engine/src/styledtext.h
@@ -35,7 +35,7 @@ public:
 	bool visit_self(MCObjectVisitor *p_visitor);
 	bool visit_children(MCObjectVisitorOptions p_options, uint32_t p_part, MCObjectVisitor* p_visitor);
 
-	IO_stat save(IO_handle p_stream, uint4 p_part, bool p_force_ext);
+	IO_stat save(IO_handle p_stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
 	IO_stat load(IO_handle p_stream, uint32_t version);
 
 private:

--- a/engine/src/vclip.cpp
+++ b/engine/src/vclip.cpp
@@ -243,9 +243,9 @@ Boolean MCVideoClip::import(MCStringRef fname, IO_handle fstream)
 	return True;
 }
 
-IO_stat MCVideoClip::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part)
+IO_stat MCVideoClip::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version)
 {
-	return defaultextendedsave(p_stream, p_part);
+	return defaultextendedsave(p_stream, p_part, p_version);
 }
 
 IO_stat MCVideoClip::extendedload(MCObjectInputStream& p_stream, uint32_t p_version, uint4 p_length)
@@ -253,13 +253,13 @@ IO_stat MCVideoClip::extendedload(MCObjectInputStream& p_stream, uint32_t p_vers
 	return defaultextendedload(p_stream, p_version, p_length);
 }
 
-IO_stat MCVideoClip::save(IO_handle stream, uint4 p_part, bool p_force_ext)
+IO_stat MCVideoClip::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
 	IO_stat stat;
 
 	if ((stat = IO_write_uint1(OT_VIDEO_CLIP, stream)) != IO_NORMAL)
 		return stat;
-	if ((stat = MCObject::save(stream, p_part, p_force_ext)) != IO_NORMAL)
+	if ((stat = MCObject::save(stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 		return stat;
 	if ((stat = IO_write_uint4(size, stream)) != IO_NORMAL)
 		return stat;
@@ -271,7 +271,7 @@ IO_stat MCVideoClip::save(IO_handle stream, uint4 p_part, bool p_force_ext)
 	if (flags & F_SCALE_FACTOR)
 		if ((stat = IO_write_int4(MCU_r8toi4(scale), stream)) != IO_NORMAL)
 			return stat;
-	return savepropsets(stream);
+	return savepropsets(stream, p_version);
 }
 
 IO_stat MCVideoClip::load(IO_handle stream, uint32_t version)

--- a/engine/src/vclip.h
+++ b/engine/src/vclip.h
@@ -59,8 +59,8 @@ public:
 	
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);
-	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
-	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part);
+	IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
+	IO_stat extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);
 
 	MCVideoClip *next()
 	{

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -721,6 +721,12 @@ IO_stat MCWidget::load(IO_handle p_stream, uint32_t p_version)
 
 IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
+	/* If the file format doesn't support widgets, skip the widget */
+	if (p_version < 8000)
+	{
+		return IO_NORMAL;
+	}
+
     // Make the widget generate a rep.
     MCAutoValueRef t_rep;
     if (m_widget != nil)

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -719,7 +719,7 @@ IO_stat MCWidget::load(IO_handle p_stream, uint32_t p_version)
     return checkloadstat(t_stat);
 }
 
-IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext)
+IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
 {
     // Make the widget generate a rep.
     MCAutoValueRef t_rep;
@@ -739,7 +739,7 @@ IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext)
         return t_stat;
     
     // Save the object state.
-	if ((t_stat = MCObject::save(p_stream, p_part, p_force_ext)) != IO_NORMAL)
+    if ((t_stat = MCObject::save(p_stream, p_part, p_force_ext, p_version)) != IO_NORMAL)
 		return t_stat;
     
     // Now the widget kind.
@@ -750,7 +750,7 @@ IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext)
     if ((t_stat = IO_write_valueref_new(*t_rep, p_stream)) != IO_NORMAL)
         return t_stat;
     
-    if ((t_stat = savepropsets(p_stream)) != IO_NORMAL)
+    if ((t_stat = savepropsets(p_stream, p_version)) != IO_NORMAL)
         return t_stat;
     
     // We are done.

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -157,7 +157,7 @@ public:
     
 	virtual Exec_stat handle(Handler_type, MCNameRef, MCParameter *, MCObject *pass_from);
 
-	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext);
+	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
 	virtual IO_stat load(IO_handle stream, uint32_t p_version);
 
 	virtual MCControl *clone(Boolean p_attach, Object_pos p_position, bool invisible);

--- a/tests/lcs/core/files/save.livecodescript
+++ b/tests/lcs/core/files/save.livecodescript
@@ -1,0 +1,146 @@
+﻿script "CoreFilesSave"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+constant kTestDirectory = "__CoreFilesSave"
+constant kTestFile = "__CoreFilesSave/Save.livecode"
+constant kVersions = "8.0:7000,7.0:7000,5.5:5500,2.7:2700"
+constant kVersionsWidget = "8.0:8000,7.0:7000,5.5:5500,2.7:2700"
+
+local sTestStack, sTestStackWidget
+
+command TestSetup
+   create folder kTestDirectory
+
+   create invisible stack "non-widget"
+   put it into sTestStack
+
+   create invisible stack "widget"
+   put it into sTestStackWidget
+   set the defaultstack to sTestStackWidget
+   TestLoadExtension "com.livecode.widget.clock"
+   create widget as "com.livecode.widget.clock"
+end TestSetup
+
+command TestTearDown
+   local tFile, tFolder
+   put the defaultfolder into tFolder
+   set the defaultfolder to kTestDirectory
+   repeat for each line tFile in the files
+      delete file tFile
+   end repeat
+   set the defaultfolder to tFolder
+   delete folder kTestDirectory
+end TestTearDown
+
+private command __TestStackFileHasFormat pVersion
+   local tActual, tExpected, tVersion
+
+   set the itemdelimiter to ":"
+   put item 1 of pVersion into tVersion
+   put "REVO" & item 2 of pVersion into tExpected
+
+   open file kTestFile for binary read
+   read from file kTestFile for 8 bytes
+   put it into tActual
+   close file kTestFile
+
+   TestAssert merge("stack file has version [[tVersion]]"), tActual is tExpected
+   TestDiagnostic merge("version was '[[tActual]]'")
+end __TestStackFileHasFormat
+
+private command __TestSaveAsFormat pStack, pVersion
+   local tVersion, tName
+   set the itemdelimiter to ":"
+   put item 1 of pVersion into tVersion
+   put the name of pStack into tName
+
+   save pStack as kTestFile with format tVersion
+   TestAssert merge("save [[tName]] stack file with version [[tVersion]]"), the result is empty
+
+   __TestStackFileHasFormat pVersion
+end __TestSaveAsFormat
+
+private command __TestSaveAsNewestFormat pStack, pVersion
+   local tName
+   put the name of pStack into tName
+   save pStack as kTestFile with newest format
+   TestAssert "save [[tName]] stack file with newest version", the result is empty
+
+   __TestStackFileHasFormat pVersion
+end __TestSaveAsNewestFormat
+
+private command __TestSaveAsGlobalFormat pStack, pVersion
+   local tVersion, tName
+   set the itemdelimiter to ":"
+   put item 1 of pVersion into tVersion
+   put the name of pStack into tName
+
+   set the stackfileversion to tVersion
+   save pStack as kTestFile
+   TestAssert merge("save [[tName]] stack file with version [[tVersion]]"), the result is empty
+
+   __TestStackFileHasFormat pVersion
+end __TestSaveAsGlobalFormat
+
+private command __TestSaveAsDefaultFormat pStack, pVersion
+   local tName
+   put the name of pStack into tName
+   save pStack as kTestFile
+   TestAssert merge("save [[tName]] stack file with default version"), the result is empty
+
+   __TestStackFileHasFormat pVersion
+end __TestSaveAsDefaultFormat
+
+on TestSaveAsFormat
+   local tVersion
+
+   set the itemdelimiter to ","
+   repeat for each item tVersion in kVersions
+      __TestSaveAsFormat sTestStack, tVersion
+   end repeat
+   repeat for each item tVersion in kVersionsWidget
+      __TestSaveAsFormat sTestStackWidget, tVersion
+   end repeat
+end TestSaveAsFormat
+
+on TestSaveAsNewestFormat
+   local tVersion
+
+   set the itemdelimiter to ","
+   __TestSaveAsNewestFormat sTestStack, item 1 of kVersions
+   __TestSaveAsNewestFormat sTestStackWidget, item 1 of kVersionsWidget
+end TestSaveAsNewestFormat
+
+on TestSaveAsGlobalFormat
+   local tVersion
+
+   set the itemdelimiter to ","
+   repeat for each item tVersion in kVersions
+      __TestSaveAsGlobalFormat sTestStack, tVersion
+   end repeat
+   repeat for each item tVersion in kVersionsWidget
+      __TestSaveAsGlobalFormat sTestStackWidget, tVersion
+   end repeat
+end TestSaveAsGlobalFormat
+
+on TestSaveAsDefaultFormat
+   local tVersion
+   set the itemdelimiter to ","
+   __TestSaveAsDefaultFormat sTestStack, item 1 of kVersions
+   __TestSaveAsDefaultFormat sTestStackWidget, item 1 of kVersionsWidget
+end TestSaveAsDefaultFormat


### PR DESCRIPTION
Only the LiveCode "8.0" stack format supports widgets.  However, it is otherwise identical to the "7.0" format.  By default, the LiveCode 8 `save` command uses the "8.0" format for stacks that contain widgets, and the "7.0" format otherwise.

[Bug 15970](http://quality.livecode.com/show_bug.cgi?id=15970) related to the behaviour of the `save` command when `the stackFileVersion` was set to something other than "8.0".  The IDE's "Save As..." dialog offers the option of which stack file format to use.  When saving a stack that uses widgets, and selecting the "7.0" format, the engine would use the "8.0" format, regardless -- and this caused confusing errors when attempting to load the resulting file into the LiveCode 7 IDE.

This pull request changes the mechanism for choosing the file format version used by the `save` command. It:
- Refactors all of the object save logic to pass the version to use as a parameter, rather than using the `MCstackfileversion` global static variable.
- Adds a new optional `with format _` clause to the `save` command, which can be used to specify the file format version.
- Adds a new optional `with newest format` clause, which causes `save` to always use the latest & greatest stack file format
- Marks `the stackFileVersion` as deprecated, and recommends specifying the file format to use directly when calling `save`.

The behaviour of all existing stacks that make use of the `save` command or `the stackFileVersion` are unaffected by this change.
