### PR TITLE
[Docs] functions - Add summary and fix syntax and parameters

### DIFF
--- a/docs/dictionary/function/controlAtLoc.lcdoc
+++ b/docs/dictionary/function/controlAtLoc.lcdoc
@@ -2,7 +2,7 @@ Name: controlAtLoc
 
 Type: function
 
-Syntax: controlAtLoc(coordinates)
+Syntax: controlAtLoc(<coordinates>)
 
 Summary:
 Returns the control at the specified location.

--- a/docs/dictionary/function/controlAtLoc.lcdoc
+++ b/docs/dictionary/function/controlAtLoc.lcdoc
@@ -31,8 +31,8 @@ The <controlAtLoc> function returns the control at the given location.
 The function returns the number of the control, below are examples of
 getting the name or long id of the control
 
-  get the name of (contolAtLoc(<coordinates>))
-  get the long id of (contolAtLoc(<coordinates>))
+  get the name of (controlAtLoc(<coordinates>))
+  get the long ID of (controlAtLoc(<coordinates>))
 
 References: mouseLoc (function), controlAtScreenLoc (function),
 control (keyword), location (property)

--- a/docs/dictionary/function/controlAtLoc.lcdoc
+++ b/docs/dictionary/function/controlAtLoc.lcdoc
@@ -2,7 +2,10 @@ Name: controlAtLoc
 
 Type: function
 
-Syntax: controlAtLoc(loc)
+Syntax: controlAtLoc(coordinates)
+
+Summary:
+Returns the control at the specified location.
 
 Introduced: 6.0
 
@@ -17,24 +20,21 @@ Example:
 get the name of (controlAtLoc(the mouseLoc))
 
 Parameters:
-location:
+coordinates(point):
 A location, relative to the current stack
 
-Returns:
+Returns(string):
 The control at the given location, in the form: control control_number.
 
 Description:
-Returns the control at the specified location.
-
 The <controlAtLoc> function returns the control at the given location.
 The function returns the number of the control, below are examples of
 getting the name or long id of the control
 
-get the name of (contolAtLoc(<location>))
-get the long id of (contolAtLoc(<location>))
+  get the name of (contolAtLoc(<coordinates>))
+  get the long id of (contolAtLoc(<coordinates>))
 
 References: mouseLoc (function), controlAtScreenLoc (function),
 control (keyword), location (property)
 
 Tags: ui
-

--- a/docs/dictionary/function/controlAtScreenLoc.lcdoc
+++ b/docs/dictionary/function/controlAtScreenLoc.lcdoc
@@ -31,8 +31,8 @@ The <controlAtScreenLoc> function returns the control at the given
 location. The function returns the number of the control, below are
 examples of getting the name or long id of the control
 
-  get the name of (contolAtLoc(<coordinates>))
-  get the long id of (contolAtLoc(<coordinates>))
+  get the name of (controlAtLoc(<coordinates>))
+  get the long ID of (controlAtLoc(<coordinates>))
 
 References: mouseLoc (function), controlAtLoc (function),
 control (keyword), location (property)

--- a/docs/dictionary/function/controlAtScreenLoc.lcdoc
+++ b/docs/dictionary/function/controlAtScreenLoc.lcdoc
@@ -2,7 +2,10 @@ Name: controlAtScreenLoc
 
 Type: function
 
-Syntax: controlAtScreenLoc(loc)
+Syntax: controlAtScreenLoc(coordinates)
+
+Summary:
+Returns the control at the specified location.
 
 Introduced: 6.0
 
@@ -17,24 +20,21 @@ Example:
 get the name of (controlAtScreenLoc(the mouseLoc))
 
 Parameters:
-location:
+coordinates(point):
 A location, relative to the screen
 
-Returns:
+Returns(string):
 The control at the given location, in the form: control control_number.
 
 Description:
-Returns the control at the specified location.
-
 The <controlAtScreenLoc> function returns the control at the given
 location. The function returns the number of the control, below are
 examples of getting the name or long id of the control
 
-get the name of (contolAtLoc(<location>))
-get the long id of (contolAtLoc(<location>))
+  get the name of (contolAtLoc(<coordinates>))
+  get the long id of (contolAtLoc(<coordinates>))
 
 References: mouseLoc (function), controlAtLoc (function),
 control (keyword), location (property)
 
 Tags: ui
