### PR TITLE
[[Documentation]] various bitwise transfer-modes repaired

### DIFF
--- a/docs/dictionary/keyword/notSrcAnd.lcdoc
+++ b/docs/dictionary/keyword/notSrcAnd.lcdoc
@@ -34,16 +34,16 @@ The <notSrcAnd> <transfer mode> performs the following steps to compute
 the color of each <pixel> :
 
 1. Each component of the object's color--the number indicating the
-    amount of red, green, or blue--is changed to its inverse. (If the
-    color is expressed as three integers between zero and 255--one for
-    each of red, green, and blue--then the inverse of each component is
-    equal to 255 minus the component's value.)
+   amount of red, green, or blue--is changed to its inverse. (If the
+   color is expressed as three integers between zero and 255--one for
+   each of red, green, and blue--then the inverse of each component is
+   equal to 255 minus the component's value.)
 2. LiveCode performs a bitAnd <operation> on each component of the
-    inverted object color with the corresponding component of the color
-    under the <object(glossary)>.
+   inverted object color with the corresponding component of the color
+   under the <object(glossary)>.
 
 Therefore the calculation made per pixel color is:
-	(255 - object component) bitAnd background component
+   (255 - object component) bitAnd background component
 
 
 The effect is that the color of the object is reversed, and the darker
@@ -55,10 +55,10 @@ the pixels under the object is 50,20,240. If the <notSrcAnd> <transfer
 mode> is used, the <object|object's> displayed color is 2,20,0.
 In <binary(glossary)> it is:
 
-	10000111, 11111111, 00000000
-	00110010, 00010100, 11110000 Logic AND
-	========  ========  ========
-    00000010, 00010100, 00000000 
+   10000111, 11111111, 00000000
+   00110010, 00010100, 11110000 Logic AND
+   ========  ========  ========
+   00000010, 00010100, 00000000 
 
 The <notSrcAnd> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>

--- a/docs/dictionary/keyword/notSrcAnd.lcdoc
+++ b/docs/dictionary/keyword/notSrcAnd.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of card button 1 to notSrcAnd
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <notSrcAnd> <keyword> to invert the colors of an
@@ -34,18 +34,16 @@ The <notSrcAnd> <transfer mode> performs the following steps to compute
 the color of each <pixel> :
 
 1. Each component of the object's color--the number indicating the
-   amount of red, green, or blue--is changed to its inverse. (If the
-   color is expressed as three integers between zero and 255--one for
-   each of red, green, and blue--then the inverse of each component is
-   equal to 255 minus the component's value.)
-
-
+    amount of red, green, or blue--is changed to its inverse. (If the
+    color is expressed as three integers between zero and 255--one for
+    each of red, green, and blue--then the inverse of each component is
+    equal to 255 minus the component's value.)
 2. LiveCode performs a bitAnd <operation> on each component of the
-   inverted object color with the corresponding component of the color
-   under the <object(glossary)>.
+    inverted object color with the corresponding component of the color
+    under the <object(glossary)>.
 
-
-    (255 - object component) bitAnd background component
+Therefore the calculation made per pixel color is:
+	(255 - object component) bitAnd background component
 
 
 The effect is that the color of the object is reversed, and the darker
@@ -55,10 +53,19 @@ completely transparent, and white parts are completely opaque.
 For example, suppose an object's color is 120,0,255, and the color of
 the pixels under the object is 50,20,240. If the <notSrcAnd> <transfer
 mode> is used, the <object|object's> displayed color is 2,20,0.
+In <binary(glossary)> it is:
+
+	10000111, 11111111, 00000000
+	00110010, 00010100, 11110000 Logic AND
+	========  ========  ========
+    00000010, 00010100, 00000000
 
 The <notSrcAnd> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear all-white.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), pixel (glossary),
 operation (glossary), Windows (glossary), transfer mode (glossary),

--- a/docs/dictionary/keyword/notSrcAnd.lcdoc
+++ b/docs/dictionary/keyword/notSrcAnd.lcdoc
@@ -58,7 +58,7 @@ In <binary(glossary)> it is:
 	10000111, 11111111, 00000000
 	00110010, 00010100, 11110000 Logic AND
 	========  ========  ========
-    00000010, 00010100, 00000000
+    00000010, 00010100, 00000000 
 
 The <notSrcAnd> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>

--- a/docs/dictionary/keyword/notSrcAnd.lcdoc
+++ b/docs/dictionary/keyword/notSrcAnd.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of card button 1 to notSrcAnd
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <notSrcAnd> <keyword> to invert the colors of an

--- a/docs/dictionary/keyword/notSrcAndReverse.lcdoc
+++ b/docs/dictionary/keyword/notSrcAndReverse.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of card button 1 to notSrcAnd
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <notSrcAndReverse> <keyword> to invert the colors under an
@@ -38,19 +38,14 @@ compute the color of each <pixel> :
    color is expressed as three integers between zero and 255--one for
    each of red, green, and blue--then the inverse of each component is
    equal to 255 minus the component's value.)
-
-
 2. Each component of the color underneath the object is changed to its
    inverse. 
-
-
 3. LiveCode performs a bitAnd <operation> on each component of the
    inverted object color with the corresponding component of the
    inverted color under the <object(glossary)>.
 
-
-    (255 - object component) bitAnd (255 - background component)
-
+Therefore the calculation made per pixel color is:
+   (255 - object component) bitAnd (255 - background component)
 
 The effect is that the color of the object is reversed, and the darker
 an object is, the more transparent it is. Black parts of an object are
@@ -59,12 +54,20 @@ completely transparent, and white parts are completely opaque.
 For example, suppose an object's color is 120,0,255, and the color of
 the pixels under the object is 50,20,240. If the <notSrcAndReverse>
 <transfer mode> is used, the <object|object's> displayed color is
-135,235,0. 
+135,235,0. In <binary(glossary)> it is:
+
+   10000111, 11111111, 00000000
+   11001101, 11101011, 00001111 Logic AND
+   ========  ========  ========
+   10000101, 11101011, 00000000
 
 The <notSrcAndReverse> mode can be used only on <Unix> and
 <Windows|Windows systems>. On <Mac OS|Mac OS systems>, <object|objects>
 whose <ink> <property> is set to this mode appear as though their <ink>
 were set to <srcCopy>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), pixel (glossary),
 operation (glossary), Windows (glossary), transfer mode (glossary),

--- a/docs/dictionary/keyword/notSrcAndReverse.lcdoc
+++ b/docs/dictionary/keyword/notSrcAndReverse.lcdoc
@@ -17,10 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of card button 1 to notSrcAnd
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
-
 Description:
 Use the <notSrcAndReverse> <keyword> to invert the colors under an
 object and make the light parts opaque.

--- a/docs/dictionary/keyword/notSrcOr.lcdoc
+++ b/docs/dictionary/keyword/notSrcOr.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of button ID 9 to notSrcOr
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <notSrcOr> <keyword> to invert the colors of an
@@ -37,15 +37,12 @@ the color of each <pixel> :
    color is expressed as three integers between zero and 255--one for
    each of red, green, and blue--then the inverse of each component is
    equal to 255 minus the component's value.)
-
-
 2. LiveCode performs a bitOr <operation> on each component of the
    inverted object color with the corresponding component of the color
    under the <object(glossary)>.
 
-
+Therefore the calculation made per pixel color is:
     (255 - object component) bitOr background component
-
 
 The effect is that the color of the object is reversed, and the lighter
 an object is, the more transparent it is. White parts of an object are
@@ -54,11 +51,20 @@ completely transparent, and black parts are completely opaque.
 For example, suppose an object's color is 120,0,255, and the color of
 the pixels under the object is 50,20,240. If the <notSrcOr> <transfer
 mode> is used, the <object|object's> displayed color is 183,255,240.
+In <binary(glossary)> it is:
+
+    10000111, 11111111, 00000000
+    00110010, 00010100, 11110000 Logic OR
+    ========  ========  ========
+    10110111, 11111111, 11110000
 
 The <notSrcOr> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
 <noOp>. 
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), pixel (glossary),
 operation (glossary), Windows (glossary), transfer mode (glossary),

--- a/docs/dictionary/keyword/notSrcOr.lcdoc
+++ b/docs/dictionary/keyword/notSrcOr.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of button ID 9 to notSrcOr
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <notSrcOr> <keyword> to invert the colors of an

--- a/docs/dictionary/keyword/notSrcOrReverse.lcdoc
+++ b/docs/dictionary/keyword/notSrcOrReverse.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of graphic "Flash" to notSrcOrReverse
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <notSrcOrReverse> <keyword> to invert the colors under an object

--- a/docs/dictionary/keyword/notSrcOrReverse.lcdoc
+++ b/docs/dictionary/keyword/notSrcOrReverse.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of graphic "Flash" to notSrcOrReverse
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <notSrcOrReverse> <keyword> to invert the colors under an object
@@ -37,19 +37,14 @@ compute the color of each <pixel> :
    color is expressed as three integers between zero and 255--one for
    each of red, green, and blue--then the inverse of each component is
    equal to 255 minus the component's value.)
-
-
 2. Each component of the color underneath the object is changed to its
-   inverse. 
-
-
+   inverse.
 3. LiveCode performs a bitOr <operation> on each component of the
    inverted object color with the corresponding component of the
    inverted color under the <object(glossary)>.
 
-
+Therefore the calculation made per pixel color is:
     (255 - object component) bitOr (255 - background component)
-
 
 The effect is that both the color of the object and the color under the
 object are reversed, and the lighter an object is, the more opaque it
@@ -59,12 +54,20 @@ completely inverted.
 For example, suppose an object's color is 120,0,255, and the color of
 the pixels under the object is 50,20,240. If the <notSrcOrReverse>
 <transfer mode> is used, the <object|object's> displayed color is
-207,255,15. 
+207,255,15. In <binary(glossary)> it is:
+
+    10000111, 11111111, 00000000
+    11001101, 11101011, 00001111 Logic OR
+    ========  ========  ========
+    11001111, 11111111, 00001111
 
 The <notSrcOrReverse> mode can be used only on <Unix> and
 <Windows|Windows systems>. On <Mac OS|Mac OS systems>, <object|objects>
 whose <ink> <property> is set to this mode appear as though their <ink>
 were set to <srcCopy>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), pixel (glossary),
 operation (glossary), Windows (glossary), transfer mode (glossary),

