### PR TITLE
[[ iOS ]] Refactor iOS specific files to support embedding.

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -449,8 +449,6 @@
 			'src/mbliphone.mm',
 			'src/mbliphonead.mm',
 			'src/mbliphoneactivityindicator.mm',
-			'src/mbliphoneapp.mm',
-			'src/mbliphoneappview.mm',
 			'src/mbliphonebrowser.mm',
 			'src/mbliphonebusyindicator.mm',
 			'src/mbliphonecalendar.mm',
@@ -463,7 +461,6 @@
 			#'src/mbliphoneembeddedtest.mm',
 			'src/mbliphoneextra.mm',
 			'src/mbliphonefs.mm',
-			'src/mbliphonegfx.mm',
 			'src/mbliphonehooks.cpp',
 			'src/mbliphoneidletimer.mm',
 			'src/mbliphoneinput.mm',
@@ -766,6 +763,15 @@
 			'src/em-view.cpp',
 		],
 		
+        # Sources which are for normal mobile standalones
+        'engine_mobile_standalone_source_files':
+        [
+            # Group "Mobile - iOS"
+            'src/mbliphoneapp.mm',
+            'src/mbliphoneappview.mm',
+			'src/mbliphonegfx.mm',
+        ],
+        
 		# Sources that need to be compiled separately for each mode
 		'engine_mode_dependent_files':
 		[

--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -126,6 +126,7 @@
 			
 			'sources':
 			[
+                '<@(engine_mobile_standalone_source_files)',
 				'src/dummy.cpp',
 				'rsrc/standalone.rc',
 			],
@@ -778,6 +779,7 @@
 			
 						'sources':
 						[
+                            '<@(engine_mobile_standalone_source_files)',
 							'src/dummy.cpp',
 							'src/main.cpp',
 						],

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -1262,27 +1262,30 @@ static void MCIPhoneDoDidBecomeActive(void *)
         // Ensure t_envp array is NULL-terminated
         t_envp[envc] = NULL;
     }
-	
+    
 	// Initialize the engine.
 	Bool t_init_success;
     t_init_success = X_init(1, args, envc, *t_envp);
 	
     [t_pool release];
 	
-	if (!t_init_success)
-	{
-		
-		if (MCValueGetTypeCode(MCresult -> getvalueref()) == kMCValueTypeCodeString)
-		{
-			NSLog(@"Startup error: %s\n", MCStringGetCString((MCStringRef)MCresult -> getvalueref()));
-			abort();
-			return;
-		}
-	}
+    if (!MCIPhoneIsEmbedded())
+    {
+        if (!t_init_success)
+        {
+            
+            if (MCValueGetTypeCode(MCresult -> getvalueref()) == kMCValueTypeCodeString)
+            {
+                NSLog(@"Startup error: %s\n", MCStringGetCString((MCStringRef)MCresult -> getvalueref()));
+                abort();
+                return;
+            }
+        }
 
-	// MW-2012-08-31: [[ Bug 10340 ]] Now we've finished initializing, get the app to
-	//   start preparing.
-	[MCIPhoneGetApplication() performSelectorOnMainThread:@selector(startPreparing) withObject:nil waitUntilDone:NO];
+        // MW-2012-08-31: [[ Bug 10340 ]] Now we've finished initializing, get the app to
+        //   start preparing.
+        [MCIPhoneGetApplication() performSelectorOnMainThread:@selector(startPreparing) withObject:nil waitUntilDone:NO];
+    }
 }
 
 // MW-2012-08-06: [[ Fibers ]] Updated entry point that triggers before the main
@@ -1298,7 +1301,8 @@ static void MCIPhoneDoDidStartPreparing(void *)
 	
 	// MW-2012-08-31: [[ Bug 10340 ]] Now we've finished preparing, get the app to
 	//   start executing.
