### PR TITLE
[[ Polygon Edit ]] Use MCAutoArray rather than MCAutoPointer

### DIFF
--- a/engine/src/edittool.cpp
+++ b/engine/src/edittool.cpp
@@ -322,9 +322,11 @@ uint4 MCPolygonEditTool::handle_under_point(int2 x, int2 y)
 {
 	uint4 npts = graphic->getnumpoints();
 
-    MCAutoPointer<MCRectangle[]> t_rects;
-    t_rects = new MCRectangle[npts];
-	point_rects(*t_rects);
+    MCAutoArray<MCRectangle> t_rects;
+    if (!t_rects . New(npts))
+        return -1;
+    
+	point_rects(t_rects . Ptr());
 
 	for (uint4 i=0; i<npts; i++)
 		if (MCU_point_in_rect(t_rects[i], x, y))
@@ -338,10 +340,11 @@ bool MCPolygonEditTool::mdown(int2 x, int2 y, uint2 which)
 	uint4 npts = graphic->getnumpoints();
 	MCPoint *pts = graphic->getpoints();
 
-    MCAutoPointer<MCRectangle[]> t_rects;
-    t_rects = new MCRectangle[npts];
+    MCAutoArray<MCRectangle> t_rects;
+    if (!t_rects . New(npts))
+        return false;
 
-	point_rects(*t_rects);
+	point_rects(t_rects . Ptr());
 
 	m_path_start_point = -1;
 
@@ -383,9 +386,11 @@ bool MCPolygonEditTool::mfocus(int2 x, int2 y)
 
 		if (t_npts > 0)
 		{
-			MCAutoPointer<MCRectangle[]> t_rects;
-			t_rects = new MCRectangle[t_npts];
-			point_rects(*t_rects);
+            MCAutoArray<MCRectangle> t_rects;
+            if (!t_rects . New(t_npts))
+                return false;
+            
+			point_rects(t_rects . Ptr());
 			for (int i=0; i<t_npts; i++)
 			{
 				if (MCU_point_in_rect(t_rects[i], x, y))
@@ -423,13 +428,14 @@ void MCPolygonEditTool::drawhandles(MCDC *dc)
 
 	if (npts > 0)
 	{
+        MCAutoArray<MCRectangle> t_rects;
+        if (!t_rects . New(npts))
+            return;
+        
+		point_rects(t_rects . Ptr());
+        
 		dc -> setopacity(255);
 		dc -> setfunction(GXcopy);
-
-        MCAutoPointer<MCRectangle[]> rects;
-        rects = new MCRectangle[npts];
-
-		point_rects(*rects);
 
 		dc->setfillstyle(FillSolid, nil, 0, 0);
 		dc->setlineatts(1, LineSolid, CapButt, JoinBevel);
@@ -439,8 +445,8 @@ void MCPolygonEditTool::drawhandles(MCDC *dc)
 
 		for (uint4 i=0; i<npts; i++)
 		{
-			if (rects[i].x != MININT2)
-				dc->fillarc((*rects)[i], 0, 360);
+			if (t_rects[i].x != MININT2)
+				dc->fillarc(t_rects[i], 0, 360);
 		}
 		dc->setquality(QUALITY_DEFAULT);
 	}
@@ -470,16 +476,18 @@ void MCPolygonEditTool::point_rects(MCRectangle *rects)
 MCRectangle MCPolygonEditTool::drawrect()
 {
 	uint4 npts = graphic->getnumpoints();
-    MCAutoPointer<MCRectangle[]> rects;
-    rects = new MCRectangle[npts];
-    
-	point_rects(*rects);
 
 	MCRectangle drect = {0,0,0,0};
 
+    MCAutoArray<MCRectangle> t_rects;
+    if (!t_rects . New(npts))
+        return drect;
+    
+    point_rects(t_rects . Ptr());
+    
 	for (uint4 i = 0; i < npts; i++)
 	{
-		drect = MCU_union_rect(drect, rects[i]);
+		drect = MCU_union_rect(drect, t_rects[i]);
 	}
 	return drect;
 }


### PR DESCRIPTION
It appears that some compilers can't distinguish MCAutoPointer<T>
from MCAutoPointer<T[]>
