### PR TITLE
[[Docs]] three - residual End tag

### DIFF
--- a/docs/dictionary/constant/three.lcdoc
+++ b/docs/dictionary/constant/three.lcdoc
@@ -17,8 +17,7 @@ Example:
 repeat three times -- same as "repeat 3 times"
 
 Description:
-Use the <three> <constant> when it is easier to read than the numeral
-3<a/>. 
+Use the <three> <constant> when it is easier to read than the numeral 3. 
 
 References: constant (command), third (keyword)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
