### PR TITLE
revvideograbber: Remove from Mac OS X builds

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -702,13 +702,11 @@ component Externals.Windows
 component Externals.MacOSX
 	into [[TargetFolder]]/Externals place
 		executable macosx:revspeech.bundle
-		executable macosx:revvideograbber.bundle
 		executable macosx:revxml.bundle
 		executable macosx:revbrowser.bundle
 		executable macosx:revzip.bundle
 		executable macosx:revfont.bundle
 	declare external "Speech" using revspeech.bundle
-	declare external "Video Grabber" using revvideograbber.bundle
 	declare external "XML" using revxml.bundle
 	declare external "Browser" using revbrowser.bundle
 	declare external "Revolution Zip" using revzip.bundle

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository contains a number of subprojects, each of which has its own subd
 
   * `revspeech/` — Text-to-speech support
 
-  * `revvideograbber/` — Video capture
+  * `revvideograbber/` — Video capture (Windows only)
 
   * `revxml/` — XML parsing and generation
 

--- a/config.sh
+++ b/config.sh
@@ -353,13 +353,6 @@ if test "${OS}" = "emscripten" ; then
     NODE_JS=${NODE_JS:-node}
 fi
 
-
-# Building on Travis
-if [ "${TRAVIS}" = "true" ] ; then
-    DISABLE_REVVIDEOGRABBER=-Denable_revvideograbber=0
-fi 
-
-
 ################################################################
 # Invoke gyp
 ################################################################
@@ -412,8 +405,7 @@ case ${OS} in
     invoke_gyp $basic_args "-DOS=${OS}" \
                            "-Dtarget_sdk=${XCODE_TARGET_SDK}" \
                            "-Dhost_sdk=${XCODE_HOST_SDK}" \
-                           "-Dtarget_arch=${TARGET_ARCH}" "$@" \
-                           ${DISABLE_REVVIDEOGRABBER}
+                           "-Dtarget_arch=${TARGET_ARCH}" "$@"
     ;;
   *)
     echo "ERROR: Bad configuration for generating project files"

--- a/docs/development/build-mac.md
+++ b/docs/development/build-mac.md
@@ -28,13 +28,10 @@ Download and install each of the following versions of Xcode, placing their app 
 | ------------- | --------------------------------------- |
 | 8.0           | /Applications/Xcode-Dev/Xcode_8_0.app   |
 | 7.2.1         | /Applications/Xcode-Dev/Xcode_7_2_1.app |
-| 6.2           | /Applications/Xcode-Dev/Xcode_6_2.app   |
-| 5.1.1 [1]     | /Applications/Xcode-Dev/Xcode_5_1_1.app |
-| 4.3.3 [2]     | /Applications/Xcode-Dev/Xcode_4_3_3.app |
+| 6.2 [1]       | /Applications/Xcode-Dev/Xcode_6_2.app   |
 
 Notes:
-1. Required for OS X build excluding "revvideograbber" extension
-2. Required for "revvideograbber" extension
+1. Required for OS X build
 
 Make sure you run and verify each of the versions of Xcode. Download and install any extra SDKs you need using the "Xcode → Preferences → Downloads" window.
 

--- a/docs/dictionary/command/revCloseVideoGrabber.lcdoc
+++ b/docs/dictionary/command/revCloseVideoGrabber.lcdoc
@@ -12,7 +12,7 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -60,6 +60,10 @@ standalone application (glossary), video grabber (glossary),
 command (glossary), LiveCode custom library (glossary),
 Video library (library), closeStack (message), shutdown (message),
 stack (object)
+
+Changes:
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revInitializeVideoGrabber.lcdoc
+++ b/docs/dictionary/command/revInitializeVideoGrabber.lcdoc
@@ -11,14 +11,11 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
 Security: disk, privacy
-
-Example:
-revInitializeVideoGrabber the short name of this stack, "QT","100,100,200,200"
 
 Example:
 revInitializeVideoGrabber the short name of this stack, "VFW",the rect of this stack
@@ -29,7 +26,7 @@ The short name of the stack that the video-grabber should attach itself
 to. 
 
 videoMethod:
