### PR TITLE
[[ Bug 17652 ]] Correct code path for 'delete tVar'

### DIFF
--- a/docs/notes/bugfix-17652.md
+++ b/docs/notes/bugfix-17652.md
@@ -1,0 +1,1 @@
+# Fix 'delete tVar' where tVar contains an object text chunk

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -4931,6 +4931,9 @@ bool MCChunk::issubstringchunk(void) const
 	if (destvar == nil)
 		return false;
 
+    if (m_transient_text_chunk)
+        return false;
+    
 	if (isstringchunk() || isdatachunk())
 		return true;
 

--- a/tests/lcs/core/chunks/delete.livecodescript
+++ b/tests/lcs/core/chunks/delete.livecodescript
@@ -1,0 +1,38 @@
+script "CoreChunksDelete"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestDeleteVar
+	create field
+	put "a" & return & "b" into field 1
+	
+	local tToDelete
+	put "line 1 of field 1" into tToDelete
+	
+	delete tToDelete
+	
+	TestAssert "delete obj text chunk in variable", field 1 is "b"
+	
+	delete tToDelete
+	
+	-- ensure left-over components from chunk evaluation are not re-used
+	-- See bug 11928
+	TestAssert "delete obj text chunk in variable again", field 1 is empty
+end TestDeleteVar
+
+
+


### PR DESCRIPTION
When the latter contained an object text chunk, it would select
the 'delete object' code path as the variable contents were not
parsed as a chunk before selection.

Also reinstate fix for bug 11928 which was lost in the refactoring
- its absence was causing 'delete tVar' to work exactly once.
