### PR TITLE
[Bug 16696] Ensure that the correct release notes are installed

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -144,7 +144,7 @@ component Misc
 			textfile "private:License Agreement.txt"
 			textfile "private:about.txt"
 		textfile "ide:Open Source Licenses.txt"
-		file "ide:Release Notes.pdf"
+		file "repo:LiveCodeNotes-[[EscapedVersionTag]].pdf" as "Release Notes.pdf"
 
 component Plugins
 	into [[ToolsFolder]]/Plugins place

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -80,6 +80,10 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
          put "Commercial" into tBaseEditionType
          break
    end switch
+
+   -- Escape the version (by replacing all non-alphanumeric characters with "_")
+   local tVersionEscaped
+   put replaceText(pVersion,"\W","_") into tVersionEscaped
    
    -- Compute the package temp folder
    local tTempFolder
@@ -137,6 +141,7 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    end if
    packageCompilerConfigureVariable tPackager, "TodaysDate", "[[todaysDate]]"
    packageCompilerConfigureVariable tPackager, "VersionTag", pVersion
+   packageCompilerConfigureVariable tPackager, "EscapedVersionTag", tVersionEscaped
    packageCompilerConfigureVariable tPackager, "ProductBranch", char 1 to 3 of pVersion
    packageCompilerConfigureVariable tPackager, "TargetArchitectures", "i386"
    if pPlatform is "linux-x86" then

--- a/docs/notes/bugfix-16696.md
+++ b/docs/notes/bugfix-16696.md
@@ -1,0 +1,1 @@
+# Include the correct version's release notes in the installer


### PR DESCRIPTION
Change the package manifest to copy the release notes directly from
the top level of the livecode repository.  This is where the
freshly-built release notes are placed by the release notes builder.

Because the file that's copied into the installer has the version
number in its filename, this should also ensure that the installer
always contains the correct version of the release notes.
