### PR TITLE
Merge develop 8.1 22.02.2017

### DIFF
--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -408,15 +408,7 @@ private command toolsBuilderMakeInstaller pVersion, pEdition, pPlatform, pIdeFol
       put builderRepoFolder() & slash & "ide-support" & slash & "revliburl.livecodescript" into tAuxStackfiles
    end if	
    put return & builderSystemFolder() & slash & "installer_utilities.livecodescript" after tAuxStackfiles
-   
-   start using stack (builderRepoFolder() & slash & "ide-support" & slash & "revsblibrary.livecodescript")
-   repeat for each line tStackFile in tAuxStackfiles
-      local tTempStackFile
-      put builderMakeTemporaryFile(tTempFolder, "stack") into tTempStackFile
-      revSBResaveScriptOnlyStackAsProperStackFile the short name of stack tStackFile, tStackFile, tTempStackFile
-      put tTempStackFile & return after tParams["auxiliary_stackfiles"]
-   end repeat
-   delete the last char of tParams["auxiliary_stackfiles"]
+   put tAuxStackfiles into tParams["auxiliary_stackfiles"]
    
    // revLibURL needs to initialise its custom props, and revLoadLibrary must therefore be called.
    put merge("send [[quote]]revLoadLibrary[[quote]] to stack [[quote]]revLibUrl[[quote]]") into tParams["startup_script"]

--- a/docs/lcb/notes/19244.md
+++ b/docs/lcb/notes/19244.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Virtual Machine
+## Foreign Function Interface
+
+# [19244] Nil pointers should bridge to nothing

--- a/docs/notes/bugfix-14238.md
+++ b/docs/notes/bugfix-14238.md
@@ -1,0 +1,1 @@
+# Ensure background pattern stays aligned in long fields

--- a/docs/notes/bugfix-18833.md
+++ b/docs/notes/bugfix-18833.md
@@ -1,0 +1,1 @@
+# Don't change name of tsNet stack during standalone build

--- a/docs/notes/bugfix-19050.md
+++ b/docs/notes/bugfix-19050.md
@@ -1,1 +1,0 @@
-# CGI does not work with lighttpd 1.4.44

--- a/docs/notes/bugfix-19154.md
+++ b/docs/notes/bugfix-19154.md
@@ -1,0 +1,1 @@
+# Fix widget browser stuck on handling javascript

--- a/docs/notes/bugfix-19293.md
+++ b/docs/notes/bugfix-19293.md
@@ -1,0 +1,1 @@
+# Server returns 'ELF' over HTTP

--- a/docs/notes/feature-script_only_deploy.md
+++ b/docs/notes/feature-script_only_deploy.md
@@ -1,0 +1,3 @@
+# Script-only deploy
+It is now possible to use script-only stacks in the mainstack and auxiliary
+stack parameters to the deploy command.

--- a/engine/src/capsule.h
+++ b/engine/src/capsule.h
@@ -70,10 +70,14 @@ enum MCCapsuleSectionType
 	// including the digest section tag.
 	kMCCapsuleSectionTypeDigest,
 
-	// The stack section contains the principal stackfile to be loaded on
+	// The stack section contains the principal (binary) stackfile to be loaded on
 	// startup.
-	kMCCapsuleSectionTypeStack,
+	kMCCapsuleSectionTypeMainStack,
 
+    // The stack section contains the principal (script-only) stackfile to be loaded on
+    // startup.
+    kMCCapsuleSectionTypeScriptOnlyMainStack,
+    
 	// An external section contains a external that should be loaded into the
 	// environment on startup;.
 	kMCCapsuleSectionTypeExternal,
@@ -84,6 +88,10 @@ enum MCCapsuleSectionType
     // Auxiliary stack sections contain other mainstacks that should be loaded
 	// alongside the mainstack (but not opened initially).
 	kMCCapsuleSectionTypeAuxiliaryStack,
+    
+    // Script-only auxiliary stack sections contain other (script-only) mainstacks that should be loaded
+    // alongside the mainstack (but not opened initially).
+    kMCCapsuleSectionTypeScriptOnlyAuxiliaryStack,
 	
 	// Simulator redirect sections contain mappings from engine relative
 	// paths to absolute paths on the host system.

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -568,15 +568,13 @@ IO_stat MCDispatch::trytoreadbinarystack(MCStringRef p_openpath,
     
     // MW-2013-11-19: [[ UnicodeFileFormat ]] newsf is no longer used.
     uint1 charset, type;
-    char* t_newsf = nullptr;
     if (IO_read_uint1(&charset, x_stream) != IO_NORMAL
         || IO_read_uint1(&type, x_stream) != IO_NORMAL
-        || IO_read_cstring_legacy(t_newsf, x_stream, 2) != IO_NORMAL)
+        || IO_discard_cstring_legacy(x_stream, 2) != IO_NORMAL)
     {
         r_result = "stack is corrupted, check for ~ backup file";
         return checkloadstat(IO_ERROR);
     }
-    MCMemoryDeallocate(t_newsf);
 
     MCtranslatechars = charset != CHARSET;
 
