### PR TITLE
[[ SocketLocalPort ]] Added the ability to specify the local host and…

### DIFF
--- a/docs/dictionary/command/open-socket.lcdoc
+++ b/docs/dictionary/command/open-socket.lcdoc
@@ -2,11 +2,11 @@ Name: open socket
 
 Type: command
 
-Syntax: open [datagram] socket [from [<localHostName>][:localPort]] [to] <socketID> [with message <callbackMessage>]
+Syntax: open [datagram] socket [from [<localHostName>][:<localPort>]] [to] <socketID> [with message <callbackMessage>]
 
-Syntax: open secure socket [from [<localHostName>][:localPort]] [to] <socketID> [with message <callbackMessage>] [without verification] [using certificate <certificate> and key <key>]
+Syntax: open secure socket [from [<localHostName>][:<localPort>]] [to] <socketID> [with message <callbackMessage>] [without verification] [using certificate <certificate> and key <key>]
 
-Syntax: open secure socket [from [<localHostName>][:localPort]] [to] <socketID> [with message <callbackMessage>] [with verification [for host <verificationHostName>]] [using certificate <certificate> and key <key>]
+Syntax: open secure socket [from [<localHostName>][:<localPort>]] [to] <socketID> [with message <callbackMessage>] [with verification [for host <verificationHostName>]] [using certificate <certificate> and key <key>]
 
 Summary:
 Establishes a <TCP> communications <socket> between your system and
@@ -35,7 +35,7 @@ Example:
 open secure socket to "livecode.com:443" with message "wasConnected" with verification for host "livecode.com"
 
 Example:
-open udp socket from ":8080" to "10.2.1.1:8080"
+open datagram socket from ":8080" to "10.2.1.1:8080"
 
 Example:
 on mouseUp

--- a/docs/dictionary/command/open-socket.lcdoc
+++ b/docs/dictionary/command/open-socket.lcdoc
@@ -2,11 +2,11 @@ Name: open socket
 
 Type: command
 
-Syntax: open [datagram] socket [to] <socketID> [with message <callbackMessage>]
+Syntax: open [datagram] socket [from [<localHostName>][:localPort]] [to] <socketID> [with message <callbackMessage>]
 
-Syntax: open secure socket [to] <socketID> [with message <callbackMessage>] [without verification] [using certificate <certificate> and key <key>]
+Syntax: open secure socket [from [<localHostName>][:localPort]] [to] <socketID> [with message <callbackMessage>] [without verification] [using certificate <certificate> and key <key>]
 
-Syntax: open secure socket [to] <socketID> [with message <callbackMessage>] [with verification [for host <verificationHostName>]] [using certificate <certificate> and key <key>]
+Syntax: open secure socket [from [<localHostName>][:localPort]] [to] <socketID> [with message <callbackMessage>] [with verification [for host <verificationHostName>]] [using certificate <certificate> and key <key>]
 
 Summary:
 Establishes a <TCP> communications <socket> between your system and
@@ -35,6 +35,9 @@ Example:
 open secure socket to "livecode.com:443" with message "wasConnected" with verification for host "livecode.com"
 
 Example:
+open udp socket from ":8080" to "10.2.1.1:8080"
+
+Example:
 on mouseUp
    open socket "www.google.com:80"
    write "test" \
@@ -47,6 +50,16 @@ on socketFinishedWriting pSocketID
 end socketFinishedWriting
 
 Parameters:
+localHostName:
+The name or IP address of the local host to use when opening the socket.
+If no local host name is specified, then the <defaultNetworkInterface>
+property will be used. If the <defaultNetworkInterface> has not been
+set, then the system's default local host will be used.
+
+localPort:
+The local port to use when opening the socket. If no local port is
+specified, then the OS will select a free local port.
+
 socketID:
 The identifier (set when you opened the socket) of the socket you want
 to close. The socket identifier starts with the IP address of the host
@@ -171,9 +184,11 @@ invoked with the resolved address as a parameter.
 Changes:
 (6.7) Added the "with verification for host" variant.
 
+(9.0) Added the ability to specify the local host and port.
+
 References: accept (command), post (command), wait (command),
 TCP (glossary), command (glossary), socket (glossary),
 Standalone Application Settings (glossary), command (glossary),
 LiveCode custom library (glossary), SSL & Encryption library (library),
-socketTimeout (message)
+socketTimeout (message), defaultNetworkInterface (property)
 

