### PR TITLE
Replace MCObjectHandle with an RAII version

### DIFF
--- a/engine/src/button.h
+++ b/engine/src/button.h
@@ -156,6 +156,9 @@ class MCButton : public MCControl
     bool m_animate_posted : 1;
 
 public:
+    
+    enum { kObjectType = CT_BUTTON };
+    
 	MCButton();
 	MCButton(const MCButton &bref);
 	// virtual functions from MCDLlist

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -531,11 +531,11 @@ bool MCButton::macmenuisopen()
 struct MCMainMenuInfo
 {
 	MCPlatformMenuRef menu;
-	MCObjectHandle *target;
+	MCObjectHandle target;
 };
 
 static MCPlatformMenuRef s_menubar = nil;
-static MCObjectHandle **s_menubar_targets = nil;
+static MCObjectHandle *s_menubar_targets = nil;
 static uindex_t s_menubar_target_count = 0;
 static uindex_t s_menubar_lock_count = 0;
 
@@ -596,7 +596,7 @@ void MCScreenDC::updatemenubar(Boolean force)
 	t_menu_index = 0;
 	
 	// We construct the new menubar as we go along.
-	MCObjectHandle **t_new_menubar_targets;
+	MCObjectHandle *t_new_menubar_targets;
 	uindex_t t_new_menubar_target_count;
 	t_new_menubar_targets = nil;
 	t_new_menubar_target_count = 0;
@@ -645,8 +645,8 @@ void MCScreenDC::updatemenubar(Boolean force)
 		MCPlatformReleaseMenu(t_menu);
 		
 		// Extend the new menubar targets array by one.
-		/* UNCHECKED */ MCMemoryResizeArray(t_new_menubar_target_count + 1, t_new_menubar_targets, t_new_menubar_target_count);
-		t_new_menubar_targets[t_menu_index] = t_menu_button -> gethandle();
+		/* UNCHECKED */ MCMemoryResizeArrayInit(t_new_menubar_target_count + 1, t_new_menubar_targets, t_new_menubar_target_count);
+		t_new_menubar_targets[t_menu_index] = t_menu_button->GetHandle();
 		
 		// Increment the index into the menubar.
 		t_menu_index++;
@@ -656,9 +656,7 @@ void MCScreenDC::updatemenubar(Boolean force)
 	if (s_menubar != nil)
 	{
 		MCPlatformReleaseMenu(s_menubar);
-		for(uindex_t i = 0; i < s_menubar_target_count; i++)
-			s_menubar_targets[i] -> Release();
-		MCMemoryDeleteArray(s_menubar_targets);
+		MCMemoryDeleteArray(s_menubar_targets, s_menubar_target_count);
 	}
 	
 	// Update to the new menubar and targets.
@@ -923,7 +921,7 @@ void MCPlatformHandleMenuUpdate(MCPlatformMenuRef p_menu)
 	// If the button it is 'attached' to still exists, dispatch the menu update
 	// message (currently mouseDown("")). We do this whilst the menubar is locked
 	// from updates as we mustn't fiddle about with it too much in this case!
