### PR TITLE
[[ Documentation ]] Fixes to mouseDown.lcdoc

### DIFF
--- a/docs/dictionary/message/mouseDown.lcdoc
+++ b/docs/dictionary/message/mouseDown.lcdoc
@@ -9,25 +9,37 @@ Sent when the user presses the <mouse button>.
 
 Introduced: 1.0
 
-OS: mac, windows, linux, ios, android
+OS: mac, windows, linux, ios, android, html5
 
 Platforms: desktop, server, mobile
 
 Example:
-on mouseDown theButton -- show popup menu on Control/Right-click
-  if theButton is 3 then popup button "Configure"
-  else pass mouseDown
+# show popup menu on Right-click/Control-click (Mac OS)
+#  assumes presence of a popup-style menu button, "Configure"
+on mouseDown theButton 
+  if theButton is 3 then 
+    popup button "Configure"
+  else 
+    pass mouseDown
+  end if
+end mouseDown
+
+Example:
+# To let the user click and drag an object
+#  put this handler in the object's script
+on mouseDown
+  grab me
 end mouseDown
 
 Parameters:
 mouseButtonNumber (enum):
 The mouseButtonNumber specifies which mouse button was pressed:
 
--  1 is the mouse button on Mac OS systems and the left button on
-   Windows and Unix systems.
--  2 is the middle button on Unix systems.
--  3 is the right button on Windows and Unix systems and Control-click
-   on Mac OS systems.
+-  1 is the the left button on systems with a multi-button mouse
+   and the mouse button on Mac OS systems with a single-button mouse.
+-  2 is the middle button on systems with a three-button mouse.
+-  3 is the right button on systems with a multi-button mouse and 
+   Control-click on Mac OS systems with a single-button mouse.
 
 
 Description:
@@ -37,12 +49,12 @@ presses the <mouse button>, before the <mouse button> is released.
 The <mouseDown> <message> is sent to the <control> that was clicked, or
 to the <card> if no <control> was under the <mouse pointer>.
 
-If the Browse tool is being used, and you click an unlocked field with
-mouse button 1 or 2, no <mouseDown> <message> is sent. If you click with
-button 3, the <mouseDown> <message> is sent even though the <field> is
-not <lock|locked>.
+If the Browse tool is being used, and you click an unlocked <field> with
+<mouse button> 1 or 2, no <mouseDown> <message> is sent. If you click with
+<button|mouse button> 3, the <mouseDown> <message> is sent even though the 
+<field> is not <lock|locked>.
 
->*Important:*  If the user clicks a transparent <pixel> in an <image>,
+>*Note:*  If the user clicks a transparent <pixel> in an <image>,
 > the <mouseDown> <message> is sent to the <object(glossary)> behind the
 > <image>, not to the <image>.
 
@@ -53,5 +65,5 @@ image (glossary), object (glossary), control (keyword),
 scrollbarBeginning (message), scrollbarLineInc (message),
 mouseDown (message), mouseStillDown (message), repeatDelay (property)
 
-Tags: ui
+Tags: ui, messages
 

--- a/docs/dictionary/message/mouseDown.lcdoc
+++ b/docs/dictionary/message/mouseDown.lcdoc
@@ -65,5 +65,5 @@ image (glossary), object (glossary), control (keyword),
 scrollbarBeginning (message), scrollbarLineInc (message),
 mouseDown (message), mouseStillDown (message), repeatDelay (property)
 
-Tags: ui, messages
+Tags: ui
 


### PR DESCRIPTION
- Clarified the param description to reflect modern OSs and mouses.
- Added html5 as OS.
- Added messages tag.
- Clarified example comments.
- Standardizing on "_Note:_" for block quoted notes.
- Added example.
