### PR TITLE
[[Docs]] seven - residual End tag

### DIFF
--- a/docs/dictionary/constant/seven.lcdoc
+++ b/docs/dictionary/constant/seven.lcdoc
@@ -17,8 +17,7 @@ Example:
 subtract seven from dayOfWeek
 
 Description:
-Use the <seven> <constant> when it is easier to read than the numeral
-7<a/>. 
+Use the <seven> <constant> when it is easier to read than the numeral 7. 
 
 References: constant (command), cross (constant), seventh (keyword)
 

--- a/docs/dictionary/constant/seven.lcdoc
+++ b/docs/dictionary/constant/seven.lcdoc
@@ -14,7 +14,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-subtract seven from dayOfWeek
+subtract seven from tDayOfWeek
 
 Description:
 Use the <seven> <constant> when it is easier to read than the numeral 7. 


### PR DESCRIPTION
- An &lt;a/&gt; tag had been left hanging around. Now removed
- Variable dayOfWeek changed to tDayOfWeek to meet naming conventions
