### PR TITLE
Don't allow drag-and-drop onto OSX backdrop windows

### DIFF
--- a/docs/notes/bugfix-16699.md
+++ b/docs/notes/bugfix-16699.md
@@ -1,0 +1,2 @@
+# Fix a crash when dragging onto a backdrop on OSX
+

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1591,6 +1591,8 @@ MCDragAction MCDispatch::wmdragmove(Window w, int2 x, int2 y)
 	static uint4 s_old_modifiers = 0;
 
 	MCStack *target = findstackd(w);
+    if (target == nil)
+        return DRAG_ACTION_NONE;
 	
 	// IM-2013-10-08: [[ FullscreenMode ]] Translate mouse location to stack coords
 	MCPoint t_mouseloc;


### PR DESCRIPTION
There is no associated MCStack object so there is nothing to handle
the operation, resulting in NULL dereference.
