### PR TITLE
[[ Bug 19045 ]] Fix surrogate processing in MCUnicodeGetProperty

### DIFF
--- a/docs/notes/bugfix-19045.md
+++ b/docs/notes/bugfix-19045.md
@@ -1,0 +1,1 @@
+# Fix BiDi algorithm for surrogate pairs

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -341,14 +341,12 @@ bool MCUnicodeGetProperty(const unichar_t *p_chars, uindex_t p_char_count, MCUni
         // If the surrogate is not valid, just ignore the error
         codepoint_t t_char = p_chars[t_offset];
         uindex_t t_advance = 1;
-        if (0xD800 <= t_char && t_char < 0xDC00 && (t_offset + 1) < p_char_count)
+        if (MCUnicodeCodepointIsLeadingSurrogate(t_char) &&
+            (t_offset + 1) < p_char_count &&
+            MCUnicodeCodepointIsTrailingSurrogate(p_chars[t_offset + 1]))
         {
-            codepoint_t t_upper = p_chars[t_offset + 1];
-            if (0xDC00 <= t_upper && t_upper < 0xE000)
-            {
-                t_char = (t_char - 0xD800) + ((t_upper - 0xDC00) << 10);
-                t_advance = 2;
-            }
+            t_char = MCUnicodeCombineSurrogates(t_char, p_chars[t_offset + 1]);
+            t_advance = 2;
         }
         
         // Look up the property

--- a/libfoundation/test/test_string.cpp
+++ b/libfoundation/test/test_string.cpp
@@ -143,14 +143,16 @@ static void check_bidi_of_surrogate_range(int p_lower, int p_upper)
 {
     int t_size = p_upper - p_lower;
 
-    unichar_t t_pua_chars[t_size * 2];
+		MCAutoArray<unichar_t> t_pua_chars;
+		ASSERT_TRUE(t_pua_chars.Resize(t_size * 2));
     for(int i = 0; i < t_size; i++)
     {
-        MCUnicodeCodepointToSurrogates(i + p_lower, t_pua_chars + i * 2);
+        MCUnicodeCodepointToSurrogates(i + p_lower, t_pua_chars.Ptr() + i * 2);
     }
 
-    uint8_t t_props[t_size];
-    MCUnicodeGetProperty(t_pua_chars, t_size, kMCUnicodePropertyBidiClass, kMCUnicodePropertyTypeUint8, t_props);
+		MCAutoArray<uint8_t> t_props;
+		ASSERT_TRUE(t_props.Resize(t_size));
+    MCUnicodeGetProperty(t_pua_chars.Ptr(), t_size, kMCUnicodePropertyBidiClass, kMCUnicodePropertyTypeUint8, t_props.Ptr());
 
     for(int i = 0; i < t_size; i++)
     {
@@ -167,7 +169,7 @@ TEST(string, surrogate_unicode_props)
     const int kSPUA_A_Lower = 0xF0000;
     const int kSPUA_A_Upper = 0xFFFFD + 1; // non-inclusive
     check_bidi_of_surrogate_range(kSPUA_A_Lower, kSPUA_A_Upper);
-    
+
     const int kSPUA_B_Lower = 0x100000;
     const int kSPUA_B_Upper = 0x10FFFD + 1; // non-inclusive
     check_bidi_of_surrogate_range(kSPUA_B_Lower, kSPUA_B_Upper);

--- a/libfoundation/test/test_string.cpp
+++ b/libfoundation/test/test_string.cpp
@@ -17,6 +17,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "gtest/gtest.h"
 
 #include "foundation.h"
+#include "foundation-unicode.h"
 #include "foundation-auto.h"
 
 
@@ -138,3 +139,36 @@ TEST(string, format_everything)
 	ASSERT_STREQ(MCStringGetCString(*t_string), "Test: hello?! 42 012 0.007");
 }
 
+static void check_bidi_of_surrogate_range(int p_lower, int p_upper)
+{
+    int t_size = p_upper - p_lower;
+
+    unichar_t t_pua_chars[t_size * 2];
+    for(int i = 0; i < t_size; i++)
+    {
+        MCUnicodeCodepointToSurrogates(i + p_lower, t_pua_chars + i * 2);
+    }
+
+    uint8_t t_props[t_size];
+    MCUnicodeGetProperty(t_pua_chars, t_size, kMCUnicodePropertyBidiClass, kMCUnicodePropertyTypeUint8, t_props);
+
+    for(int i = 0; i < t_size; i++)
+    {
+            ASSERT_TRUE(t_props[i] == kMCUnicodeDirectionLeftToRight);
+    }
+}
+
+TEST(string, surrogate_unicode_props)
+//
+// Checks that MCUnicodeGetProperty correctly deals with surrogates
+// (Regression test for Bug 19045)
+//
+{
+    const int kSPUA_A_Lower = 0xF0000;
+    const int kSPUA_A_Upper = 0xFFFFD + 1; // non-inclusive
+    check_bidi_of_surrogate_range(kSPUA_A_Lower, kSPUA_A_Upper);
+    
+    const int kSPUA_B_Lower = 0x100000;
+    const int kSPUA_B_Upper = 0x10FFFD + 1; // non-inclusive
+    check_bidi_of_surrogate_range(kSPUA_B_Lower, kSPUA_B_Upper);
+}


### PR DESCRIPTION
This patch fixes the surrogate processing in MCUnicodeGetProperty
which was previously computing the codepoint incorrectly.