### PR TITLE
[[ MergExt ]] Build edition-appropriate mergExt docs into dictionary

### DIFF
--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -1908,8 +1908,13 @@ private function escape pString, pConvertLineEndings
    return (quote & pString & quote)
 end escape
 
-command docsBuilderGenerateDocsNew pEdition, pVersion
+command docsBuilderGenerateDocsNew pEdition, pVersion   
    start using stack (builderRepoFolder() & slash & "ide-support" & slash & "revdocsparser.livecodescript")
+   
+   -- Ensure we have downloaded and extracted all the mergExt data 
+   -- needed to build the docs for this edition
+   docsBuilderEnsureMergExt pEdition
+   
    builderLog "report", "Building guide into" && builderGuideFolder(pEdition) & slash & "distributed_guide.js"
    pathEnsure (builderGuideFolder(pEdition))
    docsBuilderGenerateDistributedGuide pEdition
@@ -1984,6 +1989,37 @@ private command docsBuilderGetGuideFolders pEdition, @xFolders
    end if
 end docsBuilderGetGuideFolders
 
+private command docsBuilderAddMergExtFolders pEdition, @xFolders
+   local tDefaultFolder
+   put the defaultFolder into tDefaultFolder
+   
+   local tTargetFolder
+   put docsBuilderMergExtExtractedDocsFolder(pEdition) into tTargetFolder
+   set the defaultFolder to tTargetFolder
+   
+   repeat for each line tFolder in the folders
+      if tFolder is ".." then next repeat
+      addFolderToListIfExists tTargetFolder & slash & tFolder, true, xFolders
+   end repeat
+   
+   set the defaultFolder to tDefaultFolder
+end docsBuilderAddMergExtFolders
+
+private command docsBuilderGetAdditionalDictionaryFolders pEdition, @xFolders
+   docsBuilderEnsureMergExt "community"
+   docsBuilderAddMergExtFolders "community", xFolders
+   
+   if pEdition is not "community" then
+      docsBuilderEnsureMergExt "indy"
+      docsBuilderAddMergExtFolders "indy", xFolders
+   end if
+   
+   if pEdition is "business" then
+      docsBuilderEnsureMergExt "business"
+      docsBuilderAddMergExtFolders "business", xFolders
+   end if
+end docsBuilderGetAdditionalDictionaryFolders
+
 private command docsBuilderGetDictionaryFolders pEdition, @xFolders
    local tCommunityDocs
    put builderRepoFolder() & slash & "docs" into tCommunityDocs
@@ -2026,13 +2062,52 @@ command docsBuilderGenerateDistributedGuide pEdition
    put textEncode(tGuideData, "utf-8") into url ("binfile:" & builderGuideFolder(pEdition) & slash & "distributed_guide.js")
 end docsBuilderGenerateDistributedGuide
 
+private function docsFileGetUTF8Contents pPath, pConvertLineEndings
+   local tData, tText
+   put url ("binfile:" & pPath) into tData
+   put textDecode(tData, "utf-8") into tText
+   if pConvertLineEndings then
+      replace numToChar(13) & numToChar(10) with numToChar(10) in tText
+      replace numToChar(13) with numToChar(10) in tText
+   end if
+   return tText
+end docsFileGetUTF8Contents
+
+-- Find all lcdoc files in pFolder and add them to the list of docs 
+-- data in xLibraryA
+private command addToDictionaryFromFolder pFolder, @xLibraryA
+   local tDefaultFolder
+   put the defaultFolder into tDefaultFolder
+   
+   docsBuilderProgressUpdate "", "Building dictionary from folder" && pFolder
+   set the defaultfolder to pFolder
+   get the files
+   filter it with "*.lcdoc"
+   repeat for each line tFile in it
+      local tText, tParsedA
+      wait 0 with messages
+      put docsFileGetUTF8Contents(pFolder & slash & tFile, true) into tText
+      put revDocsParseDocText(tText) into tParsedA
+      repeat for each element tDoc in tParsedA["doc"]
+         -- TODO: Work out why something empty is returned
+         if tDoc["display name"] is empty then next repeat
+         addToList tDoc, xLibraryA
+      end repeat
+   end repeat
+   set the defaultFolder to tDefaultFolder
+end addToDictionaryFromFolder
+
 /*
 Summary: Parses the current directory into a library array.
 
-pRootDir (string): The path to the root directory of the dictionary
+pRootDirs (array): An array of paths to the relevant root folders of the 
+dictionary.
 */
 
