### PR TITLE
foundation: Prevent misleading indentation warnings with GCC6

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1441,9 +1441,9 @@ template<typename T> inline T MCValueRetain(T value)
 // Utility function for assigning to MCValueRef vars.
 template<typename T> inline void MCValueAssign(T& dst, T src)
 {
-    if (src == dst)
-        return;
-    
+	if (src == dst)
+		return;
+
 	MCValueRetain(src);
 	MCValueRelease(dst);
 	dst = src;
@@ -1452,9 +1452,9 @@ template<typename T> inline void MCValueAssign(T& dst, T src)
 // Utility function for assigning to MCValueRef vars.
 template<typename T> inline void MCValueAssignAndRelease(T& dst, T src)
 {
-    if (src == dst)
-        return;
-    
+	if (src == dst)
+		return;
+
 	MCValueRelease(dst);
 	dst = src;
 }


### PR DESCRIPTION
Fix some mixed space/tab indentation in `foundation.h` to avoid being
spammed by `-Wmisleading-indentation` warnings when building LiveCode
with GCC6.
