### PR TITLE
[[Dictionary]] by.lcdoc description clarity

### DIFF
--- a/docs/dictionary/keyword/by.lcdoc
+++ b/docs/dictionary/keyword/by.lcdoc
@@ -32,7 +32,7 @@ Use the <by> <keyword> to divide or multiply a <container> by a number
 or to specify how to <sort>.
 
 When used with the <combine> or <split> <command>, the <by> <keyword> is
-a synonym for <using>.
+a synonym for the <using> <keyword>.
 
 References: sort (command), combine (command), split (command),
 rotate (command), sort container (command), multiply (command),


### PR DESCRIPTION
It wasn’t clear that ‘using’ was a keyword when read without the angle
brackets.
