### PR TITLE
[emscripten] Allow running LiveCode Script tests in the browser

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,19 @@ Open the `livecode.sln` solution file in Visual Studio, and build the "check" pr
 
 There's not currently a convenient way to run the LiveCode Script and LiveCode Builder tests on Windows.
 
+### Running tests on Emscripten
+
+To run the C++ tests, run `make check-emscripten` from the top of the livecode git repository working tree.
+
+To run the LiveCode Script tests:
+
+1) Run `tools/emscripten_testgen.sh`.  This generates an HTML5 standalone in the `_tests/emscripten` directory.
+
+2) Open `_tests/emscripten/tests.html` in a web browser.
+
+The tests are run automatically as the web page loads, and the TAP log
+output is shown in the browser.
+
 ## Writing Tests
 
 If at all possible, please add tests whenever make a change to LiveCode -- whether it's a feature added, a bug fixed, or a behaviour tweaked.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,6 +58,16 @@ on TestSetup
 end TestSetup
 ````
 
+The `TestSetup` handler can indicate that a test should be skipped *entirely* by returning a value that begins with the word "skip".  For example:
+
+````
+on TestSetup
+   if the platform is not "Windows" then
+      return "SKIP Feature is only supported on Windows"
+   end if
+end TestSetup
+````
+
 Tests may need to clean up temporary files or other resources after running.  If a script test contains a handler called `TestTeardown`, this will be run after running each test command -- even if the test failed.  N.b. `TestTeardown` won't be run if running the test command causes an engine crash.
 
 Crashes or uncaught errors from a test command cause the test to immediately fail.

--- a/tests/_emscripten/__boot.livecodescript
+++ b/tests/_emscripten/__boot.livecodescript
@@ -1,0 +1,55 @@
+﻿script "EmscriptenTestRunner"
+
+private command TestLoadLibrary pBasename
+	local tStackname
+	put the name of stack (pBasename & ".livecodescript") into tStackname
+
+	dispatch revLoadLibrary to tStackname
+end TestLoadLibrary
+
+on startup
+	set the defaultfolder to "/boot/standalone"
+
+	-- Load test libraries
+	write "# Loading test libraries" & return to stdout
+	TestLoadLibrary "_testlib"
+	TestLoadLibrary "_testerlib"
+
+	-- Run tests
+	local tTestFile, tStackName, tCommand, tSetupResult
+
+	repeat for each element tTestFile in TesterGetTestFileNames()
+		put the name of stack tTestFile into tStackName
+
+		TestDiagnostic "framework: Running tests from" && tTestFile
+		write return to stdout
+
+		repeat for each element tCommand in TesterParseTestCommandNames(tTestFile)
+
+			TestDiagnostic "framework: Running" && tCommand
+
+			-- Send setup command and check if skip is requested
+			dispatch "TestSetup" to tStackName
+			put the result into tSetupResult
+			if word 1 of tSetupResult is "skip" then
+				TestSkip tCommand, word 2 to -1 of tSetupResult
+				write return to stdout
+				next repeat
+			end if
+
+			-- Run tests
+			dispatch tCommand to tStackName
+
+			-- Send teardown command
+			dispatch "TestTearDown" to tStackName
+
+			write return to stdout
+		end repeat
+	end repeat
+
+end startup
+
+on ErrorDialog executionError, parseError
+   write executionError & return to stderr
+   quit 1
+end ErrorDialog

--- a/tests/_emscripten/__startup.livecodescript
+++ b/tests/_emscripten/__startup.livecodescript
@@ -1,0 +1,4 @@
+﻿script "EmscriptenTestStartup"
+
+on startup
+end startup

