### PR TITLE
Valgrind issues, December 2015 issue

### DIFF
--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1553,13 +1553,17 @@ class MCRead : public MCStatement
 	Functions timeunits;
 	MCExpression *at;
 public:
-	MCRead()
+    MCRead() :
+      arg(OA_UNDEFINED),
+      fname(NULL),
+      cond(RF_UNDEFINED),
+      stop(NULL),
+      unit(FU_CHARACTER),
+      maxwait(NULL),
+      timeunits(F_UNDEFINED),
+      at(NULL)
 	{
-		fname = NULL;
-		maxwait = NULL;
-		stop = NULL;
-		unit = FU_CHARACTER;
-		at = NULL;
+        ;
 	}
 	virtual ~MCRead();
 #ifdef LEGACY_EXEC

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -2339,6 +2339,7 @@ public:
             {
                 MCU_realloc((char **)&MCprocesses, MCnprocesses,
                             MCnprocesses + 1, sizeof(Streamnode));
+                MCprocesses[MCnprocesses].pid = 0;
                 MCprocesses[MCnprocesses].name = (MCNameRef)MCValueRetain(MCM_shell);
                 MCprocesses[MCnprocesses].mode = OM_NEITHER;
                 MCprocesses[MCnprocesses].ohandle = NULL;

--- a/engine/src/fonttable.cpp
+++ b/engine/src/fonttable.cpp
@@ -41,6 +41,13 @@ struct MCLogicalFontTableEntry
 	uint2 textsize;
 };
 
+inline bool operator== (const MCLogicalFontTableEntry& a, const MCLogicalFontTableEntry& b)
+{
+    return a.textfont == b.textfont
+            && a.textstyle == b.textstyle
+            && a.textsize == b.textsize;
+}
+
 static uint32_t s_logical_font_table_size = 0;
 static uint32_t s_logical_font_table_capacity = 0;
 static MCLogicalFontTableEntry *s_logical_font_table = nil;
