### PR TITLE
Fix crash when opening cards with buttons containing icons

### DIFF
--- a/docs/notes/bugfix-18812.md
+++ b/docs/notes/bugfix-18812.md
@@ -1,0 +1,2 @@
+# Fix crash when opening cards referencing images on non-open cards
+

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -552,7 +552,13 @@ void MCControl::layer_dirtyeffectiverect(const MCRectangle& p_effective_rect, bo
 	t_control = this;
 	while (t_control -> parent -> gettype() != CT_CARD)
 	{
-		MCControl *t_parent_control;
+                // If we have reached a stack before finding a card, this control is
+                // not on an open card (it might be an image being used as a button icon
+                // for example). In this case, there is nothing that needs to be done
+                if (t_control->parent->gettype() == CT_STACK)
+                        return;
+        
+                MCControl *t_parent_control;
 		t_parent_control = t_control->parent.GetAs<MCControl>();
 		
 		// If the parent control is scrolling, we are done - defer to content


### PR DESCRIPTION
If a button on the card has an icon that is a reference to an image that is on another card, the attempt to draw that icon can cause a crash because the object tree for the icon is walked looking for the parent card (but, as the icon is on a non-open card, its parent is the stack instead).