### PR TITLE
[[ Bug 16145 ]] Use the appropriate linker script for Android standalones

### DIFF
--- a/docs/notes/bugfix-16145.md
+++ b/docs/notes/bugfix-16145.md
@@ -1,0 +1,1 @@
+[[ Bug 16145 ]] Fix crash running standalones on some Android devices (Android version < 4.2)

--- a/docs/notes/issues.md
+++ b/docs/notes/issues.md
@@ -6,7 +6,5 @@
 
 * The browser widget does not work on 32-bit Linux.
 
-* The LiveCode engine may fail to run on some Android 2.3 (Gingerbread) devices ([bug 16145](http://quality.livecode.com/show_bug.cgi?id=16145))
-
 * 64-bit standalones for Mac OS X do not have support for audio
   recording or the revVideoGrabber external.

--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -212,14 +212,14 @@
 						
 						'sources':
 						[
-							'engine/linux.link',
+							'engine/standalone-armv6-hf.link',
 						],
 						
 						'ldflags':
 						[
 							# Helpful for catching build problems
 							'-Wl,-no-undefined',
-							'-Wl,-T,$(abs_srcdir)/engine/linux.link',
+							'-Wl,-T,$(abs_srcdir)/engine/standalone-armv6-hf.link',
 						],
 
 						'actions':


### PR DESCRIPTION
Fixes a crash on some Android devices when trying to load the standalone engine.
