### PR TITLE
[[ Bug 16200 ]] Fix hang when choosing developer color 

### DIFF
--- a/docs/notes/bugfix-16200.md
+++ b/docs/notes/bugfix-16200.md
@@ -1,0 +1,1 @@
+# Fix hang when using the color picker to choose a developer color.


### PR DESCRIPTION
The NSColor objects returned by the color picker on Mac might not
have a valid colorspace (e.g. the ones from the developer tab).
This patch fixes this by wrapping the colorSpace property fetch
in an exception handling block. If the fetch fails, the color
is converted to the NSCalibratedRGBColorSpace.
