### PR TITLE
[[ ReplaceInField ]] Implement the 'replace in field' command.

### DIFF
--- a/docs/dictionary/command/replace-in-field.lcdoc
+++ b/docs/dictionary/command/replace-in-field.lcdoc
@@ -1,0 +1,37 @@
+Name: replace in field
+
+Type: command
+
+Syntax: replace <oldString> with <newString> in <fieldContainer> (preserving | replacing) styles 
+
+Summary: Replaces text in a field container with other text with control over what happens to existing styling.
+
+Introduced: 8.0
+
+OS: mac,windows,linux,ios,android
+
+Platforms: desktop,server,web,mobile
+
+Example:
+replace "A" with "N" in field 1 preserving styles -- changes all As to Ns; the Ns will retain the styling of the As
+
+Example:
+replace "foo" with "bar" in char 1 to 3 of tFieldId replacing styles -- changes foo to bar in the given range of the field reference in tFieldId; the bars will have no styling.
+
+Parameters:
+oldString (string): Any expression that evaluates to a string, and specifies the text to replace.
+newString (string): Any expression that evaluates to a string, and specifies the text to replace the oldString with.
+fieldContainer: A field chunk.
+
+Description:
+Use the <replace in field> <command> to replace all instances of one <string> with another <string> in (part of) a field, with the choice as to whether styling is preserved or replaced.
+
+If the preserving form is used, then the found strings will be replaced in the target field and the replacement text will take the same style as the first character in the found string.
+
+If the replacing form is used, then the found strings will be replaced in the target field and the replacement text will have no style.
+
+All styling outside of the instances of the pattern which are found is unaffected.
+
+References: field (object), string (keyword), field (keyword), command (glossary), regular expression (glossary), container (glossary), replaceText (function), find (command), filter (command), replace (command), function (control_st)
+
+Tags: text processing

--- a/docs/dictionary/command/replace.lcdoc
+++ b/docs/dictionary/command/replace.lcdoc
@@ -34,12 +34,8 @@ Use the <replace> <command> to replace all instances of one <string> with anothe
 
 The <replace> <command> is faster than the <replaceText> <function>, but does not support <regular expression|regular expressions>: you can replace only an exact <string> of text.
 
->*Important:*  You can use the <replace> <command> on a <field(keyword)>, but doing so removes any formatting (fonts, styles, colors, and sizes) in the field. To work around this limitation, use the <field(object)|field's> <htmlText> property as the source for replacement instead of using the <field(keyword)> itself as the source:
+>*Important:*  You can use the <replace> <command> on a <field(keyword)>, but doing so removes any formatting (fonts, styles, colors, and sizes) in the field. To preserve existing styling in fields use the <replace in field> command.
 
-  get the htmlText of field "Stuff"
-  replace "old" with "new" in it
-  set the htmlText of field "Stuff" to it
-
-References: HTMLText (property), field (object), string (keyword), field (keyword), command (glossary), regular expression (glossary), container (glossary), replaceText (function), find (command), filter (command), replace (command), function (control_st)
+References: field (object), string (keyword), field (keyword), command (glossary), regular expression (glossary), container (glossary), replaceText (function), find (command), filter (command), replace (command), function (control_st), replace in field (command)
 
 Tags: text processing

--- a/docs/notes/feature-replace_in_fields.md
+++ b/docs/notes/feature-replace_in_fields.md
@@ -3,7 +3,7 @@
 There is a new form of the 'replace' command which works directly
 with fields:
 
-  replace <pattern> with <text> in <field chunk> (replacing | preserving) styles
+    replace <pattern> with <text> in <field chunk> (replacing | preserving) styles
 
 The replacing form of the command replaces each occurrence of 'pattern' in
 the specified field chunk with 'text', removing all styling from the found

