### PR TITLE
Create weak object proxies at object creation time

### DIFF
--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -252,15 +252,9 @@ public:
         // and casting is required when returning a non-nil handle.
         //
         // The casting here looks evil but is actually well-defined and safe.
-        MCObjectProxyBase*& m_weak_proxy = static_cast<const T*>(this)->MCObject::m_weak_proxy;
-        if (m_weak_proxy == NULL)
-        {
-            m_weak_proxy = new MCObjectProxyBase(const_cast<T*>(static_cast<const T*>(this)));
-            if (!m_weak_proxy)
-                return typename MCObjectProxy<T>::Handle(nil);
-        }
-        
-        return typename MCObjectProxy<T>::Handle(static_cast<MCObjectProxy<T>*>(m_weak_proxy));
+        MCObjectProxyBase*& t_weak_proxy = static_cast<const T*>(this)->MCObject::m_weak_proxy;
+	MCAssert(t_weak_proxy != nil);
+        return typename MCObjectProxy<T>::Handle(static_cast<MCObjectProxy<T>*>(t_weak_proxy));
     }
 };
 


### PR DESCRIPTION
Instead of on-demand. This makes it easier to catch errors where using
a raw pointer to a deleted object allows creation of a weak handle to
that object.