### PR TITLE
[[ Bug 17154 ]] Update mfocused when parent rect is changed

### DIFF
--- a/docs/notes/bugfix-17154.md
+++ b/docs/notes/bugfix-17154.md
@@ -1,0 +1,1 @@
+# Moving a group containing the focused object doesn't update the focused object

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -3748,11 +3748,11 @@ void MCObject::SetRectProp(MCExecContext& ctxt, bool p_effective, MCRectangle p_
 			MCControl *mfocused = MCmousestackptr->getcard()->getmfocused();
 			if (MCU_point_in_rect(rect, MCmousex, MCmousey))
 			{
-				if (!MCU_point_in_rect(t_rect, MCmousex, MCmousey) && this == mfocused)
+				if (!MCU_point_in_rect(t_rect, MCmousex, MCmousey) && isancestorof(mfocused))
 					needmfocus = true;
 			}
 			else
-				if (MCU_point_in_rect(t_rect, MCmousex, MCmousey) && this != mfocused)
+				if (MCU_point_in_rect(t_rect, MCmousex, MCmousey) && isancestorof(mfocused))
 					needmfocus = true;
 		}
 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -5327,19 +5327,7 @@ void MCObject::sync_mfocus(void)
             // MW-2012-02-22: [[ Bug 10018 ]] If the target is a group then check
             //   to see if it is the ancestor of the mfocused control; otherwise
             //   just compare directly.
-            if (mfocused != nil && gettype() == CT_GROUP)
-            {
-                while(mfocused -> gettype() != CT_CARD)
-                {
-                    if (mfocused == this)
-                    {
-                        needmfocus = True;
-                        break;
-                    }
-                    mfocused = mfocused -> getparent();
-                }
-            }
-            else if (this == mfocused)
+            if (isancestorof(mfocused))
                 needmfocus = true;
         }
         else if (MCU_point_in_rect(rect, MCmousex, MCmousey))
@@ -5359,6 +5347,20 @@ void MCObject::sync_mfocus(void)
     
     if (needmfocus)
         MCmousestackptr->getcard()->mfocus(MCmousex, MCmousey);
+}
+
+bool MCObject::isancestorof(MCObject *p_object)
+{
+    if (p_object == nil)
+        return false;
+    
+    if (this == p_object)
+        return true;
+    
+    if (gettype() != CT_GROUP)
+        return false;
+    
+    return isancestorof(p_object -> getparent());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -949,6 +949,10 @@ public:
     // display for widgets.
     MCStringRef gettooltip(void) {return tooltip;}
     
+    // Returns true if this object is an ancestor *control* of p_object
+    //  in the parent chain.
+    bool isancestorof(MCObject *p_object);
+    
 	////////// PROPERTY SUPPORT METHODS
 
 	void Redraw(void);


### PR DESCRIPTION
This fixes the issue seen in the tutorial where clicking on the
inspector menubar icon failed sometimes.

The reason is that before the mouse down message is sent, the
menubar performs a layout which temporarily moves controls in
a group underneath the mouse pointer (which updates the mouse
focus). The group itself is subsequently moved away, which does
_not_ update the mouse focus, as MCObject::SetRectProp only
checks if the card focus is the object being moved.

This fixes the issue by recalculating the mouse focus if the moved
control is an ancestor of the focused control, rather than equal
to it.