@@ -600,17 +598,12 @@ IO_stat MCDispatch::trytoreadbinarystack(MCStringRef p_openpath,
     {
         // MW-2013-11-19: [[ UnicodeFileFormat ]] These strings are never written out, so
         //   legacy.
-        char* lstring = nullptr;
-        char* cstring = nullptr;
-        if (IO_read_cstring_legacy(lstring, x_stream, 2) != IO_NORMAL
-            || IO_read_cstring_legacy(cstring, x_stream, 2) != IO_NORMAL)
+        if (IO_discard_cstring_legacy(x_stream, 2) != IO_NORMAL
+            || IO_discard_cstring_legacy(x_stream, 2) != IO_NORMAL)
         {
             r_result = "stack is corrupted, check for ~ backup file";
             return checkloadstat(IO_ERROR);
         }
-
-        MCMemoryDeallocate(lstring);
-        MCMemoryDeallocate(cstring);
     }
     
     if (IO_read_uint1(&type, x_stream) != IO_NORMAL

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -453,60 +453,23 @@ IO_stat readheader(IO_handle& stream, uint32_t& r_version)
 // for embedded stacks/deployed stacks/revlet stacks.
 IO_stat MCDispatch::readstartupstack(IO_handle stream, MCStack*& r_stack)
 {
-	uint32_t version;
-	uint1 charset, type;
-	char *newsf;
-	
-	// MW-2013-11-19: [[ UnicodeFileFormat ]] newsf is no longer used.
-	if (readheader(stream, version) != IO_NORMAL
-	        || IO_read_uint1(&charset, stream) != IO_NORMAL
-	        || IO_read_uint1(&type, stream) != IO_NORMAL
-	        || IO_read_cstring_legacy(newsf, stream, 2) != IO_NORMAL)
-		return IO_ERROR;
-
-	// MW-2008-10-20: [[ ParentScripts ]] Set the boolean flag that tells us whether
-	//   parentscript resolution is required to false.
-	s_loaded_parent_script_reference = false;
-
-	MCtranslatechars = charset != CHARSET;
-	delete newsf; // stackfiles is obsolete
-
-	MCStack *t_stack = nil;
-	/* UNCHECKED */ MCStackSecurityCreateStack(t_stack);
-
-	t_stack -> setparent(this);
-	
+    MCAutoStringRef t_filename;
 	// MM-2013-10-30: [[ Bug 11333 ]] Set the filename of android mainstack to apk/mainstack (previously was just apk).
 	//   This solves relative file path referencing issues.
 #ifdef TARGET_SUBPLATFORM_ANDROID
-    MCAutoStringRef t_filename;
     /* UNCHECKED */ MCStringFormat(&t_filename, "%@/mainstack", MCcmd);
-	t_stack -> setfilename(*t_filename);
 #else
-   	t_stack -> setfilename(MCcmd);
+   	t_filename = MCcmd;
 #endif
 
-	if (IO_read_uint1(&type, stream) != IO_NORMAL
-	    || (type != OT_STACK && type != OT_ENCRYPT_STACK)
-	        || t_stack->load(stream, version, type) != IO_NORMAL)
-	{
-		delete t_stack;
-		return IO_ERROR;
-	}
-
-	if (t_stack->load_substacks(stream, version) != IO_NORMAL
-	        || IO_read_uint1(&type, stream) != IO_NORMAL
-	        || type != OT_END)
-	{
-		delete t_stack;
-		return IO_ERROR;
-	}
-
-	// We are reading the startup stack, so this becomes the root of the
-	// stack list.
-	stacks = t_stack;
-
-	r_stack = t_stack;
+    const char* t_result = nullptr;
+    MCStack* t_stack = nullptr;
+    if (trytoreadbinarystack(*t_filename, kMCEmptyString, stream, this,
+                             t_stack, t_result) != IO_NORMAL ||
+        t_stack == nullptr)
+    {
+        return IO_ERROR;
+    }
 
 #ifndef _MOBILE
 	// Make sure parent script references are up to date.
@@ -518,8 +481,42 @@ IO_stat MCDispatch::readstartupstack(IO_handle stream, MCStack*& r_stack)
 	if (s_loaded_parent_script_reference)
 		t_stack -> setextendedstate(True, ECS_USES_PARENTSCRIPTS);
 #endif
-
+    
+    // We are reading the startup stack, so this becomes the root of the
+    // stack list.
+    stacks = t_stack;
+    
+    r_stack = t_stack;
 	return IO_NORMAL;
+}
+
+IO_stat MCDispatch::readscriptonlystartupstack(IO_handle stream, uindex_t p_length, MCStack*& r_stack)
+{
+    MCAutoStringRef t_filename;
+    // MM-2013-10-30: [[ Bug 11333 ]] Set the filename of android mainstack to apk/mainstack (previously was just apk).
+    //   This solves relative file path referencing issues.
+#ifdef TARGET_SUBPLATFORM_ANDROID
+    /* UNCHECKED */ MCStringFormat(&t_filename, "%@/mainstack", MCcmd);
+#else
+   	t_filename = MCcmd;
+#endif
+    
+    const char* t_result = nullptr;
+    MCStack* t_stack = nullptr;
+    
+    // Read a script-only stack from the stream
+    if (trytoreadscriptonlystackofsize(*t_filename, stream,
+                                       p_length, this,
+                                       t_stack, t_result) != IO_NORMAL
+        || t_stack == nullptr)
+        return IO_ERROR;
+
+    // We are reading the startup stack, so this becomes the root of the
+    // stack list.
+    stacks = t_stack;
+    
+    r_stack = t_stack;
+    return IO_NORMAL;
 }
 
 // MW-2012-02-17: [[ LogFonts ]] Load a stack file, ensuring we clear up any
@@ -540,266 +537,365 @@ IO_stat MCDispatch::readfile(MCStringRef p_openpath, MCStringRef p_name, IO_hand
 	return stat;
 }
 
-// MW-2012-02-17: [[ LogFonts ]] Actually load the stack file (wrapped by readfile
-//   to handle font table cleanup).
-IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_handle &stream, MCStack *&sptr)
+IO_stat MCDispatch::trytoreadbinarystack(MCStringRef p_openpath,
+                                         MCStringRef p_name,
+                                         IO_handle &x_stream,
+                                         MCObject* p_parent,
+                                         MCStack* &r_stack,
+                                         const char* &r_result)
 {
-	uint32_t version;
-
-    sptr = NULL;
-    
-    // MW-2014-09-30: [[ ScriptOnlyStack ]] First see if it is a binary stack.
-	if (readheader(stream, version) == IO_NORMAL)
-	{
-		if (version > kMCStackFileFormatCurrentVersion)
-		{
-			MCresult->sets("stack was produced by a newer version");
-			return checkloadstat(IO_ERROR);
-		}
-        
-		// MW-2008-10-20: [[ ParentScripts ]] Set the boolean flag that tells us whether
-		//   parentscript resolution is required to false.
-		s_loaded_parent_script_reference = false;
-		
-		// MW-2013-11-19: [[ UnicodeFileFormat ]] newsf is no longer used.
-		uint1 charset, type;
-		char *newsf;
-		if (IO_read_uint1(&charset, stream) != IO_NORMAL
-		        || IO_read_uint1(&type, stream) != IO_NORMAL
-		        || IO_read_cstring_legacy(newsf, stream, 2) != IO_NORMAL)
-		{
-			MCresult->sets("stack is corrupted, check for ~ backup file");
-			return checkloadstat(IO_ERROR);
-		}
-		delete newsf; // stackfiles is obsolete
-		MCtranslatechars = charset != CHARSET;
-		sptr = nil;
-		/* UNCHECKED */ MCStackSecurityCreateStack(sptr);
-		if (stacks == NULL)
-			sptr->setparent(this);
-		else
-			sptr->setparent(stacks);
-			
-		sptr->setfilename(p_openpath);
-
-		if (MCModeCanLoadHome() && type == OT_HOME)
-		{
-			// MW-2013-11-19: [[ UnicodeFileFormat ]] These strings are never written out, so
-			//   legacy.
-			char *lstring = NULL;
-			char *cstring = NULL;
-			IO_read_cstring_legacy(lstring, stream, 2);
-			IO_read_cstring_legacy(cstring, stream, 2);
-			delete lstring;
-			delete cstring;
-		}
-
-		MCresult -> clear();
-
-		if (IO_read_uint1(&type, stream) != IO_NORMAL
-		    || (type != OT_STACK && type != OT_ENCRYPT_STACK)
-		    || sptr->load(stream, version, type) != IO_NORMAL)
-		{
-			if (MCresult -> isclear())
-				MCresult->sets("stack is corrupted, check for ~ backup file");
-			destroystack(sptr, False);
-			sptr = NULL;
-			return checkloadstat(IO_ERROR);
-		}
-		
-		// MW-2011-08-09: [[ Groups ]] Make sure F_GROUP_SHARED is set
-		//   appropriately.
-		sptr -> checksharedgroups();
-		
-		if (sptr->load_substacks(stream, version) != IO_NORMAL
-		        || IO_read_uint1(&type, stream) != IO_NORMAL
-		        || type != OT_END)
-		{
-			if (MCresult -> isclear())
-				MCresult->sets("stack is corrupted, check for ~ backup file");
-			destroystack(sptr, False);
-			sptr = NULL;
-			return checkloadstat(IO_ERROR);
-		}
+    uint32_t t_version;
+    if (readheader(x_stream, t_version) != IO_NORMAL)
+    {
+        return IO_NORMAL;
     }
     
-    // MW-2014-09-30: [[ ScriptOnlyStack ]] If we failed to load a stack from that step
-    //   then check to see if it is a script file stack.
-    if (sptr == NULL)
+    if (t_version > kMCStackFileFormatCurrentVersion)
     {
-        // Clear the error return.
-        MCresult -> clear();
-        
-        // Reset to position 0.
-        MCS_seek_set(stream, 0);
-        
-        // Load the file into memory - we need to process a byteorder mark and any
-        // line endings.
-        uindex_t t_size = static_cast<uindex_t>(MCS_fsize(stream));
+        r_result = "stack was produced by a newer version";
+        return checkloadstat(IO_ERROR);
+    }
+    
+    // MW-2008-10-20: [[ ParentScripts ]] Set the boolean flag that tells us whether
+    //   parentscript resolution is required to false.
+    s_loaded_parent_script_reference = false;
+    
+    // MW-2013-11-19: [[ UnicodeFileFormat ]] newsf is no longer used.
+    uint1 charset, type;
+    char* t_newsf = nullptr;
+    if (IO_read_uint1(&charset, x_stream) != IO_NORMAL
+        || IO_read_uint1(&type, x_stream) != IO_NORMAL
+        || IO_read_cstring_legacy(t_newsf, x_stream, 2) != IO_NORMAL)
+    {
+        r_result = "stack is corrupted, check for ~ backup file";
+        return checkloadstat(IO_ERROR);
+    }
+    MCMemoryDeallocate(t_newsf);
 
-        MCAutoPointer<byte_t> t_script = new byte_t[t_size];
-        if (IO_read(*t_script, t_size, stream) == IO_ERROR)
+    MCtranslatechars = charset != CHARSET;
+
+    MCStack *t_stack;
+    if (!MCStackSecurityCreateStack(t_stack))
+    {
+        r_result = "couldn't create stack";
+        return checkloadstat(IO_ERROR);
+    }
+    
+    if (p_parent != nullptr)
+        t_stack -> setparent(p_parent);
+    else if (stacks != nullptr)
+        t_stack->setparent(stacks);
+    else
+        t_stack->setparent(this);
+
+    t_stack->setfilename(p_openpath);
+    
+    if (MCModeCanLoadHome() && type == OT_HOME)
+    {
+        // MW-2013-11-19: [[ UnicodeFileFormat ]] These strings are never written out, so
+        //   legacy.
+        char* lstring = nullptr;
+        char* cstring = nullptr;
+        if (IO_read_cstring_legacy(lstring, x_stream, 2) != IO_NORMAL
+            || IO_read_cstring_legacy(cstring, x_stream, 2) != IO_NORMAL)
         {
-            MCresult -> sets("unable to read file");
+            r_result = "stack is corrupted, check for ~ backup file";
             return checkloadstat(IO_ERROR);
         }
-        
-        uindex_t t_bom_size = 0;
-        MCFileEncodingType t_file_encoding =
-        MCS_resolve_BOM_from_bytes(*t_script, t_size, t_bom_size);
-        
-        MCStringEncoding t_string_encoding;
-        switch (t_file_encoding)
-        {
-            case kMCFileEncodingUTF8:
-                t_string_encoding = kMCStringEncodingUTF8;
-                break;
-            case kMCFileEncodingUTF16:
-                t_string_encoding = kMCStringEncodingUTF16;
-                break;
-            case kMCFileEncodingUTF16BE:
-                t_string_encoding = kMCStringEncodingUTF16BE;
-                break;
-            case kMCFileEncodingUTF16LE:
-                t_string_encoding = kMCStringEncodingUTF16LE;
-                break;
-            default:
-                // Assume native
-                t_string_encoding = kMCStringEncodingNative;
-                break;
-        }
 
-        MCAutoStringRef t_raw_script_string, t_LC_script_string;
-        /* UNCHECKED */ MCStringCreateWithBytes(*t_script + t_bom_size, t_size - t_bom_size, t_string_encoding, false, &t_raw_script_string);
-        /* UNCHECKED */ MCStringConvertLineEndingsToLiveCode(*t_raw_script_string, &t_LC_script_string);
-        
-        // Now attempt to parse the header line:
-        //   'script' <string>
-        MCScriptPoint sp(*t_LC_script_string);
-        
-        // Parse 'script' token.
-        if (sp . skip_token(SP_FACTOR, TT_PROPERTY, P_SCRIPT) == PS_NORMAL)
+        MCMemoryDeallocate(lstring);
+        MCMemoryDeallocate(cstring);
+    }
+    
+    if (IO_read_uint1(&type, x_stream) != IO_NORMAL
+        || (type != OT_STACK && type != OT_ENCRYPT_STACK)
+        || t_stack->load(x_stream, t_version, type) != IO_NORMAL)
+    {
+        r_result = "stack is corrupted, check for ~ backup file";
+        destroystack(t_stack, False);
+        return checkloadstat(IO_ERROR);
+    }
+    
+    // MW-2011-08-09: [[ Groups ]] Make sure F_GROUP_SHARED is set
+    //   appropriately.
+    t_stack -> checksharedgroups();
+    
+    if (t_stack->load_substacks(x_stream, t_version) != IO_NORMAL
+        || IO_read_uint1(&type, x_stream) != IO_NORMAL
+        || type != OT_END)
+    {
+        r_result = "stack is corrupted, check for ~ backup file";
+        destroystack(t_stack, False);
+        return checkloadstat(IO_ERROR);
+    }
+    
+    r_stack = t_stack;
+    return IO_NORMAL;
+}
+
+static MCStack* script_only_stack_from_bytes(uint8_t *p_bytes,
+                                             uindex_t p_size,
+                                             MCStringEncoding p_encoding)
+{
+    MCAutoStringRef t_raw_script_string, t_LC_script_string;
+    if (!MCStringCreateWithBytes(p_bytes, p_size, p_encoding, false,
+                                 &t_raw_script_string) ||
+        !MCStringConvertLineEndingsToLiveCode(*t_raw_script_string,
+                                              &t_LC_script_string))
+    {
+        return nullptr;
+    }
+    
+    // Now attempt to parse the header line:
+    //   'script' <string>
+    MCScriptPoint sp(*t_LC_script_string);
+    
+    // Parse 'script' token.
+    if (sp . skip_token(SP_FACTOR, TT_PROPERTY, P_SCRIPT) != PS_NORMAL)
+    {
+        return nullptr;
+    }
+    
+    // Parse <string> token.
+    Symbol_type t_type;
+    if (sp . next(t_type) != PS_NORMAL || t_type != ST_LIT)
+    {
+        return nullptr;
+    }
+    
+    MCNewAutoNameRef t_script_name;
+    if (!MCNameClone(sp . gettoken_nameref(), &t_script_name))
+    {
+        return nullptr;
+    }
+    
+    // Parse end of line.
+    Parse_stat t_stat;
+    t_stat = sp . next(t_type);
+    if (t_stat != PS_EOL && t_stat != PS_EOF)
+        return nullptr;
+    
+    // MW-2014-10-23: [[ Bug ]] Make sure we trim the correct number of lines.
+    // SN-2014-10-16: [[ Merge-6.7.0-rc-3 ]] Update to StringRef
+    // Now trim the ep down to the remainder of the script.
+    // Trim the header.
+    uint32_t t_lines = sp.getline();
+    uint32_t t_index = 0;
+    
+    // Jump over the possible lines before the string token
+    while (MCStringFirstIndexOfChar(*t_LC_script_string, '\n', t_index,
+                                    kMCStringOptionCompareExact, t_index)
+           && t_lines > 0)
+    {
+        t_lines -= 1;
+    }
+    
+    // Add one to the index so we include the LF
+    t_index += 1;
+    
+    // t_line now has the last LineFeed of the token
+    MCAutoStringRef t_LC_script_body;
+    
+    // We copy the body of the stack script
+    if (!MCStringCopySubstring(*t_LC_script_string,
+                               MCRangeMake(t_index,
+                                           MCStringGetLength(*t_LC_script_string)
+                                           - t_index), &t_LC_script_body))
+    {
+        return nullptr;
+    }
+    
+    // Create a stack.
+    MCStack *t_stack;
+    if (!MCStackSecurityCreateStack(t_stack))
+        return nullptr;
+    
+    // Set it up as script only.
+    t_stack -> setasscriptonly(*t_LC_script_body);
+    
+    // Set its name.
+    t_stack -> setname(*t_script_name);
+    
+    return t_stack;
+}
+
+IO_stat MCDispatch::trytoreadscriptonlystackofsize(MCStringRef p_openpath,
+                                                   IO_handle &x_stream,
+                                                   uindex_t p_size,
+                                                   MCObject* p_parent,
+                                                   MCStack* &r_stack,
+                                                   const char* &r_result)
+{
+    MCAutoPointer<byte_t> t_bytes = new byte_t[p_size];
+    if (IO_read(*t_bytes, p_size, x_stream) == IO_ERROR)
+    {
+        return checkloadstat(IO_ERROR);
+    }
+    
+    uindex_t t_bom_size = 0;
+    MCFileEncodingType t_file_encoding =
+        MCS_resolve_BOM_from_bytes(*t_bytes, p_size, t_bom_size);
+    
+    MCStringEncoding t_string_encoding;
+    switch (t_file_encoding)
+    {
+        case kMCFileEncodingUTF8:
+            t_string_encoding = kMCStringEncodingUTF8;
+            break;
+        case kMCFileEncodingUTF16:
+            t_string_encoding = kMCStringEncodingUTF16;
+            break;
+        case kMCFileEncodingUTF16BE:
+            t_string_encoding = kMCStringEncodingUTF16BE;
+            break;
+        case kMCFileEncodingUTF16LE:
+            t_string_encoding = kMCStringEncodingUTF16LE;
+            break;
+        default:
+            // Assume native
+            t_string_encoding = kMCStringEncodingNative;
+            break;
+    }
+    
+    MCStack *t_stack = script_only_stack_from_bytes(*t_bytes + t_bom_size,
+                                                    p_size - t_bom_size,
+                                                    t_string_encoding);
+    if (t_stack == nullptr)
+        return IO_NORMAL;
+    
+    // Set its parent.
+    if (p_parent != nullptr)
+        t_stack -> setparent(p_parent);
+    else if (stacks != nullptr)
+        t_stack->setparent(stacks);
+    else
+        t_stack->setparent(this);
+    
+    // Set its filename.
+    t_stack->setfilename(p_openpath);
+    
+    // Make it invisible
+    t_stack -> setflag(False, F_VISIBLE);
+    
+    r_stack = t_stack;
+    return IO_NORMAL;
+}
+
+IO_stat MCDispatch::trytoreadscriptonlystack(MCStringRef p_openpath,
+                                             IO_handle &x_stream,
+                                             MCObject* p_parent,
+                                             MCStack* &r_stack,
+                                             const char* &r_result)
+{
+    // Load the file into memory - we need to process a byteorder mark and any
+    // line endings.
+    uindex_t t_size = static_cast<uindex_t>(MCS_fsize(x_stream));
+    
+    if (trytoreadscriptonlystackofsize(p_openpath, x_stream, t_size,
+                                       p_parent, r_stack, r_result)
+        != IO_NORMAL)
+    {
+        r_result = "failed to load script only stack";
+        return checkloadstat(IO_ERROR);
+    }
+    
+    return IO_NORMAL;
+}
+
+void MCDispatch::processstack(MCStringRef p_openpath, MCStack* &x_stack)
+{
+    if (stacks != NULL)
+    {
+        MCStack *tstk = stacks;
+        do
         {
-            // Parse <string> token.
-            Symbol_type t_type;
-            if (sp . next(t_type) == PS_NORMAL &&
-                t_type == ST_LIT)
+            if (x_stack->hasname(tstk->getname()))
             {
-                MCNewAutoNameRef t_script_name;
-                MCNameClone(sp . gettoken_nameref(), &t_script_name);
+                MCAutoNameRef t_stack_name;
+                /* UNCHECKED */ t_stack_name . Clone(x_stack -> getname());
                 
-                // Parse end of line.
-                Parse_stat t_stat;
-                t_stat = sp . next(t_type);
-                if (t_stat == PS_EOL || t_stat == PS_EOF)
+                delete x_stack;
+                x_stack = nullptr;
+                
+                
+                if (MCStringIsEqualTo(tstk -> getfilename(), p_openpath, kMCStringOptionCompareCaseless))
+                    x_stack = tstk;
+                else
                 {
-                    // MW-2014-10-23: [[ Bug ]] Make sure we trim the correct number of lines.
-                    // SN-2014-10-16: [[ Merge-6.7.0-rc-3 ]] Update to StringRef
-                    // Now trim the ep down to the remainder of the script.
-                    // Trim the header.
-                    uint32_t t_lines = sp.getline();
-                    uint32_t t_index = 0;
-
-                    // Jump over the possible lines before the string token
-                    while (MCStringFirstIndexOfChar(*t_LC_script_string, '\n', t_index, kMCStringOptionCompareExact, t_index) &&
-                           t_lines > 0)
-                        t_lines -= 1;
-                    
-                    // Add one to the index so we include the LF
-                    t_index += 1;
-
-                    // t_line now has the last LineFeed of the token
-                    MCAutoStringRef t_LC_script_body;
-
-                    // We copy the body of the stack script
-                    MCStringCopySubstring(*t_LC_script_string, MCRangeMake(t_index, MCStringGetLength(*t_LC_script_string) - t_index), &t_LC_script_body);
-                    
-                    // Create a stack.
-                    /* UNCHECKED */ MCStackSecurityCreateStack(sptr);
-                    
-                    // Set its parent.
-                    if (stacks == NULL)
-                        sptr->setparent(this);
-                    else
-                        sptr->setparent(stacks);
-                    
-                    // Set its filename.
-                    sptr->setfilename(p_openpath);
-                    
-                    // Set its name.
-                    sptr -> setname(*t_script_name);
-                    
-                    // Make it invisible
-                    sptr -> setflag(False, F_VISIBLE);
-                    
-                    // Set it up as script only.
-                    sptr -> setasscriptonly(*t_LC_script_body);
+                    MCdefaultstackptr->getcard()->message_with_valueref_args(MCM_reload_stack, tstk->getname(), p_openpath);
+                    tstk = stacks;
+                    do
+                    {
+                        if (MCNameIsEqualTo(t_stack_name, tstk->getname(), kMCCompareCaseless))
+                        {
+                            x_stack = tstk;
+                            break;
+                        }
+                        tstk = (MCStack *)tstk->next();
+                    }
+                    while (tstk != stacks);
                 }
+                return;
             }
+            tstk = (MCStack *)tstk->next();
         }
-        
+        while (tstk != stacks);
+    }
+    
+    appendstack(x_stack);
+    
+    x_stack->extraopen(false);
+    
+    // MW-2008-10-28: [[ ParentScript ]]
+    // We just loaded a stackfile, so check to see if parentScript resolution
+    // is required and if so do it.
+    // MW-2009-01-28: [[ Inherited parentScripts ]]
+    // Resolving parentScripts may allocate memory, so 'resolveparentscripts'
+    // will return false if it fails to allocate what it needs. At some point
+    // this needs to be dealt with by deleting the stack and returning an error,
+    // *However* at the time of writing, 'readfile' isn't designed to handle
+    // this - so we just ignore the result for now (note that all the 'load'
+    // methods *fail* to check for no-memory errors!).
+    if (s_loaded_parent_script_reference)
+        x_stack -> resolveparentscripts();
+}
+
+// MW-2012-02-17: [[ LogFonts ]] Actually load the stack file (wrapped by readfile
+//   to handle font table cleanup).
+IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_handle &stream, MCStack* &r_stack)
+{
+    MCresult -> clear();
+    
+    const char* t_result = nullptr;
+    MCStack *t_stack = nullptr;
+    
+	if (trytoreadbinarystack(p_openpath, p_name, stream, nullptr,
+                             t_stack, t_result) != IO_NORMAL)
+    {
+        /* UNCHECKED */ MCresult -> setvalueref(MCSTR(t_result));
+        return IO_ERROR;
+    }
+    
+    // If there was no IO error but it wasn't a binary stack then try as script-only
+    if (t_stack == nullptr)
+    {
+        // Reset to position 0.
+        MCS_seek_set(stream, 0);
+    
+        if (trytoreadscriptonlystack(p_openpath, stream, nullptr,
+                                     t_stack, t_result) != IO_NORMAL)
+        {
+            /* UNCHECKED */ MCresult -> setvalueref(MCSTR(t_result));
+            return IO_ERROR;
+        }
     }
     
     // MW-2014-09-30: [[ ScriptOnlyStack ]] If we managed to load a stack as either binary
     //   or script, then do the normal processing.
-    if (sptr != NULL)
+    if (t_stack != nullptr)
     {
-		if (stacks != NULL)
-		{
-			MCStack *tstk = stacks;
-			do
-			{
-				if (sptr->hasname(tstk->getname()))
-				{
-					MCAutoNameRef t_stack_name;
-					/* UNCHECKED */ t_stack_name . Clone(sptr -> getname());
-
-					delete sptr;
-					sptr = NULL;
-					
-					
-					if (MCStringIsEqualTo(tstk -> getfilename(), p_openpath, kMCStringOptionCompareCaseless))
-						sptr = tstk;
-					else
-					{
-						MCdefaultstackptr->getcard()->message_with_valueref_args(MCM_reload_stack, tstk->getname(), p_openpath);
-						tstk = stacks;
-						do
-						{
-							if (MCNameIsEqualTo(t_stack_name, tstk->getname(), kMCCompareCaseless))
-							{
-								sptr = tstk;
-								break;
-							}
-							tstk = (MCStack *)tstk->next();
-						}
-						while (tstk != stacks);
-					}
-
-					return IO_NORMAL;
-				}
-				tstk = (MCStack *)tstk->next();
-			}
-			while (tstk != stacks);
-		}
-		
-		appendstack(sptr);
-		
-		sptr->extraopen(false);
-
-		// MW-2008-10-28: [[ ParentScript ]]
-		// We just loaded a stackfile, so check to see if parentScript resolution
-		// is required and if so do it.
-		// MW-2009-01-28: [[ Inherited parentScripts ]]
-		// Resolving parentScripts may allocate memory, so 'resolveparentscripts'
-		// will return false if it fails to allocate what it needs. At some point
-		// this needs to be dealt with by deleting the stack and returning an error,
-		// *However* at the time of writing, 'readfile' isn't designed to handle
-		// this - so we just ignore the result for now (note that all the 'load'
-		// methods *fail* to check for no-memory errors!).
-		if (s_loaded_parent_script_reference)
-            sptr -> resolveparentscripts();
-        
+        processstack(p_openpath, t_stack);
+        r_stack = t_stack;
         return IO_NORMAL;
     }
     
@@ -829,11 +925,12 @@ IO_stat MCDispatch::doreadfile(MCStringRef p_openpath, MCStringRef p_name, IO_ha
     else
     {
         // MW-2008-06-12: [[ Bug 6476 ]] Media won't open HC stacks
-        if (!MCdispatcher->cut(True) || hc_import(p_name, stream, sptr) != IO_NORMAL)
+        if (!MCdispatcher->cut(True) || hc_import(p_name, stream, t_stack) != IO_NORMAL)
         {
             MCresult->sets("file is not a stack");
             return IO_ERROR;
         }
+        r_stack = t_stack;
 	}
     
 	return IO_NORMAL;

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -448,6 +448,12 @@ IO_stat readheader(IO_handle& stream, uint32_t& r_version)
 	return IO_NORMAL;
 }
 
+bool MCDispatch::streamstackisscriptonly(IO_handle stream)
+{
+    uint32_t t_version;
+    return readheader(stream, t_version) != IO_NORMAL;
+}
+
 // This method reads a stack from the given stream. The stack is set to
 // have parent MCDispatch, and filename MCcmd. It is designed to be used
 // for embedded stacks/deployed stacks/revlet stacks.

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -292,6 +292,9 @@ public:
                                            MCStack* &r_stack,
                                            const char* &r_result);
     
+    // Determine if the stream contains a script-only stack
+    bool streamstackisscriptonly(IO_handle stream);
+    
     // Integrate a loaded stack into the environemnt, sending reloadStack
     // if required.
     void processstack(MCStringRef p_openpath, MCStack* &x_stack);

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -92,6 +92,7 @@ public:
 	// MW-2009-06-25: This method should be used to read stacks used from startup.
 	//   Specifically, embedded stacks and ones contained in deployed project info.
 	IO_stat readstartupstack(IO_handle stream, MCStack*& r_stack);
+    IO_stat readscriptonlystartupstack(IO_handle stream, uindex_t p_length, MCStack*& r_stack);
 	
 	// Load the given external from within the app bundle
 	bool loadexternal(MCStringRef p_external);
@@ -259,6 +260,41 @@ public:
     bool fetchlibrarymapping(MCStringRef p_name, MCStringRef &r_path);
     
     virtual bool recomputefonts(MCFontRef parent_font, bool force);
+    
+    // Try to read a binary stack from the stream. If the return value is
+    // IO_ERROR, a reason is returned in r_result. If the return value is
+    // IO_NORMAL, there was no error but the stream did not contain a binary
+    // stack
+    IO_stat trytoreadbinarystack(MCStringRef p_openpath,
+                                 MCStringRef p_name,
+                                 IO_handle &x_stream,
+                                 MCObject* p_parent, MCStack* &r_stack,
+                                 const char* &r_result);
+    
+    // Try to read a script-only stack from the stream. If the return value is
+    // IO_ERROR, a reason is returned in r_result. If the return value is
+    // IO_NORMAL, there was no error but the stream did not contain a
+    // script-only stack
+    IO_stat trytoreadscriptonlystack(MCStringRef p_openpath,
+                                     IO_handle &x_stream,
+                                     MCObject* p_parent,
+                                     MCStack* &r_stack,
+                                     const char* &r_result);
+    
+    // Read a script-only stack from p_size bytes of the stream. If the
+    // return value is IO_ERROR, a reason is returned in r_result. If
+    // the return value is IO_NORMAL, there was no error but the stream
+    // did not contain a script-only stack
+    IO_stat trytoreadscriptonlystackofsize(MCStringRef p_openpath,
+                                           IO_handle &x_stream,
+                                           uindex_t p_size,
+                                           MCObject* p_parent,
+                                           MCStack* &r_stack,
+                                           const char* &r_result);
+    
+    // Integrate a loaded stack into the environemnt, sending reloadStack
+    // if required.
+    void processstack(MCStringRef p_openpath, MCStack* &x_stack);
     
 private:
 	// MW-2012-02-17: [[ LogFonts ]] Actual method which performs a load stack. This

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -917,53 +917,11 @@ void MCField::adjustpixmapoffset(MCContext *dc, uint2 index, int4 dy)
 	int4 t_offset_x, t_offset_y;
 	t_offset_x = t_current_x - textx;
 	t_offset_y = t_current_y - texty + dy;
-
-    // SN-2014-12-19: [[ Bug 14238 ]] Split the update for x and y offsets, as one of them
-    // being out of [INT16_MIN; INT16_MAX] shouldn't have the other one affected.
-
-	
-	// MW-2009-01-22: [[ Bug 3869 ]] We need to use the actual width/height of the
-	//   pixmap tile in this case to ensure the offset falls within 32767.
-	if (MCU_abs(t_offset_y) > INT16_MAX)
-    {
-        // SN-2014-12-19: [[ Bug 14238 ]] Ensure that overflowing offsets are recomputed.
-        if (t_offset_y > INT16_MAX)
-            t_offset_y %= INT16_MAX;
-        else
-        {
-            // SN-2015-01-06: [[ Bug 14238 ]] Don't use % with negative numbers, as the result sign
-            //  is implementation-defined.
-            int4 t_positive_offset;
-            t_positive_offset = -t_offset_y;
-            t_positive_offset %= INT16_MAX;
-            t_offset_y = -t_positive_offset;
-        }
-		
-		t_offset_y %= t_height;
-		if (t_offset_y < 0)
-			t_offset_y += t_height;
-	}
-
-    if (MCU_abs(t_offset_x) > INT16_MAX)
-    {
-        // SN-2014-12-19: [[ Bug 14238 ]] Ensure that overflowing offsets are recomputed.
-        if (t_offset_x > INT16_MAX)
-            t_offset_x %= INT16_MAX;
-        else
-        {
-            // SN-2015-01-06: [[ Bug 14238 ]] Don't use % with negative numbers, as the result sign
-            //  is implementation-defined.
-            int4 t_positive_offset;
-            t_positive_offset = -t_offset_x;
-            t_positive_offset %= INT16_MAX;
-            t_offset_x = -t_positive_offset;
-        }
-        
-        t_offset_x %= t_width;
-        if (t_offset_x < 0)
-            t_offset_x += t_width;
-    }
-
+    
+    // Ensure the offsets are in the 16-bit signed int range.
+    t_offset_y = MCSgn(t_offset_y) * (MCAbs(t_offset_y) % t_height);
+    t_offset_x = MCSgn(t_offset_x) * (MCAbs(t_offset_x) % t_width);
+    
 	dc -> setfillstyle(t_current_style, t_current_pixmap, t_offset_x, t_offset_y);
 }
 

