### PR TITLE
Set default ide & thirdparty submodule branches to develop-8.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "ide"]
 	path = ide
 	url = https://github.com/runrev/livecode-ide
-	branch = develop
+	branch = develop-8.1
 [submodule "thirdparty"]
 	path = thirdparty
 	url = https://github.com/runrev/livecode-thirdparty
-	branch = develop
+	branch = develop-8.1
 [submodule "libcpptest/googletest"]
 	path = libcpptest/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
This ensures that the `update-submodules.py` script works correctly
for the `develop-8.1` branch.

N.b. it's very important that this change _isn't_ included in the
`develop` branch the next time it's merged up!
