### PR TITLE
Use managed pointers in MCClipboard

### DIFF
--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -1288,8 +1288,8 @@ MCStringRef MCClipboard::ConvertStyledTextToText(MCDataRef p_pickled_text)
     if (!MCtemplatefield->exportasplaintext(t_paragraphs, 0, INT32_MAX,
                                             &t_text))
         return NULL;
-    
-    return MCValueRetain(*t_text);
+
+    return t_text.Take();
 }
 
 MCStringRef MCClipboard::ConvertStyledTextToHTML(MCDataRef p_pickled_text)
@@ -1348,7 +1348,7 @@ MCDataRef MCClipboard::ConvertStyledTextToRTF(MCDataRef p_pickled_text)
     if (!MCStringEncode(*t_text, kMCStringEncodingNative, false, &t_rtf))
         return NULL;
     
-    return MCValueRetain(*t_rtf);
+    return t_rtf.Take();
 }
 
 MCDataRef MCClipboard::ConvertRTFToStyledText(MCDataRef p_rtf_data)
@@ -1415,8 +1415,8 @@ MCArrayRef MCClipboard::ConvertStyledTextToStyledTextArray(MCDataRef p_pickled_t
     if (*t_style_array == NULL)
         return NULL;
     
-    // Return a copy of the styled text array
-    return MCValueRetain(*t_style_array);
+    // Return the styled text array
+    return t_style_array.Take();
 }
 
 MCDataRef MCClipboard::ConvertStyledTextArrayToStyledText(MCArrayRef p_styles)

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -1210,15 +1210,14 @@ MCParagraph* MCClipboard::CopyAsParagraphs(MCField* p_via_field) const
     if (CopyAsLiveCodeStyledText(&t_pickled_text))
     {
         // Turn the pickled text into a StyledText object
-        MCObject *t_object = MCObject::unpickle(*t_pickled_text, p_via_field -> getstack());
-        if (t_object == NULL)
+	    MCAutoPointer<MCObject> t_object = MCObject::unpickle(*t_pickled_text, p_via_field -> getstack());
+        if (!t_object)
             return NULL;
         
         // And from that, get the paragraph structures that the field can deal with
         MCParagraph *t_paragraphs;
-        t_paragraphs = (static_cast<MCStyledText*>(t_object))->grabparagraphs(p_via_field);
-        
-        delete t_object;
+        t_paragraphs = (static_cast<MCStyledText*>(t_object.Get()))->grabparagraphs(p_via_field);
+
         return t_paragraphs;
     }
     
