### PR TITLE
[[Docs]] then - repair example formatting

### DIFF
--- a/docs/dictionary/keyword/then.lcdoc
+++ b/docs/dictionary/keyword/then.lcdoc
@@ -26,10 +26,11 @@ If you want to execute a single statement, place the <then> <keyword>
 before the <statement> on the same line, as in these examples:
 
     if 1+1 = 2 then doSomethingTrite
+    
 or
+
     if someConditionObtains()
     then performAnAction
-
 
 If you want to execute multiple statements, place the <then> <keyword>
 on the line before the list of <statement|statements>, 

--- a/docs/dictionary/keyword/then.lcdoc
+++ b/docs/dictionary/keyword/then.lcdoc
@@ -26,20 +26,18 @@ If you want to execute a single statement, place the <then> <keyword>
 before the <statement> on the same line, as in these examples:
 
     if 1+1 = 2 then doSomethingTrite
-
-
+or
     if someConditionObtains()
     then performAnAction
 
 
 If you want to execute multiple statements, place the <then> <keyword>
-on the line before the list of <statement|statements>, as in this
-example: 
+on the line before the list of <statement|statements>, 
+as in this example: 
 
     if the backgroundColor of this stack is white then
-    doFirstAction
-    doAnotherAction
-
+        doFirstAction
+        doAnotherAction
     end if
 
 


### PR DESCRIPTION
- The last example was not displaying correctly due to a misplaced 'example:' which was confused with a display tag.
- The first two examples in the description needed splitting. At the moment this can only be done using un-tabbed text
