### PR TITLE
[[ Bug 18068 ]] Make htmlText attributes unicode-aware

### DIFF
--- a/docs/notes/bugfix-18068.md
+++ b/docs/notes/bugfix-18068.md
@@ -1,0 +1,14 @@
+# Ensure non-BMP characters roundtrip through htmlText
+
+Previously, unicode characters outside of the basic multilingual plane (i.e. those
+with codepoint < 65536) would fail to roundtrip through the htmlText property of
+fields. This has now been fixed.
+
+In addition, fixing this issue also means that unicode characters (of any
+codepoint) can now appear in the metadata attribute of 'p' and 'span' tags.
+
+Finally, the imageSource property can now span multiple characters. This is
+required to allow it to apply to surrogate pairs (i.e. characters with codepoint
+> 65535) and unicode character sequences which are considered a single 'char'
+(i.e. human readable character / grapheme).
+

--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -1763,13 +1763,7 @@ void MCField::SetImageSourceOfCharChunk(MCExecContext& ctxt, uint32_t p_part_id,
     if (si == ei)
         return;
 
-    // MW-2007-07-05: [[ Bug 5099 ]] If this is an image source property we
-    //   force to one character here to ensure unicode chars are rounded
-    //   up and down correctly.
-    findex_t t_ei;
-    t_ei = si + 1;
-
-    SetCharPropOfCharChunk< PodFieldPropType<MCStringRef> >(ctxt, this, true, p_part_id, si, t_ei, &MCBlock::SetImageSource, value);
+    SetCharPropOfCharChunk< PodFieldPropType<MCStringRef> >(ctxt, this, true, p_part_id, si, ei, &MCBlock::SetImageSource, value);
 }
 
 void MCField::GetVisitedOfCharChunk(MCExecContext& ctxt, uint32_t p_part_id, int32_t si, int32_t ei, bool& r_value)

