### PR TITLE
[Bug 17721] Correctly identify relevant release notes

### DIFF
--- a/builder/builder_tool.livecodescript
+++ b/builder/builder_tool.livecodescript
@@ -1,5 +1,6 @@
 script "Command Line Builder"
 local sWarnAsError
+local sDebug -- True if the builder should run in debugging mode
 
 on startup
    set the itemdelimiter to slash
@@ -11,6 +12,7 @@ on startup
    __loadExternal "revdb"
    
    put false into sWarnAsError
+   put ($BUILDER_DEBUG is not empty) into sDebug
    
    local tArgs, tArgIndex
    repeat with tArgIndex = 1 to $# - 1
@@ -97,6 +99,8 @@ on startup
          add 1 to tArgIndex
       else if tArgs[tArgIndex] is "--warn-as-error" then
          put true into sWarnAsError
+      else if tArgs[tArgIndex] is "--debug" then
+         put true into sDebug
       end if
       add 1 to tArgIndex
    end repeat
@@ -164,6 +168,10 @@ end __loadExternal
 
 command __builderLog pType, pMessage
    local tLine
+
+   if pType is "debug" and not sDebug then
+      exit __builderLog
+   end if
 
    -- Promote builder warnings to errors, if requested
    if pType is "warning" and sWarnAsError then

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -1374,22 +1374,24 @@ private command GitSortTags @xTags
 end GitSortTags
 
 private function GitGetRelevantTags pType
-   local tTags, tStart, tEnd
+   local tTags, tStart, tEnd, sNumericVersion
    put GitGetTags(pType) into tTags
    
-   set the itemdelimiter to "."
+   -- Ignore a pre-release version suffix (e.g. -rc-1)
+   set the itemdelimiter to "-"
+   put item 1 of sVersion into sNumericVersion
    
    put 0 into tStart
    repeat for each line tLine in tTags
       add 1 to tStart
-      if tLine begins with item 1 to 3 of sVersion then
+      if tLine begins with sNumericVersion then
          exit repeat
       end if
    end repeat
    put line (tStart - 1) to -1 of tTags into tTags
    
    repeat for each line tLine in tTags
-      if not (tLine begins with item 1 to 3 of sVersion) then
+      if not (tLine begins with sNumericVersion) then
          if not (tEnd is 0) then
             exit repeat
          end if

--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -1294,6 +1294,7 @@ end HtmlEscape
 
 private function GitRunInPath pPath, pCommand
    local tOutput, tExitCode
+   builderLog "debug", merge("git [[pCommand]]")
    put shell(merge("cd '[[pPath]]' && git [[pCommand]]")) into tOutput
    put the result into tExitCode
    if tExitCode is not 0 then
@@ -1401,6 +1402,11 @@ private function GitGetRelevantTags pType
       put return & "HEAD" after tTags
    end if
    
+   local tDebug
+   put tTags into tDebug
+   replace return with space in tDebug
+   builderLog "debug", merge("Relevant tags: [[tDebug]]")
+
    return tTags
 end GitGetRelevantTags
 


### PR DESCRIPTION
This pull request:
- Adds a debugging mode to the builder tool, activated with `--debug` or the `$BUILDER_DEBUG` environment variable
- Adds some generally-useful debug outputs to the release note builder
- Corrects a release note builder regression introduced in commit b61890a
