### PR TITLE
Ignore the background colour when drawing native-appearance tab panes

### DIFF
--- a/docs/notes/bugfix-14361.md
+++ b/docs/notes/bugfix-14361.md
@@ -1,0 +1,1 @@
+# Ignore the background color for native-appearance tab panes

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -186,8 +186,11 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 			case F_RADIO:
 			case F_RECTANGLE:
 			case F_STANDARD:
-					if (MCcurtheme == NULL || !getstack() -> ismetal() || (isstdbtn && state & CS_HILITED) ||
-						!MCcurtheme -> drawmetalbackground(dc, dirty, trect, this))
+                    if ((isstdbtn && (state & CS_HILITED))
+                        || MCcurtheme == NULL
+                        || !((getstack()->ismetal() && MCcurtheme->drawmetalbackground(dc, dirty, trect, this))
+                              || (style == F_MENU && menumode == WM_TOP_LEVEL && MCcurtheme->iswidgetsupported(WTHEME_TYPE_TABPANE))))
+
 				{
 					if (isstdbtn && noback)
 					{


### PR DESCRIPTION
It only works on some platforms and even then it doesn't match the parts of the tab control that are drawn natively (e.g. on OSX, the borders of the content pane are drawn in the system's default colour but the centre of the pane is filled in with the background colour).
