### PR TITLE
[Docs] Command Syntax and Parameter fixes - 2

### DIFF
--- a/docs/dictionary/command/encrypt-using-rsa.lcdoc
+++ b/docs/dictionary/command/encrypt-using-rsa.lcdoc
@@ -2,7 +2,7 @@ Name: encrypt using rsa
 
 Type: command
 
-Syntax: encrypt <source> using rsa with {public | private} key <key> [and passphrase <passphrase>]
+Syntax: encrypt <message> using rsa with {public | private} key <key> [and passphrase <passphrase>]
 
 Summary:
 Encrypt data using the RSA algorithm.
@@ -22,9 +22,6 @@ Example:
 encrypt thisMessage using rsa with private key privateKey
 
 Parameters:
-source:
-
-
 key:
 The key to be used for the encryption, in PEM format
 
@@ -38,22 +35,22 @@ Description:
 Use the <encrypt using rsa> command to encrypt a message using RSA
 public key encryption.
 
-Use the form 
-encrypt <message> with public key <key> 
-to encode a message that you only want to be decoded by the holder of
-the private key.
+To encode a message that you only want to be decoded by the holder of
+the private key, use the form:
 
-Use the form 
-encrypt <message> with private key <key> 
-to encode a message that a receiver can then verify has come from one of
-the holders of the private key (this is a signing operation).
+    encrypt <message> with public key <key> 
 
-Generating key pairs
-Public-private key pairs can be generated using the OpenSSL suite of
-command-line tools. For example: openssl genrsa -out private_key.pem 512
-openssl rsa -pubout -in private_key.pem -out public_key.pem
-Will generate a key pair of size 512-bits, placing the private key in
-private_key.pem and the public key in public_key.pem.
+As a signing operation, to encode a message that a receiver can then verify 
+has come from one of the holders of the private key, use the form:
+
+    encrypt <message> with private key <key> 
+
+> **Generating key pairs - **
+> Public-private key pairs can be generated using the OpenSSL suite of
+> command-line tools. For example: openssl genrsa -out private_key.pem 512
+> openssl rsa -pubout -in private_key.pem -out public_key.pem
+> Will generate a key pair of size 512-bits, placing the private key in
+> private_key.pem and the public key in public_key.pem.
 
 For more information on these utilities see
 http://www.openssl.org/docs/apps/rsa.html and

--- a/docs/dictionary/command/encrypt-using-rsa.lcdoc
+++ b/docs/dictionary/command/encrypt-using-rsa.lcdoc
@@ -45,12 +45,12 @@ has come from one of the holders of the private key, use the form:
 
     encrypt <message> with private key <key> 
 
-> **Generating key pairs - **
-> Public-private key pairs can be generated using the OpenSSL suite of
-> command-line tools. For example: openssl genrsa -out private_key.pem 512
-> openssl rsa -pubout -in private_key.pem -out public_key.pem
-> Will generate a key pair of size 512-bits, placing the private key in
-> private_key.pem and the public key in public_key.pem.
+#### Generating key pairs
+Public-private key pairs can be generated using the OpenSSL suite of
+command-line tools. For example: openssl genrsa -out private_key.pem 512
+openssl rsa -pubout -in private_key.pem -out public_key.pem
+Will generate a key pair of size 512-bits, placing the private key in
+private_key.pem and the public key in public_key.pem.
 
 For more information on these utilities see
 http://www.openssl.org/docs/apps/rsa.html and

--- a/docs/dictionary/command/export-snapshot.lcdoc
+++ b/docs/dictionary/command/export-snapshot.lcdoc
@@ -2,9 +2,9 @@ Name: export snapshot
 
 Type: command
 
-Syntax: export snapshot [from rect[angle] <rectangle>] [of <object(glossary)>] [(with | without) effects] ... | [from <object>] [{with|and} metadata <metadata>] to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
+Syntax: export snapshot [from rect[angle] <rectangle>] [of <object(glossary)>] [(with | without) effects] <suffix> | [from <object>] [{with|and} metadata <metadata>] to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
 
-Syntax: export snapshot [from rect[angle] <rectangle>] of <object(glossary)> [(with | without) effects] ... | [from <object>] [at size width, height] [{with|and} metadata <metadata>] to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
+Syntax: export snapshot [from rect[angle] <rectangle>] of <object(glossary)> [(with | without) effects] <suffix> | [from <object>] [at size width, height] [{with|and} metadata <metadata>] to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
 
 Summary:
 Creates a picture file from a portion of the screen.
