### PR TITLE
[[ Bug 16200 ]] Fix hang caused by Obj-C exception from color dialog.

### DIFF
--- a/docs/notes/bugfix-16200.md
+++ b/docs/notes/bugfix-16200.md
@@ -1,0 +1,1 @@
+# Fix hang when using the color picker to choose a developer color.


### PR DESCRIPTION
The color dialog was attempting to fetch the RGB color value of
an NSColor of the NSNamedColorSpace model. This has been updated
to convert to NSCalibratedRGBColorSpace to ensure RGB values are
available.
