### PR TITLE
[[ Bug 17109 ]] Fix hang when parsing invalid SVG path data.

### DIFF
--- a/docs/notes/bugfix-17109.md
+++ b/docs/notes/bugfix-17109.md
@@ -1,0 +1,1 @@
+# Invalid SVG path description now throws an error.


### PR DESCRIPTION
The SVG path parsing code would enter an infinite loop on
encountering an invalid path command char. This has been
fixed.
