### PR TITLE
[Docs] Command Syntax and Parameter fixes - 3

### DIFF
--- a/docs/dictionary/command/print-link.lcdoc
+++ b/docs/dictionary/command/print-link.lcdoc
@@ -2,7 +2,7 @@ Name: print link
 
 Type: command
 
-Syntax: print link to [ url | anchor ] <link> with rect <rectangle>
+Syntax: print link to [{ url | anchor }] <linkName> with rect <rectArea>
 
 Summary:
 Defines a hyperlink within a pdf print loop.
@@ -20,10 +20,10 @@ Example:
 print link to anchor "section 1.1" with rect 100,100,200,200
 
 Parameters:
-link:
+linkName:
 A URL or internal anchor name.
 
-rectangle:
+rectArea:
 A valid rectangle describing the link area in the pdf.
 
 Description:

--- a/docs/dictionary/command/rename.lcdoc
+++ b/docs/dictionary/command/rename.lcdoc
@@ -2,7 +2,7 @@ Name: rename
 
 Type: command
 
-Syntax: rename [file | folder |directory] <filePath> to <newPath>
+Syntax: rename [{file | folder | directory}] <filePath> to <newPath>
 
 Summary:
 Gives a <file> or <folder> a new name or moves it to a new location or

--- a/docs/dictionary/command/replace-in-field.lcdoc
+++ b/docs/dictionary/command/replace-in-field.lcdoc
@@ -2,7 +2,7 @@ Name: replace in field
 
 Type: command
 
-Syntax: replace <oldString> with <newString> in <fieldContainer> (preserving | replacing) styles
+Syntax: replace <oldString> with <newString> in <fieldContainer> {preserving | replacing} styles
 
 Summary:
 Replaces text in a field container with other text with control over

--- a/docs/dictionary/command/save.lcdoc
+++ b/docs/dictionary/command/save.lcdoc
@@ -2,7 +2,7 @@ Name: save
 
 Type: command
 
-Syntax: save <stack> [as <filePath>] [with format <stackFormat> | with newest format]
+Syntax: save <stack> [as <filePath>] [with {format <stackFormat> | newest format}]
 
 Summary:
 Saves a <stack file> on the user's system.

--- a/docs/dictionary/command/select.lcdoc
+++ b/docs/dictionary/command/select.lcdoc
@@ -2,7 +2,7 @@ Name: select
 
 Type: command
 
-Syntax: select [before | after] {text | <chunk>} of <field>
+Syntax: select [{before | after}] {text | <chunk>} of <field>
 
 Syntax: select empty
 

--- a/docs/dictionary/command/send.lcdoc
+++ b/docs/dictionary/command/send.lcdoc
@@ -2,7 +2,7 @@ Name: send
 
 Type: command
 
-Syntax: send <message> [ to <object> [in <time> [seconds | ticks | milliseconds]] ]
+Syntax: send <message> [ to <object> [in <time> [{seconds | ticks | milliseconds}] ] ]
 
 Summary:
 Sends a <message> to an <object(glossary)>.

--- a/docs/dictionary/command/wait.lcdoc
+++ b/docs/dictionary/command/wait.lcdoc
@@ -4,7 +4,7 @@ Type: command
 
 Syntax: wait {until | while} <condition> [with messages]
 
-Syntax: wait [for] <number> [seconds | ticks | milliseconds] [with messages]
+Syntax: wait [for] <number> [{seconds | ticks | milliseconds}] [with messages]
 
 Syntax: wait for messages
 


### PR DESCRIPTION
- Curly brackets added around variants in Syntax
- Parameter names changed where necessary (only in `print link`)
