### PR TITLE
[[ Bug 17737 ]] Screen should be force unlocked after window resize

### DIFF
--- a/docs/notes/bugfix-17737.md
+++ b/docs/notes/bugfix-17737.md
@@ -1,0 +1,1 @@
+# Screen should be force unlocked after resizeStack message is sent

--- a/engine/src/desktop-stack.cpp
+++ b/engine/src/desktop-stack.cpp
@@ -34,6 +34,7 @@
 #include "resolution.h"
 #include "player.h"
 #include "dispatch.h"
+#include "redraw.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -451,16 +452,6 @@ void MCDispatch::wredraw(Window p_window, MCPlatformSurfaceRef p_surface, MCGReg
 		t_stack -> view_surface_redrawwindow(&t_stack_surface, p_update_rgn);
 	else
 		s_update_callback(&t_stack_surface, (MCRegionRef)p_update_rgn, s_update_context);
-}
-
-void MCDispatch::wreshape(Window p_window)
-{
-	MCStack *t_stack;
-	t_stack = findstackd(p_window);
-	if (t_stack == nil)
-		return;
-	
-	t_stack -> view_configure(true);
 }
 
 void MCDispatch::wiconify(Window p_window)

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1671,11 +1671,22 @@ void MCDispatch::property(Window w, Atom atom)
 {
 }
 
-void MCDispatch::configure(Window w)
+void MCDispatch::wreshape(Window p_window)
 {
-	MCStack *target = findstackd(w);
-	if (target != NULL)
-		target->view_configure(true);
+	MCStack *t_stack;
+	t_stack = findstackd(p_window);
+	if (t_stack == nil)
+		return;
+	
+	t_stack -> view_configure(true);
+	
+	// The wreshape() invocation occurs as a direct result of a system resize window
+	// request. These can occur whilst nested inside a system modal loop thus the normal
+	// force unlock which occurs at the root loop does not happen. Therefore we
+	// do that here to ensure that a 'lock screen' inside a resizeStack does not cause
+	// subsequent resize requests (in the same user resizing action) to not have an
+	// effect.
+	MCRedrawForceUnlockScreen();
 }
 
 void MCDispatch::enter(Window w)

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1687,6 +1687,9 @@ void MCDispatch::wreshape(Window p_window)
 	// subsequent resize requests (in the same user resizing action) to not have an
 	// effect.
 	MCRedrawForceUnlockScreen();
+
+	// Now make sure we force an update screen.
+	MCRedrawUpdateScreen();
 }
 
 void MCDispatch::enter(Window w)

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -174,7 +174,6 @@ public:
 
 	void kfocusset(Window w);
 	void property(Window w, Atom atom);
-	void configure(Window w);
 	void enter(Window w);
     void redraw(Window w, MCRegionRef dirty_region);
 	MCFontlist *getfontlist();

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -781,7 +781,7 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                     gdk_window_resize(t_event->configure.window, t_new_width, t_new_height);
                 }                        
                 
-                MCdispatcher->configure(t_event->configure.window);
+                MCdispatcher->wreshape(t_event->configure.window);
                 break;
             }
                 

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -148,11 +148,6 @@ void MCStack::resize(uint2 oldw, uint2 oldh)
 		curcard->message_with_args(MCM_resize_stack, rect.width, rect.height + newy, oldw, oldh);
 	}
 	MCRedrawUnlockScreen();
-
-	// MW-2011-08-18: [[ Redraw ]] For now, update the screen here. This should
-	//   really be done 'in general' after event dispatch, but things don't work
-	//   in a suitable way for that... Yet...
-	MCRedrawUpdateScreen();
 }
 
 static bool _MCStackConfigureCallback(MCStack *p_stack, void *p_context)

--- a/engine/src/stackview.cpp
+++ b/engine/src/stackview.cpp
@@ -504,7 +504,7 @@ void MCStack::view_configure(bool p_user)
 
 	// IM-2014-10-29: [[ Bug 13812 ]] Remove need resize check and unset flag
 	m_view_need_resize = false;
-	
+
 	if (!MCU_equal_rect(t_view_rect, m_view_rect))
 	{
 		// IM-2014-02-13: [[ StackScale ]] Test if the view size has changed

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -1319,12 +1319,12 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 					if (target->isiconic())
 					{
 						MCstacks->restack(target);
-						target->view_configure(true);
+						target->wreshape(dw);
 						target->uniconify();
 						SetWindowPos((HWND)target -> getwindow() -> handle . window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER);
 					}
 					else
-						target->view_configure(true);
+						target->wreshape(dw);
 				curinfo->handled = True;
 			}
 		}
@@ -1340,7 +1340,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		}
 		else
 		{
-			MCdispatcher->configure(dw);
+			MCdispatcher->wreshape(dw);
 			curinfo->handled = True;
 		}
 		break;

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -1319,12 +1319,12 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 					if (target->isiconic())
 					{
 						MCstacks->restack(target);
-						target->wreshape(dw);
+						MCdispatcher->wreshape(dw);
 						target->uniconify();
 						SetWindowPos((HWND)target -> getwindow() -> handle . window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER);
 					}
 					else
-						target->wreshape(dw);
+						MCdispatcher->wreshape(dw);
 				curinfo->handled = True;
 			}
 		}


### PR DESCRIPTION
This patch ensures that the screen is force unlocked after a system
resize window event is processed. This ensures that using 'lock screen'
inside resizeStack does not cause a resize gesture to only be
processed for the first resize.

The reason an explicit force unlock is needed in this instance is that
the system resize events occur in a modal system loop meaning that
the root wait loop is not touched (which does force unlock the screen).

The MCDispatch::configure() method has been removed, and replaced by
MCDispatch::wreshape() - this makes sure the behavior is the same
on all platforms.
