### PR TITLE
Use `new (nothrow)` everywhere

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -117,7 +117,6 @@
 		'-std=<(c++_std)',
 		'-fno-exceptions',
 		'-fno-rtti',
-		'-fcheck-new',
 	],
 	
 	'configurations':

--- a/engine/src/aclip.cpp
+++ b/engine/src/aclip.cpp
@@ -123,7 +123,7 @@ MCAudioClip::MCAudioClip()
 	disposable = False;
 	loudness = 100;
 #ifdef TARGET_PLATFORM_LINUX
-	x11audio = new X11Audio ;
+	x11audio = new (nothrow) X11Audio ;
 #endif
 }
 
@@ -133,7 +133,7 @@ MCAudioClip::MCAudioClip(const MCAudioClip &aref) : MCObject(aref)
 	samples = osamples = NULL;
 	if (size != 0)
 	{
-		samples = new int1[size];
+		samples = new (nothrow) int1[size];
 		memcpy(samples, aref.samples, size);
 	}
 	format = aref.format;
@@ -143,7 +143,7 @@ MCAudioClip::MCAudioClip(const MCAudioClip &aref) : MCObject(aref)
 	disposable = False;
 	loudness = aref.loudness;
 #ifdef TARGET_PLATFORM_LINUX
-	x11audio = new X11Audio ;
+	x11audio = new (nothrow) X11Audio ;
 #endif
 }
 
@@ -240,7 +240,7 @@ void MCAudioClip::init()
 
 void MCAudioClip::convert_mulawtolin16()
 {
-	int2 *newsamples = new int2[size];
+	int2 *newsamples = new (nothrow) int2[size];
 	uint1 *sptr = (uint1 *)samples;
 	int2 *dptr = newsamples;
 	uint4 count = size;
@@ -260,7 +260,7 @@ void MCAudioClip::convert_mulawtolin16()
 
 void MCAudioClip::convert_mulawtoulin8()
 {
-	int1 *newsamples = new int1[size];
+	int1 *newsamples = new (nothrow) int1[size];
 	uint1 *sptr = (uint1 *)samples;
 	int1 *dptr = newsamples;
 	uint4 count = size;
@@ -287,7 +287,7 @@ void MCAudioClip::convert_slin8toslin16()
 	uint4 count = size;
 	size <<= 1;
 	swidth = 2;
-	int1 *newsamples = new int1[size];
+	int1 *newsamples = new (nothrow) int1[size];
 	int1 *sptr = samples;
 	int2 *dptr = (int2 *)newsamples;
 	while(count--)
@@ -359,7 +359,7 @@ Boolean MCAudioClip::import(MCStringRef fname, IO_handle stream)
 	size = (uint4)MCS_fsize(stream);
 	if (size == 0)
 		return False;
-	samples = new int1[size];
+	samples = new (nothrow) int1[size];
 	if (IO_read(samples, size, stream) != IO_NORMAL)
 		return False;
 	if (strnequal((char*)samples, ".snd", 4))
@@ -687,7 +687,7 @@ Boolean MCAudioClip::play()
 	if (!open_audio())
 	{
 		real8 delay =  MCS_time() + (real8)size / (real8)(rate*nchannels*swidth);
-		MCParameter *newparam = new MCParameter;
+		MCParameter *newparam = new (nothrow) MCParameter;
 		newparam->setvalueref_argument(getname());
 		MCscreen->addmessage(MCdefaultstackptr->getcurcard(), MCM_play_stopped, delay, newparam);
 		return False;
@@ -910,7 +910,7 @@ IO_stat MCAudioClip::load(IO_handle stream, uint32_t version)
 		return checkloadstat(stat);
 	if (size != 0)
 	{
-		samples = new int1[size];
+		samples = new (nothrow) int1[size];
 		if ((stat = IO_read(samples, size, stream)) != IO_NORMAL)
 			return checkloadstat(stat);
 	}
@@ -965,7 +965,7 @@ uint2 MCS_getplayloudness()
     t_loudness = (HiWord(volume) + LoWord(volume)) * 50 / 255;
 #elif defined TARGET_PLATFORM_LINUX
     X11Audio *t_x11audio = nil;
-    t_x11audio = new X11Audio ;
+    t_x11audio = new (nothrow) X11Audio ;
     if ( t_x11audio != nil)
     {
         t_loudness = t_x11audio -> getloudness() ;
@@ -1008,7 +1008,7 @@ void MCS_setplayloudness(uint2 p_loudness)
     SetDefaultOutputVolume(volume | volume << 16);
 #elif defined TARGET_PLATFORM_LINUX
     X11Audio *t_x11audio = nil;
-    t_x11audio = new X11Audio ;
+    t_x11audio = new (nothrow) X11Audio ;
     if (t_x11audio != nil)
     {
         t_x11audio -> setloudness(p_loudness);

--- a/engine/src/bitmapeffect.cpp
+++ b/engine/src/bitmapeffect.cpp
@@ -160,7 +160,7 @@ bool MCBitmapEffectsAssign(MCBitmapEffectsRef& self, MCBitmapEffectsRef src)
 	if (src != NULL)
 	{
 		// Allocate, returning false if it fails.
-		t_new_self = new MCBitmapEffects;
+		t_new_self = new (nothrow) MCBitmapEffects;
 		if (t_new_self == NULL)
 			return false;
 
@@ -437,7 +437,7 @@ IO_stat MCBitmapEffectsUnpickle(MCBitmapEffectsRef& self, MCObjectInputStream& p
 {
 	// Create a new instance
 	MCBitmapEffects *t_new_self;
-	t_new_self = new MCBitmapEffects;
+	t_new_self = new (nothrow) MCBitmapEffects;
 	if (t_new_self == NULL)
 		return IO_ERROR;
 
@@ -1041,7 +1041,7 @@ bool MCBitmapEffectsSetProperty(MCExecContext& ctxt, MCBitmapEffectsRef& self, M
         // If we are currently empty, then allocate a new object
         if (self == nil)
         {
-            self = new MCBitmapEffects;
+            self = new (nothrow) MCBitmapEffects;
             if (self == nil)
                 return false;
             
@@ -1252,7 +1252,7 @@ static void MCBitmapEffectRender(MCBitmapEffectRenderState& state, MCBitmapEffec
 	
 	// Allocate a run of mask pixels
 	uint8_t *t_mask_pixels;
-	t_mask_pixels = new uint8_t[dst . bounds . width];
+	t_mask_pixels = new (nothrow) uint8_t[dst . bounds . width];
 
 	// Calculate the attenuation bounds
 	int32_t t_left, t_top, t_right, t_bottom, t_count;

--- a/engine/src/bitmapeffectblur.cpp
+++ b/engine/src/bitmapeffectblur.cpp
@@ -139,7 +139,7 @@ static float *MCBitmapEffectComputeGaussianKernel(uint4 r)
 	t_width = r * 2 + 1;
 
 	float *lk;
-	lk = new float[t_width];
+	lk = new (nothrow) float[t_width];
 	if (lk == NULL)
 		return NULL;
 
@@ -162,7 +162,7 @@ static uint32_t *MCBitmapEffectComputeBlurKernel(uint4 r)
 	lk = MCBitmapEffectComputeGaussianKernel(r);
 	
 	float *k, t_sum;
-	k = new float[t_width * t_width];
+	k = new (nothrow) float[t_width * t_width];
 	t_sum = 0.0;
 	for(uint4 i = 0; i < t_width; i++)
 		for(uint4 j = 0; j < t_width; j++)
@@ -174,7 +174,7 @@ static uint32_t *MCBitmapEffectComputeBlurKernel(uint4 r)
 		}
 
 	uint32_t *ik;
-	ik = new uint32_t[t_width * t_width];
+	ik = new (nothrow) uint32_t[t_width * t_width];
 	for(uint4 i = 0; i < t_width; i++)
 		for(uint4 j = 0; j < t_width; j++)
 			ik[i * t_width + j] = (uint32_t)(k[i * t_width + j] * 0x1000000 / t_sum);
@@ -332,7 +332,7 @@ bool MCBitmapEffectFastGaussianBlur::Initialize(const MCBitmapEffectBlurParamete
 	if (params . radius != 0)
 	{
 		float *lk = MCBitmapEffectComputeGaussianKernel(t_spread_radius);
-		kernel = new uint32_t[t_width];
+		kernel = new (nothrow) uint32_t[t_width];
 		float t_sum = 0;
 		for (uint32_t i=0; i<(t_spread_radius * 2 + 1); i++)
 		{
@@ -364,7 +364,7 @@ bool MCBitmapEffectFastGaussianBlur::Initialize(const MCBitmapEffectBlurParamete
 
 	buffer_height = t_width;
 	buffer_nextrow = top;
-	buffer = new uint32_t[buffer_height * output_rect.width];
+	buffer = new (nothrow) uint32_t[buffer_height * output_rect.width];
 	buffer_stride = output_rect.width;
 
 	if (radius > 0)
@@ -621,7 +621,7 @@ bool MCBitmapEffectBoxBlur::Initialize(const MCBitmapEffectBlurParameters& param
 	if (t_radius == 0)
 		m_passes = 0;
 
-	pass_info = new MCBitmapEffectBoxBlurPassInfo[m_passes];
+	pass_info = new (nothrow) MCBitmapEffectBoxBlurPassInfo[m_passes];
 
 	int32_t t_maxwidth = 0;
 	for (uint32_t i=0; i<m_passes; i++)
@@ -648,7 +648,7 @@ bool MCBitmapEffectBoxBlur::Initialize(const MCBitmapEffectBlurParameters& param
 		t_pass->stride = t_pass->width + 1;
 		t_pass->height = t_pass->bottom - t_pass->top;
 		t_pass->buffer_height = t_pass->height + 1;
-		t_pass->buffer = new uint32_t[(t_pass->stride) * t_pass->buffer_height];
+		t_pass->buffer = new (nothrow) uint32_t[(t_pass->stride) * t_pass->buffer_height];
 		memset(pass_info[i].buffer, 0, (t_pass->stride) * t_pass->buffer_height * sizeof(uint32_t));
 
 		t_pass->buffer_nextrow = t_pass->top;
@@ -667,7 +667,7 @@ bool MCBitmapEffectBoxBlur::Initialize(const MCBitmapEffectBlurParameters& param
 		t_buff_bottom -= t_pass->radius;
 	}
 
-	row_buffer = new uint32_t[t_maxwidth];
+	row_buffer = new (nothrow) uint32_t[t_maxwidth];
 
 	if (m_passes > 0)
 		pixels = src_pixels + stride * pass_info[0].top;
@@ -911,19 +911,19 @@ static bool MCBitmapEffectBlurFactory(MCBitmapEffectFilter p_type, MCBitmapEffec
 	switch(p_type)
 	{
 	case kMCBitmapEffectFilterFastGaussian:
-		r_blur = new MCBitmapEffectFastGaussianBlur;
+		r_blur = new (nothrow) MCBitmapEffectFastGaussianBlur;
 		return true;
 
 	case kMCBitmapEffectFilterOnePassBox:
-		r_blur = new MCBitmapEffectBoxBlur(1);
+		r_blur = new (nothrow) MCBitmapEffectBoxBlur(1);
 		return true;
 
 	case kMCBitmapEffectFilterTwoPassBox:
-		r_blur = new MCBitmapEffectBoxBlur(2);
+		r_blur = new (nothrow) MCBitmapEffectBoxBlur(2);
 		return true;
 
 	case kMCBitmapEffectFilterThreePassBox:
-		r_blur = new MCBitmapEffectBoxBlur(3);
+		r_blur = new (nothrow) MCBitmapEffectBoxBlur(3);
 		return true;
 
 	default:

--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -82,15 +82,15 @@ MCBlock::MCBlock(const MCBlock &bref) : MCDLlist(bref)
 	flags = bref.flags;
 	if (flags & F_HAS_ATTS)
 	{
-		atts = new Blockatts;
+		atts = new (nothrow) Blockatts;
 		if (flags & F_HAS_COLOR)
 		{
-			atts->color = new MCColor;
+			atts->color = new (nothrow) MCColor;
 			*atts->color = *bref.atts->color;
 		}
 		if (flags & F_HAS_BACK_COLOR)
 		{
-			atts->backcolor = new MCColor;
+			atts->backcolor = new (nothrow) MCColor;
 			*atts->backcolor = *bref.atts->backcolor;
 		}
 
@@ -193,7 +193,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	flags &= ~F_FLAGGED;
 
 	if (atts == NULL)
-		atts = new Blockatts;
+		atts = new (nothrow) Blockatts;
 
 	// MW-2012-02-17: [[ SplitTextAttrs ]] If the font flag is present, it means there
 	//   is a font record to read.
@@ -239,7 +239,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
     }
 	if (flags & F_HAS_COLOR)
 	{
-		atts->color = new MCColor;
+		atts->color = new (nothrow) MCColor;
 		if ((stat = IO_read_mccolor(*atts->color, stream)) != IO_NORMAL)
 			return checkloadstat(stat);
 		if (flags & F_HAS_COLOR_NAME)
@@ -257,7 +257,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 	}
 	if (flags & F_HAS_BACK_COLOR)
 	{
-		atts->backcolor = new MCColor;
+		atts->backcolor = new (nothrow) MCColor;
 		if ((stat = IO_read_mccolor(*atts->backcolor, stream)) != IO_NORMAL)
 			return checkloadstat(stat);
 		if (version < kMCStackFileFormatVersion_2_0 || flags & F_HAS_BACK_COLOR_NAME)
@@ -896,7 +896,7 @@ bool MCBlock::fit(coord_t x, coord_t maxwidth, findex_t& r_break_index, bool& r_
 
 void MCBlock::split(findex_t p_index)
 {
-	MCBlock *bptr = new MCBlock(*this);
+	MCBlock *bptr = new (nothrow) MCBlock(*this);
 	findex_t newlength = m_size - (p_index - m_index);
 	bptr->SetRange(p_index, newlength);
 	m_size -= newlength;
@@ -1580,7 +1580,7 @@ void MCBlock::setshift(int2 in)
 	else
 	{
 		if (atts == NULL)
-			atts = new Blockatts;
+			atts = new (nothrow) Blockatts;
 		atts->shift = in;
 		flags |= F_HAS_SHIFT;
 	}
@@ -1615,9 +1615,9 @@ void MCBlock::setcolor(const MCColor *newcolor)
 	else
 	{
 		if (atts == NULL)
-			atts = new Blockatts;
+			atts = new (nothrow) Blockatts;
 		if (!(flags & F_HAS_COLOR))
-			atts->color = new MCColor;
+			atts->color = new (nothrow) MCColor;
 		*atts->color = *newcolor;
 		flags |= F_HAS_COLOR;
 	}
@@ -1636,9 +1636,9 @@ void MCBlock::setbackcolor(const MCColor *newcolor)
 	else
 	{
 		if (atts == NULL)
-			atts = new Blockatts;
+			atts = new (nothrow) Blockatts;
 		if (!(flags & F_HAS_BACK_COLOR))
-			atts->backcolor = new MCColor;
+			atts->backcolor = new (nothrow) MCColor;
 		*atts->backcolor = *newcolor;
 		flags |= F_HAS_BACK_COLOR;
 	}

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -336,7 +336,7 @@ MCButton::MCButton(const MCButton &bref) : MCControl(bref)
 {
 	if (bref.icons != NULL)
 	{
-		icons = new iconlist;
+		icons = new (nothrow) iconlist;
 		memcpy(icons, bref.icons, sizeof(iconlist));
 		icons->curicon = NULL;
 	}
@@ -367,7 +367,7 @@ MCButton::MCButton(const MCButton &bref) : MCControl(bref)
 		MCCdata *bptr = bref.bdata;
 		do
 		{
-			MCCdata *newbdata = new MCCdata(*bptr);
+			MCCdata *newbdata = new (nothrow) MCCdata(*bptr);
 			newbdata->appendto(bdata);
 			bptr = (MCCdata *)bptr->next();
 		}
@@ -1774,7 +1774,7 @@ void MCButton::closemenu(Boolean kfocus, Boolean disarm)
 
 MCControl *MCButton::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCButton *newbutton = new MCButton(*this);
+	MCButton *newbutton = new (nothrow) MCButton(*this);
 	if (attach)
 		newbutton->attach(p, invisible);
 	return newbutton;
@@ -2066,7 +2066,7 @@ MCCdata *MCButton::getbptr(uint4 cardid)
 	}
 	if (foundptr == NULL)
 	{
-		foundptr = new MCCdata(cardid);
+		foundptr = new (nothrow) MCCdata(cardid);
 		foundptr->appendto(bdata);
 	}
 	return foundptr;
@@ -2440,7 +2440,7 @@ public:
 		}
 		while (newdepth < stackdepth)
 			parent->makemenu(bstack, stackdepth, menuflags, fontref);
-		MCButton *newbutton = new MCButton;
+		MCButton *newbutton = new (nothrow) MCButton;
 		newbutton->appendto(bstack[stackdepth].buttons);
 		MCNameRef t_name = nil;
 		if (!MCStringIsEmpty(p_menuitem->tag))
@@ -2608,7 +2608,7 @@ Boolean MCButton::findmenu(bool p_just_for_accel)
 				//major menustring
 				nlines = MCStringCountChar(menustring, MCRangeMake(0, MCStringGetLength(menustring)), '\n', kMCStringOptionCompareExact) + 1;
 
-				MCField *fptr = new MCField;
+				MCField *fptr = new (nothrow) MCField;
 				uint2 height;
 				if (nlines > menulines)
 				{
@@ -2920,7 +2920,7 @@ void MCButton::docascade(MCStringRef p_pick)
 		//    menu button, rather than of this one.
 		if (pptr->m_menu_handler == nil || !pptr->m_menu_handler->OnMenuPick(pptr, *t_pick, nil))
 		{
-			MCParameter *param = new MCParameter;
+			MCParameter *param = new (nothrow) MCParameter;
 			param->setvalueref_argument(*t_pick);
 			MCscreen->addmessage(pptr, MCM_menu_pick, MCS_time(), param);
 		}
@@ -3403,7 +3403,7 @@ static void openicon(MCImage *&icon, uint1 *data, uint4 size)
 	// MW-2012-02-17: [[ FontRefs ]] Make sure we set a parent on the icon, and also
 	//   make it invisible. If we don't do this we get issues with parent references
 	//   and fontrefs.
-	icon = new MCImage;
+	icon = new (nothrow) MCImage;
 	icon->setparent(MCdispatcher);
 	icon->setflag(False, F_VISIBLE);
 	icon->setflag(True, F_I_ALWAYS_BUFFER);
@@ -3515,7 +3515,7 @@ IO_stat MCButton::extendedload(MCObjectInputStream& p_stream, uint32_t p_version
 		t_stat = checkloadstat(p_stream . ReadU32(t_hover_icon_id));
 		if (t_stat == IO_NORMAL)
 		{
-			icons = new iconlist;
+			icons = new (nothrow) iconlist;
 			memset(icons, 0, sizeof(iconlist));
 			icons -> iconids[CI_HOVER] = t_hover_icon_id;
 		}
@@ -3715,7 +3715,7 @@ IO_stat MCButton::load(IO_handle stream, uint32_t version)
 		if (iconid != 0 || hiliteiconid != 0)
 		{
 			flags |= F_HAS_ICONS;
-			icons = new iconlist;
+			icons = new (nothrow) iconlist;
 			memset(icons, 0, sizeof(iconlist));
 			icons->iconids[CI_DEFAULT] = iconid;
 			icons->iconids[CI_HILITED] = hiliteiconid;
@@ -3731,7 +3731,7 @@ IO_stat MCButton::load(IO_handle stream, uint32_t version)
 			//   area.
 			if (icons == NULL)
 			{
-				icons = new iconlist;
+				icons = new (nothrow) iconlist;
 				memset(icons, 0, sizeof(iconlist));
 			}
 
@@ -3873,7 +3873,7 @@ IO_stat MCButton::load(IO_handle stream, uint32_t version)
 			return checkloadstat(stat);
 		if (type == OT_BDATA)
 		{
-			MCCdata *newbdata = new MCCdata;
+			MCCdata *newbdata = new (nothrow) MCCdata;
 			if ((stat = newbdata->load(stream, this, version)) != IO_NORMAL)
 			{
 				delete newbdata;

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -179,7 +179,7 @@ MCCard::MCCard(const MCCard &cref) : MCObject(cref)
 		MCObjptr *tptr = cref.objptrs;
 		do
 		{
-			MCObjptr *newoptr = new MCObjptr;
+			MCObjptr *newoptr = new (nothrow) MCObjptr;
 			newoptr->setparent(this);
 			newoptr->setid(tptr->getid());
 			newoptr->appendto(objptrs);
@@ -827,22 +827,22 @@ Boolean MCCard::mdown(uint2 which)
 			case T_HELP:
 				break;
 			case T_BUTTON:
-				cptr = new MCButton(*MCtemplatebutton);
+				cptr = new (nothrow) MCButton(*MCtemplatebutton);
 				break;
 			case T_SCROLLBAR:
-				cptr = new MCScrollbar(*MCtemplatescrollbar);
+				cptr = new (nothrow) MCScrollbar(*MCtemplatescrollbar);
 				break;
 			case T_PLAYER:
-				cptr = new MCPlayer(*MCtemplateplayer);
+				cptr = new (nothrow) MCPlayer(*MCtemplateplayer);
 				break;
 			case T_GRAPHIC:
-				cptr = new MCGraphic(*MCtemplategraphic);
+				cptr = new (nothrow) MCGraphic(*MCtemplategraphic);
 				break;
 			case T_FIELD:
-				cptr = new MCField(*MCtemplatefield);
+				cptr = new (nothrow) MCField(*MCtemplatefield);
 				break;
 			case T_IMAGE:
-				cptr = new MCImage(*MCtemplateimage);
+				cptr = new (nothrow) MCImage(*MCtemplateimage);
 				break;
 			case T_DROPPER:
 				// IM-2013-09-23: [[ FullscreenMode ]] Get mouse loc in view coordinates
@@ -1414,7 +1414,7 @@ void MCCard::kfocusset(MCControl *target)
 MCCard *MCCard::clone(Boolean attach, Boolean controls)
 {
 	clean();
-	MCCard *newcptr = new MCCard(*this);
+	MCCard *newcptr = new (nothrow) MCCard(*this);
 	newcptr->parent = MCdefaultstackptr;
 	Boolean diffstack = getstack() != MCdefaultstackptr;
 
@@ -1499,7 +1499,7 @@ MCCard *MCCard::clone(Boolean attach, Boolean controls)
 				//   place it on the new card.
 				if (optr->getref()->gettype() == CT_GROUP && static_cast<MCGroup *>(optr -> getref()) -> isbackground())
 				{
-					MCObjptr *newoptr = new MCObjptr;
+					MCObjptr *newoptr = new (nothrow) MCObjptr;
 					newoptr->setparent(newcptr);
 					newoptr->setid(optr->getid());
 					newoptr->appendto(newcptr->objptrs);
@@ -1523,7 +1523,7 @@ void MCCard::clonedata(MCCard *source)
 		MCCdata *cptr = source->savedata;
 		do
 		{
-			MCCdata *dptr = new MCCdata(*cptr);
+			MCCdata *dptr = new (nothrow) MCCdata(*cptr);
 			dptr->appendto(savedata);
 			cptr = cptr->next();
 		}
@@ -1655,7 +1655,7 @@ void MCCard::relayercontrol_insert(MCControl *p_control, MCControl *p_target)
 {	
 	// Add the control to the card's objptr list.
 	MCObjptr *t_control_ptr;
-	t_control_ptr = new MCObjptr;
+	t_control_ptr = new (nothrow) MCObjptr;
 	t_control_ptr -> setparent(this);
 	t_control_ptr -> setref(p_control);
 	p_control -> setparent(this);
@@ -1742,7 +1742,7 @@ Exec_stat MCCard::relayer(MCControl *optr, uint2 newlayer)
 	}
 	else
 	{
-		MCObjptr *newptr = new MCObjptr;
+		MCObjptr *newptr = new (nothrow) MCObjptr;
 		newptr->setparent(this);
 		newptr->setref(optr);
 		optr->setparent(this);
@@ -2465,7 +2465,7 @@ void MCCard::resize(uint2 width, uint2 height)
 MCImage *MCCard::createimage()
 {
 	MCtemplateimage->setrect(rect);
-	MCImage *iptr = new MCImage(*MCtemplateimage);
+	MCImage *iptr = new (nothrow) MCImage(*MCtemplateimage);
 	getstack()->appendcontrol(iptr);
 	mfocused = newcontrol(iptr, False);
 	return iptr;
@@ -2555,7 +2555,7 @@ MCObjptr *MCCard::newcontrol(MCControl *cptr, Boolean needredraw)
 	if (opened)
 		cptr->setparent(this);
 
-	MCObjptr *newptr = new MCObjptr;
+	MCObjptr *newptr = new (nothrow) MCObjptr;
 	newptr->setparent(this);
 	newptr->setref(cptr);
 	newptr->appendto(objptrs);
@@ -3157,7 +3157,7 @@ IO_stat MCCard::load(IO_handle stream, uint32_t version)
 			return checkloadstat(stat);
 		if (type == OT_PTR)
 		{
-			MCObjptr *newptr = new MCObjptr;
+			MCObjptr *newptr = new (nothrow) MCObjptr;
 			if ((stat = newptr->load(stream)) != IO_NORMAL)
 			{
 				delete newptr;
@@ -3193,37 +3193,37 @@ IO_stat MCCard::loadobjects(IO_handle stream, uint32_t version)
 			switch(t_object_type)
 			{
 			case OT_GROUP:
-				t_control = new MCGroup;
+				t_control = new (nothrow) MCGroup;
 			break;
 			case OT_BUTTON:
-				t_control = new MCButton;
+				t_control = new (nothrow) MCButton;
 			break;
 			case OT_FIELD:
-				t_control = new MCField;
+				t_control = new (nothrow) MCField;
 			break;
 			case OT_IMAGE:
-				t_control = new MCImage;
+				t_control = new (nothrow) MCImage;
 			break;
 			case OT_SCROLLBAR:
-				t_control = new MCScrollbar;
+				t_control = new (nothrow) MCScrollbar;
 			break;
 			case OT_GRAPHIC:
-				t_control = new MCGraphic;
+				t_control = new (nothrow) MCGraphic;
 			break;
 			case OT_PLAYER:
-				t_control = new MCPlayer;
+				t_control = new (nothrow) MCPlayer;
 			break;
 			case OT_MCEPS:
-				t_control = new MCEPS;
+				t_control = new (nothrow) MCEPS;
 			break;
             case OT_WIDGET:
-                t_control = new MCWidget;
+                t_control = new (nothrow) MCWidget;
                 break;
 			case OT_MAGNIFY:
-				t_control = new MCMagnify;
+				t_control = new (nothrow) MCMagnify;
 			break;
 			case OT_COLORS:
-				t_control = new MCColors;
+				t_control = new (nothrow) MCColors;
 			break;
 			default:
 				return checkloadstat(IO_ERROR);

--- a/engine/src/cardlst.cpp
+++ b/engine/src/cardlst.cpp
@@ -109,7 +109,7 @@ void MCCardlist::addcard(MCCard *card)
 {
 	if ((cards != NULL && cards->card == card) || MClockrecent)
 		return;
-	MCCardnode *nptr = new MCCardnode;
+	MCCardnode *nptr = new (nothrow) MCCardnode;
 	nptr->card = card;
 	if (cards == NULL)
 		first = nptr;
@@ -246,7 +246,7 @@ void MCCardlist::pushcard(MCCard *card)
 {
 	if (card == NULL)
 		return;
-	MCCardnode *nptr = new MCCardnode;
+	MCCardnode *nptr = new (nothrow) MCCardnode;
 	nptr->card = card;
 	nptr->insertto(cards);
 }

--- a/engine/src/cdata.cpp
+++ b/engine/src/cdata.cpp
@@ -46,7 +46,7 @@ MCCdata::MCCdata(const MCCdata &cref) : MCDLlist(cref)
 			MCParagraph *tptr = (MCParagraph *)cref.data;
 			do
 			{
-				MCParagraph *newparagraph = new MCParagraph(*tptr);
+				MCParagraph *newparagraph = new (nothrow) MCParagraph(*tptr);
 				newparagraph->appendto(paragraphs);
 				tptr = (MCParagraph *)tptr->next();
 			}
@@ -122,7 +122,7 @@ IO_stat MCCdata::load(IO_handle stream, MCObject *parent, uint32_t version)
 				case OT_PARAGRAPH:
 				case OT_PARAGRAPH_EXT:
 					{
-						MCParagraph *newpar = new MCParagraph;
+						MCParagraph *newpar = new (nothrow) MCParagraph;
 						newpar->setparent((MCField *)parent);
 						
 						// MW-2012-03-04: [[ StackFile5500 ]] If the paragraph tab was the extended
@@ -205,10 +205,10 @@ MCParagraph *MCCdata::getparagraphs()
 		char *eptr = (char *)data;
 		while ((eptr = strtok(eptr, "\n")) != NULL)
 		{
-			MCParagraph *tpgptr = new MCParagraph;
+			MCParagraph *tpgptr = new (nothrow) MCParagraph;
 			tpgptr->appendto(paragraphs);
 			uint2 l = strlen(eptr) + 1;
-			char *sptr = new char[l];
+			char *sptr = new (nothrow) char[l];
 			memcpy(sptr, eptr, l);
 			MCAutoStringRef t_string;
 			/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t*)sptr, l, &t_string);
@@ -220,7 +220,7 @@ MCParagraph *MCCdata::getparagraphs()
 		id &= ~COMPACT_PARAGRAPHS;
 	}
 	if (data == NULL)
-		data = paragraphs = new MCParagraph;
+		data = paragraphs = new (nothrow) MCParagraph;
 	else
 		paragraphs = (MCParagraph *)data;
 	return paragraphs;

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -359,7 +359,7 @@ Parse_stat MCChunk::parse(MCScriptPoint &sp, Boolean doingthe)
 						MCperror->add(PE_CHUNK_BADORDER, sp);
 						return PS_ERROR;
 					}
-					curref = new MCCRef;
+					curref = new (nothrow) MCCRef;
 					curref->otype = nterm;
 					if (curref->otype == CT_BACKGROUND || curref->otype == CT_CARD)
 					{
@@ -571,7 +571,7 @@ Parse_stat MCChunk::parse(MCScriptPoint &sp, Boolean doingthe)
 						MCperror -> add(PE_PROPERTY_NOTOF, sp);
 						return PS_ERROR;
 					}
-					source = new MCChunk(False);
+					source = new (nothrow) MCChunk(False);
 					if (static_cast<MCChunk *>(source) -> parse(sp, False) != PS_NORMAL)
 					{
 						MCperror->add(PE_PROPERTY_BADCHUNK, sp);
@@ -847,7 +847,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
 
                 // SN-2014-04-08 [[ Bug 12147 ]] create button in group command fails 
                 MCScriptPoint sp(ctxt, *t_value);
-                MCChunk *tchunk = new MCChunk(False);
+                MCChunk *tchunk = new (nothrow) MCChunk(False);
                 MCerrorlock++;
                 Symbol_type type;
                 if (tchunk->parse(sp, False) == PS_NORMAL

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -1368,7 +1368,7 @@ MCClipboard* MCClipboard::CreateSystemSelectionClipboard()
 MCClipboard* MCClipboard::CreateSystemDragboard()
 {
     // Drag boards are created in a locked state
-    MCClipboard* t_dragboard = new MCClipboard(MCRawClipboard::CreateSystemDragboard());
+    MCClipboard* t_dragboard = new (nothrow) MCClipboard(MCRawClipboard::CreateSystemDragboard());
     t_dragboard->Lock(true);
     t_dragboard->Clear();
     return t_dragboard;

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -141,7 +141,7 @@ Parse_stat MCConvert::parse(MCScriptPoint &sp)
 {
 	initpoint(sp);
 	MCerrorlock++;
-	container = new MCChunk(True);
+	container = new (nothrow) MCChunk(True);
 	MCScriptPoint tsp(sp);
 	if (container->parse(sp, False) != PS_NORMAL)
 	{
@@ -342,7 +342,7 @@ Parse_stat MCDo::parse(MCScriptPoint &sp)
 			caller = true;
 		else
 		{
-			widget = new MCChunk(False);
+			widget = new (nothrow) MCChunk(False);
 			if (widget->parse(sp, False) != PS_NORMAL)
 			{
 				MCperror->add(PE_DO_BADENV, sp);
@@ -505,7 +505,7 @@ Parse_stat MCEdit::parse(MCScriptPoint &sp)
 		MCperror->add(PE_EDIT_NOOF, sp);
 		return PS_ERROR;
 	}
-	target = new MCChunk(False);
+	target = new (nothrow) MCChunk(False);
 	if (target->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add(PE_EDIT_NOTARGET, sp);
@@ -583,7 +583,7 @@ Parse_stat MCFind::parse(MCScriptPoint &sp)
 	}
 	if (sp.skip_token(SP_FACTOR, TT_IN) == PS_NORMAL)
 	{
-		field = new MCChunk(False);
+		field = new (nothrow) MCChunk(False);
 		if (field->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -681,7 +681,7 @@ Parse_stat MCMarking::parse(MCScriptPoint &sp)
 	if (sp.lookup(SP_MARK, te) != PS_NORMAL)
 	{
 		sp.backup();
-		card = new MCChunk(False);
+		card = new (nothrow) MCChunk(False);
 		if (card->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -753,7 +753,7 @@ if (sp.next(type) != PS_NORMAL)
 	}
 	if (sp.skip_token(SP_FACTOR, TT_IN) == PS_NORMAL)
 	{
-		field = new MCChunk(False);
+		field = new (nothrow) MCChunk(False);
 		if (field->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -975,7 +975,7 @@ Parse_stat MCPut::parse(MCScriptPoint &sp)
 		sp.skip_token(SP_SHOW, TT_UNDEFINED, SO_MESSAGE); // "box"
 		return PS_NORMAL;
 	}
-	dest = new MCChunk(True);
+	dest = new (nothrow) MCChunk(True);
 	if (dest->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add(PE_PUT_BADCHUNK, sp);
@@ -1415,7 +1415,7 @@ Parse_stat MCSet::parse(MCScriptPoint &sp)
 		MCperror->add(PE_SET_NOTHE, sp);
 		return PS_ERROR;
 	}
-	target = new MCProperty;
+	target = new (nothrow) MCProperty;
 	if (target->parse(sp, True) != PS_NORMAL)
 	{
 		MCperror->add(PE_SET_NOPROP, sp);
@@ -1480,7 +1480,7 @@ Parse_stat MCSort::parse(MCScriptPoint &sp)
 			switch (te->which)
 			{
 			case ST_OF:
-				of = new MCChunk(True);
+				of = new (nothrow) MCChunk(True);
 				if (of->parse(sp, False) != PS_NORMAL)
 				{
 					MCperror->add
@@ -1535,7 +1535,7 @@ Parse_stat MCSort::parse(MCScriptPoint &sp)
 			sp.backup();
 			if (of == NULL)
 			{
-				of = new MCChunk(True);
+				of = new (nothrow) MCChunk(True);
 				if (of->parse(sp, False) != PS_NORMAL)
 				{
 					MCperror->add
@@ -1887,7 +1887,7 @@ Parse_stat MCResolveImage::parse(MCScriptPoint &p_sp)
     // Parse the target object clause
     if (t_stat == PS_NORMAL)
     {
-        m_relative_object = new MCChunk(false);
+        m_relative_object = new (nothrow) MCChunk(false);
         t_stat = m_relative_object -> parse(p_sp, False);
     }
     else

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -74,7 +74,7 @@ Parse_stat MCClone::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_INVISIBLE) == PS_NORMAL)
 		visible = False;
 
-	source = new MCChunk(False);
+	source = new (nothrow) MCChunk(False);
 	if (source->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -155,7 +155,7 @@ Parse_stat MCClipboardCmd::parse(MCScriptPoint& sp)
 	MCerrorlock--;
 	if (sp.skip_token(SP_FACTOR, TT_TO, PT_TO) == PS_NORMAL)
 	{
-		dest = new MCChunk(False);
+		dest = new (nothrow) MCChunk(False);
 		if (dest->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_COPY_BADDEST, sp);
@@ -542,7 +542,7 @@ Parse_stat MCCreate::parse(MCScriptPoint &sp)
         {
             if (!script_only_stack)
             {
-                container = new MCChunk(False);
+                container = new (nothrow) MCChunk(False);
                 if (container->parse(sp, False) != PS_NORMAL)
                 {
                     MCperror->add
@@ -755,7 +755,7 @@ Parse_stat MCCustomProp::parse(MCScriptPoint &sp)
 		return PS_ERROR;
 	}
 	sp.skip_token(SP_FACTOR, TT_OF);
-	target = new MCChunk(False);
+	target = new (nothrow) MCChunk(False);
 	if (target->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -1216,7 +1216,7 @@ Parse_stat MCFlip::parse(MCScriptPoint &sp)
 	// PM-2015-08-07: [[ Bug 1751 ]] Allow more flexible parsing: 'flip the selobj ..', 'flip last img..' etc
 	
 	// Parse an arbitrary chunk. If it does not resolve as an image, a runtime error will occur in MCFlip::exec
-	image = new MCChunk(False);
+	image = new (nothrow) MCChunk(False);
 	if (image->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add(PE_FLIP_BADIMAGE, sp);
@@ -1381,7 +1381,7 @@ Parse_stat MCLaunch::parse(MCScriptPoint &sp)
 
 	if (t_is_url && sp.skip_token(SP_FACTOR, TT_IN) == PS_NORMAL)
 	{
-		widget = new MCChunk(False);
+		widget = new (nothrow) MCChunk(False);
 		if (widget->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_LAUNCH_BADWIDGETEXP, sp);
@@ -1811,7 +1811,7 @@ MCPlace::~MCPlace()
 Parse_stat MCPlace::parse(MCScriptPoint &sp)
 {
 	initpoint(sp);
-	group = new MCChunk(False);
+	group = new (nothrow) MCChunk(False);
 	if (group->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -1820,7 +1820,7 @@ Parse_stat MCPlace::parse(MCScriptPoint &sp)
 	}
 	while (sp.skip_token(SP_FACTOR, TT_PREP) == PS_NORMAL)
 		;
-	card = new MCChunk(False);
+	card = new (nothrow) MCChunk(False);
 	if (card->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -1954,7 +1954,7 @@ Parse_stat MCRemove::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_SCRIPT) == PS_NORMAL)
 	{
 		sp.skip_token(SP_FACTOR, TT_OF);
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -1993,7 +1993,7 @@ Parse_stat MCRemove::parse(MCScriptPoint &sp)
 		return PS_NORMAL;
 	}
 
-	target = new MCChunk(False);
+	target = new (nothrow) MCChunk(False);
 	if (target->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -2002,7 +2002,7 @@ Parse_stat MCRemove::parse(MCScriptPoint &sp)
 	}
 	while (sp.skip_token(SP_FACTOR, TT_FROM) == PS_NORMAL)
 		;
-	card = new MCChunk(False);
+	card = new (nothrow) MCChunk(False);
 	if (card->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -2162,7 +2162,7 @@ Parse_stat MCReplace::parse(MCScriptPoint &sp)
 		return PS_ERROR;
 	}
 	sp.skip_token(SP_FACTOR, TT_IN, PT_IN);
-	container = new MCChunk(True);
+	container = new (nothrow) MCChunk(True);
 	if (container->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add(PE_REPLACE_BADCONTAINER, sp);
@@ -2280,7 +2280,7 @@ Parse_stat MCRevert::parse(MCScriptPoint &sp)
     
     // Otherwise backup and parse a chunk
     sp.backup();
-    stack = new MCChunk(False);
+    stack = new (nothrow) MCChunk(False);
     if (stack->parse(sp, False) != PS_NORMAL)
     {
         MCperror->add(PE_REVERT_BADSTACK, sp);
@@ -2338,7 +2338,7 @@ Parse_stat MCRotate::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_FACTOR, TT_CHUNK, CT_IMAGE) == PS_NORMAL)
 	{
 		sp.backup();
-		image = new MCChunk(False);
+		image = new (nothrow) MCChunk(False);
 		if (image->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -2421,7 +2421,7 @@ Parse_stat MCCrop::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_FACTOR, TT_CHUNK, CT_IMAGE) == PS_NORMAL)
 	{
 		sp.backup();
-		image = new MCChunk(False);
+		image = new (nothrow) MCChunk(False);
 		if (image->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -2679,7 +2679,7 @@ Parse_stat MCUngroup::parse(MCScriptPoint &sp)
 	initpoint(sp);
 	MCScriptPoint oldsp(sp);
 	MCerrorlock++;
-	group = new MCChunk(False);
+	group = new (nothrow) MCChunk(False);
 	if (group->parse(sp, False) != PS_NORMAL)
 	{
 		delete group;
@@ -2751,7 +2751,7 @@ Parse_stat MCRelayer::parse(MCScriptPoint& sp)
 {
 	initpoint(sp);
 
-	control = new MCChunk(False);
+	control = new (nothrow) MCChunk(False);
 	if (control -> parse(sp, False) != PS_NORMAL)
 	{
 		MCperror -> add(PE_RELAYER_BADCONTROL, sp);
@@ -2799,7 +2799,7 @@ Parse_stat MCRelayer::parse(MCScriptPoint& sp)
 	else
 	{
 		form = kMCRelayerFormRelativeToControl;
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target -> parse(sp, False) != PS_NORMAL)
 		{
 			MCperror -> add(PE_RELAYER_BADTARGET, sp);

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -407,7 +407,7 @@ Parse_stat MCFocus::parse(MCScriptPoint &sp)
 		object = NULL;
 	else
 	{
-		object = new MCChunk(False);
+		object = new (nothrow) MCChunk(False);
 		if (object->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_FOCUS_BADOBJECT, sp);
@@ -471,7 +471,7 @@ Parse_stat MCInsert::parse(MCScriptPoint &sp)
 		MCperror->add(PE_INSERT_NOSCRIPT, sp);
 		return PS_ERROR;
 	}
-	target = new MCChunk(False);
+	target = new (nothrow) MCChunk(False);
 	if (target->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add(PE_INSERT_BADOBJECT, sp);
@@ -554,7 +554,7 @@ Parse_stat MCDispatchCmd::parse(MCScriptPoint& sp)
 	// MW-2008-12-04: Added 'to <target>' form to the syntax
 	if (sp.skip_token(SP_FACTOR, TT_TO) == PS_NORMAL)
 	{
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target -> parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_DISPATCH_BADTARGET, sp);
@@ -687,7 +687,7 @@ Parse_stat MCMessage::parse(MCScriptPoint &sp)
 	}
 	else
 	{
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_SEND_BADTARGET, sp);
@@ -815,7 +815,7 @@ MCMove::~MCMove()
 Parse_stat MCMove::parse(MCScriptPoint &sp)
 {
 	initpoint(sp);
-	object = new MCChunk(False);
+	object = new (nothrow) MCChunk(False);
 	if (object->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add(PE_MOVE_BADOBJECT, sp);
@@ -972,7 +972,7 @@ Parse_stat MCMM::parse(MCScriptPoint &sp)
 		}
 		
 		sp.backup();
-		stack = new MCChunk(False);
+		stack = new (nothrow) MCChunk(False);
 		if (stack->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_PLAY_BADSTACK, sp);
@@ -1040,7 +1040,7 @@ Parse_stat MCMM::parse(MCScriptPoint &sp)
 	MCerrorlock--;
 	if (sp.skip_token(SP_FACTOR, TT_OF) == PS_NORMAL)
 	{
-		stack = new MCChunk(False);
+		stack = new (nothrow) MCChunk(False);
 		if (stack->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_PLAY_BADSTACK, sp);
@@ -1538,7 +1538,7 @@ Parse_stat MCStart::parse(MCScriptPoint &sp)
 		        || sp.skip_token(SP_FACTOR, TT_CHUNK, CT_THIS) == PS_NORMAL)
 		{
 			sp.backup();
-			target = new MCChunk(False);
+			target = new (nothrow) MCChunk(False);
 			if (target->parse(sp, False) != PS_NORMAL)
 			{
 				MCperror->add(PE_START_BADCHUNK, sp);
@@ -1579,7 +1579,7 @@ Parse_stat MCStart::parse(MCScriptPoint &sp)
 	{
 		if (mode == SC_PLAYER)
 			sp.backup();
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_START_BADCHUNK, sp);
@@ -1741,7 +1741,7 @@ Parse_stat MCStop::parse(MCScriptPoint &sp)
 		        || sp.skip_token(SP_FACTOR, TT_CHUNK, CT_THIS) == PS_NORMAL)
 		{
 			sp.backup();
-			target = new MCChunk(False);
+			target = new (nothrow) MCChunk(False);
 			if (target->parse(sp, False) != PS_NORMAL)
 			{
 				MCperror->add(PE_START_BADCHUNK, sp);
@@ -1774,7 +1774,7 @@ Parse_stat MCStop::parse(MCScriptPoint &sp)
 	{
 		if (mode == SC_PLAYER)
 			sp.backup();
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		MCScriptPoint oldsp(sp);
 		MCerrorlock++;
 		if (target->parse(sp, False) != PS_NORMAL)

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -91,7 +91,7 @@ Parse_stat MCClose::parse(MCScriptPoint &sp)
 		else
 		{
 			sp.backup();
-			stack = new MCChunk(False);
+			stack = new (nothrow) MCChunk(False);
 			if (stack->parse(sp, False) != PS_NORMAL)
 			{
 				MCperror->add
@@ -538,7 +538,7 @@ Parse_stat MCExport::parse(MCScriptPoint &sp)
 	else
 	{
 		sp.backup();
-		image = new MCChunk(False);
+		image = new (nothrow) MCChunk(False);
 		if (image->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_EXPORT_BADTYPE, sp);
@@ -590,7 +590,7 @@ Parse_stat MCExport::parse(MCScriptPoint &sp)
 				else if (te == NULL || te -> type != TT_TO)
 				{
 					sp . backup();
-					image = new MCChunk(False);
+					image = new (nothrow) MCChunk(False);
 					if (image -> parse(sp, False) != PS_NORMAL)
 					{
 						MCperror -> add(PE_IMPORT_BADFILENAME, sp);
@@ -658,7 +658,7 @@ Parse_stat MCExport::parse(MCScriptPoint &sp)
     if (!t_is_image &&
         sp.skip_token(SP_VALIDATION, TT_UNDEFINED, IV_ARRAY) == PS_NORMAL)
     {
-        dest = new MCChunk(True);
+        dest = new (nothrow) MCChunk(True);
         if (dest->parse(sp, False) != PS_NORMAL)
         {
             MCperror->add(PE_EXPORT_NOARRAY, sp);
@@ -678,7 +678,7 @@ Parse_stat MCExport::parse(MCScriptPoint &sp)
         }
         else
         {
-            dest = new MCChunk(True);
+            dest = new (nothrow) MCChunk(True);
             if (dest->parse(sp, False) != PS_NORMAL)
             {
                 MCperror->add(PE_EXPORT_NOFILE, sp);
@@ -1126,7 +1126,7 @@ Parse_stat MCFilter::parse(MCScriptPoint &sp)
 	{
 		MCerrorlock++;
 		MCScriptPoint tsp(sp);
-		container = new MCChunk(True);
+		container = new (nothrow) MCChunk(True);
 		if (container->parse(sp, False) != PS_NORMAL)
 		{
 			sp = tsp;
@@ -1178,7 +1178,7 @@ Parse_stat MCFilter::parse(MCScriptPoint &sp)
 	{
 		if (sp.skip_token(SP_FACTOR, TT_PREP, PT_INTO) == PS_NORMAL)
 		{
-			target = new MCChunk(True);
+			target = new (nothrow) MCChunk(True);
 			if (target->parse(sp, False) != PS_NORMAL)
 				t_error = PE_FILTER_BADDEST;
         }
@@ -1435,7 +1435,7 @@ Parse_stat MCImport::parse(MCScriptPoint &sp)
 				else
 				{
 					sp . backup();
-					container = new MCChunk(False);
+					container = new (nothrow) MCChunk(False);
 					if (container -> parse(sp, False) != PS_NORMAL)
 					{
 						MCperror -> add(PE_IMPORT_BADFILENAME, sp);
@@ -1515,7 +1515,7 @@ Parse_stat MCImport::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_FACTOR, TT_IN) == PS_NORMAL
 	        || sp.skip_token(SP_FACTOR, TT_PREP) == PS_NORMAL)
 	{
-		container = new MCChunk(False);
+		container = new (nothrow) MCChunk(False);
 		if (container->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_CREATE_BADBGORCARD, sp);
@@ -1840,7 +1840,7 @@ Parse_stat MCOpen::parse(MCScriptPoint &sp)
 	{
 		sp.backup();
 		MCerrorlock++;
-		go = new MCGo;
+		go = new (nothrow) MCGo;
 		if (go->parse(sp) != PS_NORMAL)
 		{
 			MCerrorlock--;

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -88,7 +88,7 @@ Parse_stat MCAdd::parse(MCScriptPoint &sp)
 	if (sp.next(type) != PS_NORMAL || type != ST_ID || sp.findvar(sp.gettoken_nameref(), &destvar) != PS_NORMAL)
 	{
 		sp.backup();
-		dest = new MCChunk(True);
+		dest = new (nothrow) MCChunk(True);
 		if (dest->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_ADD_BADDEST, sp);
@@ -242,7 +242,7 @@ Parse_stat MCDivide::parse(MCScriptPoint &sp)
 	        || type != ST_ID || sp . findvar(sp.gettoken_nameref(), &destvar) != PS_NORMAL)
 	{
 		sp.backup();
-		dest = new MCChunk(True);
+		dest = new (nothrow) MCChunk(True);
 		if (dest->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_DIVIDE_BADDEST, sp);
@@ -407,7 +407,7 @@ Parse_stat MCMultiply::parse(MCScriptPoint &sp)
 	        || type != ST_ID || sp . findvar(sp.gettoken_nameref(), &destvar) != PS_NORMAL)
 	{
 		sp.backup();
-		dest = new MCChunk(True);
+		dest = new (nothrow) MCChunk(True);
 		if (dest->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -587,7 +587,7 @@ Parse_stat MCSubtract::parse(MCScriptPoint &sp)
 	        || type != ST_ID || sp . findvar(sp.gettoken_nameref(), &destvar) != PS_NORMAL)
 	{
 		sp.backup();
-		dest = new MCChunk(True);
+		dest = new (nothrow) MCChunk(True);
 		if (dest->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add

--- a/engine/src/cmdsp.cpp
+++ b/engine/src/cmdsp.cpp
@@ -231,7 +231,7 @@ Parse_stat MCPrint::parse(MCScriptPoint &sp)
 			{
 				MCScriptPoint oldsp(sp);
 				sp.backup();
-				target = new MCChunk(False);
+				target = new (nothrow) MCChunk(False);
 				MCerrorlock++;
 				if (target->parse(sp, False) != PS_NORMAL)
 				{
@@ -249,7 +249,7 @@ Parse_stat MCPrint::parse(MCScriptPoint &sp)
 	if ((mode != PM_CARD && sp . skip_token(SP_FACTOR, TT_OF) == PS_NORMAL) ||
 		(mode == PM_CARD && !single && target == NULL))
 	{
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_PRINT_BADTARGET, sp);

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -57,7 +57,7 @@ delete target;
 Parse_stat MCCompact::parse(MCScriptPoint &sp)
 {
 	initpoint(sp);
-	target = new MCChunk(False);
+	target = new (nothrow) MCChunk(False);
 	if (target->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -133,7 +133,7 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 			{
 				if (ct_class(oterm) == CT_ORDINAL)
 				{
-					card = new MCCRef;
+					card = new (nothrow) MCCRef;
 					card->otype = CT_CARD;
 					card->etype = oterm;
 					return PS_NORMAL;
@@ -275,7 +275,7 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 						{
 							if (sp.skip_token(SP_FACTOR, TT_IN) == PS_NORMAL)
 							{
-								widget = new MCChunk(False);
+								widget = new (nothrow) MCChunk(False);
 								if (widget->parse(sp, False) != PS_NORMAL)
 								{
 									MCperror->add(PE_GO_BADWIDGETEXP, sp);
@@ -286,7 +286,7 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 								break;
 							}
 
-							card = new MCCRef;
+							card = new (nothrow) MCCRef;
 							card->etype = nterm;
 							MCScriptPoint oldsp(sp);
 							MCerrorlock++;
@@ -301,13 +301,13 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 						break;
 					case CT_START:
 					case CT_FINISH:
-						card = new MCCRef;
+						card = new (nothrow) MCCRef;
 						card->etype = nterm;
 						sp.skip_token(SP_FACTOR, TT_CHUNK, CT_CARD);
 						break;
 					case CT_HOME:
 					case CT_HELP:
-						stack = new MCCRef;
+						stack = new (nothrow) MCCRef;
 						stack->etype = nterm;
 						break;
 					default:
@@ -326,7 +326,7 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 						(PE_GO_BADCHUNKORDER, sp);
 						return PS_ERROR;
 					}
-					curref = new MCCRef;
+					curref = new (nothrow) MCCRef;
 					if (oterm == CT_UNDEFINED)
 					{
 						if (nterm >= CT_FIRST_TEXT_CHUNK || nterm == CT_URL)
@@ -398,7 +398,7 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 						return PS_ERROR;
 					}
 					sp.backup();
-					card = new MCCRef;
+					card = new (nothrow) MCCRef;
 					card->otype = CT_CARD;
 					card->etype = CT_EXPRESSION;
 					if (sp.parseexp(False, True, &card->startpos) != PS_NORMAL)
@@ -424,7 +424,7 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 					return PS_ERROR;
 				}
 				sp.backup();
-				stack = new MCCRef;
+				stack = new (nothrow) MCCRef;
 				stack->otype = CT_STACK;
 				stack->etype = CT_EXPRESSION;
 				if (sp.parseexp(False, True, &stack->startpos) != PS_NORMAL)
@@ -475,7 +475,7 @@ MCStack *MCGo::findstack(MCExecContext &ctxt, MCStringRef p_value, Chunk_term et
 		return sptr;
 
 	MCObject *objptr;
-	MCChunk *tchunk = new MCChunk(False);
+	MCChunk *tchunk = new (nothrow) MCChunk(False);
 	MCerrorlock++;
     // AL-2014-11-10: [[ Bug 13972 ]] Parsing the chunk without passing through the context results
     //  in a parse error for unquoted stack and card names, since there is then no handler in which to
@@ -1018,7 +1018,7 @@ Parse_stat MCHide::parse(MCScriptPoint &sp)
 		(PE_HIDE_BADTARGET, sp);
 		return PS_ERROR;
 	}
-	object = new MCChunk(False);
+	object = new (nothrow) MCChunk(False);
 	if (object->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -1028,7 +1028,7 @@ Parse_stat MCHide::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_REPEAT, TT_UNDEFINED) == PS_NORMAL)
 	{
 		sp.skip_token(SP_COMMAND, TT_STATEMENT, S_VISUAL);
-		effect = new MCVisualEffect;
+		effect = new (nothrow) MCVisualEffect;
 		if (effect->parse(sp) != PS_NORMAL)
 		{
 			MCperror->add
@@ -1298,7 +1298,7 @@ Parse_stat MCPop::parse(MCScriptPoint &sp)
 		(PE_POP_BADPREP, sp);
 		return PS_ERROR;
 	}
-	dest = new MCChunk(True);
+	dest = new (nothrow) MCChunk(True);
 	if (dest->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -1373,7 +1373,7 @@ Parse_stat MCPush::parse(MCScriptPoint &sp)
 			sp . backup();
 		}
 
-		card = new MCChunk(False);
+		card = new (nothrow) MCChunk(False);
 		if (card -> parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_PUSH_BADEXP, sp);
@@ -1440,7 +1440,7 @@ MCSave::~MCSave()
 Parse_stat MCSave::parse(MCScriptPoint &sp)
 {
 	initpoint(sp);
-	target = new MCChunk(False);
+	target = new (nothrow) MCChunk(False);
 	if (target->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -1646,7 +1646,7 @@ Parse_stat MCShow::parse(MCScriptPoint &sp)
 		(PE_SHOW_BADTARGET, sp);
 		return PS_ERROR;
 	}
-	ton = new MCChunk(False);
+	ton = new (nothrow) MCChunk(False);
 	if (ton->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add
@@ -1669,7 +1669,7 @@ Parse_stat MCShow::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_REPEAT, TT_UNDEFINED) == PS_NORMAL)
 	{
 		sp.skip_token(SP_COMMAND, TT_STATEMENT, S_VISUAL);
-		effect = new MCVisualEffect;
+		effect = new (nothrow) MCVisualEffect;
 		if (effect->parse(sp) != PS_NORMAL)
 		{
 			MCperror->add
@@ -1821,7 +1821,7 @@ Parse_stat MCSubwindow::parse(MCScriptPoint &sp)
 	}
 	else
 	{
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -2170,7 +2170,7 @@ Parse_stat MCUnlock::parse(MCScriptPoint &sp)
 		if (sp.skip_token(SP_REPEAT, TT_UNDEFINED) == PS_NORMAL)
 		{
 			sp.skip_token(SP_COMMAND, TT_STATEMENT, S_VISUAL);
-			effect = new MCVisualEffect;
+			effect = new (nothrow) MCVisualEffect;
 			if (effect->parse(sp) != PS_NORMAL)
 			{
 				MCperror->add

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -1260,7 +1260,7 @@ void MCControl::start(Boolean canclone)
 			}
 			else
 			{
-				Ustruct *us = new Ustruct;
+				Ustruct *us = new (nothrow) Ustruct;
 				us->type = UT_SIZE;
 				us->ud.rect = rect;
 				MCundos->freestate();
@@ -1568,7 +1568,7 @@ Exec_stat MCControl::setsbprop(Properties which, bool p_enable,
 		{
 			if (flags & F_HSCROLLBAR)
 			{
-				hsb = new MCScrollbar(*MCtemplatescrollbar);
+				hsb = new (nothrow) MCScrollbar(*MCtemplatescrollbar);
 				hsb->setparent(this);
 				hsb->setflag(False, F_TRAVERSAL_ON);
 				hsb->setflag(flags & F_3D, F_3D);
@@ -1614,7 +1614,7 @@ Exec_stat MCControl::setsbprop(Properties which, bool p_enable,
 		{
 			if (flags & F_VSCROLLBAR)
 			{
-				vsb = new MCScrollbar(*MCtemplatescrollbar);
+				vsb = new (nothrow) MCScrollbar(*MCtemplatescrollbar);
 				vsb->setparent(this);
 				vsb->setflag(False, F_TRAVERSAL_ON);
 				vsb->setflag(flags & F_3D, F_3D);

--- a/engine/src/cpalette.cpp
+++ b/engine/src/cpalette.cpp
@@ -185,7 +185,7 @@ Boolean MCColors::count(Chunk_term type, MCObject *stop, uint2 &num)
 
 MCControl *MCColors::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCColors *newcolors = new MCColors(*this);
+	MCColors *newcolors = new (nothrow) MCColors(*this);
 	if (attach)
 		newcolors->attach(p, invisible);
 	return newcolors;

--- a/engine/src/customprinter.cpp
+++ b/engine/src/customprinter.cpp
@@ -774,10 +774,10 @@ void MCCustomMetaContext::dopathmark(MCMark *p_mark, MCPath *p_path)
 void MCCustomMetaContext::dorawpathmark(MCMark *p_mark, uint1 *p_commands, uint32_t p_command_count, int4 *p_ordinates, uint32_t p_ordinate_count, bool p_evenodd)
 {
 	MCCustomPrinterPathCommand *t_out_commands;
-	t_out_commands = new MCCustomPrinterPathCommand[p_command_count];
+	t_out_commands = new (nothrow) MCCustomPrinterPathCommand[p_command_count];
 
 	MCCustomPrinterPoint *t_out_coords;
-	t_out_coords = new MCCustomPrinterPoint[p_ordinate_count];
+	t_out_coords = new (nothrow) MCCustomPrinterPoint[p_ordinate_count];
 
 	if (t_out_commands != nil && t_out_coords != nil)
 	{
@@ -867,7 +867,7 @@ void MCCustomMetaContext::dorawpathmark(MCMark *p_mark, uint1 *p_commands, uint3
 			t_paint . gradient . transform . translate_y = p_mark->fill->gradient->origin.y;
 
 			// Map the paint stops appropriately
-			t_paint_stops = new MCCustomPrinterGradientStop[p_mark -> fill -> gradient -> ramp_length];
+			t_paint_stops = new (nothrow) MCCustomPrinterGradientStop[p_mark -> fill -> gradient -> ramp_length];
 			if (t_paint_stops != nil)
 			{
 				for(uint32_t i = 0; i < p_mark -> fill -> gradient -> ramp_length; i++)
@@ -970,7 +970,7 @@ void MCCustomMetaContext::dorawpathmark(MCMark *p_mark, uint1 *p_commands, uint3
 				{
 					t_stroke . dash_count = p_mark -> stroke -> dash . length;
 					t_stroke . dash_offset = p_mark -> stroke -> dash . offset;
-					t_stroke . dashes = new double[p_mark -> stroke -> dash . length];
+					t_stroke . dashes = new (nothrow) double[p_mark -> stroke -> dash . length];
 					if (t_stroke . dashes != nil)
 					{
 						for(uint32_t i = 0; i < p_mark -> stroke -> dash . length; i++)
@@ -1428,7 +1428,7 @@ MCPrinterResult MCCustomPrinterDevice::Begin(const MCPrinterRectangle& p_src_rec
 
 	// Now create a custom meta context, targeting our device
 	MCCustomMetaContext *t_context;
-	t_context = new MCCustomMetaContext(t_src_rect_hull);
+	t_context = new (nothrow) MCCustomMetaContext(t_src_rect_hull);
 	if (t_context == nil)
 		return PRINTER_RESULT_ERROR;
 
@@ -1664,7 +1664,7 @@ MCPrinterResult MCCustomPrinter::DoBeginPrint(MCStringRef p_document, MCPrinterD
 	t_printer_device = nil;
 	if (t_result == PRINTER_RESULT_SUCCESS)
 	{
-		t_printer_device = new MCCustomPrinterDevice(m_device);
+		t_printer_device = new (nothrow) MCCustomPrinterDevice(m_device);
 		if (t_printer_device == nil)
 			t_result = PRINTER_RESULT_ERROR;
 	}
@@ -2175,12 +2175,12 @@ Exec_stat MCCustomPrinterCreate(MCStringRef p_destination, MCStringRef p_filenam
 	}
 #ifdef _DEBUG
 	else if (MCStringIsEqualToCString(p_destination, "debug", kMCCompareCaseless))
-		t_device = new MCDebugPrintingDevice;
+		t_device = new (nothrow) MCDebugPrintingDevice;
 #endif
 
 #ifdef _DEBUG
 	if (t_device != nil)
-		t_device = new MCLoggingPrintingDevice(t_device);
+		t_device = new (nothrow) MCLoggingPrintingDevice(t_device);
 #endif
 	
 	if (t_device == nil)
@@ -2194,7 +2194,7 @@ Exec_stat MCCustomPrinterCreate(MCStringRef p_destination, MCStringRef p_filenam
 		/* UNCHECKED */ MCS_pathtonative(p_filename, &t_native_path);
 
 	MCCustomPrinter *t_printer;
-	t_printer = new MCCustomPrinter(p_destination, t_device);
+	t_printer = new (nothrow) MCCustomPrinter(p_destination, t_device);
 	t_printer -> Initialize();
 	t_printer -> SetDeviceName(p_destination);
 	t_printer -> SetDeviceOutput(PRINTER_OUTPUT_FILE, *t_native_path);

--- a/engine/src/deploy_linux.cpp
+++ b/engine/src/deploy_linux.cpp
@@ -504,7 +504,7 @@ static bool MCDeployToLinuxReadSectionHeaders(MCDeployFileRef p_file, typename T
 		return MCDeployThrow(kMCDeployErrorLinuxBadSectionSize);
 
 	// Allocate the array of the entries
-	r_table = new typename T::Shdr[p_header . e_shnum];
+	r_table = new (nothrow) typename T::Shdr[p_header . e_shnum];
 	if (r_table == NULL)
 		return MCDeployThrow(kMCDeployErrorNoMemory);
 
@@ -529,7 +529,7 @@ static bool MCDeployToLinuxReadProgramHeaders(MCDeployFileRef p_file, typename T
 		return MCDeployThrow(kMCDeployErrorLinuxBadSegmentSize);
 
 	// Allocate the array of the entries
-	r_table = new typename T::Phdr[p_header . e_phnum];
+	r_table = new (nothrow) typename T::Phdr[p_header . e_phnum];
 	if (r_table == NULL)
 		return MCDeployThrow(kMCDeployErrorNoMemory);
 

--- a/engine/src/deploy_windows.cpp
+++ b/engine/src/deploy_windows.cpp
@@ -796,7 +796,7 @@ static bool MCWindowsResourcesAddIcon(MCWindowsResources& self, MCStringRef p_ic
 	t_entries = NULL;
 	if (t_success)
 	{
-		t_entries = new ICONDIRENTRY[t_dir . idCount];
+		t_entries = new (nothrow) ICONDIRENTRY[t_dir . idCount];
 		if (t_entries == NULL)
 			t_success = MCDeployThrow(kMCDeployErrorNoMemory);
 	}
@@ -840,7 +840,7 @@ static bool MCWindowsResourcesAddIcon(MCWindowsResources& self, MCStringRef p_ic
 	t_grpicon_data = NULL;
 	if (t_success)
 	{
-		t_grpicon_data = new uint8_t[sizeof_GRPICONDIR + sizeof_GRPICONDIRENTRY * t_dir . idCount];
+		t_grpicon_data = new (nothrow) uint8_t[sizeof_GRPICONDIR + sizeof_GRPICONDIRENTRY * t_dir . idCount];
 		if (t_grpicon_data == NULL)
 			t_success = MCDeployThrow(kMCDeployErrorNoMemory);
 	}
@@ -886,7 +886,7 @@ static bool MCWindowsResourcesAddIcon(MCWindowsResources& self, MCStringRef p_ic
 		{
 			// First allocate memory and load the image data
 			uint8_t *t_image;
-			t_image = new uint8_t[t_entries[i] . dwBytesInRes];
+			t_image = new (nothrow) uint8_t[t_entries[i] . dwBytesInRes];
 			if (t_image != NULL)
 				t_success = MCDeployFileReadAt(t_icon, t_image, t_entries[i] . dwBytesInRes, t_entries[i] . dwImageOffset);
 
@@ -932,7 +932,7 @@ static bool MCWindowsVersionInfoAdd(MCWindowsVersionInfo *p_parent, const char *
 	t_child = NULL;
 	if (t_success)
 	{
-		t_child = new MCWindowsVersionInfo;
+		t_child = new (nothrow) MCWindowsVersionInfo;
 		if (t_child == NULL)
 			t_success = MCDeployThrow(kMCDeployErrorNoMemory);
 	}
@@ -1288,7 +1288,7 @@ static bool MCWindowsReadResourceEntryName(MCDeployFileRef p_file, uint32_t p_st
 	swap_uint16(t_length);
 	r_entry . name_length = t_length;
 
-	r_entry . name = new uint16_t[r_entry . name_length];
+	r_entry . name = new (nothrow) uint16_t[r_entry . name_length];
 	if (r_entry . name == NULL)
 		return MCDeployThrow(kMCDeployErrorNoMemory);
 
@@ -1329,7 +1329,7 @@ static bool MCWindowsReadResourceDir(MCDeployFileRef p_file, uint32_t p_address,
 	// Make sure we have enough room in the table.
 	r_resources . is_table = true;
 	r_resources . table . entry_count = t_dir . NumberOfIdEntries + t_dir . NumberOfNamedEntries;
-	r_resources . table . entries = new MCWindowsResources[r_resources . table . entry_count];
+	r_resources . table . entries = new (nothrow) MCWindowsResources[r_resources . table . entry_count];
 	if (r_resources . table . entries == NULL)
 		return MCDeployThrow(kMCDeployErrorNoMemory);
 
@@ -1613,7 +1613,7 @@ static bool MCDeployToWindowsReadHeaders(MCDeployFileRef p_file, IMAGE_DOS_HEADE
 	if (!MCDeployFileSeekSet(p_file, r_dos_header . e_lfanew + FIELD_OFFSET(IMAGE_NT_HEADERS, OptionalHeader) + r_nt_header . FileHeader . SizeOfOptionalHeader))
 		return MCDeployThrow(kMCDeployErrorWindowsBadSectionHeaderOffset);
 
-	r_section_headers = new IMAGE_SECTION_HEADER[r_nt_header . FileHeader . NumberOfSections];
+	r_section_headers = new (nothrow) IMAGE_SECTION_HEADER[r_nt_header . FileHeader . NumberOfSections];
 	if (r_section_headers == NULL)
 		return MCDeployThrow(kMCDeployErrorNoMemory);
 

--- a/engine/src/desktop-dc.cpp
+++ b/engine/src/desktop-dc.cpp
@@ -577,7 +577,7 @@ void MCScreenDC::redrawbackdrop(MCPlatformSurfaceRef p_surface, MCGRegionRef p_r
 	if (MCPlatformSurfaceLockGraphics(p_surface, t_bounds, t_context, t_raster))
 	{
 		MCGraphicsContext *t_gfxcontext;
-		/* UNCHECKED */ t_gfxcontext = new MCGraphicsContext(t_context);
+		/* UNCHECKED */ t_gfxcontext = new (nothrow) MCGraphicsContext(t_context);
 		t_gfxcontext -> setforeground(backdrop_colour);
 		if (backdrop_pattern != NULL)
 			t_gfxcontext -> setfillstyle(FillTiled, backdrop_pattern, 0, 0);

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -830,7 +830,7 @@ void MCScreenDC::seticonmenu(MCStringRef p_menu)
 				;
 			
 			MenuItemDescriptor *t_item;
-			t_item = new MenuItemDescriptor;
+			t_item = new (nothrow) MenuItemDescriptor;
 			if (t_item == NULL)
 				break;
             

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -619,7 +619,7 @@ void MCKeyMessageClear(MCKeyMessage *&p_message_queue)
 void MCKeyMessageAppend(MCKeyMessage *&p_message_queue, MCPlatformKeyCode p_key_code, codepoint_t p_mapped_codepoint, codepoint_t p_unmapped_codepoint, bool p_needs_mapping = true)
 {
     MCKeyMessage *t_new;
-    t_new = new MCKeyMessage;
+    t_new = new (nothrow) MCKeyMessage;
     
     t_new -> key_code = p_key_code;
     t_new -> mapped_codepoint = p_mapped_codepoint;

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -818,14 +818,14 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
     if (stacks == NULL)
     {
         MCnoui = True;
-        MCscreen = new MCUIDC;
+        MCscreen = new (nothrow) MCUIDC;
         /* UNCHECKED */ MCStackSecurityCreateStack(stacks);
         MCdefaultstackptr = MCstaticdefaultstackptr = stacks;
         stacks->setparent(this);
         stacks->setname_cstring("revScript");
         uint4 size = (uint4)MCS_fsize(stream);
         MCAutoPointer<char> script;
-        script = new char[size + 2];
+        script = new (nothrow) char[size + 2];
         (*script)[size] = '\n';
         (*script)[size + 1] = '\0';
         if (IO_read(*script, size, stream) != IO_NORMAL)
@@ -1613,7 +1613,7 @@ MCFontStruct *MCDispatch::loadfont(MCNameRef fname, uint2 &size, uint2 style, Bo
 		fonts = MCFontlistCreateNew();
 #else
 	if (fonts == nil)
-		fonts = new MCFontlist;
+		fonts = new (nothrow) MCFontlist;
 #endif
 	return fonts->getfont(fname, size, style, printer);
 }
@@ -1622,7 +1622,7 @@ MCFontStruct *MCDispatch::loadfontwithhandle(MCSysFontHandle p_handle, MCNameRef
 {
 #if defined(_MACOSX) || defined (_MAC_SERVER) || defined (TARGET_SUBPLATFORM_IPHONE)
     if (fonts == nil)
-        fonts = new MCFontlist;
+        fonts = new (nothrow) MCFontlist;
     return fonts->getfontbyhandle(p_handle, p_name);
 #else
     return NULL;
@@ -1901,7 +1901,7 @@ check:
                     }
                 }
                 
-				iptr = new MCImage;
+				iptr = new (nothrow) MCImage;
                 iptr->appendto(imagecache);
                 iptr->SetText(*ctxt, *t_data);
 				iptr->setname(*t_image_name);
@@ -2040,7 +2040,7 @@ bool MCDispatch::loadexternal(MCStringRef p_external)
 #endif
 	
 	if (m_externals == nil)
-		m_externals = new MCExternalHandlerList;
+		m_externals = new (nothrow) MCExternalHandlerList;
 	
 	bool t_loaded;
 	t_loaded = m_externals -> Load(t_filename);
@@ -2105,7 +2105,7 @@ bool MCDispatch::dopaste(MCObject*& r_objptr, bool p_explicit)
             MCExecContext ctxt(nil, nil, nil);
 
 			MCImage *t_image;
-			t_image = new MCImage;
+			t_image = new (nothrow) MCImage;
 			t_image -> open();
 			t_image -> openimage();
 			t_image -> SetText(ctxt, *t_data);
@@ -2146,7 +2146,7 @@ bool MCDispatch::dopaste(MCObject*& r_objptr, bool p_explicit)
             {
                 MCExecContext ctxt(nil, nil, nil);
 				
-				t_objects = new MCImage(*MCtemplateimage);
+				t_objects = new (nothrow) MCImage(*MCtemplateimage);
 				t_objects -> open();
 				static_cast<MCImage *>(t_objects) -> SetText(ctxt, *t_data);
 				t_objects -> close();

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -341,7 +341,7 @@ static iconv_t fetch_converter(const char *p_encoding)
         t_converter = iconv_open("UTF-16LE", p_encoding);
 
         ConverterRecord *t_record;
-        t_record = new ConverterRecord;
+        t_record = new (nothrow) ConverterRecord;
         t_record -> next = s_records;
         t_record -> encoding = p_encoding;
         t_record -> converter = t_converter;
@@ -868,7 +868,7 @@ public:
     virtual void SetEnv(MCStringRef p_name, MCStringRef p_value)
     {
 #ifdef NOSETENV
-        char *dptr = new char[strlen(p_name) + strlen(p_value) + 2];
+        char *dptr = new (nothrow) char[strlen(p_name) + strlen(p_value) + 2];
         sprintf(dptr, "%s=%s", p_name, p_value);
         putenv(dptr);
 #else
@@ -1169,7 +1169,7 @@ public:
         fptr = fopen(*t_path_utf, "wb+");
 
         if (fptr != nil)
-            t_handle = new MCStdioFileHandle(fptr);
+            t_handle = new (nothrow) MCStdioFileHandle(fptr);
 
         return t_handle;
     }
@@ -1199,7 +1199,7 @@ public:
                     //   rather than '-1'.
                     if (t_buffer != MAP_FAILED)
                     {
-                        t_handle = new MCMemoryMappedFileHandle(t_fd, t_buffer, t_len);
+                        t_handle = new (nothrow) MCMemoryMappedFileHandle(t_fd, t_buffer, t_len);
                         return t_handle;
                     }
                 }
@@ -1227,7 +1227,7 @@ public:
 
         if (t_fptr != NULL)
         {
-            t_handle = new MCStdioFileHandle(t_fptr);
+            t_handle = new (nothrow) MCStdioFileHandle(t_fptr);
         }
 
         return t_handle;
@@ -1261,7 +1261,7 @@ public:
             setbuf(t_fptr, NULL);
 
         if (t_fptr != NULL)
-            t_handle = new MCStdioFileHandle(t_fptr);
+            t_handle = new (nothrow) MCStdioFileHandle(t_fptr);
 
         return t_handle;
     }
@@ -1290,7 +1290,7 @@ public:
         {
             configureSerialPort((short)fileno(t_fptr));
 
-            t_handle = new MCStdioFileHandle(t_fptr);
+            t_handle = new (nothrow) MCStdioFileHandle(t_fptr);
         }
 
         return t_handle;
@@ -1354,7 +1354,7 @@ public:
 		 * path, a path separator character, and any possible filename. */
 		size_t t_path_len = strlen(*t_path);
 		size_t t_entry_path_len = t_path_len + 1 + NAME_MAX;
-		char *t_entry_path = new char[t_entry_path_len + 1];
+		char *t_entry_path = new (nothrow) char[t_entry_path_len + 1];
 		strcpy (t_entry_path, *t_path);
 		if ((*t_path)[t_path_len - 1] != '/')
 		{
@@ -1895,7 +1895,7 @@ public:
                     {
                         /* UNCHECKED */ t_doc_sys.Lock(p_doc);
 
-                        argv = new char *[3];
+                        argv = new (nothrow) char *[3];
                         argv[0] = t_name_copy;
                         argv[1] = (char *)*t_doc_sys;
                         argc = 2;

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -101,7 +101,7 @@ bool FourCharCodeFromString(MCStringRef p_string, uindex_t p_start, FourCharCode
 inline char *FourCharCodeToString(FourCharCode p_code)
 {
 	char *t_result;
-	t_result = new char[5];
+	t_result = new (nothrow) char[5];
 	*(FourCharCode *)t_result = MCSwapInt32NetworkToHost(p_code);
 	t_result[4] = '\0';
 	return t_result;
@@ -196,8 +196,8 @@ OSErr MCAppleEventHandlerDoSpecial(const AppleEvent *ae, AppleEvent *reply, long
 	}
 	AEAddressDesc senderDesc;
 	//
-	char *p3val = new char[128];
-	//char *p3val = new char[kNBPEntityBufferSize + 1]; //sender's address 105 + 1
+	char *p3val = new (nothrow) char[128];
+	//char *p3val = new (nothrow) char[kNBPEntityBufferSize + 1]; //sender's address 105 + 1
 	if (AEGetAttributeDesc(ae, keyOriginalAddressAttr,
 	                       typeWildCard, &senderDesc) == noErr)
 	{
@@ -269,7 +269,7 @@ OSErr MCAppleEventHandlerDoSpecial(const AppleEvent *ae, AppleEvent *reply, long
 			Size rSize;  //actual size returned
 			if ((err = AEGetParamPtr(aePtr, keyDirectObject, typeUTF8Text, &rType, NULL, 0, &rSize)) == noErr)
 			{
-				byte_t *sptr = new byte_t[rSize + 1];
+				byte_t *sptr = new (nothrow) byte_t[rSize + 1];
 				AEGetParamPtr(aePtr, keyDirectObject, typeUTF8Text, &rType, sptr, rSize, &rSize);
                 MCExecContext ctxt(MCdefaultstackptr -> getcard(), nil, nil);
                 MCAutoStringRef t_sptr;
@@ -377,7 +377,7 @@ OSErr MCAppleEventHandlerDoAEAnswer(const AppleEvent *ae, AppleEvent *reply, lon
      parameter of the reply Apple event. */
 	if (AEGetParamPtr(ae, keyErrorString, typeUTF8Text, &rType, NULL, 0, &rSize) == noErr)
 	{
-		byte_t* t_utf8 = new byte_t[rSize + 1];
+		byte_t* t_utf8 = new (nothrow) byte_t[rSize + 1];
 		AEGetParamPtr(ae, keyErrorString, typeUTF8Text, &rType, t_utf8, rSize, &rSize);
 		/* UNCHECKED */ MCStringCreateWithBytesAndRelease(t_utf8, rSize, kMCStringEncodingUTF8, false, AEAnswerErr);
 	}
@@ -406,7 +406,7 @@ OSErr MCAppleEventHandlerDoAEAnswer(const AppleEvent *ae, AppleEvent *reply, lon
                 /* UNCHECKED */ MCStringFormat(AEAnswerErr, "Got error %d when receiving Apple event", errno);
                 return errno;
 			}
-			byte_t *t_utf8 = new byte_t[rSize + 1];
+			byte_t *t_utf8 = new (nothrow) byte_t[rSize + 1];
 			AEGetParamPtr(ae, keyDirectObject, typeUTF8Text, &rType, t_utf8, rSize, &rSize);
 			/* UNCHECKED */ MCStringCreateWithBytesAndRelease(t_utf8, rSize, kMCStringEncodingUTF8, false, AEAnswerData);
 		}
@@ -723,7 +723,7 @@ static TextToUnicodeInfo fetch_unicode_info(TextEncoding p_encoding)
 			t_info = NULL;
 		
 		UnicodeInfoRecord *t_record;
-		t_record = new UnicodeInfoRecord;
+		t_record = new (nothrow) UnicodeInfoRecord;
 		t_record -> next = s_records;
 		t_record -> encoding = p_encoding;
 		t_record -> info = t_info;
@@ -2184,7 +2184,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
         }
         
         // In block sizes of 1k, copy over the data from source to destination..
-        char *t_buffer = new char[65536];
+        char *t_buffer = new (nothrow) char[65536];
         if (t_source_fork_opened && t_dest_fork_opened)
         {
             OSErr t_os_read_error, t_os_write_error;
@@ -2244,7 +2244,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
         else
         {
             char *buffer;
-            buffer = new char[fsize];
+            buffer = new (nothrow) char[fsize];
             if (buffer == NULL)
                 MCresult->sets("can't create data buffer");
             else
@@ -2382,7 +2382,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
         AEDisposeDesc(&ae);
         if (errno != noErr)
         {
-            char *buffer = new char[6 + I2L];
+            char *buffer = new (nothrow) char[6 + I2L];
             sprintf(buffer, "error %d", errno);
             MCresult->copysvalue(buffer);
             delete[] buffer;
@@ -2487,7 +2487,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
                     
                     if ((errno = AEGetParamPtr(aePtr, keyDirectObject, typeUTF8Text, &rType, NULL, 0, &rSize)) == noErr)
                     {
-                        byte_t *t_utf8 = new byte_t[rSize + 1];
+                        byte_t *t_utf8 = new (nothrow) byte_t[rSize + 1];
                         AEGetParamPtr(aePtr, keyDirectObject, typeUTF8Text, &rType, t_utf8, rSize, &rSize);
                         /* UNCHECKED */ MCStringCreateWithBytesAndRelease(t_utf8, rSize, kMCStringEncodingUTF8, false, r_value);
                     }
@@ -2540,7 +2540,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
             case AE_SENDER:
             {
                 AEAddressDesc senderDesc;
-                char *sender = new char[128];
+                char *sender = new (nothrow) char[128];
                 
                 if ((errno = AEGetAttributeDesc(aePtr, keyOriginalAddressAttr,
                                                 typeWildCard, &senderDesc)) == noErr)
@@ -2592,7 +2592,7 @@ struct MCMacSystemService: public MCMacSystemServiceInterface//, public MCMacDes
         AEDisposeDesc(&answer);
         if (errno != noErr)
         {
-            char *buffer = new char[6 + I2L];
+            char *buffer = new (nothrow) char[6 + I2L];
             sprintf(buffer, "error %d", errno);
             MCresult->copysvalue(buffer);
             delete[] buffer;
@@ -2834,8 +2834,8 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         CFStringRef t_raw;
         CFMutableStringRef t_lower, t_upper;
         CFIndex t_ignored;
-        MCuppercasingtable = new uint8_t[256];
-        MClowercasingtable = new uint8_t[256];
+        MCuppercasingtable = new (nothrow) uint8_t[256];
+        MClowercasingtable = new (nothrow) uint8_t[256];
         for(uindex_t i = 0; i < 256; ++i)
             MCuppercasingtable[i] = uint8_t(i);
         t_raw = CFStringCreateWithBytes(NULL, MCuppercasingtable, 256, kCFStringEncodingMacRoman, false);
@@ -3016,7 +3016,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 
 		if (t_len)
 		{
-			char *t_model = new char[t_len];
+			char *t_model = new (nothrow) char[t_len];
 			if (nil == t_model)
 				return false;
 			sysctlbyname("hw.model", t_model, &t_len, NULL, 0);
@@ -3727,7 +3727,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         io_object_t thePort;
         if (FindSerialPortDevices(&SerialPortIterator, &masterPort) != KERN_SUCCESS)
         {
-            char *buffer = new char[6 + I2L];
+            char *buffer = new (nothrow) char[6 + I2L];
             sprintf(buffer, "error %d", errno);
             MCresult->copysvalue(buffer);
             delete[] buffer;
@@ -3961,7 +3961,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         fptr = fopen(*t_path_utf, IO_CREATE_MODE);
 
         if (fptr != nil)
-            t_handle = new MCStdioFileHandle(fptr);
+            t_handle = new (nothrow) MCStdioFileHandle(fptr);
         
         return t_handle;
     }
@@ -4003,7 +4003,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
                     //   rather than '-1'.
                     if (t_buffer != MAP_FAILED)
                     {
-                        t_handle = new MCMemoryMappedFileHandle(t_fd, t_buffer, t_len);
+                        t_handle = new (nothrow) MCMemoryMappedFileHandle(t_fd, t_buffer, t_len);
                         return t_handle;
                     }
                 }
@@ -4055,7 +4055,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
             MCS_mac_setfiletype(p_path);
         
 		if (fptr != NULL)
-            t_handle = new MCStdioFileHandle(fptr);
+            t_handle = new (nothrow) MCStdioFileHandle(fptr);
         
         return t_handle;
     }
@@ -4091,7 +4091,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 			setvbuf(t_stream, NULL, _IONBF, 0);
 		
 		IO_handle t_handle;
-		t_handle = new MCStdioFileHandle(t_stream);
+		t_handle = new (nothrow) MCStdioFileHandle(t_stream);
 		
 		return t_handle;
     }
@@ -4143,7 +4143,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
             // SN-2014-05-02 [[ Bug 12246 ]] Serial I/O fails on write
             // The serial port number is never used in the 6.X engine... and switching to an STDIO file
             // is enough to have the serial devices working perfectly.
-            t_handle = new MCStdioFileHandle(fptr, true);
+            t_handle = new (nothrow) MCStdioFileHandle(fptr, true);
         }
         
         return t_handle;
@@ -5034,7 +5034,7 @@ static OSStatus getAEAttributes(const AppleEvent *ae, AEKeyword key, MCStringRef
 			}
             case typeUTF8Text:
             {
-                byte_t *result = new byte_t[s + 1];
+                byte_t *result = new (nothrow) byte_t[s + 1];
                 AEGetAttributePtr(ae, key, dt, &rType, result, s, &rSize);
                 t_success = MCStringCreateWithBytes(result, s, kMCStringEncodingUTF8, false, r_result);
                 delete[] result;
@@ -5042,7 +5042,7 @@ static OSStatus getAEAttributes(const AppleEvent *ae, AEKeyword key, MCStringRef
             }
             case typeChar:
             {
-                char_t *result = new char_t[s + 1];
+                char_t *result = new (nothrow) char_t[s + 1];
                 AEGetAttributePtr(ae, key, dt, &rType, result, s, &rSize);
                 t_success = MCStringCreateWithNativeChars(result, s, r_result);
                 delete[] result;
@@ -5167,14 +5167,14 @@ static OSStatus getAEParams(const AppleEvent *ae, AEKeyword key, MCStringRef &r_
 			}
             case typeUTF8Text:
             {
-                byte_t *result = new byte_t[s + 1];
+                byte_t *result = new (nothrow) byte_t[s + 1];
                 AEGetParamPtr(ae, key, dt, &rType, result, s, &rSize);
                 t_success = MCStringCreateWithBytesAndRelease(result, s, kMCStringEncodingUTF8, false, r_result);
                 break;
             }
             case typeChar:
             {
-                char_t *result = new char_t[s + 1];
+                char_t *result = new (nothrow) char_t[s + 1];
                 AEGetParamPtr(ae, key, dt, &rType, result, s, &rSize);
                 t_success = MCStringCreateWithNativeChars(result, s, r_result);
                 delete[] result;
@@ -5315,7 +5315,7 @@ static OSStatus osaexecute(MCStringRef& r_string, ComponentInstance compinstance
 	AEDesc aedresult;
 	OSADisplay(compinstance, scriptresult, typeUTF8Text, kOSAModeNull, &aedresult);
 	Size tsize = AEGetDescDataSize(&aedresult);
-	byte_t *buffer = new byte_t[tsize];
+	byte_t *buffer = new (nothrow) byte_t[tsize];
 	err = AEGetDescData(&aedresult,buffer,tsize);
     /* UNCHECKED */ MCStringCreateWithBytesAndRelease(buffer, tsize, kMCStringEncodingUTF8, false, r_string);
 	AEDisposeDesc(&aedresult);
@@ -5337,7 +5337,7 @@ static void getosacomponents()
 	compdesc.componentFlagsMask = kOSASupportsCompiling;
 	long compnumber = CountComponents(&compdesc);
 	if (compnumber - 1) //don't include the generic script comp
-		osacomponents = new OSAcomponent[compnumber - 1];
+		osacomponents = new (nothrow) OSAcomponent[compnumber - 1];
 	while ((tcomponent = FindNextComponent(tcomponent,&compdesc)) != NULL)
 	{
 		ComponentDescription founddesc;
@@ -5527,7 +5527,7 @@ static bool startprocess_create_argv(char *name, char *doc, uint32_t & r_argc, c
 	}
 	else
 	{
-		argv = new char *[3];
+		argv = new (nothrow) char *[3];
 		argv[0] = name;
 		argv[1] = doc;
 		argc = 2;

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -125,8 +125,8 @@ bool X_init(int argc, MCStringRef argv[], MCStringRef envp[])
 	// Make sure certain things are already created before MCS_init. This is
 	// required right now because the Windows MCS_init uses MCS_query_registry
 	// which needs these things.
-	MCperror = new MCError();
-	MCeerror = new MCError();
+	MCperror = new (nothrow) MCError();
+	MCeerror = new (nothrow) MCError();
 	/* UNCHECKED */ MCVariable::create(MCresult);
 #endif
 

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -502,7 +502,7 @@ static DWORD readThread(Streamnode *process)
 {
 	DWORD nread;
 	uint32_t t_bufsize = READ_PIPE_SIZE;
-	char* t_buffer = new char[t_bufsize];
+	char* t_buffer = new (nothrow) char[t_bufsize];
 
 	while (process -> ihandle != NULL)
 	{
@@ -1629,7 +1629,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 			return true;
 		}
         
-        char *buffer = new char[MAXHOSTNAMELEN + 1];
+        char *buffer = new (nothrow) char[MAXHOSTNAMELEN + 1];
         gethostname(buffer, MAXHOSTNAMELEN);
 		buffer[MAXHOSTNAMELEN] = '\0';
         return MCStringFormat(r_address, "%s:%@", buffer, MCcmd);
@@ -2240,12 +2240,12 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 				if (t_buffer == NULL)
 				{
 					CloseHandle(t_file_mapped_handle);
-					t_handle = new MCStdioFileHandle((MCWinSysHandle)t_file_handle);
+					t_handle = new (nothrow) MCStdioFileHandle((MCWinSysHandle)t_file_handle);
                     t_close_file_handler = t_handle == NULL;
 				}
 				else
 				{
-					t_handle = new MCMemoryMappedFileHandle(t_file_mapped_handle, t_buffer, t_len);
+					t_handle = new (nothrow) MCMemoryMappedFileHandle(t_file_mapped_handle, t_buffer, t_len);
                     // SN-2015-04-13: [[ Bug 14696 ]] We don't want to leave a
                     //  file handler open in case the memory mapped file could
                     //  not be allocated. We always close the normal file handle
@@ -2258,13 +2258,13 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 			// (for empty files for instance).
 			else
             {
-				t_handle = new MCStdioFileHandle((MCWinSysHandle)t_file_handle);
+				t_handle = new (nothrow) MCStdioFileHandle((MCWinSysHandle)t_file_handle);
                 t_close_file_handler = t_handle == NULL;
             }
 		}
 		else
         {
-			t_handle = new MCStdioFileHandle((MCWinSysHandle)t_file_handle);
+			t_handle = new (nothrow) MCStdioFileHandle((MCWinSysHandle)t_file_handle);
             t_close_file_handler = t_handle == NULL;
         }
 
@@ -2289,7 +2289,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 			return nil;
 
 		// Since we can only have an STD fd, we know we have a pipe.
-		t_stdio_handle = new MCStdioFileHandle((MCWinSysHandle)t_handle, true);
+		t_stdio_handle = new (nothrow) MCStdioFileHandle((MCWinSysHandle)t_handle, true);
 
 		return t_stdio_handle;
 	}
@@ -2465,7 +2465,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
     // ST-2014-12-18: [[ Bug 14259 ]] Returns the executable from the system tools, not from argv[0]
 	virtual bool GetExecutablePath(MCStringRef& r_path)
 	{
-		WCHAR* wcFileNameBuf = new WCHAR[MAX_PATH+1];
+		WCHAR* wcFileNameBuf = new (nothrow) WCHAR[MAX_PATH+1];
 		DWORD dwFileNameLen = GetModuleFileNameW(NULL, wcFileNameBuf, MAX_PATH+1);
 		
 		MCAutoStringRef t_path;
@@ -2805,8 +2805,8 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
         uint4 index = MCnprocesses;
         MCprocesses[index].name = (MCNameRef)MCValueRetain(MCM_shell);
         MCprocesses[index].mode = OM_NEITHER;
-        MCprocesses[index].ohandle = new MCMemoryFileHandle;
-		MCprocesses[index].ihandle = new MCStdioFileHandle((MCWinSysHandle)hChildStdoutRd, true);
+        MCprocesses[index].ohandle = new (nothrow) MCMemoryFileHandle;
+		MCprocesses[index].ihandle = new (nothrow) MCStdioFileHandle((MCWinSysHandle)hChildStdoutRd, true);
         if (created)
         {
             HANDLE phandle = GetCurrentProcess();
@@ -3098,12 +3098,12 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
         if (created)
         {
             if (writing)
-				MCprocesses[MCnprocesses].ohandle = new MCStdioFileHandle((MCWinSysHandle)hChildStdinWr, true);
+				MCprocesses[MCnprocesses].ohandle = new (nothrow) MCStdioFileHandle((MCWinSysHandle)hChildStdinWr, true);
             else
                 CloseHandle(hChildStdinWr);
 
             if (reading)
-				MCprocesses[MCnprocesses].ihandle = new MCStdioFileHandle((MCWinSysHandle)hChildStdoutRd, true);
+				MCprocesses[MCnprocesses].ihandle = new (nothrow) MCStdioFileHandle((MCWinSysHandle)hChildStdoutRd, true);
             else
                 CloseHandle(hChildStdoutRd);
         }

--- a/engine/src/dskw32main.cpp
+++ b/engine/src/dskw32main.cpp
@@ -175,7 +175,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
     // FG-2014-09-23: [[ Bugfix 12444 ]] Re-arrange command line processing to
     // match behaviour in 6.x and below.
-    WCHAR* wcFileNameBuf = new WCHAR[MAX_PATH+1];
+    WCHAR* wcFileNameBuf = new (nothrow) WCHAR[MAX_PATH+1];
     DWORD dwFileNameLen = GetModuleFileNameW(NULL, wcFileNameBuf, MAX_PATH+1);
     
 	// Windows uses slashes the opposite way around to the other platforms and requires conversion

--- a/engine/src/em-fontlist.cpp
+++ b/engine/src/em-fontlist.cpp
@@ -178,7 +178,7 @@ MCFontlist::getfont(MCNameRef p_name,
 	}
 
 	/* No match; create a new font with the requested parameters */
-	t_node = new MCFontnode(p_name, p_size, p_style);
+	t_node = new (nothrow) MCFontnode(p_name, p_size, p_style);
 
 	t_node->appendto(m_font_list);
 

--- a/engine/src/em-surface.cpp
+++ b/engine/src/em-surface.cpp
@@ -208,7 +208,7 @@ MCHtmlCanvasStackSurface::Lock()
     // Allocate a buffer for us to use, if not already done
     if (m_surface == nil)
     {
-        m_surface = new uint8_t[m_rect.size.width * m_rect.size.height * sizeof(uint32_t)];
+        m_surface = new (nothrow) uint8_t[m_rect.size.width * m_rect.size.height * sizeof(uint32_t)];
     }
 
     return m_surface != nil;

--- a/engine/src/eps.cpp
+++ b/engine/src/eps.cpp
@@ -82,7 +82,7 @@ MCEPS::MCEPS(const MCEPS &sref) : MCControl(sref)
 	pagecount = sref.pagecount;
 	if (pagecount != 0)
 	{
-		pageIndex = new uint4[pagecount];
+		pageIndex = new (nothrow) uint4[pagecount];
 		uint2 i = pagecount;
 		while (i--)
 			pageIndex[i] = sref.pageIndex[i];
@@ -93,7 +93,7 @@ MCEPS::MCEPS(const MCEPS &sref) : MCControl(sref)
 		image = NULL;
 	else
 	{
-		image = new MCImage(*sref.image);
+		image = new (nothrow) MCImage(*sref.image);
 		image->setparent(this);
 	}
 }
@@ -250,7 +250,7 @@ IO_stat MCEPS::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p
 
 MCControl *MCEPS::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCEPS *neweps = new MCEPS(*this);
+	MCEPS *neweps = new (nothrow) MCEPS(*this);
 	if (attach)
 		neweps->attach(p, invisible);
 	return neweps;
@@ -338,7 +338,7 @@ IO_stat MCEPS::load(IO_handle stream, uint32_t version)
 	delete prolog;
 	if ((stat = IO_read_uint4(&size, stream)) != IO_NORMAL)
 		return checkloadstat(stat);
-	postscript = new char[size + 1];
+	postscript = new (nothrow) char[size + 1];
 	if ((stat = IO_read(postscript, size, stream)) != IO_NORMAL)
 		return checkloadstat(stat);
 	postscript[size] = '\0';
@@ -369,7 +369,7 @@ IO_stat MCEPS::load(IO_handle stream, uint32_t version)
 		return checkloadstat(stat);
 	if (flags & F_RETAIN_IMAGE)
 	{
-		image = new MCImage;
+		image = new (nothrow) MCImage;
 		image->setparent(this);
 		if ((stat = image->load(stream, version)) != IO_NORMAL)
 			return checkloadstat(stat);
@@ -382,7 +382,7 @@ IO_stat MCEPS::load(IO_handle stream, uint32_t version)
 			return checkloadstat(stat);
 		if (pagecount > 0)
 		{
-			pageIndex = new uint4[pagecount];
+			pageIndex = new (nothrow) uint4[pagecount];
 			for (i = 0 ; i < pagecount ; i++)
 				if ((stat = IO_read_uint4(&pageIndex[i], stream)) != IO_NORMAL)
 					return checkloadstat(stat);
@@ -407,7 +407,7 @@ void MCEPS::setextents()
 		uint4 offset = swap_uint4(&uint4ptr[1]);
 		size = swap_uint4(&uint4ptr[2]);
 		MCswapbytes = !MCswapbytes;
-		char *newps = new char[size];
+		char *newps = new (nothrow) char[size];
 		memcpy(newps, &postscript[offset], size);
 		delete postscript;
 		postscript = newps;
@@ -495,7 +495,7 @@ Boolean MCEPS::import(MCStringRef fname, IO_handle stream)
 {
 	size = (uint4)MCS_fsize(stream);
 	delete postscript;
-	postscript = new char[size + 1];
+	postscript = new (nothrow) char[size + 1];
 	if (IO_read(postscript, size, stream) != IO_NORMAL)
 		return False;
 	postscript[size] = '\0';

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -1188,7 +1188,7 @@ static void handle_touch(MCStack *p_stack, MCEventTouchPhase p_phase, uint32_t p
 	}
 	else
 	{
-		t_touch = new MCTouch;
+		t_touch = new (nothrow) MCTouch;
 		t_touch -> next = s_touches;
 		t_touch -> id = p_id;
 		

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -767,7 +767,7 @@ void MCArraysEvalArrayEncode(MCExecContext& ctxt, MCArrayRef p_array, MCStringRe
         t_stream = nil;
         if (t_success)
         {
-            t_stream = new MCObjectOutputStream(t_stream_handle);
+            t_stream = new (nothrow) MCObjectOutputStream(t_stream_handle);
             if (t_stream == nil)
                 t_success = false;
         }
@@ -863,7 +863,7 @@ void MCArraysEvalArrayDecode(MCExecContext& ctxt, MCDataRef p_encoding, MCArrayR
         t_stream = nil;
         if (t_success)
         {
-            t_stream = new MCObjectInputStream(t_stream_handle, MCDataGetLength(p_encoding), false);
+            t_stream = new (nothrow) MCObjectInputStream(t_stream_handle, MCDataGetLength(p_encoding), false);
             if (t_stream == nil)
                 t_success = false;
         }
@@ -1341,7 +1341,7 @@ void MCArraysExecFilterWildcard(MCExecContext& ctxt, MCArrayRef p_source, MCStri
 {
     // Create the pattern matcher
     MCPatternMatcher *t_matcher;
-    t_matcher = new MCWildcardMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+    t_matcher = new (nothrow) MCWildcardMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
     MCArraysExecFilter(ctxt, p_source, p_without, t_matcher, p_match_keys, r_result);
     
@@ -1352,7 +1352,7 @@ void MCArraysExecFilterRegex(MCExecContext& ctxt, MCArrayRef p_source, MCStringR
 {
     // Create the pattern matcher
     MCPatternMatcher *t_matcher;
-    t_matcher = new MCRegexMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+    t_matcher = new (nothrow) MCRegexMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
     MCAutoStringRef t_regex_error;
     if (!t_matcher -> compile(&t_regex_error))

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -968,7 +968,7 @@ void MCEngineExecInsertScriptOfObjectInto(MCExecContext& ctxt, MCObject *p_scrip
 		ctxt . LegacyThrow(EE_INSERT_NOTLICENSED);
 		return;
 	}
-	MCObjectList *olptr = new MCObjectList(p_script);
+	MCObjectList *olptr = new (nothrow) MCObjectList(p_script);
 	olptr->insertto(listptr);
 }
 
@@ -1319,7 +1319,7 @@ static void MCEngineSplitScriptIntoMessageAndParameters(MCExecContext& ctxt, MCS
             MCAutoStringRef t_expression;
             /* UNCHECKED */ MCStringCopySubstring(p_script, t_exp_range, &t_expression);
             
-            MCParameter *newparam = new MCParameter;
+            MCParameter *newparam = new (nothrow) MCParameter;
             
             // MW-2011-08-11: [[ Bug 9668 ]] Make sure we copy 'pdata' if we use it, since
             //   mptr (into which it points) only lasts as long as this method call.
@@ -1804,7 +1804,7 @@ bool MCEngineEvalValueAsObject(MCValueRef p_value, bool p_strict, MCObjectPtr& r
     ctxt . ConvertToString(p_value, &t_string);
     MCScriptPoint sp(ctxt, *t_string);
 
-    MCChunk *tchunk = new MCChunk(False);
+    MCChunk *tchunk = new (nothrow) MCChunk(False);
     MCerrorlock++;
     Symbol_type type;
     

--- a/engine/src/exec-interface-button.cpp
+++ b/engine/src/exec-interface-button.cpp
@@ -452,7 +452,7 @@ void MCButton::DoSetIcon(MCExecContext& ctxt, Current_icon which, const MCInterf
     
 	if (icons == NULL)
 	{
-		icons = new iconlist;
+		icons = new (nothrow) iconlist;
 		memset(icons, 0, sizeof(iconlist));
 	}
     

--- a/engine/src/exec-interface-control.cpp
+++ b/engine/src/exec-interface-control.cpp
@@ -149,7 +149,7 @@ void MCControl::DoSetHScrollbar(MCExecContext& ctxt, MCScrollbar*& hsb, uint2& s
 {
 	if (flags & F_HSCROLLBAR)
 	{
-		hsb = new MCScrollbar(*MCtemplatescrollbar);
+		hsb = new (nothrow) MCScrollbar(*MCtemplatescrollbar);
 		hsb->setparent(this);
 		hsb->setflag(False, F_TRAVERSAL_ON);
 		hsb->setflag(flags & F_3D, F_3D);
@@ -185,7 +185,7 @@ void MCControl::DoSetVScrollbar(MCExecContext& ctxt, MCScrollbar*& vsb, uint2& s
 {
 	if (flags & F_VSCROLLBAR)
 	{
-		vsb = new MCScrollbar(*MCtemplatescrollbar);
+		vsb = new (nothrow) MCScrollbar(*MCtemplatescrollbar);
 		vsb->setparent(this);
 		vsb->setflag(False, F_TRAVERSAL_ON);
 		vsb->setflag(flags & F_3D, F_3D);

--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -987,7 +987,7 @@ template<typename T> void SetCharPropOfCharChunkOfParagraph(MCExecContext& ctxt,
         bptr->GetRange(t_block_index, t_block_length);
         if (t_block_index < si)
         {
-            MCBlock *tbptr = new MCBlock(*bptr);
+            MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
             bptr->append(tbptr);
             bptr->SetRange(t_block_index, si - t_block_index);
             tbptr->SetRange(si, t_block_length - (si - t_block_index));
@@ -999,7 +999,7 @@ template<typename T> void SetCharPropOfCharChunkOfParagraph(MCExecContext& ctxt,
             bptr->close();
         if (t_block_index + t_block_length > ei)
         {
-            MCBlock *tbptr = new MCBlock(*bptr);
+            MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
             // MW-2012-02-14: [[ FontRefs ]] If the block is open, pass in the parent's
             //   fontref so it can compute its.
             if (p_paragraph -> getopened())
@@ -1065,7 +1065,7 @@ template<typename T> void SetCharPropOfCharChunk(MCExecContext& ctxt, MCField *p
                     bptr->GetRange(t_block_index, t_block_length);
                     if (t_block_index < si)
                     {
-                        MCBlock *tbptr = new MCBlock(*bptr);
+                        MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
                         bptr->append(tbptr);
                         bptr->SetRange(t_block_index, si - t_block_index);
                         tbptr->SetRange(si, t_block_length - (si - t_block_index));
@@ -1077,7 +1077,7 @@ template<typename T> void SetCharPropOfCharChunk(MCExecContext& ctxt, MCField *p
                         bptr->close();
                     if (t_block_index + t_block_length > t_ei)
                     {
-                        MCBlock *tbptr = new MCBlock(*bptr);
+                        MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
                         // MW-2012-02-14: [[ FontRefs ]] If the block is open, pass in the parent's
                         //   fontref so it can compute its.
                         if (pgptr -> getopened())
@@ -1176,7 +1176,7 @@ template<typename T> void SetArrayCharPropOfCharChunk(MCExecContext& ctxt, MCFie
                     bptr->GetRange(t_block_index, t_block_length);
                     if (t_block_index < si)
                     {
-                        MCBlock *tbptr = new MCBlock(*bptr);
+                        MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
                         bptr->append(tbptr);
                         bptr->SetRange(t_block_index, si - t_block_index);
                         tbptr->SetRange(si, t_block_length - (si - t_block_index));
@@ -1188,7 +1188,7 @@ template<typename T> void SetArrayCharPropOfCharChunk(MCExecContext& ctxt, MCFie
                         bptr->close();
                     if (t_block_index + t_block_length > t_ei)
                     {
-                        MCBlock *tbptr = new MCBlock(*bptr);
+                        MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
                         // MW-2012-02-14: [[ FontRefs ]] If the block is open, pass in the parent's
                         //   fontref so it can compute its.
                         if (pgptr -> getopened())
@@ -1268,7 +1268,7 @@ template<typename T, int Min, int Max> static void setparagraphattr_int(MCParagr
         t_clamped_field = MCMin(MCMax((int)*p_value, Min), Max);
 
         if (attrs == nil)
-            attrs = new MCParagraphAttrs;
+            attrs = new (nothrow) MCParagraphAttrs;
 
         attrs -> flags |= p_flag;
         ((T *)((char *)attrs + p_field_offset))[0] = t_clamped_field;
@@ -1308,7 +1308,7 @@ static void setparagraphattr_color(MCParagraphAttrs*& attrs, uint32_t p_flag, si
         t_color = p_color . color;
 
     if (attrs == nil)
-        attrs = new MCParagraphAttrs;
+        attrs = new (nothrow) MCParagraphAttrs;
 
     attrs -> flags |= p_flag;
     ((uint32_t *)((char *)attrs + p_field_offset))[0] = MCColorGetPixel(t_color);
@@ -1327,7 +1327,7 @@ static void setparagraphattr_bool(MCParagraphAttrs*& attrs, uint32_t p_flag, boo
     else
     {
         if (attrs == nil)
-            attrs = new MCParagraphAttrs;
+            attrs = new (nothrow) MCParagraphAttrs;
 
         attrs -> flags |= p_flag;
         r_new_value = *p_value;
@@ -2527,7 +2527,7 @@ void MCParagraph::SetTextAlign(MCExecContext& ctxt, intenum_t* p_value)
         t_value = *p_value >> F_ALIGNMENT_SHIFT;
         
         if (attrs == nil)
-            attrs = new MCParagraphAttrs;
+            attrs = new (nothrow) MCParagraphAttrs;
         attrs -> flags |= PA_HAS_TEXT_ALIGN;
         attrs -> text_align = t_value;
     }
@@ -2574,7 +2574,7 @@ void MCParagraph::SetListDepth(MCExecContext& ctxt, uinteger_t* p_depth)
     }
 
     if (attrs == nil)
-        attrs = new MCParagraphAttrs;
+        attrs = new (nothrow) MCParagraphAttrs;
 
     if ((attrs -> flags & PA_HAS_LIST_STYLE) == 0)
     {
@@ -2731,7 +2731,7 @@ void MCParagraph::DoSetTabStops(MCExecContext &ctxt, bool p_is_relative, const v
     MCInterfaceTabStopsParse(ctxt, p_is_relative, p_tabs . elements, p_tabs . count, t_new_tabs, t_new_count);
 
     if (attrs == nil)
-        attrs = new MCParagraphAttrs;
+        attrs = new (nothrow) MCParagraphAttrs;
     else
         delete attrs -> tabs;
 
@@ -2849,7 +2849,7 @@ void MCParagraph::GetEffectiveTabAlignments(MCExecContext& ctxt, MCInterfaceFiel
 void MCParagraph::SetTabAlignments(MCExecContext& ctxt, const MCInterfaceFieldTabAlignments& p_alignments)
 {
     if (attrs == nil)
-        attrs = new MCParagraphAttrs;
+        attrs = new (nothrow) MCParagraphAttrs;
     else
         delete attrs -> alignments;
     
@@ -3072,7 +3072,7 @@ void MCParagraph::SetMetadata(MCExecContext& ctxt, MCStringRef p_metadata)
     else
     {
         if (attrs == nil)
-            attrs = new MCParagraphAttrs;
+            attrs = new (nothrow) MCParagraphAttrs;
 
         attrs -> flags |= PA_HAS_METADATA;
         MCValueInter(p_metadata, attrs -> metadata);
@@ -3123,7 +3123,7 @@ void MCBlock::SetLinktext(MCExecContext& ctxt, MCStringRef p_linktext)
     else
     {
         if (atts == nil)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
 
         /* UNCHECKED */ MCValueInter(p_linktext, atts -> linktext);
 
@@ -3151,7 +3151,7 @@ void MCBlock::SetMetadata(MCExecContext& ctxt, MCStringRef p_metadata)
     else
     {
         if (atts == nil)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
 
         /* UNCHECKED */ MCValueInter((MCStringRef)p_metadata, atts -> metadata);
 
@@ -3183,7 +3183,7 @@ void MCBlock::SetImageSource(MCExecContext& ctxt, MCStringRef p_image_source)
     else
     {
         if (atts == NULL)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
 
         /* UNCHECKED */ MCValueInter(p_image_source, atts -> imagesource);
 
@@ -3245,7 +3245,7 @@ void MCBlock::SetTextFont(MCExecContext& ctxt, MCStringRef p_fontname)
     else
     {
         if (atts == nil)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
         
         flags |= F_HAS_FNAME;
         /* UNCHECKED */ MCNameCreate(p_fontname, atts -> fontname);
@@ -3268,7 +3268,7 @@ void MCBlock::SetTextSize(MCExecContext& ctxt, uinteger_t* p_size)
     else
     {
         if (atts == NULL)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
         flags |= F_HAS_FSIZE;
         atts -> fontsize = *p_size;
     }
@@ -3288,7 +3288,7 @@ void MCBlock::SetTextStyle(MCExecContext& ctxt, const MCInterfaceTextStyle& p_st
     else
     {
         if (atts == NULL)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
         flags |= F_HAS_FSTYLE;
         atts -> fontstyle = p_style . style;
     }
@@ -3310,7 +3310,7 @@ void MCBlock::SetTextShift(MCExecContext& ctxt, integer_t* p_shift)
     else
     {
         if (atts == NULL)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
         atts->shift = *p_shift;
         flags |= F_HAS_SHIFT;
     }
@@ -3396,7 +3396,7 @@ void MCBlock::SetTextStyleElement(MCExecContext& ctxt, MCNameRef p_index, bool p
     if (MCF_parsetextstyle(MCNameGetString(p_index), t_text_style) == ES_NORMAL)
     {
         if (atts == NULL)
-            atts = new Blockatts;
+            atts = new (nothrow) Blockatts;
         
         // AL-2014-09-23 [[ Bug 13509 ]] Check F_HAS_FSTYLE when adding block attribute
         if (!getflag(F_HAS_FSTYLE))

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -236,14 +236,14 @@ void MCGraphic::SetEditMode(MCExecContext& ctxt, intenum_t mode)
 		{
 		case kMCEditModeFillGradient:
 			if (m_fill_gradient != NULL)
-				t_new_tool = new MCGradientEditTool(this, m_fill_gradient, t_new_mode);
+				t_new_tool = new (nothrow) MCGradientEditTool(this, m_fill_gradient, t_new_mode);
 			break;
 		case kMCEditModeStrokeGradient:
 			if (m_stroke_gradient != NULL)
-				t_new_tool = new MCGradientEditTool(this, m_stroke_gradient, t_new_mode);
+				t_new_tool = new (nothrow) MCGradientEditTool(this, m_stroke_gradient, t_new_mode);
 			break;
 		case kMCEditModePolygon:
-			t_new_tool = new MCPolygonEditTool(this);
+			t_new_tool = new (nothrow) MCPolygonEditTool(this);
 			break;
 		}
 		m_edit_tool = t_new_tool;
@@ -904,7 +904,7 @@ void MCGraphic::GetEffectivePoints(MCExecContext &ctxt, uindex_t &r_count, MCPoi
         case F_G_RECTANGLE:
         {
             nfakepoints = 4;
-            fakepoints = new MCPoint[nfakepoints];
+            fakepoints = new (nothrow) MCPoint[nfakepoints];
             get_points_for_rect(fakepoints, nfakepoints);
             DoCopyPoints(ctxt, nfakepoints, fakepoints, r_count, r_points);
             delete[] fakepoints;
@@ -913,7 +913,7 @@ void MCGraphic::GetEffectivePoints(MCExecContext &ctxt, uindex_t &r_count, MCPoi
         case F_REGULAR:
         {
             nfakepoints = nsides;
-            fakepoints = new MCPoint[nsides];
+            fakepoints = new (nothrow) MCPoint[nsides];
             get_points_for_regular_polygon(fakepoints, nfakepoints);
             DoCopyPoints(ctxt, nfakepoints, fakepoints, r_count, r_points);
             delete[] fakepoints;
@@ -960,7 +960,7 @@ void MCGraphic::GetEffectiveRelativePoints(MCExecContext &ctxt, uindex_t &r_coun
         case F_G_RECTANGLE:
         {
             nfakepoints = 4;
-            fakepoints = new MCPoint[nfakepoints];
+            fakepoints = new (nothrow) MCPoint[nfakepoints];
             get_points_for_rect(fakepoints, nfakepoints);
             MCU_offset_points(fakepoints, nfakepoints, -trect.x, -trect.y);
             DoCopyPoints(ctxt, nfakepoints, fakepoints, r_count, r_points);
@@ -970,7 +970,7 @@ void MCGraphic::GetEffectiveRelativePoints(MCExecContext &ctxt, uindex_t &r_coun
         case F_REGULAR:
         {
             nfakepoints = nsides;
-            fakepoints = new MCPoint[nsides];
+            fakepoints = new (nothrow) MCPoint[nsides];
             get_points_for_regular_polygon(fakepoints, nfakepoints);
             MCU_offset_points(fakepoints, nfakepoints, -trect.x, -trect.y);
             DoCopyPoints(ctxt, nfakepoints, fakepoints, r_count, r_points);

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1714,7 +1714,7 @@ void MCObject::SetParentScript(MCExecContext& ctxt, MCStringRef new_parent_scrip
 
 	// Create a new chunk object to parse the reference into
 	MCChunk *t_chunk;
-	t_chunk = new MCChunk(False);
+	t_chunk = new (nothrow) MCChunk(False);
 
 	// Attempt to parse a chunk. We also check that there is no 'junk' at
 	// the end of the string - if there is, its an error. Note the errorlock

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1194,7 +1194,7 @@ void MCStack::SetSubstacks(MCExecContext& ctxt, MCStringRef p_substacks)
 				t_was_mainstack = MCdispatcher -> ismainstack(toclone) == True;	
 
 				if (toclone != nil)
-					tsub = new MCStack(*toclone);
+					tsub = new (nothrow) MCStack(*toclone);
 			}
 			else
 			{
@@ -1598,7 +1598,7 @@ void MCStack::SetLinkAtt(MCExecContext& ctxt, Properties which, MCInterfaceNamed
 	{
 		if (linkatts == nil)
 		{
-			/* UNCHECKED */ linkatts = new Linkatts;
+			/* UNCHECKED */ linkatts = new (nothrow) Linkatts;
 			MCMemoryCopy(linkatts, &MClinkatts, sizeof(Linkatts));
 			linkatts->colorname = MClinkatts.colorname == nil ? nil : MCValueRetain(MClinkatts.colorname);
 			linkatts->hilitecolorname = MClinkatts.hilitecolorname == nil ? nil : MCValueRetain(MClinkatts.hilitecolorname);
@@ -1724,7 +1724,7 @@ void MCStack::SetUnderlineLinks(MCExecContext& ctxt, bool* p_value)
     {
         if (linkatts == nil)
         {
-            /* UNCHECKED */ linkatts = new Linkatts;
+            /* UNCHECKED */ linkatts = new (nothrow) Linkatts;
             MCMemoryCopy(linkatts, &MClinkatts, sizeof(Linkatts));
             linkatts->colorname = MClinkatts.colorname == nil ? nil : MCValueRetain(MClinkatts.colorname);
             linkatts->hilitecolorname = MClinkatts.hilitecolorname == nil ? nil : MCValueRetain(MClinkatts.hilitecolorname);

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -377,7 +377,7 @@ bool MCInterfaceTryToResolveObject(MCExecContext& ctxt, MCStringRef long_id, MCO
 	bool t_found;
 	t_found = false;
 	
-	MCChunk *tchunk = new MCChunk(False);
+	MCChunk *tchunk = new (nothrow) MCChunk(False);
 	MCerrorlock++;
 	MCScriptPoint sp(long_id);
 	if (tchunk->parse(sp, False) == PS_NORMAL)
@@ -1530,43 +1530,43 @@ void MCInterfaceExecResetTemplate(MCExecContext& ctxt, Reset_type p_type)
 	{
 		case RT_TEMPLATE_AUDIO_CLIP:
 			delete MCtemplateaudio;
-			MCtemplateaudio = new MCAudioClip;
+			MCtemplateaudio = new (nothrow) MCAudioClip;
 			break;
 		case RT_TEMPLATE_BUTTON:
 			delete MCtemplatebutton;
-			MCtemplatebutton = new MCButton;
+			MCtemplatebutton = new (nothrow) MCButton;
 			break;
 		case RT_TEMPLATE_CARD:
 			delete MCtemplatecard;
-			MCtemplatecard = new MCCard;
+			MCtemplatecard = new (nothrow) MCCard;
 			break;
 		case RT_TEMPLATE_EPS:
 			delete MCtemplateeps;
-			MCtemplateeps = new MCEPS;
+			MCtemplateeps = new (nothrow) MCEPS;
 			break;
 		case RT_TEMPLATE_FIELD:
 			delete MCtemplatefield;
-			MCtemplatefield = new MCField;
+			MCtemplatefield = new (nothrow) MCField;
 			break;
 		case RT_TEMPLATE_GRAPHIC:
 			delete MCtemplategraphic;
-			MCtemplategraphic = new MCGraphic;
+			MCtemplategraphic = new (nothrow) MCGraphic;
 			break;
 		case RT_TEMPLATE_GROUP:
 			delete MCtemplategroup;
-			MCtemplategroup = new MCGroup;
+			MCtemplategroup = new (nothrow) MCGroup;
 			break;
 		case RT_TEMPLATE_IMAGE:
 			delete MCtemplateimage;
-			MCtemplateimage = new MCImage;
+			MCtemplateimage = new (nothrow) MCImage;
 			break;
 		case RT_TEMPLATE_SCROLLBAR:
 			delete MCtemplatescrollbar;
-			MCtemplatescrollbar = new MCScrollbar;
+			MCtemplatescrollbar = new (nothrow) MCScrollbar;
 			break;
 		case RT_TEMPLATE_PLAYER:
 			delete MCtemplateplayer;
-			MCtemplateplayer = new MCPlayer;
+			MCtemplateplayer = new (nothrow) MCPlayer;
 			break;
 		case RT_TEMPLATE_STACK:
 			delete MCtemplatestack;
@@ -1574,7 +1574,7 @@ void MCInterfaceExecResetTemplate(MCExecContext& ctxt, Reset_type p_type)
 			break;
 		case RT_TEMPLATE_VIDEO_CLIP:
 			delete MCtemplatevideo;
-			MCtemplatevideo = new MCVideoClip;
+			MCtemplatevideo = new (nothrow) MCVideoClip;
 			break;
 		default:
 			break;
@@ -2160,7 +2160,7 @@ void MCInterfaceProcessToContainer(MCExecContext& ctxt, MCObjectPtr *p_objects, 
 				t_object -> getstack() -> removeaclip(t_aclip);
 			}
 			else
-				t_aclip = new MCAudioClip(*static_cast<MCAudioClip *>(t_object));
+				t_aclip = new (nothrow) MCAudioClip(*static_cast<MCAudioClip *>(t_object));
 
 			t_new_object = t_aclip;
 			p_dst . object -> getstack() -> appendaclip(t_aclip);
@@ -2176,7 +2176,7 @@ void MCInterfaceProcessToContainer(MCExecContext& ctxt, MCObjectPtr *p_objects, 
 				t_object -> getstack() -> removevclip(t_aclip);
 			}
 			else
-				t_aclip = new MCVideoClip(*static_cast<MCVideoClip *>(t_object));
+				t_aclip = new (nothrow) MCVideoClip(*static_cast<MCVideoClip *>(t_object));
 
 			t_new_object = t_aclip;
 			p_dst . object -> getstack() -> appendvclip(t_aclip);
@@ -2674,7 +2674,7 @@ void MCInterfaceExecMoveObject(MCExecContext& ctxt, MCObject *p_target, MCPoint 
 		break;
 	}
 
-	MCPoint *t_motion = new MCPoint[p_motion_count];
+	MCPoint *t_motion = new (nothrow) MCPoint[p_motion_count];
 	for (uindex_t i = 0; i < p_motion_count; i++)
 		t_motion[i] = p_motion[i];
 
@@ -3328,7 +3328,7 @@ void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MC
         return;
     }
     
-    MCWidget* t_widget = new MCWidget();
+    MCWidget* t_widget = new (nothrow) MCWidget();
     if (t_widget == NULL)
         return;
     t_widget -> bind(p_kind, nil);
@@ -3801,7 +3801,7 @@ void MCInterfaceExecImportAudioClip(MCExecContext& ctxt, MCStringRef p_filename)
 
 	if (t_stream != NULL)
 	{
-		MCAudioClip *aptr = new MCAudioClip;
+		MCAudioClip *aptr = new (nothrow) MCAudioClip;
 		if (!aptr->import(p_filename, t_stream))
 		{
 			ctxt . LegacyThrow(EE_IMPORT_CANTREAD);
@@ -3827,7 +3827,7 @@ void MCInterfaceExecImportVideoClip(MCExecContext& ctxt, MCStringRef p_filename)
 
 	if (t_stream != NULL)
 	{
-		MCVideoClip *vptr = new MCVideoClip;
+		MCVideoClip *vptr = new (nothrow) MCVideoClip;
 		if (!vptr->import(p_filename, t_stream))
 		{
 			ctxt . LegacyThrow(EE_IMPORT_CANTREAD);
@@ -3907,7 +3907,7 @@ void MCInterfaceExecImportObjectFromArray(MCExecContext& ctxt, MCArrayRef p_arra
     }
     
     MCWidget *t_widget;
-    t_widget = new MCWidget;
+    t_widget = new (nothrow) MCWidget;
     if (t_widget == NULL)
         return;
     
@@ -4707,12 +4707,12 @@ void MCInterfaceExecVisualEffect(MCExecContext& ctxt, MCInterfaceVisualEffect p_
 {
 	MCEffectList *effectptr = MCcur_effects;
 	if (effectptr == nil)
-		MCcur_effects = effectptr = new MCEffectList;
+		MCcur_effects = effectptr = new (nothrow) MCEffectList;
 	else
 	{
 		while (effectptr->next != NULL)
 			effectptr = effectptr->next;
-		effectptr->next = new MCEffectList;
+		effectptr->next = new (nothrow) MCEffectList;
 		effectptr = effectptr->next;
 	}
 	
@@ -4732,7 +4732,7 @@ void MCInterfaceExecVisualEffect(MCExecContext& ctxt, MCInterfaceVisualEffect p_
 	{
         t_arg = p_effect . arguments[i];
 		MCEffectArgument *t_kv;
-		t_kv = new MCEffectArgument;
+		t_kv = new (nothrow) MCEffectArgument;
 		t_kv -> next = t_arguments;
 		t_kv -> key = MCValueRetain(t_arg . key);
 		t_kv -> value = MCValueRetain(t_arg . value);

--- a/engine/src/exec-legacy.cpp
+++ b/engine/src/exec-legacy.cpp
@@ -446,7 +446,7 @@ void MCLegacyExecImport(MCExecContext& ctxt, MCStringRef p_filename, bool p_is_s
 	}
 	else
 	{
-		MCEPS *eptr = new MCEPS;
+		MCEPS *eptr = new (nothrow) MCEPS;
 		if (!eptr->import(p_filename, t_stream))
 		{
             delete eptr;

--- a/engine/src/exec-misc.cpp
+++ b/engine/src/exec-misc.cpp
@@ -428,7 +428,7 @@ void MCMiscExecExportImageToAlbum(MCExecContext& ctxt, MCStringRef p_data_or_id,
         MCLog("Type not found", nil);
 		uint4 parid;
 		MCObject *objptr;
-		MCChunk *tchunk = new MCChunk(False);
+		MCChunk *tchunk = new (nothrow) MCChunk(False);
         MCerrorlock++;
 		MCScriptPoint sp(p_data_or_id);
 		Parse_stat stat = tchunk->parse(sp, False);

--- a/engine/src/exec-multimedia.cpp
+++ b/engine/src/exec-multimedia.cpp
@@ -627,7 +627,7 @@ void MCMultimediaExecPlayAudioClip(MCExecContext& ctxt, MCStack *p_target, int p
             /* UNCHECKED */ ctxt . ConvertToData(*t_url, &t_data);
             stream = MCS_fakeopen(MCDataGetBytePtr(*t_data), MCDataGetLength(*t_data));
 		}
-		MCacptr = new MCAudioClip;
+		MCacptr = new (nothrow) MCAudioClip;
 		MCacptr->setdisposable();
 		if (!MCacptr->import(p_clip, stream))
 		{

--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -1125,7 +1125,7 @@ void MCStringsMarkBytesOfTextByOrdinal(MCExecContext& ctxt, Chunk_term p_ordinal
 
 MCTextChunkIterator_Tokenized::MCTextChunkIterator_Tokenized(MCStringRef p_text, MCChunkType p_chunk_type) : MCTextChunkIterator(p_text, p_chunk_type)
 {
-    m_sp = new MCScriptPoint(p_text);
+    m_sp = new (nothrow) MCScriptPoint(p_text);
 }
 
 MCTextChunkIterator_Tokenized::MCTextChunkIterator_Tokenized(MCStringRef p_text, MCChunkType p_chunk_type, MCRange p_restriction) : MCTextChunkIterator(p_text, p_chunk_type, p_restriction)
@@ -1133,7 +1133,7 @@ MCTextChunkIterator_Tokenized::MCTextChunkIterator_Tokenized(MCStringRef p_text,
     MCAutoStringRef t_substring;
     MCStringCopySubstring(m_text, p_restriction, &t_substring);
     MCValueAssign(m_text, *t_substring);
-    m_sp = new MCScriptPoint(m_text);
+    m_sp = new (nothrow) MCScriptPoint(m_text);
 }
 
 MCTextChunkIterator_Tokenized::~MCTextChunkIterator_Tokenized()
@@ -1168,7 +1168,7 @@ MCTextChunkIterator *MCStringsTextChunkIteratorCreate(MCExecContext& ctxt, MCStr
     if (p_chunk_type == CT_TOKEN)
     {
         MCTextChunkIterator *tci;
-        tci = new MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type));
+        tci = new (nothrow) MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type));
         return tci;
     }
     
@@ -1180,7 +1180,7 @@ MCTextChunkIterator *MCStringsTextChunkIteratorCreateWithRange(MCExecContext& ct
     if (p_chunk_type == CT_TOKEN)
     {
         MCTextChunkIterator *tci;
-        tci = new MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type), p_range);
+        tci = new (nothrow) MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type), p_range);
         return tci;
     }
     

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -2025,7 +2025,7 @@ void MCStringsExecFilterWildcard(MCExecContext& ctxt, MCStringRef p_source, MCSt
 {
     // Create the pattern matcher
 	MCPatternMatcher *matcher;
-    matcher = new MCWildcardMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+    matcher = new (nothrow) MCWildcardMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
     MCStringsExecFilterDelimited(ctxt, p_source, p_without, p_lines ? ctxt . GetLineDelimiter() : ctxt . GetItemDelimiter(), matcher, r_result);
     
@@ -2036,7 +2036,7 @@ void MCStringsExecFilterRegex(MCExecContext& ctxt, MCStringRef p_source, MCStrin
 {
 	// Create the pattern matcher
 	MCPatternMatcher *matcher;
-    matcher = new MCRegexMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+    matcher = new (nothrow) MCRegexMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
     MCAutoStringRef t_regex_error;
     if (!matcher -> compile(&t_regex_error))
@@ -2215,7 +2215,7 @@ void MCStringsSort(MCSortnode *p_items, uint4 nitems, Sort_type p_dir, Sort_type
 {
     if (nitems > 1)
     {
-        MCSortnode *tmp = new MCSortnode[nitems];
+        MCSortnode *tmp = new (nothrow) MCSortnode[nitems];
         MCStringsDoSort(p_items, nitems, tmp, p_form, p_dir == ST_DESCENDING, p_options);
         delete[] tmp;
     }
@@ -2400,7 +2400,7 @@ static void MCStringsSortIndirect(uindex_t *p_items, uint4 nitems, comparator_t 
     if (nitems == 0)
         return;
     
-    uindex_t *tmp = new uindex_t[nitems];
+    uindex_t *tmp = new (nothrow) uindex_t[nitems];
     MCStringsDoSortIndirect(p_items, nitems, tmp, is_less_or_equal, context);
     delete[] tmp;
 }
@@ -2501,7 +2501,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
     t_temp_items = nil;
     if (p_by != nil)
     {
-        t_temp_items = new MCValueRef[p_count];
+        t_temp_items = new (nothrow) MCValueRef[p_count];
         MCerrorlock++;
         for(uindex_t i = 0; i < p_count; i++)
         {
@@ -2519,7 +2519,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
     
     // Build the vector of indicies to sort.
     uindex_t *t_indicies;
-    t_indicies = new uindex_t[p_count];
+    t_indicies = new (nothrow) uindex_t[p_count];
     for(uindex_t i = 0; i < p_count; i++)
         t_indicies[i] = i;
     
@@ -2535,7 +2535,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
         {
             // DateTime is sorted by seconds.
             double *t_seconds;
-            t_seconds = new double[p_count];
+            t_seconds = new (nothrow) double[p_count];
             for(uindex_t i = 0; i < p_count; i++)
             {
                 MCDateTime t_datetime;
@@ -2553,7 +2553,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
         case ST_NUMERIC:
         {
             double *t_numbers;
-            t_numbers = new double[p_count];
+            t_numbers = new (nothrow) double[p_count];
             for(uindex_t i = 0; i < p_count; i++)
             {
                 if (MCValueIsEmpty(t_items[i]))
@@ -2609,7 +2609,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
         case ST_BINARY:
         {
             MCDataRef *t_datas;
-            t_datas = new MCDataRef[p_count];
+            t_datas = new (nothrow) MCDataRef[p_count];
             for(uindex_t i = 0; i < p_count; i++)
             {
                 if (!ctxt . ConvertToData(t_items[i], t_datas[i]))
@@ -2636,7 +2636,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
             else
             {
                 MCStringRef *t_strings;
-                t_strings = new MCStringRef[p_count];
+                t_strings = new (nothrow) MCStringRef[p_count];
                 for(uindex_t i = 0; i < p_count; i++)
                 {
                     if (!ctxt . ConvertToString(t_items[i], t_strings[i]) ||
@@ -2660,7 +2660,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
             /* UNCHECKED */ MCUnicodeCreateCollator(kMCSystemLocale, t_options, t_collator);
             
             MCDataRef *t_datas;
-            t_datas = new MCDataRef[p_count];
+            t_datas = new (nothrow) MCDataRef[p_count];
             for(uindex_t i = 0; i < p_count; i++)
             {
                 MCAutoStringRef t_string;

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1329,7 +1329,7 @@ void MCExecContext::doscript(MCExecContext &ctxt, MCStringRef p_script, uinteger
         case PS_NORMAL:
             if (type == ST_ID)
                 if (sp.lookup(SP_COMMAND, te) != PS_NORMAL)
-                    newstatement = new MCComref(sp.gettoken_nameref());
+                    newstatement = new (nothrow) MCComref(sp.gettoken_nameref());
                 else
                 {
                     if (te->type != TT_STATEMENT)

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -361,7 +361,7 @@ Parse_stat MCExpression::getparams(MCScriptPoint &sp, MCParameter **params)
 	while (True)
 	{
 		if (pptr == NULL)
-			*params = pptr = new MCParameter;
+			*params = pptr = new (nothrow) MCParameter;
 		else
 		{
 			pptr->setnext(new MCParameter);

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -320,7 +320,7 @@ Exec_stat MCExternalV0::Handle(MCObject *p_context, Handler_type p_type, uint32_
     
     // Handling of memory allocation for C-strings
     MCExternalAllocPool *t_old_pool = MCexternalallocpool;
-    MCexternalallocpool = new MCExternalAllocPool;
+    MCexternalallocpool = new (nothrow) MCExternalAllocPool;
     
     (t_handler -> call)(args, nargs, &retval, &Xpass, &Xerr);
     
@@ -716,7 +716,7 @@ static char *show_image_by_id(const char *arg1, const char *arg2,
         /* UNCHECKED */ MCStringCreateWithCString(arg1, &arg1_str);
 		MCScriptPoint sp(*arg1_str);
 		MCChunk *t_chunk;
-		t_chunk = new MCChunk(False);
+		t_chunk = new (nothrow) MCChunk(False);
 		
 		Symbol_type t_next_type;
 		MCerrorlock++;
@@ -1256,7 +1256,7 @@ static char *show_image_by_id_utf8(const char *arg1, const char *arg2,
         /* UNCHECKED */ MCStringCreateWithBytes((byte_t*)arg1, strlen(arg1), kMCStringEncodingUTF8, false, &arg1_str);
 		MCScriptPoint sp(*arg1_str);
 		MCChunk *t_chunk;
-		t_chunk = new MCChunk(False);
+		t_chunk = new (nothrow) MCChunk(False);
 		
 		Symbol_type t_next_type;
 		MCerrorlock++;

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -961,7 +961,7 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 	t_parameter_vars = NULL;
 	if (t_parameter_count != 0)
 	{
-		t_parameter_vars = new MCExternalVariableRef[t_parameter_count];
+		t_parameter_vars = new (nothrow) MCExternalVariableRef[t_parameter_count];
 		if (t_parameter_vars == nil)
 			return ES_ERROR;
 	}
@@ -977,7 +977,7 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 			// reference).
 			
 			// MW-2014-01-22: [[ CompatV1 ]] Create a reference to the MCVariable.
-			t_parameter_vars[i] = new MCReferenceExternalVariable(t_var);
+			t_parameter_vars[i] = new (nothrow) MCReferenceExternalVariable(t_var);
 		}
 		else
 		{
@@ -995,7 +995,7 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 				MCExecContext ctxt(p_context, nil, nil);
 				
 				if (t_length == 0)
-					t_parameter_vars[i] = new MCReferenceExternalVariable(t_container -> getvar());
+					t_parameter_vars[i] = new (nothrow) MCReferenceExternalVariable(t_container -> getvar());
 				else
 					t_container -> eval(ctxt, &t_value);
 			}
@@ -1004,7 +1004,7 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 			
 			// MW-2014-01-22: [[ CompatV1 ]] Create a temporary value var.
 			if (*t_value != nil)
-				t_parameter_vars[i] = new MCTransientExternalVariable(*t_value);
+				t_parameter_vars[i] = new (nothrow) MCTransientExternalVariable(*t_value);
 		}
 	}
 
@@ -1241,7 +1241,7 @@ static MCExternalError MCExternalContextQuery(MCExternalContextQueryTag op, MCEx
         case kMCExternalContextQueryResult:
             // MW-2014-01-22: [[ CompatV1 ]] If the result shim hasn't been made, make it.
             if (s_external_v1_result == nil)
-                s_external_v1_result = new MCReferenceExternalVariable(MCresult);
+                s_external_v1_result = new (nothrow) MCReferenceExternalVariable(MCresult);
             *(MCExternalVariableRef *)result = s_external_v1_result;
             break;
         case kMCExternalContextQueryIt:
@@ -1387,7 +1387,7 @@ static MCExternalError MCExternalVariableCreate(MCExternalVariableRef* r_var)
     if (r_var == NULL)
         return kMCExternalErrorNoVariable;
 
-	*r_var = new MCTemporaryExternalVariable(kMCEmptyString);
+	*r_var = new (nothrow) MCTemporaryExternalVariable(kMCEmptyString);
     // SN-2015-06-02: [[ CID 90609 ]] Check that the pointed value has been allocated
 	if (*r_var == nil)
 		return kMCExternalErrorOutOfMemory;
@@ -2350,7 +2350,7 @@ static MCExternalError MCExternalObjectResolve(const char *p_long_id, MCExternal
 
 	// Create a new chunk object to parse the reference into
 	MCChunk *t_chunk;
-	t_chunk = new MCChunk(False);
+	t_chunk = new (nothrow) MCChunk(False);
 	if (t_chunk == nil)
 		t_error = kMCExternalErrorOutOfMemory;
 
@@ -2451,7 +2451,7 @@ static MCExternalError MCExternalObjectDispatch(MCExternalObjectRef p_object, MC
 	for(uint32_t i = 0; i < p_argc; i++)
 	{
 		MCParameter *t_param;
-		t_param = new MCParameter;
+		t_param = new (nothrow) MCParameter;
 		t_param -> setvalueref_argument(p_argv[i] -> GetValueRef());
 
 		if (t_last_param == nil)

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -274,7 +274,7 @@ MCField::MCField(const MCField &fref) : MCControl(fref)
     text_direction= fref.text_direction;
 	if (fref.vscrollbar != NULL)
 	{
-		vscrollbar = new MCScrollbar(*fref.vscrollbar);
+		vscrollbar = new (nothrow) MCScrollbar(*fref.vscrollbar);
 		vscrollbar->setparent(this);
 		vscrollbar->allowmessages(False);
 		vscrollbar->setflag(flags & F_3D, F_3D);
@@ -286,7 +286,7 @@ MCField::MCField(const MCField &fref) : MCControl(fref)
 		vscrollbar = NULL;
 	if (fref.hscrollbar != NULL)
 	{
-		hscrollbar = new MCScrollbar(*fref.hscrollbar);
+		hscrollbar = new (nothrow) MCScrollbar(*fref.hscrollbar);
 		hscrollbar->setparent(this);
 		hscrollbar->allowmessages(False);
 		hscrollbar->setflag(flags & F_3D, F_3D);
@@ -300,7 +300,7 @@ MCField::MCField(const MCField &fref) : MCControl(fref)
 	ntabs = fref.ntabs;
 	if (ntabs)
 	{
-		tabs = new uint2[ntabs];
+		tabs = new (nothrow) uint2[ntabs];
 		uint2 i;
 		for (i = 0 ; i < ntabs ; i++)
 			tabs[i] = fref.tabs[i];
@@ -310,7 +310,7 @@ MCField::MCField(const MCField &fref) : MCControl(fref)
     nalignments = fref.nalignments;
     if (nalignments)
     {
-        alignments = new intenum_t[ntabs];
+        alignments = new (nothrow) intenum_t[ntabs];
         uint2 i;
         for (i = 0; i < nalignments; i++)
             alignments[i] = fref.alignments[i];
@@ -322,7 +322,7 @@ MCField::MCField(const MCField &fref) : MCControl(fref)
 		MCCdata *fptr = fref.fdata;
 		do
 		{
-			MCCdata *newfdata = new MCCdata(*fptr);
+			MCCdata *newfdata = new (nothrow) MCCdata(*fptr);
 			newfdata->appendto(fdata);
 			fptr = fptr->next();
 		}
@@ -1744,7 +1744,7 @@ MCControl *MCField::clone(Boolean attach, Object_pos p, bool invisible)
 {
 	if (opened && fdata != NULL)
 		fdata->setparagraphs(paragraphs);
-	MCField *newfield = new MCField(*this);
+	MCField *newfield = new (nothrow) MCField(*this);
 	if (attach)
 		newfield->attach(p, invisible);
 	return newfield;
@@ -1810,7 +1810,7 @@ MCCdata *MCField::getdata(uint4 cardid, Boolean clone)
 		}
 		while (fptr != fdata);
 	}
-	MCCdata *newptr = new MCCdata(cardid);
+	MCCdata *newptr = new (nothrow) MCCdata(cardid);
 	return newptr;
 }
 
@@ -2773,7 +2773,7 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 	{
 		if ((stat = IO_read_uint2(&ntabs, stream)) != IO_NORMAL)
 			return checkloadstat(stat);
-		tabs = new uint2[ntabs];
+		tabs = new (nothrow) uint2[ntabs];
 		uint2 i;
 		for (i = 0 ; i < ntabs ; i++)
 			if ((stat = IO_read_uint2(&tabs[i], stream)) != IO_NORMAL)
@@ -2796,7 +2796,7 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 			return checkloadstat(stat);
 		if (type == OT_FDATA)
 		{
-			MCCdata *newfdata = new MCCdata;
+			MCCdata *newfdata = new (nothrow) MCCdata;
 			if ((stat = newfdata->load(stream, this, version)) != IO_NORMAL)
 			{
 				delete newfdata;
@@ -2809,7 +2809,7 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 			{
 				if (flags & F_VSCROLLBAR && vscrollbar == NULL)
 				{
-					vscrollbar = new MCScrollbar;
+					vscrollbar = new (nothrow) MCScrollbar;
 					vscrollbar->setparent(this);
 					if ((stat = vscrollbar->load(stream, version)) != IO_NORMAL)
 						return checkloadstat(stat);
@@ -2821,7 +2821,7 @@ IO_stat MCField::load(IO_handle stream, uint32_t version)
 				else
 					if (flags & F_HSCROLLBAR && hscrollbar == NULL)
 					{
-						hscrollbar = new MCScrollbar;
+						hscrollbar = new (nothrow) MCScrollbar;
 						hscrollbar->setparent(this);
 						if ((stat = hscrollbar->load(stream, version)) != IO_NORMAL)
 							return checkloadstat(stat);

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -379,7 +379,7 @@ MCCdata *MCField::getcarddata(MCCdata *&list, uint4 parid, Boolean create)
 	}
 	if (foundptr == NULL && create)
 	{
-		foundptr = new MCCdata(parid);
+		foundptr = new (nothrow) MCCdata(parid);
 		foundptr->appendto(list);
 	}
 	return foundptr;
@@ -1652,7 +1652,7 @@ Boolean MCField::deleteselection(Boolean force)
 
 		findex_t si, ei;
 		selectedmark(False, si, ei, False);
-		Ustruct *us = new Ustruct;
+		Ustruct *us = new (nothrow) Ustruct;
 		us->type = UT_DELETE_TEXT;
 		us->ud.text.index = si;
 		us->ud.text.data = cloneselection();
@@ -1877,7 +1877,7 @@ void MCField::finsertnew(Field_translations function, MCStringRef p_string, KeyS
 		else
 		{
 			MCundos->freestate();
-			us = new Ustruct;
+			us = new (nothrow) Ustruct;
 			us->type = UT_TYPE_TEXT;
 			
 			// MW-UNDO-FIX: Store the index this record starts at
@@ -1930,7 +1930,7 @@ void MCField::fdel(Field_translations function, MCStringRef p_string, KeySym key
 				focusedy -= focusedparagraph->getheight(fixedheight);
 				joinparagraphs();
 				firstparagraph = lastparagraph = NULL;
-				us = new Ustruct;
+				us = new (nothrow) Ustruct;
 				us->ud.text.newline = True;
 				us->ud.text.data = NULL;
 			}
@@ -1949,14 +1949,14 @@ void MCField::fdel(Field_translations function, MCStringRef p_string, KeySym key
 				{
 					joinparagraphs();
 					firstparagraph = lastparagraph = NULL;
-					us = new Ustruct;
+					us = new (nothrow) Ustruct;
 					us->ud.text.newline = True;
 					us->ud.text.data = NULL;
 				}
 			}
 			else
 			{
-				us = new Ustruct;
+				us = new (nothrow) Ustruct;
 				us->ud.text.data = undopgptr;
 				us->ud.text.newline = False;
 				updateparagraph(True, False);
@@ -2017,7 +2017,7 @@ void MCField::fcutline(Field_translations function, MCStringRef p_string, KeySym
 		joinparagraphs();
 		if (focusedparagraph->gettextsize())
 			state &= ~CS_PARTIAL;
-		cutptr = new MCParagraph;
+		cutptr = new (nothrow) MCParagraph;
 		cutptr->setparent(this);
 	}
 	else

--- a/engine/src/fieldh.cpp
+++ b/engine/src/fieldh.cpp
@@ -672,7 +672,7 @@ bool MCField::exportasformattedtext(uint32_t p_part_id, int32_t p_start_index, i
 bool MCField::importparagraph(MCParagraph*& x_paragraphs, const MCFieldParagraphStyle *p_style)
 {
 	MCParagraph *t_new_paragraph;
-	t_new_paragraph = new MCParagraph;
+	t_new_paragraph = new (nothrow) MCParagraph;
     
     // SN-2014-04-25 [[ Bug 12177 ]] Importing HTML was creating parent-less paragraphs,
     // thus sometimes causing crashing when the parent was accessed - mainly when getfontattrs() was needed
@@ -763,7 +763,7 @@ MCParagraph *MCField::texttoparagraphs(MCStringRef p_text)
 {
     // Create a new list of paragraphs
     MCParagraph *t_paragraphs;
-	t_paragraphs = new MCParagraph;
+	t_paragraphs = new (nothrow) MCParagraph;
 	t_paragraphs -> setparent(this);
 	t_paragraphs -> inittext();
 
@@ -830,7 +830,7 @@ bool MCField::converttoparagraphs(void *p_context, const MCTextParagraph *p_para
 		t_paragraph -> defrag();
 
 		MCParagraph *t_new_paragraph;
-		t_new_paragraph = new MCParagraph;
+		t_new_paragraph = new (nothrow) MCParagraph;
 		t_new_paragraph -> setparent(t_paragraph -> getparent());
 		t_new_paragraph -> inittext();
 
@@ -966,7 +966,7 @@ extern bool RTFRead(const char *p_rtf, uint4 p_length, MCTextConvertCallback p_w
 MCParagraph *MCField::rtftoparagraphs(MCStringRef p_data)
 {
 	MCParagraph *t_paragraphs;
-	t_paragraphs = new MCParagraph;
+	t_paragraphs = new (nothrow) MCParagraph;
 	t_paragraphs -> setparent(this);
 	t_paragraphs -> inittext();
 

--- a/engine/src/fieldrtf.cpp
+++ b/engine/src/fieldrtf.cpp
@@ -784,7 +784,7 @@ static bool export_rtf_emit_paragraphs(void *p_context, MCFieldExportEventType p
 
 			// A temporary buffer to store any native converted text in.
 			uint8_t *t_native_text;
-			t_native_text = new uint8_t[t_char_count];
+			t_native_text = new (nothrow) uint8_t[t_char_count];
 
 			// Loop until we are done.
 			while(t_char_count > 0)

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -598,7 +598,7 @@ Exec_stat MCField::settext(uint4 parid, MCStringRef p_text, Boolean formatted)
                 MCStringFindAndReplaceChar(t_paragraph_text, '\n', ' ', kMCStringOptionCompareExact);
 			}
 
-			MCParagraph *tpgptr = new MCParagraph;
+			MCParagraph *tpgptr = new (nothrow) MCParagraph;
 			tpgptr->setparent(this);
 			tpgptr->appendto(pgptr);
 
@@ -622,7 +622,7 @@ Exec_stat MCField::settext(uint4 parid, MCStringRef p_text, Boolean formatted)
 	}
 	else
 	{
-		pgptr = new MCParagraph;
+		pgptr = new (nothrow) MCParagraph;
 		pgptr->setparent(this);
 	}
 	setparagraphs(pgptr, parid);
@@ -1654,7 +1654,7 @@ MCParagraph *MCField::cloneselection()
 		{
 			if (pgptr->gethilite())
 			{
-				MCParagraph *tpgptr = new MCParagraph(*pgptr);
+				MCParagraph *tpgptr = new (nothrow) MCParagraph(*pgptr);
 				tpgptr->appendto(cutptr);
 			}
 			pgptr = pgptr->next();
@@ -1771,7 +1771,7 @@ void MCField::pastetext(MCParagraph *newtext, Boolean dodel)
 		Ustruct *us = MCundos->getstate();
 		if (us == NULL || MCundos->getobject() != this)
 		{
-			us = new Ustruct;
+			us = new (nothrow) Ustruct;
 			findex_t si, ei;
 			selectedmark(False, si, ei, False);
 			us->ud.text.index = si;
@@ -1819,7 +1819,7 @@ void MCField::movetext(MCParagraph *newtext, findex_t p_to_index)
 		Ustruct *us = MCundos->getstate();
 		if (us == NULL || MCundos->getobject() != this)
 		{
-			us = new Ustruct;
+			us = new (nothrow) Ustruct;
 			us->ud.text.index = si;
 			us->ud.text.newline = False;
 			us->ud.text.data = NULL;
@@ -1858,7 +1858,7 @@ void MCField::deletetext(findex_t si, findex_t ei)
 		return;
 
 	Ustruct *us;
-	us = new Ustruct;
+	us = new (nothrow) Ustruct;
 	us->type = UT_DELETE_TEXT;
 	us->ud.text.index=si;
 	us->ud.text.data = t_deleted_text;
@@ -1915,7 +1915,7 @@ void MCField::insertparagraph(MCParagraph *newtext)
 		oldstack = NULL;
 	do
 	{
-		MCParagraph *newptr = new MCParagraph(*pgptr);
+		MCParagraph *newptr = new (nothrow) MCParagraph(*pgptr);
 		newptr->setparent(this);
 		newptr->open(m_font);
 		tfptr->append(newptr);

--- a/engine/src/fieldstyledtext.cpp
+++ b/engine/src/fieldstyledtext.cpp
@@ -436,7 +436,7 @@ MCParagraph *MCField::styledtexttoparagraphs(MCArrayRef p_array)
 MCParagraph *MCField::parsestyledtextappendparagraph(MCArrayRef p_style, MCStringRef p_metadata, bool p_split, MCParagraph*& x_paragraphs)
 {
 	MCParagraph *t_new_paragraph;
-	t_new_paragraph = new MCParagraph;
+	t_new_paragraph = new (nothrow) MCParagraph;
 	t_new_paragraph -> setparent(this);
 	t_new_paragraph -> inittext();
 	

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -144,7 +144,7 @@ Parse_stat MCFunction::parsetarget(MCScriptPoint &sp, Boolean the,
 	initpoint(sp);
 	if (sp.skip_token(SP_FACTOR, TT_OF) == PS_NORMAL)
 	{
-		object = new MCChunk(False);
+		object = new (nothrow) MCChunk(False);
 		if (object->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add
@@ -163,7 +163,7 @@ Parse_stat MCFunction::parsetarget(MCScriptPoint &sp, Boolean the,
 			}
 			if (!needone && sp.skip_token(SP_FACTOR, TT_RPAREN) == PS_NORMAL)
 				return PS_NORMAL;
-			object = new MCChunk(False);
+			object = new (nothrow) MCChunk(False);
 			if (object->parse(sp, False) != PS_NORMAL)
 			{
 				MCperror->add
@@ -1034,8 +1034,8 @@ Parse_stat MCIntersect::parse(MCScriptPoint &sp, Boolean the)
 		return PS_ERROR;
 	}
 	
-	o1 = new MCChunk(False);
-	o2 = new MCChunk(False);
+	o1 = new (nothrow) MCChunk(False);
+	o2 = new (nothrow) MCChunk(False);
 	
 	Symbol_type stype;
 	if (o1->parse(sp, False) != PS_NORMAL
@@ -1542,7 +1542,7 @@ Parse_stat MCSelectedButton::parse(MCScriptPoint &sp, Boolean the)
 	}
 	if (sp.skip_token(SP_FACTOR, TT_OF) == PS_NORMAL)
 	{
-		object = new MCChunk(False);
+		object = new (nothrow) MCChunk(False);
 		if (object->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_SELECTEDBUTTON_NOOBJECT, sp);
@@ -2283,7 +2283,7 @@ Parse_stat MCValue::parse(MCScriptPoint &sp, Boolean the)
 		}
 		if (type == ST_SEP)
 		{
-			object = new MCChunk(False);
+			object = new (nothrow) MCChunk(False);
 			if (object->parse(sp, False) != PS_NORMAL)
 			{
 				MCperror->add(PE_VALUE_BADOBJECT, sp);
@@ -2368,7 +2368,7 @@ Parse_stat MCWithin::parse(MCScriptPoint &sp, Boolean the)
 		MCperror->add(PE_FACTOR_NOLPAREN, sp);
 		return PS_ERROR;
 	}
-	object = new MCChunk(False);
+	object = new (nothrow) MCChunk(False);
 	if (object->parse(sp, False) != PS_NORMAL)
 	{
 		MCperror->add(PE_WITHIN_NOOBJECT, sp);
@@ -3076,7 +3076,7 @@ Parse_stat MCMeasureText::parse(MCScriptPoint &sp, Boolean the)
 	}
 	
 	Symbol_type type;
-	m_object = new MCChunk(False);
+	m_object = new (nothrow) MCChunk(False);
 	if (sp.next(type) != PS_NORMAL || type != ST_SEP
         || m_object->parse(sp, False) != PS_NORMAL)
 	{

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1045,8 +1045,8 @@ X_open_environment_variables(MCStringRef envp[])
 
 bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 {
-	MCperror = new MCError();
-	MCeerror = new MCError();
+	MCperror = new (nothrow) MCError();
+	MCeerror = new (nothrow) MCError();
 	/* UNCHECKED */ MCVariable::createwithname(MCNAME("MCresult"), MCresult);
     MCresultmode = kMCExecResultModeReturn;
 
@@ -1083,7 +1083,7 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
     
     ////
     
-	MCpatternlist = new MCImageList();
+	MCpatternlist = new (nothrow) MCImageList();
 
 	/* UNCHECKED */ MCVariable::ensureglobal(MCN_msg, MCmb);
 	MCmb -> setmsg();
@@ -1135,31 +1135,31 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
     MCDeletedObjectsSetup();
 
 	/* UNCHECKED */ MCStackSecurityCreateStack(MCtemplatestack);
-	MCtemplateaudio = new MCAudioClip;
+	MCtemplateaudio = new (nothrow) MCAudioClip;
 	MCtemplateaudio->init();
-	MCtemplatevideo = new MCVideoClip;
-	MCtemplategroup = new MCGroup;
-	MCtemplatecard = new MCCard;
-	MCtemplatebutton = new MCButton;
-	MCtemplategraphic = new MCGraphic;
-	MCtemplatescrollbar = new MCScrollbar;
-	MCtemplateplayer = new MCPlayer;
-	MCtemplateimage = new MCImage;
-	MCtemplatefield = new MCField;
+	MCtemplatevideo = new (nothrow) MCVideoClip;
+	MCtemplategroup = new (nothrow) MCGroup;
+	MCtemplatecard = new (nothrow) MCCard;
+	MCtemplatebutton = new (nothrow) MCButton;
+	MCtemplategraphic = new (nothrow) MCGraphic;
+	MCtemplatescrollbar = new (nothrow) MCScrollbar;
+	MCtemplateplayer = new (nothrow) MCPlayer;
+	MCtemplateimage = new (nothrow) MCImage;
+	MCtemplatefield = new (nothrow) MCField;
 	
-	MCtooltip = new MCTooltip;
+	MCtooltip = new (nothrow) MCTooltip;
 
     MCclipboard = MCClipboard::CreateSystemClipboard();
     MCdragboard = MCClipboard::CreateSystemDragboard();
     MCselection = MCClipboard::CreateSystemSelectionClipboard();
     MCclipboardlockcount = 0;
 	
-	MCundos = new MCUndolist;
-	MCselected = new MCSellist;
-	MCstacks = new MCStacklist;
-    MCtodestroy = new MCStacklist;
-	MCrecent = new MCCardlist;
-	MCcstack = new MCCardlist;
+	MCundos = new (nothrow) MCUndolist;
+	MCselected = new (nothrow) MCSellist;
+	MCstacks = new (nothrow) MCStacklist;
+    MCtodestroy = new (nothrow) MCStacklist;
+	MCrecent = new (nothrow) MCCardlist;
+	MCcstack = new (nothrow) MCCardlist;
 
 #ifdef _LINUX_DESKTOP
 	MCValueAssign(MCvcplayer, MCSTR("xanim"));
@@ -1181,7 +1181,7 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 		MCValueAssign(MCstackfiletype, MCSTR("RevoRSTK"));
 	MCValueAssign(MCserialcontrolsettings, MCSTR("baud=9600 parity=N data=8 stop=1"));
 
-	MCdispatcher = new MCDispatch;
+	MCdispatcher = new (nothrow) MCDispatch;
     MCdispatcher -> add_transient_stack(MCtooltip);
 
 	// IM-2014-08-14: [[ Bug 12372 ]] Pixel scale setup needs to happen before the
@@ -1190,7 +1190,7 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 	MCResInitPixelScaling();
 	
 	if (MCnoui)
-		MCscreen = new MCUIDC;
+		MCscreen = new (nothrow) MCUIDC;
 	else
 	{
 		MCscreen = MCCreateScreenDC();
@@ -1209,7 +1209,7 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 	MCdispatcher -> open();
 
 	// This is here because it relies on MCscreen being initialized.
-	MCtemplateeps = new MCEPS;
+	MCtemplateeps = new (nothrow) MCEPS;
 
 	MCsystemFS = MCscreen -> hasfeature(PLATFORM_FEATURE_OS_FILE_DIALOGS);
 	MCsystemCS = MCscreen -> hasfeature(PLATFORM_FEATURE_OS_COLOR_DIALOGS);
@@ -1235,7 +1235,7 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 	MCsystemprinter = MCprinter = MCscreen -> createprinter();
 	MCprinter -> Initialize();
 	
-    MCwidgeteventmanager = new MCWidgetEventManager;
+    MCwidgeteventmanager = new (nothrow) MCWidgetEventManager;
     
 	// MW-2009-07-02: Clear the result as a startup failure will be indicated
 	//   there.

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -76,13 +76,13 @@ static Exec_stat MCGradientFillLookupProperty(MCNameRef p_token, MCGradientFillP
 
 void MCGradientFillInit(MCGradientFill *&r_gradient, MCRectangle p_rect)
 {
-	r_gradient = new MCGradientFill;
+	r_gradient = new (nothrow) MCGradientFill;
 	r_gradient->kind = kMCGradientKindLinear;
 	r_gradient->quality = kMCGradientQualityNormal;
 	r_gradient->mirror = false;
 	r_gradient->wrap = false;
 	r_gradient->repeat = 1;
-	r_gradient->ramp = new MCGradientFillStop[2];
+	r_gradient->ramp = new (nothrow) MCGradientFillStop[2];
 	r_gradient->ramp[0].offset = 0;
 	r_gradient->ramp[0].color = MCGPixelPack(kMCGPixelFormatBGRA, 0, 0, 0, 255); // black
 	r_gradient->ramp[0].hw_color = MCGPixelPackNative(0, 0, 0, 255);
@@ -112,11 +112,11 @@ MCGradientFill *MCGradientFillCopy(const MCGradientFill *p_gradient)
 	if (p_gradient == NULL)
 		return NULL;
 
-	MCGradientFill *t_gradient = new MCGradientFill;
+	MCGradientFill *t_gradient = new (nothrow) MCGradientFill;
 	t_gradient->kind = p_gradient->kind;
 	
 	t_gradient->ramp_length = p_gradient->ramp_length;
-	t_gradient->ramp = new MCGradientFillStop[t_gradient->ramp_length];
+	t_gradient->ramp = new (nothrow) MCGradientFillStop[t_gradient->ramp_length];
 
 	memcpy(t_gradient->ramp, p_gradient->ramp, sizeof(MCGradientFillStop)*t_gradient->ramp_length);
 
@@ -709,7 +709,7 @@ IO_stat MCGradientFillUnserialize(MCGradientFill *p_gradient, MCObjectInputStrea
 	{
 		if (p_gradient != NULL)
 			delete[] p_gradient -> ramp; /* Allocated with new[] */
-		p_gradient -> ramp = new MCGradientFillStop[p_gradient -> ramp_length];
+		p_gradient -> ramp = new (nothrow) MCGradientFillStop[p_gradient -> ramp_length];
 		for(int i = 0; i < p_gradient -> ramp_length && t_stat == IO_NORMAL; ++i)
 		{
 			uint16_t t_offset;
@@ -805,7 +805,7 @@ void MCGradientFillUnserialize(MCGradientFill *p_gradient, uint1 *p_data, uint4 
 
 	if (p_gradient->ramp != NULL)
 		delete p_gradient->ramp;
-	p_gradient->ramp = new MCGradientFillStop[p_gradient->ramp_length];
+	p_gradient->ramp = new (nothrow) MCGradientFillStop[p_gradient->ramp_length];
 
 	for (uint4 i = 0; i < p_gradient->ramp_length; i++)
 	{

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -130,18 +130,18 @@ MCGraphic::MCGraphic(const MCGraphic &gref) : MCControl(gref)
 	markerlsize = gref.markerlsize;
 	if (gref.dashes != NULL)
 	{
-		dashes = new uint1[ndashes];
+		dashes = new (nothrow) uint1[ndashes];
 		memcpy(dashes, gref.dashes, ndashes);
 	}
 	else
 		dashes = NULL;
 	points = NULL;
 	if (gref.realpoints != NULL)
-		realpoints = new MCPoint[nrealpoints];
+		realpoints = new (nothrow) MCPoint[nrealpoints];
 	else
 		realpoints = NULL;
 	if (gref.markerpoints != NULL)
-		markerpoints = new MCPoint[nmarkerpoints];
+		markerpoints = new (nothrow) MCPoint[nmarkerpoints];
 	else
 		markerpoints = NULL;
 	uint2 i;
@@ -247,7 +247,7 @@ Boolean MCGraphic::mfocus(int2 x, int2 y)
 	        && (getstyleint(flags) == F_CURVE || getstyleint(flags) == F_POLYGON
 	            || getstyleint(flags) == F_LINE))
 	{
-		realpoints = new MCPoint[MCscreen->getmaxpoints()];
+		realpoints = new (nothrow) MCPoint[MCscreen->getmaxpoints()];
 		MCU_snap(rect.x);
 		MCU_snap(rect.y);
 		startx = rect.x;
@@ -437,7 +437,7 @@ void MCGraphic::applyrect(const MCRectangle &nrect)
 			MCRectangle trect = reduce_minrect(nrect);
 			if (oldpoints == NULL)
 			{
-				oldpoints = new MCPoint[nrealpoints];
+				oldpoints = new (nothrow) MCPoint[nrealpoints];
 				uint2 i = nrealpoints;
 				while (i--)
 					oldpoints[i] = realpoints[i];
@@ -590,7 +590,7 @@ bool MCGraphic::get_points_for_oval(MCPoint*& r_points, uint2& r_point_count)
 // MW-2011-11-23: [[ Array Chunk Props ]] Add 'effective' param to arrayprop access.
 MCControl *MCGraphic::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCGraphic *newgraphic = new MCGraphic(*this);
+	MCGraphic *newgraphic = new (nothrow) MCGraphic(*this);
 	if (attach)
 		newgraphic->attach(p, invisible);
 	return newgraphic;
@@ -1046,7 +1046,7 @@ void MCGraphic::closepolygon(MCPoint *&pts, uint2 &npts)
 		
         if (t_count)
 		{
-			MCPoint *newpts = new MCPoint[npts+t_count] ;
+			MCPoint *newpts = new (nothrow) MCPoint[npts+t_count] ;
 			startpt = pts ;
 			MCPoint *currentpt = newpts ;
 			*(currentpt++) = pts[0] ;
@@ -1142,7 +1142,7 @@ void MCGraphic::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool
 			npoints = nsides + 1;
 			if (points != NULL)
 				delete points;
-			points = new MCPoint[npoints];
+			points = new (nothrow) MCPoint[npoints];
 		}
 		// MDW-2014-06-18: [[ rect_points ]] refactored
 		get_points_for_regular_polygon(points, npoints);
@@ -1893,7 +1893,7 @@ IO_stat MCGraphic::load(IO_handle stream, uint32_t version)
 			return checkloadstat(stat);
 		if (nmarkerpoints != 0)
 		{
-			markerpoints = new MCPoint[nmarkerpoints];
+			markerpoints = new (nothrow) MCPoint[nmarkerpoints];
 			for (i = 0 ; i < nmarkerpoints ; i++)
 			{
 				if ((stat = IO_read_int2(&markerpoints[i].x, stream)) != IO_NORMAL)
@@ -1910,7 +1910,7 @@ IO_stat MCGraphic::load(IO_handle stream, uint32_t version)
 			return checkloadstat(stat);
 		if (nrealpoints != 0)
 		{
-			realpoints = new MCPoint[nrealpoints];
+			realpoints = new (nothrow) MCPoint[nrealpoints];
 			for (i = 0 ; i < nrealpoints ; i++)
 			{
 				if ((stat = IO_read_int2(&realpoints[i].x, stream)) != IO_NORMAL)
@@ -1932,7 +1932,7 @@ IO_stat MCGraphic::load(IO_handle stream, uint32_t version)
 		if (ndashes != 0)
 		{
 			flags |= F_DASHES;
-			dashes = new uint1[ndashes];
+			dashes = new (nothrow) uint1[ndashes];
 			for (i = 0 ; i < ndashes ; i++)
 				if ((stat = IO_read_uint1(&dashes[i], stream)) != IO_NORMAL)
 					return checkloadstat(stat);

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -192,7 +192,7 @@ MCGroup::MCGroup(const MCGroup &gref, bool p_copy_ids) :
     // Copy the vertical scrollbar
 	if (gref.vscrollbar != NULL)
 	{
-		vscrollbar = new MCScrollbar(*gref.vscrollbar);
+		vscrollbar = new (nothrow) MCScrollbar(*gref.vscrollbar);
 		vscrollbar->setparent(this);
 		vscrollbar->allowmessages(False);
 		vscrollbar->setflag(flags & F_DISABLED, F_DISABLED);
@@ -202,7 +202,7 @@ MCGroup::MCGroup(const MCGroup &gref, bool p_copy_ids) :
     // Copy the horizontal scrollbar
 	if (gref.hscrollbar != NULL)
 	{
-		hscrollbar = new MCScrollbar(*gref.hscrollbar);
+		hscrollbar = new (nothrow) MCScrollbar(*gref.hscrollbar);
 		hscrollbar->setparent(this);
 		hscrollbar->allowmessages(False);
 		hscrollbar->setflag(flags & F_DISABLED, F_DISABLED);
@@ -1110,7 +1110,7 @@ MCControl *MCGroup::clone(Boolean attach, Object_pos p, bool invisible)
 MCControl *MCGroup::doclone(Boolean attach, Object_pos p, bool p_copy_ids, bool invisible)
 {
 	MCGroup *newgroup;
-	newgroup = new MCGroup(*this, p_copy_ids);
+	newgroup = new (nothrow) MCGroup(*this, p_copy_ids);
 
 	if (attach)
 	{
@@ -2722,7 +2722,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 		{
 		case OT_GROUP:
 			{
-				MCGroup *newgroup = new MCGroup;
+				MCGroup *newgroup = new (nothrow) MCGroup;
 				newgroup->setparent(this);
 				if ((stat = newgroup->load(stream, version)) != IO_NORMAL)
 				{
@@ -2741,7 +2741,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_BUTTON:
 			{
-				MCButton *newbutton = new MCButton;
+				MCButton *newbutton = new (nothrow) MCButton;
 				newbutton->setparent(this);
 				if ((stat = newbutton->load(stream, version)) != IO_NORMAL)
 				{
@@ -2754,7 +2754,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_FIELD:
 			{
-				MCField *newfield = new MCField;
+				MCField *newfield = new (nothrow) MCField;
 				newfield->setparent(this);
 				if ((stat = newfield->load(stream, version)) != IO_NORMAL)
 				{
@@ -2766,7 +2766,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_IMAGE:
 			{
-				MCImage *newimage = new MCImage;
+				MCImage *newimage = new (nothrow) MCImage;
 				newimage->setparent(this);
 				if ((stat = newimage->load(stream, version)) != IO_NORMAL)
 				{
@@ -2779,7 +2779,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_SCROLLBAR:
 			{
-				MCScrollbar *newscrollbar = new MCScrollbar;
+				MCScrollbar *newscrollbar = new (nothrow) MCScrollbar;
 				newscrollbar->setparent(this);
 				if ((stat = newscrollbar->load(stream, version)) != IO_NORMAL)
 				{
@@ -2805,7 +2805,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_GRAPHIC:
 			{
-				MCGraphic *newgraphic = new MCGraphic;
+				MCGraphic *newgraphic = new (nothrow) MCGraphic;
 				newgraphic->setparent(this);
 				if ((stat = newgraphic->load(stream, version)) != IO_NORMAL)
 				{
@@ -2817,7 +2817,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_MCEPS:
 			{
-				MCEPS *neweps = new MCEPS;
+				MCEPS *neweps = new (nothrow) MCEPS;
 				neweps->setparent(this);
 				if ((stat = neweps->load(stream, version)) != IO_NORMAL)
 				{
@@ -2829,7 +2829,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
         break;
         case OT_WIDGET:
         {
-            MCWidget *neweps = new MCWidget;
+            MCWidget *neweps = new (nothrow) MCWidget;
             neweps->setparent(this);
             if ((stat = neweps->load(stream, version)) != IO_NORMAL)
             {
@@ -2841,7 +2841,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
         break;
 		case OT_MAGNIFY:
 			{
-				MCMagnify *newmag = new MCMagnify;
+				MCMagnify *newmag = new (nothrow) MCMagnify;
 				newmag->setparent(this);
 				if ((stat = newmag->load(stream, version)) != IO_NORMAL)
 				{
@@ -2853,7 +2853,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_COLORS:
 			{
-				MCColors *newcolors = new MCColors;
+				MCColors *newcolors = new (nothrow) MCColors;
 				newcolors->setparent(this);
 				if ((stat = newcolors->load(stream, version)) != IO_NORMAL)
 				{
@@ -2865,7 +2865,7 @@ IO_stat MCGroup::load(IO_handle stream, uint32_t version)
 			break;
 		case OT_PLAYER:
 			{
-				MCPlayer *newplayer = new MCPlayer;
+				MCPlayer *newplayer = new (nothrow) MCPlayer;
 				newplayer->setparent(this);
 				if ((stat = newplayer->load(stream, version)) != IO_NORMAL)
 				{

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -260,7 +260,7 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 			}
 		}
 		if (type == ST_DATA)
-			newstatement = new MCEcho;
+			newstatement = new (nothrow) MCEcho;
 		else if (sp.lookup(SP_COMMAND, te) != PS_NORMAL)
 		{
 			if (type != ST_ID)
@@ -268,7 +268,7 @@ Parse_stat MCHandler::parse(MCScriptPoint &sp, Boolean isprop)
 				MCperror->add(PE_HANDLER_NOCOMMAND, sp);
 				return PS_ERROR;
 			}
-			newstatement = new MCComref(sp.gettoken_nameref());
+			newstatement = new (nothrow) MCComref(sp.gettoken_nameref());
 		}
 		else
 		{
@@ -328,7 +328,7 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 	if (newnparams == 0)
 		newparams = NULL;
 	else
-		newparams = new MCContainer *[newnparams];
+		newparams = new (nothrow) MCContainer *[newnparams];
     
 	Boolean err = False;
 	for (i = 0 ; i < newnparams ; i++)
@@ -362,7 +362,7 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
             // AL-2014-11-04: [[ Bug 13902 ]] If 'it' was this parameter's name then create the MCVarref as a
             //  param type, with this handler and param index, so that use of the get command syncs up correctly.
             if (i < npnames && MCNameIsEqualTo(pinfo[i] . name, MCN_it))
-                m_it = new MCVarref(this, i, True);
+                m_it = new (nothrow) MCVarref(this, i, True);
             
 			plist = plist->getnext();
 		}
@@ -405,7 +405,7 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 		vars = NULL;
 	else
 	{
-		vars = new MCVariable *[nvnames];
+		vars = new (nothrow) MCVariable *[nvnames];
 		i = nvnames;
 		while (i--)
 		{
@@ -588,14 +588,14 @@ Parse_stat MCHandler::findvar(MCNameRef p_name, MCVarref **dptr)
 	for (i = 0 ; i < nvnames ; i++)
 		if (MCNameIsEqualTo(p_name, vinfo[i] . name, kMCCompareCaseless))
 		{
-			*dptr = new MCVarref(this, i, False);
+			*dptr = new (nothrow) MCVarref(this, i, False);
 			return PS_NORMAL;
 		}
 
 	for (i = 0 ; i < npnames ; i++)
 		if (MCNameIsEqualTo(p_name, pinfo[i] . name, kMCCompareCaseless))
 	{
-			*dptr = new MCVarref(this, i, True);
+			*dptr = new (nothrow) MCVarref(this, i, True);
 			return PS_NORMAL;
 		}
 
@@ -644,7 +644,7 @@ Parse_stat MCHandler::newvar(MCNameRef p_name, MCValueRef p_init, MCVarref **r_r
 		}
 	}
 
-	*r_ref = new MCVarref(this, nvnames++, False);
+	*r_ref = new (nothrow) MCVarref(this, nvnames++, False);
 
 	return PS_NORMAL;
 }
@@ -655,7 +655,7 @@ Parse_stat MCHandler::findconstant(MCNameRef p_name, MCExpression **dptr)
 	for (i = 0 ; i < nconstants ; i++)
 		if (MCNameIsEqualTo(p_name, cinfo[i].name, kMCCompareCaseless))
 		{
-			*dptr = new MCLiteral(cinfo[i].value);
+			*dptr = new (nothrow) MCLiteral(cinfo[i].value);
 			return PS_NORMAL;
 		}
 	return hlist->findconstant(p_name, dptr);

--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -430,7 +430,7 @@ static uint2 convert_style(uint2 istyle)
 static char *convert_string(const char *string)
 {
 	const uint1 *sptr = (const uint1 *)string;
-	char *newstring = new char[strlen(string) + 1];
+	char *newstring = new (nothrow) char[strlen(string) + 1];
 	uint1 *dptr = (uint1 *)newstring;
 	while (*sptr)
 	{
@@ -475,7 +475,7 @@ static char *convert_script(const char *string)
 		sptr++;
 	}
 	sptr = (const uint1 *)string;
-	char *newstring = new char[length + conversions + 1];
+	char *newstring = new (nothrow) char[length + conversions + 1];
 	uint1 *dptr = (uint1 *)newstring;
 	while (*sptr)
 	{
@@ -587,7 +587,7 @@ Boolean MCHcsnd::import(uint4 inid, MCNameRef inname, char *sptr)
 		size = get_uint4(&sptr[hsize + 4]);
 	}
 	rate = (uint2)((real8)rate / pow(1.05946309434, (real8)baserate));
-	data = new int1[size];
+	data = new (nothrow) int1[size];
 	memcpy(data, sptr + hsize + 22, size);
 	uint1 *dptr = (uint1 *)data;
 	uint4 i = size;
@@ -598,7 +598,7 @@ Boolean MCHcsnd::import(uint4 inid, MCNameRef inname, char *sptr)
 
 MCAudioClip *MCHcsnd::build()
 {
-	MCAudioClip *aptr = new MCAudioClip;
+	MCAudioClip *aptr = new (nothrow) MCAudioClip;
 	aptr->size = size;
     aptr->setname(m_name);
 	aptr->samples = (int1 *)data;
@@ -647,7 +647,7 @@ IO_stat MCHctext::parse(char *sptr)
 			tsize -= natts;
 			offset = natts + 4;
 			natts = (natts >> 1) - 1;
-			atts = new uint2[natts + 1];
+			atts = new (nothrow) uint2[natts + 1];
 			uint2 i;
 			for (i = 0 ; i < natts ; i++)
 				atts[i] = swap_uint2(&uint2ptr[i + 3]);
@@ -658,7 +658,7 @@ IO_stat MCHctext::parse(char *sptr)
 			tsize--;
 			offset = 5;
 		}
-		char *newstring = new char[tsize + 1];
+		char *newstring = new (nothrow) char[tsize + 1];
 		strncpy(newstring, &sptr[offset], tsize);
 		newstring[tsize] = '\0';
 		string = convert_string(newstring);
@@ -669,7 +669,7 @@ IO_stat MCHctext::parse(char *sptr)
 
 MCCdata *MCHctext::buildf(MCHcstak *hcsptr, MCField *parent)
 {
-	MCCdata *fptr = new MCCdata(cid);
+	MCCdata *fptr = new (nothrow) MCCdata(cid);
 	if (string == NULL)
 		string = MCU_empty();
 	char *eptr = string;
@@ -694,7 +694,7 @@ MCCdata *MCHctext::buildf(MCHcstak *hcsptr, MCField *parent)
 		if (eptr != NULL)
 			*eptr++ = '\0';
 		uint2 length = strlen(sptr);
-		MCParagraph *pgptr = new MCParagraph;
+		MCParagraph *pgptr = new (nothrow) MCParagraph;
 		pgptr->setparent(parent);
 		MCAutoStringRef t_string;
 		/* UNCHECKED */ MCStringCreateWithNativeChars((const char_t*)sptr, length, &t_string);
@@ -751,7 +751,7 @@ MCCdata *MCHctext::buildf(MCHcstak *hcsptr, MCField *parent)
 
 MCCdata *MCHctext::buildb()
 {
-	MCCdata *bptr = new MCCdata(cid);
+	MCCdata *bptr = new (nothrow) MCCdata(cid);
 	bptr->setset(string[0] == '1');
 	return bptr;
 }
@@ -911,7 +911,7 @@ MCControl *MCHcfield::build(MCHcstak *hcsptr, MCStack *sptr)
 		if (!(fptr->flags & F_VSCROLLBAR))
 		{
 			fptr->flags |= F_VSCROLLBAR;
-			fptr->vscrollbar = new MCScrollbar(*MCtemplatescrollbar);
+			fptr->vscrollbar = new (nothrow) MCScrollbar(*MCtemplatescrollbar);
 			fptr->vscrollbar->setparent(fptr);
 			fptr->vscrollbar->allowmessages(False);
 			fptr->vscrollbar->setflag(False, F_TRAVERSAL_ON);
@@ -922,10 +922,10 @@ MCControl *MCHcfield::build(MCHcstak *hcsptr, MCStack *sptr)
 	if (hctstyle & HC_TSTYLE_OUTLINE)
 	{
 		fptr->ncolors = 1;
-		fptr->colors = new MCColor;
+		fptr->colors = new (nothrow) MCColor;
 		fptr->colors[0].red = fptr->colors[0].green
 		                      = fptr->colors[0].blue = MAXUINT2;
-		fptr->colornames = new MCStringRef[1];
+		fptr->colornames = new (nothrow) MCStringRef[1];
 		fptr->colornames[0] = nil;
 		fptr->dflags |= DF_FORE_COLOR;
 	}
@@ -1096,7 +1096,7 @@ MCControl *MCHcbutton::build(MCHcstak *hcsptr, MCStack *sptr)
 	uint4 iid = hcsptr->geticon(icon);
 	if (iid != 0)
 	{
-		bptr->icons = new iconlist;
+		bptr->icons = new (nothrow) iconlist;
 		memset(bptr->icons, 0, sizeof(iconlist));
 		bptr->icons->iconids[CI_DEFAULT] = iid;	
 		bptr->flags |= F_SHOW_ICON;
@@ -1124,16 +1124,16 @@ MCControl *MCHcbutton::build(MCHcstak *hcsptr, MCStack *sptr)
 	if (hctstyle & HC_TSTYLE_OUTLINE)
 	{
 		bptr->ncolors = 1;
-		bptr->colors = new MCColor;
+		bptr->colors = new (nothrow) MCColor;
 		bptr->colors[0].red = bptr->colors[0].green = bptr->colors[0].blue
 		                      = bptr->colors[0].blue = MAXUINT2;
-		bptr->colornames = new MCStringRef[1];
+		bptr->colornames = new (nothrow) MCStringRef[1];
 		bptr->colornames[0] = nil;
 		bptr->dflags |= DF_FORE_COLOR;
 	}
 	if (bptr->flags & F_SHARED_HILITE)
 	{
-		MCCdata *newbdata = new MCCdata(0);
+		MCCdata *newbdata = new (nothrow) MCCdata(0);
 		newbdata->setset(atts & HC_B_HILITED);
 		newbdata->appendto(bptr->bdata);
 	}
@@ -1432,7 +1432,7 @@ IO_stat MCHccard::parse(char *sptr)
 		offset = 27;
 	}
 	if (nobjects)
-		objects = new uint2[nobjects];
+		objects = new (nothrow) uint2[nobjects];
 	uint2 i;
 	for (i = 0 ; i < nobjects ; i++)
 	{
@@ -1441,7 +1441,7 @@ IO_stat MCHccard::parse(char *sptr)
 		{
 		case HC_OTYPE_BUTTON:
 			{
-				MCHcbutton *newbutton = new MCHcbutton;
+				MCHcbutton *newbutton = new (nothrow) MCHcbutton;
 				newbutton->appendto(hcbuttons);
 				if (newbutton->parse(&sptr[offset * 2]) != IO_NORMAL)
 					return IO_ERROR;
@@ -1449,7 +1449,7 @@ IO_stat MCHccard::parse(char *sptr)
 			break;
 		case HC_OTYPE_FIELD:
 			{
-				MCHcfield *newfield = new MCHcfield;
+				MCHcfield *newfield = new (nothrow) MCHcfield;
 				newfield->appendto(hcfields);
 				if (newfield->parse(&sptr[offset * 2]) != IO_NORMAL)
 					return IO_ERROR;
@@ -1465,7 +1465,7 @@ IO_stat MCHccard::parse(char *sptr)
 	offset <<= 1;
 	while (ntext--)
 	{
-		MCHctext *newtext = new MCHctext;
+		MCHctext *newtext = new (nothrow) MCHctext;
 		newtext->cid = id;
 		newtext->appendto(hctexts);
 		if (newtext->parse(&sptr[offset]) != IO_NORMAL)
@@ -1503,13 +1503,13 @@ MCCard *MCHccard::build(MCHcstak *hcsptr, MCStack *sptr)
 		cptr->flags |= F_G_DONT_SEARCH;
 	if (atts & HC_BC_CANT_DELETE)
 		cptr->flags |= F_G_CANT_DELETE;
-	newoptr = new MCObjptr;
+	newoptr = new (nothrow) MCObjptr;
 	newoptr->setparent(cptr);
 	newoptr->setid(bkgdid);
 	newoptr->appendto(cptr->objptrs);
 	if (bmapid != 0)
 	{
-		newoptr = new MCObjptr;
+		newoptr = new (nothrow) MCObjptr;
 		newoptr->setparent(cptr);
 		newoptr->setid(bmapid);
 		newoptr->appendto(cptr->objptrs);
@@ -1561,7 +1561,7 @@ MCCard *MCHccard::build(MCHcstak *hcsptr, MCStack *sptr)
 				MCControl *newbutton = bptr->build(hcsptr, sptr);
 				newbutton->setparent(sptr);
 				newbutton->appendto(sptr->controls);
-				newoptr = new MCObjptr;
+				newoptr = new (nothrow) MCObjptr;
 				newoptr->setparent(cptr);
 				newoptr->setid(newbutton->getid());
 				newoptr->appendto(cptr->objptrs);
@@ -1575,7 +1575,7 @@ MCCard *MCHccard::build(MCHcstak *hcsptr, MCStack *sptr)
 				MCControl *newfield = fptr->build(hcsptr, sptr);
 				newfield->setparent(sptr);
 				newfield->appendto(sptr->controls);
-				newoptr = new MCObjptr;
+				newoptr = new (nothrow) MCObjptr;
 				newoptr->setparent(cptr);
 				newoptr->setid(newfield->getid());
 				newoptr->appendto(cptr->objptrs);
@@ -1646,7 +1646,7 @@ IO_stat MCHcbkgd::parse(char *sptr)
 		offset = 25;
 	}
 	if (nobjects)
-		objects = new uint2[nobjects];
+		objects = new (nothrow) uint2[nobjects];
 	uint2 i;
 	for (i = 0 ; i < nobjects ; i++)
 	{
@@ -1655,7 +1655,7 @@ IO_stat MCHcbkgd::parse(char *sptr)
 		{
 		case HC_OTYPE_BUTTON:
 			{
-				MCHcbutton *newbutton = new MCHcbutton;
+				MCHcbutton *newbutton = new (nothrow) MCHcbutton;
 				newbutton->appendto(hcbuttons);
 				if (newbutton->parse(&sptr[offset * 2]) != IO_NORMAL)
 					return IO_ERROR;
@@ -1663,7 +1663,7 @@ IO_stat MCHcbkgd::parse(char *sptr)
 			break;
 		case HC_OTYPE_FIELD:
 			{
-				MCHcfield *newfield = new MCHcfield;
+				MCHcfield *newfield = new (nothrow) MCHcfield;
 				newfield->appendto(hcfields);
 				if (newfield->parse(&sptr[offset * 2]) != IO_NORMAL)
 					return IO_ERROR;
@@ -1679,7 +1679,7 @@ IO_stat MCHcbkgd::parse(char *sptr)
 	offset <<= 1;
 	while (ntext--)
 	{
-		MCHctext *newtext = new MCHctext;
+		MCHctext *newtext = new (nothrow) MCHctext;
 		newtext->cid = 0;
 		newtext->appendto(hctexts);
 		if (newtext->parse(&sptr[offset]) != IO_NORMAL)
@@ -1963,7 +1963,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 				return IO_ERROR;
 			filetype = HC_MACBIN;
 			delete name;
-			name = new char[strlen(&header[2]) + 1];
+			name = new (nothrow) char[strlen(&header[2]) + 1];
 			strcpy(name, &header[2]);
 			uint1 *uint1ptr = (uint1 *)header;
 			roffset = uint1ptr[83] << 24 | uint1ptr[84] << 16
@@ -1989,7 +1989,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 				}
 				MCS_seek_set(stream, ++foffset);
 				uint4 fsize = (uint4)MCS_fsize(stream) - foffset;
-				char *tbuffer = new char[fsize * 3 / 4];
+				char *tbuffer = new (nothrow) char[fsize * 3 / 4];
 				uint1 *uint1ptr = (uint1 *)tbuffer;
 				uint1 byte;
 				uint2 tcount = 0;
@@ -2014,7 +2014,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 					}
 				}
 				uint4 fullsize = fsize;
-				fullbuffer = new char[fullsize];
+				fullbuffer = new (nothrow) char[fullsize];
 				uint4 doffset = 0;
 				uint1 *eptr = uint1ptr + boffset;
 				while (uint1ptr < eptr)
@@ -2054,7 +2054,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 				}
 				uint1ptr = (uint1 *)fullbuffer;
 				delete name;
-				name = new char[uint1ptr[0] + 1];
+				name = new (nothrow) char[uint1ptr[0] + 1];
 				strcpy(name, &tbuffer[1]);
 				delete[] tbuffer;
 
@@ -2096,7 +2096,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 				return IO_ERROR;
 			if (type == HC_BUGS)
 				size = 512;
-			fullbuffer = new char[size];
+			fullbuffer = new (nothrow) char[size];
 			if (IO_read(&fullbuffer[8], size - 8, stream) != IO_NORMAL)
 				return IO_ERROR;
 			buffer = fullbuffer;
@@ -2133,12 +2133,12 @@ IO_stat MCHcstak::read(IO_handle stream)
 			MCU_realloc((char **)&pbuffersizes, npbuffers,
 			            npbuffers + 1, sizeof(uint2));
 			pbuffersizes[npbuffers] = size;
-			pbuffers[npbuffers] = new char[size];
+			pbuffers[npbuffers] = new (nothrow) char[size];
 			memcpy(pbuffers[npbuffers++], buffer, size);
 			break;
 		case HC_BKGD:
 			{
-				MCHcbkgd *newbkgd = new MCHcbkgd;
+				MCHcbkgd *newbkgd = new (nothrow) MCHcbkgd;
 				newbkgd->appendto(hcbkgds);
 				if (newbkgd->parse(buffer) != IO_NORMAL)
 					return IO_ERROR;
@@ -2146,7 +2146,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 			break;
 		case HC_CARD:
 			{
-				MCHccard *newcard = new MCHccard;
+				MCHccard *newcard = new (nothrow) MCHccard;
 				newcard->appendto(hccards);
 				if (newcard->parse(buffer) != IO_NORMAL)
 					return IO_ERROR;
@@ -2154,7 +2154,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 			break;
 		case HC_BMAP:
 			{
-				MCHcbmap *newbmap = new MCHcbmap;
+				MCHcbmap *newbmap = new (nothrow) MCHcbmap;
 				newbmap->appendto(hcbmaps);
 				if (newbmap->parse(buffer) != IO_NORMAL)
 					return IO_ERROR;
@@ -2163,7 +2163,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 		case HC_STBL:
 			if ((natts = swap_uint2(&uint2buff[9])) != 0)
 			{
-				atts = new Hcatts[natts];
+				atts = new (nothrow) Hcatts[natts];
 				offset = 13;
 				for (i = 0 ; i < natts ; i++)
 				{
@@ -2178,7 +2178,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 		case HC_FTBL:
 			if ((nfonts = swap_uint2(&uint2buff[9])) != 0)
 			{
-				fonts = new Hcfont[nfonts];
+				fonts = new (nothrow) Hcfont[nfonts];
 				offset = 12;
 				for (i = 0 ; i < nfonts ; i++)
 				{
@@ -2218,7 +2218,7 @@ IO_stat MCHcstak::read(IO_handle stream)
 	}
 	if (filetype == HC_MACBIN)
 	{
-		fullbuffer = new char[rsize];
+		fullbuffer = new (nothrow) char[rsize];
 		MCS_seek_set(stream, roffset);
 		if (MCS_readfixed(fullbuffer, rsize, stream) != IO_NORMAL)
 			return IO_ERROR;
@@ -2258,21 +2258,21 @@ IO_stat MCHcstak::read(IO_handle stream)
 			{
 			case HC_ICON:
 				{
-					MCHcbmap *newicon = new MCHcbmap;
+					MCHcbmap *newicon = new (nothrow) MCHcbmap;
 					newicon->appendto(icons);
 					newicon->icon(id, *t_name, &rdata[offset + 4]);
 				}
 				break;
 			case HC_CURS:
 				{
-					MCHcbmap *newcurs = new MCHcbmap;
+					MCHcbmap *newcurs = new (nothrow) MCHcbmap;
 					newcurs->appendto(cursors);
 					newcurs->cursor(id, *t_name, &rdata[offset + 4]);
 				}
 				break;
 			case HC_SND:
 				{
-					MCHcsnd *newsnd = new MCHcsnd;
+					MCHcsnd *newsnd = new (nothrow) MCHcsnd;
 					if (newsnd->import(id, *t_name, &rdata[offset + 4]))
 						newsnd->appendto(snds);
 					else
@@ -2475,7 +2475,7 @@ IO_stat hc_import(MCStringRef name, IO_handle stream, MCStack *&sptr)
 
     char* t_name;
     /* UNCHECKED */ MCStringConvertToCString(name, t_name);
-	MCHcstak *hcstak = new MCHcstak(t_name);
+	MCHcstak *hcstak = new (nothrow) MCHcstak(t_name);
 	hcstat_append("Loading stack %s...", t_name);
 	uint2 startlen = MCStringGetLength(MChcstat);
 	IO_stat stat;

--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -195,7 +195,7 @@ Parse_stat MCHandlerlist::findvar(MCNameRef p_name, bool p_ignore_uql, MCVarref 
 	for (tmp = vars, t_vindex = 0 ; tmp != NULL ; tmp = tmp->getnext(), t_vindex += 1)
 		if ((!tmp -> isuql() || !p_ignore_uql) && tmp->hasname(p_name))
 		{
-			*dptr = new MCVarref(tmp, t_vindex);
+			*dptr = new (nothrow) MCVarref(tmp, t_vindex);
 			return PS_NORMAL;
 		}
 
@@ -211,13 +211,13 @@ Parse_stat MCHandlerlist::findvar(MCNameRef p_name, bool p_ignore_uql, MCVarref 
 
 	if (MCNameIsEqualTo(p_name, MCN_msg, kMCCompareCaseless))
 	{
-		*dptr = new MCVarref(MCmb);
+		*dptr = new (nothrow) MCVarref(MCmb);
 		return PS_NORMAL;
 	}
 
 	if (MCNameIsEqualTo(p_name, MCN_each, kMCCompareCaseless))
 	{
-		*dptr = new MCVarref(MCeach);
+		*dptr = new (nothrow) MCVarref(MCeach);
 		return PS_NORMAL;
 	}
 
@@ -309,7 +309,7 @@ Parse_stat MCHandlerlist::newvar(MCNameRef p_name, MCValueRef p_init, MCVarref *
 	}
 
 	// MW-2008-10-28: [[ ParentScripts ]] Make a varref for a script local variable.
-	*newptr = new MCVarref(lastvar, nvars);
+	*newptr = new (nothrow) MCVarref(lastvar, nvars);
 
 	// MW-2008-10-28: [[ ParentScripts ]] Extend the vinits array
 	// MW-2011-08-22: [[ Bug ]] Don't clone the init when we are creating a UQL in
@@ -332,7 +332,7 @@ Parse_stat MCHandlerlist::findconstant(MCNameRef p_name, MCExpression **dptr)
 	for (i = 0 ; i < nconstants ; i++)
 		if (MCNameIsEqualTo(p_name, cinfo[i].name, kMCCompareCaseless))
 		{
-			*dptr = new MCLiteral(cinfo[i].value);
+			*dptr = new (nothrow) MCLiteral(cinfo[i].value);
 			return PS_NORMAL;
 		}
 	return PS_NO_MATCH;
@@ -432,7 +432,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 	{
 		// MW-2008-11-02: [[ ParentScripts ]] Rejig the old variables list to be a vector
 		//   so we can preserve the ordering for later mapping.
-		s_old_variables = new MCVariable *[nvars];
+		s_old_variables = new (nothrow) MCVariable *[nvars];
 		s_old_variable_count = nvars;
 		for(uint32_t i = 0; vars != NULL; vars = vars -> getnext(), i++)
 			s_old_variables[i] = vars;
@@ -441,7 +441,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 		//   but only if this object is used as a parentscript.
 		if (t_is_parent_script)
 		{
-			s_old_variable_map = new uint32_t[nvars];
+			s_old_variable_map = new (nothrow) uint32_t[nvars];
 
 			// We initialize the map to all 0xffffffff's - this indicates that the existing
 			// value should not be brought forward.
@@ -488,7 +488,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 
 						t_is_private = true;
 					}
-					newhandler = new MCHandler((uint1)te->which, t_is_private);
+					newhandler = new (nothrow) MCHandler((uint1)te->which, t_is_private);
 					if (newhandler->parse(sp, te->which == HT_GETPROP || te->which == HT_SETPROP) != PS_NORMAL)
 					{
 						sp.sethandler(NULL);
@@ -515,7 +515,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 					{
 					case S_GLOBAL:
 						{
-							MCGlobal *gptr = new MCGlobal;
+							MCGlobal *gptr = new (nothrow) MCGlobal;
 							if (gptr->parse(sp) != PS_NORMAL)
 							{
 								MCperror->add(PE_HANDLER_BADVAR, sp);
@@ -526,7 +526,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 						}
 					case S_LOCAL:
 						{
-							MCLocalVariable *lptr = new MCLocalVariable;
+							MCLocalVariable *lptr = new (nothrow) MCLocalVariable;
 							if (lptr->parse(sp) != PS_NORMAL)
 							{
 								MCperror->add(PE_HANDLER_BADVAR, sp);
@@ -537,7 +537,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 						}
 					case S_CONSTANT:
 						{
-							MCLocalConstant *cptr = new MCLocalConstant;
+							MCLocalConstant *cptr = new (nothrow) MCLocalConstant;
 							if (cptr->parse(sp) != PS_NORMAL)
 							{
 								MCperror->add(PE_HANDLER_BADVAR, sp);

--- a/engine/src/ibmp.cpp
+++ b/engine/src/ibmp.cpp
@@ -1107,7 +1107,7 @@ bool MCImageDecodeBMPStruct(IO_handle p_stream, uindex_t &x_bytes_read, MCImageB
 	MCBitmapStructImageLoader *t_loader;
     t_loader = NULL;
 	if (t_success)
-		t_success = nil != (t_loader = new MCBitmapStructImageLoader(p_stream));
+		t_success = nil != (t_loader = new (nothrow) MCBitmapStructImageLoader(p_stream));
 
 	MCBitmapFrame *t_frames;
 	t_frames = nil;
@@ -1174,7 +1174,7 @@ bool MCBitmapImageLoader::LoadHeader(uint32_t &r_width, uint32_t &r_height, uint
 bool MCImageLoaderCreateForBMPStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCBitmapImageLoader *t_loader;
-	t_loader = new MCBitmapImageLoader(p_stream);
+	t_loader = new (nothrow) MCBitmapImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;
@@ -1502,7 +1502,7 @@ bool MCNetPBMImageLoader::LoadHeader(uint32_t &r_width, uint32_t &r_height, uint
 	uindex_t t_token_size;
 
 	if (t_success)
-		t_success = nil != (m_reader = new MCNetPBMTokenReader(GetStream()));
+		t_success = nil != (m_reader = new (nothrow) MCNetPBMTokenReader(GetStream()));
 
 	if (t_success)
 		t_success = m_reader->GetToken(t_token, t_token_size);
@@ -1677,7 +1677,7 @@ bool MCNetPBMImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count
 bool MCImageLoaderCreateForNetPBMStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCNetPBMImageLoader *t_loader;
-	t_loader = new MCNetPBMImageLoader(p_stream);
+	t_loader = new (nothrow) MCNetPBMImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;
@@ -2045,7 +2045,7 @@ bool MCXBMImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 bool MCImageLoaderCreateForXBMStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCXBMImageLoader *t_loader;
-	t_loader = new MCXBMImageLoader(p_stream);
+	t_loader = new (nothrow) MCXBMImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;
@@ -2625,7 +2625,7 @@ bool MCXPMImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 bool MCImageLoaderCreateForXPMStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCXPMImageLoader *t_loader;
-	t_loader = new MCXPMImageLoader(p_stream);
+	t_loader = new (nothrow) MCXPMImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;
@@ -2746,7 +2746,7 @@ bool MCXWDImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 	stream = GetStream();
 	
 	MCColor *colors = nil;
-	colors = new MCColor[m_fh.ncolors];
+	colors = new (nothrow) MCColor[m_fh.ncolors];
 	t_success = colors != nil;
 
 	for (uint32_t i = 0 ; t_success && i < (uint2)m_fh.ncolors ; i++)
@@ -2772,7 +2772,7 @@ bool MCXWDImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 		uint4 bytes = m_fh.bytes_per_line * m_fh.pixmap_height;
 		if (m_fh.bits_per_pixel == 1)
 			bytes *= m_fh.pixmap_depth;
-		t_newimage_data = new char[bytes];
+		t_newimage_data = new (nothrow) char[bytes];
 		t_success = t_newimage_data != nil &&
 			IO_read(t_newimage_data, bytes, stream) == IO_NORMAL;
 	}
@@ -2874,7 +2874,7 @@ bool MCXWDImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 bool MCImageLoaderCreateForXWDStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCXWDImageLoader *t_loader;
-	t_loader = new MCXWDImageLoader(p_stream);
+	t_loader = new (nothrow) MCXWDImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -115,7 +115,7 @@ MCIdeState *MCIdeState::Find(MCField *p_field)
 			return t_state;
 		}
 
-	t_state = new MCIdeState;
+	t_state = new (nothrow) MCIdeState;
 	t_state -> f_next = s_states;
 	t_state -> f_field = p_field;
 	s_states = t_state;
@@ -189,7 +189,7 @@ Parse_stat MCIdeScriptAction::parse_target(MCScriptPoint& p_script,MCChunk*& r_t
 
 	if (t_status == PS_NORMAL)
 	{
-		r_target = new MCChunk(True);
+		r_target = new (nothrow) MCChunk(True);
 		t_status = r_target -> parse(p_script, False);
 	}
 	
@@ -468,7 +468,7 @@ void MCIdeScriptConfigure::exec_ctxt(MCExecContext &ctxt)
     case TYPE_CLASSES:
         {
             if (s_script_class_styles == NULL)
-                s_script_class_styles = new uint1[__COLOURIZE_CLASS_COUNT__];
+                s_script_class_styles = new (nothrow) uint1[__COLOURIZE_CLASS_COUNT__];
             else
             {
                 for(uint4 t_class = 0; t_class < __COLOURIZE_CLASS_COUNT__; ++t_class)
@@ -514,7 +514,7 @@ void MCIdeScriptConfigure::exec_ctxt(MCExecContext &ctxt)
     case TYPE_KEYWORDS:
         {
             if (s_script_keyword_styles == NULL)
-                s_script_keyword_styles = new uint1[SCRIPT_KEYWORD_COUNT];
+                s_script_keyword_styles = new (nothrow) uint1[SCRIPT_KEYWORD_COUNT];
             else
             {
                 for(uint4 t_keyword = 0; t_keyword < SCRIPT_KEYWORD_COUNT; ++t_keyword)
@@ -1811,7 +1811,7 @@ Parse_stat MCIdeScriptTokenize::parse(MCScriptPoint& sp)
 
 	if (t_stat == PS_NORMAL)
 	{
-		m_script = new MCChunk(True);
+		m_script = new (nothrow) MCChunk(True);
 		t_stat = m_script -> parse(sp, False);
 	}
 
@@ -1993,7 +1993,7 @@ Parse_stat MCIdeScriptClassify::parse(MCScriptPoint& p_script)
 	
 	if (t_status == PS_NORMAL)
 	{
-		m_target = new MCChunk(False);
+		m_target = new (nothrow) MCChunk(False);
 		t_status = m_target -> parse(p_script, False);
 	}
 
@@ -2185,7 +2185,7 @@ void MCIdeScriptClassify::exec_ctxt(MCExecContext &ctxt)
                     Handler_type t_htype;
                     if (searchforhandler(t_object, sp.gettoken_nameref(), t_htype) &&
                         t_htype == HT_MESSAGE)
-                        t_call = new MCComref(sp.gettoken_nameref());
+                        t_call = new (nothrow) MCComref(sp.gettoken_nameref());
                 }
             }
         }
@@ -2310,7 +2310,7 @@ Parse_stat MCIdeSyntaxTokenize::parse(MCScriptPoint& sp)
 
 	if (t_stat == PS_NORMAL)
 	{
-		m_script = new MCChunk(True);
+		m_script = new (nothrow) MCChunk(True);
 		t_stat = m_script -> parse(sp, False);
 	}
 
@@ -2382,7 +2382,7 @@ Parse_stat MCIdeSyntaxCompile::parse(MCScriptPoint& sp)
 	
 	if (t_stat == PS_NORMAL)
 	{
-		m_target = new MCChunk(False);
+		m_target = new (nothrow) MCChunk(False);
 		t_stat = m_target -> parse(sp, False);
 	}
 	
@@ -2400,7 +2400,7 @@ void MCIdeSyntaxCompile::exec_ctxt(MCExecContext &ctxt)
     }
 
     MCHandlerlist *t_hlist;
-    t_hlist = new MCHandlerlist;
+    t_hlist = new (nothrow) MCHandlerlist;
     if (t_hlist -> parse(optr, optr -> _getscript()) == PS_NORMAL)
     {
         MCSyntaxFactoryRef t_factory;
@@ -2581,7 +2581,7 @@ Parse_stat MCIdeFilterControls::parse(MCScriptPoint& sp)
 
 	if (t_stat == PS_NORMAL)
 	{
-		m_stack = new MCChunk(false);
+		m_stack = new (nothrow) MCChunk(false);
 		t_stat = m_stack -> parse(sp, False);
 	}
 	

--- a/engine/src/idraw.cpp
+++ b/engine/src/idraw.cpp
@@ -475,7 +475,7 @@ void MCImage::magredrawrect(MCContext *dest_context, const MCRectangle &drect)
 	MCGContextClipToRect(t_context, MCRectangleToMCGRectangle(t_mr));
 
 	MCContext *t_gfxcontext = nil;
-	/* UNCHECKED */ t_gfxcontext = new MCGraphicsContext(t_context);
+	/* UNCHECKED */ t_gfxcontext = new (nothrow) MCGraphicsContext(t_context);
 
 	getstack() -> getcurcard() -> draw(t_gfxcontext, t_mr, false); 
 	

--- a/engine/src/igif.cpp
+++ b/engine/src/igif.cpp
@@ -435,7 +435,7 @@ bool MCGIFImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 bool MCImageLoaderCreateForGIFStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCGIFImageLoader *t_loader;
-	t_loader = new MCGIFImageLoader(p_stream);
+	t_loader = new (nothrow) MCGIFImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;

--- a/engine/src/ijpg.cpp
+++ b/engine/src/ijpg.cpp
@@ -847,7 +847,7 @@ bool MCJPEGImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 bool MCImageLoaderCreateForJPEGStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCJPEGImageLoader *t_loader;
-	t_loader = new MCJPEGImageLoader(p_stream);
+	t_loader = new (nothrow) MCJPEGImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -702,7 +702,7 @@ void MCImage::freeundo(Ustruct *us)
 MCControl *MCImage::clone(Boolean attach, Object_pos p, bool invisible)
 {
 	recompress();
-	MCImage *newiptr = new MCImage(*this);
+	MCImage *newiptr = new (nothrow) MCImage(*this);
 	if (attach)
 		newiptr->attach(p, invisible);
 	return newiptr;
@@ -1034,8 +1034,8 @@ IO_stat MCImage::extendedload(MCObjectInputStream& p_stream, uint32_t p_version,
 
             if (t_stat == IO_NORMAL)
 			{
-				s_control_colors = new MCColor[s_control_color_count];
-				s_control_color_names = new MCStringRef[s_control_color_count];
+				s_control_colors = new (nothrow) MCColor[s_control_color_count];
+				s_control_color_names = new (nothrow) MCStringRef[s_control_color_count];
 				if (nil == s_control_colors || nil == s_control_color_names)
 					t_stat = checkloadstat(IO_ERROR);
 			}
@@ -1599,7 +1599,7 @@ bool MCImage::convert_to_mutable()
 	{
 		t_success = lockbitmap(t_bitmap, true);
 		if (t_success)
-			t_success = nil != (t_rep = new MCMutableImageRep(this, t_bitmap));
+			t_success = nil != (t_rep = new (nothrow) MCMutableImageRep(this, t_bitmap));
 		unlockbitmap(t_bitmap);
 	}
 	else
@@ -1608,7 +1608,7 @@ bool MCImage::convert_to_mutable()
 		if (t_success)
 		{
 			MCImageBitmapClear(t_bitmap);
-			t_success = nil != (t_rep = new MCMutableImageRep(this, t_bitmap));
+			t_success = nil != (t_rep = new (nothrow) MCMutableImageRep(this, t_bitmap));
 		}
 		MCImageFreeBitmap(t_bitmap);
 	}

--- a/engine/src/image_rep.cpp
+++ b/engine/src/image_rep.cpp
@@ -720,7 +720,7 @@ bool MCImageRepCreateReferencedWithSearchKey(MCStringRef p_filename, MCStringRef
 	t_rep = nil;
 	
 	if (t_success)
-		t_success = nil != (t_rep = new MCReferencedImageRep(p_filename, p_searchkey));
+		t_success = nil != (t_rep = new (nothrow) MCReferencedImageRep(p_filename, p_searchkey));
 	
 	if (t_success)
 	{
@@ -752,7 +752,7 @@ bool MCImageRepGetResident(const void *p_data, uindex_t p_size, MCImageRep *&r_r
 {
 	bool t_success = true;
 	
-	MCCachedImageRep *t_rep = new MCResidentImageRep(p_data, p_size);
+	MCCachedImageRep *t_rep = new (nothrow) MCResidentImageRep(p_data, p_size);
 	
 	t_success = t_rep != nil;
 	if (t_success)
@@ -768,7 +768,7 @@ bool MCImageRepGetVector(void *p_data, uindex_t p_size, MCImageRep *&r_rep)
 {
 	bool t_success = true;
 	
-	MCCachedImageRep *t_rep = new MCVectorImageRep(p_data, p_size);
+	MCCachedImageRep *t_rep = new (nothrow) MCVectorImageRep(p_data, p_size);
 	
 	t_success = t_rep != nil;
 	if (t_success)
@@ -784,7 +784,7 @@ bool MCImageRepGetCompressed(MCImageCompressedBitmap *p_compressed, MCImageRep *
 {
 	bool t_success = true;
 	
-	MCCachedImageRep *t_rep = new MCCompressedImageRep(p_compressed);
+	MCCachedImageRep *t_rep = new (nothrow) MCCompressedImageRep(p_compressed);
 	
 	t_success = t_rep != nil;
 	if (t_success)
@@ -803,7 +803,7 @@ bool MCImageRepGetResampled(uint32_t p_width, uint32_t p_height, bool p_flip_hor
 {
 	bool t_success = true;
 	
-	MCCachedImageRep *t_rep = new MCResampledImageRep(p_width, p_height, p_flip_horizontal, p_flip_vertical, p_source);
+	MCCachedImageRep *t_rep = new (nothrow) MCResampledImageRep(p_width, p_height, p_flip_horizontal, p_flip_vertical, p_source);
 	
 	t_success = t_rep != nil;
 	if (t_success)
@@ -822,7 +822,7 @@ bool MCImageRepGetPixelRep(MCDataRef p_pixel_data, uint32_t p_width, uint32_t p_
 	t_success = true;
 	
 	MCPixelDataImageRep *t_rep;
-	t_rep = new MCPixelDataImageRep(p_pixel_data, p_width, p_height, p_format, p_premultiplied);
+	t_rep = new (nothrow) MCPixelDataImageRep(p_pixel_data, p_width, p_height, p_format, p_premultiplied);
 	
 	t_success = t_rep != nil;
 	if (t_success)

--- a/engine/src/image_rep_densitymapped.cpp
+++ b/engine/src/image_rep_densitymapped.cpp
@@ -525,7 +525,7 @@ bool MCImageRepCreateDensityMapped(MCStringRef p_filename, const MCImageScaledRe
 	t_rep = nil;
 	
 	if (t_success)
-		t_success = nil != (t_rep = new MCDensityMappedImageRep(p_filename));
+		t_success = nil != (t_rep = new (nothrow) MCDensityMappedImageRep(p_filename));
 	
 	for (uindex_t i = 0; t_success && i < p_count; i++)
 		t_success = t_rep->AddImageSourceWithDensity(static_cast<MCReferencedImageRep*>(p_list[i].rep), p_list[i].scale);

--- a/engine/src/image_rep_gimage.cpp
+++ b/engine/src/image_rep_gimage.cpp
@@ -204,7 +204,7 @@ void MCGImageImageRep::ReleaseBitmap()
 bool MCImageRepCreateWithGImage(MCGImageRef p_image, MCImageRep *&r_image_rep)
 {
 	MCGImageImageRep *t_rep;
-	t_rep = new MCGImageImageRep(p_image);
+	t_rep = new (nothrow) MCGImageImageRep(p_image);
 	
 	if (t_rep == nil)
 		return false;

--- a/engine/src/image_rep_mutable.cpp
+++ b/engine/src/image_rep_mutable.cpp
@@ -413,7 +413,7 @@ void MCMutableImageRep::startdraw()
 	if (!MCscreen->getlockmods())
 	{
 		MCundos->freestate();
-		Ustruct *us = new Ustruct;
+		Ustruct *us = new (nothrow) Ustruct;
 		us->type = UT_PAINT;
 		MCundos->savestate(m_owner, us);
 		MCImageFreeBitmap(m_undo_image);
@@ -442,7 +442,7 @@ void MCMutableImageRep::startdraw()
 	case T_CURVE:
 		if (points != NULL)
 			delete points;
-		points = new MCPoint[MCscreen->getmaxpoints()];
+		points = new (nothrow) MCPoint[MCscreen->getmaxpoints()];
 		npoints = MCscreen->getmaxpoints();
 		points[0].x = mx;
 		points[0].y = my;
@@ -1114,7 +1114,7 @@ void MCMutableImageRep::bucket_fill(MCImageBitmap *p_src, uint4 scolor, MCGRaste
 	if (!gotpoint)
 		return;
 
-	MCstacktype *pstack = new MCstacktype[PSTACKSIZE];
+	MCstacktype *pstack = new (nothrow) MCstacktype[PSTACKSIZE];
 	uint2 pstackptr = 0;
 	uint2 pstacktop = 1;
 	bool collision;
@@ -1669,7 +1669,7 @@ void MCMutableImageRep::selimage()
 	MCeditingimage = m_owner;
 	state |= CS_EDITED;
 	MCundos->freestate();
-	Ustruct *us = new Ustruct;
+	Ustruct *us = new (nothrow) Ustruct;
 	us->type = UT_PAINT;
 
 	MCundos->savestate(m_owner, us);
@@ -1832,7 +1832,7 @@ void MCMutableImageRep::rotatesel(int2 angle)
 	if (clearundo)
 	{
 		MCundos->freestate();
-		Ustruct *us = new Ustruct;
+		Ustruct *us = new (nothrow) Ustruct;
 		us->type = UT_PAINT;
 		MCundos->savestate(m_owner, us);
 		MCImageFreeBitmap(m_undo_image);

--- a/engine/src/imagelist.cpp
+++ b/engine/src/imagelist.cpp
@@ -382,7 +382,7 @@ MCPatternRef MCImageList::allocpat(uint4 id, MCObject *optr)
 		}
 	while (tptr != images);
 	
-	/* UNCHECKED */ tptr = new MCImageListNode(newim);
+	/* UNCHECKED */ tptr = new (nothrow) MCImageListNode(newim);
 	tptr->appendto(images);
 	tptr->allocimage(newim, pat);
 	return pat;

--- a/engine/src/internal_development.cpp
+++ b/engine/src/internal_development.cpp
@@ -633,7 +633,7 @@ public:
 			MCperror -> add(PE_OBJECT_NAME, sp);
 			return PS_ERROR;
 		}				
-		m_object = new MCChunk(False);
+		m_object = new (nothrow) MCChunk(False);
 		if (m_object -> parse(sp, False) != PS_NORMAL)
 		{
 			MCperror -> add(PE_OBJECT_NAME, sp);
@@ -735,7 +735,7 @@ public:
 			MCperror -> add(PE_OBJECT_NAME, sp);
 			return PS_ERROR;
 		}
-		m_object = new MCChunk(False);
+		m_object = new (nothrow) MCChunk(False);
 		if (m_object -> parse(sp, False) != PS_NORMAL)
 		{
 			MCperror -> add(PE_OBJECT_NAME, sp);

--- a/engine/src/ipng.cpp
+++ b/engine/src/ipng.cpp
@@ -361,7 +361,7 @@ bool MCPNGImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 bool MCImageLoaderCreateForPNGStream(IO_handle p_stream, MCImageLoader *&r_loader)
 {
 	MCPNGImageLoader *t_loader;
-	t_loader = new MCPNGImageLoader(p_stream);
+	t_loader = new (nothrow) MCPNGImageLoader(p_stream);
 	
 	if (t_loader == nil)
 		return false;

--- a/engine/src/iquantization.h
+++ b/engine/src/iquantization.h
@@ -71,9 +71,9 @@ public:
 		}
 
 		if (t_prev == NULL)
-			head = new MCPQNode(p_item, t_current);
+			head = new (nothrow) MCPQNode(p_item, t_current);
 		else
-			t_prev->next = new MCPQNode(p_item, t_current);
+			t_prev->next = new (nothrow) MCPQNode(p_item, t_current);
 
 		item_count++;
 	}

--- a/engine/src/iquantize_new.cpp
+++ b/engine/src/iquantize_new.cpp
@@ -232,11 +232,11 @@ bool MCImageMedianCutQuantization(MCWeightedPixel *p_pixels, uint32_t p_pixel_co
 	bool t_success = true;
 
 	// create first box (containing all pixels)
-	MCWeightedPixelBox *t_box = new MCWeightedPixelBox(p_pixels, 0, p_pixel_count - 1);
+	MCWeightedPixelBox *t_box = new (nothrow) MCWeightedPixelBox(p_pixels, 0, p_pixel_count - 1);
 
 	// create queue containing the box
-	MCPriorityQueue<MCWeightedPixelBox*> *t_queue = new MCPriorityQueue<MCWeightedPixelBox*>(vbox_compare_volume_population_product);
-	MCPriorityQueue<MCWeightedPixelBox*> *t_finished_queue = new MCPriorityQueue<MCWeightedPixelBox*>(vbox_compare_null);
+	MCPriorityQueue<MCWeightedPixelBox*> *t_queue = new (nothrow) MCPriorityQueue<MCWeightedPixelBox*>(vbox_compare_volume_population_product);
+	MCPriorityQueue<MCWeightedPixelBox*> *t_finished_queue = new (nothrow) MCPriorityQueue<MCWeightedPixelBox*>(vbox_compare_null);
 	if (t_box->volume == 1)
 		t_finished_queue->insert_sorted(t_box);
 	else
@@ -248,7 +248,7 @@ bool MCImageMedianCutQuantization(MCWeightedPixel *p_pixels, uint32_t p_pixel_co
 	{
 		if (f && t_count >= f)
 		{
-			MCPriorityQueue<MCWeightedPixelBox*> *t_new_queue = new MCPriorityQueue<MCWeightedPixelBox*>(vbox_compare_volume_population_product);
+			MCPriorityQueue<MCWeightedPixelBox*> *t_new_queue = new (nothrow) MCPriorityQueue<MCWeightedPixelBox*>(vbox_compare_volume_population_product);
 			while (t_queue->count() > 0)
 				t_new_queue->insert_sorted(t_queue->pop_first());
 			delete t_queue;
@@ -275,16 +275,16 @@ bool MCImageMedianCutQuantization(MCWeightedPixel *p_pixels, uint32_t p_pixel_co
 		{
 			uint32_t t_midpoint_value = ( p_pixels[t_median_index].channel[t_box->longest_axis] + t_box->channel_min[t_box->longest_axis] ) / 2;
 			uint32_t t_midpoint_index = t_box->split_axis(t_box->longest_axis, t_box->first, t_median_index, t_midpoint_value) - 1;
-			t_box1 = new MCWeightedPixelBox(p_pixels, t_box->first, t_midpoint_index);
-			t_box2 = new MCWeightedPixelBox(p_pixels, t_midpoint_index + 1, t_box->last);
+			t_box1 = new (nothrow) MCWeightedPixelBox(p_pixels, t_box->first, t_midpoint_index);
+			t_box2 = new (nothrow) MCWeightedPixelBox(p_pixels, t_midpoint_index + 1, t_box->last);
             //MCLog("split axis %d by value %d into %d+%d (population %d, first %d)", t_box->longest_axis, t_midpoint_value, t_box1->population, t_box2->population, t_box->population, t_box->first);
 		}
 		else
 		{
 			uint32_t t_midpoint_value = ( p_pixels[t_median_index].channel[t_box->longest_axis] + t_box->channel_max[t_box->longest_axis] ) / 2;
 			uint32_t t_midpoint_index = t_box->split_axis(t_box->longest_axis, t_median_index, t_box->last, t_midpoint_value) - 1;
-			t_box1 = new MCWeightedPixelBox(p_pixels, t_box->first, t_midpoint_index);
-			t_box2 = new MCWeightedPixelBox(p_pixels, t_midpoint_index + 1, t_box->last);
+			t_box1 = new (nothrow) MCWeightedPixelBox(p_pixels, t_box->first, t_midpoint_index);
+			t_box2 = new (nothrow) MCWeightedPixelBox(p_pixels, t_midpoint_index + 1, t_box->last);
             //MCLog("split axis %d by value %d into %d+%d (population %d, first %d)", t_box->longest_axis, t_midpoint_value, t_box1->population, t_box2->population, t_box->population, t_box->first);
 		}
 

--- a/engine/src/itransform.cpp
+++ b/engine/src/itransform.cpp
@@ -437,7 +437,7 @@ static void scaleimage_bicubic(void *p_src_ptr, uint4 p_src_stride, void *p_dst_
 	// Temporary resizes rows data
 	const int tmp_bytes_per_line = p_dst_width << 2;
 
-	uint1* const tmp_data = new uint1[tmp_bytes_per_line * p_src_height];
+	uint1* const tmp_data = new (nothrow) uint1[tmp_bytes_per_line * p_src_height];
 
 	// Clearing temp and destination data
 	memset(tmp_data, 0, tmp_bytes_per_line * p_src_height);
@@ -448,9 +448,9 @@ static void scaleimage_bicubic(void *p_src_ptr, uint4 p_src_stride, void *p_dst_
 	real8* bb;
 
 	if(p_src_width > p_src_height)
-		aa = new real8[p_src_width], bb = new real8[p_src_width];
+		aa = new (nothrow) real8[p_src_width], bb = new (nothrow) real8[p_src_width];
 	else
-		aa = new real8[p_src_height], bb = new real8[p_src_height];
+		aa = new (nothrow) real8[p_src_height], bb = new (nothrow) real8[p_src_height];
 
 	// resizing rows
 	for(i=0 ; i< (signed)p_src_height ; i++)

--- a/engine/src/iutil.cpp
+++ b/engine/src/iutil.cpp
@@ -147,7 +147,7 @@ void MCImage::addneed(MCObject *p_object)
 	}
 
 	// not found - create new need & add to list
-	/* UNCHECKED */ t_need = new MCImageNeed(p_object);
+	/* UNCHECKED */ t_need = new (nothrow) MCImageNeed(p_object);
 	t_need->Add(m_needs);
 }
 

--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -318,9 +318,9 @@ Parse_stat MCIf::parse(MCScriptPoint &sp)
 				if (needstatement)
 				{
 					if (type == ST_ID)
-						newstatement = new MCComref(sp.gettoken_nameref());
+						newstatement = new (nothrow) MCComref(sp.gettoken_nameref());
 					else if (type == ST_DATA)
-						newstatement = new MCEcho;
+						newstatement = new (nothrow) MCEcho;
 					else
 					{
 						MCperror->add(PE_IF_NOTCOMMAND, sp);
@@ -739,11 +739,11 @@ Parse_stat MCRepeat::parse(MCScriptPoint &sp)
 		{
 		case PS_NORMAL:
 			if (type == ST_DATA)
-				newstatement = new MCEcho;
+				newstatement = new (nothrow) MCEcho;
 			else if (sp.lookup(SP_COMMAND, te) != PS_NORMAL)
 			{
 				if (type == ST_ID)
-					newstatement = new MCComref(sp.gettoken_nameref());
+					newstatement = new (nothrow) MCComref(sp.gettoken_nameref());
 				else
 				{
 					MCperror->add
@@ -1019,11 +1019,11 @@ Parse_stat MCSwitch::parse(MCScriptPoint &sp)
 		{
 		case PS_NORMAL:
 			if (type == ST_DATA)
-				newstatement = new MCEcho;
+				newstatement = new (nothrow) MCEcho;
 			else if (sp.lookup(SP_COMMAND, te) != PS_NORMAL)
 			{
 				if (type == ST_ID)
-					newstatement = new MCComref(sp.gettoken_nameref());
+					newstatement = new (nothrow) MCComref(sp.gettoken_nameref());
 				else
 				{
 					MCperror->add
@@ -1177,11 +1177,11 @@ Parse_stat MCTry::parse(MCScriptPoint &sp)
 		{
 		case PS_NORMAL:
 			if (type == ST_DATA)
-				newstatement = new MCEcho;
+				newstatement = new (nothrow) MCEcho;
 			else if (sp.lookup(SP_COMMAND, te) != PS_NORMAL)
 			{
 				if (type == ST_ID)
-					newstatement = new MCComref(sp.gettoken_nameref());
+					newstatement = new (nothrow) MCComref(sp.gettoken_nameref());
 				else
 				{
 					MCperror->add

--- a/engine/src/line.cpp
+++ b/engine/src/line.cpp
@@ -570,7 +570,7 @@ void MCLine::SegmentLine()
             }
             
             // Create a segment covering the text up to this tab character
-            MCSegment *new_segment = new MCSegment(this);
+            MCSegment *new_segment = new (nothrow) MCSegment(this);
             new_segment->AddBlockRange(segment_start, bptr);
             if (firstsegment == NULL)
             {
@@ -600,7 +600,7 @@ void MCLine::SegmentLine()
     // Create a segment covering the remaining text
     if (t_segment_length > 0)
     {
-        MCSegment *new_segment = new MCSegment(this);
+        MCSegment *new_segment = new (nothrow) MCSegment(this);
         new_segment->AddBlockRange(segment_start, lastblock);
         if (firstsegment == NULL)
         {

--- a/engine/src/lnx-clipboard.cpp
+++ b/engine/src/lnx-clipboard.cpp
@@ -168,7 +168,7 @@ MCLinuxRawClipboardItem* MCLinuxRawClipboard::CreateNewItem()
         return NULL;
     
     // Create a new data item
-    m_item = new MCLinuxRawClipboardItem(this);
+    m_item = new (nothrow) MCLinuxRawClipboardItem(this);
     m_item->Retain();
     return m_item;
 }
@@ -425,7 +425,7 @@ bool MCLinuxRawClipboard::PullUpdates()
     
     // Create a new item for the new contents
     m_external_data = true;
-    m_item = new MCLinuxRawClipboardItem(this, m_selection, m_drag_context);
+    m_item = new (nothrow) MCLinuxRawClipboardItem(this, m_selection, m_drag_context);
     return (m_item != NULL);
 #else
     return true;
@@ -644,7 +644,7 @@ bool MCLinuxRawClipboardItem::AddRepresentation(MCStringRef p_type, MCDataRef p_
             return false;
         
         // Allocate a new representation object.
-        m_reps[t_index] = t_rep = new MCLinuxRawClipboardItemRep(p_type, p_bytes);
+        m_reps[t_index] = t_rep = new (nothrow) MCLinuxRawClipboardItemRep(p_type, p_bytes);
     }
     
     // If we still have no rep, something went wrong
@@ -792,7 +792,7 @@ void MCLinuxRawClipboardItem::FetchExternalRepresentations(GdkDragContext* p_dra
             m_reps.Extend(t_index + 1);
             
             // Add the new representation
-            m_reps[t_index] = new MCLinuxRawClipboardItemRep(m_clipboard, m_clipboard->GetSelectionAtom(), (GdkAtom)t_targets->data);
+            m_reps[t_index] = new (nothrow) MCLinuxRawClipboardItemRep(m_clipboard, m_clipboard->GetSelectionAtom(), (GdkAtom)t_targets->data);
             
             // Next item on the target list
             t_targets = t_targets->next;
@@ -862,7 +862,7 @@ void MCLinuxRawClipboardItem::FetchExternalRepresentations(GdkDragContext* p_dra
                 break;
             
             // Add the representation
-            m_reps[t_index] = new MCLinuxRawClipboardItemRep(m_clipboard, m_clipboard->GetSelectionAtom(), (GdkAtom)t_atom);
+            m_reps[t_index] = new (nothrow) MCLinuxRawClipboardItemRep(m_clipboard, m_clipboard->GetSelectionAtom(), (GdkAtom)t_atom);
         }
         
         // Free the memory containing the atoms

--- a/engine/src/lnxcursor.cpp
+++ b/engine/src/lnxcursor.cpp
@@ -51,7 +51,7 @@ struct MCCursor
 static MCCursorRef create_cursor(Pixmap_ids p_id, GdkCursor *p_cursor)
 {
 	MCCursorRef t_cursor;
-	t_cursor = new MCCursor;
+	t_cursor = new (nothrow) MCCursor;
 	t_cursor -> id = p_id;
 	t_cursor -> handle = p_cursor;
 	return t_cursor;

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -57,9 +57,9 @@ static Boolean dragclick;
 void MCScreenDC::setupcolors()
 {
 	ncolors = MCU_min(vis->colormap_size, MAX_CELLS);
-	colors = new MCColor[ncolors];
-    colornames = new MCStringRef[ncolors];
-	allocs = new int2[ncolors];
+	colors = new (nothrow) MCColor[ncolors];
+    colornames = new (nothrow) MCStringRef[ncolors];
+	allocs = new (nothrow) int2[ncolors];
 	int2 i;
 	for (i = 0 ; i < ncolors ; i++)
 	{
@@ -299,7 +299,7 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
             {
                 // Handled separately
                 //fprintf(stderr, "GDK_EXPOSE (window %p)\n", t_event->expose.window);
-                MCEventnode *t_node = new MCEventnode(gdk_event_copy(t_event));
+                MCEventnode *t_node = new (nothrow) MCEventnode(gdk_event_copy(t_event));
                 t_node->appendto(pendingevents);
                 expose();
                 break;
@@ -974,7 +974,7 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
         // Queue the message if required. Otherwise, dispose of it
         if (t_queue)
         {
-            MCEventnode *tptr = new MCEventnode(t_event);
+            MCEventnode *tptr = new (nothrow) MCEventnode(t_event);
             tptr->appendto(pendingevents);
             t_event = NULL;
         }
@@ -1018,7 +1018,7 @@ void MCScreenDC::EnqueueGdkEvents(bool p_block)
         // GTK hasn't had a chance at this event yet
         //gtk_main_do_event(t_event);
         
-        MCEventnode *t_eventnode = new MCEventnode(t_event);
+        MCEventnode *t_eventnode = new (nothrow) MCEventnode(t_event);
         t_eventnode->appendto(pendingevents);
     }
 }
@@ -1053,7 +1053,7 @@ bool MCScreenDC::GetFilteredEvent(bool (*p_filterfn)(GdkEvent*, void*), GdkEvent
 
 void MCScreenDC::EnqueueEvent(GdkEvent* p_event)
 {
-    MCEventnode *t_node = new MCEventnode(p_event);
+    MCEventnode *t_node = new (nothrow) MCEventnode(p_event);
     t_node->appendto(pendingevents);
 }
 
@@ -1183,7 +1183,7 @@ void MCScreenDC::DnDClientEvent(GdkEvent* p_event)
         {
             // Handled separately
             //fprintf(stderr, "GDK_EXPOSE (window %p)\n", t_event->expose.window);
-            MCEventnode *t_node = new MCEventnode(gdk_event_copy(p_event));
+            MCEventnode *t_node = new (nothrow) MCEventnode(gdk_event_copy(p_event));
             t_node->appendto(pendingevents);
             expose();
             break;

--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -215,7 +215,7 @@ Boolean MCScreenDC::open()
 	// TS : Changed 2008-01-08 as a more relaible way of testing for UTF-8
 	MCutf8 = (strcmp(nl_langinfo(CODESET), "UTF-8") == 0)	;
 	
-	MCimagecache = new MCXImageCache ;
+	MCimagecache = new (nothrow) MCXImageCache ;
 	
     if (MCdisplayname == NULL)
         MCdisplayname = gdk_get_display();

--- a/engine/src/lnxflst.cpp
+++ b/engine/src/lnxflst.cpp
@@ -162,7 +162,7 @@ MCFontStruct *MCNewFontlist::getfont(MCNameRef p_family, uint2& p_size, uint2 p_
 		if (MCNameIsEqualTo(p_family, t_font -> family) && p_size == t_font -> size && p_style == t_font -> style)
 			return t_font;
 
-	t_font = new MCNewFontStruct;
+	t_font = new (nothrow) MCNewFontStruct;
 	t_font -> family = MCValueRetain(p_family);
 	t_font -> size = p_size;
 	t_font -> style = p_style;
@@ -550,7 +550,7 @@ public:
 MCFontlist *MCFontlistCreateNew(void)
 {
 	MCNewFontlist *t_fontlist;
-	t_fontlist = new MCNewFontlist;
+	t_fontlist = new (nothrow) MCNewFontlist;
 	if (!t_fontlist -> create())
 	{
 		delete t_fontlist;

--- a/engine/src/lnxflstold.cpp
+++ b/engine/src/lnxflstold.cpp
@@ -468,7 +468,7 @@
 //		MCOldFonttablenode *fnptr = findtablenode(*t_node);
 //		if (fnptr == NULL)
 //		{
-//			fnptr = new MCOldFonttablenode;
+//			fnptr = new (nothrow) MCOldFonttablenode;
 //			char *temp;
 //			/* UNCHECKED */ MCStringConvertToCString(*t_node, temp);
 //			fnptr->name = strclone(temp);
@@ -569,7 +569,7 @@
 //			tmp = tmp->next();
 //		}
 //		while (tmp != fonts);
-//	tmp = new MCOldFontnode(fname, size, style);
+//	tmp = new (nothrow) MCOldFontnode(fname, size, style);
 //	tmp->appendto(fonts);
 //	return tmp->getfont(fname, size, style);
 //}

--- a/engine/src/lnxgtktheme.cpp
+++ b/engine/src/lnxgtktheme.cpp
@@ -238,7 +238,7 @@ static gboolean reload_theme(void)
 		// We have changed themes, so remove the image cache and replace with new one
 		if ( MCimagecache != NULL)
 			delete MCimagecache ;
-		MCimagecache = new MCXImageCache ;
+		MCimagecache = new (nothrow) MCXImageCache ;
 
 		MCcurtheme->unload();
 		MCcurtheme->load();

--- a/engine/src/lnximagecache.cpp
+++ b/engine/src/lnximagecache.cpp
@@ -42,7 +42,7 @@ MCXImageCacheNode::MCXImageCacheNode(GdkPixbuf *p_bitmap, GtkThemeWidgetType p_m
 	cached_image = p_bitmap ;
 	total_pixels = gdk_pixbuf_get_width(p_bitmap) * gdk_pixbuf_get_height(p_bitmap);
 	moztype = p_moztype ;
-	state = new GtkWidgetState ;
+	state = new (nothrow) GtkWidgetState ;
 	memcpy((GtkWidgetState*)state, (GtkWidgetState*)p_state, sizeof ( GtkWidgetState )) ;
 	flags = p_flags ;
 
@@ -56,7 +56,7 @@ MCXImageCacheNode::MCXImageCacheNode(GdkPixbuf *p_bitmap, GtkThemeWidgetType p_m
 	cached_image = p_bitmap ;	
 	font = p_font ;
 	total_pixels = ( p_bitmap -> width * p_bitmap -> height ) ;
-	text_string = new char[p_string_length];
+	text_string = new (nothrow) char[p_string_length];
 	memcpy(text_string, p_string, p_string_length);
 	text_string_length = p_string_length;
 	fgColor = p_fgColor ;
@@ -193,7 +193,7 @@ bool MCXImageCache::add_to_cache (GdkPixbuf * p_bitmap, MCThemeDrawInfo& p_info)
 	
 	MCXImageCacheNode * cache_node ;
 	
-	cache_node = new MCXImageCacheNode ( p_bitmap, p_info . moztype, &p_info . state, p_info.flags  ) ;
+	cache_node = new (nothrow) MCXImageCacheNode ( p_bitmap, p_info . moztype, &p_info . state, p_info.flags  ) ;
 
 	if ( cache_tail == NULL )
 		cache_tail = cache_node ;

--- a/engine/src/lnxmisc.cpp
+++ b/engine/src/lnxmisc.cpp
@@ -112,7 +112,7 @@ void MCLinuxWindowSetTransientFor(GdkWindow* p_window, GdkWindow* p_transient_fo
 //		t_converter = iconv_open("UTF-16", p_encoding);
 //
 //		ConverterRecord *t_record;
-//		t_record = new ConverterRecord;
+//		t_record = new (nothrow) ConverterRecord;
 //		t_record -> next = s_records;
 //		t_record -> encoding = p_encoding;
 //		t_record -> converter = t_converter;

--- a/engine/src/lnxmplayer.cpp
+++ b/engine/src/lnxmplayer.cpp
@@ -131,7 +131,7 @@ bool MPlayer::shutdown(void)
 //	IO_handle handle = NULL;
 //	FILE *fptr = fdopen(fd, mode);
 //	if (fptr != NULL)
-//		handle = new IO_header(fptr, NULL, 0, fd, 0);
+//		handle = new (nothrow) IO_header(fptr, NULL, 0, fd, 0);
 //	return handle;
 //}
 

--- a/engine/src/magnify.cpp
+++ b/engine/src/magnify.cpp
@@ -131,7 +131,7 @@ IO_stat MCMagnify::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32
 
 MCControl *MCMagnify::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCMagnify *newmagnify = new MCMagnify(*this);
+	MCMagnify *newmagnify = new (nothrow) MCMagnify(*this);
 	if (attach)
 		newmagnify->attach(p, invisible);
 	return newmagnify;

--- a/engine/src/mblad.cpp
+++ b/engine/src/mblad.cpp
@@ -200,7 +200,7 @@ private:
 void MCAdPostMessage(MCAd *p_ad, MCAdEventType p_type)
 {
     MCCustomEvent *t_event;
-    t_event = new MCAdEvent(p_ad, p_type);
+    t_event = new (nothrow) MCAdEvent(p_ad, p_type);
     if (t_event != nil)
         MCEventQueuePostCustom(t_event);
 }

--- a/engine/src/mblandroid.cpp
+++ b/engine/src/mblandroid.cpp
@@ -52,11 +52,11 @@ bool MCAndroidSystem::Initialize(void)
     
     // Initialize our case mapping tables
     
-    MCuppercasingtable = new uint1[256];
+    MCuppercasingtable = new (nothrow) uint1[256];
     for(uint4 i = 0; i < 256; ++i)
         MCuppercasingtable[i] = (uint1)toupper((uint1)i);
     
-    MClowercasingtable = new uint1[256];
+    MClowercasingtable = new (nothrow) uint1[256];
     for(uint4 i = 0; i < 256; ++i)
         MClowercasingtable[i] = (uint1)tolower((uint1)i);
     

--- a/engine/src/mblandroidbrowser.cpp
+++ b/engine/src/mblandroidbrowser.cpp
@@ -492,7 +492,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_nativecontrol_BrowserControl_doSt
     
     if (MCAndroidControl::FindByView(object, t_control) && MCJavaStringToNative(env, url, t_url))
     {
-        t_event = new MCAndroidBrowserStartFinishEvent((MCAndroidBrowserControl*)t_control, t_url, false);
+        t_event = new (nothrow) MCAndroidBrowserStartFinishEvent((MCAndroidBrowserControl*)t_control, t_url, false);
         MCEventQueuePostCustom(t_event);
     }
     
@@ -508,7 +508,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_nativecontrol_BrowserControl_doFi
     
     if (MCAndroidControl::FindByView(object, t_control) && MCJavaStringToNative(env, url, t_url))
     {
-        t_event = new MCAndroidBrowserStartFinishEvent((MCAndroidBrowserControl*)t_control, t_url, true);
+        t_event = new (nothrow) MCAndroidBrowserStartFinishEvent((MCAndroidBrowserControl*)t_control, t_url, true);
         MCEventQueuePostCustom(t_event);
     }
     
@@ -527,7 +527,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_nativecontrol_BrowserControl_doLo
         MCJavaStringToNative(env, url, t_url) &&
         MCJavaStringToNative(env, error, t_error))
     {
-        t_event = new MCAndroidBrowserLoadFailedEvent((MCAndroidBrowserControl*)t_control, t_url, t_error);
+        t_event = new (nothrow) MCAndroidBrowserLoadFailedEvent((MCAndroidBrowserControl*)t_control, t_url, t_error);
         MCEventQueuePostCustom(t_event);
     }
     
@@ -556,7 +556,7 @@ void MCAndroidBrowserControl::DeleteView(jobject p_view)
 
 bool MCNativeBrowserControlCreate(MCNativeControl *&r_control)
 {
-    r_control = new MCAndroidBrowserControl();
+    r_control = new (nothrow) MCAndroidBrowserControl();
     return true;
 }
 

--- a/engine/src/mblandroidcontrol.cpp
+++ b/engine/src/mblandroidcontrol.cpp
@@ -283,7 +283,7 @@ private:
 void MCAndroidControl::PostNotifyEvent(MCNameRef p_message)
 {
     MCCustomEvent *t_event;
-    t_event = new MCAndroidControlNotifyEvent(this, p_message);
+    t_event = new (nothrow) MCAndroidControlNotifyEvent(this, p_message);
     MCEventQueuePostCustom(t_event);
 }
 

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -2890,7 +2890,7 @@ bool android_run_on_main_thread(void *p_callback, void *p_callback_state, int p_
 		}
 		
 		MCRunOnMainThreadHelper *t_helper;
-		t_helper = new MCRunOnMainThreadHelper(p_callback, p_callback_state, p_options);
+		t_helper = new (nothrow) MCRunOnMainThreadHelper(p_callback, p_callback_state, p_options);
 		MCAndroidEngineCall("nativeNotify", "vii", nil, MCRunOnMainThreadHelper::DispatchThunk, t_helper);
 		return true;
 	}
@@ -2908,7 +2908,7 @@ bool android_run_on_main_thread(void *p_callback, void *p_callback_state, int p_
 		}
 		
 		MCRunOnMainThreadHelper *t_helper;
-		t_helper = new MCRunOnMainThreadHelper(p_callback, p_callback_state, p_options & ~kMCExternalRunOnMainThreadPost);
+		t_helper = new (nothrow) MCRunOnMainThreadHelper(p_callback, p_callback_state, p_options & ~kMCExternalRunOnMainThreadPost);
 		MCAndroidEngineCall("nativeNotify", "vii", nil, MCRunOnMainThreadHelper::DispatchThunk, t_helper);
 		return true;
 	}
@@ -2916,7 +2916,7 @@ bool android_run_on_main_thread(void *p_callback, void *p_callback_state, int p_
 	// Safe and immediate -> post to front of event queue
 	// Unsafe/Safe and deferred -> post to back of event queue
 	MCRunOnMainThreadEvent *t_event;
-	t_event = new MCRunOnMainThreadEvent(p_callback, p_callback_state, p_options);
+	t_event = new (nothrow) MCRunOnMainThreadEvent(p_callback, p_callback_state, p_options);
 	if ((p_options & kMCExternalRunOnMainThreadDeferred) != 0)
 		MCEventQueuePostCustom(t_event);
 	else

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -529,7 +529,7 @@ bool MCAndroidSystem::ListFolderEntries(MCStringRef p_folder, MCSystemListFolder
 	 * path, a path separator character, and any possible filename. */
 	size_t t_path_len = strlen(*t_path);
 	size_t t_entry_path_len = t_path_len + 1 + NAME_MAX;
-	char *t_entry_path = new char[t_entry_path_len + 1];
+	char *t_entry_path = new (nothrow) char[t_entry_path_len + 1];
 	strcpy (t_entry_path, *t_path);
 	if ((*t_path)[t_path_len - 1] != '/')
 	{

--- a/engine/src/mblandroidinput.cpp
+++ b/engine/src/mblandroidinput.cpp
@@ -970,7 +970,7 @@ void MCAndroidInputControl::DeleteView(jobject p_view)
 
 bool MCNativeInputControlCreate(MCNativeControl *&r_control)
 {
-    MCAndroidInputControl *t_control = new MCAndroidInputControl();
+    MCAndroidInputControl *t_control = new (nothrow) MCAndroidInputControl();
     // configure as single-line input control
     t_control->SetMultiLine(false);
     
@@ -981,7 +981,7 @@ bool MCNativeInputControlCreate(MCNativeControl *&r_control)
 bool MCNativeMultiLineInputControlCreate(MCNativeControl *&r_control)
 {
     // configure as multi-line input control
-    MCAndroidInputControl *t_control = new MCAndroidInputControl();
+    MCAndroidInputControl *t_control = new (nothrow) MCAndroidInputControl();
     t_control->SetMultiLine(true);
     
     r_control = t_control;

--- a/engine/src/mblandroidio.cpp
+++ b/engine/src/mblandroidio.cpp
@@ -296,7 +296,7 @@ IO_handle MCAndroidSystem::OpenFile(MCStringRef p_path, intenum_t p_mode, Boolea
 			return NULL;
 		}
         
-		t_handle = new MCAssetFileHandle(t_stream, t_size, t_offset);
+		t_handle = new (nothrow) MCAssetFileHandle(t_stream, t_size, t_offset);
     }
 	else
 	{
@@ -314,7 +314,7 @@ IO_handle MCAndroidSystem::OpenFile(MCStringRef p_path, intenum_t p_mode, Boolea
         if (t_stream == NULL)
             return NULL;
         
-        t_handle = new MCStdioFileHandle(t_stream);
+        t_handle = new (nothrow) MCStdioFileHandle(t_stream);
 	}
     
     return t_handle;

--- a/engine/src/mblandroidorientation.cpp
+++ b/engine/src/mblandroidorientation.cpp
@@ -222,7 +222,7 @@ struct MCOrientationChangedEvent: public MCCustomEvent
 void MCAndroidOrientationChanged(int orientation)
 {
 //	MCLog("MCAndroidOrientationChanged(%d)", orientation);
-	MCCustomEvent *t_orientation_event = new MCOrientationChangedEvent();
+	MCCustomEvent *t_orientation_event = new (nothrow) MCOrientationChangedEvent();
 	MCEventQueuePostCustom(t_orientation_event);
 }
 

--- a/engine/src/mblandroidplayer.cpp
+++ b/engine/src/mblandroidplayer.cpp
@@ -317,7 +317,7 @@ void MCAndroidPlayerControl::DeleteView(jobject p_view)
 
 bool MCNativePlayerControlCreate(MCNativeControl *&r_control)
 {
-    r_control = new MCAndroidPlayerControl();
+    r_control = new (nothrow) MCAndroidPlayerControl();
     return true;
 }
 
@@ -413,7 +413,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_nativecontrol_VideoControl_doProp
         }
         MCAndroidPlayerControl *t_player = (MCAndroidPlayerControl*)t_control;
         MCCustomEvent *t_event;
-        t_event = new MCNativePlayerPropertyAvailableEvent(t_player, t_prop_name);
+        t_event = new (nothrow) MCNativePlayerPropertyAvailableEvent(t_player, t_prop_name);
         MCEventQueuePostCustom(t_event);
     }
 }

--- a/engine/src/mblandroidscroller.cpp
+++ b/engine/src/mblandroidscroller.cpp
@@ -498,7 +498,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_nativecontrol_ScrollerControl_doS
         {
             t_scroller->SetCanPostScrollEvent(false);
             MCCustomEvent *t_event;
-            t_event = new MCNativeScrollerScrollEvent(t_scroller);
+            t_event = new (nothrow) MCNativeScrollerScrollEvent(t_scroller);
             MCEventQueuePostCustom(t_event);
         }
     }
@@ -547,7 +547,7 @@ void MCAndroidScrollerControl::DeleteView(jobject p_view)
 
 bool MCNativeScrollerControlCreate(MCNativeControl *&r_control)
 {
-    r_control = new MCAndroidScrollerControl();
+    r_control = new (nothrow) MCAndroidScrollerControl();
     return true;
 }
 

--- a/engine/src/mblandroidstore.cpp
+++ b/engine/src/mblandroidstore.cpp
@@ -766,7 +766,7 @@ bool MCStorePostProductRequestResponse(MCStringRef p_product_id)
 {
     bool t_success;
     MCCustomEvent *t_event = nil;
-    t_event = new MCStoreProductRequestResponseEvent(p_product_id);
+    t_event = new (nothrow) MCStoreProductRequestResponseEvent(p_product_id);
     t_success = t_event != nil;
     
     if (t_success)
@@ -813,7 +813,7 @@ bool MCStorePostProductRequestError(MCStringRef p_product, MCStringRef p_error)
 {
     bool t_success;
     MCCustomEvent *t_event = nil;
-    t_event = new MCStoreProductRequestErrorEvent(p_product, p_error);
+    t_event = new (nothrow) MCStoreProductRequestErrorEvent(p_product, p_error);
     t_success = t_event != nil;
     
     if (t_success)

--- a/engine/src/mblandroidtypeface.cpp
+++ b/engine/src/mblandroidtypeface.cpp
@@ -31,7 +31,7 @@ bool MCAndroidTypefaceCreateWithData(void *p_data, uint32_t p_length, MCAndroidT
     t_stream = nil;
     if (t_success)
     {
-        t_stream = new SkMemoryStream(p_data, p_length, false);
+        t_stream = new (nothrow) SkMemoryStream(p_data, p_length, false);
         t_success = t_stream != nil;
     }
     

--- a/engine/src/mblcontact.cpp
+++ b/engine/src/mblcontact.cpp
@@ -56,7 +56,7 @@ bool MCContactAddPropertyWithLabel(MCExecPoint& ep, MCVariableValue *p_contact, 
 {
 	bool t_success = true;
 	MCVariableValue *t_element;
-	t_element = new MCVariableValue();
+	t_element = new (nothrow) MCVariableValue();
 	
 	t_success = t_element != nil &&
 		t_element->assign_string(p_value) &&

--- a/engine/src/mbldc.cpp
+++ b/engine/src/mbldc.cpp
@@ -106,7 +106,7 @@ struct MCActiveTouch
 MCScreenDC::MCScreenDC(void)
 {
 	// Initialize the window stacks.
-	m_main_windows = new MCWindowStack;
+	m_main_windows = new (nothrow) MCWindowStack;
 	
 	// Initialize the list of active touches.
 	m_active_touches = nil;
@@ -254,7 +254,7 @@ void MCScreenDC::process_touch(MCEventTouchPhase p_phase, void *p_touch_handle, 
 			uint32_t t_touch_id;
 			t_touch_id = ++m_last_touch_id;
 			
-			t_touch = new MCActiveTouch;
+			t_touch = new (nothrow) MCActiveTouch;
 			t_touch -> ident = t_touch_id;
 			t_touch -> touch = p_touch_handle;
 			t_touch -> next = m_active_touches;
@@ -548,7 +548,7 @@ void MCScreenDC::unfocus_current_window(void)
 MCMobileBitmap *MCMobileBitmapCreate(uint32_t width, uint32_t height, bool mono)
 {
 	MCMobileBitmap *t_bitmap;
-	t_bitmap = new MCMobileBitmap;
+	t_bitmap = new (nothrow) MCMobileBitmap;
 	t_bitmap -> width = width;
 	t_bitmap -> height = height;
 	if (mono)

--- a/engine/src/mblflst.cpp
+++ b/engine/src/mblflst.cpp
@@ -45,7 +45,7 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style)
 	reqstyle = style;
     
 #if defined(TARGET_SUBPLATFORM_IPHONE)
-	font = new MCFontStruct;
+	font = new (nothrow) MCFontStruct;
 	font -> size = size;
 	
 	uindex_t t_comma;
@@ -62,7 +62,7 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style)
 	iphone_font_get_metrics(font -> fid,  font->m_ascent, font->m_descent, font->m_leading, font->m_xheight);
     
 #elif defined(TARGET_SUBPLATFORM_ANDROID)
-	font = new MCFontStruct;
+	font = new (nothrow) MCFontStruct;
 	font -> size = size;
 	
 	uindex_t t_comma;
@@ -94,7 +94,7 @@ MCFontnode::MCFontnode(MCSysFontHandle p_handle, MCNameRef p_name)
     reqsize = coretext_get_font_size(p_handle);
     reqstyle = FA_DEFAULT_STYLE | FA_SYSTEM_FONT;
     
-    font = new MCFontStruct;
+    font = new (nothrow) MCFontStruct;
     font->size = reqsize;
     
     font->fid = p_handle;
@@ -151,7 +151,7 @@ MCFontStruct *MCFontlist::getfont(MCNameRef fname, uint2 &size, uint2 style, Boo
 			tmp = tmp->next();
 		}
 		while (tmp != fonts);
-	tmp = new MCFontnode(fname, size, style);
+	tmp = new (nothrow) MCFontnode(fname, size, style);
 	tmp->appendto(fonts);
 	return tmp->getfont(fname, size, style);
 }
@@ -171,7 +171,7 @@ MCFontStruct *MCFontlist::getfontbyhandle(MCSysFontHandle p_fid, MCNameRef p_nam
     while (tmp != fonts);
     
     // Font has not yet been added to the list
-    tmp = new MCFontnode(p_fid, p_name);
+    tmp = new (nothrow) MCFontnode(p_fid, p_name);
     tmp->appendto(fonts);
     return tmp->getfontstruct();
 }

--- a/engine/src/mblnotification.cpp
+++ b/engine/src/mblnotification.cpp
@@ -108,7 +108,7 @@ bool MCNotificationPostCustom(MCNameRef p_name, uint32_t p_param_count, ...)
 		t_value = va_arg(t_args, MCValueRef);
 		
 		MCParameter *t_new_param;
-		t_new_param = new MCParameter();
+		t_new_param = new (nothrow) MCParameter();
 		t_success = t_new_param != nil;
 		
 		if (t_success)
@@ -130,7 +130,7 @@ bool MCNotificationPostCustom(MCNameRef p_name, uint32_t p_param_count, ...)
 	
 	if (t_success)
 	{
-		t_event = new MCNotificationEvent(p_name, t_param_list);
+		t_event = new (nothrow) MCNotificationEvent(p_name, t_param_list);
 		t_success = t_event != nil;
 	}
 	

--- a/engine/src/mblsensor.cpp
+++ b/engine/src/mblsensor.cpp
@@ -398,7 +398,7 @@ static MCSensorUpdateEvent * FetchSensorEvent(MCSensorType p_sensor)
     if (!s_sensor_message_pending[p_sensor])
     {
         s_sensor_message_pending[p_sensor] = true;
-        t_event = new MCSensorUpdateEvent(p_sensor);
+        t_event = new (nothrow) MCSensorUpdateEvent(p_sensor);
     }
     return t_event;        
 }
@@ -418,7 +418,7 @@ void MCSensorAddLocationSample(const MCSensorLocationReading& p_reading)
     }
     
     MCSensorLocationReading *t_reading;
-    t_reading = new MCSensorLocationReading(p_reading);
+    t_reading = new (nothrow) MCSensorLocationReading(p_reading);
     if (t_reading == nil)
         return;
     
@@ -459,7 +459,7 @@ void MCSensorPostChangeMessage(MCSensorType p_sensor)
 void MCSensorPostErrorMessage(MCSensorType p_sensor, MCStringRef p_error)
 {
     MCCustomEvent *t_event = nil;
-	t_event = new MCSensorErrorEvent(p_sensor, p_error);
+	t_event = new (nothrow) MCSensorErrorEvent(p_sensor, p_error);
 	MCEventQueuePostCustom(t_event);
 }
 

--- a/engine/src/mblsound.cpp
+++ b/engine/src/mblsound.cpp
@@ -73,7 +73,7 @@ private:
 void MCSoundPostSoundFinishedOnChannelMessage(MCStringRef p_channel, MCStringRef p_sound, MCObjectHandle p_object)
 {
     MCCustomEvent *t_event = nil;
-    t_event = new MCSoundFinishedOnChannelEvent(p_object, p_channel, p_sound);
+    t_event = new (nothrow) MCSoundFinishedOnChannelEvent(p_object, p_channel, p_sound);
     if (t_event != nil)
         MCEventQueuePostCustom(t_event);
 }

--- a/engine/src/mblstore.cpp
+++ b/engine/src/mblstore.cpp
@@ -356,7 +356,7 @@ void MCPurchaseNotifyUpdate(MCPurchase *p_purchase)
 	
     //MCLog("posting new update event", p_purchase);
 	MCCustomEvent *t_event;
-	t_event = new MCPurchaseUpdateEvent(p_purchase);
+	t_event = new (nothrow) MCPurchaseUpdateEvent(p_purchase);
 	MCEventQueuePostCustom(t_event);
 }
 

--- a/engine/src/mcssl.cpp
+++ b/engine/src/mcssl.cpp
@@ -156,7 +156,7 @@ unsigned long SSLError(MCStringRef& errbuf)
     if (ecode)
     {
         MCAutoPointer<char> t_errbuf;
-        t_errbuf = new char[256];
+        t_errbuf = new (nothrow) char[256];
         ERR_error_string_n(ecode,&t_errbuf,255);
         /* UNCHECKED */ MCStringCreateWithCString(*t_errbuf, errbuf);
     }

--- a/engine/src/mcutility.cpp
+++ b/engine/src/mcutility.cpp
@@ -52,7 +52,7 @@ char *strclone(const char *one)
 	char *two = NULL;
 	if (one != NULL)
 	{
-		two = new char[strlen(one) + 1];
+		two = new (nothrow) char[strlen(one) + 1];
 		strcpy(two, one);
 	}
 	return two;
@@ -60,7 +60,7 @@ char *strclone(const char *one)
 
 char *strclone(const char *one, uint4 length)
 {
-	char *two = new char[length + 1];
+	char *two = new (nothrow) char[length + 1];
 	memcpy(two, one, length);
 	two[length] = '\0';
 	return two;
@@ -158,7 +158,7 @@ MCString::MCString(const char *s)
 
 char *MCString::clone() const
 {
-	char *dptr = new char[length + 1];
+	char *dptr = new (nothrow) char[length + 1];
 	memcpy(dptr, sptr, length);
 	dptr[length] = '\0';
 	return dptr;

--- a/engine/src/meta.h
+++ b/engine/src/meta.h
@@ -261,7 +261,7 @@ private:
 
 		if (t_items != NULL)
 		{
-			f_items = new simple_string[t_count];
+			f_items = new (nothrow) simple_string[t_count];
 			if (f_items != NULL)
 			{
 				f_count = t_count;
@@ -276,7 +276,7 @@ private:
 		}
 		else
 		{
-			f_items = new simple_string[1];
+			f_items = new (nothrow) simple_string[1];
 			if (f_items != NULL)
 			{
 				f_count = 1;

--- a/engine/src/metacontext.cpp
+++ b/engine/src/metacontext.cpp
@@ -105,7 +105,7 @@ void MCMetaContext::begin(bool p_overlap)
 	}
 
 	MCMarkState *t_new_state;
-	t_new_state = new MCMarkState;
+	t_new_state = new (nothrow) MCMarkState;
 	
 	MCMark *t_root_mark;
 	t_root_mark = NULL;
@@ -932,7 +932,7 @@ void MCMetaContext::executegroup(MCMark *p_group_mark)
 					t_success = begincomposite(t_dst_clip, t_context);
 				
 				if (t_success)
-					t_success = nil != (t_gfx_context = new MCGraphicsContext(t_context));
+					t_success = nil != (t_gfx_context = new (nothrow) MCGraphicsContext(t_context));
 				
 				if (t_success)
 				{

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -542,7 +542,7 @@ bool MCObjectListAppend(MCObjectList *&x_list, MCObject *p_object, bool p_unique
 	MCObjectList *t_newobject;
 	t_newobject = nil;
 	
-	t_newobject = new MCObjectList(p_object);
+	t_newobject = new (nothrow) MCObjectList(p_object);
 	
 	if (t_newobject == nil)
 		return false;
@@ -1491,7 +1491,7 @@ void MCModeSetRevLicenseLimits(MCExecContext& ctxt, MCArrayRef p_settings)
 static MCObject *getobj(MCExecContext& ctxt, MCStringRef p_string)
 {    
     MCObject *objptr = NULL;
-    MCChunk *tchunk = new MCChunk(False);
+    MCChunk *tchunk = new (nothrow) MCChunk(False);
     MCerrorlock++;
     MCScriptPoint sp(p_string);
     if (tchunk->parse(sp, False) == PS_NORMAL)

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1218,7 +1218,7 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
     case kMCCapsuleSectionTypeStartupScript:
     {
         char *t_script;
-        t_script = new char[p_length];
+        t_script = new (nothrow) char[p_length];
         if (IO_read(t_script, p_length, p_stream) != IO_NORMAL)
         {
             MCresult -> sets("failed to read startup script");

--- a/engine/src/mode_server.cpp
+++ b/engine/src/mode_server.cpp
@@ -118,7 +118,7 @@ MCPropertyTable MCProperty::kModePropertyTable =
 
 IO_stat MCDispatch::startup(void)
 {
-	stacks = new MCServerScript;
+	stacks = new (nothrow) MCServerScript;
 	stacks -> setname_cstring("Home");
 	stacks -> setparent(this);
 

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -225,7 +225,7 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 	case kMCCapsuleSectionTypeRedirect:
 	{
 		char *t_redirect;
-		t_redirect = new char[p_length];
+		t_redirect = new (nothrow) char[p_length];
 		if (IO_read(t_redirect, p_length, p_stream) != IO_NORMAL)
 		{
 			MCresult -> sets("failed to read redirect ref");
@@ -243,7 +243,7 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
     case kMCCapsuleSectionTypeFontmap:
     {
         char *t_fontmap;
-        t_fontmap = new char[p_length];
+        t_fontmap = new (nothrow) char[p_length];
         if (IO_read(t_fontmap, p_length, p_stream) != IO_NORMAL)
         {
             MCresult -> sets("failed to read fontmap");

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -6026,7 +6026,7 @@ extern "C" MC_DLLEXPORT_DEF void MCCanvasGetPixelDataOfCanvas(MCCanvasRef p_canv
     t_pixel_count = t_width * t_height;
     
     uint32_t *t_my_pixels, *t_data_ptr;
-    t_my_pixels = new uint32_t[t_pixel_count];
+    t_my_pixels = new (nothrow) uint32_t[t_pixel_count];
     memcpy(t_my_pixels, t_pixels, t_pixel_count * sizeof(uint32_t));
     
     t_data_ptr = t_my_pixels;

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -132,7 +132,7 @@ extern "C" MC_DLLEXPORT_DEF MCScriptObjectRef MCEngineExecResolveScriptObject(MC
     
 	// Create a new chunk object to parse the reference into.
     MCChunk *t_chunk;
-    t_chunk = new MCChunk(False);
+    t_chunk = new (nothrow) MCChunk(False);
     if (t_chunk == nil)
     {
         MCErrorThrowOutOfMemory();
@@ -417,7 +417,7 @@ static bool MCEngineConvertToScriptParameters(MCExecContext& ctxt, MCProperListR
         }
         
 		MCParameter *t_param;
-		t_param = new MCParameter;
+		t_param = new (nothrow) MCParameter;
 		t_param -> setvalueref_argument(t_value);
         
 		if (t_last_param == nil)

--- a/engine/src/notify.cpp
+++ b/engine/src/notify.cpp
@@ -121,7 +121,7 @@ static MCNotifySyncEvent *MCNotifySyncEventCreate(void)
 		return MCListPopFront(s_sync_events);
 
 	MCNotifySyncEvent *t_event;
-	t_event = new MCNotifySyncEvent;
+	t_event = new (nothrow) MCNotifySyncEvent;
 	t_event -> next = NULL;
 
 #if defined(USE_WINTHREADS)
@@ -377,7 +377,7 @@ bool MCNotifyPush(void (*p_callback)(void *), void *p_state, bool p_block, bool 
 	MCNotification *t_notification;
 	t_notification = NULL;
 	if (t_success)
-		t_notification = new MCNotification;
+		t_notification = new (nothrow) MCNotification;
 
 	// Fill it in.
 	if (t_success)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -190,8 +190,8 @@ MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
 	ncolors = oref.ncolors;
 	if (ncolors > 0)
 	{
-		colors = new MCColor[ncolors];
-		colornames = new MCStringRef[ncolors];
+		colors = new (nothrow) MCColor[ncolors];
+		colornames = new (nothrow) MCStringRef[ncolors];
 		uint2 i;
 		for (i = 0 ; i < ncolors ; i++)
 		{
@@ -1780,8 +1780,8 @@ uint2 MCObject::createcindex(uint2 di)
 	MCColor *oldcolors = colors;
 	MCStringRef *oldnames = colornames;
 	ncolors++;
-	colors = new MCColor[ncolors];
-	colornames = new MCStringRef[ncolors];
+	colors = new (nothrow) MCColor[ncolors];
+	colornames = new (nothrow) MCStringRef[ncolors];
 	uint2 ri = 0;
 	uint2 i = 0;
 	uint2 c = 0;
@@ -2333,7 +2333,7 @@ bool MCObject::getnameproperty(Properties which, uint32_t p_part_id, MCValueRef&
     MCAutoPointer<char[]> tmptypestring;
     if (parent != NULL && gettype() >= CT_BUTTON && getstack()->hcaddress())
     {
-        tmptypestring = new char[strlen(itypestring) + 7];
+        tmptypestring = new (nothrow) char[strlen(itypestring) + 7];
         if (parent->gettype() == CT_GROUP)
             sprintf(*tmptypestring, "%s %s", "bkgnd", itypestring);
         else
@@ -2461,7 +2461,7 @@ Boolean MCObject::parsescript(Boolean report, Boolean force)
 			MCscreen->cancelmessageobject(this, MCM_idle);
 			hashandlers = 0;
 			if (hlist == NULL)
-				hlist = new MCHandlerlist;
+				hlist = new (nothrow) MCHandlerlist;
 			
 			getstack() -> unsecurescript(this);
 			
@@ -2634,8 +2634,8 @@ void MCObject::draw3d(MCDC *dc, const MCRectangle &drect,
 	MCLineSegment *b = bb;
 	if (bwidth > DEFAULT_BORDER)
 	{
-		t = new MCLineSegment[bwidth * 2];
-		b = new MCLineSegment[bwidth * 2];
+		t = new (nothrow) MCLineSegment[bwidth * 2];
+		b = new (nothrow) MCLineSegment[bwidth * 2];
 	}
 	int2 lx = drect.x;
 	int2 rx = drect.x + drect.width;
@@ -2880,7 +2880,7 @@ Exec_stat MCObject::domess(MCStringRef sptr)
 	MCAutoStringRef t_temp_script;
 	/* UNCHECKED */ MCStringFormat(&t_temp_script, "on message\n%@\nend message\n", sptr);
 	
-	MCHandlerlist *handlist = new MCHandlerlist;
+	MCHandlerlist *handlist = new (nothrow) MCHandlerlist;
 	// SMR 1947, suppress parsing errors
 	MCerrorlock++;
 	if (handlist->parse(this, *t_temp_script) != PS_NORMAL)
@@ -2917,7 +2917,7 @@ void MCObject::eval(MCExecContext &ctxt, MCStringRef p_script, MCValueRef &r_val
 	MCAutoStringRef t_temp_script;
 	/* UNCHECKED */ MCStringFormat(&t_temp_script, "on eval\nreturn %@\nend eval\n", p_script);
 	
-	MCHandlerlist *handlist = new MCHandlerlist;
+	MCHandlerlist *handlist = new (nothrow) MCHandlerlist;
 	if (handlist->parse(this, *t_temp_script) != PS_NORMAL)
 	{
 		r_value = MCSTR("Error parsing expression\n");
@@ -3070,7 +3070,7 @@ MCImageBitmap *MCObject::snapshot(const MCRectangle *p_clip, const MCPoint *p_si
 	
 	// MW-2014-01-07: [[ bug 11632 ]] Use the offscreen variant of the context so its
 	//   type field is appropriate for use by the player.
-	MCContext *t_context = new MCOffscreenGraphicsContext(t_gcontext);
+	MCContext *t_context = new (nothrow) MCOffscreenGraphicsContext(t_gcontext);
 	t_context -> setclip(r);
 
 	// MW-2011-01-29: [[ Bug 9355 ]] Make sure we only open a control if it needs it!
@@ -3254,8 +3254,8 @@ IO_stat MCObject::load(IO_handle stream, uint32_t version)
 		return checkloadstat(stat);
 	if (ncolors > 0)
 	{
-		colors = new MCColor[ncolors];
-		colornames = new MCStringRef[ncolors];
+		colors = new (nothrow) MCColor[ncolors];
+		colornames = new (nothrow) MCStringRef[ncolors];
 		for (i = 0 ; i < ncolors ; i++)
 		{
 			if ((stat = IO_read_mccolor(colors[i], stream)) != IO_NORMAL)
@@ -4252,7 +4252,7 @@ MCObjectHandle MCObject::GetHandle(void) const
 {
 	if (m_weak_proxy == NULL)
 	{
-		m_weak_proxy = new MCObjectProxy(this);
+		m_weak_proxy = new (nothrow) MCObjectProxy(this);
         if (!m_weak_proxy)
             return nil;
 	}
@@ -4347,7 +4347,7 @@ static void compute_objectshape_mask(MCObject *p_object, const MCObjectShape& p_
 	MCGContextClipToRect(t_context, MCRectangleToMCGRectangle(t_rect));
 
 	MCContext *t_gfxcontext = nil;
-	/* UNCHECKED */ t_gfxcontext = new MCGraphicsContext(t_context);
+	/* UNCHECKED */ t_gfxcontext = new (nothrow) MCGraphicsContext(t_context);
 	
 	// Make sure the object is opened.
 	bool t_needs_open;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -450,7 +450,8 @@ struct MCPatternInfo
 	MCPatternRef pattern;
 };
 
-class MCObject : public MCDLlist
+class MCObject :
+  public MCDLlist
 {
 protected:
 	uint4 obj_id;
@@ -560,6 +561,7 @@ public:
 	MCObject();
 	MCObject(const MCObject &oref);
 	virtual ~MCObject();
+    
 	virtual Chunk_term gettype() const;
 	virtual const char *gettypestring();
 

--- a/engine/src/objectpropsets.cpp
+++ b/engine/src/objectpropsets.cpp
@@ -58,7 +58,7 @@ bool MCObjectPropertySet::clone(MCObjectPropertySet*& r_set)
 bool MCObjectPropertySet::createwithname_nocopy(MCNameRef p_name, MCObjectPropertySet*& r_set)
 {
 	MCObjectPropertySet *t_new_set;
-	t_new_set = new MCObjectPropertySet;
+	t_new_set = new (nothrow) MCObjectPropertySet;
 	if (t_new_set == nil)
 		return false;
 

--- a/engine/src/objectstream.cpp
+++ b/engine/src/objectstream.cpp
@@ -388,7 +388,7 @@ IO_stat MCObjectInputStream::Fill(void)
 	IO_stat t_stat;
 
 	if (m_buffer == nil)
-		m_buffer = new char[16384];
+		m_buffer = new (nothrow) char[16384];
 	
 	if (m_buffer == nil)
 		return IO_ERROR;
@@ -423,7 +423,7 @@ MCObjectOutputStream::MCObjectOutputStream(IO_handle p_stream)
 {
 	m_stream = p_stream;
 
-	m_buffer = new char[16384];
+	m_buffer = new (nothrow) char[16384];
 	m_frontier = 0;
 	m_mark = 0;
 }

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -848,7 +848,7 @@ MCDataRef MCS_read_socket(MCSocket *s, MCExecContext &ctxt, uint4 length, const 
 	}
 	else
 	{
-		MCSocketread *eptr = new MCSocketread(length, until != nil ? strdup(until) : nil, ctxt . GetObject(), mptr);
+		MCSocketread *eptr = new (nothrow) MCSocketread(length, until != nil ? strdup(until) : nil, ctxt . GetObject(), mptr);
 		eptr->appendto(s->revents);
 		s->setselect();
 		if (s->accepting)
@@ -1009,7 +1009,7 @@ void MCS_write_socket(const MCStringRef d, MCSocket *s, MCObject *optr, MCNameRe
 	{
 		// MM-2014-02-12: [[ SecureSocket ]] Store against the write if it should be encrypted.
 		//  This way, upon securing a socket, all pending writes will remain unencrypted whilst all new writes will be encrypted.
-		MCSocketwrite *eptr = new MCSocketwrite(d, optr, mptr, s->secure);
+		MCSocketwrite *eptr = new (nothrow) MCSocketwrite(d, optr, mptr, s->secure);
 		eptr->appendto(s->wevents);
 		s->setselect();
 		if (mptr == NULL)
@@ -1116,7 +1116,7 @@ MCSocket *MCS_accept(uint2 port, MCObject *object, MCNameRef message, Boolean da
     // AL-2015-01-05: [[ Bug 14287 ]] Create name using the number of chars written to the string.
     uindex_t t_length;
     MCAutoPointer<char_t[]> t_port_chars;
-    t_port_chars = new char_t[U2L];
+    t_port_chars = new (nothrow) char_t[U2L];
     t_length = sprintf((char *)(*t_port_chars), "%d", port);
 
 	MCNewAutoNameRef t_portname;
@@ -1466,7 +1466,7 @@ void MCSocket::acceptone()
 		MCNameRef t_name;
 		MCNameCreate(*n, t_name);
         MCSocket *t_socket;
-        t_socket = new MCSocket(t_name, object, NULL, False, newfd, False, False,False);
+        t_socket = new (nothrow) MCSocket(t_name, object, NULL, False, newfd, False, False,False);
         if (t_socket != NULL)
         {
             MCSocketsAppendToSocketList(t_socket);
@@ -1490,7 +1490,7 @@ void MCSocket::readsome()
 		MCS_socket_ioctl(fd, FIONREAD, t_available);
 		l = t_available;
 
-		char *dbuffer = new char[l + 1]; // don't allocate 0
+		char *dbuffer = new (nothrow) char[l + 1]; // don't allocate 0
 #if defined(_WINDOWS_DESKTOP) || defined(_WINDOWS_SERVER)
 
 		l++; // Not on MacOS/UNIX?
@@ -1498,7 +1498,7 @@ void MCSocket::readsome()
 		        == SOCKET_ERROR)
 		{
 			delete dbuffer;
-			error = new char[21 + I4L];
+			error = new (nothrow) char[21 + I4L];
 			sprintf(error, "Error %d on socket", WSAGetLastError());
 			doclose();
 		}
@@ -1509,7 +1509,7 @@ void MCSocket::readsome()
 			delete[] dbuffer;
 			if (!doread && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR)
 			{
-				error = new char[21 + I4L];
+				error = new (nothrow) char[21 + I4L];
 				sprintf(error, "Error %d reading socket", errno);
 				doclose();
 			}
@@ -1531,7 +1531,7 @@ void MCSocket::readsome()
 				if (accepting && !IO_findsocket(*t_name, index))
 				{
                     MCSocket *t_socket;
-                    t_socket = new MCSocket(*t_name, object, NULL, True, fd, False, True,False);
+                    t_socket = new (nothrow) MCSocket(*t_name, object, NULL, True, fd, False, True,False);
                     if (t_socket != NULL)
                         MCSocketsAppendToSocketList(t_socket);
 				}
@@ -1539,7 +1539,7 @@ void MCSocket::readsome()
 				MCAutoDataRef t_data;
 				/* UNCHECKED */ MCDataCreateWithBytes((const byte_t *)dbuffer, l, &t_data);
 				
-				MCParameter *params = new MCParameter;
+				MCParameter *params = new (nothrow) MCParameter;
 				params->setvalueref_argument(*t_name);
 				params->setnext(new MCParameter);
 				params->getnext()->setvalueref_argument(*t_data);
@@ -1573,7 +1573,7 @@ void MCSocket::readsome()
 				/* UNCHECKED */ MCStringFormat(&n, "%s:%d", t, MCSwapInt16NetworkToHost(addr.sin_port));
 				/* UNCHECKED */ MCNameCreate(*n, &t_name);
                 MCSocket *t_socket;
-                t_socket = new MCSocket(*t_name, object, NULL, False, newfd, False, False,secure);
+                t_socket = new (nothrow) MCSocket(*t_name, object, NULL, False, newfd, False, False,secure);
                 if (t_socket != NULL)
                 {
                     MCSocketsAppendToSocketList(t_socket);
@@ -1639,7 +1639,7 @@ void MCSocket::readsome()
 								error = sslgraberror();
 							else
 							{
-								error = new char[21 + I4L];
+								error = new (nothrow) char[21 + I4L];
 								sprintf(error, "Error %d reading socket", errno);
 							}
 						}
@@ -1688,7 +1688,7 @@ void MCSocket::processreadqueue()
 				memmove(rbuffer, rbuffer + revents->size, nread);
 				MCSocketread *e = revents->remove
 				                  (revents);
-				MCParameter *params = new MCParameter;
+				MCParameter *params = new (nothrow) MCParameter;
 				params->setvalueref_argument(name);
 				params->setnext(new MCParameter);
 				params->getnext()->setvalueref_argument(*t_data);
@@ -1742,7 +1742,7 @@ void MCSocket::writesome()
 					error = sslgraberror();
 				else
 				{
-					error = new char[16 + I4L];
+					error = new (nothrow) char[16 + I4L];
 					sprintf(error, "Error %d on socket", errno);
 				}
 				doclose();
@@ -2017,7 +2017,7 @@ char *MCSocket::sslgraberror()
 		ecode = ERR_get_error();
 		if (ecode != 0)
 		{
-			terror = new char[256];
+			terror = new (nothrow) char[256];
 			ERR_error_string_n(ecode,terror,255);
 		}
 	}

--- a/engine/src/operator.cpp
+++ b/engine/src/operator.cpp
@@ -1077,13 +1077,13 @@ Parse_stat MCThere::parse(MCScriptPoint &sp, Boolean the)
 	if (sp.lookup(SP_THERE, te) != PS_NORMAL)
 	{
 		sp.backup();
-		object = new MCChunk(False);
+		object = new (nothrow) MCChunk(False);
 		if (object->parse(sp, False) != PS_NORMAL)
 		{
 			MCperror->add(PE_THERE_NOOBJECT, sp);
 			return PS_ERROR;
 		}
-		right = new MCExpression(); // satisfy check in scriptpt.parse
+		right = new (nothrow) MCExpression(); // satisfy check in scriptpt.parse
 	}
 	else
 	{

--- a/engine/src/osxflst.cpp
+++ b/engine/src/osxflst.cpp
@@ -74,7 +74,7 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style)
     
     uinteger_t t_comma_index;
     MCAutoStringRef t_reqname;
-	font = new MCFontStruct; //create MCFont structure
+	font = new (nothrow) MCFontStruct; //create MCFont structure
 	font -> size = size;
 	
     if (MCStringFirstIndexOfChar(MCNameGetString(fname), ',', 0, kMCStringOptionCompareExact, t_comma_index))
@@ -110,7 +110,7 @@ MCFontnode::MCFontnode(MCSysFontHandle p_handle, MCNameRef p_name)
     reqsize = coretext_get_font_size(p_handle);
     reqstyle = FA_DEFAULT_STYLE | FA_SYSTEM_FONT;
     
-    font = new MCFontStruct;
+    font = new (nothrow) MCFontStruct;
     font->size = reqsize;
     
     font->fid = p_handle;
@@ -176,7 +176,7 @@ MCFontStruct *MCFontlist::getfont(MCNameRef fname, uint2 &size, uint2 style, Boo
 			tmp = tmp->next();
 		}
 		while (tmp != fonts);
-	tmp = new MCFontnode(fname, size, style);
+	tmp = new (nothrow) MCFontnode(fname, size, style);
 	tmp->appendto(fonts);
 	return tmp->getfont(fname, size, style);
 }
@@ -195,7 +195,7 @@ MCFontStruct *MCFontlist::getfontbyhandle(MCSysFontHandle p_fid, MCNameRef p_nam
     while (tmp != fonts);
     
     // Font has not yet been added to the list
-    tmp = new MCFontnode(p_fid, p_name);
+    tmp = new (nothrow) MCFontnode(p_fid, p_name);
     tmp->appendto(fonts);
     return tmp->getfontstruct();
 }

--- a/engine/src/osxprinter.cpp
+++ b/engine/src/osxprinter.cpp
@@ -303,7 +303,7 @@ MCPrinterResult MCMacOSXPrinter::DoBeginPrint(MCStringRef p_document_name, MCPri
 	GetProperties(true);
 
 	MCMacOSXPrinterDevice *t_device;
-	t_device = new MCMacOSXPrinterDevice;
+	t_device = new (nothrow) MCMacOSXPrinterDevice;
 
 	MCPrinterResult t_result;
 	t_result = t_device -> Start(m_session, m_settings, m_page_format, GetJobColor());
@@ -1525,7 +1525,7 @@ void MCQuartzMetaContext::domark(MCMark *p_mark)
 		
 		if (p_mark -> stroke -> dash . length > 1)
 		{
-			CGFloat *t_lengths = new CGFloat[p_mark -> stroke -> dash . length];
+			CGFloat *t_lengths = new (nothrow) CGFloat[p_mark -> stroke -> dash . length];
 			for(uint4 i = 0; i < p_mark -> stroke -> dash . length; i++)
 				t_lengths[i] = p_mark -> stroke -> dash . data[i];
 			CGContextSetLineDash(m_context, p_mark -> stroke -> dash . offset, t_lengths, p_mark -> stroke -> dash . length);
@@ -2094,7 +2094,7 @@ MCPrinterResult MCMacOSXPrinterDevice::Begin(const MCPrinterRectangle& p_src_rec
 	t_page_height = ceil(t_paper_rect . bottom - t_paper_rect . top);
 	
 	MCQuartzMetaContext *t_context;
-	t_context = new MCQuartzMetaContext(t_src_rect_hull, t_page_width, t_page_height);
+	t_context = new (nothrow) MCQuartzMetaContext(t_src_rect_hull, t_page_width, t_page_height);
 	r_context = t_context;
 
 	m_src_rect = p_src_rect;

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -138,7 +138,7 @@ MCParagraph::MCParagraph(const MCParagraph &pref) : MCDLlist(pref)
 		MCBlock *bptr = pref.blocks;
 		do
 		{
-			MCBlock *tbptr = new MCBlock(*bptr);
+			MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
 			tbptr->appendto(blocks);
 			tbptr->setparent(this);
 			bptr = bptr->next();
@@ -194,7 +194,7 @@ MCBlock* MCParagraph::AppendText(MCStringRef p_string)
 	if (t_block->GetLength() > 0)
 	{
 		// Block already contains data, create a new one
-		MCBlock *t_newblock = new MCBlock;
+		MCBlock *t_newblock = new (nothrow) MCBlock;
 		t_newblock->setparent(this);
 		t_block->append(t_newblock);
 		t_block = t_newblock;
@@ -307,7 +307,7 @@ void MCParagraph::SetBlockDirectionLevel(findex_t si, findex_t ei, uint8_t level
         if (t_block_index < si)
         {
             // Starts part of the way through this block
-            MCBlock *tbptr = new MCBlock(*bptr);
+            MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
             bptr->append(tbptr);
             bptr->SetRange(t_block_index, si - t_block_index);
             tbptr->SetRange(si, t_block_length - (si - t_block_index));
@@ -321,7 +321,7 @@ void MCParagraph::SetBlockDirectionLevel(findex_t si, findex_t ei, uint8_t level
         if (t_block_index + t_block_length > ei)
         {
             // Ends part of the way through this block
-            MCBlock *tbptr = new MCBlock(*bptr);
+            MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
             if (getopened())
                 tbptr->open(getparent()->getfontref());
             bptr->append(tbptr);
@@ -522,7 +522,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 				case OT_BLOCK:
 				case OT_BLOCK_EXT:
 				{
-					MCBlock *newblock = new MCBlock;
+					MCBlock *newblock = new (nothrow) MCBlock;
 					newblock->setparent(this);
 					
 					// MW-2012-03-04: [[ StackFile5500 ]] If the tag was actually an
@@ -688,7 +688,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 				case OT_BLOCK:
 				case OT_BLOCK_EXT:
 				{
-					MCBlock *newblock = new MCBlock;
+					MCBlock *newblock = new (nothrow) MCBlock;
 					newblock->setparent(this);
 					
 					// MW-2012-03-04: [[ StackFile5500 ]] If the tag was actually an
@@ -763,7 +763,7 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part, uint32_t p_version)
 			// For file format compatibility, swap_uint2 must be called on each 
 			// character in the UTF-16 string (Unicodeness is now a paragraph
 			// property, not a block property, so it is done for all the text)
-			unichar_t *t_swapped_data = new unichar_t[t_data_len/sizeof(unichar_t)];
+			unichar_t *t_swapped_data = new (nothrow) unichar_t[t_data_len/sizeof(unichar_t)];
 			memcpy(t_swapped_data, t_data, t_data_len);
 			for (uindex_t i = 0; i < MCStringGetLength(m_text); i++)
 			{
@@ -1073,7 +1073,7 @@ void MCParagraph::flow(void)
     deletelines();
     
     // Initially, add all of the blocks to the one line (this segments them)
-    MCLine *lptr = new MCLine(this);
+    MCLine *lptr = new (nothrow) MCLine(this);
     lptr->appendall(blocks, true);
     
     // Do the line wrapping
@@ -1116,7 +1116,7 @@ void MCParagraph::noflow(void)
 	// selections didn't work.
 	defrag();
 	deletelines();
-    lines = new MCLine(this);
+    lines = new (nothrow) MCLine(this);
 	lines->appendall(blocks, false);
     lines->NoFlowLayout();
 
@@ -1784,7 +1784,7 @@ MCBlock *MCParagraph::indextoblock(findex_t tindex, Boolean forinsert, bool for_
 					{
                         MCExecContext ctxt(nil, nil, nil);
 						MCBlock *t_new_block;
-						t_new_block = new MCBlock(*t_block);
+						t_new_block = new (nothrow) MCBlock(*t_block);
                         t_new_block -> SetImageSource(ctxt, kMCEmptyString);
 
 						// MW-2012-02-14: [[ FontRefs ]] If the block is open, pass in the parent's
@@ -1812,7 +1812,7 @@ MCBlock *MCParagraph::indextoblock(findex_t tindex, Boolean forinsert, bool for_
 					{
                         MCExecContext ctxt(nil, nil, nil);
 						MCBlock *t_new_block;
-						t_new_block = new MCBlock(*t_block);
+						t_new_block = new (nothrow) MCBlock(*t_block);
                         t_new_block -> SetImageSource(ctxt, kMCEmptyString);
 
 						// MW-2012-02-14: [[ FontRefs ]] If the block is open, pass in the parent's
@@ -1984,7 +1984,7 @@ void MCParagraph::split(findex_t p_position)
         skip = IncrementIndex(p_position) - p_position;
     }
     
-	MCParagraph *pgptr = new MCParagraph;
+	MCParagraph *pgptr = new (nothrow) MCParagraph;
 	pgptr->parent = parent;
 
 	// MW-2012-01-25: [[ ParaStyles ]] Copy the attributes from the first para.
@@ -2010,7 +2010,7 @@ void MCParagraph::split(findex_t p_position)
 	
 	// Create a new block to cover the range from the split point to the end
 	// of the original block.
-	MCBlock *tbptr = new MCBlock(*bptr);
+	MCBlock *tbptr = new (nothrow) MCBlock(*bptr);
 	bptr->append(tbptr);
 	blocks->splitat(tbptr);
 	pgptr->blocks = tbptr;
@@ -2092,7 +2092,7 @@ void MCParagraph::deletestring(findex_t si, findex_t ei, MCFieldStylingMode p_st
 			sbptr = sbptr -> next();
 		}
 		MCBlock *t_empty_block;
-		t_empty_block = new MCBlock;
+		t_empty_block = new (nothrow) MCBlock;
 		t_empty_block -> setparent(this);
 		t_empty_block -> SetRange(si, 0);
 		if (sbptr == blocks)
@@ -2187,7 +2187,7 @@ MCParagraph *MCParagraph::copystring(findex_t si, findex_t ei)
 {
 	// The string is copied by duplicating this paragraph and then removing all
 	// text outside of the range [si, ei). This preserves all attributes, etc
-	MCParagraph *pgptr = new MCParagraph(*this);
+	MCParagraph *pgptr = new (nothrow) MCParagraph(*this);
 	
 	if (ei != MCStringGetLength(m_text))
 	{
@@ -3129,7 +3129,7 @@ void MCParagraph::inittext()
 {
 	deletelines();
 	deleteblocks();
-	blocks = new MCBlock;
+	blocks = new (nothrow) MCBlock;
 	blocks->setparent(this);
 	blocks->SetRange(0, gettextlength());
 	state |= PS_LINES_NOT_SYNCHED;
@@ -3327,7 +3327,7 @@ void MCParagraph::settext(MCStringRef p_string)
 	MCValueRelease(m_text);
 	/* UNCHECKED */ MCStringMutableCopy(p_string, m_text);
 	
-	blocks = new MCBlock;
+	blocks = new (nothrow) MCBlock;
 	blocks->setparent(this);
 	blocks->SetRange(0, MCStringGetLength(m_text));
 }
@@ -3339,7 +3339,7 @@ void MCParagraph::resettext(MCStringRef p_string)
 	findex_t i, l;
 	if (blocks == NULL)
 	{
-		blocks = new MCBlock;
+		blocks = new (nothrow) MCBlock;
 		blocks->setparent(this);
 
 		state |= PS_LINES_NOT_SYNCHED;

--- a/engine/src/paragrafattr.cpp
+++ b/engine/src/paragrafattr.cpp
@@ -206,7 +206,7 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 	// Initialize the paragraph attrs to default values.
     if (t_stat == IO_NORMAL)
     {
-        attrs = new MCParagraphAttrs;
+        attrs = new (nothrow) MCParagraphAttrs;
         attrs -> flags = t_flags;
     }
 
@@ -244,7 +244,7 @@ IO_stat MCParagraph::loadattrs(IO_handle stream, uint32_t version)
 		t_stat = checkloadstat(IO_read_uint2(&attrs -> tab_count, stream));
 		if (t_stat == IO_NORMAL)
 		{
-			attrs -> tabs = new uint16_t[attrs -> tab_count];
+			attrs -> tabs = new (nothrow) uint16_t[attrs -> tab_count];
 			for(uint32_t i = 0; i < attrs -> tab_count && t_stat == IO_NORMAL; i++)
 				t_stat = checkloadstat(IO_read_uint2(&attrs -> tabs[i], stream));
 		}
@@ -491,7 +491,7 @@ void MCParagraph::copyattrs(const MCParagraph& other)
 		return;
 
 	// Make a new attrs structure.
-	attrs = new MCParagraphAttrs;
+	attrs = new (nothrow) MCParagraphAttrs;
 	
 	// Copy across all the fields byte-wise.
 	memcpy(attrs, other . attrs, sizeof(MCParagraphAttrs));
@@ -499,7 +499,7 @@ void MCParagraph::copyattrs(const MCParagraph& other)
 	// If the struct has tabs, then copy them properly.
 	if ((other . attrs -> flags & PA_HAS_TABS) != 0)
 	{
-		attrs -> tabs = new uint16_t[other . attrs -> tab_count];
+		attrs -> tabs = new (nothrow) uint16_t[other . attrs -> tab_count];
 		memcpy(attrs -> tabs, other . attrs -> tabs, sizeof(uint16_t) * other . attrs -> tab_count);
 	}
 
@@ -659,7 +659,7 @@ void MCParagraph::importattrs(const MCFieldParagraphStyle& p_style)
 {
 	clearattrs();
 	
-	attrs = new MCParagraphAttrs;
+	attrs = new (nothrow) MCParagraphAttrs;
 	if (p_style . has_text_align)
 	{
 		attrs -> flags |= PA_HAS_TEXT_ALIGN;
@@ -700,7 +700,7 @@ void MCParagraph::importattrs(const MCFieldParagraphStyle& p_style)
 	{
 		attrs -> flags |= PA_HAS_TABS;
 		attrs -> tab_count = p_style . tab_count;
-		attrs -> tabs = new uint16_t[p_style . tab_count];
+		attrs -> tabs = new (nothrow) uint16_t[p_style . tab_count];
 		memcpy(attrs -> tabs, p_style . tabs, sizeof(uint16_t) * p_style . tab_count);
 	}
 	if (p_style . has_tab_alignments)
@@ -788,7 +788,7 @@ void MCParagraph::setliststyle(uint32_t p_new_list_style)
 	else
 	{
 		if (attrs == nil)
-			attrs = new MCParagraphAttrs;
+			attrs = new (nothrow) MCParagraphAttrs;
 		if ((attrs -> flags & PA_HAS_LIST_STYLE) == 0)
 		{
 			attrs -> flags |= PA_HAS_LIST_STYLE;
@@ -811,7 +811,7 @@ void MCParagraph::setmetadata(MCStringRef p_metadata)
 		return;
 
 	if (attrs == nil)
-		attrs = new MCParagraphAttrs;
+		attrs = new (nothrow) MCParagraphAttrs;
     attrs -> flags |= PA_HAS_METADATA;
     /* UNCHECKED */ MCValueInter(p_metadata, attrs -> metadata);
 }
@@ -829,7 +829,7 @@ void MCParagraph::setlistindex(uint32_t p_new_list_index)
 	else
 	{
 		if (attrs == nil)
-			attrs = new MCParagraphAttrs;
+			attrs = new (nothrow) MCParagraphAttrs;
 
 		attrs -> flags |= PA_HAS_LIST_INDEX;
 		attrs -> list_index = p_new_list_index;

--- a/engine/src/parentscript.cpp
+++ b/engine/src/parentscript.cpp
@@ -122,7 +122,7 @@ MCVariable *MCParentScriptUse::GetVariable(uint32_t i)
 
 	// Allocate the array of variables needed
 	m_local_count = t_handlers -> getnvars();
-	m_locals = new MCVariable *[m_local_count];
+	m_locals = new (nothrow) MCVariable *[m_local_count];
 
 	// Loop through initializing the variables as appropriate
 	for(uint32_t j = 0; j < m_local_count; ++j, t_vars = t_vars -> getnext())
@@ -169,7 +169,7 @@ void MCParentScriptUse::PreserveVars(uint32_t *p_map, MCValueRef *p_new_var_init
 
 	// We have some vars so we need to do some remapping. First allocate a new array
 	MCVariable **t_new_locals;
-	t_new_locals = new MCVariable *[p_new_var_count];
+	t_new_locals = new (nothrow) MCVariable *[p_new_var_count];
 	
 	// Initialize it to NULL
 	memset(t_new_locals, 0, sizeof(MCVariable *) * p_new_var_count);
@@ -212,7 +212,7 @@ MCParentScriptUse *MCParentScriptUse::Clone(MCObject *p_new_referrer)
 {
 	// First allocate a new instance
 	MCParentScriptUse *t_new_use;
-	t_new_use = new MCParentScriptUse(m_parent, p_new_referrer);
+	t_new_use = new (nothrow) MCParentScriptUse(m_parent, p_new_referrer);
 	if (t_new_use == NULL)
 		return NULL;
 
@@ -272,7 +272,7 @@ bool MCParentScriptUse::Inherit(void)
 
 	// Create a new use of the super-object's parentScript
 	MCParentScriptUse *t_super_use;
-	t_super_use = new MCParentScriptUse(t_super_parentscript, m_referrer);
+	t_super_use = new (nothrow) MCParentScriptUse(t_super_parentscript, m_referrer);
 	if (t_super_use == NULL)
 		return false;
 
@@ -458,7 +458,7 @@ MCParentScriptUse *MCParentScript::Acquire(MCObject *p_referrer, uint32_t p_id, 
 		// Note that the default constructor for the parent script object just
 		// zeros out the fields - we need to track the cloning of the stack
 		// and mainstack strings in case they error out.
-		t_parent = new MCParentScript;
+		t_parent = new (nothrow) MCParentScript;
 		if (t_parent == NULL)
 			t_success = false;
 
@@ -479,7 +479,7 @@ MCParentScriptUse *MCParentScript::Acquire(MCObject *p_referrer, uint32_t p_id, 
 	t_use = NULL;
 	if (t_success)
 	{
-		t_use = new MCParentScriptUse(t_parent, p_referrer);
+		t_use = new (nothrow) MCParentScriptUse(t_parent, p_referrer);
 		if (t_use == NULL)
 			t_success = false;
 	}

--- a/engine/src/path.cpp
+++ b/engine/src/path.cpp
@@ -618,17 +618,17 @@ void MCPath::get_lengths(uint4 &r_commands, uint4 &r_points)
 
 MCPath *MCPath::copy_scaled(int4 p_scale)
 {
-	MCPath *t_path = new MCPath;
+	MCPath *t_path = new (nothrow) MCPath;
 	t_path->f_references = 0;
 
 	uint4 t_numpoints, t_numcommands;
 
 	get_lengths(t_numpoints, t_numcommands);
 
-	t_path->f_commands = new uint1[t_numcommands];
+	t_path->f_commands = new (nothrow) uint1[t_numcommands];
 	memcpy(t_path->f_commands, f_commands, sizeof(uint1) * t_numcommands);
 
-	t_path->f_data = new int4[t_numpoints * 2];
+	t_path->f_data = new (nothrow) int4[t_numpoints * 2];
 	for (uint4 i = 0; i < t_numpoints * 2; i++)
 		t_path->f_data[i] = f_data[i] * p_scale;
 

--- a/engine/src/pickle.cpp
+++ b/engine/src/pickle.cpp
@@ -83,7 +83,7 @@ MCPickleContext *MCObject::startpickling(bool p_include_legacy)
 	t_context = NULL;
 	if (t_success)
 	{
-		t_context = new MCPickleContext;
+		t_context = new (nothrow) MCPickleContext;
 		if (t_context == NULL)
 			t_success = false;
 	}
@@ -401,49 +401,49 @@ static bool unpickle_object_from_stream(IO_handle p_stream, uint32_t p_version, 
 			/* UNCHECKED */ MCStackSecurityCreateStack((MCStack*&)t_object);
 		break;
 		case OT_CARD:
-			t_object = new MCCard;
+			t_object = new (nothrow) MCCard;
 		break;
 		case OT_GROUP:
-			t_object = new MCGroup;
+			t_object = new (nothrow) MCGroup;
 		break;
 		case OT_BUTTON:
-			t_object = new MCButton;
+			t_object = new (nothrow) MCButton;
 		break;
 		case OT_FIELD:
-			t_object = new MCField;
+			t_object = new (nothrow) MCField;
 		break;
 		case OT_IMAGE:
-			t_object = new MCImage;
+			t_object = new (nothrow) MCImage;
 		break;
 		case OT_SCROLLBAR:
-			t_object = new MCScrollbar;
+			t_object = new (nothrow) MCScrollbar;
 		break;
 		case OT_GRAPHIC:
-			t_object = new MCGraphic;
+			t_object = new (nothrow) MCGraphic;
 		break;
 		case OT_PLAYER:
-			t_object = new MCPlayer;
+			t_object = new (nothrow) MCPlayer;
 		break;
 		case OT_MCEPS:
-			t_object = new MCEPS;
+			t_object = new (nothrow) MCEPS;
         break;
         case OT_WIDGET:
-            t_object = new MCWidget;
+            t_object = new (nothrow) MCWidget;
         break;
 		case OT_MAGNIFY:
-			t_object = new MCMagnify;
+			t_object = new (nothrow) MCMagnify;
 		break;
 		case OT_COLORS:
-			t_object = new MCColors;
+			t_object = new (nothrow) MCColors;
 		break;
 		case OT_AUDIO_CLIP:
-			t_object = new MCAudioClip;
+			t_object = new (nothrow) MCAudioClip;
 		break;
 		case OT_VIDEO_CLIP:
-			t_object = new MCVideoClip;
+			t_object = new (nothrow) MCVideoClip;
 		break;
 		case OT_STYLED_TEXT:
-			t_object = new MCStyledText;
+			t_object = new (nothrow) MCStyledText;
 		break;
 		default:
 			t_success = false;

--- a/engine/src/player-legacy.cpp
+++ b/engine/src/player-legacy.cpp
@@ -351,7 +351,7 @@ void MCPlayer::deselect(void)
 
 MCControl *MCPlayer::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCPlayer *newplayer = new MCPlayer(*this);
+	MCPlayer *newplayer = new (nothrow) MCPlayer(*this);
 	if (attach)
 		newplayer->attach(p, invisible);
 	return newplayer;
@@ -985,7 +985,7 @@ bool MCPlayer::gethotspot(uindex_t index, uint2 &id, MCMultimediaQTVRHotSpotType
 Boolean MCPlayer::x11_prepare(void)
 {
     if ( m_player == NULL )
-        m_player = new MPlayer();
+        m_player = new (nothrow) MPlayer();
     
     // OK-2009-01-09: [[Bug 1161]] - File resolving code standardized between image and player.
     // MCPlayer::init appears to duplicate the filename buffer, so freeing it after the call should be ok.

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1182,7 +1182,7 @@ void MCPlayer::deselect(void)
 
 MCControl *MCPlayer::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCPlayer *newplayer = new MCPlayer(*this);
+	MCPlayer *newplayer = new (nothrow) MCPlayer(*this);
 	if (attach)
 		newplayer->attach(p, invisible);
 	return newplayer;
@@ -2149,7 +2149,7 @@ void MCPlayer::markerchanged(MCPlatformPlayerDuration p_time)
             MCExecContext ctxt(nil, nil, nil);
             
             MCParameter *t_param;
-            t_param = new MCParameter;
+            t_param = new (nothrow) MCParameter;
             t_param -> set_argument(ctxt, m_callbacks[i] . parameter);
             MCscreen -> addmessage(this, m_callbacks[i] . message, 0, t_param);
             
@@ -2190,7 +2190,7 @@ void MCPlayer::currenttimechanged(void)
         state |= CS_CTC_PENDING;
         
         MCParameter *t_param;
-        t_param = new MCParameter;
+        t_param = new (nothrow) MCParameter;
         t_param -> setn_argument(getmoviecurtime());
         MCscreen -> addmessage(this, MCM_current_time_changed, 0, t_param);
         
@@ -3270,7 +3270,7 @@ void MCPlayer::handle_mdown(int p_which)
             {
                 if (s_volume_popup == nil)
                 {
-                    s_volume_popup = new MCPlayerVolumePopup;
+                    s_volume_popup = new (nothrow) MCPlayerVolumePopup;
                     s_volume_popup -> setparent(MCdispatcher);
                     MCdispatcher -> add_transient_stack(s_volume_popup);
                 }
@@ -3740,7 +3740,7 @@ void MCPlayer::handle_shift_mdown(int p_which)
             
             if (s_rate_popup == nil)
             {
-                s_rate_popup = new MCPlayerRatePopup;
+                s_rate_popup = new (nothrow) MCPlayerRatePopup;
                 s_rate_popup -> setparent(MCdispatcher);
                 MCdispatcher -> add_transient_stack(s_rate_popup);
             }

--- a/engine/src/player-srv-stubs.cpp
+++ b/engine/src/player-srv-stubs.cpp
@@ -304,7 +304,7 @@ void MCPlayer::deselect(void)
 
 MCControl *MCPlayer::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCPlayer *newplayer = new MCPlayer(*this);
+	MCPlayer *newplayer = new (nothrow) MCPlayer(*this);
 	if (attach)
 		newplayer->attach(p, invisible);
 	return newplayer;

--- a/engine/src/printer.cpp
+++ b/engine/src/printer.cpp
@@ -352,7 +352,7 @@ void MCPrinter::SetJobRanges(MCPrinterPageRangeCount p_count, const MCInterval *
 	m_job_range_count = p_count;
 	if (p_count > 0)
 	{
-		m_job_ranges = new MCInterval[p_count];
+		m_job_ranges = new (nothrow) MCInterval[p_count];
 		memcpy(m_job_ranges, p_ranges, sizeof(MCInterval) * p_count);
 	}
 }

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -478,7 +478,7 @@ MCProperty::~MCProperty()
 MCObject *MCProperty::getobj(MCExecContext &ctxt)
 {
 	MCObject *objptr = NULL;
-	MCChunk *tchunk = new MCChunk(False);
+	MCChunk *tchunk = new (nothrow) MCChunk(False);
 	MCerrorlock++;
 	MCScriptPoint sp(ctxt);
 	if (tchunk->parse(sp, False) == PS_NORMAL)
@@ -1110,7 +1110,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 				{
 					if (tocount < CT_LINE)
 					{
-						target = new MCChunk(False);
+						target = new (nothrow) MCChunk(False);
 						break;
 					}
 					else
@@ -1126,7 +1126,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 					if (tocount < CT_LINE)
 					{
 						sp.backup();
-						target = new MCChunk(False);
+						target = new (nothrow) MCChunk(False);
 						break;
 					}
 					else
@@ -1142,7 +1142,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 		}
 		else
 			sp.backup();
-		target = new MCChunk(False);
+		target = new (nothrow) MCChunk(False);
 		if (target->parse(sp, doingthe) != PS_NORMAL)
 		{
 			MCperror->add

--- a/engine/src/quicktime.cpp
+++ b/engine/src/quicktime.cpp
@@ -732,7 +732,7 @@ Boolean MCQTEffectsDialog(MCStringRef &r_data)
 	}
 	HLock((Handle)effectdesc);
 	uint4 datasize = GetHandleSize(effectdesc) + sizeof(long) * 2;
-	char *dataptr = new char[datasize];
+	char *dataptr = new (nothrow) char[datasize];
 	long *aLong = (long *)dataptr;
 	HLock((Handle)effectdesc);
 	aLong[0] = EndianU32_NtoB(datasize);
@@ -830,7 +830,7 @@ static void QTEffectsQuery(void **effectatomptr)
 	numeffects = QTCountChildrenOfType(effectatom, kParentAtomIsContainer,
 	                                   kEffectNameAtom);
 	neffects = 0;
-	qteffects = new QTEffect[numeffects];
+	qteffects = new (nothrow) QTEffect[numeffects];
 	uint2 i;
 	for (i = 1; i <= numeffects; i++)
 	{
@@ -849,7 +849,7 @@ static void QTEffectsQuery(void **effectatomptr)
 			                    &qteffects[neffects].type, NULL);
 			QTLockContainer(effectatom);
 			QTGetAtomDataPtr(effectatom, nameatom, &datasize, (Ptr *)&sptr);
-			qteffects[neffects].token = new char[datasize+1];
+			qteffects[neffects].token = new (nothrow) char[datasize+1];
 			memcpy(qteffects[neffects].token,sptr,datasize);
 			qteffects[neffects].token[datasize] = '\0';
 			QTUnlockContainer(effectatom);

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -939,7 +939,7 @@ static bool tilecache_device_renderer(MCTileCacheDeviceRenderCallback p_callback
 	MCGContextConcatCTM(p_target, t_transform);
 	
 	MCGraphicsContext *t_gfx_context;
-	/* UNCHECKED */ t_gfx_context = new MCGraphicsContext(p_target);
+	/* UNCHECKED */ t_gfx_context = new (nothrow) MCGraphicsContext(p_target);
 	
 	MCRectangle t_user_rect;
 	t_user_rect = MCRectangleGetTransformedBounds(p_rectangle, MCGAffineTransformInvert(t_transform));

--- a/engine/src/regex.cpp
+++ b/engine/src/regex.cpp
@@ -347,7 +347,7 @@ regexp *MCR_compile(MCStringRef exp, bool casesensitive)
 	// If the pattern isn't found with the given flags, then create a new one.
 	if (re == nil)
 	{
-		/* UNCHECKED */ re = new regexp;
+		/* UNCHECKED */ re = new (nothrow) regexp;
 		/* UNCHECKED */ re->pattern = MCValueRetain(exp);
 		re->flags = flags;
 		int status;

--- a/engine/src/rtfsupport.cpp
+++ b/engine/src/rtfsupport.cpp
@@ -44,7 +44,7 @@ RTFStatus RTFState::Save(void)
 	t_new_entry = NULL;
 	if (t_status == kRTFStatusSuccess)
 	{
-		t_new_entry = new Entry;
+		t_new_entry = new (nothrow) Entry;
 		if (t_new_entry == NULL)
 			t_status = kRTFStatusOverflow;
 	}

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1371,15 +1371,15 @@ Parse_stat MCScriptPoint::lookupconstant(MCExpression **dest)
                     MCAutoStringRef t_nul_string;
                     /* UNCHECKED */ MCStringCreateWithBytes((const byte_t*)"", 1, kMCStringEncodingASCII, false, &t_nul_string);
                     
-                    *dest = new MCConstant(*t_nul_string, BAD_NUMERIC);
+                    *dest = new (nothrow) MCConstant(*t_nul_string, BAD_NUMERIC);
 				}
                 else if (token.getlength() == 5 && MCU_strncasecmp(token_cstring, "empty", 5) == 0)
                 {
                     // Uses the kMCNull as a StringRef - that's what is expected from 'empty'
-                    *dest = new MCConstant(kMCEmptyString, BAD_NUMERIC);
+                    *dest = new (nothrow) MCConstant(kMCEmptyString, BAD_NUMERIC);
                 }
 				else
-					*dest = new MCConstant(MCSTR(constant_table[mid].svalue),
+					*dest = new (nothrow) MCConstant(MCSTR(constant_table[mid].svalue),
 					                       constant_table[mid].nvalue);
 				return PS_NORMAL;
 			}
@@ -1681,7 +1681,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 					}
 					break;
 				case TT_CHUNK:
-					newfact = new MCChunk(False);
+					newfact = new (nothrow) MCChunk(False);
 					backup();
 					if (newfact->parse(*this, doingthe) != PS_NORMAL)
 					{
@@ -1726,7 +1726,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 								return PS_ERROR;
 							}
 							else
-								newfact = new MCLiteral(gettoken_nameref());
+								newfact = new (nothrow) MCLiteral(gettoken_nameref());
 						newfact->parse(*this, doingthe);
 					}
 					insertfactor(newfact, curfact, top);
@@ -1735,7 +1735,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 				case TT_PROPERTY:
 					thesp = *this;
 					backup();
-					newfact = new MCProperty;
+					newfact = new (nothrow) MCProperty;
 					MCerrorlock++;
 					if (newfact->parse(*this, doingthe) != PS_NORMAL)
 					{
@@ -1747,7 +1747,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 							MCperror->add(PE_EXPRESSION_NOTLITERAL, *this);
 							return PS_ERROR;
 						}
-						newfact = new MCLiteral(gettoken_nameref());
+						newfact = new (nothrow) MCLiteral(gettoken_nameref());
 					}
 					MCerrorlock--;
 					insertfactor(newfact, curfact, top);
@@ -1765,7 +1765,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 				{
 					backup();
 					thesp = *this;
-					newfact = new MCProperty;
+					newfact = new (nothrow) MCProperty;
 					MCerrorlock++;
 					if (newfact->parse(*this, doingthe) != PS_NORMAL)
 					{
@@ -1779,7 +1779,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 							return PS_ERROR;
 						}
 
-						newfact = new MCFuncref(gettoken_nameref());
+						newfact = new (nothrow) MCFuncref(gettoken_nameref());
 						newfact->parse(*this, doingthe);
 					}
 					else
@@ -1825,7 +1825,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 								newfact = newvar;
 							}
 						else if (type == ST_LP)
-								newfact = new MCFuncref(t_name);
+								newfact = new (nothrow) MCFuncref(t_name);
 						if (newfact == NULL)
 						{
 							if (MCexplicitvariables)

--- a/engine/src/scrolbar.cpp
+++ b/engine/src/scrolbar.cpp
@@ -697,7 +697,7 @@ void MCScrollbar::timer(MCNameRef mptr, MCParameter *params)
 
 MCControl *MCScrollbar::clone(Boolean attach, Object_pos p, bool invisible)
 {
-	MCScrollbar *newscrollbar = new MCScrollbar(*this);
+	MCScrollbar *newscrollbar = new (nothrow) MCScrollbar(*this);
 	if (attach)
 		newscrollbar->attach(p, invisible);
 	return newscrollbar;

--- a/engine/src/segment.cpp
+++ b/engine/src/segment.cpp
@@ -304,7 +304,7 @@ MCLine *MCSegment::Fit(coord_t p_max_width)
         else if (t_break_block != m_LastBlock)
         {
             // Split this segment
-            t_split_segment = new MCSegment(this);
+            t_split_segment = new (nothrow) MCSegment(this);
             append(t_split_segment);
             t_split_segment->AddBlockRange(t_break_block->next(), m_LastBlock);
             
@@ -328,7 +328,7 @@ MCLine *MCSegment::Fit(coord_t p_max_width)
             m_LastBlock = t_break_block;
         
         // Create a new line containing the segments and blocks that don't fit
-        t_newline = new MCLine(*m_Parent);
+        t_newline = new (nothrow) MCLine(*m_Parent);
         t_newline->appendsegments(t_split_segment, t_parent_line->lastsegment);
         
         // Update the parent line's block and segment pointers

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -146,7 +146,7 @@ void MCSellist::add(MCObject *objptr, bool p_sendmessage)
 		clear(False);
 	if (MCactivefield != NULL)
 		MCactivefield->unselect(True, True);
-	MCSelnode *nodeptr = new MCSelnode(objptr);
+	MCSelnode *nodeptr = new (nothrow) MCSelnode(objptr);
 	nodeptr->appendto(objects);
 	if (p_sendmessage)
 		objptr->message(MCM_selected_object_changed);
@@ -328,7 +328,7 @@ Exec_stat MCSellist::group(uint2 line, uint2 pos, MCGroup*& r_group_ptr)
 		else
 			gptr = (MCGroup *)MCsavegroupptr->remove(MCsavegroupptr);
 		gptr->makegroup(controls, parent);
-		objects = new MCSelnode(gptr);
+		objects = new (nothrow) MCSelnode(gptr);
 		gptr->message(MCM_selected_object_changed);
 		
 		r_group_ptr = gptr;
@@ -476,7 +476,7 @@ Boolean MCSellist::del()
 				cptr->getcard()->count(CT_LAYER, CT_UNDEFINED, cptr, num, True);
 				if (cptr->del(true))
 				{
-					Ustruct *us = new Ustruct;
+					Ustruct *us = new (nothrow) Ustruct;
 					us->type = UT_DELETE;
 					us->ud.layer = num;
 					MCundos->savestate(cptr, us);
@@ -565,7 +565,7 @@ Boolean MCSellist::endmove()
 	do
 	{
 		MCControl *cptr = (MCControl *)tptr->ref;
-		Ustruct *us = new Ustruct;
+		Ustruct *us = new (nothrow) Ustruct;
 		us->type = UT_MOVE;
 		us->ud.deltas.x = lastx - startx;
 		us->ud.deltas.y = lasty - starty;

--- a/engine/src/srvcgi.cpp
+++ b/engine/src/srvcgi.cpp
@@ -973,7 +973,7 @@ static bool cgi_compute_get_binary_var(void *p_context, MCVariable *p_var)
 // $_POST_RAW contains the entire post message and is read from stdin on access
 static bool cgi_compute_post_raw_var(void *p_context, MCVariable *p_var)
 {
-	MCCacheHandle *t_stdin = new MCCacheHandle(s_cgi_stdin_cache);
+	MCCacheHandle *t_stdin = new (nothrow) MCCacheHandle(s_cgi_stdin_cache);
 	
 	bool t_success = true;
 
@@ -987,7 +987,7 @@ static bool cgi_compute_post_raw_var(void *p_context, MCVariable *p_var)
 		uint32_t t_read = 0;
 		
 		char *t_data;
-		t_data = new char[t_length];
+		t_data = new (nothrow) char[t_length];
 		t_success = t_stdin->Read(t_data, t_length, t_read) && t_length == t_read;
 
 		// Store the raw POST data
@@ -1057,7 +1057,7 @@ static bool cgi_compute_post_variables()
 	}
 	else if (gotenv && MCStringBeginsWithCString(*t_content_type, (const char_t *)"multipart/form-data;", kMCStringOptionCompareCaseless))
     {
-		MCCacheHandle *t_stdin = new MCCacheHandle(s_cgi_stdin_cache);
+		MCCacheHandle *t_stdin = new (nothrow) MCCacheHandle(s_cgi_stdin_cache);
         IO_handle t_stdin_handle = t_stdin;
 		
         cgi_store_form_multipart(t_stdin_handle);
@@ -1529,12 +1529,12 @@ bool cgi_initialize()
 	// without conflicting
 	if (t_success)
 	{
-		s_cgi_stdin_cache = new MCStreamCache(IO_stdin);
+		s_cgi_stdin_cache = new (nothrow) MCStreamCache(IO_stdin);
 		t_success = s_cgi_stdin_cache != nil;
 	}
 	if (t_success)
 	{
-		IO_stdin = new MCCacheHandle(s_cgi_stdin_cache);
+		IO_stdin = new (nothrow) MCCacheHandle(s_cgi_stdin_cache);
 		t_success = IO_stdin != nil;
 	}
 	
@@ -1542,7 +1542,7 @@ bool cgi_initialize()
 	// before any content.
 	if (t_success)
 	{
-		IO_stdout = new cgi_stdout;
+		IO_stdout = new (nothrow) cgi_stdout;
 		t_success = IO_stdout != nil;
 	}
 	

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -573,10 +573,10 @@ void X_main_loop(void)
 		if (t_stat == ES_NOT_HANDLED && MCS_get_errormode() != kMCSErrorModeQuiet)
 		{
 			MCHandlerlist *t_handlerlist;
-			t_handlerlist = new MCHandlerlist;
+			t_handlerlist = new (nothrow) MCHandlerlist;
 			
 			MCHandler *t_handler;
-			t_handler = new MCHandler(HT_MESSAGE, true);
+			t_handler = new (nothrow) MCHandler(HT_MESSAGE, true);
 			
 			MCScriptPoint sp(MCserverscript, t_handlerlist, MCSTR(s_default_error_handler));
 			

--- a/engine/src/srvmultipart.cpp
+++ b/engine/src/srvmultipart.cpp
@@ -462,7 +462,7 @@ bool MCMultiPartReadHeaders(IO_handle p_stream, uint32_t &r_bytes_read, MCMultiP
 	bool t_success = true;
 	
 	MCBoundaryReader *t_reader;
-	t_reader = new MCBoundaryReader(p_stream, MCSTR("\r\n"));
+	t_reader = new (nothrow) MCBoundaryReader(p_stream, MCSTR("\r\n"));
 	
 	r_bytes_read = 0;
 	
@@ -557,7 +557,7 @@ bool MCMultiPartReadMessageFromStream(IO_handle p_stream, MCStringRef p_boundary
             t_success = false;
         else
         {
-            t_reader = new MCBoundaryReader(p_stream, *t_boundary_tail);
+            t_reader = new (nothrow) MCBoundaryReader(p_stream, *t_boundary_tail);
             t_success = t_reader != NULL;
         }
 	}

--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -151,7 +151,7 @@ MCServerScript::File *MCServerScript::FindFile(MCStringRef p_filename, bool p_ad
 	}
 
 	// Create a new entry.
-	t_file = new File;
+	t_file = new (nothrow) File;
 	t_file -> next = m_files;
     t_file -> filename = MCValueRetain(*t_resolved_filename);
 	t_file -> index = m_files == NULL ? 1 : m_files -> index + 1;
@@ -184,7 +184,7 @@ Parse_stat MCServerScript::ParseNextStatement(MCScriptPoint& sp, MCStatement*& r
 			if (t_type == ST_DATA)
 			{
 				// A data token turns into an Echo command.
-				t_statement = new MCEcho;
+				t_statement = new (nothrow) MCEcho;
 				if (t_statement != NULL && t_statement -> parse(sp) != PS_NORMAL)
 				{
 					MCperror->add(PE_SCRIPT_BADECHO, sp);
@@ -211,7 +211,7 @@ Parse_stat MCServerScript::ParseNextStatement(MCScriptPoint& sp, MCStatement*& r
 					if (t_symbol != nil && (t_symbol -> which == HT_MESSAGE || t_symbol -> which == HT_FUNCTION))
 					{
 						MCHandler *t_new_handler;
-						t_new_handler = new MCHandler((uint1)t_symbol -> which, t_is_private);
+						t_new_handler = new (nothrow) MCHandler((uint1)t_symbol -> which, t_is_private);
 						t_new_handler -> setfileindex(m_current_file -> index);
 						if (t_new_handler -> parse(sp, false) == PS_NORMAL && !hlist -> hashandler((Handler_type)t_symbol -> which, t_new_handler -> getname()))
 						{
@@ -238,13 +238,13 @@ Parse_stat MCServerScript::ParseNextStatement(MCScriptPoint& sp, MCStatement*& r
 					switch (t_symbol -> which)
 					{
 						case S_GLOBAL:
-							t_statement = new MCGlobal;
+							t_statement = new (nothrow) MCGlobal;
 							break;
 						case S_LOCAL:
-							t_statement = new MCLocalVariable;
+							t_statement = new (nothrow) MCLocalVariable;
 							break;
 						case S_CONSTANT:
-							t_statement = new MCLocalConstant;
+							t_statement = new (nothrow) MCLocalConstant;
 							break;
 						default:
 							t_statement = NULL;
@@ -280,7 +280,7 @@ Parse_stat MCServerScript::ParseNextStatement(MCScriptPoint& sp, MCStatement*& r
 			else if (t_type == ST_ID)
 			{
 				// Treat it as a call
-				t_statement = new MCComref(sp . gettoken_nameref());
+				t_statement = new (nothrow) MCComref(sp . gettoken_nameref());
 				if (t_statement -> parse(sp) != PS_NORMAL)
 				{
 					MCperror -> add(PE_SCRIPT_BADCOMMAND, sp);
@@ -332,12 +332,12 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 
 	if (hlist == NULL)
 	{
-		hlist = new MCHandlerlist;
+		hlist = new (nothrow) MCHandlerlist;
 	}
 	
 	if (m_ctxt == NULL)
 	{
-		m_ctxt = new MCExecContext(this, hlist, NULL);
+		m_ctxt = new (nothrow) MCExecContext(this, hlist, NULL);
 		// MW-2013-11-08: [[ RefactorIt ]] Make sure we have an 'it' var in global context.
 		/* UNCHECKED */ hlist -> newvar(MCN_it, nil, &m_it, False);
 	}
@@ -394,7 +394,7 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 
 		uindex_t t_length;
 		t_length = MCDataGetLength (*t_file_contents);
-		t_file -> script = new char[t_length + 1];
+		t_file -> script = new (nothrow) char[t_length + 1];
 
 		MCMemoryCopy (t_file -> script,
 					  MCDataGetBytePtr (*t_file_contents),

--- a/engine/src/srvspec.cpp
+++ b/engine/src/srvspec.cpp
@@ -404,7 +404,7 @@ static const char *url_execute_ftp_delete(void *p_state, CURL *p_curl)
 		t_file = strrchr(t_url, '/') + 1;
 
 		char *t_cmd_string;
-		t_cmd_string = new char[strlen(t_file) + 5 + 1];
+		t_cmd_string = new (nothrow) char[strlen(t_file) + 5 + 1];
 		if (t_cmd_string != NULL)
 		{
 			sprintf(t_cmd_string, "%s %s", (t_is_folder ? "RMD" : "DELE"), t_file); 

--- a/engine/src/srvwindows.cpp
+++ b/engine/src/srvwindows.cpp
@@ -152,7 +152,7 @@ public:
 			return NULL;
 		
 		MCStdioFileHandle *t_handle;
-		t_handle = new MCStdioFileHandle;
+		t_handle = new (nothrow) MCStdioFileHandle;
 		t_handle -> m_stream = t_stream;
 		
 		return t_handle;
@@ -170,7 +170,7 @@ public:
 			setbuf(t_stream, NULL);
 		
 		MCStdioFileHandle *t_handle;
-		t_handle = new MCStdioFileHandle;
+		t_handle = new (nothrow) MCStdioFileHandle;
 		t_handle -> m_stream = t_stream;
 		
 		return t_handle;
@@ -333,14 +333,14 @@ struct MCWindowsSystem: public MCSystemInterface
 
 		if (t_value == NULL)
 		{
-			char *dptr = new char[strlen(t_name) + 2];
+			char *dptr = new (nothrow) char[strlen(t_name) + 2];
 			sprintf(dptr, "%s=", t_name);
 			_putenv(dptr);
 			delete[] dptr;
 		}
 		else
 		{
-			char *dptr = new char[strlen(t_name) + strlen(t_value) + 2];
+			char *dptr = new (nothrow) char[strlen(t_name) + strlen(t_value) + 2];
 			sprintf(dptr, "%s=%s", t_name, t_value);
 			_putenv(dptr);
 			delete[] dptr;
@@ -436,7 +436,7 @@ struct MCWindowsSystem: public MCSystemInterface
 	
 	virtual void ResolveAlias(MCStringRef p_source, MCStringRef& r_dest)
 	{
-		char *t_dest = new char[PATH_MAX];
+		char *t_dest = new (nothrow) char[PATH_MAX];
 		HRESULT hres;
 		IShellLinkA* psl;
 		char szGotPath[PATH_MAX];
@@ -597,7 +597,7 @@ struct MCWindowsSystem: public MCSystemInterface
 		{
 			// newpath is of form "<driveletter>:"
 			char *t_modified_path;
-			t_modified_path = new char[strlen(path) + 2];
+			t_modified_path = new (nothrow) char[strlen(path) + 2];
 			strcpy(t_modified_path, path);
 			strcat(t_modified_path, "\\");
 			newpath = t_modified_path;
@@ -757,7 +757,7 @@ struct MCWindowsSystem: public MCSystemInterface
 		MCS_resolvepath(p_path, &t_newpath_string);
 
 		char *shortpath = strdup(MCStringGetCString(*t_newpath_string));
-		char *longpath = new char[PATH_MAX];
+		char *longpath = new (nothrow) char[PATH_MAX];
 		char *p, *pStart;
 		char buff[PATH_MAX];
 		WIN32_FIND_DATAA wfd;
@@ -834,7 +834,7 @@ struct MCWindowsSystem: public MCSystemInterface
 
 	char *ShortFilePath(const char *p_path)
 	{
-		char *shortpath = new char[PATH_MAX];
+		char *shortpath = new (nothrow) char[PATH_MAX];
 		MCAutoStringRef t_newpath_string;
 		MCAutoStringRef t_path_string;
 		/* UNCHECKED */ MCStringCreateWithCString(p_path, &t_path_string);
@@ -914,7 +914,7 @@ struct MCWindowsSystem: public MCSystemInterface
 			&tpath_ref = MCValueRetain (p_folder);
 
 		char *tpath = strdup(MCStringGetCString(*tpath_ref));
-		char *spath = new char [strlen(tpath) + 5];//path to be searched
+		char *spath = new (nothrow) char [strlen(tpath) + 5];//path to be searched
 		strcpy(spath, tpath);
 		if (tpath[strlen(tpath) - 1] != '\\')
 			strcat(spath, "\\");
@@ -934,7 +934,7 @@ struct MCWindowsSystem: public MCSystemInterface
 		 * path, a path separator character, and any possible filename. */
 		size_t t_path_len = strlen(tpath);
 		size_t t_entry_path_len = t_path_len + 1 + MAX_PATH;
-		char *t_entry_path = new char[t_entry_path_len + 1];
+		char *t_entry_path = new (nothrow) char[t_entry_path_len + 1];
 		strcpy (t_entry_path, tpath);
 		if (tpath[t_path_len - 1] != '\\')
 		{
@@ -1172,7 +1172,7 @@ struct MCWindowsSystem: public MCSystemInterface
 		t_ulength = TextConvert(p_string, p_string_length, NULL, 0, p_from_charset, LCH_UNICODE);
 
 		char *t_ubuffer;
-		t_ubuffer = new char[t_ulength];
+		t_ubuffer = new (nothrow) char[t_ulength];
 		TextConvert(p_string, p_string_length, t_ubuffer, t_ulength, p_from_charset, LCH_UNICODE);
 
 		uint32_t t_used;

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -429,7 +429,7 @@ MCStack::MCStack(const MCStack &sref) : MCObject(sref)
 		MCAudioClip *aptr = sref.aclips;
 		do
 		{
-			MCAudioClip *newaclip = new MCAudioClip(*aptr);
+			MCAudioClip *newaclip = new (nothrow) MCAudioClip(*aptr);
 			newaclip->setid(aptr->getid());
 			newaclip->appendto(aclips);
 			newaclip->setparent(this);
@@ -442,7 +442,7 @@ MCStack::MCStack(const MCStack &sref) : MCObject(sref)
 		MCVideoClip *vptr = sref.vclips;
 		do
 		{
-			MCVideoClip *newvclip = new MCVideoClip(*vptr);
+			MCVideoClip *newvclip = new (nothrow) MCVideoClip(*vptr);
 			newvclip->setid(vptr->getid());
 			newvclip->appendto(vclips);
 			newvclip->setparent(this);
@@ -458,7 +458,7 @@ MCStack::MCStack(const MCStack &sref) : MCObject(sref)
 	if (nstackfiles != 0)
 	{
 		uint2 ts = nstackfiles;
-		stackfiles = new MCStackfile[ts];
+		stackfiles = new (nothrow) MCStackfile[ts];
 		while (ts--)
 		{
 			stackfiles[ts].stackname = MCValueRetain(sref.stackfiles[ts].stackname);
@@ -469,7 +469,7 @@ MCStack::MCStack(const MCStack &sref) : MCObject(sref)
 		stackfiles = NULL;
 	if (sref.linkatts != NULL)
 	{
-		linkatts = new Linkatts;
+		linkatts = new (nothrow) Linkatts;
 		memcpy(linkatts, sref.linkatts, sizeof(Linkatts));
         
 		linkatts->colorname = linkatts->colorname == nil ? nil : (MCStringRef)MCValueRetain(sref.linkatts->colorname);
@@ -1599,7 +1599,7 @@ void MCStack::loadexternals(void)
 	if (MCStringIsEmpty(externalfiles) || m_externals != NULL || !MCSecureModeCanAccessExternal())
 		return;
 
-	m_externals = new MCExternalHandlerList;
+	m_externals = new (nothrow) MCExternalHandlerList;
 
 	MCAutoArrayRef t_array;
 	/* UNCHECKED */ MCStringSplit(externalfiles, MCSTR("\n"), nil, kMCStringOptionCompareExact, &t_array);

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -854,7 +854,7 @@ void MCStack::startedit(MCGroup *group)
 	editing->setcontrols(NULL);
 
 	// Create a temporary card
-	cards = curcard = new MCCard;
+	cards = curcard = new (nothrow) MCCard;
 
 	// Link the card to the parent, give it the same id as the current card and give it a temporary script
 	curcard->setparent(this);
@@ -2871,7 +2871,7 @@ void MCStack::render(MCGContextRef p_context, const MCRectangle &p_rect)
 	t_rect = MCRectangleGetTransformedBounds(p_rect, MCGAffineTransformInvert(t_transform));
 	
 	MCGraphicsContext *t_old_context = nil;
-	t_old_context = new MCGraphicsContext(p_context);
+	t_old_context = new (nothrow) MCGraphicsContext(p_context);
 	if (t_old_context != nil)
 		render(t_old_context, t_rect);
 	delete t_old_context;
@@ -3028,7 +3028,7 @@ void MCStack::snapshotwindow(const MCRectangle& p_area)
 			// IM-2013-09-30: [[ FullscreenMode ]] Apply stack transform to snapshot context
 			MCGContextConcatCTM(t_context, t_transform);
 			
-			t_success = nil != (t_gfxcontext = new MCGraphicsContext(t_context));
+			t_success = nil != (t_gfxcontext = new (nothrow) MCGraphicsContext(t_context));
 		}
 
 		if (t_success)

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -277,7 +277,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 	
 	if (flags & F_LINK_ATTS)
 	{
-		linkatts = new Linkatts;
+		linkatts = new (nothrow) Linkatts;
 		memset(linkatts, 0, sizeof(Linkatts));
 		
 		// MW-2013-11-20: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
@@ -333,7 +333,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 		{
 		case OT_CARD:
 			{
-				MCCard *newcard = new MCCard;
+				MCCard *newcard = new (nothrow) MCCard;
 				newcard->setparent(this);
 				if ((stat = newcard->load(stream, version)) != IO_NORMAL)
 				{
@@ -347,7 +347,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_GROUP:
 			{
-				MCGroup *newgroup = new MCGroup;
+				MCGroup *newgroup = new (nothrow) MCGroup;
 				newgroup->setparent(this);
 				if ((stat = newgroup->load(stream, version)) != IO_NORMAL)
 				{
@@ -360,7 +360,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_BUTTON:
 			{
-				MCButton *newbutton = new MCButton;
+				MCButton *newbutton = new (nothrow) MCButton;
 				newbutton->setparent(this);
 				if ((stat = newbutton->load(stream, version)) != IO_NORMAL)
 				{
@@ -373,7 +373,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_FIELD:
 			{
-				MCField *newfield = new MCField;
+				MCField *newfield = new (nothrow) MCField;
 				newfield->setparent(this);
 				if ((stat = newfield->load(stream, version)) != IO_NORMAL)
 				{
@@ -386,7 +386,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_IMAGE:
 			{
-				MCImage *newimage = new MCImage;
+				MCImage *newimage = new (nothrow) MCImage;
 				newimage->setparent(this);
 				if ((stat = newimage->load(stream, version)) != IO_NORMAL)
 				{
@@ -400,7 +400,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_SCROLLBAR:
 			{
-				MCScrollbar *newscrollbar = new MCScrollbar;
+				MCScrollbar *newscrollbar = new (nothrow) MCScrollbar;
 				newscrollbar->setparent(this);
 				if ((stat = newscrollbar->load(stream, version)) != IO_NORMAL)
 				{
@@ -412,7 +412,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_GRAPHIC:
 			{
-				MCGraphic *newgraphic = new MCGraphic;
+				MCGraphic *newgraphic = new (nothrow) MCGraphic;
 				newgraphic->setparent(this);
 				if ((stat = newgraphic->load(stream, version)) != IO_NORMAL)
 				{
@@ -424,7 +424,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_PLAYER:
 			{
-				MCPlayer *newplayer = new MCPlayer;
+				MCPlayer *newplayer = new (nothrow) MCPlayer;
 				newplayer->setparent(this);
 				if ((stat = newplayer->load(stream, version)) != IO_NORMAL)
 				{
@@ -437,7 +437,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_MCEPS:
 			{
-				MCEPS *neweps = new MCEPS;
+				MCEPS *neweps = new (nothrow) MCEPS;
 				neweps->setparent(this);
 				if ((stat = neweps->load(stream, version)) != IO_NORMAL)
 				{
@@ -449,7 +449,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
         case OT_WIDGET:
             {
-                MCWidget *newwidget = new MCWidget;
+                MCWidget *newwidget = new (nothrow) MCWidget;
                 newwidget->setparent(this);
                 if ((stat = newwidget->load(stream, version)) != IO_NORMAL)
                 {
@@ -461,7 +461,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
             break;
 		case OT_MAGNIFY:
 			{
-				MCMagnify *newmag = new MCMagnify;
+				MCMagnify *newmag = new (nothrow) MCMagnify;
 				newmag->setparent(this);
 				if ((stat = newmag->load(stream, version)) != IO_NORMAL)
 				{
@@ -473,7 +473,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_COLORS:
 			{
-				MCColors *newcolors = new MCColors;
+				MCColors *newcolors = new (nothrow) MCColors;
 				newcolors->setparent(this);
 				if ((stat = newcolors->load(stream, version)) != IO_NORMAL)
 				{
@@ -485,7 +485,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_AUDIO_CLIP:
 			{
-				MCAudioClip *newaclip = new MCAudioClip;
+				MCAudioClip *newaclip = new (nothrow) MCAudioClip;
 				newaclip->setparent(this);
 				if ((stat = newaclip->load(stream, version)) != IO_NORMAL)
 				{
@@ -497,7 +497,7 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 			break;
 		case OT_VIDEO_CLIP:
 			{
-				MCVideoClip *newvclip = new MCVideoClip;
+				MCVideoClip *newvclip = new (nothrow) MCVideoClip;
 				newvclip->setparent(this);
 				if ((stat = newvclip->load(stream, version)) != IO_NORMAL)
 				{

--- a/engine/src/stackcache.cpp
+++ b/engine/src/stackcache.cpp
@@ -370,7 +370,7 @@ void MCStack::cacheobjectbyid(MCObject *p_object)
 {
 	if (m_id_cache == nil)
 	{
-		m_id_cache = new MCStackIdCache;
+		m_id_cache = new (nothrow) MCStackIdCache;
 		if (!m_id_cache -> RehashBuckets(1))
 		{
 			delete m_id_cache;

--- a/engine/src/stacke.cpp
+++ b/engine/src/stacke.cpp
@@ -293,7 +293,7 @@ void MCStack::effectrect(const MCRectangle& p_area, Boolean& r_abort)
 				case VE_INVERSE:
 					{
 						MCContext *t_old_context = nil;
-						/* UNCHECKED */ t_old_context = new MCGraphicsContext(t_context);
+						/* UNCHECKED */ t_old_context = new (nothrow) MCGraphicsContext(t_context);
 						curcard->draw(t_old_context, t_user_rect, false);
 						delete t_old_context;
 						
@@ -325,7 +325,7 @@ void MCStack::effectrect(const MCRectangle& p_area, Boolean& r_abort)
 				default:
 				{
 					MCContext *t_old_context = nil;
-					/* UNCHECKED */ t_old_context = new MCGraphicsContext(t_context);
+					/* UNCHECKED */ t_old_context = new (nothrow) MCGraphicsContext(t_context);
 					curcard->draw(t_old_context, t_user_rect, false);
 					delete t_old_context;
 				}
@@ -358,7 +358,7 @@ void MCStack::effectrect(const MCRectangle& p_area, Boolean& r_abort)
 				IO_handle stream;
 				if ((stream = MCS_open(t_effects->sound, kMCOpenFileModeRead, True, False, 0)) != NULL)
 				{
-					acptr = new MCAudioClip;
+					acptr = new (nothrow) MCAudioClip;
 					acptr->setdisposable();
 					if (!acptr->import(t_effects->sound, stream))
 					{

--- a/engine/src/stacklst.cpp
+++ b/engine/src/stacklst.cpp
@@ -76,7 +76,7 @@ MCStacklist::~MCStacklist()
 
 void MCStacklist::add(MCStack *sptr)
 {
-	MCStacknode *tptr = new MCStacknode(sptr);
+	MCStacknode *tptr = new (nothrow) MCStacknode(sptr);
 	tptr->appendto(stacks);
 	if (this == MCstacks) // should be done with subclass
 		top(sptr);

--- a/engine/src/stacksecurity.cpp
+++ b/engine/src/stacksecurity.cpp
@@ -45,13 +45,13 @@ bool MCStackSecurityEncryptString(MCStringRef p_string, MCStringRef &r_enc)
 
 bool MCStackSecurityCreateStack(MCStack *&r_stack)
 {
-	r_stack = new MCStack();
+	r_stack = new (nothrow) MCStack();
 	return r_stack != nil;
 }
 
 bool MCStackSecurityCopyStack(const MCStack *p_stack, MCStack *&r_copy)
 {
-	r_copy = new MCStack(*p_stack);
+	r_copy = new (nothrow) MCStack(*p_stack);
 	return r_copy != nil;
 }
 
@@ -59,13 +59,13 @@ bool MCStackSecurityCopyStack(const MCStack *p_stack, MCStack *&r_copy)
 
 bool MCStackSecurityCreateObjectInputStream(IO_handle p_stream, uint32_t p_length, bool p_new_format, MCObjectInputStream *&r_object_stream)
 {
-	r_object_stream = new MCObjectInputStream(p_stream, p_length, p_new_format);
+	r_object_stream = new (nothrow) MCObjectInputStream(p_stream, p_length, p_new_format);
 	return r_object_stream != nil;
 }
 
 bool MCStackSecurityCreateObjectOutputStream(IO_handle p_stream, MCObjectOutputStream *&r_object_stream)
 {
-	r_object_stream = new MCObjectOutputStream(p_stream);
+	r_object_stream = new (nothrow) MCObjectOutputStream(p_stream);
 	return r_object_stream != nil;
 }
 

--- a/engine/src/statemnt.cpp
+++ b/engine/src/statemnt.cpp
@@ -133,7 +133,7 @@ Parse_stat MCStatement::gettargets(MCScriptPoint &sp, MCChunk **targets,
 			sp.backup();
 			return PS_NORMAL;
 		}
-		MCChunk *newptr = new MCChunk(forset);
+		MCChunk *newptr = new (nothrow) MCChunk(forset);
 		if (newptr->parse(sp, False) != PS_NORMAL)
 		{
 			delete newptr;
@@ -200,7 +200,7 @@ Parse_stat MCStatement::getparams(MCScriptPoint &sp, MCParameter **params)
 			sp.backup();
 			return PS_NORMAL;
 		}
-		MCParameter *newptr = new MCParameter;
+		MCParameter *newptr = new (nothrow) MCParameter;
 		if (newptr->parse(sp) != PS_NORMAL)
 		{
 			delete newptr;

--- a/engine/src/styledtext.cpp
+++ b/engine/src/styledtext.cpp
@@ -136,7 +136,7 @@ IO_stat MCStyledText::load(IO_handle p_stream, uint32_t p_version)
 		case OT_PARAGRAPH:
 		case OT_PARAGRAPH_EXT:
 			{
-				MCParagraph *newpar = new MCParagraph;
+				MCParagraph *newpar = new (nothrow) MCParagraph;
 				newpar->setparent((MCField *)parent);
 				
 				// MW-2012-03-04: [[ StackFile5500 ]] If the record is extended then

--- a/engine/src/syscfdate.cpp
+++ b/engine/src/syscfdate.cpp
@@ -496,7 +496,7 @@ static MCDateTimeLocale *do_cache_locale(void)
 	
 	s_locale_timezone = CFTimeZoneCopySystem();
 	
-	s_locale_info = new MCDateTimeLocale;
+	s_locale_info = new (nothrow) MCDateTimeLocale;
 	
 	if (!osx_cf_cache_locale(s_locale_info))
 		*s_locale_info = *g_basic_locale;

--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -553,21 +553,6 @@ struct MCFontStruct
 
 //////////////////////////////////////////////////////////////////////
 //
-//  NEW / DELETE REDEFINTIONS
-//
-
-#include <new>
-
-// MW-2014-08-14: [[ Bug 13154 ]] Make sure we use the nothrow variants of new / delete.
-// SN-2015-04-17: [[ Bug 15187 ]] Don't use the nothrow variant on iOS Simulator
-//  as they won't let iOS Simulator 6.3 engine compile.
-#if (!defined __VISUALC__) && (!TARGET_IPHONE_SIMULATOR)
-void *operator new (size_t size) throw();
-void *operator new[] (size_t size) throw();
-#endif
-
-//////////////////////////////////////////////////////////////////////
-//
 //  INTERVAL DEFINITIONS
 //
 

--- a/engine/src/sysspec-url.cpp
+++ b/engine/src/sysspec-url.cpp
@@ -106,7 +106,7 @@ private:
 MCUrlProgressEvent *MCUrlProgressEvent::CreateUrlProgressEvent(MCObjectHandle p_object, MCStringRef p_url, MCSystemUrlStatus p_status, uint32_t p_amount, uint32_t p_total, MCStringRef p_error)
 {
 	MCUrlProgressEvent *t_event;
-	t_event = new MCUrlProgressEvent();
+	t_event = new (nothrow) MCUrlProgressEvent();
 	if (t_event == nil)
 		return nil;
     
@@ -399,7 +399,7 @@ private:
 MCUrlLoadEvent *MCUrlLoadEvent::CreateUrlLoadEvent(MCObjectHandle p_object, MCNameRef p_message, MCStringRef p_url, MCSystemUrlStatus p_status, MCDataRef p_data, MCStringRef p_error)
 {
 	MCUrlLoadEvent *t_event;
-	t_event = new MCUrlLoadEvent();
+	t_event = new (nothrow) MCUrlLoadEvent();
 	if (t_event == nil)
 		return nil;
 	

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -243,11 +243,11 @@ void MCS_common_init(void)
 	// MW-2013-10-08: [[ Bug 11259 ]] We use our own tables on linux since
 	//   we use a fixed locale which isn't available on all systems.
 #if !defined(_LINUX_SERVER) && !defined(_LINUX_DESKTOP) && !defined(_WINDOWS_DESKTOP) && !defined(_WINDOWS_SERVER) && !defined(__EMSCRIPTEN__)
-	MCuppercasingtable = new uint1[256];
+	MCuppercasingtable = new (nothrow) uint1[256];
 	for(uint4 i = 0; i < 256; ++i)
 		MCuppercasingtable[i] = (uint1)toupper((uint1)i);
 	
-	MClowercasingtable = new uint1[256];
+	MClowercasingtable = new (nothrow) uint1[256];
 	for(uint4 i = 0; i < 256; ++i)
 		MClowercasingtable[i] = (uint1)tolower((uint1)i);
 #endif
@@ -1149,14 +1149,14 @@ bool MCS_pathfromnative(MCStringRef p_native_path, MCStringRef& r_livecode_path)
 IO_handle MCS_fakeopen(const void *p_data, uindex_t p_size)
 {
 	MCMemoryFileHandle *t_handle;
-    t_handle = new MCMemoryFileHandle(p_data, p_size);
+    t_handle = new (nothrow) MCMemoryFileHandle(p_data, p_size);
 	return t_handle;
 }
 
 IO_handle MCS_fakeopenwrite(void)
 {
 	MCMemoryFileHandle *t_handle;
-	t_handle = new MCMemoryFileHandle();
+	t_handle = new (nothrow) MCMemoryFileHandle();
 	return t_handle;
 }
 
@@ -1224,7 +1224,7 @@ bool MCS_tmpnam(MCStringRef& r_path)
 IO_handle MCS_fakeopencustom(MCFakeOpenCallbacks *p_callbacks, void *p_state)
 {
 	MCSystemFileHandle *t_handle;
-	t_handle = new MCCustomFileHandle(p_callbacks, p_state);
+	t_handle = new (nothrow) MCCustomFileHandle(p_callbacks, p_state);
 	return t_handle;
 }
 

--- a/engine/src/sysunxdate.cpp
+++ b/engine/src/sysunxdate.cpp
@@ -226,7 +226,7 @@ static void cache_locale(void)
 	if (s_datetime_locale != NULL)
 		return;
 
-	s_datetime_locale = new MCDateTimeLocale;
+	s_datetime_locale = new (nothrow) MCDateTimeLocale;
 
 	// OK-2007-05-23: Fix for bug 5035. Adjusted to ensure that first element of weekday names is always Sunday.
 

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1123,7 +1123,7 @@ void MCUIDC::delaymessage(MCObject *optr, MCNameRef mptr, MCStringRef p1, MCStri
 	MCParameter *params = NULL;
 	if (p1 != NULL)
 	{
-		params = new MCParameter;
+		params = new (nothrow) MCParameter;
 		params->setvalueref_argument(p1);
 		if (p2 != NULL)
 		{
@@ -1158,7 +1158,7 @@ void MCUIDC::addsubtimer(MCObject *optr, MCValueRef suboptr, MCNameRef mptr, uin
     cancelmessageobject(optr, mptr, suboptr);
     
     MCParameter *t_param;
-    t_param = new MCParameter;
+    t_param = new (nothrow) MCParameter;
     t_param -> setvalueref_argument(suboptr);
     doaddmessage(optr, mptr, MCS_time() + delay / 1000.0, 0, t_param);
 }
@@ -1359,7 +1359,7 @@ void MCUIDC::addmove(MCObject *optr, MCPoint *pts, uint2 npts,
                      real8 &duration, Boolean waiting)
 {
 	stopmove(optr, False);
-	MCMovingList *mptr = new MCMovingList;
+	MCMovingList *mptr = new (nothrow) MCMovingList;
 	mptr->appendto(moving);
 	mptr->object = optr;
 	mptr->pts = pts;
@@ -1581,7 +1581,7 @@ Boolean MCUIDC::lookupcolor(MCStringRef s, MCColor *color)
 
     uint4 slength = strlen(*t_cstring);
     MCAutoPointer<char[]> startptr;
-    startptr = new char[slength + 1];
+    startptr = new (nothrow) char[slength + 1];
 
     MCU_lower(*startptr, *t_cstring);
 

--- a/engine/src/undolst.cpp
+++ b/engine/src/undolst.cpp
@@ -86,7 +86,7 @@ MCUndolist::~MCUndolist()
 
 void MCUndolist::savestate(MCObject *objptr, Ustruct *us)
 {
-	MCUndonode *uptr = new MCUndonode(objptr, us);
+	MCUndonode *uptr = new (nothrow) MCUndonode(objptr, us);
 	uptr->appendto(nodes);
 	objptr->message(MCM_undo_changed);
 }

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -620,7 +620,7 @@ uint4 MCU_r8tos(char *&d, uint4 &s, real8 n,
 	if (d == NULL || s <  R8L)
 	{
 		delete d;
-		d = new char[R8L];
+		d = new (nothrow) char[R8L];
 		s = R8L;
 	}
 	if (n < 0.0 && n >= -MC_EPSILON)
@@ -1099,7 +1099,7 @@ void MCU_break_string(const MCString &s, MCString *&ptrs, uint2 &nptrs,
 #if !defined(_DEBUG_MEMORY)
 void MCU_realloc(char **data, uint4 osize, uint4 nsize, uint4 csize)
 {
-	char *ndata = new char[nsize * csize];
+	char *ndata = new (nothrow) char[nsize * csize];
 	if (data != NULL)
 	{
 		if (nsize > osize)
@@ -1189,7 +1189,7 @@ void MCU_roundrect(MCPoint *&points, uint2 &npoints,
 	if (points == NULL || npoints != 4 * QA_NPOINTS + 1)
 	{
 		delete[] points;
-		points = new MCPoint[4 * QA_NPOINTS + 1];
+		points = new (nothrow) MCPoint[4 * QA_NPOINTS + 1];
 	}
 
 	MCRectangle tr = rect;
@@ -1971,7 +1971,7 @@ bool MCU_path2native(MCStringRef p_path, MCStringRef& r_native_path)
 
 	unichar_t *t_dst;
 	uindex_t t_length;
-    t_dst = new unichar_t[t_length + 1];
+    t_dst = new (nothrow) unichar_t[t_length + 1];
 	t_length = MCStringGetChars(p_path, MCRangeMake(0, t_length), t_dst);
 
 	for (uindex_t i = 0; i < t_length; i++)
@@ -2034,7 +2034,7 @@ void MCU_fix_path(MCStringRef in, MCStringRef& r_out)
     uindex_t t_length;
     t_length = MCStringGetLength(in);
     
-    t_unicode_str = new unichar_t[t_length + 1];
+    t_unicode_str = new (nothrow) unichar_t[t_length + 1];
     t_length = MCStringGetChars(in, MCRangeMake(0, t_length), t_unicode_str);
     t_unicode_str[t_length] = 0;
 
@@ -2721,7 +2721,7 @@ void MCDictionary::Set(uint4 p_id, MCString p_value)
 	t_node = Find(p_id);
 	if (t_node == NULL)
 	{
-		t_node = new Node;
+		t_node = new (nothrow) Node;
 		t_node -> next = m_nodes;
 		t_node -> key = p_id;
 		m_nodes = t_node;
@@ -2752,7 +2752,7 @@ void MCDictionary::Pickle(void*& r_buffer, uint4& r_length)
 		t_size += ((t_node -> length + 3) & ~3) + 8;
 
 	char *t_buffer;
-	t_buffer = new char[t_size];
+	t_buffer = new (nothrow) char[t_size];
 	
 	char *t_buffer_ptr;
 	t_buffer_ptr = t_buffer;
@@ -3018,54 +3018,3 @@ MCU_is_token(MCStringRef p_string)
 
 	return true;
 }
-
-///////////////////////////////////////////////////////////////////////////////
-
-#ifndef _DEBUG_MEMORY
-
-// SN-2015-04-17: [[ Bug 15187 ]] Don't use the nothrow variant on iOS Simulator
-//  as they won't let iOS Simulator 6.3 engine compile.
-#if defined __VISUALC__ || TARGET_IPHONE_SIMULATOR
-void *operator new (size_t size)
-{
-    return malloc(size);
-}
-
-void operator delete (void *p)
-{
-    free(p);
-}
-
-void *operator new[] (size_t size)
-{
-    return malloc(size);
-}
-
-void operator delete[] (void *p)
-{
-    free(p);
-}
-#else
-void *operator new (size_t size) throw()
-{
-    return malloc(size);
-}
-
-void operator delete (void *p) throw()
-{
-    free(p);
-}
-
-void *operator new[] (size_t size) throw()
-{
-    return malloc(size);
-}
-
-void operator delete[] (void *p) throw()
-{
-    free(p);
-}
-#endif
-
-#endif
-

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -44,7 +44,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 bool MCVariable::create(MCVariable*& r_var)
 {
 	MCVariable *self;
-	self = new MCVariable;
+	self = new (nothrow) MCVariable;
 	if (self == nil)
 		return false;
 
@@ -1216,7 +1216,7 @@ bool MCContainer::set_real(double p_real)
 
 bool MCContainer::createwithvariable(MCVariable *p_var, MCContainer*& r_container)
 {
-	r_container = new MCContainer;
+	r_container = new (nothrow) MCContainer;
 	r_container -> m_variable = p_var;
 	r_container -> m_length = 0;
     r_container -> m_path = nil;
@@ -1226,7 +1226,7 @@ bool MCContainer::createwithvariable(MCVariable *p_var, MCContainer*& r_containe
 
 bool MCContainer::createwithpath(MCVariable *p_var, MCNameRef *p_path, uindex_t p_length, MCContainer*& r_container)
 {
-	r_container = new MCContainer;
+	r_container = new (nothrow) MCContainer;
 	r_container -> m_variable = p_var;
 	r_container -> m_path = p_path;
 	r_container -> m_length = p_length;
@@ -1748,7 +1748,7 @@ Exec_stat MCVarref::resolve(MCExecPoint& ep, MCVariable*& r_var, MCVariableValue
 bool MCDeferredVariable::createwithname(MCNameRef p_name, MCDeferredVariableComputeCallback p_callback, void *p_context, MCVariable*& r_var)
 {
 	MCDeferredVariable *self;
-	self = new MCDeferredVariable;
+	self = new (nothrow) MCDeferredVariable;
 	if (self == nil)
 		return false;
 

--- a/engine/src/vclip.cpp
+++ b/engine/src/vclip.cpp
@@ -70,7 +70,7 @@ MCVideoClip::MCVideoClip(const MCVideoClip &mref) : MCObject(mref)
 	size = mref.size;
 	if (mref.frames != NULL)
 	{
-		frames = new uint1[size];
+		frames = new (nothrow) uint1[size];
 		memcpy((char *)frames, (char *)mref.frames, size);
 	}
 	else
@@ -151,7 +151,7 @@ Boolean MCVideoClip::import(MCStringRef fname, IO_handle fstream)
     /* UNCHECKED */ MCNameCreateAndRelease(t_path, &t_path_name);
 	setname(*t_path_name);
 	size = (uint4)MCS_fsize(fstream);
-	frames = new uint1[size];
+	frames = new (nothrow) uint1[size];
 	if (MCS_readfixed(frames, size, fstream) != IO_NORMAL)
 		return False;
 	return True;
@@ -198,7 +198,7 @@ IO_stat MCVideoClip::load(IO_handle stream, uint32_t version)
 		return checkloadstat(stat);
 	if (size != 0)
 	{
-		frames = new uint1[size];
+		frames = new (nothrow) uint1[size];
 		if ((stat = IO_read(frames, size, stream)) != IO_NORMAL)
 			return checkloadstat(stat);
 	}

--- a/engine/src/visual.cpp
+++ b/engine/src/visual.cpp
@@ -184,7 +184,7 @@ Parse_stat MCVisualEffect::parse(MCScriptPoint &sp)
         if (t_key != NULL && sp . parseexp(True, False, &t_value) == PS_NORMAL)
 		{
 			KeyValue *t_kv;
-			t_kv = new KeyValue;
+			t_kv = new (nothrow) KeyValue;
             t_kv -> next = parameters;
             t_kv -> key = t_key;
 			t_kv -> value = t_value;

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -163,7 +163,7 @@ MCWin32RawClipboardItem* MCWin32RawClipboardCommon::CreateNewItem()
 		return NULL;
 
 	// Create a new data item
-	m_item = new MCWin32RawClipboardItem(this);
+	m_item = new (nothrow) MCWin32RawClipboardItem(this);
 	m_item->Retain();
 	return m_item;
 }
@@ -522,7 +522,7 @@ bool MCWin32RawClipboardCommon::SetToIDataObject(IDataObject* p_object)
 
 	// Create a wrapper for this object
 	m_external_data = true;
-	m_item = new MCWin32RawClipboardItem(this, p_object);
+	m_item = new (nothrow) MCWin32RawClipboardItem(this, p_object);
 	return true;
 }
 
@@ -685,7 +685,7 @@ bool MCWin32RawClipboard::PullUpdates()
 
 	// Create a new item to wrap this data object
 	m_external_data = true;
-	m_item = new MCWin32RawClipboardItem(this, t_contents);
+	m_item = new (nothrow) MCWin32RawClipboardItem(this, t_contents);
 
 	if (t_contents != NULL)
 		t_contents->Release();
@@ -812,7 +812,7 @@ bool MCWin32RawClipboardItem::AddRepresentation(MCStringRef p_type, MCDataRef p_
 			return false;
 
 		// Allocate a new representation object.
-		m_reps[t_index] = t_rep = new MCWin32RawClipboardItemRep(this, p_type, p_bytes);
+		m_reps[t_index] = t_rep = new (nothrow) MCWin32RawClipboardItemRep(this, p_type, p_bytes);
 	}
 
 	// If we still have no rep, something went wrong
@@ -875,7 +875,7 @@ MCWin32DataObject* MCWin32RawClipboardItem::GetDataObject()
 
 	// If the data object doesn't exist yet, create it now
 	if (m_object == NULL)
-		m_object = new MCWin32DataObject;
+		m_object = new (nothrow) MCWin32DataObject;
 
 	return static_cast<MCWin32DataObject*> (m_object);
 }
@@ -908,7 +908,7 @@ void MCWin32RawClipboardItem::GenerateRepresentations() const
 			break;
 
 		// Create a new representation object
-		m_reps[t_index] = new MCWin32RawClipboardItemRep(const_cast<MCWin32RawClipboardItem*> (this), t_format);
+		m_reps[t_index] = new (nothrow) MCWin32RawClipboardItemRep(const_cast<MCWin32RawClipboardItem*> (this), t_format);
 	}
 
 	// Release the enumerator object
@@ -1208,7 +1208,7 @@ HRESULT MCWin32DataObject::EnumFormatEtc(DWORD dwDirection, IEnumFORMATETC** ppe
 	}
 
 	// Create a new enumerator object
-	*ppenumFormatEtc = new MCWin32DataObjectFormatEnum(this, 0);
+	*ppenumFormatEtc = new (nothrow) MCWin32DataObjectFormatEnum(this, 0);
 	return S_OK;
 }
 
@@ -1374,7 +1374,7 @@ HRESULT MCWin32DataObjectFormatEnum::Clone(IEnumFORMATETC** ppenum)
 		return E_INVALIDARG;
 
 	// Create a copy of this object
-	*ppenum = new MCWin32DataObjectFormatEnum(m_object, m_index);
+	*ppenum = new (nothrow) MCWin32DataObjectFormatEnum(m_object, m_index);
 	return S_OK;
 }
 

--- a/engine/src/w32-ds-player.cpp
+++ b/engine/src/w32-ds-player.cpp
@@ -1518,7 +1518,7 @@ void MCWin32DSPlayer::UnlockBitmap(MCImageBitmap *bitmap)
 MCWin32DSPlayer *MCWin32DSPlayerCreate()
 {
 	MCWin32DSPlayer *t_player;
-	t_player = new MCWin32DSPlayer();
+	t_player = new (nothrow) MCWin32DSPlayer();
 
 	if (t_player == nil)
 		return nil;

--- a/engine/src/w32ans.cpp
+++ b/engine/src/w32ans.cpp
@@ -284,7 +284,7 @@ static void measure_filter(MCStringRef p_filter, uint4& r_length, uint4& r_count
 
 static void filter_to_spec(const wchar_t *p_filter, uint4 p_filter_count, COMDLG_FILTERSPEC*& r_types)
 {
-	r_types = new COMDLG_FILTERSPEC[p_filter_count];
+	r_types = new (nothrow) COMDLG_FILTERSPEC[p_filter_count];
 	memset(r_types, 0, sizeof(COMDLG_FILTERSPEC) * p_filter_count);
 
 	uint4 t_count;

--- a/engine/src/w32cursor.cpp
+++ b/engine/src/w32cursor.cpp
@@ -138,7 +138,7 @@ static LPCSTR kMCStandardWindowsCursors[] =
 static MCCursorRef create_standard_cursor(LPCSTR p_cursor)
 {
 	MCCursorRef t_cursor;
-	t_cursor = new MCCursor;
+	t_cursor = new (nothrow) MCCursor;
 	// IM-2013-07-17: [[ bug 9836 ]] set up the nil string as the empty 'none' cursor
 	if (p_cursor == nil)
 		t_cursor -> kind = kMCCursorNone;
@@ -151,7 +151,7 @@ static MCCursorRef create_standard_cursor(LPCSTR p_cursor)
 static MCCursorRef create_custom_cursor(HCURSOR p_cursor)
 {
 	MCCursorRef t_cursor;
-	t_cursor = new MCCursor;
+	t_cursor = new (nothrow) MCCursor;
 	t_cursor -> kind = kMCCursorCustom;
 	t_cursor -> custom = p_cursor;
 	return t_cursor;

--- a/engine/src/w32date.cpp
+++ b/engine/src/w32date.cpp
@@ -162,7 +162,7 @@ static MCStringRef windows_query_locale(uint4 t_index)
 	// Allocate a buffer for the locale information
 	int t_buf_size;
 	t_buf_size = GetLocaleInfoW(LOCALE_USER_DEFAULT, t_index, NULL, 0);
-	wchar_t* t_buffer = new wchar_t[t_buf_size];
+	wchar_t* t_buffer = new (nothrow) wchar_t[t_buf_size];
 	
 	// Get the locale information and create a StringRef from it
 	if (GetLocaleInfoW(LOCALE_USER_DEFAULT, t_index, t_buffer, t_buf_size) == 0)
@@ -361,7 +361,7 @@ static void windows_cache_locale(void)
 	if (s_datetime_locale != NULL)
 		return;
 
-	s_datetime_locale = new MCDateTimeLocale;
+	s_datetime_locale = new (nothrow) MCDateTimeLocale;
 
 	// OK-2007-05-23: Fix for bug 5035. Adjusted to ensure that first element of weekday names is always Sunday.
 	s_datetime_locale -> weekday_names[0] = windows_query_locale(LOCALE_SDAYNAME7);

--- a/engine/src/w32dc.cpp
+++ b/engine/src/w32dc.cpp
@@ -190,7 +190,7 @@ LPWSTR MCScreenDC::convertutf8towide(const char *p_utf8_string)
 	t_new_length = UTF8ToUnicode(p_utf8_string, strlen(p_utf8_string), NULL, 0);
 
 	LPWSTR t_result;
-	t_result = new WCHAR[t_new_length + 2];
+	t_result = new (nothrow) WCHAR[t_new_length + 2];
 
 	t_new_length = UTF8ToUnicode(p_utf8_string, strlen(p_utf8_string), (uint2*)t_result, t_new_length);
 	t_result[t_new_length / 2] = 0;
@@ -207,7 +207,7 @@ LPCSTR MCScreenDC::convertutf8toansi(const char *p_utf8_string)
 	t_length = WideCharToMultiByte(CP_ACP, 0, t_wide, -1, NULL, 0, NULL, NULL);
 
 	LPSTR t_result;
-	t_result = new CHAR[t_length];
+	t_result = new (nothrow) CHAR[t_length];
 	WideCharToMultiByte(CP_ACP, 0, t_wide, -1, t_result, t_length, NULL, NULL);
 
 	delete t_wide;

--- a/engine/src/w32dce.cpp
+++ b/engine/src/w32dce.cpp
@@ -682,7 +682,7 @@ char *MCScreenDC::charsettofontname(uint1 charset, const char *oldfontname)
 {
 
 	HDC hdc = f_src_dc;
-	char *fontname = new char[LF_FACESIZE];
+	char *fontname = new (nothrow) char[LF_FACESIZE];
 	LOGFONTA logfont;
 	memset(&logfont, 0, sizeof(LOGFONTA));
 	uint4 maxlength = MCU_min(LF_FACESIZE - 1U, strlen(oldfontname));

--- a/engine/src/w32dcs.cpp
+++ b/engine/src/w32dcs.cpp
@@ -161,7 +161,7 @@ Boolean MCScreenDC::open()
 	f_src_dc = CreateCompatibleDC(NULL);
 	f_dst_dc = CreateCompatibleDC(NULL);
 
-	vis = new MCVisualInfo;
+	vis = new (nothrow) MCVisualInfo;
 
 	ncolors = 0;
 			redbits = greenbits = bluebits = 8;
@@ -723,7 +723,7 @@ uintptr_t MCScreenDC::dtouint(Drawable d)
 
 Boolean MCScreenDC::uinttowindow(uintptr_t id, Window &w)
 {
-	w = new _Drawable;
+	w = new (nothrow) _Drawable;
 	w->type = DC_WINDOW;
 	w->handle.window = (MCSysWindowHandle)id;
 	return True;
@@ -780,7 +780,7 @@ Window MCScreenDC::getroot()
 {
 	static Meta::static_ptr_t<_Drawable> mydrawable;
 	if (mydrawable == DNULL)
-		mydrawable = new _Drawable;
+		mydrawable = new (nothrow) _Drawable;
 	mydrawable->type = DC_WINDOW;
 	mydrawable->handle.window = (MCSysWindowHandle)GetDesktopWindow();
 	return mydrawable;
@@ -1419,7 +1419,7 @@ void MCScreenDC::redrawbackdrop(void)
 		if (backdrop_badge != NULL && backdrop_hard)
 		{
 			MCContext *t_gfxcontext = nil;
-			t_success = nil != (t_gfxcontext = new MCGraphicsContext(t_context));
+			t_success = nil != (t_gfxcontext = new (nothrow) MCGraphicsContext(t_context));
 
 			if (t_success)
 			{

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -607,7 +607,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 						MCParameter *t_parameter;
 						MCAutoStringRef t_param;
 						/* UNCHECKED */ MCStringCopySubstring(*t_cmdline, MCRangeMake(t_argument, t_argument_length), &t_param);
-						t_parameter = new MCParameter;
+						t_parameter = new (nothrow) MCParameter;
 						t_parameter -> setvalueref_argument(*t_param);
 						if (t_first_parameter == NULL)
 							t_first_parameter = t_parameter;
@@ -693,7 +693,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		}
 		else
 		{
-			MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, lParam, 0,
+			MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, lParam, 0,
 			                                    MCmodifierstate, MCeventtime);
 			pms->appendevent(tptr);
 		}
@@ -707,7 +707,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		}
 		else
 		{
-			MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, lParam, 0,
+			MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, lParam, 0,
 			                                    MCmodifierstate, MCeventtime);
 			pms->appendevent(tptr);
 		}
@@ -726,7 +726,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		// Don't bother processing if we're not dispatching
 		if (!curinfo->dispatch)
 		{
-			MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, lParam, 0,
+			MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, lParam, 0,
 			                                    MCmodifierstate, MCeventtime);
 			pms->appendevent(tptr);
 			break;
@@ -737,7 +737,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		// 'flushEvents' can purge any repeated key messages.
 		if (LOWORD(lParam) > 1)
 		{
-			MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, MAKELPARAM(LOWORD(lParam) - 1, HIWORD(lParam)), 0, MCmodifierstate, MCeventtime);
+			MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, MAKELPARAM(LOWORD(lParam) - 1, HIWORD(lParam)), 0, MCmodifierstate, MCeventtime);
 			pms->appendevent(tptr);
 			lParam = MAKELPARAM(1, HIWORD(lParam));
 		}
@@ -917,7 +917,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		else
 		{
 			// Dispatch isn't currently enabled; accumulate to the event queue.
-			MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, lParam, keysym,
+			MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, lParam, keysym,
 			                                    MCmodifierstate, MCeventtime);
 			pms->appendevent(tptr);
 		}
@@ -975,7 +975,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		else
 		{
 			// Add to the event queue
-			MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, lParam, 0,
+			MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, lParam, 0,
 			                                    MCmodifierstate, MCeventtime);
 			pms->appendevent(tptr);
 		}
@@ -1035,7 +1035,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 				unichar_t *t_resstr;
 				MCAutoStringRef t_string;
 				t_reslen = ImmGetCompositionStringW(hIMC, GCS_RESULTSTR, NULL, 0);
-				t_resstr = new unichar_t[t_reslen/sizeof(unichar_t) + 1];
+				t_resstr = new (nothrow) unichar_t[t_reslen/sizeof(unichar_t) + 1];
 				/* UNCHECKED */ ImmGetCompositionStringW(hIMC, GCS_RESULTSTR, t_resstr, t_reslen);
 				/* UNCHECKED */ MCStringCreateWithCharsAndRelease(t_resstr, t_reslen/2, &t_string);
 				MCactivefield->finsertnew(FT_IMEINSERT, *t_string, 0);
@@ -1050,7 +1050,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 				unichar_t *t_compstr;
 				MCAutoStringRef t_string;
 				t_complen = ImmGetCompositionStringW(hIMC, GCS_COMPSTR, NULL, 0);
-				t_compstr = new unichar_t[t_complen/sizeof(unichar_t) + 1];
+				t_compstr = new (nothrow) unichar_t[t_complen/sizeof(unichar_t) + 1];
 				/* UNCHECKED */ ImmGetCompositionStringW(hIMC, GCS_COMPSTR, t_compstr, t_complen);
 				/* UNCHECKED */ MCStringCreateWithCharsAndRelease(t_compstr, t_complen/2, &t_string);
 				MCactivefield->finsertnew(FT_IMEINSERT, *t_string, 0);
@@ -1186,7 +1186,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 			}
 			else
 			{
-				MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, lParam, 0,
+				MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, lParam, 0,
 				                                    MCmodifierstate, MCeventtime);
 				pms->appendevent(tptr);
 			}
@@ -1296,7 +1296,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		}
 		else
 		{
-			MCEventnode *tptr = new MCEventnode(hwnd, msg, wParam, lParam, 0,
+			MCEventnode *tptr = new (nothrow) MCEventnode(hwnd, msg, wParam, lParam, 0,
 			                                    MCmodifierstate, MCeventtime);
 			pms->appendevent(tptr);
 		}
@@ -1392,7 +1392,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 			{
 				if (WSAGETSELECTERROR(lParam))
 				{
-					MCsockets[i]->error = new char[16 + I4L];
+					MCsockets[i]->error = new (nothrow) char[16 + I4L];
 					sprintf(MCsockets[i]->error, "Error %d on socket",
 					        WSAGETSELECTERROR(lParam));
 					MCsockets[i]->doclose();

--- a/engine/src/w32dnd.cpp
+++ b/engine/src/w32dnd.cpp
@@ -109,7 +109,7 @@ MCDragAction MCScreenDC::dodragdrop(Window w, MCDragActionSet p_allowed_actions,
 	t_drop_source = NULL;
 	if (t_success)
 	{
-		t_drop_source = new DropSource;
+		t_drop_source = new (nothrow) DropSource;
 		if (t_drop_source != NULL)
 			t_drop_source -> AddRef();
 		else

--- a/engine/src/w32flst.cpp
+++ b/engine/src/w32flst.cpp
@@ -196,7 +196,7 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style, Boolean printe
 	reqsize = size;
 	reqstyle = style;
 	reqprinter = printer;
-	font = new MCFontStruct;
+	font = new (nothrow) MCFontStruct;
 	if (MCnoui)
 	{
 		memset(font, 0, sizeof(MCFontStruct));
@@ -348,7 +348,7 @@ MCFontStruct *MCFontlist::getfont(MCNameRef fname, uint2 &size, uint2 style, Boo
 			tmp = tmp->next();
 		}
 		while (tmp != fonts);
-	tmp = new MCFontnode(fname, size, style, printer);
+	tmp = new (nothrow) MCFontnode(fname, size, style, printer);
 	tmp->appendto(fonts);
 	return tmp->getfont(fname, size, style, printer);
 }

--- a/engine/src/w32icon.cpp
+++ b/engine/src/w32icon.cpp
@@ -348,7 +348,7 @@ static HMENU create_icon_menu(MCStringRef p_menu)
 			t_item_start++;
 
 		MenuItemDescriptor *t_item;
-		t_item = new MenuItemDescriptor;
+		t_item = new (nothrow) MenuItemDescriptor;
 	
 		if (t_current_item == NULL)
 			t_items = t_item, t_current_item = t_items;

--- a/engine/src/w32printer.cpp
+++ b/engine/src/w32printer.cpp
@@ -233,10 +233,10 @@ bool WindowsGetPrinterPaperSize(MCStringRef p_name, DEVMODEW *p_devmode, POINT& 
 		return false;
 
 	WORD *t_papers;
-	t_papers = new WORD[t_papers_size];
+	t_papers = new (nothrow) WORD[t_papers_size];
 
 	POINT *t_papersizes;
-	t_papersizes = new POINT[t_papersizes_size];
+	t_papersizes = new (nothrow) POINT[t_papersizes_size];
 
 	DWORD t_papers_count;
 	t_papers_count = DeviceCapabilitiesW(*t_name_wstr, NULL, DC_PAPERS, (LPWSTR)t_papers, p_devmode);
@@ -278,10 +278,10 @@ bool WindowsGetPrinterPaperIndex(MCStringRef p_name, DEVMODEW *p_devmode, uint32
 		return false;
 
 	WORD *t_papers;
-	t_papers = new WORD[t_papers_size];
+	t_papers = new (nothrow) WORD[t_papers_size];
 
 	POINT *t_papersizes;
-	t_papersizes = new POINT[t_papersizes_size];
+	t_papersizes = new (nothrow) POINT[t_papersizes_size];
 
 	DWORD t_papers_count;
 	t_papers_count = DeviceCapabilitiesW(*t_name_wstr, NULL, DC_PAPERS, (LPWSTR)t_papers, p_devmode);
@@ -483,7 +483,7 @@ static void resolve_dashes(int2 p_offset, uint1* p_data, uint4 p_length, DWORD*&
 	uint2 t_start;
 	t_start = 0;
 	
-	r_out_data = new DWORD[p_length + 2];
+	r_out_data = new (nothrow) DWORD[p_length + 2];
 
 	while(p_offset >= p_data[t_start])
 	{
@@ -761,7 +761,7 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 		case MARK_TYPE_POLYGON:
 		{
 			POINT *t_points;
-			t_points = new POINT[p_mark -> polygon . count];
+			t_points = new (nothrow) POINT[p_mark -> polygon . count];
 			if (t_points == NULL)
 				break;
 
@@ -1298,7 +1298,7 @@ MCPrinterResult MCWindowsPrinterDevice::Begin(const MCPrinterRectangle& p_src_re
 	// rectangle
 	//
 	MCGDIMetaContext *t_context;
-	t_context = new MCGDIMetaContext(t_src_rect_hull);
+	t_context = new (nothrow) MCGDIMetaContext(t_src_rect_hull);
 	r_context = t_context;
 
 	m_src_rect = p_src_rect;
@@ -1436,7 +1436,7 @@ void MCWindowsPrinter::DoFetchSettings(void*& r_buffer, uint4& r_length)
 	EncodeSettings(m_name, m_devmode, &t_data);
 
 	// This is ugly. Hopefully printing will get sorted out soon...
-	void *t_buffer = new byte_t[MCDataGetLength(*t_data)];
+	void *t_buffer = new (nothrow) byte_t[MCDataGetLength(*t_data)];
 	memcpy(t_buffer, MCDataGetBytePtr(*t_data), MCDataGetLength(*t_data));
 	r_buffer = t_buffer;
 	r_length = MCDataGetLength(*t_data);
@@ -1460,7 +1460,7 @@ MCPrinterDialogResult MCWindowsPrinter::DoPrinterSetup(bool p_window_modal, Wind
 	t_range_count = MCU_max(0, GetJobRangeCount());
 
 	PRINTPAGERANGE *t_ranges;
-	t_ranges = new PRINTPAGERANGE[64];
+	t_ranges = new (nothrow) PRINTPAGERANGE[64];
 	for(int i = 0; i < t_range_count; ++i)
 	{
 		t_ranges[i] . nFromPage = GetJobRanges()[i] . from;
@@ -1738,7 +1738,7 @@ MCPrinterResult MCWindowsPrinter::DoBeginPrint(MCStringRef p_document_name, MCPr
 		return PRINTER_RESULT_ERROR;
 
 	MCWindowsPrinterDevice *t_device;
-	t_device = new MCWindowsPrinterDevice;
+	t_device = new (nothrow) MCWindowsPrinterDevice;
 
 	MCPrinterResult t_result;
     // SN-2014-12-22: [[ Bug 14278 ]] Updated to Unicode name and location

--- a/engine/src/w32script.cpp
+++ b/engine/src/w32script.cpp
@@ -58,7 +58,7 @@ LPOLESTR ConvertUTF8ToOLESTR(const char *p_string)
 	t_length = UTF8ToUnicode(p_string, strlen(p_string), NULL, 0);
 
 	LPOLESTR t_result;
-	t_result = new OLECHAR[t_length / 2 + 1];
+	t_result = new (nothrow) OLECHAR[t_length / 2 + 1];
 	if (t_result != NULL)
 		UTF8ToUnicode(p_string, strlen(p_string) + 1, (unsigned short *)t_result, t_length + 2);
 
@@ -71,7 +71,7 @@ char *ConvertBSTRToUTF8(BSTR p_string)
 	t_length = UnicodeToUTF8((unsigned short*)p_string, SysStringLen(p_string) * 2, NULL, 0);
 
 	char *t_result;
-	t_result = new char[t_length + 1];
+	t_result = new (nothrow) char[t_length + 1];
 	if (t_result != NULL)
 	{
 		UnicodeToUTF8((unsigned short*)p_string, SysStringLen(p_string) * 2, t_result, t_length);
@@ -233,7 +233,7 @@ HRESULT ActiveScriptDispatch::Invoke(DISPID p_member, REFIID p_interface, LCID p
 	t_result = S_OK;
 
 	char **t_str_parameters;
-	t_str_parameters = new char *[p_parameters -> cArgs];
+	t_str_parameters = new (nothrow) char *[p_parameters -> cArgs];
 	memset(t_str_parameters, 0, sizeof(char *) * p_parameters -> cArgs);
 	for(unsigned int i = 0; i < p_parameters -> cArgs; ++i)
 	{
@@ -512,7 +512,7 @@ bool MCWindowsActiveScriptEnvironment::Initialize(OLECHAR *p_language)
 	t_dispatch = NULL;
 	if (t_result == S_OK)
 	{
-		t_dispatch = new ActiveScriptDispatch;
+		t_dispatch = new (nothrow) ActiveScriptDispatch;
 		if (t_dispatch != NULL)
 			t_dispatch -> AddRef();
 		else
@@ -523,7 +523,7 @@ bool MCWindowsActiveScriptEnvironment::Initialize(OLECHAR *p_language)
 	t_site = NULL;
 	if (t_result == S_OK)
 	{
-		t_site = new ActiveScriptSite(t_dispatch);
+		t_site = new (nothrow) ActiveScriptSite(t_dispatch);
 		if (t_site != NULL)
 			t_site -> AddRef();
 		else
@@ -708,7 +708,7 @@ char *MCWindowsActiveScriptEnvironment::Call(const char *p_method, const char **
 	t_ole_arguments = NULL;
 	if (t_result == S_OK)
 	{
-		t_ole_arguments = new VARIANTARG[p_argument_count];
+		t_ole_arguments = new (nothrow) VARIANTARG[p_argument_count];
 		if (t_ole_arguments != NULL)
 			memset(t_ole_arguments, 0, sizeof(VARIANTARG) * p_argument_count);
 		else
@@ -779,7 +779,7 @@ MCScriptEnvironment *MCScreenDC::createscriptenvironment(MCStringRef p_language)
 	t_ole_language = ConvertUTF8ToOLESTR(*t_language);
 
 	MCWindowsActiveScriptEnvironment *t_environment;
-	t_environment = new MCWindowsActiveScriptEnvironment;
+	t_environment = new (nothrow) MCWindowsActiveScriptEnvironment;
 
 	if (t_environment -> Initialize(t_ole_language))
 		t_environment -> Retain();

--- a/engine/src/w32stack.cpp
+++ b/engine/src/w32stack.cpp
@@ -413,7 +413,7 @@ void MCStack::realize()
 		LONG height = wrect.bottom - wrect.top;
 		if (flags & F_WM_PLACE && !(state & CS_BEEN_MOVED))
 			x = CW_USEDEFAULT;
-		window = new _Drawable;
+		window = new (nothrow) _Drawable;
 		window->type = DC_WINDOW;
 		window->handle.window = 0; // protect against creation callbacks
 
@@ -629,7 +629,7 @@ void MCStack::start_externals()
 
 	if (!MCnoui && window != DNULL)
 	{
-		droptarget = new CDropTarget;
+		droptarget = new (nothrow) CDropTarget;
 		droptarget->setstack(this);
 		CoLockObjectExternal(droptarget, TRUE, TRUE);
 		RegisterDragDrop((HWND)window->handle.window, droptarget);

--- a/engine/src/w32text.cpp
+++ b/engine/src/w32text.cpp
@@ -23,7 +23,7 @@ WideCString::WideCString(LPCSTR p_ansi_string, int p_length)
 	int t_length;
 	t_length = MultiByteToWideChar(CP_ACP, 0, p_ansi_string, p_length, NULL, 0);
 
-	f_string = new WCHAR[t_length];
+	f_string = new (nothrow) WCHAR[t_length];
 	if (f_string != NULL)
 		MultiByteToWideChar(CP_ACP, 0, p_ansi_string, p_length, (LPWSTR)f_string, t_length);
 }
@@ -33,7 +33,7 @@ AnsiCString::AnsiCString(LPCWSTR p_wide_string)
 	int t_length;
 	t_length = WideCharToMultiByte(CP_ACP, 0, p_wide_string, -1, NULL, 0, NULL, NULL);
 
-	f_string = new CHAR[t_length];
+	f_string = new (nothrow) CHAR[t_length];
 	if (f_string != NULL)
 		WideCharToMultiByte(CP_ACP, 0, p_wide_string, -1, (LPSTR)f_string, t_length, NULL, NULL);
 }

--- a/engine/src/widget-popup.cpp
+++ b/engine/src/widget-popup.cpp
@@ -171,7 +171,7 @@ private:
 		if (m_widget != nil)
 			return true;
 		
-		m_widget = new MCWidget();
+		m_widget = new (nothrow) MCWidget();
 		if (m_widget == nil)
 			return MCErrorThrowOutOfMemory();
 		
@@ -370,7 +370,7 @@ bool MCWidgetPopupAtLocationWithProperties(MCNameRef p_kind, const MCPoint &p_at
 	MCWidgetPopup *t_popup;
 	t_popup = nil;
 	
-	t_popup = new MCWidgetPopup();
+	t_popup = new (nothrow) MCWidgetPopup();
 	if (t_popup == nil)
 	{
 		// TODO - throw memory error

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -837,7 +837,7 @@ IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext, uint3
 MCControl *MCWidget::clone(Boolean p_attach, Object_pos p_position, bool invisible)
 {
 	MCWidget *t_new_widget;
-	t_new_widget = new MCWidget(*this);
+	t_new_widget = new (nothrow) MCWidget(*this);
 	if (p_attach)
 		t_new_widget -> attach(p_position, invisible);
     

--- a/engine/test/test_new.cpp
+++ b/engine/test/test_new.cpp
@@ -76,11 +76,11 @@ TEST(new, new)
 	VeryBig* pointers[1000];
 	int i = 0;
 
-	VeryBig* p = new VeryBig;
+	VeryBig* p = new (nothrow) VeryBig;
 
 	for (; p != NULL && i < 1000; i++) {
 		pointers[i] = p;
-		p = new VeryBig;
+		p = new (nothrow) VeryBig;
 	}
 
 	ASSERT_NE(1000, i) << "All alocations succeed!";
@@ -103,11 +103,11 @@ TEST(new, array)
 	VeryBig* pointers[1000];
 	int i = 0;
 
-	VeryBig* p = new VeryBig[1];
+	VeryBig* p = new (nothrow) VeryBig[1];
 
 	for (; p != NULL && i < 1000; i++) {
 		pointers[i] = p;
-		p = new VeryBig[1];
+		p = new (nothrow) VeryBig[1];
 	}
 
 	ASSERT_NE(1000, i) << "All alocations succeed!";

--- a/lcidlc/src/InterfaceGenerate.cpp
+++ b/lcidlc/src/InterfaceGenerate.cpp
@@ -1213,7 +1213,7 @@ static void InterfaceGenerateVariant(InterfaceRef self, CoderRef p_coder, Handle
 	t_is_java = p_mapping == kHandlerMappingJava;
 	
 	MappedParameter *t_mapped_params;
-	t_mapped_params = new MappedParameter[t_variant -> parameter_count];
+	t_mapped_params = new (nothrow) MappedParameter[t_variant -> parameter_count];
 	for(uint32_t k = 0; k < t_variant -> parameter_count; k++)
 		map_parameter(self, p_mapping, &t_variant -> parameters[k], k, t_mapped_params[k]);
 	

--- a/libbrowser/src/libbrowser.cpp
+++ b/libbrowser/src/libbrowser.cpp
@@ -16,6 +16,7 @@
 
 #include <core.h>
 
+#include <new>
 #include <stdlib.h>
 #include <memory.h>
 
@@ -464,7 +465,7 @@ bool MCBrowserSetRequestHandler(MCBrowserRef p_browser, MCBrowserRequestCallback
 	}
 	
 	MCBrowserEventHandlerWrapper *t_wrapper;
-	t_wrapper = new MCBrowserEventHandlerWrapper(p_callback, p_context);
+	t_wrapper = new (std::nothrow) MCBrowserEventHandlerWrapper(p_callback, p_context);
 	
 	if (t_wrapper == nil)
 		return false;
@@ -509,7 +510,7 @@ bool MCBrowserSetJavaScriptHandler(MCBrowserRef p_browser, MCBrowserJavaScriptCa
 	}
 	
 	MCBrowserJavaScriptHandlerWrapper *t_wrapper;
-	t_wrapper = new MCBrowserJavaScriptHandlerWrapper(p_callback, p_context);
+	t_wrapper = new (std::nothrow) MCBrowserJavaScriptHandlerWrapper(p_callback, p_context);
 	
 	if (t_wrapper == nil)
 		return false;

--- a/libbrowser/src/libbrowser.cpp
+++ b/libbrowser/src/libbrowser.cpp
@@ -16,7 +16,6 @@
 
 #include <core.h>
 
-#include <new>
 #include <stdlib.h>
 #include <memory.h>
 
@@ -465,7 +464,7 @@ bool MCBrowserSetRequestHandler(MCBrowserRef p_browser, MCBrowserRequestCallback
 	}
 	
 	MCBrowserEventHandlerWrapper *t_wrapper;
-	t_wrapper = new (std::nothrow) MCBrowserEventHandlerWrapper(p_callback, p_context);
+	t_wrapper = new (nothrow) MCBrowserEventHandlerWrapper(p_callback, p_context);
 	
 	if (t_wrapper == nil)
 		return false;
@@ -510,7 +509,7 @@ bool MCBrowserSetJavaScriptHandler(MCBrowserRef p_browser, MCBrowserJavaScriptCa
 	}
 	
 	MCBrowserJavaScriptHandlerWrapper *t_wrapper;
-	t_wrapper = new (std::nothrow) MCBrowserJavaScriptHandlerWrapper(p_callback, p_context);
+	t_wrapper = new (nothrow) MCBrowserJavaScriptHandlerWrapper(p_callback, p_context);
 	
 	if (t_wrapper == nil)
 		return false;

--- a/libbrowser/src/libbrowser_android.cpp
+++ b/libbrowser/src/libbrowser_android.cpp
@@ -1042,7 +1042,7 @@ class MCAndroidWebViewBrowserFactory : public MCBrowserFactory
 	virtual bool CreateBrowser(void *p_display, void *p_parent_view, MCBrowser *&r_browser)
 	{
 		MCAndroidWebViewBrowser *t_browser;
-		t_browser = new MCAndroidWebViewBrowser();
+		t_browser = new (nothrow) MCAndroidWebViewBrowser();
 		
 		if (t_browser == nil)
 			return false;
@@ -1061,7 +1061,7 @@ class MCAndroidWebViewBrowserFactory : public MCBrowserFactory
 
 bool MCAndroidWebViewBrowserFactoryCreate(MCBrowserFactoryRef &r_factory)
 {
-	MCBrowserFactory *t_factory = new MCAndroidWebViewBrowserFactory();
+	MCBrowserFactory *t_factory = new (nothrow) MCAndroidWebViewBrowserFactory();
 	
 	if (t_factory == nil)
 		return false;

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -332,7 +332,7 @@ bool MCCefInitialise(void)
 			t_success = MCCefStringFromUtf8String(t_resource_path, &t_settings.resources_dir_path);
 	}
 	
-	CefRefPtr<CefApp> t_app = new MCCefBrowserApp();
+	CefRefPtr<CefApp> t_app = new (nothrow) MCCefBrowserApp();
 	
 	if (t_success)
 		t_success = -1 == CefExecuteProcess(t_args, t_app, nil);
@@ -1053,7 +1053,7 @@ public:
 bool MCCefBrowserBase::Initialize()
 {
 	// create client and browser
-	m_client = new MCCefBrowserClient(this);
+	m_client = new (nothrow) MCCefBrowserClient(this);
 	
 	CefWindowInfo t_window_info;
 	CefBrowserSettings t_settings;
@@ -1343,7 +1343,7 @@ char *MCCefBrowserBase::GetSource(void)
 	t_result.Clear();
 	
 	CefRefPtr<CefStringVisitor> t_visitor;
-	t_visitor = new MCStringVisitor(t_result);
+	t_visitor = new (nothrow) MCStringVisitor(t_result);
 	
 	m_browser->GetMainFrame()->GetSource(t_visitor);
 	
@@ -1799,7 +1799,7 @@ bool MCCefBrowserFactory::CreateBrowser(void *p_display, void *p_parent_view, MC
 bool MCCefBrowserFactoryCreate(MCBrowserFactoryRef &r_factory)
 {
 	MCCefBrowserFactory *t_factory;
-	t_factory = new MCCefBrowserFactory();
+	t_factory = new (nothrow) MCCefBrowserFactory();
 	
 	if (t_factory == nil)
 		return false;

--- a/libbrowser/src/libbrowser_cef_lnx.cpp
+++ b/libbrowser/src/libbrowser_cef_lnx.cpp
@@ -207,7 +207,7 @@ void MCCefLinuxBrowser::PlatformCloseBrowserWindow(CefRefPtr<CefBrowser> p_brows
 bool MCCefPlatformCreateBrowser(void *p_display, void *p_window_id, MCCefBrowserBase *&r_browser)
 {
 	MCCefLinuxBrowser *t_browser;
-	t_browser = new MCCefLinuxBrowser((Display*)p_display, (Window)p_window_id);
+	t_browser = new (nothrow) MCCefLinuxBrowser((Display*)p_display, (Window)p_window_id);
 	
 	if (t_browser == nil)
 		return false;

--- a/libbrowser/src/libbrowser_cef_win.cpp
+++ b/libbrowser/src/libbrowser_cef_win.cpp
@@ -174,7 +174,7 @@ const char *MCCefPlatformGetCefLibraryPath(void)
 bool MCCefPlatformCreateBrowser(void *p_display, void *p_parent_view, MCCefBrowserBase *&r_browser)
 {
 	MCCefWin32Browser *t_browser;
-	t_browser = new MCCefWin32Browser((HWND)p_parent_view);
+	t_browser = new (nothrow) MCCefWin32Browser((HWND)p_parent_view);
 
 	if (t_browser == nil)
 		return false;

--- a/libbrowser/src/libbrowser_cefprocess.cpp
+++ b/libbrowser/src/libbrowser_cefprocess.cpp
@@ -397,7 +397,7 @@ bool MCCefHandleGetSelectedText(CefRefPtr<CefBrowser> p_browser, CefString &r_re
 	t_success = true;
 	
 	MCGetSelectedTextDOMVisitor *t_dom_visitor;
-	t_dom_visitor = new MCGetSelectedTextDOMVisitor();
+	t_dom_visitor = new (nothrow) MCGetSelectedTextDOMVisitor();
 	t_success = t_dom_visitor != nil;
 	
 	CefRefPtr<CefDOMVisitor> t_visitor_ref;
@@ -437,7 +437,7 @@ bool MCCefHandleGetTitle(CefRefPtr<CefBrowser> p_browser, CefString &r_return_va
 	t_success = true;
 	
 	MCGetTitleDOMVisitor *t_dom_visitor;
-	t_dom_visitor = new MCGetTitleDOMVisitor();
+	t_dom_visitor = new (nothrow) MCGetTitleDOMVisitor();
 	t_success = t_dom_visitor != nil;
 	
 	CefRefPtr<CefDOMVisitor> t_visitor_ref;
@@ -740,7 +740,7 @@ private:
 		if (!p_container->HasValue(p_name))
 		{
 			CefRefPtr<CefV8Handler> t_handler;
-			t_success = nil != (t_handler = new MCCefLCFuncHandler(p_name));
+			t_success = nil != (t_handler = new (nothrow) MCCefLCFuncHandler(p_name));
 			
 			CefRefPtr<CefV8Value> t_func;
 			if (t_success)
@@ -816,7 +816,7 @@ private:
 bool MCCefCreateApp(CefRefPtr<CefApp> &r_app)
 {
 	MCCefRenderApp *t_app;
-	t_app = new MCCefRenderApp();
+	t_app = new (nothrow) MCCefRenderApp();
 	
 	if (t_app == nil)
 	{

--- a/libbrowser/src/libbrowser_value.cpp
+++ b/libbrowser/src/libbrowser_value.cpp
@@ -414,7 +414,7 @@ MC_BROWSER_DLLEXPORT_DEF
 bool MCBrowserListCreate(MCBrowserListRef &r_browser, uint32_t p_size)
 {
 	MCBrowserList *t_browser;
-	t_browser = new (std::nothrow) MCBrowserList();
+	t_browser = new (nothrow) MCBrowserList();
 	if (t_browser == nil)
 		return false;
 	
@@ -878,7 +878,7 @@ MC_BROWSER_DLLEXPORT_DEF
 bool MCBrowserDictionaryCreate(MCBrowserDictionaryRef &r_dict, uint32_t p_size)
 {
 	MCBrowserDictionary *t_dict;
-	t_dict = new (std::nothrow) MCBrowserDictionary();
+	t_dict = new (nothrow) MCBrowserDictionary();
 	if (t_dict == nil)
 		return false;
 	

--- a/libbrowser/src/libbrowser_value.cpp
+++ b/libbrowser/src/libbrowser_value.cpp
@@ -414,7 +414,7 @@ MC_BROWSER_DLLEXPORT_DEF
 bool MCBrowserListCreate(MCBrowserListRef &r_browser, uint32_t p_size)
 {
 	MCBrowserList *t_browser;
-	t_browser = new MCBrowserList();
+	t_browser = new (std::nothrow) MCBrowserList();
 	if (t_browser == nil)
 		return false;
 	
@@ -878,7 +878,7 @@ MC_BROWSER_DLLEXPORT_DEF
 bool MCBrowserDictionaryCreate(MCBrowserDictionaryRef &r_dict, uint32_t p_size)
 {
 	MCBrowserDictionary *t_dict;
-	t_dict = new MCBrowserDictionary();
+	t_dict = new (std::nothrow) MCBrowserDictionary();
 	if (t_dict == nil)
 		return false;
 	

--- a/libcore/include/core.h
+++ b/libcore/include/core.h
@@ -282,6 +282,7 @@ void MCMemoryDelete(void *p_record);
 //////////
 
 #include <new>
+using std::nothrow;
 
 // This method provides type-safe construction of an object.
 template<typename T> bool MCMemoryNew(T*& r_record)

--- a/libcore/include/core.h
+++ b/libcore/include/core.h
@@ -281,17 +281,7 @@ void MCMemoryDelete(void *p_record);
 
 //////////
 
-#ifdef _DEBUG
-#ifdef new
-#undef new
-#define redef_new
-#endif
-#endif
-
-inline void *operator new (size_t, void *p_block, bool)
-{
-	return p_block;
-}
+#include <new>
 
 // This method provides type-safe construction of an object.
 template<typename T> bool MCMemoryNew(T*& r_record)
@@ -302,7 +292,7 @@ template<typename T> bool MCMemoryNew(T*& r_record)
 		// Notice here we use the 'placement-new' operator we defined above to
 		// do the type conversion. This ensures any type-specific initialization
 		// is done.
-		r_record = new(t_record, true) T;
+		r_record = new (t_record) T;
 
 		return true;
 	}
@@ -317,13 +307,6 @@ template<typename T> void MCMemoryDelete(T* p_record)
 
 	MCMemoryDelete(static_cast<void *>(p_record));
 }
-
-#ifdef _DEBUG
-#ifdef redef_new
-#undef redef_new
-#define new new(__FILE__, __LINE__)
-#endif
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libexternal/src/unxsupport.cpp
+++ b/libexternal/src/unxsupport.cpp
@@ -88,7 +88,7 @@ char *strclone(const char *one)
 	char *two = NULL;
 	if (one != NULL)
 	{
-		two = new char[strlen(one) + 1];
+		two = new (nothrow) char[strlen(one) + 1];
 		strcpy(two, one);
 	}
 	return two;
@@ -96,7 +96,7 @@ char *strclone(const char *one)
 
 char *get_current_directory()
 {
-	char *dptr = new char[PATH_MAX + 2];
+	char *dptr = new (nothrow) char[PATH_MAX + 2];
 	getcwd(dptr, PATH_MAX);
 	return dptr;
 }
@@ -127,7 +127,7 @@ char *os_path_resolve(const char *p_native_path)
 			pw = getpwnam(tpath + 1);
 		if (pw == NULL)
 			return NULL;
-		tildepath = new char[strlen(pw->pw_dir) + strlen(tptr) + 2];
+		tildepath = new (nothrow) char[strlen(pw->pw_dir) + strlen(tptr) + 2];
 		strcpy(tildepath, pw->pw_dir);
 		if (*tptr)
 		{
@@ -144,7 +144,7 @@ char *os_path_resolve(const char *p_native_path)
 	if (lstat(tildepath, &buf) != 0 || !S_ISLNK(buf.st_mode))
 		return tildepath;
 	int4 size;
-	char *newname = new char[PATH_MAX + 2];
+	char *newname = new (nothrow) char[PATH_MAX + 2];
 	if ((size = readlink(tildepath, newname, PATH_MAX)) < 0)
 	{
 		delete tildepath;
@@ -155,7 +155,7 @@ char *os_path_resolve(const char *p_native_path)
 	newname[size] = '\0';
 	if (newname[0] != '/')
 	{
-		char *fullpath = new char[strlen(p_native_path) + strlen(newname) + 2];
+		char *fullpath = new (nothrow) char[strlen(p_native_path) + strlen(newname) + 2];
 		strcpy(fullpath, p_native_path);
 		char *sptr = strrchr(fullpath, '/');
 		if (sptr == NULL)

--- a/libexternal/src/w32support.cpp
+++ b/libexternal/src/w32support.cpp
@@ -109,7 +109,7 @@ char *strclone(const char *one)
 	char *two = NULL;
 	if (one != NULL)
 	{
-		two = new char[strlen(one) + 1];
+		two = new (nothrow) char[strlen(one) + 1];
 		strcpy(two, one);
 	}
 	return two;
@@ -117,7 +117,7 @@ char *strclone(const char *one)
 
 char *get_currrent_directory()
 {
-	char *dptr = new char[PATH_MAX + 2];
+	char *dptr = new (nothrow) char[PATH_MAX + 2];
 	GetCurrentDirectoryA(PATH_MAX +1, (LPSTR)dptr);
 	dptr = os_path_to_native(dptr);
 	return dptr;

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -716,7 +716,7 @@ public:
  * manage a value created with the "new" operator.  For example:
  *
  *     MCAutoPointer<int> number;
- *     number = new int;
+ *     number = new (nothrow) int;
  */
 template<typename T> class MCAutoPointer
 {
@@ -769,7 +769,7 @@ private:
  * manage a value created with the "new[]" operator.  For example:
  *
  *     MCAutoPointer<int[]> numbers;
- *     numbers = new int[25];
+ *     numbers = new (nothrow) int[25];
  */
 template<typename T> class MCAutoPointer<T[]>
 {

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -656,6 +656,16 @@ typedef struct __MCLocale* MCLocaleRef;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
+//  NEW AND DELETE OPERATORS
+//
+
+#ifdef __cplusplus
+# include <new>
+using std::nothrow;
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+//
 //  MINIMUM FUNCTIONS
 //
 
@@ -1067,24 +1077,12 @@ MC_DLLEXPORT void MCMemoryDelete(void *p_record);
 
 }
 
-#ifdef _DEBUG
-#ifdef new
-#undef new
-#define redef_new
-#endif
-#endif
-
-inline void *operator new (size_t, void *p_block, bool)
-{
-	return p_block;
-}
-
 template<typename T> bool MCMemoryNew(T*& r_record)
 {
 	void *t_record;
 	if (MCMemoryNew(sizeof(T), t_record))
 	{
-        r_record = new(t_record, true) T;
+        r_record = new (t_record) T;
 		return true;
 	}
 	return false;

--- a/libfoundation/src/foundation-chunk.cpp
+++ b/libfoundation/src/foundation-chunk.cpp
@@ -837,9 +837,9 @@ MCTextChunkIterator *MCChunkCreateTextChunkIterator(MCStringRef p_text, MCRange 
         case kMCChunkTypeSentence:
         case kMCChunkTypeTrueWord:
             if (p_range != nil)
-                t_iterator = new MCTextChunkIterator_ICU(p_text, p_chunk_type, *p_range);
+                t_iterator = new (nothrow) MCTextChunkIterator_ICU(p_text, p_chunk_type, *p_range);
             else
-                t_iterator = new MCTextChunkIterator_ICU(p_text, p_chunk_type);
+                t_iterator = new (nothrow) MCTextChunkIterator_ICU(p_text, p_chunk_type);
             break;
         case kMCChunkTypeLine:
         case kMCChunkTypeItem:
@@ -850,44 +850,44 @@ MCTextChunkIterator *MCChunkCreateTextChunkIterator(MCStringRef p_text, MCRange 
                 t_delimiter = p_item_delimiter;
  
             if (p_range != nil)
-                t_iterator = new MCTextChunkIterator_Delimited(p_text, p_chunk_type, t_delimiter, *p_range);
+                t_iterator = new (nothrow) MCTextChunkIterator_Delimited(p_text, p_chunk_type, t_delimiter, *p_range);
             else
-                t_iterator = new MCTextChunkIterator_Delimited(p_text, p_chunk_type, t_delimiter);
+                t_iterator = new (nothrow) MCTextChunkIterator_Delimited(p_text, p_chunk_type, t_delimiter);
             break;
 
             break;
         case kMCChunkTypeParagraph:
             if (p_range != nil)
-                t_iterator = new MCTextChunkIterator_Delimited(p_text, p_chunk_type, MCSTR("\n"), *p_range);
+                t_iterator = new (nothrow) MCTextChunkIterator_Delimited(p_text, p_chunk_type, MCSTR("\n"), *p_range);
             else
-                t_iterator = new MCTextChunkIterator_Delimited(p_text, p_chunk_type, MCSTR("\n"));
+                t_iterator = new (nothrow) MCTextChunkIterator_Delimited(p_text, p_chunk_type, MCSTR("\n"));
             break;
             break;
         case kMCChunkTypeWord:
             // AL-2015-10-08: [[ Bug 16161 ]] Word chunk needs to be passed line delimiter
             //  as words are also delimited by line breaks.
             if (p_range != nil)
-                t_iterator = new MCTextChunkIterator_Word(p_text, p_chunk_type, p_line_delimiter, *p_range);
+                t_iterator = new (nothrow) MCTextChunkIterator_Word(p_text, p_chunk_type, p_line_delimiter, *p_range);
             else
-                t_iterator = new MCTextChunkIterator_Word(p_text, p_chunk_type, p_line_delimiter);
+                t_iterator = new (nothrow) MCTextChunkIterator_Word(p_text, p_chunk_type, p_line_delimiter);
             break;
         case kMCChunkTypeCharacter:
             if (p_range != nil)
-                t_iterator = new MCTextChunkIterator_Grapheme(p_text, p_chunk_type, *p_range);
+                t_iterator = new (nothrow) MCTextChunkIterator_Grapheme(p_text, p_chunk_type, *p_range);
             else
-                t_iterator = new MCTextChunkIterator_Grapheme(p_text, p_chunk_type);
+                t_iterator = new (nothrow) MCTextChunkIterator_Grapheme(p_text, p_chunk_type);
             break;
         case kMCChunkTypeCodepoint:
             if (p_range != nil)
-                t_iterator = new MCTextChunkIterator_Codepoint(p_text, p_chunk_type, *p_range);
+                t_iterator = new (nothrow) MCTextChunkIterator_Codepoint(p_text, p_chunk_type, *p_range);
             else
-                t_iterator = new MCTextChunkIterator_Codepoint(p_text, p_chunk_type);
+                t_iterator = new (nothrow) MCTextChunkIterator_Codepoint(p_text, p_chunk_type);
             break;
         case kMCChunkTypeCodeunit:
             if (p_range != nil)
-                t_iterator = new MCTextChunkIterator_Codeunit(p_text, p_chunk_type, *p_range);
+                t_iterator = new (nothrow) MCTextChunkIterator_Codeunit(p_text, p_chunk_type, *p_range);
             else
-                t_iterator = new MCTextChunkIterator_Codeunit(p_text, p_chunk_type);
+                t_iterator = new (nothrow) MCTextChunkIterator_Codeunit(p_text, p_chunk_type);
             break;
         default:
             MCAssert(false);

--- a/libfoundation/src/foundation-locale.cpp
+++ b/libfoundation/src/foundation-locale.cpp
@@ -27,6 +27,7 @@
 #include "unicode/timezone.h"
 #include "unicode/uclean.h"
 
+#include "foundation.h"
 #include "foundation-auto.h"
 
 
@@ -267,7 +268,7 @@ bool MCLocaleCreateWithName(MCStringRef p_name, MCLocaleRef &r_locale)
     
     // Convert it into an engine locale
     __MCLocale *t_locale;
-    t_locale = new __MCLocale(*t_icu_locale);
+    t_locale = new (nothrow) __MCLocale(*t_icu_locale);
     
     // All done
     r_locale = t_locale;
@@ -729,7 +730,7 @@ bool MCTimeZoneCreate(MCStringRef p_name, MCTimeZoneRef &r_tz)
         return false;
     
     // Create the LiveCode time zone object
-    r_tz = new __MCTimeZone(*t_tz);
+    r_tz = new (nothrow) __MCTimeZone(*t_tz);
     return true;
 }
 
@@ -1046,7 +1047,7 @@ bool MCLocaleBreakIteratorCreate(MCLocaleRef p_locale, MCBreakIteratorType p_typ
         return false;
     
     // Use the ICU break iterator object to create the engine object
-    r_iter = new __MCBreakIterator(*t_iter);
+    r_iter = new (nothrow) __MCBreakIterator(*t_iter);
     return true;
 }
 

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -773,7 +773,7 @@ bool MCProperListStableSort(MCProperListRef self, bool p_reverse, MCProperListCo
         if (!__MCProperListResolveIndirect(self))
             return false;
     
-    MCValueRef *t_temp_array = new MCValueRef[t_item_count];
+    MCValueRef *t_temp_array = new (nothrow) MCValueRef[t_item_count];
     
     MCProperListDoStableSort(self -> list, t_item_count, t_temp_array, p_reverse, p_callback, context);
     

--- a/libfoundation/src/foundation-text.cpp
+++ b/libfoundation/src/foundation-text.cpp
@@ -467,15 +467,15 @@ MCTextFilter* MCTextFilterCreate(const void *p_data, uindex_t p_length, MCString
     
     // Choose the decoder based on the encoding
     if (p_encoding == kMCStringEncodingUTF16)
-        t_chain = new MCTextFilter_DecodeUTF16(reinterpret_cast<const unichar_t*>(p_data), p_length, p_from_end);
+        t_chain = new (nothrow) MCTextFilter_DecodeUTF16(reinterpret_cast<const unichar_t*>(p_data), p_length, p_from_end);
     else
-        t_chain = new MCTextFilter_DecodeNative(reinterpret_cast<const char_t*>(p_data), p_length, p_from_end);
+        t_chain = new (nothrow) MCTextFilter_DecodeNative(reinterpret_cast<const char_t*>(p_data), p_length, p_from_end);
     
     // Add filters based on the options given
     if (p_options == kMCStringOptionCompareCaseless || p_options == kMCStringOptionCompareFolded)
     {
         MCTextFilter *t_filter;
-        t_filter = new MCTextFilter_SimpleCaseFold();
+        t_filter = new (nothrow) MCTextFilter_SimpleCaseFold();
         t_chain->PlaceBefore(t_filter);
         t_chain = t_filter;
     }
@@ -483,7 +483,7 @@ MCTextFilter* MCTextFilterCreate(const void *p_data, uindex_t p_length, MCString
     if (p_encoding == kMCStringEncodingUTF16 && (p_options == kMCStringOptionCompareCaseless || p_options == kMCStringOptionCompareNonliteral))
     {
         MCTextFilter *t_filter;
-        t_filter = new MCTextFilter_NormalizeNFC(p_from_end);
+        t_filter = new (nothrow) MCTextFilter_NormalizeNFC(p_from_end);
         t_chain->PlaceBefore(t_filter);
         t_chain = t_filter;
     }

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -240,7 +240,7 @@ const unichar_t* MCUnicodeGetStringProperty(codepoint_t p_codepoint, MCUnicodePr
         case kMCUnicodePropertyCaseFolding:
         {
             // Case-fold the codepoint
-            s_pointer = new unichar_t[16];
+            s_pointer = new (nothrow) unichar_t[16];
             icu::UnicodeString t_string;
             t_string.append(UChar32(p_codepoint));
             t_string.foldCase();
@@ -256,7 +256,7 @@ const unichar_t* MCUnicodeGetStringProperty(codepoint_t p_codepoint, MCUnicodePr
         case kMCUnicodePropertyLowercaseMapping:
         {
             // Lowercase the codepoint
-            s_pointer = new unichar_t[16];
+            s_pointer = new (nothrow) unichar_t[16];
             icu::UnicodeString t_string;
             t_string.append(UChar32(p_codepoint));
             t_string.toLower();
@@ -267,8 +267,8 @@ const unichar_t* MCUnicodeGetStringProperty(codepoint_t p_codepoint, MCUnicodePr
         case kMCUnicodePropertyName:
         {
             // We assume that this is sufficient for a character name
-            s_pointer = new unichar_t[256];
-            char *t_temp = new char[256];
+            s_pointer = new (nothrow) unichar_t[256];
+            char *t_temp = new (nothrow) char[256];
             uindex_t t_length;
             
             t_length = u_charName(p_codepoint, U_UNICODE_CHAR_NAME, t_temp, 255, &t_error);
@@ -295,8 +295,8 @@ const unichar_t* MCUnicodeGetStringProperty(codepoint_t p_codepoint, MCUnicodePr
         case kMCUnicodePropertyUnicode1Name:
         {
             // We assume that this is sufficient for a character name
-            s_pointer = new unichar_t[256];
-            char *t_temp = new char[256];
+            s_pointer = new (nothrow) unichar_t[256];
+            char *t_temp = new (nothrow) char[256];
             uindex_t t_length;
             
             t_length = u_charName(p_codepoint, U_UNICODE_10_CHAR_NAME, t_temp, 255, &t_error);
@@ -315,7 +315,7 @@ const unichar_t* MCUnicodeGetStringProperty(codepoint_t p_codepoint, MCUnicodePr
         case kMCUnicodePropertyUppercaseMapping:
         {
             // Uppercase the codepoint
-            s_pointer = new unichar_t[16];
+            s_pointer = new (nothrow) unichar_t[16];
             icu::UnicodeString t_string;
             t_string.append(UChar32(p_codepoint));
             t_string.toUpper();

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -314,7 +314,7 @@ static bool MCGContextCreateWithBitmap(SkBitmap& p_bitmap, MCGContextRef& r_cont
 	t_canvas = nil;
 	if (t_success)
 	{
-		t_canvas = new SkCanvas(p_bitmap);
+		t_canvas = new (nothrow) SkCanvas(p_bitmap);
 		t_success = t_canvas != NULL;
 	}
 	
@@ -577,7 +577,7 @@ void MCGContextBegin(MCGContextRef self, bool p_need_layer)
 	
 	// We now create a canvas the same size as the device clip.
 	SkCanvas *t_new_canvas;
-	t_new_canvas = new SkCanvas(t_new_bitmap);
+	t_new_canvas = new (nothrow) SkCanvas(t_new_bitmap);
 	if (t_new_canvas == nil)
 	{
 		self -> is_valid = false;
@@ -813,7 +813,7 @@ void MCGContextBeginWithEffects(MCGContextRef self, MCGRectangle p_shape, const 
 	
 	// We now create a canvas the same size as the device clip.
 	SkCanvas *t_new_canvas;
-	t_new_canvas = new SkCanvas(t_new_bitmap);
+	t_new_canvas = new (nothrow) SkCanvas(t_new_bitmap);
 	
 	if (t_new_canvas == nil)
 	{
@@ -2127,7 +2127,7 @@ static bool MCGContextApplyPaintSettingsToSkPaint(MCGContextRef self, MCGColor p
 		}
 		else if (p_paint_style == kMCGPaintStyleStippled)
 		{
-			t_stipple = new SkStippleMaskFilter();
+			t_stipple = new (nothrow) SkStippleMaskFilter();
 			t_success = t_stipple != NULL;			
 		}
 	}	
@@ -3022,7 +3022,7 @@ void MCGContextBeginWithEffects(MCGContextRef self, const MCGBitmapEffects &p_ef
 		t_layer_info . fPaintBits = SkLayerDrawLooper::kEntirePaint_Bits;
 		t_layer_info . fColorMode = SkXfermode::kSrc_Mode;	
 		
-		t_looper = new SkLayerDrawLooper;
+		t_looper = new (nothrow) SkLayerDrawLooper;
 		t_success = t_looper != NULL;
 	}
 	
@@ -3067,12 +3067,12 @@ void MCGContextBeginWithEffects(MCGContextRef self, const MCGBitmapEffects &p_ef
 		SkImageFilter *t_blur_image_filter;
 		if (t_success)
 		{			
-			SkImageFilter *t_blur = new MCGMaskExtractImageFilter(t_blur_mask_filter, false, NULL);
-			SkImageFilter *t_invert = new MCGMaskInvertImageFilter(t_blur);
+			SkImageFilter *t_blur = new (nothrow) MCGMaskExtractImageFilter(t_blur_mask_filter, false, NULL);
+			SkImageFilter *t_invert = new (nothrow) MCGMaskInvertImageFilter(t_blur);
 			t_blur_image_filter = t_invert;
 			
 			
-			//t_blur_image_filter = new MCGMaskExtractImageFilter(t_blur_mask_filter, p_effects . inner_glow . inverted, NULL);
+			//t_blur_image_filter = new (nothrow) MCGMaskExtractImageFilter(t_blur_mask_filter, p_effects . inner_glow . inverted, NULL);
 			//t_success = t_blur_image_filter != NULL;
 		}
 		
@@ -3124,7 +3124,7 @@ void MCGContextBeginWithEffects(MCGContextRef self, const MCGBitmapEffects &p_ef
 		SkImageFilter *t_blur_image_filter;
 		if (t_success)
 		{
-			t_blur_image_filter = new MCGMaskExtractImageFilter(t_blur_mask_filter, false, NULL);
+			t_blur_image_filter = new (nothrow) MCGMaskExtractImageFilter(t_blur_mask_filter, false, NULL);
 			t_success = t_blur_image_filter != NULL;
 		}
 		
@@ -3160,14 +3160,14 @@ void MCGContextBeginWithEffects(MCGContextRef self, const MCGBitmapEffects &p_ef
 		SkImageFilter *t_blur_image_filter;
 		if (t_success)
 		{
-			t_blur_image_filter = new MCGMaskExtractImageFilter(t_blur_mask_filter, false, NULL);
+			t_blur_image_filter = new (nothrow) MCGMaskExtractImageFilter(t_blur_mask_filter, false, NULL);
 			t_success = t_blur_image_filter != NULL;
 		}
 		
 		SkImageFilter *t_offset_image_filter;
 		if (t_success)
 		{
-			t_offset_image_filter = new SkOffsetImageFilter(MCGFloatToSkScalar(p_effects . drop_shadow . x_offset), 
+			t_offset_image_filter = new (nothrow) SkOffsetImageFilter(MCGFloatToSkScalar(p_effects . drop_shadow . x_offset), 
 															MCGFloatToSkScalar(p_effects . drop_shadow . y_offset), t_blur_image_filter);
 			t_success = t_offset_image_filter != NULL;
 		}

--- a/libgraphics/src/harfbuzztext.cpp
+++ b/libgraphics/src/harfbuzztext.cpp
@@ -207,12 +207,12 @@ MCHarfbuzzSkiaFace *MCHarfbuzzGetFaceForSkiaTypeface(SkTypeface *p_typeface, uin
 		}
         
         hb_skia_face_t *t_face;
-        t_face = new hb_skia_face_t;
+        t_face = new (nothrow) hb_skia_face_t;
             
         t_face -> typeface = p_typeface;
         t_face -> size = p_size;
         
-        t_hb_sk_face = new MCHarfbuzzSkiaFace;
+        t_hb_sk_face = new (nothrow) MCHarfbuzzSkiaFace;
         t_hb_sk_face -> face = nil;
         t_hb_sk_face -> skia_face = nil;
 

--- a/libgraphics/src/image.cpp
+++ b/libgraphics/src/image.cpp
@@ -46,7 +46,7 @@ bool MCGImageCreateWithSkBitmap(const SkBitmap &p_bitmap, MCGImageRef &r_image)
 	t_bitmap = nil;
 	if (t_success)
 	{
-		t_bitmap = new SkBitmap(p_bitmap);
+		t_bitmap = new (nothrow) SkBitmap(p_bitmap);
 		t_success = nil != t_bitmap;
 	}
 	

--- a/libgraphics/src/path.cpp
+++ b/libgraphics/src/path.cpp
@@ -53,7 +53,7 @@ bool MCGPathCreateMutable(MCGPathRef& r_path)
 	
 	if (t_success)
 	{
-		t_path -> path = new SkPath();
+		t_path -> path = new (nothrow) SkPath();
 		t_success = t_path -> path != NULL;
 	}
 	

--- a/libgraphics/src/spread.cpp
+++ b/libgraphics/src/spread.cpp
@@ -64,7 +64,7 @@ void dilateDistanceXY(const uint8_t *src, uint8_t *dst, int xradius, int yradius
     
 	// Compute the x distance of each pixel from the nearest set pixel.
 	uint8_t *xd;
-	xd = new uint8_t[new_width * height];
+	xd = new (nothrow) uint8_t[new_width * height];
 	for(int y = 0; y < height; y++)
 	{
 		uint8_t *xdptr;

--- a/libgraphics/src/utils.cpp
+++ b/libgraphics/src/utils.cpp
@@ -198,7 +198,7 @@ bool MCGGradientToSkShader(MCGGradientRef self, MCGRectangle p_clip, SkShader*& 
 	
 	// MM-2013-11-19: [[ Bug 11471 ]] Move to legacy gradient code for all gradient kinds - there was a loss of quality using Skia.
 	SkShader *t_gradient_shader;
-	t_gradient_shader = new MCGLegacyGradientShader(self, p_clip);
+	t_gradient_shader = new (nothrow) MCGLegacyGradientShader(self, p_clip);
 	t_success = t_gradient_shader != NULL;
 	
 	if (t_success)
@@ -300,7 +300,7 @@ bool MCGDashesToSkDashPathEffect(MCGDashesRef self, SkDashPathEffect*& r_path_ef
 		for (uint32_t i = 0; i < t_dash_count; i++)
 			t_dashes[i] = MCGFloatToSkScalar(self -> lengths[i % self -> count]);
 	
-		t_dash_effect = new SkDashPathEffect(t_dashes, (int)t_dash_count, MCGFloatToSkScalar(self -> phase));
+		t_dash_effect = new (nothrow) SkDashPathEffect(t_dashes, (int)t_dash_count, MCGFloatToSkScalar(self -> phase));
 		t_success = t_dash_effect != NULL;
 	}
 	
@@ -408,35 +408,35 @@ void MCGBlendModesInitialize(void)
 	s_skia_blend_modes[kMCGBlendModeExclusion] = SkXfermode::Create(SkXfermode::kExclusion_Mode);
 	
 	// legacy blend modes
-	s_skia_blend_modes[kMCGBlendModeLegacyClear] = new MCGLegacyBlendMode(kMCGBlendModeLegacyClear);
-	s_skia_blend_modes[kMCGBlendModeLegacyAnd] = new MCGLegacyBlendMode(kMCGBlendModeLegacyAnd);
-	s_skia_blend_modes[kMCGBlendModeLegacyAndReverse] = new MCGLegacyBlendMode(kMCGBlendModeLegacyAndReverse);
-	s_skia_blend_modes[kMCGBlendModeLegacyCopy] = new MCGLegacyBlendMode(kMCGBlendModeLegacyCopy);
-	s_skia_blend_modes[kMCGBlendModeLegacyInverted] = new MCGLegacyBlendMode(kMCGBlendModeLegacyInverted);
-	s_skia_blend_modes[kMCGBlendModeLegacyNoop] = new MCGLegacyBlendMode(kMCGBlendModeLegacyNoop);
-	s_skia_blend_modes[kMCGBlendModeLegacyXor] = new MCGLegacyBlendMode(kMCGBlendModeLegacyXor);
-	s_skia_blend_modes[kMCGBlendModeLegacyOr] = new MCGLegacyBlendMode(kMCGBlendModeLegacyOr);
-	s_skia_blend_modes[kMCGBlendModeLegacyNor] = new MCGLegacyBlendMode(kMCGBlendModeLegacyNor);
-	s_skia_blend_modes[kMCGBlendModeLegacyEquiv] = new MCGLegacyBlendMode(kMCGBlendModeLegacyEquiv);
-	s_skia_blend_modes[kMCGBlendModeLegacyInvert] = new MCGLegacyBlendMode(kMCGBlendModeLegacyInvert);
-	s_skia_blend_modes[kMCGBlendModeLegacyOrReverse] = new MCGLegacyBlendMode(kMCGBlendModeLegacyOrReverse);
-	s_skia_blend_modes[kMCGBlendModeLegacyCopyInverted] = new MCGLegacyBlendMode(kMCGBlendModeLegacyCopyInverted);
-	s_skia_blend_modes[kMCGBlendModeLegacyOrInverted] = new MCGLegacyBlendMode(kMCGBlendModeLegacyOrInverted);
-	s_skia_blend_modes[kMCGBlendModeLegacyNand] = new MCGLegacyBlendMode(kMCGBlendModeLegacyNand);
-	s_skia_blend_modes[kMCGBlendModeLegacySet] = new MCGLegacyBlendMode(kMCGBlendModeLegacySet);
-	s_skia_blend_modes[kMCGBlendModeLegacyBlend] = new MCGLegacyBlendMode(kMCGBlendModeLegacyBlend);
-	s_skia_blend_modes[kMCGBlendModeLegacyAddPin] = new MCGLegacyBlendMode(kMCGBlendModeLegacyAddPin);
-	s_skia_blend_modes[kMCGBlendModeLegacyAddOver] = new MCGLegacyBlendMode(kMCGBlendModeLegacyAddOver);
-	s_skia_blend_modes[kMCGBlendModeLegacySubPin] = new MCGLegacyBlendMode(kMCGBlendModeLegacySubPin);
-	s_skia_blend_modes[kMCGBlendModeLegacyTransparent] = new MCGLegacyBlendMode(kMCGBlendModeLegacyTransparent);
-	s_skia_blend_modes[kMCGBlendModeLegacyAdMax] = new MCGLegacyBlendMode(kMCGBlendModeLegacyAdMax);
-	s_skia_blend_modes[kMCGBlendModeLegacySubOver] = new MCGLegacyBlendMode(kMCGBlendModeLegacySubOver);
-	s_skia_blend_modes[kMCGBlendModeLegacyAdMin] = new MCGLegacyBlendMode(kMCGBlendModeLegacyAdMin);		
-	s_skia_blend_modes[kMCGBlendModeLegacyBlendSource] = new MCGLegacyBlendMode(kMCGBlendModeLegacyBlendSource);
-	s_skia_blend_modes[kMCGBlendModeLegacyBlendDestination] = new MCGLegacyBlendMode(kMCGBlendModeLegacyBlendDestination);
+	s_skia_blend_modes[kMCGBlendModeLegacyClear] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyClear);
+	s_skia_blend_modes[kMCGBlendModeLegacyAnd] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyAnd);
+	s_skia_blend_modes[kMCGBlendModeLegacyAndReverse] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyAndReverse);
+	s_skia_blend_modes[kMCGBlendModeLegacyCopy] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyCopy);
+	s_skia_blend_modes[kMCGBlendModeLegacyInverted] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyInverted);
+	s_skia_blend_modes[kMCGBlendModeLegacyNoop] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyNoop);
+	s_skia_blend_modes[kMCGBlendModeLegacyXor] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyXor);
+	s_skia_blend_modes[kMCGBlendModeLegacyOr] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyOr);
+	s_skia_blend_modes[kMCGBlendModeLegacyNor] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyNor);
+	s_skia_blend_modes[kMCGBlendModeLegacyEquiv] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyEquiv);
+	s_skia_blend_modes[kMCGBlendModeLegacyInvert] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyInvert);
+	s_skia_blend_modes[kMCGBlendModeLegacyOrReverse] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyOrReverse);
+	s_skia_blend_modes[kMCGBlendModeLegacyCopyInverted] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyCopyInverted);
+	s_skia_blend_modes[kMCGBlendModeLegacyOrInverted] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyOrInverted);
+	s_skia_blend_modes[kMCGBlendModeLegacyNand] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyNand);
+	s_skia_blend_modes[kMCGBlendModeLegacySet] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacySet);
+	s_skia_blend_modes[kMCGBlendModeLegacyBlend] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyBlend);
+	s_skia_blend_modes[kMCGBlendModeLegacyAddPin] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyAddPin);
+	s_skia_blend_modes[kMCGBlendModeLegacyAddOver] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyAddOver);
+	s_skia_blend_modes[kMCGBlendModeLegacySubPin] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacySubPin);
+	s_skia_blend_modes[kMCGBlendModeLegacyTransparent] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyTransparent);
+	s_skia_blend_modes[kMCGBlendModeLegacyAdMax] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyAdMax);
+	s_skia_blend_modes[kMCGBlendModeLegacySubOver] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacySubOver);
+	s_skia_blend_modes[kMCGBlendModeLegacyAdMin] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyAdMin);		
+	s_skia_blend_modes[kMCGBlendModeLegacyBlendSource] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyBlendSource);
+	s_skia_blend_modes[kMCGBlendModeLegacyBlendDestination] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeLegacyBlendDestination);
 	
 	// MM-2013-11-11: [[ Bug 11422 ]] Use legacy multiply. Skia's multiply appears to blend differently.
-	s_skia_blend_modes[kMCGBlendModeMultiply] = new MCGLegacyBlendMode(kMCGBlendModeMultiply);
+	s_skia_blend_modes[kMCGBlendModeMultiply] = new (nothrow) MCGLegacyBlendMode(kMCGBlendModeMultiply);
 	
 	// TODO: non-separable blend modes and plus darker?
 	// kMCGBlendModeHue

--- a/libgraphics/src/w32text.cpp
+++ b/libgraphics/src/w32text.cpp
@@ -506,8 +506,8 @@ static bool __MCGContextTracePlatformText(MCGContextRef self, const unichar_t *p
 
 		POINT *t_points;
 		BYTE *t_types;
-		t_points = new POINT[t_count];
-		t_types = new BYTE[t_count];
+		t_points = new (nothrow) POINT[t_count];
+		t_types = new (nothrow) BYTE[t_count];
 		GetPath(t_gdicontext, t_points, t_types, t_count);
 
 		MCGPathCreateMutable(r_path);
@@ -776,8 +776,8 @@ bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self, const unichar_
 
         POINT *t_points;
         BYTE *t_types;
-        t_points = new POINT[t_count];
-        t_types = new BYTE[t_count];
+        t_points = new (nothrow) POINT[t_count];
+        t_types = new (nothrow) BYTE[t_count];
         GetPath(s_measure_dc, t_points, t_types, t_count);
 
         for(int i = 0; i < t_count;)

--- a/revbrowser/src/cefbrowser.cpp
+++ b/revbrowser/src/cefbrowser.cpp
@@ -837,7 +837,7 @@ public:
 bool MCCefBrowserBase::Initialize()
 {
 	// create client and browser
-	m_client = new MCCefBrowserClient(this);
+	m_client = new (nothrow) MCCefBrowserClient(this);
 
 	CefWindowInfo t_window_info;
 	CefBrowserSettings t_settings;
@@ -1177,7 +1177,7 @@ char *MCCefBrowserBase::GetSource(void)
 	t_result.Clear();
 
 	CefRefPtr<CefStringVisitor> t_visitor;
-	t_visitor = new MCStringVisitor(t_result);
+	t_visitor = new (nothrow) MCStringVisitor(t_result);
 
 	m_browser->GetMainFrame()->GetSource(t_visitor);
 

--- a/revbrowser/src/cefbrowser_lnx.cpp
+++ b/revbrowser/src/cefbrowser_lnx.cpp
@@ -210,7 +210,7 @@ void MCCefPlatformCloseBrowserWindow(CefRefPtr<CefBrowser> p_browser)
 bool MCCefPlatformCreateBrowser(int p_window_id, MCCefBrowserBase *&r_browser)
 {
 	MCCefLinuxBrowser *t_browser;
-	t_browser = new MCCefLinuxBrowser((Window)p_window_id);
+	t_browser = new (nothrow) MCCefLinuxBrowser((Window)p_window_id);
 	
 	if (t_browser == nil)
 		return false;

--- a/revbrowser/src/cefbrowser_w32.cpp
+++ b/revbrowser/src/cefbrowser_w32.cpp
@@ -156,7 +156,7 @@ const char *MCCefPlatformGetCefLibraryPath(void)
 bool MCCefPlatformCreateBrowser(int p_window_id, MCCefBrowserBase *&r_browser)
 {
 	MCCefWin32Browser *t_browser;
-	t_browser = new MCCefWin32Browser((HWND)p_window_id);
+	t_browser = new (nothrow) MCCefWin32Browser((HWND)p_window_id);
 
 	if (t_browser == nil)
 		return false;

--- a/revbrowser/src/cefprocess.cpp
+++ b/revbrowser/src/cefprocess.cpp
@@ -207,7 +207,7 @@ bool MCCefHandleGetSelectedText(CefRefPtr<CefBrowser> p_browser, CefString &r_re
 	t_success = true;
 
 	MCGetSelectedTextDOMVisitor *t_dom_visitor;
-	t_dom_visitor = new MCGetSelectedTextDOMVisitor();
+	t_dom_visitor = new (nothrow) MCGetSelectedTextDOMVisitor();
 	t_success = t_dom_visitor != nil;
 
 	CefRefPtr<CefDOMVisitor> t_visitor_ref;
@@ -247,7 +247,7 @@ bool MCCefHandleGetTitle(CefRefPtr<CefBrowser> p_browser, CefString &r_return_va
 	t_success = true;
 
 	MCGetTitleDOMVisitor *t_dom_visitor;
-	t_dom_visitor = new MCGetTitleDOMVisitor();
+	t_dom_visitor = new (nothrow) MCGetTitleDOMVisitor();
 	t_success = t_dom_visitor != nil;
 
 	CefRefPtr<CefDOMVisitor> t_visitor_ref;
@@ -465,7 +465,7 @@ private:
 			if (!t_livecode_obj->HasValue(p_name))
 			{
 				CefRefPtr<CefV8Handler> t_handler;
-				t_success = nil != (t_handler = new MCCefLCFuncHandler(p_name));
+				t_success = nil != (t_handler = new (nothrow) MCCefLCFuncHandler(p_name));
 				
 				CefRefPtr<CefV8Value> t_func;
 				if (t_success)
@@ -612,7 +612,7 @@ public:
 bool MCCefCreateApp(CefRefPtr<CefApp> &r_app)
 {
 	MCCefRenderApp *t_app;
-	t_app = new MCCefRenderApp();
+	t_app = new (nothrow) MCCefRenderApp();
 	
 	if (t_app == nil)
 	{

--- a/revbrowser/src/revbrowser.cpp
+++ b/revbrowser/src/revbrowser.cpp
@@ -151,7 +151,7 @@ bool BrowserInstances::FindInstanceById(int p_id, BrowserInstance *&r_instance)
 void BrowserInstances::Add(CWebBrowserBase *p_browser, bool p_is_xbrowser)
 {
 	BrowserInstance *t_instance;
-	t_instance = new BrowserInstance;
+	t_instance = new (std::nothrow) BrowserInstance;
 	t_instance -> next = m_instances;
 	t_instance -> instance_id = ++m_last_instance_id;
 	t_instance -> stack_id = NULL;

--- a/revbrowser/src/revbrowser.cpp
+++ b/revbrowser/src/revbrowser.cpp
@@ -151,7 +151,7 @@ bool BrowserInstances::FindInstanceById(int p_id, BrowserInstance *&r_instance)
 void BrowserInstances::Add(CWebBrowserBase *p_browser, bool p_is_xbrowser)
 {
 	BrowserInstance *t_instance;
-	t_instance = new (std::nothrow) BrowserInstance;
+	t_instance = new (nothrow) BrowserInstance;
 	t_instance -> next = m_instances;
 	t_instance -> instance_id = ++m_last_instance_id;
 	t_instance -> stack_id = NULL;

--- a/revbrowser/src/w32browser.cpp
+++ b/revbrowser/src/w32browser.cpp
@@ -68,7 +68,7 @@ struct MYBITMAP
 
 MYBITMAP *createmybitmap(uint2 depth, uint2 width, uint2 height)
 {
-  MYBITMAP *image = new MYBITMAP;
+  MYBITMAP *image = new (nothrow) MYBITMAP;
   image->width = width;
   image->height = height;
   image->depth = (uint1)depth;
@@ -160,9 +160,9 @@ CWebBrowser::CWebBrowser(HWND hparent,  BOOL isvisible)
 	if (SUCCEEDED(hr)) 
 		iunknown->QueryInterface(IID_IWebBrowser2,(void**)&iwebbrowser2); 
 	if (!iwebbrowser2) return;
-	browserevents = new CWebEvents(this); 
+	browserevents = new (nothrow) CWebEvents(this); 
 	browserevents->AddRef();
-	webui = new CWebUI(this);
+	webui = new (nothrow) CWebUI(this);
 	webui->AddRef();
 	browserwindow.SetExternalUIHandler(webui);
 	AtlAdvise(iwebbrowser2, browserevents, DIID_DWebBrowserEvents2,
@@ -460,7 +460,7 @@ char *CWebBrowser::CallScript(const char *p_function_name, char **p_arguments, u
 	t_ole_arguments = NULL;
 	if (t_result == S_OK)
 	{
-		t_ole_arguments = new VARIANTARG[p_argument_count];
+		t_ole_arguments = new (nothrow) VARIANTARG[p_argument_count];
 		if (t_ole_arguments != NULL)
 			memset(t_ole_arguments, 0, sizeof(VARIANTARG) * p_argument_count);
 		else
@@ -1554,10 +1554,10 @@ void CWebBrowser::swapBrowser()
 	if (SUCCEEDED(hr)) 
 		iunknown->QueryInterface(IID_IWebBrowser2,(void**)&iwebbrowser2); 
 	if (!iwebbrowser2) return;
-	browserevents = new CWebEvents(this); 
+	browserevents = new (nothrow) CWebEvents(this); 
 	browserevents->AddRef();
 	iwebbrowser2->put_Silent(VARIANT_TRUE);
-	webui = new CWebUI(this); webui->AddRef();
+	webui = new (nothrow) CWebUI(this); webui->AddRef();
 	browserwindow.SetExternalUIHandler(webui);
 	AtlAdvise(iwebbrowser2, browserevents, DIID_DWebBrowserEvents2,
 		&browserevents2_cookie);

--- a/revdb/src/dbmysqlapi.cpp
+++ b/revdb/src/dbmysqlapi.cpp
@@ -26,7 +26,7 @@ unsigned int *DBObject::idcounter = NULL;
 
 extern "C" LIBRARY_EXPORT DBConnection *newdbconnectionref() 
 {
-	DBConnection *ref = new DBConnection_MYSQL();
+	DBConnection *ref = new (nothrow) DBConnection_MYSQL();
 	return ref;
 }
 

--- a/revdb/src/dbodbcapi.cpp
+++ b/revdb/src/dbodbcapi.cpp
@@ -26,7 +26,7 @@ unsigned int *DBObject::idcounter = NULL;
 
 extern "C" LIBRARY_EXPORT DBConnection *newdbconnectionref() 
 {
-	DBConnection *ref = new DBConnection_ODBC();
+	DBConnection *ref = new (nothrow) DBConnection_ODBC();
 	return ref;
 }
 

--- a/revdb/src/dbpostgresqlapi.cpp
+++ b/revdb/src/dbpostgresqlapi.cpp
@@ -26,7 +26,7 @@ unsigned int *DBObject::idcounter = NULL;
 
 extern "C" LIBRARY_EXPORT DBConnection *newdbconnectionref() 
 {
-	DBConnection *ref = new DBConnection_POSTGRESQL();
+	DBConnection *ref = new (nothrow) DBConnection_POSTGRESQL();
 	return ref;
 }
 

--- a/revdb/src/dbsqliteapi.cpp
+++ b/revdb/src/dbsqliteapi.cpp
@@ -26,7 +26,7 @@ unsigned int *DBObject::idcounter = NULL;
 
 extern "C" LIBRARY_EXPORT DBConnection *newdbconnectionref() 
 {
-	DBConnection *ref = new DBConnection_SQLITE();
+	DBConnection *ref = new (nothrow) DBConnection_SQLITE();
 	return ref;
 }
 

--- a/revdb/src/iossupport.cpp
+++ b/revdb/src/iossupport.cpp
@@ -90,7 +90,7 @@ void MCU_fix_path(char *cstr)
 
 char *MCS_getcurdir()
 {
-  char *t_path = new char[PATH_MAX + 2];
+  char *t_path = new (nothrow) char[PATH_MAX + 2];
   getcwd(t_path, PATH_MAX);
   return t_path;
 }
@@ -126,7 +126,7 @@ char *MCS_resolvepath(const char *path)
       pw = getpwnam(tpath + 1);
     if (pw == NULL)
       return NULL;
-    tildepath = new char[strlen(pw->pw_dir) + strlen(tptr) + 2];
+    tildepath = new (nothrow) char[strlen(pw->pw_dir) + strlen(tptr) + 2];
     strcpy(tildepath, pw->pw_dir);
     if (*tptr) {
       strcat(tildepath, "/");
@@ -150,7 +150,7 @@ char *MCS_resolvepath(const char *path)
   if (lstat(tildepath, &buf) != 0 || !S_ISLNK(buf.st_mode))
     return tildepath;
   int size;
-  char *newname = new char[PATH_MAX + 2];
+  char *newname = new (nothrow) char[PATH_MAX + 2];
 
   if ((size = readlink(tildepath, newname, PATH_MAX)) < 0) {
     delete tildepath;
@@ -160,7 +160,7 @@ char *MCS_resolvepath(const char *path)
   delete tildepath;
   newname[size] = '\0';
   if (newname[0] != '/') {
-    char *fullpath = new char[strlen(path) + strlen(newname) + 2];
+    char *fullpath = new (nothrow) char[strlen(path) + strlen(newname) + 2];
     strcpy(fullpath, path);
     char *sptr = strrchr(fullpath, '/');
     if (sptr == NULL)
@@ -199,7 +199,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 		
 
 	DATABASEREC *t_result;
-	t_result = new DATABASEREC;
+	t_result = new (nothrow) DATABASEREC;
 
 	t_result -> driverref = t_driver_handle;
 	t_result -> idcounterptr = (idcounterrefptr)dlsym(t_driver_handle, "setidcounterref");
@@ -220,7 +220,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	
 	
 	DATABASEREC *t_result;
-	t_result = new DATABASEREC;
+	t_result = new (nothrow) DATABASEREC;
 	
 	t_result -> driverref = t_driver_handle;
 	t_result -> idcounterptr = (idcounterrefptr)resolve_symbol(t_driver_handle, "setidcounterref");

--- a/revdb/src/mysql_connection.cpp
+++ b/revdb/src/mysql_connection.cpp
@@ -218,7 +218,7 @@ DBCursor *DBConnection_MYSQL::sqlQuery(char *p_query, DBString *p_arguments, int
 
 	if (ExecuteQuery(p_query, p_arguments, p_argument_count))
 	{
-		t_cursor = new DBCursor_MYSQL();
+		t_cursor = new (nothrow) DBCursor_MYSQL();
 		if (!t_cursor -> open((DBConnection *)this))
 		{
 			delete t_cursor;

--- a/revdb/src/mysql_cursor.cpp
+++ b/revdb/src/mysql_cursor.cpp
@@ -205,10 +205,10 @@ Output: False on error*/
 Bool DBCursor_MYSQL::getFieldsInformation()
 {
 	MYSQL_FIELD *field_prop;
-	fields = new DBField *[fieldCount];
+	fields = new (nothrow) DBField *[fieldCount];
 	for (unsigned int i=0; i< fieldCount; i++)
 	{
-		DBField *tfield = new DBField();
+		DBField *tfield = new (nothrow) DBField();
 		fields[i] = tfield;
 		field_prop = mysql_fetch_field(mysql_res);
 		if (field_prop != NULL) 

--- a/revdb/src/odbc_connection.cpp
+++ b/revdb/src/odbc_connection.cpp
@@ -284,7 +284,7 @@ DBCursor *DBConnection_ODBC::sqlQuery(char *p_query, DBString *p_arguments, int 
 		SQLNumResultCols(t_statement, &t_column_count);
 		if (t_column_count != 0)
 		{
-			t_cursor = new DBCursor_ODBC();
+			t_cursor = new (nothrow) DBCursor_ODBC();
 			if (!t_cursor -> open((DBConnection *)this, t_statement, p_rows))
 			{
 				delete t_cursor;
@@ -401,7 +401,7 @@ bool DBConnection_ODBC::ExecuteQuery(char *p_query, DBString *p_arguments, int p
 		if (t_result == SQL_SUCCESS || t_result == SQL_SUCCESS_WITH_INFO)
 		{
 			int *t_argument_sizes;
-			t_argument_sizes = new int[t_placeholder_map . length];
+			t_argument_sizes = new (nothrow) int[t_placeholder_map . length];
 			BindVariables(t_statement, p_arguments, p_argument_count, t_argument_sizes, &t_placeholder_map);
 			t_result = SQLExecute(t_statement);
 			delete[] t_argument_sizes;
@@ -611,7 +611,7 @@ void DBConnection_ODBC::getTables(char *buffer, int *bufsize)
 		char *resultptr = result;
 		if (ncolumns)
 		{
-			newcursor = new DBCursor_ODBC();
+			newcursor = new (nothrow) DBCursor_ODBC();
 			if (newcursor->open((DBConnection *)this, querycursor, 1))
 			{
 				if (!newcursor->getEOF())

--- a/revdb/src/odbc_cursor.cpp
+++ b/revdb/src/odbc_cursor.cpp
@@ -48,7 +48,7 @@ int UnicodeToUTF8(uint2 *lpSrcStr, int cchSrc, char *lpDestStr, int cchDest);
 static char *unidecode(char *unistring, int tsize)
 {
   int length = tsize >> 1;
-  char *sansiptr = new char[tsize];
+  char *sansiptr = new (nothrow) char[tsize];
   char *ansiptr = sansiptr;
   char *uniptr = unistring;  
   while (length--)
@@ -306,10 +306,10 @@ Bool DBCursor_ODBC::getFieldsInformation()
 	SQLULEN dbsize;
 	SQLSMALLINT decDigits;
 	SQLSMALLINT nullablePtr;
-	fields = new DBField *[fieldCount];
+	fields = new (nothrow) DBField *[fieldCount];
 	for (unsigned int i=0; i < (unsigned int)fieldCount; i++)
 	{
-		DBField_ODBC *ofield = new DBField_ODBC();
+		DBField_ODBC *ofield = new (nothrow) DBField_ODBC();
 		fields[i] = (DBField *)ofield;
 		retcode = SQLDescribeColA(ODBC_res, i+1, (SQLCHAR *)ofield->fieldName, F_NAMESIZE, &buflen, &dbtype, &dbsize, &decDigits, &nullablePtr);
 		if ((retcode != SQL_SUCCESS) && (retcode != SQL_SUCCESS_WITH_INFO))
@@ -434,9 +434,9 @@ Bool DBCursor_ODBC::getFieldsInformation()
 			ofield -> maxlength = ofield -> maxlength + 1;
 
 		if (ofield -> fieldType == FT_WSTRING)
-			ofield -> data = new char[ofield -> maxlength + 2];
+			ofield -> data = new (nothrow) char[ofield -> maxlength + 2];
 		else
-			ofield -> data = new char[ofield -> maxlength + 1];
+			ofield -> data = new (nothrow) char[ofield -> maxlength + 1];
 		totalsize += ofield->maxlength;
 		ofield->freeBuffer = True;
 	}

--- a/revdb/src/osxsupport.cpp
+++ b/revdb/src/osxsupport.cpp
@@ -132,7 +132,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	}
 	
 	DATABASEREC *t_result;
-	t_result = new DATABASEREC;
+	t_result = new (nothrow) DATABASEREC;
 	t_result -> driverref = t_bundle;
 	t_result -> idcounterptr = (idcounterrefptr)CFBundleGetFunctionPointerForName(t_bundle, CFSTR("setidcounterref"));
 	t_result -> newconnectionptr = (new_connectionrefptr)CFBundleGetFunctionPointerForName(t_bundle, CFSTR("newdbconnectionref"));
@@ -171,7 +171,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	}
 	
 	DATABASEREC *t_result;
-	t_result = new DATABASEREC;
+	t_result = new (nothrow) DATABASEREC;
 	
 	t_result -> driverref = t_driver_handle;
 	t_result -> idcounterptr = (idcounterrefptr)dlsym(t_driver_handle, "setidcounterref");
@@ -276,7 +276,7 @@ void MCU_fix_path(char *cstr)
 
 char *MCS_getcurdir()
 {
-	char *t_path = new char[PATH_MAX + 2];
+	char *t_path = new (nothrow) char[PATH_MAX + 2];
 	getcwd(t_path, PATH_MAX);
 	return t_path;
 }
@@ -309,7 +309,7 @@ char *MCS_resolvepath(const char *p_path)
       pw = getpwnam(tpath + 1);
     if (pw == NULL)
       return NULL;
-    tildepath = new char[strlen(pw->pw_dir) + strlen(tptr) + 2];
+    tildepath = new (nothrow) char[strlen(pw->pw_dir) + strlen(tptr) + 2];
     strcpy(tildepath, pw->pw_dir);
     if (*tptr) {
       strcat(tildepath, "/");
@@ -332,7 +332,7 @@ char *MCS_resolvepath(const char *p_path)
   if (lstat(tildepath, (struct stat *)&buf) != 0 || !S_ISLNK(buf.st_mode))
     return tildepath;
   int size;
-  char *newname = new char[PATH_MAX + 2];
+  char *newname = new (nothrow) char[PATH_MAX + 2];
   if ((size = readlink(tildepath, newname, PATH_MAX)) < 0) {
     delete tildepath;
     delete[] newname;
@@ -341,7 +341,7 @@ char *MCS_resolvepath(const char *p_path)
   delete tildepath;
   newname[size] = '\0';
   if (newname[0] != '/') {
-    char *fullpath = new char[strlen(p_path) + strlen(newname) + 2];
+    char *fullpath = new (nothrow) char[strlen(p_path) + strlen(newname) + 2];
     strcpy(fullpath, p_path);
     char *sptr = strrchr(fullpath, '/');
     if (sptr == NULL)

--- a/revdb/src/postgresql_connection.cpp
+++ b/revdb/src/postgresql_connection.cpp
@@ -23,7 +23,7 @@ extern bool load_ssl_library();
 char *strndup(const char *p_string, int p_length)
 {
 	char *t_result;
-	t_result = new char[p_length + 1];
+	t_result = new (nothrow) char[p_length + 1];
 	memcpy(t_result, p_string, p_length);
 	t_result[p_length] = '\0';
 	return t_result;
@@ -394,7 +394,7 @@ DBCursor *DBConnection_POSTGRESQL::sqlQuery(char *p_query, DBString *p_arguments
 		t_column_count = PQnfields(t_postgres_result);
 		if (t_column_count != 0)
 		{
-			t_cursor = new DBCursor_POSTGRESQL();
+			t_cursor = new (nothrow) DBCursor_POSTGRESQL();
 			if (!t_cursor -> open((DBConnection *)this, t_postgres_result))
 			{
 				delete t_cursor;

--- a/revdb/src/postgresql_cursor.cpp
+++ b/revdb/src/postgresql_cursor.cpp
@@ -182,10 +182,10 @@ Bool DBCursor_POSTGRESQL::prev()
 Output: False on error*/
 Bool DBCursor_POSTGRESQL::getFieldsInformation()
 {
-	fields = new DBField *[fieldCount];
+	fields = new (nothrow) DBField *[fieldCount];
 	for (unsigned int i=0; i< fieldCount; i++) 
 	{
-		DBField *tfield = new DBField();
+		DBField *tfield = new (nothrow) DBField();
 		fields[i] = tfield;
 		char* tmpStr;
 		tmpStr = PQfname(POSTGRESQL_res, i);

--- a/revdb/src/revdb.cpp
+++ b/revdb/src/revdb.cpp
@@ -244,7 +244,7 @@ DATABASEREC *LoadDatabaseDriverFromName(const char *p_type)
         return NULL;
     
     DATABASEREC *t_result;
-    t_result = new DATABASEREC;
+    t_result = new (nothrow) DATABASEREC;
 #if (defined _MACOSX && !defined _MAC_SERVER)
     t_result -> driverref = (CFBundleRef)t_handle;
 #elif (defined _WINDOWS) || defined _WINDOWS_SERVER
@@ -582,7 +582,7 @@ DBString *BindVariables(char *p_arguments[],int p_argument_count, int &r_value_c
 			qsort(t_map, t_element_count, sizeof(unsigned int), SortKeysCallback);
 
 			// If there are multiple elements...
-			t_values = new DBString[t_element_count];
+			t_values = new (nothrow) DBString[t_element_count];
 			for (int i = 0; i < t_element_count; i++)
 			{
 				char *t_key_buffer;
@@ -632,7 +632,7 @@ DBString *BindVariables(char *p_arguments[],int p_argument_count, int &r_value_c
 		}
 	}
 
-	t_values = new DBString[p_argument_count - 2];
+	t_values = new (nothrow) DBString[p_argument_count - 2];
 	for (int i = 2; i < p_argument_count; i++)
 	{
 		Bool t_is_binary;

--- a/revdb/src/sqlite_connection.cpp
+++ b/revdb/src/sqlite_connection.cpp
@@ -248,7 +248,7 @@ DBCursor *DBConnection_SQLITE::sqlQuery(char *query, DBString *args, int numargs
 	}
 
 	try {
-		ret = new DBCursor_SQLITE(mDB, m_enable_binary);
+		ret = new (nothrow) DBCursor_SQLITE(mDB, m_enable_binary);
 		Dataset *ds = ret->getDataset();
 
 		ds->query(newquery);

--- a/revdb/src/sqlite_cursor.cpp
+++ b/revdb/src/sqlite_cursor.cpp
@@ -236,13 +236,13 @@ Bool DBCursor_SQLITE::getFieldsInformation()
 {
 	ENTER;
 	//create an array of columns
-	fields = new DBField *[fieldCount];
+	fields = new (nothrow) DBField *[fieldCount];
 
 	Fields *t_fields_object;
 	t_fields_object = mDataset -> get_fields_object();
 
 	for(int i = 0 ; i < fieldCount; i++) {
-		DBField *tfield = new DBField();
+		DBField *tfield = new (nothrow) DBField();
 		fields[i] = tfield;
 		
 		const char *name = mDataset->fieldName(i);
@@ -377,7 +377,7 @@ Bool DBCursor_SQLITE::getRowData()
 				else
 				{
 					int bufsize = tmp.size();
-					fields[i]->data = new char[tmp.size() + 1];
+					fields[i]->data = new (nothrow) char[tmp.size() + 1];
 
 					memset(fields[i]->data,0,bufsize+1);
 					memcpy(fields[i]->data, tmp.data(), tmp.size());

--- a/revdb/src/unxsupport.cpp
+++ b/revdb/src/unxsupport.cpp
@@ -89,7 +89,7 @@ void MCU_fix_path(char *cstr)
 
 char *MCS_getcurdir()
 {
-  char *t_path = new char[PATH_MAX + 2];
+  char *t_path = new (nothrow) char[PATH_MAX + 2];
   getcwd(t_path, PATH_MAX);
   return t_path;
 }
@@ -124,7 +124,7 @@ char *MCS_resolvepath(const char *path)
       pw = getpwnam(tpath + 1);
     if (pw == NULL)
       return NULL;
-    tildepath = new char[strlen(pw->pw_dir) + strlen(tptr) + 2];
+    tildepath = new (nothrow) char[strlen(pw->pw_dir) + strlen(tptr) + 2];
     strcpy(tildepath, pw->pw_dir);
     if (*tptr) {
       strcat(tildepath, "/");
@@ -147,7 +147,7 @@ char *MCS_resolvepath(const char *path)
   if (lstat(tildepath, &buf) != 0 || !S_ISLNK(buf.st_mode))
     return tildepath;
   int size;
-  char *newname = new char[PATH_MAX + 2];
+  char *newname = new (nothrow) char[PATH_MAX + 2];
 
   if ((size = readlink(tildepath, newname, PATH_MAX)) < 0) {
     delete tildepath;
@@ -157,7 +157,7 @@ char *MCS_resolvepath(const char *path)
   delete tildepath;
   newname[size] = '\0';
   if (newname[0] != '/') {
-    char *fullpath = new char[strlen(path) + strlen(newname) + 2];
+    char *fullpath = new (nothrow) char[strlen(path) + strlen(newname) + 2];
     strcpy(fullpath, path);
     char *sptr = strrchr(fullpath, '/');
     if (sptr == NULL)
@@ -196,7 +196,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 	}
 
 	DATABASEREC *t_result;
-	t_result = new DATABASEREC;
+	t_result = new (nothrow) DATABASEREC;
 
 	t_result -> driverref = t_driver_handle;
 	t_result -> idcounterptr = (idcounterrefptr)dlsym(t_driver_handle, "setidcounterref");

--- a/revdb/src/w32support.cpp
+++ b/revdb/src/w32support.cpp
@@ -76,7 +76,7 @@ DATABASEREC *DoLoadDatabaseDriver(const char *p_path)
 		return NULL;
 
 	DATABASEREC *t_result;
-	t_result = new DATABASEREC;
+	t_result = new (nothrow) DATABASEREC;
 	t_result -> driverref = t_module;
 	t_result -> idcounterptr = (idcounterrefptr)GetProcAddress(t_module, "setidcounterref");
 	t_result -> newconnectionptr = (new_connectionrefptr)GetProcAddress(t_module, "newdbconnectionref");
@@ -165,7 +165,7 @@ void MCU_fix_path(char *cstr)
 
 char *MCS_getcurdir(void)
 {
-  char *t_path = new char[PATH_MAX + 2];
+  char *t_path = new (nothrow) char[PATH_MAX + 2];
   GetCurrentDirectory(PATH_MAX +1, (LPTSTR)t_path);
   MCU_path2std(t_path);
   return t_path;

--- a/revpdfprinter/src/revpdfprinter.cpp
+++ b/revpdfprinter/src/revpdfprinter.cpp
@@ -1357,31 +1357,6 @@ bool custom_printer_clusters_to_cairo_clusters(const uint32_t *p_cp_clusters, ui
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// We scarecly use any C++ features so to avoid having to link with the heavy
-// stdc++ library, we just define what we need.
-
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-void * operator new (long unsigned int p_amount)
-#else
-// MP-2013-05-02: [[ x64 ]] Make sure we use the right type for 64-bit.
-void * operator new (size_t p_amount)
-#endif
-{
-	void *t_result;
-	if (!MCMemoryAllocate(p_amount, t_result))
-		return nil;
-	return t_result;
-}
-
-void operator delete(void *p_block)
-{
-	MCMemoryDeallocate(p_block);
-}
-
-extern "C" void __cxa_pure_virtual() { while (1); }
-
-////////////////////////////////////////////////////////////////////////////////
-
 // The static function export table for iOS external linkage requirements.
 
 #ifdef TARGET_SUBPLATFORM_IPHONE

--- a/revspeech/src/w32sapi4speech.cpp
+++ b/revspeech/src/w32sapi4speech.cpp
@@ -191,7 +191,7 @@ bool WindowsSAPI4Narrator::Initialize(void)
 
 	m_device_engine->QueryInterface(IID_ITTSAttributesA, (LPVOID *)&m_device_attributes);
 
-	m_device_notifier = new CNotify(this);
+	m_device_notifier = new (nothrow) CNotify(this);
 	if (m_device_notifier)
 	{
 		HRESULT hRes = m_device_engine->Register(m_device_notifier, IID_ITTSNotifySink2A, &m_device_notifier_id);
@@ -625,7 +625,7 @@ bool WindowsSAPI4Narrator::SpeakToFile(const char *p_string, const char *p_file)
 	SpeakToFileNotifier2 *t_notifier;
 	if (t_success)
 	{
-		t_notifier = new SpeakToFileNotifier2();
+		t_notifier = new (nothrow) SpeakToFileNotifier2();
 		if (t_notifier)
 		{
 			HRESULT t_result = t_central_interface -> Register(t_notifier, IID_ITTSNotifySinkA, &t_notifier_id);
@@ -647,7 +647,7 @@ bool WindowsSAPI4Narrator::SpeakToFile(const char *p_string, const char *p_file)
 
 		if (t_success)
 		{
-			t_file = new WCHAR[strlen(t_native_path) + 1];
+			t_file = new (nothrow) WCHAR[strlen(t_native_path) + 1];
 			if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, t_native_path, -1, t_file, strlen(t_native_path) + 1))
 				t_success = false;
 		}
@@ -747,7 +747,7 @@ bool WindowsSAPI4Narrator::SpeakToFileOld(const char *p_string, const char *p_fi
 
 		if (t_success)
 		{
-			t_file = new WCHAR[strlen(t_native_path) + 1];
+			t_file = new (nothrow) WCHAR[strlen(t_native_path) + 1];
 			if (!MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, t_native_path, -1, t_file, strlen(t_native_path) + 1))
 				t_success = false;
 		}
@@ -795,7 +795,7 @@ bool WindowsSAPI4Narrator::SpeakToFileOld(const char *p_string, const char *p_fi
 	CNotify *t_notifier;
 	if (t_success)
 	{
-		t_notifier = new CNotify(this);
+		t_notifier = new (nothrow) CNotify(this);
 		if (t_notifier)
 		{
 			HRESULT t_result = t_central_interface -> Register(t_notifier, IID_ITTSNotifySinkA, &t_notifier_id);

--- a/revspeech/src/w32sapi5speech.cpp
+++ b/revspeech/src/w32sapi5speech.cpp
@@ -65,7 +65,7 @@ static char *path_to_native(const char *p_path)
 static wchar_t *utf8tow(const char *p_utf8)
 {
 	wchar_t *t_utf16;
-	t_utf16 = new wchar_t[strlen(p_utf8) + 1];
+	t_utf16 = new (nothrow) wchar_t[strlen(p_utf8) + 1];
 
 	int t_length;
 	t_length = MultiByteToWideChar(CP_UTF8, 0, p_utf8, strlen(p_utf8), t_utf16, strlen(p_utf8));
@@ -78,7 +78,7 @@ static wchar_t *utf8tow(const char *p_utf8)
 static wchar_t *nativetow(const char *p_native)
 {
 	wchar_t *t_utf16;
-	t_utf16 = new wchar_t[strlen(p_native) + 1];
+	t_utf16 = new (nothrow) wchar_t[strlen(p_native) + 1];
 
 	int t_length;
 	t_length = MultiByteToWideChar(1252, MB_PRECOMPOSED, p_native, strlen(p_native), t_utf16, strlen(p_native));
@@ -192,7 +192,7 @@ bool WindowsSAPI5Narrator::Start(const char* p_string, bool p_wants_utf8)
 
 	if(!m_bUseDefaultPitch)
 	{
-		char *pstrTotal = new char[ strlen(p_string) + PITCH_XML_STRING + 10 ];
+		char *pstrTotal = new (nothrow) char[ strlen(p_string) + PITCH_XML_STRING + 10 ];
 		char strXMLtag[PITCH_XML_STRING];
 
 		sprintf( strXMLtag, "<pitch absmiddle = \'%d\'/> ", m_Npitch);
@@ -246,20 +246,20 @@ bool WindowsSAPI5Narrator::SpeakToFile(const char* p_string, const char* p_file)
 
 	if(!m_bUseDefaultPitch)
 	{
-		char *pstrTotal = new char[ strlen(p_string) + PITCH_XML_STRING + 10 ];
+		char *pstrTotal = new (nothrow) char[ strlen(p_string) + PITCH_XML_STRING + 10 ];
 		char strXMLtag[PITCH_XML_STRING];
 
 		sprintf( strXMLtag, "<pitch absmiddle = \'%d\'/> ", m_Npitch);
 		strcpy( pstrTotal, strXMLtag);
 		strcat( pstrTotal, p_string);
-		szWTextString = new WCHAR[ strlen(pstrTotal) + 20 ];	
+		szWTextString = new (nothrow) WCHAR[ strlen(pstrTotal) + 20 ];	
 		wcscpy( szWTextString, A2W(pstrTotal));	
 	}
 	else
 	{
 		int t_length;
 		t_length = strlen(p_string);
-		szWTextString = new WCHAR[ t_length + 1 ];
+		szWTextString = new (nothrow) WCHAR[ t_length + 1 ];
 
 		wcscpy( szWTextString, A2W(p_string));
 	}	
@@ -295,7 +295,7 @@ bool WindowsSAPI5Narrator::SpeakToFile(const char* p_string, const char* p_file)
 
 		if (t_success)
 		{
-			t_file = new WCHAR[strlen(t_native_path) + 1];
+			t_file = new (nothrow) WCHAR[strlen(t_native_path) + 1];
 			wcscpy(t_file, A2W(t_native_path));
 
 			// Bind the output to the stream
@@ -653,14 +653,14 @@ bool WindowsSAPI5Narrator::ListVoices(NarratorGender p_gender, NarratorListVoice
 
 		if ( t_success && 0 != ulNumTokens )
         {
-			ppcDesciptionString = new CSpDynamicString [ulNumTokens];
+			ppcDesciptionString = new (nothrow) CSpDynamicString [ulNumTokens];
             if ( NULL == ppcDesciptionString )
             {
 				/* TODO - CLEANUP */
                 return false;
             }
 
-			ppszTokenIds = new WCHAR* [ulNumTokens];
+			ppszTokenIds = new (nothrow) WCHAR* [ulNumTokens];
             if ( NULL == ppszTokenIds )
             {
 				/* TODO - CLEANUP */

--- a/revspeech/src/w32speech.cpp
+++ b/revspeech/src/w32speech.cpp
@@ -27,12 +27,12 @@ INarrator *InstantiateNarrator(NarratorProvider p_provider)
 	if (p_provider == kNarratorProviderDefault)
 	{
 		INarrator *t_narrator;
-		t_narrator = new WindowsSAPI5Narrator();
+		t_narrator = new (nothrow) WindowsSAPI5Narrator();
 		if (!t_narrator -> Initialize())
 		{
 			delete t_narrator;
 
-			t_narrator = new WindowsSAPI4Narrator();
+			t_narrator = new (nothrow) WindowsSAPI4Narrator();
 			if (!t_narrator -> Initialize())
 			{
 				delete t_narrator;

--- a/revvideograbber/src/dsvideograbber.cpp
+++ b/revvideograbber/src/dsvideograbber.cpp
@@ -2307,7 +2307,7 @@ BOOL CDirectXVideoGrabber::Snapshot(DWORD *pdwSize, LPBYTE *pBuff)
 	*pdwSize = lBufferSize;
 
 	//*pBuff = (LPBYTE)malloc(lBufferSize);
-	*pBuff = new BYTE[lBufferSize];
+	*pBuff = new (nothrow) BYTE[lBufferSize];
 	hr = m_pGrabber->GetCurrentBuffer(&lBufferSize, (long*)*pBuff);
 	if (FAILED(hr))	{
         Error( TEXT("Failed to GetCurrentBuffer!"), hr);

--- a/revvideograbber/src/qtvideograbber.cpp
+++ b/revvideograbber/src/qtvideograbber.cpp
@@ -134,7 +134,7 @@ void Path2Native(char *dptr)
 
 static OSErr path2FSSpec(const char *fname, FSSpec *fspec)
 {
-	char *nativepath = new char[strlen(fname)+1];
+	char *nativepath = new (nothrow) char[strlen(fname)+1];
 	strcpy(nativepath, fname);
 	Path2Native(nativepath);
 	OSErr err = noErr;

--- a/revvideograbber/src/revvideograbber.cpp
+++ b/revvideograbber/src/revvideograbber.cpp
@@ -115,7 +115,7 @@ struct MYBITMAP
 
 MYBITMAP *createmybitmap(uint2 depth, uint2 width, uint2 height)
 {
-  MYBITMAP *image = new (std::nothrow) MYBITMAP;
+  MYBITMAP *image = new (nothrow) MYBITMAP;
   image->width = width;
   image->height = height;
   image->depth = (uint1)depth;
@@ -638,7 +638,7 @@ void REVVideoGrabber(VideoGrabberKeyword whichkeyword,
 				{
 #endif
                     if (InitQT())
-                        gvideograbber = new (std::nothrow) CQTVideoGrabber(windowid);
+                        gvideograbber = new (nothrow) CQTVideoGrabber(windowid);
                     else
                     {
                         // SN-2015-04-17: [[ Bug 13452 ]] Break if qvideograbber

--- a/revvideograbber/src/revvideograbber.cpp
+++ b/revvideograbber/src/revvideograbber.cpp
@@ -22,6 +22,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <string.h>
 #include <math.h>
 
+#include <core.h>
+
 #ifdef WIN32
 #include <windows.h>
 #endif
@@ -113,7 +115,7 @@ struct MYBITMAP
 
 MYBITMAP *createmybitmap(uint2 depth, uint2 width, uint2 height)
 {
-  MYBITMAP *image = new MYBITMAP;
+  MYBITMAP *image = new (std::nothrow) MYBITMAP;
   image->width = width;
   image->height = height;
   image->depth = (uint1)depth;
@@ -626,7 +628,7 @@ void REVVideoGrabber(VideoGrabberKeyword whichkeyword,
                 // SN-2015-04-23: [[ Bug 15255 ]] Windows now defaults to directX
 #ifdef WIN32
 				if (_strnicmp(args[1], "vfw",strlen("vfw")) == 0)
-                    gvideograbber = new CWinVideoGrabber(windowid);
+                    gvideograbber = new (nothrow) CWinVideoGrabber(windowid);
                 else if (_strnicmp(args[1], "qt",strlen("qt")) == 0)
                 {
 #else
@@ -636,7 +638,7 @@ void REVVideoGrabber(VideoGrabberKeyword whichkeyword,
 				{
 #endif
                     if (InitQT())
-                        gvideograbber = new CQTVideoGrabber(windowid);
+                        gvideograbber = new (std::nothrow) CQTVideoGrabber(windowid);
                     else
                     {
                         // SN-2015-04-17: [[ Bug 13452 ]] Break if qvideograbber
@@ -647,7 +649,7 @@ void REVVideoGrabber(VideoGrabberKeyword whichkeyword,
                 }
 #ifdef WIN32
                 else
-                    gvideograbber = new CDirectXVideoGrabber(windowid);
+                    gvideograbber = new (nothrow) CDirectXVideoGrabber(windowid);
 #endif
 				int left,top,right,bottom;
                 // SN-2015-04-23: [[ Bug 15255 ]] Checking that qtvideograbber

--- a/revxml/src/revxml.cpp
+++ b/revxml/src/revxml.cpp
@@ -287,7 +287,7 @@ void CB_endElement(const char *name)
 //MESSAGE: XMLElementData data - sent when element data is encountered between tags
 void CB_elementData(const char *data, int length)
 {
-	char *buffer = new char[length+1];
+	char *buffer = new (nothrow) char[length+1];
 	memcpy(buffer, data, length);
 	buffer[length] = '\0';
 	DispatchMetaCardMessage("revStartXMLData",(char *)buffer);
@@ -392,7 +392,7 @@ void XML_NewDocument(char *args[], int nargs, char **retstring,
 		result = istrdup(xmlerrors[XMLERR_BADARGUMENTS]);
 	}
 	else{
-		CXMLDocument *newdoc = new CXMLDocument;
+		CXMLDocument *newdoc = new (nothrow) CXMLDocument;
 
 		Bool wellformed = util_strnicmp(args[1],"TRUE",4) == 0;
 		
@@ -534,7 +534,7 @@ void XML_NewDocumentFromFile(char *args[], int nargs, char **retstring,
 	if (!*error)
 	{
 		Bool wellformed = util_strnicmp(args[1],"TRUE",4) == 0;
-		CXMLDocument *newdoc = new CXMLDocument;
+		CXMLDocument *newdoc = new (nothrow) CXMLDocument;
 		Bool buildtree = True;
 		Bool sendmessages = False;
 		if (nargs >= 3)
@@ -2742,7 +2742,7 @@ void XML_xsltLoadStylesheet(char *args[], int nargs, char **retstring, Bool *pas
 				cur = xsltParseStylesheetDoc(xmlDoc);
 				if (NULL != cur)
 				{
-					CXMLDocument *newdoc = new CXMLDocument(cur);
+					CXMLDocument *newdoc = new (nothrow) CXMLDocument(cur);
 					doclist.add(newdoc);
 					unsigned int docid = newdoc->GetID();
 
@@ -2799,7 +2799,7 @@ void XML_xsltLoadStylesheetFromFile(char *args[], int nargs, char **retstring, B
 		cur = xsltParseStylesheetFile((const xmlChar *)t_native_path);
 		if (NULL != cur)
 		{
-			CXMLDocument *newdoc = new CXMLDocument(cur);
+			CXMLDocument *newdoc = new (nothrow) CXMLDocument(cur);
 			doclist.add(newdoc);
 			unsigned int docid = newdoc->GetID();
 			result = (char *)malloc(INTSTRSIZE);


### PR DESCRIPTION
We jump through various hoops in order to get new to be recognised as
having nothrow behaviour but it is fragile and doesn't work when the
engine is hosted inside another process (if that process uses its own
implementation of new, as it is entitled to do).

Instead of dealing with this, just bite the bullet and add the
(std::nothrow) argument to every invocation of new in the engine and
externals.