-	[MCIPhoneGetApplication() performSelectorOnMainThread:@selector(startExecuting) withObject:nil waitUntilDone:NO];
+    if (!MCIPhoneIsEmbedded())
+        [MCIPhoneGetApplication() performSelectorOnMainThread:@selector(startExecuting) withObject:nil waitUntilDone:NO];
 }
 
 // MW-2012-08-06: [[ Fibers ]] Updated entry point for execution of the main

--- a/tools/build-extension-ios.sh
+++ b/tools/build-extension-ios.sh
@@ -39,17 +39,29 @@ fi
 # SN-2015-02019: [[ Bug 14625 ]] We build and link each arch separately, and lipo them
 #  togother once it's done.
 
-# We still want to produce dylibs for the simulator
 if [ "$EFFECTIVE_PLATFORM_NAME" = "-iphonesimulator" ]; then
-	BUILD_DYLIB=1
+	BUILD_SIMULATOR=1
 else
+	BUILD_SIMULATOR =0
+fi
+
+# We still want to produce dylibs for the simulator
+if [ "$BUILD_EMBEDDED" != "1" ]; then
+	if [ "$EFFECTIVE_PLATFORM_NAME" = "-iphonesimulator" ]; then
+		BUILD_DYLIB=1
+	else
+		BUILD_DYLIB=0
+		EXPORT_SYMBOL_OPTION=-Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME
+	fi
+else
+	EXPORT_SYMBOL_OPTION=$SYMBOLS
 	BUILD_DYLIB=0
 fi
 
 # SN-2015-02-19: [[ Bug 14625 ]] Xcode only create FAT headers from iOS SDK 7.0
 FAT_INFO=$(otool -fv "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" | grep "Fat headers" || true)
 
-if [ -z "$FAT_INFO" -o $BUILD_DYLIB -eq 1 ]; then
+if [ -z "$FAT_INFO" -o $BUILD_SIMULATOR -eq 1 ]; then
 	# We set the minimum iOS or simulator version
     if [ $BUILD_DYLIB -eq 1 ]; then
         MIN_OS_VERSION="-mios-simulator-version-min=5.1.1"
@@ -67,7 +79,7 @@ if [ -z "$FAT_INFO" -o $BUILD_DYLIB -eq 1 ]; then
 		exit $?
 	fi
 
-	$BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS ${ARCHS} $MIN_OS_VERSION -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME $STATIC_DEPS
+	$BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS ${ARCHS} $MIN_OS_VERSION -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" $EXPORT_SYMBOL_OPTION $STATIC_DEPS
 
 	if [ $? -ne 0 ]; then
 		exit $?
@@ -101,7 +113,7 @@ else
 			fi
 		fi
 
-	    OUTPUT=$($BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${LCEXT_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME $STATIC_DEPS)
+	    OUTPUT=$($BIN_DIR/g++ -stdlib=libc++ -nodefaultlibs $STRIP_OPTIONS -arch ${ARCH} -miphoneos-version-min=${MIN_VERSION} -isysroot $SDKROOT -L"$SOLUTION_DIR/prebuilt/lib/ios/$SDK_NAME" -o "${LCEXT_FILE}" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" -Wl,-sectcreate -Wl,__MISC -Wl,__deps -Wl,"$SRCROOT/$PRODUCT_NAME.ios" $EXPORT_SYMBOL_OPTION $STATIC_DEPS)
 
 		if [ $? -ne 0 ]; then
 			echo "Linking ""${LCEXT_FILE}""failed:"


### PR DESCRIPTION
This patch splits up the iOS source files so that those not required
in an embedded context are not included in the main kernel target.

The build-extension-ios.sh tool now decides how to build the simulator
target (whether as a partially linked object, or as a dylib) depending
on the BUILD_EMBEDDED environment variable.

Additionally, it adds an MCIPhoneEmbedded() predicate which returns
true or false depending on the context of operation - this is used
to customize certain iOS startup methods in the embedded context.
