### PR TITLE
[[Docs]] lcdoc syntax and param fixes

### DIFF
--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -41,7 +41,7 @@ statement.
 Description:
 Use the <if> <control structure> to <execute> a <statementList|statement> 
 (or list of <statementList|statements>) only under certain circumstances. 
-#####Form: 
+
 The <if> <control structure> always begins with the <word> if. There are four forms of the <if> <control structure>:
 
     if condition then statementList [else elseStatementList]

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -2,7 +2,7 @@ Name: if
 
 Type: control structure
 
-Syntax: if <condition> then <statement> [else <elseStatement>]
+Syntax: if <condition> then <statementList> [else <elseStatementList>]
 
 Summary:
 <execute|Executes> a list of <statement|statements> if a condition is
@@ -29,50 +29,54 @@ Parameters:
 condition (bool):
 
 
-statement:
-
-
-elseStatement:
+elseStatementList:
 
 
 statementList:
-The statementList or elseStatementList consists of one or more LiveCode
+The <statementList> or <elseStatementList> consists of one or more LiveCode
 statements, and can also include if, switch, try, or repeat control
 structures. The statement or elseStatement consists of a single LiveCode
 statement. 
 
 Description:
-Use the <if> <control structure> to <execute> a <statement> (or list of
-<statement|statements>) only under certain circumstances. Form:The <if>
+Use the <if> <control structure> to <execute> a <statementList|statement> 
+(or list of <statementList|statements>) only under certain circumstances. Form:The <if>
 <control structure> always begins with the <word> if. There are four
 forms of the <if> <control structure>:
 
-if <condition> then <statement> [else <elseStatement>]
+```
+if condition then statementList [else elseStatementList]
+```
 (This form may have a line break before the words then or else or both.)
 
-if <condition> then
-<statementList> 
+```
+if condition then
+   statementList 
 [else
-elseStatementList]
+   elseStatementList]
 end if
-
-if <condition> 
-then <statement> 
+```
+```
+if condition 
+then statement 
 [else
-elseStatementList]
+   elseStatementList]
 end if
+```
+```
+if condition then
+   statementList 
+else elseStatement
+end if
+```
 
-if <condition> then
-<statementList> 
-else <elseStatement> 
-
-If the <condition> <evaluate|evaluates> to true, the <statement> or
+If the <condition> <evaluate|evaluates> to true, the statement or
 <statementList> is <execute|executed>; if the <condition>
-<evaluate|evaluates> to false, the <statement> or <statementList> is
+<evaluate|evaluates> to false, the statement or <statementList> is
 skipped. 
 
 If the <if> <control structure> contains an <else> clause, the
-<elseStatement> or elseStatementList is <execute|executed> if the
+elseStatement or <elseStatementList> is <execute|executed> if the
 <condition> is false.
 
 If one <if> <control structure> is nested inside another, use of the
@@ -82,8 +86,8 @@ cause ambiguities in interpreting which <else> clause belongs with which
 
 The <if> <control structure> is most suitable when you want to check a
 single <condition>. If you need to check for multiple possibilities,
-doing something different for each one, use a <switch> <control
-structure> instead.
+doing something different for each one, use 
+a <switch> <control structure> instead.
 
 >*Note:* The <if> <control structure> is implemented internally as a
 > <command> and appears in the <commandNames>.

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -40,35 +40,32 @@ statement.
 
 Description:
 Use the <if> <control structure> to <execute> a <statementList|statement> 
-(or list of <statementList|statements>) only under certain circumstances. Form:The <if>
-<control structure> always begins with the <word> if. There are four
-forms of the <if> <control structure>:
+(or list of <statementList|statements>) only under certain circumstances. 
+#####Form: 
+The <if> <control structure> always begins with the <word> if. There are four forms of the <if> <control structure>:
 
-```
-if condition then statementList [else elseStatementList]
-```
-(This form may have a line break before the words then or else or both.)
+    if condition then statementList [else elseStatementList]
 
