### PR TITLE
[Docs] functions C-M - parameter and syntax fixes

### DIFF
--- a/docs/dictionary/function/codepointProperty.lcdoc
+++ b/docs/dictionary/function/codepointProperty.lcdoc
@@ -21,14 +21,13 @@ Example:
 put codePointProperty(codepoint 1 of tString, "Name")
 
 Parameters:
-unicodeCodepoint:
+unicodeCodepoint(string):
 A Unicode codepoint, or an expression which evaulates to a Unicode
-codepoint. 
+codepoint.
 
 propertyName (enum):
-The name of a supported UCD codepoint property Examples of supported
-properties, for a full list see
-http://www.unicode.org/versions/Unicode6.2.0/ch04.pdf 
+The name of a supported UCD codepoint property. Examples of supported
+properties, for a full list see http://www.unicode.org/versions/Unicode6.2.0/ch04.pdf
 
 -   "Name": Unique name for the codepoint
 -   "Numeric_Value": Numerical value, e.g. 4 for 4
@@ -37,7 +36,7 @@ http://www.unicode.org/versions/Unicode6.2.0/ch04.pdf
 -   "Lowercase": True if the codepoint is lower-case
 
 
-Returns:
+Returns(string):
 The codepointProperty returns the value of the UCD property for the
 specified Unicode codepoint.
 
@@ -55,12 +54,11 @@ There are many properties available; please see the version 6.3.0 of the
 Unicode standard, Chapter 4 and Section 5 of Unicode Technical Report
 (TR)#44 for details on the names and values of properties. Property
 names may be specified with either spaces or underscores and are not
-case-sensitive. 
+case-sensitive.
 
 >*Note:*  This function is not intended for general-purpose use; please
-> use functions such as <toUpper> or the is operators instead.
+> use functions such as <toUpper> or the <is|equals> operators instead.
 
 References: nativeCharToNum (function), numToNativeChar (function),
 toUpper (function), numToCodepoint (function), codepoint (keyword),
-codepoints (keyword)
-
+codepoints (keyword), equals (operator)

--- a/docs/dictionary/function/compound.lcdoc
+++ b/docs/dictionary/function/compound.lcdoc
@@ -2,7 +2,7 @@ Name: compound
 
 Type: function
 
-Syntax: compound(<interestPerPeriod>, <numberOfPeriods>)
+Syntax: compound(<interestRate>, <numberOfPeriods>)
 
 Summary:
 <return|Returns> the principal plus accrued interest of an investment.
@@ -20,17 +20,16 @@ Example:
 put theInvestment * compound(yearlyInterest,numberYears) into endValue
 
 Parameters:
-interestPerPeriod:
-
-
-numberOfPeriods:
-A positive number.
-
-interestRate:
-A positive number. The interestRate is expressed as a fraction of 1 so,
+interestRate(number):
+A positive number. The <interestRate> is expressed as a fraction of 1 so,
 for example, an 8% rate is written .08.
 
-Returns:
+
+numberOfPeriods(integer):
+A positive number.
+
+
+Returns(number):
 The <compound> <function> <return|returns> a positive number.
 
 Description:
@@ -45,11 +44,10 @@ The formula for the value of an compound-interest-bearing account is
 The <compound> <function> calculates this value.
 
 The <numberOfPeriods> and the <interestRate> must use the same unit of
-time. For example, if the periods are months, the interest rate is the
+time. For example, if the periods are months, the <interest rate> is the
 interest per month.
 
 References: function (control structure), annuity (function),
 round (function), return (glossary)
 
 Tags: math
-

--- a/docs/dictionary/function/compound.lcdoc
+++ b/docs/dictionary/function/compound.lcdoc
@@ -44,7 +44,7 @@ The formula for the value of an compound-interest-bearing account is
 The <compound> <function> calculates this value.
 
 The <numberOfPeriods> and the <interestRate> must use the same unit of
-time. For example, if the periods are months, the <interest rate> is the
+time. For example, if the periods are months, the <interestRate> is the
 interest per month.
 
 References: function (control structure), annuity (function),

--- a/docs/dictionary/function/decompress.lcdoc
+++ b/docs/dictionary/function/decompress.lcdoc
@@ -16,7 +16,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-decompress(receivedString)
+decompress(tReceivedString)
 
 Example:
 put decompress(it) into URL "file:data.txt"
@@ -26,12 +26,9 @@ go stack decompress(URL "binfile:newstuff.gz")
 
 Parameters:
 gzippedString (string):
-
-
-data (string):
 A string of compressed binary data.
 
-Returns:
+Returns(string):
 The <decompress> <function> <return|returns> a <string>.
 
 Description:
@@ -56,4 +53,3 @@ return (glossary), function (glossary), string (keyword),
 inverse (keyword)
 
 Tags: text processing
