### PR TITLE
[CID 16689] Remove `MCObject::getname_cstring()`

### DIFF
--- a/engine/src/handler.h
+++ b/engine/src/handler.h
@@ -81,13 +81,6 @@ public:
 		return name;
 	}
 	
-	const char *getname_cstring(void)
-	{
-        char *t_name;
-        /* UNCHECKED */ MCStringConvertToCString(MCNameGetString(name), t_name);
-		return t_name;
-	}
-	
 	bool hasname(MCNameRef other_name)
 	{
 		return MCNameIsEqualTo(name, other_name, kMCCompareCaseless);

--- a/engine/src/mode_test.cpp
+++ b/engine/src/mode_test.cpp
@@ -226,10 +226,14 @@ public:
         MCAutoStringRef t_label;
         if (!ctxt . EvalOptionalExprAsStringRef(m_label, kMCEmptyString, EE_PARAM_BADSOURCE, &t_label))
             return;
+
+        MCAutoStringRefAsCString t_name;
+        if (!t_name.Lock(MCNameGetString(MCdefaultstackptr->getname())))
+            return;
         
         if (m_abort)
         {
-            MCTestDoAbort(MCStringGetCString(*t_label), MCdefaultstackptr -> getname_cstring(), line, true);
+            MCTestDoAbort(MCStringGetCString(*t_label), *t_name, line, true);
             return;
         }
         
@@ -238,9 +242,9 @@ public:
             return;
         
         if (m_type == TYPE_FALSE)
-            MCTestDoAssertTrue(MCStringGetCString(*t_label), t_value, MCdefaultstackptr -> getname_cstring(), line, true);
+            MCTestDoAssertTrue(MCStringGetCString(*t_label), t_value, *t_name, line, true);
         else
-            MCTestDoAssertFalse(MCStringGetCString(*t_label), t_value, MCdefaultstackptr -> getname_cstring(), line, true);
+            MCTestDoAssertFalse(MCStringGetCString(*t_label), t_value, *t_name, line, true);
     }
     
 private:
@@ -490,15 +494,13 @@ bool MCModeHandleMessageBoxChanged(MCExecContext& ctxt, MCStringRef)
 }
 
 // The standalone mode causes a relaunch message.
-bool MCModeHandleRelaunch(const char *& r_id)
+bool MCModeHandleRelaunch(MCStringRef& r_id)
 {
 #ifdef _WINDOWS
 	bool t_do_relaunch;
-	const char *t_id;
 
 	t_do_relaunch = MCdefaultstackptr -> hashandler(HT_MESSAGE, MCM_relaunch) == True;
-	t_id = MCdefaultstackptr -> getname_cstring();
-	r_id = t_id;
+	r_id = MCNameGetString(getname());
 
 	return t_do_relaunch;
 #else

--- a/engine/src/mode_test.cpp
+++ b/engine/src/mode_test.cpp
@@ -500,7 +500,7 @@ bool MCModeHandleRelaunch(MCStringRef& r_id)
 	bool t_do_relaunch;
 
 	t_do_relaunch = MCdefaultstackptr -> hashandler(HT_MESSAGE, MCM_relaunch) == True;
-	r_id = MCNameGetString(getname());
+	r_id = MCValueRetain(MCNameGetString(getname()));
 
 	return t_do_relaunch;
 #else

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -364,8 +364,9 @@ void MCObject::setname(MCNameRef p_new_name)
 
 void MCObject::setname_cstring(const char *p_new_name)
 {
-	MCNameDelete(_name);
-	/* UNCHECKED */ MCNameCreateWithCString(p_new_name, _name);
+	MCNewAutoNameRef t_name;
+	/* UNCHECKED */ MCNameCreateWithCString(p_new_name, &t_name);
+	setname(*t_name);
 }
 
 void MCObject::setscript(MCStringRef p_script)
@@ -3177,11 +3178,10 @@ IO_stat MCObject::load(IO_handle stream, uint32_t version)
 		return checkloadstat(stat);
 	
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-	MCNameRef t_name;
-	if ((stat = IO_read_nameref_new(t_name, stream, version >= kMCStackFileFormatVersion_7_0)) != IO_NORMAL)
+	MCNewAutoNameRef t_name;
+	if ((stat = IO_read_nameref_new(&t_name, stream, version >= kMCStackFileFormatVersion_7_0)) != IO_NORMAL)
 		return checkloadstat(stat);
-	MCNameDelete(_name);
-	_name = t_name;
+	setname(*t_name);
 
 	if ((stat = IO_read_uint4(&flags, stream)) != IO_NORMAL)
 		return checkloadstat(stat);
@@ -3501,7 +3501,7 @@ IO_stat MCObject::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_
 		return stat;
 	
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] If sfv >= 7000, use unicode.
-	if ((stat = IO_write_nameref_new(_name, stream, p_version >= kMCStackFileFormatVersion_7_0)) != IO_NORMAL)
+	if ((stat = IO_write_nameref_new(getname(), stream, p_version >= kMCStackFileFormatVersion_7_0)) != IO_NORMAL)
 		return stat;
 
 	if (!MCStringIsEmpty(_script))

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -902,12 +902,14 @@ Boolean MCObject::del(bool p_check_flag)
 
 void MCObject::paste(void)
 {
-	fprintf(stderr, "Object: ERROR tried to paste %s\n", getname_cstring());
+	MCLog("Object: tried to paste %@", getname());
+	MCUnreachable();
 }
 
 void MCObject::undo(Ustruct *us)
 {
-	fprintf(stderr, "Object: ERROR tried to undo %s\n", getname_cstring());
+	MCLog("Object:: tried to paste %@", getname());
+	MCUnreachable();
 }
 
 void MCObject::freeundo(Ustruct *us)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -102,10 +102,10 @@ MCColor MCObject::maccolors[MAC_NCOLORS] = {
         };
 
 MCObject::MCObject()
