### PR TITLE
[[Documentation]] various transfer-modes linked

### DIFF
--- a/docs/dictionary/keyword/adMin.lcdoc
+++ b/docs/dictionary/keyword/adMin.lcdoc
@@ -37,6 +37,9 @@ The <adMin> mode can be used only on <Mac OS|Mac OS systems>. On <Unix>
 and <Windows|Windows systems>, <object|objects> whose <ink> <property>
 is set to this mode appears as though their <ink> were set to <srcCopy>.
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),
 transfer mode (glossary), srcCopy (keyword), notSrcCopy (keyword),

--- a/docs/dictionary/keyword/addMax.lcdoc
+++ b/docs/dictionary/keyword/addMax.lcdoc
@@ -37,6 +37,9 @@ The <addMax> mode can be used only on <Mac OS|Mac OS systems>. On <Unix>
 and <Windows|Windows systems>, <object|objects> whose <ink> <property>
 is set to this mode appear as though their <ink> were set to <srcCopy>.
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),
 transfer mode (glossary), srcCopy (keyword), notSrcCopy (keyword),

--- a/docs/dictionary/keyword/addOver.lcdoc
+++ b/docs/dictionary/keyword/addOver.lcdoc
@@ -17,7 +17,11 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of button 2 to addOver
 
-The result:
+
+Description:
+Use the <addOver> <keyword> to combine an <object|object's> color with
+the colors underneath it.
+
 The <ink> <property> determines how an <object|object's> colors combine
 with the colors of the <pixels> underneath the <object(glossary)> to
 control how the <object|object's> color is displayed. When the <addOver>
@@ -25,10 +29,6 @@ mode is used, each component of the <object(glossary)> color--red,
 green, and blue--is added to the corresponding component of the color
 underneath. If the result is greater than 255, the component rolls over,
 back to zero.
-
-Description:
-Use the <addOver> <keyword> to combine an <object|object's> color with
-the colors underneath it.
 
 For example, suppose an object's color is 25,220,150, and the color of
 the pixels under the object is 60,40,100. If the <addOver> mode is used,

--- a/docs/dictionary/keyword/addOver.lcdoc
+++ b/docs/dictionary/keyword/addOver.lcdoc
@@ -37,7 +37,10 @@ the <object|object's> displayed color is 85,4,250.
 The <addOver> mode can be used only on <Mac OS|Mac OS systems>. On
 <Unix> and <Windows|Windows systems>, <object|objects> whose <ink>
 <property> is set to this mode appears as though their <ink> were set to
-<srcCopy>. 
+<srcCopy>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),

--- a/docs/dictionary/keyword/addPin.lcdoc
+++ b/docs/dictionary/keyword/addPin.lcdoc
@@ -37,7 +37,10 @@ the <object|object's> displayed color is 127,40,120.
 The <addPin> mode can be used only on <Mac OS|Mac OS systems>.  On
 <Unix> and <Windows|Windows systems>, <object|objects> whose <ink>
 <property> is set to this mode appears as though their <ink> were set to
-<srcCopy>. 
+<srcCopy>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),

--- a/docs/dictionary/keyword/addPin.lcdoc
+++ b/docs/dictionary/keyword/addPin.lcdoc
@@ -17,7 +17,11 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of button "Bar" to addPin
 
-The result:
+
+Description:
+Use the <addPin> <keyword> to combine an <object|object's> color with
+the colors underneath it.
+
 The <ink> <property> determines how an <object|object's> colors combine
 with the colors of the <pixels> underneath the <object(glossary)> to
 determine how the <object|object's> color is displayed. When the
@@ -25,10 +29,6 @@ determine how the <object|object's> color is displayed. When the
 color--red, green, and blue--is added to the corresponding component of
 the color underneath. If the resulting number is greater than 127 (the
 maximum), 127 is used for that component.
-
-Description:
-Use the <addPin> <keyword> to combine an <object|object's> color with
-the colors underneath it.
 
 For example, suppose an object's color is 240,0,100, and the color of
 the pixels under the object is 60,40,20. If the <addPin> mode is used,

--- a/docs/dictionary/keyword/blend.lcdoc
+++ b/docs/dictionary/keyword/blend.lcdoc
@@ -39,8 +39,11 @@ Whenever you set the <blendLevel> <property> of an <image>, its <ink>
 >*Important:*  The setting of the <blend> <property> has no effect on
 > images in <PICT> format.
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), property (glossary), keyword (glossary),
-transfer mode (glossary), PICT (glossary), blend (keyword),
+transfer mode (glossary), PICT (glossary),
 image (keyword), notSrcCopy (keyword), ink (property),
 blendLevel (property), pixels (property)
 

