### PR TITLE
Improve GPS timestamps on Android

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -275,7 +275,7 @@ WIN_PERL=${WIN_PERL:-"C:/perl/bin/perl.exe"}
 # Android default settings and tools
 if test "${OS}" = "android" ; then
     ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION:-r10d}
-    ANDROID_PLATFORM=${ANDROID_PLATFORM:-android-10}
+    ANDROID_PLATFORM=${ANDROID_PLATFORM:-android-17}
 
     # Attempt to locate an Android NDK
     if [ -z "${ANDROID_NDK}" -a "${OS}" = "android" ] ; then

--- a/docs/notes/bugfix-17661.md
+++ b/docs/notes/bugfix-17661.md
@@ -1,0 +1,16 @@
+# Improve Android timestamp accuracy for GPS and sensors
+
+Timestamps for sensors on Android were previously passed in a low-precision
+format, resulting in "sticky" timestamps that did not change more than a few
+times a minute. This has now been resolved and timestamps are now reported to
+microsecond resolution (though the accuracy is unlikely to be at the microsecond
+level).
+
+In addition to this change, the timestamps are now reported in "monotonic" time
+rather than "wall-clock" time ("wall-clock" time is the time you see reported
+as the current time). This means that the timestamps are now independent of
+changes to the device clock as a result of adjustments or daylight savings
+changes. If you want to match the readings to the device time instead, get the
+current time when receiving the location update rather than using the timestamp
+in the update.
+

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -1478,7 +1478,7 @@ public class Engine extends View implements EngineApi
         return m_sensor_module.stopTrackingRotationRate();
     }
 
-    public void onAccelerationChanged(float p_x, float p_y, float p_z, float p_timestamp)
+    public void onAccelerationChanged(float p_x, float p_y, float p_z, double p_timestamp)
     {
         doAccelerationChanged(p_x, p_y, p_z, p_timestamp);
         if (m_wake_on_event)
@@ -1493,7 +1493,7 @@ public class Engine extends View implements EngineApi
             doProcess(false);
     }
 
