### PR TITLE
[[ Bug 17413 ]] Correct returned IO status from fixed read.

### DIFF
--- a/docs/notes/bugfix-17413.md
+++ b/docs/notes/bugfix-17413.md
@@ -1,0 +1,1 @@
+# Make sure reading past end of file returns "eof"

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1284,10 +1284,11 @@ void MCFilesExecPerformReadFixedFor(MCExecContext& ctxt, IO_handle p_stream, int
         t_success = MCStringCopyAndRelease(t_buffer, (MCStringRef&)r_output);
     else
         MCValueRelease(t_buffer);
-    
-    if (t_success)
-        r_stat = IO_NORMAL;
-    else
+	
+	// If creating the buffer from the read data failed, then treat it as an IO error.
+	// Otherwise leave 'stat' as it is - as it could be EOF (which isn't stricly a
+	// failure).
+    if (!t_success)
         r_stat = IO_ERROR;
 }
 

--- a/tests/lcs/core/files/file-io.livecodescript
+++ b/tests/lcs/core/files/file-io.livecodescript
@@ -1,0 +1,31 @@
+script "CoreFileIO"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestReadForFixedEof
+   local tFile
+   put tempName() into tFile
+   put "hello world" into url ("binfile:" & tFile)
+   
+   local tResult
+   open file tFile for binary read
+   read from file tFile for 16284 bytes
+   put the result into tResult
+   close file tFile
+
+   TestAssert "reading past end of file returns eof", tResult is "eof"
+end TestReadForFixedEof


### PR DESCRIPTION
This patch ensures that the IO status returned from reading a fixed
amount of data for a file is only changed if an error occurred
constructing the buffer to return. If the IO status is IO_EOF it
leaves it as is.
