### PR TITLE
Fixes for Coverity defects

### DIFF
--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3050,6 +3050,18 @@ void MCInterfaceExecCreateStack(MCExecContext& ctxt, MCObject *p_object, MCStrin
 	MCStack *odefaultstackptr = MCdefaultstackptr;
 	Boolean wasvisible = MCtemplatestack->isvisible();
 
+	/* Check that a specified parent stack has a usable name before
+	 * doing anything with side-effects. */
+	MCAutoValueRef t_object_name;
+	if (!p_with_group && p_object != nil)
+	{
+		if (!p_object->names(P_NAME, &t_object_name))
+		{
+			ctxt.Throw();
+			return;
+		}
+	}
+
 	if (p_force_invisible)
 		MCtemplatestack->setflag(!p_force_invisible, F_VISIBLE);
 
@@ -3067,9 +3079,7 @@ void MCInterfaceExecCreateStack(MCExecContext& ctxt, MCObject *p_object, MCStrin
 	}
 	else if (p_object != nil)
 	{
-		MCAutoValueRef t_name;
-		p_object->names(P_NAME, &t_name);
-		MCdefaultstackptr->setvariantprop(ctxt, 0, P_MAIN_STACK, False, *t_name);
+		MCdefaultstackptr->setvariantprop(ctxt, 0, P_MAIN_STACK, False, *t_object_name);
 		if (ctxt . HasError())
 		{
 			delete MCdefaultstackptr;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2794,7 +2794,7 @@ void MCObject::drawdirectionaltext(MCDC *dc, int2 sx, int2 sy, MCStringRef p_str
     //  when drawing on android; HarfBuzz needs all the directions resolved to display in the correct order.
     MCAutoArray<uint8_t> t_levels;
     
-    MCBidiResolveTextDirection(p_string, MCBidiFirstStrongIsolate(p_string, 0), t_levels . PtrRef(), t_levels . SizeRef());
+    /* UNCHECKED */ MCBidiResolveTextDirection(p_string, MCBidiFirstStrongIsolate(p_string, 0), t_levels . PtrRef(), t_levels . SizeRef());
     
     MCRange t_block_range;
 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2298,7 +2298,7 @@ bool MCObject::getnameproperty(Properties which, uint32_t p_part_id, MCValueRef&
     MCStringRef &r_name = (MCStringRef&)r_name_val;
     
     const char *itypestring = gettypestring();
-    MCAutoPointer<char> tmptypestring;
+    MCAutoPointer<char[]> tmptypestring;
     if (parent != NULL && gettype() >= CT_BUTTON && getstack()->hcaddress())
     {
         tmptypestring = new char[strlen(itypestring) + 7];

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -351,7 +351,7 @@ void MCParagraph::resolvetextdirections()
     MCAutoArray<uint8_t> t_levels;
    
     // SN-2014-04-03 [[ Bug 12078 ]] Text direction resolving relocated in foundation-bidi.h
-    MCBidiResolveTextDirection(m_text, t_base_level, t_levels . PtrRef(), t_levels . SizeRef());
+    /* UNCHECKED */ MCBidiResolveTextDirection(m_text, t_base_level, t_levels . PtrRef(), t_levels . SizeRef());
     
     // Using the calculated levels, do the appropriate block creation
     uindex_t i = 0;

--- a/engine/src/text-paragraph.cpp
+++ b/engine/src/text-paragraph.cpp
@@ -489,7 +489,7 @@ void MCTextParagraph::runBidiAlgorithm()
     // Run the Unicode BiDi algorithm to get the direction level for each
     // codeunit within this paragraph.
     MCAutoArray<uint8_t> t_levels;
-    MCBidiResolveTextDirection(m_text, getConcreteTextDirection(), t_levels.PtrRef(), t_levels.SizeRef());
+    /* UNCHECKED */ MCBidiResolveTextDirection(m_text, getConcreteTextDirection(), t_levels.PtrRef(), t_levels.SizeRef());
     
     // Scan through the list of blocks and ensure that each block has a
     // consistent direction level (if not, it will need to be split)

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -823,6 +823,12 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/* This version of MCAutoPointer should be used when you need to
+ * manage a value created with the "new" operator.  For example:
+ *
+ *     MCAutoPointer<int> number;
+ *     number = new int;
+ */
 template<typename T> class MCAutoPointer
 {
 public:
@@ -866,6 +872,52 @@ public:
 		m_ptr = nil;
 	}
 
+private:
+	T *m_ptr;
+};
+
+/* This version of MCAutoPointer should be used when you need to
+ * manage a value created with the "new[]" operator.  For example:
+ *
+ *     MCAutoPointer<int[]> numbers;
+ *     numbers = new int[25];
+ */
+template<typename T> class MCAutoPointer<T[]>
+{
+public:
+	MCAutoPointer(void) : m_ptr(nil) {}
+	~MCAutoPointer(void) { delete[] m_ptr; }
+
+	T* operator = (T* value)
+	{
+		delete[] m_ptr;
+		m_ptr = value;
+		return value;
+	}
+
+	T*& operator & (void)
+	{
+		MCAssert(m_ptr != nil);
+		return m_ptr;
+	}
+
+	T* operator -> (void)
+	{
+		MCAssert(m_ptr != nil);
+		return m_ptr;
+	}
+
+	T* operator * (void)
+	{
+		return m_ptr;
+	}
+
+	void Take(T* & r_ptr)
+	{
+		r_ptr = m_ptr;
+		m_ptr = nil;
+	}
+	
 private:
 	T *m_ptr;
 };

--- a/libfoundation/include/foundation-bidi.h
+++ b/libfoundation/include/foundation-bidi.h
@@ -43,7 +43,7 @@ enum MCTextDirection
 #define kMCBidiALM      0x061C      // Arabic letter mark
 
 
-void MCBidiResolveTextDirection(MCStringRef p_string, intenum_t p_base_level, uint8_t *&r_levels, uindex_t& r_level_size);
+bool MCBidiResolveTextDirection(MCStringRef p_string, intenum_t p_base_level, uint8_t *&r_levels, uindex_t& r_level_size);
 uint8_t MCBidiFirstStrongIsolate(MCStringRef p_string, uindex_t p_offset);
 
 #endif // __MC_FOUNDATION_BIDI__

--- a/libfoundation/src/foundation-bidi.cpp
+++ b/libfoundation/src/foundation-bidi.cpp
@@ -520,7 +520,7 @@ static void bidiApplyRuleI2(isolating_run_sequence& irs, uint8_t *classes, uint8
     while (bidiIncrementISRIndex(classes, t_run, t_index));
 }
 
-void MCBidiResolveTextDirection(MCStringRef p_string, intenum_t p_base_level, uint8_t *&r_levels, uindex_t& r_level_size)
+bool MCBidiResolveTextDirection(MCStringRef p_string, intenum_t p_base_level, uint8_t *&r_levels, uindex_t& r_level_size)
 {
     intenum_t t_base_level;
     if (p_base_level == kMCTextDirectionAuto)
@@ -533,12 +533,19 @@ void MCBidiResolveTextDirection(MCStringRef p_string, intenum_t p_base_level, ui
     
     // Map every codepoint in the string to its bidi class
     MCAutoArray<uint8_t> t_classes;
-    /* UNCHECKED */ t_classes.New(t_length);
+	if (!t_classes.New(t_length))
+	{
+		return false;
+	}
+
     MCUnicodeGetProperty(MCStringGetCharPtr(p_string), t_length, kMCUnicodePropertyBidiClass, kMCUnicodePropertyTypeUint8, t_classes.Ptr());
     
     // Create an array to store the BiDi level of each character
     uint8_t *t_levels;
-    MCMemoryAllocate(t_length, t_levels);
+	if (!MCMemoryAllocate(t_length, t_levels))
+	{
+		return false;
+	}
     
     // AL-2014-11-13: [[ Bug 13948 ]] Set the array of levels to zero, since there are some 'default' characters
     //  whose levels are not set by any of the explicit direction rules of the BiDi algorithm
@@ -837,6 +844,8 @@ void MCBidiResolveTextDirection(MCStringRef p_string, intenum_t p_base_level, ui
     
     r_level_size = t_length;
     r_levels = t_levels;
+
+	return true;
 }
 
 uint8_t MCBidiFirstStrongIsolate(MCStringRef p_string, uindex_t p_offset)

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -831,25 +831,6 @@ bool MCStringCreateUnicodeStringFromData(MCDataRef p_data, bool p_is_external_re
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static bool __MCStringFormatSupportedForUnicode(const char *p_format)
-{
-	while(*p_format != '\0')
-	{
-		if (*p_format == '%' &&
-			(p_format[1] != 's' && p_format[1] != 'd' && p_format[1] != '@'))
-			return false;
-		
-		if (*p_format == '\\' &&
-			(p_format[1] != 'n' && p_format[1] != '"'))
-			return false;
-		
-		p_format++;
-	}
-	
-	return true;
-}
-
-
 MC_DLLEXPORT_DEF
 bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args)
 {
@@ -5297,7 +5278,7 @@ bool MCStringSplitByDelimiter(MCStringRef self, MCStringRef p_elem_del, MCString
     if (__MCStringIsIndirect(p_elem_del))
         p_elem_del = p_elem_del -> string;
     
-	const void *t_echar, *t_kchar;
+	const void *t_echar;
     bool del_native;
     del_native = MCStringIsNative(p_elem_del);
 	t_echar = p_elem_del -> chars;
@@ -5837,7 +5818,6 @@ static bool __MCStringNativize(MCStringRef self, uindex_t & r_char_count)
 	}
     
     uindex_t t_current = 0, t_next;
-    bool t_is_native = true;
     for (uindex_t i = 0; i < t_char_range . length; i++)
     {
         // If we've reached the end, set the next boundary manually
@@ -5867,7 +5847,6 @@ static bool __MCStringNativize(MCStringRef self, uindex_t & r_char_count)
             }
             else
             {
-                t_is_native = false;
                 chars[i] = '?';
             }
         }
@@ -6724,7 +6703,6 @@ static bool __MCStringResolveIndirect(__MCString *self)
         }
         else
         {
-            unichar_t *t_uni_chars;
             if (!__MCStringCloneBuffer(t_string, t_chars, t_char_count))
                 return false;
             


### PR DESCRIPTION
The last Coverity check detected 5 new defects, so here are fixes for 5 defects.

Please check commit 21338d6 particularly carefully, because I am not 100% certain that it is correct (`MCInterfaceExecCreateStack()` is a bit overloaded).
