### PR TITLE
MCObjectPropertySet::m_name: Convert to managed pointer.

### DIFF
--- a/engine/src/objectpropsets.cpp
+++ b/engine/src/objectpropsets.cpp
@@ -40,7 +40,7 @@ extern bool MCStringsSplit(MCStringRef p_string, codepoint_t p_delimiter, MCStri
 bool MCObjectPropertySet::clone(MCObjectPropertySet*& r_set)
 {
 	MCObjectPropertySet *t_new_set;
-	if (createwithname(m_name, t_new_set))
+	if (createwithname(*m_name, t_new_set))
 	{
 		MCValueRelease(t_new_set -> m_props);
 		if (MCArrayMutableCopy(m_props, t_new_set -> m_props))
@@ -62,7 +62,7 @@ bool MCObjectPropertySet::createwithname_nocopy(MCNameRef p_name, MCObjectProper
 	if (t_new_set == nil)
 		return false;
 
-	t_new_set -> m_name = p_name;
+	t_new_set->m_name.Give(p_name);
 
 	r_set = t_new_set;
 

--- a/engine/src/objectpropsets.h
+++ b/engine/src/objectpropsets.h
@@ -25,24 +25,23 @@ public:
 	MCObjectPropertySet(void)
 	{
 		m_next = nil;
-		m_name = nil;
         /* UNCHECKED */ MCArrayCreateMutable(m_props);
 	}
 
 	~MCObjectPropertySet(void)
 	{
-		MCNameDelete(m_name);
 		MCValueRelease(m_props);
 	}
 
 	bool hasname(MCNameRef p_name)
 	{
-		return MCNameIsEqualTo(m_name, p_name, kMCCompareCaseless);
+        return m_name.IsSet() &&
+            MCNameIsEqualTo(*m_name, p_name, kMCCompareCaseless);
 	}
 
 	MCNameRef getname(void)
 	{
-		return m_name;
+		return *m_name;
 	}
 
 	MCObjectPropertySet *getnext(void)
@@ -57,8 +56,7 @@ public:
 
 	void changename_nocopy(MCNameRef p_name)
 	{
-		MCNameDelete(m_name);
-		m_name = p_name;
+        m_name.Give(p_name);
 	}
 
 	/* CAN FAIL */ bool clone(MCObjectPropertySet*& r_set);
@@ -113,7 +111,7 @@ public:
 
 private:
 	MCObjectPropertySet *m_next;
-	MCNameRef m_name;
+	MCNewAutoNameRef m_name;
 	MCArrayRef m_props;
 };
 


### PR DESCRIPTION
This started off as a fix to CID 17002: unchecked allocation of an `MCArrayRef` within the `MCObjectPropertySet` constructor.  Unfortunately changing `m_props` to an `MCAutoArrayRef` seems to require substantially rewriting `MCObjectPropertySet`, which is slightly too large a refactor for now.  However, I took the opportunity to turn the `MCObjectPropertySet::m_name` into a managed pointer, since I was looking at the code anyway.