### PR TITLE
[[ Bug 17008 ]] Notify card of dirty rect before deselecting deleted object

### DIFF
--- a/docs/notes/bugfix-17008.md
+++ b/docs/notes/bugfix-17008.md
@@ -1,0 +1,1 @@
+# Selection handles should disappear when selected object is deleted

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -2843,14 +2843,15 @@ Boolean MCCard::removecontrol(MCControl *cptr, Boolean needredraw, Boolean cf)
 			// Remove the control from the card and close it.
 			optr->remove(objptrs);
 			delete optr;
+            
+            // MW-2011-08-19: [[ Layers ]] Notify the stack that a layer has been removed.
+            layer_removed(cptr, t_previous_optr, t_next_optr);
+            
 			if (opened)
 			{
 				cptr->close();
 				cptr->setparent(t_stack);
 			}
-
-			// MW-2011-08-19: [[ Layers ]] Notify the stack that a layer has been removed.
-			layer_removed(cptr, t_previous_optr, t_next_optr);
 
 			return True;
 		}


### PR DESCRIPTION
Otherwise the resize handles are not taken into account, leaving a selection
artefact when deleting selected objects.
