### PR TITLE
[[ Bug 18508 ]] Allow 'outputc' modes to process multiple LCB modules

### DIFF
--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -5,7 +5,7 @@ lc-compile(1) -- compile LiveCode Builder source code
 
 **lc-compile** [_OPTION_ ...] --output _OUTFILE_ [--] _LCBFILE_
 
-**lc-compile** [_OPTION_ ...] --outputc _OUTFILE_ [--] _LCBFILE_
+**lc-compile** [_OPTION_ ...] --outputc _OUTFILE_ [--] _LCBFILE_...
 
 **lc-compile** [_OPTION_ ...] --deps [_DEPSMODE_] [--] _LCBFILE_...
 
@@ -31,7 +31,7 @@ is not specified, then **lc-compile** may additionally generate an interface
   file.  If _OUTFILE_ already exists, it will be overwritten.
 
 * --outputc _OUTFILE_:
-  Generate LiveCode bytecode as a static array embedded in C source code in
+  Generate LiveCode bytecode as a static array(s) embedded in C source code in
   _OUTFILE_, which should be the path to a `.c` file.  If _OUTFILE_ already
   exists, it will be overwritten.
 

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -61,6 +61,9 @@
 
 'action' GenerateSingleModule(MODULE)
 
+    'rule' GenerateSingleModule(Module:module(_, import, Id, Definitions)):
+		-- do nothing for import modules
+
     'rule' GenerateSingleModule(Module:module(_, Kind, Id, Definitions)):
         ModuleDependencyList <- nil
         

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -107,8 +107,7 @@
                         GenerateModules(Modules)
                     |)
                 ||
-                    where(Modules -> modulelist(Head, _))
-                    Generate(Head)
+					GenerateModules(Modules)
                 |)
             |)
         |)
@@ -181,6 +180,9 @@
         Definitions(-> Definitions)
         "end" "module" OptionalSeparator
         END_OF_UNIT
+		Name'Name -> NameName
+        GetStringOfNameLiteral(NameName -> NameString)
+		AddImportedModuleName(NameString)
 
     'rule' Module(-> module(Position, widget, Name, Definitions)):
         OptionalSeparator
