### PR TITLE
libfoundation: Define byte_t to be unsigned char

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -601,12 +601,18 @@ typedef float32_t coord_t;
 // The 'char_t' type is used to hold a native encoded char.
 typedef unsigned char char_t;
 
-// The 'byte_t' type is used to hold a char in a binary string (native).
-typedef uint8_t byte_t;
+// The 'byte_t' type is used to hold a char in a binary string
+// (native).  This cannot be anything other than to be "unsigned char"
+// because we require the "sizeof" C++ operator to return sizes in
+// units of byte_t, and because we require it to be valid to cast to a
+// "byte_t*" in order to examine the object representation of a value.
+typedef unsigned char byte_t;
 
 // Constants used to represent the minimum and maximum values of a byte_t.
-#define BYTE_MIN UINT8_MIN
-#define BYTE_MAX UINT8_MAX
+// We require bytes to be 8 bits in size.
+static_assert(CHAR_BIT == 8, "Byte size is not 8 bits");
+#define BYTE_MIN (0)
+#define BYTE_MAX (255)
 
 // The 'codepoint_t' type is used to hold a single Unicode codepoint (20-bit
 // value).


### PR DESCRIPTION
We rely on 3 properties of the `byte_t` type:

1. The `sizeof` C++ operator must return object sizes in units of
   `byte_t`

2. Casting a pointer to a `byte_t*` allows examination of the object
   representation of the pointer's target object

3. A `byte_t` has 8 bits

Unless `byte_t` is either `char`, `signed char` or `unsigned char`,
properties 1 and 2 would not hold.  There is no requirement in C++
that `uint8_t` and `unsigned char` must be treated as the same type by
a C++ compiler.

This patch changes `byte_t` to directly alias `unsigned char`, and
adds a static assertion that there are 8 bits in a `char` on the
target platform.