### PR TITLE
[[ iOS ]] Add MCRunBlockOnScriptFiber API.

### DIFF
--- a/engine/src/mbliphoneapp.h
+++ b/engine/src/mbliphoneapp.h
@@ -407,6 +407,7 @@ void MCIPhoneCallSelectorOnMainFiber(id object, SEL selector);
 void MCIPhoneCallSelectorOnMainFiberWithObject(id object, SEL selector, id arg);
 void MCIPhoneRunOnScriptFiber(void (*)(void *), void *);
 void MCIPhoneRunOnMainFiber(void (*)(void *), void *);
+void MCIPhoneRunBlockOnScriptFiber(void (^)(void));
 void MCIPhoneRunBlockOnMainFiber(void (^)(void));
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -1199,6 +1199,11 @@ void MCIPhoneRunBlockOnMainFiber(void (^block)(void))
 	MCFiberCall(s_main_fiber, invoke_block, block);
 }
 
+void MCIPhoneRunBlockOnScriptFiber(void (^block)(void))
+{
+	MCFiberCall(s_script_fiber, invoke_block, block);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // MW-2012-08-06: [[ Fibers ]] Updated entry point for didBecomeActive.


### PR DESCRIPTION
This patch adds an API which runs a block on the script fiber,
the inverse of the existing MCRunBlockOnMainFiber API.
