### PR TITLE
[Bug 18441] Fixed typo in MCStoreExecConfirmPurchaseDelivery

### DIFF
--- a/docs/notes/bugfix-18441.md
+++ b/docs/notes/bugfix-18441.md
@@ -1,0 +1,1 @@
+# Make sure the purchaseStateUpdate callback is sent with status=complete when necessary

--- a/engine/src/exec-store.cpp
+++ b/engine/src/exec-store.cpp
@@ -282,7 +282,7 @@ void MCStoreExecConfirmPurchaseDelivery(MCExecContext& ctxt, uint32_t p_id)
     t_success = MCPurchaseFindById(p_id, t_purchase);
     
     if (t_success)
-        t_success = (!(t_purchase->state == kMCPurchaseStatePaymentReceived || t_purchase->state == kMCPurchaseStateRefunded || t_purchase->state == kMCPurchaseStateRestored));
+        t_success = (t_purchase->state == kMCPurchaseStatePaymentReceived || t_purchase->state == kMCPurchaseStateRefunded || t_purchase->state == kMCPurchaseStateRestored);
 	
 	if (t_success)
 		t_success = MCPurchaseConfirmDelivery(t_purchase);


### PR DESCRIPTION
The code for the (now deprecated) `mobilePurchaseConfirmDelivery tPurchaseID` function was incorrectly refactored from LC 6 -> 7, resulting in the callback `purchaseStateUpdate` to never being sent with `status`=`complete`.

This function has been replaced by `mobileStoreConfirmPurchase tProductID`, but some users may have legacy code that runs on LC 6.x but breaks in LC 7 and 8
