### PR TITLE
[[ Documentation ]] Fixes to call.lcdoc

### DIFF
--- a/docs/dictionary/command/call.lcdoc
+++ b/docs/dictionary/command/call.lcdoc
@@ -5,7 +5,7 @@ Type: command
 Syntax: call <handlerName> [of <objectRef>]
 
 Summary:
-<execute|Executes> the specified <handler> in any <object|object's>
+<execute|Executes> the specified <handler> in any <object(glossary)|object's>
 <script>. 
 
 Introduced: 1.0
@@ -35,9 +35,9 @@ Use the <call> <command> to use a <handler> that's not in the normal
 <message path>.
 
 The <call> <command> sends a <handler> <message> to the 
-<object>. If the <script> of the <object> doesn't 
+<object(glossary)>. If the <script> of the <object(glossary)> doesn't 
 <trap> the <handler> <message>, the <message> is <pass|passed> to the 
-next <object> in the <object|object's> <message path>.
+next <object(glossary)> in the <object(glossary)|object's> <message path>.
 
 When executing a <handler> invoked by the <call> <command> the <defaultStack> 
 remains the same as it was when the <call> <command> was issued. Therefore 
@@ -48,7 +48,7 @@ from which the target <handler> was called.
 
 This differs from the <send> <command> which temporarily changes the 
 context so that <object reference|object references> are evaluated 
-in the context of the object containing the target <handler>.
+in the context of the <object(glossary)> containing the target <handler>.
 
 >*Tip:* If a <handler> contains complex <parameter|parameters>, 
 especially if some <parameter|parameters> contain 

--- a/docs/dictionary/command/call.lcdoc
+++ b/docs/dictionary/command/call.lcdoc
@@ -2,7 +2,7 @@ Name: call
 
 Type: command
 
-Syntax: call <handler> [of <object>]
+Syntax: call <handlerName> [of <objectRef>]
 
 Summary:
 <execute|Executes> the specified <handler> in any <object|object's>
@@ -21,13 +21,13 @@ Example:
 call "mouseUp" of button 1 of card 1
 
 Parameters:
-handler:
+handlerName:
 Any handler in the script of the specified object, along with
 any parameters that handler requires, separated by commas. The entire 
 handler including parameters must be enclosed in quotes.
 
-object:
-Any object reference. If no object is specified, LiveCode uses
+objectRef:
+Any <object reference>. If no object is specified, LiveCode uses
 the current object.
 
 Description:
@@ -35,20 +35,20 @@ Use the <call> <command> to use a <handler> that's not in the normal
 <message path>.
 
 The <call> <command> sends a <handler> <message> to the 
-<object(glossary)>. If the <script> of the <object(glossary)> doesn't 
+<object>. If the <script> of the <object> doesn't 
 <trap> the <handler> <message>, the <message> is <pass|passed> to the 
-next <object(glossary)> in the object's <message path>.
+next <object> in the <object|object's> <message path>.
 
-When executing a handler invoked by the call command the <defaultStack> 
-remains the same as it was when the call command was issued. Therefore 
-any object references in the called handler are evaluated in the
-context of the call command that invoked the handler.  For example,
+When executing a <handler> invoked by the <call> <command> the <defaultStack> 
+remains the same as it was when the <call> <command> was issued. Therefore 
+any <object reference|object references> in the called <handler> are evaluated 
+in the context of the <call> <command> that invoked the handler.  For example,
 button 3 may commonly refer to button 3 of the current card of the stack
-from which the target handler was called.
+from which the target <handler> was called.
 
 This differs from the <send> <command> which temporarily changes the 
-context so that object references are evaluated in the context of the 
-object containing the target handler.
+context so that <object reference|object references> are evaluated 
+in the context of the object containing the target <handler>.
 
 >*Tip:* If a <handler> contains complex <parameter|parameters>, 
 especially if some <parameter|parameters> contain 
@@ -56,11 +56,14 @@ especially if some <parameter|parameters> contain
 name and <parameter|parameters> into a <variable>, then use the name of 
 the <variable> in the <call> <statement>.
 
-References: do (command), send (command), insert script (command),
-start using (command), pass (control structure), value (function),
-params (function), object (glossary), trap (glossary),
-variable (glossary), handler (glossary), execute (glossary),
-pass (glossary), message path (glossary), message (glossary),
-statement (glossary), double quote (glossary), command (glossary),
-parameter (glossary), script (property), defaultStack (property)
+References: command (glossary), defaultStack (property), do (command), 
+double quote (glossary), execute (glossary), handler (glossary), 
+insert script (command), message (glossary), 
+message path (glossary), object (glossary), 
+object reference (glossary), parameter (glossary), 
+params (function), pass (control structure), pass (glossary), 
+script (property), send (command), start using (command), 
+statement (glossary), trap (glossary), value (function), 
+variable (glossary)
 
+Tags: messages


### PR DESCRIPTION
- Added links to referenced tokens.
- Added messages tag.
- Added object reference as reference item.
- Disambiguate handler and object params in syntax.
