### PR TITLE
[ BUG 17245 ] Fix matchChunk err with optional captured group

### DIFF
--- a/docs/notes/bugfix-17245.md
+++ b/docs/notes/bugfix-17245.md
@@ -1,0 +1,1 @@
+# Fix matchChunk error with optional captured group

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -862,15 +862,16 @@ void MCStringsEvalMatchChunk(MCExecContext& ctxt, MCStringRef p_string, MCString
             t_success = MCStringFormat(r_results[i], "%d", t_compiled->matchinfo[t_match_index].rm_so + 1);
             if (t_success)
                 t_success = MCStringFormat(r_results[i + 1], "%d", t_compiled->matchinfo[t_match_index].rm_eo);
-            
-            if (++t_match_index >= NSUBEXP)
-                t_match_index = 0;
         }
         else
         {
             r_results[i] = MCValueRetain(kMCEmptyString);
             r_results[i + 1] = MCValueRetain(kMCEmptyString);
         }
+        // matchChunk did set empty values of positionVarsList with regex "(a)?(B)" applied on "B"
+        // if an optional capture group didn't match (which is valid), index wasn't updated.
+        if (++t_match_index >= NSUBEXP)
+            t_match_index = 0;
     }
     
     if (t_success)

--- a/tests/lcs/core/strings/regexoptionalcapturedgroup.livecodescript
+++ b/tests/lcs/core/strings/regexoptionalcapturedgroup.livecodescript
@@ -1,0 +1,45 @@
+﻿script "CoreStringsRegexOptCapturedGroup"
+
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+on TestRegexWithOptionalCapturedGroup
+	local aRegex, aText
+	local p0, p1, p2, p3
+	local v1, v2
+	
+	-- see Bug 17245
+	-- check that second group is not empty when 1st is.
+	
+	put "(a)?(B)" into aRegex
+	put "B" into aText
+	
+	TestAssert "matchChunk should match", matchChunk( aText, aRegex, p0,p1,p2,p3) is true
+	
+	TestAssert "... and get empty for p0 and p1", ( p0 & p1 ) is empty
+	
+	TestAssert "... and get 1 for p2 and p3", ( p2 is 1) and (p3 is 1)
+	
+	TestAssert "matchText should match", matchText( aText, aRegex, v0, v1) is true
+	
+	TestAssert "... and get empty for v0", v0 is empty
+	
+	TestAssert "... and get B for v1", v1 is "B"
+	
+	
+end TestRegexWithOptionalCapturedGroup


### PR DESCRIPTION
I'm updating the QCC with a sample stack...
