### PR TITLE
[Docs] open driver|file|process - Syntax and parameters fixes

### DIFF
--- a/docs/dictionary/command/open-driver.lcdoc
+++ b/docs/dictionary/command/open-driver.lcdoc
@@ -2,7 +2,7 @@ Name: open driver
 
 Type: command
 
-Syntax: open driver <driverName> [for [[<encoding>] text | binary] {update | read | write}]
+Syntax: open driver <driverName> [for [{text | binary}] {update | read | write}]
 
 Summary:
 Establishes a connection to a <peripheral device|device> so you can send
@@ -29,8 +29,6 @@ Parameters:
 driverName:
 The driverName specifies the name of a device driver that's installed on
 the system.
-
-encoding:
 
 
 The result:

--- a/docs/dictionary/command/open-driver.lcdoc
+++ b/docs/dictionary/command/open-driver.lcdoc
@@ -2,7 +2,7 @@ Name: open driver
 
 Type: command
 
-Syntax: open driver <driverName> [for [{text | binary}] {update | read | write}]
+Syntax: open driver <driverName> [for [{[<encoding>] text | binary}] {update | read | write}]
 
 Summary:
 Establishes a connection to a <peripheral device|device> so you can send
@@ -29,6 +29,22 @@ Parameters:
 driverName:
 The driverName specifies the name of a device driver that's installed on
 the system.
+
+encoding (enum):
+The encoding to be used.
+
+- "ASCII"
+- "UTF-16"
+- "UTF-16BE"
+- "UTF-16LE"
+- "UTF-32"
+- "UTF-32BE"
+- "UTF-32LE"
+- "UTF-8"
+- "CP1252"
+- "ISO-8859-1": Linux only
+- "MacRoman": OS X only
+- "Native": ISO-8859-1 on Linux, MacRoman on OS X, CP1252 on Windows
 
 
 The result:
@@ -73,6 +89,9 @@ On Windows systems, the <open driver> <command> is equivalent to the
 If the device is a serial port, you can set the serialControlString
 <property> to specify the speed, parity, and other settings. Set the
 <serialControlString> before using the <open driver> <command>.
+
+Changes:
+The <encoding> parameter was introduced in version 7.0
 
 References: write to driver (command), open file (command),
 function (control structure), property (glossary), Unix (glossary),

--- a/docs/dictionary/command/open-file.lcdoc
+++ b/docs/dictionary/command/open-file.lcdoc
@@ -31,14 +31,21 @@ If you specify a name but not a location, LiveCode assumes the file is
 in the defaultFolder. If the file you specify doesn't exist, LiveCode
 creates it.
 
-encoding:
-From 7.0, it's possible to specify an encoding for the file being
-opened. By doing so, you can straight read or write to a file without
-having to call <textEncode> or <textDecode>; the encoding supported by
-open file are the same as these text encoding functions. If no encoding
-is provided, then <open file> tries to read a Byte Order Mark (BOM) exists 
-at the beginning of the file. In success, the encoding is adapted and the
-BOM is ignored.
+encoding (enum):
+The encoding to be used.
+
+- "ASCII"
+- "UTF-16"
+- "UTF-16BE"
+- "UTF-16LE"
+- "UTF-32"
+- "UTF-32BE"
+- "UTF-32LE"
+- "UTF-8"
+- "CP1252"
+- "ISO-8859-1": Linux only
+- "MacRoman": OS X only
+- "Native": ISO-8859-1 on Linux, MacRoman on OS X, CP1252 on Windows
 
 The result:
 Use the for read form to open the file for reading. If the
@@ -130,6 +137,15 @@ settings.
 > manage this the engine essentially 'virtualizes' the asset files you
 > include, allowing (read-only) manipulation with all the standard
 > LiveCode file and folder handling syntax.
+
+Changes:
+From 7.0, it's possible to specify an encoding for the file being
+opened. By doing so, you can straight read or write to a file without
+having to call <textEncode> or <textDecode>; the encoding supported by
+open file are the same as these text encoding functions. If no encoding
+is provided, then <open file> tries to read a Byte Order Mark (BOM) exists 
+at the beginning of the file. In success, the encoding is adapted and the
+BOM is ignored.
 
 
 References: write to file (command), open file (command), put (command),

--- a/docs/dictionary/command/open-file.lcdoc
+++ b/docs/dictionary/command/open-file.lcdoc
@@ -2,7 +2,7 @@ Name: open file
 
 Type: command
 
-Syntax: open file <filePath> [for [ [<encoding>] text | binary] {update | read | write | append}]
+Syntax: open file <filePath> [for [ {[<encoding>] text | binary}] {update | read | write | append}]
 
 Summary:
 Opens a <file> so its contents can be accessed or modified.
