### PR TITLE
Add `<expr> as <type>` expressions to LCB

### DIFF
--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -166,6 +166,7 @@ extern "C" void EmitAttachRegisterToExpression(long reg, long expr);
 extern "C" void EmitDetachRegisterFromExpression(long expr);
 extern "C" int EmitGetRegisterAttachedToExpression(long expr, long *reg);
 extern "C" void EmitPosition(PositionRef position);
+extern "C" void EmitCast(long type_idx, long out_reg, long in_reg);
 
 extern "C" void OutputBeginManifest(void);
 extern "C" void OutputEnd(void);
@@ -1801,6 +1802,16 @@ void EmitReset(long reg)
     MCScriptEmitBytecodeInModule(s_builder, kResetOpcodeIndex, reg, UINDEX_MAX);
     
     Debug_Emit("Reset(%ld)", reg);
+}
+
+////////
+
+void EmitCast(long type_idx, long out_reg, long in_reg)
+{
+    static const __opcode_index kCastOpcodeIndex("cast");
+    MCScriptEmitBytecodeInModule(s_builder, kCastOpcodeIndex, type_idx, out_reg, in_reg, UINDEX_MAX);
+    
+    Debug_Emit("Cast(%ld, %ld, %ld)", type_idx, out_reg, in_reg);
 }
 
 ////////

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1632,6 +1632,13 @@
 
 'action' FullyResolveType(TYPE -> TYPE)
 
+'action' GenerateCastInRegister(INT, INT, POS, EXPRESSION, TYPE, INT)
+
+    'rule' GenerateCastInRegister(Result, Context, Position, Value, Type, Output)
+        GenerateType(Type -> TypeIndex)
+        GenerateExpression(Result, Context, Value -> ValueReg)
+        EmitCast(TypeIndex, Output, ValueReg)
+
 'action' GenerateCallInRegister(INT, INT, POS, ID, EXPRESSIONLIST, INT)
 
     'rule' GenerateCallInRegister(Result, Context, Position, Handler, Arguments, Output):
@@ -1739,8 +1746,8 @@
         GenerateInvoke_FreeArgument(Right)
         EmitResolveLabel(ShortLabel)
 
-    'rule' GenerateExpressionInRegister(Result, Context, as(_, _, _), Output):
-        -- TODO
+    'rule' GenerateExpressionInRegister(Result, Context, as(Position, Value, Type), Output):
+        GenerateCastInRegister(Result, Context, Position, Value, Type, Output)
     
     'rule' GenerateExpressionInRegister(Result, Context, List:list(Position, Elements), Output):
         (|

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -1015,8 +1015,8 @@
     'rule' TermExpression(-> result(Position)):
         "the" @(-> Position) "result"
 
-    --'rule' TermExpression(-> as(Position, Value, Type)):
-    --    TermExpression(-> Value) "as" @(-> Position) Type(-> Type)
+    'rule' TermExpression(-> as(Position, Value, Type)):
+        TermExpression(-> Value) "as" @(-> Position) Type(-> Type)
 
     'rule' TermExpression(-> call(Position, Handler, Arguments)):
         Identifier(-> Handler) @(-> Position) "(" OptionalExpressionList(-> Arguments) ")"

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -256,6 +256,7 @@
     EmitBeginOpcode
     EmitContinueOpcode
     EmitEndOpcode
+    EmitCast
 
     OutputBeginManifest
     OutputEnd
@@ -651,6 +652,7 @@
 'action' EmitBeginOpcode(Opcode: STRING)
 'action' EmitContinueOpcode(Output: INT)
 'action' EmitEndOpcode()
+'action' EmitCast(TypeIndex: INT, OutputReg: INT, InputReg: INT)
 
 'action' EmitAttachRegisterToExpression(INT, EXPRESSION)
 'action' EmitDetachRegisterFromExpression(EXPRESSION)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -327,8 +327,6 @@
 'table' SYNTAXMARKINFO(Index: INT, RMode: MODE, LMode: MODE, Type: SYNTAXMARKTYPE)
 'table' INVOKEINFO(Index: INT, ModuleIndex: INT, Name: STRING, ModuleName: STRING, Methods: INVOKEMETHODLIST)
 
-'table' TYPEINFO(Position: POS)
-
 --------------------------------------------------------------------------------
 
 -- All operators are classified as particular types representing their syntactic


### PR DESCRIPTION
This adds support to the compiler for cast expressions (but not yet to the VM).
