### PR TITLE
[[ Bug 17173 ]] Correct fix to bug 17112

### DIFF
--- a/docs/notes/bugfix-17173.md
+++ b/docs/notes/bugfix-17173.md
@@ -1,0 +1,1 @@
+# Fix processing of force-added chunks

--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -475,9 +475,7 @@ void MCStringsMarkTextChunkInRange(MCExecContext& ctxt, MCStringRef p_string, MC
                 MCStringMapIndices(*t_string, p_chunk_type == CT_CHARACTER ? kMCCharChunkTypeGrapheme : kMCCharChunkTypeCodepoint, t_cp_range, t_cu_range);
         
                 r_start = t_offset + t_cu_range.offset;
-                r_end = t_offset + t_cu_range.offset + t_cu_range.length;
-                //r_start = p_first;
-                //r_end = p_first + p_count;
+                r_end = MCU_min(t_offset + t_cu_range.offset + t_cu_range.length, t_length);
             }
             break;
         case CT_CODEUNIT:
@@ -485,7 +483,7 @@ void MCStringsMarkTextChunkInRange(MCExecContext& ctxt, MCStringRef p_string, MC
             if (p_include_chars)
             {
                 r_start = p_first + t_offset;
-                r_end = MCU_min(p_first + t_offset + p_count, t_offset + t_length);
+                r_end = MCU_min(p_first + t_offset + p_count, t_length);
             }
             break;
         default:

--- a/tests/lcs/core/chunks/compound.livecodescript
+++ b/tests/lcs/core/chunks/compound.livecodescript
@@ -21,3 +21,33 @@ on TestBug17112
 	put "a" & return & "b" into tLines
 	TestAssert "char range of line overrun", char 1 to 100 of line 1 of tLines is "a"
 end TestBug17112
+
+on TestPutIntoItemOfLineAdd
+	local tLines
+	put "a" & return & "1" into tLines
+	put "b" into item 2 of line 1 of tLines
+	TestAssert "force item of line addition expression", tLines is ("a,b" & return & "1")
+	
+	put "a" & return & "1" into tLines
+	put "b" into item 3 to 4 of line 1 of tLines
+	TestAssert "force item of line addition range", tLines is ("a,,b" & return & "1")
+	
+	put "a" & return & "1" into tLines
+	put "b" into the third item of line 1 of tLines
+	TestAssert "force item of line addition ordinal", tLines is ("a,,b" & return & "1")
+end TestPutIntoItemOfLineAdd
+
+on TestPutIntoItemOfLineReplace
+	local tLines
+	put "a,b" & return & "1" into tLines
+	put "c" into item 2 of line 1 of tLines
+	TestAssert "item of line replacement expression", tLines is ("a,c" & return & "1")
+	
+	put "a,b,c,d" & return & "1" into tLines
+	put "e" into item 3 to 4 of line 1 of tLines
+	TestAssert "item of line replacement range", tLines is ("a,b,e" & return & "1")
+	
+	put "a,b,c" & return & "1" into tLines
+	put "d" into the middle item of line 1 of tLines
+	TestAssert "item of line replacement ordinal", tLines is ("a,d,c" & return & "1")
+end TestPutIntoItemOfLineReplace

--- a/tests/lcs/core/chunks/text.livecodescript
+++ b/tests/lcs/core/chunks/text.livecodescript
@@ -29,3 +29,34 @@ on TestDeleteItemOfLine
 	delete item 1 of line 2 of tLines
 	TestAssert "delete item of line comprising item does not delete line", the number of lines in tLines is 3
 end TestDeleteItemOfLine
+
+on TestPutIntoItemAdd
+	local tItems
+	put "a" into tItems
+	put "b" into item 2 of tItems
+	TestAssert "force item addition expression", tItems is "a,b"
+	
+	put "a" into tItems
+	put "b" into item 3 to 4 of tItems
+	TestAssert "force item addition range", tItems is "a,,b"
+	
+	put "a" into tItems
+	put "b" into the third item of tItems
+	TestAssert "force item addition ordinal", tItems is "a,,b"
+end TestPutIntoItemAdd
+
+on TestPutIntoItemReplace
+	local tItems
+	put "a,b" into tItems
+	put "c" into item 2 of tItems
+	TestAssert "item replacement expression", tItems is "a,c"
+	
+	put "a,b,c,d" into tItems
+	put "e" into item 3 to 4 of tItems
+	TestAssert "item replacement range", tItems is "a,b,e"
+	
+	put "a,b,c" into tItems
+	put "d" into the middle item of tItems
+	TestAssert "item replacement ordinal", tItems is "a,d,c"
+end TestPutIntoItemReplace
+


### PR DESCRIPTION
It is actually the responsibility of MCStringsMarkTextChunkInRange
to restrict its calculated indices to the given range.
