### PR TITLE
[[Documentation]] keyword/long - detailed|long

### DIFF
--- a/docs/dictionary/function/date.lcdoc
+++ b/docs/dictionary/function/date.lcdoc
@@ -44,7 +44,7 @@ The abbreviated date form returns the first three letters of the day of
 the week, a comma, the first three letters of the month, a space, the
 day of the month, a comma, and the year.
 
-The long date form returns the day of the week, a comma, the name of the
+The <long> date form returns the day of the week, a comma, the name of the
 month, a space, the day of the month, a comma, and the year.
 
 The internet date form returns the following parts, separated by spaces:

--- a/docs/dictionary/function/files.lcdoc
+++ b/docs/dictionary/function/files.lcdoc
@@ -57,8 +57,8 @@ included in the list only if they refer to a <file>.
 
 ### Short form
 
-When the <files> is called as a <function>, or without the `long` or
-`detailed` modifiers, it <return(glossary)|returns> only the <file>
+When the <files> is called as a <function>, or without the `<long>` or
+`<long|detailed>` modifiers, it <return(glossary)|returns> only the <file>
 names as a string with one file name per line.
 
 > *Note:* On some <platform|platforms>, file names are permitted to
@@ -68,8 +68,8 @@ names as a string with one file name per line.
 
 ### Long form
 
-`the long files` and `the detailed files` are synonyms.  When the
-<files> <function> is called in this form, the <return(glossary)>
+`the <long> files` and `the <long|detailed> files` are synonyms.  When 
+the <files> <function> is called in this form, the <return(glossary)>
 value is a list of files with detailed file attributes.
 
 Each line in the return value is a comma-separated list of file
@@ -99,7 +99,7 @@ used for the <umask> property.
 > *Note:* On Windows, the permissions are always reported as "777".
 
 Changes:
-The long form was introduced in version 1.1.
+The <long> form was introduced in version 1.1.
 The optional <targetFolder> argument for the function call form was
 introduced in version 8.1.
 
@@ -108,7 +108,7 @@ specialFolderPath (function), alias (glossary), current folder (glossary),
 data fork (glossary), folder (glossary), function (glossary),
 platform (glossary), return (glossary), resource fork (glossary),
 shortcut (glossary), symbolic link (glossary), defaultFolder (property),
-umask (property)
+umask (property), long (keyword)
 
 Tags: file system
 

--- a/docs/dictionary/function/files.lcdoc
+++ b/docs/dictionary/function/files.lcdoc
@@ -30,9 +30,14 @@ answer merge("The files in the current folder use" && \
       "[[tTotalSize]] bytes")
 
 Example:
+local tDiskContents
 put the files & return & the folders into \
-      diskContents[the defaultFolder]
-filter diskContents[the defaultFolder] without ".."
+      tDiskContents["the defaultFolder"]
+filter tDiskContents["the defaultFolder"] without ".."
+
+Parameters:
+targetFolder (String):
+The folder path to search.
 
 Returns (String):
 A list of file names or file information, with one

--- a/docs/dictionary/function/folders.lcdoc
+++ b/docs/dictionary/function/folders.lcdoc
@@ -62,8 +62,8 @@ included in the list only if they refer to a <folder>.
 
 ### Short form
 
-When the <folders> is called as a <function>, or without the `long` or
-`detailed` modifiers, it <return(glossary)|returns> only the <folder>
+When the <folders> is called as a <function>, or without the `<long>` or
+`<long|detailed>` modifiers, it <return(glossary)|returns> only the <folder>
 names as a string with one file name per line.
 
 > *Note:* On some <platform|platforms>, folder names are permitted to
@@ -73,8 +73,8 @@ names as a string with one file name per line.
 
 ### Long form
 
-`the long folders` and `the detailed folders` are synonyms.  When the
-<folders> <function> is called in this form, the <return(glossary)>
+`the <long> folders` and `the <long|detailed> folders` are synonyms.  When 
+the <folders> <function> is called in this form, the <return(glossary)>
 value is a list of folders with detailed file attributes.  Several of
 the attributes are provided only for compatibility with the <files>
 <function> and do not have any meaning for a <folder>.
