### PR TITLE
[[ Bug 17084 ]] Fix crash in Windows LiveCode Server

### DIFF
--- a/docs/notes/bugfix-17084.md
+++ b/docs/notes/bugfix-17084.md
@@ -1,0 +1,2 @@
+# Fix crash in LiveCode Server on Windows
+

--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -548,8 +548,10 @@
 			'src/lnxelevate.cpp',
 			'src/lnxflst.cpp',
 			
-			# Group "Desktop - Windows"
-			'src/w32date.cpp',
+            # Group "Desktop - Windows"
+            'src/w32date.cpp',
+            'src/w32flst.h',
+            'src/w32flst.cpp',
 							
 			# Group "Theming"
 			'src/linux-theme.cpp',
@@ -703,7 +705,6 @@
 			'src/w32dc.h',
 			'src/w32defs.h',
 			'src/w32dnd.h',
-			'src/w32flst.h',
 			'src/w32prefix.h',
 			'src/w32printer.h',
 			'src/w32text.h',
@@ -837,7 +838,6 @@
 		[
 			'src/srvcgi.h',
 			'src/srvdebug.h',
-			'src/srvflst.h',
 			'src/srvmain.h',
 			'src/srvmultipart.h',
 			'src/srvscript.h',
@@ -845,7 +845,6 @@
 			'src/mode_server.cpp',
 			'src/srvcgi.cpp',
 			'src/srvdebug.cpp',
-			'src/srvflst.cpp',
 			'src/srvmain.cpp',
 			'src/srvmultipart.cpp',
 			'src/srvoutput.cpp',


### PR DESCRIPTION
The Windows Server engine was being compiled with a dummy fontlist
causing crashes in code which uses fonts.
