### PR TITLE
[[ Bug 18129 ]] Ensure matchChunk returns the correct char positions

### DIFF
--- a/docs/notes/bugfix-18129.md
+++ b/docs/notes/bugfix-18129.md
@@ -1,0 +1,1 @@
+# Ensure matchChunk returns the correct char positions

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -859,9 +859,16 @@ void MCStringsEvalMatchChunk(MCExecContext& ctxt, MCStringRef p_string, MCString
     {
         if (r_match && t_compiled->matchinfo[t_match_index].rm_so != -1)
         {
-            t_success = MCStringFormat(r_results[i], "%d", t_compiled->matchinfo[t_match_index].rm_so + 1);
+			MCRange t_cu_range, t_char_range;
+			t_cu_range.offset = t_compiled->matchinfo[t_match_index].rm_so;
+			t_cu_range.length = t_compiled->matchinfo[t_match_index].rm_eo - t_compiled->matchinfo[t_match_index].rm_so;
+			MCStringUnmapIndices(p_string,
+								 kMCCharChunkTypeGrapheme,
+								 t_cu_range,
+								 t_char_range);
+            t_success = MCStringFormat(r_results[i], "%d", t_char_range.offset + 1);
             if (t_success)
-                t_success = MCStringFormat(r_results[i + 1], "%d", t_compiled->matchinfo[t_match_index].rm_eo);
+                t_success = MCStringFormat(r_results[i + 1], "%d", t_char_range.offset + t_char_range.length);
         }
         else
         {

--- a/tests/lcs/core/strings/matchchunk.livecodescript
+++ b/tests/lcs/core/strings/matchchunk.livecodescript
@@ -1,0 +1,29 @@
+script "CoreStringMatchChunk"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestMatchChunkWithSurrogates
+   local tString
+   put numToCodepoint(0x1d45b) & "Hello" into tString
+
+   local tStart, tEnd
+   get matchChunk(tString, "(He)", tStart, tEnd)
+   TestAssert "matchChunk returns correct indicies for strings containing surrogates", \
+                  it and \
+                  tStart is 2 and \
+                  tEnd is 3
+end TestMatchChunkWithSurrogates


### PR DESCRIPTION
This patch corrects MCStringsEvalMatchChunk to ensure that it returns
char (grapheme) indicies, rather than code unit indicies.