--- a/engine/src/fieldhtml.cpp
+++ b/engine/src/fieldhtml.cpp
@@ -199,6 +199,35 @@ static struct { const char *entity; uint32_t codepoint; } s_export_html_unicode_
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static int atoi(MCStringRef p_string)
+{
+	MCAutoNumberRef t_number;
+	if (!MCNumberParse(p_string, &t_number))
+	{
+		return 0;
+	}
+	
+	return MCNumberFetchAsInteger(*t_number);
+}
+
+static bool MCStringContainsCString(MCStringRef p_haystack,
+									const char *p_needle,
+									MCStringOptions p_options)
+{
+	MCAutoStringRef t_needle_str;
+	if (!MCStringCreateWithCString(p_needle,
+								   &t_needle_str))
+	{
+		return false;
+	}
+	
+	return MCStringContains(p_haystack,
+							*t_needle_str,
+							p_options);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 static bool export_html_lookup_entity(uint32_t p_codepoint, char *r_buffer)
 {
 	uint4 t_low, t_high;
@@ -253,11 +282,39 @@ static void export_html_emit_char(char *p_output, uint32_t p_char, export_html_e
 
 static void export_html_emit_unicode_text(MCStringRef p_buffer, MCStringRef p_input, MCRange p_range, export_html_escape_type_t p_escape)
 {
-	for(uint32_t i = 0; i < p_range.length; i++)
+	uint32_t t_index = p_range.offset;
+	while(t_index < p_range.offset + p_range.length)
 	{
+		unichar_t t_unit =
+			MCStringGetCharAtIndex(p_input,
+								   t_index);
+		
+		// If the next unit is a low surrogate *and* there is a next unit
+		// *and* it is a high surrogate then map to a codepoint.
+		codepoint_t t_codepoint = t_unit;
+		if (MCUnicodeCodepointIsLeadingSurrogate(t_unit))
+		{
+			if (t_index + 1 < p_range.length)
+			{
+				unichar_t t_next_unit =
+					MCStringGetCharAtIndex(p_input,
+										   t_index + 1);
+				
+				if (MCUnicodeCodepointIsTrailingSurrogate(t_next_unit))
+				{
+					t_codepoint = MCUnicodeCombineSurrogates(t_unit,
+															 t_next_unit);
+					
+					t_index += 1;
+				}
+			}
+		}
+		
 		char t_output[16];
-		export_html_emit_char(t_output, MCStringGetCodepointAtIndex(p_input, p_range.offset+i), p_escape);
+		export_html_emit_char(t_output, t_codepoint, p_escape);
 		/* UNCHECKED */ MCStringAppendFormat(p_buffer, "%s", t_output);
+		
+		t_index += 1;
 	}
 }
 
@@ -908,7 +965,7 @@ static struct { const char *entity; uint32_t codepoint; } s_import_html_entities
 struct import_html_attr_t
 {
 	import_html_attr_type_t type;
-	char *value;
+	MCStringRef value;
 };
 
 struct import_html_tag_t
@@ -1005,7 +1062,7 @@ static bool import_html_lookup_tag(const char *p_start, const char *p_end, impor
 static void import_html_free_tag(import_html_tag_t& p_tag)
 {
 	for(uint32_t i = 0; i < p_tag . attr_count; i++)
-		MCCStringFree(p_tag . attrs[i] . value);
+		MCValueRelease(p_tag . attrs[i] . value);
 	MCMemoryDeleteArray(p_tag . attrs);
 }
 
@@ -1106,49 +1163,50 @@ static bool import_html_parse_entity(const char *& x_ptr, const char *p_limit, u
 
 // This method parses a (CDATA encoded) attribute value and returns it as a native
 // cstring.
-static bool import_html_parse_attr_value(const char *p_start_ptr, const char *p_end_ptr, char*& r_value)
+static bool import_html_parse_attr_value(const char *p_start_ptr, const char *p_end_ptr, MCStringRef& r_value)
 {
 	// First allocate room for the value - this is at most the length of the input
 	// string as all entities are strictly longer than what they encode.
-	char *t_value;
-	if (!MCMemoryNewArray(p_end_ptr - p_start_ptr + 1, t_value))
+	MCAutoStringRef t_value;
+	if (!MCStringCreateMutable((uindex_t)(p_end_ptr - p_start_ptr),
+							   &t_value))
+	{
 		return false;
+	}
 		
 	// Now loop through the input characters, emitting appropriate output chars
 	// at the tail of t_value.
-	char *t_value_ptr;
-	t_value_ptr = t_value;
 	while(p_start_ptr < p_end_ptr)
 	{
 		// If we encounter a '&' then check to see if its an entity - if it is
 		// then emit that char (if it can map to native!); otherwise the char is
 		// '&' and we emit the entity as written.
-		uint8_t t_char;
+		codepoint_t t_codepoint;
 		if (*p_start_ptr == '&')
 		{
-			uint32_t t_codepoint;
-			if (import_html_parse_entity(p_start_ptr, p_end_ptr, t_codepoint))
+			if (!import_html_parse_entity(p_start_ptr, p_end_ptr, t_codepoint))
 			{
-				unichar_t t_utf16_codepoint;
-				t_utf16_codepoint = t_codepoint;
-				if (!MCUnicodeMapToNative(&t_utf16_codepoint, 1, t_char))
-					t_char = '?';
+				t_codepoint = '&';
 			}
-			else
-				t_char = '&';
 		}
 		else
-			t_char = *p_start_ptr++;
+			t_codepoint = *p_start_ptr++;
 		
 		// Append the char to the value string we are accumulating.
-		*t_value_ptr++ = t_char;
+		if (!MCStringAppendCodepoint(*t_value,
+									 t_codepoint))
+		{
+			return false;
+		}
 	}
 	
-	// Make sure we terminate the string.
-	*t_value_ptr = '\0';
+	if (!t_value.MakeImmutable())
+	{
+		return false;
+	}
 	
 	// And return it.
-	r_value = t_value;
+	r_value = t_value.Take();
 	
 	return true;
 }
@@ -1172,7 +1230,7 @@ static bool import_html_parse_attr(const char*& x_ptr, const char *p_limit, impo
 	}
 	t_key_end_ptr = x_ptr;
 	
-	char *t_value;
+	MCAutoStringRef t_value;
 	if (*x_ptr == '=')
 	{
 		// MW-2014-03-11: [[ Bug 11888 ]] Ensure we consume as much as possible, else
@@ -1217,19 +1275,15 @@ static bool import_html_parse_attr(const char*& x_ptr, const char *p_limit, impo
 		
 		// MW-2012-03-16: [[ Bug ]] Make sure we un-entity encode the attribute value as
 		//   its a CDATA section.
-		if (!import_html_parse_attr_value(t_value_start_ptr, t_value_end_ptr, t_value))
+		if (!import_html_parse_attr_value(t_value_start_ptr, t_value_end_ptr, &t_value))
 			return false;
 	}
-	else
-		t_value = nil;
 		
 	if (import_html_lookup_attr(t_key_start_ptr, t_key_end_ptr, r_attr . type))
 	{
-		r_attr . value = t_value;
+		r_attr . value = t_value.Take();
 		return true;
 	}
-	
-	MCCStringFree(t_value);
 	
 	return false;
 }
@@ -1443,6 +1497,26 @@ static void import_html_append_unicode_char(import_html_t& ctxt, uint32_t p_code
 	ctxt . byte_count += 2;
 }
 
+static void import_html_append_stringref(import_html_t& ctxt, MCStringRef p_chars)
+{
+	// If the text is currently native (and there is some) or if the styling has changed
+	// then flush.
+	if ((!ctxt . is_unicode && ctxt . byte_count > 0) ||
+		!import_html_equal_style(ctxt . last_used_style, ctxt . styles[ctxt . style_index] . style))
+		import_html_flush_chars(ctxt);
+	
+	// Make sure there's enough room in the buffer.
+	if (!import_html_ensure_bytes(ctxt, sizeof(unichar_t) * MCStringGetLength(p_chars)))
+		return;
+	
+	// Append the text to the buffer.
+	ctxt . is_unicode = true;
+	MCStringGetChars(p_chars,
+					 MCRangeMake(0, MCStringGetLength(p_chars)),
+					 (unichar_t *)(ctxt.bytes + ctxt.byte_count));
+	ctxt.byte_count += sizeof(unichar_t) * MCStringGetLength(p_chars);
+}
+
 static void import_html_append_utf8_chars(import_html_t& ctxt, const char *p_chars, uint32_t p_char_count)
 {
 	while(p_char_count > 0)
@@ -1601,8 +1675,7 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 				// MW-2012-03-16: [[ Bug ]] LinkText without link style is encoded with a 'name' attr.
 				if (p_tag . attrs[i] . value != nil && (p_tag . attrs[i] . type == kImportHtmlAttrName || p_tag . attrs[i] . type == kImportHtmlAttrHref))
 				{
-					MCValueRelease(t_linktext);
-					/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)p_tag . attrs[i] . value, strlen(p_tag . attrs[i] . value), t_linktext);
+					MCValueAssign(t_linktext, p_tag.attrs[i].value);
 					t_is_link = p_tag . attrs[i] . type == kImportHtmlAttrHref;
 				}
 			}
@@ -1630,8 +1703,7 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 					// Nil-check before passing it to strlen
 					if (p_tag . attrs[i] . value != nil)
 					{
-						MCValueRelease(t_src);
-						/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t *)p_tag . attrs[i] . value, strlen(p_tag . attrs[i] . value), t_src);
+						MCValueAssign(t_src, p_tag.attrs[i].value);
 					}
 				}
 			
