### PR TITLE
[CID 127518] Only release MCObjectProxy with references

### DIFF
--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -5331,7 +5331,7 @@ void MCObjectProxy::Release()
 {
     // Sanity check to prevent over-releases (which implies a bug in the Handle
     // RAII class) as there shouldn't be another way to get a reference.
-    MCAssert(m_refcount >= 0);
+    MCAssert(m_refcount > 0);
     
     if (--m_refcount <= 0)
 	{


### PR DESCRIPTION
The assertion in `MCObjectProxy::Release()` was incorrect for two reasons.
- It had no effect; `m_refcount` is unsigned and therefore `m_refcount >= 0` is always true
- It asserted the wrong thing; if `m_refcount` was actually 0, then the following decrement would overflow, preventing a release
- Nothing should ever try to release an `MCObjectProxy` with 0 references, because by definition the caller wouldn't own a reference to it

This patch strengthens the assertion to `m_refcount > 0`.

Coverity-ID: 127518
