### PR TITLE
[[ Bug 17425 ]] Ensure widgets set 'focused' properly.

### DIFF
--- a/docs/notes/bugfix-17425.md
+++ b/docs/notes/bugfix-17425.md
@@ -1,0 +1,1 @@
+# Make sure widgets handle mouseEnter and mouseLeave events correctly

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -1016,7 +1016,7 @@ void MCWidget::SetFocused(bool p_setting)
 {
     if (p_setting)
         focused = this;
-    else
+    else if (focused == this)
         focused = nil;
 }
 


### PR DESCRIPTION
This patch ensures that a widget can only unset the 'focused'
static var in MCControl _if_ it is currently focused control. Not
doing this can result in focused being set to nil after it has
been set to the new focused control.
