### PR TITLE
docs: Expand and update documentation for the "do" command

### DIFF
--- a/docs/dictionary/command/do-as-alternatelanguage.lcdoc
+++ b/docs/dictionary/command/do-as-alternatelanguage.lcdoc
@@ -1,0 +1,86 @@
+Name: do as alternateLanguage
+
+Type: command
+
+Syntax: do <script> as <alternateLanguage>
+
+Summary: Evaluate a script written in another programming language
+
+Introduced: 1.1
+
+OS: mac, windows, html5
+
+Example:
+do field "Statements" as "AppleScript"
+
+Example:
+do "document.location" as "JavaScript"
+
+Parameters:
+script (string): A script written in a non-LiveCode programming
+language.
+
+alternateLanguage (string): The name of one of the
+<alternateLanguages>.
+
+The result: How the <result> is set depends on the <platform> and
+the selected <alternateLanguage>.
+
+Description:
+Use the <do as alternateLanguage> variant of the <do> <command> to
+evaluate a <script> written in a non-LiveCode programming language.
+You can get a list of available languages by calling the
+<alternateLanguages> function.
+
+The behavior of the <do as alternateLanguage> command is
+<platform>-dependent:
+
+- On MacOS and OS X systems, the <alternateLanguage> is a script
+  language (such as AppleScript) supported by the Open Scripting
+  Architecture.  The value returned by executing the <statementList>
+  is placed into the <result>.
+
+- On Windows systems, the <alternateLanguage> is an "active
+  scripting" language (such as VBScript) supported by the Windows
+  Scripting Host.  The <result> is set to the value of any global
+  variable called `result` in the <statementList>, or empty if no such
+  variable was defined.  For example, the following code will show a
+  dialog box containing "2":
+
+      do "result = 1 + 1" as "vbscript"
+      answer the result
+
+  Any <statementList> which contains a reference to `WScript` will
+  fail to run, because `WScript` objects do not exist in the LiveCode
+  environment.  Put return values in a global `result` variable
+  instead of using `WScript.Echo`.
+
+- In HTML5 applications, "JavaScript" is the only supported
+  <alternateLanguage>.  The <result> is set to the value returned
+  by executing the <statementList>, as long as the value is a scalar
+  (a string, number, boolean or undefined).  Returning JavaScript
+  arrays or objects is not supported.
+
+On other platforms, the <alternateLanguage> is not supported, and
+the <do as alternateLanguage> command will set the <result> to
+"alternate language not found".
+
+>*Important:* Any <file path> used in the <script> must be in the
+> native format of the current system. In particular this means that
+> paths must be converted to Windows native format before use on
+> Windows machines. In most cases this can be done by replacing slash
+> with backslash in the path.
+
+Changes:
+- Support for the Open Scripting Architecture on Mac OS systems was
+  added in version 1.1.
+- Support for the Windows Scripting Host on Windows systems was added
+  in version 2.9.
+- Support for running JavaScript on HTML5 systems was added in version
+  9.0.0
+
+References: alternateLanguages (function), result (function),
+platform (function),
+command (glossary), file path (glossary),
+as (keyword),
+do (command)

--- a/docs/dictionary/command/do.lcdoc
+++ b/docs/dictionary/command/do.lcdoc
@@ -2,11 +2,7 @@ Name: do
 
 Type: command
 
-Syntax: do <statementList>
-
-Syntax: do <statementList> in <caller>
-
-Syntax: do <statementList> as <alternateLanguageName>
+Syntax: do <statementList> [in <caller>]
 
 Summary:
 <execute|Executes> a list of <statement|statements>.
@@ -21,14 +17,11 @@ Example:
 do "go next card"
 
 Example:
-do "put"  x  "into tNumberOfRecords" 
--- might become "put 3 into tNumberOfRecords"
+do "put" && tNewValue && "into tNumberOfRecords"
+-- If tNewValue is 3, this would become "put 3 into tNumberOfRecords"
 
 Example:
 do "select" && line 3 of field "Objects"
-
-Example:
-do field "Statements" as AppleScript
 
 Parameters:
 statementList:
@@ -36,35 +29,12 @@ A LiveCode statement, a container with one or more statements, or a
 string that evaluates to a statement.
 
 caller:
