### PR TITLE
[Bugfix 18651] libfoundation: Refactor number parsing & add tests

### DIFF
--- a/docs/notes/bugfix-18651.md
+++ b/docs/notes/bugfix-18651.md
@@ -1,0 +1,1 @@
+# Ensure "10 garbage" is never a number

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -711,6 +711,10 @@ public:
 		(void) MCStringGetNativeCharPtrAndLength(*m_string, t_length);
 		return t_length;
 	}
+	MCSpan<const char_t> Span() const
+	{
+		return MCMakeSpan(operator*(), Size());
+	}
 private:
 	MCAutoStringRef m_string;
 };
@@ -723,6 +727,10 @@ public:
 	const char * operator* () const
 	{
 		return reinterpret_cast<const char *>(MCAutoStringRefAsNativeChars::operator*());
+	}
+	MCSpan<const char> Span() const
+	{
+		return MCMakeSpan(operator*(), Size());
 	}
 };
 

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -194,4 +194,13 @@ MCSpan<ElementType> MCMakeSpan(ElementType *p_ptr,
 	return MCSpan<ElementType>(p_ptr, p_count);
 }
 
+template <typename ElementType = byte_t>
+MCSpan<ElementType> MCDataGetSpan(MCDataRef p_data)
+{
+	MCAssert(MCDataGetLength(p_data) % sizeof(ElementType) == 0);
+	auto t_ptr = reinterpret_cast<ElementType*>(MCDataGetBytePtr(p_data));
+	size_t t_length = MCDataGetLength(p_data) / sizeof(ElementType);
+	return MCMakeSpan(t_ptr, t_length);
+}
+
 #endif /* !__MC_FOUNDATION_SPAN_H__ */

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -194,7 +194,8 @@ MCSpan<ElementType> MCMakeSpan(ElementType *p_ptr,
 	return MCSpan<ElementType>(p_ptr, p_count);
 }
 
