### PR TITLE
[[ Bug 17664 ]] Enables localization of iOS system UI text

### DIFF
--- a/docs/notes/bugfix-17664.md
+++ b/docs/notes/bugfix-17664.md
@@ -1,0 +1,1 @@
+# This patch enables localization of iOS system UI text.

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -266,6 +266,12 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
    
    -- Generate the plist
    revCreateMobilePlist pSettings, pAppBundle, pTarget, tCopiedFonts, tPlist
+
+   // HH-2017-01-22: [[ Bug 17664 ]] Let iOS detect supported language
+   put "af-NA ar Base ca cs da de el es-MX es fi fr he hr hu id it ja ko ms nb nl pl pt-BR pt-PT ro ru sk sv th tr uk vi zh-Hans zh-Hant" into tSupportLangs
+   repeat for each word tLang in tSupportLangs
+      create folder (pAppBundle & slash & tLang & ".lproj")
+   end repeat
    
    -- Generate the PkgInfo file
    put "APPL????" into url ("binfile:" & pAppBundle & slash & "PkgInfo")


### PR DESCRIPTION
According to [Apple's Document:The Bundle Search Pattern](https://developer.apple.com/library/content/documentation/CoreFoundation/Conceptual/CFBundles/AccessingaBundlesContents/AccessingaBundlesContents.html#//apple_ref/doc/uid/10000123i-CH104-SW7). If a .lproj folder exists in the bundle, that localization is used. This patch create .lproj folders for many language so the system can recognize and use it as default localization. Functions display text using iOS system UI (e.g. mobilePick, mobilePickPhoto) will be localized.

I've tested in simulator (10.2) and it works fine. But when testing on my iPhone (10.2) I need to change "CFBundleDevelopmentRegion" in Setting.plist to country name (e.g. US or Taiwan) rather than language name. So besides this patch, I change "CFBundleDevelopmentRegion" from "English" to "Taiwan".

Since I don't have any other iOS devices for testing. This patch should be test in some more versions of iOS devices.