### PR TITLE
[[Documentation]] subOver - link to transfermodes

### DIFF
--- a/docs/dictionary/keyword/subOver.lcdoc
+++ b/docs/dictionary/keyword/subOver.lcdoc
@@ -17,18 +17,17 @@ Platforms: desktop, server, mobile
 Example:
 set the ink of last card button to subOver
 
-The result:
+Description:
+Use the <subOver> <keyword> to combine an <object|object's> color with
+the colors underneath it.
+
 The <ink> <property> determines how an <object|object's> colors combine
 with the colors of the <pixels> underneath the <object(glossary)> to
 determine how the <object|object's> color is displayed. When the addOver
 mode is used, each component of the color underneath the
-<object(glossary)> is subtracted from the corresponding component--red,
-green, and blue--of the <object(glossary)> color. If the result is less
+<object(glossary)> is subtracted from the corresponding component - red,
+green, and blue - of the <object(glossary)> color. If the result is less
 than zero, the component rolls over backward, back to 255.
-
-Description:
-Use the <subOver> <keyword> to combine an <object|object's> color with
-the colors underneath it.
 
 For example, suppose an object's color is 25,250,150, and the color of
 the pixels under the object is 60,40,100. If the <subOver> mode is used,

--- a/docs/dictionary/keyword/subOver.lcdoc
+++ b/docs/dictionary/keyword/subOver.lcdoc
@@ -32,12 +32,18 @@ the colors underneath it.
 
 For example, suppose an object's color is 25,250,150, and the color of
 the pixels under the object is 60,40,100. If the <subOver> mode is used,
-the <object|object's> displayed color is 220,210,50.
+the <object|object's> displayed color is 220,210,50. This is because 
+25 - 60 in the red component is -35. This is then subtracted from 255 to
+produce a value of 220. Neither the green or blue components need to 
+roll back from 255.
 
 The <subOver> mode can be used only on <Mac OS|Mac OS systems>. On
 <Unix> and <Windows|Windows systems>, <object|objects> whose <ink>
 <property> is set to this mode appears as though their <ink> were set to
-<srcCopy>. 
+<srcCopy>.
+
+A list of all <transfer mode|transfer modes> can be found in the
+<transfer mode> glossary page for easy reference.
 
 References: object (glossary), property (glossary), keyword (glossary),
 Unix (glossary), Windows (glossary), Mac OS (glossary),


### PR DESCRIPTION
- Explanation of how the values are calculated
- Add a line to link to a list of all other transfer modes on the transferModes glossary page
