### PR TITLE
Coverity defect fixes

### DIFF
--- a/engine/src/fieldstyledtext.cpp
+++ b/engine/src/fieldstyledtext.cpp
@@ -617,8 +617,8 @@ void MCField::parsestyledtextblockarray(MCArrayRef p_block_value, MCParagraph*& 
     if (MCArrayFetchValue(p_block_value, false, MCNAME("style"), t_valueref) && !MCValueIsEmpty(t_valueref))
 	{
 		MCArrayRef t_array;
-		/* UNCHECKED */ ctxt . ConvertToArray(t_valueref, t_array);
-		/* UNCHECKED */ MCArrayCopyAndRelease(t_array, &t_style_entry);	
+		if (ctxt . ConvertToArray(t_valueref, t_array))
+            /* UNCHECKED */ MCArrayCopyAndRelease(t_array, &t_style_entry);
 	}
 	// Get the metadata (if any)
 	MCAutoStringRef t_metadata;

--- a/engine/src/patternmatcher.cpp
+++ b/engine/src/patternmatcher.cpp
@@ -299,7 +299,8 @@ bool MCWildcardMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_
     else
     {
         MCValueRef t_element;
-        MCArrayFetchValue(m_array_source, m_options == kMCStringOptionCompareCaseless, p_key, t_element);
+        if (!MCArrayFetchValue(m_array_source, m_options == kMCStringOptionCompareCaseless, p_key, t_element))
+            return false;
         if (!ctxt . ConvertToString(t_element, t_string))
             return false;
     }

--- a/engine/src/patternmatcher.cpp
+++ b/engine/src/patternmatcher.cpp
@@ -128,7 +128,9 @@ bool MCRegexMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key
     else
     {
         MCValueRef t_element;
-        MCArrayFetchValue(m_array_source, m_options == kMCStringOptionCompareCaseless, p_key, t_element);
+        if (!MCArrayFetchValue(m_array_source, m_options == kMCStringOptionCompareCaseless, p_key, t_element))
+            return false;
+        
         if (!ctxt . ConvertToString(t_element, t_string))
             return false;
     }

--- a/revdb/src/sqlite_connection.cpp
+++ b/revdb/src/sqlite_connection.cpp
@@ -182,6 +182,10 @@ Bool DBConnection_SQLITE::sqlExecute(char *query, DBString *args, int numargs, u
 		}
 
 		int rv = basicExec(newquery, &affectedrows);
+        
+        if (numargs > 0)
+            free(newquery);
+
 		if(rv != SQLITE_OK)
 		{
 			// MW-2008-07-29: [[ Bug 6639 ]] Executing a query doesn't return meaningful error messages.
@@ -266,7 +270,7 @@ DBCursor *DBConnection_SQLITE::sqlQuery(char *query, DBString *args, int numargs
 	}
 
 	if (numargs)
-		delete newquery;
+		free(newquery);
 
 	return ret;
 }


### PR DESCRIPTION
This hopefully covers 3 of the 4 new coverity issues. The remaining one needs some thought as I p_threads are meant to be opaque and have no invalid value to assign in the constructor. It also fixes a recently detected leak so at least the total count will be the same ;-)
