### PR TITLE
[Bug 18463] lc-compile: Correct error position on lines with control chars

### DIFF
--- a/docs/lcb/notes/lc-compile-error-context.md
+++ b/docs/lcb/notes/lc-compile-error-context.md
@@ -5,3 +5,5 @@
 * Errors, warnings and informational messages now display the affected
   line of code and visually indicate the position where the problem
   was found.
+
+# [18463] Show correct error position when source line includes tabs

--- a/tests/_compilertestrunner.livecodescript
+++ b/tests/_compilertestrunner.livecodescript
@@ -352,7 +352,7 @@ private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerEx
    put "search" into tState
    repeat for each line tOutputLine in pCompilerOutput
       local tFile, tLine, tColumn, tType, tMessage
-      local tSourceLine, tMarker
+      local tSourceLine, tCharOffset, tOutputChar, tMarker
 
       if tState is "search" then
          -- The format of each output line is:
@@ -383,13 +383,21 @@ private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerEx
 
       else if tState is "source line" then
          -- The format of the source line output is a space followed
-         -- by the corresponding line of the input source file.
+         -- by the corresponding line of the input source file.  The
+         -- compiler may replace any of the source characters with
+         -- spaces (for example, to remove control characters).
 
-         put " " & line tLine of pTestInfo["code"] into tSourceLine
+        put " " & line tLine of pTestInfo["code"] into tSourceLine
 
-         if tOutputLine is tSourceLine then
-            put "marker" into tState
-         end if
+        repeat with tCharOffset = 1 to the number of chars in tOutputLine
+           put char tCharOffset of tOutputLine into tOutputChar
+           if tOutputChar is not " " and \
+                 tOutputChar is not char tCharOffset of tSourceLine then
+              return false
+           end if
+         end repeat
+
+         put "marker" into tState
 
       else if tState is "marker" then
          -- The marker should point at the correct column within the
@@ -402,6 +410,8 @@ private function doesCompilerOutputSatisfyAssertion pCompilerOutput, pCompilerEx
 
          if tOutputLine is tMarker then
             return true
+         else
+            return false
          end if
       end if
    end repeat

--- a/toolchain/lc-compile/src/LAYOUT.b
+++ b/toolchain/lc-compile/src/LAYOUT.b
@@ -1,2 +1,2 @@
 \  { AdvanceCurrentPosition(1); }
-\t {  }
+\t { AdvanceCurrentPosition(1); }


### PR DESCRIPTION
lc-compile should show the correct source position when displaying
tab-indented lines.

This patch modifies lc-compile to sanitise ASCII control characters
from lines of LCB source code before printing them.  This has two
benefits:
- Column counts in lc-compile messages will count include tabs
- Compiling LCB code will never screw up your terminal emulator
- The caret that indicates the position of an error will appear in the
  right place.
