### PR TITLE
widgetutils: Add getNativeThemeName() handler

### DIFF
--- a/extensions/modules/widget-utils/widget-utils.lcb
+++ b/extensions/modules/widget-utils/widget-utils.lcb
@@ -253,4 +253,33 @@ public handler stringToColor(in pString as String) returns Color
 	return color tColor
 end handler
 
+/*
+Summary: Get the canonical name of the current "native" mobile theme
+
+Example:
+	variable tNativeTheme as String
+	put getNativeThemeName() into tNativeTheme
+
+	if tNativeTheme is "android" then
+		-- Draw Android themed UI
+	else
+		-- Draw iOS themed UI
+	end if
+
+Description:
+Returns the name of the current theme that should be used when the theme is
+"native".
+
+Currently, this will return either "iOS" or "Android".
+*/
+public handler getNativeThemeName() returns String
+	variable tOS as String
+	put the operating system into tOS
+	if tOS is in ["ios,mac"] then
+		return "iOS"
+	else
+		return "Android"
+	end if
+end handler
+
 end module


### PR DESCRIPTION
Add a function that returns a theme name to be used by widgets when
the theme is "native".  This returns "iOS" on iOS and Mac OS X, and
"Android" otherwise.  For the time being, widgets may use this
function to determine how to automatically adapt themselves to the
current platform.
