### PR TITLE
build: Enable automatic provisioning for iOS builds.

### DIFF
--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -43,6 +43,7 @@
 		'CLANG_CXX_LANGUAGE_STANDARD': 'c++0x',
 		
 		'CODE_SIGN_IDENTITY[sdk=iphoneos*]': 'iPhone Developer',
+		'DEVELOPMENT_TEAM': 'SA2BUJR53Y',
 	},
 	
 	'target_defaults':


### PR DESCRIPTION
For automatic provisioning, we need to specify a development team.
This patch sets the development team for iOS builds to the LiveCode
team by default.

See https://developer.apple.com/library/ios/qa/qa1814/_index.html
