### PR TITLE
[Bug 18821] Report all LCB stack frames in LCS error info

### DIFF
--- a/docs/notes/bugfix-18821.md
+++ b/docs/notes/bugfix-18821.md
@@ -1,0 +1,1 @@
+# Report all LCB stack frames in LCS error info

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -476,14 +476,19 @@ Exec_stat MCExtensionCatchError(MCExecContext& ctxt)
         MCLog("Error state indicated with no error having been thrown");
         return ES_ERROR;
     }
-    
-    ctxt . LegacyThrow(EE_EXTENSION_ERROR_DOMAIN, MCErrorGetDomain(*t_error));
-    ctxt . LegacyThrow(EE_EXTENSION_ERROR_DESCRIPTION, MCErrorGetMessage(*t_error));
-    if (MCErrorGetDepth(*t_error) > 0)
-    {
-        ctxt . LegacyThrow(EE_EXTENSION_ERROR_FILE, MCErrorGetTargetAtLevel(*t_error, 0));
-        ctxt . LegacyThrow(EE_EXTENSION_ERROR_LINE, MCErrorGetRowAtLevel(*t_error, 0));
-    }
+
+	uindex_t t_num_frames = MCErrorGetDepth(*t_error);
+	for (uindex_t t_depth = 0; t_depth < t_num_frames; ++t_depth)
+	{
+		if (t_depth == 0)
+		{
+			ctxt . LegacyThrow(EE_EXTENSION_ERROR_DOMAIN, MCErrorGetDomain(*t_error));
+			ctxt . LegacyThrow(EE_EXTENSION_ERROR_DESCRIPTION, MCErrorGetMessage(*t_error));
+		}
+		ctxt . LegacyThrow(EE_EXTENSION_ERROR_FILE, MCErrorGetTargetAtLevel(*t_error, t_depth));
+		ctxt . LegacyThrow(EE_EXTENSION_ERROR_LINE, MCErrorGetRowAtLevel(*t_error, t_depth));
+		ctxt . LegacyThrow(EE_EXTENSION_ERROR_COLUMN, MCErrorGetColumnAtLevel(*t_error, t_depth));
+	}
     
     return ES_ERROR;
 }

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2728,6 +2728,9 @@ enum Exec_errors
 
 	// {EE-0893} folders: error in folder parameter
 	EE_FOLDERS_BADFOLDER,
+
+	// {EE-0894} extension: error occured with column
+	EE_EXTENSION_ERROR_COLUMN,
 };
 
 extern const char *MCexecutionerrors;


### PR DESCRIPTION
When an error is thrown in an LCB library or extension, and this error
is converted to an LCS error info string, include the filename, line
and column for every frame in the LCB stack.