### PR TITLE
[Bug 18632] Mark the `copyResource` function as deprecated

### DIFF
--- a/docs/dictionary/function/copyResource.lcdoc
+++ b/docs/dictionary/function/copyResource.lcdoc
@@ -9,6 +9,8 @@ Copies a <resource> from one <Mac OS> <file> to another.
 
 Introduced: 1.0
 
+Deprecated: 8.1
+
 OS: mac
 
 Platforms: desktop
@@ -68,6 +70,11 @@ If you don't specify a <newID>, the new <resource> has the same ID as
 the original <resource>. Specifying a <newID> does not change the
 resource ID of the original <resource> in the <file>; it only affects
 the copy in the <destinationFile>.
+
+Changes:
+The <copyResource> function was deprecated in LiveCode 8.1, since the
+versions of MacOS supported by LiveCode no longer support resource
+forks.  It should not be used in any new code.
 
 References: copy (command), function (control structure),
 result (function), setResource (function), resource fork (glossary),

--- a/docs/notes/bugfix-18632.md
+++ b/docs/notes/bugfix-18632.md
@@ -1,0 +1,1 @@
+# Mark the copyResource function as deprecated


### PR DESCRIPTION
Modern versions of MacOS no longer support resource forks, so the
`copyResource` function is unnecessary.  Furthermore, while fixing bug
18379 (commit fab0ac4), it was found to be broken with no real options
available for making it work again.  This commit updates the
dictionary to mark the `copyResource` function as deprecated.