### PR TITLE
Fix docs builder warnings about /*...*/ comments

### DIFF
--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*  
+/**
 This module specifies the syntax definitions and bindings for canvas drawing operations in modular LiveCode.
 */
 
@@ -84,7 +84,7 @@ public foreign handler MCCanvasRectangleSetWidth(in pWidth as CanvasFloat, inout
 public foreign handler MCCanvasRectangleGetHeight(in pRect as Rectangle, out rHeight as CanvasFloat) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasRectangleSetHeight(in pHeight as CanvasFloat, inout xRect as Rectangle) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Creates a new rectangle value.
 
 mRect:		An expression which evaluates to a list of 4 numbers, the left, top, right and bottom edges of the rectangle.
@@ -105,7 +105,7 @@ begin
     MCCanvasRectangleMakeWithList(mRect, output)
 end syntax
 
-/*
+/**
 Summary:	The left edge of a rectangle value.
 
 mRect:		An expression which evaluates to a rectangle.
@@ -143,7 +143,7 @@ begin
 	MCCanvasRectangleSetLeft(input, mRect)
 end syntax
 
-/*
+/**
 Summary:	The top edge of a rectangle value.
 
 mRect:		An expression which evaluates to a rectangle.
@@ -181,7 +181,7 @@ begin
 	MCCanvasRectangleSetTop(input, mRect)
 end syntax
 
-/*
+/**
 Summary:	The right edge of a rectangle value.
 
 mRect:		An expression which evaluates to a rectangle.
@@ -212,7 +212,7 @@ begin
 	MCCanvasRectangleSetRight(input, mRect)
 end syntax
 
-/*
+/**
 Summary:	The bottom edge of a rectangle value.
 
 mRect:		An expression which evaluates to a rectangle.
@@ -243,7 +243,7 @@ begin
 	MCCanvasRectangleSetBottom(input, mRect)
 end syntax
 
-/*
+/**
 Summary:	The width of a rectangle value.
 
 mRect:		An expression which evaluates to a rectangle.
@@ -274,7 +274,7 @@ begin
 	MCCanvasRectangleSetWidth(input, mRect)
 end syntax
 
-/*
+/**
 Summary:	The height of a rectangle value.
 
 mRect:		An expression which evaluates to a rectangle.
@@ -317,7 +317,7 @@ public foreign handler MCCanvasPointSetX(in pX as CanvasFloat, inout xPoint as P
 public foreign handler MCCanvasPointGetY(in pPoint as Point, out rY as CanvasFloat) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasPointSetY(in pY as CanvasFloat, inout xPoint as Point) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Creates a new point value.
 
 mPoint:		An expression which evaluates to a list of 2 numbers, the x and y coordinates of the point.
@@ -337,7 +337,7 @@ begin
 	MCCanvasPointMakeWithList(mPoint, output)
 end syntax
 
-/*
+/**
 Summary:	The x coordinate of a point value.
 
 mPoint:		An expression which evaluates to a point.
@@ -365,7 +365,7 @@ begin
 	MCCanvasPointSetX(input, mPoint)
 end syntax
 
-/*
+/**
 Summary:	The y coordinate of a point value.
 
 mPoint:		An expression which evaluates to a point.
@@ -402,7 +402,7 @@ public foreign handler MCCanvasColorMakeRGBA(in pRed as CanvasFloat, in pGreen a
 public foreign handler MCCanvasColorMakeWithList(in pColor as List, out rColor as Color) returns nothing binds to "<builtin>"
 //public foreign handler MCCanvasColorMakeWithString(in pList as String, out rColor as Color)
 
-/*
+/**
 Summary:	Creates a new color value.
 
 mColor:		An expression which evaluates to a list of 3 or 4 numbers, the red, green, blue, and (optional) alpha components of the color.
@@ -442,7 +442,7 @@ public foreign handler MCCanvasColorSetBlue(in pBlue as CanvasFloat, inout xColo
 public foreign handler MCCanvasColorGetAlpha(in pColor as Color, out rAlpha as CanvasFloat) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasColorSetAlpha(in pAlpha as CanvasFloat, inout xColor as Color) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The red component of a color value.
 
 mColor:		An expression which evaluates to a color.
@@ -473,7 +473,7 @@ begin
 	MCCanvasColorSetRed(input, mColor)
 end syntax
 
-/*
+/**
 Summary:	The green component of a color value.
 
 mColor:		An expression which evaluates to a color.
@@ -504,7 +504,7 @@ begin
 	MCCanvasColorSetGreen(input, mColor)
 end syntax
 
-/*
+/**
 Summary:	The blue component of a color value.
 
 mColor:		An expression which evaluates to a color.
@@ -535,7 +535,7 @@ begin
 	MCCanvasColorSetBlue(input, mColor)
 end syntax
 
-/*
+/**
 Summary:	The alpha component of a color value.
 
 mColor:		An expression which evaluates to a color.
@@ -582,7 +582,7 @@ public foreign handler MCCanvasTransformMakeTranslationWithList(in pTranslation 
 public foreign handler MCCanvasTransformMakeWithMatrixValues(in pA as CanvasFloat, in pB as CanvasFloat, in pC as CanvasFloat, in pD as CanvasFloat, in pTX as CanvasFloat, in pTY as CanvasFloat, out rTransform as Transform) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasTransformMakeWithMatrixAsList(in pMatrix as List, out rTransform as Transform) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The identity transform.
 
 Returns:	A new identity transform.
@@ -603,7 +603,7 @@ begin
 	MCCanvasTransformMakeIdentity(output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new scaling transform value.
 
 mScale:		An expression which evaluates to a list of 1 or 2 numbers, the x-axis scale and y-axis scale, or the uniform scale when only a single value is given.
@@ -627,7 +627,7 @@ begin
     MCCanvasTransformMakeScaleWithList(mScale, output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new skewing transform value.
 
 mScale:		An expression which evaluates to a list of 2 numbers, the x-axis skew and y-axis skew.
@@ -648,7 +648,7 @@ begin
 	MCCanvasTransformMakeSkewWithList(mSkew, output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new rotation transform value.
 
 mRotation:	An expression which evaluates to a number, the number of degrees of the rotation.
@@ -669,7 +669,7 @@ begin
 	MCCanvasTransformMakeRotation(mRotation, output)
 end syntax
 
-/*
+/**
 Summary:		Creates a new translation transform.
 
 mTranslation:	An expression which evaluates to a list of 2 numbers, the x and y offsets of the translation.
@@ -690,7 +690,7 @@ begin
     MCCanvasTransformMakeTranslationWithList(mTranslation, output)
 end syntax
 
-/*
+/**
 Summary:		Creates a new transform.
 
 mTranslation:	An expression which evaluates to a list of 6 numbers, the a, b, c, d, tx and ty values of the transform matrix.
@@ -728,7 +728,7 @@ public foreign handler MCCanvasTransformSetMatrixAsList(in pMatrix as List, inou
 
 public foreign handler MCCanvasTransformGetInverse(in pTransform as Transform, out rInverse as Transform) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:		The scale component of a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -756,7 +756,7 @@ begin
 	MCCanvasTransformSetScaleAsList(input, mTransform)
 end syntax
 
-/*
+/**
 Summary:		The rotation component of a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -784,7 +784,7 @@ begin
 	MCCanvasTransformSetRotation(input, mTransform)
 end syntax
 
-/*
+/**
 Summary:		The skew component of a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -812,7 +812,7 @@ begin
 	MCCanvasTransformSetSkewAsList(input, mTransform)
 end syntax
 
-/*
+/**
 Summary:		The translation component of a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -840,7 +840,7 @@ begin
 	MCCanvasTransformSetTranslationAsList(input, mTransform)
 end syntax
 
-/*
+/**
 Summary:		The matrix values of a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -874,7 +874,7 @@ begin
 	MCCanvasTransformSetMatrixAsList(input, mTransform)
 end syntax
 
-/*
+/**
 Summary:		The inverse of a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -918,7 +918,7 @@ public foreign handler MCCanvasTransformTranslate(inout xTransform as Transform,
 public foreign handler MCCanvasTransformTranslateWithList(inout xTransform as Transform, in pTranslation as List) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasTransformMultiply(in pTransformA as Transform, in pTransformB as Transform, out rTransform as Transform) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:		Concatenate transform a with transform b.
 
 mTransformA:	An expression which evaluates to a transform.
@@ -955,7 +955,7 @@ begin
 	MCCanvasTransformConcat(mTransformA, mTransformB)
 end syntax
 
-/*
+/**
 Summary:		Apply a scale to a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -984,7 +984,7 @@ begin
     MCCanvasTransformScaleWithList(mTransform, mScale)
 end syntax
 
-/*
+/**
 Summary:		Apply a skew to a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -1009,7 +1009,7 @@ begin
 	MCCanvasTransformSkewWithList(mTransform, mSkew)
 end syntax
 
-/*
+/**
 Summary:		Apply a rotation to a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -1035,7 +1035,7 @@ begin
 	MCCanvasTransformRotate(mTransform, mRotation)
 end syntax
 
-/*
+/**
 Summary:		Apply a translation to a transform.
 
 mTransform:		An expression which evaluates to a transform.
@@ -1064,7 +1064,7 @@ begin
     MCCanvasTransformTranslateWithList(mTransform, mTranslation)
 end syntax
 
-/*
+/**
 Summary:		Multiply two transforms together.
 
 Left:		An expression which evaluates to a transform.
@@ -1109,7 +1109,7 @@ end syntax
 
 public foreign handler MCCanvasSolidPaintMakeWithColor(in pColor as Color, out rSolid as SolidPaint) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Creates a new solid color paint.
 
 mColor:		An expression which evaluates to a color.
@@ -1137,7 +1137,7 @@ end syntax
 public foreign handler MCCanvasSolidPaintGetColor(in pSolid as SolidPaint, out rColor as Color) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasSolidPaintSetColor(in pColor as Color, inout pSolid as SolidPaint) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The color of a solid paint value.
 
 mPaint:		An expression which evaluates to a solid paint.
@@ -1179,7 +1179,7 @@ public foreign handler MCCanvasPatternMakeWithRotatedImage(in pImage as Image, i
 public foreign handler MCCanvasPatternMakeWithTranslatedImage(in pImage as Image, in pX as CanvasFloat, in pY as CanvasFloat, out rPattern as Pattern) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasPatternMakeWithImageTranslatedWithList(in pImage as Image, in pTranslation as List, out rPattern as Pattern) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Creates a new pattern paint.
 
 mImage:		An expression which evaluates to an image.
@@ -1204,7 +1204,7 @@ begin
 	MCCanvasPatternMakeWithImage(mImage, output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new transformed pattern paint.
 
 mImage:		An expression which evaluates to an image.
@@ -1234,7 +1234,7 @@ begin
     MCCanvasPatternMakeWithTransformedImage(mImage, mTransform, output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new scaled pattern paint.
 
 mImage:		An expression which evaluates to an image.
@@ -1260,7 +1260,7 @@ begin
 	MCCanvasPatternMakeWithImageScaledWithList(mImage, mScale, output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new translated pattern paint.
 
 mImage:		An expression which evaluates to an image.
@@ -1288,7 +1288,7 @@ begin
 	MCCanvasPatternMakeWithImageTranslatedWithList(mImage, mTranslation, output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new rotated pattern paint.
 
 mImage:		An expression which evaluates to an image.
@@ -1323,7 +1323,7 @@ public foreign handler MCCanvasPatternSetImage(in pImage as Image, inout xPatter
 public foreign handler MCCanvasPatternGetTransform(in pPattern as Pattern, out rTransform as Transform) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasPatternSetTransform(in pTransform as Transform, inout xPattern as Pattern) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The image of a pattern value.
 
 mPattern:		An expression which evaluates to a pattern.
@@ -1352,7 +1352,7 @@ begin
 	MCCanvasPatternSetImage(input, mPattern)
 end syntax
 
-/*
+/**
 Summary:	The transform of a pattern value.
 
 mPattern:		An expression which evaluates to a pattern.
@@ -1395,7 +1395,7 @@ public foreign handler MCCanvasPatternRotate(inout xPattern as Pattern, in pRota
 public foreign handler MCCanvasPatternTranslate(inout xPattern as Pattern, in pX as CanvasFloat, in pY as CanvasFloat) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasPatternTranslateWithList(inout xPattern as Pattern, in pTranslation as List) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:		Apply a transform to a pattern.
 
 mPattern:	An expression which evaluates to a pattern.
@@ -1421,7 +1421,7 @@ begin
 	MCCanvasPatternTransform(mPattern, mTransform)
 end syntax
 
-/*
+/**
 Summary:	Apply a scale to a pattern.
 
 mPattern:	An expression which evaluates to a pattern.
@@ -1447,7 +1447,7 @@ begin
 	MCCanvasPatternScaleWithList(mPattern, mScale)
 end syntax
 
-/*
+/**
 Summary:	Apply a rotation to a pattern.
 
 mPattern:	An expression which evaluates to a pattern.
@@ -1473,7 +1473,7 @@ begin
 	MCCanvasPatternRotate(mPattern, mRotation)
 end syntax
 
-/*
+/**
 Summary:	Apply a translation to a pattern.
 
 mPattern:	An expression which evaluates to a pattern.
@@ -1517,7 +1517,7 @@ end syntax
 public foreign handler MCCanvasGradientStopMake(in pOffset as CanvasFloat, in pColor as Color, out rStop as GradientStop) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasGradientMakeWithRamp(in pType as LCInt, in pRamp as List, out rGradient as Gradient) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Creates a new gradient stop.
 
 mOffset:	An expression which evaluates to a number.
@@ -1548,7 +1548,7 @@ begin
 	MCCanvasGradientStopMake(mOffset, mColor, output)
 end syntax
 
-/*
+/**
 Summary:	Creates a new gradient paint.
 
 mRamp:		An expression which evaluates to a list of gradient stops.
@@ -1608,7 +1608,7 @@ public foreign handler MCCanvasGradientSetVia(in pVia as Point, inout xGradient 
 public foreign handler MCCanvasGradientGetTransform(in pGradient as Gradient, out rTransform as Transform) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasGradientSetTransform(in pTransform as Transform, inout xGradient as Gradient) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The offset of a gradient stop value.
 
 mStop:		An expression which evaluates to a gradient stop.
@@ -1636,7 +1636,7 @@ begin
 	MCCanvasGradientStopSetOffset(input, mStop)
 end syntax
 
-/*
+/**
 Summary:	The color of a gradient stop value.
 
 mStop:		An expression which evaluates to a gradient stop.
@@ -1664,7 +1664,7 @@ begin
 	MCCanvasGradientStopSetColor(input, mStop)
 end syntax
 
-/*
+/**
 Summary:	The ramp of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1696,7 +1696,7 @@ begin
 	MCCanvasGradientSetRamp(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The type of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1725,7 +1725,7 @@ begin
 	MCCanvasGradientSetTypeAsString(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The repeat count of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1754,7 +1754,7 @@ begin
 	MCCanvasGradientSetRepeat(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The wrap of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1781,7 +1781,7 @@ begin
 	MCCanvasGradientSetWrap(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The mirror of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1808,7 +1808,7 @@ begin
 	MCCanvasGradientSetMirror(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The from point of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1836,7 +1836,7 @@ begin
 	MCCanvasGradientSetFrom(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The to point of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1864,7 +1864,7 @@ begin
 	MCCanvasGradientSetTo(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The via point of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1892,7 +1892,7 @@ begin
 	MCCanvasGradientSetVia(input, mGradient)
 end syntax
 
-/*
+/**
 Summary:	The transform of a gradient paint.
 
 mGradient:		An expression which evaluates to a gradient.
@@ -1943,7 +1943,7 @@ public foreign handler MCCanvasGradientRotate(inout xGradient as Gradient, in pR
 public foreign handler MCCanvasGradientTranslate(inout xGradient as Gradient, in pX as CanvasFloat, in pY as CanvasFloat) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasGradientTranslateWithList(inout xGradient as Gradient, in pTranslation as List) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Add a new stop to the ramp of a gradient paint.
 
 mStop:	An expression which evaluates to a gradient stop
@@ -1969,7 +1969,7 @@ begin
 	MCCanvasGradientAddStop(mStop, mGradient)
 end syntax
 
-/*
+/**
 Summary:	Apply a transform to a gradient paint.
 
 mTransform:	An expression which evaluates to a transform.
@@ -1994,7 +1994,7 @@ begin
 	MCCanvasGradientTransform(mGradient, mTransform)
 end syntax
 
-/*
+/**
 Summary:	Apply a scale to a gradient paint.
 
 mScale:	An expression which evaluates to a list of numbers.
@@ -2019,7 +2019,7 @@ begin
 	MCCanvasGradientScaleWithList(mGradient, mScale)
 end syntax
 
-/*
+/**
 Summary:	Apply a rotation to a gradient paint.
 
 mRotation:	An expression which evaluates to a number.
@@ -2044,7 +2044,7 @@ begin
 	MCCanvasGradientRotate(mGradient, mRotation)
 end syntax
 
-/*
+/**
 Summary:	Apply a translation to a gradient paint.
 
 mTranslation:	An expression which evaluates to a list of numbers.
@@ -2083,7 +2083,7 @@ public foreign handler MCCanvasImageMakeWithPixelsWithSizeAsList(in pSize as Lis
 
 //////////
 
-/*
+/**
 Summary:	Creates a new image.
 
 mPath:		An expression which evaluates to a string.
@@ -2106,7 +2106,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new image.
 
 mResource:		An expression which evaluates to a string.
@@ -2128,7 +2128,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new image.
 
 mData:	An expression which evaluates to binary data
@@ -2153,7 +2153,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new image using raw pixel data.
 
 mSize:		An expression which evaluates to a list of integers.
@@ -2192,7 +2192,7 @@ public foreign handler MCCanvasImageGetPixels(in pImage as Image, out rPixels as
 
 //////////
 
-/*
+/**
 Summary:	The width of an image.
 
 mImage:		An expression which evaluates to an image.
@@ -2218,7 +2218,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The height of an image.
 
 mImage:		An expression which evaluates to an image.
@@ -2252,7 +2252,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The pixel data of an image.
 
 mImage:		An expression which evaluates to an image.
@@ -2325,7 +2325,7 @@ public foreign handler MCCanvasPathMakeWithInstructionsAsString(in pString as St
 
 //////////
 
-/*
+/**
 Summary:	Creates a new empty path.
 
 Returns:	An empty path.
@@ -2349,7 +2349,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mInstructions:	An expression which evaluates to a string.
@@ -2391,7 +2391,7 @@ public foreign handler MCCanvasPathMakeWithSegmentWithRadiiAsList(in pCenter as 
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mRect: An expression which evaluates to a rectangle.
@@ -2426,7 +2426,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mRect: An expression which evaluates to a rectangle.
@@ -2448,7 +2448,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mCenter:	An expression which evaluates to a point.
@@ -2471,7 +2471,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mCenter:	An expression which evaluates to a point.
@@ -2494,7 +2494,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mFrom:	An expression which evaluates to a point.
@@ -2517,7 +2517,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mPoints:	An expression which evaluates to a list of points.
@@ -2544,7 +2544,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mCenter:	An expression which evaluates to a point.
@@ -2575,7 +2575,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mCenter:	An expression which evaluates to a point.
@@ -2606,7 +2606,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new path.
 
 mCenter:	An expression which evaluates to a point.
@@ -2646,7 +2646,7 @@ public foreign handler MCCanvasPathGetInstructionsAsString(in pPath as Path, out
 
 //////////
 
-/*
+/**
 Summary:	The subpaths of a path.
 
 mPath:		An expression which evaluates to a path.
@@ -2678,7 +2678,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The bounding box of a path.
 
 mPath:		An expression which evaluates to a path.
@@ -2704,7 +2704,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The instructions of a path.
 
 mPath:		An expression which evaluates to a path.
@@ -2756,7 +2756,7 @@ public foreign handler MCCanvasPathClosePath(inout xPath as Path) returns nothin
 
 //////////
 
-/*
+/**
 Summary:	Move to a new point on a path.
 
 mPath:		An expression which evaluates to a path.
@@ -2791,7 +2791,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Adds a line to a path.
 
 mPath:		An expression which evaluates to a path.
@@ -2820,7 +2820,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Adds a curve to a path.
 
 mThroughA:		An expression which evaluates to a point.
@@ -2853,7 +2853,7 @@ begin
 	MCCanvasPathCurveThroughPoints(mThroughA, mThroughB, mTo, mPath)
 end syntax
 
-/*
+/**
 Summary:	Adds an arc to a path.
 
 mThrough:		An expression which evaluates to a point.
@@ -2889,7 +2889,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Adds an arc to a path.
 
 mEnd:		An expression which evaluates to a point.
@@ -2924,7 +2924,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Adds an arc to a path.
 
 mEnd:		An expression which evaluates to a point.
@@ -2971,7 +2971,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Closes the current subpath of a path.
 
 mPath:		An expression which evaluates to a path.
@@ -3002,7 +3002,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Apply a transform to a path.
 
 mTransform:	An expression which evaluates to a transform.
@@ -3028,7 +3028,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Apply a scale to a path.
 
 mScale:	An expression which evaluates to a list of numbers.
@@ -3054,7 +3054,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Apply a rotation to a path.
 
 mRotation:	An expression which evaluates to a number.
@@ -3080,7 +3080,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Apply a translation to a path.
 
 mTranslation:	An expression which evaluates to a list of numbers.
@@ -3107,7 +3107,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Extend a path by adding another path.
 
 mSource:		An expression which evaluates to a path.
@@ -3152,7 +3152,7 @@ public foreign handler MCCanvasEffectMake(in pType as LCInt, out rEffect as Effe
 
 //////////
 
-/*
+/**
 Summary:	Creates a new effect.
 
 mType:		One of color overlay, inner shadow, outer shadow, inner glow, outer glow.
@@ -3173,7 +3173,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Creates a new effect.
 
 mType:		One of color overlay, inner shadow, outer shadow, inner glow, outer glow.
@@ -3232,7 +3232,7 @@ public foreign handler MCCanvasEffectSetSourceAsString(in pSource as String, ino
 
 //////////
 
-/*
+/**
 Summary:	The type of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3258,7 +3258,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The color of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3289,7 +3289,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The blend mode of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3321,7 +3321,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The size of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3352,7 +3352,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The spread of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3383,7 +3383,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The distance of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3414,7 +3414,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The angle of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3445,7 +3445,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The knockout of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3476,7 +3476,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The source of an effect.
 
 mEffect:		An expression which evaluates to an effect.
@@ -3517,7 +3517,7 @@ public foreign handler MCCanvasFontMakeWithSize(in pName as String, in pBold as 
 
 //////////
 
-/*
+/**
 Summary:	Creates a new instance of the named font.
 
 mName:		An expression which evaluates to a string.
@@ -3539,7 +3539,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new instance of the named font.
 
 mName:		An expression which evaluates to a string.
@@ -3562,7 +3562,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new instance of the named font.
 
 mName:		An expression which evaluates to a string.
@@ -3584,7 +3584,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Creates a new instance of the named font.
 
 mName:		An expression which evaluates to a string.
@@ -3621,7 +3621,7 @@ public foreign handler MCCanvasFontSetSize(in pSize as LCUInt, inout xFont as Fo
 
 //////////
 
-/*
+/**
 Summary:	The name of a font.
 
 mFont:		An expression which evaluates to a font.
@@ -3651,7 +3651,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The bold setting of a font.
 
 mFont:		An expression which evaluates to a font.
@@ -3677,7 +3677,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The italic setting of a font.
 
 mFont:		An expression which evaluates to a font.
@@ -3703,7 +3703,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The size of a font.
 
 mFont:		An expression which evaluates to a font.
@@ -3739,7 +3739,7 @@ public foreign handler MCCanvasFontMeasureTextImageBoundsOnCanvas(in pText as St
 
 //////////
 
-/*
+/**
 Summary:	Measure text when drawn with a font.
 
 mText:	An expression which evaluates to a string.
@@ -3770,7 +3770,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Measure text when drawn to a canvas.
 
 mText:	An expression which evaluates to a string.
@@ -3799,7 +3799,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Measure text precisely when drawn with a font.
 
 mText:	An expression which evaluates to a string.
@@ -3830,7 +3830,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Measure text precisely when drawn to a canvas.
 
 mText:	An expression which evaluates to a string.
@@ -3905,7 +3905,7 @@ public foreign handler MCCanvasGetClipBounds(in pCanvas as Canvas, out rBounds a
 
 //////////
 
-/*
+/**
 Summary:	The current paint of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -3927,7 +3927,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current fill rule of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -3949,7 +3949,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current antialias setting of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -3971,7 +3971,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current opacity setting of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -3993,7 +3993,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current blend mode of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4015,7 +4015,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current stippled setting of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4038,7 +4038,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current image resize quality of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4060,7 +4060,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current stroke width of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4082,7 +4082,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current font of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4104,7 +4104,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current join style of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4127,7 +4127,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current cap style of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4150,7 +4150,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current miter limit of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4173,7 +4173,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current dashes of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4196,7 +4196,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current dash phase of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4220,7 +4220,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	The current clipping bounds of the canvas.
 
 mCanvas:	An expression which evaluates to a canvas.
@@ -4281,7 +4281,7 @@ public foreign handler MCCanvasMeasureText(in pText as String, in pCanvas as Can
 
 //////////
 
-/*
+/**
 Summary:	Apply a transform to a canvas.
 
 mTransform:	An expression which evaluates to a transform.
@@ -4303,7 +4303,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Apply a scale to a canvas.
 
 mScale:	An expression which evaluates to a list of numbers.
@@ -4325,7 +4325,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Apply a rotation to a canvas.
 
 mRotation:	An expression which evaluates to a number.
@@ -4347,7 +4347,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Apply a translation to a canvas.
 
 mTranslation:	An expression which evaluates to a list of numbers.
@@ -4370,7 +4370,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Save the current state of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4400,7 +4400,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Restore the previously saved state of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4430,7 +4430,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Begin a new drawing layer on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4467,7 +4467,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	End the current drawing layer on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4502,7 +4502,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Fill a path on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4534,7 +4534,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Stroke a path on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4566,7 +4566,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Clip to a rectangle on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4591,7 +4591,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Add a path to a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4615,7 +4615,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Draw an image on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4652,7 +4652,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Move to a point on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4679,7 +4679,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Add a line to a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4707,7 +4707,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Add a curve to a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4738,7 +4738,7 @@ begin
 	MCCanvasCurveThroughPoints(mThroughA, mThroughB, mPoint, mCanvas)
 end syntax
 
-/*
+/**
 Summary:	Closes the current subpath of a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4768,7 +4768,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Render filled text on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4794,7 +4794,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Render filled text on a canvas.
 
 mCanvas:		An expression which evaluates to a canvas.
@@ -4820,7 +4820,7 @@ end syntax
 
 //////////
 
-/*
+/**
 Summary:	Measure text when drawn to a canvas.
 
 mText:	An expression which evaluates to a string.
@@ -4853,7 +4853,7 @@ public foreign handler MCCanvasGetPixelWidthOfCanvas(in pCanvas as Canvas, out r
 
 //////////
 
-/*
+/**
 Summary:	The canvas used when drawing a widget.
 
 Returns:	The target canvas for widget drawing operations.

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library provides operations for interacting with LiveCode Script from LiveCode Builder.
 
 Tags: Engine
@@ -63,7 +63,7 @@ public foreign handler MCEngineRemoveRunloopAction(in pAction as MCRunloopAction
 public foreign handler MCEngineRunloopWait() returns CBool binds to "<builtin>"
 public foreign handler MCEngineRunloopBreakWait() returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Resolves a string to a script object.
 Object:		The string describing the script object.
 
@@ -93,7 +93,7 @@ begin
     MCEngineExecResolveScriptObject(Object)
 end syntax
 
-/*
+/**
 Summary:	Tests the existence of a script object.
 Object:		An expression that evaluates to a <ScriptObject>.
 
@@ -121,7 +121,7 @@ begin
     MCEngineEvalScriptObjectExists(Object, output)
 end syntax
 
-/*
+/**
 Summary:	Tests the existence of a script object.
 Object:		An expression that evaluates to a <ScriptObject>.
 
@@ -147,7 +147,7 @@ begin
     MCEngineEvalScriptObjectDoesNotExist(Object, output)
 end syntax
 
-/*
+/**
 Summary:	The property of a script object.
 Property: 	The name of the property to manipulate
 Object:		An expression that evaluates to a <ScriptObject>.
@@ -179,7 +179,7 @@ begin
     MCEngineExecSetPropertyOfScriptObject(input, Property, Object)
 end syntax
 
-/*
+/**
 Summary:	Get the parent object of a script object.
 Object:		An expression that evaluates to a <ScriptObject>.
 The result:	The <ScriptObject> that is the owner of <Object>.
@@ -207,7 +207,7 @@ begin
 	MCEngineEvalOwnerOfScriptObject(Object, output)
 end syntax
 
-/*
+/**
 Summary:	Get the child objects of a script object.
 Object:		An expression that evaluates to a <ScriptObject>
 The result:	A list of <ScriptObject>s that are contained within <Object>.
@@ -238,7 +238,7 @@ begin
 	MCEngineEvalChildrenOfScriptObject(Object, output)
 end syntax
 
-/*
+/**
 Summary: 	Send a message to a script object.
 Message: 	The message to dispatch.
 Object:		The script object to dispatch the message to.
@@ -279,7 +279,7 @@ begin
     MCEngineExecSendToScriptObjectWithArguments(IsFunction, Message, Object, Arguments)
 end syntax
 
-/*
+/**
 Summary: 	Post a message to a script object.
 Message: 	The message to dispatch.
 Object:		The script object to dispatch the message to.
@@ -303,7 +303,7 @@ begin
     MCEngineExecPostToScriptObjectWithArguments(Message, Object, Arguments)
 end syntax
 
-/*
+/**
 Summary: 	Determines whether a message was handled
 
 Example:
@@ -325,7 +325,7 @@ begin
     MCEngineEvalMessageWasHandled(output)
 end syntax
 
-/*
+/**
 Summary: 	Determines whether a message was handled
 
 Example:
@@ -346,7 +346,7 @@ begin
     MCEngineEvalMessageWasNotHandled(output)
 end syntax
 
-/*
+/**
 Summary: 	Executes some LiveCode script.
 Script: 	The script to execute.
 
@@ -373,7 +373,7 @@ begin
     MCEngineExecExecuteScript(Script)
 end syntax
 
-/*
+/**
 Summary: 	Logs a string.
 String:		The string to log.
 Arguments:	A list of arguments.

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the operations on widgets provided by LiveCode Builder.
 
 Tags: Widget
@@ -384,7 +384,7 @@ public foreign handler MCWidgetExecSendWithArguments(in pIsFunction as CBool, in
 public foreign handler MCWidgetExecPost(in pMessage as String) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetExecPostWithArguments(in pMessage as String, in pArguments as optional List) returns nothing binds to "<builtin>"
 
-/* 
+/**
 Summary:	Redraws the widget.
 
 Example:
@@ -413,7 +413,7 @@ begin
   MCWidgetExecRedrawAll()
 end syntax
 
-/* 
+/**
 Summary:	Schedules a timer.
 Time:		An expression which evaluates to a number.
 
@@ -436,7 +436,7 @@ begin
   MCWidgetExecScheduleTimerIn(Time)
 end syntax
 
-/* 
+/**
 Summary:	Cancels a timer.
 
 Example:
@@ -457,7 +457,7 @@ begin
   MCWidgetExecCancelTimer()
 end syntax
 
-/* 
+/**
 Summary:	Determines whether the IDE is in edit mode.
 */	
 
@@ -468,7 +468,7 @@ begin
   MCWidgetEvalInEditMode(output)
 end syntax
 
-/* 
+/**
 Summary:	Sends a message to the widget script object.
 */	
 
@@ -479,7 +479,7 @@ begin
     MCWidgetExecSendWithArguments(IsFunction, Message, Arguments)
 end syntax
 
-/* 
+/**
 Summary:	Posts a message to the widget script object.
 */	
 
@@ -503,7 +503,7 @@ public foreign handler MCWidgetGetMyEnabled(out rEnabled as CBool) returns nothi
 public foreign handler MCWidgetGetMyDisabled(out rDisabled as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetMyPaint(in pPaintType as CUInt, out rPaint as Paint) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Returns the widget script object.
 
 Returns:	The widget script object.
@@ -515,7 +515,7 @@ begin
     MCWidgetGetMyScriptObject(output)
 end syntax
 
-/*
+/**
 Summary:	Returns the name of the widget's script object
 
 Returns:	The name of the widget's script object
@@ -527,7 +527,7 @@ begin
 	MCWidgetGetMyName(output)
 end syntax
 
-/*
+/**
 Summary:	Returns the rectangle of the widget in the parent
 
 Returns:	The rectangle of the widget in the parent
@@ -539,7 +539,7 @@ begin
     MCWidgetGetMyRectangle(output)
 end syntax
 
-/* 
+/**
 Summary:	Returns the bounds of the widget.
 
 Returns:	The bounds of the widget.
@@ -551,7 +551,7 @@ begin
     MCWidgetGetMyBounds(output)
 end syntax
 
-/*
+/**
 Summary:	Returns the width of the widget.
 
 Returns:	The width of the widget.
@@ -563,7 +563,7 @@ begin
     MCWidgetGetMyWidth(output)
 end syntax
 
-/*
+/**
 Summary:	Returns the height of the widget.
 
 Returns:	The height of the widget.
@@ -575,7 +575,7 @@ begin
     MCWidgetGetMyHeight(output)
 end syntax
 
-/*
+/**
 Summary:    Returns the font of the widget.
 
 Returns:    The font of the widget
@@ -590,7 +590,7 @@ begin
     MCWidgetGetMyFont(output)
 end syntax
 
-/*
+/**
 Summary:    Returns the enabled state of the widget.
 
 Returns:    The enabled state of the widget.
@@ -601,7 +601,7 @@ begin
     MCWidgetGetMyEnabled(output)
 end syntax
 
-/*
+/**
 Summary:    Returns the disabled state of the widget.
 
 Returns:    The disabled state of the widget.
@@ -612,7 +612,7 @@ begin
     MCWidgetGetMyDisabled(output)
 end syntax
 
-/*
+/**
 Summary:    Returns a particular paint of the widget.
 
 Returns:    The current setting of the specified paint of the widget.
@@ -648,7 +648,7 @@ public foreign handler MCWidgetGetClickCount(in pCurrent as CBool, out rCount as
 --public foreign handler MCWidgetGetMouseButtonState(in pIndex as LCUInt, out rPressed /*as PressedState*/) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetModifierKeys(in pCurrent as CBool, out rKeys as List) returns nothing binds to "<builtin>"
 
-/* 
+/**
 Summary:		Determines the location of the mouse pointer relative to the widget.
 
 Returns:		The location of the mouse pointer.
@@ -674,7 +674,7 @@ begin
     MCWidgetGetMousePosition(IsCurrent, output)
 end syntax
 
-/*
+/**
 Summary:		Determines the location of a mouse click.
 
 Returns:		The location of the mouse pointer when it was clicked.
@@ -700,7 +700,7 @@ begin
     MCWidgetGetClickPosition(IsCurrent, output)
 end syntax
 
-/*
+/**
 Summary:        Determines the mouse button which started the mouse click.
 
 Returns:        The index of the mouse button which started the mouse click.
@@ -721,7 +721,7 @@ begin
     MCWidgetGetClickButton(IsCurrent, output)
 end syntax
 
-/*
+/**
 Summary:        Determines the number of successive clicks within the click distance.
 
 Returns:        The number of clicks which have occured since the initial click within the standard 'click distance' from the original point.
@@ -783,7 +783,7 @@ end syntax*/
 public foreign handler MCWidgetEvalIsPointWithinRect(in pPoint as Point, in pRect as Rectangle, out rWithin as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetEvalIsPointNotWithinRect(in pPoint as Point, in pRect as Rectangle, out rNotWithin as CBool) returns nothing binds to "<builtin>"
 
-/* 
+/**
 Summary:	Determines whether a point is within a rectangle.
 Point:		An expression that evaluates to a Point.
 Rect: 		An expression that evaluates to a Rectangle.
@@ -806,7 +806,7 @@ begin
     MCWidgetEvalIsPointWithinRect(Point, Rect, output)
 end syntax
 
-/* 
+/**
 Summary:	Determines whether a point is within a rectangle.
 Point:		An expression that evaluates to a Point.
 Rect: 		An expression that evaluates to a Rectangle.
@@ -838,7 +838,7 @@ public foreign handler MCWidgetExecClosePopup() returns nothing binds to "<built
 public foreign handler MCWidgetExecClosePopupWithResult(in pResult as any) returns nothing binds to "<builtin>"
 
 
-/*
+/**
 Summary:	Displays a popup menu.
 Menu:		An expression that evaluates to a string, which describes the menu items.
 Location:	An expression that evaluates to a <Point> relative to the current widget. The topleft corner of the popup window will be placed here.
@@ -872,7 +872,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Opens a widget within a popup window.
 Kind:		The unique identifier of the widget to use for the popup.
 Location:	An expression that evaluates to a <Point> relative to the current widget. The topleft corner of the popup window will be placed here.
@@ -915,7 +915,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Tests if the current widget is in a popup window.
 Resturns:	True if the current widget is in a popup window, False otherwise.
 
@@ -959,7 +959,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Closes the current widget popup.
 Result:		An expression that evaluates to any type. The result of popping up this widget.
 
@@ -1056,7 +1056,7 @@ public foreign handler MCWidgetSetAnnotationOfWidget(in pValue as optional any, 
 
 //
 
-/*
+/**
 Summary: The child widget that started the current execution.
 Returns: A widget object.
 
@@ -1113,7 +1113,7 @@ end syntax
 
 //
 
-/*
+/**
 Summary: The currently placed child widgets of this widget.
 Returns: A list of the child widgets of this widget.
 
@@ -1149,7 +1149,7 @@ begin
     MCWidgetEvalMyChildren(output)
 end syntax
 
-/*
+/**
 Summary: Create a widget object of the specified kind
 
 Returns: A widget object.
@@ -1170,7 +1170,7 @@ begin
     MCWidgetEvalANewWidget(mKind, output)
 end syntax
 
-/*
+/**
 Summary: Add a child widget to the parent.
 
 mWidget: The child widget object.
@@ -1191,7 +1191,7 @@ begin
     MCWidgetExecPlaceWidget(mWidget)
 end syntax
 
-/*
+/**
 Summary: Add a child widget to the parent on the top or bottom layer
 
 mWidget: The child widget object.
@@ -1212,7 +1212,7 @@ begin
     MCWidgetExecPlaceWidgetAt(mWidget, mAtBottom)
 end syntax
 
-/*
+/**
 Summary: Add a child widget to the parent on a layer relative to that of a previously placed child.
 
 mWidget: The child widget object.
@@ -1239,7 +1239,7 @@ begin
     MCWidgetExecPlaceWidgetRelative(mWidget, mIsBelow, mOtherWidget)
 end syntax
 
-/*
+/**
 Summary: Remove a child widget from the parent.
 
 mWidget: The child widget object.
@@ -1276,7 +1276,7 @@ end syntax
 
 //
 
-/*
+/**
 Summary: Manipulates a property implemented by a child widget.
 
 mName: The name of a property declared by <mWidget>
@@ -1303,7 +1303,7 @@ begin
 	MCWidgetSetPropertyOfWidget(input, mName, mWidget)
 end syntax
 
-/*
+/**
 Summary: Manipulates the rectangle property of a child widget
 
 mWidget: The child widget object
@@ -1334,7 +1334,7 @@ begin
 	MCWidgetSetRectangleOfWidget(input, mWidget)
 end syntax
 
-/*
+/**
 Summary: Manipulates the height property of a child widget
 
 mWidget: The child widget object
@@ -1365,7 +1365,7 @@ begin
 	MCWidgetSetWidthOfWidget(input, mWidget)
 end syntax
 
-/*
+/**
 Summary: Manipulates the height property of a child widget
 
 mWidget: The child widget object
@@ -1396,7 +1396,7 @@ begin
 	MCWidgetSetHeightOfWidget(input, mWidget)
 end syntax
 
-/*
+/**
 Summary: Manipulates the location property of a child widget
 
 mWidget: The child widget object
@@ -1427,7 +1427,7 @@ begin
 	MCWidgetSetLocationOfWidget(input, mWidget)
 end syntax
 
-/*
+/**
 Summary: Manipulates the enabled property of a child widget
 
 mWidget: The child widget object
@@ -1458,7 +1458,7 @@ begin
 	MCWidgetSetEnabledOfWidget(input, mWidget)
 end syntax
 
-/*
+/**
 Summary: Manipulates the disabled property of a child widget
 
 mWidget: The child widget object
@@ -1498,7 +1498,7 @@ end syntax
 
 //
 
-/*
+/**
 Summary: Manipulates an annotation of a child widget
 
 Example:

--- a/extensions/libraries/canvas/canvas.lcb
+++ b/extensions/libraries/canvas/canvas.lcb
@@ -17,7 +17,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 -- Library modules add public handlers to the bottom of the message path.
 --
-/* 
+/**
 This simple library gives access to the LiveCode Builder canvas syntax from LiveCode Script by wrapping in a few simple handlers.
 
 	Example usage:
@@ -47,7 +47,7 @@ use com.livecode.engine
 -- We store the current canvas in a module-scope variable.
 variable sCanvas as optional Canvas
 
-/*
+/**
 Summary: Creates a canvas of the given size for the other handlers to use.
 pWidth:  The width of the created canvas.
 pHeight:  The height of the created canvas.
@@ -64,7 +64,7 @@ public handler canvasCreate(in pWidth as Integer, in pHeight as Integer) returns
   fill rectangle path of rectangle [ 0, 0, pWidth, pHeight ] on sCanvas
 end handler
 
-/*
+/**
 Summary: Destroys the canvas 
 
 Description:
@@ -75,7 +75,7 @@ public handler canvasDestroy() returns nothing
   put nothing into sCanvas
 end handler
 
-/*
+/**
 Summary: Sets the current color of the canvas to the given RGBA value.
 pRed: The red component of the color to set.
 pGreen: The green component of the color to set.
@@ -89,7 +89,7 @@ public handler canvasSetColor(in pRed as Real, in pGreen as Real, in pBlue as Re
   set the paint of sCanvas to solid paint with color [pRed, pGreen, pBlue, pAlpha]
 end handler
 
-/*
+/**
 Summary: Draws a filled circle.
 pX: The x-coordinate of the centre of the circle.
 pY: The y-coordinate of the centre of the circle.
@@ -101,7 +101,7 @@ public handler canvasFillCircle(in pX as Real, in pY as Real, in pRadius as Real
   fill circle path centered at point [pX, pY] with radius pRadius on sCanvas
 end handler
 
-/*
+/**
 Summary: Copies the current contents of the canvas to the specified image object.
 pObjectId: A string which is an object chunk referring to an image.
 

--- a/extensions/libraries/iconsvg/iconsvg.lcb
+++ b/extensions/libraries/iconsvg/iconsvg.lcb
@@ -15,7 +15,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This is an SVG icon path library.
 */
 
@@ -1369,7 +1369,7 @@ private handler initialiseIcons() returns nothing
 	end repeat
 end handler
 
-/*
+/**
 Returns the available icons in the default icon family.
 
 Returns: The names of the icons for which SVG paths are available, one per line.
@@ -1450,7 +1450,7 @@ private handler resolveIconName(in pName as String) returns optional List
 	return [tFamily, tName]
 end handler
 
-/*
+/**
 Returns the SVG path for the given icon.
 
 pName: The name of the icon
@@ -1474,7 +1474,7 @@ public handler iconSVGPathFromName(in pName as String) returns String
 	return sFontArray[tResolved[1]][tResolved[2]]["svg"]
 end handler
 
-/*
+/**
 Returns the codepoint corresponding to the given icon in the fontawesome font.
 
 pName: The name of the icon

--- a/extensions/libraries/json/json.lcb
+++ b/extensions/libraries/json/json.lcb
@@ -15,7 +15,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library provides support for generating and parsing JavaScript Object
 Notation (JSON) data.  See also <http://json.org>.
 
@@ -78,7 +78,7 @@ constant kParseObjectValue is 23
 constant kParseObjectNext is 24
 
 
-/*
+/**
 Summary: Parse JSON text into a LiveCode value.
 
 pJson:   String containing JSON text
@@ -483,7 +483,7 @@ private handler JsonExportArray(in pValue as Array) returns String
 	return tResult
 end handler
 
-/*
+/**
 Summary: Format a LiveCode value as JSON text
 
 pValue:  A LiveCode value (Array, List, String, Number, Boolean, or nothing)

--- a/extensions/modules/widget-utils/widget-utils.lcb
+++ b/extensions/modules/widget-utils/widget-utils.lcb
@@ -15,7 +15,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 A library of utility handlers for functions commonly needed by widgets.
 */
 
@@ -28,7 +28,7 @@ metadata version is "1.0.0"
 metadata author is "LiveCode"
 metadata title is "Widget Utilities"
 
-/*
+/**
 Summary: Scales and translates a path to fit within a rectangle
 
 Parameters:
@@ -100,7 +100,7 @@ public handler constrainPathToRect(in pTargetRect as Rectangle, inout xPath as P
 	translate xPath by [tXTranslate + tXDiff, tYTranslate + tYDiff]
 end handler
 
-/*
+/**
 Summary: Formats an integer as a string
 
 Parameters:
@@ -128,7 +128,7 @@ public handler intToString(in pNumber as Number) returns String
 	return char 1 to tDotIndex - 1 of tFormatted
 end handler 
 
-/*
+/**
 Summary: Removes any superfluous zeros and decimal places.
 
 Parameters:
@@ -165,7 +165,7 @@ private handler colorComponentToString(in pComponent as Number)
 	return intToString(the rounded of (pComponent * 255))	
 end handler
 
-/*
+/**
 Summary: Converts a color to a string representing the color
 
 Parameters:
@@ -214,7 +214,7 @@ private handler stringToColorComponent(in pComponent as String)
 	return (pComponent parsed as number) / 255
 end handler
 
-/*
+/**
 Summary: Converts a string to a color
 
 Parameters:
@@ -253,7 +253,7 @@ public handler stringToColor(in pString as String) returns Color
 	return color tColor
 end handler
 
-/*
+/**
 Summary: Get the canonical name of the current "native" mobile theme
 
 Example:

--- a/libscript/src/arithmetic.lcb
+++ b/libscript/src/arithmetic.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*  
+/**
 This library consists of the basic arithmetic operations of standard library of LiveCode Builder.
 */
 
@@ -94,7 +94,7 @@ public foreign handler MCArithmeticExecParseListOfStringAsListOfNumber(in Target
 
 --
 
-/*
+/**
 Summary:    Adds <Value> to <Target>.
 Target:     An expression that evaluates to a numeric container.
 Value:      An expression that evaluates to a number.   
@@ -119,7 +119,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:    Subtracts <Value> from <Target>.
 Target:     An expression that evaluates to a numeric variable.
 Value:      An expression that evaluates to a number.   
@@ -143,7 +143,7 @@ begin
     MCArithmeticExecSubtractNumberFromNumber(Value, Target)
 end syntax
 
-/*
+/**
 Summary:    Multiplies <Target> by <Value>.
 Target:     An expression that evaluates to a numeric variable.
 Value:      An expression that evaluates to a number.   
@@ -167,7 +167,7 @@ begin
     MCArithmeticExecMultiplyNumberByNumber(Target, Value)
 end syntax
 
-/*
+/**
 Summary:    Divides <Target> by <Value>.
 Target:     An expression that evaluates to a numeric variable.
 Value:      An expression that evaluates to a number.   
@@ -193,7 +193,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Unary plus operator.
 Operand:    An expression that evaluates to a number.
 
@@ -215,7 +215,7 @@ begin
     MCArithmeticEvalPlusNumber(Operand, output)
 end syntax
 
-/*
+/**
 Summary:    Unary minus operator.
 Operand:    An expression that evaluates to a number.
 
@@ -236,7 +236,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Binary plus operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -256,7 +256,7 @@ begin
     MCArithmeticEvalNumberPlusNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Binary minus operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -276,7 +276,7 @@ begin
     MCArithmeticEvalNumberMinusNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Binary multiplication operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -297,7 +297,7 @@ begin
     MCArithmeticEvalNumberTimesNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Binary division operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -319,7 +319,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Mod operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -341,7 +341,7 @@ begin
     MCArithmeticEvalNumberModNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Wrap operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -371,7 +371,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Greater than relation.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -385,7 +385,7 @@ begin
     MCArithmeticEvalNumberIsGreaterThanNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Greater than or equal to relation.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -399,7 +399,7 @@ begin
     MCArithmeticEvalNumberIsGreaterThanOrEqualToNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Less than relation.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -417,7 +417,7 @@ begin
     MCArithmeticEvalNumberIsLessThanNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Less than or equal to relation.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -438,7 +438,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Equal to relation.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -456,7 +456,7 @@ begin
     MCArithmeticEvalEqualToNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines if <Left> is <Right>.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -477,7 +477,7 @@ begin
     MCArithmeticEvalEqualToNumber(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines if <Left> is not <Right>.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -500,7 +500,7 @@ begin
 end syntax
 
 
-/*
+/**
 Summary:	Formats a numeric value as a string
 
 Operand:	An expression that evaluates to a number.
@@ -523,7 +523,7 @@ begin
     MCArithmeticEvalNumberFormattedAsString(Operand, output)
 end syntax
 
-/*
+/**
 Summary:	Formats a numeric value as a string
 
 Operand:	An expression that evaluates to a number.
@@ -545,7 +545,7 @@ begin
     MCArithmeticExecFormatNumberAsString(Operand)
 end syntax
 
-/*
+/**
 Summary:	Parses a string as an number
 
 Operand:	An expression that evaluates to a string.
@@ -578,7 +578,7 @@ begin
     MCArithmeticEvalStringParsedAsNumber(Operand, output)
 end syntax
 
-/*
+/**
 Summary:	Parses a string as an number
 
 Operand:	An expression that evaluates to a string.
@@ -609,7 +609,7 @@ begin
     MCArithmeticExecParseStringAsNumber(Operand)
 end syntax
 
-/*
+/**
 Summary:	Parses a list of strings as a list of numbers
 
 Operand:	An expression that evaluates to a list of strings.
@@ -647,7 +647,7 @@ begin
     MCArithmeticEvalListOfStringParsedAsListOfNumber(Operand, output)
 end syntax
 
-/*
+/**
 Summary:	Parses a list of strings as a list of numbers
 
 Operand:	An expression that evaluates to a list of strings.

--- a/libscript/src/array.lcb
+++ b/libscript/src/array.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*  
+/**
 This library consists of the operations on arrays included in the standard library of LiveCode Builder.
 */
 
@@ -44,7 +44,7 @@ public foreign handler MCArrayDeleteElementOfCaseless(inout Target as Array, in 
 
 --
 
-/* 
+/**
 Summary:        Returns the keys of an array.
 Target:         An expression which evaluates to an array.
 
@@ -79,7 +79,7 @@ begin
     MCArrayEvalKeysOf(Target, output)
 end syntax
 
-/* 
+/**
 Summary:        Returns the elements of an array.
 Target:         An expression which evaluates to an array.
 
@@ -114,7 +114,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:        Returns the number of elements in <Target>
 Target:         An expression which evaluates to an array.
 
@@ -142,7 +142,7 @@ end syntax
 
 --
 
-/* 
+/**
 Summary:        Determines if an array has a given key
 Needle:         An expression which evaluates to an integer, string, or list of integers.
 Target:         An expression which evaluates to an array.
@@ -177,7 +177,7 @@ begin
     //MCArrayEvalIsAmongTheKeysOfMatrix(Needle, IsNot, Target, output)
 end syntax
 
-/* 
+/**
 Summary:        Determines if an array contains a given element
 Needle:         Any expression.
 Target:         An expression which evaluates to an array.
@@ -208,7 +208,7 @@ end syntax
 
 --
 
-/*
+/**
 
 Summary:            Designates the element with key <Key> in <Target>.
 Index: 				An expression which evaluates to a string.
@@ -237,7 +237,7 @@ end syntax
 
 --
 
-/*
+/**
 
 Summary:            Deletes the element with key <Key> in <Target>.
 Index: 				An expression which evaluates to a string.
@@ -264,7 +264,7 @@ end syntax
 
 --
 
-/* 
+/**
 
 Summary: 		Designates the array with no elements.
 
@@ -288,7 +288,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:        Repeat over the elements of an array.
 Iterand:        Any variable of appropriate type.
 
@@ -323,7 +323,7 @@ begin
     MCArrayRepeatForEachElement(iterator, Iterand, container)
 end syntax
 
-/*
+/**
 Summary:        Repeat over the keys of an array.
 Iterand:        A string container.
 

--- a/libscript/src/binary.lcb
+++ b/libscript/src/binary.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*  
+/**
 This library consists of the operations on binary strings provided by the standard library of LiveCode Builder.
 */
 
@@ -37,7 +37,7 @@ public foreign handler MCBinaryEvalIsGreaterThan(in Left as Data, in Right as Da
 public foreign handler MCDataEvalEmpty(out Value as Data) returns nothing binds to "<builtin>"
 --
 
-/*
+/**
 Summary:            Prepends <Source> bytes to <Target> bytes.
 
 Source: 			An expression which evaluates to binary data.
@@ -55,7 +55,7 @@ begin
     MCBinaryExecPutBytesBefore(Source, Target)
 end syntax
 
-/*
+/**
 Summary:            Appends <Source> bytes to <Target> bytes.
 
 Source: 			An expression which evaluates to binary data.
@@ -77,7 +77,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Concatenates <Left> and <Right>.
 
 Left: 				An expression which evaluates to binary data.
@@ -99,7 +99,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to binary data.
@@ -119,7 +119,7 @@ begin
     MCBinaryEvalIsEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to binary data.
@@ -139,7 +139,7 @@ begin
     MCBinaryEvalIsNotEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> is less than <Right> under a byte by byte comparison
 
 Left:       An expression which evaluates to binary data.
@@ -160,7 +160,7 @@ begin
     MCBinaryEvalIsLessThan(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> is greater than <Right> under a byte by byte comparison
 
 Left:       An expression which evaluates to binary data.
@@ -183,7 +183,7 @@ end syntax
 
 --
 
-/* 
+/**
 
 Summary: 		Designates data of length 0.
 

--- a/libscript/src/bitwise.lcb
+++ b/libscript/src/bitwise.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*  
+/**
 This module specifies the bitwise operations on integers included in the standard library of LiveCode Builder.
 */
 
@@ -32,7 +32,7 @@ public foreign handler MCBitwiseEvalBitwiseShiftRight(in Target as LCInt, in Shi
 
 --
 
-/*
+/**
 Summary:        Performs a bitwise AND operation on the binary representations of <Left> and <Right>.
 
 Left:           An expression which evaluates to an integer.
@@ -57,7 +57,7 @@ begin
     MCBitwiseEvalBitwiseAnd(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:        Performs a bitwise OR operation on the binary representations of <Left> and <Right>.
 
 Left:           An expression which evaluates to an integer.
@@ -82,7 +82,7 @@ begin
     MCBitwiseEvalBitwiseOr(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:        Performs a bitwise XOR operation on the binary representations of <Left> and <Right>.
 
 Left:           An expression which evaluates to an integer.
@@ -106,7 +106,7 @@ begin
     MCBitwiseEvalBitwiseXor(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:        Performs a bitwise NOT operation on the binary representation of <Operand>.
 
 Operand:        An expression which evaluates to an integer.
@@ -132,7 +132,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:	Shifts the bits of <Operand> left.
 
 Operand:        An expression which evaluates to an integer.
@@ -157,7 +157,7 @@ begin
     MCBitwiseEvalBitwiseShiftLeft(Operand, Shift, output)
 end syntax
 
-/*
+/**
 Summary:	Shifts the bits of <Operand> right.
 
 Operand:        An expression which evaluates to an integer.

--- a/libscript/src/byte.lcb
+++ b/libscript/src/byte.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*  
+/**
 This library consists of the operations on bytes included in the standard library of LiveCode Builder.
 */
 
@@ -61,7 +61,7 @@ public foreign handler MCByteEvalCodeOfByte(in Target as Data, out Result as LCU
 
 --
 
-/*
+/**
 Summary:            Counts the number of bytes in <Target>.
 
 Target: 			An expression which evaluates to binary data.
@@ -81,8 +81,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> within <Target>
 
 Needle: 			An expression which evaluates to binary data.
@@ -107,8 +106,7 @@ begin
     MCByteEvalOffsetOfBytes(IsLast, Needle, Target, output)
 end syntax
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> after a specified index in <Target>
 
 Needle: 			An expression which evaluates to binary data.
@@ -133,8 +131,7 @@ begin
 	MCByteEvalOffsetOfBytesAfter(IsLast, Needle, After, Target, output)
 end syntax
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> before a specified index in <Target>.
 
 Needle: 			An expression which evaluates to binary data.
@@ -159,7 +156,7 @@ begin
     MCByteEvalOffsetOfBytesBefore(IsFirst, Needle, Before, Target, output)
 end syntax
 
-/*
+/**
 Summary:            Determines whether <Needle> is in <Target>.
 Needle: 			An expression which evaluates to a single byte of binary data.
 Target: 			An expression which evaluates to binary data.
@@ -180,7 +177,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Determines whether <Needle> contains <Target>.
 Needle: 			An expression which evaluates to binary data.
 Target: 			An expression which evaluates to binary data.
@@ -199,7 +196,7 @@ begin
     MCByteEvalContainsBytes(Target, Needle, output)
 end syntax
 
-/*
+/**
 Summary:            Determines whether <Target> begins with <Needle>.
 Needle: 			An expression which evaluates to binary data.
 Target: 			An expression which evaluates to binary data.
@@ -218,7 +215,7 @@ begin
     MCByteEvalBeginsWithBytes(Target, Needle, output)
 end syntax
 
-/*
+/**
 Summary:            Determines whether <Target> ends with <Needle>.
 Needle: 			An expression which evaluates to binary data.
 Target: 			An expression which evaluates to binary data.
@@ -239,8 +236,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Designates the byte of data at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				An expression which evaluates to binary data.
@@ -260,8 +256,7 @@ begin
 	MCByteStoreByteOf(input, Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the bytes of data between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -283,8 +278,7 @@ begin
 	MCByteStoreByteRangeOf(input, Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the first byte of data in <Target>.
 Target:				An expression which evaluates to binary data.
 
@@ -303,8 +297,7 @@ begin
 	MCByteStoreFirstByteOf(input, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the first byte of data in <Target>.
 Target:				An expression which evaluates to binary data.
 
@@ -325,8 +318,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Deletes the byte of data at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				A container of binary data.
@@ -345,8 +337,7 @@ begin
 	MCByteExecDeleteByteOf(Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the bytes of data between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -367,8 +358,7 @@ begin
 	MCByteExecDeleteByteRangeOf(Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the first byte in <Target>.
 Target:				A binary data container.
 
@@ -387,8 +377,7 @@ begin
 end syntax
 
 
-/*
-
+/**
 Summary:            Deletes the last byte in <Target>.
 Target:				A binary data container.
 
@@ -408,7 +397,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:        Repeat over the bytes of some data
 Iterand:        A container of binary data.
 
@@ -426,7 +415,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:	Generate random data
 Count:		Expression evaluating to the number of bytes to generate
 
@@ -447,7 +436,7 @@ end syntax
 -- Conversion between bytes and numbers
 ----------------------------------------------------------------
 
-/*
+/**
 Summary:	Create a 1-byte data value from a number
 
 Value:		The value for the new data value
@@ -464,7 +453,7 @@ begin
 	MCByteEvalByteWithCode(Value, output)
 end syntax
 
-/*
+/**
 Summary:	Get the numeric value of a single byte.
 
 Target:	A 1-byte binary data value.

--- a/libscript/src/char.lcb
+++ b/libscript/src/char.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the operations on chars included in the standard library of LiveCode Builder.
 */
 
@@ -63,7 +63,7 @@ public foreign handler MCStringEvalCharWithCode(in pCode as LCUInt, out pChar as
 
 --
 
-/*
+/**
 Summary:            Counts the number of chars in <Target>.
 
 Target: 			An expression which evaluates to a string.
@@ -99,8 +99,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Designates the char at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				An expression which evaluates to a string.           
@@ -123,8 +122,7 @@ begin
 	MCCharStoreCharOf(input, Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the chars between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -149,8 +147,7 @@ begin
 	MCCharStoreCharRangeOf(input, Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the first char in <Target>.
 Target:				An expression which evaluates to a string.
 
@@ -176,8 +173,7 @@ begin
 	MCCharStoreFirstCharOf(input, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the last char in <Target>.
 Target:				An expression which evaluates to a string.
 
@@ -205,8 +201,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Deletes the char at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				A string container.
@@ -230,8 +225,7 @@ begin
 	MCCharExecDeleteCharOf(Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the chars between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -257,8 +251,7 @@ begin
 	MCCharExecDeleteCharRangeOf(Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the first char in <Target>.
 Target:				A string container.
 
@@ -281,8 +274,7 @@ begin
 	MCCharExecDeleteFirstCharOf(Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the last char in <Target>.
 Target:				A string container.
 
@@ -307,7 +299,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Determines whether <Needle> is in <Target>.
 Needle: 			An expression which evaluates to a char.
 Target: 			An expression which evaluates to a string.
@@ -328,8 +320,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> within <Target>
 
 Needle: 			An expression which evaluates to a string.
@@ -367,8 +358,7 @@ begin
     MCCharEvalOffsetOfChars(IsLast, Needle, Target, output)
 end syntax
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> after a specified index in <Target>
 
 Needle: 			An expression which evaluates to a string.
@@ -397,8 +387,7 @@ begin
     MCCharEvalOffsetOfCharsAfter(IsLast, Needle, After, Target, output)
 end syntax
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> before a specified index in <Target>.
 
 Needle: 			An expression which evaluates to a string.
@@ -434,7 +423,7 @@ begin
     MCCharEvalOffsetOfCharsBefore(IsFirst, Needle, Before, Target, output)
 end syntax
 
-/*
+/**
 Summary:            Determines whether <Source> contains <Needle>.
 Needle: 			An expression which evaluates to a string.
 Source: 			An expression which evaluates to a string.
@@ -457,7 +446,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Determines whether <Source> begins with <Prefix>
 Prefix: 			An expression which evaluates to a string.
 Source: 			An expression which evaluates to a string.
@@ -486,7 +475,7 @@ begin
     MCCharEvalBeginsWith(Source, Prefix, output)
 end syntax
 
-/*
+/**
 Summary:            Determines whether <Source> ends with <Suffix>
 Suffix: 			An expression which evaluates to a string.
 Source: 			An expression which evaluates to a string.
@@ -517,7 +506,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:			The new line character
 
 Example:
@@ -541,7 +530,7 @@ begin
     MCCharEvalNewlineCharacter(output)
 end syntax
 
-/*
+/**
 Summary:        Repeat over the chars of a string
 Iterand:        A string container.
 
@@ -572,7 +561,7 @@ end syntax
 
 ----------------------------------------------------------------
 
-/*
+/**
 Summary:	Get the numeric value of a single char
 
 Target:	A string containing one character
@@ -589,7 +578,7 @@ begin
     MCStringEvalCodeOfChar(Target, output)
 end syntax
 
-/*
+/**
 Summary:	Create a 1-char string from a number
 
 Value:		A Unicode codepoint index

--- a/libscript/src/codeunit.lcb
+++ b/libscript/src/codeunit.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the operations on codeunits included in the standard library of LiveCode Builder.
 */
 
@@ -58,7 +58,7 @@ public foreign handler MCCodeunitExecDeleteFirstCodeunitOf(inout Target as Strin
 
 --
 
-/*
+/**
 Summary:            Counts the number of codeunits in <Target>.
 
 Target: 			An expression which evaluates to a string.
@@ -94,8 +94,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Designates the codeunit at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				An expression which evaluates to a string.           
@@ -118,8 +117,7 @@ begin
 	MCCodeunitStoreCodeunitOf(input, Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the codeunits between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -144,8 +142,7 @@ begin
 	MCCodeunitStoreCodeunitRangeOf(input, Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the first codeunit in <Target>.
 Target:				An expression which evaluates to a string.
 
@@ -171,8 +168,7 @@ begin
 	MCCodeunitStoreFirstCodeunitOf(input, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the last codeunit in <Target>.
 Target:				An expression which evaluates to a string.
 
@@ -200,8 +196,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Deletes the codeunit at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				A string container.
@@ -225,8 +220,7 @@ begin
 	MCCodeunitExecDeleteCodeunitOf(Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the codeunits between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -252,8 +246,7 @@ begin
 	MCCodeunitExecDeleteCodeunitRangeOf(Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the first codeunit in <Target>.
 Target:				A string container.
 
@@ -276,8 +269,7 @@ begin
 	MCCodeunitExecDeleteFirstCodeunitOf(Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the last codeunit in <Target>.
 Target:				A string container.
 
@@ -302,7 +294,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Determines whether <Needle> is in <Target>.
 Needle: 			An expression which evaluates to a codeunit.
 Target: 			An expression which evaluates to a string.
@@ -323,8 +315,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> within <Target>
 
 Needle: 			An expression which evaluates to a string.
@@ -357,8 +348,7 @@ begin
     MCCodeunitEvalOffsetOfCodeunits(IsLast, Needle, Target, output)
 end syntax
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> after a specified index in <Target>
 
 Needle: 			An expression which evaluates to a string.
@@ -383,8 +373,7 @@ begin
     MCCodeunitEvalOffsetOfCodeunitsAfter(IsLast, Needle, After, Target, output)
 end syntax
 
-/*
-
+/**
 Summary:            Finds the first or last occurrence of <Needle> before a specified index in <Target>.
 
 Needle: 			An expression which evaluates to a string.
@@ -417,7 +406,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:        Repeat over the codeunits of a string
 Iterand:        A string container.
 

--- a/libscript/src/date.lcb
+++ b/libscript/src/date.lcb
@@ -15,7 +15,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library provides low-level system functionality for modular
 LiveCode programs.
 */
@@ -28,7 +28,7 @@ public foreign handler MCDateExecGetLocalDate(out rDateTime as List) returns not
 public foreign handler MCDateExecGetUniversalDate(out rDateTime as List) returns nothing binds to "<builtin>"
 public foreign handler MCDateExecGetUniversalTime(out rSeconds as CDouble) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The local Gregorian date
 
 Example:
@@ -60,7 +60,7 @@ begin
 	MCDateExecGetLocalDate(output)
 end syntax
 
-/*
+/**
 Summary:	The UTC Gregorian date
 
 Example:

--- a/libscript/src/file.lcb
+++ b/libscript/src/file.lcb
@@ -15,7 +15,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This module specifies the syntax definitions and bindings for
 filesystem operations in LiveCode Builder.
 
@@ -30,7 +30,7 @@ module com.livecode.file
 public foreign handler MCFileExecGetContents(in File as String, out Contents as Data) returns nothing binds to "<builtin>"
 public foreign handler MCFileExecSetContents(in Contents as Data, in File as String) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The data stored in a file.
 
 File:		An expression that evaluates to a filesystem path.
@@ -54,7 +54,7 @@ end syntax
 
 public foreign handler MCFileExecDeleteFile(in File as String) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Delete a file from the filesystem.
 
 File:		An expression that evaluates to a filesystem path.
@@ -76,7 +76,7 @@ public foreign handler MCFileExecCreateDirectory(in Directory as String) returns
 public foreign handler MCFileExecDeleteDirectory(in Directory as String) returns nothing binds to "<builtin>"
 public foreign handler MCFileExecGetDirectoryEntries(in Directory as String, out Entries as List) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Create a named directory.
 
 Directory:	An expression that evaluates to a filesystem path.
@@ -92,7 +92,7 @@ begin
 	MCFileExecCreateDirectory(Directory)
 end syntax
 
-/*
+/**
 Summary:	Delete a directory.
 
 Directory:	An expression that evaluates to a filesystem path.
@@ -108,7 +108,7 @@ begin
 	MCFileExecDeleteDirectory(Directory)
 end syntax
 
-/*
+/**
 Summary:	List the contents of a directory.
 
 Directory:	An expression that evaluates to a filesystem path.

--- a/libscript/src/list.lcb
+++ b/libscript/src/list.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*  
+/**
 This library consists of the operations on lists included in the standard library of LiveCode Builder.
 */
 
@@ -84,7 +84,7 @@ public foreign handler MCListEvalOffsetOfListBefore(in IsFirst as CBool, in Need
 
 --
 
-/*
+/**
 Summary:        Returns the first element of <Target>.
 Target:         An expression which evaluates to a list.
 
@@ -117,7 +117,7 @@ begin
     MCListEvalHeadOf(Target, output)
 end syntax
 
-/* 
+/**
 Summary:        Returns the last element of <Target>.
 Target:         An expression which evaluates to a list.
 
@@ -153,7 +153,7 @@ end syntax
 
 --
 
-/* 
+/**
 Summary:        Pushes <Value> onto <Target>.
 Value:          Any expression.
 Target:         An expression which evaluates to a list.
@@ -182,7 +182,7 @@ begin
     MCListExecPushSingleElementOnto(Value, IsFront, Target)
 end syntax
 
-/* 
+/**
 Summary:        Pops the last element from <Source> into <Target>
 Source:         An expression which evaluates to a list.
 Target:         An expression which evaluates to a container.
@@ -217,7 +217,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:        Returns the number of elements in <Target>
 Target:         An expression which evaluates to a list.
 
@@ -243,7 +243,7 @@ end syntax
 
 --
 
-/* 
+/**
 Summary:        Determines if a given element is in <Target>
 Needle:         Any expression.
 Target:         An expression which evaluates to a list.
@@ -269,7 +269,7 @@ begin
     MCListEvalIsAmongTheElementsOf(Needle, Target, output)
 end syntax
 
-/* 
+/**
 Summary:        Determines if <Target> contains <Needle> as a subsequence.
 Needle:         Any expression which evaluates to a list.
 Target:         An expression which evaluates to a list.
@@ -302,7 +302,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Determines whether <Source> begins with <Prefix>
 Prefix: 			An expression which evaluates to a list.
 Source: 			An expression which evaluates to a list.
@@ -332,7 +332,7 @@ begin
     MCListEvalBeginsWith(Source, Prefix, output)
 end syntax
 
-/*
+/**
 Summary:            Determines whether <Source> ends with <Suffix>
 Prefix: 			An expression which evaluates to a list.
 Source: 			An expression which evaluates to a list.
@@ -364,7 +364,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to a list.
@@ -394,7 +394,7 @@ begin
     MCListEvalIsEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to a list.
@@ -425,8 +425,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Designates the element at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				An expression which evaluates to a list.
@@ -454,8 +453,7 @@ begin
     MCListStoreElementOf(input, Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the element at index <Index> in <Target>.
 Synonym:            SingletonElementOf
 Index: 				An expression which evaluates to a valid integer index of <Target>.
@@ -484,8 +482,7 @@ begin
     MCListStoreIndexOf(input, Target, Index)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the elements between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -515,8 +512,7 @@ begin
     MCListStoreElementRangeOf(input, Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the first element in <Target>.
 Target:				An expression which evaluates to a list.
 
@@ -535,8 +531,7 @@ begin
 	MCListStoreFirstElementOf(input, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Designates the last element in <Target>.
 Target:				An expression which evaluates to a list.
 
@@ -557,8 +552,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Deletes the element at index <Index> in <Target>.
 Index: 				An expression which evaluates to a valid integer index of <Target>.
 Target:				A list container.
@@ -577,8 +571,7 @@ begin
 	MCListExecDeleteElementOf(Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the elements between indices <Start> and <Finish> in <Target>.
 
 Start:              An expression which evaluates to a valid integer index of <Target>.
@@ -599,8 +592,7 @@ begin
 	MCListExecDeleteElementRangeOf(Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Deletes the first element of <Target>.
 Target:				A list container.
 
@@ -619,8 +611,7 @@ begin
 end syntax
 
 
-/*
-
+/**
 Summary:            Deletes the last element of <Target>.
 Target:				A list container.
 
@@ -640,8 +631,7 @@ end syntax
 
 --
 
-/*
-
+/**
 Summary:            Removes the elements of <Target> from <Start > to <Finish> and inserts each of the elements of
                     <Source> into <Target> at <Start>.
 Source:             An expression which evaluates to a list.
@@ -684,8 +674,7 @@ begin
     MCListSpliceIntoElementRangeOf(Source, Start, Finish, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Removes the element of <Target> at <Index> and inserts each of the elements of <Source> into
                     <Target> at <Index>.
 Source:             An expression which evaluates to a list.
@@ -725,8 +714,7 @@ begin
     MCListSpliceIntoElementOf(Source, Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Inserts each of the elements of <Source> into <Target> before element at index <Index>.
 Source:             An expression which evaluates to a list.
 Index:              An expression which evaluates to a valid integer index of <Target>.
@@ -766,8 +754,7 @@ begin
     MCListSpliceBeforeElementOf(Source, Index, Target)
 end syntax
 
-/*
-
+/**
 Summary:            Inserts each of the elements of <Source> into <Target> after element at index <Index>.
 Source:             An expression which evaluates to a list.
 Index:              An expression which evaluates to a valid integer index of <Target>.
@@ -809,8 +796,7 @@ end syntax
 
 --
 
-/* 
-
+/**
 Summary: 		Designates the list of length zero.
 
 Example:
@@ -832,7 +818,7 @@ begin
 	MCListEvalEmpty(output)
 end syntax
 
-/*
+/**
 Summary:        Repeat over the elements of a list
 Iterand:        Any variable of appropriate type.
 
@@ -865,7 +851,7 @@ end syntax
 
 ----------------------------------------------------------------
 
-/*
+/**
 Summary:	Find the first or last occurrence of <Needle> within <Haystack>
 
 Needle:	An expression which evaluates to any value.
@@ -899,7 +885,7 @@ begin
 	MCListEvalIndexOfElement(IsLast, Needle, Haystack, output)
 end syntax
 
-/*
+/**
 Summary:	Find the first or last occurrence of <Needle> within the tail of <Haystack>
 
 Needle:	An expression which evaluates to any value.
@@ -933,7 +919,7 @@ begin
 	MCListEvalIndexOfElementAfter(IsLast, Needle, After, Haystack, output)
 end syntax
 
-/*
+/**
 Summary:	Find the first or last occurrence of <Needle> within the head of <Haystack>
 
 Needle:	An expression which evaluates to any value.
@@ -970,7 +956,7 @@ end syntax
 
 ----------------------------------------------------------------
 
-/*
+/**
 Summary:	Find the first or last occurrence of <Needle> within <Haystack>
 
 Needle:	An expression which evaluates to a list.
@@ -1005,7 +991,7 @@ begin
 	MCListEvalOffsetOfList(IsLast, Needle, Haystack, output)
 end syntax
 
-/*
+/**
 Summary:	Find the first or last occurrence of <Needle> within the tail of <Haystack>
 
 Needle:	An expression which evaluates to any list.
@@ -1043,7 +1029,7 @@ begin
 	MCListEvalOffsetOfListAfter(IsLast, Needle, After, Haystack, output)
 end syntax
 
-/*
+/**
 Summary:	Find the first or last occurrence of <Needle> within the head of <Haystack>
 
 Needle:	An expression which evaluates to List.

--- a/libscript/src/logic.lcb
+++ b/libscript/src/logic.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the logical operations included in the standard library of LiveCode Builder.
 */
 
@@ -35,7 +35,7 @@ public foreign handler MCLogicExecParseStringAsBool(in Target as String) returns
 
 --
 
-/*
+/**
 Summary:    Returns the boolean-logical value of the expression '<Left> and <Right>'
 
 Left:       An expression that evaluates to a boolean value
@@ -52,7 +52,7 @@ Returns: 	If the left hand expression evaluates to false, the value of the expre
 //    EvalOr(Left, Right, output)
 //end syntax
 
-/*
+/**
 Summary:    Returns the boolean-logical value of the expression '<Left> or <Right>'
 
 Left:       An expression that evaluates to a boolean value
@@ -69,7 +69,7 @@ Returns: 	If the left hand expression evaluates to true, the value of the expres
 //    EvalAnd(Left, Right, output)
 //end syntax
 
-/*
+/**
 Summary:    Returns the boolean-logical value of the expression 'not <Operand>'
 
 Operand:    An expression that evaluates to a boolean value
@@ -93,7 +93,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to a boolean value.
@@ -115,7 +115,7 @@ begin
     MCLogicEvalIsEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to a boolean value.
@@ -137,7 +137,7 @@ begin
     MCLogicEvalIsNotEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:	Formats a boolean value as a string
 
 Operand:	An expression that evaluates to a boolean value.
@@ -160,7 +160,7 @@ begin
     MCLogicEvalBoolFormattedAsString(Operand, output)
 end syntax
 
-/*
+/**
 Summary:	Formats a boolean value as a string
 
 Operand:	An expression that evaluates to a boolean value.
@@ -183,7 +183,7 @@ begin
     MCLogicExecFormatBoolAsString(Operand)
 end syntax
 
-/*
+/**
 Summary:	Parses a string as a boolean value
 
 Operand:	An expression that evaluates to a string.
@@ -210,7 +210,7 @@ begin
     MCLogicEvalStringParsedAsBool(Operand, output)
 end syntax
 
-/*
+/**
 Summary:	Parses a string as a boolean value
 
 Operand:	An expression that evaluates to a string.

--- a/libscript/src/math-foundation.lcb
+++ b/libscript/src/math-foundation.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the foundational mathematical operations included in the standard library of LiveCode Builder.
 */
 
@@ -38,7 +38,7 @@ public foreign handler MCMathFoundationEvalPi(out Value as CDouble) returns noth
 
 //public constant pi = 3.14159265358979323846
 
-/*
+/**
 Summary: The constant pi
 
 Example:
@@ -59,7 +59,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Rounds <Target> to the nearest integer.
 Target:     An expression that evaluates to a numeric container.
 
@@ -80,7 +80,7 @@ begin
     MCMathFoundationExecRoundNumberToNearest(Target)
 end syntax
 
-/*
+/**
 Summary:    Rounds <Target> to the nearest integer.
 Target:     An expression that evaluates to a number.
 
@@ -106,7 +106,7 @@ end syntax
 
 --
 
-/* 
+/**
 Summary:    Returns the floor of <Target>.
 Target:     An expression that evaluates to a number.
 
@@ -131,7 +131,7 @@ begin
     MCMathFoundationEvalFloorNumber(Target, output)
 end syntax
 
-/* 
+/**
 Summary:    Returns the ceiling of <Target>.
 Target:     An expression that evaluates to a number.
 

--- a/libscript/src/math.lcb
+++ b/libscript/src/math.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the mathematical operations included in the standard library of LiveCode Builder.
 */
 
@@ -82,7 +82,7 @@ public foreign handler MCMathEvalConvertFromBase10(in Operand as LCInt, in Targe
 
 --
 
-/*
+/**
 Summary:    Binary exponentiation operation.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -104,7 +104,7 @@ end syntax
 
 --
 
-/*
+/**
 Syntax:		sin(<Operand>)
 Summary:    Sin operator.
 Operand:    An expression that evaluates to a number.
@@ -132,7 +132,7 @@ public handler Sin(in pOperand as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Syntax:		cos(<Operand>)
 Summary:    Cos operator.
 Operand:    An expression that evaluates to a number.
@@ -156,7 +156,7 @@ public handler Cos(in pOperand as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Syntax:		tan(<Operand>)
 Summary:    Tan operator.
 Operand:    An expression that evaluates to a number.
@@ -184,7 +184,7 @@ public handler Tan(in pOperand as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Syntax:		asin(<Operand>)
 Summary:    Arcsin operator.
 Operand:    An expression that evaluates to a number.
@@ -215,7 +215,7 @@ public handler Asin(in pOperand as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Syntax:		acos(<Operand>)
 Summary:    Arccos operator.
 Operand:    An expression that evaluates to a number.
@@ -246,7 +246,7 @@ public handler Acos(in pOperand as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Syntax:		atan(<Operand>)
 Summary:    Arctan operator.
 Operand:    An expression that evaluates to a number.
@@ -277,7 +277,7 @@ public handler Atan(in pOperand as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Syntax:		atan2(<yCoord>,<xCoord>)
 Summary:    Binary arctan operator.
 yCoord:   	An expression that evaluates to a number.
@@ -312,7 +312,7 @@ end handler
 
 --
 
-/*
+/**
 Syntax:		log(<Operand>)
 Summary:    Base 10 log operator.
 Operand:    An expression that evaluates to a number.
@@ -338,7 +338,7 @@ end handler
 
 --
 
-/*
+/**
 Syntax:		ln(<Operand>)
 Summary:    Natural log operator.
 Operand:    An expression that evaluates to a number.
@@ -363,7 +363,7 @@ public handler Ln(in pOperand as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Syntax:		exp(<Operand>)
 Summary:    Exponentiation operator.
 Operand:    An expression that evaluates to a number.
@@ -391,7 +391,7 @@ end handler
 
 --
 
-/*
+/**
 Summary:    Truncation operator.
 Operand:    An expression that evaluates to a number.
 
@@ -414,7 +414,7 @@ begin
     MCMathEvalTruncNumber(Operand, output)
 end syntax
 
-/*
+/**
 Summary:    Absolute value operator.
 Operand:    An expression that evaluates to a number.
 
@@ -438,7 +438,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Generates a pseudo-random number.
 
 Returns: 	A real between 0.0 and 1.0.
@@ -459,7 +459,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Min operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -481,7 +481,7 @@ public handler Min(in pX as Number, in pY as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Summary:    Max operator.
 Left:       An expression that evaluates to a number.
 Right:      An expression that evaluates to a number.
@@ -503,7 +503,7 @@ public handler Max(in pX as Number, in pY as Number) returns Number
     return tVar
 end handler
 
-/*
+/**
 Summary:    Min operator.
 List:		An expression that evaluates to a list.
 
@@ -521,7 +521,7 @@ begin
     MCMathEvalMinList(ValueList, output)
 end syntax
 
-/*
+/**
 Summary:    Max operator.
 List:		An expression that evaluates to a list.
 
@@ -541,7 +541,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Converts the base of <Operand>
 Operand:    An expression that evaluates to a string.
 Source:     An expression that evaluates to an integer.
@@ -562,7 +562,7 @@ begin
     MCMathEvalConvertToBase10(Operand, Source, output)
 end syntax
 
-/*
+/**
 Summary:    Converts the base of <Operand>
 Operand:    An expression that evaluates to an integer.
 Target:     An expression that evaluates to an integer.
@@ -583,7 +583,7 @@ begin
     MCMathEvalConvertFromBase10(Operand, Target, output)
 end syntax
 
-/*
+/**
 Summary:    Converts the base of <Operand>
 Operand:    An expression that evaluates to a string.
 Source:     An expression that evaluates to an integer.

--- a/libscript/src/sort.lcb
+++ b/libscript/src/sort.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the sorting operations provided by the standard library of LiveCode Builder.
 */
 
@@ -34,8 +34,7 @@ public foreign handler MCSortExecSortListDescendingDateTime(inout Target as List
 
 --
 
-/* 
-
+/**
 Summary:        Sorts <Target> in ascending order.
 Target:         An expression that evaluates to a list.
 
@@ -58,8 +57,7 @@ begin
     MCSortExecSortListAscending(Target)
 end syntax
 
-/* 
-
+/**
 Summary:        Sorts <Target> in descending text order.
 Target:         An expression that evaluates to a list of strings.
 
@@ -84,8 +82,7 @@ end syntax
 
 --
 
-/* 
-
+/**
 Summary:        Sorts <Target> in ascending text order.
 Target:         An expression that evaluates to a list of strings.
 
@@ -114,8 +111,7 @@ begin
     MCSortExecSortListAscendingText(Target)
 end syntax
 
-/* 
-
+/**
 Summary:        Sorts <Target> in descending text order.
 Target:         An expression that evaluates to a list of strings.
 
@@ -143,8 +139,7 @@ end syntax
 
 --
 
-/* 
-
+/**
 Summary:        Sorts <Target> in ascending binary order.
 Target:         An expression that evaluates to a list of binary data.
 
@@ -161,8 +156,7 @@ begin
     MCSortExecSortListAscendingBinary(Target)
 end syntax
 
-/* 
-
+/**
 Summary:        Sorts <Target> in descending binary order.
 Target:         An expression that evaluates to a list of binary data.
 
@@ -181,8 +175,7 @@ end syntax
 
 --
 
-/* 
-
+/**
 Summary:        Sorts <Target> in ascending numeric order.
 Target:         An expression that evaluates to a list of numbers.
 
@@ -205,8 +198,7 @@ begin
     MCSortExecSortListAscendingNumeric(Target)
 end syntax
 
-/* 
-
+/**
 Summary:        Sorts <Target> in descending numeric order.
 Target:         An expression that evaluates to a list of numbers.
 
@@ -245,7 +237,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary: A handler type that can be used in the <SortListUsingHandler> command.
 
 Parameters:
@@ -267,7 +259,7 @@ public handler type SortCompare(in pLeft as any, in pRight as any) returns Integ
 
 public foreign handler MCSortExecSortListUsingHandler(inout Target as List, in Handler as SortCompare) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:        Sorts <Target> using <Handler> as a comparison function.
 Target:         An expression that evaluates to a list.
 Handler: 		A handler of type <SortCompare>

--- a/libscript/src/stream.lcb
+++ b/libscript/src/stream.lcb
@@ -15,7 +15,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This module specifies the syntax definitions and bindings for
 stream input and output operations in modular LiveCode.
 */
@@ -29,7 +29,7 @@ public foreign type Stream binds to "MCStreamTypeInfo"
 public foreign handler MCStreamExecGetStandardOutput(out Stdout as Stream) returns nothing binds to "<builtin>"
 public foreign handler MCStreamExecGetStandardError(out Stderr as Stream) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Default output stream.
 Returns:	The default output stream.
 
@@ -48,7 +48,7 @@ begin
 	MCStreamExecGetStandardOutput(output)
 end syntax
 
-/*
+/**
 Summary:	Default error stream.
 Returns:	The default error stream.
 
@@ -71,7 +71,7 @@ end syntax
 
 public foreign handler MCStreamExecWriteToStream(in Buffer as Data, in Destination as Stream) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	Write data to a stream.
 
 Buffer:	An expression that evaluates to binary data.

--- a/libscript/src/string.lcb
+++ b/libscript/src/string.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library consists of the operations on strings included in the standard library of LiveCode Builder.
 */
 
@@ -55,7 +55,7 @@ public foreign handler MCStringEvalEmpty(out Value as String) returns nothing bi
 
 --
 
-/*
+/**
 Summary:            Prepends <Source> to <Target>.
 
 Source: 			An expression which evaluates to a string.
@@ -80,7 +80,7 @@ begin
     MCStringExecPutStringBefore(Source, Target)
 end syntax
 
-/*
+/**
 Summary:            Appends <Source> to <Target>.
 
 Source: 			An expression which evaluates to a string.
@@ -106,7 +106,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Replaces occurrences of <Pattern> within <Target> in <Replacement>
 
 Source: 			An expression which evaluates to a string.
@@ -132,7 +132,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Concatenates <Left> and <Right>.
 
 Left: 				An expression which evaluates to a string.
@@ -156,7 +156,7 @@ begin
     MCStringEvalConcatenate(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:            Concatenates <Left> and <Right> with a space between.
 
 Left: 				An expression which evaluates to a string.
@@ -182,7 +182,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:            Uppercases <Source>.
 Source: 			An expression which evaluates to a string.
 
@@ -201,7 +201,7 @@ begin
     MCStringEvalUppercaseOf(Source, output)
 end syntax
 
-/*
+/**
 Summary:            Lowercases <Source>.
 Source: 			An expression which evaluates to a string.
 
@@ -222,7 +222,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to a string.
@@ -243,7 +243,7 @@ begin
     MCStringEvalIsEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> and <Right> are equal or not.
 
 Left:       An expression which evaluates to a string.
@@ -264,7 +264,7 @@ begin
     MCStringEvalIsNotEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> is less than <Right> under a char by char comparison
 
 Left:       An expression which evaluates to a string.
@@ -285,7 +285,7 @@ begin
     MCStringEvalIsLessThan(Left, Right, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Left> is greater than <Right> under a char by char comparison
 
 Left:       An expression which evaluates to a string.
@@ -307,8 +307,7 @@ end syntax
 
 --
 
-/* 
-
+/**
 Summary: 		Designates the string of length zero.
 
 Example:

--- a/libscript/src/system.lcb
+++ b/libscript/src/system.lcb
@@ -15,7 +15,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
 This library provides low-level system functionality for modular
 LiveCode programs.
 */
@@ -30,7 +30,7 @@ use com.livecode.foreign
 
 public foreign handler MCSystemExecGetOperatingSystem(out Platform as String) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The operating system
 
 Example:
@@ -70,7 +70,7 @@ public handler MCSystemExecQuitWithStatus(in Status as Number)
 	__exit(Status)
 end handler
 
-/*
+/**
 Summary:	Quit the application
 
 Example:
@@ -101,7 +101,7 @@ end syntax
 public foreign handler MCSystemExecGetCommandName (out CommandName as String) returns nothing binds to "<builtin>"
 public foreign handler MCSystemExecGetCommandArguments (out CommandArguments as List) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:	The command name
 
 Example:
@@ -125,7 +125,7 @@ begin
 	MCSystemExecGetCommandName(output)
 end syntax
 
-/*
+/**
 Summary:	The command arguments
 
 Example:

--- a/libscript/src/type-convert.lcb
+++ b/libscript/src/type-convert.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/* 
+/**
 This library consists of the operations for performing complex type conversion in LiveCode Builder.
 */
 
@@ -25,7 +25,7 @@ public foreign handler MCTypeConvertExecCombineListWithDelimiter(in Target as Li
 
 --
 
-/*
+/**
 Summary:        Splits the string in <Target> into a list of strings, using <Delimiter>
                 as the delimiter.
 
@@ -54,7 +54,7 @@ begin
     MCTypeConvertExecSplitStringByDelimiter(Target, Delimiter)
 end syntax
 
-/*
+/**
 Summary:        Combines the list of strings in <Target>, using <Delimiter>
                 as the delimiter. 
                 

--- a/libscript/src/type.lcb
+++ b/libscript/src/type.lcb
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-/*
+/**
   This library consists of the general operations on types provided by the standard library of LiveCode Builder.
 */
 
@@ -38,7 +38,7 @@ public foreign handler MCNothingEvalIsNothingEqualTo(in Left as nothing, in Righ
 public foreign handler MCNothingEvalIsNotEqualToNothing(in Left as optional any, in Right as nothing, out Value as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCNothingEvalIsNothingNotEqualTo(in Left as nothing, in Right as optional any, out Value as CBool) returns nothing binds to "<builtin>"
 
-/*
+/**
 Summary:    Determines whether <Target> is empty or not.
 
 Target:     Any expression
@@ -52,7 +52,7 @@ begin
     MCTypeEvalIsEmpty(Target, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Target> is empty or not.
 
 Target:     Any expression
@@ -68,7 +68,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Determines whether <Target> is defined or not.
 
 Target:     Any expression
@@ -87,7 +87,7 @@ begin
 	MCTypeEvalIsDefined(Target, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Target> is defined or not.
 
 Target:     Any expression
@@ -107,7 +107,7 @@ begin
 	MCTypeEvalIsNotDefined(Target, output)
 end syntax
 
-/*
+/**
 Summary:	Determines whether <Target> is defined or not.
 
 Target:	Any expression
@@ -126,7 +126,7 @@ begin
 	MCTypeEvalIsNotDefined(Target, output)
 end syntax
 
-/*
+/**
 Summary:	Determines whether <Target> is defined or not.
 Target:	Any expression
 Output:	Returns true if the given expression <Target> is defined, and false otherwise.
@@ -146,7 +146,7 @@ end syntax
 
 --
 
-/*
+/**
 Name: IsNothing
 Type: operator
 Syntax: <Target> is nothing
@@ -166,7 +166,7 @@ begin
     MCNothingEvalIsNothingEqualTo(Left, Right, output)
 end syntax
 
-/*
+/**
 Name: IsNotNothing
 Type: operator
 Syntax: <Target> is not nothing
@@ -194,7 +194,7 @@ end syntax
 
 --
 
-/*
+/**
 Summary:    Determines whether <Target> is a boolean or not.
 
 Target:     Any expression
@@ -208,7 +208,7 @@ begin
 	MCTypeEvalIsABoolean(Target, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Target> is a number or not.
 
 Target:     Any expression
@@ -222,7 +222,7 @@ begin
 	MCTypeEvalIsANumber(Target, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Target> is a string or not.
 
 Target:     Any expression
@@ -236,7 +236,7 @@ begin
 	MCTypeEvalIsAString(Target, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Target> is data or not.
 
 Target:     Any expression
@@ -250,7 +250,7 @@ begin
 	MCTypeEvalIsAData(Target, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Target> is an array or not.
 
 Target:     Any expression
@@ -264,7 +264,7 @@ begin
 	MCTypeEvalIsAnArray(Target, output)
 end syntax
 
-/*
+/**
 Summary:    Determines whether <Target> is a list or not.
 
 Target:     Any expression


### PR DESCRIPTION
Fix as much LCB source code as possible to use `/** ... */` style comments for documentation blocks.
