### PR TITLE
[Bug 17183][emscripten] Prevent multiple font-related crashes

### DIFF
--- a/docs/notes/bugfix-17183.md
+++ b/docs/notes/bugfix-17183.md
@@ -1,0 +1,1 @@
+# Prevent multiple font-related crashes in HTML5 engine

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1686,6 +1686,27 @@ void MCDispatch::redraw(Window w, MCRegionRef p_dirty_region)
 	target -> updatewindow(p_dirty_region);
 }
 
+MCFontlist *MCDispatch::getfontlist()
+{
+	/* There's lots of code in the engine that immediately
+	 * dereferences the result of getfontlist().  So, *require* it to
+	 * return valid font list, by loading a font if necessary. */
+	if (nil == fonts)
+	{
+		MCFontRef t_font;
+		bool t_success =
+			MCPlatformGetControlThemePropFont(kMCPlatformControlTypeGeneric,
+			                                  kMCPlatformControlPartNone,
+			                                  kMCPlatformControlStateNormal,
+			                                  kMCPlatformThemePropertyTextFont,
+			                                  t_font);
+		MCAssert(t_success); /* Can't proceed if this fails */
+	}
+
+	MCAssert(nil != fonts);
+	return fonts;
+}
+
 MCFontStruct *MCDispatch::loadfont(MCNameRef fname, uint2 &size, uint2 style, Boolean printer)
 {
 #if defined(_LINUX_DESKTOP)

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -177,6 +177,7 @@ public:
 	void configure(Window w);
 	void enter(Window w);
     void redraw(Window w, MCRegionRef dirty_region);
+	MCFontlist *getfontlist();
 	MCFontStruct *loadfont(MCNameRef fname, uint2 &size, uint2 style, Boolean printer);
     MCFontStruct *loadfontwithhandle(MCSysFontHandle, MCNameRef p_name);
 	
@@ -201,11 +202,6 @@ public:
 #ifdef _WINDOWS_DESKTOP
 	void freeprinterfonts();
 #endif
-
-	MCFontlist *getfontlist()
-	{
-		return fonts;
-	}
 	
 	MCStack *findstackname(MCNameRef);
 	MCStack *findstackid(uint4 fid);

--- a/engine/src/em-fontlist.cpp
+++ b/engine/src/em-fontlist.cpp
@@ -88,8 +88,6 @@ MCFontnode::MCFontnode(MCNameRef p_name,
     m_font_info.m_xheight = t_metrics.fXHeight;
 
     m_font_info.size = p_size;
-
-    //MCLog("Created dummy font: %@ %hi %hi", p_name, p_size, p_style);
 }
 
 MCFontnode::~MCFontnode()
@@ -258,7 +256,6 @@ MCFontlist::getfontstructinfo(MCNameRef & r_name,
 MCSysFontHandle emscripten_get_font_by_name(MCNameRef p_name,
                                             uint16_t p_style)
 {
-	MCLog("%s: %@", __FUNCTION__, p_name);
 	/* Decode style */
 	bool t_italic = (0 != (p_style & FA_ITALIC));
 	bool t_bold = (0x05 < (p_style & FA_WEIGHT));

--- a/engine/src/em-fontlist.cpp
+++ b/engine/src/em-fontlist.cpp
@@ -143,9 +143,8 @@ MCFontnode::remove(MCFontnode *& list)
  * MCFontlist implementation for Emscripten
  * ================================================================ */
 
-MCFontlist::MCFontlist()
+MCFontlist::MCFontlist() : m_font_list(nil)
 {
-	m_font_list = NULL;
 }
 
 MCFontlist::~MCFontlist()

--- a/engine/src/em-theme.cpp
+++ b/engine/src/em-theme.cpp
@@ -18,6 +18,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "prefix.h"
 
+#include "objdefs.h"
+#include "font.h"
 #include "platform.h"
 #include "mctheme.h"
 
@@ -51,5 +53,7 @@ MCPlatformGetControlThemePropFont(MCPlatformControlType p_type,
                                   MCPlatformThemeProperty p_prop,
                                   MCFontRef& r_font)
 {
-	return false;
+	/* For now, ask for the compiled-in default font name and size*/
+	return MCFontCreate(MCNAME(DEFAULT_TEXT_FONT), 0,
+	                    DEFAULT_TEXT_SIZE, r_font);
 }


### PR DESCRIPTION
Recent work on native theming caused several crash bugs to appear in the HTML5 engine.
- `MCPlatformGetControlThemePropFont()` is currently not permitted to fail, so it needs to be implemented for HTML5
- `MCDispatch::getfontslist()` isn't permitted to return `NULL`

As an added bonus, this patch also tidies up the (very) confusing `MCObject::getfontattsnew()` method to make it clearer what's going on.
