### PR TITLE
[[ Widgets ]] Ensure widget redraw after property change

### DIFF
--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -51,6 +51,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "font.h"
 
 #include "exec-interface.h"
+#include "widget.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1272,9 +1273,18 @@ void MCObject::Redraw(void)
 	if (!opened)
 		return;
 	
-	// MW-2011-08-18: [[ Layers ]] Invalidate the whole object.
-	if (gettype() >= CT_GROUP)
-		static_cast<MCControl *>(this) -> layer_redrawall();
+    if (gettype() == CT_WIDGET)
+    {
+        MCWidgetRef t_widget;
+        t_widget = reinterpret_cast<MCWidget *>(this) -> getwidget();
+        if (t_widget != nil)
+            MCWidgetRedrawAll(t_widget);
+    }
+    else if (gettype() >= CT_GROUP)
+    {
+        // MW-2011-08-18: [[ Layers ]] Invalidate the whole object.
+        static_cast<MCControl *>(this) -> layer_redrawall();
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -450,6 +450,7 @@ bool MCWidget::getprop(MCExecContext& ctxt, uint32_t p_part_id, Properties p_whi
         case P_REV_AVAILABLE_VARIABLES:
     
         case P_KIND:
+        case P_THEME_CONTROL_TYPE:
 			return MCControl::getprop(ctxt, p_part_id, p_which, p_index, p_effective, r_value);
             
         default:
@@ -553,6 +554,7 @@ bool MCWidget::setprop(MCExecContext& ctxt, uint32_t p_part_id, Properties p_whi
         case P_DISABLED:
             
         case P_KIND:
+        case P_THEME_CONTROL_TYPE:
 			return MCControl::setprop(ctxt, p_part_id, p_which, p_index, p_effective, p_value);
             
         default:


### PR DESCRIPTION
- Reserve themeClass property
- Make sure widgets call OnPaint after setting properties requiring redraw
