### PR TITLE
[[ Bug 16589 ]] Ensure repeated key presses are correct

### DIFF
--- a/docs/notes/bugfix-16589.md
+++ b/docs/notes/bugfix-16589.md
@@ -1,0 +1,1 @@
+# Stop junk characters being inserted into script editor after pressing Ctrl-S to save


### PR DESCRIPTION
This patch corrects two flaws in key handling where the system
key press event has a repeat count > 1.

The first is that it ensures that it only processes one iteration at
a time, pushing the event back onto the pending events queue with a
reduced repeat count allowing flushEvents() to remove any remaining
repeated key events during processing of the first.

The second is that it ensures that MCmodifierstate is correct for
each key press. Previously the engine was using 'GetAsyncKeyState()'
to compute the modifiers for a 'live' event. However, even between
a key press being registered and it being dispatched live the key
state can change. This code path now uses GetKeyState() which is tied
to the current event dispatch, correcting the problem.
