### PR TITLE
[[ Community Docs ]] Clarifications to useUnicode

### DIFF
--- a/docs/dictionary/property/useUnicode.lcdoc
+++ b/docs/dictionary/property/useUnicode.lcdoc
@@ -13,24 +13,42 @@ OS: mac,windows,linux,ios,android
 Platforms: desktop,server,web,mobile
 
 Example:
+create field "russianLetter"
 set the useUnicode to true
-
-Example:
-set the useUnicode to (the number of items of myFont is 2)
+set the unicodeText of field "russianLetter" to numToChar(1083)
 
 Value: By default, the <useUnicode> property is false.
 
 Description:
-Use the <useUnicode> property to prepare to convert between Unicode characters and their numeric values.
+Use the <useUnicode> property to prepare to convert between Unicode
+characters and their numeric values.
 
-If the useUnicode property is set to true, the numToChar and charToNum functions use double-byte characters. You can pass a number greater than 255 to the numToChar function in order to generate a double-byte character, and you can pass a double-byte character to the charToNum function.
+If the <useUnicode> property is set to true, the <numToChar> and <charToNum>
+functions use double-byte characters. You can pass a number greater than
+255 to the <numToChar> function in order to generate a double-byte
+character, and you can pass a double-byte character to the <charToNum>
+function.
 
-If the useUnicode is false, the numToChar and charToNum functions use single-byte characters. Passing a double-byte character to charToNum or a number larger than 255 to numToChar will produce incorrect results if the useUnicode is false.
+If the <useUnicode> is false, the <numToChar> and <charToNum> functions use
+single-byte characters. Passing a double-byte character to <charToNum> or
+a number larger than 255 to <numToChar> will produce incorrect results if
+the <useUnicode> is false.
 
-Since the useUnicode is a local property, its value is reset to false when the current handler finishes executing. It retains its value only for the current handler, and setting it in one handler does not affect its value in other handlers it calls.
+Since the <useUnicode> is a local property, its value is reset to false
+when the current handler finishes executing. It retains its value only
+for the current handler, and setting it in one handler does not affect
+its value in other handlers it calls.
 
-Deprecated: In LiveCode 7.0 the language was changed to handle unicode transparently. This means that language functionality which previously aided unicode text manipulation is no longer required. This property should not be used in new code, as it only affects the behaviour of numToChar and charToNum, which are themselves deprecated.
+>*Note:* The <useUnicode> property is deprecated. In LiveCode 7.0 the
+language was changed to handle unicode transparently. This means that
+language functionality which previously aided unicode text manipulation
+is no longer required. This property should not be used in new code, as
+it only affects the behaviour of <numToChar> and <charToNum>, which are
+themselves deprecated.
 
-References: allowInlineInput (property), numToChar (function)
+Changes: As of LiveCode 7.0 the <useUnicode> property is deprecated.
+
+References: allowInlineInput (property), charToNum (function), 
+numToChar (function), unicodeText (property)
 
 Tags: text processing


### PR DESCRIPTION
- Markdown was making it easy to overlook the "deprecated" notice. Changed to a block quoted note to emphasize it.
- Deleted obsolete example. (Unicode font names no longer have comma-separated names.)
- Fleshed out existing example.
- Added Changes element to further emphasize deprecation.
- Hard wrapped Description and References text.
- Added links to referenced tokens.
