### PR TITLE
[emscripten] Only import environment array if non-null.

### DIFF
--- a/engine/src/em-main.cpp
+++ b/engine/src/em-main.cpp
@@ -91,7 +91,7 @@ platform_main(int argc, char *argv[], char *envp[])
 	/* ---------- Process the environment */
 	/* Count env variables */
 	int t_envc;
-	for (t_envc = 0; envp[t_envc] != nil; ++t_envc);
+	for (t_envc = 0; envp != nil && envp[t_envc] != nil; ++t_envc);
 
 	/* Import. Note that the envp array is null-terminated */
 	MCStringRef *t_envp;


### PR DESCRIPTION
This prevents reading arbitrary memory contents as an environment
array.
