### PR TITLE
[[Docs]] six - residual End tag

### DIFF
--- a/docs/dictionary/constant/six.lcdoc
+++ b/docs/dictionary/constant/six.lcdoc
@@ -17,8 +17,7 @@ Example:
 beep six -- same as "beep 6"
 
 Description:
-Use the <six> <constant> when it is easier to read than the numeral
-6<a/>. 
+Use the <six> <constant> when it is easier to read than the numeral 6. 
 
 References: constant (command), busy (constant), sixth (keyword)
 


### PR DESCRIPTION
An &lt;a/&gt; tag had been left hanging around. Now removed
