### PR TITLE
[Bug 17239] json: Add tests for number formatting/parsing

### DIFF
--- a/extensions/libraries/json/tests/numbers.livecodescript
+++ b/extensions/libraries/json/tests/numbers.livecodescript
@@ -1,0 +1,30 @@
+script "JSONLibraryNumbers"
+
+on TestSetup
+	TestLoadExtension "com.livecode.library.json"
+end TestSetup
+
+-- Bug 17239
+on TestExportInteger
+	local tArray, tExpected
+	put (14592610+0) into tArray[1]
+	put "{" & quote & "1" & quote & ": 14592610}" into tExpected
+
+	local tJson
+	put JsonExport(tArray) into tJson
+	TestDiagnostic tJson
+	TestDiagnostic tExpected
+	TestAssertBroken "export large integer losslessly", tExpected is tArray, \
+			"bug 17239"
+end TestExportInteger
+
+-- Bug 17239
+on TestImportScientific
+	local tJson, tExpected
+	put "[ 1.459260e+09 ]" into tJson
+	put 1.459260e+09 into tExpected[1]
+
+	local tArray
+	put JsonImport(tJson) into tArray
+	TestAssert "import number in scientific notation", tExpected is tArray
+end TestImportScientific

--- a/extensions/libraries/json/tests/numbers.livecodescript
+++ b/extensions/libraries/json/tests/numbers.livecodescript
@@ -12,9 +12,7 @@ on TestExportInteger
 
 	local tJson
 	put JsonExport(tArray) into tJson
-	TestDiagnostic tJson
-	TestDiagnostic tExpected
-	TestAssertBroken "export large integer losslessly", tExpected is tArray, \
+	TestAssertBroken "export large integer losslessly", tExpected is tJson, \
 			"bug 17239"
 end TestExportInteger
 


### PR DESCRIPTION
- Add failing test for lossless encoding of integers
- Add passing test for parsing of numbers in scientific format
