### PR TITLE
[[ Bug 17149 ]] Ensure iconGravity is preserved when copying buttons

### DIFF
--- a/docs/notes/bugfix-17149.md
+++ b/docs/notes/bugfix-17149.md
@@ -1,0 +1,1 @@
+# Ensure iconGravity property is preserved when copying/cloning buttons.

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -376,7 +376,7 @@ MCButton::MCButton(const MCButton &bref) : MCControl(bref)
 	family = bref.family;
     
     // MW-2014-06-19: [[ IconGravity ]] Copy the other buttons gravity
-    m_icon_gravity = kMCGravityNone;
+    m_icon_gravity = bref.m_icon_gravity;
     
     // MM-2014-07-31: [[ ThreadedRendering ]] Used to ensure the default button animate message is only posted from a single thread.
     m_animate_posted = false;

--- a/tests/lcs/core/interface/button.livecodescript
+++ b/tests/lcs/core/interface/button.livecodescript
@@ -18,21 +18,34 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 
 on TestInterface92
-   
    create stack "Test"
    set the defaultstack to "Test"
-   
+
    create button "SelTest"
-   
+
    set the style of button "SelTest" to "menu"
-   
+
    set the menuMode of button "SelTest" to "Option"
-   
+
    set the text of button "SelTest" to "bar" & CR & "foo"
-   
+
    select line 2 of button "SelTest"
-   
+
    TestAssert "test", the label of button "SelTest" is "foo"
 end TestInterface92
 
 // Test all button-specific properties.
+
+on TestIconGravity
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   set the iconGravity of the templateButton to "top"
+   create button "TestButton"
+   TestAssert "create button from template preserves iconGravity", \
+                  the iconGravity of button "TestButton" is "top"
+
+   clone button "TestButton" as "TestButtonClone"
+   TestAssert "clone button preserves iconGravity", \
+                  the iconGravity of button "TestButtonClone" is "top"
+end TestIconGravity


### PR DESCRIPTION
The constructor for MCButton was not copying the value of 'm_icon_gravity'
from the source button, causing the iconGravity of a copied/cloned button
to be reset to none.
