### PR TITLE
Don't attempt to use a CA file for libcurl outside Linux

### DIFF
--- a/docs/notes/bugfix-16940.md
+++ b/docs/notes/bugfix-16940.md
@@ -1,0 +1,1 @@
+# Fix access to https:// URLs from OSX server engines

--- a/engine/src/srvspec.cpp
+++ b/engine/src/srvspec.cpp
@@ -350,9 +350,14 @@ static void url_execute(MCStringRef p_url, MCUrlExecuteCallback p_callback, void
 	{
 		// IM-2014-07-28: [[ Bug 12822 ]] Override default ssl certificate loading.
 		if (curl_easy_setopt(t_url_handle, CURLOPT_SSL_VERIFYPEER, 1) != CURLE_OK ||
-			curl_easy_setopt(t_url_handle, CURLOPT_SSL_VERIFYHOST, 2) != CURLE_OK ||
--			curl_easy_setopt(t_url_handle, CURLOPT_CAINFO, nil) != CURLE_OK ||
-			curl_easy_setopt(t_url_handle, CURLOPT_SSL_CTX_FUNCTION, _set_ssl_certificates_callback) != CURLE_OK)
+			curl_easy_setopt(t_url_handle, CURLOPT_SSL_VERIFYHOST, 2) != CURLE_OK
+#if TARGET_PLATFORM_LINUX
+            // These options are not supported when using the OSX system libcurl
+            // as it uses the OS' certificate database and not a cert file.
+			|| curl_easy_setopt(t_url_handle, CURLOPT_CAINFO, nil) != CURLE_OK
+			|| curl_easy_setopt(t_url_handle, CURLOPT_SSL_CTX_FUNCTION, _set_ssl_certificates_callback) != CURLE_OK
+#endif
+            )
 			t_error = "couldn't configure ssl";
 	}
 


### PR DESCRIPTION
The OSX server engine uses the system's copy of libcurl and that
uses the operating system's CA database rather than a CA bundle
as happens on Linux so trying to set a CA file path (even to the
default CA file path) causes curl to throw an error.

Windows libcurl requires a CA file to be supplied; it doesn't use
the system's certificate DB unless using Schannel (which ours
doesn't; it uses OpenSSL instead) and there is no default path to
a CA file bundle on Windows as the system doesn't supply one. As
such, we might as well remove the attempt to set it for Windows
too. (SSL doesn't work either way; we'll need some other
solution).
