### PR TITLE
Synthesize clipboardData["styledText"] from plain text on the clipboard

### DIFF
--- a/docs/notes/bugfix-16959.md
+++ b/docs/notes/bugfix-16959.md
@@ -1,0 +1,2 @@
+# Synthesize clipboardData["styledText"] from plain text on the clipboard
+

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -832,12 +832,25 @@ bool MCClipboard::CopyAsLiveCodeStyledText(MCDataRef& r_pickled_text) const
         }
     }
     
-    // Could not grab as either styled text or RTF. One last try with HTML...
+    // Could not grab as either styled text or RTF. Try with HTML.
     MCAutoDataRef t_html;
     if (CopyAsData(kMCRawClipboardKnownTypeHTML, &t_html))
     {
         // Convert to LiveCode styled text
         MCDataRef t_pickled_text = ConvertHTMLToStyledText(*t_html);
+        if (t_pickled_text != NULL)
+        {
+            r_pickled_text = t_pickled_text;
+            return true;
+        }
+    }
+    
+    // Finally, try plain text.
+    MCAutoStringRef t_plain_text;
+    if (CopyAsText(&t_plain_text))
+    {
+        // Convert to LiveCode styled text
+        MCDataRef t_pickled_text = ConvertTextToStyledText(*t_plain_text);
         if (t_pickled_text != NULL)
         {
             r_pickled_text = t_pickled_text;


### PR DESCRIPTION
This restores the pre-8.0 clipboard behaviour.
