### PR TITLE
[[ Documentation ]] Fixes to lockMessages.lcdoc

### DIFF
--- a/docs/dictionary/property/lockMessages.lcdoc
+++ b/docs/dictionary/property/lockMessages.lcdoc
@@ -31,26 +31,26 @@ from being <trigger|triggered>,or to speed up operations when
 If the <lockMessages> <property> is set to true, the following are not
 sent: 
 
-        * Navigation messages (such as openCard, <closeStack>, and so
-          on) 
-        * Object creation messages (such as newCard, <newButton>, and so
-          on) 
+        * Navigation <message|messages> (such as openCard, <closeStack>, 
+        and so on) 
+        * Object creation <message|messages> (such as newCard, <newButton>, 
+        and so on) 
         * getProp calls
         * setProp triggers
 
 
-It is useful to set this property if a handler temporarily visits a card
-and you don't want the normal messages to be triggered.
+It is useful to set this property if a <handler> temporarily visits a card
+and you don't want the normal <message|messages> to be triggered.
 
 The <lockMessages> <property> is automatically set to false when a
 <palette>, <modeless>, or <modal> <stack> is opened, even if a <handler>
 is still running.
 
 References: reset (command), lock messages (command), modal (command),
-modeless (command), palette (command), property (glossary),
+modeless (command), message (glossary), palette (command), property (glossary),
 getProp call (glossary), built-in message (glossary), handler (glossary),
 setProp trigger (glossary), trigger (glossary), execute (glossary),
 newButton (message), closeStack (message), stack (object)
 
-Tags: objects
+Tags: objects, messages
 

--- a/docs/dictionary/property/lockMessages.lcdoc
+++ b/docs/dictionary/property/lockMessages.lcdoc
@@ -28,16 +28,14 @@ Use the <lockMessages> <property> to prevent unwanted <handler|handlers>
 from being <trigger|triggered>,or to speed up operations when
 <handler|handlers> that are normally run automatically are not needed.
 
-If the <lockMessages> <property> is set to true, the following are not
-sent: 
+If the <lockMessages> <property> is set to true, the following are not sent:  
 
-        * Navigation <message|messages> (such as openCard, <closeStack>, 
-        and so on) 
-        * Object creation <message|messages> (such as newCard, <newButton>, 
-        and so on) 
-        * getProp calls
-        * setProp triggers
-
+* Navigation <message|messages> (such as openCard, <closeStack>, 
+and so on) 
+* Object creation <message|messages> (such as newCard, <newButton>, 
+and so on) 
+* getProp calls
+* setProp triggers
 
 It is useful to set this property if a <handler> temporarily visits a card
 and you don't want the normal <message|messages> to be triggered.


### PR DESCRIPTION
- Added messages tag.
- Added terms to references.
- Added links to referenced tokens.
