### PR TITLE
[[ Bug 17082 ]] Fix potential crash on exit on Windows.

### DIFF
--- a/docs/notes/bugfix-17082.md
+++ b/docs/notes/bugfix-17082.md
@@ -1,0 +1,1 @@
+# The engine will no longer potentially crash on exit on Windows.

--- a/engine/src/dskw32main.cpp
+++ b/engine/src/dskw32main.cpp
@@ -315,15 +315,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	
 	g_mainthread_errno = _errno();
 	int r = X_close();
-
+    
+    MCValueRelease(MCcmdline);
+    
     MCScriptFinalize();
     MCModulesFinalize();
 	MCFinalize();
 
 	if (t_tsf_mgr != nil)
 		t_tsf_mgr -> Release();
-
-	MCValueRelease(MCcmdline);
 
 	return r;
 }


### PR DESCRIPTION
The MCcmdline global variable was being MCValueRelease'd after
MCFinalize.
