### PR TITLE
[[ ReturnIt ]] Adds syntax for allowing an 'it' return value

### DIFF
--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -321,13 +321,14 @@ public:
 class MCReturn : public MCStatement
 {
 	MCExpression *source;
-	MCExpression *url;
-	MCVarref *var;
+	MCExpression *extra_source;
+    bool is_with_urlresult : 1;
 public:
 	MCReturn()
 	{
-		source = url = NULL;
-		var = NULL;
+        source = NULL;
+        extra_source = NULL;
+        is_with_urlresult = false;
 	}
 	virtual ~MCReturn();
 	virtual Parse_stat parse(MCScriptPoint &);

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -113,6 +113,7 @@ MC_EXEC_DEFINE_EXEC_METHOD(Engine, UnlockErrors, 0)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, UnlockMessages, 0)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, Set, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, ReturnValue, 1)
+MC_EXEC_DEFINE_EXEC_METHOD(Engine, ReturnValueAndIt, 2)
 MC_EXEC_DEFINE_SET_METHOD(Engine, CaseSensitive, 1)
 MC_EXEC_DEFINE_GET_METHOD(Engine, CaseSensitive, 1)
 MC_EXEC_DEFINE_SET_METHOD(Engine, CenturyCutOff, 1)
@@ -843,6 +844,13 @@ void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCExecValue p_value, int p
 void MCEngineExecReturnValue(MCExecContext& ctxt, MCValueRef p_value)
 {
 	ctxt . SetTheResultToValue(p_value);
+}
+
+void MCEngineExecReturnValueAndIt(MCExecContext& ctxt, MCValueRef p_value, MCValueRef p_extra_value)
+{
+    ctxt . SetTheResultToValue(p_value);
+    if (MCnexecutioncontexts > 0)
+        MCexecutioncontexts[MCnexecutioncontexts - 1] -> SetItToValue(p_extra_value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -66,7 +66,6 @@ MC_EXEC_DEFINE_EXEC_METHOD(Network, ReadFromSocketUntil, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, WriteToSocket, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, PutIntoUrl, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, ReturnValueAndUrlResult, 2)
-MC_EXEC_DEFINE_EXEC_METHOD(Network, ReturnValueAndUrlResultFromVar, 2)
 MC_EXEC_DEFINE_GET_METHOD(Network, UrlResponse, 1)
 MC_EXEC_DEFINE_GET_METHOD(Network, FtpProxy, 1)
 MC_EXEC_DEFINE_SET_METHOD(Network, FtpProxy, 1)
@@ -784,17 +783,6 @@ void MCNetworkExecReturnValueAndUrlResult(MCExecContext& ctxt, MCValueRef p_resu
 		return;
 	
 	ctxt . Throw();
-}
-
-void MCNetworkExecReturnValueAndUrlResultFromVar(MCExecContext& ctxt, MCValueRef p_result, MCVarref *p_variable)
-{
-    MCAutoValueRef t_value;
-    if (!ctxt . EvalExprAsValueRef(p_variable, EE_RETURN_BADEXP, &t_value))
-        return;
-	
-	ctxt . SetTheResultToValue(p_result);
-	MCurlresult -> set(ctxt, *t_value);
-	p_variable -> dofree(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3780,6 +3780,7 @@ extern MCExecMethodInfo *kMCEngineExecUnlockErrorsMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecUnlockMessagesMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecSetMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecReturnValueMethodInfo;
+extern MCExecMethodInfo *kMCEngineExecReturnValueAndItMethodInfo;
 extern MCExecMethodInfo *kMCEngineSetCaseSensitiveMethodInfo;
 extern MCExecMethodInfo *kMCEngineGetCaseSensitiveMethodInfo;
 extern MCExecMethodInfo *kMCEngineSetCenturyCutOffMethodInfo;
@@ -3913,6 +3914,7 @@ void MCEngineExecUnlockMessages(MCExecContext& ctxt);
 
 void MCEngineExecSet(MCExecContext& ctxt, MCProperty *target, MCValueRef value);
 void MCEngineExecReturnValue(MCExecContext& ctxt, MCValueRef value);
+void MCEngineExecReturnValueAndIt(MCExecContext& ctxt, MCValueRef value, MCValueRef extra_value);
 
 void MCEngineExecLoadExtension(MCExecContext& ctxt, MCStringRef filename, MCStringRef resource_path);
 void MCEngineExecUnloadExtension(MCExecContext& ctxt, MCStringRef filename);
@@ -4416,7 +4418,6 @@ void MCNetworkExecWriteToSocket(MCExecContext& ctxt, MCNameRef p_socket, MCStrin
 void MCNetworkExecPutIntoUrl(MCExecContext& ctxt, MCValueRef value, int prep, MCUrlChunkPtr url);
 
 void MCNetworkExecReturnValueAndUrlResult(MCExecContext& ctxt, MCValueRef value, MCValueRef url_result);
-void MCNetworkExecReturnValueAndUrlResultFromVar(MCExecContext& ctxt, MCValueRef result, MCVarref *variable);
 
 void MCNetworkGetUrlResponse(MCExecContext& ctxt, MCStringRef& r_value);
 

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -2154,6 +2154,7 @@ static LT sugar_table[] =
 		{"true", TT_UNDEFINED, SG_TRUE},
 		{"unicode", TT_UNDEFINED, SG_UNICODE},
 		{"url", TT_UNDEFINED, SG_URL},
+        {"urlresult", TT_UNDEFINED, SG_URL_RESULT},
 		// JS-2013-07-01: [[ EnhancedFilter ]] Token for 'wildcard'.
 		{"wildcard", TT_UNDEFINED, SG_WILDCARD},
 		{"without", TT_PREP, PT_WITHOUT},

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1956,6 +1956,8 @@ enum Sugar_constants {
 	SG_REPLACING,
 	SG_PRESERVING,
 	SG_STYLES,
+    
+    SG_URL_RESULT,
 };
 
 enum Statements {

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -1,4 +1,4 @@
-﻿script "revLibURL"
+script "revLibURL"
 ##libUrl v1.2.0 2010-09-16
 #
 on revLoadLibrary
@@ -193,11 +193,7 @@ on getUrl x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of the keys of laLoadedUrls and laUrlLoadStatus[newUrl] is "cached" then
-      if "2.4.1" is in the version then
-         return  empty  with  laLoadedUrls[newUrl]
-      else
-         return  empty  with cachedUrl laLoadedUrls[newUrl]
-      end if
+      return empty  with urlResult laLoadedUrls[newUrl]
    end if
    if newUrl is among the lines of keys(laLoadingUrls) and (lvAuthBlockBypass is not true) then
       return "error  URL is currently loading" with empty
@@ -223,21 +219,16 @@ on getUrl x
          
          put laUrlErrorStatus[newUrl] into tRetResult
          delete local  laUrlErrorStatus[newUrl]
-         if "2.4.1" is in the version then
-            ##for mc 2.4.1 engine only
-            put laData[newUrl] into tRetData ##swap data before deleting laData
-            delete local laData[newUrl]
-            put empty into lvBlockingUrl ##clear
-            return tRetResult  with tRetData
-         else
-            put empty into lvBlockingUrl ##clear
-            return tRetResult with url laData[newUrl]
-         end if
+
+         put laData[newUrl] into tRetData ##swap data before deleting laData
+         delete local laData[newUrl]
+         put empty into lvBlockingUrl ##clear
+         return tRetResult with urlResult tRetData
       else
          return 1
       end if
    else ##blocked by previous request
-      return "error Previous request not completed" with empty
+      return "error Previous request not completed" with urlResult empty
    end if
 end getUrl
 
@@ -249,7 +240,7 @@ on postUrl y,x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of keys(laLoadingUrls) then
-      return "error  URL is currently loading" with empty
+      return "error  URL is currently loading" with urlResult empty
    end if
    if lvBlockingUrl is empty  or lvBlockBypass or lvAuthBlockBypass is true then
       put newUrl into lvBlockingUrl
@@ -272,23 +263,18 @@ on postUrl y,x
          
          put laUrlErrorStatus[newUrl] into tRetResult
          delete local  laUrlErrorStatus[newUrl]
-         if "2.4.1" is in the version then
-            ##for mc 2.4.1 engine only
-            put laData[newUrl] into tRetData
-            delete local laData[newUrl]
-            put empty into lvBlockingUrl ##clear
-            return tRetResult  with tRetData
-         else
-            put empty into lvBlockingUrl ##clear
-            return tRetResult with url laData[newUrl]
-         end if
+
+         put laData[newUrl] into tRetData
+         delete local laData[newUrl]
+         put empty into lvBlockingUrl ##clear
+         return tRetResult with urlResult tRetData
       else
          return 1
       end if
       -----------------------------------
    else ##blocked by previous request
       put "error Previous request not completed" into tRetResult
-      return tRetResult with empty
+      return tRetResult with urlResult empty
    end if
 end postUrl
 
@@ -300,7 +286,7 @@ on putUrl y,x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of keys(laLoadingUrls) then
-      return "error  URL is currently loading" with empty
+      return "error  URL is currently loading" with urlResult empty
    end if
    if lvBlockingUrl is empty  or lvBlockBypass or lvAuthBlockBypass is true then
       put newUrl into lvBlockingUrl
@@ -323,16 +309,11 @@ on putUrl y,x
          
          put laUrlErrorStatus[newUrl] into tRetResult
          delete local  laUrlErrorStatus[newUrl]
-         if "2.4.1" is in the version then
-            ##for mc 2.4.1 engine only
-            put laData[newUrl] into tRetData
-            delete local laData[newUrl]
-            put empty into lvBlockingUrl ##clear
-            return tRetResult  with tRetData
-         else
-            put empty into lvBlockingUrl ##clear
-            return tRetResult with url laData[newUrl]
-         end if
+
+         put laData[newUrl] into tRetData
+         delete local laData[newUrl]
+         put empty into lvBlockingUrl ##clear
+         return tRetResult with urlResult tRetData
       else
          return 1
       end if
@@ -340,7 +321,7 @@ on putUrl y,x
       
    else ##blocked by previous request
       put "error Previous request not completed" into tRetResult
-      return tRetResult with empty
+      return tRetResult with urlResult empty
    end if
 end putUrl
 
@@ -351,7 +332,7 @@ on deleteUrl x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of keys(laLoadingUrls) then
-      return "error  URL is currently loading" with empty
+      return "error  URL is currently loading" with urlResult empty
    end if
    if lvBlockingUrl is empty  or lvBlockBypass is true then
       put newUrl into lvBlockingUrl
@@ -368,21 +349,16 @@ on deleteUrl x
       delete local laStatus[newUrl]
       put laUrlErrorStatus[newUrl] into tRetResult
       delete local  laUrlErrorStatus[newUrl]
-      if "2.4.1" is in the version then
-         ##for mc 2.4.1 engine only
-         put laData[newUrl] into tRetData
-         delete local laData[newUrl]
-         put empty into lvBlockingUrl ##clear
-         return tRetResult  with tRetData
-      else
-         put empty into lvBlockingUrl ##clear
-         return tRetResult with url laData[newUrl]
-      end if
+
+      put laData[newUrl] into tRetData
+      delete local laData[newUrl]
+      put empty into lvBlockingUrl ##clear
+      return tRetResult with urlResult tRetData
       -----------------------------------
       
    else ##blocked by previous request
       put "error Previous request not completed" into tRetResult
-      return tRetResult with empty
+      return tRetResult with urlResult empty
    end if
 end deleteUrl
 


### PR DESCRIPTION
This patch adds 'return X with Y' syntax where 'the result' is set
to X and 'it' (in the caller of the handler) is set to Y.
