### PR TITLE
[[ Bug 17957 ]] Fetch 'it' correctly in V1 external interface.

### DIFF
--- a/docs/notes/bugfix-17957.md
+++ b/docs/notes/bugfix-17957.md
@@ -1,0 +1,1 @@
+# Ensure V1 externals can set it when handlers called from top-level in server.

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -1018,7 +1018,7 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 		// MW-2014-01-22: [[ CompatV1 ]] Make a reference var to hold it (should it be needed).
 		//   We then store the previous global value of the it extvar, and set this one.
 		//   As external calls are recursive, this should be fine :)
-		MCReferenceExternalVariable t_it(MCECptr -> GetHandler() -> getit() -> evalvar(*MCECptr));
+		MCReferenceExternalVariable t_it(MCECptr -> GetIt() -> evalvar(*MCECptr));
 		MCReferenceExternalVariable *t_old_it;
 		t_old_it = s_external_v1_current_it;
 		s_external_v1_current_it = &t_it;


### PR DESCRIPTION
The V1 external interface allows access to 'it', however it had
not been updated to use the GetIt() member of MCExecContext, meaning
that a crash would occur if a V1 external attempted to fetch the
it variable when a command was executing in global scope in server.
