### PR TITLE
[[ LicenseCheck ]] External support code should use legacy API.

### DIFF
--- a/lcidlc/src/Support.mm
+++ b/lcidlc/src/Support.mm
@@ -2681,8 +2681,10 @@ LCError LCLicenseCheckEdition(unsigned int p_min_version)
     // old.
     if (s_interface -> version < 7)
 	{
+        // Make sure we use the legacy context query API as older engines
+        // don't have the new one.
 		bool t_has_license_check;
-		if (s_interface -> context_query(kMCExternalContextVarHasLicenseCheck, 0, &t_has_license_check) != kMCErrorNone ||
+		if (s_interface -> context_query_legacy(kMCExternalContextVarHasLicenseCheck, 0, &t_has_license_check) != kMCErrorNone ||
 			t_has_license_check == false)
 			return kLCErrorUnlicensed;
 	}


### PR DESCRIPTION
The LCLicenseCheckEdition API call must use 'context_query_legacy'
rather than 'context_query' as the latter is not available in older
engines.
