### PR TITLE
com.livecode.assert: Add "expect that _ because _" syntax

### DIFF
--- a/docs/lcb/notes/feature-expect.md
+++ b/docs/lcb/notes/feature-expect.md
@@ -1,0 +1,13 @@
+# LiveCode Builder Standard Library
+
+## Assertions
+
+* Checks for handler preconditions can now be included using the new
+  `expect` statement.  For example, the following statement will throw
+  an error if the value `pProbability` is out of the valid range for
+  probabilities:
+  
+      expect that (pProbability >= 0 and pProbability <= 1) \
+         because "Probabilities must be in the range [0,1]"
+
+  The `that` keyword and the `because <Reason>` clauses are optional.

--- a/libscript/src/assert.lcb
+++ b/libscript/src/assert.lcb
@@ -1,0 +1,144 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/**
+Sometimes there are restrictions about how some LCB code can be used
+correctly.  It may only be possible to make it work in a sensible way
+if is passed a particular range of values, or if the system is in a
+particular state.  These are known as "preconditions" for the code.
+
+Many preconditions can be expressed via the LCB type system.  For
+example, you can declare that the parameters passed to handler must be
+particular types of value.  For example, when you write `in pName as
+String`, you are saying that the handler can only work when the
+`pName` parameter is a character string.  This is a precondition that
+can be checked automatically by the LCB compiler and virtual machine.
+
+Some preconditions can't yet be automatically checked by LCB.  An
+example would be a requirement that a string contains only ASCII
+characters, or that an array has a particular key.
+
+This module provides syntax to assist with explicit precondition
+checks.
+*/
+
+module com.livecode.assert
+
+/**
+Summary:	Check a precondition
+
+Parameters:
+	Condition: Expression that must be true for code to work
+
+Example:
+	handler BoxValue(in pValue as any) returns Array
+		return { "__VALUE": pValue }
+	end handler
+
+	handler UnBoxValue(in pBox as Array) returns any
+		expect that "__VALUE" is among the elements of pBox
+		return pBox["__VALUE"]
+	end handler
+
+Description:
+Use this statement at the start of a handler to check that necessary
+preconditions for the handler are satisfied.  For example, the handler
+may require that its parameters have a particular structure or fall
+within a particular range, or may need the system to be in a specific
+state.
+
+Note that if the <Condition> is false, this statement will throw an
+error with the slightly-unhelpful message that "assertion failed".
+Usually, it will be more useful to use <ExpectsPreconditionWithReason>
+instead.
+
+Related: ExpectPreconditionWithReason(statement).
+
+Tags: Assertions
+*/
+syntax ExpectPrecondition is statement
+	"expect" ["that"] <Condition: Expression>
+begin
+	MCAssertExpectPrecondition(Condition)
+end syntax
+
+public handler MCAssertExpectPrecondition(in pCondition as Boolean) \
+		returns nothing
+	if pCondition then
+		return
+	end if
+	throw "assertion failed"
+end handler
+
+/**
+Summary: Check a precondition, with a reason
+
+Parameters:
+	Condition: Expression that must be true for code to work
+	Reason:    Description of the precondition
+
+Example:
+	-- Draw a random variate from the Bernoulli distribution with
+	-- parameter pParam.  A Bernoulli variate may be 0 or 1; the
+	-- parameter pParam is the probability that the result is 1.
+	handler BernoulliVariate(in pParam as Number) returns Number
+		expect (pParam >= 0 and pParam <= 1) \
+			 because "Bernoulli parameter must be a probability in [0,1]"
+		if (any number <= pParam) then
+			return 1
+		else
+			return 0
+		end if
+	end handler
+
+Description:
+Use this statement at the start of a handler to check that necessary
+preconditions for the handler are satisfied.  For example, the handler
+may require that its parameters have a particular structure or fall
+within a particular range, or may need the system to be in a specific
+state.
+
+If the <Condition> is false, an error will be thrown including the
+<Reason> for the check.
+
+Related: ExpectPrecondition (statement)
+
+Tags: Assertions
+*/
+syntax ExpectPreconditionWithReason is statement
+	"expect" ["that"] <Condition: Expression> "because" <Reason: Expression>
+begin
+	MCAssertExpectPreconditionWithReason(Condition, Reason)
+end syntax
+
+-- Bind to the single string operation that this module needs here,
+-- rather than messing about with a separate implementation module.
+public foreign handler MCStringExecPutStringBefore(in Source as String, \
+		inout Target as String) returns nothing binds to "<builtin>"
+
+public handler MCAssertExpectPreconditionWithReason \
+		(in pCondition as Boolean, in pReason as String) returns nothing
+	if pCondition then
+		return
+	end if
+	unsafe
+		MCStringExecPutStringBefore("assertion failed: ", pReason)
+	end unsafe
+	throw pReason
+end handler
+
+end module

