### PR TITLE
Fix JPEG support code compilation on Android & Emscripten

### DIFF
--- a/engine/src/ijpg.cpp
+++ b/engine/src/ijpg.cpp
@@ -76,7 +76,7 @@ extern "C" boolean fill_input_buffer(j_decompress_ptr cinfo)
 	MC_jpegsrc_ptr src = (MC_jpegsrc_ptr) cinfo->src;
 	src->pub.next_input_byte = src->buffer;
 	src->pub.bytes_in_buffer = src->buffersize;
-	return True;
+	return TRUE;
 }
 
 extern "C" void skip_input_data(j_decompress_ptr cinfo, long num_bytes)
@@ -360,22 +360,24 @@ static bool apply_exif_orientation(uint32_t p_orientation, MCImageBitmap *p_bitm
 static boolean
 marker_is_icc (jpeg_saved_marker_ptr marker)
 {
-  return
-    marker->marker == ICC_MARKER &&
-    marker->data_length >= ICC_OVERHEAD_LEN &&
-    /* verify the identifying string */
-    GETJOCTET(marker->data[0]) == 0x49 &&
-    GETJOCTET(marker->data[1]) == 0x43 &&
-    GETJOCTET(marker->data[2]) == 0x43 &&
-    GETJOCTET(marker->data[3]) == 0x5F &&
-    GETJOCTET(marker->data[4]) == 0x50 &&
-    GETJOCTET(marker->data[5]) == 0x52 &&
-    GETJOCTET(marker->data[6]) == 0x4F &&
-    GETJOCTET(marker->data[7]) == 0x46 &&
-    GETJOCTET(marker->data[8]) == 0x49 &&
-    GETJOCTET(marker->data[9]) == 0x4C &&
-    GETJOCTET(marker->data[10]) == 0x45 &&
-    GETJOCTET(marker->data[11]) == 0x0;
+	if (marker->marker == ICC_MARKER &&
+	    marker->data_length >= ICC_OVERHEAD_LEN &&
+	    /* verify the identifying string */
+	    GETJOCTET(marker->data[0]) == 0x49 &&
+	    GETJOCTET(marker->data[1]) == 0x43 &&
+	    GETJOCTET(marker->data[2]) == 0x43 &&
+	    GETJOCTET(marker->data[3]) == 0x5F &&
+	    GETJOCTET(marker->data[4]) == 0x50 &&
+	    GETJOCTET(marker->data[5]) == 0x52 &&
+	    GETJOCTET(marker->data[6]) == 0x4F &&
+	    GETJOCTET(marker->data[7]) == 0x46 &&
+	    GETJOCTET(marker->data[8]) == 0x49 &&
+	    GETJOCTET(marker->data[9]) == 0x4C &&
+	    GETJOCTET(marker->data[10]) == 0x45 &&
+	    GETJOCTET(marker->data[11]) == 0x0)
+		return TRUE;
+	else
+		return FALSE;
 }
 
 
@@ -510,7 +512,7 @@ boolean srcmgr_fill_input_buffer(j_decompress_ptr p_jpeg)
 	t_src->src.bytes_in_buffer = t_bytes_read;
 	t_src->src.next_input_byte = t_src->buffer;
 
-	return True;
+	return TRUE;
 }
 
 void srcmgr_skip_input_data(j_decompress_ptr p_jpeg, long p_count)
@@ -882,7 +884,7 @@ boolean destmgr_empty_output_buffer(j_compress_ptr p_jpeg_info)
 	t_manager->byte_count += JPEG_BUF_SIZE;
 	t_manager->dest.next_output_byte = t_manager->buffer;
 	t_manager->dest.free_in_buffer = JPEG_BUF_SIZE;
-	return True;
+	return TRUE;
 }
 
 void destmgr_term_destination(j_compress_ptr p_jpeg_info)
@@ -961,7 +963,7 @@ bool MCImageEncodeJPEG(MCImageBitmap *p_image, MCImageMetadata *p_metadata, IO_h
 		t_jpeg.in_color_space = JCS_RGB;
 
 		jpeg_set_defaults(&t_jpeg);
-		jpeg_set_quality(&t_jpeg, MCjpegquality, True);
+		jpeg_set_quality(&t_jpeg, MCjpegquality, TRUE);
         
         if (p_metadata != nil)
         {
@@ -977,7 +979,7 @@ bool MCImageEncodeJPEG(MCImageBitmap *p_image, MCImageMetadata *p_metadata, IO_h
             }
         }
 
-		jpeg_start_compress(&t_jpeg, True);
+		jpeg_start_compress(&t_jpeg, TRUE);
 	}
 
 	//Allocate array of pixel RGB values


### PR DESCRIPTION
The Android and Emscripten builds are unhappy with the updated
libjpeg, which appears to define its `boolean` type and `FALSE`/`TRUE`
constants slightly differently.

Update: This appears to also fix a build failure on iOS 10.
