### PR TITLE
[Bug 17013] libfoundation: Don't crash constructing huge strings

### DIFF
--- a/docs/notes/bugfix-17013.md
+++ b/docs/notes/bugfix-17013.md
@@ -1,0 +1,1 @@
+# Don't crash when constructing huge strings

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -4841,7 +4841,25 @@ static bool __MCStringExpandAt(MCStringRef self, uindex_t p_at, uindex_t p_count
 	// Fetch the capacity.
 	uindex_t t_capacity;
 	t_capacity = __MCStringGetCapacity(self);
-    
+
+	/* Overflow check.  A string's length needs to fit into an
+	 * index_t, because sometimes negative indices are used.  Ensure that the
+	 * length of the expanded string (including a null byte) fits. */
+	if (INDEX_MAX == p_count || INDEX_MAX - p_count - 1 < self->char_count)
+	{
+		return MCErrorThrow(kMCErrorOutOfMemory);
+	}
+
+	/* Overflow check.  A string's total storage size must fit into a
+	 * size_t.  The maximum capacity (i.e. number of chars) depends on whether it's a
+	 * Unicode (multibyte) or native (unibyte) string representation. */
+	size_t t_capacity_limit =
+		SIZE_MAX / (__MCStringIsNative(self) ? sizeof(char_t) : sizeof(unichar_t));
+	if (t_capacity_limit == p_count || t_capacity_limit - p_count - 1 < self->char_count)
+	{
+		return MCErrorThrow(kMCErrorOutOfMemory);
+	}
+
 	// The capacity field stores the total number of chars that could fit not
 	// including the implicit NUL, so if we fit, we can fast-track.
 	if (t_capacity != 0 && self -> char_count + p_count <= t_capacity)


### PR DESCRIPTION
Ensure that `__MCStringExpandAt()` checks for overflows and indicates
an out-of-memory error when an overflow occurs.  This prevents
horribleness occurring with the following script:

```
put "0" into x
repeat 32
   put x after x
end repeat
```

Although the character count of a string is stored as a `uindex_t`,
this checks for overflowing an `index_t`.  This prevents two bugs:
- the construction of strings for which a negative index can't be
  represented
- the construction of a string `x` such that `len(x)` is negative

This fix exposes the fact that LiveCode 7 doesn't actually do anything
if an out-of-memory error is reported and blithely continues running
the script as if nothing has happened.
