### PR TITLE
[[Dictionary]] gRevProfileReadOnly - Description repair

### DIFF
--- a/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
+++ b/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
@@ -42,11 +42,7 @@ The <gRevProfileReadOnly> <global|global variable> can also be changed
 in the Preferences dialog box:
 
 1. Choose LiveCode → Preferences from the menubar.
-
-
 2. Choose "Property Profiles" from the menu at the top.
-
-
 3. Click "Don't save changes in profile".
 
 


### PR DESCRIPTION
Removed line space to make number bullets appear correctly
