### PR TITLE
Fix various issues that caused building a standalone for iOS to fail

### DIFF
--- a/docs/notes/bugfix-17292.md
+++ b/docs/notes/bugfix-17292.md
@@ -1,0 +1,1 @@
+# Fixed codesigning issue when building iOS standalones on OSX 10.11

--- a/docs/notes/bugfix-17368.md
+++ b/docs/notes/bugfix-17368.md
@@ -1,0 +1,1 @@
+#  Make sure iOS 64bit device builds do not fail on OS X 10.10 because of linking warning

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -72,8 +72,8 @@ private function linkingIsValid pLinkingOutput
    repeat for each line tLine in pLinkingOutput
       // Discard Xcode 7 new warnings like:
       // ld: warning: object file (<path_to_exe) was built for newer iOS version (9.0) than being linked (7.0)
-      // On the first use of Xcode 7.0 for deployment, 'ld: warning: ' is duplicated...
-      if not matchtext(tLine, "(ld: warning: )+object file \(.*\) was built for newer iOS version \(.*\) than being linked \(.*\)") then
+      // ld: warning: ignoring linker optimzation..
+      if not (tLine begins with "ld: warning:") then
          return false
       end if
    end repeat

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -689,7 +689,7 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget
             quote & pAppBundle & quote) into tResult
       -- MM-2012-10-25: [[ Bug ]] try catch finally oddness meant that any errors here were being ignored.
       delete file tEntitlementsFile
-      if not (tResult contains "signed bundle") then
+      if not (tResult contains "signed bundle" or tResult contains "signed app bundle") then
          throw "codesigning failed with" && tResult
       end if
       --      finally


### PR DESCRIPTION
1. [Bug 17292] On OSX 10.11.4 the return value of a successful codesign has changed from containing `signed bundle` to containing `signed app bundle`. This caused confusion to the S/B.
2. [Bug 17368] On OSX 10.10 performing iOS 64bit device builds resulted in linking warnings. The S/B did not ignore these warnings.
