### PR TITLE
Add support for posting NSArray and NSDictionary to lcidlc externals

### DIFF
--- a/lcidlc/include/LiveCode.h
+++ b/lcidlc/include/LiveCode.h
@@ -571,17 +571,24 @@ LCError LCObjectRelease(LCObjectRef object);
 //     'i' - the parameter is of 'int' type, converts to a number
 //     'r' - the parameter is of 'double' type, converts to a number
 //     'z' - the parameter is of 'c-string' type, converts to a (text) string
+//     'u' - the parameter is of 'utf8 c-string' type, converts to a (text) string
+//     'w' - the parameter is of 'utf16 c-string' type, converts to a (text) string
 //	   'y' - the parameter is of 'c-data' type, converts to a (binary) string
+//	   'v' - the parameter is of 'utf8 c-data' type, converts to a (text) string
+//	   't' - the parameter is of 'utf16 c-data' type, converts to a (text) string
 //     'c' - the parameter is of 'char' type, converts to a (text) string
 //     'N' - the parameter is of 'NSNumber*' type, converts to a number
 //     'S' - the parameter is of 'NSString*' type, converts to a (text) string
 //     'D' - the parameter is of 'NSData*' type, converts to a (binary) string
+//     'A' - the parameter is of 'NSArray*' type, converts to a sequentially indexed array
+//     'M' - the parameter is of 'NSDictionary*' type, converts to a key/value map array
 //
 //   The parameters appear in the resulting LiveCode message in the same order
 //   that they appear in the signature.
 //
-//   The 'z' type should be passed a 'const char *' (zero-terminated) string.
-//   The 'y' type should be passed a 'const LCBytes *' type.
+//   The 'z' & 'u' types should be passed a 'const char *' (zero-terminated) string.
+//   The 'w' type should be passed a 'const uint16_t *' (zero-terminated) string.
+//   The 'y','v' & 't' types should be passed a 'const LCBytes *' type.
 //
 LCError LCObjectSend(LCObjectRef object, const char *message, const char *signature, ...);
 	

--- a/lcidlc/src/Support.mm
+++ b/lcidlc/src/Support.mm
@@ -1863,10 +1863,8 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			case 'N': // NSNumber*
 			{
 				NSNumber* t_number;
-				t_number = va_arg(p_args, NSNumber *);
-				double t_real;
-				t_real = [t_number doubleValue];
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsReal, &t_real);
+                t_number = va_arg(p_args, NSNumber *);
+                t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcNumber, &t_number);
 			}
 			break;
 				
@@ -1874,11 +1872,7 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				NSString *t_string;
 				t_string = va_arg(p_args, NSString *);
-				const char *t_cstring;
-				t_cstring = [t_string cStringUsingEncoding: NSMacOSRomanStringEncoding];
-				if (t_cstring == nil)
-					t_error = (MCError)kLCErrorCannotEncodeCString;
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsCString, &t_cstring);
+				t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcString, &t_string);
 			}
 			break;
 				
@@ -1886,12 +1880,25 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				NSData *t_data;
 				t_data = va_arg(p_args, NSData *);
-				LCBytes t_string;
-				t_string . buffer = (char *)[t_data bytes];
-				t_string . length = [t_data length];
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsString, &t_string);
+				t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcData, &t_data);
 			}
 			break;
+                
+            case 'A': // NSArray *
+            {
+                NSArray * t_array;
+                t_array = va_arg(p_args, NSArray *);
+                t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcArray, &t_array);
+            }
+                break;
+                
+            case 'H': // NSDictionary *
+            {
+                NSDictionary * t_dictionary;
+                t_dictionary = va_arg(p_args, NSDictionary *);
+                t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcDictionary, &t_dictionary);
+            }
+                break;
 #endif
 		}
 	}

--- a/lcidlc/src/Support.mm
+++ b/lcidlc/src/Support.mm
@@ -1812,7 +1812,7 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				bool t_boolean;
 				t_boolean = va_arg(p_args, int) != 0;
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsBoolean, &t_boolean);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsBoolean, &t_boolean);
 			}
 			break;
 
