### PR TITLE
[[ Bug 17384 ]] Fix various issues with the clipboard data property docs

### DIFF
--- a/docs/dictionary/property/clipboardData.lcdoc
+++ b/docs/dictionary/property/clipboardData.lcdoc
@@ -2,9 +2,15 @@ Name: clipboardData
 
 Type: property
 
-Syntax: set the clipboardData to <clipboardArray> 
+Syntax: set the clipboardData to <data> 
 
-Summary: Specifies what data and of what type is on the <clipboard>.
+Syntax: set the clipboardData[<key>] to <data> 
+
+Syntax: get the clipboardData
+
+Syntax: get the clipboardData[<key>]
+
+Summary: Specifies what data and of what type is on the <clipboard(glossary)>.
 
 Introduced: 2.0
 
@@ -28,45 +34,76 @@ set the clipboardData["image"] to image 1
 Example:
 set the clipboardData["styledText"] to the styledText of field 4
 
-Parameters:
-text: plain text
-unicode: plain text encoded as utf-16 in host byte order
-styledText: styled text in LiveCode styledText array format (the same as the styledText property of a field)
-styles: styled text in LiveCode internal styled-text format
-html: styled text in LiveCode HTML format
-rtf: styled text in LiveCode RTF format
-image: the 'text' of an image object, i.e. binary data in PNG, GIF or JPEG format
-files: a return-delimited list of filenames in LiveCode format
-objects: one or more LiveCode objects serialized into an internal format
-private: an arbitrary application-defined string. This format will only be visible within the same LiveCode process
-
 Value:
-The <clipboardData> pseudo-array provides access to the data to be transferred through a drag-drop operation.
-If the clipboard contains data compatible with the specified type, it is converted to the requested type; otherwise the array element for that type is empty. For example, if the clipboard contains text "hello", clipboardData["image"] is empty, whereas the clipboardData["html"] returns "<p>hello</p>"
+The <clipboardData> pseudo-array provides access to the data to be 
+transferred through a drag-drop operation. 
 
 Description:
-Use the <clipboardData> property to put data in the clipboard in a specified format, or to get the contents of the clipboard, without copying or pasting.
+Use the <clipboardData> property to put data in the 
+<clipboard(glossary)> in a specified format, or to get the contents of 
+the <clipboard(glossary)>, without copying or pasting. The keys for the
+<clipboardData> are the following:
+  - "text": plain text
+  - "unicode": plain text encoded as utf-16 in host byte order
+  - "rtf": LiveCode rich text format data
+  - "htmltext": LiveCode HTML text
+  - "styles": styled text in LiveCode internal styled-text format
+  - "styledtext": array of LiveCode styled text
+  - "image": the <text> of an image object, i.e. binary data in PNG, GIF or JPEG format
+  - "rtf": styled text in LiveCode RTF format
+  - "html": styled text in LiveCode HTML format
+  - "styles": LiveCode styled text data
+  - "objects": one or more LiveCode objects serialized into an internal format
+  - "files": a return-delimited list of filenames in LiveCode format
+  - "private": an arbitrary application-defined string. This format will only be visible within the same LiveCode process
 
-The <clipboardData> property is populated automatically when the clipboard content is changed, either by using the cut or copy command, or by cutting or copying in another application.
+The <clipboardData> property is populated automatically when the 
+<clipboard(glossary)> content is changed, either by using the cut or 
+copy command, or by cutting or copying in another application.
 
-You can query the keys of the <clipboardData> to determine what types of data are on the clipboard. For example, if the clipboard contains styled text, you can put that text (in htmlText format) in a variable with the following statement:
+If the <clipboard(glossary)> contains data compatible with the specified 
+type, it is converted to the requested type; otherwise the array element 
+for that type is empty. For example, if the <clipboard(glossary)> 
+contains text "hello", `the clipboardData["image"]` is empty, whereas 
+`the clipboardData["html"]` returns "&lt;p&gt;hello&lt;/p&gt;"
+
+You can query the keys of the <clipboardData> to determine what types 
+of data are on the <clipboard(glossary)>. For example, if the 
+<clipboard(glossary)> contains styled text, you can put that text (in 
+<htmlText> format) in a variable with the following statement:
 
 	put the clipboardData["html"] into tHTML
 
-To change the contents of the clipboard, you can set the <clipboardData> property directly. For example, the following statement places the text "Hello World" on the clipboard:
+To change the contents of the <clipboard(glossary)>, you can set the 
+<clipboardData> property directly. For example, the following statement 
+places the text "Hello World" on the <clipboard(glossary)>:
 
 	set the clipboardData["text"] to "Hello World"
 
-The above statement is equivalent to selecting the text "Hello World" in a field and choosing Edit menu, or to using the <copy> command. The data you place on the clipboard is accessible to your application using the <paste> command, and to other applications (that support pasting text) using the application's Paste menu item.
+The above statement is equivalent to selecting the text "Hello World" in 
+a field and choosing Edit menu, or to using the <copy> command. The data 
+you place on the <clipboard(glossary)> is accessible to your application 
+using the <paste> command, and to other applications (that support 
+pasting text) using the application's Paste menu item.
 
