### PR TITLE
[[ LCB ]] Improve tokenisation of numbers and add hex and bin literals

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -40,6 +40,8 @@ follows:
 
  - **Identifier**: [A-Za-z_][A-Za-z0-9_.]*
  - **Integer**: [0-9]+
+ - **Binary Integer**: 0b[01]+
+ - **Hexadecimal Integer**: 0x[0-9a-fA-F]+
  - **Real**: [0-9]+"."[0-9]+([eE][-+]?[0-9]+)?
  - **String**: "[^\n\r"]*"
  - **Separator**: Any whitespace containing at least one newline

--- a/docs/lcb/notes/feature-hex_bin_literals.md
+++ b/docs/lcb/notes/feature-hex_bin_literals.md
@@ -1,0 +1,23 @@
+# LiveCode Builder Language
+## Numeric literal improvements
+
+* Base 2 (binary) integer literals can now be specified by using a "0b" prefix.
+  e.g.
+
+      0b0000
+      0b1010
+
+* Base 16 (hexadecimal) integer literals can now be specified by using a "0x" prefix.
+  e.g.
+
+      0xdeadbeef
+      0x0123fedc
+
+* Parsing of numeric literals, in general, has been tightened up. In particular,
+  the compiler will detect invalid suffixes on numeric literals meaning you cannot
+  accidentally elide a number with an identifier.
+  e.g.
+
+      1.344foo -- ERROR
+      0xabcdefgh -- ERROR
+      0b010432 -- ERROR

--- a/tests/_compilertestrunner.livecodescript
+++ b/tests/_compilertestrunner.livecodescript
@@ -102,7 +102,7 @@ private command doRun pInfo
    if tScript is empty then
       runAllScripts pInfo
    else if tCommand is empty then
-      runTestScript pInfo, tScript
+      runCompilerTestScript pInfo, tScript
    else
       runTestCommand pInfo, tScript, tCommand
    end if
@@ -210,7 +210,7 @@ private command runCompilerTest pInfo, pScriptFile, pTest
    put tempName() into tTestInterfaceFile
    put textEncode(tTestInfo["code"], "utf8") into url ("binfile:" & tTestFile)
    reportCompilerTestDiag format("output test source file to '%s'", tTestFile)
-   reportCompilerTestDiag tTestInfo["code"]
+   reportCompilerTestDiagWithLineNumbers tTestInfo["code"]
 
    -- Build the command line
    local tCompilerCmdLine
@@ -459,6 +459,7 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
             put empty into tCode
             put empty into tExpectation
             put empty into tAssertions
+            put empty into tPositions
             put "code" into tState
          else if tToken is "%EXPECT" then
             -- We only allow %EXPECT directives after code blocks
@@ -641,6 +642,17 @@ private command reportCompilerTestDiag pMessage
       end repeat
    end if
 end reportCompilerTestDiag
+
+private command reportCompilerTestDiagWithLineNumbers pMessage
+   if $LCC_VERBOSE is not empty then
+      local tLineNumber
+      put 1 into tLineNumber
+      repeat for each line tLine in pMessage
+         write "DIAG:" && format("%4d", tLineNumber) && ":" && tLine & return to stderr
+         add 1 to tLineNumber
+      end repeat
+   end if
+end reportCompilerTestDiagWithLineNumbers
 
 ----------------------------------------------------------------
 -- Logging helpers

