### PR TITLE
[[ Selection Handles ]] Fix two selection handle bugs

### DIFF
--- a/docs/notes/bugfix-16968.md
+++ b/docs/notes/bugfix-16968.md
@@ -1,0 +1,1 @@
+# Check selected widget handles for focus in widget event manager

--- a/docs/notes/bugfix-17052.md
+++ b/docs/notes/bugfix-17052.md
@@ -1,0 +1,1 @@
+# Check selected object handles for focus first, rather than objects themselves

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -536,6 +536,11 @@ bool MCCard::mfocus_control(int2 x, int2 y, bool p_check_selected)
             // if the object is selected and the mouse is inside a resize handle.
             t_focused = t_tptr_object -> getstate(CS_SELECTED)
                         && t_tptr_object -> sizehandles(x, y) != 0;
+            
+            // Make sure we still call mfocus as it updates the control's stored
+            // mouse coordinates
+            if (t_focused)
+                t_tptr_object -> mfocus(x, y);
         }
         else
         {

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -514,7 +514,7 @@ bool MCCard::mfocus_control(int2 x, int2 y, bool p_check_selected)
     bool t_freed;
     do
     {
-        MCObject *t_tptr_object;
+        MCControl *t_tptr_object;
         t_tptr_object = tptr -> getref();
         
         t_freed = false;
@@ -529,9 +529,20 @@ bool MCCard::mfocus_control(int2 x, int2 y, bool p_check_selected)
             }
         }
         
