### PR TITLE
[Coverity] Fix some uninitialised MCRectangle local variables

### DIFF
--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -1125,8 +1125,7 @@ MCControl *MCHcbutton::build(MCHcstak *hcsptr, MCStack *sptr)
 	{
 		bptr->ncolors = 1;
 		bptr->colors = new (nothrow) MCColor;
-		bptr->colors[0].red = bptr->colors[0].green = bptr->colors[0].blue
-		                      = bptr->colors[0].blue = MAXUINT2;
+		bptr->colors[0].red = bptr->colors[0].green = bptr->colors[0].blue = MAXUINT2;
 		bptr->colornames = new (nothrow) MCStringRef[1];
 		bptr->colornames[0] = nil;
 		bptr->dflags |= DF_FORE_COLOR;

--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -1776,25 +1776,28 @@ MCGroup *MCHcbkgd::build(MCHcstak *hcsptr, MCStack *sptr)
 }
 
 MCHcstak::MCHcstak(char *inname)
+	: rect(kMCEmptyRectangle),
+	  name(nullptr),
+	  script(nullptr),
+	  fullbuffer(nullptr),
+	  buffer(nullptr),
+	  pages(nullptr),
+	  marks(nullptr),
+	  npages(0),
+	  fonts(nullptr),
+	  atts(nullptr),
+	  nfonts(0),
+	  natts(0),
+	  pagesize(0),
+	  npbuffers(0),
+	  pbuffersizes(nullptr),
+	  pbuffers(nullptr),
+	  hcbkgds(nullptr),
+	  hcbmaps(nullptr),
+	  icons(nullptr),
+	  cursors(nullptr),
+	  snds(nullptr)
 {
-	name = inname;
-	script = NULL;
-	fullbuffer = NULL;
-	pages = NULL;
-	marks = NULL;
-	npages = 0;
-	fonts = NULL;
-	atts = NULL;
-	nfonts = natts = 0;
-	npbuffers = 0;
-	pbuffersizes = NULL;
-	pbuffers = NULL;
-	hcbkgds = NULL;
-	hcbmaps = NULL;
-	hccards = NULL;
-	icons = NULL;
-	cursors = NULL;
-	snds = NULL;
 }
 
 MCHcstak::~MCHcstak()

--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -1085,7 +1085,7 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle &r, uint4 window, MCStringRef di
         }
         
         // Prepare for drawing the selection rectangle
-        MCRectangle t_rect;
+        MCRectangle t_rect(kMCEmptyRectangle);
         GdkColor t_color;
         t_color.pixel = ~0;
         GdkGC *t_gc = gdk_gc_new(t_root);

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -1485,7 +1485,8 @@ void MCParagraph::draw(MCDC *dc, int2 x, int2 y, uint2 fixeda,
 
 	// MW-2012-01-25: [[ ParaStyles ]] Compute the inner and outer rects of the
 	//   paragraph.
-	MCRectangle t_outer_rect, t_inner_rect;
+	MCRectangle t_outer_rect(kMCEmptyRectangle);
+	MCRectangle t_inner_rect(kMCEmptyRectangle);
 	computerects(x, y, textwidth, t_paragraph_width, pgheight, t_outer_rect, t_inner_rect); 
 
 	// MW-2012-02-09: [[ ParaStyles ]] Compute the inner rect excluding padding (for
@@ -1653,7 +1654,8 @@ void MCParagraph::draw(MCDC *dc, int2 x, int2 y, uint2 fixeda,
 				dc -> fillrect(MCU_make_rect(t_outer_rect . x, t_outer_rect . y, t_outer_rect . width, MCMax(gethgrid() ? 1 : 0, t_inner_border_rect . y - t_outer_rect . y)));
 			else
 			{
-				MCRectangle t_prev_inner, t_prev_outer;
+				MCRectangle t_prev_inner(kMCEmptyRectangle);
+				MCRectangle t_prev_outer(kMCEmptyRectangle);
 				prev() -> computerects(x, y, textwidth, prev() -> getwidth(), pgheight, t_prev_outer, t_prev_inner);
 				
 				// MW-2012-02-10: [[ FixedTable ]] The adjustrects method uses both rects so make

--- a/engine/src/paragrafattr.cpp
+++ b/engine/src/paragrafattr.cpp
@@ -1289,7 +1289,8 @@ void MCParagraph::computeparaoffsetandwidth(int32_t& r_offset, int32_t& r_width)
 // left of the inner paragraph box. It also returns the width of the paragraph box.
 void MCParagraph::computeboxoffsetandwidth(int32_t& r_offset, int32_t& r_width) const
 {
-	MCRectangle t_outer, t_inner;
+	MCRectangle t_outer(kMCEmptyRectangle);
+	MCRectangle t_inner(kMCEmptyRectangle);
 	computerects(0, 0, parent -> getlayoutwidth(), getwidth(), 0, t_outer, t_inner);
 	r_offset = t_inner . x;
 	r_width = t_inner . width;

--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -621,6 +621,8 @@ struct MCRectangle
 	uint2 width, height;
 };
 
+const MCRectangle kMCEmptyRectangle = {0, 0, 0, 0};
+
 struct MCPoint32
 {
 	int32_t x, y;


### PR DESCRIPTION
Fix several uses of uninitialised values detected by Coverity, where `MCRectangle` variables were declared on the stack without explicit initialisation.

Ideally, `MCRectangle` would have a default constructor; unfortunately, we can't add one one until we update to building with MSVC 2017.  See commit log messages for more detail.