### PR TITLE
[[ BytecodeBlocks ]] Add bytecode blocks

### DIFF
--- a/docs/guides/LiveCode Builder Bytecode Reference.md
+++ b/docs/guides/LiveCode Builder Bytecode Reference.md
@@ -1,0 +1,155 @@
+---
+group: reference
+---
+
+# LiveCode Builder Bytecode Reference
+
+## Introduction
+
+The LiveCode Builder Virtual Machine is a infinite register machine with a
+high-level and verifiable bytecode.
+
+All bytecode runs in the context of a module instance with executing handlers
+forming a stack of activation frames. Each frame contains an array of registers,
+the first part of which are parameters followed by handler-local variables and
+bytecode block registers.
+
+Most bytecode operations operate directly on registers, access to module level
+definitions (handlers, constants, variables) are indirected through the fetch
+and store operations.
+
+Each bytecode operation has an address which can be jumped to using the jump
+operations.
+
+## Operations
+
+### Jump
+
+    jump <label>
+
+The jump operation sets the address of the next instruction to execute to
+that identified by <label>.
+
+### Jump If False
+
+    jump_if_false <register>, <label>
+
+The jump_if_true operation checks the value in <register> and jumps to <label>
+if it is 'false'.
+
+If is a runtime error if <register> does not contain a boolean.
+
+### Jump If True
+
+    jump_if_true <register>, <label>
+
+The jump_if_true operation checks the value in <register> and jumps to <label>
+if it is 'true'.
+
+If is a runtime error if <register> does not contain a boolean.
+
+### Assign Constant
+
+    assign_constant <register>, <constant>
+
+The assign_constant operation copies <constant> into <register>. Here <constant>
+can be the nothing literal, the true or false literal, an integer literal, a
+real literal, a string literal, a list literal or array literal.
+
+If <register> is typed then it is a runtime error if the type of <constant>
+does not conform to that type.
+
+### Assign
+
+    assign <dst-register>, <src-register>
+
+The assign operation copies the value in <src-register> to <dst-register>.
+
+If <dst-register> is typed then it is runtime error if the type of the value
+in <src-register> does not conform to that type.
+
+### Return
+
+    return [ <result-reg> ]
+
+The return operation exits the current handler, returning to the instruction after
+the invoke operation which created it. If present, the value in <result-reg> is
+copied as the return value. If not present then the return value will be 'nothing'.
+Additionally any values in out or inout parameters are copied back to the caller.
+
+If <result-reg> is not present, then the return value will be 'nothing'.
+
+It is a runtime error if the type of the return value does not conform to the
+return type of the current handler's signature.
+
+It is a runtime error if any out or inout parameters are unassigned at the point
+of return.
+
+### Invoke
+
+    invoke <handler>, <result>, <arg_1>, ..., <arg_n>
+
+The invoke operation creates a new frame copying values from the argument registers
+for any in or inout parameters. It then starts executing the bytecode attached
+to <handler>.
+
+If is a runtime error if the number of arguments provided is different from the
+signature of <handler>
+
+If it a runtime error if for in and inout parameters, the contents of <arg_i>
+does not conform to the type of the parameter required by the signature.
+
+### Invoke Indirect
+
+    invoke <handler-reg>, <result>, <arg_1>, ..., <arg_n>
+
+The invoke indirect operation functions identically to the invoke operation
+except that it calls the handler in <handler-reg>.
+
+It is a runtime error if <handler-reg> does not contain a handler value.
+
+### Fetch
+
+    fetch <dst-register>, <definition>
+
+The fetch operation copies the value of <definition> into <dst-register>. The
+<definition> may be a variable, constant or handler. In the case of a handler,
+a handler value is created.
+
+It is a runtime error if the type of the value of <definition> does not conform
+to the type of <dst-register>.
+
+### Store
+
+    store <src-register>, <definition>
+
+The store operation copies the contents of <src-register> into <definition>. The
+<definition> must be a module level variable.
+
+It is a runtime error if the type of the value in <src-register> does not conform
+to the type of <definition>.
+
+### Assign List
+
+    assign_list <dst-reg>, <element1-reg>, ..., <elementn-reg>
+
+The assign_array operation builds a list value from <element1-reg> up to
+<elementn-reg>.
+
+It is a runtime error if the type of <dst-reg> does not conform to list.
+
+### Assign Array
+
+    assign_array <dst-reg>, <key1-reg>, <value1-reg>, ..., <keyn-reg>, <valuen-reg>
+
+The assign_array operation builds an array value from each key value pair
+<key1-reg>, <value1-reg> up to <keyn-reg>, <valuen-reg>.
+
+It is a runtime error if the type of <dst-reg> does not conform to array.
+
+### Reset
+
+    reset <reg>
+
+The reset operation performs default initialization of <reg>. If the type of
+<reg> has no default value, it reverts to unassigned.

--- a/docs/guides/LiveCode Builder Bytecode Reference.md
+++ b/docs/guides/LiveCode Builder Bytecode Reference.md
@@ -87,11 +87,11 @@ of return.
 
 ### Invoke
 
-    invoke <handler>, <result>, <arg_1>, ..., <arg_n>
+    invoke <handler>, <result-reg>, <arg1-reg>, ..., <argn-reg>
 
 The invoke operation creates a new frame copying values from the argument registers
 for any in or inout parameters. It then starts executing the bytecode attached
-to <handler>.
+to <handler>, a definition. The return value is placed into the register <result-reg>.
 
 If is a runtime error if the number of arguments provided is different from the
 signature of <handler>
@@ -101,7 +101,7 @@ does not conform to the type of the parameter required by the signature.
 
 ### Invoke Indirect
 
-    invoke <handler-reg>, <result>, <arg_1>, ..., <arg_n>
+    invoke <handler-reg>, <result-reg>, <arg1-reg>, ..., <argn-reg>
 
 The invoke indirect operation functions identically to the invoke operation
 except that it calls the handler in <handler-reg>.
@@ -133,7 +133,7 @@ to the type of <definition>.
 
     assign_list <dst-reg>, <element1-reg>, ..., <elementn-reg>
 
-The assign_array operation builds a list value from <element1-reg> up to
+The assign_list operation builds a list value from <element1-reg> up to
 <elementn-reg>.
 
 It is a runtime error if the type of <dst-reg> does not conform to list.

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -528,6 +528,7 @@ environment.
       | SetStatement
       | GetStatement
       | CallStatement
+      | BytecodeStatement
 
 There are a number of built-in statements which define control flow,
 variables, and basic variable transfer. The remaining syntax for
@@ -727,6 +728,40 @@ result** expression.
 
 > **Note:** All handlers return a value, even if it is nothing. This
 > means that calling a handler will always change **the result**.
+
+### Bytecode Statements
+
+    BytecodeStatement
+      : 'bytecode' SEPARATOR
+            { BytecodeOperation }
+        'end'
+
+    BytecodeOperation
+      : <Label: Identifier> ':'
+      | 'register' <Name: Identifier> [ 'as' <Type: Type> ]
+      | <Opcode: Identifier> { BytecodeArgument , ',' }
+
+    BytecodeArgument
+      : ConstantValueExpression
+      | Identifier
+
+The bytecode statement allows bytecode to be written directly for the LiveCode
+Builder Virtual Machine.
+
+Bytecode operation arguments can either be a constant expression, the name of a
+definition in current scope, the name of a register, or the name of a label in
+the current bytecode block. The exact opcodes and allowed arguments are defined
+in the LiveCode Builder Bytecode Reference.
+
+Labels are local to the current bytecode block, and can be used as the target
+of one of the jump instructions.
+
+Register definitions define a named register which is local to the current
+bytecode block. Registers are the same as handler-local variables except
+that they do not undergo default initialization.
+
+> **Note:** Bytecode blocks are not intended for general use and the actual
+> available operations are subject to change.
 
 ## Expressions
 

--- a/docs/lcb/notes/17821.md
+++ b/docs/lcb/notes/17821.md
@@ -1,0 +1,15 @@
+# LiveCode Builder Language
+## Bytecode Blocks
+
+* bytecode can now be directly written in handlers using a bytecode block:
+
+    bytecode
+      register tTemp
+      assign_constant tTemp, 1
+    end bytecode
+
+* for more details on what bytecode operations can be used see the LiveCode
+  Builder Bytecode Reference
+
+* bytecode blocks are not for general use and the current set of bytecode
+  operations are subject to change

--- a/docs/lcb/notes/17821.md
+++ b/docs/lcb/notes/17821.md
@@ -3,10 +3,10 @@
 
 * bytecode can now be directly written in handlers using a bytecode block:
 
-    bytecode
-      register tTemp
-      assign_constant tTemp, 1
-    end bytecode
+      bytecode
+         register tTemp
+         assign_constant tTemp, 1
+      end bytecode
 
 * for more details on what bytecode operations can be used see the LiveCode
   Builder Bytecode Reference

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -247,6 +247,32 @@ bool MCScriptCallHandlerOfInstanceIfFound(MCScriptInstanceRef instance, MCNameRe
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum MCScriptBytecodeParameterType
+{
+    // Invalid index was passed to describe
+    kMCScriptBytecodeParameterTypeUnknown,
+    // The parameter should be a label index
+    kMCScriptBytecodeParameterTypeLabel,
+    // The parameter should be a register
+    kMCScriptBytecodeParameterTypeRegister,
+    // The parameter should be a constant pool index
+    kMCScriptBytecodeParameterTypeConstant,
+    // The parameter should be a fetchable definition (variable, constant, handler)
+    kMCScriptBytecodeParameterTypeDefinition,
+    // The parameter should be a variable definition
+    kMCScriptBytecodeParameterTypeVariable,
+    // The parameter should be a handler definition
+    kMCScriptBytecodeParameterTypeHandler,
+};
+
+bool MCScriptCopyBytecodeNames(MCProperListRef& r_proper_list);
+bool MCScriptLookupBytecode(const char *opname, uindex_t& r_opcode);
+const char *MCScriptDescribeBytecode(uindex_t opcode);
+MCScriptBytecodeParameterType MCScriptDescribeBytecodeParameter(uindex_t opcode, uindex_t index);
+bool MCScriptCheckBytecodeParameterCount(uindex_t opcode, uindex_t proposed_count);
+
+////////////////////////////////////////////////////////////////////////////////
+
 typedef struct MCScriptModuleBuilder *MCScriptModuleBuilderRef;
 
 enum MCScriptModuleKind
@@ -313,7 +339,7 @@ void MCScriptBeginRecordTypeInModule(MCScriptModuleBuilderRef builder, uindex_t 
 void MCScriptContinueRecordTypeInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type);
 void MCScriptEndRecordTypeInModule(MCScriptModuleBuilderRef builder, uindex_t& r_new_type);
 
-void MCScriptAddDefinitionToModule(MCScriptModuleBuilderRef builder, uindex_t& r_index);
+void MCScriptAddDefinitionToModule(MCScriptModuleBuilderRef builder, MCScriptDefinitionKind kind, uindex_t& r_index);
 
 void MCScriptAddTypeToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index);
 void MCScriptAddConstantToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t const_idx, uindex_t index);
