### PR TITLE
Fixed typo that caused installation to fail on Windows

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -367,7 +367,7 @@ component Documentation
 		rfolder "ide:Documentation/html_viewer/fonts"
 		rfolder "ide:Documentation/html_viewer/js"
 
-	into [[ToolsFolder]]/Documentation/html_viewer/resources/ place
+	into [[ToolsFolder]]/Documentation/html_viewer/resources place
 		rfolder "ide:Documentation/html_viewer/resources/media"
 
 	into [[ToolsFolder]]/Documentation/html_viewer/resources/data place


### PR DESCRIPTION
This is just a quick fix. A more robust fix would be maybe to make the parser to resolve automatically this kind (`this/is/a//path)` of paths
