### PR TITLE
build: Improvements to extensions build script

### DIFF
--- a/util/build-extensions.sh
+++ b/util/build-extensions.sh
@@ -2,28 +2,41 @@
 
 # Utility script called by the build system to compile extensions
 
-set -e
+set -eu
+
+function err() {
+	echo "ERROR: $@" >&2
+}
 
 function extract_name {
 	# Extract an e.g. "module foo.bar.baz" line from an LCB source file
-	sed -nEe 's/^([[:space:]]*(module|widget|library)[[:space:]]*)([-_\.[:alnum:]]*)[[:space:]]*$/\3/p' < "$1"
+	sed -nEe 's,^([[:space:]]*<name>(.*)</name>[[:space:]]*)$,\2,p' < "$1"
 }
 
 function build_widget {
-	WIDGET_DIR=$1
-	WIDGET_NAME=$(basename $1)
-	WIDGET_LCB="${WIDGET_DIR}/${WIDGET_NAME}.lcb"
-	TARGET_DIR=$(extract_name "${WIDGET_LCB}")
-	BUILD_DIR=$2
-	MODULE_DIR=$3
-	LC_COMPILE=$4
+	local WIDGET_DIR=$1
+	local WIDGET_NAME=$(basename $1)
+	local WIDGET_LCB="${WIDGET_DIR}/${WIDGET_NAME}.lcb"
+	local BUILD_DIR=$2
+	local MODULE_DIR=$3
+	local LC_COMPILE=$4
 	
+	echo "LC_COMPILE ${WIDGET_NAME}"
+
 	"${LC_COMPILE}" \
 		-Werror \
 		--modulepath "${MODULE_DIR}" \
 		--manifest "${WIDGET_DIR}/manifest.xml" \
 		--output "${WIDGET_DIR}/module.lcm" \
 		"${WIDGET_LCB}"
+
+	local TARGET_DIR=$(extract_name "${WIDGET_DIR}/manifest.xml")
+	if [[ -z "${TARGET_DIR}" ]]; then
+		err "Could not find canonical name of ${WIDGET_NAME}"
+		return 1
+	fi
+
+	echo "PACKAGE ${TARGET_DIR}"
 
 	pushd "${WIDGET_DIR}" 1>/dev/null
 	zip -q -r "${TARGET_DIR}.lce" *
@@ -41,13 +54,13 @@ function build_widget {
 }
 
 # Arguments 4 and above are the list of extensions to compile
-destination_dir=$1
-module_dir=$2
-lc_compile=$3
+readonly destination_dir=$1
+readonly module_dir=$2
+readonly lc_compile=$3
 shift 3
 
 # Find the dependency/build ordering of the extensions
-build_order=$(${lc_compile} --modulepath ${module_dir} --deps changed-order -- $@)
+readonly build_order=$(${lc_compile} --modulepath ${module_dir} --deps changed-order -- $@)
 
 # Loop over the extensions that need to be (re-)built
 for ext in ${build_order} ; do


### PR DESCRIPTION
- Extract canonical extension name from manifest rather than LCB
  source file, so it's less fragile (including "library", "widget" or
  "module" in module level comments could sometimes confuse the build
  script)
- Print some messages to stdout to indicate what's going on