@@ -32,7 +32,13 @@ in the defaultFolder. If the file you specify doesn't exist, LiveCode
 creates it.
 
 encoding:
-
+From 7.0, it's possible to specify an encoding for the file being
+opened. By doing so, you can straight read or write to a file without
+having to call <textEncode> or <textDecode>; the encoding supported by
+open file are the same as these text encoding functions. If no encoding
+is provided, then <open file> tries to read a Byte Order Mark (BOM) exists 
+at the beginning of the file. In success, the encoding is adapted and the
+BOM is ignored.
 
 The result:
 Use the for read form to open the file for reading. If the
@@ -125,13 +131,6 @@ settings.
 > include, allowing (read-only) manipulation with all the standard
 > LiveCode file and folder handling syntax.
 
-From 7.0, it's possible to specify an encoding for the file being
-opened. By doing so, you can straight read or write to a file without
-having to call <textEncode> or <textDecode>; the encoding supported by
-open file are the same as these text encoding functions. If no encoding
-is provided, then <open file> tries to read a Byte Order Mark exists at
-the beginning of the file. In success, the encoding is adapted and the
-BOM is ignored.
 
 References: write to file (command), open file (command), put (command),
 constant (command), read from file (command), get (command),

--- a/docs/dictionary/command/open-process.lcdoc
+++ b/docs/dictionary/command/open-process.lcdoc
@@ -2,7 +2,7 @@ Name: open process
 
 Type: command
 
-Syntax: open [elevated] process <appName> [for [[<encoding>] text | binary] {read | write | update | neither}]
+Syntax: open [elevated] process <appName> [for [[{<encoding>] text | binary}] {read | write | update | neither}]
 
 Summary:
 Starts a program.
@@ -34,6 +34,13 @@ one instantiation of a given program at one time. The appName can be any
 program on the system.
 
 encoding:
+From 7.0, it's possible to specify an encoding for the process being
+opened. By doing so, you can straight read a process without
+having to call <textEncode> or <textDecode>; the encoding supported by
+open process are the same as these text encoding functions. If no encoding
+is provided, then <open file> tries to read a Byte Order Mark (BOM) exists 
+at the beginning of the file. In success, the encoding is adapted and the
+BOM is ignored.
 
 
 Description:
@@ -103,8 +110,7 @@ in order to support this, in version 4.5 a new form of the open process
 command was introduced that can launch a slave process with elevated
 permissions: 
 
-open elevated process process [ for [ text | binary ] ( read | write |
-update | neither ) ]
+    open elevated process processName [ for [{ text | binary }] ({ read | write | update | neither }) ]
 
 This form operates identically to the normal version, except that engine
 will ask the system to launch the given process with admin/root

--- a/docs/dictionary/command/open-process.lcdoc
+++ b/docs/dictionary/command/open-process.lcdoc
@@ -33,14 +33,21 @@ The location and name of the program you want to open. You can run only
 one instantiation of a given program at one time. The appName can be any
 program on the system.
 
-encoding:
-From 7.0, it's possible to specify an encoding for the process being
-opened. By doing so, you can straight read a process without
-having to call <textEncode> or <textDecode>; the encoding supported by
-open process are the same as these text encoding functions. If no encoding
-is provided, then <open file> tries to read a Byte Order Mark (BOM) exists 
-at the beginning of the file. In success, the encoding is adapted and the
-BOM is ignored.
+encoding (enum):
+the encoding to be used
+
+- "ASCII"
+- "UTF-16"
+- "UTF-16BE"
+- "UTF-16LE"
+- "UTF-32"
+- "UTF-32BE"
+- "UTF-32LE"
+- "UTF-8"
+- "CP1252"
+- "ISO-8859-1": Linux only
+- "MacRoman": OS X only
+- "Native": ISO-8859-1 on Linux, MacRoman on OS X, CP1252 on Windows
 
 
 Description:
@@ -122,6 +129,15 @@ a GUI front-end that interacts with the user, and a command-line
 back-end that is run with elevated permissions. These two parts can then
 talk to each other using a standard master-slave approach, or some other
 form of IPC such as sockets
+
+Changes:
+From 7.0, it's possible to specify an encoding for the file being
+opened. By doing so, you can straight read or write to a file without
+having to call <textEncode> or <textDecode>; the encoding supported by
+open file are the same as these text encoding functions. If no encoding
+is provided, then <open file> tries to read a Byte Order Mark (BOM) exists 
+at the beginning of the file. In success, the encoding is adapted and the
+BOM is ignored.
 
 References: kill (command), close process (command),
 read from process (command), write to process (command),


### PR DESCRIPTION
- Add curly braces around variants
- `Encoding` parameter changes