--- a/docs/dictionary/keyword/notSrcXOr.lcdoc
+++ b/docs/dictionary/keyword/notSrcXOr.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of scrollbar "Progress" to notSrcXOr
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <notSrcXOr> <keyword> to invert the colors of an

--- a/docs/dictionary/keyword/notSrcXOr.lcdoc
+++ b/docs/dictionary/keyword/notSrcXOr.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of scrollbar "Progress" to notSrcXOr
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <notSrcXOr> <keyword> to invert the colors of an
@@ -37,13 +37,11 @@ the color of each <pixel> :
    color is expressed as three integers between zero and 255--one for
    each of red, green, and blue--then the inverse of each component is
    equal to 255 minus the component's value.)
-
-
 2. LiveCode performs a bitXOr <operation> on each component of the
    inverted object color with the corresponding component of the color
    under the <object(glossary)>.
 
-
+Therefore the calculation made per pixel color is:
     (255 - object component) bitXOr background component
 
 
@@ -53,11 +51,20 @@ an object is, the more transparent it is.
 For example, suppose an object's color is 120,0,255, and the color of
 the pixels under the object is 50,20,240. If the <notSrcXOr> <transfer
 mode> is used, the <object|object's> displayed color is 181,235,240.
+In <binary(glossary)> it is:
+
+    10000111, 11111111, 00000000
+    00110010, 00010100, 11110000 Logic XOR
+    ========  ========  ========
+    10110101, 11101011, 11110000
 
 The <notSrcXOr> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
 <noOp>. 
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), pixel (glossary),
 operation (glossary), Windows (glossary), transfer mode (glossary),

