### PR TITLE
[[ Bug 18809 ]] Ensure MCmenuobjectptr is set to nil appropriately

### DIFF
--- a/docs/notes/bugfix-18809.md
+++ b/docs/notes/bugfix-18809.md
@@ -1,0 +1,1 @@
+# Prevent lock up of PI when not selecting choice from font menu

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1948,7 +1948,17 @@ void MCDispatch::removemenu()
 void MCDispatch::closemenus()
 {
 	if (menu != NULL)
+	{
+		MCObject *t_menu = menu;
 		menu->closemenu(True, True);
+		
+		// Ensure the menuobjectptr is set to nil. We can't do this in
+		// closemenu itself, as elsewhere menuPick is sent *after*
+		// calling closemenu and there is likely to be code that relies
+		// on 'the menuButton' during handling of menuPick
+		if (MCmenuobjectptr == t_menu)
+			MCmenuobjectptr = nil;
+	}
 }
 
 void MCDispatch::appendpanel(MCStack *sptr)


### PR DESCRIPTION
In particular, it needs to be set to nil when a combo box menu is
closed by clicking outside the drop down menu.