### PR TITLE
List directories without changing defaultFolder

### DIFF
--- a/docs/dictionary/function/files.lcdoc
+++ b/docs/dictionary/function/files.lcdoc
@@ -4,63 +4,110 @@ Type: function
 
 Syntax: the [{ detailed | long }] files
 
-Syntax: files()
+Syntax: files([<targetFolder>])
 
-Summary: Returns a list of <files> in the <defaultFolder>.
+Summary: List the files in a folder.
 
 Introduced: 1.0
 
-OS: mac,windows,linux,ios,android
+OS: mac,windows,linux,ios,android,html5
 
-Platforms: desktop,server,web,mobile
+Platforms: desktop,server,mobile
 
 Security: disk
 
 Example:
-put the files into field "Current Files"
+put files(specialFolderPath("documents")) into field "Current Docs"
+sort lines of field "Current Docs" international
 
 Example:
-repeat with x = 1 to the number of lines of the detailed files
+local tTotalSize
+repeat for each line tFileInfo in the detailed files
+   add item 3 of tFileInfo to tTotalSize
+end repeat
+answer merge("The files in the current folder use" && \
+      "[[tTotalSize]] bytes")
 
 Example:
-put the files & the folders into diskContents[the defaultFolder]
+put the files & return & the folders into \
+      diskContents[the defaultFolder]
+filter diskContents[the defaultFolder] without ".."
 
-Returns:
-The <files> <function> returns a list of file names, one per <line>. 
-The detailed files form returns a list of files, one file per line. Each line contains the following attributes, separated by commas:
-1. The file's name, URL-encoded
-2. The file's size in bytes (on Mac OS and OS X systems, the size of the file's data fork)
-3. The resource fork size in bytes (Mac OS and OS X systems only)
-4. The file's creation date in seconds (Mac OS, OS X, and Windows systems only)
-5. The file's modification date in seconds
-6. The file's last-accessed date in seconds (Unix, OS X and Windows systems only)
-7. The file's last-backup date in seconds (Mac OS and OS X systems only)
-8. The file's owner (Unix and OS X systems only)
-9. The file's group owner (Unix and OS X systems only)
-10. The file's access permissions
-11. The file's creator and file type (Mac OS and OS X only)
-Any attribute that is not supported on the current system is reported as empty.
+Returns (String): A list of file names or file information, with one
+file per line.
 
 Description:
-Use the <files> <function> to obtain a list of <files> to display for the user, or to perform an action on each <file> in the <current folder>.
+<Return(glossary)> a list of <file|files> in the <targetFolder>, with
+one file per line.  If no <targetFolder> is specified, list the files
+in the <current folder>.
 
-Folders in the <defaultFolder> are not included. To get a list of folders, use the <folders> function.
+<folder(glossary)|Folders> are not included in the list.  To get a
+list of folders, use the <folders> function.
 
-The names of aliases (on Mac OS and OS X systems), symbolic links (on Unix systems), and shortcuts (on Windows systems) are included in the value returned by the <files> if they refer to a <file>.  If they refer to a <folder>, they are not included. 
+<alias|Aliases> (on OS X systems), <symbolic links|symbolic links> (on
+Linux systems) and <shortcut|shortcuts> (on Windows systems) are
+included in the list only if they refer to a <file>.
 
-The forms the detailed files and the long files are synonyms. 
+> *Note:* The order that files are listed is platform-dependent.  The
+> order may vary between <platform|platforms>, between filesystems,
+> and even between consecutive calls to the <files> function.  If you
+> need a sorted list, use the <sort> command.
 
-When listed in the detailed files form, each file's name is URL-encoded.  To obtain the name in plain text, use the <URLDecode> function. If the detailed modifier is not used, the filename is not encoded. 
+### Short form
 
-The access permissions returned in the detailed files form consist of three octal digits. The form is the same as that used for the <umask> property.
+When the <files> is called as a <function>, or without the `long` or
+`detailed` modifiers, it <return(glossary)|returns> only the <file>
+names as a string with one file name per line.
 
-The creator and file type returned in the detailed files form is an eight-character string. The first four characters are the creator signature, and the last four are the file type.  
- 
->*Note:* For efficiency reasons, the <files> function returns a list in the order provided by the operating system which can differ between platforms and even file systems. If you require an ordered list use the <sort> command explicitly afterwards. 
- 
-Changes: 
-The detailed files form was introduced in version 1.1. In previous versions, the <files> function provided only a list of file names.
+> *Note:* On some <platform|platforms>, file names are permitted to
+> include the <return(constant)|linefeed> character.  Such a file name
+> would be split across more than one line of the string returned by
+> the <files> <function>.
 
