### PR TITLE
[Bug 16456] docs: lock clipboard is actually recursive

### DIFF
--- a/docs/dictionary/command/lock-clipboard.lcdoc
+++ b/docs/dictionary/command/lock-clipboard.lcdoc
@@ -24,8 +24,6 @@ While the clipboard is locked, the contents of the clipboard available via the <
 
 >*Tip:* Use <lock clipboard> to ensure the clipboard does not change between accesses.
 
-Locking the clipboard will throw an error if it is already locked.
-
 
 References: unlock clipboard (command), clipboard (function), clipboardData (property), fullClipboardData(property), rawClipboardData (property)
 

--- a/docs/dictionary/command/unlock-clipboard.lcdoc
+++ b/docs/dictionary/command/unlock-clipboard.lcdoc
@@ -22,8 +22,6 @@ Use the <unlock clipboard> <command> to make the contents of the clipboard avail
 
 >*Tip:* Use <lock clipboard> to ensure the clipboard does not change between accesses.
 
-Unlocking the clipboard will throw an error if the clipboard is not locked.
-
 
 References: lock clipboard (command), clipboard (function), clipboardData (property), fullClipboardData (property), rawClipboardData (property)
 

--- a/docs/notes/bugfix-16456.md
+++ b/docs/notes/bugfix-16456.md
@@ -1,0 +1,1 @@
+# Improve accuracy of "lock clipboard" documentatino


### PR DESCRIPTION
It's safe to lock a locked clipboard and unlock an unlocked clipboard.