--- a/engine/src/java/com/runrev/android/libraries/LibBrowser.java
+++ b/engine/src/java/com/runrev/android/libraries/LibBrowser.java
@@ -348,7 +348,7 @@ class LibBrowserWebView extends WebView
 
 	class JSInterface
 	{
-		//@JavascriptInterface
+		@JavascriptInterface
 		public void __invokeHandler(String p_handler, String p_json_args)
 		{
 			if (m_js_handler_list != null && m_js_handler_list.contains(p_handler))
@@ -368,7 +368,7 @@ class LibBrowserWebView extends WebView
 			}
 		}
 
-		//@JavascriptInterface
+		@JavascriptInterface
 		public void __storeExecuteJavaScriptResult(String p_tag, String p_result)
 		{
 			doJSExecutionResult(p_tag, p_result);

--- a/engine/src/java/com/runrev/android/nativecontrol/BrowserControl.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/BrowserControl.java
@@ -69,6 +69,7 @@ class BrowserControl extends NativeControl
     
     class JSInterface
     {
+    	@JavascriptInterface
         public void storeResult(String p_tag, String p_result)
         {
             doJSExecutionResult(p_tag, p_result);

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1236,11 +1236,16 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
     case kMCCapsuleSectionTypeAuxiliaryStack:
     {
         MCStack *t_aux_stack;
-        if (MCdispatcher -> readfile(NULL, NULL, p_stream, t_aux_stack) != IO_NORMAL)
+        const char *t_result;
+        if (MCdispatcher -> trytoreadbinarystack(kMCEmptyString,
+                                                 kMCEmptyString,
+                                                 p_stream, nullptr,
+                                                 t_aux_stack, t_result) != IO_NORMAL)
         {
             MCresult -> sets("failed to read auxillary stack");
             return false;
         }
+        MCdispatcher -> processstack(kMCEmptyString, t_aux_stack);
     }
         break;
 			

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1276,6 +1276,7 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
             MCresult -> sets("failed to read auxillary stack");
             return false;
         }
+        MCdispatcher -> processstack(kMCEmptyString, t_aux_stack);
     }
         break;
 			

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1187,7 +1187,7 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 	}
 	break;
 
