### PR TITLE
[[ GPS ]] Improve GPS support on Android and iOS

### DIFF
--- a/engine/src/exec-sensor.cpp
+++ b/engine/src/exec-sensor.cpp
@@ -123,70 +123,109 @@ void MCSensorGetSensorAvailable(MCExecContext& ctxt, intenum_t p_sensor, bool& r
     MCSystemGetSensorAvailable((MCSensorType)p_sensor, r_available);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+static bool __MCSensorGetDetailedLocationArray(const MCSensorLocationReading& p_reading, MCArrayRef& r_detailed_location)
+{
+    MCAutoArrayRef t_location_array;
+    /* UNCHECKED */ MCArrayCreateMutable(&t_location_array);
+    
+    MCAutoNumberRef t_latitude;
+    MCNewAutoNameRef t_latitude_name;
+    /* UNCHECKED */ MCNumberCreateWithReal(p_reading.latitude, &t_latitude);
+    /* UNCHECKED */ MCNameCreateWithCString("latitude", &t_latitude_name);
+    /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_latitude_name, *t_latitude);
+    
+    MCAutoNumberRef t_longitude;
+    MCNewAutoNameRef t_longitude_name;
+    /* UNCHECKED */ MCNumberCreateWithReal(p_reading.longitude, &t_longitude);
+    /* UNCHECKED */ MCNameCreateWithCString("longitude", &t_longitude_name);
+    /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_longitude_name, *t_longitude);
+    
+    MCAutoNumberRef t_altitude;
+    MCNewAutoNameRef t_altitude_name;
+    /* UNCHECKED */ MCNumberCreateWithReal(p_reading.altitude, &t_altitude);
+    /* UNCHECKED */ MCNameCreateWithCString("altitude", &t_altitude_name);
+    /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_altitude_name, *t_altitude);
+    
+    // MM-2013-02-21: Add speed and course to detailed location readings.
+    if (p_reading.speed >= 0.0f)
+    {
+        MCAutoNumberRef t_speed;
+        MCNewAutoNameRef t_speed_name;
+        /* UNCHECKED */ MCNumberCreateWithReal(p_reading.speed, &t_speed);
+        /* UNCHECKED */ MCNameCreateWithCString("speed", &t_speed_name);
+        /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_speed_name, *t_speed);
+    }
+    if (p_reading.course >= 0.0f)
+    {
+        MCAutoNumberRef t_course;
+        MCNewAutoNameRef t_course_name;
+        /* UNCHECKED */ MCNumberCreateWithReal(p_reading.course, &t_course);
+        /* UNCHECKED */ MCNameCreateWithCString("course", &t_course_name);
+        /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_course_name, *t_course);
+    }
+    
+    MCAutoNumberRef t_timestamp;
+    MCNewAutoNameRef t_timestamp_name;
+    /* UNCHECKED */ MCNumberCreateWithReal(p_reading.timestamp, &t_timestamp);
+    /* UNCHECKED */ MCNameCreateWithCString("timestamp", &t_timestamp_name);
+    /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_timestamp_name, *t_timestamp);
+    
+    MCAutoNumberRef t_horizontal_accuracy;
+    MCNewAutoNameRef t_horizontal_accuracy_name;
+    /* UNCHECKED */ MCNumberCreateWithReal(p_reading.horizontal_accuracy, &t_horizontal_accuracy);
+    /* UNCHECKED */ MCNameCreateWithCString("horizontal accuracy", &t_horizontal_accuracy_name);
+    /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_horizontal_accuracy_name, *t_horizontal_accuracy);
+    
+    MCAutoNumberRef t_vertical_accuracy;
+    MCNewAutoNameRef t_vertical_accuracy_name;
+    /* UNCHECKED */ MCNumberCreateWithReal(p_reading.vertical_accuracy, &t_vertical_accuracy);
+    /* UNCHECKED */ MCNameCreateWithCString("vertical accuracy", &t_vertical_accuracy_name);
+    /* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_vertical_accuracy_name, *t_vertical_accuracy);
+    
+    r_detailed_location = t_location_array.Take();
+    
+    return true;
+}
+
 void MCSensorGetDetailedLocationOfDevice(MCExecContext& ctxt, MCArrayRef &r_detailed_location)
 {
 	MCSensorLocationReading t_reading;
     if (MCSystemGetLocationReading(t_reading, true))
     {
-        MCAutoArrayRef t_location_array;
-		/* UNCHECKED */ MCArrayCreateMutable(&t_location_array);
-
-		MCAutoNumberRef t_latitude;
-		MCNewAutoNameRef t_latitude_name;
-		/* UNCHECKED */ MCNumberCreateWithReal(t_reading.latitude, &t_latitude);
-		/* UNCHECKED */ MCNameCreateWithCString("latitude", &t_latitude_name);
-		/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_latitude_name, *t_latitude);
-              
-		MCAutoNumberRef t_longitude;
-		MCNewAutoNameRef t_longitude_name;
-		/* UNCHECKED */ MCNumberCreateWithReal(t_reading.longitude, &t_longitude);
-		/* UNCHECKED */ MCNameCreateWithCString("longitude", &t_longitude_name);
-		/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_longitude_name, *t_longitude);
-
-		MCAutoNumberRef t_altitude;
-		MCNewAutoNameRef t_altitude_name;
-		/* UNCHECKED */ MCNumberCreateWithReal(t_reading.altitude, &t_altitude);
-		/* UNCHECKED */ MCNameCreateWithCString("altitude", &t_altitude_name);
-		/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_altitude_name, *t_altitude);
-        
-        // MM-2013-02-21: Add speed and course to detailed location readings.
-        if (t_reading.speed >= 0.0f)
-        {
-			MCAutoNumberRef t_speed;
-			MCNewAutoNameRef t_speed_name;
-			/* UNCHECKED */ MCNumberCreateWithReal(t_reading.speed, &t_speed);
-			/* UNCHECKED */ MCNameCreateWithCString("speed", &t_speed_name);
-			/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_speed_name, *t_speed);
-        }        
-        if (t_reading.course >= 0.0f)
-        {
-			MCAutoNumberRef t_course;
-			MCNewAutoNameRef t_course_name;
-			/* UNCHECKED */ MCNumberCreateWithReal(t_reading.course, &t_course);
-			/* UNCHECKED */ MCNameCreateWithCString("course", &t_course_name);
-			/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_course_name, *t_course);
-        }
-        
-		MCAutoNumberRef t_timestamp;
-		MCNewAutoNameRef t_timestamp_name;
-		/* UNCHECKED */ MCNumberCreateWithReal(t_reading.timestamp, &t_timestamp);
-		/* UNCHECKED */ MCNameCreateWithCString("timestamp", &t_timestamp_name);
-		/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_timestamp_name, *t_timestamp);
-        
-		MCAutoNumberRef t_horizontal_accuracy;
-		MCNewAutoNameRef t_horizontal_accuracy_name;
-		/* UNCHECKED */ MCNumberCreateWithReal(t_reading.horizontal_accuracy, &t_horizontal_accuracy);
-		/* UNCHECKED */ MCNameCreateWithCString("horizontal accuracy", &t_horizontal_accuracy_name);
-		/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_horizontal_accuracy_name, *t_horizontal_accuracy);
-        
-		MCAutoNumberRef t_vertical_accuracy;
-		MCNewAutoNameRef t_vertical_accuracy_name;
-		/* UNCHECKED */ MCNumberCreateWithReal(t_reading.vertical_accuracy, &t_vertical_accuracy);
-		/* UNCHECKED */ MCNameCreateWithCString("vertical accuracy", &t_vertical_accuracy_name);
-		/* UNCHECKED */ MCArrayStoreValue(*t_location_array, false, *t_vertical_accuracy_name, *t_vertical_accuracy);
-        
-        r_detailed_location = MCValueRetain(*t_location_array);
+        __MCSensorGetDetailedLocationArray(t_reading, r_detailed_location);
     }
