### PR TITLE
[[ Bug 17958 ]] Ignore lcidl 'tail' attribute on desktop

### DIFF
--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -1104,7 +1104,6 @@ static MCExternalError MCExternalEngineRunOnMainThread(void *p_callback, void *p
 #else
 static MCExternalError MCExternalEngineRunOnMainThread(void *p_callback, void *p_callback_state, MCExternalRunOnMainThreadOptions p_options)
 {
-#if defined(_DESKTOP)
     // MW-2014-10-30: [[ Bug 13875 ]] If either 'JumpTo' flag is specified, we just execute the callback direct.
     if ((p_options & kMCExternalRunOnMainThreadJumpTo) != 0)
     {
@@ -1134,9 +1133,6 @@ static MCExternalError MCExternalEngineRunOnMainThread(void *p_callback, void *p
 		return kMCExternalErrorOutOfMemory;
 
 	return kMCExternalErrorNone;
-#else
-	return kMCExternalErrorNotImplemented;
-#endif
 }
 #endif
 

--- a/lcidlc/src/InterfaceGenerate.cpp
+++ b/lcidlc/src/InterfaceGenerate.cpp
@@ -1575,10 +1575,14 @@ static bool InterfaceGenerateHandlers(InterfaceRef self, CoderRef p_coder)
 			CoderWriteLine(p_coder, "\tenv . argv = argv;");
 			CoderWriteLine(p_coder, "\tenv . argc = argc;");
 			CoderWriteLine(p_coder, "\tenv . result = result;");
+			CoderWriteLine(p_coder, "#if defined(__IOS__) || defined(__ANDROID__)");
 			CoderWriteLine(p_coder, "\tif (s_interface -> version >= 4)");
 			CoderWriteLine(p_coder, "\t\ts_interface -> engine_run_on_main_thread((void *)do_handler__%s, &env, kMCRunOnMainThreadJumpToUI);", NameGetCString(t_handler -> name));
 			CoderWriteLine(p_coder, "\telse");
 			CoderWriteLine(p_coder, "\t\tdo_handler__%s(&env);", NameGetCString(t_handler -> name));
+			CoderWriteLine(p_coder, "#else");
+			CoderWriteLine(p_coder, "\t\tdo_handler__%s(&env);", NameGetCString(t_handler -> name));
+			CoderWriteLine(p_coder, "#endif");
 			CoderWriteLine(p_coder, "\treturn env . return_value;");
 			CoderWriteLine(p_coder, "}");
 		}


### PR DESCRIPTION
Tail handlers specified in LCIDL should only use 'run on main thread'
on mobile platforms.
