### PR TITLE
[Bug 19185] Don't clear dragData["private"] mid drag

### DIFF
--- a/docs/notes/bugfix-19185.md
+++ b/docs/notes/bugfix-19185.md
@@ -1,0 +1,1 @@
+# Ensure the dragData["private"] isn't cleared during a drag

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -123,7 +123,7 @@ void MCClipboard::ReleaseData()
 bool MCClipboard::PullUpdates() const
 {
     // If ownership has changed, the private clipboard data needs to be cleared
-	if (!m_clipboard->IsOwned())
+	if (!this->IsDragboard() && !m_clipboard->IsOwned())
 		const_cast<MCClipboard*>(this)->ClearPrivateData();
 	
 	// Pass on the request
@@ -1549,4 +1549,9 @@ MCStringEncoding MCClipboard::GuessHTMLEncoding(MCDataRef p_html_data)
 	// function should be updated to detect it if possible.
 
 	return kMCStringEncodingUTF8;
+}
+
+bool MCClipboard::IsDragboard() const
+{
+	return this == MCdragboard;
 }

--- a/engine/src/clipboard.h
+++ b/engine/src/clipboard.h
@@ -182,7 +182,7 @@ public:
     static MCClipboard* CreateSystemSelectionClipboard();
     static MCClipboard* CreateSystemDragboard();
     
-    
+	bool IsDragboard() const;
 private:
     
     // The raw clipboard that is being wrapped


### PR DESCRIPTION
The system appears to touch the drag pasteboard mid drag accessing the
changeCount to increment. As drags either come from an outside source
or the engine if private data exists we can retain until the drag is
complete.

This is admittedly a bit of a workaround so at this stage I'll label as WIP to gauge if people think there's a better way to deal with this. It might be that updating ownership as the drag events come in is a better idea...