### PR TITLE
[CID 14954] Fix copy-and-paste error in MCField copy constructor

### DIFF
--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -310,7 +310,7 @@ MCField::MCField(const MCField &fref) : MCControl(fref)
     nalignments = fref.nalignments;
     if (nalignments)
     {
-        alignments = new (nothrow) intenum_t[ntabs];
+        /* UNCHECKED */ alignments = new (nothrow) intenum_t[nalignments];
         uint2 i;
         for (i = 0; i < nalignments; i++)
             alignments[i] = fref.alignments[i];


### PR DESCRIPTION
The `MCField::alignments` array was being allocated with length
`ntabs` rather than `nalignments`.  If `ntabs != nalignments` this
could have resulted in an array overflow or in the use of
uninitialised values.

Coverity-ID: 14954