### PR TITLE
libfoundation: Use C++11 features for MCMin, MCMax & MCClamp

### DIFF
--- a/engine/src/graphics_util.h
+++ b/engine/src/graphics_util.h
@@ -181,10 +181,10 @@ MCGRectangleGetIntegerRect(const MCGRectangle &p_rect)
 		t_height = LowerAdjust(p_rect.size.height);
 	}
 
-	return MCRectangleMake( int16_t(MCClamp(t_left,   INT16_MIN,  INT16_MAX)),
-	                        int16_t(MCClamp(t_top,    INT16_MIN,  INT16_MAX)),
-	                       uint16_t(MCClamp(t_width,  0,         UINT16_MAX)),
-	                       uint16_t(MCClamp(t_height, 0,         UINT16_MAX)));
+	return MCRectangleMake(MCClamp<MCGFloat>(t_left,   INT16_MIN,  INT16_MAX),
+	                       MCClamp<MCGFloat>(t_top,    INT16_MIN,  INT16_MAX),
+	                       MCClamp<MCGFloat>(t_width,  0,         UINT16_MAX),
+	                       MCClamp<MCGFloat>(t_height, 0,         UINT16_MAX));
 }
 
 inline MCRectangle MCGRectangleGetIntegerInterior(MCGRectangle p_rect)
@@ -225,8 +225,8 @@ static inline MCPoint MCPointMake(int16_t x, int16_t y)
 
 static inline MCPoint MCGPointToMCPoint(const MCGPoint &p_point)
 {
-	return MCPointMake(int16_t(MCClamp(p_point.x, INT16_MIN, INT16_MAX)),
-	                   int16_t(MCClamp(p_point.y, INT16_MIN, INT16_MAX)));
+	return MCPointMake(MCClamp<MCGFloat>(p_point.x, INT16_MIN, INT16_MAX),
+	                   MCClamp<MCGFloat>(p_point.y, INT16_MIN, INT16_MAX));
 }
 
 inline MCGPoint MCPointToMCGPoint(MCPoint p_point, MCGFloat p_adjustment = 0.0f)

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -714,8 +714,10 @@ template <typename T> inline compare_t MCCompare(T a, T b) { return ((a < b) ? -
 
 template <typename T> inline bool MCIsPowerOfTwo(T x) { return (x & (x - 1)) == 0; }
 
-template <typename T, typename U, typename V>
-inline T MCClamp(T value, U min, V max) {
+// TODO(C++11) constexpr
+template <typename TO, typename FROM=TO>
+inline TO MCClamp(const FROM& value, const TO& min, const TO& max)
+{
 	return MCMax(MCMin(value, max), min);
 }
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -661,6 +661,16 @@ typedef struct __MCLocale* MCLocaleRef;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
+//  EXPLICIT CONVERSIONS
+//
+
+// TODO(C++11): constexpr
+// TODO(C++11): define only for numeric types
+template <typename TO, typename FROM=TO>
+inline TO MCNarrow(const FROM& x) { return TO(x); }
+
+////////////////////////////////////////////////////////////////////////////////
+//
 //  MINIMUM FUNCTIONS
 //
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/*                                                                     -*-C++-*-
+Copyright (C) 2003-2016 LiveCode Ltd.
 
 This file is part of LiveCode.
 
@@ -663,16 +664,24 @@ typedef struct __MCLocale* MCLocaleRef;
 //  MINIMUM FUNCTIONS
 //
 
-// TODO: re-write when we adopt C++11
-template <class T, class U> inline T MCMin(T a, U b) { return a < b ? a : T(b); }
+// TODO(C++11): constexpr
+template <typename TO, typename FROM=TO>
+inline TO MCMin(const FROM& a, const TO& b)
+{
+	return TO{a} < b ? TO{a} : b;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  MAXIMUM FUNCTIONS
 //
 
-// TODO: re-write when we adopt C++11
-template <class T, class U> inline T MCMax(T a, U b) { return a > b ? a : T(b); }
+// TODO(C++11): constexpr
+template <typename TO, typename FROM=TO>
+inline TO MCMax(const FROM& a, const TO& b)
+{
+	return TO{a} > b ? TO{a} : b;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -536,7 +536,8 @@ inline bool MCGSizeIsEqual(const MCGSize &p_a, const MCGSize &p_b)
 
 inline MCGColor MCGColorComponentFromFloat(MCGFloat p_component)
 {
-    return MCGColor(MCClamp(p_component * UINT8_MAX, 0, UINT8_MAX));
+	return MCClamp<MCGColor>(MCNarrow<MCGColor>(p_component * UINT8_MAX),
+	                         0, UINT8_MAX);
 }
 
 inline MCGFloat MCGColorComponentToFloat(MCGColor p_component)


### PR DESCRIPTION
These changes use the C++11 brace initialisation to ensure `MCMin`, `MCMax` and `MCClamp` generate warnings if they require a narrowing conversion (i.e. a conversion from one numeric type `U` to another numeric type `V` where `V` cannot represent all values of `U`).  A new `MCNarrow` template function provides the ability to annotate deliberate narrowing conversions.