-

--- a/docs/dictionary/function/controlAtScreenLoc.lcdoc
+++ b/docs/dictionary/function/controlAtScreenLoc.lcdoc
@@ -2,7 +2,7 @@ Name: controlAtScreenLoc
 
 Type: function
 
-Syntax: controlAtScreenLoc(coordinates)
+Syntax: controlAtScreenLoc(<coordinates>)
 
 Summary:
 Returns the control at the specified location.

--- a/docs/dictionary/function/xsltApplyStylesheet.lcdoc
+++ b/docs/dictionary/function/xsltApplyStylesheet.lcdoc
@@ -2,7 +2,11 @@ Name: xsltApplyStylesheet
 
 Type: function
 
-Syntax: xsltApplyStylesheet xmlDocID, xsltStylesheetID
+Syntax: xsltApplyStylesheet (<xmlDocID>,<xsltStylesheetID>)
+
+Summary:
+Returns the data set resulting from applying the xslt document against the 
+specified xml document.
 
 Introduced: 6.5
 
@@ -13,7 +17,14 @@ Platforms: desktop, server, mobile
 Example:
 put xsltApplyStylesheet(tDocID, tStylesheetID) into tProcessedData
 
-The result:
+Parameters:
+xmlDocID(string):
+The ID of the xml document to use.
+
+xsltStylesheetID(string):
+The xslt stylesheet document to apply to the xml document.
+
+The result(string):
 &lt;!-- order the result by revenue --&gt;&#13;.
 
 Description:
@@ -159,4 +170,3 @@ revXMLCreateTreeFromFile (function), revXMLCreateTree (function),
 xsltApplyStylesheetFromFile (function)
 
 Tags: xml
-

--- a/docs/dictionary/function/xsltApplyStylesheet.lcdoc
+++ b/docs/dictionary/function/xsltApplyStylesheet.lcdoc
@@ -5,7 +5,7 @@ Type: function
 Syntax: xsltApplyStylesheet (<xmlDocID>,<xsltStylesheetID>)
 
 Summary:
-Returns the data set resulting from applying the xslt document against the 
+Returns the data set resulting from applying the xslt document against the
 specified xml document.
 
 Introduced: 6.5
@@ -25,144 +25,141 @@ xsltStylesheetID(string):
 The xslt stylesheet document to apply to the xml document.
 
 The result(string):
-&lt;!-- order the result by revenue --&gt;&#13;.
+&lt;!-- order the result by revenue --&gt;.
 
 Description:
 The xsltApplyStylesheet function returns the data set resulting from
 applying the xslt document against the specified xml document. For
 instance, given xml data of
 
-&lt;sales&gt;&#13;
+    &lt;sales&gt;
 
-    &lt;division id="North"&gt;&#13;
+        &lt;division id="North"&gt;
 
-    &lt;revenue&gt;10&lt;/revenue&gt;&#13;
-    &lt;growth&gt;9&lt;/growth&gt;&#13;
-    &lt;bonus&gt;7&lt;/bonus&gt;&#13;
+        &lt;revenue&gt;10&lt;/revenue&gt;
+        &lt;growth&gt;9&lt;/growth&gt;
+        &lt;bonus&gt;7&lt;/bonus&gt;
 
-    &lt;/division&gt;&#13;
-    &lt;division id="South"&gt;&#13;
+        &lt;/division&gt;
+        &lt;division id="South"&gt;
 
-    &lt;revenue&gt;4&lt;/revenue&gt;&#13;
-    &lt;growth&gt;3&lt;/growth&gt;&#13;
-    &lt;bonus&gt;4&lt;/bonus&gt;&#13;
+        &lt;revenue&gt;4&lt;/revenue&gt;
+        &lt;growth&gt;3&lt;/growth&gt;
+        &lt;bonus&gt;4&lt;/bonus&gt;
 
-    &lt;/division&gt;&#13;
-    &lt;division id="West"&gt;&#13;
+        &lt;/division&gt;
+        &lt;division id="West"&gt;
 
