### PR TITLE
LCB: Implement record type definitions

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -324,6 +324,19 @@ parameter in a foreign handler definition.
 > creation of a function pointer. The lifetime of the function pointer
 > is the same as the widget or module which created it.
 
+### Record Types
+
+    RecordTypeDefinition
+      : 'record' 'type' <Name: Identifier> SEPARATOR
+        { RecordTypeFieldDefinition }
+        'end' 'record'
+
+    RecordTypeFieldDefinition
+      : <Name: Identifier> [ 'as' <TypeOf: Type> ]
+
+A record type definition defines a type that consists of 0 or more
+named fields, each with its own optional type.
+
 ### Variables
 
     VariableDefinition

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1740,10 +1740,7 @@ struct MCRecordTypeFieldInfo
 };
 
 // Create a description of a record with the given fields.
-MC_DLLEXPORT bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef base_type, MCTypeInfoRef& r_typeinfo);
-
-// Return the base type of the record.
-MC_DLLEXPORT MCTypeInfoRef MCRecordTypeInfoGetBaseType(MCTypeInfoRef typeinfo);
+MC_DLLEXPORT bool MCRecordTypeInfoCreate(const MCRecordTypeFieldInfo *fields, index_t field_count, MCTypeInfoRef& r_typeinfo);
 
 // Return the number of fields in the record.
 MC_DLLEXPORT uindex_t MCRecordTypeInfoGetFieldCount(MCTypeInfoRef typeinfo);
