### PR TITLE
docs: Link to docs contribution guide from CONTRIBUTING file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 ![LiveCode Community Logo](http://livecode.com/wp-content/uploads/2015/02/livecode-logo.png)
 
-Copyright © 2003-2015 LiveCode Ltd., Edinburgh, UK
+Copyright © 2003-2016 LiveCode Ltd., Edinburgh, UK
+
+See also the [documentation contributions guide](docs/contributing_to_docs.md).
 
 ## Contributors' forums
 


### PR DESCRIPTION
This makes it easier to get to the documentation guide from the link GitHub generates at the top of the "Open a pull request" page.