-function docsBuilderParseDictionaryToLibraryArray pRootDirs
+command docsBuilderParseDictionaryToLibraryArray pRootDirs, @xDocsA
+   local tDefaultFolder
+   put the defaultFolder into tDefaultFolder
+   
    # Get the list of canonical glossary entries
    local tGlossaryA
    repeat for each element tRootDir in pRootDirs
@@ -2044,28 +2119,25 @@ function docsBuilderParseDictionaryToLibraryArray pRootDirs
       put tRootDir & slash & "dictionary" into tDictionaryRoot
       put tRootDir & slash & "glossary" into tGlossaryRoot
       
-      local tText, tLibraryA, tParsedA
       repeat for each item tRoot in (tDictionaryRoot & "," & tGlossaryRoot)
          set the defaultfolder to tRoot
          repeat for each line tLine in the folders
             if tLine is ".." then next repeat
-            docsBuilderProgressUpdate "", "Building dictionary from folder" && tRoot & slash & tLine
-            set the defaultfolder to tRoot & slash & tLine
-            get the files
-            filter it with "*.lcdoc"
-            repeat for each line tFile in it
-               wait 0 with messages
-               put textDecode(url ("binfile:" & tRoot & slash & tLine & slash & tFile), "utf-8") into tText
-               put revDocsParseDocText(tText) into tParsedA
-               addToList tParsedA["doc"][1], tLibraryA
-            end repeat
+            addToDictionaryFromFolder tRoot & slash & tLine, xDocsA
          end repeat
       end repeat
    end repeat
-   return tLibraryA
+   set the defaultFolder to tDefaultFolder
 end docsBuilderParseDictionaryToLibraryArray
 
-function docsBuilderParseDictionary pLibraryName, pAuthor, pRootDirsA, pRecursive
+command docsBuilderParseAdditionalFoldersToLibraryArray pDirs, @xDocsA
+   local tFolder
+   repeat for each element tFolder in pDirs      
+      addToDictionaryFromFolder tFolder, xDocsA
+   end repeat
+end docsBuilderParseAdditionalFoldersToLibraryArray
+
+function docsBuilderParseDictionary pLibraryName, pAuthor, pRootDirsA, pAdditionalDirsA, pRecursive
    local tLibraryA
    
    put revDocsModifyForUrl(pLibraryName) into tLibraryA["name"]
@@ -2073,7 +2145,11 @@ function docsBuilderParseDictionary pLibraryName, pAuthor, pRootDirsA, pRecursiv
    put pAuthor into tLibraryA["author"]
    put "dictionary" into tLibraryA["type"]
    
-   put docsBuilderParseDictionaryToLibraryArray(pRootDirsA) into tLibraryA["doc"]
+   -- Special case for the dictionary / glossary data extraction
+   docsBuilderParseDictionaryToLibraryArray pRootDirsA, tLibraryA["doc"]
+   
+   -- Add any additional docs to the dictionary
+   docsBuilderParseAdditionalFoldersToLibraryArray pAdditionalDirsA, tLibraryA["doc"]
    
    if tLibraryA["doc"] is not empty then
       return tLibraryA
@@ -2083,13 +2159,14 @@ function docsBuilderParseDictionary pLibraryName, pAuthor, pRootDirsA, pRecursiv
 end docsBuilderParseDictionary
 
 command docsBuilderGenerateDistributedAPI pEdition
-   local tDictionaryFolders
+   local tDictionaryFolders, tAdditionalFolders
    docsBuilderGetDictionaryFolders pEdition, tDictionaryFolders
+   docsBuilderGetAdditionalDictionaryFolders pEdition, tAdditionalFolders
    
    local tLibrariesA
    
    local tLCSDictionaryA
-   put docsBuilderParseDictionary("LiveCode Script", "LiveCode", tDictionaryFolders, false) into tLCSDictionaryA
+   put docsBuilderParseDictionary("LiveCode Script", "LiveCode", tDictionaryFolders, tAdditionalFolders, false) into tLCSDictionaryA
    
    if tLCSDictionaryA is empty then
       builderLog "error", "Couldn't parse script dictionary data for" && pEdition