--- a/docs/notes/feature-socket_local_port.md
+++ b/docs/notes/feature-socket_local_port.md
@@ -1,0 +1,7 @@
+# Specifying local host and port when opening a socket
+
+When opening a socket you can now specify the local port and host the socket should use. An example of this is as follows:
+
+    open socket from ":8080" to "10.2.1.1:8080"
+
+See the open socket dictionary entry for full details.

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1530,6 +1530,7 @@ class MCOpen : public MCStatement
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added new "open socket <socket> with verification for <host>" variant.
 	MCExpression *verifyhostname;
+    MCExpression *fromaddress;
 public:
 	MCOpen()
 	{
@@ -1545,6 +1546,7 @@ public:
 		elevated = False;
         textmode = True;		
 		verifyhostname = NULL;
+        fromaddress = NULL;
 	}
 	virtual ~MCOpen();
 	virtual Parse_stat parse(MCScriptPoint &);

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1530,7 +1530,7 @@ class MCOpen : public MCStatement
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added new "open socket <socket> with verification for <host>" variant.
 	MCExpression *verifyhostname;
-    MCExpression *fromaddress;
+    MCAutoPointer<MCExpression> fromaddress;
 public:
 	MCOpen()
 	{
@@ -1546,7 +1546,6 @@ public:
 		elevated = False;
         textmode = True;		
 		verifyhostname = NULL;
-        fromaddress = NULL;
 	}
 	virtual ~MCOpen();
 	virtual Parse_stat parse(MCScriptPoint &);

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -1816,7 +1816,6 @@ MCOpen::~MCOpen()
 	MCValueRelease(destination);
 	delete certificate;
 	delete verifyhostname;
-    delete fromaddress;
 }
 
 Parse_stat MCOpen::parse(MCScriptPoint &sp)
@@ -1897,7 +1896,7 @@ Parse_stat MCOpen::parse(MCScriptPoint &sp)
 	}
     if (arg == OA_SOCKET && sp.skip_token(SP_FACTOR, TT_FROM, PT_FROM) == PS_NORMAL)
     {
-        if (sp.parseexp(False, True, &fromaddress) != PS_NORMAL)
+        if (sp.parseexp(False, True, &(&fromaddress)) != PS_NORMAL)
         {
             MCperror->add(PE_OPEN_NOFROM, sp);
             return PS_ERROR;
@@ -2141,7 +2140,7 @@ void MCOpen::exec_ctxt(MCExecContext &ctxt)
                 return;
             
             MCNewAutoNameRef t_from_address;
-            if (!ctxt . EvalOptionalExprAsNameRef(fromaddress, kMCEmptyName, EE_OPEN_BADFROMADDRESS, &t_from_address))
+            if (!ctxt . EvalOptionalExprAsNameRef(fromaddress.Get(), kMCEmptyName, EE_OPEN_BADFROMADDRESS, &t_from_address))
                 return;
 
             // MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -54,9 +54,9 @@ MC_EXEC_DEFINE_EXEC_METHOD(Network, CloseSocket, 1)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, DeleteUrl, 1)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, LoadUrl, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, UnloadUrl, 1)
-MC_EXEC_DEFINE_EXEC_METHOD(Network, OpenSocket, 3)
-MC_EXEC_DEFINE_EXEC_METHOD(Network, OpenSecureSocket, 4)
-MC_EXEC_DEFINE_EXEC_METHOD(Network, OpenDatagramSocket, 3)
+MC_EXEC_DEFINE_EXEC_METHOD(Network, OpenSocket, 4)
+MC_EXEC_DEFINE_EXEC_METHOD(Network, OpenSecureSocket, 5)
+MC_EXEC_DEFINE_EXEC_METHOD(Network, OpenDatagramSocket, 4)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, PostToUrl, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptConnectionsOnPort, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Network, AcceptDatagramConnectionsOnPort, 2)
@@ -547,7 +547,7 @@ void MCNetworkExecDeleteUrl(MCExecContext& ctxt, MCStringRef p_target)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCNetworkExecPerformOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, bool p_datagram, bool p_secure, bool p_ssl, MCNameRef p_end_hostname)
+void MCNetworkExecPerformOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_from_address, MCNameRef p_message, bool p_datagram, bool p_secure, bool p_ssl, MCNameRef p_end_hostname)
 {
 	if (!ctxt . EnsureNetworkAccessIsAllowed() && !MCModeCanAccessDomain(MCNameGetString(p_name)))
 		return;
@@ -563,24 +563,24 @@ void MCNetworkExecPerformOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNam
 	MCresult -> clear();
     
     // MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
-	MCSocket *s = MCS_open_socket(p_name, p_datagram, ctxt . GetObject(), p_message, p_secure, p_ssl, kMCEmptyString, p_end_hostname);
+	MCSocket *s = MCS_open_socket(p_name, p_from_address, p_datagram, ctxt . GetObject(), p_message, p_secure, p_ssl, kMCEmptyString, p_end_hostname);
 	if (s != NULL)
         MCSocketsAppendToSocketList(s);
 }
 
