### PR TITLE
Add a set of special font names "(System UI Font - *)" for themed fonts

### DIFF
--- a/docs/dictionary/function/fontNames.lcdoc
+++ b/docs/dictionary/function/fontNames.lcdoc
@@ -39,12 +39,12 @@ If you do not specify 'printer', the fonts installed on the system and available
 In Android, iOS 3.2 and later it is possible to bundle custom fonts with an application, that only that application can use. To take advantage of this feature, you need to reference the files of any fonts you wish to include in the 'Copy Files' pane. These files can either be a direct file references, or contained in one of the folder references. The 'Standalone Builder' treats any files that end with the extension '.ttf' or '.ttc' as font files to use in this way. Any fonts included in this way appear in the <fontNames> and can be used in the same way as any other font on the system.
 
 The list of font names includes a set of special-purpose names which automatically select the matching font for the platform. You can use these to request "the font used for buttons" without having to hard-code platform-specific font names. These fonts are:
-- `(System UI Font - Content)` - the font used for fields and other controls with editable content
-- `(System UI Font - Menu text)` - the font used for menu items
-- `(System UI Font - Messages)` - the font used for buttons, labels and other communication from the app
-- `(System UI Font - Styled text)` - the font used by default for rich text
-- `(System UI Font - System)` - the font for controls not covered by another category
-- `(System UI Font - Tooltips)` - the font used for displaying tooltips
+- `(Text)` - the font used for fields and other controls with editable content
+- `(Menu)` - the font used for menu items
+- `(Message)` - the font used for buttons, labels and other communication from the app
+- `(Styled Text)` - the font used by default for rich text
+- `(System)` - the font for controls not covered by another category
+- `(Tooltip)` - the font used for displaying tooltips
 - `(Default)` - selects one of the UI fonts automatically based on the control type
 
 >*Important:* Make sure you have an appropriate license for the fonts you choose to bundle with your iOS app like you would any other media such as sounds, images and videos.

--- a/docs/dictionary/function/fontNames.lcdoc
+++ b/docs/dictionary/function/fontNames.lcdoc
@@ -38,6 +38,15 @@ If you do not specify 'printer', the fonts installed on the system and available
 
 In Android, iOS 3.2 and later it is possible to bundle custom fonts with an application, that only that application can use. To take advantage of this feature, you need to reference the files of any fonts you wish to include in the 'Copy Files' pane. These files can either be a direct file references, or contained in one of the folder references. The 'Standalone Builder' treats any files that end with the extension '.ttf' or '.ttc' as font files to use in this way. Any fonts included in this way appear in the <fontNames> and can be used in the same way as any other font on the system.
 
+The list of font names includes a set of special-purpose names which automatically select the matching font for the platform. You can use these to request "the font used for buttons" without having to hard-code platform-specific font names. These fonts are:
+- `(System UI Font - Content)` - the font used for fields and other controls with editable content
+- `(System UI Font - Menu text)` - the font used for menu items
+- `(System UI Font - Messages)` - the font used for buttons, labels and other communication from the app
+- `(System UI Font - Styled text)` - the font used by default for rich text
+- `(System UI Font - System)` - the font for controls not covered by another category
+- `(System UI Font - Tooltips)` - the font used for displaying tooltips
+- `(Default)` - selects one of the UI fonts automatically based on the control type
+
 >*Important:* Make sure you have an appropriate license for the fonts you choose to bundle with your iOS app like you would any other media such as sounds, images and videos.
 
 The fontNames (printer) form was introduced in version 2.0.

--- a/docs/dictionary/property/textFont.lcdoc
+++ b/docs/dictionary/property/textFont.lcdoc
@@ -26,10 +26,10 @@ Example:
 set the textFont of field "Input" to "Arial,Japanese"
 
 Example:
-set the textFont of button "Hello" to "Courier"
+set the textFont of field "Text" to "Japanese"
 
 Example:
-set the textFont of field "Text" to "Japanese"
+set the textFont of button "Themed" to "(System UI Font - Messages)"
 
 Value: The <textFont> of an <object> or <chunk> is either empty or a <string>.
 
@@ -42,6 +42,12 @@ If the <chunk> contains more than one font, the <chunk|chunk's> <textFont> <prop
 
 On Mac OS systems, if the specified font isn't available, the system font (which is set in the Appearance control panel and specifies the font used for menus) is used. On Unix systems, if the specified font isn't available, Helvetica is used. On Windows systems, if the specified font isn't available, the current Windows font is used.
 
-References: printTextFont (property), owner (property), printFontTable (property), allowInlineInput (property), HTMLText (property), string (keyword), effective (keyword), object (object), property (glossary), keyword (glossary), font (glossary), chunk (glossary)
+To get the list of available fonts, use the <fontNames> function.
+
+Some special font names can be used to request the themed fonts used for drawing UI elements. These are documented in the <fontNames> function.
+
+Setting the <textFont> to `(Default)` causes the control to use the default font for that type of control rather than inheriting the font from a parent object.
+
+References: fontNames (function), printTextFont (property), owner (property), printFontTable (property), allowInlineInput (property), HTMLText (property), string (keyword), effective (keyword), object (object), property (glossary), keyword (glossary), font (glossary), chunk (glossary)
 
 Tags: ui

