### PR TITLE
[[Documentation]] keyword/point - Example clarity

### DIFF
--- a/docs/dictionary/keyword/point.lcdoc
+++ b/docs/dictionary/keyword/point.lcdoc
@@ -36,11 +36,11 @@ However, the expression
 
     "22 + 3,23" is a point
 
-evaluates to false, because the double quotes prevent the expression
-"22 + 3,23" from being evaluated.
+evaluates to false, because the double quotes making it a string
+prevent the expression "22 + 3,23" from being evaluated.
 
 References: value (function), operator (glossary), keyword (glossary),
-expression (glossary), point (keyword), is a (operator),
+expression (glossary), points (property), is a (operator),
 is not a (operator)
 
 Tags: properties


### PR DESCRIPTION
- To make the example clearer, added the term “making it a string”
- removed reference to self and added points property in references
