### PR TITLE
[CID 137928] Prevent Coverity warning by explicit initialisation

### DIFF
--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1576,7 +1576,7 @@ void EmitEndArrayConstant(long *idx)
 class __opcode_index
 {
 public:
-    __opcode_index(const char *p_name)
+    __opcode_index(const char *p_name) : m_index(0)
     {
         if (!MCScriptLookupBytecode(p_name, m_index))
         {


### PR DESCRIPTION
Coverity Scan was a little confused by attempting to analyse the
behaviour of `MCScriptLookupByteCode()`, and suggests that
`__opcode_index::m_index` might not get initialized.  This patch makes
sure that `m_index` _definitely_ gets initialized by putting it in the
initializer list.

Coverity-ID: 137928