### PR TITLE
Revert "[[ Bug 19158 ]] Prevent crash when using undo to bring back removed controls"

### DIFF
--- a/docs/notes/bugfix-19158.md
+++ b/docs/notes/bugfix-19158.md
@@ -1,1 +1,0 @@
-# Prevent crash when using undo to bring back removed controls

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -582,7 +582,6 @@ void MCControl::undo(Ustruct *us)
 		{
 			MCCard *card = (MCCard *)parent->getcard();
 			getstack()->appendcontrol(this);
-			this->MCObject::m_weak_proxy = new MCObjectProxyBase(this);
 			card->newcontrol(this, False);
 			Boolean oldrlg = MCrelayergrouped;
 			MCrelayergrouped = True;


### PR DESCRIPTION
Reverts livecode/livecode#5127