### PR TITLE
[[ Bug 19017 ]] Fix crash when deleting moving object

### DIFF
--- a/docs/notes/bugfix-19017.md
+++ b/docs/notes/bugfix-19017.md
@@ -1,0 +1,2 @@
+# Fix crash when deleting object which is being moved
+

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1420,11 +1420,14 @@ bool MCUIDC::listmoves(MCExecContext& ctxt, MCListRef& r_list)
 		MCMovingList *mptr = moving;
 		do
 		{
-			MCAutoValueRef t_string;
-			if (!mptr->object->names(P_LONG_ID, &t_string))
-				return false;
-			if (!MCListAppend(*t_list, *t_string))
-				return false;
+            if (mptr->object)
+            {
+                MCAutoValueRef t_string;
+                if (!mptr->object->names(P_LONG_ID, &t_string))
+                    return false;
+                if (!MCListAppend(*t_list, *t_string))
+                    return false;
+            }
 			mptr = mptr->next();
 		}
 		while (mptr != moving);
@@ -1439,7 +1442,7 @@ void MCUIDC::stopmove(MCObject *optr, Boolean finish)
 		MCMovingList *mptr = moving;
 		do
 		{
-			if (mptr->object == optr)
+			if (mptr->object.IsBoundTo(optr))
 			{
 				mptr->remove(moving);
 				if (finish)
@@ -1455,7 +1458,7 @@ void MCUIDC::stopmove(MCObject *optr, Boolean finish)
 
 						// MW-2011-08-18: [[ Layers ]] Notify of position change.
 						if (mptr->object -> gettype() >= CT_GROUP)
-							static_cast<MCControl *>(mptr->object)->layer_setrect(newrect, false);
+							mptr->object.GetAs<MCControl>()->layer_setrect(newrect, false);
 						else
 							mptr->object->setrect(newrect);
 					}
@@ -1479,34 +1482,46 @@ void MCUIDC::handlemoves(real8 &curtime, real8 &eventtime)
 	Boolean done = False;
 	do
 	{
-		MCRectangle rect = mptr->object->getrect();
-		MCRectangle newrect = rect;
-		real8 dt = 0.0;
-		if (curtime >= mptr->starttime + mptr->duration
-		        || rect.x == mptr->donex && rect.y == mptr->doney)
-		{
-			newrect.x = mptr->donex;
-			newrect.y = mptr->doney;
-			dt = curtime - (mptr->starttime + mptr->duration);
-			done = True;
-		}
-		else
-		{
-			newrect.x = mptr->pts[mptr->curpt].x - (rect.width >> 1)
-			            + (int2)(mptr->dx * (curtime - mptr->starttime) / mptr->duration);
-			newrect.y = mptr->pts[mptr->curpt].y - (rect.height >> 1)
-			            + (int2)(mptr->dy * (curtime - mptr->starttime) / mptr->duration);
-		}
-		if (newrect.x != rect.x || newrect.y != rect.y)
-		{
-			moved = True;
-		
-			// MW-2011-08-18: [[ Layers ]] Notify of position change.
-			if (mptr->object -> gettype() >= CT_GROUP)
-				static_cast<MCControl *>(mptr->object)->layer_setrect(newrect, false);
-			else
-				mptr->object->setrect(newrect);
-		}
+        if (!mptr->object)
+        {
+            moving = mptr->prev();
+            mptr->remove(moving);
+            delete mptr;
+            if (moving == NULL)
+                mptr = NULL;
+            else
+                mptr = moving->next();
+            continue;
+        }
+        
+        MCRectangle rect = mptr->object->getrect();
+        MCRectangle newrect = rect;
+        real8 dt = 0.0;
+        if (curtime >= mptr->starttime + mptr->duration
+                || rect.x == mptr->donex && rect.y == mptr->doney)
+        {
+            newrect.x = mptr->donex;
+            newrect.y = mptr->doney;
+            dt = curtime - (mptr->starttime + mptr->duration);
+            done = True;
+        }
+        else
+        {
+            newrect.x = mptr->pts[mptr->curpt].x - (rect.width >> 1)
+                        + (int2)(mptr->dx * (curtime - mptr->starttime) / mptr->duration);
+            newrect.y = mptr->pts[mptr->curpt].y - (rect.height >> 1)
+                        + (int2)(mptr->dy * (curtime - mptr->starttime) / mptr->duration);
+        }
+        if (newrect.x != rect.x || newrect.y != rect.y)
+        {
+            moved = True;
+        
+            // MW-2011-08-18: [[ Layers ]] Notify of position change.
+            if (mptr->object -> gettype() >= CT_GROUP)
+                mptr->object.GetAs<MCControl>()->layer_setrect(newrect, false);
+            else
+                mptr->object->setrect(newrect);
+        }
 		if (done)
 		{
 			if (mptr->curpt < mptr->lastpt - 1)

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -24,6 +24,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "filedefs.h"
 #include "graphics.h"
 #include "imagebitmap.h"
+#include "object.h"
 
 enum
 {
@@ -176,7 +177,7 @@ typedef void *MCColorTransformRef;
 class MCMovingList : public MCDLlist
 {
 public:
-	MCObject *object;
+	MCObjectHandle object;
 	MCPoint *pts;
 	uint2 lastpt;
 	uint2 curpt;


### PR DESCRIPTION
If an object is deleted after it has completed moving but before
it is send a 'moveStopped' message then a invalid object handle
will be dereferenced.

This patch replaces the use of bare MCObject* ptrs in MCMovingList
with MCObjectHandle.