### PR TITLE
[CID 120191] Add missing break statements to switch

### DIFF
--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -297,12 +297,15 @@ void MCStack::sethints()
 	{
 	case kMCLicenseClassProfessional:
 		t_edition_name = "business";
+		break;
 	case kMCLicenseClassCommercial:
 		t_edition_name = "indy";
+		break;
 	case kMCLicenseClassNone:
 	case kMCLicenseClassCommunity:
 	default:
 		t_edition_name = "community";
+		break;
 	}
     
     /* UNCHECKED */ MCStringCreateMutable(0, &t_class_name);


### PR DESCRIPTION
In commit e660a83, a `switch` block was added without
any `break` statements between outcomes, leading to
predictably terrible results.