--- a/docs/notes/feature-ui_fonts.md
+++ b/docs/notes/feature-ui_fonts.md
@@ -1,0 +1,6 @@
+# Themed UI fonts
+
+LiveCode 8.0 has improved the native look-and-feel of stacks written for desktop platforms, particularly when it comes to fonts. However, LiveCode lacked an easy way to request the use of an appropriately themed font explicitly.
+
+A number of special font names have now been added to LiveCode so you can, for example, set the font of a control to the default font used for buttons. To find out more, see the dictionary entry for the fontNames function.
+

--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -554,6 +554,7 @@
 			# Group "Theming"
 			'src/linux-theme.cpp',
 			'src/mac-theme.mm',
+			'src/mblandroid-theme.cpp',
 			'src/mbliphone-theme.mm',
 			'src/windows-theme.cpp',
 				

--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -554,6 +554,7 @@
 			# Group "Theming"
 			'src/linux-theme.cpp',
 			'src/mac-theme.mm',
+			'src/mbliphone-theme.mm',
 			'src/windows-theme.cpp',
 				
 			# Group "Syntax"

--- a/engine/src/coretextfonts.mm
+++ b/engine/src/coretextfonts.mm
@@ -28,6 +28,7 @@
 
 #ifdef TARGET_SUBPLATFORM_IPHONE
 #import <CoreText/CoreText.h>
+#import <UIKit/UIFont.h>
 #else
 #import <ApplicationServices/ApplicationServices.h>
 #import <AppKit/NSFont.h>
@@ -76,42 +77,68 @@ void ios_clear_font_mapping(void)
 }
 #endif
 
-#ifndef TARGET_SUBPLATFORM_IPHONE
 static void* coretext_font_create_system(uint32_t p_size)
 {
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    return [[UIFont systemFontOfSize: p_size] retain];
+#else
     return [[NSFont systemFontOfSize: p_size] retain];
+#endif
 }
 
 static void* coretext_font_create_system_bold(uint32_t p_size)
 {
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    return [[UIFont boldSystemFontOfSize: p_size] retain];
+#else
     return [[NSFont boldSystemFontOfSize: p_size] retain];
+#endif
 }
 
 static void* coretext_font_create_content(uint32_t p_size)
 {
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    return [[UIFont systemFontOfSize: p_size] retain];
+#else
     return [[NSFont controlContentFontOfSize: p_size] retain];
+#endif
 }
 
 static void* coretext_font_create_menu(uint32_t p_size)
 {
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    return [[UIFont systemFontOfSize: p_size] retain];
+#else
     return [[NSFont menuFontOfSize: p_size] retain];
+#endif
 }
 
 static void* coretext_font_create_message(uint32_t p_size)
 {
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    return [[UIFont systemFontOfSize: p_size] retain];
+#else
     return [[NSFont messageFontOfSize: p_size] retain];
+#endif
 }
 
 static void* coretext_font_create_tooltip(uint32_t p_size)
 {
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    return [[UIFont systemFontOfSize: p_size] retain];
+#else
     return [[NSFont toolTipsFontOfSize: p_size] retain];
+#endif
 }
 
 static void* coretext_font_create_user(uint32_t p_size)
 {
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    return [[UIFont systemFontOfSize: p_size] retain];
+#else
     return [[NSFont userFontOfSize: p_size] retain];
-}
 #endif
