### PR TITLE
[[ Bug 18364 ]] Only send standalone saving messages once

### DIFF
--- a/docs/notes/bugfix-18364.md
+++ b/docs/notes/bugfix-18364.md
@@ -1,0 +1,1 @@
+# savingStandalone and standaloneSaved should only be sent once when building for multiple platforms

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -291,9 +291,19 @@ command revDoSaveAsStandalone pStack, pFolder
    revStandaloneProgress "Preparing to build standalone..."
    
    -- pre build message
-   try
-      dispatch "savingStandalone" to stack pStack
-   end try
+   local tHasDesktop
+   repeat for each item tTarget in revSBDesktopTargets()
+      if sStandaloneSettingsA[tTarget] then
+         put true into tHasDesktop
+         exit repeat
+      end if
+   end repeat
+   
+   if tHasDesktop then
+      try
+         dispatch "savingStandalone" to stack pStack
+      end try
+   end if
    
    try
       -- Create an appropriate output dir
@@ -366,9 +376,11 @@ command revDoSaveAsStandalone pStack, pFolder
       end repeat
       
       -- post build message
-      try
-         dispatch "standaloneSaved" to stack pStack with pFolder & slash
-      end try
+      if tHasDesktop then
+         try
+            dispatch "standaloneSaved" to stack pStack with pFolder & slash
+         end try
+      end if
       
    catch tError
       revAbort

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -290,6 +290,11 @@ command revDoSaveAsStandalone pStack, pFolder
    
    revStandaloneProgress "Preparing to build standalone..."
    
+   -- pre build message
+   try
+      dispatch "savingStandalone" to stack pStack
+   end try
+   
    try
       -- Create an appropriate output dir
       local tOutputFolder
@@ -359,6 +364,12 @@ command revDoSaveAsStandalone pStack, pFolder
                break
          end switch
       end repeat
+      
+      -- post build message
+      try
+         dispatch "standaloneSaved" to stack pStack with pFolder & slash
+      end try
+      
    catch tError
       revAbort
       if word 1 of tError = "Standalone:" then 
@@ -500,21 +511,12 @@ private on revStandalonePreBuild pStack, pFolder, @rStackName, @rStackFileName, 
    
    set the defaultStack to the short name of stack tStackFileName
    
-   -- pre build message
-   try
-      dispatch "savingStandalone" to stack tStackFileName
-   end try
-   
    put tStackName into rStackName
    put tStackFileName into rStackFileName
    put tStackFileList into rStackFileList
 end revStandalonePreBuild
 
 private on revStandalonePostBuild pStackFileName, pFolder
-   -- post build message
-   try
-      dispatch "standaloneSaved" to stack pStackFileName with pFolder
-   end try
 end revStandalonePostBuild
 
 private command revStandaloneCopyInclusions pStack, pStackFileList, pStackSourceFile, \ 


### PR DESCRIPTION
Move the code that sends these messages outside the platform repeat loop.
