### PR TITLE
[Bug 17342] Ensure widget mouse events happen after drag operation

### DIFF
--- a/docs/notes/bugfix-17342.md
+++ b/docs/notes/bugfix-17342.md
@@ -1,0 +1,1 @@
+# Ensure widget mouse events work after dragging a widget

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1463,9 +1463,17 @@ void MCDispatch::wmdrag(Window w)
 		//   correct from the point of view of the field.
 		if (MCdragtargetptr->gettype() > CT_CARD)
 		{
-			MCControl *cptr = (MCControl *)MCdragtargetptr;
-			cptr->munfocus();
-			cptr->getcard()->ungrab();
+			/* FIXME This is horrible */
+			if (MCdragtargetptr->gettype() != CT_WIDGET)
+			{
+				static_cast<MCControl *>(MCdragtargetptr)->munfocus();
+			}
+			else
+			{
+				MCwidgeteventmanager ->
+					event_munfocus(static_cast<MCWidget *>(MCdragtargetptr));
+			}
+			MCdragtargetptr->getcard()->ungrab();
 		}
 		MCdragtargetptr->getstack()->resetcursor(True);
 		MCdragtargetptr -> getstack() -> munfocus();

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -377,7 +377,12 @@ void MCWidgetEventManager::event_munfocus(MCWidget* p_widget)
 {
     // If a widget is currently grabbed, do nothing.
     if (m_mouse_grab != nil)
-        return;
+    {
+        if (MCWidgetGetHost(m_mouse_grab) == p_widget)
+        {
+            mouseCancel(m_mouse_grab, 0);
+        }
+    }
     
     // If the unfocused widget is the currently focused widget, then
     // leave it.


### PR DESCRIPTION
When a drag operation begins, the control being dragged stops
receiving mouse movement messages and starts receiving drag movement
messages instead.  The widget event manager's `event_munfocus()`
method needs to get called directly because `MCWidget::munfocus()`
intentionally suspends normal processing during a drag operation.

In addition, `MCWidgetManager::event_munfocus()` needs to cancel _all_
mouse status on a widget, even if the widget is currently grabbed.
