### PR TITLE
[Docs] textEncode/Decode whitespace in param enum

### DIFF
--- a/docs/dictionary/function/textDecode.lcdoc
+++ b/docs/dictionary/function/textDecode.lcdoc
@@ -36,11 +36,9 @@ the encoding of the original data
 - "UTF-32LE"
 - "UTF-8"
 - "CP1252"
-
-
--   "ISO-8859-1": Linux only
--   "MacRoman": OS X only
--   "Native": ISO-8859-1 on Minux, MacRoman on OS X, CP1252 on Windows
+- "ISO-8859-1": Linux only
+- "MacRoman": OS X only
+- "Native": ISO-8859-1 on Minux, MacRoman on OS X, CP1252 on Windows
 
 
 Returns:

--- a/docs/dictionary/function/textEncode.lcdoc
+++ b/docs/dictionary/function/textEncode.lcdoc
@@ -36,11 +36,9 @@ the encoding to be used
 - "UTF-32LE"
 - "UTF-8"
 - "CP1252"
-
-
--   "ISO-8859-1": Linux only
--   "MacRoman": OS X only
--   "Native": ISO-8859-1 on Linux, MacRoman on OS X, CP1252 on Windows
+- "ISO-8859-1": Linux only
+- "MacRoman": OS X only
+- "Native": ISO-8859-1 on Linux, MacRoman on OS X, CP1252 on Windows
 
 
 Returns:


### PR DESCRIPTION
Two lines of whitespace removed from the encoding parameter enum list
