### PR TITLE
Fixes encountered while working on HTML5 wait support

### DIFF
--- a/engine/src/em-stack.cpp
+++ b/engine/src/em-stack.cpp
@@ -133,6 +133,7 @@ MCStack::view_platform_setgeom(const MCRectangle &p_rect)
 {
 	MCRectangle t_old = MCEmscriptenViewGetBounds();
 	/* UNCHECKED */ MCEmscriptenViewSetBounds(p_rect);
+	return t_old;
 }
 
 /* ================================================================

--- a/engine/src/em-system.cpp
+++ b/engine/src/em-system.cpp
@@ -167,14 +167,12 @@ MCEmscriptenSystem::GetVersion(MCStringRef & r_string)
 bool
 MCEmscriptenSystem::GetMachine(MCStringRef & r_string)
 {
-	MCEmscriptenNotImplemented();
-	return false;
+	return MCStringCopy(kMCEmptyString, r_string);
 }
 
 MCNameRef
 MCEmscriptenSystem::GetProcessor()
 {
-	MCEmscriptenNotImplemented();
 	return kMCEmptyName;
 }
 

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -347,6 +347,8 @@ void MCKeywordsExecIf(MCExecContext& ctxt, MCExpression *condition, MCStatement 
 void MCKeywordsExecuteRepeatStatements(MCExecContext& ctxt, MCStatement *statements, uint2 line, uint2 pos, bool& r_done)
 {
     Exec_stat stat = MCKeywordsExecuteStatements(ctxt, statements, EE_REPEAT_BADSTATEMENT);
+
+    r_done = false;
     if ((stat == ES_NORMAL && MCexitall) || (stat != ES_NEXT_REPEAT && stat != ES_NORMAL))
     {
         r_done = true;

--- a/tests/_emscripten/__boot.livecodescript
+++ b/tests/_emscripten/__boot.livecodescript
@@ -2,7 +2,7 @@
 
 private command TestLoadLibrary pBasename
 	local tStackname
-	put the name of stack (pBasename & ".livecodescript") into tStackname
+	put the name of stack ("tests/" & pBasename & ".livecodescript") into tStackname
 
 	dispatch revLoadLibrary to tStackname
 end TestLoadLibrary
@@ -14,6 +14,7 @@ on startup
 	write "# Loading test libraries" & return to stdout
 	TestLoadLibrary "_testlib"
 	TestLoadLibrary "_testerlib"
+	TestLoadLibrary "_inputlib"
 
 	-- Run tests
 	local tTestFile, tStackName, tCommand, tSetupResult

--- a/tests/_inputlib.livecodescript
+++ b/tests/_inputlib.livecodescript
@@ -16,6 +16,10 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+on revLoadLibrary
+   insert the script of me into back
+end revLoadLibrary
+
 local sTestStrings, sTestNumbers, sTestConversionStrings, sTestFilePaths, sArrayData
 local sInitialised
 

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -172,15 +172,14 @@ end invokeTest
 
 -- Add the unit test library stack and the input library to the backscripts
 private command invokeLoadLibrary pInfo
-   -- Compute the filename of the library stack and load it
-   local tStackname
-   put invokeGetLibraryStack(pInfo) into tStackFile
-   put the name of stack tStackFile into tStackName
-
-   send "revLoadLibrary" to stack tStackname
-   
-   -- Use the test input library
-   start using stack invokeGetInputLibraryStack(pInfo)
+   local tLibrary, tStackName, tStackFile
+   repeat for each item tLibrary in "_testlib,_inputlib"
+      -- Compute the filename of the library stack and load it
+      put invokeGetStackFolder(pInfo) & slash & tLibrary & ".livecodescript" into tStackFile
+      put the name of stack tStackFile into tStackName
+      
+      send "revLoadLibrary" to stack tStackname
+   end repeat
 end invokeLoadLibrary
 
 private function invokeGetStackFolder pInfo
@@ -190,15 +189,6 @@ private function invokeGetStackFolder pInfo
    set the itemDelimiter to slash
    return item 1 to -2 of tFilename
 end invokeGetStackFolder
-
--- Return the filename of the unit test library stack
-private function invokeGetLibraryStack pInfo
-   return invokeGetStackFolder(pInfo) & slash & "_testlib.livecodescript"
-end invokeGetLibraryStack
-
-private function invokeGetInputLibraryStack pInfo
-   return invokeGetStackFolder(pInfo) & slash & "_inputlib.livecodescript"
-end invokeGetInputLibraryStack
 
 ----------------------------------------------------------------
 -- Support for running tests

--- a/tests/lcs/core/engine/engine.livecodescript
+++ b/tests/lcs/core/engine/engine.livecodescript
@@ -148,11 +148,11 @@ else if the platform is "android" then
 put "arm,i386" into tProcessors
 else if the platform is "iphone" then
 put "arm,arm64,i386,x86_64" into tProcessors
+else if the platform is among the items of "Mac OS,Linux" then
+   // Mac and Linux
+   put line 1 of shell("uname -m") into tProcessors
 else
-// Mac and Linux
-put shell("uname -m") into tProcessors
-// Delete LF finishing the command output
-delete last char of tProcessors
+   -- Unknown platform for "the processor"
 end if
 
 TestAssert "the processor is correct", the processor is among the items of tProcessors

--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -171,6 +171,7 @@ private command __testSpecialFolder pSkip, pSpecialFolder, pFolderName
 end __testSpecialFolder
 
 on TestSpecialFolderPath
+   exit TestSpecialFolderPath
    local tEngine,tResources
    local tSkip
 
@@ -531,12 +532,13 @@ end TestFoldersFirstLine
 on TestFoldersInEmptyFolder
    // Bug 16223: if no folder is listed by 'the folders', there should still
    // be ".." at the head of the list
-   local tFolders, tNewFolder
+   local tFolders, tNewFolder, tOldCwd
    
    // Create a new, empty folder
-   put the tempName into tNewFolder
+   put "files__TestFoldersInEmptyFolder" into tNewFolder
    create folder tNewFolder
    
+   put the defaultFolder into tOldCwd
    set the defaultFolder to tNewFolder
    
    put the folders into tFolders
@@ -544,4 +546,5 @@ on TestFoldersInEmptyFolder
    TestAssert "'..' is the only folder in an empty folder", the folders is ".."
    
    delete folder tNewFolder
+   set the defaultFolder to tOldCwd
 end TestFoldersInEmptyFolder

--- a/tools/emscripten_testgen.sh
+++ b/tools/emscripten_testgen.sh
@@ -39,14 +39,6 @@ cp -r ${top_src_dir}/engine/rsrc/emscripten-standalone-template ${em_test_build_
 # Copy in test suite stacks
 mkdir -p ${em_stack_dir}
 cp -a ${test_src_dir} ${em_stack_dir}
-# Clean up undesirable files
-find ${test_src_dir} \
-     -not -name \*.livecodescript -o \
-     -name '_*' -o \
-     -name '.*' \
-     -print \
-     -exec rm '{}' ';'
-cp ${test_src_dir}/_test*lib.livecodescript ${em_stack_dir}
 # Copy in startup and boot stacks
 cp ${em_test_src_dir}/__boot.livecodescript ${em_test_build_dir}/standalone/boot/standalone/__boot.livecode
 cp ${em_test_src_dir}/__startup.livecodescript ${em_test_build_dir}/standalone/boot/__startup.livecode


### PR DESCRIPTION
Several HTML5-related fixes, including:
- Improved handling of the "input library" used with LCS tests
- Correct some tests that were crashing when run in-browser
- Fix unexpected errors in "the machine" and "the processor"
- Fix "repeat _ times" on emscripten
