### PR TITLE
docs: LC server `session` commands are not multimedia-related

### DIFF
--- a/docs/dictionary/command/start-session.lcdoc
+++ b/docs/dictionary/command/start-session.lcdoc
@@ -52,6 +52,3 @@ delete session (command), $_SESSION (keyword), sessionSavePath (property),
 sessionLifetime (property), sessionName (property),
 sessionId (property),
 property (glossary)
-
-Tags: multimedia
-

--- a/docs/dictionary/command/stop-session.lcdoc
+++ b/docs/dictionary/command/stop-session.lcdoc
@@ -27,6 +27,3 @@ The location where the $_SESSION array is stored is configured using the
 References: start session (command), delete session (command),
 sessionSavePath (property), sessionLifetime (property),
 sessionId (property), sessionName (property)
-
-Tags: multimedia
-


### PR DESCRIPTION
The `start session` and `stop session` commands mistakenly had
the "multimedia" documentation tag applied to them.