### PR TITLE
Add compiler testrunner and unsafe keywords to LCB

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -334,7 +334,7 @@ a value.
 ### Handlers
 
     HandlerDefinition
-      : 'handler' <Name: Identifier> '(' [ ParameterList ] ')' [ 'returns' <ReturnType: Type> ] SEPARATOR
+      : [ 'unsafe' ] 'handler' <Name: Identifier> '(' [ ParameterList ] ')' [ 'returns' <ReturnType: Type> ] SEPARATOR
           { Statement }
         'end' 'handler'
 
@@ -382,6 +382,10 @@ to be *optional any* meaning it can be of any type.
 > **Note:** Only assignable expressions can be passed as arguments to
 > inout or out parameters. It is a checked compile-time error to pass a
 > non-assignable expression to such a parameter.
+
+If 'unsafe' is specified for the handler, then the handler itself is considered
+to be unsafe, and may only be called from other unsafe handlers or unsafe
+statement blocks.
 
 ### Foreign Handlers
 
@@ -476,6 +480,10 @@ non-Windows platform then it is taken to be 'default'.
 Foreign handler's bound symbols are resolved on first use and an error
 is thrown if the symbol cannot be found.
 
+Foreign handlers are always considered unsafe, and thus may only be called
+from unsafe context - i.e. from within an unsafe handler, or unsafe statement
+block.
+
 > **Note:** The current foreign handler definition is an initial
 > version, mainly existing to allow binding to implementation of the
 > syntax present in the standard language modules. It will be expanded
@@ -529,6 +537,7 @@ environment.
       | GetStatement
       | CallStatement
       | BytecodeStatement
+      | UnsafeStatement
 
 There are a number of built-in statements which define control flow,
 variables, and basic variable transfer. The remaining syntax for
@@ -760,8 +769,24 @@ Register definitions define a named register which is local to the current
 bytecode block. Registers are the same as handler-local variables except
 that they do not undergo default initialization.
 
+Bytecode statements are considered to be unsafe and can only appear inside
+unsafe handlers or unsafe statement blocks.
+
 > **Note:** Bytecode blocks are not intended for general use and the actual
 > available operations are subject to change.
+
+### Unsafe Statements
+
+    UnsafeStatement
+      : 'unsafe' SEPARATOR
+            { Statement }
+        'end' 'unsafe'
+
+The unsafe statement allows a block of unsafe code to be written in a safe
+context.
+
+In particular, calls to unsafe handlers (including all foreign handlers) and
+bytecode blocks are allowed in unsafe statement blocks but nowhere else.
 
 ## Expressions
 

--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -168,55 +168,69 @@ constant kBoolProps is [0, 1, 2, 3]
 public handler browserListToLCBList(in pBrowserList as MCBrowserListRef, out rList as List) returns Boolean
 	variable tList as List
 	put the empty list into tList
-	
+
 	variable tCount as CUInt
-	if not MCBrowserListGetSize(pBrowserList, tCount) then
-		log "couldn't get size"
-		return false
-	end if
-	
+    unsafe
+        if not MCBrowserListGetSize(pBrowserList, tCount) then
+            log "couldn't get size"
+            return false
+        end if
+    end unsafe
+
 	variable tIndex
 	repeat with tIndex from 0 up to tCount - 1
 		variable tType as MCBrowserValueType
-		if not MCBrowserListGetType(pBrowserList, tIndex, tType) then
-			log "couldn't get type of %@" with [tIndex]
-			return false
-		end if
+        unsafe
+            if not MCBrowserListGetType(pBrowserList, tIndex, tType) then
+                log "couldn't get type of %@" with [tIndex]
+                return false
+            end if
+        end unsafe
 		
 		if tType is kMCBrowserValueTypeBoolean then
 			variable tBoolean as CBool
-			if not MCBrowserListGetBoolean(pBrowserList, tIndex, tBoolean) then
-				log "couldn't get boolean %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserListGetBoolean(pBrowserList, tIndex, tBoolean) then
+                    log "couldn't get boolean %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			push tBoolean onto tList
 		else if tType is kMCBrowserValueTypeInteger then
 			variable tInteger as CInt
-			if not MCBrowserListGetInteger(pBrowserList, tIndex, tInteger) then
-				log "couldn't get integer %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserListGetInteger(pBrowserList, tIndex, tInteger) then
+                    log "couldn't get integer %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			push tInteger onto tList
 		else if tType is kMCBrowserValueTypeDouble then
 			variable tDouble as CDouble
-			if not MCBrowserListGetDouble(pBrowserList, tIndex, tDouble) then
-				log "couldn't get double %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserListGetDouble(pBrowserList, tIndex, tDouble) then
+                    log "couldn't get double %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			push tDouble onto tList
 		else if tType is kMCBrowserValueTypeUTF8String then
 			variable tUTF8String as ZStringNative
-			if not MCBrowserListGetUTF8String(pBrowserList, tIndex, tUTF8String) then
-				log "couldn't get string %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserListGetUTF8String(pBrowserList, tIndex, tUTF8String) then
+                    log "couldn't get string %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			push tUTF8String onto tList
 		else if tType is kMCBrowserValueTypeList then
 			variable tBrowserList as MCBrowserListRef
-			if not MCBrowserListGetList(pBrowserList, tIndex, tBrowserList) then
-				log "couldn't get list %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserListGetList(pBrowserList, tIndex, tBrowserList) then
+                    log "couldn't get list %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			variable tConvertedList as List
 			if not browserListToLCBList(tBrowserList, tConvertedList) then
 				log "couldn't convert list %@" with [tIndex]
