### PR TITLE
[Bug 13055] docs: Improve syntax description for "try"

### DIFF
--- a/docs/dictionary/control_st/try.lcdoc
+++ b/docs/dictionary/control_st/try.lcdoc
@@ -2,7 +2,14 @@ Name: try
 
 Type: control structure
 
-Syntax: try  <statementList> catch <errorVariable> <errorStatementsList> [finally  <cleanupStatementsList>]end try
+Syntax:
+try
+   <statementList>
+catch <errorVariable>
+   <errorStatementsList>
+[ finally
+   <cleanupStatementsList> ]
+end try
 
 Summary:
 <execute|Executes> a list of <statement|statements>, sending any

--- a/docs/notes/bugfix-13055.md
+++ b/docs/notes/bugfix-13055.md
@@ -1,0 +1,1 @@
+# Improve formatting of try syntax description


### PR DESCRIPTION
The LiveCode 8+ dictionary is able to show multiline syntax quite well
in the main documentation display.  Although it is only able to show
the first line of the syntax in the list of dictionary entries, this
change seems to make the dictionary entry for the `try` control
structure a lot clearer.