### PR TITLE
Application resume notification during startup causes crash on mac

### DIFF
--- a/docs/notes/bugfix-16872.md
+++ b/docs/notes/bugfix-16872.md
@@ -1,0 +1,1 @@
+# Application resume notification during startup causes crash on mac

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -106,7 +106,9 @@ void MCPlatformHandleApplicationSuspend(void)
 void MCPlatformHandleApplicationResume(void)
 {
 	MCappisactive = True;
-	MCdefaultstackptr -> getcard() -> message(MCM_resume);
+    
+    if (MCdefaultstackptr != nil)
+        MCdefaultstackptr -> getcard() -> message(MCM_resume);
 }
 
 void MCPlatformHandleApplicationRun(bool& r_continue)


### PR DESCRIPTION
MCdefaultstackptr was not being checked before attempting
to send a message to the current card. El Capitan appears to
be sending resume notifications when applications are
launched.