-Has the effect of executing the statementList in the context of the
-handler. 
-
-alternateLanguageName:
-On Mac OS and OS X systems, the alternateLanguageName is a script
-language (such as AppleScript) supported under the Open Scripting
-Architecture.
-On Windows systems, the alternateLanguageName is an "active scripting"
-language (such as VBScript) supported by the Windows Scripting Host.
-On HTML5, JavaScript is the only supported alternateLanguageName.
-The available languages are returned by the alternateLanguages function.
-If you specify an alternateLanguageName, the statementList must be
-written in the specified language.
+Has the effect of executing the <statementList> in the context of the
+handler.
 
 The result:
-On HTML5 and Mac OS X systems, if you use the do as
-<alternateLanguageName> form, any result returned by the script language
-is placed in the <result>.
-On Windows systems, the <result> function will return the value of the
-global variable called "result" in the script that was executed (or
-empty if no such variable was defined). For example the following code
-will produce a dialog box containing "2":
-do "result = 1 + 1" as "vbscript"; answer the result;
-If you attempt to specify an <alternateLanguageName> on a <Unix>
-<system>, the <do> <command> is not executed, and the <result> is set to
-"alternate language not found". Any scripts on Windows which contain
-references to WScript will fail to run as WScript objects do not exist
-in the LiveCode Environment. Return values should therefore be placed
-within the global <result> variable instead of using WScript.Echo.
+The <result> is
+affected by the LiveCode commands and functions in the script in the normal way.
 
 Description:
 Use the <do> command to execute statements in a container, or to execute
@@ -75,31 +45,15 @@ Using the <do> <command> is slower than directly <execute|executing> the
 <command|commands>, because each <statement> must be <compile|compiled>
 every time the <do> <command> is executed.
 
->*Important:* If using the do as <alternateLanguageName> form, any paths
-> used in the <statementList> must be in the native format of the
-> current system. In particular this means that paths must be converted
-> to Windows native format before use on Windows machines. In most cases
-> this can be done by replacing slash with backslash in the path.
-
 To see how to create a numbered set of variables see the dictionary
 entry for the <local> <command>.
 
-The ability to specify an <alternateLanguageName> on Windows systems was
-added in LiveCode 2.9.
-
-Changes:
-- The <alternateLanguageName> option was introduced in version 1.1. In
-  previous versions, it was not possible to include AppleScript or other
-  <Open Scripting Architecture (OSA)|OSA> languages in a <LiveCode>
-  <handler>. 
-- Support for running JavaScript on HTML5 systems was added in version
-  9.0.0
+You can use the <do as alternateLanguage> variant of the <do> command
+to evaluate a <statementList> written in a non-LiveCode programming
+language.
 
 References: debugDo (command), breakpoint (command), local (command),
 call (command), result (function),
-alternateLanguages (function), system (glossary), LiveCode (glossary),
 handler (glossary), execute (glossary), statement (glossary),
-Unix (glossary), compile (glossary), command (glossary),
-Open Scripting Architecture (OSA) (glossary), message box (keyword),
-as (keyword)
-
+compile (glossary), command (glossary),
+message box (keyword), do as alternateLanguage (command)

--- a/docs/dictionary/keyword/as.lcdoc
+++ b/docs/dictionary/keyword/as.lcdoc
@@ -12,12 +12,12 @@ with the <go> <command> to specify the mode of a <stack>; used with the
 
 Introduced: 1.0
 
-OS: mac, windows, linux, ios, android
+OS: mac, windows, linux, ios, android, html5
 
 Platforms: desktop, server, mobile
 
 Example:
-do field 1 as Javascript
+do field 1 as "Javascript"
 
 Example:
 export image "image" to file myFile as PNG
@@ -32,11 +32,12 @@ Description:
 Use the <as> <keyword> to modify the <do>, <export>, <go>, or <save>
 <command|commands>. 
 
-Use the alternateLanguages <function> to find out which languages can be
-used with the <do> command on <Mac OS> and <OS X|OS X systems>.
+Use the <alternateLanguages> <function> to find out which languages
+can be used with the <do as alternateLanguage> command on <Mac OS> and
+<OS X|OS X systems>.
 
-References: export (command), go (command), do (command), save (command),
-function (control structure), format (function), keyword (glossary),
-file path (glossary), command (glossary), Mac OS (glossary),
-OS X (glossary), file (keyword), stack (object)
-
+References: export (command), go (command), do (command),
+save (command), function (control structure), format (function),
+keyword (glossary), file path (glossary), command (glossary),
+Mac OS (glossary), OS X (glossary), file (keyword), stack (object),
+alternateLanguages (function), do as alternateLanguage (command)


### PR DESCRIPTION
This patch splits the documentation for the `do script as
alternateLanguage` command out from the documentation for the "normal"
`do` command, in order to provide better clarity.