### PR TITLE
[[ Bug 18440 ]] Ensure SB copy files are resolved correctly on mobile

### DIFF
--- a/docs/notes/bugfix-18440.md
+++ b/docs/notes/bugfix-18440.md
@@ -1,0 +1,1 @@
+# Respect SB Copy Files pane relative / absolute path distinction on mobile

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -272,35 +272,32 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       end if
       set the itemDelimiter to "."
       
-      local tResolvedFiles
-      revSBResolveCopyFilesList tBaseFolder, "android", tFiles, tResolvedFiles
+      local tResolvedFileData
+      revSBResolveCopyFilesList tBaseFolder, "android", tFiles, tResolvedFileData
       
-      repeat for each line tFile in tResolvedFiles
-         local tFilePath, tFileName
-         computeAssetLocation tBaseFolder, tFile, tFilePath, tFileName
-         
+      repeat for each element tFile in tResolvedFileData
          -- Look for manifest template
          local tManifest
-         if tFilePath ends with "AndroidManifest.xml" then
-            put url ("binfile:" & tFilePath) into tManifest
+         if tFile["name"] ends with "AndroidManifest.xml" then
+            put url ("binfile:" & tFile["resolved"]) into tManifest
          end if
          
          -- Only look for lcext files.
-         if the last item of tFilePath is not "lcext" then
+         if the last item of tFile["name"] is not "lcext" then
             next repeat
          end if
          
          -- Only process if the target exists
-         if there is no file tFilePath then
-            throw "could not find referenced external -" && tFile
+         if there is no file tFile["resolved"] then
+            throw "could not find referenced external -" && tFile["resolved"]
          end if
          
          -- MERG-2013-09-05: [[ Bug 11152 ]] Only list the external if it was successfully
          --   extracted.
          -- Now attempt to process the external
-         if addExternalFromFile(tFilePath, tClassesBuildFolder, tLibsBuildFolder) then
+         if addExternalFromFile(tFile["resolved"], tClassesBuildFolder, tLibsBuildFolder) then
             -- Add the external to the list to load
-            put char 1 to -7 of tFileName & return after tExternals
+            put char 1 to -7 of tFile["resolved"] & return after tExternals
          end if
       end repeat
       delete the last char of tExternals
@@ -743,7 +740,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
          throw "could not open asset archive"
       end if
       
-      addAssetsToArchive tResolvedFiles, tBaseFolder, tAssetArchive
+      addAssetsToArchive tResolvedFileData, tBaseFolder, tAssetArchive
       
       revZipCloseArchive tAssetArchive
       if the result is not empty then
@@ -895,26 +892,7 @@ end revSaveAsMobileStandaloneMain
 
 ################################################################################
 
-private command computeAssetLocation pBaseFolder, pFile, @rPath, @rName
-   local tIsAbsolute
-   put pFile begins with "/" or char 2 to 3 of pFile is ":/" into tIsAbsolute
-   
-   set the itemDelimiter to slash
-   if the last item of pFile is "*" then
-      delete the last item of pFile
-   end if
-   
-   if tIsAbsolute then
-      put item -1 of pFile into rName
-      put pFile into rPath
-   else
-      -- MM-2011-09-07 [[ Bug 10345 ]] Use the full path to the file (rather than just name), ensureing we create sub-folders.
-      put pFile into rName
-      put pBaseFolder & slash & pFile into rPath
-   end if
-end computeAssetLocation
-
-private command addAssetsToArchive pFiles, pBaseFolder, pArchive
+private command addAssetsToArchive pFileData, pBaseFolder, pArchive
    local tDeviceConfig, tConfigFile, tCustomConfigFile, tFonts
    
    put mapFIlePath(revMobileRuntimeFolder() & slash & "lc_device_config.txt") into tConfigFile
@@ -922,27 +900,25 @@ private command addAssetsToArchive pFiles, pBaseFolder, pArchive
       put empty into tConfigFile
    end if
    
-   repeat for each line tFile in pFiles
-      local tName
-      computeAssetLocation pBaseFolder, tFile, tFile, tName
-      if there is a file tFile then
-         if tConfigFile is not empty and tName is "lc_device_config.txt" then
+   repeat for each element tFile in pFileData
+      if there is a file tFile["resolved"] then
+         if tConfigFile is not empty and tFile["name"] ends with "lc_device_config.txt" then
             // need to merge config files
-            put tFile into tCustomConfigFile
-         else if tFile ends with ".ttf" or tFile ends with ".ttc" then
+            put tFile["resolved"] into tCustomConfigFile
+         else if tFile["name"] ends with ".ttf" or tFile["name"] ends with ".ttc" then
             -- MM-2012-03-07: [[ Custom fonts ]] If any fonts are found, add to the list so that they are handled correctly
-            put tFile & return after tFonts
-         else if tFile ends with ".lcext" or tFile ends with ".dylib" then
+            put tFile["resolved"] & return after tFonts
+         else if tFile["name"] ends with ".lcext" or tFile["name"] ends with ".dylib" then
             -- MW-2012-07-05: [[ Externals ]] If an 'lcext' file or dylib file is found then we ignore it.
-         else if tFile ends with "AndroidManifest.xml" then
+         else if tFile["name"] ends with "AndroidManifest.xml" then
             -- MW-2015-04-24: [[ TemplateAppMetadata ]] If an template manifest is found then we ignore it.
          else
