### PR TITLE
Log installer to stdout when no log file specified

### DIFF
--- a/builder/installer_utilities.livecodescript
+++ b/builder/installer_utilities.livecodescript
@@ -1561,6 +1561,8 @@ command log pMessage
          write "[" && the internet date && "]" && ":" && pMessage & return to file sFacelessLog
          close file sFacelessLog
       end if
+   else
+      write "[" && the internet date && "]" && ":" && pMessage & return to stdout
    end if
 end log
 


### PR DESCRIPTION
Something I added while debugging tsNet integration which may help others at some point