->*Tip:*  To quickly find out what kind of data is on the clipboard, use the <clipboard> function.
+>*Tip:*  To quickly find out what kind of data is on the clipboard, use 
+the <clipboard> function.
 
->*Tip:*  The "objects" type can be used to capture the binary form of a LiveCode object that was placed on the clipboard. This binary data can be passed to another instance of LiveCode or saved to a file and re-loaded at a later time.
+>*Tip:*  The "objects" type can be used to capture the binary form of a 
+LiveCode object that was placed on the <clipboard(glossary)>. This 
+binary data can be passed to another instance of LiveCode or saved to a 
+file and re-loaded at a later time.
 
->*Tip:*  If you require low-level access to the clipboard contents, use the <rawClipboardData> property instead.
+>*Tip:*  If you require low-level access to the <clipboard(glossary)> 
+contents, use the <rawClipboardData> property instead.
 
->*Tip:*  To prevent the clipboard from being changed by other apps while you are accessing it, use the <lock clipboard> and <unlock clipboard> commands.
+>*Tip:*  To prevent the <clipboard(glossary)> from being changed by 
+other apps while you are accessing it, use the <lock clipboard> and 
+<unlock clipboard> commands.
 
-References: copy (command), dragData (property), clipboard (function), paste (command), lock clipboard (command), unlock clipboard (command), fullClipboardData (property), rawClipboardData (property)
+References: copy (command), dragData (property), clipboard (function), 
+paste (command), lock clipboard (command), unlock clipboard (command), 
+fullClipboardData (property), rawClipboardData (property), 
+text (property), clipboard (glossary)
 
 Tags: ui, clipboard

--- a/docs/dictionary/property/fullClipboardData.lcdoc
+++ b/docs/dictionary/property/fullClipboardData.lcdoc
@@ -5,7 +5,7 @@ Type: property
 Syntax: set the fullClipboardData[<key>] to <data>
 Syntax: set the fullClipboardData to empty
 
-Summary: provides access to the contents of the <clipboard>.
+Summary: Provides access to the contents of the <clipboard(glossary)>.
 
 Introduced: 8.0
 
@@ -26,8 +26,13 @@ set the fullClipboardData["private"] to "MyCustomData"
 unlock the clipboard
 
 Value:
-The <fullClipboardData> pseudo-array provides access to the data on the clipboard. It can only be accessed while the clipboard is locked.
-The keys for the <fullClipboardData> are:
+The <fullClipboardData> pseudo-array provides access to the data on 
+the <clipboard(glossary)>. It can only be accessed while the 
+<clipboard(glossary)> is locked.
+
+Description:
+Use the <fullClipboardData> to gain access to the system 
+<clipboard(glossary)>. The keys for the <fullClipboardData> are:
   - "text": plain text
   - "rtftext": LiveCode rich text format data
   - "htmltext": LiveCode HTML text
@@ -43,19 +48,28 @@ The keys for the <fullClipboardData> are:
   - "files": List of newline-separated file paths
   - "private": available for in-app use
   
->*Note:* More keys and data types may be added in the future
+>*Note:* More keys and data types may be added in the future.
 
-Description:
-Use the <fullClipboardData> to gain access to the system clipboard. 
+If the contents of the <clipboard(glossary)> were placed there by 
+another app, the <clipboard(glossary)> will be automatically cleared 
+when written to. If you want to do this explicitly, use 
+`set the fullClipboardData to empty`.
 
-If the contents of the clipboard were placed there by another app, the clipboard will be automatically cleared when written to. If you want to do this explicitly, use ``set the fullClipboardData to empty``.
+The `text`, `rtftext`, `htmltext`, `styles` and `styledtext` 
+properties are handled specially by LiveCode: adding any one of them 
+will cause the rest to be automatically generated and added. You can 
+query the keys of the <fullClipboardData> to determine what types of 
+data are on the <clipboard(glossary)>.
 
-The ``text``, ``rtftext``, ``htmltext``, ``styles`` and ``styledtext`` properties are handled specially by LiveCode: adding any one of them will cause the rest to be automatically generated and added.
+If you require lower-level access to the <clipboard(glossary)>, see the 
+<rawClipboardData> <property>.
 
-If you require lower-level access to the clipboard, see the <rawClipboardData> <property>.
+>*Tip:* It is good practice to lock the <clipboard(glossary)> before 
+accessing it to prevent data corruption.
 
->*Tip:*		It is good practice to lock the clipboard before accessing it to prevent data corruption.
-
-References: lock clipboard (command), unlock clipboard (command), clipboard (function), clipboard (property), clipboardData (property), rawClipboardData (property), fullDragData (property)
+References: lock clipboard (command), unlock clipboard (command), 
+clipboard (function), clipboardData (property), 
+rawClipboardData (property), fullDragData (property),
+clipboard (glossary)
 
 Tags: ui, clipboard

