### PR TITLE
[[ IDE Testing ]] Allow IDE tests to be run in the IDE

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,12 @@ Before running each test command, the test framework inserts a test library stac
 * `TestGetIDERepositoryPath`: A function that returns the path to the LiveCode IDE repository.
 * `TestLoadExtension pName`: Attempt to load the extension with name `pName`, eg `TestLoadExtension "json"` will load the JSON library extension. 
 * `TestLoadAllExtensions`: Attempt to load all available extensions. 
+* `TestRepeat pDesc, pHandler, pTarget, pTimeOut, pParamsArray`: Repeatedly check the result of a handler for a test. The test is recorded as a success if the result is ever true before the given time runs out, or a failure otherwise.
+	- `pHandlerName` is the name of the handler which returns a result.
+	- `pTarget` is the object to which `pHandlerName` should be dispatched.
+	- `pTimeOut` is the amount of milliseconds to continue testing the result of the handler.
+	- `pParamsArray` is an array of parameters, keyed by the 1-based index of the required parameter to be passed to the handler.
+	
 Tests can have additional setup requirements before running, for example loading custom libraries. If the script test contains a handler called `TestSetup`, this will be run prior to running each test command. For example:
 ````
 on TestSetup

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1811,7 +1811,11 @@ void MCStack::GetScreen(MCExecContext& ctxt, integer_t& r_screen)
 {
 	const MCDisplay *t_display;
 	t_display = MCscreen -> getnearestdisplay(rect);
-	r_screen = t_display -> index + 1;
+    
+    if (t_display != nil)
+        r_screen = t_display -> index + 1;
+    else
+        r_screen = 0;
 }
 
 void MCStack::GetCurrentCard(MCExecContext& ctxt, MCStringRef& r_card)

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -2223,8 +2223,22 @@ void MCModeGetRevLicenseInfo(MCExecContext& ctxt, MCStringRef& r_info)
     MCAutoStringRef t_info;
     t_success = MCStringCreateMutable(0, &t_info);
     
+    MCStringRef t_license_name;
+    t_license_name = MClicenseparameters . license_name;
+    if (t_license_name == nil)
+        t_license_name = kMCEmptyString;
+
+    MCStringRef t_license_org;
+    t_license_org = MClicenseparameters . license_organization;
+    if (t_license_org == nil)
+        t_license_org = kMCEmptyString;
+
+    
     if (t_success)
-        t_success = MCStringAppendFormat(*t_info, "%@\n%@\n%s\n%u\n", MClicenseparameters . license_name, MClicenseparameters . license_organization, s_class_types[MClicenseparameters . license_class], MClicenseparameters . license_multiplicity);
+        t_success = MCStringAppendFormat(*t_info, "%@\n%@\n%s\n%u\n",
+                                         t_license_name, t_license_org,
+                                         s_class_types[MClicenseparameters . license_class],
+                                         MClicenseparameters . license_multiplicity);
     
     if (MClicenseparameters . deploy_targets != 0)
     {

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -195,7 +195,13 @@ void MCNativeLayerMac::doRelayer()
 
 NSWindow* MCNativeLayerMac::getStackWindow()
 {
-    return ((MCMacPlatformWindow*)(m_object->getstack()->getwindow()))->GetHandle();
+    MCMacPlatformWindow *t_window;
+    t_window = (MCMacPlatformWindow*)(m_object->getstack()->getwindow());
+    
+    if (t_window != nil)
+        return t_window -> GetHandle();
+    
+    return nil;
 }
 
 bool MCNativeLayerMac::getParentView(NSView *&r_view)
@@ -205,16 +211,22 @@ bool MCNativeLayerMac::getParentView(NSView *&r_view)
 		MCNativeLayer *t_container;
 		t_container = nil;
 		
-		if (!((MCGroup*)m_object->getparent())->getNativeContainerLayer(t_container))
-			return false;
-		
-		return t_container->GetNativeView((void*&)r_view);
+		if (((MCGroup*)m_object->getparent())->getNativeContainerLayer(t_container))
+            return t_container->GetNativeView((void*&)r_view);
 	}
 	else
 	{
-		r_view = [getStackWindow() contentView];
-		return true;
+        NSWindow* t_window;
+        t_window = getStackWindow();
+        
+        if (t_window != nil)
+        {
+            r_view = [t_window contentView];
+            return true;
+        }
 	}
+
+    return false;
 }
 
 bool MCNativeLayerMac::GetNativeView(void *&r_view)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,7 +31,7 @@ bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
 ########## LiveCode Script test parameters
 
 guess_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/Standalone-Community.app/Contents/MacOS/Standalone-Community,$(bin_dir)/standalone-community)
-guess_dev_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/LiveCode-Community.app/Contents/MacOS/LiveCode-Community,$(bin_dir)/livecode-community)
+guess_dev_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/LiveCode-Community.app/Contents/MacOS/LiveCode-Community,$(bin_dir)/LiveCode-Community)
 
 # When running on headless Linux, run tests in -ui mode.
 guess_engine_flags_script := \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -31,6 +31,7 @@ bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
 ########## LiveCode Script test parameters
 
 guess_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/Standalone-Community.app/Contents/MacOS/Standalone-Community,$(bin_dir)/standalone-community)
+guess_dev_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/LiveCode-Community.app/Contents/MacOS/LiveCode-Community,$(bin_dir)/livecode-community)
 
 # When running on headless Linux, run tests in -ui mode.
 guess_engine_flags_script := \
