### PR TITLE
lc-compile: String and manifest encoding correctness fixes

### DIFF
--- a/docs/lcb/notes/16212.md
+++ b/docs/lcb/notes/16212.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+## lc-compile
+
+# [16212] Escape XML reserved characters in manifest files

--- a/docs/lcb/notes/17767.md
+++ b/docs/lcb/notes/17767.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+## lc-compile
+
+# [17767] Process escape sequences in all string literals.

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2016 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -168,6 +168,7 @@ extern "C" void OutputEnd(void);
 extern "C" void OutputWrite(const char *msg);
 extern "C" void OutputWriteI(const char *left, NameRef name, const char *right);
 extern "C" void OutputWriteS(const char *left, const char *string, const char *right);
+extern "C" void OutputWriteXmlS(const char *left, const char *string, const char *right);
 
 extern "C" int IsBootstrapCompile(void);
 
@@ -1790,6 +1791,70 @@ void OutputWriteI(const char *p_left, NameRef p_name, const char *p_right)
     const char *t_name_string;
     GetStringOfNameLiteral(p_name, &t_name_string);
     OutputWriteS(p_left, t_name_string, p_right);
+}
+
+/* This is the same as OutputWriteS, but escapes special XML
+ * characters (&, ", ', <, >) found in p_string */
+void
+OutputWriteXmlS(const char *p_left,
+                const char *p_string,
+                const char *p_right)
+{
+	struct xml_replacement_t {
+		const char *from, *to;
+	};
+
+	static const struct xml_replacement_t k_replacements[] = {
+		{"&", "&amp;"},
+		{"<", "&lt;"},
+		{">", "&gt;"},
+		{"\"", "&quot;"},
+		{"\'", "&apos;"},
+		{NULL, NULL},
+	};
+
+	if (s_output == NULL)
+	{
+		return;
+	}
+
+	bool t_success = true;
+	MCAutoStringRef t_string;
+	if (t_success)
+	{
+		t_success =
+			MCStringCreateWithBytes(reinterpret_cast<const byte_t *>(p_string),
+			                        strlen(p_string), kMCStringEncodingUTF8,
+			                        false, &t_string);
+	}
+
+	MCAutoStringRef t_xml_string;
+	if (t_success)
+	{
+		t_success = MCStringMutableCopy(*t_string, &t_xml_string);
+	}
+	for (int i = 0; t_success && k_replacements[i].from != nil; ++i)
+	{
+		t_success = MCStringFindAndReplace(*t_xml_string,
+		                                   MCSTR(k_replacements[i].from),
+		                                   MCSTR(k_replacements[i].to),
+		                                   kMCStringOptionCompareExact);
+	}
+
+	MCAutoStringRefAsUTF8String t_xml_utf8string;
+	if (t_success)
+	{
+		t_success = t_xml_utf8string.Lock(*t_xml_string);
+	}
+
+	if (t_success)
+	{
+		OutputWriteS(p_left, *t_xml_utf8string, p_right);
+	}
+	else
+	{
+		/* UNCHECKED */ abort();
+	}
 }
 
 void OutputEnd(void)

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -23,6 +23,7 @@
 #include "literal.h"
 #include "position.h"
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <sys/stat.h>
 

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2016 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -137,19 +137,19 @@
         OutputWriteI("  <name>", Name, "</name>\n")
         [|
             QueryMetadata(Definitions, "title" -> TitleString)
-            OutputWriteS("  <title>", TitleString, "</title>\n")
+            OutputWriteXmlS("  <title>", TitleString, "</title>\n")
         |]
         [|
             QueryMetadata(Definitions, "author" -> AuthorString)
-            OutputWriteS("  <author>", AuthorString, "</author>\n")
+            OutputWriteXmlS("  <author>", AuthorString, "</author>\n")
         |]
         [|
             QueryMetadata(Definitions, "description" -> DescriptionString)
-            OutputWriteS("  <description>", DescriptionString, "</description>\n")
+            OutputWriteXmlS("  <description>", DescriptionString, "</description>\n")
         |]
         [|
             QueryMetadata(Definitions, "version" -> VersionString)
-            OutputWriteS("  <version>", VersionString, "</version>\n")
+            OutputWriteXmlS("  <version>", VersionString, "</version>\n")
         |]
         OutputWrite("  <license>community</license>\n")
         (|
@@ -215,8 +215,8 @@
         ||
             IsStringEqualToString(Key, "version")
         ||
-            OutputWriteS("  <metadata key=\"", Key, "\">")
-            OutputWriteS("", Value, "</metadata>\n")
+            OutputWriteXmlS("  <metadata key=\"", Key, "\">")
+            OutputWriteXmlS("", Value, "</metadata>\n")
         |)
 
     'rule' GenerateManifestDefinitions(type(_, public, Name, _)):

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -249,7 +249,7 @@
 'nonterm' Metadata(-> DEFINITION)
 
     'rule' Metadata(-> metadata(Position, Key, Value)):
