### PR TITLE
[[ Bug 18123 ]] Fix crash on windows when player opened by script on hidden stack

### DIFF
--- a/docs/notes/bugfix-18123.md
+++ b/docs/notes/bugfix-18123.md
@@ -1,0 +1,1 @@
+# Windows: fix crash when opening player from hidden stack

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -3040,7 +3040,7 @@ bool MCGroup::getNativeContainerLayer(MCNativeLayer *&r_layer)
 	if (getNativeLayer() == nil)
 	{
 		void *t_view;
-		if (!MCNativeLayer::CreateNativeContainer(t_view))
+		if (!MCNativeLayer::CreateNativeContainer(this, t_view))
 			return false;
 		if (!SetNativeView(t_view))
 		{

--- a/engine/src/mac-av-player.mm
+++ b/engine/src/mac-av-player.mm
@@ -65,6 +65,7 @@ public:
 	virtual ~MCAVFoundationPlayer(void);
     
 	virtual bool GetNativeView(void *&r_view);
+	virtual bool SetNativeParentView(void *p_view);
 	
 	virtual bool IsPlaying(void);
 	virtual void Start(double rate);
@@ -343,6 +344,12 @@ bool MCAVFoundationPlayer::GetNativeView(void *& r_view)
 		return false;
 	
 	r_view = m_view;
+	return true;
+}
+
+bool MCAVFoundationPlayer::SetNativeParentView(void *p_view)
+{
+	// Not used
 	return true;
 }
 

--- a/engine/src/mac-qt-player.mm
+++ b/engine/src/mac-qt-player.mm
@@ -71,6 +71,7 @@ public:
     virtual ~MCQTKitPlayer(void);
     
 	virtual bool GetNativeView(void *& r_view);
+	virtual bool SetNativeParentView(void *p_view);
 	
     virtual bool IsPlaying(void);
     // PM-2014-05-28: [[ Bug 12523 ]] Take into account the playRate property
@@ -280,6 +281,12 @@ bool MCQTKitPlayer::GetNativeView(void *& r_view)
 		return false;
 	
 	r_view = m_view;
+	return true;
+}
+
+bool MCQTKitPlayer::SetNativeParentView(void *p_view)
+{
+	// Not used
 	return true;
 }
 

--- a/engine/src/native-layer-android.cpp
+++ b/engine/src/native-layer-android.cpp
@@ -246,7 +246,7 @@ MCNativeLayer* MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_view
     return new MCNativeLayerAndroid(p_object, (jobject)p_view);
 }
 
