### PR TITLE
[[ Bug 18622 ]] Convert empty in LCS to empty list in LCB

### DIFF
--- a/docs/notes/bugfix-18622.md
+++ b/docs/notes/bugfix-18622.md
@@ -1,0 +1,1 @@
+# Ensure empty maps to empty lists when calling LCB library handlers

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -1188,7 +1188,17 @@ static bool __script_try_to_convert_to_list(MCExecContext& ctxt, MCValueRef& x_v
     bool t_is_array;
     if (!__script_try_to_convert_to_array(ctxt, x_value, t_is_array))
         return false;
-    
+	
+	// If we managed to convert to an array, and the array is empty then we
+	// can convert.
+	if (t_is_array &&
+		MCArrayIsEmpty((MCArrayRef)x_value))
+	{
+		MCValueAssign(x_value, (MCValueRef)kMCEmptyProperList);
+		r_converted = true;
+		return true;
+	}
+	
     // If we managed to convert to an array, and the array is a sequence
     // we can convert.
     if (t_is_array && MCArrayIsSequence((MCArrayRef)x_value))

--- a/tests/lcs/core/engine/_extension.lcb
+++ b/tests/lcs/core/engine/_extension.lcb
@@ -22,6 +22,10 @@ public handler TestExtensionBridgeNames_Send()
 	return the result is a string
 end handler
 
+public handler TestExtensionBridgeArrays_EmptyToEmptyList(in pList as List) returns Boolean
+	return pList is the empty list
+end handler
+
 public handler TestExtensionSupportModule_Handler()
 	return SupportHandler() is "support handler"
 end handler

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -94,6 +94,11 @@ on TestExtensionBridgeNumbers
          TestExtensionBridgeNumbers_ExecuteScript()
 end TestExtensionBridgeNumbers
 
+on TestExtensionBridgeEmptyArrays
+   TestAssert "LCS empty arrays bridge to LCB empty lists in library handlers", \
+         TestExtensionBridgeArrays_EmptyToEmptyList(empty)
+end TestExtensionBridgeEmptyArrays
+
 //////////
 
 on TestMultiModuleExtensions


### PR DESCRIPTION
This patch ensures that when empty is passed to an LCB
library handler argument with type List, that the empty
list is passed rather than throwing a type conversion
error.