### PR TITLE
[[ Bug 17150 ]] Ensure setcallbacksref is exported.

### DIFF
--- a/docs/notes/bugfix-17150.md
+++ b/docs/notes/bugfix-17150.md
@@ -1,0 +1,1 @@
+# Fix issue with MySQL loading SSL libraries on iOS

--- a/revdb/revdb.gyp
+++ b/revdb/revdb.gyp
@@ -108,6 +108,7 @@
 					'_setidcounterref',
 					'_newdbconnectionref',
 					'_releasedbconnectionref',
+					'_setcallbacksref',
 				],
 			},
 			

--- a/revdb/src/dbmysqlapi.cpp
+++ b/revdb/src/dbmysqlapi.cpp
@@ -41,6 +41,8 @@ extern "C" LIBRARY_EXPORT void setidcounterref(unsigned int *tidcounter)
 	DBObject::idcounter = tidcounter;
 }
 
+extern "C" LIBRARY_EXPORT void setcallbacksref(DBcallbacks *callbacks);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // The static function export table for iOS external linkage requirements.
@@ -67,6 +69,7 @@ extern "C" {
 		{ "newdbconnectionref", (void *)newdbconnectionref },
 		{ "releasedbconnectionref", (void *)releasedbconnectionref },
 		{ "setidcounterref", (void *)setidcounterref },
+		{ "setcallbacksref", (void *)setcallbacksref },
 		{ 0, 0 }
 	};
 	

--- a/revdb/src/iossupport.cpp
+++ b/revdb/src/iossupport.cpp
@@ -205,8 +205,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)dlsym(t_driver_handle, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)dlsym(t_driver_handle, "newdbconnectionref");
 	t_result -> releaseconnectionptr = (release_connectionrefptr)dlsym(t_driver_handle, "releasedbconnectionref");
-    // PM-2015-04-09: [[ Bug 14972 ]] Init setcallbacksptr to prevent a crash when LoadDatabaseDriver is called
-    t_result -> setcallbacksptr = (set_callbacksrefptr)nil;
+    t_result -> setcallbacksptr = (set_callbacksrefptr)dlsym(t_driver_handle, "setcallbacksref");
 	free(t_filename);
 	return t_result;
 #else
@@ -227,8 +226,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	t_result -> idcounterptr = (idcounterrefptr)resolve_symbol(t_driver_handle, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)resolve_symbol(t_driver_handle, "newdbconnectionref");
 	t_result -> releaseconnectionptr = (release_connectionrefptr)resolve_symbol(t_driver_handle, "releasedbconnectionref");
-    // PM-2015-04-09: [[ Bug 14972 ]] Init setcallbacksptr to prevent a crash when LoadDatabaseDriver is called
-    t_result -> setcallbacksptr = (set_callbacksrefptr)nil;
+    t_result -> setcallbacksptr = (set_callbacksrefptr)resolve_symbol(t_driver_handle, "setcallbacksref");
 	free(t_filename);
 	return t_result;
 #endif


### PR DESCRIPTION
The MySQL driver now ensures the setcallbacksref function is exported
allowing revDB to give it the necessary callbacks to load dynamic
modules.
