### PR TITLE
[[ Bug 17090 ]] Propagate errors occurring in restricted event handlers.

### DIFF
--- a/docs/lcb/notes/17090.md
+++ b/docs/lcb/notes/17090.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Host Library
+
+# [17090] Errors are now propagated from restricted event handlers.

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -158,7 +158,6 @@ Boolean MChidepalettes = False;
 Boolean MCdontuseNS;
 Boolean MCdontuseQT;
 Boolean MCdontuseQTeffects;
-Boolean MCfreescripts = True;
 uint4 MCeventtime;
 uint2 MCbuttonstate;
 uint2 MCmodifierstate;
@@ -554,7 +553,6 @@ void X_clear_globals(void)
 	MCdontuseNS = False;
 	MCdontuseQT = False;
 	MCdontuseQTeffects = False;
-	MCfreescripts = True;
 	MCeventtime = 0;
 	MCbuttonstate = 0;
 	MCmodifierstate = 0;

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -83,7 +83,6 @@ extern Boolean MCproportionalthumbs;
 extern Boolean MCdontuseNS;
 extern Boolean MCdontuseQT;
 extern Boolean MCdontuseQTeffects;
-extern Boolean MCfreescripts;
 extern uint4 MCeventtime;
 extern uint2 MCbuttonstate;
 extern uint2 MCmodifierstate;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -255,13 +255,13 @@ protected:
 	MCHandlerlist *hlist;
 	MCObjectPropertySet *props;
 	uint4 state;
+	uint4 scriptdepth;
 	uint2 fontheight;
 	uint2 dflags;
 	uint2 ncolors;
 	uint2 npatterns;
 	uint2 altid;
 	uint1 hashandlers;
-	uint1 scriptdepth;
 	uint1 borderwidth;
 	int1 shadowoffset;
 	uint1 ink;
@@ -625,10 +625,22 @@ public:
 	{
 		return parent;
 	}
-	uint1 getscriptdepth() const
+	
+	uint4 getscriptdepth() const
 	{
 		return scriptdepth;
 	}
+	
+	void lockforexecution(void)
+	{
+		scriptdepth += 1;
+	}
+	
+	void unlockforexecution(void)
+	{
+		scriptdepth -= 1;
+	}
+	
 	void setparent(MCObject *newparent)
 	{
 		parent = newparent;

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -749,12 +749,32 @@ MCGRectangle MCWidgetBase::MapRectFromGlobal(MCGRectangle rect)
 
 //////////
 
-bool MCWidgetBase::Dispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)
+bool MCWidgetBase::DoDispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)
 {
 	MCWidgetRef t_old_widget_object;
 	t_old_widget_object = MCcurrentwidget;
 	MCcurrentwidget = AsWidget();
+
+	bool t_success;
+	MCValueRef t_retval;
+	t_success = MCScriptCallHandlerOfInstanceIfFound(m_instance, p_event, x_args, p_arg_count, t_retval);
 	
+	if (t_success)
+	{
+		if (r_result != NULL)
+			*r_result = t_retval;
+		else
+			MCValueRelease(t_retval);
+	}
+	
+	MCcurrentwidget = t_old_widget_object;
+	
+	return t_success;
+	
+}
+
+bool MCWidgetBase::Dispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)
+{
 	MCStack *t_old_default_stack, *t_this_stack;
 	t_old_default_stack = MCdefaultstackptr;
 	
@@ -770,68 +790,65 @@ bool MCWidgetBase::Dispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_ar
     }
     else
         MCEngineScriptObjectPreventAccess();
-        
 	
     // Invoke event handler.
     bool t_success;