-```
-if condition then
-   statementList 
-[else
-   elseStatementList]
-end if
-```
-```
-if condition 
-then statement 
-[else
-   elseStatementList]
-end if
-```
-```
-if condition then
-   statementList 
-else elseStatement
-end if
-```
+This form may have a line break before the words `then` or `else` or both.
+
+    if condition then
+       statementList 
+    [else
+       elseStatementList]
+    end if
+    
+    -- OR
+    if condition 
+    then statement 
+    [else
+       elseStatementList]
+    end if
+
+    -- OR
+    if condition then
+       statementList 
+    else elseStatement
+    end if
 
 If the <condition> <evaluate|evaluates> to true, the statement or
 <statementList> is <execute|executed>; if the <condition>

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -6,20 +6,24 @@ Syntax:     repeat <loopForm>
       <statementList>
     end repeat
     
-Syntax:  repeat {forever | while <condition> | until <condition>} 
+Syntax:     repeat {forever | while <condition> | until <condition>} 
       <statementList> ; end repeat
 
-Syntax:  repeat [for] <number> [times]
-      <statementList> ; end repeat
+Syntax:     repeat [for] <number> [times]
+      <statementList>
+    end repeat
       
-Syntax:  repeat with <counterVariable> = <startValue> {to | down to} <endValue> [step <increment>]
-      <statementList> ; end repeat
+Syntax:     repeat with <counterVariable> = <startValue> {to | down to} <endValue> [step <increment>]
+      <statementList>
+    end repeat
 
-Syntax:  repeat for each <chunkType> <labelVariable> in <container>
-      <statementList> ; end repeat
+Syntax:     repeat for each <chunkType> <labelVariable> in <container>
+      <statementList>
+    end repeat
       
-Syntax:  repeat for each {element | key} <labelVariable> in <array>
-      <statementList> ; end repeat
+Syntax:     repeat for each {element | key} <labelVariable> in <array>
+      <statementList>
+    end repeat
 
 
 Summary:

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -228,7 +228,7 @@ in the <statementList>.
 Use one of these forms if you want to perform an action on each member
 of a set, and you need to refer to the member by number within the
 <statementList>. The following example loops through all the controls on
-the current card. The counter <variable> *x* is 1 during the first
+the current card. The *counterVariable* *x* is 1 during the first
 <iteration>, 2 during the second, and so on:
 
     repeat with x = 1 to the number of controls
@@ -237,7 +237,7 @@ the current card. The counter <variable> *x* is 1 during the first
 
 
 The following example loops backwards through a set of lines. The
-counter <variable> *myLine* is 20 during the first <iteration>, 18
+*counterVariable* *myLine* is 20 during the first <iteration>, 18
 during the second, and so on:
 
     repeat with myLine = 20 down to 1 step -2

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -2,28 +2,35 @@ Name: repeat
 
 Type: control structure
 
-Syntax:     repeat <loopForm>
-      <statementList>
-    end repeat
+Syntax:
+repeat <loopForm>
+    <statementList>
+end repeat
     
-Syntax:     repeat {forever | while <condition> | until <condition>} 
-      <statementList> ; end repeat
+Syntax:     
+repeat {forever | while <condition> | until <condition>} 
+    <statementList>
+end repeat
 
-Syntax:     repeat [for] <number> [times]
-      <statementList>
-    end repeat
+Syntax:     
+repeat [for] <number> [times]
+    <statementList>
+end repeat
       
-Syntax:     repeat with <counterVariable> = <startValue> {to | down to} <endValue> [step <increment>]
-      <statementList>
-    end repeat
+Syntax:     
+repeat with <counterVariable> = <startValue> {to | down to} <endValue> [step <increment>]
+    <statementList>
+end repeat
 
