### PR TITLE
[Bug 16577] SpecialFolderPath("resources") returns empty when called from a substack

### DIFF
--- a/docs/notes/bugfix-16577.md
+++ b/docs/notes/bugfix-16577.md
@@ -1,0 +1,1 @@
+#  SpecialFolderPath("resources") doesn't work in substack

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -37,6 +37,7 @@
 #include "securemode.h"
 
 #include "system.h"
+#include "object.h"
 
 #include "foundation.h"
 
@@ -375,6 +376,15 @@ void MCS_getresourcesfolder(bool p_standalone, MCStringRef &r_resources_folder)
         uindex_t t_slash_index;
         MCStringRef t_stack_filename;
         t_stack_filename = MCdefaultstackptr -> getfilename();
+		
+		// PM-2015-12-10: [[ Bug 16577 ]] If we are on a substack, use the parent stack filename
+		if (MCStringIsEmpty(t_stack_filename) )
+		{
+			MCStack *t_parent_stack;
+			t_parent_stack = static_cast<MCStack *>(MCdefaultstackptr -> getparent());
+			if (t_parent_stack != NULL)
+				t_stack_filename = t_parent_stack -> getfilename();
+		}
 
         if (!MCStringLastIndexOfChar(t_stack_filename, '/', UINDEX_MAX, kMCStringOptionCompareExact, t_slash_index))
             t_slash_index = MCStringGetLength(t_stack_filename);

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -37,7 +37,6 @@
 #include "securemode.h"
 
 #include "system.h"
-#include "object.h"
 
 #include "foundation.h"
 
@@ -378,7 +377,7 @@ void MCS_getresourcesfolder(bool p_standalone, MCStringRef &r_resources_folder)
         t_stack_filename = MCdefaultstackptr -> getfilename();
 		
 		// PM-2015-12-10: [[ Bug 16577 ]] If we are on a substack, use the parent stack filename
-		if (MCStringIsEmpty(t_stack_filename) )
+		if (MCStringIsEmpty(t_stack_filename))
 		{
 			MCStack *t_parent_stack;
 			t_parent_stack = static_cast<MCStack *>(MCdefaultstackptr -> getparent());


### PR DESCRIPTION
If `specialFolderPath("resources")` is called from a substack, it should use the parent stack's `filename` property, since the `filename` of a substack is always empty
