### PR TITLE
[Bug 17695] Improve the glossary entry for "highlight"

### DIFF
--- a/docs/dictionary/property/hilite.lcdoc
+++ b/docs/dictionary/property/hilite.lcdoc
@@ -6,7 +6,7 @@ Syntax: set the hilite of <button> to {true | false}
 
 Summary: Determines whether a <button> is <highlight|highlighted>.
 
-Synonyms: highlight,highlite,hilight,highlighted,highlited,hilighted,hilited
+Synonyms: highlight, highlite, hilight, highlighted, highlited, hilighted, hilited
 
 Associations: button
 

--- a/docs/glossary/h/highlight.lcdoc
+++ b/docs/glossary/h/highlight.lcdoc
@@ -1,12 +1,12 @@
 Name: highlight
 
-Synonyms: hilite, hilited, hiliting, highlite, highlited, highliting, hilight, hilighted, hilighting, highlight, highlighted, highlighting, unhilite, unhilited, unhiliting, unhighlite, unhighlited, unhighliting, unhilight, unhilighted, unhilighting, unhighlight, unhighlighted, unhighlighting
-
 Type: glossary
 
 Description:
-To change the appearance of a <button> or other object when it's clicked, in order to make it stand out on the screen.
+To "highlight" a <button> or other object is to change its appearance
+in order to make it stand out on the screen in some way.  For example,
+a checkbox <button> is highlighted when it is checked.
 
-References: button (glossary)
+References: button (glossary), hilite (property)
 
 Tags: ui

--- a/docs/notes/bugfix-17695.md
+++ b/docs/notes/bugfix-17695.md
@@ -1,0 +1,1 @@
+# Improve "highlight" glossary entry


### PR DESCRIPTION
- Remove the massive list of synonyms, since these are only really
  relevant to the property.
- Make the explanation grammatical
- Provide an example
