### PR TITLE
[Bug 18093] Fix heap corruption bug on Linux

### DIFF
--- a/docs/notes/bugfix-18093.md
+++ b/docs/notes/bugfix-18093.md
@@ -1,0 +1,1 @@
+# Fix a heap corruption issue due to an incompletely cleared object proxy.

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -5501,7 +5501,11 @@ MCObject* MCObjectProxy::Get()
 
 void MCObjectProxy::Clear()
 {
-	m_object = nil;
+	if (m_object)
+	{
+		m_object->m_weak_proxy = nil;
+		m_object = nil;
+	}
 }
 
 void MCObjectProxy::Retain()
@@ -5519,8 +5523,7 @@ void MCObjectProxy::Release()
 	{
         // The object in question no longer has a proxy object as we are being
         // deleted
-        if (m_object)
-            m_object->m_weak_proxy = nil;
+		Clear();
         
 		delete this;
 	}

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -1557,11 +1557,14 @@ private:
     
     void Set(MCObjectProxy* p_proxy)
     {
-        if (m_proxy != nil)
-            m_proxy->Release();
-        m_proxy = p_proxy;
-        if (m_proxy != nil)
-            m_proxy->Retain();
+	    if (m_proxy != p_proxy)
+	    {
+		    if (m_proxy != nil)
+			    m_proxy->Release();
+		    m_proxy = p_proxy;
+		    if (m_proxy != nil)
+			    m_proxy->Retain();
+	    }
     }
 };
 


### PR DESCRIPTION
This commit makes two small corrections to the implementation of `MCObjectHandle` and `MCObjectProxy` to avoid a possible over-release and a possible use-after-free error.

The changes fix a crash on Linux when closing the script editor.