@@ -2208,6 +2285,93 @@ private command docsBuilderGenerateZip pEdition, pVersion
 
    builderLog "message", merge("Generated [[tZipPath]]")
 end docsBuilderGenerateZip
+
+function docsBuilderMergExtZipPath pEdition
+   -- Ensure edition has upper case first letter
+   put toUpper(char 1 of pEdition) & char 2 to -1 of pEdition into pEdition
+   return "https://downloads.livecode.com/mergext/mergExt_" & pEdition & ".zip"
+end docsBuilderMergExtZipPath
+
+function docsBuilderMergExtUnzipFolder
+   local tUnzipDirectory
+   put builderWorkFolder() & slash & "mergext" into tUnzipDirectory
+   pathEnsure tUnzipDirectory
+   return tUnzipDirectory
+end docsBuilderMergExtUnzipFolder
+
+function docsBuilderMergExtUnzipPath pEdition
+   put toUpper(char 1 of pEdition) & char 2 to -1 of pEdition into pEdition
+   return docsBuilderMergExtUnzipFolder() & slash & "mergExt_" & pEdition & ".zip"
+end docsBuilderMergExtUnzipPath
+
+function docsBuilderMergExtExtractedDocsFolder pEdition
+   local tExtractFolder
+   put docsBuilderMergExtUnzipFolder() & slash & pEdition into tExtractFolder
+   return tExtractFolder
+end docsBuilderMergExtExtractedDocsFolder
+
+command docsBuilderEnsureMergExt pEdition
+   local tDownloaded
+   put docsBuilderMergExtUnzipPath(pEdition) into tDownloaded
+   
+   if there is not a file tDownloaded then
+      docsBuilderDownloadMergExt pEdition
+   end if
+   
+   local tExtracted
+   put docsBuilderMergExtExtractedDocsFolder(pEdition) into tExtracted
+   if there is not a folder tExtracted then
+      docsBuilderExtractMergExt pEdition
+   end if
+end docsBuilderEnsureMergExt
+
+command docsBuilderDownloadMergExt pEdition
+   local tSource, tArchive
+   put docsBuilderMergExtZipPath(pEdition) into tSource
+   put docsBuilderMergExtUnzipPath(pEdition) into tArchive
+   builderLog "message", "downloading mergext from" && tSource && "to" && tArchive
+   put url(tSource) into url("binfile:" & tArchive)
+   
+   if there is not a file tArchive then
+      builderLog "error", "failed to download from" && tSource
+      exit docsBuilderDownloadMergExt
+   end if
+end docsBuilderDownloadMergExt
+
+command docsBuilderExtractMergExt pEdition
+   local tArchive
+   put docsBuilderMergExtUnzipPath(pEdition) into tArchive
+
+   -- open the archive   
+   revZipOpenArchive tArchive, "read"
+   if the result begins with "ziperr" then
+      builderLog "error", "failed to open archive" && tArchive & return & the result
+      exit docsBuilderExtractMergExt
+   end if
+   	
+   -- enumerate all lcdoc files
+   local tItems
+   put revZipEnumerateItems(tArchive) into tItems
+   filter tItems with "*.lcdoc"
+   
+   local tTargetFolder, tBaseFolder
+   put docsBuilderMergExtExtractedDocsFolder(pEdition) into tBaseFolder
+   pathEnsure tBaseFolder
+   set the itemDelimiter to slash
+   
+   -- Extract all lcdoc files to the edition-specific folder
+   repeat for each line tDoc in tItems
+      put item 1 to -2 of (tBaseFolder & slash & tDoc) into tTargetFolder
+      pathEnsure tTargetFolder
+      builderLog "message", "extracting mergext docs to" && tTargetFolder
+      revZipExtractItemToFile tArchive, tDoc, tBaseFolder & slash & tDoc
+      if the result begins with "ziperr" then
+         builderLog "error", "failed to extract docs to" && tTargetFolder & return & the result
+         exit docsBuilderExtractMergExt
+      end if
+   end repeat
+end docsBuilderExtractMergExt
+
 
 --- LEGACY
 

--- a/docs/dictionary/command/create.lcdoc
+++ b/docs/dictionary/command/create.lcdoc
@@ -2,7 +2,7 @@ Name: create
 
 Type: command
 
-Syntax: create [invisible] <type> [<name>] [in <group>]
+Syntax: create [invisible] <objectType> [<objectName>] [in <group>]
 
 Summary: Creates a new object on the current card.
 