@@ -107,7 +107,7 @@ used for the <umask> property.
 The creator and file type are always "????????".
 
 Changes:
-The long form was introduced in version 1.1.
+The <long> form was introduced in version 1.1.
 The optional <targetFolder> argument for the function call form was
 introduced in version 8.1.
 
@@ -116,7 +116,7 @@ specialFolderPath (function), alias (glossary), current folder (glossary),
 data fork (glossary), folder (glossary), function (glossary),
 platform (glossary), return (glossary), resource fork (glossary),
 shortcut (glossary), subfolder (glossary), symbolic link (glossary),
-defaultFolder (property), umask (property)
+defaultFolder (property), umask (property), long (keyword)
 
 Tags: file system
 

--- a/docs/dictionary/function/folders.lcdoc
+++ b/docs/dictionary/function/folders.lcdoc
@@ -24,9 +24,14 @@ filter lines of field "Available Folders" without ".."
 sort lines of field "Available Folders" international
 
 Example:
+local tDiskContents
 put the files & return & the folders into \
-      diskContents[the defaultFolder]
-filter diskContents[the defaultFolder] without ".."
+      tDiskContents["the defaultFolder"]
+filter tDiskContents["the defaultFolder"] without ".."
+
+Parameters:
+targetFolder (String):
+The folder path to search.
 
 Returns (String):
 A list of folder names or folder information, with
@@ -37,7 +42,7 @@ Description:
 <targetFolder>, with one file per line.  If no <targetFolder> is
 specified, list the files in the <current folder>.
 
-The list only includes folders at the top level of the target folder.
+The list only includes folders at the top level of the <target folder>.
 The <folders> <function> does not recursively enter and examine
 folders deeper in the filesystem.  To examine the contents of a
 <subfolder|subfolders>, either pass its path as the <targetFolder>, or

--- a/docs/dictionary/function/time.lcdoc
+++ b/docs/dictionary/function/time.lcdoc
@@ -35,7 +35,7 @@ The short time form returns the same value as the time form.
 
 The abbreviated time form returns the same value as the time form.
 
-The long time form returns the hour, minute, and second separated by
+The <long> time form returns the hour, minute, and second separated by
 colons, a space, and "AM" or "PM".
 
 Description:
@@ -53,7 +53,7 @@ systems>), or the LANG environment variable (on <Unix|Unix systems>).
 >*Note:* Linux systems don't have a short system time, so the engine
 > modifies the system time format string to remove the seconds. This
 > works in most locales, but not all and our advice is to stick to using
-> the long system time on Linux systems.
+> the <long> <system> <time> on Linux systems.
 
 Changes:
 The ability to use the time format preferred by the user was introduced

--- a/docs/dictionary/function/time.lcdoc
+++ b/docs/dictionary/function/time.lcdoc
@@ -46,7 +46,7 @@ If the twelveHourTime <property> is set to false, the value
 <return|returned> by the <time> <function> does not include "AM" or
 "PM". 
 
-The format of the system time forms is set by the Date & Time control
+The <format> of the system time forms is set by the Date & Time control
 panel (on Mac OS systems), the Date control panel (on <Windows|Windows
 systems>), or the LANG environment variable (on <Unix|Unix systems>).
 
@@ -62,7 +62,7 @@ date function, consistently used the standard U.S. format, even if the
 operating system's settings specified another language or time format.
 
 References: convert (command), function (control structure),
-ticks (function), format (function), property (glossary),
+ticks (function), property (glossary),
 Windows (glossary), Unix (glossary), format (glossary), return (glossary),
 system (keyword), english (keyword), abbreviated (keyword),
 useSystemDate (property)

--- a/docs/dictionary/keyword/long.lcdoc
+++ b/docs/dictionary/keyword/long.lcdoc
@@ -26,11 +26,11 @@ Example:
 put the long seconds
 
 Example:
-set the defaultfolder to "/"
+set the defaultFolder to "/"
 put the detailed files
 
 Example:
-set the defaultfolder to "/"
+set the defaultFolder to "/"
 put the long folders
 
 Description:
@@ -39,6 +39,9 @@ Use the <long> <keyword> to obtain a date, time, name, ID, or list of
 
 In general, a <long> form is longer than either the <short> form or the
 <abbreviated> form.
