### PR TITLE
Ensure the generate-dmg.sh script runs with root privs

### DIFF
--- a/builder/generate-dmg.sh
+++ b/builder/generate-dmg.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
+set -e
 set -x
 
 # If this script is not run as root, the DMG will have incorrect ownership
 if [ $EUID -ne 0 ] ; then
+	# If this is being invoked with the intention of being privileged,
+	# this failure is a hard error.
+	if [ "${GENERATE_DMG_SCRIPT}" != "" ] ; then
+		echo >&2 "ERROR: this script must be run as root"
+		exit -1
+	fi	
 	echo >&2 "WARNING: not building DMG as root; app will have incorrect ownership"
 fi
 
 # Arguments are the name of the volume to create, the input folder and the output filename
 if [ $# -ne 3 ] ; then
 	echo >&2 "ERROR: usage: ./generate-dmg.sh volname srcfolder output"
+	exit -2
 fi
 
 volname="$1"

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -629,7 +629,7 @@ command toolsBuilderMakeDisk pVersion, pEdition, pPlatform
          throw "failure"
       end if
       
-      put $GENERATE_DMG_SCRIPT into tGenerateScript
+      put "sudo -n" && $GENERATE_DMG_SCRIPT into tGenerateScript
    else if $GENERATE_DMG_SUDO is not empty and $GENERATE_DMG_SUDO is not 0 then
       put "sudo -n" && escapeArg(builderSystemFolder() & "/generate-dmg.sh") into tGenerateScript
    else


### PR DESCRIPTION
Sudo needs to be used as OSX doesn't permit shell scripts to be setuid.
