### PR TITLE
[[ Bug 17098 ]] Ensure cursor moves to after last character in line

### DIFF
--- a/docs/notes/bugfix-17098.md
+++ b/docs/notes/bugfix-17098.md
@@ -1,0 +1,1 @@
+# Ensure cursor moves to end of last tab in line.

--- a/engine/src/MCBlock.h
+++ b/engine/src/MCBlock.h
@@ -381,6 +381,12 @@ public:
 		return flags & F_HAS_UNICODE;
 	}
     
+    // Returns true if the block has a trailing tab character.
+    bool HasTrailingTab(void) const
+    {
+        return m_size != 0 && GetCodepointAtIndex(m_size - 1) == '\t';
+    }
+    
     //////////
 
     void GetLinkText(MCExecContext& ctxt, MCStringRef& r_linktext);

--- a/engine/src/line.cpp
+++ b/engine/src/line.cpp
@@ -778,8 +778,10 @@ MCLine *MCLine::DoLayout(bool p_flow, int16_t p_linewidth)
         
         // The last segment of the line should be no larger than its contents
         // (because it doesn't contain the whitespace of another tab) unless it
-        // is to be right aligned in LTR text or left-aligned in RTL text
-        if (!t_fixed_tabs && sgptr == lastsegment
+        // is to be right aligned in LTR text or left-aligned in RTL text or it
+        // terminates with a tab character.
+        if (!t_fixed_tabs
+            && (sgptr == lastsegment && !sgptr->GetLastBlock()->HasTrailingTab())
             && ((parent->getbasetextdirection() != kMCTextDirectionRTL && sgptr->GetHorizontalAlignment() != kMCSegmentTextHAlignRight)
             ||  (parent->getbasetextdirection() == kMCTextDirectionRTL && sgptr->GetHorizontalAlignment() != kMCSegmentTextHAlignLeft)))
         {

--- a/tests/lcs/core/field/layout.livecodescript
+++ b/tests/lcs/core/field/layout.livecodescript
@@ -1,0 +1,27 @@
+﻿script "CoreFieldLayout"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestLastTabOnLineIsNotIgnored
+    create stack "TestStack"
+    set the defaultStack to "TestStack"
+    create field "Test"
+
+    set the text of field "Test" to "a" & numToChar(9)
+    set the tabStops of field "Test" to 1000
+    TestAssert "last tab on line is not ignored", the formattedWidth of line 1 of field "Test" is 1000
+end TestLastTabOnLineIsNotIgnored


### PR DESCRIPTION
When the cursor moves across the last tab in a line, it should reflect
that tab's start position and not the length of the previous segment's
content.