-Syntax:     repeat for each <chunkType> <labelVariable> in <container>
-      <statementList>
-    end repeat
+Syntax:     
+repeat for each <chunkType> <labelVariable> in <container>
+    <statementList>
+end repeat
       
-Syntax:     repeat for each {element | key} <labelVariable> in <array>
-      <statementList>
-    end repeat
+Syntax:     
+repeat for each {element | key} <labelVariable> in <array>
+    <statementList>
+end repeat
 
 
 Summary:
@@ -141,9 +148,8 @@ following example, the `go` command is executed at least once, since
 `the mouseClick` is not checked until after the `go` command:
 
     repeat forever
-
-    go next card
-    if the mouseClick then exit repeat -- user clicked
+        go next card
+        if the mouseClick then exit repeat -- user clicked
     end repeat
 
 
@@ -161,9 +167,8 @@ statements are executed. This example scrolls through the cards until
 the user clicks the mouse:
 
     repeat until the mouseClick
-
-    go next card
-    wait for 100 milliseconds
+        go next card
+        wait for 100 milliseconds
     end repeat
 
 
@@ -174,8 +179,7 @@ field is less than the given amount:
     put empty into field "myField"
     put 20 into tCount
     repeat while the number of characters in field "myField" < tCount
-
-    put "X" after field "myField"
+        put "X" after field "myField"
     end repeat
 
 
@@ -196,8 +200,7 @@ Use the for number times form if you want to execute the <statementList>
 a fixed number of times. The following simple example beeps three times:
 
     repeat for 3 times
-
-    beep
+        beep
     end repeat
 
 
@@ -205,8 +208,7 @@ Note that `for` and `times` are optional. For example the following is
 also valid:
 
     repeat 3
-
-    beep
+        beep
     end repeat
 
 
@@ -239,8 +241,7 @@ the current card. The counter <variable> *x* is 1 during the first
 <iteration>, 2 during the second, and so on:
 
     repeat with x = 1 to the number of controls
-
-    show control x
+        show control x
     end repeat
 
 
@@ -249,8 +250,7 @@ counter <variable> *myLine* is 20 during the first <iteration>, 18
 during the second, and so on:
 
     repeat with myLine = 20 down to 1 step -2
-
-    put myLine
+        put myLine
     end repeat
 
 
@@ -259,9 +259,8 @@ in the loop. However, doing this is not recommended, because it makes
 the loop logic difficult to follow:
 
     repeat with x = 1 to 20 -- this loop actually repeats ten times
-
-    answer x
-    add 1 to x -- not recommended
+        answer x
+        add 1 to x -- not recommended
     end repeat
 
 
@@ -281,8 +280,7 @@ example changes a return-<delimit|delimited> list to a
 comma-<delimit|delimited> list:
 
     repeat for each line thisLine in myList
-
-    put thisLine & comma after newList
+        put thisLine & comma after newList
     end repeat
     delete the last char of newList
 
@@ -297,12 +295,9 @@ each <element(glossary)> in an <array>. The following example gets only
 the multi-word entries in an <array> of phrases:
 
     repeat for each element thisIndexTerm in arrayOfTerms
-
-    if the number of words in thisIndexTerm > 1 then
-
-    put thisIndexTerm & return after multiWordTerms
-
-    end if
+        if the number of words in thisIndexTerm > 1 then
+            put thisIndexTerm & return after multiWordTerms
+        end if
     end repeat
 
 

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -3,27 +3,26 @@ Name: repeat
 Type: control structure
 
 Syntax:
--- Repeats until a condition is met:
 repeat [{forever | while <condition> | until <condition>}]
     <statementList>
 end repeat
 
--- Repeats a set number of times:
+Syntax:
 repeat [for] <number> [times]
     <statementList>
 end repeat
 
--- Repeats from one number to another as a variable: 
+Syntax: 
 repeat with <counterVariable> = <startValue> {to | down to} <endValue> [step <increment>]
     <statementList>
 end repeat
 
