### PR TITLE
[Bug 16619][emscripten] Disable "wait" in HTML5 engine

### DIFF
--- a/docs/guides/HTML5 Deployment.md
+++ b/docs/guides/HTML5 Deployment.md
@@ -30,8 +30,13 @@ Several important features are not yet supported:
 
 * some `ask` and `answer` message boxes
 * networking
+* JavaScript in LiveCode Builder extensions
 
-The HTML5 engine is unlikely ever to support externals (including revdb).
+Two important unsupported features are unlikely to be added in the near future:
+
+* operations that need to pause the script while something happens
+  (e.g. `wait 10`)
+* externals (including revdb)
 
 # How to deploy an app to HTML5
 

--- a/docs/notes/bugfix-16076.md
+++ b/docs/notes/bugfix-16076.md
@@ -1,1 +1,0 @@
-# Enable "wait" syntax in HTML5 standalones

--- a/docs/notes/bugfix-16619.md
+++ b/docs/notes/bugfix-16619.md
@@ -1,0 +1,10 @@
+# No "wait" syntax in HTML5 standalones
+
+In LiveCode 8.0.0-dp-11, changes were made to the HTML5 standalone
+engine to enable the use of `wait` (and related syntax; see
+[bug 16076](http://quality.livecode.com/show_bug.cgi?id/16076).  These
+changes made the HTML5 engine run unacceptably slowly, and have now
+been removed.
+
+Instead of using `wait` in stacks for HTML5 deployment, the use of the
+`send <message> in <time>` syntax is recommended.

--- a/engine/src/em-dc.cpp
+++ b/engine/src/em-dc.cpp
@@ -170,12 +170,19 @@ MCScreenDC::GetCurrentStack()
  * Event loop
  * ================================================================ */
 
-/* Returns true if quit is requested. */
+/* Returns true if quit is requested, or from any inner main loop. */
 Boolean
 MCScreenDC::wait(real64_t p_duration,
                  Boolean p_allow_dispatch,
                  Boolean p_accept_any_event)
 {
+	/* Don't permit inner main loops.  They cause amusing "-12" assertion
+	 * failures from Emterpreter. */
+	if (0 < int(MCwaitdepth))
+	{
+		return true;
+	}
+
 	p_duration = MCMax(p_duration, 0.0);
 
 	/* We allow p_duration to be infinite, but only if

--- a/engine/src/em-whitelist.json
+++ b/engine/src/em-whitelist.json
@@ -6,51 +6,9 @@
     "^__Z20send_startup_messageb",
     "^__Z13platform_mainiPPcS0_$",
     "^__Z21X_main_loop_iterationv$",
+    "^__ZN10MCScreenDC4waitEdhh$",
 
     "^_MCEventQueueDispatch$",
     "^__ZL25MCEventQueueDispatchEventP7MCEvent$",
-    "^_MCEmscriptenAsyncYield$",
-
-    "MCWidgetExec",
-    "MCWidgetOn",
-
-    "AddRunloopAction",
-    "DoRunloopActions",
-
-    "(exec|eval)_ctxt",
-    "4wait",
-    "26message_with_valueref_args",
-    "addmessage",
-    "7message",
-    "6handle",
-    "13handlepending",
-    "10handleself",
-    "11exechandler",
-    "[0-9]+close",
-    "3del",
-    "help",
-    "[0-9]+(k|m)(focus|down|up)",
-    "mdrag",
-    "paste",
-    "doubledown",
-    "layerchanged",
-    "resizeparent",
-    "sync_mfocus",
-    "toolchanged",
-    "wdoubledown",
-    "wmdragenter",
-    "wmdragleave",
-    "wmfocus_stack",
-
-    "MCExecContext[0-9]+(TryTo)?[Ee]val",
-    "MCEngineEvalValue",
-    "MCEngine\\w*Wait",
-    "MCEngineExecDispatch",
-    "MCEngineExecDo",
-    "MCEngineExecSend",
-
-    "MC[SU]_\\w*url(?!(en|de)code)",
-
-    "__ZN9MCHandler4exec",
-    "MCKeywordsExec"
+    "^_MCEmscriptenAsyncYield$"
 ]

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -241,7 +241,7 @@ uint2 MCnsockets;
 MCStack **MCusing;
 uint2 MCnusing;
 uint2 MCiconicstacks;
-uint2 MCwaitdepth;
+MCSemaphore MCwaitdepth;
 uint4 MCrecursionlimit = 400000; // actual max is about 480K on OSX
 
 MCClipboard* MCclipboard;
@@ -634,7 +634,7 @@ void X_clear_globals(void)
 	MCusing = nil;
 	MCnusing = 0;
 	MCiconicstacks = 0;
-	MCwaitdepth = 0;
+	MCwaitdepth = MCSemaphore("wait-depth");
 	MCrecursionlimit = 400000;
 	MCclipboard = NULL;
 	MCselection = NULL;

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -163,7 +163,7 @@ extern uint2 MCnsockets;
 extern MCStack **MCusing;
 extern uint2 MCnusing;
 extern uint2 MCiconicstacks;
-extern uint2 MCwaitdepth;
+extern MCSemaphore MCwaitdepth;
 extern uint4 MCrecursionlimit;
 
 

--- a/engine/src/mcsemaphore.h
+++ b/engine/src/mcsemaphore.h
@@ -64,6 +64,12 @@ class MCSemaphore
 		return IsLocked();
 	}
 
+	/* Automatic extraction of the wait depth */
+	operator int() const
+	{
+		return m_counter;
+	}
+
 	/* ---------- Locking ops */
 	void Lock()
 	{

--- a/tests/_emscripten/__boot.livecodescript
+++ b/tests/_emscripten/__boot.livecodescript
@@ -16,7 +16,7 @@ on startup
 	TestLoadLibrary "_inputlib"
 
 	-- Run tests
-	local tTestFiles, tTestFile, tStackName, tCommand, tSetupResult
+	local tTestFiles, tTestFile, tStackName, tCommand, tSetupResult, tError
 
 	put TesterGetTestFileNames("/boot/standalone") into tTestFiles
 
@@ -45,7 +45,12 @@ on startup
 			end if
 
 			-- Run tests
-			dispatch tCommand to tStackName
+			try
+				dispatch tCommand to tStackName
+			catch tError
+				TestDiagnostic tError
+				TestAssert empty, false
+			end try
 
 			-- Send teardown command
 			dispatch "TestTearDown" to tStackName


### PR DESCRIPTION
Extensive Emterpreter bytecode compilation was required to enable `wait` (and related features that use inner main loops).  This caused unacceptable degradation in engine performance.

Instead, disable inner main loops for the HTML5 engine, and this time try to generate a proper error if one is hit.