-References: fileType (property), umask (property), defaultFolder (property), file (keyword), line (keyword), sort (command), answer file (command), folders (function), files (function), volumes (function), URLDecode (function), current folder (glossary), folder (glossary), function (control structure)
+### Long form
+
+`the long files` and `the detailed files` are synonyms.  When the
+<files> <function> is called in this form, the <return(glossary)>
+value is a list of files with detailed file attributes.
+
+Each line in the return value is a comma-separated list of file
+attributes, as follows:
+
+1. **Name**.  The file name is URL-encoded.  To obtain the name as
+   plain text, use the <URLDecode> function.
+2. **Size**, in bytes.  On OS X systems, this is the size of the <data
+   fork>.
+3. **Resource fork size**, in bytes.  (OS X only).
+4. **Creation date**, in seconds.  (OS X and Windows only).
+5. **Last modification date**, in seconds.
+6. **Last access date**, in seconds.
+7. **Last backup date**, in seconds.
+8. **User owner**.  (Linux and OS X only).
+9. **Group owner**.  (Linux and OS X only).
+10. **Permissions**. (Linux and OS X only; see note).
+11. **Creator and <fileType|file type>**.  (OS X only).
+
+Any attribute that is not relevant to the current <platform> is left
+empty.
+
+The access permissions consist of three octal digits, in the same form
+used for the <umask> property.
+
+> *Note:* On Windows, the permissions are always reported as "777".
+
+Changes:
+The long form was introduced in version 1.1.
+The optional <targetFolder> argument for the function call form was
+introduced in version 8.1.
+
+References:
+sort(command),
+return(constant),
+folders(function), specialFolderPath(function),
+defaultFolder(property), umask(property),
+alias(glossary), current folder(glossary), data fork(glossary),
+folder(glossary), function(glossary), platform(glossary),
+return(glossary), resource fork(glossary), shortcut(glossary),
+symbolic link(glossary),
 
 Tags: file system

--- a/docs/dictionary/function/folders.lcdoc
+++ b/docs/dictionary/function/folders.lcdoc
@@ -4,62 +4,118 @@ Type: function
 
 Syntax: the [{ detailed | long }] folders
 
-Syntax: folders()
+Syntax: folders([<targetFolder>])
 
-Summary: Returns a list of the <folders> in the current <defaultFolder>.
-
-Synonyms: directories
+Summary: List the subfolders in a folder.
 
 Introduced: 1.0
 
-OS: mac,windows,linux,ios,android
+OS: mac,windows,linux,ios,android,html5
 
-Platforms: desktop,server,web,mobile
+Platforms: desktop,server,mobile
 
 Security: disk
 
 Example:
-set the defaultFolder to line x of the folders
+put folders(specialFolderPath("documents")) into \
+      field "Available Folders"
+filter lines of field "Available Folders" without ".."
+sort lines of field "Available Folders" international
 
 Example:
-put the detailed folders into folderList
+put the files & return & the folders into \
+      diskContents[the defaultFolder]
+filter diskContents[the defaultFolder] without ".."
 
-Returns:
-The <folders> <function> returns a list of <folder> names, one per <line>. 
-The detailed <folders> form returns a list of folders, one file per line. Each line contains the following attributes, separated by commas. (Several attributes are used only for compatibility with the <files> <function> and do not have any meaning for <folders>.)
-* The folder's name
-* The folder's size in bytes (always zero)
-* The folder's resource fork size in bytes (always zero)
-* The folder's creation date in seconds (Mac OS, OS X, and Windows systems only)
-* The folder's modification date in seconds
-* The folder's last-accessed date in seconds (Unix and Windows systems only)
-* The folder's last-backup date in seconds (Mac OS and OS X systems only)
-* The folder's owner (Unix systems only)
-* The folder's group owner (Unix systems only)
-* The folder's access permissions
-* The folder's creator and file type (always "????????") (Mac OS and OS X only)
-Any attribute that is not supported on the current system is reported as "0" (zero).
+Returns (String): A list of folder names or folder information, with
+one file per line.
 
 Description:
-Use the <folders> <function> to obtain a list of <folders> to display for the user, or to perform an action on each <folder> in the <current folder>.
+<Return(glossary)> a list of <folder(glossary)|folders> in the
+<targetFolder>, with one file per line.  If no <targetFolder> is
+specified, list the files in the <current folder>.
 
-Files in the <defaultFolder> are not included. To get a list of <folders>, use the <files> <function>. 
+The list only includes folders at the top level of the target folder.
+The <folders> <function> does not recursively enter and examine
+folders deeper in the filesystem.  To examine the contents of a
+<subfolder|subfolders>, either pass its path as the <targetFolder>, or
+temporarily set the <defaultFolder>.
 
-The names of aliases (on Mac OS systems), symbolic links (on Unix systems), and shortcuts (on Windows systems) are included in the value returned by the <folders> if they link to a <folder>. If they link to a <file>, they are not included. 
+<file(glossary)|Files> are not included in the list.  To get a list of
+files, use the <files> function.
 
-This function lists only the folders on the top level of the <defaultFolder>.  To get a list of <subfolder|subfolders> within a <folder>, set the <defaultFolder> to that <folder> and then use the <folders> <function> again.
+<alias|Aliases> (on OS X systems), <symbolic links|symbolic links> (on
+Linux systems) and <shortcut|shortcuts> (on Windows systems) are
+included in the list only if they refer to a <folder>.
 
