### PR TITLE
[CID 15138] Fix copy & paste error in MCStack::getsubstackobjname()

### DIFF
--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1586,7 +1586,7 @@ MCObject *MCStack::getsubstackobjname(Chunk_term type, MCNameRef p_name)
 		{
 			if (type == CT_AUDIO_CLIP || type == CT_VIDEO_CLIP)
 			{
-				/* UNCHECKED */ sptr->getAVname(type, p_name, optr);
+				/* UNCHECKED */ tptr->getAVname(type, p_name, optr);
 			}
 			else
 				optr = tptr->getcontrolname(type, p_name);


### PR DESCRIPTION
This fixes a bug where `MCStack::getsubstackobjname()` would fail
to find audio or video clip objects attached to substacks.

Coverity-ID: 15138