### PR TITLE
[Bug 15117] docs: lineOffset() can find multiline strings

### DIFF
--- a/docs/dictionary/function/lineOffset.lcdoc
+++ b/docs/dictionary/function/lineOffset.lcdoc
@@ -41,9 +41,7 @@ in.
 The value returned by the <lineOffset> <function> is the number of the
 <line> where <lineToFind> appears in <stringToSearch>. If the
 <lineToFind> is not in <stringToSearch>, the <lineOffset> <function>
-<return|returns> zero. If the <lineToFind> is more than one <line>, the
-<lineOffset> <function> always <return|returns> zero, even if the
-<lineToFind> appears in the <stringToSearch>.
+<return|returns> zero.
 
 If you specify how many <linesToSkip>, the <lineOffset> <function> skips
 the specified number of <lines> in the <stringToSearch>. The <value>

--- a/docs/notes/bugfix-15117.md
+++ b/docs/notes/bugfix-15117.md
@@ -1,0 +1,1 @@
+# The "lineOffset" function can search for multiline substrings


### PR DESCRIPTION
In recent versions of LiveCode, the `lineOffset()` function has been
enhanced to be able to search for multiline substrings.  It is no
longer the case that it will return 0 when the `lineToFind` contains
line separators. This patch removes that statement.