### PR TITLE
[[ Community Docs ]] patterns - formatting fixes

### DIFF
--- a/docs/dictionary/property/patterns.lcdoc
+++ b/docs/dictionary/property/patterns.lcdoc
@@ -21,29 +21,41 @@ Example:
 set the patterns of me to storedPatternsList
 
 Value:
-The <patterns> of an <object> is a list of pattern specifiers, one per <line>.  A pattern specifier is a built-in pattern number between 1 and 164 (corresponding to LiveCode's built-in patterns 136 to 300), or the <ID> of an <image> to use for a pattern. LiveCode looks for the specified <image> first in the <current stack>, then in other open <stacks>.
-The <patterns> of an <object> contains eight <lines>, some of which may be empty.
+The <patterns> of an <object> is a list of pattern specifiers, one per <line>. A pattern specifier 
+is a built-in pattern number between 1 and 164 (corresponding to LiveCode's built-in patterns 136 to 
+300), or the <ID> of an <image> to use for a pattern. LiveCode looks for the specified <image> first 
+in the <current stack>, then in other open <stacks>.
+The <patterns> of an <object> consists of eight <lines>, some of which may be empty.
 
 Description:
-Use the <patterns> <property> to get all eight basic pattern <properties> at once, or to set the patterns of one <object> to be the same as the patterns of another <object>.
+Use the <patterns> <property> to get all eight basic pattern <properties> at once, or to set the 
+patterns of one <object> to be the same as the patterns of another <object>.
 
-You can set all these patterns individually; the <patterns> <property> simply provides a shorter method of dealing with all of them at once. Each <line> of the <patterns> corresponds to one of the following pattern <properties> :
+You can set all these patterns individually; the <patterns> <property> simply provides a shorter 
+method of dealing with all of them at once. Each <line> of the <patterns> corresponds to one of the 
+following pattern <properties> :
 
-        * Line 1: the foregroundPattern
-        * Line 2: the <backgroundPattern> 
-        * Line 3: the hilitePattern
-        * Line 4: the <borderPattern> 
-        * Line 5: the topPattern
-        * Line 6: the <bottomPattern> 
-        * Line 7: the shadowPattern
-        * Line 8: the focusPattern
+ * Line 1: the foregroundPattern
+ * Line 2: the <backgroundPattern> 
+ * Line 3: the hilitePattern
+ * Line 4: the <borderPattern> 
+ * Line 5: the topPattern
+ * Line 6: the <bottomPattern> 
+ * Line 7: the shadowPattern
+ * Line 8: the focusPattern
 
-If you leave a line blank when setting the <patterns>, the pattern <property> corresponding to that <line> is left unchanged.
+If you leave a line blank when setting the <patterns>, the pattern <property> corresponding to that 
+<line> is left unchanged.
 
-If the <patterns> <property> of an <object> reports a blank <line>, the corresponding pattern is not set for the individual <object>, but is <inheritance|inherited> from the <object|object's> <owner>. Use the form the effective patterns of <object> to obtain the patterns used for the object, whether set for the <object> or <inheritance|inherited>.
+If the <patterns> <property> of an <object> reports a blank <line>, the corresponding pattern is not 
+set for the individual <object>, but is <inheritance|inherited> from the <object|object's> <owner>. 
+Use the form the effective patterns of <object> to obtain the patterns used for the object, whether 
+set for the <object> or <inheritance|inherited>.
 
 If a pattern is set for an object, that pattern is used instead of the corresponding color for that object.
 
-References: borderPattern (property), bottomPattern (property), properties (property), owner (property), backgroundPattern (property), ID (property), lines (keyword), image (keyword), line (keyword), object (object), property (glossary), current stack (glossary), inheritance (glossary), stacks (function)
+References: borderPattern (property), bottomPattern (property), colors (property), properties (property), owner (property), 
+backgroundPattern (property), ID (property), lines (keyword), image (keyword), line (keyword), object (glossary), 
+property (glossary), current stack (glossary), inheritance (glossary), stacks (function)
 
 Tags: ui

--- a/docs/dictionary/property/patterns.lcdoc
+++ b/docs/dictionary/property/patterns.lcdoc
@@ -17,7 +17,8 @@ Platforms: desktop,server,web,mobile
 Example:
 set the patterns of button 1 to the patterns of card "Template"
 
-Example:
+Example
+local storedPatternsList
 set the patterns of me to storedPatternsList
 
 Value:
@@ -35,14 +36,14 @@ You can set all these patterns individually; the <patterns> <property> simply pr
 method of dealing with all of them at once. Each <line> of the <patterns> corresponds to one of the 
 following pattern <properties> :
 
- * Line 1: the foregroundPattern
- * Line 2: the <backgroundPattern> 
- * Line 3: the hilitePattern
- * Line 4: the <borderPattern> 
- * Line 5: the topPattern
- * Line 6: the <bottomPattern> 
- * Line 7: the shadowPattern
- * Line 8: the focusPattern
+* Line 1: the <foregroundPattern>
+* Line 2: the <backgroundPattern>
+* Line 3: the <hilitePattern>
+* Line 4: the <borderPattern>
+* Line 5: the <topPattern> 
+* Line 6: the <bottomPattern>
+* Line 7: the <shadowPattern>
+* Line 8: the <focusPattern>
 
 If you leave a line blank when setting the <patterns>, the pattern <property> corresponding to that 
 <line> is left unchanged.
@@ -54,8 +55,10 @@ set for the <object> or <inheritance|inherited>.
 
 If a pattern is set for an object, that pattern is used instead of the corresponding color for that object.
 
-References: borderPattern (property), bottomPattern (property), colors (property), properties (property), owner (property), 
-backgroundPattern (property), ID (property), lines (keyword), image (keyword), line (keyword), object (glossary), 
-property (glossary), current stack (glossary), inheritance (glossary), stacks (function)
+References: foregroundPattern (property), backgroundPattern (property), hilitePattern (property), 
+borderPattern (property), topPattern (property), bottomPattern (property), shadowPattern (property), 
+focusPattern (property), colors (property), properties (property), owner (property), ID (property), 
+lines (keyword), image (keyword), line (keyword), object (glossary), property (glossary), 
+current stack (glossary), inheritance (glossary), stacks (function)
 
 Tags: ui

--- a/docs/notes/bugfix-17578.md
+++ b/docs/notes/bugfix-17578.md
@@ -1,0 +1,1 @@
+# List of patterns over indented in docs


### PR DESCRIPTION
- Line descriptions were indented too far, causing them to be rendered as a code block instead of a list.
- Object reference was incorrect, so links were not showing up.
- Hard wrapped long lines.
