### PR TITLE
[Bug 16145] Mark as a known issue.

### DIFF
--- a/docs/notes/issues.md
+++ b/docs/notes/issues.md
@@ -6,5 +6,7 @@
 
 * The browser widget does not work on 32-bit Linux.
 
+* The LiveCode engine may fail to run on some Android 2.3 (Gingerbread) devices ([bug 16145](http://quality.livecode.com/show_bug.cgi?id=16145))
+
 * 64-bit standalones for Mac OS X do not have support for audio
   recording or the revVideoGrabber external.


### PR DESCRIPTION
On investigation with @livecodeian, it appears that the crashes are
due to an issue relating to a bug in the Android Gingerbread dynamic
linker with additional ELF sections.

Although a fix may be theoretically possible, we may not be able to
find one before LiveCode 8, especially since we do not have any way to
replace or modify the dynamic linkers on affected devices.  Ensure
that this is marked as a "known issue", in case it's not possible to
find a complete fix before 8.0 release.