@@ -21,41 +21,66 @@ Example:
 create invisible field in group 1
 
 Parameters:
-type (string): A string, one of the following: field, button, image, scrollbar, graphic, player, or EPS.
-name: The name to call the newly created object. If you don't specify a name, the object is created with a default name.
-group: A reference to a group on the current card or a expression that evaluates to a reference.any group that's on the current card. If you specify a group, the new object is a member of the group, and exists on each card that has the group. If you don't specify a group, the object is created on the current card and appears only on that card.
+objectType (enum): 
+- "field"
+- "button"
+- "image"
+- "scrollbar"
+- "graphic"
+- "player"
+objectName: The name to call the newly created object. If you don't 
+specify a name, the object is created with a default name.
+group: A reference or and expression that evaluates to a reference to a 
+group on the current card. If you specify a group, the new object is a 
+member of the group, and exists on each card that has the group. If you 
+don't specify a group, the object is created on the current card and 
+appears only on that card.
 
-It: The <create> command places the ID property of the newly created object in the it variable.
+It: The <create> command places the ID property of the newly created 
+object in the it variable.
 
 Description:
 Use the create command to make a new control or grouped control.
 
-The new object takes its properties from the corresponding template; for example, newly created buttons match the properties of the templateButton.
+The new object takes its properties from the corresponding template; for 
+example, newly created buttons match the properties of the 
+<templateButton>.
 
-If you use theform, the object is created with its visible property set to false, so it cannot be seen. Use this form to create a hidden object, change its appearance or position, then make it visible.
+If you use the invisible form, the object is created with its visible 
+property set to false, so it cannot be seen. Use this form to create a 
+hidden object, change its appearance or position, then make it visible.
 
-When the new control is created, the Pointer tool is automatically chosen. If you use the create command in a handler, you can use the following statement after the create command to resume using the Browse tool:
+When the new control is created, the Pointer tool is automatically 
+chosen. If you use the create command in a handler, you can use the 
+following statement after the create command to resume using the Browse 
+tool:
 
-send "choose browse tool" to me in 1 tick
+	send "choose browse tool" to me in 1 tick
 
->*Note:*  In the development environment, after an object is created, LiveCode automatically resets the corresponding template to its default values. This means that if you change an objecttemplate and then create several objects of that type, only the first object will reflect your settings. To prevent LiveCode from automatically setting the template back to its defaults, set the lockMessages property to true before creating the objects:
+>*Note:*  In the development environment, after an object is created, 
+LiveCode automatically resets the corresponding template to its default 
+values. This means that if you change an object template and then create 
+several objects of that type, only the first object will reflect your 
+settings. To prevent LiveCode from automatically setting the template 
+back to its defaults, set the <lockMessages> property to true before 
+creating the objects:
 
-LiveCode resets the template only when in the development environment, not in standalone applications.
+	set the borderWidth of the templateButton to 8
+	lock messages
+	repeat for 5 times
+	create button
+	end repeat
+	unlock messages
 
-set the borderWidth of the templateButton to 8
-lock messages
-repeat for 5 times
-create button
-end repeat
-unlock messages
+LiveCode resets the template only when in the development environment, 
+not in standalone applications.
 
-LiveCode resets the template only when in the development environment, not in standalone applications.
+>*Tip:*  To create a control in a specific stack, first set the 
+<defaultStack> to the stack where you want to create the new control:
 
->*Tip:*  To create a control in a specific stack, first set the defaultStack to the stack where you want to create the new control:
+	set the defaultStack to "My Stack"
+	create button "My Button"
 
-set the defaultStack to "My Stack"
-create button "My Button"
-
-References: create stack (command), create card (command)
+References: create stack (command), create card (command), templateButton (keyword), lockMessages (property), defaultStack (property)
 
 Tags: objects

--- a/docs/dictionary/command/mobileControlCreate.lcdoc
+++ b/docs/dictionary/command/mobileControlCreate.lcdoc
@@ -2,7 +2,7 @@ Name: mobileControlCreate
 
 Type: command
 
-Syntax: mobileControlCreate <controlType> [, <name> ]
+Syntax: mobileControlCreate <controlType> [, <controlName> ]
 
 Summary: Creates a native iOS or Android control.
 
