### PR TITLE
[[ Bug 16917 ]] Fix foreign handler resolve failure after creating browser view

### DIFF
--- a/docs/notes/bugfix-16917.md
+++ b/docs/notes/bugfix-16917.md
@@ -1,0 +1,1 @@
+# Fix other widgets failing to render on Android if browser widget is used

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -297,6 +297,12 @@ public class Engine extends View implements EngineApi
 		return getContext() . getApplicationInfo() . sourceDir;
 	}
 
+	// IM-2016-03-04: [[ Bug 16917 ]] Return location of native libraries installed with this app
+	public String getLibraryPath()
+	{
+		return getContext() . getApplicationInfo() . nativeLibraryDir;
+	}
+	
 	public void finishActivity()
 	{
         // MM-2012-03-19: [[ Bug 10104 ]] Stop tracking any sensors on shutdown - not doing so prevents a restart for some reason.

--- a/engine/src/mblandroid.cpp
+++ b/engine/src/mblandroid.cpp
@@ -34,6 +34,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 ////////////////////////////////////////////////////////////////////////////////
 
 extern bool MCSystemLaunchUrl(MCStringRef p_url);
+extern bool MCAndroidResolveLibraryPath(MCStringRef p_library, MCStringRef &r_path);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -85,9 +86,13 @@ void MCAndroidSystem::Debug(MCStringRef p_string)
 
 MCSysModuleHandle MCAndroidSystem::LoadModule(MCStringRef p_path)
 {
+	MCAutoStringRef t_resolved_path;
+	/* UNCHECKED */ MCAndroidResolveLibraryPath(p_path, &t_resolved_path);
+	
+	MCAutoStringRefAsUTF8String t_utf8_path;
+	/* UNCHECKED */ t_utf8_path . Lock(*t_resolved_path);
+	
 	void *t_result;
-    MCAutoStringRefAsUTF8String t_utf8_path;
-    /* UNCHECKED */ t_utf8_path . Lock(p_path);
 	t_result = dlopen(*t_utf8_path, RTLD_LAZY);
 	MCLog("LoadModule(%s) - %p\n", *t_utf8_path, t_result);
 	return (MCSysModuleHandle)t_result;

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -610,6 +610,10 @@ bool MCAndroidGetLibraryPath(MCStringRef &r_path)
 // IM-2016-03-04: [[ Bug 16917 ]] Return full path to the given library
 bool MCAndroidResolveLibraryPath(MCStringRef p_library, MCStringRef &r_path)
 {
+	// if the path is absolute then just return a copy.
+	if (MCStringBeginsWithCString(p_library, (const char_t*)"/", kMCStringOptionCompareExact))
+		return MCStringCopy(p_library, r_path);
+	
 	MCAutoStringRef t_path;
 	if (!MCAndroidGetLibraryPath(&t_path))
 		return false;

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -590,3 +590,47 @@ real8 MCAndroidSystem::GetFreeDiskSpace()
     return 0.0;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+// IM-2016-03-04: [[ Bug 16917 ]] Return location of installed libraries.
+bool MCAndroidGetLibraryPath(MCStringRef &r_path)
+{
+	MCStringRef t_path;
+	t_path = nil;
+	
+	MCAndroidEngineCall("getLibraryPath", "x", &t_path);
+	
+	if (t_path == nil)
+		return false;
+	
+	r_path = t_path;
+	return true;
+}
+
+// IM-2016-03-04: [[ Bug 16917 ]] Return full path to the given library
+bool MCAndroidResolveLibraryPath(MCStringRef p_library, MCStringRef &r_path)
+{
+	MCAutoStringRef t_path;
+	if (!MCAndroidGetLibraryPath(&t_path))
+		return false;
+	
+	if (!t_path.MakeMutable())
+		return false;
+	
+	if (!MCStringEndsWithCString(*t_path, (const char_t*)"/", kMCStringOptionCompareExact))
+	{
+		if (!MCStringAppendNativeChar(*t_path, '/'))
+			return false;
+	}
+	
+	if (!MCStringAppend(*t_path, p_library))
+		return false;
+	
+	if (!t_path.MakeImmutable())
+		return false;
+	
+	r_path = t_path.Take();
+	return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch passes the full path to the standalone engine library to dlopen, which can fail if given only the library filename.
