### PR TITLE
Re-add support for BMPs as a clipboard image format

### DIFF
--- a/docs/notes/bugfix-18755.md
+++ b/docs/notes/bugfix-18755.md
@@ -1,0 +1,1 @@
+# Fix loss of BMP as supported clipboard image format

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -543,6 +543,72 @@ bool MCClipboard::AddJPEG(MCDataRef p_jpeg)
     return t_item->AddRepresentation(t_type_string, p_jpeg);
 }
 
+bool MCClipboard::AddBMP(MCDataRef p_bmp)
+{
+	AutoLock t_lock(this);
+
+	// Clear contents if the clipboard contains external data
+	if (m_clipboard->IsExternalData())
+		Clear();
+
+	// Get the first item on the clipboard
+	MCAutoRefcounted<MCRawClipboardItem> t_item = GetItem();
+	if (t_item == NULL)
+		return false;
+
+	// Add the objects to the clipboard under the correct type
+	MCStringRef t_type_string = m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeWinDIBv5);
+	if (t_type_string == NULL)
+		return false;
+
+	// Encode the BMP for transfer
+	MCAutoDataRef t_bmp(m_clipboard->EncodeBMPForTransfer(p_bmp));
+
+	return t_item->AddRepresentation(t_type_string, *t_bmp);
+}
+
+bool MCClipboard::AddWinMetafile(MCDataRef p_wmf)
+{
+	AutoLock t_lock(this);
+
+	// Clear contents if the clipboard contains external data
+	if (m_clipboard->IsExternalData())
+		Clear();
+
+	// Get the first item on the clipboard
+	MCAutoRefcounted<MCRawClipboardItem> t_item = GetItem();
+	if (t_item == NULL)
+		return false;
+
+	// Add the objects to the clipboard under the correct type
+	MCStringRef t_type_string = m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeWinMF);
+	if (t_type_string == NULL)
+		return false;
+
+	return t_item->AddRepresentation(t_type_string, p_wmf);
+}
+
+bool MCClipboard::AddWinEnhMetafile(MCDataRef p_emf)
+{
+	AutoLock t_lock(this);
+
+	// Clear contents if the clipboard contains external data
+	if (m_clipboard->IsExternalData())
+		Clear();
+
+	// Get the first item on the clipboard
+	MCAutoRefcounted<MCRawClipboardItem> t_item = GetItem();
+	if (t_item == NULL)
+		return false;
+
+	// Add the objects to the clipboard under the correct type
+	MCStringRef t_type_string = m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeWinEMF);
+	if (t_type_string == NULL)
+		return false;
+
+	return t_item->AddRepresentation(t_type_string, p_emf);
+}
+
 bool MCClipboard::AddImage(MCDataRef p_image_data)
 {
     // Examine the data to see if it matches any of the formats that we handle
@@ -552,6 +618,8 @@ bool MCClipboard::AddImage(MCDataRef p_image_data)
         return AddGIF(p_image_data);
     if (MCImageDataIsJPEG(p_image_data))
         return AddJPEG(p_image_data);
+	if (MCImageDataIsBMP(p_image_data))
+		return AddBMP(p_image_data);
     
     return false;
 }
@@ -705,11 +773,48 @@ bool MCClipboard::HasJPEG() const
     return t_item->HasRepresentation(m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeJPEG));
 }
 
