### PR TITLE
[Bug 16844] Fix Mac OS X crash due to missing legacy theme font

### DIFF
--- a/docs/notes/bugfix-16844.md
+++ b/docs/notes/bugfix-16844.md
@@ -1,0 +1,1 @@
+# Ensure legacy theme falls back to suitable system font on Mac OS X

--- a/engine/src/mac-theme.mm
+++ b/engine/src/mac-theme.mm
@@ -54,7 +54,14 @@ static NSFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlS
     // Always return the same font regardless of control type in legacy mode
     if (p_state & kMCPlatformControlStateCompatibility)
     {
-        static NSFont* s_legacy_font = [[NSFont fontWithName:get_legacy_font_name() size:11] retain];
+        static NSFont* s_legacy_font = nil;
+        if (nil == s_legacy_font)
+            s_legacy_font = [[NSFont fontWithName:get_legacy_font_name() size:11] retain];
+        if (nil == s_legacy_font)
+            s_legacy_font = [[NSFont systemFontOfSize:11] retain];
+
+        MCAssert(nil != s_legacy_font);
+
         if (r_name)
             *r_name = nil;
         return s_legacy_font;


### PR DESCRIPTION
In Mac OS X 10.11, the operating system uses the "San Francisco"
font its default UI theme.  However, this font is not licensed for
use in user documents -- only for use in user interface.
Requesting the font by name results in failure, and this failure
wasn't being detected, causing a null pointer deference when trying
to prepare fonts for the "legacy" theme.

This patch makes the legacy theme try to get a suitable font by
name first.  If that fails, it falls back to an 11pt system UI
font.
