### PR TITLE
[[Bug 11796]] iPhoneFileDataProtection empty result

### DIFF
--- a/docs/dictionary/function/iphoneFileDataProtection.lcdoc
+++ b/docs/dictionary/function/iphoneFileDataProtection.lcdoc
@@ -24,11 +24,11 @@ A string containing the path to the file.
 
 Returns (enum):
 
--   empty: The file was not accessible or argument not specified.
--   none: No protection.
--   complete: The file is not accessible, for read or write, while the device is locked.
--   complete unless open: The file is fully protected when the device is locked, unless it was already open.
--   complete until first user authentication: The file is fully protected until the user unlocks the device for this first time.
+- "empty": The file was not accessible or argument not specified.
+- "none": No protection.
+- "complete": The file is not accessible, for read or write, while the device is locked.
+- "complete unless open": The file is fully protected when the device is locked, unless it was already open.
+- "complete until first user authentication": The file is fully protected until the user unlocks the device for this first time.
 
 
 Description:

--- a/docs/dictionary/function/iphoneFileDataProtection.lcdoc
+++ b/docs/dictionary/function/iphoneFileDataProtection.lcdoc
@@ -2,7 +2,7 @@ Name: iphoneFileDataProtection
 
 Type: function
 
-Syntax: iphoneFileDataProtection <filename>
+Syntax: iphoneFileDataProtection (<filename>)
 
 Summary:
 Retrieves the data protection level of a file.
@@ -14,7 +14,7 @@ OS: ios
 Platforms: mobile
 
 Example:
-if iphoneFileDataProtection() is "none" then
+if iphoneFileDataProtection(tFile) is "none" then
    iphoneSetFileDataProtection tFile, "complete"
 end if
 
@@ -24,10 +24,11 @@ A string containing the path to the file.
 
 Returns (enum):
 
--   none: 
--   complete: 
--   complete unless open: (iOS 5 and later only)
--   complete until first user authentication: (iOS 5 and later only)
+-   empty: The file was not accessible or argument not specified.
+-   none: No protection.
+-   complete: The file is not accessible, for read or write, while the device is locked.
+-   complete unless open: The file is fully protected when the device is locked, unless it was already open.
+-   complete until first user authentication: The file is fully protected until the user unlocks the device for this first time.
 
 
 Description:


### PR DESCRIPTION
- Added tFile to the function in the example
- Added description to all results
- Added empty to the list of results
