### PR TITLE
[[ Bug 18136 ]] Make sure arithmetic commands throw errors

### DIFF
--- a/docs/notes/bugfix-18136.md
+++ b/docs/notes/bugfix-18136.md
@@ -1,0 +1,2 @@
+# Make sure arithmetic commands throw errors for bad inputs
+

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -115,7 +115,8 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
 	
     if (!ctxt . EvaluateExpression(source, EE_ADD_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
-    {
+	{
+		ctxt.LegacyThrow(EE_ADD_BADSOURCE);
         return;
     }
 	
@@ -154,7 +155,8 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
     {
         MCExecTypeRelease(t_src);
         MCExecTypeRelease(t_dst);
-        return;
+		ctxt.LegacyThrow(EE_ADD_BADDEST);
+		return;
     }
 
 	MCExecValue t_result;
@@ -277,7 +279,8 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
     
     if (!ctxt . EvaluateExpression(source, EE_DIVIDE_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
-    {
+	{
+		ctxt.LegacyThrow(EE_DIVIDE_BADSOURCE);
         return;
     }
 	
@@ -314,7 +317,8 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
     if (!ctxt . ConvertToNumberOrArray(t_dst))
     {
         MCExecTypeRelease(t_src);
-        MCExecTypeRelease(t_dst);
+		MCExecTypeRelease(t_dst);
+		ctxt.LegacyThrow(EE_DIVIDE_BADDEST);
         return;
     }
 	
@@ -443,7 +447,8 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
 
     if(!ctxt . EvaluateExpression(source, EE_MULTIPLY_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
-    {
+	{
+		ctxt.LegacyThrow(EE_MULTIPLY_BADSOURCE);
         return;
     }
 	
@@ -480,7 +485,8 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
     if (!ctxt . ConvertToNumberOrArray(t_dst))
     {
         MCExecTypeRelease(t_src);
-        MCExecTypeRelease(t_dst);
+		MCExecTypeRelease(t_dst);
+		ctxt.LegacyThrow(EE_MULTIPLY_BADDEST);
         return;
     }
 	
@@ -609,7 +615,8 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
 
     if (!ctxt . EvaluateExpression(source, EE_SUBTRACT_BADSOURCE, t_src)
             || !ctxt . ConvertToNumberOrArray(t_src))
-    {
+	{
+		ctxt.LegacyThrow(EE_SUBTRACT_BADSOURCE);
         return;
     }
 	
@@ -646,7 +653,8 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
     if (!ctxt . ConvertToNumberOrArray(t_dst))
     {
         MCExecTypeRelease(t_src);
-        MCExecTypeRelease(t_dst);
+		MCExecTypeRelease(t_dst);
+		ctxt.LegacyThrow(EE_SUBTRACT_BADDEST);
         return;
     }
 	

--- a/tests/lcs/core/math/arithmetic-commands.livecodescript
+++ b/tests/lcs/core/math/arithmetic-commands.livecodescript
@@ -1,0 +1,117 @@
+script "CoreMathArithmeticCommmands"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+----------
+
+private function MapError pError, pSrcErr, pDstErr
+   if item 1 of pError is pSrcErr then
+      return "src"
+   end if
+
+   if item 1 of pError is pDstErr then
+      return "dst"
+   end if
+
+   return empty
+end MapError
+
+----------
+
+constant kAddSrcError = 10
+constant kAddDstError = 9
+
+private function DoAdd pSrc, pDst
+   try
+      add pSrc to pDst
+   catch tError
+   end try
+   return MapError(tError, kAddSrcError, kAddDstError)
+end DoAdd
+
+on TestAdd
+   local tSrc, tDst
+   put "foo" into tSrc
+   put 0 into tDst
+   TestAssert "add bad to good is error", DoAdd(tSrc, tDst) is "src"
+   TestAssert "add good to bad is error", DoAdd(tDst, tSrc) is "dst"
+end TestAdd
+
+----------
+
+constant kSubtractSrcError = 579
+constant kSubtractDstError = 578
+
+private function DoSubtract pSrc, pDst
+   try
+      subtract pSrc from pDst
+   catch tError
+   end try
+   return MapError(tError, kSubtractSrcError, kSubtractDstError)
+end DoSubtract
+
+on TestSubtract
+   local tSrc, tDst
+   put "foo" into tSrc
+   put 0 into tDst
+   TestAssert "subtract bad from good is error", DoSubtract(tSrc, tDst) is "src"
+   TestAssert "subtract good from bad is error", DoSubtract(tDst, tSrc) is "dst"
+end TestSubtract
+
+----------
+
+constant kMultiplySrcError = 334
+constant kMultiplyDstError = 333
+
+private function DoMultiply pSrc, pDst
+   try
+      multiply pDst by pSrc
+   catch tError
+   end try
+   return MapError(tError, kMultiplySrcError, kMultiplyDstError)
+end DoMultiply
+
+on TestMultiply
+   local tSrc, tDst
+   put "foo" into tSrc
+   put 0 into tDst
+   TestAssert "multiply bad by good is error", DoMultiply(tSrc, tDst) is "src"
+   TestAssert "multiply good by bad is error", DoMultiply(tDst, tSrc) is "dst"
+end TestMultiply
+
+----------
+
+constant kDivideSrcError = 149
+constant kDivideDstError = 148
+
+private function DoDivide pSrc, pDst
+   try
+      divide pDst by pSrc
+   catch tError
+   end try
+   return MapError(tError, kDivideSrcError, kDivideDstError)
+end DoDivide
+
+on TestDivide
+   local tSrc, tDst
+   put "foo" into tSrc
+   put 0 into tDst
+   TestAssert "divide bad by good is error", DoDivide(tSrc, tDst) is "src"
+   TestAssert "divide good by bad is error", DoDivide(tDst, tSrc) is "dst"
+end TestDivide
+
+----------


### PR DESCRIPTION
This patch ensures that the add, multiply, subtract and divide
commands all throw appropriate errors if either the source or
destination expressions do not evaluation to things of either
number or array type.