--- a/docs/dictionary/property/rawClipboardData.lcdoc
+++ b/docs/dictionary/property/rawClipboardData.lcdoc
@@ -5,7 +5,7 @@ Type: property
 Syntax: set the rawClipboardData[<key>] to <data>
 Syntax: set the rawClipboardData to empty
 
-Summary: provides low-level access to the contents of the <clipboard>.
+Summary: Provides low-level access to the contents of the <clipboard(glossary)>.
 
 Introduced: 8.0
 
@@ -26,27 +26,49 @@ set the rawClipboardData["public.utf8-plain-text"] to textEncode("Hello, World!"
 unlock the clipboard
 
 Value:
-The <rawClipboardData> pseudo-array provides low-level access to the data on the clipboard. It can only be accessed while the clipboard is locked.
-The keys for the <rawClipboardData> are platform-specific.
+The <rawClipboardData> pseudo-array provides low-level access to the 
+data on the <clipboard(glossary)>. It can only be accessed while the 
+<clipboard(glossary)> is locked.
 
 Description:
->*Note:*	The <rawClipboardData> cannot be accessed outside of a <lock clipboard>/<unlock clipboard> pair. This is to ensure the clipboard contents do not change during access.
+Use the <rawClipboardData> to gain low-level access to the system 
+<clipboard(glossary)>. The keys for the <rawClipboardData> are 
+platform-specific. You can query the keys of the <rawClipboardData> to 
+determine what types of data are on the <clipboard(glossary)>.
 
-Use the <rawClipboardData> to gain low-level access to the system clipboard. 
+>*Note:* The <rawClipboardData> cannot be accessed outside of a 
+<lock clipboard>/<unlock clipboard> pair. This is to ensure the 
+<clipboard(glossary)> contents do not change during access.
 
-If the contents of the clipboard were placed there by another app, the clipboard will have to be cleared before being used: ``set the rawClipboardData to empty``.  Attempting to overwrite externally-provided data without clearing the clipboard will throw an error.
+If the contents of the <clipboard(glossary)> were placed there by 
+another app, the <clipboard(glossary)> will have to be cleared before 
+being used: ``set the rawClipboardData to empty``.  Attempting to 
+overwrite externally-provided data without clearing the 
+<clipboard(glossary)> will throw an error.
 
-This property should only be used if you require low-level access; the <fullClipboardData> <property> is more appropriate for most uses.
+This property should only be used if you require low-level access; the 
+<fullClipboardData> <property> is more appropriate for most uses.
 
-As a low-level feature, platform differences are not hidden. In particular, the form of the keys of the <rawClipboardData> are platform-specific, but can be summarised as:
- - Windows: arbitrary strings but keys of the form CF_xxx correspond to the clipboard formats defined by Windows itself
- - OSX: Uniform Type Identifiers (UTIs) with an extension: OSTypes/MIME-types can be used by prefixing the key with com.apple.ostype:/public.mime-type:
- - Linux: arbitrary strings (X11 atoms) but, by convention, MIME types are used
+As a low-level feature, platform differences are not hidden. In 
+particular, the form of the keys of the <rawClipboardData> are 
+platform-specific, but can be summarised as:
+ - Windows: arbitrary strings but keys of the form CF_xxx correspond to 
+ the <clipboard(glossary)> formats defined by Windows itself
+ - OSX: Uniform Type Identifiers (UTIs) with an extension: 
+ OSTypes/MIME-types can be used by prefixing the key with com.apple.ostype:/public.mime-type:
+ - Linux: arbitrary strings (X11 atoms) but, by convention, MIME types 
+ are used
 
->*Tip:*		All contents of the <rawClipboardData> are binary - use the <textEncode>/<textDecode> functions to convert to/from the appropriate encoding.
+>*Tip:* All contents of the <rawClipboardData> are binary - use the 
+<textEncode>/<textDecode> functions to convert to/from the appropriate 
+encoding.
 
->*Tip:*		It is good practice to clear the clipboard before use: ``set the rawClipboardData to empty``
+>*Tip:* It is good practice to clear the clipboard before use: 
+``set the rawClipboardData to empty``
 
-References: lock clipboard (command), unlock clipboard (command), clipboard (function), clipboard (property), clipboardData (property), fullClipboardData (property), rawDragData (property)
+References: lock clipboard (command), unlock clipboard (command), 
+clipboard (function), clipboardData (property), 
+fullClipboardData (property), rawDragData (property),
+clipboard (glossary), textEncode (function), textDecode (function)
 
 Tags: ui, clipboard

--- a/docs/notes/bugfix-17384.md
+++ b/docs/notes/bugfix-17384.md
@@ -1,0 +1,1 @@
+# Fix issues with clipboard data property docs


### PR DESCRIPTION
- Fix formatting
- Remove all references to the clipboard property which doesn't exist
- Add references where they are missing
- Link to the clipboard glossary entry where appropriate
- Add missing syntax
