### PR TITLE
[[ Bug ]] Support multiple architectures for Ext externals

### DIFF
--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -2368,9 +2368,8 @@ private command revCopyExternals pPlatform, pStackFilePath, pEnginePath, pStanda
       
       // AL-2015-05-07: [[ Bug 15320 ]] Make sure universal external name is used.
       local tExternal
-      set the itemdel to "."
-      put item 1 of tSourceExternal into tExternal
-      set the itemDel to slash 
+      put revSBExternalNameFromFile(tPlatform, tSourceExternal) into tExternal
+      
       revCopyModule tPlatform, tExternal, tSourceExternal, item 1 to -2 of tExternalPath, tCurrentLocation, "Externals", tPlatform is "MacOSX"
       if the result is not empty then
          revStandaloneAddWarning tPlatform && tArch & ", external" && the result & ":" && quote & tExternalPath & quote

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -708,7 +708,7 @@ constant kMacOSXArchitectures = "x86-32,x86-64"
 constant kLinuxArchitectures =  "x86-32,x86-64,armv6-hf"
 constant kAndroidArchitectures =  "armv6"
 constant kiOSArchitectures =  "armv7,arm64"
-constant kEmscriptenArchitectures =  "javascript"
+constant kEmscriptenArchitectures =  "js"
 
 function revSBPlatformArchitectures pPlatform
    switch pPlatform

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1491,6 +1491,17 @@ private function revSBFilterExternalsForDesktop pList, pPlatform
    return pList
 end revSBFilterExternalsForDesktop
 
+function revSBExternalNameFromFile pPlatform, pFile
+   local tName
+   set the itemdel to "."
+   put item 1 of pFile into tName
+   
+   local tArch
+   __ExternalArchitecture pPlatform, tName, tArch
+   
+   return tName
+end revSBExternalNameFromFile
+
 -- This is currently just used for externals that are present in the
 -- 'mergExt' folder in the app bundle or equivalent
 local sExternalsLocationA

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -786,9 +786,12 @@ private function __TargetArchitecture pTarget
    
    local tArchitecture
    repeat for each item tArchitecture in tArchitectures
-      if pTarget ends with tArchitecture then
-         return tArchitecture
-      end if
+      local tArchitectureIdentifier
+      repeat for each item tArchitectureIdentifier in __ArchitectureSynonyms(tArchitecture)
+         if pTarget ends with tArchitectureIdentifier then
+            return tArchitecture
+         end if
+      end repeat
    end repeat
    
    return item 1 of tArchitectures

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -759,10 +759,10 @@ private command __ExternalArchitecture pPlatform, @xName, @rArchitecture
                   delete item -(the number of items of tArchitectureIdentifier) to -1 of xName
                end if
             end if
+            set the itemDelimiter to comma
             
             exit repeat
          end if
-         set the itemDelimiter to comma
       end repeat
       
       if tFoundArchitecture is not empty then
@@ -1537,8 +1537,8 @@ function revSBAdditionalExternalsList pPlatform
          set the linedelimiter to slash
          repeat for each element tExtPath in tRawList
             local tExtension, tExternalName
-            put item 2 of line -1 of tExtPath into tExtension
-            put item 1 of line -1 of tExtPath into tExternalName
+            put item -1 of line -1 of tExtPath into tExtension
+            put item 1 to -2 of line -1 of tExtPath into tExternalName
             
             set the itemDelimiter to comma
             local tArchitecture

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -729,26 +729,44 @@ function revSBPlatformArchitectures pPlatform
    end switch
 end revSBPlatformArchitectures
 
+private function __ArchitectureSynonyms pArchitecture
+   switch pArchitecture
+      case "x86-32"
+         return pArchitecture,"x86,i386"
+      case "x86-64"
+         return pArchitecture,"x64"
+   end switch
+   
+   return pArchitecture
+end __ArchitectureSynonyms
+
 private command __ExternalArchitecture pPlatform, @xName, @rArchitecture
    local tArchitectures
    put revSBPlatformArchitectures(pPlatform) into tArchitectures
    
-   local tFoundArchitecture
+   local tArchitecture,tFoundArchitecture
    repeat for each item tArchitecture in tArchitectures
-      if xName ends with tArchitecture or \
-            tArchitecture is "x86-32" and xName ends with "x86" or \
-            tArchitecture is "x86-64" and xName ends with "x64" then
-         put tArchitecture into tFoundArchitecture 
-         set the itemDelimiter to "-"
-         if the number of items of xName > 1 then
-            delete item -(the number of items of tFoundArchitecture) to -1 of xName
-         else
-            set the itemDelimiter to "_"
+      local tArchitectureIdentifier
+      repeat for each item tArchitectureIdentifier in __ArchitectureSynonyms(tArchitecture)
+         if xName ends with tArchitectureIdentifier then
+            put tArchitecture into tFoundArchitecture 
+            set the itemDelimiter to "-"
             if the number of items of xName > 1 then
