### PR TITLE
[[Docs]] backslash - residual End tag

### DIFF
--- a/docs/dictionary/constant/ten.lcdoc
+++ b/docs/dictionary/constant/ten.lcdoc
@@ -17,8 +17,7 @@ Example:
 if ten is in field "Score" then beep
 
 Description:
-Use the <ten> <constant> when it is easier to read than the number
-10<a/>. 
+Use the <ten> <constant> when it is easier to read than the number 10. 
 
 References: constant (command), tenth (keyword)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
