### PR TITLE
[[ Bug 15671 ]] Ensure 'unload extension' returns a result.

### DIFF
--- a/docs/dictionary/command/unload-extension.lcdoc
+++ b/docs/dictionary/command/unload-extension.lcdoc
@@ -29,7 +29,11 @@ Use the <unload extension> <command> to unload a <LiveCode Builder extension>. T
 If the extension is a library, its public handlers will no longer be in the message path.
 If it is a widget, it will no longer be available as a control to add to a stack. 
 
->*Note:* If there is an instance of a widget still present on a stack in memory, the <unload extension> <command> will fail.
+If a module with the given identifier has already been loaded into memory, the result will be set to "module already loaded".
+
+If there is no module with the given identifier loaded into memory, the result will be set to "module not loaded".
+
+If the module is currently in use by another module or a widget, the result will be set to "module in use".
 
 References: load extension (command), loadedExtensions (function), LiveCode Builder extension (glossary)
 

--- a/docs/notes/bugfix-15671.md
+++ b/docs/notes/bugfix-15671.md
@@ -1,0 +1,7 @@
+# Ensure unload extension reports appropriate status in 'the result'
+
+If 'unload extension' is called on a module which has not been loaded,
+the result will be set to "module not loaded".
+
+If 'unload extension' is called on a module which is currently in use,
+the result will be set to "module in use".

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -211,6 +211,9 @@ MCScriptModuleRef MCScriptRetainModule(MCScriptModuleRef module);
 // Release a module.
 void MCScriptReleaseModule(MCScriptModuleRef module);
 
+// Return the reference count of the given module.
+uint32_t MCScriptGetRetainCountOfModule(MCScriptModuleRef module);
+
 // Gets the module ptr for the most recent LCB stack frame on the current thread's stack.
 MCScriptModuleRef MCScriptGetCurrentModule(void);
 

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -459,6 +459,16 @@ void MCScriptReleaseModule(MCScriptModuleRef self)
     MCScriptReleaseObject(self);
 }
 
+uint32_t MCScriptGetRetainCountOfModule(MCScriptModuleRef self)
+{
+	if (nil == self)
+		return 0;
+	
+	__MCScriptValidateObjectAndKind__(self, kMCScriptObjectKindModule);
+	
+	return MCScriptGetRetainCountOfObject(self);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCScriptCreateModuleFromStream(MCStreamRef stream, MCScriptModuleRef& r_module)
@@ -501,7 +511,7 @@ bool MCScriptCreateModuleFromStream(MCStreamRef stream, MCScriptModuleRef& r_mod
         if (MCNameIsEqualTo(t_other_module -> name, t_module -> name))
         {
             MCScriptDestroyObject(t_module);
-            return MCErrorThrowGeneric(MCSTR("module with that name already loaded"));
+            return MCErrorThrowGeneric(MCSTR("module already loaded"));
         }
     
     // Link our module into the global module list.

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -375,6 +375,13 @@ void MCScriptReleaseObject(MCScriptObject *self)
         MCScriptDestroyObject(self);
 }
 
+uint32_t MCScriptGetRetainCountOfObject(MCScriptObject *self)
+{
+	__MCScriptValidateObject__(self);
+	
+	return self -> references;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void MCScriptReleaseObjectArray(MCScriptObject **p_elements, uindex_t p_count)

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -69,6 +69,7 @@ void MCScriptDestroyObject(MCScriptObject *object);
 
 MCScriptObject *MCScriptRetainObject(MCScriptObject *object);
 void MCScriptReleaseObject(MCScriptObject *object);
+uint32_t MCScriptGetRetainCountOfObject(MCScriptObject *object);
 
 void MCScriptReleaseObjectArray(MCScriptObject **elements, uindex_t count);
 


### PR DESCRIPTION
The 'unload extension' command will now report "module in use" in
the result if the specified module is in use (i.e. referred to
by another loaded module, or a widget). It will also return
"module not loaded" if the specified module is not in memory.
