### PR TITLE
[Bug 17194] docs: Improve "file:" URL documentation and RFC xrefs

### DIFF
--- a/docs/dictionary/command/accept.lcdoc
+++ b/docs/dictionary/command/accept.lcdoc
@@ -43,9 +43,14 @@ where the connectionID is a number assigned by the <accept> <command>. (You only
 
 The <callbackMessage> is sent to the <object> whose <script> contains the <accept> <command>. Either one or two <parameter|parameters> are sent with this <message>. The first <parameter> is the <IP address> of the system or <process> making the connection. If a <datagram> is being accepted, the second <parameter> is the contents of the <datagram>.
 
-For technical information about sockets, see RFC 147 at http://www.ietf.org/rfc/rfc147.txt.
-For technical information about UDP datagrams, see RFC 768 at http://www.ietf.org/rfc/rfc0768.txt.
-For technical information about the numbers used to designate standard ports, see the list of port numbers at http://www.iana.org/assignments/port-numbers, in particular the section entitled "Well Known Port Numbers".
+- For technical information about sockets, see [RFC
+  147](https://tools.ietf.org/html/rfc147)
+- For technical information about UDP datagrams, see [RFC
+  768](https://tools.ietf.org/html/rfc768)
+- For technical information about the numbers used to designate
+  standard ports, see the
+  [official IANA list of port assignments](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)
+  and [RFC 6335](https://tools.ietf.org/html/rfc6335)
 
 References: HTTPProxy (property), script (property), read from socket (command), write to socket (command), close socket (command), open socket (command), openSockets (function), hostAddressToName (function), hostName (function), hostAddress (function), peerAddress (function), hostNameToAddress (function), datagram (glossary), IP address (glossary), TCP (glossary), port (glossary), command (glossary), socket (glossary), UDP (glossary), host (glossary), server (glossary), message (glossary), parameter (glossary), process (glossary), object (object)
 

--- a/docs/dictionary/command/get.lcdoc
+++ b/docs/dictionary/command/get.lcdoc
@@ -34,7 +34,12 @@ The <get> <command> is a shorthand way of writing the following statement:
 
   put expression into it
 
->*Note:* When specifying URLs for Android and iOS, you must use the appropriate form that confirms to the RFC standards. Ensure that you <urlEncode> any username and password fields appropriately for FTP urls.  The Android and iOS engines do not support 'libUrl', which would allow characters such as @ in the username.
+> *Note:* When specifying URLs for iOS or Android, you must use the
+> appropriate form that conforms to [RFC
+> 1738](https://tools.ietf.org/html/rfc1738). Ensure that you
+> <URLEncode> any username and password fields appropriately for FTP
+> URLs. The Android and iOS engines do not support 'libUrl', which
+> would allow characters such as @ in the username.
 
 References: it (keyword), post (command), unload (command), put (command), libURLSetFTPStopTime (command), load (command), set (command), libURLSetLogField (command), getProp (control_st), value (function), URLEncode (function), expression (glossary), command (glossary), variable (glossary)
 

--- a/docs/dictionary/command/launch-url-in-widget.lcdoc
+++ b/docs/dictionary/command/launch-url-in-widget.lcdoc
@@ -22,6 +22,8 @@ widget: A widget reference.
 Description:
 Use the <launch url> command to open a url within a widget. When <launch url in widget> is called, LiveCode sends a "OnLaunchURL" message to that widget with <url> as the parameter. The widget can then display the url in an appropriate manner.
 
-References: launch url (command), launch document (command), URL (keyword), widget (object)
+>*Note:* The <url> must be a standards-compliant URL.  In particular, `file:` urls must be of the form `file://<absolute path>`, and the path should be <URLEncode|URL-encoded>.
+
+References: launch url (command), launch document (command), URLEncode (function), URL (keyword), widget (object)
 
 Tags: widget

--- a/docs/dictionary/command/launch-url.lcdoc
+++ b/docs/dictionary/command/launch-url.lcdoc
@@ -37,8 +37,8 @@ The following <url scheme|URL schemes> are supported:
 - `file:` URLs, which open the file in the associated application
 - `tel:` URLs, which open the dialer with a given phone number
 
->*Note:* The urlToLaunch must be a standards-compliant URL, in particular file urls must be of the form file://&lt;absolute path&gt;.
+>*Note:* The <urlToLaunch> must be a standards-compliant URL.  In particular, `file:` URLs must be of the form `file://<absolute path>`, and the path should be <URLEncode|URL-encoded>.
 
 >*Important:* Mobile: Successfully launching a url  will cause another application to open and the requesting application to be quit. The application will receive a shutdown message before this happens.
 
-References: revGoURL (command), launch (command), launch document (command), URL (keyword), URL (glossary), URL scheme (glossary)
+References: revGoURL (command), launch (command), launch document (command), URLEncode (function), URL (keyword), URL (glossary), URL scheme (glossary)

--- a/docs/dictionary/command/libURLSetCustomHTTPHeaders.lcdoc
+++ b/docs/dictionary/command/libURLSetCustomHTTPHeaders.lcdoc
@@ -48,7 +48,7 @@ If you specify a set of headers using the <libURLSetCustomHTTPHeaders> <command>
 
 >*Note:*  When included in a <standalone application>, the <Internet library> is implemented as a hidden <group> and made available when the <group> receives its first <openBackground> message. During the first part of the <application|application's> startup process, before this <message> is sent, the <libURLSetCustomHTTPHeaders> <command> is not yet available. This may affect attempts to use this <command> in <startup>, <preOpenStack>, <openStack>, or <preOpenCard> <handler|handlers> in the <main stack>. Once the <application> has finished starting up, the <library> is available and the <libURLSetCustomHTTPHeaders> <command> can be used in any <handler>.
 
-For technical information about the standard headers recognized in the HTTP 1.1 protocol, see RFC 2616 at http://www.ietf.org/rfc/rfc2616.txt.
+For technical information about the standard headers recognized in the HTTP 1.1 protocol, see [RFC 2616](https://tools.ietf.org/html/rfc2616).
 
 References: httpHeaders (property), startup (message), openBackground (message), preOpenStack (message), openStack (message), preOpenCard (message), Internet library (library), LiveCode custom library (library), library (library), https (keyword), URL (keyword), default (keyword), http (keyword), application (glossary), standalone application (glossary), property (glossary), web server (glossary), command (glossary), expression (glossary), main stack (glossary), Standalone Application Settings (glossary), server (glossary), HTTP (glossary), message (glossary), handler (glossary), libURLLastHTTPHeaders (function), post (command), libURLSetCustomHTTPHeaders (command), group (command)
 

--- a/docs/dictionary/command/load.lcdoc
+++ b/docs/dictionary/command/load.lcdoc
@@ -50,7 +50,12 @@ The file is downloaded into a local cache. It does not remain available after th
 
 >*Important:*  The <load> <command> is part of the <Internet library on desktop platforms(library)>. To ensure that the <command> works in a <standalone desktop application>, you must include this <LiveCode custom library|custom library> when you create your <standalone application|standalone>. In the Inclusions section of the <Standalone Application Settings> window, make sure Internet Library is selected in the list of script libraries. The iOS and Android engines do not support 'libUrl' but allows you to use <load> in the background.
 
->*Note:* When specifying URLs for iOS and Android, you must use the appropriate form that confirms to the RFC standards. Ensure that you <URLEncode> any username and password fields appropriately for FTP urls.
+
+> *Note:* When specifying URLs for iOS or Android, you must use the
+> appropriate form that conforms to [RFC
+> 1738](https://tools.ietf.org/html/rfc1738). Ensure that you
+> <URLEncode> any username and password fields appropriately for FTP
+> URLs.
 
 >*Note:*  When included in a <standalone application>, the <Internet library> is implemented as a hidden <group> and made available when the <group> receives its first <openBackground> message. During the first part of the <application|application's> startup process, before this <message> is sent, the <load> <command> is not yet available. This may affect attempts to use this <command> in <startup>, <preOpenStack>, <openStack>, or <preOpenCard> <handler|handlers> in the <main stack>. Once the <application> has finished starting up, the <library> is available and the <load> <command> can be used in any <handler>.
 

--- a/docs/dictionary/command/post.lcdoc
+++ b/docs/dictionary/command/post.lcdoc
@@ -56,6 +56,11 @@ get URL fileURLToGet
 
 >*Note:* When included in a standalone application, the Internet library is implemented as a hidden group and made available when the group receives its first openBackground message. During the first part of the application startup process, before this message is sent, the <post> command is not yet available. This may affect attempts to use this command in startup, preOpenStack, openStack, or preOpenCard hand in the main stack. Once the application has finished starting up, the library is available and the <post> command can be used in any handler.
 
->*Note:* The Android and iOS engines do not support 'libUrl' but allow you to use post in the background. When specifying URLs for Android and iOS, you must use the appropriate form that confirms to the RFC standards. Ensure that you urlEncode any username and password fields appropriately for FTP urls.
+> *Note:* The Android and iOS engines do not support 'libUrl' but do
+> allow you to use <post> in the background. When specifying URLs for
+> Android or iOS, you must use the appropriate form that conforms to
+> [RFC 1738](https://tools.ietf.org/html/rfc1738). Ensure that you
+> <URLEncode> any username and password fields appropriately for FTP
+> URLs.
 
 References: httpHeaders (property), HTTPProxy (property), urlProgress (message), URL (keyword), ftp (keyword), http (keyword), variable (glossary), ommand (glossary), property (glossary), blocking (glossary), web server (glossary), command (glossary), expression (glossary), syntax (glossary), server (glossary), upload (glossary), statement (glossary), handler (glossary), result (function), URLStatus (function), URLEncode (function), libURLFormData (function), URLDecode (function), libURLMultipartFormAddPart (function), libURLMultipartFormData (function), post (command), write to socket (command), delete URL (command), read from socket (command), put (command), libURLSetExpect100 (command), libURLSetLogField (command), open socket (command), libURLSetCustomHTTPHeaders (command), function (control_st)

--- a/docs/dictionary/command/put.lcdoc
+++ b/docs/dictionary/command/put.lcdoc
@@ -75,7 +75,12 @@ Then you can use the <put> <command> with a <resfile> <URL> type to create the <
 
 >*Note:* On windows, it is imperative not to name a file with one of the reserved device names: CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8 and LPT9. Also do not use these names followed by an extension, for example, NUL.tx7.
 
->*Note:* The iOS engines does not support 'libUrl' but allows you to use put in the background. When specifying URLs for iOS, you must use the appropriate form that confirms to the RFC standards. Ensure that you <URLEncode> any username and password fields appropriately for FTP urls.
+> *Note:* The Android and iOS engines do not support 'libUrl' but do
+> allow you to use <put> in the background. When specifying URLs for
+> iOS, you must use the appropriate form that conforms to [RFC
+> 1738](https://tools.ietf.org/html/rfc1738). Ensure that you
+> <URLEncode> any username and password fields appropriately for FTP
+> URLs.
 
 References: explicitVariables (property), urlProgress (message), binfile URL (keyword), ftp (keyword), message box (keyword), file (keyword), resfileURL (keyword), binfile (keyword), URL (keyword), resfile (keyword), httpURL (keyword), after (keyword), field (keyword), before (keyword), http (keyword), word (keyword), handler (glossary), variable (glossary), property (glossary), blocking (glossary), binary file (glossary), command (glossary), declare (glossary), resource fork (glossary), blocking URL (glossary), error (glossary), expression (glossary), local variable (glossary), upload (glossary), server (glossary), statement (glossary), container (glossary), result (function), value (function), URLEncode (function), delete URL command (command), libURLftpUploadcommand (command), put (command), local (command), put command (command), post command (command), libURLftpUpload (command), libURLDownloadToFile (command), function (control_st)
 

--- a/docs/dictionary/command/put.lcdoc
+++ b/docs/dictionary/command/put.lcdoc
@@ -67,7 +67,10 @@ end if
 
 Then you can use the <put> <command> with a <resfile> <URL> type to create the <resource fork>.
 
->*Important:* The syntax for file urls in LiveCode does not conform to RFC1738. To ensure proper operation on all platforms make sure you use file:path rather than file://path.
+>*Important:* The syntax for file URLs with LiveCode's <URL(keyword)>
+>does not conform to [RFC 1738](https://tools.ietf.org/html/rfc1738).
+>To ensure proper operation on all platforms make sure you use
+>`file:path` rather than `file://path`.
 
 * When used with an http <URL>, uses the <HTTP> PUT method to <upload> the <value> to the <server>. However, since most <HTTP> <server|servers> don't implement the PUT method, you usually will use an <FTP> <URL> instead to <upload> files to an <HTTP> <server>.
 

--- a/docs/dictionary/function/base64Decode.lcdoc
+++ b/docs/dictionary/function/base64Decode.lcdoc
@@ -36,6 +36,6 @@ Base 64-encoded data does not necessarily contain any = signs. If a run of one o
 
 The base 64 encoding scheme is often used to encode binary data for MIME mail and HTTP transfers.
 
-For technical information about base 64 encoding, see section 6.8 of RFC 2045 at http://www.ietf.org/rfc/rfc2045.txt.
+For technical information about base 64 encoding, see [RFC 2045, section 6.8](https://tools.ietf.org/html/rfc2045#section-6.8).
 
 References: string (keyword), inverse (keyword), md5Digest (function), base64Encode (function), decompress (function), encode (glossary), return (glossary), binary file (glossary), function (control_st)

--- a/docs/dictionary/function/base64Encode.lcdoc
+++ b/docs/dictionary/function/base64Encode.lcdoc
@@ -28,7 +28,8 @@ Use the <base64Encode> function to <encode> <binary file|binary data> for transm
 The <base64Encode> function is the <inverse> of the <base64Decode> <function>. The <encode|encoded> result is generally about a third larger than the original data.
 The encoded string returned by <base64Encode> <function> can include uppercase and lowercase letters, digits, +, /, and =, but no other characters. Base 64-encoded data is wrapped at 72 characters, so each <line> of the <encode|encoded> data is 72 <characters> or (for the last or only line) fewer.
 The base 64 encoding scheme is often used to encode binary data for MIME mail and HTTP transfers.
-For technical information about base 64 encoding, see section 6.8 of RFC 2045 at http://www.ietf.org/rfc/rfc2045.txt.
+
+For technical information about base 64 encoding, see [RFC 2045, section 6.8](https://tools.ietf.org/html/rfc2045#section-6.8).
 
 References: inverse (keyword), characters (keyword), line (keyword), string (keyword), numToChar (function), md5Digest (function), base64Decode (function), encode (glossary), binary file (glossary), encodedstring (glossary), return (glossary), function (control_st)
 

--- a/docs/dictionary/function/compress.lcdoc
+++ b/docs/dictionary/function/compress.lcdoc
@@ -34,7 +34,7 @@ The compressed result is typically about half to a third the size of the origina
 
 >*Important:*  The value <return|returned> by the <compress> <function> consists of <binary file|binary data> and may include control characters, so displaying it on screen or trying to edit it may produce unexpected results. If you use a <URL> to place the <return|returned> data in a <file>, it's important to use the <binfile> <URL> scheme; using the <file> <URL> scheme will corrupt <binary file|binary data>.
 
-For technical information about the format used by the <compress> <function>, see RFC 1952 at http://www.ietf.org/rfc/rfc1952.txt. The <compress> <function> uses the zlib compression library.
+For technical information about the format used by the <compress> <function>, see [RFC 1952](https://tools.ietf.org/html/rfc1952). The <compress> <function> uses the zlib compression library.
 
 References: URL (keyword), inverse (keyword), file (keyword), binfile (keyword), string (keyword), compress (function), decompress (function), return (glossary), binary file (glossary), function (control_st)
 

--- a/docs/dictionary/function/decompress.lcdoc
+++ b/docs/dictionary/function/decompress.lcdoc
@@ -36,7 +36,7 @@ The decompress <function(control_st)> is the <inverse> of the <compress> <functi
 
 The uncompressed result is typically about half again the size of the compressed data, although different results may be obtained depending on the amount of data.
 
-For technical information about the format used by the <compress> and <decompress> <function(glossary)|functions>, see RFC 1952 at http://www.ietf.org/rfc/rfc1952.txt. The <decompress> <function(control_st)> uses the zlib compression library.
+For technical information about the format used by the <compress> and <decompress> <function(glossary)|functions>, see [RFC 1952](https://tools.ietf.org/html/rfc1952). The <decompress> <function(control_st)> uses the zlib compression library.
 
 References: string (keyword), inverse (keyword), base64Decode (function), compress (function), URLDecode (function), compress (glossary), return (glossary), function (glossary), function (control_st)
 

--- a/docs/dictionary/function/libURLftpCommand.lcdoc
+++ b/docs/dictionary/function/libURLftpCommand.lcdoc
@@ -38,7 +38,7 @@ The ability to send any FTP command to an FTP server is a powerful function that
 
   answer libURLftpCommand("HELP",ftp.example.net)
 
-For technical information about FTP server commands, see RFC 959 at http://www.ietf.org/rfc/rfc959.txt, particularly section 4.1.3.
+For technical information about FTP server commands, see [RFC 959, section 4.1.3](https://tools.ietf.org/html/rfc959).
 
 >*Important:*  The <libURLftpCommand> <function> is part of the <Internet library>. To ensure that the <function> works in a <standalone application>, you must include this <LiveCode custom library|custom library> when you create your <standalone application|standalone>. In the Inclusions section of the <Standalone Application Settings> window, make sure "Internet Library" is selected in the list of script libraries.
 

--- a/docs/dictionary/function/libUrlMultipartFormData.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormData.lcdoc
@@ -8,7 +8,7 @@ Syntax: libURLMultipartFormData(form data, array)
 
 Syntax: libURLMultipartFormData(<form data>)
 
-Summary: <libURLMultipartFormData> formats data in the way described in rfc 1867.
+Summary: <libURLMultipartFormData> formats data in the way described in RFC 1867.
 
 Introduced: 2.5
 
@@ -67,5 +67,7 @@ end if
 >*Important:*  The <libURLMultipartFormData> <function> is part of the <Internet library>. To ensure that the <keyword> works in a <standalone application>, you must include this <LiveCode custom library|custom library> when you create your <standalone application|standalone>. In the Inclusions section of the <Standalone Application Settings> window, make sure "Internet Library" is selected in the list of script libraries.
 
 >*Note:* When included in a <standalone application>, the <Internet library> is implemented as a hidden <group> and made available when the <group> receives its first <openBackground> message. During the first part of the <application|application's> startup process, before this <message> is sent, the http <keyword> is not yet available. This may affect attempts to use this <keyword> in <startup>, <preOpenStack>, <openStack>, or <preOpenCard> <handler|handlers> in the <main stack>. Once the <application> has finished starting up, the <library> is available and the http <keyword> can be used in any <handler>.
+
+See also [RFC 1867](https://tools.ietf.org/html/rfc1867).
 
 References: startup (message), openBackground (message), preOpenStack (message), openStack (message), preOpenCard (message), post (command), libURLSetExpect100 (command), libURLMultipartFormAddPart (function), libURLFormData (function), Internet library (library), LiveCode custom library (library), library (library), main stack (glossary), handler (glossary), Standalone Application Settings (glossary), message (glossary), group (glossary), standalone application (glossary), keyword (glossary), function (glossary), application (glossary)

--- a/docs/dictionary/function/md5Digest.lcdoc
+++ b/docs/dictionary/function/md5Digest.lcdoc
@@ -33,7 +33,7 @@ Use the <md5Digest> <function> to create a fingerprint of the <dataString> which
 
 The value returned for one <dataString> is mathematically unlikely to be identical to the value <return|returned> for an altered version of the <dataString>. Therefore, you can check the <md5Digest> of a <string> against a saved <md5Digest> to determine whether the <string> has changed since you saved the <value>.
 
-For technical information about the MD-5 digest algorithm, see RFC 1321 at http://www.ietf.org/rfc/rfc1321.txt.
+For technical information about the MD5 digest algorithm, see [RFC 1321](https://tools.ietf.org/html/rfc1321).
 
 References: string (keyword), characters (keyword), base64Decode (function), base64Encode (function), charToNum (function), value (function), return (glossary), bit (glossary), function (control_st)
 

--- a/docs/dictionary/function/revBrowserOpen.lcdoc
+++ b/docs/dictionary/function/revBrowserOpen.lcdoc
@@ -40,6 +40,8 @@ Returns: The <revBrowserOpen> function returns a value. If successful this will 
 Description:
 The <revBrowserOpen> function opens a new browser in the window with the given <windowId>. If a <url> is given, the new browser immediately navigates to this url.
 
+>*Note:* The <url> must be a standards-compliant URL.  In particular, `file:` URLs must be of the form `file://<absolute path>`, and the path should be <URLEncode|URL-encoded>.
+
 >*Cross-platform note:*  On Windows systems, the Internet Explorer browser is used by the <revBrowserOpen> function while on OS X Systems the Safari browser is used. To ensure cross-platform compatibility, don't use features that are not supported by both browsers, eg "ftp://" urls, which are only supported by Internet Explorer. 
 
 It is no longer necessary to initialise the Browser using XBrowser_Init, and this command now does nothing, but is still included to prevent legacy code causing script errors.

--- a/docs/dictionary/keyword/URL.lcdoc
+++ b/docs/dictionary/keyword/URL.lcdoc
@@ -39,9 +39,9 @@ resfile: on Mac OS and OS X systems, the resource fork of a file
 
 All actions that refer to a <URL> container are blocking: that is, the handler pauses until LiveCode is finished accessing the <URL>. Since fetching a web page may take some time due to network lag, accessing URLs may take long enough to be noticeable to the user. To avoid this delay, use the load command (which is non-blocking) to cache web pages before you need them.
 
-For technical information about URLs and URL schemes, see RFC 1630 at http://www.ietf.org/rfc/rfc1630.txt.
+For technical information about URLs and URL schemes, see [RFC 1630](https://tools.ietf.org/html/rfc1630).
 
->*Important:*  The http and ftp keywords are part of the Internet library on desktop platforms. To ensure that these <URL> types work in a desktop standalone application, you must include this custom library when you create your standalone. In the Inclusions section of the Standalone Application Settings window, make sure Internet Library is selected in the list of script libraries. The iOS and Android engines do not support 'libUrl' but allow you to use <URL>. When specifying URLs for iOS and Android, you must use the appropriate form that confirms to the RFC standards. Ensure that you urlEncode any username and password fields appropriately for FTP urls.
+>*Important:*  The http and ftp keywords are part of the Internet library on desktop platforms. To ensure that these <URL> types work in a desktop standalone application, you must include this custom library when you create your standalone. In the Inclusions section of the Standalone Application Settings window, make sure Internet Library is selected in the list of script libraries. The iOS and Android engines do not support 'libUrl' but allow you to use <URL>. When specifying URLs for iOS and Android, you must use the appropriate form that confirms to RFC 1630. Ensure that you urlEncode any username and password fields appropriately for FTP urls.
 
 >*Important:*  The space character is not valid in URLs, however libURL (Desktop platforms) replaces this character with the required '%20'. This is something that the mobile and server platforms do not do. Be careful to construct valid URLs when working an fully cross platform applications.
 

--- a/docs/dictionary/keyword/ftp.lcdoc
+++ b/docs/dictionary/keyword/ftp.lcdoc
@@ -81,7 +81,7 @@ The following example shows how to set a flag in a global variable to prevent mu
 
 To send any FTP command to an FTP server, use the libURLftpCommand <function>.
 
-For technical information about URLs and the <ftp> <URL> scheme, see RFC 1630 at http://www.ietf.org/rfc/rfc1630.txt.
+For technical information about URLs and the <ftp> <URL> scheme, see [RFC 1630](https://tools.ietf.org/html/rfc1630).
 
 >*Important:*  The <ftp> <keyword> is part of the <Internet library>. To ensure that the <keyword> works in a <standalone application>, you must include this <LiveCode custom library|custom library> when you create your <standalone application|standalone>. In the Inclusions section of the <Standalone Application Settings> window, make sure "Internet Library" is selected in the list of script libraries.
 

--- a/docs/dictionary/keyword/http.lcdoc
+++ b/docs/dictionary/keyword/http.lcdoc
@@ -74,7 +74,7 @@ The following example shows how to set a flag in a global variable to prevent mu
        put false into downloadInProgress -- finished
     end mouseUp
 
-For technical information about URLs and the <http> <URL(keyword)> scheme, see RFC 1630 at http://www.ietf.org/rfc/rfc1630.txt.
+For technical information about URLs and the <http> <URL(keyword)> scheme, see [RFC 1630](https://tools.ietf.org/html/rfc1630).
 
 >*Important:*  The <http> <keyword> is part of the <Internet library>. To ensure that the <keyword> works in a <standalone application>, you must include this <LiveCode custom library|custom library> when you create your <standalone application|standalone>. In the Inclusions section of the <Standalone Application Settings> window, make sure "Internet Library" is selected in the list of script libraries.
 

--- a/docs/dictionary/keyword/https.lcdoc
+++ b/docs/dictionary/keyword/https.lcdoc
@@ -76,7 +76,7 @@ The following example shows how to set a flag in a global variable to prevent mu
        put false into downloadInProgress -- finished
     end mouseUp
 
-For technical information about URLs and the <https> <URL(keyword)> scheme, see RFC 1630 at http://www.ietf.org/rfc/rfc1630.txt.
+For technical information about URLs and the <https> <URL(keyword)> scheme, see [RFC 1630](https://tools.ietf.org/html/rfc1630).
 
 >*Important:*  The <https> <keyword> is part of the <Internet library> and the SSL & Encryption library. To ensure that the <keyword> works in a <standalone application>, you must include this <LiveCode custom library|custom library> when you create your <standalone application|standalone>. In the Inclusions section of the <Standalone Application Settings> window, make sure "Internet" and "SSL & Encryption" is selected in the list of script libraries.
 

--- a/docs/dictionary/keyword/internet.lcdoc
+++ b/docs/dictionary/keyword/internet.lcdoc
@@ -33,7 +33,7 @@ An internet <date> looks like this: Sun, 28 Oct 2001 17:18:54 -0800
 
 >*Note:* The <internet> <keyword> is implemented internally as a <property> and appears in the <propertyNames>. However, it cannot be used as a <property> in an <expression>, nor with the <set> <command>.
 
-For technical information about the date format produced by the <internet> <keyword>, see RFC 2822 at http://www.ietf.org/rfc/rfc2822.txt.
+For technical information about the date format produced by the <internet> <keyword>, see [RFC 2822](https://tools.ietf.org/html/rfc2822).
 
 References: short (keyword), abbreviated (keyword), convert (command), set (command), format (function), propertyNames (function), date (function), function (control_st), keyword (glossary), property (glossary), command (glossary), protocol (glossary), error (glossary), expression (glossary)
 

--- a/docs/dictionary/property/httpHeaders.lcdoc
+++ b/docs/dictionary/property/httpHeaders.lcdoc
@@ -30,7 +30,7 @@ To replace the default headers instead of adding to them, use the <libURLSetCust
 
 >*Important:* If you have used the <libURLSetCustomHTTPHeaders> <command> to set all the headers, the <httpHeaders> setting is ignored and the headers set by <libURLSetCustomHTTPHeaders> are used instead. 
 
-For technical information about the standard headers recognized in the HTTP 1.1 protocol, see RFC 2616 at http://www. ietf. org/rfc/rfc2616. txt.
+For technical information about the standard headers recognized in the HTTP 1.1 protocol, see [RFC 2616](https://tools.ietf.org/html/rfc2616).
 
 References: URL (keyword), default (keyword), http (keyword), string (keyword), post (command), libURLSetCustomHTTPHeaders (command), URLDecode (function), libURLLastRHHeaders (function), property (glossary), expression (glossary), command (glossary), web server (glossary), server (glossary)
 

--- a/docs/notes/bugfix-17194.md
+++ b/docs/notes/bugfix-17194.md
@@ -1,0 +1,1 @@
+# Improve documentation related to "file:" URLs

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2015 LiveCode Ltd.
+Copyright (C) 2015-2016 LiveCode Ltd.
 
 This file is part of LiveCode.
 
@@ -15,150 +15,16 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
-Browser svg icon from https://www.iconfinder.com/icons/309064/browser_globe_international_internet_web_world_icon#size=128
-Copyright Ivan Boyko,
-Licensed under the terms of the Creative Commons Attribution 3.0 Unported License http://creativecommons.org/licenses/by/3.0/
-*/
-
-/*
+/**
 This widget displays web content within a native web browser view.
 
-Name: URL
-Type: property
+The browser widget can display HTML content generated in LiveCode, or
+fetch content over the Internet.  It supports JavaScript and allows
+for interaction between LiveCode scripts and JavaScript code.
 
-Syntax:
-set the URL of <widget> to <pUrl>
-get the URL of <widget>
-
-Summary: The URL displayed by the browser.
-
-Parameters:
-pUrl(string): A string specifying a URL.
-
-Example:
-	// Navigate to livecode.com by setting the url property, keeping a copy of the
-	//    previous URL
-	local tOldUrl
-	put the URL of widget "myBrowser" into tOldUrl
-	set the URL of widget "myBrowser" to "http://livecode.com"
-
-Description:
-The <URL> is the URL of the content be displayed in the browser.
-
-*Note:* The url property reflects the currently displaying page in the browser, and will change when navigating to another page. Setting the htmlText will result in the url property being empty.
-*Note:* Setting the url property to empty will clear the currently loaded page, resulting in a blank page being displayed and the url and htmlText properties being empty.
-
-Name: htmlText
-Type: property
-
-Syntax:
-set the htmlText of <widget> to <pHtmlText>
-get the htmlText of <widget>
-
-Summary: The HTML text of the content displayed by the browser.
-
-Parameters:
-pHtmlText(string): A string containing HTML data to be displayed by the browser.
-
-Example:
-	// Render a web page in the browser by specifying custom HTML content
-	local tHTML
-	put "<html><head><title>My Page Title</title></head><body>My Page Contents</body></html>" into tHTML
-	set the htmlText of widget "myBrowser" to tHTML
-
-Description:
-The <htmlText> is the HTML representation of the content displayed in the browser.
-
-*Note:* When the htmltext has been set, the url property will be empty. When the url property is not empty, the htmlText will fetch the source of the current url displayed in the browser.
-
-Name: vScrollbar
-Type: property
-
-Syntax:
-set the vScrollbar of <widget> to <pEnabled>
-get the vScrollbar of <widget>
-
-Summary: Controls whether the vertical scrollbar is visible and enabled within the browser.
-
-Parameters:
-pEnabled(boolean): True or false.
-
-Description:
-Controls whether the vertical scrollbar is visible and enabled within the browser.
-
-
-Name: hScrollbar
-Type: property
-
-Syntax:
-set the hScrollbar of <widget> to <pEnabled>
-get the hScrollbar of <widget>
-
-Summary: Controls whether the horizontal scrollbar is visible and enabled within the browser.
-
-Parameters:
-pEnabled(boolean): True or false.
-
-Description:
-Controls whether the horizontal scrollbar is visible and enabled within the browser.
-
-
-Name: userAgent
-Type: property
-
-Syntax:
-set the userAgent of <widget> to <pUserAgent>
-get the userAgent of <widget>
-
-Summary: The identifier sent by the browser when fetching content from remote URLs.
-
-Parameters:
-pUserAgent(string): A string conforming to the http specifications at http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-
-Example:
-	// Set custom User-Agent header. The remote web server may be configured to deliver custom content for browsers using this User-Agent.
-	set the userAgent of widget "myBrowser" to "myAppEmbeddedBrowser"
-	launch url "http://myexampleserver.com/content.html" in widget "myBrowser"
-
-Description:
-The <userAgent> is the identifier sent by the browser when fetching content from remote URLs.
-
-
-Name: javascriptHandlers
-Type: property
-
-Syntax:
-set the javascriptHandlers of <widget> to <pHanderList>
-get the javascriptHandlers of <widget>
-
-Summary: A list of LiveCode handlers that are made available to JavaScript calls within the browser.
-
-Parameters:
-pHandlerList(string): A return-separated list of handler names.
-
-Example:
-	// Define a handler to respond to javascript calls.
-	on myJSHandler pMessage, pValue
-		// Do appropriate actions here.
-		...
-	end myJSHandler
-	
-	...
-	
-	// Set up the browser javascript handler list
-	set the javascriptHandlers to "myJSHandler" & return & "myOtherJSHandler"
-
-	...
-	
-	// Calling the handler from JavaScript within the browser:
-	liveCode.myJSHandler("myMessage", 12345);
-	
-Description:
-The <javascriptHandlers> is a list of LiveCode handlers that are made available to JavaScript calls within the browser. The handlers will appear as methods attached to a global "liveCode" object. You can call these methods as you would any other JavaScript function and pass whatever parameters you require.
-
->*Warning:* Setting the <javascriptHandlers> property gives JavaScript running within the Web browser permission to execute parts of your application through the handlers you choose to expose. If using this feature, make sure that you have complete control over the webpages which you load into the browser widget, and consider using https to ensure that third-parties cannot inject malicious code into them.
-
+The [browser SVG icon](https://www.iconfinder.com/icons/309064/browser_globe_international_internet_web_world_icon)
+is copyright © Ivan Boyko, and is licensed under the terms of the
+[Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
 
 Name: browserDocumentLoadBegin
 Type: message
@@ -170,8 +36,7 @@ Parameters:
 pUrl(string): The URL of the loading document.
 
 Description:
-The browserDocumentLoadBegin message is sent to the widget's script object when a new document begins to load in the browser. This will happen whenever the browser navigates to a new page. The <pUrl> parameter contains the URL of the loading document.
-
+The <browserDocumentLoadBegin> message is sent to the widget's script object when a new document begins to load in the browser. This will happen whenever the browser navigates to a new page. The <pUrl> parameter contains the URL of the loading document.
 
 Name: browserDocumentLoadComplete
 Type: message
@@ -183,7 +48,7 @@ Parameters:
 pUrl(string): The URL of the loaded document.
 
 Description:
-The browserDocumentLoadComplete message is sent to the widget's script object when a new document has completed loading in the browser. The <pUrl> parameter contains the URL of the loaded document.
+The <browserDocumentLoadComplete> message is sent to the widget's script object when a new document has completed loading in the browser. The <pUrl> parameter contains the URL of the loaded document.
 
 
 Name: browserDocumentLoadFailed
@@ -197,7 +62,7 @@ pUrl(string): The URL of the document.
 pError(string): An error message describing the reason for the failure.
 
 Description:
-The browserDocumentLoadFailed message is sent to the widget's script object when a new document has failed to load in the browser. The <pUrl> parameter contains the URL of the document, and the <pError> parameter gives the reason for the failure.
+The <browserDocumentLoadFailed> message is sent to the widget's script object when a new document has failed to load in the browser. The <pUrl> parameter contains the URL of the document, and the <pError> parameter gives the reason for the failure.
 
 
 Name: browserFrameDocumentLoadBegin
@@ -210,7 +75,7 @@ Parameters:
 pUrl(string): The URL of the loading document.
 
 Description:
-The browserFrameDocumentLoadBegin message is sent to the widget's script object when a new document begins to load in a frame of the browser. This will happen whenever the browser navigates to a new page with multiple frames. The <pUrl> parameter contains the URL of the loading document.
+The <browserFrameDocumentLoadBegin> message is sent to the widget's script object when a new document begins to load in a frame of the browser. This will happen whenever the browser navigates to a new page with multiple frames. The <pUrl> parameter contains the URL of the loading document.
 
 
 Name: browserFrameDocumentLoadComplete
@@ -223,7 +88,7 @@ Parameters:
 pUrl(string): The URL of the loaded document.
 
 Description:
-The browserFrameDocumentLoadComplete message is sent to the widget's script object when a new document has completed loading in a frame of the browser. The <pUrl> parameter contains the URL of the loaded document.
+The <browserFrameDocumentLoadComplete> message is sent to the widget's script object when a new document has completed loading in a frame of the browser. The <pUrl> parameter contains the URL of the loaded document.
 
 
 Name: browserFrameDocumentLoadFailed
@@ -237,7 +102,7 @@ pUrl(string): The URL of the document.
 pError(string): An error message describing the reason for the failure.
 
 Description:
-The browserFrameDocumentLoadFailed message is sent to the widget's script object when a new document has failed to load in a frame of the browser. The <pUrl> parameter contains the URL of the document, and the <pError> parameter gives the reason for the failure.
+The <browserFrameDocumentLoadFailed> message is sent to the widget's script object when a new document has failed to load in a frame of the browser. The <pUrl> parameter contains the URL of the document, and the <pError> parameter gives the reason for the failure.
 
 
 Name: browserNavigateBegin
@@ -250,7 +115,7 @@ Parameters:
 pUrl(string): The URL of the new page.
 
 Description:
-The browserNavigateBegin message is sent to the widget's script object when the browser begins navigation to a new page. This can be triggered by launching a url in the browser, or clicking a link within the browser. The <pUrl> parameter contains the URL of the new page.
+The <browserNavigateBegin> message is sent to the widget's script object when the browser begins navigation to a new page. This can be triggered by launching a URL in the browser, or clicking a link within the browser. The <pUrl> parameter contains the URL of the new page.
 
 
 Name: browserNavigateComplete
@@ -263,7 +128,7 @@ Parameters:
 pUrl(string): The URL of the new page.
 
 Description:
-The browserNavigateComplete message is sent to the widget's script object when the browser successfully navigates to a new page. The <pUrl> parameter contains the URL of the new page.
+The <browserNavigateComplete> message is sent to the widget's script object when the browser successfully navigates to a new page. The <pUrl> parameter contains the URL of the new page.
 
 
 Name: browserNavigateFailed
@@ -277,7 +142,7 @@ pUrl(string): The URL of the document.
 pError(string): An error message describing the reason for the failure.
 
 Description:
-The browserNavigateFailed message is sent to the widget's script object when the browser has failed to navigate to a new page. The <pUrl> parameter contains the URL of the new page, and the <pError> parameter gives the reason for the failure.
+The <browserNavigateFailed> message is sent to the widget's script object when the browser has failed to navigate to a new page. The <pUrl> parameter contains the URL of the new page, and the <pError> parameter gives the reason for the failure.
 
 
 Name: browserUnhandledLoadRequest
@@ -290,7 +155,7 @@ Parameters:
 pUrl(string): The URL of the request.
 
 Description:
-The browserUnhandledLoadRequest message is sent to the widget's script object when the browser is unable to load a URL, typically due to an unrecognised URL scheme. The <pUrl> parameter contains the URL of the unhandled request.
+The <browserUnhandledLoadRequest> message is sent to the widget's script object when the browser is unable to load a URL, typically due to an unrecognised URL scheme. The <pUrl> parameter contains the URL of the unhandled request.
 */
 
 -- declaring extension as widget, followed by identifier
@@ -314,24 +179,186 @@ metadata svgicon is "M21.7,12c0,5.4-4.4,9.7-9.7,9.7S2.3,17.4,2.3,12S6.6,2.3,12,2
 --
 
 -- property declarations
+/**
+Name: URL
+Type: property
+
+Syntax:
+set the URL of <widget> to <pUrl>
+get the URL of <widget>
+
+Summary: The URL displayed by the browser.
+
+Parameters:
+pUrl(string): A string specifying a URL.
+
+Example:
+	-- Navigate to livecode.com by setting the url property,
+	-- keeping a copy of the previous URL
+	local tOldUrl
+	put the URL of widget "myBrowser" into tOldUrl
+	set the URL of widget "myBrowser" to "https://livecode.com"
+
+Description:
+The <URL> is the URL of the content be displayed in the browser.
+
+>*Note:* The <URL> must be a standards-compliant URL.  In particular, `file:` URLs must be of the form `file://<absolute path>`, and the path should be URL-encoded.  See [RFC 1738, section 2.2](https://tools.ietf.org/html/rfc1738#section-2.2).
+
+>*Note:* The <URL> reflects the currently displaying page in the browser, and will change when navigating to another page. Setting the htmlText will result in the <URL> being empty.
+
+>*Note:* Setting the <URL> to empty will clear the currently loaded page, resulting in a blank page being displayed and the <URL> and <htmlText> of the widget being empty.
+
+References: htmlText (property)
+*/
 property URL get getUrl set setUrl
 
+
+/**
+Name: htmlText
+Type: property
+
+Syntax:
+set the htmlText of <widget> to <pHtmlText>
+get the htmlText of <widget>
+
+Summary: The HTML text of the content displayed by the browser.
+
+Parameters:
+pHtmlText(string): A string containing HTML data to be displayed by the browser.
+
+Example:
+
+	-- Render a web page in the browser by specifying custom HTML
+	-- content
+	local tHTML
+	put "<html><head><title>My Page Title</title></head>" & \
+	      "<body>My Page Contents</body></html>" into tHTML
+	set the htmlText of widget "myBrowser" to tHTML
+
+Description:
+The <htmlText> is the HTML representation of the content displayed in the browser.
+
+*Note:* When the <htmlText> has been set, the <URL> property will be
+empty. When the <URL> property is not empty, the <htmlText> will
+contain the source of the current URL displayed in the browser.
+
+References: URL (property)
+*/
 property htmlText get getHtmlText set setHtmlText
 metadata htmlText.editor is "com.livecode.pi.nowraptext"
 metadata htmlText.user_visible is "false" -- bug 16927
+metadata htmlText.label is "HTML text"
 
+/**
+Name: vScrollbar
+Type: property
+
+Syntax:
+set the vScrollbar of <widget> to <pEnabled>
+get the vScrollbar of <widget>
+
+Summary: Controls the visibility of the browser's vertical scrollbar.
+
+Value (boolean): `true` if the vertical scrollbar should be enabled and displayed; `false` otherwise.
+
+References: hScrollbar (property)
+*/
 property vScrollbar get getVScrollbar set setVScrollbar
 metadata vScrollbar.editor is "com.livecode.pi.boolean"
 metadata vScrollbar.default is "false"
+metadata vScrollbar.label is "Vertical scrollbar"
 
+/**
+Name: hScrollbar
+Type: property
+
+Syntax:
+set the hScrollbar of <widget> to <pEnabled>
+get the hScrollbar of <widget>
+
+Summary: Controls the visibility of the browser's horizontal scrollbar.
+
+Value (boolean): `true` if the horizontal scrollbar should be enabled and displayed; `false` otherwise.
+
+References: vScrollbar (property)
+*/
 property hScrollbar get getHScrollbar set setHScrollbar
 metadata hScrollbar.editor is "com.livecode.pi.boolean"
 metadata hScrollbar.default is "false"
+metadata hScrollbar.label is "Horizontal scrollbar"
 
+/**
+Name: userAgent
+Type: property
+
+Syntax:
+set the userAgent of <widget> to <pUserAgent>
+get the userAgent of <widget>
+
+Summary: The identifier sent by the browser when fetching content from remote URLs.
+
+Value (string): A suitable HTTP user agent string.
+
+Example:
+
+	-- Set a custom User-Agent header. The remote web server may
+	-- be configured to deliver custom content for browsers using
+	-- this User-Agent.
+	set the userAgent of widget "myBrowser" to "myAppEmbeddedBrowser"
+	launch url "https://myexampleserver.com/content.html" in widget "myBrowser"
+
+Description:
+The <userAgent> is the identifier sent by the browser when fetching
+content from remote HTTP servers.
+
+The <userAgent> must conform to the requirements for the `User-Agent`
+header described in the HTTP specification.  See [RFC 2616, section
+14.43](https://tools.ietf.org/html/rfc2616#section-14.43).
+*/
 property userAgent get getUserAgent set setUserAgent
 metadata userAgent.editor is "com.livecode.pi.text"
 metadata userAgent.label is "User agent"
 
+/**
+Name: javascriptHandlers
+Type: property
+
+Syntax:
+set the javascriptHandlers of <widget> to <pHanderList>
+get the javascriptHandlers of <widget>
+
+Summary: A list of LiveCode handlers that are made available to JavaScript calls within the browser.
+
+Value (string): A return-separated list of handler names.
+
+Example:
+	-- Define a handler to respond to javascript calls.
+	on myJSHandler pMessage, pValue
+		-- Do appropriate actions here.
+		-- ...
+	end myJSHandler
+	
+	-- Set up the browser javascript handler list
+	-- This code goes in a suitable setup handler
+	set the javascriptHandlers to "myJSHandler" & return & "myOtherJSHandler"
+	
+	// Calling the handler from JavaScript within the browser
+	liveCode.myJSHandler("myMessage", 12345);
+
+Description:
+The <javascriptHandlers> is a list of LiveCode handlers that are made
+available to JavaScript calls within the browser. The handlers will
+appear as methods attached to a global `liveCode` object. You can call
+these methods as you would any other JavaScript function and pass
+whatever parameters you require.
+
+>*Warning:* Setting the <javascriptHandlers> property gives JavaScript
+running within the Web browser permission to execute parts of your
+application through the handlers you choose to expose. If using this
+feature, make sure that you have complete control over the webpages
+which you load into the browser widget, and consider using HTTPS to
+ensure that third-parties cannot inject malicious code into them.
+*/
 property javascriptHandlers get getJavaScriptHandlers set setJavaScriptHandlers
 metadata javascriptHandlers.editor is "com.livecode.pi.text"
 metadata javascriptHandlers.label is "JavaScript handlers"

--- a/extensions/widgets/browser/notes/17194.md
+++ b/extensions/widgets/browser/notes/17194.md
@@ -1,0 +1,1 @@
+# [17194] Improved documentation related to "file:" URLs.


### PR DESCRIPTION
- Clarify the usage of `file:` scheme URLs/URIs somewhat
- Improve references to IETF RFC documents
