### PR TITLE
[CID 16117] Ensure MCExternalV0::m_name is initialised in constructor

### DIFF
--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -170,6 +170,7 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 MCExternalV0::MCExternalV0(void)
+    : m_name(nullptr)
 {
 	m_table = nil;
 	m_free = nil;


### PR DESCRIPTION
Coverity-ID: 16117