### PR TITLE
[[ Bug 17130 ]] Make sure LiveCode doesn't keep open handles to images

### DIFF
--- a/docs/notes/bugfix-17130.md
+++ b/docs/notes/bugfix-17130.md
@@ -1,0 +1,2 @@
+# Make sure LiveCode doesn't keep open handles to images.
+

--- a/engine/src/image_rep_encoded.cpp
+++ b/engine/src/image_rep_encoded.cpp
@@ -132,10 +132,9 @@ bool MCEncodedImageRep::LoadHeader(uindex_t &r_width, uindex_t &r_height, uint32
     
     if (t_success)
     {
-        t_success = m_loader->GetMetadata(m_metadata);
-    }
-	else
+		t_success = m_loader->GetMetadata(m_metadata);
 		ClearImageLoader();
+    }
 	
 	return t_success;
 }


### PR DESCRIPTION
This patch ensures that the file handle used to fetch the header of
images is closed after header has been read. This is a trade-off between
parsing the header twice and loading and decompressing image data
when it isn't needed. Given that the latter is substantially more costly
than the former, this is a reasonable balance.
