### PR TITLE
[[Docs]] four - residual End tag

### DIFF
--- a/docs/dictionary/constant/four.lcdoc
+++ b/docs/dictionary/constant/four.lcdoc
@@ -18,7 +18,7 @@ divide quarterlyRevenue by four -- same as "...by 4"
 
 Description:
 Use the <four> <constant> when it is easier to read in a <handler> than
-the numeral 4<a/>.
+the numeral 4.
 
 References: constant (command), handler (glossary), fourth (keyword)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
