### PR TITLE
Fix an incorrect check in generate-dmg.sh

### DIFF
--- a/builder/generate-dmg.sh
+++ b/builder/generate-dmg.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 set -x
 
 # If this script is not run as root, the DMG will have incorrect ownership
@@ -34,10 +33,6 @@ if [ $EUID -eq 0 ] ; then
 fi
 
 hdiutil create -fs HFS+ -format UDRW -scrub ${ids} -attach -volname "${volname}" -srcfolder "${srcfolder}" "${output}"
-
-# Exit on failure
-result=$?
-if [ $result -ne 0 ] ; then exit $result ; fi
 
 # Ensure the ownership of the output image is correct
 user=$(who am i | awk '{print $1}')


### PR DESCRIPTION
The return codes from hdiutil cannot be trusted. Zero doesn't indicate success and non-zero doesn't indicate failure.
