### PR TITLE
[[ Bug 19057]] Add Release() to MCAutoScriptObjectRefBase

### DIFF
--- a/libscript/include/libscript/script-auto.h
+++ b/libscript/include/libscript/script-auto.h
@@ -61,6 +61,13 @@ public:
 		return m_value;
 	}
 
+	T Release(void)
+	{
+		T t_value = m_value;
+		m_value = nil;
+		return t_value;
+	}
+
 private:
 	T m_value;
 	MCAutoScriptObjectRefBase<T,REF,UNREF> & operator = (MCAutoScriptObjectRefBase<T,REF,UNREF> & x);


### PR DESCRIPTION
This patch adds a Take() method to the MCAutoScriptObject classes
allowing transfer of ownership away from the auto.