### PR TITLE
[[ CompilerTests ]] Add a compiler test runner

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,10 +2,11 @@
 
 Tests are small programs that check that a particular, specific function works correctly.  They are run automatically to check whether LiveCode works properly.  They're really useful for ensuring that changes to one part of LiveCode don't break other things!
 
-The main LiveCode engine repository contains three sets of tests ("test suites"):
+The main LiveCode engine repository contains four sets of tests ("test suites"):
 
-* **LiveCode Script tests:**  script-only stacks that are run using the LiveCode standalone engine.  They test features of the LiveCode Script language.
+* **LiveCode Script tests:** script-only stacks that are run using the LiveCode standalone engine.  They test features of the LiveCode Script language.
 * **LiveCode Builder tests:** LCB modules that are run using the **lc-run** tool.   They test features of the LCB core language and standard library.
+* **LiveCode Builder Compiler Frontend tests:** Fragments of LCB code which are run through the compiler and check that the compile succeeds, or emits the correct warnings or errors.
 * **C++ tests:** low-level tests written in C++ using [Google Test](https://github.com/google/googletest).  These perform low-level checks for things that can't be tested any other way.
 
 ## Running the Tests
@@ -62,14 +63,14 @@ Before running each test command, the test framework inserts a test library stac
 * `TestAssertThrow pDescription, pHandlerName, pTarget, pExpectedError, pParam`: Assert that a given handler triggers the expected error message. *pHandlerName* is the name of the handler containing the script expected to cause an error; it is dispatched to *pTarget* with *pParam* as a parameter within a try/catch structure. *pExpectedError* is the expected script execution error code.
 * `TestGetEngineRepositoryPath`: A function that returns the path to the main LiveCode engine repository.
 * `TestGetIDERepositoryPath`: A function that returns the path to the LiveCode IDE repository.
-* `TestLoadExtension pName`: Attempt to load the extension with name `pName`, eg `TestLoadExtension "json"` will load the JSON library extension. 
-* `TestLoadAllExtensions`: Attempt to load all available extensions. 
+* `TestLoadExtension pName`: Attempt to load the extension with name `pName`, eg `TestLoadExtension "json"` will load the JSON library extension.
+* `TestLoadAllExtensions`: Attempt to load all available extensions.
 * `TestRepeat pDesc, pHandler, pTarget, pTimeOut, pParamsArray`: Repeatedly check the result of a handler for a test. The test is recorded as a success if the result is ever true before the given time runs out, or a failure otherwise.
 	- `pHandlerName` is the name of the handler which returns a result.
 	- `pTarget` is the object to which `pHandlerName` should be dispatched.
 	- `pTimeOut` is the amount of milliseconds to continue testing the result of the handler.
 	- `pParamsArray` is an array of parameters, keyed by the 1-based index of the required parameter to be passed to the handler.
-	
+
 Tests can have additional setup requirements before running, for example loading custom libraries. If the script test contains a handler called `TestSetup`, this will be run prior to running each test command. For example:
 ````
 on TestSetup
@@ -104,6 +105,63 @@ Just like for the LCS tests described above, new `.lcb` files added to the test 
 Each test module contains a set of `public handler` definitions, with names beginning with `Test`.  Each test command gets run in a fresh LiveCode Builder environment.
 
 The LCB standard library has built-in syntax for writing unit tests, provided by the `com.livecode.unittest` module.  For more information and example code, look up `com.livecode.unittest` in the LiveCode Builder dictionary.
+
+### LiveCode Builder Compiler Frontend Tests
+
+LCB compiler frontend tests live in the 'tests/lcb/compiler/frontend' directory and its subdirectories. Compiler test files all have the extension '.compilertest'.
+
+Unlike LCB and LCS tests, the frontend compiler tests consist of fragments of LCB code which are fed to the compiler to check that it either succeeds, or emits the correct warnings or errors.
+
+The compilertest files use directives beginning with '%' to describe how the different LCB code fragments should behave when passed through the compiler. A single compilertest file can contain as many code fragments to check as necessary. The syntax is as follows:
+
+    CompilerTest
+       : { Line, NEWLINE }
+
+    Line
+       : WHITESPACE+
+       | '%%' ANYTHING_BUT_NEWLINE
+       | Test
+
+    Test
+       : '%TEST' <Name: Identifier> NEWLINE
+             { Code, NEWLINE }
+         '%EXPECT' ('PASS' | 'FAIL' | 'SKIP') [ <Reason: String> ] NEWLINE
+             { Assertion, NEWLINE }
+         '%ENDTEST'
+
+    Code
+       : { ANYTHING_BUT_NEWLINE | '%{' <Position: Identifier> '}' }
+
+    Assertion
+       : '%ERROR' <Message: String> 'AT' <Position: Identifier>
+       | '%WARNING' <Message: String> 'AT' <Position: Identifier>
+       | '%SUCCESS'
+
+Each %TEST clause indicates a separate test. Within the code fragments the '%{...}' clauses indicate named positions within the code which are used to check the position information provided for an error or a warning.
+
+At least one assertion must be present, and you cannot have an %ERROR and %SUCCESS assertion present in the same test.
+
+For each test present in the compilertest file, the code fragment is extracted, the positions of the '%{...}' references are noted and then references are removed. The resulting code is passed to lc-compile and its stderr output evaluated. The output is checked to ensure that each claimed assertion exists, and is in the correct position. When checking for assertion matches, the type (error or warning) must match, the position must match and the asserted string must be within the output message the compiler generates.
+
+For example, to check whether the scope of variables within 'repeat forever' statements blocks is correct, you might use:
+
+    %TEST RepeatForeverScope
+    module compiler_test
+    handler TestHandler()
+      variable tOuterVariable
+      repeat forever
+        variable tInnerVariable
+      end repeat
+      put %{BEFORE_BADINNERVARIABLE}tInnerVariable into tOuterVariable
+    end handler
+    end module
+    %EXPECT PASS
+    %ERROR "Identifier 'tInnerVariable' not declared" AT BEFORE_BADINNERVARIABLE
+    %ENDTEST
+
+When compiled, lc-compile will emit an error on the 'put' line because tInnerVariable is not declared at that point. This matches the specified '%ERROR' assertion and so the test will pass (i.e. the compiler is correctly identifying the fact that tInnerVariable is not declared outside of the scope of the 'repeat forever' construct).
+
+To help debug compiler tests, set the LCC_VERBOSE environment variable to 1 before running the compiler test. This will cause the compiler testrunner to emit diagnostic information, including the full output of the compile command which is being run.
 
 ### C++ tests with Google Test
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,17 @@ endif
 # Attempt to guess where to find various tools and libraries
 ################################################################
 
+MODE ?= release
+ifeq ($(MODE),release)
+	UC_MODE := Release
+else ifeq ($(MODE),debug)
+	UC_MODE := Debug
+else ifeq ($(MODE),fast)
+	UC_MODE := Fast
+else
+	$(error "Mode must be 'debug' or 'release'")
+endif
+
 top_srcdir ?= ..
 TEST_DIR ?= $(top_srcdir)/_tests
 LCM_DIR ?= $(TEST_DIR)/_build
@@ -26,7 +37,11 @@ guess_platform_script := \
 	esac
 guess_platform := $(shell $(guess_platform_script))
 
-bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
+ifeq ($(guess_platform),mac)
+	bin_dir ?= $(top_srcdir)/_build/mac/$(UC_MODE)
+else
+	bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
+endif
 
 ########## LiveCode Script test parameters
 
@@ -67,13 +82,21 @@ LCB_LOG = _lcb_test_suite.log
 LCB_TESTRUNNER = $(LCM_DIR)/_testrunner.lcm
 LCB_TESTLIB = $(LCM_DIR)/_testlib.lcm
 
+########## LiveCode Builder Compiler test parameters
+
+LCC_COMPILERTESTRUNNER ?= $(top_srcdir)/tests/_compilertestrunner.livecodescript
+
+LCC_CMD = $(LCS_ENGINE) -ui $(LCC_COMPILERTESTRUNNER) run
+
+LCC_LOG = _compiler_test_suite.log
+
 ################################################################
 # Top-level targets
 ################################################################
 
 .DEFAULT: check
 
-check: lcs-check lcb-check
+check: lcs-check lcb-check compiler-check
 
 clean:
 	-rm -rf $(TEST_DIR) $(LCS_LOG) $(LCB_LOG)
@@ -137,6 +160,18 @@ $(LCM_DIR)/%.lcm: %.lcb | $(LCM_DIR)
 lcs-check: $(LCS_ENGINE)
 	@rm -f $(LCS_LOG)
 	@cmd="$(LCS_CMD)"; \
+	echo "$$cmd" $(_PRINT_RULE); \
+	$$cmd
+
+################################################################
+# LCB compiler tests
+################################################################
+
+compiler-check: $(LC_COMPILE)
+	@rm -f $(LCC_LOG)
+	@export LC_COMPILE="$(LC_COMPILE)"; \
+	export LCC_VERBOSE="$(LCC_VERBOSE)"; \
+	cmd="$(LCC_CMD)"; \
 	echo "$$cmd" $(_PRINT_RULE); \
 	$$cmd
 

--- a/tests/_compilertestrunner.livecodescript
+++ b/tests/_compilertestrunner.livecodescript
@@ -1,0 +1,708 @@
+﻿script "CompilerTestRunner"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+-- FIXME provide this on the command line
+constant kLogFilename = "_compiler_test_suite.log"
+
+on startup
+   try
+      CompilerTestRunnerMain
+   catch tError
+      write "ERROR: " & tError & return to stderr
+   end try
+   quit 0
+end startup
+
+----------------------------------------------------------------
+-- Command-line processing
+----------------------------------------------------------------
+
+private function getCommandLineInfo
+   local tRawArg, tSelfCommand, tSelfScript, tInArgs, tArgs
+
+   put false into tInArgs
+
+   -- Treat everything up to & including the first
+   -- ".livecodescript" file as the command for running the test
+   -- runner, and everything after it as test runner arguments
+   put the commandName into tSelfCommand[1]
+   repeat for each element tRawArg in the commandArguments
+
+      if tInArgs then
+         put tRawArg into tArgs[1 + the number of elements in tArgs]
+      else
+         put tRawArg into tSelfCommand[1 + the number of elements in tSelfCommand]
+         if tRawArg ends with ".livecodescript" then
+            put tRawArg into tSelfScript
+            put true into tInArgs
+         end if
+      end if
+
+   end repeat
+
+   local tInfo
+   put tSelfCommand into tInfo["self-command"]
+   put tSelfScript into tInfo["self-script"]
+   put tArgs into tInfo["args"]
+
+   return tInfo
+end getCommandLineInfo
+
+----------------------------------------------------------------
+-- Top-level actions
+----------------------------------------------------------------
+
+command CompilerTestRunnerMain
+   local tInfo
+   put getCommandLineInfo() into tInfo
+   logInit
+
+   switch tInfo["args"][1]
+      case "run"
+         doRun tInfo
+         break
+      case "--help"
+      case "-h"
+      case "help"
+         doUsage 0
+         break
+      default
+         doUsage 1
+         break
+   end switch
+   quit 0
+end CompilerTestRunnerMain
+
+private command doRun pInfo
+   local tScript, tCommand, tAnalysis
+   put pInfo["args"][2] into tScript
+   put pInfo["args"][3] into tCommand
+
+   if $LC_COMPILE is empty then
+      throw "LC_COMPILE environment var must be set to lc-compile to use"
+   end if
+
+   runLoadLibrary pInfo
+
+   if tScript is empty then
+      runAllScripts pInfo
+   else if tCommand is empty then
+      runTestScript pInfo, tScript
+   else
+      runTestCommand pInfo, tScript, tCommand
+   end if
+
+   put the result into tAnalysis
+
+   -- Save the log to file.
+   -- We process to binary data ourselves to ensure encoding and
+   -- line endings are appropriate.
+   local tLogForWriting
+   put textEncode(tAnalysis["log"], "utf8") into tLogForWriting
+   if the platform is "win32" then
+      replace return with numToChar(13) & numToChar(10) in tLogForWriting
+   end if
+   put tLogForWriting into url ("binfile:" & kLogFilename)
+
+   if TesterTapGetWorstResult(tAnalysis) is "FAIL" then
+      quit 1
+   end if
+end doRun
+
+private command doUsage pStatus
+   write "Usage: _compilertestrunner.livecodescript run [SCRIPT [COMMAND]]" & return to stderr
+   quit pStatus
+end doUsage
+
+on ErrorDialog pExecutionError
+   write "ERROR:" && pExecutionError & return to stderr
+   quit 1
+end ErrorDialog
+
+----------------------------------------------------------------
+-- Support for running tests
+----------------------------------------------------------------
+
+-- Add the test runner library stack to the backscripts
+private command runLoadLibrary pInfo
+	-- Compute the filename of the library stack
+	local tFilename
+	put pInfo["self-script"] into tFilename
+
+	set the itemDelimiter to slash
+	put "_testerlib.livecodescript" into item -1 of tFilename
+
+	-- Load the library
+	local tStackname
+	put the name of stack tFilename into tStackname
+
+	send "revLoadLibrary" to stack tStackname
+end runLoadLibrary
+
+-- Run all the test scripts that can be found below the current
+-- directory
+private command runAllScripts pInfo
+   local tFile, tAnalysis
+   repeat for each element tFile in TesterGetTestFileNames("", "compilertest")
+      runCompilerTestScript pInfo, tFile
+      put TesterTapCombine(tAnalysis, the result) into tAnalysis
+   end repeat
+   runPrintSummary(tAnalysis)
+
+   return tAnalysis
+end runAllScripts
+
+-- Run the tests found in one specific script file
+private command runCompilerTestScript pInfo, pScriptFile
+   local tTest, tAnalysis
+
+   repeat for each element tTest in listCompilerTestsInFile(pScriptFile)
+      runCompilerTest pInfo, pScriptFile, tTest
+      put TesterTapCombine(tAnalysis, the result) into tAnalysis
+   end repeat
+   return tAnalysis
+end runCompilerTestScript
+
+private command runTestProcessOutput pScriptfile, pCommand, pOutput
+   -- Create test log
+   local tTestLog
+   put "###" && TesterGetPrettyTestName(pScriptFile, "compilertest") && pCommand \
+         & return & return into tTestLog
+   put pOutput & return after tTestLog
+
+   -- Analyse the results and print a summary line
+   local tTapResults
+   put TesterTapAnalyse(tTestLog) into tTapResults
+
+   logSummaryLine tTapResults, (TesterGetPrettyTestName(pScriptFile, "compilertest") & ":" && pCommand)
+
+   return tTapResults
+end runTestProcessOutput
+
+-- Run a specific named test command tCommand in a script file
+-- tScriptFile
+private command runCompilerTest pInfo, pScriptFile, pTest
+   local tCommandLine
+
+   -- First we need to process the specified test in script file
+
+   local tTestInfo
+   processCompilerTest pInfo, pScriptFile, pTest, tTestInfo
+
+   -- Next we emit the code for the test, then attempt to compile it
+   local tTestFile, tTestInterfaceFile
+   put tempName() into tTestFile
+   put tempName() into tTestInterfaceFile
+   put textEncode(tTestInfo["code"], "utf8") into url ("binfile:" & tTestFile)
+   reportCompilerTestDiag format("output test source file to '%s'", tTestFile)
+   reportCompilerTestDiag tTestInfo["code"]
+
+   -- Build the command line
+   local tCompilerCmdLine
+   put format("%s --interface %s %s", $LC_COMPILE, tTestInterfaceFile, tTestFile) into tCompilerCmdLine
+   reportCompilerTestDiag format("compile command is %s", tCompilerCmdLine)
+
+   -- Try to execute the compilation
+   local tCompilerOutput, tCompilerExitStatus
+   put shell(tCompilerCmdLine) into tCompilerOutput
+   put the result into tCompilerExitStatus
+   reportCompilerTestDiag "compile command output"
+
+   -- Remove the test file
+   delete file tTestFile
+   delete file tTestInterfaceFile
+
+   -- The output from the subprocesses will be native encoded utf-8.
+   put textDecode(tCompilerOutput, "utf8") into tCompilerOutput
+   reportCompilerTestDiag tCompilerOutput
+
+   -- Process the assertions and make sure each one matches up
+   repeat for each line tAssertion in tTestInfo["assertions"]
+      if doesCompilerOutputSatisfyAssertion(tCompilerOutput, tCompilerExitStatus, tAssertion, tTestInfo["positions"]) then
+         put "ok - " after tTestOutput
+      else
+         put "not ok - " after tTestOutput
+      end if
+      put compilerPrettyPrintAssertion(tAssertion, tTestInfo["positions"]) after tTestOutput
+      if tTestInfo["expectation"] is not "PASS" then
+         if tTestInfo["expectation"] is "FAIL" then
+            put " # TODO" after tTestOutput
+         else if tTestInfo["expectation"] is "SKIP" then
+            put " # SKIP" after tTestOutput
+         end if
+         if tTestInfo["reason"] is not empty then
+            put " " & tTestInfo["reason"] after tTestOutput
+         end if
+      end if
+      put return after tTestOutput
+   end repeat
+
+   runTestProcessOutput pScriptFile, pTest, tTestOutput
+   return the result
+end runCompilerTest
+
+-- Print out a table of statistics
+private command runPrintSummary pAnalysis
+   local tSummaryString, tTotal, tDecoration
+
+   put TesterTapGetTestCount(pAnalysis) into tTotal
+
+   -- Format basic summary information
+   if pAnalysis["xfail"] is 0 and pAnalysis["fail"] is 0 then
+      put "All" && tTotal && "tests passed" into tSummaryString
+
+   else if pAnalysis["fail"] is 0 then
+      put "All" && tTotal && "tests behaved as expected" into tSummaryString
+
+   else
+      put pAnalysis["fail"] && "OF" && tTotal && "TESTS FAILED" into tSummaryString
+   end if
+
+   put return after tSummaryString
+
+   -- Add extra summary info from expected failure & skip directives
+   if pAnalysis["xpass"] > 0 then
+      put tab & pAnalysis["xpass"] && "unexpected passes" & return after tSummaryString
+   end if
+   if pAnalysis["xfail"] > 0 then
+      put tab & pAnalysis["xfail"] && "expected failures" & return after tSummaryString
+   end if
+   if pAnalysis["skip"] > 0 then
+      put tab & pAnalysis["skip"] && "skipped" & return after tSummaryString
+   end if
+
+   put "================================================================" into tDecoration
+   put tDecoration & return before tSummaryString
+   put tDecoration & return after tSummaryString
+
+   write tSummaryString to stdout
+end runPrintSummary
+
+----------------------------------------------------------------
+-- Support for generating the compiler tests
+----------------------------------------------------------------
+
+-- Get a number-indexed array containing the names of all "test"
+-- blocks in pFilename.
+private function listCompilerTestsInFile pFilename
+   local tScript
+
+   -- Get the contents of the file
+   open file pFilename for "UTF-8" text read
+   if the result is not empty then
+      throw the result
+   end if
+
+   read from file pFilename until end
+   put it into tScript
+
+   close file pFilename
+
+   -- Scan the file for "on Test*" definitions
+   local tTestNames, tCount, tLine, tName
+
+   repeat for each line tLine in tScript
+      if word 1 of tLine is not "%TEST" then
+         next repeat
+      end if
+
+      put word 2 of tLine into tName
+
+      add 1 to tCount
+      put tName into tTestNames[tCount]
+   end repeat
+
+   return tTestNames
+end listCompilerTestsInFile
+
+private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerExitCode, pAssertion, pPositions
+   if item 1 of pAssertion is "success" then
+      return pCompilerExitCode is 0
+   end if
+
+   local tAssertionType, tAssertionPartialMsg, tAssertionPos
+   put item 1 of pAssertion into tAssertionType
+   put item 2 of pAssertion into tAssertionPartialMsg
+   put item 3 of pAssertion into tAssertionPos
+
+   -- Trim off any quotes around the partial message
+   if char 1 of tAssertionPartialMsg is quote then
+      delete char 1 of tAssertionPartialMsg
+      delete char -1 of tAssertionPartialMsg
+   end if
+
+   set the itemDelimiter to ":"
+   repeat for each line tOutputLine in pCompilerOutput
+      local tFile, tLine, tColumn, tType, tMessage
+
+      -- The format of each output line is:
+      --   <file>:<line>:<col>: (error|warning): <msg>
+      put item 1 of tOutputLine into tFile
+      put item 2 of tOutputLine into tLine
+      put item 3 of tOutputLine into tColumn
+      put word 1 of item 4 of tOutputLine into tType
+      put item 5 of tOutputLine into tMessage
+
+      -- If the assertion type doesn't match, continue
+      if tAssertionType is not tType then
+         next repeat
+      end if
+
+      -- If the assertion message is not within the message, continue
+      if tAssertionPartialMsg is not in tMessage then
+         next repeat
+      end if
+
+      -- If the position does not match, continue
+      if pPositions[tAssertionPos] is not tLine then
+         next repeat
+      end if
+
+      -- If we get here, we have a match so are successful!
+      return true
+   end repeat
+
+   -- We failed to find a suitable output line, so failure
+   return false
+end doesCompilerOutputSatisfyAssertion
+
+private function compilerPrettyPrintAssertion pAssertion, pPositions
+   if item 1 of pAssertion is "success" then
+      return "compile succeeded"
+   end if
+
+   if item 1 of pAssertion is among the items of "error,warning" then
+      return format("%s %s at line %d", item 1 of pAssertion, item 2 of pAssertion, pPositions[item 3 of pAssertion])
+   end if
+
+   return "UNKNOWN ASSERTION TYPE"
+end compilerPrettyPrintAssertion
+
+private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
+   -- Get the contents of the file
+   open file pScriptFile for "UTF-8" text read
+   if the result is not empty then
+      throw format("can't open file '%s'", pScriptFile)
+   end if
+
+   read from file pScriptFile until end
+   put it into tScript
+
+   close file pScriptFile
+
+   -- First extract the test block we are wanting to run
+   local tLine, tLineNumber, tTestLineNumber, tState
+   local tName, tCode, tExpectation, tExpectationReason, tAssertions, tPositions
+   put empty into tLine
+   put 0 into tLineNumber
+   put 0 into tTestLineNumber
+   put empty into tState
+   put empty into tName
+   put empty into tCode
+   put empty into tExpectation
+   put empty into tExpectationReason
+   put empty into tAssertions
+   put empty into tPositions
+   repeat for each line tLine in tScript
+      add 1 to tLineNumber
+
+      local tIsDirective
+      put false into tIsDirective
+      if tState is "code" then
+         if word 1 of tLine begins with "%" and \
+               not (word 1 of tLine begins with "%{") then
+               put true into tIsDirective
+         end if
+      else
+         if word 1 of tLine begins with "%" then
+            put true into tIsDirective
+         end if
+      end if
+
+      if tIsDirective then
+         local tToken
+         put word 1 of tLine into tToken
+
+         if tToken is "%%" then
+            -- We don't allow comment directives inside code blocks
+            if tState is "code" then
+               reportCompilerTestError pScriptFile, tLineNumber, "comment directives not allowed in code block"
+            end if
+            -- Ignore comment lines
+            next repeat
+         else if tToken is "%TEST" then
+            -- If we are already in a test block, it is an error
+            if tState is not empty then
+               reportCompilerTestError pScriptFile, tLineNumber, "%TEST directive not allowed inside test block"
+            end if
+
+            -- We've started a new test clause, so record the name and move to
+            -- code state.
+            reportCompilerTestDiag format("found test '%s' at line %d", word 2 of tLine, tLineNumber)
+            put word 2 of tLine into tName
+            put tLineNumber + 1 into tTestLineNumber
+            put empty into tCode
+            put empty into tExpectation
+            put empty into tAssertions
+            put "code" into tState
+         else if tToken is "%EXPECT" then
+            -- We only allow %EXPECT directives after code blocks
+            if tState is not "code" then
+               reportCompilerTestError pScriptFile, tLineNumber, "%EXPECT directive only allowed after code block"
+            end if
+
+            -- If the expectation isn't one of PASS, FAIL, XFAIL, SKIP then it
+            -- is an error
+            if word 2 of tLine is not among the items of "PASS,FAIL,SKIP" then
+               reportCompilerTestError pScriptFile, tLineNumber, format("invalid expectation '%s'", word 2 of tLine)
+            end if
+
+            if word 3 of tLine contains "#" then
+               reportCompilerTestError pScriptFile, tLineNumber, format("expectation reason cannot contain '#'")
+            end if
+
+            -- Record the expectation, and move to assertions state.
+            put word 2 of tLine into tExpectation
+            put word 3 of tLine into tExpectationReason
+            if char 1 of tExpectationReason is quote then
+               delete char 1 of tExpectationReason
+               delete char -1 of tExpectationReason
+            end if
+            put "assertions" into tState
+         else if tToken is among the items of "%SUCCESS,%WARNING,%ERROR" then
+            if tState is not "assertions" then
+               reportCompilerTestError pScriptFile, tLineNumber, "assertion directive outside of assertion block"
+            end if
+
+            if tToken is "%SUCCESS" then
+               if the number of words in tLine is not 1 then
+                  reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %SUCCESS"
+               end if
+
+               reportCompilerTestDiag format("found assert success at line %d", tLineNumber)
+               put "success" & return after tAssertions
+            else if tToken is "%WARNING" then
+               if (the number of words in tLine is 4 and \
+                        word 3 of tLine is "AT") then
+
+                  -- Check that the position exists
+                  if tPositions[word 4 of tLine] is empty then
+                     reportCompilerTestError pScriptFile, tLineNumber, format("unknown position '%s'", word 4 of tLine)
+                  end if
+
+                  reportCompilerTestDiag format("found assert warning %s for position %s (with '%s') at line %d", word 2 of tLine, word 4 of tLine, word 6 of tLine, tLineNumber)
+
+                  put "warning", word 2 of tLine, word 4 of tLine & return after tAssertions
+               else
+                  reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %WARNING <id> AT <position>"
+               end if
+            else if tToken is "%ERROR" then
+               if (the number of words in tLine is 4 and \
+                        word 3 of tLine is "AT") then
+
+                  -- Check that the position exists
+                  if tPositions[word 4 of tLine] is empty then
+                     reportCompilerTestError pScriptFile, tLineNumber, format("unknown position '%s'", word 4 of tLine)
+                  end if
+
+                  reportCompilerTestDiag format("found assert error %s for position %s at line %d", word 2 of tLine, word 4 of tLine, word 6 of tLine, tLineNumber)
+
+                  put "error", word 2 of tLine, word 4 of tLine & return after tAssertions
+               else
+                  reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %ERROR <id> AT <position>"
+               end if
+            end if
+         else if tToken is "%ENDTEST" then
+            -- If we aren't in assertions state then it isn't a complete test
+            -- clause
+            if tState is not "assertions" then
+               reportCompilerTestError pScriptFile, tLineNumber, "premature %ENDTEST directive"
+            end if
+
+            if tAssertions is empty then
+               reportCompilerTestError pScriptFile, tLineNumber, "no assertions specified"
+            end if
+
+            if tAssertions contains "%SUCCESS" and \
+               tAssertions contains "%ERROR" then
+               reportCompilerTestError pScriptFile, tLineNumber, "both %SUCCESS and %ERROR not allowed in the same set of assertions"
+            end if
+
+            -- If this is the test we are looking for, we are done
+            if tName is pTest then
+               exit repeat
+            end if
+
+            -- Move back to initial state
+            put empty into tName
+            put empty into tState
+         else
+            -- We've encountered an illegal directive
+            reportCompilerTestError pScriptFile, tLineNumber, format("unknown directive '%s'", tToken)
+         end if
+      else if tState is empty then
+         -- We only allow empty lines outside of test blocks
+         if word 1 to -1 of tLine is not empty then
+            reportCompilerTestError pScriptFile, tLineNumber, "junk outside of test clause"
+         end if
+      else if tState is "code" then
+         -- If we are in a code block, then accumulate the code line after
+         -- processing for position directives %{...}.
+
+         -- We loop through the line, searching for %{...}, and accumulating the
+         -- code in between as we go.
+         local tPositionSkip
+         put 0 into tPositionSkip
+         repeat forever
+            local tPositionOffset
+            put offset("%{", tLine, tPositionSkip) into tPositionOffset
+            if tPositionOffset is 0 then
+               put char tPositionSkip to -1 of tLine after tCode
+               exit repeat
+            end if
+            add tPositionSkip to tPositionOffset
+
+            put char tPositionSkip to tPositionOffset - 1 of tLine after tCode
+
+            -- Look for the end brace, it is an error if it is not there
+            local tPositionEndOffset
+            put offset("}", tLine, tPositionOffset) into tPositionEndOffset
+            if tPositionEndOffset is 0 then
+               reportCompilerTestError pScriptFile, tLineNumber, "unterminated named position"
+            end if
+            add tPositionOffset to tPositionEndOffset
+
+            -- Check that the name is not empty
+            local tPositionName
+            put char tPositionOffset + 2 to tPositionEndOffset - 1 of tLine into tPositionName
+            if tPositionName is empty then
+               reportCompilerTestError pScriptFile, tLineNumber, "empty named position"
+            end if
+
+            -- Check that the position hasn't already been defined
+            if tPositions[tPositionName] is not empty then
+               reportCompilerTestError pScriptFile, tLineNumber, "named position already defined"
+            end if
+
+            reportCompilerTestDiag format("found position '%s' at line %d", tPositionName, tLineNumber)
+            put tLineNumber - tTestLineNumber + 1 into tPositions[tPositionName]
+
+            put tPositionEndOffset + 1 into tPositionSkip
+         end repeat
+
+         -- Add the newline to the code
+         put return after tCode
+      else if tState is "assertions" then
+         -- We only allow directives inside assertion blocks
+         if word 1 to -1 of tLine is not empty then
+            reportCompilerTestError pScriptFile, tLineNumber, "junk inside assertion clause"
+         end if
+      end if
+   end repeat
+
+   if tName is empty then
+      reportCompilerTestError pScriptFile, tLineNumber, format("test '%s' not found in file", pTest)
+   end if
+
+   -- We now have the code for the test, the expectation and a list of
+   -- assertions.
+
+   put tName into rCompilerTest["name"]
+   put tCode into rCompilerTest["code"]
+   put tPositions into rCompilerTest["positions"]
+   put tExpectation into rCompilerTest["expectation"]
+   put tExpectation into rCompilerTest["reason"]
+   put tAssertions into rCompilerTest["assertions"]
+end processCompilerTest
+
+private command reportCompilerTestError pFile, pLine, pMessage
+   throw format("'%s', line %d: %s", pFile, pLine, pMessage)
+end reportCompilerTestError
+
+private command reportCompilerTestDiag pMessage
+   if $LCC_VERBOSE is not empty then
+      repeat for each line tLine in pMessage
+         write "DIAG:" && tLine & return to stderr
+      end repeat
+   end if
+end reportCompilerTestDiag
+
+----------------------------------------------------------------
+-- Logging helpers
+----------------------------------------------------------------
+
+local sLogInfo
+
+-- Figure out what the highlighting escape codes are for the terminal
+--
+-- FIXME this really doesn't work properly if LiveCode's stdout
+-- *isn't* a TTY.
+private command logInit
+   -- We can only do colour on Linux and OS X
+   if the platform is not "Linux" and the platform is not "MacOS" then
+      put false into sLogInfo
+   end if
+
+   -- Check if colouring is possible
+   local tTput
+   put shell("tput colors") into tTput
+   if the result is not empty or tTput <= 8 then
+      put false into sLogInfo
+   end if
+
+   -- Get colours
+   put shell("tput sgr0") into sLogInfo["normal"]
+   put shell("tput bold") into sLogInfo["bold"]
+   put shell("tput setaf 1") into sLogInfo["red"]
+   put shell("tput setaf 2") into sLogInfo["green"]
+   put shell("tput setaf 3") into sLogInfo["yellow"]
+   put shell("tput setaf 6") into sLogInfo["cyan"]
+end logInit
+
+private function logHighlight pString
+  if pString is "fail" then
+     return sLogInfo["red"] & sLogInfo["bold"] & pString & sLogInfo["normal"]
+  else if pString is "xfail" or pString is "xpass" then
+     return sLogInfo["yellow"] & pString & sLogInfo["normal"]
+  else if pString is "pass" then
+     return sLogInfo["green"] & pString & sLogInfo["normal"]
+  else if pString is "skip" then
+     return sLogInfo["cyan"] & pString & sLogInfo["normal"]
+  else
+     return pString
+  end if
+end logHighlight
+
+private command logSummaryLine pTapResults, pTestName
+   local tTotal, tPassed, tWorst, tMessage
+
+   put pTapResults["xpass"] + pTapResults["pass"] + pTapResults["skip"] into tPassed
+   put TesterTapGetTestCount(pTapResults) into tTotal
+
+   put TesterTapGetWorstResult(pTapResults) into tWorst
+   put logHighLight(the toUpper of tWorst) into tMessage
+   put ":" after tMessage
+   if the number of chars in tWorst < 5 then
+      put space after tMessage
+   end if
+
+   put space & pTestName after tMessage
+
+   put space & "[" & tPassed & "/" & tTotal & "]" after tMessage
+   write tMessage & return to stdout
+end logSummaryLine

--- a/tests/_testerlib.livecodescript
+++ b/tests/_testerlib.livecodescript
@@ -31,7 +31,7 @@ end revLoadLibrary
 
 -- Get all livecode script files beneath the CWD, apart from
 -- filenames starting with "." or "_"
-function TesterGetTestFileNames pBaseFolder
+function TesterGetTestFileNames pBaseFolder, pExtension
    local tFiles, tCount
 
    put empty into tFiles
@@ -41,13 +41,17 @@ function TesterGetTestFileNames pBaseFolder
       put the defaultfolder into pBaseFolder
    end if
 
-   TesterGetTestFileNames_Recursive pBaseFolder, empty, tFiles, tCount
+   if pExtension is empty then
+      put "livecodescript" into pExtension
+   end if
+
+   TesterGetActualFileNames_Recursive pBaseFolder, empty, pExtension, tFiles, tCount
 
    return tFiles
 end TesterGetTestFileNames
 
 -- Helper command used by runGetTestFileNames
-private command TesterGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCount
+private command TesterGetActualFileNames_Recursive pPath, pRelPath, pExtension, @xFiles, @xCount
    -- Save the CWD
    local tSaveFolder
    put the defaultfolder into tSaveFolder
@@ -56,7 +60,7 @@ private command TesterGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCou
    -- Process files in the current directory
    local tFile
    repeat for each line tFile in the files
-      if tFile ends with ".livecodescript" and \
+      if tFile ends with ("." & pExtension) and \
             not (tFile begins with "." or tFile begins with "_") then
 
          if pRelPath is not empty then
@@ -81,12 +85,12 @@ private command TesterGetTestFileNames_Recursive pPath, pRelPath, @xFiles, @xCou
          put pRelPath & slash before tFolder
       end if
 
-      TesterGetTestFileNames_Recursive tFolderPath, tFolder, xFiles, xCount
+      TesterGetActualFileNames_Recursive tFolderPath, tFolder, pExtension, xFiles, xCount
    end repeat
 
    -- Restore the CWD
    set the defaultfolder to tSaveFolder
-end TesterGetTestFileNames_Recursive
+end TesterGetActualFileNames_Recursive
 
 -- Get a number-indexed array contain the names of all "test"
 -- commands in pFilename.
@@ -131,8 +135,12 @@ function TesterParseTestCommandNames pFilename
 end TesterParseTestCommandNames
 
 -- Prettify a test name by removing a ".livecodescript" suffix
-function TesterGetPrettyTestName pFilename
-   if pFilename ends with ".livecodescript" then
+function TesterGetPrettyTestName pFilename, pExtension
+   if pExtension is empty then
+      put "livecodescript" into pExtension
+   end if
+
+   if pFilename ends with ("." & pExtension) then
       set the itemDelimiter to "."
       return item 1 to -2 of pFileName
    end if

--- a/tests/lcb/compiler/frontend/unsafe.compilertest
+++ b/tests/lcb/compiler/frontend/unsafe.compilertest
@@ -22,7 +22,7 @@ handler SafeHandler()
 end handler
 end module
 %EXPECT PASS
-%ERROR BytecodeNotAllowedInSafeContext AT BEFORE_BYTECODE
+%ERROR "Bytecode blocks can only be present in unsafe context" AT BEFORE_BYTECODE
 %ENDTEST
 
 %TEST BytecodeInUnsafeBlock
@@ -91,15 +91,17 @@ end module
 
 %TEST UnsafeHandlerCallInSafeContext
 module compiler_test
-unsafe handler OtherUnsafeHandler(in pArg)
+unsafe handler CmdUnsafeHandler(in pArg)
+end handler
+unsafe handler FuncUnsafeHandler(in pArg)
 end handler
 handler SafeHandler()
-   %{BEFORE_CALL}OtherUnsafeHandler(%{BEFORE_EVAL}OtherUnsafeHandler(nothing))
+   %{BEFORE_CALL}CmdUnsafeHandler(%{BEFORE_EVAL}FuncUnsafeHandler(nothing))
 end handler
 end module
 %EXPECT PASS
-%ERROR UnsafeHandlerCallNotAllowedInSafeContext AT BEFORE_CALL WITH OtherUnsafeHandler
-%ERROR UnsafeHandlerCallNotAllowedInSafeContext AT BEFORE_EVAL WITH OtherUnsafeHandler
+%ERROR "Unsafe handler 'CmdUnsafeHandler' can only be called in unsafe context" AT BEFORE_CALL
+%ERROR "Unsafe handler 'CmdUnsafeHandler' can only be called in unsafe context" AT BEFORE_EVAL
 %ENDTEST
 
 %TEST UnsafeHandlerCallInUnsafeHandler

--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -14,16 +14,17 @@ lc-compile(1) -- compile LiveCode Builder source code
 **lc-compile** compiles the named input _LCBFILE_ to bytecode, saving the
 resulting bytecode to _OUTFILE_.
 
-If one or more `--modulepath` options are provided, **lc-compile** may
-additionally generate an interface (`.lci`) file in the first `--modulepath`
-specified.
+If one or more `--modulepath` options are provided, and the `--interface` option
+is not specified, then **lc-compile** may additionally generate an interface
+(`.lci`) file in the first `--modulepath` specified.
 
 ## OPTIONS
 
 * --modulepath _PATH_:
   Search for interface (`.lci`) files in _PATH_, which should be a directory.
-  The first `--modulepath` option specified determines the directory in which
-  an interface file may be created for _LCBFILE_.
+  If the `--interface` option is not specified, then the first `--modulepath`
+  option specified determines the directory in which an interface file may be
+  created for _LCBFILE_.
 
 * --output _OUTFILE_:
   Generate LiveCode bytecode in _OUTFILE_, which should be the path to a `.lcm`
@@ -42,6 +43,9 @@ specified.
 
 * --manifest _MANIFEST_:
   Generate a module manifest in _MANIFEST_.  This is used by the LiveCode IDE.
+
+* --interface _INTERFACE_:
+  Generate the module interface file in _INTERFACE_.
 
 * -Werror:
   Turn all warnings into errors.

--- a/toolchain/lc-compile/src/lc-compile-sources.gypi
+++ b/toolchain/lc-compile/src/lc-compile-sources.gypi
@@ -50,10 +50,13 @@
 		'lc-compile_source_files':
 		[
 			'literal.c',
+            'literal.h',
 			'main.c',
 			'operator.c',
 			'position.c',
+            'position.h',
 			'report.c',
+            'report.h',
 			'set.c',
 			'syntax-gen.c',
 			'emit.cpp',

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -102,24 +102,26 @@ usage(int status)
 "Compile a LiveCode Builder source file.\n"
 "\n"
 "Options:\n"
-"      --modulepath PATH    Search PATH for module interface files.\n"
-"      --output OUTFILE     Filename for bytecode output.\n"
-"      --outputc OUTFILE    Filename for C source code output.\n"
-"      --deps make          Generate lci file dependencies in make format for\n"
-"                           the input source files.\n"
-"      --deps order         Generate the order the input source files should be\n"
-"                           compiled in.\n"
-"      --deps changed-order Generate the order the input source files should be\n"
-"                           compiled in, but only if they need recompiling.\n"
-"      --manifest MANIFEST  Filename for generated manifest.\n"
-"      -Werror              Turn all warnings into errors.\n"
-"  -v, --verbose            Output extra debugging information.\n"
-"  -h, --help               Print this message.\n"
-"  --                       Treat all remaining arguments as filenames.\n"
+"      --modulepath PATH      Search PATH for module interface files.\n"
+"      --output OUTFILE       Filename for bytecode output.\n"
+"      --outputc OUTFILE      Filename for C source code output.\n"
+"      --deps make            Generate lci file dependencies in make format for\n"
+"                             the input source files.\n"
+"      --deps order           Generate the order the input source files should be\n"
+"                             compiled in.\n"
+"      --deps changed-order   Generate the order the input source files should be\n"
+"                             compiled in, but only if they need recompiling.\n"
+"      --manifest MANIFEST    Filename for generated manifest.\n"
+"      --interface INTERFACE  Filename for generated interface.\n"
+"      -Werror                Turn all warnings into errors.\n"
+"  -v, --verbose              Output extra debugging information.\n"
+"  -h, --help                 Print this message.\n"
+"  --                         Treat all remaining arguments as filenames.\n"
 "\n"
 "More than one `--modulepath' option may be specified.  The PATHs are\n"
-"searched in the order they appear.  An interface file may be generated in\n"
-"the first PATH specified.\n"
+"searched in the order they appear.  If the `--interface' option is not\n"
+"specified, then an interface file may be generated in the first PATH\n"
+"specified.\n"
 "\n"
 "Report bugs to <http://quality.livecode.com/>\n"
             );
@@ -187,6 +189,11 @@ static void full_main(int argc, char *argv[])
             if (0 == strcmp(opt, "--manifest") && optarg)
             {
                 SetManifestOutputFile(argv[++argi]);
+                continue;
+            }
+            if (0 == strcmp(opt, "--interface") && optarg)
+            {
+                SetInterfaceOutputFile(argv[++argi]);
                 continue;
             }
             /* FIXME This should be expanded to support "-W error",

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -111,6 +111,7 @@ void yyGetPos(long *r_result)
 
 static const char *ImportedModuleDir[8];
 static int ImportedModuleDirCount = 0;
+static const char *s_interface_output_file = NULL;
 
 void AddImportedModuleDir(const char *p_dir)
 {
@@ -194,13 +195,21 @@ OpenImportedModuleFile (const char *p_name,
     char t_path[MAXPATHLEN];
     FILE *t_file;
 
-    if (ImportedModuleDirCount == 0)
+    if (ImportedModuleDirCount == 0 &&
+        s_interface_output_file == NULL)
         return NULL;
 
-    // Use the first modulepath to write the interface file into.
-    /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
-
-	if (NULL != r_filename)
+    if (NULL == s_interface_output_file)
+    {
+        // Use the first modulepath to write the interface file into.
+        /* OVERFLOW */ sprintf(t_path, "%s/%s.lci", ImportedModuleDir[0], p_name);
+    }
+    else
+    {
+        /* OVERFLOW */ sprintf(t_path, "%s", s_interface_output_file);
+    }
+    
+    if (NULL != r_filename)
 	{
 		*r_filename = strdup(t_path); /* FIXME should be strndup */
 	}
