### PR TITLE
[[ Selection Handles ]] Allow selected object resize on top layer

### DIFF
--- a/docs/notes/feature-selection_top_layer.md
+++ b/docs/notes/feature-selection_top_layer.md
@@ -1,0 +1,5 @@
+# Selected objects act as though they are on the top layer
+
+The selection handles are now drawn over the top layer, and the selected
+objects are checked first for mouse focus to enable resizing and moving
+of selected objects that are underneath others.

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -644,12 +644,9 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 	}
 
 	if (!p_isolated)
-	{
+    {
 		dc -> end();
-
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
-	}
+    }
 }
 
 void MCButton::drawlabel(MCDC *dc, int2 sx, int sy, uint2 twidth, const MCRectangle &srect, MCStringRef p_label, uint2 fstyle, uindex_t p_mnemonic)

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -3318,6 +3318,24 @@ void MCCard::drawselectionrect(MCContext *p_context)
     drawmarquee(p_context, selrect);
 }
 
+void MCCard::drawselectedchildren(MCDC *dc)
+{
+    MCObjptr *tptr = objptrs;
+    if (tptr == nil)
+        return;
+    do
+    {
+        if (tptr -> getref() -> getstate(CS_SELECTED))
+            tptr->getref()->drawselected(dc);
+        
+        if (tptr -> getrefasgroup() != nil)
+            tptr -> getrefasgroup() -> drawselectedchildren(dc);
+            
+        tptr = tptr->next();
+    }
+    while (tptr != objptrs);
+}
+
 void MCCard::draw(MCDC *dc, const MCRectangle& dirty, bool p_isolated)
 {
 	bool t_draw_cardborder;
@@ -3341,7 +3359,10 @@ void MCCard::draw(MCDC *dc, const MCRectangle& dirty, bool p_isolated)
 		}
 		while (tptr != objptrs);
 	}
-
+    
+    // Draw the selection outline and handles on top of everything
+    drawselectedchildren(dc);
+    
 	dc -> setopacity(255);
 	dc -> setfunction(GXcopy);
 

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -504,6 +504,106 @@ void MCCard::mdrag(void)
 	}
 }
 
+bool MCCard::mfocus_control(int2 x, int2 y, bool p_check_selected)
+{
+    MCObjptr *tptr = objptrs->prev();
+    
+    bool t_freed;
+    do
+    {
+        MCObject *t_tptr_object;
+        t_tptr_object = tptr -> getref();
+        
+        t_freed = false;
+        
+        // Check if any group's child is selected and focused
+        if (p_check_selected && tptr -> getrefasgroup() != nil)
+        {
+            if (tptr -> getrefasgroup() -> mfocus_control(x, y, true))
+            {
+                mfocused = tptr;
+                return true;
+            }
+        }
+        
+        // Only check mfocus for objects with the appropriate selection state
+        if ((p_check_selected == tptr -> getref() -> getstate(CS_SELECTED))
+            && t_tptr_object->mfocus(x, y))
+        {
+            // MW-2010-10-28: If mfocus calls relayer, then the objptrs can get changed.
+            //   Reloop to find the correct one.
+            tptr = objptrs -> prev();
+            while(tptr -> getref() != t_tptr_object)
+                tptr = tptr -> prev();
+            
+            Boolean newfocused = tptr != mfocused;
+            if (newfocused && mfocused != NULL)
+            {
+                MCControl *oldfocused = mfocused->getref();
+                mfocused = tptr;
+                oldfocused->munfocus();
+            }
+            else
+                mfocused = tptr;
+            
+            // The widget event manager handles enter/leave itself
+            if (newfocused && mfocused != NULL &&
+                mfocused -> getref() -> gettype() != CT_GROUP &&
+#ifdef WIDGETS_HANDLE_DND
+                mfocused -> getref() -> gettype() != CT_WIDGET)
+#else
+                (MCdispatcher -> isdragtarget() ||
+                 mfocused -> getref() -> gettype() != CT_WIDGET))
+#endif
+            {
+                mfocused->getref()->enter();
+                
+                // MW-2007-10-31: mouseMove sent before mouseEnter - make sure we send an mouseMove
+                //   It is possible for mfocused to become NULL if its deleted in mouseEnter so
+                //   we check first.
+                if (mfocused != NULL)
+                    mfocused->getref()->mfocus(x, y);
+            }
+            
+            return true;
+        }
+        
+        // Unset previously focused object
+        if (!p_check_selected && tptr == mfocused)
+        {
+            // MW-2012-02-22: [[ Bug 10018 ]] Previously, if a group was hidden and it had
+            //   mouse focus, then it wouldn't unmfocus as there was an explicit check to
+            //   stop this (for groups) here.
+            // MW-2012-03-13: [[ Bug 10074 ]] Invoke the control's munfocus() method for groups
+            //   if the group has an mfocused control.
+            if (mfocused -> getref() -> gettype() != CT_GROUP
+                || mfocused -> getrefasgroup() -> getmfocused() != nil)
+            {
+                MCControl *oldfocused = mfocused->getref();
+                mfocused = NULL;
+                oldfocused->munfocus();
+            }
+            else
+            {
+                mfocused -> getrefasgroup() -> clearmfocus();
+                mfocused = nil;
+            }
+            
+            // If munfocus calls relayer, then the objptrs can get changed
+            // so we need to loop back to the start of the objptrs again
+            t_freed = true;
+            tptr = objptrs->prev();
+        }
+        else
+        {
+            tptr = tptr->prev();
+        }
+    }
+    while (t_freed || tptr != objptrs->prev());
+    
+    return false;
+}
+
 Boolean MCCard::mfocus(int2 x, int2 y)
 {
 	if (state & CS_MENU_ATTACHED)
@@ -556,84 +656,18 @@ Boolean MCCard::mfocus(int2 x, int2 y)
 				layer_selectedrectchanged(oldrect, selrect);
 			}
 			message_with_args(MCM_mouse_move, x, y);