-Either "QT" or "VFW".
+Must be "VFW".
 
 grabberRect:
 The rectangle of the video grabber window, and consists of four integers
@@ -58,9 +55,8 @@ connected. Use the <revRecordVideo> <command> to record video from the
 camera to a <file>, or use the <revPreviewVideo> command to display
 video without saving it.
 
-To use QuickTime for video capture on Mac OS X specify "QT" as the
-<videoMethod>. To use <VFW|Video for Windows> (on <Windows|Windows
-systems>), specify "VFW".
+To use <VFW|Video for Windows> (on <Windows|Windows systems>), specify
+"VFW".
 
 To close the window and unload the video capture code, you should use
 the <revCloseVideoGrabber> <command> when you're done with <video
@@ -80,9 +76,10 @@ The use of <QuickTime> was deprecated in version 8.1 of LiveCode with
 new defaults for <dontUseQT> and <dontUseQTEffects> as true on all
 systems apart from pre OS X 10.8. The Windows build of LiveCode no
 longer supports any <QuickTime> features and setting the <dontUseQT> and
-<dontUseQTEffects> will have no effect. Additionally <QuickTime> does 
-not include 64 bit support and therefore can not be supported on OS X 64
-bit builds of LiveCode.
+<dontUseQTEffects> will have no effect.
+
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revCloseVideoGrabber (command),
 revSetVideoGrabberRect (command), revRecordVideo (command),

--- a/docs/dictionary/command/revPreviewVideo.lcdoc
+++ b/docs/dictionary/command/revPreviewVideo.lcdoc
@@ -11,7 +11,7 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -38,11 +38,6 @@ save the video as a <file> while displaying it, use the <revRecordVideo>
 If the video grabber was already recording video to a file, the
 <revPreviewVideo> <command> stops the recording.
 
->*Important:*  If you are using <QuickTime> for video capture, <execute>
-> the <revVideoGrabIdle> <command> periodically while previewing or
-> recording video. Otherwise, you may experience poor quality in the
-> video capture.
-
 To stop displaying the video input, use the <revStopPreviewingVideo>
 <command>. 
 
@@ -60,9 +55,10 @@ The use of <QuickTime> was deprecated in version 8.1 of LiveCode with
 new defaults for <dontUseQT> and <dontUseQTEffects> as true on all
 systems apart from pre OS X 10.8. The Windows build of LiveCode no
 longer supports any <QuickTime> features and setting the <dontUseQT> and
-<dontUseQTEffects> will have no effect. Additionally <QuickTime> does 
-not include 64 bit support and therefore can not be supported on OS X 64
-bit builds of LiveCode.
+<dontUseQTEffects> will have no effect.
+
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revVideoFrameImage (command), revRecordVideo (command),
 revVideoGrabIdle (command), revStopPreviewingVideo (command),

--- a/docs/dictionary/command/revRecordVideo.lcdoc
+++ b/docs/dictionary/command/revRecordVideo.lcdoc
@@ -11,7 +11,7 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -38,20 +38,11 @@ Use the <revRecordVideo> <command> to record a <movie> file.
 You must use the <revInitializeVideoGrabber> <command> to open the
 <video grabber> before you can use the <revRecordVideo> <command>.
 
-If you specified "QT" as the video method when you executed the
-<revInitializeVideoGrabber> <command>, the recorded video is stored in
-<QuickTime> <format>. If you specified "VFW", the recorded video is
-stored in <AVI> <format>.
+The recorded video is stored in <AVI> <format>.
 
 If the video grabber was already recording video to a file, executing
 the <revRecordVideo> <command> again stops that recording and starts a
 new one.
-
->*Important:*  If you are using <QuickTime> for video capture, <execute>
-> the <revVideoGrabIdle> <command> periodically while previewing or
-> recording video. Not doing so may cause the video in the <video
-> grabber> to stutter or display strange screen artifacts
-
 To stop recording the video input, use the <revStopRecordingVideo>
 <command>. 
 