--- a/tests/_testerlib.livecodescript
+++ b/tests/_testerlib.livecodescript
@@ -1,0 +1,229 @@
+﻿script "TesterLib"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/*
+This script is a library of commands and functions that can be used by
+test runner implementations.
+*/
+
+on revLoadLibrary
+	insert the script of me into back
+end revLoadLibrary
+
+----------------------------------------------------------------
+-- Script-only stack handling
+----------------------------------------------------------------
+
+-- Get all livecode script files beneath the CWD, apart from
+-- filenames starting with "." or "_"
+function TesterGetTestFileNames
+   local tFiles, tCount
+
+   put empty into tFiles
+   put 0 into tCount
+
+   TesterGetTestFileNames_Recursive the defaultfolder, empty, tFiles, tCount
+
+   return tFiles
+end TesterGetTestFileNames
+
+-- Helper command used by runGetTestFileNames
+private command TesterGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCount
+   -- Save the CWD
+   local tSaveFolder
+   put the defaultfolder into tSaveFolder
+   set the defaultfolder to pPath
+
+   -- Process files in the current directory
+   local tFile
+   repeat for each line tFile in the files
+      if tFile ends with ".livecodescript" and \
+            not (tFile begins with "." or tFile begins with "_") then
+
+         if pRelPath is not empty then
+            put pRelPath & slash before tFile
+         end if
+
+         add 1 to xCount
+         put tFile into xFiles[xCount]
+      end if
+   end repeat
+
+   -- Process subdirectories
+   local tFolder, tFolderPath
+   repeat for each line tFolder in the folders
+      if tFolder begins with "." then
+         next repeat
+      end if
+
+      put pPath & slash & tFolder into tFolderPath
+
+      if pRelPath is not empty then
+         put pRelPath & slash before tFolder
+      end if
+
+      TesterGetTestFileNames_Recursive tFolderPath, tFolder, xFiles, xCount
+   end repeat
+
+   -- Restore the CWD
+   set the defaultfolder to tSaveFolder
+end TesterGetTestFileNames_Recursive
+
+-- Get a number-indexed array contain the names of all "test"
+-- commands in pFilename.
+function TesterParseTestCommandNames pFilename
+   local tScript
+
+   -- Get the contents of the file
+   open file pFilename for "UTF-8" text read
+   if the result is not empty then
+      throw the result
+   end if
+
+   read from file pFilename until end
+   put it into tScript
+
+   close file pFilename
+
+   -- Scan the file for "on Test*" definitions
+   local tCommandNames, tCount, tLine, tName
+
+   repeat for each line tLine in tScript
+      if token 1 of tLine is not "on" then
+         next repeat
+      end if
+
+      put token 2 of tLine into tName
+
+      if not (tName begins with "Test") then
+         next repeat
+      end if
+
+      -- Exclude the test setup message
+      if tName is "TestSetup" or tName is "TestTearDown" then
+         next repeat
+      end if
+
+      add 1 to tCount
+      put tName into tCommandNames[tCount]
+   end repeat
+
+   return tCommandNames
+end TesterParseTestCommandNames
+
+-- Prettify a test name by removing a ".livecodescript" suffix
+function TesterGetPrettyTestName pFilename
+   if pFilename ends with ".livecodescript" then
+      set the itemDelimiter to "."
+      return item 1 to -2 of pFileName
+   end if
+end TesterGetPrettyTestName
+
+----------------------------------------------------------------
+-- TAP support
+----------------------------------------------------------------
+
+-- Scan TAP output and extract summary of test results
+function TesterTapAnalyse pTapData
+   local tStats
+   put 0 into tStats["pass"]
+   put 0 into tStats["xpass"]
+   put 0 into tStats["xfail"]
+   put 0 into tStats["fail"]
+   put 0 into tStats["skip"]
+   put pTapData into tStats["log"]
+
+   local tLine, tIsOkay, tIsTodo, tIsSkip
+   local tTail, tDirective
+   repeat for each line tLine in pTapData
+      -- Check if the line is a test result and, if so, whether
+      -- the test was successful
+      if token 1 of tLine is "ok" then
+         put true into tIsOkay
+      else if token 1 of tLine is "not" and token 2 of tLine is "ok" then
+         put false into tIsOkay
+      else
+         -- No test result on this line
+         next repeat
+      end if
+
+      -- Check if the test on this line was skipped or was expected to fail
+      put false into tIsTodo
+      put false into tIsSkip
+      put char (offset("#", tLine) + 1) to -1 of tLine into tTail
+      switch token 1 of tTail
+         case "TODO"
+            put true into tIsTodo
+            break
+         case "SKIP"
+            put true into tIsSkip
+            break
+      end switch
+
+      if tIsOkay then
+         if tIsTodo then
+            add 1 to tStats["xpass"]
+         else if tIsSkip then
+            add 1 to tStats["skip"]
+         else
+            add 1 to tStats["pass"]
+         end if
+      else
+         if tIsTodo then
+            add 1 to tStats["xfail"]
+         else
+            add 1 to tStats["fail"]
+         end if
+      end if
+
+   end repeat
+
+   return tStats
+end TesterTapAnalyse
+
+-- Examine the statistics generated by tapAnalyse() and return a string
+-- describing the test log's worst result
+function TesterTapGetWorstResult pTapAnalysis
+   local tResult
+   repeat for each item tResult in "fail,xpass,xfail,pass,skip"
+      if pTapAnalysis[tResult] > 0 then
+         return tResult
+      end if
+   end repeat
+   return "pass"
+end TesterTapGetWorstResult
+
+-- Get the total number of tests from the statistics generated by
+-- tapAnalyse()
+function TesterTapGetTestCount pAnalysis
+   return pAnalysis["pass"] + pAnalysis["xpass"] + pAnalysis["xfail"] + \
+         pAnalysis["fail"] + pAnalysis["skip"]
+end TesterTapGetTestCount
+
+-- Combine two sets of TAP results
+function TesterTapCombine pAnalysisA, pAnalysisB
+   local tCombined, tKey
+   repeat for each key tKey in pAnalysisB
+      if tKey is "log" then
+         put pAnalysisA[tKey] & pAnalysisB[tKey] into tCombined[tKey]
+      else
+         put pAnalysisA[tKey] + pAnalysisB[tKey] into tCombined[tKey]
+      end if
+   end repeat
+   return tCombined
+end TesterTapCombine

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -16,6 +16,10 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+on revLoadLibrary
+	insert the script of me into back
+end revLoadLibrary
+
 ----------------------------------------------------------------
 -- Helper functions
 ----------------------------------------------------------------

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -162,28 +162,21 @@ private command invokeTest pInfo
    dispatch "TestTearDown" to tStackName
 end invokeTest
 
--- Add the unit test library stack to the backscripts
+-- Add the test library stack to the backscripts
 private command invokeLoadLibrary pInfo
-   local tStackName, tStackFile
+	-- Compute the filename of the library stack
+	local tFilename
+	put pInfo["self-script"] into tFilename
 
-   -- This should auto-load the library
-   put invokeGetLibraryStack(pInfo) into tStackFile
-   put the name of stack tStackFile into tStackName
+	set the itemDelimiter to slash
+	put "_testlib.livecodescript" into item -1 of tFilename
 
-   -- Add the library to the backscripts
-   insert the script of stack tStackName into back
+	-- Load the library
+	local tStackname
+	put the name of stack tFilename into tStackname
+
+	send "revLoadLibrary" to stack tStackname
 end invokeLoadLibrary
-
--- Return the filename of the unit test library stack
-private function invokeGetLibraryStack pInfo
-   local tFilename
-   put pInfo["self-script"] into tFilename
-
-   set the itemDelimiter to slash
-   put "_testlib.livecodescript" into item -1 of tFilename
-
-   return tFilename
-end invokeGetLibraryStack
 
 ----------------------------------------------------------------
 -- Support for running tests

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -99,7 +99,7 @@ private command doRun pInfo
    put pInfo["args"][2] into tScript
    put pInfo["args"][3] into tCommand
 
-   runLoadLibrary
+   runLoadLibrary pInfo
    
    if tScript is empty then
       runAllScripts pInfo

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -147,6 +147,14 @@ private command invokeTest pInfo
    -- This should auto-load the test script
    put the name of stack pInfo["invoke"]["script"] into tStackName
 
+   -- Check that the stack script actually compiles
+   set the script of tStackname to the script of tStackname
+   put the result into tResult
+   if tResult is not empty then
+      TestDiagnostic tResult
+   end if
+   TestAssert "script compiles", tResult is empty
+
    -- Dispatch the test setup command, and check if skipping was requested
    dispatch "TestSetup" to tStackName
    put the result into tResult

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -144,14 +144,23 @@ end ErrorDialog
 
 -- Execute a test
 private command invokeTest pInfo
-   local tStackName
+   local tStackName, tResult
 
    -- This should auto-load the test script
    put the name of stack pInfo["invoke"]["script"] into tStackName
 
-   -- Dispatch the test setup command, and the test command itself
+   -- Dispatch the test setup command, and check if skipping was requested
    dispatch kSetupMessage to tStackName
+   put the result into tResult
+   if word 1 of tResult is "SKIP" then
+      TestSkip pInfo["invoke"]["command"], word 2 to -1 of tResult
+      exit invokeTest
+   end if
+
+   -- Run the actual test itself
    dispatch pInfo["invoke"]["command"] to tStackName
