### PR TITLE
[[ Foundation ]] Add module loading API to libfoundation

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -1270,33 +1270,20 @@ public:
         return MCStringCreateWithSysString(tmpnam(NULL), r_tmp_name);
     }
 
-    virtual MCSysModuleHandle LoadModule(MCStringRef p_path)
-    {
-        // dlopen loads whole 4-byte words when accessing the filename. This causes valgrind to make
-        // spurious noise - so in DEBUG mode we make sure we allocate a 4-byte aligned block of memory.
-        //
-        // Because converting to a sys string allocates memory, this alignment will always be satisfied.
-        // (malloc/new always return alignment >= int/pointer alignment)
-        MCAutoStringRefAsSysString t_filename_sys;
-        /* UNCHECKED */ t_filename_sys.Lock(p_path);
-
-        MCSysModuleHandle t_result;
-        t_result = (MCSysModuleHandle)dlopen(*t_filename_sys, (RTLD_NOW | RTLD_LOCAL));
-
-        return t_result ;
-    }
-
-    virtual MCSysModuleHandle ResolveModuleSymbol(MCSysModuleHandle p_module, MCStringRef p_symbol)
-    {
-        MCAutoStringRefAsSysString t_symbol_sys;
-        /* UNCHECKED */ t_symbol_sys.Lock(p_symbol);
-        return (MCSysModuleHandle)(dlsym(p_module, *t_symbol_sys));
-    }
-
-    virtual void UnloadModule(MCSysModuleHandle p_module)
-    {
-        dlclose(p_module);
-    }
+	virtual MCSysModuleHandle LoadModule(MCStringRef p_filename)
+	{
+		return (MCSysModuleHandle)MCSDylibLoadModule(p_filename);
+	}
+	
+	virtual MCSysModuleHandle ResolveModuleSymbol(MCSysModuleHandle p_module, MCStringRef p_symbol)
+	{
+        return (MCSysModuleHandle)MCSDylibResolveModuleSymbol(p_module, p_symbol);
+	}
+	
+	virtual void UnloadModule(MCSysModuleHandle p_module)
+	{
+		MCSDylibUnloadModule((void *)p_module);
+	}
 
     virtual bool ListFolderEntries(MCStringRef p_folder, MCSystemListFolderEntriesCallback p_callback, void *x_context)
     {

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -4140,71 +4140,53 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 	
 	virtual MCSysModuleHandle LoadModule(MCStringRef p_filename)
     {
-        
-        // SN-2014-12-09: [[ Bug 14001 ]] Update the module loading for Mac server
-#ifdef _SERVER
-        MCAutoStringRefAsUTF8String t_utf_path;
-        
-        if (!t_utf_path.Lock(p_filename))
-            return NULL;
-        
-        void *t_result;
-        
-        t_result = dlopen(*t_utf_path, RTLD_LAZY);
-        
-        return (MCSysModuleHandle)t_result;
-#else
-        MCAutoStringRefAsUTF8String t_utf_path;
-        
-        if (!t_utf_path.Lock(p_filename))
-            return NULL;
-        
-        CFURLRef t_url;
-        t_url = CFURLCreateFromFileSystemRepresentation(NULL, (const UInt8 *)*t_utf_path, strlen(*t_utf_path), False);
-        
-        if (t_url == NULL)
-            return NULL;
+		MCSysModuleHandle t_handle;
+		t_handle = (MCSysModuleHandle)MCSDylibLoadModule(p_filename);
 		
-        MCSysModuleHandle t_result;
-        t_result = (MCSysModuleHandle)CFBundleCreate(NULL, t_url);
-        
-        CFRelease(t_url);
-        
-        return (MCSysModuleHandle)t_result;
-#endif
+		if (t_handle != nil)
+			return t_handle;
+		
+		MCAutoStringRefAsSysString t_filename_sys;
+		if (!t_filename_sys.Lock(p_filename))
+			return nil;
+		
+		CFURLRef t_url;
+		t_url = CFURLCreateFromFileSystemRepresentation(NULL, (const UInt8 *)*t_filename_sys, strlen(*t_filename_sys), false);
+		
+		if (t_url == NULL)
+			return NULL;
+		
+		t_handle = (MCSysModuleHandle)CFBundleCreate(NULL, t_url);
+		
+		CFRelease(t_url);
+		
+		return t_handle;
     }
     
 	virtual MCSysModuleHandle ResolveModuleSymbol(MCSysModuleHandle p_module, MCStringRef p_symbol)
     {
-        
-        // SN-2014-12-09: [[ Bug 14001 ]] Update the module loading for Mac server
-#ifdef _SERVER
-        return (MCSysModuleHandle)dlsym(p_module, MCStringGetCString(p_symbol));
-#else
-        CFStringRef t_cf_symbol;
-       
-        MCStringConvertToCFStringRef(p_symbol, t_cf_symbol);
-        if (t_cf_symbol == NULL)
-            return NULL;
-        
-        void *t_symbol_ptr;
-        t_symbol_ptr = CFBundleGetFunctionPointerForName((CFBundleRef)p_module, t_cf_symbol);
-        
-        CFRelease(t_cf_symbol);
-        
-        return (MCSysModuleHandle) t_symbol_ptr;
-#endif
+		MCSysModuleHandle t_symbol;
+        t_symbol = (MCSysModuleHandle)MCSDylibResolveModuleSymbol(p_module, p_symbol);
+		
+		if (t_symbol != nil)
+			return t_symbol;
+
+		CFStringRef t_cf_symbol;
+		
+		MCStringConvertToCFStringRef(p_symbol, t_cf_symbol);
+		if (t_cf_symbol == NULL)
+			return NULL;
+		
+		t_symbol = (MCSysModuleHandle)CFBundleGetFunctionPointerForName((CFBundleRef)p_module, t_cf_symbol);
+		
+		CFRelease(t_cf_symbol);
+		
+		return t_symbol;
     }
     
 	virtual void UnloadModule(MCSysModuleHandle p_module)
     {
-        
-        // SN-2014-12-09: [[ Bug 14001 ]] Update the module loading for Mac server
-#ifdef _SERVER
-        dlclose(p_module);
-#else
-        CFRelease((CFBundleRef)p_module);
-#endif
+		MCSDylibUnloadModule((void *)p_module);
     }
 	
 	virtual bool LongFilePath(MCStringRef p_path, MCStringRef& r_long_path)

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -2333,26 +2333,16 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 	
 	virtual MCSysModuleHandle LoadModule(MCStringRef p_path)
     {
-		MCAutoStringRefAsWString t_path_wstr;
-		if (!t_path_wstr.Lock(p_path))
-			return NULL;
-	
-		// MW-2011-02-28: [[ Bug 9410 ]] Use the Ex form of LoadLibrary and ask it to try
-        //   to resolve dependent DLLs from the folder containing the DLL first.
-        HMODULE t_handle;
-        t_handle = LoadLibraryExW(*t_path_wstr, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
-        
-        return (MCSysModuleHandle)t_handle;
+		return (MCSysModuleHandle)MCSDylibLoadModule(p_filename);
     }
     
 	virtual MCSysModuleHandle ResolveModuleSymbol(MCSysModuleHandle p_module, MCStringRef p_symbol)
     {
-        // NOTE: symbol addresses are never Unicode and only an ANSI call exists
-		return (MCSysModuleHandle)GetProcAddress((HMODULE)p_module, MCStringGetCString(p_symbol));
+		return (MCSysModuleHandle)MCSDylibResolveModuleSymbol(p_filename);
     }
 	virtual void UnloadModule(MCSysModuleHandle p_module)
     {
-        FreeLibrary((HMODULE)p_module);
+        MCSDylibUnloadModule((void *)p_module);
     }
 	
 	// Utility function: converts FILETIME to a Unix time

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -2900,45 +2900,7 @@ void* MCU_loadmodule_stringref(MCStringRef p_module)
 {
     MCSysModuleHandle t_handle;
     t_handle = nil;
-#if defined(_MACOSX)
-    MCAutoPointer<char> t_module_cstring;
-    // SN-2015-04-07: [[ Bug 15164 ]] NSAddImage understands UTF-8.
-    if (!MCStringConvertToUTF8String(p_module, &t_module_cstring))
-        return NULL;
-    t_handle = (MCSysModuleHandle)NSAddImage(*t_module_cstring, NSADDIMAGE_OPTION_RETURN_ON_ERROR | NSADDIMAGE_OPTION_WITH_SEARCHING);
-    if (t_handle != nil)
-        return t_handle;
-    // MM-2014-02-06: [[ LipOpenSSL 1.0.1e ]] On Mac, if module cannot be found then look relative to current executable.
-    uint32_t t_buffer_size;
-    t_buffer_size = 0;
-    _NSGetExecutablePath(NULL, &t_buffer_size);
-    char *t_module_path;
-    t_module_path = (char *) malloc(t_buffer_size + strlen(*t_module_cstring) + 1);
-    if (t_module_path != NULL)
-    {
-        if (_NSGetExecutablePath(t_module_path, &t_buffer_size) == 0)
-        {
-            char *t_last_slash;
-            t_last_slash = t_module_path + t_buffer_size;
-            for (uint32_t i = 0; i < t_buffer_size; i++)
-            {
-                if (*t_last_slash == '/')
-                {
-                    *(t_last_slash + 1) = '\0';
-                    break;
-                }
-                t_last_slash--;
-            }
-            strcat(t_module_path, *t_module_cstring);
-            t_handle = (MCSysModuleHandle)NSAddImage(t_module_path, NSADDIMAGE_OPTION_RETURN_ON_ERROR | NSADDIMAGE_OPTION_WITH_SEARCHING);
-        }
-        free(t_module_path);
-        // AL-2015-02-17: [[ SB Inclusions ]] Return the handle if found here.
-        if (t_handle != nil)
-            return t_handle;
-    }
-#endif
-
+	
     MCAutoStringRef t_path;
     
     if (!MCdispatcher || !MCdispatcher -> fetchlibrarymapping(p_module, &t_path))
@@ -2980,24 +2942,13 @@ void* MCU_loadmodule_stringref(MCStringRef p_module)
 //  as extern in revbrowser/src/cefshared.h - where MCSysModuleHandle does not exist
 void MCU_unloadmodule(void *p_module)
 {
-    // SN-2015-03-04: [[ Broken module unloading ]] NSAddImage, used on Mac in
-    //  MCU_loadmodule, does not need any unloading of the module -
-    //  but the other platforms do.
-#if !defined(_MACOSX)
     MCS_unloadmodule((MCSysModuleHandle)p_module);
-#endif
 }
 
 // SN-2015-02-23: [[ Broken Win Compilation ]] Use void*, as the function is imported
 //  as extern in revbrowser/src/cefshared.h - where MCSysModuleHandle does not exist
 void *MCU_resolvemodulesymbol(void* p_module, const char *p_symbol)
 {
-#if defined(_MACOSX)
-    NSSymbol t_symbol;
-    t_symbol = NSLookupSymbolInImage((mach_header *)p_module, p_symbol, NSLOOKUPSYMBOLINIMAGE_OPTION_BIND_NOW);
-    if (t_symbol != NULL)
-        return NSAddressOfSymbol(t_symbol);
-#endif
     MCAutoStringRef t_symbol_str;
     if (!MCStringCreateWithCString(p_symbol, &t_symbol_str))
         return nil;

--- a/libfoundation/include/foundation-system.h
+++ b/libfoundation/include/foundation-system.h
@@ -24,6 +24,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 extern "C" {
 
 #include <system-commandline.h>
+#include <system-dylib.h>
 #include <system-file.h>
 #include <system-init.h>
 #include <system-random.h>

--- a/libfoundation/include/system-dylib.h
+++ b/libfoundation/include/system-dylib.h
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#if !defined(__MCS_SYSTEM_H_INSIDE__)
+#	error "Only <foundation-system.h> can be included directly"
+#endif
+
+/* ================================================================
+ * Errors
+ * ================================================================ */
+
+MC_DLLEXPORT extern MCTypeInfoRef kMCSDylibModuleNotFoundErrorTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSDylibSymbolNotFoundErrorTypeInfo;
+
+/* ================================================================
+ * Dynamic library operations
+ * ================================================================ */
+
+/* Load the module at path. */
+MC_DLLEXPORT extern "C" void *MCSDylibLoadModuleCString(const char *p_path);
+MC_DLLEXPORT void *MCSDylibLoadModule(MCStringRef p_path);
+
+/* Unload the module at path. */
+MC_DLLEXPORT extern "C" void MCSDylibUnloadModule(void *p_module);
+
+/* Resolve the symbol with given name in module. */
+MC_DLLEXPORT extern "C" void *MCSDylibResolveModuleSymbolCString(void* p_module, const char *p_symbol);
+MC_DLLEXPORT void *MCSDylibResolveModuleSymbol(void* p_module, MCStringRef p_symbol);
+
+#ifdef __MCS_INTERNAL_API__
+
+void *_MCSDylibLoadModule(MCStringRef p_path);
+void _MCSDylibUnloadModule(void *p_module);
+void *_MCSDylibResolveModuleSymbol(void* p_module, MCStringRef p_symbol);
+
+#endif
+
+/* ================================================================
+ * Dylib API initialization
+ * ================================================================ */
+
+#ifdef __MCS_INTERNAL_API__
+
+bool __MCSDylibInitialize (void);
+void __MCSDylibFinalize (void);
+
+#endif

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -61,6 +61,7 @@
 				'include/foundation-text.h',
 				'include/foundation-unicode.h',
 				'include/system-commandline.h',
+				'include/system-dylib.h',
 				'include/system-file.h',
 				'include/system-init.h',
 				'include/system-random.h',
@@ -106,6 +107,10 @@
 				'src/system-file.cpp',
 				'src/system-file-posix.cpp',
 				'src/system-file-w32.cpp',
+				'src/system-dylib.cpp',
+				'src/system-dylib-lnx.cpp',
+				'src/system-dylib-mac.cpp',
+				'src/system-dylib-w32.cpp',
 				'src/system-init.cpp',
 				'src/system-random.cpp',
 				'src/system-stream.cpp',
@@ -128,12 +133,28 @@
 						'sources/':
 						[
 							['exclude', '.*-posix\\.cpp$'],
+							['exclude', '.*-mac\\.cpp$'],
+							['exclude', '.*-lnx\\.cpp$'],
 						],
 					},
+				],
+				[
+					'OS == "linux"', 
 					{
 						'sources/':
 						[
 							['exclude', '.*-w32\\.cpp$'],
+							['exclude', '.*-mac\\.cpp$'],	
+						],
+					},
+				],
+				[
+					'OS == "mac"',
+					{
+						'sources/':
+						[
+							['exclude', '.*-w32\\.cpp$'],
+							['exclude', '.*-lnx\\.cpp$'],	
 						],
 					},
 				],

--- a/libfoundation/src/system-dylib-lnx.cpp
+++ b/libfoundation/src/system-dylib-lnx.cpp
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "system-private.h"
+
+#include <foundation-auto.h>
+#include <dlfcn.h>
+
+void *_MCSDylibLoadModule(MCStringRef p_path)
+{
+	// dlopen loads whole 4-byte words when accessing the filename. This causes valgrind to make
+	// spurious noise - so in DEBUG mode we make sure we allocate a 4-byte aligned block of memory.
+	//
+	// Because converting to a sys string allocates memory, this alignment will always be satisfied.
+	// (malloc/new always return alignment >= int/pointer alignment)
+	MCAutoStringRefAsSysString t_filename_sys;
+	if (!t_filename_sys.Lock(p_path))
+		return nil;
+	
+	return dlopen(*t_filename_sys, (RTLD_NOW | RTLD_LOCAL));
+}
+
+void _MCSDylibUnloadModule(void *p_module)
+{
+	dlclose(p_module);
+}
+
+void *_MCSDylibResolveModuleSymbol(void* p_module, MCStringRef p_symbol)
+{
+	MCAutoStringRefAsSysString t_symbol_sys;
+	if (!t_symbol_sys.Lock(p_symbol))
+		return nil;
+
+	return dlsym(p_module, *t_symbol_sys);
+}

--- a/libfoundation/src/system-dylib-mac.cpp
+++ b/libfoundation/src/system-dylib-mac.cpp
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "system-private.h"
+
+#include <foundation-auto.h>
+#ifdef _SERVER
+#include <dlfcn.h>
+#else
+#include <mach-o/dyld.h>
+#endif
+
+void *_MCSDylibLoadModule(MCStringRef p_path)
+{
+	MCAutoStringRefAsSysString t_filename_sys;
+	if (!t_filename_sys.Lock(p_path))
+		return nil;
+
+#ifdef _SERVER
+	return dlopen(*t_filename_sys, RTLD_LAZY);
+#else
+	return (void *)NSAddImage(*t_filename_sys,
+	                          NSADDIMAGE_OPTION_RETURN_ON_ERROR |
+	                          NSADDIMAGE_OPTION_WITH_SEARCHING);
+#endif
+}
+
+void _MCSDylibUnloadModule(void *p_module)
+{
+#ifdef _SERVER
+	dlclose(p_module);
+#endif
+	//  Module unloading is not required after NSAddImage
+}
+
+void *_MCSDylibResolveModuleSymbol(void* p_module, MCStringRef p_symbol)
+{
+	MCAutoStringRefAsSysString t_symbol_sys;
+	if (!t_symbol_sys.Lock(p_symbol))
+		return nil;
+
+#ifdef _SERVER
+	return dlsym(p_module, *t_symbol_sys);
+#else
+	NSSymbol t_symbol;
+	t_symbol = NSLookupSymbolInImage((mach_header *)p_module,
+									 *t_symbol_sys,
+									 NSLOOKUPSYMBOLINIMAGE_OPTION_BIND_NOW);
+	if (t_symbol != NULL)
+		return NSAddressOfSymbol(t_symbol);
+#endif
+	
+	return nil;
+}

--- a/libfoundation/src/system-dylib-w32.cpp
+++ b/libfoundation/src/system-dylib-w32.cpp
@@ -1,0 +1,46 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#define __MCS_INTERNAL_API__
+#include <foundation.h>
+#include <foundation-system.h>
+#include <foundation-auto.h>
+
+#include <windows.h>
+
+void *_MCSFileLoadModule(MCStringRef p_path)
+{
+	MCAutoStringRefAsWString t_path_wstr;
+	if (!t_path_wstr.Lock(p_path))
+		return NULL;
+	
+	// MW-2011-02-28: [[ Bug 9410 ]] Use the Ex form of LoadLibrary and ask it to try
+	//   to resolve dependent DLLs from the folder containing the DLL first.
+	HMODULE t_handle;
+	t_handle = LoadLibraryExW(*t_path_wstr, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+}
+
+void _MCSFileUnloadModule(void *p_module)
+{
+	FreeLibrary((HMODULE)p_module);
+}
+
+void *_MCSFileResolveModuleSymbol(void* p_module, MCStringRef p_symbol)
+{
+	// NOTE: symbol addresses are never Unicode and only an ANSI call exists
+	return GetProcAddress((HMODULE)p_module, MCStringGetCString(p_symbol));
+}

--- a/libfoundation/src/system-dylib.cpp
+++ b/libfoundation/src/system-dylib.cpp
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "system-private.h"
+
+#include <foundation-auto.h>
+
+extern "C" MC_DLLEXPORT_DEF
+void *MCSDylibLoadModuleCString(const char *p_path)
+{
+	return MCSDylibLoadModule(MCSTR(p_path));
+}
+
+extern "C" MC_DLLEXPORT_DEF
+void *MCSDylibLoadModule(MCStringRef p_path)
+{
+	return _MCSDylibLoadModule(p_path);
+}
+
+extern "C" MC_DLLEXPORT_DEF
+void MCSDylibUnloadModule(void *p_module)
+{
+	_MCSDylibUnloadModule(p_module);
+}
+
+extern "C" MC_DLLEXPORT_DEF
+void *MCSDylibResolveModuleSymbolCString(void* p_module, const char *p_symbol)
+{
+	return MCSDylibResolveModuleSymbol(p_module, MCSTR(p_symbol));
+}
+
+MC_DLLEXPORT_DEF
+void *MCSDylibResolveModuleSymbol(void* p_module, MCStringRef p_symbol)
+{
+	return _MCSDylibResolveModuleSymbol(p_module, p_symbol);
+}
+
+/* ================================================================
+ * Initialization
+ * ================================================================ */
+
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSDylibModuleNotFoundErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSDylibSymbolNotFoundErrorTypeInfo;
+
+bool
+__MCSDylibInitialize (void)
+{
+	/* Create error types */
+	if (!MCNamedErrorTypeInfoCreate(
+	        MCNAME("livecode.lang.DylibModuleNotFoundError"),
+			MCNAME("dylib"),
+	        MCSTR("Unable to load module '%{path}': not found"),
+	        kMCSDylibModuleNotFoundErrorTypeInfo))
+		return false;
+
+	if (!MCNamedErrorTypeInfoCreate(
+	        MCNAME("livecode.lang.DylibSymbolNotFoundError"),
+			MCNAME("dylib"),
+	        MCSTR("Unable to resolve symbol '%{name}'"),
+	        kMCSDylibSymbolNotFoundErrorTypeInfo))
+		return false;
+
+	return true;
+}
+
+void
+__MCSDylibFinalize (void)
+{
+	MCValueRelease (kMCSDylibModuleNotFoundErrorTypeInfo);
+	MCValueRelease (kMCSDylibSymbolNotFoundErrorTypeInfo);
+}


### PR DESCRIPTION
This patch removes the engine dependency from our dynamic
library loading implementations. The MCU_loadmodule
per-platform implementations now (where possible) defer to
the foundation implementations.

Note that it is not possible to move all of this code into
libfoundation, as we need to do some special things with the
module path in the engine, such as trying to load relative to
MCcmd, or in a location specified by deploy parameters.