### PR TITLE
Disable OSX LTO

### DIFF
--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -188,7 +188,7 @@
 				'ARCHS': 'i386',
 				'GCC_OPTIMIZATION_LEVEL': '3',
 				'GCC_ENABLE_FIX_AND_CONTINUE': 'NO',
-				'LLVM_LTO': 'YES',
+				#'LLVM_LTO': 'YES',
 				'DEAD_CODE_STRIPPING': 'YES',
 				'GCC_UNROLL_LOOPS': 'YES',
 			},


### PR DESCRIPTION
It causes crashes in the Xcode 7.2 linker :(