--- a/tests/lcb/compiler/frontend/numeric-literals.compilertest
+++ b/tests/lcb/compiler/frontend/numeric-literals.compilertest
@@ -1,0 +1,216 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%TEST DecimalIntegerLiterals
+module compiler_test
+constant Valid is [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+constant InvalidPrefix is %{BEFORE_PREFIX}00
+constant InvalidSuffix is %{BEFORE_SUFFIX}100foo
+handler Compute()
+  variable tVar
+  put 100+200 into tVar
+end handler
+end module
+%EXPECT PASS
+%ERROR "Malformed integer literal" AT BEFORE_PREFIX
+%ERROR "Malformed integer literal" AT BEFORE_SUFFIX
+%ENDTEST
+
+%% Note that decimal integer literals are always unsigned
+%TEST DecimalIntegerLiteralRange
+module compiler_test
+constant BiggerThanU8 is %{U8}256
+constant SmallerThanU8 is %{U8S}255
+constant BiggerThanU16 is %{U16}65536
+constant SmallerThanU16 is %{U16S}65535
+constant BiggerThanU32 is %{U32}4294967296
+constant SmallerThanU32 is %{U32S}4294967295
+constant BiggerThanU64 is %{U64}9223372036854775808
+constant SmallerThanU64 is %{U64S}9223372036854775807
+end module
+%EXPECT PASS
+%ERROR "Integer literal too big" at U32
+%ERROR "Integer literal too big" at U64
+%ERROR "Integer literal too big" at U64S
+%ENDTEST
+
+%TEST BinaryIntegerLiterals
+module compiler_test
+constant ValidLower is [ 0b0, 0b1, 0b01, 0b10, 0b010, 0b101 ]
+constant ValidUpper is [ 0B0, 0B1, 0B01, 0B10, 0B010, 0B101 ]
+constant InvalidSuffixLower is %{BEFORE_SUFFIX_LOWER}0b01foo
+constant InvalidSuffixUpper is %{BEFORE_SUFFIX_UPPER}0B01foo
+handler Compute()
+  variable tVar
+  put 0b100+0b001 into tVar
+end handler
+end module
+%EXPECT PASS
+%ERROR "Malformed integer literal" AT BEFORE_SUFFIX_LOWER
+%ERROR "Malformed integer literal" AT BEFORE_SUFFIX_UPPER
+%ENDTEST
+
+%TEST BinaryIntegerLiteralRange
+module compiler_test
+constant BiggerThanU8 is %{U8}0b111111111
+constant SmallerThanU8 is %{U8S}0b011111111
+constant BiggerThanU16 is %{U16}0b11111111111111111
+constant SmallerThanU16 is %{U16S}0b01111111111111111
+constant BiggerThanU32 is %{U32}0b111111111111111111111111111111111
+constant SmallerThanU32 is %{U32S}0b011111111111111111111111111111111
+constant BiggerThanU64 is %{U64}0b11111111111111111111111111111111111111111111111111111111111111111
+constant SmallerThanU64 is %{U64S}0b01111111111111111111111111111111111111111111111111111111111111111
+end module
+%EXPECT PASS
+%ERROR "Integer literal too big" at U32
+%ERROR "Integer literal too big" at U64
+%ERROR "Integer literal too big" at U64S
+%ENDTEST
+
+%TEST HexadecimalIntegerLiterals
+module compiler_test
+constant ValidLower is [ 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa,\
+                         0xb, 0xc, 0xd, 0xe, 0xf, 0x01, 0x10, 0x01, 0x0F, 0xF0 ]
+constant ValidLower is [ 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa,\
+                         0xB, 0xC, 0xD, 0xE, 0xF, 0x01, 0x10, 0x01, 0x0F, 0xF0 ]
+constant InvalidSuffixLower is %{BEFORE_SUFFIX_LOWER}0x01foo
+constant InvalidSuffixUpper is %{BEFORE_SUFFIX_UPPER}0X01foo
+handler Compute()
+  variable tVar
+  put 0x100f+0xf001 into tVar
+end handler
+end module
+%EXPECT PASS
+%ERROR "Malformed integer literal" AT BEFORE_SUFFIX_LOWER
+%ERROR "Malformed integer literal" AT BEFORE_SUFFIX_UPPER
+%ENDTEST
+
+%TEST HexadecimalIntegerLiteralRange
+module compiler_test
+constant BiggerThanU8 is %{U8}0x1FF
+constant SmallerThanU8 is %{U8S}0x0FF
+constant BiggerThanU16 is %{U16}0x1FFFF
+constant SmallerThanU16 is %{U16S}0x0FFFF
+constant BiggerThanU32 is %{U32}0x1FFFFFFFF
+constant SmallerThanU16 is %{U32S}0x0FFFFFFFF
+constant BiggerThanU64 is %{U64}0x1FFFFFFFFFFFFFFFF
+constant SmallerThanU16 is %{U64S}0x0FFFFFFFFFFFFFFFF
+end module
+%EXPECT PASS
+%ERROR "Integer literal too big" at U32
+%ERROR "Integer literal too big" at U64
+%ERROR "Integer literal too big" at U64S
+%ENDTEST
+
+%% The general pattern for real literals is:
+%%    I:Int P:Period F:ZeroesInt E:(Exp PlusMinus Int)
+%% Assuming all are optional then we have the following combinations
+%%    I, IP, IPF, IPFE, IF, IFE, IE, IPE
+%%    P, PF, PFE, PE
+%%    F, FE
+%%    EE
+%% Due to the underlying regex patterns there are the folllowing
+%% combinations which are the same:
+%%    IF == I, IFE == IE
+%% Which leaves the following classification:
+%%    I -- matches as integer
+%%    IP - e.g. 1. -- VALID
+%%    IPF - e.g. 1.1 -- VALID
+%%    IPFE - e.g. 1.1e1 -- VALID
+%%    IE - e.g. 1e1 -- VALID
+%%    IPE - e.g. 1.e1 -- VALID
+%%    P - . -- INVALID
+%%    PF - e.g. .1 -- VALID
+%%    PFE - e.g. .1e1 -- VALID
+%%    PE - .e1 -- INVALID
+%%    F - e.g. 01 -- INVALID
+%%    FE - e.g. 01e1 -- INVALID
+%%    E - e.g. e1 -- matches as identifier
+%%
+%TEST RealLiterals
+module compiler_test
+constant ValidInt is [ 0. , 1. , 10. ]
+constant ValidFrac is [ .0, .1, .00, .10, .01 ]
+constant ValidIntFrac is [ 0.0, 0.1, 0.00, 0.10, 0.01, \
+                          1.0, 1.1, 1.00, 1.10, 1.01, \
+                          10.0, 10.1, 10.00, 10.10, 10.01 ]
+constant ValidExp is [ 0e10, 1e1 , 10e10, 1e1 ]
+constant ValidDecExp is [ 0.e10, 0.e1 , .0e10, .0e1 ]
+constant ValidPosExp is [ 0.e+10, 0.e+1 , .0e+10, .0e+1 ]
+constant ValidNegExp is [ 0.e-10, 0.e-1 , .0e-10, .0e-1 ]
+
+constant Invalid_PE is %{INVALID_PE}.e1
+constant Invalid_F is %{INVALID_F}01
+constant Invalid_FE is %{INVALID_FE}01e1
+
+constant InvalidInt is [ %{INVALID_INT}01. ]
+constant InvalidIntFrac is [ %{INVALID_INTFRAC}01.0 ]
+constant InvalidExp is [ %{INVALID_EXP1}00e10, %{INVALID_EXP2}0e010 ]
+
+constant IntSuffix is %{INT_SUFFIX}0.foo
+constant FracSuffix is %{FRAC_SUFFIX}.0foo
+constant IntFracSuffix is %{INTFRAC_SUFFIX}0.1foo
+constant ExpSuffix is %{EXP_SUFFIX}0e10foo
+constant DecExpSuffix is %{DECEXP_SUFFIX}.0e1foo
+constant PosExpSuffix is %{POSEXP_SUFFIX}.0e+1foo
+constant NegExpSuffix is %{NEGEXP_SUFFIX}.0e-1foo
+
+constant IntDotSuffix is %{INTDOT_SUFFIX}0..
+constant FracDotSuffix is %{FRACDOT_SUFFIX}.0.
+constant IntFracDotSuffix is %{INTFRACDOT_SUFFIX}0.1.
+constant ExpDotSuffix is %{EXPDOT_SUFFIX}0e10.
+constant DecExpDotSuffix is %{DECEXPDOT_SUFFIX}.0e1.
+constant PosExpDotSuffix is %{POSEXPDOT_SUFFIX}.0e+1.
+constant NegExpDotSuffix is %{NEGEXPDOT_SUFFIX}.0e-1.
+
+end module
+%EXPECT PASS
+%ERROR "Malformed real literal" AT INVALID_PE
+%ERROR "Malformed integer literal" AT INVALID_F
+%ERROR "Malformed real literal" AT INVALID_FE
+
+%ERROR "Malformed real literal" AT INVALID_INT
+%ERROR "Malformed real literal" AT INVALID_INTFRAC
+%ERROR "Malformed real literal" AT INVALID_EXP1
+%ERROR "Malformed real literal" AT INVALID_EXP2
+
+%ERROR "Malformed real literal" AT INT_SUFFIX
+%ERROR "Malformed real literal" AT FRAC_SUFFIX
+%ERROR "Malformed real literal" AT INTFRAC_SUFFIX
+%ERROR "Malformed real literal" AT EXP_SUFFIX
+%ERROR "Malformed real literal" AT DECEXP_SUFFIX
+%ERROR "Malformed real literal" AT POSEXP_SUFFIX
+%ERROR "Malformed real literal" AT NEGEXP_SUFFIX
+
+%ERROR "Malformed real literal" AT INTDOT_SUFFIX
+%ERROR "Malformed real literal" AT FRACDOT_SUFFIX
+%ERROR "Malformed real literal" AT INTFRACDOT_SUFFIX
+%ERROR "Malformed real literal" AT EXPDOT_SUFFIX
+%ERROR "Malformed real literal" AT DECEXPDOT_SUFFIX
+%ERROR "Malformed real literal" AT POSEXPDOT_SUFFIX
+%ERROR "Malformed real literal" AT NEGEXPDOT_SUFFIX
+%ENDTEST
+
+%TEST RealLiteralRange
+module compiler_test
+constant BiggerThanFloat is %{BIGF}3.40282347E+39
+constant SmallerThanFloat is %{SMALLF}3.40282347E+38
+constant BiggerThanDouble is %{BIGD}1.7976931348623157E+309
+constant SmallerThanDouble is %{SMALLD}1.7976931348623157E+308
+end module
+%EXPECT PASS
+%ERROR "Real literal too big" at BIGD
+%ENDTEST

--- a/toolchain/lc-compile/src/DOUBLE_LITERAL.t
+++ b/toolchain/lc-compile/src/DOUBLE_LITERAL.t
@@ -1,6 +1,51 @@
-[0-9]+"."[0-9]+([eE][-+]?[0-9]+)? {
-  MakeDoubleLiteral(yytext, &yylval.attr[1]);
-  yysetpos();
-  return DOUBLE_LITERAL;
+	/* This contains both INTEGER_LITERAL and DOUBLE_LITERAL rules */
+	/* This ensures that they appear in this order, to ensure they match */
+	/* correctly. */
+
+[0-9]+"."[0-9]*([eE][-+]?[0-9]*)?([0-9a-zA-Z_\.]*) |
+[0-9]*"."[0-9]+([eE][-+]?[0-9]*)?([0-9a-zA-Z_\.]*) |
+[0-9]*"."[0-9]*([eE][-+]?[0-9]*)([0-9a-zA-Z_\.]*) |
+[0-9]+([eE][-+]?[0-9]*)([0-9a-zA-Z_\.]*) {
+	yysetpos();
+	if (IsDoubleLiteral(yytext))
+	{
+		if (MakeDoubleLiteral(yytext, &yylval.attr[1]) == 0)
+		{
+			long t_position;
+			GetCurrentPosition(&t_position);
+			Error_DoubleLiteralOutOfRange(t_position);
+			yylval.attr[1] = 0;
+		}
+	}
+	else
+	{
+		long t_position;
+        GetCurrentPosition(&t_position);
+		Error_InvalidDoubleLiteral(t_position);
+		yylval.attr[1] = 0;
+	}
+	return DOUBLE_LITERAL;
+}
+
+([0-9]+|0b[01]*|0x[0-9A-Fa-f]*)[0-9a-zA-Z_]* {
+    yysetpos();
+	if (IsIntegerLiteral(yytext))
+	{
+		if (MakeIntegerLiteral(yytext, &yylval.attr[1]) == 0)
+		{
+			long t_position;
+			GetCurrentPosition(&t_position);
+			Error_IntegerLiteralOutOfRange(t_position);
+			yylval.attr[1] = 0;
+		}
+	}
+	else
+	{
+		long t_position;
+        GetCurrentPosition(&t_position);
+		Error_InvalidIntegerLiteral(t_position);
+		yylval.attr[1] = 0;
+	}
+    return INTEGER_LITERAL;
 }
 

--- a/toolchain/lc-compile/src/INTEGER_LITERAL.t
+++ b/toolchain/lc-compile/src/INTEGER_LITERAL.t
@@ -1,12 +1,1 @@
-0|([1-9][0-9]*) {
-    yysetpos();
-    if (MakeIntegerLiteral(yytext, &yylval.attr[1]) == 0)
-    {
-        long t_position;
-        GetCurrentPosition(&t_position);
-        Error_IntegerLiteralOutOfRange(t_position);
-        yylval.attr[1] = 0;
-    }
-    return INTEGER_LITERAL;
-}
-
+ /* See DOUBLE_LITERAL.t */

--- a/toolchain/lc-compile/src/literal.h
+++ b/toolchain/lc-compile/src/literal.h
@@ -26,8 +26,10 @@ typedef struct Name *NameRef;
 void InitializeLiterals(void);
 void FinalizeLiterals(void);
 
+int IsDoubleLiteral(const char *token);
+int IsIntegerLiteral(const char *token);
 int MakeIntegerLiteral(const char *token, long *r_literal);
-void MakeDoubleLiteral(const char *token, long *r_literal);
+int MakeDoubleLiteral(const char *token, long *r_literal);
 void MakeStringLiteral(const char *token, long *r_literal);
 void MakeNameLiteral(const char *token, NameRef *r_literal);
 void MakeNameLiteralN(const char *p_token, int p_token_length, NameRef *r_literal);

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -237,7 +237,10 @@ DEFINE_ERROR_I(UnableToFindImportedModule, "Unable to find imported module '%s'"
 DEFINE_ERROR_S(MalformedToken, "Illegal token '%s'");
 DEFINE_ERROR_S(MalformedEscapedString, "Illegal escape in string '%s'");
 DEFINE_ERROR(MalformedSyntax, "Syntax error");
+DEFINE_ERROR(InvalidIntegerLiteral, "Malformed integer literal");
+DEFINE_ERROR(InvalidDoubleLiteral, "Malformed real literal");
 DEFINE_ERROR(IntegerLiteralOutOfRange, "Integer literal too big");
+DEFINE_ERROR(DoubleLiteralOutOfRange, "Real literal too big");
 
 DEFINE_ERROR_I(IdentifierPreviouslyDeclared, "Identifier '%s' already declared");
 DEFINE_ERROR_I(IdentifierNotDeclared, "Identifier '%s' not declared");

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -40,6 +40,8 @@ void Error_CouldNotWriteInterfaceFile(const char *path);
 void Error_MalformedToken(long position, const char *token);
 void Error_MalformedSyntax(long position);
 void Error_IntegerLiteralOutOfRange(long position);
+void Error_InvalidIntegerLiteral(long position);
+void Error_InvalidDoubleLiteral(long position);
     
 void Warning_EmptyUnicodeEscape(long position);
 void Warning_UnicodeEscapeTooBig(long position);

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -384,7 +384,7 @@
 'action' FinalizeLiterals()
 
 'condition' MakeIntegerLiteral(Token: STRING -> Literal: INT)
-'action' MakeDoubleLiteral(Token: STRING -> Literal: DOUBLE)
+'condition' MakeDoubleLiteral(Token: STRING -> Literal: DOUBLE)
 'action' MakeStringLiteral(Token: STRING -> Literal: STRING)
 'condition' UnescapeStringLiteral(Position:POS, String: STRING -> UnescapedString: STRING)
 'action' MakeNameLiteral(Token: STRING -> Literal: NAME)


### PR DESCRIPTION
This patch improves the tokenisation of numbers in lc-compile and adds
support for hexadecimal and binary integer literals.

The compiler will now complain about any invalid suffixes on numeric
literals, meaning that it is not possible to accidentally elide a
numeric literal with an identifier.

Hexadecimal literals are specified using the prefix "0x".

Binary literals are specified using the prefix "0b".

Real literals have been made more flexible and accurate. In particular,
leading zeros are now checked for in all but the fractional part, and
considering a real number to be of the form:

```
Int DecPoint Frac Exp
```

The allowed forms are:

```
 Int+DecPoint
 Int+Exp
 Int+DecPoint+Exp
 Int+DecPoint+Frac
 Int+DecPoint+Frac+Exp
 DecPoint+Frac
 DecPoint+Frac+Exp
```

All other combinations will be flagged as a 'malformed real literal'
error.

Note: As the regex for integers now intersects with that for reals
(e.g. 1e1 could be an integer with suffix, or a real) rules for both
DOUBLE and INTEGER literals are now in DOUBLE_LITERAL.t with the DOUBLE
rules first. This ensures DOUBLE_LITERAL matches in preference to
INTEGER_LITERAL.
