### PR TITLE
[[ Bug 19049 ]] Prevent crash when mousestackptr becomes nil during mouse click

### DIFF
--- a/docs/notes/bugfix-19049.md
+++ b/docs/notes/bugfix-19049.md
@@ -1,0 +1,1 @@
+# Prevent crash when deleting mousestack stack via button click

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -269,7 +269,7 @@ void MCPlatformHandleMouseEnter(MCPlatformWindowRef p_window)
 	if (t_stack == nil)
 		return;
 	
-	if (t_stack != MCmousestackptr)
+	if (!MCmousestackptr.IsBoundTo(t_stack))
 	{
 		MCmousestackptr = t_stack;
 		MCmousestackptr -> enter();
@@ -293,7 +293,7 @@ void MCPlatformHandleMouseLeave(MCPlatformWindowRef p_window)
 	if (t_stack == nil)
 		return;
 	
-	if (t_stack == MCmousestackptr)
+	if (MCmousestackptr.IsBoundTo(t_stack))
 	{
 		MCmousestackptr -> munfocus();
 		MCmousestackptr = nil;
@@ -310,7 +310,7 @@ void MCPlatformHandleMouseMove(MCPlatformWindowRef p_window, MCPoint p_location)
 	MCObject *t_menu;
 	t_menu = MCdispatcher -> getmenu();
 	
-	if (MCmousestackptr == t_stack || t_menu != nil)
+	if (MCmousestackptr.IsBoundTo(t_stack) || t_menu != nil)
 	{
 		MCeventtime = MCPlatformGetEventTime();
 		
@@ -349,7 +349,7 @@ void MCPlatformHandleMouseDown(MCPlatformWindowRef p_window, uint32_t p_button, 
 	MCObject *t_menu;
 	t_menu = MCdispatcher -> getmenu();
 	
-	if (MCmousestackptr == t_stack || t_menu != nil)
+	if (MCmousestackptr.IsBoundTo(t_stack) || t_menu != nil)
 	{
 		MCbuttonstate |= (1 << p_button);
 		
@@ -400,7 +400,7 @@ void MCPlatformHandleMouseUp(MCPlatformWindowRef p_window, uint32_t p_button, ui
 	MCObject *t_menu;
 	t_menu = MCdispatcher -> getmenu();
 	
-	if (MCmousestackptr == t_stack || t_menu != nil)
+	if (MCmousestackptr.IsBoundTo(t_stack) || t_menu != nil)
 	{
 		MCbuttonstate &= ~(1 << p_button);
 		
@@ -443,7 +443,7 @@ void MCPlatformHandleMouseRelease(MCPlatformWindowRef p_window, uint32_t p_butto
 	MCObject *t_menu;
 	t_menu = MCdispatcher -> getmenu();
 	
-	if (MCmousestackptr == t_stack || t_menu != nil)
+	if (MCmousestackptr.IsBoundTo(t_stack) || t_menu != nil)
 	{
 		tripleclick = False;
 		
@@ -488,7 +488,7 @@ void MCPlatformHandleMouseScroll(MCPlatformWindowRef p_window, int p_dx, int p_d
 	if (t_stack == nil)
 		return;
 	
-	if (MCmousestackptr != t_stack)
+	if (!MCmousestackptr.IsBoundTo(t_stack))
 		return;
 	
 	MCObject *mfocused;

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1473,7 +1473,7 @@ void MCDispatch::wmdragenter(Window w)
     MCdragboard->PullUpdates();
 
     // Change the mouse focus to the stack that has had the drag enter it
-	if (MCmousestackptr && target != MCmousestackptr)
+	if (MCmousestackptr && !MCmousestackptr.IsBoundTo(target))
 		MCmousestackptr -> munfocus();
 
 	MCmousestackptr = target;
@@ -1507,7 +1507,7 @@ void MCDispatch::wmdragleave(Window w)
 {
     // No stacks have mouse focus now
     MCStack *target = findstackd(w);
-	if (target != NULL && target == MCmousestackptr)
+	if (target != nullptr && MCmousestackptr.IsBoundTo(target))
 	{
 		MCmousestackptr -> munfocus();
 		MCmousestackptr = nil;

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2987,7 +2987,7 @@ void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p
 	{
 		MCwatchcursor = False;
 		p_target->resetcursor(True);
-		if (MCmousestackptr && MCmousestackptr != p_target)
+		if (MCmousestackptr && !MCmousestackptr.IsBoundTo(p_target))
 			MCmousestackptr->resetcursor(True);
 	}
     

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -765,7 +765,7 @@ void MCStack::close()
 	{
 		seticonic(false);
 	}
-	if (MCmousestackptr == this)
+	if (MCmousestackptr.IsBoundTo(this))
 	{
 		MCmousestackptr = nil;
 		int2 x, y;
@@ -1144,7 +1144,7 @@ void MCStack::mfocustake(MCControl *target)
 
 void MCStack::munfocus(void)
 {
-	if (MCmousestackptr == this)
+	if (MCmousestackptr.IsBoundTo(this))
 		MCmousestackptr = nil;
 	if (curcard != 0)
 	{
@@ -1176,7 +1176,7 @@ Boolean MCStack::mup(uint2 which, bool p_release)
 	Boolean handled = curcard->mup(which, p_release);
 	// MW-2010-07-06: [[ Bug ]] We should probably only mfocus the card if this
 	//   stack is still the mouse stack.
-	if (opened && mode < WM_PULLDOWN && MCmousestackptr == this)
+	if (opened && mode < WM_PULLDOWN && MCmousestackptr.IsBoundTo(this))
 		curcard->mfocus(MCmousex, MCmousey);
 	return handled;
 }

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -302,7 +302,7 @@ Tool MCStack::gettool(MCObject *optr) const
 
 void MCStack::hidecursor()
 {
-	if (MCmousestackptr == this)
+	if (MCmousestackptr.IsBoundTo(this))
 	{
 		cursor = MCcursors[PI_NONE];
 		MCscreen->setcursor(window, cursor);
@@ -568,7 +568,7 @@ Boolean MCStack::takewindow(MCStack *sptr)
     
 	mode_takewindow(sptr);
 	
-	if (MCmousestackptr == sptr)
+	if (MCmousestackptr.IsBoundTo(sptr))
 		MCmousestackptr = this;
 	start_externals();
     

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1106,7 +1106,7 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
 		if (MCfoundfield)
 			MCfoundfield->clearfound();
 		
-		if (MCmousestackptr == this)
+		if (MCmousestackptr.IsBoundTo(this))
 			curcard->munfocus();
 		if (state & CS_KFOCUSED)
 		{
@@ -1254,7 +1254,7 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
  
             if (wasfocused)
 				curcard->kfocus();
-			if (MCmousestackptr == this && !mfocus(MCmousex, MCmousey))
+			if (MCmousestackptr.IsBoundTo(this) && !mfocus(MCmousex, MCmousey))
 				curcard->message(MCM_mouse_enter);
 		}
 		return ES_NORMAL;
@@ -1282,7 +1282,7 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
    		
 		if (wasfocused)
 			kfocus();
-		if (MCmousestackptr == this && !mfocus(MCmousex, MCmousey))
+		if (MCmousestackptr.IsBoundTo(this) && !mfocus(MCmousex, MCmousey))
 			curcard->message(MCM_mouse_enter);
 	}
     

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -1108,18 +1108,18 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		if (curinfo->live && !pms->isgrabbed() && LOWORD(lParam) != HTCLIENT)
 			return IsWindowUnicode(hwnd) ? DefWindowProcW(hwnd, msg, wParam, lParam) : DefWindowProcA(hwnd, msg, wParam, lParam);
 		MCmousestackptr = MCdispatcher->findstackd(dw);
-		if (MCmousestackptr != NULL)
+		if (!MCmousestackptr)
 		{
 			MCmousestackptr->resetcursor(True);
 			if (pms->getmousetimer() == 0)
 				pms->setmousetimer(timeSetEvent(LEAVE_CHECK_INTERVAL, 100,
 				                                mouseproc, 0, TIME_ONESHOT));
 		}
-		if (omousestack != MCmousestackptr)
+		if (!MCmousestackptr.IsBoundTo(omousestack))
 		{
 			if (omousestack != NULL && omousestack != MCtracestackptr)
 				omousestack->munfocus();
-			if (MCmousestackptr != NULL && MCmousestackptr != MCtracestackptr)
+			if (MCmousestackptr && MCmousestackptr != MCtracestackptr)
 				MCmousestackptr->enter();
 		}
 		break;
@@ -1163,7 +1163,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 					MCscreen->setmouseloc(MCdispatcher->findstackd(dw), t_mouseloc);
 				if (MCtracewindow == DNULL || hwnd != (HWND)MCtracewindow->handle.window)
 				{
-					if (t_old_mousestack != NULL && MCmousestackptr != t_old_mousestack)
+					if (t_old_mousestack != NULL && !MCmousestackptr.IsBoundTo(t_old_mousestack))
 						t_old_mousestack->munfocus();
 					if (msg == WM_MOUSEMOVE)
 					{
@@ -1179,7 +1179,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 						}
 					}
 					else
-						if (MCmousestackptr != NULL)
+						if (MCmousestackptr)
 							MCmousestackptr->munfocus();
 					curinfo->handled = True;
 				}
@@ -1195,7 +1195,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 			return IsWindowUnicode(hwnd) ? DefWindowProcW(hwnd, msg, wParam, lParam) : DefWindowProcA(hwnd, msg, wParam, lParam);
 		break;
 	case WM_APP:
-		if (MCmousestackptr != NULL && MCdispatcher->getmenu() == NULL)
+		if (MCmousestackptr && MCdispatcher->getmenu() == NULL)
 		{
 			// IM-2014-04-17: [[ Bug 12227 ]] Convert logical stack rect to screen coords when testing for mouse intersection
 			// IM-2014-08-01: [[ Bug 13058 ]] Use stack view rect to get logical window rect
@@ -1350,7 +1350,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		break;
 	case WM_TIMER:
 		curinfo->handled = True;
-		if (MCmousestackptr != NULL && MCdispatcher->getmenu() == NULL)
+		if (MCmousestackptr && MCdispatcher->getmenu() == NULL)
 		{
 			int2 x, y;
 			pms->querymouse(x, y);
@@ -1526,7 +1526,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		return IsWindowUnicode(hwnd) ? DefWindowProcW(hwnd, msg, wParam, lParam) : DefWindowProcA(hwnd, msg, wParam, lParam);
 	case WM_MOUSEWHEEL:
 	case WM_MOUSEHWHEEL:
-		if (MCmousestackptr != NULL)
+		if (MCmousestackptr)
 		{
 			MCObject *mfocused = MCmousestackptr->getcard()->getmfocused();
 			if (mfocused == NULL)


### PR DESCRIPTION
Comparing an MCStackHandle with a MCStack * requires the former to be either
unbound or valid. When the mousestack has been deleted, MCmousestackptr is
bound but invalid so comparisons cause assertion failures. This patch uses the
IsBoundTo function to allow for such instances.