--- a/docs/dictionary/keyword/srcAnd.lcdoc
+++ b/docs/dictionary/keyword/srcAnd.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of graphic "Outline" to srcAnd
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <srcAnd> <keyword> to make the light-colored parts of an object
@@ -42,12 +42,20 @@ completely opaque.
 For example, suppose an object's color is 45,0,255, and the color of the
 pixels under the object is 20,45,100. If the <srcAnd> <transfer mode> is
 used, the <object|object's> displayed color is 4,0,100 (the decimal
-equivalent). 
+equivalent). In <binary(glossary)> this is:
+
+    00101101, 00000000, 11111111
+    00010100, 00101101, 01100100 Logic AND
+    ========  ========  ========
+    00000100, 00000000, 01100100
 
 The <srcAnd> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
 <noOp>. 
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),

--- a/docs/dictionary/keyword/srcAnd.lcdoc
+++ b/docs/dictionary/keyword/srcAnd.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of graphic "Outline" to srcAnd
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <srcAnd> <keyword> to make the light-colored parts of an object

--- a/docs/dictionary/keyword/srcAndReverse.lcdoc
+++ b/docs/dictionary/keyword/srcAndReverse.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of field "Check" to srcAndReverse
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <srcAndReverse> <keyword> to invert the color underneath the
@@ -37,14 +37,12 @@ compute the color of each <pixel> :
    inverse. (If the color is expressed as three integers between zero
    and 255--one for each of red, green, and blue--then the inverse of
    each component is equal to 255 minus the component's value.)
-
-
 2. LiveCode performs a bitAnd <operation> on each component of the
    inverted object color with the corresponding component of the color
    under the <object(glossary)>.
 
-
-object component bitAnd (255 - background component)
+Therefore the calculation made per pixel color is:
+    object component bitAnd (255 - background component)
 
 The effect is that the lighter an object is, the more transparent it is
 to the inverted color beneath. White parts of an object completely
@@ -55,11 +53,20 @@ pixels under the object is 20,45,100. The inverse of the color
 underneath is obtained by subtracting each component from 255, yielding
 235,210,155. If the <srcAndReverse> <transfer mode> is used, the
 <object|object's> displayed color is 41,0,155 (the decimal equivalent).
+In <binary(glossary)> it is:
+
+    00101101, 00000000, 11111111
+    11101011, 11010010, 10011011 Logic AND
+    ========  ========  ========
+    00101001, 00000000, 10011011
 
 The <srcAndReverse> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
 <srcCopy>. 
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), pixel (glossary),
 operation (glossary), Windows (glossary), transfer mode (glossary),

