### PR TITLE
[[ Bug 18152 ]] Use size of window content rect when adjusting native layers

### DIFF
--- a/docs/notes/bugfix-18152.md
+++ b/docs/notes/bugfix-18152.md
@@ -1,0 +1,1 @@
+# Fix browser position on Mac when shown in resized palette stack

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -136,7 +136,12 @@ bool MCNativeLayerMac::doPaint(MCGContextRef p_context)
 NSRect MCNativeLayerMac::calculateFrameRect(const MCRectangle &p_rect)
 {
 	int32_t t_gp_height;
-	t_gp_height = m_object->getcard()->getrect().height;
+	
+	NSWindow *t_window = getStackWindow();
+	if (t_window != nil)
+		t_gp_height = (int32_t)[[t_window contentView] frame].size.height;
+	else
+		t_gp_height = m_object->getcard()->getrect().height;
 	
 	NSRect t_rect;
 	t_rect = NSMakeRect(p_rect.x, t_gp_height - (p_rect.y + p_rect.height), p_rect.width, p_rect.height);

--- a/engine/src/native-layer.cpp
+++ b/engine/src/native-layer.cpp
@@ -55,7 +55,7 @@ MCNativeLayer::MCNativeLayer() :
 	m_visible(false),
 	m_show_for_tool(false),
 	m_can_render_to_context(true),
-	m_defer_geometry_changes(false)
+	m_defer_geometry_changes(true)
 {
 	m_rect = m_viewport_rect = m_deferred_rect = m_deferred_viewport_rect =
 		MCRectangleMake(0, 0, 0, 0);


### PR DESCRIPTION
On Mac, the native layer needs to be positioned based on the height of the containing window content view due to Mac's bottom-up coordinate system. Previously this was using the card height, but that can be out of sync with the native window view.
