### PR TITLE
Clear out `lvBlockingUrl` prior to return

### DIFF
--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -284,6 +284,7 @@ on getUrl x
          put empty into lvBlockingUrl ##clear
          return tRetResult with urlResult tRetData
       else
+         put empty into lvBlockingUrl ##fixes issue with NTLM auth
          return 1
       end if
    else ##blocked by previous request

--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -284,7 +284,9 @@ on getUrl x
          put empty into lvBlockingUrl ##clear
          return tRetResult with urlResult tRetData
       else
-         put empty into lvBlockingUrl ##fixes issue with NTLM auth
+         if lvAuthBlockBypass is true then
+           put empty into lvBlockingUrl ##fixes issue with NTLM auth
+         end if
          return 1
       end if
    else ##blocked by previous request


### PR DESCRIPTION
getUrl sets `lvBlockingUrl` value at the beginning. It is cleared out in the `if` portion of this handler but not in the `else`. I experienced problems with NTLM authorization callbacks if `lvBlockingUrl` wasn't reset.
