### PR TITLE
[CID 17002] Managed lifetime for MCObjectPropertySet::m_props

### DIFF
--- a/engine/src/objectpropsets.cpp
+++ b/engine/src/objectpropsets.cpp
@@ -39,20 +39,13 @@ extern bool MCStringsSplit(MCStringRef p_string, codepoint_t p_delimiter, MCStri
 
 bool MCObjectPropertySet::clone(MCObjectPropertySet*& r_set) const
 {
-	MCObjectPropertySet *t_new_set;
-	if (createwithname(*m_name, t_new_set))
-	{
-		MCValueRelease(t_new_set -> m_props);
-		if (MCArrayMutableCopy(m_props, t_new_set -> m_props))
-		{
-			r_set = t_new_set;
-			return true;
-		}
-
-		delete t_new_set;
-	}
-
-	return false;
+    MCAutoPointer<MCObjectPropertySet> t_new_set;
+    if (!createwithname(*m_name, &t_new_set))
+        return false;
+    if (!t_new_set->store(*m_props))
+        return false;
+    r_set = t_new_set.Release();
+    return true;
 }
 
 bool MCObjectPropertySet::createwithname_nocopy(MCNameRef p_name, MCObjectPropertySet*& r_set)
@@ -89,39 +82,47 @@ bool MCObjectPropertySet::createwithname(MCNameRef p_name, MCObjectPropertySet*&
 
 //////////
 
+MCArrayRef MCObjectPropertySet::fetch_nocopy() const
+{
+    return m_props.IsSet() ? *m_props : kMCEmptyArray;
+}
+
 bool MCObjectPropertySet::list(MCStringRef& r_keys) const
 {
-    if (MCArrayListKeys(m_props, '\n', r_keys))
-		return true;
-    
-	return false;
+    return MCArrayListKeys(fetch_nocopy(), '\n', r_keys);
 }
 
 bool MCObjectPropertySet::clear(void)
 {
-	MCValueRelease(m_props);
-	return MCArrayCreateMutable(m_props);
+    m_props.Reset();
+    return true;
 }
 
 bool MCObjectPropertySet::fetch(MCArrayRef& r_array) const
 {
-    return MCArrayCopy(m_props, r_array);
+    return MCArrayCopy(fetch_nocopy(), r_array);
 }
 
 bool MCObjectPropertySet::store(MCArrayRef p_array)
 {
-	MCValueRelease(m_props);
-    return MCArrayMutableCopy(p_array, m_props);
+    MCAutoArrayRef t_mutable;
+    if (!MCArrayMutableCopy(p_array, &t_mutable))
+        return false;
+    m_props.Give(t_mutable.Take());
+    return true;
 }
 
 bool MCObjectPropertySet::fetchelement(MCExecContext& ctxt, MCNameRef p_name, MCValueRef& r_value) const
 {
-	return MCArrayFetchValue(m_props, ctxt . GetCaseSensitive(), p_name, r_value);
+    return MCArrayFetchValue(fetch_nocopy(), ctxt . GetCaseSensitive(),
+                             p_name, r_value);
 }
 
 bool MCObjectPropertySet::storeelement(MCExecContext& ctxt, MCNameRef p_name, MCValueRef p_value)
 {
-	return MCArrayStoreValue(m_props, ctxt . GetCaseSensitive(), p_name, p_value);
+    if (!m_props.IsSet() && !MCArrayCreateMutable(&m_props))
+        return false;
+    return MCArrayStoreValue(*m_props, ctxt . GetCaseSensitive(), p_name, p_value);
 }
 
 bool MCObjectPropertySet::restrict(MCStringRef p_string)
@@ -131,7 +132,8 @@ bool MCObjectPropertySet::restrict(MCStringRef p_string)
     MCAutoStringRefArray t_split;
     if (!MCStringsSplit(p_string, '\n', t_split . PtrRef(), t_split . CountRef()))
         return false;
-    
+
+    MCAutoArrayRef t_old_props(fetch_nocopy());
     MCAutoArrayRef t_new_props;
     MCArrayCreateMutable(&t_new_props);
     uinteger_t t_size;
@@ -142,12 +144,12 @@ bool MCObjectPropertySet::restrict(MCStringRef p_string)
         if (t_success)
             t_success = MCNameCreate(t_split[i], &t_key_name);
         MCValueRef t_value;
-        if (!MCArrayFetchValue(m_props, false, *t_key_name, t_value))
+        if (!MCArrayFetchValue(*t_old_props, false, *t_key_name, t_value))
             t_value = kMCEmptyString;
         if (t_success)
             t_success = MCArrayStoreValue(*t_new_props, false, *t_key_name, t_value);
     }
-    MCValueAssign(m_props, *t_new_props);
+    m_props.Give(t_new_props.Take());
     return t_success;
 }
 
