### PR TITLE
[Bug 18179] Fix malformed dictionary entry for "go" command

### DIFF
--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -75,8 +75,8 @@ open a stack and go to a card within it, or to move backward and forward
 among recently visited cards.
 
 If the stack is open, is closed but loaded into memory, or is listed in
-the current stack's stackFiles property, you can specify it simply by
-name: 
+the current stack's stackFiles property, you can specify it simply
+by name:
 
 go stack "My Stack"
 

--- a/docs/notes/bugfix-18179.md
+++ b/docs/notes/bugfix-18179.md
@@ -1,0 +1,1 @@
+# Fix malformed dictionary entry for the "go" command.


### PR DESCRIPTION
The documentation builder treats any line that matches "^\w+:" as a
LCDoc section header.  This happens at the end of a paragraph, like
this:
