### PR TITLE
[[ Bug 19059 ]] Add access to LCS delimiter local properties to LCB

### DIFF
--- a/docs/lcb/notes/19059.md
+++ b/docs/lcb/notes/19059.md
@@ -1,0 +1,9 @@
+# LiveCode Builder Host Library
+
+## Engine Library
+
+* Library handlers can now access the delimiter properties set in the
+  most recent script context using `the line delimiter`, `the item delimiter`,
+  `the row delimiter` and `the column delimiter`.
+
+# [19059] Add access to script delimiters

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -1,16 +1,16 @@
 /* Copyright (C) 2003-2015 LiveCode Ltd.
- 
+
  This file is part of LiveCode.
- 
+
  LiveCode is free software; you can redistribute it and/or modify it under
  the terms of the GNU General Public License v3 as published by the Free
  Software Foundation.
- 
+
  LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
  WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
@@ -63,11 +63,16 @@ public foreign handler MCEngineRemoveRunloopAction(in pAction as MCRunloopAction
 public foreign handler MCEngineRunloopWait() returns CBool binds to "<builtin>"
 public foreign handler MCEngineRunloopBreakWait() returns nothing binds to "<builtin>"
 
+public foreign handler MCEngineEvalTheColumnDelimiter(out rDelimiter as String) returns nothing binds to "<builtin>"
+public foreign handler MCEngineEvalTheRowDelimiter(out rDelimiter as String) returns nothing binds to "<builtin>"
+public foreign handler MCEngineEvalTheLineDelimiter(out rDelimiter as String) returns nothing binds to "<builtin>"
+public foreign handler MCEngineEvalTheItemDelimiter(out rDelimiter as String) returns nothing binds to "<builtin>"
+
 /**
 Summary:	Resolves a string to a script object.
 Object:		The string describing the script object.
 
-The result:	The resolved script object. 
+The result:	The resolved script object.
 
 Example:
 	variable tObject as ScriptObject
@@ -78,8 +83,8 @@ Example:
 		log the result
 	else
 		log "No such button"
-	end if	
-	
+	end if
+
 Description:
 Use the <ResolveScriptObject|resolve script object> statement to obtain a <ScriptObject> in LiveCode Builder, in order to interact with it.
 
@@ -107,8 +112,8 @@ Example:
 		set property "name" of tObject to "Card5"
 	else
 		log "No such card"
-	end if	
-	
+	end if
+
 Description:
 Use to test the existence or otherwise of a script object, for example after attempting to resolve the object from a string using <ResolveScriptObject | resolve script object>
 
@@ -133,8 +138,8 @@ Example:
 	put the result into tObject
 	if tObject does not exist then
 		log "No such card"
-	end if	
-	
+	end if
+
 Description:
 Use to test the non-existence or otherwise of a script object, for example after attempting to resolve the object from a string using <ResolveScriptObject|resolve script object>
 
@@ -162,7 +167,7 @@ Example:
 	resolve script object "this stack"
 	set property "invisible" of the result to true
     get property "script" of my script object
-	
+
 Description:
 Use to manipulate properties of a script object.
 
@@ -251,7 +256,7 @@ Example:
 		// Send a message to the script so it can handle it.
 		send "buttonClicked" to my script object
 	end handler
-	
+
 Example:
 	// myScriptFunction takes three arguments and performs some kind of calculation
 
@@ -259,9 +264,9 @@ Example:
 	resolve script object "this stack"
 	put the result into tObject
 	send function "myScriptFunction" to tObject with [ 2, 3, 4 ]
-	
+
 	// the result contains the return value of 'myScriptFunction'
-    
+
 Description:
 Sends a message to the given script object and waits for it to finish so that it
 can return a value.
@@ -290,7 +295,7 @@ Example:
 		// Send a message to the script so it can handle it.
 		post "buttonClicked" to my script object
 	end handler
-    
+
 Description:
 Post a message to the given script object and returns immediately. Posting a message
 will cause the message to be sent at the next wait point (usually when the current
@@ -311,10 +316,10 @@ Example:
 		dispatch "buttonClicked" to my script object
 		if the message was handled then
 			return
-		end if	
+		end if
 		log "The message was not handled"
 	end handler
-	
+
 Description:
 Determines if a dispatched message was handled by any script objects in the message path.
 */
@@ -333,9 +338,9 @@ Example:
 		dispatch "buttonClicked" to my script object
 		if the message was not handled then
 			log "The message was not handled"
-		end if	
+		end if
 	end handler
-	
+
 Description:
 Determines if a dispatched message was handled by any script objects in the message path.
 */
@@ -382,10 +387,10 @@ Example:
 	variable tList as List
 	get property "name" of my script object
 	push the result onto tList
-	
+
 	get property "id" of my script object
 	push the result onto tList
