### PR TITLE
[[ Bug ]] Fix potential crash with Android photo picking

### DIFF
--- a/docs/notes/bugfix-11118.md
+++ b/docs/notes/bugfix-11118.md
@@ -1,0 +1,1 @@
+# Fix potential crash when cancelling photo picking on Android.

--- a/engine/src/mblandroidcamera.cpp
+++ b/engine/src/mblandroidcamera.cpp
@@ -134,8 +134,9 @@ bool MCSystemAcquirePhoto(MCPhotoSourceType p_source, int32_t p_max_width, int32
 	{
         if (s_pick_photo_err != nil)
         {
-            /* UNCHECKED */ MCStringCreateWithCString(s_pick_photo_err, r_result);
-            delete s_pick_photo_err;
+			/* UNCHECKED */ MCStringCreateWithCString(s_pick_photo_err, r_result);
+			MCCStringFree(s_pick_photo_err);
+			s_pick_photo_err = nil;
         }
         else
         /* UNCHECKED */MCStringCreateWithCString("cancel", r_result);


### PR DESCRIPTION
Failure to reset a static variable to nil after freeing could
cause a double free when using PickPhoto on Android.
