### PR TITLE
[[Dictionary]] exitField description incomplete

### DIFF
--- a/docs/dictionary/keyword/abbreviated.lcdoc
+++ b/docs/dictionary/keyword/abbreviated.lcdoc
@@ -47,14 +47,14 @@ An abbreviated object <ID> looks like this: field ID 2238
 
 >*Note:* The <abbreviated> <keyword> is implemented internally as a
 > <property>, and appears in the <propertyNames>. However, it cannot be
-> used as a <property> in an <expression>, nor with the <set command>.
+> used as a <property> in an <expression>, nor with the <set> <command>.
 
 Changes:
 The form the abbreviated owner was introduced in version 2.0. In
 previous versions, the form of the owner property could not be specified
 and reported only the abbreviated owner.
 
-References: set command (command), convert (command), time (function),
+References: set (command), convert (command), time (function),
 dateFormat (function), format (function), date (function),
 propertyNames (function), keyword (glossary), property (glossary),
 command (glossary), function (glossary), object type (glossary),

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -30,7 +30,7 @@ leaves a field that hasn't been changed.
 The selection is removed from a field (and the field loses focus) when
 another window is brought to the front, when the user clicks in another
 field, or when the user tabs out of the field. The field also loses
-focus when the <select command> is used to select text in another field.
+focus when the select <command> is used to select text in another field.
 However, the <exitField> message is not sent when the user clicks
 another point in the same field.
 


### PR DESCRIPTION
The term “<select command>” appeared to display a combo box and then
cause the rest of the script to fail. After checking other references,
it has been changed to “select <command>” as opposed to “<select>
command” which falls in line with ones such as closeField, openField
and scrollbarDrag.
