### PR TITLE
[[ Bug 14238 ]] Ensure field background pattern is always in sync

### DIFF
--- a/docs/notes/bugfix-14238.md
+++ b/docs/notes/bugfix-14238.md
@@ -1,0 +1,1 @@
+# Ensure background pattern stays aligned in long fields

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -917,53 +917,11 @@ void MCField::adjustpixmapoffset(MCContext *dc, uint2 index, int4 dy)
 	int4 t_offset_x, t_offset_y;
 	t_offset_x = t_current_x - textx;
 	t_offset_y = t_current_y - texty + dy;
-
-    // SN-2014-12-19: [[ Bug 14238 ]] Split the update for x and y offsets, as one of them
-    // being out of [INT16_MIN; INT16_MAX] shouldn't have the other one affected.
-
-	
-	// MW-2009-01-22: [[ Bug 3869 ]] We need to use the actual width/height of the
-	//   pixmap tile in this case to ensure the offset falls within 32767.
-	if (MCU_abs(t_offset_y) > INT16_MAX)
-    {
-        // SN-2014-12-19: [[ Bug 14238 ]] Ensure that overflowing offsets are recomputed.
-        if (t_offset_y > INT16_MAX)
-            t_offset_y %= INT16_MAX;
-        else
-        {
-            // SN-2015-01-06: [[ Bug 14238 ]] Don't use % with negative numbers, as the result sign
-            //  is implementation-defined.
-            int4 t_positive_offset;
-            t_positive_offset = -t_offset_y;
-            t_positive_offset %= INT16_MAX;
-            t_offset_y = -t_positive_offset;
-        }
-		
-		t_offset_y %= t_height;
-		if (t_offset_y < 0)
-			t_offset_y += t_height;
-	}
-
-    if (MCU_abs(t_offset_x) > INT16_MAX)
-    {
-        // SN-2014-12-19: [[ Bug 14238 ]] Ensure that overflowing offsets are recomputed.
-        if (t_offset_x > INT16_MAX)
-            t_offset_x %= INT16_MAX;
-        else
-        {
-            // SN-2015-01-06: [[ Bug 14238 ]] Don't use % with negative numbers, as the result sign
-            //  is implementation-defined.
-            int4 t_positive_offset;
-            t_positive_offset = -t_offset_x;
-            t_positive_offset %= INT16_MAX;
-            t_offset_x = -t_positive_offset;
-        }
-        
-        t_offset_x %= t_width;
-        if (t_offset_x < 0)
-            t_offset_x += t_width;
-    }
-
+    
+    // Ensure the offsets are in the 16-bit signed int range.
+    t_offset_y = MCSgn(t_offset_y) * (MCAbs(t_offset_y) % t_height);
+    t_offset_x = MCSgn(t_offset_x) * (MCAbs(t_offset_x) % t_width);
+    
 	dc -> setfillstyle(t_current_style, t_current_pixmap, t_offset_x, t_offset_y);
 }
 

--- a/tests/lcs/core/field/background-pattern-scroll.livecodescript
+++ b/tests/lcs/core/field/background-pattern-scroll.livecodescript
@@ -1,0 +1,72 @@
+script "CoreFieldBackgroundPatternScroll"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestBackgroundPatternScroll
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   -- Create black and white stripes (3 pixels then 4 pixels).
+   local tImageData
+   put empty into tImageData
+   repeat 3 times
+      put numToChar(0) & numToChar(0) & numToChar(0) & numToChar(0) after tImageData
+   end repeat
+   repeat 4 times
+      put numToChar(0) & numToChar(255) & numToChar(255) & numToChar(255) after tImageData
+   end repeat
+   set the lockLocation of the templateImage to true
+   create image "BgPattern"
+   set the rect of image "BgPattern" to 0,0,1,7
+   set the imageData of image "BgPattern" to tImageData
+   hide image "BgPattern"
+
+   -- Create the test field and make it have formattedHeight of more than
+   -- 64k pixels
+   create field "TestField"
+   set the lockLocation of the last field to true
+   set the rect of the last field to 0,0,1,7
+   set the backgroundPattern of the last field to the id of image "BgPattern"
+   set the showBorder of the last field to false
+   set the fixedLineHeight of the last field to true
+   set the textHeight of the last field to 1024
+   set the vScollbar of the last field to false
+   repeat with i = 0 to 127
+      put return after the last field
+   end repeat
+
+   -- Set the vScroll to multiples of the height of the background pattern
+   -- and ensure it remains showing the entire pattern as originally
+   -- described.
+   lock messages
+   lock screen
+   set the caseSensitive to true
+   repeat with i = 0 to the formattedHeight of field "TestField" - 15 step 7
+      set the vScroll of field "TestField" to i
+      import snapshot from field "TestField"
+      set the rect of the last image to the rect of the last field
+      if the imageData of the last image is not the imageData of image "BgPattern" then
+         TestAssert "background pattern drift detected at vScroll " & i, false
+         exit repeat
+      end if
+      delete the last image
+   end repeat
+   unlock screen
+   unlock messages
+
+   delete stack "Test"
+end TestBackgroundPatternScroll


### PR DESCRIPTION
This patch changes the pattern offset computation in the field rendering
code to ensure that it is correct even for fields whose formattedHeight
can exceed 32-bit integer sizes.