-	if (t_update_menubar || s_menubar_targets[t_parent_menu_index] -> Exists())
+	if (t_update_menubar || s_menubar_targets[t_parent_menu_index].IsValid())
 	{
         // MW-2014-06-10: [[ Bug 12590 ]] Make sure we lock screen around the menu update message.
         MCRedrawLockScreen();
@@ -940,10 +938,9 @@ void MCPlatformHandleMenuUpdate(MCPlatformMenuRef p_menu)
     // SN-2014-11-10: [[ Bug 13836 ]] Make sure that
 	// Now we've got the menu to update, process the new menu spec, but only if the
 	// menu button still exists!
-	if (!t_update_menubar && s_menubar_targets[t_parent_menu_index] -> Exists())
+	if (!t_update_menubar && s_menubar_targets[t_parent_menu_index].IsValid())
 	{
-		MCButton *t_button;
-		t_button = (MCButton *)s_menubar_targets[t_parent_menu_index] -> Get();
+		MCButton *t_button = s_menubar_targets[t_parent_menu_index].GetAs<MCButton>();
 		
 		MCPlatformRemoveAllMenuItems(p_menu);
 		MCstacks -> deleteaccelerator(t_button, t_button -> getstack());
@@ -995,10 +992,10 @@ void MCPlatformHandleMenuSelect(MCPlatformMenuRef p_menu, uindex_t p_item_index)
 	// will be the current popup menu or icon menu.
 	if (t_current_menu != nil)
 	{
-		if (s_menubar_targets[t_current_menu_index] -> Exists())
+		if (s_menubar_targets[t_current_menu_index].IsValid())
 		{
-			((MCButton *)s_menubar_targets[t_current_menu_index] -> Get()) -> setmenuhistoryprop(t_last_menu_index + 1);
-			((MCButton *)s_menubar_targets[t_current_menu_index] -> Get()) -> handlemenupick(*t_result, nil);
+			s_menubar_targets[t_current_menu_index].GetAs<MCButton>()->setmenuhistoryprop(t_last_menu_index + 1);
+            s_menubar_targets[t_current_menu_index].GetAs<MCButton>()->handlemenupick(*t_result, nil);
 		}
 	}
 	else

--- a/engine/src/exec-context.h
+++ b/engine/src/exec-context.h
@@ -339,7 +339,7 @@ public:
     
     
     // MM-2011-02-16: Added ability to get handle of current object
-    MCObjectHandle *GetObjectHandle(void);
+    MCObjectHandle GetObjectHandle(void);
 	void SetTheResultToEmpty(void);
 	void SetTheResultToValue(MCValueRef p_value);
 	void SetTheResultToStaticCString(const char *p_cstring);

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -3767,10 +3767,10 @@ void MCInterfaceDoRelayer(MCExecContext& ctxt, int p_relation, MCObjectPtr p_sou
 	{
 		// As we call handlers that might invoke messages, we need to take
 		// object handles here.
-		MCObjectHandle *t_source_handle, *t_new_owner_handle, *t_new_target_handle;
-		t_source_handle = p_source . object -> gethandle();
-		t_new_owner_handle = t_new_owner -> gethandle();
-		t_new_target_handle = t_new_target != nil ? t_new_target -> gethandle() : nil;
+		MCObjectHandle t_source_handle, t_new_owner_handle, t_new_target_handle;
+		t_source_handle = p_source . object -> GetHandle();
+		t_new_owner_handle = t_new_owner -> GetHandle();
+		t_new_target_handle = t_new_target != NULL ? t_new_target -> GetHandle() : MCObjectHandle(NULL);
         
 		// Make sure we remove focus from the control.
 		bool t_was_mfocused, t_was_kfocused;
@@ -3783,10 +3783,10 @@ void MCInterfaceDoRelayer(MCExecContext& ctxt, int p_relation, MCObjectPtr p_sou
         
 		// Check the source and new owner objects exist, and if we have a target object
 		// that that exists and is still a child of new owner.
-		if (t_source_handle -> Exists() &&
-			t_new_owner_handle -> Exists() &&
+		if (t_source_handle.IsValid() &&
+			t_new_owner_handle.IsValid() &&
 		    (t_new_target == nil ||
-		     (t_new_target_handle -> Exists() &&
+		     (t_new_target_handle.IsValid() &&
 		      t_new_target -> getparent() == t_new_owner)))
 		{
 			p_source . object -> getparent() -> relayercontrol_remove(static_cast<MCControl *>(p_source . object));
@@ -3806,11 +3806,6 @@ void MCInterfaceDoRelayer(MCExecContext& ctxt, int p_relation, MCObjectPtr p_sou
 			t_card -> kfocus();
 		if (t_was_mfocused)
 			t_card -> mfocus(MCmousex, MCmousey);
-        
-		t_source_handle -> Release();
-		t_new_owner_handle -> Release();
-		if (t_new_target != nil)
-			t_new_target_handle -> Release();
 	}
     
 	if (t_success)

--- a/engine/src/exec-sound.cpp
+++ b/engine/src/exec-sound.cpp
@@ -102,7 +102,7 @@ void MCSoundExecPlaySoundOnChannel(MCExecContext& ctxt, MCStringRef p_channel, M
     bool t_success;
 	t_success = true;
     
-    MCObjectHandle *t_handle;
+    MCObjectHandle t_handle;
     t_handle = nil;
     if (t_success)
         t_handle = ctxt.GetObjectHandle();
@@ -112,8 +112,6 @@ void MCSoundExecPlaySoundOnChannel(MCExecContext& ctxt, MCStringRef p_channel, M
 	if (!t_success)
     {
 		ctxt.SetTheResultToStaticCString("could not play sound");
-        if (t_handle != nil)
-            t_handle->Release();
     }
 }
 

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1217,10 +1217,10 @@ void MCExecContext::UserThrow(MCStringRef p_error)
 	m_stat = ES_ERROR;
 }
 
-MCObjectHandle *MCExecContext::GetObjectHandle(void) const
+MCObjectHandle MCExecContext::GetObjectHandle(void) const
 {
     extern MCExecContext *MCECptr;
-	return MCECptr->GetObject()->gethandle();
+	return MCECptr->GetObject()->GetHandle();
 }
 
 Exec_stat MCExecContext::Catch(uint2 p_line, uint2 p_pos)

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1687,7 +1687,7 @@ public:
 	}
     
     // MM-2011-02-16: Added ability to get handle of current object
-    MCObjectHandle *GetObjectHandle(void) const;
+    MCObjectHandle GetObjectHandle(void) const;
 	void SetTheResultToEmpty(void);
 	void SetTheResultToValue(MCValueRef p_value);
 	void SetTheResultToStaticCString(const char *p_cstring);

--- a/engine/src/externalv1.h
+++ b/engine/src/externalv1.h
@@ -47,7 +47,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef class MCExternalVariable *MCExternalVariableRef;
-typedef MCObjectHandle *MCExternalObjectRef;
+typedef MCObjectProxy* MCExternalObjectRef;
 
 typedef void *MCExternalVariableIteratorRef;
 typedef uint32_t MCExternalValueOptions;

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -264,6 +264,8 @@ class MCField : public MCControl
 	static MCObjectPropertyTable kPropertyTable;
 public:
 
+    enum { kObjectType = CT_FIELD };
+    
     // SN-2014-11-04: [[ Bug 13934 ]] Refactor the laying out the field when setting properties
     friend MCParagraph* PrepareLayoutSettings(bool all, MCField *p_field, uint32_t p_part_id, findex_t &si, findex_t &ei, MCFieldLayoutSettings &r_layout_settings);
     // SN-2014-12-18: [[ Bug 14161 ]] Add a parameter to force the re-layout of a paragraph

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -297,7 +297,7 @@ public:
 	MCImageNeed *GetNext();
 
 private:
-	MCObjectHandle *m_object;
+	MCObjectHandle m_object;
 	MCImageNeed *m_prev;
 	MCImageNeed *m_next;
 };

--- a/engine/src/internal_development.cpp
+++ b/engine/src/internal_development.cpp
@@ -350,13 +350,13 @@ private:
 
 struct MCObjectListenerTarget
 {
-	MCObjectHandle *target;
+	MCObjectHandle target;
 	MCObjectListenerTarget *next;
 };
 
 struct MCObjectListener
 {
-	MCObjectHandle *object;
+	MCObjectHandle object;
 	MCObjectListenerTarget *targets;
 	MCObjectListener *next;
 	double last_update_time;
@@ -393,7 +393,7 @@ static void prune_object_listeners()
         t_next_target = nil;
         
         bool t_listener_exists;
-        t_listener_exists = t_listener -> object -> Exists();
+        t_listener_exists = t_listener -> object . IsValid();
         
         // Check all the listener's targets to see if they can be pruned
         while (t_target != nil)
@@ -403,19 +403,17 @@ static void prune_object_listeners()
             // Prune target from listener target list if listener
             // doesn't exist, or if target doesn't exist, or if target
             // has been set to nil.
-            if (!t_listener_exists || t_target -> target == nil
-                || !t_target -> target -> Exists())
+            if (!t_listener_exists || !t_target->target.IsValid())
             {
                 // Release the target if it hasn't already been released
-                if (t_target -> target != nil)
-                    t_target -> target -> Release();
+                t_target->target = nil;
                 
                 if (t_prev_target != nil)
                     t_prev_target -> next = t_next_target;
                 else
                     t_listener -> targets = t_next_target;
                 
-                MCMemoryDelete(t_target);
+                MCMemoryDestroy(t_target);
             }
             else
             {
@@ -429,14 +427,14 @@ static void prune_object_listeners()
         // listener targets is nil, then prune from listener list.
         if (!t_listener_exists || t_listener -> targets == nil)
         {
-            t_listener -> object -> Release();
+            t_listener -> object = nil;
             
             if (t_prev_listener != nil)
                 t_prev_listener -> next = t_next_listener;
             else
                 s_object_listeners = t_next_listener;
             
-            MCMemoryDelete(t_listener);
+            MCMemoryDestroy(t_listener);
         }
         else
         {
@@ -469,19 +467,19 @@ void MCInternalObjectListenerMessagePendingListeners(void)
 		t_listener = s_object_listeners;
 		while(t_listener != nil)
 		{
-			if (!t_listener -> object -> Exists())
+			if (!t_listener -> object.IsValid())
             {
                 t_changed = true;
             }
 			else
 			{
 				uint8_t t_properties_changed;
-				t_properties_changed = t_listener -> object -> Get() -> propertieschanged();
+				t_properties_changed = t_listener -> object -> propertieschanged();
 				if (t_properties_changed != kMCPropertyChangedMessageTypeNone)
                 {
                     MCExecContext ctxt(nil, nil, nil);
 					MCAutoStringRef t_string;
-					t_listener -> object -> Get() -> getstringprop(ctxt, 0, P_LONG_ID, False, &t_string);			
+					t_listener -> object -> getstringprop(ctxt, 0, P_LONG_ID, False, &t_string);
 					MCObjectListenerTarget *t_target;
 					t_target = nil;
 					MCObjectListenerTarget *t_prev_target;
@@ -496,52 +494,51 @@ void MCInternalObjectListenerMessagePendingListeners(void)
                         
 						while (t_target != nil)
 						{
-                            MCObjectHandle *t_obj;
-                            t_obj = t_target -> target;
+                            MCObjectHandle t_obj = t_target -> target;
                             
                             bool t_target_exists;
-                            t_target_exists = t_obj != nil && t_obj -> Exists();
+                            t_target_exists = t_obj.IsValid();
                             
                             // Make sure the target object still exists and is still
                             // being listened to before sending any messages.
                             if (t_target_exists
                                 && t_properties_changed & kMCPropertyChangedMessageTypePropertyChanged)
                             {
-                                t_obj -> Get() -> message_with_valueref_args(MCM_property_changed, *t_string);
+                                t_obj -> message_with_valueref_args(MCM_property_changed, *t_string);
                                 t_obj = t_target -> target;
-                                t_target_exists = t_obj != nil && t_obj -> Exists();
+                                t_target_exists = t_obj.IsValid();
                             }
                             
                             if (t_target_exists
                                 && t_properties_changed & kMCPropertyChangedMessageTypeResizeControlStarted)
                             {
-                                t_obj -> Get() -> message_with_valueref_args(MCM_resize_control_started, *t_string);
+                                t_obj -> message_with_valueref_args(MCM_resize_control_started, *t_string);
                                 t_obj = t_target -> target;
-                                t_target_exists = t_obj != nil && t_obj -> Exists();
+                                t_target_exists = t_obj.IsValid();
                             }
                                 
                             if (t_target_exists
                                 && t_properties_changed & kMCPropertyChangedMessageTypeResizeControlEnded)
                             {
-                                t_obj -> Get() -> message_with_valueref_args(MCM_resize_control_ended, *t_string);
+                                t_obj -> message_with_valueref_args(MCM_resize_control_ended, *t_string);
                                 t_obj = t_target -> target;
-                                t_target_exists = t_obj != nil && t_obj -> Exists();
+                                t_target_exists = t_obj.IsValid();
                             }
                                 
                             if (t_target_exists
                                 && t_properties_changed & kMCPropertyChangedMessageTypeGradientEditStarted)
                             {
-                                t_obj -> Get() -> message_with_valueref_args(MCM_gradient_edit_started, *t_string);
+                                t_obj -> message_with_valueref_args(MCM_gradient_edit_started, *t_string);
                                 t_obj = t_target -> target;
-                                t_target_exists = t_obj != nil && t_obj -> Exists();
+                                t_target_exists = t_obj.IsValid();
                             }
                                 
                             if (t_target_exists
                                 && t_properties_changed & kMCPropertyChangedMessageTypeGradientEditEnded)
                             {
-                                t_obj -> Get() -> message_with_valueref_args(MCM_gradient_edit_ended, *t_string);
+                                t_obj -> message_with_valueref_args(MCM_gradient_edit_ended, *t_string);
                                 t_obj = t_target -> target;
-                                t_target_exists = t_obj != nil && t_obj -> Exists();
+                                t_target_exists = t_obj.IsValid();
                             }
                             
                             if (!t_target_exists)
@@ -554,7 +551,7 @@ void MCInternalObjectListenerMessagePendingListeners(void)
 						}
 					}
 					else
-						t_listener -> object -> Get() -> signallistenerswithmessage(t_properties_changed);
+						t_listener -> object -> signallistenerswithmessage(t_properties_changed);
 				}
 				
 				t_prev_listener = t_listener;
@@ -573,8 +570,8 @@ void MCInternalObjectListenerGetListeners(MCExecContext& ctxt, MCStringRef*& r_l
 {
     prune_object_listeners();
 	
-    MCObjectHandle *t_current_object;
-	t_current_object = ctxt . GetObject() -> gethandle();
+    MCObjectHandle t_current_object;
+	t_current_object = ctxt . GetObject() -> GetHandle();
 	
 	MCObjectListener *t_prev_listener;
 	t_prev_listener = nil;
@@ -592,14 +589,14 @@ void MCInternalObjectListenerGetListeners(MCExecContext& ctxt, MCStringRef*& r_l
         MCObjectListenerTarget *t_prev_target;
         t_prev_target = nil;
         
-        if (t_listener -> object -> Exists())
+        if (t_listener -> object . IsValid())
         {
             MCAutoValueRef t_long_id;
-            t_listener -> object -> Get() -> names(P_LONG_ID, &t_long_id);
+            t_listener -> object -> names(P_LONG_ID, &t_long_id);
         
             for (t_target = t_listener -> targets; t_target != nil; t_target = t_target -> next)
             {
-                if (t_target -> target ==  t_current_object)
+                if (t_target -> target == t_current_object)
                 {
                     ctxt . ConvertToString(*t_long_id, t_string);
                     t_listeners . Push(t_string);
@@ -658,8 +655,8 @@ public:
 		MCObjectListener *t_listener;
 		t_listener = nil;
 		
-		MCObjectHandle *t_object_handle;
-		t_object_handle = t_object -> gethandle();
+		MCObjectHandle t_object_handle;
+		t_object_handle = t_object -> GetHandle();
 		
 		for (t_listener = s_object_listeners; t_listener != nil; t_listener = t_listener -> next)
 		{
@@ -669,14 +666,13 @@ public:
 			
 		if (t_listener == nil)
 		{
-			if (!MCMemoryNew(t_listener))
+			if (!MCMemoryCreate(t_listener))
 			{
                 ctxt . LegacyThrow(EE_NO_MEMORY);
                 return;
 			}
 			t_object -> listen();
 			t_listener -> object = t_object_handle;
-			t_listener -> object -> Retain();
 			t_listener -> targets = nil;
 			t_listener -> next = s_object_listeners;
 			t_listener -> last_update_time = 0.0;
@@ -686,7 +682,7 @@ public:
 		MCObjectListenerTarget *t_target;
 		t_target = nil;
 		
-		MCObjectHandle *t_target_object;
+		MCObjectHandle t_target_object;
         t_target_object = ctxt . GetObjectHandle();
 		
 		for (t_target = t_listener -> targets; t_target != nil; t_target = t_target -> next)
@@ -697,13 +693,12 @@ public:
 		
 		if (t_target == nil)
 		{
-			if (!MCMemoryNew(t_target))
+			if (!MCMemoryCreate(t_target))
 			{
                 ctxt . LegacyThrow(EE_NO_MEMORY);
                 return;
 			}
 			t_target -> target = t_target_object;
-			t_target -> target -> Retain();
 			t_target -> next = t_listener -> targets;
 			t_listener -> targets = t_target;						
         }
@@ -765,8 +760,8 @@ public:
 		MCObjectListener *t_listener;
 		t_listener = nil;
 		
-		MCObjectHandle *t_object_handle;
-		t_object_handle = t_object -> gethandle();
+		MCObjectHandle t_object_handle;
+		t_object_handle = t_object -> GetHandle();
 		
 		for (t_listener = s_object_listeners; t_listener != nil; t_listener = t_listener -> next)
 		{
@@ -782,7 +777,7 @@ public:
 			MCObjectListenerTarget *t_prev_target;
 			t_prev_target = nil;
 			
-			MCObjectHandle *t_target_object;
+			MCObjectHandle t_target_object;
             t_target_object = ctxt . GetObjectHandle();
 			
             bool t_changed;
@@ -791,7 +786,6 @@ public:
 			{
 				if (t_target -> target == t_target_object)
 				{
-                    t_target -> target -> Release();
                     t_target -> target = nil;
                     t_changed = true;
                     break;

--- a/engine/src/iutil.cpp
+++ b/engine/src/iutil.cpp
@@ -70,15 +70,15 @@ void MCImage::shutdown()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCImageNeed::MCImageNeed(MCObject *p_object)
+MCImageNeed::MCImageNeed(MCObject *p_object) :
+  m_object(p_object->GetHandle()),
+  m_prev(nil),
+  m_next(nil)
 {
-	m_object = p_object->gethandle();
-	m_next = m_prev = nil;
 }
 
 MCImageNeed::~MCImageNeed()
 {
-	m_object->Release();
 }
 
 void MCImageNeed::Add(MCImageNeed *&x_head)
@@ -105,7 +105,10 @@ void MCImageNeed::Remove(MCImageNeed *&x_head)
 
 MCObject *MCImageNeed::GetObject()
 {
-	return m_object->Get();
+	if (m_object.IsValid())
+        return m_object;
+    else
+        return nil;
 }
 
 MCImageNeed *MCImageNeed::GetNext()

--- a/engine/src/mblad.cpp
+++ b/engine/src/mblad.cpp
@@ -170,23 +170,22 @@ public:
         }
         else
         {
-        MCObjectHandle *t_object;
-        t_object = m_target->GetOwner();
-        if (t_object != nil && t_object->Exists())
+        MCObjectHandle t_object = m_target->GetOwner();
+        if (t_object.IsValid())
         {
             switch(m_event)
             {
                 case kMCAdEventTypeReceive:
-                    t_object->Get()->message_with_valueref_args(MCM_ad_loaded, m_target->GetName(), kMCFalse);
+                    t_object->message_with_valueref_args(MCM_ad_loaded, m_target->GetName(), kMCFalse);
                     break;
                 case kMCAdEventTypeReceiveDefault:
-                    t_object->Get()->message_with_valueref_args(MCM_ad_loaded, m_target->GetName(), kMCTrue);
+                    t_object->message_with_valueref_args(MCM_ad_loaded, m_target->GetName(), kMCTrue);
                     break;
                 case kMCAdEventTypeReceiveFailed:
-                    t_object->Get()->message_with_valueref_args(MCM_ad_load_failed, m_target->GetName());
+                    t_object->message_with_valueref_args(MCM_ad_load_failed, m_target->GetName());
                     break;
                 case kMCAdEventTypeClick:
-                    t_object->Get()->message_with_valueref_args(MCM_ad_clicked, m_target->GetName());
+                    t_object->message_with_valueref_args(MCM_ad_clicked, m_target->GetName());
                     break;
             }
         }
@@ -208,23 +207,17 @@ void MCAdPostMessage(MCAd *p_ad, MCAdEventType p_type)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCAd::MCAd(void)
+MCAd::MCAd(void) :
+  m_references(1),
+  m_id(++s_last_ad_id),
+  m_name(MCValueRetain(kMCEmptyString)),
+  m_object(nil),
+  m_next(nil)
 {
-	m_references = 1;
-	m_id = ++s_last_ad_id;
-	m_name = MCValueRetain(kMCEmptyString);
-	m_object = nil;
-	m_next = nil;
 }
 
 MCAd::~MCAd(void)
 {
-	if (m_object != nil)
-	{
-		m_object -> Release();
-		m_object = nil;
-	}
-	
 	MCValueRelease(m_name);
     
 	if (s_ads == this)
@@ -263,15 +256,13 @@ MCStringRef MCAd::GetName()
 	return m_name;
 }
 
-MCObjectHandle *MCAd::GetOwner(void)
+MCObjectHandle MCAd::GetOwner(void)
 {
 	return m_object;
 }
 
-void MCAd::SetOwner(MCObjectHandle *p_owner)
+void MCAd::SetOwner(MCObjectHandle p_owner)
 {
-	if (m_object != nil)
-		m_object -> Release();
 	m_object = p_owner;
 }
 

--- a/engine/src/mblad.h
+++ b/engine/src/mblad.h
@@ -56,10 +56,10 @@ public:
 	bool SetName(MCStringRef name);
 	
 	// Get the owning object of the instance
-	MCObjectHandle *GetOwner(void);
+	MCObjectHandle GetOwner(void);
 	
 	// Set the owning object of the instance
-	void SetOwner(MCObjectHandle *owner);
+	void SetOwner(MCObjectHandle owner);
         
     // Return a pointer to the next ad
     MCAd *GetNext();
@@ -100,7 +100,7 @@ private:
 	// The name of the instance
 	MCStringRef m_name;
 	// The instance's owning object (handle)
-	MCObjectHandle *m_object;
+	MCObjectHandle m_object;
 };
 
 void MCAdInitialize(void);

--- a/engine/src/mblandroidmisc.cpp
+++ b/engine/src/mblandroidmisc.cpp
@@ -75,15 +75,15 @@ class MCMessageEvent : public MCCustomEvent
 {
 public:
 	template <class C>
-	static MCMessageEvent* create(MCObjectHandle *p_object, const char *p_message)
+	static MCMessageEvent* create(MCObjectHandle p_object, const char *p_message)
 	{
 		C *t_event = nil;
-		if (!MCMemoryNew(t_event))
+		if (!MCMemoryCreate(t_event))
 			return nil;
 
 		if (!t_event->setMessage(p_message))
 		{
-			MCMemoryDelete(t_event);
+			MCMemoryDestroy(t_event);
 			return nil;
 		}
 
@@ -92,7 +92,7 @@ public:
 		return t_event;
 	}
     
-    static MCMessageEvent* create(MCObjectHandle *p_object, const char *p_message)
+    static MCMessageEvent* create(MCObjectHandle p_object, const char *p_message)
     {
         return create<MCMessageEvent>(p_object, p_message);
     }
@@ -100,33 +100,28 @@ public:
 	void Dispatch(void)
 	{
         //MCLog("dispatch message \"%@\"", MCNameGetString(m_message));
-		MCObject *t_object;
-		t_object = m_object -> Get();
-		if (t_object != nil)
-			t_object -> message(m_message);
+		if (m_object.IsValid())
+			m_object -> message(m_message);
 	}
 
 	void Destroy(void)
 	{
 		MCNameDelete(m_message);
-		if (m_object != nil)
-			m_object->Release();
 		delete this;
 	}
 
 protected:
 	MCNameRef m_message;
-	MCObjectHandle *m_object;
+	MCObjectHandle m_object;
 
 	bool setMessage(const char *p_message)
 	{
 		return MCNameCreateWithCString(p_message, m_message);
 	}
 
-	bool setObject(MCObjectHandle *p_object)
+	bool setObject(MCObjectHandle p_object)
 	{
 		m_object = p_object;
-		m_object->Retain();
 		return true;
 	}
 };
@@ -462,11 +457,9 @@ public:
 	void Dispatch()
 	{
 		//MCLog("dispatching backPressed event", nil);
-		MCObject *t_object;
-		t_object = m_object -> Get();
-		if (t_object != nil)
+		if (m_object.IsValid())
 		{
-			Exec_stat t_stat = t_object -> message(m_message);
+			Exec_stat t_stat = m_object -> message(m_message);
 			//MCLog("message result: %d", t_stat);
 			if (ES_PASS == t_stat || ES_NOT_HANDLED == t_stat)
 			{
@@ -480,20 +473,18 @@ public:
 void MCAndroidBackPressed()
 {
 	MCMessageEvent *t_event;
-	MCObjectHandle *t_handle;
-	t_handle = MCdefaultstackptr->getcurcard()->gethandle();
+	MCObjectHandle t_handle;
+	t_handle = MCdefaultstackptr->getcurcard()->GetHandle();
 	t_event = MCMessageEvent::create<MCBackPressedEvent>(t_handle, "backKey");
-	t_handle->Release();
 	MCEventQueuePostCustom(t_event);
 }
 
 void MCAndroidMenuKey()
 {
     MCMessageEvent *t_event;
-    MCObjectHandle *t_handle;
-    t_handle = MCdefaultstackptr->getcurcard()->gethandle();
+    MCObjectHandle t_handle;
+    t_handle = MCdefaultstackptr->getcurcard()->GetHandle();
     t_event = MCMessageEvent::create(t_handle, "menuKey");
-    t_handle->Release();
     MCEventQueuePostCustom(t_event);
 }
 
@@ -501,10 +492,9 @@ void MCAndroidSearchKey()
 {
     //MCLog("MCAndroidSearchKey()", nil);
     MCMessageEvent *t_event;
-    MCObjectHandle *t_handle;
-    t_handle = MCdefaultstackptr->getcurcard()->gethandle();
+    MCObjectHandle t_handle;
+    t_handle = MCdefaultstackptr->getcurcard()->GetHandle();
     t_event = MCMessageEvent::create(t_handle, "searchKey");
-    t_handle->Release();
     MCEventQueuePostCustom(t_event);
 }
 

--- a/engine/src/mblandroidsound.cpp
+++ b/engine/src/mblandroidsound.cpp
@@ -99,7 +99,7 @@ void MCSystemGetPlayingSound(MCStringRef &r_sound)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCSystemPlaySoundOnChannel(MCStringRef p_channel, MCStringRef p_file, MCSoundChannelPlayType p_type, MCObjectHandle *p_object)
+bool MCSystemPlaySoundOnChannel(MCStringRef p_channel, MCStringRef p_file, MCSoundChannelPlayType p_type, MCObjectHandle p_object)
 {
     bool t_success;
     t_success = true;
@@ -109,12 +109,15 @@ bool MCSystemPlaySoundOnChannel(MCStringRef p_channel, MCStringRef p_file, MCSou
     if (t_success)
         t_success = MCS_resolvepath(p_file, &t_resolved);
     
+    // Retain a reference to the object on behalf of the Java code
+    MCObjectProxy* t_proxy = p_object.ExternalRetain();
+    
     MCAutoStringRef t_apk_file;
     if (t_success)
         if (path_to_apk_path(*t_resolved, &t_apk_file))
-            MCAndroidEngineRemoteCall("playSoundOnChannel", "bxxxibj", &t_success, p_channel, *t_apk_file, p_file, (int32_t) p_type, true, (long) p_object);
+            MCAndroidEngineRemoteCall("playSoundOnChannel", "bxxxibj", &t_success, p_channel, *t_apk_file, p_file, (int32_t) p_type, true, long(t_proxy));
         else
-            MCAndroidEngineRemoteCall("playSoundOnChannel", "bxxxibj", &t_success, p_channel, *t_resolved, p_file, (int32_t) p_type, false, (long) p_object);
+            MCAndroidEngineRemoteCall("playSoundOnChannel", "bxxxibj", &t_success, p_channel, *t_resolved, p_file, (int32_t) p_type, false, long(t_proxy));
     
     return t_success;
 }
@@ -221,26 +224,31 @@ bool MCSystemSetAudioCategory(intenum_t p_category)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern void MCSoundPostSoundFinishedOnChannelMessage(MCStringRef p_channel, MCStringRef p_sound, MCObjectHandle *p_object);
+extern void MCSoundPostSoundFinishedOnChannelMessage(MCStringRef p_channel, MCStringRef p_sound, MCObjectHandle p_object);
 
 extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_SoundModule_doSoundFinishedOnChannel(JNIEnv *env, jobject object, jstring channel, jstring sound, jlong object_handle) __attribute__((visibility("default")));
 
-JNIEXPORT void JNICALL Java_com_runrev_android_SoundModule_doSoundFinishedOnChannel(JNIEnv *env, jobject object, jstring channel, jstring sound, jlong object_handle)
+JNIEXPORT void JNICALL Java_com_runrev_android_SoundModule_doSoundFinishedOnChannel(JNIEnv *env, jobject object, jstring channel, jstring sound, jlong object_proxy)
 {
 	MCAutoStringRef t_channel;
 	MCAutoStringRef t_sound;
 	/* UNCHECKED */ MCJavaStringToStringRef(env, channel, &t_channel);
 	/* UNCHECKED */ MCJavaStringToStringRef(env, sound, &t_sound);
 	
-    MCSoundPostSoundFinishedOnChannelMessage(*t_channel, *t_sound, (MCObjectHandle*) object_handle);
+    // Convert to an object handle and release the reference that was retained
+    // on behalf of the Java world.
+    MCObjectHandle t_object_handle = reinterpret_cast<MCObjectProxy*> (object_proxy);
+    t_object_handle.ExternalRelease();
+    
+    MCSoundPostSoundFinishedOnChannelMessage(*t_channel, *t_sound, t_object_handle);
 }
 
 extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_SoundModule_doSoundReleaseCallbackHandle(JNIEnv *env, jobject object, jlong object_handle) __attribute__((visibility("default")));
 
-JNIEXPORT void JNICALL Java_com_runrev_android_SoundModule_doSoundReleaseCallbackHandle(JNIEnv *env, jobject object, jlong object_handle)
+JNIEXPORT void JNICALL Java_com_runrev_android_SoundModule_doSoundReleaseCallbackHandle(JNIEnv *env, jobject object, jlong object_proxy)
 {    
-    MCObjectHandle* t_object = (MCObjectHandle*) object_handle;
-    t_object->Release();
+    MCObjectHandle t_object = reinterpret_cast<MCObjectProxy*> (object_proxy);
+    t_object.ExternalRelease();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mblcontrol.cpp
+++ b/engine/src/mblcontrol.cpp
@@ -92,24 +92,18 @@ void MCNativeControlFinalize(void)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MCNativeControl::MCNativeControl(void)
+MCNativeControl::MCNativeControl(void) :
+  m_references(1),
+  m_id(++s_last_native_control_id),
+  m_name(MCValueRetain(kMCEmptyString)),
+  m_object(nil),
+  m_next(nil),
+  m_deleted(false)
 {
-	m_references = 1;
-	m_id = ++s_last_native_control_id;
-	m_name = MCValueRetain(kMCEmptyString);
-	m_object = nil;
-	m_next = nil;
-    m_deleted = false;
 }
 
 MCNativeControl::~MCNativeControl(void)
 {
-	if (m_object != nil)
-	{
-		m_object -> Release();
-		m_object = nil;
-	}
-	
 	if (!MCStringIsEmpty(m_name))
 	{
 		MCValueRelease(m_name);
@@ -156,14 +150,12 @@ void MCNativeControl::GetName(MCStringRef &r_name)
 
 MCObject *MCNativeControl::GetOwner(void)
 {
-	return m_object != nil ? m_object -> Get() : nil;
+	return m_object.IsValid() ? m_object.Get() : nil;
 }
 
 void MCNativeControl::SetOwner(MCObject *p_owner)
 {
-	if (m_object != nil)
-		m_object -> Release();
-	m_object = p_owner -> gethandle();
+	m_object = p_owner->GetHandle();
 }
 
 bool MCNativeControl::SetName(MCStringRef p_name)

--- a/engine/src/mblcontrol.h
+++ b/engine/src/mblcontrol.h
@@ -510,7 +510,7 @@ private:
 	// The name of the instance
 	MCStringRef m_name;
 	// The instance's owning object (handle)
-	MCObjectHandle *m_object;    
+	MCObjectHandle m_object;
 };
 
 void MCNativeControlInitialize(void);

--- a/engine/src/mblevent.h
+++ b/engine/src/mblevent.h
@@ -22,30 +22,28 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 class MCMovieTouchedEvent: public MCCustomEvent
 {
 public:
-	MCMovieTouchedEvent(MCObject *p_object)
+	MCMovieTouchedEvent(MCObject *p_object) :
+      m_object(p_object->GetHandle())
 	{
-		m_object = p_object -> gethandle();
 	}
     
     virtual ~MCMovieTouchedEvent()
     {
-        ;
     }
 	
 	void Destroy(void)
 	{
-		m_object -> Release();
 		delete this;
 	}
 	
 	void Dispatch(void)
 	{
-		if (m_object -> Exists())
-			m_object -> Get() -> message(MCM_movie_touched);
+		if (m_object.IsValid())
+			m_object->message(MCM_movie_touched);
 	}
 	
 private:
-	MCObjectHandle *m_object;
+	MCObjectHandle m_object;
 };
 
 #endif // MBLEVENTS_H

--- a/engine/src/mblsound.cpp
+++ b/engine/src/mblsound.cpp
@@ -42,19 +42,17 @@ bool MCParseParameters(MCParameter*& p_parameters, const char *p_format, ...);
 class MCSoundFinishedOnChannelEvent: public MCCustomEvent
 {
 public:
-	MCSoundFinishedOnChannelEvent(MCObjectHandle *p_object, MCStringRef p_channel, MCStringRef p_sound)
+	MCSoundFinishedOnChannelEvent(MCObjectHandle p_object, MCStringRef p_channel, MCStringRef p_sound)
 	{
 		m_object = nil;
 		m_channel = MCValueRetain(p_channel);
 		m_sound = MCValueRetain(p_sound);
 		
 		m_object = p_object;
-		m_object -> Retain();
 	}
 	
 	void Destroy(void)
 	{
-		m_object -> Release();
 		MCValueRelease(m_channel);
 		MCValueRelease(m_sound);
 		delete this;
@@ -62,17 +60,17 @@ public:
 	
 	void Dispatch(void)
 	{
-		if (m_object -> Exists())
-			m_object -> Get() -> message_with_valueref_args(MCM_sound_finished_on_channel, m_channel, m_sound);
+		if (m_object.IsValid())
+			m_object->message_with_valueref_args(MCM_sound_finished_on_channel, m_channel, m_sound);
 	}
 	
 private:
-	MCObjectHandle *m_object;
+	MCObjectHandle m_object;
 	MCStringRef m_channel;
 	MCStringRef m_sound;
 };
 
-void MCSoundPostSoundFinishedOnChannelMessage(MCStringRef p_channel, MCStringRef p_sound, MCObjectHandle *p_object)
+void MCSoundPostSoundFinishedOnChannelMessage(MCStringRef p_channel, MCStringRef p_sound, MCObjectHandle p_object)
 {
     MCCustomEvent *t_event = nil;
     t_event = new MCSoundFinishedOnChannelEvent(p_object, p_channel, p_sound);

--- a/engine/src/mblsyntax.h
+++ b/engine/src/mblsyntax.h
@@ -228,7 +228,7 @@ enum MCSoundAudioCategory
 
 bool MCSystemSoundInitialize();
 bool MCSystemSoundFinalize();
-bool MCSystemPlaySoundOnChannel(MCStringRef p_channel, MCStringRef p_file, MCSoundChannelPlayType p_type, MCObjectHandle *p_object);
+bool MCSystemPlaySoundOnChannel(MCStringRef p_channel, MCStringRef p_file, MCSoundChannelPlayType p_type, MCObjectHandle p_object);
 bool MCSystemStopSoundChannel(MCStringRef p_channel);
 bool MCSystemPauseSoundChannel(MCStringRef p_channel);
 bool MCSystemResumeSoundChannel(MCStringRef p_channel);

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -366,4 +366,17 @@ public:
     void SetColorOverlayProperty(MCExecContext& ctxt, MCNameRef index, MCExecValue p_value);
 
 };
+
+
+// MCControl has lots of derived classes so this (fragile!) specialisation is
+// needed to account for them.
+template <>
+inline MCControl* MCObjectCast<MCControl>(MCObject* p_object)
+{
+    Chunk_term t_type = p_object->gettype();
+    MCAssert(t_type != CT_UNDEFINED && t_type != CT_STACK && t_type != CT_CARD);
+    return static_cast<MCControl*> (p_object);
+}
+
+
 #endif

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -618,7 +618,7 @@ public:
 		if (s_payload_minizip != nil)
 		{
 			ExtractContext t_context;
-			t_context . target = MCtargetptr . object -> gethandle();
+			t_context . target = MCtargetptr . object -> GetHandle();
 			t_context . name = *t_item;
             t_context . var = ctxt . GetIt() -> evalvar(ctxt);
 			t_context . stream = nil;
@@ -639,8 +639,6 @@ public:
 			
 			if (t_context . stream != nil)
 				MCS_close(t_context . stream);
-
-			t_context . target -> Release();
 		}
 		else
 			ctxt . SetTheResultToCString("payload not open");
@@ -649,7 +647,7 @@ public:
 private:
 	struct ExtractContext
 	{
-		MCObjectHandle *target;
+		MCObjectHandle target;
 		MCStringRef name;
 		IO_handle stream;
 		MCVariable *var;
@@ -680,10 +678,8 @@ private:
             context -> var ->setvalueref(t_value);
 			MCValueRelease(t_value);
 		}
-
-		MCObject *t_target;
-		t_target = context -> target -> Get();
-		if (t_target != nil)
+        
+		if (context->target.IsValid())
 		{
 			MCParameter p1, p2, p3;
 			p1 . setnext(&p2);
@@ -694,7 +690,7 @@ private:
 
 			MCAutoNameRef t_message_name;
 			/* UNCHECKED */ t_message_name . CreateWithCString("payloadProgress");
-			t_target -> message(t_message_name, &p1);
+			context->target->message(t_message_name, &p1);
 		}
 
 		return true;

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -45,7 +45,7 @@ typedef struct __MCScriptObject *MCScriptObjectRef;
 
 struct __MCScriptObjectImpl
 {
-    MCObjectHandle *handle;
+    MCObjectHandle handle;
     uint32_t part_id;
 };
 
@@ -70,7 +70,7 @@ bool MCEngineScriptObjectCreate(MCObject *p_object, uint32_t p_part_id, MCScript
     
     __MCScriptObjectImpl *t_script_object_imp;
     t_script_object_imp = (__MCScriptObjectImpl *)MCValueGetExtraBytesPtr(t_script_object);
-    t_script_object_imp -> handle = p_object != nil ? p_object -> gethandle() : nil;
+    t_script_object_imp -> handle = p_object != nil ? p_object -> GetHandle() : MCObjectHandle(nil);
     t_script_object_imp -> part_id = p_part_id;
     
     r_script_object = t_script_object;
@@ -175,10 +175,7 @@ extern "C" MC_DLLEXPORT_DEF void MCEngineEvalScriptObjectExists(MCScriptObjectRe
     __MCScriptObjectImpl *t_script_object_imp;
     t_script_object_imp = (__MCScriptObjectImpl *)MCValueGetExtraBytesPtr(p_object);
     
-    if (t_script_object_imp -> handle != nil)
-        r_exists = t_script_object_imp -> handle -> Exists();
-    else
-        r_exists = false;
+    r_exists = t_script_object_imp->handle.IsValid();
 }
 
 extern "C" MC_DLLEXPORT_DEF void MCEngineEvalScriptObjectDoesNotExist(MCScriptObjectRef p_object, bool& r_not_exists)
@@ -210,13 +207,12 @@ static inline bool MCEngineEvalObjectOfScriptObject(MCScriptObjectRef p_object, 
 {
 	__MCScriptObjectImpl *t_script_object_imp;
 	t_script_object_imp = (__MCScriptObjectImpl *)MCValueGetExtraBytesPtr(p_object);
-	if (t_script_object_imp -> handle == nil ||
-		!t_script_object_imp -> handle -> Exists())
+	if (!t_script_object_imp->handle.IsValid())
 	{
 		return MCEngineThrowScripObjectDoesNotExistError();
 	}
 	
-	r_object = t_script_object_imp->handle->Get();
+	r_object = t_script_object_imp->handle;
 	r_part_id = t_script_object_imp->part_id;
 	return true;
 }
@@ -584,8 +580,7 @@ static void __MCScriptObjectDestroy(MCValueRef p_value)
     __MCScriptObjectImpl *self;
     self = (__MCScriptObjectImpl *)MCValueGetExtraBytesPtr(p_value);
     
-    if (self -> handle != nil)
-        self -> handle -> Release();
+    self->~__MCScriptObjectImpl();
 }
 
 static bool __MCScriptObjectCopy(MCValueRef p_value, bool p_release, MCValueRef& r_copy)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -5333,9 +5333,9 @@ void MCObjectProxy::Release()
 {
     // Sanity check to prevent over-releases (which implies a bug in the Handle
     // RAII class) as there shouldn't be another way to get a reference.
-    MCAssert(m_refcount != 0);
+    MCAssert(m_refcount >= 0);
     
-    if (--m_refcount == 0)
+    if (--m_refcount <= 0)
 	{
         // The object in question no longer has a proxy object as we are being
         // deleted

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -133,8 +133,8 @@ MCObject::MCObject()
 	// MW-2008-10-25: Initialize the parent script link to NULL
 	parent_script = NULL;
 
-	// MW-2009-08-25: Initialize the handle to NULL
-	m_weak_handle = NULL;
+	// No proxy initially
+	m_weak_proxy = nil;
 
 	// MW-2012-02-14: [[ Fonts ]] Initialize the font to nil.
 	m_font = nil;
@@ -239,8 +239,8 @@ MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
 	else
 		parent_script = NULL;
 
-	// MW-2009-08-25: Initialize the handle to NULL
-	m_weak_handle = NULL;
+	// No proxy initially
+	m_weak_proxy = nil;
 
 	// MW-2012-02-14: [[ FontRefs ]] As objects start off closed, the font is not
 	//   copied and starts nil.
@@ -282,12 +282,9 @@ MCObject::~MCObject()
 	// MW-2012-02-16: [[ LogFonts ]] Delete the font attrs (if any).
 	clearfontattrs();
 
-	// Clear and release the handle.
-	if (m_weak_handle != NULL)
-    {
-        m_weak_handle -> Clear();
-		m_weak_handle -> Release();
-    }
+	// This object is going away; invalidate the proxy
+	if (m_weak_proxy != NULL)
+        m_weak_proxy->Clear();
 
 	// MW-2008-10-25: Release the parent script use
 	if (parent_script != NULL)
@@ -885,8 +882,10 @@ Boolean MCObject::del(bool p_check_flag)
     //  back to the list of listened objects; in case we revert the stack to its
     //  saved state, we will now be left with a list of listened-to objects with
     //  no dangling pointers.
-    if (m_weak_handle != nil)
-        m_weak_handle -> Clear();
+    
+    // This object is in the process of being deleted; invalidate any weak refs
+    if (m_weak_proxy != nil)
+        m_weak_proxy->Clear();
     
     // MW-2012-10-10: [[ IdCache ]] Remove the object from the stack's id cache
     //   (if it is in it!).
@@ -4227,21 +4226,16 @@ MCImage *MCObject::resolveimagename(MCStringRef p_name)
 	return resolveimage(p_name, 0);
 }
 
-MCObjectHandle *MCObject::gethandle(void)
+MCObjectHandle MCObject::GetHandle(void)
 {
-	if (m_weak_handle != NULL)
+	if (m_weak_proxy == NULL)
 	{
-		m_weak_handle -> Retain();
-		return m_weak_handle;
+		m_weak_proxy = new (std::nothrow) MCObjectProxy(this);
+        if (!m_weak_proxy)
+            return MCObjectHandle(NULL);
 	}
 
-	m_weak_handle = new MCObjectHandle(this);
-	if (m_weak_handle == NULL)
-		return NULL;
-
-	m_weak_handle -> Retain();
-
-	return m_weak_handle;
+	return MCObjectHandle(m_weak_proxy);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5307,43 +5301,52 @@ bool MCObjectVisitor::OnBlock(MCBlock *p_block)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-MCObjectHandle::MCObjectHandle(MCObject *p_object)
-{
-	m_object = p_object;
-	m_references = 0;
-}
-
-MCObjectHandle::~MCObjectHandle(void)
+MCObjectProxy::MCObjectProxy(MCObject *p_object) :
+  m_object(p_object),
+  m_refcount(0)
 {
 }
 
-MCObject *MCObjectHandle::Get(void)
+MCObjectProxy::~MCObjectProxy()
 {
-	return m_object;
+    // Shouldn't get deleted if there are references outstanding!
+    MCAssert(m_refcount == 0);
 }
 
-void MCObjectHandle::Clear(void)
+MCObject* MCObjectProxy::Get()
 {
-	m_object = NULL;
+	MCAssert(m_object != nil);
+    return m_object;
 }
 
-void MCObjectHandle::Retain(void)
+void MCObjectProxy::Clear()
 {
-	m_references += 1;
+	m_object = nil;
 }
 
-void MCObjectHandle::Release(void)
+void MCObjectProxy::Retain()
 {
-	m_references -= 1;
-	if (m_references == 0)
+	m_refcount += 1;
+}
+
+void MCObjectProxy::Release()
+{
+    // Sanity check to prevent over-releases (which implies a bug in the Handle
+    // RAII class) as there shouldn't be another way to get a reference.
+    MCAssert(m_refcount != 0);
+    
+    if (--m_refcount == 0)
 	{
-		if (m_object != NULL)
-			m_object -> m_weak_handle = NULL;
+        // The object in question no longer has a proxy object as we are being
+        // deleted
+        if (m_object)
+            m_object->m_weak_proxy = nil;
+        
 		delete this;
 	}
 }
 
-bool MCObjectHandle::Exists(void)
+bool MCObjectProxy::ObjectExists() const
 {
 	return m_object != NULL;
 }

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4230,7 +4230,7 @@ MCObjectHandle MCObject::GetHandle(void)
 {
 	if (m_weak_proxy == NULL)
 	{
-		m_weak_proxy = new (std::nothrow) MCObjectProxy(this);
+		m_weak_proxy = new MCObjectProxy(this);
         if (!m_weak_proxy)
             return MCObjectHandle(NULL);
 	}

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -1361,4 +1361,16 @@ public:
 		return (MCObjectList *)MCDLlist::remove((MCDLlist *&)list);
 	}
 };
+
+// Utility function for safe(-ish) casting from an MCObject to a derived class
+// without using RTTI.
+template <typename T>
+T* MCObjectCast(MCObject* p_object)
+{
+    // Check that the object's type matches the (static) type of the desired
+    // type. This will break horribly if the desired type has derived types...
+    MCAssert(p_object->gettype() == T::kObjectType);
+    return static_cast<T*> (p_object);
+}
+
 #endif

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -1423,7 +1423,7 @@ public:
     
     ~Handle()
     {
-        if (m_proxy)
+        if (m_proxy != nil)
             m_proxy->Release();
     }
     
@@ -1473,7 +1473,7 @@ public:
     }
     bool operator!=(const Handle& other) const
     {
-        return !operator==(other);
+        return !(operator==(other));
     }
     
     // Performs a retain on the underlying proxy without an RAII wrapper. This
@@ -1505,10 +1505,10 @@ private:
     
     void Set(MCObjectProxy* p_proxy)
     {
-        if (m_proxy)
+        if (m_proxy != nil)
             m_proxy->Release();
         m_proxy = p_proxy;
-        if (m_proxy)
+        if (m_proxy != nil)
             m_proxy->Retain();
     }
 };

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -539,7 +539,7 @@ bool ntoa_callback(void *p_context, bool p_resolved, bool p_final, struct sockad
 
 typedef struct _mc_ntoa_message_callback_info
 {
-	MCObjectHandle *target;
+	MCObjectHandle target;
 	MCStringRef name;
 	MCNameRef message;
 	MCListRef list;
@@ -552,8 +552,6 @@ static void free_ntoa_message_callback_info(MCNToAMessageCallbackInfo *t_info)
 		MCValueRelease(t_info->message);
 		MCValueRelease(t_info->name);
 		MCValueRelease(t_info->list);
-		if (t_info->target)
-			t_info->target->Release();
 		MCMemoryDelete(t_info);
 	}
 }
@@ -567,7 +565,7 @@ bool ntoa_message_callback(void *p_context, bool p_resolved, bool p_final, struc
 	{
 		MCAutoStringRef t_string;
 		/* UNCHECKED */ MCListCopyAsString(t_info->list, &t_string);
-		MCscreen->delaymessage(t_info->target->Get(), t_info->message, t_info->name, *t_string);
+		MCscreen->delaymessage(t_info->target, t_info->message, t_info->name, *t_string);
 		free_ntoa_message_callback_info(t_info);
 	}
 	return true;
@@ -611,7 +609,7 @@ bool MCS_ntoa(MCStringRef p_hostname, MCObject *p_target, MCNameRef p_message, M
 
 		if (t_success)
 		{
-			t_info->target = p_target->gethandle();
+			t_info->target = p_target->GetHandle();
 			t_success = MCSocketHostNameResolve(*t_host_cstring, NULL, SOCK_STREAM, false, ntoa_message_callback, t_info);
 		}
 		

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -224,56 +224,50 @@ uint32_t MCSellist::count()
 
 MCControl *MCSellist::clone(MCObject *target)
 {
-	MCObjectHandle **t_selobj_handles = nil;
+	MCObjectHandle *t_selobj_handles = nil;
 	uint32_t t_selobj_count;
 	t_selobj_count = count();
 
-	/* UNCHECKED */ MCMemoryNewArray(t_selobj_count, t_selobj_handles);
+	/* UNCHECKED */ MCMemoryNewArrayInit(t_selobj_count, t_selobj_handles);
 	sort();
 
 	MCSelnode *t_node = objects;
 	for (uint32_t i = 0; i < t_selobj_count; i++)
 	{
-		t_selobj_handles[i] = t_node->ref->gethandle();
+		t_selobj_handles[i] = t_node->ref->GetHandle();
 		t_node = t_node->next();
 	}
 
 	clear(false);
 
-	MCObjectHandle *t_newtarget = nil;
+	MCObjectHandle t_newtarget = nil;
 	for (uint32_t i = 0; i < t_selobj_count; i++)
 	{
-		if (t_selobj_handles[i]->Exists())
+		if (t_selobj_handles[i].IsValid())
 		{
-			MCControl *t_control = (MCControl*)t_selobj_handles[i]->Get();
+			MCControl *t_control = t_selobj_handles[i].GetAs<MCControl>();
 			MCControl *t_clone = t_control->clone(True, OP_NONE, false);
 			t_clone->select();
 			if (t_control == target)
-				t_newtarget = t_clone->gethandle();
+				t_newtarget = t_clone->GetHandle();
 			t_control->deselect();
 			add(t_clone, false);
 		}
-		t_selobj_handles[i]->Release();
 	}
 	
 	MCControl *t_result;
 	t_result = nil;
-	if (t_newtarget != nil)
+	if (t_newtarget.IsValid())
 	{
-		if (t_newtarget->Exists())
-		{
-			t_newtarget->Get()->message(MCM_selected_object_changed);
-			
-			// Note that t_newtarget->Get() can change while executing the above message
-			// hence we re-evaluate here.
-			t_result = (MCControl*)t_newtarget->Get();
-		}			
-		// MW-2010-05-06: Make sure we clean up the handle.  IM-2010-05-06: release even when target doesn't exist
-		t_newtarget -> Release();
+        t_newtarget->message(MCM_selected_object_changed);
+        
+        // Note that t_newtarget->Get() can change while executing the above message
+        // hence we re-evaluate here.
+        t_result = t_newtarget.GetAs<MCControl>();
 	}
 	
 	// MW-2010-05-06: Make sure we clean up the temp array
-	MCMemoryDeleteArray(t_selobj_handles);
+	MCMemoryDeleteArray(t_selobj_handles, t_selobj_count);
 
 	return t_result;
 }

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -549,7 +549,7 @@ MCStack::~MCStack()
 		MCObject::close();
 	}
 	
-	if (m_parent_stack != nil)
+	if (m_parent_stack.IsBound())
 		setparentstack(nil);
 
 	delete mnemonics;

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -216,7 +216,7 @@ protected:
 #endif
 
 	// IM-2014-07-23: [[ Bug 12930 ]] The stack whose window is parent to this stack
-	MCObjectHandle *m_parent_stack;
+	MCObjectHandle m_parent_stack;
 	
 	MCExternalHandlerList *m_externals;
 
@@ -309,6 +309,9 @@ protected:
 	MCStackObjectVisibility m_hidden_object_visibility;
     
 public:
+    
+    enum { kObjectType = CT_STACK };
+    
 	Boolean menuwindow;
 
 	MCStack(void);

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -474,35 +474,29 @@ Window MCStack::getparentwindow()
 
 void MCStack::setparentstack(MCStack *p_parent)
 {
-	MCStack *t_parent;
-	t_parent = getparentstack();
+	MCStack *t_parent = getparentstack();
 	
 	if (t_parent == p_parent)
 		return;
 	
-	if (m_parent_stack != nil)
-	{
-		m_parent_stack->Release();
-		m_parent_stack = nil;
-	}
-	
 	if (p_parent != nil)
-		m_parent_stack = p_parent->gethandle();
+		m_parent_stack = p_parent->GetHandle();
+    else
+        m_parent_stack = nil;
 }
 
 MCStack *MCStack::getparentstack()
 {
-	if (m_parent_stack == nil)
+	if (!m_parent_stack.IsBound())
 		return nil;
 	
-	if (!m_parent_stack->Exists())
+	if (!m_parent_stack.IsValid())
 	{
-		m_parent_stack->Release();
 		m_parent_stack = nil;
 		return nil;
 	}
 	
-	return (MCStack*)m_parent_stack->Get();
+	return m_parent_stack.GetAs<MCStack>();
 }
 
 static bool _MCStackTakeWindowCallback(MCStack *p_stack, void *p_context)

--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -1191,7 +1191,6 @@ class MCPlayer;
 class MCImage;
 class MCField;
 class MCObject;
-class MCObjectHandle;
 class MCObjectList;
 class MCMagnify;
 class MCPrinter;

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -125,6 +125,9 @@ class MCNativeLayer;
 class MCWidget: public MCControl
 {
 public:
+    
+    enum { kObjectType = CT_WIDGET };
+    
 	MCWidget(void);
 	MCWidget(const MCWidget& p_other);
 	virtual ~MCWidget(void);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1076,6 +1076,14 @@ template <typename T> void inline MCMemoryClear(T&p_struct)
 	MCMemoryClear(&p_struct, sizeof(T));
 }
 
+// Re-initialise an object to its default-constructed state
+template <typename T> void inline MCMemoryReinit(T& p_object)
+{
+    // Run the destructor then default constructor
+    p_object.~T();
+    new (&p_object) T();
+}
+
 extern "C" {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1321,7 +1321,7 @@ template<typename T> void MCMemoryDeleteArray(T* p_array)
 
 // Array deleter that runs the destructor for each element
 template <typename T>
-void MCMemoryDeleteArray(T* p_array, size_t N)
+void MCMemoryDeleteArray(T* p_array, uindex_t N)
 {
     // Run the destructor for each of the elements
     for (size_t i = 0; i < N; i++)

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1191,6 +1191,29 @@ template<typename T> void MCMemoryDelete(T* p_record)
 	MCMemoryDelete(static_cast<void *>(p_record));
 }
 
+// Allocates a block of memory for an object and default-constructs it
+// (basically, ::operator new)
+template <typename T>
+bool MCMemoryCreate(T*& r_object)
+{
+    // Allocate the memory then default-construct
+    if (!MCMemoryNew(r_object))
+        return false;
+    
+    new (r_object) T();
+    return true;
+}
+
+// De-allocates a block of memory after running the object's destructor
+// (basically, ::operator delete).
+template <typename T>
+void MCMemoryDestroy(T* p_object)
+{
+    // Run the object's destructor then delete it
+    p_object->~T();
+    MCMemoryDelete(p_object);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  RESIZEABLE ARRAY ALLOCATION (INITIALIZED)
@@ -1232,6 +1255,29 @@ template<typename T> bool MCMemoryNewArray(uindex_t p_count, T*& r_array)
 	return false;
 }
 
+// Array allocator that default-constructs all elements
+template <typename T>
+bool MCMemoryNewArrayInit(uindex_t p_count, T*& r_array, uindex_t& r_count)
+{
+    if (MCMemoryNewArray(p_count, r_array, r_count))
+    {
+        // Default-construct all elements in the array
+        for (uindex_t i = 0; i < r_count; i++)
+            new (&r_array[i]) T();
+        return true;
+    }
+    
+    return false;
+}
+
+// Array allocator that default-constructs all elements
+template <typename T>
+bool MCMemoryNewArrayInit(uindex_t p_count, T*& r_array)
+{
+    uindex_t t_alloc_count;
+    return MCMemoryNewArrayInit(p_count, r_array, t_alloc_count);
+}
+
 template<typename T> inline bool MCMemoryResizeArray(uindex_t p_new_count, T*& x_array, uindex_t& x_count)
 {
 	void *t_array;
@@ -1244,9 +1290,37 @@ template<typename T> inline bool MCMemoryResizeArray(uindex_t p_new_count, T*& x
 	return false;
 }
 
+template <typename T>
+bool MCMemoryResizeArrayInit(uindex_t p_new_count, T*& x_array, uindex_t& x_count)
+{
+    // Capture the current count before resizing
+    uindex_t t_current_count = x_count;
+    if (MCMemoryResizeArray(p_new_count, x_array, x_count))
+    {
+        // Default construct any new elements that were allocated
+        for (uindex_t i = t_current_count; i < p_new_count; i++)
+            new (&x_array[i]) T();
+        return true;
+    }
+    
+    return false;
+}
+
 template<typename T> void MCMemoryDeleteArray(T* p_array)
 {
 	MCMemoryDeleteArray(static_cast<void *>(p_array));
+}
+
+// Array deleter that runs the destructor for each element
+template <typename T>
+void MCMemoryDeleteArray(T* p_array, size_t N)
+{
+    // Run the destructor for each of the elements
+    for (size_t i = 0; i < N; i++)
+        p_array[i].~T();
+    
+    // Destroy the array
+    MCMemoryDeleteArray(p_array);
 }
 
 extern "C" {


### PR DESCRIPTION
This ensures Release/Retain pairs are always balanced and fixes a crash that @livecodeali and @montegoulding observed. It needs more testing, though. There are also chunks of mobile-only code that haven't been fully refactored yet.

In principle, any use of MCObject\* (or pointers to derived classes) that represent a weak reference could now be replaced with the MCObjectHandle class which might help solve some of the problems we've observed with MCObject references. (This could easily be done as people come across them; it isn't necessary to do it wholesale).
