### PR TITLE
[[ LicenseCheck ]] Implement the ExternalV1 license check API for 6.7

### DIFF
--- a/engine/src/capsule.h
+++ b/engine/src/capsule.h
@@ -106,6 +106,10 @@ enum MCCapsuleSectionType
     // AL-2015-02-10: [[ Standalone Inclusions ]] Library consists of the mappings from universal names
     //  of resources to their platform-specific paths relative to the executable.
     kMCCapsuleSectionTypeLibrary,
+
+	// MW-2016-02-17: [[ LicenseChecks ]] License consists of the array-encoded
+	//   'revLicenseInfo' array in use at the point the standalone was built.
+	kMCCapsuleSectionTypeLicense,
 };
 
 // Each section begins with a header that defines its type and length. This is

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -152,16 +152,51 @@ static bool MCDeployWriteDefinePrologueSection(const MCDeployParameters& p_param
 	return MCDeployCapsuleDefine(p_capsule, kMCCapsuleSectionTypePrologue, &t_prologue, sizeof(t_prologue));
 }
 
+static bool MCDeployWriteDefineLicenseSection(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
+{
+	// The edition byte encoding is development/standalone engine pair
+	// specific.
+	unsigned char t_edition;
+	switch(MClicenseparameters . license_class)
+	{
+		case kMCLicenseClassNone:
+			t_edition = 0;
+			break;
+			
+		case kMCLicenseClassCommunity:
+			t_edition = 1;
+			break;
+			
+		case kMCLicenseClassCommercial:
+			t_edition = 2;
+			break;
+			
+		case kMCLicenseClassProfessional:
+			t_edition = 3;
+			break;
+	}
+	
+	return MCDeployCapsuleDefine(p_capsule,
+								 kMCCapsuleSectionTypeLicense,
+								 &t_edition,
+								 sizeof(t_edition));
+}
+
 // This method generates the standalone specific capsule elements. This is
 // just a Standalone Prologue section at the moment.
 static bool MCDeployWriteCapsuleDefineStandaloneSections(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
 {
 	bool t_success;
 	t_success = true;
-
+	
+	// First emit the prologue.
 	if (t_success)
 		t_success = MCDeployWriteDefinePrologueSection(p_params, p_capsule);
-
+	
+	// Next emit the license info.
+	if (t_success)
+		t_success = MCDeployWriteDefineLicenseSection(p_params, p_capsule);
+	
 	return t_success;
 }
 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2472,6 +2472,9 @@ enum Exec_errors
     // SN-2014-12-15: [[ Bug 14211 ]] put ... into the next line of ... should return an error
     // {EE-0810} Chunk: bad extents provided
     EE_CHUNK_BADEXTENTS,
+	
+	// {EE-0811} external: unlicensed
+	EE_EXTERNAL_UNLICENSED,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -423,6 +423,8 @@ static MCExternalV1 *s_current_external = nil;
 MCExternalV1::MCExternalV1(void)
 {
 	m_info = nil;
+	m_licensed = false;
+	m_was_licensed = false;
 }
 
 MCExternalV1::~MCExternalV1(void)

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -53,6 +53,9 @@ typedef void (*MCExternalThreadOptionalCallback)(void *state);
 typedef void (*MCExternalThreadRequiredCallback)(void *state, int flags);
 
 // MW-2013-06-14: [[ ExternalsApiV5 ]] Update the interface version.
+// MW-2016-02-25: [[ LicenseCheck ]] We cannot bump the interface version without
+//   breaking existing built externals. Instead, we keep the version at 5 for 6.7
+//   and add a HasLicenseCheck tag to the Query call.
 #define kMCExternalInterfaceVersion 5
 
 enum
@@ -162,6 +165,8 @@ enum MCExternalError
 	kMCExternalErrorNoObjectPropertyValue = 35,
 	
 	kMCExternalErrorInvalidInterfaceQuery = 36,
+	
+	kMCExternalErrorUnlicensed = 42,
 };
 
 enum MCExternalContextQueryTag
@@ -185,6 +190,17 @@ enum MCExternalContextQueryTag
 	
 	// MW-2013-06-14: [[ ExternalsApiV5 ]] Accessor to fetch 'the wholeMatches'.
 	kMCExternalContextQueryWholeMatches,
+	
+	// SN-2014-07-01: [[ ExternalsApiV6 ]] These return a UTF16CString.
+	// These are unimplemented in 6.7.
+	kMCExternalContextQueryUnicodeItemDelimiter,
+	kMCExternalContextQueryUnicodeLineDelimiter,
+	kMCExternalContextQueryUnicodeColumnDelimiter,
+	kMCExternalContextQueryUnicodeRowDelimiter,
+	
+	// If fetching this accessor works, and it returns true then
+	// the license check API is present.
+	kMCExternalContextQueryHasLicenseCheck,
 };
 
 enum MCExternalVariableQueryTag
