### PR TITLE
[Bug 18912] Fixes to object deletion when target or handling a message in behaviors

### DIFF
--- a/docs/notes/bugfix-18912.md
+++ b/docs/notes/bugfix-18912.md
@@ -1,0 +1,1 @@
+# Ensure objects can't be deleted if their behaviors are handling a message or they are the target

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1223,6 +1223,7 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int p_handler_type, MCNameRef p_m
 	}
 
 	// Dispatch the message
+	MCObjectExecutionLock t_object_lock(t_object.object);
 	t_stat = MCU_dofrontscripts((Handler_type)p_handler_type, p_message, p_parameters);
 	Boolean olddynamic = MCdynamicpath;
 	MCdynamicpath = MCdynamiccard.IsValid();

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2068,6 +2068,8 @@ Exec_stat MCObject::dispatch(Handler_type p_type, MCNameRef p_message, MCParamet
 	MCtargetptr . object = this;
     MCtargetptr . part_id = 0;
 
+    MCObjectExecutionLock t_self_lock(this);
+
 	// Dispatch the message
 	Exec_stat t_stat;
 	t_stat = MCU_dofrontscripts(p_type, p_message, p_params);
@@ -2130,6 +2132,7 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
 	}
 	else
 	{
+		MCObjectExecutionLock t_self_lock(this);
 		MCS_alarm(CHECK_INTERVAL);
 		MCdebugcontext = MAXUINT2;
 		stat = MCU_dofrontscripts(HT_MESSAGE, mess, paramptr);
@@ -2897,6 +2900,7 @@ Exec_stat MCObject::domess(MCStringRef sptr)
     MCExecContext ctxt(this, handlist, hptr);
 	Boolean oldlock = MClockerrors;
 	MClockerrors = True;
+    MCObjectExecutionLock t_self_lock(this);
 	Exec_stat stat = hptr->exec(ctxt, NULL);
 	MClockerrors = oldlock;
 	delete handlist;
@@ -2935,6 +2939,7 @@ void MCObject::eval(MCExecContext &ctxt, MCStringRef p_script, MCValueRef &r_val
 	Boolean oldlock = MClockerrors;
 	MClockerrors = True;
 	
+    MCObjectExecutionLock t_self_lock(this);
 	if (hptr->exec(ctxt, NULL) != ES_NORMAL)
 	{
 		r_value = MCSTR("Error parsing expression\n");

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -978,7 +978,6 @@ Exec_stat MCObject::execparenthandler(MCHandler *hptr, MCParameter *params, MCPa
 	if (MCmessagemessages)
 		sendmessage(hptr -> gettype(), hptr -> getname(), True);
 
-	lockforexecution();
 	MCObject *t_parentscript_object = parentscript->GetParent()->GetObject();
 	t_parentscript_object->lockforexecution();
 
@@ -1005,7 +1004,6 @@ Exec_stat MCObject::execparenthandler(MCHandler *hptr, MCParameter *params, MCPa
         parentscript -> GetParent() -> GetObject() -> getstringprop(ctxt, 0, P_LONG_ID, False, &t_id);
         MCeerror->add(EE_OBJECT_NAME, 0, 0, *t_id);
 	}
-	unlockforexecution();
 	t_parentscript_object->unlockforexecution();
 
 	return stat;
@@ -1077,6 +1075,8 @@ Exec_stat MCObject::handleself(Handler_type p_handler_type, MCNameRef p_message,
 {	
 	Exec_stat t_stat;
 	t_stat = ES_NOT_HANDLED;
+
+	MCObjectExecutionLock self_lock(this);
 
 	// Make sure this object has its script compiled.
 	parsescript(True);

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -1677,4 +1677,28 @@ inline MCObject* MCObjectCast<MCObject>(MCObject* p_object)
     return p_object;
 }
 
+/* Helper class for locking an object for execution during a block.
+ * Always allocate this on the stack, e.g.:
+ *
+ *    {
+ *        MCObjectExecutionLock obj_lock {obj};
+ *        // ... do stuff
+ *    }
+ */
+class MCObjectExecutionLock
+{
+    MCObjectHandle m_handle;
+public:
+    MCObjectExecutionLock(MCObject* obj) : m_handle(obj)
+    {
+        if (m_handle.IsValid())
+            m_handle->lockforexecution();
+    }
+    ~MCObjectExecutionLock()
+    {
+        if (m_handle.IsValid())
+            m_handle->unlockforexecution();
+    }
+};
+
 #endif

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -329,6 +329,7 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 	Exec_stat t_stat = ES_NOT_HANDLED;
 	if (!MClockmessages && (ctxt . GetObject() != this || !ctxt . GetHandler() -> hasname(t_getprop_name)))
 	{
+		MCObjectExecutionLock t_self_lock(this);
 		MCParameter p1;
 		p1.setvalueref_argument(t_param_name);
         
@@ -416,6 +417,7 @@ Exec_stat MCObject::sendsetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 	Exec_stat t_stat = ES_NOT_HANDLED;
 	if (!MClockmessages && (ctxt . GetObject() != this || !ctxt . GetHandler()->hasname(t_setprop_name)))
 	{
+		MCObjectExecutionLock t_self_lock(this);
 		MCParameter p1, p2;
 		p1.setnext(&p2);
         

--- a/tests/lcs/core/engine/target.livecodescript
+++ b/tests/lcs/core/engine/target.livecodescript
@@ -16,15 +16,37 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-on TestDeleteTargetInFrontScript
-   create button "frontscript"
-   set the script of button "frontscript" to "on doSomething; delete the target; pass doSomething; end doSomething"
-   
-   insert the script of button "frontscript" into front
+on TestSetup
+   create button "script"
+   set the script of button "script" to "on doSomething; delete the target; end doSomething"
    
    create button "test"
-   set the script of button "test" to "on doSomething; end doSomething"
-   send "doSomething" to button "test"
    
-   TestAssert "Object is deleted", there is no button "test"
+end TestSetup
+
+on TestDeleteTargetInFrontScript
+   insert the script of button "script" into front
+   TestAssertThrow "Delete target in frontscript", "__TestDeleteTarget", the long id me, 347
+   remove the script of button "script" from front
 end TestDeleteTargetInFrontScript
+
+on TestDeleteTargetInBackScript
+   insert the script of button "script" into back
+   TestAssertThrow "Delete target in backscript", "__TestDeleteTarget", the long id me, 347
+   remove the script of button "script" from back
+end TestDeleteTargetInBackScript
+
+on TestDeleteTargetInBehavior
+   set the behavior of button "test" to the long id of button "script"
+   TestAssertThrow "Delete target in behavior", "__TestDeleteTarget", the long id me, 347
+   set the behavior of button "test" to empty
+end TestDeleteTargetInBehavior
+
+on TestDeleteTargetInOwner
+   set the script of the owner of btn "test" to "on doSomething; delete the target; end doSomething"
+   TestAssertThrow "Delete target in owner", "__TestDeleteTarget", the long id me, 347
+end TestDeleteTargetInOwner
+
+on __TestDeleteTarget
+   send "doSomething" to button "test"
+end __TestDeleteTarget

--- a/tests/lcs/core/execution/object-deletion.livecodescript
+++ b/tests/lcs/core/execution/object-deletion.livecodescript
@@ -67,6 +67,19 @@ on TestDeleteSubstackWithCantDelete
    TestAssert "Delete stack with cantDelete substack", true
 end TestDeleteSubstackWithCantDelete
 
+on TestDeleteObjectInBehaviorOfNonTarget
+   create button "behavior"
+   set the script of button "behavior" to \
+         "on DeleteIt" & return & \
+         "delete stack "& quote & "lib" & quote  & return & \
+         "end DeleteIt"
+   create stack "lib"
+   set the behavior of stack "lib" to the long id of button "behavior"
+   start using stack "lib"
+   TestAssertThrow "Delete object from its behavior when not target", "DeleteIt", the long id of stack "test", 347
+end TestDeleteObjectInBehaviorOfNonTarget
+
+
 on __TestDeleteStack
       delete stack "test"
 end __TestDeleteStack


### PR DESCRIPTION
This is a slightly-modified version of #5187 which adds a new RAII `MCObjectExecutionLock` helper class.  This allows the changes required to be made much less intrusively, and ensures that `MCObject::lockforexecution()` calls are always paired with calls to `MCObject::unlockforexecution()`.