### PR TITLE
[[Documentation]] maximize - title and zoombox

### DIFF
--- a/docs/dictionary/keyword/maximize.lcdoc
+++ b/docs/dictionary/keyword/maximize.lcdoc
@@ -32,7 +32,7 @@ window's <title bar>.
 References: property (glossary), title bar (glossary), keyword (glossary),
 Windows (glossary), zoom box (glossary), menu (keyword), title (keyword),
 maximize (keyword), decorations (property), systemWindow (property),
-title (property)
+zoomBox (property)
 
 Tags: windowing
 

--- a/docs/dictionary/keyword/maximize.lcdoc
+++ b/docs/dictionary/keyword/maximize.lcdoc
@@ -18,19 +18,20 @@ Example:
 set the decorations of this stack to maximize
 
 Description:
-Use the <maximize> <keyword> to turn a window's <maximize> or <zoom box>
-on or off.
+Use the <maximize> <keyword> to turn a <systemWindow|window>'s <maximize> 
+or <zoom box> on or off.
 
 Setting a stack's <decorations> <property> to <maximize> automatically
-includes <title> in the value of the <decorations>, turning on the
-window's <title bar>.
+includes 'title' in the value of the <decorations>, turning on the 
+<systemWindow|window>'s <title bar>. The name on the <title bar> can be set 
+using the <systemWindow|window>'s <label> property.
 
 >*Cross-platform note:*  On <Windows|Windows systems>, the <menu>
-> decoration must be set along with <maximize> : you cannot use
-> <maximize> without including <menu>.
+> <decorations|decoration> must be set along with <maximize> : you cannot 
+> use <maximize> without including <menu>.
 
 References: property (glossary), title bar (glossary), keyword (glossary),
-Windows (glossary), zoom box (glossary), menu (keyword), title (keyword),
+Windows (glossary), zoom box (glossary), menu (keyword), label (property),
 maximize (keyword), decorations (property), systemWindow (property),
 zoomBox (property)
 


### PR DESCRIPTION
- There doesn't seem to be a title property. However, the zoomBox property does exist.

Note: Zoom box (glossary) does not appear and is not linking to the page. I cannot see why this is as everything else seems ok.
