### PR TITLE
Disable "conversion" and "shorten-64-to-32" warnings for Mac/iOS

### DIFF
--- a/config/ios.gypi
+++ b/config/ios.gypi
@@ -190,6 +190,10 @@
 						[ 
 							'-Wall', 
 							'-Wextra', 
+
+							'-Wno-conversion',
+							'-Wno-shorten-64-to-32',
+
 							'-Werror=declaration-after-statement',
 							'-Werror=delete-non-virtual-dtor',
 							'-Werror=overloaded-virtual',

--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -119,6 +119,10 @@
 						[ 
 							'-Wall', 
 							'-Wextra', 
+
+							'-Wno-conversion',
+							'-Wno-shorten-64-to-32',
+
 							'-Werror=declaration-after-statement',
 							'-Werror=delete-non-virtual-dtor',
 							'-Werror=overloaded-virtual',


### PR DESCRIPTION
These warnings are largely correct, but it would require an
enormous amount of work (probably a general refactor of the engine)
to address them properly.  Adding casts of dubious correctness to
silence the warnings would simply make it harder to track down and
fix the issues when the resources become available.

However, currently the Travis CI build logs are being swamped by
more than 10k lines of warnings, making it impossible to review
testsuite results.  This patch turns off the warnings for the time
being.
