### PR TITLE
[Bug 18626] Make sure the Windows standalone settings are respected

### DIFF
--- a/docs/notes/bugfix-18626.md
+++ b/docs/notes/bugfix-18626.md
@@ -1,0 +1,1 @@
+# Make sure the Standalone Application Settings on Windows are respected

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -781,6 +781,7 @@ command revSaveAsWindowsStandalone pStack, pFolder
       -- Make sure we use the user's version info data
       put sStandaloneSettingsA["Windows,fileversion1"]&"."&sStandaloneSettingsA["Windows,fileversion2"]&"." & sStandaloneSettingsA["Windows,fileversion3"]&"."&sStandaloneSettingsA["Windows,fileversion4"] into sStandaloneSettingsA["Windows,FileVersion"]
       put sStandaloneSettingsA["Windows,productversion1"]&"."&sStandaloneSettingsA["Windows,productversion2"]&"." & sStandaloneSettingsA["Windows,productversion3"]&"."&sStandaloneSettingsA["Windows,productversion4"] into sStandaloneSettingsA["Windows,ProductVersion"]
+      set the itemDelimiter to comma
       repeat for each item tField in kVersionFlds
          put sStandaloneSettingsA["Windows", tField] into tDeployInfo["version"][tField]
       end repeat


### PR DESCRIPTION
`kVersionFlds` is a comma-delimited string that contains various keys. So make sure we restore the `itemDelimiter` to comma before iterating through `each item tField in kVersionFlds`
