### PR TITLE
[[ DontLoadStacks ]] Remove automatic stack open in development mode

### DIFF
--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -293,21 +293,6 @@ bool X_init(int argc, MCStringRef argv[], MCStringRef envp[])
 
 	if (!X_open(argc, argv, envp))
 		return false;
-
-	if (MCstacknames != NULL && MCModeShouldLoadStacksOnStartup())
-	{
-		for(int i = 0 ; i < MCnstacks ; i++)
-		{
-			MCStack *sptr;
-			if (MCdispatcher->loadfile(MCstacknames[i], sptr) == IO_NORMAL)
-				sptr->open();
-            MCValueRelease(MCstacknames[i]);
-		}
-        MCnstacks = 0;
-		delete MCstacknames;
-		MCstacknames = NULL;
-		MCeerror->clear();
-	}
 	
 	return true;
 }

--- a/engine/src/mode.h
+++ b/engine/src/mode.h
@@ -91,13 +91,6 @@ bool MCModeHasCommandLineArguments(void);
 //
 bool MCModeHasEnvironmentVariables(void);
 
-// This hook is used to determine if any stacks on the command-line
-// should be opened on startup.
-//
-// This hook is called by X_init.
-//
-bool MCModeShouldLoadStacksOnStartup(void);
-
 // This hook is used to generate the alert message on Windows, should
 // initialization fail.
 //

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -644,12 +644,6 @@ MCModeHasEnvironmentVariables()
 	return true;
 }
 
-// In development mode, we always automatically open stacks.
-bool MCModeShouldLoadStacksOnStartup(void)
-{
-	return true;
-}
-
 // In development mode, we just issue a generic error.
 void MCModeGetStartupErrorMessage(MCStringRef& r_caption, MCStringRef& r_text)
 {

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1523,13 +1523,6 @@ MCModeHasEnvironmentVariables()
 	return true;
 }
 
-// In standalone mode, we only automatically open stacks if there isn't an
-// embedded stack.
-bool MCModeShouldLoadStacksOnStartup(void)
-{
-	return false;
-}
-
 // In standalone mode, we try to work out what went wrong...
 void MCModeGetStartupErrorMessage(MCStringRef& r_caption, MCStringRef& r_text)
 {

--- a/engine/src/mode_server.cpp
+++ b/engine/src/mode_server.cpp
@@ -254,13 +254,6 @@ MCModeHasEnvironmentVariables()
 	return true;
 }
 
-// In standalone mode, we only automatically open stacks if there isn't an
-// embedded stack.
-bool MCModeShouldLoadStacksOnStartup(void)
-{
-	return false;
-}
-
 // In standalone mode, we try to work out what went wrong...
 void MCModeGetStartupErrorMessage(MCStringRef& r_caption, MCStringRef& r_text)
 {

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -1054,13 +1054,6 @@ MCModeHasEnvironmentVariables()
 	return true;
 }
 
-// In standalone mode, we only automatically open stacks if there isn't an
-// embedded stack.
-bool MCModeShouldLoadStacksOnStartup(void)
-{
-	return false;
-}
-
 // In standalone mode, we try to work out what went wrong...
 void MCModeGetStartupErrorMessage(MCStringRef& r_caption, MCStringRef& r_text)
 {


### PR DESCRIPTION
This patch removes automatic loading of stackfiles
provided on the command line from the development
engine. This patch requires a patch to the IDE to
load stackFiles explicitly when the environment
is completely initialised. This patch will allow
the IDE to avoid user stacks presenting while the
splash screen is open and to handle stack files
differently depending on their type. For example,
handle script only stacks by opening the script
editor.