-			return True;
+			return true;
 		}
 		if (mgrabbed)
 			mfocused->getref()->mfocus(x, y);
 		mgrabbed = False;
-		MCObjptr *tptr = objptrs->prev();
-		Boolean freed;
-		do
-		{
-			MCObject *t_tptr_object;
-			t_tptr_object = tptr -> getref();
-			
-			freed = False;
-			
-			if (t_tptr_object->mfocus(x, y))
-			{
-				// MW-2010-10-28: If mfocus calls relayer, then the objptrs can get changed.
-				//   Reloop to find the correct one.
-				MCObjptr *tptr = objptrs -> prev();
-				while(tptr -> getref() != t_tptr_object)
-					tptr = tptr -> prev();
-				
-				Boolean newfocused = tptr != mfocused;
-				if (newfocused && mfocused != NULL)
-				{
-					MCControl *oldfocused = mfocused->getref();
-					mfocused = tptr;
-					oldfocused->munfocus();
-				}
-				else
-					mfocused = tptr;
-
-                // The widget event manager handles enter/leave itself
-				if (newfocused && mfocused != NULL &&
-                    mfocused -> getref() -> gettype() != CT_GROUP &&
-#ifdef WIDGETS_HANDLE_DND
-                    mfocused -> getref() -> gettype() != CT_WIDGET)
-#else
-                    (MCdispatcher -> isdragtarget() ||
-                    mfocused -> getref() -> gettype() != CT_WIDGET))
-#endif
-				{
-					mfocused->getref()->enter();
-					
-					// MW-2007-10-31: mouseMove sent before mouseEnter - make sure we send an mouseMove
-					//   It is possible for mfocused to become NULL if its deleted in mouseEnter so
-					//   we check first.
-					if (mfocused != NULL)
-						mfocused->getref()->mfocus(x, y);
-				}
-
-				return True;
-			}
-			if (tptr == mfocused)
-			{
-				// MW-2012-02-22: [[ Bug 10018 ]] Previously, if a group was hidden and it had
-				//   mouse focus, then it wouldn't unmfocus as there was an explicit check to
-				//   stop this (for groups) here.
-				// MW-2012-03-13: [[ Bug 10074 ]] Invoke the control's munfocus() method for groups
-				//   if the group has an mfocused control.
-				if (mfocused -> getref() -> gettype() != CT_GROUP || static_cast<MCGroup *>(mfocused -> getref()) -> getmfocused() != nil)
-				{
-					MCControl *oldfocused = mfocused->getref();
-					mfocused = NULL;
-					oldfocused->munfocus();
-				}
-				else
-				{
-					static_cast<MCGroup *>(mfocused -> getref()) -> clearmfocus();
-					mfocused = nil;
-				}
-				freed = True;
-				tptr = objptrs->prev();
-			}
-			else
-				tptr = tptr->prev();
-		}
-		while (freed || tptr != objptrs->prev());
+        
+        if (mfocus_control(x, y, true))
+            return true;
+        
+        if (mfocus_control(x, y, false))
+            return true;
+        
 		MCtooltip->cleartip();
 		// MW-2007-07-09: [[ Bug 3726 ]] dragMove is not sent to a card during
 		//   a drag-drop operation.

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -241,6 +241,8 @@ public:
 	//   the given layer. If nil is returned the control doesn't exist.
 	MCObject *getobjbylayer(uint32_t layer);
 
