### PR TITLE
Ensure exit status handled correctly when linking externals

### DIFF
--- a/lcidlc/lclink.sh
+++ b/lcidlc/lclink.sh
@@ -109,15 +109,19 @@ if [ -z "$FAT_INFO" -o $BUILD_DYLIB -eq 1 ]; then
 	# Build the 'dylib' form of the external - this is used by simulator builds, and as
 	# a dependency check for device builds - otherwise dsymutil call below may fail
 	"$DEVELOPER_BIN_DIR/g++" -stdlib=libc++ -dynamiclib $ARCHS $MIN_OS_VERSION -isysroot "$SDKROOT" $FRAMEWORK_SEARCH_PATHS $STATIC_FRAMEWORKS -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" $SYMBOL_ARGS $SYMBOLS $DEPS $OTHER_FLAGS
-
-	if [ $? -ne 0 ]; then
-		exit $?
+  RESULT=$?
+  if [ $RESULT != 0 ]; then
+  	exit $RESULT
 	fi
 
 	# Only build static library on device builds
 	if [ $BUILD_DYLIB -eq 0 ]; then
 		"$DEVELOPER_BIN_DIR/g++" -stdlib=libc++ -nodefaultlibs -Wl,-r -Wl,-x $ARCHS $MIN_OS_VERSION -isysroot "$SDKROOT" $FRAMEWORK_SEARCH_PATHS $STATIC_FRAMEWORKS -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" $DEPS_SECTION $OTHER_FLAGS -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME
-	fi
+    RESULT=$?
+    if [ $RESULT != 0 ]; then
+    	exit $RESULT
+  	fi
+  fi
 else
 	# Only executed if the binaries have a FAT header, and we need an architecture-specific
 	# linking
@@ -139,16 +143,18 @@ else
 		# Build the 'dylib' form of the external - this is used by simulator builds, and as
 		# a dependency check for device builds.
     "$DEVELOPER_BIN_DIR/g++" -stdlib=libc++ -dynamiclib -arch $ARCH -miphoneos-version-min=${MIN_VERSION} -isysroot "$SDKROOT" $FRAMEWORK_SEARCH_PATHS $STATIC_FRAMEWORKS -o "$DYLIB_FILE" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" $SYMBOL_ARGS $SYMBOLS $DEPS $OTHER_FLAGS
-		if [ $? != 0 ]; then
-			echo "error: linking step of external dylib build failed, probably due to missing framework or library references - check the contents of the $PRODUCT_NAME.ios file"
-			exit $?
+    RESULT=$?
+    if [ $RESULT != 0 ]; then
+    	echo "error: linking step of external dylib build failed, probably due to missing framework or library references - check the contents of the $PRODUCT_NAME.ios file"
+			exit $RESULT
 		fi
 
 		# Build the 'object file' form of the external - this is used by device builds.
 		"$DEVELOPER_BIN_DIR/g++" -stdlib=libc++ -nodefaultlibs -Wl,-r -Wl,-x -arch $ARCH  -miphoneos-version-min=${MIN_VERSION} -isysroot "$SDKROOT" $FRAMEWORK_SEARCH_PATHS $STATIC_FRAMEWORKS -o "$LCEXT_FILE" "$BUILT_PRODUCTS_DIR/$EXECUTABLE_NAME" $DEPS_SECTION $OTHER_FLAGS -Wl,-exported_symbol -Wl,___libinfoptr_$PRODUCT_NAME
-		if [ $? != 0 ]; then
-			echo "error: linking step of external object build failed"
-			exit $?
+    RESULT=$?
+    if [ $RESULT != 0 ]; then
+    	echo "error: linking step of external object build failed"
+			exit $RESULT
 		fi
 
 		LCEXT_FILE_LIST+=" ${LCEXT_FILE}"


### PR DESCRIPTION
I am fairly sure lclink.sh exited correctly previously but it isn't now... this patch fixes that