+bool MCClipboard::HasBMP() const
+{
+	AutoLock t_lock(this);
+
+	// Check for the corresponding type
+	MCAutoRefcounted<const MCRawClipboardItem> t_item = GetItem();
+	if (t_item == NULL)
+		return false;
+
+	return t_item->HasRepresentation(m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeWinDIB))
+		|| t_item->HasRepresentation(m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeWinDIBv5));
+}
+
+bool MCClipboard::HasWinMetafile() const
+{
+	AutoLock t_lock(this);
+
+	// Check for the corresponding type
+	MCAutoRefcounted<const MCRawClipboardItem> t_item = GetItem();
+	if (t_item == NULL)
+		return false;
+
+	return t_item->HasRepresentation(m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeWinMF));
+}
+
+bool MCClipboard::HasWinEnhMetafile() const
+{
+	AutoLock t_lock(this);
+
+	// Check for the corresponding type
+	MCAutoRefcounted<const MCRawClipboardItem> t_item = GetItem();
+	if (t_item == NULL)
+		return false;
+
+	return t_item->HasRepresentation(m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeWinEMF));
+}
+
 bool MCClipboard::HasImage() const
 {
     // Images are any of PNG, GIF or JPEG
     AutoLock t_lock(this);
-    return HasPNG() || HasGIF() || HasJPEG();
+	return HasPNG() || HasGIF() || HasJPEG() || HasBMP();
 }
 
 bool MCClipboard::HasTextOrCompatible() const
@@ -997,11 +1102,36 @@ bool MCClipboard::CopyAsJPEG(MCDataRef& r_jpeg) const
     return CopyAsData(kMCRawClipboardKnownTypeJPEG, r_jpeg);
 }
 
+bool MCClipboard::CopyAsBMP(MCDataRef& r_bmp) const
+{
+	// Copy and decode the BMP file
+	MCAutoDataRef t_bmp;
+	if (!CopyAsData(kMCRawClipboardKnownTypeWinDIBv5, &t_bmp))
+		return false;
+	
+	MCDataRef t_decoded = m_clipboard->DecodeTransferredBMP(*t_bmp);
+	if (t_decoded == nil)
+		return false;
+
+	r_bmp = t_decoded;
+	return true;
+}
+
+bool MCClipboard::CopyAsWinMetafile(MCDataRef& r_wmf) const
+{
+	return CopyAsData(kMCRawClipboardKnownTypeWinMF, r_wmf);
+}
+
+bool MCClipboard::CopyAsWinEnhMetafile(MCDataRef& r_emf) const
+{
+	return CopyAsData(kMCRawClipboardKnownTypeWinEMF, r_emf);
+}
+
 bool MCClipboard::CopyAsImage(MCDataRef& r_image) const
 {
     // The order here is fairly arbitrary
     AutoLock t_lock(this);
-    return CopyAsPNG(r_image) || CopyAsJPEG(r_image) || CopyAsGIF(r_image);
+    return CopyAsPNG(r_image) || CopyAsJPEG(r_image) || CopyAsGIF(r_image) || CopyAsBMP(r_image);
 }
 
 bool MCClipboard::CopyAsPrivateData(MCDataRef& r_data) const

--- a/engine/src/clipboard.h
+++ b/engine/src/clipboard.h
@@ -106,6 +106,9 @@ public:
     bool AddPNG(MCDataRef p_png);
     bool AddGIF(MCDataRef p_gif);
     bool AddJPEG(MCDataRef p_jpeg);
+	bool AddBMP(MCDataRef p_bmp);
+	bool AddWinMetafile(MCDataRef p_wmf);
+	bool AddWinEnhMetafile(MCDataRef p_emf);
     
     // Utility method for adding images - given the binary data for a PNG, GIF
     // or JPEG-encoded image, the image is added to the clipboard tagged with
@@ -122,7 +125,10 @@ public:
     bool HasPNG() const;
     bool HasGIF() const;
     bool HasJPEG() const;
-    bool HasImage() const;  // Any of PNG, GIF or JPEG
+	bool HasBMP() const;
+	bool HasWinMetafile() const;
+	bool HasWinEnhMetafile() const;
+    bool HasImage() const;  // Any of PNG, GIF, JPEG or BMP
     
     // Utility methods that indicate whether the clipboard contains data of that
     // type or something that can be auto-converted to that type.
@@ -143,9 +149,12 @@ public:
     bool CopyAsPNG(MCDataRef& r_png_data) const;
     bool CopyAsGIF(MCDataRef& r_gif_data) const;
     bool CopyAsJPEG(MCDataRef& r_jpeg_data) const;
