### PR TITLE
com.livecode.engine: Convert types for result of send & execute script

### DIFF
--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -120,6 +120,25 @@ void MCEngineScriptObjectAllowAccess(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static MCValueRef
+MCEngineEvalScriptResult (MCExecContext& ctxt)
+{
+	if (MCresult->isclear())
+	{
+		return nil;
+	}
+
+	MCAutoValueRef t_result(MCresult->getvalueref());
+	if (!MCExtensionConvertFromScriptType(ctxt, kMCAnyTypeInfo,
+	                                      InOut(t_result)))
+	{
+		return nil;
+	}
+	return t_result.Take();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 extern "C" MC_DLLEXPORT_DEF MCScriptObjectRef MCEngineExecResolveScriptObject(MCStringRef p_object_id)
 {
     if (!MCEngineScriptObjectAccessIsAllowed())
@@ -444,9 +463,7 @@ MCValueRef MCEngineDoSendToObjectWithArguments(bool p_is_function, MCStringRef p
     
     MCExecContext ctxt(MCdefaultstackptr, nil, nil);
     MCParameter *t_params;
-    MCValueRef t_result;
     t_params = nil;
-    t_result = nil;
     
     if (!MCEngineConvertToScriptParameters(ctxt, p_arguments, t_params))
         goto cleanup;
@@ -468,12 +485,9 @@ MCValueRef MCEngineDoSendToObjectWithArguments(bool p_is_function, MCStringRef p
     else
         s_last_message_was_handled = false;
 
-	/* Provide a return value iff the result was set */
-	t_result = MCValueRetain(MCresult->isclear() ? kMCNull : MCresult->getvalueref());
-    
 cleanup:
     MCEngineFreeScriptParameters(t_params);
-    return t_result;
+    return MCEngineEvalScriptResult(ctxt);
 }
 
 extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecSendToScriptObjectWithArguments(bool p_is_function, MCStringRef p_message, MCScriptObjectRef p_object, MCProperListRef p_arguments)
@@ -569,8 +583,9 @@ extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecExecuteScript(MCStringRef p_s
         MCEngineThrowScriptError();
         return nil;
     }
-    
-    return MCValueRetain(MCresult -> getvalueref());
+
+	MCExecContext ctxt(MCdefaultstackptr, nil, nil);
+	return MCEngineEvalScriptResult(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -111,11 +111,13 @@ $(LCM_DIR)/%.lcm: %.lcb | $(LCM_DIR)
 # Engine-based tests
 ################################################################
 
-lcs-check: $(LCS_ENGINE)
+lcs-check: $(LCS_ENGINE) lcm_compile
 	@rm -f $(LCS_LOG)
 	@cmd="$(LCS_CMD)"; \
 	echo "$$cmd" $(_PRINT_RULE); \
 	$$cmd
+
+.PHONY: lcs-check
 
 ################################################################
 # LCB compiler tests

--- a/tests/lcs/core/engine/_extension.lcb
+++ b/tests/lcs/core/engine/_extension.lcb
@@ -1,0 +1,23 @@
+library com.livecode.lcs_tests.core.extension
+
+public handler TestExtensionBridgeNames_ExecuteScript()
+	execute script "return the version"
+	return the result is a string
+end handler
+
+public handler TestExtensionBridgeNumbers_ExecuteScript()
+	execute script "return 5+0"
+	return the result is a number
+end handler
+
+public handler TestExtensionBridgeNames_Send()
+	variable tScriptObject
+	resolve script object "stack \qCoreEngineExtensions\q"
+	put the result into tScriptObject
+	test diagnostic tScriptObject
+
+	send function "TestExtensionBridgeNames_Version" to tScriptObject
+	return the result is a string
+end handler
+
+end library

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -19,6 +19,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 on TestSetup
     TestLoadExtension "com.livecode.library.json"
     TestLoadExtension "com.livecode.widget.clock"
+
+    TestDiagnostic the defaultfolder
+    load extension from file "../_tests/_build/lcs/core/engine/_extension.lcm"
+    if the result is not empty then
+       throw "Failed to load test support extension:" && the result
+    end if
 end TestSetup
 
 /////////
@@ -45,3 +51,21 @@ on TestUnloadWidgetModuleAfterDeletion
     send "_TestUnloadWidgetModuleAfterDeletion_DoDeleteAndUnload" to me in 0 millisecs
     wait 1 millisecond with messages
 end TestUnloadWidgetModuleAfterDeletion
+
+/////////
+
+function TestExtensionBridgeNames_Version
+   return the version
+end TestExtensionBridgeNames_Version
+
+on TestExtensionBridgeNames
+   TestAssert "LCS names bridge to LCB strings in execute script", \
+         TestExtensionBridgeNames_ExecuteScript()
+   TestAssert "LCS names bridge to LCB strings in send", \
+         TestExtensionBridgeNames_Send()
+end TestExtensionBridgeNames
+
+on TestExtensionBridgeNumbers
+   TestAssert "LCS numbers bridge to LCB numbers in execute script", \
+         TestExtensionBridgeNumbers_ExecuteScript()
+end TestExtensionBridgeNumbers


### PR DESCRIPTION
The engine module's `send` and `execute script` statements were
failing to correctly perform type conversion of their results,
potentially leaking `MCNameRef`s into LCB script.

This patch adds a `MCEngineEvalScriptResult()` handler that does this
correctly.  A better long-term fix would be to make sure LCB can cope
with `MCNameRef`s correctly and transparently through its typesystem.