-        "metadata" @(-> Position) StringOrNameLiteral(-> Key) "is" STRING_LITERAL(-> Value)
+        "metadata" @(-> Position) StringOrNameLiteral(-> Key) "is" StringLiteral(-> Value)
         
 --------------------------------------------------------------------------------
 -- Import Syntax
@@ -372,7 +372,7 @@
         Access(-> Access) "type" @(-> Position) Identifier(-> Name) "is" Type(-> Type)
     
     'rule' TypeDefinition(-> type(Position, Access, Name, foreign(Position, Binding))):
-        Access(-> Access) "foreign" @(-> Position) "type" Identifier(-> Name) "binds" "to" STRING_LITERAL(-> Binding)
+        Access(-> Access) "foreign" @(-> Position) "type" Identifier(-> Name) "binds" "to" StringLiteral(-> Binding)
         
     'rule' TypeDefinition(-> type(Position, Access, Name, record(Position, Base, Fields))):
         Access(-> Access) "record" @(-> Position) "type" Identifier(-> Name) OptionalBaseType(-> Base) Separator
@@ -472,7 +472,7 @@
     --    "end" "handler"
         
     'rule' HandlerDefinition(-> foreignhandler(Position, Access, Name, Signature, Binding)):
-        Access(-> Access) "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" STRING_LITERAL(-> Binding)
+        Access(-> Access) "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)
 
 'nonterm' Signature(-> SIGNATURE)
 
@@ -1124,10 +1124,10 @@
         "[" @(-> Position) Syntax(-> Operand) "]"
         
     'rule' AtomicSyntax(-> keyword(Position, Value)):
-        STRING_LITERAL(-> Value) @(-> Position)
+        StringLiteral(-> Value) @(-> Position)
 
     'rule' AtomicSyntax(-> unreservedkeyword(Position, Value)):
-        STRING_LITERAL(-> Value) @(-> Position) "!"
+        StringLiteral(-> Value) @(-> Position) "!"
         
     'rule' AtomicSyntax(-> rule(Position, Name)):
         "<" @(-> Position) Identifier(-> Name) ">"

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2016 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -252,6 +252,7 @@
     OutputWrite
     OutputWriteI
     OutputWriteS
+    OutputWriteXmlS
 
     ErrorsDidOccur
     Fatal_OutOfMemory
@@ -627,6 +628,7 @@
 'action' OutputWrite(STRING)
 'action' OutputWriteI(STRING, NAME, STRING)
 'action' OutputWriteS(STRING, STRING, STRING)
+'action' OutputWriteXmlS(STRING, STRING, STRING)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
- Ensure that when characters reserved by the XML standard (`'"&<>`) might need to be written to a manifest file, they are correctly escaped.
- Ensure that anything that looks like a string literal `"..."` gets escape sequences processed correctly.
