### PR TITLE
[Bug 16744] com.livecode.canvas: Default to non-zero path fill rule

### DIFF
--- a/docs/lcb/notes/16744.md
+++ b/docs/lcb/notes/16744.md
@@ -1,0 +1,1 @@
+# [16744] Default to non-zero path fill winding rule

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -4876,7 +4876,7 @@ bool MCCanvasPropertiesInit(MCCanvasProperties &p_properties)
 	{
 		p_properties.antialias = true;
 		p_properties.blend_mode = kMCGBlendModeSourceOver;
-		p_properties.fill_rule = kMCGFillRuleEvenOdd;
+		p_properties.fill_rule = kMCGFillRuleNonZero;
 		p_properties.opacity = 1.0;
 		p_properties.paint = nil;
 		p_properties.stippled = false;

--- a/extensions/widgets/svgpath/notes/bugfix-16744.md
+++ b/extensions/widgets/svgpath/notes/bugfix-16744.md
@@ -1,0 +1,1 @@
+# [16744] Default to non-zero SVG fill winding rule

--- a/extensions/widgets/svgpath/svgpath.lcb
+++ b/extensions/widgets/svgpath/svgpath.lcb
@@ -366,7 +366,10 @@ public handler OnPaint()
 	else
 		set the paint of this canvas to solid paint with mHiliteColor
 	end if
-	
+
+	-- FIXME Make this configurable via a property
+	set the fill rule of this canvas to "non-zero"
+
 	fill tPath on this canvas
 end handler
 


### PR DESCRIPTION
The default SVG path fill winding rule is non-zero, and the default
libgraphics path fill winding rule is non-zero, so make the canvas
library match!

Also, update the SVG icon widget to force the winding rule to
non-zero, and add a FIXME note that we should turn it into a property
in the future, probably.
