### PR TITLE
[[ Bug 17472 ]] Ensure drag-drop works from all applications on Mac

### DIFF
--- a/docs/notes/bugfix-17472.md
+++ b/docs/notes/bugfix-17472.md
@@ -1,0 +1,1 @@
+# Make sure drag-drop works from all applications on Mac

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -1362,7 +1362,7 @@ static void map_key_event(NSEvent *event, MCPlatformKeyCode& r_key_code, codepoi
     // Create a wrapper around the drag board for this operation if the drag
     // source is outside this instance of LiveCode.
     MCAutoRefcounted<MCMacRawClipboard> t_dragboard;
-    if ([sender draggingSource] != nil)
+    if ([sender draggingSource] == nil)
         t_dragboard = new MCMacRawClipboard([sender draggingPasteboard]);
     
 	NSDragOperation t_ns_operation;


### PR DESCRIPTION
When a drag-drop operation starts, the system sends a message with
the draggingSource. If the latter is nil then it means that the
operation is coming from another application and, in which case,
the supplied pasteboard needs to supplant the standard drag
pasteboard. This ensures that apps (such as Word) which create their
own drag-drop pasteboard can still send data to LiveCode.