@@ -245,6 +261,14 @@ enum MCExternalDispatchStatus
 	kMCExternalDispatchStatusAbort,
 };
 
+enum MCExternalLicenseType
+{
+	kMCExternalLicenseTypeNone = 0,
+	kMCExternalLicenseTypeCommunity = 1000,
+	kMCExternalLicenseTypeIndy = 2000,
+	kMCExternalLicenseTypeBusiness = 3000,
+};
+
 enum MCExternalHandlerType
 {
 	kMCExternalHandlerTypeNone,
@@ -277,7 +301,7 @@ struct MCExternalInterface
 
 	//////////
 
-	MCExternalError (*context_query)(MCExternalContextQueryTag op, void *result);
+	MCExternalError (*context_query_legacy)(MCExternalContextQueryTag op, void *result);
 
 	//////////
 
@@ -338,6 +362,14 @@ struct MCExternalInterface
 	//   in the current context.
 	// MW-2013-06-21: [[ ExternalsApiV5 ]] Added binds parameters for future extension.
 	MCExternalError (*context_execute)(const char *p_expression, unsigned int options, MCExternalVariableRef *binds, unsigned int bind_count); // V5
+	
+	// SN-2015-01-26: [[ Bug 14057 ]] Update context query, to allow the user to set the return type
+	MCExternalError (*context_query)(MCExternalContextQueryTag op, MCExternalValueOptions p_options, void *r_result); // V6
+	
+	// MW-2016-02-17: [[ LicenseCheck ]] Method to check the licensing of the engine. This is
+	//   present either if interface version is V7, or the HasLicenseCheck query call returns
+	//   true.
+	MCExternalError (*license_check_edition)(unsigned int options, unsigned int min_edition); // V7
 };
 
 typedef MCExternalInfo *(*MCExternalDescribeProc)(void);
@@ -360,14 +392,31 @@ public:
 	virtual Handler_type GetHandlerType(uint32_t index) const;
 	virtual bool ListHandlers(MCExternalListHandlersCallback callback, void *state);
 	virtual Exec_stat Handle(MCObject *p_context, Handler_type p_type, uint32_t p_index, MCParameter *p_parameters);
-
+	
+	void SetWasLicensed(bool p_value);
+	
 private:
 	virtual bool Prepare(void);
 	virtual bool Initialize(void);
 	virtual void Finalize(void);
 
 	MCExternalInfo *m_info;
+	
+	// This is true if startup succeeded (returned true) and license_fail was
+	// not called.
+	bool m_licensed : 1;
+
+	// This is set to true if the last external handler call on this external
+	// did not call license_fail.
+	bool m_was_licensed : 1;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+// This static variable is set to the currently executing external during
+// any calls to its exported functions (startup, shutdown etc.). It is used by
+// the license fail API to mark the external's was_licensed member as false.
+static MCExternalV1 *s_current_external = nil;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -387,8 +436,15 @@ bool MCExternalV1::Prepare(void)
 	MCExternalDescribeProc t_describe;
 	t_describe = (MCExternalDescribeProc)MCS_resolvemodulesymbol(m_module, "MCExternalDescribe");
 	
