### PR TITLE
Clean up LCB-related release notes from incorrect directory

### DIFF
--- a/docs/lcb/15111.md
+++ b/docs/lcb/15111.md
@@ -1,7 +1,0 @@
-# LiveCode Builder Host Library
-
-## Handling of mouse wheel events
-
-* If a widget does not have a 'OnMouseScroll' handler then mouse-wheel events will bypass the widget and filter through rawKey messages as usual.
-
-# [15111] Widgets eat mouse-wheel events meaning nothing else can handle them.

--- a/docs/lcb/15436.md
+++ b/docs/lcb/15436.md
@@ -1,5 +1,0 @@
-# LiveCode Builder Host Library
-
-# [15436] Attempting to call a foreign handler directly from LCS will no longer crash, but throw an error.
-# [15436] An appropriate error message will be returned if a type conversion fails when calling a library handler.
-# [15436] Calling library handlers with foreign typed arguments now works from LCS.

--- a/docs/lcb/16717.md
+++ b/docs/lcb/16717.md
@@ -1,3 +1,0 @@
-# LiveCode Builder Standard Library
-
-# [16717] Handle unicode variation selector codepoints correctly


### PR DESCRIPTION
These release notes were committed into the incorrect directory.
Since 8.0 is done and dusted they may as well be deleted rather than
moved around.
