### PR TITLE
Clear up error reporting in libURLMultipartFormData

### DIFF
--- a/docs/dictionary/function/libUrlMultipartFormData.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormData.lcdoc
@@ -26,10 +26,10 @@ put empty into tForm
 put "http://www.someserver.com/cgi-bin/form.cgi" into tUrl
 put "dave" into tName put "hello" into tMessage
 put "&lt;file&gt;" & "C:/myfile.txt" into tFile
-if libURLMultipartFormData \
- (tForm, "name", tName, "message", tMessage, "file", tFile) \
- is not empty then
- answer it ##error
+put libURLMultipartFormData \
+ (tForm, "name", tName, "message", tMessage, "file", tFile) into tError
+if tError is not empty then
+ answer tError ##error
 else
  set the httpHeaders to line 1 of tForm
  post line 2 to -1 of tForm to url tUrl

--- a/docs/dictionary/function/libUrlMultipartFormData.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormData.lcdoc
@@ -37,9 +37,6 @@ else
  set the httpHeaders to empty
 end if
 
-The result:
-## check the result, etc., here.
-
 Description:
 The function can be called in a number of ways depending on the
 parameters passed. In all cases, the first parameter must be a variable


### PR DESCRIPTION
By storing the returned value in tError it is more clear that the function returns an error message.
