### PR TITLE
For OSX debug builds, only build the active architecture

### DIFF
--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -176,6 +176,7 @@
 			'xcode_settings':
 			{
 				'ARCHS': 'i386 x86_64',
+				'ONLY_ACTIVE_ARCH': 'YES',
 				'GCC_OPTIMIZATION_LEVEL': '0',
 			},
 		},


### PR DESCRIPTION
This halves the build time when in a edit-recompile-debug cycle as we don't build both 32-bit and 64-bit engines when only one is required.