+
+   -- Do common cleanup tasks
    dispatch kTeardownMessage to tStackName
 end invokeTest
 
@@ -195,36 +204,9 @@ private command runAllScripts pInfo
    return tAnalysis
 end runAllScripts
 
--- Output a skipped line in the results for eachcommand in the given test file
-private command runTestSkipAll pInfo, pScriptFile, pReason
-   local tSkipTemplate, tAnalysis
-   put "ok - [[tCommand]] # SKIP" && pReason into tSkipTemplate
-
-   repeat for each element tCommand in runGetTestCommandNames(pScriptFile)
-      runTestProcessOutput pScriptFile, tCommand, merge(tSkipTemplate)
-      put tapCombine(tAnalysis, the result) into tAnalysis
-   end repeat
-end runTestSkipAll
-
 -- Run the tests found in one specific script file
 private command runTestScript pInfo, pScriptFile
-   local tCommand, tAnalysis, tMetadata
-   put runGetTestMetadata(pScriptFile) into tMetadata
-
-   -- Only run tests that require UI if possible
-   local tCanRunUITests
-   put true into tCanRunUITests
-   repeat for each element tElement in pInfo["self-command"]
-      if tElement is "-ui" then
-         put false into tCanRunUITests
-         exit repeat
-      end if
-   end repeat
-
-   if tMetadata["ui"] is true and not tCanRunUITests then
-      runTestSkipAll pInfo, pScriptFile, "test requires UI mode"
-      return the result
-   end if
+   local tCommand, tAnalysis
 
    repeat for each element tCommand in runGetTestCommandNames(pScriptFile)
       runTestCommand pInfo, pScriptFile, tCommand
@@ -422,51 +404,6 @@ private command runPrintSummary pAnalysis
 
    write tSummaryString to stdout
 end runPrintSummary
-
--- Get all the metadata keys and values in the stack file
-private function runGetTestMetadata pFilename
-   local tScript
-
-   -- Get the contents of the file
-   open file pFilename for "UTF-8" text read
-   if the result is not empty then
-      throw the result
-   end if
-
-   read from file pFilename until end
-   put it into tScript
-
-   close file pFilename
-
-   -- Scan the file for metadata -
-   -- Metadata is given in the form ### <key> : <value>
-
-   local tKey, tValue, tMetadata
-   repeat for each line tLine in tScript
-      -- save some time by only looking at commented out lines
-      if token 1 of tLine is not empty then
-         next repeat
-      end if
-
-      -- remove whitespace
-      put word 1 to -1 of tLine into tLine
-
-      if not (tLine begins with "###") then
-         next repeat
-      end if
-
-      -- remove hashes
-      put char 4 to -1 of tLine into tLine
-
-      set the itemdelimiter to ":"
-      put word 1 to -1 of (item 1 of tLine) into tKey
-      put word 1 to -1 of (item 2 of tLine) into tValue
-
-      put tValue into tMetadata[tKey]
-   end repeat
-
-   return tMetadata
-end runGetTestMetadata
 
 ----------------------------------------------------------------
 -- Logging helpers

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -19,11 +19,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 -- FIXME provide this on the command line
 constant kLogFilename = "_test_suite.log"
 
--- This is the message dispatched before invoking each test command
-constant kSetupMessage = "TestSetup"
--- And this message is dispatched *after* each test command
-constant kTeardownMessage = "TestTearDown"
-
 on startup
    send "TestRunnerMain" to me in 0
 end startup
@@ -103,6 +98,9 @@ private command doRun pInfo
    local tScript, tCommand, tAnalysis
    put pInfo["args"][2] into tScript
    put pInfo["args"][3] into tCommand
+
+   runLoadLibrary
+   
    if tScript is empty then
       runAllScripts pInfo
    else if tCommand is empty then
@@ -123,7 +121,7 @@ private command doRun pInfo
    end if
    put tLogForWriting into url ("binfile:" & kLogFilename)
    
-   if tapGetWorstResult(tAnalysis) is "FAIL" then
+   if TesterTapGetWorstResult(tAnalysis) is "FAIL" then
       quit 1
    end if
 end doRun
@@ -150,7 +148,7 @@ private command invokeTest pInfo
    put the name of stack pInfo["invoke"]["script"] into tStackName
 
    -- Dispatch the test setup command, and check if skipping was requested
-   dispatch kSetupMessage to tStackName
+   dispatch "TestSetup" to tStackName
    put the result into tResult
    if word 1 of tResult is "SKIP" then
       TestSkip pInfo["invoke"]["command"], word 2 to -1 of tResult
@@ -161,7 +159,7 @@ private command invokeTest pInfo
    dispatch pInfo["invoke"]["command"] to tStackName
 
    -- Do common cleanup tasks
-   dispatch kTeardownMessage to tStackName
+   dispatch "TestTearDown" to tStackName
 end invokeTest
 
 -- Add the unit test library stack to the backscripts
@@ -191,13 +189,29 @@ end invokeGetLibraryStack
 -- Support for running tests
 ----------------------------------------------------------------
 
+-- Add the test runner library stack to the backscripts
+private command runLoadLibrary pInfo
+	-- Compute the filename of the library stack
+	local tFilename
+	put pInfo["self-script"] into tFilename
+
+	set the itemDelimiter to slash
+	put "_testerlib.livecodescript" into item -1 of tFilename
+
+	-- Load the library
+	local tStackname
+	put the name of stack tFilename into tStackname
+
+	send "revLoadLibrary" to stack tStackname
+end runLoadLibrary
+
 -- Run all the test scripts that can be found below the current
 -- directory
 private command runAllScripts pInfo
    local tFile, tAnalysis
-   repeat for each element tFile in runGetTestFileNames()
+   repeat for each element tFile in TesterGetTestFileNames()
       runTestScript pInfo, tFile
-      put tapCombine(tAnalysis, the result) into tAnalysis
+      put TesterTapCombine(tAnalysis, the result) into tAnalysis
    end repeat
    runPrintSummary(tAnalysis)
 
@@ -208,9 +222,9 @@ end runAllScripts
 private command runTestScript pInfo, pScriptFile
    local tCommand, tAnalysis
 
-   repeat for each element tCommand in runGetTestCommandNames(pScriptFile)
+   repeat for each element tCommand in TesterParseTestCommandNames(pScriptFile)
       runTestCommand pInfo, pScriptFile, tCommand
