### PR TITLE
MCIs::compile(): Fix compiling "is not a number" syntax

### DIFF
--- a/engine/src/operator.cpp
+++ b/engine/src/operator.cpp
@@ -956,7 +956,7 @@ void MCIs::compile(MCSyntaxFactoryRef ctxt)
 				t_method = form == IT_NORMAL ? kMCMathEvalIsAnIntegerMethodInfo : kMCMathEvalIsNotAnIntegerMethodInfo;
 				break;
 			case IV_NUMBER:
-				t_method = form == IT_NORMAL ? kMCMathEvalIsANumberMethodInfo : kMCMathEvalIsANumberMethodInfo;
+				t_method = form == IT_NORMAL ? kMCMathEvalIsANumberMethodInfo : kMCMathEvalIsNotANumberMethodInfo;
 				break;
 			case IV_LOGICAL:
 				t_method = form == IT_NORMAL ? kMCLogicEvalIsABooleanMethodInfo : kMCLogicEvalIsNotABooleanMethodInfo;


### PR DESCRIPTION
Minor typo in conditional expression.

Coverity-ID: 15525