### PR TITLE
Use MCAutoStringRefAsCString for temp const C strings

### DIFF
--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1575,9 +1575,9 @@ void MCUIDC::siguser()
 
 Boolean MCUIDC::lookupcolor(MCStringRef s, MCColor *color)
 {
-    // SN-2015-11-26: [[ Bug 16501 ]] Do not use GetOldString (nativises)
-    MCAutoPointer<char> t_cstring;
-    MCStringConvertToCString(s, &t_cstring);
+	MCAutoStringRefAsCString t_cstring;
+	if (!t_cstring.Lock(s))
+		return false;
 
     uint4 slength = strlen(*t_cstring);
     MCAutoPointer<char> startptr;

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1737,9 +1737,10 @@ Boolean MCUIDC::parsecolor(MCStringRef s, MCColor& color, MCStringRef *cname)
 	
 	int2 i1, i2, i3;
     Boolean done;
-    MCAutoPointer<char> temp;
-    /* UNCHECKED */ MCStringConvertToCString(s, &temp);
-    const char *sptr = *temp;
+	MCAutoStringRefAsCString t_cstring;
+	if (!t_cstring.Lock(s))
+		return false;
+	const char *sptr = *t_cstring;
     uint4 l = strlen(sptr);
 	
 	// check for numeric first argument

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -421,8 +421,9 @@ char *MCU_strtok(char *s, const char *delim)
 {
 	Boolean t_converted;
 	uint4 l = MCStringGetLength(p_string);
-    MCAutoPointer<char> t_string;
-    /* UNCHECKED */ MCStringConvertToCString(p_string, &t_string);
+	MCAutoStringRefAsCString t_string;
+	if (!t_string.Lock(p_string))
+		return false;
     const char *sptr = *t_string;
 	r_l = MCU_strtol(sptr, l, '\0', t_converted);
 	return True == t_converted;


### PR DESCRIPTION
Refactor several places that were always performing an explicit copy using `MCStringConvertToCString()` so that they use an `MCAutoStringRefAsCString` instead.  This avoids a memory copy if the string is already in a suitable format for use as a C string instead, which will hopefully speed things up.

As a side effect, this fixes some "allocate with `malloc()`, free with `delete`" errors detected by valgrind.
