### PR TITLE
[Bug] Ensure database connections are released during quit

### DIFF
--- a/revdb/src/revdb.cpp
+++ b/revdb/src/revdb.cpp
@@ -404,11 +404,8 @@ void REVDB_QUIT()
 				break;
 			}
 		}
-		if (databaserec && databaserec ->releaseconnectionptr)
-        {
+		if (databaserec != NULL && databaserec ->releaseconnectionptr != NULL)
 			(*databaserec->releaseconnectionptr)(tconnection);
-            break;
-        }
 	}
 	connlist->clear();
 	DATABASERECList::iterator theIterator2;


### PR DESCRIPTION
A previous patch missidentified an errant `break;` as being in the
wrong condition when infact it should not have been there at all.
It was causing only a single connection to be released rather than
all.

This patch ensures that for each connection we iterate all databases
to find the associated database and call their `releaseconnectionptr`