-	case kMCCapsuleSectionTypeStack:
+	case kMCCapsuleSectionTypeMainStack:
 		if (MCdispatcher -> readstartupstack(p_stream, self -> stack) != IO_NORMAL)
 		{
 			MCresult -> sets("failed to read project stack");
@@ -1198,6 +1198,18 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
         //   the startup script and such work.
         MCstaticdefaultstackptr = MCdefaultstackptr = self -> stack;
 	break;
+            
+    case kMCCapsuleSectionTypeScriptOnlyMainStack:
+        if (MCdispatcher -> readscriptonlystartupstack(p_stream, p_length, self -> stack) != IO_NORMAL)
+        {
+            MCresult -> sets("failed to read project stack");
+            return false;
+        }
+        
+        // MW-2012-10-25: [[ Bug ]] Make sure we set these to the main stack so that
+        //   the startup script and such work.
+        MCstaticdefaultstackptr = MCdefaultstackptr = self -> stack;
+        break;
 
 	case kMCCapsuleSectionTypeDigest:
 		uint8_t t_read_digest[16];
@@ -1246,6 +1258,24 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
             return false;
         }
         MCdispatcher -> processstack(kMCEmptyString, t_aux_stack);
+    }
+        break;
+            
+    case kMCCapsuleSectionTypeScriptOnlyAuxiliaryStack:
+    {
+        MCStack *t_aux_stack;
+        const char *t_result;
+        if (MCdispatcher -> trytoreadscriptonlystackofsize(kMCEmptyString,
+                                                           p_stream,
+                                                           p_length,
+                                                           nullptr,
+                                                           t_aux_stack,
+                                                           t_result)
+            != IO_NORMAL)
+        {
+            MCresult -> sets("failed to read auxillary stack");
+            return false;
+        }
     }
         break;
 			

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -259,7 +259,7 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
     }
     break;
         
