### PR TITLE
Merge release 8.1.1 12.10.2016

### DIFF
--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1181,12 +1181,12 @@ end revCopyMobileStackFiles
 
 private function revGetMinimumOSByArch pMinimumOS 
    local tMinimumOSByArch  
-   -- MM-2013-09-23: We only support iOS 4.3 and later
    -- SN-2015-02-02: [[ Bug 14422 ]] Minimum OS version is the
-   --  same for all archs, and we only support version >= 5.1.1
+   --  same for all archs
+   -- We only support version >= 6.0
    --
-   if pMinimumOS is empty or pMinimumOS <= "5.1" then
-      put "5.1.1" into tMinimumOSByArch["i386"]
+   if pMinimumOS is empty or pMinimumOS < "6.0" then
+      put "6.0" into tMinimumOSByArch["i386"]
    else
       put pMinimumOS after tMinimumOSByArch["i386"]
    end if


### PR DESCRIPTION
Trivial conflict in `ide` submodule pointer, resolved by keeping the `develop-8.1` version
