### PR TITLE
MCSpan: Don't return reference to stack variable.

### DIFF
--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -140,7 +140,7 @@ public:
 	{
 		return advance(1);
 	}
-	MCSpan& operator++(int)
+	MCSpan operator++(int)
 	{
 		auto t_ret = *this;
 		++(*this);


### PR DESCRIPTION
Suppose you have:

    auto t_value = *t_span++;

The implementation of postfix `operator++` for `MCSpan` returns a
reference, which ends up returning a reference to a value on the
stack, and GCC6 correctly emits a warning.

This patch changes the postfix `operator++` to return the
pre-modification span by value, rather than by reference.