-      put tapCombine(tAnalysis, the result) into tAnalysis
+      put TesterTapCombine(tAnalysis, the result) into tAnalysis
    end repeat
    return tAnalysis
 end runTestScript
@@ -218,15 +232,15 @@ end runTestScript
 private command runTestProcessOutput pScriptfile, pCommand, pOutput
    -- Create test log
    local tTestLog
-   put "###" && runGetPrettyTestName(pScriptFile) && pCommand \
+   put "###" && TesterGetPrettyTestName(pScriptFile) && pCommand \
          & return & return into tTestLog
    put pOutput & return after tTestLog
 
    -- Analyse the results and print a summary line
    local tTapResults
-   put tapAnalyse(tTestLog) into tTapResults
+   put TesterTapAnalyse(tTestLog) into tTapResults
 
-   logSummaryLine tTapResults, (runGetPrettyTestName(pScriptFile) & ":" && pCommand)
+   logSummaryLine tTapResults, (TesterGetPrettyTestName(pScriptFile) & ":" && pCommand)
 
    return tTapResults
 end runTestProcessOutput
@@ -263,116 +277,11 @@ private command runTestCommand pInfo, pScriptFile, pCommand
    return the result
 end runTestCommand
 
--- Get all livecode script files beneath the CWD, apart from
--- filenames starting with "." or "_"
-private function runGetTestFileNames
-   local tFiles, tCount
-
-   put empty into tFiles
-   put 0 into tCount
-
-   runGetTestFileNames_Recursive the defaultfolder, empty, tFiles, tCount
-
-   return tFiles
-end runGetTestFileNames
-
--- Helper command used by runGetTestFileNames
-private command runGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCount
-   -- Save the CWD
-   local tSaveFolder
-   put the defaultfolder into tSaveFolder
-   set the defaultfolder to pPath
-
-   -- Process files in the current directory
-   local tFile
-   repeat for each line tFile in the files
-      if tFile ends with ".livecodescript" and \
-            not (tFile begins with "." or tFile begins with "_") then
-
-         if pRelPath is not empty then
-            put pRelPath & slash before tFile
-         end if
-
-         add 1 to xCount
-         put tFile into xFiles[xCount]
-      end if
-   end repeat
-
-   -- Process subdirectories
-   local tFolder, tFolderPath
-   repeat for each line tFolder in the folders
-      if tFolder begins with "." then
-         next repeat
-      end if
-
-      put pPath & slash & tFolder into tFolderPath
-
-      if pRelPath is not empty then
-         put pRelPath & slash before tFolder
-      end if
-
-      runGetTestFileNames_Recursive tFolderPath, tFolder, xFiles, xCount
-   end repeat
-
-   -- Restore the CWD
-   set the defaultfolder to tSaveFolder
-end runGetTestFileNames_Recursive
-
--- Get a number-indexed array contain the names of all "test"
--- commands in pFilename.
-private function runGetTestCommandNames pFilename
-   local tScript
-
-   -- Get the contents of the file
-   open file pFilename for "UTF-8" text read
-   if the result is not empty then
-      throw the result
-   end if
-
-   read from file pFilename until end
-   put it into tScript
-
-   close file pFilename
-
-   -- Scan the file for "on Test*" definitions
-   local tCommandNames, tCount, tLine, tName
-
-   repeat for each line tLine in tScript
-      if token 1 of tLine is not "on" then
-         next repeat
-      end if
-
-      put token 2 of tLine into tName
-
-      if not (tName begins with "Test") then
-         next repeat
-      end if
-
-      -- Exclude the test setup message
-      if tName is kSetupMessage or tName is kTeardownMessage then
-         next repeat
-      end if
-
-      add 1 to tCount
-      put tName into tCommandNames[tCount]
-   end repeat
-
-   return tCommandNames
-end runGetTestCommandNames
-
--- Prettify a test name by removing a ".livecodescript" suffix
-private function runGetPrettyTestName pFilename
-   if pFilename ends with ".livecodescript" then
-      set the itemDelimiter to "."
-      return item 1 to -2 of pFileName
-   end if
-end runGetPrettyTestName
-
 -- Print out a table of statistics
 private command runPrintSummary pAnalysis
    local tSummaryString, tTotal, tDecoration
 
-   put tapGetTestCount(pAnalysis) into tTotal
+   put TesterTapGetTestCount(pAnalysis) into tTotal
 
    -- Format basic summary information
    if pAnalysis["xfail"] is 0 and pAnalysis["fail"] is 0 then
@@ -455,9 +364,9 @@ private command logSummaryLine pTapResults, pTestName
    local tTotal, tPassed, tWorst, tMessage
 
    put pTapResults["xpass"] + pTapResults["pass"] + pTapResults["skip"] into tPassed
-   put tapGetTestCount(pTapResults) into tTotal
+   put TesterTapGetTestCount(pTapResults) into tTotal
 
-   put tapGetWorstResult(pTapResults) into tWorst
+   put TesterTapGetWorstResult(pTapResults) into tWorst
    put logHighLight(the toUpper of tWorst) into tMessage
    put ":" after tMessage
    if the number of chars in tWorst < 5 then
@@ -469,97 +378,3 @@ private command logSummaryLine pTapResults, pTestName
    put space & "[" & tPassed & "/" & tTotal & "]" after tMessage
    write tMessage & return to stdout
 end logSummaryLine
