### PR TITLE
[Bug 18542] Add usage description when accessing privacy-sensitive data

### DIFF
--- a/docs/notes/bugfix-18542.md
+++ b/docs/notes/bugfix-18542.md
@@ -1,0 +1,1 @@
+# Fix crash on iOS 10 when the app tried to access privacy-sensitive data

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -106,5 +106,19 @@
 	<array>
 		${CUSTOM_FONTS}
 	</array>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>This application requires access to Bluetooth</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>This application requires access to the device's calendar</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This application requires access to the device's camera</string>
+	<key>NSContactsUsageDescription</key>
+	<string>This application requires access to your Contacts</string>
+	<key>NSMicrophoneUsageDescription </key>
+	<string>This application requires access to the device's microphone</string>
+	<key>NSMotionUsageDescription</key>
+	<string>This application requires access to the device's accelerometer</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This application requires access to Photo Library</string>
 </dict>
 </plist>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -79,5 +79,19 @@
 	<array>
 		${CUSTOM_FONTS}
 	</array>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>This application requires access to Bluetooth</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>This application requires access to the device's calendar</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This application requires access to the device's camera</string>
+	<key>NSContactsUsageDescription</key>
+	<string>This application requires access to your Contacts</string>
+	<key>NSMicrophoneUsageDescription </key>
+	<string>This application requires access to the device's microphone</string>
+	<key>NSMotionUsageDescription</key>
+	<string>This application requires access to the device's accelerometer</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This application requires access to Photo Library</string>
 </dict>
 </plist>


### PR DESCRIPTION
On iOS 10, most APIs that require requesting authorization, **additionally** require a new key value pair to describe their usage in the Info.plist file. This was the case with iOS 8 and the Location Services API (`NSLocationWhenInUseUsageDescription` or `NSLocationAlwaysUsageDescription` keys), but now the application will **crash** if the app attempts authorization without these keys set. 

This is a quick fix. In the future we could add facilities in the S/B to allow users to enter localized usage description.
