### PR TITLE
[Bug 18488] liburl: Report error from hostnametoaddress to the user

### DIFF
--- a/docs/notes/bugfix-18488.md
+++ b/docs/notes/bugfix-18488.md
@@ -1,0 +1,1 @@
+# Error returned by hostnametoaddress was not being reported in libURL.

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -622,7 +622,7 @@ on ulGetFormat pUrl,pCount
       ## I.M. 2010-03-11  Need to check result and handle immediate failure where
       ##  no callback message will be sent
       if the result is not empty then
-         ulHostNameToAddressCallback tResolveHost, empty
+         ulHostNameToAddressCallback tResolveHost, empty, the result
       end if
       
       if laLoadReq[pUrl] is empty or  laAuthRecursCount[pUrl] > 0 then ##dc 170205
@@ -636,7 +636,7 @@ end ulGetFormat
 
 ################################################################################
 
-on ulHostNameToAddressCallback, pHostname, pIP
+on ulHostNameToAddressCallback pHostname, pIP
    local tURL, tOffset
    local tPre, tHost, tPort, tUser, tPass, tFilename, tURLHost, tURLPort
    local tConnectHost, tBadAddress
@@ -664,7 +664,11 @@ on ulHostNameToAddressCallback, pHostname, pIP
    end if
    
    if tBadAddress then
-      put "invalid host address" into laUrlErrorStatus[tURL]
+      if the paramCount >= 3 then
+         put param(3) into laUrlErrorStatus[tURL]
+      else
+         put "invalid host address" into laUrlErrorStatus[tURL]
+      end if
       if laLoadReq[tURL] then
          put "error" into laUrlLoadStatus[tURL]
          delete local laLoadingUrls[tURL]
@@ -712,7 +716,7 @@ on ulHostNameToAddressCallback, pHostname, pIP
       end if
    end if
    
-   ## AL-2013-07-30: [[ Bug 10796 ]]  HTTP "get URL" omits port number from HOST header
+   ## AL-2013-07-30: [[ Bug 10796 ]] HTTP "get URL" omits port number from HOST header
    ## delete this array at the end so that 'get url' can use the port and protocol data.
    subtract 1 from laURLFormat[tURL]["references"]
    if laURLFormat[tURL]["references"] is 0 then

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -636,7 +636,7 @@ end ulGetFormat
 
 ################################################################################
 
-on ulHostNameToAddressCallback pHostname, pIP
+on ulHostNameToAddressCallback pHostname, pIP, pOptionalError
    local tURL, tOffset
    local tPre, tHost, tPort, tUser, tPass, tFilename, tURLHost, tURLPort
    local tConnectHost, tBadAddress
@@ -664,8 +664,8 @@ on ulHostNameToAddressCallback pHostname, pIP
    end if
    
    if tBadAddress then
-      if the paramCount >= 3 then
-         put param(3) into laUrlErrorStatus[tURL]
+      if pOptionalError is not empty then
+         put pOptionalError into laUrlErrorStatus[tURL]
       else
          put "invalid host address" into laUrlErrorStatus[tURL]
       end if

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -610,15 +610,7 @@ on ulGetFormat pUrl,pCount
       # clear status before resolving hostname
       put empty into laStatus[pUrl]
       
-      ## I.M 2010.03.24  with engine versions < 4.5 calling hostnametoaddress with
-      ## an extra parameter will throw an error, so encase in a try ... catch block
-      ## and call without callback handler
-      try
-         get hostNameToAddress(tResolveHost, "ulHostnameToAddressCallback")
-      catch pError
-         get hostNameToAddress(tResolveHost)
-         if the result is empty then ulHostNameToAddressCallback tResolveHost, it
-      end try
+      get hostNameToAddress(tResolveHost, "ulHostnameToAddressCallback")
       ## I.M. 2010-03-11  Need to check result and handle immediate failure where
       ##  no callback message will be sent
       if the result is not empty then


### PR DESCRIPTION
ulHostNameToAddressCallback needs to report a detailed error rather thant "invalid host address". This fix reports the actual error.
