### PR TITLE
libfoundation: Add MCSpan class for wrapping pointer + length pairs

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -22,6 +22,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "foundation.h"
 #endif
 
+#include "foundation-span.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template<typename T> class MCAutoValueRefBase;

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -53,10 +53,10 @@ template <typename ElementType>
 class MCSpan
 {
 public:
-	using IndexType = std::ptrdiff_t;
-	using ElementPtr = ElementType*;
-	using ElementRef = ElementType&;
-	using ElementRRef = ElementType&&;
+	typedef std::ptrdiff_t IndexType;
+	typedef ElementType* ElementPtr;
+	typedef ElementType& ElementRef;
+	typedef ElementType&& ElementRRef;
 
 	/* ---------- Constructors */
 	MCSpan()

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -1,0 +1,197 @@
+/*                                                                     -*-C++-*-
+ * Copyright (C) 2016 LiveCode Ltd.
+ *
+ * This file is part of LiveCode.
+ *
+ * LiveCode is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License v3 as published
+ * by the Free Software Foundation.
+ *
+ * LiveCode is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiveCode.  If not see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __MC_FOUNDATION_SPAN_H__
+#define __MC_FOUNDATION_SPAN_H__
+
+/* An MCSpan<T> represents a "view" onto an array of values of type T.
+ * It is intended to be used anywhere where a pointer & length would
+ * otherwise be stored on the stack, either in function parameters or
+ * in local variables.  Note that an MCSpan<T> does _not_ own the
+ * buffer to which it points; you should use an `MCAutoArray` or
+ * similar when you require an owned array.
+ *
+ * MCSpan<T> behaves like a pointer + length in many respects, but the
+ * key differences are that:
+ *
+ * - All accesses are checked
+ *
+ * - Its view onto the underlying array can only be narrowed, not
+ *   widened
+ *
+ * MCSpan is heavily inspired by gsl::span from
+ * https://github.com/Microsoft/GSL
+ */
+
+/* In the C++ standard, operator[] for pointers is defined to take an
+ * argument of std::ptrdiff_t.  This is used throughout this class in
+ * order to make sure that there is as much commonality as possible
+ * between the behaviour of an MCSpan and an array pointer. */
+
+#include "foundation.h"
+#include <cstddef>
+
+static const std::ptrdiff_t kMCSpanDynamicExtent = -1;
+
+template <typename ElementType>
+class MCSpan
+{
+public:
+	using IndexType = std::ptrdiff_t;
+	using ElementPtr = ElementType*;
+	using ElementRef = ElementType&;
+	using ElementRRef = ElementType&&;
+
+	/* ---------- Constructors */
+	MCSpan()
+		: m_data(nullptr), m_length(0) {}
+	MCSpan(std::nullptr_t)
+		: m_data(nullptr), m_length(0) {}
+	MCSpan(ElementPtr p_ptr, IndexType p_count)
+		: m_data(p_ptr), m_length(p_count) {}
+
+	template <size_t N>
+	MCSpan(ElementType (&arr)[N])
+		: m_data(&arr[0]), m_length(N) {}
+
+	/* TODO[C++11] MCSpan(MCSpan &other) = default; */
+	MCSpan(MCSpan& other)
+		: m_data(other.m_data), m_length(other.m_length) {}
+
+	/* TODO[C++11] MCSpan(MCSpan &&other) = default; */
+	MCSpan(MCSpan&& other)
+		: m_data(static_cast<ElementPtr &&>(other.m_data)),
+		  m_length(static_cast<IndexType &&>(other.m_length)) {}
+
+	/* TODO[C++11] ~MCSpan() = default; */
+	~MCSpan() {}
+
+	/* ---------- Assignment ops */
+	/* TODO[C++11] MCSpan& operator=(const MCSpan& other) = default; */
+	MCSpan& operator=(const MCSpan& other) {
+		m_data = other.m_data;
+		m_length = other.m_length;
+		return *this;
+	}
+
+	/* TODO[C++11] MCSpan& operator=(MCSpan&& other) = default; */
+	MCSpan& operator=(MCSpan&& other) {
+		m_data = static_cast<ElementPtr &&>(other.m_data);
+		m_length = static_cast<IndexType &&>(other.m_length);
+		return *this;
+	}
+
+	/* ---------- Subspans */
+	MCSpan first(IndexType p_count) const
+	{
+		MCAssert(p_count >= 0 && p_count <= size());
+		return MCSpan(data(), p_count);
+	}
+
+	MCSpan last(IndexType p_count) const
+	{
+		MCAssert(p_count >= 0 && p_count <= size());
+		return MCSpan(data() + (size() - p_count), p_count);
+	}
+
+	MCSpan subspan(IndexType p_offset,
+	               IndexType p_count = kMCSpanDynamicExtent) const
+	{
+		MCAssert(p_offset == 0 || (p_offset > 0 && p_offset <= size()));
+		MCAssert(p_count == kMCSpanDynamicExtent ||
+		         (p_count >= 0 && p_offset + p_count <= size()));
+		return MCSpan(data() + p_offset,
+		              p_count == kMCSpanDynamicExtent ? size() - p_offset : p_count);
+	}
+
+	MCSpan operator+(IndexType p_offset) const
+	{
+		return subspan(p_offset);
+	}
+
+	MCSpan& operator+=(IndexType p_offset)
+	{
+		return advance(p_offset);
+	}
+
+	/* ---------- Pointer arithmetic */
+	MCSpan& operator++()
+	{
+		return advance(1);
+	}
+	MCSpan& operator++(int)
+	{
+		auto t_ret = *this;
+		++(*this);
+		return t_ret;
+	}
+
+	/* ---------- Observers */
+	IndexType length() const { return size(); }
+	IndexType size() const { return m_length; }
+	IndexType lengthBytes() const { return sizeBytes(); }
+	IndexType sizeBytes() const { return m_length * sizeof(ElementType); }
+	bool empty() const { return size() == 0; }
+
+	/* ---------- Element access */
+	ElementRef operator[](IndexType p_index) const
+	{
+		MCAssert(p_index >= 0 && p_index < size());
+		return data()[p_index];
+	}
+	ElementRef operator*() const
+	{
+		return (*this)[0];
+	}
+	ElementPtr operator->() const
+	{
+		return &((*this)[0]);
+	}
+
+	ElementPtr data() const { return m_data; }
+
+protected:
+
+	MCSpan& advance(IndexType p_offset)
+	{
+		MCAssert(p_offset == 0 || (p_offset > 0 && p_offset <= size()));
+		m_data += p_offset;
+		m_length -= p_offset;
+		return *this;
+	}
+
+	ElementPtr m_data;
+	IndexType m_length;
+};
+
+template <typename ElementType>
+MCSpan<ElementType> operator+(typename MCSpan<ElementType>::IndexType n,
+                              const MCSpan<ElementType>& rhs)
+{
+	return rhs + n;
+}
+
+template <typename ElementType>
+MCSpan<ElementType> MCMakeSpan(ElementType *p_ptr,
+                               typename MCSpan<ElementType>::IndexType p_count)
+{
+	return MCSpan<ElementType>(p_ptr, p_count);
+}
+
+#endif /* !__MC_FOUNDATION_SPAN_H__ */

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -61,7 +61,7 @@ public:
 	/* ---------- Constructors */
 	MCSpan()
 		: m_data(nullptr), m_length(0) {}
-	MCSpan(std::nullptr_t)
+	MCSpan(decltype(nullptr))
 		: m_data(nullptr), m_length(0) {}
 	MCSpan(ElementPtr p_ptr, IndexType p_count)
 		: m_data(p_ptr), m_length(p_count) {}

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -42,7 +42,7 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
                             bool reals,
                             bool octals,
                             bool& done,
-                            MCSpan<const char> r_remainder)
+                            MCSpan<const char>& r_remainder)
 {
 	done = false;
 	MCU_skip_spaces(p_chars);


### PR DESCRIPTION
There are many places in the engine where (pointer, length) pairs are
handled separately.  Some bugs have occurred where they get separated
-- for example, when the pointer gets erroneously passed to a function
that expects to receive a null-terminated array rather than an array
with an extrinsic length.

The `MCSpan` class is inspired by the `span` class recommended by the
C++ Core Guidelines [1] and the `gsl::span` class included in
Microsoft's Guideline Support Library [2].  It is intended to be a
zero-cost abstraction that combines pointer + length into a single
class, and defines safe, checked access and subscripting operations.

It's not quite right yet, because to be fully zero-cost it requires
all of its methods to be declared `constexpr` and not all of the
compilers we use support that yet.

[1] https://github.com/isocpp/CppCoreGuidelines
[2] https://github.com/Microsoft/GSL

This PR demonstrates how easy it is to convert from (pointer, length) pairs to `MCSpan` using the `MCU_strtol()` function in libfoundation.