-bool MCNativeLayer::CreateNativeContainer(void *&r_view)
+bool MCNativeLayer::CreateNativeContainer(MCObject *p_object, void *&r_view)
 {
 	jobject t_view;
 	t_view = nil;

--- a/engine/src/native-layer-ios.mm
+++ b/engine/src/native-layer-ios.mm
@@ -216,7 +216,7 @@ MCNativeLayer *MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_nati
 
 @end
 
-bool MCNativeLayer::CreateNativeContainer(void *&r_view)
+bool MCNativeLayer::CreateNativeContainer(MCObject *p_object, void *&r_view)
 {
 	UIView *t_view;
 	t_view = [[[MCContainerView alloc] init] autorelease];

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -276,7 +276,7 @@ MCNativeLayer* MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_view
 
 @end
 
-bool MCNativeLayer::CreateNativeContainer(void *&r_view)
+bool MCNativeLayer::CreateNativeContainer(MCObject *p_object, void *&r_view)
 {
 	NSView *t_view;
 	t_view = [[[ MCContainerView alloc] init] autorelease];

--- a/engine/src/native-layer-srv.cpp
+++ b/engine/src/native-layer-srv.cpp
@@ -29,7 +29,7 @@ MCNativeLayer *MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_nati
 	return nil;
 }
 
-bool MCNativeLayer::CreateNativeContainer(void *&r_view)
+bool MCNativeLayer::CreateNativeContainer(MCObject *p_object, void *&r_view)
 {
 	return false;
 }

--- a/engine/src/native-layer-win32.cpp
+++ b/engine/src/native-layer-win32.cpp
@@ -78,7 +78,7 @@ void MCNativeLayerWin32::doAttach()
 	t_parent = getStackWindow();
 
 	if (m_viewport_hwnd == nil)
-		/* UNCHECKED */ CreateNativeContainer((void*&)m_viewport_hwnd);
+		/* UNCHECKED */ CreateNativeContainer(m_object, (void*&)m_viewport_hwnd);
 
 	// Set the parent to the stack
 	SetParent(m_viewport_hwnd, t_parent);
@@ -334,14 +334,14 @@ bool getcontainerclass(ATOM &r_class)
 	return true;
 }
 
-bool MCNativeLayer::CreateNativeContainer(void *&r_container)
+bool MCNativeLayer::CreateNativeContainer(MCObject *p_object, void *&r_container)
 {
 	ATOM t_class;
 	if (!getcontainerclass(t_class))
 		return false;
 
 	HWND t_container;
-	t_container = CreateWindow((LPCSTR)t_class, "Container", WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, 0, 0, 1, 1, (HWND)MCdefaultstackptr->getrealwindow(), nil, MChInst, nil);
+	t_container = CreateWindow((LPCSTR)t_class, "Container", WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, 0, 0, 1, 1, (HWND)p_object->getstack()->getrealwindow(), nil, MChInst, nil);
 
 	DWORD t_err;
 	t_err = GetLastError();

--- a/engine/src/native-layer-x11.cpp
+++ b/engine/src/native-layer-x11.cpp
@@ -282,7 +282,7 @@ MCNativeLayer* MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_nati
     return new MCNativeLayerX11(p_object, (x11::Window)p_native_view);
 }
 
-bool MCNativeLayer::CreateNativeContainer(void *&r_view)
+bool MCNativeLayer::CreateNativeContainer(MCObject *p_object, void *&r_view)
 {
 	return false;
 }

--- a/engine/src/native-layer.h
+++ b/engine/src/native-layer.h
@@ -43,7 +43,7 @@ public:
 	
 	// Implemented by the platform-specific native layers: creates a new layer
 	static MCNativeLayer *CreateNativeLayer(MCObject *p_object, void *p_native_view);
-	static bool CreateNativeContainer(void *&r_view);
+	static bool CreateNativeContainer(MCObject *p_object, void *&r_view);
 	static void ReleaseNativeView(void *p_view);
 
 	void SetCanRenderToContext(bool p_can_render);

--- a/engine/src/platform-internal.h
+++ b/engine/src/platform-internal.h
@@ -240,6 +240,7 @@ public:
 	void Release(void);
 	
 	virtual bool GetNativeView(void *&r_view) = 0;
+	virtual bool SetNativeParentView(void *p_parent_view) = 0;
 	
 	virtual bool IsPlaying(void) = 0;
 	// PM-2014-05-28: [[ Bug 12523 ]] Take into account the playRate property

--- a/engine/src/platform-player.cpp
+++ b/engine/src/platform-player.cpp
@@ -66,6 +66,12 @@ void *MCPlatformPlayerGetNativeView(MCPlatformPlayerRef player)
 	return t_view;
 }
 
+bool MCPlatformPlayerSetNativeParentView(MCPlatformPlayerRef p_player, void *p_parent_view)
+{
+	return p_player -> SetNativeParentView(p_parent_view);
+}
+
+
 bool MCPlatformPlayerIsPlaying(MCPlatformPlayerRef player)
 {
 	return player -> IsPlaying();

--- a/engine/src/platform.h
+++ b/engine/src/platform.h
@@ -1047,6 +1047,7 @@ void MCPlatformPlayerRetain(MCPlatformPlayerRef player);
 void MCPlatformPlayerRelease(MCPlatformPlayerRef player);
 
 void *MCPlatformPlayerGetNativeView(MCPlatformPlayerRef player);
+bool MCPlatformPlayerSetNativeParentView(MCPlatformPlayerRef p_player, void *p_parent_view);
 
 bool MCPlatformPlayerIsPlaying(MCPlatformPlayerRef player);
 

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1532,6 +1532,11 @@ Boolean MCPlayer::prepare(MCStringRef options)
 	if (m_platform_player == nil)
 		return False;
 		
+#if defined(TARGET_PLATFORM_WINDOWS)
+	if (!MCPlatformPlayerSetNativeParentView(m_platform_player, getstack()->getrealwindow()))
+		return False;
+#endif
+	
     // PM-2015-01-26: [[ Bug 14435 ]] Avoid prepending the defaultFolder or the stack folder
     //  to the filename property. Use resolved_filename to set the "internal" absolute path
     MCAutoStringRef t_resolved_filename;


### PR DESCRIPTION
When creating a child window the CreateWindow function needs to be called with a valid parent HWND.
This patch ensures this by extending the MCPlatformPlayer API to allow setting the native parent view, and using the containing stack's window handle when creating native container layers.
