### PR TITLE
build: GCC 4.7 understands C++11

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -8,8 +8,7 @@
 		'exe_suffix': '',
 		'debug_info_suffix': '.dbg',
 
-		# Note: using old name for compatibility with older compilers (like GCC 4.4)
-		'c++_std': '<!(echo ${CXX_STD:-c++0x})',
+		'c++_std': '<!(echo ${CXX_STD:-c++11})',
 	},
 	
 	'defines':


### PR DESCRIPTION
Now that x86 Linux build use GCC 4.7.2, it should be safe to pass `c++11` as the requested C++ standard.
