### PR TITLE
[Bug 19390] Reposition native layer controls when resizing stacks

### DIFF
--- a/docs/notes/bugfix-19390.md
+++ b/docs/notes/bugfix-19390.md
@@ -1,0 +1,1 @@
+# Reposition native layer controls correctly when resizing stacks

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -269,6 +269,22 @@ MCNativeLayer* MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_view
 
 - (void)setFrameOrigin:(NSPoint)newOrigin
 {
+    /* By default, NSViews don't adjust the positions or sizes of their
+     * contents when their geometry changes.  There is an autoresizing
+     * behaviour that we could turn on, but we don't because it doesn't have
+     * the properties that we require for a LiveCode group.  It's therefore
+     * necessary to manually nudge subviews around when the position of a
+     * container view is adjusted. */
+    NSPoint t_origin = [self frame].origin;
+    NSPoint t_delta = {newOrigin.x - t_origin.x, newOrigin.y - t_origin.y};
+
+    for (NSView *t_subview in [self subviews])
+    {
+        NSPoint t_suborigin = [t_subview frame].origin;
+        [t_subview setFrameOrigin: {t_suborigin.x + t_delta.x,
+                                    t_suborigin.y + t_delta.y}];
+    }
+
 	[super setFrameOrigin:newOrigin];
 	[self setBoundsOrigin:newOrigin];
 }


### PR DESCRIPTION
The LiveCode coordinate space has its origin at the top left of
the stack, but the Cocoa coordinate space's origin is at the
bottom left of the window.  This means that native layer controls
end up in the wrong position if they are not explicitly
repositioned during stack resizing.

In commit 8fe69c5c43f6, the stack root container view was modified
so as to reposition its contents.  Subsequently, in commit
8f1e4c1bd1cf groups were taught to keep the same coordinate system
as the outer window.  Unfortunately, groups were not configured to
propagate position changes to their subviews.  This caused a bug
where browsers and players would be positioned in the wrong place
during stack resize, but only if they were part of a group.

This patch teaches groups' container views to propagate position
changes to subviews.