### PR TITLE
[[ Bug 18948 ]] Make handling of 'objchunk of me'  consistent for widgets

### DIFF
--- a/docs/notes/bugfix-18948.md
+++ b/docs/notes/bugfix-18948.md
@@ -1,0 +1,1 @@
+# Make 'obj of me' consistent across all control types

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -55,6 +55,27 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static bool MCChunkTermIsNestable(Chunk_term p_chunk_term)
+{
+	switch (p_chunk_term)
+	{
+		case CT_STACK:
+		case CT_GROUP:
+		case CT_LAYER:
+		case CT_ELEMENT:
+			return true;
+		default:
+			return false;
+	}
+}
+
+static bool MCChunkTermHasRange(Chunk_term p_chunk_term)
+{
+	return p_chunk_term >= CT_LINE && p_chunk_term < CT_ELEMENT;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 #ifdef COLLECTING_CHUNKS
 #include "newchunk.h"
 class MCSyntaxCollector
@@ -991,30 +1012,10 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
             ctxt . LegacyThrow(EE_CHUNK_NOTARGET);
             return;
         }
-        // SN-2015-01-13: [[ Bug 14376 ]] Remove this if statement added during the refactoring process
-        // (commit 15a49a27e387f3e49e5bcce8f8316348578bf810)
-        //  which leads to a part_id of 0 instead of the card part id.
-//        if (background == nil && card == nil && group == nil && object == nil)
-//        {
-//            r_object . object = t_object . object;
-//            r_object . part_id = t_object . part_id;
-//            return;
-//        }
-        switch (t_object . object -> gettype())
+
+		Chunk_term t_type = t_object . object -> gettype();
+		if (MCChunkTermIsControl(t_type) && t_type != CT_GROUP)
         {
-            case CT_AUDIO_CLIP:
-            case CT_VIDEO_CLIP:
-            case CT_LAYER:
-            case CT_MENU:
-            case CT_BUTTON:
-            case CT_IMAGE:
-            case CT_FIELD:
-            case CT_GRAPHIC:
-            case CT_EPS:
-            case CT_SCROLLBAR:
-            case CT_PLAYER:
-            case CT_MAGNIFY:
-            case CT_COLOR_PALETTE:
                 MCCard *t_card;
                 t_card = t_object . object -> getcard(t_object . part_id);
                 if (t_card == nil)
@@ -1028,9 +1029,7 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
                 r_object . object = t_object . object;
                 r_object . part_id = t_object . part_id;
                 return;
-            default:
-                break;
-        }
+		}
     }
     else if (noobjectchunks())
     {
@@ -3452,23 +3451,4 @@ MCChunkType MCChunkTypeFromChunkTerm(Chunk_term p_chunk_term)
         default:
             MCUnreachableReturn(kMCChunkTypeLine);
     }
-}
-
-bool MCChunkTermIsNestable(Chunk_term p_chunk_term)
-{
-    switch (p_chunk_term)
-    {
-        case CT_STACK:
-        case CT_GROUP:
-        case CT_LAYER:
-        case CT_ELEMENT:
-            return true;
-        default:
-            return false;
-    }
-}
-
-bool MCChunkTermHasRange(Chunk_term p_chunk_term)
-{
-    return p_chunk_term >= CT_LINE && p_chunk_term < CT_ELEMENT;
 }

--- a/engine/src/chunk.h
+++ b/engine/src/chunk.h
@@ -190,7 +190,8 @@ public:
 };
 
 MCChunkType MCChunkTypeFromChunkTerm(Chunk_term p_chunk_term);
-bool MCChunkTermIsNestable(Chunk_term p_chunk_term);
-bool MCChunkTermHasRange(Chunk_term p_chunk_term);
-
+inline bool MCChunkTermIsControl(Chunk_term p_chunk_term)
+{
+	return p_chunk_term >= CT_FIRST_CONTROL && p_chunk_term <= CT_LAST_CONTROL;
+}
 #endif

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -1736,7 +1736,8 @@ void MCMakeGroup::exec_ctxt(MCExecContext& ctxt)
 		for(MCChunk *t_chunk = targets; t_chunk != nil; t_chunk = t_chunk -> next)
 		{
 			MCObjectPtr t_object;
-			if (!t_chunk -> getobj(ctxt, t_object, True) || t_object . object -> gettype() < CT_FIRST_CONTROL || t_object . object -> gettype() > CT_LAST_CONTROL)
+			if (!t_chunk -> getobj(ctxt, t_object, True) ||
+			    !MCChunkTermIsControl(t_object . object -> gettype()))
             {
                 ctxt .Throw();
 				return;

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -425,9 +425,8 @@ void MCFocus::exec_ctxt(MCExecContext &ctxt)
 	{
 		MCObject *optr;
 		uint4 parid;
-        if (!object->getobj(ctxt, optr, parid, True)
-                || optr->gettype() < CT_FIRST_CONTROL
-                || optr->gettype() > CT_LAST_CONTROL)
+        if (!object->getobj(ctxt, optr, parid, True) ||
+            !MCChunkTermIsControl(optr -> gettype()))
 		{
             ctxt . LegacyThrow(EE_FOCUS_BADOBJECT);
             return;

--- a/tests/lcs/core/chunks/widget.livecodescript
+++ b/tests/lcs/core/chunks/widget.livecodescript
@@ -1,0 +1,29 @@
+script "CoreChunksWidget"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestWidgetSubchunk
+	-- Bug 18948
+	create widget "me" as ""
+	set the script of it to "function doTest; return the short name of button 1 of me; end doTest"
+	
+	local tResult
+	dispatch function doTest to widget 1
+	put the result into tResult
+	
+	TestAssert "'objchunk' of me in non-group non-behavior control is me", tResult is "me"
+end TestWidgetSubchunk


### PR DESCRIPTION
For other non-group controls that aren't behaviors, the 'me' resolves to
'this card of me' in this context.