### PR TITLE
[[Docs]] Keyword lcdoc's description and syntax

### DIFF
--- a/docs/dictionary/keyword/colorPalette.lcdoc
+++ b/docs/dictionary/keyword/colorPalette.lcdoc
@@ -13,6 +13,9 @@ OS: mac, windows, linux
 
 Platforms: desktop, server
 
-References: reserved word (glossary), colors (property),
-backgroundColor (property), foregroundColor (property)
+Description:
+The <color palette|colorPalette> <keyword> is <reserved word|reserved> for internal use only.
+
+References: reserved word (glossary), colors (property), keyword (glossary),
+backgroundColor (property), foregroundColor (property), color palette (glossary)
 

--- a/docs/dictionary/keyword/magnifier.lcdoc
+++ b/docs/dictionary/keyword/magnifier.lcdoc
@@ -13,5 +13,8 @@ OS: mac, windows, linux
 
 Platforms: desktop, server
 
-References: reserved word (glossary), magnify (property)
+Description:
+The <magnifier> <keyword> is <reserved word|reserved> for internal use only
+
+References: reserved word (glossary), magnify (property), keyword (glossary)
 

--- a/docs/dictionary/keyword/of.lcdoc
+++ b/docs/dictionary/keyword/of.lcdoc
@@ -24,8 +24,13 @@ get the length of thisDate
 Example:
 put word 12 of it after field "Go On"
 
+Description:
+The <of> <keyword> is used to provide a connection between 
+the <property> <of> an <object (glossary)>, a <parameter> <of> 
+a <function>, or the <chunk expression> <of> a <string>
+
 References: function (control structure), object (glossary),
-property (glossary), custom function (glossary),
+property (glossary), custom function (glossary), keyword (glossary),
 chunk expression (glossary), global (glossary), chunk (glossary),
 keyword (glossary), expression (glossary), parameter (glossary),
 function (glossary), object reference (glossary), string (keyword),

--- a/docs/dictionary/keyword/private.lcdoc
+++ b/docs/dictionary/keyword/private.lcdoc
@@ -2,7 +2,7 @@ Name: private
 
 Type: keyword
 
-Syntax: private (command|function) <handlerName> <parameterList>
+Syntax: private {command|function} <handlerName> <parameterList>
 
 Summary:
 The <private> keyword makes a function or command local to the script in

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -25,8 +25,6 @@ Description:
 Handle the <exitField> message if you want to do something when the user
 leaves a field that hasn't been changed.
 
-&nbsp;
-
 The selection is removed from a field (and the field loses focus) when
 another window is brought to the front, when the user clicks in another
 field, or when the user tabs out of the field. The field also loses
@@ -34,12 +32,8 @@ focus when the <select> <command> is used to select text in another field.
 However, the <exitField> message is not sent when the user clicks
 another point in the same field.
 
-&nbsp;
-
 The <exitField> message is sent to buttons whose <menuMode> is
 "comboBox", since the type-in box in a combo box behaves like a field.
-
-&nbsp;
 
 The <exitField> message is sent only if the field's contents have not
 changed since the last time it received the <openField>. If a
@@ -47,8 +41,6 @@ field is closing and its contents have changed, the <closeField>
 is sent instead of <exitField>. This means that if you want to take an
 action when the selection is removed from a field--whether the field has
 changed or not--you must handle both <closeField> and <exitField>.
-
-&nbsp;
 
 >*Note:* If the field's contents were changed by script using the <put
 > command>, then exitField will still be sent. <closeField> is only sent

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -30,7 +30,7 @@ leaves a field that hasn't been changed.
 The selection is removed from a field (and the field loses focus) when
 another window is brought to the front, when the user clicks in another
 field, or when the user tabs out of the field. The field also loses
-focus when the <select command> is used to select text in another field.
+focus when the <select> <command> is used to select text in another field.
 However, the <exitField> message is not sent when the user clicks
 another point in the same field.
 
@@ -54,7 +54,7 @@ changed or not--you must handle both <closeField> and <exitField>.
 > command>, then exitField will still be sent. <closeField> is only sent
 > when the contents are changed by the user.
 
-References: put command (command), select command (command),
+References: put (command), select (command),
 openField (message), closeField message (message),
 openField message (message), closeField (message), focusOut (message),
 menuMode (property)

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -42,8 +42,8 @@ The <exitField> message is sent to buttons whose <menuMode> is
 &nbsp;
 
 The <exitField> message is sent only if the field's contents have not
-changed since the last time it received the <openField message>. If a
-field is closing and its contents have changed, the <closeField message>
+changed since the last time it received the <openField>. If a
+field is closing and its contents have changed, the <closeField>
 is sent instead of <exitField>. This means that if you want to take an
 action when the selection is removed from a field--whether the field has
 changed or not--you must handle both <closeField> and <exitField>.
@@ -55,8 +55,7 @@ changed or not--you must handle both <closeField> and <exitField>.
 > when the contents are changed by the user.
 
 References: put (command), select (command),
-openField (message), closeField message (message),
-openField message (message), closeField (message), focusOut (message),
+openField (message), closeField (message), focusOut (message),
 menuMode (property)
 
 Tags: ui


### PR DESCRIPTION
This brings 4 keyword docs up to the correct standard. Three of them had no Description section and one had regular brackets instead of curly brackets in the Syntax. TravisCL should no longer bring up issues with these files. Finally, exitField had relic html tags and incorrectly set references
