### PR TITLE
[[ Bug ]] Use StringRefs in Linux player property accessors

### DIFF
--- a/docs/notes/bugfix-18614.md
+++ b/docs/notes/bugfix-18614.md
@@ -1,0 +1,1 @@
+# Fix Linux player crash when accessing properties

--- a/engine/src/lnxmplayer.cpp
+++ b/engine/src/lnxmplayer.cpp
@@ -288,62 +288,56 @@ void MPlayer::resize( MCRectangle p_rect)
 
 
 
-void MPlayer::write_command (const char * p_cmd )
+void MPlayer::write_command (MCStringRef p_cmd )
 {
 	if ( m_window == DNULL)
 		return ;
-	char *t_buffer;
-	t_buffer = (char *)malloc(strlen(p_cmd) + 2);
-	sprintf(t_buffer, "%s\n", p_cmd);
-	write(m_pfd_write[WRITE], t_buffer, strlen(t_buffer));
-	free(t_buffer);
+
+	MCAutoStringRefAsCString t_cstring;
+	if (t_cstring.Lock(p_cmd))
+		write(m_pfd_write[WRITE], *t_cstring, MCStringGetLength(p_cmd));
 }
 
-char * MPlayer::read_command(const char * p_ans )
+bool MPlayer::read_command(MCStringRef p_ans, MCStringRef& r_ret)
 {
-	const char * cmd_failed = "Failed to get value of property" ;
+	const char *cmd_failed = "Failed to get value of property" ;
 	
-	if ( m_window == DNULL)
-		return NULL;
-	char * t_ret, * t_ptr ;
-	t_ret = (char*)malloc(2048) ;
-	memset(t_ret, 0, 2048);
-	t_ptr = t_ret ;
-	char t_char ;
-	bool t_found = false ;
-	*t_ptr = '\0' ;
-	int t_size = read(m_pfd_read[READ], &t_char, 1 ) ;
-	while (!t_found && t_size != -1)
+	if (m_window == DNULL)
+		return false;
+	
+	MCAutoStringRef t_read;
+	if (!MCStringCreateMutable(0, &t_read))
+		return false;	
+
+	char t_char;
+	int t_size = 0;
+	while (t_size != -1)
 	{
-		while ( t_size != -1 && t_char != '\n' )
-		{
-			*t_ptr=t_char ;
-			t_ptr++;
-			int t_size = read(m_pfd_read[READ], &t_char, 1 ) ;
-		}
+		t_size = read(m_pfd_read[READ], &t_char, 1);
 		
-		if ( strcasestr(t_ret, cmd_failed) != NULL)
+		// Read a line into the string
+		if (t_char != '\n')
 		{
-			t_ret = NULL ;
-			break ;
+			if (!MCStringAppendChar(*t_read, t_char))
+				return false;
+			continue;
 		}
-		
-		
-		if ( strstr(t_ret, p_ans) != NULL)
+
+
+		if (MCStringIsEqualToCString(*t_read, cmd_failed, kMCStringOptionCompareCaseless))
+			return false;
+
+		if (MCStringBeginsWith(*t_read, p_ans, kMCStringOptionCompareCaseless))
 		{
-			t_ret += strlen(p_ans) ;
-			t_found = true ;
+			MCRange t_range = MCRangeMake(MCStringGetLength(p_ans), UINDEX_MAX);
+			return MCStringCopySubstring(*t_read, t_range, r_ret); 
 		}
-		else 
-		{
-			t_char = '\0' ;
-			memset(t_ret, 0, 2048);
-			t_ptr = t_ret ;
-			int t_size = read(m_pfd_read[READ], &t_char, 1 ) ;
-		}
+
+		if (!MCStringRemove(*t_read, MCRangeMake(0, MCStringGetLength(*t_read))))
+			return false;
 	}
 
-	return t_ret;
+	return false;
 }
 
 
@@ -355,7 +349,7 @@ void MPlayer::play ( bool p_play )
 	{
 		if ( m_playing != p_play )
 		{
-			write_command("pause");
+			write_command(MCSTR("pause"));
 			m_playing = !m_playing ;
 		}
 	}
@@ -385,26 +379,26 @@ void MPlayer::pause ( void )
 
 void MPlayer::seek ( int4 p_amount ) 
 {
-	char buffer[1024] ;
-	sprintf(buffer, "pausing_keep seek %d 0", p_amount);
-	write_command ( buffer );
+	MCAutoStringRef t_seek_cmd;
+	if (MCStringFormat(&t_seek_cmd, "pausing_keep seek %d 0", p_amount))
+		write_command (*t_seek_cmd);
 }
 
 void MPlayer::seek(void)
 {
-	write_command("frame_step");
+	write_command(MCSTR("frame_step"));
 }
 
