### PR TITLE
[[Docs]] to - use variable naming convention

### DIFF
--- a/docs/dictionary/keyword/to.lcdoc
+++ b/docs/dictionary/keyword/to.lcdoc
@@ -15,10 +15,10 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-drag button 5 from myFirstPoint to mySecondPoint with shiftKey
+drag button 5 from tFirstPoint to tSecondPoint with shiftKey
 
 Example:
-copy myButton to this card
+copy tMyButton to this card
 
 Example:
 seek to 102 in file "/usr/bin/supfiles/man"

--- a/docs/dictionary/keyword/to.lcdoc
+++ b/docs/dictionary/keyword/to.lcdoc
@@ -15,7 +15,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-drag button 5 from firstPoint to secondPoint with shiftKey
+drag button 5 from myFirstPoint to mySecondPoint with shiftKey
 
 Example:
 copy myButton to this card
@@ -24,7 +24,7 @@ Example:
 seek to 102 in file "/usr/bin/supfiles/man"
 
 Example:
-set the isRaining of me to true
+set the cIsRaining of me to true
 
 Description:
 Use the <to> <keyword> to complete a <command> that requires it.


### PR DESCRIPTION
- firstPoint and secondPoint changed to myFirstPoint and mySecondPoint to make it clearer they are variables
- isRaining changed to cIsRaining to follow custom property naming convention
