### PR TITLE
Some Coverity fixes that use MCAutoPointer

### DIFF
--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -94,10 +94,13 @@ struct __MCTypeInfo: public __MCValue
         } record;
         struct
         {
+            /* forward declaration, to avoid including FFI header here */
+            typedef struct _ffi_type ffi_type;
+
             MCHandlerTypeFieldInfo *fields;
             uindex_t field_count;
             MCTypeInfoRef return_type;
-            void **layout_args;
+            ffi_type** layout_args;
             MCHandlerTypeLayout *layouts;
         } handler;
         struct


### PR DESCRIPTION
These Coverity fixes make use of the upgrades to `MCAutoPointer` in #5019.  It should be merged after #5019 has been reviewed and merged.