### PR TITLE
[[ Bug 19065 ]] Fix error message when an incorrect call is made

### DIFF
--- a/docs/notes/bugfix-19065.md
+++ b/docs/notes/bugfix-19065.md
@@ -1,0 +1,2 @@
+# Improve error reporting for calling LCB library handlers
+

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -443,8 +443,16 @@ Exec_stat MCEngineHandleLibraryMessage(MCNameRef p_message, MCParameter *p_param
         t_param = t_param -> getnext();
     }
 	
+    // If the above looped failed with t_success == false, then a type
+    // conversion error occurred.
+    if (!t_success)
+    {
+        MCECptr->LegacyThrow(EE_INVOKE_TYPEERROR);
+    }
+    
 	// Too many parameters error.
-	if (t_param != nil)
+	if (t_success &&
+        t_param != nil)
 	{
 		MCECptr -> LegacyThrow(EE_INVOKE_TOOMANYARGS);
 		t_success = false;

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2733,7 +2733,10 @@ enum Exec_errors
 	EE_EXTENSION_ERROR_COLUMN,
 	
 	// {EE-0895} parentScript: can't change parent while parent script is executing
-	EE_PARENTSCRIPT_EXECUTING,
+    EE_PARENTSCRIPT_EXECUTING,
+    
+    // {EE-0896} call: type conversion error
+    EE_INVOKE_TYPEERROR,
 };
 
 extern const char *MCexecutionerrors;

--- a/tests/lcs/core/engine/_extension.lcb
+++ b/tests/lcs/core/engine/_extension.lcb
@@ -26,6 +26,9 @@ public handler TestExtensionBridgeArrays_EmptyToEmptyList(in pList as List) retu
 	return pList is the empty list
 end handler
 
+public handler TestExtensionLibraryHandler(in pValue as Number)
+end handler
+
 public handler TestExtensionSupportModule_Handler()
 	return SupportHandler() is "support handler"
 end handler

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -130,3 +130,34 @@ on TestMultiModuleExtensions
    TestAssert "can't load multi-module extensions with bad module names", \
          the result is not empty
 end TestMultiModuleExtensions
+
+//////////
+
+command CallLibraryHandlerWithString
+   get TestExtensionLibraryHandler("foobar")
+end CallLibraryHandlerWithString
+
+command CallLibraryHandlerWithTooFewParams
+   get TestExtensionLibraryHandler()
+end CallLibraryHandlerWithTooFewParams
+
+command CallLibraryHandlerWithTooManyParams
+   get TestExtensionLibraryHandler(1, 2)
+end CallLibraryHandlerWithTooManyParams
+
+on TestExtensionLibraryHandlerCallErrors
+   TestAssertThrow "library handler call throws correct error on type error", \
+         "CallLibraryHandlerWithString", \
+         the long id of me, \
+         896
+
+   TestAssertThrow "library handler call throws correct error on too few args error", \
+         "CallLibraryHandlerWithTooFewParams", \
+         the long id of me, \
+         885
+
+   TestAssertThrow "library handler call throws correct error on too many args error", \
+         "CallLibraryHandlerWithTooManyParams", \
+         the long id of me, \
+         886
+end TestExtensionLibraryHandlerCallErrors


### PR DESCRIPTION
This patch ensures that the correct error message is thrown when
calling an LCB library handler incorrectly. The error can be
one of:

- too few arguments
- too many arguments
- argument type conversion error