--- Repeats in the listed order for all chunks of the string or sequence as a variable:
+Syntax:
 repeat for each <chunkType> <labelVariable> in <container>
     <statementList>
 end repeat
 
--- Repeats for each element or key of an array as a variable:
+Syntax:
 repeat for each {element | key} <labelVariable> in <array>
     <statementList>
 end repeat

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -102,7 +102,7 @@ A numbers or an <expression|expressions> that evaluates to a number.
 increment (number):
 A numbers or an <expression|expressions> that evaluates to a number.
 
-counter:
+counterVariable:
 A legal <variable> name.
 
 labelVariable:

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -3,31 +3,27 @@ Name: repeat
 Type: control structure
 
 Syntax:
-repeat <loopForm>
-    <statementList>
-end repeat
-    
-Syntax:     
-repeat [{forever | while <condition> | until <condition>}] 
+-- Repeats until a condition is met:
+repeat [{forever | while <condition> | until <condition>}]
     <statementList>
 end repeat
 
-Syntax:     
+-- Repeats a set number of times:
 repeat [for] <number> [times]
     <statementList>
 end repeat
-      
-Syntax:     
+
+-- Repeats from one number to another as a variable: 
 repeat with <counterVariable> = <startValue> {to | down to} <endValue> [step <increment>]
     <statementList>
 end repeat
 
-Syntax:     
+-- Repeats in the listed order for all chunks of the string or sequence as a variable:
 repeat for each <chunkType> <labelVariable> in <container>
     <statementList>
 end repeat
-      
-Syntax:     
+
+-- Repeats for each element or key of an array as a variable:
 repeat for each {element | key} <labelVariable> in <array>
     <statementList>
 end repeat
@@ -69,20 +65,6 @@ repeat tCount times
 end repeat
 
 Parameters:
-loopForm:
-The <loopForm> is one of the following forms:
-
-  - `forever`
-  - `until `*`condition`*
-  - `while `*`condition`*
-  - `[for] `*`number`*` [times]`
-  - `with `*`counterVariable`*` = `*`startValue`*` {to | down to}
-    `*`endValue`*` [step `*`increment`*`]`
-  - `for each `*`chunkType`* *`labelVariable`*` in `*`container`*
-  - `for each element `*`labelVariable`*` in `*`array`*
-  - `for each key `*`labelVariable`*` in `*`array`*
-
-
 statementList:
 One or more LiveCode statements, and can also include `if`, `switch`,
 `try`, or `repeat` <control structure|control structures>.
@@ -127,13 +109,23 @@ actions for each member of a set: for example, for each <card> in a
 <stack>, or each <line> in a <variable>.
 
 ####Loop Form:
-The <repeat> <control structure> always begins with the `repeat`
-<keyword>.
-The last line of a <repeat> <control structure> is always the `end
-repeat` <keyword>.
+The loop form is one of the following forms:
+
+  - `forever`
+  - `until `*`condition`*
+  - `while `*`condition`*
+  - `[for] `*`number`*` [times]`
+  - `with `*`counterVariable`*` = `*`startValue`*` {to | down to}
+    `*`endValue`*` [step `*`increment`*`]`
+  - `for each `*`chunkType`* *`labelVariable`*` in `*`container`*
+  - `for each element `*`labelVariable`*` in `*`array`*
+  - `for each key `*`labelVariable`*` in `*`array`*
+
+The <repeat> <control structure> always begins with the `repeat` <keyword>.
+The last line of a <repeat> <control structure> is always the `end repeat` <keyword>.
 
 How many times the <statementList> is <execute|executed> depends on the
-<loopForm> you use. Here are the possible forms:
+loop form you use. Here are details of the possible forms:
 
 #####<forever|Forever> 
 The `forever` form continues repeating the statements in the

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -5,6 +5,22 @@ Type: control structure
 Syntax:     repeat <loopForm>
       <statementList>
     end repeat