-

--- a/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormAddPart.lcdoc
@@ -2,7 +2,7 @@ Name: libURLMultipartFormAddPart
 
 Type: function
 
-Syntax: libURLMultipartFormAddPart(<form data>,<part name>, <value> [,<MIME type>, <encoding>])
+Syntax: libURLMultipartFormAddPart(<formData>,<partName>, <value> [,<MIMEtype>, <encoding>])
 
 Summary:
 This function lets you add parts to a multipart form one at a time. It
@@ -22,10 +22,11 @@ Security: network
 
 Example:
 command UploadFileToServer pName, pMessage, pFilename
+  local tOrigHeaders, tForm, tError, tFile, tType, tEnc, tURL
   put the httpHeaders into tOrigHeaders
   put empty into tForm
   put libURLMultipartFormData (tForm, "name", pName, "message", pMessage) into tError
-  
+
   if tError is empty then
     set the httpHeaders to line 1 of tForm
     delete line 1 of tForm
@@ -34,14 +35,14 @@ command UploadFileToServer pName, pMessage, pFilename
     put "binary" into tEnc
     put libURLMultipartFormAddPart(tForm,"file", tFile, tType, tEnc) into tError
   end if
- 
+
   if tError is empty then
     post tForm to url tURL
     put the result into tError
   end if
-  
+
   set the httpHeaders to tOrigHeaders
-  
+
   if tError is not empty then
     return tError for error
   else
@@ -50,10 +51,15 @@ command UploadFileToServer pName, pMessage, pFilename
 end UploadFileToServer
 
 Parameters:
-value:
+formData(string): A variable, which will be filled with the form data.
 
+partName(string): The name of the new part to add to the <formData>.
 
-encoding:
+value(string): The value to be associated with the <partName> of the <formData>.
+
+MIMEtype(enum): The MIME type to use for the <value>.
+
+encoding(enum): The encoding type to use for the <value>.
 
 
 Description:
@@ -61,13 +67,12 @@ This function is mainly used if you have called the
 <libURLMultipartFormData> with no arguments except the form data. This
 will return an "empty" form which can be added to using this function.
 
->*Important:* The <libURLMultipartFormAddPart> <function> is part of
-> the 
-> <Internet library>. To ensure that the <function> works in a 
-> <standalone application>, you must include this 
-> <LiveCode custom library|custom library> when you create your 
-> <standalone application|standalone>. In the Inclusions pane of the 
-> <Standalone Application Settings> window, make sure the "Internet" 
+>*Important:* The <libURLMultipartFormAddPart> <function> is part of the
+> <Internet library>. To ensure that the <function> works in a
+> <standalone application>, you must include this
+> <LiveCode custom library|custom library> when you create your
+> <standalone application|standalone>. In the Inclusions pane of the
+> <Standalone Application Settings> window, make sure the "Internet"
 > script library is selected.
 
 References: post (command), libURLMultipartFormData (function),
@@ -78,4 +83,3 @@ group (glossary), standalone application (glossary), keyword (glossary),
 function (glossary), application (glossary), Internet library (library),
 library (library), startup (message), openBackground (message),
 preOpenStack (message), openStack (message), preOpenCard (message)
-

--- a/docs/dictionary/function/localLoc.lcdoc
+++ b/docs/dictionary/function/localLoc.lcdoc
@@ -9,7 +9,7 @@ Syntax: localLoc(<globalPoint>)
 Summary:
 <return|Returns> the equivalent, in <relative coordinates|local
 coordinates>, of a <point> given in <absolute coordinates|global
-coordinates>. 
+coordinates>.
 
 Introduced: 1.0
 
@@ -24,14 +24,11 @@ Example:
 localLoc(the location of field 1)
 
 Parameters:
-globalPoint:
-
-
-point:
-Any expression that evaluates to a point--a vertical and horizontal
+globalPoint(point):
+Any expression that evaluates to a <point(glossary)>--a vertical and horizontal
 distance from the top left of the screen, separated by a comma.
 
-Returns:
+Returns(point):
 The <localLoc> <function> <return|returns> two <integer|integers>
 separated by a comma.
 
@@ -39,24 +36,23 @@ Description:
 Use the <localLoc> <function> to translate between screen and <relative
 coordinates|window coordinates>.
 
-In window coordinates, the point 0,0 is at the top left of the stack
-window. In screen coordinates, the point 0,0 is at the top left of the
-screen. 
+In window coordinates, the <point(glossary)> 0,0 is at the top left of the stack
+window. In screen coordinates, the <point(glossary)> 0,0 is at the top left of
+the screen.
 
