### PR TITLE
[Coverity] Fix some "uninitialised pointer field" defects

### DIFF
--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -2482,7 +2482,7 @@ void MCField::SetTextStyleElementOfCharChunk(MCExecContext& ctxt, MCNameRef p_in
 
 void MCParagraph::GetEncoding(MCExecContext &ctxt, intenum_t &r_encoding)
 {
-    if (MCStringIsNative(m_text))
+    if (MCStringIsNative(*m_text))
         r_encoding = 0; // nativestring
     else
         r_encoding = 1; // unicode

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -52,6 +52,12 @@ enum MCExecValueType
 
 struct MCExecValue
 {
+public:
+	MCExecValue()
+	{
+		MCMemoryClear(*this);
+		type = kMCExecValueTypeNone;
+	}
 	union
 	{
 		MCValueRef valueref_value;

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -50,6 +50,10 @@ Boolean MCHandler::gotpass;
 ////////////////////////////////////////////////////////////////////////////////
 
 MCHandler::MCHandler(uint1 htype, bool p_is_private)
+    : hlist(),
+      npassedparams(),
+      firstline(),
+      lastline()
 {
 	statements = NULL;
 	vars = NULL;

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -92,7 +92,7 @@ MCIdeState *MCIdeState::s_states = NULL;
 MCIdeState *MCIdeState::s_cache = NULL;
 
 MCIdeState::MCIdeState(void)
-	: f_next(NULL), f_line_count(0), f_line_properties(0)
+	: f_next(NULL), f_field(nullptr), f_line_count(0), f_line_properties(0)
 {
 }
 

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -90,8 +90,6 @@ MCScreenDC::~MCScreenDC()
 		delete allocs;
 	}
 	
-    MCNameDelete(vendorname);
-	
 	while (pendingevents != NULL)
 	{
 		MCEventnode *tptr =(MCEventnode *)pendingevents->remove

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -70,27 +70,7 @@ MCGFloat MCResGetSystemScale(void)
 
 MCScreenDC::MCScreenDC()
 {
-	ncolors = 0;
-	ownselection = False;
-	pendingevents = NULL;
-	backdrop = DNULL;
-
-	m_backdrop_pixmap = nil;
-	
-	//Xinerama_available = false ;
-	//getdisplays_init = false ;
-
 	m_application_has_focus = true ; // The application start's up having focus, one assumes.
-	
-	backdrop_hard = false;
-	backdrop_active = false;
-    
-    m_has_native_theme = false;
-    m_has_native_color_dialogs = false;
-    m_has_native_file_dialogs = false;
-    m_has_native_print_dialogs = false;
-
-	m_im_context = NULL;
 }
 
 MCScreenDC::~MCScreenDC()

--- a/engine/src/lnxdc.h
+++ b/engine/src/lnxdc.h
@@ -110,63 +110,63 @@ extern Boolean tripleclick;
 
 class MCScreenDC : public MCUIDC
 {
-	GdkGC* gc;		// This is the GC in "Native" (i.e. actual screen) depth
+	GdkGC* gc = nullptr;		// This is the GC in "Native" (i.e. actual screen) depth
 	
-	bool m_application_has_focus ; // This allows us to track if the application is at the front.
+	bool m_application_has_focus = false; // This allows us to track if the application is at the front.
 	
-	Atom statusatom;
-	Atom selectionatom;
+	Atom statusatom = GDK_NONE;
+	Atom selectionatom = GDK_NONE;
 
-	uint2 destdepth; //
+	uint2 destdepth = 0; //
 	
-	Boolean opened;
+	Boolean opened = false;
 	
-	Window Xwin; //
-	Window NULLWindow ;
+	Window Xwin = None; //
+	Window NULLWindow = None;
 	
-	MCEventnode *pendingevents;
+	MCEventnode *pendingevents = nullptr;
 	
-	Boolean ownselection;
+	Boolean ownselection = False;
 	MCString selectiontext;
-	Boolean doubleclick;
+	Boolean doubleclick = False;
 
-	GdkColormap *cmap;			// Native colourmap
-	GdkColormap *cmap32 ;		// 32-bit colourmap
+	GdkColormap *cmap = nullptr;			// Native colourmap
+	GdkColormap *cmap32 = nullptr;		// 32-bit colourmap
 
-	GdkVisual *vis;		// Native visual
-	GdkVisual *vis32 ;	// 32-bit visual
+	GdkVisual *vis = nullptr;		// Native visual
+	GdkVisual *vis32 = nullptr;	// 32-bit visual
 
-	bool backdrop_active;
-	bool backdrop_hard;
-	Window backdrop;
-	MCColor backdropcolor;
+	bool backdrop_active = false;
+	bool backdrop_hard = false;
+	Window backdrop = None;
+	MCColor backdropcolor {0, 0, 0};
 	// IM-2014-04-15: [[ Bug 11603 ]] Store converted backdrop pattern pixmap
-	Pixmap m_backdrop_pixmap;
+	Pixmap m_backdrop_pixmap = nullptr;
 
-	Window last_window ; 	//XDND - Used for the moment to shunt the ID
+	Window last_window = None; 	//XDND - Used for the moment to shunt the ID
 	
-	bool m_has_native_theme;
-	bool m_has_native_color_dialogs;
-	bool m_has_native_print_dialogs;
-	bool m_has_native_file_dialogs;
+	bool m_has_native_theme = false;
+	bool m_has_native_color_dialogs = false;
+	bool m_has_native_print_dialogs = false;
+	bool m_has_native_file_dialogs = false;
     
     // Set if GTK is available
-    bool m_has_gtk;
+    bool m_has_gtk = false;
     
     // Input context for IME integration
-    GtkIMContext *m_im_context;
+    GtkIMContext *m_im_context = nullptr;
 
 public:
 	
-	char * syslocale ;
+	char * syslocale = nullptr;
 	
-	GdkDisplay *dpy;
-	Boolean has_composite_wm ;
-	Drawable dest; //
+	GdkDisplay *dpy = nullptr;
+	Boolean has_composite_wm = false;
+	Drawable dest = None; //
 
-	MCNameRef displayname;
-	MCNameRef vendorname;
-	uint4 savedpixel; // Move into per-context
+	MCNameRef displayname = nullptr; // TODO MCNewAutoNameRef
+	MCNameRef vendorname = nullptr;  // TODO MCNewAutoNameRef
+	uint4 savedpixel = 0; // Move into per-context
 
 	MCScreenDC();
 	virtual ~MCScreenDC();

--- a/engine/src/lnxdc.h
+++ b/engine/src/lnxdc.h
@@ -164,8 +164,8 @@ public:
 	Boolean has_composite_wm = false;
 	Drawable dest = None; //
 
-	MCNameRef displayname = nullptr; // TODO MCNewAutoNameRef
-	MCNameRef vendorname = nullptr;  // TODO MCNewAutoNameRef
+	MCNewAutoNameRef displayname;
+	MCNewAutoNameRef vendorname;
 	uint4 savedpixel = 0; // Move into per-context
 
 	MCScreenDC();

--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -254,14 +254,26 @@ Boolean MCScreenDC::open()
     GdkScreen *t_screen;
     t_screen = gdk_display_get_default_screen(dpy);
     
-    MCAutoStringRef t_displayname;
-    /* UNCHECKED */ MCStringCreateWithSysString(gdk_display_get_name(dpy), &t_displayname);
-    /* UNCHECKED */ MCNameCreate(*t_displayname, displayname);
+    {
+        MCAutoStringRef t_displayname;
+        MCNewAutoNameRef t_displayname_asname;
+        if (MCStringCreateWithSysString(gdk_display_get_name(dpy),
+                                        &t_displayname) &&
+            MCNameCreate(*t_displayname, &t_displayname_asname))
+        {
+            displayname.Reset(t_displayname_asname.Take());
+        }
+    }
 	{
         MCAutoStringRef t_vendor_string, t_vendor;
-        /* UNCHECKED */ MCStringCreateWithSysString(x11::XServerVendor(XDisplay), &t_vendor);
-        /* UNCHECKED */ MCStringFormat(&t_vendor_string, "%@ %d", *t_vendor, x11::XVendorRelease(XDisplay));
-		MCNameCreate(*t_vendor_string, vendorname);
+        MCNewAutoNameRef t_vendorname;
+        if (MCStringCreateWithSysString(x11::XServerVendor(XDisplay), &t_vendor) &&
+            MCStringFormat(&t_vendor_string, "%@ %d", *t_vendor,
+                           x11::XVendorRelease(XDisplay)) &&
+            MCNameCreate(*t_vendor_string, &t_vendorname))
+        {
+            vendorname.Reset(t_vendorname.Take());
+        }
 	}
 	
 #ifdef SYNCMODE
@@ -575,7 +587,7 @@ Boolean MCScreenDC::close(Boolean force)
 
 MCNameRef MCScreenDC::getdisplayname()
 {
-	return displayname;
+	return *displayname;
 }
 
 
@@ -1024,7 +1036,7 @@ void MCScreenDC::setbeep(uint4 which, int4 beep)
 
 MCNameRef MCScreenDC::getvendorname(void)
 {
-	return vendorname;
+	return *vendorname;
 }
 
 uint2 MCScreenDC::getpad()

--- a/engine/src/mcerror.cpp
+++ b/engine/src/mcerror.cpp
@@ -93,36 +93,38 @@ void MCError::doadd(uint2 id, uint2 line, uint2 pos, MCStringRef p_token)
         
         MCValueRelease(t_line);
 	}
-    if (!MCStringIsEmpty(buffer))
-        MCStringAppendChar(buffer, '\n');
+    if (!MCStringIsEmpty(*buffer))
+        /* UNCHECKED */ MCStringAppendChar(*buffer, '\n');
     
-	MCStringAppend(buffer, *newerror);
+	/* UNCHECKED */ MCStringAppend(*buffer, *newerror);
 	depth += 1;
 }
 
 void MCError::append(MCError& p_other)
 {
-	MCStringAppendFormat(buffer, MCStringIsEmpty(buffer) ? "%@" : "\n%@", p_other . buffer);
+	/* UNCHECKED */ MCStringAppendFormat(*buffer,
+                                         MCStringIsEmpty(*buffer) ? "%@" : "\n%@",
+                                         *p_other.buffer);
 }
 
 void MCError::copystringref(MCStringRef s, Boolean t)
 {
-	MCValueRelease(buffer);
-    MCStringMutableCopy(s, buffer);
+    buffer.Reset();
+    /* UNCHECKED */ MCStringMutableCopy(s, &buffer);
 	thrown = t;
 }
 
 bool MCError::copyasstringref(MCStringRef &r_string)
 {
-	return MCStringCopy(buffer, r_string);
+	return MCStringCopy(*buffer, r_string);
 }
 
 void MCError::clear()
 {
-	MCValueRelease(buffer);
 	errorline = errorpos = 0;
 	depth = 0;
-    MCStringCreateMutable(0, buffer);
+    buffer.Reset();
+    /* UNCHECKED */ MCStringCreateMutable(0, &buffer);
 	thrown = False;
 	if (this == MCeerror)
 		MCerrorptr = nil;

--- a/engine/src/mcerror.h
+++ b/engine/src/mcerror.h
@@ -24,7 +24,7 @@ class MCScriptPoint;
 
 class MCError
 {
-	MCStringRef buffer;
+	MCAutoStringRef buffer;
 	uint2 errorline;
 	uint2 errorpos;
 	uint2 depth;
@@ -32,14 +32,10 @@ class MCError
 public:
 	MCError()
 	{
-		MCStringCreateMutable(0, buffer);
+		/* UNCHECKED */ MCStringCreateMutable(0, &buffer);
 		errorline = errorpos = 0;
 		depth = 0;
 		thrown = False;
-	}
-	~MCError()
-	{
-		MCValueRelease(buffer);
 	}
 	void add(uint2 id, MCScriptPoint &);
 	void add(uint2 id, uint2 line, uint2 pos);
@@ -53,7 +49,7 @@ public:
 	void clear();
 	Boolean isempty()
 	{
-		return MCStringIsEmpty(buffer);
+		return MCStringIsEmpty(*buffer);
 	}
 	void geterrorloc(uint2 &line, uint2 &pos);
 

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -108,7 +108,7 @@ uint2 MCParagraph::cursorwidth = 1;
 MCParagraph::MCParagraph()
 {
 	parent = NULL;
-	/* UNCHECKED */ MCStringCreateMutable(0, m_text);
+	/* UNCHECKED */ MCStringCreateMutable(0, &m_text);
 	blocks = NULL;
     segments = NULL;
 	lines = NULL;
@@ -130,7 +130,7 @@ MCParagraph::MCParagraph()
 MCParagraph::MCParagraph(const MCParagraph &pref) : MCDLlist(pref)
 {
 	parent = pref.parent;
-	/* UNCHECKED */ MCStringMutableCopy(pref.m_text, m_text);
+	/* UNCHECKED */ MCStringMutableCopy(*pref.m_text, &m_text);
 	
 	blocks = NULL;
 	if (pref.blocks != NULL)
@@ -178,9 +178,6 @@ MCParagraph::~MCParagraph()
 	deletelines();
 
 	clearattrs();
-	
-	// Don't let the text go away until anything referencing it is gone
-	MCValueRelease(m_text);
 }
 
 MCBlock* MCParagraph::AppendText(MCStringRef p_string)
@@ -208,7 +205,7 @@ MCBlock* MCParagraph::AppendText(MCStringRef p_string)
 	// Append the text as requested
 	// TODO: trunctation
 	findex_t t_cur_len = gettextlength();
-	/* UNCHECKED */ MCStringAppend(m_text, p_string);
+	/* UNCHECKED */ MCStringAppend(*m_text, p_string);
 	
 	// Set the indices for the block containing this text
 	t_block->SetRange(t_cur_len, t_new_length);
@@ -218,14 +215,14 @@ MCBlock* MCParagraph::AppendText(MCStringRef p_string)
 findex_t MCParagraph::NextChar(findex_t p_in)
 {
     uindex_t t_index;
-    t_index = MCStringGraphemeBreakIteratorAdvance(m_text, p_in);
-    return (t_index == kMCLocaleBreakIteratorDone) ? MCStringGetLength(m_text) : t_index;
+    t_index = MCStringGraphemeBreakIteratorAdvance(*m_text, p_in);
+    return (t_index == kMCLocaleBreakIteratorDone) ? MCStringGetLength(*m_text) : t_index;
 }
 
 findex_t MCParagraph::PrevChar(findex_t p_in)
 {
     uindex_t t_index;
-    t_index = MCStringGraphemeBreakIteratorRetreat(m_text, p_in);
+    t_index = MCStringGraphemeBreakIteratorRetreat(*m_text, p_in);
     return (t_index == kMCLocaleBreakIteratorDone) ? 0 : t_index;
 }
 
@@ -233,18 +230,18 @@ findex_t MCParagraph::NextWord(findex_t p_in)
 {
     MCBreakIteratorRef t_iter;
     /* UNCHECKED */ MCLocaleBreakIteratorCreate(kMCLocaleBasic, kMCBreakIteratorTypeWord, t_iter);
-    /* UNCHECKED */ MCLocaleBreakIteratorSetText(t_iter, m_text);
+    /* UNCHECKED */ MCLocaleBreakIteratorSetText(t_iter, *m_text);
     uindex_t t_index;
     t_index = MCLocaleBreakIteratorAfter(t_iter, p_in);
     MCLocaleBreakIteratorRelease(t_iter);
-    return (t_index == kMCLocaleBreakIteratorDone) ? MCStringGetLength(m_text) : t_index;
+    return (t_index == kMCLocaleBreakIteratorDone) ? MCStringGetLength(*m_text) : t_index;
 }
 
 findex_t MCParagraph::PrevWord(findex_t p_in)
 {
     MCBreakIteratorRef t_iter;
     /* UNCHECKED */ MCLocaleBreakIteratorCreate(kMCLocaleBasic, kMCBreakIteratorTypeWord, t_iter);
-    /* UNCHECKED */ MCLocaleBreakIteratorSetText(t_iter, m_text);
+    /* UNCHECKED */ MCLocaleBreakIteratorSetText(t_iter, *m_text);
     uindex_t t_index;
     t_index = MCLocaleBreakIteratorBefore(t_iter, p_in);
     MCLocaleBreakIteratorRelease(t_iter);
@@ -348,12 +345,12 @@ void MCParagraph::resolvetextdirections()
     else if (parent->gettextdirection() == kMCTextDirectionRTL)
         t_base_level = 1;
     else // == kMCTextDirectionAuto
-        t_base_level = MCBidiFirstStrongIsolate(m_text, 0);
+        t_base_level = MCBidiFirstStrongIsolate(*m_text, 0);
     
     MCAutoArray<uint8_t> t_levels;
    
     // SN-2014-04-03 [[ Bug 12078 ]] Text direction resolving relocated in foundation-bidi.h
-    /* UNCHECKED */ MCBidiResolveTextDirection(m_text, t_base_level, t_levels . PtrRef(), t_levels . SizeRef());
+    /* UNCHECKED */ MCBidiResolveTextDirection(*m_text, t_base_level, t_levels . PtrRef(), t_levels . SizeRef());
     
     // Using the calculated levels, do the appropriate block creation
     uindex_t i = 0;
@@ -395,16 +392,16 @@ uint8_t MCParagraph::firststrongisolate(uindex_t p_offset) const
     bool t_found = false;
     uindex_t t_depth = 0;
     uint8_t t_level = 0;
-    while (!t_found && p_offset < MCStringGetLength(m_text))
+    while (!t_found && p_offset < MCStringGetLength(*m_text))
     {
         codepoint_t t_char;
-        t_char = MCStringGetCharAtIndex(m_text, p_offset);
+        t_char = MCStringGetCharAtIndex(*m_text, p_offset);
         
         // Get the surrogate pair, if required
         uindex_t t_increment = 1;
         codepoint_t t_low;
         if (MCUnicodeCodepointIsHighSurrogate(t_char) &&
-            MCUnicodeCodepointIsLowSurrogate(t_low = MCStringGetCharAtIndex(m_text, p_offset + 1)))
+            MCUnicodeCodepointIsLowSurrogate(t_low = MCStringGetCharAtIndex(*m_text, p_offset + 1)))
         {
             t_char = MCUnicodeSurrogatesToCodepoint(t_char, t_low);
             t_increment = 2;
@@ -483,8 +480,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 	uint1 type;
 
     // The constructor-created string of the paragraph must be reset
-    MCValueRelease(m_text);
-    m_text = nil;
+    m_text.Reset();
 
 	// MW-2013-11-20: [[ UnicodeFileFormat ]] Prior to 7.0, paragraphs were mixed runs
 	//   of UTF-16 and native text. 7.0 plus they are just a stringref.
@@ -498,7 +494,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
         if ((stat = IO_read_string_legacy_full(&t_text_data, t_length, stream, 2, true, false)) != IO_NORMAL)
 			return checkloadstat(stat);
 
-        if (!MCStringCreateMutable(0, m_text))
+        if (!MCStringCreateMutable(0, &m_text))
 			return checkloadstat(IO_ERROR);
 
         // MW-2012-03-04: [[ StackFile5500 ]] If this is an extended paragraph then
@@ -559,7 +555,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
                     }
                     
                     uindex_t t_index;
-                    t_index = MCStringGetLength(m_text);
+                    t_index = MCStringGetLength(*m_text);
 
 					if (newblock->IsSavedAsUnicode())
 					{
@@ -586,7 +582,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 							}
 
                             // Append to the paragraph text
-							if (!MCStringAppendChars(m_text, t_unicode_buffer.Ptr(),
+							if (!MCStringAppendChars(*m_text, t_unicode_buffer.Ptr(),
 							                         t_unicode_buffer.Size()))
 							{
                                 return checkloadstat(IO_ERROR);
@@ -597,7 +593,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 							for (uindex_t i = t_buffer_len; i < uindex_t(len); ++i)
 							{
 								unichar_t t_trailing = (*t_text_data)[index + i];
-								if (!MCStringAppendChar(m_text, t_trailing))
+								if (!MCStringAppendChar(*m_text, t_trailing))
 								{
 									return checkloadstat(IO_ERROR);
 								}
@@ -624,7 +620,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 #endif
 
 						// String is in native format. Append to paragraph text
-                        if (!MCStringAppendNativeChars(m_text, (const char_t*)(*t_text_data + index), len))
+                        if (!MCStringAppendNativeChars(*m_text, (const char_t*)(*t_text_data + index), len))
                             return checkloadstat(IO_ERROR);
 
                         // Fix the indices used by the block
@@ -647,7 +643,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 					// there were no blocks to say it was unicode, it must be native.
 					if (t_last_added == 0)
 					{
-                        if (!MCStringAppendNativeChars(m_text, (const char_t*)*t_text_data, t_length))
+                        if (!MCStringAppendNativeChars(*m_text, (const char_t*)*t_text_data, t_length))
 							return checkloadstat(IO_ERROR);
 						t_last_added = t_length;
 					}
@@ -665,11 +661,12 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 	{
 		// MW-2013-11-20: [[ UnicodeFileFormat ]] The text is just a stringref, so no
 		//   magical swizzling to be done.
-		if ((stat = IO_read_stringref_new(m_text, stream, true)) != IO_NORMAL)
+        MCAutoStringRef t_read_text;
+		if ((stat = IO_read_stringref_new(&t_read_text, stream, true)) != IO_NORMAL)
 			return checkloadstat(stat);
         
         // The paragraph text *must* be mutable
-        /* UNCHECKED */ MCStringMutableCopyAndRelease(m_text, m_text);
+        /* UNCHECKED */ MCStringMutableCopyAndRelease(t_read_text.Take(), &m_text);
 
         // MW-2012-03-04: [[ StackFile5500 ]] If this is an extended paragraph then
         //   load in the attribute extension record.
@@ -742,10 +739,10 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part, uint32_t p_version)
 		// StringRef without breaking file format compatibility.
 		uindex_t t_data_len;
 		const char *t_data;
-		if (MCStringIsNative(m_text))
+		if (MCStringIsNative(*m_text))
 		{
-			t_data_len = MCStringGetLength(m_text);
-			t_data = (const char *)MCStringGetNativeCharPtr(m_text);
+			t_data_len = MCStringGetLength(*m_text);
+			t_data = (const char *)MCStringGetNativeCharPtr(*m_text);
 		}
 		else
 		{
@@ -754,18 +751,18 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part, uint32_t p_version)
 			if (blocks == nil)
 				inittext();
 			
-			t_data_len = MCStringGetLength(m_text) * sizeof(unichar_t);
-			t_data = (const char *)MCStringGetCharPtr(m_text);
+			t_data_len = MCStringGetLength(*m_text) * sizeof(unichar_t);
+			t_data = (const char *)MCStringGetCharPtr(*m_text);
 		}
 		
-		if (!MCStringIsNative(m_text))
+		if (!MCStringIsNative(*m_text))
 		{
 			// For file format compatibility, swap_uint2 must be called on each 
 			// character in the UTF-16 string (Unicodeness is now a paragraph
 			// property, not a block property, so it is done for all the text)
 			unichar_t *t_swapped_data = new (nothrow) unichar_t[t_data_len/sizeof(unichar_t)];
 			memcpy(t_swapped_data, t_data, t_data_len);
-			for (uindex_t i = 0; i < MCStringGetLength(m_text); i++)
+			for (uindex_t i = 0; i < MCStringGetLength(*m_text); i++)
 			{
 				swap_uint2((uint2*)&t_swapped_data[i]);
 			}
@@ -778,14 +775,14 @@ IO_stat MCParagraph::save(IO_handle stream, uint4 p_part, uint32_t p_version)
 			return stat;
 
 		// If the string had to be byte swapped, delete the allocated data
-		if (!MCStringIsNative(m_text))
+		if (!MCStringIsNative(*m_text))
 			delete[] t_data;
 	}
 	else
 	{
 		// MW-2013-11-20: [[ UnicodeFileFormat ]] The text is just a stringref, so no
 		//   magical swizzling to be done.
-		if ((stat = IO_write_stringref_new(m_text, stream, true)) != IO_NORMAL)
+		if ((stat = IO_write_stringref_new(*m_text, stream, true)) != IO_NORMAL)
 			return stat;
 	}
 		
@@ -1606,7 +1603,7 @@ void MCParagraph::draw(MCDC *dc, int2 x, int2 y, uint2 fixeda,
 					parent -> setforeground(dc, DI_FORE, False, True);
 			}
 
-			lptr->draw(dc, t_current_x, ceilf(t_current_y + ascent - 1), si, ei, m_text, pstyle);
+			lptr->draw(dc, t_current_x, ceilf(t_current_y + ascent - 1), si, ei, *m_text, pstyle);
 			if (fstart != fend)
 				drawfound(dc, lptr, t_current_x, t_current_y, ceilf(linespace), fstart, fend);
 			if (compstart != compend)
@@ -1905,8 +1902,8 @@ void MCParagraph::join(bool p_preserve_zero_length_styles_if_zero)
 		return;
 	}
 
-	focusedindex = MCStringGetLength(m_text);
-	/* UNCHECKED */ MCStringAppend(m_text, pgptr->m_text);
+	focusedindex = MCStringGetLength(*m_text);
+	/* UNCHECKED */ MCStringAppend(*m_text, *pgptr->m_text);
 
 	MCBlock *bptr = blocks->prev();
 	bptr->append(pgptr->blocks);
@@ -1934,7 +1931,7 @@ void MCParagraph::replacetextwithparagraphs(findex_t p_start, findex_t p_finish,
     deletestring(p_start, p_finish);
 
     // Split the paragraph if needed
-    if (p_start < MCStringGetLength(m_text))
+    if (p_start < MCStringGetLength(*m_text))
         split(p_start);
 
     // Append the right part of the split to the end
@@ -1951,7 +1948,7 @@ void MCParagraph::replacetextwithparagraphs(findex_t p_start, findex_t p_finish,
     }
 
     // Append p_pglist to this if this is not the only, empty paragraph
-    if (MCStringIsEmpty(m_text) && next() == this)
+    if (MCStringIsEmpty(*m_text) && next() == this)
     {
         MCParagraph *t_old = this;
         delete t_old;
@@ -1977,7 +1974,7 @@ void MCParagraph::split(findex_t p_position)
     // The 'm_text' field of a paragraph should never contain '\n' now so
     // whilst we leave this check in (to be on the safe side) it should never
     // trigger - hence the assert.
-    if (p_position < MCStringGetLength(m_text) && GetCodepointAtIndex(p_position) == '\n')
+    if (p_position < MCStringGetLength(*m_text) && GetCodepointAtIndex(p_position) == '\n')
     {
         MCAssert(false);
         skip = IncrementIndex(p_position) - p_position;
@@ -1992,14 +1989,15 @@ void MCParagraph::split(findex_t p_position)
 	//   list index.
 	pgptr -> setlistindex(0);
 
-	if (!MCStringIsEmpty(m_text))
+    pgptr->m_text.Reset();
+	if (!MCStringIsEmpty(*m_text))
 	{
-        MCRange t_range = MCRangeMake(p_position, MCStringGetLength(m_text) - p_position);
-		/* UNCHECKED */ MCStringMutableCopySubstring(m_text, t_range, pgptr->m_text);
-        /* UNCHECKED */ MCStringSubstring(m_text, MCRangeMake(0, p_position));
+        MCRange t_range = MCRangeMake(p_position, MCStringGetLength(*m_text) - p_position);
+		/* UNCHECKED */ MCStringMutableCopySubstring(*m_text, t_range, &pgptr->m_text);
+        /* UNCHECKED */ MCStringSubstring(*m_text, MCRangeMake(0, p_position));
 	}
 	else
-		/* UNCHECKED */ MCStringCreateMutable(0, pgptr->m_text);
+		/* UNCHECKED */ MCStringCreateMutable(0, &pgptr->m_text);
 
 	// Trim the block containing the split so that it ends at the split point
     bptr = indextoblock(p_position, False);
@@ -2028,9 +2026,9 @@ void MCParagraph::split(findex_t p_position)
 	}
 
     // Set the focusedindex at the right position
-    if (focusedindex >= MCStringGetLength(m_text))
+    if (focusedindex >= MCStringGetLength(*m_text))
     {
-        pgptr -> focusedindex = focusedindex - MCStringGetLength(m_text);
+        pgptr -> focusedindex = focusedindex - MCStringGetLength(*m_text);
         focusedindex = 0;
     }
 	
@@ -2169,7 +2167,7 @@ void MCParagraph::deletestring(findex_t si, findex_t ei, MCFieldStylingMode p_st
 	}
 	
 	// Excise the deleted range from the paragraph text
-	/* UNCHECKED */ MCStringRemove(m_text, MCRangeMake(si, ei-si));
+	/* UNCHECKED */ MCStringRemove(*m_text, MCRangeMake(si, ei-si));
 
 	// Eliminate any zero length blocks *after* one we might have ensured
 	// is present for styling purposes.
@@ -2187,7 +2185,7 @@ MCParagraph *MCParagraph::copystring(findex_t si, findex_t ei)
 	// text outside of the range [si, ei). This preserves all attributes, etc
 	MCParagraph *pgptr = new (nothrow) MCParagraph(*this);
 	
-	if (ei != MCStringGetLength(m_text))
+	if (ei != MCStringGetLength(*m_text))
 	{
 		// Discard any text after the desired end index,
 		pgptr->focusedindex = ei;
@@ -2252,7 +2250,7 @@ void MCParagraph::finsertnobreak(MCStringRef p_string, MCRange t_range)
 	// If the byte length exceeds the space we have, truncate it.
 	uindex_t t_new_length, t_cur_length;
 	t_new_length = t_range.length;
-	t_cur_length = MCStringGetLength(m_text);
+	t_cur_length = MCStringGetLength(*m_text);
 	if (t_new_length >= PARAGRAPH_MAX_LEN - t_cur_length - 1)
 	{
 		t_new_length = PARAGRAPH_MAX_LEN - t_cur_length - 1;
@@ -2266,7 +2264,7 @@ void MCParagraph::finsertnobreak(MCStringRef p_string, MCRange t_range)
 		
 		// Insert the new text into the appropriate spot of the paragraph text
 		// TODO: truncation if the paragraph would be too long
-		/* UNCHECKED */ MCStringInsertSubstring(m_text, focusedindex, p_string, t_range);
+		/* UNCHECKED */ MCStringInsertSubstring(*m_text, focusedindex, p_string, t_range);
 
 		// The block containing the insert and subsequent blocks need to have
 		// their indices updated to account for the new text.
@@ -2387,12 +2385,12 @@ int2 MCParagraph::fdelete(Field_translations type, MCParagraph *&undopgptr)
         MCAutoStringRef t_composed, t_decomposed;
         MCRange t_range;
         t_range = MCRangeMake(t_charstart, t_charend - t_charstart);
-        /* UNCHECKED */ MCStringCopySubstring(m_text, t_range, &t_composed);
+        /* UNCHECKED */ MCStringCopySubstring(*m_text, t_range, &t_composed);
         /* UNCHECKED */ MCStringNormalizedCopyNFD(*t_composed, &t_decomposed);
         
         // Replace the character with its decomposed form. This requires adjusting
         // all the blocks to alter their indices.
-        /* UNCHECKED */ MCStringReplace(m_text, t_range, *t_decomposed);
+        /* UNCHECKED */ MCStringReplace(*m_text, t_range, *t_decomposed);
         
         findex_t t_delta = MCStringGetLength(*t_decomposed) - MCStringGetLength(*t_composed);
         MCBlock *t_bptr = indextoblock(t_charstart, False);
@@ -3314,7 +3312,7 @@ MCRectangle MCParagraph::getsplitcursorrect(findex_t fi, uint2 fixedheight, bool
 
 bool MCParagraph::copytextasstringref(MCStringRef& r_string)
 {
-	return MCStringCopy(m_text, r_string);
+	return MCStringCopy(*m_text, r_string);
 }
 
 void MCParagraph::settext(MCStringRef p_string)
@@ -3322,18 +3320,18 @@ void MCParagraph::settext(MCStringRef p_string)
 	deletelines();
 	deleteblocks();
 	
-	MCValueRelease(m_text);
-	/* UNCHECKED */ MCStringMutableCopy(p_string, m_text);
+	m_text.Reset();
+	/* UNCHECKED */ MCStringMutableCopy(p_string, &m_text);
 	
 	blocks = new (nothrow) MCBlock;
 	blocks->setparent(this);
-	blocks->SetRange(0, MCStringGetLength(m_text));
+	blocks->SetRange(0, MCStringGetLength(*m_text));
 }
 
 void MCParagraph::resettext(MCStringRef p_string)
 {
-	MCValueRelease(m_text);
-	/* UNCHECKED */ MCStringMutableCopy(p_string, m_text);
+    m_text.Reset();
+	/* UNCHECKED */ MCStringMutableCopy(p_string, &m_text);
 	findex_t i, l;
 	if (blocks == NULL)
 	{
@@ -3780,7 +3778,7 @@ findex_t MCParagraph::findwordbreakbefore(MCBlock *p_block, findex_t p_index)
 	// Create the word break iterator
     MCBreakIteratorRef t_breaker;
     MCLocaleBreakIteratorCreate(kMCBasicLocale, kMCBreakIteratorTypeWord, t_breaker);
-    MCLocaleBreakIteratorSetText(t_breaker, m_text);
+    MCLocaleBreakIteratorSetText(t_breaker, *m_text);
     
     // Find the preceding word break
     findex_t t_break;
@@ -3795,14 +3793,14 @@ findex_t MCParagraph::findwordbreakafter(MCBlock *p_block, findex_t p_index)
 	// Create the word break iterator
     MCBreakIteratorRef t_breaker;
     MCLocaleBreakIteratorCreate(kMCBasicLocale, kMCBreakIteratorTypeWord, t_breaker);
-    MCLocaleBreakIteratorSetText(t_breaker, m_text);
+    MCLocaleBreakIteratorSetText(t_breaker, *m_text);
     
     // Find the succeeding word break
     findex_t t_break;
     t_break = MCLocaleBreakIteratorAfter(t_breaker, p_index);
     MCLocaleBreakIteratorRelease(t_breaker);
     
-    return (t_break == kMCLocaleBreakIteratorDone) ? MCStringGetLength(m_text) : t_break;
+    return (t_break == kMCLocaleBreakIteratorDone) ? MCStringGetLength(*m_text) : t_break;
 }
 
 void MCParagraph::sethilite(Boolean newstate)

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -140,7 +140,7 @@ class MCSegment;
 class MCParagraph : public MCDLlist
 {
 	MCField *parent;
-	MCStringRef m_text;
+	MCAutoStringRef m_text;
 	MCBlock *blocks;
     MCSegment *segments;
 	MCLine *lines;
@@ -177,10 +177,10 @@ public:
 		// This assumes that the input string is valid UTF-16 and all surrogate
 		// pairs are matched correctly.
 		unichar_t t_lead, t_tail;
-		t_lead = MCStringGetCharAtIndex(m_text, p_index);
-		if (MCStringIsValidSurrogatePair(m_text, p_index))
+		t_lead = MCStringGetCharAtIndex(*m_text, p_index);
+		if (MCStringIsValidSurrogatePair(*m_text, p_index))
 		{
-            t_tail = MCStringGetCharAtIndex(m_text, p_index + 1);
+            t_tail = MCStringGetCharAtIndex(*m_text, p_index + 1);
 			return MCStringSurrogatesToCodepoint(t_lead, t_tail);
 		}
 		return t_lead;
@@ -192,11 +192,11 @@ public:
 	{
 		if (p_in < 0)
 			return 0;
-		unichar_t t_char = MCStringGetCharAtIndex(m_text, p_in);
+		unichar_t t_char = MCStringGetCharAtIndex(*m_text, p_in);
         // SN-2015-09-08: [[ Bug 15895 ]] A field can end with half of a
         //  surrogate pair - in which case the index only increments by 1.
 		if (0xD800 <= t_char && t_char < 0xDC00)
-            return (findex_t)MCU_min((uindex_t)(p_in + 2), MCStringGetLength(m_text));
+            return (findex_t)MCU_min((uindex_t)(p_in + 2), MCStringGetLength(*m_text));
 		return p_in + 1;
 	}
 	
@@ -206,7 +206,7 @@ public:
 	{
 		if (p_in <= 0)
             return 0;
-        unichar_t t_char = MCStringGetCharAtIndex(m_text, p_in - 1);
+        unichar_t t_char = MCStringGetCharAtIndex(*m_text, p_in - 1);
 		if (0xDC00 <= t_char && t_char < 0xE000)
 			return p_in - 2;
 		return p_in - 1;
@@ -257,7 +257,7 @@ public:
 	// paragraph in any way and should not be retained.
 	MCStringRef GetInternalStringRef() const
 	{
-		return m_text;
+		return *m_text;
 	}
 	
 	////////// BIDIRECTIONAL SUPPORT
@@ -436,13 +436,13 @@ public:
 			
         if (p_char_indices)
         {
-            MCRange t_cu_range = {0,MCStringGetLength(m_text)};
+            MCRange t_cu_range = {0,MCStringGetLength(*m_text)};
             MCRange t_char_range;
-            MCStringUnmapIndices(m_text, kMCCharChunkTypeGrapheme, t_cu_range, t_char_range);
+            MCStringUnmapIndices(*m_text, kMCCharChunkTypeGrapheme, t_cu_range, t_char_range);
             return t_char_range . length;
         }
         else
-            return MCStringGetLength(m_text);
+            return MCStringGetLength(*m_text);
 	}
 
 	// Same as gettextsize, except adjust by one for the CR character.

--- a/engine/src/player-legacy.cpp
+++ b/engine/src/player-legacy.cpp
@@ -94,6 +94,7 @@ MCPlayer::MCPlayer()
 #ifdef FEATURE_MPLAYER
 	command = NULL;
 	m_player = NULL ;
+	atom = GDK_NONE;
 #endif
     
 }
@@ -118,6 +119,7 @@ MCPlayer::MCPlayer(const MCPlayer &sref) : MCControl(sref)
 #ifdef FEATURE_MPLAYER
 	command = NULL;
 	m_player = NULL ;
+	atom = GDK_NONE;
 #endif
     
 }

--- a/engine/src/segment.cpp
+++ b/engine/src/segment.cpp
@@ -33,6 +33,10 @@
 
 
 MCSegment::MCSegment(MCLine *p_parent)
+    : m_FirstVisualBlock(),
+      m_LastVisualBlock(),
+      m_HAlign(),
+      m_VAlign()
 {
     m_Parent = p_parent;
     m_FirstBlock = m_LastBlock = NULL;
@@ -48,6 +52,8 @@ MCSegment::MCSegment(MCLine *p_parent)
 
 
 MCSegment::MCSegment(const MCSegment *sg)
+    : m_FirstVisualBlock(),
+      m_LastVisualBlock()
 {
     m_Parent = sg->m_Parent;
     m_FirstBlock = m_LastBlock = NULL;

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -219,6 +219,11 @@ MCObjectPropertyTable MCStack::kPropertyTable =
 ////////////////////////////////////////////////////////////////////////////////
 
 MCStack::MCStack()
+    : savecard(),
+      savecontrols(),
+      wposition(WP_DEFAULT),
+      walignment(OP_NONE),
+      scrollmode()
 {
 	obj_id = START_ID;
 	flags = F_VISIBLE | F_RESIZABLE | F_OPAQUE;
@@ -320,7 +325,14 @@ MCStack::MCStack()
     m_is_ide_stack = false;
 }
 
-MCStack::MCStack(const MCStack &sref) : MCObject(sref)
+MCStack::MCStack(const MCStack &sref)
+    : MCObject(sref),
+      savecard(),
+      savecontrols(),
+      wposition(WP_DEFAULT),
+      walignment(OP_NONE),
+      scrollmode(),
+      old_rect(kMCEmptyRectangle)
 {
 	obj_id = sref.obj_id;
 

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -59,11 +59,7 @@ bool MCVariable::createwithname(MCNameRef p_name, MCVariable*& r_var)
 	if (!create(self))
 		return false;
 
-	if (!MCNameClone(p_name, &self->name))
-	{
-		delete self;	
-		return false;
-}
+    self->name.Reset(p_name);
 
 	r_var = self;
 
@@ -73,29 +69,17 @@ bool MCVariable::createwithname(MCNameRef p_name, MCVariable*& r_var)
 // This is only called by MCObject to create copies of prop sets.
 bool MCVariable::createcopy(MCVariable& p_var, MCVariable*& r_new_var)
 {
-	bool t_success;
-	t_success = true;
+	MCVariable *self = nullptr;
+	if (!create(self))
+        return false;
 
-	MCVariable *self;
-	self = nil;
-	if (t_success)
-		t_success = create(self);
+    self->name.Reset(*p_var.name);
+    p_var . value . valueref_value = self -> value . valueref_value;
+    p_var . value . type = self -> value . type;
 
-	if (t_success)
-		t_success = MCNameClone(p_var . name, self -> name);
+    r_new_var = self;
 
-	if (t_success)
-    {
-		p_var . value . valueref_value = self -> value . valueref_value;
-        p_var . value . type = self -> value . type;
-    }
-
-	if (t_success)
-		r_new_var = self;
-	else
-		delete self;
-
-    return t_success;
+    return true;
 }
 
 bool MCVariable::encode(void *&r_buffer, uindex_t& r_size)
@@ -233,7 +217,6 @@ bool MCVariable::decode(void *p_buffer, uindex_t p_size)
 
 MCVariable::~MCVariable(void)
 {
-	MCNameDelete(name);
     MCExecTypeRelease(value);
 }
 
@@ -251,7 +234,7 @@ void MCVariable::clearuql(void)
     
     // SN-2014-04-09 [[ Bug 12160 ]] Put after/before on an uninitialised, by-reference parameter inserts the variable's name in it
     // The content of a UQL value was not cleared when needed
-    if (value . type == kMCExecValueTypeNameRef && MCNameIsEqualTo(value . nameref_value, name))
+    if (value . type == kMCExecValueTypeNameRef && MCNameIsEqualTo(value . nameref_value, *name))
         clear();
     
 	is_uql = false;
@@ -361,7 +344,7 @@ MCValueRef MCVariable::getvalueref(void)
         
         return value . valueref_value;
     }
-	return name;
+	return *name;
 }
 
 MCValueRef MCVariable::getvalueref(MCNameRef *p_path, uindex_t p_length, bool p_case_sensitive)
@@ -765,10 +748,10 @@ bool MCVariable::remove(MCExecContext& ctxt, MCNameRef *p_path, uindex_t p_lengt
 		
 		if (is_env)
 		{
-			if (!isdigit(MCNameGetCharAtIndex(name, 1)) && MCNameGetCharAtIndex(name, 1) != '#')
+			if (!isdigit(MCNameGetCharAtIndex(*name, 1)) && MCNameGetCharAtIndex(*name, 1) != '#')
 			{
 				MCAutoStringRef t_env;
-				/* UNCHECKED */ MCStringCopySubstring(MCNameGetString(name), MCRangeMake(1, MCStringGetLength(MCNameGetString(name))), &t_env);
+				/* UNCHECKED */ MCStringCopySubstring(MCNameGetString(*name), MCRangeMake(1, MCStringGetLength(MCNameGetString(*name))), &t_env);
 				MCS_unsetenv(*t_env);
 			}
 		}
@@ -983,13 +966,13 @@ void MCVariable::synchronize(MCExecPoint& ep, Boolean notify)
 	MCExecContext ctxt(ep);
 	if (is_env)
 	{
-		if (!isdigit(MCNameGetCharAtIndex(name, 1)) && MCNameGetCharAtIndex(name, 1) != '#')
+		if (!isdigit(MCNameGetCharAtIndex(*name, 1)) && MCNameGetCharAtIndex(*name, 1) != '#')
 		{
 			MCAutoStringRef t_string;
 			if (ep . copyasstringref(&t_string))
 			{
 				MCAutoStringRef t_env;
-				/* UNCHECKED */ MCStringCopySubstring(MCNameGetString(name), MCRangeMake(1, MCStringGetLength(MCNameGetString(name))), &t_env);
+				/* UNCHECKED */ MCStringCopySubstring(MCNameGetString(*name), MCRangeMake(1, MCStringGetLength(MCNameGetString(*name))), &t_env);
 				MCS_setenv(*t_env, *t_string);
 			}
 		}
@@ -1049,14 +1032,14 @@ void MCVariable::synchronize(MCExecContext& ctxt, bool p_notify)
     MCAutoStringRef t_stringref_value;
 	if (is_env)
 	{
-		if (!isdigit(MCNameGetCharAtIndex(name, 1)) && MCNameGetCharAtIndex(name, 1) != '#')
+		if (!isdigit(MCNameGetCharAtIndex(*name, 1)) && MCNameGetCharAtIndex(*name, 1) != '#')
 		{
             MCExecTypeCopy(value, t_value);
             MCExecTypeConvertAndReleaseAlways(ctxt, t_value . type, &t_value, kMCExecValueTypeStringRef, &(&t_stringref_value));
             if (!ctxt . HasError())
             {
                 MCAutoStringRef t_env;
-				/* UNCHECKED */ MCStringCopySubstring(MCNameGetString(name), MCRangeMake(1, MCStringGetLength(MCNameGetString(name))), &t_env);
+				/* UNCHECKED */ MCStringCopySubstring(MCNameGetString(*name), MCRangeMake(1, MCStringGetLength(MCNameGetString(*name))), &t_env);
 				MCS_setenv(*t_env, *t_stringref_value);
             }
 		}
@@ -1093,11 +1076,11 @@ void MCVariable::synchronize(MCExecContext& ctxt, bool p_notify)
                     
 					MCAutoBooleanRef t_bool;
 					if (!ctxt.HasError() && ctxt.ConvertToBoolean(*t_val, &t_bool) && *t_bool == kMCTrue)
-						MCB_setvalue(ctxt, value, name);
+						MCB_setvalue(ctxt, value, *name);
 				}
 				else
                 {
-                    MCB_setvalue(ctxt, value, name);
+                    MCB_setvalue(ctxt, value, *name);
                 }
                 
 				break;
@@ -1113,8 +1096,8 @@ Exec_stat MCVariable::remove(MCExecPoint& ep, Boolean notify)
 	
 	if (is_env)
 	{
-		if (!isdigit(MCNameGetCharAtIndex(name, 1)) && MCNameGetCharAtIndex(name, 1) != '#')
-			MCS_unsetenv(MCNameGetCString(name) + 1);
+		if (!isdigit(MCNameGetCharAtIndex(*name, 1)) && MCNameGetCharAtIndex(*name, 1) != '#')
+			MCS_unsetenv(MCNameGetCString(*name) + 1);
 	}
 
 	return ES_NORMAL;

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -48,18 +48,6 @@ bool MCVariable::create(MCVariable*& r_var)
 	if (self == nil)
 		return false;
 
-	self -> next = nil;
-	self -> name = nil;
-
-	self -> value . type = kMCExecValueTypeNone;
-    self -> value . valueref_value = nil;
-
-	self -> is_msg = false;
-	self -> is_env = false;
-	self -> is_global = false;
-	self -> is_deferred = false;
-	self -> is_uql = false;
-
 	r_var = self;
 	
 	return true;
@@ -71,7 +59,7 @@ bool MCVariable::createwithname(MCNameRef p_name, MCVariable*& r_var)
 	if (!create(self))
 		return false;
 
-	if (!MCNameClone(p_name, self -> name))
+	if (!MCNameClone(p_name, &self->name))
 	{
 		delete self;	
 		return false;

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -60,7 +60,16 @@ protected:
 
 	// The correct way to create variables is with the static 'create' methods
 	// which can catch a failure.
-	MCVariable(void) {}
+    MCVariable()
+        : name(nullptr),
+          next(nullptr),
+          is_msg(false),
+          is_env(false),
+          is_global(false),
+          is_deferred(false),
+          is_uql(false)
+    {}
+
 	MCVariable(const MCVariable& other) {}
     
     // Returns true if the existing value of the variable is can become or remain

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -38,7 +38,7 @@ typedef enum
 class MCVariable
 {
 protected:
-	MCNameRef name;
+	MCNewAutoNameRef name;
 	MCExecValue value;
 	MCVariable *next;
 
@@ -61,8 +61,7 @@ protected:
 	// The correct way to create variables is with the static 'create' methods
 	// which can catch a failure.
     MCVariable()
-        : name(nullptr),
-          next(nullptr),
+        : next(nullptr),
           is_msg(false),
           is_env(false),
           is_global(false),
@@ -230,12 +229,12 @@ public:
 
 	MCNameRef getname(void)
 	{
-		return name;
+		return *name;
 	}
 
 	bool hasname(MCNameRef other_name)
 	{
-		return MCNameIsEqualTo(name, other_name, kMCCompareCaseless);
+		return MCNameIsEqualTo(*name, other_name, kMCCompareCaseless);
 	}
 
 	//////////

--- a/revdb/src/dbdrivercommon.cpp
+++ b/revdb/src/dbdrivercommon.cpp
@@ -24,6 +24,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 // Default implementations for DBField
 DBField::DBField()
+    : maxlength(),
+      data()
 {
 	freeBuffer = False;
 	isAutoIncrement = False;


### PR DESCRIPTION
Ensure that constructors initialise all fields, especially those containing pointers.

Where appropriate, this PR also converts to using appropriate managed pointer types as member variables, allowing initialisation and destruction to be implicit.