### PR TITLE
Merge develop 8.1 18.01.2017

### DIFF
--- a/docs/notes/bugfix-17973.md
+++ b/docs/notes/bugfix-17973.md
@@ -1,0 +1,1 @@
+# Make sure `the machine` can distinguish between iOS device and simulator 

--- a/docs/notes/bugfix-18459.md
+++ b/docs/notes/bugfix-18459.md
@@ -1,0 +1,1 @@
+Fix incorrect behavior of files() and folders() function on Android.

--- a/docs/notes/bugfix-18459.md
+++ b/docs/notes/bugfix-18459.md
@@ -1,1 +1,1 @@
-Fix incorrect behavior of files() and folders() function on Android.
+# Fix incorrect behavior of files() and folders() function on Android.

--- a/docs/notes/bugfix-18977.md
+++ b/docs/notes/bugfix-18977.md
@@ -1,0 +1,1 @@
+# Ensure setting the card triggers openCard / closeCard in no UI mode

--- a/docs/notes/bugfix-19032.md
+++ b/docs/notes/bugfix-19032.md
@@ -1,0 +1,1 @@
+# Prevent crash when creating and deleting two data grids

--- a/docs/notes/bugfix-19050.md
+++ b/docs/notes/bugfix-19050.md
@@ -1,1 +1,1 @@
-[[ Bug 19050 ]] CGI does not work with lighttpd 1.4.44
+# CGI does not work with lighttpd 1.4.44

--- a/docs/notes/bugfix-19088.md
+++ b/docs/notes/bugfix-19088.md
@@ -1,0 +1,1 @@
+# Do not show "Success" dialog if an error occurred in S/B

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1158,6 +1158,7 @@ Boolean MCCard::del(bool p_check_flag)
 			}
 			else
 			{
+                optr->getref()->uncacheid();
 				getstack()->removecontrol(optr->getref());
 			}
 			MCCdata *dptr = optr->getref()->getdata(obj_id, False);
@@ -1167,6 +1168,8 @@ Boolean MCCard::del(bool p_check_flag)
 		}
 		while (optr != objptrs);
 	}
+    
+    uncacheid();
     
     // MCObject now does things on del(), so we must make sure we finish by
     // calling its implementation.

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -501,25 +501,25 @@ Boolean MCControl::del(bool p_check_flag)
 	getcard()->count(CT_LAYER, CT_UNDEFINED, this, num, True);
 	switch (parent->gettype())
 	{
-	case CT_CARD:
-		{
-			MCCard *cptr = parent.GetAs<MCCard>();
-			if (!cptr->removecontrol(this, False, True))
+        case CT_STACK:
+            uncacheid();
+            parent.GetAs<MCStack>()->removecontrol(this);
+            break;
+        
+        case CT_CARD:
+            if (!parent.GetAs<MCCard>()->removecontrol(this, False, True))
 				return False;
+            uncacheid();
 			getstack()->removecontrol(this);
 			break;
-		}
-	case CT_GROUP:
-		{
-			MCGroup *gptr = parent.GetAs<MCGroup>();
-			gptr->removecontrol(this, True);
+        
+        case CT_GROUP:
+			parent.GetAs<MCGroup>()->removecontrol(this, True);
+            uncacheid();
 			break;
-		}
-	default:
-		{ //stack
-			MCStack *sptr = parent.GetAs<MCStack>();
-			sptr->removecontrol(this);
-		}
+
+        default:
+            MCUnreachable();
 	}
 
     // IM-2012-05-16 [[ BZ 10212 ]] deleting the dragtarget control in response

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -497,8 +497,6 @@ Boolean MCControl::del(bool p_check_flag)
 	if (getselected())
 		getcard()->dirtyselection(rect);
 
-	uint2 num = 0;
-	getcard()->count(CT_LAYER, CT_UNDEFINED, this, num, True);
 	switch (parent->gettype())
 	{
         case CT_STACK:

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -1031,6 +1031,22 @@ void MCGroup::applyrect(const MCRectangle &nrect)
 	}
 }
 
