### PR TITLE
[[Dictionary]] Codepoints - script example

### DIFF
--- a/docs/dictionary/keyword/codepoints.lcdoc
+++ b/docs/dictionary/keyword/codepoints.lcdoc
@@ -26,7 +26,7 @@ characters. A single <character> is composed of one or more codepoints.
 
 Use the expression 
 
-the number of codepoints of tString
+	the number of codepoints of tString
 
 to find out how many codepoints make up a Unicode string.
 


### PR DESCRIPTION
Without the tab whitespace it is not displayed as code so this has been
added (Nice to see correct/advised variable format here, tString)
