### PR TITLE
libscript: Convert new VM to use spans instead of pointer/length pairs

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -348,6 +348,11 @@ public:
         MCAssert(m_values != nil);
         return m_values[p_index];
     }
+
+	MCSpan<T> Span() const
+	{
+		return MCMakeSpan(m_values, m_value_count);
+	}
     
 private:
 	T* m_values;

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -322,8 +322,7 @@ struct MCScriptBytecodeOp_Invoke
 				ctxt.PushFrame(t_resolved_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_resolved_definition),
 							   t_result_reg,
-							   t_argument_regs,
-							   t_argument_count);
+				               MCMakeSpan(t_argument_regs, t_argument_count));
 			}
 			break;
 				
@@ -544,8 +543,7 @@ private:
 				ctxt.PushFrame(t_handler_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_handler_def),
 							   p_result_reg,
-							   p_argument_regs,
-							   p_argument_count);
+				               MCMakeSpan(p_argument_regs, p_argument_count));
 			}
 			break;
 				

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -331,8 +331,7 @@ struct MCScriptBytecodeOp_Invoke
 				ctxt.InvokeForeign(t_resolved_instance,
 								   static_cast<MCScriptForeignHandlerDefinition *>(t_resolved_definition),
 								   t_result_reg,
-								   t_argument_regs,
-								   t_argument_count);
+				                   MCMakeSpan(t_argument_regs, t_argument_count));
 			}
 			break;
 				
@@ -552,8 +551,7 @@ private:
 				ctxt.InvokeForeign(t_handler_instance,
 								   static_cast<MCScriptForeignHandlerDefinition *>(t_handler_def),
 								   p_result_reg,
-								   p_argument_regs,
-								   p_argument_count);
+				                   MCMakeSpan(p_argument_regs, p_argument_count));
 			}
 			break;
 				

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -437,8 +437,7 @@ private:
 		if (t_min_score_ambiguous || t_min_score_definition == NULL)
 		{
 			ctxt.ThrowUnableToResolveMultiInvoke(p_group,
-												 p_arguments,
-												 p_argument_count);
+			                                     MCMakeSpan(p_arguments, p_argument_count));
 			return;
 		}
 		

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -466,10 +466,7 @@ struct MCScriptBytecodeOp_InvokeIndirect
 		t_result_reg = ctxt.GetArgument(1);
 		
 		// The argument list starts at the third argument.
-		const uindex_t *t_argument_regs;
-		uindex_t t_argument_count;
-		t_argument_regs = ctxt.GetArgumentList() + 2;
-		t_argument_count = ctxt.GetArgumentCount() - 2;
+		MCSpan<const uindex_t> t_argument_regs(ctxt.GetArguments().subspan(2));
 		
 		MCValueRef t_handler;
 		t_handler = ctxt.CheckedFetchRegister(ctxt.GetArgument(0));
@@ -484,8 +481,8 @@ struct MCScriptBytecodeOp_InvokeIndirect
 		
 #ifdef DEBUG_EXECUTION
 		MCLog("Invoke handler value %p from register %u into %u", t_handler, t_result_reg);
-		for(uindex_t i = 0; i < t_argument_count; i++)
-			MCLog("  argument register %u", t_argument_regs[i]);
+		for(MCSpan<const uindex_t> t_rest = t_argument_regs; !t_rest.empty(); ++t_rest)
+			MCLog("  argument register %u", *t_rest);
 #endif
 
 		// If the handler-ref is of 'internal' kind (i.e. a instance/definition
@@ -497,14 +494,14 @@ struct MCScriptBytecodeOp_InvokeIndirect
 			InternalInvoke(ctxt,
 						   (MCHandlerRef)t_handler,
 						   t_result_reg,
-			               MCMakeSpan(t_argument_regs, t_argument_count));
+			               t_argument_regs);
 		}
 		else
 		{
 			ExternalInvoke(ctxt,
 						   (MCHandlerRef)t_handler,
 						   t_result_reg,
-			               MCMakeSpan(t_argument_regs, t_argument_count));
+			               t_argument_regs);
 		}
 	}
 	

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -296,8 +296,7 @@ struct MCScriptBytecodeOp_Invoke
 			SelectDefinitionFromGroup(ctxt,
 									  t_instance,
 									  static_cast<MCScriptDefinitionGroupDefinition *>(t_definition),
-									  t_argument_regs,
-									  t_argument_count,
+			                          MCMakeSpan(t_argument_regs, t_argument_count),
 									  t_resolved_instance,
 									  t_resolved_definition);
 		}
