### PR TITLE
[Bug 18579] Support defaultNetworkInterface in accept

### DIFF
--- a/docs/dictionary/command/accept.lcdoc
+++ b/docs/dictionary/command/accept.lcdoc
@@ -72,6 +72,8 @@ the contents of the <datagram>.
   assignments](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)
   and [RFC 6335](https://tools.ietf.org/html/rfc6335)
 
+> **Note:** The <defaultNetworkInterface> <property> can be used to
+specify the interface to accept connections on.
 
 References: read from socket (command), write to socket (command),
 close socket (command), open socket (command), openSockets (function),
@@ -81,7 +83,6 @@ IP address (glossary), TCP (glossary), port (glossary),
 command (glossary), socket (glossary), UDP (glossary), host (glossary),
 server (glossary), message (glossary), parameter (glossary),
 process (glossary), object (glossary), HTTPProxy (property),
-script (property)
+script (property), defaultNetworkInterface (property)
 
 Tags: networking
-

--- a/docs/notes/bugfix-18579.md
+++ b/docs/notes/bugfix-18579.md
@@ -1,0 +1,1 @@
+# Support defaultNetworkInterface for the accept command

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -69,21 +69,36 @@ Parse_stat MCAccept::parse(MCScriptPoint &sp)
 		secure = True;
 	else if (sp.skip_token(SP_ACCEPT, TT_UNDEFINED, AC_DATAGRAM) == PS_NORMAL)
 		datagram = True;
-	sp.skip_token(SP_ACCEPT, TT_UNDEFINED, AC_UNDEFINED); // connections
-	sp.skip_token(SP_ACCEPT, TT_UNDEFINED, AC_UNDEFINED); // on
-	sp.skip_token(SP_ACCEPT, TT_UNDEFINED, AC_UNDEFINED); // port
-	if (sp.parseexp(False, True, &port) != PS_NORMAL)
+	
+	Parse_stat t_stat = PS_NORMAL;
+	
+	if (PS_NORMAL == t_stat)
+		t_stat = sp.skip_token(SP_ACCEPT, TT_UNDEFINED, AC_CONNECTIONS);
+	
+	if (PS_NORMAL == t_stat)
+		t_stat = sp.skip_token(SP_ACCEPT, TT_UNDEFINED, AC_ON);
+	
+	if (PS_NORMAL == t_stat)
+		t_stat = sp.skip_token(SP_ACCEPT, TT_UNDEFINED, AC_PORT);
+	
+	if (PS_NORMAL == t_stat)
+		t_stat = sp.parseexp(False, True, &port);
+	
+	if (PS_NORMAL == t_stat)
+		t_stat = sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_WITH);
+	
+	if (PS_NORMAL == t_stat)
+		t_stat = sp.skip_token(SP_SUGAR, TT_CHUNK, CT_UNDEFINED);
+	
+	if (PS_NORMAL == t_stat)
+		t_stat = sp.parseexp(False, True, &message);
+		
+	if (PS_NORMAL != t_stat)
 	{
 		MCperror->add(PE_ACCEPT_BADEXP, sp);
 		return PS_ERROR;
 	}
