### PR TITLE
[[ Bug 18459 ]] Fix incorrect behavior of files() and folders() on Android

### DIFF
--- a/docs/notes/bugfix-18459.md
+++ b/docs/notes/bugfix-18459.md
@@ -1,0 +1,1 @@
+Fix incorrect behavior of files() and folders() function on Android.

--- a/docs/notes/bugfix-18459.md
+++ b/docs/notes/bugfix-18459.md
@@ -1,1 +1,1 @@
-Fix incorrect behavior of files() and folders() function on Android.
+# Fix incorrect behavior of files() and folders() function on Android.

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -195,7 +195,7 @@ bool apk_list_folder_entries(MCStringRef p_apk_folder, MCSystemListFolderEntries
 		}
 
 		// 2017-01-07: [[ Bug 18459 ]] Make sure MCU_stob() is execute and t_is_folder is set.
-		if ( MCU_stob(t_ffolder, t_is_folder) && !MCU_stoi4(t_fsize, t_size) )
+		if (MCU_stob(t_ffolder, t_is_folder) && !MCU_stoi4(t_fsize, t_size))
 			return false;
 
 		// SN-2014-01-13: [[ RefactorUnicode ]] Asset filenames are in ASCII

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -194,7 +194,8 @@ bool apk_list_folder_entries(MCStringRef p_apk_folder, MCSystemListFolderEntries
 			t_more_entries = false;
 		}
 
-		if (!MCU_stoi4(t_fsize, t_size) && MCU_stob(t_ffolder, t_is_folder))
+		// 2017-01-07: [[ Bug 18459 ]] Make sure MCU_stob() is execute and t_is_folder is set.
+		if ( MCU_stob(t_ffolder, t_is_folder) && !MCU_stoi4(t_fsize, t_size) )
 			return false;
 
 		// SN-2014-01-13: [[ RefactorUnicode ]] Asset filenames are in ASCII


### PR DESCRIPTION
This commit fix folders() function incorrectly return all files and folders and files() function return empty in Android resource folder.