-            revZipAddUncompressedItemWithFile pArchive, "assets/" & tName, tFile
+            revZipAddUncompressedItemWithFile pArchive, "assets/" & tFile["name"], tFile["resolved"]
          end if
-      else if there is a folder tFile then
-         addAssetsFromFolderToArchive tFile, "assets" & slash & tName, pArchive, tFonts
+      else if there is a folder tFile["resolved"] then
+         addAssetsFromFolderToArchive tFile["resolved"], "assets" & slash & tFile["name"], pArchive, tFonts
       else
-         throw "could not find referenced asset to include -" && tFile
+         throw "could not find referenced asset to include -" && tFile["resolved"]
       end if
    end repeat
    

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -949,8 +949,8 @@ private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, 
    -- Start with an empty redirects list
    put empty into rRedirects
    
-   local tFiles
-   revSBResolveCopyFilesList pBaseFolder, "ios", pFiles, tFiles
+   local tFileData
+   revSBResolveCopyFilesList pBaseFolder, "ios", pFiles, tFileData
    
    -- Compute a list of the files we need to copy. This is in the form
    --   <target> [tab] <source>
@@ -958,26 +958,15 @@ private command revCopyMobileFiles pFiles, pBaseFolder, pAppBundle, pAppTarget, 
    --
    local tManifest
    set the itemDelimiter to slash
-   repeat for each line tFile in tFiles
-      local tIsAbsolute, tName
-      put tFile begins with "/" or char 2 to 3 of tFile is ":/" into tIsAbsolute
-      if the last item of tFile is "*" then
-         delete the last item of tFile
-      end if
-      if tFile begins with pBaseFolder then
-         put item (the number of items of pBaseFolder + 1) to -1 of tFile  into tName
-      else
-         put item -1 of tFile into tName
-      end if
-      
-      revSBEnsureFolder pAppBundle & slash & item 1 to -2 of tName
+   repeat for each element tFile in tFileData
+      revSBEnsureFolder pAppBundle & slash & item 1 to -2 of tFile["name"]
       
       -- MW-2010-12-16: [[ Bug 9238 ]] Check for 'resources' folder
-      if item 1 of tName is "Resources" then
+      if item 1 of tFile["name"] is "Resources" then
          throw "iOS apps that contain a top-level folder called 'Resources' will fail to run"
       end if
       
-      addToManifest tFile, tName, pAppBundle, tManifest, rRedirects
+      addToManifest tFile["resolved"], tFile["name"], pAppBundle, tManifest, rRedirects
    end repeat
    
    -- Remove trailing delimiter

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1913,7 +1913,10 @@ function revSBIncludedExternalPath pTarget, pName
    return sExternalsLocationA[tPlatform][pName][tArchitecture]
 end revSBIncludedExternalPath
 
-private command __ResolveIncludedExternal pTarget, @xFiles
+private command __ResolveIncludedExternal pTarget, @xFiles, @rHasResources
+   local tHasResources
+   put false into tHasResources
+   
    -- Added to support Ext inclusion
    if xFiles begins with "!" then
       
@@ -1940,36 +1943,49 @@ private command __ResolveIncludedExternal pTarget, @xFiles
             
             if tContents is not empty then
                appendToStringList tContents, xFiles
+               put true into tHasResources
             end if
          end if
          
       end if
    end if
+   put tHasResources into rHasResources
 end __ResolveIncludedExternal
 
-command revSBResolveCopyFilesList pBaseFolder, pTarget, pFiles, @rFiles
-   local tManifest
+command revSBResolveCopyFilesList pBaseFolder, pTarget, pFiles, @rFileData
    set the itemDelimiter to slash
    repeat for each line tFile in pFiles
-      local tResolvedFile
-      __ResolveIncludedExternal pTarget, tFile
+      local tResolvedFile, tHasResources
+      __ResolveIncludedExternal pTarget, tFile, tHasResources
+      
       -- tFile may now list multiple files if it was an external with a resources directory
       repeat for each line tResolvedFile in tFile
+         local tDataA, tFlattenStructure
+         
          if tResolvedFile ends with "/" then
             delete char -1 of tResolvedFile
          end if
          
          if the last item of tResolvedFile is "*" then
-            delete the last item of tFile
+            delete the last item of tResolvedFile
          end if
          
          local tIsAbsolute, tName
          put tResolvedFile begins with "/" or char 2 to 3 of tResolvedFile is ":/" into tIsAbsolute
+         
+         # Flatten structure of external resources
+         if tIsAbsolute or tHasResources then
+            put item -1 of tResolvedFile into tDataA["name"]
+         else
+            put tResolvedFile into tDataA["name"]
+         end if
+         
          if not tIsAbsolute then
             put pBaseFolder & slash before tResolvedFile
          end if
+         put tResolvedFile into tDataA["resolved"]
          
-         appendToStringList tResolvedFile, rFiles
+         addToList tDataA, rFileData
       end repeat
    end repeat
 end revSBResolveCopyFilesList


### PR DESCRIPTION
Currently lcext externals require their resources' folder structure
to be flattened for inclusion in standalones. The implementation of
this was losing information about whether resource paths in copy files
pane had been specified relatively or absolutely.
