### PR TITLE
lc-compile: Print contextual information for each warning or error

### DIFF
--- a/docs/lcb/notes/lc-compile-error-context.md
+++ b/docs/lcb/notes/lc-compile-error-context.md
@@ -1,0 +1,7 @@
+# LiveCode Builder Tools
+## lc-compile
+### Messages
+
+* Errors, warnings and informational messages now display the affected
+  line of code and visually indicate the position where the problem
+  was found.

--- a/tests/_compilertestrunner.livecodescript
+++ b/tests/_compilertestrunner.livecodescript
@@ -233,7 +233,7 @@ private command runCompilerTest pInfo, pScriptFile, pTest
 
    -- Process the assertions and make sure each one matches up
    repeat for each line tAssertion in tTestInfo["assertions"]
-      if doesCompilerOutputSatisfyAssertion(tCompilerOutput, tCompilerExitStatus, tAssertion, tTestInfo["positions"]) then
+      if doesCompilerOutputSatisfyAssertion(tCompilerOutput, tCompilerExitStatus, tAssertion, tTestInfo) then
          put "ok - " after tTestOutput
       else
          put "not ok - " after tTestOutput
@@ -330,7 +330,7 @@ private function listCompilerTestsInFile pFilename
    return tTestNames
 end listCompilerTestsInFile
 
-private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerExitCode, pAssertion, pPositions
+private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerExitCode, pAssertion, pTestInfo
    if item 1 of pAssertion is "success" then
       return pCompilerExitCode is 0
    end if
@@ -347,34 +347,63 @@ private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerEx
    end if
 
    set the itemDelimiter to ":"
+
+   local tState
+   put "search" into tState
    repeat for each line tOutputLine in pCompilerOutput
       local tFile, tLine, tColumn, tType, tMessage
+      local tSourceLine, tMarker
 
-      -- The format of each output line is:
-      --   <file>:<line>:<col>: (error|warning): <msg>
-      put item 1 of tOutputLine into tFile
-      put item 2 of tOutputLine into tLine
-      put item 3 of tOutputLine into tColumn
-      put word 1 of item 4 of tOutputLine into tType
-      put item 5 to -1 of tOutputLine into tMessage
+      if tState is "search" then
+         -- The format of each output line is:
+         --   <file>:<line>:<col>: (error|warning): <msg>
+         put item 1 of tOutputLine into tFile
+         put item 2 of tOutputLine into tLine
+         put item 3 of tOutputLine into tColumn
+         put word 1 of item 4 of tOutputLine into tType
+         put item 5 to -1 of tOutputLine into tMessage
 
-      -- If the assertion type doesn't match, continue
-      if tAssertionType is not tType then
-         next repeat
+         -- If the assertion type doesn't match, continue
+         if tAssertionType is not tType then
+            next repeat
+         end if
+
+         -- If the assertion message is not within the message, continue
+         if tAssertionPartialMsg is not in tMessage then
+            next repeat
+         end if
+
+         -- If the position does not match, continue
+         if pTestInfo["positions"][tAssertionPos] is not tLine then
+            next repeat
+         end if
+
+         -- If we get here, we have a match so are successful!
+         put "source line" into tState
+
+      else if tState is "source line" then
+         -- The format of the source line output is a space followed
+         -- by the corresponding line of the input source file.
+
+         put " " & line tLine of pTestInfo["code"] into tSourceLine
+
+         if tOutputLine is tSourceLine then
+            put "marker" into tState
+         end if
+
+      else if tState is "marker" then
+         -- The marker should point at the correct column within the
+         -- input source line
+
+         -- TODO the marker position should come from the position
+         -- indicated in the code block, not from the position
+         -- reported by the compiler.
+         put format(merge("%[[tColumn]]s^"),"") into tMarker
+
+         if tOutputLine is tMarker then
+            return true
+         end if
       end if
-
-      -- If the assertion message is not within the message, continue
-      if tAssertionPartialMsg is not in tMessage then
-         next repeat
-      end if
-
-      -- If the position does not match, continue
-      if pPositions[tAssertionPos] is not tLine then
-         next repeat
-      end if
-
-      -- If we get here, we have a match so are successful!
-      return true
    end repeat
 
    -- We failed to find a suitable output line, so failure

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -77,6 +77,15 @@ void GetRowOfPosition(long p_position, long *r_row)
     *r_row = ((p_position / COLUMNS_PER_ROW) % ROWS_PER_FILE) + 1;
 }
 
+void GetRowTextOfPosition(long p_position, const char **r_text)
+{
+	FileRef t_file = NULL;
+	long t_row = 0;
+	GetFileOfPosition(p_position, &t_file);
+	GetRowOfPosition(p_position, &t_row);
+	*r_text = GetFileLineText(t_file, t_row);
+}
+
 void GetFileOfPosition(long p_position, FileRef *r_file)
 {
     long t_index;

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -226,7 +226,6 @@ struct File
     FileRef next;
     char *path;
     char *name;
-    FILE *stream;
     unsigned int index;
 };
 

--- a/toolchain/lc-compile/src/position.h
+++ b/toolchain/lc-compile/src/position.h
@@ -45,6 +45,7 @@ void GetColumnOfPosition(PositionRef position, long *r_column);
 void GetRowOfPosition(PositionRef position, long *r_row);
 void GetFileOfPosition(PositionRef position, FileRef *r_file);
 void GetFilenameOfPosition(PositionRef position, const char **r_filename);