-When listed in the detailed <folders> form, each folder's name is URL-encoded. To obtain the name in plain text, use the <URLDecode> <function>. If the detailed modifier is not used, the folder name is not encoded.
+> *Important:* The list returned by the <folders> contain a ".." entry
+> representing the link to the parent folder. Care must be taken to
+> filter this entry out to prevent infinite loops and security
+> vulnerabilities.
 
-The access permissions returned in the detailed <files> form consist of three octal digits. The form is the same as that used for the <umask> <command>.
+> *Note:* The order that folders are listed is platform-dependent.
+> The order may vary between <platform|platforms>, between
+> filesystems, and even between consecutive calls to the <folders>
+> function.  If you need a sorted list, use the <sort> command.
 
->*Important:* The list returned by the <folders> contain a ".." entry representing the link to the parent folder. Care must be taken to filter this entry out when performing recursive operations to prevent infinite loops.
+### Short form
 
->*Note:* For efficiency reasons, the <folders> function returns a list in the order provided by the operating system which can differ between platforms and even file systems. If you require an ordered list use the sort command explicitly afterwards.
+When the <folders> is called as a <function>, or without the `long` or
+`detailed` modifiers, it <return(glossary)|returns> only the <folder>
+names as a string with one file name per line.
+
+> *Note:* On some <platform|platforms>, folder names are permitted to
+> include the <return(constant)|linefeed> character.  Such a folder
+> name would be split across more than one line of the string returned
+> by the <folders> <function>.
+
+### Long form
+
+`the long folders` and `the detailed folders` are synonyms.  When the
+<folders> <function> is called in this form, the <return(glossary)>
+value is a list of folders with detailed file attributes.  Several of
+the attributes are provided only for compatibility with the <files>
+<function> and do not have any meaning for a <folder>.
+
+Each line in the return value is a comma-separated list of file
+attributes, as follows:
+
+1. **Name**.  The folder name is URL-encoded.  To obtain the name as
+   plain text, use the <URLDecode> function.
+2. **Size**, in bytes.  This is always 0.
+3. **Resource fork size**, in bytes.  This is always 0.
+4. **Creation date**, in seconds.  (OS X and Windows only).
+5. **Last modification date**, in seconds.
+6. **Last access date**, in seconds.
+7. **Last backup date**, in seconds.
+8. **User owner**.  (Linux and OS X only).
+9. **Group owner**.  (Linux and OS X only).
+10. **Permissions**. (Linux and OS X only; see note).
+11. **Creator and <fileType|file type>**.  (OS X only).
+
+Any attribute that is not relevant to the current <platform> is left
+empty.
+
+The access permissions consist of three octal digits, in the same form
+used for the <umask> property.
+
+> *Note:* On Windows, the permissions are always reported as "777".
+
+The creator and file type are always "????????".
 
 Changes:
-The detailed <folders> form was introduced in version 1.1. In previous versions, the <folders> <function> provided only a list of <folder> names.
+The long form was introduced in version 1.1.
+The optional <targetFolder> argument for the function call form was
+introduced in version 8.1.
 
-References: defaultFolder (property), umask (property), file (keyword), line (keyword), revDeleteFolder (command), folders (function), files (function), volumes (function), URLDecode (function), subfolder (glossary), command (glossary), current folder (glossary), folder (glossary), function (control structure)
+References:
+sort(command),
+return(constant),
+folders(function), specialFolderPath(function),
+defaultFolder(property), umask(property),
+alias(glossary), current folder(glossary), data fork(glossary),
+folder(glossary), function(glossary), platform(glossary),
+return(glossary), resource fork(glossary), shortcut(glossary),
+subfolder (glossary), symbolic link(glossary),
 
 Tags: file system

--- a/docs/notes/feature-list_non_current_directory.md
+++ b/docs/notes/feature-list_non_current_directory.md
@@ -1,0 +1,17 @@
+# List folders other than the default folder
+
+When called as a function, the **files** and **folders** functions
+now take an optional argument specifying which directory to list.
+This makes writing filesystem code a lot easier, since code that
+looked like:
+
+    local tOldFolder, tFilesList
+    put the defaultFolder into tOldFolder
+    set the defaultFolder to "/path/to/target/directory"
+    put the files into tFilesList
+    set the defaultFolder to tOldFolder
+    return tFilesList
+
+can be replaced with:
+
+    return files("/path/to/target/directory")

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -36,6 +36,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 MC_EXEC_DEFINE_EVAL_METHOD(Files, Directories, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(Files, Files, 1)
+MC_EXEC_DEFINE_EVAL_METHOD(Files, FilesOfDirectory, 2)
 MC_EXEC_DEFINE_EVAL_METHOD(Files, DiskSpace, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(Files, DriverNames, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(Files, Drives, 1)
@@ -164,7 +165,15 @@ void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string)
     r_string = MCValueRetain(kMCEmptyString);
 }
 
-void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string)
+void MCFilesEvalFiles(MCExecContext & ctxt,
+                      MCStringRef & r_string)
+{
+	MCFilesEvalFilesOfDirectory(ctxt, nil, r_string);
+}
+
+void MCFilesEvalFilesOfDirectory(MCExecContext& ctxt,
+                                 MCStringRef p_directory,
+                                 MCStringRef& r_string)
 {
 	if (MCsecuremode & MC_SECUREMODE_DISK)
 	{
@@ -172,11 +181,14 @@ void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string)
 		return;
 	}
 	MCAutoListRef t_list;