+	// Update the current external var.
+	s_current_external = this;
+	
 	// Query the info record - if this returns nil something odd is going on!
 	m_info = t_describe();
+	
+	// Unset the current external var.
+	s_current_external = nil;
+	
 	if (m_info == nil)
 		return false;
 
@@ -402,11 +458,28 @@ bool MCExternalV1::Initialize(void)
 	t_initialize = (MCExternalInitializeProc)MCS_resolvemodulesymbol(m_module, "MCExternalInitialize");
 	if (t_initialize == nil)
 		return true;
-
+	
+	// Make sure the 'was_licensed' instance var is true. A call to LicenseFail
+	// during startup will set it to false.
+	m_was_licensed = true;
+	
+	// Update the current external var.
+	s_current_external = this;
+	
 	// See if initialization succeeds.
-	if (!t_initialize(&g_external_interface))
+	bool t_success;
+	t_success = t_initialize(&g_external_interface);
+	
+	// Unset the current external var.
+	s_current_external = nil;
+	
+	if (!t_success)
 		return false;
-
+	
+	// If license fail was invoked during startup, we mark the whole external
+	// as unlicensed which means all calls to it will throw an error.
+	m_licensed = m_was_licensed;
+	
 	return true;
 }
 
@@ -417,8 +490,14 @@ void MCExternalV1::Finalize(void)
 	t_finalize = (MCExternalFinalizeProc)MCS_resolvemodulesymbol(m_module, "MCExternalFinalize");
 	if (t_finalize == nil)
 		return;
-
+	
+	// Update the current external var.
+	s_current_external = this;
+	
 	t_finalize();
+	
+	// Unset the current external var.
+	s_current_external = nil;
 }
 
 const char *MCExternalV1::GetName(void) const
@@ -454,7 +533,14 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 	t_handler = &m_info -> handlers[p_index];
 	if (t_handler -> type != t_type)
 		return ES_NOT_HANDLED;
-
+	
+	// If the external is not licensed (as a whole) then we throw the unlicensed error.
+	if (!m_licensed)
+	{
+		MCeerror -> add(EE_EXTERNAL_UNLICENSED, 0, 0, m_info -> name);
+		return ES_ERROR;
+	}
+	
 		Exec_stat t_stat;
 		t_stat = ES_NORMAL;
 
@@ -508,10 +594,25 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 			MCVariableValue t_result;
 			t_result . set_temporary();
 			t_result . assign_empty();
-
+			
+			// Update the current external var.
+			s_current_external = this;
+			
 			// Invoke the external handler. If 'false' is returned, treat the result as a
 			// string value containing an error hint.
-			if ((t_handler -> handler)(t_parameter_vars, t_parameter_count, &t_result))
+			bool t_success;
+			t_success = (t_handler -> handler)(t_parameter_vars, t_parameter_count, &t_result);
+			
+			// Unset the current external var.
+			s_current_external = nil;
+
+			// If a license check failed during the call, then we always throw an error.
+			if (!m_was_licensed)
+			{
+				MCeerror -> add(EE_EXTERNAL_UNLICENSED, 0, 0, m_info -> name);
+				t_stat = ES_ERROR;
+			}
+			else if (t_success)
 				MCresult -> getvalue() . exchange(t_result);
 			else
 			{
@@ -529,6 +630,11 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 
 		return t_stat;
 	}
