### PR TITLE
[[ Bug 19158 ]] Prevent crash when using undo to bring back removed controls

### DIFF
--- a/docs/notes/bugfix-19158.md
+++ b/docs/notes/bugfix-19158.md
@@ -1,0 +1,1 @@
+# Prevent crash when using undo to bring back removed controls

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -582,6 +582,7 @@ void MCControl::undo(Ustruct *us)
 		{
 			MCCard *card = (MCCard *)parent->getcard();
 			getstack()->appendcontrol(this);
+			this->MCObject::m_weak_proxy = new MCObjectProxyBase(this);
 			card->newcontrol(this, False);
 			Boolean oldrlg = MCrelayergrouped;
 			MCrelayergrouped = True;


### PR DESCRIPTION
cherry-picked 5c6d57b