### PR TITLE
[[ Bugfix 18282 ]] Prevent a crash after deleting a shared background group

### DIFF
--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -40,6 +40,7 @@
 		'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',
 		'COPY_PHASE_STRIP': 'NO',
 		'STRIP_INSTALLED_PRODUCT': 'NO',
+		'CLANG_CXX_LANGUAGE_STANDARD': 'c++0x',
 		
 		'CODE_SIGN_IDENTITY[sdk=iphoneos*]': 'iPhone Developer',
 	},

--- a/docs/notes/bugfix-18282.md
+++ b/docs/notes/bugfix-18282.md
@@ -1,0 +1,1 @@
+# Fix a crash after deleting a shared background group

--- a/engine/src/aclip.h
+++ b/engine/src/aclip.h
@@ -39,6 +39,12 @@ enum Audio_format {
 
 class MCAudioClip : public MCObject
 {
+public:
+    
+    enum { kObjectType = CT_AUDIO_CLIP };
+    
+private:
+    
 	friend class MCHcsnd;
 	uint4 size;
 	int1 *samples;

--- a/engine/src/button.h
+++ b/engine/src/button.h
@@ -105,6 +105,12 @@ class ButtonMenuCallback;
 
 class MCButton : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_BUTTON };
+    
+private:
+    
 	friend class MCHcbutton;
 	MCCdata *bdata;
 	iconlist *icons;
@@ -156,8 +162,6 @@ class MCButton : public MCControl
     bool m_animate_posted : 1;
 
 public:
-    
-    enum { kObjectType = CT_BUTTON };
     
 	MCButton();
 	MCButton(const MCButton &bref);

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -2679,12 +2679,13 @@ void MCCard::clean()
 	do
 	{
 		check = False;
-		MCControl *control = tptr->getref();
+		MCObjectHandle control = tptr->Get();
 		MCObjptr *ntptr = tptr->next();
-		if (control == NULL)
+        
+        // If the control has been deleted, remove it from the object list
+		if (!control.IsValid())
 		{
-			tptr->remove
-			(objptrs);
+			tptr->remove(objptrs);
 			delete tptr;
 			if (objptrs == NULL)
 				break;

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -22,7 +22,13 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 class MCCard : public MCObject
 {
 	friend class MCHccard;
+public:
+    
+    enum { kObjectType = CT_CARD };
+	
 protected:
+    
+    friend class MCHccard;
 	MCObjptr *objptrs;
 	MCObjptr *kfocused;
 	MCObjptr *oldkfocused;

--- a/engine/src/cpalette.h
+++ b/engine/src/cpalette.h
@@ -24,7 +24,14 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 class MCColors : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_COLOR_PALETTE };
+    
+private:
+    
 	uint4 selectedcolor;
+    
 public:
 	MCColors();
 	MCColors(const MCColors &cref);

--- a/engine/src/desktop-dc.cpp
+++ b/engine/src/desktop-dc.cpp
@@ -912,7 +912,7 @@ void MCScreenDC::flushevents(uint2 e)
 	else if (e == FE_KEYUP)
 		t_mask = kMCPlatformEventKeyUp;
 	
-	if (t_mask != nil)
+	if (t_mask != 0)
 		MCPlatformFlushEvents(t_mask);
 }
 

--- a/engine/src/eps.h
+++ b/engine/src/eps.h
@@ -24,6 +24,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 class MCEPS : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_EPS };
+    
+private:
+    
 	uint4 size;
 	char *postscript;
 	char *prolog;

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -3772,7 +3772,7 @@ void MCInterfaceDoRelayer(MCExecContext& ctxt, int p_relation, MCObjectPtr p_sou
 		MCObjectHandle t_source_handle, t_new_owner_handle, t_new_target_handle;
 		t_source_handle = p_source . object -> GetHandle();
 		t_new_owner_handle = t_new_owner -> GetHandle();
-		t_new_target_handle = t_new_target != NULL ? t_new_target -> GetHandle() : MCObjectHandle(NULL);
+		t_new_target_handle = t_new_target != nil ? t_new_target -> GetHandle() : nil;
         
 		// Make sure we remove focus from the control.
 		bool t_was_mfocused, t_was_kfocused;

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -194,6 +194,12 @@ enum MCFieldStylingMode
 
 class MCField : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_FIELD };
+    
+private:
+    
 	friend class MCHcfield;
 	MCCdata *fdata;
 	MCCdata *oldfdata;
@@ -263,8 +269,6 @@ class MCField : public MCControl
 	static MCPropertyInfo kProperties[];
 	static MCObjectPropertyTable kPropertyTable;
 public:
-
-    enum { kObjectType = CT_FIELD };
     
     // SN-2014-11-04: [[ Bug 13934 ]] Refactor the laying out the field when setting properties
     friend MCParagraph* PrepareLayoutSettings(bool all, MCField *p_field, uint32_t p_part_id, findex_t &si, findex_t &ei, MCFieldLayoutSettings &r_layout_settings);

--- a/engine/src/graphic.h
+++ b/engine/src/graphic.h
@@ -43,6 +43,12 @@ enum
 
 class MCGraphic : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_GRAPHIC };
