### PR TITLE
Ensure that field color chunks are fully initialized.

### DIFF
--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -179,6 +179,9 @@ struct PodFieldPropType<MCInterfaceNamedColor>
     static void init(MCInterfaceNamedColor& self)
     {
         self . name = MCValueRetain(kMCEmptyString);
+        self . color . red = 0;
+        self . color . green = 0;
+        self . color . blue = 0;
     }
 
     static void input(MCInterfaceNamedColor p_value, MCInterfaceNamedColor& r_value)


### PR DESCRIPTION
Some C++ compilers don't fully implement the C++11 standard's
requirement that value members of structures should be value
initialised by the default (implicit) constructor.

This means that an `MCColor` is not initialised to `{0,0,0}`, and by
extension, `MCInterfaceNamedColor::color` is not zero-initialised by
its default constructor.

This patch adjusts `PodFieldPropType<MCInterfaceNamedColor>::init()`
to explicitly initialise the color to 0.