-	sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_WITH); // with
-	sp.skip_token(SP_SUGAR, TT_CHUNK, CT_UNDEFINED); // message
-	if (sp.parseexp(False, True, &message) != PS_NORMAL)
-	{
-		MCperror->add(PE_ACCEPT_BADEXP, sp);
-		return PS_ERROR;
-	}
+	
 	if (sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_WITH) == PS_NORMAL
 	        && sp.skip_token(SP_SSL, TT_STATEMENT, SSL_VERIFICATION) != PS_NORMAL)
 	{

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -118,7 +118,13 @@ void MCAccept::exec_ctxt(MCExecContext &ctxt)
     uinteger_t t_port;
     if (!ctxt . EvalExprAsUInt(port, EE_ACCEPT_BADEXP, t_port))
         return;
-    
+	
+	if (t_port > UINT16_MAX)
+	{
+		ctxt . LegacyThrow(EE_ACCEPT_BADEXP);
+		return;
+	}
+	
     MCNewAutoNameRef t_message;
     if (!ctxt . EvalExprAsNameRef(message, EE_ACCEPT_BADEXP, &t_message))
         return;

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -124,11 +124,11 @@ void MCAccept::exec_ctxt(MCExecContext &ctxt)
         return;
     
     if (datagram)
-		MCNetworkExecAcceptDatagramConnectionsOnPort(ctxt, t_port, *t_message);
+		MCNetworkExecAcceptDatagramConnectionsOnPort(ctxt, uint16_t(t_port), *t_message);
 	else if (secure)
-		MCNetworkExecAcceptSecureConnectionsOnPort(ctxt, t_port, *t_message, secureverify == True);
+		MCNetworkExecAcceptSecureConnectionsOnPort(ctxt, uint16_t(t_port), *t_message, secureverify == True);
 	else
-		MCNetworkExecAcceptConnectionsOnPort(ctxt, t_port, *t_message);
+		MCNetworkExecAcceptConnectionsOnPort(ctxt, uint16_t(t_port), *t_message);
 }
 
 void MCAccept::compile(MCSyntaxFactoryRef ctxt)

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -226,11 +226,11 @@ extern const uint4 constant_table_size = ELEMENTS(constant_table);
 
 static LT accept_table[] =
     {
-        {"connections", TT_UNDEFINED, AC_UNDEFINED},
+        {"connections", TT_UNDEFINED, AC_CONNECTIONS},
         {"datagram", TT_UNDEFINED, AC_DATAGRAM},
         {"datagrams", TT_UNDEFINED, AC_DATAGRAM},
-        {"on", TT_UNDEFINED, AC_UNDEFINED},
-        {"port", TT_UNDEFINED, AC_UNDEFINED},
+        {"on", TT_UNDEFINED, AC_ON},
+        {"port", TT_UNDEFINED, AC_PORT},
         {"secure", TT_UNDEFINED, AC_SECURE}
     };
 

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -1086,8 +1086,22 @@ MCSocket *MCS_accept(uint2 port, MCObject *object, MCNameRef message, Boolean da
 
 	memset((char *)&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
-	addr.sin_addr.s_addr = MCSwapInt32HostToNetwork(INADDR_ANY);
+	
+	if (MCdefaultnetworkinterface != NULL)
+	{
+		MCAutoStringRef MCdefaultnetworkinterface_string;
+		if (!MCStringCreateWithCString(MCdefaultnetworkinterface, &MCdefaultnetworkinterface_string) ||
+			!MCS_name_to_sockaddr(*MCdefaultnetworkinterface_string, addr))
+		{
+			MCresult->sets("can't resolve network interface");
+			return NULL;
+		}
+	}
+	else
+		addr.sin_addr.s_addr = MCSwapInt32HostToNetwork(INADDR_ANY);
+	
 	addr.sin_port = MCSwapInt16HostToNetwork(port);
+	
 #if defined(_WINDOWS_DESKTOP) || defined(_WINDOWS_SERVER)
 
 	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr))

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -33,8 +33,10 @@ constant;
 #define ELEMENTS(table) (sizeof(table) / sizeof(table[0]))
 
 enum Accept_constants {
-    AC_UNDEFINED,
-    AC_DATAGRAM,
+    AC_CONNECTIONS,
+	AC_ON,
+	AC_PORT,
+	AC_DATAGRAM,
     AC_SECURE
 };
 

--- a/engine/src/socket_resolve.cpp
+++ b/engine/src/socket_resolve.cpp
@@ -434,7 +434,7 @@ bool MCS_name_to_sockaddr(MCStringRef p_name_in, struct sockaddr_in *r_addr, MCH
     
 	memset((char *)r_addr, 0, sizeof(struct sockaddr_in));
 	r_addr->sin_family = AF_INET;
-	r_addr->sin_port = MCSwapInt16HostToNetwork(port);
+	r_addr->sin_port = MCSwapInt16HostToNetwork(uint16_t(port));
     
     MCAutoPointer<char> t_name_cstring;
     /* UNCHECKED */ MCStringConvertToCString(*t_name, &t_name_cstring);

--- a/engine/src/socket_resolve.cpp
+++ b/engine/src/socket_resolve.cpp
@@ -425,7 +425,14 @@ bool MCS_name_to_sockaddr(MCStringRef p_name_in, struct sockaddr_in *r_addr, MCH
 			}
 		}
         else
+		{
             port = MCNumberFetchAsInteger(*t_port_number);
+			if (port > UINT16_MAX)
+			{
+				MCresult->sets("not a valid port");
+				return false;
+			}
+		}
     }
     else
         t_name = MCValueRetain(*t_name_in);

--- a/tests/lcs/liburl/connect.livecodescript
+++ b/tests/lcs/liburl/connect.livecodescript
@@ -14,7 +14,7 @@ end TestSetup
 
 on TestCONNECTHeader
    constant kTestHost = "google.com"
-   set the httpproxy to "http://127.0.0.1:99999"
+   set the httpproxy to "http://127.0.0.1:65535"
    
    put url ("https://" & kTestHost) into tValue
    


### PR DESCRIPTION
Note that the `[{ with | without } verification]` clause is broken (never finished being implemented):
- always false
- doesn't actually do anything in MCS_accept

It is not actually documented for the accept command either so I'm not really sure what it's doing there. Anyway, I decided not to touch that for the time being...
