### PR TITLE
[[Dictionary]] exitField description display incomplete

### DIFF
--- a/docs/dictionary/keyword/codeunits.lcdoc
+++ b/docs/dictionary/keyword/codeunits.lcdoc
@@ -28,7 +28,7 @@ A codeunit refers to the encoded units in which codepoints are stored
 
 Use the expression 
 
-the number of codeunits of tString
+    the number of codeunits of tString
 
 to find out how many codeunits make up a Unicode string.
 

--- a/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
+++ b/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
@@ -42,11 +42,7 @@ The <gRevProfileReadOnly> <global|global variable> can also be changed
 in the Preferences dialog box:
 
 1. Choose LiveCode → Preferences from the menubar.
-
-
 2. Choose "Property Profiles" from the menu at the top.
-
-
 3. Click "Don't save changes in profile".
 
 

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -30,7 +30,7 @@ leaves a field that hasn't been changed.
 The selection is removed from a field (and the field loses focus) when
 another window is brought to the front, when the user clicks in another
 field, or when the user tabs out of the field. The field also loses
-focus when the <select command> is used to select text in another field.
+focus when the select <command> is used to select text in another field.
 However, the <exitField> message is not sent when the user clicks
 another point in the same field.
 


### PR DESCRIPTION
The term “<select command>” appeared to display a combo box and then
cause the rest of the script to fail. After checking other references,
it has been changed to “select <command>” as opposed to “<select>
command” which falls in line with ones such as closeField, openField
and scrollbarDrag.
