### PR TITLE
[[Dictionary]] exitField description incomplete

### DIFF
--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -25,8 +25,6 @@ Description:
 Handle the <exitField> message if you want to do something when the user
 leaves a field that hasn't been changed.
 
-&nbsp;
-
 The selection is removed from a field (and the field loses focus) when
 another window is brought to the front, when the user clicks in another
 field, or when the user tabs out of the field. The field also loses
@@ -34,12 +32,8 @@ focus when the <select> <command> is used to select text in another field.
 However, the <exitField> message is not sent when the user clicks
 another point in the same field.
 
-&nbsp;
-
 The <exitField> message is sent to buttons whose <menuMode> is
 "comboBox", since the type-in box in a combo box behaves like a field.
-
-&nbsp;
 
 The <exitField> message is sent only if the field's contents have not
 changed since the last time it received the <openField>. If a
@@ -47,8 +41,6 @@ field is closing and its contents have changed, the <closeField>
 is sent instead of <exitField>. This means that if you want to take an
 action when the selection is removed from a field--whether the field has
 changed or not--you must handle both <closeField> and <exitField>.
-
-&nbsp;
 
 >*Note:* If the field's contents were changed by script using the <put
 > command>, then exitField will still be sent. <closeField> is only sent

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -30,7 +30,7 @@ leaves a field that hasn't been changed.
 The selection is removed from a field (and the field loses focus) when
 another window is brought to the front, when the user clicks in another
 field, or when the user tabs out of the field. The field also loses
-focus when the <select command> is used to select text in another field.
+focus when the <select> <command> is used to select text in another field.
 However, the <exitField> message is not sent when the user clicks
 another point in the same field.
 
@@ -54,7 +54,7 @@ changed or not--you must handle both <closeField> and <exitField>.
 > command>, then exitField will still be sent. <closeField> is only sent
 > when the contents are changed by the user.
 
-References: put command (command), select command (command),
+References: put (command), select (command),
 openField (message), closeField message (message),
 openField message (message), closeField (message), focusOut (message),
 menuMode (property)

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -42,8 +42,8 @@ The <exitField> message is sent to buttons whose <menuMode> is
 &nbsp;
 
 The <exitField> message is sent only if the field's contents have not
-changed since the last time it received the <openField message>. If a
-field is closing and its contents have changed, the <closeField message>
+changed since the last time it received the <openField>. If a
+field is closing and its contents have changed, the <closeField>
 is sent instead of <exitField>. This means that if you want to take an
 action when the selection is removed from a field--whether the field has
 changed or not--you must handle both <closeField> and <exitField>.
@@ -55,8 +55,7 @@ changed or not--you must handle both <closeField> and <exitField>.
 > when the contents are changed by the user.
 
 References: put (command), select (command),
-openField (message), closeField message (message),
-openField message (message), closeField (message), focusOut (message),
+openField (message), closeField (message), focusOut (message),
 menuMode (property)
 
 Tags: ui


### PR DESCRIPTION
The term “&lt;select command&gt;” appeared to display a combo box and then
cause the rest of the script to fail. After checking other references,
it has been changed to “&lt;select&gt; &lt;command&gt;”.