-    &lt;revenue&gt;6&lt;/revenue&gt;&#13;
-    &lt;growth&gt;-1.5&lt;/growth&gt;&#13;
-    &lt;bonus&gt;2&lt;/bonus&gt;&#13;
+        &lt;revenue&gt;6&lt;/revenue&gt;
+        &lt;growth&gt;-1.5&lt;/growth&gt;
+        &lt;bonus&gt;2&lt;/bonus&gt;
 
-    &lt;/division&gt;&#13;
+        &lt;/division&gt;
 
-&lt;/sales&gt;
+    &lt;/sales&gt;
 
 and an xslt document of
 
-&lt;html xsl:version="1.0"&#13;
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&#13;
+    &lt;html xsl:version="1.0";xmlns:xsl="http://www.w3.org/1999/XSL/Transform" lang="en"&gt;
+        &lt;head&gt;
 
-    lang="en"&gt;&#13;
-    &lt;head&gt;&#13;
+        &lt;title&gt;Sales Results By Division&lt;/title&gt;
+        &lt;/head&gt;
+        &lt;body&gt;
 
-    &lt;title&gt;Sales Results By Division&lt;/title&gt;&#13;
-    &lt;/head&gt;&#13;
-    &lt;body&gt;&#13;
+        &lt;table border="1"&gt;
 
-    &lt;table border="1"&gt;&#13;
+        &lt;tr&gt;
 
-    &lt;tr&gt;&#13;
+        &lt;th&gt;Division&lt;/th&gt;
+        &lt;th&gt;Revenue&lt;/th&gt;
+        &lt;th&gt;Growth&lt;/th&gt;
+        &lt;th&gt;Bonus&lt;/th&gt;
 
-    &lt;th&gt;Division&lt;/th&gt;&#13;
-    &lt;th&gt;Revenue&lt;/th&gt;&#13;
-    &lt;th&gt;Growth&lt;/th&gt;&#13;
-    &lt;th&gt;Bonus&lt;/th&gt;&#13;
+        &lt;/tr&gt;
+        &lt;xsl:for-each select="sales/division"&gt;
 
-    &lt;/tr&gt;&#13;
-    &lt;xsl:for-each select="sales/division"&gt;&#13;
+        &lt;xsl:sort select="revenue"
 
-    &lt;xsl:sort select="revenue"&#13;
+        data-type="number"
+        order="descending"/&gt;
 
-    data-type="number"&#13;
-    order="descending"/&gt;&#13;
+        &lt;tr&gt;
 
-    &lt;tr&gt;&#13;
+        &lt;td&gt;
 
-    &lt;td&gt;&#13;
+        &lt;em&gt;&lt;xsl:value-of select="@id"/&gt;&lt;/em&gt;
 
-    &lt;em&gt;&lt;xsl:value-of select="@id"/&gt;&lt;/em&gt;&#13;
+        &lt;/td&gt;
+        &lt;td&gt;
 
-    &lt;/td&gt;&#13;
-    &lt;td&gt;&#13;
+        &lt;xsl:value-of select="revenue"/&gt;
 
-    &lt;xsl:value-of select="revenue"/&gt;&#13;
+        &lt;/td&gt;
+        &lt;td&gt;
 
-    &lt;/td&gt;&#13;
-    &lt;td&gt;&#13;
+        &lt;!-- highlight negative growth in red --&gt;
+        &lt;xsl:if test="growth &lt; 0"&gt;
 
-    &lt;!-- highlight negative growth in red --&gt;&#13;
-    &lt;xsl:if test="growth &lt; 0"&gt;&#13;
+        &lt;xsl:attribute name="style"&gt;
 
-    &lt;xsl:attribute name="style"&gt;&#13;
+        &lt;xsl:text&gt;color:red&lt;/xsl:text&gt;
 
-    &lt;xsl:text&gt;color:red&lt;/xsl:text&gt;&#13;
+        &lt;/xsl:attribute&gt;
 
-    &lt;/xsl:attribute&gt;&#13;
+        &lt;/xsl:if&gt;
+        &lt;xsl:value-of select="growth"/&gt;
 
-    &lt;/xsl:if&gt;&#13;
-    &lt;xsl:value-of select="growth"/&gt;&#13;
+        &lt;/td&gt;
+        &lt;td&gt;
 
-    &lt;/td&gt;&#13;
-    &lt;td&gt;&#13;
+        &lt;xsl:value-of select="bonus"/&gt;
 
