### PR TITLE
[[ Bug 16493 ]] Fix under-retain in MCExecContext::CopyElementAsEnum

### DIFF
--- a/docs/notes/bugfix-16493.md
+++ b/docs/notes/bugfix-16493.md
@@ -1,0 +1,1 @@
+# Fixed instability when using styledText with style arrays containing listStyle or textAlign entries

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -664,7 +664,7 @@ bool MCExecContext::CopyElementAsEnum(MCArrayRef p_array, MCNameRef p_key, bool 
 		return false;
 		
 	MCExecValue t_value;
-	t_value . valueref_value = t_val;
+	t_value . valueref_value = MCValueRetain(t_val);
 	t_value . type = kMCExecValueTypeValueRef;
 	
 	MCExecParseEnum(*this, p_enum_type_info, t_value, r_intenum);


### PR DESCRIPTION
An under-retain in MCExecContext::CopyElementAsEnum manifested itself
as memory corruption when setting listStyle and textAlign properties
of fields via a styledText array.
