### PR TITLE
[Valgrind] Buffer overflow fixes for 8.1.1 release branch

### DIFF
--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -417,9 +417,10 @@ Boolean MCDispatch::openenv(MCStringRef sname, MCStringRef env,
 
 IO_stat readheader(IO_handle& stream, uint32_t& r_version)
 {
-	char tnewheader[kMCStackFileVersionStringLength];
+	char tnewheader[kMCStackFileVersionStringLength + 1];
 	if (IO_read(tnewheader, kMCStackFileVersionStringLength, stream) != IO_NORMAL)
 		return IO_ERROR;
+	tnewheader[kMCStackFileVersionStringLength] = '\0'; /* nul-terminate */
 	
 	// AL-2014-10-27: [[ Bug 12558 ]] Check for valid header prefix
 	if (!MCStackFileParseVersionNumber(tnewheader, r_version))

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -2239,7 +2239,7 @@ bool MCUnicodeWildcardMatch(const void *source_chars, uindex_t source_length, bo
     
     codepoint_t t_source_cp, t_pattern_cp;
     
-    while (t_source_filter -> HasData())
+    while (t_source_filter -> HasData() && t_pattern_filter -> HasData())
     {
         t_source_cp = t_source_filter -> GetNextCodepoint();
         t_pattern_cp = t_pattern_filter -> GetNextCodepoint();


### PR DESCRIPTION
This resolves two issues on Linux where the engine tries to read beyond the end of a buffer in some situations.
