### PR TITLE
[[ Bug 17469 ]] Make using curly braces a syntax error

### DIFF
--- a/docs/notes/bugfix-17469.md
+++ b/docs/notes/bugfix-17469.md
@@ -1,0 +1,6 @@
+# Make using curly braces a syntax error
+
+Previously it was possible to use curly brackets or braces `{}` instead 
+of square brackets `[]` in array and custom property syntax. This was
+an undocumented and unknown feature to most users and therefore the use
+curly brackets has been reserved for future use.

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -1126,7 +1126,9 @@ static void tokenize(const unsigned char *p_text, uint4 p_length, uint4 p_in_nes
 					t_end = t_index;
 				break;
 
-				case ST_EOF:
+                case ST_LC:
+                case ST_RC:
+                case ST_EOF:
 				case ST_ERR:
 					t_char = next_valid_char(p_text, t_index);
 					t_class = COLOURIZE_CLASS_ERROR;
@@ -1493,7 +1495,9 @@ static void tokenize_stringref(MCStringRef p_string, uint4 p_in_nesting, uint4& 
 					t_end = t_index;
                     break;
                     
-				case ST_EOF:
+                case ST_LC:
+                case ST_RC:
+                case ST_EOF:
 				case ST_ERR:
 					t_char = next_valid_unichar(p_string, t_index);
 					t_class = COLOURIZE_CLASS_ERROR;

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -67,8 +67,8 @@ uint8_t type_table[256] =
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      l       m       n       o
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      p       q       r       s
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      t       u       v       w
-    ST_ID,   ST_ID,   ST_ID,   ST_LB,   //      x       y       z       {
-    ST_OP,   ST_RB,   ST_OP,   ST_ID,   //      |       }       ~       DEL
+    ST_ID,   ST_ID,   ST_ID,   ST_LC,   //      x       y       z       {
+    ST_OP,   ST_RC,   ST_OP,   ST_ID,   //      |       }       ~       DEL
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      0x80    0x81    0x82    0x83
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      0x84    0x85    0x86    0x87
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      0x88    0x89    0x8A    0x8B
@@ -135,8 +135,8 @@ uint8_t unicode_type_table[256] =
     ST_ID,          ST_ID,          ST_ID,          ST_ID,          //      l       m       n       o
     ST_ID,          ST_ID,          ST_ID,          ST_ID,          //      p       q       r       s
     ST_ID,          ST_ID,          ST_ID,          ST_ID,          //      t       u       v       w
-    ST_ID,          ST_ID,          ST_ID,          ST_LB,          //      x       y       z       {
-    ST_OP,          ST_RB,          ST_OP,          ST_ID,          //      |       }       ~       DEL
+    ST_ID,          ST_ID,          ST_ID,          ST_LC,          //      x       y       z       {
+    ST_OP,          ST_RC,          ST_OP,          ST_ID,          //      |       }       ~       DEL
     ST_UNDEFINED,   ST_UNDEFINED,   ST_UNDEFINED,   ST_UNDEFINED,	//      0x80    0x81    0x82    0x83
     ST_UNDEFINED,   ST_UNDEFINED,   ST_UNDEFINED,   ST_UNDEFINED,	//      0x84    0x85    0x86    0x87
     ST_UNDEFINED,   ST_UNDEFINED,   ST_UNDEFINED,   ST_UNDEFINED,	//      0x88    0x89    0x8A    0x8B

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -2124,7 +2124,9 @@ enum {
     ST_ID,
     ST_ESC,
     ST_LIT,
-	
+	ST_LC,
+    ST_RC,
+    
 	// MW-2009-03-03: The ST_DATA symbol type is a string that shoudl be treated
 	//   as an echoed literal - it represents the data between <?rev ?> blocks in
 	//   SERVER mode. ST_TAG is the type of '?' so we can identify '?>'.

--- a/tests/lcs/core/execution/tokens-curlybraces.livecodescript
+++ b/tests/lcs/core/execution/tokens-curlybraces.livecodescript
@@ -1,0 +1,33 @@
+﻿script "CoreExecutionTokensCurlyBraces"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestCurlyBraces
+   local tResult
+   create stack "Test1"
+   
+   set the script of stack "Test1" to "on openStack;local tArray;put true into tArray{1};end openStack"
+   TestAssert "Curly braces can't be used for array bracket syntax", the result is not empty
+   
+   set the script of stack "Test1" to "on openStack;set the cProperty{1} of stack " & quote & "Test1" & quote &";end openStack"
+   TestAssert "Curly braces can't be used for custom property bracket syntax", the result is not empty
+   
+   set the script of stack "Test1" to "on openStack;local tVar{};put true into tVar{};end openStack"
+   TestAssert "Curly braces can't be used for identifiers", the result is not empty
+   
+   delete stack "Test1"
+end TestCurlyBraces


### PR DESCRIPTION
Previously it was possible to use curly brackets or braces `{}` instead
of square brackets `[]` in array and custom property syntax. This was
an undocumented and unknown feature to most users and therefore the use
curly brackets has been reserved for future use.