@@ -41,14 +41,20 @@ controlType (enum): The type of control to create from among the following.
 - "player": Native iOS or Android player control
 - "input": Native iOS  or Android text input control
 - "multiline": Native iOS or Android multi-line text control
-name: Optional string to use to identify the control. The <name> must be unique amongst all existing controls and cannot be an integer.
 
-The result: The unique (numeric) id for the new control is returned in <the result>.
+controlName: Optional string to use to identify the control. 
+The <controlName> must be unique amongst all existing controls and 
+cannot be an integer.
+
+The result: The unique (numeric) id for the new control is returned in 
+<the result>.
 
 Description:
-Low-level support has been added for creating and manipulating some native mobile controls (views) on iOS and Android.
+Low-level support has been added for creating and manipulating some 
+native mobile controls (views) on iOS and Android.
 
-Native mobile iOS and Android controllers can only be created dynamically in script. 
+Native mobile iOS and Android controllers can only be created 
+dynamically in script. 
 
 To destroy a native control use: <mobileControlDelete> 
 To configure a native control use: <mobileControlSet> 

--- a/docs/dictionary/command/prepare-image.lcdoc
+++ b/docs/dictionary/command/prepare-image.lcdoc
@@ -2,7 +2,7 @@ Name: prepare image
 
 Type: command
 
-Syntax: prepare image <name> 
+Syntax: prepare image <imageName> 
 
 Syntax: prepare image file <filename> 
 
@@ -21,13 +21,23 @@ Example:
 prepare image file "/Disk/Folder/logo.jpg"
 
 Parameters:
-name: The name specifies what image is forced to be decompressed into the image cache.
-filename: The location and name of the image file you want to load and decompress into the image data cache. Since the image data cache is keyed on the absolute filename, any images which reference that file are able to use the data from the cache. This assumes that the cache has not been flushed.
+imageName: The name specifies what image is forced to be decompressed 
+into the image cache.
+
+filename: The location and name of the image file you want to load and 
+decompress into the image data cache. Since the image data cache is 
+keyed on the absolute filename, any images which reference that file are 
+able to use the data from the cache. This assumes that the cache has not 
+been flushed.
 
 Description:
-Use the <prepare image> <command> to speed up <execute|execution> when showing image data.
+Use the <prepare image> <command> to speed up <execute|execution> when 
+showing image data.
 
-Use the <prepare image> <command> to preload an image at some time before it is needed. Then access the image and display it as needed on your stack. Since the image is already cached into memory, it displays instantly.
+Use the <prepare image> <command> to preload an image at some time 
+before it is needed. Then access the image and display it as needed on 
+your stack. Since the image is already cached into memory, it displays 
+instantly.
 
 References: prepare (command), command (glossary), execute (glossary)
 

--- a/docs/dictionary/command/print-anchor.lcdoc
+++ b/docs/dictionary/command/print-anchor.lcdoc
@@ -2,7 +2,7 @@ Name: print anchor
 
 Type: command
 
-Syntax: print <anchor> <name> at <anchorPoint> 
+Syntax: print anchor <anchorName> at <anchorPoint> 
 
 Summary: Defines a target for an internal hyperlink within a PDF document.
 
@@ -19,16 +19,19 @@ Example:
 print anchor tAnchor at x,y
 
 Parameters:
-anchor: 
-name: A label used to identify the anchor
+anchorName: A label used to identify the anchor
 anchorPoint: An x,y coordinate pair
 
 Description:
-Use the <print anchor> command to define a target for an internal hyperlink within a pdf created using <open printing to pdf>.
+Use the <print anchor> command to define a target for an internal 
+hyperlink within a pdf created using <open printing to pdf>.
 
-The print anchor command defines a target for an internal hyperlink in a PDF file created using the <open printing to pdf> command.
+The print anchor command defines a target for an internal hyperlink in a 
+PDF file created using the <open printing to pdf> command.
 
-The name parameter is a label used to identify the anchor in related <print link> commands, and <anchorPoint> is the location on the current page to which any such link should jump.
+The name parameter is a label used to identify the anchor in related 
+<print link> commands, and <anchorPoint> is the location on the current 
+page to which any such link should jump.
 
 References: print link (command), print bookmark (command), open printing to pdf (command), cancel printing (command)
 

