### PR TITLE
[Docs] Command Syntax and Parameter fixes - 1

### DIFF
--- a/docs/dictionary/command/choose.lcdoc
+++ b/docs/dictionary/command/choose.lcdoc
@@ -23,28 +23,28 @@ Parameters:
 toolName (enum):
 
 -   select: select a rectangle in an image 	
-    * pencil: draw freehand in an image 
-    * bucket: fill a shape in an image 
-    * brush: draw brushstrokes in an image 
-    * eraser: erase an area in an image 
-    * spray can: draw airbrush strokes in an image 
-    * rectangle: draw a rectangle or square shape 
-    * line: draw a straight line in an image 
-    * round rect: draw a rectangle with rounded corners in an image 
-    * oval: draw an oval or circle shape in an image 
-    * polygon: draw a polygon in an image 
-    * curve: draw a curved line in an image 
-    * regular polygon: draw a regular polygon shape in an image 
-    * dropper: pick up a color from an image
--   "browse": perform actions such as clicking buttons and typing in
+-   pencil: draw freehand in an image 
+-   bucket: fill a shape in an image 
+-   brush: draw brushstrokes in an image 
+-   eraser: erase an area in an image 
+-   spray can: draw airbrush strokes in an image 
+-   rectangle: draw a rectangle or square shape 
+-   line: draw a straight line in an image 
+-   round rect: draw a rectangle with rounded corners in an image 
+-   oval: draw an oval or circle shape in an image 
+-   polygon: draw a polygon in an image 
+-   curve: draw a curved line in an image 
+-   regular polygon: draw a regular polygon shape in an image 
+-   dropper: pick up a color from an image
+-   browse: perform actions such as clicking buttons and typing in
     fields 
--   "pointer": select, move, or resize objects
--   "button": create all styles of button objects
--   "field": create all styles of field objects
--   "scrollbar": create all styles of scrollbar objects
--   "graphic": create all styles of graphic objects
--   "image": create paint images
--   "player": create sound and video player objects
+-   pointer: select, move, or resize objects
+-   button: create all styles of button objects
+-   field: create all styles of field objects
+-   scrollbar: create all styles of scrollbar objects
+-   graphic: create all styles of graphic objects
+-   image: create paint images
+-   player: create sound and video player objects
 
 
 Description:

--- a/docs/dictionary/command/choose.lcdoc
+++ b/docs/dictionary/command/choose.lcdoc
@@ -22,16 +22,20 @@ choose tSavedTool tool
 Parameters:
 toolName (enum):
 
--   select: select a rectangle in an image 	* pencil: draw freehand in
-    an image * bucket: fill a shape in an image * brush: draw
-    brushstrokes in an image * eraser: erase an area in an image * spray
-    can: draw airbrush strokes in an image * rectangle: draw a rectangle
-    or square shape * line: draw a straight line in an image * round
-    rect: draw a rectangle with rounded corners in an image * oval: draw
-    an oval or circle shape in an image * polygon: draw a polygon in an
-    image * curve: draw a curved line in an image * regular polygon:
-    draw a regular polygon shape in an image * dropper: pick up a color
-    from an image
+-   select: select a rectangle in an image 	
+    * pencil: draw freehand in an image 
+    * bucket: fill a shape in an image 
+    * brush: draw brushstrokes in an image 
+    * eraser: erase an area in an image 
+    * spray can: draw airbrush strokes in an image 
+    * rectangle: draw a rectangle or square shape 
+    * line: draw a straight line in an image 
+    * round rect: draw a rectangle with rounded corners in an image 
+    * oval: draw an oval or circle shape in an image 
+    * polygon: draw a polygon in an image 
+    * curve: draw a curved line in an image 
+    * regular polygon: draw a regular polygon shape in an image 
+    * dropper: pick up a color from an image
 -   "browse": perform actions such as clicking buttons and typing in
     fields 
 -   "pointer": select, move, or resize objects

--- a/docs/dictionary/command/constant.lcdoc
+++ b/docs/dictionary/command/constant.lcdoc
@@ -14,15 +14,15 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-constant defaultName="Jones"
+constant kDefaultName="Jones"
 
 Example:
-constant entryA="EF9993333WX786",entryB="GJ773281YX342"
+constant kEntryA="EF9993333WX786",kEntryB="GJ773281YX342"
 
 Parameters:
 constantsList (enum):
-The constantsList consists of one or more name=value pairs, separated by
-commas: 
+The constantsList consists of one or more name=value pairs, 
+separated by commas: 
 
 -  The name is any string.
 -  The value is any literal string.
