### PR TITLE
[Bug 17622] Encode/decode HTML text on the clipboard (backport)

### DIFF
--- a/docs/notes/bugfix-17622.md
+++ b/docs/notes/bugfix-17622.md
@@ -1,0 +1,1 @@
+# Fix extra data added on Windows when pasting html data from the clipboard

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -372,7 +372,13 @@ bool MCClipboard::AddLiveCodeStyledText(MCDataRef p_pickled_text)
         // This type is optional as it may not be a faithful representation
         MCAutoDataRef t_html(ConvertStyledTextToHTML(p_pickled_text));
         if (*t_html != NULL)
-            t_success = t_item->AddRepresentation(t_type_string, *t_html);
+		{
+			MCAutoDataRef t_encoded;
+			t_encoded = m_clipboard->EncodeHTMLFragmentForTransfer(*t_html);
+			t_success = *t_encoded != nil;
+			if (t_success)
+	            t_success = t_item->AddRepresentation(t_type_string, *t_encoded);
+		}
     }
     
     // Also attempt to add as plain text, so we have a fall-back
@@ -459,6 +465,12 @@ bool MCClipboard::AddHTML(MCDataRef p_html)
     if (t_item == NULL)
         return false;
     
+	// Encode the HTML in the required format for the clipboard
+	MCAutoDataRef t_encoded;
+	t_encoded = m_clipboard->EncodeHTMLFragmentForTransfer(p_html);
+	if (*t_encoded == nil)
+		return false;
+
     // Add the data to the clipboard with the correct type
     MCStringRef t_type_string = m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeHTML);
     if (t_type_string == NULL)
@@ -849,13 +861,19 @@ bool MCClipboard::CopyAsLiveCodeStyledText(MCDataRef& r_pickled_text) const
     MCAutoDataRef t_html;
     if (CopyAsData(kMCRawClipboardKnownTypeHTML, &t_html))
     {
-        // Convert to LiveCode styled text
-        MCDataRef t_pickled_text = ConvertHTMLToStyledText(*t_html);
-        if (t_pickled_text != NULL)
-        {
-            r_pickled_text = t_pickled_text;
-            return true;
-        }
+		MCAutoDataRef t_decodedhtml;
+		t_decodedhtml.Reset(m_clipboard->DecodeTransferredHTML(*t_html));
+
+		if (*t_decodedhtml != nil)
+		{
+			// Convert to LiveCode styled text
+			MCDataRef t_pickled_text = ConvertHTMLToStyledText(*t_decodedhtml);
+			if (t_pickled_text != NULL)
+			{
+				r_pickled_text = t_pickled_text;
+				return true;
+			}
+		}
     }
     
     // Finally, try plain text.
@@ -935,7 +953,17 @@ bool MCClipboard::CopyAsRTF(MCDataRef& r_rtf_data) const
 
 bool MCClipboard::CopyAsHTML(MCDataRef& r_html_data) const
 {
-    return CopyAsData(kMCRawClipboardKnownTypeHTML, r_html_data);
+	MCAutoDataRef t_data;
+	if (!CopyAsData(kMCRawClipboardKnownTypeHTML, &t_data))
+		return false;
+
+	MCDataRef t_decoded = nil;
+	t_decoded = m_clipboard->DecodeTransferredHTML(*t_data);
+	if (t_decoded == nil)
+		return false;
+
+	r_html_data = t_decoded;
+	return true;
 }
 
 bool MCClipboard::CopyAsPNG(MCDataRef& r_png) const

--- a/engine/src/em-clipboard.cpp
+++ b/engine/src/em-clipboard.cpp
@@ -109,3 +109,14 @@ MCStringRef MCEmscriptenRawClipboard::DecodeTransferredFileList(MCDataRef p_data
 {
     return NULL;
 }
+
+MCDataRef MCEmscriptenRawClipboard::EncodeHTMLFragmentForTransfer(MCDataRef p_html) const
+{
+	return NULL;
+}
+
+MCDataRef MCEmscriptenRawClipboard::DecodeTransferredHTML(MCDataRef p_html) const
+{
+	return NULL;
+}
+

--- a/engine/src/em-clipboard.h
+++ b/engine/src/em-clipboard.h
@@ -44,6 +44,8 @@ public:
     virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
     virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_list) const;
     virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
+	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
+	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
 };
 
 