+    
+Syntax:  repeat {forever | while <condition> | until <condition>} 
+      <statementList> ; end repeat
+
+Syntax:  repeat [for] <number> [times]
+      <statementList> ; end repeat
+      
+Syntax:  repeat with <counterVariable> = <startValue> {to | down to} <endValue> [step <increment>]
+      <statementList> ; end repeat
+
+Syntax:  repeat for each <chunkType> <labelVariable> in <container>
+      <statementList> ; end repeat
+      
+Syntax:  repeat for each {element | key} <labelVariable> in <array>
+      <statementList> ; end repeat
+
 
 Summary:
 <execute|Executes> a set of <statement|statements> repeatedly.

--- a/docs/dictionary/control_st/repeat.lcdoc
+++ b/docs/dictionary/control_st/repeat.lcdoc
@@ -8,7 +8,7 @@ repeat <loopForm>
 end repeat
     
 Syntax:     
-repeat {forever | while <condition> | until <condition>} 
+repeat [{forever | while <condition> | until <condition>}] 
     <statementList>
 end repeat
 

--- a/docs/dictionary/message/headingError.lcdoc
+++ b/docs/dictionary/message/headingError.lcdoc
@@ -15,5 +15,8 @@ OS: ios
 
 Platforms: mobile
 
+Description:
+This message is no longer in use and should be replaced with the new message, <trackingError>
+
 References: trackingError (message)
 

--- a/docs/dictionary/message/locationError.lcdoc
+++ b/docs/dictionary/message/locationError.lcdoc
@@ -15,5 +15,8 @@ OS: ios
 
 Platforms: desktop
 
+Description:
+This message has been deprecated and the message <trackingError> should be used in its place.
+
 References: trackingError (message)
 

--- a/docs/dictionary/message/menuPick.lcdoc
+++ b/docs/dictionary/message/menuPick.lcdoc
@@ -2,7 +2,7 @@ Name: menuPick
 
 Type: message
 
-Syntax: menuPick <chosenItem> {| <submenuName>}, <previousTab>
+Syntax: menuPick <chosenItem>, [<previousTab>]
 
 Summary:
 Sent to a <button(object)> when a <menu item> is chosen from the <menu>
@@ -27,9 +27,6 @@ chosenItem:
 The label of the menu item the user chose. If the menu item is part of a
 submenu, the menu item label is followed by a vertical bar (|) and the
 submenu's label.
-
-submenuName:
-
 
 previousTab:
 The text of the menu item that was selected before the user chose a new

--- a/docs/dictionary/message/menuPick.lcdoc
+++ b/docs/dictionary/message/menuPick.lcdoc
@@ -2,7 +2,7 @@ Name: menuPick
 
 Type: message
 
-Syntax: menuPick <chosenItem> [| <submenuName>], <previousTab>
+Syntax: menuPick <chosenItem> {| <submenuName>}, <previousTab>
 
 Summary:
 Sent to a <button(object)> when a <menu item> is chosen from the <menu>

--- a/docs/dictionary/message/playerPropertyAvailable.lcdoc
+++ b/docs/dictionary/message/playerPropertyAvailable.lcdoc
@@ -23,8 +23,8 @@ end playerPropertyAvailable
 
 Parameters:
 propertyName (enum):
-The name of the property that has become available. These properties can
-be: 
+The name of the property that has become available. These 
+properties can be: 
 
 -   "duration": The duration of the movie, measured in milliseconds.
 -   "naturalSize": The raw size of a video frame in pixels.

--- a/docs/dictionary/message/touchEnd.lcdoc
+++ b/docs/dictionary/message/touchEnd.lcdoc
@@ -2,7 +2,7 @@ Name: touchEnd
 
 Type: message
 
-Syntax: touchEnd <messageID>
+Syntax: touchEnd <touchID>
 
 Summary:
 Sent when the user ends a touch sequence
@@ -19,12 +19,9 @@ on touchEnd
 end touchEnd
 
 Parameters:
