### PR TITLE
[[ Bug 17468 ]] Fix crash when deleting target object

### DIFF
--- a/docs/notes/bugfix-17468.md
+++ b/docs/notes/bugfix-17468.md
@@ -1,0 +1,1 @@
+# Fix crash when deleting the target object in a front or back script.

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2164,7 +2164,18 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
     //	MCscreen->addtimer(this, MCM_idle, MCidleRate);
 
 	MCscreen->flush(mystack->getw());
-
+	
+	// Object's cannot be deleted whilst they are executing script. However,
+	// this method will run script when script in the object is *not* running
+	// i.e. during front scripts and passed handlers after the object handler.
+	// Due to this, we need to make sure that the object will not be destroyed
+	// whilst this method is running, but it should still be possible to use
+	// the delete command to delete the target whilst the script which is not
+	// in the object runs. To do this we ask the deleted objects system to
+	// suspend destruction of the object during this method.
+	void *t_deletion_cookie;
+	MCDeletedObjectsOnObjectSuspendDeletion(this, t_deletion_cookie);
+	
 	MCStack *oldstackptr = MCdefaultstackptr;
 	MCObjectPtr oldtargetptr = MCtargetptr;
 	if (changedefault)
@@ -2202,7 +2213,9 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
 		MCdefaultstackptr = oldstackptr;
 	MCtargetptr = oldtargetptr;
 	MCdynamicpath = olddynamic;
