### PR TITLE
[[Docs]] Keyword lcdoc's description and syntax

### DIFF
--- a/docs/dictionary/keyword/colorPalette.lcdoc
+++ b/docs/dictionary/keyword/colorPalette.lcdoc
@@ -13,6 +13,8 @@ OS: mac, windows, linux
 
 Platforms: desktop, server
 
-References: reserved word (glossary), colors (property),
-backgroundColor (property), foregroundColor (property)
+Description:
+The <color palette|colorPalette> <keyword> is <reserved word|reserved> for internal use only.
 
+References: reserved word (glossary), colors (property), keyword (glossary),
+backgroundColor (property), foregroundColor (property), color palette (glossary)

--- a/docs/dictionary/keyword/magnifier.lcdoc
+++ b/docs/dictionary/keyword/magnifier.lcdoc
@@ -13,5 +13,7 @@ OS: mac, windows, linux
 
 Platforms: desktop, server
 
-References: reserved word (glossary), magnify (property)
+Description:
+The <magnifier> <keyword> is <reserved word|reserved> for internal use only
 
+References: reserved word (glossary), magnify (property), keyword (glossary)

--- a/docs/dictionary/keyword/of.lcdoc
+++ b/docs/dictionary/keyword/of.lcdoc
@@ -24,8 +24,13 @@ get the length of thisDate
 Example:
 put word 12 of it after field "Go On"
 
+Description:
+The <of> <keyword> is used to provide a connection between 
+the <property> <of> an <object (glossary)>, a <parameter> <of> 
+a <function>, or the <chunk expression> <of> a <string>
+
 References: function (control structure), object (glossary),
-property (glossary), custom function (glossary),
+property (glossary), custom function (glossary), keyword (glossary),
 chunk expression (glossary), global (glossary), chunk (glossary),
 keyword (glossary), expression (glossary), parameter (glossary),
 function (glossary), object reference (glossary), string (keyword),
@@ -33,4 +38,3 @@ character (keyword), lines (keyword), the (keyword), in (keyword),
 word (keyword), line (keyword), properties (property)
 
 Tags: text processing
-

--- a/docs/dictionary/keyword/private.lcdoc
+++ b/docs/dictionary/keyword/private.lcdoc
@@ -2,7 +2,7 @@ Name: private
 
 Type: keyword
 
-Syntax: private (command|function) <handlerName> <parameterList>
+Syntax: private {command|function} <handlerName> <parameterList>
 
 Summary:
 The <private> keyword makes a function or command local to the script in
@@ -63,4 +63,3 @@ for more details.
 
 References: pass (control structure), on (control structure),
 function (control structure), command (glossary), function (glossary)
-


### PR DESCRIPTION
This brings 4 keyword docs up to the correct standard. Three of them had no Description section and one had regular brackets instead of curly brackets in the Syntax.
