### PR TITLE
Rewrite Travis CI build script to ensure errors are detected, and fix them.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script: >
       ;;
   esac
 
-  if [[ ! -v COVERITY_SCAN_BRANCH ]]; then
+  if [[ -z "${COVERITY_SCAN_BRANCH}" ]]; then
     mkdir -p "${LICENSE_DIR}" &&
     touch "${LICENSE_DIR}/livecode-firstrun.lcf" &&
     make all-${BUILD_PLATFORM} &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,12 @@ script: >
   case "${TRAVIS_OS_NAME}" in
     linux)
       BUILD_PLATFORM=linux ;
+      CHECK_COMMAND=xvfb-run ;
       LICENSE_DIR="${HOME}/.runrev/licenses" ;
       ;;
     osx)
       BUILD_PLATFORM=mac ;
+      CHECK_COMMAND= ;
       LICENSE_DIR="${HOME}/Library/Application Support/RunRev/Licenses" ;
       export XCODEBUILD="set -o pipefail && xcodebuild" ;
       export XCODEBUILD_FILTER="| xcpretty" ;
@@ -57,7 +59,7 @@ script: >
     mkdir -p "${LICENSE_DIR}" &&
     touch "${LICENSE_DIR}/livecode-firstrun.lcf" &&
     make all-${BUILD_PLATFORM} &&
-    make check-${BUILD_PLATFORM}
+    ${CHECK_COMMAND} make check-${BUILD_PLATFORM}
   fi
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,21 +40,24 @@ install:
 # Bootstrap the LCB compiler, build the default target set and run a
 # the default test suite.
 script: >
-  if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then
-      LICENSE_FILE=livecode-firstrun.lcf
-      LICENSE_DIR="$HOME/.runrev/licenses"
-      [ -d "$LICENSE_DIR" ] || mkdir -p "$LICENSE_DIR"
-      touch "$LICENSE_DIR/$LICENSE_FILE"
-      make all-linux && xvfb-run make check-linux
-    fi
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then
-      LICENSE_FILE=livecode-firstrun.lcf
-      LICENSE_DIR="$HOME/Library/Application Support/RunRev/Licenses"
-      [ -d "$LICENSE_DIR" ] || mkdir -p "$LICENSE_DIR"
-      touch "$LICENSE_DIR/$LICENSE_FILE"
-      make all-mac && make check-mac
-    fi
+  case "${TRAVIS_OS_NAME}" in
+    linux)
+      BUILD_PLATFORM=linux ;
+      LICENSE_DIR="${HOME}/.runrev/licenses" ;
+      ;;
+    osx)
+      BUILD_PLATFORM=mac ;
+      LICENSE_DIR="${HOME}/Library/Application Support/RunRev/Licenses" ;
+      export XCODEBUILD="set -o pipefail && xcodebuild" ;
+      export XCODEBUILD_FILTER="| xcpretty" ;
+      ;;
+  esac
+
+  if [[ ! -v COVERITY_SCAN_BRANCH ]]; then
+    mkdir -p "${LICENSE_DIR}" &&
+    touch "${LICENSE_DIR}/livecode-firstrun.lcf" &&
+    make all-${BUILD_PLATFORM} &&
+    make check-${BUILD_PLATFORM}
   fi
 
 addons:

--- a/libcore/include/core.h
+++ b/libcore/include/core.h
@@ -168,15 +168,15 @@ extern void __MCAssert(const char *file, uint32_t line, const char *message);
 #define MCAssert(m_expr) (void)( (!!(m_expr)) || (__MCAssert(__FILE__, __LINE__, #m_expr), 0) )
 
 extern void __MCLog(const char *file, uint32_t line, const char *format, ...);
-#define MCLog(m_format, ...) __MCLog(__FILE__, __LINE__, m_format, __VA_ARGS__)
+#define MCLog(...) __MCLog(__FILE__, __LINE__, __VA_ARGS__)
 
 extern void __MCLogWithTrace(const char *file, uint32_t line, const char *format, ...);
-#define MCLogWithTrace(m_format, ...) __MCLogWithTrace(__FILE__, __LINE__, m_format, __VA_ARGS__)
+#define MCLogWithTrace(...) __MCLogWithTrace(__FILE__, __LINE__, __VA_ARGS__)
 
 #else
 #define MCAssert(expr)
-#define MCLog(m_format, ...) 
-#define MCLogWithTrace(m_format, ...)
+#define MCLog(...)
+#define MCLogWithTrace(...)
 #endif
 
 #define MC_CONCAT(X,Y) MC_CONCAT_(X,Y)


### PR DESCRIPTION
Recent changes stopped Travis CI builds from reporting build failures. 😱  To resolve this, this patch makes two changes to the build script used for Travis builds:
- Reduce duplication by setting a bunch of variables depending on the platform and then using them in a common set of actual build commands
- Chain all build commands with `&&` in order to make sure that build failure is detected successfully

Fixing this exposes the fact that GCC doesn't like variadic templates with empty variadic argument lists.  This meant that using `MCLog("message")` in code that used libcore's log macros would fail to compile.  However, this can be worked around by making libcore's `MCLog()` a variadic macro with no named arguments.  This was already the case in libfoundation.
