### PR TITLE
[[ Bug 16970 ]] Fix crash when setting screenPixelScale

### DIFF
--- a/docs/notes/bugfix-16970.md
+++ b/docs/notes/bugfix-16970.md
@@ -1,0 +1,1 @@
+# Prevent crash when setting the screenPixelScale

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1792,6 +1792,8 @@ static bool MCPropertyParsePointList(MCStringRef p_input, char_t p_delimiter, ui
 
 void MCExecFetchProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *mark, MCExecValue& r_value)
 {
+    MCAssert(prop -> getter != nil);
+    
     switch(prop -> type)
     {
         case kMCPropertyTypeAny:
@@ -2592,6 +2594,8 @@ void MCExecFetchProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
 
 void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *mark, MCExecValue p_value)
 {
+    MCAssert(prop -> setter != nil);
+    
     switch(prop -> type)
     {
         case kMCPropertyTypeAny:

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -5430,14 +5430,13 @@ void MCProperty::eval_global_property_ctxt(MCExecContext& ctxt, MCExecValue& r_v
 	if (!MCPropertyInfoTableLookup(which, effective, t_info, t_is_array_prop))
         t_info = lookup_mode_property(getmodepropertytable(), which, effective, t_is_array_prop);
         
-    if (t_info != nil)
+    if (t_info != nil && t_info -> getter != nil)
     {
         MCExecFetchProperty(ctxt, t_info, *t_index, r_value);
         return;
 	}
 
-    MCeerror->add(EE_PROPERTY_NOPROP, line, pos);
-    ctxt . Throw();
+    ctxt . LegacyThrow(EE_PROPERTY_NOPROP);
 }
 
 void MCProperty::eval_object_property_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
@@ -5534,14 +5533,13 @@ void MCProperty::set_global_property(MCExecContext& ctxt, MCExecValue p_value)
     if (!MCPropertyInfoTableLookup(which, effective, t_info, t_is_array_prop))
         t_info = lookup_mode_property(getmodepropertytable(), which, effective, t_is_array_prop);
     
-    if (t_info != nil)
+    if (t_info != nil && t_info -> setter != nil)
     {
         MCExecStoreProperty(ctxt, t_info, *t_index, p_value);
         return;
 	}
     
-    MCeerror->add(EE_PROPERTY_CANTSET, line, pos);
-    ctxt . Throw();
+    ctxt . LegacyThrow(EE_PROPERTY_CANTSET);
 }
 
 void MCProperty::set_object_property(MCExecContext& ctxt, MCExecValue p_value)

--- a/tests/lcs/_testlib.livecodescript
+++ b/tests/lcs/_testlib.livecodescript
@@ -113,6 +113,16 @@ on TestAssertBroken pDescription, pExpectTrue, pReasonBroken
    _TestOutput pExpectTrue, pDescription, "TODO", pReasonBroken
 end TestAssertBroken
 
+on TestAssertThrow pDescription, pHandler, pTarget, pErrorCode
+   local tError
+   try
+      dispatch pHandler to pTarget
+    catch tError
+    end try
+    
+    TestAssert pDescription, pErrorCode is item 1 of line 1 of tError
+end TestAssertThrow
+
 on ErrorDialog executionError, parseError
    write executionError & return to stderr
    quit 1

--- a/tests/lcs/core/engine/globalproperties.livecodescript
+++ b/tests/lcs/core/engine/globalproperties.livecodescript
@@ -1,0 +1,27 @@
+﻿script "CoreEngineGlobalProperties"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on _TestSetReadOnlyProperty
+	set the screenPixelScale to 2
+end _TestSetReadOnlyProperty
+
+constant kCantSetPropertyCode = 448
+on TestSetReadOnlyProperty
+	TestAssertThrow "setting read-only global property throws", \
+		 "_TestSetReadOnlyProperty", the long id of me, kCantSetPropertyCode
+end TestSetReadOnlyProperty


### PR DESCRIPTION
Ensure global property setters and getters exist before getting or
setting.
