### PR TITLE
[[ LCB ]] Implement lexical scoping of variables in blocks

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -539,11 +539,8 @@ statement is defined in auxiliary modules.
       : 'variable' <Name: Identifier> [ 'as' <TypeOf: Type> ]
 
 A variable statement defines a handler-scope variable. Such variables
-can be used after the variable statement, but not before.
-
-> **Note:** Variables are currently not block-scoped, they are defined
-> from the point of declaration to the end of the handler - this might
-> change in a subsequent revision.
+can be used after the variable statement and up to the end of the current statement
+block, but not before.
 
 Variables whose type have a default value are initialized with that value at
 the point of definition in the handler. See the main Variables section for the
@@ -570,6 +567,9 @@ hold any value, including being nothing.
 The if statement enables conditional execution based on the result of an
 expression which evaluates to a boolean.
 
+Each block of code in an if/else if/else statement defines a unique scope for
+handler-local variable definitions.
+
 > **Note:** It is a checked runtime error to use an expression which
 > does not evaluate to a boolean in any condition expression.
 
@@ -592,6 +592,9 @@ expression which evaluates to a boolean.
 
 The repeat statements allow iterative execute of a sequence of
 statements.
+
+The block of code present in a repeat statement defines a unique scope for
+handler-local variable definitions.
 
 The **repeat forever** form repeats the body continually. To exit the
 loop, either an error must be thrown, or **exit repeat** must be

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -5,37 +5,37 @@ group: reference
 # LiveCode Builder Language Reference
 
 ## Introduction
-LiveCode Builder is a variant of the current LiveCode scripting language 
-(LiveCode Script) which has been designed for 'systems' building. It is 
-statically compiled with optional static typing and direct foreign code 
+LiveCode Builder is a variant of the current LiveCode scripting language
+(LiveCode Script) which has been designed for 'systems' building. It is
+statically compiled with optional static typing and direct foreign code
 interconnect (allowing easy access to APIs written in other languages).
 
-Unlike most languages, LiveCode Builder has been designed around the 
-idea of extensible syntax. Indeed, the core language is very small - 
-comprising declarations and control structures - with the majority of 
+Unlike most languages, LiveCode Builder has been designed around the
+idea of extensible syntax. Indeed, the core language is very small -
+comprising declarations and control structures - with the majority of
 the language syntax and functionality being defined in modules.
 
-> **Note:** It is an eventual aim that control structures will also be 
+> **Note:** It is an eventual aim that control structures will also be
 > extensible, however this is not the case in the current incarnation).
 
-The syntax will be familiar to anyone familiar with LiveCode Script, 
-however LiveCode Builder is a great deal more strict - the reason being 
-it is intended that it will eventually be compilable to machine code 
-with the performance and efficiency you'd expect from any 'traditional' 
-programming language. Indeed, over time we hope to move the majority of 
-implementation of the whole LiveCode system over to being written in 
+The syntax will be familiar to anyone familiar with LiveCode Script,
+however LiveCode Builder is a great deal more strict - the reason being
+it is intended that it will eventually be compilable to machine code
+with the performance and efficiency you'd expect from any 'traditional'
+programming language. Indeed, over time we hope to move the majority of
+implementation of the whole LiveCode system over to being written in
 LiveCode Builder.
 
-> **Note:** One of the principal differences is that type conversion is 
-> strict - there is no automatic conversion between different types such 
-> as between number and string. Such conversion must be explicitly 
-> specified using syntax (currently this is using things like 
+> **Note:** One of the principal differences is that type conversion is
+> strict - there is no automatic conversion between different types such
+> as between number and string. Such conversion must be explicitly
+> specified using syntax (currently this is using things like
 > *... parsed as number* and *... formatted as string*.
 
 ## Tokens
 
-The structure of tokens is similar to LiveCode Script, but again a 
-little stricter. The regular expressions describing the tokens are as 
+The structure of tokens is similar to LiveCode Script, but again a
+little stricter. The regular expressions describing the tokens are as
 follows:
 
  - **Identifier**: [A-Za-z_][A-Za-z0-9_.]*
@@ -53,27 +53,27 @@ Strings use backslash ('\') as an escape - the following are understood:
  - **\u{X...X}: character with unicode codepoint U+X...X - any number of nibbles may be specified, but any values greater than 0x10FFFF will be replaced by U+FFFD.
  - **\\**: backslash '\'
 
-> **Note:** The presence of '.' in identifiers are used as a namespace 
+> **Note:** The presence of '.' in identifiers are used as a namespace
 > scope delimiter.
 
 > **Note:** Source files are presumed to be in UTF-8 encoding.
 
 ### Case-Sensitivity
 
-At the moment, due to the nature of the parser being used, keywords are 
-all case-sensitive and reserved. The result of this is that, using all 
-lower-case identifiers for names of definitions should be avoided. 
-However, identifiers *are* case-insensitive - so a variable with name 
+At the moment, due to the nature of the parser being used, keywords are
+all case-sensitive and reserved. The result of this is that, using all
+lower-case identifiers for names of definitions should be avoided.
+However, identifiers *are* case-insensitive - so a variable with name
 pFoo can also be referenced as PFOO, PfOO, pfoO etc.
 
-> **Aside:** The current parser and syntax rules for LiveCode Builder 
-> are constructed at build-time of the LiveCode Builder compiler and 
-> uses *bison* (a standard parser generator tool) to build the parser. 
-> Unfortunately, this means that any keywords have to be reserved as the 
-> parser cannot distinguish the use of an identifier in context (whether 
+> **Aside:** The current parser and syntax rules for LiveCode Builder
+> are constructed at build-time of the LiveCode Builder compiler and
+> uses *bison* (a standard parser generator tool) to build the parser.
+> Unfortunately, this means that any keywords have to be reserved as the
+> parser cannot distinguish the use of an identifier in context (whether
 > it is a keyword at a particular point, or a name of a definition).
 
-It is highly recommended that the following naming conventions be used 
+It is highly recommended that the following naming conventions be used
 for identifiers:
 
  - **tVar** - for local variables
@@ -85,20 +85,20 @@ for identifiers:
  - **kConstant** - for constants
  - Use identifiers starting with an uppercase letter for handler and type names.
 
-By following this convention, there will not be any ambiguity between 
+By following this convention, there will not be any ambiguity between
 identifiers and keywords. (All keywords are all lower-case).
 
-> **Note:** When we have a better parsing technology we will be 
-> evaluating whether to make keywords case-insensitive as well. At the 
-> very least, at that point, we expect to be able to make all keywords 
+> **Note:** When we have a better parsing technology we will be
+> evaluating whether to make keywords case-insensitive as well. At the
+> very least, at that point, we expect to be able to make all keywords
 > unreserved.
 
 ## Typing
 
-LiveCode Builder is a typed language, although typing is completely 
-optional in most places (the only exception being in foreign handler 
-declarations). If a type annotation is not specified it is simply taken 
-to be the most general type *optional any* (meaning any value, including 
+LiveCode Builder is a typed language, although typing is completely
+optional in most places (the only exception being in foreign handler
+declarations). If a type annotation is not specified it is simply taken
+to be the most general type *optional any* (meaning any value, including
 nothing).
 
 The range of core types is relatively small, comprising the following:
@@ -210,7 +210,7 @@ definitions can only be used within the module.
 
 > **Note**: Properties and events are, by their nature, always public as
 > they define things which only make sense to access from outside.
-> 
+>
 > **Note**: When writing a library module, all public handlers are added
 > to bottom of the message path in LiveCode Script.
 
@@ -273,7 +273,7 @@ The remaining types are as follows:
  - **Pointer**: a low-level pointer (this is used with foreign code interconnect and shouldn't be generally used).
 
 > **Note:** *Integer* and *Real* are currently the same as *Number*.
- 
+
 > **Note:** In a subsequent update you will be able to specify lists and
 > arrays of fixed types. For example, *List of String*.
 
@@ -313,6 +313,24 @@ The type specification for the variable is optional, if it is not
 specified the type of the variable is *optional any* meaning that it can
 hold any value, including being nothing.
 
+Variables whose type has a default value are initialized to that value at the
+point of definition. The default values for the standard types are:
+
+- **optional**: nothing
+- **Boolean**: false
+- **Integer**: 0
+- **Real**: 0.0
+- **Number**: 0
+- **String**: the empty string
+- **Data**: the empty data
+- **Array**: the empty array
+- **List**: the empty list
+- **nothing**: nothing
+
+Variables whose type do not have a default value will remain unassigned and it
+is a checked runtime error to fetch from such variables until they are assigned
+a value.
+
 ### Handlers
 
     HandlerDefinition
@@ -350,8 +368,10 @@ return.
 
 > **Note:** It is a checked runtime error to return from a handler
 > without ensuring all non-optional 'out' parameters have been assigned
-> a value.
-> 
+> a value. However, this will only occur for typed variables whose type does
+> not have a default value as those which do will be default initialized at the
+> start of the handler.
+
 An inout parameter means that the value from the caller is copied to the
 parameter variable in the callee handler on entry, and copied back out
 again on exit.
@@ -385,8 +405,8 @@ low-level types to be specified making it easier to interoperate.
 
 Foreign types map to high-level types as follows:
 
- - bool maps to boolean 
- - int and uint map to integer (number) 
+ - bool maps to boolean
+ - int and uint map to integer (number)
  - float and double map to real (number)
 
 This mapping means that a foreign handler with a bool parameter say,
@@ -524,15 +544,14 @@ can be used after the variable statement, but not before.
 > **Note:** Variables are currently not block-scoped, they are defined
 > from the point of declaration to the end of the handler - this might
 > change in a subsequent revision.
- 
-Variables are initially undefined and thus cannot be fetched without a
-runtime error occurring until a value is placed into them. If a variable
-has been annotated with an optional type, its initial value will be
-nothing.
 
-> **Note:** It is a checked runtime error to attempt to use a
-> non-optionally typed variable before it has a value.
- 
+Variables whose type have a default value are initialized with that value at
+the point of definition in the handler. See the main Variables section for the
+defaults of the standard types.
+
+> **Note:** It is a checked runtime error to attempt to use a variable whose
+> type has no default before it is assigned a value.
+
 The type specification for the variable is optional, if it is not
 specified the type of the variable is *optional any* meaning that it can
 hold any value, including being nothing.
@@ -583,7 +602,7 @@ evaluates to a negative integer, it is taken to be zero.
 
 > **Note:** It is a checked runtime error to use an expression not
 > evaluating to a number as the Count.
- 
+
 The **repeat while** form repeats the body until the Condition
 expression evaluates to false.
 
@@ -595,7 +614,7 @@ expression evaluates to true.
 
 > **Note:** It is a checked runtime error to use an expression not
 > evaluating to a boolean as the Condition.
- 
+
 The **repeat with** form repeats the body until the Counter variable
 reaches or crosses (depending on iteration direction) the value of the
 Finish expression. The counter variable is adjusted by the value of the
@@ -606,7 +625,7 @@ statement.
 
 > **Note:** It is a checked runtime error to use expressions not
 > evaluating to a number as Start, Finish or Step.
- 
+
 The **repeat for each** form evaluates the Container expression, and
 then iterates through it in a custom manner depending on the Iterator
 syntax. For example:

--- a/docs/lcb/notes/17526.md
+++ b/docs/lcb/notes/17526.md
@@ -1,8 +1,34 @@
 # LiveCode Builder Language
-## Syntax
+## Lexical Scoping
 
-* handler-local variables are now lexically scoped within
-  statement blocks.
+* handler local variables are now lexically scoped. This means
+  variables are accessible from the point of definition to the
+  end of the block they are defined in.
+
+* each repeat control structure is considered a single block.
+
+* each separate block in an if/else if/else control structure
+  is considered a single block.
+
+* variables are reset (either to their default value, or
+  unassigned) at the point of the variable definition. In
+  particular, any variables defined within a repeat block are
+  reset on each iteration:
+
+   repeat 5 times
+      variable tVar as optional String
+      -- tVar is reset to "nothing" every time the loop runs
+   end repeat
+
+* variables in an inner block can now shadow those in an outer
+  block. For example, the following is valid:
+
+   variable tX as Array
+   repeat 5 times
+      variable tX as Number
+      repeat 4 times
+         variable tX as String
+      end repeat
+   end repeat
 
 # [17526] Make variables lexically scoped in statement blocks.
-

--- a/docs/lcb/notes/17526.md
+++ b/docs/lcb/notes/17526.md
@@ -1,0 +1,8 @@
+# LiveCode Builder Language
+## Syntax
+
+* handler-local variables are now lexically scoped within
+  statement blocks.
+
+# [17526] Make variables lexically scoped in statement blocks.
+

--- a/docs/lcb/notes/17809.md
+++ b/docs/lcb/notes/17809.md
@@ -1,0 +1,12 @@
+# LiveCode Builder Language
+## Variables
+
+* Out parameters are now initialized by default to a suitable empty value at the
+  start of the handler. For example:
+
+     public handler GetMyValue(out rValue as Integer)
+     end handler
+
+  Will result in rValue begin 0.
+
+# [17809] Initialize out parameters to default.

--- a/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
+++ b/extensions/widgets/gradientrampeditor/gradientrampeditor.lcb
@@ -493,6 +493,7 @@ private handler paintRampEditors() returns nothing
    put false into tHasSelected
    variable tStopIndex as Integer
    put 1 into tStopIndex
+   variable tSelStop as GradientStop
 
    variable tStop as GradientStop
    repeat for each element tStop in mGradientRamp
@@ -500,7 +501,6 @@ private handler paintRampEditors() returns nothing
       put the bottom of mGradientRectangle into tY
 
       if tStopIndex = mCurrentlySelectedStopIndex then
-         variable tSelStop as GradientStop
          put true into tHasSelected
          put  tStop into tSelStop
          add 1 to tStopIndex

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -272,7 +272,6 @@ enum MCScriptDefinitionKind
 	kMCScriptDefinitionKindEvent,
     kMCScriptDefinitionKindSyntax,
     kMCScriptDefinitionKindDefinitionGroup,
-	kMCScriptDefinitionKindContextVariable,
     
 	kMCScriptDefinitionKind__Last,
 };
@@ -284,14 +283,6 @@ enum MCScriptHandlerTypeParameterMode
     kMCScriptHandlerTypeParameterModeInOut,
     
     kMCScriptHandlerTypeParameterMode__Last
-};
-
-enum MCScriptHandlerScope
-{
-    kMCScriptHandlerScopeNormal,
-    kMCScriptHandlerScopeContext,
-    
-	kMCScriptHandlerScope__Last,
 };
 
 void MCScriptBeginModule(MCScriptModuleKind kind, MCNameRef name, MCScriptModuleBuilderRef& r_builder);
@@ -327,9 +318,8 @@ void MCScriptAddDefinitionToModule(MCScriptModuleBuilderRef builder, uindex_t& r
 void MCScriptAddTypeToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index);
 void MCScriptAddConstantToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t const_idx, uindex_t index);
 void MCScriptAddVariableToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index);
-void MCScriptAddContextVariableToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index, uindex_t def_index);
 
-void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef builder, MCScriptHandlerScope scope, MCNameRef name, uindex_t signature, uindex_t index);
+void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t signature, uindex_t index);
 void MCScriptAddParameterToHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t& r_index);
 void MCScriptAddVariableToHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t& r_index);
 void MCScriptEndHandlerInModule(MCScriptModuleBuilderRef builder);

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -366,6 +366,7 @@ void MCScriptContinueInvokeInModule(MCScriptModuleBuilderRef builder, uindex_t a
 void MCScriptEndInvokeInModule(MCScriptModuleBuilderRef builder);
 void MCScriptEmitFetchInModule(MCScriptModuleBuilderRef builder, uindex_t dst_reg, uindex_t index, uindex_t level);
 void MCScriptEmitStoreInModule(MCScriptModuleBuilderRef builder, uindex_t src_reg, uindex_t index, uindex_t level);
+void MCScriptEmitResetInModule(MCScriptModuleBuilderRef builder, uindex_t reg);
 
 void MCScriptEmitPositionInModule(MCScriptModuleBuilderRef builder, MCNameRef file, uindex_t line);
 

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1532,6 +1532,14 @@ void MCScriptEmitStoreInModule(MCScriptModuleBuilderRef self, uindex_t p_src_reg
         __emit_instruction(self, kMCScriptBytecodeOpStore, 3, p_src_reg, p_index, p_level - 1);
 }
 
+void MCScriptEmitResetInModule(MCScriptModuleBuilderRef self, uindex_t p_reg)
+{
+    if (self == nil || !self -> valid)
+        return;
+    
+    __emit_instruction(self, kMCScriptBytecodeOpReset, 1, p_reg);
+}
+
 void MCScriptEmitPositionInModule(MCScriptModuleBuilderRef self, MCNameRef p_file, uindex_t p_line)
 {
     if (self == nil || !self -> valid)

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -438,29 +438,6 @@ void MCScriptAddVariableToModule(MCScriptModuleBuilderRef self, MCNameRef p_name
     t_definition -> type = p_type;
 }
 
-void MCScriptAddContextVariableToModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, uindex_t p_def_index, uindex_t p_index)
-{
-    if (self == nil || !self -> valid)
-        return;
-    
-    if (p_index >= self -> module . definition_count ||
-        self -> module . definitions[p_index] != nil ||
-        !MCMemoryNew((MCScriptContextVariableDefinition*&)self -> module . definitions[p_index]))
-    {
-        self -> valid = false;
-        return;
-    }
-    
-    __assign_definition_name(self, p_index, p_name);
-    
-    MCScriptContextVariableDefinition *t_definition;
-    t_definition = static_cast<MCScriptContextVariableDefinition *>(self -> module . definitions[p_index]);
-    
-    t_definition -> kind = kMCScriptDefinitionKindContextVariable;
-    t_definition -> type = p_type;
-    t_definition -> default_value = p_def_index;
-}
-
 void MCScriptAddForeignHandlerToModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_signature, MCStringRef p_binding, uindex_t p_index)
 {
     if (self == nil || !self -> valid)
@@ -1201,7 +1178,7 @@ static void __emit_position(MCScriptModuleBuilderRef self, uindex_t p_address, u
     self -> module . positions[t_pindex] . line = p_line;
 }
 
-void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCScriptHandlerScope p_scope, MCNameRef p_name, uindex_t p_type, uindex_t p_index)
+void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, uindex_t p_index)
 {
     if (self == nil || !self -> valid)
         return;
@@ -1222,7 +1199,6 @@ void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCScriptHandler
     t_definition -> kind = kMCScriptDefinitionKindHandler;
     t_definition -> type = p_type;
     t_definition -> start_address = self -> module . bytecode_count;
-    t_definition -> scope = p_scope;
     
     self -> current_handler = p_index;
     self -> current_param_count = 0;
@@ -1296,10 +1272,10 @@ void MCScriptEndHandlerInModule(MCScriptModuleBuilderRef self)
         
         __emit_position(self, t_pos_address_offset + t_address, self -> instructions[i] . file, self -> instructions[i] . line);
         
-        __emit_bytecode_byte(self, t_op | (MCMin(t_arity, 15U) << 4));
+        __emit_bytecode_byte(self, (uint8_t)(t_op | (MCMin(t_arity, 15U) << 4)));
         
         if (t_arity >= 15U)
-            __emit_bytecode_byte(self, t_arity - 15U);
+            __emit_bytecode_byte(self, uint8_t(t_arity - 15U));
         
         for(uindex_t j = 0; j < t_arity; j++)
             __emit_bytecode_uint(self, t_operands[j]);

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -242,102 +242,226 @@ MCScriptModuleRef MCScriptGetModuleOfInstance(MCScriptInstanceRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCHandlerTypeInfoConformsToPropertyGetter(MCTypeInfoRef typeinfo)
+MCScriptVariableDefinition *MCScriptDefinitionAsVariable(MCScriptDefinition *self)
+{
+    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindVariable,
+                            "definition not a variable");
+    return static_cast<MCScriptVariableDefinition *>(self);
+}
+
+MCScriptHandlerDefinition *MCScriptDefinitionAsHandler(MCScriptDefinition *self)
+{
+    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindHandler,
+                       "definition not a handler");
+    return static_cast<MCScriptHandlerDefinition *>(self);
+}
+
+MCScriptForeignHandlerDefinition *MCScriptDefinitionAsForeignHandler(MCScriptDefinition *self)
+{
+    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindForeignHandler,
+                       "definition not a foreign handler");
+    return static_cast<MCScriptForeignHandlerDefinition *>(self);
+}
+
+MCScriptDefinitionGroupDefinition *MCScriptDefinitionAsDefinitionGroup(MCScriptDefinition *self)
+{
+    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindDefinitionGroup,
+                       "definition not a definition group");
+    return static_cast<MCScriptDefinitionGroupDefinition *>(self);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+static bool MCHandlerTypeInfoConformsToPropertyGetter(MCTypeInfoRef typeinfo)
 {
     return MCHandlerTypeInfoGetParameterCount(typeinfo) == 0 &&
             MCHandlerTypeInfoGetReturnType(typeinfo) != kMCNullTypeInfo;
 }
 
