### PR TITLE
[Bug 19121] Pass correct folder to standaloneSaved msg

### DIFF
--- a/docs/notes/bugfix-19121.md
+++ b/docs/notes/bugfix-19121.md
@@ -1,0 +1,1 @@
+# Pass correct folder to standaloneSaved message

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -393,7 +393,7 @@ command revDoSaveAsStandalone pStack, pFolder
       -- post build message
       if tHasDesktop then
          __ReloadOriginalStackFile tStackFileName, pStack
-         __SendStandaloneSavedMessage pStack, tTargetFolder
+         __SendStandaloneSavedMessage pStack, tOutputFolder
       end if
       
    catch tError


### PR DESCRIPTION
If the user chooses to save a standalone named "MyApp" in Desktop folder, then a folder is passed to `standaloneSaved` message.

In LC 8.1.3 RC-1 this folder was `path/to/Desktop/MyApp/MacOSX` (not correct), and in pre-LC 8.1.3 RC-1 this was `path/to/Desktop/` (not very useful).

In this patch the folder will now be `path/to/Desktop/MyApp/`.

This ensures that when having multiple copies of the same standalone, in folders named "MyApp", "MyApp1", "MyApp2" etc, the path to the most recent one will be passed to `standaloneSaved` message, e.g. `path/to/Desktop/MyApp5/`