### PR TITLE
lc-compile: Fix Coverity defects found in context display

### DIFF
--- a/toolchain/lc-compile/src/position.c
+++ b/toolchain/lc-compile/src/position.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include "report.h"
 #include "position.h"
@@ -419,6 +420,7 @@ static void __InitializeFileLines(FileRef x_file)
 	t_raw_text[t_file_length] = 0; /* nul-terminate */
 
 	fclose(t_stream);
+	t_stream = NULL;
 
 	/* Scan the file contents twice: once to count the number of
 	 * lines, and once to fill a pointer array with offset
@@ -470,10 +472,11 @@ static void __InitializeFileLines(FileRef x_file)
 	      x_file->path, x_file->line_count);
 
  cleanup:
+	if (NULL != t_stream)
+		fclose(t_stream);
 	if (NULL != t_raw_text)
 		free(t_raw_text);
-	if (NULL != t_lines)
-		free(t_lines);
+	assert(NULL == t_lines);
 	return;
 }
 

--- a/toolchain/lc-compile/src/report.c
+++ b/toolchain/lc-compile/src/report.c
@@ -200,6 +200,7 @@ static void _PrintContext(long p_position)
 	}
 
 	fprintf(stderr, " %s\n %*c\n", t_text, (int)t_column, '^');
+	free(t_text);
 }
 
 static void _Error(long p_position, const char *p_message)


### PR DESCRIPTION
This patch resolves three defects found by Coverity:
- commit 6c44baa934ef introduced a memory leak when removing control
  characters from source code lines
- commit c462755aff8a introduced a file pointer leak that could occur
  in some circumstances when attempting to print messages for
  unseekable files, and some unreachable cleanup code.

Coverity-Id: 136143
Coverity-Id: 136987
Coverity-Id: 136999