@@ -155,53 +157,66 @@ bool MCObjectPropertySet::restrict(MCStringRef p_string)
 
 IO_stat MCObjectPropertySet::loadprops_new(IO_handle p_stream)
 {
-    MCArrayRef t_new_props;
+    MCAutoArrayRef t_new_props;
 
     if (IO_read_valueref_new((MCValueRef&)t_new_props, p_stream) != IO_NORMAL)
 		return IO_ERROR;
-    if (!MCArrayMutableCopyAndRelease(t_new_props, t_new_props))
-		return IO_ERROR;
+    if (!t_new_props.MakeMutable())
+        return IO_ERROR;
+    m_props.Give(t_new_props.Take());
 
-    MCValueAssign(m_props, t_new_props);
-    MCValueRelease(t_new_props);
 	return IO_NORMAL;
 }
 
 IO_stat MCObjectPropertySet::saveprops_new(IO_handle p_stream) const
 {
-	return IO_write_valueref_new(m_props, p_stream);
+	return IO_write_valueref_new(fetch_nocopy(), p_stream);
 }
 
 //////////
 
 uint32_t MCObjectPropertySet::measure_legacy(bool p_nested_only) const
 {
-	return MCArrayMeasureForStreamLegacy(m_props, p_nested_only);
+	return MCArrayMeasureForStreamLegacy(fetch_nocopy(), p_nested_only);
 }
 
 bool MCObjectPropertySet::isnested_legacy(void) const
 {
-	return MCArrayIsNestedLegacy(m_props);
+	return MCArrayIsNestedLegacy(fetch_nocopy());
 }
 
 IO_stat MCObjectPropertySet::loadprops_legacy(IO_handle p_stream)
 {
-	return MCArrayLoadFromHandleLegacy(m_props, p_stream);
+    MCAutoArrayRef t_new_props;
+    if (!MCArrayCreateMutable(&t_new_props))
+        return IO_ERROR;
+
+    IO_stat t_status = MCArrayLoadFromHandleLegacy(*t_new_props, p_stream);
+    if (t_status == IO_NORMAL)
+        m_props.Give(t_new_props.Take());
+    return t_status;
 }
 
 IO_stat MCObjectPropertySet::loadarrayprops_legacy(MCObjectInputStream& p_stream)
 {
-	return MCArrayLoadFromStreamLegacy(m_props, p_stream);
+    MCAutoArrayRef t_new_props;
+    if (!MCArrayCreateMutable(&t_new_props))
+        return IO_ERROR;
+
+    IO_stat t_status = MCArrayLoadFromStreamLegacy(*t_new_props, p_stream);
+    if (t_status == IO_NORMAL)
+        m_props.Give(t_new_props.Take());
+    return t_status;
 }
 
 IO_stat MCObjectPropertySet::saveprops_legacy(IO_handle p_stream) const
 {
-	return MCArraySaveToHandleLegacy(m_props, p_stream);
+	return MCArraySaveToHandleLegacy(fetch_nocopy(), p_stream);
 }
 
 IO_stat MCObjectPropertySet::savearrayprops_legacy(MCObjectOutputStream& p_stream) const
 {
-	return MCArraySaveToStreamLegacy(m_props, true, p_stream);
+	return MCArraySaveToStreamLegacy(fetch_nocopy(), true, p_stream);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/objectpropsets.cpp
+++ b/engine/src/objectpropsets.cpp
@@ -37,7 +37,7 @@ extern bool MCStringsSplit(MCStringRef p_string, codepoint_t p_delimiter, MCStri
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCObjectPropertySet::clone(MCObjectPropertySet*& r_set)
+bool MCObjectPropertySet::clone(MCObjectPropertySet*& r_set) const
 {
 	MCObjectPropertySet *t_new_set;
 	if (createwithname(*m_name, t_new_set))
@@ -89,7 +89,7 @@ bool MCObjectPropertySet::createwithname(MCNameRef p_name, MCObjectPropertySet*&
 
 //////////
 
-bool MCObjectPropertySet::list(MCStringRef& r_keys)
+bool MCObjectPropertySet::list(MCStringRef& r_keys) const
 {
     if (MCArrayListKeys(m_props, '\n', r_keys))
 		return true;
@@ -103,7 +103,7 @@ bool MCObjectPropertySet::clear(void)
 	return MCArrayCreateMutable(m_props);
 }
 
-bool MCObjectPropertySet::fetch(MCArrayRef& r_array)
+bool MCObjectPropertySet::fetch(MCArrayRef& r_array) const
 {
     return MCArrayCopy(m_props, r_array);
 }
@@ -114,7 +114,7 @@ bool MCObjectPropertySet::store(MCArrayRef p_array)
     return MCArrayMutableCopy(p_array, m_props);
 }
 
-bool MCObjectPropertySet::fetchelement(MCExecContext& ctxt, MCNameRef p_name, MCValueRef& r_value)
+bool MCObjectPropertySet::fetchelement(MCExecContext& ctxt, MCNameRef p_name, MCValueRef& r_value) const
 {
 	return MCArrayFetchValue(m_props, ctxt . GetCaseSensitive(), p_name, r_value);
 }
@@ -167,14 +167,14 @@ IO_stat MCObjectPropertySet::loadprops_new(IO_handle p_stream)
 	return IO_NORMAL;
 }
 
-IO_stat MCObjectPropertySet::saveprops_new(IO_handle p_stream)
+IO_stat MCObjectPropertySet::saveprops_new(IO_handle p_stream) const
 {
 	return IO_write_valueref_new(m_props, p_stream);
 }
 
 //////////
 
-uint32_t MCObjectPropertySet::measure_legacy(bool p_nested_only)
+uint32_t MCObjectPropertySet::measure_legacy(bool p_nested_only) const
 {
 	return MCArrayMeasureForStreamLegacy(m_props, p_nested_only);
 }
@@ -194,12 +194,12 @@ IO_stat MCObjectPropertySet::loadarrayprops_legacy(MCObjectInputStream& p_stream
 	return MCArrayLoadFromStreamLegacy(m_props, p_stream);
 }
 
-IO_stat MCObjectPropertySet::saveprops_legacy(IO_handle p_stream)
+IO_stat MCObjectPropertySet::saveprops_legacy(IO_handle p_stream) const
 {
 	return MCArraySaveToHandleLegacy(m_props, p_stream);
 }
 
-IO_stat MCObjectPropertySet::savearrayprops_legacy(MCObjectOutputStream& p_stream)
+IO_stat MCObjectPropertySet::savearrayprops_legacy(MCObjectOutputStream& p_stream) const
 {
 	return MCArraySaveToStreamLegacy(m_props, true, p_stream);
 }

--- a/engine/src/objectpropsets.h
+++ b/engine/src/objectpropsets.h
@@ -25,12 +25,6 @@ public:
 	MCObjectPropertySet(void)
 	{
 		m_next = nil;
-        /* UNCHECKED */ MCArrayCreateMutable(m_props);
-	}
-
-	~MCObjectPropertySet(void)
-	{
-		MCValueRelease(m_props);
 	}
 
 	bool hasname(MCNameRef p_name) const
@@ -110,9 +104,13 @@ public:
 	IO_stat savearrayprops_legacy(MCObjectOutputStream& stream) const;
 
 private:
+    /* Always returns a valid array, even if m_props isn't set.  The
+     * returned array is _not_ owned by the caller */
+    MCArrayRef fetch_nocopy() const;
+
 	MCObjectPropertySet *m_next;
 	MCNewAutoNameRef m_name;
-	MCArrayRef m_props;
+	MCAutoArrayRef m_props;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/objectpropsets.h
+++ b/engine/src/objectpropsets.h
@@ -33,18 +33,18 @@ public:
 		MCValueRelease(m_props);
 	}
 
-	bool hasname(MCNameRef p_name)
+	bool hasname(MCNameRef p_name) const
 	{
         return m_name.IsSet() &&
             MCNameIsEqualTo(*m_name, p_name, kMCCompareCaseless);
 	}
 
-	MCNameRef getname(void)
+	MCNameRef getname(void) const
 	{
 		return *m_name;
 	}
 
-	MCObjectPropertySet *getnext(void)
+	MCObjectPropertySet *getnext(void) const
 	{
 		return m_next;
 	}
@@ -59,14 +59,14 @@ public:
         m_name.Give(p_name);
 	}
 
