### PR TITLE
[Bug 17973] Make sure machine() returns correct value on iOS Simulator

### DIFF
--- a/docs/notes/bugfix-17973.md
+++ b/docs/notes/bugfix-17973.md
@@ -1,0 +1,1 @@
+# Make sure `the machine` can distinguish between iOS device and simulator 

--- a/engine/src/mbliphone.mm
+++ b/engine/src/mbliphone.mm
@@ -383,7 +383,12 @@ bool MCIPhoneSystem::GetVersion(MCStringRef& r_string)
 
 bool MCIPhoneSystem::GetMachine(MCStringRef& r_string)
 {
-	return MCStringCreateWithCFString((CFStringRef)[[UIDevice currentDevice] model], r_string);
+    NSString *t_machine = [[UIDevice currentDevice] model];
+#if TARGET_IPHONE_SIMULATOR
+    t_machine = [t_machine stringByAppendingString:@" Simulator"];
+#endif
+    
+    return MCStringCreateWithCFString((CFStringRef)t_machine, r_string);
 }
 
 MCNameRef MCIPhoneSystem::GetProcessor(void)


### PR DESCRIPTION
Starting from iOS 9, `[[UIDevice currentDevice] model]` no longer distinguishes between device and simulator. In both cases it returns e.g. `iPhone` rather `iPhone` and `iPhone Simulator`.

This patch ensures that `the machine` correctly detects if the app runs on iOS device or simulator.