### PR TITLE
[CID 16631] Don't leak color names when reading XPM headers

### DIFF
--- a/engine/src/ibmp.cpp
+++ b/engine/src/ibmp.cpp
@@ -2476,6 +2476,7 @@ static bool xpm_read_v1_header(IO_handle p_stream, char x_line[XPM_MAX_LINE], ui
 		MCMemoryDeleteArray(t_color_chars);
 	}
 
+    MCCStringFree(t_name);
 	return t_success;
 }
 


### PR DESCRIPTION
Coverity-ID: 16631