### PR TITLE
[[ Bug 17026 ]] Ensure widgets display tooltips.

### DIFF
--- a/docs/notes/bugfix-17026.md
+++ b/docs/notes/bugfix-17026.md
@@ -1,0 +1,1 @@
+# Ensure widgets display tooltips.

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -46,6 +46,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "redraw.h"
 #include "objectstream.h"
 #include "widget.h"
+#include "dispatch.h"
 
 #include "mctheme.h"
 #include "globals.h"
@@ -618,7 +619,12 @@ bool MCGroup::mfocus_control(int2 x, int2 y, bool p_check_selected)
                 // The widget event manager handles enter/leave itself
                 if (newfocused && mfocused != nil &&
                     mfocused -> gettype() != CT_GROUP &&
+#ifdef WIDGETS_HANDLE_DND
                     mfocused -> gettype() != CT_WIDGET)
+#else
+                    (MCdispatcher -> isdragtarget() ||
+                     mfocused -> gettype() != CT_WIDGET))
+#endif
                 {
                         mfocused->enter();
                         

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -927,6 +927,10 @@ public:
     // AL-2015-06-30: [[ Bug 15556 ]] Refactored function to sync mouse focus
     void sync_mfocus(void);
     
+    // This accessor is used by the widget event manager to trigger tooltip
+    // display for widgets.
+    MCStringRef gettooltip(void) {return tooltip;}
+    
 	////////// PROPERTY SUPPORT METHODS
 
 	void Redraw(void);

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -40,6 +40,7 @@
 #include "chunk.h"
 #include "graphicscontext.h"
 #include "dispatch.h"
+#include "tooltip.h"
 
 #include "globals.h"
 #include "context.h"
@@ -337,6 +338,10 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
             MCValueAssignOptional(m_mouse_focus, t_focused_widget);
             
             mouseEnter(m_mouse_focus);
+            
+            // If we are in browse mode, then trigger the tooltip.
+            if (p_widget -> getstack() -> gettool(p_widget) == T_BROWSE)
+                MCtooltip -> settip(p_widget -> gettooltip());
         }
         
         if (t_pos_changed)


### PR DESCRIPTION
The widget event manager handles mouse focus events, however it
wasn't triggering the tooltip display on enter. This has been
fixed.
