### PR TITLE
Add lock screen example

### DIFF
--- a/docs/dictionary/message/textChanged.lcdoc
+++ b/docs/dictionary/message/textChanged.lcdoc
@@ -19,6 +19,14 @@ on textChanged -- enable the save button when a change is made
    enable button "save"
 end textChanged
 
+Example:
+on textChanged -- resize height of field to fit text
+   lock screen -- lock screen to delay the screen update so that there is no flicker
+   put the rect of me into tRect
+   put item 2 of tRect + the formattedHeight of me into item 4 of tRect
+   set the rect of me to tRect
+end textChanged
+
 Description:
 Is dispatched by the field whenever a user (or simulated user) action causes the content of the field to change.
 


### PR DESCRIPTION
This change adds an example showing how to use lock screen to avoid any screen flicker when resizing a field during the textChanged message.
