### PR TITLE
Remove pushbutton widget.

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -399,8 +399,6 @@ component Extensions
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.paletteActions
 	into [[ToolsFolder]]/Extensions place
-		rfolder macosx:packaged_extensions/com.livecode.widget.pushbutton
-	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.segmented
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.svgpath

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -37,7 +37,7 @@
 				'widgets/paletteactions/paletteactions.lcb',
 				#’widgets/pinkcircle/pinkcircle.lcb',
 				#'widgets/progressbar/progressbar.lcb',
-				'widgets/pushbutton/pushbutton.lcb',
+				#'widgets/pushbutton/pushbutton.lcb',
 				#'widgets/radiobutton/radiobutton.lcb',
 				'widgets/segmented/segmented.lcb',
 				#'widgets/selector/selector.lcb',


### PR DESCRIPTION
This doesn't do anything that the button control doesn't do, and we
probably don't have time to get it up to scratch in time for LiveCode
8.  We can revisit it in a future release.

Corresponding release notes will be in an IDE pull request.
