### PR TITLE
Removed syntax section

### DIFF
--- a/docs/dictionary/command/redo.lcdoc
+++ b/docs/dictionary/command/redo.lcdoc
@@ -2,8 +2,6 @@ Name: redo
 
 Type: command
 
-Syntax: redo
-
 Summary:
 The <redo> <command> is not implemented and is <reserved word|reserved>.
 
@@ -12,4 +10,3 @@ Introduced: 1.0
 Platforms: desktop, server
 
 References: undo (command), command (glossary), reserved word (glossary)
-

--- a/docs/dictionary/command/redo.lcdoc
+++ b/docs/dictionary/command/redo.lcdoc
@@ -2,7 +2,7 @@ Name: redo
 
 Type: command
 
-Syntax: <reserved word|reserved word>
+Syntax: redo
 
 Summary:
 The <redo> <command> is not implemented and is <reserved word|reserved>.

--- a/docs/dictionary/command/redo.lcdoc
+++ b/docs/dictionary/command/redo.lcdoc
@@ -2,11 +2,16 @@ Name: redo
 
 Type: command
 
+Syntax: <reserved word|reserved word>
+
 Summary:
 The <redo> <command> is not implemented and is <reserved word|reserved>.
 
 Introduced: 1.0
 
 Platforms: desktop, server
+
+Description:
+The <redo> <command> is not implemented and is <reserved word|reserved> for possible future implementation
 
 References: undo (command), command (glossary), reserved word (glossary)


### PR DESCRIPTION
removed syntax
from @seaniepie 's list "Blue are for those without descriptions"...
Not quite sure what "not ok - description of redo command not empty" means,
but it seems to me that if "redo" is not implemented then it should not have a syntax section.
