### PR TITLE
Make property label casing consistent.

### DIFF
--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -330,9 +330,11 @@ metadata hScrollbar.default is "false"
 
 property userAgent get getUserAgent set setUserAgent
 metadata userAgent.editor is "com.livecode.pi.text"
+metadata userAgent.label is "User agent"
 
 property javascriptHandlers get getJavaScriptHandlers set setJavaScriptHandlers
 metadata javascriptHandlers.editor is "com.livecode.pi.text"
+metadata javascriptHandlers.label is "JavaScript handlers"
 
 --------------------------------------------------------------------------------
 

--- a/extensions/widgets/graph/graph.lcb
+++ b/extensions/widgets/graph/graph.lcb
@@ -88,7 +88,7 @@ metadata graphColors.editor is "com.livecode.pi.editorList"
 metadata graphColors.subeditor is "com.livecode.pi.color"
 metadata graphColors.delimiter is "\n"
 metadata graphColors.default is "255,0,155,255\n155,100,255,255\n100,255,100,255"
-metadata graphColors.label is "Line Colors"
+metadata graphColors.label is "Line colors"
 metadata graphColors.section is "Colors"
 
 /*
@@ -106,7 +106,7 @@ Controls whether the horizontal lines on the graph are shown.
 */
 property graphXLines get mGridHShow set setXLinesVisibility
 metadata graphXLines.default is "true"
-metadata graphXLines.label is "Horizontal Grid Lines"
+metadata graphXLines.label is "Horizontal grid lines "
 
 /*
 Summary: Controls whether the vertical lines on the graph are shown.
@@ -123,7 +123,7 @@ Controls whether the vertical lines on the graph are shown.
 */
 property graphYLines get mGridVShow set setYLinesVisibility
 metadata graphYLines.default is "true"
-metadata graphYLines.label is "Vertical Grid Lines"
+metadata graphYLines.label is "Vertical grid lines"
 
 /*
 Summary: Controls which point on the graph is highlighted.
@@ -141,7 +141,7 @@ coordinates using dotted lines from both the axes.
 */
 property hilitedCoordinates get GetHilitedCoordinates set SetHilitedCoordinates
 metadata hilitedCoordinates.default is ""
-metadata hilitedCoordinates.label is "Hilited Coordinates"
+metadata hilitedCoordinates.label is "Hilited coordinates"
 
 /*
 Summary: Controls the color of the hilited coordinates
@@ -159,7 +159,7 @@ with the current <hilitedCoordinates>
 */
 property hilitedCoordinatesColor get mHilitedCoordinatesColor set SetHilitedCoordinatesColor
 metadata hilitedCoordinatesColor.default is "0,0,0,255"
-metadata hilitedCoordinatesColor.label is "Hilited Coordinates Color"
+metadata hilitedCoordinatesColor.label is "Hilited coordinates color"
 metadata hilitedCoordinatesColor.editor is "com.livecode.pi.colorWithAlpha"
 metadata hilitedCoordinatesColor.section is "Colors"
 

--- a/extensions/widgets/header/header.lcb
+++ b/extensions/widgets/header/header.lcb
@@ -65,7 +65,7 @@ the actions, where each line is a comma delimited list of the different componen
 
 property itemArray get getHeaderActions set setHeaderActions
 metadata itemArray.editor is "com.livecode.pi.navbar"
-metadata itemArray.label is "Header Actions"
+metadata itemArray.label is "Header actions"
 
 /**
 Summary: Sets the header actions display style.
@@ -85,7 +85,7 @@ property itemStyle get mActionStyle set setActionStyle
 metadata itemStyle.editor is "com.livecode.pi.enum"
 metadata itemStyle.options is "icons,text"
 metadata itemStyle.default is "icons"
-metadata itemStyle.label is "Action Display Style"
+metadata itemStyle.label is "Action display style"
 
 /**
 Summary: Sets the action names of the header bar
@@ -100,7 +100,7 @@ Description:
 Sets the names of the header bar actions, where <pNames> is a comma delimited list of the names.
 **/
 property itemNames get getActionNames set setActionNames
-metadata itemNames.label is "Action Names"
+metadata itemNames.label is "Action names"
 
 /**
 Summary: Sets the action labels of the header bar
@@ -226,7 +226,7 @@ Use this property to determine whether the title is visible (true) or not (false
 **/
 property "showLabel" get mShowTitle set setTitleVisibility
 metadata showLabel.default is "true"
