### PR TITLE
[[ Bug 16351 ]] Make MCtargetptr an MCObjectPtr 

### DIFF
--- a/docs/notes/bugfix-16351.md
+++ b/docs/notes/bugfix-16351.md
@@ -1,0 +1,2 @@
+# After a dispatch command, the long id of the target resolves correctly 
+for shared groups and their children

--- a/docs/notes/bugfix-16351.md
+++ b/docs/notes/bugfix-16351.md
@@ -1,2 +1,1 @@
-# After a dispatch command, the long id of the target resolves correctly 
-for shared groups and their children
+# After a dispatch command, the long id of the target resolves correctly for shared groups and their children

--- a/engine/src/cardlst.cpp
+++ b/engine/src/cardlst.cpp
@@ -88,7 +88,7 @@ bool MCCardlist::GetRecent(MCExecContext& ctxt, MCStack *stack, Properties which
 				if (which == P_SHORT_NAME)
 					tmp -> card -> GetShortName(ctxt, &t_property);
 				else
-					tmp -> card -> GetLongId(ctxt, &t_property);
+					tmp -> card -> GetLongId(ctxt, 0, &t_property);
 					
 				t_success = !ctxt . HasError();
 				if (t_success)

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -902,10 +902,12 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
                 case DT_ME:
                     //MCEngineEvalMeAsObject(ctxt, t_object);
                     if (ctxt . GetParentScript() == NULL)
+                    {
                         t_object . object = destobj;
+                        t_object . part_id = 0;
+                    }
                     else
-                        t_object . object = ctxt . GetObject();
-                    t_object . part_id = 0;
+                        t_object = ctxt . GetObjectPtr();
                     break;
                 case DT_MENU_OBJECT:
                     MCEngineEvalMenuObjectAsObject(ctxt, t_object);

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -4433,6 +4433,7 @@ void MCRelayer::exec_ctxt(MCExecContext& ctxt)
             MCInterfaceExecRelayer(ctxt, relation, t_source, t_layer);
             break;
         case kMCRelayerFormRelativeToControl:
+        {
             MCObjectPtr t_target;
             if (!target -> getobj(ctxt, t_target, True))
             {
@@ -4440,6 +4441,7 @@ void MCRelayer::exec_ctxt(MCExecContext& ctxt)
                 return;
             }
             MCInterfaceExecRelayerRelativeToControl(ctxt, relation, t_source, t_target);
+        }
             break;
         case kMCRelayerFormRelativeToOwner:
             MCInterfaceExecRelayerRelativeToOwner(ctxt, relation, t_source);

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -1611,6 +1611,7 @@ void MCHide::exec_ctxt(MCExecContext &ctxt)
 		MCInterfaceExecHideGroups(ctxt);
 		break;
 	case SO_OBJECT:
+    {
 		MCObjectPtr t_target;
         if (!object->getobj(ctxt, t_target, True))
 		{
@@ -1621,6 +1622,7 @@ void MCHide::exec_ctxt(MCExecContext &ctxt)
 			MCInterfaceExecHideObjectWithEffect(ctxt, t_target, effect);
 		else
 			MCInterfaceExecHideObject(ctxt, t_target);
+    }
 		break;
 	case SO_MENU:
 		MCInterfaceExecHideMenuBar(ctxt);

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -373,7 +373,7 @@ Exec_stat MCDispatch::handle(Handler_type htype, MCNameRef mess, MCParameter *pa
     }
     
 	if (MCmessagemessages && stat != ES_PASS)
-		MCtargetptr->sendmessage(htype, mess, False);
+		MCtargetptr . object -> sendmessage(htype, mess, False);
 		
 	if (t_has_passed)
 		return ES_PASS;

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -602,18 +602,18 @@ void MCEngineEvalMe(MCExecContext& ctxt, MCStringRef& r_string)
 
 void MCEngineEvalTarget(MCExecContext& ctxt, MCStringRef& r_string)
 {
-	if (MCtargetptr == nil)
+	if (MCtargetptr . object == nil)
 		r_string = MCValueRetain(kMCEmptyString);
 	else
-		MCtargetptr->getstringprop(ctxt, 0, P_NAME, False, r_string);
+		MCtargetptr . object -> getstringprop(ctxt, MCtargetptr . part_id, P_NAME, False, r_string);
 }
 
 void MCEngineEvalTargetContents(MCExecContext& ctxt, MCStringRef& r_string)
 {
-	if (MCtargetptr == nil)
+	if (MCtargetptr . object == nil)
 		r_string = MCValueRetain(kMCEmptyString);
 	else
-		MCtargetptr->getstringprop(ctxt, 0, MCtargetptr->gettype() == CT_FIELD ? P_TEXT : P_NAME, False, r_string);
+		MCtargetptr . object -> getstringprop(ctxt, MCtargetptr . part_id, MCtargetptr . object -> gettype() == CT_FIELD ? P_TEXT : P_NAME, False, r_string);
 }
 
 //////////
@@ -1169,22 +1169,22 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int p_handler_type, MCNameRef p_m
 	}
 	
 	// Work out the target object
-	MCObject *t_object;
+	MCObjectPtr t_object;
 	if (p_target != nil)
-		t_object = p_target -> object;
+		t_object = *p_target;
 	else
-		t_object = ctxt . GetObject();
+		t_object = ctxt . GetObjectPtr();
 		
 	// Fetch current default stack and target settings
 	MCStack *t_old_stack;
 	t_old_stack = MCdefaultstackptr;
-	MCObject *t_old_target;
+	MCObjectPtr t_old_target;
 	t_old_target = MCtargetptr;
 	
 	// Cache the current 'this stack' (used to see if we should switch back
 	// the default stack).
 	MCStack *t_this_stack;
-	t_this_stack = t_object -> getstack();
+	t_this_stack = t_object . object -> getstack();
 	
 	// Retarget this stack and the target to be relative to the target object
 	MCdefaultstackptr = t_this_stack;
@@ -1212,7 +1212,7 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int p_handler_type, MCNameRef p_m
 	Boolean olddynamic = MCdynamicpath;
 	MCdynamicpath = MCdynamiccard != NULL;
 	if (t_stat == ES_PASS || t_stat == ES_NOT_HANDLED)
-		switch(t_stat = t_object->handle((Handler_type)p_handler_type, p_message, p_parameters, t_object))
+		switch(t_stat = t_object . object -> handle((Handler_type)p_handler_type, p_message, p_parameters, t_object . object))
 		{
 		case ES_ERROR:
 			ctxt . LegacyThrow(EE_DISPATCH_BADCOMMAND, p_message);
@@ -1856,20 +1856,12 @@ void MCEngineEvalMeAsObject(MCExecContext& ctxt, MCObjectPtr& r_object)
     // refers to the derived object context, otherwise it is the object
     // we were compiled in.
     
-    MCObject *t_object;
+    MCObjectPtr t_object;
     
     if (ctxt . GetParentScript() == NULL)
-        t_object = nil; // destobj!
+        r_object . object = nil; // destobj!
     else
-        t_object = ctxt . GetObject();
-
-        r_object . object = t_object;
-        r_object . part_id = 0;
-    
-    if (t_object != nil)
-        return;
-    
-  //  ctxt . LegacyThrow(EE_CHUNK_NOTARGET);
+        r_object = ctxt . GetObjectPtr();
 }
 
 void MCEngineEvalMenuObjectAsObject(MCExecContext& ctxt, MCObjectPtr& r_object)
@@ -1886,10 +1878,9 @@ void MCEngineEvalMenuObjectAsObject(MCExecContext& ctxt, MCObjectPtr& r_object)
 
 void MCEngineEvalTargetAsObject(MCExecContext& ctxt, MCObjectPtr& r_object)
 {
-    if (MCtargetptr != nil)
+    if (MCtargetptr . object != nil)
     {
-        r_object . object = MCtargetptr;
-        r_object . part_id = 0;
+        r_object = MCtargetptr;
         return;
     }
     

--- a/engine/src/exec-interface-card.cpp
+++ b/engine/src/exec-interface-card.cpp
@@ -277,9 +277,9 @@ void MCCard::GetDefaultButton(MCExecContext& ctxt, MCStringRef& r_button)
 		return;
 	else
 		if (defbutton != nil)
-			defbutton -> GetLongId(ctxt, r_button);
+			defbutton -> GetLongId(ctxt, 0, r_button);
 		else
-			odefbutton -> GetLongId(ctxt, r_button);
+			odefbutton -> GetLongId(ctxt, 0, r_button);
 }
 
 void MCCard::SetForePixel(MCExecContext& ctxt, uinteger_t* pixel)

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1342,20 +1342,20 @@ void MCObject::GetAbbrevId(MCExecContext& ctxt, MCStringRef& r_abbrev_id)
 	ctxt . Throw();
 }
 