--- a/docs/dictionary/keyword/srcAndReverse.lcdoc
+++ b/docs/dictionary/keyword/srcAndReverse.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of field "Check" to srcAndReverse
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <srcAndReverse> <keyword> to invert the color underneath the

--- a/docs/dictionary/keyword/srcOr.lcdoc
+++ b/docs/dictionary/keyword/srcOr.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of control 11 to srcOr
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <srcOr> <keyword> to make the dark-colored parts of an object
@@ -33,7 +33,7 @@ When the <srcOr> <transfer mode> is used, LiveCode performs a <bitOr>
 operation on each component of the <object(glossary)> color with the
 corresponding component of the color under the <object(glossary)>.
 
-object component bitOr background component
+    object component bitOr background component
 
 The effect is that the darker an object is, the more transparent it is.
 Black parts of an object are completely transparent, and white parts are
@@ -42,12 +42,20 @@ completely opaque.
 For example, suppose an object's color is 45,0,255, and the color of the
 pixels under the object is 20,45,100. If the <srcOr> <transfer mode> is
 used, the <object|object's> displayed color is 61,0,255 (the decimal
-equivalent). 
+equivalent). In <binary(glossary)> it is:
+
+    00101101, 00000000, 11111111
+    11101011, 11010010, 10011011 Logic OR
+    ========  ========  ========
+    11101111, 11010010, 11111111
 
 The <srcOr> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
 <srcCopy>. 
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),

--- a/docs/dictionary/keyword/srcOr.lcdoc
+++ b/docs/dictionary/keyword/srcOr.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of control 11 to srcOr
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <srcOr> <keyword> to make the dark-colored parts of an object

--- a/docs/dictionary/keyword/srcOrReverse.lcdoc
+++ b/docs/dictionary/keyword/srcOrReverse.lcdoc
@@ -17,10 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of card field ID 8 to srcOrReverse
 
-The result:
-Each component of the resulting color rgb value is equal to the
-result of this expression. 
-
 
 Description:
 Use the <srcOrReverse> <keyword> to invert the color underneath the

--- a/docs/dictionary/keyword/srcOrReverse.lcdoc
+++ b/docs/dictionary/keyword/srcOrReverse.lcdoc
@@ -18,19 +18,8 @@ Example:
 set the ink of card field ID 8 to srcOrReverse
 
 The result:
-
-2. For each of the three components, the resulting number is converted
-   to its binary equivalent, a string of ones and zeroes. The same is
-   done for each component of the object color. 3. LiveCode performs a
-   bitOr <operation> on each component of the object color with the
-   corresponding component of the inverse color under the
-   <object(glossary)>. (A <bit> is 1 if one or both of the corresponding
-   <bit|bits> of the <object(glossary)> color and the color underneath
-   is 1. If both corresponding bits are zero, the resulting <bit> is 0.
-   ). 4. For each component, the resulting binary number is turned back
-   into a decimal number, which is one of the three components--red,
-   green, or blue--of the final color. If the <srcOrReverse> <transfer
-   mode> is used, the resulting <binary> components are.
+Each component of the resulting color rgb value is equal to the
+result of this expression. 
 
 
 Description:
