### PR TITLE
Tweaks to prebuilt/scripts/ios.inc

### DIFF
--- a/prebuilt/scripts/ios.inc
+++ b/prebuilt/scripts/ios.inc
@@ -23,14 +23,11 @@ function addiOS {
 XCODES_DIR="${HOME}/Builds/Platforms"
 
 # Detect iOS variants
-if [ -e "${XCODES_DIR}/Xcode_4_3_1" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_4_3_1/Xcode.app/Contents/Developer" iPhoneSimulator 5.1 i386
+if [ -e "${XCODES_DIR}/Xcode_4_6_2" ] ; then
+	addiOS "${XCODES_DIR}/Xcode_4_6_2/Xcode.app/Contents/Developer" iPhoneSimulator 6.1 i386
 fi
-if [ -e "${XCODES_DIR}/Xcode_4_6_0" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_4_6_0/Xcode.app/Contents/Developer" iPhoneSimulator 6.1 i386
-fi
-if [ -e "${XCODES_DIR}/Xcode_5_1_0" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_5_1_0/Xcode.app/Contents/Developer" iPhoneSimulator 7.1 i386
+if [ -e "${XCODES_DIR}/Xcode_5_1_1" ] ; then
+	addiOS "${XCODES_DIR}/Xcode_5_1_1/Xcode.app/Contents/Developer" iPhoneSimulator 7.1 i386
 fi
 if [ -e "${XCODES_DIR}/Xcode_6_2_0" ] ; then
 	addiOS "${XCODES_DIR}/Xcode_6_2_0/Xcode.app/Contents/Developer" iPhoneSimulator 8.2 "i386 x86_64"


### PR DESCRIPTION
1. Removed code for building prebuilts with iOS simulator 5.1 SDKs

2. Tweaked script to use the exact versions of xcode we have already installed in the test machine
(`Xcode4.6.0 --> xcode4.6.2` and `xcode5.1.0 -->xcode5.1.1`)