### PR TITLE
[[ Documentation ]] Fixes to frontScripts.lcdoc

### DIFF
--- a/docs/dictionary/function/frontScripts.lcdoc
+++ b/docs/dictionary/function/frontScripts.lcdoc
@@ -17,7 +17,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-the frontScripts
+put the frontScripts
 
 Example:
 if myID is not among the lines of the frontScripts then insertMe
@@ -27,28 +27,29 @@ The <frontScripts> function returns a list of the long ID property of
 all objects that have been inserted into the front, one ID per line.
 
 Description:
-Use the <frontScripts> function to find out which scripts receive
-messages and function calls before the target object.
+Use the <frontScripts> function to find out which <script|scripts> receive
+<message|messages> and function calls before the target <object>.
 
-A script inserted into the front with the <insert script> command
-receives messages before all objects in the message path.
+A <script> inserted into the front with the <insert script> command
+receives <message|messages> before all objects in the <message path>.
 
-This includes messages sent with the <send> command, so if you send a
-message to an object, the objects in the <frontScripts> receive that
-message before the target object does. If the scripts in the
+This includes <message|messages> sent with the <send> command, so if you send a
+<message> to an <object>, the objects in the <frontScripts> receive that
+<message> before the target <object> does. If the scripts in the
 <frontScripts> do not use the <pass> control structure to pass on the
-message to the next object, the target object never receives the
-message. 
+<message> to the next <object>, the target <object> never receives the
+<message>. 
 
-If more than one object is in the <frontScripts>, their order in the
-message path is the same as their order in the list. For example, the
-first object in the <frontScripts> receives messages before the second
-object. This order is the reverse of the order in which the objects were
-added with the <insert script> command.
+If more than one <object> is in the <frontScripts>, their order in the
+<message path> is the same as their order in the list. For example, the
+first <object> in the <frontScripts> receives <message|messages> before 
+the second <object>. This order is the reverse of the order in which the 
+<object|objects> were added with the <insert script> command.
 
 References: remove script (command), insert script (command),
-send (command), pass (control structure), object (glossary),
-message path (glossary), return (glossary)
+message (glossary), pass (control structure), object (glossary),
+message path (glossary), return (glossary), send (command), 
+script (glossary)
 
-Tags: objects
+Tags: objects, messages
 

--- a/docs/dictionary/function/frontScripts.lcdoc
+++ b/docs/dictionary/function/frontScripts.lcdoc
@@ -46,10 +46,12 @@ first <object> in the <frontScripts> receives <message|messages> before
 the second <object>. This order is the reverse of the order in which the 
 <object|objects> were added with the <insert script> command.
 
-References: remove script (command), insert script (command),
-message (glossary), pass (control structure), object (glossary),
-message path (glossary), return (glossary), send (command), 
-script (glossary)
+References: backScripts (function), behavior (property), call (command), 
+dispatch (command), frontScript (glossary), insert script (command), 
+message (glossary), message path (glossary), object (glossary), 
+pass (control structure), remove script (command), return (glossary), 
+script (glossary), send (command), stacksInUse (property), 
+start using (command)
 
 Tags: objects, messages
 


### PR DESCRIPTION
- Added messages tag.
- Added script (glossary) and message (glossary) to references.
- Improved example.
- Added links to referenced tokens.