-	if (MCS_getentries(nil, true, false, &t_list) && MCListCopyAsString(*t_list, r_string))
-		return;
-
-    // SN-2014-10-07: [[ Bug 13619 ]] 'the files' should return empty, in case of an error
-    r_string = MCValueRetain(kMCEmptyString);
+	if (MCS_getentries(p_directory, true, false, &t_list))
+	{
+		MCListCopyAsString(*t_list, r_string);
+	}
+	else
+	{
+		MCStringCopy(kMCEmptyString, r_string);
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -157,7 +157,7 @@ void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string)
 		return;
 	}
 	MCAutoListRef t_list;
-	if (MCS_getentries(false, false, &t_list) && MCListCopyAsString(*t_list, r_string))
+	if (MCS_getentries(nil, false, false, &t_list) && MCListCopyAsString(*t_list, r_string))
 		return;
 
     // SN-2014-10-07: [[ Bug 13619 ]] 'the folders' should return empty, in case of an error
@@ -172,7 +172,7 @@ void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string)
 		return;
 	}
 	MCAutoListRef t_list;
-	if (MCS_getentries(true, false, &t_list) && MCListCopyAsString(*t_list, r_string))
+	if (MCS_getentries(nil, true, false, &t_list) && MCListCopyAsString(*t_list, r_string))
 		return;
 
     // SN-2014-10-07: [[ Bug 13619 ]] 'the files' should return empty, in case of an error
