### PR TITLE
[[Docs]] until - use variable convention

### DIFF
--- a/docs/dictionary/keyword/until.lcdoc
+++ b/docs/dictionary/keyword/until.lcdoc
@@ -15,7 +15,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-repeat until the seconds &gt;= timeToStop
+repeat until the seconds &gt;= tTimeToStop
 
 Description:
 Use the <until> <keyword> to repeat a sequence of <statement|statements>


### PR DESCRIPTION
- timeToStop changed to tTimeToStop to follow naming conventions
