### PR TITLE
[Bug 19345] Make sure CEF can find required resources on Linux

### DIFF
--- a/config.py
+++ b/config.py
@@ -270,7 +270,8 @@ def guess_java_home(platform):
             javac_str = '/bin/javac'
             javac_path = subprocess.check_output(['/usr/bin/env', 
                          'readlink', '-f', '/usr' + javac_str]).strip()
-            if javac_path.endswith(javac_str):
+            if (os.path.isfile(javac_path) and
+                javac_path.endswith(javac_str)):
                 return javac_path[:-len(javac_str)]
         except subprocess.CalledProcessError as e:
             print(e)

--- a/prebuilt/libcef.gyp
+++ b/prebuilt/libcef.gyp
@@ -149,7 +149,7 @@
                             },
                             
                             {
-                                'destination': '<(PRODUCT_DIR)/',
+                                'destination': '<(PRODUCT_DIR)/CEF/',
                                 'files':
                                 [
                                     'lib/linux/<(target_arch)/CEF/icudtl.dat',

--- a/revbrowser/revbrowser.gyp
+++ b/revbrowser/revbrowser.gyp
@@ -147,16 +147,6 @@
 							'-lX11',
 						],
 						
-					    'library_dirs':
-					    [
-					        '../prebuilt/lib/linux/<(target_arch)/CEF/',
-					    ],
-		
-					    'libraries':
-					    [
-					        '-lcef',
-					    ],
-		
 						'all_dependent_settings':
 						{
 							'variables':

--- a/util/weak_stub_maker.pl
+++ b/util/weak_stub_maker.pl
@@ -228,6 +228,10 @@ sub generateModule
 	my $darwinLibrary = $libraries[1];
 	my $windowsLibrary = $libraries[2];
 	
+	if (@libraries < 1)
+	{
+		$unixLibrary = "";
+	}
 	if (@libraries < 2)
 	{
 		$darwinLibrary = "";


### PR DESCRIPTION
- Don't strongly link `revbrowser` with `libcef`
- Copy CEF-related files into expected place for Linux & Windows builds
- Ensure that `config.py` doesn't misdetect JDK root path