--- a/docs/dictionary/keyword/clear.lcdoc
+++ b/docs/dictionary/keyword/clear.lcdoc
@@ -31,7 +31,10 @@ black.
 The <clear> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
-<reverse>. 
+<reverse>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),

--- a/docs/dictionary/keyword/noOp.lcdoc
+++ b/docs/dictionary/keyword/noOp.lcdoc
@@ -35,6 +35,9 @@ background and border are not drawn and seem to disappear, letting
 > spot with a non-rectangular shape, use a <curve> or <polygon>
 > <graphic(keyword)> and set its <ink> property to <noOp>.
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), transfer mode (glossary),
 property (glossary), keyword (glossary), polygon (keyword),
 opaque (keyword), notSrcCopy (keyword), curve (keyword),

--- a/docs/dictionary/keyword/notSrcBic.lcdoc
+++ b/docs/dictionary/keyword/notSrcBic.lcdoc
@@ -32,7 +32,10 @@ text.
 The <notSrcBic> mode can be used only on <Mac OS|Mac OS systems>. On
 <Unix> and <Windows|Windows systems>, <object|objects> whose <ink>
 <property> is set to this mode appears as though their <ink> were set to
-<srcCopy>. 
+<srcCopy>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),

--- a/docs/dictionary/keyword/notSrcCopy.lcdoc
+++ b/docs/dictionary/keyword/notSrcCopy.lcdoc
@@ -27,16 +27,12 @@ determine how the <object|object's> color is displayed. When the
 <object(glossary)> --red, green, and blue--is raised to be equal to
 white. 
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), transfer mode (glossary),
 property (glossary), keyword (glossary), blend (keyword),
-reverse (keyword), notSrcOrReverse (keyword), notSrcAndReverse (keyword),
-subOver (keyword), adMin (keyword), srcAndReverse (keyword),
-srcBic (keyword), set (keyword), addOver (keyword), srcAnd (keyword),
-subPin (keyword), transparent (keyword), clear (keyword),
-srcCopy (keyword), notSrcAnd (keyword), addMax (keyword),
-notSrcBic (keyword), srcOr (keyword), noOp (keyword), srcXOr (keyword),
-notSrcXOr (keyword), notSrcOr (keyword), srcOrReverse (keyword),
-addPin (keyword), ink (property), pixels (property)
+set (keyword), ink (property), pixels (property)
 
 Tags: ui
 

--- a/docs/dictionary/keyword/reverse.lcdoc
+++ b/docs/dictionary/keyword/reverse.lcdoc
@@ -38,6 +38,9 @@ pixel under the object is 60,250,100. If the <reverse> mode is used, the
 <pixel|pixel's> displayed color is 195,5,155<a/>. (255 minus 60 is 195,
 255 minus 250 is 5, and 255 minus 100 is 155.)
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), property (glossary), keyword (glossary),
 pixel (glossary), transfer mode (glossary), notSrcCopy (keyword),
 ink (property), pixels (property)

--- a/docs/dictionary/keyword/set.lcdoc
+++ b/docs/dictionary/keyword/set.lcdoc
@@ -32,6 +32,9 @@ The <set> mode can be used only on <Unix> and <Windows|Windows systems>.
 On <Mac OS|Mac OS systems>, <object|objects> whose <ink> <property> is
 set to this mode appear as though their <ink> were set to <reverse>.
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),
 transfer mode (glossary), reverse (keyword), notSrcCopy (keyword),

--- a/docs/dictionary/keyword/srcCopy.lcdoc
+++ b/docs/dictionary/keyword/srcCopy.lcdoc
@@ -28,6 +28,9 @@ When the <srcCopy> mode is used, each pixel of the <object(glossary)> is
 drawn over the <pixels> underneath, blocking them completely. The color
 of the <pixel> underneath does not affect the final color.
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), property (glossary), keyword (glossary),
 pixel (glossary), transfer mode (glossary), notSrcCopy (keyword),
 ink (property), pixels (property)

--- a/docs/dictionary/keyword/transparent.lcdoc
+++ b/docs/dictionary/keyword/transparent.lcdoc
@@ -41,6 +41,9 @@ shown against whatever is directly underneath the <field> or
 Setting a button's or field's <style> <property> to "transparent" sets
 its <opaque> to false.
 
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
+
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),
 transfer mode (glossary), srcCopy (keyword), button (keyword),


### PR DESCRIPTION
- A link to a list of all transfer modes in the transferMode glossary page added to that required no additional description modification.
- Blend had a reference to itself in the references so this has been removed.
