### PR TITLE
[Bug 19215] Ensure button icons are present in standalones

### DIFF
--- a/docs/notes/bugfix-19215.md
+++ b/docs/notes/bugfix-19215.md
@@ -1,0 +1,1 @@
+# Make sure botton icons are present in standalones when building for multiple platforms

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -1462,6 +1462,8 @@ private command revCopyIcons pStack
       
       put "revGeneralIcons" & return & "revCompatibilityIcons1" & return & "revGeneralPatterns" & return & "revCompatibilityPatterns1" & return & "revCompatibilityPatterns2" & return & "revCustomCursors" into tStacksList
       set the itemDel to slash
+      local tIconA
+      put sIconA into tIconA
       repeat for each line tFile in tFiles
          if there is not a stack tFile then next repeat -- windows placeholder
          put return & the short name of stack tFile after tStacksList
@@ -1472,10 +1474,10 @@ private command revCopyIcons pStack
          repeat with tCard =1 to tCardNum
             put the number of images of cd tCard of stack tStack into tImageNum
             repeat with tImage =1 to tImageNum
-               if sIconA[the short id of image tImage of cd tCard of stack tStack] then
+               if tIconA[the short id of image tImage of cd tCard of stack tStack] then
                   copy image tImage of cd tCard of stack tStack to stack "revCopiedIcons"
                   set the id of the last image of stack "revCopiedIcons" to the short id of image tImage of cd tCard of stack tStack
-                  put false into sIconA[the short id of image tImage of cd tCard of stack tStack]
+                  put false into tIconA[the short id of image tImage of cd tCard of stack tStack]
                end if
             end repeat
          end repeat


### PR DESCRIPTION
`sIconA` contains info about which icons to include in the standalone. Changing the contents of `sIconA` resulted in icons being lost when building for multiple platforms, since `sIconA[iconID]` was false for every iconID in subsequent builds.