+void GetRowTextOfPosition(PositionRef position, const char **r_text);
 
 void GetCurrentPosition(PositionRef *r_result);
 void yyGetPos(PositionRef *r_result);

--- a/toolchain/lc-compile/src/position.h
+++ b/toolchain/lc-compile/src/position.h
@@ -60,6 +60,7 @@ int MoveToNextFile(void);
 void GetFilePath(FileRef file, const char **r_path);
 void GetFileName(FileRef file, const char **r_name);
 void GetFileIndex(FileRef file, long *r_index);
+const char *GetFileLineText(FileRef file, long p_row);
 int GetFileWithIndex(long index, FileRef *r_file);
 int GetCurrentFile(FileRef *r_file);
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -206,8 +206,6 @@ static void _ErrorS(long p_position, const char *p_message, const char *p_string
 
 static void _WarningS(long p_position, const char *p_message, const char *p_string)
 {
-    long t_row, t_column;
-    
     if (IsDependencyCompile())
         return;
 
@@ -217,8 +215,6 @@ static void _WarningS(long p_position, const char *p_message, const char *p_stri
     }
     else
     {
-        GetColumnOfPosition(p_position, &t_column);
-        GetRowOfPosition(p_position, &t_row);
         _PrintPosition(p_position);
         fprintf(stderr, "warning: ");
         fprintf(stderr, p_message, p_string);

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -62,6 +62,23 @@ void Fatal_InternalInconsistency(const char *p_message)
 ////////////////////////////////////////////////////////////////////////////////
 
 void
+Debug(const char *p_format, ...)
+{
+	va_list t_args;
+
+	if (s_verbose_level < 1)
+		return;
+
+	va_start(t_args, p_format);
+
+	fprintf(stderr, "debug: ");
+	vfprintf(stderr, p_format, t_args);
+	fprintf(stderr, "\n");
+
+	va_end(t_args);
+}
+
+void
 Debug_Emit(const char *p_format, ...)
 {
 	va_list t_args;

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -189,6 +189,7 @@ static void _Error(long p_position, const char *p_message)
 {
     _PrintPosition(p_position);
     fprintf(stderr, "error: %s\n", p_message);
+    _PrintContext(p_position);
     s_error_count += 1;
 }
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -169,6 +169,22 @@ static void _PrintPosition(long p_position)
     fprintf(stderr, "%s:%ld:%ld: ", t_path, t_row, t_column);
 }
 
+/* Print the source code line that contains p_position, and another
+ * line below it with a caret pointing "up" to the exact character
+ * that the position specifies. */
+static void _PrintContext(long p_position)
+{
+	const char *t_text = NULL;
+	long t_column;
+	GetRowTextOfPosition(p_position, &t_text);
+	GetColumnOfPosition(p_position, &t_column);
+	if (NULL != t_text)
+	{
+		fprintf(stderr, " %s\n", t_text);
+		fprintf(stderr, " %*c\n", (int)t_column, '^');
+	}
+}
+
 static void _Error(long p_position, const char *p_message)
 {
     _PrintPosition(p_position);
@@ -189,6 +205,7 @@ static void _Warning(long p_position, const char *p_message)
     {
         _PrintPosition(p_position);
         fprintf(stderr, "warning: %s\n", p_message);
+        _PrintContext(p_position);
     }
 }
 
@@ -201,6 +218,7 @@ static void _ErrorS(long p_position, const char *p_message, const char *p_string
     fprintf(stderr, "error: ");
     fprintf(stderr, p_message, p_string);
     fprintf(stderr, "\n");
+    _PrintContext(p_position);
     s_error_count += 1;
 }
 
@@ -219,6 +237,7 @@ static void _WarningS(long p_position, const char *p_message, const char *p_stri
         fprintf(stderr, "warning: ");
         fprintf(stderr, p_message, p_string);
         fprintf(stderr, "\n");
+        _PrintContext(p_position);
     }
 }
 

--- a/toolchain/lc-compile/src/report.h
+++ b/toolchain/lc-compile/src/report.h
@@ -48,8 +48,8 @@ void Warning_UnicodeEscapeTooBig(long position);
 
 void Error_Bootstrap(const char *format, ...);
 
+void Debug(const char *p_format, ...);
 void Debug_Emit(const char *p_format, ...);
-    
 void Debug_Depend(const char *p_format, ...);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This patch modifies **lc-compile**'s warning and error output to include the affected line and an indication of where in the line the problem occurs.  For example, when compiling the following module:

```
module org.example.errors
constant kBadConstant is InvalidExpression
end module
```

lc-compile will now output:

```
foo.lcb:2:26: error: Identifier 'InvalidExpression' not declared
 constant kBadConstant is InvalidExpression
                          ^
```

This is implemented by adding a lazily-constructed array of line strings to the `File` structure in **lc-compile**. The position data provided by **gentle** doesn't include a file offset, and scanning the whole file for each position to find the line in which it occurs would be really expensive.  Instead, **lc-compile** will now compute and cache an array of every line in a source file the first time that a position's source file context is requested.
