### PR TITLE
[Bug 18022] lc-compile: Improvements for comments & line continuation

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -58,6 +58,16 @@ Strings use backslash ('\') as an escape - the following are understood:
 
 > **Note:** Source files are presumed to be in UTF-8 encoding.
 
+## Line continuation
+
+A LiveCode builder statement or declaration can be continued onto
+multiple lines of code by placing the line continuation character `\`
+at the end each line.
+
+- **Line continuation**: \\(\n|\r\n|\r)
+
+> **Note:** A line continuation cannot occur within a comment.
+
 ### Case-Sensitivity
 
 At the moment, due to the nature of the parser being used, keywords are

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -58,6 +58,19 @@ Strings use backslash ('\') as an escape - the following are understood:
 
 > **Note:** Source files are presumed to be in UTF-8 encoding.
 
+## Comments
+
+LiveCode Builder supports single line comments, which begin with `//`
+or `--` and extend to the end of the line.  There are also block
+comments, which begin with `/*` and end with `*/`, and can span
+multiple lines.
+
+- **Single-line comment**: (--|//)[^\n\r]*
+- **Block comment**: /\*([^*](\*[^/])?)*\*/
+
+> **Note:** A block comment that spans multiple lines terminates the
+> line of code that it begins on.
+
 ## Line continuation
 
 A LiveCode builder statement or declaration can be continued onto

--- a/docs/lcb/notes/18022.md
+++ b/docs/lcb/notes/18022.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+## lc-compile
+
+# [18022] Multiline block comment should terminate initial line.

--- a/tests/lcb/compiler/frontend/comments.compilertest
+++ b/tests/lcb/compiler/frontend/comments.compilertest
@@ -1,0 +1,54 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%% Single line // comments
+%TEST SingleLineCommentSlashes
+module compiler_test
+// this should not be compiled
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Single line -- comments
+%TEST SingleLineCommentDashes
+module compiler_test
+-- this should not be compiled
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Block /* ... */ comments
+%TEST BlockComment
+module compiler_test
+/*
+this should not be compiled
+*/
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Bug 18022: Block comments that extend over multiple lines are
+%% supposed to terminate the line that they start on.
+%TEST ContinuationMultilineComment
+module /*
+*/ %{INCOMPLETE_MODULE}compiler_test
+end module
+%EXPECT PASS
+%ERROR "syntax error" at INCOMPLETE_MODULE
+%ENDTEST

--- a/tests/lcb/compiler/frontend/line-continuation.compilertest
+++ b/tests/lcb/compiler/frontend/line-continuation.compilertest
@@ -1,0 +1,56 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%% Continuation characters allow long lines of code to be spread
+%% across multiple lines in the source file by escaping the following
+%% newline character.
+%TEST Continuation
+module \
+		compiler_test
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Line continuation characters can't occur within a line, because
+%% they consume a following newline.
+%TEST ContinuationNoNewline
+module %{CONTINUATION_IN_LINE}\ compiler_test
+end module
+%EXPECT PASS
+%ERROR "Illegal token '\'" AT CONTINUATION_IN_LINE
+%ENDTEST
+
+%% A line continuation character consumes a following newline.  A
+%% backslash followed by a comment isn't a line continuation.
+%TEST ContinuationPreComment
+module %{CONTINUATION_BEFORE_COMMENT}\ -- test
+		compiler_test
+end module
+%EXPECT PASS
+%ERROR "Illegal token '\'" AT CONTINUATION_BEFORE_COMMENT
+%ENDTEST
+
+%% Line comments consume all characters up to the following newline
+%% and therefore cannot be continued
+%TEST CommentedContinuation
+module compiler_test
+-- comment \
+with%{SYNTAX} continuation character
+end module
+%EXPECT PASS
+%ERROR "syntax error" AT SYNTAX
+%ENDTEST

--- a/toolchain/lc-compile/src/COMMENTS.b
+++ b/toolchain/lc-compile/src/COMMENTS.b
@@ -3,5 +3,5 @@
 "/*"                { yysetpos(); BEGIN(COMMENT); }
 <COMMENT>"*/"       { yysetpos(); BEGIN(0); }
 <COMMENT>[^*\n\r]+  { yysetpos(); }
-<COMMENT>\n|\r\n|\r { AdvanceCurrentPositionToNextRow(); }
+<COMMENT>\n|\r\n|\r { AdvanceCurrentPositionToNextRow(); return SEPARATOR; }
 <COMMENT>"*"        { yysetpos(); }


### PR DESCRIPTION
- Add tests for line continuation handling
- Add documentation of comments and line continuation to language reference
- Fix bug where `/* ... /*` comments can act as line continuations
