### PR TITLE
[[Docs]] seventh - use variable convention

### DIFF
--- a/docs/dictionary/keyword/seventh.lcdoc
+++ b/docs/dictionary/keyword/seventh.lcdoc
@@ -14,7 +14,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-set the textFont of seventh button to nextFont
+set the textFont of seventh button to tNextFont
 
 Example:
 put "Hello!" into seventh line of field "Greetings"


### PR DESCRIPTION
- nextFont changed to tNextFont to avoid it getting confused with a keyword or constant and follow naming conventions