-    public void onHeadingChanged(double p_heading, double p_magnetic_heading, double p_true_heading, float p_timestamp,
+    public void onHeadingChanged(double p_heading, double p_magnetic_heading, double p_true_heading, double p_timestamp,
                                  float p_x, float p_y, float p_z, float p_accuracy)
     {
         doHeadingChanged(p_heading, p_magnetic_heading, p_true_heading, p_timestamp, p_x, p_y, p_z, p_accuracy);
@@ -1501,7 +1501,7 @@ public class Engine extends View implements EngineApi
             doProcess(false);
     }
 
-    public void onRotationRateChanged(float p_x, float p_y, float p_z, float p_timestamp)
+    public void onRotationRateChanged(float p_x, float p_y, float p_z, double p_timestamp)
     {
         doRotationRateChanged(p_x, p_y, p_z, p_timestamp);
         if (m_wake_on_event)
@@ -3453,10 +3453,10 @@ public class Engine extends View implements EngineApi
 	
     // sensor handlers
     public static native void doLocationChanged(double p_latitude, double p_longitude, double p_altitude, double p_timestamp, float p_accuracy, double p_speed, double p_course);
-    public static native void doHeadingChanged(double p_heading, double p_magnetic_heading, double p_true_heading, float p_timestamp,
+    public static native void doHeadingChanged(double p_heading, double p_magnetic_heading, double p_true_heading, double p_timestamp,
                                                float p_x, float p_y, float p_z, float p_accuracy);
-	public static native void doAccelerationChanged(float x, float y, float z, float timestamp);
-	public static native void doRotationRateChanged(float x, float y, float z, float timestamp);
+	public static native void doAccelerationChanged(float x, float y, float z, double timestamp);
+	public static native void doRotationRateChanged(float x, float y, float z, double timestamp);
 
     // input event handlers
 	public static native void doBackPressed();

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -1485,7 +1485,7 @@ public class Engine extends View implements EngineApi
             doProcess(false);
     }
 
-    public void onLocationChanged(double p_latitude, double p_longitude, double p_altitude, float p_timestamp, float p_accuracy, double p_speed, double p_course)
+    public void onLocationChanged(double p_latitude, double p_longitude, double p_altitude, double p_timestamp, float p_accuracy, double p_speed, double p_course)
     {
         // MM-2013-02-21: Added spead and course to location readings.
         doLocationChanged(p_latitude, p_longitude, p_altitude, p_timestamp, p_accuracy, p_speed, p_course);
@@ -3452,7 +3452,7 @@ public class Engine extends View implements EngineApi
 	public static native void doWait(double time, boolean dispatch, boolean anyevent);
 	
     // sensor handlers
-    public static native void doLocationChanged(double p_latitude, double p_longitude, double p_altitude, float p_timestamp, float p_accuracy, double p_speed, double p_course);
+    public static native void doLocationChanged(double p_latitude, double p_longitude, double p_altitude, double p_timestamp, float p_accuracy, double p_speed, double p_course);
     public static native void doHeadingChanged(double p_heading, double p_magnetic_heading, double p_true_heading, float p_timestamp,
                                                float p_x, float p_y, float p_z, float p_accuracy);
 	public static native void doAccelerationChanged(float x, float y, float z, float timestamp);

--- a/engine/src/mblandroidsensor.cpp
+++ b/engine/src/mblandroidsensor.cpp
@@ -245,9 +245,9 @@ JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doAccelerationChanged(JNIE
     MCSensorPostChangeMessage(kMCSensorTypeAcceleration);
 }
 
-extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doLocationChanged(JNIEnv *env, jobject object, jdouble latitude, jdouble longitude, jdouble altitude, jfloat timestamp, jfloat accuracy, jdouble speed, jdouble course) __attribute__((visibility("default")));
+extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doLocationChanged(JNIEnv *env, jobject object, jdouble latitude, jdouble longitude, jdouble altitude, jdouble timestamp, jfloat accuracy, jdouble speed, jdouble course) __attribute__((visibility("default")));
 
-JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doLocationChanged(JNIEnv *env, jobject object, jdouble latitude, jdouble longitude, jdouble altitude, jfloat timestamp, jfloat accuracy, jdouble speed, jdouble course)
+JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doLocationChanged(JNIEnv *env, jobject object, jdouble latitude, jdouble longitude, jdouble altitude, jdouble timestamp, jfloat accuracy, jdouble speed, jdouble course)
 {
     // MM-2012-03-13: Create first reading value only when we get a callback.  
     //     This means we can properly handle the case where the user requests a reading before one has been taken.

--- a/engine/src/mblandroidsensor.cpp
+++ b/engine/src/mblandroidsensor.cpp
@@ -227,9 +227,9 @@ bool MCSystemGetLocationAuthorizationStatus(MCStringRef& r_status)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doAccelerationChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jfloat timestamp) __attribute__((visibility("default")));
+extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doAccelerationChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jdouble timestamp) __attribute__((visibility("default")));
 
-JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doAccelerationChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jfloat timestamp)
+JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doAccelerationChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jdouble timestamp)
 {
     // MM-2012-03-13: Create first reading value only when we get a callback.  
     //     This means we can properly handle the case where the user requests a reading before one has been taken.
@@ -269,9 +269,9 @@ JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doLocationChanged(JNIEnv *
     MCSensorPostChangeMessage(kMCSensorTypeLocation);
 }
 
-extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doHeadingChanged(JNIEnv *env, jobject object, jdouble heading, jdouble magnetic_heading, jdouble true_heading, jfloat timestamp, jfloat x, jfloat y, jfloat z, jfloat accuracy) __attribute__((visibility("default")));
+extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doHeadingChanged(JNIEnv *env, jobject object, jdouble heading, jdouble magnetic_heading, jdouble true_heading, jdouble timestamp, jfloat x, jfloat y, jfloat z, jfloat accuracy) __attribute__((visibility("default")));
 
-JNIEXPORT void JNICALL JNICALL Java_com_runrev_android_Engine_doHeadingChanged(JNIEnv *env, jobject object, jdouble heading, jdouble magnetic_heading, jdouble true_heading, jfloat timestamp, jfloat x, jfloat y, jfloat z, jfloat accuracy)
+JNIEXPORT void JNICALL JNICALL Java_com_runrev_android_Engine_doHeadingChanged(JNIEnv *env, jobject object, jdouble heading, jdouble magnetic_heading, jdouble true_heading, jdouble timestamp, jfloat x, jfloat y, jfloat z, jfloat accuracy)
 {
     // MM-2012-03-13: Create first reading value only when we get a callback.  
     //     This means we can properly handle the case where the user requests a reading before one has been taken.
@@ -291,9 +291,9 @@ JNIEXPORT void JNICALL JNICALL Java_com_runrev_android_Engine_doHeadingChanged(J
     MCSensorPostChangeMessage(kMCSensorTypeHeading);
 }
 
-extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doRotationRateChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jfloat timestamp) __attribute__((visibility("default")));
+extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doRotationRateChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jdouble timestamp) __attribute__((visibility("default")));
 
-JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doRotationRateChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jfloat timestamp)
+JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doRotationRateChanged(JNIEnv *env, jobject object, jfloat x, jfloat y, jfloat z, jdouble timestamp)
 {
     // MM-2012-03-13: Create first reading value only when we get a callback.  
     //     This means we can properly handle the case where the user requests a reading before one has been taken.


### PR DESCRIPTION
Problem 1: float doesn't have enough bits of precision for second resolution this far from the Unix epoch.

Problem 2: the timestamps we are using for the GPS timestamps are wall-clock time, not monotonic, so are affected by changes to the device clock.

The docs should probably be updated to clarify that the GPS timestamps are monotonic and may not be equal to the current wall-clock time.
