### PR TITLE
Refactor AutoStringRefAs* classes

### DIFF
--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -5819,15 +5819,16 @@ static void MCS_startprocess_unix(MCNameRef name, MCStringRef doc, Open_mode mod
                 // [[ Bug 13622 ]] Make sure environ is appropriate (on Yosemite it can
                 //    be borked).
                 environ = fix_environ();
-                
-				MCAutoStringRefAsUTF8String t_utf8_string;
-                /* UNCHECKED */ t_utf8_string . Lock(MCNameGetString(name));
-				
+
+                char *t_utf8_string = nil;
+                /* UNCHECKED */ MCStringConvertToUTF8String(MCNameGetString(name),
+                                                            t_utf8_string);
+
 				// The pid is 0, so here we are in the child process.
 				// Construct the argument string to pass to the process..
 				char **argv = NULL;
 				uint32_t argc = 0;
-				startprocess_create_argv(*t_utf8_string, t_doc, argc, argv);
+				startprocess_create_argv(t_utf8_string, t_doc, argc, argv);
 				
 				// The parent is reading, so we (we are child) are writing.
 				if (reading)

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -2821,7 +2821,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
         // SN-2014-06-16 [[ Bug 12648 ]] Shell command does not accept spaces despite being quoted (Windows)
         // Fix for 7
 		/* UNCHECKED */ MCStringFormat(t_cmd, "%@ /C \"%@\"", MCshellcmd, p_command);
-		MCAutoStringRefAsWString t_wcmd;
+		MCAutoStringRefAsLPWSTR t_wcmd;
 		t_wcmd . Lock(t_cmd);
         MCU_realloc((char **)&MCprocesses, MCnprocesses,
                     MCnprocesses + 1, sizeof(Streamnode));
@@ -3092,7 +3092,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
                     siStartInfo.hStdOutput = hChildStdoutWr;
                     siStartInfo.hStdError = hChildStderrWr;
 
-					MCAutoStringRefAsWString t_cmdline_wstr;
+					MCAutoStringRefAsLPWSTR t_cmdline_wstr;
 					/* UNCHECKED */ t_cmdline_wstr.Lock(*t_cmdline);
 
                     if (CreateProcessW(NULL, *t_cmdline_wstr, NULL, NULL, TRUE, CREATE_NEW_CONSOLE, NULL, NULL, &siStartInfo, &piProcInfo))

--- a/engine/src/exec-filters.cpp
+++ b/engine/src/exec-filters.cpp
@@ -859,7 +859,7 @@ void MCFiltersEvalBinaryEncode(MCExecContext& ctxt, MCStringRef p_format, MCValu
 					break;
                                 
                 MCAutoStringRefAsNativeChars t_auto_native;
-                char_t* t_native;
+                const char_t* t_native;
                 uindex_t t_length;
                 /* UNCHECKED */ t_auto_native . Lock(*t_string, t_native, t_length);
 

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -1099,9 +1099,9 @@ void MCStringsEvalFormat(MCExecContext& ctxt, MCStringRef p_format, MCValueRef* 
 
             MCAutoStringRef t_substring;
             MCAutoStringRefAsNativeChars t_auto_native;
-            char_t* t_native_format;
+            const char_t* t_native_format;
             uindex_t t_cformat_length;
-            char_t* t_cstart;
+            const char_t* t_cstart;
 
             /* UNCHECKED */ MCStringCreateWithChars(t_unicode_start, format - t_start, &t_substring);
             /* UNCHECKED */ t_auto_native . Lock(*t_substring, t_native_format, t_cformat_length);

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -151,10 +151,10 @@ bool apk_list_folder_entries(MCStringRef p_apk_folder, MCSystemListFolderEntries
 	t_entry . permissions = t_stat . st_mode & 0444;
 
     char* t_next_entry;
-    MCAutoStringRefAsUTF8String t_utf8_files;
-    
-    t_success = t_utf8_files . Lock(*t_list);
-    
+    MCAutoCustomPointer<char, MCMemoryDeleteArray> t_utf8_files;
+    if (t_success)
+	    t_success = MCStringConvertToUTF8String(*t_list, &t_utf8_files);
+
     if (t_success)
         t_next_entry = *t_utf8_files;
     

--- a/engine/src/w32printer.cpp
+++ b/engine/src/w32printer.cpp
@@ -138,7 +138,7 @@ static HANDLE Win32OpenPrinter(MCStringRef p_name)
 	t_defaults . pDevMode = NULL;
 	t_defaults . DesiredAccess = PRINTER_ACCESS_USE;
 
-	MCAutoStringRefAsWString t_name_wstr;
+	MCAutoStringRefAsLPWSTR t_name_wstr;
 	/* UNCHECKED */ t_name_wstr.Lock(p_name);
 
 	if (OpenPrinterW(*t_name_wstr, &t_printer, &t_defaults) == 0)

--- a/engine/src/w32relaunch.cpp
+++ b/engine/src/w32relaunch.cpp
@@ -450,7 +450,7 @@ bool relaunch_startup(MCStringRef p_stack_name)
 	{
 		for(unsigned int t_instance = 0; t_instance < t_existing_instance_count; ++t_instance)
 		{
-			MCAutoStringRefAsWString t_cmdline_wstr;
+			MCAutoStringRefAsLPWSTR t_cmdline_wstr;
 			/* UNCHECKED */ t_cmdline_wstr.Lock(MCcmdline);
 			
 			message_t t_message;

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -397,8 +397,15 @@ public:
             MCMemoryDeleteArray(m_wstring);
         m_wstring = nil;
     }
-    
-    unichar_t *operator * (void)
+
+    /* FIXME Unlike many of the other MCAutoStringRefAs* classes, this
+     * operator*() implementation does _not_ return a const T*.  It's
+     * common to use this class when invoking Win32 API functions that
+     * require an LPWSTR which is notably _not_ `const`. It may be a
+     * good idea to modify this implementation to _always_ use a
+     * temporary buffer, so as to ensure there's no danger of
+     * mutations to the locked MCStringRef. */
+    unichar_t *operator * (void) const
     {
         return m_wstring;
     }
@@ -435,7 +442,7 @@ public:
         m_utf8string = nil;
     }
     
-    char *operator * (void)
+    const char *operator * (void) const
     {
         return m_utf8string;
     }
@@ -616,7 +623,7 @@ public:
         m_pascal_string = nil;
     }
     
-    unsigned char* operator * (void)
+    const unsigned char* operator * (void) const
     {
         return m_pascal_string;
     }

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2135,6 +2135,9 @@ MC_DLLEXPORT void MCStringNativize(MCStringRef string);
 // Create a native copy of p_string
 MC_DLLEXPORT bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy);
 
+// Create a Unicode copy of p_string
+MC_DLLEXPORT bool MCStringUnicodeCopy(MCStringRef p_string, MCStringRef& r_copy);
+
 // Maps from a codepoint (character) range to a code unit (StringRef) range
 MC_DLLEXPORT bool MCStringMapCodepointIndices(MCStringRef, MCRange p_codepoint_range, MCRange& r_string_range);
 

--- a/libfoundation/src/foundation-filters.cpp
+++ b/libfoundation/src/foundation-filters.cpp
@@ -41,7 +41,7 @@ bool MCFiltersBase64Decode(MCStringRef p_src, MCDataRef& r_dst)
     
     uint32_t l;
     MCAutoStringRefAsNativeChars t_native;
-    char_t *s = nil;
+    const char_t *s = nil;
     byte_t *p = nil;
     
     if (!t_native . Lock(p_src, s, l))

--- a/libfoundation/src/foundation-math.cpp
+++ b/libfoundation/src/foundation-math.cpp
@@ -51,7 +51,7 @@ bool MCMathConvertToBase10(MCStringRef p_source, integer_t p_source_base, bool& 
     t_negative = false;
     
     MCAutoStringRefAsNativeChars t_auto_native;
-    char_t* t_native;
+    const char_t* t_native;
     uindex_t t_length;
     
     if (!t_auto_native . Lock(p_source, t_native, t_length))

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1669,29 +1669,45 @@ void MCStringNativize(MCStringRef self)
 	/* UNCHECKED */ __MCStringNativize(self);
 }
 
-MC_DLLEXPORT_DEF
-bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
+static bool __MCStringConvertCopy(MCStringRef p_string, bool p_to_unicode,
+                                  MCStringRef& r_copy)
 {
 	__MCAssertIsString(p_string);
 
-    // AL-2014-12-12: [[ Bug 14208 ]] Implement a native copy function to aid conversion to data
-    if (MCStringIsNative(p_string))
-        return MCStringCopy(p_string, r_copy);
-    
-    MCStringRef t_string;
-    t_string = nil;
-    
-    if (!MCStringMutableCopy(p_string, t_string))
-        return false;
+	if (MCStringIsNative(p_string) ^ p_to_unicode)
+		return MCStringCopy(p_string, r_copy);
 
-	if (!__MCStringNativize(t_string))
+	MCAutoStringRef t_string;
+	if (!MCStringMutableCopy(p_string, &t_string))
 		return false;
-    
-    __MCStringMakeImmutable(t_string);
-    t_string -> flags &= ~kMCStringFlagIsMutable;
-    
-    r_copy = t_string;
-    return true;
+
+	if (p_to_unicode)
+	{
+		if (!__MCStringUnnativize(*t_string))
+			return false;
+	}
+	else
+	{
+		if (!__MCStringNativize(*t_string))
+			return false;
+	}
+
+    __MCStringMakeImmutable(*t_string);
+    (*t_string) -> flags &= ~kMCStringFlagIsMutable;
+
+    return MCStringCopy(*t_string, r_copy);
+}
+
+MC_DLLEXPORT_DEF
+bool MCStringNativeCopy(MCStringRef p_string, MCStringRef& r_copy)
+{
+	return __MCStringConvertCopy(p_string, false, r_copy);
+}
+
+MC_DLLEXPORT_DEF
+bool MCStringUnicodeCopy(MCStringRef p_string, MCStringRef& r_copy)
+{
+	return __MCStringConvertCopy(p_string, true, r_copy);
 }
 
 MC_DLLEXPORT_DEF


### PR DESCRIPTION
When compiling LiveCode using GCC6, the compiler was getting very
upset by several strict aliasing violations in
`MCAutoStringRefAsNativeChars`.  Shutting it up was a good excuse for
a refactor.  Accordingly:
- No strict-aliasing warnings from GCC 6
- The underlying stringref is cached in an MCAutoStringRef, so no
  explicit dereferencing or destruction is needed
- No messing about with buffers, by using `MCStringNativeCopy()` to
  obtain a nativized string without modifying the original string
- `MCStringRefAsNativChars` has an API that's more compatible with the
  other `MCAutoStringRefAs*` classes, including a single-operand
  `Lock()`, a `Size()` method and an `operator*` implementation
- `MCStringRefAsCString` is a small subclass of
  `MCStringRefAsNativeChars` that dereferences as a `char *` instead
  of a `char_t *`
