### PR TITLE
[[Docs]] nine - residual End tag

### DIFF
--- a/docs/dictionary/constant/nine.lcdoc
+++ b/docs/dictionary/constant/nine.lcdoc
@@ -17,8 +17,8 @@ Example:
 if offset(it,pathName) &gt; nine then put true into longFldr
 
 Description:
-Use the <nine> <constant> when it is easier to read than the numeral
-9<a/>. 
+Use the <nine> <constant> when it is easier to read than 
+the numeral 9. 
 
 References: constant (command), iBeam (constant)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