-	/* CAN FAIL */ bool clone(MCObjectPropertySet*& r_set);
+	/* CAN FAIL */ bool clone(MCObjectPropertySet*& r_set) const;
 	/* CAN FAIL */ static bool createwithname_nocopy(MCNameRef p_name, MCObjectPropertySet*& r_set);
 	/* CAN FAIL */ static bool createwithname(MCNameRef p_name, MCObjectPropertySet*& r_set);
 
 	//////////
 
 	// List the props in the property set into the ep.
-    bool list(MCStringRef& r_keys);
+    bool list(MCStringRef& r_keys) const;
 
 	// Clear the contents of the propset.
 	bool clear(void);
@@ -75,12 +75,12 @@ public:
     /* WRAPPER */ bool restrict(MCStringRef p_string);
     
 	// Copy the prop set into the ep.
-    bool fetch(MCArrayRef& r_array);
+    bool fetch(MCArrayRef& r_array) const;
     
 	// Store the contents of the ep as the prop set.
     bool store(MCArrayRef p_array);
 
-    bool fetchelement(MCExecContext& ctxt, MCNameRef p_name, MCValueRef& r_value);
+    bool fetchelement(MCExecContext& ctxt, MCNameRef p_name, MCValueRef& r_value) const;
     bool storeelement(MCExecContext& ctxt, MCNameRef p_name, MCValueRef p_value);
     
 	//////////
