### PR TITLE
[[ Bug 18977 ]] Don't short-cut card setting in no ui mode

### DIFF
--- a/docs/notes/bugfix-18977.md
+++ b/docs/notes/bugfix-18977.md
@@ -1,0 +1,1 @@
+# Ensure setting the card triggers openCard / closeCard in no UI mode

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1076,17 +1076,9 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
 
 	if (editing != NULL && card != curcard)
 		stopedit();
-	if (!opened || !haswindow())
+	if (!opened)
 	{
-		if (opened)
-		{
-			curcard->close();
-			curcard = card;
-			curcard->open();
-		}
-
-		else
-			curcard = card;
+		curcard = card;
 		return ES_NORMAL;
 	}
 

--- a/tests/lcs/core/interface/go.livecodescript
+++ b/tests/lcs/core/interface/go.livecodescript
@@ -25,3 +25,17 @@ on TestGoTwice
    TestAssert "go stack twice does not cause crash", true
 end TestGoTwice
 
+
+on TestGoToCard
+	create stack
+	set the defaultstack to the short name of it
+	create card
+	set the script of this card to \ 
+		"on closeCard; set the cClosed of me to true; end closeCard"
+	set the script of card 1 to \
+		"on openCard; set the cOpened of me to true; end openCard"
+	go card 1
+	
+	TestAssert "openCard sent to opened card", the cOpened of card 1
+	TestAssert "closeCard sent to closed card", the cClosed of card 2
+end TestGoToCard


### PR DESCRIPTION
This was preventing openCard messages in no ui mode.