@@ -69,9 +60,10 @@ The use of <QuickTime> was deprecated in version 8.1 of LiveCode with
 new defaults for <dontUseQT> and <dontUseQTEffects> as true on all
 systems apart from pre OS X 10.8. The Windows build of LiveCode no
 longer supports any <QuickTime> features and setting the <dontUseQT> and
-<dontUseQTEffects> will have no effect. Additionally <QuickTime> does 
-not include 64 bit support and therefore can not be supported on OS X 64
-bit builds of LiveCode.
+<dontUseQTEffects> will have no effect.
+
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revVideoGrabIdle (command), revPreviewVideo (command),
 revInitializeVideoGrabber (command), revStopRecordingVideo (command),

--- a/docs/dictionary/command/revSetVideoGrabSettings.lcdoc
+++ b/docs/dictionary/command/revSetVideoGrabSettings.lcdoc
@@ -11,7 +11,9 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac
+Deprecated: 9.0
+
+OS:
 
 Platforms: desktop
 
@@ -29,18 +31,7 @@ settings string is a block of binary data returned by the
 revVideoGrabSettings function.
 
 Description:
-Use the <revSetVideoGrabSettings> <command> to restore settings for
-<video capture>.
-
-You specify settings for video capture in the video capture dialog box,
-which is displayed by the revVideoGrabDialog <command>. You can get the
-current settings with the <revVideoGrabSettings> <function> and restore
-them later with the <revSetVideoGrabSettings> <command>. This allows you
-to make changes to the <video capture|video-capture> settings under
-script control.
-
->*Important:*  The <revSetVideoGrabSettings> <command> works only for
-> <QuickTime> <video capture>.
+The <revSetVideoGrabSettings> is ignored and and has no effect.
 
 >*Important:*  The <revSetVideoGrabSettings> <command> is part of the 
 > <Video library>. To ensure that the <command> works in a 
@@ -56,9 +47,10 @@ The use of <QuickTime> was deprecated in version 8.1 of LiveCode with
 new defaults for <dontUseQT> and <dontUseQTEffects> as true on all
 systems apart from pre OS X 10.8. The Windows build of LiveCode no
 longer supports any <QuickTime> features and setting the <dontUseQT> and
-<dontUseQTEffects> will have no effect. Additionally <QuickTime> does 
-not include 64 bit support and therefore can not be supported on OS X 64
-bit builds of LiveCode.
+<dontUseQTEffects> will have no effect.
+
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revVideoGrabSettings (command), function (control structure),
 video capture (glossary), Standalone Application Settings (glossary),

--- a/docs/dictionary/command/revSetVideoGrabberRect.lcdoc
+++ b/docs/dictionary/command/revSetVideoGrabberRect.lcdoc
@@ -12,7 +12,7 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -58,6 +58,10 @@ left, bottom, and right edges of the <video grabber>, in <absolute
 > <Standalone Application Settings> window, make sure the
 > "Video Grabber" 
 > library checkbox is checked.
+
+Changes:
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revInitializeVideoGrabber (command), globalLoc (function),
 Standalone Application Settings (glossary),

--- a/docs/dictionary/command/revStopPreviewingVideo.lcdoc
+++ b/docs/dictionary/command/revStopPreviewingVideo.lcdoc
@@ -12,7 +12,7 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -45,6 +45,10 @@ Standalone Application Settings (glossary),
 standalone application (glossary), video grabber (glossary),
 command (glossary), LiveCode custom library (glossary),
 Video library (library)
+
+Changes:
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revStopRecordingVideo.lcdoc
+++ b/docs/dictionary/command/revStopRecordingVideo.lcdoc
@@ -12,7 +12,7 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -40,6 +40,10 @@ has no effect.
 > <Standalone Application Settings> window, make sure the
 > "Video Grabber" 
 > library checkbox is checked.
+
+Changes:
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revStopPreviewingVideo (command), revRecordVideo (command),
 stop recording (command), video capture (glossary),

--- a/docs/dictionary/command/revVideoFrameImage.lcdoc
+++ b/docs/dictionary/command/revVideoFrameImage.lcdoc
@@ -11,7 +11,7 @@ Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -68,6 +68,10 @@ x 100 <pixels>, but you specify 200 as the <frameWidth> and 100 as the
 > <Standalone Application Settings> window, make sure the
 > "Video Grabber" 
 > library checkbox is checked.