-bool MCHandlerTypeInfoConformsToPropertySetter(MCTypeInfoRef typeinfo)
+static bool MCHandlerTypeInfoConformsToPropertySetter(MCTypeInfoRef typeinfo)
 {
     return MCHandlerTypeInfoGetParameterCount(typeinfo) == 1 &&
             MCHandlerTypeInfoGetParameterMode(typeinfo, 0) == kMCHandlerTypeFieldModeIn;
 }
 
-///////////
+////////////////////////////////////////////////////////////////////////////////
+//
+//  ERROR PROPAGATORS
+//
 
-bool MCScriptThrowAttemptToSetReadOnlyPropertyError(MCScriptModuleRef p_module, MCNameRef p_property)
+static bool MCScriptThrowAttemptToSetReadOnlyPropertyError(MCScriptModuleRef p_module, MCNameRef p_property)
 {
-    return MCErrorCreateAndThrow(kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo, "module", p_module -> name, "property", p_property, nil);
+    return MCErrorCreateAndThrow(kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "property",
+                                    p_property,
+                                    nil);
 }
 
-bool MCScriptThrowInvalidValueForPropertyError(MCScriptModuleRef p_module, MCNameRef p_property, MCTypeInfoRef p_expected_type, MCValueRef p_value)
+static bool MCScriptThrowInvalidValueForPropertyError(MCScriptModuleRef p_module, MCNameRef p_property, MCTypeInfoRef p_expected_type, MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptInvalidPropertyValueErrorTypeInfo, "module", p_module -> name, "property", p_property, "type", MCNamedTypeInfoGetName(p_expected_type), "value", p_value, nil);
+    return MCErrorCreateAndThrow(kMCScriptInvalidPropertyValueErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "property",
+                                    p_property,
+                                    "type",
+                                    MCNamedTypeInfoGetName(p_expected_type),
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowInvalidValueForResultError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, MCTypeInfoRef p_expected_type, MCValueRef p_value)
+static bool MCScriptThrowInvalidValueForResultError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, MCTypeInfoRef p_expected_type, MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptInvalidReturnValueErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_handler), "type", MCNamedTypeInfoGetName(p_expected_type), "value", p_value, nil);
+    return MCErrorCreateAndThrow(kMCScriptInvalidReturnValueErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_handler),
+                                    "type",
+                                    MCNamedTypeInfoGetName(p_expected_type),
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowInParameterNotDefinedError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index)
+static bool MCScriptThrowInParameterNotDefinedError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index)
 {
-    return MCErrorCreateAndThrow(kMCScriptInParameterNotDefinedErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_handler), "parameter", MCScriptGetNameOfParameterInModule(p_module, p_handler, p_index), nil);
+    return MCErrorCreateAndThrow(kMCScriptInParameterNotDefinedErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_handler),
+                                    "parameter",
+                                    MCScriptGetNameOfParameterInModule(p_module, p_handler, p_index),
+                                    nil);
 }
 
-bool MCScriptThrowOutParameterNotDefinedError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index)
+static bool MCScriptThrowOutParameterNotDefinedError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index)
 {
-    return MCErrorCreateAndThrow(kMCScriptOutParameterNotDefinedErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_handler), "parameter", MCScriptGetNameOfParameterInModule(p_module, p_handler, p_index), nil);
+    return MCErrorCreateAndThrow(kMCScriptOutParameterNotDefinedErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_handler),
+                                    "parameter",
+                                    MCScriptGetNameOfParameterInModule(p_module, p_handler, p_index),
+                                    nil);
 }
 
