### PR TITLE
[[ Docs ]] Remove references to liveResizing from other docs

### DIFF
--- a/docs/dictionary/message/resizeStack.lcdoc
+++ b/docs/dictionary/message/resizeStack.lcdoc
@@ -28,18 +28,41 @@ oldWidth: The stack's original width in pixels.
 oldHeight: The stack's original height in pixels.
 
 Description:
-Handle the <resizeStack> <message> if you want to update the position of <object|objects> or do other tasks when the <stack window> changes size.
+Handle the <resizeStack> <message> if you want to update the position of 
+<object|objects> or do other tasks when the <stack window> changes size.
 
-The <resizeStack> <message> is sent when the user resizes the <stack> by dragging its size box. It is also sent if a <handler> changes the size of the <stack> by changing its <properties> (<width>, <height>, and so on).
+The <resizeStack> <message> is sent when the user resizes the <stack> by 
+dragging its size box. It is also sent if a <handler> changes the size 
+of the <stack> by changing its <properties> (<width>, <height>, and so 
+on).
 
-The <resizeStack> <message> is sent after the resizing is finished. This means that you cannot prevent a <stack|stack's> size from being changed by <trap|trapping> this <message>. If the <stack|stack's> <liveResizing> <property> is true, <resizeStack> <message|messages> are sent continuously during resizing, but you still cannot prevent resizing by trapping the <message>.
+The <resizeStack> <message> is sent after the resizing is finished. This 
+means that you cannot prevent a <stack|stack's> size from being changed 
+by <trap|trapping> this <message>.
 
-On Mac OS X systems when the <liveResizing> <property> is true and on all other systems, the <oldWidth> and <oldHeight> for each <resizeStack> <message> is the same as the <newWidth> and <newHeight> for the previous <resizeStack>. The <stack|stack's> original <width> and <height> are passed only with the first <resizeStack> <message> sent during a resize operation. 
+The <oldWidth> and <oldHeight> for each <resizeStack> <message> is the 
+same as the <newWidth> and <newHeight> for the previous <resizeStack>. 
+The <stack|stack's> original <width> and <height> are passed only with 
+the first <resizeStack> <message> sent during a resize operation. 
 
-The screen is locked while a <resizeStack> <handler> is running, so it is not necessary to use the <lock screen> <command> to prevent changes from being seen. (However, the <lockScreen> <property> is not set to true.)
+The screen is locked while a <resizeStack> <handler> is running, so it 
+is not necessary to use the <lock screen> <command> to prevent changes 
+from being seen. (However, the <lockScreen> <property> is not set to 
+true.)
 
->*Note:* If the <stack's vScroll property> is nonzero, the amount of scroll is not included in the <newHeight> and <oldHeight>. This means that the <parameter|parameters> of the <resizeStack> < message(keyword)> are always equal to the <stack's height> before and after resizing, regardless of the <vScroll> setting.
+>*Note:* If the stack's <vScroll> property is nonzero, the amount of 
+> scroll is not included in the <newHeight> and <oldHeight>. This means 
+> that the <parameter|parameters> of the <resizeStack> 
+> <message(keyword)> are always equal to the stack's <height> before and 
+> after resizing, regardless of the <vScroll> setting.
 
-References: maxWidth (property), width (property), height (property), minHeight (property), resizable (property), lockScreen (property), properties (property), vScroll (property), liveResizing (property), moveStack (message), resizeControl (message), unIconifyStack (message), revChangeWindowSize (command), lock screen (command), stack's vScroll property (object), stack's height (object), stack (object), object (glossary), property (glossary), current card (glossary), stack window (glossary), handler (glossary), message (glossary), parameter (glossary), command (glossary), trap (glossary)
+References: maxWidth (property), width (property), height (property), 
+minHeight (property), resizable (property), lockScreen (property), 
+properties (property), vScroll (property), moveStack (message), 
+resizeControl (message), unIconifyStack (message), 
+revChangeWindowSize (command), lock screen (command), stack (object), 
+object (glossary), property (glossary), current card (glossary), 
+stack window (glossary), handler (glossary), message (glossary), 
+parameter (glossary), command (glossary), trap (glossary)
 
 Tags: windowing

--- a/docs/dictionary/property/rectangle.lcdoc
+++ b/docs/dictionary/property/rectangle.lcdoc
@@ -24,37 +24,80 @@ set the rectangle of button "Tangle" to 20,20,45,200
 Example:
 set the rectangle of group 1 to the rectangle of this card
 
