### PR TITLE
[Bug 12196] Correct documentation for the "do" command

### DIFF
--- a/docs/dictionary/command/do.lcdoc
+++ b/docs/dictionary/command/do.lcdoc
@@ -2,7 +2,7 @@ Name: do
 
 Type: command
 
-Syntax: do <statementList> [in <caller>]
+Syntax: do <statementList> [in caller]
 
 Summary:
 <execute|Executes> a list of <statement|statements>.
@@ -28,10 +28,6 @@ statementList:
 A LiveCode statement, a container with one or more statements, or a
 string that evaluates to a statement.
 
-caller:
-Has the effect of executing the <statementList> in the context of the
-handler.
-
 The result:
 The <result> is
 affected by the LiveCode commands and functions in the script in the normal way.
@@ -44,6 +40,10 @@ container or the return value from a function.
 Using the <do> <command> is slower than directly <execute|executing> the
 <command|commands>, because each <statement> must be <compile|compiled>
 every time the <do> <command> is executed.
+
+When the `do statementList in caller` form of the <do> command is
+used, the <statementList> is evaluated in the context of the handler
+where the <do> command appears.
 
 To see how to create a numbered set of variables see the dictionary
 entry for the <local> <command>.

--- a/docs/notes/bugfix-12196.md
+++ b/docs/notes/bugfix-12196.md
@@ -1,0 +1,1 @@
+# Correct documentation for "do" command


### PR DESCRIPTION
Update the syntax documentation to make it clear that `caller` is a
syntax token, rather than a parameter, and move the explanation of the
effects of the `in caller` qualifier into the description section.