### PR TITLE
[[ Bug 17825 ]] Ensure printing text uses the foreground color

### DIFF
--- a/docs/notes/bugfix-17825.md
+++ b/docs/notes/bugfix-17825.md
@@ -1,0 +1,1 @@
+# Make sure printing in color on Mac works


### PR DESCRIPTION
When rendering attributed strings via CoreText, it is necessary
to explicitly mark the string as 'using foreground from context'
otherwise black is used.
