### PR TITLE
[[ Toolchain ]] Allow foreign handlers to be marked as safe

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -913,3 +913,31 @@ available as **the result**.
 > **Note:** Handlers which return no value (i.e. have nothing as their
 > result type) can still be used in call expressions. In this case the
 > value of the call is **nothing**.
+
+## Experimental Features
+
+**Warning**: This section describes current language features and syntax
+that are considered experimental and unstable.  They are likely to change
+or go away without warning.
+
+### Safe Foreign Handlers
+
+    SafeForeignHandler
+      : '____safe' 'foreign' 'handler' <Name: Identifier> '(' [ ParameterList ] ')' [ 'returns' <ReturnType: Type> ) ] 'binds' 'to' <Binding: String>
+
+By default foreign handlers are considered unsafe and thus can only be used in
+unsafe blocks, or unsafe handlers. However, at the moment it is possible for a
+foreign handler to actually be safe if it has been explicitly written to wrap
+a foreign function so it can be easily used from LCB.
+
+Specifically, it is reasonable to consider a foreign handler safe if it
+conforms to the following rules:
+
+ - Parameter types and return type are either ValueRefs, or bridgeable types
+ - Return values of ValueRef type are retained
+ - If the function fails then MCErrorThrow has been used
+ - 'out' mode parameters are only changed if the function succeeds
+ - A return value is only provided if the function succeeds
+
+Examples of foreign handlers which can be considered safe are all the foreign
+handlers which bind to syntax in the LCB standard library.

--- a/tests/lcb/compiler/frontend/unsafe.compilertest
+++ b/tests/lcb/compiler/frontend/unsafe.compilertest
@@ -129,3 +129,26 @@ end module
 %EXPECT PASS
 %SUCCESS
 %ENDTEST
+
+%TEST ForeignHandlerCallInSafeContext
+module compiler_test
+foreign handler ForeignHandler(in pArg as optional any) returns nothing binds to "<builtin>"
+handler SafeHandler()
+    %{BEFORE_CALL}ForeignHandler(%{BEFORE_EVAL}ForeignHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%ERROR "Unsafe handler 'ForeignHandler' can only be called in unsafe context" AT BEFORE_CALL
+%ERROR "Unsafe handler 'ForeignHandler' can only be called in unsafe context" AT BEFORE_EVAL
+%ENDTEST
+
+%TEST SafeForeignHandlerCallInSafeContext
+module compiler_test
+__safe foreign handler SafeForeignHandler(in pArg as optional any) returns nothing binds to "<builtin>"
+handler SafeHandler()
+    %{BEFORE_CALL}SafeForeignHandler(%{BEFORE_EVAL}SafeForeignHandler(nothing))
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -289,11 +289,15 @@
         DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, normal, Signature))
         DefineParameters(Name, Parameters)
 
+	'rule' Define(ModuleId, foreignhandler(Position, Access, Name, Signature:signature(Parameters, _), _)):
+		DefineSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
+		DefineParameters(Name, Parameters)
+
     'rule' Define(ModuleId, unsafe(_, handler(Position, Access, Name, Signature:signature(Parameters, _), _, _))):
         DefineUnsafeSymbolId(Name, ModuleId, Access, handler, handler(Position, normal, Signature))
         DefineParameters(Name, Parameters)
 
-    'rule' Define(ModuleId, foreignhandler(Position, Access, Name, Signature:signature(Parameters, _), _)):
+    'rule' Define(ModuleId, unsafe(_, foreignhandler(Position, Access, Name, Signature:signature(Parameters, _), _))):
         DefineUnsafeSymbolId(Name, ModuleId, Access, handler, handler(Position, foreign, Signature))
         DefineParameters(Name, Parameters)
 

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -464,7 +464,10 @@
             Statements(-> Body)
         "end" "handler"
 
-    'rule' HandlerDefinition(-> foreignhandler(Position, Access, Name, Signature, Binding)):
+	'rule' HandlerDefinition(-> foreignhandler(Position, Access, Name, Signature, Binding)):
+		Access(-> Access) "__safe" "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)
+
+    'rule' HandlerDefinition(-> unsafe(Position, foreignhandler(Position, Access, Name, Signature, Binding))):
         Access(-> Access) "foreign" "handler" @(-> Position) Identifier(-> Name) Signature(-> Signature) "binds" "to" StringLiteral(-> Binding)
 
 'nonterm' Signature(-> SIGNATURE)


### PR DESCRIPTION
This patch allows a foreign handler definition to be prefixed by '__safe'
indicating that it is safe to call from safe context.

The motivation for this is to ease binding to C/C++ functions which are
implemented with the LCB C calling convention.
