### PR TITLE
[[ Bug 17962 ]] Ensure _mainStacksChanged isn't sent to a deleted stack

### DIFF
--- a/docs/notes/bugfix-17962.md
+++ b/docs/notes/bugfix-17962.md
@@ -1,0 +1,1 @@
+# Ensure the defaultStack hasn't been deleted before resetting it

--- a/docs/notes/bugfix-17962.md
+++ b/docs/notes/bugfix-17962.md
@@ -1,0 +1,1 @@
+# Ensure _mainStacksChanged message isn't sent to a deleted stack

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1176,8 +1176,7 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int p_handler_type, MCNameRef p_m
 		t_object = ctxt . GetObjectPtr();
 		
 	// Fetch current default stack and target settings
-	MCStack *t_old_stack;
-	t_old_stack = MCdefaultstackptr;
+	MCObjectHandle t_old_stack(MCdefaultstackptr->GetHandle());
 	MCObjectPtr t_old_target;
 	t_old_target = MCtargetptr;
 	
@@ -1249,8 +1248,9 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int p_handler_type, MCNameRef p_m
 	
 	// Reset the default stack pointer and target - note that we use 'send'esque
 	// semantics here. i.e. If the default stack has been changed, the change sticks.
-	if (MCdefaultstackptr == t_this_stack)
-		MCdefaultstackptr = t_old_stack;
+	if (t_old_stack.IsValid() &&
+		MCdefaultstackptr == t_this_stack)
+		MCdefaultstackptr = t_old_stack.GetAs<MCStack>();
 
 	// Reset target pointer
 	MCtargetptr = t_old_target;

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2097,9 +2097,8 @@ void MCInterfaceProcessToContainer(MCExecContext& ctxt, MCObjectPtr *p_objects, 
 		{
 			if (!p_cut)
 			{
-				MCStack *t_old_default;
-				t_old_default = MCdefaultstackptr;
-				MCdefaultstackptr = static_cast<MCStack *>(p_dst . object);
+                MCObjectHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+                MCdefaultstackptr = static_cast<MCStack *>(p_dst . object);
 				MCdefaultstackptr -> stopedit();
 
 				MCCard *t_card;
@@ -2107,7 +2106,9 @@ void MCInterfaceProcessToContainer(MCExecContext& ctxt, MCObjectPtr *p_objects, 
 
 				t_new_object = t_card -> clone(True, True);
 
-				MCdefaultstackptr = t_old_default;
+                if (t_old_defaultstack.IsValid())
+                    MCdefaultstackptr = t_old_defaultstack.GetAs<MCStack>();
+
 			}
 		}
 		break;
@@ -2875,9 +2876,8 @@ void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p
         
 	// MW-2007-05-01: Reverting this as it causes problems :o(
 	//stackptr -> setflag(True, F_VISIBLE);
-
-	MCStack *olddefault = MCdefaultstackptr;
-	Boolean oldtrace = MCtrace;
+    MCObjectHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+    Boolean oldtrace = MCtrace;
 	MCtrace = False;
 	if (p_mode >= WM_MODELESS)
 		MCRedrawForceUnlockScreen();
@@ -2904,8 +2904,8 @@ void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p
     
 	MCtrace = oldtrace;
     
-	if (p_mode > WM_TOP_LEVEL)
-		MCdefaultstackptr = olddefault;
+	if (p_mode > WM_TOP_LEVEL && t_old_defaultstack.IsValid())
+		MCdefaultstackptr = t_old_defaultstack.GetAs<MCStack>();
 }
 
 void MCInterfaceExecDrawerOrSheetStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned, int p_mode)