@@ -1274,21 +1273,20 @@ const MCRawClipboardItem* MCClipboard::GetItem() const
 MCStringRef MCClipboard::ConvertStyledTextToText(MCDataRef p_pickled_text)
 {
     // Turn the pickled text into a StyledText object
-    MCObject *t_object = MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
-    if (t_object == NULL)
+	MCAutoPointer<MCObject> t_object = MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
+    if (!t_object)
         return NULL;
     
     // And from that, get the paragraph structures that the field can deal with
     MCParagraph *t_paragraphs;
-    t_paragraphs = (static_cast<MCStyledText*>(t_object))->getparagraphs();
+    t_paragraphs = (static_cast<MCStyledText*>(t_object.Get()))->getparagraphs();
     if (t_paragraphs == NULL)
         return NULL;
     
     // Export the field contents as plain text
     MCAutoStringRef t_text;
-    bool t_success = MCtemplatefield->exportasplaintext(t_paragraphs, 0, INT32_MAX, &t_text);
-    delete t_object;
-    if (!t_success)
+    if (!MCtemplatefield->exportasplaintext(t_paragraphs, 0, INT32_MAX,
+                                            &t_text))
         return NULL;
     
     return MCValueRetain(*t_text);
@@ -1297,21 +1295,21 @@ MCStringRef MCClipboard::ConvertStyledTextToText(MCDataRef p_pickled_text)
 MCStringRef MCClipboard::ConvertStyledTextToHTML(MCDataRef p_pickled_text)
 {
     // Turn the pickled text into a StyledText object
-    MCObject *t_object = MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
-    if (t_object == NULL)
+    MCAutoPointer<MCObject> t_object =
+        MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
+    if (!t_object)
         return NULL;
     
     // And from that, get the paragraph structures that the field can deal with
     MCParagraph *t_paragraphs;
-    t_paragraphs = (static_cast<MCStyledText*>(t_object))->getparagraphs();
+    t_paragraphs = (static_cast<MCStyledText*>(t_object.Get()))->getparagraphs();
     if (t_paragraphs == NULL)
         return NULL;
     
     // Export the field contents as HTML
     MCAutoDataRef t_html;
-    bool t_success = MCtemplatefield->exportashtmltext(t_paragraphs, 0, INT32_MAX, false, &t_html);
-    delete t_object;
-    if (!t_success)
+    if (!MCtemplatefield->exportashtmltext(t_paragraphs, 0, INT32_MAX,
+                                           false, &t_html))
         return NULL;
 
 	// Convert the HTML into a string
@@ -1326,21 +1324,20 @@ MCStringRef MCClipboard::ConvertStyledTextToHTML(MCDataRef p_pickled_text)
 MCDataRef MCClipboard::ConvertStyledTextToRTF(MCDataRef p_pickled_text)
 {
     // Turn the pickled text into a StyledText object
-    MCObject *t_object = MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
-    if (t_object == NULL)
+    MCAutoPointer<MCObject> t_object =
+        MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
+    if (!t_object)
         return NULL;
     
     // And from that, get the paragraph structures that the field can deal with
     MCParagraph *t_paragraphs;
-    t_paragraphs = (static_cast<MCStyledText*>(t_object))->getparagraphs();
+    t_paragraphs = (static_cast<MCStyledText*>(t_object.Get()))->getparagraphs();
     if (t_paragraphs == NULL)
         return NULL;
     
     // Export the field contents as RTF
     MCAutoStringRef t_text;
-    bool t_success = MCtemplatefield->exportasrtftext(t_paragraphs, 0, INT32_MAX, &t_text);
-    delete t_object;
-    if (!t_success)
+    if (!MCtemplatefield->exportasrtftext(t_paragraphs, 0, INT32_MAX, &t_text))
         return NULL;
     
     // The RTF format description specifies that only 7-bit ASCII characters are
@@ -1401,19 +1398,18 @@ MCDataRef MCClipboard::ConvertHTMLToStyledText(MCStringRef p_html_string)
 MCArrayRef MCClipboard::ConvertStyledTextToStyledTextArray(MCDataRef p_pickled_text)
 {
     // Turn the pickled text into a StyledText object
-    MCObject *t_object = MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
-    if (t_object == NULL)
+    MCAutoPointer<MCObject> t_object =
+        MCObject::unpickle(p_pickled_text, MCtemplatefield -> getstack());
+    if (!t_object)
         return NULL;
     
     // Grab the paragraphs from the object and turn them into a text styles
     // array.
     MCParagraph* t_paragraphs;
     MCAutoArrayRef t_style_array;
-    t_paragraphs = (static_cast<MCStyledText*>(t_object))->getparagraphs();
+    t_paragraphs = (static_cast<MCStyledText*>(t_object.Get()))->getparagraphs();
     if (t_paragraphs != NULL)
         MCtemplatefield->exportasstyledtext(t_paragraphs, 0, INT32_MAX, false, false, &t_style_array);
-
-    delete t_object;
     
     // If generating the array failed, return NULL
     if (*t_style_array == NULL)

--- a/engine/src/clipboard.h
+++ b/engine/src/clipboard.h
@@ -20,6 +20,7 @@
 
 
 #include "foundation.h"
+#include "foundation-auto.h"
 #include "mixin-refcounted.h"
 #include "raw-clipboard.h"
 
@@ -192,7 +193,7 @@ private:
     mutable uindex_t m_lock_count;
     
     // Private data (if any) added to this clipboard
-    MCDataRef m_private_data;
+    MCAutoDataRef m_private_data;
     
     // Set whenever a modification is made to the clipboard. No updates are
     // pushed if no modifications have been made.
@@ -202,7 +203,6 @@ private:
     // Constructor and destructor
     friend class MCMixinRefcounted<MCClipboard>;
     MCClipboard(MCRawClipboard* t_underlying_clipboard);
-    ~MCClipboard();
     
     
     // Returns the first item on the clipboard, creating a new one if required


### PR DESCRIPTION
- Replace `MCClipboard::m_private_data` with a managed pointer
- Avoid explicit `delete` by using `MCAutoPointer`
- `Take()` managed pointer contents to avoid unnecessary retains and releases