-metadata showLabel.label is "Show Title"
+metadata showLabel.label is "Show title"
 
 /**
 Summary: Whether to display the first action on the left
@@ -240,7 +240,7 @@ the left hand side of the header bar.
 **/
 property firstItemLeft get mFirstActionLeft set setFirstActionLeft
 metadata firstItemLeft.default is "true"
-metadata firstItemLeft.label is "First Action On Left"
+metadata firstItemLeft.label is "First action on left"
 
 /**
 Syntax: set the <opaque> of <widget> to {true | false}
@@ -249,12 +249,12 @@ Syntax: get the <opaque> of <widget>
 Summary: Whether the background of the header bar is drawn opaque or not
 
 Description:
-Use the <opaque> property to determine whether objects underneath the header bar are 
+Use the <opaque> property to determine whether objects underneath the header bar are
 visible or not.
 **/
 property "opaque" get mIsOpaque set setBackgroundOpacity
 metadata opaque.default is "true"
-metadata opaque.label is "Opaque Background"
+metadata opaque.label is "Opaque background"
 
 /**
 Syntax: set the <showBorder> of <widget> to {true | false}
@@ -263,12 +263,12 @@ Syntax: get the <showBorder> of <widget>
 Summary: Whether the dividing line at the bottom of the header bar is drawn or not
 
 Description:
-Use the <showBorder> property to determine whether the dividing line at the bottom of the 
+Use the <showBorder> property to determine whether the dividing line at the bottom of the
 header bar is drawn or not.
 **/
 property showBorder get mShowDivide set setShowDivide
 metadata showBorder.default is "false"
-metadata showBorder.label is "Show Bottom Border"
+metadata showBorder.label is "Show bottom border"
 
 /**
 Syntax: set the foreColor of <widget> to <pColor>
@@ -281,7 +281,7 @@ Use the <foreColor> property to control the text color of the header bar.
 **/
 metadata foregroundColor.editor		is "com.livecode.pi.color"
 metadata foregroundColor.section is "Colors"
-metadata foregroundColor.label is "Text Color"
+metadata foregroundColor.label is "Text color"
 metadata foregroundColor.default is "0,0,0"
 
 /**
@@ -296,7 +296,7 @@ header bar.
 **/
 metadata backgroundColor.editor		is "com.livecode.pi.color"
 metadata backgroundColor.section is "Colors"
-metadata backgroundColor.label is "Background Color"
+metadata backgroundColor.label is "Background color"
 metadata backgroundColor.default is "244,244,244"
 
 /**
@@ -310,7 +310,7 @@ Use the <hiliteColor> property to control the color of the icons of the header b
 **/
 metadata hiliteColor.editor		is "com.livecode.pi.color"
 metadata hiliteColor.section is "Colors"
-metadata hiliteColor.label is "Highlight Color"
+metadata hiliteColor.label is "Hilite color"
 metadata hiliteColor.default is "10,95,244"
 
 /**
@@ -325,7 +325,7 @@ Use the <borderColor> property to control the color of the header bar border.
 
 metadata borderColor.editor		is "com.livecode.pi.color"
 metadata borderColor.section is "Colors"
-metadata borderColor.label is "Border Color"
+metadata borderColor.label is "Border color"
 metadata borderColor.default is "109,109,109"
 
 metadata textSize.default is "16"

--- a/extensions/widgets/navbar/navbar.lcb
+++ b/extensions/widgets/navbar/navbar.lcb
@@ -95,7 +95,7 @@ error to be thrown
 */
 property itemArray get getNavData set setNavData
 metadata itemArray.editor is "com.livecode.pi.navbar"
-metadata itemArray.label is "Navigation Data"
+metadata itemArray.label is "Navigation data"
 
 /**
 Syntax: set the itemNames of <widget> to <pNames>
@@ -117,7 +117,7 @@ property itemNames		get getNavNames			set setNavNames
 metadata itemNames.editor is "com.livecode.pi.editorList"
 metadata itemNames.subeditor is "com.livecode.pi.string"
 metadata itemNames.delimiter is ","
-metadata itemNames.label is "Navigation Names"
+metadata itemNames.label is "Navigation names"
 
 /**
 Syntax: set the itemIcons of <widget> to <pIcons>
@@ -213,7 +213,7 @@ property itemStyle	get mItemStyle	set setItemStyle
 metadata itemStyle.editor is "com.livecode.pi.enum"
 metadata itemStyle.options is "icons,text,both"
 metadata itemStyle.default is "both"
-metadata itemStyle.label is "Display Style"
+metadata itemStyle.label is "Display style"
 
 /**
 Syntax: set the hiliteColor of <widget> to <pColor>
@@ -226,7 +226,7 @@ Use the <hiliteColor> property to control the color used to draw icons and text
 of the currently-selected navbar item.
 */
 metadata hiliteColor.editor is "com.livecode.pi.color"