@@ -345,30 +371,12 @@ void MCScriptAddEventToModule(MCScriptModuleBuilderRef builder, MCNameRef name, 
 
 void MCScriptDeferLabelForBytecodeInModule(MCScriptModuleBuilderRef builder, uindex_t& r_label);
 void MCScriptResolveLabelForBytecodeInModule(MCScriptModuleBuilderRef builder, uindex_t label);
-void MCScriptEmitJumpInModule(MCScriptModuleBuilderRef builder, uindex_t target_label);
-void MCScriptEmitJumpIfUndefinedInModule(MCScriptModuleBuilderRef builder, uindex_t value_reg, uindex_t target_label);
-void MCScriptEmitJumpIfDefinedInModule(MCScriptModuleBuilderRef builder, uindex_t value_reg, uindex_t target_label);
-void MCScriptEmitJumpIfFalseInModule(MCScriptModuleBuilderRef builder, uindex_t value_reg, uindex_t target_label);
-void MCScriptEmitJumpIfTrueInModule(MCScriptModuleBuilderRef builder, uindex_t value_reg, uindex_t target_label);
-void MCScriptEmitAssignConstantInModule(MCScriptModuleBuilderRef builder, uindex_t dst_reg, uindex_t const_idx);
-void MCScriptEmitAssignInModule(MCScriptModuleBuilderRef builder, uindex_t dst_reg, uindex_t src_reg);
-void MCScriptEmitBeginAssignListInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
-void MCScriptEmitContinueAssignListInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
-void MCScriptEmitEndAssignListInModule(MCScriptModuleBuilderRef builder);
-void MCScriptEmitBeginAssignArrayInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
-void MCScriptEmitContinueAssignArrayInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
-void MCScriptEmitEndAssignArrayInModule(MCScriptModuleBuilderRef builder);
-void MCScriptEmitReturnInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
-void MCScriptEmitReturnUndefinedInModule(MCScriptModuleBuilderRef builder);
-void MCScriptBeginInvokeInModule(MCScriptModuleBuilderRef builder, uindex_t handler_index, uindex_t result_reg);
-void MCScriptBeginInvokeIndirectInModule(MCScriptModuleBuilderRef builder, uindex_t handler_reg, uindex_t result_reg);
-void MCScriptContinueInvokeInModule(MCScriptModuleBuilderRef builder, uindex_t arg_reg);
-void MCScriptEndInvokeInModule(MCScriptModuleBuilderRef builder);
-void MCScriptEmitFetchInModule(MCScriptModuleBuilderRef builder, uindex_t dst_reg, uindex_t index, uindex_t level);
-void MCScriptEmitStoreInModule(MCScriptModuleBuilderRef builder, uindex_t src_reg, uindex_t index, uindex_t level);
-void MCScriptEmitResetInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
 
-void MCScriptEmitPositionInModule(MCScriptModuleBuilderRef builder, MCNameRef file, uindex_t line);
+void MCScriptEmitBytecodeInModule(MCScriptModuleBuilderRef builder, uindex_t opcode, ...);
+void MCScriptEmitBytecodeInModuleV(MCScriptModuleBuilderRef builder, uindex_t opcode, va_list args);
+void MCScriptEmitBytecodeInModuleA(MCScriptModuleBuilderRef builder, uindex_t opcode, uindex_t *arguments, uindex_t argument_count);
+
+void MCScriptEmitPositionForBytecodeInModule(MCScriptModuleBuilderRef builder, MCNameRef file, uindex_t line);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -2014,8 +2014,18 @@ static bool MCScriptPerformMultiInvoke(MCScriptFrame*& x_frame, byte_t*& x_next_
         return false;
     
     for(uindex_t i = 0; i < p_arity - 1; i++)
-        if (!MCProperListPushElementOntoBack(*t_args, MCScriptFetchFromRegisterInFrame(x_frame, p_arguments[i + 1])))
+    {
+        MCValueRef t_value;
+        t_value = MCScriptFetchFromRegisterInFrame(x_frame, p_arguments[i + 1]);
+        
+        if (t_value == nil)
+        {
+            t_value = kMCNull;
+        }
+        
+        if (!MCProperListPushElementOntoBack(*t_args, t_value))
             return false;
+    }
         
     return MCScriptThrowUnableToResolveMultiInvoke(p_instance -> module, p_handler, *t_args);
 }

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -90,44 +90,44 @@ bool MCScriptInitialize(void)
         
         uindex_t t_def_index, t_type_index;
             
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCAnyTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("any"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_null_type_index;
-        MCScriptAddDefinitionToModule(t_builder, t_null_type_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_null_type_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCNullTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("undefined"), t_type_index, t_null_type_index);
         MCScriptAddExportToModule(t_builder, t_null_type_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCBooleanTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("boolean"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCNumberTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("number"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_string_type_index;
-        MCScriptAddDefinitionToModule(t_builder, t_string_type_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_string_type_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCStringTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("string"), t_type_index, t_string_type_index);
         MCScriptAddExportToModule(t_builder, t_string_type_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCDataTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("data"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCArrayTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("array"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCProperListTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("list"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
@@ -135,34 +135,34 @@ bool MCScriptInitialize(void)
         ////
         
         uindex_t t_bool_type_index;
-        MCScriptAddDefinitionToModule(t_builder, t_bool_type_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_bool_type_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignBoolTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("bool"), t_type_index, t_bool_type_index);
         MCScriptAddExportToModule(t_builder, t_bool_type_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignIntTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("int"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_uint_type_index;
-        MCScriptAddDefinitionToModule(t_builder, t_uint_type_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_uint_type_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignUIntTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("uint"), t_type_index, t_uint_type_index);
         MCScriptAddExportToModule(t_builder, t_uint_type_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignFloatTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("float"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_double_type_index;
-        MCScriptAddDefinitionToModule(t_builder, t_double_type_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_double_type_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignDoubleTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("double"), t_type_index, t_double_type_index);
         MCScriptAddExportToModule(t_builder, t_double_type_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
         MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignPointerTypeInfo"), t_type_index);
         MCScriptAddTypeToModule(t_builder, MCNAME("pointer"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
@@ -176,14 +176,14 @@ bool MCScriptInitialize(void)
         MCScriptAddDefinedTypeToModule(t_builder, t_null_type_index, t_null_type_def);
         MCScriptAddDefinedTypeToModule(t_builder, t_string_type_index, t_string_type_def);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
         MCScriptBeginHandlerTypeInModule(t_builder, t_bool_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeInOut, MCNAME("count"), t_uint_type_def);
         MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
         MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatCounted"), t_type_index, MCSTR("MCScriptBuiltinRepeatCounted"), t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
         MCScriptBeginHandlerTypeInModule(t_builder, t_bool_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("limit"), t_double_type_def);
@@ -191,7 +191,7 @@ bool MCScriptInitialize(void)
         MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatUpToCondition"), t_type_index, MCSTR("MCScriptBuiltinRepeatUpToCondition"), t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
         MCScriptBeginHandlerTypeInModule(t_builder, t_double_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("step"), t_double_type_def);
@@ -199,7 +199,7 @@ bool MCScriptInitialize(void)
         MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatUpToIterate"), t_type_index, MCSTR("MCScriptBuiltinRepeatUpToIterate"), t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
         MCScriptBeginHandlerTypeInModule(t_builder, t_bool_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("limit"), t_double_type_def);
@@ -207,7 +207,7 @@ bool MCScriptInitialize(void)
         MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatDownToCondition"), t_type_index, MCSTR("MCScriptBuiltinRepeatDownToCondition"), t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
         MCScriptBeginHandlerTypeInModule(t_builder, t_double_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("step"), t_double_type_def);
@@ -215,7 +215,7 @@ bool MCScriptInitialize(void)
         MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatDownToIterate"), t_type_index, MCSTR("MCScriptBuiltinRepeatDownToIterate"), t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
-        MCScriptAddDefinitionToModule(t_builder, t_def_index);
+        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
         MCScriptBeginHandlerTypeInModule(t_builder, t_null_type_def);
         MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("reason"), t_string_type_def);
         MCScriptEndHandlerTypeInModule(t_builder, t_type_index);

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -474,6 +474,7 @@ enum MCScriptBytecodeOp
 	// Unconditional jump:
 	//  X: jump <Y-X>
 	// Location is encoded as relative position to jump instruction.
+    //
 	kMCScriptBytecodeOpJump,
 	
 	// Conditional jumps:
@@ -490,12 +491,14 @@ enum MCScriptBytecodeOp
 	//   assign-constant <dst>, <index>
 	// Dst is a register and index is a constant pool index. The value in dst is
     // freed, and the constant value at the specified index is assigned to it.
+    //
 	kMCScriptBytecodeOpAssignConstant,
     
 	// Register assignment:
 	//   assign <dst>, <src>
 	// Dst and Src are registers. The value in dst is freed, and src copied
 	// into it.
+    //
 	kMCScriptBytecodeOpAssign,
     
 	// Return control to caller with value:
@@ -540,7 +543,6 @@ enum MCScriptBytecodeOp
     // The <level> indicates where the definition should be looked up with 0 being
     // the enclosing scope, 1 the next scope and so on.
     //
-    //
 	kMCScriptBytecodeOpFetch,
     
 	// Store:
@@ -558,13 +560,15 @@ enum MCScriptBytecodeOp
     // Dst is a register. The remaining arguments are registers and are used to
     // build a list. (This will be replaced by an invoke when variadic bindings are
     // implemented).
+    //
     kMCScriptBytecodeOpAssignList,
 
 	// Array creation assignment.
 	//   assign-array <dst>, <key_1>, <value_1>, ..., <key_n>, <value_n>
 	// Dst is a register.  The remaining arguments are registers and
 	// are used, pair-wise, to build an array. (This will be replaced by an invoke
-	// when variadic bindings are implemented).
+    // when variadic bindings are implemented).
+    //
 	kMCScriptBytecodeOpAssignArray,
     
     // Slot resetting

--- a/tests/lcb/compiler/bytecode.lcb
+++ b/tests/lcb/compiler/bytecode.lcb
@@ -1,0 +1,308 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.compiler.bytecode.tests
+
+public handler TestJump()
+   variable tTest as Boolean
+   put false into tTest
+   bytecode
+         jump lAfterAssign
+         assign_constant tTest, true
+      lAfterAssign:
+   end bytecode
+   test "jump forward label" when tTest is false
+end handler
+
+public handler TestJumpIfFalse()
+   variable tTest as Boolean
+   put false into tTest
+   bytecode
+         register regTemp
+         assign_constant regTemp, false
+         jump_if_false regTemp, lAfterAssign
+         assign_constant tTest, true
+      lAfterAssign:
+   end bytecode
+   test "jumpiffalse forward label" when tTest is false
+end handler
+
+public handler TestJumpIfTrue()
+   variable tTest as Boolean
+   put false into tTest
+   bytecode
+         register regTemp
+         assign_constant regTemp, true
+         jump_if_true regTemp, lAfterAssign
+         assign_constant tTest, true
+      lAfterAssign:
+   end bytecode
+   test "jumpiffalse forward label" when tTest is false
+end handler
+
+public handler TestAssignConstant()
+   variable tTest
+   put "Hello World!" into tTest
+
+   bytecode
+         assign_constant tTest, nothing
+   end bytecode
+   test "assignconstant nothing literal" when tTest is nothing
+
+   bytecode
+         assign_constant tTest, false
+   end bytecode
+   test "assignconstant boolean literal" when tTest is false
+
+   bytecode
+         assign_constant tTest, 0
+   end bytecode
+   test "assignconstant int literal" when tTest is 0
+
+   bytecode
+         assign_constant tTest, 0.125
+   end bytecode
+   test "assignconstant float literal" when tTest is 0.125
+
+   bytecode
+         assign_constant tTest, "Foo"
+   end bytecode
+   test "assignconstant string literal" when tTest is "Foo"
+end handler
+
+private handler DoTestAssignParameter(in pSource)
+   bytecode
+         register regTemp
+         assign_constant regTemp, true
+         assign pSource, regTemp
+   end bytecode
+   test "assign temp to param" when pSource is true
+
+   variable tTarget
+   put true into tTarget
+   put false into pSource
+   bytecode
+         register regTemp
+         assign regTemp, pSource
+         assign tTarget, regTemp
+   end bytecode
+   test "assign param to temp" when tTarget is false
+end handler
+
+public handler TestAssign()
+   variable tTarget
+
+   put false into tTarget
+   bytecode
+         register regTemp
+         assign_constant regTemp, true
+         assign tTarget, regTemp
+   end bytecode
+   test "assign temp to local" when tTarget is true
+
+   variable tSource
+   put true into tSource
+   put false into tTarget
+   bytecode
+         register regTemp
+         assign regTemp, tSource
+         assign tTarget, regTemp
+   end bytecode
+   test "assign local to temp" when tTarget is true
+
+   DoTestAssignParameter(false)
+end handler
+
+private handler DoTestReturnNothing()
+   bytecode
+         return
+   end bytecode
+   return true
+end handler
+
+private handler DoTestReturnValue(in pValue)
+   bytecode
+         return pValue
+   end bytecode
+   return true
+end handler
+
+public handler TestReturn()
+   DoTestReturnNothing()
+   test "return nothing" when the result is nothing
+
+   DoTestReturnValue(100)
+   test "return value" when the result is 100
+end handler
+
+private handler DoTestInvoke(in pInput, out rOutput)
+   put pInput into rOutput
+   return true
+end handler
+
+public handler TestInvoke()
+   variable tOutput
+   variable tResult
+   put nothing into tOutput
+   put nothing into tResult
+   bytecode
+         register regTemp
+         assign_constant regTemp, 100
+         invoke DoTestInvoke, tResult, regTemp, tOutput
+   end bytecode
+   test "invoke in and out params" when tOutput is 100
+   test "invoke result" when tResult is true
+end handler
+
+public handler TestInvokeIndirect()
+   variable tOutput
+   variable tResult
+   put nothing into tOutput
+   put nothing into tResult
+   bytecode
+         register regTemp
+         register regHandler
+         fetch regHandler, DoTestInvoke
+         assign_constant regTemp, 100
+         invoke_indirect regHandler, tResult, regTemp, tOutput
+   end bytecode
+   test "invokeindirect in and out params" when tOutput is 100
+   test "invokeindirect result" when tResult is true
+end handler
+
+constant kConstantNothing is nothing
+constant kConstantBoolean is false
+constant kConstantInteger is 0
+constant kConstantFloat is 0.125
+constant kConstantString is "Foo"
+variable sModuleVariable
+
+handler type Return100Type()
+private handler Return100()
+   return 100
+end handler
+
+public handler TestFetch()
+   variable tTest
+
+   put "Hello World!" into tTest
+   bytecode
+         fetch tTest, kConstantNothing
+   end bytecode
+   test "fetch nothing literal" when tTest is kConstantNothing
+
+   put "Hello World!" into tTest
+   bytecode
+         fetch tTest, kConstantBoolean
+   end bytecode
+   test "fetch boolean literal" when tTest is kConstantBoolean
+
+   put "Hello World!" into tTest
+   bytecode
+         fetch tTest, kConstantInteger
+   end bytecode
+   test "fetch int literal" when tTest is kConstantInteger
+
+   put "Hello World!" into tTest
+   bytecode
+         fetch tTest, kConstantFloat
+   end bytecode
+   test "fetch float literal" when tTest is kConstantFloat
+
+   put "Hello World!" into tTest
+   bytecode
+         fetch tTest, kConstantString
+   end bytecode
+   test "fetch string literal" when tTest is kConstantString
+
+   put "Hello World!" into tTest
+   put 100 into sModuleVariable
+   bytecode
+         fetch tTest, sModuleVariable
+   end bytecode
+   test "fetch variable" when tTest is 100
+
+   put "Hello World!" into tTest
+   bytecode
+         fetch tTest, Return100
+   end bytecode
+   variable tTestHandler as Return100Type
+   put tTest into tTestHandler
+   test "fetch handler" when tTestHandler() is 100
+end handler
+
+public handler TestStore()
+   put nothing into sModuleVariable
+   bytecode
+         register regTemp
+         assign_constant regTemp, 100
+         store regTemp, sModuleVariable
+   end bytecode
+   test "store variable" when sModuleVariable is 100
+end handler
+
+public handler TestAssignList()
+   variable tTest
+
+   variable tElement1
+   variable tElement2
+   put 1 into tElement1
+   put 2 into tElement2
+   put nothing into tTest
+   bytecode
+         assign_list tTest, tElement1, tElement2
+   end bytecode
+   test "assignlist" when tTest is [1, 2]
+end handler
+
+public handler TestAssignArray()
+   variable tTest
+
+   variable tElement1
+   variable tElement2
+   variable tKey1
+   variable tKey2
+   put 1 into tElement1
+   put 2 into tElement2
+   put "foo" into tKey1
+   put "bar" into tKey2
+   put nothing into tTest
+   bytecode
+         assign_array tTest, tKey1, tElement1, tKey2, tElement2
+   end bytecode
+   test "assignarray" when the number of elements in tTest is 2 and \
+                           tTest["foo"] is 1 and tTest["bar"] is 2
+end handler
+
+public handler TestReset()
+   variable tTest as Boolean
+   put true into tTest
+   bytecode
+         reset tTest
+   end bytecode
+   test "reset handler variable" when tTest is false
+
+   put true into tTest
+   bytecode
+         register regTemp as Boolean
+         reset regTemp
+         assign tTest, regTemp
+   end bytecode
+   test "reset register variable" when tTest is false
+end handler
+
+end module

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1456,21 +1456,27 @@ void EmitCurrentRepeatLabels(long& r_next, long& r_exit)
 
 void EmitUndefinedConstant(long *idx)
 {
-    MCScriptAddValueToModule(s_builder, kMCNull, (uindex_t&)*idx);
+    uindex_t t_index;
+    MCScriptAddValueToModule(s_builder, kMCNull, t_index);
+    *idx = t_index;
     
     Debug_Emit("UndefinedConstant(-> %ld)", *idx);
 }
 
 void EmitTrueConstant(long *idx)
 {
-    MCScriptAddValueToModule(s_builder, kMCTrue, (uindex_t&)*idx);
+    uindex_t t_index;
+    MCScriptAddValueToModule(s_builder, kMCTrue, t_index);
+    *idx = t_index;
     
     Debug_Emit("TrueConstant(-> %ld)", *idx);
 }
 
 void EmitFalseConstant(long *idx)
 {
-    MCScriptAddValueToModule(s_builder, kMCFalse, (uindex_t&)*idx);
+    uindex_t t_index;
+    MCScriptAddValueToModule(s_builder, kMCFalse, t_index);
+    *idx = t_index;
     
     Debug_Emit("FalseConstant(%ld)", *idx);
 }
@@ -1478,8 +1484,10 @@ void EmitFalseConstant(long *idx)
 void EmitIntegerConstant(long value, long *idx)
 {
     MCAutoNumberRef t_number;
+    uindex_t t_index;
     MCNumberCreateWithInteger(value, &t_number);
-    MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
+    MCScriptAddValueToModule(s_builder, *t_number, t_index);
+    *idx = t_index;
     
     Debug_Emit("IntegerConstant(%ld -> %ld)", value, *idx);
 }
@@ -1487,8 +1495,10 @@ void EmitIntegerConstant(long value, long *idx)
 void EmitUnsignedIntegerConstant(unsigned long value, long *idx)
 {
     MCAutoNumberRef t_number;
+    uindex_t t_index;
     MCNumberCreateWithUnsignedInteger(value, &t_number);
-    MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
+    MCScriptAddValueToModule(s_builder, *t_number, t_index);
+    *idx = t_index;
     
     Debug_Emit("UnsignedIntegerConstant(%lu -> %ld)", value, *idx);
 }
@@ -1496,8 +1506,10 @@ void EmitUnsignedIntegerConstant(unsigned long value, long *idx)
 void EmitRealConstant(long value, long *idx)
 {
     MCAutoNumberRef t_number;
+    uindex_t t_index;
     MCNumberCreateWithReal(*(double *)value, &t_number);
-    MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
+    MCScriptAddValueToModule(s_builder, *t_number, t_index);
+    *idx = t_index;
     
     Debug_Emit("RealConstant(%lf -> %ld)", *(double *)value, *idx);
 }
@@ -1505,8 +1517,10 @@ void EmitRealConstant(long value, long *idx)
 void EmitStringConstant(long value, long *idx)
 {
     MCAutoStringRef t_string;
+    uindex_t t_index;
     MCStringCreateWithBytes((const byte_t *)value, strlen((const char *)value), kMCStringEncodingUTF8, false, &t_string);
-    MCScriptAddValueToModule(s_builder, *t_string, (uindex_t&)*idx);
+    MCScriptAddValueToModule(s_builder, *t_string, t_index);
+    *idx = t_index;
     
     Debug_Emit("StringConstant(\"%s\" -> %ld)", (const char *)value, *idx);
 }
@@ -1520,7 +1534,7 @@ void EmitBeginListConstant(void)
 
 void EmitContinueListConstant(long idx)
 {
-    MCScriptContinueListValueInModule(s_builder, idx);
+    MCScriptContinueListValueInModule(s_builder, (uindex_t)idx);
     
     Debug_Emit("ContinueListConstant(%ld)", idx);
 }
@@ -1541,14 +1555,16 @@ void EmitBeginArrayConstant(void)
 
 void EmitContinueArrayConstant(long key_idx, long value_idx)
 {
-    MCScriptContinueArrayValueInModule(s_builder, key_idx, value_idx);
+    MCScriptContinueArrayValueInModule(s_builder, (uindex_t)key_idx, (uindex_t)value_idx);
     
     Debug_Emit("ContinueArrayConstant(%ld, %ld)", key_idx, value_idx);
 }
 
 void EmitEndArrayConstant(long *idx)
 {
-    MCScriptEndArrayValueInModule(s_builder, (uindex_t&)*idx);
+    uindex_t t_index;
+    MCScriptEndArrayValueInModule(s_builder, t_index);
+    *idx = t_index;
     
     Debug_Emit("EndArrayConstant(-> %ld)", *idx);
 }

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -50,7 +50,7 @@ extern "C" void EmitImportedVariable(long module_index, NameRef name, long type_
 extern "C" void EmitImportedHandler(long module_index, NameRef name, long type_index, long& r_index);
 extern "C" void EmitImportedSyntax(long p_module_index, NameRef p_name, long p_type_index, long& r_index);
 extern "C" void EmitExportedDefinition(long index);
-extern "C" void EmitDefinitionIndex(long& r_index);
+extern "C" void EmitDefinitionIndex(const char *type, long& r_index);
 extern "C" void EmitTypeDefinition(long index, PositionRef position, NameRef name, long type_index);
 extern "C" void EmitConstantDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_const_index);
 extern "C" void EmitVariableDefinition(long index, PositionRef position, NameRef name, long type_index);
@@ -118,6 +118,9 @@ extern "C" void EmitDeferLabel(long& r_label);
 extern "C" void EmitResolveLabel(long label);
 extern "C" void EmitCreateRegister(long& r_regindex);
 extern "C" void EmitDestroyRegister(long regindex);
+extern "C" void EmitBeginOpcode(long opcode);
+extern "C" void EmitContinueOpcode(long argument);
+extern "C" void EmitEndOpcode(void);
 extern "C" void EmitJump(long label);
 extern "C" void EmitJumpIfTrue(long reg, long label);
 extern "C" void EmitJumpIfFalse(long reg, long label);
@@ -176,6 +179,12 @@ extern "C" void DependStart(void);
 extern "C" void DependFinish(void);
 extern "C" void DependDefineMapping(NameRef module_name, const char *source_file);
 extern "C" void DependDefineDependency(NameRef module_name, NameRef dependency_name);
+
+extern "C" int BytecodeEnumerate(long index, long *r_name);
+extern "C" int BytecodeLookup(long name, long *r_opcode);
+extern "C" void BytecodeDescribe(long opcode, long *r_name);
+extern "C" int BytecodeIsValidArgumentCount(long opcode, long count);
+extern "C" void BytecodeDescribeParameter(long opcode, long index, long *r_type);
 
 //////////
 
@@ -761,13 +770,40 @@ void EmitExportedDefinition(long p_index)
     Debug_Emit("ExportedDefinition(%ld)", p_index);
 }
 
-void EmitDefinitionIndex(long& r_index)
+void EmitDefinitionIndex(const char *p_type, long& r_index)
 {
+    static struct { const char *name; MCScriptDefinitionKind kind; } s_type_map[] =
+    {
+        { "external", kMCScriptDefinitionKindExternal },
+        { "type", kMCScriptDefinitionKindType },
+        { "constant", kMCScriptDefinitionKindConstant },
+        { "variable", kMCScriptDefinitionKindVariable },
+        { "handler", kMCScriptDefinitionKindHandler },
+        { "foreignhandler", kMCScriptDefinitionKindForeignHandler },
+        { "property", kMCScriptDefinitionKindProperty },
+        { "event", kMCScriptDefinitionKindEvent },
+        { "syntax", kMCScriptDefinitionKindSyntax },
+        { "definitiongroup", kMCScriptDefinitionKindDefinitionGroup },
+    };
+    
+    int t_kind_index = -1;
+    for(int i = 0; i < (int)(sizeof(s_type_map) / sizeof(s_type_map[0])); i++)
+    {
+        if (strcmp(s_type_map[i].name, p_type) == 0)
+        {
+            t_kind_index = i;
+            break;
+        }
+    }
+    
+    if (t_kind_index == -1)
+        Fatal_InternalInconsistency("unknown definition kind");
+    
     uindex_t t_index;
-    MCScriptAddDefinitionToModule(s_builder, t_index);
+    MCScriptAddDefinitionToModule(s_builder, s_type_map[t_kind_index] . kind, t_index);
     r_index = t_index;
 
-    Debug_Emit("DefinitionIndex(-> %u)", t_index);
+    Debug_Emit("DefinitionIndex(%s -> %u)", p_type, t_index);
 }
 
 void EmitTypeDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
@@ -1384,29 +1420,6 @@ void EmitDestroyRegister(long regindex)
 
 //////////
 
-void EmitJump(long label)
-{
-    MCScriptEmitJumpInModule(s_builder, label);
-
-    Debug_Emit("Jump(%ld)", label);
-}
-
-void EmitJumpIfTrue(long reg, long label)
-{
-    MCScriptEmitJumpIfTrueInModule(s_builder, reg, label);
-
-    Debug_Emit("JumpIfTrue(%ld, %ld)", label);
-}
-
-void EmitJumpIfFalse(long reg, long label)
-{
-    MCScriptEmitJumpIfFalseInModule(s_builder, reg, label);
-
-    Debug_Emit("JumpIfFalse(%ld, %ld)", reg, label);
-}
-
-//////////
-
 struct RepeatLabels
 {
     RepeatLabels *next;
@@ -1441,55 +1454,24 @@ void EmitCurrentRepeatLabels(long& r_next, long& r_exit)
 
 //////////
 
-void EmitBeginInvoke(long index, long contextreg, long resultreg)
-{
-    MCScriptBeginInvokeInModule(s_builder, index, resultreg);
-
-    Debug_Emit("BeginExecuteInvoke(%ld, %ld, %ld)",
-               index, contextreg, resultreg);
-}
-
-void EmitBeginIndirectInvoke(long handlerreg, long contextreg, long resultreg)
-{
-    MCScriptBeginInvokeIndirectInModule(s_builder, handlerreg, resultreg);
-    Debug_Emit("BeginExecuteIndirectInvoke(%ld, %ld, %ld)",
-               handlerreg, contextreg, resultreg);
-}
-
-void EmitContinueInvoke(long reg)
-{
-    MCScriptContinueInvokeInModule(s_builder, reg);
-
-    Debug_Emit("ContinueInvoke(%ld)", reg);
-}
-
-void EmitEndInvoke(void)
-{
-    MCScriptEndInvokeInModule(s_builder);
-
-    Debug_Emit("EndInvoke()", 0);
-}
-
-//////////
-
 void EmitUndefinedConstant(long *idx)
 {
     MCScriptAddValueToModule(s_builder, kMCNull, (uindex_t&)*idx);
-
+    
     Debug_Emit("UndefinedConstant(-> %ld)", *idx);
 }
 
 void EmitTrueConstant(long *idx)
 {
     MCScriptAddValueToModule(s_builder, kMCTrue, (uindex_t&)*idx);
-
+    
     Debug_Emit("TrueConstant(-> %ld)", *idx);
 }
 
 void EmitFalseConstant(long *idx)
 {
     MCScriptAddValueToModule(s_builder, kMCFalse, (uindex_t&)*idx);
-
+    
     Debug_Emit("FalseConstant(%ld)", *idx);
 }
 
@@ -1498,7 +1480,7 @@ void EmitIntegerConstant(long value, long *idx)
     MCAutoNumberRef t_number;
     MCNumberCreateWithInteger(value, &t_number);
     MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
-
+    
     Debug_Emit("IntegerConstant(%ld -> %ld)", value, *idx);
 }
 
@@ -1507,7 +1489,7 @@ void EmitUnsignedIntegerConstant(unsigned long value, long *idx)
     MCAutoNumberRef t_number;
     MCNumberCreateWithUnsignedInteger(value, &t_number);
     MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
-
+    
     Debug_Emit("UnsignedIntegerConstant(%lu -> %ld)", value, *idx);
 }
 
@@ -1516,7 +1498,7 @@ void EmitRealConstant(long value, long *idx)
     MCAutoNumberRef t_number;
     MCNumberCreateWithReal(*(double *)value, &t_number);
     MCScriptAddValueToModule(s_builder, *t_number, (uindex_t&)*idx);
-
+    
     Debug_Emit("RealConstant(%lf -> %ld)", *(double *)value, *idx);
 }
 
@@ -1525,104 +1507,238 @@ void EmitStringConstant(long value, long *idx)
     MCAutoStringRef t_string;
     MCStringCreateWithBytes((const byte_t *)value, strlen((const char *)value), kMCStringEncodingUTF8, false, &t_string);
     MCScriptAddValueToModule(s_builder, *t_string, (uindex_t&)*idx);
-
+    
     Debug_Emit("StringConstant(\"%s\" -> %ld)", (const char *)value, *idx);
 }
 
 void EmitBeginListConstant(void)
 {
     MCScriptBeginListValueInModule(s_builder);
-
+    
     Debug_Emit("BeginListConstant()", 0);
 }
 
 void EmitContinueListConstant(long idx)
 {
     MCScriptContinueListValueInModule(s_builder, idx);
-
+    
     Debug_Emit("ContinueListConstant(%ld)", idx);
 }
 
 void EmitEndListConstant(long *idx)
 {
     MCScriptEndListValueInModule(s_builder, (uindex_t&)*idx);
-
+    
     Debug_Emit("EndListConstant(-> %ld)", *idx);
 }
 
 void EmitBeginArrayConstant(void)
 {
     MCScriptBeginArrayValueInModule(s_builder);
-
+    
     Debug_Emit("BeginArrayConstant()", 0);
 }
 
 void EmitContinueArrayConstant(long key_idx, long value_idx)
 {
-	MCScriptContinueArrayValueInModule(s_builder, key_idx, value_idx);
-
-	Debug_Emit("ContinueArrayConstant(%ld, %ld)", key_idx, value_idx);
+    MCScriptContinueArrayValueInModule(s_builder, key_idx, value_idx);
+    
+    Debug_Emit("ContinueArrayConstant(%ld, %ld)", key_idx, value_idx);
 }
 
 void EmitEndArrayConstant(long *idx)
 {
     MCScriptEndArrayValueInModule(s_builder, (uindex_t&)*idx);
-
+    
     Debug_Emit("EndArrayConstant(-> %ld)", *idx);
 }
 
+//////////
+
+class __opcode_index
+{
+public:
+    __opcode_index(const char *p_name)
+    {
+        if (!MCScriptLookupBytecode(p_name, m_index))
+        {
+            Fatal_InternalInconsistency(p_name /*"unknown bytecode op"*/);
+            return;
+        }
+    }
+    
+    operator uindex_t (void) const
+    {
+        return m_index;
+    }
+    
+private:
+    uindex_t m_index;
+};
+
+static uindex_t s_opcode;
+static uindex_t *s_arguments = nil;
+static uindex_t s_argument_count = 0;
+
+static void push_argument(long arg)
+{
+    s_arguments = (uindex_t *)Reallocate(s_arguments, sizeof(uindex_t) * (s_argument_count + 1));
+    s_arguments[s_argument_count] = (uindex_t)arg;
+    s_argument_count += 1;
+}
+
+static void log_instruction(void)
+{
+    MCAutoStringRef t_string;
+    MCStringCreateMutable(0, &t_string);
+    MCStringAppendFormat(*t_string, "%s(", MCScriptDescribeBytecode(s_opcode));
+    for(uindex_t i = 0; i < s_argument_count; i++)
+    {
+        if (i != 0)
+            MCStringAppendFormat(*t_string, ", ");
+        MCStringAppendFormat(*t_string, "%ld", s_arguments[i]);
+    }
+    MCStringAppendFormat(*t_string, ")");
+    
+    MCAutoStringRefAsCString t_cstring;
+    t_cstring.Lock(*t_string);
+    Debug_Emit("%s", *t_cstring);
+}
+
+void EmitBeginOpcode(long name)
+{
+    __opcode_index t_opcode((const char *)name);
+    s_opcode = t_opcode;
+}
+
+void EmitContinueOpcode(long param)
+{
+    push_argument(param);
+}
+
+void EmitEndOpcode(void)
+{
+    MCScriptEmitBytecodeInModuleA(s_builder, s_opcode, s_arguments, s_argument_count);
+    
+    log_instruction();
+    
+    s_argument_count = 0;
+}
+
+void EmitJump(long label)
+{
+    static __opcode_index s_opcode_index("jump");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, label, UINDEX_MAX);
+    
+    Debug_Emit("Jump(%ld)", label);
+}
+
+void EmitJumpIfTrue(long reg, long label)
+{
+    static __opcode_index s_opcode_index("jump_if_true");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, label, UINDEX_MAX);
+    
+    Debug_Emit("JumpIfTrue(%ld, %ld)", label);
+}
+
+void EmitJumpIfFalse(long reg, long label)
+{
+    static __opcode_index s_opcode_index("jump_if_false");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, label, UINDEX_MAX);
+    
+    Debug_Emit("JumpIfFalse(%ld, %ld)", reg, label);
+}
+
+void EmitBeginInvoke(long index, long contextreg, long resultreg)
+{
+    static __opcode_index s_opcode_index("invoke");
+    
+    s_opcode = s_opcode_index;
+    push_argument(index);
+    push_argument(resultreg);
+}
+
+void EmitBeginIndirectInvoke(long handlerreg, long contextreg, long resultreg)
+{
+    static __opcode_index s_opcode_index("invoke_indirect");
+    
+    s_opcode = s_opcode_index;
+    push_argument(handlerreg);
+    push_argument(resultreg);
+}
+
+void EmitContinueInvoke(long reg)
+{
+    push_argument(reg);
+}
+
+void EmitEndInvoke(void)
+{
+    MCScriptEmitBytecodeInModuleA(s_builder, s_opcode, s_arguments, s_argument_count);
+
+    log_instruction();
+    
+    s_argument_count = 0;
+}
+
+//////////
+
 void EmitBeginAssignList(long reg)
 {
-    MCScriptEmitBeginAssignListInModule(s_builder, reg);
-
-    Debug_Emit("BeginAssignList(%ld)", reg);
+    static __opcode_index s_opcode_index("assign_list");
+    
+    s_opcode = s_opcode_index;
+    push_argument(reg);
 }
 
 void EmitContinueAssignList(long reg)
 {
-    MCScriptEmitContinueAssignListInModule(s_builder, reg);
-
-    Debug_Emit("ContinueAssignList(%ld)", reg);
+    push_argument(reg);
 }
 
 void EmitEndAssignList(void)
 {
-    MCScriptEmitEndAssignListInModule(s_builder);
-
-    Debug_Emit("EndAssignList()", 0);
+    MCScriptEmitBytecodeInModuleA(s_builder, s_opcode, s_arguments, s_argument_count);
+    
+    log_instruction();
+    
+    s_argument_count = 0;
 }
 
 void EmitBeginAssignArray(long reg)
 {
-    MCScriptEmitBeginAssignArrayInModule(s_builder, reg);
-
-    Debug_Emit("BeginAssignArray(%ld)", reg);
+    static __opcode_index s_opcode_index("assign_array");
+    
+    s_opcode = s_opcode_index;
+    push_argument(reg);
 }
 
 void EmitContinueAssignArray(long reg)
 {
-    MCScriptEmitContinueAssignArrayInModule(s_builder, reg);
-
-    Debug_Emit("ContinueAssignArray(%ld)", reg);
+    push_argument(reg);
 }
 
 void EmitEndAssignArray(void)
 {
-    MCScriptEmitEndAssignArrayInModule(s_builder);
-
-    Debug_Emit("EndAssignArray()", 0);
+    MCScriptEmitBytecodeInModuleA(s_builder, s_opcode, s_arguments, s_argument_count);
+    
+    log_instruction();
+    
+    s_argument_count = 0;
 }
 
 void EmitAssign(long dst, long src)
 {
-    MCScriptEmitAssignInModule(s_builder, dst, src);
-
+    static __opcode_index s_opcode_index("assign");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, dst, src, UINDEX_MAX);
+    
     Debug_Emit("Assign(%ld, %ld)", dst, src);
 }
 
 void EmitAssignConstant(long dst, long idx)
 {
-    MCScriptEmitAssignConstantInModule(s_builder, dst, idx);
+    static __opcode_index s_opcode_index("assign_constant");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, dst, idx, UINDEX_MAX);
 
     Debug_Emit("AssignConstant(%ld, %ld)", dst, idx);
 }
@@ -1631,35 +1747,40 @@ void EmitAssignConstant(long dst, long idx)
 
 void EmitFetch(long reg, long var, long level)
 {
-    MCScriptEmitFetchInModule(s_builder, reg, var, level);
+    static __opcode_index s_opcode_index("fetch");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, var, UINDEX_MAX);
 
-    Debug_Emit("Fetch(%ld, %ld, %ld)", reg, var, level);
+    Debug_Emit("Fetch(%ld, %ld)", reg, var);
 }
 
 void EmitStore(long reg, long var, long level)
 {
-    MCScriptEmitStoreInModule(s_builder, reg, var, level);
+    static __opcode_index s_opcode_index("store");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, var, UINDEX_MAX);
 
-    Debug_Emit("Store(%ld, %ld, %ld)", reg, var, level);
+    Debug_Emit("Store(%ld, %ld)", reg, var);
 }
 
 void EmitReturn(long reg)
 {
-    MCScriptEmitReturnInModule(s_builder, reg);
+    static __opcode_index s_opcode_index("return");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, UINDEX_MAX);
 
     Debug_Emit("Return(%ld)", reg);
 }
 
 void EmitReturnNothing(void)
 {
-    MCScriptEmitReturnUndefinedInModule(s_builder);
+    static __opcode_index s_opcode_index("return");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, UINDEX_MAX);
 
     Debug_Emit("ReturnUndefined()", 0);
 }
 
 void EmitReset(long reg)
 {
-    MCScriptEmitResetInModule(s_builder, reg);
+    static __opcode_index s_opcode_index("reset");
+    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, UINDEX_MAX);
     
     Debug_Emit("Reset(%ld)", reg);
 }
@@ -1750,7 +1871,7 @@ void EmitPosition(PositionRef p_position)
     MakeNameLiteral(t_filename, &t_filename_name);
     long t_line;
     GetRowOfPosition(p_position, &t_line);
-    MCScriptEmitPositionInModule(s_builder, to_mcnameref(t_filename_name), t_line);
+    MCScriptEmitPositionForBytecodeInModule(s_builder, to_mcnameref(t_filename_name), (uindex_t)t_line);
 
     Debug_Emit("Position('%s', %ld)", t_filename, t_line);
 }