@@ -375,6 +384,11 @@ void SetOutputCodeFile(const char *p_output)
 void SetManifestOutputFile(const char *p_output)
 {
     s_manifest_output_file = p_output;
+}
+
+void SetInterfaceOutputFile(const char *p_output)
+{
+    s_interface_output_file = p_output;
 }
 
 void SetTemplateFile(const char *p_output)

--- a/toolchain/lc-compile/src/position.h
+++ b/toolchain/lc-compile/src/position.h
@@ -67,6 +67,7 @@ void SetOutputBytecodeFile(const char *filename);
 void SetOutputCodeFile(const char *filename);
 void SetOutputGrammarFile(const char *filename);
 void SetManifestOutputFile(const char *filename);
+void SetInterfaceOutputFile(const char *filename);
 void SetTemplateFile(const char *filename);
 void GetOutputFile(const char **r_filename);
     

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -27,7 +27,7 @@ extern int IsDependencyCompile(void);
 ////////////////////////////////////////////////////////////////////////////////
 
 static int s_error_count;
-int s_verbose_level = 1;
+int s_verbose_level;
 int s_is_werror_enabled;
 
 void InitializeReports(void)


### PR DESCRIPTION
This patch adds a new test runner for running LCB compiler tests.

The compiler tests are run by using 'make compiler-check' in the
tests folder.

The compiler test runner recursively searches for tests in the
tests folder, processing any file with a 'compilertest' extension.

Compiler tests are text files containing a number of test clauses.
Each test clause is named, and consists of a fragment of LCB code
to be parsed to the compiler, along with an expectation and list
of errors and/or warnings to check for.

The compiler test format uses lines beginning with %% to indicate
comments.

A test clause has the following structure:

```
%TEST <name>
... LCB code ...
%EXPECT ( PASS | FAIL | SKIP ) <reason>
... assertions ...
%ENDTEST
```

Here the assertion clauses can be one of the following:

```
%SUCCESS
%ERROR <error-id> AT <pos-id>
%WARNING <warning-id> AT <pos-id>
```

In the body of LCB code for each test clause, %{pos-id} can be used
to indicate a named position - these can be used in error and warning
assertions.

When running a test clause, the test runner will first extract the
LCB code, removing any named positions from it. It will then attempt
to compile the code. The output of the compiler is checked against
the list of expected errors and warnings, or success and each test
will succeed or fail as a result, in line with the expectation.
