### PR TITLE
[CID 16610] tokenize_stringref(): Fix uninitialized variable

### DIFF
--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -1194,8 +1194,8 @@ static void tokenize_stringref(MCStringRef p_string, uint4 p_in_nesting, uint4& 
 		uint4 t_class_index;
 		t_class_index = 0;
         
-		uint4 t_start, t_end;
-		t_start = t_index;
+		uint4 t_start = t_index;
+		uint4 t_end = t_index;
         
 		MCColourizeClass t_comment_class;
 		uint4 t_nesting_delta;


### PR DESCRIPTION
Ensure that `t_end` is always initialised before use.

Coverity-ID: 16610