--- a/docs/notes/feature-replace_in_fields.md
+++ b/docs/notes/feature-replace_in_fields.md
@@ -1,0 +1,17 @@
+# Replacing text in fields
+
+There is a new form of the 'replace' command which works directly
+with fields:
+
+  replace <pattern> with <text> in <field chunk> (replacing | preserving) styles
+
+The replacing form of the command replaces each occurrence of 'pattern' in
+the specified field chunk with 'text', removing all styling from the found
+range.
+
+The preserving form of the command replaces each occurrence of 'pattern' in
+the specified field chunk with 'text', retaining the style which was present
+on the first char of the occurrence of the pattern for the whole of the
+replacement.
+
+**This feature was sponsored by the community Feature Exchange.**

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -844,14 +844,24 @@ public:
 
 class MCReplace : public MCStatement
 {
+	enum Mode
+	{
+		kIgnoreStyles,
+		kReplaceStyles,
+		kPreserveStyles,
+	};
+	
 	MCExpression *pattern;
 	MCExpression *replacement;
 	MCChunk *container;
+	Mode mode;
+	
 public:
 	MCReplace()
 	{
 		pattern = replacement = NULL;
 		container = NULL;
+		mode = kIgnoreStyles;
 	}
 	virtual ~MCReplace();
 	virtual Parse_stat parse(MCScriptPoint &);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3149,6 +3149,7 @@ void MCInterfaceExecExportObjectToArray(MCExecContext& ctxt, MCObject *p_contain
 void MCInterfaceExecSortCardsOfStack(MCExecContext &ctxt, MCStack *p_target, bool p_ascending, int p_format, MCExpression *p_by, bool p_only_marked);
 void MCInterfaceExecSortField(MCExecContext &ctxt, MCObjectPtr p_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by);
 void MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef& x_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by);
+void MCInterfaceExecReplaceInField(MCExecContext& ctxt, MCStringRef p_pattern, MCStringRef p_replacement, MCObjectChunkPtr& p_container, bool p_preserve_styles);
 
 void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_tool);
 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2698,6 +2698,9 @@ enum Exec_errors
 
 	// {EE-0883} save: error in file format expression
 	EE_SAVE_BADNOFORMATEXP,
+	
+	// {EE-0884} replace: not a field chunk
+	EE_REPLACE_BADFIELDCHUNK,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -175,6 +175,21 @@ struct MCInterfaceFieldRange;
 // SN-2014-11-04: [[ Bug 13934 ]] Add forward declaration for the friends function of MCField
 struct MCFieldLayoutSettings;
 
