### PR TITLE
[Bugfix 17965] Don't panic when GDK reports 0x0 maximum cursor size

### DIFF
--- a/docs/notes/bugfix-17965.md
+++ b/docs/notes/bugfix-17965.md
@@ -1,0 +1,1 @@
+# Do something sensible when GDK reports a maximum cursor size of 0

--- a/engine/src/itransform.cpp
+++ b/engine/src/itransform.cpp
@@ -525,6 +525,12 @@ bool MCImageScaleBitmap(MCImageBitmap *p_src_bitmap, uindex_t p_width, uindex_t 
 	if (!MCImageBitmapCreate(p_width, p_height, r_scaled))
 		return false;
 
+	/* If the target bitmap has 0 pixels, then no scaling is required. */
+	if (0 == p_width || 0 == p_height)
+	{
+		return true;
+	}
+
 	uindex_t owidth = p_src_bitmap->width;
 	uindex_t oheight = p_src_bitmap->height;
 

--- a/engine/src/lnxcursor.cpp
+++ b/engine/src/lnxcursor.cpp
@@ -29,6 +29,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <gtk/gtk.h>
 
+const guint kMCDefaultCursorSize = 64;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef void (*g_object_getPTR) (void *widget, const gchar *first_property_name, ...);
@@ -56,9 +58,6 @@ static MCCursorRef create_cursor(Pixmap_ids p_id, GdkCursor *p_cursor)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-static bool s_checked_xcursor = false;
-static bool s_has_xcursor = false;
 
 static GdkCursorType cursorlist[PI_NCURSORS] =
     {
@@ -96,7 +95,10 @@ void MCScreenDC::resetcursors()
         // Get the maximum cursor size
         guint width, height;
         gdk_display_get_maximal_cursor_size(dpy, &width, &height);
-        MCcursormaxsize = MCU_max(width, height);
+		if (0 == width || 0 == height)
+			MCcursormaxsize = kMCDefaultCursorSize;
+		else
+			MCcursormaxsize = MCU_max(width, height);
     }
     
     // TODO: do we need to do this?


### PR DESCRIPTION
On some Linux desktops, `gdk_display_get_maximal_cursor_size()`
returns a cursor size of (0, 0).  This is unhelpful.

If GDK reports a maximum cursor size of 0, then use (64, 64) instead.

See also https://bugzilla.redhat.com/show_bug.cgi?id=1353610.

Relatedly, don't crash with a division-by-zero FPE trap when trying to resize an image to 0 pixels.
