### PR TITLE
[[ Bug 18521 ]] Ensure 'files' and 'folders' resolve folder path

### DIFF
--- a/docs/notes/bugfix-18521.md
+++ b/docs/notes/bugfix-18521.md
@@ -1,0 +1,1 @@
+# Resolve folder path before processing files(folder) and folders(folder)

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -1017,9 +1017,17 @@ bool MCS_getentries(MCStringRef p_folder,
                     bool p_files,
                     bool p_detailed,
                     MCListRef& r_list)
-{    
+{
+	MCAutoStringRef t_resolved_folder;
+	MCAutoStringRef t_native_folder;
+	if (p_folder != nil)
+	{
+		if (!(MCS_resolvepath(p_folder, &t_resolved_folder) &&
+			  MCS_pathtonative(*t_resolved_folder, &t_native_folder)))
+			return false;
+	}
+	
 	MCAutoListRef t_list;
-    
 	if (!MCListCreateMutable('\n', &t_list))
 		return false;
 
@@ -1036,7 +1044,7 @@ bool MCS_getentries(MCStringRef p_folder,
 			return false;
 	}
     
-	if (!MCsystem -> ListFolderEntries(p_folder, MCS_getentries_callback, (void*)&t_state))
+	if (!MCsystem -> ListFolderEntries(*t_native_folder, MCS_getentries_callback, (void*)&t_state))
 		return false;
     
 	if (!MCListCopy(*t_list, r_list))

--- a/tests/lcs/core/files/folders.livecodescript
+++ b/tests/lcs/core/files/folders.livecodescript
@@ -126,3 +126,12 @@ on TestFoldersInEmptyFolder
    delete folder tNewFolder
    set the defaultFolder to tOldCwd
 end TestFoldersInEmptyFolder
+
+on TestFoldersOfTilde
+	TestAssert "folders(~) is the same as folders($HOME)", folders($HOME) is folders("~")
+end TestFoldersOfTilde
+
+on TestFilesOfTilde
+	TestAssert "files(~) is the same as files($HOME)", files($HOME) is files("~")
+end TestFilesOfTilde
+


### PR DESCRIPTION
This patch ensures that the files(<folder>) and folders(<folder>)
functions resolve and convert the folder to a native path before
processing.

In particular, this means that files("~") now works correctly.
