### PR TITLE
build: Ensure removed dictionary entries don't break the build

### DIFF
--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -1006,8 +1006,13 @@ private command DictionaryScan @xAdded, @xModified
 end DictionaryScan
 
 private command DictionaryScanFile pFile, @xAdded, @xModified
-   local tContents
-   put FileGetUTF8Contents(pFile) into tContents
+   local tContents, tError
+   try
+      put FileGetUTF8Contents(pFile) into tContents
+   catch tError
+      BuilderLog "report", tError
+      exit DictionaryScanFile
+   end try
    
    -- Extract basic metadata from the dictionary entry
    local tName, tType, tVersion


### PR DESCRIPTION
Both the dictionary info gathering and the release note fragment
gathering steps use lists of changed files in order to determine which
files to consider.  Some of these files have changed because they've
been removed.  It isn't an error or even a warning if these files are
missing; it's just an interesting and perhaps notable fact.
