### PR TITLE
[[Docs]] third - use variable convention

### DIFF
--- a/docs/dictionary/keyword/third.lcdoc
+++ b/docs/dictionary/keyword/third.lcdoc
@@ -17,7 +17,7 @@ Example:
 set the hilite of the third button to true
 
 Example:
-repeat until third line of keysPressed is "Control"
+repeat until third line of tKeysPressed is "Control"
 
 Description:
 Use the <third> <keyword> in an <object reference> or <chunk


### PR DESCRIPTION
- keysPressed replaced with tKeysPressed to avoid confusion with keywords and follows naming conventions
