### PR TITLE
[[ Bug 17764 ]] Fix invalid graphics context when drawing empty strings

### DIFF
--- a/docs/notes/bugfix-17764.md
+++ b/docs/notes/bugfix-17764.md
@@ -1,0 +1,1 @@
+# Fix widget drawing when attempting to draw empty strings

--- a/libgraphics/src/coretext.cpp
+++ b/libgraphics/src/coretext.cpp
@@ -215,7 +215,7 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 		
 		t_clipped_bounds = MCGRectangleIntegerBounds(t_float_clipped_bounds);
 		
-		if (t_clipped_bounds . width == 0 || t_clipped_bounds . height == 0)
+		if (t_clipped_bounds . width <= 0 || t_clipped_bounds . height <= 0)
         {
             if (t_line != NULL)
                 CFRelease(t_line);


### PR DESCRIPTION
This patch changes the clipped bounds check to ensure the size is

> 0 before attempting to draw the text.
