### PR TITLE
Fix some Coverity defects relating to deallocator usage

### DIFF
--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -266,10 +266,8 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 			//   so load, delete and unset the flag.
 			// MW-2013-11-19: [[ UnicodeFileFormat ]] The storage of this is ignored,
 			//   so is legacy,
-			char *backcolorname;
-			if ((stat = IO_read_cstring_legacy(backcolorname, stream, 2)) != IO_NORMAL)
+			if ((stat = IO_discard_cstring_legacy(stream, 2)) != IO_NORMAL)
 				return checkloadstat(stat);
-			delete backcolorname;
 			flags &= ~F_HAS_BACK_COLOR_NAME;
 		}
 	}

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -455,13 +455,12 @@ IO_stat MCDispatch::readstartupstack(IO_handle stream, MCStack*& r_stack)
 {
 	uint32_t version;
 	uint1 charset, type;
-	char *newsf;
 	
 	// MW-2013-11-19: [[ UnicodeFileFormat ]] newsf is no longer used.
 	if (readheader(stream, version) != IO_NORMAL
 	        || IO_read_uint1(&charset, stream) != IO_NORMAL
 	        || IO_read_uint1(&type, stream) != IO_NORMAL
-	        || IO_read_cstring_legacy(newsf, stream, 2) != IO_NORMAL)
+	        || IO_discard_cstring_legacy(stream, 2) != IO_NORMAL)
 		return IO_ERROR;
 
 	// MW-2008-10-20: [[ ParentScripts ]] Set the boolean flag that tells us whether
@@ -469,7 +468,6 @@ IO_stat MCDispatch::readstartupstack(IO_handle stream, MCStack*& r_stack)
 	s_loaded_parent_script_reference = false;
 
 	MCtranslatechars = charset != CHARSET;
-	delete newsf; // stackfiles is obsolete
 
 	MCStack *t_stack = nil;
 	/* UNCHECKED */ MCStackSecurityCreateStack(t_stack);

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -563,15 +563,13 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
 		
 		// MW-2013-11-19: [[ UnicodeFileFormat ]] newsf is no longer used.
 		uint1 charset, type;
-		char *newsf;
 		if (IO_read_uint1(&charset, stream) != IO_NORMAL
 		        || IO_read_uint1(&type, stream) != IO_NORMAL
-		        || IO_read_cstring_legacy(newsf, stream, 2) != IO_NORMAL)
+		        || IO_discard_cstring_legacy(stream, 2) != IO_NORMAL)
 		{
 			MCresult->sets("stack is corrupted, check for ~ backup file");
 			return checkloadstat(IO_ERROR);
 		}
-		delete newsf; // stackfiles is obsolete
 		MCtranslatechars = charset != CHARSET;
 		sptr = nil;
 		/* UNCHECKED */ MCStackSecurityCreateStack(sptr);
@@ -586,12 +584,8 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
 		{
 			// MW-2013-11-19: [[ UnicodeFileFormat ]] These strings are never written out, so
 			//   legacy.
-			char *lstring = NULL;
-			char *cstring = NULL;
-			IO_read_cstring_legacy(lstring, stream, 2);
-			IO_read_cstring_legacy(cstring, stream, 2);
-			delete lstring;
-			delete cstring;
+			IO_discard_cstring_legacy(stream, 2);
+			IO_discard_cstring_legacy(stream, 2);
 		}
 
 		MCresult -> clear();

--- a/engine/src/lnxelevate.cpp
+++ b/engine/src/lnxelevate.cpp
@@ -37,11 +37,10 @@ static bool make_tmp_fifo_pair(char*& r_name)
 	bool t_success;
 	t_success = true;
 
-	char *t_name;
-	t_name = strclone("/tmp/revtalk-XXXXXX");
+	MCAutoPointer<char[]> t_name = strclone("/tmp/revtalk-XXXXXX");
 
 	if (t_success &&
-		mkdtemp(t_name) == nil)
+		mkdtemp(*t_name) == nil)
 		t_success = false;
 
 	char t_input_fifo_name[64], t_output_fifo_name[64];
@@ -50,8 +49,8 @@ static bool make_tmp_fifo_pair(char*& r_name)
 	t_has_output_fifo = false;
 	if (t_success)
 	{
-		sprintf(t_input_fifo_name, "%s/input", t_name);
-		sprintf(t_output_fifo_name, "%s/output", t_name);
+		sprintf(t_input_fifo_name, "%s/input", *t_name);
+		sprintf(t_output_fifo_name, "%s/output", *t_name);
 
 		t_has_input_fifo = mkfifo(t_input_fifo_name, 0600) != -1;
 		t_has_output_fifo = mkfifo(t_output_fifo_name, 0600) != -1;
@@ -60,14 +59,13 @@ static bool make_tmp_fifo_pair(char*& r_name)
 	}
 
 	if (t_success)
-		r_name = t_name;
+		r_name = t_name.Release();
 	else
 	{
 		if (t_has_input_fifo)
 			unlink(t_input_fifo_name);
 		if (t_has_output_fifo)
 			unlink(t_output_fifo_name);
-		MCCStringFree(t_name);
 	}
 
 	return t_success;
@@ -207,7 +205,7 @@ bool MCSystemOpenElevatedProcess(MCStringRef p_command, int32_t& r_pid, int32_t&
 	if (t_success)
 		t_success = MCCStringTokenize(*t_command, t_argv, t_argc);
 
-	MCAutoPointer<char> t_fifo_name;
+	MCAutoPointer<char[]> t_fifo_name;
 	if (t_success)
 		t_success = make_tmp_fifo_pair(&t_fifo_name);
 		

--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -435,33 +435,31 @@ IO_stat IO_read_string_legacy_full(char *&r_string, uint32_t &r_length, IO_handl
 		}
 	}
 	
-	char *t_string = nil;
+	MCAutoCustomPointer<char,MCMemoryDeallocate> t_string;
 	if (t_bytes != 0)
 	{
 		t_length = p_includes_null ? t_bytes - 1 : t_bytes;
-		if (!MCMemoryAllocate(t_bytes, t_string))
+		if (!MCMemoryAllocate(t_bytes, &t_string))
 			return IO_ERROR;
-		stat = MCStackSecurityRead(t_string, t_length, p_stream);
+		stat = MCStackSecurityRead(*t_string, t_length, p_stream);
 		if (stat == IO_NORMAL && p_includes_null)
-			stat = IO_read_uint1((uint1*)t_string + t_length, p_stream);
+			stat = IO_read_uint1(reinterpret_cast<uint1*>(*t_string) + t_length,
+                                 p_stream);
 		if (stat != IO_NORMAL)
-		{
-			delete t_string;
 			return stat;
-		}
 
 		if (MCtranslatechars && p_translate)
 		{
 #ifdef __MACROMAN__
-			IO_iso_to_mac(t_string, t_length);
+			IO_iso_to_mac(*t_string, t_length);
 #else
-			IO_mac_to_iso(t_string, t_length);
+			IO_mac_to_iso(*t_string, t_length);
 #endif
 			
 		}
 	}
 	
-	r_string = t_string;
+	r_string = t_string.Release();
 	r_length = t_length;
 	
 	return IO_NORMAL;

--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -473,6 +473,15 @@ IO_stat IO_read_cstring_legacy(char *&r_string, IO_handle stream, uint1 size)
 	return IO_read_string_legacy_full(r_string, t_length, stream, size, true, true);
 }
 
+IO_stat IO_discard_cstring_legacy(IO_handle stream, uint1 size)
+{
+    /* TODO[2017-02-06] Refactor so that this doesn't allocate any
+     * memory, rather than inefficiently allocating a buffer and then
+     * immediately freeing it. */
+	MCAutoCustomPointer<char,MCMemoryDeallocate> t_discarded;
+	return IO_read_cstring_legacy(&t_discarded, stream, size);
+}
+
 #if 0
 IO_stat IO_read_string(char *&string, uint4 &outlen, IO_handle stream,
                        bool isunicode, uint1 size)

