### PR TITLE
[Bug 14980] lc-compile: Allow any identifier as a property name

### DIFF
--- a/docs/lcb/notes/14980.md
+++ b/docs/lcb/notes/14980.md
@@ -1,0 +1,8 @@
+# LiveCode Builder Language
+## Property definitions
+
+* It is now possible to define a property named with a string instead of an
+  identifier.  This allows properties to have names that are also used as
+  syntax keywords.
+
+# [14980] Allow any identifier as a property name.

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1731,7 +1731,8 @@
         CheckIdentifiers(Signature)
 
     'rule' CheckIdentifiers(DEFINITION'property(_, _, Id, _, _)):
-        CheckIdIsSuitableForDefinition(Id)
+        -- Do nothing; properties don't create a lexical binding in the module
+        -- environment so they can be called anything
 
     'rule' CheckIdentifiers(DEFINITION'event(_, _, Id, Signature)):
         CheckIdIsSuitableForDefinition(Id)

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -528,7 +528,10 @@
 
     'rule' PropertyDefinition(-> property(Position, public, Name, Getter, Setter)):
         "property" @(-> Position) Identifier(-> Name) "get" Identifier(-> Getter) OptionalSetClause(-> Setter)
-        
+
+    'rule' PropertyDefinition(-> property(Position, public, Name, Getter, Setter)):
+        "property" @(-> Position) StringyIdentifier(-> Name) "get" Identifier(-> Getter) OptionalSetClause(-> Setter)
+
 'nonterm' OptionalSetClause(-> OPTIONALID)
 
     'rule' OptionalSetClause(-> id(Setter)):


### PR DESCRIPTION
- Properties can now be named using strings instead of using
  identifiers
- lc-compile won't complain about properties with keyword-like
  names
