### PR TITLE
[[ Documentation ]] Fixes to defaultFolder.lcdoc

### DIFF
--- a/docs/dictionary/property/defaultFolder.lcdoc
+++ b/docs/dictionary/property/defaultFolder.lcdoc
@@ -17,10 +17,10 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-set the defaultFolder to "/Applications/GetIt" --MacOS, Linux-style file path"
+set the defaultFolder to "/Applications/GetIt" --MacOS, Linux-style file path
 
 Example:
-set the defaultFolder to "c:/Program Files/GetIt" -- Windows-style file path
+set the defaultFolder to "C:/Program Files/GetIt" -- Windows-style file path
 
 Example:
 # set the defaultFolder to the folder containing the stackfile

--- a/docs/dictionary/property/defaultFolder.lcdoc
+++ b/docs/dictionary/property/defaultFolder.lcdoc
@@ -17,13 +17,20 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-set the defaultFolder to "/Hard Disk/Applications/GetIt"
+set the defaultFolder to "/Applications/GetIt" --MacOS, Linux-style file path"
 
 Example:
-set the defaultFolder to it
+set the defaultFolder to "c:/Program Files/GetIt" -- Windows-style file path
+
+Example:
+# set the defaultFolder to the folder containing the stackfile
+set the itemDelimiter to slash
+get the effective filename of this stack
+set the defaultFolder to item 1 to -2 of it
+
 
 The result:
-If you set the <defaultFolder> to a <folder> that doesn't exist, the
+If you set the <defaultFolder> to a <folder(glossary)> that doesn't exist, the
 <result> is set to "can't open directory" and the <value> of the
 <defaultFolder> does not change.
 
@@ -36,14 +43,14 @@ the application resides in, however this is not always the case and
 shouldn't be relied on. It is best always to set the <defaultFolder>
 before using relative paths.
 
-When you start up the application via a file association (eg by
+When you start up the application via a file association (e.g. by
 launching a document you have chosen to link to your application using
 "Open With..." on Windows or by dragging the document onto the
-application icon on OS X ) then the defaultFolder is set to the folder
-containing the document being launched.
+application icon on OS X ) then the <defaultFolder> is set to the 
+<folder> containing the document being launched.
 
 Description:
-Use the <defaultFolder> to perform <file> manipulations on <files> in
+Use the <defaultFolder> to perform <file> manipulations on <file|files> in
 the same <folder> without having to include the <absolute file path|full
 path>. 
 
@@ -52,7 +59,8 @@ the <current folder|current directory> when resolving <relative file
 path|relative paths> (except for <relative file path|relative paths>
 specified in the <stackFiles> <property>).
 
-If you specify a file without giving its full path, LiveCode looks for
+If you specify a <file> without giving its 
+<absolute file path|full path>, LiveCode looks for
 the file in the <defaultFolder>. If you specify a <relative file
 path|relative path>, the <defaultFolder> is <prepend|prepended> to it to
 create the <absolute file path|full path>.
@@ -65,14 +73,15 @@ You cannot delete the current <defaultFolder>.
 > paths> (starting with a disk or partition name) must begin with a "/"
 > character. 
 
-References: create alias (command), revSetDatabaseDriverPath (command),
-result (function), files (function), folders (function),
-file path (glossary), property (glossary), function (glossary),
-command (glossary), prepend (glossary), Windows (glossary),
-relative file path (glossary), absolute file path (glossary),
-current folder (glossary), Unix (glossary), value (glossary),
-Mac OS (glossary), folder (glossary), string (keyword), file (keyword),
-stackFiles (property)
+References: absolute file path (glossary), command (glossary), 
+create alias (command), current folder (glossary), effective (keyword), 
+file (glossary), file path (glossary), files (function), folder (glossary),
+folders (function), function (glossary), it (keyword), item (keyword),
+itemDelimiter (property), Mac OS (glossary), prepend (glossary),
+property (glossary), relative file path (glossary), result (function),
+revSetDatabaseDriverPath (command), slash (constant), 
+stackFiles (property), string (glossary), Unix (glossary), 
+value (glossary), Windows (glossary)
 
 Tags: file system
 

--- a/docs/notes/bugfix-7214.md
+++ b/docs/notes/bugfix-7214.md
@@ -1,0 +1,1 @@
+# Examples in dictionary entries referring to file paths should be updated 


### PR DESCRIPTION
- Improved examples to better reflect modern file path examples. (Old example most similar to Classic Mac OS.)
- Changed some referenced tokens. 
- Added and fixed linked text.
- Added missing references.
