### PR TITLE
[[ Docs ]] Make sure auto-association works for docs in a library docs file

### DIFF
--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -1383,7 +1383,7 @@ function revDocsParseDocText pText, pFilename
    
    local tAssociationsDefault
    put "Associations" into tAssociationsDefault["name"]
-   put tParsedA["display name"] into tAssociationsDefault["content"]
+   put tParsedA["name"] into tAssociationsDefault["content"]
    repeat with tElementNum = tStartNum to the number of elements in tElementsA
       add 1 to tEntryElementCount
       local tElementA


### PR DESCRIPTION
In particular, mark all LCB syntax as associated with the library it is
defined in
