### PR TITLE
[[Docs]] eight - residual End tag

### DIFF
--- a/docs/dictionary/constant/eight.lcdoc
+++ b/docs/dictionary/constant/eight.lcdoc
@@ -17,8 +17,7 @@ Example:
 set the bottomMargin of the target to eight
 
 Description:
-Use the <eight> <constant> when it is easier to read than the numeral
-8<a/>. 
+Use the <eight> <constant> when it is easier to read than the numeral 8. 
 
 References: constant (command), hand (constant), eighth (keyword)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
