### PR TITLE
[[ Bug 16996 ]] Turn off CEF debug.log

### DIFF
--- a/docs/notes/bugfix-16996.md
+++ b/docs/notes/bugfix-16996.md
@@ -1,0 +1,1 @@
+# Stop generation of CEF debug.log

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -299,6 +299,7 @@ bool MCCefInitialise(void)
 	t_settings.multi_threaded_message_loop = MC_CEF_USE_MULTITHREADED_MESSAGELOOP;
 	t_settings.command_line_args_disabled = true;
 	t_settings.no_sandbox = true;
+	t_settings.log_severity = LOGSEVERITY_DISABLE;
 	
 	bool t_success;
 	t_success = MCCefStringFromUtf8String(MCCefPlatformGetSubProcessName(), &t_settings.browser_subprocess_path);


### PR DESCRIPTION
The CefSettings object used to initialize a CEF instance has been
tweaked to ensure debug logging is turned off.