+    
+private:
+    
 	uint2 linesize;
 	uint2 angle;
 	uint2 startangle;

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -26,6 +26,12 @@ class MCScrollbar;
 
 class MCGroup : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_GROUP };
+
+private:
+    
 	friend class MCHcbkgd;
 	friend class MCHcstak;
 	MCControl *controls;

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -304,6 +304,12 @@ private:
 
 class MCImage : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_IMAGE };
+
+private:
+    
 	friend class MCHcbmap;
 	
 	MCImageRep *m_rep;

--- a/engine/src/mac-qt-player.mm
+++ b/engine/src/mac-qt-player.mm
@@ -264,8 +264,8 @@ MCQTKitPlayer::~MCQTKitPlayer(void)
 	
     // MW-2014-07-16: [[ Bug 12506 ]] Make sure we unhook the callbacks before releasing (it
     //   seems it takes a while for QTKit to actually release the objects!).
-    MCSetActionFilterWithRefCon([m_movie quickTimeMovieController], nil, nil);
-    SetMovieDrawingCompleteProc([m_movie quickTimeMovie], movieDrawingCallAlways, nil, nil);
+    MCSetActionFilterWithRefCon([m_movie quickTimeMovieController], nil, 0);
+    SetMovieDrawingCompleteProc([m_movie quickTimeMovie], movieDrawingCallAlways, nil, 0);
     
     [[NSNotificationCenter defaultCenter] removeObserver: m_observer];
     [m_observer release];
@@ -401,7 +401,7 @@ void MCQTKitPlayer::DoSwitch(void *ctxt)
 			t_player -> m_current_frame = nil;
 		}
 
-		SetMovieDrawingCompleteProc([t_player -> m_movie quickTimeMovie], movieDrawingCallAlways, nil, nil);
+		SetMovieDrawingCompleteProc([t_player -> m_movie quickTimeMovie], movieDrawingCallAlways, nil, 0);
         
 		// Switching to non-offscreen
 		t_player -> m_offscreen = t_player -> m_pending_offscreen;
@@ -527,8 +527,8 @@ void MCQTKitPlayer::Load(MCStringRef p_filename, bool p_is_url)
     m_has_invalid_filename = false;
 	
     // MW-2014-07-18: [[ Bug ]] Clean up callbacks before we release.
-    MCSetActionFilterWithRefCon([m_movie quickTimeMovieController], nil, nil);
-    SetMovieDrawingCompleteProc([m_movie quickTimeMovie], movieDrawingCallAlways, nil, nil);
+    MCSetActionFilterWithRefCon([m_movie quickTimeMovieController], nil, 0);
+    SetMovieDrawingCompleteProc([m_movie quickTimeMovie], movieDrawingCallAlways, nil, 0);
 	[m_movie release];
     
     // PM-2014-09-02: [[ Bug 13306 ]] Make sure we reset the previous value of loadedtime when loading a new movie

--- a/engine/src/magnify.h
+++ b/engine/src/magnify.h
@@ -24,6 +24,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 class MCMagnify : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_MAGNIFY };
+    
 protected:
 	uint2 inside;
 public:

