### PR TITLE
[Bug 14473] docs: Provide a complete revZipAddItemWithData example

### DIFF
--- a/docs/dictionary/command/revZipAddItemWithData.lcdoc
+++ b/docs/dictionary/command/revZipAddItemWithData.lcdoc
@@ -16,10 +16,12 @@ Platforms: desktop, server, mobile
 Security: disk, network
 
 Example:
-revZipAddItemWithData tArchive, "myZippedItem", "tData"
-
-Example:
-revZipAddItemWithData the cArchive of me, "Test.txt", "This is a test text file"
+-- Add a text file directly to the zip file, using the UTF-8
+-- text encoding
+local tContent, tData
+put "Hello, world!" into tContent
+put textEncode(tContent, "utf-8") into tData
+revZipAddItemWithData tArchive, "hello-world.txt", "tData"
 
 Parameters:
 archivePath:

--- a/docs/notes/bugfix-14473.md
+++ b/docs/notes/bugfix-14473.md
@@ -1,0 +1,1 @@
+# Provide a complete example for revZipAddItemWithData


### PR DESCRIPTION
Argument 3 passed to the `revZipAddItemWithData` command is required
to be the name of a variable containing the data to be stored.  The
previous example 2 of the command was incorrect, attempting to pass a
string literal to be stored as the content as argument 3.

This patch removes the incorrect example, and makes the original,
correct example more complete by providing a full example of how to
use `revZipAddItemWithData` to create a UTF-8 encoded text file in the
zip archive.