### PR TITLE
[[ Bug 17624 ]] Fix the files and folders functions crash on Android

### DIFF
--- a/docs/notes/bugfix-17624.md
+++ b/docs/notes/bugfix-17624.md
@@ -1,0 +1,1 @@
+#Fix crash on Android in the files and folders functions

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -510,7 +510,7 @@ bool MCAndroidSystem::ListFolderEntries(MCStringRef p_folder, MCSystemListFolder
 {
 	MCAutoStringRef t_apk_folder;
 	if ((p_folder == nil && apk_get_current_folder (&t_apk_folder)) ||
-		path_to_apk_path (p_folder, &t_apk_folder))
+		(p_folder != nil && path_to_apk_path (p_folder, &t_apk_folder)))
 		return apk_list_folder_entries (*t_apk_folder, p_callback, p_context);
 
 	MCAutoStringRefAsUTF8String t_path;


### PR DESCRIPTION
The code path allowed MCStringBeginsWith to be called with a nil
parameter