+	bool CopyAsBMP(MCDataRef& r_bmp_data) const;
+	bool CopyAsWinMetafile(MCDataRef& r_wmf_data) const;
+	bool CopyAsWinEnhMetafile(MCDataRef& r_emf_data) const;
     
     // Utility method for copying images - it tries to copy as any image format
-    // that is supported by LiveCode (PNG, JPEG or GIF, in that order).
+    // that is supported by LiveCode (PNG, JPEG, GIF or BMP, in that order).
     bool CopyAsImage(MCDataRef& r_image_data) const;
     
     // Utility method for pasting into fields -- converts the clipboard contents

--- a/engine/src/exec-pasteboard.cpp
+++ b/engine/src/exec-pasteboard.cpp
@@ -178,6 +178,9 @@ enum MCTransferType
     TRANSFER_TYPE_PNG,
     TRANSFER_TYPE_GIF,
     TRANSFER_TYPE_JPEG,
+	TRANSFER_TYPE_BMP,
+	TRANSFER_TYPE_WIN_METAFILE,
+	TRANSFER_TYPE_WIN_ENH_METAFILE,
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -432,6 +435,15 @@ MCTransferType MCPasteboardTransferTypeFromName(MCNameRef p_key, bool p_legacy =
     if (MCNameIsEqualTo(p_key, MCN_jpeg))
         return TRANSFER_TYPE_JPEG;
 
+	if (MCNameIsEqualTo(p_key, MCN_win_bitmap))
+		return TRANSFER_TYPE_BMP;
+
+	if (MCNameIsEqualTo(p_key, MCN_win_metafile))
+		return TRANSFER_TYPE_WIN_METAFILE;
+
+	if (MCNameIsEqualTo(p_key, MCN_win_enh_metafile))
+		return TRANSFER_TYPE_WIN_ENH_METAFILE;
+
 	return TRANSFER_TYPE_NULL;
 }
 
