### PR TITLE
[Bug 18853] Support multi-module assemblies in "load extension"

### DIFF
--- a/docs/dictionary/command/load-extension.lcdoc
+++ b/docs/dictionary/command/load-extension.lcdoc
@@ -51,9 +51,20 @@ added to the bottom of the message path. If it is a widget, it will be
 available as a control in the tools palette to drag out, or to create
 with the <create widget> <command>.
 
+If the <moduleData> or the data loaded from <filePath> contains more
+than one LiveCode Builder module, then the first module is treated as
+the extension's main module and the remaining modules are treated as
+support modules.  Support modules are only kept loaded if they are
+used by the main module.  Support modules' names must begin with the
+name of the main module.
+
 References: unload extension (command), create widget (command),
 loadedExtensions (function), result (function),
 LiveCode Builder extension (glossary)
+
+Changes:
+The ability to load multiple modules in a single <load extension>
+command was added in LiveCode 9.0.
 
 Tags: extensions
 

--- a/docs/notes/bugfix-18853.md
+++ b/docs/notes/bugfix-18853.md
@@ -1,0 +1,14 @@
+# Support for loading multi-module bytecode files (experimental)
+
+The **load extension** command is now able to load LiveCode Builder
+bytecode files (`.lcm` files) that contain multiple modules' bytecode.
+
+The first module in each `.lcm` file is treated as the "main module"
+of the module (i.e. the library or widget), and other modules are
+treated as support modules.
+
+Support modules only remain loaded if they are used by the main
+module, and support modules must be submodules of the main module.
+For example, if the main module is "com.livecode.newbutton", then all
+other modules in the bytecode file must have names like
+"com.livecode.newbutton.&lt;something&gt;".

--- a/libscript/include/libscript/script-auto.h
+++ b/libscript/include/libscript/script-auto.h
@@ -140,6 +140,22 @@ private:
 typedef MCAutoScriptObjectRefArrayBase<MCScriptModuleRef, MCScriptRetainModule, MCScriptReleaseModule> MCAutoScriptModuleRefArray;
 typedef MCAutoScriptObjectRefArrayBase<MCScriptInstanceRef, MCScriptRetainInstance, MCScriptReleaseInstance> MCAutoScriptInstanceRefArray;
 
-/* ================================================================ */
+/* ================================================================
+ * libscript functions relying on managed-lifetime types
+ * ================================================================
+ *
+ * This header declares some libscript functions in addition to those
+ * declared in "script.h".  These functions rely on the managed
+ * lifetime types declared in this header but not available in
+ * "script.h".
+ */
+
+/* ----------------------------------------------------------------
+ * Module-related functions
+ * ---------------------------------------------------------------- */
+MC_DLLEXPORT bool MCScriptCreateModulesFromStream(MCStreamRef p_stream,
+                                                  MCAutoScriptModuleRefArray& x_modules);
+MC_DLLEXPORT bool MCScriptCreateModulesFromData(MCDataRef p_data,
+                                                MCAutoScriptModuleRefArray& x_modules);
 
 #endif /* !__MC_SCRIPT_AUTO__ */

--- a/libscript/include/libscript/script-auto.h
+++ b/libscript/include/libscript/script-auto.h
@@ -19,6 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define __MC_SCRIPT_AUTO__
 
 #include "script.h"
+#include "foundation-span.h"
 
 /* ================================================================ */
 
@@ -123,6 +124,11 @@ public:
 			return false;
 		m_values[m_count - 1] = REF(p_value);
 		return true;
+	}
+
+	MCSpan<T> Span()
+	{
+		return MCMakeSpan(Ptr(), Size());
 	}
 
 	T & operator [] (const int p_index)

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -457,6 +457,43 @@ MCScriptCreateModuleFromData (MCDataRef data,
 	return true;
 }
 
