### PR TITLE
[[ Bug 15429 ]] Fix compilation of nested invokes in inout contexts

### DIFF
--- a/docs/lcb/notes/15429.md
+++ b/docs/lcb/notes/15429.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+## lc-compile
+
+# [15429] Fix compilation of nested invokes in inout contexts.

--- a/tests/lcb/compiler/invoke.lcb
+++ b/tests/lcb/compiler/invoke.lcb
@@ -1,0 +1,67 @@
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.compiler.invoke.tests
+
+/* From Bug 15013 */
+public handler TestInvokeIndexes()
+	variable tArray
+
+   put the empty array into tArray
+   put 1 into tArray["foo"]
+	test "single index" when tArray["foo"] is 1
+
+   put the empty array into tArray
+   put the empty array into tArray["foo"]
+   put 1 into tArray["foo"]["bar"]
+	test "double index" when tArray["foo"]["bar"] is 1
+
+   put the empty array into tArray
+   put the empty array into tArray["foo"]
+   put the empty array into tArray["foo"]["bar"]
+   put 1 into tArray["foo"]["bar"]["baz"]
+	test "triple index" when tArray["foo"]["bar"]["baz"] is 1
+end handler
+
+/* From Bug 15429 */
+private handler DoMutateInOut(inout xVar)
+   add 1 to xVar
+end handler
+
+public handler TestInvokeInOutIndex()
+	variable tArray
+
+   put the empty array into tArray
+   put 0 into tArray["foo"]
+   DoMutateInOut(tArray["foo"])
+	test "single index after inout" when tArray["foo"] is 1
+
+   put the empty array into tArray
+   put the empty array into tArray["foo"]
+   put 0 into tArray["foo"]["bar"]
+   DoMutateInOut(tArray["foo"]["bar"])
+	test "double index after inout" when tArray["foo"]["bar"] is 1
+
+   put the empty array into tArray
+   put the empty array into tArray["foo"]
+   put the empty array into tArray["foo"]["bar"]
+   put 0 into tArray["foo"]["bar"]["baz"]
+   DoMutateInOut(tArray["foo"]["bar"]["baz"])
+	test "triple index after inout" when tArray["foo"]["bar"]["baz"] is 1
+end handler
+
+end module

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1671,7 +1671,8 @@ void EmitDetachRegisterFromExpression(long expr)
             }
     }
     
-    Debug_Emit("DetachRegister(%d, %p)", t_remove -> reg, t_remove -> expr);
+    if (t_remove != nil)
+        Debug_Emit("DetachRegister(%d, %p)", t_remove -> reg, t_remove -> expr);
     
     MCMemoryDelete(t_remove);
 }

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1615,6 +1615,7 @@
     'rule' GenerateExpression(Result, Context, Expr -> Output):
         EmitCreateRegister(-> Output)
         GenerateExpressionInRegister(Result, Context, Expr, Output)
+        GenerateInvoke_FreeArgument(Expr)
 
 'action' GenerateExpressionInRegister(INT, INT, EXPRESSION, INT)
 
@@ -1651,15 +1652,19 @@
     'rule' GenerateExpressionInRegister(Result, Context, logicalor(_, Left, Right), Output):
         EmitDeferLabel(-> ShortLabel)
         GenerateExpressionInRegister(Result, Context, Left, Output)
+        GenerateInvoke_FreeArgument(Left)
         EmitJumpIfTrue(Output, ShortLabel)
         GenerateExpressionInRegister(Result, Context, Right, Output)
+        GenerateInvoke_FreeArgument(Right)
         EmitResolveLabel(ShortLabel)
 
     'rule' GenerateExpressionInRegister(Result, Context, logicaland(_, Left, Right), Output):
         EmitDeferLabel(-> ShortLabel)
         GenerateExpressionInRegister(Result, Context, Left, Output)
+        GenerateInvoke_FreeArgument(Left)
         EmitJumpIfFalse(Output, ShortLabel)
         GenerateExpressionInRegister(Result, Context, Right, Output)
+        GenerateInvoke_FreeArgument(Right)
         EmitResolveLabel(ShortLabel)
 
     'rule' GenerateExpressionInRegister(Result, Context, as(_, _, _), Output):
@@ -1691,7 +1696,6 @@
         EmitEndInvoke()
         EmitDestroyRegister(IgnoredReg)
         GenerateInvoke_AssignArguments(Result, Context, Signature, Arguments)
-        GenerateInvoke_FreeArguments(Arguments)
         
     'rule' GenerateExpressionInRegister(_, _, Expr, _):
         print(Expr)

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -61,7 +61,12 @@ void bootstrap_main(int argc, char *argv[])
     
     for(i = 0; i < argc; i++)
     {
-        if (strcmp(argv[i], "--inputg") == 0 && i + 1 < argc)
+        if (0 == strcmp(argv[i], "-v") || 0 == strcmp(argv[i], "--verbose"))
+        {
+            ++s_verbose_level;
+            continue;
+        }
+        else if (strcmp(argv[i], "--inputg") == 0 && i + 1 < argc)
            SetTemplateFile(argv[++i]);
         else if (strcmp(argv[i], "--outputg") == 0 && i + 1 < argc)
             SetOutputGrammarFile(argv[++i]);


### PR DESCRIPTION
Code which passes nested invokes to an inout argument (whether it be
for an LCB handler, or to a foreign handler via syntax) now compiles
correctly.

The code generation phase was freeing expression register attachments
too soon, meaning that the assignment phase of code generation was
unable to find the appropriate register to use.

Additionally, a consistency check has been added to ensure that when
a handler has finished being compiled all register attachments have
been detached.
