### PR TITLE
[[ Bug 17733 ]] Make sure borderColor of line chunk is correct

### DIFF
--- a/docs/notes/bugfix-17733.md
+++ b/docs/notes/bugfix-17733.md
@@ -1,0 +1,2 @@
+# Make sure borderColor of line chunk returns borderColor
+

--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -2899,7 +2899,7 @@ void MCParagraph::GetBorderColor(MCExecContext& ctxt, MCInterfaceNamedColor &r_c
     else
     {
         MCColor t_color;
-		MCColorSetPixel(t_color, attrs -> background_color);
+		MCColorSetPixel(t_color, attrs -> border_color);
         get_interface_color(t_color, nil, r_color);
     }
 }
@@ -2909,7 +2909,7 @@ void MCParagraph::GetEffectiveBorderColor(MCExecContext& ctxt, MCInterfaceNamedC
     if (attrs != nil && (attrs -> flags & PA_HAS_BORDER_COLOR) != 0)
     {
         MCColor t_color;
-		MCColorSetPixel(t_color, attrs -> background_color);
+		MCColorSetPixel(t_color, attrs -> border_color);
         get_interface_color(t_color, nil, r_color);
     }
 }

--- a/tests/lcs/core/field/line-chunk-colors.livecodescript
+++ b/tests/lcs/core/field/line-chunk-colors.livecodescript
@@ -1,0 +1,27 @@
+script "CoreFieldLineChunkColors"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestColorsOfLineChunk
+	create field "Test"
+	put "a" & return & "b" into field "Test"
+	set the borderColor of line 1 of field "Test" to 127,127,127
+	set the backgroundColor of line 1 of field "Test" to 128,128,128
+	TestDiagnostic the borderColor of line 1 of field "Test"
+	TestAssert "borderColor of line of field sets correctly", the borderColor of line 1 of field "Test" is "127,127,127"
+	TestAssert "backgroundColor of line of field sets correctly", the backgroundColor of line 1 of field "Test" is "128,128,128"
+end TestColorsOfLineChunk


### PR DESCRIPTION
This patch corrects the getters for the borderColor of line chunks
of fields which would previously return the backgroundColor.
