### PR TITLE
[[ Trial ]] Tweaks

### DIFF
--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -761,6 +761,8 @@ void MCIdeDeploy::exec_ctxt(MCExecContext& ctxt)
 	if (t_license_class == kMCLicenseClassNone)
 		t_license_class = MClicenseparameters . license_class;
 	
+	t_params . banner_class = t_license_class;
+	
 	// Now check to see if we should build a trial - this if the license class is a
 	// trail, or the banner_class override is specified and the chosen option is
 	// compatible with the license class.

--- a/engine/src/java/com/runrev/android/BitmapView.java
+++ b/engine/src/java/com/runrev/android/BitmapView.java
@@ -157,7 +157,7 @@ public class BitmapView extends View
 		Resources t_resources;
 		t_resources = getContext().getResources();
 		
-		p_canvas . drawRGB(50, 50, 50);
+		p_canvas . drawRGB(255, 255, 255);
 		
 		int t_splash_image_id;
 		t_splash_image_id = t_resources.getIdentifier("drawable/splash_image", null, t_package);


### PR DESCRIPTION
This patch fixes a license type mismatch when building standalones
and tweaks the background color of the android banner to be white.
