### PR TITLE
[[ Bug 17138 ]] Make sure geometry updates are deferred consistently

### DIFF
--- a/docs/notes/bugfix-17138.md
+++ b/docs/notes/bugfix-17138.md
@@ -1,0 +1,1 @@
+# Browser: Fix windows browser not setting correct size when resized after creation


### PR DESCRIPTION
This fixes a bug where geometry updates to native layers were not happening when a browser was resized after being created but before being made visible.
