### PR TITLE
[[ Bug 16528 ]] Fix commandArguments/commandName crash in IDE

### DIFF
--- a/docs/notes/bugfix-16528.md
+++ b/docs/notes/bugfix-16528.md
@@ -1,0 +1,1 @@
+# 'put the commandArguments' crashes LiveCode IDE

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1114,6 +1114,11 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
         if (!t_success)
             return false;
     }
+    else
+    {
+        MCcommandname = MCValueRetain(kMCEmptyString);
+        MCcommandarguments = MCValueRetain(kMCEmptyArray);
+    }
     
     MCDeletedObjectsSetup();
 


### PR DESCRIPTION
Sets an empty value to MCcommandarguments / MCcommandname if we are not in a mode where we allow them to be populated
