### PR TITLE
[[ LCB ]] Add notion of 'bridged' handlers.

### DIFF
--- a/tests/lcb/compiler/frontend/unsafe.compilertest
+++ b/tests/lcb/compiler/frontend/unsafe.compilertest
@@ -129,3 +129,26 @@ end module
 %EXPECT PASS
 %SUCCESS
 %ENDTEST
+
+%TEST ForeignHandlerCallInSafeContext
+module compiler_test
+foreign handler ForeignHandler(in pArg as optional any) returns nothing binds to "<builtin>"
+handler SafeHandler()
+    %{BEFORE_CALL}ForeignHandler(%{BEFORE_EVAL}ForeignHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%ERROR "Unsafe handler 'ForeignHandler' can only be called in unsafe context" AT BEFORE_CALL
+%ERROR "Unsafe handler 'ForeignHandler' can only be called in unsafe context" AT BEFORE_EVAL
+%ENDTEST
+
+%TEST BridgedHandlerCallInSafeContext
+module compiler_test
+__bridged handler BridgedHandler(in pArg as optional any) returns nothing binds to "<builtin>"
+handler SafeHandler()
+    %{BEFORE_CALL}BridgedHandler(%{BEFORE_EVAL}BridgedHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -142,6 +142,9 @@
     
     'rule' DeclareImportedDefinitions(foreignhandler(Position, _, Name, _, _)):
         DeclareId(Name)
+
+    'rule' DeclareImportedDefinitions(bridgedhandler(Position, _, Name, _, _)):
+        DeclareId(Name)
     
     'rule' DeclareImportedDefinitions(property(Position, _, Name, _, _)):
         DeclareId(Name)
@@ -206,6 +209,9 @@
     'rule' Declare(foreignhandler(Position, _, Name, _, _)):
         DeclareId(Name)
     
+    'rule' Declare(bridgedhandler(Position, _, Name, _, _)):
+        DeclareId(Name)
+
     'rule' Declare(property(Position, _, Name, _, _)):
         DeclareId(Name)
     
@@ -297,6 +303,10 @@
         DefineUnsafeSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
         DefineParameters(Name, Parameters)
 
+    'rule' Define(ModuleId, bridgedhandler(Position, Access, Name, Signature:signature(Parameters, _), _)):
+        DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
+        DefineParameters(Name, Parameters)
+
     'rule' Define(ModuleId, property(Position, Access, Name, Getter, Setter)):
         DefineSymbolId(Name, ModuleId, Access, property, nil)
 
@@ -385,6 +395,16 @@
         LeaveScope
         
     'rule' Apply(DEFINITION'foreignhandler(_, _, _, signature(Parameters, Type), _)):
+        -- The type of the foreign handler is resolved in the current scope.
+        Apply(Type)
+        
+        -- Enter a new scope to check parameters.
+        EnterScope
+        DeclareParameters(Parameters)
+        Apply(Parameters)
+        LeaveScope
+
+    'rule' Apply(DEFINITION'bridgedhandler(_, _, _, signature(Parameters, Type), _)):
         -- The type of the foreign handler is resolved in the current scope.
         Apply(Type)
         
@@ -833,6 +853,9 @@
         DumpBindings(Body)
     'rule' DumpBindings(DEFINITION'foreignhandler(_, _, Name, Signature, _)):
         DumpId("foreign handler", Name)
+        DumpBindings(Signature)
+    'rule' DumpBindings(DEFINITION'bridgedhandler(_, _, Name, Signature, _)):
+        DumpId("__bridged handler", Name)
         DumpBindings(Signature)
     'rule' DumpBindings(DEFINITION'property(_, _, Name, Getter, OptionalSetter)):
         DumpId("property", Name)

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1630,6 +1630,14 @@
         |]
         CheckForeignHandlerParameterTypes(Parameters)
         
+    'rule' CheckDeclaredTypes(DEFINITION'bridgedhandler(Position, _, _, signature(Parameters, ReturnType), _)):
+        -- Foreign handlers must be fully typed.
+        [|
+            where(ReturnType -> unspecified)
+            Error_NoReturnTypeSpecifiedForForeignHandler(Position)
+        |]
+        CheckBridgedHandlerParameterTypes(Parameters)
+
     'rule' CheckDeclaredTypes(PARAMETER'parameter(Position, _, _, Type)):
         (|
             IsHighLevelType(Type)
@@ -1656,6 +1664,25 @@
         
     'rule' CheckForeignHandlerParameterTypes(nil):
         -- do nothing
+
+'action' CheckBridgedHandlerParameterTypes(PARAMETERLIST)
+
+    'rule' CheckBridgedHandlerParameterTypes(parameterlist(parameter(Position, _, _, Type), Rest)):
+        [|
+            where(Type -> unspecified)
+            Error_NoTypeSpecifiedForForeignHandlerParameter(Position)
+        |]
+        CheckBridgedHandlerParameterTypes(Rest)
+        
+    'rule' CheckBridgedHandlerParameterTypes(nil):
+        -- do nothing
+
+
+'condition' IsTypeSuitableForBridgedHandler(TYPE)
+
+	'rule' IsTypeSuitableForBridgedHandler(_):
+		-- At the moment this does nothing, but should be used to ensure that
+		-- bridged handler parameters conform to the rules required of them.
 
 
 'condition' IsHighLevelType(TYPE)
@@ -1723,6 +1750,10 @@
         CheckIdentifiers(Body)
 
     'rule' CheckIdentifiers(DEFINITION'foreignhandler(_, _, Id, Signature, _)):
+        CheckIdIsSuitableForDefinition(Id)
+        CheckIdentifiers(Signature)
+
+    'rule' CheckIdentifiers(DEFINITION'bridgedhandler(_, _, Id, Signature, _)):
         CheckIdIsSuitableForDefinition(Id)
         CheckIdentifiers(Signature)
 

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -781,6 +781,7 @@ void EmitDefinitionIndex(const char *p_type, long& r_index)
         { "variable", kMCScriptDefinitionKindVariable },
         { "handler", kMCScriptDefinitionKindHandler },
         { "foreignhandler", kMCScriptDefinitionKindForeignHandler },
+        { "bridgedhandler", kMCScriptDefinitionKindForeignHandler },
         { "property", kMCScriptDefinitionKindProperty },
         { "event", kMCScriptDefinitionKindEvent },
         { "syntax", kMCScriptDefinitionKindSyntax },

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -234,6 +234,9 @@
     'rule' GenerateManifestDefinitions(foreignhandler(_, public, Name, Signature, _)):
         GenerateManifestHandlerDefinition(Name, Signature)
 
+    'rule' GenerateManifestDefinitions(bridgedhandler(_, public, Name, Signature, _)):
+        GenerateManifestHandlerDefinition(Name, Signature)
+
     'rule' GenerateManifestDefinitions(property(_, public, Name, Getter, OptionalSetter)):
         QuerySymbolId(Getter -> GetInfo)
         GetInfo'Type -> GetDefType
@@ -535,6 +538,9 @@
     'rule' GenerateDefinitionIndexes(foreignhandler(_, _, Name, _, _)):
         GenerateDefinitionIndex("foreignhandler", Name)
 
+    'rule' GenerateDefinitionIndexes(bridgedhandler(_, _, Name, _, _)):
+        GenerateDefinitionIndex("bridgedhandler", Name)
+
     'rule' GenerateDefinitionIndexes(property(_, _, Name, _, _)):
         GenerateDefinitionIndex("property", Name)
 
@@ -616,6 +622,9 @@
         GenerateExportedDefinition(Id)
 
     'rule' GenerateExportedDefinitions(foreignhandler(_, public, Id, _, _)):
+        GenerateExportedDefinition(Id)
+
+    'rule' GenerateExportedDefinitions(bridgedhandler(_, public, Id, _, _)):
         GenerateExportedDefinition(Id)
 
     'rule' GenerateExportedDefinitions(property(_, _, Id, _, _)):
@@ -712,6 +721,14 @@
         Info'Index -> DefIndex
         EmitForeignHandlerDefinition(DefIndex, Position, Name, TypeIndex, Binding)
         
+    'rule' GenerateDefinitions(bridgedhandler(Position, _, Id, Signature, Binding)):
+        GenerateType(handler(Position, foreign, Signature) -> TypeIndex)
+        
+        QuerySymbolId(Id -> Info)
+        Id'Name -> Name
+        Info'Index -> DefIndex
+        EmitForeignHandlerDefinition(DefIndex, Position, Name, TypeIndex, Binding)
+
     'rule' GenerateDefinitions(property(Position, _, Id, Getter, OptionalSetter)):
         QuerySymbolId(Id -> Info)
         Id'Name -> Name

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -244,6 +244,9 @@
     'rule' ImportDefinition(-> foreignhandler(Position, public, Id, Signature, "")):
         "foreign" "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
 
+    'rule' ImportDefinition(-> bridgedhandler(Position, public, Id, Signature, "")):
+        "__bridged" "handler" @(-> Position) Identifier(-> Id) Signature(-> Signature)
+
 --------------------------------------------------------------------------------
 -- Metadata Syntax
 --------------------------------------------------------------------------------
@@ -466,6 +469,9 @@
 
     'rule' HandlerDefinition(-> foreignhandler(Position, Access, Name, Signature, Binding)):
         Access(-> Access) "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)
+
+    'rule' HandlerDefinition(-> bridgedhandler(Position, Access, Name, Signature, Binding)):
+        Access(-> Access) "__bridged" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)
 
 'nonterm' Signature(-> SIGNATURE)
 

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -65,6 +65,7 @@
     variable(Position: POS, Access: ACCESS, Name: ID, Type: TYPE)
     handler(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE, Definitions: DEFINITION, Body: STATEMENT)
     foreignhandler(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE, Binding: STRING)
+	bridgedhandler(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE, Binding: STRING)
     property(Position: POS, Access: ACCESS, Name: ID, Getter: ID, Setter: OPTIONALID)
     event(Position: POS, Access: ACCESS, Name: ID, Signature: SIGNATURE)
     syntax(Position: POS, Access: ACCESS, Name: ID, Class: SYNTAXCLASS, Warnings: SYNTAXWARNING, Syntax: SYNTAX, Methods: SYNTAXMETHODLIST)


### PR DESCRIPTION
The LCB VM currently has some implicit semantics regarding the
calling of foreign handlers which are really only suitable when
the foreign handler has been written to a certain set of rules -
those which the VM expects for its syntax handlers written in C.

In order to explicitly mark a (foreign) handler as conforming to
these rules, this patch adds a new type of handler a 'bridged'
handler. Such a handler is defined using:

```
__bridged handler MyHandler() returns nothing binds to "..."
```

At present bridged handlers only differ from foreign handlers in
that they are implicitly safe.

The notion of bridged handler is intended to be temporary and will
be removed when glue code generators have been written for C
foreign handlers.
