### PR TITLE
[[ ReturnValue ]] Provide new return forms to return values and errors

### DIFF
--- a/docs/dictionary/control_st/return.lcdoc
+++ b/docs/dictionary/control_st/return.lcdoc
@@ -2,7 +2,7 @@ Name: return
 
 Type: control structure
 
-Syntax: return [ { value | error } ] <value>
+Syntax: return <value> [ for { value | error } ]
 
 Summary: Stops the current <handler> and <return|returns> a <value> to the
 <handler> that <call|called> the current <handler>.
@@ -27,7 +27,7 @@ Example:
 
 Example:
     function simpleFunction
-       return value 1
+       return 1 for value
     end simpleFunction
     on testSimpleFunction
        local tVar
@@ -37,7 +37,7 @@ Example:
 
 Example:
     function simpleFunction
-       return error 1
+       return 1 for error
     end simpleFunction
     on testSimpleFunction
        local tVar
@@ -56,7 +56,7 @@ Example:
 
 Example:
     command simpleCommand
-       return value 1
+       return 1 for value
     end simpleCommand
     on testSimpleCommand
        simpleCommand
@@ -65,7 +65,7 @@ Example:
 
 Example:
     command simpleCommand
-       return error 1
+       return 1 for error
     end simpleCommand
     on testSimpleCommand
        simpleCommand
@@ -116,12 +116,12 @@ halt the current <message handler> and <pass> the <message> on through the
 <handler> without returning a value, use the <exit> <control structure>
 instead.
 
-The <return error> and <return value> forms of the <return> command allow much
-easier scripting of the distinction between a return value of a handler call,
-and an error return value of a handler call. If a command or function <handler>
-succeeds, then the 'return value' form should be used to return the result of
-the execution to the calling <handler>. If a command or function <handler> fails,
-then the 'return error' form should be used to return an error status to the
+The value and error forms of the <return> command allow much easier scripting of
+the distinction between a return value of a handler call, and an error return
+value of a handler call. If a command or function <handler> succeeds, then the
+'return for value' form should be used to return the result of the execution to
+the calling <handler>. If a command or function <handler> fails, then the
+'return for error' form should be used to return an error status to the
 calling <handler>.
 
 Any callers of handlers using the new error and value forms of the <return>

--- a/docs/dictionary/control_st/return.lcdoc
+++ b/docs/dictionary/control_st/return.lcdoc
@@ -2,39 +2,142 @@ Name: return
 
 Type: control structure
 
-Syntax: return <value> 
+Syntax: return [ { value | error } ] <value>
 
-Summary: Stops the current <handler> and <return|returns> a <value> to the <handler> that <call|called> the current <handler>. Sets the result to the value as well
+Summary: Stops the current <handler> and <return|returns> a <value> to the
+<handler> that <call|called> the current <handler>.
 
 Introduced: 1.0
+
+Changed: 8.1.0
 
 OS: mac,windows,linux,ios,android
 
 Platforms: desktop,server,web,mobile
 
-Parameters:
-value: 
-handler: The name of the handler in which the return control structure appears.
+Example:
+    function simpleFunction
+       return 1
+    end simpleFunction
+    on testSimpleFunction
+       local tVar
+       put simpleFunction() into tVar
+       -- tVar contains 1, the result contains 1
+    end testSimpleFunction
 
-The result: The <return> control structure set <the result> to the value being returned. If the <return> <control structure> is within an <on> or <setProp> <control structure>, the <value> can be retrieved by checking the <result> <function> in the <caller|calling handler>. Usually, when the <return> <control structure> is used within an <on> or <setProp> <control structure>, it <return(glossary)|returns> an error message. (If you want a <handler> to compute a <value> as its main reason for existence, you should implement it as a custom function rather than a custom command.). >*Note:* As well as the <return> <control structure> returns the value to the caller, it sets <the result> to the value.
+Example:
+    function simpleFunction
+       return value 1
+    end simpleFunction
+    on testSimpleFunction
+       local tVar
+       put simpleFunction() into tVar
+       -- tVar contains 1, the result contains empty
+    end testSimpleFunction
+
+Example:
+    function simpleFunction
+       return error 1
+    end simpleFunction
+    on testSimpleFunction
+       local tVar
+       put simpleFunction() into tVar
+       -- tVar contains empty, the result contains 1
+    end testSimpleFunction
+
+Example:
+    command simpleCommand
+       return 1
+    end simpleCommand
+    on testSimpleCommand
+       simpleCommand
+       -- the result contains 1
+    end testSimpleCommand
+
+Example:
+    command simpleCommand
+       return value 1
+    end simpleCommand
+    on testSimpleCommand
+       simpleCommand
+       -- it contains 1, the result contains empty
+    end testSimpleCommand
+
+Example:
+    command simpleCommand
+       return error 1
+    end simpleCommand
+    on testSimpleCommand
+       simpleCommand
+       -- it contains empty, the result contains 1
+    end testSimpleCommand
+
+Parameters:
+value: The value to return to the calling handler.
 
 Description:
-Use the <return> <control structure> to <return(constant)> a <value> from a custom function or <getProp> <handler>, or to <return(constant)> an error message from a <message handler> or <setProp> <handler>.
+Use the <return> <control structure> to <return(constant)> a <value> from a
+custom function or <getProp> <handler>, or to <return(constant)> an error
+message from a <message handler> or <setProp> <handler>.
 
 Form:
-The <return> <statement> appears on a line by itself, anywhere inside a <handler>.
+The <return> <statement> appears on a line by itself, anywhere inside a
+<handler>.
 
-When the <return> <control structure> is <execute|executed>, any remaining <statement|statements> in the <handler> are skipped. Hence, the <return> <control structure> is usually used either at the end of a <handler> or within an <if> <control structure>.
+When the <return> <control structure> is <execute|executed>, any remaining
+<statement|statements> in the <handler> are skipped. Hence, the <return>
+<control structure> is usually used either at the end of a <handler> or within
+an <if> <control structure>.
 
-If the <return> <control structure> is within a <function> or <getProp> <control structure>, the <value> is returned to the <caller|calling handler> as the <function> <value> or <property> setting. For example, if you have the following <function> <handler> :
+The plain form of the <return> <control structure> always sets <the result> to
+<value>. Additionally, if it is used within a <function> or <getProp> <handler>
+then <value> is passed to the calling handler as the return value of the
+<function>, or value of the property.
 
-which is called in the following statement:
+The value form of the <return> <control structure> always sets <the result> to
+empty. If it is used within a <command> or <message> handler then the <it>
+variable in the calling handler will be set to <value>. If it is used within a
+<function> handler, then <value> is passed to the calling handler as the return
+value of the <function>, or value of the property.
 
-then 1, the value returned by "simpleFunction", is placed in the field.
+The error form of the <return> <control structure> sets <the result> to <value>.
+If it is used within a <command> or <message> handler, then the <it> variable
+in the calling handler will be set to empty. If it is used within a <function>
+handler, then the return value of the <function> or the value of the property is
+returned as empty.
 
-When a message handler executes a <return> <statement>, the <message> stops and is not <pass|passed> to the next <object(glossary)> in the <message path>. To halt the current <message handler> and <pass> the <message> on through the <message path>, use the <pass> <control structure> instead. To halt the current <handler> without returning a result, use the <exit> <control structure> instead.
+*Note:* The value and error forms can only be used within message, command and
+function handlers - not getProp or setProp handlers.
 
->*Note:* The <return> <control structure> is implemented internally as a <command> and appears in the <commandNames>.
+When a message handler executes a <return> <statement>, the <message> stops and
+is not <pass|passed> to the next <object(glossary)> in the <message path>. To
+halt the current <message handler> and <pass> the <message> on through the
+<message path>, use the <pass> <control structure> instead. To halt the current
+<handler> without returning a value, use the <exit> <control structure>
+instead.
 
+The <return error> and <return value> forms of the <return> command allow much
+easier scripting of the distinction between a return value of a handler call,
+and an error return value of a handler call. If a command or function <handler>
+succeeds, then the 'return value' form should be used to return the result of
+the execution to the calling <handler>. If a command or function <handler> fails,
+then the 'return error' form should be used to return an error status to the
+calling <handler>.
 
-References: object (glossary), return (constant), result (function), commandNames (function), value (function), merge (function), the result (function), message handler (glossary), return (glossary), call (glossary), property (glossary), pass (glossary), execute (glossary), command (glossary), control structure (glossary), message path (glossary), caller (glossary), message (glossary), statement (glossary), handler (glossary), setProp (control structure), getProp (control structure), throw (control structure), if (control structure), pass (control structure), exit (control structure), on (control structure), function (control structure)
+Any callers of handlers using the new error and value forms of the <return>
+command can uniformly check <the result> is empty to determine if the
+operation succeeded, and if it did then either <it> or the return value can be
+processed to continue operation.
+
+>*Note:* The <return> <control structure> is implemented internally as a
+<command> and appears in the <commandNames>.
+
+References: object (glossary), return (constant), result (function),
+commandNames (function), value (function), merge (function),
+the result (function), message handler (glossary), return (glossary),
+call (glossary), property (glossary), pass (glossary), execute (glossary),
+command (glossary), control structure (glossary), message path (glossary),
+caller (glossary), message (glossary), statement (glossary), handler (glossary),
+setProp (control structure), getProp (control structure),
+throw (control structure), if (control structure), pass (control structure),
+exit (control structure), on (control structure), function (control structure)