@@ -66,10 +66,8 @@ maskFile:
 Specifies the name and location of a file to export as an image mask.
 You can use a maskFile only when exporting in PBM format (paint).
 
-effect:
-Specifies whether graphic effects and a blendLevel should be applied to
-the object before rendering export. ...: Denotes the usual possible
-suffixes for the export snapshot command.
+suffix:
+The usual possible suffixes for the export snapshot command.
 
 Description:
 Use the <export snapshot> <command> to export a screenshot to a <file>
@@ -82,6 +80,9 @@ can specify a location for the mask file.) The <export snapshot> ... as
 JPEG form exports as a JPEG file, and the <export snapshot> ... as PNG
 form exports as a PNG file. If you do not specify a <format>, the file
 is exported as <PBM>, PGM, or <PPM>.
+
+Using 'with' or 'without effects' specifies whether graphic effects and a 
+blendLevel should be applied to the object before rendering export.
 
 iOS supports both the object and screen snapshot variants of the export
 snapshot command. In the screen snapshot case, coordinates are given
@@ -121,10 +122,12 @@ Where 'chunk' is any chunk expression resolving to a control, or any
 expression evaluating to a control reference.
 
 To export a snapshot of an object in iOS use the form:
-<export snapshot> from [rectangle rect of] <object(glossary)> 
+
+    <export snapshot> from [rectangle rect of] <object(glossary)> 
 
 To export a snapshot of the screen in iOS use the form:
-<export snapshot> from rectangle rect
+
+    <export snapshot> from rectangle rect
 
 >*Note:*  There is no way to render the status bar without using private
 > features of the iOS API. Therefore, if your snapshot rectangle

--- a/docs/dictionary/command/export-widget.lcdoc
+++ b/docs/dictionary/command/export-widget.lcdoc
@@ -15,7 +15,8 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, mobile
 
 Example:
-export widget 1 to array myArray
+local tMyArray
+export widget 1 to array tMyArray
 
 Parameters:
 widget:

--- a/docs/dictionary/command/export-widget.lcdoc
+++ b/docs/dictionary/command/export-widget.lcdoc
@@ -2,7 +2,7 @@ Name: export widget
 
 Type: command
 
-Syntax: export <widget> to array arrayVar
+Syntax: export <widget> to array <arrayVar>
 
 Summary:
 Exports the state of the given widget in a form which can be imported
@@ -15,7 +15,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, mobile
 
 Example:
-export widget 1 to array tMyArray
+export widget 1 to array myArray
 
 Parameters:
 widget:
@@ -35,8 +35,7 @@ typically the values of all the widget's persistent properties, although
 its exact structure is defined by the widget.
 
 >*Note:* The <export widget> command is subject to change throughout the
-> 8.0 
-development cycle.
+> 8.0 development cycle.
 
 References: import widget (command), create widget (command)
 

--- a/docs/dictionary/command/kill.lcdoc
+++ b/docs/dictionary/command/kill.lcdoc
@@ -27,12 +27,12 @@ kill QUIT process it
 Parameters:
 signalNumber:
 The number of the Unix signal to send to the process. 
->*Note:* The signalNumber parameter is ignored on Mac OS and Windows systems.
+>*Note:* The <signalNumber> parameter is ignored on Mac OS and Windows systems.
 
 signalName:
 The name of a Unix signal, minus the leading "SIG". (For example, to
-send SIGHUP to a process, use HUP as the signalName.)
->*Note:* The signalName parameter is ignored on Mac OS and Windows systems.
+send SIGHUP to a process, use HUP as the <signalName>.)
+>*Note:* The <signalName> parameter is ignored on Mac OS and Windows systems.
 
 processName:
 The name of a currently executing process.

--- a/docs/dictionary/command/kill.lcdoc
+++ b/docs/dictionary/command/kill.lcdoc
@@ -2,7 +2,7 @@ Name: kill
 
 Type: command
 
-Syntax: kill [<signalNumber> | <signalName>] process <processName>
+Syntax: kill [{<signalNumber> | <signalName>}] process <processName>
 
 Summary:
 Signals or quits another <process> or application on the same system.
@@ -26,13 +26,13 @@ kill QUIT process it
 
 Parameters:
 signalNumber:
-The number of the Unix signal to send to the process. The signalName is
-the name of a Unix signal, minus the leading "SIG". (For example, to
-send SIGHUP to a process, use HUP as the signalName.) (The signalNumber
-or signalName parameter is ignored on Mac OS and Windows systems.)
+The number of the Unix signal to send to the process. 
+>*Note:* The signalNumber parameter is ignored on Mac OS and Windows systems.
 
 signalName:
-
+The name of a Unix signal, minus the leading "SIG". (For example, to
+send SIGHUP to a process, use HUP as the signalName.)
+>*Note:* The signalName parameter is ignored on Mac OS and Windows systems.
 
 processName:
 The name of a currently executing process.

--- a/docs/dictionary/command/libURLFollowHttpRedirects.lcdoc
+++ b/docs/dictionary/command/libURLFollowHttpRedirects.lcdoc
@@ -2,7 +2,7 @@ Name: libURLFollowHttpRedirects
 
 Type: command
 
-Syntax: libURLFollowHttpRedirects &lt;true|false&gt;
+Syntax: libURLFollowHttpRedirects {true|false}
 
 Summary:
 Set this to true if you want libURL GET requests to follow HTTP

--- a/docs/dictionary/command/libURLSetLogField.lcdoc
+++ b/docs/dictionary/command/libURLSetLogField.lcdoc
@@ -27,16 +27,7 @@ libURLSetLogField(the cLogField of me)
 
 Parameters:
 longFieldDescriptor:
-
-
-fieldDescriptor:
-Any expression that evaluates to a field reference.>*Important:* The
-libURLSetLogField command does not accept direct field references. For
-example, the following statement causes an error message:
-libURLSetLogField field "Log" -- CAN'T USE THIS FORM Instead, use a form
-that evaluates to a field reference, like this: : libURLSetLogField the
-name of field "Log" -- use this form instead libURLSetLogField ("field"
-&& quote & "Log" & quote) -- or this
+Any expression that evaluates to a field reference.
 
 Description:
 Use the <libURLSetLogField> <command> to <debug> file transfers.

--- a/docs/dictionary/command/libURLftpUpload.lcdoc
+++ b/docs/dictionary/command/libURLftpUpload.lcdoc
@@ -28,12 +28,14 @@ libURLftpUpload myData,"ftp://me:secret@example.net/file.txt"
 
 Parameters:
 value (string):
-
+The data to upload.
 
 uploadURL:
 The uploadURL specifies the server and location to upload to,
-in the form of an FTP URL. callbackMessage: The name of a message to
-send after the URL is uploaded.
+in the form of an FTP URL. 
+
+callbackMessage: 
+The name of a message to send after the URL is uploaded.
 
 Description:
 Use the <libURLftpUpload> <command> to put a <file> on a
@@ -72,10 +74,8 @@ command is part of the <Internet library> and is implemented in a
 particular, do not use constructions like the following, which will sit
 forever without <upload|uploading> the file:
 
-    libURLftpUpload field "Upload Data" ,myURL wait until the URLStatus \
-          of
-
-    myURL is "uploaded" -- DON'T DO THIS
+    libURLftpUpload field "Upload Data" ,myURL wait until the \
+        URLStatus of myURL is "uploaded" -- DON'T DO THIS
 
 
 The <URLStatus> <function(control structure)> returns the status of the

--- a/docs/dictionary/command/libUrlSetAuthCallback.lcdoc
+++ b/docs/dictionary/command/libUrlSetAuthCallback.lcdoc
@@ -4,6 +4,9 @@ Type: command
 
 Syntax: libURLSetAuthCallback
 
+Summary:
+Allows HTTP Server authentication message handling by a callback routine.
+
 Associations: internet library
 
 Introduced: 2.5

--- a/docs/dictionary/command/libUrlSetExpect100.lcdoc
+++ b/docs/dictionary/command/libUrlSetExpect100.lcdoc
@@ -4,6 +4,9 @@ Type: command
 
 Syntax: libURLSetExpect100 <limit>
 
+Summary:
+Allows for a '100 Continue' header response to be received from the server
+
 Associations: internet library
 
 Introduced: 2.5
@@ -16,11 +19,9 @@ Security: network
 
 Parameters:
 limit:
-
+A number of bytes.
 
 Description:
-<limit> is a number of bytes. 
-
 When called, subsequent <POST> requests will add an
 "Expect: 100-continue" field to the http headers when the data to be
 posted excedes the limit. The data won't be written to the socket until

--- a/docs/dictionary/command/libUrlSetSSLVerification.lcdoc
+++ b/docs/dictionary/command/libUrlSetSSLVerification.lcdoc
@@ -4,6 +4,9 @@ Type: command
 
 Syntax: libURLSetSSLVerification {true|false}
 
