### PR TITLE
[[ LC Compile FFI Java ]] Include executable in installed application

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -421,18 +421,21 @@ component Toolchain.MacOSX
 	into [[ToolsFolder]]/Toolchain place
 		executable macosx:lc-compile as lc-compile
 		executable macosx:lc-run as lc-run
+		executable macosx:lc-compile-ffi-java as lc-compile-ffi-java
 		rfolder macosx:modules
 
 component Toolchain.Windows
 	into [[ToolsFolder]]/Toolchain place
 		executable windows:lc-compile.exe as lc-compile.exe
 		executable windows:lc-run.exe as lc-run.exe
+		executable macosx:lc-compile-ffi-java.exe as lc-compile-ffi-java.exe
 		rfolder windows:modules
 
 component Toolchain.Linux
 	into [[ToolsFolder]]/Toolchain place
 		executable linux-[[TargetArchitecture]]:lc-compile as lc-compile
 		executable linux-[[TargetArchitecture]]:lc-run as lc-run
+		executable linux-[[TargetArchitecture]]:lc-compile-ffi-java as lc-compile-ffi-java
 		rfolder linux-[[TargetArchitecture]]:modules
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Ensure the lc-compile-ffi-java tool ends up in the Toolchain folder of the installed LC.