### PR TITLE
Clean up incorrect precedence of logical not operator

### DIFF
--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -193,6 +193,7 @@
 							'-Werror=uninitialized',
 							'-Werror=return-type',
 							'-Werror=tautological-compare',
+							'-Werror=logical-not-paretheses',
 						],
 					},
 				},

--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -124,6 +124,7 @@
 							'-Werror=uninitialized',
 							'-Werror=return-type',
 							'-Werror=tautological-compare',
+							'-Werror=logical-not-parentheses',
 						],
 					},
 				},

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -2704,7 +2704,7 @@ void MCSetResource::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
     if (!ctxt . EvalExprAsStringRef(value, EE_RESOURCES_BADPARAM, &t_value))
         return;
     
-    if (!MCStringGetLength(*t_id) > 0 && !MCStringGetLength(*t_name) > 0)
+    if (MCStringGetLength(*t_id) <= 0 || MCStringGetLength(*t_name) <= 0)
     {
         ctxt . LegacyThrow(EE_RESOURCES_BADPARAM);
         return;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -2704,7 +2704,7 @@ void MCSetResource::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
     if (!ctxt . EvalExprAsStringRef(value, EE_RESOURCES_BADPARAM, &t_value))
         return;
     
-    if (MCStringGetLength(*t_id) <= 0 || MCStringGetLength(*t_name) <= 0)
+    if (MCStringIsEmpty(*t_id) || MCStringIsEmpty(*t_name))
     {
         ctxt . LegacyThrow(EE_RESOURCES_BADPARAM);
         return;

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -530,13 +530,13 @@ bool MCScreenDC::loadfont(MCStringRef p_path, bool p_globally, void*& r_loaded_f
     MCAutoStringRefAsSysString t_font_file;
     t_font_file . Lock(p_path);
     
-    if (!FcConfigAppFontAddFile(t_config, (FcChar8*)*t_font_file) == FcTrue)
+    if (FcFalse == FcConfigAppFontAddFile(t_config, (FcChar8*)*t_font_file))
         return false;
     
-    if (!FcConfigSetCurrent(t_config))
+    if (FcFalse == FcConfigSetCurrent(t_config))
         return false;
     
-    if (!FcConfigBuildFonts(t_config))
+    if (FcFalse == FcConfigBuildFonts(t_config))
         return false;
     
     // We don't actually do anything with the loaded font handle at the moment.


### PR DESCRIPTION
The C++ `!` operator has lower precedence than comparisons.