-metadata hiliteColor.label is "Selected Item Color"
+metadata hiliteColor.label is "Selected item color"
 metadata hiliteColor.section is "Colors"
 metadata hiliteColor.default is "10,95,244"
 
@@ -243,7 +243,7 @@ Use the <foreColor> property to control the color used to draw icons and text
 of the navbar items that are not selected.
 */
 metadata foregroundColor.editor is "com.livecode.pi.color"
-metadata foregroundColor.label is "Item Color"
+metadata foregroundColor.label is "Item color"
 metadata foregroundColor.section is "Colors"
 metadata foregroundColor.default is "128,128,128"
 
@@ -260,7 +260,7 @@ Use the <backColor> property to control the way the background of the navbar
 is painted.
 */
 metadata backgroundColor.editor is "com.livecode.pi.color"
-metadata backgroundColor.label is "Background Color"
+metadata backgroundColor.label is "Background color"
 metadata backgroundColor.section is "Colors"
 metadata backgroundColor.default is "244,244,244"
 
@@ -275,7 +275,7 @@ Use the <borderColor> property to control the color used to draw the top border
 of the navbar.
 */
 metadata borderColor.editor is "com.livecode.pi.color"
-metadata borderColor.label is "Border Color"
+metadata borderColor.label is "Border color"
 metadata borderColor.section is "Colors"
 metadata borderColor.default is "166,166,166"
 
@@ -297,7 +297,7 @@ References: hilitedItemName (property)
 property hilitedItem	get mSelectedItem 	set setNavSelectedItem
 metadata hilitedItem.editor is "com.livecode.pi.integer"
 metadata hilitedItem.default is "1"
-metadata hilitedItem.label is "Selected Item Index"
+metadata hilitedItem.label is "Selected item index"
 metadata hilitedItem.step is "1"
 metadata hilitedItem.min is "1"
 
@@ -317,7 +317,7 @@ item.
 References: hilitedItem (property)
 */
 property hilitedItemName	get getNavSelectedItemName	set setNavSelectedItemName
-metadata hilitedItemName.label is "Selected Item Name"
+metadata hilitedItemName.label is "Selected item name"
 
 /**
 Syntax: set the editMode of <widget> to (true | false)
@@ -359,7 +359,7 @@ of the navbar is drawn or not.
 */
 property showBorder get mShowDivide set setShowDivide
 metadata showBorder.default is "true"
-metadata showBorder.label is "Show Border"
+metadata showBorder.label is "Show border"
 
 /**
 Syntax: set the <opaque> of <widget> to {true | false}
@@ -373,7 +373,7 @@ transparent.
 */
 property "opaque" get mShowBackground set setShowBackground
 metadata opaque.default is "true"
-metadata opaque.label is "Opaque Background"
+metadata opaque.label is "Opaque background"
 
 metadata textSize.default is "10"
 

--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -60,7 +60,7 @@ segment, or to allow multiple segments to be highlighted.
 **/
 property multipleHilites		get mMultiSelect		set setMultiSelect		
 metadata multipleHilites.default		is "false"
