### PR TITLE
docs: Fixed introduction date for ceil/ceiling function

### DIFF
--- a/docs/dictionary/function/ceil.lcdoc
+++ b/docs/dictionary/function/ceil.lcdoc
@@ -9,7 +9,7 @@ Syntax: ceil(<number>)
 Summary:
 <return|Returns> the smallest integer greater than or equal to number.
 
-Introduced: 6.7
+Introduced: 7.1
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/function/floor.lcdoc
+++ b/docs/dictionary/function/floor.lcdoc
@@ -9,7 +9,7 @@ Syntax: floor(<number>)
 Summary:
 <return|Returns> the greatest integer less than or equal to number.
 
-Introduced: 6.7
+Introduced: 7.1
 
 OS: mac, windows, linux, ios, android
 


### PR DESCRIPTION
The `ceil`/`ceiling` function wasn't available in LiveCode 6.7.  It
was in fact introduced in commit d919382b, which was included in
LiveCode 7.1.