### PR TITLE
Fix incorrect font metrics under Emscripten

### DIFF
--- a/docs/notes/bugfix-15811_part1.md
+++ b/docs/notes/bugfix-15811_part1.md
@@ -1,0 +1,1 @@
+# Fix incorrect text layout in the HTML5 engine

--- a/engine/src/em-fontlist.cpp
+++ b/engine/src/em-fontlist.cpp
@@ -16,6 +16,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+#include <SkPaint.h>
 #include <SkTypeface.h>
 
 #include "em-fontlist.h"
@@ -70,7 +71,22 @@ MCFontnode::MCFontnode(MCNameRef p_name,
     // Load the font as requested
     m_font_info.fid = emscripten_get_font_by_name(p_name);
 
-    /* FIXME Dummy values */
+    // Calculate the metrics for this typeface and size
+    SkPaint t_paint;
+    t_paint.setTypeface((SkTypeface*)m_font_info.fid);
+    t_paint.setTextSize(p_size);
+        
+    SkPaint::FontMetrics t_metrics;
+        
+    t_paint.getFontMetrics(&t_metrics);
+        
+    // SkPaint::FontMetrics gives the ascent value as a negative offset from the baseline, where we expect the (positive) distance.
+    m_font_info.m_ascent = -t_metrics.fAscent;
+    m_font_info.m_descent = t_metrics.fDescent;
+    m_font_info.m_leading = t_metrics.fLeading;
+    m_font_info.m_xheight = t_metrics.fXHeight;
+
+    // Compatibility metrics calculations
 	m_font_info.size = p_size;
 	m_font_info.ascent = p_size - 1;
 	m_font_info.descent = p_size * 2 / 14 + 1;


### PR DESCRIPTION
The metrics that are used for text layout were being left
uninitialised, which caused much ugliness.
