### PR TITLE
[[ Docs ]] Format fixes to mobileControlDo.lcdoc

### DIFF
--- a/docs/dictionary/function/mobileControlGet.lcdoc
+++ b/docs/dictionary/function/mobileControlGet.lcdoc
@@ -50,23 +50,19 @@ Use the <mobileControlGet> function to get the value of
 - "id": Returns the id of the control where the name is passed.
 - "name": Returns the name of the control where the id is passed.
 - "rect": Returns the bounds of the control, relative to the top-left of
-
 the card. For example "0,0,100,100".
 
 - "visible": Returns true if the control is visible.
 - "alpha": Returns the blendlevel of the control as an integer between 0
-
 and 255.
 
 - "backgroundColor": Returns the background color of the control as an
-
 integer between 0 to 255.
 
 **Global properties (All native iOS controls)**
 
 - "opaque": Returns true if the control is opaque.
 - "ignoreVoiceOverSensitivity": Returns true if the control is
-
 accessible through Voice Over. Default value is false.
 
 **Browser Specific Properties**
@@ -75,203 +71,169 @@ accessible through Voice Over. Default value is false.
 - "canAdvance": returns true if there is a next page in the history.
 - "canRetreat": Returns true if there is a previous page in the history.
 - "autoFit" (iOS Only): returns true if the page is scaled to fit the
-
 rect of the control
 
 - "delayRequests" (iOS Only): returns true | false
 - "dataDetectorTypes": returns a comma delimited list of the types of
+data that are automatically converted to clickable URLs. This is none 
+or more of the following:
 
-data that are automatically converted 
-to clickable URLs. This is none or more of the following:
-
-  - "phone number": 
-  - "calendar event": iOS4.0+
-  - "link": 
-  - "address": iOS4.0+
+  - "phone number" 
+  - "calendar event" (iOS4.0+)
+  - "link"
+  - "address" (OS4.0+)
+  
+  
 - "allowsInlinePlayback" (iOS Only): returns true if the web-view allows
-
 media files to be played 'inline' in the page.
 
 - "mediaPlaybackRequiresUserAction" (iOS Only): returns true if media
-
 files DO NOT play automatically in the webview. Note: This property is
 only available on iOS4.0 and later.
 
 - "scrollingEnabled": specifies whether or not the browser can be
-
 scrolled (boolean).
 
 - "canBounce": determines whether the scroller 'bounces' when it hits
-
 the edge of the contentRect.
 
 - "pagingEnabled" (iOS Only): returns true if scrolling stops on
-
 multiples of the scroller's bounds (maps to the UIScrollView
 pagingEnabled property).
 
 **Scroller Specific Properties**
 
 - "contentRect": returns the rectangle over which the scroller scrolls.
-
 This is distinct from the scroller's rect. The minimum/maximum values of
 the scroll properties (adjusted for the size of the scroller). This is a
 comma-separated list of four integers, describing a rectangle. For
 example "0,0,100,100".
 
 - "hScroll": returns the horizontal scroll offset. This is an integer
-
 value ranging between the left and right of the contentRect, adjusting
 appropriately for the size of the scroller (i.e. contentRect.left to
 contentRect.right - rect.width).
 
 - "vScroll": returns the vertical scroll offset. This is an integer
-
 value ranging between the top and bottom of the contentRect, adjusting
 appropriately for the size of the scroller (i.e. contentRect.top to
 contentRect.bottom - rect.height).
 
 - "tracking": returns true if the scroller is monitoring a touch for the
-
 start of a scroll action (maps to the UIScrollView tracking property).
 
 - "dragging": returns true if the scroller is currently performing a
-
 scroll action (maps to the UIScrollView dragging property).
 
 - "scrollingEnabled": returns true if touches on the scroller cause
-
 scrolling (maps to the UIScrollView scrollEnabled property).
 
 - "hIndicator": returns true if the horizontal indicator should be
-
 displayed when scrolling (maps to the UIScrollView
 showsHorizontalScrollIndicator property).
 
 - "vIndicator": returns true if the vertical indicator should be
