### PR TITLE
[[ Bug 17216 ]] Reinstate TIFF processing in Mac clipboard

### DIFF
--- a/docs/notes/bugfix-17216.md
+++ b/docs/notes/bugfix-17216.md
@@ -1,0 +1,1 @@
+# Allow pasting images from some applications on Mac

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -657,7 +657,7 @@ bool MCClipboard::HasPNG() const
     if (t_item == NULL)
         return false;
 	
-#ifdef __MAC__
+#if defined(__MAC__) && !defined(MODE_SERVER)
 	// Many Mac apps (like Preview) present things as TIFF on the clipboard. Since
 	// the engine doesn't currently understand TIFF generally we make TIFF data
 	// masquerade as PNG.
@@ -943,7 +943,7 @@ bool MCClipboard::CopyAsPNG(MCDataRef& r_png) const
     if (CopyAsData(kMCRawClipboardKnownTypePNG, r_png))
 		return true;
 	
-#ifdef __MAC__
+#if defined(__MAC__) && !defined(MODE_SERVER)
 	MCAutoDataRef t_tiff_data;
 	if (!CopyAsData(kMCRawClipboardKnownTypeTIFF, &t_tiff_data))
 		return false;

--- a/engine/src/lnx-clipboard.cpp
+++ b/engine/src/lnx-clipboard.cpp
@@ -47,6 +47,7 @@ const char * const MCLinuxRawClipboard::s_formats[kMCRawClipboardKnownTypeLast+1
     "image/png",                    // PNG image
     "image/gif",                    // GIF image
     "image/jpeg",                   // JPEG image
+	"image/tiff",					// TIFF image
     NULL,                           // Windows metafile
     NULL,                           // Windows enhanced metafile
     NULL,                           // Windows bitmap

--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -36,6 +36,7 @@ const char* const MCMacRawClipboard::s_clipboard_types[] =
     "public.png",
     "com.compuserve.gif",
     "public.jpeg",
+	"public.tiff",
     NULL,
     NULL,
     NULL,                   // "com.microsoft.bmp" but the Mac engine doesn't support this format

--- a/engine/src/raw-clipboard.h
+++ b/engine/src/raw-clipboard.h
@@ -48,6 +48,7 @@ enum MCRawClipboardKnownType
     kMCRawClipboardKnownTypePNG,        // PNG image
     kMCRawClipboardKnownTypeGIF,        // GIF image
     kMCRawClipboardKnownTypeJPEG,       // JPEG image
+	kMCRawClipboardKnownTypeTIFF,		// TIFF image
     kMCRawClipboardKnownTypeWinMF,      // Windows Metafile image
     kMCRawClipboardKnownTypeWinEMF,     // Windows Enhanced Metafile image
     kMCRawClipboardKnownTypeWinDIB,     // Windows BMP image

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -36,6 +36,7 @@ MCWin32RawClipboardCommon::format_mapping MCWin32RawClipboardCommon::s_formats[]
 	{ 0, "PNG" },										// PNG image
 	{ 0, "GIF" },										// GIF image
 	{ 0, "JFIF" },										// JPEG image
+	{ 6, "CF_TIFF" },									// TIFF image
 	{ CF_METAFILEPICT, "CF_METAFILEPICT" },				// Windows Metafile image
 	{ CF_ENHMETAFILE, "CF_ENHMETAFILE" },				// Windows Enhanced Metafile image
 	{ CF_DIB, "CF_DIB" },								// Windows bitmap image
@@ -66,7 +67,6 @@ MCWin32RawClipboardCommon::format_mapping MCWin32RawClipboardCommon::s_formats[]
 	{ 10, "CF_PENDATA" },								// Windows 3.1 (!) pen input data
 	{ 11, "CF_RIFF" },									// RIFF-encoded audio
 	{ 4, "CF_SYLK" },									// Microsoft Symbolic Link format
-	{ 6, "CF_TIFF" },									// TIFF image
 	{ 12, "CF_WAVE" },									// PCM audio
 };
 


### PR DESCRIPTION
Some applications on Mac only present TIFF as the image format on
the clipboard (Preview included).

As the engine (as a whole) does not understand TIFF data, this
patch makes TIFF data on the clipboard masquerade as PNG data
allowing it to be used in a loss-less way (relative to the original
TIFF encoding).

The TIFF data will still be listed in the rawClipboardData, but
in the fullClipboardData it will come through as image and png.
