### PR TITLE
Feature not equal operator

### DIFF
--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -513,6 +513,7 @@ static LT export_table[] =
 
 LT factor_table[] =
     {
+    	// MDW-2016-03-16 [[ feature_not_equal_operator ]] implement ! and != operators
         {"!", TT_UNOP, O_NOT},
         {"!=", TT_BINOP, O_NE},
         {"&", TT_BINOP, O_CONCAT},

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -513,6 +513,8 @@ static LT export_table[] =
 
 LT factor_table[] =
     {
+        {"!", TT_UNOP, O_NOT},
+        {"!=", TT_BINOP, O_NE},
         {"&", TT_BINOP, O_CONCAT},
         {"&&", TT_BINOP, O_CONCAT_SPACE},
         {"(", TT_LPAREN, O_GROUPING},


### PR DESCRIPTION
Since this was so easy to implement, I figure there must be a reason it hasn't been done, so I'm open for comments.

This implements both the ! and the != operators:

put 2 != 3
put !(2=3)
put !false

The only downside I see is the removal of "!" as a valid character in variable names, and that operator can be easily separated from the != operator by commenting one line here.
