### PR TITLE
[[ SB Externals ]] Detect iOS externals in mergext folder

### DIFF
--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -924,6 +924,16 @@ private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, 
    local tManifest
    set the itemDelimiter to slash
    repeat for each line tFile in pFiles
+      -- Added to support mergExt inclusion for iOS
+      if tFile begins with "!" then
+         local tExtPath
+         put revSBGetExternalPath("ios", char 2 to -1 of tFile) into tExtPath
+         -- if the file prefixed with ! was not a named external, treat normally
+         if tExtPath is not empty then
+            put tExtPath into tFile
+         end if
+      end if
+      
       local tIsAbsolute, tName
       put tFile begins with "/" or char 2 to 3 of tFile is ":/" into tIsAbsolute
       if the last item of tFile is "*" then
@@ -995,7 +1005,13 @@ private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, 
       -- MM-2012-09-18: Updated to use the new copied externals array instead of the copy files,
       -- where we extract the appropraite external for the instruciton set(s) we are building for.
       --
-      if tSource ends with ".lcext" and lcextFileIsZipArchive(tSource) then
+      local tIsZip, tError
+      put revSBLcextFileIsZipArchive(tSource, tError) into tIsZip
+      if tError is not empty then
+         throw tError
+      end if
+      
+      if tSource ends with ".lcext" and tIsZip then
          if tProcessedDylibs[tSource] then
             next repeat
          end if         
@@ -1076,19 +1092,6 @@ private command revCopyMobileFilesComputeFolderManifest @xManifest, pSource, pTa
 end revCopyMobileFilesComputeFolderManifest
 
 ################################################################################
-
-private function lcextFileIsZipArchive pFile
-   open file pFile for binary read
-   if the result is empty then
-      read from file pFile for 4 bytes
-      close file pFile
-   end if
-   if it is empty then
-      throw "could not open external -" && pFile
-   end if
-   
-   return byte 1 of it is "P" and byte 2 of it is "K" and byte 3 of it is numToChar(3) and byte 4 of it is numToChar(4)
-end lcextFileIsZipArchive
 
 -- MERG-2013-09-05: [[ Bug 11152 ]] Change to function to return whether the external was found or not. 
 private function lcextExtractExternal pExternal, pBuild, pTarget

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1048,7 +1048,7 @@ local sExternalsLocationA
 function revSBExternalsList pPlatform
    if sExternalsLocationA is empty then
       local tMergExtFolder
-      put specialFolderPath("engine") & "/Tools/MergExt" into tMergExtFolder
+      put revEnvironmentToolsPath() & "/MergExt" into tMergExtFolder
       
       local tContents
       put __revSBEnumerateFolder(tMergExtFolder, tMergExtFolder & slash) into tContents

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -995,3 +995,88 @@ function revSBLibraryList
 
    return the keys of tLibrariesA
 end revSBLibraryList
+
+function revSBLcextFileIsZipArchive pFile, @rError
+   open file pFile for binary read
+   if the result is empty then
+      read from file pFile for 4 bytes
+      close file pFile
+   end if
+   if it is empty then
+      put "could not open external -" && pFile into rError
+      return false
+   end if
+   
+   return byte 1 of it is "P" and byte 2 of it is "K" and byte 3 of it is numToChar(3) and byte 4 of it is numToChar(4)
+end revSBLcextFileIsZipArchive
+
+function revSBLcextExternalHasiOSFolder pExternal
+   local tContents
+   revZipOpenArchive pExternal, "read"
+   if the result is empty then
+      put revZipEnumerateItems(pExternal) into tContents
+      filter tContents with "iOS/*"
+   end if
+   return tContents is not empty
+end revSBLcextExternalHasiOSFolder
+
+function revSBLcextFileIsIOSExternal pFile
+   local tError
+   return revSBLcextFileIsZipArchive(pFile, tError) and \
+         revSBLcextExternalHasiOSFolder(pFile)
+end revSBLcextFileIsIOSExternal
+
+private function __filterExternalsForIOS pList
+   filter pList with "*.lcext"
+   
+   local tList, tError
+   repeat for each line tLine in pList
+      if revSBLcextFileIsIOSExternal(tLine) then
+         if tList is empty then
+            put tLine into tList
+         else
+            put return & tLine after tList
+         end if
+      end if
+   end repeat
+   return tList
+end __filterExternalsForIOS
+
+-- This is currently just used for iOS externals that are present in the
+-- 'mergExt' folder in the app bundle or equivalent
+local sExternalsLocationA
+function revSBExternalsList pPlatform
+   if sExternalsLocationA is empty then
+      local tMergExtFolder
+      put specialFolderPath("engine") & "/Tools/MergExt" into tMergExtFolder
+      
+      local tContents
+      put __revSBEnumerateFolder(tMergExtFolder, tMergExtFolder & slash) into tContents
+      
+      local tRawList
+      switch pPlatform
+         case "ios"
+            put __filterExternalsForIOS(tContents) into tRawList
+            break
+         default
+            put empty into tRawList
+            break
+      end switch
+      
+      split tRawList by return
+      set the itemdelimiter to "."
+      set the linedelimiter to slash
+      repeat for each element tExtPath in tRawList
+         put tExtPath into sExternalsLocationA[pPlatform][item 1 of line -1 of tExtPath]
+      end repeat
+   end if
+   return the keys of sExternalsLocationA[pPlatform]
+end revSBExternalsList
+
+function revSBGetExternalPath pPlatform, pName
+   if sExternalsLocationA is empty then
+      get revSBExternalsList(pPlatform)
+   end if
+   
+   return sExternalsLocationA[pPlatform][pName] into tExtPath
+end revSBGetExternalPath


### PR DESCRIPTION
- Move some iOS external detection code into revSBLibrary
- Add function to list per-platform externals
- Treat `!<external>` in copy files list as a ref to a mergext external
