### PR TITLE
[[Docs]] five - residual End tag

### DIFF
--- a/docs/dictionary/constant/five.lcdoc
+++ b/docs/dictionary/constant/five.lcdoc
@@ -17,8 +17,7 @@ Example:
 multiply field "Raw Score" by five
 
 Description:
-Use the <five> <constant> when it is easier to read than the numeral
-5<a/>. 
+Use the <five> <constant> when it is easier to read than the numeral 5. 
 
 References: constant (command), fifth (keyword)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
