### PR TITLE
[[ Bug 16566 ]] Ensure smoothness of resizing on El Capitan

### DIFF
--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -668,21 +668,21 @@ static void runloop_observer(CFRunLoopObserverRef observer, CFRunLoopActivity ac
 		MCPlatformBreakWait();
 }
 
-static bool s_event_checking_enabled = true;
+static uindex_t s_event_checking_enabled = 0;
 
 void MCMacPlatformEnableEventChecking(void)
 {
-	s_event_checking_enabled = true;
+	s_event_checking_enabled += 1;
 }
 
 void MCMacPlatformDisableEventChecking(void)
 {
-	s_event_checking_enabled = false;
+	s_event_checking_enabled -= 1;
 }
 
 bool MCMacPlatformIsEventCheckingEnabled(void)
 {
-	return s_event_checking_enabled;
+	return s_event_checking_enabled == 0;
 }
 
 bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -1710,8 +1710,15 @@ void MCMacPlatformWindow::ProcessDidMove(void)
 	MCRectangle t_content;
 	MCMacPlatformMapScreenNSRectToMCRectangle(t_new_cocoa_content, t_content);
 	
+	// Make sure we don't tickle the event queue whilst resizing, otherwise
+	// redraws can be done by the OS during the process resulting in tearing
+	// as the window resizes.
+	MCMacPlatformDisableEventChecking();
+	
 	// And get the super class to deal with it.
 	HandleReshape(t_content);
+	
+	MCMacPlatformEnableEventChecking();
 }
 
 void MCMacPlatformWindow::ProcessDidResize(void)


### PR DESCRIPTION
In order to prevent the SPOD in long running loops, the engine
'tickles' the event queue periodically (every 0.25s) to ensure
the OS does not think the engine has hung.

The tickling of the event queue can cause redraws to occur, which
is inappropriate whilst a resizeStack handler is running.

To fix this, the event checking is now turned off for the duration
of the handling of a resize event meaning that a redraw will only
occur at the end of its operation.
