### PR TITLE
Add a proper MCTristate type

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -50,6 +50,7 @@
 			'src/tilecachegl.cpp',
 			'src/tilecachesw.cpp',
 			'src/mcsemaphore.h',
+			'src/mctristate.h',
 			
 			# Group "Core - Language"
 			'src/ans.h',

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -437,16 +437,16 @@ void MCButton::open()
 	//   has changed (i.e. background transition has occured).
 	uint32_t t_old_state;
 	t_old_state = state;
-	switch(gethilite(0))
+	switch(gethilite(0).value)
 	{
-	case True:
+	case kMCTristateTrue:
 		state |= CS_HILITED;
 		state &= ~CS_MIXED;
 		break;
-	case False:
+	case kMCTristateFalse:
 		state &= ~(CS_HILITED | CS_MIXED);
 		break;
-	case Mixed:
+	case kMCTristateMixed:
 		state &= ~CS_HILITED;
 		state |= CS_MIXED;
 		break;
@@ -1860,16 +1860,16 @@ void MCButton::replacedata(MCCdata *&data, uint4 newid)
 	bptr->appendto(bdata);
 	if (opened)
 	{
-		switch(gethilite(newid))
+		switch(gethilite(newid).value)
 		{
-		case True:
+		case kMCTristateTrue:
 			state |= CS_HILITED;
 			state &= ~CS_MIXED;
 			break;
-		case False:
+		case kMCTristateFalse:
 			state &= ~(CS_HILITED | CS_MIXED);
 			break;
-		case Mixed:
+		case kMCTristateMixed:
 			state &= ~CS_HILITED;
 			state |= CS_MIXED;
 			break;
@@ -2060,7 +2060,7 @@ uint2 MCButton::getfamily()
 	return family;
 }
 
-Boolean MCButton::gethilite(uint4 parid)
+MCTristate MCButton::gethilite(uint4 parid)
 {
 	if (flags & F_SHARED_HILITE)
 		parid = 0;
@@ -2089,7 +2089,7 @@ void MCButton::setdefault(Boolean def)
 	}
 }
 
-Boolean MCButton::sethilite(uint4 parid, Boolean hilite)
+Boolean MCButton::sethilite(uint4 parid, MCTristate hilite)
 {
 	Boolean set
 		= True;
@@ -2104,21 +2104,21 @@ Boolean MCButton::sethilite(uint4 parid, Boolean hilite)
 	MCCdata *foundptr = getbptr(parid);
 	
 	bool t_hilite_changed;
-	t_hilite_changed = hilite != foundptr -> getset();
+	t_hilite_changed = hilite != MCTristate(foundptr -> getset());
 	
-	foundptr->setset(hilite);
+	foundptr->setset(!hilite.isFalse());
 	uint4 oldstate = state;
 	if (opened && set)
-			switch (hilite)
+			switch (hilite.value)
 			{
-			case True:
+			case kMCTristateTrue:
 				state |= CS_HILITED;
 				state &= ~CS_MIXED;
 				break;
-			case False:
+			case kMCTristateFalse:
 				state &= ~(CS_HILITED | CS_MIXED);
 				break;
-			case Mixed:
+			case kMCTristateMixed:
 				state &= ~CS_HILITED;
 				state |= CS_MIXED;
 			}
@@ -2129,7 +2129,7 @@ Boolean MCButton::sethilite(uint4 parid, Boolean hilite)
 	return state != oldstate;
 }
 
-void MCButton::resethilite(uint4 parid, Boolean hilite)
+void MCButton::resethilite(uint4 parid, MCTristate hilite)
 {
 	if (sethilite(parid, hilite))
 	{

--- a/engine/src/button.h
+++ b/engine/src/button.h
@@ -19,7 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "mccontrol.h"
 #include "stack.h"
-
+#include "mctristate.h"
 
 #define AQUA_FUDGE 8
 
@@ -234,10 +234,10 @@ public:
 	void setupmnemonic();
 	MCCdata *getbptr(uint4 cardid);
 	uint2 getfamily();
-	Boolean gethilite(uint4 parid);
+	MCTristate gethilite(uint4 parid);
 	void setdefault(Boolean def);
-	Boolean sethilite(uint4 parid, Boolean hilite);
-	void resethilite(uint4 parid, Boolean hilite);
+	Boolean sethilite(uint4 parid, MCTristate hilite);
+	void resethilite(uint4 parid, MCTristate hilite);
 
 	// MW-2011-09-30: [[ Redraw ]] This function conditionally does a redraw all
 	//   if flags means it might need to be.

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -2788,7 +2788,7 @@ bool MCCard::selectedbutton(integer_t p_family, bool p_background, MCStringRef& 
 	MCButton *bptr;
 	while (nil != (bptr = (MCButton *)getnumberedchild(i, CT_BUTTON, ptype)))
 	{
-		if (bptr->getfamily() == p_family && bptr->gethilite(obj_id))
+		if (bptr->getfamily() == p_family && !(bptr->gethilite(obj_id).isFalse()))
 		{
 			uint2 bnum = 0;
 			getcard()->count(CT_BUTTON, ptype, bptr, bnum, True);

--- a/engine/src/chunk.h
+++ b/engine/src/chunk.h
@@ -71,7 +71,7 @@ class MCChunk : public MCExpression
 	MCObject *destobj;
 	Dest_type desttype;
 	Functions function;
-	Boolean marked : 1;
+	bool marked : 1;
     
     // MW-2014-05-28: [[ Bug 11928 ]] This is set to true after 'destvar' has been evaluated
     //   as a chunk. This stops stale chunk information being used in MCChunk::del.

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -93,7 +93,7 @@ class MCDo : public MCStatement
 	MCChunk *widget;
 protected:
 	bool browser : 1;
-	Boolean debug : 1;
+	bool debug : 1;
 	bool caller : 1;
 public:
 	MCDo()
@@ -500,11 +500,11 @@ class MCCreate : public MCStatement
 	MCExpression *file;
     MCExpression *kind;
     MCChunk *container;
-    Boolean directory: 1;
-    Boolean visible: 1;
-    Boolean alias: 1;
+    bool directory: 1;
+    bool visible: 1;
+    bool alias: 1;
     // MW-2014-09-30: [[ ScriptOnlyStack ]] For 'create script only stack ...' form.
-    Boolean script_only_stack : 1;
+    bool script_only_stack : 1;
 public:
 	MCCreate()
 	{
@@ -1517,16 +1517,16 @@ class MCOpen : public MCStatement
 	MCStringRef destination;
 	Open_argument arg : 4;
 	Open_mode mode : 4;
-	Boolean dialog : 1;
-	Boolean datagram : 1;
-	Boolean sheet : 1;
-	Boolean secure : 1;
-	Boolean secureverify : 1;
-    Boolean textmode : 1;
+	bool dialog : 1;
+	bool datagram : 1;
+	bool sheet : 1;
+	bool secure : 1;
+	bool secureverify : 1;
+    bool textmode : 1;
 
 	// MW-2010-05-09: Indicates that the process should be opened with elevated
 	//   (admin) permissions
-	Boolean elevated : 1;
+	bool elevated : 1;
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added new "open socket <socket> with verification for <host>" variant.
 	MCExpression *verifyhostname;
@@ -1768,7 +1768,7 @@ class MCSetOp : public MCStatement
 	MCVarref *destvar;
 	MCExpression *source;
 protected:
-	Boolean intersect : 1;
+	bool intersect : 1;
 	bool overlap : 1;
     // MERG-2013-08-26: [[ RecursiveArrayOp ]] Support nested arrays in union and intersect
     bool recursive : 1;
@@ -2197,7 +2197,7 @@ public:
 	
 private:
 	MCExpression *m_sock_name;
-	Boolean secureverify : 1;
+	bool secureverify : 1;
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added new host name variant for use with verification.
 	MCExpression *m_verify_host_name;

--- a/engine/src/exec-interface-button.cpp
+++ b/engine/src/exec-interface-button.cpp
@@ -1183,29 +1183,12 @@ void MCButton::SetMargins(MCExecContext& ctxt, const MCInterfaceMargins& p_margi
 
 void MCButton::GetHilite(MCExecContext& ctxt, uint32_t p_part, MCInterfaceTriState& r_hilite)
 {
-    uint2 t_hilite;
-    t_hilite = gethilite(p_part);
-    
-    if (t_hilite == Mixed)
-    {
-        r_hilite . type = kMCInterfaceTriStateMixed;
-        r_hilite . mixed = t_hilite;
-        return;
-    }
-
-    r_hilite . type = kMCInterfaceTriStateBoolean;
-    r_hilite . state = (Boolean)t_hilite == True;
+    r_hilite.value = gethilite(p_part);
 }
 
 void MCButton::SetHilite(MCExecContext& ctxt, uint32_t p_part, const MCInterfaceTriState& p_hilite)
 {
-    Boolean t_new_state;
-    if (p_hilite . type == kMCInterfaceTriStateMixed)
-        t_new_state = p_hilite . mixed;
-    else
-        t_new_state = (Boolean)p_hilite . state;
-    
-    if (sethilite(p_part, t_new_state))
+    if (sethilite(p_part, p_hilite.value))
     {
         if (state & CS_HILITED)
         {

--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -173,7 +173,7 @@ void MCGroup::GetHilitedButton(MCExecContext& ctxt, uint32_t part, integer_t& r_
 			{
 				MCButton *bptr = (MCButton *)cptr;
 				if (!(mgrabbed == True && cptr == mfocused)
-				        && bptr->gethilite(part))
+                    && !bptr->gethilite(part).isFalse())
                 {
                     t_found = true;
 					break;

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1121,13 +1121,14 @@ void MCInterfaceTriStateParse(MCExecContext& ctxt, MCStringRef p_input, MCInterf
 {
     if (MCStringIsEqualToCString(p_input, "mixed", kMCCompareCaseless))
     {
-        r_output . mixed = Mixed;
-        r_output . type = kMCInterfaceTriStateMixed;
+        r_output . value = kMCTristateMixed;
+        return;
     }
-    
-    if (MCTypeConvertStringToBool(p_input, r_output . state))
+
+    bool t_bool = false;
+    if (MCTypeConvertStringToBool(p_input, t_bool))
     {
-        r_output . type = kMCInterfaceTriStateBoolean;
+        r_output . value = t_bool;
         return;
     }
     
@@ -1136,16 +1137,14 @@ void MCInterfaceTriStateParse(MCExecContext& ctxt, MCStringRef p_input, MCInterf
 
 void MCInterfaceTriStateFormat(MCExecContext& ctxt, const MCInterfaceTriState& p_input, MCStringRef& r_output)
 {
-    if (p_input . type == kMCInterfaceTriStateBoolean)
+    if (p_input.value.isMixed())
     {
-        r_output = MCValueRetain(p_input . state ? kMCTrueString : kMCFalseString);
+        if (!MCStringCreateWithCString("mixed", r_output))
+            ctxt.Throw();
         return;
     }
-    
-    if (MCStringCreateWithCString("mixed", r_output))
-        return;
-    
-    ctxt . Throw();
+
+    r_output = MCValueRetain(p_input.value.isFalse() ? kMCFalseString : kMCTrueString);
 }
 
 void MCInterfaceTriStateFree(MCExecContext& ctxt, MCInterfaceTriState& p_input)

--- a/engine/src/exec-interface.h
+++ b/engine/src/exec-interface.h
@@ -17,6 +17,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef EXEC_INTERFACE_H
 #define EXEC_INTERFACE_H
 
+#include "mctristate.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct MCInterfaceImagePaletteSettings
@@ -191,22 +193,9 @@ struct MCMultimediaQTVRConstraints
 
 //////////
 
-enum MCInterfaceTriStateType
-{
-    kMCInterfaceTriStateMixed,
-    kMCInterfaceTriStateBoolean
-};
-
 struct MCInterfaceTriState
 {
-    MCInterfaceTriStateType type;
-    
-    union
-    {
-        bool state;
-        uint2 mixed;
-    };
-    
+    MCTristate value;
 };
 
 void MCInterfaceTriStateParse(MCExecContext& ctxt, MCStringRef p_input, MCInterfaceTriState& r_output);

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -1897,7 +1897,7 @@ void MCGroup::radio(uint4 parid, MCControl *focused)
 		{
 			MCButton *bptr = (MCButton *)focused;
 			if (bptr->getstyle() == F_RADIO
-			        && (bptr->gethilite(parid)
+                && (!bptr->gethilite(parid).isFalse()
 			            || (bptr->getstate(CS_MFOCUSED)
 			                && MCU_point_in_rect(bptr->getrect(), mx, my))))
 			{
@@ -1930,7 +1930,7 @@ MCButton *MCGroup::gethilitedbutton(uint4 parid)
 			{
 				MCButton *bptr = (MCButton *)cptr;
 				if (!(mgrabbed == True && cptr == mfocused)
-				        && bptr->gethilite(parid))
+                    && !bptr->gethilite(parid).isFalse())
 					return bptr;
 			}
 			cptr = cptr->next();

--- a/engine/src/mctristate.h
+++ b/engine/src/mctristate.h
@@ -1,0 +1,69 @@
+/* Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef MC_TRISTATE_H
+#define MC_TRISTATE_H
+
+/* In a few places in the engine, a type is needed that can be true,
+ * false, or somewhere between the two.  This is provided by the
+ * MCTristate type.  The values in the MCTristateValue enumeration
+ * shouldn't be used except to implement a switch over an MCTristate.
+ *
+ * Always use an MCTristate as a value (just like bool or int).
+ */
+
+enum MCTristateValue {
+    kMCTristateFalse = 0,
+    kMCTristateTrue = 1,
+    kMCTristateMixed = 2,
+};
+
+class MCTristate {
+ public:
+    MCTristate() : value(kMCTristateFalse) {}
+
+    MCTristate(const MCTristate& t) : value (t.value) {}
+
+    MCTristate(MCTristateValue v) : value(v) {}
+
+    MCTristate(bool b) : value(b ? kMCTristateTrue : kMCTristateFalse) {}
+
+    bool isFalse() const { return value == kMCTristateFalse; }
+
+    bool isMixed() const { return value == kMCTristateMixed; }
+
+    bool isTrue() const { return value == kMCTristateTrue; }
+
+    bool operator==(const MCTristate& t) const
+    {
+        return value == t.value;
+    }
+
+    bool operator!=(const MCTristate& t) const
+    {
+        return !operator==(t);
+    }
+
+    MCTristate& operator=(const MCTristate& t)
+    {
+        value = t.value;
+        return *this;
+    }
+
+    MCTristateValue value = kMCTristateFalse;
+};
+
+#endif /* !MC_TRISTATE_H */

--- a/engine/src/mctristate.h
+++ b/engine/src/mctristate.h
@@ -63,7 +63,7 @@ class MCTristate {
         return *this;
     }
 
-    MCTristateValue value = kMCTristateFalse;
+    MCTristateValue value;
 };
 
 #endif /* !MC_TRISTATE_H */

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -436,11 +436,12 @@ void MCStack::mode_load(void)
 		MCAutoNameRef t_ide_override_name;
 		/* UNCHECKED */ t_ide_override_name . CreateWithCString("ideOverride");
 
-		MClockmessages++;
+        bool t_old_lock = MClockmessages;
+		MClockmessages = true;
         MCExecValue t_value;
         MCExecContext ctxt(nil, nil, nil);
         getcustomprop(ctxt, kMCEmptyName, t_ide_override_name, nil, t_value);
-		MClockmessages--;
+		MClockmessages = t_old_lock;
 
 		bool t_treat_as_ide;
         MCExecTypeConvertAndReleaseAlways(ctxt, t_value . type, &t_value, kMCExecValueTypeBool, &t_treat_as_ide);

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -294,9 +294,11 @@ IO_stat MCStack::load_stack(IO_handle stream, uint32_t version)
 		if ((stat = IO_read_mccolor(linkatts->visitedcolor, stream)) != IO_NORMAL
 		        || (stat=IO_read_stringref_new(linkatts->visitedcolorname, stream, version >= kMCStackFileFormatVersion_7_0))!=IO_NORMAL)
 			return checkloadstat(stat);
-		
-		if ((stat = IO_read_uint1(&linkatts->underline, stream)) != IO_NORMAL)
+
+        uint1 t_underline = 0;
+		if ((stat = IO_read_uint1(&t_underline, stream)) != IO_NORMAL)
 			return checkloadstat(stat);
+        linkatts->underline = (t_underline != 0);
         
         // for interface colors, empty name means unset whereas nil name means
         // defer to rgb values. Therefore set values to nil if they are empty.

--- a/engine/src/typedefs.h
+++ b/engine/src/typedefs.h
@@ -88,14 +88,14 @@ typedef double          real8;
 
 // Boolean definitions
 
-typedef unsigned char Boolean;
+#ifndef __MACTYPES__
+typedef bool Boolean;
+#endif
+static const bool True = true;
+static const bool False = false;
 
 #ifndef Bool
 #define Bool int
 #endif
-
-#define False 0
-#define True 1
-#define Mixed 2
 
 #endif

--- a/engine/src/variable.h
+++ b/engine/src/variable.h
@@ -338,11 +338,11 @@ protected:
 	};
 	unsigned index : 16;
 	unsigned dimensions : 8;
-	Boolean isparam : 1;
+	bool isparam : 1;
 
 	// MW-2008-10-28: [[ ParentScripts ]] This boolean flag is True if this
 	//   varref refers to a script local.
-	Boolean isscriptlocal : 1;
+	bool isscriptlocal : 1;
 	
 	// MW-2012-03-15: [[ Bug ]] This boolean flag is true if this varref is
 	//   a plain var and doesn't require synching.


### PR DESCRIPTION
The engine extensively used a `Boolean` type which was similar to `bool` but allowed a third `Mixed` state.  This was confusing.

This PR adds an `MCTristate` value type and makes `Boolean` an alias for `bool`.  It should fix lots and lots of Windows build warnings.