### PR TITLE
[[Bug 16730]] Added the ability to access aspect-specific bounding

### DIFF
--- a/extensions/widgets/svgpath/notes/bugfix-16730.md
+++ b/extensions/widgets/svgpath/notes/bugfix-16730.md
@@ -1,1 +1,0 @@
-# [16730] Add the ability to access the scaledWidth and scaledHeight of an svgPath widget

--- a/extensions/widgets/svgpath/notes/bugfix-16730.md
+++ b/extensions/widgets/svgpath/notes/bugfix-16730.md
@@ -1,0 +1,1 @@
+# [16730] Add the ability to access the scaledWidth and scaledHeight of an svgPath widget

--- a/extensions/widgets/svgpath/notes/feature-svgWidgetScaledSizeProperty.md
+++ b/extensions/widgets/svgpath/notes/feature-svgWidgetScaledSizeProperty.md
@@ -1,0 +1,5 @@
+# Properties
+
+* New **scaledWidth** and **scaledHeight** properties has been added.  These are read-only values
+  that expose the effective size of the rendered SVG path independent of the widget size. When
+  maintainAspectRatio is false, then these values are equal to the width and height of the widget.

--- a/extensions/widgets/svgpath/notes/feature-svgWidgetScaledSizeProperty.md
+++ b/extensions/widgets/svgpath/notes/feature-svgWidgetScaledSizeProperty.md
@@ -1,5 +1,5 @@
 # Properties
 
-* New **scaledWidth** and **scaledHeight** properties has been added.  These are read-only values
+* New **scaledWidth** and **scaledHeight** properties have been added.  These are read-only values
   that expose the effective size of the rendered SVG path independent of the widget size. When
   maintainAspectRatio is false, then these values are equal to the width and height of the widget.

--- a/extensions/widgets/svgpath/svgpath.lcb
+++ b/extensions/widgets/svgpath/svgpath.lcb
@@ -262,8 +262,6 @@ public handler OnCreate()
 	put false into mFlipVertically
 	put "non-zero" into mFillRule
 	setPathPreset("Star")
-
-	CalculateScaledSizes()
 end handler
 ----------
 
@@ -336,6 +334,7 @@ end handler
 
 public handler setMaintainAspectRatio(in pBoolean as Boolean)
 	put pBoolean into mMaintainAspectRatio
+	CalculateScaledSizes()
 	redraw all
 end handler
 
@@ -347,17 +346,20 @@ end handler
 public handler setPath(in pPath as String) returns nothing
 	put pPath into mPath
 	put "" into mPathName
+	CalculateScaledSizes()
 	redraw all
 end handler
 
 public handler setPathPreset(in pPresetName as String) returns nothing
 	put iconSVGPathFromName(pPresetName) into mPath
 	put pPresetName into mPathName
+	CalculateScaledSizes()
 	redraw all
 end handler
 
 public handler setAngle(in pAngle as Number) returns nothing
 	put pAngle into mAngle
+	CalculateScaledSizes()
 	redraw all
 end handler
 

--- a/extensions/widgets/svgpath/svgpath.lcb
+++ b/extensions/widgets/svgpath/svgpath.lcb
@@ -36,16 +36,16 @@ metadata version is "2.1.0"
 metadata svgicon is "M61.8,0H4C1.8,0,0,1.8,0,4v27.8c0,2.2,1.8,4,4,4h57.8c2.2,0,4-1.8,4-4V4C65.8,1.8,64,0,61.8,0z M20.9,25.3c-1.2,0.9-2.8,1.4-4.9,1.4c-0.8,0-1.6-0.1-2.2-0.2c-0.7-0.1-1.3-0.3-1.9-0.5c-0.1,0.2-0.3,0.4-0.5,0.5s-0.5,0.2-0.8,0.2c-0.6,0-1-0.1-1.2-0.3c-0.2-0.2-0.4-0.6-0.4-1.2l-0.1-3.2v-0.2c0-0.6,0.1-1,0.3-1.3c0.2-0.2,0.6-0.4,1.2-0.4c0.6,0,1.1,0.4,1.5,1.3c0.1,0.2,0.2,0.4,0.2,0.5c0.4,0.7,0.9,1.2,1.5,1.6c0.6,0.4,1.4,0.5,2.4,0.5c0.8,0,1.5-0.2,2-0.5c0.5-0.4,0.7-0.8,0.7-1.5c0-1-1.1-1.7-3.2-2.2c-0.6-0.1-1.1-0.3-1.5-0.4c-1.8-0.5-3-1.1-3.7-1.8c-0.7-0.7-1-1.7-1-2.9c0-1.6,0.6-2.9,1.8-3.9c1.2-1,2.7-1.5,4.6-1.5c0.6,0,1.2,0.1,1.8,0.2c0.6,0.1,1.2,0.3,1.8,0.6c0.1-0.3,0.3-0.5,0.5-0.6c0.2-0.1,0.4-0.2,0.8-0.2c0.5,0,0.9,0.1,1,0.3c0.2,0.2,0.2,0.6,0.3,1.2l0.1,2.7v0.2c0,0.5-0.1,0.9-0.3,1.1c-0.2,0.2-0.6,0.3-1.1,0.3c-0.7,0-1.1-0.4-1.5-1.1c0-0.1-0.1-0.2-0.1-0.2c-0.3-0.6-0.7-1-1.2-1.3c-0.5-0.3-1.1-0.4-1.7-0.4c-0.8,0-1.5,0.2-2,0.6s-0.8,0.9-0.8,1.5c0,0.8,1.2,1.5,3.5,2c0.4,0.1,0.7,0.1,0.9,0.2c1.8,0.4,3.1,1,3.8,1.8c0.8,0.8,1.2,1.9,1.2,3.2C22.6,23.1,22,24.4,20.9,25.3zM40.9,12.5c-0.3,0.3-0.6,0.4-1.1,0.4h-0.2l-4.2,12c-0.2,0.6-0.4,1-0.6,1.1s-0.6,0.2-1.1,0.2h-1.7c-0.8,0-1.4-0.4-1.7-1.3l0-0.1l-4.3-12h-0.2c-0.5,0-0.8-0.1-1.1-0.4s-0.4-0.6-0.4-1.1c0-0.6,0.1-0.9,0.4-1.2s0.7-0.4,1.3-0.4H30c0.6,0,1,0.1,1.3,0.4c0.3,0.2,0.4,0.6,0.4,1.2c0,0.5-0.1,0.9-0.4,1.2c-0.3,0.2-0.7,0.4-1.3,0.4h-0.4l3.3,9.8l3.4-9.8H36c-0.6,0-1-0.1-1.3-0.4c-0.3-0.2-0.4-0.6-0.4-1.2c0-0.5,0.1-0.9,0.4-1.2c0.3-0.2,0.7-0.4,1.3-0.4h3.5c0.6,0,1.1,0.1,1.3,0.4c0.3,0.2,0.4,0.6,0.4,1.2C41.3,11.9,41.2,12.2,40.9,12.5z M57.8,20.6c-0.3,0.3-0.6,0.4-1.1,0.4h-0.2v3.3v0.2c0,0.3,0,0.5-0.1,0.6s-0.2,0.2-0.4,0.4c-0.5,0.3-1.4,0.6-2.5,0.8c-1.1,0.2-2.3,0.4-3.5,0.4c-2.4,0-4.4-0.8-5.9-2.4c-1.5-1.6-2.2-3.7-2.2-6.2c0-2.5,0.8-4.5,2.3-6.2c1.5-1.6,3.4-2.5,5.8-2.5c0.6,0,1.3,0.1,1.9,0.2s1.3,0.4,2,0.7c0.2-0.3,0.4-0.6,0.6-0.7c0.2-0.1,0.4-0.2,0.7-0.2c0.5,0,0.8,0.1,1,0.4c0.2,0.2,0.3,0.6,0.3,1.2l0,3.6c0,0.6-0.1,1.1-0.3,1.3c-0.2,0.2-0.6,0.3-1.1,0.3c-0.4,0-0.7-0.1-0.9-0.3c-0.2-0.2-0.4-0.5-0.5-1C53.3,14,53,13.4,52.5,13s-1.2-0.6-2.2-0.6c-1.4,0-2.5,0.5-3.3,1.4c-0.8,1-1.1,2.3-1.1,4.2s0.4,3.2,1.2,4.2c0.8,1,1.9,1.5,3.4,1.5c0.3,0,0.7,0,1.1-0.1c0.4-0.1,0.9-0.2,1.5-0.4V21h-1.6c-0.6,0-1.1-0.1-1.3-0.3c-0.3-0.2-0.4-0.6-0.4-1.1c0-0.6,0.1-0.9,0.4-1.2s0.7-0.4,1.3-0.4h5c0.6,0,1.1,0.1,1.4,0.3s0.4,0.6,0.4,1.2C58.2,20,58.1,20.4,57.8,20.6z"
 
 private variable mPathName as String
