### PR TITLE
[[ Bug 19067 ]] Ensure error is thrown if no script access

### DIFF
--- a/docs/lcb/notes/19067.md
+++ b/docs/lcb/notes/19067.md
@@ -1,0 +1,5 @@
+# LiveCode Builder Host Library
+
+## Widget library
+
+# [19067] Ensure an error is thrown if there is no script access

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -104,9 +104,14 @@ bool MCEngineThrowNoScriptContextError(void)
 
 static uint32_t s_script_object_access_lock_count;
 
-bool MCEngineScriptObjectAccessIsAllowed(void)
+bool MCEngineEnsureScriptObjectAccessIsAllowed(void)
 {
-    return s_script_object_access_lock_count == 0;
+    if (s_script_object_access_lock_count != 0)
+    {
+        return MCEngineThrowNoScriptContextError();
+    }
+    
+    return true;
 }
 
 void MCEngineScriptObjectPreventAccess(void)
@@ -142,8 +147,10 @@ MCEngineEvalScriptResult (MCExecContext& ctxt)
 
 extern "C" MC_DLLEXPORT_DEF MCScriptObjectRef MCEngineExecResolveScriptObject(MCStringRef p_object_id)
 {
-    if (!MCEngineScriptObjectAccessIsAllowed())
+    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
+    {
         return nil;
+    }
     
     MCExecContext ctxt(MCdefaultstackptr, nil, nil);
     
@@ -239,9 +246,6 @@ static inline bool MCEngineEvalObjectOfScriptObject(MCScriptObjectRef p_object, 
 
 MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id)
 {
-    if (!MCEngineScriptObjectAccessIsAllowed())
-        return nil;
-    
 	Properties t_prop;
 	t_prop = parse_property_name(p_property);
 	
@@ -276,9 +280,8 @@ MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_proper
 
 extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object, MCValueRef& r_value)
 {
-    if (!MCEngineScriptObjectAccessIsAllowed())
+    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
     {
-        r_value = MCValueRetain(kMCNull);
         return;
     }
     
@@ -286,7 +289,6 @@ extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringR
 	uint32_t t_part_id;
 	if (!MCEngineEvalObjectOfScriptObject(p_object, t_object, t_part_id))
     {
-        r_value = MCValueRetain(kMCNull);
         return;
     }
 	
@@ -339,6 +341,11 @@ void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MC
 
 extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfScriptObject(MCValueRef p_value, MCStringRef p_property, MCScriptObjectRef p_object)
 {
+    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
+    {
+        return;
+    }
+    
 	MCObject *t_object;
 	uint32_t t_part_id;
 	if (!MCEngineEvalObjectOfScriptObject(p_object, t_object, t_part_id))
@@ -493,7 +500,7 @@ cleanup:
 
 extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecSendToScriptObjectWithArguments(bool p_is_function, MCStringRef p_message, MCScriptObjectRef p_object, MCProperListRef p_arguments)
 {
-    if (!MCEngineScriptObjectAccessIsAllowed())
+    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
         return nil;
     
 	MCObject *t_object;
@@ -529,7 +536,7 @@ void MCEngineDoPostToObjectWithArguments(MCStringRef p_message, MCObject *p_obje
 
 extern "C" MC_DLLEXPORT_DEF void MCEngineExecPostToScriptObjectWithArguments(MCStringRef p_message, MCScriptObjectRef p_object, MCProperListRef p_arguments)
 {
-    if (!MCEngineScriptObjectAccessIsAllowed())
+    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
         return;
     
 	MCObject *t_object;
@@ -561,7 +568,7 @@ extern "C" MC_DLLEXPORT_DEF void MCEngineEvalMessageWasNotHandled(bool& r_not_ha
 
 extern "C" MC_DLLEXPORT_DEF MCValueRef MCEngineExecExecuteScript(MCStringRef p_script)
 {
-    if (!MCEngineScriptObjectAccessIsAllowed())
+    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
         return nil;
     
     MCStack *t_stack;

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -1001,12 +1001,19 @@ void MCWidget::GetKind(MCExecContext& ctxt, MCNameRef& r_kind)
 void MCWidget::GetState(MCExecContext& ctxt, MCArrayRef& r_state)
 {
     MCAutoValueRef t_value;
-    MCWidgetOnSave(m_widget, &t_value);
+    if (!MCWidgetOnSave(m_widget,
+                        &t_value))
+    {
+        r_state = MCValueRetain(kMCEmptyArray);
+        return;
+    }
+    
     if (!MCExtensionConvertToScriptType(ctxt, InOut(t_value)))
     {
         CatchError(ctxt);
         return;
     }
+    
     r_state = (MCArrayRef)t_value . Take();
 }
 

--- a/tests/lcs/core/engine/_widget.lcb
+++ b/tests/lcs/core/engine/_widget.lcb
@@ -1,0 +1,23 @@
+widget com.livecode.lcs_tests.core.widget
+
+private variable mTestMode
+
+property testMode get mTestMode set mTestMode
+
+public handler OnSave(out rProperties as Array)
+   if mTestMode is "resolve" then
+      resolve script object "this stack"
+   else if mTestMode is "get" then
+      get property "name" of my script object
+   else if mTestMode is "set" then
+      set property "name" of my script object to "foo"
+   else if mTestMode is "send" then
+      send "foo" to my script object
+   else if mTestMode is "post" then
+      post "foo" to my script object
+   else if mTestMode is "execute" then
+      execute script "return 1"
+   end if
+end handler
+
+end widget

--- a/tests/lcs/core/engine/widget.livecodescript
+++ b/tests/lcs/core/engine/widget.livecodescript
@@ -1,0 +1,82 @@
+script "CoreEngineWidgets"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+//////////
+
+on TestSetup
+   TestLoadAuxillaryExtension "_widget"
+   TestLoadAuxillaryExtension "_widget_support"
+end TestSetup
+
+//////////
+
+on TestWidgetBindErrorsDontEscape
+   create stack "WidgetBindErrorTest"
+   set the defaultStack to "WidgetBindErrorTest"
+
+   local tArray
+   put "foo" into tArray["$kind"]
+   put empty into tArray["$state"]
+   import widget from array tArray
+
+   local tErrorIsPending
+   try
+      put TestWidget_MCErrorIsPending() into tErrorIsPending
+   catch tError
+      put true into tErrorIsPending
+   end try
+
+   TestAssert "no error lingers after widget bind failure", not tErrorIsPending
+
+   delete stack "WidgetBindErrorTest"
+end TestWidgetBindErrorsDontEscape
+
+//////////
+
+global gLastSentWidgetError
+
+private command _DoTestWidgetScriptObjectAccess pMode
+   set the testMode of widget "Test" to pMode
+
+   export widget "Test" to array tVar
+
+   put empty into gLastSentWidgetError
+   wait for messages
+
+   TestAssert "no script access allowed for" && pMode, gLastSentWidgetError contains "script access not allowed"
+end _DoTestWidgetScriptObjectAccess
+
+on TestWidgetScriptObjectAccess
+   create stack "WidgetScriptAccessTest"
+   set the defaultStack to "WidgetScriptAccessTest"
+
+   create widget "Test" as "com.livecode.lcs_tests.core.widget"
+   set the behavior of it to the long id of me
+
+   repeat for each item tMode in "resolve,get,set,send,post,execute"
+      _DoTestWidgetScriptObjectAccess tMode
+   end repeat
+
+   delete stack "WidgetScriptAccessTest"
+end TestWidgetScriptObjectAccess
+
+//////////
+
+on errorDialog pError
+   put pError into gLastSentWidgetError
+end errorDialog


### PR DESCRIPTION
This patch ensures that an error is thrown if an attempt to use
an operation requiring script access is used in a context which
has no script access.