### PR TITLE
build: Put docs inputs in the right place before running builder

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -137,12 +137,17 @@ dist-docs: dist-docs-commercial
 endif
 
 dist-docs-community:
+	mkdir -p $(docs_build_dir)
+	cp -R $(docs_source_dir) $(docs_build_dir)/raw-community
 	$(buildtool_command) --platform $(buildtool_platform) --stage docs \
 	  --edition community \
 	  --docs-dir $(docs_build_dir)/raw-community \
 	  --built-docs-dir $(docs_build_dir)/cooked-community
 	  
 dist-docs-commercial:
+	mkdir -p $(docs_build_dir)
+	cp -R $(docs_source_dir) $(docs_build_dir)/raw-commercial
+	rsync -a $(docs_private_source_dir)/ $(docs_build_dir)/raw-commercial/
 	$(buildtool_command) --platform $(buildtool_platform) \
 	  --stage docs --edition indy \
 	  --docs-dir $(docs_build_dir)/raw-commercial \


### PR DESCRIPTION
Commit bdd89483 incorrectly removed some steps from the documentation
build rules that were required to generate the correct documentation
data.
