### PR TITLE
Turn on -Werror=enum-compare

### DIFF
--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -142,6 +142,7 @@
 							'-Werror=objc-literal-compare',
 							'-Werror=shadow',
 							'-Werror=unreachable-code',
+							'-Werror=enum-compare',
 						],
 					},
 				},

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2306,8 +2306,8 @@ void MCObject::sendmessage(Handler_type htype, MCNameRef m, Boolean h)
 	};
 	enum { max_htype = (sizeof(htypes)/sizeof(htypes[0])) - 1 };
     
-	MCAssert(htype <= max_htype);
-	MCStaticAssert(max_htype == HT_MAX);
+	MCAssert(htype <= Handler_type(max_htype));
+	MCStaticAssert(Handler_type(max_htype) == HT_MAX);
     MCmessagemessages = False;
 
     MCExecContext ctxt(this, nil, nil);

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -1597,7 +1597,7 @@ T* MCObjectCast(MCObject* p_object)
 {
     // Check that the object's type matches the (static) type of the desired
     // type. This will break horribly if the desired type has derived types...
-    MCAssert(p_object->gettype() == T::kObjectType);
+    MCAssert(p_object->gettype() == Chunk_term(T::kObjectType));
     return static_cast<T*> (p_object);
 }
 


### PR DESCRIPTION
enum-compare appears to be a documented warning but it's not showing up in Xcode. I noticed these in Travis logs.
