### PR TITLE
[[ Bug 19060 ]] Ensure errors when binding widget don't linger (8.1 backport)

### DIFF
--- a/docs/notes/bugfix-19060.md
+++ b/docs/notes/bugfix-19060.md
@@ -1,0 +1,1 @@
+# Ensure error when binding widget is caught correctly

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -129,6 +129,11 @@ void MCWidget::bind(MCNameRef p_kind, MCValueRef p_rep)
     // If we failed then store the rep and destroy the imp.
     if (!t_success)
     {
+        // Make sure we swallow the error so that it doesn't affect
+        // future execution.
+        MCAutoErrorRef t_error;
+        MCErrorCatch(&t_error);
+        
         MCValueRelease(m_widget);
         m_widget = nil;
         

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -242,6 +242,26 @@ on TestLoadExtension pName
 
 end TestLoadExtension
 
+-- This loads an extension whose lcb source sits in the same folder as the
+-- current test.
+on TestLoadAuxillaryExtension pName
+	local tBasePath, tExtraPath
+	set the itemDelimiter to slash
+	put item 1 to -2 of the filename of this stack into tBasePath
+	repeat while the last item of tBasePath is not "tests"
+		put item -1 of tBasePath & slash before tExtraPath
+		delete the last item of tBasePath
+	end repeat
+
+	local tModuleFile
+	put tBasePath & "/../_tests/_build/" & tExtraPath & pName & ".lcm" into tModuleFile
+
+	load extension from data url ("binfile:" & tModuleFile)
+	if the result is not empty then
+		throw "Failed to load auxillary extension:" && the result && tModuleFile
+	end if
+end TestLoadAuxillaryExtension
+
 on TestLoadAllExtensions
    local tExtFolder
    put _TestGetBuiltExtensionsFolder() into tExtFolder

--- a/tests/lcs/core/engine/_widget_support.lcb
+++ b/tests/lcs/core/engine/_widget_support.lcb
@@ -1,0 +1,12 @@
+library com.livecode.lcs_tests.core.widget_support
+
+use com.livecode.foreign
+
+private foreign handler MCErrorIsPending() returns CBool binds to "<builtin>"
+public handler TestWidget_MCErrorIsPending() returns Boolean
+	unsafe
+		return MCErrorIsPending()
+	end unsafe
+end handler
+
+end library


### PR DESCRIPTION
This patch swallows any error resulting from attempting to bind a
widget to ensure that it does not affect subsequent execution.

(cherry picked from commit 0ab2d388669a0035e5bb5ae8f5b5784a8c8427b0)