### PR TITLE
Force a redraw of a stack when its mainstack is changed

### DIFF
--- a/docs/notes/bugfix-6706.md
+++ b/docs/notes/bugfix-6706.md
@@ -1,0 +1,2 @@
+# Repaint stacks when changing its mainstack
+

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1075,6 +1075,9 @@ void MCStack::SetMainStack(MCExecContext& ctxt, MCStringRef p_main_stack)
 			parent = stackptr;
 		}
 
+        // Any inherited properties have changed so force a redraw
+        dirtyall();
+        
 		// OK-2008-04-10 : Added parameters to mainstackChanged message to specify the new
 		// and old mainstack names.
 		message_with_valueref_args(MCM_main_stack_changed, t_old_stackptr -> getname(), stackptr -> getname());


### PR DESCRIPTION
The IDE needs a "lock screen" around the File->New Substack option as otherwise the stack visibly redraws between being created and having its mainstack set.
