### PR TITLE
[[ Bug 17430 ]] Prevent a hang when inserting \n before VTAB

### DIFF
--- a/docs/notes/bugfix-17430.md
+++ b/docs/notes/bugfix-17430.md
@@ -1,0 +1,1 @@
+# Stop a hang when inserting a return before a VTAB

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -2288,9 +2288,19 @@ void MCParagraph::split(findex_t p_position)
     MCBlock *bptr = indextoblock(p_position, False);
 	findex_t skip = 0;
 	
-    if (p_position < MCStringGetLength(m_text) && TextIsLineBreak(GetCodepointAtIndex(p_position)))
+    // Reinstate original check for the presence of '\n' after the split.
+    // We believe this check was there as previously when importing text
+    // into a field, it would be set in a paragraph and then the paragraph
+    // would be iteratively split - which entailed removing the \n's.
+    // The 'm_text' field of a paragraph should never contain '\n' now so
+    // whilst we leave this check in (to be on the safe side) it should never
+    // trigger - hence the assert.
+    if (p_position < MCStringGetLength(m_text) && GetCodepointAtIndex(p_position) == '\n')
+    {
+        MCAssert(false);
         skip = IncrementIndex(p_position) - p_position;
-	
+    }
+    
 	MCParagraph *pgptr = new MCParagraph;
 	pgptr->parent = parent;
 

--- a/tests/lcs/core/field/interactive-mutation.livecodescript
+++ b/tests/lcs/core/field/interactive-mutation.livecodescript
@@ -1,0 +1,27 @@
+﻿script "CoreFieldInteractiveMutation"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestReturnBeforeVTab
+    create stack "TestStack"
+    set the defaultStack to "TestStack"
+    create field "Test"
+    set the text of field "Test" to "First" & numToChar(11) & "Second"
+    select after char 5 of field "Test"
+    type return
+    TestAssert "insert return before vtab", the text of field "Test" is ("First" & return & numToChar(11) & "Second")
+end TestReturnBeforeVTab


### PR DESCRIPTION
An error in updating MCParagraph::split() to unicode meant that a
check was specific to finding \n in a the paragraph's text was
actually checking for VTAB or LS. The original check should no
longer be needed now (as \n should never appear in the paragraph's
text), however it has been reinstated with an assert (in debug
mode).
