### PR TITLE
[Bug 19229] Fix crash when connecting an IR Receiver

### DIFF
--- a/docs/notes/bugfix-19229.md
+++ b/docs/notes/bugfix-19229.md
@@ -1,0 +1,1 @@
+# Fix crash when connecting an IR Receiver

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -1746,8 +1746,8 @@ void MCFilesExecPerformReadTextUntil(MCExecContext& ctxt, IO_handle p_stream, in
                     doingspace = True;
                 }
         }
-        else
-        {            
+        else if (!MCStringIsEmpty(*t_norm_sent))
+        {
             // Normalise the character read and append it to the normalised buffer
             unichar_t *t_norm_chunk;
             uint4 t_norm_chunk_size;


### PR DESCRIPTION
Previously, in function `MCFilesExecPerformReadTextUntil`, if `*t_norm_sent` was empty, then the call to:
`uint4 i = MCStringGetLength(*t_norm_sent) - 1;` caused `i` to underflow, resulting in unexpected behavior later.
 
This patch checks if `*t_norm_sent` is empty before performing any operation on it. A similar check is done in `MCFilesExecPerformReadBinaryUntil`