-
 displayed when scrolling (maps to the UIScrollView
 showsVerticalScrollIndicator property).
 
 - "canBounce" (iOS Only): returns true if the scroller bounces when it
-
 hits the edge of the contentRect (maps to the UIScrollView bounces
 property).
 
 - "canScrollToTop" (iOS Only): returns true if a touch on the status bar
-
 causes the scroll to scroll to the top (maps to the UIScrollView
 scrollsToTop property).
 
 - "canCancelTouches" (iOS Only): returns true if the scroller is allowed
-
 to cancel a touch that has been passed through to the underlying
 controls when it thinks it's a scroll gesture (maps to the UIScrollView
 canCancelContentTouches property).
 
 - "delayTouches" (iOS Only): returns true if the scroller delays passing
-
 on touch-down events until it has determined whether it is the start of
 a scroll gesture or not (maps to the UIScrollView delaysContentTouches
 property).
 
 - "decelerationRate" (iOS Only): returns the rate at which scrolling
-
 decelerates when a finger is lifted (maps to the UIScrollView
 decelerationRate property). This can be either normal, fast or a real
 number.
 
 - "indicatorStyle" (iOS Only): returns the style of indicators to
-
 display (maps to the UIScrollView indicatorStyle property). One of the
-following:  - "default": 
-
-  - "white": 
-  - "black": 
+following:
+  - "default"
+  - "white"
+  - "black"
+  
+  
 - "indicatorInsets" (iOS Only): returns how far from the edge of the
-
 scroller's bounds, the indicators are inset (maps to the UIScrollView
 scrollIndicatorInsets property). This is a comma-separated list of four
 integers, describing the left, top, right and bottom inset distances.
 For example "0,0,100,100".
 
 - "lockDirection" (iOS Only): returns true if scrolling is locked to the
-
 initial direction a drag occurs in (maps to the UIScrollView
 directionalLockEnabled property).
 
 - "decelerating" (iOS Only): returns true if the scroll is currently
-
 decelerating after a scroll action (maps to the UIScrollView
 decelerating property).
 
 **Player Specific Properties**
 
 - "filename": returns the filename or URL of the media set on the
-
 player, if any.
 
 - "showController": returns true if the controller is displayed over the
-
 content.
 
 - "currentTime": returns the current position of the playhead, measured
-
 in milliseconds (maps to the native currentPlaybackTime property). This
 is an integer value.
 
 - "looping": returns true if the playback of the movie loops
-
 indefinitely.
 
 - "fullscreen" (iOS Only): returns true if the player's content is set
-
 to play fullscreen.
 
 - "preserveAspect" (iOS Only): returns true if the player's content
-
 should preserve its aspect ratio when scaled to fit within the control's
 bounds. 
 
 - "useApplicationAudioSession" (iOS Only): returns true if the movie
-
 uses a system-supplied audio session or not (maps to the native
 useApplicationAudioSession property).
 
 - "shouldAutoplay" (iOS Only): returns true if the playback of
-
 network-based content begins automatically when there is enough buffered
 data to ensure uninterrupted playback (maps to the native shouldAutoplay
 property).
 
 - "allowsAirPlay" (iOS Only): returns true if a control is presented to
-
 allow the user to choose AirPlay-enabled hardware for playback (maps to
 the native allowsAirPlay property). Note: This property is only
 supported on iOS 4.3 and later.
 
 - "duration": returns the duration of a movie, measured in
-
 milliseconds (maps to the native duration property on iOS). This is an integer
 value.
 
 - "playableDuration": returns the amount of currently
-
 playable content, measured in milliseconds (maps to the native
 playableDuration property on iOS). This is an integer value.
 
 - "startTime" (iOS Only): returns the position at which playback starts,
-
 measured in milliseconds (maps to the native initialPlaybackTime
 property). This is an integer value.
 
 - "endTime" (iOS Only): returns the position at which playback ends,
-
 measured in milliseconds (maps to the native endPlaybackTime property).
 This is an integer value.
 
 - "playRate" (iOS Only): returns the current playback rate for the
