### PR TITLE
Build revvideograbber dependencies as universal binary

### DIFF
--- a/libcore/libcore.gyp
+++ b/libcore/libcore.gyp
@@ -70,6 +70,17 @@
 					'include',
 				],
 			},
+			
+			'configurations':
+			{
+				'Debug':
+				{
+					'xcode_settings':
+					{
+						'ONLY_ACTIVE_ARCH': 'NO',
+					},
+				},
+			},
 		},
 	],
 }

--- a/libexternal/libexternal.gyp
+++ b/libexternal/libexternal.gyp
@@ -67,7 +67,18 @@
 						},
 					],
 				],
-			}
+			},
+			
+			'configurations':
+			{
+				'Debug':
+				{
+					'xcode_settings':
+					{
+						'ONLY_ACTIVE_ARCH': 'NO',
+					},
+				},
+			},
 		},
 		{
 			'target_name': 'libExternal-symbol-exports',

--- a/livecode.gyp
+++ b/livecode.gyp
@@ -71,7 +71,6 @@
 							'revmobile/revmobile.gyp:external-revandroid',
 							'revmobile/revmobile.gyp:external-reviphone',
 							'revspeech/revspeech.gyp:external-revspeech',
-							'revvideograbber/revvideograbber.gyp:external-revvideograbber',
 							
 							# Server externals
 							'revdb/revdb.gyp:external-revdb-server',
@@ -94,6 +93,7 @@
 						[
 							# Externals
 							'revfont/revfont.gyp:external-revfont',
+							'revvideograbber/revvideograbber.gyp:external-revvideograbber',
 						],
 					},
 				],

--- a/revvideograbber/revvideograbber.gyp
+++ b/revvideograbber/revvideograbber.gyp
@@ -129,6 +129,17 @@
 				# we also need to compile that file on Windows. Force using Objective-C++
 				'OTHER_CPLUSPLUSFLAGS': '-x objective-c++',
 			},
+			
+			'configurations':
+			{
+				'Debug':
+				{
+					'xcode_settings':
+					{
+						'ONLY_ACTIVE_ARCH': 'NO',
+					},
+				},
+			},
 		},
 	],
 }


### PR DESCRIPTION
This patch fixes compile errors in the revvideograbber
project which is i386 only when building the LiveCode-all
target in Xcode as 64 bit by building its dependences
as universal binaries.