-	
+
 	log "Widget %@ has id %@" with tList
 
 Description:
@@ -404,6 +409,70 @@ syntax Log is statement
 begin
     MCEngineExecLog(Message)
     MCEngineExecLogWithValues(Message, Arguments)
+end syntax
+
+/**
+Summary: 	Fetches the 'columnDelimiter' property from script context
+
+Example:
+	split tString by the column delimiter
+
+Description:
+Fetches the calling (script) handler's columnDelimiter property. If there is no
+script context, then it returns tab.
+*/
+syntax TheColumnDelimiter is expression
+    "the" "column" "delimiter"
+begin
+    MCEngineEvalTheColumnDelimiter(output)
+end syntax
+
+/**
+Summary: 	Fetches the 'rowDelimiter' property from script context
+
+Example:
+	split tString by the row delimiter
+
+Description:
+Fetches the calling (script) handler's rowDelimiter property. If there is no
+script context, then it returns lf.
+*/
+syntax TheRowDelimiter is expression
+    "the" "row" "delimiter"
+begin
+    MCEngineEvalTheRowDelimiter(output)
+end syntax
+
+/**
+Summary: 	Fetches the 'lineDelimiter' property from script context
+
+Example:
+	split tString by the line delimiter
+
+Description:
+Fetches the calling (script) handler's lineDelimiter property. If there is no
+script context, then it returns lf.
+*/
+syntax TheLineDelimiter is expression
+    "the" "line" "delimiter"
+begin
+    MCEngineEvalTheLineDelimiter(output)
+end syntax
+
+/**
+Summary: 	Fetches the 'itemDelimiter' property from script context
+
+Example:
+	split tString by the item delimiter
+
+Description:
+Fetches the calling (script) handler's itemDelimiter property. If there is no
+script context, then it returns comma.
+*/
+syntax TheItemDelimiter is expression
+    "the" "item" "delimiter"
+begin
+    MCEngineEvalTheItemDelimiter(output)
 end syntax
 
 end module

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -412,14 +412,20 @@ begin
 end syntax
 
 /**
-Summary: 	Fetches the 'columnDelimiter' property from script context
+Summary: 	Fetches the `columnDelimiter` property from script context
 
 Example:
-	split tString by the column delimiter
+   -- Split a string into a list using the column delimiter
+   variable tItems
+   put "alice\tbob\teve" into tItems
+   split tItems by the column delimiter
+   -- tItems is now a list: ["alice", "bob", "eve"]
 
 Description:
-Fetches the calling (script) handler's columnDelimiter property. If there is no
-script context, then it returns tab.
+Fetches the calling (script) handler's `columnDelimiter` property, or horizontal
+tab (U+0009) if no script context is available.
+
+Related: TheRowDelimiter (expression), TheItemDelimiter (expression), TheLineDelimiter (expression)
 */
 syntax TheColumnDelimiter is expression
     "the" "column" "delimiter"
@@ -428,14 +434,20 @@ begin
 end syntax
 
 /**
-Summary: 	Fetches the 'rowDelimiter' property from script context
+Summary: 	Fetches the `rowDelimiter` property from script context
 
 Example:
-	split tString by the row delimiter
+  -- Split a string into a list using the row delimiter
+   variable tItems
+   put "alice\nbob\neve" into tItems
+   split tItems by the row delimiter
+   -- tItems is now a list: ["alice", "bob", "eve"]
 
 Description:
-Fetches the calling (script) handler's rowDelimiter property. If there is no
-script context, then it returns lf.
+Fetches the calling (script) handler's `rowDelimiter` property, or linefeed
+(U+000A) if no script context is available.
+
+Related: TheColumnDelimiter (expression), TheItemDelimiter (expression), TheLineDelimiter (expression)
 */
 syntax TheRowDelimiter is expression
     "the" "row" "delimiter"
@@ -444,14 +456,20 @@ begin
 end syntax
 
 /**
-Summary: 	Fetches the 'lineDelimiter' property from script context
+Summary: 	Fetches the `lineDelimiter` property from script context
 
 Example:
-	split tString by the line delimiter
+  -- Split a string into a list using the line delimiter
+   variable tItems
+   put "alice\nbob\neve" into tItems
+   split tItems by the line delimiter
+   -- tItems is now a list: ["alice", "bob", "eve"]
 
 Description:
-Fetches the calling (script) handler's lineDelimiter property. If there is no
-script context, then it returns lf.
+Fetches the calling (script) handler's `lineDelimiter` property, or linefeed
+(U+000A) if no script context is available.
+
+Related: TheColumnDelimiter (expression), TheItemDelimiter (expression), TheRowDelimiter (expression)
 */
 syntax TheLineDelimiter is expression
     "the" "line" "delimiter"
