### PR TITLE
Make sure the release notes appear in the IDE guide

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -355,6 +355,7 @@ component Documentation
 	into [[ToolsFolder]]/Documentation place
 		rfolder "repo:docs/guides"
 		rfolder "ide:Documentation/guides"
+		rfolder "docs:guides"
 	
 	into [[ToolsFolder]]/Documentation/html_viewer place
 		file "ide:Documentation/html_viewer/api.html.template"
@@ -366,9 +367,6 @@ component Documentation
 	into [[ToolsFolder]]/Documentation/html_viewer/resources/data place
 		rfolder "ide:Documentation/html_viewer/resources/data/[[TargetEdition]]/api"
 		rfolder "ide:Documentation/html_viewer/resources/data/[[TargetEdition]]/guide"
-
-	into [[ToolsFolder]]/Documentation/guides place
-		file "repo:LiveCodeNotes-[[EscapedVersionTag]].md" as "Release Notes.md"
 	
 	into [[ToolsFolder]]/Documentation/pdf place
 		file "repo:LiveCode[[TargetEdition]]UserGuide-[[EscapedVersionTag]].pdf" as "LiveCode User Guide.pdf"

--- a/buildbot.mk
+++ b/buildbot.mk
@@ -133,10 +133,12 @@ UPLOAD_MAX_RETRIES = 50
 ifeq ($(BUILD_EDITION),commercial)
   dist-docs: dist-docs-commercial
   dist-docs: dist-guide-commercial
+  dist-notes: dist-notes-commercial
 endif
 
 dist-docs: dist-docs-community
 dist-docs: dist-guide-community
+dist-notes: dist-notes-community
 
 dist-docs-community:
 	mkdir -p $(docs_build_dir)
@@ -153,11 +155,18 @@ dist-docs-commercial:
 	  --stage docs --edition business \
 	  --built-docs-dir $(docs_build_dir)/cooked-commercial
 
-dist-notes:
+dist-notes-community:
 	WKHTMLTOPDF=$(WKHTMLTOPDF) \
 	$(buildtool_command) --platform $(buildtool_platform) \
-	    --stage notes --warn-as-error
-	    
+	  --stage notes --warn-as-error \
+	  --built-docs-dir $(docs_build_dir)/cooked-community
+
+dist-notes-commercial:
+	WKHTMLTOPDF=$(WKHTMLTOPDF) \
+	$(buildtool_command) --platform $(buildtool_platform) \
+	  --stage notes --warn-as-error \
+	  --built-docs-dir $(docs_build_dir)/cooked-commercial
+
 dist-guide-community:
 	WKHTMLTOPDF=$(WKHTMLTOPDF) \
 	$(buildtool_command) --platform $(buildtool_platform) \

--- a/buildbot.mk
+++ b/buildbot.mk
@@ -228,6 +228,7 @@ dist-upload-files.txt sha1sum.txt:
 	  > dist-upload-files.txt; \
 	if test "${UPLOAD_RELEASE_NOTES}" = "yes"; then \
 		find . -maxdepth 1 -name 'LiveCodeNotes*.pdf' >> dist-upload-files.txt; \
+		find . -maxdepth 1 -name 'LiveCodeNotes*.html' >> dist-upload-file; \
 	fi; \
 	if test "$(UPLOAD_ENABLE_CHECKSUM)" = "yes"; then \
 	  $(SHA1SUM) < dist-upload-files.txt > sha1sum.txt; \

--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -315,6 +315,12 @@ function builderBuiltNotesFolder
    return builderRepoFolder()
 end builderBuiltNotesFolder
 
+-- Folder for storing guide Markdown files that are generated as part
+-- of the build process.
+function builderBuiltGuidesFolder
+   return builderBuiltDocsFolder() & slash & "guides"
+end builderBuiltGuidesFolder
+
 function builderCommercialFolder
    set the itemDel to slash
    return item 1 to -4 of the filename of me

--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -1987,6 +1987,8 @@ private command docsBuilderGetGuideFolders pEdition, @xFolders
       put RepoBusinessDocsFolder() & slash & "guides" into tBusinessGuides
       addFolderToListIfExists tBusinessGuides, false, xFolders
    end if
+
+   addFolderToListIfExists builderBuiltGuidesFolder(), false, xFolders
 end docsBuilderGetGuideFolders
 
 private command docsBuilderAddMergExtFolders pEdition, @xFolders

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -78,6 +78,11 @@ private function OutputGetUpdatesFilename tSuffix, pVersion
    return sOutputPath & slash & tBasename & "." & tSuffix
 end OutputGetUpdatesFilename
 
+private function OutputGetGuideFilename
+   builderEnsureFolder builderBuiltGuidesFolder()
+   return builderBuiltGuidesFolder() & slash & "Release Notes.md"
+end OutputGetGuideFilename
+
 private function OutputGetNotesUrl tSuffix, pVersion
    put replaceText(pVersion, "[-,\.]", "_") into pVersion
    
@@ -93,6 +98,8 @@ private command OutputNotes
    OutputNotesMarkdown
    OutputNotesHtml
    OutputNotesPdf
+
+   OutputNotesGuide
 end OutputNotes
 
 private command OutputNotesMarkdown
@@ -101,6 +108,13 @@ private command OutputNotesMarkdown
    builderLog "report", merge("Writing [[tPath]]")
    FileSetUTF8Contents tPath, sMarkdownText["notes"]
 end OutputNotesMarkdown
+
+private command OutputNotesGuide
+   local tPath
+   put OutputGetGuideFilename() into tPath
+   builderLog "report", merge("Writing [[tPath]]")
+   FileSetUTF8Contents tPath, sMarkdownText["notes"]
+end OutputNotesGuide
 
 private command OutputNotesHtml
    -- Try to do the minimum possible escaping to be able to insert the

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -282,7 +282,7 @@ Single-line files are added to the table of bugfixes.  Multi-line
 files get their own section in the release notes.
 */
 private command V1NotesCreate pType, pReadableType, pTitle
-   builderLog "report", merge("Creating [[pType]] release notes")
+   builderLog "report", merge("Creating [[pReadableType]] release notes")
    
    MarkdownAppend "notes", merge("# [[pTitle]]")
    MarkdownAppend "updates", merge("# [[pTitle]]")
@@ -561,7 +561,7 @@ end V1NotesGenerateBlock
 ----------------------------------------------------------------
 
 private command V2NotesCreate pType, pReadableType, pTitle
-   builderLog "report", merge("Creating [[pType]] release notes")
+   builderLog "report", merge("Creating [[pReadableType]] release notes")
    
    MarkdownAppend "notes", merge("# [[pTitle]]")
    MarkdownAppend "updates", merge("# [[pTitle]]")


### PR DESCRIPTION
Add the concept of a "built guides" directory to the builder; make sure the docs builder looks there; and teach the release notes builder to put the release notes in that location.
