### PR TITLE
[Bug 6506] Fix regression to global watched variables

### DIFF
--- a/docs/notes/bugfix-6506.md
+++ b/docs/notes/bugfix-6506.md
@@ -1,0 +1,1 @@
+# Fix regression to watching global variables

--- a/tests/lcs/core/engine/debugger.livecodescript
+++ b/tests/lcs/core/engine/debugger.livecodescript
@@ -1,0 +1,37 @@
+﻿script "CoreEngineDebugger"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestWatchedVariables
+   TestAssert "watchedVariables initially empty", the watchedVariables is empty
+   
+   local tWatches
+   put ",,someVar,someVar is true" into tWatches
+   set the watchedVariables to tWatches
+   TestAssert "watchedVariables global round trips", the watchedVariables is tWatches
+   
+   set the watchedVariables to empty
+   TestAssert "watchedVariables clears", the watchedVariables is empty
+   
+   put the long id of me,",someVar,someVar is true" into tWatches
+   set the watchedVariables to tWatches
+   TestAssert "watchedVariables script local round trips", the watchedVariables is tWatches
+   
+   put the long id of me,"someHandler,someVar,someVar is true" into tWatches
+   set the watchedVariables to tWatches
+   TestAssert "watchedVariables handler local round trips", the watchedVariables is tWatches
+end TestWatchedVariables

--- a/tests/lcs/core/interface/interfaceui.livecodescript
+++ b/tests/lcs/core/interface/interfaceui.livecodescript
@@ -182,7 +182,9 @@ if the platform is "win32" then
 else if the platform is "MacOS" then 
 	TestAssert "test", the screenname is "local Mac"  
 else if the platform is "Linux" then
-	TestAssert "test", the screenname is ":0.0" or the screenname is ":0"
+	local tScreenMajor, tScreenMinor
+	TestAssert "screenname is well-formed X11 display ID", \
+			matchText(the screenname, ":[0-9]+(?:\.[0-9]+)?")
 end if
 
 end TestInterface44


### PR DESCRIPTION
Not sure about milestone for this as it should probably be 8.2 given the new version numbering scheme.