-metadata multipleHilites.label			is "Multiple Hilites"
+metadata multipleHilites.label			is "Multiple hilites"
 
 /**
 Syntax: set the showBorder of <widget> to { true | false }
@@ -88,7 +88,7 @@ property itemCount 	get mNumSegments		set setSegmentCount
 metadata itemCount.editor		is "com.livecode.pi.integer"
 metadata itemCount.step is "1"
 metadata itemCount.min is "0"
-metadata itemCount.label is "Number of Segments"
+metadata itemCount.label is "Number of segments"
 
 /**
 Syntax: set the itemStyle of <widget> to <pSegmentDisplay>
@@ -108,7 +108,7 @@ property itemStyle		get mSegmentDisplay		set setSegmentDisplay
 metadata itemStyle.editor		is "com.livecode.pi.enum"
 metadata itemStyle.options		is "text,icons"
 metadata itemStyle.default		is "text"
-metadata itemStyle.label		is "Display Style"
+metadata itemStyle.label		is "Display style"
 
 /**
 Syntax: set the itemNames of <widget> to <pNames>
@@ -126,7 +126,7 @@ metadata itemNames.editor		is "com.livecode.pi.editorList"
 metadata itemNames.subeditor		is "com.livecode.pi.string"
 metadata itemNames.delimiter		is ","
 metadata itemNames.default		is "segment1,segment2,segment3"
-metadata itemNames.label			is "Segment Names"
+metadata itemNames.label			is "Segment names"
 
 /**
 Syntax: set the itemLabels of <widget> to <pLabels>
@@ -145,7 +145,7 @@ metadata itemLabels.editor			is "com.livecode.pi.editorList"
 metadata itemLabels.subeditor		is "com.livecode.pi.string"
 metadata itemLabels.delimiter		is ","
 metadata itemLabels.default			is "Label 1,Label 2,Label 3"
-metadata itemLabels.label			is "Segment Labels"
+metadata itemLabels.label			is "Segment labels"
 
 /**
 Syntax: set the itemIcons of <widget> to <pIcons>
@@ -178,20 +178,20 @@ Syntax: get the hilitedItemIcons of <widget>
 Summary: Sets the selected icons of the segments.
 
 Parameters:
-pIcons: A comma-delimited list of icon names which display as the icons for 
+pIcons: A comma-delimited list of icon names which display as the icons for
 each segment when it is highlighted.
 
 Description:
 Use the <hilitedItemIcons> property to get or set the icons of the segments when they are
 highlighted.
-The name of an icon must be one of the names returned by the iconNames() function 
+The name of an icon must be one of the names returned by the iconNames() function
 of the com.livecode.library.iconSVG library.
 
 References: itemIcons (property)
 **/
 
 property hilitedItemIcons		get getSelectedIcons		set setSelectedIcons
-metadata hilitedItemIcons.label 		is "Highlighted Segment Icons"
+metadata hilitedItemIcons.label 		is "Hilited segment icons"
 metadata hilitedItemIcons.editor		is "com.livecode.pi.editorlist"
 metadata hilitedItemIcons.subeditor	is "com.livecode.pi.svgicon"
 metadata hilitedItemIcons.delimiter	is ","
@@ -217,7 +217,7 @@ metadata itemMinWidths.editor		is "com.livecode.pi.editorList"
 metadata itemMinWidths.subeditor	is "com.livecode.pi.number"
 metadata itemMinWidths.delimiter	is ","
 metadata itemMinWidths.default 	is "50,50,50"
