### PR TITLE
[[ Toolchain ]] Add --outputauxc option to lc-compile

### DIFF
--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -56,29 +56,43 @@ static uindex_t s_builtin_module_count = 0;
 static MCScriptResolveSharedLibraryCallback s_resolve_shared_library_callback = nil;
 
 static bool MCFetchBuiltinModuleSection(MCBuiltinModule**& r_modules, unsigned int& r_count);
+static bool MCFetchBuiltinAuxModuleSection(MCBuiltinModule**& r_modules, unsigned int& r_count);
+
+static bool __MCScriptCreateBuiltinModules(MCBuiltinModule **p_modules, unsigned int p_module_count)
+{
+	uindex_t t_current_module_count;
+	t_current_module_count = s_builtin_module_count;
+	
+	if (!MCMemoryResizeArray(t_current_module_count + p_module_count, s_builtin_modules, s_builtin_module_count))
+		return false;
+	
+	for(uindex_t i = 0; i < p_module_count; i++)
+	{
+		MCStreamRef t_stream;
+		if (!MCMemoryInputStreamCreate(p_modules[i] -> data, p_modules[i] -> size, t_stream))
+			return false;
+		
+		if (!MCScriptCreateModuleFromStream(t_stream, s_builtin_modules[t_current_module_count + i]))
+			return false;
+		
+		MCValueRelease(t_stream);
+	}
+	
+	return true;
+}
 
 bool MCScriptInitialize(void)
 {
     MCBuiltinModule **t_modules;
     unsigned int t_module_count;
-    if (!MCFetchBuiltinModuleSection(t_modules, t_module_count))
+    if (!MCFetchBuiltinModuleSection(t_modules, t_module_count) ||
+		!__MCScriptCreateBuiltinModules(t_modules, t_module_count))
         return true;
-    
-    if (!MCMemoryNewArray(t_module_count, s_builtin_modules))
-        return false;
-    
-    for(uindex_t i = 0; i < t_module_count; i++)
-    {
-        MCStreamRef t_stream;
-        if (!MCMemoryInputStreamCreate(t_modules[i] -> data, t_modules[i] -> size, t_stream))
-            return false;
-        
-        if (!MCScriptCreateModuleFromStream(t_stream, s_builtin_modules[i]))
-            return false;
-        
-        MCValueRelease(t_stream);
-    }
-    
+	
+	if (!MCFetchBuiltinAuxModuleSection(t_modules, t_module_count) ||
+		!__MCScriptCreateBuiltinModules(t_modules, t_module_count))
+		return true;
+	
     s_builtin_module_count = t_module_count;
     
     // This block builds the builtin module - which isn't possible to compile from
@@ -412,7 +426,9 @@ void __MCScriptAssertFailed__(const char *label, const char *expr, const char *f
 extern "C"
 {
     extern MCBuiltinModule* g_builtin_modules[];
-    extern unsigned int g_builtin_module_count;
+	extern unsigned int g_builtin_module_count;
+	extern MCBuiltinModule* g_builtin_aux_modules[];
+	extern unsigned int g_builtin_aux_module_count;
 }
 
 static bool MCFetchBuiltinModuleSection(MCBuiltinModule**& r_modules, unsigned int& r_count)
@@ -421,4 +437,12 @@ static bool MCFetchBuiltinModuleSection(MCBuiltinModule**& r_modules, unsigned i
     r_modules = g_builtin_modules;
     r_count = g_builtin_module_count;
     return true;
+}
+
+static bool MCFetchBuiltinAuxModuleSection(MCBuiltinModule**& r_modules, unsigned int& r_count)
+{
+	// Use the array defined in the module-helper.cpp file
+	r_modules = g_builtin_aux_modules;
+	r_count = g_builtin_aux_module_count;
+	return true;
 }

--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -7,6 +7,8 @@ lc-compile(1) -- compile LiveCode Builder source code
 
 **lc-compile** [_OPTION_ ...] --outputc _OUTFILE_ [--] _LCBFILE_
 
+**lc-compile** [_OPTION_ ...] --outputauxc _OUTFILE_ [--] _LCBFILE_
+
 **lc-compile** [_OPTION_ ...] --deps [_DEPSMODE_] [--] _LCBFILE_...
 
 ## DESCRIPTION
@@ -35,6 +37,12 @@ is not specified, then **lc-compile** may additionally generate an interface
   _OUTFILE_, which should be the path to a `.c` file.  If _OUTFILE_ already
   exists, it will be overwritten.
 
+* --outputauxc _OUTFILE_:
+  Generate LiveCode bytecode as a static array embedded in C source code in
+  _OUTFILE_, which should be the path to a `.c` file.  This option differs from
+  `--outputc` in the name of the C arrays which are generated. If _OUTFILE_
+  already exists, it will be overwritten.
+  
 * --deps [_DEPSMODE_]:
   Generate dependency information on standard output.  _DEPSMODE_ may
   be `order`, `changed-order`, or `make`.  If _DEPSMODE_ is omitted,
@@ -56,7 +64,7 @@ is not specified, then **lc-compile** may additionally generate an interface
 * --:
   Stop processing options.  This is useful in case _LCBFILE_ begins with `--`.
 
-The `--output` and `--outputc` options cannot be used together.
+The `--output`, `--outputc` and `--outputauxc` options cannot be used together.
 
 ## DEPENDENCY INFORMATION
 

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -32,6 +32,7 @@ static int s_is_bootstrap = 0;
 extern enum DependencyModeType DependencyMode;
 extern int OutputFileAsC;
 extern int OutputFileAsBytecode;
+extern int OutputFileAsAuxC;
 
 int IsBootstrapCompile(void)
 {
@@ -75,7 +76,7 @@ void bootstrap_main(int argc, char *argv[])
             OutputFileAsC = 1;
             OutputFileAsBytecode = 0;
             SetOutputCodeFile(argv[++i]);
-        }
+		}
         else if (strcmp(argv[i], "--outputi") == 0 && i + 1 < argc)
             AddImportedModuleDir(argv[++i]);
         else
@@ -105,6 +106,7 @@ usage(int status)
 "      --modulepath PATH      Search PATH for module interface files.\n"
 "      --output OUTFILE       Filename for bytecode output.\n"
 "      --outputc OUTFILE      Filename for C source code output.\n"
+"      --outputauxc OUTFILE   Filename for C source code output (auxillary modules).\n"
 "      --deps make            Generate lci file dependencies in make format for\n"
 "                             the input source files.\n"
 "      --deps order           Generate the order the input source files should be\n"
@@ -185,7 +187,15 @@ static void full_main(int argc, char *argv[])
                 OutputFileAsBytecode = 0;
                 have_output_file = 1;
                 continue;
-            }
+			}
+			if (0 == strcmp(opt, "--outputauxc") && optarg)
+			{
+                SetOutputCodeFile(argv[++argi]);
+				OutputFileAsC = 1;
+				OutputFileAsAuxC = 1;
+				OutputFileAsBytecode = 0;
+				continue;
+			}
             if (0 == strcmp(opt, "--manifest") && optarg)
             {
                 SetManifestOutputFile(argv[++argi]);
@@ -272,6 +282,8 @@ static void full_main(int argc, char *argv[])
 // No built-in modules for the compiler
 void* g_builtin_modules[1] = {NULL};
 unsigned int g_builtin_module_count = 0;
+void* g_builtin_aux_modules[1] = {NULL};
+unsigned int g_builtin_aux_module_count = 0;
 
 extern int yydebug;
 extern void InitializeFoundation(void);

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -304,7 +304,7 @@ void AddFile(const char *p_filename)
         Fatal_OutOfMemory();
     
     t_new_file -> index = s_next_file_index++;
-
+	
 	t_new_file->line_text_initialized = 0;
 
     for(t_last_file_ptr = &s_files; *t_last_file_ptr != NULL; t_last_file_ptr = &((*t_last_file_ptr) -> next))


### PR DESCRIPTION
This patch adds an --outputauxc option to lc-compile which can
be used instead of --outputc. It generates modules (encoded in C
arrays) using a global variable g_builtin_aux_modules, rather than
g_builtin_modules. The purpose is to allow additional builtin modules
to be included in a application beyond those included in the engine.

Note: This approach is only necessary because we do not use a C section
listing pointers to modules to initialize. That would be a much preferable
approach as anything being linked into an executable could then contain
LCB modules.