--- a/docs/dictionary/command/put-cookie.lcdoc
+++ b/docs/dictionary/command/put-cookie.lcdoc
@@ -2,7 +2,7 @@ Name: put cookie
 
 Type: command
 
-Syntax: put [<secure>] [<httponly>] cookie <name> [for <path>] [on <domain>] with <value> [until <expires>]
+Syntax: put [secure] [httponly] cookie <cookieName> [for <filePath>] [on <cookieDomain>] with <cookieValue> [until <expiryTime>]
 
 Summary: Sets a cookie in a visiting browser for a given URL.
 
@@ -31,27 +31,50 @@ Example:
 put secure httponly cookie "testcookie4" for "/products/" on "www.livecode.com" with "some cookie value" until (the seconds + 60 * 60 * 24 * 365)
 
 Parameters:
-secure: An optional value. If present, the browser only sends the cookie if communicating over a secure connection (https).
-httponly: An optional value. If present, the cookie is only available from the browser when communicating with the server and hidden from client-side scripting (for example JavaScript).
-i: 
-name (String): A String containing the name by which the cookie is identified.
-path (string): A string containing the path on the server at which the cookie is available. If a path is not specified, then the containing folder of the current URL is used.
-domain (string): A string containing the domain at which the cookie is available. If the domain is not specified, then the domain of the current URL is used.
-value (string): A string containing the contents of the cookie. This is automatically URL encoded.
-expires: A number containing the time at which the cookie expires. This is expressed in seconds since the UNIX epoch (midnight, January 1, 1970 GMT). If this is not specified or empty, the cookie expires when the client browser closes.
+cookieName (string): A string containing the name by which the cookie is 
+identified.
+filePath (string): A string containing the path on the server at which the 
+cookie is available. If a path is not specified, then the containing 
+folder of the current URL is used.
+cookieDomain (string): A string containing the domain at which the cookie is 
+available. If the domain is not specified, then the domain of the 
+current URL is used.
+cookieValue (string): A string containing the contents of the cookie. 
+This is automatically URL encoded.
+expiryTime: A number containing the time at which the cookie expires. This 
+is expressed in seconds since the UNIX epoch (midnight, January 1, 1970 
+GMT). If this is not specified or empty, the cookie expires when the 
+client browser closes.
 
 Description:
-Use the <put cookie> command to create a cookie with the given data in the visiting browser for a specific URL.
+Use the <put cookie> command to create a cookie with the given data in 
+the visiting browser for a specific URL.
 
-A cookie is used by a website to store state information in the user's browser, which is returned to the website on subsequent visits. Cookies are often used to store user preferences and session data. For example, you may allow a user to choose a theme through which to view your website and store this choice in a cookie to be used on subsequent visits.
+If the secure form is used, the browser only sends the cookie if 
+communicating over a secure connection (https).
 
-When setting a cookie you can specify a path. Cookies are returned to all URLs within the specified path. For example, a cookie set on the domain "www.livecode.com" with the following path:
+If the httponly form is used, the cookie is only available from the 
+browser when communicating with the server and hidden from client-side 
+scripting (for example JavaScript).
 
-/products/
+A cookie is used by a website to store state information in the user's 
+browser, which is returned to the website on subsequent visits. Cookies 
+are often used to store user preferences and session data. For example, 
+you may allow a user to choose a theme through which to view your 
+website and store this choice in a cookie to be used on subsequent 
+visits.
 
-Is available to all pages within and under http://www.livecode.com/products/
+When setting a cookie you can specify a path. Cookies are returned to 
+all URLs within the specified path. For example, a cookie set on the 
+domain "www.livecode.com" with the following path:
 
-To make the cookie available across your entire website, set the path to: "/"
+	/products/
+
+is available to all pages within and under 
+http://www.livecode.com/products/
+
+To make the cookie available across your entire website, set the path 
+to "/".
 
 >*Note:* Cookies must be set before any headers are sent.
 

--- a/docs/dictionary/command/revXMLInsertNode.lcdoc
+++ b/docs/dictionary/command/revXMLInsertNode.lcdoc
@@ -2,7 +2,7 @@ Name: revXMLInsertNode
 
 Type: command
 
-Syntax: revXMLInsertNode <treeId>, <siblingNode>, <name>, <contents>, [<location>]
+Syntax: revXMLInsertNode <treeId>, <siblingNode>, <nodeName>, <contents>, [<location>]
 
 Summary: Inserts a node as a sibling of siblingNode in the specified tree.
 
