### PR TITLE
Insert some explicit casts to solve macosx10.10 SDK issues

### DIFF
--- a/docs/notes/bugfix-16211.md
+++ b/docs/notes/bugfix-16211.md
@@ -1,0 +1,2 @@
+# Fix compilation errors with MacOSX SDK 10.10 and higher
+

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -233,7 +233,7 @@ enum
 
 static OSErr preDispatchAppleEvent(const AppleEvent *p_event, AppleEvent *p_reply, SRefCon p_context)
 {
-    return [[NSApp delegate] preDispatchAppleEvent: p_event withReply: p_reply];
+    return [(MCApplicationDelegate*)[NSApp delegate] preDispatchAppleEvent: p_event withReply: p_reply];
 }
 
 - (OSErr)preDispatchAppleEvent: (const AppleEvent *)p_event withReply: (AppleEvent *)p_reply

--- a/revbrowser/src/osxbrowser.mm
+++ b/revbrowser/src/osxbrowser.mm
@@ -176,7 +176,7 @@ static NSRect RectToNSRect(NSWindow *p_window, Rect p_rect)
 	
 	id myDocument = [[NSDocumentController sharedDocumentController] openUntitledDocumentOfType:@"DocumentType" display:YES];
     [[[myDocument webView] mainFrame] loadRequest:request];
-    return [myDocument webView];
+    return (WebView*)[myDocument webView];
 }
 
 - (void)webViewShow:(WebView *)sender


### PR DESCRIPTION
Because the contents of various headers have changed, we need to be
more explicit about casts because the compiler's automagic deduction
is no longer working for these particular cases.
