### PR TITLE
	[[ Bug 18100 ]] Attach / Detach stacks from window when switching focus on mobile

### DIFF
--- a/docs/notes/bugfix-18100.md
+++ b/docs/notes/bugfix-18100.md
@@ -1,0 +1,1 @@
+# Fix browser widget remaining visible after going to another stack on mobile

--- a/docs/notes/bugfix-18153.md
+++ b/docs/notes/bugfix-18153.md
@@ -1,0 +1,1 @@
+# Fix browser widget disappearing when stack decorations changed

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1323,6 +1323,34 @@ void MCCard::toolchanged(Tool p_new_tool)
     }
 }
 
+void MCCard::OnAttach()
+{
+	if (objptrs != NULL)
+	{
+		MCObjptr *optr = objptrs;
+		do
+		{
+			optr->getref()->OnAttach();
+			optr = optr->next();
+		}
+		while (optr != objptrs);
+	}
+}
+
+void MCCard::OnDetach()
+{
+	if (objptrs != NULL)
+	{
+		MCObjptr *optr = objptrs;
+		do
+		{
+			optr->getref()->OnDetach();
+			optr = optr->next();
+		}
+		while (optr != objptrs);
+	}
+}
+
 void MCCard::kfocusset(MCControl *target)
 {
 	if (objptrs != NULL)

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1330,7 +1330,9 @@ void MCCard::OnAttach()
 		MCObjptr *optr = objptrs;
 		do
 		{
-			optr->getref()->OnAttach();
+			MCObject *t_obj = optr->getref();
+			if (t_obj != nil)
+				t_obj->OnAttach();
 			optr = optr->next();
 		}
 		while (optr != objptrs);
@@ -1344,7 +1346,9 @@ void MCCard::OnDetach()
 		MCObjptr *optr = objptrs;
 		do
 		{
-			optr->getref()->OnDetach();
+			MCObject *t_obj = optr->getref();
+			if (t_obj != nil)
+				t_obj->OnDetach();
 			optr = optr->next();
 		}
 		while (optr != objptrs);

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -90,6 +90,9 @@ public:
 	virtual void recompute();
 	
     virtual void toolchanged(Tool p_new_tool);
+	
+	virtual void OnAttach();
+	virtual void OnDetach();
     
 	// MW-2011-09-20: [[ Collision ]] Compute shape of card.
 	virtual bool lockshape(MCObjectShape& r_shape);

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1916,7 +1916,7 @@ void MCStack::SetDecorations(MCExecContext& ctxt, const MCInterfaceDecoration& p
             if (window != NULL)
             {
                 stop_externals();
-                MCscreen->destroywindow(window);
+                destroywindow();
 				MCValueAssign(titlestring, kMCEmptyString);
             }
         }

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -283,6 +283,38 @@ void MCGroup::toolchanged(Tool p_new_tool)
 	}
 }
 
+void MCGroup::OnAttach()
+{
+	MCControl::OnAttach();
+	if (controls != nil)
+	{
+		MCControl *t_ctrl;
+		t_ctrl = controls;
+		do
+		{
+			t_ctrl->OnAttach();
+			t_ctrl = t_ctrl->next();
+		}
+		while (t_ctrl != controls);
+	}
+}
+
+void MCGroup::OnDetach()
+{
+	if (controls != nil)
+	{
+		MCControl *t_ctrl;
+		t_ctrl = controls;
+		do
+		{
+			t_ctrl->OnDetach();
+			t_ctrl = t_ctrl->next();
+		}
+		while (t_ctrl != controls);
+	}
+	MCControl::OnDetach();
+}
+
 MCRectangle MCGroup::getviewportgeometry()
 {
 	MCRectangle t_viewport;

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -126,6 +126,9 @@ public:
 	virtual void relayercontrol_insert(MCControl *control, MCControl *target);
 
 	virtual void toolchanged(Tool p_new_tool);
+	
+	virtual void OnAttach();
+	virtual void OnDetach();
 
 	virtual void geometrychanged(const MCRectangle &p_rect);
 

--- a/engine/src/mbldc.cpp
+++ b/engine/src/mbldc.cpp
@@ -481,6 +481,9 @@ void MCScreenDC::refresh_window(Window p_window)
 		//   the need to only do OpenGL calls on the main thread.
         t_old_stack -> deactivatetilecache();
 		
+		// IM-2016-08-17: [[ Bug 18100 ]] Detach old stack from window
+		t_old_stack->OnDetach();
+		
 		m_current_window = nil;
 		m_current_focus = false;
 		m_mouse_x = -100000;
@@ -507,6 +510,9 @@ void MCScreenDC::refresh_window(Window p_window)
 		
 		if (!m_current_focus)
 			focus_window(p_window);
+		
+		// IM-2016-08-17: [[ Bug 18100 ]] Attach new stack to window
+		t_new_stack->OnAttach();
 		
 #ifdef _IOS_MOBILE
 		// MW-2012-03-05: [[ ViewStack ]] Make sure we tell the app's view

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -1244,6 +1244,18 @@ void MCObject::OnClose()
 		getNativeLayer()->OnDetach();
 }
 
