### PR TITLE
[Bug 17373] clock: Make local timezone default & fix setting local tz

### DIFF
--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -42,7 +42,7 @@ metadata version is "1.0.3"
 metadata preferredSize is "76,76"
 metadata svgicon is "M31.7,0C14.2,0,0,14.2,0,31.7s14.2,31.7,31.7,31.7s31.7-14.2,31.7-31.7S49.2,0,31.7,0z M30.2,3.2h2.8v7.3h-2.8V3.2zM10.4,33.1H3.1v-2.8h7.3V33.1z M12.5,52.9l-2-2l5.2-5.2l2,2L12.5,52.9z M15.7,17.7l-5.2-5.2l2-2l5.2,5.2L15.7,17.7z M33.1,60.2h-2.8v-7.3h2.8V60.2z M42.3,45.4L31.8,34.9c0,0-0.1,0-0.1,0c-1.7,0-3-1.3-3-3c0-1.1,0.6-2.1,1.6-2.6V12.9h2.8v16.3c0.9,0.5,1.6,1.5,1.6,2.6c0,0.2,0,0.4-0.1,0.5L45,42.8L42.3,45.4z M50.8,52.9l-5.2-5.2l2-2l5.2,5.2L50.8,52.9z M47.7,17.7l-2-2l5.2-5.2l2,2L47.7,17.7z M52.9,33.1v-2.8h7.3v2.8H52.9z"
 
-metadata timeZone.default is "0"
+metadata timeZone.default is ""
 --
 
 -- property declarations
@@ -335,8 +335,10 @@ private handler getStrokeWidth(in pHand as String) returns Real
 end handler
 
 public handler setTimeZone(in pTimeZone as optional Number) returns nothing
-	if pTimeZone is not the trunc of pTimeZone then
-		throw "The timeZone offset must be an integer"
+	if not (pTimeZone is a number) then
+		if pTimeZone is not nothing then
+			throw "The timeZone offset must be an integer or empty"
+		end if
 	end if
 
 	put pTimeZone into mTimeZone

--- a/extensions/widgets/clock/notes/17373.md
+++ b/extensions/widgets/clock/notes/17373.md
@@ -1,0 +1,1 @@
+# [17373] enable setting local timezone, make local default

--- a/extensions/widgets/clock/tests/properties.livecodescript
+++ b/extensions/widgets/clock/tests/properties.livecodescript
@@ -1,0 +1,40 @@
+script "ClockWidgetProperties"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSetup
+	TestLoadExtension "com.livecode.widget.clock"
+	create widget "testClock" as "com.livecode.widget.clock"
+end TestSetup
+
+on TestTeardown
+	delete widget "testClock"
+end TestTeardown
+
+on TestCreateClock
+	TestAssert "created clock exists", exists(widget "testClock")
+end TestCreateClock
+
+on TestGetDefautTimeZone
+   TestAssert "timeZone on creation is empty, i.e. local time", the timeZone of widget "testClock" is ""
+end TestGetDefautTimeZone
+
+on TestSettingLocalTimeZone
+   set the timeZone of widget "testClock" to 0
+ 	set the timeZone of widget "testClock" to ""
+	TestAssert "timeZone successfully set to local", the timeZone of widget "testClock" is ""
+end TestSettingLocalTimeZone


### PR DESCRIPTION
- Ensure that the clock treats an empty timezone as the local
  timezone
- Change the default clock timezone to local
- Add some basic tests for setting the local timezone
