### PR TITLE
[[ Bug 16515 ]] Fix media player callback creation

### DIFF
--- a/docs/notes/bugfix-16515.md
+++ b/docs/notes/bugfix-16515.md
@@ -1,0 +1,1 @@
+# Player callbacks not sent

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -2952,7 +2952,6 @@ void MCPlayer::SynchronizeUserCallbacks(void)
         {
             if (isspace(MCStringGetCharAtIndex(*t_callback, t_space_index)))
             {
-                ++t_space_index;
                 MCAutoStringRef t_param;
                 /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_space_index, t_end_index - t_space_index), &t_param);
                 /* UNCHECKED */ MCNameCreate(*t_param, m_callbacks[m_callback_count - 1] . parameter);
@@ -2962,7 +2961,7 @@ void MCPlayer::SynchronizeUserCallbacks(void)
         }
         
         MCAutoStringRef t_message;
-        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_callback_index, t_space_index - 1 - t_callback_index), &t_message);
+        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_callback_index, t_space_index - t_callback_index), &t_message);
         /* UNCHECKED */ MCNameCreate(*t_message, m_callbacks[m_callback_count - 1] . message);
         
         // If no parameter is specified, use the time.


### PR DESCRIPTION
After 7.0 refactoring, the first trailing whitespace was left in the callback name.
The fix to the bug 15689 was fixing it in a pretty erroneous way.
It is now fixed by not adding the first found whitespace in the callback name
