### PR TITLE
docs: Include the release notes in the the IDE's "Guides" tab

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -386,7 +386,10 @@ component Documentation
 	into [[ToolsFolder]]/Documentation place
 		rfolder "ide:Documentation/guides"
 		rfolder "repo:docs/guides"
-		
+
+	into [[ToolsFolder]]/Documentation/guides place
+		file "repo:LiveCodeNotes-[[EscapedVersionTag]].md" as "Release Notes.md"
+
 component Extensions
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.browser

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -993,7 +993,7 @@ private command PreviousCreate
          next repeat
          
       else      
-         put OutputGetNotesUrl(tVersion) into tUrl
+         put OutputGetNotesUrl("pdf", tVersion) into tUrl
          MarkdownAppend "notes", merge("* [LiveCode [[tVersion]] Release Notes]([[tUrl]])")
       end if
       


### PR DESCRIPTION
Does what it says on the tin (and also fixes some broken links because why not).
