### PR TITLE
Enable 64-bit OSX builds in Release mode

### DIFF
--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -185,7 +185,7 @@
 		{
 			'xcode_settings':
 			{
-				'ARCHS': 'i386',
+				'ARCHS': 'i386 x86_64',
 				'GCC_OPTIMIZATION_LEVEL': '3',
 				'GCC_ENABLE_FIX_AND_CONTINUE': 'NO',
 				'LLVM_LTO': 'YES',


### PR DESCRIPTION
Does what it says on the tin... without it https://github.com/livecode/livecode-ide/pull/810 just gives false hope.
