### PR TITLE
[[ Bug 17411 ]] Release widget instance on del()

### DIFF
--- a/docs/notes/bugfix-17411.md
+++ b/docs/notes/bugfix-17411.md
@@ -1,0 +1,1 @@
+# Make sure deleting a widget stops using its module.

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -712,6 +712,23 @@ void MCWidget::geometrychanged(const MCRectangle &p_rect)
 		MCwidgeteventmanager -> event_setrect(this, p_rect);
 }
 
+Boolean MCWidget::del(void)
+{
+    if (!MCControl::del())
+        return False;
+
+    // Make sure we release the widget ref here. Otherwise its
+    // module cannot be released until the pending object pools
+    // are drained.
+    if (m_widget != nil)
+    {
+        MCValueRelease(m_widget);
+        m_widget = nil;
+    }
+    
+    return True;
+}
+
 void MCWidget::OnOpen()
 {
 	if (m_widget != nil)

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -176,6 +176,9 @@ public:
     virtual void visibilitychanged(bool p_visible);
     virtual void layerchanged();
 	virtual void geometrychanged(const MCRectangle &p_rect);
+    
+    virtual Boolean del(void);
+    
 	virtual void OnOpen();
 	virtual void OnClose();
 	


### PR DESCRIPTION
When an object is deleted its 'del()' method is called and then
it is put into the deleted objects pool. This means that an
unused reference to the widget's module can remain until the
pool is drained.

This patch ensures that the MCWidget::del() method releases the
widget instance, meaning that unload extension can work immediately
rather than after the next drain.
