### PR TITLE
[[ Bug 17738 ]] Fix potential crash on startup on Mac

### DIFF
--- a/docs/notes/bugfix-17738.md
+++ b/docs/notes/bugfix-17738.md
@@ -1,0 +1,1 @@
+# Fix potential crash on startup on Mac

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -124,6 +124,13 @@ void MCPlatformHandleApplicationRun(bool& r_continue)
 
 void MCPlatformHandleScreenParametersChanged(void)
 {
+	// It is possible for this notification to be sent *before* MCscreen has
+	// been initialized. In this case, we do nothing (the screen info is fetched
+	// on first use so there's no need to do anything before MCscreen is
+	// initialized).
+	if (MCscreen == nil)
+		return;
+	
 	// IM-2014-01-28: [[ HiDPI ]] Use updatedisplayinfo() method to update & compare display details
 	bool t_changed;
 	t_changed = false;


### PR DESCRIPTION
It appears it is possible for applicationDidChangeScreenParameters to
be sent to the application delegate before MCscreen has been
initialized. As the engine has not started at that point, this should
be an no-op.
