### PR TITLE
[Bug 18579] Implement accept on ip:port

### DIFF
--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -942,6 +942,7 @@ class MCAccept : public MCStatement
 {
 	MCExpression *port;
 	MCExpression *message;
+	MCExpression *name;
 	Boolean datagram;
 	Boolean secure;
 	Boolean secureverify;
@@ -950,6 +951,7 @@ public:
 	MCAccept()
 	{
 		port = message = NULL;
+		name = NULL;
 		datagram = False;
 		secure = False;
 		certificate = NULL;

--- a/engine/src/em-osspec-network.cpp
+++ b/engine/src/em-osspec-network.cpp
@@ -27,6 +27,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 MCSocket *
 MCS_accept(uint16_t p_port,
+		   MCNameRef p_name,
            MCObject *p_object,
            MCNameRef p_message,
            Boolean p_datagram,

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -61,6 +61,9 @@ MC_EXEC_DEFINE_EXEC_METHOD(Network, PostToUrl, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptConnectionsOnPort, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptDatagramConnectionsOnPort, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptSecureConnectionsOnPort, 3)
+MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptConnectionsOnAddress, 2)
+MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptDatagramConnectionsOnAddress, 2)
+MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptSecureConnectionsOnAddress, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, ReadFromSocketFor, 4)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, ReadFromSocketUntil, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, WriteToSocket, 3)
@@ -599,7 +602,7 @@ void MCNetworkExecCloseSocket(MCExecContext& ctxt, MCNameRef p_socket)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCNetworkExecPerformAcceptConnections(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message, bool p_datagram, bool p_secure, bool p_with_verification)
+void MCNetworkExecPerformAcceptConnections(MCExecContext& ctxt, uint2 p_port, MCNameRef p_name, MCNameRef p_message, bool p_datagram, bool p_secure, bool p_with_verification)
 {
 	// MW-2005-01-28: Fix bug 2412 - accept doesn't clear the result.
 	MCresult -> clear();
@@ -607,24 +610,39 @@ void MCNetworkExecPerformAcceptConnections(MCExecContext& ctxt, uint2 p_port, MC
 	if (!ctxt . EnsureNetworkAccessIsAllowed())
 		return;
 
-	MCSocket *s = MCS_accept(p_port, ctxt . GetObject(), p_message, p_datagram ? True : False, p_secure ? True : False, p_with_verification ? True : False, kMCEmptyString);
+	MCSocket *s = MCS_accept(p_port, p_name, ctxt . GetObject(), p_message, p_datagram ? True : False, p_secure ? True : False, p_with_verification ? True : False, kMCEmptyString);
 	if (s != NULL)
         MCSocketsAppendToSocketList(s);
 }
 
 void MCNetworkExecAcceptConnectionsOnPort(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message)
 {
-	MCNetworkExecPerformAcceptConnections(ctxt, p_port, p_message, false, false, false);
+	MCNetworkExecPerformAcceptConnections(ctxt, p_port, nil, p_message, false, false, false);
 }
 
 void MCNetworkExecAcceptDatagramConnectionsOnPort(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message)
 {
-	MCNetworkExecPerformAcceptConnections(ctxt, p_port, p_message, true, false, false);
+	MCNetworkExecPerformAcceptConnections(ctxt, p_port, nil, p_message, true, false, false);
 }
 
 void MCNetworkExecAcceptSecureConnectionsOnPort(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message, bool p_with_verification)
 {
-	MCNetworkExecPerformAcceptConnections(ctxt, p_port, p_message, false, true, p_with_verification);
+	MCNetworkExecPerformAcceptConnections(ctxt, p_port, nil, p_message, false, true, p_with_verification);
+}
+
+void MCNetworkExecAcceptConnectionsOnAddress(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message)
+{
+	MCNetworkExecPerformAcceptConnections(ctxt, 0, p_name, p_message, false, false, false);
+}
+
+void MCNetworkExecAcceptDatagramConnectionsOnAddress(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message)
+{
+	MCNetworkExecPerformAcceptConnections(ctxt, 0, p_name, p_message, true, false, false);
+}
+
+void MCNetworkExecAcceptSecureConnectionsOnAddress(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, bool p_with_verification)
+{
+	MCNetworkExecPerformAcceptConnections(ctxt, 0, p_name, p_message, false, true, p_with_verification);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4382,6 +4382,9 @@ extern MCExecMethodInfo *kMCNetworkExecPostToUrlMethodInfo;
 extern MCExecMethodInfo *kMCNetworkExecAcceptConnectionsOnPortMethodInfo;
 extern MCExecMethodInfo *kMCNetworkExecAcceptDatagramConnectionsOnPortMethodInfo;
 extern MCExecMethodInfo *kMCNetworkExecAcceptSecureConnectionsOnPortMethodInfo;
+extern MCExecMethodInfo *kMCNetworkExecAcceptConnectionsOnAddressMethodInfo;
+extern MCExecMethodInfo *kMCNetworkExecAcceptDatagramConnectionsOnAddressMethodInfo;
+extern MCExecMethodInfo *kMCNetworkExecAcceptSecureConnectionsOnAddressMethodInfo;
 extern MCExecMethodInfo *kMCNetworkExecReadFromSocketForMethodInfo;
 extern MCExecMethodInfo *kMCNetworkExecReadFromSocketUntilMethodInfo;
 extern MCExecMethodInfo *kMCNetworkExecWriteToSocketMethodInfo;
@@ -4432,6 +4435,10 @@ void MCNetworkExecPostToUrl(MCExecContext& ctxt, MCValueRef p_data, MCStringRef 
 void MCNetworkExecAcceptConnectionsOnPort(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message);
 void MCNetworkExecAcceptDatagramConnectionsOnPort(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message);
 void MCNetworkExecAcceptSecureConnectionsOnPort(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message, bool p_with_verification);
+
+void MCNetworkExecAcceptConnectionsOnAddress(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message);
+void MCNetworkExecAcceptDatagramConnectionsOnAddress(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message);
+void MCNetworkExecAcceptSecureConnectionsOnAddress(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, bool p_with_verification);
 
 void MCNetworkExecReadFromSocketFor(MCExecContext& ctxt, MCNameRef p_socket, uint4 p_count, int p_unit_type, MCNameRef p_message);
 void MCNetworkExecReadFromSocketUntil(MCExecContext& ctxt, MCNameRef p_socket, MCStringRef p_sentinel, MCNameRef p_message);

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -193,7 +193,7 @@ extern MCSocket *MCS_open_socket(MCNameRef name, Boolean datagram, MCObject *o, 
 extern void MCS_close_socket(MCSocket *s);
 extern MCDataRef MCS_read_socket(MCSocket *s, MCExecContext &ctxt, uint4 length, const char *until, MCNameRef m);
 extern void MCS_write_socket(const MCStringRef d, MCSocket *s, MCObject *optr, MCNameRef m);
-extern MCSocket *MCS_accept(uint2 p, MCObject *o, MCNameRef m, Boolean datagram,Boolean secure,Boolean sslverify, MCStringRef sslcertfile);
+extern MCSocket *MCS_accept(uint2 p, MCNameRef p_name, MCObject *o, MCNameRef m, Boolean datagram,Boolean secure,Boolean sslverify, MCStringRef sslcertfile);
 extern bool MCS_ha(MCSocket *s, MCStringRef& r_string);
 extern bool MCS_hn(MCStringRef& r_string);
 extern bool MCS_aton(MCStringRef p_address, MCStringRef& r_name);


### PR DESCRIPTION
Previously the accept connections command always bound to INADDR_ANY
which is a security risk if the application only needs to bind to
known interfaces. This patch implements a host string parameter
in the same form as the open socket command of ip:port allowing
it to bind to specific interface ports.

Not sold on the syntax. Possibly this is better as `on host` doesn't sound right:

```
accept [datagram] connections on {port <port> | <ip:port>} with message <callback>
```

I also note that the accept command parser is quite lax and doesn't check a number of tokens. I'm not sure if this is deliberate but perhaps we should tighten it up?
