### PR TITLE
Bugfix 17553

### DIFF
--- a/docs/dictionary/property/brush.lcdoc
+++ b/docs/dictionary/property/brush.lcdoc
@@ -20,7 +20,7 @@ set the brush to the short ID of image "My Custom Brush"
 
 Value:
 The <brush> is a brush specifier.
-A <brushID> is a built-in brush number between 1 and 35. (These brushes correspond to LiveCode's built-in patterns 101 to 135.)
+A <brushID> is a built-in brush number between 1 and 36. (These brushes correspond to LiveCode's built-in patterns 101 to 136.)
 
 An <imageID> is the ID of an <image> to use for painting with the brush. LiveCode looks for the specified <image> first in the <current stack>, then in other open <stacks>.
 

--- a/docs/dictionary/property/eraser.lcdoc
+++ b/docs/dictionary/property/eraser.lcdoc
@@ -17,7 +17,7 @@ set the eraser to 12
 
 Value:
 The <eraser> is a brush specifier.
-A <brushID> is a built-in brush number between 1 and 35. (These brushes correspond to LiveCode's built-in patterns 101 to 135.)
+A <brushID> is a built-in brush number between 1 and 36. (These brushes correspond to LiveCode's built-in patterns 101 to 136.)
 
 An <imageID> is the ID of an <image> to use for erasing. LiveCode looks for the specified <image> first in the <current stack>, then in other open <stacks>.
 

--- a/docs/dictionary/property/spray.lcdoc
+++ b/docs/dictionary/property/spray.lcdoc
@@ -17,7 +17,7 @@ set the spray to 30
 
 Value:
 The <spray> is a brush specifier.
-A <brushID> is a built-in brush number between 1 and 100. (These brushes correspond to LiveCode's built-in patterns 100 to 135.)
+A <brushID> is a built-in brush number between 1 and 35. (These brushes correspond to LiveCode's built-in patterns 101 to 135.)
 
 An <imageID> is the ID of an <image> to use for painting with the spray can. LiveCode looks for the specified <image> first in the <current stack>, then in other open <stacks>.
 

--- a/docs/dictionary/property/spray.lcdoc
+++ b/docs/dictionary/property/spray.lcdoc
@@ -17,7 +17,7 @@ set the spray to 30
 
 Value:
 The <spray> is a brush specifier.
-A <brushID> is a built-in brush number between 1 and 35. (These brushes correspond to LiveCode's built-in patterns 101 to 135.)
+A <brushID> is a built-in brush number between 1 and 36. (These brushes correspond to LiveCode's built-in patterns 101 to 136.)
 
 An <imageID> is the ID of an <image> to use for painting with the spray can. LiveCode looks for the specified <image> first in the <current stack>, then in other open <stacks>.
 

--- a/docs/notes/bugfix-17553.md
+++ b/docs/notes/bugfix-17553.md
@@ -1,0 +1,1 @@
+# Paint Tools Not Working in IDE

--- a/engine/src/exec-graphics.cpp
+++ b/engine/src/exec-graphics.cpp
@@ -215,9 +215,10 @@ void MCGraphicsExecResetPaint(MCExecContext& ctxt)
 {
     MCeditingimage = nil;
     
-    MCbrush = 8;
-    MCspray = 31;
-    MCeraser = 2;
+		// MDW-2016-05-06 [[ bugfix_17553 ]] set brush defaults using validators
+    MCInterfaceSetBrush(ctxt, 8);
+    MCInterfaceSetSpray(ctxt, 34);
+    MCInterfaceSetEraser(ctxt, 2);
     MCcentered = False;
     MCfilled = False;
     MCgrid = False;

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -2026,7 +2026,8 @@ void MCInterfaceSetRelayerGroupedControls(MCExecContext& ctxt, bool p_value)
 void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_value)
 {
 	uint4 t_newbrush = p_value;
-	if (t_newbrush < PI_PATTERNS)
+	// MDW-2016-05-06 [[ bugfix_17553 ]] safer to compare against PI_BRUSHES than PI_PATTERNS
+	if (t_newbrush < PI_BRUSHES)
 		t_newbrush += PI_BRUSHES;
 
 	// MW-2009-02-02: [[ Improved image search ]]

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -2026,8 +2026,6 @@ void MCInterfaceSetRelayerGroupedControls(MCExecContext& ctxt, bool p_value)
 void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_value)
 {
 	uint4 t_newbrush = p_value;
-	// MDW-2016-05-21 [[ bugfix_17553 ]] map low brush values up to 101..135 range
-	// if less than 36, map to 101..135
 	if (t_newbrush <= (PI_PATTERNS-PI_BRUSHES))
 		t_newbrush += PI_BRUSHES;
 
@@ -2065,7 +2063,6 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_v
 
 void MCInterfaceGetBrush(MCExecContext& ctxt, uinteger_t& r_value)
 {
-	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
 	r_value = MCbrush > PI_BRUSHES && MCbrush <= PI_PATTERNS ? MCbrush - PI_BRUSHES : MCbrush;
 }
 
@@ -2076,7 +2073,6 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, uinteger_t p_value)
 
 void MCInterfaceGetEraser(MCExecContext& ctxt, uinteger_t& r_value)
 {
-	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
 	r_value = MCeraser > PI_BRUSHES && MCeraser <= PI_PATTERNS ? MCeraser - PI_BRUSHES : MCeraser;
 }
 
@@ -2087,7 +2083,6 @@ void MCInterfaceSetEraser(MCExecContext& ctxt, uinteger_t p_value)
 
 void MCInterfaceGetSpray(MCExecContext& ctxt, uinteger_t& r_value)
 {
-	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
 	r_value = MCspray > PI_BRUSHES && MCspray <= PI_PATTERNS ? MCspray - PI_BRUSHES : MCspray;
 }
 

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -2066,10 +2066,7 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_v
 void MCInterfaceGetBrush(MCExecContext& ctxt, uinteger_t& r_value)
 {
 	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
-	if (MCbrush < PI_PATTERNS)
-		r_value = MCbrush > PI_BRUSHES ? MCbrush - PI_BRUSHES : MCbrush;
-	else
-		r_value = MCbrush;
+	r_value = MCbrush > PI_BRUSHES && MCbrush < PI_PATTERNS ? MCbrush - PI_BRUSHES : MCbrush;
 }
 
 void MCInterfaceSetBrush(MCExecContext& ctxt, uinteger_t p_value)
@@ -2080,10 +2077,7 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, uinteger_t p_value)
 void MCInterfaceGetEraser(MCExecContext& ctxt, uinteger_t& r_value)
 {
 	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
-	if (MCeraser < PI_PATTERNS)
-		r_value = MCeraser > PI_BRUSHES ? MCeraser - PI_BRUSHES : MCeraser;
-	else
-		r_value = MCeraser;
+	r_value = MCeraser > PI_BRUSHES && MCeraser < PI_PATTERNS ? MCeraser - PI_BRUSHES : MCeraser;
 }
 
 void MCInterfaceSetEraser(MCExecContext& ctxt, uinteger_t p_value)
@@ -2094,10 +2088,7 @@ void MCInterfaceSetEraser(MCExecContext& ctxt, uinteger_t p_value)
 void MCInterfaceGetSpray(MCExecContext& ctxt, uinteger_t& r_value)
 {
 	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
-	if (MCspray < PI_PATTERNS)
-		r_value = MCspray > PI_BRUSHES ? MCspray - PI_BRUSHES : MCspray;
-	else
-		r_value = MCspray;
+	r_value = MCspray > PI_BRUSHES && MCspray < PI_PATTERNS ? MCspray - PI_BRUSHES : MCspray;
 }
 
 void MCInterfaceSetSpray(MCExecContext& ctxt, uinteger_t p_value)

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -2026,8 +2026,9 @@ void MCInterfaceSetRelayerGroupedControls(MCExecContext& ctxt, bool p_value)
 void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_value)
 {
 	uint4 t_newbrush = p_value;
-	// MDW-2016-05-06 [[ bugfix_17553 ]] safer to compare against PI_BRUSHES than PI_PATTERNS
-	if (t_newbrush < PI_BRUSHES)
+	// MDW-2016-05-21 [[ bugfix_17553 ]] map low brush values up to 101..135 range
+	// if less than 36, map to 101..135
+	if (t_newbrush < (PI_PATTERNS-PI_BRUSHES))
 		t_newbrush += PI_BRUSHES;
 
 	// MW-2009-02-02: [[ Improved image search ]]
@@ -2064,7 +2065,11 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_v
 
 void MCInterfaceGetBrush(MCExecContext& ctxt, uinteger_t& r_value)
 {
-	r_value = MCbrush < PI_PATTERNS ? MCbrush - PI_BRUSHES : MCbrush;
+	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
+	if (MCbrush < PI_PATTERNS)
+		r_value = MCbrush > PI_BRUSHES ? MCbrush - PI_BRUSHES : MCbrush;
+	else
+		r_value = MCbrush;
 }
 
 void MCInterfaceSetBrush(MCExecContext& ctxt, uinteger_t p_value)
@@ -2074,7 +2079,11 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, uinteger_t p_value)
 
 void MCInterfaceGetEraser(MCExecContext& ctxt, uinteger_t& r_value)
 {
-	r_value = MCeraser < PI_PATTERNS ? MCeraser - PI_BRUSHES : MCeraser;
+	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
+	if (MCeraser < PI_PATTERNS)
+		r_value = MCeraser > PI_BRUSHES ? MCeraser - PI_BRUSHES : MCeraser;
+	else
+		r_value = MCeraser;
 }
 
 void MCInterfaceSetEraser(MCExecContext& ctxt, uinteger_t p_value)
@@ -2084,7 +2093,11 @@ void MCInterfaceSetEraser(MCExecContext& ctxt, uinteger_t p_value)
 
 void MCInterfaceGetSpray(MCExecContext& ctxt, uinteger_t& r_value)
 {
-	r_value = MCspray < PI_PATTERNS ? MCspray - PI_BRUSHES : MCspray;
+	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
+	if (MCspray < PI_PATTERNS)
+		r_value = MCspray > PI_BRUSHES ? MCspray - PI_BRUSHES : MCspray;
+	else
+		r_value = MCspray;
 }
 
 void MCInterfaceSetSpray(MCExecContext& ctxt, uinteger_t p_value)

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -2028,7 +2028,7 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_v
 	uint4 t_newbrush = p_value;
 	// MDW-2016-05-21 [[ bugfix_17553 ]] map low brush values up to 101..135 range
 	// if less than 36, map to 101..135
-	if (t_newbrush < (PI_PATTERNS-PI_BRUSHES))
+	if (t_newbrush <= (PI_PATTERNS-PI_BRUSHES))
 		t_newbrush += PI_BRUSHES;
 
 	// MW-2009-02-02: [[ Improved image search ]]
@@ -2066,7 +2066,7 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, Properties p_which, uinteger_t p_v
 void MCInterfaceGetBrush(MCExecContext& ctxt, uinteger_t& r_value)
 {
 	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
-	r_value = MCbrush > PI_BRUSHES && MCbrush < PI_PATTERNS ? MCbrush - PI_BRUSHES : MCbrush;
+	r_value = MCbrush > PI_BRUSHES && MCbrush <= PI_PATTERNS ? MCbrush - PI_BRUSHES : MCbrush;
 }
 
 void MCInterfaceSetBrush(MCExecContext& ctxt, uinteger_t p_value)
@@ -2077,7 +2077,7 @@ void MCInterfaceSetBrush(MCExecContext& ctxt, uinteger_t p_value)
 void MCInterfaceGetEraser(MCExecContext& ctxt, uinteger_t& r_value)
 {
 	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
-	r_value = MCeraser > PI_BRUSHES && MCeraser < PI_PATTERNS ? MCeraser - PI_BRUSHES : MCeraser;
+	r_value = MCeraser > PI_BRUSHES && MCeraser <= PI_PATTERNS ? MCeraser - PI_BRUSHES : MCeraser;
 }
 
 void MCInterfaceSetEraser(MCExecContext& ctxt, uinteger_t p_value)
@@ -2088,7 +2088,7 @@ void MCInterfaceSetEraser(MCExecContext& ctxt, uinteger_t p_value)
 void MCInterfaceGetSpray(MCExecContext& ctxt, uinteger_t& r_value)
 {
 	// MDW-2016-05-21 [[ bugfix_17553 ]] map 101..135 down to 1..35
-	r_value = MCspray > PI_BRUSHES && MCspray < PI_PATTERNS ? MCspray - PI_BRUSHES : MCspray;
+	r_value = MCspray > PI_BRUSHES && MCspray <= PI_PATTERNS ? MCspray - PI_BRUSHES : MCspray;
 }
 
 void MCInterfaceSetSpray(MCExecContext& ctxt, uinteger_t p_value)

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -119,8 +119,8 @@ on TestInitialPaintConditions
 	TestAssert "the multiSpace is initially 1", the multiSpace is 1
 
 # not sure if this should work. it doesn't in previous builds either
-	TestAssert "the penPattern is initially 136", the penPattern is 136
-	TestAssert "the brushPattern is initially 136", the brushPattern is 136
+	TestAssert "the penPattern is initially empty", the penPattern is empty
+	TestAssert "the brushPattern is initially empty", the brushPattern is empty
 	TestAssert "the polySides is initially 4", the polySides is 4
 
 	TestAssert "the roundEnds is initially false", the roundEnds is false
@@ -234,8 +234,8 @@ on TestResetPaint
 	TestAssert "the multiSpace is reset to 1", the multiSpace is 1
 
 # not sure if this should be empty. it isn't in previous builds either
-	TestAssert "the penPattern is reset to 136", the penPattern is 136
-	TestAssert "the brushPattern is reset to 136", the brushPattern is 136
+	TestAssert "the penPattern is reset to empty", the penPattern is empty
+	TestAssert "the brushPattern is reset to empty", the brushPattern is empty
 	TestAssert "the polySides is reset to 4", the polySides is 4
 
 	TestAssert "the roundEnds is reset to false", the roundEnds is false

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -180,7 +180,7 @@ on TestRemappedBrush
 	local tBrush
 	
 	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
-	repeat with tBrush = 101 to 135
+	repeat with tBrush = 101 to 136
 		set the brush to tBrush
 		TestAssert "setting brush to" && tBrush && "subtracts 100", the brush is (tBrush-100)
 	end repeat
@@ -190,7 +190,7 @@ on TestBrushInBounds
 	local tBrush
 	
 	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
-	repeat with tBrush = 1 to 35
+	repeat with tBrush = 1 to 36
 		set the brush to tBrush
 		TestAssert "setting brush to" && tBrush && "is unchanged", the brush is tBrush
 	end repeat
@@ -200,15 +200,9 @@ on TestBrushBoundaries
 	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 #	set the brush to 99
 #	TestAssert "brush = 99 unchanged", the brush is 99
-	set the brush to 136
-	TestAssert "brush = 136 unchanged", the brush is 136
-end TestBrushBoundaries
-
-on TestBrush137
-	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the brush to 137
 	TestAssert "brush > 136 is unchanged", the brush is 137
-end TestBrush137
+end TestBrushBoundaries
 
 on TestSpray
 	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -91,3 +91,119 @@ TestAssert "test", "-6,-11" is not within "-5,-10,5,10"
 TestAssert "test", "5,10" is not within "-5,-10,5,10"
 
 end TestGraphicsIsNotWithin
+
+-- new brush mapping for 101..135
+-- brush < 101 = brush
+-- 101 < brush < 135 = brush - 100
+-- brush > 136 = brush
+
+on TestBrushWithNoIcons
+	TestAssert "set brush with revicons stack not loaded", SetBrushNoIcons() is not 2
+end TestBrushWithNoIcons
+
+on TestBadBrush100
+	open stack "../ide/Toolset/palettes/revicons.rev"
+	set the brush to 8
+	TestAssert "no brush with id=100", SetBrush100() is not 100
+	TestAssert "brush image not found", the brush is 8
+end TestBadBrush100
+
+on TestBadBrushZero
+	open stack "../ide/Toolset/palettes/revicons.rev"
+	set the brush to 8
+	TestAssert "no brush with id=0", SetBrushZero() is not zero
+	TestAssert "brush image not found", the brush is 8
+end TestBadBrushZero
+
+function SetBrushNoIcons
+	try
+		set the brush to 2
+	catch e
+		TestDiagnostic e
+	end try
+	return the brush
+end SetBrushNoIcons
+
+function SetBrush100
+	try
+		set the brush to 100
+	catch e
+		TestDiagnostic e
+	end try
+	return the brush
+end SetBrush100
+
+function SetBrushZero
+	try
+		set the brush to 0
+	catch e
+		TestDiagnostic e
+	end try
+	return the brush
+end SetBrushZero
+
+on TestBrush
+	open stack "../ide/Toolset/palettes/revicons.rev"
+	set the brush to 30
+	TestAssert "brush > 35 unchanged", the brush is 30
+end TestBrush
+
+on TestRemappedBrush
+	local tBrush
+	
+	open stack "../ide/Toolset/palettes/revicons.rev"
+#	repeat with tBrush = 101 to 102
+#		set the brush to tBrush
+#		TestAssert "100 < brush < 136 subtracts 100", the brush is (tBrush-100)
+#	end repeat
+	set the brush to 101
+	TestAssert "brush = 101 unchanged", the brush is 1
+end TestRemappedBrush
+
+on TestBrushInBounds
+	local tBrush
+	
+	open stack "../ide/Toolset/palettes/revicons.rev"
+#	repeat with tBrush = 1 to 1
+#		set the brush to tBrush
+#		TestAssert "1 < brush < 35 unchanged", the brush is tBrush
+#	end repeat
+	set the brush to 1
+	TestAssert "brush = 1 unchanged", the brush is 1
+end TestBrushInBounds
+
+on TestBrushBoundaries
+	open stack "../ide/Toolset/palettes/revicons.rev"
+#	set the brush to 99
+#	TestAssert "brush = 99 unchanged", the brush is 99
+	set the brush to 136
+	TestAssert "brush = 136 unchanged", the brush is 136
+end TestBrushBoundaries
+
+on TestBrush137
+	open stack "../ide/Toolset/palettes/revicons.rev"
+	set the brush to 137
+	TestAssert "brush > 136 is unchanged", the brush is 137
+end TestBrush137
+
+on TestSpray
+	open stack "../ide/Toolset/palettes/revicons.rev"
+	set the spray to 2
+	TestAssert "directly setting the spray", the spray is 2
+end TestSpray
+
+on TestEraser
+	open stack "../ide/Toolset/palettes/revicons.rev"
+	set the eraser to 8
+	TestAssert "directly setting the eraser", the eraser is 8
+end TestEraser
+
+on TestResetPaint
+	open stack "../ide/Toolset/palettes/revicons.rev"
+	reset paint
+	TestAssert "brush is reset to 8", the brush is 8
+	TestAssert "spray is reset to 34", the spray is 34
+	TestAssert "eraser is reset to 2", the eraser is 2
+end TestResetPaint
+
+

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -94,7 +94,7 @@ end TestGraphicsIsNotWithin
 
 -- new brush mapping for 101..135
 -- brush < 101 = brush
--- 101 < brush < 135 = brush - 100
+-- 101 < brush < 137 = brush - 100
 -- brush > 136 = brush
 
 on TestBrushWithNoIcons
@@ -173,7 +173,7 @@ end SetBrushZero
 on TestBrush
 	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the brush to 30
-	TestAssert "brush < 35 unchanged", the brush is 30
+	TestAssert "brush < 37 unchanged", the brush is 30
 end TestBrush
 
 on TestRemappedBrush
@@ -201,7 +201,7 @@ on TestBrushBoundaries
 #	set the brush to 99
 #	TestAssert "brush = 99 unchanged", the brush is 99
 	set the brush to 137
-	TestAssert "brush > 136 is unchanged", the brush is 137
+	TestAssert "brush can be set to a pattern", the brush is 137
 end TestBrushBoundaries
 
 on TestSpray

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -101,15 +101,43 @@ on TestBrushWithNoIcons
 	TestAssert "set brush with revicons stack not loaded", SetBrushNoIcons() is not 2
 end TestBrushWithNoIcons
 
+on TestInitialPaintConditions
+#	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
+	TestAssert "brush is initially 8", the brush is 8
+	TestAssert "spray is initially 34", the spray is 34
+	TestAssert "eraser is initially 2", the eraser is 2
+	
+	TestAssert "the centered is initially false", the centered is false
+	TestAssert "the filled is initially false", the filled is false
+	
+	TestAssert "the grid is initially true", the grid is true
+
+	TestAssert "the gridSize is initially 4", the gridSize is 4
+	TestAssert "the lineSize is initially 0", the lineSize is 0
+
+	TestAssert "the multiple is initially false", the multiple is false
+	TestAssert "the multiSpace is initially 1", the multiSpace is 1
+
+# not sure if this should work. it doesn't in previous builds either
+	TestAssert "the penPattern is initially 136", the penPattern is 136
+	TestAssert "the brushPattern is initially 136", the brushPattern is 136
+	TestAssert "the polySides is initially 4", the polySides is 4
+
+	TestAssert "the roundEnds is initially false", the roundEnds is false
+	TestAssert "the slices is initially 16", the slices is 16
+	TestAssert "the penColor is initially 0,0,0", the penColor is "0,0,0"
+	TestAssert "the brushColor is initially 255,255,255", the brushColor is "255,255,255"
+end TestInitialPaintConditions
+
 on TestBadBrush100
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the brush to 8
 	TestAssert "no brush with id=100", SetBrush100() is not 100
 	TestAssert "brush image not found", the brush is 8
 end TestBadBrush100
 
 on TestBadBrushZero
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the brush to 8
 	TestAssert "no brush with id=0", SetBrushZero() is not zero
 	TestAssert "brush image not found", the brush is 8
@@ -143,37 +171,33 @@ function SetBrushZero
 end SetBrushZero
 
 on TestBrush
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the brush to 30
-	TestAssert "brush > 35 unchanged", the brush is 30
+	TestAssert "brush < 35 unchanged", the brush is 30
 end TestBrush
 
 on TestRemappedBrush
 	local tBrush
 	
-	open stack "../ide/Toolset/palettes/revicons.rev"
-#	repeat with tBrush = 101 to 102
-#		set the brush to tBrush
-#		TestAssert "100 < brush < 136 subtracts 100", the brush is (tBrush-100)
-#	end repeat
-	set the brush to 101
-	TestAssert "brush = 101 unchanged", the brush is 1
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
+	repeat with tBrush = 101 to 135
+		set the brush to tBrush
+		TestAssert "setting brush to" && tBrush && "subtracts 100", the brush is (tBrush-100)
+	end repeat
 end TestRemappedBrush
 
 on TestBrushInBounds
 	local tBrush
 	
-	open stack "../ide/Toolset/palettes/revicons.rev"
-#	repeat with tBrush = 1 to 1
-#		set the brush to tBrush
-#		TestAssert "1 < brush < 35 unchanged", the brush is tBrush
-#	end repeat
-	set the brush to 1
-	TestAssert "brush = 1 unchanged", the brush is 1
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
+	repeat with tBrush = 1 to 35
+		set the brush to tBrush
+		TestAssert "setting brush to" && tBrush && "is unchanged", the brush is tBrush
+	end repeat
 end TestBrushInBounds
 
 on TestBrushBoundaries
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 #	set the brush to 99
 #	TestAssert "brush = 99 unchanged", the brush is 99
 	set the brush to 136
@@ -181,29 +205,54 @@ on TestBrushBoundaries
 end TestBrushBoundaries
 
 on TestBrush137
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the brush to 137
 	TestAssert "brush > 136 is unchanged", the brush is 137
 end TestBrush137
 
 on TestSpray
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the spray to 2
 	TestAssert "directly setting the spray", the spray is 2
 end TestSpray
 
 on TestEraser
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	set the eraser to 8
 	TestAssert "directly setting the eraser", the eraser is 8
 end TestEraser
 
 on TestResetPaint
-	open stack "../ide/Toolset/palettes/revicons.rev"
+	open stack TestGetIDERepositoryPath() & "/Toolset/palettes/revicons.rev"
 	reset paint
 	TestAssert "brush is reset to 8", the brush is 8
 	TestAssert "spray is reset to 34", the spray is 34
 	TestAssert "eraser is reset to 2", the eraser is 2
+	
+	TestAssert "the centered is reset to false", the centered is false
+	TestAssert "the filled is reset to false", the filled is false
+	TestAssert "the grid is reset to false", the grid is false
+
+	TestAssert "the gridSize is reset to 8", the gridSize is 8
+	TestAssert "the lineSize is reset to 1", the lineSize is 1
+
+	TestAssert "the multiple is reset to false", the multiple is false
+	TestAssert "the multiSpace is reset to 1", the multiSpace is 1
+
+# not sure if this should be empty. it isn't in previous builds either
+	TestAssert "the penPattern is reset to 136", the penPattern is 136
+	TestAssert "the brushPattern is reset to 136", the brushPattern is 136
+	TestAssert "the polySides is reset to 4", the polySides is 4
+
+	TestAssert "the roundEnds is reset to false", the roundEnds is false
+	TestAssert "the slices is reset to 16", the slices is 16
+	TestAssert "the penColor is reset to 0,0,0", the penColor is "0,0,0"
+	TestAssert "the brushColor is reset to 255,255,255", the brushColor is "255,255,255"
 end TestResetPaint
 
+on TestTeardown
+	if there is a stack "revicons" then
+		close stack "revicons"
+	end if
+end TestTeardown
 


### PR DESCRIPTION
Rebased, pushed, and reopened. Couldn't reopen the previous PR (3996) because of the rebase, so I'm resubmitting this.

The tools palette in LC8 attempts to assign some very large numbers (no doubt converted from negatives) to the spray, brush, and eraser properties, and these numbers do not correspond to valid images. That causes an error which is not normally displayed to the users, since it happens in a system stack. This patch fixes some suspicious-looking math in the MCInterfaceSetBrush function and also vectors setting the brush values in MCGraphicsExecResetPaint through MCInterfaceSetBrush so that the values get validated on the way in.

For extra credit, I fixed the default value of the spray brush, which was getting set to 31 instead of the documented value of 34. Something else must be fixing the value later on, because retrieving the value shows 34 anyway.

This fixes http://quality.livecode.com/show_bug.cgi?id=17553.