+}
 
 static void *coretext_font_create_with_name_and_size(MCStringRef p_name, uint32_t p_size)
 {
@@ -132,7 +159,6 @@ static void *coretext_font_create_with_name_and_size(MCStringRef p_name, uint32_
     bool t_success;
     t_success = true;
 
-#ifndef TARGET_SUBPLATFORM_IPHONE
     // On OSX, use the special "system" and "user" fonts where requested. OSX
     // doesn't actually let you get the display-optimised fonts by name (in
     // particular, the optimised Helvetica Neue and San Fransisco fonts).
@@ -148,7 +174,6 @@ static void *coretext_font_create_with_name_and_size(MCStringRef p_name, uint32_
         return coretext_font_create_message(p_size);
     if (MCStringIsEqualTo(p_name, MCNameGetString(MCN_font_tooltip), kMCStringOptionCompareCaseless))
         return coretext_font_create_tooltip(p_size);
-#endif
     
     // SN-2015-02-16: [[ iOS Font mapping ]] On iOS, try to fetch the mapped
     //  if one exists.

--- a/engine/src/coretextfonts.mm
+++ b/engine/src/coretextfonts.mm
@@ -136,17 +136,17 @@ static void *coretext_font_create_with_name_and_size(MCStringRef p_name, uint32_
     // On OSX, use the special "system" and "user" fonts where requested. OSX
     // doesn't actually let you get the display-optimised fonts by name (in
     // particular, the optimised Helvetica Neue and San Fransisco fonts).
-    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - System", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualTo(p_name, MCNameGetString(MCN_font_system), kMCStringOptionCompareCaseless))
         return coretext_font_create_system(p_size);
-    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - User", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualTo(p_name, MCNameGetString(MCN_font_usertext), kMCStringOptionCompareCaseless))
         return coretext_font_create_user(p_size);
-    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - Content", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualTo(p_name, MCNameGetString(MCN_font_content), kMCStringOptionCompareCaseless))
         return coretext_font_create_content(p_size);
-    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - Menu", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualTo(p_name, MCNameGetString(MCN_font_menutext), kMCStringOptionCompareCaseless))
         return coretext_font_create_menu(p_size);
-    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - Message", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualTo(p_name, MCNameGetString(MCN_font_message), kMCStringOptionCompareCaseless))
         return coretext_font_create_message(p_size);
-    if (MCStringIsEqualToCString(p_name, "Aqua UI Font - Tooltip", kMCStringOptionCompareCaseless))
+    if (MCStringIsEqualTo(p_name, MCNameGetString(MCN_font_tooltip), kMCStringOptionCompareCaseless))
         return coretext_font_create_tooltip(p_size);
 #endif
     

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1706,7 +1706,7 @@ MCFontStruct *MCDispatch::loadfont(MCNameRef fname, uint2 &size, uint2 style, Bo
 
 MCFontStruct *MCDispatch::loadfontwithhandle(MCSysFontHandle p_handle, MCNameRef p_name)
 {
-#if defined(_MACOSX) || defined (_MAC_SERVER)
+#if defined(_MACOSX) || defined (_MAC_SERVER) || defined (TARGET_SUBPLATFORM_IPHONE)
     if (fonts == nil)
         fonts = new MCFontlist;
     return fonts->getfontbyhandle(p_handle, p_name);

--- a/engine/src/exec-text.cpp
+++ b/engine/src/exec-text.cpp
@@ -65,7 +65,7 @@ void MCTextEvalFontNames(MCExecContext& ctxt, MCStringRef p_type, MCStringRef& r
         // Prepend the special UI font names
         if (MCStringFormat(r_names, "%@\n%@\n%@\n%@\n%@\n%@\n%@\n%@",
                            MCN_font_default, MCN_font_usertext, MCN_font_menutext,
-                           MCN_font_content, MCN_font_message, MCN_font_message,
+                           MCN_font_content, MCN_font_message, MCN_font_tooltip,
                            MCN_font_system, *t_names))
         {
             return;

--- a/engine/src/exec-text.cpp
+++ b/engine/src/exec-text.cpp
@@ -58,9 +58,19 @@ bool MCTextBaseFontName(MCStringRef p_font, MCStringRef& r_base_name)
 void MCTextEvalFontNames(MCExecContext& ctxt, MCStringRef p_type, MCStringRef& r_names)
 {
 	MCAutoListRef t_name_list;
+    MCAutoStringRef t_names;
 	if (MCdispatcher->getfontlist()->getfontnames(p_type, &t_name_list) &&
-		MCListCopyAsString(*t_name_list, r_names))
-		return;
+		MCListCopyAsString(*t_name_list, &t_names))
+    {
+        // Prepend the special UI font names
+        if (MCStringFormat(r_names, "%@\n%@\n%@\n%@\n%@\n%@\n%@\n%@",
+                           MCN_font_default, MCN_font_usertext, MCN_font_menutext,
+                           MCN_font_content, MCN_font_message, MCN_font_message,
+                           MCN_font_system, *t_names))
+        {
+            return;
+        }
+    }
 
 	ctxt . Throw();
 }

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1204,37 +1204,8 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 
 	// IM-2014-01-27: [[ HiDPI ]] Initialize pixel scale settings
 	MCResInitPixelScaling();
-
-	// MW-2012-02-14: [[ FontRefs ]] Open the dispatcher after we have an open
-	//   screen, otherwise we don't have a root fontref!
-	// MW-2013-08-07: [[ Bug 10995 ]] Configure fonts based on platform.
-#if defined(TARGET_PLATFORM_WINDOWS)
-	/*if (MCmajorosversion >= 0x0600)
-	{
-		// Vista onwards
-		MCdispatcher -> setfontattrs(MCSTR("Segoe UI"), 12, FA_DEFAULT_STYLE);
-	}
-	else
-	{
-		// Pre-Vista
-		MCdispatcher -> setfontattrs("Tahoma", 11, FA_DEFAULT_STYLE);
-	}*/
-#elif defined(TARGET_PLATFORM_MACOS_X)
-    /*if (MCmajorosversion < 0x10A0)
-        MCdispatcher -> setfontattrs("Lucida Grande", 11, FA_DEFAULT_STYLE);
-    else
-    {
-        MCdispatcher -> setfontattrs("Helvetica Neue", 11, FA_DEFAULT_STYLE);
-        MCttfont = "Helvetica Neue";
-    }*/
-#elif defined(TARGET_PLATFORM_LINUX)
-    //MCdispatcher -> setfontattrs("Helvetica", 12, FA_DEFAULT_STYLE);
-#else
-	MCdispatcher -> setfontattrs(MCSTR(DEFAULT_TEXT_FONT), DEFAULT_TEXT_SIZE, FA_DEFAULT_STYLE);
-#endif
-
-    // MW-2012-02-14: [[ FontRefs ]] Open the dispatcher after we have an open
-	//   screen, otherwise we don't have a root fontref!
+    
+    // Set up fonts
 	MCdispatcher -> open();
 
 	// This is here because it relies on MCscreen being initialized.

--- a/engine/src/linux-theme.cpp
+++ b/engine/src/linux-theme.cpp
@@ -336,6 +336,22 @@ bool MCPlatformGetControlThemePropColor(MCPlatformControlType p_type, MCPlatform
     return t_found;
 }
 
+// Utility function needed by the Linux font code. Gets the family name of the
+// font for the given control type.
+bool MCPlatformGetControlThemePropString(MCPlatformControlType p_type, MCPlatformControlPart p_part, MCPlatformControlState, MCPlatformThemeProperty p_prop, MCStringRef& r_string)
+{
+    if (p_prop != kMCPlatformThemePropertyTextFont)
+        return false;
+    
+    GtkStyle* t_style;
+    t_style = getStyleForControlType(p_type, p_part);
+    if (t_style == NULL)
+        return false;
+    
+    const PangoFontDescription* t_pango = t_style->font_desc;
+    return MCStringCreateWithCString(pango_font_description_get_family(t_pango), r_string);
+}
+
 bool MCPlatformGetControlThemePropFont(MCPlatformControlType p_type, MCPlatformControlPart p_part, MCPlatformControlState p_state, MCPlatformThemeProperty p_prop, MCFontRef& r_font)
 {
     GtkStyle* t_style;

--- a/engine/src/mac-theme.mm
+++ b/engine/src/mac-theme.mm
@@ -73,7 +73,7 @@ static NSFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlS
         {
             static NSFont* s_user_font = [[NSFont userFontOfSize:-1.0] retain];
             if (r_name)
-                *r_name = MCNAME("Aqua UI Font - User");
+                *r_name = MCValueRetain(MCN_font_usertext);
             return s_user_font;
         }
             
@@ -85,7 +85,7 @@ static NSFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlS
         {
             static NSFont* s_menu_font = [[NSFont menuFontOfSize:-1.0] retain];
             if (r_name)
-                *r_name = MCNAME("Aqua UI Font - Menu");
+                *r_name = MCValueRetain(MCN_font_menutext);
             return s_menu_font;
         }
             
@@ -94,7 +94,7 @@ static NSFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlS
         {
             static NSFont* s_content_font = [[NSFont controlContentFontOfSize:-1.0] retain];
             if (r_name)
-                *r_name = MCNAME("Aqua UI Font - Content");
+                *r_name = MCValueRetain(MCN_font_content);
             return s_content_font;
         }
             
@@ -109,7 +109,7 @@ static NSFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlS
         {
             static NSFont* s_message_font = [[NSFont messageFontOfSize:-1.0] retain];
             if (r_name)
-                *r_name = MCNAME("Aqua UI Font - Message");
+                *r_name = MCValueRetain(MCN_font_message);
             return s_message_font;
         }
             
@@ -117,7 +117,7 @@ static NSFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlS
         {
             static NSFont* s_tooltip_font = [[NSFont toolTipsFontOfSize:-1.0] retain];
             if (r_name)
-                *r_name = MCNAME("Aqua UI Font - Tooltip");
+                *r_name = MCValueRetain(MCN_font_tooltip);
             return s_tooltip_font;
         }
             
@@ -125,7 +125,7 @@ static NSFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlS
         {
             static NSFont* s_system_font = [[NSFont systemFontOfSize:[NSFont systemFontSize]] retain];
             if (r_name)
-                *r_name = MCNAME("Aqua UI Font - System");
+                *r_name = MCValueRetain(MCN_font_system);
             return s_system_font;
         }
     }

--- a/engine/src/mblandroid-theme.cpp
+++ b/engine/src/mblandroid-theme.cpp
@@ -1,0 +1,110 @@
+/* Copyright (C) 2016 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+#include "platform.h"
+
+#include "globdefs.h"
+#include "objdefs.h"
+#include "parsedef.h"
+#include "filedefs.h"
+#include "mcstring.h"
+#include "globals.h"
+#include "mctheme.h"
+#include "util.h"
+#include "object.h"
+#include "stack.h"
+#include "font.h"
+
+
+// Typographic information for Android: https://www.google.com/design/spec/style/typography.html#typography-styles
+// Android design cheatsheet: http://petrnohejl.github.io/Android-Cheatsheet-For-Graphic-Designers/
+// Android theming values: https://github.com/android/platform_frameworks_base/tree/master/core/res/res/values
+
+bool MCPlatformGetControlThemePropBool(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, bool&)
+{
+    return false;
+}
+
+bool MCPlatformGetControlThemePropInteger(MCPlatformControlType p_type, MCPlatformControlPart, MCPlatformControlState p_state, MCPlatformThemeProperty p_prop, int& r_int)
+{
+    // The only integer property currently implemented for Android is text size
+    if (p_prop != kMCPlatformThemePropertyTextSize)
+        return false;
+    
+    // For legacy theming, the font is always 12-point Arial
+    if (p_state & kMCPlatformControlStateCompatibility)
+    {
+        r_int = 12;
+        return true;
+    }
+    
+    // What type of control are we looking at?
+    switch (p_type)
+    {
+        // Text input areas use 14-point Roboto
+        case kMCPlatformControlTypeInputField:
+        case kMCPlatformControlTypeComboBox:
+        case kMCPlatformControlTypeTooltip:
+        case kMCPlatformControlTypeRichText:
+            r_int = 14;
+            return true;
+            
+        // Everything else uses 18-point Roboto
+        case kMCPlatformControlTypeMenu:
+        case kMCPlatformControlTypeMenuItem:
+        case kMCPlatformControlTypePopupMenu:
+        case kMCPlatformControlTypeOptionMenu:
+        case kMCPlatformControlTypePulldownMenu:
+        case kMCPlatformControlTypeButton:
+        case kMCPlatformControlTypeCheckbox:
+        case kMCPlatformControlTypeLabel:
+        case kMCPlatformControlTypeRadioButton:
+        case kMCPlatformControlTypeList:
+        case kMCPlatformControlTypeMessageBox:
+        case kMCPlatformControlTypeTabButton:
+        case kMCPlatformControlTypeTabPane:
+        default:
+            r_int = 18;
+            return true;
+    }
+    
+    return false;
+}
+
+bool MCPlatformGetControlThemePropColor(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCColor&)
+{
+    return false;
+}
+
+bool MCPlatformGetControlThemePropFont(MCPlatformControlType p_type, MCPlatformControlPart p_part, MCPlatformControlState p_state, MCPlatformThemeProperty p_prop, MCFontRef& r_font)
+{
+    // The only supported font property is the text font
+    if (p_prop != kMCPlatformThemePropertyTextFont)
+        return false;
+    
+    // For legacy theming, the font is always 12-point Arial
+    if (p_state & kMCPlatformControlStateCompatibility)
+        return MCFontCreate(MCNAME("Arial"), 0, 12, r_font);
+    
+    // Get the text size for this control type
+    int t_text_size;
+    if (!MCPlatformGetControlThemePropInteger(p_type, p_part, p_state, kMCPlatformThemePropertyTextSize, t_text_size))
+        return false;
+    
+    // The default font is Roboto of the appropriate size
+    return MCFontCreate(MCNAME("Roboto"), 0, t_text_size, r_font);
+}

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -2961,24 +2961,3 @@ void MCJavaDetachCurrentThread()
 
 
 ////////////////////////////////////////////////////////////////////////////////
-
-// No theming for mobile platforms yet
-bool MCPlatformGetControlThemePropBool(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, bool&)
-{
-    return false;
-}
-
-bool MCPlatformGetControlThemePropInteger(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, int&)
-{
-    return false;
-}
-
-bool MCPlatformGetControlThemePropColor(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCColor&)
-{
-    return false;
-}
-
-bool MCPlatformGetControlThemePropFont(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCFontRef& r_font)
-{
-    return MCFontCreate(MCNAME("Arial"), 0, 12, r_font);
-}

--- a/engine/src/mblflst.cpp
+++ b/engine/src/mblflst.cpp
@@ -89,7 +89,7 @@ MCFontnode::MCFontnode(MCSysFontHandle p_handle, MCNameRef p_name)
     if (p_name == nil)
         coretext_get_font_name(p_handle, &reqname);
     else
-        reqname = MCValueRetain(p_name);
+        reqname = p_name;
     
     reqsize = coretext_get_font_size(p_handle);
     reqstyle = FA_DEFAULT_STYLE | FA_SYSTEM_FONT;

--- a/engine/src/mblflst.h
+++ b/engine/src/mblflst.h
@@ -29,6 +29,9 @@ class MCFontnode : public MCDLlist
 	MCFontStruct *font;
 public:
 	MCFontnode(MCNameRef fname, uint2 &size, uint2 style);
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    MCFontnode(MCSysFontHandle, MCNameRef name);
+#endif
 	~MCFontnode();
 
 	MCFontStruct *getfont(MCNameRef fname, uint2 size, uint2 style);
@@ -100,6 +103,10 @@ public:
 	bool getfontsizes(MCStringRef p_fname, MCListRef& r_sizes);
 	bool getfontstyles(MCStringRef p_fname, uint2 fsize, MCListRef& r_styles);
 	bool getfontstructinfo(MCNameRef& r_name, uint2 &r_size, uint2 &r_style, Boolean &r_printer, MCFontStruct *p_font);
+    
+#ifdef TARGET_SUBPLATFORM_IPHONE
+    MCFontStruct *getfontbyhandle(MCSysFontHandle, MCNameRef name);
+#endif
 };
 
 

--- a/engine/src/mbliphone-theme.mm
+++ b/engine/src/mbliphone-theme.mm
@@ -1,0 +1,164 @@
+/* Copyright (C) 2015 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+#include "platform.h"
+
+#include "globdefs.h"
+#include "objdefs.h"
+#include "parsedef.h"
+#include "filedefs.h"
+#include "mcstring.h"
+#include "globals.h"
+#include "mctheme.h"
+#include "util.h"
+#include "object.h"
+#include "stack.h"
+#include "font.h"
+
+#import <UIKit/UIColor.h>
+#import <UIKit/UIFont.h>
+#import <CoreText/CoreText.h>
+
+
+// The following methods are documented in the UIFont class documentation but
+// aren't declared in the header so we extend the UIFont interface here to
+// ensure the compiler knows about them.
+@interface UIFont ()
++ (CGFloat)labelFontSize;
++ (CGFloat)buttonFontSize;
++ (CGFloat)systemFontSize;
+@end
+
+
+// Returns the name of the legacy font
+static NSString* get_legacy_font_name()
+{
+    return @"Helvetica";
+}
+
+// Returns the correct font for a control of the given type
+static UIFont* font_for_control(MCPlatformControlType p_type, MCPlatformControlState p_state, MCNameRef* r_name = nil)
+{
+    // Always return the same font regardless of control type in legacy mode
+    if (p_state & kMCPlatformControlStateCompatibility)
+    {
+        static UIFont* s_legacy_font = nil;
+        if (nil == s_legacy_font)
+            s_legacy_font = [[UIFont fontWithName:get_legacy_font_name() size:13] retain];
+        if (nil == s_legacy_font)
+            s_legacy_font = [[UIFont systemFontOfSize:13] retain];
+
+        MCAssert(nil != s_legacy_font);
+
+        if (r_name)
+            *r_name = nil;
+        return s_legacy_font;
+    }
+    
+    switch (p_type)
+    {
+        case kMCPlatformControlTypeMenu:
+        case kMCPlatformControlTypeMenuItem:
+        case kMCPlatformControlTypePopupMenu:
+        case kMCPlatformControlTypeOptionMenu:
+        case kMCPlatformControlTypePulldownMenu:
+        {
+            static UIFont* s_label_font = [[UIFont systemFontOfSize: [UIFont labelFontSize]] retain];
+            if (r_name)
+                *r_name = MCValueRetain(MCN_font_system);
+            return s_label_font;
+        }
+            
+        case kMCPlatformControlTypeButton:
+        case kMCPlatformControlTypeCheckbox:
+        case kMCPlatformControlTypeLabel:
+        case kMCPlatformControlTypeRadioButton:
+        case kMCPlatformControlTypeList:
+        case kMCPlatformControlTypeMessageBox:
+        case kMCPlatformControlTypeTabButton:
+        case kMCPlatformControlTypeTabPane:
+        {
+            static UIFont* s_button_font = [[UIFont systemFontOfSize: [UIFont buttonFontSize]] retain];
+            if (r_name)
+                *r_name = MCValueRetain(MCN_font_system);
+            return s_button_font;
+        }
+            
+        case kMCPlatformControlTypeInputField:
+        case kMCPlatformControlTypeComboBox:
+        case kMCPlatformControlTypeTooltip:
+        case kMCPlatformControlTypeRichText:
+        default:
+        {
+            static UIFont* s_system_font = [[UIFont systemFontOfSize: [UIFont systemFontSize]] retain];
+            if (r_name)
+                *r_name = MCValueRetain(MCN_font_system);
+            return s_system_font;
+        }
+    }
+    
+    if (r_name)
+        *r_name = nil;
+    return nil;
+}
+
+
+bool MCPlatformGetControlThemePropBool(MCPlatformControlType p_type, MCPlatformControlPart p_part, MCPlatformControlState p_state, MCPlatformThemeProperty p_which, bool& r_bool)
+{
+    return false;
+}
+
+bool MCPlatformGetControlThemePropInteger(MCPlatformControlType p_type, MCPlatformControlPart p_part, MCPlatformControlState p_state, MCPlatformThemeProperty p_which, int& r_int)
+{
+    bool t_found;
+    t_found = false;
+    
+    switch (p_which)
+    {
+        case kMCPlatformThemePropertyTextSize:
+        {
+            // If in backwards-compatibility mode, all text is size 13
+            if (p_state & kMCPlatformControlStateCompatibility)
+                r_int = 13;
+            else
+                return [font_for_control(p_type, p_state) pointSize];
+        }
+        
+        // Property is not known
+        default:
+            break;
+    }
+    
+    return t_found;
+}
+
+bool MCPlatformGetControlThemePropColor(MCPlatformControlType p_type, MCPlatformControlPart p_part, MCPlatformControlState p_state, MCPlatformThemeProperty p_which, MCColor& r_color)
+{
+    return false;
+}
+
+bool MCPlatformGetControlThemePropFont(MCPlatformControlType p_type, MCPlatformControlPart p_part, MCPlatformControlState p_state, MCPlatformThemeProperty p_which, MCFontRef& r_font)
+{
+    // Get the font for the given control type
+    MCNameRef t_font_name = nil;
+    UIFont* t_font = font_for_control(p_type, p_state, &t_font_name);
+    if (t_font == nil)
+        return false;
+    
+    // Ensure the font is registered and return it
+    return MCFontCreateWithHandle((MCSysFontHandle)t_font, t_font_name, r_font);
+}

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -1729,24 +1729,3 @@ MCGFloat MCScreenDC::logicaltoscreenscale(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-// No theming for mobile platforms yet
-bool MCPlatformGetControlThemePropBool(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, bool&)
-{
-    return false;
-}
-
-bool MCPlatformGetControlThemePropInteger(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, int&)
-{
-    return false;
-}
-
-bool MCPlatformGetControlThemePropColor(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCColor&)
-{
-    return false;
-}
-
-bool MCPlatformGetControlThemePropFont(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCFontRef& r_font)
-{
-    return MCFontCreate(MCNAME("Helvetica"), 0, 13, r_font);
-}

--- a/engine/src/mcstring.cpp
+++ b/engine/src/mcstring.cpp
@@ -623,6 +623,14 @@ MCNameRef MCM_protected_data_unavailable;
 MCNameRef MCM_remote_control_received;
 #endif
 
+MCNameRef MCN_font_default;
+MCNameRef MCN_font_usertext;
+MCNameRef MCN_font_menutext;
+MCNameRef MCN_font_content;
+MCNameRef MCN_font_message;
+MCNameRef MCN_font_tooltip;
+MCNameRef MCN_font_system;
+
 void MCU_initialize_names(void)
 {
 	/* UNCHECKED */ MCNameCreateWithCString("msg", MCN_msg);
@@ -1071,6 +1079,14 @@ void MCU_initialize_names(void)
 	// MW-2013-05-30: [[ RemoteControl ]] Message sent when a remote control event is received.
 	/* UNCHECKED */ MCNameCreateWithCString("remoteControlReceived", MCM_remote_control_received);
 #endif
+    
+    /* UNCHECKED */ MCNameCreateWithCString("(Default)", MCN_font_default);
+    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - User text)", MCN_font_usertext);
+    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Menu text)", MCN_font_menutext);
+    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Content)", MCN_font_content);
+    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Messages)", MCN_font_message);
+    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Tooltips)", MCN_font_tooltip);
+    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - System)", MCN_font_system);
 }
 
 void MCU_finalize_names(void)