+
+When used with a <files> or <folders> <function> it has the same effect
+as using the term 'the detailed files' or 'the detailed folders'.
 
 If the useSystemDate <property> is set to false, a long <date> looks
 like this: Thursday, June 22, 2000

--- a/docs/dictionary/keyword/long.lcdoc
+++ b/docs/dictionary/keyword/long.lcdoc
@@ -34,7 +34,7 @@ set the defaultFolder to "/"
 put the long folders
 
 Description:
-Use the <long> <keyword> to obtain a date, time, name, ID, or list of
+Use the <long> <keyword> to obtain a <date>, <time>, <name>, <ID>, or list of
 <files> or <folders> with the greatest amount of available detail.
 
 In general, a <long> form is longer than either the <short> form or the
@@ -43,22 +43,22 @@ In general, a <long> form is longer than either the <short> form or the
 When used with a <files> or <folders> <function> it has the same effect
 as using the term 'the detailed files' or 'the detailed folders'.
 
-If the useSystemDate <property> is set to false, a long <date> looks
+If the <useSystemDate> <property> is set to false, a long <date> looks
 like this: Thursday, June 22, 2000
-If the useSystemDate is true, the long <date> is formatted according to
+If the <useSystemDate> is true, the long <date> is formatted according to
 the system settings.
 
-If the useSystemDate <property> is set to false, a long <time> looks
+If the <useSystemDate> <property> is set to false, a long <time> looks
 like this: 11:22:47 AM
-If the useSystemDate is true, the long <time> is formatted according to
+If the <useSystemDate> is true, the long <time> is formatted according to
 the system settings.
 
-A long object name consists of the <object type>, followed by the name
+A long object <name> consists of the <object type>, followed by the name
 in quotes, for the <object(glossary)> and its <owner> (and the <owner>
-of that <object(glossary)>, and so on). For example, a long <card> name
+of that <object(glossary)>, and so on). For example, a long <card> <name>
 looks like this: card "My Card" of stack "/Drive/Folder/Stack.rev"
 
-A long object ID looks like this:
+A long object <ID> looks like this:
 card "My Card" of stack "/Drive/Folder/Stack.rev"
 
 >*Note:*  The <long> <keyword> is implemented internally as a <property>
@@ -72,7 +72,8 @@ propertyNames (function), time (function), folders (function),
 files (function), dateFormat (function), date (function),
 keyword (glossary), property (glossary), command (glossary),
 object type (glossary), expression (glossary), object (glossary),
-card (keyword), short (keyword), abbreviated (keyword), owner (property)
+card (keyword), short (keyword), abbreviated (keyword), id (property)
+name (property), owner (property), useSystemDate (property)
 
 Tags: file system
 

--- a/docs/dictionary/keyword/long.lcdoc
+++ b/docs/dictionary/keyword/long.lcdoc
@@ -72,7 +72,7 @@ propertyNames (function), time (function), folders (function),
 files (function), dateFormat (function), date (function),
 keyword (glossary), property (glossary), command (glossary),
 object type (glossary), expression (glossary), object (glossary),
-card (keyword), short (keyword), abbreviated (keyword), id (property)
+card (keyword), short (keyword), abbreviated (keyword), ID (property)
 name (property), owner (property), useSystemDate (property)
 
 Tags: file system

--- a/docs/dictionary/property/ID.lcdoc
+++ b/docs/dictionary/property/ID.lcdoc
@@ -75,13 +75,13 @@ The abbreviated ID of an object is the object's type, followed by "id",
 followed by the object's short ID. For example, if a button's short ID
 is "27", its abbreviated ID is "button id 27".
 
