### PR TITLE
[Bug 17147] Make docs builder cope with LCB line continuation chars

### DIFF
--- a/docs/notes/bugfix-17147.md
+++ b/docs/notes/bugfix-17147.md
@@ -1,0 +1,1 @@
+# Generate correct docs for LCB syntax with continuation lines

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -1540,6 +1540,10 @@ command revDocsUpdateModularSyntaxDocBlocks pData, pComment, pHandlersA, pPhrase
    end if
    
    put line tCurrentLine of pData into tSyntaxLine
+   repeat while tSyntaxLine ends with "\"
+      add 1 to tCurrentLine
+      put line tCurrentLine of pData into char -1 of tSyntaxLine
+   end repeat
    add 1 to tCurrentLine
    
    repeat with x = tCurrentLine to the number of lines in pData


### PR DESCRIPTION
Ensure that the docs builder parses LCB syntax definitions spread over
multiple lines correctly.