-
 player (maps to the native currentPlaybackRate property). This
 represents a multiplier for the default playback rate of the current
 content. A value of 0.0 indicates playback is stopped, while a value of
@@ -279,162 +241,129 @@ content. A value of 0.0 indicates playback is stopped, while a value of
 while negative values indicate reverse playback. This is real value.
 
 - "loadState" (iOS Only): returns the network load state of the player
-
 (maps to the native loadStateproperty). This is a comma delimited list
 of zero or more of the following:
-
   - "playable": enough data is available to start playing, but it may
-
 run out before playback finishes.
-
   - "playthrough": enough data has been buffered for playback to
-
 continue uninterrupted.
-
   - "stalled": buffer of data has stalled and playback may pause
-
 automatically if the player runs out of data.
 
-- "playbackState" (iOS Only): returns the current playback state of the
 
+- "playbackState" (iOS Only): returns the current playback state of the
 player (maps to the native playbackState property). This is one of the
 following:  - "stopped": playback is stopped and commences from the
 beginning when started.
-
   - "playing": playback is current underway.
   - "paused": playback is paused and resumes from the point it was
-
 paused.
-
   - "interrupted": playback is temporarily interrupted, perhaps because
-
 the buffer ran out of content.
-
   - "seeking forward": the player is currently seeking towards the end
-
 of the movie.
-
   - "seeking backward": the player is currently seeking towards the
-
 beginning of the movie.
 
-- "naturalSize" (iOS Only): The raw size of a video frame in pixels
 
+- "naturalSize" (iOS Only): The raw size of a video frame in pixels
 (maps to the native naturalSize property). This is a comma-separated
 list of two integers, the first is the width, the second is the height.
+
 
 **Text Input Specific Properties**
 
 - "text": returns the content of the control (maps to the native text
-
 property). This is a string value.
 
 - "unicodeText": returns the content of control encoded as UTF-16 (maps
-
 to the native text property). This is a binary value.
 
 - "textColor": returns the color used for the text in control (maps to
-
 the native textColor property). This is either a standard color name, or
 a string of the form red,green,blue or red,green,blue,alpha. Where the
 components are integers in the range 0 to 255.
 
 - "fontName" (iOS Only): returns the name of the font used for text in
-
 the control. This is a string value.
 
 - "fontSize": returns the size of the font used for text in the control.
-
 This is an integer value.
 
 - "textAlign": returns the alignment used for text in the control (maps
-
 to the native textAlignment property). One of:
+  - "left"
+  - "center"
+  - "right"
 
-  - "left": 
-  - "center": 
-  - "right": 
-- "autoFit" (iOS Only): returns true if the size of the text is scaled
 
-so that it fits within the width of the control down to the size
+- "autoFit" (iOS Only): returns true if the size of the text is scaledo that it fits within the width of the control down to the size
 specified by the minimumFontSize property (maps to the native
 adjustsFontSizeToFitWidth property). 
 
 - "minimumFontSize" (iOS Only): returns the minimum size text is shrunk
-
 to satisfy autoFit requirements (maps to the native minimumFontSize
 property). This is an integer value.
 
 - "maximumTextLength" (iOS Only): returns the maximum number of characters
-
 that can be entered in the field. This is an integer value.
 
 - "autoClear" (iOS Only): returns true if the control is emptied
-
 automatically when editing begins (maps to the native
 clearsOnBeginEditing property). This is a boolean.
 
 - "clearButtonMode" (iOS Only): returns the display mode of the standard
-
 'clear' button overlay (maps to the native clearButtonMode property).
 This is one of the following:
-
   - "never": never display the clear button
   - "while editing": only display the clear button while editing
   - "unless editing": only display the clear button when not editing
   - "always": always display the clear button
-- "borderStyle" (iOS Only): returns the type of border around the
 
+
+- "borderStyle" (iOS Only): returns the type of border around the
 control (maps to the native borderStyle property). This is one of the
 following:  - "none": do not draw a border
