### PR TITLE
[[ Bug 17213 ]] Correct type of brush, spray and eraser props.

### DIFF
--- a/docs/notes/bugfix-17213.md
+++ b/docs/notes/bugfix-17213.md
@@ -1,0 +1,2 @@
+# Allow brush, spray and eraser properties to use image ids > 65535
+

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -347,9 +347,9 @@ static MCPropertyInfo kMCPropertyInfoTable[] =
 	DEFINE_RW_PROPERTY(P_BEEP_DURATION, Int16, Interface, BeepDuration)
 	DEFINE_RW_PROPERTY(P_BEEP_SOUND, String, Interface, BeepSound)
 	DEFINE_RW_PROPERTY(P_TOOL, String, Interface, Tool)
-	DEFINE_RW_PROPERTY(P_BRUSH, UInt16, Interface, Brush)
-	DEFINE_RW_PROPERTY(P_ERASER, UInt16, Interface, Eraser)
-	DEFINE_RW_PROPERTY(P_SPRAY, UInt16, Interface, Spray)
+	DEFINE_RW_PROPERTY(P_BRUSH, UInt32, Interface, Brush)
+	DEFINE_RW_PROPERTY(P_ERASER, UInt32, Interface, Eraser)
+	DEFINE_RW_PROPERTY(P_SPRAY, UInt32, Interface, Spray)
 
 	DEFINE_RW_PROPERTY(P_DEFAULT_NETWORK_INTERFACE, String, Network, DefaultNetworkInterface)
 	DEFINE_RO_PROPERTY(P_NETWORK_INTERFACES, String, Network, NetworkInterfaces)


### PR DESCRIPTION
The global brush, spray and eraser properties are now correctly
specified as being UInt32, rather than UInt16.