@@ -44,7 +45,13 @@ LCS_ENGINE ?= $(guess_engine)
 LCS_ENGINE_FLAGS ?= $(guess_engine_flags)
 
 LCS_LOG = _lcs_test_suite.log
-LCS_TESTRUNNER = $(top_srcdir)/tests/_testrunner.livecodescript
+LCS_TESTRUNNER ?= $(top_srcdir)/tests/_testrunner.livecodescript
+
+ifeq ($(LCS_TESTENGINE),development)
+LCS_CMD = $(LCS_ENGINE) $(LCS_ENGINE_FLAGS) $(LCS_TESTRUNNER) run $(guess_dev_engine)
+else
+LCS_CMD = $(LCS_ENGINE) $(LCS_ENGINE_FLAGS) $(LCS_TESTRUNNER) run
+endif
 
 ########## LiveCode Builder test parameters
 
@@ -129,7 +136,7 @@ $(LCM_DIR)/%.lcm: %.lcb | $(LCM_DIR)
 
 lcs-check: $(LCS_ENGINE)
 	@rm -f $(LCS_LOG)
-	@cmd="$(LCS_ENGINE) $(LCS_ENGINE_FLAGS) $(LCS_TESTRUNNER) run"; \
+	@cmd="$(LCS_CMD)"; \
 	echo "$$cmd" $(_PRINT_RULE); \
 	$$cmd
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -48,7 +48,7 @@ LCS_LOG = _lcs_test_suite.log
 LCS_TESTRUNNER ?= $(top_srcdir)/tests/_testrunner.livecodescript
 
 ifeq ($(LCS_TESTENGINE),development)
-LCS_CMD = $(LCS_ENGINE) $(LCS_ENGINE_FLAGS) $(LCS_TESTRUNNER) run $(guess_dev_engine)
+LCS_CMD = $(LCS_ENGINE) $(LCS_ENGINE_FLAGS) $(LCS_TESTRUNNER) run $(guess_dev_engine) $(LCS_ENGINE_FLAGS)
 else
 LCS_CMD = $(LCS_ENGINE) $(LCS_ENGINE_FLAGS) $(LCS_TESTRUNNER) run
 endif

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -299,3 +299,40 @@ on TestLoadAllExtensions
       _TestLoadExtension tAllExtensionsA[tExtFile], tExtFile
    end repeat
 end TestLoadAllExtensions
+
+on TestRepeat pDesc, pHandler, pTarget, pTimeOut, pParamsArray
+	# Construct a dispatch command with all the desired parameters
+	local tDoString, tParams, tResult
+	put "dispatch pHandler to pTarget" into tDoString
+
+	repeat with tParam = 1 to the number of elements in pParamsArray
+		if tParams is empty then
+        	put " with pParamsArray[" & tParam & "]" into tParams
+        else
+        	put ", pParamsArray[" & tParam & "]" after tParams
+        end if
+    end repeat
+    
+    put tParams after tDoString
+    put "; put the result into tResult" after tDoString
+    
+    put false into tResult
+    
+    local tTimer, tTimeout
+    put false into tTimeout
+    put the millisecs into tTimerStart
+    
+    repeat while tResult is false and not tTimeout
+       wait 1 millisecs with messages
+	   do tDoString
+       if the millisecs - tTimerStart > pTimeOut then
+          put true into tTimeOut
+       end if
+	end repeat
+	
+    TestAssert pDesc, tResult
+    
+    if (not tResult) and tTimeOut then
+		TestDiagnostic pDesc & "- timed out"
+	end if
+end TestRepeat

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -24,6 +24,9 @@ end revLoadLibrary
 -- Helper functions
 ----------------------------------------------------------------
 
+local sOutputToVariable
+local sOutput
+
 private function _TestValidateCount pCount
    if pCount is not an integer or pCount <= 0 then
       throw "Bad test count '" & pCount & "': must be positive integer"
@@ -104,7 +107,11 @@ end _TestOutput
 private command _TestWriteOutput pMessage
    -- As stdout is considered to be a 'native' stream, we encode to UTF-8 first
    -- then will unencode in the test runner.
-   write textEncode(pMessage, "UTF8") to stdout
+   if sOutputToVariable then
+      put pMessage after sOutput
+   else
+      write textEncode(pMessage, "UTF8") to stdout
+   end if
 end _TestWriteOutput
 
 private function _TestGetBuiltExtensionsFolder
@@ -134,6 +141,21 @@ end _TestLoadExtension
 ----------------------------------------------------------------
 -- Unit test library functions
 ----------------------------------------------------------------
+
+on TestOutputToVariable
+   put true into sOutputToVariable
+end TestOutputToVariable
+
+function TestFetchAndClearOutput
+   if not sOutputToVariable then
+      return empty
+   end if
+   
+   local tOutput
+   put sOutput into tOutput
+   put empty into sOutput
+   return tOutput
+end TestFetchAndClearOutput
 
 on TestPlan pCount
    _TestWriteOutput "1.." & _TestValidateCount(pCount) & return


### PR DESCRIPTION
This PR tweaks the test library and makefile to enable the IDE test runner to use the development engine.

It also adds a `TestRepeat` handler to the test library which repeatedly checks a test condition until the given time runs out. This is necessary in order to stall the execution of the test runner while ide messages are sent to palettes in response to actions such as creating an object.
