### PR TITLE
[[ BuildBot ]] Add uploads of .bz2 tarballs

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -200,6 +200,7 @@ dist-upload-files.txt sha1sum.txt:
 	                -o -name 'LiveCode*Server-*-Windows.zip' \
 	                -o -name 'LiveCode*Docs-*.zip' \
 	                -o -name '*-bin.tar.xz' \
+	                -o -name '*-bin.tar.bz2' \
 	  > dist-upload-files.txt; \
 	if test "${UPLOAD_RELEASE_NOTES}" = "yes"; then \
 		find . -maxdepth 1 -name 'LiveCodeNotes*.pdf' >> dist-upload-files.txt; \


### PR DESCRIPTION
This patch ensures both .bz2 and .xz tarballs are uploaded to
the staging server. This ensures it doesn't matter which archive
utility used is to compress the tars.