### PR TITLE
[Bug 18908] Fix parsing of JSON files containing exactly a single digit

### DIFF
--- a/extensions/libraries/json/json.lcb
+++ b/extensions/libraries/json/json.lcb
@@ -218,10 +218,21 @@ public handler JsonImport(in pJson as String) returns optional any
         put tChar into tToken
         put tChar into tTokenValue
         put kScanInLiteral into tScanState
-      else if tChar is in "-0123456789" then
+      else if tChar is "-" then
+         -- If a number begins with a "-" then it *must* be contain at
+         -- least one further character
+         put "0" into tToken
+         put tChar into tTokenValue
+         put kScanInNumber into tScanState
+      else if tChar is in "0123456789" then
+        -- A number is permitted to be a single digit
         put "0" into tToken
         put tChar into tTokenValue
-        put kScanInNumber into tScanState
+        if tCharCount < tJsonLength then
+           put kScanInNumber into tScanState
+        else
+           put kScanEndToken into tScanState
+        end if
       else
         return JsonSyntaxError(tLine, tColumn, \
               "Unexpected character '" & FormatChar(tChar) & "'")

--- a/extensions/libraries/json/notes/18908.md
+++ b/extensions/libraries/json/notes/18908.md
@@ -1,0 +1,3 @@
+# JSON parser improvements
+
+# [18908] Fix parsing of JSON files containing only a single-digit integer

--- a/extensions/libraries/json/tests/numbers.livecodescript
+++ b/extensions/libraries/json/tests/numbers.livecodescript
@@ -26,3 +26,26 @@ on TestImportScientific
 	put JsonImport(tJson) into tArray
 	TestAssert "import number in scientific notation", tExpected is tArray
 end TestImportScientific
+
+-- Bug 18697
+on __TestImportLonelyInt_Minus pParam
+   get JSONImport("-")
+end __TestImportLonelyInt_Minus
+on TestImportLonelyInt
+	local tJson, tExpected, tValue
+
+	TestPlan 2
+
+	put "42" into tJson
+	put 42 into tExpected
+	put JsonImport(tJson) into tValue
+	TestAssert "import lonely multi-digit integer", tExpected is tValue
+
+	put "2" into tJson
+	put 2 into tExpected
+	put JsonImport(tJson) into tValue
+	TestAssert "import lonely single-digit integer", tExpected is tValue
+
+	TestAssertThrow "import lonely minus sign", "__TestImportLonelyInt_Minus", \
+		the long id of me, 863, ""
+end TestImportLonelyInt


### PR DESCRIPTION
This patch ensures that both of the following calls work:

    JSONImport("42")
    JSONImport("2")

But this one doesn't:

    JSONImport("-")