### PR TITLE
Fix crashes when walking the player list without checking handle validity

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -457,27 +457,27 @@ static void handle_signal(int sig)
     case SIGCHLD:
         {
 #if defined(_LINUX_DESKTOP)
-            MCPlayer *tptr = MCplayers;
+            MCPlayerHandle t_player = MCplayers;
             // If we have some players waiting then deal with these first
             waitedpid = -1;
-            if ( tptr != NULL)
+            if (t_player.IsValid())
             {
                 waitedpid = wait(NULL);
                 // Moving these two lines half fixes bug 5966 - however it still isn't quite right
                 // as there will still be some interaction between a player and shell command
-                while(tptr != NULL)
+                while(t_player.IsValid())
                 {
-                    if ( waitedpid == tptr -> getpid())
+                    if (t_player.IsValid() && waitedpid == t_player->getpid())
                     {
-                        if (tptr->isdisposable())
-                            tptr->playstop();
+                        if (t_player->isdisposable())
+                            t_player->playstop();
                         else
-                            MCscreen->delaymessage(tptr, MCM_play_stopped, NULL, NULL);
+                            MCscreen->delaymessage(t_player, MCM_play_stopped, NULL, NULL);
 
-                        tptr->shutdown();
+                        t_player->shutdown();
                         break;
                     }
-                    tptr = tptr -> getnextplayer() ;
+                    t_player = t_player -> getnextplayer() ;
                 }
             }
             else

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -2946,9 +2946,11 @@ void MCStack::view_surface_redrawwindow(MCStackSurface *p_surface, MCGRegionRef 
 	t_tilecache = view_gettilecache();
 	
     // SN-2014-08-25: [[ Bug 13187 ]] MCplayers's syncbuffering relocated
-    for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-        if (t_player -> getstack() == this)
-            t_player -> syncbuffering(nil);
+    for(MCPlayerHandle t_player = MCplayers; t_player.IsValid(); t_player = t_player -> getnextplayer())
+	{
+        	if (t_player -> getstack() == this)
+            	t_player -> syncbuffering(nil);
+	}
     
 	if (t_tilecache == nil || !MCTileCacheIsValid(t_tilecache))
 	{


### PR DESCRIPTION
These were causing crashes when running the IDE tests on Linux when
the player failed to initialise properly (e.g. missing mplayer).