-bool MCScriptThrowLocalVariableUsedBeforeDefinedError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index)
+static bool MCScriptThrowLocalVariableUsedBeforeDefinedError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index)
 {
-    return MCErrorCreateAndThrow(kMCScriptVariableUsedBeforeDefinedErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_handler), "variable", MCScriptGetNameOfLocalVariableInModule(p_module, p_handler, p_index), nil);
+    return MCErrorCreateAndThrow(kMCScriptVariableUsedBeforeDefinedErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_handler),
+                                    "variable",
+                                    MCScriptGetNameOfLocalVariableInModule(p_module, p_handler, p_index),
+                                    nil);
 }
 
-bool MCScriptThrowGlobalVariableUsedBeforeDefinedError(MCScriptModuleRef p_module, uindex_t p_index)
+static bool MCScriptThrowGlobalVariableUsedBeforeDefinedError(MCScriptModuleRef p_module, MCScriptVariableDefinition *p_definition)
 {
-    return MCErrorCreateAndThrow(kMCScriptVariableUsedBeforeDefinedErrorTypeInfo, "module", p_module -> name, "variable", MCScriptGetNameOfGlobalVariableInModule(p_module, p_index), nil);
+    return MCErrorCreateAndThrow(kMCScriptVariableUsedBeforeDefinedErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "variable",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_definition),
+                                    nil);
 }
 
-bool MCScriptThrowInvalidValueForLocalVariableError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index, MCTypeInfoRef p_expected_type, MCValueRef p_value)
+static bool MCScriptThrowInvalidValueForLocalVariableError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler, uindex_t p_index, MCTypeInfoRef p_expected_type, MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptInvalidVariableValueErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_handler), "variable", MCScriptGetNameOfLocalVariableInModule(p_module, p_handler, p_index), "type", MCNamedTypeInfoGetName(p_expected_type), "value", p_value, nil);
+    return MCErrorCreateAndThrow(kMCScriptInvalidVariableValueErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_handler),
+                                    "variable",
+                                    MCScriptGetNameOfLocalVariableInModule(p_module, p_handler, p_index),
+                                    "type",
+                                    MCNamedTypeInfoGetName(p_expected_type),
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowInvalidValueForGlobalVariableError(MCScriptModuleRef p_module, uindex_t p_index, MCTypeInfoRef p_expected_type, MCValueRef p_value)
+static bool MCScriptThrowInvalidValueForGlobalVariableError(MCScriptModuleRef p_module, MCScriptVariableDefinition *p_index, MCTypeInfoRef p_expected_type, MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptInvalidVariableValueErrorTypeInfo, "module", p_module -> name, "variable",  MCScriptGetNameOfGlobalVariableInModule(p_module, p_index), "type", MCNamedTypeInfoGetName(p_expected_type), "value", p_value, nil);
+    return MCErrorCreateAndThrow(kMCScriptInvalidVariableValueErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "variable",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_index),
+                                    "type",
+                                    MCNamedTypeInfoGetName(p_expected_type),
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowInvalidValueForContextVariableError(MCScriptModuleRef p_module, uindex_t p_index, MCTypeInfoRef p_expected_type, MCValueRef p_value)
+static bool MCScriptThrowNotABooleanError(MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptInvalidVariableValueErrorTypeInfo, "module", p_module -> name, "variable",  MCScriptGetNameOfContextVariableInModule(p_module, p_index), "type", MCNamedTypeInfoGetName(p_expected_type), "value", p_value, nil);
+    return MCErrorCreateAndThrow(kMCScriptNotABooleanValueErrorTypeInfo,
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowNotABooleanError(MCValueRef p_value)
+static bool MCScriptThrowNotAStringError(MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptNotABooleanValueErrorTypeInfo, "value", p_value, nil);
+	return MCErrorCreateAndThrow(kMCScriptNotAStringValueErrorTypeInfo,
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowNotAStringError(MCValueRef p_value)
-{
-	return MCErrorCreateAndThrow(kMCScriptNotAStringValueErrorTypeInfo, "value", p_value, nil);
-}
-
-bool MCScriptThrowWrongNumberOfArgumentsForInvokeError(MCScriptModuleRef p_module, MCScriptDefinition *p_definition, uindex_t p_provided)
+static bool MCScriptThrowWrongNumberOfArgumentsForInvokeError(MCScriptModuleRef p_module, MCScriptDefinition *p_definition, uindex_t p_provided)
 {
     // TODO: Encode provided / expected.
-    return MCErrorCreateAndThrow(kMCScriptWrongNumberOfArgumentsErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_definition), nil);
+    return MCErrorCreateAndThrow(kMCScriptWrongNumberOfArgumentsErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_definition),
+                                    nil);
 }
 
-bool MCScriptThrowInvalidValueForArgumentError(MCScriptModuleRef p_module, MCScriptDefinition *p_definition, uindex_t p_arg_index, MCTypeInfoRef p_expected_type, MCValueRef p_value)
+static bool MCScriptThrowInvalidValueForArgumentError(MCScriptModuleRef p_module, MCScriptDefinition *p_definition, uindex_t p_arg_index, MCTypeInfoRef p_expected_type, MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptInvalidArgumentValueErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_definition), "parameter", MCScriptGetNameOfParameterInModule(p_module, p_definition, p_arg_index), "type", MCNamedTypeInfoGetName(p_expected_type), "value", p_value, nil);
+    return MCErrorCreateAndThrow(kMCScriptInvalidArgumentValueErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_definition),
+                                    "parameter",
+                                    MCScriptGetNameOfParameterInModule(p_module, p_definition, p_arg_index),
+                                    "type",
+                                    MCNamedTypeInfoGetName(p_expected_type),
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowUnableToResolveForeignHandlerError(MCScriptModuleRef p_module, MCScriptDefinition *p_definition)
+static bool MCScriptThrowUnableToResolveForeignHandlerError(MCScriptModuleRef p_module, MCScriptDefinition *p_definition)
 {
-    return MCErrorCreateAndThrow(kMCScriptForeignHandlerBindingErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_definition), nil);
+    return MCErrorCreateAndThrow(kMCScriptForeignHandlerBindingErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    MCScriptGetNameOfDefinitionInModule(p_module, p_definition),
+                                    nil);
 }
 
-bool MCScriptThrowUnableToResolveTypeError(MCTypeInfoRef p_type)
+static bool MCScriptThrowUnableToResolveTypeError(MCTypeInfoRef p_type)
 {
     return MCErrorThrowUnboundType(p_type);
 }
 
-bool MCScriptThrowUnableToResolveMultiInvoke(MCScriptModuleRef p_module, MCScriptDefinition *p_definition, MCProperListRef p_arguments)
+static bool MCScriptThrowUnableToResolveMultiInvoke(MCScriptModuleRef p_module, MCScriptDefinition *p_definition, MCProperListRef p_arguments)
 {
     MCAutoListRef t_handlers;
     if (!MCListCreateMutable(',', &t_handlers))
@@ -377,60 +501,114 @@ bool MCScriptThrowUnableToResolveMultiInvoke(MCScriptModuleRef p_module, MCScrip
         !MCListCopyAsString(*t_types, &t_type_list))
         return false;
     
-    return MCErrorCreateAndThrow(kMCScriptNoMatchingHandlerErrorTypeInfo, "handlers", *t_handler_list, "types", *t_type_list, nil);
+    return MCErrorCreateAndThrow(kMCScriptNoMatchingHandlerErrorTypeInfo,
+                                    "handlers",
+                                    *t_handler_list,
+                                    "types",
+                                    *t_type_list,
+                                    nil);
 }
 
-bool MCScriptThrowNotAHandlerValueError(MCValueRef p_value)
+static bool MCScriptThrowNotAHandlerValueError(MCValueRef p_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptNotAHandlerValueErrorTypeInfo, "value", p_value, nil);
+    return MCErrorCreateAndThrow(kMCScriptNotAHandlerValueErrorTypeInfo,
+                                    "value",
+                                    p_value,
+                                    nil);
 }
 
-bool MCScriptThrowCannotCallContextHandlerError(MCScriptModuleRef p_module, MCScriptDefinition *p_handler)
+static bool MCScriptThrowHandlerNotFoundError(MCScriptModuleRef p_module, MCNameRef p_handler)
 {
-    return MCErrorCreateAndThrow(kMCScriptCannotCallContextHandlerErrorTypeInfo, "module", p_module -> name, "handler", MCScriptGetNameOfDefinitionInModule(p_module, p_handler), nil);
+    return MCErrorCreateAndThrow(kMCScriptHandlerNotFoundErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "handler",
+                                    p_handler,
+                                    nil);
 }
 
-bool MCScriptThrowHandlerNotFoundError(MCScriptModuleRef p_module, MCNameRef p_handler)
+static bool MCScriptThrowPropertyNotFoundError(MCScriptModuleRef p_module, MCNameRef p_property)
 {
-    return MCErrorCreateAndThrow(kMCScriptHandlerNotFoundErrorTypeInfo, "module", p_module -> name, "handler", p_handler, nil);
+    return MCErrorCreateAndThrow(kMCScriptPropertyNotFoundErrorTypeInfo,
+                                    "module",
+                                    p_module -> name,
+                                    "property",
+                                    p_property,
+                                    nil);
 }
 
-bool MCScriptThrowPropertyNotFoundError(MCScriptModuleRef p_module, MCNameRef p_property)
+////////////////////////////////////////////////////////////////////////////////
+//
+//  INSTANCE AND MODULE MANIPULATION
+//
+
+static bool
+MCScriptCheckedFetchFromVariableInInstance(MCScriptInstanceRef self,
+                                           MCScriptVariableDefinition *p_definition,
+                                           MCValueRef& r_value)
 {
-    return MCErrorCreateAndThrow(kMCScriptPropertyNotFoundErrorTypeInfo, "module", p_module -> name, "property", p_property, nil);
+    MCValueRef t_value;
+    t_value = self -> slots[p_definition -> slot_index];
+    
+    if (t_value == kMCNull &&
+        !MCTypeInfoIsOptional(self -> module -> types[p_definition -> type] -> typeinfo))
+        return MCScriptThrowGlobalVariableUsedBeforeDefinedError(self -> module,
+                                                                 p_definition);
+    
+    r_value = t_value;
+    
+    return true;
 }
 
-///////////
-
-MCScriptVariableDefinition *MCScriptDefinitionAsVariable(MCScriptDefinition *self)
+static bool
+MCScriptCheckedStoreToVariableInInstance(MCScriptInstanceRef self,
+                                         MCScriptVariableDefinition *p_definition,
+                                         MCValueRef p_value)
 {
-    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindVariable,
-                            "definition not a variable");
-    return static_cast<MCScriptVariableDefinition *>(self);
+    MCTypeInfoRef t_output_type;
+    t_output_type = self -> module -> types[p_definition -> type] -> typeinfo;
+    
+    if (!MCTypeInfoConforms(MCValueGetTypeInfo(p_value), t_output_type))
+        return MCScriptThrowInvalidValueForGlobalVariableError(self -> module,
+                                                               p_definition,
+                                                               t_output_type,
+                                                               p_value);
+    
+    MCValueAssign(self -> slots[p_definition -> slot_index], p_value);
+    
+    return true;
 }
 
-MCScriptHandlerDefinition *MCScriptDefinitionAsHandler(MCScriptDefinition *self)
+static inline
+void MCScriptResolveDefinitionInInstance(MCScriptInstanceRef self,
+                                         uindex_t p_index,
+                                         MCScriptInstanceRef& r_instance,
+                                         MCScriptDefinition*& r_definition)
 {
-    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindHandler,
-                       "definition not a handler");
-    return static_cast<MCScriptHandlerDefinition *>(self);
+    MCScriptDefinition *t_definition;
+    t_definition = self -> module -> definitions[p_index];
+    
+    MCScriptInstanceRef t_instance;
+    if (t_definition -> kind != kMCScriptDefinitionKindExternal)
+    {
+        t_instance = self;
+    }
+    else
+    {
+        MCScriptExternalDefinition *t_ext_def;
+        t_ext_def = static_cast<MCScriptExternalDefinition *>(t_definition);
+        
+        MCScriptImportedDefinition *t_import_def;
+        t_import_def = &self -> module -> imported_definitions[t_ext_def -> index];
+        
+        t_instance = t_import_def -> resolved_module -> shared_instance;
+        t_definition = t_import_def -> resolved_definition;
+    }
+    
+    r_instance = t_instance;
+    r_definition = t_definition;
 }
