### PR TITLE
[Bug 16853] Prevent crash when <img> tag is used in htmlText and there is a space between "src" attribute and "=" sign

### DIFF
--- a/docs/notes/bugfix-16853.md
+++ b/docs/notes/bugfix-16853.md
@@ -1,0 +1,1 @@
+#   set htlmtext crash if there are spaces between <attribute_name> and "=" sign

--- a/engine/src/fieldhtml.cpp
+++ b/engine/src/fieldhtml.cpp
@@ -1643,8 +1643,13 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 			for(uint32_t i = 0; i < p_tag . attr_count; i++)
 				if (p_tag . attrs[i] . type == kImportHtmlAttrSrc)
 				{
-					MCValueRelease(t_src);
-					/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)p_tag . attrs[i] . value, strlen(p_tag . attrs[i] . value), t_src);
+					// PM-2015-02-05: [[ Bug 16853 ]] Allow spaces between <atribute_name> and "=" sign
+					// Nil-check before passing it to strlen
+					if (p_tag . attrs[i] . value != nil)
+					{
+						MCValueRelease(t_src);
+						/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)p_tag . attrs[i] . value, strlen(p_tag . attrs[i] . value), t_src);
+					}
 				}
 			
 			if (t_src != nil)


### PR DESCRIPTION
Note that I have submitted this PR against release-7.1.2 branch, although this is not a bug introduced in RC-1. I did this because this is an important but also simple fix (just a `NULL` check before using `strlen`) that is not likely to cause any further regression. If you feel this PR should be submitted against develop-7.0 please let me know.
