### PR TITLE
Fix a crash on saving field data under obscure circumstances

### DIFF
--- a/docs/notes/bugfix-18762.md
+++ b/docs/notes/bugfix-18762.md
@@ -1,0 +1,1 @@
+# Fix a rare crash on saving after cloning a field

--- a/engine/src/cdata.cpp
+++ b/engine/src/cdata.cpp
@@ -27,13 +27,28 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "field.h"
 #include "paragraf.h"
 
-MCCdata::MCCdata()
+MCCdata::MCCdata() :
+  id(0),
+  data(nil)
 {
-	id = 0;
-	data = NULL;
 }
 
-MCCdata::MCCdata(const MCCdata &cref) : MCDLlist(cref)
+MCCdata::MCCdata(const MCCdata &cref) :
+  MCDLlist(cref)
+{
+	// Ensure that the paragraphs of the cloned data have their parent field
+	// set to nil - this will catch attempts to use them without properly
+	// setting the parent first.
+	CloneData(cref, nil);
+}
+
+MCCdata::MCCdata(const MCCdata& cref, MCField* p_new_owner) :
+  MCDLlist(cref)
+{
+	CloneData(cref, p_new_owner);
+}
+
+void MCCdata::CloneData(const MCCdata& cref, MCField* p_new_owner)
 {
 	id = cref.id;
 	if (cref.data != NULL && cref.data != (void *)1)
@@ -46,7 +61,10 @@ MCCdata::MCCdata(const MCCdata &cref) : MCDLlist(cref)
 			MCParagraph *tptr = (MCParagraph *)cref.data;
 			do
 			{
+				// Clone the paragraph
 				MCParagraph *newparagraph = new MCParagraph(*tptr);
+				newparagraph->setparent(p_new_owner);
+				
 				newparagraph->appendto(paragraphs);
 				tptr = (MCParagraph *)tptr->next();
 			}

--- a/engine/src/cdata.h
+++ b/engine/src/cdata.h
@@ -32,6 +32,7 @@ public:
 	MCCdata();
 	MCCdata(uint4 newid);
 	MCCdata(const MCCdata &fref);
+	MCCdata(const MCCdata &fref, MCField* p_new_owner);
 	~MCCdata();
 	IO_stat load(IO_handle stream, MCObject *parent, uint32_t version);
 	IO_stat save(IO_handle stream, Object_type type, uint4 p_part, uint32_t p_version);
@@ -81,6 +82,13 @@ public:
 	{
 		return (MCCdata *)MCDLlist::remove((MCDLlist *&)list);
 	}
+	
+private:
+	
+	// Clones the data from the given other MCCdata object, setting the
+	// paragraphs of the data to have the given field as the parent object
+	// (set to nil for non-field card data).
+	void CloneData(const MCCdata& fref, MCField* p_new_owner);
 };
 
 #endif

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -317,12 +317,13 @@ MCField::MCField(const MCField &fref) : MCControl(fref)
     }
     else
         alignments = NULL;
+	
 	if (fref.fdata != NULL)
 	{
 		MCCdata *fptr = fref.fdata;
 		do
 		{
-			MCCdata *newfdata = new MCCdata(*fptr);
+			MCCdata *newfdata = new MCCdata(*fptr, this);
 			newfdata->appendto(fdata);
 			fptr = fptr->next();
 		}


### PR DESCRIPTION
It involves cloning then saving a field without the field ever being 'opened' (@runrevmark has attempted to create a test case but has not had any success).