### PR TITLE
[Bug 17137] browser: Set default values for scrollbar properties.

### DIFF
--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -322,9 +322,11 @@ metadata htmlText.user_visible is "false" -- bug 16927
 
 property vScrollbar get getVScrollbar set setVScrollbar
 metadata vScrollbar.editor is "com.livecode.pi.boolean"
+metadata vScrollbar.default is "false"
 
 property hScrollbar get getHScrollbar set setHScrollbar
 metadata hScrollbar.editor is "com.livecode.pi.boolean"
+metadata hScrollbar.default is "false"
 
 property userAgent get getUserAgent set setUserAgent
 metadata userAgent.editor is "com.livecode.pi.text"

--- a/extensions/widgets/browser/notes/17137.md
+++ b/extensions/widgets/browser/notes/17137.md
@@ -1,0 +1,1 @@
+# [17137] Set default values for hScrollbar and vScrollbar properties


### PR DESCRIPTION
The **vScrollBar** and **hScrollBar** properties are booleans.
However, the browser LiveCode Builder source code doesn't specify
a default value for them, which means the property inspector tries
to set their value to empty when the browser is dragged out from
tools palette.  Since the empty string isn't a boolean (according
to the LiveCode Script to LiveCode Builder default conversion
rules) bad things happen.