+    bool mfocus_control(int2 x, int2 y, bool p_check_selected);
+    
 	MCCard *next()
 	{
 		return (MCCard *)MCDLlist::next();

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -209,7 +209,8 @@ public:
 	void drawbackground(MCContext *p_context, const MCRectangle &p_dirty);
 	// IM-2013-09-13: [[ RefactorGraphics ]] render the card selection rect
 	void drawselectionrect(MCContext *);
-	
+    void drawselectedchildren(MCDC *dc);
+    
 	Exec_stat openbackgrounds(bool p_is_preopen, MCCard *p_other);
 	Exec_stat closebackgrounds(MCCard *p_other);
 	

--- a/engine/src/eps.cpp
+++ b/engine/src/eps.cpp
@@ -565,8 +565,6 @@ void MCEPS::draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_spr
 			drawborder(dc, trect, borderwidth);
 	if (getstate(CS_KFOCUSED))
 		drawfocus(dc, dirty);
-	if (state & CS_SELECTED)
-		drawselected(dc);
 }
 
 IO_stat MCEPS::load(IO_handle stream, uint32_t version)

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -3211,9 +3211,6 @@ void MCField::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 	if (!p_isolated)
 	{
 		dc -> end();
-
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
 	}
 }
 

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -2314,11 +2314,9 @@ void MCGraphic::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool
 	if (!p_isolated)
 	{
 		dc -> end();
-
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
-		if (m_edit_tool != NULL)
-			m_edit_tool->drawhandles(dc);
+        
+        if (m_edit_tool != NULL)
+            m_edit_tool->drawhandles(dc);
 	}
 
 	dc -> setquality(QUALITY_DEFAULT);

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2790,6 +2790,23 @@ void MCGroup::boundcontrols()
 	}
 }
 
+void MCGroup::drawselectedchildren(MCDC *dc)
+{
+    MCControl *t_control = controls;
+    if (t_control == nil)
+        return;
+    do
+    {
+        if (t_control -> getstate(CS_SELECTED))
+            t_control -> drawselected(dc);
+        
+        if (t_control -> gettype() == CT_GROUP)
+            static_cast<MCGroup *>(t_control) -> drawselectedchildren(dc);
+        
+        t_control = t_control -> next();
+    }
+    while (t_control != controls);
+}
 
 //-----------------------------------------------------------------------------
 //  Redraw Management
@@ -2927,9 +2944,6 @@ void MCGroup::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 	if (!p_isolated)
 	{
 		dc -> end();
-
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
 	}
 }
 

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -131,6 +131,8 @@ public:
 
     virtual void scheduledelete(bool p_is_child);
     
+    void drawselectedchildren(MCDC *dc);
+    
 	MCControl *findchildwithid(Chunk_term type, uint4 p_id);
 
 	// MCGroup functions

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -198,6 +198,8 @@ public:
 	//   group.
     bool islocked(void) { return m_updates_locked; }
 
+    bool mfocus_control(int2 x, int2 y, bool p_check_selected);
+    
 	MCGroup *next()
 	{
 		return (MCGroup *)MCDLlist::next();

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -1642,9 +1642,6 @@ void MCImage::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 
 		if (getstate(CS_MAGNIFY))
 			drawmagrect(dc);
-
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
 	}
 }
 

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -3087,13 +3087,9 @@ void MCPlayer::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 			drawborder(dc, rect, borderwidth);
 	
 	if (!p_isolated)
-	{
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
-	}
-    
-	if (!p_isolated)
+    {
 		dc -> end();
+    }
 }
 
 

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -1028,6 +1028,7 @@ bool MCCard::tilecache_render_foreground(void *p_context, MCContext *p_target, c
 	// IM-2013-09-13: [[ RefactorGraphics ]] Use shared code to render card foreground
 	t_card -> drawselectionrect(p_target);
 
+    t_card -> drawselectedchildren(p_target);
 	return true;
 }
 

--- a/engine/src/scrollbardraw.cpp
+++ b/engine/src/scrollbardraw.cpp
@@ -375,9 +375,6 @@ void MCScrollbar::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bo
 	if (!p_isolated)
 	{
 		dc -> end();
-
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
 	}
 }
 

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -877,9 +877,6 @@ void MCWidget::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 	if (!p_isolated)
 	{
 		dc -> end();
-
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
 	}
 }
 


### PR DESCRIPTION
The selection handles are now drawn over the top layer, and the selected
objects are checked first for mouse focus to enable resizing and moving
of selected objects that are underneath others.
