### PR TITLE
Fix various OpenSSL 1.1.0 issues blocking our builds

### DIFF
--- a/engine/src/deploy_sign.cpp
+++ b/engine/src/deploy_sign.cpp
@@ -1582,7 +1582,7 @@ bool MCDeploySignLoadPVK(MCStringRef p_filename, MCStringRef p_passphrase, EVP_P
 	if (t_success)
 	{
         t_rsa_e = BN_new();
-		if (!t_rsa_e || !BN_set_word(&t_rsa_e, t_rsa_header.exponent))
+		if (!t_rsa_e || !BN_set_word(*t_rsa_e, t_rsa_header.exponent))
 			t_success = MCDeployThrowOpenSSL(kMCDeployErrorNoMemory);
 	}
 	

--- a/engine/src/deploy_sign.cpp
+++ b/engine/src/deploy_sign.cpp
@@ -1146,10 +1146,10 @@ bool MCDeploySignWindows(const MCDeploySignParameters& p_params)
 	// The various ASN.1 structures we are going to use require a number of ObjectIDs.
 	// We register them all here, to save having to check the return value of OBJ_txt2obj.
 	if (t_success)
-		if (!OBJ_create(SPC_INDIRECT_DATA_OBJID, NULL, NULL) ||
-			!OBJ_create(SPC_PE_IMAGE_DATA_OBJID, NULL, NULL) ||
-			!OBJ_create(SPC_STATEMENT_TYPE_OBJID, NULL, NULL) ||
-			!OBJ_create(SPC_SP_OPUS_INFO_OBJID, NULL, NULL))
+		if (!OBJ_create(SPC_INDIRECT_DATA_OBJID, SPC_INDIRECT_DATA_OBJID, SPC_INDIRECT_DATA_OBJID) ||
+			!OBJ_create(SPC_PE_IMAGE_DATA_OBJID, SPC_PE_IMAGE_DATA_OBJID, SPC_PE_IMAGE_DATA_OBJID) ||
+			!OBJ_create(SPC_STATEMENT_TYPE_OBJID, SPC_STATEMENT_TYPE_OBJID, SPC_STATEMENT_TYPE_OBJID) ||
+			!OBJ_create(SPC_SP_OPUS_INFO_OBJID, SPC_SP_OPUS_INFO_OBJID, SPC_SP_OPUS_INFO_OBJID))
 			t_success = MCDeployThrowOpenSSL(kMCDeployErrorBadSignature);
 
 	// Authenticode signatures require a single SignerInfo structure to be present.

--- a/prebuilt/scripts/build-openssl.sh
+++ b/prebuilt/scripts/build-openssl.sh
@@ -74,8 +74,10 @@ function buildOpenSSL {
 			local PLATFORM_NAME=${PLATFORM}
 		fi
 		
+		CUSTOM_SPEC="${SPEC}-livecode"
+
 		OPENSSL_ARCH_SRC="${OPENSSL_SRC}-${PLATFORM_NAME}-${ARCH}"
-		OPENSSL_ARCH_CONFIG="no-rc5 no-hw shared --prefix=${INSTALL_DIR}/${NAME} ${SPEC}"
+		OPENSSL_ARCH_CONFIG="no-rc5 no-hw shared --prefix=${INSTALL_DIR}/${NAME} ${CUSTOM_SPEC}"
 		OPENSSL_ARCH_LOG="${OPENSSL_ARCH_SRC}.log"
 	
 		# Copy the source to a target-specific directory
@@ -94,6 +96,17 @@ function buildOpenSSL {
 		# Re-configure and re-build, if required
 		if [ "${OPENSSL_ARCH_CONFIG}" != "${OPENSSL_ARCH_CURRENT_CONFIG}" ] ; then
 			cd "${OPENSSL_ARCH_SRC}"
+
+			# Customise the OpenSSL configuration to ensure variables are exported as functions
+			cat > Configurations/99-livecode.conf << EOF
+%targets = (
+	"${CUSTOM_SPEC}" => {
+		inherit_from => [ "${SPEC}" ],
+		bn_ops => sub { join(" ",(@_,"EXPORT_VAR_AS_FN")) },
+	},
+);
+EOF
+
 			echo "Configuring OpenSSL for ${NAME}"
 			
 			setCCForArch "${ARCH}" "${SUBPLATFORM_INDEX}"
@@ -108,9 +121,6 @@ function buildOpenSSL {
 			if [ "${PLATFORM}" == "ios" ] ; then
 				sed -i "" -e "s/MAKEDEPPROG=makedepend/MAKEDEPPROG=$\(CC\) -M/" Makefile
 			fi
-
-			# Ensure that variables get exported as functions
-			echo "#define OPENSSL_EXPORT_VAR_AS_FUNCTION 1" >> crypto/opensslconf.h
 
 			echo "Building OpenSSL for ${NAME}"
 			make clean >> "${OPENSSL_ARCH_LOG}" 2>&1 && make depend >> "${OPENSSL_ARCH_LOG}" 2>&1 && make ${MAKEFLAGS} >> "${OPENSSL_ARCH_LOG}" 2>&1 && make install_sw >> "${OPENSSL_ARCH_LOG}" 2>&1


### PR DESCRIPTION
Summary of fixes:

- typo (& vs *) causing assertion failures when using an MCAutoCustomPointer
- passing NULL to OpenSSL functions that (now) require a valid string
- ensuring OpenSSL exports variables as functions (new config system in 1.1.0 broke how we were setting that before)