### PR TITLE
[[ Bug 19046 ]] Fix error reporting for undeclared identifier

### DIFF
--- a/docs/lcb/notes/19046.md
+++ b/docs/lcb/notes/19046.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Tools
+
+# [19046] Ensure error is reported for undeclared identifiers 

--- a/tests/lcb/compiler/frontend/namespace.compilertest
+++ b/tests/lcb/compiler/frontend/namespace.compilertest
@@ -69,7 +69,7 @@ variable ModuleVar as Number
 handler Shadow()
 	variable ModuleVar as String
 	put "a" into ModuleVar
-	
+
 	put 5 into compiler_test.ModuleVar
 end handler
 end module
@@ -87,4 +87,18 @@ end handler
 end module
 %EXPECT PASS
 %ERROR "Identifier 'nonexistent_module.DoNothing' not declared" AT AFTER_IDENTIFIER
+%ENDTEST
+
+%TEST UseUndeclaredIdentifier
+module compiler_test
+handler Foo()
+	variable tFoo as %{BEFORE_TYPE}UndeclaredType
+	%{BEFORE_HANDLER}UndeclaredHandler()
+	put %{BEFORE_VAR}UndeclaredVar into tFoo
+end handler
+end module
+%EXPECT PASS
+%ERROR "Identifier 'UndeclaredType' not declared" AT BEFORE_TYPE
+%ERROR "Identifier 'UndeclaredHandler' not declared" AT BEFORE_HANDLER
+%ERROR "Identifier 'UndeclaredVar' not declared" AT BEFORE_VAR
 %ENDTEST

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -628,7 +628,7 @@
 
 --------------------------------------------------------------------------------
 
-'action' ResolveNamespace(OPTIONALID -> NAME)
+'condition' ResolveNamespace(OPTIONALID -> NAME)
 
 'action' DeclareImportedId(ID, ID)
 

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -1319,7 +1319,7 @@
 	'rule' ResolveIdInNamespace(nil, Id -> Name):
 		Id'Name -> Name
 
-'action' ResolveNamespace(OPTIONALID -> NAME)
+'condition' ResolveNamespace(OPTIONALID -> NAME)
 
 	'rule' ResolveNamespace(id(NamespaceId) -> Name):
 		GetQualifiedName(NamespaceId -> Name)


### PR DESCRIPTION
This patch ensures that the appropriate error is reported when
attempting to use an undeclared identifier.