@@ -347,8 +346,7 @@ private:
 	static void SelectDefinitionFromGroup(MCScriptExecuteContext& ctxt,
 										  MCScriptInstanceRef p_instance,
 										  MCScriptDefinitionGroupDefinition *p_group,
-										  const uindex_t *p_arguments,
-										  uindex_t p_argument_count,
+	                                      MCSpan<const uindex_t> p_arguments,
 										  MCScriptInstanceRef& r_selected_instance,
 										  MCScriptDefinition*& r_selected_definition)
 	{
@@ -378,11 +376,11 @@ private:
 			MCTypeInfoRef t_current_signature;
 			t_current_signature = t_current_instance -> module -> types[t_current_handler -> type] -> typeinfo;
 			
-			if (MCHandlerTypeInfoGetParameterCount(t_current_signature) != p_argument_count)
+			if (MCHandlerTypeInfoGetParameterCount(t_current_signature) != p_arguments.size())
 				continue;
 			
 			uindex_t t_current_score = 0;
-			for(uindex_t t_arg_idx = 0; t_arg_idx < p_argument_count; t_arg_idx++)
+			for(uindex_t t_arg_idx = 0; t_arg_idx < p_arguments.size(); t_arg_idx++)
 			{
 				// We can't compare types of out arguments as they have no value
 				// (yet).
@@ -436,8 +434,7 @@ private:
 		}
 		if (t_min_score_ambiguous || t_min_score_definition == NULL)
 		{
-			ctxt.ThrowUnableToResolveMultiInvoke(p_group,
-			                                     MCMakeSpan(p_arguments, p_argument_count));
+			ctxt.ThrowUnableToResolveMultiInvoke(p_group, p_arguments);
 			return;
 		}
 		

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -497,8 +497,7 @@ struct MCScriptBytecodeOp_InvokeIndirect
 			InternalInvoke(ctxt,
 						   (MCHandlerRef)t_handler,
 						   t_result_reg,
-						   t_argument_regs,
-						   t_argument_count);
+			               MCMakeSpan(t_argument_regs, t_argument_count));
 		}
 		else
 		{
@@ -514,8 +513,7 @@ private:
 	static void InternalInvoke(MCScriptExecuteContext& ctxt,
 							   MCHandlerRef p_handler,
 							   uindex_t p_result_reg,
-							   const uindex_t *p_argument_regs,
-							   uindex_t p_argument_count)
+	                           MCSpan<const uindex_t> p_argument_regs)
 	{
 		// An 'internal' handler-ref is nothing more than an instance/definition
 		// pair, so we can execute directly inside this execution context. This
@@ -535,7 +533,7 @@ private:
 				ctxt.PushFrame(t_handler_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_handler_def),
 							   p_result_reg,
-				               MCMakeSpan(p_argument_regs, p_argument_count));
+				               p_argument_regs);
 			}
 			break;
 				
@@ -544,7 +542,7 @@ private:
 				ctxt.InvokeForeign(t_handler_instance,
 								   static_cast<MCScriptForeignHandlerDefinition *>(t_handler_def),
 								   p_result_reg,
-				                   MCMakeSpan(p_argument_regs, p_argument_count));
+				                   p_argument_regs);
 			}
 			break;
 				

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -276,15 +276,12 @@ struct MCScriptBytecodeOp_Invoke
 		t_result_reg = ctxt.GetArgument(1);
 		
 		// The argument list starts at the third argument.
-		const uindex_t *t_argument_regs;
-		uindex_t t_argument_count;
-		t_argument_regs = ctxt.GetArgumentList() + 2;
-		t_argument_count = ctxt.GetArgumentCount() - 2;
+		MCSpan<const uindex_t> t_arguments(ctxt.GetArguments().subspan(2));
 
 #ifdef DEBUG_EXECUTION
 		MCLog("Select handler into register %u", t_result_reg);
-		for(uindex_t i = 0; i < t_argument_count; i++)
-			MCLog("  argument register %u", t_argument_regs[i]);
+		for (MCSpan<const uindex_t> t_rest = t_arguments; !t_rest.empty(); ++t_rest)
+			MCLog("  argument register %u", *t_rest);
 #endif
 		
 		// If the definition kind is a group, then we must select which handler
@@ -296,7 +293,7 @@ struct MCScriptBytecodeOp_Invoke
 			SelectDefinitionFromGroup(ctxt,
 									  t_instance,
 									  static_cast<MCScriptDefinitionGroupDefinition *>(t_definition),
-			                          MCMakeSpan(t_argument_regs, t_argument_count),
+			                          t_arguments,
 									  t_resolved_instance,
 									  t_resolved_definition);
 		}
@@ -321,7 +318,7 @@ struct MCScriptBytecodeOp_Invoke
 				ctxt.PushFrame(t_resolved_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_resolved_definition),
 							   t_result_reg,
-				               MCMakeSpan(t_argument_regs, t_argument_count));
+				               t_arguments);
 			}
 			break;
 				
