### PR TITLE
Fix OSX codesigning on El Capitan 10.11.4

### DIFF
--- a/Installer/osx-installer-stub.gyp
+++ b/Installer/osx-installer-stub.gyp
@@ -1,0 +1,30 @@
+{
+	'includes':
+	[
+		'../common.gypi',
+	],
+
+	'targets':
+	[
+		{
+			'target_name': 'osx-installer-stub',
+			'product_name': 'installer-stub',
+			'type': 'executable',
+			'mac_bundle': '0',
+			
+			'sources':
+			[
+				'osx-installer-stub.mm',
+			],
+
+			'all_dependent_settings':
+			{
+				'variables':
+				{
+					'dist_files': [ '<(PRODUCT_DIR)/<(_product_name)>(exe_suffix)' ],
+				},
+			},
+		},
+	],
+}
+

--- a/Installer/osx-installer-stub.mm
+++ b/Installer/osx-installer-stub.mm
@@ -1,0 +1,79 @@
+/* Copyright (C) 2016 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+
+#import <Foundation/Foundation.h>
+
+
+// This file is a simple stub executable for launching the AppleScript that
+// opens a Finder window showing the contents of the DMG. It is used by the
+// auto-updater to display the contents of the DMG so the user can copy the new
+// app bundle to their Applications folder.
+//
+// Previously, we used a shell script to do the launching. However, as of OSX
+// 10.11.4, the `codesign` tool generates signatures that cannot be verified on
+// earlier versions of OSX when asked to sign a non-MachO executable as code.
+//
+// Therefore, we use this executable in place of the shell script so that the
+// object being signed is one that doesn't cause problems.
+
+
+int main(int argc, char* argv[])
+{
+    // Get the main bundle for the application
+    NSBundle* mainBundle = [NSBundle mainBundle];
+    
+    // Path to the subdirectory containing the bundle's resources
+    NSString* resourcePath = [mainBundle resourcePath];
+    
+    // Append the path to the AppleScript that opens a Finder window
+    NSString* scriptPath = [resourcePath stringByAppendingPathComponent:@"Installer/ShowDmgWindow.scpt"];
+    
+    // Turn the path into a URL and load it into an AppleScript object
+    NSURL* scriptURL = [[NSURL alloc] initFileURLWithPath:scriptPath];
+    NSAppleScript* appleScript = [[NSAppleScript alloc] initWithContentsOfURL:scriptURL error:nil];
+    
+    // Generate the "run" AppleEvent to send to the script. It needs to be given
+    // an array containing 1 item which is the POSIX path to the DMG folder.
+    NSString* dmgPath = [[mainBundle bundlePath] stringByDeletingLastPathComponent];
+    NSAppleEventDescriptor* pathDescriptor = [NSAppleEventDescriptor descriptorWithString:dmgPath];
+    NSAppleEventDescriptor* argvList = [NSAppleEventDescriptor listDescriptor];
+    NSAppleEventDescriptor* appleEvent = [NSAppleEventDescriptor appleEventWithEventClass:kCoreEventClass
+                                                                                  eventID:kAEOpenApplication
+                                                                         targetDescriptor:nil
+                                                                                 returnID:kAutoGenerateReturnID
+                                                                            transactionID:kAnyTransactionID ];
+    [argvList insertDescriptor:pathDescriptor atIndex:1];
+    [appleEvent setParamDescriptor:argvList forKeyword:keyDirectObject];
+    
+    // Execute the script
+    [appleScript executeAppleEvent:appleEvent error:nil];
+    
+    // Cleanup
+    [appleEvent release];
+    [argvList release];
+    [pathDescriptor release];
+    [dmgPath release];
+    [appleScript release];
+    [scriptURL release];
+    [scriptPath release];
+    [resourcePath release];
+    [mainBundle release];
+    
+    // All done
+    return 0;
+}

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -530,6 +530,10 @@ command toolsBuilderMakeAppBundle pVersion, pEdition, pPlatform
       throw "failure"
    end if
    
+   -- Remove a problematic (but un-neccessary) file from the CEF framework bundle
+   -- Doing it here is ugly, but is temporary (only needed in 6.7 and 7.1).
+   get shell ("rm -f" && escapeArg(tAppBundle & "/Contents/Frameworks/Chromium Embedded Framework.framework/Manifest"))
+
    -- Find the signing identity and sign the app bundle
    get findSigningIdentity()
    if it is not empty then

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -510,13 +510,21 @@ command toolsBuilderMakeAppBundle pVersion, pEdition, pPlatform
    
    -- Copy a shell script and AppleScript into the app bundle to catch attempts 
    -- from old auto-updaters to launch the installer
+   local tEngineFolder
+   builderFetchEngine empty, "macosx"
+   put the result into tEngineFolder
    builderLog "message", "Adding installer shim to app bundle"
-   get shell ("install -m755" && escapeArg(builderCommunityResourceFolder() & "/dmg/fake-installer.sh") && escapeArg(tAppBundle & "/Contents/MacOS/installer"))
+   get shell ("install -m755" && escapeArg(tEngineFolder & "/installer-stub") && escapeArg(tAppBundle & "/Contents/MacOS/installer"))
    if the result is not zero then
       builderLog "error", "Failed to copy installer stub shell script:" && it
       throw "failure"
    end if
-   get shell ("osacompile" && "-o" && escapeArg(tAppBundle & "/Contents/MacOS/installer.scpt") && escapeArg(builderCommunityResourceFolder() & "/dmg/open-dmg.applescript"))
+   get shell ("mkdir -p" && escapeArg(tAppBundle & "/Contents/Resources/Installer"))
+   if the result is not zero then
+      builderLog "error", "Failed to create installer resources directory:" && it
+      throw "failure"
+   end if
+   get shell ("osacompile" && "-o" && escapeArg(tAppBundle & "/Contents/Resources/Installer/ShowDmgWindow.scpt") && escapeArg(builderCommunityResourceFolder() & "/dmg/open-dmg.applescript"))
    if the result is not zero then
       builderLog "error", "Failed to compile installer stub AppleScript:" && it
       throw "failure"

--- a/livecode.gyp
+++ b/livecode.gyp
@@ -54,6 +54,15 @@
 					},
 				],
 				[
+					'OS == "mac"',
+					{
+						'dependencies':
+						[
+							'Installer/osx-installer-stub.gyp:osx-installer-stub',
+						],
+					},
+				],
+				[
 					'OS == "mac" or OS == "win"',
 					{
 						'dependencies':


### PR DESCRIPTION
Apple changed the codesigning process for non-MachO executables on 10.11.4. The signatures that it generates cannot be verified by earlier versions of OSX so are reported as invalid and the affected app bundle is blocked from running.

This PR changes the installer stub from a simple text script to a compiled executable in order to avoid having non-binary files in the code directory. A similar (but un-needed) file gets removed from the CEF framework directory when building the app bundle as well.
