### PR TITLE
[[ ScriptStatus ]] Implement scriptStatus of object property

### DIFF
--- a/docs/dictionary/property/scriptStatus.lcdoc
+++ b/docs/dictionary/property/scriptStatus.lcdoc
@@ -1,0 +1,48 @@
+Name: scriptStatus
+
+Type: property
+
+Syntax: get the scriptStatus of <object>
+
+Summary:
+Determine the status of the last script compilation of an object.
+
+Associations: object
+
+Introduced: 8.1
+
+OS: mac, windows, linux, ios, android, html5
+
+Platforms: desktop, mobile, server
+
+Example:
+if the scriptStatus of stack "MyStack" is "error" then
+   edit the script of stack "MyStack"
+end if
+
+Parameters:
+object:
+The name or ID of the object.
+
+Value (enum): The status of the last compile
+
+- "uncompiled": The LiveCode engine compiles scripts on demand,
+  therefore, if an object is loaded into memory but has not been sent
+  any messages it will be in an uncompiled state.
+- "compiled": Compiled with no errors. Any handlers will be in the
+  message path.
+- "warning": One or more warnings. Currently unused but reserved for
+  future use.
+- "error": One or more errors in the script causing the script to
+  remain in an uncompiled state.
+
+Description:
+Use the scriptStatus property to determine the success of the
+last compilation of the object's script. Compilation of scripts occurs
+when a stack is loaded into memory and when the script property is set.
+
+>*Note:* The LiveCode IDE script editor uses an intermediate object to
+test compilation, therefore, the script editor may display compilation
+errors when the scriptStatus returns empty.
+
+References: script (property)

--- a/docs/notes/feature-scriptstatus.md
+++ b/docs/notes/feature-scriptstatus.md
@@ -1,0 +1,5 @@
+# A new scriptStatus of object property has been implemented
+
+Use `the scriptStatus of <object>` to determine the status of the
+last time the script property was set or the script was compiled
+when the stack was opened.

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1252,6 +1252,24 @@ MCExecEnumTypeInfo _kMCInterfaceThemeControlTypeTypeInfo =
     _kMCInterfaceThemeControlTypeElementInfo
 };
 
+//////////
+
+MCExecEnumTypeElementInfo _kMCInterfaceScriptStatusElementInfo[] =
+{
+    { "compiled", kMCInterfaceScriptStatusCompiled, false },
+    { "uncompiled", kMCInterfaceScriptStatusUncompiled, false },
+    { "warning", kMCInterfaceScriptStatusWarning, false },
+    { "error", kMCInterfaceScriptStatusError, false },
+};
+
+MCExecEnumTypeInfo _kMCInterfaceScriptStatusTypeInfo =
+{
+    "Interface.ScriptStatus",
+    sizeof(_kMCInterfaceScriptStatusElementInfo) / sizeof(MCExecEnumTypeElementInfo),
+    _kMCInterfaceScriptStatusElementInfo
+};
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 MCExecCustomTypeInfo *kMCInterfaceLayerTypeInfo = &_kMCInterfaceLayerTypeInfo;
@@ -1264,6 +1282,7 @@ MCExecCustomTypeInfo *kMCInterfaceTriStateTypeInfo = &_kMCInterfaceTriStateTypeI
 MCExecEnumTypeInfo *kMCInterfaceListStyleTypeInfo = &_kMCInterfaceListStyleTypeInfo;
 MCExecEnumTypeInfo *kMCInterfaceThemeTypeInfo = &_kMCInterfaceThemeTypeInfo;
 MCExecEnumTypeInfo *kMCInterfaceThemeControlTypeTypeInfo = &_kMCInterfaceThemeControlTypeTypeInfo;
+MCExecEnumTypeInfo *kMCInterfaceScriptStatusTypeInfo = &_kMCInterfaceScriptStatusTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -4347,4 +4366,14 @@ void MCObject::SetThemeControlType(MCExecContext& ctxt, intenum_t p_theme)
 void MCObject::GetEffectiveThemeControlType(MCExecContext& ctxt, intenum_t& r_theme)
 {
     r_theme = getcontroltype();
+}
+
+void MCObject::GetScriptStatus(MCExecContext& ctxt, intenum_t& r_status)
+{
+    if (hashandlers & HH_DEAD_SCRIPT)
+        r_status = kMCInterfaceScriptStatusError;
+    else if (hlist == nil && flags & F_SCRIPT)
+        r_status = kMCInterfaceScriptStatusUncompiled;
+    else
+        r_status = kMCInterfaceScriptStatusCompiled;
 }

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3476,6 +3476,7 @@ extern MCExecEnumTypeInfo *kMCInterfaceEncodingTypeInfo;
 extern MCExecEnumTypeInfo *kMCInterfaceListStyleTypeInfo;
 extern MCExecEnumTypeInfo *kMCInterfaceThemeTypeInfo;
 extern MCExecEnumTypeInfo *kMCInterfaceThemeControlTypeTypeInfo;