-void MCNetworkExecOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, MCNameRef p_end_hostname)
+void MCNetworkExecOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_from_address, MCNameRef p_message, MCNameRef p_end_hostname)
 {
-	MCNetworkExecPerformOpenSocket(ctxt, p_name, p_message, false, false, false, p_end_hostname);
+	MCNetworkExecPerformOpenSocket(ctxt, p_name, p_from_address, p_message, false, false, false, p_end_hostname);
 }
 
-void MCNetworkExecOpenSecureSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, MCNameRef p_end_hostname, bool p_with_verification)
+void MCNetworkExecOpenSecureSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_from_address, MCNameRef p_message, MCNameRef p_end_hostname, bool p_with_verification)
 {
-	MCNetworkExecPerformOpenSocket(ctxt, p_name, p_message, false, true, p_with_verification, p_end_hostname);
+	MCNetworkExecPerformOpenSocket(ctxt, p_name, p_from_address, p_message, false, true, p_with_verification, p_end_hostname);
 }
 
-void MCNetworkExecOpenDatagramSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, MCNameRef p_end_hostname)
+void MCNetworkExecOpenDatagramSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_from_address, MCNameRef p_message, MCNameRef p_end_hostname)
 {
-	MCNetworkExecPerformOpenSocket(ctxt, p_name, p_message, true, false, false, p_end_hostname);
+	MCNetworkExecPerformOpenSocket(ctxt, p_name, p_from_address, p_message, true, false, false, p_end_hostname);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4440,9 +4440,9 @@ void MCNetworkExecDeleteUrl(MCExecContext& ctxt, MCStringRef p_target);
 void MCNetworkExecLoadUrl(MCExecContext& ctxt, MCStringRef p_url, MCNameRef p_message);
 void MCNetworkExecUnloadUrl(MCExecContext& ctxt, MCStringRef p_url);
 
-void MCNetworkExecOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, MCNameRef p_end_hostname);
-void MCNetworkExecOpenSecureSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, MCNameRef p_end_hostname, bool p_with_verification);
-void MCNetworkExecOpenDatagramSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_message, MCNameRef p_end_hostname);
+void MCNetworkExecOpenSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_from_address, MCNameRef p_message, MCNameRef p_end_hostname);
+void MCNetworkExecOpenSecureSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_from_address, MCNameRef p_message, MCNameRef p_end_hostname, bool p_with_verification);
+void MCNetworkExecOpenDatagramSocket(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_from_address, MCNameRef p_message, MCNameRef p_end_hostname);
 
 void MCNetworkExecPostToUrl(MCExecContext& ctxt, MCValueRef p_data, MCStringRef p_url);
 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2737,6 +2737,9 @@ enum Exec_errors
     
     // {EE-0896} call: type conversion error
     EE_INVOKE_TYPEERROR,
+
+    // {EE-0897} open: error in from address expression
+    EE_OPEN_BADFROMADDRESS,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -708,9 +708,9 @@ bool MCS_connect_socket(MCSocket *p_socket, struct sockaddr_in *p_addr)
                 return false;
             }
 
-            // setting the SO_REUSEPORT option allows the same local port to be used to connect to multiple hosts
+            // setting the SO_REUSEADDR option allows the same local address to be used to connect to multiple hosts
             int t_port_reuse = 1;
