### PR TITLE
Fix formattedheight to return a realistic value

### DIFF
--- a/engine/src/exec-interface-field.cpp
+++ b/engine/src/exec-interface-field.cpp
@@ -751,8 +751,18 @@ void MCField::GetFormattedHeight(MCExecContext& ctxt, integer_t& r_height)
 {
 	if (opened)
 	{
-		r_height = textheight + rect.height - getfheight()
-		          + topmargin + bottommargin - TEXT_Y_OFFSET;
+        // It seems that in all other locations that use TEXT_Y_OFFSET when
+        // calculating field heights, it is used 2*, presumably because it is
+        // being applied to both the top and bottom margins.
+        //
+        // The meaning of topmargin and bottommargin aren't exactly clear for
+        // fields - testing suggests that bottommargin is ignored entirely
+        // except when calculating formatted heights and similar while topmargin
+        // is obeyed... except that text may protrude by up to TEXT_Y_OFFSET
+        // pixels into the margin.
+        //
+        r_height = textheight + rect.height - getfheight();
+		          + topmargin + bottommargin - 2*TEXT_Y_OFFSET;
 	}
 	else
 		r_height = 0;

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -3504,7 +3504,7 @@ MCRectangle MCParagraph::getsplitcursorrect(findex_t fi, uint2 fixedheight, bool
     
 	// MW-2012-01-08: [[ ParaStyles ]] Top of text starts after spacing above.
 	MCRectangle drect;
-	drect.y = 1 + t_space_above;
+	drect.y = t_space_above;
     
 	MCLine *lptr;
 	findex_t i, l;

--- a/engine/src/w32flst.cpp
+++ b/engine/src/w32flst.cpp
@@ -229,8 +229,11 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style, Boolean printe
 	font->size = size;
 	font->printer = printer;
     
-    font->m_ascent = tm.tmAscent;
-    font->m_descent = tm.tmDescent;
+    // We divide the internal leading evenly over ascent and descent. This is
+    // done because we need to account for it but the text layout code doesn't
+    // know about internal leading.
+    font->m_ascent = tm.tmAscent + (tm.tmInternalLeading+1)/2;
+    font->m_descent = tm.tmDescent + (tm.tmInternalLeading)/2;
     font->m_leading = tm.tmExternalLeading;
     font->m_xheight = tm.tmAveCharWidth;
 }


### PR DESCRIPTION
Contains 3 fixes that allows https://github.com/livecode/livecode-ide/pull/851 to work properly:
1. Don't draw carets so low they descend outside the formattedheight
2. Correct the metrics used for Windows fonts
3. Fix the "magic" factor used when calculating formattedHeight for fields
