### PR TITLE
[[ Documentation ]] Fix tag - mouseUp.lcdoc

### DIFF
--- a/docs/dictionary/message/mouseUp.lcdoc
+++ b/docs/dictionary/message/mouseUp.lcdoc
@@ -86,5 +86,5 @@ mouseStillDown (message), mouseDoubleUp (message),
 mouseRelease (message), mouseUpInBackdrop (message), 
 script (property), double-click (glossary)
 
-Tags: ui, message
+Tags: ui, messages
 

--- a/docs/dictionary/message/mouseUp.lcdoc
+++ b/docs/dictionary/message/mouseUp.lcdoc
@@ -86,5 +86,5 @@ mouseStillDown (message), mouseDoubleUp (message),
 mouseRelease (message), mouseUpInBackdrop (message), 
 script (property), double-click (glossary)
 
-Tags: ui, messages
+Tags: ui
 


### PR DESCRIPTION
- Tag is 'message', not 'message'.
