### PR TITLE
[Bug 17190] Add test for PCRE recursion-based stack overflow

### DIFF
--- a/docs/notes/bugfix-17190.md
+++ b/docs/notes/bugfix-17190.md
@@ -1,0 +1,1 @@
+# Prevent stack overflows with matchText()

--- a/tests/lcs/core/strings/matchtext.livecodescript
+++ b/tests/lcs/core/strings/matchtext.livecodescript
@@ -1,0 +1,23 @@
+﻿script "CoreStringsMatchText"
+
+-- Bug 16: Ensure that very deeply recursive regular expressions do
+-- not cause a stack overflow in libpcre
+constant kRecursionExpr = "x(?R)?"
+constant kRecursionLength = 16384
+
+on TestMatchTextRecursion
+
+   -- Build a suitably long string
+   local tTarget
+   put "x" into tTarget
+   repeat
+      if length(tTarget) >= kRecursionLength then
+         delete char (1+kRecursionLength) to -1 of tTarget
+         exit repeat
+      end if
+      put tTarget after tTarget
+   end repeat
+
+   get matchText(tTarget, kRecursionExpr)
+
+end TestMatchTextRecursion


### PR DESCRIPTION
Add a suitably simple-yet-abusive `matchText()` recursion test that
causes a stack overflow, in the hope that it'll prevent bug 17190 (and
indeed bug 16) from regressing again next time we update PCRE.
