### PR TITLE
[[ Bug 17199 ]] Fix evaluation of numeric literals in array indices

### DIFF
--- a/docs/notes/bugfix-17199.md
+++ b/docs/notes/bugfix-17199.md
@@ -1,0 +1,1 @@
+# Numberformat shouldn't affect number to string conversion in array access

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -186,16 +186,10 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
 #endif /* MCAdd */
 
     MCExecValue t_src;
-    Boolean t_old_expectation;
-    
-    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
-    t_old_expectation = ctxt . GetNumberExpected();
-    ctxt . SetNumberExpected(True);
-    
+	
     if (!ctxt . EvaluateExpression(source, EE_ADD_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
     {
-        ctxt . SetNumberExpected(t_old_expectation);
         return;
     }
 	
@@ -217,7 +211,6 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
         {
             ctxt . LegacyThrow(EE_ADD_BADDEST);
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
             
@@ -227,13 +220,9 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
         if (!ctxt . EvaluateExpression(dest, EE_ADD_BADDEST, t_dst))
         {
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
-    }    
-    
-    // Set the number expectation back to its previous state
-    ctxt . SetNumberExpected(t_old_expectation);
+    }
 
     if (!ctxt . ConvertToNumberOrArray(t_dst))
     {
@@ -453,16 +442,10 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
 #endif /* MCDivide */
 
 	MCExecValue t_src;
-    Boolean t_old_expectation;
-    
-    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
-    t_old_expectation = ctxt . GetNumberExpected();
-    ctxt . SetNumberExpected(True);
     
     if (!ctxt . EvaluateExpression(source, EE_DIVIDE_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
     {
-        ctxt . SetNumberExpected(t_old_expectation);
         return;
     }
 	
@@ -484,7 +467,6 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
         {
             ctxt . LegacyThrow(EE_DIVIDE_BADDEST);
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 	}
@@ -493,13 +475,9 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
         if (!ctxt . EvaluateExpression(dest, EE_DIVIDE_BADDEST, t_dst))
         {
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 	}
-    
-    // Set the number expectation back to its previous state
-    ctxt . SetNumberExpected(t_old_expectation);
 
     if (!ctxt . ConvertToNumberOrArray(t_dst))
     {
@@ -718,16 +696,10 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
 #endif /* MCMultiply */
 
     MCExecValue t_src;
-    Boolean t_old_expectation;
-    
-    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
-    t_old_expectation = ctxt . GetNumberExpected();
-    ctxt . SetNumberExpected(True);
 
     if(!ctxt . EvaluateExpression(source, EE_MULTIPLY_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
     {
-        ctxt . SetNumberExpected(t_old_expectation);
         return;
     }
 	
@@ -749,7 +721,6 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
         {
             ctxt . LegacyThrow(EE_MULTIPLY_BADDEST);
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 	}
@@ -758,13 +729,9 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
         if (!ctxt . EvaluateExpression(dest, EE_MULTIPLY_BADDEST, t_dst))
         {
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 	}
-    
-    // Set the number expectation back to the previous state
-    ctxt . SetNumberExpected(t_old_expectation);
 
     if (!ctxt . ConvertToNumberOrArray(t_dst))
     {
@@ -966,16 +933,10 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
 #endif /* MCSubtract */
 
 	MCExecValue t_src;
-    Boolean t_old_expectation;
-    
-    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
-    t_old_expectation = ctxt . GetNumberExpected();
-    ctxt . SetNumberExpected(True);
 
     if (!ctxt . EvaluateExpression(source, EE_SUBTRACT_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
     {
-        ctxt . SetNumberExpected(t_old_expectation);
         return;
     }
 	
@@ -997,7 +958,6 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
         {
             ctxt . LegacyThrow(EE_SUBTRACT_BADDEST);
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 	}
@@ -1006,13 +966,9 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
         if (!ctxt . EvaluateExpression(dest, EE_SUBTRACT_BADDEST, t_dst))
         {
             MCExecTypeRelease(t_src);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 	}
-    
-    // Set the number expectation back to its previous state
-    ctxt . SetNumberExpected(t_old_expectation);
 
     if (!ctxt . ConvertToNumberOrArray(t_dst))
     {

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -821,10 +821,6 @@ bool MCExecContext::TryToEvaluateExpressionAsDouble(MCExpression *p_expr, uint2 
 	
     bool t_failure, t_can_debug;
     t_can_debug = true;
-    
-    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
-    Boolean t_old_expectation = m_numberexpected;
-    m_numberexpected = True;
 
     MCExecValue t_value;
     double t_result;
@@ -862,8 +858,7 @@ bool MCExecContext::TryToEvaluateExpressionAsDouble(MCExpression *p_expr, uint2 
             r_result = t_value . float_value;
         else
             r_result = t_value . double_value;
-        
-        m_numberexpected = t_old_expectation;
+		
 		return true;
     }
 	
@@ -958,22 +953,16 @@ static bool EvalExprAsStrictNumber(MCExecContext* self, MCExpression *p_expr, Ex
 {
 	MCAssert(p_expr != nil);
 	
-    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
     MCExecValue t_value;
-    Boolean t_number_expected = self -> GetNumberExpected();
-    self -> SetNumberExpected(True);
-    
+	
 	p_expr -> eval_ctxt(*self, t_value);
     
     if (t_value . type == kMCExecValueTypeNone
         || (MCExecTypeIsValueRef(t_value . type) && MCValueIsEmpty(t_value . valueref_value)))
     {
         self -> LegacyThrow(p_error);
-        
         return false;
     }
-    
-    self -> SetNumberExpected(t_number_expected);
     
     if (!self -> HasError())
         MCExecTypeConvertAndReleaseAlways(*self, t_value . type, &t_value, p_type, &r_value);
@@ -995,14 +984,9 @@ static bool EvalExprAsNumber(MCExecContext* self, MCExpression *p_expr, Exec_err
 {
 	MCAssert(p_expr != nil);
 	
-    // SN-2014-04-08 [[ NumberExpectation ]] Ensure we get a number when it's possible instead of a ValueRef
     MCExecValue t_value;
-    Boolean t_number_expected = self -> GetNumberExpected();
-    self -> SetNumberExpected(True);
     
 	p_expr -> eval_ctxt(*self, t_value);
-    
-    self -> SetNumberExpected(t_number_expected);
     
     if (!self -> HasError())
         MCExecTypeConvertAndReleaseAlways(*self, t_value . type, &t_value, p_type, &r_value);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1423,11 +1423,6 @@ public:
 	{
         return m_nfforce;
 	}
-    
-    Boolean GetNumberExpected() const
-    {
-        return m_numberexpected;
-    }
 	
 	//////////
 
@@ -1497,11 +1492,6 @@ public:
 	void SetRowDelimiter(MCStringRef p_value)
 	{
         MCValueAssign(m_rowdel, p_value);
-    }
-    
-    void SetNumberExpected(Boolean p_value)
-    {
-        m_numberexpected = (bool)p_value;
     }
 
     //////////
@@ -1819,10 +1809,6 @@ private:
     bool m_wholematches : 1;
     bool m_usesystemdate : 1;
     bool m_useunicode : 1;
-    // SN-2014-04-08 [[ NumberExpectation ]]
-    // New property allowing to specify, when evaluating a literal number,
-    // that we expect a number over a valueref
-    bool m_numberexpected : 1;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/literal.cpp
+++ b/engine/src/literal.cpp
@@ -53,35 +53,4 @@ void MCLiteral::compile(MCSyntaxFactoryRef ctxt)
 	MCSyntaxFactoryEndExpression(ctxt);
 }
 
-Parse_stat MCLiteralNumber::parse(MCScriptPoint &sp, Boolean the)
-{
-	initpoint(sp);
-	return PS_NORMAL;
-}
 
-void MCLiteralNumber::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
-{
-	// IM-2013-05-02: *TODO* the bugfix here cannot be applied to the syntax
-	// refactor branch as MCExecPoint::setboth() does not exist there
-#ifdef OLD_EXEC
-	// MW-2013-04-12: [[ Bug 10837 ]] Make sure we set 'both' when evaluating the
-	//   literal. Not doing this causes problems for things like 'numberFormat'.
-	if (nvalue == BAD_NUMERIC)
-		ep.setvalueref_nullable(value);
-	else
-        ep.setboth(MCNameGetOldString(value), nvalue);
-	return ES_NORMAL;
-#else
-    // SN-2014-04-08 [[ NumberExpectation ]]
-    // Ensure we return a number when it's possible and asked for, instead of a ValueRef
-    if (ctxt . GetNumberExpected() && nvalue != BAD_NUMERIC)
-    {
-        MCExecValueTraits<double>::set(r_value, nvalue);
-    }
-    else
-    {
-        r_value . type = kMCExecValueTypeValueRef;
-        r_value . valueref_value = MCValueRetain(value);
-    }
-#endif
-}

--- a/engine/src/literal.h
+++ b/engine/src/literal.h
@@ -40,23 +40,4 @@ public:
 	virtual void compile(MCSyntaxFactoryRef ctxt);
 };
 
-class MCLiteralNumber : public MCExpression
-{
-	MCValueRef value;
-	double nvalue;
-public:
-	MCLiteralNumber(MCValueRef v, double n)
-	{
-		/* UNCHECKED */ value = MCValueRetain(v);
-		nvalue = n;
-	}
-	~MCLiteralNumber(void)
-	{
-		MCValueRelease(value);
-	}
-
-    virtual Parse_stat parse(MCScriptPoint &, Boolean the);
-    virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
-};
-
 #endif

--- a/engine/src/operator.cpp
+++ b/engine/src/operator.cpp
@@ -621,11 +621,6 @@ void MCMinus::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
 #endif /* MCMinus */
 
     MCExecValue t_left, t_right;
-    
-    Boolean t_old_expectation;
-    
-    t_old_expectation = ctxt . GetNumberExpected();
-    ctxt . SetNumberExpected(True);
 
     if (left == nil)
     {
@@ -635,7 +630,6 @@ void MCMinus::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
              || !ctxt . ConvertToNumberOrArray(t_left))
     {
         ctxt . LegacyThrow(EE_MINUS_BADLEFT);
-        ctxt . SetNumberExpected(t_old_expectation);
         return;
     }
 
@@ -643,13 +637,9 @@ void MCMinus::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
             || !ctxt . ConvertToNumberOrArray(t_right))
     {
         ctxt . LegacyThrow(EE_MINUS_BADRIGHT);
-        ctxt . SetNumberExpected(t_old_expectation);
         MCExecTypeRelease(t_left);
         return;
     }
-    
-    // Set the number expectation back to its previous state
-    ctxt . SetNumberExpected(t_old_expectation);
 
     r_value . valueref_value = nil;
     if (t_left. type == kMCExecValueTypeArrayRef)

--- a/engine/src/operator.h
+++ b/engine/src/operator.h
@@ -154,19 +154,12 @@ public:
         MCExecValue t_left, t_right;
         t_left . type = kMCExecValueTypeNone;
         t_right . type = kMCExecValueTypeNone;
-        
-        Boolean t_old_expectation;
-        
-        t_old_expectation = ctxt . GetNumberExpected();
-        
-        ctxt . SetNumberExpected(True);
 
         left -> eval_ctxt(ctxt, t_left);
         if (ctxt . HasError()
                 || ! ctxt . ConvertToNumberOrArray(t_left))
         {
             ctxt . LegacyThrow(EvalLeftError);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 
@@ -177,12 +170,8 @@ public:
             ctxt . LegacyThrow(EvalRightError);
             if (t_left . type == kMCExecValueTypeArrayRef)
                 MCValueRelease(t_left . arrayref_value);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
-        
-        // Set the numiber expectation back to its previous state
-        ctxt . SetNumberExpected(t_old_expectation);
 
         r_value . valueref_value = nil;
         if (t_left . type == kMCExecValueTypeArrayRef)
@@ -244,18 +233,12 @@ public:
         MCExecValue t_left, t_right;
 		t_left . type = kMCExecValueTypeNone;
 		t_right . type = kMCExecValueTypeNone;
-		
-        Boolean t_old_expectation;
-        
-        t_old_expectation = ctxt . GetNumberExpected();
-        ctxt . SetNumberExpected(True);
 
         // PM-2015-01-15: [[ Bug 14384 ]] Prevent a crash when putting +1 into variable
         if ((left != nil && (left -> eval_ctxt(ctxt, t_left), ctxt . HasError()))
                 || !ctxt . ConvertToNumberOrArray(t_left))
         {
             ctxt . LegacyThrow(EvalLeftError);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 
@@ -265,7 +248,6 @@ public:
             ctxt . LegacyThrow(EvalRightError);
             if (t_left . type == kMCExecValueTypeArrayRef)
                 MCValueRelease(t_left . valueref_value);
-            ctxt . SetNumberExpected(t_old_expectation);
             return;
         }
 
@@ -284,9 +266,6 @@ public:
             else
                 Eval(ctxt, t_left . double_value, t_right . double_value, r_value . double_value);
         }
-        
-        // Set the number expectation back to its previous state
-        ctxt . SetNumberExpected(t_old_expectation);
         
         if (ctxt . HasError())
             MCExecTypeRelease(r_value);

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1581,8 +1581,9 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
             }
 
             nvalue = MCNumberFetchAsReal(*t_number);
+            MCStringSetNumericValue(MCNameGetString(gettoken_nameref()), nvalue);
 
-			newfact = insertfactor(new MCLiteralNumber(gettoken_nameref(), nvalue), curfact, top);
+			newfact = insertfactor(new MCLiteral(gettoken_nameref()), curfact, top);
 			newfact->parse(*this, doingthe);
 			needfact = False;
         }

--- a/tests/lcs/core/execution/literal-evaluation.livecodescript
+++ b/tests/lcs/core/execution/literal-evaluation.livecodescript
@@ -1,6 +1,6 @@
 script "CoreExecutionLiteralEvaluation"
 /*
-Copyright (C) 2015 LiveCode Ltd.
+Copyright (C) 2016 LiveCode Ltd.
 
 This file is part of LiveCode.
 

--- a/tests/lcs/core/execution/literal-evaluation.livecodescript
+++ b/tests/lcs/core/execution/literal-evaluation.livecodescript
@@ -1,0 +1,27 @@
+script "CoreExecutionLiteralEvaluation"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestEvaluateNumericLiteral
+   set the numberFormat to "00"
+   TestAssert "numeric literal remains string", (2 & empty) is "2"
+   TestAssert "numeric literal becomes number in numeric context", ((2 + 0) & empty) is "02"
+
+   local tArray
+   put "2" into tArray["2"]
+   TestAssert "numeric literal remains string in computation context", (tArray[2] + 1) is "03"
+end TestEvaluateNumericLiteral


### PR DESCRIPTION
The 'NumberExpected' mechanism put in as an optimization had an
unfortunate consequence of cause numeric literals to go through
an extra string -> number -> string conversion compared to previous
engine versions. This manifested itself in array indicies being affected
by the numberFormat when they should not be.

This patch removes the NumberExpected mechanism, replacing it by
a use of SetNumericValue of StringRefs which should offer much the
same level of performance.
