### PR TITLE
[[Docs]] backslash - residual End tag

### DIFF
--- a/docs/dictionary/constant/colon.lcdoc
+++ b/docs/dictionary/constant/colon.lcdoc
@@ -17,7 +17,7 @@ Example:
 replace slash with colon in tPath
 
 Description:
-Use the <colon> <constant> as an easier-to-read replacement for ":"<a/>.
+Use the <colon> <constant> as an easier-to-read replacement for ":"
 
 References: constant (command), character (keyword),
 itemDelimiter (property)


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
