### PR TITLE
[[ Community Docs ]] Fixes to repeat

### DIFF
--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -41,20 +41,6 @@ repeat tCount times
   put "X" after field "counting"
 end repeat
 
-Example:
--- To create a numbered set of variables with similar names
--- eg myVar1, myVar2, ... myVar20, you can use a repeat loop
--- together with concatenation in the following form. Note that
--- this structure will only work with variable checking 
--- turned off.
--- If you prefer to declare your variables then an array is the
--- recommended way of doing this.
-local tPrefix = "myVar"
-local tVarCount = 20
-repeat with tVarNum = 1 to 20
-  put tPrefix  x into tVarName
-  do "put empty into "  tVarNameend repeat
-
 Parameters:
 loopForm: 
 The <loopForm> is one of the following forms:
@@ -75,7 +61,7 @@ counter or labelVariable: A legal <variable> name.
 chunkType: One of these text chunk types: byte, codeunit, codepoint, character (or char), 
 token, trueword, word (or segment), item, sentence, paragraph or line.
 container: Any existing <container>; e.g. a <variable> or a <field>.
-array (array): Any existing <container> that contains an <array> of <value|values>.
+array (array): Any existing container, usually a variable, that contains an <array> of values.
 
 Description:
 Use the <repeat> <control structure> to perform the same series of
@@ -120,6 +106,7 @@ Use the `until `*`condition`* or `while `*`condition`* form if you want
 to test a <conditional|condition> at the top of the loop, before the
 statements are executed. This example scrolls through the cards until
 the user clicks the mouse:
+
     repeat until the mouseClick
       go next card
       wait for 100 milliseconds
@@ -127,6 +114,7 @@ the user clicks the mouse:
     
 This example repeats as long as the total number of characters in a
 field is less than the given amount:
+
     local tCount
     put empty into field "myField"
     put 20 into tCount
@@ -172,8 +160,8 @@ you're using the `down to` form), the loop performs its final
 <iteration> and then ends.
 
 If you specify an *increment*, the *increment* is added to the *counter*
-each time through the loop, rather than the *counter* being increased by
-1. (The *increment* is not treated as an absolute value: if you're using
+each time through the loop, rather than the *counter* being increased by 1. 
+(The *increment* is not treated as an absolute value: if you're using
 the `down to` form, the *increment* must be negative.)
 
 As with the `for `*`number`*` times` form described above, the
@@ -224,7 +212,7 @@ example changes a return-<delimit|delimited> list to a
 comma-<delimit|delimited> list:
 
     repeat for each line thisLine in myList
-      put thisLine  comma after newList
+      put thisLine & comma after newList
     end repeat
     delete the last char of newList
 
@@ -238,8 +226,8 @@ each <element(glossary)> in an <array>. The following example gets only
 the multi-word entries in an <array> of phrases:
 
     repeat for each element thisIndexTerm in listOfTerms
-      if the number of words in thisIndexTerm  1 then
-        put thisIndexTerm  return after multiWordTerms
+      if the number of words in thisIndexTerm > 1 then
+        put thisIndexTerm & return after multiWordTerms
       end if
     end repeat
 
@@ -253,17 +241,16 @@ will not affect what is being <iterate|iterated> over.
 command and appears in the commandNames.
 
 Changes:
-The ability to specify an increment for the `repeat with `*`counter`*` =
-`*`startValue`*` to `*`endValue`* form was added in version 2.0. In
-previous versions, this form of the repeat control structure is always
-incremented or decremented the counter by 1 each time through the loop.
+The ability to specify an increment for the repeat with form was added in version 2.0.
+In previous versions, this form of the repeat control structure is always
+incremented or decremented the counter by 1 each time through the loop. 
 
 The ability to iterate through the keys of an array using repeat for
-each key was added in version 2.7.2
+each key was added in version 2.7.2. 
 
-Starting in version 7.0 it is possible to modify the *<container>*
-variable inside a `for each` loop without affecting the
-<iterate|iterations> of the loop.
+Starting in version 7.0 it is possible to modify the container
+variable inside a for each loop without affecting the
+iterations of the loop.
 
 References: iteration (glossary), array (glossary), card (keyword), 
 chunk (glossary), conditional (glossary), container (glossary), 


### PR DESCRIPTION
- Removed example that had several errors; moreover the example is a confusing edge case that is poor programming practice.
- Removed markdown that was producing a javascript error in the rendered text.
- Removed markdown from Changes element, which does not render markdown.
- Minor wording changes for clarity.
- Minor formatting fixes.
- Ampersands and other operators had been stripped out of some inline examples. Replaced those.
