### PR TITLE
Reinstate -Wno-error=maybe-uninitialized

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -71,6 +71,7 @@
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
 					'-Werror=uninitialized',
+					'-Wno-error=maybe-uninitialized',
 					'-Werror=conversion-null',
 					'-Werror=empty-body',
 				],


### PR DESCRIPTION
The absence of this was causing the Android builds to fail, since they use the Linux toolchain.