@@ -460,14 +478,20 @@ begin
 end syntax
 
 /**
-Summary: 	Fetches the 'itemDelimiter' property from script context
+Summary: 	Fetches the `itemDelimiter` property from script context
 
 Example:
-	split tString by the item delimiter
+  -- Split a string into a list using the item delimiter
+   variable tItems
+   put "alice,bob,eve" into tItems
+   split tItems by the item delimiter
+   -- tItems is now a list: ["alice", "bob", "eve"]
 
 Description:
-Fetches the calling (script) handler's itemDelimiter property. If there is no
-script context, then it returns comma.
+Fetches the calling (script) handler's `itemDelimiter` property, or the comma
+char if no script context is available.
+
+Related: TheColumnDelimiter (expression), TheLineDelimiter (expression), TheRowDelimiter (expression)
 */
 syntax TheItemDelimiter is expression
     "the" "item" "delimiter"

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -31,6 +31,8 @@ Description:
 Use the <ResolveScriptObject|resolve script object>, or <MyScriptObject|my script object> to obtain an object of type <ScriptObject>
 
 References: ResolveScriptObject(statement), MyScriptObject(expression)
+
+Tags: Script Engine
 */
 
 module com.livecode.engine
@@ -90,6 +92,8 @@ Use the <ResolveScriptObject|resolve script object> statement to obtain a <Scrip
 
 >*Note:* An error is thrown if this syntax is used in a context where access
 to script objects is not allowed.
+
+Tags: Script Engine
 */
 
 syntax ResolveScriptObject is statement
@@ -118,6 +122,8 @@ Description:
 Use to test the existence or otherwise of a script object, for example after attempting to resolve the object from a string using <ResolveScriptObject | resolve script object>
 
 References: ResolveScriptObject(statement)
+
+Tags: Script Engine
 */
 
 syntax ScriptObjectExists is postfix operator with comparison precedence
@@ -144,6 +150,8 @@ Description:
 Use to test the non-existence or otherwise of a script object, for example after attempting to resolve the object from a string using <ResolveScriptObject|resolve script object>
 
 References: ResolveScriptObject(statement)
+
+Tags: Script Engine
 */
 
 syntax ScriptObjectDoesNotExist is postfix operator with comparison precedence
@@ -175,6 +183,8 @@ Use to manipulate properties of a script object.
 
 >*Note:* An error is thrown if this syntax is used in a context where access
 to script objects is not allowed.
+
+Tags: Script Engine
 */
 
 syntax PropertyOfScriptObject is prefix operator with property precedence
@@ -204,6 +214,8 @@ Description:
 	Use to get the script object that contains a script object.
 
 >*Note:* An error is thrown if the script object does not exist.
+
+Tags: Script Engine
 */
 
 syntax OwnerOfScriptObject is prefix operator with property precedence
@@ -235,6 +247,8 @@ Description:
 	Use to get the script objects contained within a script object.
 
 >*Note:* An error is thrown if the script object does not exist.
+
+Tags: Script Engine
 */
 
 syntax ChildrenOfScriptObject is prefix operator with property precedence
@@ -276,6 +290,8 @@ message passed through the message path untouched.
 
 >*Note:* An error is thrown if this syntax is used in a context where access
 to script objects is not allowed.
+
+Tags: Script Engine
 */
 syntax SendToScriptObject is statement
     "send" ( "function" <IsFunction=true> | "command" <IsFunction=false> | <IsFunction=false> ) <Message: Expression> "to" <Object: Expression> [ "with" <Arguments: Expression> ]
@@ -300,6 +316,8 @@ Description:
 Post a message to the given script object and returns immediately. Posting a message
 will cause the message to be sent at the next wait point (usually when the current
 event has finished being handled).
+
+Tags: Script Engine
 */
 syntax PostToScriptObject is statement
     "post" <Message: Expression> "to" <Object: Expression> [ "with" <Arguments: Expression> ]
@@ -322,6 +340,8 @@ Example:
 
 Description:
 Determines if a dispatched message was handled by any script objects in the message path.
+
+Tags: Script Engine
 */
 
 syntax MessageWasHandled is expression
@@ -343,6 +363,8 @@ Example:
 
 Description:
 Determines if a dispatched message was handled by any script objects in the message path.
+
+Tags: Script Engine
 */
 
 syntax MessageWasNotHandled is expression
@@ -370,6 +392,8 @@ Executes the given piece of LiveCode script in the context of the current script
 object.
 >*Note:* An error is thrown if this syntax is used in a context where access
 to script objects is not allowed.
+
+Tags: Script Engine
 */
 
 syntax ExecuteScript is statement
