### PR TITLE
[Bug 18958] Make sure our prebuilt libs do not use reserved function names

### DIFF
--- a/docs/notes/bugfix-18958.md
+++ b/docs/notes/bugfix-18958.md
@@ -1,0 +1,1 @@
+# Make sure our prebuilt libs do not use reserved (by Apple private APIs) function names

--- a/prebuilt/scripts/build-openssl.sh
+++ b/prebuilt/scripts/build-openssl.sh
@@ -77,7 +77,7 @@ function buildOpenSSL {
 		CUSTOM_SPEC="${SPEC}-livecode"
 
 		OPENSSL_ARCH_SRC="${OPENSSL_SRC}-${PLATFORM_NAME}-${ARCH}"
-		OPENSSL_ARCH_CONFIG="no-rc5 no-hw shared --prefix=${INSTALL_DIR}/${NAME} ${CUSTOM_SPEC}"
+		OPENSSL_ARCH_CONFIG="no-rc5 no-hw shared -DOPENSSL_NO_ASYNC=1 --prefix=${INSTALL_DIR}/${NAME} ${CUSTOM_SPEC}"
 		OPENSSL_ARCH_LOG="${OPENSSL_ARCH_SRC}.log"
 	
 		# Copy the source to a target-specific directory


### PR DESCRIPTION
Defining `OPENSSL_NO_ASYNC` to 1 results in `ASYNC_POSIX` not being defined, thus the following non public symbols are no longer present in an iOS standalone binary:

`_getcontext`, `_setcontext`,`_makecontext`