-The point returned by the <localLoc> <function> is relative to the top
+The <point(glossary)> returned by the <localLoc> <function> is relative to the top
 left of the <current stack>.
 
 The first item of the returned value is the horizontal distance in
 pixels from the left edge of the current stack to the location given by
-<point>. The second <item> of the <return value|returned value> is the
+<globalPoint>. The second <item> of the <return value|returned value> is the
 vertical distance from the top edge of the <current stack> to the
-location given by <point>.
+location given by <globalPoint>.
 
 References: function (control structure), selectedLoc (function),
 relative coordinates (glossary), current stack (glossary),
 absolute coordinates (glossary), return (glossary),
 return value (glossary), integer (glossary), item (keyword),
-point (keyword), relative (keyword)
+point (keyword), point (glossary), relative (keyword)
 
 Tags: ui
-

--- a/docs/dictionary/function/measureText.lcdoc
+++ b/docs/dictionary/function/measureText.lcdoc
@@ -2,7 +2,7 @@ Name: measureText
 
 Type: function
 
-Syntax: measureText(<text>,<object reference>,[<mode>])
+Syntax: measureText(<text>,<objectReference>,[<mode>])
 
 Summary:
 <return|Returns> the width, size or bounds of the text drawn with the
@@ -15,25 +15,33 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-put measureText(theText,me) into theTextWidth
+put measureText(tText,me) into tTextWidth
 
 Example:
-put measureText(theText,me,"size") into theTextSize
+put measureText(tText,me,"size") into tTextSize
 
 Example:
-put measureText(theText,me,"bounds") into theTextBounds
+put measureText(tText,me,"bounds") into tTextBounds
 
 Parameters:
-text:
+text(string):
 Any native string. For unicode strings use measureUnicodeText.
 
-mode:
-One of: 	 width - (default if not specified) - returns the width of the
-text size - returns the width,height of the text bounds - returns a
-rectangle identifying the bounds of the text in the form
-0,-ascent,width,descent where ascent and descent are relative to a 0
-baseline the text is drawn on. object reference: An expression that
-evaluates to an object reference.
+objectReference(string):
+An expression that evaluates to an object reference.
+
+mode(enum):
+-   width: (default if not specified)
+-   size:
+-   bounds:
+
+returns:
+-   width(number): the width of the text
+-   size(int,int): the width,height of the text
+-   bounds(rect): a rectangle identifying the bounds of the text in the
+form `0,-ascent,width,descent` where ascent and descent are relative to
+a 0 baseline the text is drawn on.
+
 
 Description:
 Use the <measureText> <function> to find the dimensions of text drawn
@@ -43,4 +51,3 @@ References: function (control structure), measureUnicodeText (function),
 return (glossary), formattedWidth (property), formattedHeight (property)
 
 Tags: ui
-

--- a/docs/dictionary/function/mobileBuildInfo.lcdoc
+++ b/docs/dictionary/function/mobileBuildInfo.lcdoc
@@ -2,7 +2,7 @@ Name: mobileBuildInfo
 
 Type: function
 
-Syntax: mobileBuildInfo(<propertyName>)
+Syntax: mobileBuildInfo(<propertyInfo>)
 
 Summary:
 Returns information about the current device.
@@ -20,16 +20,13 @@ Example:
 put mobileBuildInfo("SERIAL") into tDeviceSerialNumber
 
 Parameters:
-propertyName:
-
-
 propertyInfo (enum):
 The name of the property to be retrieved.
 
 -   "BOARD": The name of the underlying board, like "goldfish"
 -   "BOOTLOADER": The system bootloader version number.
 -   "BRAND": The brand (e.g. carrier) the software is customized for, if
-    any. 
+    any.
 -   "CPU_ABI": The name of the instruction set (CPU type + ABI
     converntion) of native code.
 -   "CPU_ABI2": The name of the second instruction set (CPU type + ABI
@@ -48,20 +45,18 @@ The name of the property to be retrieved.
 -   "RADIO": The radio firmware version number.
 -   "SERIAL": A hardware serial number, if available.
 -   "TAGS": Comma-separated tags describing the build, like
-    "unsigned,debug". 
+    "unsigned,debug".
 -   "TIME": The time, in seconds since the start of the eon.
 -   "TYPE": The type of build, like "user" or "eng".
 -   "USER": The user name of the user who built the current version of
-    Android. 
+    Android.
+
+Returns(string):
+The requested information about the current device.
 
 
 Description:
 Use the <mobileBuildInfo> function to fetch information about the
 current device, such as the manufacturer and device name.
 
-The <mobileBuildInfo> function returns information about the current
-device. 
-
 >*Note:* Property names are case sensitive.
-
-


### PR DESCRIPTION
parameter and syntax fixes to the following functions:
codepointProperty, compound, decompress, libUrlMultipartFormAddPart,
localLoc, measureText and mobileBuildInfo