+
+Changes:
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revPreviewVideo (command), revRecordVideo (command),
 function (control structure), format (function), value (function),

--- a/docs/dictionary/command/revVideoGrabDialog.lcdoc
+++ b/docs/dictionary/command/revVideoGrabDialog.lcdoc
@@ -5,14 +5,13 @@ Type: command
 Syntax: revVideoGrabDialog [<settingsType>]
 
 Summary:
-Displays a dialog box for configuring <QuickTime> or <VFW|Video for
-Windows> <video capture>.
+Displays a dialog box for configuring <VFW|Video for Windows> <video capture>.
 
 Associations: video library
 
 Introduced: 2.0
 
-OS: mac, windows
+OS: windows
 
 Platforms: desktop
 
@@ -29,16 +28,12 @@ revVideoGrabDialog the label of button "Dialog Type"
 
 Parameters:
 settingsType (enum):
-
 -   compression: Settings for compression when recording video
 -   format: Video format, dimensions, and image depth
 -   display: Appearance of previewed video in the video grabber
--   source: Video input channels and hue, contrast, and saturation
-    settings 
--   video: Pops up the QT video compression choice dialog for the
-    videograbber 
--   audio: Pops up the QT audio compression choice dialog for the
-    videograbber 
+-   source: Video input channels and hue, contrast, and saturation settings 
+-   video: Pops up the video compression choice dialog for the videograbber 
+-   audio: Pops up the audio compression choice dialog for the videograbber 
 
 
 Description:
@@ -48,16 +43,8 @@ the <video grabber>.
 You must use the revInitializeVideoGrabber <command> to open the <video
 grabber> before you can use the <revVideoGrabDialog> <command>.
 
-If you specified "QT" as the video method when you executed the
-revInitializeVideoGrabber <command>, do not specify a <settingsType>.
-<QuickTime> video recording settings are found in a single <dialog box>,
-which you display with the following <statement> :
-
-    revVideoGrabDialog
-
-
-If you specified "VFW", use the <settingsType> <parameter> to specify
-which <dialog box> you want to show.
+Use the <settingsType> <parameter> to specify which <dialog box> you
+want to show.
 
 >*Note:* Some video camera drivers don't support some <settingsType>
 > values. 
@@ -76,9 +63,10 @@ The use of <QuickTime> was deprecated in version 8.1 of LiveCode with
 new defaults for <dontUseQT> and <dontUseQTEffects> as true on all
 systems apart from pre OS X 10.8. The Windows build of LiveCode no
 longer supports any <QuickTime> features and setting the <dontUseQT> and
-<dontUseQTEffects> will have no effect. Additionally <QuickTime> does 
-not include 64 bit support and therefore can not be supported on OS X 64
-bit builds of LiveCode.
+<dontUseQTEffects> will have no effect.
+
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revVideoGrabSettings (command), command (glossary),
 video capture (glossary), VFW (glossary),

--- a/docs/dictionary/command/revVideoGrabIdle.lcdoc
+++ b/docs/dictionary/command/revVideoGrabIdle.lcdoc
@@ -6,15 +6,17 @@ Syntax: revVideoGrabIdle
 
 Summary:
 Gives processing time to <QuickTime> during video previewing and
-recording. 
+recording.
 
 Associations: video library
 
 Introduced: 2.0
 
-OS: mac
+Deprecated: 9.0
 
-Platforms: desktop
+OS:
+
+Platforms:
 
 Security: disk, privacy
 
@@ -25,28 +27,7 @@ Example:
 send "revVideoGrabIdle" to me in 10 milliseconds
 
 Description:
-Use the <revVideoGrabIdle> <command> to avoid display problems during
-<video capture>.
-
-When using QuickTime for video capture, you need to execute the
-<revVideoGrabIdle> command periodically in order to let <QuickTime>
-update the display. (Not doing so may cause the video in the <video
-grabber> to stutter or display strange screen artifacts.) If you have
-issued the <revPreviewVideo> or <revRecordVideo> <command>, be sure to
-call the <revVideoGrabIdle> <command> periodically until you stop
-previewing or recording video.
-
-There is no specific interval to use between calls to
-<revVideoGrabIdle>. If you are seeing jittering or strange artifacts in
-the <video grabber> window, try decreasing the interval and calling
-<revVideoGrabIdle> more often.
-
->*Note:* If you specified "VFW" or "directx" as the video method when
-> you executed the <revInitializeVideoGrabber> <command>, you don't need
-> to call <revVideoGrabIdle>. If the <video capture> is using <VFW|Video
-> for Windows>, the <revVideoGrabIdle> <command> is ignored and has no
-> effect. You need to call <revVideoGrabIdle> only if you specified "QT"
-> as the video method.
+The <revVideoGrabIdle> <command> is ignored and has no effect.
 
 >*Important:*  The <revVideoGrabIdle> <command> is part of the 
 > <Video library>. To ensure that the <command> works in a 
@@ -62,9 +43,10 @@ The use of <QuickTime> was deprecated in version 8.1 of LiveCode with
 new defaults for <dontUseQT> and <dontUseQTEffects> as true on all
 systems apart from pre OS X 10.8. The Windows build of LiveCode no
 longer supports any <QuickTime> features and setting the <dontUseQT> and
-<dontUseQTEffects> will have no effect. Additionally <QuickTime> does 
-not include 64 bit support and therefore can not be supported on OS X 64
-bit builds of LiveCode.
+<dontUseQTEffects> will have no effect.
+
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revInitializeVideoGrabber (command),
 revPreviewVideo (command), revRecordVideo (command),

--- a/docs/dictionary/command/revVideoGrabSettings.lcdoc
+++ b/docs/dictionary/command/revVideoGrabSettings.lcdoc
@@ -8,21 +8,22 @@ Summary:
 Puts the current <video capture> settings, stored as <binary file|binary
 data>, into a <variable>.
 
+Associations: video library
+
 Introduced: 2.0
 
-OS: mac
+Deprecated: 9.0
+
+OS:
 
 Platforms: desktop
 
 Security: disk, privacy
 
 Example:
+local tSettings
 revVideoGrabSettings "tSettings"
-
-Example:
 set the savedVideoSettings of this card to tSettings
-
-Example:
 put tSettings into URL "binfile:/Data/Video Settings.dat"
 
 Parameters:
@@ -30,27 +31,8 @@ dataVariable:
 The name of an existing variable.
 
 Description:
-Use the <revVideoGrabSettings> command to store video-capture settings
-you specify in the video capture dialog box.
-
-The revVideoFrameImage command returns binary data, placing it in the
-<dataVariable>. 
-
-You specify settings for video capture in the video capture dialog box,
-which is displayed by the <revVideoGrabDialog> command. You can get the
-current settings with the <revVideoGrabSettings> command and restore
-them later with the revSetVideoGrabSettings command. This allows you to
-make changes to the video-capture settings under script control.
-
-The value returned by the <revVideoGrabSettings> command consists of
-binary data and is not human-readable, but you can store it in a file or
-custom property and restore your settings later using the
-revSetVideoGrabSettings command.
-
->*Important:*  The <revVideoGrabSettings> command works only for
-> QuickTime video capture. If you are capturing video with Video for
-> Windows, the <revVideoGrabSettings> command does not return a
-> meaningful value.
+The <revVideoGrabSettings> <command> is deprecated, and does not
+return a meaningful value.
 
 >*Important:*  The <revVideoGrabSettings> <command> is part of the 
 > <Video library>. To ensure that the <command> works in a 
@@ -66,9 +48,10 @@ The use of <QuickTime> was deprecated in version 8.1 of LiveCode with
 new defaults for <dontUseQT> and <dontUseQTEffects> as true on all
 systems apart from pre OS X 10.8. The Windows build of LiveCode no
 longer supports any <QuickTime> features and setting the <dontUseQT> and