-    &lt;xsl:value-of select="bonus"/&gt;&#13;
+        &lt;/td&gt;
 
-    &lt;/td&gt;&#13;
+        &lt;/tr&gt;
 
-    &lt;/tr&gt;&#13;
+        &lt;/xsl:for-each&gt;
 
-    &lt;/xsl:for-each&gt;&#13;
+        &lt;/table&gt;
+        &lt;/body&gt;
 
-    &lt;/table&gt;&#13;
-    &lt;/body&gt;&#13;
-
-&lt;/html&gt;
+    &lt;/html&gt;
 
 You would end up with
 
-&lt;html lang="en"&gt;
-&lt;head&gt;
-&lt;meta http-equiv="Content-Type" content="text/html;
-charset=UTF-8"&gt; &lt;title&gt;Sales Results By Division&lt;/title&gt;
-&lt;/head&gt;
-&lt;body&gt;&lt;table border="1"&gt;
-&lt;tr&gt;
-&lt;th&gt;Division&lt;/th&gt;
-&lt;th&gt;Revenue&lt;/th&gt;
-&lt;th&gt;Growth&lt;/th&gt;
-&lt;th&gt;Bonus&lt;/th&gt;
-&lt;/tr&gt;
-&lt;tr&gt;
-&lt;td&gt;&lt;em&gt;North&lt;/em&gt;&lt;/td&gt;
-&lt;td&gt;10&lt;/td&gt;
-&lt;td&gt;9&lt;/td&gt;
-&lt;td&gt;7&lt;/td&gt;
-&lt;/tr&gt;
-&lt;tr&gt;
-&lt;td&gt;&lt;em&gt;West&lt;/em&gt;&lt;/td&gt;
-&lt;td&gt;6&lt;/td&gt;
-&lt;td style="color:red"&gt;-1.5&lt;/td&gt;
-&lt;td&gt;2&lt;/td&gt;
-&lt;/tr&gt;
-&lt;tr&gt;
-&lt;td&gt;&lt;em&gt;South&lt;/em&gt;&lt;/td&gt;
-&lt;td&gt;4&lt;/td&gt;
-&lt;td&gt;3&lt;/td&gt;
-&lt;td&gt;4&lt;/td&gt;
-&lt;/tr&gt;
-&lt;/table&gt;&lt;/body&gt;
-&lt;/html&gt;
+    &lt;html lang="en"&gt;
+    &lt;head&gt;
+    &lt;meta http-equiv="Content-Type" content="text/html;
+    charset=UTF-8"&gt; &lt;title&gt;Sales Results By Division&lt;/title&gt;
+    &lt;/head&gt;
+    &lt;body&gt;&lt;table border="1"&gt;
+    &lt;tr&gt;
+    &lt;th&gt;Division&lt;/th&gt;
+    &lt;th&gt;Revenue&lt;/th&gt;
+    &lt;th&gt;Growth&lt;/th&gt;
+    &lt;th&gt;Bonus&lt;/th&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+    &lt;td&gt;&lt;em&gt;North&lt;/em&gt;&lt;/td&gt;
+    &lt;td&gt;10&lt;/td&gt;
+    &lt;td&gt;9&lt;/td&gt;
+    &lt;td&gt;7&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+    &lt;td&gt;&lt;em&gt;West&lt;/em&gt;&lt;/td&gt;
+    &lt;td&gt;6&lt;/td&gt;
+    &lt;td style="color:red"&gt;-1.5&lt;/td&gt;
+    &lt;td&gt;2&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+    &lt;td&gt;&lt;em&gt;South&lt;/em&gt;&lt;/td&gt;
+    &lt;td&gt;4&lt;/td&gt;
+    &lt;td&gt;3&lt;/td&gt;
+    &lt;td&gt;4&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;/table&gt;&lt;/body&gt;
+    &lt;/html&gt;
 
 References: revXMLEvaluateXpath (function), xsltLoadStylesheet (function),
 xsltLoadStylesheetFromFile (function),

--- a/docs/dictionary/function/xsltApplyStylesheet.lcdoc
+++ b/docs/dictionary/function/xsltApplyStylesheet.lcdoc
@@ -24,8 +24,6 @@ The ID of the xml document to use.
 xsltStylesheetID(string):
 The xslt stylesheet document to apply to the xml document.
 