@@ -271,7 +273,7 @@
             (|
                 -- In bootstrap mode, all modules have to be listed on command line.
                 IsBootstrapCompile()
-            ||
+			||
                 AddImportedModuleFile(NameString)
             |)
         ||

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -96,7 +96,7 @@ usage(int status)
 {
     fprintf(stderr,
 "Usage: lc-compile [OPTION ...] --output OUTFILE [--] LCBFILE\n"
-"       lc-compile [OPTION ...] --outputc OUTFILE [--] LCBFILE\n"
+"       lc-compile [OPTION ...] --outputc OUTFILE [--] LCBFILE ... LCBFILE\n"
 "       lc-compile [OPTION ...] --deps DEPTYPE [--] LCBFILE ... LCBFILE\n"
 "\n"
 "Compile a LiveCode Builder source file.\n"
@@ -133,6 +133,8 @@ static void full_main(int argc, char *argv[])
     /* Process options. */
     int have_input_file = 0;
     int have_output_file = 0;
+	int have_interface_file = 0;
+	int have_manifest_file = 0;
     int end_of_args = 0;
     int argi;
 
@@ -189,11 +191,13 @@ static void full_main(int argc, char *argv[])
             if (0 == strcmp(opt, "--manifest") && optarg)
             {
                 SetManifestOutputFile(argv[++argi]);
+				have_manifest_file = 1;
                 continue;
             }
             if (0 == strcmp(opt, "--interface") && optarg)
             {
                 SetInterfaceOutputFile(argv[++argi]);
+				have_interface_file = 1;
                 continue;
             }
             /* FIXME This should be expanded to support "-W error",
@@ -230,28 +234,27 @@ static void full_main(int argc, char *argv[])
             }
         }
 
-        /* Accept only one input file */
-        if (DependencyMode == 0 || have_output_file)
-        {
-            if (!have_input_file)
-            {
-                AddFile(opt);
-                have_input_file = 1;
-                continue;
-            }
-            else
-            {
-                fprintf(stderr, "WARNING: Ignoring multiple input filenames.\n");
-                continue;
-            }
-            
-            break; /* Doesn't match any option */
-        }
-        else
-        {
-            AddFile(opt);
-            have_input_file = 1;
-        }
+        /* Accept any number of input files for dependency or output-c
+		   modes; only a single file in all other cases */
+		if (DependencyMode == 1 ||
+			(OutputFileAsC == 1 &&
+				have_interface_file == 0 &&
+				have_manifest_file == 0))
+		{
+			AddFile(opt);
+			have_input_file = 1;
+		}
+		else
+		{
+			if (have_input_file == 1)
+			{
+				fprintf(stderr, "WARNING: Ignoring multiple input filenames.\n");
+				continue;
+			}
+			
+			AddFile(opt);
+			have_input_file = 1;
+		}
     }
 
 	// If there is no filename, error.

--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -121,6 +121,21 @@ void yyGetPos(long *r_result)
 static const char *ImportedModuleDir[8];
 static int ImportedModuleDirCount = 0;
 static const char *s_interface_output_file = NULL;
+static const char *ImportedModuleNames[32];
+static int ImportedModuleNameCount = 0;
+
+static int IsImportedModuleName(const char *p_name)
+{
+	int i;
+	for(i = 0; i < ImportedModuleNameCount; i++)
+	{
+		if (strcmp(p_name, ImportedModuleNames[i]) == 0)
+		{
+			return 1;
+		}
+	}
+	return 0;
+}
 
 void AddImportedModuleDir(const char *p_dir)
 {
@@ -130,11 +145,32 @@ void AddImportedModuleDir(const char *p_dir)
         Fatal_InternalInconsistency("Too many module paths");
 }
 
+void AddImportedModuleName(const char *p_name)
+{
+	if (IsImportedModuleName(p_name))
+	{
+		return;
+	}
+	
+	if (ImportedModuleNameCount == sizeof(ImportedModuleNames) / sizeof(const char *))
+	{
+		Fatal_InternalInconsistency("Too many imported module names");
+		return;
+	}
+	
+	ImportedModuleNames[ImportedModuleNameCount++] = p_name;
+}
+
 int AddImportedModuleFile(const char *p_name)
 {
     char t_path[MAXPATHLEN];
 	FILE *t_file;
-    
+	
+	if (IsImportedModuleName(p_name))
+	{
+		return 1;
+	}
+	
     t_file = NULL;
     if (ImportedModuleDirCount > 0)
     {

--- a/toolchain/lc-compile/src/position.h
+++ b/toolchain/lc-compile/src/position.h
@@ -54,6 +54,7 @@ void InitializeFiles(void);
 void FinalizeFiles(void);
 
 void AddImportedModuleDir(const char *dir);
+void AddImportedModuleName(const char *name);
 int AddImportedModuleFile(const char *name);
     
 void AddFile(const char *filename);

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -31,6 +31,7 @@
     GetColumnOfCurrentPosition
     GetUndefinedPosition
     AddImportedModuleFile
+	AddImportedModuleName
     GetFilenameOfPosition
 
     InitializeLiterals
@@ -375,6 +376,7 @@
 'action' GetUndefinedPosition(-> Position: POS)
 
 'condition' AddImportedModuleFile(Name: STRING)
+'action' AddImportedModuleName(Name: STRING)
 
 'action' GetFilenameOfPosition(Position: POS -> Filename: STRING)
 


### PR DESCRIPTION
This patch adds the ability for lc-compile to process multiple
LCB modules together to produce a C output file.

This is similar to --outputc mode in bootstrap mode, except that
it doesn't require all modules and their dependencies to be present.
Instead, when resolving a use clause, the compiler will first
search the modules on the command line and _then_ search for
interface files in the specified modulepath directories.
