### PR TITLE
Fix uninited member var in MCAutoStringRefAsLPWSTR

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -399,7 +399,13 @@ typedef MCAutoStringRefAsUTF16String MCAutoStringRefAsLPCWSTR;
 class MCAutoStringRefAsLPWSTR
 {
 public:
-	MCAutoStringRefAsLPWSTR() {}
+
+	MCAutoStringRefAsLPWSTR() :
+	  m_buffer(nil),
+	  m_size(0)
+	{
+	}
+
 	~MCAutoStringRefAsLPWSTR()
 	{
 		Unlock();


### PR DESCRIPTION
It was causing assertion failures in Windows debug builds (and probably
other craziness in non-debug builds).