### PR TITLE
[build] Tweaks to toolsBuilderFilterExternals

### DIFF
--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -78,7 +78,13 @@ end toolsBuilderRunBundle
 
 private command toolsBuilderFilterExternals pFolder, pPlatform
    -- Enter the extension directory
+   local tOldFolder
+   put the defaultFolder into tOldFolder
    set the defaultFolder to pFolder
+   if the result is not empty then
+      builderLog "error", merge("Failed to enter '[[pFolder]]': [[the result]]")
+      exit toolsBuilderFilterExternals
+   end if
 
    local tFiles
    -- Remove any iOS code if we're not building the OSX installer
@@ -101,7 +107,7 @@ private command toolsBuilderFilterExternals pFolder, pPlatform
          revZipCloseArchive pFolder & slash & tLCExt
          
          if tArchiveFiles is not empty then
-            get shell(merge("rm -f '[[ tLCExt ]]'"))
+            get shell(merge("rm -fv '[[ tLCExt ]]'"))
          end if
       end repeat
    end if
@@ -109,7 +115,12 @@ private command toolsBuilderFilterExternals pFolder, pPlatform
    -- If the directory contains no code any more, remove it
    put the files & return & the folders into tFiles
    filter lines of tFiles with regex pattern "^.*\.(so|dylib|bundle|dll|lcext)$"
-   
+
+   set the defaultFolder to tOldFolder
+   if the result is not empty then
+      builderLog "error", merge("Failed to enter '[[tOldFolder]]': [[the result]]")
+   end if
+
    return tFiles is not empty
 end toolsBuilderFilterExternals
 


### PR DESCRIPTION
A regression was introduced to installer construction somewhere
between commit 38cae350 and commit c9ced4b7.  The regression causes
the Windows executable to be omitted from Indy and Business
installers.

Examination of the git logs suggest that commit d3ed540c is the only
change that should have affected the build process.  This patch:
- checks that setting the current working directory is successful
- sets the current working directory back to what it was initially
- tells the `rm` command to print a list of the files that it deletes
