### PR TITLE
[[ Bug 17029 ]] Finalize CEF library on shutdown

### DIFF
--- a/docs/notes/bugfix-17029.md
+++ b/docs/notes/bugfix-17029.md
@@ -1,0 +1,1 @@
+# Fix Windows Application with browser widget not fully shutting down.

--- a/libbrowser/src/libbrowser.cpp
+++ b/libbrowser/src/libbrowser.cpp
@@ -186,8 +186,6 @@ bool MCBrowserBase::BrowserListIterate(MCBrowserIterateCallback p_callback, void
 
 // Init functions
 
-static MCBrowserFactoryRef s_browser_factory = nil;
-
 MC_BROWSER_DLLEXPORT_DEF
 bool MCBrowserLibraryInitialize()
 {
@@ -197,8 +195,18 @@ bool MCBrowserLibraryInitialize()
 MC_BROWSER_DLLEXPORT_DEF
 void MCBrowserLibraryFinalize()
 {
-	if (s_browser_factory)
-		delete s_browser_factory;
+	// IM-2016-03-10: [[ Bug 17029 ]] Delete any instantiated browser factories.
+	if (s_factory_list != nil)
+	{
+		for (uint32_t i = 0; s_factory_list[i].factory_id != nil; i++)
+		{
+			if (s_factory_list[i].instance != nil)
+			{
+				delete s_factory_list[i].instance;
+				s_factory_list[i].instance = nil;
+			}
+		}
+	}
 }
 
 //////////

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -394,9 +394,6 @@ void MCCefBrowserFinalise(void)
 	if (!s_cefbrowser_initialised)
 		return;
 	
-	// IM-2014-03-13: [[ revBrowserCEF ]] CEF library can't be cleanly shutdown and restarted - don't call finalise
-	// MCCefFinalise();
-	
 	if (!MC_CEF_USE_MULTITHREADED_MESSAGELOOP)
 		MCBrowserRemoveRunloopAction(MCCefBrowserRunloopAction, nil);
 	
@@ -1741,11 +1738,19 @@ MCCefBrowserFactory::MCCefBrowserFactory()
 
 MCCefBrowserFactory::~MCCefBrowserFactory()
 {
+	// IM-2016-03-10: [[ Bug 17029 ]] Shutdown CEF library when factory deleted
+	Finalize();
 }
 
 bool MCCefBrowserFactory::Initialize()
 {
 	return MCCefBrowserInitialise();
+}
+
+void MCCefBrowserFactory::Finalize()
+{
+	MCCefBrowserFinalise();
+	MCCefFinalise();
 }
 
 bool MCCefBrowserFactory::CreateBrowser(void *p_display, void *p_parent_view, MCBrowser *&r_browser)

--- a/libbrowser/src/libbrowser_cef.h
+++ b/libbrowser/src/libbrowser_cef.h
@@ -164,6 +164,7 @@ public:
 	//////////
 	
 	bool Initialize();
+	void Finalize();
 };
 
 bool MCCefBrowserFactoryCreate(MCBrowserFactoryRef &r_factory);


### PR DESCRIPTION
Fixes application hang on Windows when browser widget used.