+void MCGroup::uncacheid()
+{
+    if (controls != NULL)
+    {
+        MCControl *t_control;
+        t_control = controls;
+        do
+        {   t_control -> uncacheid();
+            t_control = t_control -> next();
+        }
+        while(t_control != controls);
+    }
+    
+    MCObject::uncacheid();
+}
+
 bool MCGroup::isdeletable(bool p_check_flag)
 {
     if (!parent || scriptdepth != 0 ||

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -1079,7 +1079,6 @@ Boolean MCGroup::del(bool p_check_flag)
 	if (!isdeletable(p_check_flag))
 	    return False;
 	
-    rect = getcard()->getrect();
 	return MCControl::del(p_check_flag);
 }
 

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -92,7 +92,7 @@ public:
 	virtual Boolean doubleup(uint2 which);
 	virtual void applyrect(const MCRectangle &nrect);
 
-    
+    virtual void uncacheid(void);
 	virtual Boolean del(bool p_check_flag);
 	virtual void recompute();
 

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -1550,7 +1550,7 @@ void MCIdeScriptColourize::exec_ctxt(MCExecContext &ctxt)
 	t_state = MCIdeState::Find(t_target);
 
 
-    if (t_target && t_target -> getparagraphs() != NULL)
+    if (t_target && t_target -> getparagraphs() != NULL && t_target -> getopened())
         TokenizeField(t_target, t_state, f_type, t_start, t_end, colourize_paragraph);
 }
 

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -195,7 +195,7 @@ bool apk_list_folder_entries(MCStringRef p_apk_folder, MCSystemListFolderEntries
 		}
 
 		// 2017-01-07: [[ Bug 18459 ]] Make sure MCU_stob() is execute and t_is_folder is set.
-		if ( MCU_stob(t_ffolder, t_is_folder) && !MCU_stoi4(t_fsize, t_size) )
+		if (MCU_stob(t_ffolder, t_is_folder) && !MCU_stoi4(t_fsize, t_size))
 			return false;
 
 		// SN-2014-01-13: [[ RefactorUnicode ]] Asset filenames are in ASCII

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -194,7 +194,8 @@ bool apk_list_folder_entries(MCStringRef p_apk_folder, MCSystemListFolderEntries
 			t_more_entries = false;
 		}
 
-		if (!MCU_stoi4(t_fsize, t_size) && MCU_stob(t_ffolder, t_is_folder))
+		// 2017-01-07: [[ Bug 18459 ]] Make sure MCU_stob() is execute and t_is_folder is set.
+		if ( MCU_stob(t_ffolder, t_is_folder) && !MCU_stoi4(t_fsize, t_size) )
 			return false;
 
 		// SN-2014-01-13: [[ RefactorUnicode ]] Asset filenames are in ASCII

--- a/engine/src/mbliphone.mm
+++ b/engine/src/mbliphone.mm
@@ -383,7 +383,12 @@ bool MCIPhoneSystem::GetVersion(MCStringRef& r_string)
 
 bool MCIPhoneSystem::GetMachine(MCStringRef& r_string)
 {
-	return MCStringCreateWithCFString((CFStringRef)[[UIDevice currentDevice] model], r_string);
+    NSString *t_machine = [[UIDevice currentDevice] model];
+#if TARGET_IPHONE_SIMULATOR
+    t_machine = [t_machine stringByAppendingString:@" Simulator"];
+#endif
+    
+    return MCStringCreateWithCFString((CFStringRef)t_machine, r_string);
 }
 
 MCNameRef MCIPhoneSystem::GetProcessor(void)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -317,11 +317,6 @@ MCObject::~MCObject()
 	MCMemoryDeleteArray(patterns);
 	deletepropsets();
 	MCValueRelease(tooltip);
-
-	// MW-2012-11-20: [[ IdCache ]] Make sure we delete the object from the cache - not
-	//   all deletions vector through 'scheduledelete'.
-	if (m_in_id_cache)
-		getstack() -> uncacheobjectbyid(this);
     
     // If this object is a parent-script make sure we flush it from the table.
 	if (m_is_parent_script)
