### PR TITLE
[Bug 18642] Fix crash on iOS 10 when calling mobileGetNotificationDetails

### DIFF
--- a/docs/notes/bugfix-18642.md
+++ b/docs/notes/bugfix-18642.md
@@ -1,0 +1,1 @@
+# Fixed crash on iOS 10 when trying to read local notifications

--- a/engine/src/mbliphonenotification.mm
+++ b/engine/src/mbliphonenotification.mm
@@ -119,9 +119,20 @@ bool MCSystemGetNotificationDetails(int32_t p_id, MCNotification &r_notification
         UILocalNotification* t_local_notification = [t_scheduled_local_notifications objectAtIndex:i];
         if (atoi ([[t_local_notification.userInfo objectForKey:@"notificationId"] cStringUsingEncoding:NSMacOSRomanStringEncoding]) == p_id) 
         {
-            MCStringCreateWithCFString ((CFStringRef)[t_local_notification alertBody], r_notification.body); // or ""
-            MCStringCreateWithCFString ((CFStringRef)[t_local_notification alertAction], r_notification.action); // or ""
-            MCStringCreateWithCFString ((CFStringRef)[t_local_notification.userInfo objectForKey:@"payload"], r_notification.user_info);
+			if ([t_local_notification alertBody] == nil)
+				r_notification.body = MCValueRetain(kMCEmptyString);
+			else
+				MCStringCreateWithCFString ((CFStringRef)[t_local_notification alertBody], r_notification.body); // or ""
+			
+			if ([t_local_notification alertAction] == nil)
+				r_notification.action = MCValueRetain(kMCEmptyString);
+			else
+				MCStringCreateWithCFString ((CFStringRef)[t_local_notification alertAction], r_notification.action); // or ""
+			
+			if ([t_local_notification.userInfo objectForKey:@"payload"] == nil)
+				r_notification.user_info = MCValueRetain(kMCEmptyString);
+			else
+				MCStringCreateWithCFString ((CFStringRef)[t_local_notification.userInfo objectForKey:@"payload"], r_notification.user_info);
             r_notification.time = [[t_local_notification fireDate] timeIntervalSince1970];
             r_notification.badge_value = t_local_notification.applicationIconBadgeNumber;
             r_notification.play_sound = t_local_notification.soundName != nil ? true : false;


### PR DESCRIPTION
1. Using `mobileCreateLocalNotification alertBody, alertButtonMessage, alertPayload, alertTime, playSound [, badgeValue]` successfully creates a local notification on both iOS 9 and 10.
2. The LC param `alertButtonMessage` corresponds to `[t_local_notification alertAction]`
3. Setting this param works as expected on both iOS 9 and 10.

However, getting this param on iOS 10 ( `[t_local_notification alertAction]`) returns `nil`, which causes a crash when calling `mobileGetNotificationDetails`

This patch fixes the crash. However, if one examines the array returned by `mobileGetNotificationDetails`:

iOS 9: `alertButtonMessage = myAlertButtonMessage`
iOS 10: `alertButtonMessage = ""`
