### PR TITLE
[Bug 17530] Fixed reversed parameter passed to statusIconMenuPick

### DIFF
--- a/docs/notes/bugfix-17530.md
+++ b/docs/notes/bugfix-17530.md
@@ -1,0 +1,1 @@
+#  statusIconMenuPick parameter no longer reverses order of selected menu option when selecting from submenu

--- a/engine/src/w32icon.cpp
+++ b/engine/src/w32icon.cpp
@@ -466,7 +466,7 @@ bool build_pick_string(HMENU p_menu, UINT32 p_command, MCStringRef x_mutable)
 		{
 			if (t_info . hSubMenu != NULL && build_pick_string(t_info . hSubMenu, p_command, x_mutable))
 			{
-				/* UNCHECKED */ MCStringAppendChar(x_mutable, '|');
+				/* UNCHECKED */ MCStringPrependChar(x_mutable, '|');
 				t_success = true;
 			}
 		}
@@ -474,7 +474,7 @@ bool build_pick_string(HMENU p_menu, UINT32 p_command, MCStringRef x_mutable)
 		if (t_success)
 		{
 			// SN-2014-80-28: [[ Bug 13289 ]] dwItemData contains what has been selected (the tag, if not the name).
-			/* UNCHECKED */ MCStringAppendChars(x_mutable, (unichar_t*)t_info . dwItemData, lstrlenW((unichar_t*)t_info . dwItemData));
+			/* UNCHECKED */ MCStringPrependChars(x_mutable, (unichar_t*)t_info . dwItemData, lstrlenW((unichar_t*)t_info . dwItemData));
 			return true;
 		}
 	}


### PR DESCRIPTION
This patch restores the LC 6.x behavior, where the parameter string passed to `statusIconMenuPick` message was constructed using `p_result . insert("|", 0, 0);` and `p_result . insert((char *)t_info . dwItemData, 0, 0);`, i.e. by prepending what has been selected to the output string