+}
+
+void MCSensorGetLocationHistoryOfDevice(MCExecContext& ctxt, MCArrayRef& r_location_history)
+{
+    MCAutoArrayRef t_history;
+    if (!MCArrayCreateMutable(&t_history))
+        return;
+    
+    uindex_t t_index;
+    t_index = 1;
+    for(;;)
+    {
+        MCSensorLocationReading t_reading;
+        if (!MCSensorPopLocationSample(t_reading))
+            break;
+        
+        MCAutoArrayRef t_sample;
+        if (!__MCSensorGetDetailedLocationArray(t_reading,
+                                                &t_sample))
+            return;
+        
+        if (!MCArrayStoreValueAtIndex(*t_history,
+                                      t_index,
+                                      *t_sample))
+            return;
+        
+        t_index += 1;
+    }
+    
+    r_location_history = t_history.Take();
 }
 
 void MCSensorGetLocationOfDevice(MCExecContext& ctxt, MCStringRef &r_location)
@@ -228,6 +267,8 @@ void MCSensorGetLocationOfDevice(MCExecContext& ctxt, MCStringRef &r_location)
             ctxt.Throw();
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////
 
 void MCSensorGetDetailedHeadingOfDevice(MCExecContext& ctxt, MCArrayRef &r_detailed_heading)
 {

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -5311,14 +5311,20 @@ extern MCExecMethodInfo *kMCSensorSetLocationAuthorizationStatusMethodInfo;
 void MCSensorExecStartTrackingSensor(MCExecContext& ctxt, intenum_t p_sensor, bool p_loosely);
 void MCSensorExecStopTrackingSensor(MCExecContext& ctxt, intenum_t p_sensor);
 void MCSensorGetSensorAvailable(MCExecContext& ctxt, intenum_t p_sensor, bool& r_available);
+
 void MCSensorGetDetailedLocationOfDevice(MCExecContext& ctxt, MCArrayRef &r_detailed_location);
 void MCSensorGetLocationOfDevice(MCExecContext& ctxt, MCStringRef &r_location);
+void MCSensorGetLocationHistoryOfDevice(MCExecContext& ctxt, MCArrayRef& r_location_history);
+
 void MCSensorGetDetailedHeadingOfDevice(MCExecContext& ctxt, MCArrayRef &r_detailed_heading);
 void MCSensorGetHeadingOfDevice(MCExecContext& ctxt, MCStringRef &r_heading);
+
 void MCSensorGetDetailedAccelerationOfDevice(MCExecContext& ctxt, MCArrayRef &r_detailed_acceleration);
 void MCSensorGetAccelerationOfDevice(MCExecContext& ctxt, MCStringRef &r_acceleration);
+
 void MCSensorGetDetailedRotationRateOfDevice(MCExecContext& ctxt, MCArrayRef &r_detailed_rotation_rate);
 void MCSensorGetRotationRateOfDevice(MCExecContext& ctxt, MCStringRef &r_rotation_rate);
+
 void MCSensorSetLocationCalibrationTimeout(MCExecContext& ctxt, int32_t p_timeout);
 void MCSensorGetLocationCalibrationTimeout(MCExecContext& ctxt, int32_t& r_timeout);
 // SN-2014-10-15: [[ Merge-6.7.0-rc-3 ]]

--- a/engine/src/mblandroidsensor.cpp
+++ b/engine/src/mblandroidsensor.cpp
@@ -266,6 +266,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doLocationChanged(JNIEnv *
     s_location_reading->speed = speed;
     s_location_reading->course = course;
     
+    MCSensorAddLocationSample(*s_location_reading);
     MCSensorPostChangeMessage(kMCSensorTypeLocation);
 }
 

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -1291,6 +1291,39 @@ Exec_stat MCHandleCanTrackHeading(void *p_context, MCParameter *p_parameters)
 	return ES_ERROR;
 }
 
