### PR TITLE
[Bug 13696] docs: Remove volume function's references to Unix

### DIFF
--- a/docs/dictionary/function/volumes.lcdoc
+++ b/docs/dictionary/function/volumes.lcdoc
@@ -48,8 +48,6 @@ are not currently mounted, do not appear in the list returned by the
 > <function>. On <Windows|Windows systems>, empty but connected
 > removable drives are reported by the <volumes> <function>.
 
-This function always returns empty on Unix systems.
-
 >*Note:* On Mac OS and OS X systems, volumes may contain slash
 > characters (/) in their names. To use such a volume as part of a path,
 > <replace> the slash with a semi colon before constructing the path.

--- a/docs/notes/bugfix-13696.md
+++ b/docs/notes/bugfix-13696.md
@@ -1,0 +1,1 @@
+# The "volumes" function is only supported on Mac & Windows


### PR DESCRIPTION
The `volume()` function is documented as only being supported on
Windows and Mac OS X, so it is not necessary for its documentation
to describe its behaviour on other platforms.