### PR TITLE
Use the correct colour index for selected text in fields

### DIFF
--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -1414,7 +1414,7 @@ Boolean MCObject::getforecolor(uint2 p_di, Boolean rev, Boolean hilite,
 				if (MClook != LF_MOTIF && hilite && flags & F_OPAQUE
 				        && !(flags & F_DISABLED))
 				{
-                    if (di == DI_BACK)
+                    if (p_di == DI_BACK)
                     {
                         // Use the themed colours and ignore inheritance. We do
                         // this so that controls always have the appropriate


### PR DESCRIPTION
The text should not use the DI_BACK colour. This was introduced when fixing the problem of fields inheriting the background colour.
