### PR TITLE
[build] Correct typo in iOS compiler flags

### DIFF
--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -194,7 +194,7 @@
 							'-Werror=uninitialized',
 							'-Werror=return-type',
 							'-Werror=tautological-compare',
-							'-Werror=logical-not-paretheses',
+							'-Werror=logical-not-parentheses',
 						],
 					},
 				},

--- a/engine/src/mbliphonecontrol.mm
+++ b/engine/src/mbliphonecontrol.mm
@@ -244,7 +244,7 @@ void MCiOSControl::GetRect(MCExecContext& ctxt, MCRectangle& r_rect)
 void MCiOSControl::GetVisible(MCExecContext& ctxt, bool& r_visible)
 {
     if (m_view != nil)
-        r_visible = ![m_view isHidden] == True;
+        r_visible = [m_view isHidden] != True;
     else
         r_visible = false;
 }


### PR DESCRIPTION
Fix a compilation flag typo that was causing unhelpful
warnings in iOS builds.
