### PR TITLE
[[ Bug 15452 ]] Improve error reporting for LCB library handlers.

### DIFF
--- a/docs/notes/bugfix-15452.md
+++ b/docs/notes/bugfix-15452.md
@@ -1,0 +1,5 @@
+# Improve error message when calling LCB library function incorrectly.
+
+If a handler in an LCB library is called with the wrong number of
+arguments then the engine will now throw either a "too few arguments"
+or "too many arguments" error.

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2701,6 +2701,12 @@ enum Exec_errors
 	
 	// {EE-0884} replace: not a field chunk
 	EE_REPLACE_BADFIELDCHUNK,
+	
+	// {EE-0885} call: too few arguments
+	EE_INVOKE_TOOFEWARGS,
+	
+	// {EE-0886} call: too many arguments
+	EE_INVOKE_TOOMANYARGS
 };
 
 extern const char *MCexecutionerrors;


### PR DESCRIPTION
When calling an LCB library handler from LCS, then engine will now
throw either a 'too many arguments' or 'too few arguments' error
in the case of the arity of the parameter list being incorrect.
