### PR TITLE
[[ Bug 17104 ]] Change MCStringFindAndReplace to use MCStringFind

### DIFF
--- a/docs/notes/bugfix-17104.md
+++ b/docs/notes/bugfix-17104.md
@@ -1,0 +1,1 @@
+# Ensure replace works correctly with decomposed characters

--- a/tests/lcs/core/strings/replace.livecodescript
+++ b/tests/lcs/core/strings/replace.livecodescript
@@ -1,0 +1,44 @@
+﻿script "CoreStringReplace"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestReplace
+   local tNeedle, tNewNeedle, tHaystack
+   put "é" into tNeedle
+   put "e" into tNewNeedle
+   put "héllo" into tHaystack
+   replace tNeedle with tNewNeedle in tHaystack
+   TestAssert "replace composed with base in composed", tHaystack is "hello"
+   
+   put normalizeText("é", "NFD") into tNeedle
+   put "e" into tNewNeedle
+   put "héllo" into tHaystack
+   replace tNeedle with tNewNeedle in tHaystack
+   TestAssert "replace decomposed with base in composed", tHaystack is "hello"
+   
+   put "é" into tNeedle
+   put "e" into tNewNeedle
+   put normalizeText("héllo", "NFD") into tHaystack
+   replace tNeedle with tNewNeedle in tHaystack
+   TestAssert "replace composed with base in decomposed", tHaystack is "hello"
+   
+   put normalizeText("é", "NFD") into tNeedle
+   put "e" into tNewNeedle
+   put normalizeText("héllo", "NFD") into tHaystack
+   replace tNeedle with tNewNeedle in tHaystack
+   TestAssert "replace decomposed with base in decomposed", tHaystack is "hello"
+end TestReplace


### PR DESCRIPTION
This patch changes the MCStringFindAndReplace API to use MCStringFind
which returns the range of the found string in the target string.

This ensures that replacement works correctly regardless of the
normalization form of the needle or the haystack.