-
-----------------------------------------------------------------
--- TAP support
-----------------------------------------------------------------
-
--- Scan TAP output and extract summary of test results
-private function tapAnalyse pTapData
-   local tStats
-   put 0 into tStats["pass"]
-   put 0 into tStats["xpass"]
-   put 0 into tStats["xfail"]
-   put 0 into tStats["fail"]
-   put 0 into tStats["skip"]
-   put pTapData into tStats["log"]
-
-   local tLine, tIsOkay, tIsTodo, tIsSkip
-   local tTail, tDirective
-   repeat for each line tLine in pTapData
-      -- Check if the line is a test result and, if so, whether
-      -- the test was successful
-      if token 1 of tLine is "ok" then
-         put true into tIsOkay
-      else if token 1 of tLine is "not" and token 2 of tLine is "ok" then
-         put false into tIsOkay
-      else
-         -- No test result on this line
-         next repeat
-      end if
-
-      -- Check if the test on this line was skipped or was expected to fail
-      put false into tIsTodo
-      put false into tIsSkip
-      put char (offset("#", tLine) + 1) to -1 of tLine into tTail
-      switch token 1 of tTail
-         case "TODO"
-            put true into tIsTodo
-            break
-         case "SKIP"
-            put true into tIsSkip
-            break
-      end switch
-
-      if tIsOkay then
-         if tIsTodo then
-            add 1 to tStats["xpass"]
-         else if tIsSkip then
-            add 1 to tStats["skip"]
-         else
-            add 1 to tStats["pass"]
-         end if
-      else
-         if tIsTodo then
-            add 1 to tStats["xfail"]
-         else
-            add 1 to tStats["fail"]
-         end if
-      end if
-
-   end repeat
-
-   return tStats
-end tapAnalyse
-
--- Examine the statistics generated by tapAnalyse() and return a string
--- describing the test log's worst result
-private function tapGetWorstResult pTapAnalysis
-   local tResult
-   repeat for each item tResult in "fail,xpass,xfail,pass,skip"
-      if pTapAnalysis[tResult] > 0 then
-         return tResult
-      end if
-   end repeat
-   return "pass"
-end tapGetWorstResult
-
--- Get the total number of tests from the statistics generated by
--- tapAnalyse()
-private function tapGetTestCount pAnalysis
-   return pAnalysis["pass"] + pAnalysis["xpass"] + pAnalysis["xfail"] + \
-         pAnalysis["fail"] + pAnalysis["skip"]
-end tapGetTestCount
-
--- Combine two sets of TAP results
-private function tapCombine pAnalysisA, pAnalysisB
-   local tCombined, tKey
-   repeat for each key tKey in pAnalysisB
-      if tKey is "log" then
-         put pAnalysisA[tKey] & pAnalysisB[tKey] into tCombined[tKey]
-      else
-         put pAnalysisA[tKey] + pAnalysisB[tKey] into tCombined[tKey]
-      end if
-   end repeat
-   return tCombined
-end tapCombine

--- a/tests/lcs/core/engine/clipboard.livecodescript
+++ b/tests/lcs/core/engine/clipboard.livecodescript
@@ -17,9 +17,16 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 
--- Clipboard access requires system interaction so, generally, cannot be run in no-UI mode
-### ui : true
-### platforms: MacOS, Linux, Win32
+-- Clipboard access requires system interaction so, generally, cannot
+-- be run in no-UI mode
+on TestSetup
+   if the environment is "command line" then
+      return "SKIP Clipboard requires GUI mode"
+   end if
+   if the platform is not among the items of "MacOS,Windows,Linux" then
+      return "SKIP Clipboard not available on" && the platform
+   end if
+end TestSetup
 
 -- Utility function that returns the smallest possible valid PNG image
 local sTinyPNG

--- a/tests/lcs/core/engine/engine.livecodescript
+++ b/tests/lcs/core/engine/engine.livecodescript
@@ -473,7 +473,7 @@ end TestEngine35
 on TestEngine36
    if the platform is "HTML" then
       TestSkip "cancel message", "bug 16076"
-      exit TestEngine25
+      exit TestEngine36
    end if
 
 local tTime

--- a/tests/lcs/core/engine/engine.livecodescript
+++ b/tests/lcs/core/engine/engine.livecodescript
@@ -223,6 +223,7 @@ end TestEngine19
 on TestSystemVersion
    if the platform is "HTML" then
       TestSkip "systemVersion not empty", "bug 16539"
+      exit TestSystemVersion
    end if
    TestAssert "test", the systemVersion is not empty
 end TestSystemVersion
@@ -314,7 +315,10 @@ TestAssert "test", item 1 of tItem3 is an integer
 end TestEngine24
 
 on TestEngine25
-
+   if the platform is "HTML" then
+      TestSkip "cancel message", "bug 16076"
+      exit TestEngine25
+   end if
 
 create button
 
@@ -467,7 +471,10 @@ close stack "Test1"
 end TestEngine35
 
 on TestEngine36
-
+   if the platform is "HTML" then
+      TestSkip "cancel message", "bug 16076"
+      exit TestEngine25
+   end if
 
 local tTime
 

--- a/tests/lcs/core/engine/engine.livecodescript
+++ b/tests/lcs/core/engine/engine.livecodescript
@@ -223,6 +223,7 @@ end TestEngine19
 on TestSystemVersion
    if the platform is "HTML" then
       TestSkip "systemVersion not empty", "bug 16539"
+   end if
    TestAssert "test", the systemVersion is not empty
 end TestSystemVersion
 

--- a/tests/lcs/core/engine/engine.livecodescript
+++ b/tests/lcs/core/engine/engine.livecodescript
@@ -220,11 +220,12 @@ TestAssert "test", tError is not 0
 
 end TestEngine19
 
-on TestEngine20
+on TestSystemVersion
+   if the platform is "HTML" then
+      TestSkip "systemVersion not empty", "bug 16539"
+   TestAssert "test", the systemVersion is not empty
+end TestSystemVersion
 
-TestAssert "test", the systemVersion is not empty
-
-end TestEngine20
 on TestEngine21
 
 

--- a/tests/lcs/core/field/rtfText.livecodescript
+++ b/tests/lcs/core/field/rtfText.livecodescript
@@ -90,6 +90,12 @@ end testRtfExport
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
 
+on TestSetup
+   if the platform is "HTML" then
+      return "SKIP bug 16545"
+   end if
+end TestSetup
+
 // Test backgroundColour on its own
 on TestRtfExportWithBackgroundColour
    createField

--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -17,7 +17,10 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestFolderInListing
-   
+   if the platform is "HTML" then
+      TestSkip "(folder) is in the folder listing", "bug 16543"
+      exit TestFolderInListing
+   end if
    
    set the defaultFolder to specialFolderPath("temporary")
    
@@ -36,6 +39,11 @@ on TestFolderInListing
 end TestFolderInListing
 
 on TestBugfix12039
+   if the platform is "HTML" then
+      TestSkip "(file) is among the files", "bug 16543"
+      exit TestFolderInListing
+   end if
+
    // 12039
    put the defaultFolder into tOldCwd
    set the defaultFolder to specialFolderPath("temporary")

--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -316,7 +316,7 @@ end TestLaunch
 
 
 on TestLaunchWith
-   if the plaform is "HTML" then
+   if the platform is "HTML" then
       TestSkip "launch subprocess with", "HTML5 platform does not support subprocesses"
       exit TestLaunchWith
    end if

--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -41,7 +41,7 @@ end TestFolderInListing
 on TestBugfix12039
    if the platform is "HTML" then
       TestSkip "(file) is among the files", "bug 16543"