@@ -1753,9 +1750,6 @@ MC_DLLEXPORT MCNameRef MCRecordTypeInfoGetFieldName(MCTypeInfoRef typeinfo, uind
 
 // Return the type of the field at the given index.
 MC_DLLEXPORT MCTypeInfoRef MCRecordTypeInfoGetFieldType(MCTypeInfoRef typeinfo, uindex_t index);
-
-// Return true if typeinfo is derived from p_base_typeinfo.
-MC_DLLEXPORT bool MCRecordTypeInfoIsDerivedFrom(MCTypeInfoRef typeinfo, MCTypeInfoRef p_base_typeinfo);
 
 //////////
 
@@ -2820,12 +2814,6 @@ MC_DLLEXPORT bool MCRecordCopyAndRelease(MCRecordRef record, MCRecordRef& r_new_
 
 MC_DLLEXPORT bool MCRecordMutableCopy(MCRecordRef record, MCRecordRef& r_new_record);
 MC_DLLEXPORT bool MCRecordMutableCopyAndRelease(MCRecordRef record, MCRecordRef& r_new_record);
-
-MC_DLLEXPORT bool MCRecordCopyAsBaseType(MCRecordRef record, MCTypeInfoRef p_base_typeinfo, MCRecordRef & r_new_record);
-MC_DLLEXPORT bool MCRecordCopyAsBaseTypeAndRelease(MCRecordRef record, MCTypeInfoRef p_base_typeinfo, MCRecordRef & r_new_record);
-
-MC_DLLEXPORT bool MCRecordCopyAsDerivedType(MCRecordRef record, MCTypeInfoRef p_derived_typeinfo, MCRecordRef & r_new_record);
-MC_DLLEXPORT bool MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef record, MCTypeInfoRef p_derived_typeinfo, MCRecordRef & r_new_record);
 
 MC_DLLEXPORT bool MCRecordIsMutable(MCRecordRef self);
 

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -90,7 +90,6 @@ struct __MCTypeInfo: public __MCValue
         {
             MCRecordTypeFieldInfo *fields;
             uindex_t field_count;
-            MCTypeInfoRef base;
         } record;
         struct
         {
@@ -558,7 +557,6 @@ bool __MCTypeInfoCopyDescription(__MCTypeInfo *self, MCStringRef& r_description)
 MCTypeInfoRef __MCTypeInfoResolve(__MCTypeInfo *self);
 
 uindex_t __MCRecordTypeInfoGetFieldCount (__MCTypeInfo *self);
-void __MCRecordTypeInfoGetBaseTypeForField (__MCTypeInfo *self, uindex_t p_index, __MCTypeInfo *& r_base_type, uindex_t & r_base_index);
 
 bool __MCForeignValueInitialize(void);
 void __MCForeignValueFinalize(void);

--- a/libfoundation/src/foundation-record.cpp
+++ b/libfoundation/src/foundation-record.cpp
@@ -22,14 +22,6 @@
 
 static bool __check_conformance(MCTypeInfoRef p_typeinfo, const MCValueRef *p_values, uindex_t p_value_count, uindex_t& x_offset)
 {
-    if (p_typeinfo -> record . base != kMCNullTypeInfo)
-    {
-        MCTypeInfoRef t_resolved_typeinfo;
-        t_resolved_typeinfo = __MCTypeInfoResolve(p_typeinfo);
-        if (!__check_conformance(t_resolved_typeinfo, p_values, p_value_count, x_offset))
-            return false;
-    }
-    
     if (x_offset + p_typeinfo -> record . field_count > p_value_count)
         return MCErrorThrowGeneric(nil);
     
@@ -219,9 +211,6 @@ static bool __fetch_value(MCTypeInfoRef p_typeinfo, MCRecordRef self, MCNameRef 
             return true;
         }
     
-    if (p_typeinfo -> record . base != kMCNullTypeInfo)
-        return __fetch_value(p_typeinfo -> record . base, self, p_field, r_value);
-    
     return false;
 }
 
@@ -248,9 +237,6 @@ static bool __store_value(MCTypeInfoRef p_typeinfo, MCRecordRef self, MCNameRef 
             return true;
         }
     
-    if (p_typeinfo -> record . base != kMCNullTypeInfo)
-        return __store_value(p_typeinfo -> record . base, self, p_field, p_value);
-    
     return false;
 }
 
@@ -261,108 +247,6 @@ bool MCRecordStoreValue(MCRecordRef self, MCNameRef p_field, MCValueRef p_value)
 	__MCAssertIsName(p_field);
 	MCAssert(nil != p_value);
     return __store_value(self -> typeinfo, self, p_field, p_value);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-MC_DLLEXPORT_DEF bool
-MCRecordCopyAsBaseType(MCRecordRef self,
-                       MCTypeInfoRef p_base_typeinfo,
-                       MCRecordRef & r_new_record)
-{
-	bool t_success;
-	MCValueRetain(self);
-	t_success = MCRecordCopyAsBaseTypeAndRelease(self,
-	                                             p_base_typeinfo,
-	                                             r_new_record);
-	if (!t_success) MCValueRelease(self);
-	return t_success;
-}
-
-MC_DLLEXPORT_DEF bool
-MCRecordCopyAsBaseTypeAndRelease(MCRecordRef self,
-                                 MCTypeInfoRef p_base_typeinfo,
-                                 MCRecordRef & r_new_record)
-{
-	__MCAssertIsRecord(self);
-	MCAssert(MCRecordTypeInfoIsDerivedFrom(self -> typeinfo, p_base_typeinfo));
-
-	/* If there's only one reference, just swap the typeinfo out and
-	 * make it immutable */
-	if (self -> references == 1)
-	{
-		MCValueRelease(self -> typeinfo);
-		self -> typeinfo = MCValueRetain(p_base_typeinfo);
-		self -> flags &= ~kMCRecordFlagIsMutable;
-		r_new_record = self;
-		return true;
-	}
-
-	if (!MCRecordCreate(p_base_typeinfo, self -> fields,
-	                    MCRecordTypeInfoGetFieldCount (p_base_typeinfo),
-	                    r_new_record))
-		return false;
-
-	MCValueRelease(self);
-	return true;
-}
-
-MC_DLLEXPORT_DEF bool
-MCRecordCopyAsDerivedType(MCRecordRef self,
-                          MCTypeInfoRef p_derived_typeinfo,
-                          MCRecordRef & r_new_record)
-{
-	bool t_success;
-	MCValueRetain(self);
-	t_success = MCRecordCopyAsDerivedTypeAndRelease(self,
-	                                                p_derived_typeinfo,
-	                                                r_new_record);
-	if (!t_success) MCValueRelease(self);
-	return t_success;
-}
-
-MC_DLLEXPORT_DEF bool
-MCRecordCopyAsDerivedTypeAndRelease(MCRecordRef self,
-                                    MCTypeInfoRef p_derived_typeinfo,
-                                    MCRecordRef & r_new_record)
-{
-	__MCAssertIsRecord(self);
-	MCAssert(MCRecordTypeInfoIsDerivedFrom(p_derived_typeinfo, self -> typeinfo));
-
-	uindex_t t_field_count, t_new_field_count;
-	t_field_count = MCRecordTypeInfoGetFieldCount(self -> typeinfo);
-	t_new_field_count = MCRecordTypeInfoGetFieldCount(p_derived_typeinfo);
-
-	/* If there's only one reference, then we need to: 1) swap the
-	 * typeinfo, 2) resize the field array and fill the new fields
-	 * with null values, and 3) make the record immutable. */
-	if (self -> references == 1)
-	{
-		/* Resize the array */
-		if (!MCMemoryResizeArray(t_new_field_count, self -> fields, t_field_count))
-			return false;
-		/* Clear new values */
-		for (uindex_t i = t_field_count; i < t_new_field_count; ++i)
-			self -> fields[i] = MCValueRetain(kMCNull);
-
-		/* Set the typeinfo and make immutable */
-		MCValueRelease(self -> typeinfo);
-		self -> typeinfo = MCValueRetain(p_derived_typeinfo);
-		self -> flags &= ~kMCRecordFlagIsMutable;
-
-		r_new_record = self;
-		return true;
-	}
-
-	/* Otherwise, create and manually populate the new array */
-	MCRecordRef t_result;
-	if (!MCRecordCreateMutable(p_derived_typeinfo, t_result))
-		return false;
-
-	for (uindex_t i = 0; i < t_field_count; ++i)
-		t_result -> fields[i] = MCValueRetain(self -> fields[i]);
-
-	return MCRecordCopyAndRelease(t_result, r_new_record);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -360,7 +360,7 @@ void MCScriptBeginHandlerTypeInModule(MCScriptModuleBuilderRef builder, uindex_t
 void MCScriptBeginForeignHandlerTypeInModule(MCScriptModuleBuilderRef builder, uindex_t return_type);
 void MCScriptContinueHandlerTypeInModule(MCScriptModuleBuilderRef builder, MCScriptHandlerTypeParameterMode mode, MCNameRef name, uindex_t type);
 void MCScriptEndHandlerTypeInModule(MCScriptModuleBuilderRef builder, uindex_t& r_new_type);
-void MCScriptBeginRecordTypeInModule(MCScriptModuleBuilderRef builder, uindex_t base_type);
+void MCScriptBeginRecordTypeInModule(MCScriptModuleBuilderRef builder);
 void MCScriptContinueRecordTypeInModule(MCScriptModuleBuilderRef builder, MCNameRef name, uindex_t type);
 void MCScriptEndRecordTypeInModule(MCScriptModuleBuilderRef builder, uindex_t& r_new_type);
 

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -918,7 +918,7 @@ void MCScriptEndHandlerTypeInModule(MCScriptModuleBuilderRef self, uindex_t& r_n
     __add_script_type(self, t_type, r_new_type);
 }
 
-void MCScriptBeginRecordTypeInModule(MCScriptModuleBuilderRef self, uindex_t p_base_type)
+void MCScriptBeginRecordTypeInModule(MCScriptModuleBuilderRef self)
 {
     if (self == nil ||
         !self -> valid)
@@ -932,7 +932,6 @@ void MCScriptBeginRecordTypeInModule(MCScriptModuleBuilderRef self, uindex_t p_b
     }
     
     t_type -> kind = kMCScriptTypeKindRecord;
-    t_type -> base_type = p_base_type;
     
     self -> current_type = t_type;
 }
@@ -974,9 +973,6 @@ void MCScriptEndRecordTypeInModule(MCScriptModuleBuilderRef self, uindex_t& r_ne
         t_other_type = static_cast<MCScriptRecordType *>(self -> module . types[i]);
         
         if (t_type -> field_count != t_other_type -> field_count)
-            continue;
-        
-        if (t_type -> base_type != t_other_type -> base_type)
             continue;
         
         bool t_equal;

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -74,7 +74,6 @@ MC_PICKLE_BEGIN_RECORD(MCScriptRecordTypeField)
 MC_PICKLE_END_RECORD()
 
 MC_PICKLE_BEGIN_RECORD(MCScriptRecordType)
-    MC_PICKLE_UINDEX(base_type)
     MC_PICKLE_ARRAY_OF_RECORD(MCScriptRecordTypeField, fields, field_count)
 MC_PICKLE_END_RECORD()
 
@@ -751,7 +750,7 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
 						goto error_cleanup; // oom
                 }
                 
-                if (!MCRecordTypeInfoCreate(t_fields . Ptr(), t_type -> field_count, self -> types[t_type -> base_type] -> typeinfo, &t_typeinfo))
+                if (!MCRecordTypeInfoCreate(t_fields . Ptr(), t_type -> field_count, &t_typeinfo))
 					goto error_cleanup; // oom
             }
             break;

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -1388,8 +1388,24 @@ bool MCScriptWriteInterfaceOfModule(MCScriptModuleRef self, MCStreamRef stream)
                     }
                     break;
                     case kMCScriptTypeKindRecord:
-                        // TODO - Records not yet supported
-                        break;
+                    {
+                        auto t_record_type =
+                            static_cast<MCScriptRecordType *>(t_type);
+                        __enterln(stream, "record type %@", t_def_name);
+                        for (uindex_t t_field = 0;
+                             t_field < t_record_type->field_count;
+                             ++t_field)
+                        {
+                            MCAutoStringRef t_ftype_name;
+                            type_to_string(self, t_record_type->fields[t_field].type,
+                                           &t_ftype_name);
+                            __writeln(stream, "%@ as %@",
+                                      t_record_type->fields[t_field].name,
+                                      *t_ftype_name);
+                        }
+                        __leaveln(stream, "end type");
+                    }
+                    break;
                     default:
                     {
                         MCAutoStringRef t_sig;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -194,7 +194,6 @@ struct MCScriptRecordTypeField
 
 struct MCScriptRecordType: public MCScriptType
 {
-    uindex_t base_type;
     MCScriptRecordTypeField *fields;
     uindex_t field_count;
 };

--- a/tests/lcb/compiler/frontend/record-definition.compilertest
+++ b/tests/lcb/compiler/frontend/record-definition.compilertest
@@ -1,0 +1,58 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%% Empty record declaration
+%TEST SelfReferentialRecord
+module compiler_test
+record type record_type
+end type
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Record with implicitly-typed field
+%TEST ImplicitFieldTypeRecord
+module compiler_test
+record type record_type
+   mField
+end type
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Record with explicitly-typed field
+%TEST ExplicitFieldTypeRecord
+module compiler_test
+record type record_type
+   mField as Boolean
+end type
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Record with field of unknown type
+%TEST UnknownFieldTypeRecord
+module compiler_test
+record type record_type
+   mField as %{UNDEFINED_TYPE}undefined_type
+end type
+end module
+%EXPECT PASS
+%ERROR "Identifier 'undefined_type' not declared" at UNDEFINED_TYPE
+%ENDTEST

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -425,10 +425,7 @@
     'rule' Apply(TYPE'named(_, Name)):
         ApplyId(Name)
     
-    'rule' Apply(TYPE'record(_, BaseType, Fields)):
-        -- Apply the base type
-        Apply(BaseType)
-        
+    'rule' Apply(TYPE'record(_, Fields)):
         -- Enter a new scope for fields
         EnterScope
         

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1674,7 +1674,7 @@
     'rule' IsHighLevelType(optional(_, Type)):
         IsHighLevelType(Type)
     'rule' IsHighLevelType(handler(_, _, _)):
-    'rule' IsHighLevelType(record(_, _, _)):
+    'rule' IsHighLevelType(record(_, _)):
     'rule' IsHighLevelType(boolean(_)):
     'rule' IsHighLevelType(integer(_)):
     'rule' IsHighLevelType(real(_)):

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -104,7 +104,7 @@ extern "C" void EmitDataType(long& r_new_index);
 extern "C" void EmitArrayType(long& r_new_index);
 extern "C" void EmitListType(long& r_new_index);
 extern "C" void EmitUndefinedType(long& r_new_index);
-extern "C" void EmitBeginRecordType(long base_type_index);
+extern "C" void EmitBeginRecordType(void);
 extern "C" void EmitRecordTypeField(NameRef name, long type_index);
 extern "C" void EmitEndRecordType(long& r_type_index);
 extern "C" void EmitBeginHandlerType(long return_type_index);
@@ -1275,11 +1275,11 @@ void EmitUndefinedType(long& r_new_index)
 
 //////////
 
-void EmitBeginRecordType(long p_base_type_index)
+void EmitBeginRecordType()
 {
-    MCScriptBeginRecordTypeInModule(s_builder, (uindex_t)p_base_type_index);
+    MCScriptBeginRecordTypeInModule(s_builder);
 
-    Debug_Emit("BeginRecordType(%ld)", p_base_type_index);
+    Debug_Emit("BeginRecordType()");
 }
 
 void EmitRecordTypeField(NameRef name, long type_index)

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -2070,7 +2070,7 @@
             where(Type -> handler(_, _, _))
             where(ThisType -> Base)
         ||
-            where(Type -> record(_, _, _))
+            where(Type -> record(_, _))
             where(ThisType -> Base)
         ||
             where(Type -> Base)
@@ -2105,9 +2105,8 @@
     'rule' GenerateBaseType(foreign(_, Binding) -> Index):
         EmitForeignType(Binding -> Index)
 
-    'rule' GenerateBaseType(record(_, Base, Fields) -> Index):
-        GenerateType(Base -> BaseTypeIndex)
-        EmitBeginRecordType(BaseTypeIndex)
+    'rule' GenerateBaseType(record(_, Fields) -> Index):
+        EmitBeginRecordType()
         GenerateRecordTypeFields(Fields)
         EmitEndRecordType(-> Index)
 

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -375,8 +375,8 @@
     'rule' TypeDefinition(-> type(Position, Access, Name, foreign(Position, Binding))):
         Access(-> Access) "foreign" @(-> Position) "type" Identifier(-> Name) "binds" "to" StringLiteral(-> Binding)
         
-    'rule' TypeDefinition(-> type(Position, Access, Name, record(Position, Base, Fields))):
-        Access(-> Access) "record" @(-> Position) "type" Identifier(-> Name) OptionalBaseType(-> Base) Separator
+    'rule' TypeDefinition(-> type(Position, Access, Name, record(Position, Fields))):
+        Access(-> Access) "record" @(-> Position) "type" Identifier(-> Name) Separator
             RecordFields(-> Fields)
         "end" "type"
         

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -227,7 +227,12 @@
 
     'rule' ImportDefinition(-> type(Position, public, Id, handler(Position, foreign, Signature))):
         "foreign" @(-> Position) "handler" "type" Identifier(-> Id) Signature(-> Signature)
-        
+
+    'rule' ImportDefinition(-> type(Position, public, Id, record(Position, Fields))):
+        "record" @(-> Position) "type" Identifier(-> Id) Separator
+            RecordFields(-> Fields)
+        "end" "type"
+
     'rule' ImportDefinition(-> type(Position, public, Id, Type)):
         "type" @(-> Position) Identifier(-> Id) "is" Type(-> Type)
 

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -609,7 +609,7 @@
 'action' EmitListType(-> INT)
 'action' EmitUndefinedType(-> INT)
 
-'action' EmitBeginRecordType(BaseType: INT)
+'action' EmitBeginRecordType()
 'action' EmitRecordTypeField(Name: NAME, Type: INT)
 'action' EmitEndRecordType(-> INT)
 

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -86,7 +86,7 @@
     named(Position: POS, Name: ID)
     foreign(Position: POS, Binding: STRING)
     optional(Position: POS, Type: TYPE)
-    record(Position: POS, Base: TYPE, Fields: FIELDLIST)
+    record(Position: POS, Fields: FIELDLIST)
     enum(Position: POS, Base: TYPE, Fields: FIELDLIST)
     handler(Position: POS, Language: LANGUAGE, Signature: SIGNATURE)
     boolean(Position: POS)


### PR DESCRIPTION
This pull request makes some progress towards implementing record types in LCB, including the following improvements:
- the "base type" mechanism for record types has been removed
- record types with the same fields are no longer considered interchangeable
- public record type info is now included in .lci files
- LCB language spec updates and compiler frontend tests
