### PR TITLE
Fix use of MCObject::setcustomprop()

### DIFF
--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -865,7 +865,7 @@ IO_stat MCDispatch::startup(void)
 		MCExecValue t_value;
 		t_value . int_value = (integer_t)t_info . banner_timeout;
 		t_value . type = kMCExecValueTypeInt;
-		t_banner_stack -> setcustomprop(ctxt, kMCEmptyName, MCNAME("uTimeout"), t_value);
+		t_banner_stack -> setcustomprop(ctxt, kMCEmptyName, MCNAME("uTimeout"), nil, t_value);
 		
 		t_banner_stack -> open();
 		double t_end_time;


### PR DESCRIPTION
Its prototype was updated in one branch and a use added in another
without being detected by CI, review or git merge conflict.  Bad
times!
