### PR TITLE
[CID 16332] Fix resource leak in MCServerScript::FindFileIndex()

### DIFF
--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -33,6 +33,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "debug.h"
 #include "stack.h"
 #include "cmds.h"
+#include "variable.h"
 
 
 #include "system.h"

--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -119,7 +119,15 @@ uint4 MCServerScript::FindFileIndex(MCStringRef p_filename, bool p_add)
 
 	if (t_file == NULL)
 		return 0;
-	
+
+    /* If the file was newly-created, link it into the MCServerScript
+     * instance's list of files so that it doesn't get leaked. */
+    /* TODO[2017-02-06] This is fragile; FindFile() should be
+     * refactored so that it's not necessary to guess whether the
+     * caller owns the returned pointer or not. */
+    if (t_file->next == m_files)
+        m_files = t_file;
+
 	return t_file -> index;
 }
 

--- a/engine/src/srvscript.cpp
+++ b/engine/src/srvscript.cpp
@@ -67,8 +67,6 @@ MCServerScript::~MCServerScript(void)
         else
             delete t_file -> script;
 
-        // SN-2015-07-09: [[ Merge 6.7.7 RC 1 ]] Avoid memory leak
-        MCValueRelease(t_file -> filename);
 		delete t_file;
 	}
 	
@@ -83,7 +81,7 @@ void MCServerScript::ListFiles(MCStringRef &r_string)
 	MCListRef t_list;
 	/* UNCHECKED */ MCListCreateMutable('\n', t_list);
 	for(File *t_file = m_files; t_file != NULL; t_file = t_file -> next)
-		/* UNCHECKED */ MCListAppend(t_list, t_file->filename);
+		/* UNCHECKED */ MCListAppend(t_list, *t_file->filename);
 	
 	/* UNCHECKED */ MCListCopyAsStringAndRelease(t_list, r_string);
 }
@@ -109,7 +107,7 @@ bool MCServerScript::GetFileForContext(MCExecContext &ctxt, MCStringRef &r_file)
 	
 	for(File *t_file = m_files; t_file != NULL; t_file = t_file -> next)
 		if (t_file -> index == t_file_index)
-            return MCStringCopy(t_file -> filename, r_file);
+            return MCStringCopy(*t_file -> filename, r_file);
 	
     return false;
 }
@@ -141,7 +139,7 @@ MCServerScript::File *MCServerScript::FindFile(MCStringRef p_filename, bool p_ad
 	// Look through the file list...
 	File *t_file;
 	for(t_file = m_files; t_file != NULL; t_file = t_file -> next)
-        if (MCStringIsEqualTo(t_file -> filename, *t_resolved_filename, kMCStringOptionCompareExact))
+        if (MCStringIsEqualTo(*t_file -> filename, *t_resolved_filename, kMCStringOptionCompareExact))
 			break;
 	
 	// If we are here the file doesn't exist (yet). If we aren't in
@@ -351,7 +349,7 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
     {
 		// Set the default folder to the folder containing the current script
 		MCAutoStringRef t_full_path;
-        /* UNCHECKED */ MCsystem->LongFilePath(m_current_file -> filename, &t_full_path);
+        /* UNCHECKED */ MCsystem->LongFilePath(*m_current_file -> filename, &t_full_path);
 		
 		uindex_t t_last_separator;
 		if (MCStringLastIndexOfChar(*t_full_path, '/', UINDEX_MAX, kMCStringOptionCompareExact, t_last_separator))
@@ -367,7 +365,7 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 	t_file = FindFile(p_filename, true);
 	if (t_file -> index == 1)
 	{
-		setfilename(t_file -> filename);
+		setfilename(*t_file -> filename);
 	}
 
 	// Set back the old default folder
@@ -385,10 +383,10 @@ bool MCServerScript::Include(MCExecContext& ctxt, MCStringRef p_filename, bool p
 	{
 		MCAutoDataRef t_file_contents;
 
-		if (!MCS_loadbinaryfile (t_file->filename,
+		if (!MCS_loadbinaryfile (*t_file->filename,
 								 &t_file_contents))
 		{
-			MCeerror -> add(EE_INCLUDE_FILENOTFOUND, 0, 0, t_file -> filename);
+			MCeerror -> add(EE_INCLUDE_FILENOTFOUND, 0, 0, *t_file -> filename);
 			delete t_file;
 			return false;
 		}

--- a/engine/src/srvscript.h
+++ b/engine/src/srvscript.h
@@ -58,7 +58,7 @@ private:
 		File *next;
 		
 		// The absolute filename of the file it refers to.
-        MCStringRef filename;
+        MCAutoStringRef filename;
 		
 		// The buffer containing the file's contents. This should be treated
 		// as read-only as it could be mmapped. We need to keep this around


### PR DESCRIPTION
`MCServerScript::FindFile()` looks for and returns the server script
file record for the specified filename, and optionally allocates a new
record if one was not found.

When a new record is allocated, it is _not_ added to the list of
records in the `MCServerScript` instance.  This requires the caller of
`FindFile()` to free or store the record.  However, there is no
_direct_ way to determine whether the record returned by `FindFile()`
was newly allocated or is owned by the `MCServerScript`.

`MCServerScript::FindFileIndex()` is used by the server debug
infrastructure while adding breakpoints.  Sometimes it is called to
add breakpoints in files that have not yet been loaded, which means it
needs to call `FindFile()` to create new records for unloaded files.

Coverity Scan detected that `FindFileIndex()` was always discarding
the return value of `FindFile()`, leading to memory leaks and broken
server debugging.

This patch works around the problem by making `FindFileIndex()` try to
detect if `FindFile()` allocated a new record and, if so, handing over
ownership to the `MCServerScript` instance.  However, this is fragile,
and it would be better to refactor `MCServerScript::FindFile()` (etc.)
to make this unnecessary.