-The result(string):
-&lt;!-- order the result by revenue --&gt;.
 
 Description:
 The xsltApplyStylesheet function returns the data set resulting from
@@ -79,6 +77,7 @@ and an xslt document of
         &lt;/tr&gt;
         &lt;xsl:for-each select="sales/division"&gt;
 
+        &lt;!-- order the result by revenue --&gt;
         &lt;xsl:sort select="revenue"
 
         data-type="number"

--- a/docs/dictionary/function/xsltApplyStylesheetFromFile.lcdoc
+++ b/docs/dictionary/function/xsltApplyStylesheetFromFile.lcdoc
@@ -5,7 +5,7 @@ Type: function
 Syntax: xsltApplyStylesheetFromFile (<xmlDocID>,<pathToXSLTFile>)
 
 Summary:
-Returns the data set resulting from applying the xslt document in the specified 
+Returns the data set resulting from applying the xslt document in the specified
 file against the specified xml document.
 
 Introduced: 6.5
@@ -33,137 +33,133 @@ The xsltApplyStylesheetFromFile function returns the data set resulting
 from applying the xslt document in the specified file against the
 specified xml document. For instance, given xml data of
 
-&lt;sales&gt;
+    &lt;sales&gt;
 
-    &lt;division id="North"&gt;
+        &lt;division id="North"&gt;
 
-    &lt;revenue&gt;10&lt;/revenue&gt;
-    &lt;growth&gt;9&lt;/growth&gt;
-    &lt;bonus&gt;7&lt;/bonus&gt;
+        &lt;revenue&gt;10&lt;/revenue&gt;
+        &lt;growth&gt;9&lt;/growth&gt;
+        &lt;bonus&gt;7&lt;/bonus&gt;
 
-    &lt;/division&gt;
-    &lt;division id="South"&gt;
+        &lt;/division&gt;
+        &lt;division id="South"&gt;
 
-    &lt;revenue&gt;4&lt;/revenue&gt;
-    &lt;growth&gt;3&lt;/growth&gt;
-    &lt;bonus&gt;4&lt;/bonus&gt;
+        &lt;revenue&gt;4&lt;/revenue&gt;
+        &lt;growth&gt;3&lt;/growth&gt;
+        &lt;bonus&gt;4&lt;/bonus&gt;
 
-    &lt;/division&gt;
-    &lt;division id="West"&gt;
+        &lt;/division&gt;
+        &lt;division id="West"&gt;
 
-    &lt;revenue&gt;6&lt;/revenue&gt;
-    &lt;growth&gt;-1.5&lt;/growth&gt;
-    &lt;bonus&gt;2&lt;/bonus&gt;
+        &lt;revenue&gt;6&lt;/revenue&gt;
+        &lt;growth&gt;-1.5&lt;/growth&gt;
+        &lt;bonus&gt;2&lt;/bonus&gt;
 
-    &lt;/division&gt;
+        &lt;/division&gt;
 
-&lt;/sales&gt;
+    &lt;/sales&gt;
 
 and a file containing xslt data of
 
-&lt;html xsl:version="1.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    &lt;html xsl:version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" lang="en"&gt;
+        &lt;head&gt;
 
