### PR TITLE
[[ Bug 18220 ]] Use Mac module interface folder in Windows installer

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -423,7 +423,9 @@ component Toolchain.Windows
 	into [[ToolsFolder]]/Toolchain place
 		executable windows:lc-compile.exe as lc-compile.exe
 		executable windows:lc-run.exe as lc-run.exe
-		rfolder windows:modules
+		// Temporarily use the mac interface files until they are 
+		// all generated correctly on windows.
+		rfolder macosx:modules
 
 component Toolchain.Linux
 	into [[ToolsFolder]]/Toolchain place

--- a/docs/notes/bugfix-18220.md
+++ b/docs/notes/bugfix-18220.md
@@ -1,0 +1,1 @@
+# Ensure all relevant LCB interface files are present in IDE


### PR DESCRIPTION
The unzip command appears to be failing when unpackaging modules on
Windows, which is causing the interface files not to be copied to the
expected location. Temporarily use the Mac version of the folder for
the purpose (as the interface files are not currently platform-specific).