@@ -225,10 +239,12 @@ public handler browserListToLCBList(in pBrowserList as MCBrowserListRef, out rLi
 			push tConvertedList onto tList
 		else if tType is kMCBrowserValueTypeDictionary then
 			variable tBrowserDict as MCBrowserDictionaryRef
-			if not MCBrowserListGetDictionary(pBrowserList, tIndex, tBrowserDict) then
-				log "couldn't get dictionary %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserListGetDictionary(pBrowserList, tIndex, tBrowserDict) then
+                    log "couldn't get dictionary %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			variable tConvertedDict as Array
 			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then 
 				log "couldn't convert dictionary %@" with [tIndex]
@@ -251,59 +267,75 @@ public handler browserDictionaryToLCBArray(in pBrowserDict as MCBrowserDictionar
 	put the empty array into tArray
 	
 	variable tCount as CUInt
-	if not MCBrowserDictionaryGetKeyCount(pBrowserDict, tCount) then
-		log "couldn't get size"
-		return false
-	end if
-	
+    unsafe
+        if not MCBrowserDictionaryGetKeyCount(pBrowserDict, tCount) then
+            log "couldn't get size"
+            return false
+        end if
+    end unsafe
+
 	variable tIndex
 	repeat with tIndex from 0 up to tCount - 1
 		variable tKey as String
-		if not MCBrowserDictionaryGetKey(pBrowserDict, tIndex, tKey) then
-			log "couldn't get key of %@" with [tIndex]
-			return false
-		end if
+        unsafe
+            if not MCBrowserDictionaryGetKey(pBrowserDict, tIndex, tKey) then
+                log "couldn't get key of %@" with [tIndex]
+                return false
+            end if
+        end unsafe
 		
 		variable tType as MCBrowserValueType
-		if not MCBrowserDictionaryGetType(pBrowserDict, tKey, tType) then
-			log "couldn't get type of %@" with [tIndex]
-			return false
-		end if
-		
+        unsafe
+            if not MCBrowserDictionaryGetType(pBrowserDict, tKey, tType) then
+                log "couldn't get type of %@" with [tIndex]
+                return false
+            end if
+        end unsafe
+
 		if tType is kMCBrowserValueTypeBoolean then
 			variable tBoolean as CBool
-			if not MCBrowserDictionaryGetBoolean(pBrowserDict, tKey, tBoolean) then
-				log "couldn't get boolean %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserDictionaryGetBoolean(pBrowserDict, tKey, tBoolean) then
+                    log "couldn't get boolean %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			put tBoolean into tArray[tKey]
 		else if tType is kMCBrowserValueTypeInteger then
 			variable tInteger as CInt
-			if not MCBrowserDictionaryGetInteger(pBrowserDict, tKey, tInteger) then
-				log "couldn't get integer %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserDictionaryGetInteger(pBrowserDict, tKey, tInteger) then
+                    log "couldn't get integer %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			put tInteger into tArray[tKey]
 		else if tType is kMCBrowserValueTypeDouble then
 			variable tDouble as CDouble
-			if not MCBrowserDictionaryGetDouble(pBrowserDict, tKey, tDouble) then
-				log "couldn't get double %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserDictionaryGetDouble(pBrowserDict, tKey, tDouble) then
+                    log "couldn't get double %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			put tDouble into tArray[tKey]
 		else if tType is kMCBrowserValueTypeUTF8String then
 			variable tUTF8String as ZStringNative
-			if not MCBrowserDictionaryGetUTF8String(pBrowserDict, tKey, tUTF8String) then
-				log "couldn't get string %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserDictionaryGetUTF8String(pBrowserDict, tKey, tUTF8String) then
+                    log "couldn't get string %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			put tUTF8String into tArray[tKey]
 		else if tType is kMCBrowserValueTypeList then
 			variable tBrowserList as MCBrowserListRef
-			if not MCBrowserDictionaryGetList(pBrowserDict, tKey, tBrowserList) then
-				log "couldn't get list %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserDictionaryGetList(pBrowserDict, tKey, tBrowserList) then
+                    log "couldn't get list %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			variable tConvertedList as List
 			if not browserListToLCBList(tBrowserList, tConvertedList) then
 				log "couldn't convert list %@" with [tIndex]
@@ -312,10 +344,12 @@ public handler browserDictionaryToLCBArray(in pBrowserDict as MCBrowserDictionar
 			put tConvertedList into tArray[tKey]
 		else if tType is kMCBrowserValueTypeDictionary then
 			variable tBrowserDict as MCBrowserDictionaryRef
-			if not MCBrowserDictionaryGetDictionary(pBrowserDict, tKey, tBrowserDict) then
-				log "couldn't get dictionary %@" with [tIndex]
-				return false
-			end if
+            unsafe
+                if not MCBrowserDictionaryGetDictionary(pBrowserDict, tKey, tBrowserDict) then
+                    log "couldn't get dictionary %@" with [tIndex]
+                    return false
+                end if
+            end unsafe
 			variable tConvertedDict as Array
 			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then 
 				log "couldn't convert dictionary %@" with [tIndex]
@@ -349,12 +383,14 @@ end handler
 ----------
 
 public handler browserGetEnumProperty(in pBrowser as MCBrowserRef, in pProperty as MCBrowserProperty, out rValue as optional any) returns Boolean
-	if pProperty is in kStringProps then
-		return MCBrowserGetStringProperty(pBrowser, pProperty, rValue)
-	else if pProperty is in kBoolProps then
-		return MCBrowserGetBoolProperty(pBrowser, pProperty, rValue)
-	end if
-	
+    unsafe
+        if pProperty is in kStringProps then
+            return MCBrowserGetStringProperty(pBrowser, pProperty, rValue)
+        else if pProperty is in kBoolProps then
+            return MCBrowserGetBoolProperty(pBrowser, pProperty, rValue)
+        end if
+    end unsafe
+
 	return false
 end handler
 
@@ -368,12 +404,14 @@ public handler browserGetProperty(in pBrowser as MCBrowserRef, in pProperty as S
 end handler
 
 public handler browserSetEnumProperty(in pBrowser as MCBrowserRef, in pProperty as MCBrowserProperty, in pValue as any) returns Boolean
-	if pProperty is in kStringProps then
-		return MCBrowserSetStringProperty(pBrowser, pProperty, pValue)
-	else if pProperty is in kBoolProps then
-		return MCBrowserSetBoolProperty(pBrowser, pProperty, pValue)
-	end if
-	
+    unsafe
+        if pProperty is in kStringProps then
+            return MCBrowserSetStringProperty(pBrowser, pProperty, pValue)
+        else if pProperty is in kBoolProps then
+            return MCBrowserSetBoolProperty(pBrowser, pProperty, pValue)
+        end if
+    end unsafe
+
 	return false
 end handler
 	
@@ -392,12 +430,12 @@ private variable mRunloopAction as MCRunloopActionRef
 private variable mWaitHandler
 
 /* TODO - need to provide a wrapper handler here as we can't (yet) get a pointer to a foreign native handler */
-private handler doWait() returns CBool
+private unsafe handler doWait() returns CBool
 	MCEngineRunloopWait()
 	return true
 end handler
 
-private handler doBreakWait() returns nothing
+private unsafe handler doBreakWait() returns nothing
 	MCEngineRunloopBreakWait()
 end handler
 
@@ -405,19 +443,21 @@ public handler libbrowserInit() returns nothing
 	if mInitialized is not nothing then
 		return
 	end if
-	
-	if not MCBrowserLibraryInitialize() then
-		return
-	end if
 
-	MCBrowserLibrarySetWaitFunction(doWait)
-	MCBrowserLibrarySetBreakWaitFunction(doBreakWait)
+    unsafe
+        if not MCBrowserLibraryInitialize() then
+            return
+        end if
 
-	variable tCallback as MCRunloopActionCallback
-	variable tContext as Pointer
-	if MCBrowserLibraryGetRunloopCallback(tCallback, tContext) then
-		MCEngineAddRunloopAction(tCallback, tContext, mRunloopAction)
-	end if
+        MCBrowserLibrarySetWaitFunction(doWait)
+        MCBrowserLibrarySetBreakWaitFunction(doBreakWait)
+
+        variable tCallback as MCRunloopActionCallback
+        variable tContext as Pointer
+        if MCBrowserLibraryGetRunloopCallback(tCallback, tContext) then
+            MCEngineAddRunloopAction(tCallback, tContext, mRunloopAction)
+        end if
+    end unsafe
 	
 	put true into mInitialized
 end handler

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -405,7 +405,7 @@ end handler
 
 --
 
-private handler InitBrowserView()
+private unsafe handler InitBrowserView()
 	variable tParent as Pointer
 	
 	// put my native window into tParent
@@ -437,7 +437,7 @@ private handler InitBrowserView()
 	applyProperties(mProperties)
 end handler
 
-private handler FinalizeBrowserView()
+private unsafe handler FinalizeBrowserView()
 	//set my native layer to nothing
 	MCWidgetSetMyNativeLayer(nothing)
 	
@@ -454,11 +454,15 @@ public handler OnOpen()
 
 	put true into mOpened
 
-	InitBrowserView()
+    unsafe
+        InitBrowserView()
+    end unsafe
 end handler
 
 public handler OnClose()
-	FinalizeBrowserView()
+    unsafe
+        FinalizeBrowserView()
+    end unsafe
 
 	put false into mOpened
 end handler
@@ -565,9 +569,11 @@ private handler setUrl(in pUrl as String)
 		updateUrlProperty(pUrl)
 
 		if mBrowser is not nothing then
-			if not MCBrowserGoToURL(mBrowser, pUrl) then
-				throw "error launching url " & pUrl
-			end if
+            unsafe
+                if not MCBrowserGoToURL(mBrowser, pUrl) then
+                    throw "error launching url " & pUrl
+                end if
+            end unsafe
 		end if
 	end if
 end handler
@@ -665,17 +671,21 @@ end handler
 
 public handler OnGoBack()
 	if mBrowser is not nothing then
-		if not MCBrowserGoBack(mBrowser) then
-			throw "error going back"
-		end if
+        unsafe
+            if not MCBrowserGoBack(mBrowser) then
+                throw "error going back"
+            end if
+        end unsafe
 	end if
 end handler
 
 public handler OnGoForward()
 	if mBrowser is not nothing then
-		if not MCBrowserGoForward(mBrowser) then
-			throw "error going forward"
-		end if
+        unsafe
+            if not MCBrowserGoForward(mBrowser) then
+                throw "error going forward"
+            end if
+        end unsafe
 	end if
 end handler
 
@@ -686,10 +696,12 @@ end handler
 private handler browserEvaluateJavaScript(in pScript as String) returns String
 	if mBrowser is not nothing then
 		variable tResult as String
-		if not MCBrowserEvaluateJavaScript(mBrowser, pScript, tResult) then
-			throw "error evaluating javascript"
-		end if
-		
+        unsafe
+            if not MCBrowserEvaluateJavaScript(mBrowser, pScript, tResult) then
+                throw "error evaluating javascript"
+            end if
+        end unsafe
+
 		return tResult
 	end if
 	

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1312,7 +1312,9 @@ foreign handler MCStringDecode(in BinaryData as Data, in Encoding as LCUInt, in 
 
 // Temporary wrapper to allow conversion of data to string until it is implemented in the LCB stdlib
 private handler ConvertToString(in pData as Data, out rString as optional String) returns Boolean
-    return MCStringDecode(pData, kUTF8Encoding, false, rString)
+    unsafe
+        return MCStringDecode(pData, kUTF8Encoding, false, rString)
+    end unsafe
 end handler
 
 // Convert an array to a list, as used by this widget. Ignoring the 'folded' ans selected

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3283,6 +3283,7 @@ struct MCPickleVariantInfo
 #define MC_PICKLE_TYPEINFOREF(Field) MC_PICKLE_FIELD(TypeInfoRef, Field, 0)
 
 #define MC_PICKLE_INTENUM(EType, EField) MC_PICKLE_FIELD(IntEnum, EField, k##EType##__Last)
+#define MC_PICKLE_INTSET(SType, SField) MC_PICKLE_FIELD(IntEnum, SField, 0)
 
 #define MC_PICKLE_ARRAY_OF_BYTE(Field, CountField) MC_PICKLE_FIELD_AUX(ArrayOfByte, Field, CountField, 0)
 #define MC_PICKLE_ARRAY_OF_UINDEX(Field, CountField) MC_PICKLE_FIELD_AUX(ArrayOfUIndex, Field, CountField, 0)

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -311,6 +311,12 @@ enum MCScriptHandlerTypeParameterMode
     kMCScriptHandlerTypeParameterMode__Last
 };
 
+enum MCScriptHandlerAttributes
+{
+    kMCScriptHandlerAttributeSafe = 0 << 0,
+    kMCScriptHandlerAttributeUnsafe = 1 << 0,
+};
+    
 void MCScriptBeginModule(MCScriptModuleKind kind, MCNameRef name, MCScriptModuleBuilderRef& r_builder);
 bool MCScriptEndModule(MCScriptModuleBuilderRef builder, MCStreamRef stream);
 
@@ -345,7 +351,7 @@ void MCScriptAddTypeToModule(MCScriptModuleBuilderRef builder, MCNameRef name, u
 void MCScriptAddConstantToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t const_idx, uindex_t index);
 void MCScriptAddVariableToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index);
 
-void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t signature, uindex_t index);
+void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t signature, MCScriptHandlerAttributes attributes, uindex_t index);
 void MCScriptAddParameterToHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t& r_index);
 void MCScriptAddVariableToHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t& r_index);
 void MCScriptEndHandlerInModule(MCScriptModuleBuilderRef builder);

