### PR TITLE
[Bug 18054] switchbutton: Use accessors to update props in OnLoad()

### DIFF
--- a/extensions/widgets/switchbutton/notes/18054.md
+++ b/extensions/widgets/switchbutton/notes/18054.md
@@ -1,0 +1,1 @@
+# [18054] Ensure that appearance reflects loaded state

--- a/extensions/widgets/switchbutton/switchbutton.lcb
+++ b/extensions/widgets/switchbutton/switchbutton.lcb
@@ -224,8 +224,12 @@ public handler OnSave(out rProperties as Array)
 end handler
 
 public handler OnLoad(in pProperties as Array)
-	put pProperties["highlight"] into mSwitchIsOn
-	put pProperties["showBorder"] into mShowFrameBorder
+	if "highlight" is among the keys of pProperties then
+		setSwitch(pProperties["highlight"])
+	end if
+	if "showBorder" is among the keys of pProperties then
+		setShowFrameBorder(pProperties["showBorder"])
+	end if
 end handler
 
 public handler OnCreate() returns nothing


### PR DESCRIPTION
Use property accessor functions to set properties during `OnLoad()` in
order to ensure that all relevant updates are performed (such as
redrawing the widget).
