### PR TITLE
[Bug] Fix crash when colorizing closed field

### DIFF
--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -1550,7 +1550,7 @@ void MCIdeScriptColourize::exec_ctxt(MCExecContext &ctxt)
 	t_state = MCIdeState::Find(t_target);
 
 
-    if (t_target && t_target -> getparagraphs() != NULL)
+    if (t_target && t_target -> getparagraphs() != NULL && t_target -> getopened())
         TokenizeField(t_target, t_state, f_type, t_start, t_end, colourize_paragraph);
 }
 


### PR DESCRIPTION
This patch works around a crash that occurs if the script
editor is closed and attempts to colorize the script field.
This situation may occur if the target object was deleted
and the editor closed as a result.
