### PR TITLE
[[Community Docs ]] Cancel command fixes

### DIFF
--- a/docs/dictionary/command/cancel.lcdoc
+++ b/docs/dictionary/command/cancel.lcdoc
@@ -4,7 +4,8 @@ Type: command
 
 Syntax: cancel <messageQueueID> 
 
-Summary: Removes a <message> that was queued with the <send> <command> and is waiting to be sent.
+Summary: Removes a <message> that was queued with the <send> <command> 
+and is waiting to be sent.
 
 Introduced: 1.0
 
@@ -18,24 +19,56 @@ cancel 2298
 Example:
 cancel item 1 of last line of the pendingMessages
 
+Example:
+# Assume these two handlers in a card script.
+# Call scheduleBeep to queue a message
+# Call cancelBeep to cancel the pending message
+
+local sMessageID
+
+on scheduleBeep
+  send "beep" to this card in 20 seconds
+  put the result into sMessageID
+end scheduleBeep
+
+on cancelBeep
+  cancel sMessageID
+end cancelBeep
+
 Parameters:
-messageQueueID: The ID number of the message.
+messageQueueID (integer): The ID number of the message.
 
 Description:
-Use the <cancel> <command> to get rid of <message|messages> that were set up but are no longer required.
+Use the <cancel> <command> to get rid of <message|messages> that were
+set up but are no longer required.
 
-The ID number of the message is returned by the <send> <command> that sent the <message>. This number is also the first <item> of the line corresponding to the message in the <pendingMessages> <function>.
+The ID number of the message is returned by the <send> <command> that
+sent the <message>. This number is also the first <item> of the line
+corresponding to the message in the <pendingMessages> <function>.
 
-All pending messages are automatically canceled when the application quits.
+All <pendingMessages|pending messages> are automatically canceled when 
+the application quits.
 
-It is common to need to cancel a number of messages when leaving a card or stack, if the messages only pertain to that card or stack. For example, you might have queued a number of messages that create an animated display on the current card, and need to cancel them when the user goes to another card. The best solution in a case like this is to place each message ID number in a global variable or custom property at the time the <message> is sent. Then you can cancel all those <message|messages> in a <repeat> <loop> :
+It is common to need to <cancel> a number of <message|messages> when leaving a <card>
+or <stack>, if the <message|messages> only pertain to that card or stack. For
+example, you might have queued a number of <message|messages> that create an
+animated display on the current <card>, and need to <cancel> them when the
+user goes to another <card>. The best solution in a case like this is to
+place each messageQueueID in a <script local variable>, a <global> <variable>, 
+or a <custom property> at the time the <message> is sent. Then you can <cancel> all those
+<message|messages> in a <repeat> <loop> :
 
-    global myPendingMessages -- you've stored the message IDs here
-    repeat for each line thisMessageID in myPendingMessages
-     cancel thisMessageID
-    end repeat
-  end closeCard
+    global myPendingMessages # you've stored the message IDs here
+    on closeCard
+      repeat for each line thisMessageID in myPendingMessages
+        cancel thisMessageID
+      end repeat
+    end closeCard
 
-References: item (keyword), send (command), flushEvents (function), pendingMessages (function), command (glossary), message (glossary), loop (glossary), function (control structure), repeat (control structure)
+References: card (object), command (glossary), custom property (glossary),
+flushEvents (function), function (control structure), global (glossary),
+item (keyword), loop (glossary), message (glossary), pendingMessages
+(function), repeat (control structure), result (function), script local variable
+(glossary), send (command), stack (object), variable (glossary)
 
 Tags: objects


### PR DESCRIPTION
- Corrected formatting of example embedded in Description element. ( @livecodeali - are indented lines interpreted as code blocks by markdown?) Should this be moved to the Examples element?
- Linked words that refer to control structures (repeat, function) do not show up in final dictionary text. Is this related to bug #17408?
- Reviewed and updated links and references.
- Added a more complete example.
- Is Tag: objects appropriate here?
