### PR TITLE
[[Docs]] zero - residual End tag

### DIFF
--- a/docs/dictionary/constant/zero.lcdoc
+++ b/docs/dictionary/constant/zero.lcdoc
@@ -19,8 +19,7 @@ Example:
 if the number of fields is zero then beep
 
 Description:
-Use the <zero> <constant> when it is easier to read than the numeral
-0<a/>. 
+Use the <zero> <constant> when it is easier to read than the numeral 0. 
 
 References: constant (command)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