-private variable mPath    		as String
-private variable mHilited      as Boolean
+private variable mPath as String
+private variable mHilited as Boolean
 private variable mMaintainAspectRatio as Boolean
 -- some SVG Paths need to be flipped (all font awesome SVG paths do,
 -- Illustrator SVG does not)
-private variable mFlipVertically     as Boolean
-private variable mAngle     as Real
+private variable mFlipVertically as Boolean
+private variable mAngle as Real
 private variable mFillRule as String
-private variable mWidth as Real
-private variable mHeight as Real
+private variable mScaledWidth as Real
+private variable mScaledHeight as Real
 
 
 /**
@@ -172,7 +172,7 @@ Otherwise, it will return the width of the widget.
 
 Related: scaledHeight(property), maintainAspectRatio(property)
 */
-property "scaledWidth" get mWidth
+property "scaledWidth" get mScaledWidth
 
 /**
 Syntax:
@@ -187,7 +187,7 @@ Otherwise, it will return the height of the widget.
 
 Related: scaledWidth(property), maintainAspectRatio(property)
 */
-property "scaledHeight" get mHeight
+property "scaledHeight" get mScaledHeight
 
 /**
 Syntax:
@@ -262,6 +262,8 @@ public handler OnCreate()
 	put false into mFlipVertically
 	put "non-zero" into mFillRule
 	setPathPreset("Star")
+
+	CalculateScaledSizes()
 end handler
 ----------
 
@@ -276,8 +278,6 @@ public handler OnSave(out rProperties as Array)
 	put mFlipVertically into rProperties["flip vertically"]
 	put mAngle into rProperties["angle"]
 	put mFillRule into rProperties["fillRule"]
-	put mWidth into rProperties["scaledWidth"]
-	put mHeight into rProperties["scaledHeight"]
 end handler
 ----------
 
@@ -289,13 +289,20 @@ public handler OnLoad(in pProperties as Array)
 	put pProperties["maintain aspect ratio"] into mMaintainAspectRatio
 	put pProperties["flip vertically"] into mFlipVertically
 	put pProperties["angle"] into mAngle
-	put pProperties["scaledWidth"] into mWidth
-	put pProperties["scaledHeight"] into mHeight
 
 	// Older SVG widgets do not have this property
 	if "fillRule" is among the keys of pProperties then
 		put pProperties["fillRule"] into mFillRule
 	end if
+
+	CalculateScaledSizes()
+end handler
+----------
+
+----------
+-- this handler is called when the widget is resized
+public handler OnGeometryChanged()
+	CalculateScaledSizes()
 end handler
 ----------
 
@@ -322,18 +329,15 @@ public handler OnMouseLeave()
 end handler
 ----------
 
-
 public handler setIsHilited(in pBoolean as Boolean)
 	put pBoolean into mHilited
 	redraw all
 end handler
 
-
 public handler setMaintainAspectRatio(in pBoolean as Boolean)
 	put pBoolean into mMaintainAspectRatio
 	redraw all
 end handler
-
 
 public handler setFlipVertically(in pBoolean as Boolean)
 	put pBoolean into mFlipVertically
@@ -351,7 +355,6 @@ public handler setPathPreset(in pPresetName as String) returns nothing
 	put pPresetName into mPathName
 	redraw all
 end handler
-
 
 public handler setAngle(in pAngle as Number) returns nothing
 	put pAngle into mAngle
@@ -382,18 +385,14 @@ public handler OnPaint()
 	// scale to fit within widget and maintain aspect ratio
 	if mMaintainAspectRatio then
 		constrainPathToRect(my bounds, tPath)
-		put the width of the bounding box of tPath into mWidth
-		put the height of the bounding box of tPath into mHeight
 	else
-		put my height into mHeight
-		put my width into mWidth
 		scale tPath by [my width / the width of the bounding box of tPath, \
 				my height / the height of the bounding box of tPath]
 		put the bounding box of tPath into tBounds
 		translate tPath by [the left of tBounds * -1, the top of tBounds * -1]
 	end if
 
-	if  mHilited is false then
+	if mHilited is false then
 		set the paint of this canvas to my foreground paint
 	else
 		set the paint of this canvas to my highlight paint
@@ -403,5 +402,23 @@ public handler OnPaint()
 
 	fill tPath on this canvas
 end handler
+----------
+
+----------
+-- used in various places to calculate the scaledWidth & scaledHeight variables
+private handler CalculateScaledSizes()
+	//recalculate the bounding box for the path
+	variable tPath as Path
+	put path mPath into tPath
+	if mMaintainAspectRatio then
+		constrainPathToRect(my bounds, tPath)
+		put the width of the bounding box of tPath into mScaledWidth
+		put the height of the bounding box of tPath into mScaledHeight
+	else
+		put my width into mScaledWidth
+		put my height into mScaledHeight
+	end if
+end handler
+----------
 
 end widget

--- a/extensions/widgets/svgpath/svgpath.lcb
+++ b/extensions/widgets/svgpath/svgpath.lcb
@@ -32,7 +32,7 @@ use com.livecode.library.widgetutils
 -- adding metadata to ensure the extension displays correctly in livecode
 metadata title is "SVG Icon"
 metadata author is "LiveCode"
-metadata version is "2.0.1"
+metadata version is "2.1.0"
 metadata svgicon is "M61.8,0H4C1.8,0,0,1.8,0,4v27.8c0,2.2,1.8,4,4,4h57.8c2.2,0,4-1.8,4-4V4C65.8,1.8,64,0,61.8,0z M20.9,25.3c-1.2,0.9-2.8,1.4-4.9,1.4c-0.8,0-1.6-0.1-2.2-0.2c-0.7-0.1-1.3-0.3-1.9-0.5c-0.1,0.2-0.3,0.4-0.5,0.5s-0.5,0.2-0.8,0.2c-0.6,0-1-0.1-1.2-0.3c-0.2-0.2-0.4-0.6-0.4-1.2l-0.1-3.2v-0.2c0-0.6,0.1-1,0.3-1.3c0.2-0.2,0.6-0.4,1.2-0.4c0.6,0,1.1,0.4,1.5,1.3c0.1,0.2,0.2,0.4,0.2,0.5c0.4,0.7,0.9,1.2,1.5,1.6c0.6,0.4,1.4,0.5,2.4,0.5c0.8,0,1.5-0.2,2-0.5c0.5-0.4,0.7-0.8,0.7-1.5c0-1-1.1-1.7-3.2-2.2c-0.6-0.1-1.1-0.3-1.5-0.4c-1.8-0.5-3-1.1-3.7-1.8c-0.7-0.7-1-1.7-1-2.9c0-1.6,0.6-2.9,1.8-3.9c1.2-1,2.7-1.5,4.6-1.5c0.6,0,1.2,0.1,1.8,0.2c0.6,0.1,1.2,0.3,1.8,0.6c0.1-0.3,0.3-0.5,0.5-0.6c0.2-0.1,0.4-0.2,0.8-0.2c0.5,0,0.9,0.1,1,0.3c0.2,0.2,0.2,0.6,0.3,1.2l0.1,2.7v0.2c0,0.5-0.1,0.9-0.3,1.1c-0.2,0.2-0.6,0.3-1.1,0.3c-0.7,0-1.1-0.4-1.5-1.1c0-0.1-0.1-0.2-0.1-0.2c-0.3-0.6-0.7-1-1.2-1.3c-0.5-0.3-1.1-0.4-1.7-0.4c-0.8,0-1.5,0.2-2,0.6s-0.8,0.9-0.8,1.5c0,0.8,1.2,1.5,3.5,2c0.4,0.1,0.7,0.1,0.9,0.2c1.8,0.4,3.1,1,3.8,1.8c0.8,0.8,1.2,1.9,1.2,3.2C22.6,23.1,22,24.4,20.9,25.3zM40.9,12.5c-0.3,0.3-0.6,0.4-1.1,0.4h-0.2l-4.2,12c-0.2,0.6-0.4,1-0.6,1.1s-0.6,0.2-1.1,0.2h-1.7c-0.8,0-1.4-0.4-1.7-1.3l0-0.1l-4.3-12h-0.2c-0.5,0-0.8-0.1-1.1-0.4s-0.4-0.6-0.4-1.1c0-0.6,0.1-0.9,0.4-1.2s0.7-0.4,1.3-0.4H30c0.6,0,1,0.1,1.3,0.4c0.3,0.2,0.4,0.6,0.4,1.2c0,0.5-0.1,0.9-0.4,1.2c-0.3,0.2-0.7,0.4-1.3,0.4h-0.4l3.3,9.8l3.4-9.8H36c-0.6,0-1-0.1-1.3-0.4c-0.3-0.2-0.4-0.6-0.4-1.2c0-0.5,0.1-0.9,0.4-1.2c0.3-0.2,0.7-0.4,1.3-0.4h3.5c0.6,0,1.1,0.1,1.3,0.4c0.3,0.2,0.4,0.6,0.4,1.2C41.3,11.9,41.2,12.2,40.9,12.5z M57.8,20.6c-0.3,0.3-0.6,0.4-1.1,0.4h-0.2v3.3v0.2c0,0.3,0,0.5-0.1,0.6s-0.2,0.2-0.4,0.4c-0.5,0.3-1.4,0.6-2.5,0.8c-1.1,0.2-2.3,0.4-3.5,0.4c-2.4,0-4.4-0.8-5.9-2.4c-1.5-1.6-2.2-3.7-2.2-6.2c0-2.5,0.8-4.5,2.3-6.2c1.5-1.6,3.4-2.5,5.8-2.5c0.6,0,1.3,0.1,1.9,0.2s1.3,0.4,2,0.7c0.2-0.3,0.4-0.6,0.6-0.7c0.2-0.1,0.4-0.2,0.7-0.2c0.5,0,0.8,0.1,1,0.4c0.2,0.2,0.3,0.6,0.3,1.2l0,3.6c0,0.6-0.1,1.1-0.3,1.3c-0.2,0.2-0.6,0.3-1.1,0.3c-0.4,0-0.7-0.1-0.9-0.3c-0.2-0.2-0.4-0.5-0.5-1C53.3,14,53,13.4,52.5,13s-1.2-0.6-2.2-0.6c-1.4,0-2.5,0.5-3.3,1.4c-0.8,1-1.1,2.3-1.1,4.2s0.4,3.2,1.2,4.2c0.8,1,1.9,1.5,3.4,1.5c0.3,0,0.7,0,1.1-0.1c0.4-0.1,0.9-0.2,1.5-0.4V21h-1.6c-0.6,0-1.1-0.1-1.3-0.3c-0.3-0.2-0.4-0.6-0.4-1.1c0-0.6,0.1-0.9,0.4-1.2s0.7-0.4,1.3-0.4h5c0.6,0,1.1,0.1,1.4,0.3s0.4,0.6,0.4,1.2C58.2,20,58.1,20.4,57.8,20.6z"
 
 private variable mPathName as String
@@ -161,29 +161,33 @@ metadata maintainAspectRatio.label is "Fix aspect ratio"
 
 /**
 Syntax:
-get the aspectWidth of <widget>
+get the scaledWidth of <widget>
 
-Summary: The width of the bounding rect of the SVG path, in pixels.
+Summary: The width of the bounding rect of the SVG path, in fractional pixels.
 
 Description:
-If the <maintainAspectRatio> of the SVG path is `true`, then the <aspectWidth>
+If the <maintainAspectRatio> of the SVG path is `true`, then the <scaledWidth>
 of the object will return the width of the bounding rect of the SVG path.
 Otherwise, it will return the width of the widget.
+
+Related: scaledHeight(property), maintainAspectRatio(property)
 */
