### PR TITLE
[Bug 17159] header: Tweak firstItemLeft documentation

### DIFF
--- a/extensions/widgets/header/header.lcb
+++ b/extensions/widgets/header/header.lcb
@@ -235,8 +235,15 @@ Syntax: set the firstItemLeft of <widget> to { true | false }
 Syntax: get the firstItemLeft of <widget>
 
 Description:
-If the <firstItemLeft> property is true, then the first action in the <itemArray> is displayed on 
-the left hand side of the header bar.
+
+If the <firstItemLeft> property is `true`, then the first action in the
+<itemArray> is displayed on the left hand side of the header bar.
+
+**Note:** In some <theme|themes>, the first action always has its
+label displayed when <firstItemLeft> is `true`.  If you don't want
+this to happen, you can set the action's label to the empty string.
+
+References: itemArray (property), theme (property)
 **/
 property firstItemLeft get mFirstActionLeft set setFirstActionLeft
 metadata firstItemLeft.default is "true"

--- a/extensions/widgets/header/notes/17159.md
+++ b/extensions/widgets/header/notes/17159.md
@@ -1,0 +1,1 @@
+# [17159] Add note about firstItemLeft and label visibility


### PR DESCRIPTION
- Fix missing references
- Add note that in some themes the left action's label is always
  visible
