### PR TITLE
build: Add dummy rules for win-x86_64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,16 @@ all-win-%:
 
 $(addsuffix -win,all config compile): %: %-x86
 
+# Dummy rules for Windows x86-64 builds
+# TODO Replace with real rules
+config-win-x86_64:
+	mkdir -p build-win-x86_64
+compile-win-x86_64:
+	mkdir -p win-x86_64-bin
+all-win-x86_64:
+	$(MAKE) config-win-x86_64
+	$(MAKE) compile-win-x86_64
+
 ################################################################
 # Emscripten rules
 ################################################################


### PR DESCRIPTION
We need to be able to run the build system against branches that
don't support 64-bit Windows.  This patch works around the lack of
support for running builds conditionally by branch by adding dummy
build rules for win-x86_64.