--- a/engine/src/mblandroidstore.cpp
+++ b/engine/src/mblandroidstore.cpp
@@ -274,7 +274,7 @@ void MCPurchaseGetPurchaseDate(MCExecContext& ctxt,MCPurchase *p_purchase, integ
 {
     MCAndroidPurchase *t_android_data = (MCAndroidPurchase*)p_purchase->platform_data;
     
-    if (t_android_data->purchase_time != nil)
+    if (t_android_data->purchase_time != 0)
     {
         r_date = (integer_t)(t_android_data->purchase_time);
         return;

--- a/engine/src/mbliphonebusyindicator.mm
+++ b/engine/src/mbliphonebusyindicator.mm
@@ -115,7 +115,7 @@ static com_runrev_livecode_MCBusyIndicator *s_busy_indicator = nil;
     // Create the text
     m_label = [[UILabel alloc] initWithFrame:CGRectMake (10, t_busy_size.height - 85, t_busy_size.width - 20, 70)];
     m_label.textColor = [UIColor whiteColor];
-    m_label.textAlignment = UITextAlignmentCenter;
+    m_label.textAlignment = NSTextAlignmentCenter;
     
     // PM-2015-03-16: [[ Bug 14946 ]] Allow up to 3 lines for the text
     m_label.numberOfLines = 3;

--- a/engine/src/mbliphoneinput.mm
+++ b/engine/src/mbliphoneinput.mm
@@ -351,9 +351,9 @@ static MCNativeControlEnumEntry s_contenttype_enum[] =
 
 static MCNativeControlEnumEntry s_textalign_enum[] =
 { 
-	{"left", UITextAlignmentLeft},
-	{"right", UITextAlignmentRight},
-	{"center", UITextAlignmentCenter},
+	{"left", NSTextAlignmentLeft},
+	{"right", NSTextAlignmentRight},
+	{"center", NSTextAlignmentCenter},
 	{nil, 0}
 };
 
@@ -614,18 +614,18 @@ void MCiOSInputControl::SetTextAlign(MCExecContext& ctxt, MCNativeControlInputTe
     
     if (t_field)
     {
-        UITextAlignment t_align;
+        NSTextAlignment t_align;
         
         switch (p_align)
         {
             case kMCNativeControlInputTextAlignCenter:
-                t_align = UITextAlignmentCenter;
+                t_align = NSTextAlignmentCenter;
                 break;
             case kMCNativeControlInputTextAlignLeft:
-                t_align = UITextAlignmentLeft;
+                t_align = NSTextAlignmentLeft;
                 break;
             case kMCNativeControlInputTextAlignRight:
-                t_align = UITextAlignmentRight;
+                t_align = NSTextAlignmentRight;
                 break; 
         }
         [t_field setTextAlignment: t_align];
@@ -889,13 +889,13 @@ void MCiOSInputControl::GetTextAlign(MCExecContext& ctxt, MCNativeControlInputTe
     {
         switch ([t_field textAlignment])
         {
-            case UITextAlignmentCenter:
+            case NSTextAlignmentCenter:
                 r_align = kMCNativeControlInputTextAlignCenter;
                 return;
-            case UITextAlignmentLeft:
+            case NSTextAlignmentLeft:
                 r_align = kMCNativeControlInputTextAlignLeft;
                 return;
-            case UITextAlignmentRight:
+            case NSTextAlignmentRight:
                 r_align = kMCNativeControlInputTextAlignRight;
                 return;
         }

--- a/engine/src/mbliphonestore.mm
+++ b/engine/src/mbliphonestore.mm
@@ -1050,19 +1050,19 @@ void MCStoreProductRequestResponseEvent::Dispatch()
                      && MCArrayStoreValue(*t_array, kMCCompareCaseless, *t_currency_symbol_key, *t_currency_symbol));
     }
     
-    if (t_success && *t_unicode_description != nil)
+    if (t_success && *t_unicode_description != 0)
     {
         t_success = (MCNameCreateWithCString("unicode description", &t_unicode_description_key)
                      && MCArrayStoreValue(*t_array, kMCCompareCaseless, *t_unicode_description_key, *t_utf16_description));
     }
     
-    if (t_success && *t_unicode_title != nil)
+    if (t_success && *t_unicode_title != 0)
     {
         t_success = (MCNameCreateWithCString("unicode title", &t_unicode_title_key)
                      && MCArrayStoreValue(*t_array, kMCCompareCaseless, *t_unicode_title_key, *t_utf16_title));
     }
     
-    if (t_success && *t_unicode_currency_symbol != nil)
+    if (t_success && *t_unicode_currency_symbol != 0)
     {
         t_success = (MCNameCreateWithCString("unicode currency symbol", &t_unicode_currency_symbol_key)
                      && MCArrayStoreValue(*t_array, kMCCompareCaseless, *t_unicode_currency_symbol_key, *t_utf16_currency_symbol));

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -369,12 +369,13 @@ public:
 
 
 // MCControl has lots of derived classes so this (fragile!) specialisation is
-// needed to account for them.
+// needed to account for them. It depends on the correctness of the CT_x_CONTROL
+// enum values (i.e everything within that range must derive from MCControl).
 template <>
 inline MCControl* MCObjectCast<MCControl>(MCObject* p_object)
 {
     Chunk_term t_type = p_object->gettype();
-    MCAssert(t_type != CT_UNDEFINED && t_type != CT_STACK && t_type != CT_CARD && t_type != CT_AUDIO_CLIP && t_type != CT_VIDEO_CLIP);
+    MCAssert(t_type >= CT_FIRST_CONTROL && t_type <= CT_LAST_CONTROL);
     return static_cast<MCControl*> (p_object);
 }
 

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -374,7 +374,7 @@ template <>
 inline MCControl* MCObjectCast<MCControl>(MCObject* p_object)
 {
     Chunk_term t_type = p_object->gettype();
-    MCAssert(t_type != CT_UNDEFINED && t_type != CT_STACK && t_type != CT_CARD);
+    MCAssert(t_type != CT_UNDEFINED && t_type != CT_STACK && t_type != CT_CARD && t_type != CT_AUDIO_CLIP && t_type != CT_VIDEO_CLIP);
     return static_cast<MCControl*> (p_object);
 }
 

--- a/engine/src/native-layer-win32.cpp
+++ b/engine/src/native-layer-win32.cpp
@@ -308,9 +308,9 @@ MCNativeLayer* MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_view
 extern HINSTANCE MChInst;
 bool getcontainerclass(ATOM &r_class)
 {
-	static ATOM s_container_class = nil;
+	static ATOM s_container_class = 0;
 
-	if (s_container_class == nil)
+	if (s_container_class == 0)
 	{
 		WNDCLASSEX t_class;
 		MCMemoryClear(t_class);
@@ -325,7 +325,7 @@ bool getcontainerclass(ATOM &r_class)
 		DWORD t_err;
 		t_err = GetLastError();
 
-		if (s_container_class == nil)
+		if (s_container_class == 0)
 			return false;
 	}
 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4242,7 +4242,7 @@ MCImage *MCObject::resolveimagename(MCStringRef p_name)
 	return resolveimage(p_name, 0);
 }
 
-MCObjectHandle MCObject::GetHandle(void)
+MCObjectHandle MCObject::GetHandle(void) const
 {
 	if (m_weak_proxy == NULL)
 	{
@@ -5342,9 +5342,9 @@ bool MCObjectVisitor::OnBlock(MCBlock *p_block)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-MCObjectProxy::MCObjectProxy(MCObject *p_object) :
-  m_object(p_object),
-  m_refcount(0)
+MCObjectProxy::MCObjectProxy(const MCObject *p_object) :
+  m_refcount(0),
+  m_object(const_cast<MCObject*>(p_object))
 {
 }
 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4248,7 +4248,7 @@ MCObjectHandle MCObject::GetHandle(void) const
 	{
 		m_weak_proxy = new MCObjectProxy(this);
         if (!m_weak_proxy)
-            return MCObjectHandle(NULL);
+            return nil;
 	}
 
 	return MCObjectHandle(m_weak_proxy);

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -230,7 +230,7 @@ public:
     {
     }
     
-    explicit Handle(MCObjectProxy* p_proxy) :
+    Handle(MCObjectProxy* p_proxy) :
       m_proxy(nullptr)
     {
         Set(p_proxy);

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -185,6 +185,10 @@ struct MCObjectVisitor
 #define OBJECT_EXTRA_THEME_INFO     (1U << 5)       // "theme" and/or "themeClass" properties are present
 
 
+// Forward declaration of MCObjectCast safe-casting utility function
+template <typename T>
+inline T* MCObjectCast(MCObject*);
+
 // Proxy allowing for weak references to MCObjects
 class MCObjectProxy
 {
@@ -1405,6 +1409,13 @@ T* MCObjectCast(MCObject* p_object)
     // type. This will break horribly if the desired type has derived types...
     MCAssert(p_object->gettype() == T::kObjectType);
     return static_cast<T*> (p_object);
+}
+
+// Casting to an MCObject* is always safe
+template <>
+inline MCObject* MCObjectCast<MCObject>(MCObject* p_object)
+{
+    return p_object;
 }
 
 

--- a/engine/src/objptr.cpp
+++ b/engine/src/objptr.cpp
@@ -91,7 +91,12 @@ MCObjectHandle MCObjptr::Get()
 
 MCControl* MCObjptr::getref()
 {
-    return Get().GetAs<MCControl>();
+    // A number of callers expect this method to return null when not valid
+    MCObjectHandle t_handle = Get();
+    if (!Get().IsValid())
+        return nullptr;
+    
+    return t_handle.GetAs<MCControl>();
 }
 
 void MCObjptr::setref(MCControl *optr)

--- a/engine/src/objptr.cpp
+++ b/engine/src/objptr.cpp
@@ -29,11 +29,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "util.h"
 
-MCObjptr::MCObjptr()
+MCObjptr::MCObjptr() :
+  m_id(0),
+  m_objptr(nullptr),
+  m_parent(nullptr)
 {
-	id = 0;
-	parent = NULL;
-	objptr = NULL;
 }
 
 MCObjptr::~MCObjptr()
@@ -42,12 +42,16 @@ MCObjptr::~MCObjptr()
 
 bool MCObjptr::visit(MCObjectVisitorOptions p_options, uint32_t p_part, MCObjectVisitor *p_visitor)
 {
-	return getref() -> visit(p_options, p_part, p_visitor);
+    // Skip this node if the reference has been broken
+    if (!Get().IsValid())
+        return true;
+    
+    return Get()->visit(p_options, p_part, p_visitor);
 }
 
 IO_stat MCObjptr::load(IO_handle stream)
 {
-	return checkloadstat(IO_read_uint4(&id, stream));
+	return checkloadstat(IO_read_uint4(&m_id, stream));
 }
 
 IO_stat MCObjptr::save(IO_handle stream, uint4 p_part)
@@ -55,40 +59,69 @@ IO_stat MCObjptr::save(IO_handle stream, uint4 p_part)
 	IO_stat stat;
 	if ((stat = IO_write_uint1(OT_PTR, stream)) != IO_NORMAL)
 		return stat;
-	return IO_write_uint4(id, stream);
+	return IO_write_uint4(m_id, stream);
 }
 
 void MCObjptr::setparent(MCObject *newparent)
 {
-	parent = newparent;
+    // Assumption: the new parent is a valid object pointer
+    MCAssert(newparent != nullptr);
+    
+    // Assumption: this pointer is still valid given the new parent
+    // (i.e the re-parenting isn't to a completely unrelated object)
+    //
+    // This is a relatively expensive assertion to check so should only be
+    // enabled in debug builds.
+    MCAssert(!m_objptr.IsBound() || newparent->getstack()->getcontrolid(CT_LAYER, m_id) == m_objptr);
+    
+    m_parent = newparent;
 }
 
-MCControl *MCObjptr::getref()
+MCObjectHandle MCObjptr::Get()
 {
-	if (objptr == NULL)
-		return (objptr = (parent->getstack())->getcontrolid(CT_LAYER, id));
-	else
-		return objptr;
+    // If the object pointer hasn't yet been bound, resolve it using the ID
+    if (!m_objptr.IsBound())
+    {
+        // Note that this may return null if the control doesn't exist
+        m_objptr = m_parent->getstack()->getcontrolid(CT_LAYER, m_id);
+    }
+    
+    return m_objptr;
+}
+
+MCControl* MCObjptr::getref()
+{
+    return Get().GetAs<MCControl>();
 }
 
 void MCObjptr::setref(MCControl *optr)
 {
-	objptr = optr;
-	id = objptr->getid();
+    // Assumption: the new control is a valid control pointer
+    MCAssert(optr != nullptr);
+    
+    // Store a handle to the control so we don't have a dangling pointer should
+    // the referent be deleted (shared background groups can cause this to
+    // happen as the group isn't "really" a child of each card it is on)
+    m_objptr = optr;
+    
+    // Store the ID too as it is what is stored when serialising this pointer
+    m_id = m_objptr->getid();
 }
 
 void MCObjptr::clearref()
 {
-	objptr = NULL;
+    // Note that this doesn't reset the ID
+    m_objptr = nullptr;
 }
 
 uint4 MCObjptr::getid()
 {
-	return id;
+	return m_id;
 }
 
 void MCObjptr::setid(uint4 newid)
 {
-	id = newid;
-	objptr = NULL;
+    // Update the stored ID. The object pointer will only be bound when needed.
+    m_objptr = nullptr;
+    m_id = newid;
 }

--- a/engine/src/objptr.h
+++ b/engine/src/objptr.h
@@ -21,16 +21,24 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define	OBJPTR_H
 
 #include "dllst.h"
+#include "object.h"
+#include "mccontrol.h"
+#include "group.h"
 
 class MCObjptr : public MCDLlist
 {
-protected:
-	uint4 id;
-	MCControl *objptr;
-	MCObject *parent;
+private:
+    
+	uint32_t            m_id;
+	MCObjectHandle      m_objptr;
+	MCObjectHandle      m_parent;
+    
 public:
+    
+    MCDLlistAdaptorFunctions(MCObjptr)
+    
 	MCObjptr();
-	virtual ~MCObjptr();
+	~MCObjptr();
 
 	bool visit(MCObjectVisitorOptions p_options, uint32_t p_part, MCObjectVisitor* p_visitor);
 
@@ -38,53 +46,21 @@ public:
 	IO_stat save(IO_handle stream, uint4 p_part);
 	void setparent(MCObject *newparent);
 	MCControl *getref();
+    MCObjectHandle Get();
 	void setref(MCControl *optr);
 	void clearref();
-	uint4 getid();
-	void setid(uint4 id);
+	uint32_t getid();
+	void setid(uint32_t id);
 
 	// MW-2011-08-08: [[ Groups ]] Returns the referenced object as an MCGroup
 	//   or nil, if it isn't a group.
 	MCGroup *getrefasgroup(void)
 	{
-		MCObject *t_group;
-		t_group = (MCObject *)getref();
-		if (t_group -> gettype() != CT_GROUP)
-			return NULL;
-		return (MCGroup *)t_group;
-	}
-
-	MCObjptr *next()
-	{
-		return (MCObjptr *)MCDLlist::next();
-	}
-	MCObjptr *prev()
-	{
-		return (MCObjptr *)MCDLlist::prev();
-	}
-	void totop(MCObjptr *&list)
-	{
-		MCDLlist::totop((MCDLlist *&)list);
-	}
-	void insertto(MCObjptr *&list)
-	{
-		MCDLlist::insertto((MCDLlist *&)list);
-	}
-	void appendto(MCObjptr *&list)
-	{
-		MCDLlist::appendto((MCDLlist *&)list);
-	}
-	void append(MCObjptr *node)
-	{
-		MCDLlist::append((MCDLlist *)node);
-	}
-	void splitat(MCObjptr *node)
-	{
-		MCDLlist::splitat((MCDLlist *)node) ;
-	}
-	MCObjptr *remove(MCObjptr *&list)
-	{
-		return (MCObjptr *)MCDLlist::remove((MCDLlist *&)list);
+		MCControl* t_ref = getref();
+        if (t_ref->gettype() != CT_GROUP)
+            return nullptr;
+        
+        return static_cast<MCGroup*>(t_ref);
 	}
 };
 #endif

--- a/engine/src/player-legacy.h
+++ b/engine/src/player-legacy.h
@@ -36,6 +36,12 @@ struct MCPlayerOffscreenBuffer;
 //  since we use &MCControl::kPropertyTable
 class MCPlayer : public MCControl, public MCPlayerInterface
 {
+public:
+    
+    enum { kObjectType = CT_PLAYER };
+    
+private:
+    
 #ifdef FEATURE_MPLAYER
 	char *command;
 	Atom atom;

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -63,6 +63,12 @@ struct MCPlayerCallback
 //  since we use &MCControl::kPropertyTable
 class MCPlayer : public MCControl, public MCPlayerInterface
 {
+public:
+    
+    enum { kObjectType = CT_PLAYER };
+
+private:
+    
     MCPlayer *nextplayer;
     
 	MCPlatformPlayerRef m_platform_player;

--- a/engine/src/quicktime.cpp
+++ b/engine/src/quicktime.cpp
@@ -720,7 +720,7 @@ Boolean MCQTEffectsDialog(MCStringRef &r_data)
 			case codecParameterDialogConfirm:
 			case userCanceledErr:
 				QTDismissStandardParameterDialog(createdDialogID);
-				createdDialogID =nil;
+				createdDialogID = 0;
 				break;
 		}
 	}

--- a/engine/src/scrolbar.h
+++ b/engine/src/scrolbar.h
@@ -37,6 +37,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 class MCScrollbar : public MCControl
 {
+public:
+    
+    enum { kObjectType = CT_SCROLLBAR };
+    
+private:
+    
 	real8 thumbpos;
 	real8 thumbsize;
 	real8 lineinc;

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -158,10 +158,14 @@ struct MCStackAttachment
 
 class MCStack : public MCObject
 {
-	friend class MCHcstak;
-	friend class MCHccard;
+public:
+    
+    enum { kObjectType = CT_STACK };
 
 protected:
+    
+    friend class MCHcstak;
+    friend class MCHccard;
     
 	Window window;
 	MCCursorRef cursor;
@@ -311,8 +315,6 @@ protected:
 	MCStackObjectVisibility m_hidden_object_visibility;
     
 public:
-    
-    enum { kObjectType = CT_STACK };
     
 	Boolean menuwindow;
 

--- a/engine/src/vclip.h
+++ b/engine/src/vclip.h
@@ -24,6 +24,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 class MCVideoClip : public MCObject
 {
+public:
+    
+    enum { kObjectType = CT_VIDEO_CLIP };
+    
+private:
+    
 	real8 scale;
 	uint2 framerate;
 	uint1 *frames;

--- a/engine/src/w32-ds-player.cpp
+++ b/engine/src/w32-ds-player.cpp
@@ -366,7 +366,7 @@ void MCWin32DSFreeMediaType(AM_MEDIA_TYPE &t_type)
 	if (t_type.cbFormat != 0)
 	{
 		CoTaskMemFree(t_type.pbFormat);
-		t_type.cbFormat = nil;
+		t_type.cbFormat = 0;
 		t_type.pbFormat = nil;
 	}
 	if (t_type.pUnk != nil)

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -592,11 +592,7 @@ typedef const struct __CFData *CFDataRef;
 //
 
 #if defined(__cplusplus) /* C++ */
-#	if defined(__GCC__)
-#		define nil __null
-#	else
-#		define nil uintptr_t(0)
-#	endif
+#   define nil nullptr
 
 #else /* C */
 #	if defined(__GCC__)


### PR DESCRIPTION
The save code walks the object tree to check which version to use. Deleting a shared background group left a dangling pointer to the group in the list of card objects, causing a crash when saving.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/livecode/livecode/4437)

<!-- Reviewable:end -->