-	case kMCCapsuleSectionTypeStack:
+	case kMCCapsuleSectionTypeMainStack:
 		if (MCdispatcher -> readstartupstack(p_stream, self -> stack) != IO_NORMAL)
 		{
 			MCresult -> sets("failed to read standalone stack");
@@ -270,7 +270,19 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 		//   the startup script and such work.
 		MCstaticdefaultstackptr = MCdefaultstackptr = self -> stack;
 	break;
-			
+            
+    case kMCCapsuleSectionTypeScriptOnlyMainStack:
+        if (MCdispatcher -> readscriptonlystartupstack(p_stream, p_length, self -> stack) != IO_NORMAL)
+        {
+            MCresult -> sets("failed to read standalone stack");
+            return false;
+        }
+            
+        // MW-2012-10-25: [[ Bug ]] Make sure we set these to the main stack so that
+        //   the startup script and such work.
+        MCstaticdefaultstackptr = MCdefaultstackptr = self -> stack;
+        break;
+            
 	case kMCCapsuleSectionTypeExternal:
 	{
 		MCAutoStringRef t_external_str;
@@ -332,6 +344,25 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
         MCdispatcher -> processstack(kMCEmptyString, t_aux_stack);
     }
         break;
+
+    case kMCCapsuleSectionTypeScriptOnlyAuxiliaryStack:
+    {
+        MCStack *t_aux_stack;
+        const char *t_result;
+        if (MCdispatcher -> trytoreadscriptonlystackofsize(kMCEmptyString,
+                                                           p_stream,
+                                                           p_length,
+                                                           nullptr,
+                                                           t_aux_stack,
+                                                           t_result)
+            != IO_NORMAL)
+        {
+            MCresult -> sets("failed to read auxillary stack");
+            return false;
+        }
+        MCdispatcher -> processstack(kMCEmptyString, t_aux_stack);
+    }
+    break;
             
     case kMCCapsuleSectionTypeModule:
     {

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -317,16 +317,21 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 	}
 	break;
 			
-	case kMCCapsuleSectionTypeAuxiliaryStack:
-	{
-		MCStack *t_aux_stack;
-		if (MCdispatcher -> readfile(NULL, NULL, p_stream, t_aux_stack) != IO_NORMAL)
-		{
-            MCresult -> sets("failed to read auxiliary stack");
-			return false;
-		}
-	}
-	break;
+    case kMCCapsuleSectionTypeAuxiliaryStack:
+    {
+        MCStack *t_aux_stack;
+        const char *t_result;
+        if (MCdispatcher -> trytoreadbinarystack(kMCEmptyString,
+                                                 kMCEmptyString,
+                                                 p_stream, nullptr,
+                                                 t_aux_stack, t_result) != IO_NORMAL)
+        {
+            MCresult -> sets("failed to read auxillary stack");
+            return false;
+        }
+        MCdispatcher -> processstack(kMCEmptyString, t_aux_stack);
+    }
+        break;
             
     case kMCCapsuleSectionTypeModule:
     {

--- a/engine/src/srvcgi.cpp
+++ b/engine/src/srvcgi.cpp
@@ -827,6 +827,87 @@ static void cgi_store_form_urlencoded(MCVariable *p_variable, MCDataRef p_data, 
 }
 
 
+static void cgi_fix_path_variables()
+{
+    char *t_path;
+
+	MCStringRef env;
+    env = nil;
+    t_path = nil;
+    
+    // SN-2014-07-29: [[ Bug 12865 ]] When a LiveCode CGI script has a .cgi extension and has
+    //  the appropriate shebang pointing to the LiveCode server, PATH_TRANSLATED is not set by Apache.
+    //  The current file (stored in SCRIPT_FILENAME) is the one containing the script.
+	if (MCS_getenv(MCSTR("PATH_TRANSLATED"), env))
+		t_path = strdup(MCStringGetCString(env));
+    else if (MCS_getenv(MCSTR("SCRIPT_FILENAME"), env))
+        t_path = strdup(MCStringGetCString(env));
+
+    // SN-2015-02-11: [[ Bug 14457 ]] We want to split PATH_TRANSLATED
+    //  between what is the real filename (into PATH_TRANSLATED)
+    //  and what was appended to the URI (into PATH_INFO)
+    MCStringRef t_path_string;
+    MCStringRef t_path_info;
+             
+    if (t_path != nil)
+    {
+#ifdef _WINDOWS_SERVER
+		for(uint32_t i = 0; t_path[i] != '\0'; i++)
+			if (t_path[i] == '\\')
+				t_path[i] = '/';
+#endif
+
+        // SN-2015-02-12: [[ Bug 14457 ]] We use a mutable string for
+        //  the path info, as we will need to prepend each segment we
+        //  cut off of the TRANSLATED_PATH.
+        // Initialise path_string and path_info
+        MCAutoStringRef t_mutable_path_info;
+        /* UNCHECKED */ MCStringCreateWithCString(t_path, t_path_string);
+        MCStringCreateMutable(0, &t_mutable_path_info);
+        
+        // SN-2015-02-12: [[ Bug 14457 ]] As long as the path does not lead
+        //  to an existing file, we cut it at the last path separator.
+        //
+        while (!MCS_exists(t_path_string, True))
+        {
+            uindex_t t_offset;
+            MCAutoStringRef t_new_path;
+            MCAutoStringRef t_new_path_info;
+
+            // SN-2015-02-11: [[ Bug 14457 ]] If we cannot find any slash, we are done.
+            if (!MCStringLastIndexOfChar(t_path_string, '/', UINDEX_MAX, kMCStringOptionCompareExact, t_offset))
+                break;
+
+            // We take split from the last separator (which must be
+            // included in the tail).
+            if (!MCStringCopySubstring(t_path_string, MCRangeMake(0, t_offset), &t_new_path)
+                    || !MCStringCopySubstring(t_path_string, MCRangeMake(t_offset, UINDEX_MAX), &t_new_path_info))
+                break;
+
+            // SN-2015-02-11: [[ Bug 14457 ]] Update path and path_info
+            MCValueAssign(t_path_string, *t_new_path);
+           /* UNCHECKED */ MCStringPrepend(*t_mutable_path_info, *t_new_path_info);
+        }
+
+        // SN-2015-02-12: [[ Bug 14457 ]] We get the constructed path info
+        /* UNCHECKED */ MCStringCopy(*t_mutable_path_info, t_path_info);
+    }
+    else
+    {
+        // SN-2015-02-11: [[ Bug 14457 ]] Initialise the values to empty
+        //  if we failed to get the path
+        t_path_string = MCValueRetain(kMCEmptyString);
+        t_path_info = MCValueRetain(kMCEmptyString);
+    }
+
+    MCS_setenv(MCSTR("PATH_TRANSLATED"), t_path_string);
+    MCS_setenv(MCSTR("PATH_INFO"), t_path_info);
+
+    MCValueRelease(t_path_string);
+    MCValueRelease(t_path_info);
+	free(t_path);
+}
+
 static bool cgi_compute_get_var(void *p_context, MCVariable *p_var)
 {
 	MCAutoStringRef t_query_string;
@@ -1409,15 +1490,14 @@ bool cgi_initialize()
 	
 	s_cgi_upload_temp_dir = MCValueRetain(kMCEmptyString);
 	s_cgi_temp_dir = MCValueRetain(kMCEmptyString);
+	// need to ensure PATH_TRANSLATED points to the script and PATH_INFO contains everything that follows
+	cgi_fix_path_variables();
 
 	// Resolve the main script that has been requested by the CGI interface.
 	MCAutoStringRef t_env;
-    
-    // SN-2017-01-06: [[ Bug 19050 ]] Use SCRIPT_FILENAME, which contains the
-    // correct absolute path to the CGI script, instead of fiddling and
-    // tampering with PATH_TRANSLATED
+
 	if (t_success)
-		t_success = MCS_getenv(MCSTR("SCRIPT_FILENAME"), &t_env);
+		t_success = MCS_getenv(MCSTR("PATH_TRANSLATED"), &t_env);
 	if (t_success)
 		t_success = MCsystem -> ResolvePath(*t_env, MCserverinitialscript);
 

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -144,12 +144,6 @@ on revSaveAsStandalone pStack, pFolder, pPreview
       put the short name of the topStack into pStack
    end if
    
-   -- Script only stacks can not store standalone settings so don't allow them as targets
-   if the scriptOnly of stack pStack then
-      answer error "Script only stacks are not currently supported as standalone mainstacks"
-      exit revSaveAsStandalone
-   end if
-   
    if the fileName of stack pStack = empty then
       put "edited" into gREVStackStatus[pStack]
    end if

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1051,22 +1051,6 @@ end utilityMakePathRelative
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-command revSBResaveScriptOnlyStackAsProperStackFile pStackName, pStackFilePath, pOutputStackFilePath
-   lock messages
-   if there is a stack pStackName then
-      set the name of stack pStackName to "__keep_this_around__"
-   end if
-   create invisible stack "__temp_real_stack__"
-   set the script of stack "__temp_real_stack__" to the script of stack pStackFilePath
-   set the name of stack "__temp_real_stack__" to pStackName
-   save stack pStackName as pOutputStackFilePath
-   delete stack pStackName
-   if there is a stack "__keep_this_around__" then
-      set the name of stack "__keep_this_around__" to pStackName
-   end if
-   unlock messages
-end revSBResaveScriptOnlyStackAsProperStackFile
-
 # AL-2015-02-02: [[ Scriptify IDE ]] As we remove buttons from revLIbrary, we'll need to add to
 # this function to return the 'common' name of each of the libraries.
 function revSBScriptLibraryNameFromStackName pStack
@@ -2090,23 +2074,12 @@ command revSBUpdateDeployParams pStack, pTarget, pStandaloneSettings, @xDeployPa
       prependToStringList tInitScript, tStartupScript
    end if
    
-   -- Resave all aux stack files as non-script-only files 
-   local tResavedAux
-   if tAuxiliaryStackFiles is not empty then
-      repeat for each line tStackFile in tAuxiliaryStackFiles
-         local tTempStackFile
-         put the tempname into tTempStackFile
-         revSBResaveScriptOnlyStackAsProperStackFile the short name of stack tStackFile, tStackFile, tTempStackFile
-         appendToStringList tTempStackFile, tResavedAux
-      end repeat
-   end if
-   
    -- If the datagrid is used, then include the library as an aux stack
    if tIncludeDataGrid or "data grid templates" is in the subStacks of stack pStack and there is a stack "revDataGridLibrary" then
-      appendToStringList the effective filename of stack "revDataGridLibrary", tResavedAux
+      appendToStringList the effective filename of stack "revDataGridLibrary", tAuxiliaryStackFiles
    end if
    
-   put tResavedAux into xDeployParams["auxiliary_stackfiles"]
+   put tAuxiliaryStackFiles into xDeployParams["auxiliary_stackfiles"]
    put tStartupScript into xDeployParams["startup_script"]
    put tModules into xDeployParams["modules"]
 end revSBUpdateDeployParams

--- a/libbrowser/src/libbrowser_android.cpp
+++ b/libbrowser/src/libbrowser_android.cpp
@@ -710,15 +710,16 @@ public:
 			
 		MCAndroidObjectRemoteCall(m_view, "executeJavaScript", "ss", &m_js_tag, p_script);
 		
-		// wait for result, timeout after 30 seconds    
-		double t_current_time = MCBrowserTimeInSeconds();
-		double t_timeout = t_current_time + 30.0;
+		// HH-2017-01-26: [[ Bug 19154 ]]: Fix browser stuck for JS handlers execute 
+		// wait for result, timeout after 30 seconds
+		// double t_current_time = MCBrowserTimeInSeconds();
+		// double t_timeout = t_current_time + 30.0;
 		
-		while (m_js_tag != nil && t_current_time < t_timeout)
-		{
-			MCBrowserRunloopWait();
-			t_current_time = MCBrowserTimeInSeconds();
-		}
+		// while (m_js_tag != nil && t_current_time < t_timeout)
+		// {
+		// 	MCBrowserRunloopWait();
+		// 	t_current_time = MCBrowserTimeInSeconds();
+		// }
 		
 		if (m_js_tag != nil)
 		{

--- a/libbrowser/src/libbrowser_android.cpp
+++ b/libbrowser/src/libbrowser_android.cpp
@@ -710,16 +710,15 @@ public:
 			
 		MCAndroidObjectRemoteCall(m_view, "executeJavaScript", "ss", &m_js_tag, p_script);
 		
-		// HH-2017-01-26: [[ Bug 19154 ]]: Fix browser stuck for JS handlers execute 
-		// wait for result, timeout after 30 seconds
-		// double t_current_time = MCBrowserTimeInSeconds();
-		// double t_timeout = t_current_time + 30.0;
+		// wait for result, timeout after 30 seconds    
+		double t_current_time = MCBrowserTimeInSeconds();
+		double t_timeout = t_current_time + 30.0;
 		
-		// while (m_js_tag != nil && t_current_time < t_timeout)
-		// {
-		// 	MCBrowserRunloopWait();
-		// 	t_current_time = MCBrowserTimeInSeconds();
-		// }
+		while (m_js_tag != nil && t_current_time < t_timeout)
+		{
+			MCBrowserRunloopWait();
+			t_current_time = MCBrowserTimeInSeconds();
+		}
 		
 		if (m_js_tag != nil)
 		{

--- a/tests/lcb/vm/foreign-invoke.lcb
+++ b/tests/lcb/vm/foreign-invoke.lcb
@@ -1,0 +1,21 @@
+module __VMTEST.foreign_invoke
+
+use com.livecode.foreign
+
+foreign handler MCStringGetNativeCharPtr(in pString as String) returns optional Pointer binds to "<builtin>"
+
+public handler TestForeignInvoke_OptionalPointerResult()
+   variable tNullNativeCharPtr as optional Pointer
+   unsafe
+      put MCStringGetNativeCharPtr("\u{1F4A9}") into tNullNativeCharPtr
+   end unsafe
+   test "nullptr maps to nothing for optional Pointer" when tNullNativeCharPtr is nothing
+
+   variable tNonNullNativeCharPtr as optional Pointer
+   unsafe
+      put MCStringGetNativeCharPtr("a") into tNonNullNativeCharPtr
+   end unsafe
+   test "non-nullptr maps to non-nothing for optional Pointer" when tNonNullNativeCharPtr is not nothing
+end handler
+
+end module

--- a/tests/lcs/core/field/background-pattern-scroll.livecodescript
+++ b/tests/lcs/core/field/background-pattern-scroll.livecodescript
@@ -1,0 +1,72 @@
+script "CoreFieldBackgroundPatternScroll"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestBackgroundPatternScroll
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   -- Create black and white stripes (3 pixels then 4 pixels).
+   local tImageData
+   put empty into tImageData
+   repeat 3 times
+      put numToChar(0) & numToChar(0) & numToChar(0) & numToChar(0) after tImageData
+   end repeat
+   repeat 4 times
+      put numToChar(0) & numToChar(255) & numToChar(255) & numToChar(255) after tImageData
+   end repeat
+   set the lockLocation of the templateImage to true
+   create image "BgPattern"
+   set the rect of image "BgPattern" to 0,0,1,7
+   set the imageData of image "BgPattern" to tImageData
+   hide image "BgPattern"
+
+   -- Create the test field and make it have formattedHeight of more than
+   -- 64k pixels
+   create field "TestField"
+   set the lockLocation of the last field to true
+   set the rect of the last field to 0,0,1,7
+   set the backgroundPattern of the last field to the id of image "BgPattern"
+   set the showBorder of the last field to false
+   set the fixedLineHeight of the last field to true
+   set the textHeight of the last field to 1024
+   set the vScollbar of the last field to false
+   repeat with i = 0 to 127
+      put return after the last field
+   end repeat
+
+   -- Set the vScroll to multiples of the height of the background pattern
+   -- and ensure it remains showing the entire pattern as originally
+   -- described.
+   lock messages
+   lock screen
+   set the caseSensitive to true
+   repeat with i = 0 to the formattedHeight of field "TestField" - 15 step 7
+      set the vScroll of field "TestField" to i
+      import snapshot from field "TestField"
+      set the rect of the last image to the rect of the last field
+      if the imageData of the last image is not the imageData of image "BgPattern" then
+         TestAssert "background pattern drift detected at vScroll " & i, false
+         exit repeat
+      end if
+      delete the last image
+   end repeat
+   unlock screen
+   unlock messages
+
+   delete stack "Test"
+end TestBackgroundPatternScroll


### PR DESCRIPTION
Conflicts in:
`engine/src/dispatch.cpp` and `libscript/src/script-instance.cpp`

Resolution:
In `engine/src/dispatch.cpp` kept the `develop-8.1` version, which includes the changes described in this commit: https://github.com/livecode/livecode/commit/a1eb36fdb4465e969bf11c8b9b39b0d493af041b

In `libscript/src/script-instance.cpp`, kept the `develop` version. Actually `script-instance.cpp` should be unchanged in `develop` after merging that commit, since there is a new VM implementation in `develop`.