### PR TITLE
Fix libURLMultipartFormAddPart example

### DIFF
--- a/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
@@ -38,8 +38,8 @@ if libURLMultipartFormAddPart(tForm,"file", tFile, tType, tEnc) \
    ##handle error and exit
 else
    post tForm to url tURL
-   set the httpHeaders to empty
 end if
+set the httpHeaders to empty
 
 Parameters:
 value:

--- a/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
@@ -24,8 +24,8 @@ Example:
 put empty into tForm
 put "dave" into tName
 put "hello" into tMessage
-if libURLMultipartFormData (tForm, "name", tName, "message", tMessage) \
-     is not empty then
+put libURLMultipartFormData (tForm, "name", tName, "message", tMessage) into tError
+if tError is not empty then
    ##handle error and exit
 end if
 set the httpHeaders to line 1 of tForm

--- a/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
@@ -33,8 +33,8 @@ delete line 1 of tForm
 put "&lt;file&gt;" & "C:/myfile.gif" into tFile
 put "image/gif" into tType
 put "binary" into tEnc
-if libURLMultipartFormAddPart(tForm,"file", tFile, tType, tEnc) \
-    is empty then
+put libURLMultipartFormAddPart(tForm,"file", tFile, tType, tEnc) into tError
+if tError is empty then
    ##handle error and exit
 else
    post tForm to url tURL

--- a/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
@@ -21,25 +21,33 @@ Platforms: desktop, server
 Security: network
 
 Example:
-put empty into tForm
-put "dave" into tName
-put "hello" into tMessage
-put libURLMultipartFormData (tForm, "name", tName, "message", tMessage) into tError
-if tError is not empty then
-   ##handle error and exit
-end if
-set the httpHeaders to line 1 of tForm
-delete line 1 of tForm
-put "&lt;file&gt;" & "C:/myfile.gif" into tFile
-put "image/gif" into tType
-put "binary" into tEnc
-put libURLMultipartFormAddPart(tForm,"file", tFile, tType, tEnc) into tError
-if tError is not empty then
-   ##handle error and exit
-else
-   post tForm to url tURL
-end if
-set the httpHeaders to empty
+command UploadFileToServer pName, pMessage, pFilename
+  put the httpHeaders into tOrigHeaders
+  put empty into tForm
+  put libURLMultipartFormData (tForm, "name", pName, "message", pMessage) into tError
+  
+  if tError is empty then
+    set the httpHeaders to line 1 of tForm
+    delete line 1 of tForm
+    put "&lt;file&gt;" & pFilename into tFile
+    put "image/gif" into tType
+    put "binary" into tEnc
+    put libURLMultipartFormAddPart(tForm,"file", tFile, tType, tEnc) into tError
+  end if
+ 
+  if tError is empty then
+    post tForm to url tURL
+    put the result into tError
+  end if
+  
+  set the httpHeaders to tOrigHeaders
+  
+  if tError is not empty then
+    return tError for error
+  else
+    return empty for value
+  end if
+end UploadFileToServer
 
 Parameters:
 value:

--- a/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
@@ -34,7 +34,7 @@ put "&lt;file&gt;" & "C:/myfile.gif" into tFile
 put "image/gif" into tType
 put "binary" into tEnc
 put libURLMultipartFormAddPart(tForm,"file", tFile, tType, tEnc) into tError
-if tError is empty then
+if tError is not empty then
    ##handle error and exit
 else
    post tForm to url tURL


### PR DESCRIPTION
The example was not restoring the httpHeaders to empty if an error occurred.
