### PR TITLE
[Valgrind] More fixes from running IDE tests under Valgrind

### DIFF
--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -302,7 +302,7 @@ bool X_init(int argc, MCStringRef argv[], MCStringRef envp[])
             MCValueRelease(MCstacknames[i]);
 		}
         MCnstacks = 0;
-		delete MCstacknames;
+        delete[] MCstacknames; /* Allocated with new[] */
 		MCstacknames = NULL;
 		MCeerror->clear();
 	}

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1464,7 +1464,7 @@ int X_close(void)
 	for(uint4 i = 0; i < MCnstacks; ++i)
 		MCValueRelease(MCstacknames[i]);
 
-	delete MCstacknames;
+	delete[] MCstacknames; /* allocated with new[] */
 
 	// Cleanup the parentscript stuff
 	MCParentScript::Cleanup();

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -164,7 +164,8 @@ static real64_t MCU_strtor8(const char *&r_str, uindex_t &r_len, int8_t p_delim,
         r_done = done;
         return i;
     }
-    l = MCMin(R8L - 1U, strlen(sptr));
+    sptr = r_str;
+    l = MCMin(R8L - 1U, strnlen(sptr, r_len));
     MCU_skip_spaces(sptr, l);
     // bugs in MSL means we need to check these things
     // MW-2006-04-21: [[ Purify ]] This was incorrect - we need to ensure l > 1 before running most


### PR DESCRIPTION
These problems were found by running:

``` sh
cd ide/tests
valgrind --log-file='valgrind.%p.log' \
    ../../linux-x86-64-bin/LiveCode-Community _testrunner.livecodescript
```