-Value: The <rectangle> of an <object(glossary)> consists of four <integer|integers> separated by commas.
+Value: The <rectangle> of an <object(glossary)> consists of four 
+<integer|integers> separated by commas.
 
 Description:
-Use the <rectangle> <property> to find out how far an <object(glossary)> extends, to move it, or to resize it.
+Use the <rectangle> <property> to find out how far an <object(glossary)> 
+extends, to move it, or to resize it.
 
-The four items of an object's <rectangle> describe the <object|object's> left, top, right, and bottom edges:
+The four items of an object's <rectangle> describe the <object|object's> 
+left, top, right, and bottom edges:
 
-* The <left> is the number of <pixels> between the left edge of the <stack window> and the leftmost pixel of the <object(glossary)>.
+* The <left> is the number of <pixels> between the left edge of the 
+<stack window> and the leftmost pixel of the <object(glossary)>.
 
-* The <top> is the number of <pixels> between the top edge of the <stack window> and the topmost pixel of the <object(glossary)>.
+* The <top> is the number of <pixels> between the top edge of the 
+<stack window> and the topmost pixel of the <object(glossary)>.
 
-* The <right> is the horizontal distance in <pixels> between the left edge of the <stack window> and the rightmost pixel of the <object(glossary)>.
+* The <right> is the horizontal distance in <pixels> between the left 
+edge of the <stack window> and the rightmost pixel of the 
+<object(glossary)>.
 
-* The <bottom> is the vertical distance in <pixels> between the top edge of the <stack window> and the bottommost pixel of the <object(glossary)>.
+* The <bottom> is the vertical distance in <pixels> between the top edge 
+of the <stack window> and the bottommost pixel of the 
+<object(glossary)>.
 
->*Note:* The sides of an <object|object's> <rectangle> specify the lines between <pixels>, not the <pixels> themselves. For example, if an <object|object's> <rectangle> is "0,0,2,2", the <object(glossary)> includes four <pixels>, starting at the top left corner of the <card>. In the case of a line or curve <graphic(keyword)>, the <graphic(object)|graphic's> <rectangle> encloses all the <pixels> in the <graphic(object)|graphic's> <points> <property> without touching any of them.
+>*Note:* The sides of an <object|object's> <rectangle> specify the lines 
+> between <pixels>, not the <pixels> themselves. For example, if an 
+> <object|object's> <rectangle> is "0,0,2,2", the <object(glossary)> 
+> includes four <pixels>, starting at the top left corner of the <card>. 
+> In the case of a line or curve <graphic(keyword)>, the 
+> <graphic(object)|graphic's> <rectangle> encloses all the <pixels> in 
+> the <graphic(object)|graphic's> <points> <property> without touching 
+> any of them.
 
-If the object is a stack, its <rectangle> is relative to the left and top of the screen, rather than the left and top of the <stack window>.
+If the object is a stack, its <rectangle> is relative to the left and 
+top of the screen, rather than the left and top of the <stack window>.
 
-The first two items of a card's <rectangle> are always zero. The third <item> is the <height> of the <card>, and the fourth is the <width> of the <card>.
+The first two items of a card's <rectangle> are always zero. The third 
+<item> is the <height> of the <card>, and the fourth is the <width> of 
+the <card>.
 
->*Note:* The <rectangle> of a <graphic(keyword)> is drawn around all its <points> without touching them. (Usually, this makes no difference, but in some circumstances where you need to place a <graphic(object)|graphic's> <vertex> precisely with respect to another <object|object's> <rectangle>, you may need to take this into account.)
+>*Note:* The <rectangle> of a <graphic(keyword)> is drawn around all its 
+> <points> without touching them. (Usually, this makes no difference, 
+> but in some circumstances where you need to place a 
+> <graphic(object)|graphic's> <vertex> precisely with respect to another 
+> <object|object's> <rectangle>, you may need to take this into 
+> account.)
 
-If you specify the effective <keyword>, the rectangle includes the outline added by the <showFocusBorder> <property>. It also includes the heavy outline added to the <defaultButton>. If the <showFocusBorder> of the <object(glossary)> is false, or the <object(glossary)> is not currently <focus|focused>, the effective rectangle is the same as the rectangle.
+If you specify the effective <keyword>, the rectangle includes the 
+outline added by the <showFocusBorder> <property>. It also includes the 
+heavy outline added to the <defaultButton>. If the <showFocusBorder> of 
+the <object(glossary)> is false, or the <object(glossary)> is not 
+currently <focus|focused>, the effective rectangle is the same as the 
+rectangle.
 