-property "aspectWidth" get mWidth
+property "scaledWidth" get mWidth
 
 /**
 Syntax:
-get the aspectHeight of <widget>
+get the scaledHeight of <widget>
 
-Summary: The height of the bounding rect of the SVG path, in pixels.
+Summary: The height of the bounding rect of the SVG path, in fractional pixels.
 
 Description:
-If the <maintainAspectRatio> of the SVG path is `true`, then the <aspectHeight>
-of the object will return the width of the bounding rect of the SVG path.
-Otherwise, it will return the width of the widget.
+If the <maintainAspectRatio> of the SVG path is `true`, then the <scaledHeight>
+of the object will return the height of the bounding rect of the SVG path.
+Otherwise, it will return the height of the widget.
+
+Related: scaledWidth(property), maintainAspectRatio(property)
 */
-property "aspectHeight" get mHeight
+property "scaledHeight" get mHeight
 
 /**
 Syntax:
@@ -242,7 +246,6 @@ encirclements.
 See https://www.w3.org/TR/SVG/painting.html#FillRuleProperty for examples of
 the "non-zero" and "even odd" fill rules.
 */
-
 property fillRule       get mFillRule      set setFillRule
 metadata fillRule.editor is "com.livecode.pi.enum"
 metadata fillRule.options is "non-zero,even odd"