-               delete item -(the number of items of tFoundArchitecture) to -1 of xName
+               delete item -(the number of items of tArchitectureIdentifier) to -1 of xName
+            else
+               set the itemDelimiter to "_"
+               if the number of items of xName > 1 then
+                  delete item -(the number of items of tArchitectureIdentifier) to -1 of xName
+               end if
             end if
+            
+            exit repeat
          end if
          set the itemDelimiter to comma
+      end repeat
+      
+      if tFoundArchitecture is not empty then
+         exit repeat
       end if
    end repeat
    

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1526,12 +1526,14 @@ function revSBAdditionalExternalsList pPlatform
             put item 2 of line -1 of tExtPath into tExtension
             put item 1 of line -1 of tExtPath into tExternalName
             
+            set the itemDelimiter to comma
             local tArchitecture
             if pPlatform is among the items of kAdditionalTargets then
                put pPlatform into tArchitecture
             else
-             __ExternalArchitecture pPlatform, tExternalName, tArchitecture
-           end if
+               __ExternalArchitecture pPlatform, tExternalName, tArchitecture
+            end if
+            set the itemDelimiter to "."
             
             put tExtPath into sExternalsLocationA[pPlatform][tExternalName][tArchitecture]
          end repeat

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1545,26 +1545,6 @@ function revSBAdditionalExternalsList pPlatform
    return the keys of sExternalsLocationA[pPlatform]
 end revSBAdditionalExternalsList
 
--- Instead of resolving the path to an included external each time
--- fetch the stored path from a script local array
-function revSBGetExternalPath pTarget, pName
-   local tPlatform
-   put revSBTargetToPlatform(pTarget) into tPlatform
-   
-   if sExternalsLocationA[tPlatform] is empty then
-      get revSBExternalsList(tPlatform)
-   end if
-   
-   local tArchitecture
-   if tPlatform is among the items of kAdditionalTargets then
-      put tPlatform into tArchitecture
-   else
-      put __TargetArchitecture(pTarget) into tArchitecture
-   end if
-   
-   return sExternalsLocationA[tPlatform][pName][tArchitecture]
-end revSBGetExternalPath
-
 -- Ensure the name used for platforms is consistent
 constant kMacPlatform = "MacOSX"
 constant kWindowsPlatform = "Windows"
@@ -1896,7 +1876,21 @@ command revSBConvertSettingsForPlatform @xSettings, pPlatform
 end revSBConvertSettingsForPlatform
 
 function revSBIncludedExternalPath pTarget, pName
-  return revSBGetExternalPath(pTarget, pName)
+   local tPlatform
+   put revSBTargetToPlatform(pTarget) into tPlatform
+   
+   if sExternalsLocationA[tPlatform] is empty then
+      get revSBExternalsList(tPlatform)
+   end if
+   
+   local tArchitecture
+   if tPlatform is among the items of kAdditionalTargets then
+      put tPlatform into tArchitecture
+   else
+      put __TargetArchitecture(pTarget) into tArchitecture
+   end if
+   
+   return sExternalsLocationA[tPlatform][pName][tArchitecture]
 end revSBIncludedExternalPath
 
 command revSBResolveIncludedExternal pTarget, @xFile

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -702,6 +702,80 @@ function revSBTargetToPlatform pTarget
    end if
 end revSBTargetToPlatform
 
