### PR TITLE
browser: Don't access host properties in OnPaint()

### DIFF
--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -761,8 +761,8 @@ public handler OnPaint() returns nothing
 	put solid paint with color [0.25, 0.25, 0.25] into tStrokePaint
 
 	variable tNameString as String
-	put property "name" of my script object into tNameString
-	
+	put "Browser Widget" into tNameString
+
 	set the font of this canvas to font "Arial" at size 14
 
 	variable tTextBounds as Rectangle


### PR DESCRIPTION
It's no longer permitted to run LCS code from `OnPaint()`, and
`property "name" of my script object` is included in that
prohibition.

For now, just draw "Browser Widget" rather than the actual name
of the control.
