### PR TITLE
[[ Documentation ]] Format fix in defaultFolder.lcdoc

### DIFF
--- a/docs/dictionary/property/defaultFolder.lcdoc
+++ b/docs/dictionary/property/defaultFolder.lcdoc
@@ -69,9 +69,9 @@ You cannot delete the current <defaultFolder>.
 
 >*Important:*  The <folderPath> is specified using <Unix> conventions,
 > even on <Mac OS> and <Windows> systems. The names of <folder|folders>
-> are separated with a "/" character, and <absolute file path|absolute
-> paths> (starting with a disk or partition name) must begin with a "/"
-> character. 
+> are separated with a "/" character, 
+> and <absolute file path|absolute paths> (starting with a disk or 
+> partition name) must begin with a "/" character. 
 
 References: absolute file path (glossary), command (glossary), 
 create alias (command), current folder (glossary), effective (keyword), 


### PR DESCRIPTION
Wrapping a reference link inside a block quote broke the link in the rendered dictionary entry. Rewrapped to avoid this problem.
