### PR TITLE
Fix redraw issues in combo-box fields

### DIFF
--- a/docs/notes/bugfix-15965.md
+++ b/docs/notes/bugfix-15965.md
@@ -1,0 +1,2 @@
+# Fix incorrect clipping of combo box text
+

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -3608,3 +3608,22 @@ MCPlatformControlState MCField::getcontrolstate()
     
     return MCPlatformControlState(t_state);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+void MCField::layer_redrawrect(const MCRectangle& m_dirty_rect)
+{
+    // If the parent of this field is a button, this is the entry field for
+    // a combo-box. In that case, the text is vertically centred(-ish)
+    // within the field so the y offsets we calculate here are wrong.
+    // Calculating the correct position is fairly complicated so the simpler
+    // solution is to just invalidate the whole field in that case.
+    //
+    // This doesn't make much of a difference performance-wise; the number
+    // of pixels to be rasterised is higher but only by 3 or 4 rows in most
+    // cases.
+    if (getparent()->gettype() != CT_BUTTON)
+        MCControl::layer_redrawrect(m_dirty_rect);
+    else
+        MCControl::layer_redrawrect(rect);
+}

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -927,6 +927,15 @@ public:
     void GetEffectiveTextStyleElementOfCharChunk(MCExecContext& ctxt, MCNameRef p_index, uint32_t p_part_id, int32_t si, int32_t ei, bool& r_mixed, bool& r_value);
     void SetTextStyleElementOfCharChunk(MCExecContext& ctxt, MCNameRef p_index, uint32_t p_part_id, int32_t si, int32_t ei, bool *p_value);
 
+    // Invalidates the given rect of this field *unless* this field is the entry
+    // box in a combo-box. Because the text is vertically-centred in those
+    // fields, the y offsets calculated during dirty calculations are wrong and
+    // the rect cannot be trusted so a full-field invalidation is needed.
+    //
+    // This override is non-virtual as the method is never called in a dynamic
+    // context.
+    void layer_redrawrect(const MCRectangle& m_dirty_rect);
+    
 protected:
     
     // FG-2014-11-11: [[ Better theming ]] Fetch the control type/state for theming purposes


### PR DESCRIPTION
Unlike any other field, the text in a combo-box entryfield is
vertically centred. This means that most of the field code that
calculates dirty rects for redraws uses the wrong y offsets and
ends up clipping incorrectly.

This patch is brute-force and overrides the layer_redrawrect
method for fields to redraw the whole field if it is a combo-box
entry field.

There are still some issues, like cursor positioning being slightly
incorrect, but they are much less jarring and problematic than
having text with clipped descenders!

A proper fix requires fairly invasive changes to various parts
of the field code and is too risky for this part of the development
cycle.
