### PR TITLE
[CID 16621][CID 15762] revxml: Fix attribute-related defects

### DIFF
--- a/revxml/src/revxml.cpp
+++ b/revxml/src/revxml.cpp
@@ -2182,7 +2182,7 @@ void XML_FindElementByAttributeValue(char *args[], int nargs, char **retstring, 
 						else
 							t_comparison_result = util_strnicmp(attvalue, tvalue, strlen(tvalue));
                         
-                        delete tvalue;
+                        free(tvalue);
                         
                         if (t_comparison_result == 0)
                         {

--- a/revxml/src/revxml.cpp
+++ b/revxml/src/revxml.cpp
@@ -2096,6 +2096,7 @@ void XML_ListByAttributeValue(char *args[], int nargs, char **retstring,
 						if (attributevalue){
 							util_concatstring(attributevalue, strlen(attributevalue), 
 							result, buflen , bufsize);
+                            free(attributevalue);
 						}
 						util_concatstring(itemsep, itemseplen,result, buflen , bufsize);
 				}

--- a/revxml/src/revxml.cpp
+++ b/revxml/src/revxml.cpp
@@ -2091,14 +2091,18 @@ void XML_ListByAttributeValue(char *args[], int nargs, char **retstring,
 				CXMLElementEnumerator tenum(&telement,maxdepth);
 				while (tenum.Next(childfilter))
 				{
-					CXMLElement *curelement = tenum.GetElement();
-						char *attributevalue = curelement->GetAttributeValue(attname, True);
+                    if (attname != nullptr)
+                    {
+                        char *attributevalue =
+                            tenum.GetElement()->GetAttributeValue(attname, True);
+
 						if (attributevalue){
 							util_concatstring(attributevalue, strlen(attributevalue), 
 							result, buflen , bufsize);
                             free(attributevalue);
 						}
-						util_concatstring(itemsep, itemseplen,result, buflen , bufsize);
+                    }
+                    util_concatstring(itemsep, itemseplen,result, buflen , bufsize);
 				}
 				if (buflen)
 					result[buflen-itemseplen] = '\0'; //strip trailing item seperator


### PR DESCRIPTION
- Fix a memory leak and a possible null dereference in `XML_ListByAttributeValue()`
- Use correct deallocator for attribute values