### PR TITLE
Cleanup use of pthreads API

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -510,6 +510,7 @@
 			'src/sysw32network.cpp',
 			'src/sysw32region.cpp',
 			'src/sysw32registry.cpp',
+			'src/mcmanagedpthread.h',
 			
 			# Group "Text"
 			'src/text.h',

--- a/engine/src/mcmanagedpthread.h
+++ b/engine/src/mcmanagedpthread.h
@@ -1,0 +1,98 @@
+/*                                                                     -*-c++-*-
+
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef __MC_MANAGED_PTHREAD_H__
+#define __MC_MANAGED_PTHREAD_H__
+
+#include <pthread.h>
+
+/* This class encapsulates a pthread_t value, and assists in tracking
+ * its state, comparing it with other threads, and some other
+ * stuff. Note that this structure is not itself thread-safe, and
+ * should normally be protected with a mutex.  (You'll probably need a
+ * mutex anyway). */
+class MCManagedPThread
+{
+ public:
+	MCManagedPThread() : m_live(false) {}
+	MCManagedPThread(pthread_t p_thread)
+		: m_live(true), m_thread(p_thread) {}
+
+	operator bool() const { return m_live; }
+
+	MCManagedPThread & operator=(pthread_t p_thread)
+	{
+		MCAssert(!m_live);
+		m_thread = p_thread;
+		m_live = true;
+		return *this;
+	}
+
+	bool operator==(const MCManagedPThread & other) const
+	{
+		return (0 != pthread_equal(m_thread, other.m_thread));
+	}
+	bool operator==(const pthread_t & other) const
+	{
+		return (0 != pthread_equal(m_thread, other));
+	}
+
+	bool IsCurrent() const
+	{
+		return operator==(pthread_self());
+	}
+
+	int Create(const pthread_attr_t *attr,
+	           void *(*start_routine) (void *),
+	           void *arg)
+	{
+		if (m_live)
+			return EDEADLK;
+
+		int status = pthread_create(&m_thread, attr, start_routine, arg);
+		m_live = (status == 0);
+		return status;
+	}
+
+	int Join(void **retval)
+	{
+		if (!m_live)
+			return EINVAL;
+
+		int status = pthread_join(m_thread, retval);
+
+		switch (status)
+		{
+		case EINVAL:
+		case ESRCH:
+		case 0:
+			m_live = false;
+			break;
+		case EDEADLK:
+			break;
+		}
+
+		return status;
+	}
+
+ private:
+	bool m_live;
+	pthread_t m_thread;
+};
+
+#endif /* !__MC_MANAGED_PTHREAD_H__ */

--- a/engine/src/notify.cpp
+++ b/engine/src/notify.cpp
@@ -232,7 +232,7 @@ static bool MCNotifyIsMainThread(void)
 #if defined(USE_WINTHREADS)
 	return GetCurrentThreadId() == s_main_thread_id;
 #elif defined(USE_PTHREADS)
-	return pthread_self() == s_main_thread;
+	return pthread_equal(pthread_self(), s_main_thread);
 #else
 #error Threading API not specified
 #endif

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -106,11 +106,12 @@ extern char *osx_cfstring_to_cstring(CFStringRef p_string, bool p_release, bool 
 #endif
 
 #if defined(USE_AUX_THREAD)
-#include <pthread.h>
+#include "mcmanagedpthread.h"
+#include <signal.h>
 
-static pthread_t s_socket_poll_thread = NULL;
+static MCManagedPThread s_socket_poll_thread;
 static pthread_mutex_t s_socket_list_mutex;
-static bool s_socket_poll_run = false;
+volatile sig_atomic_t s_socket_poll_thread_enabled;
 static int s_socket_poll_signal_pipe[2];
 #endif
 
@@ -144,7 +145,7 @@ Boolean MCSocket::sslinited = False;
 static void MCSocketsLockSocketList(void)
 {
 #if defined(USE_AUX_THREAD)
-    if (s_socket_poll_thread != NULL)
+    if (s_socket_poll_thread)
         pthread_mutex_lock(&s_socket_list_mutex);
 #endif
 }
@@ -152,7 +153,7 @@ static void MCSocketsLockSocketList(void)
 static void MCSocketsUnlockSocketList(void)
 {
 #if defined(USE_AUX_THREAD)
-    if (s_socket_poll_thread != NULL)
+    if (s_socket_poll_thread)
         pthread_mutex_unlock(&s_socket_list_mutex);
 #endif
 }
@@ -187,7 +188,7 @@ static void *MCSocketsPoll(void *p_arg)
     fd_set rmaskfd, wmaskfd, emaskfd;
     int4 maxfd;
     
-    while (s_socket_poll_run)
+    while (s_socket_poll_thread_enabled)
     {
         FD_ZERO(&rmaskfd);
         FD_ZERO(&wmaskfd);
@@ -242,7 +243,7 @@ static bool MCSocketsPollInterrupt(void)
 #if defined(USE_AUX_THREAD)
     if (t_success)
     {
-        if (s_socket_poll_thread == NULL)
+        if (!s_socket_poll_thread)
         {
             if (t_success)
                 t_success = pthread_mutex_init(&s_socket_list_mutex, NULL) == 0;
@@ -250,8 +251,8 @@ static bool MCSocketsPollInterrupt(void)
                 t_success = pipe(s_socket_poll_signal_pipe) == 0;
             if (t_success)
             {
-                s_socket_poll_run = true;
-                t_success = pthread_create(&s_socket_poll_thread, NULL, MCSocketsPoll, NULL) == 0;
+                s_socket_poll_thread_enabled = true;
+                t_success = (0 == s_socket_poll_thread.Create(NULL, MCSocketsPoll, NULL));
             }
         }
         else
@@ -265,8 +266,8 @@ static bool MCSocketsPollInterrupt(void)
 bool MCSocketsInitialize(void)
 {
 #if defined(USE_AUX_THREAD)
-    s_socket_poll_thread = NULL;
-    s_socket_poll_run = false;
+	MCMemoryReinit(s_socket_poll_thread);
+	s_socket_poll_thread_enabled = false;
 #endif
     return true;
 }
@@ -274,14 +275,13 @@ bool MCSocketsInitialize(void)
 void MCSocketsFinalize(void)
 {
 #if defined(USE_AUX_THREAD)
-    if (s_socket_poll_thread != NULL)
+    if (s_socket_poll_thread)
     {
-        s_socket_poll_run = false;
+		s_socket_poll_thread_enabled = false;
         MCSocketsPollInterrupt();
         
         void *t_result;
-        pthread_join(s_socket_poll_thread, &t_result);
-        s_socket_poll_thread = NULL;
+		s_socket_poll_thread.Join(&t_result);
         
         pthread_mutex_destroy(&s_socket_list_mutex);
     }


### PR DESCRIPTION
The `pthread_t` type is opaque, and its structure is
implementation-defined.  The POSIX thread specification doesn't
provide any value for a `pthread_t` that is guaranteed to be an
invalid thread identifier, so it can't be validly initialised to
`NULL` or compared with `NULL`.

Similarly, `pthread_t` values can only be safely compared with
`pthread_equal()`, not with `==`.

The new `MCManagedPThread` class provides an implicit `bool` cast
operator so that it can be used directly in `if` statements, provides
`==` operators for other `MCManagedPThread` values and for `pthread_t`
values for comparison purposes, and provides `Join()` and `Create()`
methods that wrap the corresponding pthread API procedures.

Most uses of `pthread_t` and related procedure calls can be replaced with `MCManagedPThread` instances.