-    lang="en"&gt;
+        &lt;title&gt;Sales Results By Division&lt;/title&gt;
+        &lt;/head&gt;
+        &lt;body&gt;
+
+        &lt;table border="1"&gt;
+
+        &lt;tr&gt;
+
+        &lt;th&gt;Division&lt;/th&gt;
+        &lt;th&gt;Revenue&lt;/th&gt;
+        &lt;th&gt;Growth&lt;/th&gt;
+        &lt;th&gt;Bonus&lt;/th&gt;
+
+        &lt;/tr&gt;
+        &lt;xsl:for-each select="sales/division"&gt;
+
+        &lt;xsl:sort select="revenue"
+            data-type="number"
+            order="descending"/&gt;
+
+        &lt;tr&gt;
+
+        &lt;td&gt;
+
+        &lt;em&gt;&lt;xsl:value-of select="@id"/&gt;&lt;/em&gt;
+
+        &lt;/td&gt;
+        &lt;td&gt;
+
+        &lt;xsl:value-of select="revenue"/&gt;
+
+        &lt;/td&gt;
+        &lt;td&gt;
+
+        &lt;!-- highlight negative growth in red --&gt;
+        &lt;xsl:if test="growth &lt; 0"&gt;
+
+        &lt;xsl:attribute name="style"&gt;
+
+        &lt;xsl:text&gt;color:red&lt;/xsl:text&gt;
+
+        &lt;/xsl:attribute&gt;
+
+        &lt;/xsl:if&gt;
+        &lt;xsl:value-of select="growth"/&gt;
+
+        &lt;/td&gt;
+        &lt;td&gt;
+
+        &lt;xsl:value-of select="bonus"/&gt;
+
+        &lt;/td&gt;
+
+        &lt;/tr&gt;
+
+        &lt;/xsl:for-each&gt;
+
+        &lt;/table&gt;
+        &lt;/body&gt;
+
+    &lt;/html&gt;
+
+You would end up with
+
+    &lt;html lang="en"&gt;
     &lt;head&gt;
-
-    &lt;title&gt;Sales Results By Division&lt;/title&gt;
+    &lt;meta http-equiv="Content-Type" content="text/html;
+    charset=UTF-8"&gt; &lt;title&gt;Sales Results By Division&lt;/title&gt;
     &lt;/head&gt;
-    &lt;body&gt;
-
-    &lt;table border="1"&gt;
-
+    &lt;body&gt;&lt;table border="1"&gt;
     &lt;tr&gt;
-
     &lt;th&gt;Division&lt;/th&gt;
     &lt;th&gt;Revenue&lt;/th&gt;
     &lt;th&gt;Growth&lt;/th&gt;
     &lt;th&gt;Bonus&lt;/th&gt;
-
     &lt;/tr&gt;
-    &lt;xsl:for-each select="sales/division"&gt;
-
-    &lt;xsl:sort select="revenue"
-
-    data-type="number"
-    order="descending"/&gt;
-
     &lt;tr&gt;
-
-    &lt;td&gt;
-
-    &lt;em&gt;&lt;xsl:value-of select="@id"/&gt;&lt;/em&gt;
-
-    &lt;/td&gt;
-    &lt;td&gt;
-
-    &lt;xsl:value-of select="revenue"/&gt;
-
-    &lt;/td&gt;
-    &lt;td&gt;
-
-    &lt;!-- highlight negative growth in red --&gt;
-    &lt;xsl:if test="growth &lt; 0"&gt;
-
-    &lt;xsl:attribute name="style"&gt;
-
-    &lt;xsl:text&gt;color:red&lt;/xsl:text&gt;
-
-    &lt;/xsl:attribute&gt;
-
-    &lt;/xsl:if&gt;
-    &lt;xsl:value-of select="growth"/&gt;
-
-    &lt;/td&gt;
-    &lt;td&gt;
-
-    &lt;xsl:value-of select="bonus"/&gt;
-
-    &lt;/td&gt;
-
+    &lt;td&gt;&lt;em&gt;North&lt;/em&gt;&lt;/td&gt;
+    &lt;td&gt;10&lt;/td&gt;
+    &lt;td&gt;9&lt;/td&gt;
+    &lt;td&gt;7&lt;/td&gt;
     &lt;/tr&gt;
