### PR TITLE
Fix an Android JNI-related crash on certain VMs

### DIFF
--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -1786,7 +1786,7 @@ void MCAndroidObjectCallWithArgs(jobject p_object, const char *p_method, const c
     if (t_success)
         MCAndroidJavaMethodCall(nil, p_object, p_method, p_return_value, t_params, p_on_engine_thread);
 
-    MCJavaMethodParamsFree(t_env, t_params);
+    MCJavaMethodParamsFree(t_env, t_params, !p_on_engine_thread);
 }
 
 void MCAndroidStaticCallWithArgs(const char *p_class, const char *p_method, const char *p_signature, void *p_return_value, bool p_on_engine_thread, va_list p_args)
@@ -1803,7 +1803,7 @@ void MCAndroidStaticCallWithArgs(const char *p_class, const char *p_method, cons
     if (t_success)
         MCAndroidJavaMethodCall(p_class, nil, p_method, p_return_value, t_params, p_on_engine_thread);
 
-    MCJavaMethodParamsFree(t_env, t_params);
+    MCJavaMethodParamsFree(t_env, t_params, !p_on_engine_thread);
 }
 
 void MCAndroidObjectCall(jobject p_object, const char *p_method, const char *p_signature, void *p_return_value, ...)

--- a/engine/src/mblandroidjava.cpp
+++ b/engine/src/mblandroidjava.cpp
@@ -1833,7 +1833,7 @@ bool MCJavaConvertParameters(JNIEnv *env, const char *p_signature, va_list p_arg
     }
     else
     {
-        MCJavaMethodParamsFree(env, t_params);
+        MCJavaMethodParamsFree(env, t_params, p_global_refs);
     }
     
     return t_success;

--- a/engine/src/mblandroidjava.h
+++ b/engine/src/mblandroidjava.h
@@ -103,7 +103,7 @@ bool MCJavaIterateMap(JNIEnv *env, jobject p_map, MCJavaMapCallback p_callback, 
 bool MCJavaObjectGetField(JNIEnv *env, jobject p_object, const char *p_fieldname, MCJavaType p_fieldtype, void *r_value);
 
 bool MCJavaConvertParameters(JNIEnv *env, const char *p_signature, va_list p_args, MCJavaMethodParams *&r_params, bool p_global_refs = false);
-void MCJavaMethodParamsFree(JNIEnv *env, MCJavaMethodParams *p_params, bool p_global_refs = false);
+void MCJavaMethodParamsFree(JNIEnv *env, MCJavaMethodParams *p_params, bool p_global_refs);
 
 void MCJavaColorToComponents(uint32_t p_color, uint16_t &r_red, uint16_t &r_green, uint16_t &r_blue, uint16_t &r_alpha);
 


### PR DESCRIPTION
We were creating Java objects as global references and freeing as local references, which causes some versions of the Dalvik VM to abort.

I wouldn't be surprised if this has caused reports of mysterious Android crashes previously, but the Android log gives nothing useful that would indicate it is this bug.
