### PR TITLE
[[ Documentation ]] Fixes to ampersandampersand.lcdoc

### DIFF
--- a/docs/dictionary/operator/ampersandampersand.lcdoc
+++ b/docs/dictionary/operator/ampersandampersand.lcdoc
@@ -5,12 +5,12 @@ Type: operator
 Syntax: <string1> && <string2>
 
 Summary:
-<concatenate|Concatenates> two <string|strings> and inserts a space
-between them.
+<concatenate|Concatenates> two <string|strings> and inserts a 
+<space> between them.
 
 Introduced: 1.0
 
-OS: mac, windows, linux, ios, android
+OS: mac, windows, linux, ios, android, html5
 
 Platforms: desktop, server, mobile
 
@@ -21,27 +21,30 @@ Example:
 put field "First" && field "Last" into field "Name"
 
 Example:
-find it && "Card"
+ask "Enter a name for this card."
+set the name of this card to it && "Card"
 
 Parameters:
 string1 (string):
-And <string2> are <literal string|literal strings> of characters
-(<delimit|delimited> with <double quote|double quotes>), or
-<expression|expressions> that <evaluate> to <string|strings>.
+A <literal string> of <character|characters> (<delimit|delimited> with 
+<double quote|double quotes>), or <expression|expressions> that evaluate 
+to <string|strings>. 
 
 string2 (string):
-
-
-The result:
-The result of the  <operator> is a <string(keyword)> consisting of
-<string1>, a space, and <string2>.
+A <literal string> of <character|characters> (<delimit|delimited> with 
+<double quote|double quotes>), or <expression|expressions> that evaluate 
+to <string|strings>. 
 
 Description:
 Use the && <operator> to combine two <string(glossary)|strings> with a
-space between them, for example, to combine two words or phrases.
+<space> between them, for example, to combine two words or phrases. That is, 
+<string1> && <string2> results in a <string(keyword)> consisting of
+<string1>, a <space>, and <string2>.
 
-References: split (command), string (glossary), concatenate (glossary),
-operator (glossary), \ (keyword), string (keyword)
+References: ask (command), character (glossary), concatenate (glossary), 
+delimit (glossary), double quote (glossary), evaluate (glossary), 
+expression (glossary), it (keyword), literal string (glossary), 
+operator (glossary), set (command), space (constant), string (glossary)
 
 Tags: text processing
 


### PR DESCRIPTION
- Added html5 as OS.
- Improved example.
- Removed The result element; && does  not set the result.
- Clarified Description.
- Fixed references and links.
