### PR TITLE
[Bug 15706] Make sure the ask/answer dialog icon is included in standalones

### DIFF
--- a/docs/notes/bugfix-15706.md
+++ b/docs/notes/bugfix-15706.md
@@ -1,0 +1,1 @@
+#   Mac - Icons to display on ask and answer dialogs - not showing

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -2235,8 +2235,10 @@ private command revBuildStandaloneDeploy pPlatform, pStackFilePath, pEnginePath,
    end if
    
    # AL-2015-01-29: [[ Scriptify IDE ]] Add user script libraries to deploy parameters
+   -- PM-2015-12-07: [[ Bug 15706 ]] Put double quotes around the stack name to avoid confusing the 
+   -- parser when the stack name is 'copy of ...'
    repeat for each line tLine in sUserScriptLibraries
-      put return & "if there is a stack" && tLine && "then library" && tLine after sStandaloneSettingsA["startup_script"]
+      put return & "if there is a stack" && quote & tLine & quote && "then library" && quote & tLine & quote after sStandaloneSettingsA["startup_script"]
    end repeat
    
    # AL-2015-01-29: [[ Scriptify IDE ]] Add OSX App icons to deploy parameters


### PR DESCRIPTION
Previously, sStandaloneSettingsA["startup_script"] could contain the following:

```
if there is a stack copy of revErrorReport then library copy of revErrorReport
```

causing confusion to the parser, since `copy` is a valid command. With this patch, double quotes are put around the stack name:

```
if there is a stack "copy of revErrorReport" then library "copy of revErrorReport"
```