-
   - "line": draw a thin line around the control
   - "bezel": draw a bezel-style border around the control
   - "rounded": draw a rounded rectangle style border around the control
-- "editing" (iOS Only): returns true if control is currently being
 
+
+- "editing" (iOS Only): returns true if control is currently being
 edited (maps to the native editing property). This is a boolean value.
 
 - "autoCapitalizationType": returns when the shift-key is automatically
-
 enabled (maps to the native autocapitalizationType property). This is
 one of the following:
-
   - "none": the shift-key is never automatically enabled
   - "words": the shift-key is enabled at the start of words
   - "sentences": the shift-key is enabled at the start of sentences
   - "all characters": the shift-key is enabled at the start of each
-
 character
 
 - "autoCorrectionType": returns whether auto-correct behavior is enabled
-
 (maps to the native autocorrectionType property). This is one of the
 following:  - "default": use the appropriate auto-correct behavior for
 the current script system
-
   - "no": disable auto-correct behavior
   - "yes": enable auto-correct behavior
-- "manageReturnKey" (iOS Only): returns true if the return key is
 
+
+- "manageReturnKey" (iOS Only): returns true if the return key is
 automatically enabled or disabled based on whether the control has
 content or not (maps to the native enablesReturnKeyAutomatically
 property). This is a boolean value.
 
 - "keyboardStyle" (iOS Only): returns what kind of appearance the
-
 keyboard has (maps to the native keyboardAppearance property). This is
 one of the following:
-
   - "default": the standard keyboard appearance
   - "alert": the keyboard that is suitable for an alert panel
-
 (iPhone/iPod only)
 
+
 - "keyboardType": returns what kind of keyboard is displayed (maps to
-
 the native keyboardType property). This is one of the following:
-
   - "default": the normal keyboard
   - "alphabet": the alphabetic keyboard
   - "numeric": the numeric keyboard with punctuation
@@ -444,11 +373,11 @@ the native keyboardType property). This is one of the following:
   - "contact": the phone contact pad keyboard
   - "email": the email keyboard
   - "decimal": the decimal numeric pad keyboard (iOS 4.1+)
+  
+  
 - "returnKeyType": returns what kind of return-key the keyboard has
-
 (maps to the native returnKeyType property). This is one of the
 following:  - "default": the normal return key
-
   - "go": the 'Go' return key
   - "google": the 'Google' return key
   - "join": the 'Join' return key
@@ -459,95 +388,83 @@ following:  - "default": the normal return key
   - "yahoo": the 'Yahoo' return key
   - "done": the 'Done' return key
   - "emergency call": the 'emergency call' return key
+
+
 - "contentType": returns what kind of content the control contains. This
-
 is one of the following:
-
   - "plain": plain, unstyled text
   - "password": plain text displayed in the standard iOS password style
-- "enabled": Determines whether the control is enabled or not. This is a
 
+
+- "enabled": Determines whether the control is enabled or not. This is a
 boolean value.
 
 - "multiline" (Android only): Determines whether the control can contain
-
 multiple lines of text or not. This is a boolean value.
+
 
 **Multi-line Text Input Specific Properties**
 
 - "text": returns the content of the control (maps to the native text
-
 property). This is a string value.
 
 - "unicodeText": returns the content of control encoded as UTF-16 (maps
-
 to the native text property). This is a binary value.
 
 - "textColor": returns the color used for the text in control (maps to
-
 the native textColor property). This is either a standard color name, or
 a string of the form red,green,blue or red,green,blue,alpha. Where the
 components are integers in the range 0 to 255.
 
 - "fontName" (iOS Only): returns the name of the font used for text in
-
 the control. This is a string value.
 
 - "fontSize": returns the size of the font used for text in the control.
-
 This is an integer value.
 
 - "textAlign": returns the alignment used for text in the control (maps
-
 to the native textAlignment property). One of:
-
-  - "left": 
-  - "center": 
-  - "right": 
+  - "left"
+  - "center"
+  - "right"
+  
+  
 - "editing" (iOS Only): returns true if control is currently being
