### PR TITLE
[Bug 18929] Update LCB bytecode file format version for LiveCode 9

### DIFF
--- a/docs/lcb/notes/18929.md
+++ b/docs/lcb/notes/18929.md
@@ -1,0 +1,1 @@
+# [18929] Update LiveCode Builder ABI version for LiveCode 9

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -842,7 +842,8 @@ MCScriptBytecodeDecodeSignedArgument(uindex_t p_original_value)
 
 #define kMCScriptModuleVersion_8_0_0_DP_1 0
 #define kMCScriptModuleVersion_8_1_0_DP_2 1
-#define kMCScriptCurrentModuleVersion kMCScriptModuleVersion_8_1_0_DP_2
+#define kMCScriptModuleVersion_9_0_0_DP_4 2
+#define kMCScriptCurrentModuleVersion kMCScriptModuleVersion_9_0_0_DP_4
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The module file format and the LCB bytecode have not changed in
LiveCode 9.  Nevertheless, LCB extensions compiled with LiveCode 8.1
can't be used in LiveCode 9 developer previews (and _vice versa_).
This is because the LiveCode Builder ABI -- the set of implementation
functions bound to by LiveCode Builder standard library syntax -- has
changed.

Bytecode modules could embed explicit information about the ABI they
were compiled for, but until they do, it will be necessary to
increment the module version each time the LCB ABI changes.