### PR TITLE
libfoundation: Make span creation and access "constexpr" if possible

### DIFF
--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -44,6 +44,11 @@
  * order to make sure that there is as much commonality as possible
  * between the behaviour of an MCSpan and an array pointer. */
 
+/* TODO[C++11] Many of the constructors & methods in MCSpan are
+ * declared constexpr.  However, some of our compilers don't support
+ * constexpr, and for those compilers constexpr is defined to
+ * empty. */
+
 #include "foundation.h"
 #include <cstddef>
 
@@ -59,23 +64,23 @@ public:
 	typedef ElementType&& ElementRRef;
 
 	/* ---------- Constructors */
-	MCSpan()
+	constexpr MCSpan()
 		: m_data(nullptr), m_length(0) {}
-	MCSpan(decltype(nullptr))
+	constexpr MCSpan(decltype(nullptr))
 		: m_data(nullptr), m_length(0) {}
-	MCSpan(ElementPtr p_ptr, IndexType p_count)
+	constexpr MCSpan(ElementPtr p_ptr, IndexType p_count)
 		: m_data(p_ptr), m_length(p_count) {}
 
 	template <size_t N>
-	MCSpan(ElementType (&arr)[N])
+	constexpr MCSpan(ElementType (&arr)[N])
 		: m_data(&arr[0]), m_length(N) {}
 
 	/* TODO[C++11] MCSpan(MCSpan &other) = default; */
-	MCSpan(MCSpan& other)
+	constexpr MCSpan(MCSpan& other)
 		: m_data(other.m_data), m_length(other.m_length) {}
 
 	/* TODO[C++11] MCSpan(MCSpan &&other) = default; */
-	MCSpan(MCSpan&& other)
+	constexpr MCSpan(MCSpan&& other)
 		: m_data(static_cast<ElementPtr &&>(other.m_data)),
 		  m_length(static_cast<IndexType &&>(other.m_length)) {}
 
@@ -98,20 +103,20 @@ public:
 	}
 
 	/* ---------- Subspans */
-	MCSpan first(IndexType p_count) const
+	constexpr MCSpan first(IndexType p_count) const
 	{
 		MCAssert(p_count >= 0 && p_count <= size());
 		return MCSpan(data(), p_count);
 	}
 
-	MCSpan last(IndexType p_count) const
+	constexpr MCSpan last(IndexType p_count) const
 	{
 		MCAssert(p_count >= 0 && p_count <= size());
 		return MCSpan(data() + (size() - p_count), p_count);
 	}
 
-	MCSpan subspan(IndexType p_offset,
-	               IndexType p_count = kMCSpanDynamicExtent) const
+	constexpr MCSpan subspan(IndexType p_offset,
+	                               IndexType p_count = kMCSpanDynamicExtent) const
 	{
 		MCAssert(p_offset == 0 || (p_offset > 0 && p_offset <= size()));
 		MCAssert(p_count == kMCSpanDynamicExtent ||
@@ -120,7 +125,7 @@ public:
 		              p_count == kMCSpanDynamicExtent ? size() - p_offset : p_count);
 	}
 
-	MCSpan operator+(IndexType p_offset) const
+	constexpr MCSpan operator+(IndexType p_offset) const
 	{
 		return subspan(p_offset);
 	}
@@ -143,28 +148,31 @@ public:
 	}
 
 	/* ---------- Observers */
-	IndexType length() const { return size(); }
-	IndexType size() const { return m_length; }
-	IndexType lengthBytes() const { return sizeBytes(); }
-	IndexType sizeBytes() const { return m_length * sizeof(ElementType); }
-	bool empty() const { return size() == 0; }
+	constexpr IndexType length() const { return size(); }
+	constexpr IndexType size() const { return m_length; }
+	constexpr IndexType lengthBytes() const { return sizeBytes(); }
+	constexpr IndexType sizeBytes() const
+	{
+		return m_length * sizeof(ElementType);
+	}
+	constexpr bool empty() const { return size() == 0; }
 
 	/* ---------- Element access */
-	ElementRef operator[](IndexType p_index) const
+	constexpr ElementRef operator[](IndexType p_index) const
 	{
 		MCAssert(p_index >= 0 && p_index < size());
 		return data()[p_index];
 	}
-	ElementRef operator*() const
+	constexpr ElementRef operator*() const
 	{
 		return (*this)[0];
 	}
-	ElementPtr operator->() const
+	constexpr ElementPtr operator->() const
 	{
 		return &((*this)[0]);
 	}
 
-	ElementPtr data() const { return m_data; }
+	constexpr ElementPtr data() const { return m_data; }
 
 protected:
 
@@ -181,15 +189,17 @@ protected:
 };
 
 template <typename ElementType>
-MCSpan<ElementType> operator+(typename MCSpan<ElementType>::IndexType n,
-                              const MCSpan<ElementType>& rhs)
+constexpr MCSpan<ElementType>
+operator+(typename MCSpan<ElementType>::IndexType n,
+          const MCSpan<ElementType>& rhs)
 {
 	return rhs + n;
 }
 
 template <typename ElementType>
-MCSpan<ElementType> MCMakeSpan(ElementType *p_ptr,
-                               typename MCSpan<ElementType>::IndexType p_count)
+constexpr MCSpan<ElementType>
+MCMakeSpan(ElementType *p_ptr,
+           typename MCSpan<ElementType>::IndexType p_count)
 {
 	return MCSpan<ElementType>(p_ptr, p_count);
 }

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -434,7 +434,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #    define alignof(x)      __alignof__(x)
 #  elif defined(__GNUC__)
      // GCC added C++11 alignof(x) in GCC 4.8
-#    if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR < 8)
+#    if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
 #      define alignof(x)    __alignof__(x)
 #    endif
 #  elif defined(_MSC_VER)

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -447,6 +447,27 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #  endif
 #endif
 
+// Ensure we have constexpr keyword defined
+#if defined(__cplusplus) && (!defined(__cpp_constexpr) || (__cpp_constexpr < 200704))
+// Testing __cplusplus isn't sufficient as some compilers changed the
+// value before being fully-conforming
+#  if defined(__clang__)
+     // clang defines __cpp_constexpr appropriately
+#    define constexpr /*constexpr*/
+#  elif defined(__GNUC__)
+     // GCC added C++11 constexpr in GCC 4.6
+#    if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 6)
+#      define constexpr /*constexpr*/
+#    endif
+#  elif defined(_MSC_VER) && (_MCS_VER < 1900)
+     // MSVC added C++11 constexpr in Visual Studio 2015 (compiler
+     // version 14.0, _MSC_VER 1900)
+#    define constexpr /*constexpr*/
+#  else
+#    error Do not know whether this compiler provides C++11 constexpr
+#  endif
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  FIXED WIDTH INTEGER TYPES


### PR DESCRIPTION
This patch attempts to ensure that the `constexpr` keyword is at least defined for all the compilers we use, and then modifies `MCSpan` to make its methods `constexpr inline` wherever possible.

See commit messages for more info!
