### PR TITLE
[[ Foundation ]] Correct index operator of MCAutoValueRefArrayBase.

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -331,7 +331,7 @@ public:
 		return m_values;
 	}
     
-    T& operator [] (const int p_index)
+    T& operator [] (const uindex_t p_index)
     {
         MCAssert(m_values != nil);
         return m_values[p_index];


### PR DESCRIPTION
The Count() member returns a uindex_t, so the [] operator should
take one.
