### PR TITLE
Correct filenames for archived documentation data

### DIFF
--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -2235,6 +2235,7 @@ private command docsBuilderGenerateZip pEdition, pVersion
    -- Ensure edition string is in titlecase
    put toLower(pEdition) into pEdition
    put toUpper(char 1 of pEdition) into char 1 of pEdition
+   put replaceText(pVersion, "[-,\.]", "_") into pVersion
 
    local tInputs, tZipPath
 


### PR DESCRIPTION
The documentation archives should be named like `8_0_0_dp_15`, not
`8.0.0-dp-15`, in order to match all the other versioned built
artefacts that are uploaded to the release server.
