### PR TITLE
[[Glossary]] object.lcdoc include control & widget

### DIFF
--- a/docs/glossary/o/object.lcdoc
+++ b/docs/glossary/o/object.lcdoc
@@ -6,9 +6,13 @@ Type: glossary
 
 Description:
 A LiveCode module capable of receiving <message|messages>. One of the
-building blocks of a LiveCode application.
+building blocks of a LiveCode application. Objects may also be referred
+to as a <keyword|control> or a <object|widget>. Controls include
+<button|buttons>, <field|fields>, <image|images>, <graphic|graphics>,
+<player|players>, <EPS|EPS objects>, <scrollbar|scrollbars>, and
+<group|groups>.
 
-References: message (glossary)
+References: message (glossary), control (glossary)
 
 Tags: objects
 


### PR DESCRIPTION
To make it easier to locate object types and references