-messageID:
-
-
 touchID:
-A number which uniquely identifies a sequence of touch messages
-corresponding to an individual, physical touch action
+A number which uniquely identifies an individual physical touch action from  
+a sequence of touch messages 
 
 Description:
 Handle the <touchEnd> message to perform an action when the user ends a
@@ -33,7 +30,7 @@ touch sequence.
 The <touchEnd> message is sent to the control which received the
 <touchStart> message which began the touch sequence.
 
-The id parameter is a number which uniquely identifies a sequence of
+The <touchID> parameter is a number which uniquely identifies a sequence of
 touch messages corresponding to an individual, physical touch action.
 All such sequences start with a <touchStart> message, have one or more
 <touchMove> messages and finish with either a <touchEnd> or a

--- a/docs/dictionary/message/urlWakeUp.lcdoc
+++ b/docs/dictionary/message/urlWakeUp.lcdoc
@@ -2,7 +2,7 @@ Name: urlWakeUp
 
 Type: message
 
-Syntax: urlWakeUp <wakeUpString>
+Syntax: urlWakeUp <wakeUpURL>
 
 Summary:
 Sent to an application when a custom URL is selected.
@@ -19,14 +19,11 @@ on urlWakeUp pURL
 end urlWakeUp
 
 Parameters:
-wakeUpString (string):
-
-
-urlString (string):
+wakeUpURL (string):
 The custom url that was used to launch the application
 
 Description:
-Handle the urlWakeUp messags if you want to perform an action when an
+Handle the urlWakeUp messages if you want to perform an action when an
 application is started up using the custom URL scheme.
 
 Custom URLs allow an application to be woken up when a specific URL is

--- a/docs/dictionary/operator/is-not-strictly.lcdoc
+++ b/docs/dictionary/operator/is-not-strictly.lcdoc
@@ -2,7 +2,7 @@ Name: is not strictly
 
 Type: operator
 
-Syntax: <value> is not strictly [ nothing | a boolean | an integer | a real | a string | a binary string | an array ]
+Syntax: <value> is not strictly { nothing | a boolean | an integer | a real | a string | a binary string | an array }
 
 Summary:
 Evaluates to true if the actual type of <value> is not the specified
@@ -28,7 +28,7 @@ the compress of "Hello World!" is not strictly a binary string -- evaluates to f
 
 Parameters:
 value:
-The expression to test the type of.
+The expression which will be tested for its type.
 
 Description:
 Use the <is not strictly> operator to determine what the true type of

--- a/docs/dictionary/operator/is-strictly.lcdoc
+++ b/docs/dictionary/operator/is-strictly.lcdoc
@@ -2,7 +2,7 @@ Name: is strictly
 
 Type: operator
 
-Syntax: <value> is strictly [ nothing | a boolean | an integer | a real | a string | a binary string | an array ]
+Syntax: <value> is strictly { nothing | a boolean | an integer | a real | a string | a binary string | an array }
 
 Summary:
 Evaluates to true if the actual type of <value> is the specified type.
@@ -27,7 +27,7 @@ the compress of "Hello World!" is strictly a binary string -- evaluates to true
 
 Parameters:
 value:
-The expression to test the type of.
+The expression which will be tested for its type.
 
 Description:
 Use the <is strictly> operator to determine the true type of a

--- a/docs/dictionary/operator/less-than-or-greater-than.lcdoc
+++ b/docs/dictionary/operator/less-than-or-greater-than.lcdoc
@@ -4,7 +4,7 @@ Synonyms: is not
 
 Type: operator
 
-Syntax: <value1> <> <value2>
+Syntax: <value1> &lt;&gt; <value2>
 
 Summary:
 Compares two <value|values> and <return|returns> true if they are not


### PR DESCRIPTION
- Fixes to Control Structures, Operators and Messages Syntax and Parameters
  - Should help Travis parse and validate these docs