+Summary:
+Allows for server credential authentication.
+
 Associations: internet library
 
 Introduced: 2.5

--- a/docs/dictionary/command/local.lcdoc
+++ b/docs/dictionary/command/local.lcdoc
@@ -80,8 +80,9 @@ is recompiled.
 It is recommended that naming conventions are followed for <variable>s in 
 Livecode <script>s. For handler <local variable>s prefix with a lowercase 't' 
 and for <script local variable>s prefix with a lowercase 's' (as in 
-tMyVariable and sMyVariable). This helps in understanding a variables 
-influence across the application.
+tMyVariable and sMyVariable). This enables anyone reading the code to 
+identify the <scope> of a variable when it is used, without having to 
+find where it is <declare|declared>
 
 References: constant (command), do (command), delete variable (command),
 global (command), variableNames (function), localNames (function),
@@ -89,5 +90,5 @@ property (glossary), variable (glossary), handler (glossary),
 value (glossary), global (glossary), local variable (glossary),
 declare (glossary), script local variable (glossary), command (glossary),
 preserveVariables (property), script (property),
-explicitVariables (property)
+explicitVariables (property), scope (glossary)
 

--- a/docs/dictionary/command/local.lcdoc
+++ b/docs/dictionary/command/local.lcdoc
@@ -2,7 +2,7 @@ Name: local
 
 Type: command
 
-Syntax: local <variablesList>
+Syntax: local <variableName> [= <value>] [, ...]
 
 Summary:
 <declare|Declares> one or more <local variable|local variables> and
@@ -18,29 +18,25 @@ Example:
 local currentStatus -- creates one local variable
 
 Example:
-local thisThing,thatThing,theOtherThing -- creates three variables
+local thisThing, thatThing, theOtherThing -- creates 3 variables
 
 Example:
 local A=1,B=2,C=3 -- creates variables with initial values
 
 Example:
 -- To make a numbered list of variables:
-repeat with x=1 to 20
-  do "local tVar_" & x & "; put empty into tVar_" & x
+repeat with tNum = 1 to 20
+    do "local tVar_" & tNum & "; put empty into tVar_" & tNum
 end repeat
 
 Parameters:
-variablesList (enum):
-The variablesList consists of one or more name=value pairs, separated by
-commas: 
-
--  The name is any string.
--  The value is any literal string.
-
+variableName:
+The variableName is any string.
 
 value:
-Optional; you can specify just the variable name. In this case, the
-specified local variables contain empty when created.
+Optional; The <value> is any literal string. You can specify just the 
+variable name. In this case, the specified <local variable>s contain 
+empty when created.
 
 Description:
 Use the <local> <command> to define a <local variable> for a <handler>,
@@ -80,6 +76,12 @@ turned on, script locals retain their values when the <script> is
 re-compiled, unless there is an error in the script. With variable
 preservation turned off, script locals lose their values when the script
 is recompiled.
+
+It is recommended that naming conventions are followed for <variable>s in 
+Livecode <script>s. For handler <local variable>s prefix with a lowercase 't' 
+and for <script local variable>s prefix with a lowercase 's' (as in 
+tMyVariable and sMyVariable). This helps in understanding a variables 
+influence across the application.
 
 References: constant (command), do (command), delete variable (command),
 global (command), variableNames (function), localNames (function),

--- a/docs/dictionary/command/mobileAdCreate.lcdoc
+++ b/docs/dictionary/command/mobileAdCreate.lcdoc
@@ -22,36 +22,46 @@ The name of the ad to create. This is used to reference the ad
 throughout its lifetime.
 
 type (enum):
-The type of the ad. The possible ad types are:
+The ad type.
 
-- 'text'
-- 'full screen'
-- 'banner' - This is the default.
+- "text":
+- "full screen":
+- "banner": This is the default.
 
 
 topLeft:
 The location of the top left corner of the ad (coordinates are
 in left,top - x,y order) in pixels. The default is: 0,0
 
-metaData (enum):
+metaData:
 An array of values that are used to target the ad. The keys 
 are as follows: 
 
