### PR TITLE
LCB: Add array expressions to language.

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -522,6 +522,7 @@ The return value of a handler is subsequently available by using **the result** 
       | VariableExpression
       | ResultExpression
       | ListExpression
+      | ArrayExpression
       | CallExpression
 
 There are a number of expressions which are built-in and allow constant values, access to call results, list construction and calls. The remaining syntax for expressions is defined in auxiliary modules.
@@ -576,6 +577,23 @@ A list expression evaluates all the elements in the expression list from left to
 The elements list is optional, so the empty list can be specified as *[]*.
 
 List expressions are not assignable.
+
+## Array Expressions
+
+    ArrayExpression
+      : '{' [ <Contents: ArrayDatumList> ] '}'
+    ArrayDatumList
+      : <Head: ArrayDatum> [ ',' <Tail: ArrayDatumList> ]
+    ArrayDatum
+      : <Key: Expression> ':' <Value: Expression>
+
+An array expression evaluates all of the key and value expressions
+from left to right, and constructs an **Array** value as appropriate.
+Each key expression must evaluate to a **String**.
+
+The contents are optional, so the empty array can be written as `{}`.
+
+Array expressions are not assignable.
 
 ## Call Expressions
 

--- a/docs/lcb/notes/feature-array_expressions.md
+++ b/docs/lcb/notes/feature-array_expressions.md
@@ -1,0 +1,18 @@
+# LiveCode Builder Language
+## Expressions
+
+* It is now possible to use array constants and array expressions in
+  LiveCode Builder programs.  For example:
+
+      variable tArray as Array
+      put {"key": true} into tArray
+
+  Keys in array literals must be strings.
+
+# LiveCode Builder Tools
+## lc-compile
+### Errors
+
+* List expressions with more than 254 elements will now generate an error.
+* Array expressions with more than 127 key-value pairs will now generate an error.
+* Array constants with non-string keys will now generate an error.

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -304,6 +304,9 @@ void MCScriptAddValueToModule(MCScriptModuleBuilderRef builder, MCValueRef value
 void MCScriptBeginListValueInModule(MCScriptModuleBuilderRef builder);
 void MCScriptContinueListValueInModule(MCScriptModuleBuilderRef builder, uindex_t index);
 void MCScriptEndListValueInModule(MCScriptModuleBuilderRef builder, uindex_t& r_index);
+void MCScriptBeginArrayValueInModule(MCScriptModuleBuilderRef builder);
+void MCScriptContinueArrayValueInModule(MCScriptModuleBuilderRef builder, uindex_t key_index, uindex_t value_index);
+void MCScriptEndArrayValueInModule(MCScriptModuleBuilderRef builder, uindex_t& r_index);
 
 void MCScriptAddDefinedTypeToModule(MCScriptModuleBuilderRef builder, uindex_t index, uindex_t& r_type);
 void MCScriptAddForeignTypeToModule(MCScriptModuleBuilderRef builder, MCStringRef p_binding, uindex_t& r_type);
@@ -359,6 +362,9 @@ void MCScriptEmitAssignInModule(MCScriptModuleBuilderRef builder, uindex_t dst_r
 void MCScriptEmitBeginAssignListInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
 void MCScriptEmitContinueAssignListInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
 void MCScriptEmitEndAssignListInModule(MCScriptModuleBuilderRef builder);
+void MCScriptEmitBeginAssignArrayInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
+void MCScriptEmitContinueAssignArrayInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
+void MCScriptEmitEndAssignArrayInModule(MCScriptModuleBuilderRef builder);
 void MCScriptEmitReturnInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
 void MCScriptEmitReturnUndefinedInModule(MCScriptModuleBuilderRef builder);
 void MCScriptBeginInvokeInModule(MCScriptModuleBuilderRef builder, uindex_t handler_index, uindex_t result_reg);

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -279,6 +279,11 @@ bool MCScriptThrowNotABooleanError(MCValueRef p_value)
     return MCErrorCreateAndThrow(kMCScriptNotABooleanValueErrorTypeInfo, "value", p_value, nil);
 }
 
+bool MCScriptThrowNotAStringError(MCValueRef p_value)
+{
+	return MCErrorCreateAndThrow(kMCScriptNotAStringValueErrorTypeInfo, "value", p_value, nil);
+}
+
 bool MCScriptThrowWrongNumberOfArgumentsForInvokeError(MCScriptModuleRef p_module, MCScriptDefinition *p_definition, uindex_t p_provided)
 {
     // TODO: Encode provided / expected.
@@ -2360,6 +2365,58 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                     MCMemoryDeleteArray(t_values);
             }
             break;
+			case kMCScriptBytecodeOpAssignArray:
+			{
+				int t_dst;
+				t_dst = t_arguments[0];
+
+				MCAutoArrayRef t_array;
+				if (!MCArrayCreateMutable(&t_array))
+				{
+					t_success = false;
+				}
+
+				for (int t_arg_ofs = 1; t_success && t_arg_ofs + 1 < t_arity; t_arg_ofs += 2)
+				{
+					MCValueRef t_raw_key, t_value;
+					MCNewAutoNameRef t_key;
+					if (t_success)
+					{
+						t_success = MCScriptCheckedFetchFromRegisterInFrame(t_frame, t_arguments[t_arg_ofs], t_raw_key);
+					}
+					if (t_success)
+					{
+						t_success = MCScriptCheckedFetchFromRegisterInFrame(t_frame, t_arguments[t_arg_ofs + 1], t_value);
+					}
+					if (t_success)
+					{
+						// FIXME allow construction of arrays from
+						// string-bridging foreign values.
+						if (MCValueGetTypeCode(t_raw_key) != kMCValueTypeCodeString)
+						{
+							t_success = MCScriptThrowNotAStringError(t_raw_key);
+						}
+					}
+					if (t_success)
+					{
+						t_success = MCNameCreate(reinterpret_cast<MCStringRef>(t_raw_key), &t_key);
+					}
+					if (t_success)
+					{
+						t_success = MCArrayStoreValue(*t_array, false, *t_key, t_value);
+					}
+				}
+
+				if (t_success)
+				{
+					t_success = t_array.MakeImmutable();
+				}
+				if (t_success)
+				{
+					t_success = MCScriptCheckedStoreToRegisterInFrame(t_frame, t_dst, *t_array);
+				}
+			}
+			break;
         }
         
         // If we failed, then make sure the frame address is up to date.

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -403,6 +403,18 @@ bool MCScriptValidateModule(MCScriptModuleRef self)
                         for(uindex_t i = 0; i < t_arity; i++)
                             t_temporary_count = MCMax(t_temporary_count, t_operands[i] + 1);
                         break;
