### PR TITLE
[[ Bug 6530 ]] Make 'group' return the long id of the new group

### DIFF
--- a/docs/dictionary/command/group.lcdoc
+++ b/docs/dictionary/command/group.lcdoc
@@ -11,6 +11,8 @@ Associations: group
 
 Introduced: 1.0
 
+Changed: 8.1
+
 OS: mac, windows, linux, ios, android
 
 Platforms: desktop, server, mobile
@@ -28,6 +30,10 @@ Parameters:
 objectList:
 A list of object references, separated by the word "and".
 
+It:
+The <group> command places the ID property of the newly created
+object in the it variable.
+
 Description:
 Use the <group> <command> after <select|selecting> <object|objects> to
 make a <group> out of them.
@@ -39,11 +45,12 @@ or <object|objects> are placed in the <group>.
 As with any group on a card, you can use the place <command> to make the
 newly-created <group> appear on other <card|cards>.
 
->*Tip:*  To refer to the newly-created <group>, use the <last> <keyword>
-> : 
+>*Tip:*  To refer to the newly-created <group>, use the it variable immediately
+> after the 'group' command
+> :
 
     group button "Yes" and button "No"
-    set the name of last group to "Do It"
+    set the name of it to "Do It"
 
 
 References: group (command), start editing (command),
@@ -53,4 +60,3 @@ card (object), selected (property), relayerGroupedControls (property),
 layer (property)
 
 Tags: objects
-

--- a/docs/notes/bugfix-6530.md
+++ b/docs/notes/bugfix-6530.md
@@ -1,0 +1,8 @@
+# Group command does not return new group id in it
+
+The group command has been changed so that it returns the long id
+of the newly created group in the 'it' variable.
+
+If no group is created (as a result of using 'group' with an empty
+selection) the 'it' variable will be set to empty.
+

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2080,12 +2080,32 @@ void MCInterfaceExecGroupControls(MCExecContext& ctxt, MCObjectPtr *p_controls, 
         gptr = (MCGroup *)MCtemplategroup->clone(False, OP_NONE, false);
     else
         gptr = (MCGroup *)MCsavegroupptr->remove(MCsavegroupptr);
-    gptr->makegroup(controls, t_card);
+	gptr->makegroup(controls, t_card);
+	
+	MCAutoValueRef t_id;
+	gptr -> names(P_LONG_ID, &t_id);
+	ctxt . SetItToValue(*t_id);
 }
 
 void MCInterfaceExecGroupSelection(MCExecContext& ctxt)
 {
-	MCselected->group();
+	MCGroup *t_group = nil;
+	if (MCselected->group(ctxt.GetLine(), ctxt.GetPos(), t_group) != ES_NORMAL)
+	{
+		ctxt.Throw();
+		return;
+	}
+	
+	if (t_group != nil)
+	{
+		MCAutoValueRef t_id;
+		t_group -> names(P_LONG_ID, &t_id);
+		ctxt.SetItToValue(*t_id);
+	}
+	else
+	{
+		ctxt.SetItToEmpty();
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -272,7 +272,7 @@ MCControl *MCSellist::clone(MCObject *target)
 	return t_result;
 }
 
-Exec_stat MCSellist::group(uint2 line, uint2 pos)
+Exec_stat MCSellist::group(uint2 line, uint2 pos, MCGroup*& r_group_ptr)
 {
 	MCresult->clear(False);
 	if (objects != NULL && objects->ref->gettype() <= CT_LAST_CONTROL
@@ -330,7 +330,14 @@ Exec_stat MCSellist::group(uint2 line, uint2 pos)
 		gptr->makegroup(controls, parent);
 		objects = new MCSelnode(gptr);
 		gptr->message(MCM_selected_object_changed);
+		
+		r_group_ptr = gptr;
 	}
+	else
+	{
+		r_group_ptr = nil;
+	}
+	
     return ES_NORMAL;
 }
 

--- a/engine/src/sellst.h
+++ b/engine/src/sellst.h
@@ -84,7 +84,7 @@ public:
 	void sort();
 	uint32_t count();
 	MCControl *clone(MCObject *target);
-	Exec_stat group(uint2 line = 0, uint2 pos = 0);
+	Exec_stat group(uint2 line, uint2 pos, MCGroup*& r_group);
 	Boolean copy();
 	Boolean cut();
 	Boolean del();

--- a/tests/lcs/core/interface/group.livecodescript
+++ b/tests/lcs/core/interface/group.livecodescript
@@ -1,0 +1,51 @@
+script "CoreInterfaceGroup"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestGroupSelection
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   select empty
+   get "ThisIsNotEmpty"
+   group
+   TestAssert "Group empty selection sets it to empty", it is empty
+
+   create button "A"
+   create button "B"
+   select button "A" and button "B"
+   set the name of the templateGroup to "NewGroup"
+   get "ThisIsNotEmpty"
+   group
+   TestAssert "Group selection sets it to new group", the short name of it is "NewGroup"
+
+   delete stack "Test"
+end TestGroupSelection
+
+on TestGroupByScript
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   create button "A"
+   create button "B"
+   set the name of the templateGroup to "NewGroup"
+   get "ThisIsNotEmpty"
+   group button "A" and button "B"
+   TestAssert "Group objects sets it to new group", the short name of it is "NewGroup"
+
+   delete stack "Test"
+end TestGroupByScript


### PR DESCRIPTION
This patch changes the behavior of the 'group' command so that it
returns the long id of the newly created group (or empty, if no
group is created).
