### PR TITLE
[[ Bug 17422 ]] Allow unloading of unreferenced library modules.

### DIFF
--- a/docs/notes/bugfix-17422.md
+++ b/docs/notes/bugfix-17422.md
@@ -1,0 +1,1 @@
+# Make sure unreferenced library modules can be unloaded.


### PR DESCRIPTION
If a library module is currently unreferenced it will have a ref
count of 2 - in comparison to an unreferenced widget module which
will have a ref count of 1.