-    MCValueRef t_retval;
-    t_success = MCScriptCallHandlerOfInstanceIfFound(m_instance, p_event, x_args, p_arg_count, t_retval);
-    
-    if (t_success)
-    {
-        if (r_result != NULL)
-            *r_result = t_retval;
-        else
-            MCValueRelease(t_retval);
-    }
-    else if (GetHost() != nil)
-        GetHost() -> SendError();
-    
-    if (GetHost() != nil)
-    {
-        MCtargetptr = t_old_target;
-        if (MCdefaultstackptr == t_this_stack)
-            MCdefaultstackptr = t_old_default_stack;
-    }
-    else
-        MCEngineScriptObjectAllowAccess();
-    
-	MCcurrentwidget = t_old_widget_object;
+	t_success = DoDispatch(p_event, x_args, p_arg_count, r_result);
+	
+	if (GetHost() != nil)
+	{
+		MCtargetptr = t_old_target;
+		if (MCdefaultstackptr == t_this_stack)
+			MCdefaultstackptr = t_old_default_stack;
+	}
+	else
+		MCEngineScriptObjectAllowAccess();
+	
+    if (!t_success)
+	{
+		if (GetHost() != nil)
+			GetHost() -> SendError();
+	}
 	
 	return t_success;
 }
 
 bool MCWidgetBase::DispatchRestricted(MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)
 {
-	MCWidgetRef t_old_widget_object;
-	t_old_widget_object = MCcurrentwidget;
-	MCcurrentwidget = AsWidget();
-	
     MCEngineScriptObjectPreventAccess();
     
-    // Invoke event handler.
-    bool t_success;
-    MCValueRef t_retval;
-    t_success = MCScriptCallHandlerOfInstanceIfFound(m_instance, p_event, x_args, p_arg_count, t_retval);
-    
+	// Invoke event handler.
+	bool t_success;
+	t_success = DoDispatch(p_event, x_args, p_arg_count, r_result);
+	
     MCEngineScriptObjectAllowAccess();
     
-    if (t_success)
-    {
-        if (r_result != NULL)
-            *r_result = t_retval;
-        else
-            MCValueRelease(t_retval);
-    }
-    
-	MCcurrentwidget = t_old_widget_object;
+    if (GetHost() != nil)
+		GetHost() -> SendError();
+	else
+	{
+		MCAutoErrorRef t_error;
+		MCErrorCatch(&t_error);
+	}
 	
 	return t_success;
 }
 
 void MCWidgetBase::DispatchRestrictedNoThrow(MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)
 {
-    DispatchRestricted(p_event, x_args, p_arg_count, r_result);
+	MCEngineScriptObjectPreventAccess();
+	
+	// Invoke event handler.
+	bool t_success;
+	t_success = DoDispatch(p_event, x_args, p_arg_count, r_result);
+	
+	MCEngineScriptObjectAllowAccess();
+	
+	if (!t_success)
+	{
+		MCAutoErrorRef t_error;
+		MCErrorCatch(&t_error);
+	}
 }
 
 bool MCWidgetBase::DispatchRecursive(DispatchOrder p_order, MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -756,15 +756,13 @@ bool MCWidgetBase::DoDispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_
 	MCcurrentwidget = AsWidget();
 
 	bool t_success;
-	MCValueRef t_retval;
-	t_success = MCScriptCallHandlerOfInstanceIfFound(m_instance, p_event, x_args, p_arg_count, t_retval);
+	MCAutoValueRef t_retval;
+	t_success = MCScriptCallHandlerOfInstanceIfFound(m_instance, p_event, x_args, p_arg_count, &t_retval);
 	
 	if (t_success)
 	{
 		if (r_result != NULL)
-			*r_result = t_retval;
-		else
-			MCValueRelease(t_retval);
+			*r_result = t_retval . Take();
 	}
 	
 	MCcurrentwidget = t_old_widget_object;

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -156,10 +156,18 @@ bool MCWidgetBase::SetProperty(MCNameRef p_property, MCValueRef p_value)
     MCWidgetRef t_old_widget;
     t_old_widget = MCcurrentwidget;
     MCcurrentwidget = AsWidget();
-    
+	
+	MCWidget *t_host;
+	t_host = GetHost();
+	if (t_host != nil)
+		t_host -> lockforexecution();
+	
     bool t_success;
     t_success = MCScriptSetPropertyOfInstance(m_instance, p_property, p_value);
-    
+	
+	if (t_host != nil)
+		t_host -> unlockforexecution();
+	
     MCcurrentwidget = t_old_widget;
     
     return t_success;
@@ -170,10 +178,18 @@ bool MCWidgetBase::GetProperty(MCNameRef p_property, MCValueRef& r_value)
     MCWidgetRef t_old_widget;
     t_old_widget = MCcurrentwidget;
     MCcurrentwidget = AsWidget();
-    
+	
+	MCWidget *t_host;
+	t_host = GetHost();
+	if (t_host != nil)
+		t_host -> lockforexecution();
+	
     bool t_success;
     t_success = MCScriptGetPropertyOfInstance(m_instance, p_property, r_value);
-    
+	
+	if (t_host != nil)
+		t_host -> unlockforexecution();
+	
     MCcurrentwidget = t_old_widget;
     
     return t_success;
@@ -755,9 +771,21 @@ bool MCWidgetBase::DoDispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_
 	t_old_widget_object = MCcurrentwidget;
 	MCcurrentwidget = AsWidget();
 
+	// Make sure the host object's 'scriptdepth' is incremented and
+	// decremented appropriately. This prevents script from deleting
+	// a widget which has its LCB code on the stack (just as it would if
+	// it had its LCS code on the stack).
+	MCWidget *t_host;
+	t_host = GetHost();
+	if (t_host != nil)
+		t_host -> lockforexecution();
+	
 	bool t_success;
 	MCAutoValueRef t_retval;
 	t_success = MCScriptCallHandlerOfInstanceIfFound(m_instance, p_event, x_args, p_arg_count, &t_retval);
+	
+	if (t_host != nil)
+		t_host -> unlockforexecution();
 	
 	if (t_success)
 	{

--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -123,12 +123,17 @@ private:
         kDispatchOrderTopDownAfter,
         kDispatchOrderBottomUp,
         kDispatchOrderTopDown,
-    };
-    
-    // Dispatch an event to the widget.
+	};
+	
+	// Inner method for dispatching an event.
+	bool DoDispatch(MCNameRef event, MCValueRef *x_args = nil, uindex_t arg_count = 0, MCValueRef *r_result = nil);
+	
+    // Dispatch an event to the widget allowing script access.
+	// Any errors are sent to the host (if any).
     bool Dispatch(MCNameRef event, MCValueRef *x_args = nil, uindex_t arg_count = 0, MCValueRef *r_result = nil);
     
-    // Dispatch an event to the widget but don't allow script access.
+	// Dispatch an event to the widget but don't allow script access.
+	// Any errors are sent to the host (if any).
     bool DispatchRestricted(MCNameRef event, MCValueRef *args = nil, uindex_t arg_count = 0, MCValueRef *r_result = nil);
     
     // Dispatch an event to the widget, don't allow script access and swallow


### PR DESCRIPTION
If a widget event handler is called in restricted mode (e.g. OnPaint), then
errors will now propagate correctly rather than leaving an unhandled
exception state.