+extern MCExecEnumTypeInfo *kMCInterfaceScriptStatusTypeInfo;
 
 ///////////
 

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -753,7 +753,7 @@ LT factor_table[] =
         {"commandkey", TT_FUNCTION, F_COMMAND_KEY},
         {"commandname", TT_FUNCTION, F_COMMAND_NAME},
         {"commandnames", TT_FUNCTION, F_COMMAND_NAMES},
-		// MW-2011-09-10: [[ TileCache ]] The maximum number of bytes to use for the tile cache
+        // MW-2011-09-10: [[ TileCache ]] The maximum number of bytes to use for the tile cache
 		{"compositorcachelimit", TT_PROPERTY, P_COMPOSITOR_CACHE_LIMIT},
 		// MW-2011-09-10: [[ TileCache ]] Read-only statistics about recent composites
 		{"compositorstatistics", TT_PROPERTY, P_COMPOSITOR_STATISTICS},
@@ -1526,6 +1526,7 @@ LT factor_table[] =
         {"scriptlimits", TT_FUNCTION, F_SCRIPT_LIMITS},
         {"scriptonly", TT_PROPERTY, P_SCRIPT_ONLY},
         {"scriptparsingerrors", TT_PROPERTY, P_SCRIPT_PARSING_ERRORS},
+        {"scriptstatus", TT_PROPERTY, P_SCRIPT_STATUS},
         {"scripttextfont", TT_PROPERTY, P_SCRIPT_TEXT_FONT},
         {"scripttextsize", TT_PROPERTY, P_SCRIPT_TEXT_SIZE},		
         {"scroll", TT_PROPERTY, P_VSCROLL},

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -115,6 +115,15 @@ enum MCInterfaceTheme
     kMCInterfaceThemeLegacy = 2         // Backwards-compatibility theming
 };
 
+enum MCInterfaceScriptStatus
+{
+    kMCInterfaceScriptStatusCompiled,
+    kMCInterfaceScriptStatusUncompiled,
+    kMCInterfaceScriptStatusWarning,
+    kMCInterfaceScriptStatusError,
+};
+
+
 struct MCObjectShape
 {
 	// The type of shape.
@@ -1222,6 +1231,8 @@ public:
     void GetThemeControlType(MCExecContext& ctxt, intenum_t& r_type);
     void SetThemeControlType(MCExecContext& ctxt, intenum_t  p_type);
     void GetEffectiveThemeControlType(MCExecContext& ctxt, intenum_t& r_type);
+    
+    void GetScriptStatus(MCExecContext& ctxt, intenum_t& r_status);
     
 	////////// ARRAY PROPS
     

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -242,6 +242,8 @@ MCPropertyInfo MCObject::kProperties[] =
     
     DEFINE_RW_OBJ_NON_EFFECTIVE_ENUM_PROPERTY(P_THEME_CONTROL_TYPE, InterfaceThemeControlType, MCObject, ThemeControlType)
     DEFINE_RO_OBJ_EFFECTIVE_ENUM_PROPERTY(P_THEME_CONTROL_TYPE, InterfaceThemeControlType, MCObject, ThemeControlType)
+
+    DEFINE_RO_OBJ_ENUM_PROPERTY(P_SCRIPT_STATUS, InterfaceScriptStatus, MCObject, ScriptStatus)
 };
 
 MCObjectPropertyTable MCObject::kPropertyTable =

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1732,6 +1732,8 @@ enum Properties {
     P_THEME,
     P_THEME_CONTROL_TYPE,
     
+    P_SCRIPT_STATUS,
+    
     __P_LAST,
 };
 

--- a/tests/lcs/core/engine/script-status.livecodescript
+++ b/tests/lcs/core/engine/script-status.livecodescript
@@ -1,0 +1,44 @@
+﻿script "CoreEngineScriptStatus"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestScriptStatus
+   create stack "foo"
+   
+   set the script of stack "foo" to \
+         "on bar" & return & \
+         "   ,fooBar" & return & \
+         "end bar"
+   
+   TestAssert "script status is error when script is bad", \
+         the scriptStatus of stack "foo" is "error" and the result is not empty
+   
+   set the script of stack "foo" to \
+         "on bar" & return & \
+         "   fooBar" & return & \
+         "end bar"
+   
+   TestAssert "script status is compiled when script is good", \
+         the scriptStatus of stack "foo" is "compiled" and the result is empty
+   
+   delete stack "foo"
+   
+   get the long id of stack (TestGetIDERepositoryPath() & "/Toolset/palettes/revaskdialog.rev")
+   
+   TestAssert "script status is uncompiled when stack is only loaded", \
+         the scriptStatus of card 1 of it is "uncompiled"
+end TestScriptStatus


### PR DESCRIPTION
Use `the compileStatus of <object>` to determine the status of the
last time the script property was set or the script was compiled
when the stack was opened.
