### PR TITLE
libfoundation: MCAssert(false) -> MCUnreachable() in MCStringFormat

### DIFF
--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1084,8 +1084,7 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
                     case 'n':
                     default:
                         // Oh dear. Something we didn't recognise!
-                        MCAssert(false);
-                        t_success = false;
+                        MCUnreachable();
                         break;
                 }
                 


### PR DESCRIPTION
This provides a slightly more helpful log message when hit.