--   "phone number": The user's mobile number (MSISDN format with international prefix).
--   "keywords": Keywords relevant to the user's specific session. This is comma separated without spaces.
--   "gender": The expected gender of the target user. The allowed values are M, m, Male, F, f, Female.
--   "distribution id": The distribution Channel ID (559 for banner ads and full screen ads, 600 for text ads).
--   "refresh": A value in seconds that defines how often the ad should refresh. Values are between 30 and 300 seconds. The default is 120 seconds. 
+-   "phone number": The user's mobile number (MSISDN format with 
+international prefix).
+-   "keywords": Keywords relevant to the user's specific session. This 
+is comma separated without spaces.
+-   "gender": The expected gender of the target user. The allowed values 
+are M, m, Male, F, f, Female.
+-   "distribution id": The distribution Channel ID (559 for banner ads 
+and full screen ads, 600 for text ads).
+-   "refresh": A value in seconds that defines how often the ad should 
+refresh. Values are between 30 and 300 seconds. The default is 120 seconds. 
 -   "age": An integer defining the expected age of the target user.
--   "coordinates": GPS ISO code location data in latitude, longitude format. - (iOS only)
--   "location": A comma delimited list of country, state/province, city. - (iOS only)
+-   "coordinates": GPS ISO code location data in latitude, longitude 
+format. - (iOS only)
+-   "location": A comma delimited list of country, state/province, 
+city. - (iOS only)
 
 
 The result:
--   'empty': If successful.
--   'not registered with service': if you did not register your app id using <mobileAdRegister> before calling <mobileAdCreate>. 
--   'ad already exists': if an ad of the given name already exists.
--   'could not create ad': if the ad could not be created. This is the case, if the app does not have Internet permissions or the registered app key is not valid.
+-   empty: If successful.
+-   "not registered with service": if you did not register your app id 
+using <mobileAdRegister> before calling <mobileAdCreate>. 
+-   "ad already exists": if an ad of the given name already exists.
+-   "could not create ad": if the ad could not be created. This is the 
+case, if the app does not have Internet permissions or the registered 
+app key is not valid.
 
 Description:
 Use the <mobileAdCreate> to place an add of a given type.

--- a/docs/dictionary/command/mobileAdCreate.lcdoc
+++ b/docs/dictionary/command/mobileAdCreate.lcdoc
@@ -49,7 +49,7 @@ are as follows:
 
 The result:
 -   'empty': If successful.
--   'not registered with service': if you did not register your app id using mobileAdRegister before calling <mobileAdCreate>. 
+-   'not registered with service': if you did not register your app id using <mobileAdRegister> before calling <mobileAdCreate>. 
 -   'ad already exists': if an ad of the given name already exists.
 -   'could not create ad': if the ad could not be created. This is the case, if the app does not have Internet permissions or the registered app key is not valid.
 

--- a/docs/dictionary/command/mobileAdCreate.lcdoc
+++ b/docs/dictionary/command/mobileAdCreate.lcdoc
@@ -22,53 +22,36 @@ The name of the ad to create. This is used to reference the ad
 throughout its lifetime.
 
 type (enum):
-The type of the ad. The possible ad types are
+The type of the ad. The possible ad types are:
 
-- "text"
-- "full screen"
-
-
--   "banner": This is the default.
+- 'text'
+- 'full screen'
+- 'banner' - This is the default.
 
 
 topLeft:
-The location in pixel of the top left corner of the ad (coordinates are
-in left,top - x,y order). The default is: 0,0
+The location of the top left corner of the ad (coordinates are
+in left,top - x,y order) in pixels. The default is: 0,0
 
 metaData (enum):
-An array of values that are used to target the ad. The keys are as
-follows: 
+An array of values that are used to target the ad. The keys 
+are as follows: 
 
--   "phone number": The user's mobile number (MSISDN format with
-    international prefix).
--   "keywords": Keywords relevant to the user's specific session. This
-    is comma separated without spaces.
--   "gender": The expected gender of the target user. The allowed values
-    are M, m, Male, F, f, Female.
--   "distribution id": The distribution Channel ID (559 for banner ads
-    and full screen ads, 600 for text ads).
--   "refresh": A value in seconds that defines how often the ad should
-    refresh. Values are between 30 and 300 seconds. The default is 120
-    seconds. 
+-   "phone number": The user's mobile number (MSISDN format with international prefix).
+-   "keywords": Keywords relevant to the user's specific session. This is comma separated without spaces.
+-   "gender": The expected gender of the target user. The allowed values are M, m, Male, F, f, Female.
+-   "distribution id": The distribution Channel ID (559 for banner ads and full screen ads, 600 for text ads).
+-   "refresh": A value in seconds that defines how often the ad should refresh. Values are between 30 and 300 seconds. The default is 120 seconds. 
 -   "age": An integer defining the expected age of the target user.