-The long id of an object includes information about its owner (and about
+The <long> id of an object includes information about its owner (and about
 the <owner> of that <object(glossary)>, and so forth). For example,
 suppose a <stack> named "My Stack" contains a <card> whose ID is 11.
 This <card> has a <group> whose ID is 28, which in turn contains a
 <button> whose ID is 34. The <card> also has a <card control|card field>
 whose ID is 46. If "My Stack" is a <main stack> and it's in a <file>
-whose <file path|path> is "/Drive/Folder/Stack. rev", the long IDs of
+whose <file path|path> is "/Drive/Folder/Stack. rev", the <long> IDs of
 these <object|objects> look like this:
 
 * The stack: stack "/Drive/Folder/Stack. rev"
@@ -92,17 +92,17 @@ these <object|objects> look like this:
   "/Drive/Folder/Stack. rev" 
 * The card field: field id 46 of card id 11 of stack
   "/Drive/Folder/Stack. rev" If the stack is a substack, its <ID> is
-  included in the long <name> of each of its <object|objects>, before
+  included in the <long> <name> of each of its <object|objects>, before
   the <file path|path> of the <main stack>.
 
 
-The long ID of a group includes the <ID> of the <current card>. If the
+The <long> ID of a group includes the <ID> of the <current card>. If the
 <group> does not appear on the <current card>, requesting its <ID>
 causes an <execution error>. If you need to get the <ID> of a <group>,
 use the "<background>" terminology instead.
 
-The long ID of a background includes the <ID> of the <current card>, if
-the <background> appears on the <current card>. If not, the long <ID> of
+The <long> ID of a background includes the <ID> of the <current card>, if
+the <background> appears on the <current card>. If not, the <long> <ID> of
 the <background> includes the ID of the first <card> the <background>
 appears on.
 

--- a/docs/dictionary/property/name.lcdoc
+++ b/docs/dictionary/property/name.lcdoc
@@ -41,13 +41,13 @@ example, if a <player|player's> short name is Heaven, its abbreviated
 name is player "Heaven". If you don't specify a modifier for the <name>
 <property>, the abbreviated name is what you get.
 
-The long name of an object includes information about its <owner> (and
+The <long> name of an object includes information about its <owner> (and
 about the <owner> of that <object(object)>, and so forth). For example,
 suppose a <stack> named "My <stack>" contains a <card> named "My Card".
 This <card> has a <group> named "My Group" which contains a <button>
 named "My Button". The <card> also has a <card control|card field> named
 "My Field". If "My Stack" is a <main stack> and it's in a <file> whose
-<file path|path> is "/Drive/Folder/Stack.rev", the long names of these
+<file path|path> is "/Drive/Folder/Stack.rev", the <long> names of these
 <objects(object)> look like this:
 
 * The stack:
@@ -73,26 +73,26 @@ named "My Button". The <card> also has a <card control|card field> named
 > application|standalone applications> are stored as <application
 > bundle|application bundles>. A <application bundle|bundle> behaves
 > like a <file> but is actually a <folder>, and the <main stack> of a
-> <standalone application> is inside this <folder>. The long name of a
+> <standalone application> is inside this <folder>. The <long> name of a
 > stack in an application is the location of the application inside the
 > <application bundle|bundle>, not the <application bundle|bundle's>
 > location. For example, if the <bundle'sfile path> is
-> "/Volumes/Disk/MyApp.app/", the long name of the application's main
+> "/Volumes/Disk/MyApp.app/", the <long> name of the application's main
 > stack might be "/Volumes/Disk/MyApp.app/Contents/MacOS/MyApp".
 
-If the stack is a substack, its name is included in the long names of
+If the stack is a substack, its name is included in the <long> names of
 its objects, before the path of the main stack: stack "My Substack" of
 stack "/Drive/Folder/Stack.rev"
 
-The long <name> of a <group> includes the name of the <current card>. If
+The <long> <name> of a <group> includes the name of the <current card>. If
 the <group> does not appear on the <current card>, requesting its <name>
 results in an <execution error>. If you need to get the name of a
 <group> that is not on the <current card>, use the "<background>"
 terminology instead.
 
-The long <name> of a <background> includes the name of the <current
+The <long> <name> of a <background> includes the name of the <current
 card>, if the <background> appears on the <current card>. If not, the
-long name of the <background> includes the name of the first <card> the
+<long> name of the <background> includes the name of the first <card> the
 <background> appears on.
 
 You can use an object's <name> to refer to the <object(object)> in a


### PR DESCRIPTION
- camelCase from defaultfolder to defaultFolder
- Describe relationship between 'long' and 'detailed' with script formatting.
