### PR TITLE
Fix browser pi templates for URL and htmlText properties

### DIFF
--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -302,7 +302,6 @@ metadata svgicon is "M21.7,12c0,5.4-4.4,9.7-9.7,9.7S2.3,17.4,2.3,12S6.6,2.3,12,2
 
 -- property declarations
 property URL get getUrl set setUrl
-metadata URL.editor is "com.livecode.pi.text"
 
 property htmlText get getHtmlText set setHtmlText
 

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -304,6 +304,7 @@ metadata svgicon is "M21.7,12c0,5.4-4.4,9.7-9.7,9.7S2.3,17.4,2.3,12S6.6,2.3,12,2
 property URL get getUrl set setUrl
 
 property htmlText get getHtmlText set setHtmlText
+metadata htmlText.editor is "com.livecode.pi.text"
 
 property vScrollbar get getVScrollbar set setVScrollbar
 metadata vScrollbar.editor is "com.livecode.pi.boolean"


### PR DESCRIPTION
Both properties were using the wrong PI controls. <URL> was using text and <htmlText> was using string. <URL> now uses string and <htmlText> uses text.
