### PR TITLE
widgets: Clarify access to hilited items from hiliteChanged handler

### DIFF
--- a/extensions/widgets/segmented/support/defaultscript.livecodescript
+++ b/extensions/widgets/segmented/support/defaultscript.livecodescript
@@ -1,5 +1,8 @@
 ﻿script "com.livecode.widget.segmented.__DefaultScript"
--- Sent when the set of highlighted segments changes
+-- Sent when a navigation item is clicked
+--
+-- Use the "hilitedItems" property to get the current item number and the
+-- "hilitedItemNames" property to get its item name
 on hiliteChanged
-   
+   put the hilitedItems of me && the hilitedItemNames of me
 end hiliteChanged

--- a/extensions/widgets/svgpath/support/defaultscript.livecodescript
+++ b/extensions/widgets/svgpath/support/defaultscript.livecodescript
@@ -1,4 +1,5 @@
 ﻿script "com.livecode.widget.svgpath.__DefaultScript"
 on mouseUp
+   -- Toggle the hilited property when clicked
    set the hilited of me to (not the hilited of me)
 end mouseUp

--- a/extensions/widgets/switchbutton/support/defaultscript.livecodescript
+++ b/extensions/widgets/switchbutton/support/defaultscript.livecodescript
@@ -1,4 +1,5 @@
 ﻿script "com.livecode.widget.switchbutton.__DefaultScript"
-on hiliteChanged pHilited
-
+-- Sent when the switchbutton switches from off to on or from on to off.
+on hiliteChanged
+   put the hilited of me
 end hiliteChanged


### PR DESCRIPTION
Now that we don't pass a parameter to the "hiliteChanged" signal,
update the default scripts for widgets that send the
"hiliteChanged" signal to show how to access the hightlighted
status and/or chunk information.
