### PR TITLE
[[ LicenseCheck ]] Add a simple license check API to externals V1 API.

### DIFF
--- a/engine/src/capsule.h
+++ b/engine/src/capsule.h
@@ -101,6 +101,10 @@ enum MCCapsuleSectionType
     // AL-2015-02-10: [[ Standalone Inclusions ]] Library consists of the mappings from universal names
     //  of resources to their platform-specific paths relative to the executable.
     kMCCapsuleSectionTypeLibrary,
+    
+    // MW-2016-02-17: [[ LicenseChecks ]] License consists of the array-encoded
+    //   'revLicenseInfo' array in use at the point the standalone was built.
+    kMCCapsuleSectionTypeLicense,
 };
 
 // Each section begins with a header that defines its type and length. This is

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -365,6 +365,41 @@ static bool MCDeployWriteDefinePrologueSection(const MCDeployParameters& p_param
 	return MCDeployCapsuleDefine(p_capsule, kMCCapsuleSectionTypePrologue, &t_prologue, sizeof(t_prologue));
 }
 
+static bool MCDeployWriteDefineLicenseSection(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
+{
+    MCAutoArrayRef t_license;
+    if (!MCArrayCreateMutable(&t_license))
+        return false;
+
+    // The edition byte encoding is development/standalone engine pair
+    // specific.
+    unsigned char t_edition;
+    switch(MClicenseparameters . license_class)
+    {
+        case kMCLicenseClassNone:
+            t_edition = 0;
+            break;
+            
+        case kMCLicenseClassCommunity:
+            t_edition = 1;
+            break;
+            
+        case kMCLicenseClassCommercial:
+            t_edition = 2;
+            break;
+        
+        case kMCLicenseClassProfessional:
+            t_edition = 3;
+            break;
+    }
+    
+    
+    return MCDeployCapsuleDefine(p_capsule,
+                                 kMCCapsuleSectionTypeLicense,
+                                 &t_edition,
+                                 sizeof(t_edition));
+}
+
 // This method generates the standalone specific capsule elements. This is
 // just a Standalone Prologue section at the moment.
 static bool MCDeployWriteCapsuleDefineStandaloneSections(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
@@ -372,9 +407,14 @@ static bool MCDeployWriteCapsuleDefineStandaloneSections(const MCDeployParameter
 	bool t_success;
 	t_success = true;
 
+    // First emit the prologue.
 	if (t_success)
 		t_success = MCDeployWriteDefinePrologueSection(p_params, p_capsule);
 
+    // Next emit the license info.
+    if (t_success)
+        t_success = MCDeployWriteDefineLicenseSection(p_params, p_capsule);
+    
 	return t_success;
 }
 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2695,6 +2695,9 @@ enum Exec_errors
 
 	// {EE-0882} save: error in file format expression
 	EE_SAVE_BADNOFORMATEXP,
+    
+    // {EE-0883} external: unlicensed
+    EE_EXTERNAL_UNLICENSED,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -44,6 +44,13 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// This static variable is set to the currently executing external during
+// any calls to its exported functions (startup, shutdown etc.). It is used by
+// the license fail API to mark the external's was_licensed member as false.
+static MCExternalV1 *s_current_external = nil;
+
+////////////////////////////////////////////////////////////////////////////////
+
 static bool number_to_string(double p_number, MCExternalValueOptions p_options, MCStringRef &r_buffer)
 {
     bool t_success;
@@ -827,9 +834,16 @@ bool MCExternalV1::Prepare(void)
 	// external is only created if it does!
 	MCExternalDescribeProc t_describe;
 	t_describe = (MCExternalDescribeProc)MCS_resolvemodulesymbol(m_module, MCSTR("MCExternalDescribe"));
-	
+    
+    // Update the current external var.
+    s_current_external = this;
+    
 	// Query the info record - if this returns nil something odd is going on!
 	m_info = t_describe();
+    
+    // Unset the current external var.
+    s_current_external = nil;
+    
 	if (m_info == nil)
 		return false;
 
@@ -844,10 +858,27 @@ bool MCExternalV1::Initialize(void)
 	if (t_initialize == nil)
 		return true;
 
+    // Make sure the 'was_licensed' instance var is true. A call to LicenseFail
+    // during startup will set it to false.
+    m_was_licensed = true;
+    
+    // Update the current external var.
+    s_current_external = this;
+    
 	// See if initialization succeeds.
-	if (!t_initialize(&g_external_interface))
+    bool t_success;
+    t_success = t_initialize(&g_external_interface);
+    
+    // Unset the current external var.
+    s_current_external = nil;
+    
+    if (!t_success)
 		return false;
 
+    // If license fail was invoked during startup, we mark the whole external
+    // as unlicensed which means all calls to it will throw an error.
+    m_licensed = m_was_licensed;
+    
 	return true;
 }
 
@@ -858,8 +889,14 @@ void MCExternalV1::Finalize(void)
 	t_finalize = (MCExternalFinalizeProc)MCS_resolvemodulesymbol(m_module, MCSTR("MCExternalFinalize"));
 	if (t_finalize == nil)
 		return;
-
-	t_finalize();
+    
+    // Update the current external var.
+    s_current_external = this;
+    
+    t_finalize();
+    
+    // Unset the current external var.
+    s_current_external = nil;
 }
 
 const char *MCExternalV1::GetName(void) const
@@ -896,105 +933,140 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 	if (t_handler -> type != t_type)
 		return ES_NOT_HANDLED;
 
-		Exec_stat t_stat;
-		t_stat = ES_NORMAL;
+    // If the external is not licensed (as a whole) then we throw the unlicensed error.
+    if (!m_licensed)
+    {
+        MCAutoStringRef t_name;
+        if (!MCStringCreateWithCString(m_info -> name, &t_name))
+            return ES_ERROR;
+        MCeerror -> add(EE_EXTERNAL_UNLICENSED, 0, 0, *t_name);
+        return ES_ERROR;
+    }
+    
+    Exec_stat t_stat;
+    t_stat = ES_NORMAL;
 
-		// Count the number of parameters.
-		uint32_t t_parameter_count;
-		t_parameter_count = 0;
-		for(MCParameter *t_param = p_parameters; t_param != nil; t_param = t_param -> getnext())
-			t_parameter_count += 1;
-			
-		// Allocate an array of values.
-		MCExternalVariableRef *t_parameter_vars;
-		t_parameter_vars = NULL;
-		if (t_parameter_count != 0)
-		{
-			t_parameter_vars = new MCExternalVariableRef[t_parameter_count];
-			if (t_parameter_vars == nil)
-				return ES_ERROR;
-		}
-		
-		// Now iterate through the parameters, fetching the parameter values as we go.
-		for(uint32_t i = 0; p_parameters != nil && t_stat == ES_NORMAL; i++, p_parameters = p_parameters -> getnext())
-		{
-			MCVariable* t_var;
-			t_var = p_parameters -> eval_argument_var();
-			if (t_var != nil)
-			{
-				// We are a variable parameter so use the value directly (i.e. pass by
-				// reference).
-				
-				// MW-2014-01-22: [[ CompatV1 ]] Create a reference to the MCVariable.
-				t_parameter_vars[i] = new MCReferenceExternalVariable(t_var);
-			}
-			else
-			{
-                // AL-2014-08-28: [[ ArrayElementRefParams ]] Evaluate container if necessary
-                MCAutoValueRef t_value;
-                MCContainer *t_container;
-                t_container = p_parameters -> eval_argument_container();
+    // Count the number of parameters.
+    uint32_t t_parameter_count;
+    t_parameter_count = 0;
+    for(MCParameter *t_param = p_parameters; t_param != nil; t_param = t_param -> getnext())
+        t_parameter_count += 1;
+        
+    // Allocate an array of values.
+    MCExternalVariableRef *t_parameter_vars;
+    t_parameter_vars = NULL;
+    if (t_parameter_count != 0)
+    {
+        t_parameter_vars = new MCExternalVariableRef[t_parameter_count];
+        if (t_parameter_vars == nil)
+            return ES_ERROR;
+    }
+    
+    // Now iterate through the parameters, fetching the parameter values as we go.
+    for(uint32_t i = 0; p_parameters != nil && t_stat == ES_NORMAL; i++, p_parameters = p_parameters -> getnext())
+    {
+        MCVariable* t_var;
+        t_var = p_parameters -> eval_argument_var();
+        if (t_var != nil)
+        {
+            // We are a variable parameter so use the value directly (i.e. pass by
+            // reference).
+            
+            // MW-2014-01-22: [[ CompatV1 ]] Create a reference to the MCVariable.
+            t_parameter_vars[i] = new MCReferenceExternalVariable(t_var);
+        }
+        else
+        {
+            // AL-2014-08-28: [[ ArrayElementRefParams ]] Evaluate container if necessary
+            MCAutoValueRef t_value;
+            MCContainer *t_container;
+            t_container = p_parameters -> eval_argument_container();
+            
+            if (t_container != nil)
+            {
+                MCNameRef *t_path;
+                uindex_t t_length;
+                t_container -> getpath(t_path, t_length);
                 
-                if (t_container != nil)
-                {
-                    MCNameRef *t_path;
-                    uindex_t t_length;
-                    t_container -> getpath(t_path, t_length);
-                    
-                    MCExecContext ctxt(p_context, nil, nil);
-                    
-                    if (t_length == 0)
-                        t_parameter_vars[i] = new MCReferenceExternalVariable(t_container -> getvar());
-                    else
-                        t_container -> eval(ctxt, &t_value);
-                }
+                MCExecContext ctxt(p_context, nil, nil);
+                
+                if (t_length == 0)
+                    t_parameter_vars[i] = new MCReferenceExternalVariable(t_container -> getvar());
                 else
-                    t_value = p_parameters -> getvalueref_argument();
-                
-				// MW-2014-01-22: [[ CompatV1 ]] Create a temporary value var.
-                if (*t_value != nil)
-                    t_parameter_vars[i] = new MCTransientExternalVariable(*t_value);
-			}
-		}
+                    t_container -> eval(ctxt, &t_value);
+            }
+            else
+                t_value = p_parameters -> getvalueref_argument();
+            
+            // MW-2014-01-22: [[ CompatV1 ]] Create a temporary value var.
+            if (*t_value != nil)
+                t_parameter_vars[i] = new MCTransientExternalVariable(*t_value);
+        }
+    }
 
-		// We have our list of parameters (hopefully), so now call - passing a temporary
-		// result.
-		if (t_stat == ES_NORMAL)
-		{
-			// MW-2014-01-22: [[ CompatV1 ]] Initialize a temporary var to empty.
-			MCTransientExternalVariable t_result(kMCEmptyString);
-			
-			// MW-2014-01-22: [[ CompatV1 ]] Make a reference var to hold it (should it be needed).
-			//   We then store the previous global value of the it extvar, and set this one.
-			//   As external calls are recursive, this should be fine :)
-			MCReferenceExternalVariable t_it(MCECptr -> GetHandler() -> getit() -> evalvar(*MCECptr));
-			MCReferenceExternalVariable *t_old_it;
-			t_old_it = s_external_v1_current_it;
-			s_external_v1_current_it = &t_it;
-			
-			// Invoke the external handler. If 'false' is returned, treat the result as a
-			// string value containing an error hint.
-			if ((t_handler -> handler)(t_parameter_vars, t_parameter_count, &t_result))
-				MCresult -> setvalueref(t_result . GetValueRef());
-			else
-			{
-				MCeerror -> add(EE_EXTERNAL_EXCEPTION, 0, 0, t_result . GetValueRef());
-				t_stat = ES_ERROR;
-			}
-			
-			// Restore the old it.
-			s_external_v1_current_it = t_old_it;
-		}
+    // We have our list of parameters (hopefully), so now call - passing a temporary
+    // result.
+    if (t_stat == ES_NORMAL)
+    {
+        // MW-2014-01-22: [[ CompatV1 ]] Initialize a temporary var to empty.
+        MCTransientExternalVariable t_result(kMCEmptyString);
+        
+        // MW-2014-01-22: [[ CompatV1 ]] Make a reference var to hold it (should it be needed).
+        //   We then store the previous global value of the it extvar, and set this one.
+        //   As external calls are recursive, this should be fine :)
+        MCReferenceExternalVariable t_it(MCECptr -> GetHandler() -> getit() -> evalvar(*MCECptr));
+        MCReferenceExternalVariable *t_old_it;
+        t_old_it = s_external_v1_current_it;
+        s_external_v1_current_it = &t_it;
+        
+        // Update the current external var.
+        s_current_external = this;
+        
+        // Invoke the external handler. If 'false' is returned, treat the result as a
+        // string value containing an error hint.
+        bool t_success;
+        t_success = (t_handler -> handler)(t_parameter_vars, t_parameter_count, &t_result);
+        
+        // Unset the current external var.
+        s_current_external = nil;
+        
+        // If a license check failed during the call, then we always throw an error.
+        if (!m_was_licensed)
+        {
+            MCAutoStringRef t_name;
+            if (!MCStringCreateWithCString(m_info -> name, &t_name))
+                return ES_ERROR;
+            MCeerror -> add(EE_EXTERNAL_UNLICENSED, 0, 0, *t_name);
+            t_stat = ES_ERROR;
+        }
+        else if (t_success)
+        {
+            MCresult -> setvalueref(t_result . GetValueRef());
+        }
+        else
+        {
+            MCeerror -> add(EE_EXTERNAL_EXCEPTION, 0, 0, t_result . GetValueRef());
+            t_stat = ES_ERROR;
+        }
+        
+        // Restore the old it.
+        s_external_v1_current_it = t_old_it;
+    }
 
-		// Finally, loop through and free the parameters as necessary.
-		for(uint32_t i = 0; i < t_parameter_count; i++)
-			delete t_parameter_vars[i];
+    // Finally, loop through and free the parameters as necessary.
+    for(uint32_t i = 0; i < t_parameter_count; i++)
+        delete t_parameter_vars[i];
 
-        // SN-2015-03-25: [[ CID 15424 ]] Delete an array: use delete []
-		delete[] t_parameter_vars;
+    // SN-2015-03-25: [[ CID 15424 ]] Delete an array: use delete []
+    delete[] t_parameter_vars;
 
-		return t_stat;
-	}
+    return t_stat;
+}
+
+void MCExternalV1::SetWasLicensed(bool p_value)
+{
+    m_was_licensed = p_value;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2801,6 +2873,43 @@ static MCExternalError MCExternalInterfaceQuery(MCExternalInterfaceQueryTag op, 
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MCExternalError MCExternalLicenseCheckEdition(unsigned int p_options, unsigned int p_min_edition)
+{
+    unsigned int t_current_edition;
+    switch(MClicenseparameters . license_class)
+    {
+        case kMCLicenseClassNone:
+            t_current_edition = kMCExternalLicenseTypeNone;
+            break;
+            
+        case kMCLicenseClassCommunity:
+            t_current_edition = kMCExternalLicenseTypeCommunity;
+            break;
+            
+        case kMCLicenseClassCommercial:
+            t_current_edition = kMCExternalLicenseTypeIndy;
+            break;
+            
+        case kMCLicenseClassProfessional:
+            t_current_edition = kMCExternalLicenseTypeBusiness;
+            break;
+            
+        default:
+            MCUnreachableReturn(kMCExternalErrorUnlicensed);
+            break;
+    }
+    
+    if (t_current_edition < p_min_edition)
+    {
+        s_current_external -> SetWasLicensed(false);
+        return kMCExternalErrorUnlicensed;
+    }
+    
+    return kMCExternalErrorNone;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 MCExternalInterface g_external_interface =
 {
 	kMCExternalInterfaceVersion,
@@ -2849,6 +2958,9 @@ MCExternalInterface g_external_interface =
     
     // SN-2015-01-26: [[ Bug 14057 ]] Update the ContextQuery for the new delimiters
     MCExternalContextQuery,
+    
+    // MW-2016-02-17: [[ LicenseCheck ]] Declare the check call.
+    MCExternalLicenseCheckEdition,
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/externalv1.h
+++ b/engine/src/externalv1.h
@@ -57,7 +57,8 @@ typedef void (*MCExternalThreadRequiredCallback)(void *state, int flags);
 
 // MW-2013-06-14: [[ ExternalsApiV5 ]] Update the interface version.
 // MW-2014-06-26: [[ ExternalsApiV6 ]] Update the interface version for unicode changes.
-#define kMCExternalInterfaceVersion 6
+// MW-2016-02-17: [[ ExternalsApiV7 ]] Update the interface version for license check.
+#define kMCExternalInterfaceVersion 7
 
 enum
 {
@@ -200,10 +201,10 @@ enum MCExternalError
     
     // SN-2014-07-01" [[ ExternalsApiV6 ]] Errors which might get triggered when converting from an MC* type to a CF* type
     // Following the definitions in Support.mm
-#ifdef __HAS_CORE_FOUNDATION__
     kMCExternalErrorNotASequence = 40,
     kMCExternalErrorCannotEncodeMap = 41,
-#endif
+
+    kMCExternalErrorUnlicensed = 42,
 };
 
 enum MCExternalContextQueryTag
@@ -292,6 +293,14 @@ enum MCExternalDispatchStatus
     kMCExternalDispatchStatusError,
     kMCExternalDispatchStatusExit,
     kMCExternalDispatchStatusAbort,
+};
+
+enum MCExternalLicenseType
+{
+    kMCExternalLicenseTypeNone = 0,
+    kMCExternalLicenseTypeCommunity = 1000,
+    kMCExternalLicenseTypeIndy = 2000,
+    kMCExternalLicenseTypeBusiness = 3000,
 };
 
 enum MCExternalHandlerType
@@ -395,6 +404,9 @@ struct MCExternalInterface
     
     // SN-2015-01-26: [[ Bug 14057 ]] Update context query, to allow the user to set the return type
     MCExternalError (*context_query)(MCExternalContextQueryTag op, MCExternalValueOptions p_options, void *r_result); // V6
+    
+    // MW-2016-02-17: [[ LicenseCheck ]] Method to check the licensing of the engine
+    MCExternalError (*license_check_edition)(unsigned int options, unsigned int min_edition); // V7
 };
 
 typedef MCExternalInfo *(*MCExternalDescribeProc)(void);
@@ -520,12 +532,22 @@ public:
     virtual bool ListHandlers(MCExternalListHandlersCallback callback, void *state);
     virtual Exec_stat Handle(MCObject *p_context, Handler_type p_type, uint32_t p_index, MCParameter *p_parameters);
     
+    void SetWasLicensed(bool p_value);
+    
 private:
     virtual bool Prepare(void);
     virtual bool Initialize(void);
     virtual void Finalize(void);
     
     MCExternalInfo *m_info;
+    
+    // This is true if startup succeeded (returned true) and license_fail was
+    // not called.
+    bool m_licensed : 1;
+    
+    // This is set to true if the last external handler call on this external
+    // did not call license_fail.
+    bool m_was_licensed : 1;
 };
 
 #endif

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -366,7 +366,32 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 		}
 		break;
 			
