### PR TITLE
[[ LicenseCheck ]] Implement the ExternalV1 license check API (6.7)

### DIFF
--- a/engine/src/capsule.h
+++ b/engine/src/capsule.h
@@ -106,6 +106,10 @@ enum MCCapsuleSectionType
     // AL-2015-02-10: [[ Standalone Inclusions ]] Library consists of the mappings from universal names
     //  of resources to their platform-specific paths relative to the executable.
     kMCCapsuleSectionTypeLibrary,
+
+	// MW-2016-02-17: [[ LicenseChecks ]] License consists of the array-encoded
+	//   'revLicenseInfo' array in use at the point the standalone was built.
+	kMCCapsuleSectionTypeLicense,
 };
 
 // Each section begins with a header that defines its type and length. This is

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -152,16 +152,51 @@ static bool MCDeployWriteDefinePrologueSection(const MCDeployParameters& p_param
 	return MCDeployCapsuleDefine(p_capsule, kMCCapsuleSectionTypePrologue, &t_prologue, sizeof(t_prologue));
 }
 
+static bool MCDeployWriteDefineLicenseSection(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
+{
+	// The edition byte encoding is development/standalone engine pair
+	// specific.
+	unsigned char t_edition;
+	switch(MClicenseparameters . license_class)
+	{
+		case kMCLicenseClassNone:
+			t_edition = 0;
+			break;
+			
+		case kMCLicenseClassCommunity:
+			t_edition = 1;
+			break;
+			
+		case kMCLicenseClassCommercial:
+			t_edition = 2;
+			break;
+			
+		case kMCLicenseClassProfessional:
+			t_edition = 3;
+			break;
+	}
+	
+	return MCDeployCapsuleDefine(p_capsule,
+								 kMCCapsuleSectionTypeLicense,
+								 &t_edition,
+								 sizeof(t_edition));
+}
+
 // This method generates the standalone specific capsule elements. This is
 // just a Standalone Prologue section at the moment.
 static bool MCDeployWriteCapsuleDefineStandaloneSections(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
 {
 	bool t_success;
 	t_success = true;
-
+	
+	// First emit the prologue.
 	if (t_success)
 		t_success = MCDeployWriteDefinePrologueSection(p_params, p_capsule);
-
+	
+	// Next emit the license info.
+	if (t_success)
+		t_success = MCDeployWriteDefineLicenseSection(p_params, p_capsule);
+	
 	return t_success;
 }
 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2472,6 +2472,9 @@ enum Exec_errors
     // SN-2014-12-15: [[ Bug 14211 ]] put ... into the next line of ... should return an error
     // {EE-0810} Chunk: bad extents provided
     EE_CHUNK_BADEXTENTS,
+	
+	// {EE-0811} external: unlicensed
+	EE_EXTERNAL_UNLICENSED,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1258,7 +1258,19 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
             }
         }
             break;
-
+			
+		case kMCCapsuleSectionTypeLicense:
+		{
+			// Just read the edition byte and ignore it in installer mode.
+			char t_edition_byte;
+			if (IO_read_bytes(&t_edition_byte, 1, p_stream) != IO_NORMAL)
+			{
+				MCresult -> sets("failed to read license");
+				return false;
+			}
+		}
+			break;
+			
 	default:
 		MCresult -> sets("unrecognized section encountered");
 		return false;

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -290,7 +290,31 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 		}
 		break;
 			
-			
+	case kMCCapsuleSectionTypeLicense:
+	{
+		char t_edition_byte;
+		if (IO_read_bytes(&t_edition_byte, 1, p_stream) != IO_NORMAL)
+		{
+			MCresult -> sets("failed to read license");
+			return false;
+		}
+		
+		bool t_success;
+		t_success = true;
+		
+		// The edition encoding is engine version / IDE engine version
+		// specific - for now its just a byte with value 0-3.
+		if (t_edition_byte == 1)
+			MClicenseparameters . license_class = kMCLicenseClassCommunity;
+		else if (t_edition_byte == 2)
+			MClicenseparameters . license_class = kMCLicenseClassCommercial;
+		else if (t_edition_byte == 3)
+			MClicenseparameters . license_class = kMCLicenseClassProfessional;
+		else
+			MClicenseparameters . license_class = kMCLicenseClassNone;
+	}
+	break;
+		
 	default:
 		MCresult -> sets("unrecognized section encountered");
 		return false;


### PR DESCRIPTION
This patch adds the LicenseCheck API to the 6.7 ExternalV1 interface.

As the current V1 glue code uses the interface version number to
decide if Unicode support is present we cannot bump that number in
6.7 - it must remain at 5.

So that the glue code can be updated to support 6.7, there is a new
context query for 'HasLicenseCheck' - if a call to query this does
not fail, then the caller can assume that the LicenseCheck API is
present in the function table.
