### PR TITLE
Get the "System" and "User" UI fonts on OSX using NSFont

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -541,7 +541,7 @@
 			'<(SHARED_INTERMEDIATE_DIR)/src/quicktimestubs.mac.cpp',
 			
 			# Group "Desktop - Mac"
-			'src/coretextfonts.cpp',
+			'src/coretextfonts.mm',
 			'src/osxflst.cpp',
 			
 			# Group "Desktop - Linux"
@@ -1150,7 +1150,6 @@
 					'sources!':
 					[
 						'src/cgimageutil.cpp',
-						'src/coretextfonts.cpp',
 						'src/syscfdate.cpp',
 						'src/tilecachecg.cpp',
 					],

--- a/engine/src/coretextfonts.mm
+++ b/engine/src/coretextfonts.mm
@@ -111,9 +111,9 @@ static void *coretext_font_create_with_name_and_size(MCStringRef p_name, uint32_
     // On OSX, use the special "system" and "user" fonts where requested. OSX
     // doesn't actually let you get the display-optimised fonts by name (in
     // particular, the optimised Helvetica Neue and San Fransisco fonts).
-    if (MCStringIsEqualToCString(p_name, "System", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - System", kMCStringOptionCompareCaseless))
         return coretext_font_create_system(p_size);
-    if (MCStringIsEqualToCString(p_name, "User", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - User", kMCStringOptionCompareCaseless))
         return coretext_font_create_user(p_size);
 #endif
     

--- a/engine/src/coretextfonts.mm
+++ b/engine/src/coretextfonts.mm
@@ -30,6 +30,7 @@
 #import <CoreText/CoreText.h>
 #else
 #import <ApplicationServices/ApplicationServices.h>
+#import <AppKit/NSFont.h>
 #endif
 
 #ifdef TARGET_SUBPLATFORM_IPHONE
@@ -75,6 +76,18 @@ void ios_clear_font_mapping(void)
 }
 #endif
 
+#ifndef TARGET_SUBPLATFORM_IPHONE
+static void* coretext_font_create_system(uint32_t p_size)
+{
+    return [[NSFont systemFontOfSize: p_size] retain];
+}
+
+static void* coretext_font_create_user(uint32_t p_size)
+{
+    return [[NSFont userFontOfSize: p_size] retain];
+}
+#endif
+
 static void *coretext_font_create_with_name_and_size(MCStringRef p_name, uint32_t p_size)
 {
 	/*CFStringRef t_name;
@@ -94,6 +107,16 @@ static void *coretext_font_create_with_name_and_size(MCStringRef p_name, uint32_
     bool t_success;
     t_success = true;
 
+#ifndef TARGET_SUBPLATFORM_IPHONE
+    // On OSX, use the special "system" and "user" fonts where requested. OSX
+    // doesn't actually let you get the display-optimised fonts by name (in
+    // particular, the optimised Helvetica Neue and San Fransisco fonts).
+    if (MCStringIsEqualToCString(p_name, "System", kMCStringOptionCompareCaseless))
+        return coretext_font_create_system(p_size);
+    if (MCStringIsEqualToCString(p_name, "User", kMCStringOptionCompareCaseless))
+        return coretext_font_create_user(p_size);
+#endif
+    
     // SN-2015-02-16: [[ iOS Font mapping ]] On iOS, try to fetch the mapped
     //  if one exists.
     //  Defaults to the given name if no one matches, or on MacOS

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1684,12 +1684,12 @@ MCFontStruct *MCDispatch::loadfont(MCNameRef fname, uint2 &size, uint2 style, Bo
 	return fonts->getfont(fname, size, style, printer);
 }
 
-MCFontStruct *MCDispatch::loadfontwithhandle(MCSysFontHandle p_handle)
+MCFontStruct *MCDispatch::loadfontwithhandle(MCSysFontHandle p_handle, MCNameRef p_name)
 {
 #if defined(_MACOSX) || defined (_MAC_SERVER)
     if (fonts == nil)
         fonts = new MCFontlist;
-    return fonts->getfontbyhandle(p_handle);
+    return fonts->getfontbyhandle(p_handle, p_name);
 #else
     return NULL;
 #endif

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -178,7 +178,7 @@ public:
 	void enter(Window w);
     void redraw(Window w, MCRegionRef dirty_region);
 	MCFontStruct *loadfont(MCNameRef fname, uint2 &size, uint2 style, Boolean printer);
-    MCFontStruct *loadfontwithhandle(MCSysFontHandle);
+    MCFontStruct *loadfontwithhandle(MCSysFontHandle, MCNameRef p_name);
 	
 	// This method iterates through all stacks and ensures none have a reference
 	// to one of the ones in MCcursors.

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -162,10 +162,10 @@ bool MCFontCreateWithFontStruct(MCNameRef p_name, MCFontStyle p_style, int32_t p
 	return true;
 }
 
-bool MCFontCreateWithHandle(MCSysFontHandle p_handle, MCFontRef& r_font)
+bool MCFontCreateWithHandle(MCSysFontHandle p_handle, MCNameRef p_name, MCFontRef& r_font)
 {
     MCFontStruct* t_font_struct;
-    t_font_struct = MCdispatcher->loadfontwithhandle(p_handle);
+    t_font_struct = MCdispatcher->loadfontwithhandle(p_handle, p_name);
     if (t_font_struct == nil)
         return false;
     

--- a/engine/src/font.h
+++ b/engine/src/font.h
@@ -45,7 +45,7 @@ void MCFontFinalize(void);
 
 bool MCFontCreate(MCNameRef name, MCFontStyle style, int32_t size, MCFontRef& r_font);
 bool MCFontCreateWithFontStruct(MCNameRef name, MCFontStyle style, int32_t size, MCFontStruct*, MCFontRef& r_font);
-bool MCFontCreateWithHandle(MCSysFontHandle, MCFontRef& r_font);
+bool MCFontCreateWithHandle(MCSysFontHandle, MCNameRef name, MCFontRef& r_font);
 MCFontRef MCFontRetain(MCFontRef font);
 void MCFontRelease(MCFontRef font);
 

--- a/engine/src/mac-theme.mm
+++ b/engine/src/mac-theme.mm
@@ -282,6 +282,7 @@ bool MCPlatformGetControlThemePropFont(MCPlatformControlType p_type, MCPlatformC
     static MCFontRef s_system_font_13;
     
     MCFontRef* t_which_fontref = nil;
+    MCNameRef t_font_name;
     
     NSFont* t_font = nil;
     switch (p_type)
@@ -290,12 +291,14 @@ bool MCPlatformGetControlThemePropFont(MCPlatformControlType p_type, MCPlatformC
             t_which_fontref = t_font_size == 11 ? &s_user_font_11 : &s_user_font_13;
             if (*t_which_fontref == nil)
                 t_font = [[NSFont userFontOfSize: t_font_size] retain];
+            t_font_name = MCNAME("Aqua UI Font - User");
             break;
             
         default:
             t_which_fontref = t_font_size == 11 ? &s_system_font_11 : &s_system_font_13;
             if (*t_which_fontref == nil)
                 t_font = [[NSFont systemFontOfSize: t_font_size] retain];
+            t_font_name = MCNAME("Aqua UI Font - System");
             break;
     }
     
@@ -305,7 +308,7 @@ bool MCPlatformGetControlThemePropFont(MCPlatformControlType p_type, MCPlatformC
     if (*t_which_fontref == nil)
     {
         // Create the in-engine font representation
-        MCFontCreateWithHandle((MCSysFontHandle)t_font, *t_which_fontref);
+        MCFontCreateWithHandle((MCSysFontHandle)t_font, t_font_name, *t_which_fontref);
     }
 
     r_font = MCFontRetain(*t_which_fontref);

--- a/engine/src/osxflst.cpp
+++ b/engine/src/osxflst.cpp
@@ -100,9 +100,13 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style)
     calculatemetrics();
 }
 
-MCFontnode::MCFontnode(MCSysFontHandle p_handle)
+MCFontnode::MCFontnode(MCSysFontHandle p_handle, MCNameRef p_name)
 {
-    coretext_get_font_name(p_handle, reqname);
+    if (p_name == nil)
+        coretext_get_font_name(p_handle, reqname);
+    else
+        reqname = MCValueRetain(p_name);
+    
     reqsize = coretext_get_font_size(p_handle);
     reqstyle = FA_DEFAULT_STYLE | FA_SYSTEM_FONT;
     
@@ -177,7 +181,7 @@ MCFontStruct *MCFontlist::getfont(MCNameRef fname, uint2 &size, uint2 style, Boo
 	return tmp->getfont(fname, size, style);
 }
 
-MCFontStruct *MCFontlist::getfontbyhandle(MCSysFontHandle p_fid)
+MCFontStruct *MCFontlist::getfontbyhandle(MCSysFontHandle p_fid, MCNameRef p_name)
 {
     MCFontnode *tmp = fonts;
     if (tmp != NULL)
@@ -191,7 +195,7 @@ MCFontStruct *MCFontlist::getfontbyhandle(MCSysFontHandle p_fid)
     while (tmp != fonts);
     
     // Font has not yet been added to the list
-    tmp = new MCFontnode(p_fid);
+    tmp = new MCFontnode(p_fid, p_name);
     tmp->appendto(fonts);
     return tmp->getfontstruct();
 }

--- a/engine/src/osxflst.h
+++ b/engine/src/osxflst.h
@@ -31,7 +31,7 @@ class MCFontnode : public MCDLlist
 public:
     
 	MCFontnode(MCNameRef fname, uint2 &size, uint2 style);
-    MCFontnode(MCSysFontHandle);
+    MCFontnode(MCSysFontHandle, MCNameRef name);
 	~MCFontnode();
     
 	MCFontStruct *getfont(MCNameRef fname, uint2 size, uint2 style);
@@ -104,6 +104,6 @@ public:
 	bool getfontstyles(MCStringRef p_fname, uint2 fsize, MCListRef& r_styles);
 	bool getfontstructinfo(MCNameRef& r_name, uint2 &r_size, uint2 &r_style, Boolean &r_printer, MCFontStruct *p_font);
 
-    MCFontStruct *getfontbyhandle(MCSysFontHandle);
+    MCFontStruct *getfontbyhandle(MCSysFontHandle, MCNameRef name);
 };
 #endif


### PR DESCRIPTION
The font that you get by requesting "Helvetica Neue" on OSX is
_not_ the same as the HN display font used by the system. To get
that one, [NSFont systemFontOfSize:] is required. And similarly
for the user font.

This patch changes the CoreText font code to handle those names
specially and return the appropriate magic font.
