### PR TITLE
[[ Community Docs ]] Update parameter names and descriptions in entry for 'ask password'

### DIFF
--- a/docs/dictionary/command/ask-password.lcdoc
+++ b/docs/dictionary/command/ask-password.lcdoc
@@ -2,7 +2,7 @@ Name: ask password
 
 Type: command
 
-Syntax: ask password [clear] <question> [with <defaultAnswer>] [titled <windowTitle>] [as sheet]
+Syntax: ask password [clear] <question> [with <defaultResponse>] [titled <windowTitle>] [as sheet]
 
 Summary: Displays a <dialog box> like the <ask> <command>, but with the characters the user types displayed as asterisks (*) for privacy.
 
@@ -26,8 +26,7 @@ Example:
 ask password "Please log in:" with "PASSWORD" titled "Password Test"
 
 Parameters:
-question (string): 
-defaultAnswer: 
+question (string): The string to display as a prompt above the password entry box. 
 windowTitle: If specified, appears in the title bar of the dialog box. If no windowTitle is given, the title bar is blank.
 defaultResponse: Placed in the text box when the dialog box appears. If no defaultResponse is specified, the text box is empty when the dialog box appears.
 


### PR DESCRIPTION
- Changed **defaultAnswer** parameter name to **defaultResponse**
