### PR TITLE
[Bug 17068] Parse "ask files()" correctly

### DIFF
--- a/docs/notes/bugfix-17068.md
+++ b/docs/notes/bugfix-17068.md
@@ -1,0 +1,1 @@
+# Parse "ask files()" correctly

--- a/engine/src/ask.cpp
+++ b/engine/src/ask.cpp
@@ -117,6 +117,7 @@ Parse_stat MCAsk::parse(MCScriptPoint &sp)
 
 		default:
 			sp . backup();
+			mode = AT_QUESTION;
 			t_error = parse_question(sp);
 		break;
 	}


### PR DESCRIPTION
When backing up the MCAsk parser after failing to parse "ask files()"
as "ask files", reset to the default ask type (i.e. question).
