### PR TITLE
[CID 15009] Remove dead code from MCPSPrinter::DoFetchSettings()

### DIFF
--- a/engine/src/lnxpsprinter.cpp
+++ b/engine/src/lnxpsprinter.cpp
@@ -151,21 +151,12 @@ bool MCPSPrinter::DoResetSettings(MCDataRef p_settings)
 
 void MCPSPrinter::DoFetchSettings(void*& r_buffer, uint4& r_length)
 {
-	bool t_success;
-	t_success = true;
-
 	MCDictionary t_dictionary;
 	
 	if ( m_printersettings . printername != NULL ) 
 		t_dictionary . Set('NMEA', MCString(m_printersettings . printername , strlen(m_printersettings . printername ) + 1 ) );
 
-	if (t_success)
-		t_dictionary . Pickle(r_buffer, r_length);
-	else
-	{
-		r_buffer = NULL;
-		r_length = 0;
-	}
+	t_dictionary . Pickle(r_buffer, r_length);
 }
 
 const char *MCPSPrinter::DoFetchName(void)


### PR DESCRIPTION
Remove an unused `t_success` variable and failure codepath from
this function, because nothing the function does reports failure.

Coverity-ID: 15009