### PR TITLE
Compile the engine as C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "R/JfoBMrkhCGWhfWM1m3gPHuLtMBlp2SIK1R9BaPbRsbGBUJmAg9V0g0YXSaw8SVxoyuiL/jsLtHPfDeub9oTxrYydew+6/4KaoQdG7EGXQJfBhH2f0ag/hTKJfXnmZX9jMMnTxPf5Axjq+w4E6sKkU2+d1oAJRhrqzYNwDhVlc="
-   - CXX_STD: "gnu++98"
+   - CXX_STD: "c++11"
 
 # Set up the source tree by fetching Linux-specific prebuilt objects
 install: (cd prebuilt && ./fetch-libraries.sh linux)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "R/JfoBMrkhCGWhfWM1m3gPHuLtMBlp2SIK1R9BaPbRsbGBUJmAg9V0g0YXSaw8SVxoyuiL/jsLtHPfDeub9oTxrYydew+6/4KaoQdG7EGXQJfBhH2f0ag/hTKJfXnmZX9jMMnTxPf5Axjq+w4E6sKkU2+d1oAJRhrqzYNwDhVlc="
-   - CXX_STD: "c++11"
+   - CXX_STD: "c++0x"
 
 # Set up the source tree by fetching Linux-specific prebuilt objects
 install: (cd prebuilt && ./fetch-libraries.sh linux)

--- a/INSTALL-linux.md
+++ b/INSTALL-linux.md
@@ -19,7 +19,7 @@ The LiveCode build obeys all of the standard make environment variables, includi
 
 There are some additional environment variables that it understands:
 
-* `CXX_STD`: which version of the C++ standard to use (`gnu++98` is recommended)
+* `CXX_STD`: which version of the C++ standard to use (`c++11` is recommended)
 
 ## Configuring LiveCode
 

--- a/config/android-settings.gypi
+++ b/config/android-settings.gypi
@@ -1,4 +1,9 @@
 {
+	'variables':
+	{
+		'c++_std': '<!(echo ${CXX_STD:-c++11})',
+	},
+
 	'cflags':
 	[
 		'-fstrict-aliasing',
@@ -13,7 +18,7 @@
 	
 	'cflags_cc':
 	[
-		'-std=c++03',
+		'-std=<(c++_std)',
 		'-fno-exceptions',
 		'-fno-rtti',
 	],

--- a/config/emscripten-settings.gypi
+++ b/config/emscripten-settings.gypi
@@ -9,7 +9,7 @@
 		'exe_suffix': '.js',
 		'debug_info_suffix': '.dbg',
 
-		'c++_std': '<!(echo ${CXX_STD:-c++03})',
+		'c++_std': '<!(echo ${CXX_STD:-c++11})',
 	},
 
 	'defines':

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -7,8 +7,9 @@
 		'ext_suffix': '.so',
 		'exe_suffix': '',
 		'debug_info_suffix': '.dbg',
-		
-		'c++_std': '<!(echo ${CXX_STD:-c++03})',
+
+		# Note: using old name for compatibility with older compilers (like GCC 4.4)
+		'c++_std': '<!(echo ${CXX_STD:-c++0x})',
 	},
 	
 	'defines':

--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -29,6 +29,7 @@
 		'COPY_PHASE_STRIP': 'NO',
 		'STRIP_INSTALLED_PRODUCT': 'NO',
 		'CLANG_LINK_OBJC_RUNTIME': 'NO',
+		'CLANG_CXX_LANGUAGE_STANDARD': 'c++0x',
 	},
 	
 	'target_defaults':

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -205,7 +205,7 @@ OSErr MCAppleEventHandlerDoSpecial(const AppleEvent *ae, AppleEvent *reply, long
 		AEDisposeDesc(&senderDesc);
 	}
 	else
-		p3val = '\0';
+		p3val[0] = '\0';
     
 	aePtr = ae; //saving the current AE pointer for use in mcs_request_ae()
 	MCParameter p1, p2, p3;