+                    case kMCScriptBytecodeOpAssignArray:
+	                    // assignarray <dst>, [ <key_1>, <value_1>, ..., <key_n>, <value_n> ]
+	                    if (t_arity < 1)
+		                    goto invalid_bytecode_error;
+	                    if (t_arity % 2 != 1) // parameters must come in pairs
+		                    goto invalid_bytecode_error;
+
+	                    for (uindex_t i = 0; i < t_arity; ++i)
+	                    {
+		                    t_temporary_count = MCMax(t_temporary_count, t_operands[i] + 1);
+	                    }
+	                    break;
                 }
             }
             

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -28,6 +28,7 @@ MCTypeInfoRef kMCScriptInvalidReturnValueErrorTypeInfo;
 MCTypeInfoRef kMCScriptInvalidVariableValueErrorTypeInfo;
 MCTypeInfoRef kMCScriptInvalidArgumentValueErrorTypeInfo;
 MCTypeInfoRef kMCScriptNotABooleanValueErrorTypeInfo;
+MCTypeInfoRef kMCScriptNotAStringValueErrorTypeInfo;
 MCTypeInfoRef kMCScriptWrongNumberOfArgumentsErrorTypeInfo;
 MCTypeInfoRef kMCScriptForeignHandlerBindingErrorTypeInfo;
 MCTypeInfoRef kMCScriptMultiInvokeBindingErrorTypeInfo;
@@ -256,6 +257,8 @@ bool MCScriptInitialize(void)
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.ArgumentValueTypeError"), MCNAME("runtime"), MCSTR("Value is not of correct type for passing as argument - expected type %{type} for passing to parameter %{parameter} of %{module}.%{handler}"), kMCScriptInvalidArgumentValueErrorTypeInfo))
 			return false;
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.NotABooleanValueError"), MCNAME("runtime"), MCSTR("Value is not a boolean"), kMCScriptNotABooleanValueErrorTypeInfo))
+			return false;
+		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.NotAStringValueError"), MCNAME("runtime"), MCSTR("Value is not a string"), kMCScriptNotAStringValueErrorTypeInfo))
 			return false;
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.WrongNumberOfArgumentsError"), MCNAME("runtime"), MCSTR("Wrong number of arguments passed to handler %{module}.%{handler}"), kMCScriptWrongNumberOfArgumentsErrorTypeInfo))
 			return false;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -33,6 +33,7 @@ extern MCTypeInfoRef kMCScriptInvalidReturnValueErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptInvalidVariableValueErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptInvalidArgumentValueErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptNotABooleanValueErrorTypeInfo;
