### PR TITLE
[[ Bug 19158 ]] Prevent crash when using undo to bring back removed controls

### DIFF
--- a/docs/notes/bugfix-19158.md
+++ b/docs/notes/bugfix-19158.md
@@ -1,0 +1,1 @@
+# Prevent crash when using undo to bring back removed controls

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -582,6 +582,7 @@ void MCControl::undo(Ustruct *us)
 		{
 			MCCard *card = (MCCard *)parent->getcard();
 			getstack()->appendcontrol(this);
+			this->MCObject::m_weak_proxy = new MCObjectProxyBase(this);
 			card->newcontrol(this, False);
 			Boolean oldrlg = MCrelayergrouped;
 			MCrelayergrouped = True;


### PR DESCRIPTION
In develop environment, crash happens in line 256 of object.h indicates t_weak_proxy is null. That's because when removing control, m_weak_proxy is cleared as well (line 889, object.cpp). This patch I just recreate MCObjectProxyBase before adding the control back to the card. 

I'm new to lc engine. Not sure that's the proper way to fix this. If not, please give me some guidance so I can make it right.