### PR TITLE
[[ Bug 17086 ]] Add a check for object type to SetParentScript

### DIFF
--- a/docs/notes/bugfix-17086.md
+++ b/docs/notes/bugfix-17086.md
@@ -1,0 +1,1 @@
+# Check that a behavior reference is a button or a stack.

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1663,7 +1663,13 @@ void MCObject::SetParentScript(MCExecContext& ctxt, MCStringRef new_parent_scrip
 	uint32_t t_part_id;
 	if (t_success)
         t_success = t_chunk -> getobj(ctxt, t_object, t_part_id, False);
-
+    
+    // Check that the object is a button or a stack.
+    if (t_success &&
+        t_object -> gettype() != CT_BUTTON &&
+        t_object -> gettype() != CT_STACK)
+        t_success = false;
+    
 	// MW-2013-07-18: [[ Bug 11037 ]] Make sure the object isn't in the hierarchy
 	//   of the parentScript.
 	bool t_is_cyclic;


### PR DESCRIPTION
The check for object type when setting the behavior of an object
has been reinstated.
