### PR TITLE
[[ Bug 19166 ]] Make sure ASLR is taken into account on Mac

### DIFF
--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1843,8 +1843,8 @@ static void *MCExecutableFindSection(const char *p_name)
 			if (MCMemoryEqual(t_segment -> segname, p_name, MCMin(16, strlen(p_name) + 1)))
 			{
 				const section *t_section;
-				t_section = (const section *)(t_segment + 1);
-				return (void *)t_section -> addr;
+                t_section = (const section *)(t_segment + 1);
+				return reinterpret_cast<char *>(t_section -> addr) + _dyld_get_image_vmaddr_slide(0);
 			}
 		}
 		


### PR DESCRIPTION
This patch ensures that the 'slide' required by ASLR is taken into
account when computing the address of the PROJECT section in the
installer startup functions.