--- a/engine/src/lnx-clipboard.cpp
+++ b/engine/src/lnx-clipboard.cpp
@@ -315,6 +315,16 @@ MCStringRef MCLinuxRawClipboard::DecodeTransferredFileList(MCDataRef p_data) con
     return t_paths;
 }
 
+MCDataRef MCLinuxRawClipboard::EncodeHTMLFragmentForTransfer(MCDataRef p_html) const
+{
+	return MCValueRetain(p_html);
+}
+
+MCDataRef MCLinuxRawClipboard::DecodeTransferredHTML(MCDataRef p_html) const
+{
+	return MCValueRetain(p_html);
+}
+
 const MCLinuxRawClipboardItem* MCLinuxRawClipboard::GetSelectionItem() const
 {
     if (m_selected_item)

--- a/engine/src/lnx-clipboard.h
+++ b/engine/src/lnx-clipboard.h
@@ -112,6 +112,8 @@ public:
     virtual bool FlushData();
     virtual uindex_t GetMaximumItemCount() const;
     virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
+    virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_list) const;
+    virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
 	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
 	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
     

--- a/engine/src/lnx-clipboard.h
+++ b/engine/src/lnx-clipboard.h
@@ -112,8 +112,8 @@ public:
     virtual bool FlushData();
     virtual uindex_t GetMaximumItemCount() const;
     virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
-    virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_list) const;
-    virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
+	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
+	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
     
     // Gets the item that was most recently pushed to the system (this is used
     // to respond to selection requests in order to perform copies)

--- a/engine/src/mac-clipboard.h
+++ b/engine/src/mac-clipboard.h
@@ -111,6 +111,8 @@ public:
     virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
     virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_path) const;
     virtual MCStringRef DecodeTransferredFileList(MCDataRef p_encoded_path) const;
+	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
+	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
     
     // Constructor. The NSPasteboard being wrapped is required.
     MCMacRawClipboard(NSPasteboard* p_pasteboard);

--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -274,6 +274,16 @@ MCStringRef MCMacRawClipboard::DecodeTransferredFileList(MCDataRef p_encoded_pat
     return t_path;
 }
 
+MCDataRef MCMacRawClipboard::EncodeHTMLFragmentForTransfer(MCDataRef p_html) const
+{
+	return MCValueRetain(p_html);
+}
+
+MCDataRef MCMacRawClipboard::DecodeTransferredHTML(MCDataRef p_html) const
+{
+	return MCValueRetain(p_html);
+}
+
 MCStringRef MCMacRawClipboard::CopyAsUTI(MCStringRef p_key)
 {
     // If the key is already in UTI form, just pass it out

--- a/engine/src/mblandroid-clipboard.cpp
+++ b/engine/src/mblandroid-clipboard.cpp
@@ -109,3 +109,14 @@ MCStringRef MCAndroidRawClipboard::DecodeTransferredFileList(MCDataRef p_data) c
 {
     return NULL;
 }
+
+MCDataRef MCAndroidRawClipboard::EncodeHTMLFragmentForTransfer(MCDataRef p_html) const
+{
+	return NULL;
+}
+
+MCDataRef MCAndroidRawClipboard::DecodeTransferredHTML(MCDataRef p_html) const
+{
+	return NULL;
+}
+

--- a/engine/src/mblandroid-clipboard.h
+++ b/engine/src/mblandroid-clipboard.h
@@ -44,6 +44,8 @@ public:
     virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
     virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_list) const;
     virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
+	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
+	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
 };
 
 

--- a/engine/src/mbliphone-clipboard.h
+++ b/engine/src/mbliphone-clipboard.h
@@ -44,6 +44,8 @@ public:
     virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
     virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_list) const;
     virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
+	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
+	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
 };
 
 

--- a/engine/src/mbliphone-clipboard.mm
+++ b/engine/src/mbliphone-clipboard.mm
@@ -109,3 +109,14 @@ MCStringRef MCIPhoneRawClipboard::DecodeTransferredFileList(MCDataRef p_data) co
 {
     return NULL;
 }
+
+MCDataRef MCIPhoneRawClipboard::EncodeHTMLFragmentForTransfer(MCDataRef p_html) const
+{
+	return NULL;
+}
+
+MCDataRef MCIPhoneRawClipboard::DecodeTransferredHTML(MCDataRef p_html) const
+{
+	return NULL;
+}
+