-
-MCScriptForeignHandlerDefinition *MCScriptDefinitionAsForeignHandler(MCScriptDefinition *self)
-{
-    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindForeignHandler,
-                       "definition not a foreign handler");
-    return static_cast<MCScriptForeignHandlerDefinition *>(self);
-}
-
-MCScriptDefinitionGroupDefinition *MCScriptDefinitionAsDefinitionGroup(MCScriptDefinition *self)
-{
-    __MCScriptAssert__(self -> kind == kMCScriptDefinitionKindDefinitionGroup,
-                       "definition not a definition group");
-    return static_cast<MCScriptDefinitionGroupDefinition *>(self);
-}
-
-///////////
+////////////////////////////////////////////////////////////////////////////////
 
 bool MCScriptGetPropertyOfInstance(MCScriptInstanceRef self, MCNameRef p_property, MCValueRef& r_value)
 {
@@ -457,15 +635,14 @@ bool MCScriptGetPropertyOfInstance(MCScriptInstanceRef self, MCNameRef p_propert
         MCScriptVariableDefinition *t_variable_def;
         t_variable_def = MCScriptDefinitionAsVariable(t_getter);
         
-        // Variables are backed by an slot in the instance.
-        uindex_t t_slot_index;
-        t_slot_index = t_variable_def -> slot_index;
+        MCValueRef t_value;
+        if (!MCScriptCheckedFetchFromVariableInInstance(self,
+                                                        t_variable_def,
+                                                        t_value))
+            return false;
         
-        /* COMPUTE CHECK */ __MCScriptAssert__(t_slot_index < self -> module -> slot_count,
-                                               "computed variable slot out of range");
-        
-        // Slot based properties are easy, we just copy the value out of the slot.
-        r_value = MCValueRetain(self -> slots[t_slot_index]);
+        // Copy the value out
+        r_value = MCValueRetain(t_value);
     }
     else if (t_getter -> kind == kMCScriptDefinitionKindHandler)
     {
@@ -525,19 +702,11 @@ bool MCScriptSetPropertyOfInstance(MCScriptInstanceRef self, MCNameRef p_propert
         if (!MCTypeInfoConforms(MCValueGetTypeInfo(p_value), t_type))
             return MCScriptThrowInvalidValueForPropertyError(self -> module, p_property, t_type, p_value);
         
-        // Variables are backed by an slot in the instance.
-        uindex_t t_slot_index;
-        t_slot_index = t_variable_def -> slot_index;
-        
-        /* COMPUTE CHECK */ __MCScriptAssert__(t_slot_index < self -> module -> slot_count,
-                                               "computed variable slot out of range");
-        
-        // If the value of the slot isn't changing, assign our new value.
-        if (p_value != self -> slots[t_slot_index])
-        {
-            MCValueRelease(self -> slots[t_slot_index]);
-            self -> slots[t_slot_index] = MCValueRetain(p_value);
-        }
+        // Store the value
+        if (!MCScriptCheckedStoreToVariableInInstance(self,
+                                                      t_variable_def,
+                                                      p_value))
+            return false;
     }
     else if (t_setter -> kind == kMCScriptDefinitionKindHandler)
     {
@@ -578,11 +747,6 @@ static bool MCScriptCallHandlerOfInstanceDirect(MCScriptInstanceRef self, MCScri
     // Get the signature of the handler.
     MCTypeInfoRef t_signature;
     t_signature = self -> module -> types[p_handler -> type] -> typeinfo;
-    
-    // If the handler is of context scope, then we cannot call it directly - only
-    // from a LCB frame.
-    if (p_handler -> scope == kMCScriptHandlerScopeContext)
-        return MCScriptThrowCannotCallContextHandlerError(self -> module, p_handler);
     
     // Check the number of arguments.
     uindex_t t_required_param_count;
@@ -684,14 +848,14 @@ struct MCScriptFrame
 	uindex_t *mapping;
 };
 
-static inline bool MCScriptIsRegisterValidInFrame(MCScriptFrame *p_frame, int p_register)
+static inline bool MCScriptIsRegisterValidInFrame(MCScriptFrame *p_frame, uindex_t p_register)
 {
-    return p_register >= 0 && p_register < p_frame -> handler -> slot_count;
+    return p_register < p_frame -> handler -> slot_count;
 }
 
-static inline bool MCScriptIsConstantValidInFrame(MCScriptFrame *p_frame, int p_constant)
+static inline bool MCScriptIsConstantValidInFrame(MCScriptFrame *p_frame, uindex_t p_constant)
 {
-    return p_constant >= 0 && p_constant < p_frame -> instance -> module -> value_count;
+    return p_constant < p_frame -> instance -> module -> value_count;
 }
 
 static inline MCTypeInfoRef MCScriptGetSignatureForFrame(MCScriptFrame *p_frame)
@@ -834,7 +998,7 @@ static MCScriptFrame *MCScriptDestroyFrame(MCScriptFrame *self)
     MCScriptFrame *t_caller;
     t_caller = self -> caller;
     
-    for(int i = 0; i < self -> handler -> slot_count; i++)
+    for(uindex_t i = 0; i < self -> handler -> slot_count; i++)
         MCValueRelease(self -> slots[i]);
     
     MCScriptReleaseInstance(self -> instance);
@@ -885,31 +1049,7 @@ static inline uindex_t MCScriptBytecodeDecodeArgument(byte_t*& x_bytecode_ptr)
     return t_value;
 }
 
-static inline void MCScriptResolveDefinitionInFrame(MCScriptFrame *p_frame, uindex_t p_index, MCScriptInstanceRef& r_instance, MCScriptDefinition*& r_definition)
-{
-    MCScriptInstanceRef t_instance;
-    t_instance = p_frame -> instance;
-    
-    MCScriptDefinition *t_definition;
-    t_definition = t_instance -> module -> definitions[p_index];
-    
-    if (t_definition -> kind == kMCScriptDefinitionKindExternal)
-    {
-        MCScriptExternalDefinition *t_ext_def;
-        t_ext_def = static_cast<MCScriptExternalDefinition *>(t_definition);
-        
-        MCScriptImportedDefinition *t_import_def;
-        t_import_def = &t_instance -> module -> imported_definitions[t_ext_def -> index];
-        
-        t_instance = t_import_def -> resolved_module -> shared_instance;
-        t_definition = t_import_def -> resolved_definition;
-    }
-
-    r_instance = t_instance;
-    r_definition = t_definition;
-}
-
-static inline MCTypeInfoRef MCScriptGetRegisterTypeInFrame(MCScriptFrame *p_frame, int p_register)
+static inline MCTypeInfoRef MCScriptGetRegisterTypeInFrame(MCScriptFrame *p_frame, uindex_t p_register)
 {
     /* LOAD CHECK */ __MCScriptAssert__(MCScriptIsRegisterValidInFrame(p_frame, p_register),
                                         "register out of range on fetch register type");
@@ -929,7 +1069,7 @@ static inline MCTypeInfoRef MCScriptGetRegisterTypeInFrame(MCScriptFrame *p_fram
     return nil;
 }
 
-static bool MCScriptGetRegisterTypeIsOptionalInFrame(MCScriptFrame *p_frame, int p_register)
+static bool MCScriptGetRegisterTypeIsOptionalInFrame(MCScriptFrame *p_frame, uindex_t p_register)
 {
     /* LOAD CHECK */ __MCScriptAssert__(MCScriptIsRegisterValidInFrame(p_frame, p_register),
                                         "register out of range on fetch register type is optional");
@@ -947,7 +1087,7 @@ static bool MCScriptGetRegisterTypeIsOptionalInFrame(MCScriptFrame *p_frame, int
     return t_resolved_type . is_optional;
 }
 
-static inline MCValueRef MCScriptFetchFromRegisterInFrame(MCScriptFrame *p_frame, int p_register)
+static inline MCValueRef MCScriptFetchFromRegisterInFrame(MCScriptFrame *p_frame, uindex_t p_register)
 {
     /* LOAD CHECK */ __MCScriptAssert__(MCScriptIsRegisterValidInFrame(p_frame, p_register),
                                         "register out of range on fetch");
@@ -955,7 +1095,7 @@ static inline MCValueRef MCScriptFetchFromRegisterInFrame(MCScriptFrame *p_frame
     return p_frame -> slots[p_register];
 }
 
-static inline void MCScriptStoreToRegisterInFrameAndRelease(MCScriptFrame *p_frame, int p_register, MCValueRef p_value)
+static inline void MCScriptStoreToRegisterInFrameAndRelease(MCScriptFrame *p_frame, uindex_t p_register, MCValueRef p_value)
 {
     /* LOAD CHECK */ __MCScriptAssert__(MCScriptIsRegisterValidInFrame(p_frame, p_register),
                                         "register out of range on store");
@@ -967,7 +1107,7 @@ static inline void MCScriptStoreToRegisterInFrameAndRelease(MCScriptFrame *p_fra
     }
 }
 
-static inline void MCScriptStoreToRegisterInFrame(MCScriptFrame *p_frame, int p_register, MCValueRef p_value)
+static inline void MCScriptStoreToRegisterInFrame(MCScriptFrame *p_frame, uindex_t p_register, MCValueRef p_value)
 {
     /* LOAD CHECK */ __MCScriptAssert__(MCScriptIsRegisterValidInFrame(p_frame, p_register),
                        "register out of range on store");
@@ -979,7 +1119,7 @@ static inline void MCScriptStoreToRegisterInFrame(MCScriptFrame *p_frame, int p_
     }
 }
 
-static bool MCScriptCheckedFetchFromRegisterInFrame(MCScriptFrame *p_frame, int p_register, MCValueRef& r_value)
+static bool MCScriptCheckedFetchFromRegisterInFrame(MCScriptFrame *p_frame, uindex_t p_register, MCValueRef& r_value)
 {
     MCValueRef t_value;
     t_value = MCScriptFetchFromRegisterInFrame(p_frame, p_register);
@@ -993,7 +1133,7 @@ static bool MCScriptCheckedFetchFromRegisterInFrame(MCScriptFrame *p_frame, int 
     return true;
 }
 
-static bool MCScriptCheckedStoreToRegisterInFrame(MCScriptFrame *p_frame, int p_register, MCValueRef p_value)
+static bool MCScriptCheckedStoreToRegisterInFrame(MCScriptFrame *p_frame, uindex_t p_register, MCValueRef p_value)
 {
     MCTypeInfoRef t_type;
     t_type = MCScriptGetRegisterTypeInFrame(p_frame, p_register);
@@ -1007,7 +1147,7 @@ static bool MCScriptCheckedStoreToRegisterInFrame(MCScriptFrame *p_frame, int p_
     return true;
 }
 
-static inline MCValueRef MCScriptFetchConstantInFrame(MCScriptFrame *p_frame, int p_index)
+static inline MCValueRef MCScriptFetchConstantInFrame(MCScriptFrame *p_frame, uindex_t p_index)
 {
     /* LOAD CHECK */ __MCScriptAssert__(MCScriptIsConstantValidInFrame(p_frame, p_index),
                        "constant out of range on fetch");
@@ -1797,7 +1937,7 @@ static bool MCScriptPerformForeignInvoke(MCScriptFrame*& x_frame, MCScriptInstan
 
 static bool MCScriptPerformInvoke(MCScriptFrame*& x_frame, byte_t*& x_next_bytecode, MCScriptInstanceRef p_instance, MCScriptDefinition *p_handler, uindex_t *p_arguments, uindex_t p_arity)
 {
-    x_frame -> address = x_next_bytecode - x_frame -> instance -> module -> bytecode;
+    x_frame -> address = (uindex_t)(x_next_bytecode - x_frame -> instance -> module -> bytecode);
     
 	if (p_handler -> kind == kMCScriptDefinitionKindHandler)
 	{
@@ -1850,7 +1990,10 @@ static bool MCScriptPerformMultiInvoke(MCScriptFrame*& x_frame, byte_t*& x_next_
     {
         MCScriptInstanceRef t_instance;
         MCScriptDefinition *t_definition;
-        MCScriptResolveDefinitionInFrame(x_frame, t_group -> handlers[i], t_instance, t_definition);
+        MCScriptResolveDefinitionInInstance(x_frame -> instance,
+                                            t_group -> handlers[i],
+                                            t_instance,
+                                            t_definition);
         
         uindex_t t_type_index = 0;
         if (t_definition -> kind == kMCScriptDefinitionKindHandler)
@@ -1993,7 +2136,7 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
 		uindex_t t_arity;
         MCScriptBytecodeDecodeOp(t_next_bytecode, t_op, t_arity);
 		
-		for(int i = 0; i < t_arity; i++)
+		for(uindex_t i = 0; i < t_arity; i++)
 			t_arguments[i] = MCScriptBytecodeDecodeArgument(t_next_bytecode);
 		
         switch(t_op)
@@ -2196,7 +2339,10 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                 
 				MCScriptInstanceRef t_instance;
                 MCScriptDefinition *t_definition;
-                MCScriptResolveDefinitionInFrame(t_frame, t_index, t_instance, t_definition);
+                MCScriptResolveDefinitionInInstance(t_frame -> instance,
+                                                    t_index,
+                                                    t_instance,
+                                                    t_definition);
 
                 if (t_definition -> kind != kMCScriptDefinitionKindDefinitionGroup)
                     t_success = MCScriptPerformInvoke(t_frame, t_next_bytecode, t_instance, t_definition, t_result_then_args, t_result_then_arg_count);
@@ -2257,7 +2403,7 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                     if (t_success)
                         t_success = MCMemoryNewArray(t_arg_count, t_linear_args);
                 
-                    for(int i = 0; t_success && i < t_arg_count; i++)
+                    for(uindex_t i = 0; t_success && i < t_arg_count; i++)
                         t_success = MCScriptCheckedFetchFromRegisterInFrame(t_frame, t_arg_regs[i], t_linear_args[i]);
                 
                     MCValueRef t_result;
@@ -2305,66 +2451,34 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                 t_dst = t_arguments[0];
                 t_index = t_arguments[1];
                 
-				MCScriptInstanceRef t_instance;
+                MCScriptInstanceRef t_instance;
                 MCScriptDefinition *t_definition;
-                MCScriptResolveDefinitionInFrame(t_frame, t_index, t_instance, t_definition);
+                MCScriptResolveDefinitionInInstance(t_frame -> instance,
+                                                    t_index,
+                                                    t_instance,
+                                                    t_definition);
                 
                 // Fetch the value:
                 //   - variables get fetched from the slot
                 //   - constants from the constant pool
                 //   - handlers have a value constructed
+                MCValueRef t_value;
                 if (t_definition -> kind == kMCScriptDefinitionKindVariable)
                 {
-                    MCScriptVariableDefinition *t_var_definition;
-                    t_var_definition = static_cast<MCScriptVariableDefinition *>(t_definition);
+                    MCScriptVariableDefinition *t_variable_definition;
+                    t_variable_definition = static_cast<MCScriptVariableDefinition *>(t_definition);
                     
-                    MCValueRef t_value;
-                    t_value = t_instance -> slots[t_var_definition -> slot_index];
-                
-                    if (t_value == kMCNull &&
-                        !MCTypeInfoIsOptional(t_instance -> module -> types[t_var_definition -> type] -> typeinfo))
-                        t_success = MCScriptThrowGlobalVariableUsedBeforeDefinedError(t_frame -> instance -> module, t_index);
+                    t_success = MCScriptCheckedFetchFromVariableInInstance(t_frame -> instance,
+                                                                           t_variable_definition,
+                                                                           t_value);
                     
-                    if (t_success)
-                        t_success = MCScriptCheckedStoreToRegisterInFrame(t_frame, t_dst, t_value);
                 }
                 else if (t_definition -> kind == kMCScriptDefinitionKindConstant)
                 {
                     MCScriptConstantDefinition *t_constant_definition;
                     t_constant_definition = static_cast<MCScriptConstantDefinition *>(t_definition);
                     
-                    MCValueRef t_value;
                     t_value = t_instance -> module -> values[t_constant_definition -> value];
-                    
-                    if (t_success)
-                        t_success = MCScriptCheckedStoreToRegisterInFrame(t_frame, t_dst, t_value);
-                }
-                else if (t_definition -> kind == kMCScriptDefinitionKindContextVariable)
-                {
-                    MCScriptContextVariableDefinition *t_var_definition;
-                    t_var_definition = static_cast<MCScriptContextVariableDefinition *>(t_definition);
-                    
-                    // If we are a normal handler we use the current frame.
-                    // If we are context handler, we use the caller's frame.
-                    MCScriptFrame *t_target_frame = nil;
-                    if (t_frame -> handler -> scope == kMCScriptHandlerScopeNormal)
-                        t_target_frame = t_frame;
-                    else if (t_frame -> caller != nil)
-                        t_target_frame = t_frame -> caller;
-                    else
-                        __MCScriptUnreachable__("cannot determine context variable target frame");
-                    
-                    // If there is no context table, or the value of the slot at the given
-                    // index is nil then we use the default.
-                    MCValueRef t_value;
-                    if (t_target_frame -> context == nil ||
-                        t_target_frame -> context -> count < t_var_definition -> slot_index ||
-                        t_target_frame -> context -> slots[t_var_definition -> slot_index] == nil)
-                        t_value = t_instance -> module -> values[t_var_definition -> default_value];
-                    else
-                        t_value = t_target_frame -> context -> slots[t_var_definition -> slot_index];
-                    
-                    t_success = MCScriptCheckedStoreToRegisterInFrame(t_target_frame, t_dst, t_value);
                 }
                 else if (t_definition -> kind == kMCScriptDefinitionKindHandler ||
                          t_definition -> kind == kMCScriptDefinitionKindForeignHandler)
@@ -2377,11 +2491,18 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                     // previously created one. These MCHandlerRefs are retained
                     // on a per-instance basis. Unbindable foreign handlers are
                     // returned as nil.
-                    MCHandlerRef t_value;
-                    t_success = MCScriptEvaluateHandlerOfInstanceInternal(t_instance, t_handler_definition, t_value);
-                    if (t_success)
-                        t_success = MCScriptCheckedStoreToRegisterInFrame(t_frame, t_dst, t_value != nil ? (MCValueRef)t_value : kMCNull);
+                    MCHandlerRef t_handler_value;
+                    if (MCScriptEvaluateHandlerOfInstanceInternal(t_instance, t_handler_definition, t_handler_value))
+                    {
+                        if (t_handler_value != nil)
+                            t_value = t_handler_value;
+                        else
+                            t_value = kMCNull;
+                    }
                 }
+                
+                if (t_success)
+                    t_success = MCScriptCheckedStoreToRegisterInFrame(t_frame, t_dst, t_value);
             }
             break;
             case kMCScriptBytecodeOpStore:
@@ -2393,64 +2514,25 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
                 t_dst = t_arguments[0];
                 t_index = t_arguments[1];
                 
-				MCScriptInstanceRef t_instance;
+                MCScriptInstanceRef t_instance;
                 MCScriptDefinition *t_definition;
-                MCScriptResolveDefinitionInFrame(t_frame, t_index, t_instance, t_definition);
+                MCScriptResolveDefinitionInInstance(t_frame -> instance,
+                                                    t_index,
+                                                    t_instance,
+                                                    t_definition);
                 
                 MCValueRef t_value;
                 t_success = MCScriptCheckedFetchFromRegisterInFrame(t_frame, t_dst, t_value);
                 
                 if (t_definition -> kind == kMCScriptDefinitionKindVariable)
                 {
-                    MCScriptVariableDefinition *t_var_definition;
-                    t_var_definition = static_cast<MCScriptVariableDefinition *>(t_definition);
-                    
-                    MCTypeInfoRef t_output_type;
-                    t_output_type = t_instance -> module -> types[t_var_definition -> type] -> typeinfo;
-                    
-                    if (t_success &&
-                        !MCTypeInfoConforms(MCValueGetTypeInfo(t_value), t_output_type))
-                        t_success = MCScriptThrowInvalidValueForGlobalVariableError(t_frame -> instance -> module, t_index, t_output_type, t_value);
+                    MCScriptVariableDefinition *t_variable_definition;
+                    t_variable_definition = static_cast<MCScriptVariableDefinition *>(t_definition);
                     
                     if (t_success)
-                        MCValueAssign(t_instance -> slots[t_var_definition -> slot_index], t_value);
-                }
-                else if (t_definition -> kind == kMCScriptDefinitionKindContextVariable)
-                {
-                    MCScriptContextVariableDefinition *t_var_definition;
-                    t_var_definition = static_cast<MCScriptContextVariableDefinition *>(t_definition);
-                    
-                    MCTypeInfoRef t_output_type;
-                    t_output_type = t_instance -> module -> types[t_var_definition -> type] -> typeinfo;
-                    
-                    if (t_success &&
-                        !MCTypeInfoConforms(MCValueGetTypeInfo(t_value), t_output_type))
-                        t_success = MCScriptThrowInvalidValueForContextVariableError(t_frame -> instance -> module, t_index, t_output_type, t_value);
-                    
-                    // If we are a normal handler we use the current frame.
-                    // If we are context handler, we use the caller's frame.
-                    MCScriptFrame *t_target_frame = nil;
-                    if (t_frame -> handler -> scope == kMCScriptHandlerScopeNormal)
-                        t_target_frame = t_frame;
-                    else if (t_frame -> caller != nil)
-                        t_target_frame = t_frame -> caller;
-                    else
-	                    __MCScriptUnreachable__("cannot determine context variable target frame");
-                    
-                    if (t_success &&
-                        (t_target_frame -> context == nil ||
-                         t_target_frame -> context -> count <= t_var_definition -> slot_index))
-                    {
-                        // Note that MCScriptFrameContext has an implement MCValueRef
-                        // so we don't need to adjust index to be a count.
-                        if (MCMemoryReallocate(t_target_frame -> context, sizeof(MCScriptFrameContext) + (sizeof(MCValueRef) * t_var_definition -> slot_index), t_target_frame -> context))
-                            t_target_frame -> context -> count = t_var_definition -> slot_index + 1;
-                        else
-                            t_success = false;
-                    }
-                    
-                    if (t_success)
-                        MCValueAssign(t_target_frame -> context -> slots[t_var_definition -> slot_index], t_value);
+                        t_success = MCScriptCheckedStoreToVariableInInstance(t_instance,
+                                                                             t_variable_definition,
+                                                                             t_value);
                 }
                 else
                     MCUnreachable();
@@ -2495,7 +2577,7 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
 					t_success = false;
 				}
 
-				for (int t_arg_ofs = 1; t_success && t_arg_ofs + 1 < t_arity; t_arg_ofs += 2)
+				for (uindex_t t_arg_ofs = 1; t_success && t_arg_ofs + 1 < t_arity; t_arg_ofs += 2)
 				{
 					MCValueRef t_raw_key, t_value;
 					MCNewAutoNameRef t_key;
@@ -2541,7 +2623,7 @@ bool MCScriptCallHandlerOfInstanceInternal(MCScriptInstanceRef self, MCScriptHan
         // If we failed, then make sure the frame address is up to date.
         if (!t_success)
         {
-            t_frame -> address = t_bytecode - t_frame -> instance -> module -> bytecode;
+            t_frame -> address = uindex_t(t_bytecode - t_frame -> instance -> module -> bytecode);
             break;
         }
         

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -1098,7 +1098,10 @@ MCNameRef MCScriptGetNameOfLocalVariableInModule(MCScriptModuleRef self, MCScrip
     if (p_index < t_type -> parameter_name_count)
         return t_type -> parameter_names[p_index];
     
-    return t_handler -> local_names[p_index - t_type -> parameter_name_count];
+    if (p_index - t_type -> parameter_name_count < t_handler -> local_name_count)
+        return t_handler -> local_names[p_index - t_type -> parameter_name_count];
+    
+    return kMCEmptyName;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -383,6 +383,11 @@ bool MCScriptValidateModule(MCScriptModuleRef self)
 		                    t_temporary_count = MCMax(t_temporary_count, t_operands[j] + 1);
 	                    }
 	                    break;
+                    case kMCScriptBytecodeOpReset:
+                        // create <reg_1>, ..., <reg_n>
+                        for(uindex_t j = 0; j < t_arity; j++)
+                            t_temporary_count = MCMax(t_temporary_count, t_operands[j] + 1);
+                        break;
                 }
             }
             

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -127,18 +127,12 @@ MC_PICKLE_BEGIN_RECORD(MCScriptVariableDefinition)
     MC_PICKLE_UINDEX(type)
 MC_PICKLE_END_RECORD()
 
-MC_PICKLE_BEGIN_RECORD(MCScriptContextVariableDefinition)
-    MC_PICKLE_UINDEX(type)
-    MC_PICKLE_UINDEX(default_value)
-MC_PICKLE_END_RECORD()
-
 MC_PICKLE_BEGIN_RECORD(MCScriptHandlerDefinition)
     MC_PICKLE_UINDEX(type)
     MC_PICKLE_ARRAY_OF_UINDEX(local_types, local_type_count)
     MC_PICKLE_ARRAY_OF_NAMEREF(local_names, local_name_count)
     MC_PICKLE_UINDEX(start_address)
     MC_PICKLE_UINDEX(finish_address)
-    MC_PICKLE_INTENUM(MCScriptHandlerScope, scope)
 MC_PICKLE_END_RECORD()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptForeignHandlerDefinition)
@@ -175,7 +169,6 @@ MC_PICKLE_BEGIN_VARIANT(MCScriptDefinition, kind)
     MC_PICKLE_VARIANT_CASE(kMCScriptDefinitionKindEvent, MCScriptEventDefinition)
     MC_PICKLE_VARIANT_CASE(kMCScriptDefinitionKindSyntax, MCScriptSyntaxDefinition)
     MC_PICKLE_VARIANT_CASE(kMCScriptDefinitionKindDefinitionGroup, MCScriptDefinitionGroupDefinition)
-    MC_PICKLE_VARIANT_CASE(kMCScriptDefinitionKindContextVariable, MCScriptContextVariableDefinition)
 MC_PICKLE_END_VARIANT()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptModule)
@@ -220,7 +213,6 @@ static MCStringRef __MCScriptDefinitionKindToString(MCScriptDefinitionKind p_kin
         case kMCScriptDefinitionKindEvent: return MCSTR("event");
         case kMCScriptDefinitionKindSyntax: return MCSTR("syntax");
         case kMCScriptDefinitionKindDefinitionGroup: return MCSTR("group");
-        case kMCScriptDefinitionKindContextVariable: return MCSTR("context variable");
         default:
             return MCSTR("unknown");
     }
@@ -275,30 +267,6 @@ bool MCScriptValidateModule(MCScriptModuleRef self)
             MCScriptVariableDefinition *t_variable;
             t_variable = static_cast<MCScriptVariableDefinition *>(self -> definitions[i]);
             t_variable -> slot_index = self -> slot_count++;
-        }
-        else if (self -> definitions[i] -> kind == kMCScriptDefinitionKindContextVariable)
-        {
-            MCScriptContextVariableDefinition *t_variable;
-            t_variable = static_cast<MCScriptContextVariableDefinition *>(self -> definitions[i]);
-            
-            uindex_t t_index;
-            t_index = UINDEX_MAX;
-            for(uindex_t i = 0; i < s_context_slot_count; i++)
-                if (s_context_slot_owners[i] == nil)
-                {
-                    t_index = i;
-                    break;
-                }
-
-            if (t_index == UINDEX_MAX)
-            {
-                if (!MCMemoryResizeArray(s_context_slot_count + 1, s_context_slot_owners, s_context_slot_count))
-                    return false; // oom
-                
-                t_index = s_context_slot_count - 1;
-            }
-            
-            s_context_slot_owners[t_index] = self;
         }
         else if (self -> definitions[i] -> kind == kMCScriptDefinitionKindHandler)
         {
@@ -373,16 +341,16 @@ bool MCScriptValidateModule(MCScriptModuleRef self)
                         // check index operand is within definition range
                         // check definition[index] is handler or definition group
                         // check signature of defintion[index] conforms with invoke arity
-                        for(uindex_t i = 1; i < t_arity; i++)
-                            t_temporary_count = MCMax(t_temporary_count, t_operands[i] + 1);
+                        for(uindex_t j = 1; j < t_arity; j++)
+                            t_temporary_count = MCMax(t_temporary_count, t_operands[j] + 1);
                         break;
                     case kMCScriptBytecodeOpInvokeIndirect:
                         // invoke *<src>, <result>, [ <arg_1>, ..., <arg_n> ]
                         if (t_arity < 2)
                             goto invalid_bytecode_error;
                         
-                        for(uindex_t i = 0; i < t_arity; i++)
-                            t_temporary_count = MCMax(t_temporary_count, t_operands[i] + 1);
+                        for(uindex_t j = 0; j < t_arity; j++)
+                            t_temporary_count = MCMax(t_temporary_count, t_operands[j] + 1);
                         break;
                     case kMCScriptBytecodeOpFetch:
                     case kMCScriptBytecodeOpStore:
@@ -400,8 +368,8 @@ bool MCScriptValidateModule(MCScriptModuleRef self)
                         if (t_arity < 1)
                             goto invalid_bytecode_error;
                         
-                        for(uindex_t i = 0; i < t_arity; i++)
-                            t_temporary_count = MCMax(t_temporary_count, t_operands[i] + 1);
+                        for(uindex_t j = 0; j < t_arity; j++)
+                            t_temporary_count = MCMax(t_temporary_count, t_operands[j] + 1);
                         break;
                     case kMCScriptBytecodeOpAssignArray:
 	                    // assignarray <dst>, [ <key_1>, <value_1>, ..., <key_n>, <value_n> ]
@@ -410,9 +378,9 @@ bool MCScriptValidateModule(MCScriptModuleRef self)
 	                    if (t_arity % 2 != 1) // parameters must come in pairs
 		                    goto invalid_bytecode_error;
 
-	                    for (uindex_t i = 0; i < t_arity; ++i)
+	                    for (uindex_t j = 0; j < t_arity; ++j)
 	                    {
-		                    t_temporary_count = MCMax(t_temporary_count, t_operands[i] + 1);
+		                    t_temporary_count = MCMax(t_temporary_count, t_operands[j] + 1);
 	                    }
 	                    break;
                 }
@@ -790,11 +758,11 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                 t_type = static_cast<MCScriptRecordType *>(self -> types[i]);
                 
                 MCAutoArray<MCRecordTypeFieldInfo> t_fields;
-                for(uindex_t i = 0; i < t_type -> field_count; i++)
+                for(uindex_t j = 0; j < t_type -> field_count; j++)
                 {
                     MCRecordTypeFieldInfo t_field;
-                    t_field . name = t_type -> fields[i] . name;
-                    t_field . type = self -> types[t_type -> fields[i] . type] -> typeinfo;
+                    t_field . name = t_type -> fields[j] . name;
+                    t_field . type = self -> types[t_type -> fields[j] . type] -> typeinfo;
                     if (!t_fields . Push(t_field))
 						goto error_cleanup; // oom
                 }
@@ -1131,20 +1099,6 @@ MCNameRef MCScriptGetNameOfLocalVariableInModule(MCScriptModuleRef self, MCScrip
         return t_type -> parameter_names[p_index];
     
     return t_handler -> local_names[p_index - t_type -> parameter_name_count];
-}
-
-MCNameRef MCScriptGetNameOfGlobalVariableInModule(MCScriptModuleRef self, uindex_t p_index)
-{
-    if (self -> definition_name_count > 0)
-        return self -> definition_names[p_index];
-    return kMCEmptyName;
-}
-
-MCNameRef MCScriptGetNameOfContextVariableInModule(MCScriptModuleRef self, uindex_t p_index)
-{
-    if (self -> definition_name_count > 0)
-        return self -> definition_names[p_index];
-    return kMCEmptyName;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -37,7 +37,6 @@ MCTypeInfoRef kMCScriptNoMatchingHandlerErrorTypeInfo;
 MCTypeInfoRef kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo;
 MCTypeInfoRef kMCScriptInvalidPropertyValueErrorTypeInfo;
 MCTypeInfoRef kMCScriptNotAHandlerValueErrorTypeInfo;
-MCTypeInfoRef kMCScriptCannotCallContextHandlerErrorTypeInfo;
 MCTypeInfoRef kMCScriptHandlerNotFoundErrorTypeInfo;
 MCTypeInfoRef kMCScriptPropertyNotFoundErrorTypeInfo;
 
@@ -273,8 +272,6 @@ bool MCScriptInitialize(void)
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.PropertyValueTypeError"), MCNAME("runtime"), MCSTR("Value is not of correct type for setting property - expected type %{type} for setting property %{module}.%{property}"), kMCScriptInvalidPropertyValueErrorTypeInfo))
 			return false;
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.NotAHandlerValueError"), MCNAME("runtime"), MCSTR("Value is not a handler"), kMCScriptNotAHandlerValueErrorTypeInfo))
-			return false;
-		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.CannotCallContextHandlerError"), MCNAME("runtime"), MCSTR("Cannot call context handler"), kMCScriptCannotCallContextHandlerErrorTypeInfo))
 			return false;
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.HandlerNotFoundError"), MCNAME("runtime"), MCSTR("No handler %{handler} in module %{module}"), kMCScriptHandlerNotFoundErrorTypeInfo))
 			return false;

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -243,11 +243,11 @@ bool MCScriptInitialize(void)
     
     // This block creates all the default errors
     {
-        if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.InParameterNotDefinedError"), MCNAME("runtime"), MCSTR("In parameters must be defined before calling - parameter %{parameter} of %{module}.%{handler}"), kMCScriptInParameterNotDefinedErrorTypeInfo))
+        if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.InParameterNotDefinedError"), MCNAME("runtime"), MCSTR("In parameters must be assigned before calling - parameter %{parameter} of %{module}.%{handler}"), kMCScriptInParameterNotDefinedErrorTypeInfo))
 			return false;
-		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.OutParameterNotDefinedError"), MCNAME("runtime"), MCSTR("Out parameters must be defined before returning - parameter %{parameter} of %{module}.%{handler}"), kMCScriptOutParameterNotDefinedErrorTypeInfo))
+		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.OutParameterNotDefinedError"), MCNAME("runtime"), MCSTR("Out parameters must be assigned before returning - parameter %{parameter} of %{module}.%{handler}"), kMCScriptOutParameterNotDefinedErrorTypeInfo))
 			return false;
-		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.VariableUsedBeforeDefinedError"), MCNAME("runtime"), MCSTR("Variables must be defined before being used - variable %{variable} in %{module}.%{handler}"), kMCScriptVariableUsedBeforeDefinedErrorTypeInfo))
+		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.VariableUsedBeforeDefinedError"), MCNAME("runtime"), MCSTR("Variables must be assigned before being used - variable %{variable} in %{module}.%{handler}"), kMCScriptVariableUsedBeforeDefinedErrorTypeInfo))
 			return false;
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.ReturnValueTypeError"), MCNAME("runtime"), MCSTR("Value is not of correct type for return - expected type %{type} when returning from %{module}.%{handler}"), kMCScriptInvalidReturnValueErrorTypeInfo))
 			return false;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -566,6 +566,12 @@ enum MCScriptBytecodeOp
 	// are used, pair-wise, to build an array. (This will be replaced by an invoke
 	// when variadic bindings are implemented).
 	kMCScriptBytecodeOpAssignArray,
+    
+    // Slot resetting
+    //   reset <reg_1>, ..., <reg_n>
+    // Initializes the given slots to default values, if the type of the slot
+    // has a default, otherwise makes the slot unassigned.
+    kMCScriptBytecodeOpReset,
 };
 
 bool MCScriptBytecodeIterate(byte_t*& x_bytecode, byte_t *p_bytecode_limit, MCScriptBytecodeOp& r_op, uindex_t& r_arity, uindex_t *r_arguments);

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -41,7 +41,6 @@ extern MCTypeInfoRef kMCScriptNoMatchingHandlerErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptInvalidPropertyValueErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptNotAHandlerValueErrorTypeInfo;
-extern MCTypeInfoRef kMCScriptCannotCallContextHandlerErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptPropertyNotFoundErrorTypeInfo;
 extern MCTypeInfoRef kMCScriptHandlerNotFoundErrorTypeInfo;
 
@@ -256,15 +255,6 @@ struct MCScriptVariableDefinition: public MCScriptDefinition
 	uindex_t slot_index;
 };
 
-struct MCScriptContextVariableDefinition: public MCScriptDefinition
-{
-    uindex_t type;
-    uindex_t default_value;
-    
-    // (computed) The index of the variable in the context slot table - not pickled
-    uindex_t slot_index;
-};
-
 struct MCScriptCommonHandlerDefinition: public MCScriptDefinition
 {
     uindex_t type;
@@ -280,8 +270,6 @@ struct MCScriptHandlerDefinition: public MCScriptCommonHandlerDefinition
     
 	uindex_t start_address;
 	uindex_t finish_address;
-    
-    MCScriptHandlerScope scope;
     
     // The number of slots required in a frame in order to execute this handler - computed.
     uindex_t slot_count;
@@ -392,12 +380,6 @@ struct MCScriptModule: public MCScriptObject
     // (computed) The number of slots needed by an instance - not pickled
     uindex_t slot_count;
     
-    // (computed) The number of slots needed by this modules context - not pickled
-    uindex_t context_slot_count;
-    
-    // (computed) The index of this module's context info in a frame's context vector - not pickled
-    uindex_t context_index;
-    
     // If this is a non-widget module, then it only has one instance - not pickled
     MCScriptInstanceRef shared_instance;
     
@@ -421,7 +403,6 @@ MCNameRef MCScriptGetNameOfDefinitionInModule(MCScriptModuleRef module, MCScript
 MCNameRef MCScriptGetNameOfParameterInModule(MCScriptModuleRef module, MCScriptDefinition *definition, uindex_t index);
 MCNameRef MCScriptGetNameOfLocalVariableInModule(MCScriptModuleRef module, MCScriptDefinition *definition, uindex_t index);
 MCNameRef MCScriptGetNameOfGlobalVariableInModule(MCScriptModuleRef module, uindex_t index);
-MCNameRef MCScriptGetNameOfContextVariableInModule(MCScriptModuleRef module, uindex_t index);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/lcb/compiler/default-values.lcb
+++ b/tests/lcb/compiler/default-values.lcb
@@ -1,4 +1,21 @@
-module __VMTEST.default_values
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.compiler.default_values.tests
 
 variable sBoolean as Boolean
 variable sOptionalString as optional String
@@ -45,6 +62,15 @@ public handler TestDefaultValueOfModuleVariable()
 	test "default value (boolean)" when sBoolean is false
 	test "default value (optional)" when sOptionalString is nothing
 	test "default value (untyped)" when sVariant is nothing
+end handler
+
+private handler DoTestDefaultValueOfOutParameter(out rValue as Boolean)
+end handler
+
+public handler TestDefaultValueOfOutParameter()
+   variable tValue
+   DoTestDefaultValueOfOutParameter(tValue)
+   test "default value of parameter (boolean)" when tValue is false
 end handler
 
 end module

--- a/tests/lcb/compiler/lexical-scoping.lcb
+++ b/tests/lcb/compiler/lexical-scoping.lcb
@@ -1,0 +1,118 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+module com.livecode.compiler.lexical_scoping.tests
+
+public handler TestIfLexicalScoping()
+   variable tValue as Boolean
+
+   put true into tValue
+   if true then
+      variable tValue as Boolean
+      test "shadowing var in if consequent is default" when tValue is false
+      put false into tValue
+   end if
+   test "shadowed var after if consequence is unchanged" when tValue is true
+
+   put true into tValue
+   if false then
+   else
+      variable tValue as Boolean
+      test "shadowing var in if alternate is default" when tValue is false
+   end if
+   test "shadowed var after if alternate is unchanged" when tValue is true
+
+   put true into tValue
+   if false then
+   else if true then
+      variable tValue as Boolean
+      test "shadowing var in else-if is default" when tValue is false
+   end if
+   test "shadowed var after else-if is unchanged" when tValue is true
+
+end handler
+
+public handler TestRepeatLexicalScoping()
+   variable tValue as Integer
+   variable tCounter as Integer
+
+   put 0 into tValue
+   put 0 into tCounter
+   repeat forever
+      variable tInnerValue as Integer
+      add 1 to tInnerValue
+      put tInnerValue into tValue
+      add 1 to tCounter
+      if tCounter is 5 then
+         exit repeat
+      end if
+   end repeat
+   test "inner var is reset on each iteration in repeat forever" when tValue is 1
+
+   put 0 into tValue
+   repeat 5 times
+      variable tInnerValue as Integer
+      add 1 to tInnerValue
+      put tInnerValue into tValue
+   end repeat
+   test "inner var is reset on each iteration in repeat counted" when tValue is 1
+
+   put 0 into tCounter
+   repeat while tCounter < 5
+      variable tInnerValue as Integer
+      add 1 to tInnerValue
+      put tInnerValue into tValue
+      add 1 to tCounter
+   end repeat
+   test "inner var is reset on each iteration in repeat while" when tValue is 1
+
+   put 0 into tCounter
+   repeat until tCounter is 5
+      variable tInnerValue as Integer
+      add 1 to tInnerValue
+      put tInnerValue into tValue
+      add 1 to tCounter
+   end repeat
+   test "inner var is reset on each iteration in repeat until" when tValue is 1
+
+   put 0 into tValue
+   repeat with tCounter from 1 up to 5
+      variable tInnerValue as Integer
+      add 1 to tInnerValue
+      put tInnerValue into tValue
+   end repeat
+   test "inner var is reset on each iteration in repeat up to" when tValue is 1
+
+   put 0 into tValue
+   repeat with tCounter from 5 down to 1
+      variable tInnerValue as Integer
+      add 1 to tInnerValue
+      put tInnerValue into tValue
+   end repeat
+   test "inner var is reset on each iteration in repeat down to" when tValue is 1
+
+   put 0 into tValue
+   repeat for each element tCounter in [1,2,3,4,5]
+      variable tInnerValue as Integer
+      add 1 to tInnerValue
+      put tInnerValue into tValue
+   end repeat
+   test "inner var is reset on each iteration in repeat for each" when tValue is 1
+
+end handler
+
+end module

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -133,11 +133,8 @@
     
     'rule' DeclareImportedDefinitions(variable(Position, _, Name, _)):
         DeclareId(Name)
-    
-    'rule' DeclareImportedDefinitions(contextvariable(Position, _, Name, _, _)):
-        DeclareId(Name)
 
-    'rule' DeclareImportedDefinitions(handler(Position, _, Name, _, _, _, _)):
+    'rule' DeclareImportedDefinitions(handler(Position, _, Name, _, _, _)):
         DeclareId(Name)
     
     'rule' DeclareImportedDefinitions(foreignhandler(Position, _, Name, _, _)):
@@ -197,10 +194,7 @@
     'rule' Declare(variable(Position, _, Name, _)):
         DeclareId(Name)
     
-    'rule' Declare(contextvariable(Position, _, Name, _, _)):
-        DeclareId(Name)
-    
-    'rule' Declare(handler(Position, _, Name, _, _, _, _)):
+    'rule' Declare(handler(Position, _, Name, _, _, _)):
         DeclareId(Name)
     
     'rule' Declare(foreignhandler(Position, _, Name, _, _)):
@@ -272,11 +266,8 @@
     
     'rule' Define(ModuleId, variable(Position, Access, Name, Type)):
         DefineSymbolId(Name, ModuleId, Access, variable, Type)
-
-    'rule' Define(ModuleId, contextvariable(Position, Access, Name, Type, _)):
-        DefineSymbolId(Name, ModuleId, Access, context, Type)
     
-    'rule' Define(ModuleId, handler(Position, Access, Name, _, Signature:signature(Parameters, _), _, _)):
+    'rule' Define(ModuleId, handler(Position, Access, Name, Signature:signature(Parameters, _), _, _)):
         DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, normal, Signature))
         DefineParameters(Name, Parameters)
     
@@ -351,7 +342,7 @@
 
     ----------
 
-    'rule' Apply(DEFINITION'handler(_, _, Id, _, signature(Parameters, Type), _, Body)):
+    'rule' Apply(DEFINITION'handler(_, _, Id, signature(Parameters, Type), _, Body)):
         -- The type of the handler is resolved in the current scope
         Apply(Type)
         
@@ -736,10 +727,7 @@
     'rule' DumpBindings(DEFINITION'variable(_, _, Name, Type)):
         DumpId("variable", Name)
         DumpBindings(Type)
-    'rule' DumpBindings(DEFINITION'contextvariable(_, _, Name, Type, _)):
-        DumpId("variable", Name)
-        DumpBindings(Type)
-    'rule' DumpBindings(DEFINITION'handler(_, _, Name, _, Signature, Definitions, Body)):
+    'rule' DumpBindings(DEFINITION'handler(_, _, Name, Signature, Definitions, Body)):
         DumpId("handler", Name)
         DumpBindings(Signature)
         DumpBindings(Definitions)

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -457,25 +457,62 @@
         CurrentHandlerId -> ParentId
         DefineSymbolId(Name, ParentId, inferred, local, Type)
         Apply(Type)
-        
+
+    'rule' Apply(STATEMENT'if(Position, Condition, Consequent, Alternate)):
+        Apply(Condition)
+
+        EnterScope
+        Apply(Consequent)
+        LeaveScope
+
+        EnterScope
+        Apply(Alternate)
+        LeaveScope
+
+    'rule' Apply(STATEMENT'repeatforever(_, Body)):
+        EnterScope
+        Apply(Body)
+        LeaveScope
+
+    'rule' Apply(STATEMENT'repeatwhile(_, Expression, Body)):
+        Apply(Expression)
+        EnterScope
+        Apply(Body)
+        LeaveScope
+
+    'rule' Apply(STATEMENT'repeatuntil(_, Expression, Body)):
+        Apply(Expression)
+        EnterScope
+        Apply(Body)
+        LeaveScope
+
     'rule' Apply(STATEMENT'repeatupto(_, Slot, Start, Finish, Step, Body)):
         ApplyId(Slot)
         Apply(Start)
         Apply(Finish)
         Apply(Step)
+
+        EnterScope
         Apply(Body)
+        LeaveScope
 
     'rule' Apply(STATEMENT'repeatdownto(_, Slot, Start, Finish, Step, Body)):
         ApplyId(Slot)
         Apply(Start)
         Apply(Finish)
         Apply(Step)
+
+        EnterScope
         Apply(Body)
+        LeaveScope
 
     'rule' Apply(STATEMENT'repeatforeach(_, Iterator, Container, Body)):
         Apply(Iterator)
         Apply(Container)
+
+        EnterScope
         Apply(Body)
+        LeaveScope
 
     'rule' Apply(STATEMENT'call(_, Handler, Arguments)):
         ApplyId(Handler)

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1613,14 +1613,6 @@
         ||
             --Error_VariableMustHaveHighLevelType(Position)
         |)
-        
-    'rule' CheckDeclaredTypes(DEFINITION'contextvariable(Position, _, _, Type, _)):
-        -- Variable types must be high-level
-        (|
-            IsHighLevelType(Type)
-        ||
-            --Error_VariableMustHaveHighLevelType(Position)
-        |)
 
     'rule' CheckDeclaredTypes(DEFINITION'foreignhandler(Position, _, _, signature(Parameters, ReturnType), _)):
         -- Foreign handlers must be fully typed.
@@ -1716,11 +1708,7 @@
     'rule' CheckIdentifiers(DEFINITION'variable(_, _, Id, _)):
         CheckIdIsSuitableForDefinition(Id)
 
-    'rule' CheckIdentifiers(DEFINITION'contextvariable(_, _, Id, Type, _)):
-        CheckIdIsSuitableForDefinition(Id)
-        CheckIdentifiers(Type)
-
-    'rule' CheckIdentifiers(DEFINITION'handler(_, _, Id, _, Signature, Definitions, Body)):
+    'rule' CheckIdentifiers(DEFINITION'handler(_, _, Id, Signature, Definitions, Body)):
         CheckIdIsSuitableForDefinition(Id)
         CheckIdentifiers(Signature)
         CheckIdentifiers(Definitions)

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -157,6 +157,7 @@ extern "C" void EmitFetch(long reg, long var, long level);
 extern "C" void EmitStore(long reg, long var, long level);
 extern "C" void EmitReturn(long reg);
 extern "C" void EmitReturnNothing(void);
+extern "C" void EmitReset(long reg);
 extern "C" void EmitAttachRegisterToExpression(long reg, long expr);
 extern "C" void EmitDetachRegisterFromExpression(long expr);
 extern "C" int EmitGetRegisterAttachedToExpression(long expr, long *reg);
@@ -1654,6 +1655,13 @@ void EmitReturnNothing(void)
     MCScriptEmitReturnUndefinedInModule(s_builder);
 
     Debug_Emit("ReturnUndefined()", 0);
+}
+
+void EmitReset(long reg)
+{
+    MCScriptEmitResetInModule(s_builder, reg);
+    
+    Debug_Emit("Reset()", 0);
 }
 
 ////////

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -54,9 +54,7 @@ extern "C" void EmitDefinitionIndex(long& r_index);
 extern "C" void EmitTypeDefinition(long index, PositionRef position, NameRef name, long type_index);
 extern "C" void EmitConstantDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_const_index);
 extern "C" void EmitVariableDefinition(long index, PositionRef position, NameRef name, long type_index);
-extern "C" void EmitContextVariableDefinition(long index, PositionRef position, NameRef name, long type_index, long default_index);
 extern "C" void EmitBeginHandlerDefinition(long index, PositionRef position, NameRef name, long type_index);
-extern "C" void EmitBeginContextHandlerDefinition(long index, PositionRef position, NameRef name, long type_index);
 extern "C" void EmitEndHandlerDefinition(void);
 extern "C" void EmitForeignHandlerDefinition(long index, PositionRef position, NameRef name, long type_index, long binding);
 extern "C" void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index);
@@ -795,14 +793,6 @@ void EmitVariableDefinition(long p_index, PositionRef p_position, NameRef p_name
                cstring_from_nameref(p_name), p_type_index);
 }
 
-void EmitContextVariableDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index, long p_default_index)
-{
-    MCScriptAddContextVariableToModule(s_builder, to_mcnameref(p_name), p_type_index, p_default_index, p_index);
-
-    Debug_Emit("ContextVariableDefinition(%ld, %s, %ld, %ld)", p_index,
-               cstring_from_nameref(p_name), p_type_index, p_default_index);
-}
-
 void EmitForeignHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index, long p_binding)
 {
     MCAutoStringRef t_binding_str;
@@ -863,17 +853,9 @@ void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, l
 
 void EmitBeginHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
 {
-    MCScriptBeginHandlerInModule(s_builder, kMCScriptHandlerScopeNormal, to_mcnameref(p_name), p_type_index, p_index);
+    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), p_type_index, p_index);
 
     Debug_Emit("BeginHandlerDefinition(%ld, %s, %ld)", p_index,
-               cstring_from_nameref(p_name), p_type_index);
-}
-
-void EmitBeginContextHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
-{
-    MCScriptBeginHandlerInModule(s_builder, kMCScriptHandlerScopeContext, to_mcnameref(p_name), p_type_index, p_index);
-
-    Debug_Emit("BeginContextHandlerDefinition(%ld, %s, %ld)", p_index,
                cstring_from_nameref(p_name), p_type_index);
 }
 

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1661,7 +1661,7 @@ void EmitReset(long reg)
 {
     MCScriptEmitResetInModule(s_builder, reg);
     
-    Debug_Emit("Reset()", 0);
+    Debug_Emit("Reset(%ld)", reg);
 }
 
 ////////

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -225,9 +225,7 @@
     
     'rule' GenerateManifestDefinitions(variable(_, public, Name, _)):
 
-    'rule' GenerateManifestDefinitions(contextvariable(_, public, Name, _, _)):
-
-    'rule' GenerateManifestDefinitions(handler(_, public, Name, _, Signature, _, _)):
+    'rule' GenerateManifestDefinitions(handler(_, public, Name, Signature, _, _)):
         GenerateManifestHandlerDefinition(Name, Signature)
 
     'rule' GenerateManifestDefinitions(foreignhandler(_, public, Name, Signature, _)):
@@ -525,10 +523,7 @@
     'rule' GenerateDefinitionIndexes(variable(_, _, Name, _)):
         GenerateDefinitionIndex(Name)
     
-    'rule' GenerateDefinitionIndexes(contextvariable(_, _, Name, _, _)):
-        GenerateDefinitionIndex(Name)
-    
-    'rule' GenerateDefinitionIndexes(handler(_, _, Name, _, _, _, _)):
+    'rule' GenerateDefinitionIndexes(handler(_, _, Name, _, _, _)):
         GenerateDefinitionIndex(Name)
 
     'rule' GenerateDefinitionIndexes(foreignhandler(_, _, Name, _, _)):
@@ -608,10 +603,7 @@
     'rule' GenerateExportedDefinitions(variable(_, public, Id, _)):
         GenerateExportedDefinition(Id)
 
-    'rule' GenerateExportedDefinitions(contextvariable(_, public, Id, _, _)):
-        GenerateExportedDefinition(Id)
-
-    'rule' GenerateExportedDefinitions(handler(_, public, Id, _, _, _, _)):
+    'rule' GenerateExportedDefinitions(handler(_, public, Id, _, _, _)):
         GenerateExportedDefinition(Id)
 
     'rule' GenerateExportedDefinitions(foreignhandler(_, public, Id, _, _)):
@@ -673,28 +665,13 @@
         Info'Index -> DefIndex
         EmitVariableDefinition(DefIndex, Position, Name, TypeIndex)
 
-    'rule' GenerateDefinitions(contextvariable(Position, _, Id, Type, Default)):
-        GenerateType(Type -> TypeIndex)
-        EmitConstant(Default -> ConstIndex)
-
-        QuerySymbolId(Id -> Info)
-        Id'Name -> Name
-        Info'Index -> DefIndex
-        EmitContextVariableDefinition(DefIndex, Position, Name, TypeIndex, ConstIndex)
-
-    'rule' GenerateDefinitions(handler(Position, _, Id, Scope, Signature:signature(Parameters, _), _, Body)):
+    'rule' GenerateDefinitions(handler(Position, _, Id, Signature:signature(Parameters, _), _, Body)):
         GenerateType(handler(Position, normal, Signature) -> TypeIndex)
         
         QuerySymbolId(Id -> Info)
         Id'Name -> Name
         Info'Index -> DefIndex
-        (|
-            where(Scope -> normal)
-            EmitBeginHandlerDefinition(DefIndex, Position, Name, TypeIndex)
-        ||
-            where(Scope -> context)
-            EmitBeginContextHandlerDefinition(DefIndex, Position, Name, TypeIndex)
-        |)
+        EmitBeginHandlerDefinition(DefIndex, Position, Name, TypeIndex)
         GenerateParameters(Parameters)
         CreateParameterRegisters(Parameters)
         CreateVariableRegisters(Body)

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -665,6 +665,7 @@
         Info'Index -> DefIndex
         EmitVariableDefinition(DefIndex, Position, Name, TypeIndex)
 
+
     'rule' GenerateDefinitions(handler(Position, _, Id, Signature:signature(Parameters, _), _, Body)):
         GenerateType(handler(Position, normal, Signature) -> TypeIndex)
         
@@ -808,12 +809,17 @@
 
 'action' GenerateParameters(PARAMETERLIST)
 
-    'rule' GenerateParameters(parameterlist(parameter(_, _, Id, Type), Rest)):
+    'rule' GenerateParameters(parameterlist(parameter(Position, Mode, Id, Type), Rest)):
         QuerySymbolId(Id -> Info)
         Id'Name -> Name
         GenerateType(Type -> TypeIndex)
         EmitHandlerParameter(Name, TypeIndex -> Index)
         Info'Index <- Index
+        [|
+            where(Mode -> out)
+            EmitPosition(Position)
+            EmitReset(Index)
+        |]
         GenerateParameters(Rest)
 
     'rule' GenerateParameters(nil):
@@ -870,6 +876,8 @@
         GenerateType(Type -> TypeIndex)
         EmitHandlerVariable(Name, TypeIndex -> Index)
         Info'Index <- Index
+        EmitPosition(Position)
+        EmitReset(Index)
     
     'rule' GenerateBody(Result, Context, if(Position, Condition, Consequent, Alternate)):
         EmitDeferLabel(-> AlternateLabel)

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -236,7 +236,7 @@
     'rule' ImportDefinition(-> variable(Position, public, Id, Type)):
         "variable" @(-> Position) Identifier(-> Id) "as" Type(-> Type)
 
-    'rule' ImportDefinition(-> handler(Position, public, Id, normal, Signature, nil, nil)):
+    'rule' ImportDefinition(-> handler(Position, public, Id, Signature, nil, nil)):
         "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
 
     'rule' ImportDefinition(-> foreignhandler(Position, public, Id, Signature, "")):
@@ -352,9 +352,6 @@
 
     'rule' VariableDefinition(-> variable(Position, Access, Name, Type)):
         Access(-> Access) "variable" @(-> Position) Identifier(-> Name) OptionalTypeClause(-> Type)
-
-    'rule' VariableDefinition(-> contextvariable(Position, Access, Name, Type, Default)):
-        Access(-> Access) "context" @(-> Position) "variable" Identifier(-> Name) OptionalTypeClause(-> Type) "default" Expression(-> Default)
         
 'nonterm' OptionalTypeClause(-> TYPE)
 
@@ -455,21 +452,10 @@
 
 'nonterm' HandlerDefinition(-> DEFINITION)
 
-    'rule' HandlerDefinition(-> handler(Position, Access, Name, normal, Signature, nil, Body)):
+    'rule' HandlerDefinition(-> handler(Position, Access, Name, Signature, nil, Body)):
         Access(-> Access) "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) Separator
             Statements(-> Body)
         "end" "handler"
-        
-    'rule' HandlerDefinition(-> handler(Position, Access, Name, context, Signature, nil, Body)):
-        Access(-> Access) "context" @(-> Position) "handler" Identifier(-> Name) Signature(-> Signature) Separator
-            Statements(-> Body)
-        "end" "handler"
-            --'rule' HandlerDefinition(-> handler(Position, Access, Name, Signature, nil, Body)):
-    --    Access(-> Access) "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) Separator
-    --        Definitions(-> Definitions)
-    --    "begin"
-    --        Statements(-> Body)
-    --    "end" "handler"
         
     'rule' HandlerDefinition(-> foreignhandler(Position, Access, Name, Signature, Binding)):
         Access(-> Access) "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -240,6 +240,7 @@
     EmitStore
     EmitReturn
     EmitReturnNothing
+    EmitReset
     EmitAttachRegisterToExpression
     EmitDetachRegisterFromExpression
     EmitGetRegisterAttachedToExpression
@@ -613,6 +614,7 @@
 'action' EmitStore(Register: INT, Var: INT, Level: INT)
 'action' EmitReturn(Register: INT)
 'action' EmitReturnNothing()
+'action' EmitReset(Register: INT)
 'action' EmitPosition(Position: POS)
 
 'action' EmitAttachRegisterToExpression(INT, EXPRESSION)

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -146,10 +146,8 @@
     EmitTypeDefinition
     EmitConstantDefinition
     EmitVariableDefinition
-    EmitContextVariableDefinition
     EmitBeginHandlerDefinition
     EmitEndHandlerDefinition
-    EmitBeginContextHandlerDefinition
     EmitForeignHandlerDefinition
     EmitPropertyDefinition
     EmitEventDefinition
@@ -513,9 +511,7 @@
 'action' EmitTypeDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitConstantDefinition(Index: INT, Position: POS, Name: NAME, ConstIndex: INT)
 'action' EmitVariableDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
-'action' EmitContextVariableDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT, DefaultIndex: INT)
 'action' EmitBeginHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
-'action' EmitBeginContextHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitEndHandlerDefinition()
 'action' EmitForeignHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT, Binding: STRING)
 'action' EmitPropertyDefinition(Index: INT, Position: POS, Name: NAME, GetIndex: INT, SetIndex: INT)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -21,7 +21,7 @@
 
 'export'
     MODULE MODULELIST MODULEKIND
-    DEFINITION SIGNATURE ACCESS SCOPE
+    DEFINITION SIGNATURE ACCESS
     TYPE FIELD FIELDLIST LANGUAGE
     PARAMETER MODE PARAMETERLIST
     STATEMENT
@@ -55,10 +55,6 @@
 'type' MODULE
     module(Position: POS, Kind: MODULEKIND, Name: ID, Definitions: DEFINITION)
 
-'type' SCOPE
-    normal
-    context
-
 'type' DEFINITION
     sequence(Left: DEFINITION, Right: DEFINITION)
     metadata(Position: POS, Key: STRING, Value: STRING)
@@ -66,8 +62,7 @@
     type(Position: POS, Access: ACCESS, Name: ID, Type: TYPE)
     constant(Position: POS, Access: ACCESS, Name: ID, Value: EXPRESSION)
     variable(Position: POS, Access: ACCESS, Name: ID, Type: TYPE)
-    contextvariable(Position: POS, Access: ACCESS, Name: ID, Type: TYPE, Default: EXPRESSION)
-    handler(Position: POS, Access: ACCESS, Name: ID, Scope: SCOPE, Signature: SIGNATURE, Definitions: DEFINITION, Body: STATEMENT)
+    handler(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE, Definitions: DEFINITION, Body: STATEMENT)
     foreignhandler(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE, Binding: STRING)
     property(Position: POS, Access: ACCESS, Name: ID, Getter: ID, Setter: OPTIONALID)
     event(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE)


### PR DESCRIPTION
This patch makes variable definitions lexically scoped within blocks. e.g. The following won't compile as tVar is declared inside the repeat block:

```
   repeat forever
     variable tVar
   end repeat
   put tVar
```

In order to implement this a couple of VM changes have been made, as well as compiler changes.

The first change is that the VM internally now uses the nil pointer to represent an unassigned slot - this solves the previous problem of it not being able to tell the difference between a slot with 'optional' type and a slot which has not actually had a value assigned to it.

The second change is that giving variables default values is now the responsibility of the compiler. It now does this using a new opcode 'Reset' which resets a slot to its type based default, or to unassigned if the slot is untyped/its type has no default value.
