### PR TITLE
Restore legacy behaviour when parsing hexadecimal literals

### DIFF
--- a/docs/notes/bugfix-17338.md
+++ b/docs/notes/bugfix-17338.md
@@ -1,0 +1,2 @@
+# Restore legacy behavior when parsing hexadecimal constants
+

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1571,16 +1571,18 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 		{
 		case ST_NUM:
         {
-			real8 nvalue;
-            MCAutoNumberRef t_number;
-
-            if (!MCNumberParse(gettoken_stringref(), &t_number))
+            // It is absolutely *vital* that we use the same method here for
+            // parsing numbers as MCExecContext::ConvertToNumber. If we don't,
+            // very strange inconsistencies occur depending on whether the
+            // number is used in an arithmetic context or not (for an example,
+            // see bug #17338 in Bugzilla).
+            real8 nvalue;
+            if (!MCTypeConvertStringToReal(gettoken_stringref(), nvalue, false))
 			{
 				MCperror->add(PE_EXPRESSION_NOTLITERAL, *this);
 				return PS_ERROR;
             }
 
-            nvalue = MCNumberFetchAsReal(*t_number);
             MCStringSetNumericValue(MCNameGetString(gettoken_nameref()), nvalue);
 
 			newfact = insertfactor(new MCLiteral(gettoken_nameref()), curfact, top);

--- a/tests/lcs/core/execution/literal-evaluation.livecodescript
+++ b/tests/lcs/core/execution/literal-evaluation.livecodescript
@@ -1,4 +1,4 @@
-script "CoreExecutionLiteralEvaluation"
+﻿script "CoreExecutionLiteralEvaluation"
 /*
 Copyright (C) 2016 LiveCode Ltd.
 
@@ -25,3 +25,24 @@ on TestEvaluateNumericLiteral
    put "2" into tArray["2"]
    TestAssert "numeric literal remains string in computation context", (tArray[2] + 1) is "03"
 end TestEvaluateNumericLiteral
+
+on TestEvaluateHexSigned
+   -- Hexadecimal literals should be parsed as *signed* numbers (contrary to expectations!)
+   TestAssert "hexadecimal literals are signed", (0xffffffff is -1)
+   TestAssert "hexadecimal literals are signed in arithmetic contexts", ((0xffffffff + 0) is -1)
+end TestEvaluateHexSigned
+
+on TestEvaluateHexOverflowIgnored
+   -- Legacy behaviour is to ignore overflow of hex literals
+   TestAssert "hexadecimal overflow is ignored", (0x10000002A+0) is 42
+end TestEvaluateHexOverflowIgnored
+
+on TestParseOctals
+   -- The parser currently fails to parse octal numeric literals correctly
+   set the convertOctals to true
+   TestAssertBroken "parser octal conversion of strings", ("010"+0) is 8
+   TestAssertBroken "parser octal conversion of numbers", (010+0) is 8
+
+   -- The legacy behaviour of the parser is to accept invalid octal literals!
+   TestAssert "parser octal conversion legacy behaviour", "018" is 16
+end TestParseOctals


### PR DESCRIPTION
This results in them being treated as signed integer values rather than unsigned.
