### PR TITLE
[Bug 18580] Fix NSSavePanel exception

### DIFF
--- a/docs/notes/bugfix-18580.md
+++ b/docs/notes/bugfix-18580.md
@@ -1,0 +1,1 @@
+# Fix crash when saving files on Mac

--- a/engine/src/mac-dialog.mm
+++ b/engine/src/mac-dialog.mm
@@ -641,16 +641,16 @@ void MCPlatformBeginFileDialog(MCPlatformFileDialogKind p_kind, MCPlatformWindow
 		[(NSOpenPanel *)t_panel setCanChooseFiles: YES];
 		[(NSOpenPanel *)t_panel setCanChooseDirectories: NO];
 		[(NSOpenPanel *)t_panel setAllowsMultipleSelection: p_kind == kMCPlatformFileDialogKindOpenMultiple ? YES : NO];
+		
+		if ([(NSOpenPanel *)t_panel respondsToSelector:@selector(isAccessoryViewDisclosed)])
+		{
+			// show accessory view when dialog opens
+			[(NSOpenPanel *)t_panel setAccessoryViewDisclosed: YES];
+		}
 	}
 	// MM-2012-03-01: [[ BUG 10046]] Make sure the "new folder" button is enabled for save dialogs
-	else 
+	else
 		[t_panel setCanCreateDirectories: YES];
-	
-	if ([t_panel respondsToSelector:@selector(isAccessoryViewDisclosed)])
-	{
-		// show accessory view when dialog opens
-		[t_panel setAccessoryViewDisclosed: YES];
-	}
 	
 	MCMacPlatformBeginOpenSaveDialog(p_owner, t_panel, *t_initial_folder, *t_initial_file);
 }


### PR DESCRIPTION
This patch fixes a crash where NSSavePanel is incorrectly responding
to the isAccessoryViewDisclosed selector causing an NSOpenPanel
method to be called on NSSavePanel.

The accessoryViewDisclosed property of NSOpenPanel is 10.11+ so
it is still guarded by respondsToSelector but this patch will
test that only when opening a save dialog.