@@ -1507,4 +1523,12 @@ void MCU_finalize_names(void)
 	MCNameDelete(MCM_player_stopped);
 	MCNameDelete(MCM_reachability_changed);
 #endif
+    
+    MCNameDelete(MCN_font_default);
+    MCNameDelete(MCN_font_usertext);
+    MCNameDelete(MCN_font_menutext);
+    MCNameDelete(MCN_font_content);
+    MCNameDelete(MCN_font_message);
+    MCNameDelete(MCN_font_tooltip);
+    MCNameDelete(MCN_font_system);
 }

--- a/engine/src/mcstring.cpp
+++ b/engine/src/mcstring.cpp
@@ -1081,12 +1081,12 @@ void MCU_initialize_names(void)
 #endif
     
     /* UNCHECKED */ MCNameCreateWithCString("(Default)", MCN_font_default);
-    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Styled text)", MCN_font_usertext);
-    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Menu text)", MCN_font_menutext);
-    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Content)", MCN_font_content);
-    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Messages)", MCN_font_message);
-    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Tooltips)", MCN_font_tooltip);
-    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - System)", MCN_font_system);
+    /* UNCHECKED */ MCNameCreateWithCString("(Styled Text)", MCN_font_usertext);
+    /* UNCHECKED */ MCNameCreateWithCString("(Menu)", MCN_font_menutext);
+    /* UNCHECKED */ MCNameCreateWithCString("(Text)", MCN_font_content);
+    /* UNCHECKED */ MCNameCreateWithCString("(Message)", MCN_font_message);
+    /* UNCHECKED */ MCNameCreateWithCString("(Tooltip)", MCN_font_tooltip);
+    /* UNCHECKED */ MCNameCreateWithCString("(System)", MCN_font_system);
 }
 
 void MCU_finalize_names(void)