@@ -49,6 +38,17 @@ compute the color of each pixel:
    inverse. (If the color is expressed as three integers between zero
    and 255--one for each of red, green, and blue--then the inverse of
    each component is equal to 255 minus the component's value.)
+2. For each of the three components, the resulting number is converted
+   to its binary equivalent, a string of ones and zeroes. The same is
+   done for each component of the object color. 
+3. LiveCode performs a bitOr <operation> on each component of the object 
+   color with the corresponding component of the inverse color under the
+   <object(glossary)>.
+   (A <bit> is 1 if one or both of the corresponding <bit|bits> of
+   the <object(glossary)> color and the color underneath is 1. If both
+   corresponding bits are zero, the resulting <bit> is 0). 
+4. For each component, the resulting binary number is turned back
+   into a decimal number producing a color value.
 
 
 The effect is that the darker an object is, the more transparent it is
@@ -56,19 +56,22 @@ to the inverted color beneath. Black parts of an object completely
 invert the color underneath them, and white parts are completely opaque.
 
 For example, suppose an object's color is 45,0,255, and the color of the
-pixels under the object is 20,45,100. The binary equivalent of the
-object's color is 00101101, 00000000, 11111111 and the binary equivalent
-of the inverse of the color underneath is 11101011, 11010010, 10011011
+pixels under the object is 20,45,100. The <binary(glossary)> equivalent is:
 
+	00101101, 00000000, 11111111
+	11101011, 11010010, 10011011 Logic OR
+	========  ========  ========
     11101111, 11010010, 11111111
 
-and the object's displayed color is 239,210,255 (the decimal
-equivalent). 
+and the object's displayed color is 239,210,255 (the decimal equivalent). 
 
 The <srcOrReverse> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
 <srcCopy>. 
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), operation (glossary),
 Windows (glossary), bit (glossary), transfer mode (glossary),

--- a/docs/dictionary/keyword/srcXOr.lcdoc
+++ b/docs/dictionary/keyword/srcXOr.lcdoc
@@ -18,8 +18,8 @@ Example:
 set the ink of field "Meld" of group 1 to srcXOr
 
 The result:
-Each component of the resulting color is equal to the result of this
-expression:. 
+Each component of the resulting color rgb value is equal to the 
+result of this expression. 
 
 Description:
 Use the <srcXOr> <keyword> to combine an object's colors with the color
@@ -33,17 +33,25 @@ When the <srcXOr> <transfer mode> is used, LiveCode performs a <bitXOr>
 operation on each component of the <object(glossary)> color with the
 corresponding component of the color under the <object(glossary)>.
 
-object component bitXOr background component
+    object component bitXOr background component
 
 For example, suppose an object's color is 45,0,255, and the color of the
 pixels under the object is 20,45,100. If the <srcXOr> <transfer mode> is
 used, the <object|object's> displayed color is 57,45,210 (the decimal
-equivalent). 
+equivalent). In <binary(glossary)> it is:
+
+    00101101, 00000000, 11111111
+    00010100, 00101101, 01100100 Logic XOR
+    ========  ========  ========
+    00111001, 00101101, 10011011
 
 The <srcXOr> mode can be used only on <Unix> and <Windows|Windows
 systems>. On <Mac OS|Mac OS systems>, <object|objects> whose <ink>
 <property> is set to this mode appear as though their <ink> were set to
-<reverse>. 
+<reverse>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),

--- a/docs/dictionary/keyword/srcXOr.lcdoc
+++ b/docs/dictionary/keyword/srcXOr.lcdoc
@@ -17,9 +17,6 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of field "Meld" of group 1 to srcXOr
 
-The result:
-Each component of the resulting color rgb value is equal to the 
-result of this expression. 
 
 Description:
 Use the <srcXOr> <keyword> to combine an object's colors with the color


### PR DESCRIPTION
Common repairs to notSrcAnd, notSrcAndReverse, notSrcOr, notSrcOrReverse, notSrcXOr, srcAnd, srcAndReverse, srcOr, srcOrReverse, srcXOr:
-  'rgb value' added to the term 'resulting color' for clarity.
- Occasionally a number bullet system displayed incorrectly. Fixed.
- Tab added to bitwise expression to make it more script like.
- 'Binary' glossary reference made and an example of the binary calculation.
- Add a line to link to a list of all other transfer modes on the transferModes glossary page
- srcOrReverse had an additional issue with the numbered bullets from the description listed in the Result table. This is moved back into the description and the common Result displayed in the other bitwise transferMode keywords.
