### PR TITLE
Fix a crash when quitting from the script editor

### DIFF
--- a/docs/notes/bugfix-18600.md
+++ b/docs/notes/bugfix-18600.md
@@ -1,0 +1,1 @@
+# Fix crash when quitting from script editor

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1704,9 +1704,9 @@ void MCStack::createmenu(MCControl *nc, uint2 width, uint2 height)
         }
 	}
 
-
-	updatecardsize();
 	cards->setparent(this);
+	updatecardsize();
+	
 	MCControl *cptr = nc;
 	do
 	{


### PR DESCRIPTION
Was happening on Linux but possibly Windows too.