### PR TITLE
[[ Bug 18923 ]] Make sure CMYK images display correctly on Mac

### DIFF
--- a/docs/notes/bugfix-18923.md
+++ b/docs/notes/bugfix-18923.md
@@ -1,0 +1,4 @@
+# Ensure CMYK JPEGs display correctly on Mac
+
+This fixes the incorrect rendering of CMYK JPEGs containing an
+ICC profile on Mac.

--- a/engine/src/mac-color.mm
+++ b/engine/src/mac-color.mm
@@ -197,7 +197,7 @@ bool MCPlatformApplyColorTransform(MCPlatformColorTransformRef p_transform, MCIm
 	{
 		CGBitmapInfo t_bm_info;
 		if (CGColorSpaceGetModel(p_transform->colorspace) == kCGColorSpaceModelCMYK)
-			t_bm_info = kCGBitmapByteOrder32Host;
+			t_bm_info = kCGBitmapByteOrder32Big;
 		else
 			t_bm_info = t_dst_bm_info;
 			


### PR DESCRIPTION
This patch ensures that when a CYMK image is color converted using
an ICC profile on Mac, the byteorder of the incoming data is
declared correctly as big endian.