-<dontUseQTEffects> will have no effect. Additionally <QuickTime> does 
-not include 64 bit support and therefore can not be supported on OS X 64
-bit builds of LiveCode.
+<dontUseQTEffects> will have no effect.
+
+Support for the "Video Grabber" library on Mac OS X ended in LiveCode
+9.0.
 
 References: revVideoGrabDialog (command),
 revSetVideoGrabSettings (command), binary file (glossary),

--- a/docs/notes/feature-no_mac_videograbber.md
+++ b/docs/notes/feature-no_mac_videograbber.md
@@ -1,0 +1,15 @@
+# revvideograbber end-of-life on Mac OS X
+
+The revvideograbber external depends on QuickTime in order to operate
+on Mac OS X.  On Mac OS X 10.9 and above, QuickTime is no longer
+available.
+
+The revvideograbber external remains available for use on Windows,
+using Video for Windows (DirectShow).
+
+The following revvideograbber commands are now deprecated and have no
+effect:
+
+- **revVideoGrabSettings**
+- **revSetVideoGrabSettings**
+- **revVideoGrabIdle**

--- a/revvideograbber/revvideograbber.gyp
+++ b/revvideograbber/revvideograbber.gyp
@@ -9,15 +9,9 @@
 		{
 			'target_name': 'external-revvideograbber',
 			'type': 'loadable_module',
-			'mac_bundle': 1,
 			'product_prefix': '',
 			'product_name': 'revvideograbber',
 
-			'variables':
-			{
-				'enable_revvideograbber%': '1',
-			},
-			
 			'dependencies':
 			[
 				'../libcore/libcore.gyp:libCore',
@@ -54,7 +48,7 @@
 			'conditions':
 			[
 				[
-					'(OS != "mac" and OS != "win") or enable_revvideograbber == 0',
+					'OS != "win"',
 					{
 						'type': 'none',
 						'mac_bundle': '0',
@@ -79,21 +73,7 @@
 					},
 				],
 				[
-					'OS == "mac" and enable_revvideograbber != 0',
-					{
-						'libraries':
-						[
-							'$(SDKROOT)/System/Library/Frameworks/Carbon.framework',
-							'$(SDKROOT)/System/Library/Frameworks/Cocoa.framework',
-							'$(SDKROOT)/System/Library/Frameworks/CoreVideo.framework',
-							'$(SDKROOT)/System/Library/Frameworks/QTKit.framework',
-							'$(SDKROOT)/System/Library/Frameworks/Quartz.framework',
-							'$(SDKROOT)/System/Library/Frameworks/QuickTime.framework',
-						],
-					},
-				],
-				[
-					'OS == "win" and enable_revvideograbber != 0',
+					'OS == "win"',
 					{
 						'include_dirs':
 						[
@@ -119,22 +99,6 @@
 					},
 				],
 			],
-			
-			'xcode_settings':
-			{
-				'INFOPLIST_FILE': 'rsrc/revvideograbber-Info.plist',
-				'EXPORTED_SYMBOLS_FILE': 'revvideograbber.exports',
-				
-				# The QuickTime support we need was dropped after 10.6. Correspondingly, it doesn't
-				# work when built for 64-bit either.
-				'SDKROOT': 'macosx10.6',
-				'ARCHS': 'i386',
-				
-				# Gyp adds "-x c++" to the build process, which is a problem as one of the .cpp files
-				# contains some Objective-C code. Changing it to .mm would be the obvious solution, but
-				# we also need to compile that file on Windows. Force using Objective-C++
-				'OTHER_CPLUSPLUSFLAGS': '-x objective-c++',
-			},
 		},
 	],
 }


### PR DESCRIPTION
revvideograbber for Mac OS X depends on QuickTime, which is not
available to build against when using the `macosx10.9` SDK (or newer).
In LiveCode 9, we will end support for Mac OS X 10.8 and earlier.  The
need to be able to build revvideograbber has been preventing from
using newer C++ language and standard library features, and has made
it difficult to get started with LiveCode engine development.

This patch discontinues revvideograbber for Mac, and updates all
revvideograbber documentation accordingly.  revvideograbber is still
supported on Windows, using DirectShow.  Some of its commands are no
longer useful, including `revVideoGrabSettings`,
`revSetVideoGrabSettings`, and `revVideoGrabIdle`.