--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -796,7 +796,7 @@ IO_stat IO_read_stringref_legacy_utf8(MCStringRef& r_string, IO_handle stream, u
 		return stat;
 	if (!MCStringCreateWithBytesAndRelease((byte_t *)t_bytes, t_bytes != nil ? strlen(t_bytes) : 0, kMCStringEncodingUTF8, false, r_string))
 	{
-		delete[] t_bytes;
+		MCMemoryDeallocate (t_bytes);
 		return IO_ERROR;
 	}
 	

--- a/engine/src/mcio.h
+++ b/engine/src/mcio.h
@@ -120,6 +120,8 @@ extern IO_stat IO_read_string_legacy_full(char *&r_string, uint32_t &r_length, I
 extern IO_stat IO_write_string_legacy_full(const MCString &string, IO_handle stream, uint1 size, bool p_write_null);
 extern IO_stat IO_read_cstring_legacy(char*& r_string, IO_handle stream, uint1 size);
 extern IO_stat IO_write_cstring_legacy(const char* string, IO_handle stream, uint1 size);
+// Read and immediately discard a legacy string
+extern IO_stat IO_discard_cstring_legacy(IO_handle string, uint1 size);
 
 // These methods are used by 5.5 -> 7.0 props which saved their value out in UTF-8.
 extern IO_stat IO_read_stringref_legacy_utf8(MCStringRef& r_string, IO_handle stream, uint1 size = 2);

--- a/engine/src/visual.cpp
+++ b/engine/src/visual.cpp
@@ -170,30 +170,28 @@ Parse_stat MCVisualEffect::parse(MCScriptPoint &sp)
 		
 	do
     {
-        char* t_key;
+        MCAutoCustomPointer<char,MCMemoryDeleteArray> t_key;
 		MCExpression *t_value = NULL;
 		bool t_has_id = false;
-        t_key = nil;
 	
         if (sp . next(type) == PS_NORMAL && type == ST_ID)
-            MCStringConvertToCString(sp . gettoken_stringref(), t_key);
+            MCStringConvertToCString(sp . gettoken_stringref(), &t_key);
 		
 		if (sp . skip_token(SP_FACTOR, TT_PROPERTY, P_ID) == PS_NORMAL)
 			t_has_id = true;
 		
-        if (t_key != NULL && sp . parseexp(True, False, &t_value) == PS_NORMAL)
+        if (t_key && sp . parseexp(True, False, &t_value) == PS_NORMAL)
 		{
 			KeyValue *t_kv;
 			t_kv = new (nothrow) KeyValue;
             t_kv -> next = parameters;
-            t_kv -> key = t_key;
+            t_kv -> key = t_key.Release();
 			t_kv -> value = t_value;
 			t_kv -> has_id = t_has_id;
 			parameters = t_kv;
 		}
 		else
 		{
-			delete[] t_key;
 			MCperror -> add(PE_VISUAL_BADPARAM, sp);
 		}
 	}

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1113,6 +1113,10 @@ template<typename T> bool MCMemoryReallocate(T *p_block, size_t p_new_size, T*& 
 	return false;
 }
 
+template<typename T> void MCMemoryDeallocate(T* p_block) {
+    MCMemoryDeallocate (static_cast<void*>(p_block));
+}
+
 extern "C" {
     
 ////////////////////////////////////////////////////////////////////////////////

--- a/revbrowser/src/revbrowser.cpp
+++ b/revbrowser/src/revbrowser.cpp
@@ -511,7 +511,7 @@ send \"browser%s\" && %d, quote & \"%s\" & quote to this card of XBrowservar";
 	SendCardMessageUTF8(t_message, &t_retval);
 	t_instance -> callback_depth -= 1;
 	
-    delete t_message;
+    MCCStringFree (t_message);
     
 	if (t_instance -> stack_id != NULL)
 		free(t_instance -> stack_id);

--- a/revdb/src/unxsupport.cpp
+++ b/revdb/src/unxsupport.cpp
@@ -124,13 +124,14 @@ char *MCS_resolvepath(const char *path)
       pw = getpwnam(tpath + 1);
     if (pw == NULL)
       return NULL;
-    tildepath = new (nothrow) char[strlen(pw->pw_dir) + strlen(tptr) + 2];
+    tildepath = static_cast<char*>(malloc(sizeof(*tildepath) *
+                                          (strlen(pw->pw_dir) + strlen(tptr) + 2)));
     strcpy(tildepath, pw->pw_dir);
     if (*tptr) {
       strcat(tildepath, "/");
       strcat(tildepath, tptr);
     }
-    delete tpath;
+    free(tpath);
   }
   else
     tildepath = strclone(path);
@@ -150,11 +151,11 @@ char *MCS_resolvepath(const char *path)
   char *newname = new (nothrow) char[PATH_MAX + 2];
 
   if ((size = readlink(tildepath, newname, PATH_MAX)) < 0) {
-    delete tildepath;
-    delete newname;
+      free(tildepath);
+    delete[] newname;
     return NULL;
   }
-  delete tildepath;
+  free(tildepath);
   newname[size] = '\0';
   if (newname[0] != '/') {
     char *fullpath = new (nothrow) char[strlen(path) + strlen(newname) + 2];
@@ -165,9 +166,9 @@ char *MCS_resolvepath(const char *path)
     else
       sptr++;
     strcpy(sptr, newname);
-    delete newname;
+    delete[] newname;
     newname = MCS_resolvepath(fullpath);
-    delete fullpath;
+    delete[] fullpath;
   }
   return newname;
 }


### PR DESCRIPTION
This PR fixes several Coverity defects relating to incorrect deallocator usage, including:

- Using `free()` when `delete` or `delete[]` should have been used (and *vice versa*)
- Using `delete` when `delete[]` should have been used (and *vice versa*)

Where possible, the fix has been accomplished by using appropriate managed pointers.