### PR TITLE
[[ Bug 17779 ]] Fix clipping of scrolling group content when acceleratedRendering used

### DIFF
--- a/docs/notes/bugfix-17247.md
+++ b/docs/notes/bugfix-17247.md
@@ -1,0 +1,1 @@
+# Remove selection artefacts when handles are drawn outside of parent group rect

--- a/docs/notes/bugfix-17247.md
+++ b/docs/notes/bugfix-17247.md
@@ -1,1 +1,0 @@
-# Remove selection artefacts when handles are drawn outside of parent group rect

--- a/docs/notes/bugfix-17779.md
+++ b/docs/notes/bugfix-17779.md
@@ -1,0 +1,1 @@
+# Fix scrolling group drawing outside its bounds when acceleratedRendering used.

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -3030,6 +3030,20 @@ void MCCard::drawselectedchildren(MCDC *dc)
     while (tptr != objptrs);
 }
 
+void MCCard::dirtyselection(const MCRectangle &p_rect)
+{
+	// redraw marquee rect
+	// selrect with 0 width or height will still draw a 1px line, so increase rect size to account for this.
+	layer_dirtyrect(MCU_reduce_rect(p_rect, -1));
+	
+	// redraw selection handles
+	MCRectangle t_handles[8];
+	MCControl::sizerects(p_rect, t_handles);
+
+	for (uint32_t i = 0; i < 8; i++)
+		layer_dirtyrect(t_handles[i]);
+}
+
 bool MCCard::updatechildselectedrect(MCRectangle& x_rect)
 {
     bool t_updated;

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -215,6 +215,11 @@ public:
 	// IM-2013-09-13: [[ RefactorGraphics ]] render the card selection rect
 	void drawselectionrect(MCContext *);
     void drawselectedchildren(MCDC *dc);
+	
+	// IM-2016-09-26: [[ Bug 17247 ]] request redraw of the area occupied by
+	//      selection marquee + handles
+	void dirtyselection(const MCRectangle &p_rect);
+	
     bool updatechildselectedrect(MCRectangle& x_rect);
     
 	Exec_stat openbackgrounds(bool p_is_preopen, MCCard *p_other);

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2070,6 +2070,10 @@ bool MCGroup::computeminrect(Boolean scrolling)
 			t_all = true;
 		state = oldstate;
 		
+		// IM-2016-09-27: [[ Bug 17779 ]] redrawselection handles if selected
+		if (getselected())
+			getcard()->dirtyselection(oldrect);
+		
 		// IM-2015-12-16: [[ NativeLayer ]] The group rect has changed, so send geometry change notification.
 		geometrychanged(getrect());
 		

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -3101,22 +3101,3 @@ void MCGroup::scheduledelete(bool p_is_child)
 		while(t_control != controls);
 	}
 }
-
-MCRectangle MCGroup::geteffectiverect(void) const
-{
-    MCRectangle t_rect;
-    t_rect = MCControl::geteffectiverect();
-    
-    if (controls != NULL)
-    {
-        MCControl *t_control;
-        t_control = controls;
-        do
-        {   t_rect = MCU_union_rect(t_rect, t_control -> geteffectiverect());
-            t_control = t_control -> next();
-        }
-        while(t_control != controls);
-    }
-    
-    return t_rect;
-}

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2072,7 +2072,10 @@ bool MCGroup::computeminrect(Boolean scrolling)
 		
 		// IM-2016-09-27: [[ Bug 17779 ]] redrawselection handles if selected
 		if (getselected())
+		{
 			getcard()->dirtyselection(oldrect);
+			getcard()->dirtyselection(rect);
+		}
 		
 		// IM-2015-12-16: [[ NativeLayer ]] The group rect has changed, so send geometry change notification.
 		geometrychanged(getrect());

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -148,11 +148,6 @@ public:
     
     virtual bool isdeletable(bool p_check_flag);
     
-    // This call computes the pixel bounds of the group, rather than
-    // just its active bounds - transients, bitmap effects and selection
-    // handles of a group's children may extend beyond the group's bounds.
-    virtual MCRectangle geteffectiverect(void) const;
-    
     void drawselectedchildren(MCDC *dc);
     bool updatechildselectedrect(MCRectangle& x_rect);
     

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -156,7 +156,9 @@ public:
 
 	void redraw(MCDC *dc, const MCRectangle &dirty);
 
-	void sizerects(MCRectangle *rects);
+	// IM-2016-09-26: [[ Bug 17247 ]] Return rect of selection handles for the given object rect
+	static void sizerects(const MCRectangle &p_object_rect, MCRectangle rects[8]);
+	
 	void drawselected(MCDC *dc);
 	void drawarrow(MCDC *dc, int2 x, int2 y, uint2 size,
 	               Arrow_direction dir, Boolean border, Boolean hilite);

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -555,8 +555,12 @@ void MCControl::layer_dirtyeffectiverect(const MCRectangle& p_effective_rect, bo
 			return;
 		}
 		
-		// Otherwise intersect the dirty rect with the parent's effective rect.
-		t_dirty_rect = MCU_intersect_rect(t_dirty_rect, t_parent_control -> geteffectiverect());
+		// Otherwise intersect the dirty rect with the parent's rect.
+		t_dirty_rect = MCU_intersect_rect(t_dirty_rect, t_control -> parent -> getrect());
+
+		// Expand due to bitmap effects (if any).
+		if (t_parent_control -> m_bitmap_effects != nil)
+			MCBitmapEffectsComputeBounds(t_parent_control -> m_bitmap_effects, t_dirty_rect, t_dirty_rect);
 
 		t_control = t_parent_control;
 	}

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -358,6 +358,10 @@ void MCControl::layer_setrect(const MCRectangle& p_new_rect, bool p_redraw_all)
 		return;
 	}
 
+	// IM-2016-09-26: [[ Bug 17247 ]] dirty old selection rect
+	if (getselected())
+		getcard()->dirtyselection(rect);
+	
 	MCRectangle t_old_effectiverect;
 	t_old_effectiverect = geteffectiverect();
 
@@ -368,6 +372,10 @@ void MCControl::layer_setrect(const MCRectangle& p_new_rect, bool p_redraw_all)
 		p_redraw_all = true;
 		
 	setrect(p_new_rect);
+
+	// IM-2016-09-26: [[ Bug 17247 ]] dirty new selection rect
+	if (getselected())
+		getcard()->dirtyselection(rect);
 
 	layer_changeeffectiverect(t_old_effectiverect, p_redraw_all, t_is_visible);
 }

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -540,12 +540,9 @@ void MCSellist::continuemove(int2 x, int2 y)
 		}
 		if (cptr->moveable())
 		{
-			// IM-2014-09-09: [[ Bug 13222 ]] Use the layer_setrect method to ensure the old
-			// effectiverect is appropriately dirtied when edittools are displayed for a graphic
-			if (cptr->resizeparent())
-				cptr->setrect(trect);
-			else
-				cptr->layer_setrect(trect, false);
+			// IM-2016-09-27: [[ Bug 17779 ]] Change to always calling layer_setrect, which invalidates selection handles if required.
+			cptr->layer_setrect(trect, false);
+			cptr->resizeparent();
 		}
 		tptr = tptr->next();
 	}


### PR DESCRIPTION
Reverted PR https://github.com/livecode/livecode/pull/3805 and reimplemented fix in a way that doesn't modify the effective rect of groups.