@@ -39,7 +39,9 @@ A constant cannot be defined as an array, only as a single value.
 >*Note:*  Choose easy-to-understand names for
 > <constant(glossary)|constants> to improve the readability of your
 > code. Use <constant(glossary)|constants> as substitutes for long or
-> convoluted <string|strings>.
+> convoluted <string|strings>. Use the prefix letter k for your constant
+> names to follow convention and make it easy to recognise. See the
+> Tips For Writing Good Code in the Livecode Script Guide.
 
 If you place the <constant> <statement> in a <handler>, you can use the
 <constant(command)> anywhere in the <handler>. If you place the

--- a/docs/dictionary/command/constant.lcdoc
+++ b/docs/dictionary/command/constant.lcdoc
@@ -20,12 +20,12 @@ Example:
 constant kEntryA="EF9993333WX786",kEntryB="GJ773281YX342"
 
 Parameters:
-constantsList (enum):
-The constantsList consists of one or more name=value pairs, 
+constantsList:
+The constantsList consists of one or more <name>=<value> pairs, 
 separated by commas: 
 
--  The name is any string.
--  The value is any literal string.
+-  The <name> is any string.
+-  The <value> is any literal string.
 
 
 Description:

--- a/docs/dictionary/command/constant.lcdoc
+++ b/docs/dictionary/command/constant.lcdoc
@@ -21,11 +21,11 @@ constant kEntryA="EF9993333WX786",kEntryB="GJ773281YX342"
 
 Parameters:
 constantsList:
-The constantsList consists of one or more <name>=<value> pairs, 
+The constantsList consists of one or more 'name=value' pairs, 
 separated by commas: 
 
--  The <name> is any string.
--  The <value> is any literal string.
+-  The 'name' is any string.
+-  The 'value' is any literal string.
 
 
 Description:

--- a/docs/dictionary/command/copy.lcdoc
+++ b/docs/dictionary/command/copy.lcdoc
@@ -2,7 +2,7 @@ Name: copy
 
 Type: command
 
-Syntax: copy [<object> [to {<card> | group | stack} ]] | [<chunk> of <field>]
+Syntax: copy {[<object> [to {<card> | group | stack} ]] | [<chunk> of <field>]}
 
 Summary:
 Copies <selected> text or an <object(glossary)> to the <clipboard> or to
@@ -37,10 +37,10 @@ instead of being placed in the clipboard, and the clipboard is left
 unchanged. 
 
 chunk:
-
+Expression to define a range of the field
 
 field:
-
+The object from which the text chunk will be derived
 
 It:
 If a destination <card>, group, or stack is specified, the <copy>

--- a/docs/dictionary/command/decrypt-using-rsa.lcdoc
+++ b/docs/dictionary/command/decrypt-using-rsa.lcdoc
@@ -2,7 +2,11 @@ Name: decrypt using rsa
 
 Type: command
 
-Syntax: decrypt <source> using rsa with {public | private} key <key> [and passphrase <passphrase>]
+Syntax: decrypt <message> using rsa with {public | private} key <key> [and passphrase <passphrase>]
+
+Summary:
+Used to decrypt a file or string with RSA public or private keys 
+and an optional passphrase.
 
 Introduced: 4.6
 
@@ -19,9 +23,6 @@ Example:
 decrypt field 1 using rsa with private key tPrivateKey
 
 Parameters:
-source:
-
-
 key:
 The key to be used for the decryption, in PEM format
 
@@ -36,12 +37,12 @@ Use the <decrypt using rsa> command to decrypt a message using RSA
 public key encryption.
 
 Use the form
-decrypt <message> with private key <key> 
+'decrypt <message> with private key <key> '
 to decode a message that a sender has encrypted with its corresponding
 public key.
 
 Use the form
-decrypt <message> with public key <key> 
+'decrypt <message> with public key <key>' 
 to verify that a message has been encoded with the corresponding private
 key, and there has come from one of its holders (this is a verify
 operation). 

--- a/docs/dictionary/command/decrypt-using-rsa.lcdoc
+++ b/docs/dictionary/command/decrypt-using-rsa.lcdoc
@@ -36,23 +36,23 @@ Description:
 Use the <decrypt using rsa> command to decrypt a message using RSA
 public key encryption.
 
-Use the form
-'decrypt <message> with private key <key> '
-to decode a message that a sender has encrypted with its corresponding
-public key.
+To decode a message that a sender has encrypted with its corresponding
+public key, use the form:
 
-Use the form
-'decrypt <message> with public key <key>' 
-to verify that a message has been encoded with the corresponding private
-key, and there has come from one of its holders (this is a verify
-operation). 
+    decrypt tMessage with private key tPrivateKey
 
