### PR TITLE
[Bug 15604] docs: Update links to PCRE pattern documentation

### DIFF
--- a/docs/dictionary/function/matchChunk.lcdoc
+++ b/docs/dictionary/function/matchChunk.lcdoc
@@ -75,10 +75,11 @@ matched substrings in the optional <positionVarsList> variables, while
 the <matchText> <function(control structure)> records the substrings
 themselves. 
 
->*Tip:*  LiveCode implements <regular expression|regular expressions>
+>*Tip:* LiveCode implements <regular expression|regular expressions>
 > compatible with the PCRE library. For detailed information about
-> <regular expression> elements you can use with this <function(control
-> structure)>, see the PCRE manual at http://www.pcre.org/man.txt.
+> <regular expression> elements you can use with this
+> <function(control structure)>, see the PCRE pattern documentation at
+> http://www.pcre.org/original/doc/html/pcrepattern.html.
 
 Changes:
 The regular expression format changed in version 2.0 to use PCRE

--- a/docs/dictionary/function/matchText.lcdoc
+++ b/docs/dictionary/function/matchText.lcdoc
@@ -85,10 +85,11 @@ substrings in the optional <foundTextVarsList>, which the <matchChunk>
 <function(control structure)> records the character positions of the
 matched substrings.
 
->*Tip:*  LiveCode implements <regular expression|regular expressions>
+>*Tip:* LiveCode implements <regular expression|regular expressions>
 > compatible with the PCRE library. For detailed information about
-> <regular expression> elements you can use with this <function(control
-> structure)>, see the PCRE manual at http://www.pcre.org/man.txt.
+> <regular expression> elements you can use with this
+> <function(control structure)>, see the PCRE pattern documentation at
+> http://www.pcre.org/original/doc/html/pcrepattern.html.
 
 Changes:
 The regular expression format changed in version 2.0 to use PCRE

--- a/docs/notes/bugfix-15604.md
+++ b/docs/notes/bugfix-15604.md
@@ -1,0 +1,1 @@
+# Update dictionary links to PCRE pattern documentation


### PR DESCRIPTION
When PCRE2 was introduced, the location of the PCRE documentation on
the PCRE website was changed, breaking the links in the dictionary.

This patch updates the dictionary to link directly to the
documentation of PCRE regular expression patterns, rather than to the
toplevel list of PCRE documentation.  Most of the PCRE documentation
is about the PCRE APIs, which aren't relevant to almost all LiveCode
users.