+    : _name(kMCEmptyName)
 {
 	parent = nil;
 	obj_id = 0;
-	/* UNCHECKED */ MCNameClone(kMCEmptyName, _name);
 	flags = F_VISIBLE | F_SHOW_BORDER | F_3D | F_OPAQUE;
 	fontheight = 0;
 	dflags = 0;
@@ -173,14 +173,14 @@ MCObject::MCObject()
     MCDeletedObjectsOnObjectCreated(this);
 }
 
-MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
+MCObject::MCObject(const MCObject &oref)
+    : MCDLlist(oref),
+      _name(oref._name)
 {
 	if (!oref.parent)
 		parent = MCdefaultstackptr;
 	else
 		parent = oref.parent;
-	
-	/* UNCHECKED */ MCNameClone(oref . getname(), _name);
 	
 	obj_id = 0;
 	rect = oref.rect;
@@ -303,7 +303,6 @@ MCObject::~MCObject()
 	removefrom(MCbackscripts);
 	MCundos->freeobject(this);
 	delete hlist;
-	MCNameDelete(_name);
 	delete[] colors; /* Allocated with new[] */
 	if (colornames != nil)
 	{
@@ -358,8 +357,7 @@ bool MCObject::hasname(MCNameRef p_other_name)
 
 void MCObject::setname(MCNameRef p_new_name)
 {
-	MCNameDelete(_name);
-	/* UNCHECKED */ MCNameClone(p_new_name, _name);
+	_name.Reset(p_new_name);
 }
 
 void MCObject::setname_cstring(const char *p_new_name)

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -801,7 +801,7 @@ public:
 	// Returns true if the object has not been named.
 	bool isunnamed(void) const
 	{
-		return MCNameIsEmpty(_name);
+		return MCNameIsEmpty(getname());
 	}
 
 	// Returns the name of the object.
@@ -813,7 +813,7 @@ public:
 	const char *getname_cstring(void) const
 	{
         char *t_name;
-        /* UNCHECKED */ MCStringConvertToCString(MCNameGetString(_name), t_name);
+        /* UNCHECKED */ MCStringConvertToCString(MCNameGetString(getname()), t_name);
 		return t_name;
 	}
 

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -810,13 +810,6 @@ public:
 		return *_name;
 	}
 
-	const char *getname_cstring(void) const
-	{
-        char *t_name;
-        /* UNCHECKED */ MCStringConvertToCString(MCNameGetString(getname()), t_name);
-		return t_name;
-	}
-
     /*
 	MCString getname_oldstring(void) const
 	{

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -515,7 +515,7 @@ class MCObject :
 protected:
 	uint4 obj_id;
 	MCObjectHandle parent;
-	MCNameRef _name;
+	MCNewAutoNameRef _name;
 	uint4 flags;
 	MCRectangle rect;
 	MCColor *colors;
@@ -807,7 +807,7 @@ public:
 	// Returns the name of the object.
 	MCNameRef getname(void) const
 	{
-		return _name;
+		return *_name;
 	}
 
 	const char *getname_cstring(void) const

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -838,7 +838,7 @@ public:
 	{
 		if (!MCStringIsEmpty(title))
 			return title;
-		return MCNameGetString(_name);
+		return MCNameGetString(getname());
 	}
 	MCControl *getcontrols()
 	{

--- a/engine/src/w32stack.cpp
+++ b/engine/src/w32stack.cpp
@@ -308,10 +308,7 @@ void MCStack::setopacity(uint1 p_level)
 			Bool t_is_xp_menu;
 			t_is_xp_menu = (mode == WM_PULLDOWN || mode == WM_POPUP || mode == WM_CASCADE) && (MCcurtheme && MCcurtheme->getthemeid() == LF_NATIVEWIN);
 
-			if (!t_is_xp_menu && mode < WM_PULLDOWN)
-				window -> handle . window = (MCSysWindowHandle)CreateWindowExW(t_ex_style, MC_WIN_CLASS_NAME_W, WideCString(getname_cstring()), t_style | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, t_rect . left, t_rect . top, t_rect . right - t_rect . left, t_rect . bottom - t_rect . top, NULL, NULL, MChInst, NULL);
-			else
-				window -> handle . window = (MCSysWindowHandle)CreateWindowExA(t_ex_style, t_is_xp_menu ? MC_MENU_WIN_CLASS_NAME : mode >= WM_PULLDOWN ? MC_POPUP_WIN_CLASS_NAME : MC_WIN_CLASS_NAME, getname_cstring(), t_style | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, t_rect . left, t_rect . top, t_rect . right - t_rect . left, t_rect . bottom - t_rect . top, NULL, NULL, MChInst, NULL);
+            window -> handle . window = (MCSysWindowHandle)CreateWindowExW(t_ex_style, MC_WIN_CLASS_NAME_W, WideCString(getname_cstring()), t_style | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, t_rect . left, t_rect . top, t_rect . right - t_rect . left, t_rect . bottom - t_rect . top, NULL, NULL, MChInst, NULL);
 			
 			// MW-2010-10-22: [[ Bug 8151 ]] Make sure we update the title string.
 			MCscreen -> setname(window, titlestring);
@@ -429,14 +426,7 @@ void MCStack::realize()
 
 		HWND t_parenthwnd = NULL;
 
-		// MW-2007-07-06: [[ Bug 3226 ]] If the platform is NT always create a Unicode window
-		if ((MCruntimebehaviour & RTB_NO_UNICODE_WINDOWS) == 0 && !isxpmenu && mode < WM_PULLDOWN)
-			window -> handle . window = (MCSysWindowHandle)CreateWindowExW(exstyle, MC_WIN_CLASS_NAME_W, WideCString(getname_cstring()),wstyle | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, width, height,
-		                 t_parenthwnd, NULL, MChInst, NULL);
-		else
-			window->handle.window = (MCSysWindowHandle)CreateWindowExA(exstyle, isxpmenu? MC_MENU_WIN_CLASS_NAME: mode >= WM_PULLDOWN ? MC_POPUP_WIN_CLASS_NAME
-		                 : MC_WIN_CLASS_NAME, getname_cstring(), wstyle | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, width, height,
-		                 t_parenthwnd, NULL, MChInst, NULL);
+        window -> handle . window = (MCSysWindowHandle)CreateWindowExW(exstyle, MC_WIN_CLASS_NAME_W, WideCString(getname_cstring()),wstyle | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, width, height, t_parenthwnd, NULL, MChInst, NULL);
 
 		SetWindowLongA((HWND)window->handle.window, GWL_USERDATA, mode);
 		

--- a/engine/src/w32stack.cpp
+++ b/engine/src/w32stack.cpp
@@ -308,7 +308,9 @@ void MCStack::setopacity(uint1 p_level)
 			Bool t_is_xp_menu;
 			t_is_xp_menu = (mode == WM_PULLDOWN || mode == WM_POPUP || mode == WM_CASCADE) && (MCcurtheme && MCcurtheme->getthemeid() == LF_NATIVEWIN);
 
-            window -> handle . window = (MCSysWindowHandle)CreateWindowExW(t_ex_style, MC_WIN_CLASS_NAME_W, WideCString(getname_cstring()), t_style | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, t_rect . left, t_rect . top, t_rect . right - t_rect . left, t_rect . bottom - t_rect . top, NULL, NULL, MChInst, NULL);
+            MCAutoStringRefAsWString t_window_name;
+            /* UNCHECKED */ t_window_name.Lock(MCNameGetString(getname()));
+            window -> handle . window = (MCSysWindowHandle)CreateWindowExW(t_ex_style, MC_WIN_CLASS_NAME_W, *t_window_name, t_style | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, t_rect . left, t_rect . top, t_rect . right - t_rect . left, t_rect . bottom - t_rect . top, NULL, NULL, MChInst, NULL);
 			
 			// MW-2010-10-22: [[ Bug 8151 ]] Make sure we update the title string.
 			MCscreen -> setname(window, titlestring);
@@ -426,7 +428,10 @@ void MCStack::realize()
 
 		HWND t_parenthwnd = NULL;
 
-        window -> handle . window = (MCSysWindowHandle)CreateWindowExW(exstyle, MC_WIN_CLASS_NAME_W, WideCString(getname_cstring()),wstyle | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, width, height, t_parenthwnd, NULL, MChInst, NULL);
+        MCAutoStringRefAsWString t_window_name;
+        /* UNCHECKED */ t_window_name.Lock(MCNameGetString(getname()));
+        window -> handle . window = (MCSysWindowHandle)CreateWindowExW(exstyle, MC_WIN_CLASS_NAME_W, *t_window_name, wstyle | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, width, height,
+                                                                       t_parenthwnd, NULL, MChInst, NULL);
 
 		SetWindowLongA((HWND)window->handle.window, GWL_USERDATA, mode);
 		


### PR DESCRIPTION
Coverity Scan detected that every call to `MCObject::getname_cstring()` was creating a new C string buffer and leaking it.  This patch ensures that:

- to the greatest extent possible, `MCObject::_name` is now accessed only via `MCObject::getname()` and `MCObject::setname()`
- `MCObject::_name` has a managed lifetime by making it an `MCNewAutoNameRef`
- `MCObject::getname_cstring()` is completely removed
