### PR TITLE
MCProperty: Remove unused pointer field & switch to managed pointers

### DIFF
--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -498,7 +498,6 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 	Boolean lp = False;
 
 	initpoint(sp);
-	parent = sp.getobj();
 
 	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_EFFECTIVE) == PS_NORMAL)
 		effective = True;

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -460,19 +460,11 @@ MCProperty::MCProperty()
 	ptype = CT_UNDEFINED;
 	which = P_UNDEFINED;
 	function = F_UNDEFINED;
-	target = NULL;
-	destvar = NULL;
 	effective = False;
-	customindex = NULL;
-	customprop = nil;
 }
 
 MCProperty::~MCProperty()
 {
-	delete target;
-	delete destvar;
-	delete customindex;
-	MCNameDelete(customprop);
 }
 
 MCObject *MCProperty::getobj(MCExecContext &ctxt)
@@ -510,7 +502,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 	{
 		// MW-2011-06-22: [[ SERVER ]] Update to use SP findvar method to take into account
 		//   execution outwith a handler.
-		if (sp . findvar(sp.gettoken_nameref(), &destvar) == PS_NORMAL)
+		if (sp . findvar(sp.gettoken_nameref(), &(&destvar)) == PS_NORMAL)
 		{
 			destvar->parsearray(sp);
 			which = P_CUSTOM_VAR;
@@ -518,10 +510,10 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 		else
 		{
 			which = P_CUSTOM;
-			/* UNCHECKED */ MCNameClone(sp . gettoken_nameref(), customprop);
+			/* UNCHECKED */ MCNameClone(sp . gettoken_nameref(), &customprop);
 			if (sp.next(type) == PS_NORMAL && type == ST_LB)
 			{
-				if (sp.parseexp(False, True, &customindex) != PS_NORMAL
+				if (sp.parseexp(False, True, &(&customindex)) != PS_NORMAL
 				        || sp.next(type) != PS_NORMAL || type != ST_RB)
 				{
 					MCperror->add(PE_PROPERTY_BADINDEX, sp);
@@ -957,7 +949,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 			sp.backup();
 			break;
 		}
-		if (sp.parseexp(False, True, &customindex) != PS_NORMAL)
+		if (sp.parseexp(False, True, &(&customindex)) != PS_NORMAL)
 		{
 			MCperror->add(PE_VARIABLE_BADINDEX, sp);
 			return PS_ERROR;
@@ -1036,7 +1028,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
         {
             if (type == ST_LB)
             {
-                if (sp.parseexp(False, True, &customindex) != PS_NORMAL
+                if (sp.parseexp(False, True, &(&customindex)) != PS_NORMAL
                         || sp.next(type) != PS_NORMAL || type != ST_RB)
                 {
                     MCperror->add(PE_PROPERTY_BADINDEX, sp);
@@ -1057,7 +1049,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 				
 				// MW-2011-06-22: [[ SERVER ]] Update to use SP findvar method to take into account
 				//   execution outwith a handler.
-				if (sp . finduqlvar(sp.gettoken_nameref(), &destvar) != PS_NORMAL)
+				if (sp . finduqlvar(sp.gettoken_nameref(), &(&destvar)) != PS_NORMAL)
 				{
 					MCperror->add(PE_PROPERTY_NOTOF, sp);
 					return PS_ERROR;
@@ -1109,7 +1101,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 				{
 					if (tocount < CT_LINE)
 					{
-						target = new (nothrow) MCChunk(False);
+						/* UNCHECKED */ target.Reset(new (nothrow) MCChunk(False));
 						break;
 					}
 					else
@@ -1125,7 +1117,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 					if (tocount < CT_LINE)
 					{
 						sp.backup();
-						target = new (nothrow) MCChunk(False);
+						/* UNCHECKED */ target.Reset(new (nothrow) MCChunk(False));
 						break;
 					}
 					else
@@ -1141,7 +1133,7 @@ Parse_stat MCProperty::parse(MCScriptPoint &sp, Boolean the)
 		}
 		else
 			sp.backup();
-		target = new (nothrow) MCChunk(False);
+		/* UNCHECKED */ target.Reset(new (nothrow) MCChunk(False));
 		if (target->parse(sp, doingthe) != PS_NORMAL)
 		{
 			MCperror->add
@@ -1187,7 +1179,7 @@ bool MCProperty::resolveprop(MCExecContext& ctxt, Properties& r_which, MCNameRef
 	//   simplify code.
 	if (which == P_CUSTOM)
     {
-        if (!MCNameClone(customprop, t_prop_name))
+        if (!MCNameClone(*customprop, t_prop_name))
             return false;
     }
 	
@@ -1198,7 +1190,7 @@ bool MCProperty::resolveprop(MCExecContext& ctxt, Properties& r_which, MCNameRef
 	if (which == P_CUSTOM_VAR)
 	{
         MCAutoStringRef t_string;
-        if (!ctxt  . EvalExprAsStringRef(destvar, EE_PROPERTY_BADEXPRESSION, &t_string))
+        if (!ctxt  . EvalExprAsStringRef(destvar.Get(), EE_PROPERTY_BADEXPRESSION, &t_string))
             return false;
 
         // AL-2015-08-27: [[ Bug 15798 ]] Parse into index and property name before determining
@@ -1256,9 +1248,10 @@ bool MCProperty::resolveprop(MCExecContext& ctxt, Properties& r_which, MCNameRef
 			t_prop = P_CUSTOM;
 		}
 	}
-	else if (customindex != nil)
+	else if (customindex)
     {
-        if (!ctxt . EvalExprAsNameRef(customindex, EE_PROPERTY_BADEXPRESSION, t_index_name))
+        if (!ctxt . EvalExprAsNameRef(customindex.Get(), EE_PROPERTY_BADEXPRESSION,
+                                      t_index_name))
             return false;
     }
     
@@ -1428,8 +1421,9 @@ void MCProperty::eval_global_property_ctxt(MCExecContext& ctxt, MCExecValue& r_v
     bool t_is_array_prop;
     MCNewAutoNameRef t_index;
     
-    if (customindex != nil)
-        ctxt . EvalExprAsNameRef(customindex, EE_PROPERTY_BADEXPRESSION, &t_index);
+    if (customindex)
+        ctxt . EvalExprAsNameRef(customindex.Get(), EE_PROPERTY_BADEXPRESSION,
+                                 &t_index);
     
     t_is_array_prop = (*t_index != nil && !MCNameIsEmpty(*t_index));
     
@@ -1492,13 +1486,13 @@ void MCProperty::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
 {
 	ctxt . SetLineAndPos(line, pos);
     
-	if (destvar != nil && which != P_CUSTOM_VAR)
+	if (destvar && which != P_CUSTOM_VAR)
 		return eval_variable_ctxt(ctxt, r_value);
 	
 	if (function != F_UNDEFINED)
 		return eval_function_ctxt(ctxt, r_value);
 	
-	if (target == nil)
+	if (!target)
 		return eval_global_property_ctxt(ctxt, r_value);
 	
 	if (tocount == CT_UNDEFINED)
@@ -1517,8 +1511,9 @@ void MCProperty::set_global_property(MCExecContext& ctxt, MCExecValue p_value)
     bool t_is_array_prop;
     MCNewAutoNameRef t_index;
     
-    if (customindex != nil)
-        ctxt . EvalExprAsNameRef(customindex, EE_PROPERTY_BADEXPRESSION, &t_index);
+    if (customindex)
+        ctxt . EvalExprAsNameRef(customindex.Get(), EE_PROPERTY_BADEXPRESSION,
+                                 &t_index);
     
     t_is_array_prop = (*t_index != nil && !MCNameIsEmpty(*t_index));
     
@@ -1571,9 +1566,9 @@ void MCProperty::set_object_property(MCExecContext& ctxt, MCExecValue p_value)
 
 void MCProperty::set(MCExecContext& ctxt, MCExecValue p_value)
 {
-    if (destvar != NULL && which != P_CUSTOM_VAR)
+    if (destvar && which != P_CUSTOM_VAR)
         set_variable(ctxt, p_value);
-    else if (target == nil)
+    else if (!target)
         set_global_property(ctxt, p_value);
     else
         set_object_property(ctxt, p_value);

--- a/engine/src/property.h
+++ b/engine/src/property.h
@@ -37,7 +37,6 @@ class MCProperty : public MCExpression
 	Properties which;
 	MCChunk *target;
 	Functions function;
-	MCObject *parent;
 	MCVarref *destvar;
 	Boolean effective;
 	MCNameRef customprop;

--- a/engine/src/property.h
+++ b/engine/src/property.h
@@ -35,12 +35,12 @@ class MCProperty : public MCExpression
 	Chunk_term tocount;
 	Chunk_term ptype;
 	Properties which;
-	MCChunk *target;
+	MCAutoPointer<MCChunk> target;
 	Functions function;
-	MCVarref *destvar;
+	MCAutoPointer<MCVarref> destvar;
 	Boolean effective;
-	MCNameRef customprop;
-	MCExpression *customindex;
+	MCNewAutoNameRef customprop;
+	MCAutoPointer<MCExpression> customindex;
 public:
 	MCProperty();
 	virtual ~MCProperty();


### PR DESCRIPTION
- The `MCProperty::parent` field is unused; remove it
- Switch to managed pointers for all pointer fields in `MCProperty`, leaving it with an empty destructor