-      exit TestFolderInListing
+      exit TestBugfix12039
    end if
 
    // 12039

--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -98,6 +98,11 @@ on TestShortFilePath
 end TestShortFilePath
 
 on TestFileCreationWithOpenForWrite
+   if the platform is "HTML" then
+      TestSkip "Open file for write creates the file", "bug 16543"
+      exit TestFileCreationWithOpenForWrite
+   end if
+
    set the defaultFolder to specialFolderPath("temporary")
    
    local tFileName
@@ -144,10 +149,16 @@ end TestShortFilePath2
 
 on TestSpecialFolderPath
    local tFolder, tHome
-   put specialFolderPath("Temporary") into tFolder
-   TestAssert "temporary folder is not empty", tFolder is not empty
-   TestAssert "temporary folder exists", there is a folder tFolder
-   
+
+   if the platform is "HTML" then
+      TestSkip "temporary folder is not empty", "bug 16543"
+      TestSkip "temporary folder exists", "bug 16543"
+   else
+      put specialFolderPath("Temporary") into tFolder
+      TestAssert "temporary folder is not empty", tFolder is not empty
+      TestAssert "temporary folder exists", there is a folder tFolder
+   end if
+
    // windows numeric folder codes
    if the platform is "win32" then
       put specialFolderPath("home") into tHome
@@ -191,6 +202,14 @@ end TestTempName
 
 
 on TestThereIsAFile
+   if the platform is "HTML" then
+      TestSkip "after creation - there is a file (file)", "bug 16543"
+      TestSkip "after creation - not (there is not a file (file))", "bug 16543"
+      TestSkip "after deletion - not (there is a file (file))", "bug 16543"
+      TestSkip "after deletion - there is not a file (file)", "bug 16543"
+      exit TestThereIsAFile
+   end if
+
    set the defaultFolder to specialFolderPath("temporary")
    
    put "evalThereIsAFileTest.txt" into tTestfile
@@ -207,6 +226,14 @@ end TestThereIsAFile
 
 
 on TestThereIsAFolder
+   if the platform is "HTML" then
+      TestSkip "after creation - there is a folder (folder)", "bug 16543"
+      TestSkip "after creation - not (there is not a folder (folder))", "bug 16543"
+      TestSkip "after deletion - not (there is a folder (folder))", "bug 16543"
+      TestSkip "after deletion - there is not a folder (folder)", "bug 16543"
+      exit TestThereIsAFolder
+   end if
+
    set the defaultFolder to specialFolderPath("temporary")
    
    put "evalThereIsAFolderTest" into tTestFolder
@@ -282,11 +309,18 @@ on TestLaunch
       local tPID
       put word 1 of line it of taskList into tPID
       get shell ("kill" && tPID)
+   else if the platform is "HTML" then
+      TestSkip "launch subprocess", "HTML5 platform does not support subprocesses"
    end if	
 end TestLaunch
 
 
 on TestLaunchWith
+   if the plaform is "HTML" then
+      TestSkip "launch subprocess with", "HTML5 platform does not support subprocesses"
+      exit TestLaunchWith
+   end if
+
    set the defaultFolder to specialFolderPath("Desktop")
    
    open file "Test.txt" for write

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -23,7 +23,7 @@ TestAssert "test", "red" is a color
 TestAssert "test", not ("red" is not a color)
 
 # Bug 157 (!) - all integers are colors
-TestSkip "test", not (257 is a color), "157"
+TestSkip "test", /* not (257 is a color) */ "bug 157"
 
 TestAssert "test", "0,0,0" is a color
 

