### PR TITLE
[[ Bug 18041 ]] codeunit offset results should be 1 indexed

### DIFF
--- a/docs/notes/bugfix-18041.md
+++ b/docs/notes/bugfix-18041.md
@@ -1,0 +1,1 @@
+# Ensure codeunitOffset and codepointOffset return 1 indexed offset

--- a/libfoundation/src/foundation-chunk.cpp
+++ b/libfoundation/src/foundation-chunk.cpp
@@ -591,7 +591,7 @@ uindex_t MCTextChunkIterator_Codeunit::ChunkOffset(MCStringRef p_needle, uindex_
     if (MCStringFind(m_text, t_in_range, p_needle, m_options, &t_range))
     {
         if (!p_whole_matches || t_range . length == 1)
-            return t_range . offset;
+            return t_range . offset + 1;
     }
     
     return 0;

--- a/tests/lcs/core/strings/codepointoffset.livecodescript
+++ b/tests/lcs/core/strings/codepointoffset.livecodescript
@@ -1,0 +1,37 @@
+script "CoreStringCodepointOffset"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestCodepointOffsetSingleUnicodeChar
+   local tNativeNeedle, tUnicodeNeedle, tNativeHaystack, tUnicodeHaystack
+   
+   put "B" into tNativeNeedle
+   put numToCodepoint(0x391) into tUnicodeNeedle
+   
+   put "aAbBcC" into tNativeHaystack
+   put "aAbBcC" & numToCodepoint(0x3B1) & numToCodepoint(0x391) into tUnicodeHaystack
+
+   set the caseSensitive to true
+   TestAssert "codepoint offset of native needle in unicode string - case-sensitive", codepointOffset(tNativeNeedle, tUnicodeHaystack) is 4
+   TestAssert "codepoint offset of unicode needle in unicode string - case-sensitive", codepointOffset(tUnicodeNeedle, tUnicodeHaystack) is 8
+   TestAssert "codepoint offset of native needle in native string - case-sensitive", codepointOffset(tNativeNeedle, tNativeHaystack) is 4
+
+   set the caseSensitive to false
+   TestAssert "codepoint offset of native needle in unicode string - caseless", codepointOffset(tNativeNeedle, tUnicodeHaystack) is 3
+   TestAssert "codepoint offset of unicode needle in unicode string - caseless", codepointOffset(tUnicodeNeedle, tUnicodeHaystack) is 7
+   TestAssert "codepoint offset of native needle in native string - caseless", codepointOffset(tNativeNeedle, tNativeHaystack) is 3
+end TestCodepointOffsetSingleUnicodeChar

--- a/tests/lcs/core/strings/codeunitoffset.livecodescript
+++ b/tests/lcs/core/strings/codeunitoffset.livecodescript
@@ -1,0 +1,37 @@
+script "CoreStringCodeunitOffset"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestCodeunitOffsetSingleUnicodeChar
+   local tNativeNeedle, tUnicodeNeedle, tNativeHaystack, tUnicodeHaystack
+   
+   put "B" into tNativeNeedle
+   put numToCodepoint(0x391) into tUnicodeNeedle
+   
+   put "aAbBcC" into tNativeHaystack
+   put "aAbBcC" & numToCodepoint(0x3B1) & numToCodepoint(0x391) into tUnicodeHaystack
+
+   set the caseSensitive to true
+   TestAssert "codeunit offset of native needle in unicode string - case-sensitive", codeunitOffset(tNativeNeedle, tUnicodeHaystack) is 4
+   TestAssert "codeunit offset of unicode needle in unicode string - case-sensitive", codeunitOffset(tUnicodeNeedle, tUnicodeHaystack) is 8
+   TestAssert "codeunit offset of native needle in native string - case-sensitive", codeunitOffset(tNativeNeedle, tNativeHaystack) is 4
+
+   set the caseSensitive to false
+   TestAssert "codeunit offset of native needle in unicode string - caseless", codeunitOffset(tNativeNeedle, tUnicodeHaystack) is 3
+   TestAssert "codeunit offset of unicode needle in unicode string - caseless", codeunitOffset(tUnicodeNeedle, tUnicodeHaystack) is 7
+   TestAssert "codeunit offset of native needle in native string - caseless", codeunitOffset(tNativeNeedle, tNativeHaystack) is 3
+end TestCodeunitOffsetSingleUnicodeChar


### PR DESCRIPTION
This patch fixes codeunitOffset in all cases
and codepointOffset in cases where it is simplified
to codeunitOffset.