@@ -57,10 +64,6 @@ static void MCLogicalFontTableGetEntry(uint32_t p_index, MCNameRef& r_textfont, 
 
 static void MCLogicalFontTableSetEntry(uint32_t p_index, MCNameRef p_textfont, uint2 p_textstyle, uint2 p_textsize, bool p_unicode)
 {
-    // Clear the entry - this avoid spurious warnings from valgrind due to
-    // padding bytes in the entries.
-    memset(&s_logical_font_table[p_index], 0, sizeof(MCLogicalFontTableEntry));
-    
     s_logical_font_table[p_index] . textfont = p_textfont;
 	s_logical_font_table[p_index] . textstyle = p_textstyle;
 	s_logical_font_table[p_index] . textsize = p_textsize & 0x7fff;
@@ -78,7 +81,7 @@ static uint32_t MCLogicalFontTableLookupEntry(MCNameRef p_textfont, uint2 p_text
 		t_entry . textsize |= 0x8000;
 	
 	for(uint32_t i = 0; i < s_logical_font_table_size; i++)
-		if (memcmp(&t_entry, &s_logical_font_table[i], sizeof(MCLogicalFontTableEntry)) == 0)
+		if (t_entry == s_logical_font_table[i])
 			return i;
 
 	if (p_add)

--- a/engine/src/fonttable.cpp
+++ b/engine/src/fonttable.cpp
@@ -57,7 +57,11 @@ static void MCLogicalFontTableGetEntry(uint32_t p_index, MCNameRef& r_textfont, 
 
 static void MCLogicalFontTableSetEntry(uint32_t p_index, MCNameRef p_textfont, uint2 p_textstyle, uint2 p_textsize, bool p_unicode)
 {
-	s_logical_font_table[p_index] . textfont = p_textfont;
+    // Clear the entry - this avoid spurious warnings from valgrind due to
+    // padding bytes in the entries.
+    memset(&s_logical_font_table[p_index], 0, sizeof(MCLogicalFontTableEntry));
+    
+    s_logical_font_table[p_index] . textfont = p_textfont;
 	s_logical_font_table[p_index] . textstyle = p_textstyle;
 	s_logical_font_table[p_index] . textsize = p_textsize & 0x7fff;
 	if (p_unicode)

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -115,38 +115,50 @@ MCObjectPropertyTable MCGroup::kPropertyTable =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCGroup::MCGroup()
+MCGroup::MCGroup() :
+  MCControl(),
+  controls(NULL),
+  kfocused(NULL),
+  oldkfocused(NULL),
+  newkfocused(NULL),
+  mfocused(NULL),
+  vscrollbar(NULL),
+  hscrollbar(NULL),
+  scrollx(0),
+  scrolly(0),
+  scrollbarwidth(MCscrollbarwidth),
+  label(MCValueRetain(kMCEmptyString)),
+  minrect(MCU_make_rect(0, 0, 0, 0)),
+  number(MAXUINT2),
+  mgrabbed(False),
+  m_updates_locked(false),
+  m_clips_to_rect(false)
 {
 	flags |= F_TRAVERSAL_ON | F_RADIO_BEHAVIOR | F_GROUP_ONLY;
 	flags &= ~(F_SHOW_BORDER | F_OPAQUE);
-	label = MCValueRetain(kMCEmptyString);
-	controls = NULL;
-	kfocused = mfocused = NULL;
-	newkfocused = oldkfocused = NULL;
-	number = MAXUINT2;
-	leftmargin = rightmargin = topmargin = bottommargin = defaultmargin;
-	vscrollbar = hscrollbar = NULL;
-	scrollx = scrolly = 0;
-	scrollbarwidth = MCscrollbarwidth;
-	minrect.x = minrect.y = minrect.width = minrect.height = 0;
-	
-	// MERG-2013-06-02: [[ GrpLckUpdates ]] Make sure the group's updates are unlocked
-	//   when created.
-    m_updates_locked = false;
-    
-    // MW-2014-06-20: [[ ClipsToRect ]] Initialize to false.
-    m_clips_to_rect = false;
+    leftmargin = rightmargin = topmargin = bottommargin = defaultmargin;
 }
 
-MCGroup::MCGroup(const MCGroup &gref) : MCControl(gref)
+MCGroup::MCGroup(const MCGroup &gref, bool p_copy_ids) :
+  MCControl(gref),
+  controls(NULL),
+  kfocused(NULL),
+  oldkfocused(NULL),
+  newkfocused(NULL),
+  mfocused(NULL),
+  vscrollbar(NULL),
+  hscrollbar(NULL),
+  scrollx(gref.scrollx),
+  scrolly(gref.scrolly),
+  scrollbarwidth(gref.scrollbarwidth),
+  label(MCValueRetain(gref.label)),
+  minrect(gref.minrect),
+  number(MAXUINT2),
+  mgrabbed(False),
+  m_updates_locked(false),
+  m_clips_to_rect(gref.m_clips_to_rect)
 {
-	MCGroup(gref, false);
-}
-
-MCGroup::MCGroup(const MCGroup &gref, bool p_copy_ids) : MCControl(gref)
-{
-	label = MCValueRetain(gref.label);
-	controls = NULL;
+    // Copy the controls
 	if (gref.controls != NULL)
 	{
 		MCControl *optr = gref.controls;
@@ -173,9 +185,8 @@ MCGroup::MCGroup(const MCGroup &gref, bool p_copy_ids) : MCControl(gref)
 		}
 		while (optr != gref.controls);
 	}
-	minrect = gref.minrect;
-	kfocused = mfocused = NULL;
-	number = MAXUINT2;
+
+    // Copy the vertical scrollbar
 	if (gref.vscrollbar != NULL)
 	{
 		vscrollbar = new MCScrollbar(*gref.vscrollbar);
@@ -184,8 +195,8 @@ MCGroup::MCGroup(const MCGroup &gref, bool p_copy_ids) : MCControl(gref)
 		vscrollbar->setflag(flags & F_DISABLED, F_DISABLED);
 		vscrollbar->setembedded();
 	}
-	else
-		vscrollbar = NULL;
+
+    // Copy the horizontal scrollbar
 	if (gref.hscrollbar != NULL)
 	{
 		hscrollbar = new MCScrollbar(*gref.hscrollbar);
@@ -194,18 +205,6 @@ MCGroup::MCGroup(const MCGroup &gref, bool p_copy_ids) : MCControl(gref)
 		hscrollbar->setflag(flags & F_DISABLED, F_DISABLED);
 		hscrollbar->setembedded();
 	}
-	else
-		hscrollbar = NULL;
-	scrollx = gref.scrollx;
-	scrolly = gref.scrolly;
-	scrollbarwidth = gref.scrollbarwidth;
-	
-    // MW-2014-06-20: [[ ClipsToRect ]] Copy other group's value.
-    m_clips_to_rect = gref.m_clips_to_rect;
-    
-	// MERG-2013-06-02: [[ GrpLckUpdates ]] Make sure the group's updates are unlocked
-	//   when cloned.
-    m_updates_locked = false;
 }
 
 MCGroup::~MCGroup()

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -55,7 +55,6 @@ class MCGroup : public MCControl
 	static MCObjectPropertyTable kPropertyTable;
 public:
 	MCGroup();
-	MCGroup(const MCGroup &gref);
 	MCGroup(const MCGroup &gref, bool p_copy_ids);
 	// virtual functions from MCObject
 	virtual ~MCGroup();

--- a/engine/src/image_rep_mutable.cpp
+++ b/engine/src/image_rep_mutable.cpp
@@ -509,8 +509,7 @@ void MCMutableImageRep::startdraw()
 		selrect.x = mx - rect.x;
 		selrect.y = my - rect.y;
 		selrect.width = selrect.height = 1;
-		brect.width = brect.height = 1;
-		selrect = MCU_bound_rect(selrect, rect.x, rect.y, rect.width, rect.height);
+		brect = selrect = MCU_bound_rect(selrect, rect.x, rect.y, rect.width, rect.height);
 		state |= CS_DRAW | CS_OWN_SELECTION;
 
 		MCactiveimage = m_owner;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4391,7 +4391,7 @@ static bool mask_intersects_with_rect(const MCRectangle &p_rect, const object_ma
 		t_src_row = (uint32_t*)t_src_ptr;
 		
 		for (uint32_t x = 0; x < t_rect.width; x++)
-			if (MCGPixelGetNativeAlpha(*t_src_ptr++) > p_threshold)
+			if (MCGPixelGetNativeAlpha(*t_src_row++) > p_threshold)
 				return true;
 		
 		t_src_ptr += p_mask.image->stride;

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1672,7 +1672,7 @@ Boolean MCUIDC::lookupcolor(MCStringRef s, MCColor *color)
 	char *tptr = sptr;
 	while (*tptr)
 		if (isspace((uint1)*tptr))
-			strcpy(tptr, tptr + 1);
+            memmove(tptr, tptr + 1, strlen(tptr));
 		else
 			tptr++;
 	uint2 high = ELEMENTS(color_table);

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -1086,6 +1086,22 @@ bool __MCValueInitialize(void)
 
 void __MCValueFinalize(void)
 {
+    MCMemoryDeleteArray(s_unique_values);
+    s_unique_values = nil;
+    s_unique_value_count = 0;
+    s_unique_value_capacity_idx = 0;
+    
+    MCValueRelease(kMCFalse);
+    kMCFalse = nil;
+    
+    MCValueRelease(kMCTrue);
+    kMCTrue = nil;
+    
+    MCValueRelease(kMCNull);
+    kMCNull = nil;
+    
+    // Make sure to delete the value pools last, as they need to be around until
+    // all other valuerefs have been deleted.
     for(uindex_t i = 0; i < kMCValuePoolCount; i++)
         while(s_value_pools[i] . count > 0)
         {
@@ -1104,20 +1120,7 @@ void __MCValueFinalize(void)
             MCMemoryDelete(t_value);
         }
 	MCMemoryDeleteArray(s_value_pools);
-    
-	MCMemoryDeleteArray(s_unique_values);
-	s_unique_values = nil;
-	s_unique_value_count = 0;
-	s_unique_value_capacity_idx = 0;
-
-	MCValueRelease(kMCFalse);
-	kMCFalse = nil;
-	
-	MCValueRelease(kMCTrue);
-	kMCTrue = nil;
-
-	MCValueRelease(kMCNull);
-	kMCNull = nil;
+    s_value_pools = nil;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes to various issues revealed by running the test system under Valgrind.

Magic options used to run valgrind:

valgrind --num-callers=40 --track-origins=yes --keep-stacktraces=alloc-and-free --malloc-fill=0x55 --free-fill=0xAA

As a side note, be wary of doing this on OSX - I tried it a couple of times under 10.9, and it killed the operating system.