--- a/tests/lcs/core/interface/interface-button-props.livecodescript
+++ b/tests/lcs/core/interface/interface-button-props.livecodescript
@@ -1,4 +1,4 @@
-script "CoreButtonProps"
+﻿script "CoreButtonProps"
 /*
 Copyright (C) 2015 LiveCode Ltd.
 
@@ -23,23 +23,13 @@ on TestUnhighlight
 
 	unhilite button 1
 	TestAssert "no hilite on button 1", not the hilite of button 1
-	hilite button 1
-	TestAssert "still dehilited", the hilite of button 1
-
-	unhilite button 1
-	TestAssert "no hilite on button 1", not the hilite of button 1
-	highlight button 2
-	TestAssert "test", the hilite of button 2
+	hilite button 2
+	TestAssert "still dehilited", not the hilite of button 1
 
 	dehilite button 2
 	TestAssert "no hilite on button 2", not the hilite of button 2
 	hilite button 1
-	TestAssert "still dehilited", the hilite of button 1
-
-	dehilite button 1
-	TestAssert "no hilite on button 1", not the hilite of button 1
-	highlight button 1
-	TestAssert "still dehilited", the hilite of button 1
+	TestAssert "still dehilited", not the hilite of button 2
 end TestUnhighlight
 
 on TestHighlightedButtonID
@@ -48,23 +38,23 @@ on TestHighlightedButtonID
 	create button in group 1
 
 	TestAssert "empty hilite on button creation", the hilitedbuttonid of group 1 is 0
-	set the highlitedbuttonid of group 1 to the short id of button 2
-	TestAssertBroken "button 1 of group 1 is unhilited", not the hilite of button 1, "bug 16281"
+	set the hilitedbuttonid of group 1 to the short id of button 2
+	TestAssert "button 1 of group 1 is unhilited", not the hilite of button 1
 	hilite button 1
-	TestAssertBroken "hilitedbuttonid is button 1 of group 1", the hilitedbuttonid of group 1 is the short id of button 1, "bug 16281"
-	TestAssertBroken "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1, "bug 16281"
+	TestAssert "hilitedbuttonid is button 1 of group 1", the hilitedbuttonid of group 1 is the short id of button 1
+	TestAssertBroken "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1, "bug 16551"
 
 	unhilite button 1
-	TestAssertBroken "button 1 of group 1 is unhilited", not the hilite of button 1, "bug 16281"
-	highlight button 2
-	TestAssertBroken "hilitedbuttonid is button 2 of group 1", the hilitedbuttonid of group 1 is the short id of button 2, "bug 16281"
-	TestAssertBroken "hilitedbuttonname is button 2 of group 1", the hilitedbuttonname of group 1 is the short name of button 2, "bug 16281"
+	TestAssert "button 1 of group 1 is unhilited", not the hilite of button 1
+	hilite button 2
+	TestAssert "hilitedbuttonid is button 2 of group 1", the hilitedbuttonid of group 1 is the short id of button 2
+	TestAssertBroken "hilitedbuttonname is button 2 of group 1", the hilitedbuttonname of group 1 is the short name of button 2, "bug 16551"
 
 	dehilite button 2
-	TestAssertBroken "button 2 of group 1 is unhilited", not the hilite of button 2, "bug 16281"
-	set the highlitedbuttonid of group 1 to the short id of button 1
-	TestAssertBroken "hilitedbuttonid is button 1 of group 1", the hilitedbuttonid of group 1 is the short id of button 1, "bug 16281"
-	TestAssertBroken "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1, "bug 16281"
+	TestAssert "button 2 of group 1 is unhilited", not the hilite of button 2
+	set the hilitedbuttonid of group 1 to the short id of button 1
+	TestAssert "hilitedbuttonid is button 1 of group 1", the hilitedbuttonid of group 1 is the short id of button 1
+	TestAssertBroken "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1, "bug 16551"
 end TestHighlightedButtonID
 
 on TestHighlightBorder
@@ -83,13 +73,15 @@ end TestHighlightBorder
 
 on TestHighlightFill
 	create button
-	TestAssert "hilitefill is false on button creation", the hilitefill of button 1 is false
 
-	set the hilitefill of button 1 to true
-	TestAssert "button hilitefill set to true", the hilitefill of button 1
+	-- Consistent with LiveCode 6.7
+	TestAssert "hilitefill is true on button creation", the hilitefill of button 1
 
 	set the hilitefill of button 1 to false
 	TestAssert "button hilitefill set to false", the hilitefill of button 1 is false
+
+	set the hilitefill of button 1 to true
+	TestAssert "button hilitefill set to true", the hilitefill of button 1
 end TestHighlightFill
 
 on TestHighlightedIcon
@@ -104,29 +96,29 @@ end TestHighlightedIcon
 
 on TestSharedHighlight
 	create button
-	TestAssert "sharedhilite is false on button creation", the sharedhilite of button 1 is false
+	TestAssert "sharedhilite is true on button creation", the sharedhilite of button 1 is true
+
+	set the sharedhilite of button 1 to false
+	TestAssert "sharedhilite set to false", the sharedhilite of button 1 is false
 
 	set the sharedhilite of button 1 to true
 	TestAssert "sharedhilite set to true", the sharedhilite of button 1
-	
-	set the sharedhilite of button 1 to false
-	TestAssert "sharedhilite set to false", the sharedhilite of button 1 is false
 end TestSharedHighlight
 
 on TestShowHighlight
 	create button
-	TestAssert "showhilite is true on button creation", the showhilite of button 1 is true
-
-	set the showhilite of button 1 to false
-	TestAssert "showhilite set to false", the showhilite of button 1 is false
+	TestAssert "showhilite is false on button creation", the showhilite of button 1 is false
 
 	set the showhilite of button 1 to true
 	TestAssert "showhilite set to true", the showhilite of button 1
+
+	set the showhilite of button 1 to false
+	TestAssert "showhilite set to false", the showhilite of button 1 is false
 end TestShowHighlight
 
 on TestHighlightColorDefault
 	create button
-	TestAssert "default button hilitecolor", the button of field 1 is empty
+	TestAssert "default button hilitecolor", the hilitecolor of button 1 is empty
 end TestHighlightColorDefault
 
 on TestHighlightColors
@@ -147,13 +139,13 @@ end TestHighlightColors
 
 on TestLinkHighlightColors
 	set the linkhilitecolor to "blue"
-	TestAssertBroken "linkhilitecolor set to blue", the linkhilitecolor is "blue", "bug 16280"
+	TestAssert "linkhilitecolor set to blue", the linkhilitecolor is "blue"
 
 	set the linkhilitecolor to "255,255,0"
-	TestAssertBroken "linkhilitecolor set to RGB value", the linkhilitecolor is "255,255,0", "bug 16280"
+	TestAssert "linkhilitecolor set to RGB value", the linkhilitecolor is "255,255,0"
 
 	set the linkhilitecolor to "#336633"
-	TestAssertBroken "linkhilitecolor set to hex value", the linkhilitecolor is "#336633", "bug 16280"
+	TestAssert "linkhilitecolor set to hex value", the linkhilitecolor is "#336633"
 end TestLinkHighlightColors
 
 on TestHighlighted
@@ -169,7 +161,7 @@ end TestHighlighted
 
 on TestButtonAutoHighlightDefault
 	create button
-	TestAssert "button autohilite is false on button creation", the autohilite of button 1 is false
+	TestAssert "button autohilite is true on button creation", the autohilite of button 1 is true
 end TestButtonAutoHighlightDefault
 
 on TestButtonAutoHighlight

--- a/tests/lcs/core/interface/interface-field-props.livecodescript
+++ b/tests/lcs/core/interface/interface-field-props.livecodescript
@@ -69,13 +69,13 @@ end TestHighlightColors
 
 on TestLinkHighlightColors
 	set the linkhilitecolor to "blue"
-	TestAssertBroken "linkhilitecolor set to blue", the linkhilitecolor is "blue", "bug 16280"
+	TestAssert "linkhilitecolor set to blue", the linkhilitecolor is "blue"
 
 	set the linkhilitecolor to "255,255,0"
-	TestAssertBroken "linkhilitecolor set to RGB value", the linkhilitecolor is "255,255,0", "bug 16280"
+	TestAssert "linkhilitecolor set to RGB value", the linkhilitecolor is "255,255,0"
 
 	set the linkhilitecolor to "#336633"
-	TestAssertBroken "linkhilitecolor set to hex value", the linkhilitecolor is "#336633", "bug 16280"
+	TestAssert "linkhilitecolor set to hex value", the linkhilitecolor is "#336633"
 end TestLinkHighlightColors
 
 on TestFieldAutoHighlightDefault

--- a/tests/lcs/core/interface/interface-system-props.livecodescript
+++ b/tests/lcs/core/interface/interface-system-props.livecodescript
@@ -18,11 +18,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestLinkHighlightColors
 	set the linkhilitecolor to "blue"
-	TestAssertBroken "linkhilitecolor set to blue", the linkhilitecolor is "blue", "bug 16280"
+	TestAssert "linkhilitecolor set to blue", the linkhilitecolor is "blue"
 
 	set the linkhilitecolor to "255,255,0"
-	TestAssertBroken "linkhilitecolor set to RGB value", the linkhilitecolor is "255,255,0", "bug 16280"
+	TestAssert "linkhilitecolor set to RGB value", the linkhilitecolor is "255,255,0"
 
 	set the linkhilitecolor to "#336633"
-	TestAssertBroken "linkhilitecolor set to hex value", the linkhilitecolor is "#336633", "bug 16280"
+	TestAssert "linkhilitecolor set to hex value", the linkhilitecolor is "#336633"
 end TestLinkHighlightColors

--- a/tests/lcs/core/interface/interface.livecodescript
+++ b/tests/lcs/core/interface/interface.livecodescript
@@ -241,6 +241,10 @@ TestAssert "test", the mouse is "up"
 
 end TestInterface30
 on TestInterface37
+   if the platform is "HTML" then
+      TestSkip "moving button", "bug 16076"
+      exit TestInterface37
+   end if
 
 TestAssert "test", the movingControls is empty
 create button
@@ -790,7 +794,10 @@ TestAssert "test", line 1 of field "tf" is "a" and line 2 of field "tf" is "b" a
 
 end TestInterface107
 on TestInterface99
-
+   if the platform is "HTML" then
+      TestSkip "stop moving button", "bug 16076"
+      exit TestInterface99
+   end if
 
 create button
 
@@ -809,7 +816,10 @@ TestAssert "test", not (the loc of button 1 is 0,0)
 end TestInterface99
 -- no key options working properly
 on TestInterface101
-
+   if the platform is "HTML" then
+      TestSkip "key options", "bug 16544"
+      exit TestInterface101
+   end if
 
 create stack "Test"
 set the defaultstack to "Test"

--- a/tests/lcs/core/interface/interfaceui.livecodescript
+++ b/tests/lcs/core/interface/interfaceui.livecodescript
@@ -20,6 +20,9 @@ on TestSetup
    if the environment is "command line" then
       return "SKIP GUI-only tests"
    end if
+   if the platform is "HTML" then
+      return "SKIP bug 16544"
+   end if
 end TestSetup
 
 on TestInterface2

--- a/tests/lcs/core/interface/interfaceui.livecodescript
+++ b/tests/lcs/core/interface/interfaceui.livecodescript
@@ -16,8 +16,11 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-// Meta Data
-### ui:true
+on TestSetup
+   if the environment is "command line" then
+      return "SKIP GUI-only tests"
+   end if
+end TestSetup
 
 on TestInterface2
 create stack "Test"

--- a/tests/lcs/core/multimedia/multimedia.livecodescript
+++ b/tests/lcs/core/multimedia/multimedia.livecodescript
@@ -35,7 +35,8 @@ end if
 end TestMultimedia1
 on TestMultimedia2
 
-if the platform is not "linux" and the qtversion is not "0.0" then
+if the platform is not among the items of "linux,HTML" and \
+      the qtversion is not "0.0" then
   TestAssert "test", the qteffects is not empty
 else
   TestAssert "test", the qteffects is empty

--- a/tests/lcs/core/network/network.livecodescript
+++ b/tests/lcs/core/network/network.livecodescript
@@ -16,9 +16,13 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+on TestSetup
+   if the platform is "HTML" then
+      return "SKIP DNS and socket APIs unavailable on HTML5"
+   end if
+end TestSetup
 
 on TestNetwork2
-
 TestAssert "test", the dnsservers is not empty
 
 repeat for each line tServer in the dnsservers

--- a/tests/lcs/docs/docsparser.livecodescript
+++ b/tests/lcs/docs/docsparser.livecodescript
@@ -17,6 +17,11 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestSetup
+   -- Only run these tests on desktop platforms
+   if the platform is not among the items of "MacOS,Windows,Linux" then
+      return "SKIP Tests are not runnable on" && the platform
+   end if
+
    local tDocsParser
    put TestGetEngineRepositoryPath() & "/ide-support/revdocsparser.livecodescript" into tDocsParser
    start using stack tDocsParser

--- a/tools/emscripten_testgen.sh
+++ b/tools/emscripten_testgen.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -e
+
+# This script generates a standalone .zip file that contains
+# LiveCodeScript tests.
+
+# Preparation
+# -----------
+
+# Figure out some paths
+top_src_dir=$(cd $(dirname $0)/.. && pwd)
+em_bin_dir=${top_src_dir}/emscripten-bin
+
+test_src_dir=${top_src_dir}/tests
+em_test_src_dir=${test_src_dir}/_emscripten
+test_build_dir=${top_src_dir}/_tests
+em_test_build_dir=${test_build_dir}/emscripten
+em_stack_dir=${em_test_build_dir}/standalone/boot/standalone
+
+# Get version information
+short_ver=$(perl ${top_src_dir}/util/decode_version.pl BUILD_SHORT_VERSION ${top_src_dir}/version)
+
+# Clean up from previous run and create required directories
+rm -rf ${em_test_build_dir}
+mkdir -p ${em_test_build_dir}
+
+# Engine
+# ------
+
+# Copy the engine into place
+cp -a ${em_bin_dir}/standalone-community-${short_ver}.{js,html.mem} ${em_test_build_dir}
+cp -a ${em_bin_dir}/standalone-community-${short_ver}.html ${em_test_build_dir}/tests.html
+
+# Standalone
+# ----------
+# Construct a basic standalone boot filesystem
+cp -r ${top_src_dir}/engine/rsrc/emscripten-standalone-template ${em_test_build_dir}/standalone
+# Copy in test suite stacks
+mkdir -p ${em_stack_dir}
+cp -a ${test_src_dir} ${em_stack_dir}
+# Clean up undesirable files
+find ${test_src_dir} \
+     -not -name \*.livecodescript -o \
+     -name '_*' -o \
+     -name '.*' \
+     -print \
+     -exec rm '{}' ';'
+cp ${test_src_dir}/_test*lib.livecodescript ${em_stack_dir}
+# Copy in startup and boot stacks
+cp ${em_test_src_dir}/__boot.livecodescript ${em_test_build_dir}/standalone/boot/standalone/__boot.livecode
+cp ${em_test_src_dir}/__startup.livecodescript ${em_test_build_dir}/standalone/boot/__startup.livecode
+# Create the standalone.zip file
+( cd ${em_test_build_dir}/standalone && zip -0qr ${em_test_build_dir}/standalone.zip * )


### PR DESCRIPTION
These changes allow (most of) the LiveCode Script tests to be run in the browser.  There are some tests that are currently skipped due to crash bugs in the HTML5 engine (bug reports have been filed).

Much of the desktop LCS test runner has been moved into a new unit test support library, so the extra code for the browser-based test runner is very compact.