--   "coordinates": GPS ISO code location data in latitude, longitude
-    format. - This is only available on iOS.
--   "location": A comma delimited list of country, state/province, city.
-    - This is only available on iOS.
+-   "coordinates": GPS ISO code location data in latitude, longitude format. - (iOS only)
+-   "location": A comma delimited list of country, state/province, city. - (iOS only)
 
 
 The result:
-If successful, the result is empty.
-The result contains: not registered with service, if you did not
-register your app id using mobileAdRegister before calling
-<mobileAdCreate>. 
-
-The result contains: ad already exists, if an ad of the given name
-already exists.
-
-The result contains: could not create ad, if the ad could not be
-created. This is the case, if the app does not have Internet permissions
-or the registered app key is not valid.
+-   'empty': If successful.
+-   'not registered with service': if you did not register your app id using mobileAdRegister before calling <mobileAdCreate>. 
+-   'ad already exists': if an ad of the given name already exists.
+-   'could not create ad': if the ad could not be created. This is the case, if the app does not have Internet permissions or the registered app key is not valid.
 
 Description:
 Use the <mobileAdCreate> to place an add of a given type.

--- a/docs/dictionary/command/mobileAdDelete.lcdoc
+++ b/docs/dictionary/command/mobileAdDelete.lcdoc
@@ -21,10 +21,13 @@ ad:
 The name of the loaded ad to delete.
 
 The result:
--   'empty': If successful.
--   'not registered with service': if you did not register your app id using <mobileAdRegister> before calling <mobileAdCreate>. 
--   'ad already exists': if an ad of the given name already exists.
--   'could not create ad': if the ad could not be created. This is the case, if the app does not have Internet permissions or the registered app key is not valid.
+-   empty: If successful.
+-   "not registered with service": if you did not register your app 
+id using <mobileAdRegister> before calling <mobileAdCreate>. 
+-   "ad already exists": if an ad of the given name already exists.
+-   "could not create ad": if the ad could not be created. This is 
+the case, if the app does not have Internet permissions or the 
+registered app key is not valid.
 
 
 Description:

--- a/docs/dictionary/command/mobileAdDelete.lcdoc
+++ b/docs/dictionary/command/mobileAdDelete.lcdoc
@@ -21,17 +21,11 @@ ad:
 The name of the loaded ad to delete.
 
 The result:
-If successful, the result is empty.
-The result contains: not registered with service, if you did not
-register your app id using <mobileAdRegister> before calling
-<mobileAdDelete>. 
+-   'empty': If successful.
+-   'not registered with service': if you did not register your app id using <mobileAdRegister> before calling <mobileAdCreate>. 
+-   'ad already exists': if an ad of the given name already exists.
+-   'could not create ad': if the ad could not be created. This is the case, if the app does not have Internet permissions or the registered app key is not valid.
 
-The result contains: ad cannot be found, if an ad of the given name
-cannot be found.
-
-The result contains: could not create ad, if the ad could not be
-created. This is the case, if the app does not have Internet permissions
-or the registered app key is not valid.
 
 Description:
 Use the <mobileAdDelete> command to delete a given ad.

--- a/docs/dictionary/command/mobileAddContact.lcdoc
+++ b/docs/dictionary/command/mobileAddContact.lcdoc
@@ -22,37 +22,81 @@ mobileUpdateContact tContact
 
 Parameters:
 contactArray (array):
-(enum): <name/> Person Information - The personal information of the
-contact is stored at the top level of the array and has the following
-keys: 
+**Person Information** - The personal information of the contact is stored 
+at the top level of the array and has the following keys: 
 
-- "firstname": The first name.
-- "middlename": The middle name.
-- "lastname": The last name.
-- "alternatename": The alternative name.
-- "nickname": The nick name (iOS only).
-- "firstnamephonetic": The phonetic transcription of the first name.
-- "middlenamephonetic": The phonetic transcription of the middle name.
-- "lastnamephonetic": The phonetic transcription of the last name.
-- "prefix": The name prefix.
-- "suffix": The name suffix.
-- "organization": The name of the organization.
-- "jobtitle": The job title (iOS only).
-- "department": The name of the department (iOS only).
-- "message": A person message (iOS only).
-- "note": A person note.
+- `firstname`: The first name.
+- `middlename`: The middle name.
+- `lastname`: The last name.
+- `alternatename`: The alternative name.
+- `nickname`: The nick name (iOS only).
+- `firstnamephonetic`: The phonetic transcription of the first name.
+- `middlenamephonetic`: The phonetic transcription of the middle name.
+- `lastnamephonetic`: The phonetic transcription of the last name.
+- `prefix`: The name prefix.
+- `suffix`: The name suffix.
+- `organization`: The name of the organization.
+- `jobtitle`: The job title (iOS only).
+- `department`: The name of the department (iOS only).
+- `message`: A person message (iOS only).
+- `note`: A person note.
 