+Exec_stat MCHandleSetLocationHistoryLimit(void *p_context, MCParameter *p_parameters)
+{
+    MCExecContext ctxt(nil, nil, nil);
+    
+    if (p_parameters == nil)
+        return ES_NORMAL;
+    
+    MCAutoValueRef t_value;
+    p_parameters->eval(ctxt, &t_value);
+        
+    uinteger_t t_limit = 0;
+    /* UNCHECKED */ ctxt . ConvertToUnsignedInteger(*t_value, t_limit);
+    
+    MCSensorSetLocationSampleLimit(t_limit);
+    return ES_NORMAL;
+}
+
+Exec_stat MCHandleGetLocationHistoryLimit(void *p_context, MCParameter *p_parameters)
+{
+    MCExecContext ctxt(nil, nil, nil);
+    ctxt.SetTheResultToNumber(MCSensorGetLocationSampleLimit());
+    return ES_NORMAL;
+}
+
+Exec_stat MCHandleGetLocationHistory(void *p_context, MCParameter *p_parameters)
+{
+    MCExecContext ctxt(nil, nil, nil);
+    MCAutoArrayRef t_array;
+    MCSensorGetLocationHistoryOfDevice(ctxt, &t_array);
+    ctxt.SetTheResultToValue(*t_array);
+    return ES_NORMAL;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCContactParseParams(MCParameter *p_params, MCArrayRef &r_contact, char *&r_title, char *&r_message, char *&r_alternate_name)
@@ -4239,6 +4272,10 @@ static MCPlatformMessageSpec s_platform_messages[] =
 	/* DEPRECATED */ {false, "iphoneDisableAccelerometer", MCHandleAccelerometerEnablement, (void *)false},
 	/* DEPRECATED */ {false, "mobileEnableAccelerometer", MCHandleAccelerometerEnablement, (void *)true},
 	/* DEPRECATED */ {false, "mobileDisableAccelerometer", MCHandleAccelerometerEnablement, (void *)false},
+    
+    {false, "mobileSetLocationHistoryLimit", MCHandleSetLocationHistoryLimit, nil},
+    {false, "mobileGetLocationHistoryLimit", MCHandleGetLocationHistoryLimit, nil},
+    {false, "mobileGetLocationHistory", MCHandleGetLocationHistory, nil},
     
     {false, "mobileBusyIndicatorStart", MCHandleStartBusyIndicator, nil},
     {false, "mobileBusyIndicatorStop", MCHandleStopBusyIndicator, nil},

--- a/engine/src/mbliphonesensor.mm
+++ b/engine/src/mbliphonesensor.mm
@@ -42,14 +42,20 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static MCSensorLocationReading *s_location_reading = nil;
+
+////////////////////////////////////////////////////////////////////////////////
+
 // MM-2012-03-13: Added intialize and finalize calls to sensor module.
 //  Only really needed for Android.
 void MCSystemSensorInitialize(void)
 {
+    s_location_reading = nil;
 }
 
 void MCSystemSensorFinalize(void)
 {
+    MCMemoryDelete(s_location_reading);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -155,8 +161,44 @@ static int32_t s_location_calibration_timeout = 0;
 
 - (void)locationManager: (CLLocationManager *)manager didUpdateToLocation: (CLLocation *)newLocation fromLocation: (CLLocation *)oldLocation
 {
-    if (s_location_enabled)
-        MCSensorPostChangeMessage(kMCSensorTypeLocation);
+    if (!s_location_enabled)
+        return;
+    
+    if (s_location_reading == nil)
+        if (!MCMemoryNew(s_location_reading))
+            return;
+    
+    CLLocation *t_location = newLocation;
+    
+    if ([t_location horizontalAccuracy] >= 0.0)
+    {
+        s_location_reading->latitude = [t_location coordinate].latitude;
+        s_location_reading->longitude = [t_location coordinate].longitude;
+        s_location_reading->horizontal_accuracy = [t_location horizontalAccuracy];
+    }
+    else
+    {
+        s_location_reading->latitude = s_location_reading->longitude = NAN;
+    }
+    
+    if ([t_location verticalAccuracy] >= 0.0)
+    {
+        s_location_reading->altitude = [t_location altitude];
+        s_location_reading->vertical_accuracy = [t_location verticalAccuracy];
+    }
+    else
+    {
+        s_location_reading->altitude = NAN;
+    }
+    
+    // MM-2013-02-21: Added speed and course to the detailed readings.
+    s_location_reading->timestamp = [[t_location timestamp] timeIntervalSince1970];
+    s_location_reading->speed = [t_location speed];
+    s_location_reading->course = [t_location course];
+    
+    MCSensorAddLocationSample(*s_location_reading);
+    
+    MCSensorPostChangeMessage(kMCSensorTypeLocation);
 }
 
 - (void)locationManager: (CLLocationManager *)manager didUpdateHeading: (CLHeading *)newHeading
@@ -394,36 +436,37 @@ bool MCSystemStopTrackingLocation()
 
 bool MCSystemGetLocationReading(MCSensorLocationReading &r_reading, bool p_detailed)
 {
-	if (s_location_enabled)
-	{
-		CLLocation *t_location;
-		t_location = [s_location_manager location];        
+#if 0
+    if (s_location_enabled)
+    {
+        CLLocation *t_location;
+        t_location = [s_location_manager location];
         if(t_location == nil)
             return false;
-		
-		if ([t_location horizontalAccuracy] >= 0.0)
-		{
+        
+        if ([t_location horizontalAccuracy] >= 0.0)
+        {
             r_reading.latitude = [t_location coordinate].latitude;
-            r_reading.longitude = [t_location coordinate].longitude;            
+            r_reading.longitude = [t_location coordinate].longitude;
             if (p_detailed)
                 r_reading.horizontal_accuracy = [t_location horizontalAccuracy];
-		}
+        }
         else
         {
             r_reading.latitude = r_reading.longitude = NAN;
         }
-		
-		if ([t_location verticalAccuracy] >= 0.0)
-		{
+        
+        if ([t_location verticalAccuracy] >= 0.0)
+        {
             r_reading.altitude = [t_location altitude];
             if (p_detailed)
                 r_reading.vertical_accuracy = [t_location verticalAccuracy];
-		}
+        }
         else
         {
             r_reading.altitude = NAN;
         }
-		
+        
         // MM-2013-02-21: Added speed and course to the detailed readings.
         if (p_detailed)
         {
@@ -433,8 +476,13 @@ bool MCSystemGetLocationReading(MCSensorLocationReading &r_reading, bool p_detai
         }
         
         return true;
-	}
-    return false;
+    }
+#endif
+    if (s_location_reading == nil)
+        return false;
+    
+    MCMemoryCopy(&r_reading, s_location_reading, sizeof(MCSensorLocationReading));
+    return true;
 }
 
 // MM-2012-02-11: Added iPhoneGet/SetCalibrationTimeout

--- a/engine/src/mblsensor.cpp
+++ b/engine/src/mblsensor.cpp
@@ -37,9 +37,112 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// This implements a simple singly-linked list with constant time pop front
+// and push back. The list is bounded by a maximum length, elements are popped
+// if the limit is exceeded until it reduces to the limit.
+template<class T>
+class MCBoundedLinkedList
+{
+public:
+    MCBoundedLinkedList(void)
+        : m_head(nil), m_tail(nil), m_count(0), m_limit(0)
+    {
+    }
+    
+    ~MCBoundedLinkedList(void)
+    {
+        while(!IsEmpty())
+        {
+            T *t_top = Pop();
+            delete t_top;
+        }
+    }
+    
+    bool IsEmpty(void) const
+    {
+        return m_head == nil;
+    }
+    
+    size_t GetLength(void) const
+    {
+        return m_count;
+    }
+    
+    size_t GetLimit(void) const
+    {
+        return m_limit;
+    }
+    
+    void SetLimit(size_t p_limit)
+    {
+        m_limit = p_limit;
+        
+        Fit();
+    }
+    
+    T *First(void) const
+    {
+        return m_head;
+    }
+    
+    T *Last(void) const
+    {
+        return m_tail;
+    }
+    
+    T *Pop(void)
+    {
+        if (IsEmpty())
+            return nil;
+        
+        T *t_element;
+        t_element = m_head;
+        
+        m_head = m_head -> next;
+        if (m_head == nil)
+            m_tail = nil;
+        
+        m_count -= 1;
+        
+        return t_element;
+    }
+    
+    void Push(T *p_element)
+    {
+        if (m_tail != nil)
+            m_tail -> next = p_element;
+        else
+            m_head = p_element;
+        m_tail = p_element;
+        m_count += 1;
+        
+        Fit();
+    }
+    
+private:
+    void Fit(void)
+    {
+        if (m_limit == 0)
+            return;
+        
+        while(GetLength() > m_limit)
+        {
+            delete Pop();
+        }
+    }
+    
+    T *m_head;
+    T *m_tail;
+    size_t m_count;
+    size_t m_limit;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 static bool s_sensor_message_pending[] = {false, false, false, false, false};
 
-static MCSensorLocationReading *s_last_location_reading = nil;
+static MCBoundedLinkedList<MCSensorLocationReading> s_location_readings;
+
 static MCSensorHeadingReading *s_last_heading_reading = nil;
 static MCSensorAccelerationReading *s_last_acceleration_reading = nil;
 static MCSensorRotationRateReading *s_last_rotation_rate_reading = nil;
@@ -49,21 +152,23 @@ static MCSensorRotationRateReading *s_last_rotation_rate_reading = nil;
 // MM-2012-03-13: Added intialize and finalize calls to sensor module.
 void MCSensorInitialize(void)
 {
-    s_last_location_reading = nil;
+    s_location_readings.SetLimit(1);
+    
     s_last_heading_reading = nil;
     s_last_acceleration_reading = nil;
     s_last_rotation_rate_reading = nil;
+    
     s_sensor_message_pending[kMCSensorTypeUnknown] = false;
     s_sensor_message_pending[kMCSensorTypeLocation] = false;
     s_sensor_message_pending[kMCSensorTypeHeading] = false;
     s_sensor_message_pending[kMCSensorTypeAcceleration] = false;
     s_sensor_message_pending[kMCSensorTypeRotationRate] = false;
+    
     MCSystemSensorInitialize();
 }
 
 void MCSensorFinalize(void)
 {
-    /* UNCHECKED */ MCMemoryDelete(s_last_location_reading);
     /* UNCHECKED */ MCMemoryDelete(s_last_heading_reading);
     /* UNCHECKED */ MCMemoryDelete(s_last_acceleration_reading);
     /* UNCHECKED */ MCMemoryDelete(s_last_rotation_rate_reading);
@@ -195,24 +300,15 @@ public:
             {
                 MCSensorLocationReading t_reading;
                 if (MCSystemGetLocationReading(t_reading, false))
-				{                    
-                    if (s_last_location_reading == nil ||
-                        location_reading_changed(t_reading, *s_last_location_reading, MCSystemGetSensorDispatchThreshold(m_sensor)))
-                    {
-                        MCParameter p1, p2, p3;
-                        p1.setn_argument(t_reading.latitude);
-                        p1.setnext(&p2);
-                        p2.setn_argument(t_reading.longitude);
-                        p2.setnext(&p3);
-                        p3.setn_argument(t_reading.altitude);
-                        
-                        MCdefaultstackptr->getcurcard()->message(MCM_location_changed, &p1);
-                        
-                        if (s_last_location_reading == nil)
-                            /* UNCHECKED */ MCMemoryNew(s_last_location_reading);
-                        
-                        *s_last_location_reading = t_reading;
-                    }         
+				{
+                    MCParameter p1, p2, p3;
+                    p1.setn_argument(t_reading.latitude);
+                    p1.setnext(&p2);
+                    p2.setn_argument(t_reading.longitude);
+                    p2.setnext(&p3);
+                    p3.setn_argument(t_reading.altitude);
+                    
+                    MCdefaultstackptr->getcurcard()->message(MCM_location_changed, &p1);
 				}
                 break;
             }                
@@ -305,6 +401,49 @@ static MCSensorUpdateEvent * FetchSensorEvent(MCSensorType p_sensor)
         t_event = new MCSensorUpdateEvent(p_sensor);
     }
     return t_event;        
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void MCSensorAddLocationSample(const MCSensorLocationReading& p_reading)
+{
+    if (!s_location_readings.IsEmpty())
+    {
+        if (!location_reading_changed(p_reading,
+                                      *(s_location_readings.Last()),
+                                      MCSystemGetSensorDispatchThreshold(kMCSensorTypeLocation)))
+        {
+            return;
+        }
+    }
+    
+    MCSensorLocationReading *t_reading;
+    t_reading = new MCSensorLocationReading(p_reading);
+    if (t_reading == nil)
+        return;
+    
+    s_location_readings.Push(t_reading);
+}
+
+bool MCSensorPopLocationSample(MCSensorLocationReading& r_reading)
+{
+    MCSensorLocationReading *t_sample;
+    t_sample = s_location_readings.Pop();
+    if (t_sample == nil)
+        return false;
+    
+    r_reading = *t_sample;
+    return true;
+}
+
+size_t MCSensorGetLocationSampleLimit(void)
+{
+    return s_location_readings.GetLimit();
+}
+
+void MCSensorSetLocationSampleLimit(size_t p_limit)
+{
+    s_location_readings.SetLimit(p_limit);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mblsensor.h
+++ b/engine/src/mblsensor.h
@@ -19,8 +19,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "mblsyntax.h"
 
-typedef struct
+struct MCSensorLocationReading
 {
+    MCSensorLocationReading *next;
+    
     double latitude;
     double longitude;
     double altitude;
@@ -33,7 +35,7 @@ typedef struct
     // MM-2013-02-21: Add speed and course to detailed location reading.
     double speed;
     double course;
-} MCSensorLocationReading;
+};
 
 typedef struct
 {
@@ -98,6 +100,11 @@ void MCSystemSensorFinalize(void);
 
 // SN-2014-10-15: [[ Merge-6.7.0-rc-3 ]]
 bool MCSystemGetLocationAuthorizationStatus(MCStringRef& r_status);
+
+void MCSensorAddLocationSample(const MCSensorLocationReading& p_reading);
+bool MCSensorPopLocationSample(MCSensorLocationReading& r_reading);
+size_t MCSensorGetLocationSampleLimit(void);
+void MCSensorSetLocationSampleLimit(size_t p_limit);
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This patch does two things.

The first is to make GPS behavior identical on Android and iOS. On
both platforms, the location reading returned by GetLocationReading
is that which was sent with the last system locationChanged event.
(This brings iOS behavior inline with that of Android).

The second is to add three new handlers:

```
mobileGetLocationHistory
mobileSetLocationHistoryLimit
mobileGetLocationHistoryLimit
```

Whenever a system locationChanged event occurs, the location reading
is pushed onto the front of a list. The list is capped at the length
set by 'SetLocationHistoryLimit', dropping any old samples over this
length.

The mobileGetLocationHistory function returns a numerically keyed
array of all accumulated samples since the last time it was called
with lower indicies being older samples. Calling the function clears
the internal history.

Each element in the array is the same format as the detailed location
array as returned from the mobileCurrentLocation() function.

If an application wants historical access to all samples, then it
should set the location history limit to the maximum number of samples
it ever wants to record, or 0 to record the entire history (between
calls to mobileGetLocationHistory).

The best way to use the history is to fetch the list in 'locationChanged'
and process each sample in turn, rather than the sample provided
with the locationChanged event (which will always be the last sample
in the history). e.g.

```
on locationChanged
    local tHistory
    put mobileGetLocationHistory() into tHistory
    repeat for each element tSample in tHistory
        processLocationChanged tSample
    end repeat
end locationChanged
```

The default history limit is 1 - meaning that only one sample is
ever kept at a time.
