### PR TITLE
Remove "sessionSavePath property (property)"

### DIFF
--- a/docs/dictionary/command/stop-session.lcdoc
+++ b/docs/dictionary/command/stop-session.lcdoc
@@ -20,6 +20,6 @@ Use the <stop session> command to end the session explicitly and save the conten
 
 The location where the $_SESSION array is stored is configured using the <sessionSavePath property>.
 
-References: start session (command), delete session (command), sessionSavePath (property), sessionLifetime (property), sessionId (property), sessionSavePath property (property), sessionName (property)
+References: start session (command), delete session (command), sessionSavePath (property), sessionLifetime (property), sessionId (property), sessionName (property)
 
 Tags: multimedia

--- a/docs/dictionary/command/stop-session.lcdoc
+++ b/docs/dictionary/command/stop-session.lcdoc
@@ -18,7 +18,7 @@ stop session
 Description:
 Use the <stop session> command to end the session explicitly and save the contents of the $_SESSION variable.
 
-The location where the $_SESSION array is stored is configured using the <sessionSavePath property>.
+The location where the $_SESSION array is stored is configured using the <sessionSavePath> property.
 
 References: start session (command), delete session (command), sessionSavePath (property), sessionLifetime (property), sessionId (property), sessionName (property)
 


### PR DESCRIPTION
The reference contained duplicate information that was not properly formatted. The incorrect information was removed. The string "sessionSavePath (property)" exists in the reference, and is correctly formatted.
