### PR TITLE
build: Launch mspdbsrv (well) outside build tree

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -15,7 +15,12 @@ ECHO %ProgramFilesBase%
 @REM Works around hangs when generating .pdb files
 @REM Needs to run in the background as never terminates
 @REM
+@REM Run this with its CWD outside the build tree so that
+@REM the fact it hangs around does not interfere with
+@REM cleaning up the build tree.
+@pushd %ProgramFilesBase%
 @start /min /b mspdbsrv -start -spawn -shutdowntime -1
+@popd
 
 @REM Select the correct build mode.
 @REM


### PR DESCRIPTION
The first step in each buildbot run is to clean the working tree
from the last run.  On Windows, it is not possible to delete a
directory (or its parents) which is still the current working
directory for a process.

The `make.cmd` batch script launches the `mspdbsrv` service to
collect debug information from the Windows build.  The service
runs continuously in the background; it isn't shut down when the
build completes.

Since the `make.cmd` script was being run with its CWD in the build
tree, `mspdbsrv` was also remaining running in the build tree,
blocking the deletion of the build tree.

`mspdbsrv` can be run with any CWD, so this patch modifies
`make.cmd` to launch `mspdbsrv` in the `$ProgramFiles(x86)`
directory.