->*Note:*As of version 6.0 the effective rect property of stacks returns the rect of the given stack with its decorations and
-frame taken into account. The effective rect of a stack can also be set. Here, the rect of the frame of the stack will be set appropriately before setting the rect of the stack.
+>*Note:*As of version 6.0 the effective rect property of stacks returns 
+> the rect of the given stack with its decorations and frame taken into 
+> account. The effective rect of a stack can also be set. Here, the rect 
+> of the frame of the stack will be set appropriately before setting the 
+> rect of the stack.
 
 Changes:
-The use of the effective keyword with the rectangle property was introduced in version 1.1. In previous versions, the rectangle of the defaultButton included the heavy outline.
+The use of the effective keyword with the rectangle property was 
+introduced in version 1.1. In previous versions, the rectangle of the 
+defaultButton included the heavy outline.
 
-References: bottom (property), topRight (property), pixels (property), liveResizing (property), points (property), defaultButton (property), width (property), showFocusBorder (property), height (property), backSize (property), orientation (property), margins (property), windowManagerPlace (property), card (keyword), item (keyword), graphic (keyword), moveStack (message), revChangeWindowSize (command), export snapshot (command), crop (command), object (glossary), graphic (object), property (glossary), keyword (glossary), focus (glossary), vertex (glossary), stack window (glossary), integer (glossary)
+References: bottom (property), topRight (property), pixels (property), 
+points (property), defaultButton (property), width (property), 
+showFocusBorder (property), height (property), backSize (property), 
+orientation (property), margins (property), 
+windowManagerPlace (property), card (keyword), item (keyword), 
+graphic (keyword), moveStack (message), revChangeWindowSize (command), 
+export snapshot (command), crop (command), object (glossary), 
+graphic (object), property (glossary), keyword (glossary), 
+focus (glossary), vertex (glossary), stack window (glossary), 
+integer (glossary)
 
 Tags: ui

--- a/docs/dictionary/property/resizable.lcdoc
+++ b/docs/dictionary/property/resizable.lcdoc
@@ -18,16 +18,27 @@ Example:
 set the resizable of this stack to false
 
 Value (bool):The <resizable> of a <stack> is true or false.
-By default, the <resizable> <property> of newly created <stacks> is set to true.
+By default, the <resizable> <property> of newly created <stacks> is set 
+to true.
 
 Value:
-The <resizable> <property> <control|controls> only whether the user can change the <stack|stack's> size. Even if the <resizable> is false, you can use the <rectangle> <property> (and related <properties>) to change the <stack|stack's> size in a <handler>.
+The <resizable> <property> <control|controls> only whether the user can 
+change the <stack|stack's> size. Even if the <resizable> is false, you 
+can use the <rectangle> <property> (and related <properties>) to change 
+the <stack|stack's> size in a <handler>.
 
-If the stack's style is "modal", or if is has been opened with the <modal> <command>, the setting of the <resizable> <property> has no effect, and the <stack window> cannot be resized.
+If the stack's style is "modal", or if is has been opened with the 
+<modal> <command>, the setting of the <resizable> <property> has no 
+effect, and the <stack window> cannot be resized.
 
 Description:
-Use the <resizable> <property> to control whether the user can change a window's size.
+Use the <resizable> <property> to control whether the user can change a 
+window's size.
 
-References: minHeight (property), liveResizing (property), properties (property), maxWidth (property), resizeStack (message), rectangle (keyword), property (glossary), handler (glossary), command (glossary), stack window (glossary), stacks (function), modal (command), stack (object), control (object)
+References: minHeight (property), properties (property), 
+maxWidth (property), resizeStack (message), rectangle (keyword), 
+property (glossary), handler (glossary), command (glossary), 
+stack window (glossary), stacks (function), modal (command), 
+stack (object), control (object)
 
 Tags: windowing

--- a/docs/notes/bugfix-17971.md
+++ b/docs/notes/bugfix-17971.md
@@ -1,0 +1,1 @@
+# Fix formatting of resizeStack message docs entry


### PR DESCRIPTION
- Remove references to liveResizing property from resizeStack, rectangle and resizable docs
- Fix bug 17971 by fixing broken links 
- Rewrap entries to 72 characters