@@ -330,7 +327,7 @@ struct MCScriptBytecodeOp_Invoke
 				ctxt.InvokeForeign(t_resolved_instance,
 								   static_cast<MCScriptForeignHandlerDefinition *>(t_resolved_definition),
 								   t_result_reg,
-				                   MCMakeSpan(t_argument_regs, t_argument_count));
+				                   t_arguments);
 			}
 			break;
 				

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -220,8 +220,7 @@ void
 MCScriptExecuteContext::InvokeForeign(MCScriptInstanceRef p_instance,
 									  MCScriptForeignHandlerDefinition *p_handler_def,
 									  uindex_t p_result_reg,
-									  const uindex_t *p_argument_regs,
-									  uindex_t p_argument_count)
+                                      MCSpan<const uindex_t> p_argument_regs)
 {
 	if (m_error)
 	{
@@ -244,11 +243,11 @@ MCScriptExecuteContext::InvokeForeign(MCScriptInstanceRef p_instance,
 								  p_handler_def);
 	
 	// Check the parameter count.
-	if (MCHandlerTypeInfoGetParameterCount(t_signature) != p_argument_count)
+	if (MCHandlerTypeInfoGetParameterCount(t_signature) != p_argument_regs.size())
 	{
 		ThrowWrongNumberOfArguments(p_instance,
 									p_handler_def,
-									p_argument_count);
+		                            p_argument_regs.size());
 		return;
 	}
 	

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -330,29 +330,20 @@ MCScriptExecuteContext::GetNextAddress(void) const
 inline uindex_t
 MCScriptExecuteContext::GetArgumentCount(void) const
 {
-	MCAssert(m_operation_ready);
-	return m_argument_count;
+	return GetArguments().size();
 }
 
 inline uindex_t
 MCScriptExecuteContext::GetArgument(uindex_t p_index) const
 {
-	MCAssert(m_operation_ready);
-	return m_arguments[p_index];
-}
-
-inline const uindex_t *
-MCScriptExecuteContext::GetArgumentList(void) const
-{
-	MCAssert(m_operation_ready);
-	return m_arguments;
+	return GetArguments()[p_index];
 }
 
 inline MCSpan<const uindex_t>
 MCScriptExecuteContext::GetArguments() const
 {
 	MCAssert(m_operation_ready);
-	return MCMakeSpan(GetArgumentList(), GetArgumentCount());
+	return MCMakeSpan(m_arguments, m_argument_count);
 }
 
 inline index_t

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -50,6 +50,9 @@ public:
 	
 	// Return the list of arguments to the current opcode
 	const uindex_t *GetArgumentList(void) const;
+
+	// Return the list of arguments to the current opcode
+	MCSpan<const uindex_t> GetArguments() const;
 	
 	// Fetch the type of the given register. The type of the register might
 	// be nil, if it has no assigned type.
@@ -346,6 +349,13 @@ MCScriptExecuteContext::GetArgumentList(void) const
 {
 	MCAssert(m_operation_ready);
 	return m_arguments;
+}
+
+inline MCSpan<const uindex_t>
+MCScriptExecuteContext::GetArguments() const
+{
+	MCAssert(m_operation_ready);
+	return MCMakeSpan(GetArgumentList(), GetArgumentCount());
 }
 
 inline index_t

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -145,8 +145,7 @@ public:
 	void InvokeForeign(MCScriptInstanceRef instance,
 					   MCScriptForeignHandlerDefinition *handler,
 					   uindex_t result_reg,
-					   const uindex_t *argument_regs,
-					   uindex_t argument_count);
+	                   MCSpan<const uindex_t> argument_regs);
 	
 	// Enter the LCB VM to execute the specified handler in the given instance.
 	void Enter(MCScriptInstanceRef instance,

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -202,8 +202,7 @@ public:
 	
 	// Raise an 'unable to resolve multi-invoke' error.
 	void ThrowUnableToResolveMultiInvoke(MCScriptDefinitionGroupDefinition *group,
-										 const uindex_t *arguments,
-										 uindex_t argument_count);
+	                                     MCSpan<const uindex_t> arguments);
 	
 	// Raise a 'value is not a handler' error.
 	void ThrowNotAHandlerValue(MCValueRef actual_value);
@@ -1237,14 +1236,13 @@ MCScriptExecuteContext::Rethrow(bool /*ignored*/)
 
 inline void
 MCScriptExecuteContext::ThrowUnableToResolveMultiInvoke(MCScriptDefinitionGroupDefinition *p_group,
-														const uindex_t *p_arguments,
-														uindex_t p_argument_count)
+                                                        MCSpan<const uindex_t> p_arguments)
 {
 	MCAutoProperListRef t_args;
 	if (!MCProperListCreateMutable(&t_args))
 		return;
 	
-	for(uindex_t i = 0; i < p_argument_count; i++)
+	for(uindex_t i = 0; i < p_arguments.size(); i++)
 	{
 		MCValueRef t_value;
 		t_value = FetchRegister(p_arguments[i]);

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -204,8 +204,7 @@ __MCScriptCallHandlerDefinitionInInstance(MCScriptInstanceRef self,
 	MCScriptExecuteContext t_execute_ctxt;
 	t_execute_ctxt.Enter(self,
 						 p_handler_def,
-						 p_arguments,
-						 p_argument_count,
+	                     MCMakeSpan(p_arguments, p_argument_count),
 						 r_value);
 	
 	while(t_execute_ctxt.Step())


### PR DESCRIPTION
This PR modifies the new LCB virtual machine implementation to use `MCSpan` as much as possible instead of passing (pointer, length) pairs around.

It looks like this has a lot of commits, but it works in a fairly bottom-up approach: modify leaf functions to use `MCSpan`, then modify the functions that call it, and so on.
