### PR TITLE
[[ Bug 19060 ]] Ensure errors when binding widget don't linger

### DIFF
--- a/docs/notes/bugfix-19060.md
+++ b/docs/notes/bugfix-19060.md
@@ -1,0 +1,1 @@
+# Ensure error when binding widget is caught correctly

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -129,6 +129,11 @@ void MCWidget::bind(MCNameRef p_kind, MCValueRef p_rep)
     // If we failed then store the rep and destroy the imp.
     if (!t_success)
     {
+        // Make sure we swallow the error so that it doesn't affect
+        // future execution.
+        MCAutoErrorRef t_error;
+        MCErrorCatch(&t_error);
+        
         MCValueRelease(m_widget);
         m_widget = nil;
         

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -126,7 +126,7 @@ private function _TestGetBuildFolder
          return tPath
       end if
       delete item -1 of tPath
-   end repeat	
+   end repeat
 end _TestGetBuildFolder
 
 private function _TestGetBuiltExtensionsFolder
@@ -213,7 +213,7 @@ function TestGetExtractedDocsFolder
    return _TestGetBuildFolder() & slash & "extracted_docs"
 end TestGetExtractedDocsFolder
 
-on TestLoadExtension pName	
+on TestLoadExtension pName
    set the itemdelimiter to "."
    local tExtensionUnzipFolder
    put pName into tExtensionUnzipFolder
@@ -249,6 +249,26 @@ on TestLoadExtension pName
    end if
 
 end TestLoadExtension
+
+-- This loads an extension whose lcb source sits in the same folder as the
+-- current test.
+on TestLoadAuxillaryExtension pName
+	local tBasePath, tExtraPath
+	set the itemDelimiter to slash
+	put item 1 to -2 of the filename of this stack into tBasePath
+	repeat while the last item of tBasePath is not "tests"
+		put item -1 of tBasePath & slash before tExtraPath
+		delete the last item of tBasePath
+	end repeat
+
+	local tModuleFile
+	put tBasePath & "/../_tests/_build/" & tExtraPath & pName & ".lcm" into tModuleFile
+
+	load extension from data url ("binfile:" & tModuleFile)
+	if the result is not empty then
+		throw "Failed to load auxillary extension:" && the result && tModuleFile
+	end if
+end TestLoadAuxillaryExtension
 
 on TestLoadAllExtensions
    local tExtFolder

--- a/tests/lcs/core/engine/_widget.lcb
+++ b/tests/lcs/core/engine/_widget.lcb
@@ -1,0 +1,3 @@
+widget com.livecode.lcs_tests.core.widget
+
+end widget

--- a/tests/lcs/core/engine/_widget_support.lcb
+++ b/tests/lcs/core/engine/_widget_support.lcb
@@ -1,0 +1,12 @@
+library com.livecode.lcs_tests.core.widget_support
+
+use com.livecode.foreign
+
+private foreign handler MCErrorIsPending() returns CBool binds to "<builtin>"
+public handler TestWidget_MCErrorIsPending() returns Boolean
+	unsafe
+		return MCErrorIsPending()
+	end unsafe
+end handler
+
+end library

--- a/tests/lcs/core/engine/widget.livecodescript
+++ b/tests/lcs/core/engine/widget.livecodescript
@@ -1,0 +1,47 @@
+script "CoreEngineWidgets"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+//////////
+
+on TestSetup
+   TestLoadAuxillaryExtension "_widget"
+   TestLoadAuxillaryExtension "_widget_support"
+end TestSetup
+
+//////////
+
+on TestWidgetBindErrorsDontEscape
+   create stack "WidgetErrorTest"
+   set the defaultStack to "WidgetErrorTest"
+
+   local tArray
+   put "foo" into tArray["$kind"]
+   put empty into tArray["$state"]
+   import widget from array tArray
+
+   local tErrorIsPending
+   try
+      put TestWidget_MCErrorIsPending() into tErrorIsPending
+   catch tError
+      put true into tErrorIsPending
+   end try
+
+   TestAssert "no error lingers after widget bind failure", not tErrorIsPending
+end TestWidgetBindErrorsDontEscape
+
+//////////


### PR DESCRIPTION
This patch swallows any error resulting from attempting to bind a
widget to ensure that it does not affect subsequent execution.