-
 edited (maps to the native editing property). This is a boolean value.
 
 - "autoCapitalizationType": returns when the shift-key is automatically
-
 enabled (maps to the native autocapitalizationType property). This is
 one of the following:
-
   - "none": the shift-key is never automatically enabled
   - "words": the shift-key is enabled at the start of words
   - "sentences": the shift-key is enabled at the start of sentences
   - "all characters": the shift-key is enabled at the start of each
-
 character
 
-- "autoCorrectionType": returns whether auto-correct behavior is enabled
 
+- "autoCorrectionType": returns whether auto-correct behavior is enabled
 (maps to the native autocorrectionType property). This is one of the
 following:  - "default": use the appropriate auto-correct behavior for
 the current script system
-
   - "no": disable auto-correct behavior
   - "yes": enable auto-correct behavior
-- "manageReturnKey" (iOS Only): returns true if the return key is
 
+
+- "manageReturnKey" (iOS Only): returns true if the return key is
 automatically enabled or disabled based on whether the control has
 content or not (maps to the native enablesReturnKeyAutomatically
 property). This is a boolean value.
 
 - "keyboardStyle" (iOS Only): returns what kind of appearance the
-
 keyboard has (maps to the native keyboardAppearance property). This is
 one of the following:
-
   - "default": the standard keyboard appearance
   - "alert": the keyboard that is suitable for an alert panel
-
 (iPhone/iPod only)
 
+
 - "keyboardType": returns what kind of keyboard is displayed (maps to
-
 the native keyboardType property). This is one of the following:
-
   - "default": the normal keyboard
   - "alphabet": the alphabetic keyboard
   - "numeric": the numeric keyboard with punctuation
@@ -557,11 +474,11 @@ the native keyboardType property). This is one of the following:
   - "contact": the phone contact pad keyboard
   - "email": the email keyboard
   - "decimal": the decimal numeric pad keyboard (iOS 4.1+)
+  
+  
 - "returnKeyType": returns what kind of return-key the keyboard has
-
 (maps to the native returnKeyType property). This is one of the
 following:  - "default": the normal return key
-
   - "go": the 'Go' return key
   - "google": the 'Google' return key
   - "join": the 'Join' return key
@@ -572,146 +489,128 @@ following:  - "default": the normal return key
   - "yahoo": the 'Yahoo' return key
   - "done": the 'Done' return key
   - "emergency call": the 'emergency call' return key
+
+
 - "contentType": returns what kind of content the control contains. This
-
 is one of the following:
-
   - "plain": plain, unstyled text
   - "password": plain text displayed in the standard iOS password style
+
+
 - "editable": returns whether the text field can be edited. This is one
-
 of the following:
-
   - "false": the text field cannot be edited
   - "true": the text field can be edited
+  
+  
 - "dataDetectorTypes" (iOS Only): returns a comma delimited list of the
-
 types of data that are automatically converted to clickable URLs. None
 or more of the following:
-
   - "phone number": 
-  - "calendar event": iOS4.0+
+  - "calendar event" (iOS4.0+)
   - "link": 
-  - "address": iOS4.0+
+  - "address" m(iOS4.0+)
+  
+  
 - "selectedRange": returns the start index and the length of the text
-
 selected in a text field.
 
 - "contentRect" (iOS Only): returns the rectangle over which the
-
 scroller scrolls. This is distinct from the scroller's rect. The
 minimum/maximum values of the scroll properties (adjusted for the size
 of the scroller). This is a comma-separated list of four integers,
 describing a rectangle. For example "0,0,100,100".
 
 - "hScroll" (iOS Only): returns the horizontal scroll offset. This is an
-
 integer value ranging between the left and right of the contentRect,
 adjusting appropriately for the size of the scroller (i.e.
 contentRect.left to contentRect.right - rect.width).
 
 - "vScroll" (iOS Only): returns the vertical scroll offset. This is an
