### PR TITLE
[Docs] Glossary - objects & controls listed

### DIFF
--- a/docs/glossary/c/control.lcdoc
+++ b/docs/glossary/c/control.lcdoc
@@ -5,14 +5,22 @@ Synonyms: control, widget
 Type: glossary
 
 Description:
-An <object(glossary)> that can be placed on a <card>. Controls include
-<button|buttons>, <field|fields>, <image|images>, <graphic|graphics>,
-<player|players>, <EPS|EPS objects>, <scrollbar|scrollbars>, and
-<group|groups>. 
+An <object(glossary)> that can be placed on a <card>. Controls include:
+
+-  <button|buttons> 
+-  <field|fields>
+-  <image|images>
+-  <graphic|graphics>
+-  <player|players>
+-  <EPS|EPS objects>
+-  <scrollbar|scrollbars>
+-  <group|groups>
+-  <widget|widgets>
 
 References: graphic (glossary), image (glossary), button (glossary),
 scrollbar (glossary), player (glossary), object (glossary),
-field (glossary), card (glossary), EPS (glossary), group (glossary)
+field (glossary), card (glossary), EPS (glossary), group (glossary),
+widget (object)
 
 Tags: objects
 

--- a/docs/glossary/o/object.lcdoc
+++ b/docs/glossary/o/object.lcdoc
@@ -6,10 +6,22 @@ Type: glossary
 
 Description:
 A LiveCode module capable of receiving <message|messages>. One of the
-building blocks of a LiveCode application. Objects include <stack|stacks>, 
-<card|cards> and <control|controls>. <control|Controls> include 
-<button|buttons>, <field|fields>, <image|images>, <graphic|graphics>, 
-<player|players>, <EPS|EPS objects>, <scrollbar|scrollbars>, and <group|groups>.
+building blocks of a LiveCode application. Objects include: 
+-  <stack|stacks>
+-  <card|cards>
+-  <control|controls>
+
+<control|Controls> include:
+
+-  <button|buttons> 
+-  <field|fields>
+-  <image|images>
+-  <graphic|graphics>
+-  <player|players>
+-  <EPS|EPS objects>
+-  <scrollbar|scrollbars>
+-  <group|groups>
+-  <widget|widgets>
 
 References: message (glossary), card (glossary), stack (glossary),
 control (glossary), button (glossary), field (glossary), image (glossary),

--- a/docs/glossary/o/object.lcdoc
+++ b/docs/glossary/o/object.lcdoc
@@ -6,9 +6,15 @@ Type: glossary
 
 Description:
 A LiveCode module capable of receiving <message|messages>. One of the
-building blocks of a LiveCode application.
+building blocks of a LiveCode application. Objects include <stack|stacks>, 
+<card|cards> and <control|controls>. <control|Controls> include 
+<button|buttons>, <field|fields>, <image|images>, <graphic|graphics>, 
+<player|players>, <EPS|EPS objects>, <scrollbar|scrollbars>, and <group|groups>.
 
-References: message (glossary)
+References: message (glossary), card (glossary), stack (glossary),
+control (glossary), button (glossary), field (glossary), image (glossary),
+graphic (glossary), player (glossary), EPS (glossary), scrollbar (glossary),
+group (glossary), widget (object)
 
 Tags: objects
 


### PR DESCRIPTION
- Add a list of objects and controls to glossary/object.lcdoc
- Controls laid out in bullets and 'widget' added to list in glossary/control.lcdoc
