### PR TITLE
[[ Bug 18357 ]] Dispatch command array as argument

### DIFF
--- a/docs/dictionary/command/dispatch.lcdoc
+++ b/docs/dictionary/command/dispatch.lcdoc
@@ -2,7 +2,6 @@ Name: dispatch
 
 Type: command
 
-Syntax: dispatch <message> [ to <target> ][ with {<argumentList>, | arrayName} ]
 Syntax: dispatch <message> [ to <target> ][ with <argumentList> ]
 
 Summary:
@@ -18,9 +17,36 @@ Example:
 dispatch "updateWidget"
 
 Example:
-dispatch "setList" with myVar1, myVar2
+on mouseUp
+  local tWidth, tHeight
+   
+  put 200 into tWidth
+  put 100 into tHeight
+  dispatch "setSize" with tWidth, tHeight
+end mouseUp
+
+on setSize pWidth, pHeight
+  set the width of graphic "myRectangle" to pWidth
+  set the height of graphic "myRectangle" to pHeight
+end setSize
 
 Example:
+# An example of using an array as an argument
+
+on mouseUp
+  local tDataArray
+  
+  put "Mickey" into tDataArray["firstName"]
+  put "Mouse" into tDataArray["lastName"]
+  
+  dispatch "updateUI" to card "myCard" with "Hello World", tDataArray
+end mouseUp
+
+on updateUI pTitle, @pArray
+  put pTitle into field "Title"
+  put pArray["firstName"] into field "First Name"
+  put pArray["lastName"] into field "Last Name"
+end updateUI
 
 Parameters:
 message:
@@ -31,7 +57,7 @@ A reference to any LiveCode object.
 
 argumentList:
 A comma separated list of expressions containing the arguments to send.
-
+Arrays are expressions and are valid to send as arguments.
 
 It (enum):
 Set by <dispatch> to indicate how the message was processed.
@@ -50,6 +76,8 @@ as it allows a <behavior> script to send an 'event' to one of its child
 objects and then perform an action depending on the outcome.
 
 Executing a <dispatch> command causes the <message> to be sent to the
+target object with the given argument list. This message passes through
+the message path in the normal way.
 
 If no <target> is specified, the <message> is sent to ' <me> '. In the
 context of a <behavior>, this is typically the child that is executing

--- a/docs/dictionary/command/dispatch.lcdoc
+++ b/docs/dictionary/command/dispatch.lcdoc
@@ -2,7 +2,7 @@ Name: dispatch
 
 Type: command
 
-Syntax: dispatch <message> [ to <target> ][ with <argumentList> ]
+Syntax: dispatch <message> [ to <target> ][ with {<argumentList>, | arrayName} ]
 
 Summary:
 Sends a message to an object via the normal message path.
@@ -17,7 +17,10 @@ Example:
 dispatch "updateWidget"
 
 Example:
-dispatch "setList" with tNewList
+dispatch "setList" with myVar1, myVar2
+
+Example:
+dispatch "updateFields" with arrayName
 
 Parameters:
 message:
@@ -29,6 +32,9 @@ A reference to any LiveCode object.
 argumentList:
 A comma separated list of expressions containing the arguments to send.
 
+arrayName (array):
+The name of a single array variable.
+
 It (enum):
 Set by <dispatch> to indicate how the message was processed.
 
@@ -38,7 +44,7 @@ Set by <dispatch> to indicate how the message was processed.
 
 
 Description:
-Use the <dispatch> command to send a mesage to an object, via the
+Use the <dispatch> command to send a message to an object, via the
 message path and find out whether it was handled or not.
 
 The <dispatch> command is most useful when using <behavior|behaviors>,
@@ -46,8 +52,8 @@ as it allows a <behavior> script to send an 'event' to one of its child
 objects and then perform an action depending on the outcome.
 
 Executing a <dispatch> command causes the <message> to be sent to the
-target object with the given argument list. This message passes through
-the message path in the normal way.
+target object with the given argument list or array data. This message
+passes through the message path in the normal way.
 
 If no <target> is specified, the <message> is sent to ' <me> '. In the
 context of a <behavior>, this is typically the child that is executing

--- a/docs/dictionary/command/dispatch.lcdoc
+++ b/docs/dictionary/command/dispatch.lcdoc
@@ -3,6 +3,7 @@ Name: dispatch
 Type: command
 
 Syntax: dispatch <message> [ to <target> ][ with {<argumentList>, | arrayName} ]
+Syntax: dispatch <message> [ to <target> ][ with <argumentList> ]
 
 Summary:
 Sends a message to an object via the normal message path.
@@ -20,7 +21,6 @@ Example:
 dispatch "setList" with myVar1, myVar2
 
 Example:
-dispatch "updateFields" with arrayName
 
 Parameters:
 message:
@@ -32,8 +32,6 @@ A reference to any LiveCode object.
 argumentList:
 A comma separated list of expressions containing the arguments to send.
 
-arrayName (array):
-The name of a single array variable.
 
 It (enum):
 Set by <dispatch> to indicate how the message was processed.
@@ -52,8 +50,6 @@ as it allows a <behavior> script to send an 'event' to one of its child
 objects and then perform an action depending on the outcome.
 
 Executing a <dispatch> command causes the <message> to be sent to the
-target object with the given argument list or array data. This message
-passes through the message path in the normal way.
 
 If no <target> is specified, the <message> is sent to ' <me> '. In the
 context of a <behavior>, this is typically the child that is executing

--- a/docs/notes/bugfix-18357.md
+++ b/docs/notes/bugfix-18357.md
@@ -1,0 +1,1 @@
+# dispatch documentation should mention arguments can be arrays


### PR DESCRIPTION
- Added arrayName to dispatch command syntax
- Added example showing arrayName usage
- Updated description text to mention use of array as an argument

Other fixes not related to bug 18357:
- Added “,” after argumentList in command syntax
- update example usage to show multiple arguments
- Fixed “mesage” to “message” typo in description
