### PR TITLE
[[Docs]] constant/backslash - remove old tag

### DIFF
--- a/docs/dictionary/constant/backslash.lcdoc
+++ b/docs/dictionary/constant/backslash.lcdoc
@@ -17,8 +17,7 @@ Example:
 put theDrive & backslash & theNode into windowsStylePath
 
 Description:
-Use the <backslash> <constant> as an easier-to-read replacement for "\"
-<a/>. 
+Use the <backslash> <constant> as an easier-to-read replacement for "\". 
 
 References: constant (command), slash (constant), character (keyword)
 


### PR DESCRIPTION
- An &lt;a/&gt; tag had been left hanging around. Now removed
