### PR TITLE
[Bug 16691][emscripten] Fix typo in startup script

### DIFF
--- a/docs/notes/bugfix-16691.md
+++ b/docs/notes/bugfix-16691.md
@@ -1,0 +1,1 @@
+# Fix LCB extension loading in HTML5 startup script

--- a/engine/rsrc/emscripten-startup-template.livecodescript
+++ b/engine/rsrc/emscripten-startup-template.livecodescript
@@ -96,7 +96,7 @@ on startup
          close file kExtensionListFile
          
          repeat for each line tModuleName in tModuleList
-            put tExtensionFolder & slash & tModuleName into tFolder
+            put kExtensionFolder & slash & tModuleName into tFolder
             
             load extension from file (tFolder & slash & "module.lcm") \
                   with resource path (tFolder & slash & "resources")
@@ -116,7 +116,7 @@ on startup
    
    -- Try to print something vaguely helpful to the the log
    if tError is not empty then
-      write "startup failed:" && tError to stderr
+      write "startup failed:" && tError & return to stderr
    end if
    
    return tError


### PR DESCRIPTION
Fix a typo in the HTML5 standalone startup script template that was
preventing the engine from loading any LCB extensions.  The typo made
the startup script unable to correctly compute the filesystem path for
the extension bytecode.
