### PR TITLE
Include full range of commits when computing relevant release notes

### DIFF
--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -1369,13 +1369,14 @@ private function GitGetRelevantTags pType
    
    set the itemdelimiter to "."
    
+   put 0 into tStart
    repeat for each line tLine in tTags
+      add 1 to tStart
       if tLine begins with item 1 to 3 of sVersion then
          exit repeat
       end if
-      add 1 to tStart
    end repeat
-   put line tStart to -1 of tTags into tTags
+   put line (tStart - 1) to -1 of tTags into tTags
    
    repeat for each line tLine in tTags
       if not (tLine begins with item 1 to 3 of sVersion) then


### PR DESCRIPTION
Previously, if there was a series of tags:
- 8.0.2-rc-1
- 8.0.2-rc-2
- 8.1.0-dp-1

Then only the changes between 8.1.0-dp-1 and HEAD would be considered
when computing release notes.  This patch ensures that all changes
between 8.0.2-rc-2 and HEAD are considered.
