### PR TITLE
Revert "[[ Clang ]] Support for building LiveCode 8.1.x with clang"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ dist: trusty
 
 language: c++
 
-compiler: clang
-
 # Skip vulcan CI branches
 branches:
   only:

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -70,6 +70,7 @@
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
 					'-Werror=uninitialized',
+					'-Wno-error=maybe-uninitialized',
 					'-Werror=conversion-null',
 				],
 
@@ -82,6 +83,7 @@
 				'cflags':
 				[
 					'-w',						# Disable warnings
+					'-fpermissive',				# Be more lax with old code
 					'-Wno-return-type',
 				],
 				
@@ -115,7 +117,7 @@
 		'-std=<(c++_std)',
 		'-fno-exceptions',
 		'-fno-rtti',
-		'-Wno-deprecated-register',
+		'-fcheck-new',
 	],
 	
 	'configurations':

--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -266,7 +266,7 @@
 					{
 						'ldflags':
 						[
-							'-Wl,-T,$(abs_srcdir)/engine/linux.link',
+							'-T', '$(abs_srcdir)/engine/linux.link',
 						],
 					},
 				],

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -1673,7 +1673,7 @@ public:
 
     virtual uint32_t TextConvert(const void *p_string, uint32_t p_string_length, void *r_buffer, uint32_t p_buffer_length, uint32_t p_from_charset, uint32_t p_to_charset)
     {
-        uint32_t t_used = 0;
+        uint32_t t_used;
         if (p_to_charset == LCH_UNICODE)
         {
             if (p_buffer_length == 0)

--- a/engine/src/lnxgtktheme.cpp
+++ b/engine/src/lnxgtktheme.cpp
@@ -813,16 +813,17 @@ Widget_Part MCNativeTheme::hittestcombobutton(const MCWidgetInfo &winfo,
         int2 mx, int2 my, const MCRectangle &drect)
 {
 	Widget_Part wpart = WTHEME_PART_UNDEFINED;
-	const uint2 btnWidth = MCClamp(getmetric(WTHEME_METRIC_COMBOSIZE),
-								   0, drect.width);
-	
-	uint2 t_text_width = drect.width - btnWidth;
-	int2 t_btn_left = drect.x + t_text_width;
-	
-	MCRectangle btnRect = {	t_btn_left, drect.y,
-							btnWidth, drect.height };
-	MCRectangle txtRect = { drect.x, drect.y,
-		                    t_text_width, drect.height };
+	const int btnWidth = getmetric(WTHEME_METRIC_COMBOSIZE);
+
+
+	MCRectangle btnRect = {	int2(drect.x + (drect.width - btnWidth)),
+	                        drect.y,
+	                        int2(btnWidth),
+	                        drect.height };
+	MCRectangle txtRect = { drect.x,
+	                        drect.y,
+	                        int2(drect.width - btnWidth),
+	                        drect.height };
 
 	if(MCU_point_in_rect(btnRect, mx, my))
 		wpart = WTHEME_PART_COMBOBUTTON;

--- a/revdb/revdb.gyp
+++ b/revdb/revdb.gyp
@@ -476,16 +476,6 @@
 					},
 				],
 				[
-					'OS == "linux"',
-					{
-						'cflags!':
-						[
-							# Error in ../../thirdparty/libsqlite/include/qry_dat.h
-							'-Werror=return-type',
-						],
-					},
-				],
-				[
 					'OS == "mac" or OS == "ios"',
 					{
 						'xcode_settings':
@@ -563,12 +553,6 @@
 						'cflags_cc':
 						[
 							'-fexceptions',
-						],
-	
-						'cflags!':
-						[
-							# Error in ../../thirdparty/libsqlite/include/qry_dat.h
-							'-Werror=return-type',
 						],
 					},
 				],


### PR DESCRIPTION
Reverts livecode/livecode#4939. These changes are no longer necessary, because the problem that prompted them has been fixed.