### PR TITLE
[[ Tests ]] Broken private key test on Linux

### DIFF
--- a/tests/lcs/core/engine/clipboard.livecodescript
+++ b/tests/lcs/core/engine/clipboard.livecodescript
@@ -201,9 +201,15 @@ on TestClipboardPrivateKey
    end if
 
    TestAssert "helper changed clipboard externally", the result is 0
-
-   TestAssert "private key not present after external change", \
-      "private" is not among the keys of the clipboardData
+   
+   if the platform is "Linux" then
+      TestAssertBroken "private key not present after external change", \
+         "private" is not among the keys of the clipboardData, \
+         "Bug 19117"
+   else
+      TestAssert "private key not present after external change", \
+         "private" is not among the keys of the clipboardData
+   end if
 end TestClipboardPrivateKey
 
 # This is a regression test for Bug 19084


### PR DESCRIPTION
This test is skipped in the develop-8.1 CI because there is no UI. This was masking the fact that there is actually a bug on Linux (http://quality.livecode.com/show_bug.cgi?id=19117). Targeting at develop-8.1 because the test was added there,  and this prevents possible problems later on if we needed to use the Travis GUI for Linux on develop-8.1. 