### PR TITLE
[Tests][emscripten] Fix some incorrect platform skip checks.

### DIFF
--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -179,7 +179,7 @@ on TestSpecialFolderPath
    end if
    
    // Only Linux and HTML5 do not have a Document special folder
-   put the platform contains "linux" or the platform is "html" into tSkip
+   put the platform contains "linux" or the platform is "html5" into tSkip
    __testSpecialFolder tSkip, "documents"
    
    // Only mobiles have Cache special folder
@@ -192,13 +192,13 @@ on TestSpecialFolderPath
    
    // Not all the platforms actually have a Desktop folder - such as servers
    // so we only check that the path returned is not empty.
-   if the environment is "mobile" or the platform is "html" then
+   if the environment is "mobile" or the platform is "html5" then
       TestSkip  "specialFolderPath(desktop) is not empty"
    else
       TestAssert "specialFolderPath(desktop) is not empty", specialFolderPath("desktop") is not empty
    end if
    
-   put the environment is "mobile" or the platform contains "linux" or the platform is "html" into tSkip
+   put the environment is "mobile" or the platform contains "linux" or the platform is "html5" into tSkip
    __testSpecialFolder tSkip, "system"
    __testSpecialFolder tSkip, "support"
 

--- a/tests/lcs/core/interface/interface.livecodescript
+++ b/tests/lcs/core/interface/interface.livecodescript
@@ -713,7 +713,7 @@ end TestMoveControl
 
 -- no key options working properly
 on TestUndo
-   if the platform is "HTML" then
+   if the platform is "HTML5" then
       TestSkip "key options", "bug 16544"
       exit TestUndo
    end if

--- a/tests/lcs/core/multimedia/multimedia.livecodescript
+++ b/tests/lcs/core/multimedia/multimedia.livecodescript
@@ -35,7 +35,7 @@ end if
 end TestMultimedia1
 on TestMultimedia2
 
-if the platform is not among the items of "linux,HTML" and \
+if the platform is not among the items of "linux,HTML5" and \
       the qtversion is not "0.0" then
   TestAssert "test", the qteffects is not empty
 else


### PR DESCRIPTION
Some platform tests weren't correctly updated when changing "the
platform" from "HTML" to "HTML5".

This was due to a slight mismerge in #3372.