@@ -402,6 +426,7 @@ on logChanged pLog
 end logChanged
 ```
 
+Tags: Script Engine
 */
 
 syntax Log is statement
@@ -426,6 +451,8 @@ Fetches the calling (script) handler's `columnDelimiter` property, or horizontal
 tab (U+0009) if no script context is available.
 
 Related: TheRowDelimiter (expression), TheItemDelimiter (expression), TheLineDelimiter (expression)
+
+Tags: Script Engine
 */
 syntax TheColumnDelimiter is expression
     "the" "column" "delimiter"
@@ -448,6 +475,8 @@ Fetches the calling (script) handler's `rowDelimiter` property, or linefeed
 (U+000A) if no script context is available.
 
 Related: TheColumnDelimiter (expression), TheItemDelimiter (expression), TheLineDelimiter (expression)
+
+Tags: Script Engine
 */
 syntax TheRowDelimiter is expression
     "the" "row" "delimiter"
@@ -470,6 +499,8 @@ Fetches the calling (script) handler's `lineDelimiter` property, or linefeed
 (U+000A) if no script context is available.
 
 Related: TheColumnDelimiter (expression), TheItemDelimiter (expression), TheRowDelimiter (expression)
+
+Tags: Script Engine
 */
 syntax TheLineDelimiter is expression
     "the" "line" "delimiter"
@@ -492,6 +523,8 @@ Fetches the calling (script) handler's `itemDelimiter` property, or the comma
 char if no script context is available.
 
 Related: TheColumnDelimiter (expression), TheLineDelimiter (expression), TheRowDelimiter (expression)
+
+Tags: Script Engine
 */
 syntax TheItemDelimiter is expression
     "the" "item" "delimiter"

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -782,6 +782,46 @@ extern "C" MC_DLLEXPORT_DEF void MCEngineRunloopBreakWait()
 
 ////////////////////////////////////////////////////////////////////////////////
 
+extern MCExecContext *MCECptr;
+
+extern "C" MC_DLLEXPORT_DEF void
+MCEngineEvalTheColumnDelimiter(MCStringRef& r_del)
+{
+    MCStringRef t_del =
+        MCECptr != nil ? MCECptr->GetColumnDelimiter() : MCSTR("\t");
+
+    r_del = MCValueRetain(t_del);
+}
+
+extern "C" MC_DLLEXPORT_DEF void
+MCEngineEvalTheRowDelimiter(MCStringRef& r_del)
+{
+    MCStringRef t_del =
+        MCECptr != nil ? MCECptr->GetRowDelimiter() : MCSTR("\n");
+    
+    r_del = MCValueRetain(t_del);
+}
+
+extern "C" MC_DLLEXPORT_DEF void
+MCEngineEvalTheLineDelimiter(MCStringRef& r_del)
+{
+    MCStringRef t_del =
+            MCECptr != nil ? MCECptr->GetLineDelimiter() : MCSTR("\n");
+
+    r_del = MCValueRetain(t_del);
+}
+
+extern "C" MC_DLLEXPORT_DEF void
+MCEngineEvalTheItemDelimiter(MCStringRef& r_del)
+{
+    MCStringRef t_del =
+            MCECptr != nil ? MCECptr->GetItemDelimiter() : MCSTR(",");
+    
+    r_del = MCValueRetain(t_del);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCEngineScriptObjectDoesNotExistErrorTypeInfo = nil;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCEngineScriptObjectNoContextErrorTypeInfo = nil;
 

--- a/tests/lcs/core/engine/_extension.lcb
+++ b/tests/lcs/core/engine/_extension.lcb
@@ -33,4 +33,8 @@ public handler TestExtensionSupportModule_Handler()
 	return SupportHandler() is "support handler"
 end handler
 
+public handler TestExtensionDelimiterAccess()
+	return [the item delimiter, the line delimiter, the column delimiter, the row delimiter]
+end handler
+
 end library

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -161,3 +161,19 @@ on TestExtensionLibraryHandlerCallErrors
          the long id of me, \
          886
 end TestExtensionLibraryHandlerCallErrors
+
+//////////
+
+on TestExtensionLibraryDelimiterAccess
+   set the itemDelimiter to "a"
+   set the lineDelimiter to "b"
+   set the columnDelimiter to "c"
+   set the rowDelimiter to "d"
+
+   local tDelimiters
+   put TestExtensionDelimiterAccess() into tDelimiters
+   combine tDelimiters with comma
+
+   TestDiagnostic tDelimiters
+   TestAssert "library handler can access delimiters", tDelimiters is "a,b,c,d"
+end TestExtensionLibraryDelimiterAccess


### PR DESCRIPTION
This patch adds the following syntax to LCB when running in the
LC engine:

   the line delimiter
   the item delimiter
   the row delimiter
   the column delimiter

These give access to the value of the delimiter properties in the
most recent LCS handler on the stack; or sensible defaults if there
is no LCS handler on the stack.