### PR TITLE
[Bug 14172] docs: "combine" uses lexicographic key ordering

### DIFF
--- a/docs/dictionary/command/combine.lcdoc
+++ b/docs/dictionary/command/combine.lcdoc
@@ -66,13 +66,14 @@ lost in the transformation.
 If you use the `as set` form the <combine> command rebuilds the list using
 the delimiter passed; the values of the <array> are ignored.
 
->*Note:*  The order of the elements is not alphabetical or
-> chronological; it is based on the internal hash order of the <array>. To
-> alphabetize the list, use the <sort> command:
-
-    combine monthlyReceivables using return and comma
-    sort lines of monthlyReceivables by item 2 of each
-
+> *Note:* The order of the elements is based on case-sensitive
+> lexicographical sorting of the array's keys.  The ordering is
+> equivalent to:
+>
+>     local tKeys
+>     put the keys of tArray into tKeys
+>     set the caseSensitive to true
+>     sort tKeys text ascending
 
 If the second form of the <combine> command is used, the elements of the
 original <array> are considered to be either columns or rows, separated by

--- a/docs/notes/bugfix-14172.md
+++ b/docs/notes/bugfix-14172.md
@@ -1,0 +1,1 @@
+# Clarify that the "combine" command works in lexicographic key order


### PR DESCRIPTION
The `combine` command was previously documented as producing a result
based on internal hash order of the input array's keys.  However, the
ordering is in fact in case-sensitive lexicographic order.  This patch
corrects the incorrect note and provides an example of a script that
places the keys in an equivalent ordering.