### PR TITLE
Initialise LCB variables with default values

### DIFF
--- a/docs/lcb/14659.md
+++ b/docs/lcb/14659.md
@@ -1,0 +1,14 @@
+# LiveCode Builder Language
+## Variables
+
+- Typed variables are now initialised by default to a suitable empty
+  value.  For example:
+
+  ```
+  variable tList as List
+  push "element" onto tList
+  ```
+
+  Untyped and `optional` variables are initialised to `nothing`.
+
+# [14659] Initialise variables with a default value

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1558,6 +1558,9 @@ MC_DLLEXPORT bool MCTypeInfoIsForeign(MCTypeInfoRef typeinfo);
 // Returns true if the typeinfo is of custom type.
 MC_DLLEXPORT bool MCTypeInfoIsCustom(MCTypeInfoRef typeinfo);
 
+// Returns the default value for the given type if it has one, otherwise nil.
+MC_DLLEXPORT MCValueRef MCTypeInfoGetDefault(MCTypeInfoRef typeinfo);
+    
 // Typeinfo's form a chain with elements in the chain potentially providing critical
 // information about the specified type. This structure describes the represented
 // type, after a typeinfo chain has been suitably processed.

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -114,6 +114,59 @@ bool MCTypeInfoIsCustom(MCTypeInfoRef self)
 }
 
 MC_DLLEXPORT_DEF
+MCValueRef MCTypeInfoGetDefault(MCTypeInfoRef self)
+{
+    __MCAssertIsTypeInfo(self);
+    switch(__MCTypeInfoGetExtendedTypeCode(self))
+    {
+        case kMCValueTypeCodeNull:
+            return kMCNull;
+        case kMCValueTypeCodeBoolean:
+            return kMCFalse;
+        case kMCValueTypeCodeNumber:
+            return kMCZero;
+        case kMCValueTypeCodeName:
+            return kMCEmptyName;
+        case kMCValueTypeCodeString:
+            return kMCEmptyString;
+        case kMCValueTypeCodeData:
+            return kMCEmptyData;
+        case kMCValueTypeCodeArray:
+            return kMCEmptyArray;
+        case kMCValueTypeCodeList:
+            return kMCEmptyList;
+        case kMCValueTypeCodeSet:
+            return kMCEmptySet;
+        case kMCValueTypeCodeProperList:
+            return kMCEmptyProperList;
+        case kMCValueTypeCodeCustom:
+            return nil;
+        case kMCValueTypeCodeRecord:
+            return nil;
+        case kMCValueTypeCodeHandler:
+            return nil;
+        case kMCValueTypeCodeTypeInfo:
+            return nil;
+        case kMCValueTypeCodeError:
+            return nil;
+        case kMCValueTypeCodeForeignValue:
+            return nil;
+        
+        case kMCTypeInfoTypeIsOptional:
+            return kMCNull;
+            
+        case kMCTypeInfoTypeIsAlias:
+            return MCTypeInfoGetDefault(self -> alias . typeinfo);
+            
+        case kMCTypeInfoTypeIsNamed:
+            return MCTypeInfoGetDefault(self -> named . typeinfo);
+            
+        default:
+            return nil;
+    }
+}
+
+MC_DLLEXPORT_DEF
 bool MCTypeInfoResolve(MCTypeInfoRef self, MCResolvedTypeInfo& r_resolution)
 {
 	__MCAssertIsTypeInfo(self);

--- a/tests/lcb/vm/default-values.lcb
+++ b/tests/lcb/vm/default-values.lcb
@@ -32,4 +32,9 @@ public handler TestDefaultValueOfOptional()
 	test "default value (optional)" when tOptional is nothing
 end handler
 
+public handler TestDefaultValueOfUntyped()
+	variable tVar
+	test "default value (untyped)" when tVar is nothing
+end handler
+
 end module

--- a/tests/lcb/vm/default-values.lcb
+++ b/tests/lcb/vm/default-values.lcb
@@ -1,5 +1,9 @@
 module __VMTEST.default_values
 
+variable sBoolean as Boolean
+variable sOptionalString as optional String
+variable sVariant
+
 public handler TestDefaultValueOfBoolean()
 	variable tBoolean as Boolean
 	test "default value (boolean)" when tBoolean is false
@@ -35,6 +39,12 @@ end handler
 public handler TestDefaultValueOfUntyped()
 	variable tVar
 	test "default value (untyped)" when tVar is nothing
+end handler
+
+public handler TestDefaultValueOfModuleVariable()
+	test "default value (boolean)" when sBoolean is false
+	test "default value (optional)" when sOptionalString is nothing
+	test "default value (untyped)" when sVariant is nothing
 end handler
 
 end module

--- a/tests/lcb/vm/default-values.lcb
+++ b/tests/lcb/vm/default-values.lcb
@@ -1,0 +1,35 @@
+module __VMTEST.default_values
+
+public handler TestDefaultValueOfBoolean()
+	variable tBoolean as Boolean
+	test "default value (boolean)" when tBoolean is false
+end handler
+
+public handler TestDefaultValueOfNumber()
+	variable tNumber as Number
+	test "default value (number)" when tNumber is 0.0
+end handler
+
+public handler TestDefaultValueOfString()
+	variable tString as String
+	test "default value (string)" when tString is ""
+end handler
+
+public handler TestDefaultValueOfData()
+	variable tData as Data
+	test "default value (boolean)" when tData is the empty data
+end handler
+
+public handler TestDefaultValueOfArray()
+	variable tArray as Array
+
+	-- We don't have array equality yet, so check the number of elements
+	test "default value (array)" when the number of elements in tArray is 0
+end handler
+
+public handler TestDefaultValueOfOptional()
+	variable tOptional as optional any
+	test "default value (optional)" when tOptional is nothing
+end handler
+
+end module


### PR DESCRIPTION
Most LCB variables will be initialised with a default value if they are non-optionally typed with a type for which a default value is defined.

For example, this is now valid:

```
variable tList as List
push "foo" onto tList
```

**Note:** This doesn't include default initialisation of out parameters.
