### PR TITLE
Allow files on clipboards to auto-convert to text

### DIFF
--- a/docs/notes/bugfix-17072.md
+++ b/docs/notes/bugfix-17072.md
@@ -1,0 +1,1 @@
+# Restore the ability to drop files into text fields

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -693,9 +693,10 @@ bool MCClipboard::HasImage() const
 
 bool MCClipboard::HasTextOrCompatible() const
 {
-    // Styled text is compatible with plain text
+    // Styled text is compatible with plain text. A list of file paths can also
+    // be auto-converted into text.
     AutoLock t_lock(this);
-    return HasText() || HasLiveCodeStyledTextOrCompatible();
+    return HasText() || HasLiveCodeStyledTextOrCompatible() || HasFileList();
 }
 
 bool MCClipboard::HasLiveCodeStyledTextOrCompatible() const
@@ -800,6 +801,10 @@ bool MCClipboard::CopyAsText(MCStringRef& r_text) const
     if (CopyAsEncodedText(t_item, kMCRawClipboardKnownTypeMacRoman, kMCStringEncodingMacRoman, r_text))
         return true;
     if (CopyAsEncodedText(t_item, kMCRawClipboardKnownTypeCP1252, kMCStringEncodingWindows1252, r_text))
+        return true;
+    
+    // As a fallback, try to convert a list of file paths into text
+    if (CopyAsFileList(r_text))
         return true;
     
     // None of the text representations existed


### PR DESCRIPTION
Restores the ability to drop files into a field and have the path to the file be inserted.
