### PR TITLE
Ensure MCAutoStringRefAsLPWSTR is initialised

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -399,7 +399,12 @@ typedef MCAutoStringRefAsUTF16String MCAutoStringRefAsLPCWSTR;
 class MCAutoStringRefAsLPWSTR
 {
 public:
-	MCAutoStringRefAsLPWSTR() {}
+	MCAutoStringRefAsLPWSTR() :
+	  m_buffer(nil),
+	  m_size(0)
+	{
+	}
+
 	~MCAutoStringRefAsLPWSTR()
 	{
 		Unlock();


### PR DESCRIPTION
The constructor didn't initialise any of the members leading to
assertion failures in debug mode on Windows.
