### PR TITLE
[[ Bug 17747 ]] Make sure mouseUp is sent before popup is closed

### DIFF
--- a/docs/notes/bugfix-17747.md
+++ b/docs/notes/bugfix-17747.md
@@ -1,0 +1,1 @@
+# Make sure widgets get mouseUp in popup stacks

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -761,12 +761,12 @@ Boolean MCObject::mup(uint2 which, bool p_release)
 		else
 		{
 			MCStack *oldmenu = attachedmenu;
-			closemenu(True, True);
 			MCAutoStringRef t_pick;
 			uint2 menuhistory;
 			MCmenupoppedup = true;
 			oldmenu->menumup(which, &t_pick, menuhistory);
 			MCmenupoppedup = false;
+			closemenu(True, True);
 		}
 		return True;
 	}


### PR DESCRIPTION
This patch ensures that a mouseUp which causes a popup to close
is sent _before_ the menu is closed. This fixes the problem of
menu closure causing a 'mouseCancel' event in widgets which
occurred previously because closemenu() would cause the grabbed
widget to be reset to nil, indicating that the mouse event
was cancelled even though it was not.
