### PR TITLE
Fix the permissions on generated DMGs

### DIFF
--- a/builder/generate-dmg.sh
+++ b/builder/generate-dmg.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -x
+
+# If this script is not run as root, the DMG will have incorrect ownership
+if [ $EUID -ne 0 ] ; then
+	echo >&2 "WARNING: not building DMG as root; app will have incorrect ownership"
+fi
+
+# Arguments are the name of the volume to create, the input folder and the output filename
+if [ $# -ne 3 ] ; then
+	echo >&2 "ERROR: usage: ./generate-dmg.sh volname srcfolder output"
+fi
+
+volname="$1"
+srcfolder="$2"
+output="$3"
+
+# Make the DMG
+# UID and GID 99 are magical - they are needed to ensure ownership is correct
+# when the app bundle is copied out of the DMG. They are also the reason that
+# this script needs to be run with root permissions.
+#
+if [ $EUID -eq 0 ] ; then
+  ids="-uid 99 -gid 99"
+fi
+
+hdiutil create -fs HFS+ -format UDRW -scrub ${ids} -attach -volname "${volname}" -srcfolder "${srcfolder}" "${output}"
+
+# Exit on failure
+result=$?
+if [ $result -ne 0 ] ; then exit $result ; fi
+
+# Ensure the ownership of the output image is correct
+user=$(who am i | awk '{print $1}')
+group=$(id -g -n "${user}")
+chown ${user}:${group} "${output}"

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -599,8 +599,31 @@ command toolsBuilderMakeDisk pVersion, pEdition, pPlatform
    get shell ("hdiutil detach" && escapeArg(tVolumeName))
    
    -- Generate an initial read-write DMG and mount it
+   -- This needs to be run with root privileges to get the ownership correct
+   -- If the $GENERATE_DMG_SCRIPT env var is set, the script identified by
+   -- that path will be used instead of the one stored in the repo
    builderLog "message", "Generating initial DMG"
-   get shell ("hdiutil create -fs HFS+ -format UDRW -attach -volname" && escapeArg(tVolumeName) && "-srcfolder" && escapeArg(tDmgFolder) && escapeArg(tTempDmg))
+   local tGenerateScript
+   if $GENERATE_DMG_SCRIPT is not empty then
+      -- Check that the generate script is identical to the in-repo copy
+      -- so it is kept up-to-date
+      local tLocalScript
+      local tRepoScript
+      get shell("which" && escapeArg($GENERATE_DMG_SCRIPT))
+      put url("file:" & line 1 of it) into tLocalScript
+      put url("file:" & builderSystemFolder() & "/generate-dmg.sh") into tRepoScript
+      if tLocalScript is not tRepoScript then
+         builderLog "error", "Local DMG generation script differs from the repo copy (please update)"
+         throw "failure"
+      end if
+      
+      put $GENERATE_DMG_SCRIPT into tGenerateScript
+   else if $GENERATE_DMG_SUDO is not empty and $GENERATE_DMG_SUDO is not 0 then
+      put "sudo -n" && escapeArg(builderSystemFolder() & "/generate-dmg.sh") into tGenerateScript
+   else
+      put escapeArg(builderSystemFolder() & "/generate-dmg.sh") into tGenerateScript
+   end if
+   get shell (tGenerateScript && escapeArg(tVolumeName) && escapeArg(tDmgFolder) && escapeArg(tTempDmg))
    if "created:" is not in it then
       builderLog "error", "Failed to create initial DMG:" && it
       throw "failure"

--- a/docs/notes/bugfix-17195.md
+++ b/docs/notes/bugfix-17195.md
@@ -1,0 +1,2 @@
+# Fix permissions on apps dragged from LiveCode DMG
+


### PR DESCRIPTION
Unfortunately, hdiutil needs root permissions to generate the
correct permissions within DMGs. This commit adds a hooks for
running under sudo or some other mechanism for gaining the
appropriate permissions.
