### PR TITLE
[[Documentation]] printerColon - COMn: references

### DIFF
--- a/docs/dictionary/keyword/printercolon.lcdoc
+++ b/docs/dictionary/keyword/printercolon.lcdoc
@@ -31,14 +31,14 @@ To write data to the printer port, use the <write to file> <command>.
 
 To use the modem port on Mac OS systems, use the 'modem:' <keyword>.
 (LiveCode does not support additional serial <port|ports>.) To use
-serial <port|ports> on <Windows|Windows systems>, use the <COMnColon|COM1:>
-through <COMnColon|COM9:> <keyword|keywords>.
+serial <port|ports> on <Windows|Windows systems>, use the <COMn:|COM1:>
+through <COMn:|COM9:> <keyword|keywords>.
 
 References: write to file (command), close file (command),
 open file (command), write to driver (command), read from file (command),
 property (glossary), keyword (glossary), Windows (glossary),
 command (glossary), Mac OS (glossary), port (glossary), 
-<COMnColon|COMn:> (keyword), serialControlString (property)
+COMn: (keyword), serialControlString (property)
 
 Tags: networking
 

--- a/docs/dictionary/keyword/printercolon.lcdoc
+++ b/docs/dictionary/keyword/printercolon.lcdoc
@@ -37,8 +37,8 @@ through <COMn:|COM9:> <keyword|keywords>.
 References: write to file (command), close file (command),
 open file (command), write to driver (command), read from file (command),
 property (glossary), keyword (glossary), Windows (glossary),
-command (glossary), Mac OS (glossary), port (glossary), 
-COMn: (keyword), serialControlString (property)
+command (glossary), Mac OS (glossary),   port (glossary), 
+serialControlString (property), COMn: (keyword)
 
 Tags: networking
 

--- a/docs/dictionary/keyword/printercolon.lcdoc
+++ b/docs/dictionary/keyword/printercolon.lcdoc
@@ -21,24 +21,24 @@ Use the <printer:> <keyword> to communicate through the printer serial
 <port>. 
 
 To set the port parameters (such as baud rate, handshaking, and parity),
-set the serialControlString <property> before opening the <port> with
+<set> the <serialControlString> <property> before opening the <port> with
 the <open file> <command>.
 
-To read data from the printer port, use the <read from file> <command>,
-specifying the keyword printer: as the file to read from.
+To read data from the printer <port>, use the <read from file> <command>,
+specifying the <keyword> 'printer:' as the file to read from.
 
 To write data to the printer port, use the <write to file> <command>.
 
-To use the modem port on Mac OS systems, use the modem: <keyword>.
+To use the modem port on Mac OS systems, use the 'modem:' <keyword>.
 (LiveCode does not support additional serial <port|ports>.) To use
-serial <port|ports> on <Windows|Windows systems>, use the <COM1:>
-through <COM9:> <keyword|keywords>.
+serial <port|ports> on <Windows|Windows systems>, use the <COMnColon|COM1:>
+through <COMnColon|COM9:> <keyword|keywords>.
 
 References: write to file (command), close file (command),
 open file (command), write to driver (command), read from file (command),
 property (glossary), keyword (glossary), Windows (glossary),
-command (glossary), Mac OS (glossary), port (glossary), COM1: (keyword),
-COM9: (keyword)
+command (glossary), Mac OS (glossary), port (glossary), 
+<COMnColon|COMn:> (keyword), serialControlString (property)
 
 Tags: networking
 


### PR DESCRIPTION
- Added an alias to the COM1: and COM9: keyword display in the description
- Replaced COM1: with COMncolon to link to the keyword dictionary item correctly
- Add links to serialControlString property
