### PR TITLE
[[ Cleanup ]] Name all Obj-C classes consistently.

### DIFF
--- a/engine/src/mbliphonebrowser.mm
+++ b/engine/src/mbliphonebrowser.mm
@@ -48,7 +48,7 @@ bool MCParseParameters(MCParameter*& p_parameters, const char *p_format, ...);
 
 class MCiOSBrowserControl;
 
-@interface MCiOSBrowserDelegate : NSObject <UIWebViewDelegate>
+@interface com_runrev_livecode_MCiOSBrowserDelegate : NSObject <UIWebViewDelegate>
 {
 	MCiOSBrowserControl *m_instance;
 	bool m_pending_request;
@@ -130,7 +130,7 @@ protected:
 	virtual void DeleteView(UIView *view);
 	
 private:
-	MCiOSBrowserDelegate *m_delegate;
+	com_runrev_livecode_MCiOSBrowserDelegate *m_delegate;
 	bool m_delay_requests;
 };
 
@@ -902,7 +902,7 @@ UIView *MCiOSBrowserControl::CreateView(void)
 	
 	[t_view setHidden: YES];
 	
-	m_delegate = [[MCiOSBrowserDelegate alloc] initWithInstance: this];
+	m_delegate = [[com_runrev_livecode_MCiOSBrowserDelegate alloc] initWithInstance: this];
 	[t_view setDelegate: m_delegate];
 	
 	return t_view;
