### PR TITLE
[bug 18111] Make PDF user guide typography match dictionary view

### DIFF
--- a/builder/user-guide-template.html
+++ b/builder/user-guide-template.html
@@ -563,9 +563,9 @@ Author URI: http://www.livecode.com/
 a{ text-decoration:none; color:#799327; } /* aecf36 */
 a:hover{ color:#585858}
 
-h1,h2,h3,h4{ font-family:FontAwesome; font-style:normal; font-weight:normal}
-h1{ font-weight:normal}
-h2{ margin:2em 0 0.5em 0; font-weight:normal}
+h1,h2,h3,h4{ font-family:FontAwesome; font-style:normal; font-weight:bold}
+h1{ font-weight:bold}
+h2{ margin:2em 0 0.5em 0; font-weight:bold}
 h3{ margin:1.5em 0 0.1em 0}
 p{ font-size:13px;line-height:135%}
 

--- a/docs/notes/bugfix-18111.md
+++ b/docs/notes/bugfix-18111.md
@@ -1,0 +1,1 @@
+[bug 18111] Make PDF user guide typography match dictionary view

--- a/docs/notes/bugfix-18111.md
+++ b/docs/notes/bugfix-18111.md
@@ -1,1 +1,1 @@
-[bug 18111] Make PDF user guide typography match dictionary view
+# Make PDF user guide typography match dictionary view


### PR DESCRIPTION
The weight of the heading styles changed from "normal" to "bold" to match the appearance of the guides when viewed in the dictionary.
