### PR TITLE
Ensure Win32 drag-and-drop doesn't crash with only private data

### DIFF
--- a/docs/notes/bugfix-16667.md
+++ b/docs/notes/bugfix-16667.md
@@ -1,0 +1,2 @@
+# Fix a crash when dragging in the project browser on Windows
+

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -554,6 +554,10 @@ bool MCClipboard::AddPrivateData(MCDataRef p_private_data)
         MCValueRelease(m_private_data);
     m_private_data = MCValueRetain(p_private_data);
     
+    // Ensure that an item is always on the clipboard, even if it is empty
+    if (m_clipboard->GetItemCount() == 0)
+        m_clipboard->AddItem(m_clipboard->CreateNewItem());
+    
     return true;
 }
 

--- a/engine/src/w32-clipboard.h
+++ b/engine/src/w32-clipboard.h
@@ -77,6 +77,10 @@ public:
     
 	// Returns the data object representing the clipboard data
 	IDataObject* GetIDataObject() const;
+    
+    // Returns m_object cast to MCWin32DataObject if the data is non-external.
+    // Will return NULL if m_object_is_external is true.
+    MCWin32DataObject* GetDataObject();
 
 private:
     
@@ -96,10 +100,6 @@ private:
 	MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_parent);
 	MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_parent, IDataObject* p_external_data);
 	~MCWin32RawClipboardItem();
-
-	// Returns m_object cast to MCWin32DataObject if the data is non-external.
-	// Will return NULL if m_object_is_external is true.
-	MCWin32DataObject* GetDataObject();
 
 	// Ensures that the representations have been loaded if the data is from
 	// an external source. Does nothing if the data is local.

--- a/engine/src/w32dnd.cpp
+++ b/engine/src/w32dnd.cpp
@@ -116,9 +116,11 @@ MCDragAction MCScreenDC::dodragdrop(Window w, MCDragActionSet p_allowed_actions,
 			t_success = false;
 	}
 	
-	// Get the IDataObject from the dragboard
+	// Get the IDataObject from the dragboard. Because we need one for the
+	// COM drag-and-drop API, we call the method that forces one to be
+	// created if it does not yet exist.
 	MCRawClipboard* t_dragboard = MCdragboard->GetRawClipboard();
-	IDataObject* t_transfer_data = (static_cast<MCWin32RawClipboardItem*>(t_dragboard->GetItemAtIndex(0)))->GetIDataObject();
+	IDataObject* t_transfer_data = (static_cast<MCWin32RawClipboardItem*>(t_dragboard->GetItemAtIndex(0)))->GetDataObject();
 
 	IDragSourceHelper *t_source_helper;
 	t_source_helper = NULL;


### PR DESCRIPTION
Because the COM drag-and-drop data object wasn't being created
when private data was added, the drag code crashed.
