### PR TITLE
build: Don't use QuickTime SDK when compiling Windows engine

### DIFF
--- a/engine/kernel-server.gyp
+++ b/engine/kernel-server.gyp
@@ -167,6 +167,7 @@
 								'-lshlwapi',
 								'-luser32',
 								'-lusp10',
+								'-lversion',
 								'-lwinmm',
 								'-lwinspool',
 								'-lws2_32',

--- a/engine/kernel-server.gyp
+++ b/engine/kernel-server.gyp
@@ -99,15 +99,6 @@
 					},
 				],
 				[
-					'OS == "win"',
-					{
-						'include_dirs':
-						[
-							'<(quicktime_sdk)/CIncludes',
-						],
-					},
-				],
-				[
 					'mobile != 0',
 					{
 						'type': 'none',
@@ -158,11 +149,6 @@
 					[
 						'OS == "win"',
 						{
-							'library_dirs':
-							[
-								'<(quicktime_sdk)/Libraries',
-							],
-							
 							'libraries':
 							[
 								'-ladvapi32',
@@ -184,9 +170,6 @@
 								'-lwinmm',
 								'-lwinspool',
 								'-lws2_32',
-								
-								'-lQTMLClient',
-								'-lQTVR',
 							],
 						},
 					],

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -251,6 +251,7 @@
 								'-lstrmiids',
 								'-luser32',
 								'-lusp10',
+								'-lversion',
 								'-lwinmm',
 								'-lwinspool',
 								'-lws2_32',

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -92,15 +92,6 @@
 					},
 				],
 				[
-					'OS == "win"',
-					{
-						'include_dirs':
-						[
-							'<(quicktime_sdk)/CIncludes',
-						],
-					},
-				],
-				[
 					'OS == "emscripten"',
 					{
 						'dependencies':
@@ -241,11 +232,6 @@
 					[
 						'OS == "win"',
 						{
-							'library_dirs':
-							[
-								'<(quicktime_sdk)/Libraries',
-							],
-							
 							'libraries':
 							[
 								'-ladvapi32',
@@ -268,9 +254,6 @@
 								'-lwinmm',
 								'-lwinspool',
 								'-lws2_32',
-								
-								'-lQTMLClient',
-								'-lQTVR',
 							],
 						},
 					],

--- a/engine/src/quicktime.cpp
+++ b/engine/src/quicktime.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2016 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -21,13 +21,18 @@
 #include "objdefs.h"
 #include "parsedef.h"
 
+#include "osspec.h"
+#include "variable.h"
+
+/* Pretty much everything in this file is only needed if quicktime
+ * effects are enabled. */
+#if defined(FEATURE_QUICKTIME_EFFECTS)
+
 #include "graphics.h"
 #include "stack.h"
 
 #include "player.h"
 #include "util.h"
-#include "osspec.h"
-#include "variable.h"
 
 #ifdef _WINDOWS_DESKTOP
 #include "w32prefix.h"
@@ -79,8 +84,6 @@ void UnlockPixels(PixMapHandle pix);
 #endif
 
 #endif
-
-#ifdef FEATURE_QUICKTIME_EFFECTS
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1262,5 +1265,5 @@ void MCQTGetVersion(MCStringRef& r_version)
 }
 
 
-#endif
+#endif /* !FEATURE_QUICKTIME_EFFECTS */
 


### PR DESCRIPTION
In LiveCode 8.1, the engine no longer uses QuickTime, so it's not
necessary to use the SDK when compiling.  This ensures that
QuickTime's bogus not-compatible C headers aren't incorrectly used
when compiling the engine.

QuickTime is still needed for compiling the revVideoGrabber external,
and that's left unchanged.