--- a/docs/notes/feature-return_error_and_value.md
+++ b/docs/notes/feature-return_error_and_value.md
@@ -1,0 +1,24 @@
+# Improved return command
+The 'return' command has had two new forms added:
+
+    return value <value>
+    return error <value>
+
+When running in a command handler, the 'return value' form will cause execution
+of the handler to halt, and control to return to the calling handler. At this
+point the 'it' variable in the calling handler will be set to 'value' and
+'the result' will be set to empty. In contrast, the 'return error' form will
+cause the 'it' variable in the calling handler to be set to empty and
+'the result' to be set to 'value'.
+
+When running in a function handler, the 'return value' form will cause execution
+of the handler to halt, and control to return to the calling handler. At this
+point the return value of the function call will be 'value', and 'the result'
+will be set to empty. In contrast, the 'return error' form will cause the
+return value of the function call to be empty, and 'the result' will be set to
+'value'.
+
+These forms of return are designed to be used by script library functions to
+allow them to have the same ability as built-in engine functions and commands -
+namely the ability to return a value (in it for commands, or return value for
+functions) *or* return a status (in the result).

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -1275,45 +1275,57 @@ void MCReset::compile(MCSyntaxFactoryRef ctxt)
 MCReturn::~MCReturn()
 {
 	delete source;
-	delete url;
-	delete var;
+	delete extra_source;
 }
 
 Parse_stat MCReturn::parse(MCScriptPoint &sp)
 {
 	initpoint(sp);
-	if (sp.parseexp(False, True, &source) != PS_NORMAL)
+    if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_VALUE) == PS_NORMAL)
+    {
+        kind = kReturnValue;
+    }
+    else if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_ERROR) == PS_NORMAL)
+    {
+        kind = kReturnError;
+    }
+    else
+    {
+        kind = kReturn;
+    }
+    
+    if (sp.parseexp(False, True, &source) != PS_NORMAL)
 	{
 		MCperror->add
 		(PE_RETURN_BADEXP, sp);
 		return PS_ERROR;
 	}
-	if (sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_WITH) == PS_NORMAL)
-	{
-		if (sp.skip_token(SP_FACTOR, TT_CHUNK, CT_URL))
-		{
-			// MW-2011-06-22: [[ SERVER ]] Update to use SP findvar method to take into account
-			//   execution outwith a handler.
-			Symbol_type type;
-			if (sp.next(type) != PS_NORMAL || sp.findvar(sp.gettoken_nameref(), &var) != PS_NORMAL)
-				sp.backup();
-			else
-				var->parsearray(sp);
-		}
-		if (var == NULL)
-		{
-			sp.skip_token(SP_FACTOR, TT_FUNCTION, F_CACHED_URLS);
-			if (sp.parseexp(False, True, &url) != PS_NORMAL)
-			{
-				MCperror->add
-				(PE_RETURN_BADEXP, sp);
-				return PS_ERROR;
-			}
-		}
+	
+    if (kind == kReturn &&
+        sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_WITH) == PS_NORMAL)
+    {
+        kind = kReturnWithUrlResult;
+		if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_URL_RESULT) == PS_NORMAL)
+            ;
+        if (sp.parseexp(False, True, &extra_source) != PS_NORMAL)
+        {
+            MCperror->add(PE_RETURN_BADEXP, sp);
+            return PS_ERROR;
+        }
 	}
+    
+    Handler_type t_handler_type;
+    t_handler_type = sp.gethandler()->gettype();
+    if (kind != kReturn &&
+        t_handler_type != HT_MESSAGE &&
+        t_handler_type != HT_FUNCTION)
+    {
+        MCperror->add(PE_RETURN_BADFORMINCONTEXT, sp);
+        return PS_ERROR;
+    }
+        
 	return PS_NORMAL;
 }
-
 
 // MW-2007-07-03: [[ Bug 4570 ]] - Using the return command now causes a
 //   RETURN_HANDLER status rather than EXIT_HANDLER. This is used to not
@@ -1325,23 +1337,27 @@ void MCReturn::exec_ctxt(MCExecContext &ctxt)
     if (!ctxt . EvalExprAsValueRef(source, EE_RETURN_BADEXP, &t_result))
         return;
 	
-	if (url != nil)
-	{
-		MCAutoValueRef t_url_result;
-        if (!ctxt . EvalExprAsValueRef(url, EE_RETURN_BADEXP, &t_url_result))
+    if (kind == kReturn)
+    {
+        MCEngineExecReturn(ctxt, *t_result);
+    }
+    else if (kind == kReturnValue)
+    {
+        MCEngineExecReturnValue(ctxt, *t_result);
+    }
+    else if (kind == kReturnError)
+    {
+        MCEngineExecReturnError(ctxt, *t_result);
+    }
+    else if (kind == kReturnWithUrlResult)
+    {
+        MCAutoValueRef t_extra_result;
+        if (!ctxt . EvalExprAsValueRef(extra_source, EE_RETURN_BADEXP, &t_extra_result))
             return;
+        
+        MCNetworkExecReturnValueAndUrlResult(ctxt, *t_result, *t_extra_result);
+    }
 
-		MCNetworkExecReturnValueAndUrlResult(ctxt, *t_result, *t_url_result);
-	}
-	else if (var != nil)
-	{
-		MCNetworkExecReturnValueAndUrlResultFromVar(ctxt, *t_result, var);
-	}
-	else
-	{
-		MCEngineExecReturnValue(ctxt, *t_result);
-	}
-	
 	if (!ctxt . HasError())
         ctxt . SetIsReturnHandler();
 }
@@ -1357,18 +1373,23 @@ void MCReturn::compile(MCSyntaxFactoryRef ctxt)
 
 	source -> compile(ctxt);
 