-			
+    
+    case kMCCapsuleSectionTypeLicense:
+    {
+        char t_edition_byte;
+        if (IO_read(&t_edition_byte, 1, p_stream) != IO_NORMAL)
+        {
+            MCresult -> sets("failed to read license");
+            return false;
+        }
+
+        bool t_success;
+        t_success = true;
+        
+        // The edition encoding is engine version / IDE engine version
+        // specific - for now its just a byte with value 0-3.
+        if (t_edition_byte == 1)
+            MClicenseparameters . license_class = kMCLicenseClassCommunity;
+        else if (t_edition_byte == 2)
+            MClicenseparameters . license_class = kMCLicenseClassCommercial;
+        else if (t_edition_byte == 3)
+            MClicenseparameters . license_class = kMCLicenseClassProfessional;
+        else
+            MClicenseparameters . license_class = kMCLicenseClassNone;
+    }
+    break;
+            
 	default:
 		MCresult -> sets("unrecognized section encountered");
 		return false;

--- a/lcidlc/include/LiveCode.h
+++ b/lcidlc/include/LiveCode.h
@@ -122,6 +122,12 @@ typedef enum LCError
 	
 	// The value argument to object set/get was nil
 	kLCErrorNoObjectPropertyValue = 35,
+    
+    // The query option passed to InterfaceQuery was unknown
+    kLCErrorInvalidInterfaceQuery = 36,
+    
+    // Returned if LicenseCheck fails.
+    kLCErrorUnlicensed = 42,
 	
 	//////////
 	
