### PR TITLE
[CID 16349] Fix memory leaks in MCParagraph::load()

### DIFF
--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -518,14 +518,14 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
 				case OT_BLOCK:
 				case OT_BLOCK_EXT:
 				{
-					MCBlock *newblock = new (nothrow) MCBlock;
+					/* UNCHECKED */ MCAutoPointer<MCBlock> newblock =
+						new (nothrow) MCBlock;
 					newblock->setparent(this);
 					
 					// MW-2012-03-04: [[ StackFile5500 ]] If the tag was actually an
 					//   extended block, then pass in 'true' for is_ext.
 					if ((stat = newblock->load(stream, version, type == OT_BLOCK_EXT)) != IO_NORMAL)
 					{
-						delete newblock;
 						return checkloadstat(IO_ERROR);
 					}
 					
@@ -626,7 +626,7 @@ IO_stat MCParagraph::load(IO_handle stream, uint32_t version, bool is_ext)
                         // Fix the indices used by the block
                         newblock->SetRange(t_index, len);
 					}
-					newblock->appendto(blocks);
+					newblock.Release()->appendto(blocks);
 				}
 					break;
 				default:


### PR DESCRIPTION
There were four different codepaths that could allow a
heap-allocated `MCBlock` to be leaked.  Fix all of them by using
an `MCAutoPointer`.

Coverity-ID: 16349