### PR TITLE
[Bug 16795][emscripten] Correctly get drawing canvas from DOM element

### DIFF
--- a/docs/notes/bugfix-16795.md
+++ b/docs/notes/bugfix-16795.md
@@ -1,0 +1,1 @@
+# Use HTML5 Canvas API in standards-compliant way

--- a/engine/src/em-surface.js
+++ b/engine/src/em-surface.js
@@ -26,7 +26,7 @@ mergeInto(LibraryManager.library, {
         var canvas = Module['canvas'];
 
         // Create and get a 2D rendering context for the canvas
-        var context = canvas.getContext('2d', false);
+        var context = canvas.getContext('2d');
         if (!context) {
             context = Browser.createContext(canvas, false, true);
         }


### PR DESCRIPTION
We were using the HTML Canvas API incorrectly, which was causing
exceptions to be thrown by browsers with conformant implementations.

See:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1244480
- https://github.com/whatwg/html/issues/595
