### PR TITLE
[[ UnsafeAttrib ]] Add unsafe handlers and unsafe blocks

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -334,7 +334,7 @@ a value.
 ### Handlers
 
     HandlerDefinition
-      : 'handler' <Name: Identifier> '(' [ ParameterList ] ')' [ 'returns' <ReturnType: Type> ] SEPARATOR
+      : [ 'unsafe' ] 'handler' <Name: Identifier> '(' [ ParameterList ] ')' [ 'returns' <ReturnType: Type> ] SEPARATOR
           { Statement }
         'end' 'handler'
 
@@ -382,6 +382,10 @@ to be *optional any* meaning it can be of any type.
 > **Note:** Only assignable expressions can be passed as arguments to
 > inout or out parameters. It is a checked compile-time error to pass a
 > non-assignable expression to such a parameter.
+
+If 'unsafe' is specified for the handler, then the handler itself is considered
+to be unsafe, and may only be called from other unsafe handlers or unsafe
+statement blocks.
 
 ### Foreign Handlers
 
@@ -476,6 +480,10 @@ non-Windows platform then it is taken to be 'default'.
 Foreign handler's bound symbols are resolved on first use and an error
 is thrown if the symbol cannot be found.
 
+Foreign handlers are always considered unsafe, and thus may only be called
+from unsafe context - i.e. from within an unsafe handler, or unsafe statement
+block.
+
 > **Note:** The current foreign handler definition is an initial
 > version, mainly existing to allow binding to implementation of the
 > syntax present in the standard language modules. It will be expanded
@@ -529,6 +537,7 @@ environment.
       | GetStatement
       | CallStatement
       | BytecodeStatement
+      | UnsafeStatement
 
 There are a number of built-in statements which define control flow,
 variables, and basic variable transfer. The remaining syntax for
@@ -760,8 +769,24 @@ Register definitions define a named register which is local to the current
 bytecode block. Registers are the same as handler-local variables except
 that they do not undergo default initialization.
 
+Bytecode statements are considered to be unsafe and can only appear inside
+unsafe handlers or unsafe statement blocks.
+
 > **Note:** Bytecode blocks are not intended for general use and the actual
 > available operations are subject to change.
+
+### Unsafe Statements
+
+    UnsafeStatement
+      : 'unsafe' SEPARATOR
+            { Statement }
+        'end' 'unsafe'
+
+The unsafe statement allows a block of unsafe code to be written in a safe
+context.
+
+In particular, calls to unsafe handlers (including all foreign handlers) and
+bytecode blocks are allowed in unsafe statement blocks but nowhere else.
 
 ## Expressions
 

--- a/docs/lcb/notes/feature-unsafe_attribs.md
+++ b/docs/lcb/notes/feature-unsafe_attribs.md
@@ -1,0 +1,27 @@
+# LiveCode Builder Language
+## Unsafe Attributes
+
+* The compiler now understands the idea of 'safety' of handlers and blocks of
+  code.
+
+* Handlers can be marked as being 'unsafe', e.g.
+
+      unsafe handler Foo()
+          ... do unsafe things ...
+      end handler
+
+* Blocks of statements can be marked as being 'unsafe', e.g.
+
+      unsafe
+          ... do unsafe things ...
+      end unsafe
+
+* All foreign handlers are considered to be 'unsafe'.
+
+* All bytecode blocks are considered to be 'unsafe'.
+
+* Calls to foreign handlers and unsafe handlers can only be made within unsafe
+  handlers or unsafe statement blocks.
+
+* Usage of bytecode blocks can only be made within unsafe handlers or unsafe
+  statement blocks.

--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -168,55 +168,69 @@ constant kBoolProps is [0, 1, 2, 3]
 public handler browserListToLCBList(in pBrowserList as MCBrowserListRef, out rList as List) returns Boolean
 	variable tList as List
 	put the empty list into tList
-	
+
 	variable tCount as CUInt
-	if not MCBrowserListGetSize(pBrowserList, tCount) then
-		log "couldn't get size"
-		return false
-	end if
-	
+	unsafe
+		if not MCBrowserListGetSize(pBrowserList, tCount) then
+			log "couldn't get size"
+			return false
+		end if
+	end unsafe
+
 	variable tIndex
 	repeat with tIndex from 0 up to tCount - 1
 		variable tType as MCBrowserValueType
-		if not MCBrowserListGetType(pBrowserList, tIndex, tType) then
-			log "couldn't get type of %@" with [tIndex]
-			return false
-		end if
-		
-		if tType is kMCBrowserValueTypeBoolean then
-			variable tBoolean as CBool
-			if not MCBrowserListGetBoolean(pBrowserList, tIndex, tBoolean) then
-				log "couldn't get boolean %@" with [tIndex]
+		unsafe
+			if not MCBrowserListGetType(pBrowserList, tIndex, tType) then
+				log "couldn't get type of %@" with [tIndex]
 				return false
 			end if
+		end unsafe
+
+		if tType is kMCBrowserValueTypeBoolean then
+			variable tBoolean as CBool
+			unsafe
+				if not MCBrowserListGetBoolean(pBrowserList, tIndex, tBoolean) then
+					log "couldn't get boolean %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			push tBoolean onto tList
 		else if tType is kMCBrowserValueTypeInteger then
 			variable tInteger as CInt
-			if not MCBrowserListGetInteger(pBrowserList, tIndex, tInteger) then
-				log "couldn't get integer %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserListGetInteger(pBrowserList, tIndex, tInteger) then
+					log "couldn't get integer %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			push tInteger onto tList
 		else if tType is kMCBrowserValueTypeDouble then
 			variable tDouble as CDouble
-			if not MCBrowserListGetDouble(pBrowserList, tIndex, tDouble) then
-				log "couldn't get double %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserListGetDouble(pBrowserList, tIndex, tDouble) then
+					log "couldn't get double %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			push tDouble onto tList
 		else if tType is kMCBrowserValueTypeUTF8String then
 			variable tUTF8String as ZStringNative
-			if not MCBrowserListGetUTF8String(pBrowserList, tIndex, tUTF8String) then
-				log "couldn't get string %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserListGetUTF8String(pBrowserList, tIndex, tUTF8String) then
+					log "couldn't get string %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			push tUTF8String onto tList
 		else if tType is kMCBrowserValueTypeList then
 			variable tBrowserList as MCBrowserListRef
-			if not MCBrowserListGetList(pBrowserList, tIndex, tBrowserList) then
-				log "couldn't get list %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserListGetList(pBrowserList, tIndex, tBrowserList) then
+					log "couldn't get list %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			variable tConvertedList as List
 			if not browserListToLCBList(tBrowserList, tConvertedList) then
 				log "couldn't convert list %@" with [tIndex]
