### PR TITLE
[Bug 19120] Don't check flags when calling del on substacks

### DIFF
--- a/docs/notes/bugfix-19120.md
+++ b/docs/notes/bugfix-19120.md
@@ -1,0 +1,1 @@
+# Ensure substacks with cantDelete don't cause execution errors when deleting the mainstack

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1375,12 +1375,12 @@ bool MCStack::isdeletable(bool p_check_flag)
 
 Boolean MCStack::del(bool p_check_flag)
 {
-    if (!isdeletable(true))
+    if (!isdeletable(p_check_flag))
 	   return False;
 
 	while (substacks)
 	{
-		if (!substacks -> del(p_check_flag))
+		if (!substacks -> del(false))
 			return False;
 	}
 	

--- a/tests/lcs/core/execution/object-deletion.livecodescript
+++ b/tests/lcs/core/execution/object-deletion.livecodescript
@@ -53,6 +53,26 @@ on TestDeleteThisCard
    TestAssert "Delete card from button in shared group on card", there is not a button "test" of card 1 of stack "test"
 end TestDeleteThisCard
 
-on TestTeardown
+on TestDeleteStackWithCantDelete
+   set the cantDelete of stack "test" to true
+   TestAssertThrow "Delete stack with cantDelete", "__TestDeleteStack", the long id me, 347
+   set the cantDelete of stack "test" to false
+end TestDeleteStackWithCantDelete
+
+on TestDeleteSubstackWithCantDelete
+   create stack "test substack"
+   set the mainstack of stack "test substack" to "test"
+   set the cantDelete of stack "test substack" to true
    delete stack "test"
+   TestAssert "Delete stack with cantDelete substack", true
+end TestDeleteSubstackWithCantDelete
+
+on __TestDeleteStack
+      delete stack "test"
+end __TestDeleteStack
+
+on TestTeardown
+   if there is a stack "test" then
+      delete stack "test"
+   end if
 end TestTeardown


### PR DESCRIPTION
When calling `del` on a substack from a mainstack `del` the
`p_check_flags` paraeter should be false so that `cantDelete`
is not checked.