### PR TITLE
[[ Bug 17615 ]] Fix CGImage using source MCGImageRef after release

### DIFF
--- a/docs/notes/bugfix-17615.md
+++ b/docs/notes/bugfix-17615.md
@@ -1,0 +1,1 @@
+# Fix crash when printing preview of card with browser widget on OSX

--- a/engine/src/cgimageutil.cpp
+++ b/engine/src/cgimageutil.cpp
@@ -125,7 +125,8 @@ bool MCGRasterCreateCGDataProvider(const MCGRaster &p_raster, const MCGIntegerRe
 	if (!p_copy)
 	{
 		t_dst_stride = p_raster.stride;
-		t_success = nil != (t_data_provider = CGDataProviderCreateWithData(nil, t_src_ptr, t_height * p_raster.stride, nil));
+		t_data_provider = CGDataProviderCreateWithData(nil, t_src_ptr, t_height * p_raster.stride, nil);
+		t_success = t_data_provider != nil;
 	}
 	else
 	{
@@ -158,7 +159,10 @@ bool MCGRasterCreateCGDataProvider(const MCGRaster &p_raster, const MCGIntegerRe
 			}
 		}
 		if (t_success)
-			t_success = nil != (t_data_provider = CGDataProviderCreateWithData(nil, t_buffer, t_buffer_size, __CGDataProviderDeallocate));
+		{
+			t_data_provider = CGDataProviderCreateWithData(nil, t_buffer, t_buffer_size, __CGDataProviderDeallocate);
+			t_success = t_data_provider != nil;
+		}
 		
 		if (!t_success)
 			MCMemoryDeallocate(t_buffer);
@@ -193,7 +197,10 @@ bool MCGRasterToCGImage(const MCGRaster &p_raster, const MCGIntegerRectangle &p_
 	t_bm_info = MCGPixelFormatToCGBitmapInfo(kMCGPixelFormatNative, t_alpha);
 	
 	if (t_success)
-		t_success = nil != (t_image = CGImageCreate(p_src_rect.size.width, p_src_rect.size.height, 8, 32, t_dst_stride, p_colorspace, t_bm_info, t_data_provider, nil, true, kCGRenderingIntentDefault));
+	{
+		t_image = CGImageCreate(p_src_rect.size.width, p_src_rect.size.height, 8, 32, t_dst_stride, p_colorspace, t_bm_info, t_data_provider, nil, true, kCGRenderingIntentDefault);
+		t_success = t_image != nil;
+	}
 	
 	CGDataProviderRelease(t_data_provider);
 	
@@ -233,7 +240,8 @@ bool MCGImageCreateCGDataProvider(MCGImageRef p_src, const MCGIntegerRectangle &
 		const void *t_src_ptr;
 		t_src_ptr = MCGRasterGetPixelPtr(t_raster, p_src_rect.origin.x, p_src_rect.origin.y);
 		
-		t_success = nil != (t_data_provider = CGDataProviderCreateWithData(p_src, t_src_ptr, p_src_rect.size.height * t_raster.stride, MCGImageDataProviderReleaseDataCallback));
+		t_data_provider = CGDataProviderCreateWithData(p_src, t_src_ptr, p_src_rect.size.height * t_raster.stride, MCGImageDataProviderReleaseDataCallback);
+		t_success = t_data_provider != nil;
 	}
 	
 	if (t_success)
@@ -272,7 +280,10 @@ bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect,
 	t_bm_info = MCGPixelFormatToCGBitmapInfo(kMCGPixelFormatNative, t_alpha);
 	
 	if (t_success)
-		t_success = nil != (t_image = CGImageCreate(p_src_rect.size.width, p_src_rect.size.height, 8, 32, t_raster.stride, p_colorspace, t_bm_info, t_data_provider, nil, true, kCGRenderingIntentDefault));
+	{
+		t_image = CGImageCreate(p_src_rect.size.width, p_src_rect.size.height, 8, 32, t_raster.stride, p_colorspace, t_bm_info, t_data_provider, nil, true, kCGRenderingIntentDefault);
+		t_success = t_image != nil;
+	}
 	
 	CGDataProviderRelease(t_data_provider);
 	

--- a/engine/src/cgimageutil.cpp
+++ b/engine/src/cgimageutil.cpp
@@ -93,8 +93,18 @@ CGBitmapInfo MCGPixelFormatToCGBitmapInfo(uint32_t p_pixel_format, bool p_alpha)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCGRasterToCGImage(const MCGRaster &p_raster, MCGRectangle p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image)
+inline void *MCGRasterGetPixelPtr(const MCGRaster &p_raster, uint32_t x, uint32_t y)
 {
+	MCAssert(x < p_raster.width && y < p_raster.height);
+	return (uint8_t*)p_raster.pixels + y * p_raster.stride + x * sizeof(uint32_t);
+}
+
+bool MCGRasterCreateCGDataProvider(const MCGRaster &p_raster, const MCGIntegerRectangle &p_src_rect, bool p_copy, bool p_invert, CGDataProviderRef &r_data_provider, uint32_t &r_stride)
+{
+	MCAssert(p_src_rect.origin.x >= 0 && p_src_rect.origin.y >= 0);
+	MCAssert(p_src_rect.origin.x + p_src_rect.size.width <= p_raster.width);
+	MCAssert(p_src_rect.origin.y + p_src_rect.size.height <= p_raster.height);
+	
 	bool t_success = true;
 	
 	int32_t t_x, t_y;
@@ -104,18 +114,14 @@ bool MCGRasterToCGImage(const MCGRaster &p_raster, MCGRectangle p_src_rect, CGCo
 	t_width = p_src_rect.size.width;
 	t_height = p_src_rect.size.height;
 	
-	/* OVERHAUL - REVISIT: pixel formats */
-	const uint8_t *t_src_ptr = (uint8_t*)p_raster.pixels;
-	t_src_ptr += t_y * p_raster.stride + t_x * sizeof(uint32_t);
+	const uint8_t *t_src_ptr = (uint8_t*)MCGRasterGetPixelPtr(p_raster, t_x, t_y);
 	
 	uint32_t t_dst_stride;
 	
 	if (p_invert)
 		p_copy = true;
 	
-	CGImageRef t_image = nil;
 	CGDataProviderRef t_data_provider = nil;
-	
 	if (!p_copy)
 	{
 		t_dst_stride = p_raster.stride;
@@ -156,8 +162,27 @@ bool MCGRasterToCGImage(const MCGRaster &p_raster, MCGRectangle p_src_rect, CGCo
 		
 		if (!t_success)
 			MCMemoryDeallocate(t_buffer);
-		
 	}
+	
+	if (t_success)
+	{
+		r_data_provider = t_data_provider;
+		r_stride = t_dst_stride;
+	}
+	
+	return t_success;
+}
+
+bool MCGRasterToCGImage(const MCGRaster &p_raster, const MCGIntegerRectangle &p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image)
+{
+	bool t_success = true;
+	
+	CGImageRef t_image = nil;
+	CGDataProviderRef t_data_provider = nil;
+	uint32_t t_dst_stride;
+
+	if (t_success)
+		t_success = MCGRasterCreateCGDataProvider(p_raster, p_src_rect, p_copy, p_invert, t_data_provider, t_dst_stride);
 	
 	// IM-2014-05-20: [[ GraphicsPerformance ]] Opaque rasters should indicate no alpha in the bitmap info
 	bool t_alpha;
@@ -168,7 +193,7 @@ bool MCGRasterToCGImage(const MCGRaster &p_raster, MCGRectangle p_src_rect, CGCo
 	t_bm_info = MCGPixelFormatToCGBitmapInfo(kMCGPixelFormatNative, t_alpha);
 	
 	if (t_success)
-		t_success = nil != (t_image = CGImageCreate(t_width, t_height, 8, 32, t_dst_stride, p_colorspace, t_bm_info, t_data_provider, nil, true, kCGRenderingIntentDefault));
+		t_success = nil != (t_image = CGImageCreate(p_src_rect.size.width, p_src_rect.size.height, 8, 32, t_dst_stride, p_colorspace, t_bm_info, t_data_provider, nil, true, kCGRenderingIntentDefault));
 	
 	CGDataProviderRelease(t_data_provider);
 	
@@ -180,17 +205,84 @@ bool MCGRasterToCGImage(const MCGRaster &p_raster, MCGRectangle p_src_rect, CGCo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image)
+void MCGImageDataProviderReleaseDataCallback(void *p_info, const void *p_data, size_t p_size)
+{
+	MCGImageRef t_image;
+	t_image = (MCGImageRef)p_info;
+	
+	MCGImageRelease(t_image);
+}
+
+bool MCGImageCreateCGDataProvider(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, CGDataProviderRef &r_data_provider)
+{
+	MCAssert(p_src_rect.origin.x >= 0 && p_src_rect.origin.y >= 0);
+	MCAssert(p_src_rect.origin.x + p_src_rect.size.width <= (uint32_t)MCGImageGetWidth(p_src));
+	MCAssert(p_src_rect.origin.y + p_src_rect.size.height <= (uint32_t)MCGImageGetHeight(p_src));
+	
+	bool t_success = true;
+	
+	MCGRaster t_raster;
+	if (t_success)
+		t_success = MCGImageGetRaster(p_src, t_raster);
+	
+	CGDataProviderRef t_data_provider;
+	t_data_provider = nil;
+	
+	if (t_success)
+	{
+		const void *t_src_ptr;
+		t_src_ptr = MCGRasterGetPixelPtr(t_raster, p_src_rect.origin.x, p_src_rect.origin.y);
+		
+		t_success = nil != (t_data_provider = CGDataProviderCreateWithData(p_src, t_src_ptr, p_src_rect.size.height * t_raster.stride, MCGImageDataProviderReleaseDataCallback));
+	}
+	
+	if (t_success)
+	{
+		MCGImageRetain(p_src);
+		r_data_provider = t_data_provider;
+	}
+	
+	return t_success;
+}
+
+bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, CGColorSpaceRef p_colorspace, bool p_invert, CGImageRef &r_image)
 {
 	MCGRaster t_raster;
-	
 	if (!MCGImageGetRaster(p_src, t_raster))
 		return false;
 	
-	return MCGRasterToCGImage(t_raster, p_src_rect, p_colorspace, p_copy, p_invert, r_image);
+	if (p_invert)
+	{
+		return MCGRasterToCGImage(t_raster, p_src_rect, p_colorspace, true, true, r_image);
+	}
+	
+	// If we don't need to modify the data then create image with data provider that references the MCGImageRef
+	bool t_success = true;
+	
+	CGImageRef t_image = nil;
+	CGDataProviderRef t_data_provider = nil;
+	
+	if (t_success)
+		t_success = MCGImageCreateCGDataProvider(p_src, p_src_rect, t_data_provider);
+	
+	bool t_alpha;
+	t_alpha = !MCGImageIsOpaque(p_src);
+	
+	CGBitmapInfo t_bm_info;
+	t_bm_info = MCGPixelFormatToCGBitmapInfo(kMCGPixelFormatNative, t_alpha);
+	
+	if (t_success)
+		t_success = nil != (t_image = CGImageCreate(p_src_rect.size.width, p_src_rect.size.height, 8, 32, t_raster.stride, p_colorspace, t_bm_info, t_data_provider, nil, true, kCGRenderingIntentDefault));
+	
+	CGDataProviderRelease(t_data_provider);
+	
+	if (t_success)
+		r_image = t_image;
+	
+	return t_success;
 }
 
-bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, bool p_copy, bool p_invert, CGImageRef &r_image)
+bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, bool p_invert, CGImageRef &r_image)
 {
 	bool t_success = true;
 	
@@ -200,7 +292,7 @@ bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, bool p_copy, 
 		t_success = MCImageGetCGColorSpace(t_colorspace);
 	
 	if (t_success)
-		t_success = MCGImageToCGImage(p_src, p_src_rect, t_colorspace, p_copy, p_invert, r_image);
+		t_success = MCGImageToCGImage(p_src, p_src_rect, t_colorspace, p_invert, r_image);
 	
 	CGColorSpaceRelease(t_colorspace);
 	
@@ -217,7 +309,7 @@ bool MCImageBitmapToCGImage(MCImageBitmap *p_bitmap, CGColorSpaceRef p_colorspac
 	MCGRaster t_raster;
 	t_raster = MCImageBitmapGetMCGRaster(p_bitmap, true);
 	
-	return MCGRasterToCGImage(t_raster, MCGRectangleMake(0, 0, p_bitmap->width, p_bitmap->height), p_colorspace, p_copy, p_invert, r_image);
+	return MCGRasterToCGImage(t_raster, MCGIntegerRectangleMake(0, 0, p_bitmap->width, p_bitmap->height), p_colorspace, p_copy, p_invert, r_image);
 }
 
 bool MCImageBitmapToCGImage(MCImageBitmap *p_bitmap, bool p_copy, bool p_invert, CGImageRef &r_image)

--- a/engine/src/mac-surface.mm
+++ b/engine/src/mac-surface.mm
@@ -33,8 +33,8 @@
 
 // COCOA-TODO: Clean up external linkage for surface.
 extern MCRectangle MCU_intersect_rect(const MCRectangle&, const MCRectangle&);
-extern bool MCGRasterToCGImage(const MCGRaster &p_raster, MCGRectangle p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image);
-extern bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, bool p_copy, bool p_invert, CGImageRef &r_image);
+extern bool MCGRasterToCGImage(const MCGRaster &p_raster, const MCGIntegerRectangle &p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image);
+extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, bool p_invert, CGImageRef &r_image);
 extern MCGFloat MCResGetDeviceScale(void);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -419,7 +419,7 @@ static void MCMacRenderImageToCG(CGContextRef p_target, CGRect p_dst_rect, MCGIm
 	
 	CGImageRef t_image = nil;
 	
-	t_success = MCGImageToCGImage(p_src, p_src_rect, false, false, t_image);
+	t_success = MCGImageToCGImage(p_src, MCGRectangleGetBounds(p_src_rect), false, t_image);
 	if (t_success)
 	{
 		MCMacRenderCGImage(p_target, p_dst_rect, t_image, p_alpha, p_blend);
@@ -435,7 +435,7 @@ static void MCMacRenderRasterToCG(CGContextRef p_target, CGRect p_dst_rect, cons
 		CGImageRef t_image;
 		t_image = nil;
 		
-		if (MCGRasterToCGImage(p_src, p_src_rect, t_colorspace, false, false, t_image))
+		if (MCGRasterToCGImage(p_src, MCGRectangleGetBounds(p_src_rect), t_colorspace, false, false, t_image))
 		{
 			MCMacRenderCGImage(p_target, p_dst_rect, t_image, p_alpha, p_blend);
 			CGImageRelease(t_image);

--- a/engine/src/mbliphonegfx.mm
+++ b/engine/src/mbliphonegfx.mm
@@ -49,7 +49,7 @@ extern UIView *MCIPhoneGetView(void);
 extern float MCIPhoneGetResolutionScale(void);
 extern float MCIPhoneGetDeviceScale(void);
 
-extern bool MCGRasterToCGImage(const MCGRaster &p_raster, MCGRectangle p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image);
+extern bool MCGRasterToCGImage(const MCGRaster &p_raster, const MCGIntegerRectangle &p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image);
 extern bool MCImageGetCGColorSpace(CGColorSpaceRef &r_colorspace);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -366,7 +366,7 @@ protected:
 		// IM-2014-07-01: [[ GraphicsPerformance ]] Clip the output context to only those areas we've had to redraw
 		MCMacClipCGContextToRegion(t_context, m_region, m_height);
 		
-		if (MCGRasterToCGImage(t_raster, MCGRectangleMake(0, 0, p_area.size.width, p_area.size.height), t_colorspace, false, false, t_image))
+		if (MCGRasterToCGImage(t_raster, MCGIntegerRectangleMake(0, 0, p_area.size.width, p_area.size.height), t_colorspace, false, false, t_image))
 		{
 			CGContextDrawImage(t_context, CGRectMake((float)p_area.origin.x, (float)(m_height - (p_area.origin.y + p_area.size.height)), (float)p_area.size.width, (float)p_area.size.height), t_image);
 			CGImageRelease(t_image);

--- a/engine/src/mbliphonestack.mm
+++ b/engine/src/mbliphonestack.mm
@@ -267,7 +267,7 @@ void layer_animation_changes(UIView *p_new_view, UIView *p_old_view, uint32_t p_
 //    push     (Push)
 //    reveal   (Reveal)
 
-extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle p_src_rect, bool p_invert, CGImageRef &r_image);
+extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, bool p_invert, CGImageRef &r_image);
 
 // IM-2013-07-18: [[ ResIndependence ]] added scale parameter to support hi-res images
 static bool MCGImageToUIImage(MCGImageRef p_image, bool p_copy, MCGFloat p_scale, UIImage *&r_uiimage)

--- a/engine/src/mbliphonestack.mm
+++ b/engine/src/mbliphonestack.mm
@@ -267,7 +267,7 @@ void layer_animation_changes(UIView *p_new_view, UIView *p_old_view, uint32_t p_
 //    push     (Push)
 //    reveal   (Reveal)
 
-extern bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, bool p_copy, bool p_invert, CGImageRef &r_image);
+extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle p_src_rect, bool p_invert, CGImageRef &r_image);
 
 // IM-2013-07-18: [[ ResIndependence ]] added scale parameter to support hi-res images
 static bool MCGImageToUIImage(MCGImageRef p_image, bool p_copy, MCGFloat p_scale, UIImage *&r_uiimage)
@@ -277,7 +277,7 @@ static bool MCGImageToUIImage(MCGImageRef p_image, bool p_copy, MCGFloat p_scale
 	CGImageRef t_cg_image = nil;
 	UIImage *t_image = nil;
 	
-	t_success = MCGImageToCGImage(p_image, MCGRectangleMake(0, 0, MCGImageGetWidth(p_image), MCGImageGetHeight(p_image)), p_copy, false, t_cg_image);
+	t_success = MCGImageToCGImage(p_image, MCGIntegerRectangleMake(0, 0, MCGImageGetWidth(p_image), MCGImageGetHeight(p_image)), false, t_cg_image);
 	
 	if (t_success)
 		t_success = nil != (t_image = [UIImage imageWithCGImage:t_cg_image scale:p_scale orientation:/*0.0*/UIImageOrientationUp]);

--- a/engine/src/osxcisupport.mm
+++ b/engine/src/osxcisupport.mm
@@ -32,7 +32,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 ////////////////////////////////////////////////////////////////////////////////
 
 extern bool MCMacPlatformGetImageColorSpace(CGColorSpaceRef &r_colorspace);
-extern bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, bool p_copy, bool p_invert, CGImageRef &r_image);
+extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, bool p_invert, CGImageRef &r_image);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -249,7 +249,7 @@ bool MCGImageToCIImage(MCGImageRef p_image, CIImage *&r_image)
 {
 	CGImageRef t_cg_image = nil;
 	CIImage *t_ci_image = nil;
-	if (!MCGImageToCGImage(p_image, MCGRectangleMake(0, 0, MCGImageGetWidth(p_image), MCGImageGetHeight(p_image)), false, false, t_cg_image))
+	if (!MCGImageToCGImage(p_image, MCGIntegerRectangleMake(0, 0, MCGImageGetWidth(p_image), MCGImageGetHeight(p_image)), false, t_cg_image))
 		return false;
 	
 	bool t_success = true;

--- a/engine/src/osxprinter.cpp
+++ b/engine/src/osxprinter.cpp
@@ -77,8 +77,8 @@ extern void MCRemotePageSetupDialog(MCDataRef p_config_data, MCDataRef &r_reply_
 // SN-2014-12-22: [[ Bug 14278 ]] Parameter added to choose a UTF-8 string.
 extern char *osx_cfstring_to_cstring(CFStringRef p_string, bool p_release = true, bool p_utf8_string = false);
 extern bool MCImageBitmapToCGImage(MCImageBitmap *p_bitmap, bool p_copy, bool p_invert, CGImageRef &r_image);
-extern bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, CGColorSpaceRef p_colorspace, bool p_copy, bool p_invert, CGImageRef &r_image);
-extern bool MCGImageToCGImage(MCGImageRef p_src, MCGRectangle p_src_rect, bool p_copy, bool p_invert, CGImageRef &r_image);
+extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, CGColorSpaceRef p_colorspace, bool p_invert, CGImageRef &r_image);
+extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_src_rect, bool p_invert, CGImageRef &r_image);
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1178,9 +1178,9 @@ bool MCGImageToCGImage(MCGImageRef p_src, CGImageRef &r_image)
 	if (t_success)
 		t_success = nil != (t_colorspace = OSX_CGColorSpaceCreateGenericRGB());
 	
-	MCGRectangle t_src_rect = MCGRectangleMake(0, 0, MCGImageGetWidth(p_src), MCGImageGetHeight(p_src));
+	MCGIntegerRectangle t_src_rect = MCGIntegerRectangleMake(0, 0, MCGImageGetWidth(p_src), MCGImageGetHeight(p_src));
 	if (t_success)
-		t_success = MCGImageToCGImage(p_src, t_src_rect, t_colorspace, true, true, r_image);
+		t_success = MCGImageToCGImage(p_src, t_src_rect, t_colorspace, true, r_image);
 	
 	if (t_colorspace != nil)
 		CGColorSpaceRelease(t_colorspace);
@@ -1814,7 +1814,7 @@ void MCQuartzMetaContext::domark(MCMark *p_mark)
 			
 			// MW-2013-10-01: [[ ImprovedPrint ]] If we didn't manage to use the input data, use the bitmap instead.
 			if (t_image == nil)
-				/* UNCHECKED */ MCGImageToCGImage(p_mark->image.descriptor.image, MCGRectangleMake(0, 0, t_dst_width, t_dst_height), false, false, t_image);
+				/* UNCHECKED */ MCGImageToCGImage(p_mark->image.descriptor.image, MCGIntegerRectangleMake(0, 0, t_dst_width, t_dst_height), false, t_image);
 
 			CGContextClipToRect(m_context, CGRectMake(p_mark -> image . dx, p_mark -> image . dy, p_mark -> image . sw, p_mark -> image . sh));
 			
@@ -1913,7 +1913,7 @@ void MCQuartzMetaContext::endcomposite(MCRegionRef p_clip_region)
 	m_composite_context = nil;
 	
 	CGImageRef t_cgimage = nil;
-	/* UNCHECKED */ MCGImageToCGImage(t_image, MCGRectangleMake(0, 0, MCGImageGetWidth(t_image), MCGImageGetHeight(t_image)), false, true, t_cgimage);
+	/* UNCHECKED */ MCGImageToCGImage(t_image, MCGIntegerRectangleMake(0, 0, MCGImageGetWidth(t_image), MCGImageGetHeight(t_image)), true, t_cgimage);
 	
 	CGContextDrawImage(m_context, CGRectMake(m_composite_rect . x, m_composite_rect . y, m_composite_rect . width, m_composite_rect . height), t_cgimage);
 	CGImageRelease(t_cgimage);


### PR DESCRIPTION
The CGImage created while printing to preview can in some circumstances be retained and used after the MCGImageRef from which it was created has been destroyed.

This patch modifies the MCGImageToCGImage function to maintain a reference to the source MCGImageRef until the CGImage is freed