-Generating key pairs
-Public-private key pairs can be generated using the OpenSSL suite of
-command-line tools. For example: openssl genrsa -out private_key.pem 512
-openssl rsa -pubout -in private_key.pem -out public_key.pem
-Will generate a key pair of size 512-bits, placing the private key in
-private_key.pem and the public key in public_key.pem.
+As a verify operation to ensure that a message has been encoded with the 
+corresponding private key and it has come from one of its holders, 
+use the form:
+
+    decrypt tMessage with public key tPublicKey
+
+> **Generating key pairs - **
+> Public-private key pairs can be generated using the OpenSSL suite of
+> command-line tools. For example: openssl genrsa -out private_key.pem 512
+> openssl rsa -pubout -in private_key.pem -out public_key.pem
+> Will generate a key pair of size 512-bits, placing the private key in
+> private_key.pem and the public key in public_key.pem.
 
 For more information on these utilities see
 http://www.openssl.org/docs/apps/rsa.html and

--- a/docs/dictionary/command/decrypt.lcdoc
+++ b/docs/dictionary/command/decrypt.lcdoc
@@ -2,7 +2,7 @@ Name: decrypt
 
 Type: command
 
-Syntax: decrypt <source> using <cipher> with [password|key] <passorkey> [and salt <saltvalue>] [and IV <IVvalue>] [at <bitvalue> bit]
+Syntax: decrypt <source> using <cipher> with {password|key} <passorkey> [and salt <saltvalue>] [and IV <IVvalue>] [at <bitvalue> bit]
 
 Summary:
 Decrypt data using a cipher

--- a/docs/dictionary/command/do.lcdoc
+++ b/docs/dictionary/command/do.lcdoc
@@ -6,7 +6,7 @@ Syntax: do <statementList>
 
 Syntax: do <statementList> in <caller>
 
-Syntax: do <statementList> as a <lternateLanguageName>
+Syntax: do <statementList> as <alternateLanguageName>
 
 Summary:
 <execute|Executes> a list of <statement|statements>.
@@ -38,9 +38,6 @@ string that evaluates to a statement.
 caller:
 Has the effect of executing the statementList in the context of the
 handler. 
-
-lternateLanguageName:
-
 
 alternateLanguageName:
 On Mac OS and OS X systems, the alternateLanguageName is a script

--- a/docs/dictionary/command/encrypt.lcdoc
+++ b/docs/dictionary/command/encrypt.lcdoc
@@ -2,7 +2,7 @@ Name: encrypt
 
 Type: command
 
-Syntax: encrypt <source> using <cipher> with [password|key] <passorkey> [and salt <saltvalue>] [and IV <IVvalue>] [at <bitvalue> bit]
+Syntax: encrypt <source> using <cipher> with {password|key} <passorkey> [and salt <saltvalue>] [and IV <IVvalue>] [at <bitvalue> bit]
 
 Summary:
 Encrypt data using a cipher.

--- a/docs/dictionary/command/play-video.lcdoc
+++ b/docs/dictionary/command/play-video.lcdoc
@@ -2,7 +2,7 @@ Name: play video
 
 Type: command
 
-Syntax: play video (<video-file> | <video-url>)
+Syntax: play video {<video-file> | <video-url>}
 
 Summary:
 Plays a full screen video.
@@ -55,7 +55,7 @@ the <templatePlayer> to true before executing the <play video> command.
 Looping a video is only supported on iOS 3.2 and later.
 
 A section of a video can be played by setting the <playSelection>
-property of the <templatePlayer> to true before executing the play video
+property of the <templatePlayer> to true before executing the <play video>
 command. This will use the <startTime> and <endTime> properties of the
 <templatePlayer> to determine what section to play. The values of these
 properties are interpreted as the number of milliseconds from the

--- a/docs/dictionary/command/play.lcdoc
+++ b/docs/dictionary/command/play.lcdoc
@@ -4,7 +4,7 @@ Type: command
 
 Syntax: play [<clipType>] {<filePath> | <clip>} [looping] [at <point>] [options <xOptions>]
 
-Syntax: play {stop | pause | resume | step {forward | back}]} [<clipType>] [<clip>]
+Syntax: play {stop | pause | resume | step {forward | back}} [<clipType>] [<clip>]
 
 Summary:
 Plays a movie or sound.
@@ -97,9 +97,10 @@ by using the put <command> :
 
     put newPath into $PATH
 
