### PR TITLE
Fix incorrect rendering of labels for disabled tabs

### DIFF
--- a/docs/notes/bugfix-16139.md
+++ b/docs/notes/bugfix-16139.md
@@ -1,0 +1,2 @@
+# Don't draw leading '(' on labels for disabled tab buttons
+

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -1571,7 +1571,7 @@ void MCButton::drawtabs(MCDC *dc, MCRectangle &srect)
 				break;
 			default:
 				setforeground(dc, DI_TOP, False);
-                dc -> drawtext(textx, cury + yoffset + 1, t_tab, m_font, false, kMCDrawTextNoBreak);
+                dc -> drawtext_substring(textx, cury + yoffset + 1, t_tab, t_range, m_font, false, kMCDrawTextNoBreak);
 				setforeground(dc, DI_BOTTOM, False);
 				break;
 			}


### PR DESCRIPTION
The double-drawing used for the 3D inset look for disabled text was drawing with different strings each time.
