### PR TITLE
Fix two places where indentation is misleading.

### DIFF
--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -2354,8 +2354,10 @@ void MCObject::SetColors(MCExecContext& ctxt, MCStringRef p_input)
 			MCInterfaceNamedColor t_color;
 			t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_color_string);
 			if (t_success)
+			{
 				MCInterfaceNamedColorParse(ctxt, *t_color_string, t_color);
 				t_success = !ctxt . HasError();
+			}
 			if (t_success)
 			{
 				uint2 i, j;

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -2287,7 +2287,7 @@ void MCField::fmove(Field_translations function, MCStringRef p_string, KeySym ke
 			drect.x = -textx;
 			if (indent < 0)
 				drect.x += indent;
-				break;
+			break;
 		case FT_END:
 		case FT_EOL:
 			drect.x = textwidth + leftmargin + indent + rect.width;


### PR DESCRIPTION
These were found by compiling using GCC6 with
`-ftabstop=4 -Werror=misleading-indentation`.