-
-    &lt;/xsl:for-each&gt;
-
-    &lt;/table&gt;
-    &lt;/body&gt;
-
-&lt;/html&gt;
-
-You would end up with
-
-&lt;html lang="en"&gt;
-&lt;head&gt;
-&lt;meta http-equiv="Content-Type" content="text/html;
-charset=UTF-8"&gt; &lt;title&gt;Sales Results By Division&lt;/title&gt;
-&lt;/head&gt;
-&lt;body&gt;&lt;table border="1"&gt;
-&lt;tr&gt;
-&lt;th&gt;Division&lt;/th&gt;
-&lt;th&gt;Revenue&lt;/th&gt;
-&lt;th&gt;Growth&lt;/th&gt;
-&lt;th&gt;Bonus&lt;/th&gt;
-&lt;/tr&gt;
-&lt;tr&gt;
-&lt;td&gt;&lt;em&gt;North&lt;/em&gt;&lt;/td&gt;
-&lt;td&gt;10&lt;/td&gt;
-&lt;td&gt;9&lt;/td&gt;
-&lt;td&gt;7&lt;/td&gt;
-&lt;/tr&gt;
-&lt;tr&gt;
-&lt;td&gt;&lt;em&gt;West&lt;/em&gt;&lt;/td&gt;
-&lt;td&gt;6&lt;/td&gt;
-&lt;td style="color:red"&gt;-1.5&lt;/td&gt;
-&lt;td&gt;2&lt;/td&gt;
-&lt;/tr&gt;
-&lt;tr&gt;
-&lt;td&gt;&lt;em&gt;South&lt;/em&gt;&lt;/td&gt;
-&lt;td&gt;4&lt;/td&gt;
-&lt;td&gt;3&lt;/td&gt;
-&lt;td&gt;4&lt;/td&gt;
-&lt;/tr&gt;
-&lt;/table&gt;&lt;/body&gt;
-&lt;/html&gt;
+    &lt;tr&gt;
+    &lt;td&gt;&lt;em&gt;West&lt;/em&gt;&lt;/td&gt;
+    &lt;td&gt;6&lt;/td&gt;
+    &lt;td style="color:red"&gt;-1.5&lt;/td&gt;
+    &lt;td&gt;2&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+    &lt;td&gt;&lt;em&gt;South&lt;/em&gt;&lt;/td&gt;
+    &lt;td&gt;4&lt;/td&gt;
+    &lt;td&gt;3&lt;/td&gt;
+    &lt;td&gt;4&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;/table&gt;&lt;/body&gt;
+    &lt;/html&gt;
 
 References: revXMLEvaluateXpath (function), xsltLoadStylesheet (function),
 xsltLoadStylesheetFromFile (function),

--- a/docs/dictionary/function/xsltApplyStylesheetFromFile.lcdoc
+++ b/docs/dictionary/function/xsltApplyStylesheetFromFile.lcdoc
@@ -25,8 +25,6 @@ The ID of the xml document to use.
 pathToXSLTFile(string):
 The file path to the xslt document that will be applied to the xml document.
 
-The result(string):
-&lt;!-- order the result by revenue --&gt;.
 
 Description:
 The xsltApplyStylesheetFromFile function returns the data set resulting
@@ -80,6 +78,7 @@ and a file containing xslt data of
         &lt;/tr&gt;
         &lt;xsl:for-each select="sales/division"&gt;
 
+        &lt;!-- order the result by revenue --&gt;
         &lt;xsl:sort select="revenue"
             data-type="number"
             order="descending"/&gt;

--- a/docs/dictionary/function/xsltApplyStylesheetFromFile.lcdoc
+++ b/docs/dictionary/function/xsltApplyStylesheetFromFile.lcdoc
@@ -2,7 +2,11 @@ Name: xsltApplyStylesheetFromFile
 
 Type: function
 
-Syntax: xsltApplyStylesheetFromFile xmlDocID, pathToXSLTFile
+Syntax: xsltApplyStylesheetFromFile (<xmlDocID>,<pathToXSLTFile>)
+
+Summary:
+Returns the data set resulting from applying the xslt document in the specified 
+file against the specified xml document.
 
 Introduced: 6.5
 
@@ -14,7 +18,14 @@ Example:
 put xsltApplyStylesheetFromFile(tDocID, "getData.xml" ) into tProcessedData
 put xsltApplyStylesheetFromFile(tDocID, tFilePath) into tProcessedData
 
-The result:
+Parameters:
+xmlDocID(string):
+The ID of the xml document to use.
+
+pathToXSLTFile(string):
+The file path to the xslt document that will be applied to the xml document.
+
+The result(string):
 &lt;!-- order the result by revenue --&gt;.
 
 Description:
@@ -160,4 +171,3 @@ revXMLCreateTreeFromFile (function), revXMLCreateTree (function),
 xsltApplyStylesheetFromFile (function)
 
 Tags: xml
-


### PR DESCRIPTION
For controlAtLoc docs:
- Spelling of function in the Description examples corrected

For xslt docs:
- Put parameters into angle braces in the syntax and created parameters descriptions
- Removed the `&# 13` tags from the end of each example line
- Indented examples to display correctly
