### PR TITLE
Fix syntax example for codepointProperty

### DIFF
--- a/docs/dictionary/function/codepointProperty.lcdoc
+++ b/docs/dictionary/function/codepointProperty.lcdoc
@@ -2,7 +2,7 @@ Name: codepointProperty
 
 Type: function
 
-Syntax: codepointToNum(<unicodeCodepoint>, <propertyName>)
+Syntax: codepointProperty(<unicodeCodepoint>, <propertyName>)
 
 Summary: Retrieves a Unicode Character Database (UCD )character property of a Unicode codepoint.
 


### PR DESCRIPTION
The syntax example used codepointToNum rather than codepointProperty.