@@ -225,12 +239,14 @@ public handler browserListToLCBList(in pBrowserList as MCBrowserListRef, out rLi
 			push tConvertedList onto tList
 		else if tType is kMCBrowserValueTypeDictionary then
 			variable tBrowserDict as MCBrowserDictionaryRef
-			if not MCBrowserListGetDictionary(pBrowserList, tIndex, tBrowserDict) then
-				log "couldn't get dictionary %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserListGetDictionary(pBrowserList, tIndex, tBrowserDict) then
+					log "couldn't get dictionary %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			variable tConvertedDict as Array
-			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then 
+			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then
 				log "couldn't convert dictionary %@" with [tIndex]
 				return false
 			end if
@@ -240,70 +256,86 @@ public handler browserListToLCBList(in pBrowserList as MCBrowserListRef, out rLi
 			return false
 		end if
 	end repeat
-	
+
 	put tList into rList
-	
+
 	return true
 end handler
 
 public handler browserDictionaryToLCBArray(in pBrowserDict as MCBrowserDictionaryRef, out rArray as Array) returns Boolean
 	variable tArray as Array
 	put the empty array into tArray
-	
+
 	variable tCount as CUInt
-	if not MCBrowserDictionaryGetKeyCount(pBrowserDict, tCount) then
-		log "couldn't get size"
-		return false
-	end if
-	
+	unsafe
+		if not MCBrowserDictionaryGetKeyCount(pBrowserDict, tCount) then
+			log "couldn't get size"
+			return false
+		end if
+	end unsafe
+
 	variable tIndex
 	repeat with tIndex from 0 up to tCount - 1
 		variable tKey as String
-		if not MCBrowserDictionaryGetKey(pBrowserDict, tIndex, tKey) then
-			log "couldn't get key of %@" with [tIndex]
-			return false
-		end if
-		
-		variable tType as MCBrowserValueType
-		if not MCBrowserDictionaryGetType(pBrowserDict, tKey, tType) then
-			log "couldn't get type of %@" with [tIndex]
-			return false
-		end if
-		
-		if tType is kMCBrowserValueTypeBoolean then
-			variable tBoolean as CBool
-			if not MCBrowserDictionaryGetBoolean(pBrowserDict, tKey, tBoolean) then
-				log "couldn't get boolean %@" with [tIndex]
+		unsafe
+			if not MCBrowserDictionaryGetKey(pBrowserDict, tIndex, tKey) then
+				log "couldn't get key of %@" with [tIndex]
 				return false
 			end if
+		end unsafe
+
+		variable tType as MCBrowserValueType
+		unsafe
+			if not MCBrowserDictionaryGetType(pBrowserDict, tKey, tType) then
+				log "couldn't get type of %@" with [tIndex]
+				return false
+			end if
+		end unsafe
+
+		if tType is kMCBrowserValueTypeBoolean then
+			variable tBoolean as CBool
+			unsafe
+				if not MCBrowserDictionaryGetBoolean(pBrowserDict, tKey, tBoolean) then
+					log "couldn't get boolean %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			put tBoolean into tArray[tKey]
 		else if tType is kMCBrowserValueTypeInteger then
 			variable tInteger as CInt
-			if not MCBrowserDictionaryGetInteger(pBrowserDict, tKey, tInteger) then
-				log "couldn't get integer %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserDictionaryGetInteger(pBrowserDict, tKey, tInteger) then
+					log "couldn't get integer %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			put tInteger into tArray[tKey]
 		else if tType is kMCBrowserValueTypeDouble then
 			variable tDouble as CDouble
-			if not MCBrowserDictionaryGetDouble(pBrowserDict, tKey, tDouble) then
-				log "couldn't get double %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserDictionaryGetDouble(pBrowserDict, tKey, tDouble) then
+					log "couldn't get double %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			put tDouble into tArray[tKey]
 		else if tType is kMCBrowserValueTypeUTF8String then
 			variable tUTF8String as ZStringNative
-			if not MCBrowserDictionaryGetUTF8String(pBrowserDict, tKey, tUTF8String) then
-				log "couldn't get string %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserDictionaryGetUTF8String(pBrowserDict, tKey, tUTF8String) then
+					log "couldn't get string %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			put tUTF8String into tArray[tKey]
 		else if tType is kMCBrowserValueTypeList then
 			variable tBrowserList as MCBrowserListRef
-			if not MCBrowserDictionaryGetList(pBrowserDict, tKey, tBrowserList) then
-				log "couldn't get list %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserDictionaryGetList(pBrowserDict, tKey, tBrowserList) then
+					log "couldn't get list %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			variable tConvertedList as List
 			if not browserListToLCBList(tBrowserList, tConvertedList) then
 				log "couldn't convert list %@" with [tIndex]
@@ -312,12 +344,14 @@ public handler browserDictionaryToLCBArray(in pBrowserDict as MCBrowserDictionar
 			put tConvertedList into tArray[tKey]
 		else if tType is kMCBrowserValueTypeDictionary then
 			variable tBrowserDict as MCBrowserDictionaryRef
-			if not MCBrowserDictionaryGetDictionary(pBrowserDict, tKey, tBrowserDict) then
-				log "couldn't get dictionary %@" with [tIndex]
-				return false
-			end if
+			unsafe
+				if not MCBrowserDictionaryGetDictionary(pBrowserDict, tKey, tBrowserDict) then
+					log "couldn't get dictionary %@" with [tIndex]
+					return false
+				end if
+			end unsafe
 			variable tConvertedDict as Array
-			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then 
+			if not browserDictionaryToLCBArray(tBrowserDict, tConvertedDict) then
 				log "couldn't convert dictionary %@" with [tIndex]
 				return false
 			end if
@@ -327,9 +361,9 @@ public handler browserDictionaryToLCBArray(in pBrowserDict as MCBrowserDictionar
 			return false
 		end if
 	end repeat
-	
+
 	put tArray into rArray
-	
+
 	return true
 end handler
 
@@ -338,23 +372,25 @@ end handler
 private handler browserLookupProperty(in pProp as String) returns MCBrowserProperty
 	variable tIndex as optional Integer
 	put the index of pProp in kMCBrowserPropertyMap into tIndex
-	
+
 	if tIndex is 0 then
 		throw "Unknown property: " & pProp
 	end if
-	
+
 	return tIndex - 1
 end handler
 
 ----------
 
 public handler browserGetEnumProperty(in pBrowser as MCBrowserRef, in pProperty as MCBrowserProperty, out rValue as optional any) returns Boolean
-	if pProperty is in kStringProps then
-		return MCBrowserGetStringProperty(pBrowser, pProperty, rValue)
-	else if pProperty is in kBoolProps then
-		return MCBrowserGetBoolProperty(pBrowser, pProperty, rValue)
-	end if
-	
+	unsafe
+		if pProperty is in kStringProps then
+			return MCBrowserGetStringProperty(pBrowser, pProperty, rValue)
+		else if pProperty is in kBoolProps then
+			return MCBrowserGetBoolProperty(pBrowser, pProperty, rValue)
+		end if
+	end unsafe
+
 	return false
 end handler
 
@@ -363,20 +399,22 @@ public handler browserGetProperty(in pBrowser as MCBrowserRef, in pProperty as S
 	if not browserGetEnumProperty(pBrowser, browserLookupProperty(pProperty), tValue) then
 		throw "Error retrieving browser property: " & pProperty
 	end if
-	
+
 	return tValue
 end handler
 
 public handler browserSetEnumProperty(in pBrowser as MCBrowserRef, in pProperty as MCBrowserProperty, in pValue as any) returns Boolean
-	if pProperty is in kStringProps then
-		return MCBrowserSetStringProperty(pBrowser, pProperty, pValue)
-	else if pProperty is in kBoolProps then
-		return MCBrowserSetBoolProperty(pBrowser, pProperty, pValue)
-	end if
-	
+	unsafe
+		if pProperty is in kStringProps then
+			return MCBrowserSetStringProperty(pBrowser, pProperty, pValue)
+		else if pProperty is in kBoolProps then
+			return MCBrowserSetBoolProperty(pBrowser, pProperty, pValue)
+		end if
+	end unsafe
+
 	return false
 end handler
-	
+
 public handler browserSetProperty(in pBrowser as MCBrowserRef, in pProperty as String, in pValue as any)
 	variable tValue as any
 	if not browserSetEnumProperty(pBrowser, browserLookupProperty(pProperty), pValue) then
@@ -392,12 +430,12 @@ private variable mRunloopAction as MCRunloopActionRef
 private variable mWaitHandler
 
 /* TODO - need to provide a wrapper handler here as we can't (yet) get a pointer to a foreign native handler */
-private handler doWait() returns CBool
+private unsafe handler doWait() returns CBool
 	MCEngineRunloopWait()
 	return true
 end handler
 
-private handler doBreakWait() returns nothing
+private unsafe handler doBreakWait() returns nothing
 	MCEngineRunloopBreakWait()
 end handler
 
@@ -405,20 +443,22 @@ public handler libbrowserInit() returns nothing
 	if mInitialized is not nothing then
 		return
 	end if
-	
-	if not MCBrowserLibraryInitialize() then
-		return
-	end if
 
-	MCBrowserLibrarySetWaitFunction(doWait)
-	MCBrowserLibrarySetBreakWaitFunction(doBreakWait)
+	unsafe
+		if not MCBrowserLibraryInitialize() then
+			return
+		end if
 
-	variable tCallback as MCRunloopActionCallback
-	variable tContext as Pointer
-	if MCBrowserLibraryGetRunloopCallback(tCallback, tContext) then
-		MCEngineAddRunloopAction(tCallback, tContext, mRunloopAction)
-	end if
-	
+		MCBrowserLibrarySetWaitFunction(doWait)
+		MCBrowserLibrarySetBreakWaitFunction(doBreakWait)
+
+		variable tCallback as MCRunloopActionCallback
+		variable tContext as Pointer
+		if MCBrowserLibraryGetRunloopCallback(tCallback, tContext) then
+			MCEngineAddRunloopAction(tCallback, tContext, mRunloopAction)
+		end if
+	end unsafe
+
 	put true into mInitialized
 end handler
 

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -232,7 +232,7 @@ Example:
 	-- content
 	local tHTML
 	put "<html><head><title>My Page Title</title></head>" & \
-	      "<body>My Page Contents</body></html>" into tHTML
+		  "<body>My Page Contents</body></html>" into tHTML
 	set the htmlText of widget "myBrowser" to tHTML
 
 Description:
@@ -339,11 +339,11 @@ Example:
 		-- Do appropriate actions here.
 		-- ...
 	end myJSHandler
-	
+
 	-- Set up the browser javascript handler list
 	-- This code goes in a suitable setup handler
 	set the javascriptHandlers to "myJSHandler" & return & "myOtherJSHandler"
-	
+
 	// Calling the handler from JavaScript within the browser
 	liveCode.myJSHandler("myMessage", 12345);
 
@@ -405,42 +405,42 @@ end handler
 
 --
 
-private handler InitBrowserView()
+private unsafe handler InitBrowserView()
 	variable tParent as Pointer
-	
+
 	// put my native window into tParent
 	MCWidgetGetMyStackNativeView(tParent)
-		
+
 	variable tFactory as MCBrowserFactoryRef
 	if not MCBrowserFactoryGet(the empty string, tFactory) then
 		throw "error getting browser factory"
 	end if
-	
+
 	variable tDisplay as Pointer
 	MCWidgetGetMyStackNativeDisplay(tDisplay)
-	
+
 	if not MCBrowserFactoryCreateBrowser(tFactory, tDisplay, tParent, mBrowser) then
 		throw "error creating browser"
 	end if
-	
+
 	variable tBrowserView as Pointer
 	put MCBrowserGetNativeLayer(mBrowser) into tBrowserView
-	
+
 	// set my native layer to tBrowserView
 	MCWidgetSetMyNativeLayer(tBrowserView)
 	// tell native layer that we can't render a snapshot of the browser view.
 	MCWidgetSetMyNativeLayerCanRenderToContext(false)
-	
+
 	MCBrowserSetRequestHandler(mBrowser, OnBrowserRequestCallback, nothing)
 	MCBrowserSetJavaScriptHandler(mBrowser, OnJavaScriptCallback, nothing)
 
 	applyProperties(mProperties)
 end handler
 
-private handler FinalizeBrowserView()
+private unsafe handler FinalizeBrowserView()
 	//set my native layer to nothing
 	MCWidgetSetMyNativeLayer(nothing)
-	
+
 	MCBrowserRelease(mBrowser)
 	put nothing into mBrowser
 end handler
@@ -454,11 +454,15 @@ public handler OnOpen()
 
 	put true into mOpened
 
-	InitBrowserView()
+	unsafe
+		InitBrowserView()
+	end unsafe
 end handler
 
 public handler OnClose()
-	FinalizeBrowserView()
+	unsafe
+		FinalizeBrowserView()
+	end unsafe
 
 	put false into mOpened
 end handler
@@ -469,7 +473,7 @@ private handler Capitalize(in pString as String) returns String
 	if pString is empty then
 		return the empty string
 	end if
-	
+
 	put (the upper of char 1 of pString) into char 1 of pString
 	return pString
 end handler
@@ -479,14 +483,14 @@ end handler
 private handler OnBrowserRequestCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pType as MCBrowserRequestType, in pState as MCBrowserRequestState, in pFrame as CBool, in pUrl as ZStringUTF8, in pError as optional ZStringUTF8) returns nothing
 	variable tType as String
 	put element (pType + 1) of kMCBrowserRequestTypeMap into tType
-	
+
 	variable tState as String
 	put element (pState + 1) of kMCBrowserRequestStateMap into tState
-	
+
 	if pState is kMCBrowserRequestStateFailed then
 		log "Failed: %@" with [pError]
 	end if
-	
+
 	/* Dispatch browser message */
 	variable tMessage as String
 	if tType is "navigate" and tState is "unhandled" then
@@ -498,18 +502,18 @@ private handler OnBrowserRequestCallback(in pContext as optional Pointer, in pBr
 			put "browser" & Capitalize(tType) & Capitalize(tState) into tMessage
 		end if
 	end if
-	
+
 	variable tArgs as List
 	if pState is kMCBrowserRequestStateFailed then
 		put [pUrl, pError] into tArgs
 	else
 		put [pUrl] into tArgs
 	end if
-	
+
 	if pType is kMCBrowserRequestTypeNavigate and pState is kMCBrowserRequestStateBegin and not pFrame then
 		updateUrlProperty(pUrl)
 	end if
-	
+
 	post tMessage to mScriptObject with tArgs
 end handler
 
@@ -565,9 +569,11 @@ private handler setUrl(in pUrl as String)
 		updateUrlProperty(pUrl)
 
 		if mBrowser is not nothing then
-			if not MCBrowserGoToURL(mBrowser, pUrl) then
-				throw "error launching url " & pUrl
-			end if
+			unsafe
+				if not MCBrowserGoToURL(mBrowser, pUrl) then
+					throw "error launching url " & pUrl
+				end if
+			end unsafe
 		end if
 	end if
 end handler
@@ -665,17 +671,21 @@ end handler
 
 public handler OnGoBack()
 	if mBrowser is not nothing then
-		if not MCBrowserGoBack(mBrowser) then
-			throw "error going back"
-		end if
+		unsafe
+			if not MCBrowserGoBack(mBrowser) then
+				throw "error going back"
+			end if
+		end unsafe
 	end if
 end handler
 
 public handler OnGoForward()
 	if mBrowser is not nothing then
-		if not MCBrowserGoForward(mBrowser) then
-			throw "error going forward"
-		end if
+		unsafe
+			if not MCBrowserGoForward(mBrowser) then
+				throw "error going forward"
+			end if
+		end unsafe
 	end if
 end handler
 
@@ -686,13 +696,15 @@ end handler
 private handler browserEvaluateJavaScript(in pScript as String) returns String
 	if mBrowser is not nothing then
 		variable tResult as String
-		if not MCBrowserEvaluateJavaScript(mBrowser, pScript, tResult) then
-			throw "error evaluating javascript"
-		end if
-		
+		unsafe
+			if not MCBrowserEvaluateJavaScript(mBrowser, pScript, tResult) then
+				throw "error evaluating javascript"
+			end if
+		end unsafe
+
 		return tResult
 	end if
-	
+
 	return the empty string
 end handler
 
@@ -711,34 +723,34 @@ public handler OnPaint() returns nothing
 	variable tStrokePaint as Paint
 	put solid paint with color [0.875, 0.875, 0.875] into tFillPaint
 	put solid paint with color [0.75, 0.75, 0.75] into tStrokePaint
-	
+
 	variable tBounds as Rectangle
 	put my bounds into tBounds
-	
+
 	set the paint of this canvas to tFillPaint
 	fill rectangle path of tBounds on this canvas
 	set the paint of this canvas to tStrokePaint
 	set the stroke width of this canvas to kBorderWidth
 	set the join style of this canvas to "bevel"
 	stroke rectangle path of expandRectangle(tBounds, -kBorderWidth / 2) on this canvas
-	
+
 	variable tPath as Path
 	put path kSvgIcon into tPath
 	constrainPathToRect(expandRectangle(tBounds, -2 * kBorderWidth), tPath)
 	fill tPath on this canvas
-	
+
 	// Draw the control name
 	put solid paint with color [1, 1, 1] into tFillPaint
 	put solid paint with color [0.25, 0.25, 0.25] into tStrokePaint
 
 	variable tNameString as String
 	put my name into tNameString
-	
+
 	set the font of this canvas to font "Arial" at size 14
 
 	variable tTextBounds as Rectangle
 	put the image bounds of text tNameString on this canvas into tTextBounds
-	
+
 	translate this canvas by [ the width of tBounds / 2, the height of tBounds / 2]
 	translate this canvas by [ -(the width of tTextBounds / 2), the height of tTextBounds / 2]
 	set the paint of this canvas to tFillPaint

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1312,7 +1312,9 @@ foreign handler MCStringDecode(in BinaryData as Data, in Encoding as LCUInt, in 
 
 // Temporary wrapper to allow conversion of data to string until it is implemented in the LCB stdlib
 private handler ConvertToString(in pData as Data, out rString as optional String) returns Boolean
-    return MCStringDecode(pData, kUTF8Encoding, false, rString)
+    unsafe
+        return MCStringDecode(pData, kUTF8Encoding, false, rString)
+    end unsafe
 end handler
 
 // Convert an array to a list, as used by this widget. Ignoring the 'folded' ans selected

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3283,6 +3283,7 @@ struct MCPickleVariantInfo
 #define MC_PICKLE_TYPEINFOREF(Field) MC_PICKLE_FIELD(TypeInfoRef, Field, 0)
 
 #define MC_PICKLE_INTENUM(EType, EField) MC_PICKLE_FIELD(IntEnum, EField, k##EType##__Last)
+#define MC_PICKLE_INTSET(SType, SField) MC_PICKLE_FIELD(IntEnum, SField, 0)
 
 #define MC_PICKLE_ARRAY_OF_BYTE(Field, CountField) MC_PICKLE_FIELD_AUX(ArrayOfByte, Field, CountField, 0)
 #define MC_PICKLE_ARRAY_OF_UINDEX(Field, CountField) MC_PICKLE_FIELD_AUX(ArrayOfUIndex, Field, CountField, 0)

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -311,6 +311,12 @@ enum MCScriptHandlerTypeParameterMode
     kMCScriptHandlerTypeParameterMode__Last
 };
 
+enum MCScriptHandlerAttributes
+{
+    kMCScriptHandlerAttributeSafe = 0 << 0,
+    kMCScriptHandlerAttributeUnsafe = 1 << 0,
+};
+    
 void MCScriptBeginModule(MCScriptModuleKind kind, MCNameRef name, MCScriptModuleBuilderRef& r_builder);
 bool MCScriptEndModule(MCScriptModuleBuilderRef builder, MCStreamRef stream);
 
@@ -345,7 +351,7 @@ void MCScriptAddTypeToModule(MCScriptModuleBuilderRef builder, MCNameRef name, u
 void MCScriptAddConstantToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t const_idx, uindex_t index);
 void MCScriptAddVariableToModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t index);
 
-void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t signature, uindex_t index);
+void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t signature, MCScriptHandlerAttributes attributes, uindex_t index);
 void MCScriptAddParameterToHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t& r_index);
 void MCScriptAddVariableToHandlerInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type, uindex_t& r_index);
 void MCScriptEndHandlerInModule(MCScriptModuleBuilderRef builder);

