### PR TITLE
[Bug 16166] Don't use internal IDE functions in dictionary examples

### DIFF
--- a/docs/dictionary/command/load-extension.lcdoc
+++ b/docs/dictionary/command/load-extension.lcdoc
@@ -13,7 +13,7 @@ OS: mac,windows,linux,ios,android
 Platforms: desktop,server,web,mobile
 
 Example:
-load extension from file (revIDESpecialFolderPath("extensions") & slash & "com.livecode.extensions.livecode.navbar" & slash & "module.lcm")
+load extension from file "packaged_extensions/com.livecode.widget.navbar/module.lcm"
 if the result is empty then
 	create widget "My Navbar" as "com.livecode.widget.navbar"
 end if

--- a/docs/notes/bugfix-16166.md
+++ b/docs/notes/bugfix-16166.md
@@ -1,0 +1,1 @@
+# Don't use internal IDE functions in dictionary entries


### PR DESCRIPTION
The `revIDESpecialFolderPath()` function isn't part of the normal
LiveCode standard library -- it's a special IDE library function that
isn't available everywhere (and we're not sure if it's quite ready to
be widely used).

Avoid using it in dictionary entries.
