### PR TITLE
[[ Bug 17071 ]] Delete recent card and card stack lists after draining obj pool

### DIFF
--- a/docs/notes/bugfix-17071.md
+++ b/docs/notes/bugfix-17071.md
@@ -1,0 +1,1 @@
+# Prevent crash on exit related to recent cards and card stack

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1338,10 +1338,13 @@ int X_close(void)
 	delete MCselected;
     delete MCtodestroy;
 	delete MCstacks;
-	delete MCcstack;
-	delete MCrecent;
     
     MCDeletedObjectsTeardown();
+    
+    // These card lists must be deleted *after* draining the deleted
+    // objects pool, as they are used in stack destructors
+    delete MCcstack;
+    delete MCrecent;
     
 	// Temporary workaround for a crash
     //MCS_close(IO_stdin);


### PR DESCRIPTION
These lists are used in the MCStack destructor.