--- a/libscript/src/module-assert.cpp
+++ b/libscript/src/module-assert.cpp
@@ -1,0 +1,29 @@
+/*                                                                     -*-c++-*-
+ Copyright (C) 2016 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+////////////////////////////////////////////////////////////////////////////////
+
+extern "C" bool com_livecode_assert_Initialize (void)
+{
+	return true;
+}
+
+extern "C" void com_livecode_assert_Finalize (void)
+{
+}
+
+////////////////////////////////////////////////////////////////

--- a/libscript/stdscript-sources.gypi
+++ b/libscript/stdscript-sources.gypi
@@ -6,6 +6,7 @@
 		[
 			'src/arithmetic.lcb',
 			'src/array.lcb',
+			'src/assert.lcb',
 			'src/binary.lcb',
 			'src/bitwise.lcb',
 			'src/byte.lcb',
@@ -42,6 +43,7 @@
 		[
 			'src/module-arithmetic.cpp',
 			'src/module-array.cpp',
+			'src/module-assert.cpp',
 			'src/module-binary.cpp',
 			'src/module-bitwise.cpp',
 			'src/module-byte.cpp',

--- a/tests/lcb/stdlib/assert.lcb
+++ b/tests/lcb/stdlib/assert.lcb
@@ -1,0 +1,33 @@
+module com.livecode.array.tests
+
+use com.livecode.__INTERNAL._testlib
+
+handler testExpect_Pass()
+	expect true is true
+	return true
+end handler
+
+handler testExpect_Fail()
+	expect false is true
+	return true
+end handler
+
+handler testExpectReason_Pass()
+	expect that true is true because "reasons"
+	return true
+end handler
+
+handler testExpectReason_Fail()
+	expect that false is true because "reasons"
+	return true
+end handler
+
+public handler testExpect()
+	test "expect success" when testExpect_Pass()
+	MCUnitTestHandlerThrows(testExpect_Fail, "expect failure")
+
+	test "expect success with reason" when testExpectReason_Pass()
+	MCUnitTestHandlerThrows(testExpectReason_Fail, "expect failure with reason")
+end handler
+
+end module

--- a/toolchain/lc-compile/src/module-helper.cpp
+++ b/toolchain/lc-compile/src/module-helper.cpp
@@ -27,6 +27,7 @@ struct builtin_module_descriptor {};
 extern builtin_module_descriptor __com_livecode_foreign_module_info;
 extern builtin_module_descriptor __com_livecode_arithmetic_module_info;
 extern builtin_module_descriptor __com_livecode_array_module_info;
+extern builtin_module_descriptor __com_livecode_assert_module_info;
 extern builtin_module_descriptor __com_livecode_binary_module_info;
 extern builtin_module_descriptor __com_livecode_bitwise_module_info;
 extern builtin_module_descriptor __com_livecode_byte_module_info;
@@ -56,6 +57,7 @@ builtin_module_descriptor* g_builtin_modules[] =
     &__com_livecode_foreign_module_info,
     &__com_livecode_arithmetic_module_info,
     &__com_livecode_array_module_info,
+    &__com_livecode_assert_module_info,
     &__com_livecode_binary_module_info,
     &__com_livecode_bitwise_module_info,
     &__com_livecode_byte_module_info,


### PR DESCRIPTION
This patch adds some new syntax to LiveCode Builder for ergonomically
checking handler preconditions that cannot currently expressed in the
LCB typesystem (e.g. numerical ranges and array structure).  There are
two new statement forms:

    expect that <Condition>
    expect that <Condition> because <Reason>

The `that` token is optional, but you can include it if it makes the
assertion more readable.

My expectation is that this new syntax will be used in the initial
lines of a handler.  For example:

    handler FormatNumberList(in pNumbers as List) returns String
        expect IsListOfNumbers(pNumbers) \
	      because "Input list is expected to contain only numbers"
	/* ... */
    end handler

My use of "expect" rather than "assert" here is an intentional design
decision.  "Assert" is used in English prose in a slightly different
way than typically used in a programming context, whereas "expect" in
this context does exactly what might be expected from the use in
English: it checks the state which the handler expects its argument
(and the larger system) to be in before it's run.

I considered "expects".  I found that it works find as long as the
statements are always at the start of the handler, but an "expects"
statement placed elsewhere looked a bit odd.