-void MCObject::GetLongName(MCExecContext& ctxt, MCStringRef& r_long_name)
+void MCObject::GetLongName(MCExecContext& ctxt, uint32_t p_part_id, MCStringRef& r_long_name)
 {
 	MCAutoValueRef t_long_name;
-	if (names(P_LONG_NAME, &t_long_name))
+	if (getnameproperty(P_LONG_NAME, p_part_id, &t_long_name))
 		if (ctxt.ConvertToString(*t_long_name, r_long_name))
 			return;
 	
 	ctxt . Throw();
 }
 
-void MCObject::GetLongId(MCExecContext& ctxt, MCStringRef& r_long_id)
+void MCObject::GetLongId(MCExecContext& ctxt, uint32_t p_part_id, MCStringRef& r_long_id)
 {
 	MCAutoValueRef t_long_id;
-	if (names(P_LONG_ID, &t_long_id))
+	if (getnameproperty(P_LONG_ID, p_part_id, &t_long_id))
 		if (ctxt.ConvertToString(*t_long_id, r_long_id))
 			return;
 	
@@ -3252,10 +3252,10 @@ void MCObject::GetAbbrevOwner(MCExecContext& ctxt, MCStringRef& r_owner)
 		parent -> GetAbbrevName(ctxt, r_owner);
 }
 
