### PR TITLE
[[ VarAccess ]] Cleanup and optimization

### DIFF
--- a/benchmarks/lcs/control/variable.livecodescript
+++ b/benchmarks/lcs/control/variable.livecodescript
@@ -1,0 +1,317 @@
+script "ControlVariable"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+constant kRepetitions = 100000
+
+private command BenchmarkArrayAccess pOne, pTwo, pThree, pFour
+   BenchmarkStartTiming "Store[]"
+   repeat kRepetitions times
+      put empty into tVar
+      put 1 into tVar[pOne]
+      put 2 into tVar[pTwo]
+      put 3 into tVar[pThree]
+      put 4 into tVar[pFour]
+   end repeat
+   BenchmarkStopTiming
+
+   BenchmarkStartTiming "Fetch[]"
+   repeat kRepetitions times
+      get tVar[pOne]
+      get tVar[pTwo]
+      get tVar[pThree]
+      get tVar[pFour]
+   end repeat
+   BenchmarkStopTiming
+
+   BenchmarkStartTiming "Store[][]"
+   repeat kRepetitions times
+      put empty into tVar
+      put 1 into tVar[pOne][pTwo]
+      put 2 into tVar[pTwo][pThree]
+      put 3 into tVar[pThree][pFour]
+      put 4 into tVar[pFour][pOne]
+   end repeat
+   BenchmarkStopTiming
+
+   BenchmarkStartTiming "Fetch[][]"
+   repeat kRepetitions times
+      get tVar[pOne][pTwo]
+      get tVar[pTwo][pThree]
+      get tVar[pThree][pFour]
+      get tVar[pFour][pOne]
+   end repeat
+   BenchmarkStopTiming
+end BenchmarkArrayAccess
+
+on BenchmarkArrayNameKeys
+   BenchmarkArrayAccess "one", "two", "three", "four"
+end BenchmarkArrayNameKeys
+
+on BenchmarkArrayIndexKeys
+   BenchmarkArrayAccess 1+0, 2+0, 3+0, 4+0
+end BenchmarkArrayIndexKeys
+
+on BenchmarkArrayStringKeys
+   BenchmarkArrayAccess "on" & "e", "tw" & "o", "thre" & "e", "fou" & "r"
+end BenchmarkArrayStringKeys
+
+on BenchmarkVariableFetchLocal
+   local tVar
+
+   local tName1, tName2, tName3, tName4
+   put "one" into tName1
+   put "two" into tName1
+   put "three" into tName1
+   put "four" into tName1
+
+   local tNumber1, tNumber2, tNumber3, tNumber4
+   put 1 + 0 into tNumber1
+   put 2 + 0 into tNumber2
+   put 3 + 0 into tNumber3
+   put 4 + 0 into tNumber4
+
+   local tString1, tString2, tString3, tString4
+   put "on" & "e" into tString1
+   put "tw" & "o" into tString2
+   put "thre" & "e" into tString3
+   put "fou" & "r" into tString4
+
+   local tSeq1_1, tSeq1_2, tSeq1_3, tSeq1_4
+   put tName1 into tSeq1_1[1]
+   put tName2 into tSeq1_2[1]
+   put tName3 into tSeq1_3[1]
+   put tName4 into tSeq1_4[1]
+
+   local tSeq2_1, tSeq2_2, tSeq2_3, tSeq2_4
+   put tName1 into tSeq2_1[1]
+   put tName1 into tSeq2_1[2]
+   put tName2 into tSeq2_2[1]
+   put tName2 into tSeq2_2[2]
+   put tName3 into tSeq2_3[1]
+   put tName3 into tSeq2_3[2]
+   put tName4 into tSeq2_4[1]
+   put tName4 into tSeq2_4[2]
+
+   put empty into tVar
+   put 100 into tVar
+   BenchmarkStartTiming "Get Base"
+   repeat kRepetitions times
+      get tVar
+      get tVar
+      get tVar
+      get tVar
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tName1]
+   put 100 into tVar[tName2]
+   put 100 into tVar[tName3]
+   put 100 into tVar[tName4]
+   BenchmarkStartTiming "Get Base[<name>]"
+   repeat kRepetitions times
+      get tVar[tName1]
+      get tVar[tName2]
+      get tVar[tName3]
+      get tVar[tName4]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tNumber1]
+   put 100 into tVar[tNumber2]
+   put 100 into tVar[tNumber3]
+   put 100 into tVar[tNumber4]
+   BenchmarkStartTiming "Get Base[<number>]"
+   repeat kRepetitions times
+      get tVar[tNumber1]
+      get tVar[tNumber2]
+      get tVar[tNumber3]
+      get tVar[tNumber4]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tString1]
+   put 100 into tVar[tString2]
+   put 100 into tVar[tString3]
+   put 100 into tVar[tString4]
+   BenchmarkStartTiming "Get Base[<string>]"
+   repeat kRepetitions times
+      get tVar[tString1]
+      get tVar[tString2]
+      get tVar[tString3]
+      get tVar[tString4]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tSeq1_1]
+   put 100 into tVar[tSeq1_2]
+   put 100 into tVar[tSeq1_3]
+   put 100 into tVar[tSeq1_4]
+   BenchmarkStartTiming "Get Base[<seq-1>]"
+   repeat kRepetitions times
+      get tVar[tSeq1_1]
+      get tVar[tSeq1_2]
+      get tVar[tSeq1_3]
+      get tVar[tSeq1_4]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tName1][tName1]
+   put 100 into tVar[tName2][tName2]
+   put 100 into tVar[tName3][tName3]
+   put 100 into tVar[tName4][tName4]
+   BenchmarkStartTiming "Get Base[<name>][<name>]"
+   repeat kRepetitions times
+      get tVar[tName1][tName1]
+      get tVar[tName2][tName2]
+      get tVar[tName3][tName3]
+      get tVar[tName4][tName4]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tNumber1][tNumber1]
+   put 100 into tVar[tNumber2][tNumber2]
+   put 100 into tVar[tNumber3][tNumber3]
+   put 100 into tVar[tNumber4][tNumber4]
+   BenchmarkStartTiming "Get Base[<number>][<number>]"
+   repeat kRepetitions times
+      get tVar[tNumber1][tNumber1]
+      get tVar[tNumber2][tNumber2]
+      get tVar[tNumber3][tNumber3]
+      get tVar[tNumber4][tNumber4]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tString1][tString1]
+   put 100 into tVar[tString2][tString2]
+   put 100 into tVar[tString3][tString3]
+   put 100 into tVar[tString4][tString4]
+   BenchmarkStartTiming "Get Base[<string>][<string>]"
+   repeat kRepetitions times
+      get tVar[tString1][tString1]
+      get tVar[tString2][tString2]
+      get tVar[tString3][tString3]
+      get tVar[tString4][tString4]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tSeq2_1]
+   put 100 into tVar[tSeq2_2]
+   put 100 into tVar[tSeq2_3]
+   put 100 into tVar[tSeq2_4]
+   BenchmarkStartTiming "Get Base[<seq-2>]"
+   repeat kRepetitions times
+      get tVar[tSeq2_1]
+      get tVar[tSeq2_2]
+      get tVar[tSeq2_3]
+      get tVar[tSeq2_4]
+   end repeat
+   BenchmarkStopTiming
+end BenchmarkVariableFetchLocal
+
+on BenchmarkVariableStoreLocal
+   local tVar, tName, tNumber, tString, tSeq1, tSeq2
+   put "one" into tName
+   put 1 + 0 into tNumber
+   put "on" & "e" into tString
+   put tName into tSeq1[1]
+   put tName into tSeq2[1]
+   put tName into tSeq2[2]
+
+   put empty into tVar
+   put 100 into tVar
+   BenchmarkStartTiming "Replace Into Base"
+   repeat kRepetitions times
+      put 100 into tVar
+      put 100 into tVar
+      put 100 into tVar
+      put 100 into tVar
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tName]
+   BenchmarkStartTiming "Replace Into Base[<name>]"
+   repeat kRepetitions times
+      put 100 into tVar[tName]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tNumber]
+   BenchmarkStartTiming "Replace Into Base[<number>]"
+   repeat kRepetitions times
+      put 100 into tVar[tNumber]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tString]
+   BenchmarkStartTiming "Replace Into Base[<string>]"
+   repeat kRepetitions times
+      put 100 into tVar[tString]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tSeq1]
+   BenchmarkStartTiming "Replace Into Base[<seq-1>]"
+   repeat kRepetitions times
+      put 100 into tVar[tSeq1]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tName][tName]
+   BenchmarkStartTiming "Replace Into Base[<name>][<name>]"
+   repeat kRepetitions times
+      put 100 into tVar[tName][tName]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tNumber][tNumber]
+   BenchmarkStartTiming "Replace Into Base[<number>][<number>]"
+   repeat kRepetitions times
+      put 100 into tVar[tNumber][tNumber]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tString][tString]
+   BenchmarkStartTiming "Replace Into Base[<string>][<string>]"
+   repeat kRepetitions times
+      put 100 into tVar[tString][tString]
+   end repeat
+   BenchmarkStopTiming
+
+   put empty into tVar
+   put 100 into tVar[tSeq2]
+   BenchmarkStartTiming "Replace Into Base[<seq-2>]"
+   repeat kRepetitions times
+      put 100 into tVar[tSeq2]
+   end repeat
+   BenchmarkStopTiming
+end BenchmarkVariableStoreLocal

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -982,11 +982,6 @@ Parse_stat MCPut::parse(MCScriptPoint &sp)
 		return PS_ERROR;
 	}
 
-	MCVarref *t_src_ref, *t_dst_ref;
-	t_src_ref = source -> getrootvarref();
-	t_dst_ref = dest -> getrootvarref();
-	overlap = t_src_ref != NULL && t_dst_ref != NULL && t_src_ref -> rootmatches(t_dst_ref);
-
 	return PS_NORMAL;
 }
 

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -256,7 +256,6 @@ class MCPut : public MCStatement
 	// MW-2012-02-23: [[ UnicodePut ]] Indicates if the 'unicode' adjective
 	//   was present.
 	bool is_unicode : 1;
-	bool overlap : 1;
 
 	//cookie
 	MCExpression *name;
@@ -272,7 +271,6 @@ public:
 		// MW-2011-06-22: [[ SERVER ]] Make a distinction between 'put' and 'put .. into msg'
 		prep = PT_UNDEFINED;
 		dest = NULL;
-		overlap = false;
 		// cookie
 		name = NULL;
 		path = NULL;
@@ -1626,14 +1624,12 @@ class MCAdd : public MCStatement
 	MCExpression *source;
 	MCChunk *dest;
 	MCVarref *destvar;
-	bool overlap;
 public:
 	MCAdd()
 	{
 		source = NULL;
 		dest = NULL;
 		destvar = NULL;
-		overlap = false;
 	}
 	virtual ~MCAdd();
 	virtual Parse_stat parse(MCScriptPoint &);
@@ -1646,14 +1642,12 @@ class MCDivide : public MCStatement
 	MCExpression *source;
 	MCChunk *dest;
 	MCVarref *destvar;
-	bool overlap;
 public:
 	MCDivide()
 	{
 		source = NULL;
 		dest = NULL;
 		destvar = NULL;
-		overlap = false;
 	}
 	virtual ~MCDivide();
 	virtual Parse_stat parse(MCScriptPoint &);
@@ -1666,14 +1660,12 @@ class MCMultiply : public MCStatement
 	MCExpression *source;
 	MCChunk *dest;
 	MCVarref *destvar;
-	bool overlap;
 public:
 	MCMultiply()
 	{
 		source = NULL;
 		dest = NULL;
 		destvar = NULL;
-		overlap = false;
 	}
 	virtual ~MCMultiply();
 	virtual Parse_stat parse(MCScriptPoint &);
@@ -1686,14 +1678,12 @@ class MCSubtract : public MCStatement
 	MCExpression *source;
 	MCChunk *dest;
 	MCVarref *destvar;
-	bool overlap;
 public:
 	MCSubtract()
 	{
 		source = NULL;
 		dest = NULL;
 		destvar = NULL;
-		overlap = false;
 	}
 	virtual ~MCSubtract();
 	virtual Parse_stat parse(MCScriptPoint &);
@@ -1768,7 +1758,6 @@ class MCSetOp : public MCStatement
 	MCExpression *source;
 protected:
 	Boolean intersect : 1;
