### PR TITLE
[[ Bug 17217 ]] Enable drag drop to be started from a widget

### DIFF
--- a/docs/notes/bugfix-17217.md
+++ b/docs/notes/bugfix-17217.md
@@ -1,0 +1,1 @@
+# dragStart message reinstated for widgets

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -292,8 +292,12 @@ void MCWidget::munfocus(void)
 
 void MCWidget::mdrag(void)
 {
+#ifdef WIDGETS_HANDLE_DND
     if (m_widget != nil)
         MCwidgeteventmanager->event_mdrag(this);
+#else
+	MCControl::mdrag();
+#endif
 }
 
 Boolean MCWidget::doubledown(uint2 p_which)


### PR DESCRIPTION
The dragStart message was blocked from being dispatched when the
target was a widget. As widget's cannot currently leverage drag-
drop internally, the default behavior has been re-established
meaning that handling a dragStart message in the widget's script
will work as expected.