--- a/engine/src/raw-clipboard.h
+++ b/engine/src/raw-clipboard.h
@@ -180,6 +180,10 @@ public:
 	// Reverses CreateEncodedFileList.
 	virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const = 0;
 
+	// Convert html to system-specific encoding for transfer on the clipboard
+	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const = 0;
+	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const = 0;
+
     // Destructor
     virtual ~MCRawClipboard() = 0;
     

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -315,6 +315,193 @@ MCStringRef MCWin32RawClipboardCommon::DecodeTransferredFileList(MCDataRef p_dat
 	return t_decoded;
 }
 
+MCDataRef MCWin32RawClipboardCommon::EncodeHTMLFragmentForTransfer(MCDataRef p_html) const
+{
+	const char *t_header_template = "Version:0.9\r\nStartHTML:%010d\r\nEndHTML:%010d\r\nStartFragment:%010d\r\nEndFragment:%010d\r\n";
+	const char *t_doc_prefix = "<html><body><!--StartFragment -->";
+	const char *t_doc_suffix = "<!--EndFragment --></body></html>";
+
+	uindex_t t_starthtml, t_endhtml, t_startfragment, t_endfragment;
+	// length of header will be length of template + difference between placeholder length and inserted string length
+	// numbers are padded to 10 digits using '0's
+	t_starthtml = strlen(t_header_template) + 4 * (10 - 5);
+	t_startfragment = t_starthtml + strlen(t_doc_prefix);
+	t_endfragment = t_startfragment + MCDataGetLength(p_html);
+	t_endhtml = t_endfragment + strlen(t_doc_suffix);
+
+	MCAutoStringRef t_header;
+	MCAutoStringRef t_start_string;
+	MCAutoStringRef t_end_string;
+
+	if (!MCStringFormat(&t_header, t_header_template, t_starthtml, t_endhtml, t_startfragment, t_endfragment))
+		return nil;
+
+	MCAutoDataRef t_header_data;
+	if (!MCStringEncode(*t_header, kMCStringEncodingUTF8, false, &t_header_data))
+		return nil;
+
+	MCAutoDataRef t_data;
+	if (!MCDataMutableCopy(*t_header_data, &t_data))
+		return nil;
+
+	if (!MCDataAppendBytes(*t_data, (const byte_t*)t_doc_prefix, strlen(t_doc_prefix)))
+		return nil;
+
+	if (!MCDataAppend(*t_data, p_html))
+		return nil;
+
+	if (!MCDataAppendBytes(*t_data, (const byte_t*)t_doc_suffix, strlen(t_doc_suffix)))
+		return nil;
+
+	return t_data.Take();
+}
+
+bool MCWin32RawClipboardGetHTMLDataHeader(MCDataRef p_data, uindex_t &x_index, MCStringRef &r_key, MCStringRef &r_value)
+{
+	MCAutoStringRef t_key;
+	MCAutoStringRef t_value;
+
+	uindex_t t_length;
+	t_length = MCDataGetLength(p_data);
+
+	const byte_t *t_data_ptr;
+	t_data_ptr = MCDataGetBytePtr(p_data);
+
+	uindex_t t_index = x_index;
+
+	for (uint32_t i = t_index; i < t_length; i++)
+	{
+		if (char(t_data_ptr[i]) == ':')
+		{
+			if (!MCStringCreateWithBytes(t_data_ptr + t_index, i - t_index, kMCStringEncodingUTF8, false, &t_key))
+				return false;
+			t_index = i + 1;
+			break;
+		}
+
+		// end of line with no ':' char - not a header
+		if (char(t_data_ptr[i]) == '\r' || char(t_data_ptr[i]) == '\n')
+			return false;
+
+		// start of html data - no header
+		if (char(t_data_ptr[i]) == '<')
+			return false;
+	}
+
+	// reached end without finding key
+	if (*t_key == nil)
+		return false;
+
+	// look for end of line - may be cr, lf, or crlf
+	for (uindex_t i = t_index; i < t_length; i++)
+	{
+		// end of line
+		if (char(t_data_ptr[i]) == '\r' || char(t_data_ptr[i]) == '\n')
+		{
+			if (!MCStringCreateWithBytes(t_data_ptr + t_index, i - t_index, kMCStringEncodingUTF8, false, &t_value))
+				return false;
+			t_index = i + 1;
+			// check for crlf
+			if (char(t_data_ptr[i]) == '\r' && t_index < t_length && char(t_data_ptr[t_index]) == '\n')
+				t_index++;
+
+			break;
+		}
+	}
+
+	// reached end without finding line ending
+	if (*t_value == nil)
+		return false;
+
+	r_key = t_key.Take();
+	r_value = t_value.Take();
+
+	x_index = t_index;
+
+	return true;
+}
+
+MCDataRef MCWin32RawClipboardCommon::DecodeTransferredHTML(MCDataRef p_data) const 
+{
+	bool t_success = true;
+
+	uindex_t t_index = 0;
+
+	index_t t_starthtml = -1;
+	index_t t_endhtml = -1;
+	index_t t_startfragment = -1;
+	index_t t_endfragment = -1;
+	index_t t_startselection = -1;
+	index_t t_endselection = -1;
+
+	MCStringRef t_headerkey = nil;
+	MCStringRef t_headervalue = nil;
+
+	while (MCWin32RawClipboardGetHTMLDataHeader(p_data, t_index, t_headerkey, t_headervalue))
+	{
+		MCAutoNumberRef t_number;
+		if (MCStringIsEqualToCString(t_headerkey, "starthtml", kMCStringOptionCompareCaseless))
+		{
+			if (MCNumberParse(t_headervalue, &t_number))
+				t_starthtml = MCNumberFetchAsInteger(*t_number);
+		}
+		else if (MCStringIsEqualToCString(t_headerkey, "endhtml", kMCStringOptionCompareCaseless))
+		{
+			if (MCNumberParse(t_headervalue, &t_number))
+				t_endhtml = MCNumberFetchAsInteger(*t_number);
+		}
+		else if (MCStringIsEqualToCString(t_headerkey, "startfragment", kMCStringOptionCompareCaseless))
+		{
+			if (MCNumberParse(t_headervalue, &t_number))
+				t_startfragment = MCNumberFetchAsInteger(*t_number);
+		}
+		else if (MCStringIsEqualToCString(t_headerkey, "endfragment", kMCStringOptionCompareCaseless))
+		{
+			if (MCNumberParse(t_headervalue, &t_number))
+				t_endfragment = MCNumberFetchAsInteger(*t_number);
+		}
+		else if (MCStringIsEqualToCString(t_headerkey, "startselection", kMCStringOptionCompareCaseless))
+		{
+			if (MCNumberParse(t_headervalue, &t_number))
+				t_startselection = MCNumberFetchAsInteger(*t_number);
+		}
+		else if (MCStringIsEqualToCString(t_headerkey, "endselection", kMCStringOptionCompareCaseless))
+		{
+			if (MCNumberParse(t_headervalue, &t_number))
+				t_endselection = MCNumberFetchAsInteger(*t_number);
+		}
+
+		MCValueRelease(t_headerkey);
+		MCValueRelease(t_headervalue);
+		t_headerkey = nil;
+		t_headervalue = nil;
+	}
+
+	uindex_t t_start = -1;
+	uindex_t t_end = -1;
+
+	if (t_starthtml != -1 && t_endhtml != -1)
+	{
+		t_start = t_starthtml;
+		t_end = t_endhtml;
+	}
+
+	if (t_startfragment != -1 && t_endfragment != -1)
+	{
+		t_start = t_startfragment;
+		t_end = t_endfragment;
+	}
+
+	t_end = MCClamp(t_end, 0, MCDataGetLength(p_data));
+	t_start = MCClamp(t_start, 0, t_end);
+
+	MCDataRef t_decoded;
+	if (MCDataCopyRange(p_data, MCRangeMakeMinMax(t_start, t_end), t_decoded))
+		return t_decoded;
+
+	return nil;
+}
+
 void MCWin32RawClipboardCommon::SetDirty()
 {
 	m_dirty = true;

--- a/engine/src/w32-clipboard.h
+++ b/engine/src/w32-clipboard.h
@@ -128,7 +128,9 @@ public:
     virtual MCStringRef GetKnownTypeString(MCRawClipboardKnownType p_type) const;
     virtual MCDataRef EncodeFileListForTransfer(MCStringRef p_file_list) const;
 	virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
-    
+	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
+	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
+
 	// Sets the clipboard as being dirty
 	void SetDirty();
 


### PR DESCRIPTION
Backport of #4525 to `develop-8.1` branch. No conflicts.
