### PR TITLE
[Bug 16738] Ensure widgets in substacks are saved.

### DIFF
--- a/docs/notes/bugfix-16739.md
+++ b/docs/notes/bugfix-16739.md
@@ -1,0 +1,1 @@
+# Save widgets in substacks when main stack doesn't have widgets

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -892,7 +892,7 @@ public:
     
     // MW-2014-12-17: [[ Widgets ]] Returns true if the object is a widget or contains
     //   a widget.
-    bool haswidgets(void);
+    virtual bool haswidgets(void);
     
     // Currently non-functional: always returns false
     bool is_rtl() const { return false; }

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -566,6 +566,9 @@ public:
 	
     // MW-2014-12-17: [[ Widgets ]] Returns true if one of the stacks substacks have widgets.
     bool substackhaswidgets();
+
+    /* Return true iff the stack or one of its substacks has widgets. */
+    virtual bool haswidgets();
     
 	//////////
     

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -3338,6 +3338,12 @@ MCRectangle MCStack::getvisiblerect(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool
+MCStack::haswidgets()
+{
+	return MCObject::haswidgets() || substackhaswidgets();
+}
+
 bool MCStack::substackhaswidgets(void)
 {
 	if (substacks != NULL)


### PR DESCRIPTION
Although there was an `MCStack::substackhaswidgets()` method defined,
`MCObject::haswidgets()` wasn't calling it.

When saving stack files with widgets only in substacks (not in the
main stack), the save logic thought that no widgets were present and
downgraded the file format to 7.0, causing widgets in substacks to be
discarded.

This patch makes `MCObject::haswidgets()` virtual and overrides it in
`MCStack` with an implementation that calls `substackhaswidgets()`.
