### PR TITLE
[[ Community Docs ]] added defaultFolder help

### DIFF
--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -37,6 +37,7 @@ Example:
 go invisible stack "Preferences"
 
 Example:
+local tStackFile, tStackFolder
 put the effective filename of me into tStackFile
 set the itemDelimiter to "/"
 put item 1 to -2 of tStackFile into tStackFolder

--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -36,6 +36,13 @@ go back 7
 Example:
 go invisible stack "Preferences"
 
+Example:
+put the filename of me into tStackFile
+set the itemDelimiter to "/"
+put item 1 to -2 of tStackFile into tStackFolder
+set the defaultFolder to tStackFolder
+go stack somethingElse.livecode
+
 Parameters:
 card:
 Any card reference. Cards can be described by their name, number, or ID
@@ -81,6 +88,10 @@ by name:
 go stack "My Stack"
 
 Otherwise, you must include the stack's file path.
+
+If you don't include a file path the <go> command will look in
+the defaultFolder. If you're in the IDE (not a standalone) the
+defaultFolder will probably start off as a system folder.
 
 When going to a previously-unopened stack, if you don't specify a card,
 the <go> command displays the first card of the stack. If the stack is

--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -37,11 +37,12 @@ Example:
 go invisible stack "Preferences"
 
 Example:
-put the filename of me into tStackFile
+put the effective filename of me into tStackFile
 set the itemDelimiter to "/"
 put item 1 to -2 of tStackFile into tStackFolder
 set the defaultFolder to tStackFolder
-go stack somethingElse.livecode
+go stack "somethingElse.livecode"
+-- "somethingElse" being the name of a stack file in the same folder
 
 Parameters:
 card:
@@ -89,9 +90,8 @@ go stack "My Stack"
 
 Otherwise, you must include the stack's file path.
 
-If you don't include a file path the <go> command will look in
-the defaultFolder. If you're in the IDE (not a standalone) the
-defaultFolder will probably start off as a system folder.
+If the specified file path is relative, the <go> command
+will look in the <defaultFolder>.
 
 When going to a previously-unopened stack, if you don't specify a card,
 the <go> command displays the first card of the stack. If the stack is
@@ -178,7 +178,7 @@ push (command), previous (keyword), recent (keyword), as (keyword),
 card (keyword), stack (object), lockRecent property (property),
 lockScreen (property), lockScreen property (property),
 HCImportStat (property), visible property (property),
-defaultStack (property)
+defaultStack (property), defaultFolder (property)
 
 Tags: navigation
 


### PR DESCRIPTION
- I got hung up for hours because I didn't think of "go" using the defaultFolder
- now there's a little code snippet that will ensure the defaultFolder is set to the stack's folder
- it also can be easily modified in other ways
