### PR TITLE
[[ LCB ]] Add 'my name' syntax

### DIFF
--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -198,6 +198,14 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetExecPost(MCStringRef p_message)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMyName(MCStringRef& r_name)
+{
+	if (!MCWidgetEnsureCurrentWidget())
+		return;
+	
+	r_name = MCValueRetain(MCNameGetString(MCWidgetGetHost(MCcurrentwidget) -> getname()));
+}
+
 extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMyBounds(MCCanvasRectangleRef& r_rect)
 {
     if (!MCWidgetEnsureCurrentWidget())

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -472,6 +472,7 @@ end syntax
 // ---------- External properties of widgets ---------- //
 
 public foreign handler MCWidgetGetMyScriptObject(out rObject as ScriptObject) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetMyName(out rName as String) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetMyRectangle(out rRect as Rectangle) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetMyBounds(out rRect as Rectangle) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetMyWidth(out rWidth as Real) returns nothing binds to "<builtin>"
@@ -493,7 +494,19 @@ begin
     MCWidgetGetMyScriptObject(output)
 end syntax
 
-/* 
+/*
+Summary:	Returns the name of the widget's script object
+
+Returns:	The name of the widget's script object
+*/
+
+syntax MyName is expression
+	"my" "name"
+begin
+	MCWidgetGetMyName(output)
+end syntax
+
+/*
 Summary:	Returns the rectangle of the widget in the parent
 
 Returns:	The rectangle of the widget in the parent

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -761,7 +761,7 @@ public handler OnPaint() returns nothing
 	put solid paint with color [0.25, 0.25, 0.25] into tStrokePaint
 
 	variable tNameString as String
-	put property "name" of my script object into tNameString
+	put my name into tNameString
 	
 	set the font of this canvas to font "Arial" at size 14
 


### PR DESCRIPTION
This patch adds 'my name' syntax to LCB. This allows widgets to fetch
the (short) name of the host script object.
