### PR TITLE
Only include QT headers when FEATURE_QUICKTIME is defined

### DIFF
--- a/engine/src/mac-pasteboard.mm
+++ b/engine/src/mac-pasteboard.mm
@@ -24,8 +24,6 @@
 
 #include "mac-internal.h"
 
-#include <QuickTime/QuickTime.h>
-
 ////////////////////////////////////////////////////////////////////////////////
 
 extern bool MCImageBitmapToCGImage(MCImageBitmap *p_bitmap, bool p_copy, bool p_invert, CGImageRef &r_image);

--- a/engine/src/mac-qt-player.mm
+++ b/engine/src/mac-qt-player.mm
@@ -15,7 +15,10 @@
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <Cocoa/Cocoa.h>
-#include <QTKit/QTKit.h>
+
+#ifdef FEATURE_QUICKTIME
+# include <QTKit/QTKit.h>
+#endif
 
 #include "globdefs.h"
 #include "imagebitmap.h"

--- a/engine/src/mac-qt-recorder.mm
+++ b/engine/src/mac-qt-recorder.mm
@@ -35,11 +35,14 @@
 #include "variable.h"
 
 #include <Cocoa/Cocoa.h>
-#include <QTKit/QTKit.h>
-#include <QuickTime/QuickTime.h>
 #include <CoreAudioKit/CoreAudioKit.h>
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
+
+#ifdef FEATURE_QUICKTIME
+# include <QTKit/QTKit.h>
+# include <QuickTime/QuickTime.h>
+#endif
 
 #import <sys/stat.h>
 


### PR DESCRIPTION
This allows the 64-bit Mac engine to build out-of-the-box against the
newest macOS SDK (10.12) as 64-bit builds have QuickTime disabled.

The 32-bit build still uses QT (for now) and includes those headers so
is not improved by this change.