### PR TITLE
[[ Bug 19063 ]] Bind builtin foreign handlers to libscript's object

### DIFF
--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -652,31 +652,8 @@ __MCScriptLoadSharedLibrary(MCScriptModuleRef p_module,
 	// If there is no library name then we resolve to the executable module.
 	if (MCStringIsEmpty(p_library))
 	{
-#if defined(_WIN32)
-		r_handle = GetModuleHandle(NULL);
-#elif defined(TARGET_SUBPLATFORM_ANDROID)
-		// IM-2016-03-04: [[ Bug 16917 ]] dlopen can fail if the full path to the library is not
-		//    given, so first resolve the path to the library.
-		extern bool MCAndroidResolveLibraryPath(MCStringRef p_library,
-												MCStringRef &r_path);
-		MCAutoStringRef t_path;
-		if (!MCAndroidResolveLibraryPath(MCSTR("librevandroid.so"),
-										 &t_path))
-		{
-			return false;
-		}
-		
-		MCAutoStringRefAsCString t_cstring;
-		if (!t_cstring.Lock(*t_path))
-		{
-			return false;
-		}
-		
-		r_handle = dlopen(*t_cstring, 0);
-#else
-		r_handle = dlopen(NULL, 0);
-#endif
-		return true;
+        r_handle = MCScriptGetModuleHandle();
+        return true;
 	}
 	
 	// If there is no slash in the name, we try to resolve based on the module.
@@ -1116,7 +1093,7 @@ MCScriptEvaluateHandlerInInstanceInternal(MCScriptInstanceRef p_instance,
 	{
 		return false;
 	}
-	
+    
 	// Now put the handler value into the instance's handler list. First we make
 	// space in the array, then insert the value at the index we computed at the
 	// start.

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -711,15 +711,15 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                 MCScriptForeignType *t_type;
                 t_type = static_cast<MCScriptForeignType *>(self -> types[i]);
                 
+                MCAutoStringRefAsCString t_binding;
+                if (!t_binding.Lock(t_type->binding))
+                    goto error_cleanup; // oom
+                
                 void *t_symbol;
 #ifdef _WIN32
-				t_symbol = GetProcAddress(GetModuleHandle(NULL), MCStringGetCString(t_type -> binding));
-#elif defined(__EMSCRIPTEN__)
-				void *t_handle = dlopen(NULL, RTLD_LAZY);
-				t_symbol = dlsym(t_handle, MCStringGetCString(t_type->binding));
-				dlclose(t_handle);
+				t_symbol = GetProcAddress((HMODULE)MCScriptGetModuleHandle(), *t_binding);
 #else
-                t_symbol = dlsym(RTLD_DEFAULT, MCStringGetCString(t_type -> binding));
+                t_symbol = dlsym(MCScriptGetModuleHandle(), *t_binding);
 #endif
                 if (t_symbol == nil)
                 {

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -45,6 +45,13 @@ extern MCTypeInfoRef kMCScriptHandlerNotFoundErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Return the module handle for the loadable module containing libscript - this
+// is used to resolve 'builtin' foreign functions.
+void *
+MCScriptGetModuleHandle(void);
+
+////////////////////////////////////////////////////////////////////////////////
+
 enum MCScriptObjectKind
 {
     kMCScriptObjectKindNone,


### PR DESCRIPTION
This patch changes the use of GetProcAddress() / dlsym() in libscript
so that it uses the shared object containing libscript, rather than
the main application shared object.

The handle for libscript's shared object is acquired in Initialize
and released in Finalize.

It can be queried at any time using the (libscript private) API
MCScriptGetModuleHandle.