### PR TITLE
Refine release notes for 8.1.0-dp-1

### DIFF
--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -1104,7 +1104,11 @@ private command V2BugGenerate pBugInfo, pBugCategory
    put the keys of pBugInfo into tTags
    GitSortTags tTags
    put the number of lines of tTags into tTagCount
-   
+
+   if tTagCount is 0 then
+      exit V2BugGenerate
+   end if
+
    MarkdownAppend "notes", merge("## Specific [[pBugCategory]] bug fixes")
    
    local tVersion, tBugs, tPrettyVersion, tBugList

--- a/docs/notes/bugfix-17515.md
+++ b/docs/notes/bugfix-17515.md
@@ -1,4 +1,4 @@
-#Add support for custom entitlements for iOS
+# Add support for custom entitlements for iOS
 
 Custom entitlements can now be added to an iOS app by including one or more 
 `.xcent` files in the copy files section of the standalone builder containing an

--- a/docs/notes/feature-windows_directshow_player.md
+++ b/docs/notes/feature-windows_directshow_player.md
@@ -1,21 +1,32 @@
 # Windows DirectShow Player Control
 
-Due to the recent decision by Apple to end support for QuickTime on Windows, the player implementation on that platform has been replaced with one based on DirectShow - a Multimedia API available on all supported Windows versions.
-The new implementation should function as a drop-in replacement for the old one, though some properties are not yet implemented.
+Due to the recent decision by Apple to end support for QuickTime on
+Windows, the player implementation on that platform has been replaced
+with one based on DirectShow.  This is a multimedia API that is
+available by default on all versions of Windows supported by LiveCode.
 
-## Property Changes
-Functionality of the following Player properties on Windows has changed:
+The new implementation should function as a drop-in replacement for
+the old one, though some properties are not yet implemented.
 
-**Removed:** alwaysBuffer, callbacks, enabledTracks, mediaTypes, mirrored, trackCount, tracks.
+### Property Changes
+On Windows, the behaviour of some properties of the player control have changed.
 
-**Added:** loadedTime.
+- The **loadedTime** property previously did not work on Windows, but now does.
+- The **alwaysBuffer**, **callbacks**, **enabledTracks**,
+  **mediaTypes**, **mirrored**, **trackCount** and **tracks**
+  properties do not currently work, but will be re-enabled in a
+  subsequent release.
 
-We will be working to reinstate these properties where possible.
+On all platforms, the following player control properties, which are
+specific to QuickTime and QTVR, have been deprecated: **constraints**,
+**currentNode**, **movieControllerId**, **nodes**, **pan**, **tilt**,
+and **zoom**.
 
-In addition, the following properties specific to QuickTime and QTVR have been deprecated:
+### Supported File Formats
 
-**Deprecated:** constraints, currentNode, movieControllerId, nodes, pan, tilt, zoom
+Media format support in the new Windows player control depends on
+which codecs are installed.
 
-## Supported File Formats
-
-Media format support in DirectShow depends on the installed codecs, though the following page lists the file formats and compression types available as standard: https://msdn.microsoft.com/en-us/library/ms787745(VS.85).aspx
+A list of the
+[file formats and compression types available as standard](https://msdn.microsoft.com/en-us/library/ms787745(VS.85).aspx)
+on Windows is available in the MSDN documentation

--- a/docs/notes/overview.md
+++ b/docs/notes/overview.md
@@ -1,59 +1,11 @@
 # Overview
 
-LiveCode 8.0 brings important new capabilities to all LiveCode developers:
+LiveCode 8.1 provides important improvements for delivering
+high-quality cross-platform applications:
 
-* Use new custom controls and libraries in your applications, including a new browser widget.
+- The standalone builder now has a greatly-improved user experience
+  for including externals, script libraries and LiveCode Builder
+  extensions in your cross-platform application.
 
-* Extend LiveCode with the new LiveCode Builder language
-
-* Deploy to HTML5 and run your application in a web browser
-
-* Many other improvements!
-
-## Simplify design with widgets
-
-With LiveCode 8.0, your apps are set free from using the small range of user interface controls that were previously available in LiveCode.  The LiveCode engine now lets you load custom controls, called widgets, and use them in your apps just like any other control.
-
-LiveCode comes with a selection of widgets that simplify creating many commonly-needed sets of controls in mobile apps, and if they aren't enough, you can download and install widgets created by members of the LiveCode development community and third-party vendors.
-
-One of the most exciting new widgets introduced in LiveCode 8.0 is the browser widget.  It replaces the revBrowser external with a much more powerful and flexible browser control that's easier to use and more reliable.
-
-The LiveCode IDE has also been extended and revised in order to support widgets and other extensions.  Widgets are now available in the "Tools" palette, and installed extensions can be viewed in the "Extension Manager".  The dictionary has been extended to include extension documentation.
-
-## Extend Livecode with LiveCode Builder
-
-In LiveCode 8.0, the well-known LiveCode scripting language is joined by a brand new programming language called LiveCode Builder.  LiveCode Builder looks a lot like LiveCode script, and should be easy to learn for any experienced LiveCode developer.
-
-Using LiveCode Builder, it is now possible to extend LiveCode with new controls and libraries without any need to program in C or C++.  The IDE has a new "Extension Builder" tool that helps developers test, debug and package their extensions.
-
-For more information, please refer to the "Extending LiveCode" guide and the "LiveCode Builder" section of the dictionary.
-
-**Note:** LiveCode Builder is a new and experimental language.  There is no stability guarantee for the language or its standard libraries.  Be aware that the language syntax or features may change incompatibly in future versions of LiveCode!
-
-## Deploy to the browser with HTML5
-
-The LiveCode 8.0 engine now runs on a new platform: the web browser.  The LiveCode engine now runs as a JavaScript library in an HTML page, allowing users to run your application without having to install anything.
-
-For more information, please refer to the "HTML5 Deployment" guide.
-
-**Note:** The HTML5 platform is very different to the other platforms that LiveCode supports, and many engine features are either unsupported or work differently.
-
-## More!
-
-LiveCode 8.0 includes many other enhancements, including:
-
-* more powerful and complete clipboard access, sponsored by [FMProMigrator](https://www.fmpromigrator.com)
-
-* 64-bit Mac standalone deployment, SSL support for PostgreSQL
-  connections, and "find and replace" that preserves text style, all
-  sponsored by the community Feature Exchange
-
-* optimised Unicode text processing
-
-* Unicode printing on Linux
-
-* a new JSON library extension
-
-* greatly improved native theming on desktop platforms
-
-* a new IDE Start Center and interactive tutorial
+- The player control can be used in Windows application without any
+  need for users to install any additional libraries or dependencies.


### PR DESCRIPTION
- Make sure all bugfix headers are correctly formatted
- Rewrite release overview section
- Tweak notes builder to omit empty bugfix lists
- Minor improvements to Windows player feature release note