@@ -18,17 +18,28 @@ Example:
 revXMLInsertNode tTreeId, "sister", field "Name", field "Contents", "before"
 
 Parameters:
-treeId: The  the number returned by the revXMLCreateTree or revXMLCreateTreeFromFile function when you created the XML tree.
+treeId: The number returned by the <revXMLCreateTree> or 
+<revXMLCreateTreeFromFile> function when you created the XML tree.
 siblingNode: The node the new node will have as sibling after insertion.
-name: name is the name of the new node.
-contents: The  contents is the text to place in the new node.
-location: If location is not present or is equal to "after", the node will be added as the next sibling of siblingNode. If location is "before" then the node will be added as the previous sibling of siblingNode.
+nodeName: The name of the new node.
+contents: The text to place in the new node.
+location: If location is not present or is equal to "after", the node 
+will be added as the next sibling of <siblingNode>. If location is 
+"before" then the node will be added as the previous sibling of 
+<siblingNode>.
 
-The result: If the <revXMLInsertNode> <command> encounters an error, the <result> is set to an error message beginning with "xmlerr".
+The result: If the <revXMLInsertNode> <command> encounters an error, 
+the <result> is set to an error message beginning with "xmlerr".
 
 Description:
-Use revXMLInsertNode to insert a node into an XML tree.
+Use <revXMLInsertNode> to insert a node into an XML tree.
 
->*Important:*  The <revXMLInsertNode> <command> is part of the <XML library>. To ensure that the <command> works in a <standalone application>, you must include this <LiveCode custom library|custom library> when you create your <standalone application|standalone>. In the Inclusions section on the General screen of the <Standalone Application Settings> window, make sure "XML Library" is selected in the list of script libraries.
+> *Important:*  The <revXMLInsertNode> <command> is part of the 
+<XML library>. To ensure that the <command> works in a 
+<standalone application>, you must include this 
+<LiveCode custom library|custom library> when you create your 
+<standalone application|standalone>. In the Inclusions section on the 
+General screen of the <Standalone Application Settings> window, make 
+sure "XML Library" is selected in the list of script libraries.
 
 References: revXMLAppend (command), result (function), XML library (library), LiveCode custom library (library), Standalone Application Settings (glossary), standalone application (glossary), command (glossary)

--- a/docs/dictionary/function/uuid.lcdoc
+++ b/docs/dictionary/function/uuid.lcdoc
@@ -2,7 +2,7 @@ Name: uuid
 
 Type: function
 
-Syntax: uuid ([<type>, [namespace, <name>]])
+Syntax: uuid ([<uuidType>, [<namespace>, <uuidName>]])
 
 Summary: Genrates a universally unique identifier (UUID)
 
@@ -19,24 +19,31 @@ Example:
 put uuid(random) into tRandomUUID
 
 Parameters:
-type (enum): A string. The type of UUID to be generated, one of:
-- "empty"
+uuidType (enum): A string. The type of UUID to be generated, one of:
+- empty
 - "random"
 - "md5"
 - "sha1"
-name (string): Any string, where type is "md5" or "sha1"
-namespace_id: Where type is "md5" or "sha1" the UUID of the namespace in which the name sits
+uuidName (string): Any string, where type is "md5" or "sha1"
+namespace: Where type is "md5" or "sha1", the UUID of the namespace in 
+which the <uuidName> sits
 
 Returns:
-If the type is empty or random a version 4 (random) UUID is returned. A cryptographic quality pseudo-random number generator is used to generate the randomness.
-If the type is md5 a version 3 UUID is returned.
-If the type is sha1 a version 5 UUID is returned.
+If the <uuidType> is empty or "random" a version 4 (random) UUID is 
+returned. A cryptographic quality pseudo-random number generator is used 
+to generate the randomness.
+
+If the <uuidType> is md5 a version 3 UUID is returned.
+
+If the <uuidType> is sha1 a version 5 UUID is returned.
 
 Description:
 Use the <uuid> function to genrate a universally unique identifier.
 
 The <uuid> returns a UUID, the type of UUID can be specified.
 