-	if (url != nil)
-	{
-		url -> compile(ctxt);
-		MCSyntaxFactoryExecMethod(ctxt, kMCNetworkExecReturnValueAndUrlResultMethodInfo);
-	}
-	else if (var != nil)
-	{
-		MCSyntaxFactoryEvalConstant(ctxt, var);
-		MCSyntaxFactoryExecMethod(ctxt, kMCNetworkExecReturnValueAndUrlResultFromVarMethodInfo);
-	}
-	else
-		MCSyntaxFactoryExecMethod(ctxt, kMCEngineExecReturnValueMethodInfo);
+    if (kind == kReturn)
+    {
+        MCSyntaxFactoryExecMethod(ctxt, kMCEngineExecReturnMethodInfo);
+    }
+    else if (kind == kReturnValue)
+    {
+        MCSyntaxFactoryExecMethod(ctxt, kMCEngineExecReturnValueMethodInfo);
+    }
+    else if (kind == kReturnError)
+    {
+        MCSyntaxFactoryExecMethod(ctxt, kMCEngineExecReturnErrorMethodInfo);
+    }
+    else if (kind == kReturnWithUrlResult)
+    {
+        extra_source -> compile(ctxt);
+        MCSyntaxFactoryExecMethod(ctxt, kMCNetworkExecReturnValueAndUrlResultMethodInfo);
+    }
 
 	MCSyntaxFactoryEndStatement(ctxt);
 }

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -317,14 +317,22 @@ public:
 
 class MCReturn : public MCStatement
 {
+    enum Kind
+    {
+        kReturn,
+        kReturnValue,
+        kReturnError,
+        kReturnWithUrlResult,
+    };
 	MCExpression *source;
-	MCExpression *url;
-	MCVarref *var;
+	MCExpression *extra_source;
+    Kind kind;
 public:
 	MCReturn()
 	{
-		source = url = NULL;
-		var = NULL;
+        source = NULL;
+        extra_source = NULL;
+        kind = kReturn;
 	}
 	virtual ~MCReturn();
 	virtual Parse_stat parse(MCScriptPoint &);

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -112,7 +112,9 @@ MC_EXEC_DEFINE_EXEC_METHOD(Engine, LockMessages, 0)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, UnlockErrors, 0)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, UnlockMessages, 0)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, Set, 2)
+MC_EXEC_DEFINE_EXEC_METHOD(Engine, Return, 1)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, ReturnValue, 1)
+MC_EXEC_DEFINE_EXEC_METHOD(Engine, ReturnError, 1)
 MC_EXEC_DEFINE_SET_METHOD(Engine, CaseSensitive, 1)
 MC_EXEC_DEFINE_GET_METHOD(Engine, CaseSensitive, 1)
 MC_EXEC_DEFINE_SET_METHOD(Engine, CenturyCutOff, 1)
@@ -840,9 +842,19 @@ void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCExecValue p_value, int p
     }
 }
 