+MC_DLLEXPORT_DEF bool
+MCScriptCreateModulesFromStream(MCStreamRef p_stream,
+                                MCAutoScriptModuleRefArray& x_modules)
+{
+    size_t t_available = 0;
+    do
+    {
+        MCAutoScriptModuleRef t_module;
+
+        if (!MCScriptCreateModuleFromStream(p_stream, &t_module))
+            return false;
+
+        if (!x_modules.Push(*t_module))
+            return false;
+
+        if (!MCStreamGetAvailableForRead(p_stream, t_available))
+            return false;
+    }
+    while (t_available > 0);
+
+    return true;
+}
+
+MC_DLLEXPORT_DEF bool
+MCScriptCreateModulesFromData(MCDataRef p_data,
+                              MCAutoScriptModuleRefArray& x_modules)
+{
+    MCAutoValueRefBase<MCStreamRef> t_stream;
+
+    if (!MCMemoryInputStreamCreate(MCDataGetBytePtr(p_data),
+                                   MCDataGetLength(p_data),
+                                   &t_stream))
+        return false;
+
+    return MCScriptCreateModulesFromStream(*t_stream, x_modules);
+}
+
 bool MCScriptLookupModule(MCNameRef p_name, MCScriptModuleRef& r_module)
 {
     for(MCScriptModule *t_module = s_modules; t_module != nil; t_module = t_module -> next_module)

--- a/tests/lcs/core/engine/_extension.lcb
+++ b/tests/lcs/core/engine/_extension.lcb
@@ -1,5 +1,7 @@
 library com.livecode.lcs_tests.core.extension
 
+use com.livecode.lcs_tests.core.extension.support
+
 public handler TestExtensionBridgeNames_ExecuteScript()
 	execute script "return the version"
 	return the result is a string
@@ -18,6 +20,10 @@ public handler TestExtensionBridgeNames_Send()
 
 	send function "TestExtensionBridgeNames_Version" to tScriptObject
 	return the result is a string
+end handler
+
+public handler TestExtensionSupportModule_Handler()
+	return SupportHandler() is "support handler"
 end handler
 
 end library

--- a/tests/lcs/core/engine/_extension_support.lcb
+++ b/tests/lcs/core/engine/_extension_support.lcb
@@ -1,0 +1,7 @@
+module com.livecode.lcs_tests.core.extension.support
+
+public handler SupportHandler()
+	return "support handler"
+end handler
+
+end module

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -16,16 +16,40 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+constant kBytecodePath = "../_tests/_build/lcs/core/engine"
+
+local sTestExtension
+
 on TestSetup
     TestLoadExtension "com.livecode.library.json"
     TestLoadExtension "com.livecode.widget.clock"
 
-    TestDiagnostic the defaultfolder
-    load extension from file "../_tests/_build/lcs/core/engine/_extension.lcm"
+    buildMultiModuleExtension "_extension,_extension_support"
+    if the result is not empty then
+       throw "Failed to build test support extension:" && the result
+    end if
+    put it into sTestExtension
+
+    load extension from data sTestExtension
     if the result is not empty then
        throw "Failed to load test support extension:" && the result
     end if
 end TestSetup
+
+private command buildMultiModuleExtension pInputs, pOutput
+    -- Build a multi-module extension
+    local tBasename, tBytecode, tFile
+    repeat for each item tBasename in pInputs
+       put merge("[[kBytecodePath]]/[[tBasename]].lcm") into tFile
+       put url("binfile:" & tFile) after tBytecode
+       put the result into tResult
+       if tResult is not empty then
+          return merge("Failed to load [[tFile]]: [[tResult]]") for error
+       end if
+    end repeat
+
+    return tBytecode for value
+end buildMultiModuleExtension
 
 /////////
 
@@ -69,3 +93,35 @@ on TestExtensionBridgeNumbers
    TestAssert "LCS numbers bridge to LCB numbers in execute script", \
          TestExtensionBridgeNumbers_ExecuteScript()
 end TestExtensionBridgeNumbers
+
+//////////
+
+on TestMultiModuleExtensions
+   TestAssert "support modules are not in extension list", \
+         "com.livecode.lcs_tests.core.extension.support" is not among \
+         the lines of the loadedExtensions
+   TestAssert "main modules are in extension list", \
+         "com.livecode.lcs_tests.core.extension" is among \
+         the lines of the loadedExtensions
+   TestAssert "extension support module handlers work", \
+         TestExtensionSupportModule_Handler()
+
+   -- Check that unloading an extension also unloads support modules
+   -- (allowing them to be loaded again)
+   unload extension "com.livecode.lcs_tests.core.extension"
+   TestAssert "unload multi-module extension", the result is empty
+
+   load extension from data sTestExtension
+   TestAssert "reload multi-module extension", the result is empty
+
+   -- Check that extensions with incorrect support module names don't
+   -- load
+   unload extension "com.livecode.lcs_tests.core.extension"
+   buildMultiModuleExtension "_extension_support,_extension"
+   if the result is not empty then
+      throw "Failed to build assembly:" && the result
+   end if
+   load extension from data it
+   TestAssert "can't load multi-module extensions with bad module names", \
+         the result is not empty
+end TestMultiModuleExtensions

--- a/toolchain/lc-compile/src/lc-run.cpp
+++ b/toolchain/lc-compile/src/lc-run.cpp
@@ -395,27 +395,7 @@ MCRunLoadModulesFromFile (MCStringRef p_filename,
 	if (!MCSFileGetContents (p_filename, &t_module_data))
 		return false;
 
-	if (!MCMemoryInputStreamCreate (MCDataGetBytePtr (*t_module_data),
-	                                MCDataGetLength (*t_module_data),
-	                                &t_stream))
-		return false;
-
-	size_t t_available = 0;
-	do
-	{
-		MCAutoScriptModuleRef t_module;
-
-		if (!MCScriptCreateModuleFromStream (*t_stream, &t_module))
-			return false;
-
-		x_modules.Push(*t_module);
-
-		if (!MCStreamGetAvailableForRead (*t_stream, t_available))
-			return false;
-	}
-	while (t_available > 0);
-
-	return true;
+	return MCScriptCreateModulesFromData(*t_module_data, x_modules);
 }
 
 static bool


### PR DESCRIPTION
In commit 221897f, `lc-run` gained the ability to load multiple modules from a single `.lcm` bytecode file.  This was not at the time extended to the engine's `load extension` command.

For the Java FFI project, extensions will need to include both a widget or library module, and additionally a generated Java FFI module.  In the absence of a mechanism for multi-module extension packages and/or automatic dependency management between extension packages, some solution is required.

This patch enables `load extension` to load multiple modules from a file or binary string.  The first module in the input is considered the main module. Its name must be a proper prefix of the names of  subsequent support modules.  Support modules only remain loaded after the `load extension` command if they are transitively used by the main module.

This allows extensions that make use of Java FFI features to bundle both the main widget/library and the Java FFI module into a single package `module.lcm` file.