### PR TITLE
Sanitise $FRAMEWORK_SEARCH_PATHS

### DIFF
--- a/lcidlc/lclink.sh
+++ b/lcidlc/lclink.sh
@@ -52,8 +52,8 @@ if [ -f "$LIVECODE_DEP_FILE" ]; then
 
 fi
 
-# Workaround trailing whitespace issue
-FRAMEWORK_SEARCH_PATHS="$(echo -e "${FRAMEWORK_SEARCH_PATHS}" | sed -e 's/[[:space:]]*$//')"
+# Workaround trailing whitespace and multiple spaces issues
+FRAMEWORK_SEARCH_PATHS="$(echo -e "${FRAMEWORK_SEARCH_PATHS}" | sed -e 's/[[:space:]]*$//' | sed -e 's/  */ /')"
 
 FRAMEWORK_SEARCH_PATHS="-F${FRAMEWORK_SEARCH_PATHS// / -F}"
 

--- a/lcidlc/lclink.sh
+++ b/lcidlc/lclink.sh
@@ -53,7 +53,7 @@ if [ -f "$LIVECODE_DEP_FILE" ]; then
 fi
 
 # Workaround trailing whitespace and multiple spaces issues
-FRAMEWORK_SEARCH_PATHS="$(echo -e "${FRAMEWORK_SEARCH_PATHS}" | sed -e 's/[[:space:]]*$//' | sed -e 's/  */ /')"
+FRAMEWORK_SEARCH_PATHS=$(echo ${FRAMEWORK_SEARCH_PATHS} | xargs)
 
 FRAMEWORK_SEARCH_PATHS="-F${FRAMEWORK_SEARCH_PATHS// / -F}"
 


### PR DESCRIPTION
While Xcode 7.2 decided to add trailing space to
$FRAMEWORK_SEARCH_PATHS Xcode 7.3 decided to put
two spaces between the paths.