+// Specifies how styling should be applied to replaced text.
+enum MCFieldStylingMode
+{
+	// The new text will have no style.
+	kMCFieldStylingNone,
+	
+	// The new text will take the style from the character before the start
+	// of the insertion range.
+	kMCFieldStylingFromBefore,
+	
+	// The new text will take the style from the character after the start
+	// of the insertion range.
+	kMCFieldStylingFromAfter,
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class MCField : public MCControl
@@ -425,7 +440,11 @@ public:
     void setparagraphs(MCParagraph *newpgptr, uint4 parid, findex_t p_start, findex_t p_end, bool p_preserv_zero_length_styles = false);
     // SN-2014-01-17: [[ Unicodification ]] Suppressed old string version of settext and settextindex
     Exec_stat settext(uint4 parid, MCStringRef p_text, Boolean p_formatted);
-	Exec_stat settextindex(uint4 parid, findex_t si, findex_t ei, MCStringRef s, Boolean undoing);
+	
+	// If 'preserve_first_style' is true, then the style of s will be the same as the style
+	// immediately following si.
+	Exec_stat settextindex(uint4 parid, findex_t si, findex_t ei, MCStringRef s, Boolean undoing, MCFieldStylingMode styling_mode = kMCFieldStylingFromBefore);
+	
 	void getlinkdata(MCRectangle &r, MCBlock *&sb, MCBlock *&eb);
     
 #ifdef LEGACY_EXEC

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -643,7 +643,7 @@ MCParagraph *MCField::verifyindices(MCParagraph *p_top, findex_t& si, findex_t& 
 	return t_start_pg;
 }
 
-Exec_stat MCField::settextindex(uint4 parid, findex_t si, findex_t ei, MCStringRef p_text, Boolean undoing)
+Exec_stat MCField::settextindex(uint4 parid, findex_t si, findex_t ei, MCStringRef p_text, Boolean undoing, MCFieldStylingMode p_styling_mode)
 {
 	state &= ~CS_CHANGED;
 	if (!undoing)
@@ -718,8 +718,10 @@ Exec_stat MCField::settextindex(uint4 parid, findex_t si, findex_t ei, MCStringR
         // First delete the portion of the first paragraph in the range.
         int4 tei;
         tei = MCMin(ei, pgptr -> gettextlength());
-        
-		pgptr->deletestring(si, tei);
+		
+		// Pass through the first style preservation flag. This will leave us with
+		// a zero length block at si (which finsertnew will extend).
+		pgptr->deletestring(si, tei, p_styling_mode);
         ei -= (tei - si);
         
 		if (ei > pgptr -> gettextlength())

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -2134,17 +2134,20 @@ static LT sugar_table[] =
 		{"path", TT_UNDEFINED, SG_PATH},
 		// JS-2013-07-01: [[ EnhancedFilter ]] Token for 'pattern'.
 		{"pattern", TT_UNDEFINED, SG_PATTERN},
+		{"preserving", TT_UNDEFINED, SG_PRESERVING},
         {"real", TT_UNDEFINED, SG_REAL},
 		// MERG-2013-08-26: [[ RecursiveArrayOp ]] Support nested arrays in union and intersect
 		// AL-2013-10-30: [[ Bug 11351 ]] Ensure table is in alphabetical order.
         {"recursively", TT_UNDEFINED, SG_RECURSIVELY},
 		// JS-2013-07-01: [[ EnhancedFilter ]] Token for 'regex'.
 		{"regex", TT_UNDEFINED, SG_REGEX},
+		{"replacing", TT_UNDEFINED, SG_REPLACING},
 		{"resource", TT_UNDEFINED, SG_RESOURCE},
 		{"standard", TT_UNDEFINED, SG_STANDARD},
         {"strictly", TT_UNDEFINED, SG_STRICTLY},
 		// MERG-2013-06-24: [[ IsAnAsciiString ]] Token for 'string'.
         {"string", TT_UNDEFINED, SG_STRING},
+		{"styles", TT_UNDEFINED, SG_STYLES},
 		// MW-2013-11-14: [[ AssertCmd ]] Token for 'success'
 		{"success", TT_UNDEFINED, SG_SUCCESS},
 		// MW-2013-11-14: [[ AssertCmd ]] Token for 'true'

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -308,12 +308,9 @@ public:
 	// paragraph after which a word-break can occur.
 	findex_t findwordbreakafter(MCBlock *p_block, findex_t p_index);
 
-	// Make sure there are no empty blocks in the paragraph:
-	//   - called by MCField::deleteselection
-	//   - called by MCField::fdel
-	//   - called by MCField::freturn
-	//   - called by methods in MCParagraph
-	Boolean clearzeros();
+	// Remove all empty blocks in the paragraph starting at
+	// the specified block (inclusive).
+	Boolean clearzeros(MCBlock *start_from = nil);
 	
 	// Return the list of blocks:
 	//   - called by MCField::getparagraphmacstyles
@@ -371,10 +368,15 @@ public:
     void replacetextwithparagraphs(findex_t p_start, findex_t p_finish, MCParagraph *p_pglist);
 
 	// Delete the text from si to ei in the paragraph.
-	// Called by:
-	//   MCField::deletecomposition
-	//   MCField::settextindex
-	void deletestring(findex_t si, findex_t ei);
+	// The 'styling_mode' determines what block is left at si.
+	// If it is 'frombefore' then no block is left so any text inserted at si will
+	// take styles from the preceeding block.
+	// If it is 'fromafter' then a zero length block with the same style as the first
+	// char in the deleted string is left so any text inserted at si will take
+	// styles from the first char in the deleted string.
+	// If it is 'none' then a zero length block with no styles is left so any text
+	// inserted at si will have no style.
+	void deletestring(findex_t si, findex_t ei, MCFieldStylingMode p_preserve_first_style = kMCFieldStylingFromBefore);
 
 	// Delete the current selection in the paragraph.
 	// Called by:

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1952,6 +1952,10 @@ enum Sugar_constants {
     
     SG_STRICTLY,
     SG_REAL,
+	
+	SG_REPLACING,
+	SG_PRESERVING,
+	SG_STYLES,
 };
 
 enum Statements {

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1754,6 +1754,9 @@ enum Parse_errors
 	// {PE-0568} save: error in format expression
 	PE_SAVE_BADFORMATEXP,
 	
+	// {PE-0569} replace: missing 'styles'
+	PE_REPLACE_NOSTYLES,
+	
 };
 
 extern const char *MCparsingerrors;

--- a/tests/lcs/core/field/replace-in-field.livecodescript
+++ b/tests/lcs/core/field/replace-in-field.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "CoreFieldReplaceInField"
 /*
-Copyright (C) 2015 LiveCode Ltd.
+Copyright (C) 2016 LiveCode Ltd.
 
 This file is part of LiveCode.
 

--- a/tests/lcs/core/field/replace-in-field.livecodescript
+++ b/tests/lcs/core/field/replace-in-field.livecodescript
@@ -1,0 +1,40 @@
+﻿script "CoreFieldReplaceInField"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestReplaceInField
+   open this stack
+   create field "Text"
+   
+   set the htmlText of field "Text" to "<p><b>foo</b> <i>foobar</i> <i><b>foobar</b></i> <u>foo</u></p>"
+   replace "foo" with "baz" in field "Text" preserving styles
+   TestAssert "replace in whole field preserving styles", the htmlText of field "Text" is "<p><b>baz</b> <i>bazbar</i> <i><b>bazbar</b></i> <u>baz</u></p>"
+   
+   set the htmlText of field "Text" to "<p><b>foo</b> <i>foobar</i> <i><b>foobar</b></i> <u>foo</u></p>"
+   replace "foo" with "baz" in field "Text" replacing styles
+   TestAssert "replace in whole field preserving styles", the htmlText of field "Text" is "<p>baz baz<i>bar</i> baz<i><b>bar</b></i> baz</p>"
+   
+   set the htmlText of field "Text" to "<p><b>foo</b> <i>foobar</i> <i><b>foobar</b></i> <u>foo</u></p>"
+   replace "foo" with "baz" in word 2 to 3 of field "Text" preserving styles
+   TestAssert "replace in range of field preserving styles", the htmlText of field "Text" is "<p><b>foo</b> <i>bazbar</i> <i><b>bazbar</b></i> <u>foo</u></p>"
+   
+   set the htmlText of field "Text" to "<p><b>foo</b> <i>foobar</i> <i><b>foobar</b></i> <u>foo</u></p>"
+   replace "foo" with "baz" in word 2 to 3 of field "Text" replacing styles
+   TestAssert "replace in range of field preserving styles", the htmlText of field "Text" is "<p><b>foo</b> baz<i>bar</i> baz<i><b>bar</b></i> <u>foo</u></p>"
+   
+   delete field "Text"
+end TestReplaceInField


### PR DESCRIPTION
This patch implements:

```
  replace ... with ... in <field chunk> (replacing | preserving) styles
```

It differs from the replace command in the following ways:

The field chunk is always evaluated as a field. This means that
'char 1 to 5 of tLongIdOfField' will be interpreted as char range
1 to 5 of the field which tLongIdOfField resolves to (rather than
of the variable).

If the preserving form is specified the replacement text takes the
style of the first char of the found pattern in each case.

If the replacing form is specified the replacement text takes no
style.