@@ -2796,7 +2796,7 @@ void MCFilesGetFiles(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(true, false, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, true, false, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();
@@ -2808,7 +2808,7 @@ void MCFilesGetDetailedFiles(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(true, true, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, true, true, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();
@@ -2820,7 +2820,7 @@ void MCFilesGetFolders(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(false, false, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, false, false, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();
@@ -2832,7 +2832,7 @@ void MCFilesGetDetailedFolders(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(false, true, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, false, true, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -35,6 +35,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 ////////////////////////////////////////////////////////////////////////////////
 
 MC_EXEC_DEFINE_EVAL_METHOD(Files, Directories, 1)
+MC_EXEC_DEFINE_EVAL_METHOD(Files, DirectoriesOfDirectory, 2)
 MC_EXEC_DEFINE_EVAL_METHOD(Files, Files, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(Files, FilesOfDirectory, 2)
 MC_EXEC_DEFINE_EVAL_METHOD(Files, DiskSpace, 1)
@@ -150,7 +151,15 @@ MCExecEnumTypeInfo *kMCFilesEofEnumTypeInfo = &_kMCFilesEofEnumTypeInfo;
 
 //////////
 
-void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string)
+void MCFilesEvalDirectories(MCExecContext & ctxt,
+                            MCStringRef & r_string)
+{
+	MCFilesEvalDirectoriesOfDirectory(ctxt, nil, r_string);
+}
+
+void MCFilesEvalDirectoriesOfDirectory(MCExecContext& ctxt,
+                                       MCStringRef p_directory,
+                                       MCStringRef& r_string)
 {
 	if (MCsecuremode & MC_SECUREMODE_DISK)
 	{
@@ -158,11 +167,14 @@ void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string)
 		return;
 	}
 	MCAutoListRef t_list;
-	if (MCS_getentries(nil, false, false, &t_list) && MCListCopyAsString(*t_list, r_string))
-		return;
-
-    // SN-2014-10-07: [[ Bug 13619 ]] 'the folders' should return empty, in case of an error
-    r_string = MCValueRetain(kMCEmptyString);
+	if (MCS_getentries(p_directory, false, false, &t_list))
+	{
+		MCListCopyAsString(*t_list, r_string);
+	}
+	else
+	{
+		MCStringCopy(kMCEmptyString, r_string);
+	}
 }
 
 void MCFilesEvalFiles(MCExecContext & ctxt,

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4006,6 +4006,7 @@ void MCEngineEvalIsNotStrictlyAnArray(MCExecContext& ctxt, MCValueRef value, boo
 ///////////
 
 extern MCExecMethodInfo *kMCFilesEvalDirectoriesMethodInfo;
+extern MCExecMethodInfo *kMCFilesEvalDirectoriesOfDirectoryMethodInfo;
 extern MCExecMethodInfo *kMCFilesEvalFilesMethodInfo;
 extern MCExecMethodInfo *kMCFilesEvalFilesOfDirectoryMethodInfo;
 extern MCExecMethodInfo *kMCFilesEvalDiskSpaceMethodInfo;
@@ -4101,6 +4102,7 @@ extern MCExecMethodInfo *kMCFilesGetFoldersMethodInfo;
 extern MCExecMethodInfo *kMCFilesGetDetailedFoldersMethodInfo;
 
 void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string);
+void MCFilesEvalDirectoriesOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, MCStringRef& r_string);
 void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string);
 void MCFilesEvalFilesOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, MCStringRef& r_string);
 void MCFilesEvalDiskSpace(MCExecContext& ctxt, real64_t& r_result);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4007,6 +4007,7 @@ void MCEngineEvalIsNotStrictlyAnArray(MCExecContext& ctxt, MCValueRef value, boo
 
 extern MCExecMethodInfo *kMCFilesEvalDirectoriesMethodInfo;
 extern MCExecMethodInfo *kMCFilesEvalFilesMethodInfo;
+extern MCExecMethodInfo *kMCFilesEvalFilesOfDirectoryMethodInfo;
 extern MCExecMethodInfo *kMCFilesEvalDiskSpaceMethodInfo;
 extern MCExecMethodInfo *kMCFilesEvalDriverNamesMethodInfo;
 extern MCExecMethodInfo *kMCFilesEvalDrivesMethodInfo;
@@ -4101,6 +4102,7 @@ extern MCExecMethodInfo *kMCFilesGetDetailedFoldersMethodInfo;
 
 void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string);
 void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string);
+void MCFilesEvalFilesOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, MCStringRef& r_string);
 void MCFilesEvalDiskSpace(MCExecContext& ctxt, real64_t& r_result);
 void MCFilesEvalDriverNames(MCExecContext& ctxt, MCStringRef& r_string);
 void MCFilesEvalDrives(MCExecContext& ctxt, MCStringRef& r_string);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2722,6 +2722,9 @@ enum Exec_errors
     
     // {EE-0891} vectordot: arrays are not key-wise compatible
     EE_VECTORDOT_MISMATCH,
+
+	// {EE-0892} files: error in folder parameter
+	EE_FILES_BADFOLDER,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2725,6 +2725,9 @@ enum Exec_errors
 
 	// {EE-0892} files: error in folder parameter
 	EE_FILES_BADFOLDER,
+
+	// {EE-0893} folders: error in folder parameter
+	EE_FOLDERS_BADFOLDER,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -693,6 +693,63 @@ void MCExists::compile(MCSyntaxFactoryRef ctxt)
 	MCSyntaxFactoryEndExpression(ctxt);
 }
 
+MCTheFiles::~MCTheFiles()
+{
+	delete m_folder;
+}
+
+Parse_stat
+MCTheFiles::parse(MCScriptPoint & sp, Boolean p_is_the)
+{
+	if (p_is_the)
+	{
+		initpoint(sp);
+	}
+	else
+	{
+		if (PS_NORMAL != get0or1param(sp, &m_folder, p_is_the))
+		{
+			MCperror->add(PE_FILES_BADPARAM, sp);
+			return PS_ERROR;
+		}
+	}
+	return PS_NORMAL;
+}
+
+void
+MCTheFiles::eval_ctxt(MCExecContext & ctxt, MCExecValue & r_value)
+{
+	if (m_folder) {
+		MCAutoStringRef t_folder;
+		if (!ctxt.EvalExprAsStringRef(m_folder, EE_FILES_BADFOLDER, &t_folder))
+			return;
+
+		r_value.type = kMCExecValueTypeStringRef;
+		MCFilesEvalFilesOfDirectory(ctxt, *t_folder, r_value.stringref_value);
+	}
+	else
+	{
+		r_value.type = kMCExecValueTypeStringRef;
+		MCFilesEvalFiles(ctxt, r_value.stringref_value);
+	}
+}
+
+void
+MCTheFiles::compile(MCSyntaxFactoryRef ctxt)
+{
+	MCSyntaxFactoryBeginExpression(ctxt, line, pos);
+	if (nil != m_folder)
+	{
+		m_folder -> compile(ctxt);
+		MCSyntaxFactoryEvalMethod(ctxt, kMCFilesEvalFilesOfDirectoryMethodInfo);
+	}
+	else
+	{
+		MCSyntaxFactoryEvalMethod(ctxt, kMCFilesEvalFilesMethodInfo);
+	}
+	MCSyntaxFactoryEndExpression(ctxt);
+}
+
 MCFontNames::~MCFontNames()
 {
 	delete type;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -624,6 +624,63 @@ void MCCommandName::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
         MCExecValueTraits<MCStringRef>::set(r_value, kMCEmptyString);
 }
 
+MCDirectories::~MCDirectories()
+{
+	delete m_folder;
+}
+
+Parse_stat
+MCDirectories::parse(MCScriptPoint & sp, Boolean p_is_the)
+{
+	if (p_is_the)
+	{
+		initpoint(sp);
+	}
+	else
+	{
+		if (PS_NORMAL != get0or1param(sp, &m_folder, p_is_the))
+		{
+			MCperror->add(PE_FILES_BADPARAM, sp);
+			return PS_ERROR;
+		}
+	}
+	return PS_NORMAL;
+}
+
+void
+MCDirectories::eval_ctxt(MCExecContext & ctxt, MCExecValue & r_value)
+{
+	if (m_folder) {
+		MCAutoStringRef t_folder;
+		if (!ctxt.EvalExprAsStringRef(m_folder, EE_FILES_BADFOLDER, &t_folder))
+			return;
+
+		r_value.type = kMCExecValueTypeStringRef;
+		MCFilesEvalDirectoriesOfDirectory(ctxt, *t_folder, r_value.stringref_value);
+	}
+	else
+	{
+		r_value.type = kMCExecValueTypeStringRef;
+		MCFilesEvalDirectories(ctxt, r_value.stringref_value);
+	}
+}
+
+void
+MCDirectories::compile(MCSyntaxFactoryRef ctxt)
+{
+	MCSyntaxFactoryBeginExpression(ctxt, line, pos);
+	if (nil != m_folder)
+	{
+		m_folder -> compile(ctxt);
+		MCSyntaxFactoryEvalMethod(ctxt, kMCFilesEvalDirectoriesOfDirectoryMethodInfo);
+	}
+	else
+	{
+		MCSyntaxFactoryEvalMethod(ctxt, kMCFilesEvalDirectoriesMethodInfo);
+	}
+	MCSyntaxFactoryEndExpression(ctxt);
+}
+
 MCDriverNames::~MCDriverNames()
 {
 	delete type;
@@ -709,7 +766,7 @@ MCTheFiles::parse(MCScriptPoint & sp, Boolean p_is_the)
 	{
 		if (PS_NORMAL != get0or1param(sp, &m_folder, p_is_the))
 		{
-			MCperror->add(PE_FILES_BADPARAM, sp);
+			MCperror->add(PE_FOLDERS_BADPARAM, sp);
 			return PS_ERROR;
 		}
 	}
@@ -721,7 +778,7 @@ MCTheFiles::eval_ctxt(MCExecContext & ctxt, MCExecValue & r_value)
 {
 	if (m_folder) {
 		MCAutoStringRef t_folder;
-		if (!ctxt.EvalExprAsStringRef(m_folder, EE_FILES_BADFOLDER, &t_folder))
+		if (!ctxt.EvalExprAsStringRef(m_folder, EE_FOLDERS_BADFOLDER, &t_folder))
 			return;
 
 		r_value.type = kMCExecValueTypeStringRef;

--- a/engine/src/funcs.h
+++ b/engine/src/funcs.h
@@ -761,12 +761,16 @@ public:
     virtual ~MCExtents(){}
 };
 
-class MCTheFiles : public MCConstantFunctionCtxt<MCStringRef, MCFilesEvalFiles>
+class MCTheFiles : public MCFunction
 {
 public:
-	// virtual Exec_stat eval(MCExecPoint &);
-	virtual MCExecMethodInfo *getmethodinfo(void) const { return kMCFilesEvalFilesMethodInfo; }
-
+	MCTheFiles() : m_folder(nil) {}
+	virtual ~MCTheFiles();
+	virtual Parse_stat parse(MCScriptPoint &, Boolean p_is_the);
+	virtual void eval_ctxt(MCExecContext &, MCExecValue &);
+	virtual void compile(MCSyntaxFactoryRef);
+private:
+	MCExpression *m_folder;
 };
 
 class MCFlushEvents : public MCUnaryFunctionCtxt<MCNameRef, MCStringRef, MCInterfaceEvalFlushEvents, EE_FLUSHEVENTS_BADTYPE, PE_FLUSHEVENTS_BADPARAM, kMCInterfaceEvalFlushEventsMethodInfo>

--- a/engine/src/funcs.h
+++ b/engine/src/funcs.h
@@ -592,12 +592,16 @@ public:
     virtual ~MCDecompress(){}
 };
 
-class MCDirectories : public MCConstantFunctionCtxt<MCStringRef, MCFilesEvalDirectories>
+class MCDirectories : public MCFunction
 {
 public:
-	// virtual Exec_stat eval(MCExecPoint &);
-	virtual MCExecMethodInfo *getmethodinfo(void) const { return kMCFilesEvalDirectoriesMethodInfo; }
-
+	MCDirectories() : m_folder(nil) {}
+	virtual ~MCDirectories();
+	virtual Parse_stat parse(MCScriptPoint &, Boolean p_is_the);
+	virtual void eval_ctxt(MCExecContext &, MCExecValue &);
+	virtual void compile(MCSyntaxFactoryRef);
+private:
+	MCExpression *m_folder;
 };
 
 class MCDiskSpace : public MCConstantFunctionCtxt<double, MCFilesEvalDiskSpace>

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -78,7 +78,7 @@ extern bool MCS_resolvepath(MCStringRef p_path, MCStringRef& r_resolved_path);
 extern void MCS_getcurdir(MCStringRef& r_path);
 /* LEGACY */ extern char *MCS_getcurdir();
 extern Boolean MCS_setcurdir(MCStringRef p_path);
-extern bool MCS_getentries(bool p_files, bool p_detailed, MCListRef& r_list);
+extern bool MCS_getentries(MCStringRef p_folder, bool p_files, bool p_detailed, MCListRef& r_list);
 
 extern bool MCS_getDNSservers(MCListRef& r_list);
 extern Boolean MCS_getdevices(MCStringRef& r_list);

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1768,6 +1768,9 @@ enum Parse_errors
     
     // {PE-0573} return: form not allowed in handler type
     PE_RETURN_BADFOR,
+
+	// {PE-0574} files: bad folder expression
+	PE_FILES_BADPARAM,
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1771,6 +1771,9 @@ enum Parse_errors
 
 	// {PE-0574} files: bad folder expression
 	PE_FILES_BADPARAM,
+
+	// {PE-0574} folders: bad folder expression
+	PE_FOLDERS_BADPARAM,
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -1006,7 +1006,10 @@ static bool MCS_getentries_callback(void *p_context, const MCSystemFolderEntry *
 	return true;
 }
 
-bool MCS_getentries(bool p_files, bool p_detailed, MCListRef& r_list)
+bool MCS_getentries(MCStringRef p_folder,
+                    bool p_files,
+                    bool p_detailed,
+                    MCListRef& r_list)
 {    
 	MCAutoListRef t_list;
     
@@ -1026,7 +1029,7 @@ bool MCS_getentries(bool p_files, bool p_detailed, MCListRef& r_list)
 			return false;
 	}
     
-	if (!MCsystem -> ListFolderEntries(nil, MCS_getentries_callback, (void*)&t_state))
+	if (!MCsystem -> ListFolderEntries(p_folder, MCS_getentries_callback, (void*)&t_state))
 		return false;
     
 	if (!MCListCopy(*t_list, r_list))

--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -16,49 +16,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-on TestFolderInListing
-   set the defaultFolder to specialFolderPath("temporary")
-   
-   local tTestFolder
-   put "evalThereIsAFolderTest" into tTestFolder
-   create folder tTestFolder
-   
-   TestAssert merge("[[tTestFolder]] is in the folder listing"), tTestFolder is among the lines of the directories
-   
-   delete folder tTestFolder
-   
-   repeat for each line tLine in the directories
-      TestAssert merge("Folder [[tLine]] is a folder"), there is a folder tLine
-      TestAssert merge("Folder [[tLine]] is not a file"), there is not a file tLine
-   end repeat
-   
-end TestFolderInListing
-
-on TestBugfix12039
-   // 12039
-   local tOldCwd, tTestFile
-   put the defaultFolder into tOldCwd
-   set the defaultFolder to specialFolderPath("temporary")
-   
-   put "evalfilestest.txt" into tTestfile
-   put "some text" into url ("binfile:" & tTestfile)
-   TestAssert merge("[[tTestFile]] is amongs the files"), tTestfile is among the lines of the files
-   
-   delete file tTestfile
-   TestAssert merge("[[tTestFile]] is not amongst the files after deletion"), tTestfile is not among the lines of the files
-   
-   set the defaultFolder to tOldCwd
-   
-   repeat for each line tLine in the files
-      if char -4 to -1 of tLine is not "sock" then
-         TestDiagnostic tLine
-         TestAssert "files are files", there is a file tLine
-         TestAssert "files are not folders", there is not a folder tLine
-      end if
-   end repeat
-   
-end TestBugfix12039
-
 on TestRegistryKeys
    // set up test keys & values
    if the platform is "Win32" then
@@ -477,32 +434,3 @@ on TestRenameFile
    
    delete file "Test2.tmp"
 end TestRenameFile
-
-
-on TestFoldersFirstLine
-   // ".." must be the first folder listed
-   local tFolders
-   put the folders into tFolders
-   
-   TestAssert "Fist line of the folders is always  '..'", first line of tFolders is ".."
-end TestFoldersFirstLine
-
-on TestFoldersInEmptyFolder
-   // Bug 16223: if no folder is listed by 'the folders', there should still
-   // be ".." at the head of the list
-   local tFolders, tNewFolder, tOldCwd
-   
-   // Create a new, empty folder
-   put "files__TestFoldersInEmptyFolder" into tNewFolder
-   create folder tNewFolder
-   
-   put the defaultFolder into tOldCwd
-   set the defaultFolder to tNewFolder
-   
-   put the folders into tFolders
-   
-   TestAssert "'..' is the only folder in an empty folder", the folders is ".."
-   
-   delete folder tNewFolder
-   set the defaultFolder to tOldCwd
-end TestFoldersInEmptyFolder

--- a/tests/lcs/core/files/folders.livecodescript
+++ b/tests/lcs/core/files/folders.livecodescript
@@ -54,6 +54,26 @@ on TestFilesOfFolder
    delete file tTestPath
 end TestFilesOfFolder
 
+on TestFoldersOfFolder
+   local tFolder, tTestFolder, tTestPath
+   put specialFolderPath("temporary") into tFolder
+   put "evalfolderstest" into tTestFolder
+   put tFolder & slash & tTestFolder into tTestPath
+   create folder tTestPath
+   TestDiagnostic the result
+
+   TestAssert "list non-current directory", tTestFolder is among the lines of folders(tFolder)
+
+   local tOldFolder
+   put the defaultFolder into tOldFolder
+   set the defaultFolder to tFolder
+
+   TestAssert "list current directory", tTestFolder is among the lines of folders()
+
+   set the defaultFolder to tOldFolder
+   delete folder tTestPath
+end TestFoldersOfFolder
+
 on TestBugfix12039
    // 12039
    local tOldCwd, tTestFile

--- a/tests/lcs/core/files/folders.livecodescript
+++ b/tests/lcs/core/files/folders.livecodescript
@@ -1,0 +1,88 @@
+﻿script "CoreFilesFolders"
+/*
+Copyright (C) 2015-2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestFolderInListing
+   set the defaultFolder to specialFolderPath("temporary")
+   
+   local tTestFolder
+   put "evalThereIsAFolderTest" into tTestFolder
+   create folder tTestFolder
+   
+   TestAssert merge("[[tTestFolder]] is in the folder listing"), tTestFolder is among the lines of the directories
+   
+   delete folder tTestFolder
+   
+   repeat for each line tLine in the directories
+      TestAssert merge("Folder [[tLine]] is a folder"), there is a folder tLine
+      TestAssert merge("Folder [[tLine]] is not a file"), there is not a file tLine
+   end repeat
+   
+end TestFolderInListing
+
+on TestBugfix12039
+   // 12039
+   local tOldCwd, tTestFile
+   put the defaultFolder into tOldCwd
+   set the defaultFolder to specialFolderPath("temporary")
+   
+   put "evalfilestest.txt" into tTestfile
+   put "some text" into url ("binfile:" & tTestfile)
+   TestAssert merge("[[tTestFile]] is amongs the files"), tTestfile is among the lines of the files
+   
+   delete file tTestfile
+   TestAssert merge("[[tTestFile]] is not amongst the files after deletion"), tTestfile is not among the lines of the files
+   
+   set the defaultFolder to tOldCwd
+   
+   repeat for each line tLine in the files
+      if char -4 to -1 of tLine is not "sock" then
+         TestDiagnostic tLine
+         TestAssert "files are files", there is a file tLine
+         TestAssert "files are not folders", there is not a folder tLine
+      end if
+   end repeat
+   
+end TestBugfix12039
+
+on TestFoldersFirstLine
+   // ".." must be the first folder listed
+   local tFolders
+   put the folders into tFolders
+   
+   TestAssert "Fist line of the folders is always  '..'", first line of tFolders is ".."
+end TestFoldersFirstLine
+
+on TestFoldersInEmptyFolder
+   // Bug 16223: if no folder is listed by 'the folders', there should still
+   // be ".." at the head of the list
+   local tFolders, tNewFolder, tOldCwd
+   
+   // Create a new, empty folder
+   put "files__TestFoldersInEmptyFolder" into tNewFolder
+   create folder tNewFolder
+   
+   put the defaultFolder into tOldCwd
+   set the defaultFolder to tNewFolder
+   
+   put the folders into tFolders
+   
+   TestAssert "'..' is the only folder in an empty folder", the folders is ".."
+   
+   delete folder tNewFolder
+   set the defaultFolder to tOldCwd
+end TestFoldersInEmptyFolder

--- a/tests/lcs/core/files/folders.livecodescript
+++ b/tests/lcs/core/files/folders.livecodescript
@@ -34,6 +34,26 @@ on TestFolderInListing
    
 end TestFolderInListing
 
+on TestFilesOfFolder
+   local tFolder, tTempContents, tTestFile, tTestPath
+   put specialFolderPath("temporary") into tFolder
+
+   put "evalfilestest.txt" into tTestFile
+   put tFolder & slash & tTestFile into tTestPath
+   put "some text" into url ("file:" & tTestPath)
+
+   TestAssert "list non-current directory", tTestFile is among the lines of files(tFolder)
+
+   local tOldFolder
+   put the defaultFolder into tOldFolder
+   set the defaultFolder to tFolder
+
+   TestAssert "list current directory", tTestFile is among the lines of files()
+
+   set the defaultFolder to tOldFolder
+   delete file tTestPath
+end TestFilesOfFolder
+
 on TestBugfix12039
    // 12039
    local tOldCwd, tTestFile


### PR DESCRIPTION
When called as a function, the **files** and **folders** functions
now take an optional argument specifying which directory to list.
This makes writing filesystem code a lot easier, since code that
looked like:

```
local tOldFolder, tFilesList
put the defaultFolder into tOldFolder
set the defaultFolder to "/path/to/target/directory"
put the files into tFilesList
set the defaultFolder to tOldFolder
return tFilesList
```

can be replaced with:

```
return files("/path/to/target/directory")
```
