### PR TITLE
[[ Clang ]] Support for building LiveCode 8.1.x with clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ dist: trusty
 
 language: c++
 
+compiler: clang
+
 # Skip vulcan CI branches
 branches:
   only:

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -83,7 +83,6 @@
 				'cflags':
 				[
 					'-w',						# Disable warnings
-					'-fpermissive',				# Be more lax with old code
 					'-Wno-return-type',
 				],
 				

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -70,7 +70,6 @@
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
 					'-Werror=uninitialized',
-					'-Wno-error=maybe-uninitialized',
 					'-Werror=conversion-null',
 				],
 

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -117,7 +117,6 @@
 		'-std=<(c++_std)',
 		'-fno-exceptions',
 		'-fno-rtti',
-		'-fcheck-new',
 	],
 	
 	'configurations':

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -117,6 +117,7 @@
 		'-std=<(c++_std)',
 		'-fno-exceptions',
 		'-fno-rtti',
+		'-Wno-deprecated-register',
 	],
 	
 	'configurations':

--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -266,7 +266,7 @@
 					{
 						'ldflags':
 						[
-							'-T', '$(abs_srcdir)/engine/linux.link',
+							'-Wl,-T,$(abs_srcdir)/engine/linux.link',
 						],
 					},
 				],

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -1673,7 +1673,7 @@ public:
 
     virtual uint32_t TextConvert(const void *p_string, uint32_t p_string_length, void *r_buffer, uint32_t p_buffer_length, uint32_t p_from_charset, uint32_t p_to_charset)
     {
-        uint32_t t_used;
+        uint32_t t_used = 0;
         if (p_to_charset == LCH_UNICODE)
         {
             if (p_buffer_length == 0)

--- a/engine/src/lnxgtktheme.cpp
+++ b/engine/src/lnxgtktheme.cpp
@@ -813,17 +813,16 @@ Widget_Part MCNativeTheme::hittestcombobutton(const MCWidgetInfo &winfo,
         int2 mx, int2 my, const MCRectangle &drect)
 {
 	Widget_Part wpart = WTHEME_PART_UNDEFINED;
-	const int btnWidth = getmetric(WTHEME_METRIC_COMBOSIZE);
-
-
-	MCRectangle btnRect = {	int2(drect.x + (drect.width - btnWidth)),
-	                        drect.y,
-	                        int2(btnWidth),
-	                        drect.height };
-	MCRectangle txtRect = { drect.x,
-	                        drect.y,
-	                        int2(drect.width - btnWidth),
-	                        drect.height };
+	const uint2 btnWidth = MCClamp(getmetric(WTHEME_METRIC_COMBOSIZE),
+								   0, drect.width);
+	
+	uint2 t_text_width = drect.width - btnWidth;
+	int2 t_btn_left = drect.x + t_text_width;
+	
+	MCRectangle btnRect = {	t_btn_left, drect.y,
+							btnWidth, drect.height };
+	MCRectangle txtRect = { drect.x, drect.y,
+		                    t_text_width, drect.height };
 
 	if(MCU_point_in_rect(btnRect, mx, my))
 		wpart = WTHEME_PART_COMBOBUTTON;

--- a/revdb/revdb.gyp
+++ b/revdb/revdb.gyp
@@ -476,6 +476,16 @@
 					},
 				],
 				[
+					'OS == "linux"',
+					{
+						'cflags!':
+						[
+							# Error in ../../thirdparty/libsqlite/include/qry_dat.h
+							'-Werror=return-type',
+						],
+					},
+				],
+				[
 					'OS == "mac" or OS == "ios"',
 					{
 						'xcode_settings':
@@ -553,6 +563,12 @@
 						'cflags_cc':
 						[
 							'-fexceptions',
+						],
+	
+						'cflags!':
+						[
+							# Error in ../../thirdparty/libsqlite/include/qry_dat.h
+							'-Werror=return-type',
 						],
 					},
 				],


### PR DESCRIPTION
Backport #4924 to `develop-8.1`, so that stable builds may be built using clang on the Vulcan build cluster.