### PR TITLE
[Bugfix 18392] Improvements to "ceiling" function documentation

### DIFF
--- a/docs/dictionary/function/ceiling.lcdoc
+++ b/docs/dictionary/function/ceiling.lcdoc
@@ -34,11 +34,10 @@ Description:
 Use the <ceiling> <function> to return the greatest integer less than or
 equal to a number.
 
-The <ceiling> function does not always <return(constant)> the <integer>
-closest to the <number>.. For example, ceiling(5.1)
-<return(glossary)|returns> 6, but ceiling(4.99) <return(glossary)|returns>
-
-5. 
+The <ceiling> function does not always <return(constant)> the
+<integer> closest to the <number>. For example, `ceiling(5.1)`
+<return(glossary)|returns> 6, but `ceiling(4.99)`
+<return(glossary)|returns> 5.
 
 
 References: return (constant), function (control structure),

--- a/docs/dictionary/function/ceiling.lcdoc
+++ b/docs/dictionary/function/ceiling.lcdoc
@@ -1,10 +1,12 @@
-Name: ceil
+Name: ceiling
+
+Synonyms: ceil
 
 Type: function
 
-Syntax: the ceil of <number>
+Syntax: the ceiling of <number>
 
-Syntax: ceil(<number>)
+Syntax: ceiling(<number>)
 
 Summary:
 <return|Returns> the smallest integer greater than or equal to number.
@@ -16,25 +18,25 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-ceil(33.567) -- result is 34
+ceiling(33.567) -- result is 34
 
 Example:
-ceil(-6.3) -- result is -6
+ceiling(-6.3) -- result is -6
 
 Parameters:
 number:
 Any number, or expression that evaluates to a number.
 
 Returns:
-The <ceil> <function> <return|returns> an <integer>.
+The <ceiling> <function> <return|returns> an <integer>.
 
 Description:
-Use the <ceil> <function> to return the greatest integer less than or
+Use the <ceiling> <function> to return the greatest integer less than or
 equal to a number.
 
-The <ceil> function does not always <return(constant)> the <integer>
-closest to the <number>.. For example, ceil(5.1)
-<return(glossary)|returns> 6, but ceil(4.99) <return(glossary)|returns>
+The <ceiling> function does not always <return(constant)> the <integer>
+closest to the <number>.. For example, ceiling(5.1)
+<return(glossary)|returns> 6, but ceiling(4.99) <return(glossary)|returns>
 
 5. 
 

--- a/docs/dictionary/function/floor.lcdoc
+++ b/docs/dictionary/function/floor.lcdoc
@@ -34,11 +34,11 @@ equal to a number.
 
 The <floor> <function> is different from <round> in that floor
 completely ignores the fractional part of the number. For example,
-`floor(5.1)` <return(glossary)|returns> 5, but `floor(4.99)`
-<return(glossary)|returns> 4. This means that the <floor> function does
-not always <return(constant)> the <integer> closest to the <number>.
+`floor(5.1)` <return|returns> 5, but `floor(4.99)` <return|returns> 4.
+This means that the <floor> function does not always <return> the
+<integer> closest to the <number>.
 
-References: return (constant), function (control structure),
+References: function (control structure),
 ceiling (function), round (function), abs (function), trunc (function),
 return (glossary), integer (keyword)
 

--- a/docs/dictionary/function/floor.lcdoc
+++ b/docs/dictionary/function/floor.lcdoc
@@ -34,7 +34,7 @@ equal to a number.
 
 The <floor> <function> is different from <round> in that floor
 completely ignores the fractional part of the number. For example,
-floor(5.1) <return(glossary)|returns> 5, but floor(4.99)
+`floor(5.1)` <return(glossary)|returns> 5, but `floor(4.99)`
 <return(glossary)|returns> 4. This means that the <floor> function does
 not always <return(constant)> the <integer> closest to the <number>.
 

--- a/docs/dictionary/function/floor.lcdoc
+++ b/docs/dictionary/function/floor.lcdoc
@@ -39,7 +39,7 @@ floor(5.1) <return(glossary)|returns> 5, but floor(4.99)
 not always <return(constant)> the <integer> closest to the <number>.
 
 References: return (constant), function (control structure),
-ceil (function), round (function), abs (function), trunc (function),
+ceiling (function), round (function), abs (function), trunc (function),
 return (glossary), integer (keyword)
 
 Tags: math

--- a/docs/notes/bugfix-18392.md
+++ b/docs/notes/bugfix-18392.md
@@ -1,0 +1,1 @@
+# Ensure "ceiling" is listed as a reserved word


### PR DESCRIPTION
Renamed documentation name to be the full function name `ceiling` instead of the abbreviated synonym `ceil`. Some other formatting tweaks.

This is a rebased version of #4914 