### PR TITLE
[[ Bug 18058 ]] Fix keyboard not show in landscape orientation on Android

### DIFF
--- a/docs/notes/bugfix-18058.md
+++ b/docs/notes/bugfix-18058.md
@@ -1,0 +1,1 @@
+# Fix keyboard not show in landscape orientation

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -579,7 +579,8 @@ public class Engine extends View implements EngineApi
 		if (imm != null)
 			imm.restartInput(this);
 		
-        imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
+		// HH-2017-01-18: [[ Bug 18058 ]] Fix keyboard not show in landscape orientation
+        imm.showSoftInput(this, InputMethodManager.SHOW_FORCED);
     }
 
     public void hideKeyboard()


### PR DESCRIPTION
Fix keyboard not show in landscape orientation on Android