### PR TITLE
Make sure android externals are included in the standalone

### DIFF
--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -297,7 +297,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
          -- Now attempt to process the external
          if addExternalFromFile(tFile["resolved"], tClassesBuildFolder, tLibsBuildFolder) then
             -- Add the external to the list to load
-            put char 1 to -7 of tFile["resolved"] & return after tExternals
+            put char 1 to -7 of tFile["name"] & return after tExternals
          end if
       end repeat
       delete the last char of tExternals


### PR DESCRIPTION
`tExternals` must **not** include the resolved path, since later the script does:

```
-- Copy across the externals into the libs folder
      repeat for each line tEntry in tExternals
         ...
         put url ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & tEntry)) into url ("binfile:" & tArmLibsBuildFolder & slash & "lib" & tEntry & ".so")
         // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occured
         if the result is not empty then
            throw "Could not find " & tEntry && "library"
         end if
      end repeat
```