-void MPlayer::osd ( uint4 p_level = 0 )
+void MPlayer::osd (uint4 p_level = 0)
 {
-	char buffer[1024] ;
-	sprintf(buffer, "pausing_keep osd %d", p_level );
-	write_command ( buffer );
+	MCAutoStringRef t_pause_cmd;
+	if (MCStringFormat(&t_pause_cmd, "pausing_keep osd %d", p_level))
+		write_command (*t_pause_cmd);
 }
 
 void MPlayer::osd(void)
 {
-	write_command("pausing_keep osd");
+	write_command(MCSTR("pausing_keep osd"));
 }
 
 void MPlayer::quit(void)
@@ -412,7 +406,7 @@ void MPlayer::quit(void)
 	if ( m_cpid > -1 && m_window != DNULL ) 
 	{
 		int t_status ;
-		write_command("quit");
+		write_command(MCSTR("quit"));
 		// Wait for the child to quit.
 		waitpid(m_cpid, &t_status, 0) ;
 		shutdown();
@@ -425,61 +419,108 @@ void MPlayer::quit(void)
 		}
 
 	}
-} 
+}  
 
-
-void MPlayer::set_property (const char * p_prop, const char * p_value ) 
+void MPlayer::set_property(const char * p_prop, MCPlayerPropertyType p_type, void *p_value) 
 {
-	char t_buffer[1024] ;
-	sprintf(t_buffer, "pausing_keep set_property %s %s", p_prop, p_value ) ;
-	write_command( t_buffer ) ;
+	MCAutoStringRef t_set_cmd;
+	bool t_success = false;
+	switch (p_type)
+	{
+		case kMCPlayerPropertyTypeUInt:
+		{
+			uint4 t_value;
+			t_value = *(uint4 *)p_value;
+			t_success = MCStringFormat(&t_set_cmd, "pausing_keep set_property %s %d", p_prop, t_value);
+		}			
+			break;
+		case kMCPlayerPropertyTypeDouble:
+		{
+			double t_value;
+			t_value = *(double *)p_value;
+			t_success = MCStringFormat(&t_set_cmd, "pausing_keep set_property %s %f", p_prop, t_value);
+		}
+			break;
+		case kMCPlayerPropertyTypeBool:
+		{
+			const char *t_value;
+			if (*(bool *)p_value)
+				t_value = "0";
+			else
+				t_value = "-1";
+			t_success = MCStringFormat(&t_set_cmd, "pausing_keep set_property %s %s", p_prop, t_value);
+		}
+			break;
+		default:
+			return;
+	}
+	
+	if (t_success)
+		write_command (*t_set_cmd);
 }
 
 
-char * MPlayer::get_property (const char * p_prop ) 
+bool MPlayer::get_property(const char* p_prop, MCPlayerPropertyType p_type, void *r_value) 
 {
 	if ( m_window == DNULL ) 
-		return NULL;
-		
-	char t_response[1024] ;
-	char t_question[1024];
-	sprintf(t_question, "pausing_keep get_property %s", p_prop);
-	sprintf(t_response, "ANS_%s=", p_prop);
-	write_command(t_question);
-	return (read_command(t_response));
-}
+		return false;
 
+	MCAutoStringRef t_get_cmd;
+	if (!MCStringFormat(&t_get_cmd, "pausing_keep get_property %s", p_prop))
+		return false;
+	
+	write_command (*t_get_cmd);
+		
+	MCAutoStringRef t_response;
+	if (!MCStringFormat(&t_response, "ANS_%s=", p_prop))
+		return false;
+
+	MCAutoStringRef t_string_value;
+	if (!read_command(*t_response, &t_string_value))
+		return false;
+
+	switch (p_type)
+	{
+		case kMCPlayerPropertyTypeUInt:
+		{
+			uint4 t_value;
+			if (!MCU_strtol(*t_string_value, (int4&)t_value))
+				return false;
+			*(uint4 *)r_value = t_value;
+			return true;
+		}		
+		case kMCPlayerPropertyTypeDouble:
+		{
+			double t_value;
+			if (!MCU_stor8(*t_string_value, t_value, false))
+				return false;
+			*(double *)r_value = t_value;
+			return true;
+		}
+		case kMCPlayerPropertyTypeBool:
+		default:
+			break;
+	}
+	return false;
+}
 
 uint4 MPlayer::getduration(void)
 {
 	if (m_duration == UINT32_MAX)
 	{
-		char * t_ret ;
-		t_ret = get_property("stream_length") ;
-		if ( t_ret != NULL )
-		{
- 			m_duration = atoi(t_ret);
-			free (t_ret);
-		}
-		else 
-			m_duration = 0 ;
+		if (!get_property("stream_length", kMCPlayerPropertyTypeUInt, &m_duration))
+			m_duration = 0;
 	}
-	return m_duration ;
+	return m_duration;
 }
 
 
 uint4 MPlayer::getcurrenttime(void)
 {
-	char * t_ret ;
 	uint4 t_time;
-	t_ret = get_property("stream_pos") ;
-	if ( t_ret != NULL )
-	{
- 		t_time = atoi(t_ret);
-		free (t_ret);
-	}
-	else 
+	if (!get_property("stream_pos", kMCPlayerPropertyTypeUInt, &t_time))
 		t_time = 0;
+
 	return t_time;
 }
 
