### PR TITLE
build: Adjust C++ unininitialised variable detection

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -70,6 +70,8 @@
 					'-Wextra',
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
+					'-Werror=uninitialized',
+					'-Wno-error=maybe-uninitialized',
 				],
 
 				'cflags_cc':
@@ -127,7 +129,6 @@
 			[
 				'-O0',
 				'-g3',
-				'-Werror=uninitialized',
 			],
 			
 			'defines':
@@ -157,7 +158,6 @@
 			[
 				'-O0',
 				'-g0',
-				'-Werror=uninitialized',
 			],
 			
 			'defines':


### PR DESCRIPTION
These changes affect build configuration on Linux.
- `-Wuninitialized` warnings are only treated as errors if errors are
  not silenced for a build.  We build some particularly old and
  idiosyncratic thirdparty tools without warnings enabled because
  their code is a mess and written to ancient standards
- `-Wmaybe-uninitialized` warnings are not treated as errors, because
  they have the occasional false positive and, more importantly, we
  have lots of places where we don't check the results of memory
  allocation functions that leave their target variable unchanged if
  allocation fails
