### PR TITLE
[[ Docs ]] Remove space before colon in stack doc entry

### DIFF
--- a/docs/dictionary/object/stack.lcdoc
+++ b/docs/dictionary/object/stack.lcdoc
@@ -4,7 +4,7 @@ Type: object
 
 Syntax: stack
 
-Summary: The basic LiveCode <object> : a window.
+Summary: The basic LiveCode <object>: a window.
 
 Synonyms: window,wd
 


### PR DESCRIPTION
Not only is this a grammatical correction but it seems to fix
a formatting problem in the stack dictionary entry.
