### PR TITLE
[CID 140474] MCXWDImageLoader::LoadFrames(): Use after free

### DIFF
--- a/engine/src/ibmp.cpp
+++ b/engine/src/ibmp.cpp
@@ -2788,6 +2788,7 @@ bool MCXWDImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
     if (!MCImageBitmapCreate(t_width, t_height, t_frame->image))
     {
         MCImageFreeFrames(t_frame, 1);
+        return false;
     }
 
     uint2 redshift, greenshift, blueshift, redbits, greenbits, bluebits;


### PR DESCRIPTION
In commit b02c4524, which refactored the function to remove a
success flag and explicit cleanup code, a `return` statement was
omitted.  This caused a possible use-after-free on a memory
allocation failure path.

Coverity-ID: 140474