### PR TITLE
[[ Docs ]] Changes to uniEncode.lcdoc

### DIFF
--- a/docs/dictionary/function/uniEncode.lcdoc
+++ b/docs/dictionary/function/uniEncode.lcdoc
@@ -50,7 +50,7 @@ one of the following
 - "SimplifiedChinese"
 - "Unicode" (UTF-16)
 - "UTF8"
-- "w" (synonym for "Unicode"
+- "w" (synonym for "Unicode")
 
 
 Returns (string):
@@ -68,18 +68,21 @@ Description:
 Use the <uniEncode> <function(control structure)> to convert single-byte
 characters to double-byte characters.
 
->*Note:* As of LiveCode 7.0 the uniEncode function has been deprecated. It will
-> continue to work as in previous versions but should not be used in new
-> code as the existing behaviour is incompatible with the new, transparent
-> Unicode handling (the resulting value will be treated as binary data
-> rather than text). This functions is only useful in combination with the
-> also-deprecated uniDecode function and unicodeText field property.
+>*Important:* As of LiveCode 7.0 the <uniEncode> function has been 
+> deprecated. It will continue to work as in previous versions but 
+> should not be used in newcode as the existing behaviour is
+> incompatible with the new, transparent Unicode handling (the resulting 
+> value will be treated as binary data rather than text). This function 
+> is only useful in combination with the also-deprecated <uniDecode> 
+> function and <unicodeText> field property. Instead, for converting 
+> text between encodings, use the <textEncode> and <textDecode> 
+> functions.
 
 >*Important:*
 > The <uniEncode> <function(control structure)> is the <inverse> of the
 > <uniDecode> <function(control structure)> and inserts <null> bytes for
-> <Unicode> compatibility. In other words, it turns single-byte characters
-> into their double-byte equivalent.
+> <Unicode> compatibility. In other words, it turns single-byte 
+> <character|characters> into their double-byte equivalent.
 
 >*Note:*  You can use the UTF8 encoding only with the <uniDecode> and
 > <uniEncode> <function(glossary)|functions>. You cannot set an
@@ -87,14 +90,14 @@ characters to double-byte characters.
 > Unicode text in an <object(glossary)>, use either "Unicode" or a
 > language name as the second item of the <object|object's> <textFont>.
 
->*Important:* The <format> produced by the <uniEncode> <function(control
-> structure)> is processor-dependent. On "big-endian" processors, where
-> the first <byte> is least significant (such as Intel and Alpha
-> processors), the <uniEncode> <function(control structure)> adds the
-> <null> <byte> after each <character>. On "little-endian" processors,
-> where the last <byte> is least significant (such as PowerPC
-> processors), the <uniEncode> <function(control structure)> adds the
-> <null> <byte> before each <character>.
+>*Important:* The <format> produced by the <uniEncode> 
+> <function(control structure)> is processor-dependent. On "big-endian" 
+> processors, where the first <byte> is least significant (such as Intel 
+> and Alpha processors), the <uniEncode> <function(control structure)> 
+> adds the <null> <byte> after each <character>. On "little-endian" 
+> processors, where the last <byte> is least significant (such as 
+> PowerPC processors), the <uniEncode> <function(control structure)> 
+> adds the <null> <byte> before each <character>.
 
 The ability to handle double-byte characters on "little-endian"
 processors was added in version 2.0. In previous versions, the
@@ -108,12 +111,15 @@ added in version 2.0. In previous versions, the <uniEncode>
 Changes:
 The ability to encode text in Polish was added in version 2.1.1.
 
-Deprecated:
-uniEncode, uniDecode and unicodeText are all deprecated from version 7.0
+The tokens uniEncode, uniDecode and unicodeText are all deprecated 
+from version 7.0.
 
-References: null (constant), function (control structure),
-uniDecode (function), format (function), platform (function),
-object (glossary), property (glossary), Unicode (glossary),
-function (glossary), byte (glossary), return (glossary), string (keyword),
-inverse (keyword), character (keyword), textFont (property),
-unicodeTitle (property)
+References: byte (glossary), character (keyword), format (function), 
+function (control structure), function (glossary), inverse (keyword), 
+null (constant), object (glossary), platform (function), 
+property (glossary), return (glossary), string (keyword), 
+textDecode (function), textEncode (function), textFont (property), 
+Unicode (glossary), unicodeTitle (property), uniDecode (function)
+
+Tags: text processing
+


### PR DESCRIPTION
* Added information and links to textEncode and textDecode to the deprecated note.
* Added references to newer textEncode and textDecode.
* Corrected formatting problems.
* Added text processing tag.
* Deleted extra Deprecated element heading.