### PR TITLE
[CID 139074] Ensure MCStackList's constructor initialises all fields

### DIFF
--- a/engine/src/stacklst.cpp
+++ b/engine/src/stacklst.cpp
@@ -45,6 +45,7 @@ MCStack *MCStacknode::getstack()
 }
 
 MCStacklist::MCStacklist(bool p_manage_topstack)
+    : restart(False)
 {
 	stacks = NULL;
 	menus = NULL;


### PR DESCRIPTION
Ensure the `MCStackList::restart` field gets initialised.

Coverity-ID: 139074