### PR TITLE
[Bug 17792] Ensure datagrid dictionary entries are listed.

### DIFF
--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -2206,7 +2206,7 @@ command docsBuilderGenerateDistributedAPI pEdition
    
    put "dictionary" into tDataGridA["type"]
    
-   addToList tLCBDictionaryA, tLibrariesA
+   addToList tDataGridA, tLibrariesA
    
    local tJSON
    put revDocsFormatLibrariesArrayAsJSON(tLibrariesA) into tJSON


### PR DESCRIPTION
Fixes a typo in commit 76860e2.