@@ -1013,7 +1013,7 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@implementation MCiOSBrowserDelegate
+@implementation com_runrev_livecode_MCiOSBrowserDelegate
 
 - (id)initWithInstance:(MCiOSBrowserControl*)instance
 {

--- a/engine/src/mbliphonebusyindicator.mm
+++ b/engine/src/mbliphonebusyindicator.mm
@@ -36,7 +36,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 UIView *MCIPhoneGetView(void);
 
-@interface BusyIndicator : NSObject <UIApplicationDelegate, UIActionSheetDelegate>
+@interface com_runrev_livecode_MCBusyIndicator : NSObject <UIApplicationDelegate, UIActionSheetDelegate>
 {
     UIView* m_indicator_view;
     UIView* m_view;
@@ -46,9 +46,9 @@ UIView *MCIPhoneGetView(void);
  }
 @end
 
-static BusyIndicator *s_busy_indicator = nil;
+static com_runrev_livecode_MCBusyIndicator *s_busy_indicator = nil;
 
-@implementation BusyIndicator
+@implementation com_runrev_livecode_MCBusyIndicator
 
 // MM-2013-02-04: [[ Bug 10642 ]] Added new optional opacity parameter to busy indicator.
 - (void) showBusy: (NSString*) p_title withOpacity: (int32_t) p_opacity
@@ -179,7 +179,7 @@ bool MCSystemBusyIndicatorStart (intenum_t p_indicator, MCStringRef p_label, int
                 [s_busy_indicator hideBusy];
                 [s_busy_indicator release];
             }
-            s_busy_indicator = [[BusyIndicator alloc] init];
+            s_busy_indicator = [[com_runrev_livecode_MCBusyIndicator alloc] init];
             if (p_label == nil)
                 [s_busy_indicator showBusy:@"" withOpacity:p_opacity];
             else

--- a/engine/src/mbliphonecalendar.mm
+++ b/engine/src/mbliphonecalendar.mm
@@ -43,9 +43,9 @@ UIViewController *MCIPhoneGetViewController(void);
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifdef __IPHONE_4_0
-@interface MCIPhonePickEventDelegate : UIViewController <EKEventEditViewDelegate>
+@interface com_runrev_livecode_MCIPhonePickEventDelegate : UIViewController <EKEventEditViewDelegate>
 #else
-@interface MCIPhonePickEventDelegate : UIViewController <EKEventEditViewDelegate, EKEventViewDelegate>
+@interface com_runrev_livecode_MCIPhonePickEventDelegate : UIViewController <EKEventEditViewDelegate, EKEventViewDelegate>
 #endif
 {
     bool m_running;
@@ -63,7 +63,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 @end
 
-@implementation MCIPhonePickEventDelegate
+@implementation com_runrev_livecode_MCIPhonePickEventDelegate
 
 - (id)init
 {
@@ -536,8 +536,8 @@ bool MCSystemShowEvent(MCStringRef p_event_id, MCStringRef& r_result)
     bool t_result = false;
     NSString* t_ns_result = nil;
     NSString* t_ns_event = [NSString stringWithMCStringRef: p_event_id];
-    MCIPhonePickEventDelegate *t_show_event;
-    t_show_event = [[MCIPhonePickEventDelegate alloc] init];
+    com_runrev_livecode_MCIPhonePickEventDelegate *t_show_event;
+    t_show_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
 	[t_show_event showViewEvent:t_ns_event withResult: t_ns_result];
     if (t_ns_result != nil)
 		t_result = MCStringCreateWithCFString((CFStringRef)t_ns_result, r_result);
@@ -550,8 +550,8 @@ bool MCSystemCreateEvent(MCStringRef& r_result)
 {
     bool t_result = false;
     NSString* t_ns_result = nil;
-    MCIPhonePickEventDelegate *t_create_event;
-    t_create_event = [[MCIPhonePickEventDelegate alloc] init];
+    com_runrev_livecode_MCIPhonePickEventDelegate *t_create_event;
+    t_create_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
 	[t_create_event showCreateEvent: t_ns_result];
     if (t_ns_result.length > 0)
 		t_result = MCStringCreateWithCFString((CFStringRef)t_ns_result, r_result);
@@ -564,8 +564,8 @@ bool MCSystemUpdateEvent(MCStringRef p_event_id, MCStringRef& r_result)
     bool t_result = false;
     NSString* t_ns_result = nil; 
     NSString* t_ns_event = [NSString stringWithMCStringRef: p_event_id];
-    MCIPhonePickEventDelegate *t_update_event;
-    t_update_event = [[MCIPhonePickEventDelegate alloc] init];
+    com_runrev_livecode_MCIPhonePickEventDelegate *t_update_event;
+    t_update_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
 
 	if (t_ns_event != nil)
     {
@@ -585,8 +585,8 @@ bool MCSystemGetEventData(MCExecContext &r_ctxt, MCStringRef p_event_id, MCArray
     bool t_result = false;
     NSString* t_ns_event = [NSString stringWithMCStringRef: p_event_id];
     MCCalendar t_event_result;
-    MCIPhonePickEventDelegate *t_get_event;
-    t_get_event = [[MCIPhonePickEventDelegate alloc] init];
+    com_runrev_livecode_MCIPhonePickEventDelegate *t_get_event;
+    t_get_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
     t_event_result = [t_get_event getEventData: t_ns_event withGotData:t_result];
     // Convert the event structure to an array of pairs
     if (t_result == true)
@@ -600,8 +600,8 @@ bool MCSystemRemoveEvent(MCStringRef p_event_id, bool p_reocurring, MCStringRef&
     bool t_result = false;
     NSString* t_ns_result = NULL;
     NSString* t_ns_event = [NSString stringWithMCStringRef: p_event_id];
-    MCIPhonePickEventDelegate *t_delete_event;
-    t_delete_event = [[MCIPhonePickEventDelegate alloc] init];
+    com_runrev_livecode_MCIPhonePickEventDelegate *t_delete_event;
+    t_delete_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
     [t_delete_event deleteEvent: t_ns_event withInstances:p_reocurring withResult: t_ns_result];
     if (t_ns_result != NULL)
 		t_result = MCStringCreateWithCFString((CFStringRef)t_ns_result, r_event_id_deleted);
@@ -614,8 +614,8 @@ bool MCSystemAddEvent(MCCalendar p_new_calendar_data, MCStringRef& r_result)
 {
     bool t_result = false;
     NSString* t_ns_result = NULL;
-    MCIPhonePickEventDelegate *t_add_event;
-    t_add_event = [[MCIPhonePickEventDelegate alloc] init];
+    com_runrev_livecode_MCIPhonePickEventDelegate *t_add_event;
+    t_add_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
 	[t_add_event addEvent: p_new_calendar_data withResult: t_ns_result];
 	if (t_ns_result != NULL)
 		t_result = MCStringCreateWithCFString((CFStringRef)t_ns_result, r_result);
@@ -627,8 +627,8 @@ bool MCSystemGetCalendarsEvent(MCStringRef& r_result)
 {
     bool t_result = false;
     NSString* t_ns_result = NULL;
-    MCIPhonePickEventDelegate *t_get_calendars_event;
-    t_get_calendars_event = [[MCIPhonePickEventDelegate alloc] init];
+    com_runrev_livecode_MCIPhonePickEventDelegate *t_get_calendars_event;
+    t_get_calendars_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
 	[t_get_calendars_event getCalendarsEvent: t_ns_result];
 	if (t_ns_result != NULL)
 		t_result = MCStringCreateWithCFString((CFStringRef)t_ns_result, r_result);
@@ -659,8 +659,8 @@ bool MCSystemFindEvent(MCDateTime p_start_date, MCDateTime p_end_date, MCStringR
     }
     if (t_start_date != NULL && t_end_date != NULL)
     {
-        MCIPhonePickEventDelegate *t_find_event;
-        t_find_event = [[MCIPhonePickEventDelegate alloc] init];
+        com_runrev_livecode_MCIPhonePickEventDelegate *t_find_event;
+        t_find_event = [[com_runrev_livecode_MCIPhonePickEventDelegate alloc] init];
     	[t_find_event findEvent:t_start_date andEnd: t_end_date withResult: t_ns_result];
 	    if (t_ns_result != NULL)
             t_result = MCStringCreateWithCFString((CFStringRef)t_ns_result, r_result);

--- a/engine/src/mbliphonecamera.mm
+++ b/engine/src/mbliphonecamera.mm
@@ -37,7 +37,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 ////////////////////////////////////////////////////////////////////////////////
 
 // MM-2013-09-23: [[ iOS7 Support ]] Added missing delegates implemented in order to appease llvm 5.0.
-@interface MCIPhoneImagePickerDialog : UIImagePickerController<UIImagePickerControllerDelegate, UIPopoverControllerDelegate, UINavigationControllerDelegate>
+@interface com_runrev_livecode_MCIPhoneImagePickerDialog : UIImagePickerController<UIImagePickerControllerDelegate, UIPopoverControllerDelegate, UINavigationControllerDelegate>
 {
 	bool m_cancelled;
 	bool m_running;
@@ -52,9 +52,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 }
 @end
 
-static MCIPhoneImagePickerDialog *s_image_picker = nil;
+static com_runrev_livecode_MCIPhoneImagePickerDialog *s_image_picker = nil;
 
-@implementation MCIPhoneImagePickerDialog
+@implementation com_runrev_livecode_MCIPhoneImagePickerDialog
 
 - (void)setMaxWidth:(int32_t)mwidth maxHeight:(int32_t)mheight
 {
@@ -154,7 +154,7 @@ static MCIPhoneImagePickerDialog *s_image_picker = nil;
     // AL-2013-10-04 [[ Bug 11255 ]] Uninitialised variable can cause crash in iPhonePickPhoto
     id t_popover = nil;
     uint32_t t_orientations;
-    t_orientations = [[MCIPhoneApplication sharedApplication] allowedOrientations];
+    t_orientations = [[MCIPhoneGetApplication() sharedApplication] allowedOrientations];
     bool t_allowed_landscape = false;
     bool t_allowed_portrait_upside_down = false;
     
@@ -224,13 +224,13 @@ static MCIPhoneImagePickerDialog *s_image_picker = nil;
     }
     
 	if (s_image_picker == nil)
-		s_image_picker = [[MCIPhoneImagePickerDialog alloc] init];
+		s_image_picker = [[com_runrev_livecode_MCIPhoneImagePickerDialog alloc] init];
 	
 }
 
 + (NSData *)showModalForSource: (UIImagePickerControllerSourceType)sourceType deviceType: (UIImagePickerControllerCameraDevice)deviceType maxWidth: (int32_t)maxWidth maxHeight: (int32_t)maxHeight
 {
-	MCIPhoneCallSelectorOnMainFiber([MCIPhoneImagePickerDialog class], @selector(prepare));
+	MCIPhoneCallSelectorOnMainFiber([com_runrev_livecode_MCIPhoneImagePickerDialog class], @selector(prepare));
 	
 	s_image_picker -> m_running = true;
 	s_image_picker -> m_cancelled = true;
@@ -302,7 +302,7 @@ bool MCSystemAcquirePhoto(MCPhotoSourceType p_source, int32_t p_max_width, int32
 	map_photo_source_to_source_and_device(p_source, t_source_type, t_device_type);
 	
 	NSData *t_ns_image_data;
-	t_ns_image_data = [MCIPhoneImagePickerDialog showModalForSource: t_source_type deviceType: t_device_type maxWidth: p_max_width maxHeight: p_max_height];
+	t_ns_image_data = [com_runrev_livecode_MCIPhoneImagePickerDialog showModalForSource: t_source_type deviceType: t_device_type maxWidth: p_max_width maxHeight: p_max_height];
 	
 	if (t_ns_image_data != nil)
 	{

--- a/engine/src/mbliphonecontact.mm
+++ b/engine/src/mbliphonecontact.mm
@@ -819,7 +819,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCIPhoneContactDelegate : NSObject
+@interface com_runrev_livecode_MCIPhoneContactDelegate : NSObject
 {
 	bool m_running, m_finished, m_success;
 	UINavigationController *m_navigation;
@@ -831,7 +831,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 @end
 
-@implementation MCIPhoneContactDelegate
+@implementation com_runrev_livecode_MCIPhoneContactDelegate
 
 - (id)init
 {
@@ -890,7 +890,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCIPhonePickContactDelegate : MCIPhoneContactDelegate <ABPeoplePickerNavigationControllerDelegate>
+@interface com_runrev_livecode_MCIPhonePickContactDelegate : com_runrev_livecode_MCIPhoneContactDelegate <ABPeoplePickerNavigationControllerDelegate>
 {
     ABPeoplePickerNavigationController *m_pick_contact;
 }
@@ -900,7 +900,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 @end
 
-@implementation MCIPhonePickContactDelegate
+@implementation com_runrev_livecode_MCIPhonePickContactDelegate
 
 - (id)init
 {
@@ -1024,7 +1024,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCIPhoneShowContactDelegate : MCIPhoneContactDelegate <ABPersonViewControllerDelegate>
+@interface com_runrev_livecode_MCIPhoneShowContactDelegate : com_runrev_livecode_MCIPhoneContactDelegate <ABPersonViewControllerDelegate>
 {
 	ABPersonViewController *m_view_contact;
 }
@@ -1034,7 +1034,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 @end
 
-@implementation MCIPhoneShowContactDelegate
+@implementation com_runrev_livecode_MCIPhoneShowContactDelegate
 
 - (id)init
 {
@@ -1161,7 +1161,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCIPhoneCreateContactDelegate : MCIPhoneContactDelegate <ABNewPersonViewControllerDelegate>
+@interface com_runrev_livecode_MCIPhoneCreateContactDelegate : com_runrev_livecode_MCIPhoneContactDelegate <ABNewPersonViewControllerDelegate>
 {
 	ABNewPersonViewController *m_get_contact;
 }
@@ -1171,7 +1171,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 @end
 
-@implementation MCIPhoneCreateContactDelegate
+@implementation com_runrev_livecode_MCIPhoneCreateContactDelegate
 
 - (id)init
 {
@@ -1240,7 +1240,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCIPhoneUpdateContactDelegate : MCIPhoneContactDelegate <ABUnknownPersonViewControllerDelegate>
+@interface com_runrev_livecode_MCIPhoneUpdateContactDelegate : com_runrev_livecode_MCIPhoneContactDelegate <ABUnknownPersonViewControllerDelegate>
 {
 	ABUnknownPersonViewController *m_update_contact;
 }
@@ -1250,7 +1250,7 @@ bool MCContactFindContact(MCStringRef p_person_name, MCStringRef &r_chosen)
 
 @end
 
-@implementation MCIPhoneUpdateContactDelegate
+@implementation com_runrev_livecode_MCIPhoneUpdateContactDelegate
 
 - (id)init
 {
@@ -1379,8 +1379,8 @@ bool MCSystemPickContact(int32_t& r_result) // ABPeoplePickerNavigationControlle
 {
     bool t_success = true;
 	
-    MCIPhonePickContactDelegate *t_pick_contact = nil;
-	t_success = nil != (t_pick_contact = [[MCIPhonePickContactDelegate alloc] init]);
+    com_runrev_livecode_MCIPhonePickContactDelegate *t_pick_contact = nil;
+	t_success = nil != (t_pick_contact = [[com_runrev_livecode_MCIPhonePickContactDelegate alloc] init]);
 	
 	if (t_success)
 		t_success = [t_pick_contact showPickContact: r_result];
@@ -1395,8 +1395,8 @@ bool MCSystemShowContact(int32_t p_contact_id, int32_t& r_result) // ABPersonVie
 {
     bool t_success = true;
 	
-    MCIPhoneShowContactDelegate *t_view_contact = nil;
-	t_success = nil != (t_view_contact = [[MCIPhoneShowContactDelegate alloc] init]);
+    com_runrev_livecode_MCIPhoneShowContactDelegate *t_view_contact = nil;
+	t_success = nil != (t_view_contact = [[com_runrev_livecode_MCIPhoneShowContactDelegate alloc] init]);
 	
 	if (t_success)
 		t_success = [t_view_contact showViewContact:p_contact_id withResult: r_result];
@@ -1411,8 +1411,8 @@ bool MCSystemCreateContact(int32_t& r_result) // ABNewPersonViewController
 {
     bool t_success = true;
 	
-    MCIPhoneCreateContactDelegate *t_create_contact = nil;
-	t_success = nil != (t_create_contact = [[MCIPhoneCreateContactDelegate alloc] init]);
+    com_runrev_livecode_MCIPhoneCreateContactDelegate *t_create_contact = nil;
+	t_success = nil != (t_create_contact = [[com_runrev_livecode_MCIPhoneCreateContactDelegate alloc] init]);
 	
 	if (t_success)
 		t_success = [t_create_contact showCreateContact:r_result];
@@ -1431,9 +1431,9 @@ bool MCSystemUpdateContact(MCArrayRef p_contact, MCStringRef p_title, MCStringRe
 	ABRecordRef t_contact = nil;
 	t_success = MCCreatePerson(p_contact, t_contact);
 
-	MCIPhoneUpdateContactDelegate *t_update_contact = nil;
+	com_runrev_livecode_MCIPhoneUpdateContactDelegate *t_update_contact = nil;
 	if (t_success)
-		t_success = nil != (t_update_contact = [[MCIPhoneUpdateContactDelegate alloc] init]);
+		t_success = nil != (t_update_contact = [[com_runrev_livecode_MCIPhoneUpdateContactDelegate alloc] init]);
 	if (t_success)
 		t_success = [t_update_contact showUpdateContact:t_contact
 											  withTitle:p_title withMessage:p_message withAlternateName:p_alternate_name

--- a/engine/src/mbliphonedialog.mm
+++ b/engine/src/mbliphonedialog.mm
@@ -50,14 +50,14 @@ extern UITextView *MCIPhoneGetTextView(void);
 
 static bool s_in_modal = false;
 
-@interface ModalDelegate : NSObject <UITextFieldDelegate>
+@interface com_runrev_livecode_MCModalDelegate : NSObject <UITextFieldDelegate>
 {
 	NSInteger m_index;
 	UIAlertView *m_view;
 }
 @end
 
-@implementation ModalDelegate
+@implementation com_runrev_livecode_MCModalDelegate
 
 - (void)setView: (UIAlertView *)view
 {
@@ -104,7 +104,7 @@ struct popupanswerdialog_t
 	int32_t result;
 	
 	UIAlertView *alert_view;
-	ModalDelegate *delegate;
+	com_runrev_livecode_MCModalDelegate *delegate;
 };
 
 static void dopopupanswerdialog_prewait(void *p_context)
@@ -119,7 +119,7 @@ static void dopopupanswerdialog_prewait(void *p_context)
 
     if (MCmajorosversion < 800)
     {
-        ctxt -> delegate = [[ModalDelegate alloc] init];
+        ctxt -> delegate = [[com_runrev_livecode_MCModalDelegate alloc] init];
         ctxt -> alert_view = [[UIAlertView alloc] initWithTitle:t_title message:t_prompt delegate:ctxt -> delegate cancelButtonTitle:nil otherButtonTitles:nil];
         
         if (ctxt -> button_count == 0)
@@ -222,7 +222,7 @@ int32_t MCScreenDC::popupanswerdialog(MCStringRef p_buttons[], uint32_t p_button
 #define kUITextFieldXPadding 12.0
 #define kUIAlertOffset 100.0
 
-@interface TextAlertView : UIAlertView
+@interface com_runrev_livecode_MCTextAlertView : UIAlertView
 {
 	NSInteger m_index;
 	UITextField *m_textResult;
@@ -237,7 +237,7 @@ int32_t MCScreenDC::popupanswerdialog(MCStringRef p_buttons[], uint32_t p_button
 
 @end
 
-@implementation TextAlertView
+@implementation com_runrev_livecode_MCTextAlertView
 
 // UIAlertView/TextAlertView delegate method(s) 
 - (void)alertView:(UIAlertView *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
@@ -407,8 +407,8 @@ struct popupaskdialog_t
 	bool hint;
 	MCStringRef result;
 	
-	TextAlertView *alert;
-	ModalDelegate *delegate;
+	com_runrev_livecode_MCTextAlertView *alert;
+	com_runrev_livecode_MCModalDelegate *delegate;
 	UIAlertView *alert_view;
 	UITextField *text_field;
 };
@@ -429,13 +429,13 @@ static void dopopupaskdialog_prewait(void *p_context)
     
     if (MCmajorosversion < 800)
     {
-        ctxt -> delegate = [[ModalDelegate alloc] init];
+        ctxt -> delegate = [[com_runrev_livecode_MCModalDelegate alloc] init];
         
         UITextField *t_text_field;
         UIAlertView *t_alert;
         if (MCmajorosversion < 500)
         {
-            ctxt-> alert = [[TextAlertView alloc] initWithTitle:t_title
+            ctxt-> alert = [[com_runrev_livecode_MCTextAlertView alloc] initWithTitle:t_title
                                                         message:t_message
                                                        delegate:ctxt -> delegate
                                                            type:ctxt -> type

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -217,7 +217,7 @@ UIWindow *MCIPhoneGetWindow(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCExportImageToAlbumDelegate : NSObject
+@interface com_runrev_livecode_MCExportImageToAlbumDelegate : NSObject
 {
 	bool m_finished;
 	bool m_successful;
@@ -228,7 +228,7 @@ UIWindow *MCIPhoneGetWindow(void);
 - (void)image: (UIImage *)image didFinishSavingWithError: (NSError *)error contextInfo: (void *)contextInfo;
 @end
 
-@implementation MCExportImageToAlbumDelegate
+@implementation com_runrev_livecode_MCExportImageToAlbumDelegate
 
 - (id)init
 {
@@ -281,7 +281,7 @@ UIWindow *MCIPhoneGetWindow(void);
 
 struct export_image_t
 {
-    MCExportImageToAlbumDelegate *delegate;
+    com_runrev_livecode_MCExportImageToAlbumDelegate *delegate;
     MCDataRef raw_data;
     // PM-2014-12-12: [[ Bug 13860 ]] Added support for exporting referenced images to album
     bool is_raw_data;
@@ -377,7 +377,7 @@ Exec_stat MCHandleExportImageToAlbum(void *context, MCParameter *p_parameters)
 	export_image_t ctxt;
     ctxt . is_raw_data = t_is_raw_data;
 	ctxt . image_data = t_image_data;
-	ctxt . delegate = [[MCExportImageToAlbumDelegate alloc] init];
+	ctxt . delegate = [[com_runrev_livecode_MCExportImageToAlbumDelegate alloc] init];
 	
 	MCIPhoneRunOnMainFiber(export_image, &ctxt);
 	
@@ -401,7 +401,7 @@ bool MCSystemExportImageToAlbum(MCStringRef& r_save_result, MCDataRef p_raw_data
 	export_image_t ctxt;
     ctxt . is_raw_data = p_is_raw_data;
     ctxt . raw_data = p_raw_data;
-	ctxt . delegate = [[MCExportImageToAlbumDelegate alloc] init];
+	ctxt . delegate = [[com_runrev_livecode_MCExportImageToAlbumDelegate alloc] init];
 
 	MCIPhoneRunOnMainFiber(export_image, &ctxt);
 

--- a/engine/src/mbliphoneinput.mm
+++ b/engine/src/mbliphoneinput.mm
@@ -51,7 +51,7 @@ UIView *MCIPhoneGetView(void);
 class MCiOSInputControl;
 
 // Note that we use the notifications, rather than delegate methods.
-@interface MCiOSInputDelegate : NSObject <UITextFieldDelegate, UITextViewDelegate>
+@interface com_runrev_livecode_MCiOSInputDelegate : NSObject <UITextFieldDelegate, UITextViewDelegate>
 {
 	MCiOSInputControl *m_instance;
 	bool m_didchange_pending;
@@ -76,7 +76,7 @@ class MCiOSInputControl;
 @end
 
 
-@interface MCiOSMultiLineDelegate : MCiOSInputDelegate <UIScrollViewDelegate>
+@interface com_runrev_livecode_MCiOSMultiLineDelegate : com_runrev_livecode_MCiOSInputDelegate <UIScrollViewDelegate>
 {
     UIView* m_view;
 	int32_t m_verticaltextalign;
@@ -151,12 +151,12 @@ public:
     
 	void HandleNotifyEvent(MCNameRef p_notification);
 
-	MCiOSInputDelegate *GetDelegate(void);
+	com_runrev_livecode_MCiOSInputDelegate *GetDelegate(void);
 	
 protected:
 	virtual ~MCiOSInputControl(void);
 	
-	MCiOSInputDelegate *m_delegate;
+	com_runrev_livecode_MCiOSInputDelegate *m_delegate;
 };
 
 // single line input control
@@ -1320,7 +1320,7 @@ void MCiOSInputControl::ExecFocus(MCExecContext &ctxt)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCiOSInputDelegate *MCiOSInputControl::GetDelegate(void)
+com_runrev_livecode_MCiOSInputDelegate *MCiOSInputControl::GetDelegate(void)
 {
 	return m_delegate;
 }
@@ -1613,7 +1613,7 @@ UIView *MCiOSInputFieldControl::CreateView(void)
 	
 	[t_view setHidden: YES];
 	
-	m_delegate = [[MCiOSInputDelegate alloc] initWithInstance: this view: t_view];
+	m_delegate = [[com_runrev_livecode_MCiOSInputDelegate alloc] initWithInstance: this view: t_view];
 	[t_view setDelegate: m_delegate];
 	
 	return t_view;
@@ -1698,8 +1698,8 @@ void MCiOSMultiLineControl::SetVerticalTextAlign(MCExecContext& ctxt, MCNativeCo
 {
 	if (m_delegate != nil)
     {
-       	MCiOSMultiLineDelegate *t_delegate;
-        t_delegate = (MCiOSMultiLineDelegate*)m_delegate;
+       	com_runrev_livecode_MCiOSMultiLineDelegate *t_delegate;
+        t_delegate = (com_runrev_livecode_MCiOSMultiLineDelegate*)m_delegate;
         
         [t_delegate setVerticalTextAlign:(int32_t)p_align];
     }
@@ -1771,8 +1771,8 @@ void MCiOSMultiLineControl::GetDataDetectorTypes(MCExecContext& ctxt, MCNativeCo
 
 void MCiOSMultiLineControl::GetVerticalTextAlign(MCExecContext& ctxt, MCNativeControlInputVerticalAlign& r_align)
 {
-	MCiOSMultiLineDelegate *t_delegate;
-	t_delegate = (MCiOSMultiLineDelegate*)m_delegate;
+	com_runrev_livecode_MCiOSMultiLineDelegate *t_delegate;
+	t_delegate = (com_runrev_livecode_MCiOSMultiLineDelegate*)m_delegate;
  
     if (t_delegate)
         r_align = (MCNativeControlInputVerticalAlign)[t_delegate getVerticalTextAlign];
@@ -2202,8 +2202,8 @@ Exec_stat MCiOSMultiLineControl::Set(MCNativeControlProperty p_property, MCExecP
 	if (t_view == nil)
 		return MCiOSControl::Set(p_property, ep);
 	
-	MCiOSMultiLineDelegate *t_delegate;
-	t_delegate = (MCiOSMultiLineDelegate*)m_delegate;
+	com_runrev_livecode_MCiOSMultiLineDelegate *t_delegate;
+	t_delegate = (com_runrev_livecode_MCiOSMultiLineDelegate*)m_delegate;
 	
 	bool t_bool;
 	NSString *t_string;
@@ -2281,8 +2281,8 @@ Exec_stat MCiOSMultiLineControl::Get(MCNativeControlProperty p_property, MCExecP
 	if (t_view == nil)
 		return MCiOSControl::Get(p_property, ep);
 	
-	MCiOSMultiLineDelegate *t_delegate;
-	t_delegate = (MCiOSMultiLineDelegate*)m_delegate;
+	com_runrev_livecode_MCiOSMultiLineDelegate *t_delegate;
+	t_delegate = (com_runrev_livecode_MCiOSMultiLineDelegate*)m_delegate;
 	
 	switch(p_property)
 	{	
@@ -2437,7 +2437,7 @@ UIView *MCiOSMultiLineControl::CreateView(void)
 	
 	[t_view setHidden: YES];
 	
-	m_delegate = [[MCiOSMultiLineDelegate alloc] initWithInstance: this view: t_view];
+	m_delegate = [[com_runrev_livecode_MCiOSMultiLineDelegate alloc] initWithInstance: this view: t_view];
 	[t_view setDelegate: m_delegate];
 	
 	return t_view;
@@ -2525,7 +2525,7 @@ static struct { NSString *name; SEL selector; } s_input_notifications[] =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@implementation MCiOSInputDelegate
+@implementation com_runrev_livecode_MCiOSInputDelegate
 
 - (id)initWithInstance:(MCiOSInputControl*)instance view: (UIView *)view
 {
@@ -2685,7 +2685,7 @@ private:
 	MCiOSMultiLineControl *m_target;
 };
 
-@implementation MCiOSMultiLineDelegate
+@implementation com_runrev_livecode_MCiOSMultiLineDelegate
 
 - (id)initWithInstance:(MCiOSInputControl *)instance view:(UIView *)view
 {

--- a/engine/src/mbliphonemail.mm
+++ b/engine/src/mbliphonemail.mm
@@ -42,7 +42,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCIPhoneMailComposerDialog : MFMailComposeViewController <MFMailComposeViewControllerDelegate>
+@interface com_runrev_livecode_MCIPhoneMailComposerDialog : MFMailComposeViewController <MFMailComposeViewControllerDelegate>
 {
 	bool m_running;
 }
@@ -56,9 +56,9 @@ UIViewController *MCIPhoneGetViewController(void);
 
 @end
 
-static MCIPhoneMailComposerDialog *s_mail_composer_dialog = nil;
+static com_runrev_livecode_MCIPhoneMailComposerDialog *s_mail_composer_dialog = nil;
 
-@implementation MCIPhoneMailComposerDialog
+@implementation com_runrev_livecode_MCIPhoneMailComposerDialog
 
 - (bool)isRunning
 {
@@ -103,7 +103,7 @@ struct iphone_send_email_t
 	MCStringRef cc_addresses;
 	MCStringRef subject;
 	MCStringRef body;
-	MCIPhoneMailComposerDialog *dialog; 
+	com_runrev_livecode_MCIPhoneMailComposerDialog *dialog;
 };
 
 static void iphone_send_email_prewait(void *p_context)
@@ -143,7 +143,7 @@ static void iphone_send_email_prewait(void *p_context)
 	iphone_send_email_t *ctxt;
 	ctxt = (iphone_send_email_t *)p_context;
 	
-	ctxt -> dialog = [[MCIPhoneMailComposerDialog alloc ] init];
+	ctxt -> dialog = [[com_runrev_livecode_MCIPhoneMailComposerDialog alloc ] init];
 	[ ctxt -> dialog setMailComposeDelegate: ctxt -> dialog ];
 	
 	NSArray *t_recipients;
@@ -184,7 +184,7 @@ static void iphone_send_email_postwait(void *p_context)
 #ifdef /* MCIPhoneSendEmail */ LEGACY_EXEC
 static void MCIPhoneSendEmail(const char *p_to_addresses, const char *p_cc_addresses, const char *p_subject, const char *p_body)
 {
-	if (![MCIPhoneMailComposerDialog canSendMail])
+	if (![com_runrev_livecode_MCIPhoneMailComposerDialog canSendMail])
 	{
 		MCresult -> sets("not configured");
 		return;
@@ -345,7 +345,7 @@ struct compose_mail_t
 	MCMailType type;
 	MCAttachmentData *attachments;
 	uindex_t attachment_count;
-	MCIPhoneMailComposerDialog *dialog;
+	com_runrev_livecode_MCIPhoneMailComposerDialog *dialog;
 };
 
 static void compose_mail_prewait(void *p_context)
@@ -368,7 +368,7 @@ static void compose_mail_prewait(void *p_context)
 	
 	if (t_success)
 	{
-		ctxt -> dialog = [[MCIPhoneMailComposerDialog alloc ] init];
+		ctxt -> dialog = [[com_runrev_livecode_MCIPhoneMailComposerDialog alloc ] init];
 		[ ctxt -> dialog setMailComposeDelegate: ctxt -> dialog ];
 		
 		NSCharacterSet *t_separator_set;
@@ -455,7 +455,7 @@ static void compose_mail_prewait(void *p_context)
 	bool t_success;
 	t_success = true;
 
-	ctxt -> dialog = [[MCIPhoneMailComposerDialog alloc ] init];
+	ctxt -> dialog = [[com_runrev_livecode_MCIPhoneMailComposerDialog alloc ] init];
 	[ ctxt -> dialog setMailComposeDelegate: ctxt -> dialog ];
 
 	if (ctxt -> attachments != nil)
@@ -580,7 +580,7 @@ Exec_stat MCHandleComposeHtmlMail(void *context, MCParameter *p_parameters)
 #ifdef /* MCHandleCanSendMailIphone */ LEGACY_EXEC
 Exec_stat MCHandleCanSendMail(void *context, MCParameter *p_parameters)
 {
-	if (![MCIPhoneMailComposerDialog canSendMail])
+	if (![com_runrev_livecode_MCIPhoneMailComposerDialog canSendMail])
 	{
 		MCresult -> sets(MCfalsestring);
 		return ES_NORMAL;
@@ -649,7 +649,7 @@ void MCSystemSendMailWithAttachments(MCStringRef p_to, MCStringRef p_cc, MCStrin
 
 void MCSystemGetCanSendMail(bool& r_result)
 {
-	r_result = [MCIPhoneMailComposerDialog canSendMail];
+	r_result = [com_runrev_livecode_MCIPhoneMailComposerDialog canSendMail];
 }
 
 void MCSystemMailResult(MCStringRef& r_result)

--- a/engine/src/mbliphonemediapick.mm
+++ b/engine/src/mbliphonemediapick.mm
@@ -38,7 +38,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCIPhonePickMediaDelegate : UIViewController <MPMediaPickerControllerDelegate, UIPopoverControllerDelegate>
+@interface com_runrev_livecode_MCIPhonePickMediaDelegate : UIViewController <MPMediaPickerControllerDelegate, UIPopoverControllerDelegate>
 {
 	bool m_running;
 	NSArray *media_returned;
@@ -50,7 +50,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 @end
 
-@implementation MCIPhonePickMediaDelegate
+@implementation com_runrev_livecode_MCIPhonePickMediaDelegate
 
 - (id)init
 {
@@ -105,11 +105,11 @@ bool MCIPhonePickMedia(bool p_allow_multiple_items, MPMediaType p_media_types, N
 // HC-2011-10-28: [[ Media Picker ]] Ensure we do not crash if the media picker is used on the simulator.
 	r_media_returned = nil;
 #ifndef __i386__
-	__block MCIPhonePickMediaDelegate *t_media_picker;
+	__block com_runrev_livecode_MCIPhonePickMediaDelegate *t_media_picker;
 	__block NSArray *t_result_data;
 	t_result_data = nil;
     MCIPhoneRunBlockOnMainFiber(^(void) {
-        t_media_picker = [[MCIPhonePickMediaDelegate alloc] init];
+        t_media_picker = [[com_runrev_livecode_MCIPhonePickMediaDelegate alloc] init];
     });
     [t_media_picker showMediaPicker: p_allow_multiple_items andTypes: p_media_types withResult: t_result_data];
 	if (t_result_data != nil)

--- a/engine/src/mbliphonepick.mm
+++ b/engine/src/mbliphonepick.mm
@@ -37,7 +37,7 @@ UIViewController *MCIPhoneGetViewController(void);
 ////////////////////////////////////////////////////////////////////////////////
 
 // MM-2013-09-23: [[ iOS7 Support ]] Added missing delegates implemented in order to appease llvm 5.0.
-@interface MCIPhonePickWheelDelegate : UIViewController <UIPickerViewDelegate, UIPickerViewDataSource, UIActionSheetDelegate, UITableViewDelegate, UIPopoverControllerDelegate, UITableViewDataSource>
+@interface com_runrev_livecode_MCIPhonePickWheelDelegate : UIViewController <UIPickerViewDelegate, UIPickerViewDataSource, UIActionSheetDelegate, UITableViewDelegate, UIPopoverControllerDelegate, UITableViewDataSource>
 {
 	bool iSiPad;
 	bool m_running;
@@ -65,7 +65,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 @end
 
-@implementation MCIPhonePickWheelDelegate
+@implementation com_runrev_livecode_MCIPhonePickWheelDelegate
 
 - (id)init
 {
@@ -800,7 +800,7 @@ return 1;
 }
 @end
 
-static MCIPhonePickWheelDelegate *s_pick_wheel_delegate = nil;
+static com_runrev_livecode_MCIPhonePickWheelDelegate *s_pick_wheel_delegate = nil;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -816,7 +816,7 @@ struct picker_t
 	NSArray *initial_index_array;
 	NSString *return_index;
 	MCRectangle button_rect;
-	MCIPhonePickWheelDelegate *picker;
+	com_runrev_livecode_MCIPhonePickWheelDelegate *picker;
 	bool cancelled;
 };
 
@@ -826,7 +826,7 @@ static void do_pickn_prewait(void *p_context)
 	ctxt = (picker_t *)p_context;
 	
 	// call the picker with the label and options list
-	ctxt -> picker = [[MCIPhonePickWheelDelegate alloc] init];
+	ctxt -> picker = [[com_runrev_livecode_MCIPhonePickWheelDelegate alloc] init];
 	[ctxt -> picker setUseCheckmark: ctxt -> use_checkmark];
 
 	// HC-2011-09-28 [[ Picker Buttons ]] Added arguments to force the display of buttons and picker
@@ -919,7 +919,7 @@ static void pick_option_prewait(void *p_context)
 	picker_t *ctxt;
 	ctxt = (picker_t *)p_context;
 	
-	ctxt -> picker = [[MCIPhonePickWheelDelegate alloc] init];
+	ctxt -> picker = [[com_runrev_livecode_MCIPhonePickWheelDelegate alloc] init];
 	[ctxt -> picker setUseCheckmark: !ctxt->use_hilited];
 	// HC-2011-09-28 [[ Picker Buttons ]] Added arguments to force the display of buttons and picker
 	[ctxt -> picker startPicking: ctxt->option_list_array andInitial: ctxt->initial_index_array andCancel: ctxt->use_cancel andDone: ctxt->use_done andPicker: ctxt->use_picker andButtonRect: ctxt->button_rect];

--- a/engine/src/mbliphonepickdate.mm
+++ b/engine/src/mbliphonepickdate.mm
@@ -41,7 +41,7 @@ UIViewController *MCIPhoneGetViewController(void);
 ////////////////////////////////////////////////////////////////////////////////
 
 // MM-2013-09-23: [[ iOS7 Support ]] Added missing delegates implemented in order to appease llvm 5.0.
-@interface MCIPhonePickDateWheelDelegate : UIViewController <UIPickerViewDelegate, UIPickerViewDataSource, UIActionSheetDelegate, UITableViewDelegate, UIPopoverControllerDelegate>
+@interface com_runrev_livecode_MCIPhonePickDateWheelDelegate : UIViewController <UIPickerViewDelegate, UIPickerViewDataSource, UIActionSheetDelegate, UITableViewDelegate, UIPopoverControllerDelegate>
 {
 	bool iSiPad;
 	bool m_running;
@@ -58,7 +58,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 @end
 
-@implementation MCIPhonePickDateWheelDelegate
+@implementation com_runrev_livecode_MCIPhonePickDateWheelDelegate
 
 - (id)init
 {
@@ -541,7 +541,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 @end
 
-static MCIPhonePickDateWheelDelegate *s_pick_date_wheel_delegate = nil;
+static com_runrev_livecode_MCIPhonePickDateWheelDelegate *s_pick_date_wheel_delegate = nil;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -556,7 +556,7 @@ struct datepicker_t
 	bool use_cancel;
 	bool use_done;
 	MCRectangle button_rect;
-	MCIPhonePickDateWheelDelegate *picker;
+	com_runrev_livecode_MCIPhonePickDateWheelDelegate *picker;
 	bool cancelled;
 };
 
@@ -565,7 +565,7 @@ static void pickdate_prewait(void *p_context)
 	datepicker_t *ctxt;
 	ctxt = (datepicker_t *)p_context;
 	
-	ctxt -> picker = [[MCIPhonePickDateWheelDelegate alloc] init];
+	ctxt -> picker = [[com_runrev_livecode_MCIPhonePickDateWheelDelegate alloc] init];
 	
 	// MW-2012-09-21: [[ Bug 10402 ]] Make sure we pass the 'step' parameter through.
 	[ctxt -> picker startDatePicker: ctxt -> style andCurrent: ctxt -> current andStart: ctxt -> min andEnd: ctxt -> max andStep: ctxt -> step andCancel: ctxt -> use_cancel andDone: ctxt -> use_done andButtonRect: ctxt -> button_rect];

--- a/engine/src/mbliphoneplayer.mm
+++ b/engine/src/mbliphoneplayer.mm
@@ -58,7 +58,7 @@ extern MPMoviePlayerViewController *g_movie_player;
 
 class MCiOSPlayerControl;
 
-@interface MCiOSPlayerDelegate : NSObject
+@interface com_runrev_livecode_MCiOSPlayerDelegate : NSObject
 {
 	MCiOSPlayerControl *m_instance;
     UIControl *m_overlay;
@@ -171,7 +171,7 @@ protected:
 	
 private:
 	MPMoviePlayerController *m_controller;
-	MCiOSPlayerDelegate *m_delegate;
+	com_runrev_livecode_MCiOSPlayerDelegate *m_delegate;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1058,7 +1058,7 @@ UIView *MCiOSPlayerControl::CreateView(void)
     [t_view setHidden: YES];
     [t_view setFrame: CGRectMake(0, 0, 0, 0)];
 
-    m_delegate = [[MCiOSPlayerDelegate alloc] initWithInstance: this];
+    m_delegate = [[com_runrev_livecode_MCiOSPlayerDelegate alloc] initWithInstance: this];
     return t_view;
 }
 
@@ -1156,7 +1156,7 @@ static struct { NSString* const* name; SEL selector; } s_player_notifications[] 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@implementation MCiOSPlayerDelegate
+@implementation com_runrev_livecode_MCiOSPlayerDelegate
 
 - (id)initWithInstance:(MCiOSPlayerControl*)instance
 {

--- a/engine/src/mbliphonescroller.mm
+++ b/engine/src/mbliphonescroller.mm
@@ -45,7 +45,7 @@ extern UIView *MCIPhoneGetView(void);
 
 class MCiOSScrollerControl;
 
-@interface MCiOSScrollViewDelegate : NSObject <UIScrollViewDelegate>
+@interface com_runrev_livecode_MCiOSScrollViewDelegate : NSObject <UIScrollViewDelegate>
 {
 	MCiOSScrollerControl *m_instance;
 }
@@ -53,7 +53,7 @@ class MCiOSScrollerControl;
 - (id)initWithInstance:(MCiOSScrollerControl *)instance;
 @end
 
-@interface MCNativeViewEventForwarder : UIView
+@interface com_runrev_livecode_MCNativeViewEventForwarder : UIView
 {
 	UIView *m_target;
 	
@@ -146,8 +146,8 @@ protected:
 	virtual ~MCiOSScrollerControl(void);
 	
 private:
-	MCiOSScrollViewDelegate *m_delegate;
-	MCNativeViewEventForwarder *m_forwarder;
+	com_runrev_livecode_MCiOSScrollViewDelegate *m_delegate;
+	com_runrev_livecode_MCNativeViewEventForwarder *m_forwarder;
 	MCRectangle32 m_content_rect;
 };
 
@@ -1198,9 +1198,9 @@ UIView *MCiOSScrollerControl::CreateView(void)
 	
 	[t_view setHidden: YES];
 	
-	m_delegate = [[MCiOSScrollViewDelegate alloc] initWithInstance: this];
+	m_delegate = [[com_runrev_livecode_MCiOSScrollViewDelegate alloc] initWithInstance: this];
 	[t_view setDelegate: m_delegate];
-	m_forwarder = [[MCNativeViewEventForwarder alloc] initWithFrame: CGRectMake(0,0,0,0)];
+	m_forwarder = [[com_runrev_livecode_MCNativeViewEventForwarder alloc] initWithFrame: CGRectMake(0,0,0,0)];
 	[t_view addSubview: m_forwarder];
 	
 	if (MCmajorosversion >= DELAYS_TOUCHES_WORKAROUND_MIN)
@@ -1310,7 +1310,7 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@implementation MCiOSScrollViewDelegate
+@implementation com_runrev_livecode_MCiOSScrollViewDelegate
 
 - (id)initWithInstance:(MCiOSScrollerControl*)instance
 {
@@ -1385,7 +1385,7 @@ bool MCNativeScrollerControlCreate(MCNativeControl *&r_control)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@implementation MCNativeViewEventForwarder
+@implementation com_runrev_livecode_MCNativeViewEventForwarder
 
 - (id) initWithFrame: (CGRect)withFrame
 {

--- a/engine/src/mbliphonesensor.mm
+++ b/engine/src/mbliphonesensor.mm
@@ -88,7 +88,7 @@ static void initialize_core_motion(void)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-@interface MCIPhoneLocationDelegate : NSObject <CLLocationManagerDelegate>
+@interface com_runrev_livecode_MCIPhoneLocationDelegate : NSObject <CLLocationManagerDelegate>
 {
 	NSTimer *m_calibration_timer;
     bool m_ready;
@@ -96,13 +96,13 @@ static void initialize_core_motion(void)
 @end
 
 static CLLocationManager *s_location_manager = nil;
-static MCIPhoneLocationDelegate *s_location_delegate = nil;
+static com_runrev_livecode_MCIPhoneLocationDelegate *s_location_delegate = nil;
 static bool s_location_enabled = false;
 static bool s_heading_enabled = false;
 static bool s_tracking_heading_loosely = false;
 static int32_t s_location_calibration_timeout = 0;
 
-@implementation MCIPhoneLocationDelegate 
+@implementation com_runrev_livecode_MCIPhoneLocationDelegate
 
 - (void)dealloc
 {
@@ -240,7 +240,7 @@ static void initialize_core_location(void)
 	
     // PM-2014-10-07: [[ Bug 13590 ]] Configuration of the location manager object must always occur on a thread with an active run loop
     MCIPhoneRunBlockOnMainFiber(^(void) {s_location_manager = [[CLLocationManager alloc] init];});
-	s_location_delegate = [[MCIPhoneLocationDelegate alloc] init];
+	s_location_delegate = [[com_runrev_livecode_MCIPhoneLocationDelegate alloc] init];
     [s_location_delegate setReady: False];
     
    	[s_location_manager setDelegate: s_location_delegate];

--- a/engine/src/mbliphonesound.mm
+++ b/engine/src/mbliphonesound.mm
@@ -82,7 +82,7 @@ void MCIHandleFinishedPlayingSound(MCStringRef p_payload)
 }
 
 // HC-2011-10-20 [[ Media Picker ]] Added functionality to access iPod by accessing the AVFoundation.
-@interface MCSoundPlayerDelegate: NSObject
+@interface com_runrev_livecode_MCSoundPlayerDelegate: NSObject
 {
     AVAsset *m_asset;
 	AVPlayer *m_player;
@@ -99,7 +99,7 @@ void MCIHandleFinishedPlayingSound(MCStringRef p_payload)
 - (void)dealloc;
 @end
 
-static MCSoundPlayerDelegate *s_sound_player_delegate = nil;
+static com_runrev_livecode_MCSoundPlayerDelegate *s_sound_player_delegate = nil;
 static float s_sound_loudness = 1.0;
 static MCStringRef s_sound_file = nil;
 
@@ -115,7 +115,7 @@ bool MCSystemSoundFinalize()
 	return true;
 }
 
-@implementation MCSoundPlayerDelegate
+@implementation com_runrev_livecode_MCSoundPlayerDelegate
 
 -(id)init
 {
@@ -334,7 +334,7 @@ bool MCSystemPlaySound(MCStringRef p_sound, bool p_looping)
     if (t_success)
     { 
 		MCIPhoneRunBlockOnMainFiber(^(void) {
-			s_sound_player_delegate = [MCSoundPlayerDelegate alloc];
+			s_sound_player_delegate = [com_runrev_livecode_MCSoundPlayerDelegate alloc];
 			[s_sound_player_delegate init];
 			*t_success_ptr = [s_sound_player_delegate playSound:t_url looping: p_looping];
 		});
@@ -361,7 +361,7 @@ void MCSystemGetPlayingSound(MCStringRef &r_sound)
 
 struct MCSystemSoundChannel;
 
-@interface MCSystemSoundChannelDelegate : NSObject <AVAudioPlayerDelegate>
+@interface com_runrev_livecode_MCSystemSoundChannelDelegate : NSObject <AVAudioPlayerDelegate>
 {
 	MCSystemSoundChannel *m_channel;
 }
@@ -382,7 +382,7 @@ struct MCSystemSoundChannel
 {
 	MCSystemSoundChannel *next;
 	MCStringRef name;
-	MCSystemSoundChannelDelegate *delegate;
+	com_runrev_livecode_MCSystemSoundChannelDelegate *delegate;
 	MCSystemSoundPlayer current_player;
 	MCSystemSoundPlayer next_player;
 	bool paused;
@@ -432,7 +432,7 @@ static bool new_sound_channel(MCStringRef p_channel, MCSystemSoundChannel*& r_ch
 	
 	if (t_success)
 	{
-		t_channel -> delegate = [[MCSystemSoundChannelDelegate alloc] initWithSoundChannel: t_channel];
+		t_channel -> delegate = [[com_runrev_livecode_MCSystemSoundChannelDelegate alloc] initWithSoundChannel: t_channel];
 		if (t_channel -> delegate == nil)
 			t_success = false;
 	}
@@ -721,7 +721,7 @@ bool MCSystemListSoundChannels(MCStringRef& r_channels)
 
 extern void MCSoundPostSoundFinishedOnChannelMessage(MCStringRef p_channel, MCStringRef p_sound, MCObjectHandle *p_object);
 
-@implementation MCSystemSoundChannelDelegate
+@implementation com_runrev_livecode_MCSystemSoundChannelDelegate
 
 - (id)initWithSoundChannel: (MCSystemSoundChannel *)channel
 {

--- a/engine/src/mbliphonestack.mm
+++ b/engine/src/mbliphonestack.mm
@@ -52,7 +52,7 @@ extern bool g_engine_manipulating_container;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface EffectDelegate : NSObject
+@interface com_runrev_livecode_MCEffectDelegate : NSObject
 {
 	BOOL m_finished;
 }
@@ -63,7 +63,7 @@ extern bool g_engine_manipulating_container;
 - (void) blockAnimationDidStop: (NSString *)animationID finished: (NSNumber *)finished context: (void*)context;
 @end
 
-@implementation EffectDelegate
+@implementation com_runrev_livecode_MCEffectDelegate
 - (void) animationDidStart: (CAAnimation *)theAnimation
 {
 }
@@ -305,7 +305,7 @@ struct effectrect_t
 	UIView *main_view;
 	UIView *composite_view;
 	UIView *background_view;
-	EffectDelegate *effect_delegate;
+	com_runrev_livecode_MCEffectDelegate *effect_delegate;
 	real8 duration;
 	UIViewAnimationTransition transition;
 };
@@ -356,7 +356,7 @@ static void effectrect_phase_2(void *p_context)
 	
 	ctxt -> duration = MCU_max(1, MCeffectrate / (ctxt -> effect->speed - VE_VERY)) / 1000.0;
 	
-	ctxt -> effect_delegate = [[EffectDelegate alloc] init];
+	ctxt -> effect_delegate = [[com_runrev_livecode_MCEffectDelegate alloc] init];
 	[ctxt -> effect_delegate setFinished:NO];
 	
 	ctxt -> composite_view = [ctxt -> main_view superview];

--- a/engine/src/mbliphonestore.mm
+++ b/engine/src/mbliphonestore.mm
@@ -700,7 +700,7 @@ void update_purchase_state(MCPurchase *p_purchase)
 	}
 }
 
-@interface MCPurchaseObserver : NSObject <SKPaymentTransactionObserver>
+@interface com_runrev_livecode_MCPurchaseObserver : NSObject <SKPaymentTransactionObserver>
 {
 }
 
@@ -711,7 +711,7 @@ void update_purchase_state(MCPurchase *p_purchase)
 
 @end
 
-@implementation MCPurchaseObserver
+@implementation com_runrev_livecode_MCPurchaseObserver
 
 - (void)paymentQueue:(SKPaymentQueue *)queue removedTransactions:(NSArray *)transactions
 {
@@ -789,14 +789,14 @@ void update_purchase_state(MCPurchase *p_purchase)
 
 @end
 
-MCPurchaseObserver *s_purchase_observer = nil;
+com_runrev_livecode_MCPurchaseObserver *s_purchase_observer = nil;
 
 bool MCStoreEnablePurchaseUpdates()
 {
 	if (s_purchase_observer != nil)
 		return true;
 	
-	s_purchase_observer = [[MCPurchaseObserver alloc] init];
+	s_purchase_observer = [[com_runrev_livecode_MCPurchaseObserver alloc] init];
 	if (s_purchase_observer == nil)
 		return false;
 	
@@ -822,7 +822,7 @@ bool MCStoreDisablePurchaseUpdates()
 bool MCStorePostProductRequestError(MCStringRef p_product, MCStringRef p_error);
 bool MCStorePostProductRequestResponse(SKProduct *p_product);
 
-@interface MCProductsRequest : SKProductsRequest
+@interface com_runrev_livecode_MCProductsRequest : SKProductsRequest
 {
     NSString *m_product_id;
 }
@@ -832,7 +832,7 @@ bool MCStorePostProductRequestResponse(SKProduct *p_product);
 
 @end
 
-@implementation MCProductsRequest
+@implementation com_runrev_livecode_MCProductsRequest
 
 - (id)initWithProductId:(NSString *)p_productId
 {
@@ -860,7 +860,7 @@ bool MCStorePostProductRequestResponse(SKProduct *p_product);
 
 @end
 
-@interface MCProductsRequestDelegate : NSObject <SKProductsRequestDelegate>
+@interface com_runrev_livecode_MCProductsRequestDelegate : NSObject <SKProductsRequestDelegate>
 {
 }
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response;
@@ -870,7 +870,7 @@ bool MCStorePostProductRequestResponse(SKProduct *p_product);
 
 @end
 
-@implementation MCProductsRequestDelegate
+@implementation com_runrev_livecode_MCProductsRequestDelegate
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response
 {
     if (response.invalidProductIdentifiers != nil)
@@ -901,7 +901,7 @@ bool MCStorePostProductRequestResponse(SKProduct *p_product);
 {
     MCAutoStringRef t_product, t_error;
     
-    /* UNCHECKED */ MCStringCreateWithCFString((CFStringRef)[(MCProductsRequest*)request getProductId], &t_product);
+    /* UNCHECKED */ MCStringCreateWithCFString((CFStringRef)[(com_runrev_livecode_MCProductsRequest*)request getProductId], &t_product);
     /* UNCHECKED */ MCStringCreateWithCFString((CFStringRef)[error description], &t_error);
 
     MCStorePostProductRequestError(*t_product, *t_error);
@@ -918,9 +918,9 @@ bool MCStoreRequestProductDetails(MCStringRef p_product_id)
     NSString *t_product_id = nil;
     
     t_product_id = [NSString stringWithMCStringRef: p_product_id];
-    t_request = [[MCProductsRequest alloc] initWithProductId: t_product_id];
+    t_request = [[com_runrev_livecode_MCProductsRequest alloc] initWithProductId: t_product_id];
     
-    [t_request setDelegate: [[MCProductsRequestDelegate alloc] init]];
+    [t_request setDelegate: [[com_runrev_livecode_MCProductsRequestDelegate alloc] init]];
     
     [t_request start];
     

--- a/engine/src/mbliphonetextmessaging.mm
+++ b/engine/src/mbliphonetextmessaging.mm
@@ -36,7 +36,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 UIViewController *MCIPhoneGetViewController(void);
 
-@interface MCIPhoneSmsComposerDialog : MFMessageComposeViewController <MFMessageComposeViewControllerDelegate>
+@interface com_runrev_livecode_MCIPhoneSmsComposerDialog : MFMessageComposeViewController <MFMessageComposeViewControllerDelegate>
 {
 	bool m_running;
 }
@@ -48,9 +48,9 @@ UIViewController *MCIPhoneGetViewController(void);
 - (void)postWait;
 @end
 
-static MCIPhoneSmsComposerDialog *s_sms_composer_dialog = nil;
+static com_runrev_livecode_MCIPhoneSmsComposerDialog *s_sms_composer_dialog = nil;
 
-@implementation MCIPhoneSmsComposerDialog
+@implementation com_runrev_livecode_MCIPhoneSmsComposerDialog
 
 - (bool)isRunning
 {
@@ -104,7 +104,7 @@ struct compose_text_message_t
 {
 	MCStringRef recipients;
 	MCStringRef body;
-	MCIPhoneSmsComposerDialog *dialog;
+	com_runrev_livecode_MCIPhoneSmsComposerDialog *dialog;
 	bool success;
 };
 
@@ -120,7 +120,7 @@ static void compose_text_message_prewait(void *p_context)
 		return;
 	}
 	
-	ctxt -> dialog = [[MCIPhoneSmsComposerDialog alloc] init];
+	ctxt -> dialog = [[com_runrev_livecode_MCIPhoneSmsComposerDialog alloc] init];
     [ctxt -> dialog setMessageComposeDelegate: ctxt -> dialog];
     [ctxt -> dialog setRecipients: [[NSString stringWithMCStringRef: ctxt -> recipients] componentsSeparatedByString:@","]];
     [ctxt -> dialog setBody: [NSString stringWithMCStringRef: ctxt -> body]];

--- a/engine/src/mbliphoneurl.mm
+++ b/engine/src/mbliphoneurl.mm
@@ -93,7 +93,7 @@ bool UrlRequestSetHTTPHeader(MCStringRef p_key, MCStringRef p_value, void *p_con
 }
 
 @class MCSystemUrlTimer;
-@interface MCSystemUrlDelegate : NSObject
+@interface com_runrev_livecode_MCSystemUrlDelegate : NSObject
 {
 	MCSystemUrlCallback m_callback;
 	void *m_context;
@@ -124,7 +124,7 @@ bool UrlRequestSetHTTPHeader(MCStringRef p_key, MCStringRef p_value, void *p_con
 
 @end
 
-@implementation MCSystemUrlDelegate
+@implementation com_runrev_livecode_MCSystemUrlDelegate
 
 - initWithCallback:(MCSystemUrlCallback)callback context: (void*)context
 {
@@ -309,11 +309,11 @@ static void do_system_load_url(void *p_ctxt)
 			t_success = MCHTTPParseHeaders(MChttpheaders, UrlRequestSetHTTPHeader, t_request);
 	}
 	
-	MCSystemUrlDelegate *t_delegate;
+	com_runrev_livecode_MCSystemUrlDelegate *t_delegate;
 	t_delegate = nil;
 	if (t_success)
 	{
-		t_delegate = [[MCSystemUrlDelegate alloc] initWithCallback: ctxt -> callback context: ctxt -> context];
+		t_delegate = [[com_runrev_livecode_MCSystemUrlDelegate alloc] initWithCallback: ctxt -> callback context: ctxt -> context];
 		if (t_delegate == nil)
 			t_success = false;
 	}
@@ -350,16 +350,16 @@ bool MCSystemLoadUrl(MCStringRef p_url, MCSystemUrlCallback p_callback, void *p_
 	return ctxt . success;
 }
 
-@interface PostUrlTimeoutMonitor : NSObject
+@interface com_runrev_livecode_MCPostUrlTimeoutMonitor : NSObject
 {
 	NSURLConnection *m_connection;
 	NSTimer *m_timer;
-	MCSystemUrlDelegate *m_delegate;
+	com_runrev_livecode_MCSystemUrlDelegate *m_delegate;
 }
 @end
 
-@implementation PostUrlTimeoutMonitor
-- (PostUrlTimeoutMonitor*) initWithTimeInterval:(NSTimeInterval)interval withConnection:(NSURLConnection*)connection withDelegate:(MCSystemUrlDelegate*)delegate
+@implementation com_runrev_livecode_MCPostUrlTimeoutMonitor
+- (com_runrev_livecode_MCPostUrlTimeoutMonitor*) initWithTimeInterval:(NSTimeInterval)interval withConnection:(NSURLConnection*)connection withDelegate:(com_runrev_livecode_MCSystemUrlDelegate*)delegate
 {
 	self = [super init];
 	if (self)
@@ -409,8 +409,8 @@ static void do_post_url(void *p_ctxt)
 	NSMutableURLRequest *t_request = nil;
 	NSURLConnection *t_connection = nil;
 	NSData *t_data = nil;
-	MCSystemUrlDelegate *t_delegate = nil;
-	PostUrlTimeoutMonitor *t_timeout_monitor = nil;
+	com_runrev_livecode_MCSystemUrlDelegate *t_delegate = nil;
+	com_runrev_livecode_MCPostUrlTimeoutMonitor *t_timeout_monitor = nil;
 	
 	if (t_success)
 	{
@@ -436,7 +436,7 @@ static void do_post_url(void *p_ctxt)
 	
 	if (t_success)
 	{
-		t_delegate = [[MCSystemUrlDelegate alloc] initWithCallback: ctxt -> callback context: ctxt -> context];
+		t_delegate = [[com_runrev_livecode_MCSystemUrlDelegate alloc] initWithCallback: ctxt -> callback context: ctxt -> context];
 		t_success = (t_delegate != nil);
 	}
 	
@@ -448,7 +448,7 @@ static void do_post_url(void *p_ctxt)
 	
 	if (t_success)
 	{
-		t_timeout_monitor = [[PostUrlTimeoutMonitor alloc] initWithTimeInterval: MCsockettimeout withConnection:t_connection
+		t_timeout_monitor = [[com_runrev_livecode_MCPostUrlTimeoutMonitor alloc] initWithTimeInterval: MCsockettimeout withConnection:t_connection
 																   withDelegate: t_delegate];
 		t_success = t_timeout_monitor != nil;
 	}
@@ -610,7 +610,7 @@ void PutFTPUrlClientCallback(CFWriteStreamRef p_stream, CFStreamEventType p_even
 	}
 }
 
-@interface PutFTPUrlTimeoutMonitor : NSObject
+@interface com_runrev_livecode_MCPutFTPUrlTimeoutMonitor : NSObject
 {
 	CFWriteStreamRef m_stream;
 	NSTimer *m_timer;
@@ -618,8 +618,8 @@ void PutFTPUrlClientCallback(CFWriteStreamRef p_stream, CFStreamEventType p_even
 }
 @end
 
-@implementation PutFTPUrlTimeoutMonitor
-- (PutFTPUrlTimeoutMonitor*) initWithTimeInterval:(NSTimeInterval)interval withStream:(CFWriteStreamRef)stream withContext:(FTPClientCallbackData*)context;
+@implementation com_runrev_livecode_MCPutFTPUrlTimeoutMonitor
+- (com_runrev_livecode_MCPutFTPUrlTimeoutMonitor*) initWithTimeInterval:(NSTimeInterval)interval withStream:(CFWriteStreamRef)stream withContext:(FTPClientCallbackData*)context;
 {
 	self = [super init];
 	if (self)
@@ -649,7 +649,7 @@ bool MCSystemPutFTPUrl(NSURL *p_url, const void *p_data, uint32_t p_length, MCSy
 	
 	CFWriteStreamRef t_ftp_stream = nil;
 	FTPClientCallbackData *t_context = nil;
-	PutFTPUrlTimeoutMonitor *t_monitor = nil;
+	com_runrev_livecode_MCPutFTPUrlTimeoutMonitor *t_monitor = nil;
 	
 	if (t_success)
 	{
@@ -667,7 +667,7 @@ bool MCSystemPutFTPUrl(NSURL *p_url, const void *p_data, uint32_t p_length, MCSy
 		t_context->callback = p_callback;
 		t_context->context = p_context;
 		
-		t_success = nil != (t_monitor = [[PutFTPUrlTimeoutMonitor alloc] initWithTimeInterval:MCsockettimeout withStream:t_ftp_stream withContext:t_context]);
+		t_success = nil != (t_monitor = [[com_runrev_livecode_MCPutFTPUrlTimeoutMonitor alloc] initWithTimeInterval:MCsockettimeout withStream:t_ftp_stream withContext:t_context]);
 	}
 	if (t_success)
 	{

--- a/engine/src/mbliphonevideo.mm
+++ b/engine/src/mbliphonevideo.mm
@@ -58,7 +58,7 @@ static NSObject *s_movie_player_delegate = nil;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface FullscreenMovieDelegate : NSObject
+@interface com_runrev_livecode_MCFullscreenMovieDelegate : NSObject
 {
 	bool m_running;
 	UIControl *m_overlay;
@@ -78,7 +78,7 @@ static NSObject *s_movie_player_delegate = nil;
 
 @end
 
-@implementation FullscreenMovieDelegate
+@implementation com_runrev_livecode_MCFullscreenMovieDelegate
 
 // AL-2014-09-09: [[ Bug 13354 ]] Replace deprecated MPMoviePlayerContentPreloadDidFinishNotification
 - (id)initWithPlayer: (MPMoviePlayerController *)p_player
@@ -196,7 +196,7 @@ struct play_fullscreen_t
 	bool looping;
 	bool with_controller;
 	MPMoviePlayerController *movie_player;
-	FullscreenMovieDelegate *delegate;
+	com_runrev_livecode_MCFullscreenMovieDelegate *delegate;
 };
 
 static void play_fullscreen_movie_prewait(void *p_context)
@@ -242,7 +242,7 @@ static void play_fullscreen_movie_prewait(void *p_context)
 	
 	configure_playback_range(ctxt -> movie_player);
 	
-	ctxt -> delegate = [[FullscreenMovieDelegate alloc] initWithPlayer:ctxt -> movie_player];
+	ctxt -> delegate = [[com_runrev_livecode_MCFullscreenMovieDelegate alloc] initWithPlayer:ctxt -> movie_player];
 	
 	// Present the view controller and get the delegate to setup its overlay
 	// if needed.

--- a/libbrowser/src/libbrowser_uiwebview.h
+++ b/libbrowser/src/libbrowser_uiwebview.h
@@ -19,7 +19,7 @@
 
 #include "libbrowser_internal.h"
 
-@class MCUIWebViewBrowserDelegate;
+@class com_runrev_livecode_MCUIWebViewBrowserDelegate;
 
 class MCUIWebViewBrowser : public MCBrowserBase
 {
@@ -73,7 +73,7 @@ private:
 	bool SyncJavaScriptHandlers(NSArray *p_handlers);
 	
 	UIWebView *m_view;
-	MCUIWebViewBrowserDelegate *m_delegate;
+	com_runrev_livecode_MCUIWebViewBrowserDelegate *m_delegate;
 	
 	char *m_js_handlers;
 	NSArray *m_js_handler_list;

--- a/libbrowser/src/libbrowser_uiwebview.mm
+++ b/libbrowser/src/libbrowser_uiwebview.mm
@@ -176,7 +176,7 @@ bool MCNSArrayToBrowserValue(NSArray *p_array, MCBrowserValue &r_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@interface MCUIWebViewBrowserDelegate : NSObject <UIWebViewDelegate>
+@interface com_runrev_livecode_MCUIWebViewBrowserDelegate : NSObject <UIWebViewDelegate>
 {
 	MCUIWebViewBrowser *m_instance;
 	bool m_pending_request;
@@ -757,7 +757,7 @@ bool MCUIWebViewBrowser::Init(void)
 		{
 			[t_view setHidden: YES];
 			
-			m_delegate = [[MCUIWebViewBrowserDelegate alloc] initWithInstance: this];
+			m_delegate = [[com_runrev_livecode_MCUIWebViewBrowserDelegate alloc] initWithInstance: this];
 			t_success = m_delegate != nil;
 		}
 		
@@ -775,7 +775,7 @@ bool MCUIWebViewBrowser::Init(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@implementation MCUIWebViewBrowserDelegate
+@implementation com_runrev_livecode_MCUIWebViewBrowserDelegate
 
 - (id)initWithInstance:(MCUIWebViewBrowser*)instance
 {


### PR DESCRIPTION
This patch makes sure all Objective-C classes defined by the engine
have prefix com_runrev_livecode_MC*.
