### PR TITLE
[[ Bug 19093 ]] Use blocking wait when waiting for screen refresh

### DIFF
--- a/docs/notes/bugfix-19093.md
+++ b/docs/notes/bugfix-19093.md
@@ -1,0 +1,1 @@
+# Prevent recursion when fetching mouseColor in mouseMove handler

--- a/engine/src/mac-snapshot.mm
+++ b/engine/src/mac-snapshot.mm
@@ -281,12 +281,12 @@ static void wait_for_refresh(void)
     s_display_link_fired = false;
     
     while(!s_display_link_fired)
-		MCPlatformWaitForEvent(60.0, false);
+		MCPlatformWaitForEvent(60.0, true);
     
     s_display_link_fired = false;
     
     while(!s_display_link_fired)
-		MCPlatformWaitForEvent(60.0, false);
+		MCPlatformWaitForEvent(60.0, true);
     
     CVDisplayLinkStop(t_link);
     


### PR DESCRIPTION
Otherwise many snapshots in quick succession can cause recursionLimit
to be reached.