-	bool overlap : 1;
     // MERG-2013-08-26: [[ RecursiveArrayOp ]] Support nested arrays in union and intersect
     bool recursive : 1;
 public:

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -597,7 +597,6 @@ Parse_stat MCDispatchCmd::parse(MCScriptPoint& sp)
 // This method follows along the same lines as MCComref::exec
 void MCDispatchCmd::exec_ctxt(MCExecContext &ctxt)
 {
-	
     MCNewAutoNameRef t_message;
     if (!ctxt . EvalExprAsNameRef(message, EE_DISPATCH_BADMESSAGEEXP, &t_message))
         return;
@@ -623,9 +622,9 @@ void MCDispatchCmd::exec_ctxt(MCExecContext &ctxt)
 	while (tptr != NULL)
 	{
         // AL-2014-08-20: [[ ArrayElementRefParams ]] Use containers for potential reference parameters
-        MCContainer *t_container;
-        if (tptr -> evalcontainer(ctxt, t_container))
-            tptr -> set_argument_container(t_container);
+        MCAutoPointer<MCContainer> t_container = new (nothrow) MCContainer;
+        if (tptr -> evalcontainer(ctxt, **t_container))
+            tptr -> set_argument_container(t_container.Release());
         else
         {
             MCExecValue t_value;

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -37,28 +37,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////
 
-//
-
-inline bool MCMathOpCommandComputeOverlap(MCExpression *p_source, MCExpression *p_dest, MCVarref *p_destvar)
-{
-	MCVarref *t_src_ref;
-	t_src_ref = p_source -> getrootvarref();
-	if (t_src_ref == NULL)
-		return false;
-
-	if (p_destvar != NULL)
-		return t_src_ref -> rootmatches(p_destvar);
-
-	MCVarref *t_dst_ref;
-	t_dst_ref = p_dest -> getrootvarref();
-	if (t_dst_ref == NULL)
-		 return false;
-
-	return t_src_ref -> rootmatches(t_dst_ref);
-}
-
-//
-
 MCAdd::~MCAdd()
 {
 	delete source;
@@ -101,8 +79,6 @@ Parse_stat MCAdd::parse(MCScriptPoint &sp)
 	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
 	if (dest != NULL && dest -> isvarchunk())
 		destvar = dest -> getrootvarref();
-
-	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
 	return PS_NORMAL;
 }
@@ -265,8 +241,6 @@ Parse_stat MCDivide::parse(MCScriptPoint &sp)
 	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
 	if (dest != NULL && dest -> isvarchunk())
 		destvar = dest -> getrootvarref();
-	
-	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
 	return PS_NORMAL;
 }
@@ -433,8 +407,6 @@ Parse_stat MCMultiply::parse(MCScriptPoint &sp)
 	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
 	if (dest != NULL && dest -> isvarchunk())
 		destvar = dest -> getrootvarref();
-	
-	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
 	return PS_NORMAL;
 }
@@ -601,8 +573,6 @@ Parse_stat MCSubtract::parse(MCScriptPoint &sp)
 	// MW-2013-08-01: [[ Bug 10925 ]] If the dest chunk is just a var, extract the varref.
 	if (dest != NULL && dest -> isvarchunk())
 		destvar = dest -> getrootvarref();
-	
-	overlap = MCMathOpCommandComputeOverlap(source, dest, destvar);
 
 	return PS_NORMAL;
 }

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -100,17 +100,8 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
     MCContainer t_dst_container;
 	if (destvar != nil)
 	{
-        bool t_success;
-        if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
-                            && t_dst_container.eval_ctxt(ctxt, t_dst);
-        else
-        {
-            destvar -> eval_ctxt(ctxt, t_dst);
-            t_success = !ctxt . HasError();
-        }
-        
-        if (!t_success)
+        if (!destvar->evalcontainer(ctxt, t_dst_container) ||
+            !t_dst_container.eval_ctxt(ctxt, t_dst))
         {
             ctxt . LegacyThrow(EE_ADD_BADDEST);
             MCExecTypeRelease(t_src);
@@ -162,13 +153,7 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
 	{
 		if (destvar != nil)
 		{
-            bool t_success;
-            if (destvar -> needsContainer())
-                t_success = t_dst_container.give_value(ctxt, t_result);
-            else
-                t_success = destvar -> give_value(ctxt, t_result);
-            
-            if (!t_success)
+            if (!t_dst_container.give_value(ctxt, t_result))
                 ctxt . Throw();
 		}
 		else
@@ -257,22 +242,13 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
 		ctxt.LegacyThrow(EE_DIVIDE_BADSOURCE);
         return;
     }
-	
-	MCExecValue t_dst;
-	MCContainer t_dst_container;
-	if (destvar != nil)
-	{
-        bool t_success;
-        if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
-                            && t_dst_container.eval_ctxt(ctxt, t_dst);
-        else
-        {
-            destvar -> eval_ctxt(ctxt, t_dst);
-            t_success = !ctxt.HasError();
-        }
-        
-        if (!t_success)
+    
+    MCExecValue t_dst;
+    MCContainer t_dst_container;
+    if (destvar != nil)
+    {
+        if (!destvar->evalcontainer(ctxt, t_dst_container) ||
+            !t_dst_container.eval_ctxt(ctxt, t_dst))
         {
             ctxt . LegacyThrow(EE_DIVIDE_BADDEST);
             MCExecTypeRelease(t_src);
@@ -320,19 +296,12 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
     MCExecTypeRelease(t_dst);
 	
 	if (!ctxt . HasError())
-	{
-		if (destvar != nil)
-		{
-            bool t_success;
-            
-            if (destvar -> needsContainer())
-                t_success = t_dst_container.give_value(ctxt, t_result);
-            else
-                t_success = destvar -> give_value(ctxt, t_result);
-            
-            if (!t_success)
+    {
+        if (destvar != nil)
+        {
+            if (!t_dst_container.give_value(ctxt, t_result))
                 ctxt . Throw();
-		}
+        }
 		else
 		{
             if (dest->set(ctxt, PT_INTO, t_result))
@@ -423,22 +392,13 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
 		ctxt.LegacyThrow(EE_MULTIPLY_BADSOURCE);
         return;
     }
-	
-	MCExecValue t_dst;
-	MCContainer t_dst_container;
-	if (destvar != nil)
-	{
-        bool t_success;
-        if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
-                            && t_dst_container.eval_ctxt(ctxt, t_dst);
-        else
-        {
-            destvar -> eval_ctxt(ctxt, t_dst);
-            t_success = !ctxt . HasError();
-        }
-        
-        if (!t_success)
+    
+    MCExecValue t_dst;
+    MCContainer t_dst_container;
+    if (destvar != nil)
+    {
+        if (!destvar->evalcontainer(ctxt, t_dst_container) ||
+            !t_dst_container.eval_ctxt(ctxt, t_dst))
         {
             ctxt . LegacyThrow(EE_MULTIPLY_BADDEST);
             MCExecTypeRelease(t_src);
@@ -486,19 +446,12 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
     MCExecTypeRelease(t_dst);
 	
 	if (!ctxt . HasError())
-	{
-		if (destvar != nil)
-		{
-            bool t_success;
-            
-            if (destvar -> needsContainer())
-                t_success = t_dst_container.give_value(ctxt, t_result);
-            else
-                t_success = destvar -> give_value(ctxt, t_result);
-            
-            if (!t_success)
+    {
+        if (destvar != nil)
+        {
+            if (!t_dst_container.give_value(ctxt, t_result))
                 ctxt . Throw();
-		}
+        }
 		else
 		{            
 			if (dest->set(ctxt, PT_INTO, t_result))
@@ -589,22 +542,13 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
 		ctxt.LegacyThrow(EE_SUBTRACT_BADSOURCE);
         return;
     }
-	
-	MCExecValue t_dst;
-	MCContainer t_dst_container;
-	if (destvar != nil)
-	{
-        bool t_success;
-        if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
-                            && t_dst_container.eval_ctxt(ctxt, t_dst);
-        else
-        {
-            destvar -> eval_ctxt(ctxt, t_dst);
-            t_success = !ctxt . HasError();
-        }
-        
-        if (!t_success)
+    
+    MCExecValue t_dst;
+    MCContainer t_dst_container;
+    if (destvar != nil)
+    {
+        if (!destvar->evalcontainer(ctxt, t_dst_container) ||
+            !t_dst_container.eval_ctxt(ctxt, t_dst))
         {
             ctxt . LegacyThrow(EE_SUBTRACT_BADDEST);
             MCExecTypeRelease(t_src);
@@ -652,19 +596,12 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
     MCExecTypeRelease(t_dst);
 	
 	if (!ctxt . HasError())
-	{
-		if (destvar != nil)
-		{
-            bool t_success;
-            
-            if (destvar -> needsContainer())
-                t_success =  t_dst_container.give_value(ctxt, t_result);
-            else
-                t_success = destvar -> give_value(ctxt, t_result);
-            
-            if (!t_success)
+    {
+        if (destvar != nil)
+        {
+            if (!t_dst_container.give_value(ctxt, t_result))
                 ctxt . Throw();
-		}
+        }
 		else
 		{
 			if (dest->set(ctxt, PT_INTO, t_result))

--- a/engine/src/cmdsm.cpp
+++ b/engine/src/cmdsm.cpp
@@ -97,13 +97,13 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
     }
 	
 	MCExecValue t_dst;
-    MCAutoPointer<MCContainer> t_dst_container;
+    MCContainer t_dst_container;
 	if (destvar != nil)
 	{
         bool t_success;
         if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, &t_dst_container)
-                            && t_dst_container -> eval_ctxt(ctxt, t_dst);
+            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
+                            && t_dst_container.eval_ctxt(ctxt, t_dst);
         else
         {
             destvar -> eval_ctxt(ctxt, t_dst);
@@ -164,7 +164,7 @@ void MCAdd::exec_ctxt(MCExecContext &ctxt)
 		{
             bool t_success;
             if (destvar -> needsContainer())
-                t_success = t_dst_container -> give_value(ctxt, t_result);
+                t_success = t_dst_container.give_value(ctxt, t_result);
             else
                 t_success = destvar -> give_value(ctxt, t_result);
             
@@ -259,13 +259,13 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
     }
 	
 	MCExecValue t_dst;
-	MCAutoPointer<MCContainer> t_dst_container;
+	MCContainer t_dst_container;
 	if (destvar != nil)
 	{
         bool t_success;
         if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, &t_dst_container)
-                            && t_dst_container -> eval_ctxt(ctxt, t_dst);
+            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
+                            && t_dst_container.eval_ctxt(ctxt, t_dst);
         else
         {
             destvar -> eval_ctxt(ctxt, t_dst);
@@ -326,7 +326,7 @@ void MCDivide::exec_ctxt(MCExecContext &ctxt)
             bool t_success;
             
             if (destvar -> needsContainer())
-                t_success = t_dst_container -> give_value(ctxt, t_result);
+                t_success = t_dst_container.give_value(ctxt, t_result);
             else
                 t_success = destvar -> give_value(ctxt, t_result);
             
@@ -425,13 +425,13 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
     }
 	
 	MCExecValue t_dst;
-	MCAutoPointer<MCContainer> t_dst_container;
+	MCContainer t_dst_container;
 	if (destvar != nil)
 	{
         bool t_success;
         if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, &t_dst_container)
-                            && t_dst_container -> eval_ctxt(ctxt, t_dst);
+            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
+                            && t_dst_container.eval_ctxt(ctxt, t_dst);
         else
         {
             destvar -> eval_ctxt(ctxt, t_dst);
@@ -492,7 +492,7 @@ void MCMultiply::exec_ctxt(MCExecContext &ctxt)
             bool t_success;
             
             if (destvar -> needsContainer())
-                t_success = t_dst_container -> give_value(ctxt, t_result);
+                t_success = t_dst_container.give_value(ctxt, t_result);
             else
                 t_success = destvar -> give_value(ctxt, t_result);
             
@@ -591,13 +591,13 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
     }
 	
 	MCExecValue t_dst;
-	MCAutoPointer<MCContainer> t_dst_container;
+	MCContainer t_dst_container;
 	if (destvar != nil)
 	{
         bool t_success;
         if (destvar -> needsContainer())
-            t_success = destvar -> evalcontainer(ctxt, &t_dst_container)
-                            && t_dst_container -> eval_ctxt(ctxt, t_dst);
+            t_success = destvar -> evalcontainer(ctxt, t_dst_container)
+                            && t_dst_container.eval_ctxt(ctxt, t_dst);
         else
         {
             destvar -> eval_ctxt(ctxt, t_dst);
@@ -658,7 +658,7 @@ void MCSubtract::exec_ctxt(MCExecContext &ctxt)
             bool t_success;
             
             if (destvar -> needsContainer())
-                t_success =  t_dst_container -> give_value(ctxt, t_result);
+                t_success =  t_dst_container.give_value(ctxt, t_result);
             else
                 t_success = destvar -> give_value(ctxt, t_result);
             
@@ -805,15 +805,15 @@ void MCArrayOp::exec_ctxt(MCExecContext &ctxt)
             return;
 	}
 
-	MCAutoPointer<MCContainer> t_container;
+	MCContainer t_container;
     MCAutoValueRef t_container_value;
-    if (!destvar -> evalcontainer(ctxt, &t_container))
+    if (!destvar -> evalcontainer(ctxt, t_container))
 	{
         ctxt . LegacyThrow(EE_ARRAYOP_BADEXP);
         return;
     }
 
-    if (!t_container -> eval(ctxt, &t_container_value))
+    if (!t_container.eval(ctxt, &t_container_value))
     {
         ctxt . Throw();
         return;
@@ -841,7 +841,7 @@ void MCArrayOp::exec_ctxt(MCExecContext &ctxt)
 			MCArraysExecCombineAsSet(ctxt, *t_array, *t_element_del, &t_string);
 
         if (!ctxt . HasError())
-            t_container -> set(ctxt, *t_string);
+            t_container.set(ctxt, *t_string);
 	}
 	else
 	{
@@ -861,7 +861,7 @@ void MCArrayOp::exec_ctxt(MCExecContext &ctxt)
 			MCArraysExecSplitAsSet(ctxt, *t_string, *t_element_del, &t_array);
 
 		if (!ctxt . HasError())
-            t_container -> set(ctxt, *t_array);
+            t_container.set(ctxt, *t_array);
     }
 }
 
@@ -960,15 +960,15 @@ void MCSetOp::exec_ctxt(MCExecContext &ctxt)
     if (!ctxt . EvalExprAsValueRef(source, EE_ARRAYOP_BADEXP, &t_src))
         return;
     
-	MCAutoPointer<MCContainer> t_container;
-    if (!destvar -> evalcontainer(ctxt, &t_container))
+	MCContainer t_container;
+    if (!destvar -> evalcontainer(ctxt, t_container))
 	{
         ctxt . LegacyThrow(EE_ARRAYOP_BADEXP);
         return;
 	}
 
     MCAutoValueRef t_dst;
-    if (!t_container -> eval(ctxt, &t_dst))
+    if (!t_container.eval(ctxt, &t_dst))
         return;
 
     MCAutoValueRef t_dst_value;
@@ -990,7 +990,7 @@ void MCSetOp::exec_ctxt(MCExecContext &ctxt)
     }
 
 	if (!ctxt . HasError())
-        t_container -> set(ctxt, *t_dst_value);
+        t_container.set(ctxt, *t_dst_value);
 }
 
 void MCSetOp::compile(MCSyntaxFactoryRef ctxt)

--- a/engine/src/constant.h
+++ b/engine/src/constant.h
@@ -37,6 +37,11 @@ public:
 
     virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
 	
+    virtual bool is_pure(void) const
+    {
+        return true;
+    }
+    
 	virtual void compile(MCSyntaxFactoryRef ctxt);
 };
 #endif

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -463,13 +463,12 @@ Exec_stat MCEngineHandleLibraryMessage(MCNameRef p_message, MCParameter *p_param
             
             if (t_mode != kMCHandlerTypeFieldModeIn)
             {
-                MCContainer *t_container;
+                MCContainer t_container;
                 if (t_param -> evalcontainer(*MCECptr, t_container))
                 {
                     if (!MCExtensionConvertToScriptType(*MCECptr, t_arguments[i]) ||
-                        !t_container -> set(*MCECptr, t_arguments[i]))
+                        !t_container.set(*MCECptr, t_arguments[i]))
                         t_success = false;
-                    delete t_container;
                 }
                 else
                     t_param -> set_argument(*MCECptr, t_arguments[i]);

--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -259,7 +259,7 @@ void MCGroup::SetHilitedButtonName(MCExecContext& ctxt, uint32_t part, MCStringR
                 // Clicking on the button attemps to hilite the option "title,menu,maximize,minimise,close"
                 // but only "title,menu,minimize,maximise,close" exists, returning a nil NameRef
                 MCNameRef t_nameref;
-                t_nameref = MCNameLookup(p_name);
+                t_nameref = MCNameLookupCaseless(p_name);
                 if (t_nameref != nil)
                     bptr->resethilite(part, bptr->hasname(t_nameref));
                 else

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1169,7 +1169,7 @@ void MCStack::SetSubstacks(MCExecContext& ctxt, MCStringRef p_substacks)
 			{
 				// Lookup 't_name_string' as a name, if it doesn't exist it can't exist as a substack
 				// name.
-				&t_name = MCValueRetain(MCNameLookup(*t_name_string));
+				&t_name = MCValueRetain(MCNameLookupCaseless(*t_name_string));
 				if (*t_name != nil)
 				{
 					while (tsub -> hasname(*t_name))

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -778,7 +778,7 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                             {
                                 MCAutoStringRef t_error;
                                 MCeerror -> copyasstringref(&t_error);
-                                errorvar->evalvar(ctxt)->setvalueref(*t_error);
+                                errorvar->set(ctxt, *t_error);
                             }
                             
                             // MW-2007-09-04: At this point we need to clear the execution error
@@ -808,13 +808,16 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
             case ES_PASS:
                 if (state == TS_CATCH)
                 {
+                    MCAutoValueRef t_value;
                     MCAutoStringRef t_string;
-                    if (ctxt . ConvertToString(errorvar->evalvar(ctxt)->getvalueref(), &t_string))
+                    if ((errorvar->eval(ctxt, &t_value), !ctxt.HasError()) &&
+                        ctxt . ConvertToString(*t_value, &t_string))
                     {
                         MCeerror->copystringref(*t_string, False);
-                        MCeerror->add(EE_TRY_BADSTATEMENT, line, pos);
-                        stat = ES_ERROR;
                     }
+                    
+                    MCeerror->add(EE_TRY_BADSTATEMENT, line, pos);
+                    stat = ES_ERROR;
                 }
             default:
                 if (state == TS_FINALLY)

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -149,9 +149,9 @@ void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, bool resolved, MCHandl
 	while (tptr != NULL)
 	{
         // AL-2014-08-20: [[ ArrayElementRefParams ]] Use containers for potential reference parameters
-        MCContainer *t_container;
-        if (tptr -> evalcontainer(ctxt, t_container))
-            tptr -> set_argument_container(t_container);
+        MCAutoPointer<MCContainer> t_container = new (nothrow) MCContainer;
+        if (tptr -> evalcontainer(ctxt, **t_container))
+            tptr -> set_argument_container(t_container.Release());
         else
         {
             tptr -> clear_argument();

--- a/engine/src/exec-multimedia.cpp
+++ b/engine/src/exec-multimedia.cpp
@@ -448,7 +448,7 @@ static MCPlayer* MCMultimediaExecGetClip(MCExecContext& ctxt, MCStringRef p_clip
 	{
         // AL-2014-05-27: [[ Bug 12517 ]] MCNameLookup does not increase the ref count
 		MCNameRef t_obj_name;
-		t_obj_name = MCNameLookup(p_clip);
+		t_obj_name = MCNameLookupCaseless(p_clip);
 		if (t_obj_name != nil)
 		{
 			tptr = MCplayers;

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -365,10 +365,35 @@ bool MCExecContext::ConvertToData(MCValueRef p_value, MCDataRef& r_data)
 
 bool MCExecContext::ConvertToName(MCValueRef p_value, MCNameRef& r_name)
 {
-    if (MCValueGetTypeCode(p_value) == kMCValueTypeCodeName)
+    switch(MCValueGetTypeCode(p_value))
     {
-        r_name = MCValueRetain((MCNameRef)p_value);
-        return true;
+        case kMCValueTypeCodeName:
+        {
+            r_name = MCValueRetain((MCNameRef)p_value);
+            return true;
+        }
+        
+        case kMCValueTypeCodeString:
+        {
+            return MCNameCreate((MCStringRef)p_value,
+                                r_name);
+        }
+            
+        case kMCValueTypeCodeNumber:
+        {
+            index_t t_index;
+            if (MCNumberStrictFetchAsIndex((MCNumberRef)p_value,
+                                           t_index))
+            {
+                return MCNameCreateWithIndex(t_index,
+                                             r_name);
+            }
+            else
+                break;
+        }
+            
+        default:
+            break;
     }
     
     MCAutoStringRef t_string;

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -65,7 +65,7 @@ MCVariable *MCExpression::evalvar(MCExecContext& ctxt)
     return NULL;
 }
 
-bool MCExpression::evalcontainer(MCExecContext& ctxt, MCContainer*& r_container)
+bool MCExpression::evalcontainer(MCExecContext& ctxt, MCContainer& r_container)
 {
     return false;
 }

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -60,11 +60,6 @@ MCVarref *MCExpression::getrootvarref(void)
 	return NULL;
 }
 
-MCVariable *MCExpression::evalvar(MCExecContext& ctxt)
-{
-    return NULL;
-}
-
 bool MCExpression::evalcontainer(MCExecContext& ctxt, MCContainer& r_container)
 {
     return false;

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -60,6 +60,11 @@ MCVarref *MCExpression::getrootvarref(void)
 	return NULL;
 }
 
+bool MCExpression::is_pure(void) const
+{
+    return false;
+}
+
 bool MCExpression::evalcontainer(MCExecContext& ctxt, MCContainer& r_container)
 {
     return false;

--- a/engine/src/express.h
+++ b/engine/src/express.h
@@ -58,7 +58,7 @@ public:
 	// Evaluate the expression as a container, and place the reference to
 	// the container's value in r_ref.
     // EP-less version of evaluation functions
-    virtual bool evalcontainer(MCExecContext& ctxt, MCContainer*& r_container);
+    virtual bool evalcontainer(MCExecContext& ctxt, MCContainer& r_container);
     virtual MCVariable *evalvar(MCExecContext& ctxt);
 
 	// Return the var-ref which lies at the root of this expression. 

--- a/engine/src/express.h
+++ b/engine/src/express.h
@@ -59,7 +59,6 @@ public:
 	// the container's value in r_ref.
     // EP-less version of evaluation functions
     virtual bool evalcontainer(MCExecContext& ctxt, MCContainer& r_container);
-    virtual MCVariable *evalvar(MCExecContext& ctxt);
 
 	// Return the var-ref which lies at the root of this expression. 
 	// A return value of NULL means that there is no root variable.

--- a/engine/src/express.h
+++ b/engine/src/express.h
@@ -40,15 +40,13 @@ public:
 	MCExpression();
 	virtual ~MCExpression();
 	
-	virtual Parse_stat parse(MCScriptPoint &, Boolean the);
-
-	
+    virtual Parse_stat parse(MCScriptPoint &, Boolean the);
+    
 	// Evaluate the expression as its natural type basic type (note that
 	// execvalue's cannot be set/enum/custom, they should all be resolved
 	// to the appropriate basic type first!). This form should be used for
 	// descendents of MCExpression which are an umbrella for many syntax forms
 	// and thus have variant return type (such as MCProperty).
-
 	virtual void eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value);
 	
 	// Compile the syntax into the (new) tree for use by the new evaluator.
@@ -59,7 +57,11 @@ public:
 	// the container's value in r_ref.
     // EP-less version of evaluation functions
     virtual bool evalcontainer(MCExecContext& ctxt, MCContainer& r_container);
-
+    
+    // Returns true if evaluating this expression has no side-effects. This
+    // allows certain operations to be performed much more efficiently.
+    virtual bool is_pure(void) const;
+    
 	// Return the var-ref which lies at the root of this expression. 
 	// A return value of NULL means that there is no root variable.
 	// The purpose of this call is to analyze (after parsing) whether the

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -403,10 +403,10 @@ static Exec_stat getvarptr(MCExecContext& ctxt, const MCString &vname,MCVariable
 	if ((*tvar = newvar->evalvar(ctxt)) == NULL)
     {
         // SN-2014-10-21: [[ Bug 13728 ]] The variable might be held in a container.
-        MCAutoPointer<MCContainer> t_container;
+        MCContainer t_container;
         
-        if (!newvar->evalcontainer(*MCECptr, &t_container) ||
-                (*tvar = t_container->getvar()) == NULL)
+        if (!newvar->evalcontainer(*MCECptr, t_container) ||
+                (*tvar = t_container.getvar()) == NULL)
         {
             delete newvar;
             return ES_ERROR;

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -390,34 +390,27 @@ static int trans_stat(Exec_stat stat)
 	return xresNotImp;
 }
 
-static Exec_stat getvarptr(MCExecContext& ctxt, const MCString &vname,MCVariable **tvar)
+static Exec_stat getvarptr(MCExecContext& ctxt, const MCString &vname, MCContainer& r_container)
 {
 	MCAutoNameRef t_name;
 	/* UNCHECKED */ t_name . CreateWithOldString(vname);
 
-	MCVarref *newvar;
-    
-    if (MCECptr -> FindVar(t_name, &newvar) != PS_NORMAL)
-		return ES_ERROR;
-	
-	if ((*tvar = newvar->evalvar(ctxt)) == NULL)
+	MCAutoPointer<MCVarref> newvar;
+    if (MCECptr -> FindVar(t_name, &(&newvar)) != PS_NORMAL)
     {
-        // SN-2014-10-21: [[ Bug 13728 ]] The variable might be held in a container.
-        MCContainer t_container;
-        
-        if (!newvar->evalcontainer(*MCECptr, t_container) ||
-                (*tvar = t_container.getvar()) == NULL)
-        {
-            delete newvar;
-            return ES_ERROR;
-        }
-	}
-	delete newvar;
+		return ES_ERROR;
+    }
+    
+    if (!newvar->evalcontainer(ctxt,
+                               r_container))
+    {
+        return ES_ERROR;
+    }
 
 	return ES_NORMAL;
 }
 
-static Exec_stat getvarptr_utf8(MCExecContext& ctxt, const MCString &vname, MCVariable **tvar)
+static Exec_stat getvarptr_utf8(MCExecContext& ctxt, const MCString &vname, MCContainer& r_container)
 {
 	MCNewAutoNameRef t_name;
     MCAutoStringRef t_arg1_string;
@@ -426,17 +419,17 @@ static Exec_stat getvarptr_utf8(MCExecContext& ctxt, const MCString &vname, MCVa
             || !MCNameCreate(*t_arg1_string, &t_name))
         return ES_ERROR;
     
-	MCVarref *newvar;
+    MCAutoPointer<MCVarref> newvar;
+    if (MCECptr -> FindVar(*t_name, &(&newvar)) != PS_NORMAL)
+    {
+        return ES_ERROR;
+    }
     
-    if (MCECptr -> FindVar(*t_name, &newvar) != PS_NORMAL)
-		return ES_ERROR;
-	
-	if ((*tvar = newvar->evalvar(ctxt)) == NULL)
-	{
-		delete newvar;
-		return ES_ERROR;
-	}
-	delete newvar;
+    if (!newvar->evalcontainer(ctxt,
+                               r_container))
+    {
+        return ES_ERROR;
+    }
     
 	return ES_NORMAL;
 }
@@ -747,40 +740,47 @@ static char *show_image_by_id(const char *arg1, const char *arg2,
 static char *get_variable(const char *arg1, const char *arg2,
                           const char *arg3, int *retval)
 {
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
 	}
-	*retval = trans_stat(getvarptr(*MCECptr, arg1, &var));
-	if (var == NULL)
+    
+    MCContainer var;
+	*retval = trans_stat(getvarptr(*MCECptr, arg1, var));
+	if (*retval != xresSucc)
 		return NULL;
+    
     MCAutoValueRef t_value;
-	var -> eval(*MCECptr, &t_value);
+	var.eval(*MCECptr, &t_value);
+    
     MCAutoStringRef t_string;
     /* UNCHECKED */ MCECptr -> ConvertToString(*t_value, &t_string);
+    
     char *t_result;
     /* UNCHECKED */ MCStringNormalizeAndConvertToCString(*t_string, t_result);
-	return t_result;
+	
+    return t_result;
 }
 
 static char *set_variable(const char *arg1, const char *arg2,
                           const char *arg3, int *retval)
 {
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr(*MCECptr, arg1,&var));
-	if (var == NULL)
-		return NULL;
-	//MCECptr->GetEP().setsvalue(arg2);
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
+    
     MCAutoStringRef t_string;
     /* UNCHECKED */ MCStringCreateWithCString(arg2, &t_string);
-	var->set(*MCECptr, *t_string);
+	var.set(*MCECptr, *t_string);
+    
 	return NULL;
 }
 
@@ -788,27 +788,27 @@ static char *get_variable_ex(const char *arg1, const char *arg2,
                              const char *arg3, int *retval)
 {
 	MCString *value = (MCString *)arg3;
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr(*MCECptr, arg1, &var));
-	if (var == NULL)
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
 		return NULL;
     
     MCAutoValueRef t_value;
-
 	if (arg2 != NULL && strlen(arg2) != 0)
 	{
 		MCNameRef t_key;
 		/* UNCHECKED */ MCNameCreateWithCString(arg2, t_key);
-		var -> eval(*MCECptr, &t_key, 1, &t_value);
+		var.eval_on_path(*MCECptr, &t_key, 1, &t_value);
 		MCValueRelease(t_key);
 	}
 	else
-		var -> eval(*MCECptr, &t_value);
+		var.eval(*MCECptr, &t_value);
     
     
     MCAutoStringRef t_string;
@@ -826,26 +826,28 @@ static char *get_variable_ex(const char *arg1, const char *arg2,
 static char *set_variable_ex(const char *arg1, const char *arg2,
                              const char *arg3, int *retval)
 {
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr(*MCECptr, arg1,&var));
-	if (var == NULL)
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
 		return NULL;
+    
     MCAutoStringRef t_string;
     /* UNCHECKED */ MCStringCreateWithOldString(*(MCString*)arg3, &t_string);
 	if (arg2 != NULL && strlen(arg2) > 0)
 	{
 		MCNameRef t_key;
 		/* UNCHECKED */ MCNameCreateWithCString(arg2, t_key);
-		var->set(*MCECptr, *t_string, &t_key, 1);
+		var.set_on_path(*MCECptr, &t_key, 1, *t_string);
 		MCValueRelease(t_key);
 	}
 	else
-		var->set(*MCECptr, *t_string);
+		var.set(*MCECptr, *t_string);
 
 	return NULL;
 }
@@ -899,24 +901,32 @@ static char *get_array(const char *arg1, const char *arg2,
                        const char *arg3, int *retval)
 {
 	MCarray *value = (MCarray *)arg3;
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr(*MCECptr, arg1,&var));
-	if (var == NULL)
-		return NULL;
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
 
-	if (!var -> isarray())
+    MCAutoValueRef t_value;
+    if (!var.eval(*MCECptr,
+                  &t_value))
+    {
+        *retval = xresFail;
+        return NULL;
+    }
+    
+	if (!MCValueIsArray(*t_value))
+    {
+        value->nelements = 0;
 		return NULL;
+    }
 
-    MCArrayRef t_array;
-    t_array = (MCArrayRef)var -> getvalueref();
-	if (t_array == nil)
-		return NULL;
-
+    MCArrayRef t_array = (MCArrayRef)*t_value;
 	if (value->nelements == 0)
 	{
 		value->nelements = MCArrayGetCount(t_array);
@@ -939,16 +949,18 @@ static char *set_array(const char *arg1, const char *arg2,
                        const char *arg3, int *retval)
 {
 	MCarray *value = (MCarray *)arg3;
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr(*MCECptr, arg1,&var));
-	if (var == NULL)
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
 		return NULL;
-	var->remove(*MCECptr, nil, 0);//clear variable
+	
+    var.remove(*MCECptr);//clear variable
 	char tbuf[U4L];
 	for (unsigned int i = 0; i <value->nelements; i++)
 	{
@@ -963,7 +975,7 @@ static char *set_array(const char *arg1, const char *arg2,
 		}
 		else
 			/* UNCHECKED */ MCNameCreateWithCString(value -> keys[i], t_key);
-		var->set(*MCECptr, *t_string, &t_key, 1);
+		var.set_on_path(*MCECptr, &t_key, 1, *t_string);
 	}
 	return NULL;
 }
@@ -1250,17 +1262,17 @@ static char *show_image_by_id_utf8(const char *arg1, const char *arg2,
 static char *get_variable_utf8(const char *arg1, const char *arg2,
                           const char *arg3, int *retval)
 {
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr_utf8(*MCECptr, arg1, &var));
-	if (var == NULL)
-		return NULL;
+    }
+    MCContainer var;
+    *retval = trans_stat(getvarptr_utf8(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
     MCAutoValueRef t_value;
-	var -> eval(*MCECptr, &t_value);
+	var.eval(*MCECptr, &t_value);
     MCAutoStringRef t_string;
     /* UNCHECKED */ MCECptr -> ConvertToString(*t_value, &t_string);
     char *t_result;
@@ -1271,19 +1283,18 @@ static char *get_variable_utf8(const char *arg1, const char *arg2,
 static char *set_variable_utf8(const char *arg1, const char *arg2,
                           const char *arg3, int *retval)
 {
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr_utf8(*MCECptr, arg1,&var));
-	if (var == NULL)
-		return NULL;
-	//MCECptr->GetEP().setsvalue(arg2);
+    }
+    MCContainer var;
+    *retval = trans_stat(getvarptr_utf8(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
     MCAutoStringRef t_string;
     /* UNCHECKED */ MCStringCreateWithBytes((byte_t*)arg2, strlen(arg2), kMCStringEncodingUTF8, false, &t_string);
-	var->set(*MCECptr, *t_string);
+	var.set(*MCECptr, *t_string);
 	return NULL;
 }
 
@@ -1293,15 +1304,16 @@ static char *get_variable_ex_utf8(const char *arg1, const char *arg2,
                                   const char *arg3, int *retval, Bool p_is_text)
 {
 	MCString *value = (MCString *)arg3;
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr_utf8(*MCECptr, arg1, &var));
-	if (var == NULL)
-		return NULL;
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr_utf8(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
     
     MCAutoValueRef t_value;
     
@@ -1311,11 +1323,11 @@ static char *get_variable_ex_utf8(const char *arg1, const char *arg2,
         MCAutoStringRef t_key_as_string;
         /* UNCHECKED */ MCStringCreateWithBytes((byte_t*)arg2, strlen(arg2), kMCStringEncodingUTF8, false, &t_key_as_string);
 		/* UNCHECKED */ MCNameCreate(*t_key_as_string, t_key);
-		var -> eval(*MCECptr, &t_key, 1, &t_value);
+		var.eval_on_path(*MCECptr, &t_key, 1, &t_value);
 		MCValueRelease(t_key);
 	}
 	else
-		var -> eval(*MCECptr, &t_value);
+		var.eval(*MCECptr, &t_value);
     
     
     MCAutoStringRef t_string;
@@ -1353,15 +1365,16 @@ static char *set_variable_ex_utf8(const char *arg1, const char *arg2,
                              const char *arg3, int *retval, Bool p_is_text)
 {
     MCString *t_value = (MCString*)arg3;
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr_utf8(*MCECptr, arg1,&var));
-	if (var == NULL)
-		return NULL;
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr_utf8(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
     
     MCAutoStringRef t_string;
     if (p_is_text)
@@ -1375,11 +1388,11 @@ static char *set_variable_ex_utf8(const char *arg1, const char *arg2,
         MCAutoStringRef t_key_as_string;
         /* UNCHECKED */ MCStringCreateWithBytes((byte_t*)arg2, strlen(arg2), kMCStringEncodingUTF8, false, &t_key_as_string);
 		/* UNCHECKED */ MCNameCreate(*t_key_as_string, t_key);
-		var->set(*MCECptr, *t_string, &t_key, 1);
+		var.set_on_path(*MCECptr, &t_key, 1, *t_string);
 		MCValueRelease(t_key);
 	}
 	else
-		var->set(*MCECptr, *t_string);
+		var.set(*MCECptr, *t_string);
     
 	return NULL;
 }
@@ -1441,29 +1454,38 @@ static char *get_array_utf8(const char *arg1, const char *arg2,
                        const char *arg3, int *retval, bool p_is_text)
 {
 	MCarray *value = (MCarray *)arg3;
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr_utf8(*MCECptr, arg1,&var));
-	if (var == NULL)
-		return NULL;
+    }
     
-	if (!var -> isarray())
-		return NULL;
+    MCContainer var;
+    *retval = trans_stat(getvarptr_utf8(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
     
-    MCArrayRef t_array;
-    t_array = (MCArrayRef)var -> getvalueref();
-	if (t_array == nil)
-		return NULL;
+    MCAutoValueRef t_value;
+    if (!var.eval(*MCECptr,
+                  &t_value))
+    {
+        *retval = xresFail;
+        return NULL;
+    }
     
-	if (value->nelements == 0)
-	{
-		value->nelements = MCArrayGetCount(t_array);
-		return NULL;
-	}
+    if (!MCValueIsArray(*t_value))
+    {
+        value->nelements = 0;
+        return NULL;
+    }
+    
+    MCArrayRef t_array = (MCArrayRef)*t_value;
+    if (value->nelements == 0)
+    {
+        value->nelements = MCArrayGetCount(t_array);
+        return NULL;
+    }
+
     
 	value->nelements = MCU_min(value->nelements, MCArrayGetCount(t_array));
     
@@ -1496,16 +1518,18 @@ static char *set_array_utf8(const char *arg1, const char *arg2,
                        const char *arg3, int *retval, bool p_is_text)
 {
 	MCarray *value = (MCarray *)arg3;
-	MCVariable *var = NULL;
 	if (MCECptr == NULL)
 	{
 		*retval = xresFail;
 		return NULL;
-	}
-	*retval = trans_stat(getvarptr_utf8(*MCECptr, arg1,&var));
-	if (var == NULL)
-		return NULL;
-	var->remove(*MCECptr, nil, 0);//clear variable
+    }
+    
+    MCContainer var;
+    *retval = trans_stat(getvarptr(*MCECptr, arg1, var));
+    if (*retval != xresSucc)
+        return NULL;
+    
+	var.remove(*MCECptr);//clear variable
 	char tbuf[U4L];
 	for (unsigned int i = 0; i <value->nelements; i++)
 	{
@@ -1528,7 +1552,7 @@ static char *set_array_utf8(const char *arg1, const char *arg2,
             MCStringCreateWithBytes((byte_t*)value -> keys[i], strlen(value -> keys[i]), kMCStringEncodingUTF8, false, &t_key_as_string);
             /* UNCHECKED */ MCNameCreate(*t_key_as_string, t_key);
         }
-		var->set(*MCECptr, *t_string, &t_key, 1);
+		var.set_on_path(*MCECptr, &t_key, 1, *t_string);
         
         MCNameDelete(t_key);
 	}

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -789,9 +789,9 @@ bool MCTemporaryExternalVariable::IsTemporary(void)
 
 //////////
 
-MCReferenceExternalVariable::MCReferenceExternalVariable(MCVariable *p_variable)
+MCReferenceExternalVariable::MCReferenceExternalVariable(MCContainer& p_container)
+    : m_container(p_container)
 {
-	m_variable = p_variable;
 }
 
 MCReferenceExternalVariable::~MCReferenceExternalVariable(void)
@@ -810,12 +810,12 @@ bool MCReferenceExternalVariable::IsTransient(void)
 
 MCValueRef MCReferenceExternalVariable::GetValueRef(void)
 {
-	return m_variable -> getvalueref();
+	return m_container.get_valueref();
 }
 
 void MCReferenceExternalVariable::SetValueRef(MCValueRef p_value)
 {
-	m_variable -> setvalueref(p_value);
+	m_container.set_valueref(p_value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -967,44 +967,17 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 	
 	// Now iterate through the parameters, fetching the parameter values as we go.
 	for(uint32_t i = 0; p_parameters != nil && t_stat == ES_NORMAL; i++, p_parameters = p_parameters -> getnext())
-	{
-		MCVariable* t_var;
-		t_var = p_parameters -> eval_argument_var();
-		if (t_var != nil)
-		{
-			// We are a variable parameter so use the value directly (i.e. pass by
-			// reference).
-			
-			// MW-2014-01-22: [[ CompatV1 ]] Create a reference to the MCVariable.
-			t_parameter_vars[i] = new (nothrow) MCReferenceExternalVariable(t_var);
-		}
-		else
-		{
-			// AL-2014-08-28: [[ ArrayElementRefParams ]] Evaluate container if necessary
-			MCAutoValueRef t_value;
-			MCContainer *t_container;
-			t_container = p_parameters -> eval_argument_container();
-			
-			if (t_container != nil)
-			{
-				MCNameRef *t_path;
-				uindex_t t_length;
-				t_container -> getpath(t_path, t_length);
-				
-				MCExecContext ctxt(p_context, nil, nil);
-				
-				if (t_length == 0)
-					t_parameter_vars[i] = new (nothrow) MCReferenceExternalVariable(t_container -> getvar());
-				else
-					t_container -> eval(ctxt, &t_value);
-			}
-			else
-				t_value = p_parameters -> getvalueref_argument();
-			
-			// MW-2014-01-22: [[ CompatV1 ]] Create a temporary value var.
-			if (*t_value != nil)
-				t_parameter_vars[i] = new (nothrow) MCTransientExternalVariable(*t_value);
-		}
+    {
+        MCContainer *t_container
+                = p_parameters -> eval_argument_container();
+        if (t_container != nil)
+        {
+            t_parameter_vars[i] = new (nothrow) MCReferenceExternalVariable(*t_container);
+        }
+        else
+        {
+            t_parameter_vars[i] = new (nothrow) MCTransientExternalVariable(p_parameters->getvalueref_argument());
+        }
 	}
 
 	// We have our list of parameters (hopefully), so now call - passing a temporary
@@ -1017,7 +990,10 @@ Exec_stat MCExternalV1::Handle(MCObject *p_context, Handler_type p_type, uint32_
 		// MW-2014-01-22: [[ CompatV1 ]] Make a reference var to hold it (should it be needed).
 		//   We then store the previous global value of the it extvar, and set this one.
 		//   As external calls are recursive, this should be fine :)
-		MCReferenceExternalVariable t_it(MCECptr -> GetIt() -> evalvar(*MCECptr));
+        MCContainer t_it_container;
+        MCECptr->GetIt()->evalcontainer(*MCECptr, t_it_container);
+		MCReferenceExternalVariable t_it(t_it_container);
+        
 		MCReferenceExternalVariable *t_old_it;
 		t_old_it = s_external_v1_current_it;
 		s_external_v1_current_it = &t_it;
@@ -1240,7 +1216,10 @@ static MCExternalError MCExternalContextQuery(MCExternalContextQueryTag op, MCEx
         case kMCExternalContextQueryResult:
             // MW-2014-01-22: [[ CompatV1 ]] If the result shim hasn't been made, make it.
             if (s_external_v1_result == nil)
-                s_external_v1_result = new (nothrow) MCReferenceExternalVariable(MCresult);
+            {
+                s_external_v1_result_container = new (nothrow) MCContainer(MCresult);
+                s_external_v1_result = new (nothrow) MCReferenceExternalVariable(*s_external_v1_result_container);
+            }
             *(MCExternalVariableRef *)result = s_external_v1_result;
             break;
         case kMCExternalContextQueryIt:

--- a/engine/src/externalv1.h
+++ b/engine/src/externalv1.h
@@ -506,7 +506,7 @@ public:
 class MCReferenceExternalVariable: public MCExternalVariable
 {
 public:
-    MCReferenceExternalVariable(MCVariable *value);
+    MCReferenceExternalVariable(MCContainer& value);
     ~MCReferenceExternalVariable(void);
     
     virtual bool IsTemporary(void);
@@ -515,13 +515,14 @@ public:
     virtual void SetValueRef(MCValueRef value);
     
 private:
-    MCVariable *m_variable;
+    MCContainer& m_container;
 };
 
 // MW-2014-01-22: [[ CompatV1 ]] This global holds the current handlers it-shim.
 static MCReferenceExternalVariable *s_external_v1_current_it = nil;
 // MW-2014-01-22: [[ CompatV1 ]] This global holds the result-shim.
 static MCReferenceExternalVariable *s_external_v1_result = nil;
+static MCContainer *s_external_v1_result_container = nil;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -1220,27 +1220,14 @@ bool MCNameIsEqualToOldString(MCNameRef p_left, const MCString& p_oldstring, MCC
 	return MCStringIsEqualToOldString(MCNameGetString(p_left), p_oldstring, p_options);
 }
 
-MCNameRef MCNameLookupWithCString(const char *cstring, MCCompareOptions options)
+MCNameRef MCNameLookupWithCStringCaseless(const char *cstring)
 {
 	MCStringRef t_string;
 	if (!MCStringCreateWithNativeChars((const char_t *)cstring, strlen(cstring), t_string))
 		return nil;
 
 	MCNameRef t_name;
-	t_name = MCNameLookup(t_string);
-	MCValueRelease(t_string);
-
-	return t_name;
-}
-
-MCNameRef MCNameLookupWithOldString(const MCString& string, MCCompareOptions options)
-{	
-	MCStringRef t_string;
-	if (!MCStringCreateWithNativeChars((const char_t *)string . getstring(), string . getlength(), t_string))
-		return nil;
-
-	MCNameRef t_name;
-	t_name = MCNameLookup(t_string);
+	t_name = MCNameLookupCaseless(t_string);
 	MCValueRelease(t_string);
 
 	return t_name;

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -92,8 +92,7 @@ bool MCNameIsEqualTo(MCNameRef left, MCNameRef right, MCCompareOptions options);
 bool MCNameIsEqualToCString(MCNameRef left, const char *cstring, MCCompareOptions options);
 bool MCNameIsEqualToOldString(MCNameRef left, const MCString& string, MCCompareOptions options);
 
-MCNameRef MCNameLookupWithCString(const char *cstring, MCCompareOptions options);
-MCNameRef MCNameLookupWithOldString(const MCString& string, MCCompareOptions options);
+MCNameRef MCNameLookupWithCStringCaseless(const char *cstring);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -339,14 +339,14 @@ void MCBinaryDecode::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
             {
                 // AL-2014-09-09: [[ Bug 13359 ]] Make sure containers are used in case a param is a handler variable
                 // AL-2014-09-18: [[ Bug 13465 ]] Use auto class to prevent memory leak
-                MCAutoPointer<MCContainer> t_container;
-                if (!t_params->evalcontainer(ctxt, &t_container))
+                MCContainer t_container;
+                if (!t_params->evalcontainer(ctxt, t_container))
                 {
                     ctxt . LegacyThrow(EE_BINARYD_BADDEST);
                     return;
                 }
                 
-                /* UNCHECKED */ t_container->set_valueref(t_results[i]);
+                /* UNCHECKED */ t_container.set_valueref(t_results[i]);
             }
             else
             {
@@ -1363,14 +1363,14 @@ void MCMatch::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
         {
             // AL-2014-09-09: [[ Bug 13359 ]] Make sure containers are used in case a param is a handler variable
             // AL-2014-09-18: [[ Bug 13465 ]] Use auto class to prevent memory leak
-            MCAutoPointer<MCContainer> t_container;
-            if (!t_result_params->evalcontainer(ctxt, &t_container))
+            MCContainer t_container;
+            if (!t_result_params->evalcontainer(ctxt, t_container))
             {
                 ctxt . LegacyThrow(EE_MATCH_BADDEST);
                 return;
             }
 
-            /* UNCHECKED */ t_container->set_valueref(t_results[i]);
+            /* UNCHECKED */ t_container.set_valueref(t_results[i]);
             
             t_result_params = t_result_params->getnext();
         }
@@ -2518,11 +2518,11 @@ void MCQueryRegistry::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
     if (!ctxt . EvalExprAsStringRef(key, EE_QUERYREGISTRY_BADEXP, &t_key))
         return;
 
-	MCAutoPointer<MCContainer> t_container;
+    MCContainer t_container;
     MCAutoStringRef t_type;
 	if (type != NULL)
 	{
-		if (!type -> evalcontainer(ctxt, &t_container))
+		if (!type -> evalcontainer(ctxt, t_container))
 		{
 			ctxt . LegacyThrow(EE_QUERYREGISTRY_BADDEST);
 			return;
@@ -2539,8 +2539,8 @@ void MCQueryRegistry::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
 
 	if (!ctxt.HasError())
 	{
-		if (*t_container != nil)
-			/* UNCHECKED */ t_container->set_valueref(*t_type);
+        if (type != NULL)
+            /* UNCHECKED */ t_container.set_valueref(*t_type);
 	}
 }
 

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -358,8 +358,9 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 				}
                 
                 MCVariable *t_new_var;
+                /* UNCHECKED */ newparams[i] = new(nothrow) MCContainer;
 				/* UNCHECKED */ MCVariable::createwithname(i < npnames ? pinfo[i] . name : kMCEmptyName, t_new_var);
-                /* UNCHECKED */ MCContainer::createwithvariable(t_new_var, newparams[i]);
+                /* UNCHECKED */ MCContainer::createwithvariable(t_new_var, *newparams[i]);
                 
 				newparams[i]->give_value(ctxt, t_value);
 			}
@@ -379,8 +380,9 @@ Exec_stat MCHandler::exec(MCExecContext& ctxt, MCParameter *plist)
 				break;
 			}
             MCVariable *t_new_var;
+            /* UNCHECKED */ newparams[i] = new(nothrow) MCContainer;
             /* UNCHECKED */ MCVariable::createwithname(i < npnames ? pinfo[i] . name : kMCEmptyName, t_new_var);
-            /* UNCHECKED */ MCContainer::createwithvariable(t_new_var, newparams[i]);
+            /* UNCHECKED */ MCContainer::createwithvariable(t_new_var, *newparams[i]);
 		}
 	}
 	if (err)

--- a/engine/src/literal.h
+++ b/engine/src/literal.h
@@ -36,8 +36,15 @@ public:
 	}
 
     virtual Parse_stat parse(MCScriptPoint &, Boolean the);
+    
     virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
-	virtual void compile(MCSyntaxFactoryRef ctxt);
+    
+    virtual bool is_pure(void) const
+    {
+        return true;
+    }
+	
+    virtual void compile(MCSyntaxFactoryRef ctxt);
 };
 
 #endif

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -607,19 +607,19 @@ public:
         if (!ctxt . EvalOptionalExprAsStringRef(m_file_expr, kMCEmptyString, EE_PUT_BADEXP, &t_file))
             return;
 		
-
 		if (s_payload_minizip != nil)
 		{
 			ExtractContext t_context;
 			t_context . target = MCtargetptr . object -> GetHandle();
 			t_context . name = *t_item;
-            t_context . var = ctxt . GetIt() -> evalvar(ctxt);
+            if (!ctxt.GetIt()->evalcontainer(ctxt, t_context.var))
+                return;
 			t_context . stream = nil;
 
 			if (!MCStringIsEmpty(*t_file))
 				t_context . stream = MCS_open(*t_file, kMCOpenFileModeWrite, False, False, 0);
 
-			t_context . var -> clear();
+			t_context.var.clear();
 			if (MCStringIsEmpty(*t_file) || t_context . stream != nil)
 			{
 				if (MCMiniZipExtractItem(s_payload_minizip, t_context . name, extract_item, &t_context))
@@ -643,7 +643,7 @@ private:
 		MCObjectHandle target;
 		MCStringRef name;
 		IO_handle stream;
-		MCVariable *var;
+		MCContainer var;
 	};
 
 	static bool extract_item(void *p_context, const void *p_data, uint32_t p_data_length, uint32_t p_data_offset, uint32_t p_data_total)
@@ -661,15 +661,7 @@ private:
 			MCExecContext ctxt;
 			MCAutoStringRef t_data;
 			/* UNCHECKED */ MCStringCreateWithBytes((const byte_t *)p_data, p_data_length, kMCStringEncodingNative, false, &t_data);
-			MCStringRef t_value;
-            MCAutoValueRef t_valueref;
-            context -> var -> copyasvalueref(&t_valueref);
-			/* UNCHECKED */ ctxt . ConvertToString(*t_valueref, t_value);
-			/* UNCHECHED */ MCStringMutableCopyAndRelease(t_value, t_value);
-			if (!MCStringAppend(t_value, *t_data))
-				return false;
-            context -> var ->setvalueref(t_value);
-			MCValueRelease(t_value);
+            context->var.set(ctxt, *t_data, kMCVariableSetAfter);
 		}
         
 		if (context->target.IsValid())

--- a/engine/src/param.cpp
+++ b/engine/src/param.cpp
@@ -94,19 +94,10 @@ void MCParameter::clear_argument(void)
     // AL-2014-09-17: [[ Bug 13465 ]] Delete container when clearing a parameter
     delete container;
     container = nil;
-    var  = nil;
 	MCExecTypeRelease(value);
 }
 
 ////////
-
-MCVariable *MCParameter::evalvar(MCExecContext &ctxt)
-{
-    if (exp == NULL)
-        return NULL;
-
-    return exp -> evalvar(ctxt);
-}
 
 bool MCParameter::eval(MCExecContext &ctxt, MCValueRef &r_value)
 {
@@ -154,9 +145,6 @@ bool MCParameter::evalcontainer(MCExecContext &ctxt, MCContainer& r_container)
 
 bool MCParameter::eval_argument(MCExecContext &ctxt, MCValueRef &r_value)
 {
-    if (var != NULL)
-        return var -> eval(ctxt, r_value);
-
     // AL-2014-08-28: [[ ArrayElementRefParams ]] MCParameter argument can now be a container
     if (container != nil)
         return container -> eval(ctxt, r_value);
@@ -182,19 +170,11 @@ bool MCParameter::eval_argument(MCExecContext &ctxt, MCValueRef &r_value)
 
 bool MCParameter::eval_argument_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
 {
-    if (var != NULL)
-        return var -> eval_ctxt(ctxt, r_value);
-    
     if (container != nil)
         return container -> eval_ctxt(ctxt, r_value);
     
     MCExecTypeCopy(value, r_value);
     return true;
-}
-
-MCVariable *MCParameter::eval_argument_var(void)
-{
-	return var;
 }
 
 MCContainer *MCParameter::eval_argument_container(void)
@@ -210,7 +190,6 @@ void MCParameter::set_argument(MCExecContext& ctxt, MCValueRef p_value)
     t_new_value = MCValueRetain(p_value);
     MCExecTypeRelease(value);
     MCExecTypeSetValueRef(value, t_new_value);
-	var = NULL;
 }
 
 void MCParameter::set_exec_argument(MCExecContext& ctxt, MCExecValue p_value)
@@ -219,12 +198,6 @@ void MCParameter::set_exec_argument(MCExecContext& ctxt, MCExecValue p_value)
 	t_old_value = value;
     MCExecTypeCopy(p_value, value);
 	MCExecTypeRelease(t_old_value);
-	var = NULL;
-}
-
-void MCParameter::set_argument_var(MCVariable* p_var)
-{
-	var = p_var;
 }
 
 void MCParameter::set_argument_container(MCContainer* p_container)

--- a/engine/src/param.cpp
+++ b/engine/src/param.cpp
@@ -144,7 +144,7 @@ bool MCParameter::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
     return true;
 }
 
-bool MCParameter::evalcontainer(MCExecContext &ctxt, MCContainer *&r_container)
+bool MCParameter::evalcontainer(MCExecContext &ctxt, MCContainer& r_container)
 {
     if (exp == NULL)
         return false;

--- a/engine/src/param.h
+++ b/engine/src/param.h
@@ -30,7 +30,7 @@ public:
 	{
 		exp = nil;
 		next = nil;
-		var = nil;
+		//var = nil;
         container = nil;
 		value . type = kMCExecValueTypeNone;
         value . valueref_value = nil;
@@ -65,7 +65,6 @@ public:
 
 	// Evaluate the value *stored* in the parameter - i.e. Used by
     // the callee in a function/command invocation.
-    MCVariable *eval_argument_var(void);
     MCContainer *eval_argument_container(void);
     
     bool eval_argument(MCExecContext& ctxt, MCValueRef &r_value);
@@ -74,7 +73,6 @@ public:
 	// Set the value of the parameter to be used by the callee.
     void set_argument(MCExecContext &ctxt, MCValueRef p_value);
     void set_exec_argument(MCExecContext& ctxt, MCExecValue p_value);
-	void set_argument_var(MCVariable* var);
     void set_argument_container(MCContainer* container);
 
 	// Evaluate the value of the given parameter in the context of
@@ -82,8 +80,6 @@ public:
     bool eval(MCExecContext& ctxt, MCValueRef &r_value);
     bool eval_ctxt(MCExecContext& ctxt, MCExecValue &r_value);
     bool evalcontainer(MCExecContext& ctxt, MCContainer& r_container);
-    MCVariable *evalvar(MCExecContext& ctxt);
-
 	Parse_stat parse(MCScriptPoint &);
 
 	void compile(MCSyntaxFactoryRef);
@@ -102,7 +98,6 @@ private:
 
 	// Parameter as value (i.e. value of the argument when
 	// passed to a function/command).
-	MCVariable *var;
     MCContainer *container;
 	MCExecValue value;
 };

--- a/engine/src/param.h
+++ b/engine/src/param.h
@@ -81,7 +81,7 @@ public:
 	// <ep>.
     bool eval(MCExecContext& ctxt, MCValueRef &r_value);
     bool eval_ctxt(MCExecContext& ctxt, MCExecValue &r_value);
-    bool evalcontainer(MCExecContext& ctxt, MCContainer*& r_container);
+    bool evalcontainer(MCExecContext& ctxt, MCContainer& r_container);
     MCVariable *evalvar(MCExecContext& ctxt);
 
 	Parse_stat parse(MCScriptPoint &);

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -797,7 +797,7 @@ Exec_stat MCStack::resubstack(MCStringRef p_data)
 			// If t_val doesn't exist as a name, it can't exist as a substack name.
 			// t_val is always a stringref (fetched from an MCSplitString array)
 			MCNameRef t_name;
-			t_name = MCNameLookup((MCStringRef)t_val);
+			t_name = MCNameLookupCaseless((MCStringRef)t_val);
 		
 			if (t_name != nil)
 				while (tsub -> hasname(t_name))

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1330,17 +1330,6 @@ MCVarref *MCVarref::getrootvarref(void)
 	return this;
 }
 
-bool MCVarref::rootmatches(MCVarref *p_other) const
-{
-	if (this == p_other)
-		return true;
-
-	if (p_other -> ref != NULL)
-		return ref == p_other -> ref;
-
-	return handler == p_other -> handler && index == p_other -> index && isparam == p_other -> isparam;
-}
-
 bool MCVarref::set(MCExecContext& ctxt, MCValueRef p_value, MCVariableSettingStyle p_setting)
 {
 	if (dimensions == 0 && !isparam)

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1186,27 +1186,25 @@ bool MCContainer::set_real(double p_real)
 	return set_valueref(*t_number);
 }
 
-bool MCContainer::createwithvariable(MCVariable *p_var, MCContainer*& r_container)
+bool MCContainer::createwithvariable(MCVariable *p_var, MCContainer& r_container)
 {
-	r_container = new (nothrow) MCContainer;
-	r_container -> m_variable = p_var;
-	r_container -> m_length = 0;
-    r_container -> m_path = nil;
-	r_container -> m_case_sensitive = false;
+	r_container.m_variable = p_var;
+	r_container.m_length = 0;
+    r_container.m_path = nil;
+	r_container.m_case_sensitive = false;
 	return true;
 }
 
-bool MCContainer::createwithpath(MCVariable *p_var, MCNameRef *p_path, uindex_t p_length, MCContainer*& r_container)
+bool MCContainer::createwithpath(MCVariable *p_var, MCNameRef *p_path, uindex_t p_length, MCContainer& r_container)
 {
-	r_container = new (nothrow) MCContainer;
-	r_container -> m_variable = p_var;
-	r_container -> m_path = p_path;
-	r_container -> m_length = p_length;
-	r_container -> m_case_sensitive = false;
+	r_container.m_variable = p_var;
+	r_container.m_path = p_path;
+	r_container.m_length = p_length;
+	r_container.m_case_sensitive = false;
 	return true;
 }
 
-bool MCContainer::copywithpath(MCContainer *p_container, MCNameRef *p_path, uindex_t p_length, MCContainer*& r_container)
+bool MCContainer::copywithpath(MCContainer *p_container, MCNameRef *p_path, uindex_t p_length, MCContainer& r_container)
 {
 	return createwithpath(p_container -> m_variable, p_path, p_length, r_container);
 }
@@ -1280,16 +1278,16 @@ void MCVarref::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
 	}
     else
     {
-        MCAutoPointer<MCContainer> t_container;
-        if (resolve(ctxt, &t_container)
-                && t_container -> eval_ctxt(ctxt, r_value))
+        MCContainer t_container;
+        if (resolve(ctxt, t_container)
+                && t_container.eval_ctxt(ctxt, r_value))
             return;
     }
     
     ctxt . Throw();
 }
 
-bool MCVarref::evalcontainer(MCExecContext& ctxt, MCContainer*& r_container)
+bool MCVarref::evalcontainer(MCExecContext& ctxt, MCContainer& r_container)
 {
 	if (dimensions == 0 && !isparam)
         return MCContainer::createwithvariable(fetchvar(ctxt), r_container);
@@ -1341,11 +1339,11 @@ bool MCVarref::set(MCExecContext& ctxt, MCValueRef p_value, MCVariableSettingSty
         return t_resolved_ref -> set(ctxt, p_value, p_setting);
 	}
     
-	MCAutoPointer<MCContainer> t_container;
-    if (!resolve(ctxt, &t_container))
+	MCContainer t_container;
+    if (!resolve(ctxt, t_container))
 		return false;
 	
-	return t_container -> set(ctxt, p_value, p_setting);
+	return t_container.set(ctxt, p_value, p_setting);
 }
 
 bool MCVarref::give_value(MCExecContext& ctxt, MCExecValue p_value, MCVariableSettingStyle p_setting)
@@ -1359,11 +1357,11 @@ bool MCVarref::give_value(MCExecContext& ctxt, MCExecValue p_value, MCVariableSe
         return t_resolved_ref -> give_value(ctxt, p_value, p_setting);
 	}
     
-	MCAutoPointer<MCContainer> t_container;
-    if (!resolve(ctxt, &t_container))
+    MCContainer t_container;
+    if (!resolve(ctxt, t_container))
 		return false;
 	
-    return t_container -> give_value(ctxt, p_value, p_setting);
+    return t_container.give_value(ctxt, p_value, p_setting);
 }
 
 bool MCVarref::replace(MCExecContext &ctxt, MCValueRef p_replacement, MCRange p_range)
@@ -1377,11 +1375,11 @@ bool MCVarref::replace(MCExecContext &ctxt, MCValueRef p_replacement, MCRange p_
         return t_resolved_ref -> replace(ctxt, p_replacement, p_range);
     }
     
-    MCAutoPointer<MCContainer> t_container;
-    if (!resolve(ctxt, &t_container))
+    MCContainer t_container;
+    if (!resolve(ctxt, t_container))
         return false;
     
-    return t_container -> replace(ctxt, p_replacement, p_range);
+    return t_container.replace(ctxt, p_replacement, p_range);
 }
 
 bool MCVarref::deleterange(MCExecContext &ctxt, MCRange p_range)
@@ -1395,11 +1393,11 @@ bool MCVarref::deleterange(MCExecContext &ctxt, MCRange p_range)
         return t_resolved_ref -> deleterange(ctxt, p_range);
     }
     
-    MCAutoPointer<MCContainer> t_container;
-    if (!resolve(ctxt, &t_container))
+    MCContainer t_container;
+    if (!resolve(ctxt, t_container))
         return false;
     
-    return t_container -> deleterange(ctxt, p_range);
+    return t_container.deleterange(ctxt, p_range);
 }
 
 Parse_stat MCVarref::parsearray(MCScriptPoint &sp)
@@ -1497,15 +1495,15 @@ bool MCVarref::dofree(MCExecContext& ctxt)
 		return t_var -> remove(ctxt);
 	}
 	
-	MCAutoPointer<MCContainer> t_container;
-    if (!resolve(ctxt, &t_container))
+	MCContainer t_container;
+    if (!resolve(ctxt, t_container))
         return false;
     
-	return t_container -> remove(ctxt);
+	return t_container.remove(ctxt);
 }
 
 // Resolve references to the appropriate element refered to by this Varref.
-bool MCVarref::resolve(MCExecContext& ctxt, MCContainer*& r_container)
+bool MCVarref::resolve(MCExecContext& ctxt, MCContainer& r_container)
 {
     if (dimensions == 0 && !isparam)
         return MCContainer::createwithvariable(fetchvar(ctxt), r_container);
@@ -1651,7 +1649,7 @@ void MCDeferredVarref::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
         ctxt . Throw();
 }
 
-bool MCDeferredVarref::evalcontainer(MCExecContext &ctxt, MCContainer *&r_container)
+bool MCDeferredVarref::evalcontainer(MCExecContext &ctxt, MCContainer& r_container)
 {
     bool t_error = false;
     if (ref -> isdeferred())

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1201,6 +1201,7 @@ bool MCContainer::remove(MCExecContext& ctxt)
 
 bool MCContainer::set_valueref(MCValueRef p_value)
 {
+    m_variable->clearuql();
 	return m_variable -> setvalueref(m_path, m_length, m_case_sensitive, p_value);
 }
 
@@ -1901,15 +1902,10 @@ public:
 // MW-2008-08-18: [[ Bug 6945 ]] Cannot delete a nested array key.
 bool MCVarref::dofree(MCExecContext& ctxt)
 {
-    if (!isparam &&
+    /*if (!isparam &&
         dimensions > 0 &&
         m_is_pure)
     {
-        if (ctxt.HasError())
-        {
-            return false;
-        }
-        
         __MCVarrefPureRemoveActor t_actor;
         
         action(ctxt,
@@ -1917,7 +1913,7 @@ bool MCVarref::dofree(MCExecContext& ctxt)
         
         return ctxt.HasError();
     }
-    else
+    else*/
     {
         MCContainer t_container;
         if (!resolve(ctxt, t_container))

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -898,7 +898,7 @@ MCVariable *MCVariable::lookupglobal_cstring(const char *p_name)
 	// If we can't find an existing name, then there can be no global with
 	// name 'p_name'.
 	MCNameRef t_name;
-	t_name = MCNameLookupWithCString(p_name, kMCCompareCaseless);
+	t_name = MCNameLookupWithCStringCaseless(p_name);
 	if (t_name == nil)
 		return nil;
 

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1296,16 +1296,6 @@ MCContainer *MCVarref::fetchcontainer(MCExecContext& ctxt)
     return nil;
 }
 
-void MCVarref::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
-{
-    MCContainer t_container;
-    if (evalcontainer(ctxt, t_container)
-            && t_container.eval_ctxt(ctxt, r_value))
-        return;
-    
-    ctxt . Throw();
-}
-
 bool MCVarref::evalcontainer(MCExecContext& ctxt, MCContainer& r_container)
 {
     return resolve(ctxt, r_container);
@@ -1342,42 +1332,6 @@ void MCVarref::compile_inout(MCSyntaxFactoryRef ctxt)
 MCVarref *MCVarref::getrootvarref(void)
 {
 	return this;
-}
-
-bool MCVarref::set(MCExecContext& ctxt, MCValueRef p_value, MCVariableSettingStyle p_setting)
-{
-	MCContainer t_container;
-    if (!evalcontainer(ctxt, t_container))
-		return false;
-	
-	return t_container.set(ctxt, p_value, p_setting);
-}
-
-bool MCVarref::give_value(MCExecContext& ctxt, MCExecValue p_value, MCVariableSettingStyle p_setting)
-{
-    MCContainer t_container;
-    if (!evalcontainer(ctxt, t_container))
-		return false;
-	
-    return t_container.give_value(ctxt, p_value, p_setting);
-}
-
-bool MCVarref::replace(MCExecContext &ctxt, MCValueRef p_replacement, MCRange p_range)
-{
-    MCContainer t_container;
-    if (!evalcontainer(ctxt, t_container))
-        return false;
-    
-    return t_container.replace(ctxt, p_replacement, p_range);
-}
-
-bool MCVarref::deleterange(MCExecContext &ctxt, MCRange p_range)
-{
-    MCContainer t_container;
-    if (!evalcontainer(ctxt, t_container))
-        return false;
-    
-    return t_container.deleterange(ctxt, p_range);
 }
 
 Parse_stat MCVarref::parsearray(MCScriptPoint &sp)
@@ -1471,97 +1425,22 @@ void MCVarref::clearuql()
         handler->getcontainer(index, isparam)->getvar()->clearuql();
 }
 
-// MW-2008-08-18: [[ Bug 6945 ]] Cannot delete a nested array key.
-bool MCVarref::dofree(MCExecContext& ctxt)
+bool MCVarref::replace(MCExecContext &ctxt, MCValueRef p_replacement, MCRange p_range)
 {
-	MCContainer t_container;
-    if (!resolve(ctxt, t_container))
+    MCContainer t_container;
+    if (!evalcontainer(ctxt, t_container))
         return false;
     
-	return t_container.remove(ctxt);
+    return t_container.replace(ctxt, p_replacement, p_range);
 }
 
-// Resolve references to the appropriate element refered to by this Varref.
-bool MCVarref::resolve(MCExecContext& ctxt, MCContainer& r_container)
+bool MCVarref::deleterange(MCExecContext &ctxt, MCRange p_range)
 {
-    if (dimensions == 0 && !isparam)
-        return MCContainer::createwithvariable(fetchvar(ctxt), r_container);
-
-	MCExpression **t_dimensions;
-	if (dimensions == 1)
-		t_dimensions = &exp;
-	else
-		t_dimensions = exps;
-    
-	uindex_t t_path_length;
-	t_path_length = 0;
-    
-    // AL-2014-08-20: [[ ArrayElementRefParams ]] If the Varref refers to a container then
-    //  resolving the path requires appending the new dimensions to the old path
-    
-	MCNameRef *t_path, *t_old_path;
-    getpath(ctxt, t_old_path, t_path_length);
-    
-    uindex_t t_new_dimension_count;
-	t_new_dimension_count = dimensions + t_path_length;
-
-    /* UNCHECKED */ MCMemoryNewArray(t_new_dimension_count, t_path, t_new_dimension_count);
-
-    for (uindex_t i = 0; i < t_path_length; i++)
-        t_path[i] = MCValueRetain(t_old_path[i]);
-    
-    for(uindex_t i = 0; i < dimensions && !ctxt . HasError(); i++)
-	{
-        MCAutoValueRef t_value;
-        if (ctxt . EvalExprAsValueRef(t_dimensions[i], EE_VARIABLE_BADINDEX, &t_value))
-        {
-            MCAutoArrayRef t_array;
-
-            if (ctxt . ConvertToArray(*t_value, &t_array)
-                    && !MCArrayIsEmpty(*t_array))
-            {
-                if (!MCArrayIsSequence(*t_array))
-                    ctxt . LegacyThrow(EE_VARIABLE_BADINDEX);
-                else
-				{
-					uindex_t t_length;
-                    t_length = MCArrayGetCount(*t_array);
-                    
-					/* UNCHECKED */ MCMemoryResizeArray(t_new_dimension_count + t_length, t_path, t_new_dimension_count);
-
-					for(uindex_t t_index = 1; t_index <= t_length; t_index += 1)
-                    {
-                        MCValueRef t_value_fetched;
-                        /* UNCHECKED */ MCArrayFetchValueAtIndex(*t_array, t_index, t_value_fetched);
-
-                        if (!ctxt . ConvertToName(t_value_fetched, t_path[t_path_length++]))
-                        {
-                            ctxt . LegacyThrow(EE_VARIABLE_BADINDEX);
-							break;
-						}
-					}
-				}
-			}
-            else if (!ctxt . ConvertToName(*t_value, t_path[t_path_length++]))
-                ctxt . LegacyThrow(EE_VARIABLE_BADINDEX);
-		}
-	}
-
-    if (!ctxt . HasError())
-    {
-        if (isparam)
-            return MCContainer::copywithpath(fetchcontainer(ctxt), t_path, t_path_length, r_container);
-        else
-            return MCContainer::createwithpath(fetchvar(ctxt), t_path, t_path_length, r_container);
-    }
-	else
-	{
-		for(uindex_t i = 0; i < t_path_length; i++)
-			MCValueRelease(t_path[i]);
-        MCMemoryDeleteArray(t_path);
-
+    MCContainer t_container;
+    if (!evalcontainer(ctxt, t_container))
         return false;
-    }
+    
+    return t_container.deleterange(ctxt, p_range);
 }
 
 void MCVarref::getpath(MCExecContext& ctxt, MCNameRef*& r_path, uindex_t& r_length)
@@ -1574,6 +1453,547 @@ void MCVarref::getpath(MCExecContext& ctxt, MCNameRef*& r_path, uindex_t& r_leng
     }
     
     fetchcontainer(ctxt) -> getpath(r_path, r_length);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template<typename Actor>
+static bool
+__MCVarrefDimensionAction(MCExecContext& ctxt,
+                          Actor& p_actor,
+                          MCValueRef p_key)
+{
+    if (MCValueGetTypeCode(p_key) == kMCValueTypeCodeArray)
+    {
+        MCArrayRef t_array_key =
+        (MCArrayRef)p_key;
+        
+        // If the array is not a sequence, it is an error.
+        if (!MCArrayIsSequence(t_array_key))
+        {
+            ctxt.LegacyThrow(EE_VARIABLE_BADINDEX);
+            return false;
+        }
+        
+        // Get the number of keys.
+        uindex_t t_array_key_count =
+        MCArrayGetCount(t_array_key);
+        
+        // Hint at the number of dimensions
+        if (!p_actor.Hint(ctxt,
+                          t_array_key_count - 1))
+        {
+            return false;
+        }
+        
+        // Now iterate and recurse on each element of the sequence.
+        for(uindex_t i = 1; i <= MCArrayGetCount(t_array_key); i++)
+        {
+            MCValueRef t_sub_key = nullptr;
+            /* CANNOT_FAIL */ MCArrayFetchValueAtIndex(t_array_key,
+                                                       i,
+                                                       t_sub_key);
+            
+            if (!__MCVarrefDimensionAction(ctxt,
+                                           p_actor,
+                                           t_sub_key))
+            {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+    
+    MCNewAutoNameRef t_name_key;
+    if (!ctxt.ConvertToName(p_key,
+                            &t_name_key))
+    {
+        ctxt.LegacyThrow(EE_VARIABLE_BADINDEX);
+        return false;
+    }
+    
+    if (!p_actor.Continue(ctxt,
+                          *t_name_key))
+    {
+        return false;
+    }
+    
+    return true;
+}
+
+template<typename Actor>
+void MCVarref::action(MCExecContext& ctxt,
+                      Actor& p_actor)
+{
+    MCVariable *t_var = nullptr;
+    MCNameRef *t_existing_path = nullptr;
+    uindex_t t_existing_path_length = 0;
+    if (!isparam)
+    {
+        t_var = fetchvar(ctxt);
+    }
+    else
+    {
+        MCContainer *t_container =
+        fetchcontainer(ctxt);
+        
+        t_var = t_container->getvar();
+        t_container->getpath(t_existing_path,
+                             t_existing_path_length);
+    }
+    
+    // Start the action
+    if (!p_actor.Begin(ctxt,
+                       t_var))
+    {
+        return;
+    }
+    
+    // Hint at the number of upcoming dimensions.
+    if (!p_actor.Hint(ctxt,
+                      t_existing_path_length + dimensions))
+    {
+        return;
+    }
+    
+    // Iterate over the existing path
+    for(uindex_t i = 0; i < t_existing_path_length; i++)
+    {
+        if (!p_actor.Continue(ctxt,
+                              t_existing_path[i]))
+        {
+            return;
+        }
+    }
+    
+    // Get the dimension array (which is a union tagged by dimensions).
+    if (dimensions > 0)
+    {
+        MCExpression **t_dimensions =
+        dimensions == 1 ? &exp : exps;
+        
+        // Iterate through each provided dimension.
+        for(uindex_t i = 0; i < dimensions; i++)
+        {
+            // First evaluate the dimension expression to get the next key.
+            MCAutoValueRef t_key;
+            if (!ctxt.EvalExprAsValueRef(t_dimensions[i],
+                                         EE_VARIABLE_BADINDEX,
+                                         &t_key))
+            {
+                return;
+            }
+            
+            // Now visit the key. As the key could be an array, it is possible for a
+            // single dimension to give rise to multiple keys.
+            if (!__MCVarrefDimensionAction(ctxt,
+                                           p_actor,
+                                           *t_key))
+            {
+                return;
+            }
+        }
+    }
+    
+    // Complete the operation.
+    if (!p_actor.End(ctxt))
+    {
+        return;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class __MCVarrefPureFetchActor
+{
+public:
+    __MCVarrefPureFetchActor(void)
+        : m_value(nil)
+    {
+    }
+    
+    bool Hint(MCExecContext& ctxt,
+              uindex_t p_extra_dimensions)
+    {
+        return true;
+    }
+    
+    bool Begin(MCExecContext& ctxt,
+               MCVariable* p_var)
+    {
+        m_value = p_var->getvalueref();
+        return true;
+    }
+    
+    bool Continue(MCExecContext& ctxt,
+                  MCNameRef p_key)
+    {
+        // If m_value is not an array, or the array key is not present in it as
+        // an array then we return null.
+        if (MCValueGetTypeCode(m_value) != kMCValueTypeCodeArray ||
+            !MCArrayFetchValue((MCArrayRef)m_value,
+                               ctxt.GetCaseSensitive(),
+                               p_key,
+                               m_value))
+        {
+            m_value = kMCNull;
+            return false;
+        }
+        
+        return true;
+    }
+    
+    bool End(MCExecContext& ctxt)
+    {
+        return true;
+    }
+    
+    ////////
+    
+    bool Copy(MCValueRef& r_value)
+    {
+        return MCValueCopy(m_value,
+                           r_value);
+    }
+    
+private:
+    MCValueRef m_value;
+};
+
+void MCVarref::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
+{
+    if (m_is_pure)
+    {
+        __MCVarrefPureFetchActor t_actor;
+        
+        action(ctxt,
+               t_actor);
+        
+        if (ctxt.HasError())
+        {
+            return;
+        }
+        
+        if (!t_actor.Copy(r_value.valueref_value))
+        {
+            ctxt.Throw();
+            return;
+        }
+        
+        r_value.type = kMCExecValueTypeValueRef;
+    }
+    else
+    {
+        MCContainer t_container;
+        if (evalcontainer(ctxt, t_container) &&
+            t_container.eval_ctxt(ctxt, r_value))
+            return;
+        
+        ctxt.Throw();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class __MCVarrefPureMutateActor
+{
+public:
+    __MCVarrefPureMutateActor(void)
+        : m_variable(nullptr),
+          m_array(nullptr)
+    {
+    }
+    
+    bool Hint(MCExecContext& ctxt,
+              uindex_t p_extra_dimensions)
+    {
+        return true;
+    }
+    
+    bool Begin(MCExecContext& ctxt,
+               MCVariable* p_var)
+    {
+        if (!p_var->converttomutablearray())
+        {
+            ctxt.Throw();
+            return false;
+        }
+        
+        m_variable = p_var;
+        m_array = (MCArrayRef)p_var->getvalueref();
+        
+        return true;
+    }
+    
+    bool Continue(MCExecContext& ctxt,
+                  MCNameRef p_key)
+    {
+        if (*m_key == nullptr)
+        {
+            m_key.Reset(p_key);
+            return true;
+        }
+        
+        MCValueRef *t_slot_ptr;
+        if (!MCArrayMutateValue(m_array,
+                                ctxt.GetCaseSensitive(),
+                                *m_key,
+                                t_slot_ptr))
+        {
+            ctxt.Throw();
+            return false;
+        }
+        
+        MCArrayRef t_new_array = nullptr;
+        if (MCValueGetTypeCode(*t_slot_ptr) == kMCValueTypeCodeArray)
+        {
+            MCArrayRef& t_array_slot = (MCArrayRef&)*t_slot_ptr;
+            if (!MCArrayIsMutable(t_array_slot))
+            {
+                if (!MCArrayMutableCopyAndRelease(t_array_slot,
+                                                  t_array_slot))
+                {
+                    ctxt.Throw();
+                    return false;
+                }
+            }
+            
+            t_new_array = t_array_slot;
+        }
+        else
+        {
+            if (!MCArrayCreateMutable(t_new_array))
+            {
+                ctxt.Throw();
+                return false;
+            }
+            
+            MCValueAssignAndRelease(*t_slot_ptr,
+                                    (MCValueRef)t_new_array);
+        }
+        
+        m_array = t_new_array;
+        m_key.Reset(p_key);
+        
+        return true;
+    }
+    
+    bool End(MCExecContext& ctxt)
+    {
+        m_variable->synchronize(ctxt,
+                                true);
+        return true;
+    }
+    
+protected:
+    MCVariable *m_variable;
+    MCArrayRef m_array;
+    MCNewAutoNameRef m_key;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class __MCVarrefPureStoreActor: public __MCVarrefPureMutateActor
+{
+public:
+    __MCVarrefPureStoreActor(MCValueRef p_value)
+        : m_value(p_value)
+    {
+    }
+    
+    bool End(MCExecContext& ctxt)
+    {
+        if (!MCArrayStoreValue(m_array,
+                               ctxt.GetCaseSensitive(),
+                               *m_key,
+                               m_value))
+        {
+            ctxt.Throw();
+            return false;
+        }
+        
+        return __MCVarrefPureMutateActor::End(ctxt);
+    }
+    
+private:
+    MCValueRef m_value;
+};
+
+bool MCVarref::set(MCExecContext& ctxt, MCValueRef p_value, MCVariableSettingStyle p_setting)
+{
+    if (!isparam &&
+        dimensions > 0 &&
+        p_setting == kMCVariableSetInto &&
+        m_is_pure)
+    {
+        __MCVarrefPureStoreActor t_actor(p_value);
+        
+        action(ctxt,
+               t_actor);
+        
+        return ctxt.HasError();
+    }
+    else
+    {
+        MCContainer t_container;
+        if (!evalcontainer(ctxt, t_container))
+            return false;
+        
+        return t_container.set(ctxt, p_value, p_setting);
+    }
+}
+
+bool MCVarref::give_value(MCExecContext& ctxt, MCExecValue p_value, MCVariableSettingStyle p_setting)
+{
+    if (!isparam &&
+        dimensions > 0 &&
+        p_setting == kMCVariableSetInto &&
+        m_is_pure)
+    {
+        MCAutoValueRef t_boxed_value;
+        MCExecTypeConvertAndReleaseAlways(ctxt,
+                                          p_value.type,
+                                          &p_value,
+                                          kMCExecValueTypeValueRef,
+                                          &(&t_boxed_value));
+        if (ctxt.HasError())
+        {
+            return false;
+        }
+
+        __MCVarrefPureStoreActor t_actor(*t_boxed_value);
+        
+        action(ctxt,
+               t_actor);
+        
+        return ctxt.HasError();
+    }
+    else
+    {
+        MCContainer t_container;
+        if (!evalcontainer(ctxt, t_container))
+            return false;
+        
+        return t_container.give_value(ctxt, p_value, p_setting);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class __MCVarrefPureRemoveActor: public __MCVarrefPureMutateActor
+{
+public:
+    bool End(MCExecContext& ctxt)
+    {
+        if (!MCArrayRemoveValue(m_array,
+                                ctxt.GetCaseSensitive(),
+                                *m_key))
+        {
+            ctxt.Throw();
+            return false;
+        }
+        
+        return __MCVarrefPureMutateActor::End(ctxt);
+    }
+};
+
+// MW-2008-08-18: [[ Bug 6945 ]] Cannot delete a nested array key.
+bool MCVarref::dofree(MCExecContext& ctxt)
+{
+    if (!isparam &&
+        dimensions > 0 &&
+        m_is_pure)
+    {
+        if (ctxt.HasError())
+        {
+            return false;
+        }
+        
+        __MCVarrefPureRemoveActor t_actor;
+        
+        action(ctxt,
+               t_actor);
+        
+        return ctxt.HasError();
+    }
+    else
+    {
+        MCContainer t_container;
+        if (!resolve(ctxt, t_container))
+            return false;
+    
+        return t_container.remove(ctxt);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class __MCVarrefResolveActor
+{
+public:
+    bool Hint(MCExecContext& ctxt,
+              uindex_t p_extra_dimensions)
+    {
+        return m_path.Ensure(p_extra_dimensions);
+    }
+    
+    bool Begin(MCExecContext& ctxt,
+               MCVariable* p_var)
+    {
+        m_variable = p_var;
+        return true;
+    }
+    
+    bool Continue(MCExecContext& ctxt,
+                  MCNameRef p_key)
+    {
+        m_path.Push(p_key);
+        return true;
+    }
+    
+    bool End(MCExecContext& ctxt)
+    {
+        return true;
+    }
+    
+    //////////
+    
+    bool Defer(MCExecContext& ctxt,
+               MCContainer& r_container)
+    {
+        MCNameRef *t_path = nullptr;
+        uindex_t t_path_length = 0;
+        m_path.Take(t_path,
+                    t_path_length);
+        
+        MCContainer::createwithpath(m_variable,
+                                    t_path,
+                                    t_path_length,
+                                    r_container);
+        
+        m_variable = nullptr;
+        
+        return true;
+    }
+    
+private:
+    MCVariable *m_variable;
+    MCAutoNameRefArray m_path;
+};
+
+bool MCVarref::resolve(MCExecContext& ctxt,
+                       MCContainer& r_container)
+{
+    __MCVarrefResolveActor t_actor;
+    action(ctxt,
+           t_actor);
+    if (ctxt.HasError())
+    {
+        return false;
+    }
+    return t_actor.Defer(ctxt,
+                         r_container);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1431,6 +1431,14 @@ Parse_stat MCVarref::parsearray(MCScriptPoint &sp)
 			exps[dimensions] = t_new_dimension;
 			dimensions = t_dimensions;
 		}
+        
+        // If we are pure, but the new index expression is not pure, then
+        // we are not pure.
+        if (m_is_pure &&
+            !t_new_dimension->is_pure())
+        {
+            m_is_pure = false;
+        }
 	}
 
 	return PS_NORMAL;

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -289,14 +289,25 @@ public:
     {
     }
     
+    MCContainer(MCVariable *var)
+        : m_variable(var),
+          m_path(nullptr),
+          m_length(0),
+          m_case_sensitive(false)
+    {
+    }
+    
 	~MCContainer(void);
 
 	//
 
+    bool remove(MCExecContext& ctxt);
     
     bool eval(MCExecContext& ctxt, MCValueRef& r_value);
-	bool remove(MCExecContext& ctxt);
+    bool eval_on_path(MCExecContext& ctxt, MCNameRef *path, uindex_t path_length, MCValueRef& r_value);
+    
     bool set(MCExecContext& ctxt, MCValueRef p_value, MCVariableSettingStyle p_setting = kMCVariableSetInto);
+    bool set_on_path(MCExecContext& ctxt, MCNameRef *path, uindex_t path_length, MCValueRef p_value);
     
     bool eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value);
     bool give_value(MCExecContext& ctxt, MCExecValue p_value, MCVariableSettingStyle p_setting = kMCVariableSetInto);
@@ -396,11 +407,8 @@ public:
 	}
     virtual ~MCVarref();
     
-    bool needsContainer(void) const {return dimensions != 0;}
-    
     void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
     virtual bool evalcontainer(MCExecContext &ctxt, MCContainer& r_container);
-    virtual MCVariable *evalvar(MCExecContext& ctxt);
 	
 	virtual void compile(MCSyntaxFactoryRef);
 	virtual void compile_in(MCSyntaxFactoryRef);
@@ -465,7 +473,6 @@ public:
 	// super-class methods with the same name are invoked.
     virtual void eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value);
     virtual bool evalcontainer(MCExecContext& ctxt, MCContainer& r_container);
-    virtual MCVariable *evalvar(MCExecContext& ctxt);
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -399,12 +399,7 @@ public:
 	virtual void compile_out(MCSyntaxFactoryRef);
 	virtual void compile_inout(MCSyntaxFactoryRef);
 
-	//virtual MCVariable *getvar();
 	virtual MCVarref *getrootvarref(void);
-
-	// This method returns true if p_other refers to the same root
-	// variable as self.
-	bool rootmatches(MCVarref *p_other) const;
 
 	Boolean getisscriptlocal() { return isscriptlocal; };
 

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -281,6 +281,14 @@ public:
 class MCContainer
 {
 public:
+    MCContainer(void)
+        : m_variable(nullptr),
+          m_path(nullptr),
+          m_length(0),
+          m_case_sensitive(false)
+    {
+    }
+    
 	~MCContainer(void);
 
 	//
@@ -308,9 +316,9 @@ public:
         r_length = m_length;
     }
 
-	static bool createwithvariable(MCVariable *var, MCContainer*& r_container);
-	static bool createwithpath(MCVariable *var, MCNameRef *path, uindex_t length, MCContainer*& r_container);
-    static bool copywithpath(MCContainer *p_container, MCNameRef *p_path, uindex_t p_length, MCContainer*& r_container);
+	static bool createwithvariable(MCVariable *var, MCContainer& r_container);
+	static bool createwithpath(MCVariable *var, MCNameRef *path, uindex_t length, MCContainer& r_container);
+    static bool copywithpath(MCContainer *p_container, MCNameRef *p_path, uindex_t p_length, MCContainer& r_container);
     
     MCVariable *getvar()
     {
@@ -391,7 +399,7 @@ public:
     bool needsContainer(void) const {return dimensions != 0;}
     
     void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
-    bool evalcontainer(MCExecContext &ctxt, MCContainer*& r_container);
+    virtual bool evalcontainer(MCExecContext &ctxt, MCContainer& r_container);
     virtual MCVariable *evalvar(MCExecContext& ctxt);
 	
 	virtual void compile(MCSyntaxFactoryRef);
@@ -419,7 +427,7 @@ private:
     MCVariable *fetchvar(MCExecContext& ctxt);
     MCContainer *fetchcontainer(MCExecContext& ctxt);
     
-    bool resolve(MCExecContext& ctxt, MCContainer*& r_container);
+    bool resolve(MCExecContext& ctxt, MCContainer& r_container);
     
     void getpath(MCExecContext& ctxt, MCNameRef*& r_path, uindex_t& r_length);
 };
@@ -456,7 +464,7 @@ public:
 	// just ensure 'compute' is called on the MCDeferredVar before the
 	// super-class methods with the same name are invoked.
     virtual void eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value);
-    virtual bool evalcontainer(MCExecContext& ctxt, MCContainer*& r_container);
+    virtual bool evalcontainer(MCExecContext& ctxt, MCContainer& r_container);
     virtual MCVariable *evalvar(MCExecContext& ctxt);
 };
 

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -367,6 +367,9 @@ protected:
 	//   a plain var and doesn't require synching.
 	bool isplain : 1;
 
+    // If this is true, then none of the index expressions have side-effects.
+    bool m_is_pure : 1;
+    
 public:
 	MCVarref(MCVariable *var)
 	{
@@ -378,6 +381,10 @@ public:
 		isscriptlocal = False;
 		handler = NULL;
 		isplain = var -> isplain();
+        
+        // Varref's become impure if a non-pure index expression is parsed
+        // into it.
+        m_is_pure = true;
 	}
 
 	// MW-2008-10-28: [[ ParentScripts ]] A new constructor to handle the case
@@ -391,7 +398,11 @@ public:
 		isparam = False;
 		isscriptlocal = True;
 		handler = NULL;
-		isplain = true;
+        isplain = true;
+        
+        // Varref's become impure if a non-pure index expression is parsed
+        // into it.
+        m_is_pure = true;
 	}
 
 	MCVarref(MCHandler *hptr, uint2 i, Boolean param)
@@ -403,7 +414,11 @@ public:
 		exp = NULL;
 		dimensions = 0;
 		isscriptlocal = False;
-		isplain = true;
+        isplain = true;
+        
+        // Varref's become impure if a non-pure index expression is parsed
+        // into it.
+        m_is_pure = true;
 	}
     virtual ~MCVarref();
     
@@ -417,6 +432,8 @@ public:
 
 	virtual MCVarref *getrootvarref(void);
 
+    virtual bool is_pure(void) const { return m_is_pure; }
+    
 	Boolean getisscriptlocal() { return isscriptlocal; };
 
     bool set(MCExecContext& ctxt, MCValueRef p_value, MCVariableSettingStyle p_setting = kMCVariableSetInto);

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -449,6 +449,10 @@ public:
 	bool getisplain(void) const { return isplain; }
 	
 private:
+    template<typename T>
+    void action(MCExecContext& ctxt,
+                T& actor);
+    
     MCVariable *fetchvar(MCExecContext& ctxt);
     MCContainer *fetchcontainer(MCExecContext& ctxt);
     

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -209,6 +209,7 @@ public:
 	{
 		m_values = nil;
         m_value_count = 0;
+        m_capacity = 0;
 	}
     
 	~MCAutoValueRefArrayBase(void)
@@ -221,9 +222,31 @@ public:
 	bool New(uindex_t p_size)
 	{
 		MCAssert(m_values == nil);
-		return MCMemoryNewArray(p_size, m_values, m_value_count);
+		if (!MCMemoryNewArray(p_size, m_values, m_value_count))
+        {
+            return false;
+        }
+        
+        m_capacity = m_value_count;
+        
+        return true;
 	}
 
+    bool Ensure(uindex_t p_extra)
+    {
+        if (m_value_count + p_extra > m_capacity)
+        {
+            if (!MCMemoryResizeArray(m_value_count + p_extra,
+                                     m_values,
+                                     m_capacity))
+            {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+    
 	//////////
 
 	void Give(T* p_array, uindex_t p_size)
@@ -235,11 +258,19 @@ public:
 
 	void Take(T*& r_array, uindex_t& r_count)
 	{
+        if (m_value_count < m_capacity)
+        {
+            MCMemoryResizeArray(m_value_count,
+                                m_values,
+                                m_capacity);
+        }
+        
 		r_array = m_values;
 		r_count = m_value_count;
 
 		m_values = nil;
-		m_value_count = 0;
+        m_value_count = 0;
+        m_capacity = 0;
 	}
 
 	/* Take the contents of the array as an immutable MCProperList.
@@ -254,6 +285,7 @@ public:
 
 		m_values = nil;
 		m_value_count = 0;
+        m_capacity = 0;
 
 		r_list = t_list;
 		return true;
@@ -268,6 +300,9 @@ public:
             for (uindex_t i = 0; i < m_value_count; i++)
                 MCValueRelease(m_values[i]);
             MCMemoryDeleteArray(m_values);
+            
+            m_value_count = 0;
+            m_capacity = 0;
         }
 	}
 
@@ -299,7 +334,17 @@ public:
 
 	bool Resize(uindex_t p_new_size)
 	{
-		return MCMemoryResizeArray(p_new_size, m_values, m_value_count);
+        if (p_new_size > m_capacity)
+        {
+            if (!MCMemoryResizeArray(p_new_size, m_values, m_value_count))
+            {
+                return false;
+            }
+            
+            m_capacity = m_value_count;
+        }
+        
+        return true;
 	}
 
 	bool Extend(uindex_t p_new_size)
@@ -318,21 +363,20 @@ public:
 
 	bool Append(MCAutoValueRefArrayBase<T> &p_array)
 	{
-		uindex_t t_index = Count();
-		if (!Extend(t_index + p_array.Count()))
+		if (!Ensure(p_array.Count()))
 			return false;
 
-		for (uindex_t i = 0; i < p_array.m_value_count; i++)
-			m_values[t_index + i] = MCValueRetain(p_array.m_values[i]);
+		for (uindex_t i = 0; i < p_array.Count(); i++)
+			m_values[m_value_count++] = MCValueRetain(p_array.m_values[i]);
 
 		return true;
 	}
     
     bool Push(T p_value)
     {
-        if (!Extend(m_value_count + 1))
+        if (!Ensure(1))
             return false;
-        m_values[m_value_count - 1] = MCValueRetain(p_value);
+        m_values[m_value_count++] = MCValueRetain(p_value);
         return true;
     }
 
@@ -364,6 +408,7 @@ public:
 private:
 	T* m_values;
     uindex_t m_value_count;
+    uindex_t m_capacity;
 };
 
 typedef MCAutoValueRefArrayBase<MCValueRef> MCAutoValueRefArray;

--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -580,6 +580,24 @@ inline codepoint_t MCUnicodeCombineSurrogates(unichar_t p_leading, unichar_t p_t
 	return 0x10000U + (((p_leading - 0xD800U) << 10) | (p_trailing - 0xDC00U));
 }
 
+inline bool MCUnicodeSplitIntoSurrogates(codepoint_t p_codepoint,
+                                         unichar_t& r_leading,
+                                         unichar_t& r_trailing)
+{
+    if (p_codepoint <= UNICHAR_MAX)
+    {
+        r_leading = p_codepoint & 0xFFFF;
+        r_trailing = 0;
+        return false;
+    }
+    
+    p_codepoint -= 0x10000;
+    r_leading = 0xD800 + (p_codepoint >> 10);
+    r_trailing = 0xDC00 + (p_codepoint & 0x3FF);
+    
+    return true;
+}
+
 // Compute and advance the current surrogate pair (used by MCUnicodeCodepointAdvance to
 // help the compiler make good choices about inlining - effectively a 'trap' to a very
 // rare case).

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1314,11 +1314,21 @@ MC_DLLEXPORT hash_t MCHashPointer(void *p);
 
 // Returns a hash value for the given sequence of bytes.
 MC_DLLEXPORT hash_t MCHashBytes(const void *bytes, size_t byte_count);
-
+    
 // Returns a hash value for the given sequence of bytes, continuing a previous
 // hashing sequence (byte_count should be a multiple of 4).
 MC_DLLEXPORT hash_t MCHashBytesStream(hash_t previous, const void *bytes, size_t byte_count);
 
+// Returns a hash value for the given sequence of native chars. The chars are
+// folded before being processed.
+MC_DLLEXPORT hash_t MCHashNativeChars(const char_t *chars,
+                                      size_t char_count);
+    
+// Returns a hash value for the given sequence of code units. The chars are
+// normalized and folded before being processed.
+MC_DLLEXPORT hash_t MCHashChars(const unichar_t *chars,
+                                size_t char_count);
+    
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1867,6 +1867,9 @@ MC_DLLEXPORT bool MCNumberIsReal(MCNumberRef number);
 MC_DLLEXPORT integer_t MCNumberFetchAsInteger(MCNumberRef number);
 MC_DLLEXPORT uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef number);
 MC_DLLEXPORT real64_t MCNumberFetchAsReal(MCNumberRef number);
+    
+MC_DLLEXPORT bool MCNumberStrictFetchAsIndex(MCNumberRef number,
+                                             index_t& r_index);
 
 MC_DLLEXPORT bool MCNumberParseOffsetPartial(MCStringRef p_string, uindex_t offset, uindex_t &r_chars_used, MCNumberRef &r_number);
 
@@ -1897,12 +1900,17 @@ MC_DLLEXPORT bool MCNameCreate(MCStringRef string, MCNameRef& r_name);
 MC_DLLEXPORT bool MCNameCreateWithChars(const unichar_t *chars, uindex_t count, MCNameRef& r_name);
 // Create a name using native chars.
 MC_DLLEXPORT bool MCNameCreateWithNativeChars(const char_t *chars, uindex_t count, MCNameRef& r_name);
-
+// Create a name using an integral index.
+MC_DLLEXPORT bool MCNameCreateWithIndex(index_t index, MCNameRef& r_name);
+    
 // Create a name using the given string, releasing the original.
 MC_DLLEXPORT bool MCNameCreateAndRelease(MCStringRef string, MCNameRef& r_name);
 
 // Looks for an existing name matching the given string.
 MC_DLLEXPORT MCNameRef MCNameLookupCaseless(MCStringRef string);
+
+// Looks for an existing name matching the given index.
+MC_DLLEXPORT MCNameRef MCNameLookupIndex(index_t index);
 
 // Returns a unsigned integer which can be used to order a table for a binary
 // search.

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2322,6 +2322,7 @@ MC_DLLEXPORT hash_t MCStringHash(MCStringRef string, MCStringOptions options);
 // Returns true if the two strings are equal, processing as appropriate according
 // to options.
 MC_DLLEXPORT bool MCStringIsEqualTo(MCStringRef string, MCStringRef other, MCStringOptions options);
+MC_DLLEXPORT bool MCStringIsEqualToChars(MCStringRef string, const unichar_t *chars, uindex_t char_count, MCStringOptions options);
 MC_DLLEXPORT bool MCStringIsEqualToNativeChars(MCStringRef string, const char_t *chars, uindex_t char_count, MCStringOptions options);
 
 // Returns true if the substring is equal to the other, according to options

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1902,7 +1902,7 @@ MC_DLLEXPORT bool MCNameCreateWithNativeChars(const char_t *chars, uindex_t coun
 MC_DLLEXPORT bool MCNameCreateAndRelease(MCStringRef string, MCNameRef& r_name);
 
 // Looks for an existing name matching the given string.
-MC_DLLEXPORT MCNameRef MCNameLookup(MCStringRef string);
+MC_DLLEXPORT MCNameRef MCNameLookupCaseless(MCStringRef string);
 
 // Returns a unsigned integer which can be used to order a table for a binary
 // search.

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2708,6 +2708,11 @@ MC_DLLEXPORT bool MCArrayFetchValue(MCArrayRef array, bool case_sensitive, MCNam
 MC_DLLEXPORT bool MCArrayStoreValue(MCArrayRef array, bool case_sensitive, MCNameRef key, MCValueRef value);
 // Remove the given key from the array.
 MC_DLLEXPORT bool MCArrayRemoveValue(MCArrayRef array, bool case_sensitive, MCNameRef key);
+// Ensure that the given key is present in array, and return the pointer to its
+// slot. If the key was not present, the value in the slot will be kMCNull.
+// The returned pointer is only valid up until the next operation on array and
+// should be MCValueAssign'd to.
+MC_DLLEXPORT bool MCArrayMutateValue(MCArrayRef array, bool case_sensitive, MCNameRef key, MCValueRef*& r_value);
 
 // Fetches index i in the given (sequence) array.
 MC_DLLEXPORT bool MCArrayFetchValueAtIndex(MCArrayRef array, index_t index, MCValueRef& r_value);

--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -612,14 +612,15 @@ bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_va
 {
 	__MCAssertIsArray(self);
 
-	char t_index_str[16];
-	sprintf(t_index_str, "%d", p_index);
+    MCNameRef t_key =
+            MCNameLookupIndex(p_index);
+    
+    if (t_key == nil)
+    {
+        return false;
+    }
 
-	MCNewAutoNameRef t_key;
-	if (!MCNameCreateWithNativeChars((const char_t *)t_index_str, strlen(t_index_str), &t_key))
-		return false;
-
-	return MCArrayFetchValue(self, true, *t_key, r_value);
+	return MCArrayFetchValue(self, true, t_key, r_value);
 }
 
 MC_DLLEXPORT_DEF
@@ -627,27 +628,30 @@ bool MCArrayStoreValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef p_val
 {
 	__MCAssertIsArray(self);
 
-	char t_index_str[16];
-	sprintf(t_index_str, "%d", p_index);
-
 	MCNewAutoNameRef t_key;
-	if (!MCNameCreateWithNativeChars((const char_t *)t_index_str, strlen(t_index_str), &t_key))
+	if (!MCNameCreateWithIndex(p_index,
+                               &t_key))
+    {
 		return false;
-
+    }
+    
 	return MCArrayStoreValue(self, true, *t_key, p_value);
 }
 
 bool
 MCArrayRemoveValueAtIndex(MCArrayRef self, index_t p_index)
 {
-	char t_index_str[16];
-	sprintf(t_index_str, "%d", p_index);
-	MCNewAutoNameRef t_key;
-	if (!MCNameCreateWithNativeChars((const char_t *)t_index_str,
-									 strlen(t_index_str),
-									 &t_key))
-		return false;
-	return MCArrayRemoveValue(self, true, *t_key);
+    __MCAssertIsArray(self);
+    
+    MCNameRef t_key =
+            MCNameLookupIndex(p_index);
+    
+    if (t_key == nil)
+    {
+        return true;
+    }
+
+	return MCArrayRemoveValue(self, true, t_key);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -18,6 +18,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <foundation-stdlib.h>
 
 #include "foundation-private.h"
+#include "foundation-hash.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -206,131 +207,69 @@ void MCMemoryDeleteArray(void *p_array)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// These hash functions are taken from CoreFoundation - if they are good enough
-// for Apple, they should be good enough for us :)
-
-#define HASHFACTOR 2654435761U
-
-/* Templates for hashing arbitrary-sized integers */
-template <typename T>
-static inline hash_t
-MCHashUInt(T i)
-{
-	hash_t h = 0;
-	for (unsigned int o = 0; o < sizeof(T); o += sizeof(hash_t))
-		h += HASHFACTOR * (hash_t) (i >> (o << 3));
-	return h;
-}
-
-template <typename T>
-static inline hash_t
-MCHashInt(T i)
-{
-	return MCHashUInt((i >= 0) ? i : (-i));
-}
-
 MC_DLLEXPORT_DEF
 hash_t MCHashInteger(integer_t i)
 {
-	return MCHashInt (i);
+	return __MCHashInt (i);
 }
 
 MC_DLLEXPORT_DEF
 hash_t
 MCHashUInteger (uinteger_t i)
 {
-	return MCHashUInt(i);
+	return __MCHashUInt(i);
 }
 
 MC_DLLEXPORT_DEF
 hash_t
 MCHashSize (ssize_t i)
 {
-	return MCHashInt (i);
+	return __MCHashInt (i);
 }
 
 hash_t
 MCHashUSize (size_t i)
 {
-	return MCHashUInt (i);
+	return __MCHashUInt (i);
 }
 
 MC_DLLEXPORT_DEF
 hash_t MCHashPointer(void *p)
 {
-	return MCHashUInt((uintptr_t) p);
+	return __MCHashUInt((uintptr_t) p);
 }
 
 MC_DLLEXPORT_DEF
 hash_t MCHashDouble(double d)
 {
-	double i;
-	if (d < 0)
-		d = -d;
-	i = floor(d + 0.5);
-	
-	hash_t t_integral_hash;
-	t_integral_hash = HASHFACTOR * (hash_t)fmod(i, (double)UINT32_MAX);
-
-	return (hash_t)(t_integral_hash + (hash_t)((d - i) * UINT32_MAX));
-}
-
-#define ELF_STEP(B) T1 = (H << 4) + B; T2 = T1 & 0xF0000000; if (T2) T1 ^= (T2 >> 24); T1 &= (~T2); H = T1;
-
-MC_DLLEXPORT_DEF
-hash_t MCHashBytes(const void *p_bytes, size_t length)
-{
-	MCAssert(nil != p_bytes || 0 == length);
-
-	uint8_t *bytes = (uint8_t *)p_bytes;
-
-    /* The ELF hash algorithm, used in the ELF object file format */
-    uint32_t H = 0, T1, T2;
-    int32_t rem = length;
-
-    while (3 < rem)
-	{
-		ELF_STEP(bytes[length - rem]);
-		ELF_STEP(bytes[length - rem + 1]);
-		ELF_STEP(bytes[length - rem + 2]);
-		ELF_STEP(bytes[length - rem + 3]);
-		rem -= 4;
-    }
-
-    switch (rem)
-	{
-    case 3:  ELF_STEP(bytes[length - 3]);
-    case 2:  ELF_STEP(bytes[length - 2]);
-    case 1:  ELF_STEP(bytes[length - 1]);
-    case 0:  ;
-    }
-
-    return H;
+    return __MCHashFlt(d);
 }
 
 MC_DLLEXPORT_DEF
-hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t length)
+hash_t MCHashBytes(const void *p_bytes, size_t p_length)
 {
-	MCAssert(p_bytes != nil || length == 0);
-    MCAssert((length % 4) == 0);
-    uint8_t *bytes = (uint8_t *)p_bytes;
+    MCAssert(nil != p_bytes || 0 == p_length);
+
+    __MCHashBytesContext t_hash;
+    t_hash.Consume(reinterpret_cast<const byte_t *>(p_bytes),
+                   p_length);
     
-    /* The ELF hash algorithm, used in the ELF object file format */
-    uint32_t H = p_start, T1, T2;
-    int32_t rem = length;
-    
-    while (3 < rem)
-	{
-		ELF_STEP(bytes[length - rem]);
-		ELF_STEP(bytes[length - rem + 1]);
-		ELF_STEP(bytes[length - rem + 2]);
-		ELF_STEP(bytes[length - rem + 3]);
-		rem -= 4;
-    }
-    
-    return H;
+    return t_hash.Current();
 }
 
-#undef ELF_STEP
+MC_DLLEXPORT_DEF
+hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t p_length)
+{
+	MCAssert(p_bytes != nil || 0 == p_length);
+    
+    __MCHashBytesContext t_hash(p_start);
+    t_hash.Consume(reinterpret_cast<const byte_t *>(p_bytes),
+                   p_length);
+    
+    return t_hash.Current();
+}
+
+// Note: MCHashNativeChars is implemented in foundation-string-native.cpp.h
+// Note: MCHashChars is implemented in foundation-unicode.cpp
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-hash.h
+++ b/libfoundation/src/foundation-hash.h
@@ -1,0 +1,244 @@
+/* Copyright (C) 2003-2017 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef __MC_FOUNDATION_HASH__
+#define __MC_FOUNDATION_HASH__
+
+#include <cmath>
+
+#include "foundation-unicode.h"
+
+////////////////////////////////////////////////////////////////////////////////
+
+// These hash functions are taken from CoreFoundation - if they are good enough
+// for Apple, they should be good enough for us :)
+
+#define HASHFACTOR 2654435761U
+
+// Hash an arbitrary sized UInt - the hash code generated is independent on the
+// number of bytes representing the integer.
+template <typename T>
+static inline hash_t
+__MCHashUInt(T i)
+{
+    hash_t h = 0;
+    for (unsigned int o = 0; o < sizeof(T); o += sizeof(hash_t))
+        h += HASHFACTOR * (hash_t) (i >> (o << 3));
+    return h;
+}
+
+// Hash an arbitrary sized Int - the hash code generated is independent on the
+// number of bytes representing the integer.
+template <typename T>
+static inline hash_t
+__MCHashInt(T i)
+{
+    return __MCHashUInt((i >= 0) ? i : (-i));
+}
+
+// Hash a floating point value - the hash code generated is independent of the
+// number of bytes representing the value and if the value is an integer it will
+// be the same as using __MCHashInt.
+template <typename T>
+static inline hash_t
+__MCHashFlt(T d)
+{
+    if (d < 0)
+        d = -d;
+    
+    double i;
+    i = std::floor(d + 0.5);
+    
+    hash_t t_integral_hash;
+    t_integral_hash = HASHFACTOR * (hash_t)std::fmod(i, UINT32_MAX);
+    
+    return (hash_t)(t_integral_hash + (hash_t)((d - i) * UINT32_MAX));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Hash an arbitrary sequence of bytes.
+class __MCHashBytesContext
+{
+private:
+    void Step(byte_t p_byte)
+    {
+        uint32_t T1, T2;
+        T1 = (m_hash << 4) + p_byte;
+        T2 = T1 & 0xF0000000;
+        if (T2)
+        {
+            T1 ^= (T2 >> 24);
+        }
+        T1 &= ~T2;
+        m_hash = T1;
+    }
+    
+public:
+    // Default constructor for hashing a sequence of bytes from the start.
+    __MCHashBytesContext(void)
+        : m_hash(0)
+    {
+    }
+    
+    // Constructor for continuing a hash of a sequence of bytes.
+    __MCHashBytesContext(hash_t p_initial_hash)
+        : m_hash(p_initial_hash)
+    {
+    }
+    
+    // Reset hashing to an initial value.
+    void Reset(hash_t p_initial_hash = 0)
+    {
+        m_hash = p_initial_hash;
+    }
+    
+    // Hash a further p_length bytes.
+    void Consume(const byte_t *p_bytes,
+                 size_t p_length)
+    {
+        while(3 < p_length)
+        {
+            Step(*p_bytes++);
+            Step(*p_bytes++);
+            Step(*p_bytes++);
+            Step(*p_bytes++);
+            p_length -= 4;
+        }
+        
+        switch(p_length)
+        {
+            case 3: Step(*p_bytes++);
+            case 2: Step(*p_bytes++);
+            case 1: Step(*p_bytes++);
+            case 0: ;
+        }
+    }
+    
+    // Return the hash of all bytes processed so far.
+    hash_t Current(void) const
+    {
+        return m_hash;
+    }
+
+private:
+    hash_t m_hash;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Hash an arbitrary sequence of chars - it uses the Fowler-Noll-Vo 1a hash
+// function.
+//
+// Note: This hashes the incoming chars exactly, and assumes that Unicode
+// encoding is being used.
+//
+class __MCHashCharContext
+{
+private:
+#ifdef __LARGE__
+    // 64-bit variant
+    const uint64_t kPrime = 1099511628211ULL;
+    const uint64_t kOffset = 14695981039346656037ULL;
+#else
+    // 32-bit variant
+    const uint32_t kPrime = 16777619UL;
+    const uint32_t kOffset = 2166136261UL;
+#endif
+    
+    // Perform a single step for a unicode code unit representable as a single
+    // byte.
+    void StepHalf(uint8_t p_char)
+    {
+        // Hash the byte
+        m_hash ^= p_char;
+        m_hash *= kPrime;
+        m_hash *= kPrime;
+    }
+    
+    // Perform a single step for a unicode code unit.
+    void StepFull(uint16_t p_char)
+    {
+        // Hash the byte
+        m_hash ^= p_char & 0xFF;
+        m_hash *= kPrime;
+        
+        // Hash the second byte of the unichar
+        m_hash ^= p_char >> 8;
+        m_hash *= kPrime;
+    }
+    
+public:
+    // Default constructor for hashing a sequence of bytes from the start.
+    __MCHashCharContext(void)
+        : m_hash(kOffset)
+    {
+    }
+    
+    // Constructor for continuing a hash of a sequence of bytes.
+    __MCHashCharContext(hash_t p_initial_hash)
+        : m_hash(p_initial_hash)
+    {
+    }
+    
+    // Reset hashing to an initial value.
+    void Reset(hash_t p_initial_hash = 0)
+    {
+        m_hash = p_initial_hash;
+    }
+
+    // Hash a single code unit which fits in a byte
+    void ConsumeHalfChar(char_t p_char)
+    {
+        StepHalf(reinterpret_cast<uint8_t>(p_char));
+    }
+    
+    // Hash a single code unit
+    void ConsumeChar(unichar_t p_char)
+    {
+        StepFull(reinterpret_cast<uint16_t>(p_char));
+    }
+    
+    // Hash a single codepoint
+    void ConsumeCodepoint(codepoint_t p_codepoint)
+    {
+        unichar_t t_lead, t_trail;
+        if (!MCUnicodeSplitIntoSurrogates(p_codepoint,
+                                          t_lead,
+                                          t_trail))
+        {
+            StepFull(reinterpret_cast<uint16_t>(t_lead));
+        }
+        else
+        {
+            StepFull(reinterpret_cast<uint16_t>(t_lead));
+            StepFull(reinterpret_cast<uint16_t>(t_trail));
+        }
+    }
+    
+    // Return the hash of all bytes processed so far.
+    hash_t Current(void) const
+    {
+        return m_hash;
+    }
+    
+private:
+    hash_t m_hash;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+#endif

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -206,7 +206,7 @@ bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
 }
 
 MC_DLLEXPORT_DEF
-MCNameRef MCNameLookup(MCStringRef p_string)
+MCNameRef MCNameLookupCaseless(MCStringRef p_string)
 {
 	// Compute the hash of the characters, up to case.
 	hash_t t_hash;

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -17,6 +17,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <foundation.h>
 
 #include "foundation-private.h"
+#include "foundation-span.h"
+#include "foundation-hash.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -56,142 +58,440 @@ MCNameRef MCNAME(const char *p_string)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// This class is a generic implementation of the algorithm used to search the
+// name table for a given key, and then create it if required.
+//
+// It is parameterized by an Input class which must have the following methods:
+//
+//   1) IsEmpty() - should return true if the input is the empty string
+//   2) IsEquivalentTo(other) - should return true if the input lies in the same
+//      (caseless) equivalence class as other.
+//   3) IsEqualTo(other) - should return true if the input is identical to
+//      other.
+//   4) Copy(&string) - return a copy of the input as a string ref for use in
+//      constructing the new name.
+//   5) Hash() - return the hash of the input.
+//
+// The LookupCaseless method can be used to check to see if a name is already in
+// the table. This method returns the representative up to caseless equivalence
+// for the given input if it is present in the table, or nil otherwise.
+//
+// The Create method can be used to ensure the given input exists as an exact
+// name. This method returns true if construction is successful, and returns a
+// copy of the new name as an out parameter.
+//
+template<typename Input>
+class __MCNameTableSearcher
+{
+public:
+    __MCNameTableSearcher(const Input& p_input)
+        : m_input(p_input),
+          m_hash(p_input.Hash())
+    {
+    }
+    
+    MCNameRef LookupCaseless(void) const
+    {
+        // If the input is the empty string, then make sure we return the existing
+        // empty name value.
+        if (m_input.IsEmpty() &&
+            kMCEmptyName != nil)
+        {
+            return kMCEmptyName;
+        }
+        
+        // Calculate the index of the chain in the name table where this might be
+        // found. The capacity is always a power-of-two, so its just a mask op.
+        uindex_t t_index =
+                m_hash & (s_name_table_capacity - 1);
+        
+        // Search for the first representation of the would-be name's equivalence
+        // class.
+        __MCName *t_key_name =
+                s_name_table[t_index];
+        while(t_key_name != nil)
+        {
+            // If the hash is the same, see if the input is equivalent to the
+            // key name in the current equivalence class.
+            if (m_hash == t_key_name->hash &&
+                m_input.IsEquivalentTo(t_key_name->string))
+                break;
+            
+            // Skip to the next equivalence class.
+            while(t_key_name->next != nil &&
+                  t_key_name->key == t_key_name->next->key)
+                t_key_name = t_key_name -> next;
+            
+            // Next name must be the next one.
+            t_key_name = t_key_name->next;
+        }
+
+        return t_key_name;
+    }
+    
+    bool Create(MCNameRef& r_name)
+    {
+        MCNameRef t_key_name =
+                LookupCaseless();
+        
+        // Search for the exact representative, if present and return it if found.
+        __MCName *t_name = nil;
+        for(t_name = t_key_name; t_name != nil && t_name -> key == t_key_name; t_name = t_name -> next)
+            if (m_input.IsEqualTo(t_name->string))
+            {
+                r_name = MCValueRetain(t_name);
+                return true;
+            }
+        
+        // An exact match was not found, so we must now create a new name.
+        
+        if (!__MCValueCreate(kMCValueTypeCodeName,
+                             t_name))
+        {
+            return false;
+        }
+        
+        if (!m_input.Copy(t_name->string))
+        {
+            MCMemoryDelete(t_name);
+            return false;
+        }
+        
+        // If there is no existing equivalence class, we chain at the start,
+        // otherwise we insert the name after the representative.
+        if (t_key_name == nil)
+        {
+            // To keep hashin efficient, we (try to) double the size of the
+            // table each time occupancy reaches capacity.
+            uindex_t t_index;
+            if (s_name_table_occupancy == s_name_table_capacity)
+            {
+                __MCNameGrowTable();
+            }
+            t_index = m_hash & (s_name_table_capacity - 1);
+            
+            // Increase occupancy.
+            s_name_table_occupancy += 1;
+            
+            t_name->next = s_name_table[t_index];
+            t_name->key = t_name;
+            s_name_table[t_index] = t_name;
+        }
+        else
+        {
+            t_name -> next = t_key_name -> next;
+            t_name -> key = t_key_name;
+            t_key_name -> next = t_name;
+            
+            // Increment the reference count of the representative as we need
+            // it to 'hang around' for the entire lifetime of all others in the
+            // equivalence class to give a search handle.
+            t_key_name -> references += 1;
+        }
+        
+        // Record the hash (speeds up searching and such).
+        t_name->hash = m_hash;
+        
+        // Return the new name.
+        r_name = t_name;
+        
+        return true;
+    }
+    
+private:
+    const Input& m_input;
+    const hash_t m_hash;
+};
+
+//////////
+
+// This comparator is used to search for a stringref in the name table. The
+// provided StringRef can be mutable or immutable, as it is Copied if the
+// name needs to be created.
+class __MCNameStringInput
+{
+public:
+    __MCNameStringInput(MCStringRef p_string)
+        : m_string(p_string)
+    {
+    }
+
+    bool IsEmpty(void) const
+    {
+        return m_string->char_count == 0;
+    }
+    
+    hash_t Hash(void) const
+    {
+        return MCStringHash(m_string,
+                            kMCStringOptionCompareCaseless);
+    }
+    
+    bool IsEquivalentTo(MCStringRef p_other_string) const
+    {
+        return MCStringIsEqualTo(m_string,
+                                 p_other_string,
+                                 kMCStringOptionCompareCaseless);
+    }
+    
+    bool IsEqualTo(MCStringRef p_other_string) const
+    {
+        return MCStringIsEqualTo(m_string,
+                                 p_other_string,
+                                 kMCStringOptionCompareExact);
+    }
+    
+    bool Copy(MCStringRef& r_copied_string) const
+    {
+        return MCStringCopy(m_string,
+                            r_copied_string);
+    }
+    
+private:
+    MCStringRef m_string;
+};
+
 MC_DLLEXPORT_DEF
 bool MCNameCreate(MCStringRef p_string, MCNameRef& r_name)
 {
 	__MCAssertIsString(p_string);
-
-	if (p_string -> char_count == 0 && kMCEmptyName != nil)
-	{
-		MCValueRetain(kMCEmptyName);
-		r_name = kMCEmptyName;
-		return true;
-	}
-
-	// Compute the has of the characters, up to case.
-	hash_t t_hash;
-	t_hash = MCStringHash(p_string, kMCStringOptionCompareCaseless);
-
-	// Calculate the index of the chain in the name table where this might be
-	// found. The capacity is always a power-of-two, so its just a mask op.
-	uindex_t t_index;
-	t_index = t_hash & (s_name_table_capacity - 1);
-
-	// Search for the first representation of the would-be name's equivalence
-	// class.
-	__MCName *t_key_name;
-	t_key_name = s_name_table[t_index];
-	while(t_key_name != nil)
-	{
-		// If the string matches, then we are done - notice we compare the
-		// full hash first.
-		if (t_hash == t_key_name -> hash &&
-			MCStringIsEqualTo(p_string, t_key_name -> string, kMCStringOptionCompareCaseless))
-			break;
-
-		// Otherwise skip all other members of the same equivalence class.
-		while(t_key_name -> next != nil &&
-				t_key_name -> key == t_key_name -> next -> key)
-			t_key_name = t_key_name -> next;
-
-		// Next name must be the next one.
-		t_key_name = t_key_name -> next;
-	}
-
-	// Now search within the equivalence class for one with the same string and
-	// return immediately if we find a match.
-	__MCName *t_name;
-	for(t_name = t_key_name; t_name != nil && t_name -> key == t_key_name; t_name = t_name -> next)
-		if (MCStringIsEqualTo(p_string, t_name -> string, kMCStringOptionCompareExact))
-		{
-			t_name -> references += 1;
-			r_name = t_name;
-			return true;
-		}
-
-	// We haven't found an exact match, so we create a new name...
-	bool t_success;
-	t_success = true;
-
-	// Allocate a name record.
-	if (t_success)
-		t_success = __MCValueCreate(kMCValueTypeCodeName, t_name);
-
-	// Copy the string (as immutable).
-	if (t_success)
-		t_success = MCStringCopy(p_string, t_name -> string);
-
-	// Now add the name to the table and fill in the rest of the fields.
-	if (t_success)
-	{
-		// If there is no existing equivalence class, we chain at the start,
-		// otherwise we insert the name after the representative.
-		if (t_key_name == nil)
-		{
-			// To keep hashin efficient, we (try to) double the size of the
-			// table each time occupancy reaches capacity.
-			if (s_name_table_occupancy == s_name_table_capacity)
-			{
-				__MCNameGrowTable();
-				t_index = t_hash & (s_name_table_capacity - 1);
-			}
-
-			// Increase occupancy.
-			s_name_table_occupancy += 1;
-
-			t_name -> next = s_name_table[t_index];
-			t_name -> key = t_name;
-			s_name_table[t_index] = t_name;
-		}
-		else
-		{
-			t_name -> next = t_key_name -> next;
-			t_name -> key = t_key_name;
-			t_key_name -> next = t_name;
-
-			// Increment the reference count of the representative as we need
-			// it to 'hang around' for the entire lifetime of all others in the
-			// equivalence class to give a search handle.
-			t_key_name -> references += 1;
-		}
-
-		// Record the hash (speeds up searching and such).
-		t_name -> hash = t_hash;
-
-		// Return the new name.
-		r_name = t_name;
-	}
-	else
-	{
-		MCValueRelease(t_name -> string);
-		MCMemoryDelete(t_name);
-	}
-
-	return t_success;
+    
+    return __MCNameTableSearcher<__MCNameStringInput>(p_string).Create(r_name);
 }
+
+//////////
+
+// This comparator is used to search for native string in the name table.
+class __MCNameNativeCharsInput
+{
+public:
+    __MCNameNativeCharsInput(MCSpan<const char_t> p_native_chars)
+        : m_native_chars(p_native_chars)
+    {
+    }
+    
+    bool IsEmpty(void) const
+    {
+        return m_native_chars.length() == 0;
+    }
+    
+    hash_t Hash(void) const
+    {
+        return MCHashNativeChars(m_native_chars.data(),
+                                 m_native_chars.length());
+    }
+    
+    bool IsEquivalentTo(MCStringRef p_other_string) const
+    {
+        return MCStringIsEqualToNativeChars(p_other_string,
+                                            m_native_chars.data(),
+                                            m_native_chars.length(),
+                                            kMCStringOptionCompareCaseless);
+    }
+    
+    bool IsEqualTo(MCStringRef p_other_string) const
+    {
+        return MCStringIsEqualToNativeChars(p_other_string,
+                                            m_native_chars.data(),
+                                            m_native_chars.length(),
+                                            kMCStringOptionCompareExact);
+    }
+    
+    bool Copy(MCStringRef& r_copied_string) const
+    {
+        return MCStringCreateWithNativeChars(m_native_chars.data(),
+                                             m_native_chars.length(),
+                                             r_copied_string);
+    }
+    
+private:
+    MCSpan<const char_t> m_native_chars;
+};
 
 MC_DLLEXPORT_DEF
 bool MCNameCreateWithNativeChars(const char_t *p_chars, uindex_t p_count, MCNameRef& r_name)
 {
-	MCStringRef t_string;
-	if (!MCStringCreateWithNativeChars(p_chars, p_count, t_string))
-		return false;
-	if (!MCNameCreateAndRelease(t_string, r_name))
-	{
-		MCValueRelease(t_string);
-		return false;
-	}
-	return true;
+    return __MCNameTableSearcher<__MCNameNativeCharsInput>(MCMakeSpan(p_chars,
+                                                                      p_count)).Create(r_name);
 }
+
+//////////
+
+// This comparator is used to search for native string in the name table.
+class __MCNameCharsInput
+{
+public:
+    __MCNameCharsInput(MCSpan<const unichar_t> p_chars)
+        : m_chars(p_chars)
+    {
+    }
+    
+    bool IsEmpty(void) const
+    {
+        return m_chars.length() == 0;
+    }
+    
+    hash_t Hash(void) const
+    {
+        return MCHashChars(m_chars.data(),
+                           m_chars.length());
+    }
+    
+    bool IsEquivalentTo(MCStringRef p_other_string) const
+    {
+        return MCStringIsEqualToChars(p_other_string,
+                                      m_chars.data(),
+                                      m_chars.length(),
+                                      kMCStringOptionCompareCaseless);
+    }
+    
+    bool IsEqualTo(MCStringRef p_other_string) const
+    {
+        return MCStringIsEqualToChars(p_other_string,
+                                      m_chars.data(),
+                                      m_chars.length(),
+                                      kMCStringOptionCompareExact);
+    }
+    
+    bool Copy(MCStringRef& r_copied_string) const
+    {
+        return MCStringCreateWithChars(m_chars.data(),
+                                       m_chars.length(),
+                                       r_copied_string);
+    }
+    
+private:
+    MCSpan<const unichar_t> m_chars;
+};
 
 MC_DLLEXPORT_DEF
 bool MCNameCreateWithChars(const unichar_t *p_chars, uindex_t p_count, MCNameRef& r_name)
 {
-	MCStringRef t_string;
-	if (!MCStringCreateWithChars(p_chars, p_count, t_string))
-		return false;
-	return MCNameCreateAndRelease(t_string, r_name);
+    return __MCNameTableSearcher<__MCNameCharsInput>(MCMakeSpan(p_chars,
+                                                                p_count)).Create(r_name);
 }
+
+//////////
+
+class __MCNameIndexInput
+{
+public:
+    __MCNameIndexInput(index_t p_index)
+        : m_char_count(0)
+    {
+        IndexToString(p_index);
+    }
+    
+    bool IsEmpty(void) const
+    {
+        return false;
+    }
+    
+    hash_t Hash(void) const
+    {
+        __MCHashCharContext t_context;
+        for(uindex_t i = 0; i < m_char_count; i++)
+            t_context.ConsumeHalfChar(m_chars[i]);
+        return t_context.Current();
+    }
+    
+    bool IsEquivalentTo(MCStringRef p_other_string) const
+    {
+        return MCStringIsEqualToNativeChars(p_other_string,
+                                            m_chars,
+                                            m_char_count,
+                                            kMCStringOptionCompareCaseless);
+    }
+    
+    // As equivalence => equality for index strings, this is always true.
+    bool IsEqualTo(MCStringRef p_other_string) const
+    {
+        return true;
+    }
+    
+    bool Copy(MCStringRef& r_copied_string) const
+    {
+        return MCStringCreateWithNativeChars(m_chars,
+                                             m_char_count,
+                                             r_copied_string);
+    }
+    
+private:
+    char_t m_chars[16];
+    uindex_t m_char_count;
+    
+    static uindex_t CountDigits(index_t p_index)
+    {
+        uint32_t t_count = 1;
+        for (;;) {
+            if (p_index < 10) return t_count;
+            if (p_index < 100) return t_count + 1;
+            if (p_index < 1000) return t_count + 2;
+            if (p_index < 10000) return t_count + 3;
+            p_index /= 10000U;
+            t_count += 4;
+        }
+        return t_count;
+    }
+    
+    void IndexToString(index_t p_value)
+    {
+        static const char kDigits[201] =
+            "0001020304050607080910111213141516171819"
+            "2021222324252627282930313233343536373839"
+            "4041424344454647484950515253545556575859"
+            "6061626364656667686970717273747576777879"
+            "8081828384858687888990919293949596979899";
+        
+        if (p_value < 0)
+        {
+            m_chars[m_char_count++] = '-';
+            p_value = -p_value;
+        }
+        
+        uindex_t t_length =
+                CountDigits(p_value);
+        
+        m_char_count += t_length;
+        
+        uindex_t t_next =
+                m_char_count - 1;
+        
+        while(p_value >= 100)
+        {
+            index_t t_offset =
+                (p_value % 100) * 2;
+            p_value /= 100;
+            
+            m_chars[t_next] = kDigits[t_offset + 1];
+            m_chars[t_next - 1] = kDigits[t_offset];
+            
+            t_next -= 2;
+        }
+        
+        if (p_value < 10)
+        {
+            m_chars[t_next] = '0' + p_value;
+        }
+        else
+        {
+            index_t t_offset =
+                    p_value * 2;
+            
+            m_chars[t_next] = kDigits[t_offset + 1];
+            m_chars[t_next - 1] = kDigits[t_offset];
+        }
+    }
+};
+
+MC_DLLEXPORT_DEF
+bool MCNameCreateWithIndex(index_t p_index,
+                           MCNameRef& r_name)
+{
+    return __MCNameTableSearcher<__MCNameIndexInput>(p_index).Create(r_name);
+}
+
+//////////
 
 MC_DLLEXPORT_DEF
 bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
@@ -205,39 +505,23 @@ bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
 	return false;
 }
 
+//////////
+
 MC_DLLEXPORT_DEF
 MCNameRef MCNameLookupCaseless(MCStringRef p_string)
 {
-	// Compute the hash of the characters, up to case.
-	hash_t t_hash;
-	t_hash = MCStringHash(p_string, kMCStringOptionCompareCaseless);
-
-	// Calculate the index of the chain in the name table where this name might
-	// be found. The capacity is always a power-of-two, so its just a mask op.
-	uindex_t t_index;
-	t_index = t_hash & (s_name_table_capacity - 1);
-
-	// Search for the first representative of the would-be name's equivalence class.
-	__MCName *t_key_name;
-	t_key_name = s_name_table[t_index];
-	while(t_key_name != nil)
-	{
-		// If the string matches, then we are done - notice we compare the full
-		// hash first.
-		if (t_hash == t_key_name -> hash &&
-			MCStringIsEqualTo(p_string, t_key_name -> string, kMCStringOptionCompareCaseless))
-			break;
-
-		// Otherwise skip all other members of the same equivalence class.
-		while(t_key_name -> next != nil && t_key_name -> key == t_key_name -> next -> key)
-			t_key_name = t_key_name -> next;
-
-		// Next name must be the next one
-		t_key_name = t_key_name -> next;
-	}
-
-	return t_key_name;
+    __MCAssertIsString(p_string);
+    
+    return __MCNameTableSearcher<__MCNameStringInput>(p_string).LookupCaseless();
 }
+
+MC_DLLEXPORT_DEF
+MCNameRef MCNameLookupIndex(index_t p_index)
+{
+    return __MCNameTableSearcher<__MCNameIndexInput>(p_index).LookupCaseless();
+}
+
+//////////
 
 MC_DLLEXPORT_DEF
 uintptr_t MCNameGetCaselessSearchKey(MCNameRef self)

--- a/libfoundation/src/foundation-number.cpp
+++ b/libfoundation/src/foundation-number.cpp
@@ -99,6 +99,28 @@ uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef self)
 	return self -> real >= 0.0 ? (uinteger_t)(self -> real + 0.5) : (uinteger_t)0.0;
 }
 
+MC_DLLEXPORT_DEF
+bool MCNumberStrictFetchAsIndex(MCNumberRef self,
+                                index_t& r_index)
+{
+    MCStaticAssert(sizeof(index_t) == sizeof(integer_t));
+    
+    if (MCNumberIsInteger(self))
+    {
+        r_index = self->integer;
+        return true;
+    }
+    
+    index_t t_as_int = (index_t)(self -> real);
+    if (self->real - t_as_int != 0.0)
+    {
+        return false;
+    }
+    
+    r_index = t_as_int;
+    return true;
+}
+
 compare_t MCNumberCompareTo(MCNumberRef self, MCNumberRef p_other_self)
 {
 	// First determine the storage types of both numbers.

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -2988,6 +2988,32 @@ bool MCStringIsEqualToNativeChars(MCStringRef self, const char_t *p_chars, uinde
 }
 
 MC_DLLEXPORT_DEF
+bool MCStringIsEqualToChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_char_count, MCStringOptions p_options)
+{
+    __MCAssertIsString(self);
+    MCAssert(nil != p_chars);
+    
+    if (__MCStringIsIndirect(self))
+        self = self -> string;
+    
+    bool self_native = __MCStringIsNative(self);
+    
+    const void *self_chars;
+    if (self_native)
+        self_chars = self -> native_chars;
+    else
+        self_chars = self -> chars;
+    
+    return MCUnicodeCompare(self_chars,
+                            self->char_count,
+                            self_native,
+                            p_chars,
+                            p_char_count,
+                            false,
+                            (MCUnicodeCompareOption)p_options) == 0;
+}
+
+MC_DLLEXPORT_DEF
 compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
 	__MCAssertIsString(self);

--- a/tests/lcs/core/control/variable.livecodescript
+++ b/tests/lcs/core/control/variable.livecodescript
@@ -1,0 +1,204 @@
+script "CoreControlVariable"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestFetchLocal
+   local tVar, tIndex
+
+   put empty into tVar
+   put 100 into tVar
+   TestAssert "local direct access", tVar is 100
+
+   put empty into tVar
+   put 100 into tVar["one"]
+   TestAssert "local indirect name - depth 1", tVar["one"] is 100
+
+   put empty into tVar
+   put 100 into tVar["one"]["one"]
+   TestAssert "local indirect name - depth 2", tVar["one"]["one"] is 100
+
+   put empty into tVar
+   put 100 into tVar[1+0]
+   TestAssert "local indirect number - depth 1", tVar[1+0] is 100
+
+   put empty into tVar
+   put 100 into tVar[1+0][1+0]
+   TestAssert "local indirect number - depth 2", tVar[1+0][1+0] is 100
+
+   put empty into tIndex
+   put 1+0 into tIndex[1+0]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "local indirect number array - depth 1", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put 1+0 into tIndex[1+0]
+   put 1+0 into tIndex[2+0]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "local indirect number array - depth 2", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "one" into tIndex[1+0]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "local indirect name array - depth 1", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "one" into tIndex[1+0]
+   put "one" into tIndex[2+0]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "local indirect name array - depth 2", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put 1+0 into tIndex[1]
+   put "one" into tIndex[2]
+   put empty into tVar
+   put 100 into tVar[1][tIndex]["one"]
+   TestAssert "local indirect mixed - depth 4", tVar[1+0][tIndex]["one"] is 100
+end TestFetchLocal
+
+private command DoTestFetchParam tVar
+   local tIndex
+
+   put empty into tVar
+   put 100 into tVar
+   TestAssert "param direct access", tVar is 100
+
+   put empty into tVar
+   put 100 into tVar["one"]
+   TestAssert "param indirect name - depth 1", tVar["one"] is 100
+
+   put empty into tVar
+   put 100 into tVar["one"]["one"]
+   TestAssert "param indirect name - depth 2", tVar["one"]["one"] is 100
+
+   put empty into tVar
+   put 100 into tVar[1]
+   TestAssert "param indirect number - depth 1", tVar[1] is 100
+
+   put empty into tVar
+   put 100 into tVar[1][1]
+   TestAssert "param indirect number - depth 2", tVar[1][1] is 100
+
+   put empty into tIndex
+   put 1 into tIndex[1]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect number array - depth 1", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put 1 into tIndex[1]
+   put 1 into tIndex[2]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect number array - depth 2", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "one" into tIndex[1]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect name array - depth 1", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "one" into tIndex[1]
+   put "one" into tIndex[2]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect name array - depth 2", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "1" into tIndex[1]
+   put "one" into tIndex[2]
+   put empty into tVar
+   put 100 into tVar[1][tIndex]["one"]
+   TestAssert "param indirect mixed - depth 4", tVar[1][tIndex]["one"] is 100
+end DoTestFetchParam
+
+on TestFetchParam
+   local tParam
+   DoTestFetchParam tParam
+end TestFetchParam
+
+private command DoTestFetchRefParam @tVar
+   local tIndex
+
+   put empty into tVar
+   put 100 into tVar
+   TestAssert "param direct access", tVar is 100
+
+   put empty into tVar
+   put 100 into tVar["one"]
+   TestAssert "param indirect name - depth 1", tVar["one"] is 100
+
+   put empty into tVar
+   put 100 into tVar["one"]["one"]
+   TestAssert "param indirect name - depth 2", tVar["one"]["one"] is 100
+
+   put empty into tVar
+   put 100 into tVar[1]
+   TestAssert "param indirect number - depth 1", tVar[1] is 100
+
+   put empty into tVar
+   put 100 into tVar[1][1]
+   TestAssert "param indirect number - depth 2", tVar[1][1] is 100
+
+   put empty into tIndex
+   put 1 into tIndex[1]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect number array - depth 1", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put 1 into tIndex[1]
+   put 1 into tIndex[2]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect number array - depth 2", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "one" into tIndex[1]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect name array - depth 1", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "one" into tIndex[1]
+   put "one" into tIndex[2]
+   put empty into tVar
+   put 100 into tVar[tIndex]
+   TestAssert "param indirect name array - depth 2", tVar[tIndex] is 100
+
+   put empty into tIndex
+   put "1" into tIndex[1]
+   put "one" into tIndex[2]
+   put empty into tVar
+   put 100 into tVar[1][tIndex]["one"]
+   TestAssert "param indirect mixed - depth 4", tVar[1][tIndex]["one"] is 100
+end DoTestFetchRefParam
+
+on TestFetchRefParam
+   local tParam
+   DoTestFetchRefParam tParam
+end TestFetchRefParam
+
+on TestFetchScriptLocal
+end TestFetchScriptLocal
+
+on TestFetchGlobal
+end TestFetchGlobal


### PR DESCRIPTION
This is work-in-progress set of st-git patches which cleans up the implementation of variable access in the engine.

At present it includes the following:

- Basic (incomplete) tests and benchmarks
- Removal of some unused virtual methods from MCExpression (and descendants)
- Changes uses of MCContainer to be mostly allocated 'on stack'
- Moves all code to use just 'evalcontainer' which removes the 'evalvar' virtual method.
- Unifies various hashing code from different places
- Refactors code in MCName to do lookup and creation into a template based approach
- Adds optimized code paths for creating 'index' names (integers which fit into index_t)
- Ensures index name code paths are used when looking up array indices.
- Adds the idea of purity to MCExpression (a pure MCExpression is one which has no side effects)
- Uses templates to allow more efficient code paths for common MCVarref operations
- Implements 'pure' code paths for set(into), give_value(into), dofree() and eval_ctxt MCVarref operations

This patch provides a *substantial* speed up to variable manipulation operations. Indeed, indexing operations using strings or literals (names) are 2-3 times faster (both storing and fetching); whilst indexing operations using integers are 4 times faster (storing) and 7 times faster (fetching). (All timings compared against 9dp4).

Note: This additionally changes the external interfaces so that internally they act on a container, rather than a variable - this should mean that externals should now be able to correctly set variables which are references to array elements... Tests need to be added for the externals interfaces to ensure that nothing has broken!

Note: The 'before' and 'after' operations still need optimized codepaths to be implemented; this should be combined with a refactoring of the code which manipulates Data and String values in this way since it is currently spread out in several places and the semantics are not 100% clear.

Note: There remains a fault with case-sensitivity being remembered for reference parameters - they are currently evaluated with the caseSensitive of the callee, rather then when the path was evaluated in the caller.

Note: The 'pure' dofree() code path is currently broken (I thought it might be because it is creating nested arrays when not necessary, but changing that does not seem to fix things - the IDE won't run properly with that code path enabled).

Note: For some reason one of the matchText tests fails without ensuring 'clearuql()' is done in MCVariable::setvalueref. There must be a subtle change somewhere which means the 'v0' undeclared var in the test is *not* getting cleared whereas it did before.