### PR TITLE
[[Doc]] tenth - Use variable conventions

### DIFF
--- a/docs/dictionary/keyword/tenth.lcdoc
+++ b/docs/dictionary/keyword/tenth.lcdoc
@@ -17,7 +17,7 @@ Example:
 put the ID of tenth card into myID
 
 Example:
-multiply the tenth word of currentAmounts by ten
+multiply the tenth word of tCurrentAmounts by ten
 
 Description:
 Use the <tenth> <keyword> in an <object reference> or <chunk


### PR DESCRIPTION
- Change currentAmounts to tCurrentAmounts to follow naming conventions and avoid misunderstanding
