### PR TITLE
[[ Travis CI ]] Don't wait with messages in the test environment

### DIFF
--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -266,7 +266,10 @@ function revDocsParseDictionaryToLibraryArray pRootDir
          get the files
          filter it with "*.lcdoc"
          repeat for each line tFile in it
-            wait 0 with messages
+            if the environment is "development" and \
+                not revTestEnvironment() then
+               wait 0 with messages
+            end if
             local tFullPath
             put tRoot & slash & tLine & slash & tFile into tFullPath
             put revDocsUtf8FileContents(tFullPath) into tText


### PR DESCRIPTION
This was apparently causing IDE loading to silently fail.
