### PR TITLE
libfoundation: Remove unnecessary semi-colons.

### DIFF
--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -791,7 +791,7 @@ static bool __MCArrayCreateIndirect(__MCArray *p_contents, __MCArray*& r_array)
 
 	r_array = self;
 	return true;
-};
+}
 
 static uindex_t __MCArrayGetTableSizeIndex(__MCArray *self)
 {

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -1034,7 +1034,7 @@ static bool __MCProperListCreateIndirect(__MCProperList *p_contents, __MCProperL
 
 	r_list = self;
 	return true;
-};
+}
 
 
 static bool __MCProperListIsIndirect(__MCProperList *self)


### PR DESCRIPTION
My C++ compiler is a pedant.
