### PR TITLE
[[ Script-only deploy ]] Add missing call to processstack

### DIFF
--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1276,6 +1276,7 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
             MCresult -> sets("failed to read auxillary stack");
             return false;
         }
+        MCdispatcher -> processstack(kMCEmptyString, t_aux_stack);
     }
         break;
 			


### PR DESCRIPTION
Without this, script-only auxiliary stacks loaded from the capsule
in installer mode do not get added to the stacks list.