-metadata itemMinWidths.label	 	is "Minimum Segment Widths"
+metadata itemMinWidths.label	 	is "Minimum segment widths"
 
 /**
 Syntax: set the hilitedItems of <widget> to <pIndices>
@@ -237,7 +237,7 @@ References: hilitedItemNames (property)
 property hilitedItems	get getSelectedSegmentIndices	set setSelectedSegmentIndices
 metadata hilitedItems.editor		is "com.livecode.pi.string"
 metadata hilitedItems.default	is ""
-metadata hilitedItems.label 		is "Highlighted Segment Indices"
+metadata hilitedItems.label 		is "Hilited segment indices"
 
 /**
 Syntax: set the hilitedItemNames of <widget> to <pIndices>
@@ -257,7 +257,7 @@ References: hilitedItems (property)
 property hilitedItemNames	get getSelectedSegmentNames	set setSelectedSegmentNames
 metadata hilitedItemNames.editor		is "com.livecode.pi.string"
 metadata hilitedItemNames.default	is ""
-metadata hilitedItemNames.label 		is "Highlighted Segment Names"
+metadata hilitedItemNames.label 		is "Hilited segment names"
 
 /**
 Syntax: set the foreColor of <widget> to <pColor>
@@ -287,7 +287,7 @@ segments.
 metadata backgroundColor.editor		is "com.livecode.pi.color"
 metadata backgroundColor.default is "244,244,244"
 metadata backgroundColor.section is "Colors"
-metadata backgroundColor.label is "Segment Color"
+metadata backgroundColor.label is "Segment color"
 
 /**
 Syntax: set the hiliteColor of <widget> to <pColor>
@@ -302,7 +302,7 @@ of the selected segment.
 metadata hiliteColor.editor		is "com.livecode.pi.color"
 metadata hiliteColor.default is "10,95,244"
 metadata hiliteColor.section is "Colors"
-metadata hiliteColor.label is "Selected Segment Color"
+metadata hiliteColor.label is "Selected segment color"
 
 /**
 Syntax: set the borderColor of <widget> to <pColor>
@@ -317,7 +317,7 @@ Use the <borderColor> property to control the text color of the segments.
 metadata borderColor.editor		is "com.livecode.pi.color"
 metadata borderColor.default is "109,109,109"
 metadata borderColor.section is "Colors"
-metadata borderColor.label is "Border Color"
+metadata borderColor.label is "Border color"
 
 /**
 Syntax: set the hilitedTextColor of <widget> to <pColor>
@@ -333,7 +333,7 @@ property hilitedTextColor 	get getSelectedLabelColor		set setSelectedLabelColor
 metadata hilitedTextColor.editor		is "com.livecode.pi.color"
 metadata hilitedTextColor.default is "255,255,255"
 metadata hilitedTextColor.section is "Colors"
-metadata hilitedTextColor.label is "Highlighted Segment Label Color"
+metadata hilitedTextColor.label is "Hilited segment label color"
 
 metadata themeClass.default is "list"
 metadata themeClass.user_visible is "false"

--- a/extensions/widgets/svgpath/svgpath.lcb
+++ b/extensions/widgets/svgpath/svgpath.lcb
@@ -59,7 +59,7 @@ isn't highlighted.
 metadata foregroundColor.editor is "com.livecode.pi.color"
 metadata foregroundColor.default is ""
 metadata foregroundColor.section is "Colors"
-metadata foregroundColor.label is "Normal Color"
+metadata foregroundColor.label is "Normal color"
 
 /**
 Syntax:
@@ -75,7 +75,7 @@ is highlighted.
 metadata hiliteColor.editor is "com.livecode.pi.color"
 metadata hiliteColor.default is ""
 metadata hiliteColor.section is "Colors"
-metadata hiliteColor.label is "Highlight Color"
+metadata hiliteColor.label is "Hilite color"
 
 /**
 Syntax:
@@ -123,7 +123,7 @@ specification.
 */
 property iconPath get mPath set setPath
 metadata iconPath.editor is "com.livecode.pi.text"
-metadata iconPath.label is "Path Data"
+metadata iconPath.label is "Path data"
 
 /**
 Syntax:
@@ -154,7 +154,7 @@ to height. If `false`, it will stretch to fit the extent of its bounds.
 */
 property maintainAspectRatio  get mMaintainAspectRatio  set setMaintainAspectRatio
 metadata maintainAspectRatio.default is "true"
-metadata maintainAspectRatio.label is "Fix Aspect Ratio"
+metadata maintainAspectRatio.label is "Fix aspect ratio"
 
 /**
 Syntax:
@@ -218,7 +218,7 @@ property fillRule       get mFillRule      set setFillRule
 metadata fillRule.editor is "com.livecode.pi.enum"
 metadata fillRule.options is "non-zero,even odd"
 metadata fillRule.default is "non-zero"
-metadata fillRule.label is "Fill Rule"
+metadata fillRule.label is "Fill rule"
 --
 
 ----------

--- a/extensions/widgets/switchbutton/switchbutton.lcb
+++ b/extensions/widgets/switchbutton/switchbutton.lcb
@@ -118,7 +118,7 @@ switch button.
 metadata backgroundColor.editor is "com.livecode.pi.color"
 metadata backgroundColor.default is "244,244,244"
 metadata backgroundcolor.section is "Colors"
-metadata backgroundColor.label is "Background Color"
+metadata backgroundColor.label is "Background color"
 
 /**
 Syntax: set the hiliteColor of <widget> to <pColor>
@@ -133,7 +133,7 @@ switch button.
 metadata hiliteColor.editor is "com.livecode.pi.color"
 metadata hiliteColor.default is "10,95,244"
 metadata hilitecolor.section is "Colors"
-metadata hiliteColor.label is "Highlight Color"
+metadata hiliteColor.label is "Hilite color"
 
 /**
 Syntax: set the borderColor of <widget> to <pColor>
@@ -148,7 +148,7 @@ switch button.
 metadata borderColor.editor is "com.livecode.pi.color"
 metadata borderColor.default is "109,109,109"
 metadata bordercolor.section is "Colors"
-metadata borderColor.label is "Border Color"
+metadata borderColor.label is "Border color"
 
 
 -- private instance variables

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -101,6 +101,7 @@ The arrayData is the data currently being displayed by the tree view widget.
 **/
 
 property arrayData 					get getArrayData 				set setArrayData
