### PR TITLE
Revert "[Bug 18220] Use Mac module interface folder in Win installer"

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -423,9 +423,7 @@ component Toolchain.Windows
 	into [[ToolsFolder]]/Toolchain place
 		executable windows:lc-compile.exe as lc-compile.exe
 		executable windows:lc-run.exe as lc-run.exe
-		// Temporarily use the mac interface files until they are 
-		// all generated correctly on windows.
-		rfolder macosx:modules
+		rfolder windows:modules
 
 component Toolchain.Linux
 	into [[ToolsFolder]]/Toolchain place


### PR DESCRIPTION
This reverts commit b5a720814113.  Now that the `unzip` command is
available in the Windows build container, it should be possible to use
the Windows modules in the Windows installers.
