### PR TITLE
lc-compile: Always define a yywrap() function

### DIFF
--- a/toolchain/lc-compile/src/YYWRAP.b
+++ b/toolchain/lc-compile/src/YYWRAP.b
@@ -1,3 +1,1 @@
-#ifndef yywrap
 int yywrap(void) { return 1; }
-#endif


### PR DESCRIPTION
Since we never link in libfl on any platform, unconditionally
define a `yywrap()` function.  This allows compilation with flex
2.6.