### PR TITLE
build: Enable building with macosx10.12 SDK

### DIFF
--- a/engine/src/mac-pasteboard.mm
+++ b/engine/src/mac-pasteboard.mm
@@ -24,8 +24,6 @@
 
 #include "mac-internal.h"
 
-#include <QuickTime/QuickTime.h>
-
 ////////////////////////////////////////////////////////////////////////////////
 
 extern bool MCImageBitmapToCGImage(MCImageBitmap *p_bitmap, bool p_copy, bool p_invert, CGImageRef &r_image);

--- a/engine/src/mac-qt-player.mm
+++ b/engine/src/mac-qt-player.mm
@@ -15,7 +15,9 @@
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <Cocoa/Cocoa.h>
-#include <QTKit/QTKit.h>
+#if defined(FEATURE_QUICKTIME)
+#   include <QTKit/QTKit.h>
+#endif
 
 #include "globdefs.h"
 #include "imagebitmap.h"

--- a/engine/src/mac-qt-player.mm
+++ b/engine/src/mac-qt-player.mm
@@ -14,14 +14,14 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+#include "globdefs.h"
+#include "imagebitmap.h"
+#include "region.h"
+
 #include <Cocoa/Cocoa.h>
 #if defined(FEATURE_QUICKTIME)
 #   include <QTKit/QTKit.h>
 #endif
-
-#include "globdefs.h"
-#include "imagebitmap.h"
-#include "region.h"
 
 #include "platform.h"
 #include "platform-internal.h"

--- a/engine/src/mac-qt-recorder.mm
+++ b/engine/src/mac-qt-recorder.mm
@@ -35,8 +35,10 @@
 #include "variable.h"
 
 #include <Cocoa/Cocoa.h>
-#include <QTKit/QTKit.h>
-#include <QuickTime/QuickTime.h>
+#if defined(FEATURE_QUICKTIME)
+#   include <QTKit/QTKit.h>
+#   include <QuickTime/QuickTime.h>
+#endif
 #include <CoreAudioKit/CoreAudioKit.h>
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>


### PR DESCRIPTION
The macosx10.12 SDK doesn't include any QuickTime headers, so its
necessary to conditionally include them only if `FEATURE_QUICKTIME`
is defined.