-If type is "md5" or "sha1" then it returns a version 3 (md5) or version 5 (sha1) UUID. Here namespace_id should be the UUID of the namespace in which name sits, and name can be any string.
+If <uuidType> is "md5" or "sha1" then it returns a version 3 (md5) or 
+version 5 (sha1) UUID. Here <namespace> should be the UUID of the 
+namespace in which name sits, and <uuidName> can be any string.
 
 References: md5Digest (function)

--- a/docs/dictionary/keyword/private.lcdoc
+++ b/docs/dictionary/keyword/private.lcdoc
@@ -2,7 +2,7 @@ Name: private
 
 Type: keyword
 
-Syntax: private (command|function) <name> <parameterList> 
+Syntax: private (command|function) <handlerName> <parameterList> 
 
 Summary: The <private> keyword makes a function or command local to the script in which it is present
 
@@ -20,23 +20,40 @@ end someLocalCommand
 Example:
 private function someLocalFunction
    -- do something
- end someLocalFunction
+end someLocalFunction
 
 Parameters:
-name: 
-parameterList: 
+handlerName: The name of the handler
+parameterList: A comma-delimited list of the parameters
 
 Description:
-Use the <private> keyword to declare a <function> or <command> as local to the object whose script it is in and stop it being directly called by any other objects.
+Use the <private> keyword to declare a <function> or <command> as local 
+to the object whose script it is in and stop it being directly called by 
+any other objects.
 
-Whenever an implicit handler call is made (ie calling the handler simply by its name as opposed to using send or call), LiveCode will check the current script for a private handler before allowing the call to pass through the message path. If a private handler is found in the curent script, it will be directly called.
+Whenever an implicit handler call is made (ie calling the handler simply 
+by its name as opposed to using send or call), LiveCode will check the 
+current script for a private handler before allowing the call to pass 
+through the message path. If a private handler is found in the curent 
+script, it will be directly called.
 
->*Note:* Attempting to compile a private handler containing a <pass control structure> will cause a compilation error because private handlers cannot be passed through the message path.
+> *Note:* Attempting to compile a private handler containing a <pass> 
+control structure will cause a compilation error because private 
+handlers cannot be passed through the message path.
 
-The use of private handlers for functionality local to a particular object is recommended as it encourages better encapsulation and helps avoid problems with namespace pollution caused by multiple handlers in the message path with the same name.
+The use of private handlers for functionality local to a particular 
+object is recommended as it encourages better encapsulation and helps 
+avoid problems with namespace pollution caused by multiple handlers in 
+the message path with the same name.
 
-Using private handlers when appropriate will also result in a performance gain as less messages are passed through the message path.
+Using private handlers when appropriate will also result in a 
+performance gain as fewer messages are passed through the message path.
 
->*Note:* Although it is also possible to use <on> when declaring a private handler this is not recommended as it implies that the handler is a message sent when some event occurs. As private handlers are not passed through the message path, this is incorrect and can make the code harder to understand. Please see the <on control structure> entry for more details.
+> *Note:* Although it is also possible to use <on> when declaring a 
+private handler this is not recommended as it implies that the handler 
+is a message sent when some event occurs. As private handlers are not 
+passed through the message path, this is incorrect and can make the code 
+harder to understand. Please see the <on> control structure entry for 
+more details.
 
-References: command (glossary), function (glossary), on control structure (glossary), pass control structure (glossary), on (control_st), function (control_st)
+References: command (glossary), function (glossary), pass (control_st), on (control_st), function (control_st)

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -1345,8 +1345,7 @@ function revDocsParseDocText pText, pFilename
          case empty
             exit repeat
          case "Library"
-            put tElementsA[tStartNum]["content"] into tParsedA["display name"]
-            put revDocsModifyForURL(tParsedA["display name"]) into tParsedA["name"]
+            put tElementsA[tStartNum]["content"] into tParsedA["name"]
             add 1 to tStartNum
             break
          case "Description"
@@ -1434,6 +1433,7 @@ function revDocsParseDocText pText, pFilename
    local tCount
    put 1 into tCount
    add 1 to tEntryCount
+   
    repeat for each item tItem in "name,description,author,type,example"
       if tParsedA[tItem] is not empty then
          put tItem into tEntriesA[tEntryCount]["elements"][tCount]["name"]


### PR DESCRIPTION
Also fixes a few issues the above brought to light, namely
- Some of the dictionary entries had parameters called <name> which causes issues for the parser
- The parser was lower casing the library display names