--- a/engine/src/mcstring.cpp
+++ b/engine/src/mcstring.cpp
@@ -1081,7 +1081,7 @@ void MCU_initialize_names(void)
 #endif
     
     /* UNCHECKED */ MCNameCreateWithCString("(Default)", MCN_font_default);
-    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - User text)", MCN_font_usertext);
+    /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Styled text)", MCN_font_usertext);
     /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Menu text)", MCN_font_menutext);
     /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Content)", MCN_font_content);
     /* UNCHECKED */ MCNameCreateWithCString("(System UI Font - Messages)", MCN_font_message);

--- a/engine/src/mcstring.h
+++ b/engine/src/mcstring.h
@@ -606,3 +606,11 @@ extern MCNameRef MCM_protected_data_unavailable;
 extern MCNameRef MCM_remote_control_received;
 #endif
 
+// Names for the "special" fonts that resolve to the platform's default font
+extern MCNameRef MCN_font_default;          // Default font for this control type
+extern MCNameRef MCN_font_usertext;         // User-styleable text (e.g. RichText)
+extern MCNameRef MCN_font_menutext;         // Menu items
+extern MCNameRef MCN_font_content;          // Control contents
+extern MCNameRef MCN_font_message;          // Message boxes and status messages
+extern MCNameRef MCN_font_tooltip;          // Tooltip text
+extern MCNameRef MCN_font_system;           // Anything else not covered above

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4894,8 +4894,22 @@ bool MCObject::mapfont(bool recursive)
 		    (gettype() == CT_STACK && ((MCStack *)this) -> getuseideallayout()))
 			t_font_style |= kMCFontStylePrinterMetrics;
 
