### PR TITLE
[[ Bugfix 18472 ]] Cleanup load url in socketError

### DIFF
--- a/docs/notes/bugfix-18472.md
+++ b/docs/notes/bugfix-18472.md
@@ -1,0 +1,1 @@
+# 'load url' is not properly cleaned up on socketError 

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -3235,6 +3235,12 @@ on socketError x, pErr
       if x is among the lines of keys(laFTPCommandStatus) then ##may be waiting for a server reply
          put pErr into laFTPCommandStatus[x] ##unblock waits
       end if
+      
+      ## Handle cleanup for load url
+      if laLoadReq[laUrl[x]] then
+         ulHttpLateCleanUp x
+      end if
+        
    else if x is among the lines of keys(laControlXDataMap)then##must be ftp passive data socket
       put laControlXDataMap[x] into tControlSocket
       put false into laStatus[laUrl[tControlSocket]] ##unblock waits


### PR DESCRIPTION
No cleanup was happening on socketErrors for load url. This can happen when an invalid proxy is being used or an sslcertificate error occurs.
