### PR TITLE
[[ Bug 18032 ]] Remove broken parameter evaluation from send script

### DIFF
--- a/docs/notes/bugfix-18032.md
+++ b/docs/notes/bugfix-18032.md
@@ -1,0 +1,1 @@
+# Resolve poor parsing of command parameters in message box


### PR DESCRIPTION
This patch removes the parameter evaluation from send when a chunk
of script is being sent rather than a command. In the event that
`message` fails the parameter no longer makes sense or at least
would need to be far more sophisticated than the present
implementation.
