### PR TITLE
[[ Bug 17590 ]] Fix field chunk addition logic

### DIFF
--- a/docs/notes/bugfix-17590.md
+++ b/docs/notes/bugfix-17590.md
@@ -1,0 +1,1 @@
+# Insert item into a field line beyond range correctly

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3384,16 +3384,22 @@ void MCInterfaceExecPutIntoField(MCExecContext& ctxt, MCStringRef p_string, int 
     // SN-2014-09-03: [[ Bug 13314 ]] MCMarkedText::changed updated to store the number of chars appended
     if (p_chunk . mark . changed != 0)
     {
+        findex_t t_added_start;
+        t_added_start = p_chunk.mark.start - p_chunk.mark.changed;
+        
         MCAutoStringRef t_string;
         // SN-2015-05-05: [[ Bug 15315 ]] Changing the whole text of a field
         //  will delete all the settings of the field, so we only append the
         //  chars which were added (similar to MCExecResolveCharsOfField).
-        if (!MCStringCopySubstring((MCStringRef)p_chunk . mark . text, MCRangeMake(p_chunk.mark.start - p_chunk.mark.changed, p_chunk.mark.changed), &t_string))
+        if (!MCStringCopySubstring((MCStringRef)p_chunk . mark . text,
+                                   MCRangeMake(t_added_start, p_chunk.mark.changed),
+                                   &t_string))
             return;
         
-        //  The insertion position of the added chunk delimiters is right before
-        //  the insertion position for the string.
-        t_field -> settextindex(p_chunk .part_id, p_chunk.mark.start - 1, p_chunk.mark.start - 1, *t_string, False);
+        // The insertion position of the added chunk delimiters is at
+        // the position prior to the added chunk adjustment
+        t_field -> settextindex(p_chunk .part_id, t_added_start,
+                                t_added_start, *t_string, False);
     }
      
     integer_t t_start, t_finish;

--- a/tests/lcs/core/chunks/field.livecodescript
+++ b/tests/lcs/core/chunks/field.livecodescript
@@ -1,0 +1,25 @@
+script "CoreChunksField"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestFieldChunkInsert
+	create field
+	set the text of field 1 to ("a" & return & "b")
+	put "x" into item 2 of line 1 of field 1
+	
+	TestAssert "insert chunk on correct line", the text of field 1 is ("a,x" & return & "b")
+end TestFieldChunkInsert


### PR DESCRIPTION
The target index for the chunk is amended in the marking functions
when there are chunk delimiters to be added. These were not correctly
unadjusted when adding these delimiters directly to the field.