@@ -418,6 +424,13 @@ enum
 	kLCValueOptionNumberFormatFromContext = 3 << 26,	
 };
 	
+enum
+{
+    kLCLicenseEditionCommunity = 1000,
+    kLCLicenseEditionIndy = 2000,
+    kLCLicenseEditionBusiness = 3000,
+};
+    
 ////////////////////////////////////////////////////////////////////////////////
 	
 typedef struct __LCArray *LCArrayRef;
@@ -1506,6 +1519,32 @@ LCError LCPostBlockOnMainThread(unsigned int options, void (^callback)(void));
 	
 ////////////////////////////////////////////////////////////////////////////////
 
+// Function:
+//   LCLicenseCheckEdition
+// Parameters:
+//   (in) min_edition
+//
+// Errors:
+//   Unlicensed - the license check failed.
+// Context Safety:
+//   Must be called from handler context.
+// Semantics:
+//   Checks that the engine is licensed with at min_edition edition level.
+//
+//   If the check fails, then an 'unlicensed' error will be returned when control
+//   returns to the engine.
+//
+//   If a license check fails during the external's initialize handler then the
+//   whole external is marked as unlicensed and all further calls to it will cause
+//   an unlicensed error to be raised.
+//
+//   If a license check fails during an external's handler execution then just
+//   that call will fail.
+//
+LCError LCLicenseCheckEdition(unsigned int min_edition);
+    
+////////////////////////////////////////////////////////////////////////////////
+    
 #if defined(__OBJC__) && TARGET_OS_IPHONE
 
 #import <UIKit/UIKit.h>

