### PR TITLE
lcidlc: Mapped data type support

### DIFF
--- a/lcidlc/src/Interface.cpp
+++ b/lcidlc/src/Interface.cpp
@@ -89,6 +89,17 @@ static const char *s_interface_native_types[] =
 	nil
 };
 
+static const char *s_interface_mapped_types[] =
+{
+    "string",
+    "number",
+    "data",
+    "array",
+    "dictionary",
+    
+    nil
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern const char *g_input_filename;
@@ -180,8 +191,12 @@ static void InterfaceCheckType(InterfaceRef self, Position p_where, NameRef p_ty
 	for(uint32_t i = 0; s_interface_native_types[i] != nil; i++)
 		if (NameEqualToCString(p_type, s_interface_native_types[i]))
 			return;
-			
-	for(uint32_t i = 0; i < self -> enum_count; i++)
+    
+    for(uint32_t i = 0; s_interface_mapped_types[i] != nil; i++)
+        if (NameEqualToCString(p_type, s_interface_mapped_types[i]))
+            return;
+    
+    for(uint32_t i = 0; i < self -> enum_count; i++)
 		if (NameEqual(self -> enums[i] . name, p_type))
 			return;
 			


### PR DESCRIPTION
A long time ago some work was done on mapping generalised data types to
native data types e.g.
- string
  -> objc-string on iOS and Mac
  -> c-string on Windows and Linux
  -> jstring on Android

These types use the `use <language> on <platform>, ...` definitions to
map the generalised type to the appropriate object type for the language
which enables the use of a single handler definition to apply to
multiple languages. All the work was done apart from the error checking
on the types being declared was throwing an error on the generalised
types.
