### PR TITLE
[[ Bug 17832 ]] Make sure line height is rounded up when rendering.

### DIFF
--- a/docs/notes/bugfix-17382.md
+++ b/docs/notes/bugfix-17382.md
@@ -1,0 +1,2 @@
+# Make sure click position of lines in fields match up to vertical location
+

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -1602,7 +1602,7 @@ void MCParagraph::draw(MCDC *dc, int2 x, int2 y, uint2 fixeda,
 				drawcomposition(dc, lptr, t_current_x, t_current_y, ceilf(linespace), compstart, compend, compconvstart, compconvend);
 		}
 
-		t_current_y += linespace;
+		t_current_y += ceilf(linespace);
 
 		lptr = lptr->next();
 	}


### PR DESCRIPTION
When rendering a paragraph, the vertical position of text was being
accumulated without taking the ceiling of the specific line's height.
This caused a mismatch to visual position on screen, and logical
position in the engine.
