### PR TITLE
libfoundation: Convert MCSpan to standard iterators

### DIFF
--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -176,12 +176,11 @@ MCEngineCheckModulesHaveNamePrefix(MCNameRef p_prefix,
           MCStringAppendChar(*t_prefix, '.')))
         return false;
 
-    while (!p_modules.empty())
+    for (MCScriptModuleRef t_iter : p_modules)
     {
-        if (!MCStringBeginsWith(MCNameGetString(MCScriptGetNameOfModule(*p_modules)),
+        if (!MCStringBeginsWith(MCNameGetString(MCScriptGetNameOfModule(t_iter)),
                                 *t_prefix, kMCStringOptionCompareCaseless))
             return false;
-        ++p_modules;
     }
     return true;
 }

--- a/engine/src/gradient.cpp
+++ b/engine/src/gradient.cpp
@@ -747,17 +747,17 @@ IO_stat MCGradientFillUnserialize(MCGradientFill *p_gradient, MCObjectInputStrea
 
 template <typename IntType>
 static IntType
-MCGradientFillUnserializeInt(MCSpan<const byte_t>& p_data)
+MCGradientFillUnserializeInt(MCSpan<byte_t>::const_iterator& p_data)
 {
 	IntType t_value;
-	MCAssert(size_t(p_data.size()) >= sizeof(t_value));
-	MCMemoryCopy(&t_value, p_data.data(), sizeof(t_value));
-	p_data += sizeof(t_value);
+    const byte_t &t_data = *p_data;
+    p_data += sizeof(t_value);
+	MCMemoryCopy(&t_value, &t_data, sizeof(t_value));
 	return MCSwapIntHostToNetwork(t_value);
 }
 
 static MCPoint
-MCGradientFillUnserializePoint(MCSpan<const byte_t>& p_data)
+MCGradientFillUnserializePoint(MCSpan<byte_t>::const_iterator& p_data)
 {
 	MCPoint t_point;
 	t_point.x = MCGradientFillUnserializeInt<int16_t>(p_data);
@@ -767,7 +767,8 @@ MCGradientFillUnserializePoint(MCSpan<const byte_t>& p_data)
 
 void MCGradientFillUnserialize(MCGradientFill *p_gradient, uint1 *p_data, uint4 &r_length)
 {
-	MCSpan<const byte_t> t_ptr(p_data, r_length);
+    MCSpan<byte_t> t_span(p_data, r_length);
+    MCSpan<byte_t>::const_iterator t_ptr = t_span.cbegin();
 
 	uint1 t_packed = *t_ptr++;
 	p_gradient->kind = t_packed >> 4;
@@ -794,5 +795,5 @@ void MCGradientFillUnserialize(MCGradientFill *p_gradient, uint1 *p_data, uint4 
 		if (p_gradient->ramp[i].offset != p_gradient->ramp[i - 1].offset)
 			p_gradient->ramp[i - 1].difference = STOP_DIFF_MULT / (p_gradient->ramp[i].offset - p_gradient->ramp[i - 1].offset);
 
-	r_length = t_ptr.size();
+	r_length = t_span.cend() - t_ptr;
 }

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1124,11 +1124,11 @@ __join_paths(MCSpan<MCNameRef> p_base,
             new (nothrow) MCNameRef[p_base.size() + p_extra.size()];
     if (t_result)
     {
-        for(int i = 0; i < p_base.size(); i++)
-            t_result[i] = p_base[i];
-    
-        for(int i = 0; i < p_extra.size(); i++)
-            t_result[i + p_base.size()] = p_extra[i];
+        int t_count = 0;
+        for (MCNameRef t_name : p_base)
+            t_result[t_count++] = t_name;
+        for (MCNameRef t_name : p_extra)
+            t_result[t_count++] = t_name;
     }
     
     return std::move(t_result);

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -76,7 +76,7 @@ public:
     typedef typename std::conditional<IsConst,
                                       const element_type_,
                                       element_type_>::type & reference;
-    typedef typename std::add_pointer<reference> pointer;
+    typedef typename std::add_pointer<reference>::type pointer;
 
     /* The const version of this MCSpanIterator type should be a
      * friend so that its fields are accessible.  N.b. the converse is
@@ -320,22 +320,22 @@ public:
                    p_count == kMCSpanDynamicExtent ? size() - p_offset : p_count);
 	}
 
-	constexpr MCSpan operator+(index_type p_offset) const
+    [[deprecated]] constexpr MCSpan operator+(index_type p_offset) const
 	{
 		return subspan(p_offset);
 	}
 
-	MCSpan& operator+=(index_type p_offset)
+	[[deprecated]] MCSpan& operator+=(index_type p_offset)
 	{
 		return advance(p_offset);
 	}
 
 	/* ---------- Pointer arithmetic */
-	MCSpan& operator++()
+	[[deprecated]] MCSpan& operator++()
 	{
 		return advance(1);
 	}
-	MCSpan operator++(int)
+	[[deprecated]] MCSpan operator++(int)
 	{
 		auto t_ret = *this;
 		++(*this);
@@ -397,7 +397,7 @@ protected:
 };
 
 template <typename ElementType>
-constexpr MCSpan<ElementType>
+[[deprecated]] constexpr MCSpan<ElementType>
 operator+(typename MCSpan<ElementType>::index_type n,
           const MCSpan<ElementType>& rhs)
 {

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -59,15 +59,15 @@ template <typename ElementType>
 class MCSpan
 {
 public:
-	typedef std::ptrdiff_t IndexType;
-	typedef ElementType* ElementPtr;
-	typedef ElementType& ElementRef;
-	typedef ElementType&& ElementRRef;
+    typedef ElementType element_type;
+	typedef std::ptrdiff_t index_type;
+	typedef element_type* pointer;
+	typedef element_type& reference;
 
 	/* ---------- Constructors */
 	constexpr MCSpan() = default;
 	constexpr MCSpan(decltype(nullptr)) {}
-	constexpr MCSpan(ElementPtr p_ptr, IndexType p_count)
+	constexpr MCSpan(pointer p_ptr, index_type p_count)
 		: m_data(p_ptr), m_length(p_count) {}
 
 	template <size_t N>
@@ -86,20 +86,20 @@ public:
 	MCSpan& operator=(MCSpan&& other) = default;
 
 	/* ---------- Subspans */
-	constexpr MCSpan first(IndexType p_count) const
+	constexpr MCSpan first(index_type p_count) const
 	{
         return MCAssert(p_count >= 0 && p_count <= size()),
             MCSpan(data(), p_count);
 	}
 
-	constexpr MCSpan last(IndexType p_count) const
+	constexpr MCSpan last(index_type p_count) const
 	{
         return MCAssert(p_count >= 0 && p_count <= size()),
             MCSpan(data() + (size() - p_count), p_count);
 	}
 
-	constexpr MCSpan subspan(IndexType p_offset,
-	                               IndexType p_count = kMCSpanDynamicExtent) const
+	constexpr MCSpan subspan(index_type p_offset,
+	                               index_type p_count = kMCSpanDynamicExtent) const
 	{
         return
             MCAssert(p_offset == 0 || (p_offset > 0 && p_offset <= size())),
@@ -109,12 +109,12 @@ public:
                    p_count == kMCSpanDynamicExtent ? size() - p_offset : p_count);
 	}
 
-	constexpr MCSpan operator+(IndexType p_offset) const
+	constexpr MCSpan operator+(index_type p_offset) const
 	{
 		return subspan(p_offset);
 	}
 
-	MCSpan& operator+=(IndexType p_offset)
+	MCSpan& operator+=(index_type p_offset)
 	{
 		return advance(p_offset);
 	}
@@ -132,35 +132,35 @@ public:
 	}
 
 	/* ---------- Observers */
-	constexpr IndexType length() const { return size(); }
-	constexpr IndexType size() const { return m_length; }
-	constexpr IndexType lengthBytes() const { return sizeBytes(); }
-	constexpr IndexType sizeBytes() const
+	constexpr index_type length() const { return size(); }
+	constexpr index_type size() const { return m_length; }
+	constexpr index_type lengthBytes() const { return sizeBytes(); }
+	constexpr index_type sizeBytes() const
 	{
 		return m_length * sizeof(ElementType);
 	}
 	constexpr bool empty() const { return size() == 0; }
 
 	/* ---------- Element access */
-	constexpr ElementRef operator[](IndexType p_index) const
+	constexpr reference operator[](index_type p_index) const
 	{
         return MCAssert(p_index >= 0 && p_index < size()),
             data()[p_index];
 	}
-	constexpr ElementRef operator*() const
+	constexpr reference operator*() const
 	{
 		return (*this)[0];
 	}
-	constexpr ElementPtr operator->() const
+	constexpr pointer operator->() const
 	{
 		return &((*this)[0]);
 	}
 
-	constexpr ElementPtr data() const { return m_data; }
+	constexpr pointer data() const { return m_data; }
 
 protected:
 
-	MCSpan& advance(IndexType p_offset)
+	MCSpan& advance(index_type p_offset)
 	{
 		MCAssert(p_offset == 0 || (p_offset > 0 && p_offset <= size()));
 		m_data += p_offset;
@@ -168,13 +168,13 @@ protected:
 		return *this;
 	}
 
-	ElementPtr m_data = nullptr;
-	IndexType m_length = 0;
+	pointer m_data = nullptr;
+	index_type m_length = 0;
 };
 
 template <typename ElementType>
 constexpr MCSpan<ElementType>
-operator+(typename MCSpan<ElementType>::IndexType n,
+operator+(typename MCSpan<ElementType>::index_type n,
           const MCSpan<ElementType>& rhs)
 {
 	return rhs + n;
@@ -191,7 +191,7 @@ MCMakeSpan(ElementType (&arr)[N])
 template <typename ElementType>
 constexpr MCSpan<ElementType>
 MCMakeSpan(ElementType *p_ptr,
-           typename MCSpan<ElementType>::IndexType p_count)
+           typename MCSpan<ElementType>::index_type p_count)
 {
 	return MCSpan<ElementType>(p_ptr, p_count);
 }

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -320,28 +320,6 @@ public:
                    p_count == kMCSpanDynamicExtent ? size() - p_offset : p_count);
 	}
 
-    [[deprecated]] constexpr MCSpan operator+(index_type p_offset) const
-	{
-		return subspan(p_offset);
-	}
-
-	[[deprecated]] MCSpan& operator+=(index_type p_offset)
-	{
-		return advance(p_offset);
-	}
-
-	/* ---------- Pointer arithmetic */
-	[[deprecated]] MCSpan& operator++()
-	{
-		return advance(1);
-	}
-	[[deprecated]] MCSpan operator++(int)
-	{
-		auto t_ret = *this;
-		++(*this);
-		return t_ret;
-	}
-
 	/* ---------- Observers */
 	constexpr index_type length() const { return size(); }
 	constexpr index_type size() const { return m_length; }
@@ -395,14 +373,6 @@ protected:
 	pointer m_data = nullptr;
 	index_type m_length = 0;
 };
-
-template <typename ElementType>
-[[deprecated]] constexpr MCSpan<ElementType>
-operator+(typename MCSpan<ElementType>::index_type n,
-          const MCSpan<ElementType>& rhs)
-{
-	return rhs + n;
-}
 
 /* TODO[C++17] Remove when we have class and struct template type inference */
 template<typename ElementType, size_t N>

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -46,64 +46,64 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
                             MCSpan<const char>& r_remainder)
 {
 	done = false;
-	p_chars = skip_spaces(p_chars);
-	if (p_chars.empty())
+	MCSpan<const char> t_chars = skip_spaces(p_chars);
+	if (t_chars.empty())
 		return 0;
 	bool negative = false;
 	integer_t value = 0;
-	if (*p_chars == '-' || *p_chars == '+')
+	if (*t_chars == '-' || *t_chars == '+')
 	{
-		negative = *p_chars == '-';
-		++p_chars;
+		negative = *t_chars == '-';
+		++t_chars;
 	}
-	if (p_chars.empty())
+	if (t_chars.empty())
 		return 0;
-	uinteger_t startlength = p_chars.size();
+	uinteger_t startlength = t_chars.size();
 	uint16_t base = 10;
-	if (!p_chars.empty() && *p_chars == '0')
+	if (!t_chars.empty() && *t_chars == '0')
     {
-	    if (p_chars.size() > 2 && MCNativeCharFold(*(p_chars + 1)) == 'x')
+	    if (t_chars.size() > 2 && MCNativeCharFold(*(t_chars + 1)) == 'x')
 		{
 			base = 16;
-			p_chars += 2;
+			t_chars += 2;
 		}
 		else
         {
 			if (octals)
 			{
 				base = 8;
-				p_chars += 1;
+				t_chars += 1;
 			}
         }
     }
-	while (!p_chars.empty())
+	while (!t_chars.empty())
 	{
-		if (isdigit((uint8_t)*p_chars))
+		if (isdigit((uint8_t)*t_chars))
 		{
-			integer_t v = *p_chars - '0';
+			integer_t v = *t_chars - '0';
 			if (base < 16 && value > INTEGER_MAX / base - v)  // prevent overflow
 				return 0;
 			value *= base;
 			value += v;
 		}
 		else
-			if (isspace((uint8_t)*p_chars))
+			if (isspace((uint8_t)*t_chars))
 			{
-				p_chars = skip_spaces(p_chars);
-				if (!p_chars.empty() && *p_chars == c)
+				t_chars = skip_spaces(t_chars);
+				if (!t_chars.empty() && *t_chars == c)
 				{
-					++p_chars;
+					++t_chars;
 				}
 				break;
 			}
 			else
-				if (!p_chars.empty() && c && *p_chars == c)
+				if (!t_chars.empty() && c && *t_chars == c)
 				{
-					++p_chars;
+					++t_chars;
 					break;
 				}
 				else
-					if (*p_chars == '.')
+					if (*t_chars == '.')
 					{
 						if (startlength > 1)
 						{
@@ -111,27 +111,27 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
 							{
 								// MDW-2013-06-09: [[ Bug 10964 ]] Round integral values to nearest
 								//   (consistent with getuint4() and round()).
-								if (*(p_chars+1) > '4')
+								if (*(t_chars+1) > '4')
 								{
 									value++;
 								}
 								do
 								{
-									++p_chars;
+									++t_chars;
 								}
-								while (!p_chars.empty() && isdigit((uint8_t)*p_chars));
+								while (!t_chars.empty() && isdigit((uint8_t)*t_chars));
 							}
 							else
 								do
 								{
-									++p_chars;
+									++t_chars;
 								}
-								while (!p_chars.empty() && *p_chars == '0');
-							if (p_chars.empty())
+								while (!t_chars.empty() && *t_chars == '0');
+							if (t_chars.empty())
 								break;
-							if (*p_chars == c || isspace((uint8_t)*p_chars))
+							if (*t_chars == c || isspace((uint8_t)*t_chars))
 							{
-								++p_chars;
+								++t_chars;
 								break;
 							}
 						}
@@ -139,7 +139,7 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
 					}
 					else
 					{
-						char t_char = MCNativeCharFold(*p_chars);
+						char t_char = MCNativeCharFold(*t_chars);
 						if (base == 16 && t_char >= 'a' && t_char <= 'f')
 						{
 							value *= base;
@@ -148,13 +148,13 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
 						else
 							return 0;
 					}
-		++p_chars;
+		++t_chars;
 	}
 	if (negative)
 		value = -value;
-	p_chars = skip_spaces(p_chars);
+	t_chars = skip_spaces(t_chars);
 	done = true;
-	r_remainder = p_chars;
+	r_remainder = t_chars;
 	return value;
 }
 

--- a/libfoundation/src/foundation-typeconvert.cpp
+++ b/libfoundation/src/foundation-typeconvert.cpp
@@ -20,12 +20,22 @@
 
 #define R8L 384
 
-inline void MCU_skip_spaces(MCSpan<const char>& x_span)
+static MCSpan<const char>::const_iterator
+skip_spaces(MCSpan<const char>::const_iterator p_start,
+            MCSpan<const char>::const_iterator p_end)
 {
-	while (!x_span.empty() && isspace(uint8_t(x_span[0])))
-	{
-		++x_span;
-	}
+    auto t_iter = p_start;
+    while (t_iter != p_end && isspace(uint8_t(*t_iter)))
+        ++t_iter;
+    return t_iter;
+}
+
+static MCSpan<const char>
+skip_spaces(MCSpan<const char> p_span)
+{
+    MCSpan<const char>::const_iterator t_iter =
+        skip_spaces(p_span.cbegin(), p_span.cend());
+    return p_span.subspan(t_iter - p_span.cbegin());
 }
 
 static integer_t MCU_strtol(MCSpan<const char> p_chars,
@@ -36,7 +46,7 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
                             MCSpan<const char>& r_remainder)
 {
 	done = false;
-	MCU_skip_spaces(p_chars);
+	p_chars = skip_spaces(p_chars);
 	if (p_chars.empty())
 		return 0;
 	bool negative = false;
@@ -79,7 +89,7 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
 		else
 			if (isspace((uint8_t)*p_chars))
 			{
-				MCU_skip_spaces(p_chars);
+				p_chars = skip_spaces(p_chars);
 				if (!p_chars.empty() && *p_chars == c)
 				{
 					++p_chars;
@@ -142,7 +152,7 @@ static integer_t MCU_strtol(MCSpan<const char> p_chars,
 	}
 	if (negative)
 		value = -value;
-	MCU_skip_spaces(p_chars);
+	p_chars = skip_spaces(p_chars);
 	done = true;
 	r_remainder = p_chars;
 	return value;
@@ -167,7 +177,7 @@ static real64_t MCU_strtor8(MCSpan<const char> p_chars,
 
 	r_done = false;
 
-	MCU_skip_spaces(p_chars);
+	p_chars = skip_spaces(p_chars);
 	if (p_chars.empty())
 		return 0;
 
@@ -196,7 +206,7 @@ static real64_t MCU_strtor8(MCSpan<const char> p_chars,
 		return 0;
 
 	p_chars += (t_end - t_buff);
-	MCU_skip_spaces(p_chars);
+	p_chars = skip_spaces(p_chars);
 	if (!p_chars.empty())
 		return 0;
 

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -1233,11 +1233,11 @@ MCScriptExecuteContext::ThrowUnableToResolveMultiInvoke(MCScriptDefinitionGroupD
 	MCAutoProperListRef t_args;
 	if (!MCProperListCreateMutable(&t_args))
 		return;
-	
-	for(uindex_t i = 0; i < p_arguments.size(); i++)
-	{
+
+    for (const uindex_t t_argument : p_arguments)
+    {
 		MCValueRef t_value;
-		t_value = FetchRegister(p_arguments[i]);
+		t_value = FetchRegister(t_argument);
 		
 		if (t_value == nil)
 		{


### PR DESCRIPTION
C++11 range-based `for` loops require the iterable to support the C++ standard library iterator protocol.  `gsl::span`, the Guideline Support Library class on which `MCSpan` is based, works with the protocol just like other standard library containers.

This PR adds STL iterator support to `MCSpan`, and removes the direct arithmetic operator overloads on `MCSpan` itself.  This has the following effects:

- Cleaner implementations of `MCSpan` and `MC::Details::MCSpanIterator`; one holds the range information, and the other traverses it
- Support for backward and/or `const` iteration, as well as just forward iteration
- Much nicer `for` loops (and even nicer when we can use range-based `for`)
- Slightly more thought needed when converting existing code to use a `MCSpan` instead of a pointer + length

Comments appreciated.