### PR TITLE
build: Fix release note warnings and ensure new ones will error

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -153,7 +153,8 @@ dist-docs-commercial:
 
 dist-notes:
 	WKHTMLTOPDF=$(WKHTMLTOPDF) \
-	$(buildtool_command) --platform $(buildtool_platform) --stage notes
+	$(buildtool_command) --platform $(buildtool_platform) \
+	    --stage notes --warn-as-error
 
 ifeq ($(BUILD_EDITION),commercial)
 dist-server: dist-server-commercial

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -254,8 +254,8 @@ filenames.
 
 Each file details a single bug fix or feature implementation.
 
-* Name the files "bugfix-<bug number>.md" or
-"feature-<description>.md"
+* Name the files "bugfix-<bug number>.md",
+  "bugfix-<bug number>-suffix.md", or "feature-<description>.md"
 
 * Put the title as the first line, e.g. "# <title>"
 
@@ -423,7 +423,7 @@ private function V1NotesGetBugId pFileInfo
    put pFileInfo["basename"] into tBasename
    
    -- Try strict mode first, and issue a warning if no match
-   get matchText(tBasename, "(?i)^bugfix-(\d*)$", tBugId)
+   get matchText(tBasename, "(?i)^bugfix-(\d*)($|-)", tBugId)
    if tBugId is not empty then
       return tBugId
    end if

--- a/docs/notes/bugfix-15811_part1.md
+++ b/docs/notes/bugfix-15811_part1.md
@@ -1,1 +1,5 @@
+---
+version: 8.0.0-dp-12
+basename: bugfix-15811-part1
+---
 # Fix incorrect text layout in the HTML5 engine


### PR DESCRIPTION
- Fix a release note warning due to a release note fragment with a funny filename
- Allow release notes name `bugfix-<number>-<suffix>.md` (even though you can override the effective basename in a YAML header)
- Make all release note build warnings into errors when packaging LiveCode