@@ -273,8 +276,8 @@ public handler OnSave(out rProperties as Array)
 	put mFlipVertically into rProperties["flip vertically"]
 	put mAngle into rProperties["angle"]
 	put mFillRule into rProperties["fillRule"]
-	put mWidth into rProperties["aspectWidth"]
-	put mHeight into rProperties["aspectHeight"]
+	put mWidth into rProperties["scaledWidth"]
+	put mHeight into rProperties["scaledHeight"]
 end handler
 ----------
 
@@ -286,10 +289,10 @@ public handler OnLoad(in pProperties as Array)
 	put pProperties["maintain aspect ratio"] into mMaintainAspectRatio
 	put pProperties["flip vertically"] into mFlipVertically
 	put pProperties["angle"] into mAngle
-	put pProperties["aspectWidth"] into mWidth
-	put pProperties["aspectHeight"] into mHeight
+	put pProperties["scaledWidth"] into mWidth
+	put pProperties["scaledHeight"] into mHeight
 
-   // Older SVG widgets do not have this property
+	// Older SVG widgets do not have this property
 	if "fillRule" is among the keys of pProperties then
 		put pProperties["fillRule"] into mFillRule
 	end if
@@ -382,8 +385,8 @@ public handler OnPaint()
 		put the width of the bounding box of tPath into mWidth
 		put the height of the bounding box of tPath into mHeight
 	else
-	    put my height into mHeight
-	    put my width into mWidth
+		put my height into mHeight
+		put my width into mWidth
 		scale tPath by [my width / the width of the bounding box of tPath, \
 				my height / the height of the bounding box of tPath]
 		put the bounding box of tPath into tBounds

--- a/extensions/widgets/svgpath/svgpath.lcb
+++ b/extensions/widgets/svgpath/svgpath.lcb
@@ -32,7 +32,7 @@ use com.livecode.library.widgetutils
 -- adding metadata to ensure the extension displays correctly in livecode
 metadata title is "SVG Icon"
 metadata author is "LiveCode"