+**E-Mail Addresses** - The e-mail addresses of the contact are stored in 
+integer indexed arrays starting at one under the key email. This allows any 
+number of e-mail addresses to be stored against a particular category. 
+
+There are three categories of e-mail address:
+-	`home`: - The home e-mail address.       
+-	`work`: - The work e-mail address.
+-	`other`: - An alternative e-mail address.
+
+**Telephone Numbers** - The telephone numbers of the contact are stored in 
+integer indexed arrays starting at one under the key phone. This allows 
+any number of telephone numbers to be stored against a particular category. 
+
+There are ten categories of phone numbers:
+-	`mobile` - The mobile telephone number.       
+-	`iphone` - The iPhone telephone number (iOS only).
+-	`main` - The main telephone number (iOS only).
+-	`home` - The home telephone number.
+-	`work` - The work telephone number.
+-	`homefax` - The home FAX number (iOS only).
+-	`workfax` - The work FAX number (iOS only).
+-	`otherfax` - The other FAX number (iOS >= 5.0 only).
+-	`pager` - The pager number (iOS only).
+-	`other` - An alternative telephone number.
+
+**Address** - Addresses of the contact are stored as sub arrays under the 
+key address. 
+
+There are three categories of address:
+-	`home` - The home address.       
+-	`work` - The work address.
+-	`other` - The other address.
+
+**Address Subkey** - Each address category is an integer indexed array, 
+starting at one under the key address. This allows any number of 
+addresses to be stored against a particular category. 
+
+There are six categories of address subkey:
+-	`street` - The address street.       
+-	`city` - The address city.
+-	`state` - The address state.
+-	`zip` - The address ZIP code.
+-	`country` - The address country.
+-	`countrycode` - The address country code (iOS only).
 
 Returns:
 The ID of the contact that was created.
-If no contact could be created, then empty is returned.
+If no contact could be created, then *empty* is returned.
 
 Description:
 Allows the user to create a contact in the contact list, based on some
 existing contact information. The contact information is collected in a
-nested array structure that is defined as follows:
+nested array structure that is defined in the Parameters section.
 
 Use the <mobileAddContact> command to add a contact to the contact list.
+Use the <mobileGetContactData> function to retreive contact 
 
 References: mobilePickDate (command), mobileRemoveContact (command),
 mobilePickMedia (command), mobilePickContact (command),

--- a/docs/dictionary/command/mobileAddContact.lcdoc
+++ b/docs/dictionary/command/mobileAddContact.lcdoc
@@ -22,69 +22,7 @@ mobileUpdateContact tContact
 
 Parameters:
 contactArray (array):
-**Person Information** - The personal information of the contact is stored 
-at the top level of the array and has the following keys: 
-
-- `firstname`: The first name.
-- `middlename`: The middle name.
-- `lastname`: The last name.
-- `alternatename`: The alternative name.
-- `nickname`: The nick name (iOS only).
-- `firstnamephonetic`: The phonetic transcription of the first name.
-- `middlenamephonetic`: The phonetic transcription of the middle name.
-- `lastnamephonetic`: The phonetic transcription of the last name.
-- `prefix`: The name prefix.
-- `suffix`: The name suffix.
-- `organization`: The name of the organization.
-- `jobtitle`: The job title (iOS only).
-- `department`: The name of the department (iOS only).
-- `message`: A person message (iOS only).
-- `note`: A person note.
-
-**E-Mail Addresses** - The e-mail addresses of the contact are stored in 
-integer indexed arrays starting at one under the key email. This allows any 
-number of e-mail addresses to be stored against a particular category. 
-
-There are three categories of e-mail address:
--	`home`: - The home e-mail address.       
--	`work`: - The work e-mail address.
--	`other`: - An alternative e-mail address.
-
-**Telephone Numbers** - The telephone numbers of the contact are stored in 
-integer indexed arrays starting at one under the key phone. This allows 
-any number of telephone numbers to be stored against a particular category. 
-
-There are ten categories of phone numbers:
--	`mobile` - The mobile telephone number.       
--	`iphone` - The iPhone telephone number (iOS only).
--	`main` - The main telephone number (iOS only).
--	`home` - The home telephone number.
--	`work` - The work telephone number.
--	`homefax` - The home FAX number (iOS only).
--	`workfax` - The work FAX number (iOS only).
--	`otherfax` - The other FAX number (iOS >= 5.0 only).
--	`pager` - The pager number (iOS only).
--	`other` - An alternative telephone number.
-
-**Address** - Addresses of the contact are stored as sub arrays under the 
-key address. 
-
-There are three categories of address:
--	`home` - The home address.       
--	`work` - The work address.
--	`other` - The other address.
-
-**Address Subkey** - Each address category is an integer indexed array, 
-starting at one under the key address. This allows any number of 
-addresses to be stored against a particular category. 
-
-There are six categories of address subkey:
--	`street` - The address street.       
--	`city` - The address city.
--	`state` - The address state.
--	`zip` - The address ZIP code.
--	`country` - The address country.
--	`countrycode` - The address country code (iOS only).
+An array describing the contact.
 
 Returns:
 The ID of the contact that was created.