@@ -859,6 +854,12 @@ void MCObject::deselect()
 	state &= ~CS_SELECTED;
 }
 
+void MCObject::uncacheid()
+{
+    if (m_in_id_cache)
+        getstack()->uncacheobjectbyid(this);
+}
+
 bool MCObject::isdeletable(bool p_check_flag)
 {
     if (!parent || scriptdepth != 0 || MCdispatcher -> getmenu() == this || MCmenuobjectptr == this)
@@ -880,18 +881,6 @@ Boolean MCObject::del(bool p_check_flag)
 		MCParentScript::FlushObject(this);
         m_is_parent_script = false;
     }
-    
-    // SN-2015-06-04: [[ Bug 14642 ]] These two blocks have been moved from
-    //  MCObject::scheduledelete, since a deleted object is no longer something
-    //  we want to listen to. In case we undo the deletion, it will be added
-    //  back to the list of listened objects; in case we revert the stack to its
-    //  saved state, we will now be left with a list of listened-to objects with
-    //  no dangling pointers.
-    
-    // MW-2012-10-10: [[ IdCache ]] Remove the object from the stack's id cache
-    //   (if it is in it!).
-    if (m_in_id_cache)
-        getstack() -> uncacheobjectbyid(this);
 	
 	// This object is in the process of being deleted; invalidate any weak refs
 	// and prevent any new ones from being created.

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -280,7 +280,9 @@ MCObject::MCObject(const MCObject &oref) : MCDLlist(oref)
 
 MCObject::~MCObject()
 {
-	while (opened)
+    MCAssert(!m_in_id_cache);
+    
+    while (opened)
 		close();
 
 	// MW-2012-02-16: [[ LogFonts ]] Delete the font attrs (if any).

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -672,6 +672,8 @@ public:
 	virtual void undo(Ustruct *us);
 	virtual void freeundo(Ustruct *us);
 
+    virtual void uncacheid(void);
+    
 	// [[ C++11 ]] MSVC doesn't support typename here while other compilers require it
 #ifdef _MSC_VER
 	virtual MCObjectProxy<MCStack>::Handle getstack();

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1076,17 +1076,9 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
 
 	if (editing != NULL && card != curcard)
 		stopedit();
-	if (!opened || !haswindow())
+	if (!opened)
 	{
-		if (opened)
-		{
-			curcard->close();
-			curcard = card;
-			curcard->open();
-		}
-
-		else
-			curcard = card;
+		curcard = card;
 		return ES_NORMAL;
 	}
 

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -240,10 +240,10 @@ on revSaveAsStandalone pStack, pFolder, pPreview
       put the result into tError
    end if
    
-   if revStandaloneGetWarnings() is not empty then
+   if revStandaloneGetWarnings() is not empty and tError is empty then
       set the cWarnings of stack "revBuildResults" to revStandaloneGetWarnings()
    else
-      if not revSBSuppressDialogs() then
+      if not revSBSuppressDialogs() and tError is empty then
          answer information "Standalone application saved successfully."
       end if
       

--- a/tests/lcs/core/interface/go.livecodescript
+++ b/tests/lcs/core/interface/go.livecodescript
@@ -25,3 +25,17 @@ on TestGoTwice
    TestAssert "go stack twice does not cause crash", true
 end TestGoTwice
 
+
+on TestGoToCard
+	create stack
+	set the defaultstack to the short name of it
+	create card
+	set the script of this card to \ 
+		"on closeCard; set the cClosed of me to true; end closeCard"
+	set the script of card 1 to \
+		"on openCard; set the cOpened of me to true; end openCard"
+	go card 1
+	
+	TestAssert "openCard sent to opened card", the cOpened of card 1
+	TestAssert "closeCard sent to closed card", the cClosed of card 2
+end TestGoToCard


### PR DESCRIPTION
Conflict in `tests/lcs/core/interface/go.livecodescript`, resolved by keeping the `develop-8.1` version of the file, which includes one extra test (see diffs below for details)

This PR also fixes the failure in `develop` nightly builds (because of a bad header in a bugfix note)