### PR TITLE
[[ Bug 19005 ]] Copy target string in replaceText/matchText

### DIFF
--- a/docs/notes/bugfix-19005.md
+++ b/docs/notes/bugfix-19005.md
@@ -1,0 +1,5 @@
+# Ensure matchText and replaceText don't affect target string
+
+Previously calling matchText or replaceText on a string would
+cause subsequent uses of that string to use slower codepaths
+causing unexpected performance degredation.


### PR DESCRIPTION
This patch ensures that the target string is copied when used in
replaceText or matchText, ensuring that the original string is not
force converted to unicode internally.