### PR TITLE
[[ Bug 17085 ]] Normalize filenames before building detailed files.

### DIFF
--- a/docs/notes/bugfix-17085.md
+++ b/docs/notes/bugfix-17085.md
@@ -1,0 +1,12 @@
+# Make filenames with accented characters appear correctly in the detailed files on Mac
+
+The detailed files uses URL encoding to be able to present the filename in a comma-
+separated list. However, this causes a problem because the current definition or url
+encode and decode in LiveCode is that it %-encodes the native encoding of the string.
+
+As Mac HFS(+) volumes store filenames in decomposed unicode form, this means that
+any filenames containing accented characters will not appear correctly in the
+detailed files, even if the combined character is in the native character set.
+
+To improve this situation, the detailed files will now normalize all filenames to
+composed form before url encoding.

--- a/engine/src/srvoutput.cpp
+++ b/engine/src/srvoutput.cpp
@@ -491,7 +491,7 @@ bool MCServerSetCookie(MCStringRef p_name, MCStringRef p_value, uint32_t p_expir
 	
 	MCAutoStringRef t_encoded;
 	if (t_success && !MCStringIsEmpty(p_value))
-		MCU_urlencode(p_value, false, &t_encoded);
+		t_success = MCU_urlencode(p_value, false, &t_encoded);
 	
 	if (t_success)
 	{

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -964,53 +964,62 @@ static bool MCS_getentries_callback(void *p_context, const MCSystemFolderEntry *
 		// harm to first normalize to NFC - i.e. decomposed strings won't work now
 		// but at least these means some strings will work.
 		MCAutoStringRef t_normalized;
-		/* UNCHECKED */ MCStringNormalizedCopyNFC(p_entry -> name, &t_normalized);
+		if (!MCStringNormalizedCopyNFC(p_entry -> name, &t_normalized))
+			return false;
         
         // SN-2015-01-22: [[ Bug 14412 ]] the detailed files should return
         //   URL-encoded filenames
         MCAutoStringRef t_url_encoded;
-        MCU_urlencode(*t_normalized, false, &t_url_encoded);
+        if (!MCU_urlencode(*t_normalized, false, &t_url_encoded))
+			return false;
         
 #ifdef _WIN32
-		/* UNCHECKED */ MCStringFormat(&t_details,
-                                       "%@,%I64d,,%ld,%ld,%ld,,,,%03o,",
-                                       *t_url_encoded,
-                                       p_entry -> data_size,
-                                       p_entry -> creation_time,
-                                       p_entry -> modification_time,
-                                       p_entry -> access_time,
-                                       p_entry -> permissions);
+		if (!MCStringFormat(&t_details,
+							"%@,%I64d,,%ld,%ld,%ld,,,,%03o,",
+							*t_url_encoded,
+							p_entry -> data_size,
+							p_entry -> creation_time,
+							p_entry -> modification_time,
+							p_entry -> access_time,
+							p_entry -> permissions))
+			return false;
 #elif defined(_MACOSX)
-		/* UNCHECKED */ MCStringFormat(&t_details,
-                                       "%@,%lld,%lld,%u,%u,%u,%u,%d,%d,%03o,%.8s",
-                                       *t_url_encoded,
-                                       p_entry -> data_size,
-                                       p_entry -> resource_size,
-                                       p_entry -> creation_time,
-                                       p_entry -> modification_time,
-                                       p_entry -> access_time,
-                                       p_entry -> backup_time,
-                                       p_entry -> user_id,
-                                       p_entry -> group_id,
-                                       p_entry -> permissions,
-                                       p_entry -> file_type);
+		if (!MCStringFormat(&t_details,
+							"%@,%lld,%lld,%u,%u,%u,%u,%d,%d,%03o,%.8s",
+							*t_url_encoded,
+							p_entry -> data_size,
+							p_entry -> resource_size,
+							p_entry -> creation_time,
+							p_entry -> modification_time,
+							p_entry -> access_time,
+							p_entry -> backup_time,
+							p_entry -> user_id,
+							p_entry -> group_id,
+							p_entry -> permissions,
+							p_entry -> file_type))
+			return false;
 #else
-		/* UNCHECKED */ MCStringFormat(&t_details,
-                                       "%@,%lld,,,%u,%u,,%d,%d,%03o,",
-                                       *t_url_encoded,
-                                       p_entry -> data_size,
-                                       p_entry -> modification_time,
-                                       p_entry -> access_time,
-                                       p_entry -> user_id,
-                                       p_entry -> group_id,
-                                       p_entry -> permissions);
+		if (!MCStringFormat(&t_details,
+							"%@,%lld,,,%u,%u,,%d,%d,%03o,",
+							*t_url_encoded,
+							p_entry -> data_size,
+							p_entry -> modification_time,
+							p_entry -> access_time,
+							p_entry -> user_id,
+							p_entry -> group_id,
+							p_entry -> permissions))
+			return false;
         
 #endif
 
-		/* UNCHECKED */ MCListAppend(t_state->list, *t_details);
+		if (!MCListAppend(t_state->list, *t_details))
+			return false;
 	}
 	else
-    /* UNCHECKED */ MCListAppendFormat(t_state->list, "%@", p_entry -> name);
+	{
+		if (!MCListAppendFormat(t_state->list, "%@", p_entry -> name))
+			return false;
+	}
 	
 	return true;
 }
@@ -1030,7 +1039,10 @@ bool MCS_getentries(bool p_files, bool p_detailed, MCListRef& r_list)
     // SN-2015-11-09: [[ Bug 16223 ]] Make sure that the list starts with ..
     // if we ask for folders.
     if (!p_files)
-        MCListAppendCString(*t_list, "..");
+	{
+		if (!MCListAppendCString(*t_list, ".."))
+			return false;
+	}
     
 	if (!MCsystem -> ListFolderEntries(MCS_getentries_callback, (void*)&t_state))
 		return false;

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -956,11 +956,20 @@ static bool MCS_getentries_callback(void *p_context, const MCSystemFolderEntry *
 	if (t_state -> details)
 	{
         MCAutoStringRef t_details;
+		
+		// The current expectation is that urlEncode maps to and from the native
+		// encoding. This causes a problem on Mac where filenames are stored in
+		// NFD form - i.e. u-umlaut is u then umlaut. As the decomposed form has
+		// no representation when urlEncoded via the native encoding, it does no
+		// harm to first normalize to NFC - i.e. decomposed strings won't work now
+		// but at least these means some strings will work.
+		MCAutoStringRef t_normalized;
+		/* UNCHECKED */ MCStringNormalizedCopyNFC(p_entry -> name, &t_normalized);
         
         // SN-2015-01-22: [[ Bug 14412 ]] the detailed files should return
         //   URL-encoded filenames
         MCAutoStringRef t_url_encoded;
-        MCU_urlencode(p_entry -> name, false, &t_url_encoded);
+        MCU_urlencode(*t_normalized, false, &t_url_encoded);
         
 #ifdef _WIN32
 		/* UNCHECKED */ MCStringFormat(&t_details,

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -2387,9 +2387,9 @@ void MCU_base64decode(MCStringRef in, MCDataRef &out)
 // SN-2014-12-02": [[ Bug 14015 ]] The fix should only affect the URLs explicitely encoded as UTF-8
 bool MCFiltersUrlEncode(MCStringRef p_source, bool p_use_utf8, MCStringRef& r_result);
 
-void MCU_urlencode(MCStringRef p_url, bool p_use_utf8, MCStringRef &r_encoded)
+bool MCU_urlencode(MCStringRef p_url, bool p_use_utf8, MCStringRef &r_encoded)
 {
-	/* UNCHECKED */ MCFiltersUrlEncode(p_url, p_use_utf8, r_encoded);
+	return MCFiltersUrlEncode(p_url, p_use_utf8, r_encoded);
 }
 
 bool MCFiltersUrlDecode(MCStringRef p_source, bool p_use_utf8, MCStringRef& r_result);

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -191,7 +191,7 @@ extern void MCU_fix_path(MCStringRef in, MCStringRef& r_out);
 extern void MCU_base64encode(MCDataRef in, MCStringRef &out);
 extern void MCU_base64decode(MCStringRef in, MCDataRef &out);
 extern void MCU_urldecode(MCStringRef p_source, bool p_use_utf8, MCStringRef& r_result);
-extern void MCU_urlencode(MCStringRef p_url, bool p_use_utf8, MCStringRef &r_encoded);
+extern bool MCU_urlencode(MCStringRef p_url, bool p_use_utf8, MCStringRef &r_encoded);
 extern Boolean MCU_freeinserted(MCObjectList *&l);
 extern void MCU_cleaninserted();
 //extern Exec_stat MCU_change_color(MCColor &c, char *&n, MCExecPoint &ep, uint2 line, uint2 pos);


### PR DESCRIPTION
So that accented characters which are in the native character set
will work in the detailed files, the filename strings are now
normalized to NFC before being url encoded.