-void MCObject::GetLongOwner(MCExecContext& ctxt, MCStringRef& r_owner)
+void MCObject::GetLongOwner(MCExecContext& ctxt, uint32_t p_part_id, MCStringRef& r_owner)
 {
 	if (parent != nil)
-		parent -> GetLongName(ctxt, r_owner);
+        parent -> GetLongName(ctxt, p_part_id, r_owner);
 }
 
 void MCObject::DoGetProperties(MCExecContext& ctxt, uint32_t part, bool p_effective, MCArrayRef& r_props)

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1001,7 +1001,7 @@ void MCStack::SetIcon(MCExecContext& ctxt, uinteger_t p_id)
 void MCStack::GetOwner(MCExecContext& ctxt, MCStringRef& r_owner)
 {
 	if (parent != nil && !MCdispatcher -> ismainstack(this))
-		parent -> GetLongId(ctxt, r_owner);
+		parent -> GetLongId(ctxt, 0, r_owner);
 }
 
 void MCStack::GetMainStack(MCExecContext& ctxt, MCStringRef& r_main_stack)

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2804,7 +2804,7 @@ void MCInterfaceExecPopupButton(MCExecContext& ctxt, MCButton *p_target, MCPoint
 		while (t_state)
 		{
 			if (t_state & 0x1)
-				MCtargetptr -> mup(t_which, true);
+				MCtargetptr . object -> mup(t_which, true);
 			t_state >>= 1;
 			t_which += 1;
 		}
@@ -2960,13 +2960,13 @@ void MCInterfaceExecOpenStackByName(MCExecContext& ctxt, MCNameRef p_name, int p
 void MCInterfaceExecPopupStack(MCExecContext& ctxt, MCStack *p_target, MCPoint *p_at, int p_mode)
 {
 	// MW-2007-04-10: [[ Bug 4260 ]] We shouldn't attempt to attach a menu to a control that is descendent of itself
-	if (MCtargetptr -> getstack() == p_target)
+	if (MCtargetptr . object -> getstack() == p_target)
 	{
 		ctxt . LegacyThrow(EE_SUBWINDOW_BADEXP);
 		return;
 	}
 
-	if (MCtargetptr->attachmenu(p_target))
+	if (MCtargetptr . object -> attachmenu(p_target))
 	{
 		if (p_mode == WM_POPUP && p_at != nil)
 		{
@@ -2974,7 +2974,7 @@ void MCInterfaceExecPopupStack(MCExecContext& ctxt, MCStack *p_target, MCPoint *
 			MCmousey = p_at -> y;
 		}
 		MCRectangle t_rect;
-		t_rect = MCU_recttoroot(MCtargetptr->getstack(), MCtargetptr->getrect());
+		t_rect = MCU_recttoroot(MCtargetptr . object -> getstack(), MCtargetptr . object -> getrect());
 		MCInterfaceExecSubwindow(ctxt, p_target, nil, t_rect, WP_DEFAULT, OP_NONE, p_mode);
 		if (!MCabortscript)
 			return;

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -3819,7 +3819,7 @@ void MCInterfaceExecResolveImageById(MCExecContext& ctxt, MCObject *p_object, ui
     if (t_found_image != nil)
     {
         
-        t_found_image -> GetLongId(ctxt, &t_long_id);
+        t_found_image -> GetLongId(ctxt, 0, &t_long_id);
         if (!ctxt . HasError())
             ctxt . SetItToValue(*t_long_id);
     }
@@ -3837,7 +3837,7 @@ void MCInterfaceExecResolveImageByName(MCExecContext& ctxt, MCObject *p_object, 
     
     if (t_found_image != nil)
     {
-        t_found_image -> GetLongId(ctxt, &t_long_id);
+        t_found_image -> GetLongId(ctxt, 0, &t_long_id);
         if (!ctxt . HasError())
             ctxt . SetItToValue(*t_long_id);
     }

--- a/engine/src/exec-misc.cpp
+++ b/engine/src/exec-misc.cpp
@@ -325,8 +325,8 @@ void MCMiscExecClearTouches(MCExecContext& ctxt)
     MCEventQueueClearTouches();
 
     // PM-2015-03-16: [[ Bug 14333 ]] Make sure the object that triggered a mouse down msg is not focused, as this stops later mouse downs from working
-    if (MCtargetptr != nil)
-        MCtargetptr -> munfocus();
+    if (MCtargetptr . object != nil)
+        MCtargetptr . object -> munfocus();
 }
 
 void MCMiscGetSystemIdentifier(MCExecContext& ctxt, MCStringRef& r_identifier)
@@ -372,7 +372,7 @@ void MCMiscGetReachabilityTarget(MCExecContext& ctxt, MCStringRef& r_hostname)
 
 void MCMiscExecLibUrlDownloadToFile(MCExecContext& ctxt, MCStringRef p_url, MCStringRef p_filename)
 {
-    MCS_downloadurl(MCtargetptr, p_url, p_filename);
+    MCS_downloadurl(MCtargetptr . object, p_url, p_filename);
 }
 
 void MCMiscExecLibUrlSetSSLVerification(MCExecContext& ctxt, bool p_enabled)

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1187,7 +1187,7 @@ MCVarref* MCExecContext::GetIt() const
 #ifdef _SERVER
     // If we are here it means we must be in global scope, executing in a
     // MCServerScript object.
-    return static_cast<MCServerScript *>(m_object) -> GetIt();
+    return static_cast<MCServerScript *>(m_object . object) -> GetIt();
 #else
     // We should never get here as execution only occurs within handlers unless
     // in server mode.

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1272,7 +1272,8 @@ public:
     MCExecContext(MCObject *object, MCHandlerlist *hlist, MCHandler *handler)
     {
         memset(this, 0, sizeof(MCExecContext));
-        m_object = object;
+        m_object . object = object;
+        m_object . part_id = 0;
         m_hlist = hlist;
         m_curhandler = handler;
         m_itemdel = MCValueRetain(kMCCommaString);
@@ -1651,10 +1652,21 @@ public:
     
     MCObject *GetObject(void) const
 	{
-        return m_object;
+        return m_object . object;
 	}
 
-	void SetObject(MCObject *p_object)
+    MCObjectPtr GetObjectPtr(void) const
+    {
+        return m_object;
+    }
+    
+    void SetObject(MCObject *p_object)
+    {
+        m_object . object = p_object;
+        m_object . part_id = 0;
+    }
+    
+	void SetObjectPtr(MCObjectPtr p_object)
 	{
         m_object = p_object;
     }
@@ -1778,7 +1790,7 @@ private:
 #endif
 	Exec_stat m_stat;
 
-    MCObject *m_object;
+    MCObjectPtr m_object;
 
     // MW-2009-01-30: [[ Inherited parentScripts ]]
     // We store a reference to the parentScript use which is the current context

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -1154,7 +1154,7 @@ static MCExternalError MCExternalContextQuery(MCExternalContextQueryTag op, MCEx
         case kMCExternalContextQueryTarget:
         {
             MCObjectHandle *t_handle;
-            t_handle = MCtargetptr -> gethandle();
+            t_handle = MCtargetptr . object -> gethandle();
             if (t_handle == nil)
                 return kMCExternalErrorOutOfMemory;
             *(MCObjectHandle **)result = t_handle;

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -273,7 +273,7 @@ MCCard *MCdynamiccard;
 Boolean MCdynamicpath;
 MCObject *MCerrorptr;
 MCObject *MCerrorlockptr;
-MCObject *MCtargetptr;
+MCObjectPtr MCtargetptr;
 MCObject *MCmenuobjectptr;
 MCGroup *MCsavegroupptr;
 MCGroup *MCdefaultmenubar;
@@ -663,7 +663,7 @@ void X_clear_globals(void)
 	MCdynamicpath = False;
 	MCerrorptr = nil;
 	MCerrorlockptr = nil;
-	MCtargetptr = nil;
+	memset(&MCtargetptr, 0, sizeof(MCObjectPtr));
 	MCmenuobjectptr = nil;
 	MCsavegroupptr = nil;
 	MCdefaultmenubar = nil;

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -181,7 +181,7 @@ extern MCStack *MCstaticdefaultstackptr;
 extern MCStack *MCmousestackptr;
 extern MCStack *MCclickstackptr;
 extern MCStack *MCfocusedstackptr;
-extern MCObject *MCtargetptr;
+extern MCObjectPtr MCtargetptr;
 extern MCObject *MCmenuobjectptr;
 extern MCCard *MCdynamiccard;
 extern Boolean MCdynamicpath;

--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -729,7 +729,7 @@ static bool enumerate_handlers(MCExecContext& ctxt, const char *p_type, MCHandle
 		if (p_first && p_object != nil)
         {
             t_format = "%s%s %@ %d %d %@";
-            p_object -> GetLongId(ctxt, &t_long_id);
+            p_object -> GetLongId(ctxt, 0, &t_long_id);
         }
         else
             t_format = "%s%s %@ %d %d";

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -5706,7 +5706,7 @@ Exec_stat MCHandlePick(void *context, MCParameter *p_parameters)
         
 	// call the Exec method to process the pick wheel
     // The function sets the result itself.
-	MCPickExecPickOptionByIndex(ctxt, kMCChunkTypeLine, t_option_lists . Ptr(), t_option_lists . Size(), t_indices . Ptr(), t_indices . Size(),t_use_checkmark, t_use_picker, t_use_cancel, t_use_done, MCtargetptr->getrect());
+	MCPickExecPickOptionByIndex(ctxt, kMCChunkTypeLine, t_option_lists . Ptr(), t_option_lists . Size(), t_indices . Ptr(), t_indices . Size(),t_use_checkmark, t_use_picker, t_use_cancel, t_use_done, MCtargetptr . object -> getrect());
     
     // Free memory
     for (uindex_t i = 0; i < t_option_lists . Size(); i++)
@@ -5904,13 +5904,13 @@ Exec_stat MCHandlePickDate(void *context, MCParameter *p_parameters)
     {
         // MM-2012-03-15: [[ Bug ]] Make sure we handle no type being passed.
         if (t_type == nil)
-            MCPickExecPickDate(ctxt, *t_current, *t_start, *t_end, (intenum_t)t_button_type, MCtargetptr->getrect());
+            MCPickExecPickDate(ctxt, *t_current, *t_start, *t_end, (intenum_t)t_button_type, MCtargetptr . object -> getrect());
         else if (MCCStringEqualCaseless("time", t_type))
-            MCPickExecPickTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr->getrect());
+            MCPickExecPickTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr . object -> getrect());
         else if (MCCStringEqualCaseless("datetime", t_type))
-            MCPickExecPickDateAndTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr->getrect());
+            MCPickExecPickDateAndTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr . object -> getrect());
         else
-            MCPickExecPickDate(ctxt, *t_current, *t_start, *t_end, (intenum_t)t_button_type, MCtargetptr->getrect());
+            MCPickExecPickDate(ctxt, *t_current, *t_start, *t_end, (intenum_t)t_button_type, MCtargetptr . object -> getrect());
     }
     
     MCCStringFree(t_type);
@@ -6071,7 +6071,7 @@ Exec_stat MCHandlePickTime(void *context, MCParameter *p_parameters)
     ctxt.SetTheResultToEmpty();
     
 	if (t_success)
-		MCPickExecPickTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr->getrect());
+		MCPickExecPickTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr . object -> getrect());
     
 	if (!ctxt . HasError())
 		return ES_NORMAL;
@@ -6230,7 +6230,7 @@ Exec_stat MCHandlePickDateAndTime(void *context, MCParameter *p_parameters)
     ctxt.SetTheResultToEmpty();
        
 	if (t_success)
-		MCPickExecPickDateAndTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr->getrect());
+		MCPickExecPickDateAndTime(ctxt, *t_current, *t_start, *t_end, t_step_ptr, (intenum_t)t_button_type, MCtargetptr . object -> getrect());
     
 	if (!ctxt . HasError())
 		return ES_NORMAL;

--- a/engine/src/mbliphonecamera.mm
+++ b/engine/src/mbliphonecamera.mm
@@ -179,10 +179,10 @@ static MCIPhoneImagePickerDialog *s_image_picker = nil;
 		t_main_controller = MCIPhoneGetViewController();
 		
 		CGRect t_rect;
-		if (MCtargetptr != nil)
+		if (MCtargetptr . object != nil)
 		{
 			MCRectangle t_mc_rect;
-			t_mc_rect = MCtargetptr -> getrect();
+			t_mc_rect = MCtargetptr . object -> getrect();
 			t_rect = MCUserRectToLogicalCGRect(t_mc_rect);
 		}
 		else

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -609,7 +609,7 @@ public:
 		if (s_payload_minizip != nil)
 		{
 			ExtractContext t_context;
-			t_context . target = MCtargetptr -> gethandle();
+			t_context . target = MCtargetptr . object -> gethandle();
 			t_context . name = *t_item;
             t_context . var = ctxt . GetIt() -> evalvar(ctxt);
 			t_context . stream = nil;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2044,7 +2044,7 @@ Exec_stat MCObject::dispatch(Handler_type p_type, MCNameRef p_message, MCParamet
 	// Fetch current default stack and target settings
 	MCStack *t_old_stack;
 	t_old_stack = MCdefaultstackptr;
-	MCObject *t_old_target;
+	MCObjectPtr t_old_target;
 	t_old_target = MCtargetptr;
 	
 	// Cache the current 'this stack' (used to see if we should switch back
@@ -2054,7 +2054,8 @@ Exec_stat MCObject::dispatch(Handler_type p_type, MCNameRef p_message, MCParamet
 	
 	// Retarget this stack and the target to be relative to the target object
 	MCdefaultstackptr = t_this_stack;
-	MCtargetptr = this;
+	MCtargetptr . object = this;
+    MCtargetptr . part_id = 0;
 
 	// Dispatch the message
 	Exec_stat t_stat;
@@ -2089,11 +2090,12 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
 	MCscreen->flush(mystack->getw());
 
 	MCStack *oldstackptr = MCdefaultstackptr;
-	MCObject *oldtargetptr = MCtargetptr;
+	MCObjectPtr oldtargetptr = MCtargetptr;
 	if (changedefault)
 	{
 		MCdefaultstackptr = mystack;
-		MCtargetptr = this;
+		MCtargetptr . object = this;
+        MCtargetptr . part_id = 0;
 	}
 	Boolean olddynamic = MCdynamicpath;
 	MCdynamicpath = False;
@@ -2291,97 +2293,108 @@ Exec_stat MCObject::names_old(Properties which, MCExecPoint& ep, uint32_t parid)
 }
 #endif
 
-bool MCObject::names(Properties which, MCValueRef& r_name_val)
+bool MCObject::getnameproperty(Properties which, uint32_t p_part_id, MCValueRef& r_name_val)
 {
-	MCStringRef &r_name = (MCStringRef&)r_name_val;
-	
-	const char *itypestring = gettypestring();
-	MCAutoPointer<char> tmptypestring;
-	if (parent != NULL && gettype() >= CT_BUTTON && getstack()->hcaddress())
-	{
-		tmptypestring = new char[strlen(itypestring) + 7];
-		if (parent->gettype() == CT_GROUP)
-			sprintf(*tmptypestring, "%s %s", "bkgnd", itypestring);
-		else
-			sprintf(*tmptypestring, "%s %s", "card", itypestring);
-		itypestring = *tmptypestring;
-	}
-	switch (which)
-	{
-	case P_ID:
-	case P_SHORT_ID:
-		return MCStringFormat(r_name, "%u", obj_id);
-	case P_ABBREV_ID:
-		return MCStringFormat(r_name, "%s id %d", itypestring, obj_id);
-
-	// The stack object has its own version of long * which we check for here. We
-	// could make 'names()' virtual and do this that way, but since there shouldn't
-	// really be an exception to how id is formatted (and there won't be for any
-	// future object types) we handle it here.
-	case P_LONG_NAME:
-	case P_LONG_ID:
-		if (gettype() == CT_STACK)
-		{
-			MCStack *t_this;
-			t_this = static_cast<MCStack *>(this);
-			
-			MCStringRef t_filename;
-			t_filename = t_this -> getfilename();
-			if (MCStringIsEmpty(t_filename))
-			{
-				if (MCdispatcher->ismainstack(t_this))
-				{
-					if (!isunnamed())
-						return MCStringFormat(r_name, "stack \"%@\"", getname());
-					r_name = MCValueRetain(kMCEmptyString);
-					return true;
-				}
-				if (isunnamed())
-				{
-					r_name = MCValueRetain(kMCEmptyString);
-					return true;
-				}
-				which = P_LONG_NAME;
-			}
-			else
-				return MCStringFormat(r_name, "stack \"%@\"", t_filename);
-		}
-
-		// MW-2013-01-15: [[ Bug 2629 ]] If this control is unnamed, use the abbrev id form
-		//   but *only* for this control (continue with names the rest of the way).
-		Properties t_which_requested;
-		t_which_requested = which;
-		if (which == P_LONG_NAME && isunnamed())
-			which = P_LONG_ID;
-		if (parent != NULL)
-		{
-			MCAutoValueRef t_parent;
-			if (!parent -> names(t_which_requested, &t_parent))
-				return false;
-			if (gettype() == CT_GROUP && parent->gettype() == CT_STACK)
-				itypestring = "bkgnd";
-			if (which == P_LONG_ID)
-				return MCStringFormat(r_name, "%s id %d of %@", itypestring, obj_id, *t_parent);
-			return MCStringFormat(r_name, "%s \"%@\" of %@", itypestring, getname(), *t_parent);
-		}
-		return MCStringFormat(r_name, "the template%c%s", MCS_toupper(itypestring[0]), itypestring + 1);
-
-	case P_NAME:
-	case P_ABBREV_NAME:
-		if (isunnamed())
-            return names(P_ABBREV_ID, r_name_val);
-		return MCStringFormat(r_name, "%s \"%@\"", itypestring, getname());
-	case P_SHORT_NAME:
+    MCStringRef &r_name = (MCStringRef&)r_name_val;
+    
+    const char *itypestring = gettypestring();
+    MCAutoPointer<char> tmptypestring;
+    if (parent != NULL && gettype() >= CT_BUTTON && getstack()->hcaddress())
+    {
+        tmptypestring = new char[strlen(itypestring) + 7];
+        if (parent->gettype() == CT_GROUP)
+            sprintf(*tmptypestring, "%s %s", "bkgnd", itypestring);
+        else
+            sprintf(*tmptypestring, "%s %s", "card", itypestring);
+        itypestring = *tmptypestring;
+    }
+    switch (which)
+    {
+        case P_ID:
+        case P_SHORT_ID:
+            return MCStringFormat(r_name, "%u", obj_id);
+        case P_ABBREV_ID:
+            return MCStringFormat(r_name, "%s id %d", itypestring, obj_id);
+            
+            // The stack object has its own version of long * which we check for here. We
+            // could make 'names()' virtual and do this that way, but since there shouldn't
+            // really be an exception to how id is formatted (and there won't be for any
+            // future object types) we handle it here.
+        case P_LONG_NAME:
+        case P_LONG_ID:
+            if (gettype() == CT_STACK)
+            {
+                MCStack *t_this;
+                t_this = static_cast<MCStack *>(this);
+                
+                MCStringRef t_filename;
+                t_filename = t_this -> getfilename();
+                if (MCStringIsEmpty(t_filename))
+                {
+                    if (MCdispatcher->ismainstack(t_this))
+                    {
+                        if (!isunnamed())
+                            return MCStringFormat(r_name, "stack \"%@\"", getname());
+                        r_name = MCValueRetain(kMCEmptyString);
+                        return true;
+                    }
+                    if (isunnamed())
+                    {
+                        r_name = MCValueRetain(kMCEmptyString);
+                        return true;
+                    }
+                    which = P_LONG_NAME;
+                }
+                else
+                    return MCStringFormat(r_name, "stack \"%@\"", t_filename);
+            }
+            
+            // MW-2013-01-15: [[ Bug 2629 ]] If this control is unnamed, use the abbrev id form
+            //   but *only* for this control (continue with names the rest of the way).
+            Properties t_which_requested;
+            t_which_requested = which;
+            if (which == P_LONG_NAME && isunnamed())
+                which = P_LONG_ID;
+            if (parent != NULL)
+            {
+                MCObject *t_parent_object;
+                if (parent -> gettype() == CT_CARD)
+                    t_parent_object = getcard(p_part_id);
+                else
+                    t_parent_object = parent;
+                
+                MCAutoValueRef t_parent;
+                if (!t_parent_object -> getnameproperty(t_which_requested, p_part_id, &t_parent))
+                    return false;
+                if (gettype() == CT_GROUP && t_parent_object->gettype() == CT_STACK)
+                    itypestring = "bkgnd";
+                if (which == P_LONG_ID)
+                    return MCStringFormat(r_name, "%s id %d of %@", itypestring, obj_id, *t_parent);
+                return MCStringFormat(r_name, "%s \"%@\" of %@", itypestring, getname(), *t_parent);
+            }
+            return MCStringFormat(r_name, "the template%c%s", MCS_toupper(itypestring[0]), itypestring + 1);
+            
+        case P_NAME:
+        case P_ABBREV_NAME:
+            if (isunnamed())
+                return names(P_ABBREV_ID, r_name_val);
+            return MCStringFormat(r_name, "%s \"%@\"", itypestring, getname());
+        case P_SHORT_NAME:
             if (isunnamed())
                 return names(P_ABBREV_ID, r_name_val);
             r_name = MCValueRetain(MCNameGetString(getname()));
-		return true;
-	default:
-		break;
-	}
+            return true;
+        default:
+            break;
+    }
+    
+    // Shouldn't actually get here, so just return false.
+    return false;
+}
 
-	// Shouldn't actually get here, so just return false.
-	return false;
+bool MCObject::names(Properties which, MCValueRef& r_name_val)
+{
+    return getnameproperty(which, 0, r_name_val);
 }
 
 // MW-2012-10-17: [[ Bug 10476 ]] Returns true if message should be fired.
@@ -2830,8 +2843,9 @@ Exec_stat MCObject::domess(MCStringRef sptr)
 		return ES_ERROR;
 	}
 	MCerrorlock--;
-	MCObject *oldtargetptr = MCtargetptr;
-	MCtargetptr = this;
+	MCObjectPtr oldtargetptr = MCtargetptr;
+	MCtargetptr . object = this;
+    MCtargetptr . part_id = 0;
 	MCHandler *hptr;
     handlist->findhandler(HT_MESSAGE, MCM_message, hptr);
 
@@ -2864,8 +2878,9 @@ void MCObject::eval(MCExecContext &ctxt, MCStringRef p_script, MCValueRef &r_val
 		ctxt.Throw();
 		return;
 	}
-	MCObject *oldtargetptr = MCtargetptr;
-	MCtargetptr = this;
+	MCObjectPtr oldtargetptr = MCtargetptr;
+	MCtargetptr . object = this;
+    MCtargetptr . part_id = 0;
 	MCHandler *hptr;
 	MCHandler *oldhandler = ctxt.GetHandler();
 	MCHandlerlist *oldhlist = ctxt.GetHandlerList();

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -687,6 +687,8 @@ public:
 	// New method for returning the various 'names' of an object. This should really
 	// return an 'MCValueRef' at some point, but as it stands that causes issues.
 	bool names(Properties which, MCValueRef& r_name);
+    bool getnameproperty(Properties which, uint32_t p_part_id, MCValueRef& r_name_val);
+    
 #ifdef LEGACY_EXEC
 	// Wrapper for 'names()' working in the old way (for convenience).
 	Exec_stat names_old(Properties which, MCExecPoint& ep, uint32_t parid);
@@ -917,8 +919,8 @@ public:
 	void GetId(MCExecContext& ctxt, uint32_t& r_id);
 	virtual void SetId(MCExecContext& ctxt, uint32_t id);
 	void GetAbbrevId(MCExecContext& ctxt, MCStringRef& r_abbrev_id);
-	void GetLongName(MCExecContext& ctxt, MCStringRef& r_long_name);
-	void GetLongId(MCExecContext& ctxt, MCStringRef& r_long_id);
+	void GetLongName(MCExecContext& ctxt, uint32_t p_part_id, MCStringRef& r_long_name);
+	void GetLongId(MCExecContext& ctxt, uint32_t p_part_id, MCStringRef& r_long_id);
 	void GetName(MCExecContext& ctxt, MCStringRef& r_name);
 	virtual void SetName(MCExecContext& ctxt, MCStringRef name);
 	void GetAbbrevName(MCExecContext& ctxt, MCStringRef& r_abbrev_name);
@@ -1080,7 +1082,7 @@ public:
 	void GetOwner(MCExecContext& ctxt, MCStringRef& r_owner);
 	void GetShortOwner(MCExecContext& ctxt, MCStringRef& r_owner);
 	void GetAbbrevOwner(MCExecContext& ctxt, MCStringRef& r_owner);
-	void GetLongOwner(MCExecContext& ctxt, MCStringRef& r_owner);
+	void GetLongOwner(MCExecContext& ctxt, uint32_t p_part_id, MCStringRef& r_owner);
 
 	void GetProperties(MCExecContext& ctxt, uint32_t part, MCArrayRef& r_props);
 	void SetProperties(MCExecContext& ctxt, uint32_t part, MCArrayRef props);

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -69,12 +69,12 @@ MCPropertyInfo MCObject::kProperties[] =
 	DEFINE_RW_OBJ_PROPERTY(P_ID, UInt32, MCObject, Id)
 	DEFINE_RW_OBJ_PROPERTY(P_SHORT_ID, UInt32, MCObject, Id)
 	DEFINE_RO_OBJ_PROPERTY(P_ABBREV_ID, String, MCObject, AbbrevId)
-	DEFINE_RO_OBJ_PROPERTY(P_LONG_ID, String, MCObject, LongId)
+	DEFINE_RO_OBJ_PART_PROPERTY(P_LONG_ID, String, MCObject, LongId)
 	DEFINE_RW_OBJ_PROPERTY(P_NAME, String, MCObject, Name)
     // SN-2014-08-25: [[ Bug 13276 ]] Added the property definition for 'abbreviated name'
     DEFINE_RO_OBJ_PROPERTY(P_ABBREV_NAME, String, MCObject, AbbrevName)
 	DEFINE_RO_OBJ_PROPERTY(P_SHORT_NAME, String, MCObject, ShortName)
-	DEFINE_RO_OBJ_PROPERTY(P_LONG_NAME, String, MCObject, LongName)
+	DEFINE_RO_OBJ_PART_PROPERTY(P_LONG_NAME, String, MCObject, LongName)
 	DEFINE_RW_OBJ_PROPERTY(P_ALT_ID, UInt32, MCObject, AltId)
 	DEFINE_RW_OBJ_PART_CUSTOM_PROPERTY(P_LAYER, InterfaceLayer, MCObject, Layer)
 	DEFINE_RW_OBJ_PROPERTY(P_SCRIPT, String, MCObject, Script)
@@ -183,7 +183,7 @@ MCPropertyInfo MCObject::kProperties[] =
 	DEFINE_RO_OBJ_PROPERTY(P_OWNER, OptionalString, MCObject, Owner)
 	DEFINE_RO_OBJ_PROPERTY(P_SHORT_OWNER, OptionalString, MCObject, ShortOwner)
 	DEFINE_RO_OBJ_PROPERTY(P_ABBREV_OWNER, OptionalString, MCObject, AbbrevOwner)
-	DEFINE_RO_OBJ_PROPERTY(P_LONG_OWNER, OptionalString, MCObject, LongOwner)
+	DEFINE_RO_OBJ_PART_PROPERTY(P_LONG_OWNER, OptionalString, MCObject, LongOwner)
 
 	DEFINE_RW_OBJ_PART_NON_EFFECTIVE_PROPERTY(P_PROPERTIES, Array, MCObject, Properties)
     // MERG-2013-05-07: [[ RevisedPropsProp ]] Add support for 'the effective
@@ -451,8 +451,9 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
         
 		MCStack *oldstackptr = MCdefaultstackptr;
 		MCdefaultstackptr = getstack();
-		MCObject *oldtargetptr = MCtargetptr;
-		MCtargetptr = this;
+		MCObjectPtr oldtargetptr = MCtargetptr;
+		MCtargetptr . object = this;
+        MCtargetptr . part_id = 0;
 		Boolean added = False;
 		if (MCnexecutioncontexts < MAX_CONTEXTS)
 		{
@@ -1637,8 +1638,9 @@ Exec_stat MCObject::sendsetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		
 		MCStack *oldstackptr = MCdefaultstackptr;
 		MCdefaultstackptr = getstack();
-		MCObject *oldtargetptr = MCtargetptr;
-		MCtargetptr = this;
+		MCObjectPtr oldtargetptr = MCtargetptr;
+		MCtargetptr . object = this;
+        MCtargetptr . part_id = 0;
 		Boolean added = False;
 		if (MCnexecutioncontexts < MAX_CONTEXTS)
 		{

--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -1374,6 +1374,13 @@ struct MCObjectPtr
 {
 	MCObject *object;
 	uint32_t part_id;
+    
+    MCObjectPtr& operator = (const MCObjectPtr& p_obj_ptr)
+    {
+        object = p_obj_ptr . object;
+        part_id = p_obj_ptr . part_id;
+        return *this;
+    }
 };
 
 // NOTE: the indices in this structure are UTF-16 code unit indices if the value is a stringref,

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -781,13 +781,14 @@ bool MCWidgetBase::Dispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_ar
 	MCStack *t_old_default_stack, *t_this_stack;
 	t_old_default_stack = MCdefaultstackptr;
 	
-    MCObject *t_old_target;
+    MCObjectPtr t_old_target;
     if (GetHost() != nil)
     {
         t_old_target = MCtargetptr;
         
-        MCtargetptr = GetHost();
-        t_this_stack = MCtargetptr->getstack();
+        MCtargetptr . object = GetHost();
+        MCtargetptr . part_id = 0;
+        t_this_stack = MCtargetptr . object -> getstack();
         MCdefaultstackptr = t_this_stack;
     }
     else


### PR DESCRIPTION
The initial work to ensure that 'the target' keeps track of the
part id as well as the object pointer. This will prevent 'the long
id of the target' from always resolving to the instance on the
current card when the target is a shared group.

This does not yet go all the way to fixing bug 10822 however, as
the part id is not yet passed as a parameter into intenal MCObject
functions such as message and dispatch, or when retrieving custom
properties (as in the example for bug 10822)

It does do the groundwork for fixing 10822 however, and it fixes the
issue in the specific case when the dispatch / send / call syntax is
used in script.