+extern MCTypeInfoRef kMCScriptNotAStringValueErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptWrongNumberOfArgumentsErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptForeignHandlerBindingErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptMultiInvokeBindingErrorTypeInfo;
@@ -576,6 +577,13 @@ enum MCScriptBytecodeOp
     // build a list. (This will be replaced by an invoke when variadic bindings are
     // implemented).
     kMCScriptBytecodeOpAssignList,
+
+	// Array creation assignment.
+	//   assign-array <dst>, <key_1>, <value_1>, ..., <key_n>, <value_n>
+	// Dst is a register.  The remaining arguments are registers and
+	// are used, pair-wise, to build an array. (This will be replaced by an invoke
+	// when variadic bindings are implemented).
+	kMCScriptBytecodeOpAssignArray,
 };
 
 bool MCScriptBytecodeIterate(byte_t*& x_bytecode, byte_t *p_bytecode_limit, MCScriptBytecodeOp& r_op, uindex_t& r_arity, uindex_t *r_arguments);

--- a/tests/lcb/compiler/literals.lcb
+++ b/tests/lcb/compiler/literals.lcb
@@ -28,4 +28,26 @@ public handler TestLiteralNul()
 	test "literal nuls" when the number of chars in tString is 5
 end handler
 
+public handler TestLiteralList()
+	test "empty list constant" when the number of elements in [] is 0
+
+	test "non-empty list constant" when the number of elements in [1] is 1
+
+	variable tValue
+	put "bar" into tValue
+	test "non-empty list expression" when the number of elements in [tValue] is 1
+end handler
+
+public handler TestLiteralArray()
+	test "empty array constant" when the number of elements in {} is 0
+
+	test "non-empty array constant" when the number of elements in {"foo": 1} is 1
+
+	variable tKey
+	put "foo" into tKey
+	variable tValue
+	put {} into tValue
+	test "non-empty array expression" when the number of elements in {tKey: tValue} is 1
+end handler
+
 end module

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -47,6 +47,10 @@
         -- Check that repeat-specific commands are appropriate
         CheckRepeats(Module, 0)
 
+        -- Check that all composite value expressions are built from
+        -- compatible value expressions
+        CheckLiterals(Module)
+
 --------------------------------------------------------------------------------
 
 -- At this point all identifiers either have a defined meaning, or are defined
@@ -452,6 +456,13 @@
 
     'rule' IsExpressionSimpleConstant(list(_, List)):
         IsExpressionListSimpleConstant(List)
+
+    'rule' IsExpressionSimpleConstant(array(_, Pairs)):
+        IsExpressionListSimpleConstant(Pairs)
+
+    'rule' IsExpressionSimpleConstant(pair(_, Key, Value)):
+        IsExpressionSimpleConstant(Key)
+        IsExpressionSimpleConstant(Value)
 
     'rule' IsExpressionSimpleConstant(invoke(Position, invokelist(Info, nil), expressionlist(Operand, nil))):
         Info'Name -> SyntaxName
@@ -1791,6 +1802,47 @@
 
 --------------------------------------------------------------------------------
 
