### PR TITLE
[Cleanup] Deletions of non-final classes without virtual destructors

### DIFF
--- a/config/android-settings.gypi
+++ b/config/android-settings.gypi
@@ -34,6 +34,11 @@
 				[
 					'-Werror=declaration-after-statement',	# Ensure compliance with C89
 				],
+
+				'cflags_cc':
+				[
+					'-Werror=delete-non-virtual-dtor',
+				]
 			},
 			{
 				'cflags':

--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -189,6 +189,7 @@
 							'-Wall', 
 							'-Wextra', 
 							'-Werror=declaration-after-statement',
+							'-Werror=delete-non-virtual-dtor',
 							'-Wno-unused-parameter',
 							'-Werror=uninitialized',
 							'-Werror=return-type',

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -70,6 +70,12 @@
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
 				],
+
+				'cflags_cc':
+				[
+					# Needs GCC 4.7
+					#'-Werror=delete-non-virtual-dtor',
+				],
 			},
 			{
 				'cflags':

--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -119,6 +119,7 @@
 							'-Wall', 
 							'-Wextra', 
 							'-Werror=declaration-after-statement',
+							'-Werror=delete-non-virtual-dtor',
 							'-Wno-unused-parameter',
 							'-Werror=uninitialized',
 							'-Werror=return-type',

--- a/engine/src/eventqueue.h
+++ b/engine/src/eventqueue.h
@@ -93,6 +93,7 @@ void MCEventQueueClearTouches(void);
 class MCCustomEvent
 {
 public:
+	virtual ~MCCustomEvent() {};
 	virtual void Destroy(void) = 0;
 	virtual void Dispatch(void) = 0;
 };

--- a/engine/src/scriptenvironment.h
+++ b/engine/src/scriptenvironment.h
@@ -22,6 +22,8 @@ typedef char *(*MCScriptEnvironmentCallback)(const char* const* p_arguments, uns
 class MCScriptEnvironment
 {
 public:
+	virtual ~MCScriptEnvironment() {}
+
 	virtual void Retain(void) = 0;
 	virtual void Release(void) = 0;
 

--- a/lcidlc/src/InterfaceGenerate.cpp
+++ b/lcidlc/src/InterfaceGenerate.cpp
@@ -163,6 +163,8 @@ static NativeType map_native_type(HandlerMapping p_mapping, NameRef p_type)
 class TypeMapper
 {
 public:
+	virtual ~TypeMapper() {};
+
 	virtual const char *GetTypedef(ParameterType mode) = 0;
 	
 	virtual void Initialize(CoderRef coder, ParameterType mode, const char *name) = 0;

--- a/revvideograbber/src/revcapture.h
+++ b/revvideograbber/src/revcapture.h
@@ -19,6 +19,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 struct MCCaptureInputDevice
 {
+    virtual ~MCCaptureInputDevice() {}
+
 	virtual bool IsDefaultForAudio(void) = 0;
 	virtual bool IsDefaultForVideo(void) = 0;
 	
@@ -30,6 +32,8 @@ struct MCCaptureInputDevice
 
 struct MCCaptureAudioPreviewDevice
 {
+    virtual ~MCCaptureAudioPreviewDevice() {}
+
 	virtual bool IsDefault(void) = 0;
 	
 	virtual const char *GetName(void) = 0;
@@ -106,6 +110,8 @@ struct MCCaptureImageBuffer
 
 struct MCCaptureSession
 {
+    virtual ~MCCaptureSession() {}
+
 	virtual bool Create(MCCaptureSessionDelegate *delegate) = 0;
 	virtual void Destroy(void) = 0;
 	


### PR DESCRIPTION
When using the C++ `delete` operator on an instance pointer of a non-final class, there is the possibility that the pointer is to an instance of a derived class.  If the base class has a non-virtual destructor, the incorrect destructor will be run.  This can be fixed by either:
- Adding a virtual destructor to the class
- Marking the class as `final`