-            if (setsockopt(p_socket->fd, SOL_SOCKET, SO_REUSEPORT, (const char *)&t_port_reuse, sizeof(t_port_reuse)) != 0)
+            if (setsockopt(p_socket->fd, SOL_SOCKET, SO_REUSEADDR, (const char *)&t_port_reuse, sizeof(t_port_reuse)) != 0)
             {
                 p_socket->error = strclone("can't use the local port");
                 p_socket->doclose();
@@ -1531,7 +1531,7 @@ void MCSocket::acceptone()
 		MCNameRef t_name;
 		MCNameCreate(*n, t_name);
         MCSocket *t_socket;
-        t_socket = new (nothrow) MCSocket(t_name, object, NULL, False, newfd, False, False,False);
+        t_socket = new (nothrow) MCSocket(t_name, NULL, object, NULL, False, newfd, False, False,False);
         if (t_socket != NULL)
         {
             MCSocketsAppendToSocketList(t_socket);

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -655,29 +655,76 @@ bool MCS_connect_socket(MCSocket *p_socket, struct sockaddr_in *p_addr)
 	if (p_socket != NULL && p_socket->fd != 0)
 	{
 		
-		// MM-2011-07-07: Added support for binding sockets to a network interface.
-		if (MCdefaultnetworkinterface != NULL)
-		{
-			struct sockaddr_in t_bind_addr;
-			MCAutoStringRef MCdefaultnetworkinterface_string;
-			/* UNCHECKED */ MCStringCreateWithCString(MCdefaultnetworkinterface, &MCdefaultnetworkinterface_string);
-			if (!MCS_name_to_sockaddr(*MCdefaultnetworkinterface_string, t_bind_addr))
-			{
-				p_socket->error = strclone("can't resolve network interface");
-				p_socket->doclose();
-				return false;
-			}
-			
-			t_bind_addr.sin_port = 0;
-			
-			if (0 != bind(p_socket->fd, (struct sockaddr *)&t_bind_addr, sizeof(struct sockaddr_in)))
-			{
-				p_socket->error = strclone("can't bind to network interface address");
-				p_socket->doclose();
-				return false;
-			}
-		}
-		
+        // check to see if a local host or port has been passed and if so, attempt to bind
+        // if no local host has been passed then, if set, use the network interface
+        MCAutoStringRef t_from_host;
+        MCAutoNumberRef t_from_port;
+        if (!MCValueIsEmpty(p_socket->from))
+        {
+            if (!MCS_name_to_host_and_port(MCNameGetString(p_socket->from), &t_from_host, &t_from_port))
+            {
+                p_socket->error = strclone("error parsing the local host and port");
+                p_socket->doclose();
+                return false;
+            }
+        }
+        if (!t_from_host.IsSet() && MCdefaultnetworkinterface != NULL)
+        {
+            if (!MCStringCreateWithCString(MCdefaultnetworkinterface, &t_from_host))
+            {
+                p_socket->error = strclone("error parsing the network interface address");
+                p_socket->doclose();
+                return false;
+            }
+        }
+
+        if (t_from_host.IsSet() || t_from_port.IsSet())
+        {
+            // the 0 defaults tell the OS to choose any avaliable host or port
+            if (!t_from_host.IsSet())
+            {
+                if (!MCStringCreateWithCString("0.0.0.0", &t_from_host))
+                {
+                    p_socket->error = strclone("error setting the default local host");
+                    p_socket->doclose();
+                    return false;
+                }
+            }
+            else if (!t_from_port.IsSet())
+            {
+                if (!MCNumberCreateWithUnsignedInteger(0, &t_from_port))
+                {
+                    p_socket->error = strclone("error setting the default local port");
+                    p_socket->doclose();
+                    return false;
+                }
+            }
+
+            struct sockaddr_in t_bind_addr;
+            if (!MCS_host_and_port_to_sockaddr(*t_from_host, *t_from_port, t_bind_addr))
+            {
+                p_socket->error = strclone("can't resolve local host and port");
+                p_socket->doclose();
+                return false;
+            }
+
+            // setting the SO_REUSEPORT option allows the same local port to be used to connect to multiple hosts
+            int t_port_reuse = 1;
+            if (setsockopt(p_socket->fd, SOL_SOCKET, SO_REUSEPORT, (const char *)&t_port_reuse, sizeof(t_port_reuse)) != 0)
+            {
+                p_socket->error = strclone("can't use the local port");
+                p_socket->doclose();
+                return false;
+            }
+
+            if (bind(p_socket->fd, (struct sockaddr *)&t_bind_addr, sizeof(struct sockaddr_in)) != 0)
+            {
+                p_socket->error = strclone("can't bind to local host and port");
+                p_socket->doclose();
+                return false;
+            }
+        }
+
 		p_socket->setselect();
 
 #if defined(_WINDOWS_DESKTOP) || defined(_WINDOWS_SERVER)
@@ -738,7 +785,7 @@ bool open_socket_resolve_callback(void *p_context, bool p_resolved, bool p_final
 }
 
 // MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
-MCSocket *MCS_open_socket(MCNameRef name, Boolean datagram, MCObject *o, MCNameRef mess, Boolean secure, Boolean sslverify, MCStringRef sslcertfile, MCNameRef hostname)
+MCSocket *MCS_open_socket(MCNameRef name, MCNameRef from, Boolean datagram, MCObject *o, MCNameRef mess, Boolean secure, Boolean sslverify, MCStringRef sslcertfile, MCNameRef hostname)
 {
 	if (!MCS_init_sockets())
 		return NULL;
@@ -775,7 +822,7 @@ MCSocket *MCS_open_socket(MCNameRef name, Boolean datagram, MCObject *o, MCNameR
 	MCS_socket_ioctl(sock, FIONBIO, on);
 
 	MCSocket *s = NULL;
-	s = (MCSocket *)new MCSocket(name, o, mess, datagram, sock, False, False,secure);
+	s = (MCSocket *)new MCSocket(name, from, o, mess, datagram, sock, False, False,secure);
 
 	if (s != NULL)
 	{
@@ -1137,7 +1184,7 @@ MCSocket *MCS_accept(uint2 port, MCObject *object, MCNameRef message, Boolean da
 	if (!MCNameCreateWithNativeChars(*t_port_chars, t_length, &t_portname))
         return nil;
     
-	return new MCSocket(*t_portname, object, message, datagram, sock, True, False, secure);
+	return new MCSocket(*t_portname, NULL, object, message, datagram, sock, True, False, secure);
 }
 
 // MM-2014-02-12: [[ SecureSocket ]] New secure socket command. If socket is not already secure, flag as secure to ensure future communications are encrypted.
@@ -1337,7 +1384,7 @@ MCSocketwrite::~MCSocketwrite()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-MCSocket::MCSocket(MCNameRef n, MCObject *o, MCNameRef m, Boolean d, MCSocketHandle sock, Boolean a, Boolean s, Boolean issecure)
+MCSocket::MCSocket(MCNameRef n, MCNameRef f, MCObject *o, MCNameRef m, Boolean d, MCSocketHandle sock, Boolean a, Boolean s, Boolean issecure)
 {
 	name = MCValueRetain(n);
 	object = o;
@@ -1366,6 +1413,7 @@ MCSocket::MCSocket(MCNameRef n, MCObject *o, MCNameRef m, Boolean d, MCSocketHan
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
 	endhostname = MCValueRetain(kMCEmptyName);
+    from = MCValueRetain(f);
 }
 
 MCSocket::~MCSocket()
@@ -1379,6 +1427,7 @@ MCSocket::~MCSocket()
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
 	MCValueRelease(endhostname);
+    MCValueRelease(from);
 }
 
 void MCSocket::deletereads()
@@ -1546,7 +1595,7 @@ void MCSocket::readsome()
 				if (accepting && !IO_findsocket(*t_name, index))
 				{
                     MCSocket *t_socket;
-                    t_socket = new (nothrow) MCSocket(*t_name, object, NULL, True, fd, False, True,False);
+                    t_socket = new (nothrow) MCSocket(*t_name, NULL, object, NULL, True, fd, False, True,False);
                     if (t_socket != NULL)
                         MCSocketsAppendToSocketList(t_socket);
 				}
@@ -1590,7 +1639,7 @@ void MCSocket::readsome()
 				/* UNCHECKED */ MCStringFormat(&n, "%s:%d", t, MCSwapInt16NetworkToHost(addr.sin_port));
 				/* UNCHECKED */ MCNameCreate(*n, &t_name);
                 MCSocket *t_socket;
-                t_socket = new (nothrow) MCSocket(*t_name, object, NULL, False, newfd, False, False,secure);
+                t_socket = new (nothrow) MCSocket(*t_name, NULL, object, NULL, False, newfd, False, False,secure);
                 if (t_socket != NULL)
                 {
                     MCSocketsAppendToSocketList(t_socket);

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -659,9 +659,9 @@ bool MCS_connect_socket(MCSocket *p_socket, struct sockaddr_in *p_addr)
         // if no local host has been passed then, if set, use the network interface
         MCAutoStringRef t_from_host;
         MCAutoNumberRef t_from_port;
-        if (!MCValueIsEmpty(p_socket->from))
+        if (!MCValueIsEmpty(*p_socket->from))
         {
-            if (!MCS_name_to_host_and_port(MCNameGetString(p_socket->from), &t_from_host, &t_from_port))
+            if (!MCS_name_to_host_and_port(MCNameGetString(*p_socket->from), &t_from_host, &t_from_port))
             {
                 p_socket->error = strclone("error parsing the local host and port");
                 p_socket->doclose();
@@ -1385,6 +1385,7 @@ MCSocketwrite::~MCSocketwrite()
 ////////////////////////////////////////////////////////////////////////////////
 
 MCSocket::MCSocket(MCNameRef n, MCNameRef f, MCObject *o, MCNameRef m, Boolean d, MCSocketHandle sock, Boolean a, Boolean s, Boolean issecure)
+    : from(f)
 {
 	name = MCValueRetain(n);
 	object = o;
@@ -1413,7 +1414,6 @@ MCSocket::MCSocket(MCNameRef n, MCNameRef f, MCObject *o, MCNameRef m, Boolean d
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
 	endhostname = MCValueRetain(kMCEmptyName);
-    from = MCValueRetain(f);
 }
 
 MCSocket::~MCSocket()
@@ -1427,7 +1427,6 @@ MCSocket::~MCSocket()
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
 	MCValueRelease(endhostname);
-    MCValueRelease(from);
 }
 
 void MCSocket::deletereads()

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -187,7 +187,7 @@ extern void MCS_setplayloudness(uint2 p_loudness);
 
 extern bool MCS_init_sockets();
 extern bool MCS_compare_host_domain(MCStringRef p_host_a, MCStringRef p_host_b);
-extern MCSocket *MCS_open_socket(MCNameRef name, Boolean datagram, MCObject *o, MCNameRef m, Boolean secure, Boolean sslverify, MCStringRef sslcertfile, MCNameRef p_end_hostname);
+extern MCSocket *MCS_open_socket(MCNameRef name, MCNameRef from, Boolean datagram, MCObject *o, MCNameRef m, Boolean secure, Boolean sslverify, MCStringRef sslcertfile, MCNameRef p_end_hostname);
 extern void MCS_close_socket(MCSocket *s);
 extern MCDataRef MCS_read_socket(MCSocket *s, MCExecContext &ctxt, uint4 length, const char *until, MCNameRef m);
 extern void MCS_write_socket(const MCStringRef d, MCSocket *s, MCObject *optr, MCNameRef m);

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1774,6 +1774,9 @@ enum Parse_errors
 
 	// {PE-0574} folders: bad folder expression
 	PE_FOLDERS_BADPARAM,
+
+    // {PE-0575} open: expected 'from' address
+    PE_OPEN_NOFROM,
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/socket.h
+++ b/engine/src/socket.h
@@ -142,8 +142,9 @@ public:
 	MCSocketHandle fd;	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
 	MCNameRef endhostname;
+    MCNameRef from;
     
-	MCSocket(MCNameRef n, MCObject *o, MCNameRef m, Boolean d, MCSocketHandle sock, Boolean a, Boolean s, Boolean issecure);
+	MCSocket(MCNameRef n, MCNameRef f, MCObject *o, MCNameRef m, Boolean d, MCSocketHandle sock, Boolean a, Boolean s, Boolean issecure);
 
 	void setselect();
 	void setselect(uint2 sflags);
@@ -209,6 +210,9 @@ bool MCS_name_to_sockaddr(MCStringRef p_name_in, struct sockaddr_in *r_addr,
 
 bool MCS_name_to_sockaddr(MCStringRef p_name, struct sockaddr_in &r_addr);
 
+bool MCS_name_to_host_and_port(MCStringRef p_name, MCStringRef &r_host, MCNumberRef &r_port);
+bool MCS_host_and_port_to_sockaddr(MCStringRef p_host, MCNumberRef p_port, struct sockaddr_in *r_addr, MCHostNameResolveCallback p_callback, void *p_context);
+bool MCS_host_and_port_to_sockaddr(MCStringRef p_host, MCNumberRef p_port, struct sockaddr_in &r_addr);
 
 
 bool addrinfo_lookup(const char *p_name, const char *p_port, int p_socktype, struct addrinfo *&r_addrinfo);

--- a/engine/src/socket.h
+++ b/engine/src/socket.h
@@ -142,7 +142,7 @@ public:
 	MCSocketHandle fd;	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
 	MCNameRef endhostname;
-    MCNameRef from;
+    MCNewAutoNameRef from;
     
 	MCSocket(MCNameRef n, MCNameRef f, MCObject *o, MCNameRef m, Boolean d, MCSocketHandle sock, Boolean a, Boolean s, Boolean issecure);
 

--- a/tests/lcs/core/network/network.livecodescript
+++ b/tests/lcs/core/network/network.livecodescript
@@ -88,16 +88,86 @@ on TestOpenSocketFromMultipleHostsSamePort
    open socket from ":8002" to "livecode.com"
    open socket from ":8002" to "google.com"
    TestAssert "open socket from with multiple hosts on same local port", "livecode.com" is among the lines of the openSockets
-   TestAssert "open socket from with multiple hosts on same local port", "livecode.com" is among the lines of the openSockets
+   TestAssert "open socket from with multiple hosts on same local port", "google.com" is among the lines of the openSockets
    close socket "livecode.com"
    close socket "google.com"
 end TestOpenSocketFromMultipleHostsSamePort
 
-on TestOpenSocketFromSameHostDifferntPort
+on TestOpenSocketFromSameHostDifferentPort
    open socket from ":8003" to "livecode.com|1"
    open socket from ":8004" to "livecode.com|2"
    TestAssert "open socket from with same host on different local port", "livecode.com|1" is among the lines of the openSockets
    TestAssert "open socket from with same host on different local port", "livecode.com|2" is among the lines of the openSockets
    close socket "livecode.com|1"
    close socket "livecode.com|2"
-end TestOpenSocketFromSameHostDifferntPort
+end TestOpenSocketFromSameHostDifferentPort
+
+on TestOpenSocketFromWithAddress
+   local tLocalAddress
+   repeat for each line tInterface in the networkInterfaces
+      if tInterface is not "127.0.0.1" then
+         put tInterface into tLocalAddress
+         exit repeat
+      end if
+   end repeat
+
+   if tLocalAddress is not empty then
+      open socket from tLocalAddress to "livecode.com"
+      TestAssert "open socket from with local address", "livecode.com" is among the lines of the openSockets
+      close socket "livecode.com"
+   end if
+end TestOpenSocketFromWithAddress
+
+on TestOpenSocketFromWithAddressAndPort
+   local tLocalAddress
+   repeat for each line tInterface in the networkInterfaces
+      if tInterface is not "127.0.0.1" then
+         put tInterface into tLocalAddress
+         exit repeat
+      end if
+   end repeat
+
+   if tLocalAddress is not empty then
+      open socket from tLocalAddress & ":8005" to "livecode.com"
+      TestAssert "open socket from with local address and port", "livecode.com" is among the lines of the openSockets
+      close socket "livecode.com"
+   end if
+end TestOpenSocketFromWithAddressAndPort
+
+on TestOpenSocketFromMultipleHostsSameAddress
+   local tLocalAddress
+   repeat for each line tInterface in the networkInterfaces
+      if tInterface is not "127.0.0.1" then
+         put tInterface into tLocalAddress
+         exit repeat
+      end if
+   end repeat
+
+   if tLocalAddress is not empty then
+      open socket from tLocalAddress & ":8006" to "livecode.com"
+      open socket from tLocalAddress & ":8006" to "google.com"
+      TestAssert "open socket from with multiple hosts using same local address", "livecode.com" is among the lines of the openSockets
+      TestAssert "open socket from with multiple hosts using same local address", "google.com" is among the lines of the openSockets
+      close socket "livecode.com"
+      close socket "google.com"
+   end if
+end TestOpenSocketFromMultipleHostsSameAddress
+
+on TestOpenSocketFromSameHostDifferentAddress
+   local tLocalAddresses
+   put the networkInterfaces into tLocalAddresses
+   filter tLocalAddresses without "127.0.0.1"
+
+   if the number of lines in tLocalAddresses > 1 then
+      local tSocketCount
+      put 1 into tSocketCount
+      repeat for each line tLocalAddress in tLocalAddresses
+         open socket from tLocalAddress & ":8007" to "livecode.com|" & tSocketCount
+         TestAssert "open socket from with same host on different local address", "livecode.com|" & tSocketCount is among the lines of the openSockets
+         add 1 to tSocketCount
+      end repeat
+      repeat with tSocketCount = 1 to the number of lines in tLocalAddresses
+         close socket "livecode.com|" & tSocketCount
+      end repeat
+   end if
+end TestOpenSocketFromSameHostDifferentAddress

--- a/tests/lcs/core/network/network.livecodescript
+++ b/tests/lcs/core/network/network.livecodescript
@@ -68,3 +68,36 @@ end repeat
 TestSkip "peeraddress", "connection timed out"
 close socket tSock
 end TestPeerAddress
+
+on TestOpenSocketFrom
+   open socket from ":8000" to "livecode.com"
+   TestAssert "open socket from", "livecode.com" is among the lines of the openSockets
+   close socket "livecode.com"
+end TestOpenSocketFrom
+
+on TestOpenSocketFromWithLSOF
+   if the platform is "MacOS" or the platform contains "linux" then
+      open socket from ":8001" to "livecode.com"
+      get shell("lsof -i4TCP:8001")
+      TestAssert "open socket from testing with lsof", it contains "LiveCode"
+      close socket "livecode.com"
+   end if
+end TestOpenSocketFromWithLSOF
+
+on TestOpenSocketFromMultipleHostsSamePort
+   open socket from ":8002" to "livecode.com"
+   open socket from ":8002" to "google.com"
+   TestAssert "open socket from with multiple hosts on same local port", "livecode.com" is among the lines of the openSockets
+   TestAssert "open socket from with multiple hosts on same local port", "livecode.com" is among the lines of the openSockets
+   close socket "livecode.com"
+   close socket "google.com"
+end TestOpenSocketFromMultipleHostsSamePort
+
+on TestOpenSocketFromSameHostDifferntPort
+   open socket from ":8003" to "livecode.com|1"
+   open socket from ":8004" to "livecode.com|2"
+   TestAssert "open socket from with same host on different local port", "livecode.com|1" is among the lines of the openSockets
+   TestAssert "open socket from with same host on different local port", "livecode.com|2" is among the lines of the openSockets
+   close socket "livecode.com|1"
+   close socket "livecode.com|2"
+end TestOpenSocketFromSameHostDifferntPort

--- a/tests/lcs/core/network/network.livecodescript
+++ b/tests/lcs/core/network/network.livecodescript
@@ -171,3 +171,27 @@ on TestOpenSocketFromSameHostDifferentAddress
       end repeat
    end if
 end TestOpenSocketFromSameHostDifferentAddress
+
+on TestOpenSocketFromWithAddressUsingLocalServer
+   accept connections on port "8008" with message "connectedPlaceHolder"
+   wait until "8008" is among the lines of the openSockets with messages
+
+   open socket from "127.0.0.1" to "127.0.0.1:8008"
+   TestAssert "open socket from with local address to local server", "127.0.0.1:8008" is among the lines of the openSockets
+
+   repeat for each line tSocket in the openSockets
+      close socket tSocket
+   end repeat
+end TestOpenSocketFromWithAddressUsingLocalServer
+
+on TestOpenSocketFromWithAddressAndPortUsingLocalServer
+   accept connections on port "8009" with message "connectedPlaceHolder"
+   wait until "8009" is among the lines of the openSockets with messages
+
+   open socket from "127.0.0.1:8010" to "127.0.0.1:8009"
+   TestAssert "open socket from with local address and port to local server", "127.0.0.1:8009" is among the lines of the openSockets
+
+   close socket "127.0.0.1:8010"
+   close socket "127.0.0.1:8009"
+   close socket "8009"
+end TestOpenSocketFromWithAddressAndPortUsingLocalServer


### PR DESCRIPTION
… port when opening a new socket.

Updated the parsing of open socket so that it now accepts the following form:
open socket [from [<local host>][:<local port>]] to <host>[:<port>]

Reworked the name to sockaddr parsing into:
- name to host and port
- host and port to sockaddr
Name to sockaddr now calls name to host and port and then host and port to
sockaddr.

The reworked name to sockaddr parsing is used to parse any local from details in
MCS_connect_socket: It checks to see if any local host or port has been passed.
If no local host has been passed, then we use, if set, the networkinterface
property. It then binds the socket to any found local host and port.