### PR TITLE
[Bug 18042] Fix special character escaping in guide PDF

### DIFF
--- a/builder/user-guide-template.html
+++ b/builder/user-guide-template.html
@@ -753,16 +753,6 @@ table{border-spacing:1em 2px;}
 				img_no_pg_break += '&nbsp;</div>';
 				return img_no_pg_break;
 			}
-		
-			renderer.code = function (code, language, callback)
-			{
-				return '<pre><code>' + code + '</code></pre>';
-			}
-			
-			renderer.codespan = function (code)
-			{
-				return '<code class="inline">' + code + '</code>';
-			}
 			
 			var content_html = marked(prefix, { renderer: renderer });
 

--- a/docs/notes/bugfix-18042.md
+++ b/docs/notes/bugfix-18042.md
@@ -1,0 +1,1 @@
+# Ensure guide PDF escapes special characters correctly.


### PR DESCRIPTION
The HTML template for generating the User Guide PDF overrode the `marked.js` built-in functions for rendering code sections.  This meant that `<` and `>` characters in MarkDown code blocks were appearing literally in the output HTML.  Among other problems, this gave the User Guide PDF the very surprising title of `" theDataA[theIndex]["Title"] & "`, thanks to an example in the Data Grid guide!