@@ -525,18 +525,18 @@ sysfolders;
 // http://lists.apple.com/archives/carbon-development/2003/Oct/msg00318.html
 
 static sysfolders sysfolderlist[] = {
-    {&MCN_desktop, 'desk', kOnAppropriateDisk, 'desk'},
-    {&MCN_fonts,'font', kOnAppropriateDisk, 'font'},
-    {&MCN_preferences,'pref', kUserDomain, 'pref'},
-    {&MCN_temporary,'temp', kUserDomain, 'temp'},
-    {&MCN_system, 'macs', kOnAppropriateDisk, 'macs'},
+    {&MCN_desktop, 'desk', OSType(kOnAppropriateDisk), 'desk'},
+    {&MCN_fonts,'font', OSType(kOnAppropriateDisk), 'font'},
+    {&MCN_preferences,'pref', OSType(kUserDomain), 'pref'},
+    {&MCN_temporary,'temp', OSType(kUserDomain), 'temp'},
+    {&MCN_system, 'macs', OSType(kOnAppropriateDisk), 'macs'},
     // TS-2007-08-20: Added to allow a common notion of "home" between all platforms
-    {&MCN_home, 'cusr', kUserDomain, 'cusr'},
+    {&MCN_home, 'cusr', OSType(kUserDomain), 'cusr'},
     // MW-2007-09-11: Added for uniformity across platforms
-    {&MCN_documents, 'docs', kUserDomain, 'docs'},
+    {&MCN_documents, 'docs', OSType(kUserDomain), 'docs'},
     // MW-2007-10-08: [[ Bug 10277 ] Add support for the 'application support' at user level.
     // FG-2014-09-26: [[ Bug 13523 ]] This entry must not match a request for "asup"
-    {&MCN_support, 0, kUserDomain, 'asup'},
+    {&MCN_support, 0, OSType(kUserDomain), 'asup'},
 };
 
 static bool MCS_mac_specialfolder_to_mac_folder(MCStringRef p_type, uint32_t& r_folder, OSType& r_domain)

--- a/engine/src/lnxgtktheme.cpp
+++ b/engine/src/lnxgtktheme.cpp
@@ -816,13 +816,13 @@ Widget_Part MCNativeTheme::hittestcombobutton(const MCWidgetInfo &winfo,
 	const int btnWidth = getmetric(WTHEME_METRIC_COMBOSIZE);
 
 
-	MCRectangle btnRect = {	drect.x + (drect.width - btnWidth),
+	MCRectangle btnRect = {	int2(drect.x + (drect.width - btnWidth)),
 	                        drect.y,
-	                        btnWidth,
+	                        int2(btnWidth),
 	                        drect.height };
 	MCRectangle txtRect = { drect.x,
 	                        drect.y,
-	                        drect.width - btnWidth,
+	                        int2(drect.width - btnWidth),
 	                        drect.height };
 
 	if(MCU_point_in_rect(btnRect, mx, my))

--- a/engine/src/mblsensor.cpp
+++ b/engine/src/mblsensor.cpp
@@ -206,7 +206,7 @@ MCStringRef MCSensorTypeToStringRef(MCSensorType p_sensor)
         default:
 			return MCSTR("unknown");
     }
-    return false;
+    return NULL;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -126,7 +126,7 @@ bool MCNativeLayerMac::doPaint(MCGContextRef p_context)
     
     // Draw the image
     // FG-2014-10-10: a y offset of 1 is needed to keep things lined up, for some reason...
-    MCGRectangle rect = {{0, 1}, {t_raster.width, t_raster.height}};
+    MCGRectangle rect = {{0, 1}, {MCGFloat(t_raster.width), MCGFloat(t_raster.height)}};
     MCGContextDrawImage(p_context, t_gimage, rect, kMCGImageFilterNone);
     MCGImageRelease(t_gimage);
     

--- a/revmobile/src/DVTiPhoneSimulatorRemoteClient.h
+++ b/revmobile/src/DVTiPhoneSimulatorRemoteClient.h
@@ -78,7 +78,7 @@
 - (id)dvt_latestRuntime;
 - (id)dvt_supportedArchs;
 - (id)dvt_supportedArchStrings;
-- (_Bool)dvt_has64BitArch;
+- (bool)dvt_has64BitArch;
 @end
 
 @interface SimDeviceSet (DVTAdditions)


### PR DESCRIPTION
In addition to updating GCC/Clang flags to request C++11/C++0x (depending on which the compiler recognises!) this PR fixes a few issues that are flagged as errors in C++11 mode.

Note that MSVC always compiles C++ using the newest standard available so no flag is required in order to enable it for Windows.