-template <typename ElementType = byte_t>
+/* TODO[C++11] The default value for ElementType should be byte_t */
+template <typename ElementType>
 MCSpan<ElementType> MCDataGetSpan(MCDataRef p_data)
 {
 	MCAssert(MCDataGetLength(p_data) % sizeof(ElementType) == 0);

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -10,6 +10,7 @@
 		[
 			'test/environment.cpp',
 			'test/test_string.cpp',
+			'test/test_typeconvert.cpp',
 		],
 	},
 

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -235,12 +235,22 @@ bool MCTypeConvertStringToLongInteger(MCStringRef p_string, integer_t& r_convert
         return false;
     
     MCAutoStringRefAsCString t_cstring;
-    t_cstring . Lock(p_string);
-    
-    bool t_done;
-    uindex_t t_length = strlen(*t_cstring);
-    r_converted = MCU_strtol(*t_cstring, t_length, '\0', t_done, false, false);
-	return t_done;
+	if (!t_cstring . Lock(p_string))
+		return false;
+
+	bool t_done = false;
+	MCSpan<const char> t_remainder;
+	integer_t t_converted = MCU_strtol(t_cstring.Span(), '\0', false, false,
+	                                   t_done, t_remainder);
+	if (t_done && t_remainder.empty())
+	{
+		r_converted = t_converted;
+		return true;
+	}
+	else
+	{
+		return false;
+	}
 }
 
 MC_DLLEXPORT_DEF

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -276,10 +276,9 @@ bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool
 MC_DLLEXPORT_DEF
 bool MCTypeConvertDataToReal(MCDataRef p_data, real64_t& r_converted, bool p_convert_octals)
 {
-    const char *t_sptr = (const char *)MCDataGetBytePtr(p_data);
-	uindex_t t_length = MCDataGetLength(p_data);
-	bool t_done;
-    real64_t t_value = MCU_strtor8(t_sptr, t_length, '\0', t_done, p_convert_octals);
+    bool t_done = false;
+    real64_t t_value = MCU_strtor8(MCDataGetSpan<const char>(p_data),
+                                   p_convert_octals, t_done);
     
     if (t_done)
         r_converted = t_value;

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -260,13 +260,11 @@ bool MCTypeConvertStringToReal(MCStringRef p_string, real64_t& r_converted, bool
         return false;
     
     MCAutoStringRefAsCString t_cstring;
-    t_cstring . Lock(p_string);
-    
-    const char *t_sptr = *t_cstring;
-    uindex_t t_length = strlen(t_sptr);
-    bool t_done;
-    
-    real64_t t_value = MCU_strtor8(t_sptr, t_length, '\0', t_done, p_convert_octals);
+	if (!t_cstring . Lock(p_string))
+		return false;
+
+	bool t_done = false;
+	real64_t t_value = MCU_strtor8(t_cstring.Span(), p_convert_octals, t_done);
     
     if (t_done)
         r_converted = t_value;

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -20,15 +20,6 @@
 
 #define R8L 384
 
-inline void MCU_skip_spaces(const char *&sptr, uinteger_t &l)
-{
-	while (l && isspace((uint8_t)*sptr))
-	{
-		sptr++;
-		l--;
-	}
-}
-
 inline void MCU_skip_spaces(MCSpan<const char>& x_span)
 {
 	while (!x_span.empty() && isspace(uint8_t(x_span[0])))
@@ -157,16 +148,6 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
 	return value;
 }
 
-static integer_t MCU_strtol(const char *sptr, uindex_t &l, int8_t c, bool &done,
-                            bool reals, bool octals)
-{
-	MCSpan<const char> t_remainder;
-	integer_t t_result = MCU_strtol(MCMakeSpan(sptr, l), c, reals, octals,
-	                                done, t_remainder);
-	l = t_remainder.size();
-	return t_result;
-}
-
 static real64_t MCU_strtor8(MCSpan<const char> p_chars,
                             bool convertoctals,
                             bool & r_done)
@@ -221,11 +202,6 @@ static real64_t MCU_strtor8(MCSpan<const char> p_chars,
 
 	r_done = true;
 	return t_value;
-}
-
-static real64_t MCU_strtor8(const char *&r_str, uindex_t &r_len, int8_t p_delim,  bool &r_done, bool convertoctals)
-{
-	return MCU_strtor8(MCMakeSpan(r_str, r_len), convertoctals, r_done);
 }
 
 MC_DLLEXPORT_DEF

--- a/libfoundation/test/test_typeconvert.cpp
+++ b/libfoundation/test/test_typeconvert.cpp
@@ -1,0 +1,103 @@
+/*                                                                     -*-C++-*-
+ * Copyright (C) 2016 LiveCode Ltd.
+ *
+ * This file is part of LiveCode.
+ *
+ * LiveCode is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License v3 as published
+ * by the Free Software Foundation.
+ *
+ * LiveCode is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LiveCode.  If not see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "gtest/gtest.h"
+
+#include "foundation.h"
+#include "foundation-auto.h"
+
+TEST(typeconvert, string_integer)
+//
+// Checks string-to-integer conversion
+//
+{
+	integer_t t_value;
+
+	t_value = 0;
+	EXPECT_FALSE(MCTypeConvertStringToLongInteger(kMCEmptyString, t_value));
+	EXPECT_EQ(t_value, 0);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToLongInteger(MCSTR("42"), t_value));
+	EXPECT_EQ(t_value, 42);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToLongInteger(MCSTR("0x42"), t_value));
+	EXPECT_EQ(t_value, 0x42);
+
+	t_value = 0;
+	EXPECT_FALSE(MCTypeConvertStringToLongInteger(MCSTR("42 43"), t_value));
+	EXPECT_EQ(t_value, 0);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToLongInteger(MCSTR(" 42 "), t_value));
+	EXPECT_EQ(t_value, 42);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToLongInteger(MCSTR("+42"), t_value));
+	EXPECT_EQ(t_value, 42);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToLongInteger(MCSTR("-42"), t_value));
+	EXPECT_EQ(t_value, -42);
+
+	t_value = 0;
+	EXPECT_FALSE(MCTypeConvertStringToLongInteger(MCSTR("0x"), t_value));
+	EXPECT_EQ(t_value, 0);
+}
+
+TEST(typeconvert, string_real)
+//
+// Checks string-to-integer conversion
+//
+{
+	real64_t t_value;
+
+	t_value = 0;
+	EXPECT_FALSE(MCTypeConvertStringToReal(kMCEmptyString, t_value, false));
+	EXPECT_EQ(t_value, 0);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToReal(MCSTR("42"), t_value, false));
+	EXPECT_EQ(t_value, 42);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToReal(MCSTR("0x42"), t_value, false));
+	EXPECT_EQ(t_value, 0x42);
+
+	t_value = 0;
+	EXPECT_FALSE(MCTypeConvertStringToReal(MCSTR("42 43"), t_value, false));
+	EXPECT_EQ(t_value, 0);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToReal(MCSTR(" 42 "), t_value, false));
+	EXPECT_EQ(t_value, 42);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToReal(MCSTR("+42"), t_value, false));
+	EXPECT_EQ(t_value, 42);
+
+	t_value = 0;
+	EXPECT_TRUE(MCTypeConvertStringToReal(MCSTR("-42"), t_value, false));
+	EXPECT_EQ(t_value, -42);
+
+	t_value = 0;
+	EXPECT_FALSE(MCTypeConvertStringToReal(MCSTR("0x"), t_value, false));
+	EXPECT_EQ(t_value, 0);
+}

--- a/tests/lcs/core/execution/type-conversion.livecodescript
+++ b/tests/lcs/core/execution/type-conversion.livecodescript
@@ -33,3 +33,9 @@ on TestStrictUInt
    local tEmpty
    TestAssert "empty variable does not convert to 0 in object ID", not exists(button id tEmpty)
 end TestStrictUInt
+
+on TestJunkAfterNumber -- Bug 18651
+   TestAssert "whitespace after number", "0    " is a number
+   TestAssert "digits after number", "0 9" is not a number
+   TestAssert "junk after number", "0 foo" is not a number
+end TestJunkAfterNumber


### PR DESCRIPTION
Includes and depends on #4791.
- Convert `MCTypeConvert` internal API to be based on `MCSpan`, fixing several issues
- Remove non-`MCSpan` API
- Add C++ & script tests
