### PR TITLE
[Bug 17692] graph: Prevent setting empty data

### DIFF
--- a/extensions/widgets/graph/graph.lcb
+++ b/extensions/widgets/graph/graph.lcb
@@ -326,6 +326,10 @@ public handler setData(in pData as String) returns nothing
 	variable tNewData as List
 	put the empty list into tNewData
 
+	if pData is empty then
+		throw "Invalid graph data"
+	end if
+
 	split pData by newline into tData
 
 	variable tCount as Number

--- a/extensions/widgets/graph/notes/17692.md
+++ b/extensions/widgets/graph/notes/17692.md
@@ -1,0 +1,6 @@
+# Properties
+
+- Throw an error when the **graphData** property is set to an invalid
+  value, such as an empty string.
+
+# [17692] Prevent errors in onPaint with empty graphData

--- a/extensions/widgets/graph/tests/properties.livecodescript
+++ b/extensions/widgets/graph/tests/properties.livecodescript
@@ -49,3 +49,13 @@ on TestHilitedCoordinates
 	
 	TestAssert "set hilited coordinates interpolate x value", true
 end TestHilitedCoordinates
+
+-- Bug 17692
+on _TestEmptyGraphData
+	TestDiagnostic "SetEmptyGraphData"
+	set the graphData of sGraphID to empty
+end _TestEmptyGraphData
+on TestEmptyGraphData
+	TestAssertThrow "set graph data to empty", "_TestEmptyGraphData", \
+		the long id of me, 863 -- Error occurred in extension
+end TestEmptyGraphData


### PR DESCRIPTION
Previously, setting the **graphData** property of a graph widget to an
empty string would appear to succeed, but would make the graph widget
throw an error every time the engine tried to paint it, with
appropriately catastrophic results.

This patch simply ensures that it is impossible to set the
**graphData** to an empty string by throwing an error if you attempt
to do so.
