### PR TITLE
[[ Community Docs ]] alwaysBuffer fixes

### DIFF
--- a/docs/dictionary/property/alwaysBuffer.lcdoc
+++ b/docs/dictionary/property/alwaysBuffer.lcdoc
@@ -23,24 +23,45 @@ set the alwaysBuffer of image "Smile" to false
 Example:
 set the alwaysBuffer of the templatePlayer to true
 
-Value (bool): The <alwaysBuffer> of an <object(glossary)> is true or false. By <default>, the <alwaysBuffer> <property> of newly created <image|images>, <player|players>, and <stacks> is set to false.
+Value (bool): The <alwaysBuffer> of an <object> is true or false. By <default>, 
+the <alwaysBuffer> <property> of newly created <image|images>, <player|players>, 
+and <stack|stacks> is set to false.
 
 Description:
-Use the <alwaysBuffer> <property> to eliminate unwanted flicker when <object|objects> are being <redraw|redrawn>. This <property> is especially useful for eliminating flicker when using animation in a <stack>.
+Use the <alwaysBuffer> <property> to eliminate unwanted flicker when <object|objects> are 
+being <redraw|redrawn>. This <property> is especially useful for eliminating flicker when 
+using animation in a <stack>.
 
-Prior to 2.7, setting the <alwaysBuffer> of a stack to true would cause the stack's display to be double-buffered, eliminating flicker. However, 2.7 introduced a new rendering model which double-buffers a stacks contents as and when required. As a result, setting the <alwaysBuffer> of a stack no longer has any effect.
+Prior to 2.7, setting the <alwaysBuffer> of a <stack> to true would cause the <stack|stack's> display 
+to be double-buffered, eliminating flicker. However, 2.7 introduced a new rendering model 
+which double-buffers a <stack|stack's> contents as and when required. As a result, setting the 
+<alwaysBuffer> of a <stack> no longer has any effect.
 
-Setting an image's <alwaysBuffer> <property> to true forces the <image(keyword)> to <uncompress> immediately, even if the <image(keyword)> is hidden. This speeds up using the <show> command to display an <image(keyword)>. Setting the <alwaysBuffer> <property> of all <image(object)|images> to true is equivalent to setting the <global>  <bufferHiddenImages> <property> to true.
+Setting an <image|image's> <alwaysBuffer> <property> to true forces the <image> to <uncompress>
+immediately, even if the <image> is hidden. This speeds up using the <show> <command> to 
+display an <image>. Setting the <alwaysBuffer> <property> of all <image|images> 
+to true is equivalent to setting the <global> <bufferHiddenImages> <property> to true.
 
-Setting a player's <alwaysBuffer> <property> to true forces the movie to be drawn in an offscreen <buffer>. This prevents the movie from flickering when other <object|objects> (such as <button|buttons>) are drawn on top of it. It also allows the current frame to be seen when the <card> is printed.
+Setting a <player|player's> <alwaysBuffer> <property> to true forces the movie to be drawn in an offscreen 
+<buffer>. This prevents the movie from flickering when other <object|objects> (such as <button|buttons>) 
+are drawn on top of it. It also allows the current frame to be seen when the <card> is printed.
 
-If a player's movie contains only sound with no visual track, the setting of its <alwaysBuffer> <property> has no effect.
-If a player's <alwaysBuffer> is false, the movie it contains is drawn in front of all <object|objects>. The <visual effect> <command> does not affect the screen area inside the <rectangle> of a <player(keyword)> whose <alwaysBuffer> is false. If a player's <alwaysBuffer> is true, it cannot be controlled with the <controller bar> and must be operated by <script> <control>.
+If a <player|player's> movie contains only sound with no visual track, the setting of its <alwaysBuffer> <property> has no effect.
+If a <player|player's> <alwaysBuffer> is false, the movie it contains is drawn in front of all <object|objects>. 
+The <visual effect> <command> does not affect the screen area inside the <rectangle> of a <player> 
+whose <alwaysBuffer> is false. If a <player|player's> <alwaysBuffer> is true, it cannot be controlled with the 
+<controller bar> and must be operated by <script> control.
 
->*Note:* Setting a <player(object)|player's> <alwaysBuffer> to true always increases memory usage, and may make movie playing more jerky.
+>*Note:* Setting a <player|player's> <alwaysBuffer> to true always increases memory usage, and may make movie playing more jerky.
 
->*Note:* The <alwaysBuffer> property has no effect on Windows if the global <dontUseQT property> is set to true.
+>*Note:* The <alwaysBuffer> <property> has no effect on Windows if the global <dontUseQT> <property> is set to true.
 
-References: screenSharedMemory (property), dontUseQT property (property), script (property), constantMask (property), bufferHiddenImages (property), card (keyword), player (keyword), image (keyword), default (keyword), rectangle (keyword), control (keyword), visual effect (command), show (command), lock screen (command), global (command), heapSpace (function), stacks (function), hasMemory (function), button (object), image (object), player (object), object (glossary), stack (object), property (glossary), uncompress (glossary), controller bar (glossary), buffer (glossary), command (glossary), redraw (glossary)
+References: screenSharedMemory (property), dontUseQT (property), script (property), 
+constantMask (property), bufferHiddenImages (property), card (object), 
+default (glossary), rectangle (glossary), control (keyword), visual effect (command), 
+show (command), lock screen (command), global (command), heapSpace (function), stacks (function), 
+hasMemory (function), button (object), image (object), player (object), object (glossary), 
+stack (object), property (glossary), uncompress (glossary), controller bar (glossary), 
+buffer (glossary), command (glossary), redraw (glossary)
 
 Tags: multimedia

--- a/docs/dictionary/property/alwaysBuffer.lcdoc
+++ b/docs/dictionary/property/alwaysBuffer.lcdoc
@@ -23,12 +23,12 @@ set the alwaysBuffer of image "Smile" to false
 Example:
 set the alwaysBuffer of the templatePlayer to true
 
-Value (bool): The <alwaysBuffer> of an <object> is true or false. By <default>, 
+Value (bool): The <alwaysBuffer> of an <object(glossary)> is true or false. By <default>, 
 the <alwaysBuffer> <property> of newly created <image|images>, <player|players>, 
 and <stack|stacks> is set to false.
 
 Description:
-Use the <alwaysBuffer> <property> to eliminate unwanted flicker when <object|objects> are 
+Use the <alwaysBuffer> <property> to eliminate unwanted flicker when <object(glossary)|objects> are 
 being <redraw|redrawn>. This <property> is especially useful for eliminating flicker when 
 using animation in a <stack>.
 
@@ -47,7 +47,7 @@ Setting a <player|player's> <alwaysBuffer> <property> to true forces the movie t
 are drawn on top of it. It also allows the current frame to be seen when the <card> is printed.
 
 If a <player|player's> movie contains only sound with no visual track, the setting of its <alwaysBuffer> <property> has no effect.
-If a <player|player's> <alwaysBuffer> is false, the movie it contains is drawn in front of all <object|objects>. 
+If a <player|player's> <alwaysBuffer> is false, the movie it contains is drawn in front of all <object(glossary)|objects>. 
 The <visual effect> <command> does not affect the screen area inside the <rectangle> of a <player> 
 whose <alwaysBuffer> is false. If a <player|player's> <alwaysBuffer> is true, it cannot be controlled with the 
 <controller bar> and must be operated by <script> control.


### PR DESCRIPTION
- Errors in references list were preventing a couple of links from appearing.
- Several references were pointing to an inappropriate entry (e.g., keyword vs. glossary).
- Adding links to referenced terms.
- Hard wrapped long lines.
