### PR TITLE
[Bug 18470] Don't require target for libURLSetStatusCallback

### DIFF
--- a/docs/dictionary/command/libURLSetStatusCallback.lcdoc
+++ b/docs/dictionary/command/libURLSetStatusCallback.lcdoc
@@ -37,7 +37,7 @@ updated.
 
 objectLongID:
 The long ID of the object to send the message to. If <messageName> is 
-not empty but <objectLongID> is empty then the message will be sent to
+not empty and <objectLongID> is not specified then the message will be sent to
 the revLibURL library stack. The message can be handled in a frontscript,
 backscript, or library stack.
 

--- a/docs/dictionary/command/libURLSetStatusCallback.lcdoc
+++ b/docs/dictionary/command/libURLSetStatusCallback.lcdoc
@@ -2,7 +2,7 @@ Name: libURLSetStatusCallback
 
 Type: command
 
-Syntax: libURLSetStatusCallback [<messageName>, <objectLongID>]
+Syntax: libURLSetStatusCallback [<messageName>[, <objectLongID>]]
 
 Summary:
 Sets up a <callback|callback message> to be sent periodically during
@@ -25,6 +25,9 @@ Example:
 libURLSetStatusCallback myAction,the long ID of button "Upload"
 
 Example:
+libURLSetStatusCallback "putPercentage" -- sends message to url library. Handle the message in a frontscript, backscript, or stack in use.
+
+Example:
 libURLSetStatusCallback -- turns off status callback messages
 
 Parameters:
@@ -33,7 +36,10 @@ The name of a message to be sent whenever the URLStatus function is
 updated. 
 
 objectLongID:
-The long ID of the object to send the message to.
+The long ID of the object to send the message to. If <messageName> is 
+not empty but <objectLongID> is empty then the message will be sent to
+the revLibURL library stack. The message can be handled in a frontscript,
+backscript, or library stack.
 
 Description:
 Use the <libURLSetStatusCallback> <command> if you want to do periodic

--- a/docs/notes/feature-libUrlSetStatusCallback-no-object.md
+++ b/docs/notes/feature-libUrlSetStatusCallback-no-object.md
@@ -1,0 +1,8 @@
+---
+version: 8.2
+---
+# libURLSetStatusCallback no longer requires a target object for the message
+
+Passing an object reference as a second parameter to libURLSetStatusCallback 
+is no longer required. If no object is passed in then the message will be sent
+to revLibURL itself and you can handle the message anywhere in the message path.

--- a/docs/notes/feature-libUrlSetStatusCallback-no-object.md
+++ b/docs/notes/feature-libUrlSetStatusCallback-no-object.md
@@ -1,6 +1,3 @@
----
-version: 8.2
----
 # libURLSetStatusCallback no longer requires a target object for the message
 
 Passing an object reference as a second parameter to libURLSetStatusCallback 

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -3563,7 +3563,12 @@ end libUrlSetLogField
 on libUrlSetStatusCallback pMessage,pObject
   ##pObject must be a long ID
   ##Allow empty value in which case we use send to self.
-  if pMessage <> empty then
+  if pMessage is not empty and the paramCount is 1 then
+    put pMessage & comma into lvStatusCallback
+  else if pMessage is not empty and the paramCount is 2 then
+    if not exists(pObject) then
+      return "Invalid callback target object" for error
+    end if
     put pMessage & comma & pObject into lvStatusCallback
   else
     put empty into lvStatusCallback

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -3567,7 +3567,7 @@ on libUrlSetStatusCallback pMessage,pObject
     put pMessage & comma into lvStatusCallback
   else if pMessage is not empty and the paramCount is 2 then
     if not exists(pObject) then
-      return "Invalid callback target object" for error
+      return "invalid callback target object" for error
     end if
     put pMessage & comma & pObject into lvStatusCallback
   else

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -3562,7 +3562,8 @@ end libUrlSetLogField
 ---------------------------
 on libUrlSetStatusCallback pMessage,pObject
   ##pObject must be a long ID
-  if pMessage <> empty and exists(pObject)  then
+  ##Allow empty value in which case we use send to self.
+  if pMessage <> empty then
     put pMessage & comma & pObject into lvStatusCallback
   else
     put empty into lvStatusCallback
@@ -3945,6 +3946,9 @@ on ulSendCallback pUrl, pStatus
   if exists(tObject) then
     ## need quotes for the url formatting and the possibility of multiple items in second argument
     send tMessage &&  quote & pUrl & quote & comma & quote & pStatus & quote to tObject in 0 milliseconds
+   else
+    # If no target then just send to self so it propagates through message path.
+    send tMessage &&  quote & pURL & quote & comma & quote & pStatus & quote to me in 0 milliseconds
   end if
 end ulSendCallback
 -----------------------------

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -3937,18 +3937,20 @@ on ulSendMessage pUrl
 end ulSendMessage
 ----------------------------
 on ulSendCallback pUrl, pStatus
-  local tMessage,tObject
+  local tMessage,tObject,tSendStr
   
   if lvStatusCallback is empty then exit ulSendCallback
   put item 1 of lvStatusCallback into tMessage
 
   put item 2 to -1 of lvStatusCallback into tObject   ##modified dc 220905
+  put tMessage && "pURL, pStatus" into tSendStr
+  
   if exists(tObject) then
     ## need quotes for the url formatting and the possibility of multiple items in second argument
-    send tMessage &&  quote & pUrl & quote & comma & quote & pStatus & quote to tObject in 0 milliseconds
+    send tSendStr to tObject in 0 milliseconds
    else
     # If no target then just send to self so it propagates through message path.
-    send tMessage &&  quote & pURL & quote & comma & quote & pStatus & quote to me in 0 milliseconds
+    send tSendStr to me in 0 milliseconds
   end if
 end ulSendCallback
 -----------------------------


### PR DESCRIPTION
Passing an object reference as a second parameter to libURLSetStatusCallback 
is no longer required. If no object is passed in then the message will be sent
to revLibURL itself and you can handle the message anywhere in the message path.

Enhancement request #18470
