### PR TITLE
[[ Bug 16983 ]] GradienRampEditor put upper handle higher

### DIFF
--- a/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
+++ b/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
@@ -516,6 +516,7 @@ private handler paintRampEditors() returns nothing
       drawStop (tX, tY, tSelStop) -- BN
 
       -- If this is the selected stop then draw an extra ramp point above the gradient and a line linking it.
+      put the top of mGradientRectangle into tY
       move to point [tX, tY] on this canvas
       line to point [tX, tY - mRulerLineHeight] on this canvas
       set the paint of this canvas to solid paint with mGradientHandleBorderColor

--- a/extensions/widgets/gradientrampeditor/notes/16983.md
+++ b/extensions/widgets/gradientrampeditor/notes/16983.md
@@ -1,0 +1,1 @@
+# [16983] Put upper handle higher


### PR DESCRIPTION
add an accidentally deleted Y-value to draw upper selected handle at the top
