### PR TITLE
[Bug 17385] Prevent repeated OS X app bundle verification

### DIFF
--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -559,7 +559,7 @@ command toolsBuilderMakeAppBundle pVersion, pEdition, pPlatform
    end if
 
    -- One last permission change (but a non-signature-breaking one) to prevent accidental IDE modifications
-   get shell ("chmod -Rvv -w" && escapeArg(tAppBundle))
+   get shell ("chmod -Rvv -w" && escapeArg(tAppBundle & slash & "Contents"))
    if the result is not zero then
       builderLog "error", "Failed to make app bundle read-only:" && it
       throw "failure"

--- a/docs/notes/bugfix-17385.md
+++ b/docs/notes/bugfix-17385.md
@@ -1,0 +1,1 @@
+# Prevent LiveCode app bundle re-verification on every launch on OS X


### PR DESCRIPTION
OS X 10.11 requires the `.app` directory to be writable to allow
Gatekeeper to set an xattr on the directory.  This was manifesting
itself by repeated signature verifications and "are you sure you
want to run this app" prompts.  To fix, make only the `Contents`
tree of the LiveCode app bundle read-only.
