### PR TITLE
Turn on -Werror=shadow

### DIFF
--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -135,6 +135,7 @@
 							'-Werror=unknown-pragmas',
 							'-Werror=missing-field-initializers',
 							'-Werror=objc-literal-compare',
+							'-Werror=shadow',
 						],
 					},
 				},

--- a/engine/src/bitmapeffectblur.cpp
+++ b/engine/src/bitmapeffectblur.cpp
@@ -715,7 +715,7 @@ void MCBitmapEffectBoxBlur::CalculateRows(uint32_t p_pass)
 			CalculateRows(p_pass - 1);
 
 			uint32_t *t_buff_top, *t_buff_bottom;
-			int32_t t_nextbufferrow = t_y + t_top - 1;
+            t_nextbufferrow = t_y + t_top - 1;
 			while (t_nextbufferrow < 0)
 				t_nextbufferrow += t_prev_pass->buffer_height;
 			t_buff_top = t_prev_pass->buffer + (t_prev_pass->stride * (t_nextbufferrow % t_prev_pass->buffer_height));

--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -1385,10 +1385,10 @@ void MCBlock::draw(MCDC *dc, coord_t x, coord_t lx, coord_t cx, int2 y, findex_t
 			if (IsMacLF() && !f->isautoarm())
 			{
 				MCPatternRef t_pattern;
-				int2 x, y;
+				int2 t_x, t_y;
 				MCColor fc, hc;
-				f->getforecolor(DI_FORE, False, True, fc, t_pattern, x, y, dc -> gettype(), f);
-				f->getforecolor(DI_HILITE, False, True, hc, t_pattern, x, y, dc -> gettype(), f);
+				f->getforecolor(DI_FORE, False, True, fc, t_pattern, t_x, t_y, dc -> gettype(), f);
+				f->getforecolor(DI_HILITE, False, True, hc, t_pattern, t_x, t_y, dc -> gettype(), f);
 				if (MCColorGetPixel(hc) == MCColorGetPixel(fc))
 					f->setforeground(dc, DI_BACK, False, True);
                 else

--- a/engine/src/bsdiff_build.cpp
+++ b/engine/src/bsdiff_build.cpp
@@ -244,9 +244,9 @@ static bool bsdiffmain(MCBsDiffInputStream *p_old_file, MCBsDiffInputStream *p_n
 		(close(fd)==-1)) err(1,"%s",argv[1]);*/
 	if (t_success)
 	{
-		uint32_t s;
-		t_success = p_old_file -> Measure(s);
-		oldsize = (signed)s;
+		uint32_t t_size;
+		t_success = p_old_file -> Measure(t_size);
+		oldsize = (signed)t_size;
 	}
 	if (t_success)
 		t_success = MCMemoryNewArray(oldsize + 1, old);
@@ -276,9 +276,9 @@ static bool bsdiffmain(MCBsDiffInputStream *p_old_file, MCBsDiffInputStream *p_n
 		(close(fd)==-1)) err(1,"%s",argv[2]);*/
 	if (t_success)
 	{
-		uint32_t s;
-		t_success = p_new_file -> Measure(s);
-		newsize = (signed)s;
+		uint32_t t_size;
+		t_success = p_new_file -> Measure(t_size);
+		newsize = (signed)t_size;
 	}
 	if (t_success)
 		t_success = MCMemoryNewArray(newsize + 1, newp);

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -197,8 +197,8 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 						trect = MCU_reduce_rect(trect, 1);
 						if (state & CS_HILITED)
 						{
-							uint2 i;
-							if (getcindex(DI_HILITE, i) || getpindex(DI_HILITE, i))
+                            uint2 t_index;
+							if (getcindex(DI_HILITE, t_index) || getpindex(DI_HILITE, t_index))
 								setforeground(dc, DI_HILITE, False, False);
 							else
 								dc->setforeground(dc->getgray());
@@ -445,7 +445,7 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
             }
             
             coord_t starty = sy;
-            uint2 i;
+            uint2 t_line;
             coord_t twidth = 0;
             
             dc->save();
@@ -479,11 +479,11 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 			}
 			
 			uindex_t t_totallen = 0;
-			for (i = 0 ; i < nlines ; i++)
+			for (t_line = 0 ; t_line < nlines ; t_line++)
 			{
 				// Note: 'lines' is an array of strings
 				MCValueRef lineval = nil;
-				/* UNCHECKED */ MCArrayFetchValueAtIndex(*lines, i + 1, lineval);
+				/* UNCHECKED */ MCArrayFetchValueAtIndex(*lines, t_line + 1, lineval);
 				MCStringRef line = (MCStringRef)(lineval);
                 // MM-2014-04-16: [[ Bug 11964 ]] Pass through the transform of the stack to make sure the measurment is correct for scaled text.
                 twidth = MCFontMeasureTextFloat(m_font, line, getstack() -> getdevicetransform());
@@ -498,7 +498,7 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 				{
 				case F_ALIGN_LEFT:
 				case F_ALIGN_JUSTIFY:
-					if (i == 0)
+					if (t_line == 0)
 					{
 						if (indicator && !(flags & F_SHOW_ICON))
 						{
@@ -869,7 +869,6 @@ void MCButton::drawradio(MCDC *dc, MCRectangle &srect, Boolean white)
 	if (!(flags & F_AUTO_ARM) && MCcurtheme &&
 	        MCcurtheme->iswidgetsupported(WTHEME_TYPE_RADIOBUTTON))
 	{
-		MCRectangle trect;
 		if (!IsNativeGTK())
 		{
 			trect.x = srect.x + leftmargin - 2;

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1795,7 +1795,7 @@ Exec_stat MCCard::relayer(MCControl *optr, uint2 newlayer)
 	if (oldparent == this)
 	{
 		MCObjptr *newoptr = NULL;
-		MCObjptr *tptr = objptrs;
+		tptr = objptrs;
 		do
 		{
 			if (tptr->getref() == optr)
@@ -2812,7 +2812,7 @@ MCRectangle MCCard::computecrect()
 }
 
 void MCCard::updateselection(MCControl *cptr, const MCRectangle &oldrect,
-                             const MCRectangle &selrect, MCRectangle &drect)
+                             const MCRectangle &p_selrect, MCRectangle &drect)
 {
 	// MW-2008-01-30: [[ Bug 5749 ]] Make sure we check to see if the object is
 	//   selectable - this will recurse up the object tree as necessary.
@@ -2835,7 +2835,7 @@ void MCCard::updateselection(MCControl *cptr, const MCRectangle &oldrect,
         t_group_oldrect = MCU_intersect_rect(oldrect, t_group_rect);
         
         MCRectangle t_group_selrect;
-        t_group_selrect = MCU_intersect_rect(selrect, t_group_rect);
+        t_group_selrect = MCU_intersect_rect(p_selrect, t_group_rect);
         
         do
         {
@@ -2854,7 +2854,7 @@ void MCCard::updateselection(MCControl *cptr, const MCRectangle &oldrect,
 		if (MCselectintersect)
 		{
             was = cptr->maskrect(oldrect);
-            is = cptr->maskrect(selrect);
+            is = cptr->maskrect(p_selrect);
 
             // AL-2015-10-07:: [[ External Handles ]] If either dimension is 0,
             //  recheck the selection intersect
@@ -2867,13 +2867,13 @@ void MCCard::updateselection(MCControl *cptr, const MCRectangle &oldrect,
                     was = MCU_line_intersect_rect(oldrect, t_rect);
                 
                 if (!is)
-                    is = MCU_line_intersect_rect(selrect, t_rect);
+                    is = MCU_line_intersect_rect(p_selrect, t_rect);
             }
 		}
 		else
 		{
 			was = MCU_rect_in_rect(cptr->getrect(), oldrect);
-			is = MCU_rect_in_rect(cptr->getrect(), selrect);
+			is = MCU_rect_in_rect(cptr->getrect(), p_selrect);
 		}
 		if (is != was)
 		{

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -1854,9 +1854,7 @@ void MCStop::exec_ctxt(MCExecContext &ctxt)
             }
             else if (target != NULL)
 			{
-				MCObject *optr;
-				uint4 parid;
-                if (!target->getobj(ctxt, optr, parid, True)
+				if (!target->getobj(ctxt, optr, parid, True)
 				        || optr->gettype() != CT_STACK)
 				{
                     ctxt . LegacyThrow(EE_STOP_BADTARGET);

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -521,7 +521,7 @@ MCExport::~MCExport()
 Parse_stat MCExport::parse(MCScriptPoint &sp)
 {
 	Symbol_type type;
-	const LT *te;
+	const LT *te = NULL;
 
 	initpoint(sp);
 	if (sp.next(type) != PS_NORMAL)
@@ -565,13 +565,13 @@ Parse_stat MCExport::parse(MCScriptPoint &sp)
 			
 			if (!t_has_rectangle ||	sp.skip_token(SP_FACTOR, TT_OF) == PS_NORMAL)
 			{
-				Symbol_type type;
-				const LT *te = NULL;
+				Symbol_type t_type;
+				const LT *t_te = NULL;
 
 				// MW-2006-05-04: Bug 3506 - crash in specific case due to not checking result of sp.lookup
 				// MW-2007-09-11: [[ Bug 5242 ]] - the alternate of this if used to fail if te == NULL, this
 				//   can happen though if we are looking at a variable chunk.
-				if (sp.next(type) == PS_NORMAL && sp.lookup(SP_FACTOR, te) == PS_NORMAL && te -> type == TT_CHUNK && te -> which == CT_STACK)
+				if (sp.next(t_type) == PS_NORMAL && sp.lookup(SP_FACTOR, t_te) == PS_NORMAL && t_te -> type == TT_CHUNK && t_te -> which == CT_STACK)
 				{
 					if (sp.parseexp(False, True, &exsstack) != PS_NORMAL)
 					{
@@ -587,7 +587,7 @@ Parse_stat MCExport::parse(MCScriptPoint &sp)
 							return PS_ERROR;
 						}
 				}
-				else if (te == NULL || te -> type != TT_TO)
+				else if (t_te == NULL || t_te -> type != TT_TO)
 				{
 					sp . backup();
 					image = new MCChunk(False);
@@ -1370,7 +1370,7 @@ MCImport::~MCImport()
 Parse_stat MCImport::parse(MCScriptPoint &sp)
 {
 	Symbol_type type;
-	const LT *te;
+	const LT *te = NULL;
 
 	initpoint(sp);
 	if (sp.next(type) != PS_NORMAL)
@@ -1412,11 +1412,11 @@ Parse_stat MCImport::parse(MCScriptPoint &sp)
 
 			if (!t_has_rectangle || sp.skip_token(SP_FACTOR, TT_OF) == PS_NORMAL)
 			{
-				Symbol_type type;
-				const LT *te = NULL;
+				Symbol_type t_type;
+				const LT *t_te = NULL;
 
 				// MW-2006-03-24: Bug 3442 - crash in specific case due to not checking result of sp.lookup
-				if (sp.next(type) == PS_NORMAL && sp.lookup(SP_FACTOR, te) == PS_NORMAL && te -> type == TT_CHUNK && te -> which == CT_STACK)
+				if (sp.next(t_type) == PS_NORMAL && sp.lookup(SP_FACTOR, t_te) == PS_NORMAL && t_te -> type == TT_CHUNK && t_te -> which == CT_STACK)
 				{
 					if (sp.parseexp(False, True, &mname) != PS_NORMAL)
 					{

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -1098,11 +1098,11 @@ void MCControl::continuesize(int2 x, int2 y)
 		}
 		else
 		{
-			int2 newwidth;
-			newwidth = (int2)(newrect.height / aspect);
+			int2 t_newwidth;
+			t_newwidth = (int2)(newrect.height / aspect);
 			if (state & CS_SIZEL)
-				newrect.x += newrect.width - newwidth;
-			newrect.width = newwidth;
+				newrect.x += newrect.width - t_newwidth;
+			newrect.width = t_newwidth;
 		}
 	}
 	else if (MCmodifierstate & MS_MOD1)

--- a/engine/src/customprinter.cpp
+++ b/engine/src/customprinter.cpp
@@ -166,7 +166,7 @@ bool MCCustomPrinterImageFromMCGImage(MCGImageRef p_image, MCCustomPrinterImage 
 			uint32_t *t_dst_row;
 			t_dst_row = (uint32_t*)t_dst;
 			
-			for (uint32_t i = 0; i < t_raster.width; i++)
+			for (uint32_t j = 0; j < t_raster.width; j++)
 				*t_dst_row++ = MCGPixelFromNative(kMCCustomPrinterImagePixelFormat, *t_src_row++);
 			
 			t_src += t_raster.stride;

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -80,8 +80,8 @@ extern void MCU_initialize_names();
 
 bool X_init(int argc, MCStringRef argv[], MCStringRef envp[])
 {
-	int i;
-	MCstackbottom = (char *)&i;
+    void *t_bottom;
+    MCstackbottom = (char *)&t_bottom;
 	
 #ifdef _WINDOWS_DESKTOP
 	// MW-2011-07-26: Make sure errno pointer is initialized - this won't be
@@ -312,8 +312,8 @@ bool X_init(int argc, MCStringRef argv[], MCStringRef envp[])
 
 void X_main_loop_iteration()
 {
-	int i;
-	MCstackbottom = (char *)&i;
+    void *t_bottom;
+    MCstackbottom = (char *)&t_bottom;
 
 	////
 

--- a/engine/src/eps.cpp
+++ b/engine/src/eps.cpp
@@ -404,11 +404,11 @@ void MCEPS::setextents()
 	{
 		MCswapbytes = !MCswapbytes;
 		uint4 *uint4ptr = (uint4 *)postscript;
-		uint4 offset = swap_uint4(&uint4ptr[1]);
+		uint4 t_offset = swap_uint4(&uint4ptr[1]);
 		size = swap_uint4(&uint4ptr[2]);
 		MCswapbytes = !MCswapbytes;
 		char *newps = new char[size];
-		memcpy(newps, &postscript[offset], size);
+		memcpy(newps, &postscript[t_offset], size);
 		delete postscript;
 		postscript = newps;
 	}

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -267,10 +267,10 @@ void MCGraphic::SetCapStyle(MCExecContext& ctxt, intenum_t style)
 	t_new_style = (uint2)style;
 	if (t_new_style != getcapstyle())
 	{
-		MCRectangle oldrect = rect;
+		MCRectangle t_oldrect = rect;
 		setcapstyle(t_new_style);
 		compute_minrect();
-		Redraw(oldrect);
+		Redraw(t_oldrect);
 	}
 }
 
@@ -287,10 +287,10 @@ void MCGraphic::SetJoinStyle(MCExecContext& ctxt, intenum_t style)
 	t_new_style = (uint2)style;
 	if (t_new_style != getjoinstyle())
 	{
-		MCRectangle oldrect = rect;
+		MCRectangle t_oldrect = rect;
 		setjoinstyle(t_new_style);
 		compute_minrect();
-		Redraw(oldrect);
+		Redraw(t_oldrect);
 	}
 }
 
@@ -305,10 +305,10 @@ void MCGraphic::SetMiterLimit(MCExecContext& ctxt, double limit)
 	t_new_limit = MCU_fmax(1, limit);
 	if (m_stroke_miter_limit != t_new_limit)
 	{
-		MCRectangle oldrect = rect;
+		MCRectangle t_oldrect = rect;
 		m_stroke_miter_limit = (real4)t_new_limit;
 		compute_minrect();
-		Redraw(oldrect);
+		Redraw(t_oldrect);
 	}
 }
 
@@ -319,11 +319,11 @@ void MCGraphic::GetLineSize(MCExecContext& ctxt, integer_t& r_size)
 
 void MCGraphic::SetLineSize(MCExecContext& ctxt, integer_t size)
 {
-	MCRectangle oldrect = rect;
+	MCRectangle t_oldrect = rect;
 	linesize = size;
 	compute_minrect();
 	delpoints();
-	Redraw(oldrect);
+	Redraw(t_oldrect);
 }
 
 void MCGraphic::GetPolySides(MCExecContext& ctxt, integer_t& r_sides)
@@ -402,10 +402,10 @@ void MCGraphic::GetArrowSize(MCExecContext& ctxt, integer_t& r_size)
 
 void MCGraphic::SetArrowSize(MCExecContext& ctxt, integer_t p_size)
 {
-	MCRectangle oldrect = rect;
+	MCRectangle t_oldrect = rect;
 	arrowsize = p_size;
 	compute_minrect();
-	Redraw(oldrect);
+	Redraw(t_oldrect);
 }
 
 void MCGraphic::GetStartArrow(MCExecContext& ctxt, bool& r_setting)
@@ -418,10 +418,10 @@ void MCGraphic::SetStartArrow(MCExecContext& ctxt, bool setting)
 	bool t_dirty;
 	t_dirty = changeflag(setting, F_START_ARROW);
 
-	MCRectangle oldrect = rect;
+	MCRectangle t_oldrect = rect;
 	compute_minrect();
 	if (t_dirty)
-		Redraw(oldrect);
+		Redraw(t_oldrect);
 }
 
 void MCGraphic::GetEndArrow(MCExecContext& ctxt, bool& r_setting)
@@ -434,10 +434,10 @@ void MCGraphic::SetEndArrow(MCExecContext& ctxt, bool setting)
 	bool t_dirty;
 	t_dirty = changeflag(setting, F_END_ARROW);
 
-	MCRectangle oldrect = rect;
+	MCRectangle t_oldrect = rect;
 	compute_minrect();
 	if (t_dirty)
-		Redraw(oldrect);
+		Redraw(t_oldrect);
 }
 
 void MCGraphic::GetMarkerLineSize(MCExecContext& ctxt, integer_t& r_size)
@@ -447,10 +447,10 @@ void MCGraphic::GetMarkerLineSize(MCExecContext& ctxt, integer_t& r_size)
 
 void MCGraphic::SetMarkerLineSize(MCExecContext& ctxt, integer_t size)
 {
-	MCRectangle oldrect = rect;
+	MCRectangle t_oldrect = rect;
 	markerlsize = size;
 	compute_minrect();
-	Redraw(oldrect);
+	Redraw(t_oldrect);
 }
 
 void MCGraphic::GetMarkerDrawn(MCExecContext& ctxt, bool& r_setting)
@@ -463,10 +463,10 @@ void MCGraphic::SetMarkerDrawn(MCExecContext& ctxt, bool setting)
 	bool t_dirty;
 	t_dirty = changeflag(setting, F_MARKER_DRAWN);
 
-	MCRectangle oldrect = rect;
+	MCRectangle t_oldrect = rect;
 	compute_minrect();
 	if (t_dirty)
-		Redraw(oldrect);
+		Redraw(t_oldrect);
 }
 
 void MCGraphic::GetMarkerOpaque(MCExecContext& ctxt, bool& r_setting)
@@ -520,7 +520,7 @@ void MCGraphic::GetStyle(MCExecContext& ctxt, intenum_t& r_style)
 void MCGraphic::SetStyle(MCExecContext& ctxt, intenum_t p_style)
 {
 	flags &= ~F_STYLE;
-	MCRectangle oldrect = rect;
+	MCRectangle t_oldrect = rect;
 
 	if (p_style == kMCGraphicStyleText)
 	{
@@ -547,7 +547,7 @@ void MCGraphic::SetStyle(MCExecContext& ctxt, intenum_t p_style)
 		}
 	}
 	delpoints();
-	Redraw(oldrect);
+	Redraw(t_oldrect);
 }
 
 void MCGraphic::GetShowName(MCExecContext& ctxt, bool& r_setting)
@@ -722,9 +722,9 @@ void MCGraphic::SetMarkerPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* 
     
     // SN-2014-06-02 [[ Bug 12576 ]] drawing_bug_when_rotating_graphic
     // Ensure that the functions which might change the size of the graphic redraw the former rectangle
-    MCRectangle oldrect = rect;
+    MCRectangle t_oldrect = rect;
     compute_minrect();
-    Redraw(oldrect);
+    Redraw(t_oldrect);
 }
 
 void MCGraphic::GetDashes(MCExecContext& ctxt, uindex_t& r_count, uinteger_t*& r_dashes)
@@ -828,9 +828,9 @@ void MCGraphic::SetPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_poin
     
     // SN-2014-06-02 [[ Bug 12576 ]] drawing_bug_when_rotating_graphic
     // The rectangle might change, we need to redraw what was the previous size.
-    MCRectangle oldrect = rect;
+    MCRectangle t_oldrect = rect;
     compute_minrect();
-    Redraw(oldrect);
+    Redraw(t_oldrect);
 }
 
 void MCGraphic::GetRelativePoints(MCExecContext& ctxt, uindex_t& r_count, MCPoint*& r_points)
@@ -877,9 +877,9 @@ void MCGraphic::SetRelativePoints(MCExecContext& ctxt, uindex_t p_count, MCPoint
     
     // SN-2014-06-02 [[ Bug 12576 ]] drawing_bug_when_rotating_graphic
     // Ensure that the functions which might change the size of the graphic redraw the former rectangle
-    MCRectangle oldrect = rect;
+    MCRectangle t_oldrect = rect;
     compute_minrect();
-    Redraw(oldrect);
+    Redraw(t_oldrect);
 }
 
 // SN-2014-06-25: [[ MERGE-6.7 ]] Effective points getter udpated

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -2706,7 +2706,7 @@ void MCObject::GetPatterns(MCExecContext& ctxt, MCStringRef& r_patterns)
 	ctxt . Throw();
 }
 
-void MCObject::SetPatterns(MCExecContext& ctxt, MCStringRef patterns)
+void MCObject::SetPatterns(MCExecContext& ctxt, MCStringRef p_patterns)
 {
 	bool t_success;
 	t_success = true;
@@ -2714,18 +2714,18 @@ void MCObject::SetPatterns(MCExecContext& ctxt, MCStringRef patterns)
 	uindex_t t_old_offset = 0;
 	uindex_t t_new_offset = 0;
 	uindex_t t_length;
-	t_length = MCStringGetLength(patterns);
+	t_length = MCStringGetLength(p_patterns);
 
 	for (uint2 p = P_FORE_PATTERN; p <= P_FOCUS_PATTERN; p++)
 	{
 		MCAutoStringRef t_pattern;
 		uint4 t_id;
-		if (!MCStringFirstIndexOfChar(patterns, '\n', t_old_offset, kMCCompareExact, t_new_offset))
+		if (!MCStringFirstIndexOfChar(p_patterns, '\n', t_old_offset, kMCCompareExact, t_new_offset))
 			t_new_offset = t_length;
 		
 		if (t_new_offset > t_old_offset)
 		{
-			t_success = MCStringCopySubstring(patterns, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_pattern);
+			t_success = MCStringCopySubstring(p_patterns, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_pattern);
 			if (t_success)
 				t_success = MCU_stoui4(*t_pattern, t_id);
 			if (t_success)
@@ -3440,7 +3440,7 @@ static struct { Properties prop; const char *tag; } s_preprocess_props[] =
     { P_PATTERNS, "patterns" },
 };
 
-void MCObject::SetProperties(MCExecContext& ctxt, uint32_t part, MCArrayRef props)
+void MCObject::SetProperties(MCExecContext& ctxt, uint32_t part, MCArrayRef p_props)
 {
 	// MW-2011-08-18: [[ Redraw ]] Update to use redraw.
 	MCRedrawLockScreen();
@@ -3456,7 +3456,7 @@ void MCObject::SetProperties(MCExecContext& ctxt, uint32_t part, MCArrayRef prop
     {
 		// MERG-2013-06-24: [[ RevisedPropsProp ]] Make sure we do a case-insensitive search
 		//   for the property name.
-        if (!MCArrayFetchValue(props, false, MCNAME(s_preprocess_props[j].tag), t_value))
+        if (!MCArrayFetchValue(p_props, false, MCNAME(s_preprocess_props[j].tag), t_value))
             continue;
 
         // MW-2013-06-24: [[ RevisedPropsProp ]] Workaround Bug 10977 - only set the
@@ -3475,7 +3475,7 @@ void MCObject::SetProperties(MCExecContext& ctxt, uint32_t part, MCArrayRef prop
 	uintptr_t t_iterator;
 	t_iterator = 0;
     MCNameRef t_key;
-	while(MCArrayIterate(props, t_iterator, t_key, t_value))
+	while(MCArrayIterate(p_props, t_iterator, t_key, t_value))
 	{
 		MCScriptPoint sp(MCNameGetString(t_key));
 		Symbol_type type;
@@ -4179,9 +4179,9 @@ void MCObject::SetTextStyleElement(MCExecContext& ctxt, MCNameRef p_index, bool 
         
         MCF_changetextstyle(t_style_set, t_style, p_setting);
         
-        MCInterfaceTextStyle t_style;
-        t_style . style = t_style_set;
-        SetTextStyle(ctxt, t_style);
+        MCInterfaceTextStyle t_interface_style;
+        t_interface_style . style = t_style_set;
+        SetTextStyle(ctxt, t_interface_style);
         return;
     }
     

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1187,9 +1187,9 @@ void MCStack::SetSubstacks(MCExecContext& ctxt, MCStringRef p_substacks)
 			bool t_was_mainstack;
 			if (tsub == nil)
 			{
-				MCNewAutoNameRef t_name;
-				/* UNCHECKED */ MCNameCreate(*t_name_string, &t_name);
-				MCStack *toclone = MCdispatcher -> findstackname(*t_name);
+				MCNewAutoNameRef t_stack_name;
+				/* UNCHECKED */ MCNameCreate(*t_name_string, &t_stack_name);
+				MCStack *toclone = MCdispatcher -> findstackname(*t_stack_name);
 				t_was_mainstack = MCdispatcher -> ismainstack(toclone) == True;	
 
 				if (toclone != nil)

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1693,8 +1693,8 @@ void MCInterfaceExecDrag(MCExecContext& ctxt, uint2 p_which, MCPoint p_start, MC
 	int2 y = p_start . y;
 	while (x != p_end . x || y != p_end . y)
 	{
-		int2 oldx = x;
-		int2 oldy = y;
+		int2 t_oldx = x;
+		int2 t_oldy = y;
 		x = p_start . x + (int2)(ix * (dx * (curtime - starttime) / duration));
 		y = p_start . y + (int2)(iy * (dy * (curtime - starttime) / duration));
 		if (MCscreen->wait((real8)MCsyncrate / 1000.0, False, True))
@@ -1709,7 +1709,7 @@ void MCInterfaceExecDrag(MCExecContext& ctxt, uint2 p_which, MCPoint p_start, MC
 			y = p_end . y;
 			curtime = endtime;
 		}
-		if (x != oldx || y != oldy)
+		if (x != t_oldx || y != t_oldy)
 			MCdefaultstackptr->mfocus(x, y);
 	}
 	MCdefaultstackptr->mup(p_which, false);

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1394,7 +1394,7 @@ void MCExecContext::doscript(MCExecContext &ctxt, MCStringRef p_script, uinteger
     while (statements != NULL)
     {
         statements->exec_ctxt(ctxt2);
-        Exec_stat stat = ctxt2 . GetExecStat();
+        stat = ctxt2 . GetExecStat();
         if (stat == ES_ERROR)
         {
             deletestatements(statements);
@@ -2761,10 +2761,10 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
                 ctxt . LegacyThrow(EE_PROPERTY_NOTAINTPAIR);
             if (!ctxt . HasError())
             {
-                integer_t t_value[2];
-                t_value[0] = a;
-                t_value[1] = b;
-                ((void(*)(MCExecContext&, void *, integer_t[2]))prop -> setter)(ctxt, mark, t_value);
+                integer_t t_int_value[2];
+                t_int_value[0] = a;
+                t_int_value[1] = b;
+                ((void(*)(MCExecContext&, void *, integer_t[2]))prop -> setter)(ctxt, mark, t_int_value);
             }
         }
             break;
@@ -2778,12 +2778,12 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
                 ctxt . LegacyThrow(EE_PROPERTY_NOTAINTQUAD);
             if (!ctxt . HasError())
             {
-                integer_t t_value[4];
-                t_value[0] = a;
-                t_value[1] = b;
-                t_value[2] = c;
-                t_value[3] = d;
-                ((void(*)(MCExecContext&, void *, integer_t[4]))prop -> setter)(ctxt, mark, t_value);
+                integer_t t_int_value[4];
+                t_int_value[0] = a;
+                t_int_value[1] = b;
+                t_int_value[2] = c;
+                t_int_value[3] = d;
+                ((void(*)(MCExecContext&, void *, integer_t[4]))prop -> setter)(ctxt, mark, t_int_value);
             }
         }
             break;
@@ -2797,12 +2797,12 @@ void MCExecStoreProperty(MCExecContext& ctxt, const MCPropertyInfo *prop, void *
                 ctxt . LegacyThrow(EE_PROPERTY_NOTAINTQUAD);
             if (!ctxt . HasError())
             {
-                integer_t t_value[4];
-                t_value[0] = a;
-                t_value[1] = b;
-                t_value[2] = c;
-                t_value[3] = d;
-                ((void(*)(MCExecContext&, void *, integer_t[4]))prop -> setter)(ctxt, mark, t_value);
+                integer_t t_int_value[4];
+                t_int_value[0] = a;
+                t_int_value[1] = b;
+                t_int_value[2] = c;
+                t_int_value[3] = d;
+                ((void(*)(MCExecContext&, void *, integer_t[4]))prop -> setter)(ctxt, mark, t_int_value);
             }
         }
             break;

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -586,12 +586,12 @@ MCExternalError MCExternalVariable::GetBoolean(MCExternalValueOptions p_options,
 	else
 	{
 		MCExternalError t_error;
-		MCAutoStringRef t_value;
-		t_error = GetString(p_options, &t_value);
+		MCAutoStringRef t_string_value;
+		t_error = GetString(p_options, &t_string_value);
 		if (t_error != kMCExternalErrorNone)
 			return t_error;
 		
-		return string_to_boolean(*t_value, p_options, &r_value);
+		return string_to_boolean(*t_string_value, p_options, &r_value);
 	}
 	
 	return kMCExternalErrorNone;
@@ -1620,8 +1620,6 @@ static MCExternalError MCExternalVariableStore(MCExternalVariableRef var, MCExte
     {
         // For efficiency, we use 'exchange' - this prevents copying a temporary array.
         MCExternalVariableRef t_tmp_array;
-        MCExternalError t_error;
-        
         MCAutoArrayRef t_tmp_array_ref;
         
         t_error = kMCExternalErrorNone;
@@ -1645,7 +1643,6 @@ static MCExternalError MCExternalVariableStore(MCExternalVariableRef var, MCExte
     {
         // For efficiency, we use 'exchange' - this prevents copying a temporary array.
         MCExternalVariableRef t_tmp_array;
-        MCExternalError t_error;
         MCAutoArrayRef t_tmp_array_ref;
         
         t_error = kMCExternalErrorNone;
@@ -1839,7 +1836,6 @@ static MCExternalError MCExternalVariableFetch(MCExternalVariableRef var, MCExte
     case kMCExternalValueOptionAsNSArray:
     case kMCExternalValueOptionAsCFArray:
     {
-        MCExternalError t_error;
         CFArrayRef t_value;
         
         t_error = kMCExternalErrorNone;
@@ -1866,7 +1862,6 @@ static MCExternalError MCExternalVariableFetch(MCExternalVariableRef var, MCExte
     case kMCExternalValueOptionAsNSDictionary:
     case kMCExternalValueOptionAsCFDictionary:
     {
-        MCExternalError t_error;
         CFDictionaryRef t_value;
         
         t_error = kMCExternalErrorNone;

--- a/engine/src/fieldhtml.cpp
+++ b/engine/src/fieldhtml.cpp
@@ -2260,8 +2260,8 @@ MCParagraph *MCField::importhtmltext(MCValueRef p_text)
                         {
                             import_html_begin(ctxt, nil);
                             
-                            MCFieldCharacterStyle t_char_style;
-                            t_char_style = ctxt . styles[ctxt . style_index] . style;
+                            MCFieldCharacterStyle t_tag_style;
+                            t_tag_style = ctxt . styles[ctxt . style_index] . style;
                             
                             uint32_t t_font_size, t_font_style;
                             t_font_size = 0;
@@ -2291,11 +2291,11 @@ MCParagraph *MCField::importhtmltext(MCValueRef p_text)
                             }
                             
                             if (t_font_style != 0)
-                                t_char_style . has_text_style = true, t_char_style . text_style = t_font_style;
+                                t_tag_style . has_text_style = true, t_tag_style . text_style = t_font_style;
                             if (t_font_size != 0)
-                                t_char_style . has_text_size = true, t_char_style . text_size = t_font_size;
+                                t_tag_style . has_text_size = true, t_tag_style . text_size = t_font_size;
 							
-                            import_html_push_tag(ctxt, t_tag . type, t_char_style);
+                            import_html_push_tag(ctxt, t_tag . type, t_tag_style);
                         }
                         else
                             import_html_pop_tag(ctxt, t_tag . type, true);

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -285,11 +285,11 @@ Boolean MCGraphic::mfocus(int2 x, int2 y)
 				real8 dx = (real8)(mx - startx);
 				real8 dy = (real8)(my - starty);
 				real8 length = sqrt(dx * dx + dy * dy);
-				real8 angle = atan2(dy, dx);
+				real8 t_angle = atan2(dy, dx);
 				real8 quanta = M_PI * 2.0 / (real8)MCslices;
-				angle = floor((angle + quanta / 2.0) / quanta) * quanta;
-				mx = startx + (int2)(cos(angle) * length);
-				my = starty + (int2)(sin(angle) * length);
+				angle = floor((t_angle + quanta / 2.0) / quanta) * quanta;
+				mx = startx + (int2)(cos(t_angle) * length);
+				my = starty + (int2)(sin(t_angle) * length);
 			}
 			realpoints[nrealpoints - 1].x = mx;
 			realpoints[nrealpoints - 1].y = my;
@@ -724,12 +724,12 @@ void MCGraphic::draw_arrow(MCDC *dc, MCPoint &p1, MCPoint &p2)
 	if (arrowsize == 0 || (dx == 0.0 && dy == 0.0))
 		return;
 	MCPoint pts[3];
-	real8 angle = atan2(dy, dx);
-	real8 a1 = angle + 3.0 * M_PI / 4.0;
-	real8 a2 = angle - 3.0 * M_PI / 4.0;
+	real8 t_angle = atan2(dy, dx);
+	real8 a1 = t_angle + 3.0 * M_PI / 4.0;
+	real8 a2 = t_angle - 3.0 * M_PI / 4.0;
 	real8 size = get_arrow_size();
-	pts[0].x = p2.x + (int2)(cos(angle) * size);
-	pts[0].y = p2.y + (int2)(sin(angle) * size);
+	pts[0].x = p2.x + (int2)(cos(t_angle) * size);
+	pts[0].y = p2.y + (int2)(sin(t_angle) * size);
 	pts[1].x = p2.x + (int2)(cos(a1) * size);
 	pts[1].y = p2.y + (int2)(sin(a1) * size);
 	pts[2].x = p2.x + (int2)(cos(a2) * size);

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -150,13 +150,13 @@ Parse_stat MCHandler::newparam(MCScriptPoint& sp)
 Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 {
 	Parse_stat stat;
-	Symbol_type type;
+	Symbol_type t_type;
 	
 	firstline = sp.getline();
 	hlist = sp.gethlist();
 	prop = isprop;
 
-	if (sp.next(type) != PS_NORMAL)
+	if (sp.next(t_type) != PS_NORMAL)
 	{
 		MCperror->add(PE_HANDLER_NONAME, sp);
 		return PS_ERROR;
@@ -166,7 +166,7 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 	
 	const LT *te;
 	// MW-2010-01-08: [[Bug 7792]] Check whether the handler name is a reserved function identifier
-	if (type != ST_ID ||
+	if (t_type != ST_ID ||
 			sp.lookup(SP_COMMAND, te) != PS_NO_MATCH ||
 			(sp.lookup(SP_FACTOR, te) != PS_NO_MATCH &&
 			te -> type == TT_FUNCTION))
@@ -176,11 +176,11 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 	}
 	if (prop)
 	{
-		if (sp.next(type) == PS_NORMAL)
+		if (sp.next(t_type) == PS_NORMAL)
 		{
-			if (type == ST_LB)
+			if (t_type == ST_LB)
 			{
-				if (sp.next(type) != PS_NORMAL || type != ST_ID)
+				if (sp.next(t_type) != PS_NORMAL || t_type != ST_ID)
 				{
 					MCperror->add(PE_HANDLER_BADPARAM, sp);
 					return PS_ERROR;
@@ -189,7 +189,7 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 				if (newparam(sp) != PS_NORMAL)
 					return PS_ERROR;
 
-				if (sp.next(type) != PS_NORMAL || type != ST_RB)
+				if (sp.next(t_type) != PS_NORMAL || t_type != ST_RB)
 				{
 					MCperror->add(PE_HANDLER_BADPARAM, sp);
 					return PS_ERROR;
@@ -204,14 +204,15 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
     bool t_needs_it;
     t_needs_it = true;
     
-	while (sp.next(type) == PS_NORMAL)
+	while (sp.next(t_type) == PS_NORMAL)
 	{
-		if (type == ST_SEP)
+		if (t_type == ST_SEP)
 			continue;
-		const LT *te;
-		MCExpression *newfact = NULL;
-		if (type != ST_ID
-		        || sp.lookup(SP_FACTOR, te) != PS_NO_MATCH
+		const LT *t_te;
+		
+        MCExpression *newfact = NULL;
+		if (t_type != ST_ID
+		        || sp.lookup(SP_FACTOR, t_te) != PS_NO_MATCH
 		        || sp.lookupconstant(&newfact) == PS_NORMAL)
 		{
 			delete newfact;
@@ -241,7 +242,7 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 	MCStatement *newstatement = NULL;
 	while (True)
 	{
-		if ((stat = sp.next(type)) != PS_NORMAL)
+		if ((stat = sp.next(t_type)) != PS_NORMAL)
 		{
 			if (stat == PS_EOL)
 			{
@@ -259,11 +260,11 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 				return PS_ERROR;
 			}
 		}
-		if (type == ST_DATA)
+		if (t_type == ST_DATA)
 			newstatement = new MCEcho;
 		else if (sp.lookup(SP_COMMAND, te) != PS_NORMAL)
 		{
-			if (type != ST_ID)
+			if (t_type != ST_ID)
 			{
 				MCperror->add(PE_HANDLER_NOCOMMAND, sp);
 				return PS_ERROR;
@@ -278,7 +279,7 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 				newstatement = MCN_new_statement(te->which);
 				break;
 			case TT_END:
-				if ((stat = sp.next(type)) != PS_NORMAL)
+				if ((stat = sp.next(t_type)) != PS_NORMAL)
 				{
 					MCperror->add(PE_HANDLER_NOEND, sp);
 					return PS_ERROR;

--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -2019,9 +2019,9 @@ IO_stat MCHcstak::read(IO_handle stream)
 				uint1 *eptr = uint1ptr + boffset;
 				while (uint1ptr < eptr)
 				{
-					uint1 byte = *uint1ptr++;
+					uint1 t_byte = *uint1ptr++;
 					uint2 count = 1;
-					if (byte == 0x90 && *uint1ptr == 0)
+					if (t_byte == 0x90 && *uint1ptr == 0)
 						uint1ptr++;
 					else
 						if (*uint1ptr == 0x90)
@@ -2031,7 +2031,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 							if (count == 0)
 							{
 								fullbuffer[doffset++] = byte;
-								byte = 0x90;
+								t_byte = 0x90;
 								if (*uint1ptr == 0x90)
 								{
 									uint1ptr++;
@@ -2044,7 +2044,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 							}
 						}
 					while (count--)
-						fullbuffer[doffset++] = byte;
+						fullbuffer[doffset++] = t_byte;
 					if (doffset > fullsize - 256)
 					{
 						MCU_realloc((char **)&fullbuffer, fullsize,
@@ -2077,14 +2077,14 @@ IO_stat MCHcstak::read(IO_handle stream)
 	}
 	uint2 i;
 	uint4 type = 0;
-	char *buffer;
+	char *t_buffer;
 	while (type != HC_TAIL)
 	{
 		if (filetype == HC_BINHEX)
 		{
-			buffer = &fullbuffer[boffset];
-			uint2buff = (uint2 *)buffer;
-			uint4buff = (uint4 *)buffer;
+			t_buffer = &fullbuffer[boffset];
+			uint2buff = (uint2 *)t_buffer;
+			uint4buff = (uint4 *)t_buffer;
 			type = swap_uint4(&uint4buff[1]);
 			size = swap_uint4(&uint4buff[0]);
 			boffset += size;
@@ -2099,15 +2099,15 @@ IO_stat MCHcstak::read(IO_handle stream)
 			fullbuffer = new char[size];
 			if (IO_read(&fullbuffer[8], size - 8, stream) != IO_NORMAL)
 				return IO_ERROR;
-			buffer = fullbuffer;
-			uint2buff = (uint2 *)buffer;
-			uint4buff = (uint4 *)buffer;
+			t_buffer = fullbuffer;
+			uint2buff = (uint2 *)t_buffer;
+			uint4buff = (uint4 *)t_buffer;
 		}
 		uint2 offset;
 		switch (type)
 		{
 		case HC_STAK:
-			version = buffer[108];
+			version = t_buffer[108];
 			if (version > 2)
 				return IO_ERROR;
 			if (version == 0)
@@ -2119,7 +2119,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 				rect.width = 512;
 				rect.height = 342;
 			}
-			script = convert_script(&buffer[1536]);
+			script = convert_script(&t_buffer[1536]);
 			break;
 		case HC_LIST:
 			if (version == 1)
@@ -2134,7 +2134,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 			            npbuffers + 1, sizeof(uint2));
 			pbuffersizes[npbuffers] = size;
 			pbuffers[npbuffers] = new char[size];
-			memcpy(pbuffers[npbuffers++], buffer, size);
+			memcpy(pbuffers[npbuffers++], t_buffer, size);
 			break;
 		case HC_BKGD:
 			{
@@ -2148,7 +2148,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 			{
 				MCHccard *newcard = new MCHccard;
 				newcard->appendto(hccards);
-				if (newcard->parse(buffer) != IO_NORMAL)
+				if (newcard->parse(t_buffer) != IO_NORMAL)
 					return IO_ERROR;
 			}
 			break;
@@ -2183,8 +2183,8 @@ IO_stat MCHcstak::read(IO_handle stream)
 				for (i = 0 ; i < nfonts ; i++)
 				{
 					fonts[i].id = swap_uint2(&uint2buff[offset]);
-					fonts[i].name = convert_font(&buffer[(offset + 1) * 2]);
-					offset += (strlen(&buffer[(offset + 1) * 2]) + 4) >> 1;
+					fonts[i].name = convert_font(&t_buffer[(offset + 1) * 2]);
+					offset += (strlen(&t_buffer[(offset + 1) * 2]) + 4) >> 1;
 				}
 			}
 			break;
@@ -2226,16 +2226,16 @@ IO_stat MCHcstak::read(IO_handle stream)
 	else
 		memcpy(fullbuffer, &fullbuffer[roffset], rsize);
 	iconx = icony = cursorx = cursory = 0;
-	buffer = fullbuffer;
-	uint4buff = (uint4 *)buffer;
-	char *rdata = &buffer[swap_uint4(&uint4buff[0])];
+	t_buffer = fullbuffer;
+	uint4buff = (uint4 *)t_buffer;
+	char *rdata = &t_buffer[swap_uint4(&uint4buff[0])];
 	char *rheader = rdata + swap_uint4(&uint4buff[2]);
 	uint2 typecount = get_uint2(&rheader[28]) + 1;
 	char *strings = rheader + get_uint2(&rheader[26]);
 	char *objects = &rheader[typecount * 8 + 30];
 	for (i = 0 ; i < typecount ; i++)
 	{
-		uint4 type = get_uint4(&rheader[i * 8 + 30]);
+		uint4 t_type = get_uint4(&rheader[i * 8 + 30]);
 		uint2 count = get_uint2(&rheader[i * 8 + 34]) + 1;
 		while (count--)
 		{
@@ -2254,7 +2254,7 @@ IO_stat MCHcstak::read(IO_handle stream)
             
 			uint4 offset = get_uint4(&objects[4]);
 			offset &= 0xFFFFFF;
-			switch (type)
+			switch (t_type)
 			{
 			case HC_ICON:
 				{
@@ -2281,7 +2281,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 				break;
 			default:
 				hcstat_append("Not converting %4.4s id %5d \"%s\"",
-				        (char *)&type, id, MCNameGetCString(*t_name));
+				        (char *)&t_type, id, MCNameGetCString(*t_name));
 				break;
 			}
 			objects += 12;

--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -226,7 +226,6 @@ Parse_stat MCHandlerlist::findvar(MCNameRef p_name, bool p_ignore_uql, MCVarref 
 	// 'code' in 'global' scope).
 	if (MCNameGetCharAtIndex(p_name, 0) == '$')
 	{
-		MCVariable *tmp;
 		for (tmp = MCglobals ; tmp != NULL ; tmp = tmp->getnext())
 			if (tmp->hasname(p_name))
 			{

--- a/engine/src/ifile.cpp
+++ b/engine/src/ifile.cpp
@@ -186,7 +186,6 @@ void MCImage::openimage()
 	{
 		// MW-2013-06-21: [[ Valgrind ]] Initialize width/height to defaults in
 		//   case GetGeometry fails.
-		uindex_t t_width, t_height;
 		t_width = rect . width;
 		t_height = rect . height;
 		

--- a/engine/src/ijpg.cpp
+++ b/engine/src/ijpg.cpp
@@ -236,7 +236,7 @@ static bool read_exif_orientation(j_decompress_ptr cinfo, uint32_t *r_orientatio
 	
 	for(uindex_t i = 0; i < t_count; i++)
 	{
-		uint16_t t_tag, t_format;
+		uint16_t t_format;
 		uint32_t t_components;
 		memcpy(&t_tag, t_ifd_ptr + 0, 2);
 		memcpy(&t_format, t_ifd_ptr + 2, 2);

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -552,7 +552,7 @@ Boolean MCObject::kdown(MCStringRef p_string, KeySym key)
 			return True;
         break;
     default:
-		MCAutoStringRef t_string;
+		MCAutoStringRef t_key_string;
 			
 		// Special keys as their number converted to a string, the rest by value
         // SN-2014-12-08: [[ Bug 12681 ]] Avoid to print the keycode in case we have a
@@ -560,26 +560,26 @@ Boolean MCObject::kdown(MCStringRef p_string, KeySym key)
         // SN-2015-05-05: [[ Bug 15305 ]] Ensure that the keys are not printing
         //  their numeric value, if not wanted.
         if (key > 0xFF && (key & XK_Class_mask) == XK_Class_compat && (key < XK_KP_Space || key > XK_KP_Equal))
-            /* UNCHECKED */ MCStringFormat(&t_string, "%ld", key);
+            /* UNCHECKED */ MCStringFormat(&t_key_string, "%ld", key);
         else if (MCmodifierstate & MS_CONTROL)
-            /* UNCHECKED */ MCStringFormat(&t_string, "%c", (char)key);
+            /* UNCHECKED */ MCStringFormat(&t_key_string, "%c", (char)key);
 		else
-			t_string = p_string;
+			t_key_string = p_string;
 			
 		if (MCmodifierstate & MS_CONTROL)
         {
-			if (message_with_valueref_args(MCM_command_key_down, *t_string) == ES_NORMAL)
+			if (message_with_valueref_args(MCM_command_key_down, *t_key_string) == ES_NORMAL)
 				return True;
 		}
 		else if (MCmodifierstate & MS_MOD1)
         {
-				if (message_with_valueref_args(MCM_option_key_down, *t_string) == ES_NORMAL)
+				if (message_with_valueref_args(MCM_option_key_down, *t_key_string) == ES_NORMAL)
 				return True;
         }
 #ifdef _MACOSX
 		else if (MCmodifierstate & MS_MAC_CONTROL)
         {
-			if (message_with_valueref_args(MCM_control_key_down, *t_string) == ES_NORMAL)
+			if (message_with_valueref_args(MCM_control_key_down, *t_key_string) == ES_NORMAL)
 				return True;
         }
 #endif
@@ -953,9 +953,9 @@ Exec_stat MCObject::exechandler(MCHandler *hptr, MCParameter *params)
 		//   differently.
 		if (hptr -> getfileindex() == 0)
         {
-            MCExecContext ctxt(this, nil, nil);
+            MCExecContext ctxt2(this, nil, nil);
             MCAutoStringRef t_id;
-			getstringprop(ctxt, 0, P_LONG_ID, False, &t_id);
+			getstringprop(ctxt2, 0, P_LONG_ID, False, &t_id);
             MCeerror->add(EE_OBJECT_NAME, 0, 0, *t_id);
 		}
 		else
@@ -1005,9 +1005,9 @@ Exec_stat MCObject::execparenthandler(MCHandler *hptr, MCParameter *params, MCPa
 		stat = hptr->exec(ctxt, params);
 	if (stat == ES_ERROR)
     {
-        MCExecContext ctxt(this, nil, nil);
+        MCExecContext ctxt2(this, nil, nil);
         MCAutoStringRef t_id;
-        parentscript -> GetParent() -> GetObject() -> getstringprop(ctxt, 0, P_LONG_ID, False, &t_id);
+        parentscript -> GetParent() -> GetObject() -> getstringprop(ctxt2, 0, P_LONG_ID, False, &t_id);
         MCeerror->add(EE_OBJECT_NAME, 0, 0, *t_id);
 	}
 	unlockforexecution();

--- a/engine/src/operator.cpp
+++ b/engine/src/operator.cpp
@@ -485,47 +485,47 @@ Parse_stat MCIs::parse(MCScriptPoint &sp, Boolean the)
 				{
 					if (sp . skip_token(SP_FACTOR, TT_THE) == PS_NORMAL)
 					{
-						Symbol_type type;
-						const LT *te;
-						if (sp . next(type) == PS_NORMAL)
+						Symbol_type t_type;
+						const LT *t_te;
+						if (sp . next(t_type) == PS_NORMAL)
 						{
-							if ((sp.lookup(SP_FACTOR, te) == PS_NORMAL
-									&& (te->which == P_DRAG_DATA
-                                        || te->which == P_CLIPBOARD_DATA
-                                        || te->which == P_RAW_CLIPBOARD_DATA
-                                        || te->which == P_RAW_DRAGBOARD_DATA
-                                        || te->which == P_FULL_CLIPBOARD_DATA
-                                        || te->which == P_FULL_DRAGBOARD_DATA)))
+							if ((sp.lookup(SP_FACTOR, t_te) == PS_NORMAL
+									&& (t_te->which == P_DRAG_DATA
+                                        || t_te->which == P_CLIPBOARD_DATA
+                                        || t_te->which == P_RAW_CLIPBOARD_DATA
+                                        || t_te->which == P_RAW_DRAGBOARD_DATA
+                                        || t_te->which == P_FULL_CLIPBOARD_DATA
+                                        || t_te->which == P_FULL_DRAGBOARD_DATA)))
 							{
-								if (te -> which == P_CLIPBOARD_DATA)
+								if (t_te -> which == P_CLIPBOARD_DATA)
 								{
 									if (form == IT_NOT_AMONG)
 										form = IT_NOT_AMONG_THE_CLIPBOARD_DATA;
 									else
 										form = IT_AMONG_THE_CLIPBOARD_DATA;
 								}
-                                else if (te -> which == P_RAW_CLIPBOARD_DATA)
+                                else if (t_te -> which == P_RAW_CLIPBOARD_DATA)
                                 {
                                     if (form == IT_NOT_AMONG)
                                         form = IT_NOT_AMONG_THE_RAW_CLIPBOARD_DATA;
                                     else
                                         form = IT_AMONG_THE_RAW_CLIPBOARD_DATA;
                                 }
-                                else if (te -> which == P_RAW_DRAGBOARD_DATA)
+                                else if (t_te -> which == P_RAW_DRAGBOARD_DATA)
                                 {
                                    if (form == IT_NOT_AMONG)
                                        form = IT_NOT_AMONG_THE_RAW_DRAGBOARD_DATA;
                                     else
                                         form = IT_AMONG_THE_RAW_DRAGBOARD_DATA;
                                 }
-                                else if (te -> which == P_FULL_CLIPBOARD_DATA)
+                                else if (t_te -> which == P_FULL_CLIPBOARD_DATA)
                                 {
                                     if (form == IT_NOT_AMONG)
                                         form = IT_NOT_AMONG_THE_FULL_CLIPBOARD_DATA;
                                     else
                                         form = IT_AMONG_THE_FULL_CLIPBOARD_DATA;
                                 }
-                                else if (te -> which == P_FULL_DRAGBOARD_DATA)
+                                else if (t_te -> which == P_FULL_DRAGBOARD_DATA)
                                 {
                                     if (form == IT_NOT_AMONG)
                                         form = IT_NOT_AMONG_THE_FULL_DRAGBOARD_DATA;
@@ -588,7 +588,6 @@ void MCIs::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
         if (!ctxt . EvalExprAsValueRef(right, EE_IS_BADLEFT, &t_value))
             return;
         
-        bool t_result;
         switch(valid)
         {
             case IV_UNDEFINED:

--- a/engine/src/osxcoreimage.cpp
+++ b/engine/src/osxcoreimage.cpp
@@ -199,22 +199,22 @@ bool MCCoreImageEffectBegin(const char *p_name, MCGImageRef p_source_a, MCGImage
                 }
 				if (t_image != NULL)
 				{
-					MCRectangle t_rect;
-					t_rect = t_image -> getrect();
+					MCRectangle t_image_rect;
+					t_image_rect = t_image -> getrect();
 					
 					rei_uint32_t *t_data;
-					t_data = (rei_uint32_t *)malloc(t_rect . width * t_rect . height * 4);
+					t_data = (rei_uint32_t *)malloc(t_image_rect . width * t_image_rect . height * 4);
 					if (t_data != NULL)
 					{
 						MCImageBitmap *t_bitmap = nil;
 						if (t_image->lockbitmap(t_bitmap, true))
-							MCImageBitmapPremultiplyRegion(t_bitmap, 0, 0, t_bitmap->width, t_bitmap->height, t_rect.width * sizeof(uint32_t), t_data);
+							MCImageBitmapPremultiplyRegion(t_bitmap, 0, 0, t_bitmap->width, t_bitmap->height, t_image_rect.width * sizeof(uint32_t), t_data);
 						else
-							MCMemoryClear(t_data, t_rect.width * sizeof(uint32_t) * t_rect.height);
+							MCMemoryClear(t_data, t_image_rect.width * sizeof(uint32_t) * t_image_rect.height);
 						t_image->unlockbitmap(t_bitmap);
 						
-						t_parameters -> entries[t_index] . value . image . width = t_rect . width;
-						t_parameters -> entries[t_index] . value . image . height = t_rect . height;
+						t_parameters -> entries[t_index] . value . image . width = t_image_rect . width;
+						t_parameters -> entries[t_index] . value . image . height = t_image_rect . height;
 						t_parameters -> entries[t_index] . value . image . data = t_data;
 					}
 					else

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -1582,10 +1582,10 @@ void MCParagraph::draw(MCDC *dc, int2 x, int2 y, uint2 fixeda,
 					if (IsMacLF() && !parent->isautoarm())
 					{
 						MCPatternRef t_pattern;
-						int2 x, y;
+						int2 t_x, t_y;
 						MCColor fc, hc;
-						parent->getforecolor(DI_FORE, False, True, fc, t_pattern, x, y, dc -> gettype(), parent);
-						parent->getforecolor(DI_HILITE, False, True, hc, t_pattern, x, y, dc -> gettype(), parent);
+						parent->getforecolor(DI_FORE, False, True, fc, t_pattern, t_x, t_y, dc -> gettype(), parent);
+						parent->getforecolor(DI_HILITE, False, True, hc, t_pattern, t_x, t_y, dc -> gettype(), parent);
 						if (MCColorGetPixel(hc) == MCColorGetPixel(fc))
 							parent->setforeground(dc, DI_BACK, False, True);
 					}
@@ -1715,17 +1715,17 @@ void MCParagraph::draw(MCDC *dc, int2 x, int2 y, uint2 fixeda,
 			t_limit = parent -> getrect() . x + parent -> getrect() . width;
 
 			uint2 ct = 0; 
-			int4 x = t[0] + t_delta;
-			while (x <= t_limit)
+			int4 t_x = t[0] + t_delta;
+			while (t_x <= t_limit)
 			{
-				dc->drawline(x, t_inner_border_rect . y, x, t_inner_border_rect . y + t_inner_border_rect . height);
+				dc->drawline(t_x, t_inner_border_rect . y, t_x, t_inner_border_rect . y + t_inner_border_rect . height);
 				
 				if (ct < nt - 1)
-					x = t_delta + t[++ct];
+					t_x = t_delta + t[++ct];
 				else if (nt == 1)
-					x += t[0];
+					t_x += t[0];
 				else
-					x += t[nt - 1] - t[nt - 2];
+					t_x += t[nt - 1] - t[nt - 2];
 
 				// MW-2012-02-10: [[ FixedTable ]] If we have reached the final tab in fixed
 				//   table mode, we are done.

--- a/engine/src/regex.cpp
+++ b/engine/src/regex.cpp
@@ -364,7 +364,6 @@ regexp *MCR_compile(MCStringRef exp, bool casesensitive)
 	// If the pattern is new, put it in the cache.
 	if (!found)
 	{
-		uint2 i;
 		MCR_free(MCregexcache[PATTERN_CACHE_SIZE - 1]);
 		for (i = PATTERN_CACHE_SIZE - 1 ; i ; i--)
 		{

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -306,7 +306,7 @@ Exec_stat MCSellist::group(uint2 line, uint2 pos, MCGroup*& r_group_ptr)
 		MCControl *controls = NULL;
 		while (objects != NULL)
 		{
-			MCSelnode *tptr = objects->remove(objects);
+			tptr = objects->remove(objects);
 			MCControl *cptr = (MCControl *)tptr->ref;
 			delete tptr;
 			if (parent->gettype() == CT_CARD)

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -335,8 +335,8 @@ extern void MCU_initialize_names();
 
 bool X_init(int argc, MCStringRef argv[], MCStringRef envp[])
 {
-	int i;
-	MCstackbottom = (char *)&i;
+	int t_bottom;
+	MCstackbottom = (char *)&t_bottom;
 
     ////
 
@@ -627,28 +627,28 @@ int platform_main(int argc, char *argv[], char *envp[])
 	MCStringRef *t_new_argv;
 	/* UNCHECKED */ MCMemoryNewArray(argc, t_new_argv);
 	
-	for (int i = 0; i < argc; i++)
+	for (int t_arg = 0; t_arg < argc; t_arg++)
 	{
-		/* UNCHECKED */ MCStringCreateWithBytes((const byte_t *)argv[i], strlen(argv[i]), kMCStringEncodingUTF8, false, t_new_argv[i]);
+		/* UNCHECKED */ MCStringCreateWithBytes((const byte_t *)argv[t_arg], strlen(argv[t_arg]), kMCStringEncodingUTF8, false, t_new_argv[t_arg]);
 	}
 	
 	MCStringRef *t_new_envp;
 	/* UNCHECKED */ MCMemoryNewArray(1, t_new_envp);
 	
-	int i = 0;
+	uindex_t t_env = 0;
 	uindex_t t_envp_count = 0;
 	
-	while (envp[i] != NULL)
+	while (envp[t_env] != NULL)
 	{
 		t_envp_count++;
-		uindex_t t_count = i;
-		/* UNCHECKED */ MCMemoryResizeArray(i + 1, t_new_envp, t_count);
-		/* UNCHECKED */ MCStringCreateWithBytes((const byte_t *)envp[i], strlen(envp[i]), kMCStringEncodingUTF8, false, t_new_envp[i]);
-		i++;
+		uindex_t t_count = t_env;
+		/* UNCHECKED */ MCMemoryResizeArray(t_env + 1, t_new_envp, t_count);
+		/* UNCHECKED */ MCStringCreateWithBytes((const byte_t *)envp[t_env], strlen(envp[t_env]), kMCStringEncodingUTF8, false, t_new_envp[t_env]);
+		t_env++;
 	}
 	
-	/* UNCHECKED */ MCMemoryResizeArray(i + 1, t_new_envp, t_envp_count);
-	t_new_envp[i] = nil;
+	/* UNCHECKED */ MCMemoryResizeArray(t_env + 1, t_new_envp, t_envp_count);
+	t_new_envp[t_env] = nil;
 // END MAC SPECIFIC	
 
 	if (!X_init(argc, t_new_argv, t_new_envp))
@@ -659,15 +659,15 @@ int platform_main(int argc, char *argv[], char *envp[])
 	int t_exit_code;
 	t_exit_code = X_close();
 
-	for (int i = 0; i < argc; i++)
+	for (int t_arg = 0; t_arg < argc; t_arg++)
 	{
-		MCValueRelease(t_new_argv[i]);
+		MCValueRelease(t_new_argv[t_arg]);
 	}
 	MCMemoryDeleteArray(t_new_argv);
 
-	for (uindex_t i = 0; i < t_envp_count; i++)
+	for (t_env = 0; t_env < t_envp_count; t_env++)
 	{
-		MCValueRelease(t_new_envp[i]);
+		MCValueRelease(t_new_envp[t_env]);
 	}
 	MCMemoryDeleteArray(t_new_envp);
 

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1703,10 +1703,10 @@ bool MCStack::resolve_relative_path_to_default_folder(MCStringRef p_path, MCStri
 // This function will attempt to resolve the specified filename relative to the stack
 // and will either return an absolute path if the filename was found relative to the stack,
 // or a copy of the original buffer. The returned buffer should be freed by the caller.
-bool MCStack::resolve_filename(MCStringRef filename, MCStringRef& r_resolved)
+bool MCStack::resolve_filename(MCStringRef p_filename, MCStringRef& r_resolved)
 {
     MCAutoStringRef t_filename;
-    if (resolve_relative_path(filename, &t_filename))
+    if (resolve_relative_path(p_filename, &t_filename))
     {
         if (MCS_exists(*t_filename, True))
         {
@@ -1715,7 +1715,7 @@ bool MCStack::resolve_filename(MCStringRef filename, MCStringRef& r_resolved)
         }
     }
     
-	r_resolved = MCValueRetain(filename);
+	r_resolved = MCValueRetain(p_filename);
 	return true;
 }
 

--- a/engine/src/stacklst.cpp
+++ b/engine/src/stacklst.cpp
@@ -354,15 +354,15 @@ Boolean MCStacklist::doaccelerator(KeySym p_key)
 				t_menubar -> message_with_valueref_args(MCM_mouse_down, kMCEmptyString);
 
 				// We now need to re-search for the accelerator, since it could have gone/been deleted in the mouseDown
-				for(uint2 i = 0; i < naccelerators; i++)
+				for(uint2 t_accelerator = 0; t_accelerator < naccelerators; t_accelerator++)
 				{
-					if (t_lowersym == accelerators[i] . key && (MCmodifierstate & t_mod_mask) == (accelerators[i].mods & t_mod_mask) && accelerators[i] . button -> getparent() == t_menubar)
+					if (t_lowersym == accelerators[t_accelerator] . key && (MCmodifierstate & t_mod_mask) == (accelerators[t_accelerator].mods & t_mod_mask) && accelerators[t_accelerator] . button -> getparent() == t_menubar)
 					{
                         MCmodifierstate &= t_mod_mask;
                         // TKD-2014-09-26: [[ Bug 13560 ]] Unlock the screen prior to triggering menu item. If code outside of
                         //   the engine updates the window size the window isn't redrawn (e.g. [NSWindow toggleFullScreen:nil]).
                         MCRedrawUnlockScreen();
-                        accelerators[i] . button -> activate(True, t_lowersym);
+                        accelerators[t_accelerator] . button -> activate(True, t_lowersym);
 						return True;
 					}
 				}

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -429,7 +429,7 @@ char *MCU_strtok(char *s, const char *delim)
 	return True == t_converted;
 }
 
-int4 MCU_strtol(const char *&sptr, uint4 &l, int1 c, Boolean &done,
+int4 MCU_strtol(const char *&sptr, uint4 &l, int1 p_delim, Boolean &done,
                 Boolean reals, Boolean octals)
 {
 	done = False;
@@ -476,7 +476,7 @@ int4 MCU_strtol(const char *&sptr, uint4 &l, int1 c, Boolean &done,
 			if (isspace((uint1)*sptr))
 			{
 				MCU_skip_spaces(sptr, l);
-				if (l && *sptr == c)
+				if (l && *sptr == p_delim)
 				{
 					sptr++;
 					l--;
@@ -484,7 +484,7 @@ int4 MCU_strtol(const char *&sptr, uint4 &l, int1 c, Boolean &done,
 				break;
 			}
 			else
-				if (l && c && *sptr == c)
+				if (l && p_delim && *sptr == p_delim)
 				{
 					sptr++;
 					l--;
@@ -519,7 +519,7 @@ int4 MCU_strtol(const char *&sptr, uint4 &l, int1 c, Boolean &done,
 								while (l && *sptr == '0');
 							if (l == 0)
 								break;
-							if (*sptr == c || isspace((uint1)*sptr))
+							if (*sptr == p_delim || isspace((uint1)*sptr))
 							{
 								sptr++;
 								l--;
@@ -530,11 +530,11 @@ int4 MCU_strtol(const char *&sptr, uint4 &l, int1 c, Boolean &done,
 					}
 					else
 					{
-						char c = MCS_tolower(*sptr);
-						if (base == 16 && c >= 'a' && c <= 'f')
+						char t_char = MCS_tolower(*sptr);
+						if (base == 16 && t_char >= 'a' && t_char <= 'f')
 						{
 							value *= base;
-							value += c - 'a' + 10;
+							value += t_char - 'a' + 10;
 						}
 						else
 							return 0;
@@ -1183,7 +1183,7 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
                    const MCRectangle &rect, uint2 radius, uint2 startAngle, uint2 arcAngle, uint2 flags)
 {
 	uint2 i, j, k, count;
-	uint2 x, y;
+	uint2 t_x, t_y;
 	bool ignore = false;
 
 	if (points == NULL || npoints != 4 * QA_NPOINTS + 1)
@@ -1235,8 +1235,8 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 		{
 			if (flags & F_OPAQUE)
 			{
-				x = origin_horiz;
-				y = origin_vert;
+				t_x = origin_horiz;
+				t_y = origin_vert;
 			}
 			else
 			{
@@ -1245,31 +1245,31 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 		}
 		else if (count < 90) // quadrant 1
 		{
-			x = tr . x + tr . width - rr_width + (qa_points[j] . x * rr_width / MAXINT2);
-			y = tr . y                         + (qa_points[j] . y * rr_height / MAXINT2);
+			t_x = tr . x + tr . width - rr_width + (qa_points[j] . x * rr_width / MAXINT2);
+			t_y = tr . y                         + (qa_points[j] . y * rr_height / MAXINT2);
 		}
 		else if (count < 180) // quadrant 2
 		{
-			x = origin_horiz - (qa_points[k] . x * rr_width / MAXINT2);
-			y = tr . y       + (qa_points[k] . y * rr_height / MAXINT2);
+			t_x = origin_horiz - (qa_points[k] . x * rr_width / MAXINT2);
+			t_y = tr . y       + (qa_points[k] . y * rr_height / MAXINT2);
 		}
 		else if (count < 270) // quadrant 3
 		{
-			x = origin_horiz         - (qa_points[j] . x * rr_width / MAXINT2);
-			y = tr . y + tr . height - (qa_points[j] . y * rr_height / MAXINT2);
+			t_x = origin_horiz         - (qa_points[j] . x * rr_width / MAXINT2);
+			t_y = tr . y + tr . height - (qa_points[j] . y * rr_height / MAXINT2);
 		}
 		else // quadrant 4
 		{
-			x = tr . x + tr . width - rr_width + (qa_points[k] . x * rr_width / MAXINT2);
-			y = tr . y + tr . height           - (qa_points[k] . y * rr_height / MAXINT2);
+			t_x = tr . x + tr . width - rr_width + (qa_points[k] . x * rr_width / MAXINT2);
+			t_y = tr . y + tr . height           - (qa_points[k] . y * rr_height / MAXINT2);
 		}
 
 		if (ignore == false)
 		{
-			if (x != points[i-1] . x || y != points[i-1] . y)
+			if (t_x != points[i-1] . x || t_y != points[i-1] . y)
 			{
-				points[i] . x = x;
-				points[i] . y = y;
+				points[i] . x = t_x;
+				points[i] . y = t_y;
 				i++;
 			}
 		}
@@ -1358,26 +1358,26 @@ Boolean MCU_parsepoint(MCPoint &point, MCStringRef data)
 	return True;
 }
 
-void MCU_set_rect(MCRectangle &rect, int2 x, int2 y, uint2 w, uint2 h)
+void MCU_set_rect(MCRectangle &rect, int2 p_x, int2 p_y, uint2 p_w, uint2 p_h)
 {
-	rect.x = x;
-	rect.y = y;
-	rect.width = w;
-	rect.height = h;
+	rect.x = p_x;
+	rect.y = p_y;
+	rect.width = p_w;
+	rect.height = p_h;
 }
 
-void MCU_set_rect(MCRectangle32 &rect, int32_t x, int32_t y, int32_t w, int32_t h)
+void MCU_set_rect(MCRectangle32 &rect, int32_t p_x, int32_t p_y, int32_t p_w, int32_t p_h)
 {
-	rect.x = x;
-	rect.y = y;
-	rect.width = w;
-	rect.height = h;
+	rect.x = p_x;
+	rect.y = p_y;
+	rect.width = p_w;
+	rect.height = p_h;
 }
 
-Boolean MCU_point_in_rect(const MCRectangle &srect, int2 x, int2 y)
+Boolean MCU_point_in_rect(const MCRectangle &srect, int2 p_x, int2 p_y)
 {
-	if (x >= srect.x && x < srect.x + srect.width
-	        && y >= srect.y && y < srect.y + srect.height)
+	if (p_x >= srect.x && p_x < srect.x + srect.width
+	        && p_y >= srect.y && p_y < srect.y + srect.height)
 		return True;
 	return False;
 }
@@ -1421,76 +1421,76 @@ bool MCU_line_intersect_rect(const MCRectangle& srect, const MCRectangle& line)
 }
 
 
-static inline double distance_to_point(int4 x, int4 y, int4 px, int4 py)
+static inline double distance_to_point(int4 p_x, int4 p_y, int4 p_px, int4 p_py)
 {
 	double dx, dy;
 
-	dx = px - x;
-	dy = py - y;
+	dx = p_px - p_x;
+	dy = p_py - p_y;
 
 	return dx * dx + dy * dy;
 }
 
-double MCU_squared_distance_from_line(int4 sx, int4 sy, int4 ex, int4 ey, int4 x, int4 y)
+double MCU_squared_distance_from_line(int4 p_sx, int4 p_sy, int4 p_ex, int4 p_ey, int4 p_x, int4 p_y)
 {
 	double dx, dy;
 	double d;
 
-	dx = ex - sx;
-	dy = ey - sy;
+	dx = p_ex - p_sx;
+	dy = p_ey - p_sy;
 
 	if (dx == 0 && dy == 0)
-		d = distance_to_point(x, y, sx, sy);
+		d = distance_to_point(p_x, p_y, p_sx, p_sy);
 	else
 	{
 		double pdx, pdy;
 		double u;
 
-		pdx = x - sx;
-		pdy = y - sy;
+		pdx = p_x - p_sx;
+		pdy = p_y - p_sy;
 
 		u = (pdx * dx + pdy * dy) / (dx * dx + dy * dy);
 
 		if (u <= 0)
-			d = distance_to_point(x, y, sx, sy);
+			d = distance_to_point(p_x, p_y, p_sx, p_sy);
 		else if (u >= 1)
-			d = distance_to_point(x, y, ex, ey);
+			d = distance_to_point(p_x, p_y, p_ex, p_ey);
 		else
-			d = distance_to_point((int4)(sx + u * dx), (int4)(sy + u * dy), x, y);
+			d = distance_to_point((int4)(p_sx + u * dx), (int4)(p_sy + u * dy), p_x, p_y);
 	}
 
 	return d;
 }
 
 
-Boolean MCU_point_on_line(MCPoint *points, uint2 npoints,
-                          int2 x, int2 y, uint2 linesize)
+Boolean MCU_point_on_line(MCPoint *p_points, uint2 p_npoints,
+                          int2 p_x, int2 p_y, uint2 p_linesize)
 {
 	// OK-2008-12-04: [[Bug 7292]] - Old code replaced with stuff copied from pathprocess.cpp
 	uint2 i;
-	for (i = 0 ; i < npoints -  1 ; i++)
+	for (i = 0 ; i < p_npoints -  1 ; i++)
 	{
 		// SMR 1913 expand radius for hit testing lines
-		linesize >>= 1;
-		linesize *= linesize;
+		p_linesize >>= 1;
+		p_linesize *= p_linesize;
 
 		double t_distance;
-		t_distance = MCU_squared_distance_from_line(points[i]. x, points[i] . y, points[i + 1] . x, points[i + 1] . y, x, y);
-		if (t_distance < linesize + (4 * 4))
+		t_distance = MCU_squared_distance_from_line(p_points[i]. x, p_points[i] . y, p_points[i + 1] . x, p_points[i + 1] . y, p_x, p_y);
+		if (t_distance < p_linesize + (4 * 4))
 			return True;
 	}
 	return False;
 }
 
-Boolean MCU_point_in_polygon(MCPoint *points, uint2 npoints, int2 x, int2 y)
+Boolean MCU_point_in_polygon(MCPoint *p_points, uint2 p_npoints, int2 p_x, int2 p_y)
 {
 	// SMR 1958 don't do check if no points
-	if (npoints <= 1)
+	if (p_npoints <= 1)
 		return False;
-	MCU_offset_points(points, npoints, -x, -y);
+	MCU_offset_points(p_points, p_npoints, -p_x, -p_y);
 
-	MCPoint *endLp = &points[npoints];
-	MCPoint *lp = points;
+	MCPoint *endLp = &p_points[p_npoints];
+	MCPoint *lp = p_points;
 
 	uint2 ncross = 0;
 	int2 sign = lp->y < 0 ? -1 : 1;
@@ -1518,7 +1518,7 @@ Boolean MCU_point_in_polygon(MCPoint *points, uint2 npoints, int2 x, int2 y)
 				ncross++;
 		}
 	}
-	MCU_offset_points(points, npoints, x, y);
+	MCU_offset_points(p_points, p_npoints, p_x, p_y);
 	if (ncross & 1)
 		return True;
 	return False;
@@ -1574,51 +1574,51 @@ MCRectangle MCU_center_rect(const MCRectangle &one, const MCRectangle &two)
 	return drect;
 }
 
-MCRectangle MCU_bound_rect(const MCRectangle &srect,
-                           int2 x, int2 y, uint2 width, uint2 height)
+MCRectangle MCU_bound_rect(const MCRectangle &p_srect,
+                           int2 p_x, int2 p_y, uint2 p_width, uint2 p_height)
 {
-	MCRectangle drect = srect;
-	if (drect.x + drect.width > x + width)
-		drect.x = x + width - drect.width;
-	if (drect.x < x)
-		drect.x = x;
-	if (drect.y + drect.height > y + height)
-		drect.y = y + height - drect.height;
-	if (drect.y < y)
-		drect.y = y;
+	MCRectangle drect = p_srect;
+	if (drect.x + drect.width > p_x + p_width)
+		drect.x = p_x + p_width - drect.width;
+	if (drect.x < p_x)
+		drect.x = p_x;
+	if (drect.y + drect.height > p_y + p_height)
+		drect.y = p_y + p_height - drect.height;
+	if (drect.y < p_y)
+		drect.y = p_y;
 	return drect;
 }
 
-MCRectangle MCU_clip_rect(const MCRectangle &srect,
-                          int2 x, int2 y, uint2 width, uint2 height)
+MCRectangle MCU_clip_rect(const MCRectangle &p_srect,
+                          int2 p_x, int2 p_y, uint2 p_width, uint2 p_height)
 {
-	MCRectangle drect = srect;
-	if (srect.x < x)
+	MCRectangle drect = p_srect;
+	if (p_srect.x < p_x)
 	{
-		drect.x = x;
-		if (x - srect.x > srect.width)
+		drect.x = p_x;
+		if (p_x - p_srect.x > p_srect.width)
 			drect.width = 0;
 		else
-			drect.width -= x - srect.x;
+			drect.width -= p_x - p_srect.x;
 	}
-	if (srect.x + srect.width > x + width)
-		if (srect.x > x + width)
+	if (p_srect.x + p_srect.width > p_x + p_width)
+		if (p_srect.x > p_x + p_width)
 			drect.width = 0;
 		else
-			drect.width = x + width - drect.x;
-	if (srect.y < y)
+			drect.width = p_x + p_width - drect.x;
+	if (p_srect.y < p_y)
 	{
-		drect.y = y;
-		if (y - srect.y > srect.height)
+		drect.y = p_y;
+		if (p_y - p_srect.y > p_srect.height)
 			drect.height = 0;
 		else
-			drect.height -= y - srect.y;
+			drect.height -= p_y - p_srect.y;
 	}
-	if (srect.y + srect.height > y + height)
-		if (srect.y > y + height)
+	if (p_srect.y + p_srect.height > p_y + p_height)
+		if (p_srect.y > p_y + p_height)
 			drect.height = 0;
 		else
-			drect.height = y + height - drect.y;
+			drect.height = p_y + p_height - drect.y;
 	return drect;
 }
 

--- a/libfoundation/src/foundation-pickle.cpp
+++ b/libfoundation/src/foundation-pickle.cpp
@@ -869,10 +869,10 @@ static bool MCPickleWriteField(MCStreamRef stream, MCPickleFieldType p_kind, voi
                 
                 MCPickleRecordInfo *t_record_info;
                 t_record_info = nil;
-                for(int i = 0; t_info -> cases[i] . kind != -1; i++)
-                    if (t_kind == t_info -> cases[i] . kind)
+                for(int t_cases = 0; t_info -> cases[t_cases] . kind != -1; t_cases++)
+                    if (t_kind == t_info -> cases[t_cases] . kind)
                     {
-                        t_record_info = t_info -> cases[i] . record;
+                        t_record_info = t_info -> cases[t_cases] . record;
                         break;
                     }
                 
@@ -972,10 +972,10 @@ static void MCPickleReleaseField(MCPickleFieldType p_kind, void *p_base_ptr, voi
                         int t_kind;
                         t_kind = *((int *)((uint8_t *)t_variant + t_info -> kind_offset));
 
-                        for(int i = 0; t_info -> cases[i] . kind != -1; i++)
-                            if (t_kind == t_info -> cases[i] . kind)
+                        for(int t_case = 0; t_info -> cases[t_case] . kind != -1; t_case++)
+                            if (t_kind == t_info -> cases[t_case] . kind)
                             {
-                                MCPickleRelease(t_info -> cases[i] . record, t_variant);
+                                MCPickleRelease(t_info -> cases[t_case] . record, t_variant);
                                 break;
                             }
                     }

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -134,11 +134,11 @@ static integer_t MCU_strtol(const char *sptr, uindex_t &l, int8_t c, bool &done,
 					}
 					else
 					{
-						char c = MCNativeCharFold(*sptr);
-						if (base == 16 && c >= 'a' && c <= 'f')
+						char t_char = MCNativeCharFold(*sptr);
+						if (base == 16 && t_char >= 'a' && t_char <= 'f')
 						{
 							value *= base;
-							value += c - 'a' + 10;
+							value += t_char - 'a' + 10;
 						}
 						else
 							return 0;

--- a/libfoundation/src/system-file-posix.cpp
+++ b/libfoundation/src/system-file-posix.cpp
@@ -364,10 +364,11 @@ __MCSFileSetContents (MCStringRef p_native_path,
 
 	if (0 != rename (*t_temp_path_sys, *t_path_sys))
 	{
-		int t_save_errno = errno;
-
-		/* UNCHECKED */ unlink (*t_temp_path_sys);
-
+		t_save_errno = errno;
+        
+        /* UNCHECKED */ unlink (*t_temp_path_sys);
+        errno = t_save_errno;
+        
 		/* Report rename error */
 		MCAutoStringRef t_description, t_path, t_temp_path;
 		MCAutoNumberRef t_error_code;

--- a/libgraphics/src/blur.cpp
+++ b/libgraphics/src/blur.cpp
@@ -176,7 +176,7 @@ static int boxBlur(const uint8_t* src, int src_y_stride, uint8_t* dst,
             RIGHT_BORDER_ITER
         }
 #undef RIGHT_BORDER_ITER
-        for (int x = 0; x < leftRadius - rightRadius; x++) {
+        for (int t_x = 0; t_x < leftRadius - rightRadius; t_x++) {
             *dptr = 0;
             dptr += dst_x_stride;
         }
@@ -246,7 +246,7 @@ static int boxBlurInterp(const uint8_t* src, int src_y_stride, uint8_t* dst,
             LEFT_BORDER_ITER
         }
 #undef LEFT_BORDER_ITER
-        for (int x = width; x < diameter; ++x) {
+        for (int t_x = width; t_x < diameter; ++t_x) {
             *dptr = (outer_sum * outer_scale + inner_sum * inner_scale) >> 24;
             dptr += dst_x_stride;
         }

--- a/revdb/src/revdb.cpp
+++ b/revdb/src/revdb.cpp
@@ -646,7 +646,6 @@ DBString *BindVariables(char *p_arguments[],int p_argument_count, int &r_value_c
 			t_name += 2;
 		}	
 
-		int t_return_value;
 		ExternalString t_value;
 		t_value . buffer = NULL;
 		t_value . length = 0;

--- a/revxml/src/cxml.h
+++ b/revxml/src/cxml.h
@@ -64,8 +64,8 @@ class CXMLDocument
 public:
 CXMLDocument() {Init();}
 // MDW-2013-09-03: [[ RevXmlXslt ]] new constructors
-CXMLDocument(xmlXPathContextPtr id) {Init(); xpathContext = id;}
-CXMLDocument(xsltStylesheetPtr id) {Init(); xsltID = id;}
+CXMLDocument(xmlXPathContextPtr p_id) {Init(); xpathContext = p_id;}
+CXMLDocument(xsltStylesheetPtr p_id) {Init(); xsltID = p_id;}
 ~CXMLDocument() {Free();}
 inline Bool isinited() {return doc != NULL;}
 Bool Read(char *data, unsigned long tlength, Bool wellformed);

--- a/revxml/src/revxml.cpp
+++ b/revxml/src/revxml.cpp
@@ -2899,7 +2899,7 @@ void XML_xsltApplyStylesheet(char *args[], int nargs, char **retstring, Bool *pa
 			xmlDocPtr xmlDoc = xmlDocument->GetDocPtr();
 			if (NULL != xmlDoc)
 			{
-				int docID = atoi(args[1]);
+				docID = atoi(args[1]);
 				CXMLDocument *xsltDocument = doclist.find(docID);
 				
 				// MW-2013-09-11: [[ RevXmlXslt ]] Only try to fetch the xsltContext if


### PR DESCRIPTION
Based on #4479 because a number of unused vars were unused because of shadowing
