### PR TITLE
[CID 16585] Remove unused MCS_generate_uuid() function

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -517,38 +517,6 @@ static void handle_signal(int sig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCS_generate_uuid(char p_buffer[128])
-{
-    typedef void (*uuid_generate_ptr)(unsigned char uuid[16]);
-    typedef void (*uuid_unparse_ptr)(unsigned char uuid[16], char *out);
-    static void *s_uuid_generate = NULL, *s_uuid_unparse = NULL;
-
-    if (s_uuid_generate == NULL && s_uuid_unparse == NULL)
-    {
-        void *t_libuuid;
-        t_libuuid = dlopen("libuuid.so", RTLD_LAZY);
-        if (t_libuuid == NULL)
-            t_libuuid = dlopen("libuuid.so.1", RTLD_LAZY);
-        if (t_libuuid != NULL)
-        {
-            s_uuid_generate = dlsym(t_libuuid, "uuid_generate");
-            s_uuid_unparse = dlsym(t_libuuid, "uuid_unparse");
-}
-    }
-
-    if (s_uuid_generate != NULL && s_uuid_unparse != NULL)
-    {
-        unsigned char t_uuid[16];
-        ((uuid_generate_ptr)s_uuid_generate)(t_uuid);
-        ((uuid_unparse_ptr)s_uuid_unparse)(t_uuid, p_buffer);
-        return true;
-    }
-
-    return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 class MCStdioFileHandle: public MCSystemFileHandle
 {
 public:

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -5995,26 +5995,3 @@ static void MCS_startprocess_unix(MCNameRef name, MCStringRef doc, Open_mode mod
     delete t_doc;
 
 }
-
-bool MCS_generate_uuid(char p_buffer[128])
-{
-	CFUUIDRef t_uuid;
-	t_uuid = CFUUIDCreate(kCFAllocatorDefault);
-	if (t_uuid != NULL)
-	{
-		CFStringRef t_uuid_string;
-		
-		t_uuid_string = CFUUIDCreateString(kCFAllocatorDefault, t_uuid);
-		if (t_uuid_string != NULL)
-		{
-			CFStringGetCString(t_uuid_string, p_buffer, 127, kCFStringEncodingMacRoman);
-			CFRelease(t_uuid_string);
-		}
-		
-		CFRelease(t_uuid);
-        
-		return true;
-	}
-    
-	return false;
-}

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -3905,23 +3905,5 @@ uint2 MCS_charsettolangid(uint1 charset)
 	return 0;
 }
 
-bool MCS_generate_uuid(char p_buffer[128])
-{
-	GUID t_guid;
-	if (CoCreateGuid(&t_guid) == S_OK)
-	{
-		unsigned char __RPC_FAR *t_guid_string;
-		if (UuidToStringA(&t_guid, &t_guid_string) == RPC_S_OK)
-		{
-			strcpy(p_buffer, (char *)t_guid_string);
-			RpcStringFreeA(&t_guid_string);
-		}
-        
-		return true;
-	}
-    
-	return false;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -169,8 +169,6 @@ extern bool MCS_isnan(double p_value);
 
 extern bool MCS_mcisendstring(MCStringRef p_command, MCStringRef& r_result, bool& r_error);
 
-bool MCS_generate_uuid(char buffer[128]);
-
 bool MCS_getnetworkinterfaces(MCStringRef& r_interfaces);
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We have built-in UUID generation now.

Coverity-ID: 16585