@@ -88,14 +88,14 @@ public:
 	// MW-2013-12-05: [[ UnicodeFileFormat ]] These are the non-unicode propset
 	//   pickle routines.
 	IO_stat loadprops_new(IO_handle stream);
-	IO_stat saveprops_new(IO_handle stream);
+	IO_stat saveprops_new(IO_handle stream) const;
 	
 	// MW-2013-12-05: [[ UnicodeFileFormat ]] These are the non-unicode propset
 	//   pickle routines.
 
 	// Returns the (old-style) serialized size of the array. If 'nested_only'
 	// is true, then it only counts the size of the props containing arrays.
-	uint32_t measure_legacy(bool p_nested_only);
+	uint32_t measure_legacy(bool p_nested_only) const;
 	// Returns true if the prop set has nested arrays.
 	bool isnested_legacy(void) const;
 	// Load the props from the given stream - this merges the existing array
@@ -105,9 +105,9 @@ public:
 	// array with any we find.
 	IO_stat loadarrayprops_legacy(MCObjectInputStream& stream);
 	// Save the non-array props to the given stream.
-	IO_stat saveprops_legacy(IO_handle stream);
+	IO_stat saveprops_legacy(IO_handle stream) const;
 	// Save the array props to the given stream.
-	IO_stat savearrayprops_legacy(MCObjectOutputStream& stream);
+	IO_stat savearrayprops_legacy(MCObjectOutputStream& stream) const;
 
 private:
 	MCObjectPropertySet *m_next;


### PR DESCRIPTION
This PR contains some improvements to `MCObjectPropertySet`:

- All eligible member functions are now explicitly `const`
- All member variables now have automatically managed lifetime, so the default destructor can be used
- Several cases where error paths could fail to preserve state have been fixed