@@ -463,6 +475,12 @@ MCNameRef MCPasteboardTransferTypeToName(MCTransferType p_type, bool p_legacy = 
         return MCN_gif;
     case TRANSFER_TYPE_JPEG:
         return MCN_jpeg;
+	case TRANSFER_TYPE_BMP:
+		return MCN_win_bitmap;
+	case TRANSFER_TYPE_WIN_METAFILE:
+		return MCN_win_metafile;
+	case TRANSFER_TYPE_WIN_ENH_METAFILE:
+		return MCN_win_enh_metafile;
 	case TRANSFER_TYPE_FILES:
 		return MCN_files;
 	case TRANSFER_TYPE_PRIVATE:
@@ -808,6 +826,12 @@ void MCPasteboardEvalFullClipboardOrDragKeys(MCExecContext& ctxt, const MCClipbo
         t_success = MCListAppend(*t_list, MCN_gif);
     if (t_success && p_clipboard->HasJPEG())
         t_success = MCListAppend(*t_list, MCN_jpeg);
+	if (t_success && p_clipboard->HasBMP())
+		t_success = MCListAppend(*t_list, MCN_win_bitmap);
+	if (t_success && p_clipboard->HasWinMetafile())
+		t_success = MCListAppend(*t_list, MCN_win_metafile);
+	if (t_success && p_clipboard->HasWinEnhMetafile())
+		t_success = MCListAppend(*t_list, MCN_win_enh_metafile);
     
     // Check for specific styled text formats. These are the "true" formats and
     // aren't round-tripped via a LiveCode field.
@@ -911,6 +935,18 @@ void MCPasteboardEvalIsAmongTheKeysOfTheFullClipboardOrDragData(MCExecContext& c
         case TRANSFER_TYPE_JPEG:
             r_result = p_clipboard->HasJPEG();
             break;
+
+		case TRANSFER_TYPE_BMP:
+			r_result = p_clipboard->HasBMP();
+			break;
+
+		case TRANSFER_TYPE_WIN_METAFILE:
+			r_result = p_clipboard->HasWinMetafile();
+			break;
+
+		case TRANSFER_TYPE_WIN_ENH_METAFILE:
+			r_result = p_clipboard->HasWinEnhMetafile();
+			break;
             
         case TRANSFER_TYPE_FILES:
             r_result = p_clipboard->HasFileList();
@@ -1589,6 +1625,18 @@ void MCPasteboardGetFullClipboardOrDragData(MCExecContext& ctxt, MCNameRef p_ind
         case TRANSFER_TYPE_JPEG:
             p_clipboard->CopyAsJPEG((MCDataRef&)&t_data);
             break;
+
+		case TRANSFER_TYPE_BMP:
+			p_clipboard->CopyAsBMP((MCDataRef&)&t_data);
+			break;
+
+		case TRANSFER_TYPE_WIN_METAFILE:
+			p_clipboard->CopyAsWinMetafile((MCDataRef&)&t_data);
+			break;
+
+		case TRANSFER_TYPE_WIN_ENH_METAFILE:
+			p_clipboard->CopyAsWinEnhMetafile((MCDataRef&)&t_data);
+			break;
             
         case TRANSFER_TYPE_OBJECTS:
             p_clipboard->CopyAsLiveCodeObjects((MCDataRef&)&t_data);
@@ -1692,6 +1740,21 @@ void MCPasteboardSetFullClipboardOrDragData(MCExecContext& ctxt, MCNameRef p_ind
             if (ctxt.ConvertToData(p_value, &t_data))
                 t_success = p_clipboard->AddJPEG(*t_data);
             break;
+
+		case TRANSFER_TYPE_BMP:
+			if (ctxt.ConvertToData(p_value, &t_data))
+				t_success = p_clipboard->AddBMP(*t_data);
+			break;
+
+		case TRANSFER_TYPE_WIN_METAFILE:
+			if (ctxt.ConvertToData(p_value, &t_data))
+				t_success = p_clipboard->AddWinMetafile(*t_data);
+			break;
+
+		case TRANSFER_TYPE_WIN_ENH_METAFILE:
+			if (ctxt.ConvertToData(p_value, &t_data))
+				t_success = p_clipboard->AddWinEnhMetafile(*t_data);
+			break;
             
         case TRANSFER_TYPE_FILES:
             if (ctxt.ConvertToString(p_value, &t_string))

--- a/engine/src/imagebitmap.cpp
+++ b/engine/src/imagebitmap.cpp
@@ -851,6 +851,18 @@ bool MCImageDataIsGIF(MCDataRef p_input)
 	return memcmp(t_data, "GIF87a", 6) == 0 || memcmp(t_data, "GIF89a", 6) == 0;
 }
 
+bool MCImageDataIsBMP(MCDataRef p_input)
+{
+	const byte_t* t_data = MCDataGetBytePtr(p_input);
+	uindex_t t_length = MCDataGetLength(p_input);
+
+	// This only recognises Win32-format BMPs (all other formats are obsolete)
+	if (t_length < 2)
+		return false;
+
+	return memcmp(t_data, "BM", 2) == 0;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 MCGRaster MCImageBitmapGetMCGRaster(MCImageBitmap *p_bitmap, bool p_is_premultiplied)

--- a/engine/src/imagebitmap.h
+++ b/engine/src/imagebitmap.h
@@ -112,6 +112,7 @@ void MCImageFreeFrames(MCBitmapFrame *p_frames, uindex_t p_count);
 bool MCImageDataIsJPEG(MCDataRef p_data);
 bool MCImageDataIsPNG(MCDataRef p_data);
 bool MCImageDataIsGIF(MCDataRef p_data);
+bool MCImageDataIsBMP(MCDataRef p_data);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/mcstring.cpp
+++ b/engine/src/mcstring.cpp
@@ -208,6 +208,9 @@ MCNameRef MCN_gif;
 MCNameRef MCN_jpeg;
 MCNameRef MCN_rtf;
 MCNameRef MCN_html;
+MCNameRef MCN_win_bitmap;
+MCNameRef MCN_win_metafile;
+MCNameRef MCN_win_enh_metafile;
 
 MCNameRef MCN_browser;
 MCNameRef MCN_command_line;
@@ -674,6 +677,9 @@ void MCU_initialize_names(void)
     /* UNCHECKED */ MCNameCreateWithCString("png", MCN_png);
     /* UNCHECKED */ MCNameCreateWithCString("gif", MCN_gif);
     /* UNCHECKED */ MCNameCreateWithCString("jpeg", MCN_jpeg);
+	/* UNCHECKED */ MCNameCreateWithCString("windows bitmap", MCN_win_bitmap);
+	/* UNCHECKED */ MCNameCreateWithCString("windows metafile", MCN_win_metafile);
+	/* UNCHECKED */ MCNameCreateWithCString("windows enhanced metafile", MCN_win_enh_metafile);
 	/* UNCHECKED */ MCNameCreateWithCString("rtf", MCN_rtf);
 	/* UNCHECKED */ MCNameCreateWithCString("html", MCN_html);
 
@@ -1137,6 +1143,9 @@ void MCU_finalize_names(void)
     MCNameDelete(MCN_png);
     MCNameDelete(MCN_gif);
     MCNameDelete(MCN_jpeg);
+	MCNameDelete(MCN_win_bitmap);
+	MCNameDelete(MCN_win_metafile);
+	MCNameDelete(MCN_win_enh_metafile);
 	MCNameDelete(MCN_rtf);
 	MCNameDelete(MCN_html);
 

--- a/engine/src/mcstring.h
+++ b/engine/src/mcstring.h
@@ -159,6 +159,9 @@ extern MCNameRef MCN_gif;
 extern MCNameRef MCN_jpeg;
 extern MCNameRef MCN_rtf;
 extern MCNameRef MCN_html;
+extern MCNameRef MCN_win_bitmap;
+extern MCNameRef MCN_win_metafile;
+extern MCNameRef MCN_win_enh_metafile;
 
 extern MCNameRef MCN_browser;
 extern MCNameRef MCN_command_line;

--- a/engine/src/raw-clipboard.cpp
+++ b/engine/src/raw-clipboard.cpp
@@ -71,3 +71,15 @@ MCRawClipboardItemRep::~MCRawClipboardItemRep()
     ;
 }
 
+MCDataRef MCRawClipboard::EncodeBMPForTransfer(MCDataRef p_bmp) const
+{
+	// Most platforms transfer BMP files without any further transformations
+	return MCValueRetain(p_bmp);
+}
+
+MCDataRef MCRawClipboard::DecodeTransferredBMP(MCDataRef p_bmp) const
+{
+	// Most platforms transfer BMP files without any further transformations
+	return MCValueRetain(p_bmp);
+}
+

--- a/engine/src/raw-clipboard.h
+++ b/engine/src/raw-clipboard.h
@@ -184,6 +184,10 @@ public:
 	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const = 0;
 	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const = 0;
 
+	// Converts a Windows DIB (BMP file) to and from the on-clipboard format
+	virtual MCDataRef EncodeBMPForTransfer(MCDataRef p_bmp) const;
+	virtual MCDataRef DecodeTransferredBMP(MCDataRef p_bmp) const;
+
     // Destructor
     virtual ~MCRawClipboard() = 0;
     

--- a/engine/src/w32-clipboard.h
+++ b/engine/src/w32-clipboard.h
@@ -130,6 +130,8 @@ public:
 	virtual MCStringRef DecodeTransferredFileList(MCDataRef p_data) const;
 	virtual MCDataRef EncodeHTMLFragmentForTransfer(MCDataRef p_html) const;
 	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
+	virtual MCDataRef EncodeBMPForTransfer(MCDataRef p_bmp) const;
+	virtual MCDataRef DecodeTransferredBMP(MCDataRef p_bmp) const;
 
 	// Sets the clipboard as being dirty
 	void SetDirty();


### PR DESCRIPTION
This was unintentionally lost in the clipboard re-write for 8.0.

The old clipboard code also recognised Windows metafiles so they are now listed in the fullClipboardData too.