-
+	
+	MCDeletedObjectsOnObjectResumeDeletion(this, t_deletion_cookie);
+	
 	if (stat == ES_ERROR && !MCerrorlock && !MCtrylock)
 	{
 		if (MCnoui)
@@ -5537,6 +5550,7 @@ struct MCDeletedObjectPool
 
 static MCDeletedObjectPool *MCsparedeletedobjectpool = nil;
 static MCDeletedObjectPool *MCdeletedobjectpool = nil;
+static MCDeletedObjectPool *MCrootdeletedobjectpool = nil;
 
 static bool MCDeletedObjectPoolCreate(MCDeletedObjectPool*& r_pool)
 {
@@ -5577,9 +5591,23 @@ void MCDeletedObjectsSetup(void)
     // Setup occurs before the outer wait loop so if we get here we should not
     // have a deletedobjectpool.
     MCAssert(MCdeletedobjectpool == nil);
-    
-    if (!MCMemoryNew(MCdeletedobjectpool))
+	
+	// First create the root object pool - this is only drained right at the end
+	// and will only ever temporarily contain objects which have deletion suspended
+	// whilst they are executing.
+    if (!MCMemoryNew(MCrootdeletedobjectpool))
         return;
+	
+	// Now create the root object pool which is drained during the top-level
+	// event loop.
+	if (!MCMemoryNew(MCdeletedobjectpool))
+		return;
+	
+	// Set the references to 2 - this is the reference from the active deleted object
+	// pool list, and the reference from the MCrootdeletedobjectpool var. This stops
+	// the root pool getting flushed.
+	MCrootdeletedobjectpool -> references = 2;
+	MCdeletedobjectpool -> parent = MCrootdeletedobjectpool;
 }
 
 void MCDeletedObjectsTeardown(void)
@@ -5591,15 +5619,15 @@ void MCDeletedObjectsTeardown(void)
 	// Teardown occurs in X_close and can occur whilst inside a nested wait.
 	// In particular, on Mac the NSApp willTerminate method will never return
 	// meaning there are inbalanced waits on the stack. Therefore, we must
-	// 'LeaveWait' until the MCdeletedobjetpool has a nil parent.
+	// 'LeaveWait' until the MCdeletedobjetpool is the root pool.
 	while(MCdeletedobjectpool -> parent != nil)
 		MCDeletedObjectsLeaveWait(true);
 	
     // Ensure all objects in the pool are deleted.
     MCDeletedObjectsDoDrain();
     
-    MCMemoryDelete(MCdeletedobjectpool);
-    MCdeletedobjectpool = nil;
+    MCMemoryDelete(MCrootdeletedobjectpool);
+    MCrootdeletedobjectpool = nil;
     
     if (MCsparedeletedobjectpool != nil)
     {
@@ -5677,6 +5705,7 @@ void MCDeletedObjectsOnObjectCreated(MCObject *p_object)
 {
     MCdeletedobjectpool -> references += 1;
     p_object -> setdeletedobjectpool(MCdeletedobjectpool);
+	p_object -> setdeletionissuspended(false);
 }
 
 void MCDeletedObjectsOnObjectDeleted(MCObject *p_object)
@@ -5727,6 +5756,33 @@ void MCDeletedObjectsOnObjectDestroyed(MCObject *p_object)
         t_pool = t_pool -> parent;
         MCDeletedObjectPoolDestroy(t_this_pool);
     }
+}
+
+void MCDeletedObjectsOnObjectSuspendDeletion(MCObject *p_object, void*& r_deletion_cookie)
+{
+	if (p_object -> getdeletionissuspended())
+	{
+		r_deletion_cookie = nil;
+		return;
+	}
+	
+	MCDeletedObjectPool *t_pool;
+	t_pool = p_object -> getdeletedobjectpool();
+	
+	MCAssert(t_pool != nil && t_pool -> parent != nil);
+	
+	r_deletion_cookie = t_pool;
+	p_object -> setdeletedobjectpool(t_pool -> parent);
+	p_object -> setdeletionissuspended(true);
+}
+
+void MCDeletedObjectsOnObjectResumeDeletion(MCObject *p_object, void *p_deletion_cookie)
+{
+	if (p_deletion_cookie == nil)
+		return;
+	
+	p_object -> setdeletedobjectpool((MCDeletedObjectPool *)p_deletion_cookie);
+	p_object -> setdeletionissuspended(false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -231,6 +231,8 @@ void MCDeletedObjectsLeaveWait(bool p_dispatching);
 void MCDeletedObjectsOnObjectCreated(MCObject *object);
 void MCDeletedObjectsOnObjectDeleted(MCObject *object);
 void MCDeletedObjectsOnObjectDestroyed(MCObject *object);
+void MCDeletedObjectsOnObjectSuspendDeletion(MCObject *object, void*& r_cookie);
+void MCDeletedObjectsOnObjectResumeDeletion(MCObject *object, void *cookie);
 
 void MCDeletedObjectsDoDrain(void);
 
@@ -287,7 +289,10 @@ protected:
     
     // If this is true, then this object is in the parentScript resolution table.
     bool m_is_parent_script : 1;
-    
+	
+	// If this is true, then the object is currently suspended from deletion.
+	bool m_deletion_is_suspended : 1;
+	
     // Whether to use legacy theming (or native-like theming)
     MCInterfaceTheme m_theme;
     
@@ -1261,6 +1266,8 @@ public:
     // Object pool instance variable manipulation
     MCDeletedObjectPool *getdeletedobjectpool(void) const { return m_pool; }
     void setdeletedobjectpool(MCDeletedObjectPool *pool) { m_pool = pool; }
+	bool getdeletionissuspended(void) const { return m_deletion_is_suspended; }
+	void setdeletionissuspended(bool value) { m_deletion_is_suspended = value; }
 
 protected:
     IO_stat defaultextendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint32_t p_version);

--- a/tests/lcs/core/engine/target.livecodescript
+++ b/tests/lcs/core/engine/target.livecodescript
@@ -1,0 +1,30 @@
+﻿script "CoreEngineTarget"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestDeleteTargetInFrontScript
+   create button "frontscript"
+   set the script of button "frontscript" to "on doSomething; delete the target; pass doSomething; end doSomething"
+   
+   insert the script of button "frontscript" into front
+   
+   create button "test"
+   set the script of button "test" to "on doSomething; end doSomething"
+   send "doSomething" to button "test"
+   
+   TestAssert "Object is deleted", there is no button "test"
+end TestDeleteTargetInFrontScript


### PR DESCRIPTION
Previously it was possible for a crash to occur because the target
object can be deleted in a frontScript and the deleted object pool
mechanism meant that it would be destroyed whilst still being on
the C stack (in MCObject::message).

This patch fixes the problem by introducing a root pool, and actions
to suspend and resume an object's deletion. When an object's deletion
is suspended it is promoted to the parent pool, thus making it
impossible for it to be deleted until after the current invocation of
MCObject::message completes. The object is demoted back to its original
pool after the message has fallen through the message path.
