### PR TITLE
Set the LiveCode IDE to run in 32-bit mode by default

### DIFF
--- a/engine/rsrc/LiveCode-Info.plist
+++ b/engine/rsrc/LiveCode-Info.plist
@@ -53,6 +53,11 @@
 	<true/>
 	<key>LSGetAppDiedEvents</key>
 	<true/>
+	<key>LSArchitecturePriority</key>
+	<array>
+		<string>i386</string>
+		<string>x86_64</string>
+	</array>
 	<key>NSAppleScriptEnabled</key>
 	<string>YES</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
This can be changed by the end-user manually by toggling the
"Open in 32-bit Mode" option in the app bundle Info page. We still
need a way of re-launching the IDE in 32-bit or 64-bit mode though
as this is likely something that will need to change on a per-run
basis. (There are command-line utilities for running specific
architectures within app bundles).

Documentation for this feature will be required but would be best
placed in the PR including the "Re-launch in {32,64}-bit mode"
option.
