### PR TITLE
[CID 137762] MCAutoValueRefBase: Allow move construction/assignment

### DIFF
--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -58,6 +58,9 @@ public:
         Reset(other.m_value);
     }
     
+    MCAutoValueRefBase(MCAutoValueRefBase&& other)
+        : m_value(other.Take()) {}
+
     inline MCAutoValueRefBase(T p_value)
 		: m_value(nil)
 	{
@@ -76,6 +79,12 @@ public:
 		m_value = (T)MCValueRetain(value);
 		return value;
 	}
+
+    MCAutoValueRefBase& operator=(MCAutoValueRefBase&& other)
+    {
+        Give(other.Take());
+        return *this;
+    }
 
 	inline T& operator & (void)
 	{


### PR DESCRIPTION
Coverity identified that adding a move assignment operator to
`MCNewAutoNameRef` would allow slightly better code to be generated
in some cases.  This seems like a good idea, so this patch adds
both move assignment and move construction to `MCAutoValueRefBase`.

Coverity-ID: 137762