@@ -1820,7 +1820,7 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				int t_integer;
 				t_integer = va_arg(p_args, int);
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsInteger, &t_integer);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsInteger, &t_integer);
 			}
 			break;
 				
@@ -1828,18 +1828,15 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				double t_real;
 				t_real = va_arg(p_args, double);
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsReal, &t_real);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsReal, &t_real);
 			}
 			break;
 				
 			case 'c': // char
 			{
 				char t_char;
-				LCBytes t_bytes;
-				t_bytes . buffer = &t_char;
-				t_bytes . length = 1;
 				t_char = (char)va_arg(p_args, int);
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsString, &t_bytes);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsCChar, &t_char);
 			}
 			break;
 				
@@ -1847,24 +1844,54 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				const char *t_cstring;
 				t_cstring = va_arg(p_args, const char *);
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsCString, &t_cstring);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsCString, &t_cstring);
 			}
 			break;
 				
-			case 'y': // bytes
+            case 'u': // utf8 cstring
+            {
+                const char *t_cstring;
+                t_cstring = va_arg(p_args, const char *);
+                t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsUTF8CString, &t_cstring);
+            }
+            break;
+                
+            case 'w': // utf16 cstring
+            {
+                const uint16_t *t_cstring;
+                t_cstring = va_arg(p_args, const uint16_t *);
+                t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsUTF16CString, &t_cstring);
+            }
+            break;
+                
+            case 'y': // bytes
 			{
 				const LCBytes *t_bytes;
 				t_bytes = va_arg(p_args, const LCBytes *);
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsString, &t_bytes);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsCData, &t_bytes);
 			}
 			break;
+                
+            case 't': // utf8 bytes
+            {
+                const LCBytes *t_bytes;
+                t_bytes = va_arg(p_args, const LCBytes *);
+                t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsUTF8CData, &t_bytes);
+            }
+                
+            case 'v': // utf16 bytes
+            {
+                const LCBytes *t_bytes;
+                t_bytes = va_arg(p_args, const LCBytes *);
+                t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsUTF16CData, &t_bytes);
+            }
 				
 #ifdef __OBJC__
 			case 'N': // NSNumber*
 			{
 				NSNumber* t_number;
                 t_number = va_arg(p_args, NSNumber *);
-                t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcNumber, &t_number);
+                t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsObjcNumber, &t_number);
 			}
 			break;
 				
@@ -1872,7 +1899,7 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				NSString *t_string;
 				t_string = va_arg(p_args, NSString *);
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcString, &t_string);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsObjcString, &t_string);
 			}
 			break;
 				
@@ -1880,7 +1907,7 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 			{
 				NSData *t_data;
 				t_data = va_arg(p_args, NSData *);
-				t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcData, &t_data);
+				t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsObjcData, &t_data);
 			}
 			break;
                 
@@ -1888,15 +1915,15 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
             {
                 NSArray * t_array;
                 t_array = va_arg(p_args, NSArray *);
-                t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcArray, &t_array);
+                t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsObjcArray, &t_array);
             }
                 break;
                 
-            case 'H': // NSDictionary *
+            case 'M': // NSDictionary *
             {
                 NSDictionary * t_dictionary;
                 t_dictionary = va_arg(p_args, NSDictionary *);
-                t_error = MCVariableStore(t_argv[i], kMCOptionAsObjcDictionary, &t_dictionary);
+                t_error = (MCError) LCValueStore(t_argv[i], kLCValueOptionAsObjcDictionary, &t_dictionary);
             }
                 break;
 #endif


### PR DESCRIPTION
- LCArugmentsCreateV was still doing conversions to C types
  even though Objective-C conversions are now in the engine
- LCArugmentsCreateV did not support NSArray or NSDictionary
- H has been used as for dictionary because D is taken and
  H is possibly reasonable for hash table/map.
