### PR TITLE
[Bug 19088] Do not show "Success" dialog if an error occurred in S/B

### DIFF
--- a/docs/notes/bugfix-19088.md
+++ b/docs/notes/bugfix-19088.md
@@ -1,0 +1,1 @@
+# Do not show "Success" dialog if an error occurred in S/B

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -240,10 +240,10 @@ on revSaveAsStandalone pStack, pFolder, pPreview
       put the result into tError
    end if
    
-   if revStandaloneGetWarnings() is not empty then
+   if revStandaloneGetWarnings() is not empty and tError is empty then
       set the cWarnings of stack "revBuildResults" to revStandaloneGetWarnings()
    else
-      if not revSBSuppressDialogs() then
+      if not revSBSuppressDialogs() and tError is empty then
          answer information "Standalone application saved successfully."
       end if
       


### PR DESCRIPTION
Use case 1:
Build an ios standalone without setting the path to Xcode.
EXPECTED RESULT: Show error and quit S/B
OBSERVED RESULT: Error is shown and then dialog "Standalone saved successfully" is shown.

Use case 2:
Build a standalone from a stack that has a non-existent widget in LC 8 Inclusions (e.g. a spinner widget from LC 9).
EXPECTED RESULT: Error "Could not open module file" and quit S/B
OBSERVED RESULT: Error "Could not open module file" is shown and then `revBuildResults` window displaying warnings (such as "No iPad Portrait Splash Screen) is shown.

This patch ensures that no misleading "Success" dialog will be shown to the user in the above 2 use cases.