--- a/libscript/src/math.lcb
+++ b/libscript/src/math.lcb
@@ -128,7 +128,9 @@ end syntax
 
 public handler Sin(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalSinNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalSinNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -152,7 +154,9 @@ end syntax
 
 public handler Cos(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalCosNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalCosNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -180,7 +184,9 @@ end syntax
 
 public handler Tan(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalTanNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalTanNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -211,7 +217,9 @@ end syntax
 
 public handler Asin(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalAsinNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalAsinNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -242,7 +250,9 @@ end syntax
 
 public handler Acos(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalAcosNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalAcosNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -273,7 +283,9 @@ end syntax
 
 public handler Atan(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalAtanNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalAtanNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -306,7 +318,9 @@ end syntax
 
 public handler atan2(in pY as Number, in pX as Number) returns Number
     variable tVar as Number
-    MCMathEvalAtan2Number(pX, pY, tVar)
+    unsafe
+        MCMathEvalAtan2Number(pX, pY, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -332,7 +346,9 @@ end syntax
 
 public handler log10(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalBase10LogNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalBase10LogNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -359,7 +375,9 @@ end syntax
 
 public handler Ln(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalNaturalLogNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalNaturalLogNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -385,7 +403,9 @@ end syntax
 
 public handler Exp(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalExpNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalExpNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -477,7 +497,9 @@ end syntax
 
 public handler Min(in pX as Number, in pY as Number) returns Number
     variable tVar as Number
-    MCMathEvalMinNumber(pX, pY, tVar)
+    unsafe
+        MCMathEvalMinNumber(pX, pY, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -499,7 +521,9 @@ end syntax
 
 public handler Max(in pX as Number, in pY as Number) returns Number
     variable tVar as Number
-    MCMathEvalMaxNumber(pX, pY, tVar)
+    unsafe
+        MCMathEvalMaxNumber(pX, pY, tVar)
+    end unsafe
     return tVar
 end handler
 

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1357,7 +1357,7 @@ static void __emit_position(MCScriptModuleBuilderRef self, uindex_t p_address, u
     self -> module . positions[t_pindex] . line = p_line;
 }
 
-void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, uindex_t p_index)
+void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, MCScriptHandlerAttributes p_attributes, uindex_t p_index)
 {
     if (self == nil || !self -> valid)
         return;
@@ -1377,6 +1377,7 @@ void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCNameRef p_nam
     
     t_definition -> kind = kMCScriptDefinitionKindHandler;
     t_definition -> type = p_type;
+    t_definition -> attributes = p_attributes;
     t_definition -> start_address = self -> module . bytecode_count;
     
     self -> current_handler = p_index;

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -133,6 +133,7 @@ MC_PICKLE_BEGIN_RECORD(MCScriptHandlerDefinition)
     MC_PICKLE_ARRAY_OF_NAMEREF(local_names, local_name_count)
     MC_PICKLE_UINDEX(start_address)
     MC_PICKLE_UINDEX(finish_address)
+    MC_PICKLE_INTSET(MCScriptHandlerAttributes, attributes)
 MC_PICKLE_END_RECORD()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptForeignHandlerDefinition)
@@ -1293,9 +1294,14 @@ bool MCScriptWriteInterfaceOfModule(MCScriptModuleRef self, MCStreamRef stream)
             break;
             case kMCScriptDefinitionKindHandler:
             {
+                MCScriptHandlerDefinition *t_handler;
+                t_handler = static_cast<MCScriptHandlerDefinition *>(t_def);
                 MCAutoStringRef t_sig;
-                type_to_string(self, static_cast<MCScriptHandlerDefinition *>(t_def) -> type, &t_sig);
-                __writeln(stream, "handler %@%@", t_def_name, *t_sig);
+                type_to_string(self, t_handler -> type, &t_sig);
+                if ((t_handler -> attributes & kMCScriptHandlerAttributeUnsafe) == 0)
+                    __writeln(stream, "handler %@%@", t_def_name, *t_sig);
+                else
+                    __writeln(stream, "unsafe handler %@%@", t_def_name, *t_sig);
             }
             break;
             case kMCScriptDefinitionKindForeignHandler:

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -271,6 +271,8 @@ struct MCScriptHandlerDefinition: public MCScriptCommonHandlerDefinition
 	uindex_t start_address;
 	uindex_t finish_address;
     
+    MCScriptHandlerAttributes attributes;
+    
     // The number of slots required in a frame in order to execute this handler - computed.
     uindex_t slot_count;
 };
@@ -600,7 +602,8 @@ bool MCScriptBytecodeIterate(byte_t*& x_bytecode, byte_t *p_bytecode_limit, MCSc
 // of each module version.
 
 #define kMCScriptModuleVersion_8_0_0_DP_1 0
-#define kMCScriptCurrentModuleVersion kMCScriptModuleVersion_8_0_0_DP_1
+#define kMCScriptModuleVersion_8_1_0_DP_2 1
+#define kMCScriptCurrentModuleVersion kMCScriptModuleVersion_8_1_0_DP_2
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libscript/src/system.lcb
+++ b/libscript/src/system.lcb
@@ -63,11 +63,15 @@ end syntax
 foreign handler __exit(in ExitStatus as CInt) returns nothing binds to "exit"
 
 public handler MCSystemExecQuit() returns nothing
-	__exit(0)
+    unsafe
+        __exit(0)
+    end unsafe
 end handler
 
 public handler MCSystemExecQuitWithStatus(in Status as Number)
-	__exit(Status)
+    unsafe
+        __exit(Status)
+    end unsafe
 end handler
 
 /**

--- a/libscript/src/unittest-impl.lcb
+++ b/libscript/src/unittest-impl.lcb
@@ -43,7 +43,9 @@ end handler
 
 public handler MCUnitDiagnostic(in pMessage as any)
 	variable tCopyMessage as String
-	MCValueCopyDescription(pMessage, tCopyMessage)
+    unsafe
+        MCValueCopyDescription(pMessage, tCopyMessage)
+    end unsafe
 
 	variable tMessageLines as List
 	split tCopyMessage by "\n" into tMessageLines
@@ -94,7 +96,9 @@ public handler MCUnitOutput(in pMessage as String)
 	-- Encode as UTF-8, always.
 	-- FIXME this should use LCB encoding library rather than directly
 	-- calling into libfoundation
-	MCStringEncode(pMessage, 4 /* UTF-8 */, false, tEncoded)
+    unsafe
+        MCStringEncode(pMessage, 4 /* UTF-8 */, false, tEncoded)
+    end unsafe
 
 	write tEncoded to the output stream
 end handler

--- a/libscript/src/unittest.lcb
+++ b/libscript/src/unittest.lcb
@@ -137,7 +137,9 @@ begin
 end syntax
 
 public handler MCUnitTest(in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, "", "", "")
+    unsafe
+        MCUnitOutputTest(pCondition, "", "", "")
+    end unsafe
 end handler
 
 /**
@@ -164,7 +166,9 @@ begin
 end syntax
 
 public handler MCUnitTestDescription(in pDescription as String, in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, pDescription, "", "")
+    unsafe
+        MCUnitOutputTest(pCondition, pDescription, "", "")
+    end unsafe
 end handler
 
 ----------------------------------------------------------------
@@ -187,7 +191,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkip()
-	MCUnitOutputTest(true, "", "SKIP", "")
+    unsafe
+        MCUnitOutputTest(true, "", "SKIP", "")
+    end unsafe
 end handler
 
 /**
@@ -212,7 +218,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkipDescription(in pDescription as String)
-	MCUnitOutputTest(true, pDescription, "SKIP", "")
+    unsafe
+        MCUnitOutputTest(true, pDescription, "SKIP", "")
+    end unsafe
 end handler
 
 /**
@@ -237,7 +245,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkipReason(in pReason as String)
-	MCUnitOutputTest(true, "", "SKIP", pReason)
+    unsafe
+        MCUnitOutputTest(true, "", "SKIP", pReason)
+    end unsafe
 end handler
 
 /**
@@ -265,7 +275,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkipDescriptionAndReason(in pDescription as String, in pReason as String)
-	MCUnitOutputTest(true, pDescription, "SKIP", pReason)
+    unsafe
+        MCUnitOutputTest(true, pDescription, "SKIP", pReason)
+    end unsafe
 end handler
 
 ----------------------------------------------------------------
@@ -295,7 +307,9 @@ begin
 end syntax
 
 public handler MCUnitTestFails(in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, "", "TODO", "")
+    unsafe
+        MCUnitOutputTest(pCondition, "", "TODO", "")
+    end unsafe
 end handler
 
 /**
@@ -326,7 +340,9 @@ begin
 end syntax
 
 public handler MCUnitTestFailsDescription(in pDescription as String, in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, pDescription, "TODO", "")
+    unsafe
+        MCUnitOutputTest(pCondition, pDescription, "TODO", "")
+    end unsafe
 end handler
 
 /**
@@ -358,7 +374,9 @@ begin
 end syntax
 
 public handler MCUnitTestFailsReason(in pCondition as Boolean, in pReason as String)
-	MCUnitOutputTest(pCondition, "", "TODO", pReason)
+    unsafe
+        MCUnitOutputTest(pCondition, "", "TODO", pReason)
+    end unsafe
 end handler
 
 /**
@@ -391,7 +409,9 @@ begin
 end syntax
 
 public handler MCUnitTestFailsDescriptionAndReason(in pDescription as String, in pCondition as Boolean, in pReason as String)
-	MCUnitOutputTest(pCondition, pDescription, "TODO", pReason)
+    unsafe
+        MCUnitOutputTest(pCondition, pDescription, "TODO", pReason)
+    end unsafe
 end handler
 
 end module

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,17 @@ endif
 # Attempt to guess where to find various tools and libraries
 ################################################################
 
+MODE ?= release
+ifeq ($(MODE),release)
+	UC_MODE := Release
+else ifeq ($(MODE),debug)
+	UC_MODE := Debug
+else ifeq ($(MODE),fast)
+	UC_MODE := Fast
+else
+	$(error "Mode must be 'debug' or 'release'")
+endif
+
 top_srcdir ?= ..
 TEST_DIR ?= $(top_srcdir)/_tests
 LCM_DIR ?= $(TEST_DIR)/_build
@@ -26,7 +37,11 @@ guess_platform_script := \
 	esac
 guess_platform := $(shell $(guess_platform_script))
 
-bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
+ifeq ($(guess_platform),mac)
+	bin_dir ?= $(top_srcdir)/_build/mac/$(UC_MODE)
+else
+	bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
+endif
 
 ########## LiveCode Script test parameters
 
@@ -66,6 +81,14 @@ LCB_LOG = _lcb_test_suite.log
 
 LCB_TESTRUNNER = $(LCM_DIR)/_testrunner.lcm
 LCB_TESTLIB = $(LCM_DIR)/_testlib.lcm
+
+########## LiveCode Builder Compiler test parameters
+
+LCC_COMPILERTESTRUNNER ?= $(top_srcdir)/tests/_compilertestrunner.livecodescript
+
+LCC_CMD = $(LCS_ENGINE) -ui $(LCC_COMPILERTESTRUNNER) run
+
+LCC_LOG = _compiler_test_suite.log
 
 ################################################################
 # Top-level targets
@@ -137,6 +160,17 @@ $(LCM_DIR)/%.lcm: %.lcb | $(LCM_DIR)
 lcs-check: $(LCS_ENGINE)
 	@rm -f $(LCS_LOG)
 	@cmd="$(LCS_CMD)"; \
+	echo "$$cmd" $(_PRINT_RULE); \
+	$$cmd
+
+################################################################
+# LCB compiler tests
+################################################################
+
+compiler-check: $(LC_COMPILE)
+	@rm -f $(LCC_LOG)
+	@export LC_COMPILE="$(LC_COMPILE)"; \
+	cmd="$(LCC_CMD)"; \
 	echo "$$cmd" $(_PRINT_RULE); \
 	$$cmd
 

--- a/tests/_compilertestrunner.livecodescript
+++ b/tests/_compilertestrunner.livecodescript
@@ -1,0 +1,681 @@
+﻿script "CompilerTestRunner"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+-- FIXME provide this on the command line
+constant kLogFilename = "_compiler_test_suite.log"
+
+on startup
+   try
+      CompilerTestRunnerMain
+   catch tError
+      write "ERROR: " & tError & return to stderr
+   end try
+   quit 0
+end startup
+
+----------------------------------------------------------------
+-- Command-line processing
+----------------------------------------------------------------
+
+private function getCommandLineInfo
+   local tRawArg, tSelfCommand, tSelfScript, tInArgs, tArgs
+
+   put false into tInArgs
+
+   -- Treat everything up to & including the first
+   -- ".livecodescript" file as the command for running the test
+   -- runner, and everything after it as test runner arguments
+   put the commandName into tSelfCommand[1]
+   repeat for each element tRawArg in the commandArguments
+
+      if tInArgs then
+         put tRawArg into tArgs[1 + the number of elements in tArgs]
+      else
+         put tRawArg into tSelfCommand[1 + the number of elements in tSelfCommand]
+         if tRawArg ends with ".livecodescript" then
+            put tRawArg into tSelfScript
+            put true into tInArgs
+         end if
+      end if
+
+   end repeat
+
+   local tInfo
+   put tSelfCommand into tInfo["self-command"]
+   put tSelfScript into tInfo["self-script"]
+   put tArgs into tInfo["args"]
+
+   return tInfo
+end getCommandLineInfo
+
+----------------------------------------------------------------
+-- Top-level actions
+----------------------------------------------------------------
+
+command CompilerTestRunnerMain
+   local tInfo
+   put getCommandLineInfo() into tInfo
+   logInit
+
+   switch tInfo["args"][1]
+      case "run"
+         doRun tInfo
+         break
+      case "--help"
+      case "-h"
+      case "help"
+         doUsage 0
+         break
+      default
+         doUsage 1
+         break
+   end switch
+   quit 0
+end CompilerTestRunnerMain
+
+private command doRun pInfo
+   local tScript, tCommand, tAnalysis
+   put pInfo["args"][2] into tScript
+   put pInfo["args"][3] into tCommand
+
+   if $LC_COMPILE is empty then
+      throw "LC_COMPILE environment var must be set to lc-compile to use"
+   end if
+
+   runLoadLibrary pInfo
+
+   if tScript is empty then
+      runAllScripts pInfo
+   else if tCommand is empty then
+      runTestScript pInfo, tScript
+   else
+      runTestCommand pInfo, tScript, tCommand
+   end if
+
+   put the result into tAnalysis
+
+   -- Save the log to file.
+   -- We process to binary data ourselves to ensure encoding and
+   -- line endings are appropriate.
+   local tLogForWriting
+   put textEncode(tAnalysis["log"], "utf8") into tLogForWriting
+   if the platform is "win32" then
+      replace return with numToChar(13) & numToChar(10) in tLogForWriting
+   end if
+   put tLogForWriting into url ("binfile:" & kLogFilename)
+
+   if TesterTapGetWorstResult(tAnalysis) is "FAIL" then
+      quit 1
+   end if
+end doRun
+
+private command doUsage pStatus
+   write "Usage: _compilertestrunner.livecodescript run [SCRIPT [COMMAND]]" & return to stderr
+   quit pStatus
+end doUsage
+
+on ErrorDialog pExecutionError
+   write "ERROR:" && pExecutionError & return to stderr
+   quit 1
+end ErrorDialog
+
+----------------------------------------------------------------
+-- Support for running tests
+----------------------------------------------------------------
+
+-- Add the test runner library stack to the backscripts
+private command runLoadLibrary pInfo
+	-- Compute the filename of the library stack
+	local tFilename
+	put pInfo["self-script"] into tFilename
+
+	set the itemDelimiter to slash
+	put "_testerlib.livecodescript" into item -1 of tFilename
+
+	-- Load the library
+	local tStackname
+	put the name of stack tFilename into tStackname
+
+	send "revLoadLibrary" to stack tStackname
+end runLoadLibrary
+
+-- Run all the test scripts that can be found below the current
+-- directory
+private command runAllScripts pInfo
+   local tFile, tAnalysis
+   repeat for each element tFile in TesterGetTestFileNames("", "compilertest")
+      runCompilerTestScript pInfo, tFile
+      put TesterTapCombine(tAnalysis, the result) into tAnalysis
+   end repeat
+   runPrintSummary(tAnalysis)
+
+   return tAnalysis
+end runAllScripts
+
+-- Run the tests found in one specific script file
+private command runCompilerTestScript pInfo, pScriptFile
+   local tTest, tAnalysis
+
+   repeat for each element tTest in listCompilerTestsInFile(pScriptFile)
+      runCompilerTest pInfo, pScriptFile, tTest
+      put TesterTapCombine(tAnalysis, the result) into tAnalysis
+   end repeat
+   return tAnalysis
+end runCompilerTestScript
+
+private command runTestProcessOutput pScriptfile, pCommand, pOutput
+   -- Create test log
+   local tTestLog
+   put "###" && TesterGetPrettyTestName(pScriptFile, "compilertest") && pCommand \
+         & return & return into tTestLog
+   put pOutput & return after tTestLog
+
+   -- Analyse the results and print a summary line
+   local tTapResults
+   put TesterTapAnalyse(tTestLog) into tTapResults
+
+   logSummaryLine tTapResults, (TesterGetPrettyTestName(pScriptFile, "compilertest") & ":" && pCommand)
+
+   return tTapResults
+end runTestProcessOutput
+
+-- Run a specific named test command tCommand in a script file
+-- tScriptFile
+private command runCompilerTest pInfo, pScriptFile, pTest
+   local tCommandLine
+
+   -- First we need to process the specified test in script file
+
+   local tTestInfo
+   processCompilerTest pInfo, pScriptFile, pTest, tTestInfo
+
+   -- Next we emit the code for the test, then attempt to compile it
+   local tTestFile, tTestInterfaceFile
+   put tempName() into tTestFile
+   put tempName() into tTestInterfaceFile
+   put textEncode(tTestInfo["code"], "utf8") into url ("binfile:" & tTestFile)
+   reportCompilerTestDiag format("output test source file to '%s'", tTestFile)
+   reportCompilerTestDiag tTestInfo["code"]
+
+   -- Build the command line
+   local tCompilerCmdLine
+   put format("%s --error-info --interface %s %s", $LC_COMPILE, tTestInterfaceFile, tTestFile) into tCompilerCmdLine
+   reportCompilerTestDiag format("compile command is %s", tCompilerCmdLine)
+
+   -- Try to execute the compilation
+   local tCompilerOutput, tCompilerExitStatus
+   put shell(tCompilerCmdLine) into tCompilerOutput
+   put the result into tCompilerExitStatus
+   reportCompilerTestDiag "compile command output"
+
+   -- Remove the test file
+   delete file tTestFile
+   delete file tTestInterfaceFile
+
+   -- The output from the subprocesses will be native encoded utf-8.
+   put textDecode(tCompilerOutput, "utf8") into tCompilerOutput
+   reportCompilerTestDiag tCompilerOutput
+
+   -- Process the assertions and make sure each one matches up
+   repeat for each line tAssertion in tTestInfo["assertions"]
+      if doesCompilerOutputSatisfyAssertion(tCompilerOutput, tCompilerExitStatus, tAssertion, tTestInfo["positions"]) then
+         put "ok - " after tTestOutput
+      else
+         put "not ok - " after tTestOutput
+      end if
+      put compilerPrettyPrintAssertion(tAssertion, tTestInfo["positions"]) & return after tTestOutput
+   end repeat
+
+   runTestProcessOutput pScriptFile, pTest, tTestOutput
+   return the result
+end runCompilerTest
+
+-- Print out a table of statistics
+private command runPrintSummary pAnalysis
+   local tSummaryString, tTotal, tDecoration
+
+   put TesterTapGetTestCount(pAnalysis) into tTotal
+
+   -- Format basic summary information
+   if pAnalysis["xfail"] is 0 and pAnalysis["fail"] is 0 then
+      put "All" && tTotal && "tests passed" into tSummaryString
+
+   else if pAnalysis["fail"] is 0 then
+      put "All" && tTotal && "tests behaved as expected" into tSummaryString
+
+   else
+      put pAnalysis["fail"] && "OF" && tTotal && "TESTS FAILED" into tSummaryString
+   end if
+
+   put return after tSummaryString
+
+   -- Add extra summary info from expected failure & skip directives
+   if pAnalysis["xpass"] > 0 then
+      put tab & pAnalysis["xpass"] && "unexpected passes" & return after tSummaryString
+   end if
+   if pAnalysis["xfail"] > 0 then
+      put tab & pAnalysis["xfail"] && "expected failures" & return after tSummaryString
+   end if
+   if pAnalysis["skip"] > 0 then
+      put tab & pAnalysis["skip"] && "skipped" & return after tSummaryString
+   end if
+
+   put "================================================================" into tDecoration
+   put tDecoration & return before tSummaryString
+   put tDecoration & return after tSummaryString
+
+   write tSummaryString to stdout
+end runPrintSummary
+
+----------------------------------------------------------------
+-- Support for generating the compiler tests
+----------------------------------------------------------------
+
+-- Get a number-indexed array containing the names of all "test"
+-- blocks in pFilename.
+private function listCompilerTestsInFile pFilename
+   local tScript
+
+   -- Get the contents of the file
+   open file pFilename for "UTF-8" text read
+   if the result is not empty then
+      throw the result
+   end if
+
+   read from file pFilename until end
+   put it into tScript
+
+   close file pFilename
+
+   -- Scan the file for "on Test*" definitions
+   local tTestNames, tCount, tLine, tName
+
+   repeat for each line tLine in tScript
+      if word 1 of tLine is not "%TEST" then
+         next repeat
+      end if
+
+      put word 2 of tLine into tName
+
+      add 1 to tCount
+      put tName into tTestNames[tCount]
+   end repeat
+
+   return tTestNames
+end listCompilerTestsInFile
+
+private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerExitCode, pAssertion, pPositions
+   if item 1 of pAssertion is "success" then
+      return pCompilerExitCode is 0
+   end if
+
+   local tAssertionType, tAssertionTag, tAssertionPos, tAssertionParam
+   put item 1 of pAssertion into tAssertionType
+   put item 2 of pAssertion into tAssertionTag
+   put item 3 of pAssertion into tAssertionPos
+   put item 4 of pAssertion into tAssertionParam
+
+   set the itemDelimiter to ":"
+   repeat for each line tOutputLine in pCompilerOutput
+      local tFile, tLine, tRow, tType, tTag, tParam
+      put item 1 of tOutputLine into tFile
+      put item 2 of tOutputLine into tLine
+      put item 3 of tOutputLine into tRow
+      put item 4 of tOutputLine into tType
+      put item 5 of tOutputLine into tTag
+      put item 6 of tOutputLine into tParam
+
+      -- If the assertion type doesn't match, continue
+      if tAssertionType is not tType then
+         next repeat
+      end if
+
+      -- If the tag doesn't match, continue
+      if tAssertionTag is not tTag then
+         next repeat
+      end if
+
+      -- If the position does not match, continue
+      if pPositions[tAssertionPos] is not tLine then
+         next repeat
+      end if
+
+      -- If the param does not match, continue
+      if tAssertionParam is not tParam then
+         next repeat
+      end if
+
+      -- If we get here, we have a match so are successful!
+      return true
+   end repeat
+
+   -- We failed to find a suitable output line, so failure
+   return false
+end doesCompilerOutputSatisfyAssertion
+
+private function compilerPrettyPrintAssertion pAssertion, pPositions
+   if item 1 of pAssertion is "success" then
+      return "compile succeeded"
+   end if
+
+   if item 1 of pAssertion is among the items of "error,warning" then
+      return format("%s %s at line %d", item 1 of pAssertion, item 2 of pAssertion, pPositions[item 3 of pAssertion])
+   end if
+
+   return "UNKNOWN ASSERTION TYPE"
+end compilerPrettyPrintAssertion
+
+private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
+   -- Get the contents of the file
+   open file pScriptFile for "UTF-8" text read
+   if the result is not empty then
+      throw format("can't open file '%s'", pScriptFile)
+   end if
+
+   read from file pScriptFile until end
+   put it into tScript
+
+   close file pScriptFile
+
+   -- First extract the test block we are wanting to run
+   local tLine, tLineNumber, tTestLineNumber, tState
+   local tName, tCode, tExpectation, tAssertions, tPositions
+   put empty into tLine
+   put 0 into tLineNumber
+   put 0 into tTestLineNumber
+   put empty into tState
+   put empty into tName
+   put empty into tCode
+   put empty into tExpectation
+   put empty into tAssertions
+   put empty into tPositions
+   repeat for each line tLine in tScript
+      add 1 to tLineNumber
+
+      local tIsDirective
+      put false into tIsDirective
+      if tState is "code" then
+         if word 1 of tLine begins with "%" and \
+               not (word 1 of tLine begins with "%{") then
+               put true into tIsDirective
+         end if
+      else
+         if word 1 of tLine begins with "%" then
+            put true into tIsDirective
+         end if
+      end if
+
+      if tIsDirective then
+         local tToken
+         put word 1 of tLine into tToken
+
+         if tToken is "%%" then
+            -- We don't allow comment directives inside code blocks
+            if tState is "code" then
+               reportCompilerTestError pScriptFile, tLineNumber, "comment directives not allowed in code block"
+            end if
+            -- Ignore comment lines
+            next repeat
+         else if tToken is "%TEST" then
+            -- If we are already in a test block, it is an error
+            if tState is not empty then
+               reportCompilerTestError pScriptFile, tLineNumber, "%TEST directive not allowed inside test block"
+            end if
+
+            -- We've started a new test clause, so record the name and move to
+            -- code state.
+            reportCompilerTestDiag format("found test '%s' at line %d", word 2 of tLine, tLineNumber)
+            put word 2 of tLine into tName
+            put tLineNumber + 1 into tTestLineNumber
+            put empty into tCode
+            put empty into tExpectation
+            put empty into tAssertions
+            put "code" into tState
+         else if tToken is "%EXPECT" then
+            -- We only allow %EXPECT directives after code blocks
+            if tState is not "code" then
+               reportCompilerTestError pScriptFile, tLineNumber, "%EXPECT directive only allowed after code block"
+            end if
+
+            -- If the expectation isn't one of PASS, FAIL, XFAIL, SKIP then it
+            -- is an error
+            if word 2 of tLine is not among the items of "PASS,FAIL,XFAIL,SKIP" then
+               reportCompilerTestError pScriptFile, tLineNumber, format("invalid expectation '%s'", word 2 of tLine)
+            end if
+
+            -- Record the expectation, and move to assertions state.
+            put word 2 of tLine into tExpectation
+            put "assertions" into tState
+         else if tToken is among the items of "%SUCCESS,%WARNING,%ERROR" then
+            if tState is not "assertions" then
+               reportCompilerTestError pScriptFile, tLineNumber, "assertion directive outside of assertion block"
+            end if
+
+            if tToken is "%SUCCESS" then
+               if the number of words in tLine is not 1 then
+                  reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %SUCCESS"
+               end if
+
+               reportCompilerTestDiag format("found assert success at line %d", tLineNumber)
+               put "success" & return after tAssertions
+            else if tToken is "%WARNING" then
+               if (the number of words in tLine is 4 and \
+                        word 3 of tLine is "AT") or \
+                  (the number of words in tLine is 6 and \
+                        word 3 of tLine is "AT" and \
+                        word 5 of tLine is "WITH") then
+
+                  -- Check that the position exists
+                  if tPositions[word 4 of tLine] is empty then
+                     reportCompilerTestError pScriptFile, tLineNumber, format("unknown position '%s'", word 4 of tLine)
+                  end if
+
+                  reportCompilerTestDiag format("found assert warning %s for position %s (with '%s') at line %d", word 2 of tLine, word 4 of tLine, word 6 of tLine, tLineNumber)
+
+                  put "warning", word 2 of tLine, word 4 of tLine, word 6 of tLine & return after tAssertions
+               else
+                  reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %WARNING <id> AT <position> [ WITH <id> ]"
+               end if
+            else if tToken is "%ERROR" then
+               if (the number of words in tLine is 4 and \
+                        word 3 of tLine is "AT") or \
+                  (the number of words in tLine is 6 and \
+                        word 3 of tLine is "AT" and \
+                        word 5 of tLine is "WITH") then
+
+                  -- Check that the position exists
+                  if tPositions[word 4 of tLine] is empty then
+                     reportCompilerTestError pScriptFile, tLineNumber, format("unknown position '%s'", word 4 of tLine)
+                  end if
+
+                  reportCompilerTestDiag format("found assert error %s for position %s (with '%s') at line %d", word 2 of tLine, word 4 of tLine, word 6 of tLine, tLineNumber)
+
+                  put "error", word 2 of tLine, word 4 of tLine, word 6 of tLine & return after tAssertions
+               else
+                  reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %ERROR <id> AT <position> [ WITH <id> ]"
+               end if
+            end if
+         else if tToken is "%ENDTEST" then
+            -- If we aren't in assertions state then it isn't a complete test
+            -- clause
+            if tState is not "assertions" then
+               reportCompilerTestError pScriptFile, tLineNumber, "premature %ENDTEST directive"
+            end if
+
+            -- If this is the test we are looking for, we are done
+            if tName is pTest then
+               exit repeat
+            end if
+
+            -- Move back to initial state
+            put empty into tName
+            put empty into tState
+         else
+            -- We've encountered an illegal directive
+            reportCompilerTestError pScriptFile, tLineNumber, format("unknown directive '%s'", tToken)
+         end if
+      else if tState is empty then
+         -- We only allow empty lines outside of test blocks
+         if word 1 to -1 of tLine is not empty then
+            reportCompilerTestError pScriptFile, tLineNumber, "junk outside of test clause"
+         end if
+      else if tState is "code" then
+         -- If we are in a code block, then accumulate the code line after
+         -- processing for position directives %{...}.
+
+         -- We loop through the line, searching for %{...}, and accumulating the
+         -- code in between as we go.
+         local tPositionSkip
+         put 0 into tPositionSkip
+         repeat forever
+            local tPositionOffset
+            put offset("%{", tLine, tPositionSkip) into tPositionOffset
+            if tPositionOffset is 0 then
+               put char tPositionSkip to -1 of tLine after tCode
+               exit repeat
+            end if
+            add tPositionSkip to tPositionOffset
+
+            put char tPositionSkip to tPositionOffset - 1 of tLine after tCode
+
+            -- Look for the end brace, it is an error if it is not there
+            local tPositionEndOffset
+            put offset("}", tLine, tPositionOffset) into tPositionEndOffset
+            if tPositionEndOffset is 0 then
+               reportCompilerTestError pScriptFile, tLineNumber, "unterminated named position"
+            end if
+            add tPositionOffset to tPositionEndOffset
+
+            -- Check that the name is not empty
+            local tPositionName
+            put char tPositionOffset + 2 to tPositionEndOffset - 1 of tLine into tPositionName
+            if tPositionName is empty then
+               reportCompilerTestError pScriptFile, tLineNumber, "empty named position"
+            end if
+
+            -- Check that the position hasn't already been defined
+            if tPositions[tPositionName] is not empty then
+               reportCompilerTestError pScriptFile, tLineNumber, "named position already defined"
+            end if
+
+            reportCompilerTestDiag format("found position '%s' at line %d", tPositionName, tLineNumber)
+            put tLineNumber - tTestLineNumber + 1 into tPositions[tPositionName]
+
+            put tPositionEndOffset + 1 into tPositionSkip
+         end repeat
+
+         -- Add the newline to the code
+         put return after tCode
+      else if tState is "assertions" then
+         -- We only allow directives inside assertion blocks
+         if word 1 to -1 of tLine is not empty then
+            reportCompilerTestError pScriptFile, tLineNumber, "junk inside assertion clause"
+         end if
+      end if
+   end repeat
+
+   if tName is empty then
+      reportCompilerTestError pScriptFile, tLineNumber, format("test '%s' not found in file", pTest)
+   end if
+
+   -- We now have the code for the test, the expectation and a list of
+   -- assertions.
+
+   put tName into rCompilerTest["name"]
+   put tCode into rCompilerTest["code"]
+   put tPositions into rCompilerTest["positions"]
+   put tExpectation into rCompilerTest["expectation"]
+   put tAssertions into rCompilerTest["assertions"]
+end processCompilerTest
+
+private command reportCompilerTestError pFile, pLine, pMessage
+   throw format("'%s', line %d: %s", pFile, pLine, pMessage)
+end reportCompilerTestError
+
+private command reportCompilerTestDiag pMessage
+   if $LCC_VERBOSE then
+      repeat for each line tLine in pMessage
+         write "DIAG:" && tLine & return to stderr
+      end repeat
+   end if
+end reportCompilerTestDiag
+
+----------------------------------------------------------------
+-- Logging helpers
+----------------------------------------------------------------
+
+local sLogInfo
+
+-- Figure out what the highlighting escape codes are for the terminal
+--
+-- FIXME this really doesn't work properly if LiveCode's stdout
+-- *isn't* a TTY.
+private command logInit
+   -- We can only do colour on Linux and OS X
+   if the platform is not "Linux" and the platform is not "MacOS" then
+      put false into sLogInfo
+   end if
+
+   -- Check if colouring is possible
+   local tTput
+   put shell("tput colors") into tTput
+   if the result is not empty or tTput <= 8 then
+      put false into sLogInfo
+   end if
+
+   -- Get colours
+   put shell("tput sgr0") into sLogInfo["normal"]
+   put shell("tput bold") into sLogInfo["bold"]
+   put shell("tput setaf 1") into sLogInfo["red"]
+   put shell("tput setaf 2") into sLogInfo["green"]
+   put shell("tput setaf 3") into sLogInfo["yellow"]
+   put shell("tput setaf 6") into sLogInfo["cyan"]
+end logInit
+
+private function logHighlight pString
+  if pString is "fail" then
+     return sLogInfo["red"] & sLogInfo["bold"] & pString & sLogInfo["normal"]
+  else if pString is "xfail" or pString is "xpass" then
+     return sLogInfo["yellow"] & pString & sLogInfo["normal"]
+  else if pString is "pass" then
+     return sLogInfo["green"] & pString & sLogInfo["normal"]
+  else if pString is "skip" then
+     return sLogInfo["cyan"] & pString & sLogInfo["normal"]
+  else
+     return pString
+  end if
+end logHighlight
+
+private command logSummaryLine pTapResults, pTestName
+   local tTotal, tPassed, tWorst, tMessage
+
+   put pTapResults["xpass"] + pTapResults["pass"] + pTapResults["skip"] into tPassed
+   put TesterTapGetTestCount(pTapResults) into tTotal
+
+   put TesterTapGetWorstResult(pTapResults) into tWorst
+   put logHighLight(the toUpper of tWorst) into tMessage
+   put ":" after tMessage
+   if the number of chars in tWorst < 5 then
+      put space after tMessage
+   end if
+
+   put space & pTestName after tMessage
+
+   put space & "[" & tPassed & "/" & tTotal & "]" after tMessage
+   write tMessage & return to stdout
+end logSummaryLine

--- a/tests/_testerlib.livecodescript
+++ b/tests/_testerlib.livecodescript
@@ -31,7 +31,7 @@ end revLoadLibrary
 
 -- Get all livecode script files beneath the CWD, apart from
 -- filenames starting with "." or "_"
-function TesterGetTestFileNames pBaseFolder
+function TesterGetTestFileNames pBaseFolder, pExtension
    local tFiles, tCount
 
    put empty into tFiles
@@ -41,13 +41,17 @@ function TesterGetTestFileNames pBaseFolder
       put the defaultfolder into pBaseFolder
    end if
 
-   TesterGetTestFileNames_Recursive pBaseFolder, empty, tFiles, tCount
+   if pExtension is empty then
+      put "livecodescript" into pExtension
+   end if
+
+   TesterGetActualFileNames_Recursive pBaseFolder, empty, pExtension, tFiles, tCount
 
    return tFiles
 end TesterGetTestFileNames
 
 -- Helper command used by runGetTestFileNames
-private command TesterGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCount
+private command TesterGetActualFileNames_Recursive pPath, pRelPath, pExtension, @xFiles, @xCount
    -- Save the CWD
    local tSaveFolder
    put the defaultfolder into tSaveFolder
@@ -56,7 +60,7 @@ private command TesterGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCou
    -- Process files in the current directory
    local tFile
    repeat for each line tFile in the files
-      if tFile ends with ".livecodescript" and \
+      if tFile ends with ("." & pExtension) and \
             not (tFile begins with "." or tFile begins with "_") then
 
          if pRelPath is not empty then
@@ -81,12 +85,12 @@ private command TesterGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCou
          put pRelPath & slash before tFolder
       end if
 
-      TesterGetTestFileNames_Recursive tFolderPath, tFolder, xFiles, xCount
+      TesterGetActualFileNames_Recursive tFolderPath, tFolder, pExtension, xFiles, xCount
    end repeat
 
    -- Restore the CWD
    set the defaultfolder to tSaveFolder
-end TesterGetTestFileNames_Recursive
+end TesterGetActualFileNames_Recursive
 
 -- Get a number-indexed array contain the names of all "test"
 -- commands in pFilename.
@@ -131,8 +135,12 @@ function TesterParseTestCommandNames pFilename
 end TesterParseTestCommandNames
 
 -- Prettify a test name by removing a ".livecodescript" suffix
-function TesterGetPrettyTestName pFilename
-   if pFilename ends with ".livecodescript" then
+function TesterGetPrettyTestName pFilename, pExtension
+   if pExtension is empty then
+      put "livecodescript" into pExtension
+   end if
+
+   if pFilename ends with ("." & pExtension) then
       set the itemDelimiter to "."
       return item 1 to -2 of pFileName
    end if

--- a/tests/_testlib.lcb
+++ b/tests/_testlib.lcb
@@ -27,10 +27,13 @@ handler MCUnitTestHandlerThrowsImpl(in pHandler as any, in pDescription as Strin
 
 	variable tArgList as optional List
 	variable tResult as optional any
-	variable tMaybeError as optional any
+   variable tMaybeError as optional any
 
 	put [] into tArgList
-	put MCHandlerTryToInvokeWithList(tHandler, tArgList, tResult) into tMaybeError
+
+   unsafe
+     put MCHandlerTryToInvokeWithList(tHandler, tArgList, tResult) into tMaybeError
+   end unsafe
 
 	variable tHasError as Boolean
 	put tMaybeError is not nothing into tHasError

--- a/tests/_testrunner.lcb
+++ b/tests/_testrunner.lcb
@@ -45,7 +45,10 @@ foreign handler __system(in Command as ZStringNative) returns CInt binds to "sys
 
 handler System(in pCommand as String) returns Number
 	variable tExitStatus as Number
-	put __system(pCommand) into tExitStatus
+
+   unsafe
+      put __system(pCommand) into tExitStatus
+   end unsafe
 
 	if tExitStatus is in [0, -1] then
 		return tExitStatus
@@ -71,13 +74,17 @@ foreign handler MCStringDecode(in Encoded as Data, in Encoding as CInt, in IsExt
 
 handler EncodeUTF8(in pString as String) returns Data
 	variable tEncoded as Data
-	MCStringEncode(pString, 4 /* UTF-8 */, false, tEncoded)
+   unsafe
+	   MCStringEncode(pString, 4 /* UTF-8 */, false, tEncoded)
+   end unsafe
 	return tEncoded
 end handler
 
 handler DecodeUTF8(in pData as Data) returns String
 	variable tString as String
-	MCStringDecode(pData, 4 /* UTF-8 */, false, tString)
+   unsafe
+	   MCStringDecode(pData, 4 /* UTF-8 */, false, tString)
+   end unsafe
 	return tString
 end handler
 

--- a/tests/lcb/compiler/bytecode.lcb
+++ b/tests/lcb/compiler/bytecode.lcb
@@ -17,7 +17,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 module com.livecode.compiler.bytecode.tests
 
-public handler TestJump()
+public unsafe handler TestJump()
    variable tTest as Boolean
    put false into tTest
    bytecode
@@ -28,7 +28,7 @@ public handler TestJump()
    test "jump forward label" when tTest is false
 end handler
 
-public handler TestJumpIfFalse()
+public unsafe handler TestJumpIfFalse()
    variable tTest as Boolean
    put false into tTest
    bytecode
@@ -41,7 +41,7 @@ public handler TestJumpIfFalse()
    test "jumpiffalse forward label" when tTest is false
 end handler
 
-public handler TestJumpIfTrue()
+public unsafe handler TestJumpIfTrue()
    variable tTest as Boolean
    put false into tTest
    bytecode
@@ -54,7 +54,7 @@ public handler TestJumpIfTrue()
    test "jumpiffalse forward label" when tTest is false
 end handler
 
-public handler TestAssignConstant()
+public unsafe handler TestAssignConstant()
    variable tTest
    put "Hello World!" into tTest
 
@@ -84,7 +84,7 @@ public handler TestAssignConstant()
    test "assignconstant string literal" when tTest is "Foo"
 end handler
 
-private handler DoTestAssignParameter(in pSource)
+private unsafe handler DoTestAssignParameter(in pSource)
    bytecode
          register regTemp
          assign_constant regTemp, true
@@ -103,7 +103,7 @@ private handler DoTestAssignParameter(in pSource)
    test "assign param to temp" when tTarget is false
 end handler
 
-public handler TestAssign()
+public unsafe handler TestAssign()
    variable tTarget
 
    put false into tTarget
@@ -127,21 +127,21 @@ public handler TestAssign()
    DoTestAssignParameter(false)
 end handler
 
-private handler DoTestReturnNothing()
+private unsafe handler DoTestReturnNothing()
    bytecode
          return
    end bytecode
    return true
 end handler
 
-private handler DoTestReturnValue(in pValue)
+private unsafe handler DoTestReturnValue(in pValue)
    bytecode
          return pValue
    end bytecode
    return true
 end handler
 
-public handler TestReturn()
+public unsafe handler TestReturn()
    DoTestReturnNothing()
    test "return nothing" when the result is nothing
 
@@ -154,7 +154,7 @@ private handler DoTestInvoke(in pInput, out rOutput)
    return true
 end handler
 
-public handler TestInvoke()
+public unsafe handler TestInvoke()
    variable tOutput
    variable tResult
    put nothing into tOutput
@@ -168,7 +168,7 @@ public handler TestInvoke()
    test "invoke result" when tResult is true
 end handler
 
-public handler TestInvokeIndirect()
+public unsafe handler TestInvokeIndirect()
    variable tOutput
    variable tResult
    put nothing into tOutput
@@ -196,7 +196,7 @@ private handler Return100()
    return 100
 end handler
 
-public handler TestFetch()
+public unsafe handler TestFetch()
    variable tTest
 
    put "Hello World!" into tTest
@@ -245,7 +245,7 @@ public handler TestFetch()
    test "fetch handler" when tTestHandler() is 100
 end handler
 
-public handler TestStore()
+public unsafe handler TestStore()
    put nothing into sModuleVariable
    bytecode
          register regTemp
@@ -255,7 +255,7 @@ public handler TestStore()
    test "store variable" when sModuleVariable is 100
 end handler
 
-public handler TestAssignList()
+public unsafe handler TestAssignList()
    variable tTest
 
    variable tElement1
@@ -269,7 +269,7 @@ public handler TestAssignList()
    test "assignlist" when tTest is [1, 2]
 end handler
 
-public handler TestAssignArray()
+public unsafe handler TestAssignArray()
    variable tTest
 
    variable tElement1
@@ -288,7 +288,7 @@ public handler TestAssignArray()
                            tTest["foo"] is 1 and tTest["bar"] is 2
 end handler
 
-public handler TestReset()
+public unsafe handler TestReset()
    variable tTest as Boolean
    put true into tTest
    bytecode

--- a/tests/lcb/compiler/frontend/unsafe.compilertest
+++ b/tests/lcb/compiler/frontend/unsafe.compilertest
@@ -1,0 +1,129 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%TEST BytecodeInSafeHandler
+module compiler_test
+handler SafeHandler()
+   %{BEFORE_BYTECODE}bytecode
+   end bytecode
+end handler
+end module
+%EXPECT PASS
+%ERROR BytecodeNotAllowedInSafeContext AT BEFORE_BYTECODE
+%ENDTEST
+
+%TEST BytecodeInUnsafeBlock
+module compiler_test
+handler SafeHandler()
+   unsafe
+      bytecode
+      end bytecode
+   end unsafe
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST BytecodeInUnsafeHandler
+module compiler_test
+unsafe handler UnsafeHandler()
+   bytecode
+   end bytecode
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%%
+
+%TEST SafeHandlerCallInSafeContext
+module compiler_test
+handler OtherSafeHandler(in pArg)
+end handler
+handler SafeHandler()
+   OtherSafeHandler(OtherSafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST SafeHandlerCallInUnsafeHandler
+module compiler_test
+handler OtherSafeHandler(in pArg)
+end handler
+unsafe handler UnsafeHandler()
+   OtherSafeHandler(OtherSafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST SafeHandlerCallInUnsafeContext
+module compiler_test
+handler SafeHandler(in pArg)
+end handler
+handler Handler()
+   unsafe
+      SafeHandler(SafeHandler(nothing))
+   end unsafe
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST UnsafeHandlerCallInSafeContext
+module compiler_test
+unsafe handler OtherUnsafeHandler(in pArg)
+end handler
+handler SafeHandler()
+   %{BEFORE_CALL}OtherUnsafeHandler(%{BEFORE_EVAL}OtherUnsafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%ERROR UnsafeHandlerCallNotAllowedInSafeContext AT BEFORE_CALL WITH OtherUnsafeHandler
+%ERROR UnsafeHandlerCallNotAllowedInSafeContext AT BEFORE_EVAL WITH OtherUnsafeHandler
+%ENDTEST
+
+%TEST UnsafeHandlerCallInUnsafeHandler
+module compiler_test
+unsafe handler OtherUnsafeHandler(in pArg)
+end handler
+unsafe handler UnsafeHandler()
+   OtherUnsafeHandler(OtherUnsafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST UnsafeHandlerCallInUnsafeContext
+module compiler_test
+unsafe handler UnsafeHandler(in pArg)
+end handler
+handler SafeHandler()
+   unsafe
+      UnsafeHandler(UnsafeHandler(nothing))
+   end unsafe
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST

--- a/tests/lcb/stdlib/byte.lcb
+++ b/tests/lcb/stdlib/byte.lcb
@@ -283,8 +283,10 @@ foreign handler MCStringEncode(in Unencoded as String, in Encoding as CInt, in I
 handler EncodeUTF8(in pString as String) returns Data
 	variable tEncoded as Data
 	variable tStatus as Boolean
-	MCStringEncode(pString, kEncodingIndexUTF8, false, tEncoded)
-	if tEncoded is empty then
+   unsafe
+	   MCStringEncode(pString, kEncodingIndexUTF8, false, tEncoded)
+   end unsafe
+   if tEncoded is empty then
 		return the empty data
 	end if
 	return tEncoded

--- a/tests/lcb/vm/native-callback.lcb
+++ b/tests/lcb/vm/native-callback.lcb
@@ -25,11 +25,15 @@ public handler TestNativeCallback_Manual()
 
     -- Fetch the function pointer
     variable tFunctionPtr as Pointer
-    test "create function pointer - manual" when MCHandlerGetFunctionPtr_Manual(tHandler, tFunctionPtr)
+    unsafe
+        test "create function pointer - manual" when MCHandlerGetFunctionPtr_Manual(tHandler, tFunctionPtr)
+    end unsafe
 
     -- See if it works
     put 0 into sTotal_Manual
-    MCProperListApply_Manual([1, 2, 3, 4, 5, 6], tFunctionPtr, nothing)
+    unsafe
+        MCProperListApply_Manual([1, 2, 3, 4, 5, 6], tFunctionPtr, nothing)
+    end unsafe
     test "use function pointer - manual" when sTotal_Manual is (1 + 2 + 3 + 4 + 5 + 6)
 end handler
 
@@ -48,7 +52,9 @@ foreign handler MCProperListApply(in pList as List, in pCallback as MCProperList
 
 public handler TestNativeCallback()
     put 0 into sTotal
-    MCProperListApply([1, 2, 3, 4, 5, 6], SumElementOfList, nothing)
+    unsafe
+        MCProperListApply([1, 2, 3, 4, 5, 6], SumElementOfList, nothing)
+    end unsafe
     test "use function pointer" when sTotal is (1 + 2 + 3 + 4 + 5 + 6)
 end handler
 

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -124,7 +124,10 @@
     'rule' DeclareImportedDefinitions(sequence(Left, Right)):
         DeclareImportedDefinitions(Left)
         DeclareImportedDefinitions(Right)
-        
+
+    'rule' DeclareImportedDefinitions(unsafe(_, Definition)):
+        DeclareImportedDefinitions(Definition)
+
     'rule' DeclareImportedDefinitions(type(Position, _, Name, _)):
         DeclareId(Name)
 
@@ -184,7 +187,10 @@
     'rule' Declare(sequence(Left, Right)):
         Declare(Left)
         Declare(Right)
-        
+
+    'rule' Declare(unsafe(_, Definition)):
+        Declare(Definition)
+
     'rule' Declare(type(Position, _, Name, _)):
         DeclareId(Name)
 
@@ -282,9 +288,13 @@
     'rule' Define(ModuleId, handler(Position, Access, Name, Signature:signature(Parameters, _), _, _)):
         DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, normal, Signature))
         DefineParameters(Name, Parameters)
-    
+
+    'rule' Define(ModuleId, unsafe(_, handler(Position, Access, Name, Signature:signature(Parameters, _), _, _))):
+        DefineUnsafeSymbolId(Name, ModuleId, Access, handler, handler(Position, normal, Signature))
+        DefineParameters(Name, Parameters)
+
     'rule' Define(ModuleId, foreignhandler(Position, Access, Name, Signature:signature(Parameters, _), _)):
-        DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
+        DefineUnsafeSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
         DefineParameters(Name, Parameters)
 
     'rule' Define(ModuleId, property(Position, Access, Name, Getter, Setter)):
@@ -551,6 +561,11 @@
         DefineSymbolId(Name, ParentId, inferred, local, Type)
         Apply(Type)
 
+    'rule' Apply(STATEMENT'unsafe(_, Block)):
+        EnterScope
+        Apply(Block)
+        LeaveScope
+
     ---------
 
     'rule' Apply(EXPRESSION'slot(_, Name)):
@@ -688,6 +703,20 @@
         Info'Kind <- Kind
         Info'Type <- Type
         Info'Access <- Access
+        Info'Safety <- safe
+        Id'Meaning <- symbol(Info)
+
+'action' DefineUnsafeSymbolId(ID, ID, ACCESS, SYMBOLKIND, TYPE)
+
+    'rule' DefineUnsafeSymbolId(Id, ParentId, Access, Kind, Type)
+        Info::SYMBOLINFO
+        Info'Index <- -1
+        Info'Generator <- -1
+        Info'Parent <- ParentId
+        Info'Kind <- Kind
+        Info'Type <- Type
+        Info'Access <- Access
+        Info'Safety <- unsafe
         Id'Meaning <- symbol(Info)
 
 'action' DefineSyntaxId(ID, ID, SYNTAXCLASS, SYNTAX, SYNTAXMETHODLIST)

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -55,6 +55,7 @@ extern "C" void EmitTypeDefinition(long index, PositionRef position, NameRef nam
 extern "C" void EmitConstantDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_const_index);
 extern "C" void EmitVariableDefinition(long index, PositionRef position, NameRef name, long type_index);
 extern "C" void EmitBeginHandlerDefinition(long index, PositionRef position, NameRef name, long type_index);
+extern "C" void EmitBeginUnsafeHandlerDefinition(long index, PositionRef position, NameRef name, long type_index);
 extern "C" void EmitEndHandlerDefinition(void);
 extern "C" void EmitForeignHandlerDefinition(long index, PositionRef position, NameRef name, long type_index, long binding);
 extern "C" void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index);
@@ -891,9 +892,17 @@ void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, l
 
 void EmitBeginHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
 {
-    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, (uindex_t)p_index);
+    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, kMCScriptHandlerAttributeSafe, (uindex_t)p_index);
 
     Debug_Emit("BeginHandlerDefinition(%ld, %s, %ld)", p_index,
+               cstring_from_nameref(p_name), p_type_index);
+}
+
+void EmitBeginUnsafeHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
+{
+    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, kMCScriptHandlerAttributeUnsafe, (uindex_t)p_index);
+    
+    Debug_Emit("BeginUnsafeHandlerDefinition(%ld, %s, %ld)", p_index,
                cstring_from_nameref(p_name), p_type_index);
 }
 

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -204,7 +204,10 @@
     'rule' GenerateManifestDefinitions(sequence(Left, Right)):
         GenerateManifestDefinitions(Left)
         GenerateManifestDefinitions(Right)
-        
+
+    'rule' GenerateManifestDefinitions(unsafe(_, Definition)):
+        GenerateManifestDefinitions(Definition)
+
     'rule' GenerateManifestDefinitions(metadata(_, Key, Value)):
         (|
             IsStringEqualToString(Key, "title")
@@ -513,7 +516,10 @@
     'rule' GenerateDefinitionIndexes(sequence(Left, Right)):
         GenerateDefinitionIndexes(Left)
         GenerateDefinitionIndexes(Right)
-        
+
+    'rule' GenerateDefinitionIndexes(unsafe(_, Definition)):
+        GenerateDefinitionIndexes(Definition)
+
     'rule' GenerateDefinitionIndexes(type(_, _, Name, _)):
         GenerateDefinitionIndex("type", Name)
     
@@ -593,7 +599,10 @@
     'rule' GenerateExportedDefinitions(sequence(Left, Right)):
         GenerateExportedDefinitions(Left)
         GenerateExportedDefinitions(Right)
-        
+
+    'rule' GenerateExportedDefinitions(unsafe(_, Definition)):
+        GenerateExportedDefinitions(Definition)
+
     'rule' GenerateExportedDefinitions(type(_, public, Id, _)):
         GenerateExportedDefinition(Id)
         
@@ -641,7 +650,10 @@
     'rule' GenerateDefinitions(sequence(Left, Right)):
         GenerateDefinitions(Left)
         GenerateDefinitions(Right)
-        
+
+    'rule' GenerateDefinitions(unsafe(_, Definition)):
+        GenerateDefinitions(Definition)
+
     'rule' GenerateDefinitions(type(Position, _, Id, Type)):
         GenerateType(Type -> TypeIndex)
         
@@ -665,14 +677,20 @@
         Info'Index -> DefIndex
         EmitVariableDefinition(DefIndex, Position, Name, TypeIndex)
 
-
     'rule' GenerateDefinitions(handler(Position, _, Id, Signature:signature(Parameters, _), _, Body)):
         GenerateType(handler(Position, normal, Signature) -> TypeIndex)
         
         QuerySymbolId(Id -> Info)
         Id'Name -> Name
+        Info'Safety -> Safety
         Info'Index -> DefIndex
-        EmitBeginHandlerDefinition(DefIndex, Position, Name, TypeIndex)
+        (|
+            where(Safety -> safe)
+            EmitBeginHandlerDefinition(DefIndex, Position, Name, TypeIndex)
+        ||
+            where(Safety -> unsafe)
+            EmitBeginUnsafeHandlerDefinition(DefIndex, Position, Name, TypeIndex)
+        |)
         GenerateParameters(Parameters)
         CreateParameterRegisters(Parameters)
         CreateVariableRegisters(Body)
@@ -1194,6 +1212,9 @@
     'rule' GenerateBody(Result, Context, bytecode(Position, Block)):
         GenerateBytecodeDeferLabels(Block)
         GenerateBytecode(Block)
+
+    'rule' GenerateBody(Result, Context, unsafe(Position, Block)):
+        GenerateBody(Result, Context, Block)
 
     'rule' GenerateBody(Result, Context, nil):
         -- nothing

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -238,6 +238,9 @@
     'rule' ImportDefinition(-> handler(Position, public, Id, Signature, nil, nil)):
         "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
 
+    'rule' ImportDefinition(-> unsafe(Position, handler(Position, public, Id, Signature, nil, nil))):
+        "unsafe" "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
+
     'rule' ImportDefinition(-> foreignhandler(Position, public, Id, Signature, "")):
         "foreign" "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
 
@@ -455,7 +458,12 @@
         Access(-> Access) "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) Separator
             Statements(-> Body)
         "end" "handler"
-        
+
+    'rule' HandlerDefinition(-> unsafe(Position, handler(Position, Access, Name, Signature, nil, Body))):
+        Access(-> Access) "unsafe" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) Separator
+            Statements(-> Body)
+        "end" "handler"
+
     'rule' HandlerDefinition(-> foreignhandler(Position, Access, Name, Signature, Binding)):
         Access(-> Access) "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)
 
@@ -822,6 +830,11 @@
         "bytecode" @(-> Position) Separator
             Bytecodes(-> Opcodes)
         "end" "bytecode"
+
+    'rule' Statement(-> unsafe(Position, Body)):
+        "unsafe" @(-> Position) Separator
+            Statements(-> Body)
+        "end" "unsafe"
 
     'rule' Statement(-> postfixinto(Position, Statement, Target)):
         CustomStatements(-> Statement) "into" @(-> Position) Expression(-> Target)

--- a/toolchain/lc-compile/src/lc-compile-sources.gypi
+++ b/toolchain/lc-compile/src/lc-compile-sources.gypi
@@ -50,10 +50,13 @@
 		'lc-compile_source_files':
 		[
 			'literal.c',
+            'literal.h',
 			'main.c',
 			'operator.c',
 			'position.c',
+            'position.h',
 			'report.c',
+            'report.h',
 			'set.c',
 			'syntax-gen.c',
 			'emit.cpp',

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -29,6 +29,7 @@ extern void InitializeCustomInvokeLists(void);
 
 static int s_is_bootstrap = 0;
 
+extern int ErrorInfo;
 extern enum DependencyModeType DependencyMode;
 extern int OutputFileAsC;
 extern int OutputFileAsBytecode;
@@ -102,20 +103,22 @@ usage(int status)
 "Compile a LiveCode Builder source file.\n"
 "\n"
 "Options:\n"
-"      --modulepath PATH    Search PATH for module interface files.\n"
-"      --output OUTFILE     Filename for bytecode output.\n"
-"      --outputc OUTFILE    Filename for C source code output.\n"
-"      --deps make          Generate lci file dependencies in make format for\n"
-"                           the input source files.\n"
-"      --deps order         Generate the order the input source files should be\n"
-"                           compiled in.\n"
-"      --deps changed-order Generate the order the input source files should be\n"
-"                           compiled in, but only if they need recompiling.\n"
-"      --manifest MANIFEST  Filename for generated manifest.\n"
-"      -Werror              Turn all warnings into errors.\n"
-"  -v, --verbose            Output extra debugging information.\n"
-"  -h, --help               Print this message.\n"
-"  --                       Treat all remaining arguments as filenames.\n"
+"      --modulepath PATH      Search PATH for module interface files.\n"
+"      --output OUTFILE       Filename for bytecode output.\n"
+"      --outputc OUTFILE      Filename for C source code output.\n"
+"      --deps make            Generate lci file dependencies in make format for\n"
+"                             the input source files.\n"
+"      --deps order           Generate the order the input source files should be\n"
+"                             compiled in.\n"
+"      --deps changed-order   Generate the order the input source files should be\n"
+"                             compiled in, but only if they need recompiling.\n"
+"      --manifest MANIFEST    Filename for generated manifest.\n"
+"      --interface INTERFACE  Filename for generated interface.\n"
+"      -Werror                Turn all warnings into errors.\n"
+"      --error-info           Emit warnings and errors in form suitable for testing.\n"
+"  -v, --verbose              Output extra debugging information.\n"
+"  -h, --help                 Print this message.\n"
+"  --                         Treat all remaining arguments as filenames.\n"
 "\n"
 "More than one `--modulepath' option may be specified.  The PATHs are\n"
 "searched in the order they appear.  An interface file may be generated in\n"
@@ -163,6 +166,11 @@ static void full_main(int argc, char *argv[])
                 }
                 continue;
             }
+            if (0 == strcmp(opt, "--error-info"))
+            {
+                ErrorInfo = 1;
+                continue;
+            }
             if (0 == strcmp(opt, "--modulepath") && optarg)
             {
                 AddImportedModuleDir(argv[++argi]);
@@ -187,6 +195,11 @@ static void full_main(int argc, char *argv[])
             if (0 == strcmp(opt, "--manifest") && optarg)
             {
                 SetManifestOutputFile(argv[++argi]);
+                continue;
+            }
+            if (0 == strcmp(opt, "--interface") && optarg)
+            {
+                SetInterfaceOutputFile(argv[++argi]);
                 continue;
             }
             /* FIXME This should be expanded to support "-W error",

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -111,6 +111,7 @@ void yyGetPos(long *r_result)
 
 static const char *ImportedModuleDir[8];
 static int ImportedModuleDirCount = 0;
+static const char *s_interface_output_file = NULL;
 
 void AddImportedModuleDir(const char *p_dir)
 {
@@ -194,13 +195,21 @@ OpenImportedModuleFile (const char *p_name,
     char t_path[MAXPATHLEN];
     FILE *t_file;
 
-    if (ImportedModuleDirCount == 0)
+    if (ImportedModuleDirCount == 0 &&
+        s_interface_output_file == NULL)
         return NULL;
 
-    // Use the first modulepath to write the interface file into.
-    /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
-
-	if (NULL != r_filename)
+    if (NULL == s_interface_output_file)
+    {
+        // Use the first modulepath to write the interface file into.
+        /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
+    }
+    else
+    {
+        /* OVERFLOW */ sprintf(t_path, "%s", s_interface_output_file);
+    }
+    
+    if (NULL != r_filename)
 	{
 		*r_filename = strdup(t_path); /* FIXME should be strndup */
 	}
@@ -375,6 +384,11 @@ void SetOutputCodeFile(const char *p_output)
 void SetManifestOutputFile(const char *p_output)
 {
     s_manifest_output_file = p_output;
+}
+
+void SetInterfaceOutputFile(const char *p_output)
+{
+    s_interface_output_file = p_output;
 }
 
 void SetTemplateFile(const char *p_output)

--- a/toolchain/lc-compile/src/position.h
+++ b/toolchain/lc-compile/src/position.h
@@ -67,6 +67,7 @@ void SetOutputBytecodeFile(const char *filename);
 void SetOutputCodeFile(const char *filename);
 void SetOutputGrammarFile(const char *filename);
 void SetManifestOutputFile(const char *filename);
+void SetInterfaceOutputFile(const char *filename);
 void SetTemplateFile(const char *filename);
 void GetOutputFile(const char **r_filename);
     

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -364,6 +364,9 @@ DEFINE_ERROR(OpcodeArgumentMustBeVariable, "Opcode argument must be a module var
 DEFINE_ERROR(OpcodeArgumentMustBeDefinition, "Opcode argument must be a module variable, constant id or handler id")
 DEFINE_ERROR(IllegalNumberOfArgumentsForOpcode, "Wrong number of arguments for opcode")
 
+DEFINE_ERROR(BytecodeNotAllowedInSafeContext, "Bytecode blocks can only be present in unsafe context")
+DEFINE_ERROR_I(UnsafeHandlerCallNotAllowedInSafeContext, "Unsafe handler '%s' can only be called in unsafe context")
+
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(long p_position) { _Warning(p_position, #Name, Message); }
 #define DEFINE_WARNING_I(Name, Message) \

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -26,14 +26,17 @@ extern int IsDependencyCompile(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static int s_error_count;
-int s_verbose_level = 1;
+int s_verbose_level;
 int s_is_werror_enabled;
+int ErrorInfo;
+
+static int s_error_count;
 
 void InitializeReports(void)
 {
     s_error_count = 0;
     s_verbose_level = 0;
+    ErrorInfo = 0;
 }
 
 void FinalizeReports(void)
@@ -149,45 +152,66 @@ static void _PrintPosition(long p_position)
     GetRowOfPosition(p_position, &t_row);
     GetFileOfPosition(p_position, &t_file);
     GetFilePath(t_file, &t_path);
-    fprintf(stderr, "%s:%ld:%ld: ", t_path, t_row, t_column);
+    fprintf(stderr, "%s:%ld:%ld:", t_path, t_row, t_column);
 }
 
-static void _Error(long p_position, const char *p_message)
+static void _Error(long p_position, const char *p_tag, const char *p_message)
 {
     _PrintPosition(p_position);
-    fprintf(stderr, "error: %s\n", p_message);
+    if (0 == ErrorInfo)
+    {
+        fprintf(stderr, " error: %s\n", p_message);
+    }
+    else
+    {
+        fprintf(stderr, "error:%s\n", p_tag);
+    }
     s_error_count += 1;
 }
 
-static void _Warning(long p_position, const char *p_message)
+static void _Warning(long p_position, const char *p_tag, const char *p_message)
 {
     if (IsDependencyCompile())
         return;
 
     if (s_is_werror_enabled)
     {
-        _Error(p_position, p_message);
+        _Error(p_position, p_tag, p_message);
     }
     else
     {
         _PrintPosition(p_position);
-        fprintf(stderr, "warning: %s\n", p_message);
+        if (0 == ErrorInfo)
+        {
+            fprintf(stderr, " warning: %s\n", p_message);
+        }
+        else
+        {
+            fprintf(stderr, "warning:%s\n", p_tag);
+        }
     }
 }
 
-static void _ErrorS(long p_position, const char *p_message, const char *p_string)
+static void _ErrorS(long p_position, const char *p_tag, const char *p_message, const char *p_string)
 {
     long t_row, t_column;
     GetColumnOfPosition(p_position, &t_column);
     GetRowOfPosition(p_position, &t_row);
     _PrintPosition(p_position);
-    fprintf(stderr, "error: ");
-    fprintf(stderr, p_message, p_string);
-    fprintf(stderr, "\n");
+    if (0 == ErrorInfo)
+    {
+        fprintf(stderr, " error: ");
+        fprintf(stderr, p_message, p_string);
+        fprintf(stderr, "\n");
+    }
+    else
+    {
+        fprintf(stderr, "error:%s:%s\n", p_tag, p_string);
+    }
     s_error_count += 1;
 }
 
-static void _WarningS(long p_position, const char *p_message, const char *p_string)
+static void _WarningS(long p_position, const char *p_tag, const char *p_message, const char *p_string)
 {
     long t_row, t_column;
     
@@ -196,41 +220,48 @@ static void _WarningS(long p_position, const char *p_message, const char *p_stri
 
     if (s_is_werror_enabled)
     {
-       _ErrorS(p_position, p_message, p_string);
+       _ErrorS(p_position, p_tag, p_message, p_string);
     }
     else
     {
         GetColumnOfPosition(p_position, &t_column);
         GetRowOfPosition(p_position, &t_row);
         _PrintPosition(p_position);
-        fprintf(stderr, "warning: ");
-        fprintf(stderr, p_message, p_string);
-        fprintf(stderr, "\n");
+        if (0 == ErrorInfo)
+        {
+            fprintf(stderr, " warning: ");
+            fprintf(stderr, p_message, p_string);
+            fprintf(stderr, "\n");
+        }
+        else
+        {
+            fprintf(stderr, "warning:%s:%s\n", p_tag, p_string);
+        }
     }
 }
 
-static void _ErrorI(long p_position, const char *p_message, NameRef p_name)
+static void _ErrorI(long p_position, const char *p_tag, const char *p_message, NameRef p_name)
 {
     const char *t_string;
     GetStringOfNameLiteral(p_name, &t_string);
-    _ErrorS(p_position, p_message, t_string);
+    _ErrorS(p_position, p_tag, p_message, t_string);
 }
 
-static void _WarningI(long p_position, const char *p_message, NameRef p_name)
+static void _WarningI(long p_position, const char *p_tag, const char *p_message, NameRef p_name)
 {
 	const char *t_string;
 	GetStringOfNameLiteral(p_name, &t_string);
-	_WarningS(p_position, p_message, t_string);
+	_WarningS(p_position, p_tag, p_message, t_string);
 }
 
 #define DEFINE_ERROR(Name, Message) \
-    void Error_##Name(long p_position) { _Error(p_position, Message); }
+    void Error_##Name(long p_position) { _Error(p_position, #Name, Message); }
 
 #define DEFINE_ERROR_I(Name, Message) \
-    void Error_##Name(long p_position, NameRef p_id) { _ErrorI(p_position, Message, p_id); }
+    void Error_##Name(long p_position, NameRef p_id) { _ErrorI(p_position, #Name, Message, p_id); }
 
 #define DEFINE_ERROR_S(Name, Message) \
-void Error_##Name(long p_position, const char *p_string) { _ErrorS(p_position, Message, p_string); }
+void Error_##Name(long p_position, const char *p_string) { _ErrorS(p_position, #Name, Message, p_string); }
 
 DEFINE_ERROR_I(UnableToFindImportedModule, "Unable to find imported module '%s'");
 
@@ -334,11 +365,11 @@ DEFINE_ERROR(OpcodeArgumentMustBeDefinition, "Opcode argument must be a module v
 DEFINE_ERROR(IllegalNumberOfArgumentsForOpcode, "Wrong number of arguments for opcode")
 
 #define DEFINE_WARNING(Name, Message) \
-    void Warning_##Name(long p_position) { _Warning(p_position, Message); }
+    void Warning_##Name(long p_position) { _Warning(p_position, #Name, Message); }
 #define DEFINE_WARNING_I(Name, Message) \
-    void Warning_##Name(long p_position, NameRef p_id) { _WarningI(p_position, Message, p_id); }
+    void Warning_##Name(long p_position, NameRef p_id) { _WarningI(p_position, #Name, Message, p_id); }
 #define DEFINE_WARNING_S(Name, Message) \
-	void Warning_##Name(long p_position, const char *p_string) { _WarningS(p_position, Message, p_string); }
+	void Warning_##Name(long p_position, const char *p_string) { _WarningS(p_position, #Name, Message, p_string); }
 
 DEFINE_WARNING(EmptyUnicodeEscape, "Unicode escape sequence specified with no nibbles")
 DEFINE_WARNING(UnicodeEscapeTooBig, "Unicode escape sequence too big, replaced with U+FFFD");
@@ -355,7 +386,14 @@ void yyerror(const char *p_text)
     GetCurrentPosition(&t_position);
     
     _PrintPosition(t_position);
-    fprintf(stderr, "Parsing error - %s\n", p_text);
+    if (0 == ErrorInfo)
+    {
+        fprintf(stderr, "Parsing error - %s\n", p_text);
+    }
+    else
+    {
+        fprintf(stderr, "error:SyntaxError");
+    }
     
     s_error_count += 1;
 }

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -155,6 +155,7 @@
     EmitVariableDefinition
     EmitBeginHandlerDefinition
     EmitEndHandlerDefinition
+    EmitBeginUnsafeHandlerDefinition
     EmitForeignHandlerDefinition
     EmitPropertyDefinition
     EmitEventDefinition
@@ -345,6 +346,9 @@
     Error_OpcodeArgumentMustBeVariable
     Error_OpcodeArgumentMustBeDefinition
     Error_IllegalNumberOfArgumentsForOpcode
+    Error_BytecodeNotAllowedInSafeContext
+    Error_UnsafeHandlerCallNotAllowedInSafeContext
+
     Warning_MetadataClausesShouldComeAfterUseClauses
     Warning_DeprecatedTypeName
     Warning_UnsuitableNameForDefinition
@@ -542,6 +546,7 @@
 'action' EmitVariableDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitBeginHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitEndHandlerDefinition()
+'action' EmitBeginUnsafeHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitForeignHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT, Binding: STRING)
 'action' EmitPropertyDefinition(Index: INT, Position: POS, Name: NAME, GetIndex: INT, SetIndex: INT)
 'action' EmitEventDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
@@ -761,6 +766,9 @@
 'action' Error_OpcodeArgumentMustBeVariable(Position: POS)
 'action' Error_OpcodeArgumentMustBeDefinition(Position: POS)
 'action' Error_IllegalNumberOfArgumentsForOpcode(Position: POS)
+
+'action' Error_BytecodeNotAllowedInSafeContext(Position: POS)
+'action' Error_UnsafeHandlerCallNotAllowedInSafeContext(Position: POS, Identifier: NAME)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -33,7 +33,7 @@
     NAMELIST
     MEANING
     MODULEINFO
-    SYMBOLINFO SYMBOLKIND
+    SYMBOLINFO SYMBOLKIND SYMBOLSAFETY
     SYNTAXINFO
     SYNTAXMARKINFO SYNTAXMARKTYPE
     NAME DOUBLE
@@ -68,6 +68,7 @@
     property(Position: POS, Access: ACCESS, Name: ID, Getter: ID, Setter: OPTIONALID)
     event(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE)
     syntax(Position: POS, Access: ACCESS, Name: ID, Class: SYNTAXCLASS, Warnings: SYNTAXWARNING, Syntax: SYNTAX, Methods: SYNTAXMETHODLIST)
+    unsafe(Position: POS, Definition: DEFINITION)
     nil
 
 'type' SIGNATURE
@@ -154,6 +155,7 @@
     throw(Position: POS, Error: EXPRESSION)
     postfixinto(Position: POS, Command: STATEMENT, Target: EXPRESSION)
     bytecode(Position: POS, Block: BYTECODE)
+    unsafe(Position: POS, Block: STATEMENT)
     nil
     
 'type' EXPRESSIONLIST
@@ -291,6 +293,10 @@
     context
     label
 
+'type' SYMBOLSAFETY
+    safe
+    unsafe
+
 'type' INTLIST
     intlist(Head: INT, Tail: INTLIST)
     nil
@@ -316,7 +322,7 @@
 'table' ID(Position: POS, Name: NAME, Meaning: MEANING)
 
 'table' MODULEINFO(Index: INT, Generator: INT)
-'table' SYMBOLINFO(Index: INT, Generator: INT, Parent: ID, Access: ACCESS, Kind: SYMBOLKIND, Type: TYPE)
+'table' SYMBOLINFO(Index: INT, Generator: INT, Parent: ID, Access: ACCESS, Safety: SYMBOLSAFETY, Kind: SYMBOLKIND, Type: TYPE)
 'table' SYNTAXINFO(Index: INT, Parent: ID, Class: SYNTAXCLASS, Syntax: SYNTAX, Methods: SYNTAXMETHODLIST, Prefix: SYNTAXTERM, Suffix: SYNTAXTERM)
 'table' SYNTAXMARKINFO(Index: INT, RMode: MODE, LMode: MODE, Type: SYNTAXMARKTYPE)
 'table' INVOKEINFO(Index: INT, ModuleIndex: INT, Name: STRING, ModuleName: STRING, Methods: INVOKEMETHODLIST)


### PR DESCRIPTION
This patch adds a new test runner for running LCB compiler tests.

The compiler tests are run by using 'make compiler-check' in the
tests folder.

The compiler test runner recursively searches for tests in the
tests folder, processing any file with a 'compilertest' extension.

Compiler tests are text files containing a number of test clauses.
Each test clause is named, and consists of a fragment of LCB code
to be parsed to the compiler, along with an expectation and list
of errors and/or warnings to check for.

The compiler test format uses lines beginning with %% to indicate
comments.

A test clause has the following structure:

```
%TEST <name>
... LCB code ...
%EXPECT ( PASS | FAIL | XPASS | SKIP )
... assertions ...
%ENDTEST
```

Here the assertion clauses can be one of the following:

```
%SUCCESS
%ERROR <error-id> AT <pos-id>
%WARNING <warning-id> AT <pos-id>
```

In the body of LCB code for each test clause, %{pos-id} can be used
to indicate a named position - these can be used in error and warning
assertions.

When running a test clause, the test runner will first extract the
LCB code, removing any named positions from it. It will then attempt
to compile the code. The output of the compiler is checked against
the list of expected errors and warnings, or success and each test
will succeed or fail as a result, in line with the expectation.

Additionally, there is a new compiler option '--error-info' which
emits error information in a more structured way. Each error or
warning that is emitted has the following format:

```
<file>:<line>:<col>:warning|error:<id>:<param>
```

Here, rather than use a human readable message, the compiler emits
the error's id, and optional parameter separately.

---

This patch adds the idea of unsafe handlers and unsafe blocks
to LCB.
