### PR TITLE
[[ Bug 16756 ]] Make selection handle hit detection less strict

### DIFF
--- a/docs/notes/bugfix-16756.md
+++ b/docs/notes/bugfix-16756.md
@@ -1,0 +1,1 @@
+# Hit detection in new resize handles not quite right

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -253,11 +253,14 @@ Boolean MCControl::mfocus(int2 x, int2 y)
 	}
 	MCRectangle srect;
 	MCU_set_rect(srect, x, y, 1, 1);
+    
+    mx = x;
+    my = y;
+    
 	Boolean is = maskrect(srect) || (state & CS_SELECTED
 	                                 && MCU_point_in_rect(geteffectiverect(), x, y)
 	                                 && sizehandles() != 0);
-	mx = x;
-	my = y;
+    
 	if (is || state & CS_MFOCUSED)
 	{
 		if (focused == this || getstack() -> gettool(this) == T_POINTER)
@@ -1450,6 +1453,9 @@ uint2 MCControl::sizehandles()
 		sizerects(rects);
 		int2 i;
 		for (i = 7 ; i >= 0 ; i--)
+        {
+            // Be more forgiving about handle hit detection
+            MCU_reduce_rect(rects[i], -1);
 			if (MCU_point_in_rect(rects[i], mx, my))
 			{
 				if (i < 3)
@@ -1476,6 +1482,7 @@ uint2 MCControl::sizehandles()
 					}
 				break;
 			}
+        }
 	}
 	return newstate;
 }

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -1444,6 +1444,8 @@ void MCControl::continuesize(int2 x, int2 y)
 	resizeparent();
 }
 
+#define SIZE_HANDLE_HIT_TOLERANCE 1
+
 uint2 MCControl::sizehandles()
 {
 	uint2 newstate = 0;
@@ -1455,7 +1457,7 @@ uint2 MCControl::sizehandles()
 		for (i = 7 ; i >= 0 ; i--)
         {
             // Be more forgiving about handle hit detection
-            MCU_reduce_rect(rects[i], -1);
+            MCU_reduce_rect(rects[i], -SIZE_HANDLE_HIT_TOLERANCE);
 			if (MCU_point_in_rect(rects[i], mx, my))
 			{
 				if (i < 3)


### PR DESCRIPTION
This is more of a change proposal than a strict fix of a bug. I feel like an extra pixel of hit on the selection handles is better. 

I think the use of the previously set mouse loc member variables in sizehandles() is actually a bug - they should be updated before sizehandles() is called.
