### PR TITLE
[[ Bug ]] Fix a couple of bugs in MCHcstak constructor

### DIFF
--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -1776,7 +1776,7 @@ MCGroup *MCHcbkgd::build(MCHcstak *hcsptr, MCStack *sptr)
 
 MCHcstak::MCHcstak(char *inname)
 	: rect(kMCEmptyRectangle),
-	  name(nullptr),
+	  name(inname),
 	  script(nullptr),
 	  fullbuffer(nullptr),
 	  buffer(nullptr),
@@ -1792,6 +1792,7 @@ MCHcstak::MCHcstak(char *inname)
 	  pbuffersizes(nullptr),
 	  pbuffers(nullptr),
 	  hcbkgds(nullptr),
+	  hccards(nullptr),
 	  hcbmaps(nullptr),
 	  icons(nullptr),
 	  cursors(nullptr),


### PR DESCRIPTION
These were introduced in https://github.com/livecode/livecode/pull/4980/commits/484e59d824a7f0b503b1a58d307fb41ca3259e6e and completely missed by the reviewer.