### PR TITLE
Minor refactor of number-to-string conversion

### DIFF
--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3016,7 +3016,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 
 		if (t_len)
 		{
-			auto t_model = new char[t_len];
+			char *t_model = new char[t_len];
 			if (nil == t_model)
 				return false;
 			sysctlbyname("hw.model", t_model, &t_len, NULL, 0);

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3016,8 +3016,8 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 
 		if (t_len)
 		{
-			char *t_model;
-			if (!MCMemoryNewArray(t_len, t_model))
+			auto t_model = new char[t_len];
+			if (nil == t_model)
 				return false;
 			sysctlbyname("hw.model", t_model, &t_len, NULL, 0);
 

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -84,35 +84,16 @@ bool MCExecContext::ConvertToString(MCValueRef p_value, MCStringRef& r_string)
         return MCListCopyAsString((MCListRef)p_value, r_string);
     case kMCValueTypeCodeNumber:
     {
-        if (MCNumberIsInteger((MCNumberRef)p_value))
+	    MCNumberRef t_number = reinterpret_cast<MCNumberRef>(p_value);
+	    if (MCNumberIsInteger(t_number))
             // SN-2014-04-28 [[ StonCache ]]
             // Stores the numeric value in the string
-            return MCStringFormat(r_string, "%d", MCNumberFetchAsInteger((MCNumberRef)p_value)) && MCStringSetNumericValue(r_string, MCNumberFetchAsReal((MCNumberRef)p_value));
-
-        char *t_buffer;
-        uint32_t t_buffer_size;
-        t_buffer = nil;
-        t_buffer_size = 0;
-
-        uint32_t t_length;
-        t_length = MCU_r8tos(t_buffer, t_buffer_size, MCNumberFetchAsReal((MCNumberRef)p_value), m_nffw, m_nftrailing, m_nfforce);
-
-        if (!MCStringCreateWithNativeCharBufferAndRelease((char_t *)t_buffer,
-                                                          t_length,
-                                                          t_buffer_size,
-                                                          r_string))
-        {
-	        delete[] t_buffer;
-	        return false;
-        }
-
-        if (!MCStringSetNumericValue(r_string,
-                                     MCNumberFetchAsReal((MCNumberRef)p_value)))
-        {
-	        return false;
-        }
-
-        return true;
+		    return
+			    MCStringFormat(r_string, "%d", MCNumberFetchAsInteger(t_number)) &&
+			    MCStringSetNumericValue(r_string, MCNumberFetchAsReal(t_number));
+	    else
+		    return MCU_r8tos(MCNumberFetchAsReal(t_number),
+		                     m_nffw, m_nftrailing, m_nfforce, r_string);
     }
     break;
     default:

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -665,18 +665,8 @@ bool MCValueConvertToStringForSave(MCValueRef self, MCStringRef& r_string)
 		r_string = MCValueRetain(MCNameGetString((MCNameRef)self));
 		break;
 	case kMCValueTypeCodeNumber:
-		{
-			char *t_buffer;
-			uint32_t t_buffer_length;
-			t_buffer = nil;
-			t_buffer_length = 0;
-
-			uint32_t t_length;
-			t_length = MCU_r8tos(t_buffer, t_buffer_length, MCNumberFetchAsReal((MCNumberRef)self), 8, 6, 0);
-
-			t_success = MCStringCreateWithNativeChars((char_t *)t_buffer, t_length, r_string);
-            delete[] t_buffer;
-		}
+		t_success = MCU_r8tos(MCNumberFetchAsReal(static_cast<MCNumberRef>(self)),
+		                      8, 6, 0, r_string);
 		break;
 	case kMCValueTypeCodeString:
 		t_success = MCStringCopy((MCStringRef)self, r_string);

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -592,23 +592,26 @@ real8 MCU_fwrap(real8 p_x, real8 p_y)
 
 bool MCU_r8tos(real8 n, uint2 fw, uint2 trailing, uint2 force, MCStringRef &r_string)
 {
+	bool t_success = true;
 	char *t_str = nil;
 	uint4 t_s = 0;
-	if (MCU_r8tos(t_str, t_s, n, fw, trailing, force) == 0)
-	{
-		delete[] t_str;
-		return false;
-	}
+	if (t_success)
+		t_success = (0 != MCU_r8tos(t_str, t_s, n, fw, trailing, force));
 	
-	MCStringRef t_string;
-	if (!MCStringCreateWithCStringAndRelease(t_str, t_string))
-	{
+	MCAutoStringRef t_string;
+	if (t_success)
+		t_success = MCStringCreateWithCStringAndRelease(t_str, &t_string);
+
+	if (t_success)
+		t_success = MCStringSetNumericValue(*t_string, n);
+
+	if (t_success)
+		t_success = MCStringCopy(*t_string, r_string);
+
+	if (!t_success)
 		delete[] t_str;
-		return false;
-	}
-	
-	r_string = t_string;
-	return true;
+
+	return t_success;
 }
 
 uint4 MCU_r8tos(char *&d, uint4 &s, real8 n,

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1982,7 +1982,7 @@ MC_DLLEXPORT bool MCStringCreateWithNativeCharBufferAndRelease(char_t* buffer, u
 
 // Create an immutable string from the given (native) c-string.
 MC_DLLEXPORT bool MCStringCreateWithCString(const char *cstring, MCStringRef& r_string);
-MC_DLLEXPORT bool MCStringCreateWithCStringAndRelease(char *cstring, MCStringRef& r_string);
+MC_DLLEXPORT bool MCStringCreateWithCStringAndRelease(char *cstring /*delete[]*/, MCStringRef& r_string);
 
 #ifdef __HAS_CORE_FOUNDATION__
 // Create a string from a CoreFoundation string object.

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -248,7 +248,7 @@ bool MCStringCreateWithCStringAndRelease(char* p_cstring, MCStringRef& r_string)
 
 	if (MCStringCreateWithNativeChars((const char_t *)p_cstring, p_cstring == nil ? 0 : strlen((const char*)p_cstring), r_string))
     {
-        delete p_cstring;
+        delete[] p_cstring;
         return true;
     }
     


### PR DESCRIPTION
Small refactor of number-to-string conversion using `MCU_r8tos()`:
- Fix a buffer that was being allocated with `new[]` and destroyed with `delete`
- Always set the numeric value when creating a stringref
- Remove duplicated code from various `MCU_r8tos()` consumers that subsequently construct a string ref, such as `MCExecContext::ConvertToString()`
