### PR TITLE
iOS automatic provisioning

### DIFF
--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -42,7 +42,7 @@
 		'STRIP_INSTALLED_PRODUCT': 'NO',
 		'CLANG_CXX_LANGUAGE_STANDARD': 'c++0x',
 		
-		'CODE_SIGN_IDENTITY[sdk=iphoneos*]': 'iPhone Developer',
+		'CODE_SIGN_IDENTITY[sdk=iphoneos*]': 'iOS Developer',
 	},
 	
 	'target_defaults':


### PR DESCRIPTION
For automatic provisioning, Xcode needs the 'Code Signing Identity'
setting to be 'iOS Developer'.

See https://developer.apple.com/library/ios/qa/qa1814/_index.html
