### PR TITLE
[[ Bug 19076 ]] Ensure stack resize requirement is fulfilled in no ui mode

### DIFF
--- a/docs/notes/bugfix-19076.md
+++ b/docs/notes/bugfix-19076.md
@@ -1,0 +1,1 @@
+﻿# Prevent redraw recursion when going to stack twice in no ui mode

--- a/engine/src/em-stack.cpp
+++ b/engine/src/em-stack.cpp
@@ -80,7 +80,7 @@ MCStack::platform_openwindow(Boolean override)
 void
 MCStack::setgeom()
 {
-	if (MCnoui || !opened)
+	if (!opened)
 		return;
 
 	MCRectangle t_old_rect;

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -572,7 +572,7 @@ MCRectangle MCStack::view_device_setgeom(const MCRectangle &p_rect,
 
 void MCStack::setgeom()
 {
-	if (MCnoui || !opened)
+	if (!opened)
 		return;
 	
 	if (window == DNULL)

--- a/engine/src/mblstack.cpp
+++ b/engine/src/mblstack.cpp
@@ -95,7 +95,7 @@ void MCStack::destroywindowshape(void)
 // IM-2013-09-30: [[ FullscreenMode ]] Mobile version of setgeom now calls view methods
 void MCStack::setgeom(void)
 {
-	if (MCnoui || !opened)
+	if (!opened)
 		return;
 	
 	// IM-2013-10-03: [[ FullscreenMode ]] Use view methods to get / set the stack viewport

--- a/engine/src/osxstack.cpp
+++ b/engine/src/osxstack.cpp
@@ -83,7 +83,7 @@ extern void MCMacEnableScreenUpdates();
 void MCStack::setgeom()
 {
 	//set stack(window) size or position from script
-	if (MCnoui || !opened)
+	if (!opened)
 		return;
 	
 	// MW-2009-09-25: Ensure things are the right size when doing

--- a/engine/src/w32stack.cpp
+++ b/engine/src/w32stack.cpp
@@ -533,7 +533,7 @@ MCRectangle MCStack::view_platform_setgeom(const MCRectangle &p_rect)
 
 void MCStack::setgeom()
 {
-	if (MCnoui || !opened)
+	if (!opened)
 		return;
 
 	// MW-2009-09-25: Ensure things are the right size when doing

--- a/tests/lcs/core/interface/go.livecodescript
+++ b/tests/lcs/core/interface/go.livecodescript
@@ -1,0 +1,27 @@
+script "CoreGoStack"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestGoTwice
+   create stack
+   lock screen
+   go it
+   go it
+   unlock screen
+   TestAssert "go stack twice does not cause crash", true
+end TestGoTwice
+


### PR DESCRIPTION
Stacks in -ui mode could have their CS_NEED_RESIZE flag bit set, causing
recursion in screen updates as MCStack::setgeom was returning if MCnoui true
instead of continuing to resize the stack and unset the flag.