### PR TITLE
[Bug 18449] Use xvfb-run to run testsuite on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install: (cd prebuilt && ./fetch-libraries.sh linux)
 # the default test suite.
 script: >
   if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then
-      make all-linux && make check-linux
+      make all-linux && xvfb-run make check-linux
   fi
 
 addons:
@@ -61,3 +61,4 @@ addons:
       - libpopt-dev
       - libesd0-dev
       - liblcms-dev
+      - xvfb

--- a/tests/lcs/core/interface/interfaceui.livecodescript
+++ b/tests/lcs/core/interface/interfaceui.livecodescript
@@ -182,7 +182,9 @@ if the platform is "win32" then
 else if the platform is "MacOS" then 
 	TestAssert "test", the screenname is "local Mac"  
 else if the platform is "Linux" then
-	TestAssert "test", the screenname is ":0.0" or the screenname is ":0"
+	local tScreenMajor, tScreenMinor
+	TestAssert "screenname is well-formed X11 display ID", \
+			matchText(the screenname, ":[0-9]+(?:\.[0-9]+)?")
 end if
 
 end TestInterface44


### PR DESCRIPTION
The `xvfb-run` command launches a virtual, framebuffer-based X server
as a background process and then runs a specified comand using the
virtual display.

This should make it possible to run tests on Travis CI without needing an
actual desktop.