+-- item 1 of the architectures should be the default architecture
+constant kWindowsArchitectures = "x86-32"
+constant kMacOSXArchitectures = "x86-32,x86-64"
+constant kLinuxArchitectures =  "x86-32,x86-64,armv6-hf"
+constant kAndroidArchitectures =  "armv6"
+constant kiOSArchitectures =  "armv7,arm64"
+constant kEmscriptenArchitectures =  "javascript"
+
+function revSBPlatformArchitectures pPlatform
+   switch pPlatform
+      case "Windows"
+         return kWindowsArchitectures
+      case "MacOSX"
+         return kMacOSXArchitectures
+      case "Linux"
+         return kLinuxArchitectures
+      case "Android"
+         return kAndroidArchitectures
+      case "iOS"
+         return kiOSArchitectures
+      case "Emscripten"
+         return kEmscriptenArchitectures
+      default
+         return empty
+   end switch
+end revSBPlatformArchitectures
+
+private command __ExternalArchitecture pPlatform, @xName, @rArchitecture
+   local tArchitectures
+   put revSBPlatformArchitectures(pPlatform) into tArchitectures
+   
+   local tFoundArchitecture
+   repeat for each item tArchitecture in tArchitectures
+      if xName ends with tArchitecture or \
+            tArchitecture is "x86-32" and xName ends with "x86" or \
+            tArchitecture is "x86-64" and xName ends with "x64" then
+         put tArchitecture into tFoundArchitecture 
+         set the itemDelimiter to "-"
+         if the number of items of xName > 1 then
+            delete item -(the number of items of tFoundArchitecture) to -1 of xName
+         else
+            set the itemDelimiter to "_"
+            if the number of items of xName > 1 then
+               delete item -(the number of items of tFoundArchitecture) to -1 of xName
+            end if
+         end if
+         set the itemDelimiter to comma
+      end if
+   end repeat
+   
+   if tFoundArchitecture is empty then
+      put item 1 of tArchitectures into tFoundArchitecture
+   end if
+   
+   put tFoundArchitecture into rArchitecture
+end __ExternalArchitecture
+
+private function __TargetArchitecture pTarget
+   local tPlatform
+   put revSBTargetToPlatform(pTarget) into tPlatform
+   
+   local tArchitectures
+   put revSBPlatformArchitectures(tPlatform) into tArchitectures
+   
+   local tArchitecture
+   repeat for each item tArchitecture in tArchitectures
+      if pTarget ends with tArchitecture then
+         return tArchitecture
+      end if
+   end repeat
+   
+   return item 1 of tArchitectures
+end __TargetArchitecture
+
 constant kDefaultCreator             = "????"
 constant kDefaultDocumentType        = ""
 constant kDefaultDocumentExtension   = ""
@@ -1430,7 +1504,18 @@ function revSBAdditionalExternalsList pPlatform
          set the itemdelimiter to "."
          set the linedelimiter to slash
          repeat for each element tExtPath in tRawList
-            put tExtPath into sExternalsLocationA[pPlatform][item 1 of line -1 of tExtPath]
+            local tExtension, tExternalName
+            put item 2 of line -1 of tExtPath into tExtension
+            put item 1 of line -1 of tExtPath into tExternalName
+            
+            local tArchitecture
+            if pPlatform is among the items of kAdditionalTargets then
+               put pPlatform into tArchitecture
+            else
+             __ExternalArchitecture pPlatform, tExternalName, tArchitecture
+           end if
+            
+            put tExtPath into sExternalsLocationA[pPlatform][tExternalName][tArchitecture]
          end repeat
       end repeat
    end if
@@ -1439,12 +1524,22 @@ end revSBAdditionalExternalsList
 
 -- Instead of resolving the path to an included external each time
 -- fetch the stored path from a script local array
-function revSBGetExternalPath pPlatform, pName
-   if sExternalsLocationA is empty then
-      get revSBExternalsList(pPlatform)
+function revSBGetExternalPath pTarget, pName
+   local tPlatform
+   put revSBTargetToPlatform(pTarget) into tPlatform
+   
+   if sExternalsLocationA[tPlatform] is empty then
+      get revSBExternalsList(tPlatform)
    end if
    
-   return sExternalsLocationA[pPlatform][pName]
+   local tArchitecture
+   if tPlatform is among the items of kAdditionalTargets then
+      put tPlatform into tArchitecture
+   else
+      put __TargetArchitecture(pTarget) into tArchitecture
+   end if
+   
+   return sExternalsLocationA[tPlatform][pName][tArchitecture]
 end revSBGetExternalPath
 
 -- Ensure the name used for platforms is consistent
@@ -1778,9 +1873,7 @@ command revSBConvertSettingsForPlatform @xSettings, pPlatform
 end revSBConvertSettingsForPlatform
 
 function revSBIncludedExternalPath pTarget, pName
-   local tPlatform
-   put revSBTargetToPlatform(pTarget) into tPlatform
-   return revSBGetExternalPath(tPlatform, pName)
+  return revSBGetExternalPath(pTarget, pName)
 end revSBIncludedExternalPath
 
 command revSBResolveIncludedExternal pTarget, @xFile


### PR DESCRIPTION
Previously Linux -x64.so and -x86.so were being
listed as separate inclusions. This patch allows
for the following naming convention:

`<externalName>[{-|_}{<architecture>|<architecture synonym>].<extension>`

If no architecture is specified then the default
architecture is assumed.

https://github.com/livecode/livecode/pull/4196 Will depend on this
