### PR TITLE
[[ Bug ]] Ensure out param's 'new argument' status is always set

### DIFF
--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -1413,6 +1413,7 @@ static bool MCScriptPerformForeignInvoke(MCScriptFrame*& x_frame, MCScriptInstan
                 t_argument = nil;
                 
                 // Nothing to free.
+                t_arg_new[t_arg_index] = false;
             }
         }
         


### PR DESCRIPTION
Otherwise the post-invoke cleanup tries to release an invalid pointer.
