### PR TITLE
Fix pasting from LiveCode into WordPad on Windows

### DIFF
--- a/docs/notes/bugfix-16522.md
+++ b/docs/notes/bugfix-16522.md
@@ -1,0 +1,2 @@
+# Fix a hang when pasting from LiveCode into WordPad on Windows
+

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -466,7 +466,14 @@ bool MCWin32RawClipboard::PushUpdates()
 
 	// Clipboard is now clean
 	if (t_result == S_OK)
+	{
+		// Flush the clipboard. By doing this now, we ensure that other apps
+		// won't hang if LiveCode is busy processing something and they
+		// attempt to fetch data from the clipboard.
+		OleFlushClipboard();
+		
 		m_dirty = false;
+	}
 
 	return (t_result == S_OK);
 }


### PR DESCRIPTION
Flushing the uploaded data to the clipboard more aggressively removes the dependency on LiveCode pumping messages at the time the clipboard contents are requested.
