### PR TITLE
Change LCB stdlib examples not to use "the result"

### DIFF
--- a/libscript/src/arithmetic.lcb
+++ b/libscript/src/arithmetic.lcb
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2016 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -532,8 +532,10 @@ The result:	<Operand> formatted as a string.
 
 Example:
 	variable tNum as Number
+	variable tString as String
 	put 5 into tNum
-	format tNum as string -- the result contains "5"
+	format tNum as string into tString
+	-- tString contains "5"
 
 Description:
 Use <FormatNumberAsString> when you want to manipulate a numeric value as text.
@@ -591,11 +593,11 @@ Example:
 	parse tString as Number -- the result is 5.6
 
 Example:
-	variable tResult as String
+	variable tResult as optional String
 	variable tNum as optional Number
-	parse "aaaa" as Number
+	parse "aaaa" as Number into tNum
 	
-	if the result is nothing then
+	if tNum is nothing then
 		put "unable to parse string" into tResult
 	end if
 
@@ -658,7 +660,8 @@ Example:
 	variable tListOfString as List
 	variable tListOfNum as List
 	split "1,2,3,4" by "," into tListOfString
-	parse tListOfString as list of number -- the result contains [ 1, 2, 3, 4 ]
+	parse tListOfString as list of number into tListOfNum
+	-- tListOfNum contains [ 1, 2, 3, 4 ]
 
 Description:
 Use <ParseListOfStringAsListOfNumber> when you want to interpret pieces of text numerically. If the input list contains elements which cannot be parsed as numbers, the corresponding element will be nothing.

--- a/libscript/src/logic.lcb
+++ b/libscript/src/logic.lcb
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2016 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -169,8 +169,7 @@ The result:	"true" or "false"
 
 Example:
 	variable tVar as String
-	parse 1 = 0 as String
-	put the result into tVar
+	format 1 = 0 as String into tVar
 	put "e" into char 3 of tVar -- tVar is "tree"
 
 Description:
@@ -225,8 +224,9 @@ Example:
 
 Example:
 	variable tResult as String
-	parse "sdfsdf" as Boolean
-	if the result is nothing then
+	variable tCheck as optional Boolean
+	parse "sdfsdf" as boolean into tCheck
+	if tCheck is nothing then
 		put "not a valid boolean" into tResult
 	end if
 

--- a/libscript/src/type-convert.lcb
+++ b/libscript/src/type-convert.lcb
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2016 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -38,8 +38,7 @@ Example:
 	variable tVar as String
     put "first,second,third,fourth,fifth" into tVar
     variable tSplit as List
-    split tVar by ","
-    put the result into tSplit
+    split tVar by "," into tSplit
     put element 1 of tSplit into tFirstElement // tFirstElement contains "first"
     
 Description:
@@ -64,13 +63,13 @@ Delimiter:      An expression that evaluates to a string.
 The result: 	The combined string.
 
 Example:
-	variable tDigits as List
-	put [1,2,3,4,5,6,7,8,9] into tDigits
+	variable tWords as List
+	put ["A","List","of","words"] into tWords
 	
 	variable tString as String
-    combine tDigits with "|" 
-    put the result into tString // tString contains "1|2|3|4|5|6|7|8|9"
-            
+	combine tWords with " " into tString
+	-- tString contains "A List of words"
+
 Description:
 Use the combine command to convert a list into a string representation of the list.
 

--- a/tests/lcb/stdlib/arithmetic.lcb
+++ b/tests/lcb/stdlib/arithmetic.lcb
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2015 LiveCode Ltd.
+Copyright (C) 2015-2016 LiveCode Ltd.
 
 This file is part of LiveCode.
 
@@ -208,9 +208,17 @@ public handler TestLessThanEqual()
 end handler
 
 public handler TestFormatString()
-	test "format as string (int)" when (-1) formatted as string is "-1"
+	test "formatted as string (int)" when (-1) formatted as string is "-1"
 
-	test "format as string (real)" when (-1.1) formatted as string is "-1.1"
+	test "formatted as string (real)" when (-1.1) formatted as string is "-1.1"
+
+	variable tString as String
+
+	format -1 as string into tString
+	test "format as string (int)" when tString is "-1"
+
+	format -1.1 as string into tString
+	test "format as string (real)" when tString is "-1.1"
 end handler
 
 public handler TestParseString()

--- a/tests/lcb/stdlib/logic.lcb
+++ b/tests/lcb/stdlib/logic.lcb
@@ -1,0 +1,24 @@
+module com.livecode.logic.tests
+
+public handler TestFormatString()
+	test "formatted as string" when true formatted as string is "true"
+
+	variable tString as String
+
+	format false as string into tString
+	test "format as string" when tString is "false"
+end handler
+
+public handler TestParseString()
+	test "parsed as boolean" when "true" parsed as boolean
+
+	variable tBool as optional Boolean
+
+	parse "false" as boolean into tBool
+	test "parse as boolean" when not tBool
+
+	parse "sdfthtoeu" as boolean into tBool
+	test "parse as boolean (invalid)" when tBool is nothing
+end handler
+
+end module

--- a/tests/lcb/stdlib/typeconvert.lcb
+++ b/tests/lcb/stdlib/typeconvert.lcb
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2015 LiveCode Ltd.
+Copyright (C) 2015-2016 LiveCode Ltd.
 
 This file is part of LiveCode.
 
@@ -17,6 +17,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 module com.livecode.typeconvert.tests
 
+use com.livecode.__INTERNAL._testlib
+
 public handler TestSplit()
 	-- Bug 15440
 	variable tString
@@ -33,6 +35,25 @@ public handler TestSplitEmpty()
 	put "security.selinux\u{0}user.test\u{0}user.uuid" into tString
 	split tSTring by "" into tList
 	test "split (empty)" when the number of elements in tList is 1
+end handler
+
+private handler TestCombine_NonString()
+	variable tString
+	combine [1, 2, 3] with "," into tString
+end handler
+
+public handler TestCombine()
+	variable tString
+	variable tList
+	put ["a", "b", "c"] into tList
+
+	combine tList with "," into tString
+	test "combine (comma)" when the number of chars in tString is 5
+
+	combine tList with "" into tString
+	test "combine (empty)" when the number of chars in tString is 3
+
+	MCUnitTestHandlerThrows(TestCombine_NonString, "combine non-string")
 end handler
 
 end module


### PR DESCRIPTION
Currently, the status of `the result` expression in LCB is still a bit indeterminate.  For now, avoid recommend its use and recommend `into` forms instead.

This pull requests adds some missing tests for the features used in the updated examples.