-
 integer value ranging between the top and bottom of the contentRect,
 adjusting appropriately for the size of the scroller (i.e.
 contentRect.top to contentRect.bottom - rect.height).
 
 - "canBounce" (iOS Only): returns true if the scroller bounces when it
-
 hits the edge of the contentRect (maps to the UIScrollView bounces
 property).
 
 - "canScrollToTop" (iOS Only): returns true if a touch on the status bar
-
 causes the scroll to scroll to the top (maps to the UIScrollView
 scrollsToTop property).
 
 - "canCancelTouches" (iOS Only): returns true if the scroller is allowed
-
 to cancel a touch that has been passed through to the underlying
 controls when it thinks it's a scroll gesture (maps to the UIScrollView
 canCancelContentTouches property).
 
 - "delayTouches" (iOS Only): returns true if the scroller delays passing
-
 on touch-down events until it has determined whether it is the start of
 a scroll gesture or not (maps to the UIScrollView delaysContentTouches
 property).
 
 - "pagingEnabled" (iOS Only): returns true if scrolling stops on
-
 multiples of the scroller's bounds (maps to the UIScrollView
 pagingEnabled property).
 
 - "decelerationRate" (iOS Only): returns the rate at which scrolling
-
 decelerates when a finger is lifted (maps to the UIScrollView
 decelerationRate property). This can be either normal, fast or a real
 number.
 
 - "indicatorStyle" (iOS Only): returns the style of indicators to
-
 display (maps to the UIScrollView indicatorStyle property). One of the
-following:  - "default": 
-
-  - "white": 
-  - "black": 
+following:  
+  - "default"
+  - "white"
+  - "black"
+  
+  
 - "indicatorInsets" (iOS Only): returns how far from the edge of the
-
 scroller's bounds, the indicators are inset (maps to the UIScrollView
 scrollIndicatorInsets property). This is a comma-separated list of four
 integers, describing the left, top, right and bottom inset distances.
 For example "0,0,100,100".
 
 - "scrollingEnabled": returns true if touches on the scroller cause
-
 scrolling (maps to the UIScrollView scrollEnabled property).
 
 - "hIndicator" (iOS Only): returns true if the horizontal indicator
-
 should be displayed when scrolling (maps to the UIScrollView
 showsHorizontalScrollIndicator property).
 
 - "vIndicator" (iOS Only): returns true if the vertical indicator should
-
 be displayed when scrolling (maps to the UIScrollView
 showsVerticalScrollIndicator property).
 
 - "lockDirection" (iOS Only): returns true if scrolling is locked to the
-
 initial direction a drag occurs in (maps to the UIScrollView
 directionalLockEnabled property).
 
 - "tracking" (iOS Only): returns true if the scroller is monitoring a
-
 touch for the start of a scroll action (maps to the UIScrollView
 tracking property).
 
 - "dragging" (iOS Only): returns true if the scroller is currently
-
 performing a scroll action (maps to the UIScrollView dragging property).
 
 - "decelerating" (iOS Only): returns true if the scroll is currently
-
 decelerating after a scroll action (maps to the UIScrollView
 decelerating property).
 
 - "multiline" (Android only): Determines whether the control can contain
-
 multiple lines of text or not. This is a boolean value.
 
 - "scrollingEnabled": specifies whether or not the browser can be
-
 scrolled (boolean).
 
 - "enabled" (iOS Only): Determines whether the control is enabled or
-
 not. This is a boolean value.
 
 References: mobileControlCreate (command), mobileControlDelete (command),
 mobileControlDo (command), mobileControlSet (command),
 mobileControls (function), mobileControlTarget (function),
-property (glossary), boolean (glossary), integer (glossary),  (glossary),
+property (glossary), boolean (glossary), integer (glossary),
 value (glossary)
 
 Tags: properties


### PR DESCRIPTION
- Bullet list paragraphs had somehow gotten an extra LF char after the 
first line of text, so everything after the first line of the bullet point 
was formatted as a separate, non-bullet-list paragraph.
- Bullet points coming after a sub-bullet point will read as a sub-sub-point 
unless there a blank line break after the preceding paragraph.