### PR TITLE
Use libfoundation allocators for arrays that will be resized.

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -226,9 +226,9 @@ static IO_stat MCS_lnx_shellread(int fd, char *&buffer, uint4 &buffersize, uint4
         readsize += READ_PIPE_SIZE;
         if (size + readsize > buffersize)
         {
-            MCU_realloc((char **)&buffer, buffersize,
-                        buffersize + readsize + 1, sizeof(char));
-            buffersize += readsize;
+	        if (!MCMemoryResizeArray(buffersize + readsize + 1,
+	                                 buffer, buffersize))
+		        return IO_ERROR;
         }
         errno = 0;
         int4 amount = read(fd, &buffer[size], readsize);

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1249,7 +1249,7 @@ MCVarref::~MCVarref()
     {
         for(uint4 i = 0; i < dimensions; ++i)
             delete exps[i];
-        delete exps;
+        MCMemoryDeleteArray(exps); /* Allocated with MCMemoryNewArray() */
     }
 }
 
@@ -1477,26 +1477,21 @@ Parse_stat MCVarref::parsearray(MCScriptPoint &sp)
 		}
 		else if (dimensions == 1)
 		{
-			MCExpression *t_current_exp;
-			t_current_exp = exp;
-			exps = (MCExpression **)malloc(sizeof(MCExpression *) * 2);
-			if (exps != NULL)
-			{
-				exps[0] = t_current_exp;
-				exps[1] = t_new_dimension;
-				dimensions += 1;
-			}
+			MCExpression *t_current_exp = exp;
+			uindex_t t_dimensions = dimensions;
+			if (!MCMemoryNewArray(2, exps, t_dimensions))
+				return PS_ERROR;
+			exps[0] = t_current_exp;
+			exps[1] = t_new_dimension;
+			dimensions = t_dimensions;
 		}
 		else
 		{
-			MCExpression **t_new_exps;
-			t_new_exps = (MCExpression **)realloc(exps, sizeof(MCExpression *) * (dimensions + 1));
-			if (t_new_exps != NULL)
-			{
-				t_new_exps[dimensions] = t_new_dimension;
-				exps = t_new_exps;
-				dimensions += 1;
-			}
+			uindex_t t_dimensions = dimensions;
+			if (!MCMemoryResizeArray(t_dimensions + 1, exps, t_dimensions))
+				return PS_ERROR;
+			exps[dimensions] = t_new_dimension;
+			dimensions = t_dimensions;
 		}
 	}
 


### PR DESCRIPTION
Using `new[]` and `delete[]` for allocating an array prevents resizing
the array by reallocation.  Resizing by reallocation may cause a
memory address change for the array, which could cause problems if
something holds a pointer to the contents of the array.  Special
handling is therefore required if resizing an array allocated with
`new[]`, often involving an explicit memory copy or move.  When it's
known/obvious that it's safe to `realloc()` a buffer, it's better to
use the libfoundation memory handling functions, which will avoid a
copy most of the time.
