### PR TITLE
lc-compile: Fix possible use of memory before initialisation

### DIFF
--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -1428,8 +1428,8 @@ static RepeatLabels *s_repeat_labels = nil;
 
 void EmitPushRepeatLabels(long next, long exit)
 {
-    RepeatLabels *t_labels;
-    MCMemoryNew(t_labels);
+    RepeatLabels *t_labels = nullptr;
+    /* UNCHECKED */ MCMemoryNew(t_labels);
     t_labels -> head = next;
     t_labels -> tail = exit;
     t_labels -> next = s_repeat_labels;
@@ -1814,11 +1814,11 @@ static bool FindAttachedReg(long expr, AttachedReg*& r_attach)
 
 void EmitAttachRegisterToExpression(long reg, long expr)
 {
-    AttachedReg *t_attach;
+    AttachedReg *t_attach = nullptr;
     if (FindAttachedReg(expr, t_attach))
         Fatal_InternalInconsistency("Register attached to expression which is already attached");
     
-    MCMemoryNew(t_attach);
+    /* UNCHECKED */ MCMemoryNew(t_attach);
     t_attach -> next = s_attached_regs;
     t_attach -> expr = expr;
     t_attach -> reg = reg;

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -234,9 +234,9 @@ static MCStringRef to_mcstringref(long p_string)
     MCStringCreateWithBytes(reinterpret_cast<const byte_t *>(p_string),
                             (uindex_t)strlen(reinterpret_cast<const char *>(p_string)),
                             kMCStringEncodingUTF8, false, &t_string);
-    MCStringRef t_uniq_string;
-    MCValueInter(*t_string, t_uniq_string);
-    return t_uniq_string;
+    MCAutoStringRef t_uniq_string;
+    MCValueInter(*t_string, &t_uniq_string);
+    return t_uniq_string.Take();
 }
 
 static NameRef nameref_from_mcstringref(MCStringRef p_string)

--- a/toolchain/lc-compile/src/syntax-gen.c
+++ b/toolchain/lc-compile/src/syntax-gen.c
@@ -578,7 +578,7 @@ static void JoinSyntaxNodes(SyntaxNodeRef p_left, SyntaxNodeRef p_right)
 
 static long CountSyntaxNodeMarks(SyntaxNodeRef p_node)
 {
-    long t_index;
+    long t_index = 0;
     switch(p_node -> kind)
     {
         case kSyntaxNodeKindEmpty:

--- a/toolchain/libcompile/src/position.c
+++ b/toolchain/libcompile/src/position.c
@@ -95,7 +95,7 @@ void GetFileOfPosition(long p_position, FileRef *r_file)
 
 void GetFilenameOfPosition(long p_position, const char **r_filename)
 {
-    FileRef t_file;
+    FileRef t_file = NULL;
     GetFileOfPosition(p_position, &t_file);
     GetFilePath(t_file, r_filename);
 }


### PR DESCRIPTION
Fix several places in `lc-compile` where GCC 6.3.1 detects possible use of uninitialised values in release builds.