@@ -3057,7 +3057,7 @@ void MCInterfaceExecPopupStackByName(MCExecContext& ctxt, MCNameRef p_name, MCPo
 
 void MCInterfaceExecCreateStack(MCExecContext& ctxt, MCObject *p_object, MCStringRef p_new_name, bool p_force_invisible, bool p_with_group)
 {
-	MCStack *odefaultstackptr = MCdefaultstackptr;
+	MCObjectHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
 	Boolean wasvisible = MCtemplatestack->isvisible();
 
 	/* Check that a specified parent stack has a usable name before
@@ -3100,8 +3100,10 @@ void MCInterfaceExecCreateStack(MCExecContext& ctxt, MCObject *p_object, MCStrin
 
 	MCtemplatestack->setflag(wasvisible, F_VISIBLE);
 	MCObject *t_object = MCdefaultstackptr;
-	MCdefaultstackptr = odefaultstackptr;
-
+    
+    if (t_old_defaultstack.IsValid())
+        MCdefaultstackptr = t_old_defaultstack.GetAs<MCStack>();
+	
 	if (p_new_name != nil)
 		t_object->setstringprop(ctxt, 0, P_NAME, False, p_new_name);
 	
@@ -3266,8 +3268,8 @@ void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MC
 
 void MCInterfaceExecClone(MCExecContext& ctxt, MCObject *p_target, MCStringRef p_new_name, bool p_force_invisible)
 {
-	MCStack *odefaultstackptr = MCdefaultstackptr;
-
+    MCObjectHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+    
 	MCObject *t_object = nil;
 	switch (p_target->gettype())
 	{
@@ -3363,7 +3365,8 @@ void MCInterfaceExecClone(MCExecContext& ctxt, MCObject *p_target, MCStringRef p
 	t_object->names(P_LONG_ID, &t_id);
 	ctxt . SetItToValue(*t_id);
 
-	MCdefaultstackptr = odefaultstackptr;
+    if (t_old_defaultstack.IsValid())
+        MCdefaultstackptr = t_old_defaultstack.GetAs<MCStack>();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1424,7 +1424,7 @@ void MCModeQueueEvents(void)
 	// MW-2013-03-20: [[ MainStacksChanged ]]
 	if (MCmainstackschanged)
 	{
-		MCdefaultstackptr -> message(MCM_main_stacks_changed);
+        MCdispatcher -> gethome() -> message(MCM_main_stacks_changed);
 		MCmainstackschanged = False;
 	}
 #endif

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -454,8 +454,8 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		MCParameter p1;
 		p1.setvalueref_argument(t_param_name);
         
-		MCStack *oldstackptr = MCdefaultstackptr;
-		MCdefaultstackptr = getstack();
+        MCObjectHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+        MCdefaultstackptr = getstack();
 		MCObjectPtr oldtargetptr = MCtargetptr;
 		MCtargetptr . object = this;
         MCtargetptr . part_id = 0;
@@ -468,8 +468,11 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		t_stat = MCU_dofrontscripts(HT_GETPROP, t_getprop_name, &p1);
 		if (t_stat == ES_NOT_HANDLED || t_stat == ES_PASS)
 			t_stat = handle(HT_GETPROP, t_getprop_name, &p1, this);
-		MCdefaultstackptr = oldstackptr;
-		MCtargetptr = oldtargetptr;
+        
+        if (t_old_defaultstack.IsValid())
+            MCdefaultstackptr = t_old_defaultstack.GetAs<MCStack>();
+        
+        MCtargetptr = oldtargetptr;
 		if (added)
 			MCnexecutioncontexts--;
 	}
@@ -1642,7 +1645,7 @@ Exec_stat MCObject::sendsetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		p1.setvalueref_argument(t_param_name);
 		p2.setvalueref_argument(p_value);
 		
-		MCStack *oldstackptr = MCdefaultstackptr;
+		MCObjectHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
 		MCdefaultstackptr = getstack();
 		MCObjectPtr oldtargetptr = MCtargetptr;
 		MCtargetptr . object = this;
@@ -1660,8 +1663,11 @@ Exec_stat MCObject::sendsetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
         
 		if (added)
 			MCnexecutioncontexts--;
-		MCdefaultstackptr = oldstackptr;
-		MCtargetptr = oldtargetptr;
+        
+        if (t_old_defaultstack.IsValid())
+            MCdefaultstackptr = t_old_defaultstack.GetAs<MCStack>();
+        
+        MCtargetptr = oldtargetptr;
 	}
     
 	return t_stat;

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -882,8 +882,8 @@ bool MCWidgetBase::DoDispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_
 
 bool MCWidgetBase::Dispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)
 {
-	MCStack *t_old_default_stack, *t_this_stack;
-	t_old_default_stack = MCdefaultstackptr;
+	MCStack *t_this_stack;
+	MCObjectHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
 	
 	// Preserve the host ptr we get across the dispatch so that
 	// we definitely return things to the way they were.
@@ -910,8 +910,8 @@ bool MCWidgetBase::Dispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_ar
 	if (t_host != nil)
 	{
 		MCtargetptr = t_old_target;
-		if (MCdefaultstackptr == t_this_stack)
-			MCdefaultstackptr = t_old_default_stack;
+        if (MCdefaultstackptr == t_this_stack && t_old_defaultstack.IsValid())
+            MCdefaultstackptr = t_old_defaultstack.GetAs<MCStack>();
 	}
 	else
 		MCEngineScriptObjectAllowAccess();


### PR DESCRIPTION
When deleting a stack the default stack may be left
in a state where it references the deleted stack
which is an issue which needs further thought and
broader changes in a non-maintenance release. This
patch changes the target for `_mainStacksChanged`
which is always sent just after a stack is deleted
to the home stack. `_mainStacksChanged` is an IDE
only message so this change should have no impact
on users.