--- a/lcidlc/src/Support.mm
+++ b/lcidlc/src/Support.mm
@@ -109,7 +109,8 @@ typedef enum MCError
 	kMCErrorNoObjectProperty = 34,
 	kMCErrorNoObjectPropertyValue = 35,
 	kMCErrorInvalidInterfaceQuery = 36,
-	kMCErrorNotSupported = 37,
+    kMCErrorNotSupported = 37,
+    kMCErrorUnlicensed = 42,
 } MCError;
 
 typedef uint32_t MCValueOptions;
@@ -149,6 +150,8 @@ enum
     kMCOptionAsCFData = 25,
     kMCOptionAsCFArray = 26,
     kMCOptionAsCFDictionary = 27,
+    
+    kMCOptionAsNothing = 28,
     
 	kMCOptionNumberFormatDefault = 0 << 26,
 	kMCOptionNumberFormatDecimal = 1 << 26,
@@ -291,6 +294,9 @@ typedef struct MCExternalInterface
     
     // SN-2015-01-26: [[ Bug 14057 ]] Added new function in the API v6, to allow the users to choose their return type (for the delimiters)
     MCError (*context_query)(MCExternalContextVar op, MCValueOptions p_options, void *result);
+    
+    // MW-2016-02-17: [[ LicenseCheck ]] Method to check the engine's license
+    MCExternalError (*license_check_edition)(unsigned int options, unsigned int min_edition);
 } MCExternalInterface;
 
 typedef struct MCExternalInfo
@@ -2664,7 +2670,19 @@ LCError LCInterfaceDismissModalViewController(UIViewController *p_controller, bo
 }
 	
 #endif
+    
+/////////
 
+LCError LCLicenseCheckEdition(unsigned int p_min_version)
+{
+    // If the external requires license calls, then abort if the engine is too
+    // old.
+    if (s_interface -> version < 7)
+        return kLCErrorUnlicensed;
+    
+    return s_interface -> license_check_edition(0, p_min_version);
+}
+    
 END_EXTERN_C
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The V1 externals API has been extended with a new API LicenseCheck().

This API takes the minimum edition (one of Community, Indy, Business)
which the external requires. If the engine is not licensed at that level
or above, it will cause the external handler to fail and raise an
error in the engine. If a call to the API fails in an external initialize
handler, then it will cause all future calls to the external to fail
with an error.

In addition to the new external API, the deploy command will now include
an edition byte in the standalone capsule - allowing license checks to
occur in standalones rather than just in the IDE.
