### PR TITLE
build: Enable -Werror=delete-non-virtual-dtor on Linux

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -76,8 +76,7 @@
 
 				'cflags_cc':
 				[
-					# Needs GCC 4.7
-					#'-Werror=delete-non-virtual-dtor',
+					'-Werror=delete-non-virtual-dtor',
 				],
 			},
 			{


### PR DESCRIPTION
This warning setting was previously disabled for Linux builds because
the compiler being used for x86 builds didn't understand it.
