### PR TITLE
[Bug 18683] Prevent crash on iOS 10 when the app wants to use the device's microphone

### DIFF
--- a/docs/notes/bugfix-18683.md
+++ b/docs/notes/bugfix-18683.md
@@ -1,0 +1,1 @@
+# Fix crash on iOS 10 when the app needs access to the device's microphone

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -118,6 +118,8 @@
 	<string>This application requires access to the device's microphone</string>
 	<key>NSMotionUsageDescription</key>
 	<string>This application requires access to the device's accelerometer</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>This application requires access to your Reminders</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
 </dict>

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -114,7 +114,7 @@
 	<string>This application requires access to the device's camera</string>
 	<key>NSContactsUsageDescription</key>
 	<string>This application requires access to your Contacts</string>
-	<key>NSMicrophoneUsageDescription </key>
+	<key>NSMicrophoneUsageDescription</key>
 	<string>This application requires access to the device's microphone</string>
 	<key>NSMotionUsageDescription</key>
 	<string>This application requires access to the device's accelerometer</string>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -87,7 +87,7 @@
 	<string>This application requires access to the device's camera</string>
 	<key>NSContactsUsageDescription</key>
 	<string>This application requires access to your Contacts</string>
-	<key>NSMicrophoneUsageDescription </key>
+	<key>NSMicrophoneUsageDescription</key>
 	<string>This application requires access to the device's microphone</string>
 	<key>NSMotionUsageDescription</key>
 	<string>This application requires access to the device's accelerometer</string>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -91,6 +91,8 @@
 	<string>This application requires access to the device's microphone</string>
 	<key>NSMotionUsageDescription</key>
 	<string>This application requires access to the device's accelerometer</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>This application requires access to your Reminders</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
 </dict>


### PR DESCRIPTION
Also added another privacy-related key-val pair in iOS .plist, which might be needed in the future
