### PR TITLE
[Bug 19287] Update the clickLoc on mouseDown/touchStart on mobile

### DIFF
--- a/docs/notes/bugfix-19287.md
+++ b/docs/notes/bugfix-19287.md
@@ -1,0 +1,1 @@
+# Make sure the clickLoc is updated on mouseDown/touchEnd on mobile

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -358,14 +358,15 @@ static void MCEventQueueDispatchEvent(MCEvent *p_event)
 					s_click_count += 1;
 				else
 					s_click_count = 0;
+                
+                MCclicklocx = MCmousex;
+                MCclicklocy = MCmousey;
 			}
 			else
 				s_click_time = t_event -> mouse . time;
 
 			MCeventtime = t_event -> mouse . time;
 			MCmodifierstate = t_event -> mouse . press . modifiers;
-			MCclicklocx = MCmousex;
-			MCclicklocy = MCmousey;
 			MCclickstackptr = MCmousestackptr;
 
 			MCObject *t_target;


### PR DESCRIPTION
The `clickLoc` is the position of the mouse pointer when the user pressed the mouse button, not when the user released the button. This works as expected on Desktop platforms, but not on mobile. This patch ensures the `clickLoc` always reports the mouse position at the most recent mouseDown/touchStart on mobile. 