### PR TITLE
[[ Docs ]] Changes to precedence.lcdoc

### DIFF
--- a/docs/glossary/p/precedence.lcdoc
+++ b/docs/glossary/p/precedence.lcdoc
@@ -14,9 +14,9 @@ The set of rules that determine what order <operator|operators> are
 3. Multiplication and division, from left to right.
 4. Addition and subtraction, from left to right.
 
-For example, the \* <operator> has higher precedence than the + 
+For example, the <*|\*> <operator> has higher precedence than the <+> 
 <operator>, so 2 + 3 \* 4
 is <evaluate|evaluated> as 2 + (3 \* 4), not (2 + 3) \* 4.
 
-References: evaluate (glossary), operator (glossary),
-expression (glossary)
+References: * (operator), + (operator), evaluate (glossary), 
+operator (glossary), expression (glossary)

--- a/docs/glossary/p/precedence.lcdoc
+++ b/docs/glossary/p/precedence.lcdoc
@@ -7,12 +7,16 @@ Type: glossary
 Description:
 The set of rules that determine what order <operator|operators> are
 <evaluate|evaluated> in, in an <expression> that has more than one
-<operator>. 
+<operator>. Simplified, the rules for numeric operators are as follows:
 
-For example, the * <operator> has higher precedence than the +
-<operator>, so 2 + 3 * 4
-is <evaluate|evaluated> as 2 + (3 * 4), not (2 + 3) * 4.
+1. Operations grouped by parentheses.
+2. Exponentiation.
+3. Multiplication and division, from left to right.
+4. Addition and subtraction, from left to right.
+
+For example, the \* <operator> has higher precedence than the + 
+<operator>, so 2 + 3 \* 4
+is <evaluate|evaluated> as 2 + (3 \* 4), not (2 + 3) \* 4.
 
 References: evaluate (glossary), operator (glossary),
 expression (glossary)
-


### PR DESCRIPTION
* Escaped /* symbols so they would show up.
* Added more detail about operator precedence.