### PR TITLE
libgraphics: Fix places where values may be used before initialisation

### DIFF
--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -248,6 +248,10 @@ typedef uint32_t MCGColor;
 
 struct MCGPoint
 {
+public:
+    /* TODO[C++11] Use member initialisers and remove these constructors */
+    MCGPoint() : x(0), y(0) {}
+    MCGPoint(MCGFloat p_x, MCGFloat p_y) : x(p_x), y(p_y) {}
 	MCGFloat x, y;
 };
 

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -114,20 +114,22 @@ static inline void MCGPixelUnpack(MCGPixelFormat p_format, uint32_t p_pixel, uin
 	{
 		case kMCGPixelFormatRGBA:
 			__MCGPixelUnpackComponents(p_pixel, r_red, r_green, r_blue, r_alpha);
-			break;
+			return;
 			
 		case kMCGPixelFormatBGRA:
 			__MCGPixelUnpackComponents(p_pixel, r_blue, r_green, r_red, r_alpha);
-			break;
+			return;
 			
 		case kMCGPixelFormatABGR:
 			__MCGPixelUnpackComponents(p_pixel, r_alpha, r_blue, r_green, r_red);
-			break;
+			return;
 			
 		case kMCGPixelFormatARGB:
 			__MCGPixelUnpackComponents(p_pixel, r_alpha, r_red, r_green, r_blue);
-			break;
+			return;
 	}
+	r_red = r_green = r_blue = r_alpha = 0;
+	MCUnreachable();
 }
 
 static inline void MCGPixelUnpackNative(uint32_t p_pixel, uint8_t &r_red, uint8_t &r_green, uint8_t &r_blue, uint8_t &r_alpha)

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -1078,11 +1078,11 @@ static void MCGContextRenderEffect(MCGContextRef self, const SkMask& p_mask, MCG
 			t_tmp_mask . fRowBytes = p_mask . fRowBytes;
 			t_tmp_mask . fImage = SkMask::AllocImage(p_mask . computeImageSize());
 			
-			uint8_t *t_blur_ptr, *t_mask_ptr, *t_shape_ptr;
-			t_shape_ptr = p_mask . fImage;
-			t_shape_ptr -= p_mask . fBounds . left();
-			t_blur_ptr = t_tmp_mask . fImage;
-			t_blur_ptr -= t_tmp_mask . fBounds . left();
+			uint8_t *t_mask_ptr = nullptr;
+			uint8_t *t_shape_ptr =
+				(p_mask . fImage - p_mask . fBounds . left());
+			uint8_t *t_blur_ptr =
+				(t_tmp_mask . fImage - t_tmp_mask . fBounds . left());
 			if (t_overlap)
 			{
 				t_mask_ptr = t_blurred_mask . getAddr8(t_inside . x(), t_inside . y());

--- a/libgraphics/src/image.cpp
+++ b/libgraphics/src/image.cpp
@@ -228,7 +228,8 @@ bool MCGImageHasPartialTransparency(MCGImageRef self)
 		return false;
 
 	MCGRaster t_raster;
-	/* UNCHECKED */ MCGImageGetRaster(self, t_raster);
+	if (!MCGImageGetRaster(self, t_raster))
+        return false;
 
 	if (t_raster.format == kMCGRasterFormat_A)
 		return true;

--- a/libgraphics/src/path.cpp
+++ b/libgraphics/src/path.cpp
@@ -1163,13 +1163,10 @@ bool MCGPathIterate(MCGPathRef self, MCGPathIterateCallback p_callback, void *p_
 {
 	if (!MCGPathIsValid(self))
 		return false;
-	
-	bool t_success;
-	t_success = true;
-	
+
 	MCGPoint t_points[3];
-	uint32_t t_point_count;
-	MCGPathCommand t_command;
+	uint32_t t_point_count = 0;
+	MCGPathCommand t_command = kMCGPathCommandEnd;
 	
 	SkPath::Iter t_iter(*self->path, false);
 	SkPath::Verb t_verb;
@@ -1177,8 +1174,9 @@ bool MCGPathIterate(MCGPathRef self, MCGPathIterateCallback p_callback, void *p_
 	
 	// IM-2015-03-20: [[ Bug 15035 ]] The first point returned by SkPath::Iter::next() is
 	//  always the last moveTo point; the points for the current verb start at index 1.
-	while (t_success && (t_verb = t_iter.next(t_sk_points)) != SkPath::kDone_Verb)
+	while ((t_verb = t_iter.next(t_sk_points)) != SkPath::kDone_Verb)
 	{
+
 		switch(t_verb)
 		{
 			case SkPath::kMove_Verb:
@@ -1219,15 +1217,11 @@ bool MCGPathIterate(MCGPathRef self, MCGPathIterateCallback p_callback, void *p_
 				
 			default:
 				// Unknown path instruction
-				t_success = false;
-				break;
+				return false;
 		}
-		
-		t_success = p_callback(p_context, t_command, t_points, t_point_count);
+		if (!p_callback(p_context, t_command, t_points, t_point_count))
+			return false;
 	}
 	
-	if (t_success)
-		t_success = p_callback(p_context, kMCGPathCommandEnd, nil, 0);
-	
-	return t_success;
+	return p_callback(p_context, kMCGPathCommandEnd, nil, 0);
 }

--- a/libgraphics/src/utils.cpp
+++ b/libgraphics/src/utils.cpp
@@ -280,36 +280,26 @@ bool MCGDashesToSkDashPathEffect(MCGDashesRef self, SkDashPathEffect*& r_path_ef
 		r_path_effect = NULL;
 		return true;
 	}
-	
-	bool t_success;
-	t_success = true;
-	
+
     // Skia won't except odd numbers of dashes, so we must replicate in that case.
-    uint32_t t_dash_count;
-    if (t_success)
-        t_dash_count = (self -> count % 2) == 0 ? self -> count : self -> count * 2;
-        
-	SkScalar *t_dashes;
-	if (t_success)
-		t_success = MCMemoryNewArray(t_dash_count, t_dashes);
-	
-	SkDashPathEffect *t_dash_effect;
-	t_dash_effect = NULL;
-	if (t_success)
-	{
-		for (uint32_t i = 0; i < t_dash_count; i++)
-			t_dashes[i] = MCGFloatToSkScalar(self -> lengths[i % self -> count]);
-	
-		t_dash_effect = new (nothrow) SkDashPathEffect(t_dashes, (int)t_dash_count, MCGFloatToSkScalar(self -> phase));
-		t_success = t_dash_effect != NULL;
-	}
-	
-	if (t_success)
-		r_path_effect = t_dash_effect;
-	
-	MCMemoryDeleteArray(t_dashes);
-	
-	return t_success;	
+    uint32_t t_dash_count =
+        (self -> count % 2) == 0 ? self -> count : self -> count * 2;
+
+    MCAutoPointer<SkScalar[]> t_dashes = new (nothrow) SkScalar[t_dash_count];
+    if (!t_dashes)
+        return false;
+
+    for (uint32_t i = 0; i < t_dash_count; i++)
+        t_dashes[i] = MCGFloatToSkScalar(self -> lengths[i % self -> count]);
+
+    SkDashPathEffect *t_dash_effect =
+        new (nothrow) SkDashPathEffect(t_dashes.Get(), (int)t_dash_count, MCGFloatToSkScalar(self -> phase));
+
+    if (!t_dash_effect)
+        return false;
+
+    r_path_effect = t_dash_effect;
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes several places in `libgraphics` where GCC 6.3.1 detected that values may be used without initialisation in release builds.  These fixes involve:

- Adding default constructors, where appropriate
- Checking the result of functions that allocate memory
- Using managed pointers and removing success-flag-checking ladders