### PR TITLE
[[ Bug 17953 ]] Fix moveStack regression on Mac

### DIFF
--- a/docs/notes/bugfix-17953.md
+++ b/docs/notes/bugfix-17953.md
@@ -1,0 +1,1 @@
+# Fix regression to Mac window moveStack handling

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -212,7 +212,6 @@ class MCMacPlatformSurface;
 
 - (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize;
 - (void)windowDidMove:(NSNotification *)notification;
-- (void)windowDidChangeScreen:(NSNotification *)notification;
 
 - (void)windowWillStartLiveResize:(NSNotification *)notification;
 - (void)windowDidEndLiveResize:(NSNotification *)notification;

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -441,7 +441,6 @@ static bool s_lock_responder_change = false;
 {
     // IM-2014-10-29: [[ Bug 13814 ]] Make sure we unset the user reshape flag once dragging is finished.
 	m_user_reshape = false;
-    m_window -> ProcessDidMove();
 }
 
 - (void)windowDidMove:(NSNotification *)notification

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -397,7 +397,6 @@ static bool s_lock_responder_change = false;
 //   frame sizes).
 - (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize
 {
-    NSLog(@"windowWillResize");
     MCRectangle t_frame;
     t_frame = MCRectangleMake(0, 0, frameSize . width, frameSize . height);
     

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -433,7 +433,7 @@ static bool s_lock_responder_change = false;
         
         // MW-2014-08-14: [[ Bug 13016 ]] Ask our NSApp to start sending us windowMoved
         //   messages.
-        [NSApp windowStartedMoving: m_window];
+        [(com_runrev_livecode_MCApplication *)NSApp windowStartedMoving: m_window];
     }
 }
 

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -448,11 +448,6 @@ static bool s_lock_responder_change = false;
     m_window -> ProcessDidMove();
 }
 
-- (void)windowDidChangeScreen:(NSNotification *)notification
-{
-    m_window -> ProcessDidMove();
-}
-
 - (void)windowWillStartLiveResize:(NSNotification *)notification
 {
     // MW-2014-04-23: [[ Bug 12270 ]] The user has started sizing the window

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -420,6 +420,11 @@ static bool s_lock_responder_change = false;
 
 - (void)windowWillMove:(NSNotification *)notification
 {
+    
+    NSWindow * t_window = m_window -> GetHandle();
+    if ([t_window respondsToSelector: @selector(setMovingFrame:)])
+        [((NSWindow <com_runrev_livecode_MCMovingFrame> *)t_window) setMovingFrame:[t_window frame]];
+    
     if (!m_window -> IsSynchronizing())
     {
         // MW-2014-04-23: [[ Bug 12270 ]] The user has started moving the window


### PR DESCRIPTION
The primary issue this patch addresses is processing moves in windowMoveFinished is it is possible for windowMoveFinished to be called on the delegate when the title bar has only been clicked and no actual move events handled. This was causing issues because `m_moving_frame` was uninitialised. As an extra guard I ensured it was initialised when moves begin and removed the windowDidChangeScreen method as unnecessary and possibly a risk to the move stack handling.
