### PR TITLE
Tweak regexp cache random removal to use a pointer hash

### DIFF
--- a/engine/src/regex.cpp
+++ b/engine/src/regex.cpp
@@ -376,7 +376,7 @@ regexp *MCR_compile(MCStringRef exp, bool casesensitive)
 		// If we don't have a free slot, evict a randomish one.
 		if (t_last_free == -1)
 		{
-			t_last_free = (uintptr_t(exp) >> 2) % PATTERN_CACHE_SIZE;
+			t_last_free = MCHashPointer(exp) % PATTERN_CACHE_SIZE;
 			MCR_free(MCregexcache[t_last_free]);
 		}
 		


### PR DESCRIPTION
Each platform we support uses a slightly different standard library
`new` and `delete` implementation, with different minimum allocation
chunk sizes.  For example, the smallest heap chunks handed out by
`libstdc++` are 16 bytes, meaning that any heap pointer will have its
lowest 4 bits cleared.

Avoid worrying about this entirely by hashing each newly-allocated
`regexp*` and using the hashed value to choose an appropriate cache
entry for eviction.