### PR TITLE
[[ Bug 18019 ]] Fix deletability test for objects on a card

### DIFF
--- a/docs/notes/bugfix-18019.md
+++ b/docs/notes/bugfix-18019.md
@@ -1,0 +1,1 @@
+# Ensure cards with objects on can be deleted

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1105,9 +1105,13 @@ bool MCCard::isdeletable(bool p_check_flag)
         MCObjptr *t_object_ptr = objptrs;
         do
         {
-            // if it's a background group then don't check flags
-            if (!((t_object_ptr->getref()->gettype() == CT_GROUP && static_cast<MCGroup *>(t_object_ptr->getref())->isshared())) &&
-                t_object_ptr->getref()->isdeletable(true))
+            MCGroup * t_group = t_object_ptr->getrefasgroup();
+            
+            if (t_group != nil && t_group->isshared())
+            {
+                // if it's a shared group then don't check deletability because the object won't be deleted
+            }
+            else if (!t_object_ptr->getref()->isdeletable(true))
                 return false;
             
             t_object_ptr = t_object_ptr->next();

--- a/tests/lcs/core/execution/object-deletion.livecodescript
+++ b/tests/lcs/core/execution/object-deletion.livecodescript
@@ -38,6 +38,21 @@ on TestDeleteObjectInNestedGroup
    TestAssertThrow "Delete object executing script in nested group", "DeleteIt", the long id of button "test" of stack "test", 347
 end TestDeleteObjectInNestedGroup
 
+on TestDeleteThisCard
+   set the defaultStack to "test"
+   create group "test"
+   create button "test" in group "test"
+   set the script of button "test" to \
+         "on DeleteIt" & return & \
+         "delete this card" & return & \
+         "end DeleteIt"
+   TestAssertThrow "Delete card from button on card", "DeleteIt", the long id of button "test" of stack "test", 347
+   
+   set the sharedBehavior of group "test" to true
+   dispatch "DeleteIt" to button "test"
+   TestAssert "Delete card from button in shared group on card", there is not a button "test" of card 1 of stack "test"
+end TestDeleteThisCard
+
 on TestTeardown
    delete stack "test"
 end TestTeardown


### PR DESCRIPTION
This patch fixes a logic error in the `isdeletable`
implementation for cards which meant cards with
objects on them could not be deleted.
