### PR TITLE
libfoundation: Enhancements to managed pointers

### DIFF
--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -825,10 +825,9 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
         stacks->setparent(this);
         stacks->setname_cstring("revScript");
         uint4 size = (uint4)MCS_fsize(stream);
-        MCAutoPointer<char> script;
-        script = new (nothrow) char[size + 2];
-        (*script)[size] = '\n';
-        (*script)[size + 1] = '\0';
+        /* UNCHECKED */ MCAutoPointer<char[]> script = new (nothrow) char[size + 2];
+        script[size] = '\n';
+        script[size + 1] = '\0';
         if (IO_read(*script, size, stream) != IO_NORMAL)
             return IO_ERROR;
         MCAutoStringRef t_script_str;

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1711,8 +1711,7 @@ void MCObject::SetParentScript(MCExecContext& ctxt, MCStringRef new_parent_scrip
 	MCScriptPoint sp(new_parent_script);
 
 	// Create a new chunk object to parse the reference into
-	MCAutoPointer<MCChunk> t_chunk;
-	t_chunk = new (nothrow) MCChunk(False);
+	/* UNCHECKED */ MCAutoPointer<MCChunk> t_chunk = new (nothrow) MCChunk(False);
 
 	// Attempt to parse a chunk. We also check that there is no 'junk' at
 	// the end of the string - if there is, its an error. Note the errorlock

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -332,8 +332,8 @@ void MCNetworkEvalHTTPProxyForURL(MCExecContext& ctxt, MCStringRef p_url, MCStri
     t_arguments[0] = t_url;
     t_arguments[1] = t_host;
 
-	MCAutoPointer<char> t_proxies;
-	t_proxies = s_pac_engine -> Call("__FindProxyForURL", t_arguments, 2);
+    /* UNCHECKED */ MCAutoPointer<char[]> t_proxies =
+        s_pac_engine -> Call("__FindProxyForURL", t_arguments, 2);
 
 	if (*t_proxies != nil)
 		/* UNCHECKED */ MCStringCreateWithCString(*t_proxies, r_proxy);

--- a/engine/src/lnxelevate.cpp
+++ b/engine/src/lnxelevate.cpp
@@ -208,7 +208,6 @@ bool MCSystemOpenElevatedProcess(MCStringRef p_command, int32_t& r_pid, int32_t&
 		t_success = MCCStringTokenize(*t_command, t_argv, t_argc);
 
 	MCAutoPointer<char> t_fifo_name;
-	t_fifo_name = nil;
 	if (t_success)
 		t_success = make_tmp_fifo_pair(&t_fifo_name);
 		

--- a/engine/src/mcssl.cpp
+++ b/engine/src/mcssl.cpp
@@ -160,8 +160,7 @@ unsigned long SSLError(MCStringRef& errbuf)
     //  errbuf won't be nil, but will always be empty though.
     if (ecode)
     {
-        MCAutoPointer<char> t_errbuf;
-        t_errbuf = new (nothrow) char[256];
+        /* UNCHECKED */ MCAutoPointer<char[]> t_errbuf = new (nothrow) char[256];
         ERR_error_string_n(ecode,&t_errbuf,255);
         /* UNCHECKED */ MCStringCreateWithCString(*t_errbuf, errbuf);
     }

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2335,7 +2335,9 @@ bool MCObject::getnameproperty(Properties which, uint32_t p_part_id, MCValueRef&
     MCAutoPointer<char[]> tmptypestring;
     if (parent && gettype() >= CT_BUTTON && getstack()->hcaddress())
     {
-        tmptypestring = new (nothrow) char[strlen(itypestring) + 7];
+        tmptypestring.Reset(new (nothrow) char[strlen(itypestring) + 7]);
+        if (!tmptypestring)
+            return false;
         if (parent->gettype() == CT_GROUP)
             sprintf(*tmptypestring, "%s %s", "bkgnd", itypestring);
         else

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -1128,8 +1128,7 @@ MCSocket *MCS_accept(uint2 port, MCObject *object, MCNameRef message, Boolean da
     
     // AL-2015-01-05: [[ Bug 14287 ]] Create name using the number of chars written to the string.
     uindex_t t_length;
-    MCAutoPointer<char_t[]> t_port_chars;
-    t_port_chars = new (nothrow) char_t[U2L];
+    /* UNCHECKED */ MCAutoPointer<char_t[]> t_port_chars = new (nothrow) char_t[U2L];
     t_length = sprintf((char *)(*t_port_chars), "%d", port);
 
 	MCNewAutoNameRef t_portname;

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1642,8 +1642,7 @@ Boolean MCUIDC::lookupcolor(MCStringRef s, MCColor *color)
 		return false;
 
     uint4 slength = strlen(*t_cstring);
-    MCAutoPointer<char[]> startptr;
-    startptr = new (nothrow) char[slength + 1];
+    /* UNCHECKED */ MCAutoPointer<char[]> startptr = new (nothrow) char[slength + 1];
 
     MCU_lower(*startptr, *t_cstring);
 

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -790,6 +790,10 @@ public:
         return t_result;
     }
 
+    /* Return the pointer managed by the MCAutoPointer, or nullptr if
+     * there is no managed pointer. */
+    pointer Get() { return m_ptr; }
+
 	T* operator = (T* value)
 	{
         Reset(value);
@@ -863,6 +867,10 @@ public:
         m_ptr = nullptr;
         return t_result;
     }
+
+    /* Return the pointer managed by the MCAutoPointer, or nullptr if
+     * there is no managed pointer. */
+    pointer Get() { return m_ptr; }
 
 	T* operator = (T* value)
 	{

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -783,7 +783,7 @@ public:
 
     /* Relinquish ownership of the managed pointer.  The MCAutoPointer is
      * null after Release() is called. */
-    pointer Release()
+    pointer Release() ATTRIBUTE_UNUSED
     {
         pointer t_result = m_ptr;
         m_ptr = nullptr;
@@ -864,7 +864,7 @@ public:
 
     /* Relinquish ownership of the managed pointer.  The MCAutoPointer is
      * null after Release() is called. */
-    pointer Release()
+    pointer Release() ATTRIBUTE_UNUSED
     {
         pointer t_result = m_ptr;
         m_ptr = nullptr;

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -213,12 +213,7 @@ public:
     
 	~MCAutoValueRefArrayBase(void)
 	{
-        if (m_values != nil)
-        {
-            for (uindex_t i = 0; i < m_value_count; i++)
-                MCValueRelease(m_values[i]);
-            MCMemoryDeleteArray(m_values);
-        }
+		Reset();
 	}
     
 	//////////
@@ -262,6 +257,18 @@ public:
 
 		r_list = t_list;
 		return true;
+	}
+
+	/* Reset the managed array by releasing all the values in the
+	 * array and the underlying array storage. */
+	void Reset()
+	{
+        if (m_values != nil)
+        {
+            for (uindex_t i = 0; i < m_value_count; i++)
+                MCValueRelease(m_values[i]);
+            MCMemoryDeleteArray(m_values);
+        }
 	}
 
 	//////////

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -757,6 +757,8 @@ public:
 template<typename T> class MCAutoPointer
 {
 public:
+    typedef T* pointer;
+
 	MCAutoPointer(void)
 	{
 		m_ptr = nil;
@@ -767,16 +769,21 @@ public:
 	{
 	}
 
-	~MCAutoPointer(void)
-	{
-		delete m_ptr;
-	}
+    ~MCAutoPointer() { Reset(); }
+
+    /* Destroy the managed pointer, and take ownership of the value
+     * provided.  Providing no value results in the managed pointer
+     * being cleared after calling Reset(). */
+    void Reset(pointer value = nullptr)
+    {
+        delete m_ptr;
+        m_ptr = value;
+    }
 
 	T* operator = (T* value)
 	{
-		delete m_ptr;
-		m_ptr = value;
-		return value;
+        Reset(value);
+        return m_ptr;
 	}
 
 	T*& operator & (void)
@@ -815,14 +822,24 @@ private:
 template<typename T> class MCAutoPointer<T[]>
 {
 public:
+    typedef T* pointer;
+
 	MCAutoPointer(void) : m_ptr(nil) {}
-	~MCAutoPointer(void) { delete[] m_ptr; }
+    ~MCAutoPointer() { Reset(); }
+
+    /* Destroy the managed pointer, and take ownership of the value
+     * provided.  Providing no value results in the managed pointer
+     * being cleared after calling Reset(). */
+    void Reset(pointer value = nullptr)
+    {
+        delete[] m_ptr;
+        m_ptr = value;
+    }
 
 	T* operator = (T* value)
 	{
-		delete[] m_ptr;
-		m_ptr = value;
-		return value;
+        Reset(value);
+        return m_ptr;
 	}
 
 	T*& operator & (void)

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -803,12 +803,6 @@ public:
         return *this;
     }
 
-	T* operator = (T* value)
-	{
-        Reset(value);
-        return m_ptr;
-	}
-
 	T*& operator & (void)
 	{
 		MCAssert(m_ptr == nil);
@@ -889,12 +883,6 @@ public:
         Reset(other.Release());
         return *this;
     }
-
-	T* operator = (T* value)
-	{
-        Reset(value);
-        return m_ptr;
-	}
 
 	T*& operator & (void)
 	{

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -794,6 +794,12 @@ public:
      * there is no managed pointer. */
     pointer Get() { return m_ptr; }
 
+    MCAutoPointer& operator=(MCAutoPointer&& other)
+    {
+        Reset(other.Release());
+        return *this;
+    }
+
 	T* operator = (T* value)
 	{
         Reset(value);
@@ -871,6 +877,12 @@ public:
     /* Return the pointer managed by the MCAutoPointer, or nullptr if
      * there is no managed pointer. */
     pointer Get() { return m_ptr; }
+
+    MCAutoPointer& operator=(MCAutoPointer&& other)
+    {
+        Reset(other.Release());
+        return *this;
+    }
 
 	T* operator = (T* value)
 	{

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -780,6 +780,15 @@ public:
         m_ptr = value;
     }
 
+    /* Relinquish ownership of the managed pointer.  The MCAutoPointer is
+     * null after Release() is called. */
+    pointer Release()
+    {
+        pointer t_result = m_ptr;
+        m_ptr = nullptr;
+        return t_result;
+    }
+
 	T* operator = (T* value)
 	{
         Reset(value);
@@ -805,8 +814,7 @@ public:
 
 	void Take(T*&r_ptr)
 	{
-		r_ptr = m_ptr;
-		m_ptr = nil;
+        r_ptr = Release();
 	}
 
 private:
@@ -836,6 +844,15 @@ public:
         m_ptr = value;
     }
 
+    /* Relinquish ownership of the managed pointer.  The MCAutoPointer is
+     * null after Release() is called. */
+    pointer Release()
+    {
+        pointer t_result = m_ptr;
+        m_ptr = nullptr;
+        return t_result;
+    }
+
 	T* operator = (T* value)
 	{
         Reset(value);
@@ -861,8 +878,7 @@ public:
 
 	void Take(T* & r_ptr)
 	{
-		r_ptr = m_ptr;
-		m_ptr = nil;
+        r_ptr = Release();
 	}
     
     T& operator [] (size_t x)

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -790,6 +790,9 @@ public:
         return t_result;
     }
 
+    /* Test whether the MCAutoPointer has been set. */
+    operator bool() { return m_ptr != nullptr; }
+
     /* Return the pointer managed by the MCAutoPointer, or nullptr if
      * there is no managed pointer. */
     pointer Get() { return m_ptr; }
@@ -873,6 +876,9 @@ public:
         m_ptr = nullptr;
         return t_result;
     }
+
+    /* Test whether the MCAutoPointer has been set. */
+    operator bool() { return m_ptr != nullptr; }
 
     /* Return the pointer managed by the MCAutoPointer, or nullptr if
      * there is no managed pointer. */

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -759,15 +759,16 @@ template<typename T> class MCAutoPointer
 public:
     typedef T* pointer;
 
-	MCAutoPointer(void)
-	{
-		m_ptr = nil;
-	}
-	
-	MCAutoPointer(T* value)
-		: m_ptr(value)
-	{
-	}
+    MCAutoPointer() : m_ptr(nullptr) {}
+
+    MCAutoPointer(decltype(nullptr)) : m_ptr(nullptr) {}
+
+    /* Construct the managed pointer using a specific value. */
+    MCAutoPointer(pointer p) : m_ptr(p) {}
+
+    /* Construct managed pointer by moving a pointer from another
+     * managed pointer of the same type. */
+    MCAutoPointer(MCAutoPointer&& other) : m_ptr(other.Release()) {}
 
     ~MCAutoPointer() { Reset(); }
 
@@ -832,7 +833,17 @@ template<typename T> class MCAutoPointer<T[]>
 public:
     typedef T* pointer;
 
-	MCAutoPointer(void) : m_ptr(nil) {}
+    MCAutoPointer() : m_ptr(nullptr) {}
+
+    MCAutoPointer(decltype(nullptr)) : m_ptr(nullptr) {}
+
+    /* Construct the managed pointer using a specific value. */
+    MCAutoPointer(pointer p) : m_ptr(p) {}
+
+    /* Construct managed pointer by moving a pointer from another
+     * managed pointer of the same type. */
+    MCAutoPointer(MCAutoPointer&& other) : m_ptr(other.Release()) {}
+
     ~MCAutoPointer() { Reset(); }
 
     /* Destroy the managed pointer, and take ownership of the value

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -2226,11 +2226,11 @@ bool MCUnicodeCanBreakWordBetween(uinteger_t xc, uinteger_t x, uinteger_t y, uin
 bool MCUnicodeWildcardMatch(const void *source_chars, uindex_t source_length, bool p_source_native, const void *pattern_chars, uindex_t pattern_length, bool p_pattern_native, MCUnicodeCompareOption p_option)
 {
     // Set up the filter chains for the strings
-	MCAutoPointer<MCTextFilter> t_source_filter;
-	t_source_filter = MCTextFilterCreate(source_chars, source_length, p_source_native ? kMCStringEncodingNative : kMCStringEncodingUTF16, p_option);
+    MCAutoPointer<MCTextFilter> t_source_filter =
+        MCTextFilterCreate(source_chars, source_length, p_source_native ? kMCStringEncodingNative : kMCStringEncodingUTF16, p_option);
 	
-	MCAutoPointer<MCTextFilter> t_pattern_filter;
-	t_pattern_filter = MCTextFilterCreate(pattern_chars, pattern_length, p_pattern_native ? kMCStringEncodingNative : kMCStringEncodingUTF16, p_option);
+    MCAutoPointer<MCTextFilter> t_pattern_filter =
+        MCTextFilterCreate(pattern_chars, pattern_length, p_pattern_native ? kMCStringEncodingNative : kMCStringEncodingUTF16, p_option);
     
     codepoint_t t_source_cp, t_pattern_cp;
     


### PR DESCRIPTION
This PR adds some missing features to libfoundation's managed pointer types.

It adds `MCAutoValueRefArrayBase::Reset()`. This method, destroys and frees the managed array, leaving the managed pointer empty.

It also adds `Release()` and `Reset()` methods to `MCAutoPointer` (both array and non-array variants).  This makes it possible to reliably transfer ownership of a pointer from one `MCAutoPointer` to another using:

    target.Reset(source.Release());

Finally, it implements a `bool` conversion operator for `MCAutoPointer`, so that it becomes valid to write:

    if (t_auto_pointer)
    {
        /* Statements if t_auto_pointer has been set */
    }

These improvements go some way towards giving libfoundation's managed pointer types some of the features present in `std::unique_ptr`.