### PR TITLE
[[ Community Docs ]] Differentiate field and chunk heights

### DIFF
--- a/docs/dictionary/property/formattedHeight.lcdoc
+++ b/docs/dictionary/property/formattedHeight.lcdoc
@@ -34,7 +34,9 @@ If you specify an image or player, the <formattedHeight> <property> reports the 
 
 If you specify an object in a group, the value reported is the <formattedHeight> that <object> requires for the <current card>, so if you want to get the <formattedHeight> of a <field(object)|field's> text on a certain <card>, you must go to that <card> first.
 
-The <formattedHeight> of a <chunk> in a <field(keyword)> is the amount of vertical space that portion of the <field(object)|field's> text requires, taking line breaks into account.
+The <formattedHeight> of a <field(keyword)> is the amount of vertical space the <field(object)|field's> text requires, taking line breaks into account and including top and bottom margins.
+
+The <formattedHeight> of a <chunk> in a <field(keyword)> is the amount of vertical space that portion of the <field(object)|field's> text requires, taking line breaks into account but disregarding margins.
 
 References: formattedTop (property), visible (property), thumbSize (property), fixedLineHeight (property), margins (property), integer (keyword), image (keyword), field (keyword), card (keyword), revChangeWindowSize (command), group (command), textHeightSum (function), stack (object), object (object), field (object), property (glossary), handler (glossary), current card (glossary), chunk (glossary)
 


### PR DESCRIPTION
Added explanation that a field's formattedheight includes margins, where a chunk height does not.
