### PR TITLE
[[ Bug 17088 ]] Make handling of very long cwd more robust on Mac

### DIFF
--- a/docs/notes/bugfix-17088.md
+++ b/docs/notes/bugfix-17088.md
@@ -1,0 +1,2 @@
+# Correct processing of very long file paths on Mac.
+


### PR DESCRIPTION
It is possible for the current working directory to exceed PATH_MAX
chars on Mac.

This patch ensures that a crash won't occur in this case by using
getcwd(NULL, 0) to force a buffer to be created by the system for
the path.

Additionally it makes sure that in the case the current folder cannot
be fetched, that calling functions don't crash.