-        // Only check mfocus for objects with the appropriate selection state
-        if ((p_check_selected == tptr -> getref() -> getstate(CS_SELECTED))
-            && t_tptr_object->mfocus(x, y))
+        bool t_focused;
+        if (p_check_selected)
+        {
+            // On the first pass (checking selected objects), just check
+            // if the object is selected and the mouse is inside a resize handle.
+            t_focused = t_tptr_object -> getstate(CS_SELECTED)
+                        && t_tptr_object -> sizehandles(x, y) != 0;
+        }
+        else
+        {
+            t_focused = t_tptr_object->mfocus(x, y);
+        }
+        
+        if (t_focused)
         {
             // MW-2010-10-28: If mfocus calls relayer, then the objptrs can get changed.
             //   Reloop to find the correct one.

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -259,7 +259,7 @@ Boolean MCControl::mfocus(int2 x, int2 y)
     
 	Boolean is = maskrect(srect) || (state & CS_SELECTED
 	                                 && MCU_point_in_rect(geteffectiverect(), x, y)
-	                                 && sizehandles() != 0);
+	                                 && sizehandles(x, y) != 0);
     
 	if (is || state & CS_MFOCUSED)
 	{
@@ -1446,7 +1446,7 @@ void MCControl::continuesize(int2 x, int2 y)
 
 #define SIZE_HANDLE_HIT_TOLERANCE 1
 
-uint2 MCControl::sizehandles()
+uint2 MCControl::sizehandles(int2 px, int2 py)
 {
 	uint2 newstate = 0;
 	if (!(flags & F_LOCK_LOCATION))
@@ -1458,29 +1458,29 @@ uint2 MCControl::sizehandles()
         {
             // Be more forgiving about handle hit detection
             rects[i] = MCU_reduce_rect(rects[i], -SIZE_HANDLE_HIT_TOLERANCE);
-			if (MCU_point_in_rect(rects[i], mx, my))
+			if (MCU_point_in_rect(rects[i], px, py))
 			{
 				if (i < 3)
 				{
 					newstate |= CS_SIZET;
-					yoffset = my - rect.y;
+					yoffset = py - rect.y;
 				}
 				else
 					if (i > 4)
 					{
 						newstate |= CS_SIZEB;
-						yoffset = rect.y + rect.height - my;
+						yoffset = rect.y + rect.height - py;
 					}
 				if (i == 0 || i == 3 || i == 5)
 				{
 					newstate |= CS_SIZEL;
-					xoffset = mx - rect.x;
+					xoffset = px - rect.x;
 				}
 				else
 					if (i == 2 || i == 4 || i == 7)
 					{
 						newstate |= CS_SIZER;
-						xoffset = rect.x + rect.width - mx;
+						xoffset = rect.x + rect.width - px;
 					}
 				break;
 			}
@@ -1497,7 +1497,7 @@ void MCControl::start(Boolean canclone)
 	getstack()->kfocusset(NULL);
 	kunfocus();
 	
-	state |= sizehandles();
+	state |= sizehandles(mx, my);
 	if (!(state & CS_SELECTED))
 	{
 		if (MCmodifierstate & MS_SHIFT)
@@ -1507,7 +1507,7 @@ void MCControl::start(Boolean canclone)
 	}
 	else
 	{
-		if (MCmodifierstate & MS_SHIFT && sizehandles() == 0)
+		if (MCmodifierstate & MS_SHIFT && sizehandles(mx, my) == 0)
 		{
 			MCselected->remove(this);
 			return;

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -607,10 +607,16 @@ bool MCGroup::mfocus_control(int2 x, int2 y, bool p_check_selected)
                 // if the object is selected and the mouse is inside a resize handle.
                 t_focused = tptr -> getstate(CS_SELECTED)
                 && tptr -> sizehandles(x, y) != 0;
+                
+                // Make sure we still call mfocus as it updates the control's stored
+                // mouse coordinates
+                if (t_focused)
+                    tptr -> mfocus(x, y);
+                
             }
             else
             {
-                t_focused = tptr->mfocus(x, y);
+                t_focused = tptr -> mfocus(x, y);
             }
             
             if (t_focused)

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -600,9 +600,20 @@ bool MCGroup::mfocus_control(int2 x, int2 y, bool p_check_selected)
                 }
             }
             
-            // Only check mfocus for objects with the appropriate selection state
-            if ((p_check_selected == tptr -> getstate(CS_SELECTED))
-                && tptr -> mfocus(x, y))
+            bool t_focused;
+            if (p_check_selected)
+            {
+                // On the first pass (checking selected objects), just check
+                // if the object is selected and the mouse is inside a resize handle.
+                t_focused = tptr -> getstate(CS_SELECTED)
+                && tptr -> sizehandles(x, y) != 0;
+            }
+            else
+            {
+                t_focused = tptr->mfocus(x, y);
+            }
+            
+            if (t_focused)
             {
                 Boolean newfocused = tptr != mfocused;
                 

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -170,7 +170,7 @@ public:
 	void drawarrow(MCDC *dc, int2 x, int2 y, uint2 size,
 	               Arrow_direction dir, Boolean border, Boolean hilite);
 	void continuesize(int2 x, int2 y);
-	uint2 sizehandles();
+	uint2 sizehandles(int2 px, int2 py);
 	void start(Boolean canclone);
 	void end(bool p_send_mouse_up, bool p_release);
 	void create(int2 x, int2 y);

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -281,6 +281,16 @@ Boolean MCWidgetEventManager::event_mfocus(MCWidget* p_widget, int2 p_x, int2 p_
 
     if (t_focused_widget == nil)
     {
+        // We can still be focused if the mouse is within the resize handles
+        if (p_widget -> getstate(CS_SELECTED)
+            && p_widget -> sizehandles(p_x, p_y) != 0)
+        {
+            t_focused_widget = p_widget -> getwidget();
+        }
+    }
+    
+    if (t_focused_widget == nil)
+    {
         if (m_mouse_focus != nil &&
             MCWidgetGetHost(m_mouse_focus) != p_widget)
             return False;


### PR DESCRIPTION
- (17052) Check selection handles for focus, rather than entire selected objects
- (16968) Make sure widgets can be focused when the mouse is within selection handles in browse mode

Note sizehandles() has been updated to take the mouse coords as parameters rather than using the member variables.