+metadata arrayData.label is "Array data"
 
 /**
 Syntax: set the hilitedElement of <widget> to <pPath>
@@ -120,6 +121,7 @@ of the widget, to select a row corresponding to tArray["key1"]["subkey2"]["subsu
 **/
 
 property hilitedElement			get getSelectedElement			set setSelectedElement
+metadata hilitedElement.label is "Hilited element"
 
 /**
 Name: foreColor
@@ -139,7 +141,7 @@ Use the <foreColor> property to get or set the color the tree view widget uses f
 **/
 
 metadata foregroundColor.default is "50,50,50"
-metadata foregroundColor.label is "Text Color"
+metadata foregroundColor.label is "Text color"
 
 /**
 Name: backColor
@@ -159,7 +161,7 @@ Use the <backColor> property to get or set the color the tree view widget uses f
 background of its rows.
 **/
 metadata backgroundColor.default is "244,244,244"
-metadata backgroundColor.label is "Row Background Color"
+metadata backgroundColor.label is "Row background color"
 
 /**
 Syntax: set the hiliteColor of <widget> to <pColor>
@@ -176,7 +178,7 @@ the selected row.
 **/
 
 metadata hiliteColor.default is "10,95,244"
-metadata hiliteColor.label is "Selected Row Color"
+metadata hiliteColor.label is "Selected row color"
 
 /**
 Name: borderColor
@@ -198,7 +200,7 @@ border, and the separator (if the <showSeparator> property is true).
 References: showSeparator (property)
 **/
 metadata borderColor.default is "109,109,109"
-metadata borderColor.label is "Border Color"
+metadata borderColor.label is "Border color"
 
 /**
 Syntax: set the sortOrder of <widget> to <pOrder>
@@ -222,6 +224,7 @@ property sortOrder                 get getSortOrder                 set setSortO
 
 metadata sortOrder.editor is "com.livecode.pi.enum"
 metadata sortOrder.options is "ascending,descending"
+metadata sortOrder.label is "Sort order"
 
 /**
 Syntax: set the sortType of <widget> to <pType>
@@ -245,6 +248,7 @@ property sortType                 get getSortType                 set setSortTyp
 
 metadata sortType.editor is "com.livecode.pi.enum"
 metadata sortType.options is "text,numeric"
+metadata sortType.label is "Sort type"
 
 /**
 Syntax: set the alternateRowBackgrounds of <widget> to {true|false}
@@ -257,6 +261,7 @@ Use the alternateRowBackgrounds property if you want to more clearly distinguish
 **/
 
 property alternateRowBackgrounds 	get mAlternateRowBackgrounds 	set setRowBackgrounds
+metadata alternateRowBackgrounds.label is "Alternate row backgrounds"
 
 /**
 Syntax: set the showBorder of <widget> to {true|false}
@@ -270,6 +275,7 @@ object.
 **/
 
 property showBorder			get mFrameBorder				set setFrameBorder
+metadata showBorder.label is "Show border"
 
 /**
 Syntax: set the readOnly of <widget> to {true|false}
@@ -285,6 +291,7 @@ appear at the right to enable the removal of that element, or the addition of a 
 **/
 
 property readOnly					get mReadOnly					set setReadOnly
+metadata readOnly.label is "Read only"
 
 /**
 Syntax: set the arrayStyle of <widget> to {true|false}
@@ -300,6 +307,7 @@ References: arrayData (property)
 **/
 
 property arrayStyle                 get mArrayStyle                 set setArrayStyle
+metadata arrayStyle.label is "Array style"
 
 /**
 Syntax: set the showSeparator of <widget> to {true|false}
@@ -314,6 +322,7 @@ of the tree view widget in columns separated by a movable divide.
 Related: separatorRatio (property)
 **/
 property showSeparator		get mShowSeparator		set setShowSeparator
+metadata showSeparator.label is "Show separator"
 
 /**
 Syntax: set the separatorRatio of <widget> to {true|false}
@@ -334,6 +343,7 @@ metadata separatorRatio.editor is "com.livecode.pi.number"
 metadata separatorRatio.step is "0.05"
 metadata separatorRatio.min is "0"
 metadata separatorRatio.max is "1"
+metadata separatorRatio.label is "Separator ratio"
 
 metadata themeClass.default is "list"
 metadata themeClass.user_visible is "false"


### PR DESCRIPTION
Updates widget property labels to use sentence
casing.

Closes: livecode/livecode-ide#1001
