### PR TITLE
[[ Bug 17232 ]] Correct fast code path for single unicode char in string

### DIFF
--- a/docs/notes/bugfix-17232.md
+++ b/docs/notes/bugfix-17232.md
@@ -1,0 +1,1 @@
+# Correct searching for a single character in a unicode string

--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -331,9 +331,9 @@ bool    MCUnicodeCaseFold(const unichar_t *p_in, uindex_t p_in_length,
 enum MCUnicodeCompareOption
 {
     kMCUnicodeCompareOptionExact = 0,       // Codepoint (not code unit!) equality
-    kMCUnicodeCompareOptionNormalised = 1,  // Normalise inputs before comparison
-    kMCUnicodeCompareOptionCaseless = 2,    // Both normalise and case fold
-    kMCUnicodeCompareOptionFolded = 3,      // Case fold inputs before comparison
+	kMCUnicodeCompareOptionNormalised = 1,  // Normalise inputs before comparison
+	kMCUnicodeCompareOptionFolded = 2,      // Case fold inputs before comparison
+    kMCUnicodeCompareOptionCaseless = 3,    // Both normalise and case fold
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -330,10 +330,10 @@ bool    MCUnicodeCaseFold(const unichar_t *p_in, uindex_t p_in_length,
 // Comparison options
 enum MCUnicodeCompareOption
 {
-    kMCUnicodeCompareOptionExact = 0,       // Codepoint (not code unit!) equality
-	kMCUnicodeCompareOptionNormalised = 1,  // Normalise inputs before comparison
-	kMCUnicodeCompareOptionFolded = 2,      // Case fold inputs before comparison
-    kMCUnicodeCompareOptionCaseless = 3,    // Both normalise and case fold
+    kMCUnicodeCompareOptionExact = kMCStringOptionCompareExact,       // Codepoint (not code unit!) equality
+	kMCUnicodeCompareOptionNormalised = kMCStringOptionCompareNonliteral,  // Normalise inputs before comparison
+	kMCUnicodeCompareOptionFolded = kMCStringOptionCompareFolded,      // Case fold inputs before comparison
+    kMCUnicodeCompareOptionCaseless = kMCStringOptionCompareCaseless,    // Both normalise and case fold
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -1095,12 +1095,22 @@ bool MCUnicodeFirstIndexOfChar(const unichar_t *p_string, uindex_t p_string_leng
 {
     // Create filter chain for the string being searched
     MCTextFilter* t_string_filter = MCTextFilterCreate(p_string, p_string_length, kMCStringEncodingUTF16, p_option);
-    
+	
+	// Process the needle codepoint according to the string options.
+	// We use NFC for normalization, so all single char unicode strings
+	// are already normalized. Therefore we just need to fold if
+	// caseless or folded.
+	codepoint_t t_processed_needle;
+	if (p_option == kMCUnicodeCompareOptionFolded || p_option == kMCUnicodeCompareOptionCaseless)
+		t_processed_needle = MCUnicodeGetCharacterProperty(p_needle, kMCUnicodePropertySimpleCaseFolding);
+	else
+		t_processed_needle = p_needle;
+		
     // Loop until we find the character
     while (t_string_filter->HasData())
     {
         codepoint_t t_cp = t_string_filter->GetNextCodepoint();
-        if (t_cp == p_needle)
+        if (t_cp == t_processed_needle)
         {
             t_string_filter->MarkText();
             r_index = t_string_filter->GetMarkedLength() - 1;

--- a/tests/lcs/core/strings/offset.livecodescript
+++ b/tests/lcs/core/strings/offset.livecodescript
@@ -1,0 +1,31 @@
+script "CoreStringOffset"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestOffsetSingleUnicodeChar
+   local tNeedle, tHaystack
+   -- Native needle
+   put "B" into tNeedle
+   -- Unicode pattern
+   put "aAbBcCdDeEfFgG" & numToCodepoint(0x3B1) into tHaystack
+
+   set the caseSensitive to true
+   TestAssert "offset of native needle in unicode string - case-sensitive", offset(tNeedle, tHaystack) is 4
+
+   set the caseSensitive to false
+   TestAssert "offset of native needle in unicode string - caseless", offset(tNeedle, tHaystack) is 3
+end TestOffsetSingleUnicodeChar


### PR DESCRIPTION
This patch corrects two problems.

The first is a mismatch between the enums MCUnicodeCompareOptions and
MCStringOptions.

The second is to ensure that a single character needle is folded
appropriately in MCUnicodeFirstIndexOfChar.
