### PR TITLE
[[ Bug 18852 ]] Prevent add / remove from MCtodestroy stacklist from unsetting MCtopstack

### DIFF
--- a/docs/notes/bugfix-18852.md
+++ b/docs/notes/bugfix-18852.md
@@ -1,0 +1,1 @@
+# Fix exception thrown in IDE when saving standalone with more than one stack

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1156,8 +1156,9 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 	
 	MCundos = new MCUndolist;
 	MCselected = new MCSellist;
-	MCstacks = new MCStacklist;
-    MCtodestroy = new MCStacklist;
+	MCstacks = new MCStacklist(true);
+	// IM-2016-11-22: [[ Bug 18852 ]] Changes to MCtodestroy shouldn't affect MCtopstack
+    MCtodestroy = new MCStacklist(false);
 	MCrecent = new MCCardlist;
 	MCcstack = new MCCardlist;
 

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -112,7 +112,7 @@ void MCStack::checkdestroy()
 					}
 					while (sptr != substacks);
 				}
-                MCtodestroy -> remove(this);
+                MCtodestroy -> remove(this); // prevent duplicates
                 MCtodestroy -> add(this);
 			}
 	}

--- a/engine/src/stacklst.cpp
+++ b/engine/src/stacklst.cpp
@@ -44,20 +44,21 @@ MCStack *MCStacknode::getstack()
 	return stackptr;
 }
 
-MCStacklist::MCStacklist()
+MCStacklist::MCStacklist(bool p_manage_topstack)
 {
 	stacks = NULL;
 	menus = NULL;
 	nmenus = 0;
 	accelerators = NULL;
 	naccelerators = 0;
-	locktop = False;
 #ifdef _MACOSX
 	active = False;
 #else
 	active = True;
 #endif
 	dirty = false;
+	
+	m_manage_topstack = p_manage_topstack;
 }
 
 MCStacklist::~MCStacklist()
@@ -78,8 +79,7 @@ void MCStacklist::add(MCStack *sptr)
 {
 	MCStacknode *tptr = new MCStacknode(sptr);
 	tptr->appendto(stacks);
-	if (this == MCstacks) // should be done with subclass
-		top(sptr);
+	top(sptr);
 }
 
 void MCStacklist::remove(MCStack *sptr)
@@ -152,7 +152,7 @@ static bool stack_is_above(MCStack *p_stack_a, MCStack *p_stack_b)
 
 void MCStacklist::top(MCStack *sptr)
 {
-	if (stacks == NULL || locktop)
+	if (stacks == NULL || !m_manage_topstack)
 		return;
 
 	MCStacknode *tptr = stacks;

--- a/engine/src/stacklst.h
+++ b/engine/src/stacklst.h
@@ -91,15 +91,17 @@ class MCStacklist
 	uint2 nmenus;
 	Accelerator *accelerators;
 	uint2 naccelerators;
-	Boolean locktop;
 	Boolean restart;
 	Boolean active;
 
 	// MW-2011-08-17: [[ Redraw ]] This is true if something needs updating.
 	bool dirty;
+	
+	// IM-2016-11-22: [[ Bug 18852 ]] true if this stacklist should set the topstack when its contents change
+	bool m_manage_topstack;
 
 public:
-	MCStacklist();
+	MCStacklist(bool p_manage_topstack);
 	~MCStacklist();
 	void add(MCStack *sptr);
 	void remove(MCStack *sptr);


### PR DESCRIPTION
The bug no longer caused a crash, most likely due to @livecodefraser's work on MCobjecthandles, however an exception was still being dumped to the msgbox due to the topstack being unset.

This PR fixes that by stopping the MCtodelete stacklist from manipulating MCtopstack.