### PR TITLE
[Bug 16511] docs: "fourthPixel" is not synonym of "borderPixel"

### DIFF
--- a/docs/dictionary/property/borderPixel.lcdoc
+++ b/docs/dictionary/property/borderPixel.lcdoc
@@ -4,7 +4,7 @@ Synonyms: fourthpixel
 
 Type: property
 
-Syntax: set the fourthPixel of <object> to <colorNumber>
+Syntax: set the borderPixel of <object> to <colorNumber>
 
 Summary:
 Specifies which entry in the <color table> is used for the color of an
@@ -20,7 +20,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-set the fourthPixel of group 1 to 200
+set the borderPixel of group 1 to 200
 
 Value:
 The <borderPixel> of an <object(glossary)> is an <integer> between zero

--- a/docs/notes/bugfix-16511.md
+++ b/docs/notes/bugfix-16511.md
@@ -1,0 +1,1 @@
+# Make examples of "borderPixel" use its main synonym


### PR DESCRIPTION
The documentation of the `borderPixel` correctly lists `fourthPixel`
as its synonym .  However, `fourthPixel` isn't a very commonly-used
synonym, and perhaps its use should be discouraged.

This patch modifies the examples to use `borderPixel` rather than
`fourthPixel`.