+'sweep' CheckLiterals(ANY)
+
+    'rule' CheckLiterals(EXPRESSION'list(Position, Elements)):
+        (|
+            IsExpressionSimpleConstant(list(Position, Elements))
+        ||
+            QueryExpressionListLength(Elements -> ElementCount)
+            [|
+                gt(ElementCount, 254)
+                Error_ListExpressionTooLong(Position)
+            |]
+        |)
+        CheckLiterals(Elements)
+
+    'rule' CheckLiterals(EXPRESSION'array(Position, Pairs)):
+        (|
+            IsExpressionSimpleConstant(array(Position, Pairs))
+        ||
+            QueryExpressionListLength(Pairs -> PairCount)
+            [|
+                gt(PairCount, 127)
+                Error_ArrayExpressionTooLong(Position)
+            |]
+        |)
+        CheckLiterals(Pairs)
+
+    'rule' CheckLiterals(EXPRESSION'pair(Position, Key, Value)):
+        (|
+            IsExpressionSimpleConstant(Key)
+            (|
+                where(Key -> string(_, _))
+            ||
+                Error_ConstantArrayKeyIsNotStringLiteral(Position)
+            |)
+        ||
+            CheckLiterals(Key)
+        |)
+        CheckLiterals(Value)
+
+--------------------------------------------------------------------------------
+
 'condition' QueryHandlerIdSignature(ID -> SIGNATURE)
 
     'rule' QueryHandlerIdSignature(Id -> Signature)
@@ -1855,5 +1907,15 @@
         Id'Meaning -> Meaning
         
 'condition' QuerySymbolId(ID -> SYMBOLINFO)
+
+--------------------------------------------------------------------------------
+
+'action' QueryExpressionListLength(EXPRESSIONLIST -> INT)
+
+    'rule' QueryExpressionListLength(expressionlist(_, Tail) -> TailCount + 1)
+        QueryExpressionListLength(Tail -> TailCount)
+
+    'rule' QueryExpressionListLength(nil -> 0)
+        -- nothing
 
 --------------------------------------------------------------------------------

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -145,9 +145,15 @@ extern "C" void EmitStringConstant(long value, long *idx);
 extern "C" void EmitBeginListConstant(void);
 extern "C" void EmitContinueListConstant(long idx);
 extern "C" void EmitEndListConstant(long *idx);
+extern "C" void EmitBeginArrayConstant(void);
+extern "C" void EmitContinueArrayConstant(long key_idx, long value_idx);
+extern "C" void EmitEndArrayConstant(long *idx);
 extern "C" void EmitBeginAssignList(long reg);
 extern "C" void EmitContinueAssignList(long reg);
 extern "C" void EmitEndAssignList(void);
+extern "C" void EmitBeginAssignArray(long reg);
+extern "C" void EmitContinueAssignArray(long reg);
+extern "C" void EmitEndAssignArray(void);
 extern "C" void EmitFetch(long reg, long var, long level);
 extern "C" void EmitStore(long reg, long var, long level);
 extern "C" void EmitReturn(long reg);
@@ -1553,6 +1559,27 @@ void EmitEndListConstant(long *idx)
     Debug_Emit("EndListConstant(-> %ld)", *idx);
 }
 
+void EmitBeginArrayConstant(void)
+{
+    MCScriptBeginArrayValueInModule(s_builder);
+
+    Debug_Emit("BeginArrayConstant()", 0);
+}
+
+void EmitContinueArrayConstant(long key_idx, long value_idx)
+{
+	MCScriptContinueArrayValueInModule(s_builder, key_idx, value_idx);
+
+	Debug_Emit("ContinueArrayConstant(%ld, %ld)", key_idx, value_idx);
+}
+
+void EmitEndArrayConstant(long *idx)
+{
+    MCScriptEndArrayValueInModule(s_builder, (uindex_t&)*idx);
+
+    Debug_Emit("EndArrayConstant(-> %ld)", *idx);
+}
+
 void EmitBeginAssignList(long reg)
 {
     MCScriptEmitBeginAssignListInModule(s_builder, reg);
@@ -1572,6 +1599,27 @@ void EmitEndAssignList(void)
     MCScriptEmitEndAssignListInModule(s_builder);
 
     Debug_Emit("EndAssignList()", 0);
+}
+
+void EmitBeginAssignArray(long reg)
+{
+    MCScriptEmitBeginAssignArrayInModule(s_builder, reg);
+
+    Debug_Emit("BeginAssignArray(%ld)", reg);
+}
+
+void EmitContinueAssignArray(long reg)
+{
+    MCScriptEmitContinueAssignArrayInModule(s_builder, reg);
+
+    Debug_Emit("ContinueAssignArray(%ld)", reg);
+}
+
+void EmitEndAssignArray(void)
+{
+    MCScriptEmitEndAssignArrayInModule(s_builder);
+
+    Debug_Emit("EndAssignArray()", 0);
 }
 
 void EmitAssign(long dst, long src)

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -994,6 +994,9 @@
     'rule' TermExpression(-> list(Position, List)):
         "[" @(-> Position) OptionalExpressionList(-> List) "]"
 
+    'rule' TermExpression(-> array(Position, Pairs)):
+        "{" @(-> Position) OptionalExpressionArray(-> Pairs) "}"
+
     'rule' TermExpression(-> Expression):
         "(" Expression(-> Expression) ")"
 
@@ -1057,6 +1060,29 @@
 
     'rule' ExpressionListAsExpression(-> list(Position, List)):
         ExpressionList(-> List) @(-> Position)
+
+----------
+
+'nonterm' OptionalExpressionArray(-> EXPRESSIONLIST)
+
+    'rule' OptionalExpressionArray(-> Pairs):
+        ExpressionArray(-> Pairs)
+
+    'rule' OptionalExpressionArray(-> nil):
+        -- empty
+
+'nonterm' ExpressionArray(-> EXPRESSIONLIST)
+
+    'rule' ExpressionArray(-> expressionlist(Head, Tail)):
+        ExpressionArrayEntry(-> Head) "," ExpressionArray(-> Tail)
+
+    'rule' ExpressionArray(-> expressionlist(Head, nil)):
+        ExpressionArrayEntry(-> Head)
+
+'nonterm' ExpressionArrayEntry(-> EXPRESSION)
+
+    'rule' ExpressionArrayEntry(-> pair(Position, Key, Value)):
+        Expression(-> Key) ":" @(-> Position) Expression(-> Value)
 
 --------------------------------------------------------------------------------
 -- Syntax Syntax

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -320,6 +320,10 @@ DEFINE_ERROR(ExitRepeatOutOfContext, "'exit repeat' must appear within a repeat"
 DEFINE_ERROR(NoReturnTypeSpecifiedForForeignHandler, "Foreign handlers must specify a return type")
 DEFINE_ERROR(NoTypeSpecifiedForForeignHandlerParameter, "Foreign handler parameters must be typed")
 
+DEFINE_ERROR(ConstantArrayKeyIsNotStringLiteral, "Array keys must be strings")
+DEFINE_ERROR(ListExpressionTooLong, "List expressions can have at most 254 elements")
+DEFINE_ERROR(ArrayExpressionTooLong, "Array expressions can have at most 127 keys")
+
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(long p_position) { _Warning(p_position, Message); }
 #define DEFINE_WARNING_I(Name, Message) \

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -229,9 +229,15 @@
     EmitBeginListConstant
     EmitContinueListConstant
     EmitEndListConstant
+    EmitBeginArrayConstant
+    EmitContinueArrayConstant
+    EmitEndArrayConstant
     EmitBeginAssignList
     EmitContinueAssignList
     EmitEndAssignList
+    EmitBeginAssignArray
+    EmitContinueAssignArray
+    EmitEndAssignArray
     EmitFetch
     EmitStore
     EmitReturn
@@ -318,6 +324,9 @@
     Error_InterfaceFileNameMismatch
     Error_NoReturnTypeSpecifiedForForeignHandler
     Error_NoTypeSpecifiedForForeignHandlerParameter
+    Error_ConstantArrayKeyIsNotStringLiteral
+    Error_ListExpressionTooLong
+    Error_ArrayExpressionTooLong
     Warning_MetadataClausesShouldComeAfterUseClauses
     Warning_DeprecatedTypeName
     Warning_UnsuitableNameForDefinition
@@ -594,9 +603,15 @@
 'action' EmitBeginListConstant()
 'action' EmitContinueListConstant(ConstIndex: INT)
 'action' EmitEndListConstant(-> ConstIndex: INT)
+'action' EmitBeginArrayConstant()
+'action' EmitContinueArrayConstant(ConstKeyIndex: INT, ConstValueIndex: INT)
+'action' EmitEndArrayConstant(-> ConstIndex: INT)
 'action' EmitBeginAssignList(Register: INT)
 'action' EmitContinueAssignList(Register: INT)
 'action' EmitEndAssignList()
+'action' EmitBeginAssignArray(Register: INT)
+'action' EmitContinueAssignArray(Register: INT)
+'action' EmitEndAssignArray()
 'action' EmitFetch(Register: INT, Var: INT, Level: INT)
 'action' EmitStore(Register: INT, Var: INT, Level: INT)
 'action' EmitReturn(Register: INT)
@@ -702,6 +717,10 @@
 
 'action' Error_NoReturnTypeSpecifiedForForeignHandler(Position: POS)
 'action' Error_NoTypeSpecifiedForForeignHandlerParameter(Position: POS)
+
+'action' Error_ConstantArrayKeyIsNotStringLiteral(Position: POS)
+'action' Error_ListExpressionTooLong(Position: POS)
+'action' Error_ArrayExpressionTooLong(Position: POS)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -172,6 +172,8 @@
     list(Position: POS, List: EXPRESSIONLIST)
     call(Position: POS, Handler: ID, Arguments: EXPRESSIONLIST)
     invoke(Position: POS, Info: INVOKELIST, Arguments: EXPRESSIONLIST)
+    array(Position: POS, Pairs: EXPRESSIONLIST)
+    pair(Position: POS, Key: EXPRESSION, Value: EXPRESSION)
     nil
 
 'type' INVOKELIST


### PR DESCRIPTION
Add array expressions to the LiveCode Builder language.  They have the
grammar:

```
array          ::= "{" [key-datum-list] "}"
key-datum-list ::= key-datum ("," key-datum)*
key-datum      ::= expression ":" expression
```
