### PR TITLE
[[ Bug 18833 ]] Don't resave script only stacks when deploying standalone

### DIFF
--- a/docs/notes/bugfix-18833.md
+++ b/docs/notes/bugfix-18833.md
@@ -1,0 +1,1 @@
+# Don't change name of tsNet stack during standalone build

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1051,22 +1051,6 @@ end utilityMakePathRelative
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-command revSBResaveScriptOnlyStackAsProperStackFile pStackName, pStackFilePath, pOutputStackFilePath
-   lock messages
-   if there is a stack pStackName then
-      set the name of stack pStackName to "__keep_this_around__"
-   end if
-   create invisible stack "__temp_real_stack__"
-   set the script of stack "__temp_real_stack__" to the script of stack pStackFilePath
-   set the name of stack "__temp_real_stack__" to pStackName
-   save stack pStackName as pOutputStackFilePath
-   delete stack pStackName
-   if there is a stack "__keep_this_around__" then
-      set the name of stack "__keep_this_around__" to pStackName
-   end if
-   unlock messages
-end revSBResaveScriptOnlyStackAsProperStackFile
-
 # AL-2015-02-02: [[ Scriptify IDE ]] As we remove buttons from revLIbrary, we'll need to add to
 # this function to return the 'common' name of each of the libraries.
 function revSBScriptLibraryNameFromStackName pStack
@@ -2086,23 +2070,12 @@ command revSBUpdateDeployParams pStack, pTarget, pStandaloneSettings, @xDeployPa
       prependToStringList tInitScript, tStartupScript
    end if
    
-   -- Resave all aux stack files as non-script-only files 
-   local tResavedAux
-   if tAuxiliaryStackFiles is not empty then
-      repeat for each line tStackFile in tAuxiliaryStackFiles
-         local tTempStackFile
-         put the tempname into tTempStackFile
-         revSBResaveScriptOnlyStackAsProperStackFile the short name of stack tStackFile, tStackFile, tTempStackFile
-         appendToStringList tTempStackFile, tResavedAux
-      end repeat
-   end if
-   
    -- If the datagrid is used, then include the library as an aux stack
    if tIncludeDataGrid or "data grid templates" is in the subStacks of stack pStack and there is a stack "revDataGridLibrary" then
-      appendToStringList the effective filename of stack "revDataGridLibrary", tResavedAux
+      appendToStringList the effective filename of stack "revDataGridLibrary", tAuxiliaryStackFiles
    end if
    
-   put tResavedAux into xDeployParams["auxiliary_stackfiles"]
+   put tAuxiliaryStackFiles into xDeployParams["auxiliary_stackfiles"]
    put tStartupScript into xDeployParams["startup_script"]
    put tModules into xDeployParams["modules"]
 end revSBUpdateDeployParams


### PR DESCRIPTION
This was causing the tsNet behavior to become unlinked during standalone
build.

Requires http://quality.livecode.com/show_bug.cgi?id=19197 to be fixed before merging.