### PR TITLE
[Bug 16927] com.livecode.browser: Don't show htmlText in prop inspector

### DIFF
--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -351,6 +351,7 @@ property URL get getUrl set setUrl
 
 property htmlText get getHtmlText set setHtmlText
 metadata htmlText.editor is "com.livecode.pi.nowraptext"
+metadata htmlText.user_visible is "false" -- bug 16927
 
 property vScrollbar get getVScrollbar set setVScrollbar
 metadata vScrollbar.editor is "com.livecode.pi.boolean"

--- a/extensions/widgets/browser/notes/16927.md
+++ b/extensions/widgets/browser/notes/16927.md
@@ -1,0 +1,1 @@
+# [16927] Prevent unresponsive PI with large websites


### PR DESCRIPTION
Some webpages -- such as https://livecode.com/ -- have crazily
enormous inner HTML content.  The field takes a long time to lay it
out (even with wrapping disabled), which can make it look like the
engine has hung when opening a property inspector for a browser
widget.

It would be difficult to speed up the field adequately to address this
easy, but hiding the `htmlText` property seems like an adequate
workaround for now.