@@ -2098,3 +2219,61 @@ void DependDefineDependency(NameRef p_module_name, NameRef p_dependency_name)
     s_depend_deps[s_depend_dep_count - 1] . dependency = p_dependency_name;
 }
 
+//////////
+
+static MCProperListRef s_bytecode_names = nil;
+
+int BytecodeEnumerate(long index, long *r_name)
+{
+    if (s_bytecode_names == nil)
+        MCScriptCopyBytecodeNames(s_bytecode_names);
+    
+    if (index >= MCProperListGetLength(s_bytecode_names))
+    {
+        MCLog("%@", s_bytecode_names);
+        MCValueRelease(s_bytecode_names);
+        s_bytecode_names = nil;
+        return 0;
+    }
+    
+    MCStringRef t_name;
+    t_name = (MCStringRef)MCProperListFetchElementAtIndex(s_bytecode_names, (uindex_t)index);
+    MCLog("%@", t_name);
+    *r_name = (long)nameref_from_mcstringref(t_name);
+    
+    return 1;
+}
+
+int BytecodeLookup(long name, long *r_opcode)
+{
+    uindex_t t_opcode;
+    if (!MCScriptLookupBytecode((const char *)name, t_opcode))
+        return 0;
+    
+    *r_opcode = t_opcode;
+    return 1;
+}
+
+void BytecodeDescribe(long opcode, long *r_name)
+{
+    *r_name = (long)MCScriptDescribeBytecode((uindex_t)opcode);
+}
+
+int BytecodeIsValidArgumentCount(long opcode, long count)
+{
+    return MCScriptCheckBytecodeParameterCount((uindex_t)opcode, (uindex_t)count) ? 1 : 0;
+}
+
+void BytecodeDescribeParameter(long opcode, long index, long *r_type)
+{
+    *r_type = (long)MCScriptDescribeBytecodeParameter((uindex_t)opcode, (uindex_t)index);
+}
+
+//////////
+
+extern "C" void InitializeFoundation(void);
+void InitializeFoundation(void)
+{
+    if (!MCInitialize())
+        Fatal_InternalInconsistency("unable to initialize foundation");
+}

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -212,7 +212,7 @@ static MCNameRef to_mcnameref(NameRef p_name)
      * for example, which generate a name but via a string literal. */
     MCAutoStringRef t_string;
     MCStringCreateWithBytes(reinterpret_cast<const byte_t *>(t_cstring),
-                            strlen(t_cstring), kMCStringEncodingUTF8,
+                            (uindex_t)strlen(t_cstring), kMCStringEncodingUTF8,
                             false, &t_string);
     
     MCNameRef t_name;
