### PR TITLE
[[ Bug 17083 ]] Fix Windows standard cursors.

### DIFF
--- a/docs/notes/bugfix-17083.md
+++ b/docs/notes/bugfix-17083.md
@@ -1,0 +1,4 @@
+# Standard help cursor now works on Windows
+
+If the standard cursors are not overriden on Windows, then they now
+work correctly.

--- a/engine/src/w32cursor.cpp
+++ b/engine/src/w32cursor.cpp
@@ -98,6 +98,7 @@ Drag-Text-Add	25
 #define IDC_SIZENSA          MAKEINTRESOURCEA(32645)
 #define IDC_SIZEALLA         MAKEINTRESOURCEA(32646)
 #define IDC_NOA              MAKEINTRESOURCEA(32648)
+#define IDC_HELPA            MAKEINTRESOURCEA(32651)
 
 static LPCSTR kMCStandardWindowsCursors[] =
 {
@@ -116,7 +117,7 @@ static LPCSTR kMCStandardWindowsCursors[] =
 	IDC_ARROWA, /* PI_DROPPER */
 	IDC_CROSSA, /* PI_PLUS */
 	IDC_WAITA, /* PI_WATCH */
-	/* PI_HELP */
+	IDC_HELPA, /* PI_HELP */
 	IDC_WAITA, /* PI_BUSY1 */
 	IDC_WAITA, /* PI_BUSY2 */
 	IDC_WAITA, /* PI_BUSY3 */


### PR DESCRIPTION
The array of standard window cursors was missing an element
potentially causing an off by one error and potential for
a crash.