@@ -1654,7 +1726,7 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 							t_style . has_text_font = true;
 							if (t_style . text_font != nil)
 								MCNameDelete(t_style . text_font);
-							MCNameCreateWithCString(p_tag . attrs[i] . value, t_style . text_font);
+							MCNameCreate(p_tag . attrs[i] . value, t_style . text_font);
 						}
 						break;
 					case kImportHtmlAttrSize:
@@ -1664,7 +1736,10 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 							t_size = atoi(p_tag . attrs[i] . value);
 							if (t_size != 0)
 							{
-								if (p_tag . attrs[i] . value[0] == '+' || p_tag . attrs[i] . value[0] == '-')
+								unichar_t t_first_char =
+									MCStringGetCharAtIndex(p_tag.attrs[i].value,
+														   0);
+								if (t_first_char == '+' || t_first_char == '-')
 								{
 									t_size += 4;
 									if (t_size < 1)
@@ -1683,9 +1758,7 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 					case kImportHtmlAttrColor:
 						{
 							MCColor t_color;
-							MCAutoStringRef t_value;
-							/* UNCHECKED */ MCStringCreateWithCString(p_tag . attrs[i] . value, &t_value);
-							if (p_tag . attrs[i] . value != nil && MCscreen -> parsecolor(*t_value, t_color, nil))
+							if (p_tag . attrs[i] . value != nil && MCscreen -> parsecolor(p_tag . attrs[i] . value, t_color, nil))
 							{
 								t_style . has_text_color = true;
 								t_style . text_color = MCColorGetPixel(t_color);
@@ -1694,10 +1767,8 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 						break;
 					case kImportHtmlAttrBgColor:
 						{
-							MCAutoStringRef t_value;
-							/* UNCHECKED */ MCStringCreateWithCString(p_tag . attrs[i] . value, &t_value);
 							MCColor t_color;
-							if (p_tag . attrs[i] . value != nil && MCscreen -> parsecolor(*t_value, t_color, nil))
+							if (p_tag . attrs[i] . value != nil && MCscreen -> parsecolor(p_tag . attrs[i] . value, t_color, nil))
 							{
 								t_style . has_background_color = true;
 								t_style . background_color = MCColorGetPixel(t_color);
@@ -1738,8 +1809,8 @@ static void import_html_change_style(import_html_t& ctxt, const import_html_tag_
 			for(uint32_t i = 0; i < p_tag . attr_count; i++)
 				if (p_tag . attrs[i] . value != nil && p_tag . attrs[i] . type == kImportHtmlAttrMetadata)
 				{
-					MCValueRelease(t_metadata);
-					MCStringCreateWithCString(p_tag . attrs[i] . value, t_metadata);
+					MCValueAssign(t_metadata,
+								  p_tag.attrs[i].value);
 				}
 			
 			if (t_metadata != nil)
@@ -1791,10 +1862,11 @@ static void import_html_parse_paragraph_attrs(import_html_tag_t& p_tag, MCFieldP
 {
 	for(uint32_t i = 0; i < p_tag . attr_count; i++)
 	{
-		const char *t_value;
-		t_value = p_tag . attrs[i] . value;
+		MCStringRef t_value = p_tag.attrs[i].value;
 		if (t_value == nil)
-			t_value = "";
+		{
+			t_value = kMCEmptyString;
+		}
 			
 		switch(p_tag . attrs[i] . type)
 		{
@@ -1806,11 +1878,9 @@ static void import_html_parse_paragraph_attrs(import_html_tag_t& p_tag, MCFieldP
 					r_style . has_metadata = false;
 				}
 
-				if (*t_value != '\0')
+				if (!MCStringIsEmpty(t_value))
 				{
-                    MCStringRef t_valueref;
-                    /* UNCHECKED */ MCStringCreateWithCString(t_value, t_valueref);
-                    /* UNCHECKED */ MCValueInterAndRelease(t_valueref, r_style . metadata);
+                    /* UNCHECKED */ MCValueInter(t_value, r_style . metadata);
 					r_style . has_metadata = true;
 				}
 				break;
@@ -1818,7 +1888,9 @@ static void import_html_parse_paragraph_attrs(import_html_tag_t& p_tag, MCFieldP
 				// MW-2012-05-01: [[ Bug 10183 ]] Crash and oddness when 'align' attribute is present
 				//   due to using i rather than j (oops!).
 				for(uint32_t j = 0; j < 4; j++)
-					if (MCCStringEqualCaseless(t_value, MCtextalignstrings[j]))
+					if (MCStringIsEqualToCString(t_value,
+												 MCtextalignstrings[j],
+												 kMCStringOptionCompareCaseless))
 					{
 						r_style . has_text_align = true;
 						r_style . text_align = j;
@@ -1857,9 +1929,7 @@ static void import_html_parse_paragraph_attrs(import_html_tag_t& p_tag, MCFieldP
 					r_style . tabs = nil;
 					r_style . has_tabs = false;
 				}
-                MCAutoStringRef t_value_str;
-                /* UNCHECKED */ MCStringCreateWithCString(t_value, &t_value_str);
-				if (MCField::parsetabstops(P_TAB_STOPS, *t_value_str, r_style . tabs, r_style . tab_count))
+				if (MCField::parsetabstops(P_TAB_STOPS, t_value, r_style . tabs, r_style . tab_count))
                 {
 					r_style . has_tabs = true;
                 }
@@ -1867,10 +1937,8 @@ static void import_html_parse_paragraph_attrs(import_html_tag_t& p_tag, MCFieldP
 			break;
 			case kImportHtmlAttrBgColor:
             {
-				MCAutoStringRef t_value_str;
-				/* UNCHECKED */ MCStringCreateWithCString(t_value, &t_value_str);
 				MCColor t_color;
-				if (MCscreen -> parsecolor(*t_value_str, t_color, nil))
+				if (MCscreen -> parsecolor(t_value, t_color, nil))
 				{
 					r_style . has_background_color = true;
 					r_style . background_color = MCColorGetPixel(t_color);
@@ -1884,10 +1952,8 @@ static void import_html_parse_paragraph_attrs(import_html_tag_t& p_tag, MCFieldP
 			break;
 			case kImportHtmlAttrBorderColor:
             {
-				MCAutoStringRef t_value_str;
-				/* UNCHECKED */ MCStringCreateWithCString(t_value, &t_value_str);
 				MCColor t_color;
-				if (MCscreen -> parsecolor(*t_value_str, t_color, nil))
+				if (MCscreen -> parsecolor(t_value, t_color, nil))
 				{
 					r_style . has_border_color = true;
 					r_style . border_color = MCColorGetPixel(t_color);
@@ -2038,7 +2104,9 @@ MCParagraph *MCField::importhtmltext(MCValueRef p_text)
                                 if (t_tag . attrs[i] . type == kImportHtmlAttrType)
                                 {
                                     for(uint32_t j = 0; s_export_html_list_types[j] != nil; j++)
-                                        if (MCCStringEqual(t_tag . attrs[i] . value, s_export_html_list_types[j]))
+                                        if (MCStringIsEqualToCString(t_tag . attrs[i] . value,
+																	 s_export_html_list_types[j],
+																	 kMCStringOptionCompareCaseless))
                                         {
                                             t_style = j;
                                             break;
@@ -2061,7 +2129,9 @@ MCParagraph *MCField::importhtmltext(MCValueRef p_text)
                             t_is_utf8 = false;
                             for(uint32_t i = 0; i < t_tag . attr_count; i++)
                                 if (t_tag . attrs[i] . type == kImportHtmlAttrContent || t_tag . attrs[i] . type == kImportHtmlAttrCharset)
-                                    if (MCCStringContains(t_tag . attrs[i] . value, "utf-8"))
+                                    if (MCStringContainsCString(t_tag . attrs[i] . value,
+																"utf-8",
+																kMCStringOptionCompareCaseless))
                                     {
                                         t_is_utf8 = true;
                                         break;
@@ -2195,7 +2265,6 @@ MCParagraph *MCField::importhtmltext(MCValueRef p_text)
                                     t_font_size = 10, t_font_style = FA_BOLD;
                                     break;
 								default:
-									MCUnreachable();
 									break;
                             }
                             
@@ -2227,14 +2296,21 @@ MCParagraph *MCField::importhtmltext(MCValueRef p_text)
                         if (!t_tag . is_terminator)
                         {
                             import_html_change_style(ctxt, t_tag);
-                            
-                            const char *t_char;
-                            t_char = " ";
+							
+							MCStringRef t_chars = nil;
                             for(uint32_t i = 0; i < t_tag . attr_count; i++)
                                 if (t_tag . attrs[i] . type == kImportHtmlAttrChar)
-                                    t_char = t_tag . attrs[i] . value;
-                            
-                            import_html_append_native_chars(ctxt, t_char, 1);
+                                    t_chars = t_tag . attrs[i] . value;
+							
+							if (t_chars != nil)
+							{
+								import_html_append_stringref(ctxt, t_chars);
+							}
+							else
+							{
+								import_html_append_native_chars(ctxt, " ", 1);
+							}
+							
                             import_html_pop_tag(ctxt, kImportHtmlTagImage, false);
                         }
                         break;

--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -526,7 +526,7 @@ inline bool MCUnicodeCodepointIsIdeographic(uinteger_t x)
 extern uinteger_t MCUnicodeCodepointGetBreakClass(uinteger_t x);
 
 // Returns true if the given codepoint is in the high surrogate area
-inline bool MCUnicodeCodepointIsHighSurrogate(uinteger_t x)
+inline bool MCUnicodeCodepointIsLeadingSurrogate(codepoint_t x)
 {
 	if (x < 0xD800)
 		return false;
@@ -537,14 +537,25 @@ inline bool MCUnicodeCodepointIsHighSurrogate(uinteger_t x)
 	return true;
 }
 
+inline bool MCUnicodeCodepointIsHighSurrogate(uinteger_t x)
+{
+	return MCUnicodeCodepointIsLeadingSurrogate(x);
+}
+
+
 // Returns true if the given codepoint is in the low surrogate area
-inline bool MCUnicodeCodepointIsLowSurrogate(uinteger_t x)
+inline bool MCUnicodeCodepointIsTrailingSurrogate(codepoint_t x)
 {
 	if (x < 0xDC00)
 		return false;
 	if (x > 0xDFFF)
 		return false;
 	return true;
+}
+
+inline bool MCUnicodeCodepointIsLowSurrogate(uinteger_t x)
+{
+	return MCUnicodeCodepointIsTrailingSurrogate(x);
 }
 
 // Returns true if the given codepoint is a base character
@@ -556,6 +567,12 @@ inline bool MCUnicodeCodepointIsBase(uinteger_t x)
 	return !MCUnicodeCodepointIsCombiner(x);
 }
 
+// Returns the codepoint formed by combining a low and high surrogate
+inline codepoint_t MCUnicodeCombineSurrogates(unichar_t p_leading, unichar_t p_trailing)
+{
+	return 0x10000U + (((p_leading - 0xD800U) << 10) | (p_trailing - 0xDC00U));
+}
+
 // Compute and advance the current surrogate pair (used by MCUnicodeCodepointAdvance to
 // help the compiler make good choices about inlining - effectively a 'trap' to a very
 // rare case).
@@ -565,7 +582,7 @@ inline uinteger_t MCUnicodeCodepointAdvanceSurrogate(const unichar_t* p_input, u
 	{
         // FG-2014-10-23: [[ Bugfix 13761 ]] Codepoint was calculated incorrectly
         uinteger_t t_codepoint;
-		t_codepoint = (0x10000U + ((p_input[x_index] - 0xD800U) << 10)) | (p_input[x_index + 1] - 0xDC00U);
+		t_codepoint = MCUnicodeCombineSurrogates(p_input[x_index], p_input[x_index + 1]);
 		x_index += 2;
 		return t_codepoint;
 	}

--- a/tests/lcs/core/field/htmlText.livecodescript
+++ b/tests/lcs/core/field/htmlText.livecodescript
@@ -1,0 +1,43 @@
+script "CoreFieldHtmlText"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+private function q pString
+   replace "'" with quote in pString
+   return pString
+end q
+
+on TestSurrogateRoundtrip
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   create field "TestField"
+
+   set the htmlText of field "TestField" to "<p>&#78730;</p>"
+   TestAssert "htmlText roundtrips surrogates", the htmlText of field "TestField" is "<p>&#78730;</p>"
+
+   set the htmlText of field "TestField" to "<p metadata='&#78730;'></p>"
+   TestAssert "htmlText roundtrips surrogates in paragraph metadata", the htmlText of field "TestField" is q("<p metadata='&#78730;'></p>")
+
+   set the htmlText of field "TestField" to "<p><span metadata='&#78730;'>a</span></p>"
+   TestAssert "htmlText roundtrips surrogates in span metadata", the htmlText of field "TestField" is q("<p><span metadata='&#78730;'>a</span></p>")
+
+   set the htmlText of field "TestField" to "<p><img src='1000' char='&#78730;'></p>"
+   TestAssert "htmlText roundtrips surrogates in imageSource char", the htmlText of field "TestField" is q("<p><img src='1000' char='&#78730;'></p>")
+
+   delete stack "Test"
+end TestSurrogateRoundtrip


### PR DESCRIPTION
This patch makes the htmlText importer and exporter correctly work
where attributes require unicode text encoding (using entities).

Additionally, it also fixes the use of non-BMP unicode chars in
all areas the htmlText.

Finally, it generalizes the imageSource char field to multiple
chars. This means that imageSource can now cover multiple characters
which is required for it to work with surrogates and complex graphemes.
