### PR TITLE
[[ Community Docs ]] Specified that time is in epoch seconds

### DIFF
--- a/docs/dictionary/function/pendingMessages.lcdoc
+++ b/docs/dictionary/function/pendingMessages.lcdoc
@@ -22,7 +22,7 @@ repeat with x = 1 to the number of lines of the pendingMessages
 
 The result: The message ID is the same as the one placed in the result function when it was scheduled with the <send> command.
 
-Returns (enum): The <pendingMessages> <function> <return|returns> a list of <message|messages>, one per line. Each line consists of four <items>, separated by commas:
+Returns: The <pendingMessages> <function> <return|returns> a list of <message|messages>, one per line. Each line consists of four <items>, separated by commas:
 1. the message ID
 2. the time the message is scheduled for (in seconds, Unix epoch time)
 3. the message name

--- a/docs/dictionary/function/pendingMessages.lcdoc
+++ b/docs/dictionary/function/pendingMessages.lcdoc
@@ -23,10 +23,10 @@ repeat with x = 1 to the number of lines of the pendingMessages
 The result: The message ID is the same as the one placed in the result function when it was scheduled with the <send> command.
 
 Returns (enum): The <pendingMessages> <function> <return|returns> a list of <message|messages>, one per line. Each line consists of four <items>, separated by commas:
-        - the message ID
-        - the time the message is scheduled for
-        - the message name
-        - the long ID <property> of the <object> that the <message> will be sent to
+1. the message ID
+2. the time the message is scheduled for (in seconds, Unix epoch time)
+3. the message name
+4. the long ID <property> of the <object> that the <message> will be sent to
 
 Description:
 Use the <pendingMessages> <function> to check whether a <message> has been sent yet, or to perform some action on each pending <message>.


### PR DESCRIPTION
for the pendingMessages function. Moreover I switched from unordered list to numbered list, regarding the items of each line of the pendingMessages list.