@@ -233,7 +233,7 @@ static MCStringRef to_mcstringref(long p_string)
 {
     MCAutoStringRef t_string;
     MCStringCreateWithBytes(reinterpret_cast<const byte_t *>(p_string),
-                            strlen(reinterpret_cast<const char *>(p_string)),
+                            (uindex_t)strlen(reinterpret_cast<const char *>(p_string)),
                             kMCStringEncodingUTF8, false, &t_string);
     MCStringRef t_uniq_string;
     MCValueInter(*t_string, t_uniq_string);
@@ -480,7 +480,7 @@ EmitEndModuleGetByteCodeBuffer (MCAutoByteArray & r_bytecode)
 	                            t_bytecode_len);
 
 	MCAssert (t_bytecode_len <= UINDEX_MAX);
-	r_bytecode.Give ((byte_t *) t_bytecode, t_bytecode_len);
+	r_bytecode.Give ((byte_t *) t_bytecode, (uindex_t)t_bytecode_len);
 
 	return true;
 
@@ -606,7 +606,7 @@ EmitEndModuleGetInterfaceBuffer (const byte_t *p_bytecode,
 		goto error_cleanup;
 
 	MCAssert (t_interface_len <= UINDEX_MAX);
-	r_interface.Give ((byte_t *) t_interface, t_interface_len);
+	r_interface.Give ((byte_t *) t_interface, (uindex_t)t_interface_len);
 
 	return true;
 
@@ -716,7 +716,7 @@ void EmitModuleDependency(NameRef p_name, long& r_index)
 void EmitImportedType(long p_module_index, NameRef p_name, long p_type_index, long& r_index)
 {
     uindex_t t_index;
-    MCScriptAddImportToModule(s_builder, p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindType, p_type_index, t_index);
+    MCScriptAddImportToModule(s_builder, (uindex_t)p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindType, (uindex_t)p_type_index, t_index);
     r_index = t_index;
 
     Debug_Emit("ImportedType(%ld, %s, %ld -> %d)", p_module_index,
@@ -726,7 +726,7 @@ void EmitImportedType(long p_module_index, NameRef p_name, long p_type_index, lo
 void EmitImportedConstant(long p_module_index, NameRef p_name, long p_type_index, long& r_index)
 {
     uindex_t t_index;
-    MCScriptAddImportToModule(s_builder, p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindConstant, p_type_index, t_index);
+    MCScriptAddImportToModule(s_builder, (uindex_t)p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindConstant, (uindex_t)p_type_index, t_index);
     r_index = t_index;
 
     Debug_Emit("ImportedConstant(%ld, %s, %ld -> %d)", p_module_index,
@@ -736,7 +736,7 @@ void EmitImportedConstant(long p_module_index, NameRef p_name, long p_type_index
 void EmitImportedVariable(long p_module_index, NameRef p_name, long p_type_index, long& r_index)
 {
     uindex_t t_index;
-    MCScriptAddImportToModule(s_builder, p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindVariable, p_type_index, t_index);
+    MCScriptAddImportToModule(s_builder, (uindex_t)p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindVariable, (uindex_t)p_type_index, t_index);
     r_index = t_index;
 
     Debug_Emit("ImportedVariable(%ld, %s, %ld -> %d)", p_module_index,
@@ -746,7 +746,7 @@ void EmitImportedVariable(long p_module_index, NameRef p_name, long p_type_index
 void EmitImportedHandler(long p_module_index, NameRef p_name, long p_type_index, long& r_index)
 {
     uindex_t t_index;
-    MCScriptAddImportToModule(s_builder, p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindHandler, p_type_index, t_index);
+    MCScriptAddImportToModule(s_builder, (uindex_t)p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindHandler, (uindex_t)p_type_index, t_index);
     r_index = t_index;
 
     Debug_Emit("ImportedHandler(%ld, %s, %ld -> %d)", p_module_index,
@@ -756,7 +756,7 @@ void EmitImportedHandler(long p_module_index, NameRef p_name, long p_type_index,
 void EmitImportedSyntax(long p_module_index, NameRef p_name, long p_type_index, long& r_index)
 {
     uindex_t t_index;
-    MCScriptAddImportToModule(s_builder, p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindSyntax, p_type_index, t_index);
+    MCScriptAddImportToModule(s_builder, (uindex_t)p_module_index - 1, to_mcnameref(p_name), kMCScriptDefinitionKindSyntax, (uindex_t)p_type_index, t_index);
     r_index = t_index;
 
     Debug_Emit("ImportedSyntax(%ld, %s, %ld -> %d)", p_module_index,
@@ -765,14 +765,14 @@ void EmitImportedSyntax(long p_module_index, NameRef p_name, long p_type_index, 
 
 void EmitExportedDefinition(long p_index)
 {
-    MCScriptAddExportToModule(s_builder, p_index);
+    MCScriptAddExportToModule(s_builder, (uindex_t)p_index);
 
     Debug_Emit("ExportedDefinition(%ld)", p_index);
 }
 
 void EmitDefinitionIndex(const char *p_type, long& r_index)
 {
-    static struct { const char *name; MCScriptDefinitionKind kind; } s_type_map[] =
+    static const struct { const char *name; MCScriptDefinitionKind kind; } kTypeMap[] =
     {
         { "external", kMCScriptDefinitionKindExternal },
         { "type", kMCScriptDefinitionKindType },
@@ -785,11 +785,12 @@ void EmitDefinitionIndex(const char *p_type, long& r_index)
         { "syntax", kMCScriptDefinitionKindSyntax },
         { "definitiongroup", kMCScriptDefinitionKindDefinitionGroup },
     };
+    static const int kTypeMapLength = sizeof(kTypeMap) / sizeof(kTypeMap[0]);
     
     int t_kind_index = -1;
-    for(int i = 0; i < (int)(sizeof(s_type_map) / sizeof(s_type_map[0])); i++)
+    for(int i = 0; i < kTypeMapLength; i++)
     {
-        if (strcmp(s_type_map[i].name, p_type) == 0)
+        if (strcmp(kTypeMap[i].name, p_type) == 0)
         {
             t_kind_index = i;
             break;
@@ -800,7 +801,7 @@ void EmitDefinitionIndex(const char *p_type, long& r_index)
         Fatal_InternalInconsistency("unknown definition kind");
     
     uindex_t t_index;
-    MCScriptAddDefinitionToModule(s_builder, s_type_map[t_kind_index] . kind, t_index);
+    MCScriptAddDefinitionToModule(s_builder, kTypeMap[t_kind_index] . kind, t_index);
     r_index = t_index;
 
     Debug_Emit("DefinitionIndex(%s -> %u)", p_type, t_index);
@@ -808,7 +809,7 @@ void EmitDefinitionIndex(const char *p_type, long& r_index)
 
 void EmitTypeDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
 {
-    MCScriptAddTypeToModule(s_builder, to_mcnameref(p_name), p_type_index, p_index);
+    MCScriptAddTypeToModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, (uindex_t)p_index);
 
     Debug_Emit("TypeDefinition(%ld, %s, %ld)", p_index,
                cstring_from_nameref(p_name), p_type_index);
@@ -816,7 +817,7 @@ void EmitTypeDefinition(long p_index, PositionRef p_position, NameRef p_name, lo
 
 void EmitConstantDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_const_index)
 {
-    MCScriptAddConstantToModule(s_builder, to_mcnameref(p_name), p_const_index, p_index);
+    MCScriptAddConstantToModule(s_builder, to_mcnameref(p_name), (uindex_t)p_const_index, (uindex_t)p_index);
 
     Debug_Emit("ConstantDefinition(%ld, %s, %ld)", p_index,
                cstring_from_nameref(p_name), p_const_index);
@@ -824,7 +825,7 @@ void EmitConstantDefinition(long p_index, PositionRef p_position, NameRef p_name
 
 void EmitVariableDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
 {
-    MCScriptAddVariableToModule(s_builder, to_mcnameref(p_name), p_type_index, p_index);
+    MCScriptAddVariableToModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, (uindex_t)p_index);
 
     Debug_Emit("VariableDefinition(%ld, %s, %ld)", p_index,
                cstring_from_nameref(p_name), p_type_index);
@@ -839,7 +840,7 @@ void EmitForeignHandlerDefinition(long p_index, PositionRef p_position, NameRef 
         t_binding_str = to_mcstringref(p_binding);
     
     if (!MCStringBeginsWithCString(*t_binding_str, (const char_t *)"lcb:", kMCStringOptionCompareExact))
-        MCScriptAddForeignHandlerToModule(s_builder, to_mcnameref(p_name), p_type_index, *t_binding_str, p_index);
+        MCScriptAddForeignHandlerToModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, *t_binding_str, (uindex_t)p_index);
     else
     {
         // The string should be of the form:
@@ -864,7 +865,7 @@ void EmitForeignHandlerDefinition(long p_index, PositionRef p_position, NameRef 
         MCNewAutoNameRef t_hand_name;
         MCNameCreate(*t_handler, &t_hand_name);
         
-        MCScriptAddImportToModuleWithIndex(s_builder, t_module_dep - 1, *t_hand_name, kMCScriptDefinitionKindHandler, p_type_index, p_index);
+        MCScriptAddImportToModuleWithIndex(s_builder, (uindex_t)t_module_dep - 1, *t_hand_name, kMCScriptDefinitionKindHandler, (uindex_t)p_type_index, (uindex_t)p_index);
     }
 
     Debug_Emit("ForeignHandlerDefinition(%ld, %s, %ld, %s)", p_index,
@@ -874,7 +875,7 @@ void EmitForeignHandlerDefinition(long p_index, PositionRef p_position, NameRef 
 
 void EmitPropertyDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_getter, long p_setter)
 {
-    MCScriptAddPropertyToModule(s_builder, to_mcnameref(p_name), p_getter, p_setter, p_index);
+    MCScriptAddPropertyToModule(s_builder, to_mcnameref(p_name), (uindex_t)p_getter, (uindex_t)p_setter, (uindex_t)p_index);
 
     Debug_Emit("PropertyDefinition(%ld, %s, %ld, %ld)", p_index,
                cstring_from_nameref(p_name), p_getter, p_setter);
@@ -882,7 +883,7 @@ void EmitPropertyDefinition(long p_index, PositionRef p_position, NameRef p_name
 
 void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
 {
-    MCScriptAddEventToModule(s_builder, to_mcnameref(p_name), p_type_index, p_index);
+    MCScriptAddEventToModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, (uindex_t)p_index);
 
     Debug_Emit("EmitEvent(%ld, %s, %ld)", p_index, cstring_from_nameref(p_name),
                p_type_index);
@@ -890,7 +891,7 @@ void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, l
 
 void EmitBeginHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
 {
-    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), p_type_index, p_index);
+    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, (uindex_t)p_index);
 
     Debug_Emit("BeginHandlerDefinition(%ld, %s, %ld)", p_index,
                cstring_from_nameref(p_name), p_type_index);
@@ -912,7 +913,7 @@ void EmitEndHandlerDefinition(void)
 
 void EmitBeginSyntaxDefinition(long p_index, PositionRef p_position, NameRef p_name)
 {
-    MCScriptBeginSyntaxInModule(s_builder, to_mcnameref(p_name), p_index);
+    MCScriptBeginSyntaxInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_index);
 
     Debug_Emit("BeginSyntaxDefinition(%ld, %s)", p_index,
                cstring_from_nameref(p_name));
@@ -927,7 +928,7 @@ void EmitEndSyntaxDefinition(void)
 
 void EmitBeginSyntaxMethod(long p_handler_index)
 {
-    MCScriptBeginSyntaxMethodInModule(s_builder, p_handler_index);
+    MCScriptBeginSyntaxMethodInModule(s_builder, (uindex_t)p_handler_index);
 
     Debug_Emit("BeginSyntaxMethod(%ld)", p_handler_index);
 }
@@ -1001,7 +1002,7 @@ void EmitFalseSyntaxMethodArgument(void)
 void EmitIntegerSyntaxMethodArgument(long p_int)
 {
     MCAutoNumberRef t_number;
-    MCNumberCreateWithInteger(p_int, &t_number);
+    MCNumberCreateWithInteger((uindex_t)p_int, &t_number);
     MCScriptAddConstantArgumentToSyntaxMethodInModule(s_builder, *t_number);
 
     Debug_Emit("IntegerSyntaxMethodArgument(%ld)", p_int);
@@ -1010,7 +1011,7 @@ void EmitIntegerSyntaxMethodArgument(long p_int)
 void EmitRealSyntaxMethodArgument(long p_double)
 {
     MCAutoNumberRef t_number;
-    MCNumberCreateWithInteger(p_double, &t_number);
+    MCNumberCreateWithInteger((uindex_t)p_double, &t_number);
     MCScriptAddConstantArgumentToSyntaxMethodInModule(s_builder, *t_number);
 
     Debug_Emit("RealSyntaxMethodArgument(%lf)", *(double *)p_double);
@@ -1026,14 +1027,14 @@ void EmitStringSyntaxMethodArgument(long p_string)
 
 void EmitVariableSyntaxMethodArgument(long p_index)
 {
-    MCScriptAddVariableArgumentToSyntaxMethodInModule(s_builder, p_index);
+    MCScriptAddVariableArgumentToSyntaxMethodInModule(s_builder, (uindex_t)p_index);
 
     Debug_Emit("VariableSyntaxMethodArgument(%ld)", p_index);
 }
 
 void EmitIndexedVariableSyntaxMethodArgument(long p_var_index, long p_element_index)
 {
-    MCScriptAddIndexedVariableArgumentToSyntaxMethodInModule(s_builder, p_var_index, p_element_index);
+    MCScriptAddIndexedVariableArgumentToSyntaxMethodInModule(s_builder, (uindex_t)p_var_index, (uindex_t)p_element_index);
 
     Debug_Emit("IndexedVariableSyntaxMethodArgument(%ld, %ld)", p_var_index,
                p_element_index);
@@ -1048,7 +1049,7 @@ void EmitBeginDefinitionGroup(void)
 
 void EmitContinueDefinitionGroup(long p_index)
 {
-    MCScriptAddHandlerToDefinitionGroupInModule(s_builder, p_index);
+    MCScriptAddHandlerToDefinitionGroupInModule(s_builder, (uindex_t)p_index);
 
     Debug_Emit("ContinueDefinitionGroup(%ld)", p_index);
 }
@@ -1110,7 +1111,7 @@ void EmitAliasType(NameRef name, long target_index, long& r_new_index)
 void EmitDefinedType(long index, long& r_type_index)
 {
     uindex_t t_type_index;
-    MCScriptAddDefinedTypeToModule(s_builder, index, t_type_index);
+    MCScriptAddDefinedTypeToModule(s_builder, (uindex_t)index, t_type_index);
     r_type_index = t_type_index;
 
     Debug_Emit("DefinedType(%ld -> %ld)", index, r_type_index);
@@ -1128,7 +1129,7 @@ void EmitForeignType(long p_binding, long& r_type_index)
 void EmitOptionalType(long base_index, long& r_new_index)
 {
     uindex_t t_index;
-    MCScriptAddOptionalTypeToModule(s_builder, base_index, t_index);
+    MCScriptAddOptionalTypeToModule(s_builder, (uindex_t)base_index, t_index);
     r_new_index = t_index;
 
     Debug_Emit("OptionalType(%ld -> %ld)", base_index, r_new_index);
@@ -1265,20 +1266,16 @@ void EmitUndefinedType(long& r_new_index)
 
 //////////
 
-static MCTypeInfoRef s_current_record_basetype = nil;
-static MCRecordTypeFieldInfo *s_current_record_fields = nil;
-static uindex_t s_current_record_field_count = 0;
-
 void EmitBeginRecordType(long p_base_type_index)
 {
-    MCScriptBeginRecordTypeInModule(s_builder, p_base_type_index);
+    MCScriptBeginRecordTypeInModule(s_builder, (uindex_t)p_base_type_index);
 
     Debug_Emit("BeginRecordType(%ld)", p_base_type_index);
 }
 
 void EmitRecordTypeField(NameRef name, long type_index)
 {
-    MCScriptContinueRecordTypeInModule(s_builder, to_mcnameref(name), type_index);
+    MCScriptContinueRecordTypeInModule(s_builder, to_mcnameref(name), (uindex_t)type_index);
     Debug_Emit("RecordTypeField(%s, %ld)", cstring_from_nameref(name),
                type_index);
 }
@@ -1294,27 +1291,23 @@ void EmitEndRecordType(long& r_type_index)
 
 //////////
 
-static MCTypeInfoRef s_current_handler_returntype = nil;
-static MCHandlerTypeFieldInfo *s_current_handler_fields = nil;
-static uindex_t s_current_handler_field_count = 0;
-
 void EmitBeginHandlerType(long return_type_index)
 {
-    MCScriptBeginHandlerTypeInModule(s_builder, return_type_index);
+    MCScriptBeginHandlerTypeInModule(s_builder, (uindex_t)return_type_index);
 
     Debug_Emit("BeginHandlerType(%ld)", return_type_index);
 }
 
 void EmitBeginForeignHandlerType(long return_type_index)
 {
-    MCScriptBeginForeignHandlerTypeInModule(s_builder, return_type_index);
+    MCScriptBeginForeignHandlerTypeInModule(s_builder, (uindex_t)return_type_index);
     
     Debug_Emit("BeginForeignHandlerType(%ld)", return_type_index);
 }
 
 static void EmitHandlerTypeParameter(MCHandlerTypeFieldMode mode, NameRef name, long type_index)
 {
-    MCScriptContinueHandlerTypeInModule(s_builder, (MCScriptHandlerTypeParameterMode)mode, to_mcnameref(name), type_index);
+    MCScriptContinueHandlerTypeInModule(s_builder, (MCScriptHandlerTypeParameterMode)mode, to_mcnameref(name), (uindex_t)type_index);
 
     Debug_Emit("HandlerTypeParameter(%d, %s, %ld)", mode,
                cstring_from_nameref(name), type_index);
@@ -1349,7 +1342,7 @@ void EmitEndHandlerType(long& r_type_index)
 void EmitHandlerParameter(NameRef name, long type_index, long& r_index)
 {
     uindex_t t_index;
-    MCScriptAddParameterToHandlerInModule(s_builder, to_mcnameref(name), type_index, t_index);
+    MCScriptAddParameterToHandlerInModule(s_builder, to_mcnameref(name), (uindex_t)type_index, t_index);
     r_index = t_index;
 
     Debug_Emit("HandlerParameter(%s, %ld -> %ld)", cstring_from_nameref(name),
@@ -1359,7 +1352,7 @@ void EmitHandlerParameter(NameRef name, long type_index, long& r_index)
 void EmitHandlerVariable(NameRef name, long type_index, long& r_index)
 {
     uindex_t t_index;
-    MCScriptAddVariableToHandlerInModule(s_builder, to_mcnameref(name), type_index, t_index);
+    MCScriptAddVariableToHandlerInModule(s_builder, to_mcnameref(name), (uindex_t)type_index, t_index);
     r_index = t_index;
 
     Debug_Emit("HandlerVariable(%s, %ld -> %ld)", cstring_from_nameref(name),
@@ -1377,7 +1370,7 @@ void EmitDeferLabel(long& r_label)
 
 void EmitResolveLabel(long label)
 {
-    MCScriptResolveLabelForBytecodeInModule(s_builder, label);
+    MCScriptResolveLabelForBytecodeInModule(s_builder, (uindex_t)label);
 
     Debug_Emit("ResolveLabel(%ld)", label);
 }
@@ -1485,7 +1478,7 @@ void EmitIntegerConstant(long value, long *idx)
 {
     MCAutoNumberRef t_number;
     uindex_t t_index;
-    MCNumberCreateWithInteger(value, &t_number);
+    MCNumberCreateWithInteger((integer_t)value, &t_number);
     MCScriptAddValueToModule(s_builder, *t_number, t_index);
     *idx = t_index;
     
@@ -1496,7 +1489,7 @@ void EmitUnsignedIntegerConstant(unsigned long value, long *idx)
 {
     MCAutoNumberRef t_number;
     uindex_t t_index;
-    MCNumberCreateWithUnsignedInteger(value, &t_number);
+    MCNumberCreateWithUnsignedInteger((uinteger_t)value, &t_number);
     MCScriptAddValueToModule(s_builder, *t_number, t_index);
     *idx = t_index;
     
@@ -1518,7 +1511,7 @@ void EmitStringConstant(long value, long *idx)
 {
     MCAutoStringRef t_string;
     uindex_t t_index;
-    MCStringCreateWithBytes((const byte_t *)value, strlen((const char *)value), kMCStringEncodingUTF8, false, &t_string);
+    MCStringCreateWithBytes((const byte_t *)value, (uindex_t)strlen((const char *)value), kMCStringEncodingUTF8, false, &t_string);
     MCScriptAddValueToModule(s_builder, *t_string, t_index);
     *idx = t_index;
     
@@ -1643,42 +1636,42 @@ void EmitEndOpcode(void)
 
 void EmitJump(long label)
 {
-    static __opcode_index s_opcode_index("jump");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, label, UINDEX_MAX);
+    static const __opcode_index kJumpOpcodeIndex("jump");
+    MCScriptEmitBytecodeInModule(s_builder, kJumpOpcodeIndex, label, UINDEX_MAX);
     
     Debug_Emit("Jump(%ld)", label);
 }
 
 void EmitJumpIfTrue(long reg, long label)
 {
-    static __opcode_index s_opcode_index("jump_if_true");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, label, UINDEX_MAX);
+    static const __opcode_index kJumpIfTrueOpcodeIndex("jump_if_true");
+    MCScriptEmitBytecodeInModule(s_builder, kJumpIfTrueOpcodeIndex, reg, label, UINDEX_MAX);
     
     Debug_Emit("JumpIfTrue(%ld, %ld)", label);
 }
 
 void EmitJumpIfFalse(long reg, long label)
 {
-    static __opcode_index s_opcode_index("jump_if_false");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, label, UINDEX_MAX);
+    static const __opcode_index kJumpIfFalseOpcodeIndex("jump_if_false");
+    MCScriptEmitBytecodeInModule(s_builder, kJumpIfFalseOpcodeIndex, reg, label, UINDEX_MAX);
     
     Debug_Emit("JumpIfFalse(%ld, %ld)", reg, label);
 }
 
 void EmitBeginInvoke(long index, long contextreg, long resultreg)
 {
-    static __opcode_index s_opcode_index("invoke");
+    static const __opcode_index kInvokeOpcodeIndex("invoke");
     
-    s_opcode = s_opcode_index;
+    s_opcode = kInvokeOpcodeIndex;
     push_argument(index);
     push_argument(resultreg);
 }
 
 void EmitBeginIndirectInvoke(long handlerreg, long contextreg, long resultreg)
 {
-    static __opcode_index s_opcode_index("invoke_indirect");
+    static const __opcode_index kInvokeIndirectOpcodeIndex("invoke_indirect");
     
-    s_opcode = s_opcode_index;
+    s_opcode = kInvokeIndirectOpcodeIndex;
     push_argument(handlerreg);
     push_argument(resultreg);
 }
@@ -1701,9 +1694,9 @@ void EmitEndInvoke(void)
 
 void EmitBeginAssignList(long reg)
 {
-    static __opcode_index s_opcode_index("assign_list");
+    static const __opcode_index kAssignListOpcodeIndex("assign_list");
     
-    s_opcode = s_opcode_index;
+    s_opcode = kAssignListOpcodeIndex;
     push_argument(reg);
 }
 
@@ -1723,9 +1716,9 @@ void EmitEndAssignList(void)
 
 void EmitBeginAssignArray(long reg)
 {
-    static __opcode_index s_opcode_index("assign_array");
+    static const __opcode_index kAssignArrayOpcodeIndex("assign_array");
     
-    s_opcode = s_opcode_index;
+    s_opcode = kAssignArrayOpcodeIndex;
     push_argument(reg);
 }
 
@@ -1745,16 +1738,16 @@ void EmitEndAssignArray(void)
 
 void EmitAssign(long dst, long src)
 {
-    static __opcode_index s_opcode_index("assign");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, dst, src, UINDEX_MAX);
+    static const __opcode_index kAssignOpcodeIndex("assign");
+    MCScriptEmitBytecodeInModule(s_builder, kAssignOpcodeIndex, dst, src, UINDEX_MAX);
     
     Debug_Emit("Assign(%ld, %ld)", dst, src);
 }
 
 void EmitAssignConstant(long dst, long idx)
 {
-    static __opcode_index s_opcode_index("assign_constant");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, dst, idx, UINDEX_MAX);
+    static const __opcode_index kAssignConstantOpcodeIndex("assign_constant");
+    MCScriptEmitBytecodeInModule(s_builder, kAssignConstantOpcodeIndex, dst, idx, UINDEX_MAX);
 
     Debug_Emit("AssignConstant(%ld, %ld)", dst, idx);
 }
@@ -1763,40 +1756,40 @@ void EmitAssignConstant(long dst, long idx)
 
 void EmitFetch(long reg, long var, long level)
 {
-    static __opcode_index s_opcode_index("fetch");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, var, UINDEX_MAX);
+    static const __opcode_index kFetchOpcodeIndex("fetch");
+    MCScriptEmitBytecodeInModule(s_builder, kFetchOpcodeIndex, reg, var, UINDEX_MAX);
 
     Debug_Emit("Fetch(%ld, %ld)", reg, var);
 }
 
 void EmitStore(long reg, long var, long level)
 {
-    static __opcode_index s_opcode_index("store");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, var, UINDEX_MAX);
+    static const __opcode_index kStoreOpcodeIndex("store");
+    MCScriptEmitBytecodeInModule(s_builder, kStoreOpcodeIndex, reg, var, UINDEX_MAX);
 
     Debug_Emit("Store(%ld, %ld)", reg, var);
 }
 
 void EmitReturn(long reg)
 {
-    static __opcode_index s_opcode_index("return");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, UINDEX_MAX);
+    static const __opcode_index kReturnOpcodeIndex("return");
+    MCScriptEmitBytecodeInModule(s_builder, kReturnOpcodeIndex, reg, UINDEX_MAX);
 
     Debug_Emit("Return(%ld)", reg);
 }
 
 void EmitReturnNothing(void)
 {
-    static __opcode_index s_opcode_index("return");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, UINDEX_MAX);
+    static const __opcode_index kReturnOpcodeIndex("return");
+    MCScriptEmitBytecodeInModule(s_builder, kReturnOpcodeIndex, UINDEX_MAX);
 
     Debug_Emit("ReturnUndefined()", 0);
 }
 
 void EmitReset(long reg)
 {
-    static __opcode_index s_opcode_index("reset");
-    MCScriptEmitBytecodeInModule(s_builder, s_opcode_index, reg, UINDEX_MAX);
+    static const __opcode_index kResetOpcodeIndex("reset");
+    MCScriptEmitBytecodeInModule(s_builder, kResetOpcodeIndex, reg, UINDEX_MAX);
     
     Debug_Emit("Reset(%ld)", reg);
 }
@@ -1958,7 +1951,7 @@ OutputWriteXmlS(const char *p_left,
 	{
 		t_success =
 			MCStringCreateWithBytes(reinterpret_cast<const byte_t *>(p_string),
-			                        strlen(p_string), kMCStringEncodingUTF8,
+			                        (uindex_t)strlen(p_string), kMCStringEncodingUTF8,
 			                        false, &t_string);
 	}
 
@@ -2246,7 +2239,6 @@ int BytecodeEnumerate(long index, long *r_name)
     
     if (index >= MCProperListGetLength(s_bytecode_names))
     {
-        MCLog("%@", s_bytecode_names);
         MCValueRelease(s_bytecode_names);
         s_bytecode_names = nil;
         return 0;
@@ -2254,7 +2246,6 @@ int BytecodeEnumerate(long index, long *r_name)
     
     MCStringRef t_name;
     t_name = (MCStringRef)MCProperListFetchElementAtIndex(s_bytecode_names, (uindex_t)index);
-    MCLog("%@", t_name);
     *r_name = (long)nameref_from_mcstringref(t_name);
     
     return 1;

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -98,6 +98,7 @@
             ||
                 (|
                     IsBootstrapCompile()
+                    InitializeSyntax
                     GenerateSyntaxForModules(Modules)
                     (|
                         ErrorsDidOccur()
@@ -141,8 +142,6 @@
 'action' GenerateSyntaxForModules(MODULELIST)
 
     'rule' GenerateSyntaxForModules(modulelist(Head, Tail)):
-        InitializeSyntax
-        
         (|
             Head'Kind -> import
         ||
@@ -819,6 +818,11 @@
     'rule' Statement(-> call(Position, Handler, Arguments)):
         Identifier(-> Handler) @(-> Position) "(" OptionalExpressionList(-> Arguments) ")"
 
+    'rule' Statement(-> bytecode(Position, Opcodes)):
+        "bytecode" @(-> Position) Separator
+            Bytecodes(-> Opcodes)
+        "end" "bytecode"
+
     'rule' Statement(-> postfixinto(Position, Statement, Target)):
         CustomStatements(-> Statement) "into" @(-> Position) Expression(-> Target)
 
@@ -852,6 +856,34 @@
     'rule' TryStatementCatches(-> catch(Position, Type, Body)):
         "catch" Type(-> Type) Separator
             Statements(-> Body)*/
+
+--------------------------------------------------------------------------------
+-- Bytecode Syntax
+--------------------------------------------------------------------------------
+
+'nonterm' Bytecodes(-> BYTECODE)
+
+    'rule' Bytecodes(-> sequence(Left, Right)):
+        Bytecode(-> Left) Separator
+        Bytecodes(-> Right)
+
+    'rule' Bytecodes(-> nil):
+        -- empty
+
+'nonterm' Bytecode(-> BYTECODE)
+
+    'rule' Bytecode(-> label(Position, Name)):
+        Identifier(-> Name) @(-> Position) ":"
+
+    'rule' Bytecode(-> register(Position, Name, Type)):
+        "register" @(-> Position) Identifier(-> Name) OptionalTypeClause(-> Type)
+
+    'rule' Bytecode(-> opcode(Position, Opcode, Arguments)):
+        NAME_LITERAL(-> Opcode) @(-> Position) OptionalExpressionList(-> Arguments)
+
+    'rule' Bytecode(-> opcode(Position, Opcode, Arguments)):
+        CustomKeywords(-> OpcodeString) @(-> Position) OptionalExpressionList(-> Arguments)
+        MakeNameLiteral(OpcodeString -> Opcode)
 
 --------------------------------------------------------------------------------
 -- Expression Syntax

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -267,6 +267,7 @@ void* g_builtin_modules[1] = {NULL};
 unsigned int g_builtin_module_count = 0;
 
 extern int yydebug;
+extern void InitializeFoundation(void);
 
 int main(int argc, char *argv[])
 {
@@ -287,6 +288,9 @@ int main(int argc, char *argv[])
         yydebug = 1;
 #endif
     }
+    
+    // Initialize libfoundation
+    InitializeFoundation();
     
     InitializeFiles();
     InitializePosition();

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -27,7 +27,7 @@ extern int IsDependencyCompile(void);
 ////////////////////////////////////////////////////////////////////////////////
 
 static int s_error_count;
-int s_verbose_level;
+int s_verbose_level = 1;
 int s_is_werror_enabled;
 
 void InitializeReports(void)
@@ -112,7 +112,7 @@ void Error_Bootstrap(const char *p_format, ...)
 
 void Error_CouldNotGenerateBytecode (void)
 {
-	fprintf(stderr, "error: Could not generate interface\n");
+	fprintf(stderr, "error: Could not generate bytecode\n");
 	++s_error_count;
 }
 
@@ -323,6 +323,15 @@ DEFINE_ERROR(NoTypeSpecifiedForForeignHandlerParameter, "Foreign handler paramet
 DEFINE_ERROR(ConstantArrayKeyIsNotStringLiteral, "Array keys must be strings")
 DEFINE_ERROR(ListExpressionTooLong, "List expressions can have at most 254 elements")
 DEFINE_ERROR(ArrayExpressionTooLong, "Array expressions can have at most 127 keys")
+
+DEFINE_ERROR_I(UnknownOpcode, "Unknown opcode '%s'")
+DEFINE_ERROR(OpcodeArgumentMustBeLabel, "Opcode argument must be a label")
+DEFINE_ERROR(OpcodeArgumentMustBeRegister, "Opcode argument must be a temporary variable, local variable or parameter variable")
+DEFINE_ERROR(OpcodeArgumentMustBeConstant, "Opcode argument must be a literal expression")
+DEFINE_ERROR(OpcodeArgumentMustBeHandler, "Opcode argument must be a handler id")
+DEFINE_ERROR(OpcodeArgumentMustBeVariable, "Opcode argument must be a module variable")
+DEFINE_ERROR(OpcodeArgumentMustBeDefinition, "Opcode argument must be a module variable, constant id or handler id")
+DEFINE_ERROR(IllegalNumberOfArgumentsForOpcode, "Wrong number of arguments for opcode")
 
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(long p_position) { _Warning(p_position, Message); }

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -47,6 +47,7 @@ void Warning_UnicodeEscapeTooBig(long position);
 void Error_Bootstrap(const char *format, ...);
 
 void Debug_Emit(const char *p_format, ...);
+    
 void Debug_Depend(const char *p_format, ...);
 
 #ifdef __cplusplus

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -122,12 +122,19 @@
     PushInMarkArgumentSyntaxMapping
     PushOutMarkArgumentSyntaxMapping
     PushInOutMarkArgumentSyntaxMapping
+    AddUnreservedSyntaxKeyword
 
     IsDependencyCompile
     DependStart
     DependFinish
     DependDefineMapping
     DependDefineDependency
+
+    BytecodeEnumerate
+    BytecodeLookup
+    BytecodeDescribe
+    BytecodeDescribeParameter
+    BytecodeIsValidArgumentCount
 
     EmitStart
     EmitFinish
@@ -245,6 +252,9 @@
     EmitDetachRegisterFromExpression
     EmitGetRegisterAttachedToExpression
     EmitPosition
+    EmitBeginOpcode
+    EmitContinueOpcode
+    EmitEndOpcode
 
     OutputBeginManifest
     OutputEnd
@@ -327,6 +337,14 @@
     Error_ConstantArrayKeyIsNotStringLiteral
     Error_ListExpressionTooLong
     Error_ArrayExpressionTooLong
+    Error_UnknownOpcode
+    Error_OpcodeArgumentMustBeLabel
+    Error_OpcodeArgumentMustBeRegister
+    Error_OpcodeArgumentMustBeConstant
+    Error_OpcodeArgumentMustBeHandler
+    Error_OpcodeArgumentMustBeVariable
+    Error_OpcodeArgumentMustBeDefinition
+    Error_IllegalNumberOfArgumentsForOpcode
     Warning_MetadataClausesShouldComeAfterUseClauses
     Warning_DeprecatedTypeName
     Warning_UnsuitableNameForDefinition
@@ -479,6 +497,8 @@
 'action' PushStringArgumentSyntaxMapping(Value: STRING)
 'action' PushIndexedMarkArgumentSyntaxMapping(MarkIndex: INT, Index: INT)
 
+'action' AddUnreservedSyntaxKeyword(Token: NAME)
+
 --------------------------------------------------------------------------------
 
 'condition' IsDependencyCompile()
@@ -486,6 +506,14 @@
 'action' DependFinish()
 'action' DependDefineMapping(ModuleName: NAME, SourceFile: STRING)
 'action' DependDefineDependency(ModuleName: NAME, RequiredModuleName: NAME)
+
+--------------------------------------------------------------------------------
+
+'condition' BytecodeEnumerate(Index: INT -> Name: NAME)
+'condition' BytecodeLookup(Name: STRING -> Opcode: INT)
+'action' BytecodeDescribe(Opcode: INT -> Name: NAME)
+'condition' BytecodeIsValidArgumentCount(Opcode: INT, Count: INT)
+'action' BytecodeDescribeParameter(Opcode: INT, Index: INT -> Type: INT)
 
 --------------------------------------------------------------------------------
 
@@ -507,7 +535,7 @@
 
 'action' EmitExportedDefinition(Index: INT)
 
-'action' EmitDefinitionIndex(-> Index: INT)
+'action' EmitDefinitionIndex(Kind: STRING -> Index: INT)
 
 'action' EmitTypeDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitConstantDefinition(Index: INT, Position: POS, Name: NAME, ConstIndex: INT)
@@ -616,6 +644,9 @@
 'action' EmitReturnNothing()
 'action' EmitReset(Register: INT)
 'action' EmitPosition(Position: POS)
+'action' EmitBeginOpcode(Opcode: STRING)
+'action' EmitContinueOpcode(Output: INT)
+'action' EmitEndOpcode()
 
 'action' EmitAttachRegisterToExpression(INT, EXPRESSION)
 'action' EmitDetachRegisterFromExpression(EXPRESSION)
@@ -721,6 +752,15 @@
 'action' Error_ConstantArrayKeyIsNotStringLiteral(Position: POS)
 'action' Error_ListExpressionTooLong(Position: POS)
 'action' Error_ArrayExpressionTooLong(Position: POS)
+
+'action' Error_UnknownOpcode(Position: POS, Opcode: NAME)
+'action' Error_OpcodeArgumentMustBeLabel(Position: POS)
+'action' Error_OpcodeArgumentMustBeRegister(Position: POS)
+'action' Error_OpcodeArgumentMustBeConstant(Position: POS)
+'action' Error_OpcodeArgumentMustBeHandler(Position: POS)
+'action' Error_OpcodeArgumentMustBeVariable(Position: POS)
+'action' Error_OpcodeArgumentMustBeDefinition(Position: POS)
+'action' Error_IllegalNumberOfArgumentsForOpcode(Position: POS)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)

--- a/toolchain/lc-compile/src/syntax.g
+++ b/toolchain/lc-compile/src/syntax.g
@@ -29,7 +29,19 @@
 'action' InitializeSyntax
 
     'rule' InitializeSyntax:
-        -- do nothing
+        -- Add all bytecode names as 'unreserved keywords'
+        GenerateBytecodeUnreservedSyntaxKeywords(0)
+
+'action' GenerateBytecodeUnreservedSyntaxKeywords(INT)
+
+    'rule' GenerateBytecodeUnreservedSyntaxKeywords(Index):
+        BytecodeEnumerate(Index -> Name)
+        AddUnreservedSyntaxKeyword(Name)
+        GenerateBytecodeUnreservedSyntaxKeywords(Index + 1)
+
+    'rule' GenerateBytecodeUnreservedSyntaxKeywords(Index):
+        -- will get here when there are no more keywords to add
+
 
 'sweep' GenerateSyntax(ANY)
 

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -38,6 +38,7 @@
     SYNTAXMARKINFO SYNTAXMARKTYPE
     NAME DOUBLE
     SYNTAXPRECEDENCE
+    BYTECODE OPCODE
 
 --------------------------------------------------------------------------------
 
@@ -125,6 +126,27 @@
     out
     inout
 
+'type' OPCODE
+    jump
+    jumpiftrue
+    jumpiffalse
+    assignconstant
+    assign
+    return
+    invoke
+    invokeindirect
+    fetch
+    store
+    assignlist
+    assignarray
+
+'type' BYTECODE
+    sequence(Left: BYTECODE, Right: BYTECODE)
+    label(Position: POS, Name: ID)
+    register(Position: POS, Name: ID, Type: TYPE)
+    opcode(Position: POS, Opcode: NAME, Arguments: EXPRESSIONLIST)
+    nil
+
 'type' STATEMENT
     sequence(Left: STATEMENT, Right: STATEMENT)
     variable(Position: POS, Name: ID, Type: TYPE)
@@ -145,6 +167,7 @@
     invoke(Position: POS, Info: INVOKELIST, Arguments: EXPRESSIONLIST)
     throw(Position: POS, Error: EXPRESSION)
     postfixinto(Position: POS, Command: STATEMENT, Target: EXPRESSION)
+    bytecode(Position: POS, Block: BYTECODE)
     nil
     
 'type' EXPRESSIONLIST
@@ -280,6 +303,7 @@
     parameter
     local
     context
+    label
 
 'type' INTLIST
     intlist(Head: INT, Tail: INTLIST)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -38,7 +38,7 @@
     SYNTAXMARKINFO SYNTAXMARKTYPE
     NAME DOUBLE
     SYNTAXPRECEDENCE
-    BYTECODE OPCODE
+    BYTECODE
 
 --------------------------------------------------------------------------------
 
@@ -125,20 +125,6 @@
     in
     out
     inout
-
-'type' OPCODE
-    jump
-    jumpiftrue
-    jumpiffalse
-    assignconstant
-    assign
-    return
-    invoke
-    invokeindirect
-    fetch
-    store
-    assignlist
-    assignarray
 
 'type' BYTECODE
     sequence(Left: BYTECODE, Right: BYTECODE)


### PR DESCRIPTION
This patch adds the ability to write bytecode directly inside 'bytecode'
blocks in LCB:

```
bytecode
  ...
end bytecode
```

Labels are local to the block and can be specified by using:

```
myLabel:
```

Temporaries are local to the block and can be specified by using:

   variable myTemp

Temporaries, local variables and parameters can be used as register type
arguments to opcodes.

Module variables, defined constants and handler identifiers can be used
as the 'source' parameter for the 'fetch' opcode.

Module variables can be used as the 'dest' parameter for the 'source'
opcode.

Handler identifiers can be used as the 'handler' parameter for the 'invoke'
opcode.
