### PR TITLE
[[ Documentation ]] Fixes to backScripts.lcdoc

### DIFF
--- a/docs/dictionary/function/backScripts.lcdoc
+++ b/docs/dictionary/function/backScripts.lcdoc
@@ -18,7 +18,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-the backScripts
+put the backScripts
 
 Example:
 if the long ID of me is not among the lines of the backScripts then beep
@@ -29,22 +29,24 @@ objects that have been inserted into the back, one ID per line.
 
 Description:
 Use the <backScripts> function to find out which scripts receive
-messages and function calls after the current object, the objects that
-own the current object, and any stacks in the stacksInUse.
+<message|messages> and function calls after the current <object>, the 
+<object|objects> that own the current <object>, and any stacks in 
+the <stacksInUse>.
 
-A script inserted into the back with the <insert script> command
-receives messages after all objects in the message path, just before the
-application itself receives the message.
+A <script> inserted into the back with the <insert script> command
+receives <message|messages> after all objects in the <message path>, 
+just before the application itself receives the <message>.
 
-If more than one object is in the <backScripts>, their order in the
-message path is the same as their order in the list. For example, the
-first object in the <backScripts> receives messages before the second
-object. This order is the reverse of the order in which the objects were
-added with the <insert script> command.
+If more than one <object> is in the <backScripts>, their order in the
+<message path> is the same as their order in the list. For example, the
+first <object> in the <backScripts> receives <message|messages> before 
+the second <object>. This order is the reverse of the order in which 
+the objects were added with the <insert script> command.
 
 References: remove script (command), insert script (command),
-object (glossary), message path (glossary), return (glossary),
-back (keyword), stack (object)
+message (glossary), pass (control structure), object (glossary),
+message path (glossary), return (glossary), send (command), 
+script (glossary), stacksInUse (property)
 
-Tags: objects
+Tags: objects, messages
 

--- a/docs/dictionary/function/backScripts.lcdoc
+++ b/docs/dictionary/function/backScripts.lcdoc
@@ -43,10 +43,13 @@ first <object> in the <backScripts> receives <message|messages> before
 the second <object>. This order is the reverse of the order in which 
 the objects were added with the <insert script> command.
 
-References: remove script (command), insert script (command),
-message (glossary), pass (control structure), object (glossary),
-message path (glossary), return (glossary), send (command), 
-script (glossary), stacksInUse (property)
+References: backScript (glossary), behavior (property), call (command), 
+dispatch(command), frontScripts (function), 
+insert script (command), message (glossary), 
+message path (glossary), object (glossary), 
+pass (control structure), remove script (command), 
+return (glossary), script (glossary), send (command), 
+stacksInUse (property), start using (command)
 
 Tags: objects, messages
 


### PR DESCRIPTION
- Added messages tag.
- Added stacksInUse (property), script (glossary) and message (glossary) to references.
- Improved example.
- Added links to referenced tokens.
