### PR TITLE
[[ AuxSocketThread ]] Refactor the socket code so that select is call…

### DIFF
--- a/docs/notes/bugfix-15938.md
+++ b/docs/notes/bugfix-15938.md
@@ -1,0 +1,1 @@
+# Mouse messages are sometimes not sent on iOS when using sockets

--- a/docs/notes/bugfix-16707.md
+++ b/docs/notes/bugfix-16707.md
@@ -1,0 +1,1 @@
+# Socket messages are sometimes not sent on Mac

--- a/engine/src/desktop-dc.cpp
+++ b/engine/src/desktop-dc.cpp
@@ -878,20 +878,6 @@ Boolean MCScreenDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 		// IM-2014-06-25: [[ Bug 12671 ]] If there are runloop actions then set a timeout instead of waiting for the next event
 		if (HasRunloopActions())
 			t_sleep = MCMin(0.01, t_sleep);
-		
-        // MW-2014-07-16: [[ Bug 12799 ]] If polling sockets does something then don't wait for long.
-        extern Boolean MCS_handle_sockets();
-        
-        // SN-2014-10-17: [[ Bug 13360 ]] If MCS_handle_sockets returns true, we don't want to get stuck in a
-        //  loop waiting 0.0 s for events. That was causing issues in MCRead::readuntil, if data arrived after
-        //  the call to read()
-        if (MCS_handle_sockets())
-        {
-            if (anyevent)
-                done = True;
-            t_sleep = 0.0;
-        }
-        
         
 		// Wait for t_sleep seconds and collect at most one event. If an event
 		// is collected and anyevent is True, then we are done.

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -3290,8 +3290,6 @@ public:
                 maxfd = MCinputfd;
         }
 
-        handled = MCSocketsAddToFileDescriptorSets(maxfd, rmaskfd, wmaskfd, emaskfd);
-
         if (g_notify_pipe[0] != -1)
         {
             FD_SET(g_notify_pipe[0], &rmaskfd);
@@ -3345,7 +3343,6 @@ public:
             return True;
         if (MCinputfd != -1 && FD_ISSET(MCinputfd, &rmaskfd))
             readinput = True;
-        MCSocketsHandleFileDescriptorSets(rmaskfd, wmaskfd, emaskfd);
 
         // Check whether any of the GLib file descriptors were signalled
         for (uindex_t i = 0; i < t_glib_fds.Size(); i++)

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -7479,7 +7479,6 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 
 	return True;
 #endif /* MCS_poll_dsk_mac */
-        Boolean handled = False;
         fd_set rmaskfd, wmaskfd, emaskfd;
         FD_ZERO(&rmaskfd);
         FD_ZERO(&wmaskfd);
@@ -7498,10 +7497,6 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
                 maxfd = MCshellfd;
         }
         
-        handled = MCSocketsAddToFileDescriptorSets(maxfd, rmaskfd, wmaskfd, emaskfd);
-        if (handled)
-            p_delay = 0.0;
-        
         struct timeval timeoutval;
         timeoutval.tv_sec = (long)p_delay;
         timeoutval.tv_usec = (long)((p_delay - floor(p_delay)) * 1000000.0);
@@ -7510,12 +7505,10 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         n = select(maxfd + 1, &rmaskfd, &wmaskfd, &emaskfd, &timeoutval);
         
         if (n <= 0)
-            return handled;
+            return False;
         
         if (MCshellfd != -1 && FD_ISSET(MCshellfd, &rmaskfd))
             return True;
-        
-        MCSocketsHandleFileDescriptorSets(rmaskfd, wmaskfd, emaskfd);
         
         return True;
     }

--- a/engine/src/lnxspec.cpp
+++ b/engine/src/lnxspec.cpp
@@ -1693,7 +1693,6 @@ Boolean MCS_poll(real8 delay, int fd)
 	int4 n;
 	uint2 i;
 	Boolean wasalarm = alarmpending;
-	Boolean handled = False;
 	if (alarmpending)
 		MCS_alarm(0.0);
 	
@@ -1721,9 +1720,6 @@ Boolean MCS_poll(real8 delay, int fd)
 		if (MCinputfd > maxfd)
 			maxfd = MCinputfd;
 	}
