### PR TITLE
Use Ubuntu 14.04 Trusty Tahr for Travis CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "R/JfoBMrkhCGWhfWM1m3gPHuLtMBlp2SIK1R9BaPbRsbGBUJmAg9V0g0YXSaw8SVxoyuiL/jsLtHPfDeub9oTxrYydew+6/4KaoQdG7EGXQJfBhH2f0ag/hTKJfXnmZX9jMMnTxPf5Axjq+w4E6sKkU2+d1oAJRhrqzYNwDhVlc="
-   - CXX_STD: "c++0x"
+   - CXX_STD: "c++11"
 
 # Set up the source tree by fetching Linux-specific prebuilt objects
 install: (cd prebuilt && ./fetch-libraries.sh linux)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 # Very basic Travis CI (http://travis-ci.org) control file that allows
 # some basic Linux-based continuous integration testing (for free).
 
-language: c++
+# We currently support running LiveCode on Ubuntu 14.04 and 16.04
+# See https://docs.travis-ci.com/user/ci-environment/
+sudo: required
+dist: trusty
 
-# Use container-based infrastructure
-sudo: false
+language: c++
 
 # Skip vulcan CI branches
 branches:


### PR DESCRIPTION
Per the new platform support policy, the oldest desktop Linux that we
support is Ubuntu 14.04.