-metadata version is "2.0.0"
+metadata version is "2.0.1"
 metadata svgicon is "M61.8,0H4C1.8,0,0,1.8,0,4v27.8c0,2.2,1.8,4,4,4h57.8c2.2,0,4-1.8,4-4V4C65.8,1.8,64,0,61.8,0z M20.9,25.3c-1.2,0.9-2.8,1.4-4.9,1.4c-0.8,0-1.6-0.1-2.2-0.2c-0.7-0.1-1.3-0.3-1.9-0.5c-0.1,0.2-0.3,0.4-0.5,0.5s-0.5,0.2-0.8,0.2c-0.6,0-1-0.1-1.2-0.3c-0.2-0.2-0.4-0.6-0.4-1.2l-0.1-3.2v-0.2c0-0.6,0.1-1,0.3-1.3c0.2-0.2,0.6-0.4,1.2-0.4c0.6,0,1.1,0.4,1.5,1.3c0.1,0.2,0.2,0.4,0.2,0.5c0.4,0.7,0.9,1.2,1.5,1.6c0.6,0.4,1.4,0.5,2.4,0.5c0.8,0,1.5-0.2,2-0.5c0.5-0.4,0.7-0.8,0.7-1.5c0-1-1.1-1.7-3.2-2.2c-0.6-0.1-1.1-0.3-1.5-0.4c-1.8-0.5-3-1.1-3.7-1.8c-0.7-0.7-1-1.7-1-2.9c0-1.6,0.6-2.9,1.8-3.9c1.2-1,2.7-1.5,4.6-1.5c0.6,0,1.2,0.1,1.8,0.2c0.6,0.1,1.2,0.3,1.8,0.6c0.1-0.3,0.3-0.5,0.5-0.6c0.2-0.1,0.4-0.2,0.8-0.2c0.5,0,0.9,0.1,1,0.3c0.2,0.2,0.2,0.6,0.3,1.2l0.1,2.7v0.2c0,0.5-0.1,0.9-0.3,1.1c-0.2,0.2-0.6,0.3-1.1,0.3c-0.7,0-1.1-0.4-1.5-1.1c0-0.1-0.1-0.2-0.1-0.2c-0.3-0.6-0.7-1-1.2-1.3c-0.5-0.3-1.1-0.4-1.7-0.4c-0.8,0-1.5,0.2-2,0.6s-0.8,0.9-0.8,1.5c0,0.8,1.2,1.5,3.5,2c0.4,0.1,0.7,0.1,0.9,0.2c1.8,0.4,3.1,1,3.8,1.8c0.8,0.8,1.2,1.9,1.2,3.2C22.6,23.1,22,24.4,20.9,25.3zM40.9,12.5c-0.3,0.3-0.6,0.4-1.1,0.4h-0.2l-4.2,12c-0.2,0.6-0.4,1-0.6,1.1s-0.6,0.2-1.1,0.2h-1.7c-0.8,0-1.4-0.4-1.7-1.3l0-0.1l-4.3-12h-0.2c-0.5,0-0.8-0.1-1.1-0.4s-0.4-0.6-0.4-1.1c0-0.6,0.1-0.9,0.4-1.2s0.7-0.4,1.3-0.4H30c0.6,0,1,0.1,1.3,0.4c0.3,0.2,0.4,0.6,0.4,1.2c0,0.5-0.1,0.9-0.4,1.2c-0.3,0.2-0.7,0.4-1.3,0.4h-0.4l3.3,9.8l3.4-9.8H36c-0.6,0-1-0.1-1.3-0.4c-0.3-0.2-0.4-0.6-0.4-1.2c0-0.5,0.1-0.9,0.4-1.2c0.3-0.2,0.7-0.4,1.3-0.4h3.5c0.6,0,1.1,0.1,1.3,0.4c0.3,0.2,0.4,0.6,0.4,1.2C41.3,11.9,41.2,12.2,40.9,12.5z M57.8,20.6c-0.3,0.3-0.6,0.4-1.1,0.4h-0.2v3.3v0.2c0,0.3,0,0.5-0.1,0.6s-0.2,0.2-0.4,0.4c-0.5,0.3-1.4,0.6-2.5,0.8c-1.1,0.2-2.3,0.4-3.5,0.4c-2.4,0-4.4-0.8-5.9-2.4c-1.5-1.6-2.2-3.7-2.2-6.2c0-2.5,0.8-4.5,2.3-6.2c1.5-1.6,3.4-2.5,5.8-2.5c0.6,0,1.3,0.1,1.9,0.2s1.3,0.4,2,0.7c0.2-0.3,0.4-0.6,0.6-0.7c0.2-0.1,0.4-0.2,0.7-0.2c0.5,0,0.8,0.1,1,0.4c0.2,0.2,0.3,0.6,0.3,1.2l0,3.6c0,0.6-0.1,1.1-0.3,1.3c-0.2,0.2-0.6,0.3-1.1,0.3c-0.4,0-0.7-0.1-0.9-0.3c-0.2-0.2-0.4-0.5-0.5-1C53.3,14,53,13.4,52.5,13s-1.2-0.6-2.2-0.6c-1.4,0-2.5,0.5-3.3,1.4c-0.8,1-1.1,2.3-1.1,4.2s0.4,3.2,1.2,4.2c0.8,1,1.9,1.5,3.4,1.5c0.3,0,0.7,0,1.1-0.1c0.4-0.1,0.9-0.2,1.5-0.4V21h-1.6c-0.6,0-1.1-0.1-1.3-0.3c-0.3-0.2-0.4-0.6-0.4-1.1c0-0.6,0.1-0.9,0.4-1.2s0.7-0.4,1.3-0.4h5c0.6,0,1.1,0.1,1.4,0.3s0.4,0.6,0.4,1.2C58.2,20,58.1,20.4,57.8,20.6z"
 
 private variable mPathName as String
