### PR TITLE
[[ Bug 19214 ]] Increase useful range of IntSize and IntSSize

### DIFF
--- a/docs/lcb/notes/19214.md
+++ b/docs/lcb/notes/19214.md
@@ -1,0 +1,14 @@
+# LiveCode Builder Standard Library
+
+## Foreign function interface
+
+* When passing a Number to one of the foreign integer types (`LCInt`, `LCUInt`,
+  `IntSize`, `UIntSize`), an error will be thrown if the value is outside the
+  range of the requested type.
+
+* The `IntSize` and `UIntSize` types can hold the full 64-bit integer range,
+  however the maximum magnitude which is supported for converting to and from
+  Number is 2^53. An error will be thrown for any conversions outside this
+  range.
+
+# [19214] Increase usable range of IntSize and UIntSize types

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -19,6 +19,8 @@
 
 #include "foundation-private.h"
 
+#include <limits>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCBoolTypeInfo;
@@ -173,6 +175,15 @@ bool __MCForeignValueCopyDescription(__MCForeignValue *self, MCStringRef& r_desc
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static bool
+__throw_numeric_overflow(MCTypeInfoRef p_error, MCTypeInfoRef p_type)
+{
+    return MCErrorCreateAndThrow(p_error,
+                                 "type", p_type,
+                                 "reason", MCSTR("numeric overflow"),
+                                 nil);
+}
+
 // bool foreign type handlers
 
 static void __bool_finalize(void *)
@@ -322,19 +333,25 @@ __size_import (void *contents,
                bool release,
                MCValueRef & r_value)
 {
-	size_t t_value = *(size_t *) contents;
+	size_t t_value = *static_cast<size_t *>(contents);
 
-	if (t_value > UINTEGER_MAX)
-	{
-		MCErrorCreateAndThrow (kMCForeignImportErrorTypeInfo,
-		                       "type", kMCSizeTypeInfo,
-		                       "reason", MCSTR("too large for Number representation"),
-		                       nil);
-		return false;
+    if (t_value <= UINTEGER_MAX)
+    {
+        return MCNumberCreateWithUnsignedInteger(uinteger_t(t_value),
+                                                 reinterpret_cast<MCNumberRef&>(r_value));
+    }
+#ifdef __64_BIT__
+    else if (t_value <= (1ULL << std::numeric_limits<double>::digits))
+    {
+        return MCNumberCreateWithReal(double(t_value),
+                                      reinterpret_cast<MCNumberRef&>(r_value));
+    }
+#endif
+    else
+    {
+        return __throw_numeric_overflow(kMCForeignImportErrorTypeInfo,
+                                        kMCSizeTypeInfo);
 	}
-
-	return MCNumberCreateWithUnsignedInteger((uinteger_t) t_value,
-	                                         (MCNumberRef &) r_value);
 }
 
 static bool
@@ -342,19 +359,26 @@ __ssize_import (void *contents,
                bool release,
                MCValueRef & r_value)
 {
-	ssize_t t_value = *(ssize_t *) contents;
+	ssize_t t_value = *static_cast<ssize_t *>(contents);
     
-	if (t_value < INTEGER_MIN || t_value > INTEGER_MAX)
-	{
-		MCErrorCreateAndThrow (kMCForeignImportErrorTypeInfo,
-		                       "type", kMCSizeTypeInfo,
-		                       "reason", MCSTR("too large for Number representation"),
-		                       nil);
-		return false;
+    if (t_value >= INTEGER_MIN && t_value <= INTEGER_MAX)
+    {
+        return MCNumberCreateWithInteger(integer_t(t_value),
+                                         reinterpret_cast<MCNumberRef&>(r_value));
+    }
+#ifdef __64_BIT__
+    else if (t_value >= -(1LL << std::numeric_limits<double>::digits) &&
+             t_value <= (1LL << std::numeric_limits<double>::digits))
+    {
+        return MCNumberCreateWithReal(double(t_value),
+                                      reinterpret_cast<MCNumberRef&>(r_value));
+    }
+#endif
+    else
+    {
+        return __throw_numeric_overflow(kMCForeignImportErrorTypeInfo,
+                                        kMCSSizeTypeInfo);
 	}
-    
-	return MCNumberCreateWithInteger((integer_t) t_value,
-                                     (MCNumberRef &) r_value);
 }
 
 static bool __float_import(void *contents, bool release, MCValueRef& r_value)
@@ -367,47 +391,64 @@ static bool __double_import(void *contents, bool release, MCValueRef& r_value)
     return MCNumberCreateWithReal(*(double *)contents, (MCNumberRef&)r_value);
 }
 
-static bool __int_export(MCValueRef value, bool release, void *contents)
+template <typename T>
+static bool
+__any_int_export(MCValueRef value,
+                 bool release,
+                 void *contents,
+                 MCTypeInfoRef typeinfo)
 {
-    *(integer_t *)contents = MCNumberFetchAsInteger((MCNumberRef)value);
+    // Fetch the number as a double
+    double t_value =
+            MCNumberFetchAsReal(static_cast<MCNumberRef>(value));
+ 
+    // First check that the value is within the contiguous integer range
+    // of doubles. If that succeeds, then check it fits within the target
+    // integer type.
+    if (t_value < double(-(1LL << std::numeric_limits<double>::digits)) ||
+        t_value > double(1LL << std::numeric_limits<double>::digits) ||
+        t_value < double(std::numeric_limits<T>::min()) ||
+        t_value > double(std::numeric_limits<T>::max()))
+    {
+        return __throw_numeric_overflow(kMCForeignExportErrorTypeInfo,
+                                        typeinfo);
+    }
+
+    *(T *)contents = T(t_value);
+
     if (release)
         MCValueRelease(value);
+    
     return true;
 }
 
-template <typename T>
 static bool
-__uint_export (MCValueRef value,
-               bool release,
-               void *contents,
-               MCTypeInfoRef typeinfo)
+__int_export(MCValueRef value, bool release, void *contents)
 {
-	/* Unsigned values can't be negative */
-	if (0 > MCNumberFetchAsReal ((MCNumberRef) value))
-	{
-		MCErrorCreateAndThrow (kMCForeignExportErrorTypeInfo,
-		                       "type", typeinfo,
-		                       "reason", MCSTR("cannot store negative value in unsigned integer"),
-		                       nil);
-		return false;
-	}
-
-    *(T *)contents = MCNumberFetchAsUnsignedInteger((MCNumberRef)value);
-
-    if (release)
-        MCValueRelease(value);
-    return true;
+    return __any_int_export<integer_t>(value, release, contents, kMCIntTypeInfo);
 }
 
 static bool
 __uint_export(MCValueRef value, bool release, void *contents)
 {
-	return __uint_export<uinteger_t>(value, release, contents, kMCUIntTypeInfo);
+	return __any_int_export<uinteger_t>(value, release, contents, kMCUIntTypeInfo);
+}
+
+static bool
+__size_export(MCValueRef value, bool release, void *contents)
+{
+    return __any_int_export<size_t>(value, release, contents, kMCSizeTypeInfo);
+}
+
+static bool
+__ssize_export(MCValueRef value, bool release, void *contents)
+{
+    return __any_int_export<ssize_t>(value, release, contents, kMCSSizeTypeInfo);
 }
 
 static bool __float_export(MCValueRef value, bool release, void *contents)
 {
-    *(float *)contents = MCNumberFetchAsReal((MCNumberRef)value);
+    *(float *)contents = float(MCNumberFetchAsReal((MCNumberRef)value));
     if (release)
         MCValueRelease(value);
     return true;
@@ -419,18 +460,6 @@ static bool __double_export(MCValueRef value, bool release, void *contents)
     if (release)
         MCValueRelease(value);
     return true;
-}
-
-static bool
-__size_export(MCValueRef value, bool release, void *contents)
-{
-	return __uint_export<size_t>(value, release, contents, kMCSizeTypeInfo);
-}
-
-static bool
-__ssize_export(MCValueRef value, bool release, void *contents)
-{
-	return __uint_export<ssize_t>(value, release, contents, kMCSSizeTypeInfo);
 }
 
 static bool

--- a/tests/lcb/stdlib/foreign.lcb
+++ b/tests/lcb/stdlib/foreign.lcb
@@ -20,6 +20,8 @@ module com.livecode.foreign.tests
 use com.livecode.foreign
 use com.livecode.__INTERNAL._testlib
 
+----------
+
 handler TestZStringNative_Null()
 	variable tList as ZStringNative
 	put "\u{0}" into tList
@@ -47,6 +49,125 @@ public handler TestZStringUTF16()
 	-- Check that strings containing embedded nuls can't be
 	-- bridged.
 	MCUnitTestHandlerThrowsBroken(TestZStringUTF16_Null, "ZStringUTF16 (nulls)", "bug 14829")
+end handler
+
+----------
+
+private foreign handler printf_int(in pFormat as ZStringNative, in pValue as LCInt) returns nothing binds to "printf"
+private foreign handler printf_uint(in pFormat as ZStringNative, in pValue as LCUInt) returns nothing binds to "printf"
+private foreign handler printf_intsize(in pFormat as ZStringNative, in pValue as IntSize) returns nothing binds to "printf"
+private foreign handler printf_uintsize(in pFormat as ZStringNative, in pValue as UIntSize) returns nothing binds to "printf"
+
+foreign handler MCHandlerTryToInvokeWithList(in Handler as any, inout Arguments as optional List, out Result as optional any) returns optional any binds to "<builtin>"
+
+private handler __Is64Bit() returns nothing
+    variable tSize as UIntSize
+    put 4294967296.0 into tSize
+    unsafe
+        printf_uintsize("", tSize)
+    end unsafe
+end handler
+
+private handler Is64Bit()
+    variable tResult as optional any
+    variable tArguments as optional List
+    variable tError as optional any
+    put [] into tArguments
+    unsafe
+        put MCHandlerTryToInvokeWithList(__Is64Bit, tArguments, tResult) into tError
+    end unsafe
+    return tError is nothing
+end handler
+
+handler TestIntRange_Min()
+    variable tInt as LCInt
+    put -2147483649.0 into tInt
+    unsafe
+        printf_int("", tInt)
+    end unsafe
+end handler
+
+handler TestIntRange_Max()
+    variable tInt as LCInt
+    put 2147483648.0 into tInt
+    unsafe
+        printf_int("", tInt)
+    end unsafe
+end handler
+
+handler TestUIntRange_Min()
+    variable tUInt as LCUInt
+    put -1.0 into tUInt
+    unsafe
+        printf_uint("", tUInt)
+    end unsafe
+end handler
+
+handler TestUIntRange_Max()
+    variable tUInt as LCUInt
+    put 4294967296.0 into tUInt
+    unsafe
+        printf_uint("", tUInt)
+    end unsafe
+end handler
+
+handler TestIntSizeRange_Min()
+    variable tInt as IntSize
+    if Is64Bit() then
+        put -9007199254740994.0 into tInt
+    else
+        put -2147483649.0 into tInt
+    end if
+    unsafe
+        printf_intsize("", tInt)
+    end unsafe
+end handler
+
+handler TestIntSizeRange_Max()
+    variable tInt as IntSize
+    if Is64Bit() then
+        put 9007199254740994.0 into tInt
+    else
+        put 2147483648.0 into tInt
+    end if
+    unsafe
+        printf_intsize("", tInt)
+    end unsafe
+end handler
+
+handler TestUIntSizeRange_Min()
+    variable tUInt as UIntSize
+    put -1.0 into tUInt
+    unsafe
+        printf_uintsize("", tUInt)
+    end unsafe
+end handler
+
+handler TestUIntSizeRange_Max()
+    variable tUInt as UIntSize
+    if Is64Bit() then
+        test diagnostic "64-bit"
+        put 9007199254740994.0 into tUInt
+    else
+        put 4294967296.0 into tUInt
+    end if
+    unsafe
+        printf_uintsize("", tUInt)
+    end unsafe
+end handler
+
+public handler TestForeignIntRanges()
+    MCUnitTestHandlerThrows(TestIntRange_Min, "LCInt minimum value")
+    MCUnitTestHandlerThrows(TestIntRange_Max, "LCInt maximum value")
+
+    MCUnitTestHandlerThrows(TestUIntRange_Min, "LCUInt minimum value")
+    MCUnitTestHandlerThrows(TestUIntRange_Max, "LCUInt maximum value")
+
+    MCUnitTestHandlerThrows(TestIntSizeRange_Min, "IntSize minimum value")
+    MCUnitTestHandlerThrows(TestIntSizeRange_Max, "IntSize maximum value")
+
+    MCUnitTestHandlerThrows(TestUIntSizeRange_Min, "UIntSize minimum value")
+    MCUnitTestHandlerThrows(TestUIntSizeRange_Max, "UIntSize maximum value")
 end handler
 
 end module


### PR DESCRIPTION
This patch ensures that IntSize and IntSSize values are truncated
to the maximum exact integer value double will allow - +/- 2^53
rather than the range of an Int32.

The rationale behind this change is that all arithmetic in the engine
is currently done using doubles regardless of the internal storage
type of the MCNumberRef and nowhere distinguishes between
integer and real MCNumberRefs.