### PR TITLE
[[Docs]] comma - residual End tag

### DIFF
--- a/docs/dictionary/constant/comma.lcdoc
+++ b/docs/dictionary/constant/comma.lcdoc
@@ -14,13 +14,13 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-put "3" & comma & "287" into dollarAmount
+put "3" & comma & "287" into tDollarAmount
 
 Example:
 if char 3 of it is comma then get field "Circus"
 
 Description:
-Use the <comma> <constant> as an easier-to-read replacement for ","<a/>.
+Use the <comma> <constant> as an easier-to-read replacement for ",".
 
 References: constant (command), character (keyword),  (operator),
 itemDelimiter (property)


### PR DESCRIPTION
- An &lt;a/&gt; tag had been left hanging around. Now removed
- replaced dollarAmount with the variable convention friendly tDollarAmount
