### PR TITLE
Unblock input events to native layers in run mode on Linux

### DIFF
--- a/docs/notes/bugfix-17255.md
+++ b/docs/notes/bugfix-17255.md
@@ -1,0 +1,1 @@
+# Unblock keyboard and mouse interaction with the browser widget on Linux

--- a/engine/src/native-layer-x11.cpp
+++ b/engine/src/native-layer-x11.cpp
@@ -88,7 +88,7 @@ void MCNativeLayerX11::OnToolChanged(Tool p_new_tool)
 
 void MCNativeLayerX11::updateInputShape()
 {
-    if (m_show_for_tool)
+    if (!m_show_for_tool)
         // In edit mode. Mask out all input events
         gdk_window_input_shape_combine_region(gtk_widget_get_window(GTK_WIDGET(m_child_window)), m_input_shape, 0, 0);
     else


### PR DESCRIPTION
The check for run-vs-edit mode was inverted so events were blocked in run mode and permitted in edit mode.
