### PR TITLE
[[ Bug 18376 ]] Fix slow performance of trueWord chunk

### DIFF
--- a/docs/notes/bugfix-18376.md
+++ b/docs/notes/bugfix-18376.md
@@ -1,0 +1,1 @@
+# Fix slow performance of trueWord chunk on large strings

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1745,8 +1745,8 @@ void MCInterfaceExecType(MCExecContext& ctxt, MCStringRef p_typing, uint2 p_modi
 			MCStringGetCodepointAtIndex(p_typing, i);
 		
 		// Compute the number of codeunits used by the char
-		uindex_t t_cp_advance =
-			t_cp_char <= UNICHAR_MAX ? 1 : 2;
+		uindex_t t_cp_length =
+			MCUnicodeCodepointGetCodeunitLength(t_cp_char);
 		
 		KeySym keysym = t_cp_char;
         MCAutoStringRef t_char;
@@ -1761,7 +1761,7 @@ void MCInterfaceExecType(MCExecContext& ctxt, MCStringRef p_typing, uint2 p_modi
 			keysym |= XK_Class_codepoint;
 		else
         {
-            MCStringCopySubstring(p_typing, MCRangeMake(i, t_cp_advance), &t_char);
+            MCStringCopySubstring(p_typing, MCRangeMake(i, t_cp_length), &t_char);
 			t_string = *t_char;
         }
         // PM-2014-10-03: [[ Bug 13907 ]] Make sure we don't pass nil to kdown
@@ -1775,7 +1775,7 @@ void MCInterfaceExecType(MCExecContext& ctxt, MCStringRef p_typing, uint2 p_modi
 		
 		// If the codepoint was in SMP, then make sure we bump two codeunit
 		// indicies.
-		i += t_cp_advance - 1;
+		i += t_cp_length - 1;
 	}
     
     // AL-2014-01-07 return lock mods to false

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1740,7 +1740,15 @@ void MCInterfaceExecType(MCExecContext& ctxt, MCStringRef p_typing, uint2 p_modi
 
 	for (i = 0 ; i < MCStringGetLength(p_typing); i++)
 	{
-		KeySym keysym = MCStringGetCodepointAtIndex(p_typing, i);
+		// Fetch the codepoint at the given codeunit index
+		codepoint_t t_cp_char =
+			MCStringGetCodepointAtIndex(p_typing, i);
+		
+		// Compute the number of codeunits used by the char
+		uindex_t t_cp_advance =
+			t_cp_char <= UNICHAR_MAX ? 1 : 2;
+		
+		KeySym keysym = t_cp_char;
         MCAutoStringRef t_char;
 		if (keysym < 0x20 || keysym == 0xFF)
 		{
@@ -1753,7 +1761,7 @@ void MCInterfaceExecType(MCExecContext& ctxt, MCStringRef p_typing, uint2 p_modi
 			keysym |= XK_Class_codepoint;
 		else
         {
-            MCStringCopySubstring(p_typing, MCRangeMake(i, 1), &t_char);
+            MCStringCopySubstring(p_typing, MCRangeMake(i, t_cp_advance), &t_char);
 			t_string = *t_char;
         }
         // PM-2014-10-03: [[ Bug 13907 ]] Make sure we don't pass nil to kdown
@@ -1764,6 +1772,10 @@ void MCInterfaceExecType(MCExecContext& ctxt, MCStringRef p_typing, uint2 p_modi
 		real8 delay = nexttime - MCS_time();
 		if (MCscreen->wait(delay, False, False))
 			ctxt . LegacyThrow(EE_TYPE_ABORT);
+		
+		// If the codepoint was in SMP, then make sure we bump two codeunit
+		// indicies.
+		i += t_cp_advance - 1;
 	}
     
     // AL-2014-01-07 return lock mods to false

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -278,10 +278,19 @@ bool MCParagraph::TextIsPunctuation(codepoint_t p_codepoint)
 
 bool MCParagraph::TextFindNextParagraph(MCStringRef p_string, findex_t p_after, findex_t &r_next)
 {
-	codepoint_t t_cp;
 	uindex_t t_length = MCStringGetLength(p_string);
-	while (p_after < t_length && !TextIsParagraphBreak(MCStringGetCodepointAtIndex(p_string, p_after)))
+	while (p_after < t_length)
+	{
+		codepoint_t t_char =
+			MCStringGetCodepointAtIndex(p_string, p_after);
+		
+		if (TextIsParagraphBreak(t_char))
+			break;
+		
 		p_after++;
+		if (t_char > UNICHAR_MAX)
+			p_after++;
+	}
 	
 	if (p_after == t_length)
 		return false;

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -287,9 +287,7 @@ bool MCParagraph::TextFindNextParagraph(MCStringRef p_string, findex_t p_after, 
 		if (TextIsParagraphBreak(t_char))
 			break;
 		
-		p_after++;
-		if (t_char > UNICHAR_MAX)
-			p_after++;
+		p_after += MCUnicodeCodepointGetCodeunitLength(t_char);
 	}
 	
 	if (p_after == t_length)

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -1218,8 +1218,11 @@ bool MCProperty::resolveprop(MCExecContext& ctxt, Properties& r_which, MCNameRef
             
             // AL-2015-08-27: [[ Bug 15798 ]] If the index is quoted, we don't want to include the
             //  quotes in the index name.
-            if (MCStringGetCodepointAtIndex(*t_string, t_offset + 1) == '"' &&
-                MCStringGetCodepointAtIndex(*t_string, t_end_offset - 1) == '"')
+			
+			// As we are only looking for an ASCII char, GetCharAtIndex is
+			// sufficient (no need for GetCodepointAtIndex).
+            if (MCStringGetCharAtIndex(*t_string, t_offset + 1) == '"' &&
+                MCStringGetCharAtIndex(*t_string, t_end_offset - 1) == '"')
             {
                 t_offset++;
                 t_end_offset--;

--- a/libfoundation/include/foundation-chunk.h
+++ b/libfoundation/include/foundation-chunk.h
@@ -66,11 +66,6 @@ bool MCChunkIsAmongTheChunksOfRange(MCStringRef p_chunk, MCStringRef p_string, M
 
 bool MCChunkOffsetOfChunkInRange(MCStringRef p_string, MCStringRef p_needle, MCStringRef p_delimiter, bool p_whole_matches, MCStringOptions p_options, MCRange p_range, uindex_t& r_offset);
 
-typedef bool (*MCChunkApplyCallback)(void *context, MCStringRef string, MCRange chunk_range);
-bool MCChunkApplyInRange(MCStringRef p_string, MCRange *p_range, MCStringRef p_delimiter, MCStringOptions p_options, MCChunkApplyCallback p_callback, void *context);
-
-bool MCChunkIterate(MCRange& x_range, MCStringRef p_string, MCStringRef p_delimiter, MCStringOptions p_options, bool p_first);
-
 void MCChunkSkipWord(MCStringRef p_string, MCStringRef p_line_delimiter, MCStringOptions p_options, bool p_skip_spaces, uindex_t& x_offset);
 
 class MCTextChunkIterator

--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -558,6 +558,13 @@ inline bool MCUnicodeCodepointIsLowSurrogate(uinteger_t x)
 	return MCUnicodeCodepointIsTrailingSurrogate(x);
 }
 
+inline uindex_t MCUnicodeCodepointGetCodeunitLength(codepoint_t cp)
+{
+	if (cp > UNICHAR_MAX)
+		return 2;
+	return 1;
+}
+
 // Returns true if the given codepoint is a base character
 inline bool MCUnicodeCodepointIsBase(uinteger_t x)
 {

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2105,7 +2105,7 @@ MC_DLLEXPORT const char_t *MCStringGetNativeCharPtr(MCStringRef string);
 // The native length may be different from the string char count.
 MC_DLLEXPORT const char_t *MCStringGetNativeCharPtrAndLength(MCStringRef self, uindex_t& r_native_length);
 
-// Returns the Unicode codepoint at the given codepoint index
+// Returns the Unicode codepoint at the given index
 MC_DLLEXPORT codepoint_t MCStringGetCodepointAtIndex(MCStringRef string, uindex_t index);
 
 // Returns the char at the given index.

--- a/libfoundation/src/foundation-locale.cpp
+++ b/libfoundation/src/foundation-locale.cpp
@@ -1149,9 +1149,7 @@ bool MCLocaleWordBreakIteratorAdvance(MCStringRef self, MCBreakIteratorRef p_ite
 			if (MCStringCodepointIsWordPart(t_cp))
 				break;
 			
-			t_left_break++;
-			if (t_cp > UNICHAR_MAX)
-				t_left_break++;
+			t_left_break += MCUnicodeCodepointGetCodeunitLength(t_cp);
         }
         
         if (t_left_break < t_right_break)

--- a/libfoundation/src/foundation-locale.cpp
+++ b/libfoundation/src/foundation-locale.cpp
@@ -1143,10 +1143,15 @@ bool MCLocaleWordBreakIteratorAdvance(MCStringRef self, MCBreakIteratorRef p_ite
         // if the intervening chars contain a letter or number then it was a valid 'word'
         while (t_left_break < t_right_break)
         {
-            if (MCStringCodepointIsWordPart(MCStringGetCodepointAtIndex(self, t_left_break)))
-                break;
-            if (MCStringIsValidSurrogatePair(self, t_left_break++))
-                t_left_break++;
+			codepoint_t t_cp =
+				MCStringGetCodepointAtIndex(self, t_left_break);
+			
+			if (MCStringCodepointIsWordPart(t_cp))
+				break;
+			
+			t_left_break++;
+			if (t_cp > UNICHAR_MAX)
+				t_left_break++;
         }
         
         if (t_left_break < t_right_break)

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -2348,15 +2348,13 @@ bool MCStringUnmapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRang
             while (t_left_break < t_right_break)
             {
 				// NB: GetCodepointAtIndex takes a code-unit index
-				codepoint_t t_char =
+				codepoint_t t_cp =
 					MCStringGetCodepointAtIndex(self, t_left_break);
-                if (MCStringCodepointIsWordPart(t_char))
+                if (MCStringCodepointIsWordPart(t_cp))
                     break;
 				
 				// If the char is in the SMP, it is two codeunits long.
-				t_left_break++;
-				if (t_char > UNICHAR_MAX)
-					t_left_break++;
+				t_left_break += MCUnicodeCodepointGetCodeunitLength(t_cp);
             }
             
             if (t_left_break < t_right_break)


### PR DESCRIPTION
This patch corrects MCStringGetCodepointAtIndex which previously had assumed the input index was in codepoints, not in codeunits.

As an addendum, all uses of MCStringGetCodepointAtIndex have been vetted, and those which were fetching values at indicies > 0 now correctly process surrogates (i.e. skip the right number of codeunits).
