### PR TITLE
Fix <my width> documentation

### DIFF
--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -517,9 +517,9 @@ begin
 end syntax
 
 /*
-Summary:	Returns the height of the widget.
+Summary:	Returns the width of the widget.
 
-Returns:	The height of the widget.
+Returns:	The width of the widget.
 */
 
 syntax MyWidth is expression


### PR DESCRIPTION
The documentation for <my width> referred to the height of the widget rather than the width of the widget.
