### PR TITLE
[[ Bug 18132 ]] Fix cluster computation for non-monotonic lines

### DIFF
--- a/docs/notes/bugfix-18132.md
+++ b/docs/notes/bugfix-18132.md
@@ -1,0 +1,1 @@
+# Ensure complex unicode scripts render correctly to PDF.


### PR DESCRIPTION
CoreText can generate runs which reference chars in the string
'out of order' for certain unicode strings (the case which gave
rise to the bug is from gujarati).

This patch ensures that reasonable cluster information is always
generated by ignoring the char range fetched from a CTRun, and
computing it as the min/max indices in the string index array
fetched from a CTRun.
