### PR TITLE
[Bug 18327] Fixed how the MCmajorosversion is calculated on iOS

### DIFF
--- a/docs/notes/bugfix-18327.md
+++ b/docs/notes/bugfix-18327.md
@@ -1,0 +1,1 @@
+# Calculate global MCmajorosversion in a more robust way 

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -262,13 +262,17 @@ static UIDeviceOrientation patch_device_orientation(id self, SEL _cmd)
     // MW-2014-10-02: [[ iOS 8 Support ]] We need this global initialized as early as
     //   possible.
     // Setup the value of the major OS version global.
-    NSString *t_sys_version;
-    t_sys_version = [[UIDevice currentDevice] systemVersion];
-    MCmajorosversion = ([t_sys_version characterAtIndex: 0] - '0') * 100;
-    MCmajorosversion += ([t_sys_version characterAtIndex: 2] - '0') * 10;
-    if ([t_sys_version length] == 5)
-        MCmajorosversion += [t_sys_version characterAtIndex: 4] - '0';
+	// PM-2016-09-08: [[ Bug 18327 ]] Take into account if x.y.z version of iOS has more than one digits in x,y,z
+    NSArray *t_sys_version_array = [[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."];
     
+    MCmajorosversion = [[t_sys_version_array objectAtIndex:0] intValue] * 100;
+    MCmajorosversion += [[t_sys_version_array objectAtIndex:1] intValue] * 10;
+    
+    if ([t_sys_version_array count] == 3)
+    {
+        MCmajorosversion += [[t_sys_version_array objectAtIndex:2] intValue];
+    }
+
 	// We are done (successfully) so return ourselves.
 	return self;
 }


### PR DESCRIPTION
Prior to iOS 8, the value reported for the view rect was always as if in portrait orientation. To ensure that the values reported would be correct when the device was in landscape orientation, we checked for the device orientation, and if it was landscape, we swapped the width/height:

```
t_viewport = [[UIScreen mainScreen] bounds];
if (UIInterfaceOrientationIsLandscape([self fetchOrientation]))
        return CGRectMake(0.0f, t_status_bar_size, t_viewport . size . height, t_viewport . size . width - t_status_bar_size);
```

However, on iOS 8, the `[[UIScreen mainScreen] bounds]` already takes into account the orientation.

So to ensure backwards compatibility, we did:

```
t_viewport = [[UIScreen mainScreen] bounds];

// MM-2014-09-26: [[ iOS 8 Support ]] iOS 8 already takes into account orientation when returning the bounds.
if (MCmajorosversion < 800 && UIInterfaceOrientationIsLandscape([self fetchOrientation]))
    return CGRectMake(0.0f, t_status_bar_size, t_viewport . size . height, t_viewport . size . width - t_status_bar_size);

return CGRectMake(0.0f, t_status_bar_size, t_viewport . size . width, t_viewport . size . height - t_status_bar_size);
```

The `MCmajorosversion` was calculated as follows:

```
NSString *t_sys_version;
t_sys_version = [[UIDevice currentDevice] systemVersion];
MCmajorosversion = ([t_sys_version characterAtIndex: 0] - '0') * 100;
MCmajorosversion += ([t_sys_version characterAtIndex: 2] - '0') * 10;
if ([t_sys_version length] == 5)
    MCmajorosversion += [t_sys_version characterAtIndex: 4] - '0';
```

If the `systemVersion` was e.g. 9.3.1, the `MCmajorosversion` was 931.

This conversion breaks when any of the x.y.z in systemVersion has more than one digits.
With iOS 10.0, the systemVersion reported `10.0`, but `MCmajorosversion` was 80.

This resulted in the app being treated as if it run on iOS < 8, thus swapping the width/height in the view rect when in landscape orientation.

This patch now calculates the `MCmajorosversion` in a more robust way.