+
+void MCExternalV1::SetWasLicensed(bool p_value)
+{
+	m_was_licensed = p_value;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1032,6 +1138,9 @@ static MCExternalError MCExternalContextQuery(MCExternalContextQueryTag op, void
 				return kMCExternalErrorOutOfMemory;
 			*(MCObjectHandle **)result = t_handle;
 		}
+		break;
+	case kMCExternalContextQueryHasLicenseCheck:
+		*(bool *)result = true;
 		break;
 	default:
 		return kMCExternalErrorInvalidContextQuery;
@@ -2046,6 +2155,44 @@ static MCExternalError MCExternalInterfaceQuery(MCExternalInterfaceQueryTag op, 
 	return kMCExternalErrorNone;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+
+MCExternalError MCExternalLicenseCheckEdition(unsigned int p_options, unsigned int p_min_edition)
+{
+	unsigned int t_current_edition;
+	switch(MClicenseparameters . license_class)
+	{
+		case kMCLicenseClassNone:
+			t_current_edition = kMCExternalLicenseTypeNone;
+			break;
+			
+		case kMCLicenseClassCommunity:
+			t_current_edition = kMCExternalLicenseTypeCommunity;
+			break;
+			
+		case kMCLicenseClassCommercial:
+			t_current_edition = kMCExternalLicenseTypeIndy;
+			break;
+			
+		case kMCLicenseClassProfessional:
+			t_current_edition = kMCExternalLicenseTypeBusiness;
+			break;
+			
+		default:
+			abort();
+			break;
+	}
+	
+	if (t_current_edition < p_min_edition)
+	{
+		s_current_external -> SetWasLicensed(false);
+		return kMCExternalErrorUnlicensed;
+	}
+	
+	return kMCExternalErrorNone;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 MCExternalInterface g_external_interface =
@@ -2092,6 +2239,12 @@ MCExternalInterface g_external_interface =
 	//   for the outside world.
 	MCExternalContextEvaluate,
 	MCExternalContextExecute,
+	
+	// This is the new 'ContextQuery' call in 7+, it is unimplemented in 6.7.
+	nil,
+
+	// MW-2016-02-17: [[ LicenseCheck ]] Declare the check call.
+	MCExternalLicenseCheckEdition,
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1258,7 +1258,19 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
             }
         }
             break;
-
+			
+		case kMCCapsuleSectionTypeLicense:
+		{
+			// Just read the edition byte and ignore it in installer mode.
+			char t_edition_byte;
+			if (IO_read_bytes(&t_edition_byte, 1, p_stream) != IO_NORMAL)
+			{
+				MCresult -> sets("failed to read license");
+				return false;
+			}
+		}
+			break;
+			
 	default:
 		MCresult -> sets("unrecognized section encountered");
 		return false;

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -290,7 +290,31 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 		}
 		break;
 			
-			
+	case kMCCapsuleSectionTypeLicense:
+	{
+		char t_edition_byte;
+		if (IO_read_bytes(&t_edition_byte, 1, p_stream) != IO_NORMAL)
+		{
+			MCresult -> sets("failed to read license");
+			return false;
+		}
+		
+		bool t_success;
+		t_success = true;
+		
+		// The edition encoding is engine version / IDE engine version
+		// specific - for now its just a byte with value 0-3.
+		if (t_edition_byte == 1)
+			MClicenseparameters . license_class = kMCLicenseClassCommunity;
+		else if (t_edition_byte == 2)
+			MClicenseparameters . license_class = kMCLicenseClassCommercial;
+		else if (t_edition_byte == 3)
+			MClicenseparameters . license_class = kMCLicenseClassProfessional;
+		else
+			MClicenseparameters . license_class = kMCLicenseClassNone;
+	}
+	break;
+		
 	default:
 		MCresult -> sets("unrecognized section encountered");
 		return false;


### PR DESCRIPTION
This patch adds the LicenseCheck API to the 6.7 ExternalV1 interface.

As the current V1 glue code uses the interface version number to
decide if Unicode support is present we cannot bump that number in
6.7 - it must remain at 5.

So that the glue code can be updated to support 6.7, there is a new
context query for 'HasLicenseCheck' - if a call to query this does
not fail, then the caller can assume that the LicenseCheck API is
present in the function table.