-		// Create our font.
-		/* UNCHECKED */ MCFontCreate(t_textfont, t_font_style, t_textsize, m_font);
+        // If the font is explicitly requesting the default font for this
+        // control type, use the themed font
+        if (MCNameIsEqualTo(t_textfont, MCN_font_default))
+        {
+            // Don't inherit the parent's themed font
+            if (recursive)
+                return false;
+            
+            // Get the appropriate themed font
+            MCPlatformGetControlThemePropFont(getcontroltype(), getcontrolsubpart(), getcontrolstate(), kMCPlatformThemePropertyTextFont, m_font);
+        }
+        else
+        {
+            // Explicit non-default font
+            /* UNCHECKED */ MCFontCreate(t_textfont, t_font_style, t_textsize, m_font);
+        }
 	}
 	else if (parent != nil && t_explicit_font)
 	{

--- a/engine/src/platform.h
+++ b/engine/src/platform.h
@@ -1268,6 +1268,7 @@ bool MCPlatformGetControlThemePropBool(MCPlatformControlType, MCPlatformControlP
 bool MCPlatformGetControlThemePropInteger(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, int&);
 bool MCPlatformGetControlThemePropColor(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCColor&);
 bool MCPlatformGetControlThemePropFont(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCFontRef&);
+bool MCPlatformGetControlThemePropString(MCPlatformControlType, MCPlatformControlPart, MCPlatformControlState, MCPlatformThemeProperty, MCStringRef&);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/w32flst.cpp
+++ b/engine/src/w32flst.cpp
@@ -142,6 +142,53 @@ static Language2FontCharset s_fontcharsetmap[] =
 	{LCH_UNICODE, ANSI_CHARSET}
 };
 
+// Sets the lfFaceName of a LOGFONT structure to the correct name for the
+// appropriate special UI font
+static void set_facename_for_status_font(LOGFONTW& x_logfont)
+{
+    // Cache the face name to avoid repeated queries
+    static WCHAR s_facename[sizeof(x_logfont.lfFaceName) / sizeof(x_logfont.lfFaceName[0])];
+    if (s_facename[0] == 0)
+    {
+        NONCLIENTMETRICSW ncm;
+        ncm.cbSize = sizeof(ncm);
+        SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm, 0);
+        memcpy(s_facename, ncm.lfStatusFont.lfFaceName, sizeof(s_facename));
+    }
+    
+    memcpy(x_logfont.lfFaceName, s_facename, sizeof(s_facename));
+}
+
+static void set_facename_for_menu_font(LOGFONTW& x_logfont)
+{
+    // Cache the face name to avoid repeated queries
+    static WCHAR s_facename[sizeof(x_logfont.lfFaceName) / sizeof(x_logfont.lfFaceName[0])];
+    if (s_facename[0] == 0)
+    {
+        NONCLIENTMETRICSW ncm;
+        ncm.cbSize = sizeof(ncm);
+        SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm, 0);
+        memcpy(s_facename, ncm.lfMenuFont.lfFaceName, sizeof(s_facename));
+    }
+    
+    memcpy(x_logfont.lfFaceName, s_facename, sizeof(s_facename));
+}
+
+static void set_facename_for_message_font(LOGFONTW& x_logfont)
+{
+    // Cache the face name to avoid repeated queries
+    static WCHAR s_facename[sizeof(x_logfont.lfFaceName) / sizeof(x_logfont.lfFaceName[0])];
+    if (s_facename[0] == 0)
+    {
+        NONCLIENTMETRICSW ncm;
+        ncm.cbSize = sizeof(ncm);
+        SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm, 0);
+        memcpy(s_facename, ncm.lfMessageFont.lfFaceName, sizeof(s_facename));
+    }
+    
+    memcpy(x_logfont.lfFaceName, s_facename, sizeof(s_facename));
+}
+
 MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style, Boolean printer)
 {
 	// MW-2012-05-03: [[ Values* ]] 'reqname' is now an autoref type.
@@ -158,24 +205,39 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style, Boolean printe
 	LOGFONTW logfont;
 	memset(&logfont, 0, sizeof(LOGFONTW));
 
-    
-    //parse font and encoding
-    MCStringRef t_name = MCNameGetString(fname);
-    MCAutoStringRef t_font_name;
-    uindex_t t_offset;
-	if (MCStringFirstIndexOfChar(t_name, ',', 0, kMCCompareExact, t_offset))
+    // Is the font name one of the special UI font names?
+    if (MCNameIsEqualTo(fname, MCN_font_usertext))
+        set_facename_for_message_font(logfont);
+    else if (MCNameIsEqualTo(fname, MCN_font_menutext))
+        set_facename_for_menu_font(logfont);
+    else if (MCNameIsEqualTo(fname, MCN_font_content))
+        set_facename_for_message_font(logfont);
+    else if (MCNameIsEqualTo(fname, MCN_font_message))
+        set_facename_for_message_font(logfont);
+    else if (MCNameIsEqualTo(fname, MCN_font_tooltip))
+        set_facename_for_status_font(logfont);
+    else if (MCNameIsEqualTo(fname, MCN_font_system))
+        set_facename_for_message_font(logfont);
+    else
     {
-        MCStringCopySubstring(t_name, MCRangeMake(0, t_offset), &t_font_name);
-        t_name = *t_font_name;
-    }
-    
-	MCAutoStringRefAsWString t_fname_wstr;
-	if (!t_fname_wstr.Lock(t_name))
-		return;
+        //parse font and encoding
+        MCStringRef t_name = MCNameGetString(fname);
+        MCAutoStringRef t_font_name;
+        uindex_t t_offset;
+        if (MCStringFirstIndexOfChar(t_name, ',', 0, kMCCompareExact, t_offset))
+        {
+            MCStringCopySubstring(t_name, MCRangeMake(0, t_offset), &t_font_name);
+            t_name = *t_font_name;
+        }
+        
+        MCAutoStringRefAsWString t_fname_wstr;
+        if (!t_fname_wstr.Lock(t_name))
+            return;
 
-	// Copy the family name
-	if (StringCchCopyW(logfont.lfFaceName, LF_FACESIZE, *t_fname_wstr) != S_OK)
-			return;
+        // Copy the family name
+        if (StringCchCopyW(logfont.lfFaceName, LF_FACESIZE, *t_fname_wstr) != S_OK)
+                return;
+    }
 
 	// MW-2012-05-03: [[ Bug 10180 ]] Make sure the default charset for the font
 	//   is chosen - otherwise things like WingDings don't work!


### PR DESCRIPTION
Also adds a font called "(Default)" that requests the default font for that particular control type (instead of inheriting an explicit font set on an ancestor).