+void MCEngineExecReturn(MCExecContext& ctxt, MCValueRef p_value)
+{
+	ctxt.SetTheResultToValue(p_value);
+}
+
 void MCEngineExecReturnValue(MCExecContext& ctxt, MCValueRef p_value)
 {
-	ctxt . SetTheResultToValue(p_value);
+    ctxt.SetTheReturnValue(p_value);
+}
+
+void MCEngineExecReturnError(MCExecContext& ctxt, MCValueRef p_value)
+{
+    ctxt.SetTheReturnError(p_value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -66,7 +66,6 @@ MC_EXEC_DEFINE_EXEC_METHOD(Network, ReadFromSocketUntil, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, WriteToSocket, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, PutIntoUrl, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, ReturnValueAndUrlResult, 2)
-MC_EXEC_DEFINE_EXEC_METHOD(Network, ReturnValueAndUrlResultFromVar, 2)
 MC_EXEC_DEFINE_GET_METHOD(Network, UrlResponse, 1)
 MC_EXEC_DEFINE_GET_METHOD(Network, FtpProxy, 1)
 MC_EXEC_DEFINE_SET_METHOD(Network, FtpProxy, 1)
@@ -784,17 +783,6 @@ void MCNetworkExecReturnValueAndUrlResult(MCExecContext& ctxt, MCValueRef p_resu
 		return;
 	
 	ctxt . Throw();
-}
-
-void MCNetworkExecReturnValueAndUrlResultFromVar(MCExecContext& ctxt, MCValueRef p_result, MCVarref *p_variable)
-{
-    MCAutoValueRef t_value;
-    if (!ctxt . EvalExprAsValueRef(p_variable, EE_RETURN_BADEXP, &t_value))
-        return;
-	
-	ctxt . SetTheResultToValue(p_result);
-	MCurlresult -> set(ctxt, *t_value);
-	p_variable -> dofree(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1231,36 +1231,55 @@ Exec_stat MCExecContext::Catch(uint2 p_line, uint2 p_pos)
 void MCExecContext::SetTheResultToEmpty(void)
 {
 	MCresult -> clear();
+    MCresultmode = kMCExecResultModeReturn;
 }
 
 void MCExecContext::SetTheResultToValue(MCValueRef p_value)
 {
-	MCresult -> setvalueref(p_value);
+    MCresult -> setvalueref(p_value);
+    MCresultmode = kMCExecResultModeReturn;
 }
 
 void MCExecContext::SetTheResultToStaticCString(const char *p_cstring)
 {
-	MCresult -> sets(p_cstring);
+    MCresult -> sets(p_cstring);
+    MCresultmode = kMCExecResultModeReturn;
 }
 
 void MCExecContext::SetTheResultToNumber(real64_t p_value)
 {
     MCresult -> setnvalue(p_value);
+    MCresultmode = kMCExecResultModeReturn;
 }
 
 void MCExecContext::GiveCStringToResult(char *p_cstring)
 {
     MCresult -> grab(p_cstring, MCCStringLength(p_cstring));
+    MCresultmode = kMCExecResultModeReturn;
 }
 
 void MCExecContext::SetTheResultToCString(const char *p_string)
 {
     MCresult -> copysvalue(p_string);
+    MCresultmode = kMCExecResultModeReturn;
 }
 
 void MCExecContext::SetTheResultToBool(bool p_bool)
 {
     MCresult -> sets(MCU_btos(p_bool));
+    MCresultmode = kMCExecResultModeReturn;
+}
+
+void MCExecContext::SetTheReturnError(MCValueRef p_value)
+{
+    MCresult -> setvalueref(p_value);
+    MCresultmode = kMCExecResultModeReturnError;
+}
+
+void MCExecContext::SetTheReturnValue(MCValueRef p_value)
+{
+    MCresult -> setvalueref(p_value);
+    MCresultmode = kMCExecResultModeReturnValue;
 }
 
 // SN-2015-06-03: [[ Bug 11277 ]] Refactor MCExecPoint update

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1335,7 +1335,7 @@ public:
 	{
 		abort();
 	}
-
+    
 	//////////
 
 	bool GetCaseSensitive(void) const
@@ -1695,6 +1695,9 @@ public:
     void GiveCStringToResult(char *p_cstring);
     void SetTheResultToCString(const char *p_string);
     void SetTheResultToBool(bool p_bool);
+    
+    void SetTheReturnValue(MCValueRef p_value);
+    void SetTheReturnError(MCValueRef p_value);
 
     // SN-2015-06-03: [[ Bug 11277 ]] Refactor MCExecPoint update
     void deletestatements(MCStatement* p_statements);
@@ -3781,7 +3784,9 @@ extern MCExecMethodInfo *kMCEngineExecLockMessagesMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecUnlockErrorsMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecUnlockMessagesMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecSetMethodInfo;
+extern MCExecMethodInfo *kMCEngineExecReturnMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecReturnValueMethodInfo;
+extern MCExecMethodInfo *kMCEngineExecReturnErrorMethodInfo;
 extern MCExecMethodInfo *kMCEngineSetCaseSensitiveMethodInfo;
 extern MCExecMethodInfo *kMCEngineGetCaseSensitiveMethodInfo;
 extern MCExecMethodInfo *kMCEngineSetCenturyCutOffMethodInfo;
@@ -3914,7 +3919,9 @@ void MCEngineExecUnlockErrors(MCExecContext& ctxt);
 void MCEngineExecUnlockMessages(MCExecContext& ctxt);
 
 void MCEngineExecSet(MCExecContext& ctxt, MCProperty *target, MCValueRef value);
+void MCEngineExecReturn(MCExecContext& ctxt, MCValueRef value);
 void MCEngineExecReturnValue(MCExecContext& ctxt, MCValueRef value);
+void MCEngineExecReturnError(MCExecContext& ctxt, MCValueRef value);
 
 void MCEngineExecLoadExtension(MCExecContext& ctxt, MCStringRef filename, MCStringRef resource_path);
 void MCEngineExecUnloadExtension(MCExecContext& ctxt, MCStringRef filename);
@@ -4418,7 +4425,6 @@ void MCNetworkExecWriteToSocket(MCExecContext& ctxt, MCNameRef p_socket, MCStrin
 void MCNetworkExecPutIntoUrl(MCExecContext& ctxt, MCValueRef value, int prep, MCUrlChunkPtr url);
 
 void MCNetworkExecReturnValueAndUrlResult(MCExecContext& ctxt, MCValueRef value, MCValueRef url_result);
-void MCNetworkExecReturnValueAndUrlResultFromVar(MCExecContext& ctxt, MCValueRef result, MCVarref *variable);
 
 void MCNetworkGetUrlResponse(MCExecContext& ctxt, MCStringRef& r_value);
 

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -493,10 +493,29 @@ void MCFuncref::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
 		return;
 	}
 
-	if (MCresult->eval(ctxt, r_value . valueref_value))
-	{
-        r_value . type = kMCExecValueTypeValueRef;
-		return;
+    if (MCresultmode == kMCExecResultModeReturn)
+    {
+        if (MCresult->eval(ctxt, r_value . valueref_value))
+        {
+            r_value . type = kMCExecValueTypeValueRef;
+            return;
+        }
+    }
+    else if (MCresultmode == kMCExecResultModeReturnValue)
+    {
+        // Our return value is MCresult, and 'the result' gets set to empty.
+        if (MCresult->eval(ctxt, r_value . valueref_value))
+        {
+            r_value . type = kMCExecValueTypeValueRef;
+            ctxt.SetTheResultToEmpty();
+            return;
+        }
+    }
+    else if (MCresultmode == kMCExecResultModeReturnError)
+    {
+        // Our return value is empty, and 'the result' remains as it is.
+        MCExecTypeSetValueRef(r_value, MCValueRetain(kMCEmptyString));
+        return;
     }
     
     ctxt . Throw();

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -374,6 +374,7 @@ MCVariable *MCdialogdata;
 MCStringRef MChcstat;
 
 MCVariable *MCresult;
+MCExecResultMode MCresultmode;
 MCVariable *MCurlresult;
 Boolean MCexitall;
 int4 MCretcode;
@@ -1044,6 +1045,7 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 	MCperror = new MCError();
 	MCeerror = new MCError();
 	/* UNCHECKED */ MCVariable::createwithname(MCNAME("MCresult"), MCresult);
+    MCresultmode = kMCExecResultModeReturn;
 
 	/* UNCHECKED */ MCVariable::createwithname(MCNAME("MCurlresult"), MCurlresult);
 	/* UNCHECKED */ MCVariable::createwithname(MCNAME("MCdialogdata"), MCdialogdata);

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -282,6 +282,7 @@ extern MCError *MCeerror;
 extern MCVariable *MCmb;
 extern MCVariable *MCeach;
 extern MCVariable *MCresult;
+extern MCExecResultMode MCresultmode;
 extern MCVariable *MCurlresult;
 extern MCVariable *MCglobals;
 extern MCVariable *MCdialogdata;

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -2108,6 +2108,7 @@ static LT sugar_table[] =
 		{"effects", TT_UNDEFINED, SG_EFFECTS},
 		{"elevated", TT_UNDEFINED, SG_ELEVATED},
         {"empty", TT_CHUNK, CT_UNDEFINED},
+        {"error", TT_UNDEFINED, SG_ERROR},
         {"extension", TT_UNDEFINED, SG_EXTENSION},
 		// MW-2013-11-14: [[ AssertCmd ]] Token for 'failure'
 		{"failure", TT_UNDEFINED, SG_FAILURE},
@@ -2161,6 +2162,8 @@ static LT sugar_table[] =
 		{"true", TT_UNDEFINED, SG_TRUE},
 		{"unicode", TT_UNDEFINED, SG_UNICODE},
 		{"url", TT_UNDEFINED, SG_URL},
+        {"urlresult", TT_UNDEFINED, SG_URL_RESULT},
+        {"value", TT_UNDEFINED, SG_VALUE},
 		// JS-2013-07-01: [[ EnhancedFilter ]] Token for 'wildcard'.
 		{"wildcard", TT_UNDEFINED, SG_WILDCARD},
 		{"without", TT_PREP, PT_WITHOUT},

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -350,8 +350,8 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 			MCnexecutioncontexts--;
 	}
     
-	if (t_stat == ES_NORMAL)
-		t_stat = MCresult -> eval(ctxt, r_value) ? ES_NORMAL : ES_ERROR;
+    if (t_stat == ES_NORMAL)
+        t_stat = MCresult -> eval(ctxt, r_value) ? ES_NORMAL : ES_ERROR;
     
 	return t_stat;
 }

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -616,9 +616,9 @@ enum Handler_type {
 	HT_BEFORE,
 	HT_AFTER,
 
-		HT_PRIVATE,
+    HT_PRIVATE,
 
-		HT_MAX = HT_PRIVATE
+    HT_MAX = HT_PRIVATE
 };
 
 enum If_format {
@@ -1964,6 +1964,10 @@ enum Sugar_constants {
 	SG_REPLACING,
 	SG_PRESERVING,
 	SG_STYLES,
+    
+    SG_URL_RESULT,
+    SG_ERROR,
+    SG_VALUE,
 };
 
 enum Statements {
@@ -2296,6 +2300,13 @@ enum Server_keywords
 	SK_UNICODE,
 	SK_SECURE,
 	SK_HTTPONLY,
+};
+
+enum MCExecResultMode
+{
+    kMCExecResultModeReturn,
+    kMCExecResultModeReturnValue,
+    kMCExecResultModeReturnError,
 };
 
 #include "parseerrors.h"

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1762,6 +1762,9 @@ enum Parse_errors
 	
     // {PE-0571} vectordot: bad parameter
     PE_VECTORDOT_BADPARAM,
+    
+    // {PE-0572} return: form not allowed in handler type
+    PE_RETURN_BADFORMINCONTEXT,
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1765,6 +1765,9 @@ enum Parse_errors
     
     // {PE-0572} return: form not allowed in handler type
     PE_RETURN_BADFORMINCONTEXT,
+    
+    // {PE-0573} return: form not allowed in handler type
+    PE_RETURN_BADFOR,
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/statemnt.cpp
+++ b/engine/src/statemnt.cpp
@@ -383,6 +383,30 @@ Parse_stat MCComref::parse(MCScriptPoint &sp)
 void MCComref::exec_ctxt(MCExecContext& ctxt)
 {
     MCKeywordsExecCommandOrFunction(ctxt, resolved, handler, params, name, line, pos, global_handler, false);
+    
+    if (MCresultmode == kMCExecResultModeReturn)
+    {
+        // Do nothing!
+    }
+    else if (MCresultmode == kMCExecResultModeReturnValue)
+    {
+        // Set 'it' to the result and clear the result
+        MCAutoValueRef t_value;
+        if (!MCresult->eval(ctxt, &t_value))
+        {
+            ctxt.Throw();
+            return;
+        }
+        
+        ctxt.SetItToValue(*t_value);
+        ctxt.SetTheResultToEmpty();
+    }
+    else if (MCresultmode == kMCExecResultModeReturnError)
+    {
+        // Set 'it' to empty
+        ctxt.SetItToEmpty();
+        // Leave the result as is
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -1,4 +1,4 @@
-﻿script "revLibURL"
+script "revLibURL"
 ##libUrl v1.2.0 2010-09-16
 #
 on revLoadLibrary
@@ -194,11 +194,7 @@ on getUrl x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of the keys of laLoadedUrls and laUrlLoadStatus[newUrl] is "cached" then
-      if "2.4.1" is in the version then
-         return  empty  with  laLoadedUrls[newUrl]
-      else
-         return  empty  with cachedUrl laLoadedUrls[newUrl]
-      end if
+      return empty  with urlResult laLoadedUrls[newUrl]
    end if
    if newUrl is among the lines of keys(laLoadingUrls) and (lvAuthBlockBypass is not true) then
       return "error  URL is currently loading" with empty
@@ -224,21 +220,16 @@ on getUrl x
          
          put laUrlErrorStatus[newUrl] into tRetResult
          delete local  laUrlErrorStatus[newUrl]
-         if "2.4.1" is in the version then
-            ##for mc 2.4.1 engine only
-            put laData[newUrl] into tRetData ##swap data before deleting laData
-            delete local laData[newUrl]
-            put empty into lvBlockingUrl ##clear
-            return tRetResult  with tRetData
-         else
-            put empty into lvBlockingUrl ##clear
-            return tRetResult with url laData[newUrl]
-         end if
+
+         put laData[newUrl] into tRetData ##swap data before deleting laData
+         delete local laData[newUrl]
+         put empty into lvBlockingUrl ##clear
+         return tRetResult with urlResult tRetData
       else
          return 1
       end if
    else ##blocked by previous request
-      return "error Previous request not completed" with empty
+      return "error Previous request not completed" with urlResult empty
    end if
 end getUrl
 
@@ -250,7 +241,7 @@ on postUrl y,x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of keys(laLoadingUrls) then
-      return "error  URL is currently loading" with empty
+      return "error  URL is currently loading" with urlResult empty
    end if
    if lvBlockingUrl is empty  or lvBlockBypass or lvAuthBlockBypass is true then
       put newUrl into lvBlockingUrl
@@ -273,23 +264,18 @@ on postUrl y,x
          
          put laUrlErrorStatus[newUrl] into tRetResult
          delete local  laUrlErrorStatus[newUrl]
-         if "2.4.1" is in the version then
-            ##for mc 2.4.1 engine only
-            put laData[newUrl] into tRetData
-            delete local laData[newUrl]
-            put empty into lvBlockingUrl ##clear
-            return tRetResult  with tRetData
-         else
-            put empty into lvBlockingUrl ##clear
-            return tRetResult with url laData[newUrl]
-         end if
+
+         put laData[newUrl] into tRetData
+         delete local laData[newUrl]
+         put empty into lvBlockingUrl ##clear
+         return tRetResult with urlResult tRetData
       else
          return 1
       end if
       -----------------------------------
    else ##blocked by previous request
       put "error Previous request not completed" into tRetResult
-      return tRetResult with empty
+      return tRetResult with urlResult empty
    end if
 end postUrl
 
@@ -301,7 +287,7 @@ on putUrl y,x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of keys(laLoadingUrls) then
-      return "error  URL is currently loading" with empty
+      return "error  URL is currently loading" with urlResult empty
    end if
    if lvBlockingUrl is empty  or lvBlockBypass or lvAuthBlockBypass is true then
       put newUrl into lvBlockingUrl
@@ -324,16 +310,11 @@ on putUrl y,x
          
          put laUrlErrorStatus[newUrl] into tRetResult
          delete local  laUrlErrorStatus[newUrl]
-         if "2.4.1" is in the version then
-            ##for mc 2.4.1 engine only
-            put laData[newUrl] into tRetData
-            delete local laData[newUrl]
-            put empty into lvBlockingUrl ##clear
-            return tRetResult  with tRetData
-         else
-            put empty into lvBlockingUrl ##clear
-            return tRetResult with url laData[newUrl]
-         end if
+
+         put laData[newUrl] into tRetData
+         delete local laData[newUrl]
+         put empty into lvBlockingUrl ##clear
+         return tRetResult with urlResult tRetData
       else
          return 1
       end if
@@ -341,7 +322,7 @@ on putUrl y,x
       
    else ##blocked by previous request
       put "error Previous request not completed" into tRetResult
-      return tRetResult with empty
+      return tRetResult with urlResult empty
    end if
 end putUrl
 
@@ -352,7 +333,7 @@ on deleteUrl x
    put false into lvJumpOut
    put ulStripUrl(x) into newUrl
    if newUrl is among the lines of keys(laLoadingUrls) then
-      return "error  URL is currently loading" with empty
+      return "error  URL is currently loading" with urlResult empty
    end if
    if lvBlockingUrl is empty  or lvBlockBypass is true then
       put newUrl into lvBlockingUrl
@@ -369,21 +350,16 @@ on deleteUrl x
       delete local laStatus[newUrl]
       put laUrlErrorStatus[newUrl] into tRetResult
       delete local  laUrlErrorStatus[newUrl]
-      if "2.4.1" is in the version then
-         ##for mc 2.4.1 engine only
-         put laData[newUrl] into tRetData
-         delete local laData[newUrl]
-         put empty into lvBlockingUrl ##clear
-         return tRetResult  with tRetData
-      else
-         put empty into lvBlockingUrl ##clear
-         return tRetResult with url laData[newUrl]
-      end if
+
+      put laData[newUrl] into tRetData
+      delete local laData[newUrl]
+      put empty into lvBlockingUrl ##clear
+      return tRetResult with urlResult tRetData
       -----------------------------------
       
    else ##blocked by previous request
       put "error Previous request not completed" into tRetResult
-      return tRetResult with empty
+      return tRetResult with urlResult empty
    end if
 end deleteUrl
 

--- a/tests/lcs/core/engine/return.livecodescript
+++ b/tests/lcs/core/engine/return.livecodescript
@@ -46,11 +46,11 @@ on TestReturn
 end TestReturn
 
 private command DoReturnValueInCommand pValue
-   return value pValue
+   return pValue for value
 end DoReturnValueInCommand
 
 private function DoReturnValueInFunction pValue
-   return value pValue
+   return pValue for value
 end DoReturnValueInFunction
 
 on TestReturnValue
@@ -70,11 +70,11 @@ on TestReturnValue
 end TestReturnValue
 
 private command DoReturnErrorInCommand pValue
-   return error pValue
+   return pValue for error
 end DoReturnErrorInCommand
 
 private function DoReturnErrorInFunction pValue
-   return error pValue
+   return pValue for error
 end DoReturnErrorInFunction
 
 on TestReturnError

--- a/tests/lcs/core/engine/return.livecodescript
+++ b/tests/lcs/core/engine/return.livecodescript
@@ -1,0 +1,94 @@
+script "CoreEngineReturn"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+private command SetTheResultTo pValue
+   return pValue
+end SetTheResultTo
+
+private command DoReturnInCommand pValue
+   return pValue
+end DoReturnInCommand
+
+private function DoReturnInFunction pValue
+   return pValue
+end DoReturnInFunction
+
+on TestReturn
+   SetTheResultTo empty
+   get "TheIt"
+   DoReturnInCommand "TheResult"
+   TestAssert "return in command leaves it and sets the result", \
+                  it is "TheIt" and \
+                  the result is "TheResult"
+
+   local tFu
+   SetTheResultTo empty
+   get "TheIt"
+   TestAssert "return in function leaves it, sets the result to return value and returns the return value", \
+                  DoReturnInFunction("TheResult") is "TheResult" and \
+                  the result is "TheResult" and \
+                  it is "TheIt"
+end TestReturn
+
+private command DoReturnValueInCommand pValue
+   return value pValue
+end DoReturnValueInCommand
+
+private function DoReturnValueInFunction pValue
+   return value pValue
+end DoReturnValueInFunction
+
+on TestReturnValue
+   SetTheResultTo "TheResult"
+   get empty
+   DoReturnValueInCommand "TheIt"
+   TestAssert "return value in command sets it and clears the result", \
+                  the result is empty and \
+                  it is "TheIt"
+
+   SetTheResultTo "TheResult"
+   get "TheIt"
+   TestAssert "return value in function leaves it, clears the result and returns the return value", \
+                  DoReturnValueInFunction("ReturnValue") is "ReturnValue" and \
+                  the result is empty and \
+                  it is "TheIt"
+end TestReturnValue
+
+private command DoReturnErrorInCommand pValue
+   return error pValue
+end DoReturnErrorInCommand
+
+private function DoReturnErrorInFunction pValue
+   return error pValue
+end DoReturnErrorInFunction
+
+on TestReturnError
+   SetTheResultTo empty
+   get "TheIt"
+   DoReturnErrorInCommand "TheResult"
+   TestAssert "return error in command clears it and sets the result", \
+                  the result is "TheResult" and \
+                  it is empty
+
+   SetTheResultTo empty
+   get "TheIt"
+   TestAssert "return error in function leaves it, sets the result to the return value and returns empty", \
+                  DoReturnErrorInFunction("ReturnValue") is empty and \
+                  the result is "ReturnValue" and \
+                  it is "TheIt"
+end TestReturnError


### PR DESCRIPTION
This patch adds two new forms of the 'return' command:

```
return <value> for value
return <value> for error
```

These forms act slightly differently, depending on whether the handler
calling them is a command or a function handler.

If the handler performing the return is a command handler then:

The 'return for value' form, sets 'it' in the caller to <value> and
sets 'the result' to empty.

The 'return for error' form, sets 'it' in the caller to empty and
sets 'the result' to <value>.

If the handler performingthe return is a function handler then:

The 'return for value' form, returns <value> as the return value of
the function call and sets 'the result' to empty.

The 'return for error' form, returns empty as the return value of
the function call and sets 'the result' to <value>.

These forms of return are designed to be used by script library
functions to allow them to have the same ability as built-in engine
functions and commands - namely the ability to return a value (in it
for commands, or return value for functions) _or_ return a status
(in the result).