+void MCObject::OnAttach()
+{
+	if (getNativeLayer() != nil)
+		getNativeLayer()->OnAttach();
+}
+
+void MCObject::OnDetach()
+{
+	if (getNativeLayer() != nil)
+		getNativeLayer()->OnDetach();
+}
+
 const MCRectangle& MCObject::getrect(void) const
 {
 	return rect;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -444,6 +444,12 @@ public:
 	virtual void OnOpen();
 	// IM-2015-12-16: [[ NativeWidgets ]] Informs the object that it will be closed.
 	virtual void OnClose();
+	
+	// IM-2016-08-16: [[ Bug 18153 ]] Inform the object that the stack has been attached to the window
+	virtual void OnAttach();
+	
+	// IM-2016-08-16: [[ Bug 18153 ]] Inform the object that the stack will be removed from the window
+	virtual void OnDetach();
     
 	// MW-2011-09-20: [[ Collision ]] Compute the shape of the object's mask.
 	virtual bool lockshape(MCObjectShape& r_shape);

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -563,7 +563,7 @@ MCStack::~MCStack()
 	if (window != NULL && !(state & CS_FOREIGN_WINDOW))
 	{
 		stop_externals();
-		MCscreen->destroywindow(window);
+		destroywindow();
 	}
 
 	while (controls != NULL)
@@ -803,7 +803,7 @@ void MCStack::close()
 		if (flags & F_DESTROY_WINDOW && MCdispatcher -> gethome() != this)
 		{
 			stop_externals();
-			MCscreen->destroywindow(window);
+			destroywindow();
 			window = NULL;
 			cursor = None;
 			MCValueAssign(titlestring, kMCEmptyString);
@@ -1491,7 +1491,7 @@ Exec_stat MCStack::handle(Handler_type htype, MCNameRef message, MCParameter *pa
 		{
 			// IM-2014-01-16: [[ StackScale ]] Ensure view has the current stack rect
 			view_setstackviewport(rect);
-			realize();
+			createwindow();
 		}
 	}
 
@@ -1562,6 +1562,18 @@ void MCStack::toolchanged(Tool p_new_tool)
 {
     if (curcard != NULL)
         curcard->toolchanged(p_new_tool);
+}
+
+void MCStack::OnAttach()
+{
+	if (curcard != nil)
+		curcard->OnAttach();
+}
+
+void MCStack::OnDetach()
+{
+	if (curcard != nil)
+		curcard->OnDetach();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -358,6 +358,9 @@ public:
 	virtual void recompute();
 	
     virtual void toolchanged(Tool p_new_tool);
+	
+	virtual void OnAttach();
+	virtual void OnDetach();
     
 	// MW-2011-09-20: [[ Collision ]] Compute shape of stack.
 	virtual bool lockshape(MCObjectShape& r_shape);
@@ -877,6 +880,9 @@ public:
 	// IM-2013-10-08: [[ FullscreenMode ]] Separate out window sizing hints
 	void setsizehints();
     
+	bool createwindow();
+	void destroywindow();
+	
 	void destroywindowshape();
     void updatewindowshape(MCWindowShape *shape);
 


### PR DESCRIPTION
This makes sure native layers are cleared when their objects are no longer visible.

This PR depends on #4371 