->*Note:* The type of audio and video clip formats supported by the 
-<play> command is limited. See the entries for <audioClip> and <videoClip> 
-for details. To play a wider variety of formats, use a <player> object.
+> *Note:* The type of audio and video clip formats supported  
+> by the <play> command is limited. See the entries for <audioClip> 
+> and <videoClip> for details. To play a wider variety of formats, 
+> use a <player> object.
 
 References: audioClip (object), beep (command), callbacks (property), 
 command (glossary), current card (glossary), currentTime (property), 

--- a/docs/dictionary/command/revXMLRPC_SetMethod.lcdoc
+++ b/docs/dictionary/command/revXMLRPC_SetMethod.lcdoc
@@ -2,7 +2,7 @@ Name: revXMLRPC_SetMethod
 
 Type: command
 
-Syntax: revXMLRPC_SetMethod <XML-RPC document>,<method name>
+Syntax: revXMLRPC_SetMethod <XML_RPC_documentID>,<method_name>
 
 Summary:
 Sets the name of the method in an XML-RPC document structure.
@@ -21,10 +21,13 @@ Example:
 revXMLRPC_SetMethod theRequest,"sample.elizabethanInsult"
 
 Parameters:
-documentID:
+XML_RPC_documentID:
 The number returned by the revXMLRPC_CreateRequest when you created the
-XML-RPC request. method name: The the method name to be called upon
-execution of the XML-RPC document documentID.
+XML-RPC request. 
+
+method_name: 
+The the method name to be called upon execution of the XML-RPC 
+documents documentID.
 
 The result:
 If the <revXMLRPC_SetMethod> <command> encounters an error, the <result>

--- a/docs/dictionary/command/revXMLRPC_SetMethod.lcdoc
+++ b/docs/dictionary/command/revXMLRPC_SetMethod.lcdoc
@@ -2,7 +2,7 @@ Name: revXMLRPC_SetMethod
 
 Type: command
 
-Syntax: revXMLRPC_SetMethod <XML_RPC_documentID>,<method_name>
+Syntax: revXMLRPC_SetMethod <XMLRPCdocumentID>,<methodName>
 
 Summary:
 Sets the name of the method in an XML-RPC document structure.
@@ -21,11 +21,11 @@ Example:
 revXMLRPC_SetMethod theRequest,"sample.elizabethanInsult"
 
 Parameters:
-XML_RPC_documentID:
+XMLRPCdocumentID:
 The number returned by the revXMLRPC_CreateRequest when you created the
 XML-RPC request. 
 
-method_name: 
+methodName: 
 The the method name to be called upon execution of the XML-RPC 
 documents documentID.
 
@@ -37,8 +37,8 @@ Description:
 Use the <revXMLRPC_SetMethod> <command> to set the method name to be
 called upon execution of an existing <XML-RPC document>.
 
-Where the path of the <XML-RPC document> tells the server which resource
-will handle the request, the <method name> tells that resource which
+Where the path of the XML-RPC document tells the server which resource
+will handle the request, the method name tells that resource which
 method is being called specifically within that resource.
 
 >*Important:*  The <revXMLRPC_SetMethod> <command> is part of the 

--- a/docs/dictionary/command/revZipSetProgressCallback.lcdoc
+++ b/docs/dictionary/command/revZipSetProgressCallback.lcdoc
@@ -28,26 +28,19 @@ revZipSetProgressCallback command is called without any parameters, then
 the progress callback will be disabled. The progress callback will be
 called with the following parameters:
 
-pArchive:
-pArchive: the name of the archive being processed
+- pArchive: the name of the archive being processed
 
-pItem:
-pItem: the name of the item being processed
+- pItem: the name of the item being processed
 
-pType:
-pType: the operation type, either "packing" or "unpacking"
+- pType: the operation type, either "packing" or "unpacking"
 
-pItemProgress:
-pItemProgress: the progress of the current item
+- pItemProgress: the progress of the current item
 
-pItemTotal:
-pItemTotal: the total progress for the items
+- pItemTotal: the total progress for the items
 
-pGlobalProgress:
-pGlobalProgress: the global progress
+- pGlobalProgress: the global progress
 
-pGlobalTotal:
-pGlobalTotal: the global total progress
+- pGlobalTotal: the global total progress
 
 Description:
 Use the <revZipSetProgressCallback> command to get information about the


### PR DESCRIPTION
Choose, Constant, Copy, Decrypt, Decrypt RSA, Do, Encrypt, Play, Play Video, revXMLRPC_SetMethod & revZipSetProgressCallback commands:
Fixes to Syntax and Parameter sections (plus minor formatting issues)
