### PR TITLE
[[ Bug 18264 ]] Don't fail to build when unlicensed platform selected

### DIFF
--- a/docs/notes/bugfix-18264.md
+++ b/docs/notes/bugfix-18264.md
@@ -1,0 +1,1 @@
+# Don't fail standalone build completely if unlicensed platforms are selected

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -188,27 +188,17 @@ on revSaveAsStandalone pStack, pFolder, pPreview
    end if
    
    -- Make sure there is actually something to build..
-   # Check if any platforms have actually been selected..
-   local tCanBuild
-   put false into tCanBuild
-   
-   local tMessage, tError
-   put "You have not selected any platforms to build for. Please do so using Standalone Settings." into tMessage
-   repeat for each item tPlatform in revSBDesktopTargets()
-      put tCanBuild or tSettings[tPlatform] into tCanBuild
-   end repeat
-   put tCanBuild or tSettings["ios"] into tCanBuild
-   put tCanBuild or tSettings["android"] into tCanBuild
-   put tCanBuild or tSettings["emscripten"] into tCanBuild
-   if not tCanBuild then
+   if revSBNoPlatforms(tSettings) then
+      local tMessage
+      put "You have not selected any platforms to build for. Please do so using Standalone Settings." into tMessage
       if revSBSuppressDialogs() then
-         return tError
+         return tMessage
       else
          answer error tMessage
       end if
       exit revSaveAsStandalone
    end if
-   
+
    # OK-2010-03-31: Ensure that the standalone name doesn't contain stuff that is not allowed in folder names,
    # otherwise this could cause problems. In particular a return char at the end of the name causes the cleanup
    # routines to try and delete the parent folder, which can result in data loss. The data loss potential has also
@@ -243,6 +233,7 @@ on revSaveAsStandalone pStack, pFolder, pPreview
       setSettings pStack, tSettings
    end if
    
+   local tError
    # Do the check and continue building as normal.
    if revSaveCheck(pStack) then
       revDoSaveAsStandalone pStack, pFolder
@@ -287,6 +278,24 @@ command revDoSaveAsStandalone pStack, pFolder
    
    # Set empty values to defaults
    revSBDefaultStandaloneSettings pStack, sStandaloneSettingsA
+   
+   -- Don't build for any platform we are not licensed for
+   local tRemoved
+   put revSBRemoveUnlicensedTargetsFromSettings(sStandaloneSettingsA) into tRemoved
+   replace return with comma in tRemoved
+   
+   if revSBNoPlatforms(sStandaloneSettingsA) then
+      local tMessage
+      put "You are not licensed to build for any selected platforms." into tMessage
+      if not revSBSuppressDialogs() then
+         answer error tMessage
+      end if
+      return tMessage
+   end if
+   
+   if tRemoved is not empty then
+      revStandaloneAddWarning "Not licensed to build for the following selected platforms:" && tRemoved
+   end if
    
    revStandaloneProgress "Preparing to build standalone..."
    
@@ -385,19 +394,16 @@ command revDoSaveAsStandalone pStack, pFolder
    catch tError
       revAbort
       if word 1 of tError = "Standalone:" then 
-         if revSBSuppressDialogs() then
-            return word 2 to -1 of tError
-         else
+         put word 2 to -1 of tError into tError
+         if not revSBSuppressDialogs() then
             answer error word 2 to -1 of tError
          end if
       else  
-         if revSBSuppressDialogs() then
-            return tError
-         else
+         if not revSBSuppressDialogs() then
             answer error "There was an error while saving the standalone application"&cr&tError
          end if
       end if
-      exit to top
+      return tError
    end try
    
    revReset

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2623,9 +2623,10 @@ function revSBEnginePath pPlatform
 end revSBEnginePath
 
 function revSBLicensedToDeployToTarget pTarget
-   -- In non-development mode we just rely on the license
-   -- parameters check within the deploy command
-   if not the environment begins with "development" then
+   -- We can only check the license parameters in development mode,
+   -- and they are only set in UI mode. So just return true unless
+   -- the mode is development.
+   if the environment is not "development" then
       return true
    end if
    

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -833,8 +833,8 @@ on revSBDefaultStandaloneSettings pStack, @xSettingsA
    if xSettingsA["UNIX,printerChooser"] = "" then put true into xSettingsA["UNIX,printerChooser"]
    if xSettingsA["UNIX,pageSetup"] = "" then put true into xSettingsA["UNIX,pageSetup"]
    if xSettingsA["UNIX,fileSelector"] = "" then put true into xSettingsA["UNIX,fileSelector"]
-   -- build for every platform we have engines for
    
+   -- build for every platform we have engines for
    repeat for each item tTarget in kInitialTargets
       if xSettingsA[tTarget] = "" then
          put revEngineCheck(tTarget) into xSettingsA[tTarget]
@@ -860,6 +860,20 @@ on revSBDefaultStandaloneSettings pStack, @xSettingsA
       end if
    end if
 end revSBDefaultStandaloneSettings
+
+function revSBRemoveUnlicensedTargetsFromSettings @xSettingsA
+   -- don't build for any platform we are not licensed for
+   local tRemoved
+   repeat for each item tTarget in kDesktopTargets, kAdditionalTargets
+      if xSettingsA[tTarget] then
+         if not revSBLicensedToDeployToTarget(tTarget) then
+            put false into xSettingsA[tTarget]
+            put true into tRemoved[tTarget]
+         end if
+      end if
+   end repeat
+   return the keys of tRemoved
+end revSBRemoveUnlicensedTargetsFromSettings
 
 command revSBRelativeStackFilesList pStack, @rStackFiles
    local tLine,tChars,tMainStackPath
@@ -2607,3 +2621,43 @@ function revSBEnginePath pPlatform
       end switch
    end if
 end revSBEnginePath
+
+function revSBLicensedToDeployToTarget pTarget
+   -- In non-development mode we just rely on the license
+   -- parameters check within the deploy command
+   if not the environment begins with "development" then
+      return true
+   end if
+   
+   -- In development mode, check the revLicenseInfo
+   local tLicensedTargets
+   put line 5 of revLicenseInfo into tLicensedTargets
+   
+   local tPlatform
+   put revSBTargetToPlatform(pTarget) into tPlatform
+   
+   local tLicensePlatform
+   switch tPlatform
+      case "MacOSX"
+         put "Mac OS X" into tLicensePlatform
+         break
+      case "Emscripten"
+         put "HTML5" into tLicensePlatform
+         break
+      default
+         put tPlatform into tLicensePlatform
+         break
+   end switch
+   
+   return tLicensePlatform is among the items of tLicensedTargets
+end revSBLicensedToDeployToTarget
+
+function revSBNoPlatforms pSettings
+   repeat for each item tTarget in kDesktopTargets, kAdditionalTargets
+      if pSettings[tTarget] then
+         return false
+      end if
+   end repeat
+   
+   return true
+end revSBNoPlatforms


### PR DESCRIPTION
When unlicensed platforms are selected, an SB warning is added that
they were not licensed to build for those platforms.

If no licensed platforms are selected, the user is informed via an
error dialog and no further action is taken.