-    handled = MCSocketsAddToFileDescriptorSets(maxfd, rmaskfd, wmaskfd, emaskfd);
-    if (handled)
-        delay = 0.0;
 
 	if (g_notify_pipe[0] != -1)
 	{
@@ -1740,12 +1736,11 @@ Boolean MCS_poll(real8 delay, int fd)
 	
 		n = select(maxfd + 1, &rmaskfd, &wmaskfd, &emaskfd, &timeoutval);
 	if (n <= 0)
-		return handled;
+		return False;
 	if (MCshellfd != -1 && FD_ISSET(MCshellfd, &rmaskfd))
 		return True;
 	if (MCinputfd != -1 && FD_ISSET(MCinputfd, &rmaskfd))
 		readinput = True;
-    MCSocketsHandleFileDescriptorSets(rmaskfd, wmaskfd, emaskfd);
     
 	if (g_notify_pipe[0] != -1 && FD_ISSET(g_notify_pipe[0], &rmaskfd))
 	{

--- a/engine/src/mbliphone.mm
+++ b/engine/src/mbliphone.mm
@@ -1149,31 +1149,9 @@ void MCIPhoneSystem::KillAll()
     return;
 }
 
-// MM-2015-06-08: [[ MobileSockets ]] Poll sockets.
 Boolean MCIPhoneSystem::Poll(real8 p_delay, int p_fd)
 {
-    Boolean handled = False;
-    fd_set rmaskfd, wmaskfd, emaskfd;
-    FD_ZERO(&rmaskfd);
-    FD_ZERO(&wmaskfd);
-    FD_ZERO(&emaskfd);
-    int4 maxfd = 0;
-    
-    handled = MCSocketsAddToFileDescriptorSets(maxfd, rmaskfd, wmaskfd, emaskfd);
-    if (handled)
-        p_delay = 0.0;
-    
-    struct timeval timeoutval;
-    timeoutval.tv_sec = (long)p_delay;
-    timeoutval.tv_usec = (long)((p_delay - floor(p_delay)) * 1000000.0);
-    
-    int n = 0;
-    n = select(maxfd + 1, &rmaskfd, &wmaskfd, &emaskfd, &timeoutval);
-    if (n <= 0)
-        return handled;
-    
-    MCSocketsHandleFileDescriptorSets(rmaskfd, wmaskfd, emaskfd);
-    return True;
+    return False;
 }
 
 Boolean MCIPhoneSystem::IsInteractiveConsole(int p_fd)

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -731,16 +731,7 @@ Boolean MCScreenDC::wait(real8 duration, Boolean dispatch, Boolean anyevent)
 			done = True;
 		else if (!done && eventtime > curtime)
 			t_sleep = MCMin(eventtime - curtime, exittime - curtime);
-		
-        // MM-2015-08-11: [[ Bug 15700 ]] Poll the sockets. Code pulled over from OS X wait.
-        extern Boolean MCS_handle_sockets();
-        if (MCS_handle_sockets())
-        {
-            if (anyevent)
-                done = True;
-            t_sleep = 0.0;
-        }
-        
+
 		// Switch to the main fiber and wait for at most t_sleep seconds. This
 		// returns 'true' if the wait was broken rather than timed out.
 		if (MCIPhoneWait(t_sleep) && anyevent)

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -98,8 +98,15 @@ extern char *osx_cfstring_to_cstring(CFStringRef p_string, bool p_release, bool 
 #include "mcssl.h"
 
 #if defined(TARGET_SUBPLATFORM_ANDROID)
-#include <pthread.h>
 #include "mblandroidjava.h"
+#endif
+
+#if defined(_MAC_DESKTOP) || defined(_LINUX_DESKTOP) || defined(TARGET_SUBPLATFORM_IPHONE) || defined(TARGET_SUBPLATFORM_ANDROID)
+#define USE_AUX_THREAD
+#endif
+
+#if defined(USE_AUX_THREAD)
+#include <pthread.h>
 
 static pthread_t s_socket_poll_thread = NULL;
 static pthread_mutex_t s_socket_list_mutex;
@@ -134,71 +141,9 @@ extern HANDLE g_socket_wakeup;
 
 Boolean MCSocket::sslinited = False;
 
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-static void socketCallback (CFSocketRef cfsockref, CFSocketCallBackType type, CFDataRef address, const void *pData, void *pInfo)
-{
-	uint2 i;
-	int fd = CFSocketGetNative(cfsockref);
-	for (i = 0 ; i < MCnsockets ; i++)
-	{
-		if ( fd == MCsockets[i]->fd && !MCsockets[i]->shared)
-			break;
-	}
-	if (i < MCnsockets)
-	{
-		fd_set rmaskfd, wmaskfd, emaskfd;
-		FD_ZERO(&rmaskfd);
-		FD_ZERO(&wmaskfd);
-		FD_ZERO(&emaskfd);
-		FD_SET(fd, &rmaskfd);
-		struct timeval t_time = {0,0};
-		select(fd, &rmaskfd, &wmaskfd, &emaskfd, &t_time);
-		switch (type)
-		{
-		case kCFSocketReadCallBack:
-			if (FD_ISSET(fd, &rmaskfd))
-			{
-				MCsockets[i]->readsome();
-				MCsockets[i]->setselect();
-			}
-			break;
-		case kCFSocketWriteCallBack:
-			MCsockets[i]->writesome();
-			MCsockets[i]->setselect();
-			break;
-		case kCFSocketConnectCallBack:
-			MCsockets[i]->writesome();
-			MCsockets[i]->readsome();
-			break;
-		}
-#ifdef _MACOSX
-        MCPlatformBreakWait();
-#else
-        extern void MCIPhoneBreakWait(void);
-        MCIPhoneBreakWait();
-#endif
-
-	}
-	MCS_poll(0.0,0);//quick poll of other sockets
-}
-#endif
-
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-Boolean MCS_handle_sockets()
-{
-    return MCS_poll(0.0,0);
-}
-#else
-Boolean MCS_handle_sockets()
-{
-    return True;
-}
-#endif
-
-
 static void MCSocketsLockSocketList(void)
 {
-#if defined(TARGET_SUBPLATFORM_ANDROID)
+#if defined(USE_AUX_THREAD)
     if (s_socket_poll_thread != NULL)
         pthread_mutex_lock(&s_socket_list_mutex);
 #endif
@@ -206,17 +151,18 @@ static void MCSocketsLockSocketList(void)
 
 static void MCSocketsUnlockSocketList(void)
 {
-#if defined(TARGET_SUBPLATFORM_ANDROID)
+#if defined(USE_AUX_THREAD)
     if (s_socket_poll_thread != NULL)
         pthread_mutex_unlock(&s_socket_list_mutex);
 #endif
 }
 
-#if defined(TARGET_SUBPLATFORM_ANDROID)
+#if defined(USE_AUX_THREAD)
 // MM-2015-07-07: [[ MobileSockets ]] Since on Android we can't hook into system
 //  calls to monitor sockets, we instead have an auxiliary thread that polls the
 //  sockets checking for any activity. If any sockets are pending, a notification
 //  is pushed onto the main thread which will complete the read/write.
+// MM-2016-01-27: [[ AuxThread ]] Updated to use the auxiliary thread on all platforms other than Windows.
 
 struct MCSocketsHandleFileDescriptorsCallbackContext
 {
@@ -234,7 +180,9 @@ static void MCSocketsHandleFileDescriptorsCallback(void *p_context)
 
 static void *MCSocketsPoll(void *p_arg)
 {
+#if defined(TARGET_SUBPLATFORM_ANDROID)
     MCJavaAttachCurrentThread();
+#endif
     
     fd_set rmaskfd, wmaskfd, emaskfd;
     int4 maxfd;
@@ -278,7 +226,10 @@ static void *MCSocketsPoll(void *p_arg)
         }
     }
     
+#if defined(TARGET_SUBPLATFORM_ANDROID)
     MCJavaDetachCurrentThread();
+#endif
+
     return NULL;
 }
 #endif
@@ -288,7 +239,7 @@ static bool MCSocketsPollInterrupt(void)
     bool t_success;
     t_success = true;
     
-#if defined(TARGET_SUBPLATFORM_ANDROID)
+#if defined(USE_AUX_THREAD)
     if (t_success)
     {
         if (s_socket_poll_thread == NULL)
@@ -313,7 +264,7 @@ static bool MCSocketsPollInterrupt(void)
 
 bool MCSocketsInitialize(void)
 {
-#if defined(TARGET_SUBPLATFORM_ANDROID)
+#if defined(USE_AUX_THREAD)
     s_socket_poll_thread = NULL;
     s_socket_poll_run = false;
 #endif
@@ -322,7 +273,7 @@ bool MCSocketsInitialize(void)
 
 void MCSocketsFinalize(void)
 {
-#if defined(TARGET_SUBPLATFORM_ANDROID)
+#if defined(USE_AUX_THREAD)
     if (s_socket_poll_thread != NULL)
     {
         s_socket_poll_run = false;
@@ -1888,32 +1839,11 @@ void MCSocket::setselect(uint2 sflags)
 		WSAEventSelect(fd, g_socket_wakeup, event);
 	}
 #endif
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-	if (sflags & BIONB_TESTWRITE)
-		CFSocketEnableCallBacks(cfsockref,kCFSocketWriteCallBack);
-	if (sflags & BIONB_TESTREAD)
-		CFSocketEnableCallBacks(cfsockref,kCFSocketReadCallBack);
-#endif
 }
 
 Boolean MCSocket::init(MCSocketHandle newfd)
 {
 	fd = newfd;
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-
-	cfsockref = NULL;
-	rlref = NULL;
-	cfsockref = CFSocketCreateWithNative (kCFAllocatorDefault,fd, kCFSocketReadCallBack|kCFSocketWriteCallBack,
-	                                      (CFSocketCallBack)&socketCallback, NULL);
-	if (cfsockref)
-	{
-		rlref = CFSocketCreateRunLoopSource(kCFAllocatorDefault, cfsockref, 0);
-        // MM-2015-06-04: [[ MobileSockets ]] Make sure we post the callbacks to the main thread (since we run a twin thread set up on iOS)
-		CFRunLoopAddSource((CFRunLoopRef) CFRunLoopGetMain(), rlref, kCFRunLoopCommonModes);
-		CFOptionFlags socketOptions = 0 ;
-		CFSocketSetSocketFlags( cfsockref, socketOptions );
-	}
-#endif
 	return True;
 }
 
@@ -1924,15 +1854,6 @@ void MCSocket::close()
 	{
 		if (secure)
 			sslclose();
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-
-		if (rlref != NULL)
-		{
-			CFRunLoopRemoveSource (CFRunLoopGetCurrent(), rlref, kCFRunLoopDefaultMode);
-			CFRelease (rlref);
-			rlref = NULL;
-		}
-#endif
 #if defined(_WINDOWS_DESKTOP) || defined(_WINDOWS_SERVER)
 		closesocket(fd);
 #else
@@ -1941,16 +1862,6 @@ void MCSocket::close()
 #endif
 
 		fd = 0;
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-
-		if (cfsockref != NULL)
-		{
-			CFSocketInvalidate (cfsockref);
-			CFRelease (cfsockref);
-			cfsockref = NULL;
-		}
-#endif
-
 	}
 }
 

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -189,7 +189,6 @@ extern void MCS_setplayloudness(uint2 p_loudness);
 
 ///////////////////////////////////////////////////////////////////////////////
 
-extern Boolean MCS_handle_sockets(void);
 extern bool MCS_init_sockets();
 extern bool MCS_compare_host_domain(MCStringRef p_host_a, MCStringRef p_host_b);
 extern MCSocket *MCS_open_socket(MCNameRef name, Boolean datagram, MCObject *o, MCNameRef m, Boolean secure, Boolean sslverify, MCStringRef sslcertfile, MCNameRef p_end_hostname);


### PR DESCRIPTION
…ed on an auxiliary thread.

This was already the case on Android. Updated so all platfroms other than Windows check for socket updates by calling select on an auxiliary thread.
Using the platform specific callbacks was not always working: the event loop was not always waking up on Mac since the update to Cocoa and the interupting of the runloop on iOS was causing oddities.
Linux was updated for consitency. Windows would be a little more fiddly (and appears to be working well) so was left as is for the time being.
