### PR TITLE
[Bug 15384] Add support for 204 header

### DIFF
--- a/docs/notes/bugfix-15384.md
+++ b/docs/notes/bugfix-15384.md
@@ -1,0 +1,1 @@
+# Fix incorrect handling of a 204 response from a server.

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -1306,6 +1306,7 @@ on ulDoProcess x,y
          
          ##normal case
       case laLength[laUrl[x]] is not empty
+      case laStatusCode[laUrl[x]] is "204"  -- When a 204 is returned no data is returned, just the length of the data in the header.
          
          put  laTmpData[laUrl[x]] into tData
          ulStoreData laUrl[x],tData

--- a/tests/lcs/liburl/status_codes.livecodescript
+++ b/tests/lcs/liburl/status_codes.livecodescript
@@ -1,0 +1,25 @@
+script "TestLibUrlStatusCodes"
+
+local sLogField
+
+on TestSetup
+   -- Only run these tests on desktop platforms
+   if the platform is not among the items of "MacOS,Windows,Linux" then
+      return "SKIP Tests are not runnable on" && the platform
+   end if
+
+   local tLibURl
+   put TestGetEngineRepositoryPath() & "/ide-support/revliburl.livecodescript" into tLibUrl
+   send "revLoadLibrary" to stack tLibUrl
+end TestSetup
+
+
+on TestStatusCodes
+   # Response Code 204
+   set the socketTimeoutInterval to 10000
+   put the milliseconds into tStartTime
+   put URL "http://httpstat.us/204" into tData
+   TestAssert "no error is reported", the result is empty
+   TestAssert "response is not delayed until socket timeout", the milliseconds - tStartTime < 9000
+   TestAssert "data is empty", tData is empty
+end TestStatusCodes


### PR DESCRIPTION
When a 204 header is received there is no content, just the length of the data in the header. This commit adds explicit support for this.