@@ -44,6 +44,9 @@ private variable mMaintainAspectRatio as Boolean
 private variable mFlipVertically     as Boolean
 private variable mAngle     as Real
 private variable mFillRule as String
+private variable mWidth as Real
+private variable mHeight as Real
+
 
 /**
 Syntax:
@@ -158,6 +161,32 @@ metadata maintainAspectRatio.label is "Fix aspect ratio"
 
 /**
 Syntax:
+get the aspectWidth of <widget>
+
+Summary: The width of the bounding rect of the SVG path, in pixels.
+
+Description:
+If the <maintainAspectRatio> of the SVG path is `true`, then the <aspectWidth>
+of the object will return the width of the bounding rect of the SVG path.
+Otherwise, it will return the width of the widget.
+*/
+property "aspectWidth" get mWidth
+
+/**
+Syntax:
+get the aspectHeight of <widget>
+
+Summary: The height of the bounding rect of the SVG path, in pixels.
+
+Description:
+If the <maintainAspectRatio> of the SVG path is `true`, then the <aspectHeight>
+of the object will return the width of the bounding rect of the SVG path.
+Otherwise, it will return the width of the widget.
+*/
+property "aspectHeight" get mHeight
+
+/**
+Syntax:
 set the flipped of <widget> to {true|false}
 get the flipped of <widget>
 
@@ -244,6 +273,8 @@ public handler OnSave(out rProperties as Array)
 	put mFlipVertically into rProperties["flip vertically"]
 	put mAngle into rProperties["angle"]
 	put mFillRule into rProperties["fillRule"]
+	put mWidth into rProperties["aspectWidth"]
+	put mHeight into rProperties["aspectHeight"]
 end handler
 ----------
 
@@ -255,6 +286,8 @@ public handler OnLoad(in pProperties as Array)
 	put pProperties["maintain aspect ratio"] into mMaintainAspectRatio
 	put pProperties["flip vertically"] into mFlipVertically
 	put pProperties["angle"] into mAngle
+	put pProperties["aspectWidth"] into mWidth
+	put pProperties["aspectHeight"] into mHeight
 
    // Older SVG widgets do not have this property
 	if "fillRule" is among the keys of pProperties then
@@ -346,7 +379,11 @@ public handler OnPaint()
 	// scale to fit within widget and maintain aspect ratio
 	if mMaintainAspectRatio then
 		constrainPathToRect(my bounds, tPath)
+		put the width of the bounding box of tPath into mWidth
+		put the height of the bounding box of tPath into mHeight
 	else
+	    put my height into mHeight
+	    put my width into mWidth
 		scale tPath by [my width / the width of the bounding box of tPath, \
 				my height / the height of the bounding box of tPath]
 		put the bounding box of tPath into tBounds

--- a/extensions/widgets/svgpath/tests/properties.livecodescript
+++ b/extensions/widgets/svgpath/tests/properties.livecodescript
@@ -22,6 +22,7 @@ end getPathData
 
 on TestSetup
 	TestLoadExtension "com.livecode.library.widgetutils"
+	TestLoadExtension "com.livecode.library.iconSVG"
 	TestLoadExtension "com.livecode.widget.svgPath"
 	create widget "testSvgPath" as "com.livecode.widget.svgPath"
 end TestSetup

--- a/extensions/widgets/svgpath/tests/properties.livecodescript
+++ b/extensions/widgets/svgpath/tests/properties.livecodescript
@@ -1,0 +1,67 @@
+﻿script "SvgPathWidgetProperties"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+private function getPathData
+     return "M1664 698Q1664 720 1638 746L1275 1100 1361 1600Q1362 1607 1362 1620 1362 1641 1351.5 1655.5 1341 1670 1321 1670 1302 1670 1281 1658L832 1422 383 1658Q361 1670 343 1670 322 1670 311.5 1655.5 301 1641 301 1620 301 1614 303 1600L389 1100 25 746Q0 719 0 698 0 661 56 652L558 579 783 124Q802 83 832 83 862 83 881 124L1106 579 1608 652Q1664 661 1664 698Z"
+end getPathData
+
+on TestSetup
+     TestLoadExtension "com.livecode.library.widgetutils"
+     TestLoadExtension "com.livecode.widget.svgPath"
+     create widget "testSvgPath" as "com.livecode.widget.svgPath"
+end TestSetup
+
+on TestTeardown
+     delete widget "testSvgPath"
+end TestTeardown
+
+on TestCreateHeader
+     TestAssert "created svgPath exists", there is a widget "testSvgPath"
+end TestCreateHeader
+
+on TestSetPath
+     set the iconPath of widget "testSvgPath" to getPathData()
+     TestAssert "iconPath set to default 'star' value", the iconPath of widget "testSvgPath" is getPathData()
+end TestSetPath
+
+on TestMaintainAspectRatioBasic
+     set the maintainAspectRatio of widget "testSvgPath" to true
+     TestAssert "maintainAspectRatio set to true", the maintainAspectRatio of widget "testSvgPath" is true
+     
+     set the maintainAspectRatio of widget "testSvgPath" to false
+     TestAssert "maintainAspectRatio set to false", the maintainAspectRatio of widget "testSvgPath" is false
+end TestMaintainAspectRatioBasic
+
+on TestSetRect
+     set the rect of widget "testSvgPath" to "0,0,100,100"
+     TestAssert "the rect was set to 0,0,100,100", the rect of widget "testSvgPath" is "0,0,100,100"
+end TestSetRect
+
+on TestScaledSizing
+     set the iconPath of widget "testSvgPath" to getPathData()
+     set the maintainAspectRatio of widget "testSvgPath" to true
+     set the rect of widget "testSvgPath" to "0,0,100,100"
+     TestAssert "scaledHeight with maintainAspectRatio = true", the scaledHeight of widget "testSvgPath" is 95.372589
+
+     set the rect of widget "testSvgPath" to "0,0,150,100"
+     TestAssert "scaledWidth with maintainAspectRatio = true", the scaledWidth of widget "testSvgPath" is 104.851929
+
+     set the maintainAspectRatio of widget "testSvgPath" to false
+     TestAssert "scaledHeight with maintainAspectRatio = false", the scaledHeight of widget "testSvgPath" is 100
+     TestAssert "scaledWidth with maintainAspectRatio = false", the scaledWidth of widget "testSvgPath" is 150
+end TestScaledSizing

--- a/extensions/widgets/svgpath/tests/properties.livecodescript
+++ b/extensions/widgets/svgpath/tests/properties.livecodescript
@@ -58,11 +58,8 @@ on TestScaledSizing
 	set the maintainAspectRatio of widget "testSvgPath" to true
 
 	set the rect of widget "testSvgPath" to "0,0,90,100"
-	TestAssert "scaledWidth with maintainAspectRatio = true", (the scaledWidth of widget "testSvgPath" is 90 and the scaledHeight of widget "testSvgPath" is 90)
-
-	set the rect of widget "testSvgPath" to "0,0,100,90"
-	TestAssert "scaledWidth with maintainAspectRatio = true", (the scaledWidth of widget "testSvgPath" is 90 and the scaledHeight of widget "testSvgPath" is 90)
+	TestAssert "scaled sizing with maintainAspectRatio = true", (round(the scaledWidth of widget "testSvgPath") is 90 and round(the scaledHeight of widget "testSvgPath") is 90)
 
 	set the maintainAspectRatio of widget "testSvgPath" to false
-	TestAssert "scaledHeight with maintainAspectRatio = false", (the scaledHeight of widget "testSvgPath" is not the scaledWidth of widget "testSvgPath")
+	TestAssert "scaled sizing with maintainAspectRatio = false", (round(the scaledHeight of widget "testSvgPath") is not round(the scaledWidth of widget "testSvgPath"))
 end TestScaledSizing

--- a/extensions/widgets/svgpath/tests/properties.livecodescript
+++ b/extensions/widgets/svgpath/tests/properties.livecodescript
@@ -17,14 +17,13 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 private function getPathData
-	return "M1664 698Q1664 720 1638 746L1275 1100 1361 1600Q1362 1607 1362 1620 1362 1641 1351.5 1655.5 1341 1670 1321 1670 1302 1670 1281 1658L832 1422 383 1658Q361 1670 343 1670 322 1670 311.5 1655.5 301 1641 301 1620 301 1614 303 1600L389 1100 25 746Q0 719 0 698 0 661 56 652L558 579 783 124Q802 83 832 83 862 83 881 124L1106 579 1608 652Q1664 661 1664 698Z"
+	return "M10 10 H 90 V 90 H 10 L 10 10"
 end getPathData
 
 on TestSetup
 	TestLoadExtension "com.livecode.library.widgetutils"
-	TestLoadExtension "com.livecode.library.iconSVG"
-	TestLoadExtension "com.livecode.widget.svgPath"
-	create widget "testSvgPath" as "com.livecode.widget.svgPath"
+	TestLoadExtension "com.livecode.widget.svgpath"
+	create widget "testSvgPath" as "com.livecode.widget.svgpath"
 end TestSetup
 
 on TestTeardown
@@ -56,13 +55,13 @@ end TestSetRect
 on TestScaledSizing
 	set the iconPath of widget "testSvgPath" to getPathData()
 	set the maintainAspectRatio of widget "testSvgPath" to true
-	set the rect of widget "testSvgPath" to "0,0,100,100"
-	TestAssert "scaledHeight with maintainAspectRatio = true", round(the scaledHeight of widget "testSvgPath",3) is 95.373
 
-	set the rect of widget "testSvgPath" to "0,0,150,100"
-	TestAssert "scaledWidth with maintainAspectRatio = true", round(the scaledWidth of widget "testSvgPath",3) is 104.852
+	set the rect of widget "testSvgPath" to "0,0,90,100"
+	TestAssert "scaledWidth with maintainAspectRatio = true", (the scaledWidth of widget "testSvgPath" is 90 and the scaledHeight of widget "testSvgPath" is 90)
+
+	set the rect of widget "testSvgPath" to "0,0,100,90"
+	TestAssert "scaledWidth with maintainAspectRatio = true", (the scaledWidth of widget "testSvgPath" is 90 and the scaledHeight of widget "testSvgPath" is 90)
 
 	set the maintainAspectRatio of widget "testSvgPath" to false
-	TestAssert "scaledHeight with maintainAspectRatio = false", the scaledHeight of widget "testSvgPath" is 100
-	TestAssert "scaledWidth with maintainAspectRatio = false", the scaledWidth of widget "testSvgPath" is 150
+	TestAssert "scaledHeight with maintainAspectRatio = false", (the scaledHeight of widget "testSvgPath" is not the scaledWidth of widget "testSvgPath")
 end TestScaledSizing

--- a/extensions/widgets/svgpath/tests/properties.livecodescript
+++ b/extensions/widgets/svgpath/tests/properties.livecodescript
@@ -22,6 +22,7 @@ end getPathData
 
 on TestSetup
 	TestLoadExtension "com.livecode.library.widgetutils"
+	TestLoadExtension "com.livecode.library.iconSVG"
 	TestLoadExtension "com.livecode.widget.svgpath"
 	create widget "testSvgPath" as "com.livecode.widget.svgpath"
 end TestSetup

--- a/extensions/widgets/svgpath/tests/properties.livecodescript
+++ b/extensions/widgets/svgpath/tests/properties.livecodescript
@@ -17,51 +17,51 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 private function getPathData
-     return "M1664 698Q1664 720 1638 746L1275 1100 1361 1600Q1362 1607 1362 1620 1362 1641 1351.5 1655.5 1341 1670 1321 1670 1302 1670 1281 1658L832 1422 383 1658Q361 1670 343 1670 322 1670 311.5 1655.5 301 1641 301 1620 301 1614 303 1600L389 1100 25 746Q0 719 0 698 0 661 56 652L558 579 783 124Q802 83 832 83 862 83 881 124L1106 579 1608 652Q1664 661 1664 698Z"
+	return "M1664 698Q1664 720 1638 746L1275 1100 1361 1600Q1362 1607 1362 1620 1362 1641 1351.5 1655.5 1341 1670 1321 1670 1302 1670 1281 1658L832 1422 383 1658Q361 1670 343 1670 322 1670 311.5 1655.5 301 1641 301 1620 301 1614 303 1600L389 1100 25 746Q0 719 0 698 0 661 56 652L558 579 783 124Q802 83 832 83 862 83 881 124L1106 579 1608 652Q1664 661 1664 698Z"
 end getPathData
 
 on TestSetup
-     TestLoadExtension "com.livecode.library.widgetutils"
-     TestLoadExtension "com.livecode.widget.svgPath"
-     create widget "testSvgPath" as "com.livecode.widget.svgPath"
+	TestLoadExtension "com.livecode.library.widgetutils"
+	TestLoadExtension "com.livecode.widget.svgPath"
+	create widget "testSvgPath" as "com.livecode.widget.svgPath"
 end TestSetup
 
 on TestTeardown
-     delete widget "testSvgPath"
+	delete widget "testSvgPath"
 end TestTeardown
 
-on TestCreateHeader
-     TestAssert "created svgPath exists", there is a widget "testSvgPath"
-end TestCreateHeader
+on TestCreateSvgPath
+	TestAssert "created svgPath exists", exists(widget "testSvgPath")
+end TestCreateSvgPath
 
 on TestSetPath
-     set the iconPath of widget "testSvgPath" to getPathData()
-     TestAssert "iconPath set to default 'star' value", the iconPath of widget "testSvgPath" is getPathData()
+	set the iconPath of widget "testSvgPath" to getPathData()
+	TestAssert "iconPath set to default 'star' value", the iconPath of widget "testSvgPath" is getPathData()
 end TestSetPath
 
-on TestMaintainAspectRatioBasic
-     set the maintainAspectRatio of widget "testSvgPath" to true
-     TestAssert "maintainAspectRatio set to true", the maintainAspectRatio of widget "testSvgPath" is true
-     
-     set the maintainAspectRatio of widget "testSvgPath" to false
-     TestAssert "maintainAspectRatio set to false", the maintainAspectRatio of widget "testSvgPath" is false
-end TestMaintainAspectRatioBasic
+on TestMaintainAspectRatio
+	set the maintainAspectRatio of widget "testSvgPath" to true
+	TestAssert "maintainAspectRatio set to true", the maintainAspectRatio of widget "testSvgPath" is true
+
+	set the maintainAspectRatio of widget "testSvgPath" to false
+	TestAssert "maintainAspectRatio set to false", the maintainAspectRatio of widget "testSvgPath" is false
+end TestMaintainAspectRatio
 
 on TestSetRect
-     set the rect of widget "testSvgPath" to "0,0,100,100"
-     TestAssert "the rect was set to 0,0,100,100", the rect of widget "testSvgPath" is "0,0,100,100"
+	set the rect of widget "testSvgPath" to "0,0,100,100"
+	TestAssert "the rect was set to 0,0,100,100", the rect of widget "testSvgPath" is "0,0,100,100"
 end TestSetRect
 
 on TestScaledSizing
-     set the iconPath of widget "testSvgPath" to getPathData()
-     set the maintainAspectRatio of widget "testSvgPath" to true
-     set the rect of widget "testSvgPath" to "0,0,100,100"
-     TestAssert "scaledHeight with maintainAspectRatio = true", the scaledHeight of widget "testSvgPath" is 95.372589
+	set the iconPath of widget "testSvgPath" to getPathData()
+	set the maintainAspectRatio of widget "testSvgPath" to true
+	set the rect of widget "testSvgPath" to "0,0,100,100"
+	TestAssert "scaledHeight with maintainAspectRatio = true", round(the scaledHeight of widget "testSvgPath",3) is 95.373
 
-     set the rect of widget "testSvgPath" to "0,0,150,100"
-     TestAssert "scaledWidth with maintainAspectRatio = true", the scaledWidth of widget "testSvgPath" is 104.851929
+	set the rect of widget "testSvgPath" to "0,0,150,100"
+	TestAssert "scaledWidth with maintainAspectRatio = true", round(the scaledWidth of widget "testSvgPath",3) is 104.852
 
-     set the maintainAspectRatio of widget "testSvgPath" to false
-     TestAssert "scaledHeight with maintainAspectRatio = false", the scaledHeight of widget "testSvgPath" is 100
-     TestAssert "scaledWidth with maintainAspectRatio = false", the scaledWidth of widget "testSvgPath" is 150
+	set the maintainAspectRatio of widget "testSvgPath" to false
+	TestAssert "scaledHeight with maintainAspectRatio = false", the scaledHeight of widget "testSvgPath" is 100
+	TestAssert "scaledWidth with maintainAspectRatio = false", the scaledWidth of widget "testSvgPath" is 150
 end TestScaledSizing

--- a/extensions/widgets/svgpath/tests/properties.livecodescript
+++ b/extensions/widgets/svgpath/tests/properties.livecodescript
@@ -61,5 +61,5 @@ on TestScaledSizing
 	TestAssert "scaled sizing with maintainAspectRatio = true", (round(the scaledWidth of widget "testSvgPath") is 90 and round(the scaledHeight of widget "testSvgPath") is 90)
 
 	set the maintainAspectRatio of widget "testSvgPath" to false
-	TestAssert "scaled sizing with maintainAspectRatio = false", (round(the scaledHeight of widget "testSvgPath") is not round(the scaledWidth of widget "testSvgPath"))
+	TestAssert "scaled sizing with maintainAspectRatio = false", (round(the scaledWidth of widget "testSvgPath") is 90 and round(the scaledHeight of widget "testSvgPath") is 100)
 end TestScaledSizing


### PR DESCRIPTION
Adds the ability to access the height and width of an SVG path with
subpixel precision when maintainAspectRatio is engaged.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/livecode/livecode/4005)

<!-- Reviewable:end -->
