### PR TITLE
build: Tweak Linux build flags to make clang builds quieter

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -67,10 +67,10 @@
 				[
 					'-Wall',
 					'-Wextra',
+					'-Wno-deprecated-register',	# Fix when we move to C++17
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
 					'-Werror=uninitialized',
-					'-Wno-error=maybe-uninitialized',
 					'-Werror=conversion-null',
 					'-Werror=empty-body',
 				],


### PR DESCRIPTION
- The `register` keyword is used by some of the GLib headers that
  we include.  This keyword was deprecated in C++11 and will be
  removed in C++17, but since we currently are building for C++11
  the deprecation warnings are just adding unnecessary build noise.

- clang doesn't have a `maybe-uninitialized` warning; GCC does, but
  we also have Coverity for detecting those problems.

Hopefully this will bring Travis CI build logs back below 10k
lines.