@@ -489,16 +530,14 @@ uint4 MPlayer::gettimescale(void)
 	if (m_timescale == UINT32_MAX)
 	{
 		double t_length ;
-		char * t_ret ;
-		t_ret = get_property("length") ;
-		if ( t_ret != NULL )
+		if (get_property("length", kMCPlayerPropertyTypeDouble, &t_length))
 		{
-			t_length = atof(t_ret);
-			m_timescale = floor(getduration() / t_length) ;
-			free (t_ret);
+			m_timescale = floor(getduration() / t_length);
 		}
-		else 
-			m_timescale = 1 ;
+		else
+		{
+			m_timescale = 1;
+		}
 	}
 	return m_timescale ;
 }
@@ -506,33 +545,25 @@ uint4 MPlayer::gettimescale(void)
 
 void MPlayer::setspeed(double p_speed)
 {
-	char t_buffer[100];
-	sprintf(t_buffer, "%f", p_speed);
-	set_property("speed", t_buffer);
+	set_property("speed", kMCPlayerPropertyTypeDouble, &p_speed);
 }
 
 void MPlayer::setlooping(bool p_loop)
 {
-	set_property("looping", (char*)(p_loop ? "0" : "-1") ) ;
+	set_property("looping", kMCPlayerPropertyTypeBool, &p_loop);
 }	
 
-void MPlayer::setloudness(uint4 p_volume )
+void MPlayer::setloudness(uint4 p_volume)
 {
-	char t_buffer[4] ;
-	sprintf(t_buffer,"%d", p_volume);
-	set_property("volume", t_buffer);
+	set_property("volume", kMCPlayerPropertyTypeUInt, &p_volume);
 }
 
 uint4 MPlayer::getloudness(void)
 {
 	if (m_loudness == UINT32_MAX)
 	{
-		char * t_ret ;
-		t_ret = get_property("volume") ;
-		if ( t_ret != NULL)
-			m_loudness = atoi(t_ret);
-		else 
-			m_loudness = 0 ;
+		if (!get_property("volume", kMCPlayerPropertyTypeUInt, &m_loudness))
+			m_loudness = 0;
 	}
 	return m_loudness;
 

--- a/engine/src/lnxmplayer.h
+++ b/engine/src/lnxmplayer.h
@@ -18,6 +18,13 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef MPLAYER_H
 #define MPLAYER_H
 
+enum MCPlayerPropertyType
+{
+	kMCPlayerPropertyTypeBool,
+	kMCPlayerPropertyTypeUInt,
+	kMCPlayerPropertyTypeDouble,
+};
+
 class MPlayer
 {
 	public:
@@ -74,15 +81,13 @@ class MPlayer
 		uint32_t m_loudness ;
 
 	
-		bool launch_player(void) ;
-		void write_command (const char * p_cmd) ;
-		char * read_command(const char * p_ans ) ;
-		char * get_property (const char * p_prop) ;
-		void set_property (const char * p_prop, const char * p_value) ;
-
-
+		bool launch_player(void);
+		void write_command(MCStringRef p_cmd);
+		bool read_command(MCStringRef p_ans, MCStringRef& r_ret);
+		bool get_property(const char *p_prop, MCPlayerPropertyType p_type, void *r_value);
+		void set_property(const char *p_prop, MCPlayerPropertyType p_type, void *p_value);
+		
 } ;
-
 
 
 #endif


### PR DESCRIPTION
Previously there was at least one memory management issue with the
c strings used in the code.