--- a/libscript/src/math.lcb
+++ b/libscript/src/math.lcb
@@ -128,7 +128,9 @@ end syntax
 
 public handler Sin(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalSinNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalSinNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -152,7 +154,9 @@ end syntax
 
 public handler Cos(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalCosNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalCosNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -180,7 +184,9 @@ end syntax
 
 public handler Tan(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalTanNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalTanNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -211,7 +217,9 @@ end syntax
 
 public handler Asin(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalAsinNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalAsinNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -242,7 +250,9 @@ end syntax
 
 public handler Acos(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalAcosNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalAcosNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -273,7 +283,9 @@ end syntax
 
 public handler Atan(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalAtanNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalAtanNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -306,7 +318,9 @@ end syntax
 
 public handler atan2(in pY as Number, in pX as Number) returns Number
     variable tVar as Number
-    MCMathEvalAtan2Number(pX, pY, tVar)
+    unsafe
+        MCMathEvalAtan2Number(pX, pY, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -332,7 +346,9 @@ end syntax
 
 public handler log10(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalBase10LogNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalBase10LogNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -359,7 +375,9 @@ end syntax
 
 public handler Ln(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalNaturalLogNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalNaturalLogNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -385,7 +403,9 @@ end syntax
 
 public handler Exp(in pOperand as Number) returns Number
     variable tVar as Number
-    MCMathEvalExpNumber(pOperand, tVar)
+    unsafe
+        MCMathEvalExpNumber(pOperand, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -477,7 +497,9 @@ end syntax
 
 public handler Min(in pX as Number, in pY as Number) returns Number
     variable tVar as Number
-    MCMathEvalMinNumber(pX, pY, tVar)
+    unsafe
+        MCMathEvalMinNumber(pX, pY, tVar)
+    end unsafe
     return tVar
 end handler
 
@@ -499,7 +521,9 @@ end syntax
 
 public handler Max(in pX as Number, in pY as Number) returns Number
     variable tVar as Number
-    MCMathEvalMaxNumber(pX, pY, tVar)
+    unsafe
+        MCMathEvalMaxNumber(pX, pY, tVar)
+    end unsafe
     return tVar
 end handler
 

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1357,7 +1357,7 @@ static void __emit_position(MCScriptModuleBuilderRef self, uindex_t p_address, u
     self -> module . positions[t_pindex] . line = p_line;
 }
 
-void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, uindex_t p_index)
+void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCNameRef p_name, uindex_t p_type, MCScriptHandlerAttributes p_attributes, uindex_t p_index)
 {
     if (self == nil || !self -> valid)
         return;
@@ -1377,6 +1377,7 @@ void MCScriptBeginHandlerInModule(MCScriptModuleBuilderRef self, MCNameRef p_nam
     
     t_definition -> kind = kMCScriptDefinitionKindHandler;
     t_definition -> type = p_type;
+    t_definition -> attributes = p_attributes;
     t_definition -> start_address = self -> module . bytecode_count;
     
     self -> current_handler = p_index;

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -133,6 +133,7 @@ MC_PICKLE_BEGIN_RECORD(MCScriptHandlerDefinition)
     MC_PICKLE_ARRAY_OF_NAMEREF(local_names, local_name_count)
     MC_PICKLE_UINDEX(start_address)
     MC_PICKLE_UINDEX(finish_address)
+    MC_PICKLE_INTSET(MCScriptHandlerAttributes, attributes)
 MC_PICKLE_END_RECORD()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptForeignHandlerDefinition)
@@ -1293,9 +1294,14 @@ bool MCScriptWriteInterfaceOfModule(MCScriptModuleRef self, MCStreamRef stream)
             break;
             case kMCScriptDefinitionKindHandler:
             {
+                MCScriptHandlerDefinition *t_handler;
+                t_handler = static_cast<MCScriptHandlerDefinition *>(t_def);
                 MCAutoStringRef t_sig;
-                type_to_string(self, static_cast<MCScriptHandlerDefinition *>(t_def) -> type, &t_sig);
-                __writeln(stream, "handler %@%@", t_def_name, *t_sig);
+                type_to_string(self, t_handler -> type, &t_sig);
+                if ((t_handler -> attributes & kMCScriptHandlerAttributeUnsafe) == 0)
+                    __writeln(stream, "handler %@%@", t_def_name, *t_sig);
+                else
+                    __writeln(stream, "unsafe handler %@%@", t_def_name, *t_sig);
             }
             break;
             case kMCScriptDefinitionKindForeignHandler:

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -271,6 +271,8 @@ struct MCScriptHandlerDefinition: public MCScriptCommonHandlerDefinition
 	uindex_t start_address;
 	uindex_t finish_address;
     
+    MCScriptHandlerAttributes attributes;
+    
     // The number of slots required in a frame in order to execute this handler - computed.
     uindex_t slot_count;
 };
@@ -600,7 +602,8 @@ bool MCScriptBytecodeIterate(byte_t*& x_bytecode, byte_t *p_bytecode_limit, MCSc
 // of each module version.
 
 #define kMCScriptModuleVersion_8_0_0_DP_1 0
-#define kMCScriptCurrentModuleVersion kMCScriptModuleVersion_8_0_0_DP_1
+#define kMCScriptModuleVersion_8_1_0_DP_2 1
+#define kMCScriptCurrentModuleVersion kMCScriptModuleVersion_8_1_0_DP_2
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libscript/src/system.lcb
+++ b/libscript/src/system.lcb
@@ -63,11 +63,15 @@ end syntax
 foreign handler __exit(in ExitStatus as CInt) returns nothing binds to "exit"
 
 public handler MCSystemExecQuit() returns nothing
-	__exit(0)
+	unsafe
+		__exit(0)
+	end unsafe
 end handler
 
 public handler MCSystemExecQuitWithStatus(in Status as Number)
-	__exit(Status)
+	unsafe
+		__exit(Status)
+	end unsafe
 end handler
 
 /**

--- a/libscript/src/unittest-impl.lcb
+++ b/libscript/src/unittest-impl.lcb
@@ -43,7 +43,9 @@ end handler
 
 public handler MCUnitDiagnostic(in pMessage as any)
 	variable tCopyMessage as String
-	MCValueCopyDescription(pMessage, tCopyMessage)
+	unsafe
+		MCValueCopyDescription(pMessage, tCopyMessage)
+	end unsafe
 
 	variable tMessageLines as List
 	split tCopyMessage by "\n" into tMessageLines
@@ -94,7 +96,9 @@ public handler MCUnitOutput(in pMessage as String)
 	-- Encode as UTF-8, always.
 	-- FIXME this should use LCB encoding library rather than directly
 	-- calling into libfoundation
-	MCStringEncode(pMessage, 4 /* UTF-8 */, false, tEncoded)
+	unsafe
+		MCStringEncode(pMessage, 4 /* UTF-8 */, false, tEncoded)
+	end unsafe
 
 	write tEncoded to the output stream
 end handler

--- a/libscript/src/unittest.lcb
+++ b/libscript/src/unittest.lcb
@@ -137,7 +137,9 @@ begin
 end syntax
 
 public handler MCUnitTest(in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, "", "", "")
+	unsafe
+		MCUnitOutputTest(pCondition, "", "", "")
+	end unsafe
 end handler
 
 /**
@@ -164,7 +166,9 @@ begin
 end syntax
 
 public handler MCUnitTestDescription(in pDescription as String, in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, pDescription, "", "")
+	unsafe
+		MCUnitOutputTest(pCondition, pDescription, "", "")
+	end unsafe
 end handler
 
 ----------------------------------------------------------------
@@ -187,7 +191,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkip()
-	MCUnitOutputTest(true, "", "SKIP", "")
+	unsafe
+		MCUnitOutputTest(true, "", "SKIP", "")
+	end unsafe
 end handler
 
 /**
@@ -212,7 +218,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkipDescription(in pDescription as String)
-	MCUnitOutputTest(true, pDescription, "SKIP", "")
+	unsafe
+		MCUnitOutputTest(true, pDescription, "SKIP", "")
+	end unsafe
 end handler
 
 /**
@@ -237,7 +245,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkipReason(in pReason as String)
-	MCUnitOutputTest(true, "", "SKIP", pReason)
+	unsafe
+		MCUnitOutputTest(true, "", "SKIP", pReason)
+	end unsafe
 end handler
 
 /**
@@ -265,7 +275,9 @@ begin
 end syntax
 
 public handler MCUnitTestSkipDescriptionAndReason(in pDescription as String, in pReason as String)
-	MCUnitOutputTest(true, pDescription, "SKIP", pReason)
+	unsafe
+		MCUnitOutputTest(true, pDescription, "SKIP", pReason)
+	end unsafe
 end handler
 
 ----------------------------------------------------------------
@@ -295,7 +307,9 @@ begin
 end syntax
 
 public handler MCUnitTestFails(in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, "", "TODO", "")
+	unsafe
+		MCUnitOutputTest(pCondition, "", "TODO", "")
+	end unsafe
 end handler
 
 /**
@@ -326,7 +340,9 @@ begin
 end syntax
 
 public handler MCUnitTestFailsDescription(in pDescription as String, in pCondition as Boolean)
-	MCUnitOutputTest(pCondition, pDescription, "TODO", "")
+	unsafe
+		MCUnitOutputTest(pCondition, pDescription, "TODO", "")
+	end unsafe
 end handler
 
 /**
@@ -358,7 +374,9 @@ begin
 end syntax
 
 public handler MCUnitTestFailsReason(in pCondition as Boolean, in pReason as String)
-	MCUnitOutputTest(pCondition, "", "TODO", pReason)
+	unsafe
+		MCUnitOutputTest(pCondition, "", "TODO", pReason)
+	end unsafe
 end handler
 
 /**
@@ -391,7 +409,9 @@ begin
 end syntax
 
 public handler MCUnitTestFailsDescriptionAndReason(in pDescription as String, in pCondition as Boolean, in pReason as String)
-	MCUnitOutputTest(pCondition, pDescription, "TODO", pReason)
+	unsafe
+		MCUnitOutputTest(pCondition, pDescription, "TODO", pReason)
+	end unsafe
 end handler
 
 end module

--- a/tests/_testlib.lcb
+++ b/tests/_testlib.lcb
@@ -30,7 +30,10 @@ handler MCUnitTestHandlerThrowsImpl(in pHandler as any, in pDescription as Strin
 	variable tMaybeError as optional any
 
 	put [] into tArgList
-	put MCHandlerTryToInvokeWithList(tHandler, tArgList, tResult) into tMaybeError
+
+	unsafe
+		put MCHandlerTryToInvokeWithList(tHandler, tArgList, tResult) into tMaybeError
+	end unsafe
 
 	variable tHasError as Boolean
 	put tMaybeError is not nothing into tHasError

--- a/tests/_testrunner.lcb
+++ b/tests/_testrunner.lcb
@@ -45,7 +45,10 @@ foreign handler __system(in Command as ZStringNative) returns CInt binds to "sys
 
 handler System(in pCommand as String) returns Number
 	variable tExitStatus as Number
-	put __system(pCommand) into tExitStatus
+
+	unsafe
+		put __system(pCommand) into tExitStatus
+	end unsafe
 
 	if tExitStatus is in [0, -1] then
 		return tExitStatus
@@ -71,13 +74,17 @@ foreign handler MCStringDecode(in Encoded as Data, in Encoding as CInt, in IsExt
 
 handler EncodeUTF8(in pString as String) returns Data
 	variable tEncoded as Data
-	MCStringEncode(pString, 4 /* UTF-8 */, false, tEncoded)
+	unsafe
+		MCStringEncode(pString, 4 /* UTF-8 */, false, tEncoded)
+	end unsafe
 	return tEncoded
 end handler
 
 handler DecodeUTF8(in pData as Data) returns String
 	variable tString as String
-	MCStringDecode(pData, 4 /* UTF-8 */, false, tString)
+	unsafe
+		MCStringDecode(pData, 4 /* UTF-8 */, false, tString)
+	end unsafe
 	return tString
 end handler
 
@@ -383,8 +390,8 @@ end handler
 --
 -- Must be called like this:
 --
---     lc-run --handler RunModuleTests -- \
---         _testrunner.lcm --lc-run /path/to/lc-run /path/to/foo.lcm
+--	 lc-run --handler RunModuleTests -- \
+--		 _testrunner.lcm --lc-run /path/to/lc-run /path/to/foo.lcm
 --
 -- RunModuleTests() will run a handler from the target module if all
 -- of the following conditions are met:
@@ -508,8 +515,8 @@ end handler
 --
 -- Must be called like this:
 --
---     lc-run --handler SummarizeTests -- \
---         _testrunner.lcm --summary-log /path/to/summary [LOGFILE ...]
+--	 lc-run --handler SummarizeTests -- \
+--		 _testrunner.lcm --summary-log /path/to/summary [LOGFILE ...]
 --
 public handler SummarizeTests()
 

--- a/tests/lcb/compiler/bytecode.lcb
+++ b/tests/lcb/compiler/bytecode.lcb
@@ -17,7 +17,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 module com.livecode.compiler.bytecode.tests
 
-public handler TestJump()
+public unsafe handler TestJump()
    variable tTest as Boolean
    put false into tTest
    bytecode
@@ -28,7 +28,7 @@ public handler TestJump()
    test "jump forward label" when tTest is false
 end handler
 
-public handler TestJumpIfFalse()
+public unsafe handler TestJumpIfFalse()
    variable tTest as Boolean
    put false into tTest
    bytecode
@@ -41,7 +41,7 @@ public handler TestJumpIfFalse()
    test "jumpiffalse forward label" when tTest is false
 end handler
 
-public handler TestJumpIfTrue()
+public unsafe handler TestJumpIfTrue()
    variable tTest as Boolean
    put false into tTest
    bytecode
@@ -54,7 +54,7 @@ public handler TestJumpIfTrue()
    test "jumpiffalse forward label" when tTest is false
 end handler
 
-public handler TestAssignConstant()
+public unsafe handler TestAssignConstant()
    variable tTest
    put "Hello World!" into tTest
 
@@ -84,7 +84,7 @@ public handler TestAssignConstant()
    test "assignconstant string literal" when tTest is "Foo"
 end handler
 
-private handler DoTestAssignParameter(in pSource)
+private unsafe handler DoTestAssignParameter(in pSource)
    bytecode
          register regTemp
          assign_constant regTemp, true
@@ -103,7 +103,7 @@ private handler DoTestAssignParameter(in pSource)
    test "assign param to temp" when tTarget is false
 end handler
 
-public handler TestAssign()
+public unsafe handler TestAssign()
    variable tTarget
 
    put false into tTarget
@@ -127,21 +127,21 @@ public handler TestAssign()
    DoTestAssignParameter(false)
 end handler
 
-private handler DoTestReturnNothing()
+private unsafe handler DoTestReturnNothing()
    bytecode
          return
    end bytecode
    return true
 end handler
 
-private handler DoTestReturnValue(in pValue)
+private unsafe handler DoTestReturnValue(in pValue)
    bytecode
          return pValue
    end bytecode
    return true
 end handler
 
-public handler TestReturn()
+public unsafe handler TestReturn()
    DoTestReturnNothing()
    test "return nothing" when the result is nothing
 
@@ -154,7 +154,7 @@ private handler DoTestInvoke(in pInput, out rOutput)
    return true
 end handler
 
-public handler TestInvoke()
+public unsafe handler TestInvoke()
    variable tOutput
    variable tResult
    put nothing into tOutput
@@ -168,7 +168,7 @@ public handler TestInvoke()
    test "invoke result" when tResult is true
 end handler
 
-public handler TestInvokeIndirect()
+public unsafe handler TestInvokeIndirect()
    variable tOutput
    variable tResult
    put nothing into tOutput
@@ -196,7 +196,7 @@ private handler Return100()
    return 100
 end handler
 
-public handler TestFetch()
+public unsafe handler TestFetch()
    variable tTest
 
    put "Hello World!" into tTest
@@ -245,7 +245,7 @@ public handler TestFetch()
    test "fetch handler" when tTestHandler() is 100
 end handler
 
-public handler TestStore()
+public unsafe handler TestStore()
    put nothing into sModuleVariable
    bytecode
          register regTemp
@@ -255,7 +255,7 @@ public handler TestStore()
    test "store variable" when sModuleVariable is 100
 end handler
 
-public handler TestAssignList()
+public unsafe handler TestAssignList()
    variable tTest
 
    variable tElement1
@@ -269,7 +269,7 @@ public handler TestAssignList()
    test "assignlist" when tTest is [1, 2]
 end handler
 
-public handler TestAssignArray()
+public unsafe handler TestAssignArray()
    variable tTest
 
    variable tElement1
@@ -288,7 +288,7 @@ public handler TestAssignArray()
                            tTest["foo"] is 1 and tTest["bar"] is 2
 end handler
 
-public handler TestReset()
+public unsafe handler TestReset()
    variable tTest as Boolean
    put true into tTest
    bytecode

--- a/tests/lcb/compiler/frontend/unsafe.compilertest
+++ b/tests/lcb/compiler/frontend/unsafe.compilertest
@@ -1,0 +1,129 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%TEST BytecodeInSafeHandler
+module compiler_test
+handler SafeHandler()
+   %{BEFORE_BYTECODE}bytecode
+   end bytecode
+end handler
+end module
+%EXPECT PASS
+%ERROR BytecodeNotAllowedInSafeContext AT BEFORE_BYTECODE
+%ENDTEST
+
+%TEST BytecodeInUnsafeBlock
+module compiler_test
+handler SafeHandler()
+   unsafe
+      bytecode
+      end bytecode
+   end unsafe
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST BytecodeInUnsafeHandler
+module compiler_test
+unsafe handler UnsafeHandler()
+   bytecode
+   end bytecode
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%%
+
+%TEST SafeHandlerCallInSafeContext
+module compiler_test
+handler OtherSafeHandler(in pArg)
+end handler
+handler SafeHandler()
+   OtherSafeHandler(OtherSafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST SafeHandlerCallInUnsafeHandler
+module compiler_test
+handler OtherSafeHandler(in pArg)
+end handler
+unsafe handler UnsafeHandler()
+   OtherSafeHandler(OtherSafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST SafeHandlerCallInUnsafeContext
+module compiler_test
+handler SafeHandler(in pArg)
+end handler
+handler Handler()
+   unsafe
+      SafeHandler(SafeHandler(nothing))
+   end unsafe
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST UnsafeHandlerCallInSafeContext
+module compiler_test
+unsafe handler OtherUnsafeHandler(in pArg)
+end handler
+handler SafeHandler()
+   %{BEFORE_CALL}OtherUnsafeHandler(%{BEFORE_EVAL}OtherUnsafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%ERROR UnsafeHandlerCallNotAllowedInSafeContext AT BEFORE_CALL WITH OtherUnsafeHandler
+%ERROR UnsafeHandlerCallNotAllowedInSafeContext AT BEFORE_EVAL WITH OtherUnsafeHandler
+%ENDTEST
+
+%TEST UnsafeHandlerCallInUnsafeHandler
+module compiler_test
+unsafe handler OtherUnsafeHandler(in pArg)
+end handler
+unsafe handler UnsafeHandler()
+   OtherUnsafeHandler(OtherUnsafeHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST UnsafeHandlerCallInUnsafeContext
+module compiler_test
+unsafe handler UnsafeHandler(in pArg)
+end handler
+handler SafeHandler()
+   unsafe
+      UnsafeHandler(UnsafeHandler(nothing))
+   end unsafe
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST

--- a/tests/lcb/stdlib/byte.lcb
+++ b/tests/lcb/stdlib/byte.lcb
@@ -283,7 +283,9 @@ foreign handler MCStringEncode(in Unencoded as String, in Encoding as CInt, in I
 handler EncodeUTF8(in pString as String) returns Data
 	variable tEncoded as Data
 	variable tStatus as Boolean
-	MCStringEncode(pString, kEncodingIndexUTF8, false, tEncoded)
+	unsafe
+		MCStringEncode(pString, kEncodingIndexUTF8, false, tEncoded)
+	end unsafe
 	if tEncoded is empty then
 		return the empty data
 	end if

--- a/tests/lcb/vm/native-callback.lcb
+++ b/tests/lcb/vm/native-callback.lcb
@@ -10,27 +10,31 @@ variable sTotal_Manual as Number
 handler type ProperListCallbackThunk_Manual(in pContext as optional Pointer, in pElement as optional any) returns CBool
 
 handler SumElementOfList_Manual(in pContext as optional Pointer, in pElement as optional any) returns CBool
-    add pElement to sTotal_Manual
-    return true
+	add pElement to sTotal_Manual
+	return true
 end handler
 
 foreign handler MCHandlerGetFunctionPtr_Manual(in pHandler as any, out rFuncPtr as Pointer) returns CBool binds to "MCHandlerGetFunctionPtr"
 foreign handler MCProperListApply_Manual(in pList as List, in pCallback as Pointer, in pContext as optional Pointer) returns CBool binds to "MCProperListApply"
 
 public handler TestNativeCallback_Manual()
-    -- For memory management reasons we need to keep a reference to the handler
-    -- we want to use around for as long as the function ptr we need.
-    variable tHandler as ProperListCallbackThunk_Manual
-    put SumElementOfList_Manual into tHandler
+	-- For memory management reasons we need to keep a reference to the handler
+	-- we want to use around for as long as the function ptr we need.
+	variable tHandler as ProperListCallbackThunk_Manual
+	put SumElementOfList_Manual into tHandler
 
-    -- Fetch the function pointer
-    variable tFunctionPtr as Pointer
-    test "create function pointer - manual" when MCHandlerGetFunctionPtr_Manual(tHandler, tFunctionPtr)
+	-- Fetch the function pointer
+	variable tFunctionPtr as Pointer
+	unsafe
+		test "create function pointer - manual" when MCHandlerGetFunctionPtr_Manual(tHandler, tFunctionPtr)
+	end unsafe
 
-    -- See if it works
-    put 0 into sTotal_Manual
-    MCProperListApply_Manual([1, 2, 3, 4, 5, 6], tFunctionPtr, nothing)
-    test "use function pointer - manual" when sTotal_Manual is (1 + 2 + 3 + 4 + 5 + 6)
+	-- See if it works
+	put 0 into sTotal_Manual
+	unsafe
+		MCProperListApply_Manual([1, 2, 3, 4, 5, 6], tFunctionPtr, nothing)
+	end unsafe
+	test "use function pointer - manual" when sTotal_Manual is (1 + 2 + 3 + 4 + 5 + 6)
 end handler
 
 --------- AUTOMATIC FUNCTION PTRS
@@ -40,16 +44,18 @@ variable sTotal as Number
 foreign handler type MCProperListApplyCallback(in pContext as optional Pointer, in pElement as optional any) returns CBool
 
 handler SumElementOfList(in pContext as optional Pointer, in pElement as optional any) returns CBool
-    add pElement to sTotal
-    return true
+	add pElement to sTotal
+	return true
 end handler
 
 foreign handler MCProperListApply(in pList as List, in pCallback as MCProperListApplyCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 
 public handler TestNativeCallback()
-    put 0 into sTotal
-    MCProperListApply([1, 2, 3, 4, 5, 6], SumElementOfList, nothing)
-    test "use function pointer" when sTotal is (1 + 2 + 3 + 4 + 5 + 6)
+	put 0 into sTotal
+	unsafe
+		MCProperListApply([1, 2, 3, 4, 5, 6], SumElementOfList, nothing)
+	end unsafe
+	test "use function pointer" when sTotal is (1 + 2 + 3 + 4 + 5 + 6)
 end handler
 
 --------- FOREIGN HANDLER FUNCTION PTRS

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -124,7 +124,10 @@
     'rule' DeclareImportedDefinitions(sequence(Left, Right)):
         DeclareImportedDefinitions(Left)
         DeclareImportedDefinitions(Right)
-        
+
+    'rule' DeclareImportedDefinitions(unsafe(_, Definition)):
+        DeclareImportedDefinitions(Definition)
+
     'rule' DeclareImportedDefinitions(type(Position, _, Name, _)):
         DeclareId(Name)
 
@@ -184,7 +187,10 @@
     'rule' Declare(sequence(Left, Right)):
         Declare(Left)
         Declare(Right)
-        
+
+    'rule' Declare(unsafe(_, Definition)):
+        Declare(Definition)
+
     'rule' Declare(type(Position, _, Name, _)):
         DeclareId(Name)
 
@@ -282,9 +288,13 @@
     'rule' Define(ModuleId, handler(Position, Access, Name, Signature:signature(Parameters, _), _, _)):
         DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, normal, Signature))
         DefineParameters(Name, Parameters)
-    
+
+    'rule' Define(ModuleId, unsafe(_, handler(Position, Access, Name, Signature:signature(Parameters, _), _, _))):
+        DefineUnsafeSymbolId(Name, ModuleId, Access, handler, handler(Position, normal, Signature))
+        DefineParameters(Name, Parameters)
+
     'rule' Define(ModuleId, foreignhandler(Position, Access, Name, Signature:signature(Parameters, _), _)):
-        DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
+        DefineUnsafeSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
         DefineParameters(Name, Parameters)
 
     'rule' Define(ModuleId, property(Position, Access, Name, Getter, Setter)):
@@ -551,6 +561,11 @@
         DefineSymbolId(Name, ParentId, inferred, local, Type)
         Apply(Type)
 
+    'rule' Apply(STATEMENT'unsafe(_, Block)):
+        EnterScope
+        Apply(Block)
+        LeaveScope
+
     ---------
 
     'rule' Apply(EXPRESSION'slot(_, Name)):
@@ -688,6 +703,20 @@
         Info'Kind <- Kind
         Info'Type <- Type
         Info'Access <- Access
+        Info'Safety <- safe
+        Id'Meaning <- symbol(Info)
+
+'action' DefineUnsafeSymbolId(ID, ID, ACCESS, SYMBOLKIND, TYPE)
+
+    'rule' DefineUnsafeSymbolId(Id, ParentId, Access, Kind, Type)
+        Info::SYMBOLINFO
+        Info'Index <- -1
+        Info'Generator <- -1
+        Info'Parent <- ParentId
+        Info'Kind <- Kind
+        Info'Type <- Type
+        Info'Access <- Access
+        Info'Safety <- unsafe
         Id'Meaning <- symbol(Info)
 
 'action' DefineSyntaxId(ID, ID, SYNTAXCLASS, SYNTAX, SYNTAXMETHODLIST)

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -55,6 +55,7 @@ extern "C" void EmitTypeDefinition(long index, PositionRef position, NameRef nam
 extern "C" void EmitConstantDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_const_index);
 extern "C" void EmitVariableDefinition(long index, PositionRef position, NameRef name, long type_index);
 extern "C" void EmitBeginHandlerDefinition(long index, PositionRef position, NameRef name, long type_index);
+extern "C" void EmitBeginUnsafeHandlerDefinition(long index, PositionRef position, NameRef name, long type_index);
 extern "C" void EmitEndHandlerDefinition(void);
 extern "C" void EmitForeignHandlerDefinition(long index, PositionRef position, NameRef name, long type_index, long binding);
 extern "C" void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index);
@@ -891,9 +892,17 @@ void EmitEventDefinition(long p_index, PositionRef p_position, NameRef p_name, l
 
 void EmitBeginHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
 {
-    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, (uindex_t)p_index);
+    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, kMCScriptHandlerAttributeSafe, (uindex_t)p_index);
 
     Debug_Emit("BeginHandlerDefinition(%ld, %s, %ld)", p_index,
+               cstring_from_nameref(p_name), p_type_index);
+}
+
+void EmitBeginUnsafeHandlerDefinition(long p_index, PositionRef p_position, NameRef p_name, long p_type_index)
+{
+    MCScriptBeginHandlerInModule(s_builder, to_mcnameref(p_name), (uindex_t)p_type_index, kMCScriptHandlerAttributeUnsafe, (uindex_t)p_index);
+    
+    Debug_Emit("BeginUnsafeHandlerDefinition(%ld, %s, %ld)", p_index,
                cstring_from_nameref(p_name), p_type_index);
 }
 

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -204,7 +204,10 @@
     'rule' GenerateManifestDefinitions(sequence(Left, Right)):
         GenerateManifestDefinitions(Left)
         GenerateManifestDefinitions(Right)
-        
+
+    'rule' GenerateManifestDefinitions(unsafe(_, Definition)):
+        GenerateManifestDefinitions(Definition)
+
     'rule' GenerateManifestDefinitions(metadata(_, Key, Value)):
         (|
             IsStringEqualToString(Key, "title")
@@ -513,7 +516,10 @@
     'rule' GenerateDefinitionIndexes(sequence(Left, Right)):
         GenerateDefinitionIndexes(Left)
         GenerateDefinitionIndexes(Right)
-        
+
+    'rule' GenerateDefinitionIndexes(unsafe(_, Definition)):
+        GenerateDefinitionIndexes(Definition)
+
     'rule' GenerateDefinitionIndexes(type(_, _, Name, _)):
         GenerateDefinitionIndex("type", Name)
     
@@ -593,7 +599,10 @@
     'rule' GenerateExportedDefinitions(sequence(Left, Right)):
         GenerateExportedDefinitions(Left)
         GenerateExportedDefinitions(Right)
-        
+
+    'rule' GenerateExportedDefinitions(unsafe(_, Definition)):
+        GenerateExportedDefinitions(Definition)
+
     'rule' GenerateExportedDefinitions(type(_, public, Id, _)):
         GenerateExportedDefinition(Id)
         
@@ -641,7 +650,10 @@
     'rule' GenerateDefinitions(sequence(Left, Right)):
         GenerateDefinitions(Left)
         GenerateDefinitions(Right)
-        
+
+    'rule' GenerateDefinitions(unsafe(_, Definition)):
+        GenerateDefinitions(Definition)
+
     'rule' GenerateDefinitions(type(Position, _, Id, Type)):
         GenerateType(Type -> TypeIndex)
         
@@ -665,14 +677,20 @@
         Info'Index -> DefIndex
         EmitVariableDefinition(DefIndex, Position, Name, TypeIndex)
 
-
     'rule' GenerateDefinitions(handler(Position, _, Id, Signature:signature(Parameters, _), _, Body)):
         GenerateType(handler(Position, normal, Signature) -> TypeIndex)
         
         QuerySymbolId(Id -> Info)
         Id'Name -> Name
+        Info'Safety -> Safety
         Info'Index -> DefIndex
-        EmitBeginHandlerDefinition(DefIndex, Position, Name, TypeIndex)
+        (|
+            where(Safety -> safe)
+            EmitBeginHandlerDefinition(DefIndex, Position, Name, TypeIndex)
+        ||
+            where(Safety -> unsafe)
+            EmitBeginUnsafeHandlerDefinition(DefIndex, Position, Name, TypeIndex)
+        |)
         GenerateParameters(Parameters)
         CreateParameterRegisters(Parameters)
         CreateVariableRegisters(Body)
@@ -1194,6 +1212,9 @@
     'rule' GenerateBody(Result, Context, bytecode(Position, Block)):
         GenerateBytecodeDeferLabels(Block)
         GenerateBytecode(Block)
+
+    'rule' GenerateBody(Result, Context, unsafe(Position, Block)):
+        GenerateBody(Result, Context, Block)
 
     'rule' GenerateBody(Result, Context, nil):
         -- nothing

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -238,6 +238,9 @@
     'rule' ImportDefinition(-> handler(Position, public, Id, Signature, nil, nil)):
         "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
 
+    'rule' ImportDefinition(-> unsafe(Position, handler(Position, public, Id, Signature, nil, nil))):
+        "unsafe" "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
+
     'rule' ImportDefinition(-> foreignhandler(Position, public, Id, Signature, "")):
         "foreign" "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
 
@@ -455,7 +458,12 @@
         Access(-> Access) "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) Separator
             Statements(-> Body)
         "end" "handler"
-        
+
+    'rule' HandlerDefinition(-> unsafe(Position, handler(Position, Access, Name, Signature, nil, Body))):
+        Access(-> Access) "unsafe" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) Separator
+            Statements(-> Body)
+        "end" "handler"
+
     'rule' HandlerDefinition(-> foreignhandler(Position, Access, Name, Signature, Binding)):
         Access(-> Access) "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)
 
@@ -822,6 +830,11 @@
         "bytecode" @(-> Position) Separator
             Bytecodes(-> Opcodes)
         "end" "bytecode"
+
+    'rule' Statement(-> unsafe(Position, Body)):
+        "unsafe" @(-> Position) Separator
+            Statements(-> Body)
+        "end" "unsafe"
 
     'rule' Statement(-> postfixinto(Position, Statement, Target)):
         CustomStatements(-> Statement) "into" @(-> Position) Expression(-> Target)

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -333,6 +333,9 @@ DEFINE_ERROR(OpcodeArgumentMustBeVariable, "Opcode argument must be a module var
 DEFINE_ERROR(OpcodeArgumentMustBeDefinition, "Opcode argument must be a module variable, constant id or handler id")
 DEFINE_ERROR(IllegalNumberOfArgumentsForOpcode, "Wrong number of arguments for opcode")
 
+DEFINE_ERROR(BytecodeNotAllowedInSafeContext, "Bytecode blocks can only be present in unsafe context")
+DEFINE_ERROR_I(UnsafeHandlerCallNotAllowedInSafeContext, "Unsafe handler '%s' can only be called in unsafe context")
+
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(long p_position) { _Warning(p_position, Message); }
 #define DEFINE_WARNING_I(Name, Message) \

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -155,6 +155,7 @@
     EmitVariableDefinition
     EmitBeginHandlerDefinition
     EmitEndHandlerDefinition
+    EmitBeginUnsafeHandlerDefinition
     EmitForeignHandlerDefinition
     EmitPropertyDefinition
     EmitEventDefinition
@@ -345,6 +346,9 @@
     Error_OpcodeArgumentMustBeVariable
     Error_OpcodeArgumentMustBeDefinition
     Error_IllegalNumberOfArgumentsForOpcode
+    Error_BytecodeNotAllowedInSafeContext
+    Error_UnsafeHandlerCallNotAllowedInSafeContext
+
     Warning_MetadataClausesShouldComeAfterUseClauses
     Warning_DeprecatedTypeName
     Warning_UnsuitableNameForDefinition
@@ -542,6 +546,7 @@
 'action' EmitVariableDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitBeginHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitEndHandlerDefinition()
+'action' EmitBeginUnsafeHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
 'action' EmitForeignHandlerDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT, Binding: STRING)
 'action' EmitPropertyDefinition(Index: INT, Position: POS, Name: NAME, GetIndex: INT, SetIndex: INT)
 'action' EmitEventDefinition(Index: INT, Position: POS, Name: NAME, TypeIndex: INT)
@@ -761,6 +766,9 @@
 'action' Error_OpcodeArgumentMustBeVariable(Position: POS)
 'action' Error_OpcodeArgumentMustBeDefinition(Position: POS)
 'action' Error_IllegalNumberOfArgumentsForOpcode(Position: POS)
+
+'action' Error_BytecodeNotAllowedInSafeContext(Position: POS)
+'action' Error_UnsafeHandlerCallNotAllowedInSafeContext(Position: POS, Identifier: NAME)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -33,7 +33,7 @@
     NAMELIST
     MEANING
     MODULEINFO
-    SYMBOLINFO SYMBOLKIND
+    SYMBOLINFO SYMBOLKIND SYMBOLSAFETY
     SYNTAXINFO
     SYNTAXMARKINFO SYNTAXMARKTYPE
     NAME DOUBLE
@@ -68,6 +68,7 @@
     property(Position: POS, Access: ACCESS, Name: ID, Getter: ID, Setter: OPTIONALID)
     event(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE)
     syntax(Position: POS, Access: ACCESS, Name: ID, Class: SYNTAXCLASS, Warnings: SYNTAXWARNING, Syntax: SYNTAX, Methods: SYNTAXMETHODLIST)
+    unsafe(Position: POS, Definition: DEFINITION)
     nil
 
 'type' SIGNATURE
@@ -154,6 +155,7 @@
     throw(Position: POS, Error: EXPRESSION)
     postfixinto(Position: POS, Command: STATEMENT, Target: EXPRESSION)
     bytecode(Position: POS, Block: BYTECODE)
+    unsafe(Position: POS, Block: STATEMENT)
     nil
     
 'type' EXPRESSIONLIST
@@ -291,6 +293,10 @@
     context
     label
 
+'type' SYMBOLSAFETY
+    safe
+    unsafe
+
 'type' INTLIST
     intlist(Head: INT, Tail: INTLIST)
     nil
@@ -316,7 +322,7 @@
 'table' ID(Position: POS, Name: NAME, Meaning: MEANING)
 
 'table' MODULEINFO(Index: INT, Generator: INT)
-'table' SYMBOLINFO(Index: INT, Generator: INT, Parent: ID, Access: ACCESS, Kind: SYMBOLKIND, Type: TYPE)
+'table' SYMBOLINFO(Index: INT, Generator: INT, Parent: ID, Access: ACCESS, Safety: SYMBOLSAFETY, Kind: SYMBOLKIND, Type: TYPE)
 'table' SYNTAXINFO(Index: INT, Parent: ID, Class: SYNTAXCLASS, Syntax: SYNTAX, Methods: SYNTAXMETHODLIST, Prefix: SYNTAXTERM, Suffix: SYNTAXTERM)
 'table' SYNTAXMARKINFO(Index: INT, RMode: MODE, LMode: MODE, Type: SYNTAXMARKTYPE)
 'table' INVOKEINFO(Index: INT, ModuleIndex: INT, Name: STRING, ModuleName: STRING, Methods: INVOKEMETHODLIST)


### PR DESCRIPTION
This patch adds the idea of unsafe handlers and unsafe blocks
to LCB.

An unsafe handler can be declared by using the 'unsafe' keyword:

```
unsafe handler Foo()
end handler
```

An unsafe statement block can be written as:

```
unsafe
    ... do unsafe things ...
end unsafe
```

Calls to unsafe handlers, foreign handlers and usage of bytecode blocks can only occur within either an unsafe handler, or unsafe block.