@@ -93,7 +31,66 @@ If no contact could be created, then *empty* is returned.
 Description:
 Allows the user to create a contact in the contact list, based on some
 existing contact information. The contact information is collected in a
-nested array structure that is defined in the Parameters section.
+nested array structure as follows:
+
+**Person Information** - The personal information of the contact is stored 
+at the top level of the array and has the following keys: 
+
+- "firstname": The first name.
+- "middlename": The middle name.
+- "lastname": The last name.
+- "alternatename": The alternative name.
+- "nickname": The nick name (iOS only).
+- "firstnamephonetic": The phonetic transcription of the first name.
+- "middlenamephonetic": The phonetic transcription of the middle name.
+- "lastnamephonetic": The phonetic transcription of the last name.
+- "prefix": The name prefix.
+- "suffix": The name suffix.
+- "organization": The name of the organization.
+- "jobtitle": The job title (iOS only).
+- "department": The name of the department (iOS only).
+- "message": A person message (iOS only).
+- "note": A person note.
+
+**E-Mail Addresses** - The e-mail addresses of the contact are stored in 
+integer indexed arrays starting at one under the key email. This allows any 
+number of e-mail addresses to be stored against a particular category. There 
+are three categories of e-mail address:
+- "home": - The home e-mail address.       
+- "work": - The work e-mail address.
+- "other": - An alternative e-mail address.
+
+**Telephone Numbers** - The telephone numbers of the contact are stored in 
+integer indexed arrays starting at one under the key phone. This allows 
+any number of telephone numbers to be stored against a particular 
+category. There are ten categories of phone numbers:
+- "mobile" - The mobile telephone number.       
+- "iphone" - The iPhone telephone number (iOS only).
+- "main" - The main telephone number (iOS only).
+- "home" - The home telephone number.
+- "work" - The work telephone number.
+- "homefax" - The home FAX number (iOS only).
+- "workfax" - The work FAX number (iOS only).
+- "otherfax" - The other FAX number (iOS >= 5.0 only).
+- "pager" - The pager number (iOS only).
+- "other" - An alternative telephone number.
+
+**Address** - Addresses of the contact are stored as sub arrays under the 
+key address. There are three categories of address:
+- "home" - The home address.       
+- "work" - The work address.
+- "other" - The other address.
+
+**Address Subkey** - Each address category is an integer indexed array, 
+starting at one under the key address. This allows any number of 
+addresses to be stored against a particular category. There are six 
+categories of address subkey:
+- "street" - The address street.       
+- "city" - The address city.
+- "state" - The address state.
+- "zip" - The address ZIP code.
+- "country" - The address country.
+- "countrycode" - The address country code (iOS only).
 
 Use the <mobileAddContact> command to add a contact to the contact list.
 Use the <mobileGetContactData> function to retreive contact 


### PR DESCRIPTION
Fixes to the syntax and parameter sections of:
- encrypt using rsa
- export snapshot
- export widget
- kill
- libURLFollowHttpRedirects
- libURLftpUpload
- libURLSetAuthCallback
- libURLSetExpect100
- libURLSetLogField
- libURLSetSSLVerification
- local
- mobileAdCreate
- mobileAdDelete
- mobileAddContact
