### PR TITLE
Resolve most C++11 "TODO" comments

### DIFF
--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -19,6 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "statemnt.h"
 #include "objdefs.h"
+#include "express.h"
 #include "regex.h"
 #include "util.h"
 #include "uidc.h"

--- a/engine/src/native-layer-win32.cpp
+++ b/engine/src/native-layer-win32.cpp
@@ -198,7 +198,7 @@ bool MCNativeLayerWin32::doPaint(MCGContextRef p_context)
 	if (t_success)
 	{
 		// At last - we can draw it!
-		MCGRectangle rect = {{0, 0}, {t_rect.width, t_rect.height}};
+		MCGRectangle rect = {{0, 0}, {MCGFloat(t_rect.width), MCGFloat(t_rect.height)}};
 		MCGContextDrawImage(p_context, t_gimage, rect, kMCGImageFilterNone);
 	}
 

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -29,7 +29,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "native-layer.h"
 
-#include <algorithm>
+#include <utility>
 
 // Disabled until C++11 support is available on all platforms
 #if 0
@@ -269,38 +269,29 @@ class MCObjectProxy<T>::Handle
 {
 public:
     
-    Handle() :
-      m_proxy(nullptr)
-    {
-    }
+	constexpr Handle() = default;
     
-    Handle(MCObjectProxy* p_proxy) :
-      m_proxy(nullptr)
+    Handle(MCObjectProxy* p_proxy)
     {
         Set(p_proxy);
     }
     
-    explicit Handle(const T* p_object) :
-      m_proxy(nullptr)
+    explicit Handle(const T* p_object)
     {
         Set(p_object);
     }
     
-    Handle(const Handle& p_handle) :
-      m_proxy(nullptr)
+    Handle(const Handle& p_handle)
     {
         Set(p_handle.m_proxy);
     }
     
-    Handle(Handle&& p_handle) : m_proxy(nullptr)
+    Handle(Handle&& p_handle)
     {
         std::swap(m_proxy, p_handle.m_proxy);
     }
 
-    Handle(decltype(nullptr)) :
-      m_proxy(nullptr)
-    {
-    }
+    constexpr Handle(decltype(nullptr)) {}
     
     Handle& operator= (MCObjectProxy* p_proxy)
     {
@@ -452,7 +443,7 @@ public:
 private:
     
     // The proxy for the object this is a handle to
-    MCObjectProxy*  m_proxy;
+    MCObjectProxy*  m_proxy = nullptr;
     
     void Set(MCObjectProxy* p_proxy)
     {

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -29,6 +29,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "native-layer.h"
 
+#include <algorithm>
+
 // Disabled until C++11 support is available on all platforms
 #if 0
 #include <type_traits>
@@ -292,9 +294,7 @@ public:
     
     Handle(Handle&& p_handle) : m_proxy(nullptr)
     {
-        /* TODO[C++11] std::swap */
-        m_proxy = p_handle.m_proxy;
-        p_handle.m_proxy = nullptr;
+        std::swap(m_proxy, p_handle.m_proxy);
     }
 
     Handle(decltype(nullptr)) :
@@ -323,9 +323,7 @@ public:
     Handle& operator=(Handle&& p_handle)
     {
         Set(nullptr);
-        /* TODO[C++11] std::swap */
-        m_proxy = p_handle.m_proxy;
-        p_handle.m_proxy = nullptr;
+        std::swap(m_proxy, p_handle.m_proxy);
         return *this;
     }
 

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -113,29 +113,13 @@ public:
     
     MCObjectHandle      m_object;
     MCNewAutoNameRef    m_message;
-    real64_t            m_time;
-    MCParameter*        m_params;
-    uint32_t            m_id;
-    
-    // [[ C++11 ]] Replace with `MCPendingMessage() = default;`
-    MCPendingMessage() :
-      m_object(),
-      m_message(),
-      m_time(0),
-      m_params(nil),
-      m_id(0)
-    {
-    }
+    real64_t            m_time = 0;
+    MCParameter*        m_params = nullptr;
+    uint32_t            m_id = 0;
 
-    // [[ C++11 ]] Replace with `MCPendingMessage(const MCPendingMessage&) = default;`
-    MCPendingMessage(const MCPendingMessage& other) :
-      m_object(other.m_object),
-      m_message(other.m_message),
-      m_time(other.m_time),
-      m_params(other.m_params),
-      m_id(other.m_id)
-    {
-    }
+    constexpr MCPendingMessage() = default;
+
+    MCPendingMessage(const MCPendingMessage& other) = default;
 
     // [[ C++11 ]] Replace with `MCPendingMessage(MCObject*, MCNameRef, real64_t, MCParameter*, uint32_t) = default;`
     MCPendingMessage(MCObject* p_object, MCNameRef p_message, real64_t p_time, MCParameter* p_params, uint32_t p_id) :

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -50,10 +50,7 @@ template<typename T> class MCAutoValueRefBase
 {
 public:
 
-	inline MCAutoValueRefBase(void)
-		: m_value(nil)
-	{
-	}
+    constexpr MCAutoValueRefBase(void) = default;
     
     inline MCAutoValueRefBase(const MCAutoValueRefBase& other) :
       m_value(nil)
@@ -139,7 +136,7 @@ public:
     friend T& InOut<>(MCAutoValueRefBase<T>&);
     
 protected:
-	T m_value;
+	T m_value = nullptr;
     
     // Return the contents of the auto pointer in a form for an in parameter.
     T In(void) const
@@ -169,7 +166,7 @@ class MCAutoMutableValueRefBase :
   public MCAutoValueRefBase<T>
 {
 public:
-    inline MCAutoMutableValueRefBase() :
+    constexpr MCAutoMutableValueRefBase() :
       MCAutoValueRefBase<T>()
     {
     }
@@ -217,11 +214,7 @@ typedef MCAutoMutableValueRefBase<MCProperListRef, MCProperListMutableCopyAndRel
 template<typename T> class MCAutoValueRefArrayBase
 {
 public:
-	MCAutoValueRefArrayBase(void)
-	{
-		m_values = nil;
-        m_value_count = 0;
-	}
+	constexpr MCAutoValueRefArrayBase() = default;
     
 	~MCAutoValueRefArrayBase(void)
 	{
@@ -374,8 +367,8 @@ public:
 	}
     
 private:
-	T* m_values;
-    uindex_t m_value_count;
+	T* m_values = nullptr;
+    uindex_t m_value_count = 0;
 };
 
 typedef MCAutoValueRefArrayBase<MCValueRef> MCAutoValueRefArray;
@@ -393,8 +386,8 @@ typedef MCAutoValueRefArrayBase<MCNameRef> MCAutoNameRefArray;
 class MCAutoStringRefAsUTF16String
 {
 public:
-	MCAutoStringRefAsUTF16String() {}
-	~MCAutoStringRefAsUTF16String() {}
+    constexpr MCAutoStringRefAsUTF16String() = default;
+
 	bool Lock(MCStringRef p_string)
 	{
 		return MCStringUnicodeCopy(p_string, &m_string);
@@ -434,11 +427,7 @@ typedef MCAutoStringRefAsUTF16String MCAutoStringRefAsLPCWSTR;
 class MCAutoStringRefAsLPWSTR
 {
 public:
-	MCAutoStringRefAsLPWSTR() :
-	  m_buffer(nil),
-	  m_size(0)
-	{
-	}
+	constexpr MCAutoStringRefAsLPWSTR() = default;
 
 	~MCAutoStringRefAsLPWSTR()
 	{
@@ -470,8 +459,8 @@ public:
 		return Ptr();
 	}
 private:
-	unichar_t *m_buffer;
-	uindex_t m_size;
+	unichar_t *m_buffer = nullptr;
+	uindex_t m_size = 0;
 };
 #endif /* __WINDOWS__ */
 
@@ -480,11 +469,7 @@ private:
 class MCAutoStringRefAsUTF8String
 {
 public:
-    MCAutoStringRefAsUTF8String(void)
-    {
-        m_utf8string = nil;
-		m_size = 0;
-    }
+	constexpr MCAutoStringRefAsUTF8String() = default;
     
     ~MCAutoStringRefAsUTF8String(void)
     {
@@ -513,8 +498,8 @@ public:
     }
     
 private:
-    char *m_utf8string;
-    uindex_t m_size;
+	char *m_utf8string = nullptr;
+    uindex_t m_size = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -524,9 +509,7 @@ private:
 class MCAutoStringRefAsCFString
 {
 public:
-    MCAutoStringRefAsCFString(void) :
-        m_cfstring(nil)
-    {}
+    constexpr MCAutoStringRefAsCFString(void) = default;
     
     ~MCAutoStringRefAsCFString(void)
     {
@@ -551,7 +534,7 @@ public:
     }
     
 private:
-    CFStringRef m_cfstring;
+    CFStringRef m_cfstring = nullptr;
 };
 
 #endif
@@ -561,10 +544,7 @@ private:
 class MCAutoStringRefAsPascalString
 {
 public:
-    MCAutoStringRefAsPascalString(void)
-    {
-        m_pascal_string = nil;
-    }
+    constexpr MCAutoStringRefAsPascalString() = default;
     
     ~MCAutoStringRefAsPascalString(void)
     {
@@ -603,7 +583,7 @@ public:
     }
     
 private:
-    unsigned char *m_pascal_string;
+    unsigned char *m_pascal_string = nullptr;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -611,11 +591,7 @@ private:
 class MCAutoStringRefAsSysString
 {
 public:
-    MCAutoStringRefAsSysString()
-    {
-        m_bytes = nil;
-        m_byte_count = 0;
-    }
+    constexpr MCAutoStringRefAsSysString() = default;
 
     ~MCAutoStringRefAsSysString()
     {
@@ -655,8 +631,8 @@ public:
     }
 
 private:
-    char *m_bytes;
-    size_t m_byte_count;
+    char *m_bytes = nullptr;
+    size_t m_byte_count = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -667,9 +643,7 @@ private:
 class MCAutoStringRefAsBSTR
 {
 public:
-    MCAutoStringRefAsBSTR(void)
-    {
-    }
+    constexpr MCAutoStringRefAsBSTR() = default;
     
     ~MCAutoStringRefAsBSTR(void)
     {
@@ -693,7 +667,7 @@ public:
     }
     
 private:
-    BSTR m_bstr;
+    BSTR m_bstr = nullptr;
 };
 #endif // __WINDOWS__
 #endif
@@ -703,8 +677,8 @@ private:
 class MCAutoStringRefAsNativeChars
 {
 public:
-	MCAutoStringRefAsNativeChars() {}
-	~MCAutoStringRefAsNativeChars() {}
+	constexpr MCAutoStringRefAsNativeChars() = default;
+
 	bool Lock(MCStringRef p_string)
 	{
 		return MCStringNativeCopy(p_string, &m_string);
@@ -775,12 +749,12 @@ template<typename T> class MCAutoPointer
 public:
     typedef T* pointer;
 
-    MCAutoPointer() : m_ptr(nullptr) {}
+    constexpr MCAutoPointer() = default;
 
-    MCAutoPointer(decltype(nullptr)) : m_ptr(nullptr) {}
+    constexpr MCAutoPointer(decltype(nullptr)) {}
 
     /* Construct the managed pointer using a specific value. */
-    MCAutoPointer(pointer p) : m_ptr(p) {}
+    constexpr MCAutoPointer(pointer p) : m_ptr(p) {}
 
     /* Construct managed pointer by moving a pointer from another
      * managed pointer of the same type. */
@@ -842,7 +816,7 @@ public:
 	}
 
 private:
-	T *m_ptr;
+	T *m_ptr = nullptr;
 };
 
 /* This version of MCAutoPointer should be used when you need to
@@ -856,12 +830,12 @@ template<typename T> class MCAutoPointer<T[]>
 public:
     typedef T* pointer;
 
-    MCAutoPointer() : m_ptr(nullptr) {}
+    constexpr MCAutoPointer() = default;
 
-    MCAutoPointer(decltype(nullptr)) : m_ptr(nullptr) {}
+    constexpr MCAutoPointer(decltype(nullptr)) {}
 
     /* Construct the managed pointer using a specific value. */
-    MCAutoPointer(pointer p) : m_ptr(p) {}
+    constexpr MCAutoPointer(pointer p) : m_ptr(p) {}
 
     /* Construct managed pointer by moving a pointer from another
      * managed pointer of the same type. */
@@ -928,7 +902,7 @@ public:
     }
 	
 private:
-	T *m_ptr;
+	T *m_ptr = nullptr;
 };
 
 template <typename T, void (Deleter)(T*)>
@@ -938,15 +912,9 @@ public:
  
     typedef T* pointer;
     
-	MCAutoCustomPointer() :
-      m_ptr(nil)
-	{
-	}
+    constexpr MCAutoCustomPointer() = default;
     
-    MCAutoCustomPointer(T*&& take) :
-      m_ptr(take)
-    {
-    }
+    constexpr MCAutoCustomPointer(T*&& take) : m_ptr(take) {}
     
 	~MCAutoCustomPointer()
 	{
@@ -997,7 +965,7 @@ public:
 	
 private:
     
-	T* m_ptr;
+	T* m_ptr = nullptr;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1046,11 +1014,7 @@ private:
 template<typename T> class MCAutoArray
 {
 public:
-	MCAutoArray(void)
-	{
-		m_ptr = nil;
-		m_size = 0;
-	}
+    constexpr MCAutoArray() = default;
 
 	~MCAutoArray(void)
 	{
@@ -1151,19 +1115,15 @@ public:
     }
 
 private:
-	T *m_ptr;
-	uindex_t m_size;
+	T *m_ptr = nullptr;
+	uindex_t m_size = 0;
 };
 
 // Version of MCAutoArray that applies the provided deallocator to each element of the array when freed
 template <typename T, void (*FREE)(T)> class MCAutoCustomPointerArray
 {
 public:
-	MCAutoCustomPointerArray(void)
-	{
-		m_ptr = nil;
-		m_size = 0;
-	}
+    constexpr MCAutoCustomPointerArray() = default;
 	
 	~MCAutoCustomPointerArray(void)
 	{
@@ -1271,8 +1231,8 @@ public:
 	}
 	
 private:
-	T *m_ptr;
-	uindex_t m_size;
+    T *m_ptr = nullptr;
+    uindex_t m_size = 0;
 	
 	void FreeElements(const MCRange &p_elements)
 	{
@@ -1295,11 +1255,7 @@ private:
 class MCAutoNativeCharArray
 {
 public:
-	MCAutoNativeCharArray(void)
-	{
-		m_chars = nil;
-		m_char_count = 0;
-	}
+    constexpr MCAutoNativeCharArray() = default;
 
 	~MCAutoNativeCharArray(void)
 	{
@@ -1382,18 +1338,14 @@ public:
 	}
 
 private:
-	char_t *m_chars;
-	uindex_t m_char_count;
+	char_t *m_chars = nullptr;
+	uindex_t m_char_count = 0;
 };
 
 class MCAutoByteArray
 {
 public:
-	MCAutoByteArray(void)
-	{
-		m_bytes = nil;
-		m_byte_count = 0;
-	}
+    constexpr MCAutoByteArray() = default;
 	
 	~MCAutoByteArray(void)
 	{
@@ -1474,8 +1426,8 @@ public:
 	}
 	
 private:
-	char_t *m_bytes;
-	uindex_t m_byte_count;
+	char_t *m_bytes = nullptr;
+	uindex_t m_byte_count = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -65,10 +65,8 @@ public:
 	typedef ElementType&& ElementRRef;
 
 	/* ---------- Constructors */
-	constexpr MCSpan()
-		: m_data(nullptr), m_length(0) {}
-	constexpr MCSpan(decltype(nullptr))
-		: m_data(nullptr), m_length(0) {}
+	constexpr MCSpan() = default;
+	constexpr MCSpan(decltype(nullptr)) {}
 	constexpr MCSpan(ElementPtr p_ptr, IndexType p_count)
 		: m_data(p_ptr), m_length(p_count) {}
 
@@ -76,32 +74,16 @@ public:
 	constexpr MCSpan(ElementType (&arr)[N])
 		: m_data(&arr[0]), m_length(N) {}
 
-	/* TODO[C++11] MCSpan(MCSpan &other) = default; */
-	constexpr MCSpan(MCSpan& other)
-		: m_data(other.m_data), m_length(other.m_length) {}
+	constexpr MCSpan(MCSpan& other) = default;
 
-	/* TODO[C++11] MCSpan(MCSpan &&other) = default; */
-	constexpr MCSpan(MCSpan&& other)
-		: m_data(static_cast<ElementPtr &&>(other.m_data)),
-		  m_length(static_cast<IndexType &&>(other.m_length)) {}
+	constexpr MCSpan(MCSpan&& other) = default;
 
-	/* TODO[C++11] ~MCSpan() = default; */
-	~MCSpan() {}
+	~MCSpan() = default;
 
 	/* ---------- Assignment ops */
-	/* TODO[C++11] MCSpan& operator=(const MCSpan& other) = default; */
-	MCSpan& operator=(const MCSpan& other) {
-		m_data = other.m_data;
-		m_length = other.m_length;
-		return *this;
-	}
+	MCSpan& operator=(const MCSpan& other) = default;
 
-	/* TODO[C++11] MCSpan& operator=(MCSpan&& other) = default; */
-	MCSpan& operator=(MCSpan&& other) {
-		m_data = static_cast<ElementPtr &&>(other.m_data);
-		m_length = static_cast<IndexType &&>(other.m_length);
-		return *this;
-	}
+	MCSpan& operator=(MCSpan&& other) = default;
 
 	/* ---------- Subspans */
 	constexpr MCSpan first(IndexType p_count) const
@@ -186,8 +168,8 @@ protected:
 		return *this;
 	}
 
-	ElementPtr m_data;
-	IndexType m_length;
+	ElementPtr m_data = nullptr;
+	IndexType m_length = 0;
 };
 
 template <typename ElementType>

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -211,8 +211,7 @@ MCMakeSpan(ElementType *p_ptr,
 	return MCSpan<ElementType>(p_ptr, p_count);
 }
 
-/* TODO[C++11] The default value for ElementType should be byte_t */
-template <typename ElementType>
+template <typename ElementType = byte_t>
 MCSpan<ElementType> MCDataGetSpan(MCDataRef p_data)
 {
 	MCAssert(MCDataGetLength(p_data) % sizeof(ElementType) == 0);

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -74,7 +74,7 @@ public:
 	constexpr MCSpan(ElementType (&arr)[N])
 		: m_data(&arr[0]), m_length(N) {}
 
-	constexpr MCSpan(MCSpan& other) = default;
+	constexpr MCSpan(const MCSpan& other) = default;
 
 	constexpr MCSpan(MCSpan&& other) = default;
 

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -44,11 +44,6 @@
  * order to make sure that there is as much commonality as possible
  * between the behaviour of an MCSpan and an array pointer. */
 
-/* TODO[C++11] Many of the constructors & methods in MCSpan are
- * declared constexpr.  However, some of our compilers don't support
- * constexpr, and for those compilers constexpr is defined to
- * empty. */
-
 /* TODO[C++14] Some of the constexpr methods in MCSpan use assertions,
  * and have to do ugly chaining using the comma operator in a return
  * statement in order to comply with the C++11 restrictions on

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -779,8 +779,6 @@ inline T MCClamp(T value, U min, V max) {
 //  BYTE ORDER FUNCTIONS
 //
 
-// TODO[C++11] All of the functions in this section should be constexpr
-
 enum MCByteOrder
 {
 	kMCByteOrderUnknown,
@@ -794,81 +792,81 @@ const MCByteOrder kMCByteOrderHost = kMCByteOrderLittleEndian;
 const MCByteOrder kMCByteOrderHost = kMCByteOrderBigEndian;
 #endif
 
-inline MCByteOrder MCByteOrderGetCurrent(void)
+constexpr MCByteOrder MCByteOrderGetCurrent(void)
 {
 	return kMCByteOrderHost;
 }
 
-inline uint8_t MCSwapInt(uint8_t x) { return x; }
-inline int8_t MCSwapInt(int8_t x) { return x; }
+constexpr uint8_t MCSwapInt(uint8_t x) { return x; }
+constexpr int8_t MCSwapInt(int8_t x) { return x; }
 
-inline uint16_t MCSwapInt(uint16_t x)
+constexpr uint16_t MCSwapInt(uint16_t x)
 {
 	return (uint16_t)(x >> 8) | (uint16_t)(x << 8);
 }
-inline int16_t MCSwapInt(int16_t x) { return int16_t(MCSwapInt(uint16_t(x))); }
+constexpr int16_t MCSwapInt(int16_t x) { return int16_t(MCSwapInt(uint16_t(x))); }
 
-inline uint32_t MCSwapInt(uint32_t x)
+constexpr uint32_t MCSwapInt(uint32_t x)
 {
 	return (x >> 24) | ((x >> 8) & 0xff00) | ((x & 0xff00) << 8) | (x << 24);
 }
-inline int32_t MCSwapInt(int32_t x) { return int32_t(MCSwapInt(uint32_t(x))); }
+constexpr int32_t MCSwapInt(int32_t x) { return int32_t(MCSwapInt(uint32_t(x))); }
 
-inline uint64_t MCSwapInt(uint64_t x)
+constexpr uint64_t MCSwapInt(uint64_t x)
 {
 	return (x >> 56) | ((x >> 40) & 0xff00) | ((x >> 24) & 0xff0000) | ((x >> 8) & 0xff000000) |
 			((x & 0xff000000) << 8) | ((x & 0xff0000) << 24) | ((x & 0xff00) << 40) | (x << 56);
 }
-inline int64_t MCSwapInt(int64_t x) { return int16_t(MCSwapInt(uint64_t(x))); }
+constexpr int64_t MCSwapInt(int64_t x) { return int16_t(MCSwapInt(uint64_t(x))); }
 
-inline uint16_t MCSwapInt16(uint16_t x) { return MCSwapInt(x); }
-inline uint32_t MCSwapInt32(uint32_t x) { return MCSwapInt(x); }
-inline uint64_t MCSwapInt64(uint64_t x) { return MCSwapInt(x); }
+constexpr uint16_t MCSwapInt16(uint16_t x) { return MCSwapInt(x); }
+constexpr uint32_t MCSwapInt32(uint32_t x) { return MCSwapInt(x); }
+constexpr uint64_t MCSwapInt64(uint64_t x) { return MCSwapInt(x); }
 
 template <typename T>
-inline T MCSwapIntBigToHost(T x)
+constexpr T MCSwapIntBigToHost(T x)
 {
 	return (kMCByteOrderHost == kMCByteOrderBigEndian) ? x : MCSwapInt(x);
 }
 template <typename T>
-inline T MCSwapIntHostToBig(T x) { return MCSwapIntBigToHost(x); }
+constexpr T MCSwapIntHostToBig(T x) { return MCSwapIntBigToHost(x); }
 
 template <typename T>
-inline T MCSwapIntNetworkToHost(T x) { return MCSwapIntBigToHost(x); }
+constexpr T MCSwapIntNetworkToHost(T x) { return MCSwapIntBigToHost(x); }
 template <typename T>
-inline T MCSwapIntHostToNetwork(T x) { return MCSwapIntHostToBig(x); }
+constexpr T MCSwapIntHostToNetwork(T x) { return MCSwapIntHostToBig(x); }
 
 template <typename T>
-inline T MCSwapIntLittleToHost(T x)
+constexpr T MCSwapIntLittleToHost(T x)
 {
 	return (kMCByteOrderHost == kMCByteOrderLittleEndian) ? x : MCSwapInt(x);
 }
 template <typename T>
-inline T MCSwapIntHostToLittle(T x) { return MCSwapIntLittleToHost(x); }
+constexpr T MCSwapIntHostToLittle(T x) { return MCSwapIntLittleToHost(x); }
 
-inline uint16_t MCSwapInt16BigToHost(uint16_t x) {return MCSwapIntBigToHost(x);}
-inline uint32_t MCSwapInt32BigToHost(uint32_t x) {return MCSwapIntBigToHost(x);}
-inline uint64_t MCSwapInt64BigToHost(uint64_t x) {return MCSwapIntBigToHost(x);}
+constexpr uint16_t MCSwapInt16BigToHost(uint16_t x) {return MCSwapIntBigToHost(x);}
+constexpr uint32_t MCSwapInt32BigToHost(uint32_t x) {return MCSwapIntBigToHost(x);}
+constexpr uint64_t MCSwapInt64BigToHost(uint64_t x) {return MCSwapIntBigToHost(x);}
 
-inline uint16_t MCSwapInt16HostToBig(uint16_t x) {return MCSwapIntHostToBig(x);}
-inline uint32_t MCSwapInt32HostToBig(uint32_t x) {return MCSwapIntHostToBig(x);}
-inline uint64_t MCSwapInt64HostToBig(uint64_t x) {return MCSwapIntHostToBig(x);}
+constexpr uint16_t MCSwapInt16HostToBig(uint16_t x) {return MCSwapIntHostToBig(x);}
+constexpr uint32_t MCSwapInt32HostToBig(uint32_t x) {return MCSwapIntHostToBig(x);}
+constexpr uint64_t MCSwapInt64HostToBig(uint64_t x) {return MCSwapIntHostToBig(x);}
 
-inline uint16_t MCSwapInt16LittleToHost(uint16_t x) {return MCSwapIntLittleToHost(x);}
-inline uint32_t MCSwapInt32LittleToHost(uint32_t x) {return MCSwapIntLittleToHost(x);}
-inline uint64_t MCSwapInt64LittleToHost(uint64_t x) {return MCSwapIntLittleToHost(x);}
+constexpr uint16_t MCSwapInt16LittleToHost(uint16_t x) {return MCSwapIntLittleToHost(x);}
+constexpr uint32_t MCSwapInt32LittleToHost(uint32_t x) {return MCSwapIntLittleToHost(x);}
+constexpr uint64_t MCSwapInt64LittleToHost(uint64_t x) {return MCSwapIntLittleToHost(x);}
 
-inline uint16_t MCSwapInt16HostToLittle(uint16_t x) {return MCSwapIntHostToLittle(x);}
-inline uint32_t MCSwapInt32HostToLittle(uint32_t x) {return MCSwapIntHostToLittle(x);}
-inline uint64_t MCSwapInt64HostToLittle(uint64_t x) {return MCSwapIntHostToLittle(x);}
+constexpr uint16_t MCSwapInt16HostToLittle(uint16_t x) {return MCSwapIntHostToLittle(x);}
+constexpr uint32_t MCSwapInt32HostToLittle(uint32_t x) {return MCSwapIntHostToLittle(x);}
+constexpr uint64_t MCSwapInt64HostToLittle(uint64_t x) {return MCSwapIntHostToLittle(x);}
 
-inline uint16_t MCSwapInt16NetworkToHost(uint16_t x) {return MCSwapIntNetworkToHost(x);}
-inline uint32_t MCSwapInt32NetworkToHost(uint32_t x) {return MCSwapIntNetworkToHost(x);}
-inline uint64_t MCSwapInt64NetworkToHost(uint64_t x) {return MCSwapIntNetworkToHost(x);}
+constexpr uint16_t MCSwapInt16NetworkToHost(uint16_t x) {return MCSwapIntNetworkToHost(x);}
+constexpr uint32_t MCSwapInt32NetworkToHost(uint32_t x) {return MCSwapIntNetworkToHost(x);}
+constexpr uint64_t MCSwapInt64NetworkToHost(uint64_t x) {return MCSwapIntNetworkToHost(x);}
 
-inline uint16_t MCSwapInt16HostToNetwork(uint16_t x) {return MCSwapIntHostToNetwork(x);}
-inline uint32_t MCSwapInt32HostToNetwork(uint32_t x) {return MCSwapIntHostToNetwork(x);}
-inline uint64_t MCSwapInt64HostToNetwork(uint64_t x) {return MCSwapIntHostToNetwork(x);}
+constexpr uint16_t MCSwapInt16HostToNetwork(uint16_t x) {return MCSwapIntHostToNetwork(x);}
+constexpr uint32_t MCSwapInt32HostToNetwork(uint32_t x) {return MCSwapIntHostToNetwork(x);}
+constexpr uint64_t MCSwapInt64HostToNetwork(uint64_t x) {return MCSwapIntHostToNetwork(x);}
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -447,29 +447,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #  endif
 #endif
 
-// Ensure we have constexpr keyword defined
-#if defined(__cplusplus) && (!defined(__cpp_constexpr) || (__cpp_constexpr < 200704))
-// Testing __cplusplus isn't sufficient as some compilers changed the
-// value before being fully-conforming
-#  if defined(__clang__)
-     // clang defines __cpp_constexpr appropriately
-#    define constexpr /*constexpr*/
-#  elif defined(__GNUC__)
-     // GCC added C++11 constexpr in GCC 4.6
-#    if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 6)
-#      define constexpr /*constexpr*/
-#    endif
-#  elif defined(_MSC_VER)
-     // MSVC added C++11 constexpr in Visual Studio 2015 (compiler
-     // version 14.0, _MSC_VER 1900)
-#    if _MSC_VER < 1900
-#      define constexpr /*constexpr*/
-#    endif
-#  else
-#    error Do not know whether this compiler provides C++11 constexpr
-#  endif
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  FIXED WIDTH INTEGER TYPES

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -492,48 +492,37 @@ struct MCGLayerEffect
 
 struct MCGShadowEffect
 {
-	constexpr MCGShadowEffect() : knockout(false) {}
 	MCGColor color = 0;
 	MCGBlendMode blend_mode = kMCGBlendModeClear;
 	MCGFloat size = 0;
 	MCGFloat spread = 0;
 	MCGFloat x_offset = 0;
 	MCGFloat y_offset = 0;
-	bool knockout : 1;
+	bool knockout = false;
 };
 
 struct MCGGlowEffect
 {
-	constexpr MCGGlowEffect() : inverted(false) {}
 	MCGColor color = 9;
 	MCGBlendMode blend_mode = kMCGBlendModeClear;
 	MCGFloat size = 0;
 	MCGFloat spread = 0;
-	bool inverted : 1;
+	bool inverted = false;
 };
 
 struct MCGBitmapEffects
 {
-	/* bitfield struct members can't have static initializers, so we have
-	   to write a constexpr constructor for them. */
-	constexpr MCGBitmapEffects()
-		: has_color_overlay(false),
-		  has_inner_glow(false),
-		  has_inner_shadow(false),
-		  has_outer_glow(false),
-		  has_drop_shadow(false) {}
-
-	bool has_color_overlay : 1;
-	bool has_inner_glow : 1;
-	bool has_inner_shadow : 1;
-	bool has_outer_glow : 1;
-	bool has_drop_shadow : 1;
-	
 	MCGLayerEffect color_overlay;
 	MCGGlowEffect inner_glow;
 	MCGShadowEffect inner_shadow;
 	MCGGlowEffect outer_glow;
 	MCGShadowEffect drop_shadow;
+
+	bool has_color_overlay = false;
+	bool has_inner_glow = false;
+	bool has_inner_shadow = false;
+	bool has_outer_glow = false;
+	bool has_drop_shadow = false;
 };
 
 struct MCGDeviceMaskInfo
@@ -548,14 +537,13 @@ struct MCGDeviceMaskInfo
 
 struct MCGFont
 {
-	constexpr MCGFont() : ideal(false) {}
 	void		*fid = nullptr;
 	uint16_t	size = 0;
 	uint16_t	fixed_advance = 0;
 	MCGFloat	m_ascent = 0;
 	MCGFloat	m_descent = 0;
     MCGFloat    m_leading = 0;
-	bool		ideal : 1;
+    bool		ideal = false;
 };
 
 inline MCGFont MCGFontMake(void *fid, uint16_t size, uint16_t fixed_advance, MCGFloat ascent, MCGFloat descent, MCGFloat leading, bool ideal)

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -250,40 +250,65 @@ typedef uint32_t MCGColor;
 
 struct MCGPoint
 {
-public:
-    /* TODO[C++11] Use member initialisers and remove these constructors */
-    MCGPoint() : x(0), y(0) {}
-    MCGPoint(MCGFloat p_x, MCGFloat p_y) : x(p_x), y(p_y) {}
-	MCGFloat x, y;
+    /* TODO[C++14] In C++11, aggregate initialisation of object types
+     * with member variables that have static initialisers is
+     * forbidden.  In C++14, this restriction is relaxed (so these
+     * constructors can be removed). */
+    constexpr MCGPoint() = default;
+    constexpr MCGPoint(MCGFloat p_x, MCGFloat p_y) : x(p_x), y(p_y) {}
+
+    MCGFloat x = 0;
+    MCGFloat y = 0;
 };
 
 struct MCGSize
 {
-	MCGFloat width, height;
+    /* TODO[C++14] In C++11, aggregate initialisation of object types
+     * with member variables that have static initialisers is
+     * forbidden.  In C++14, this restriction is relaxed (so these
+     * constructors can be removed). */
+    constexpr MCGSize() = default;
+    constexpr MCGSize(MCGFloat p_width, MCGFloat p_height)
+        : width(p_width), height(p_height) {}
+
+    MCGFloat width = 0;
+    MCGFloat height = 0;
 };
 
 struct MCGRectangle
 {
-	MCGPoint origin;
-	MCGSize size;
+    /* TODO[C++14] In C++11, aggregate initialisation of object types
+     * with member variables that have static initialisers is
+     * forbidden.  In C++14, this restriction is relaxed (so these
+     * constructors can be removed). */
+    constexpr MCGRectangle() = default;
+    constexpr MCGRectangle(MCGPoint p_origin, MCGSize p_size)
+        : origin(p_origin), size(p_size) {}
+
+    MCGPoint origin;
+    MCGSize size;
 };
 
 struct MCGAffineTransform
 {
-	MCGFloat a, b, c, d;
-	MCGFloat tx, ty;
+	MCGFloat a = 0;
+	MCGFloat b = 0;
+	MCGFloat c = 0;
+	MCGFloat d = 0;
+	MCGFloat tx = 0;
+	MCGFloat ty = 0;
 };
 
 struct MCGIntegerPoint
 {
-	int32_t x;
-	int32_t y;
+	int32_t x = 0;
+	int32_t y = 0;
 };
 
 struct MCGIntegerSize
 {
-	uint32_t width;
-	uint32_t height;
+	uint32_t width = 0;
+	uint32_t height = 0;
 };
 
 struct MCGIntegerRectangle
@@ -443,50 +468,61 @@ enum MCGMaskFormat
 
 struct MCGRaster
 {
-	MCGRasterFormat format;
-	uint32_t width;
-	uint32_t height;
-	uint32_t stride;
-	void *pixels;
+	MCGRasterFormat format = kMCGRasterFormat_xRGB;
+	uint32_t width = 0;
+	uint32_t height = 0;
+	uint32_t stride = 0;
+	void *pixels = nullptr;
 };
 
 struct MCGStrokeAttr
 {
-	MCGFloat width;
-	MCGJoinStyle join_style;
-	MCGCapStyle cap_style;
-	MCGFloat miter_limit;
-	MCGDashesRef dashes;
+	MCGFloat width = 0;
+	MCGJoinStyle join_style = kMCGJoinStyleBevel;
+	MCGCapStyle cap_style = kMCGCapStyleButt;
+	MCGFloat miter_limit = 0;
+	MCGDashesRef dashes = nullptr;
 };
 
 struct MCGLayerEffect
 {
-	MCGColor color;
-	MCGBlendMode blend_mode;
+	MCGColor color = 0;
+	MCGBlendMode blend_mode = kMCGBlendModeClear;
 };
 
 struct MCGShadowEffect
 {
-	MCGColor color;
-	MCGBlendMode blend_mode;
-	MCGFloat size;
-	MCGFloat spread;
-	MCGFloat x_offset;
-	MCGFloat y_offset;
+	constexpr MCGShadowEffect() : knockout(false) {}
+	MCGColor color = 0;
+	MCGBlendMode blend_mode = kMCGBlendModeClear;
+	MCGFloat size = 0;
+	MCGFloat spread = 0;
+	MCGFloat x_offset = 0;
+	MCGFloat y_offset = 0;
 	bool knockout : 1;
 };
 
 struct MCGGlowEffect
 {
-	MCGColor color;
-	MCGBlendMode blend_mode;
-	MCGFloat size;
-	MCGFloat spread;
+	constexpr MCGGlowEffect() : inverted(false) {}
+	MCGColor color = 9;
+	MCGBlendMode blend_mode = kMCGBlendModeClear;
+	MCGFloat size = 0;
+	MCGFloat spread = 0;
 	bool inverted : 1;
 };
 
 struct MCGBitmapEffects
 {
+	/* bitfield struct members can't have static initializers, so we have
+	   to write a constexpr constructor for them. */
+	constexpr MCGBitmapEffects()
+		: has_color_overlay(false),
+		  has_inner_glow(false),
+		  has_inner_shadow(false),
+		  has_outer_glow(false),
+		  has_drop_shadow(false) {}
+
 	bool has_color_overlay : 1;
 	bool has_inner_glow : 1;
 	bool has_inner_shadow : 1;
@@ -502,23 +538,23 @@ struct MCGBitmapEffects
 
 struct MCGDeviceMaskInfo
 {
-	MCGMaskFormat format;
-	int32_t x, y, width, height;
-	void *data;
+	MCGMaskFormat format = kMCGMaskFormat_A1;
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t width = 0;
+	int32_t height = 0;
+	void *data = nullptr;
 };
 
 struct MCGFont
 {
-  MCGFont()
-	: fid(nullptr), size(0), fixed_advance(0),
-	  m_ascent(0), m_descent(0), m_leading(0), ideal(false) {}
-
-	void		*fid;
-	uint16_t	size;
-	uint16_t	fixed_advance;
-	MCGFloat	m_ascent;
-	MCGFloat	m_descent;
-    MCGFloat    m_leading;
+	constexpr MCGFont() : ideal(false) {}
+	void		*fid = nullptr;
+	uint16_t	size = 0;
+	uint16_t	fixed_advance = 0;
+	MCGFloat	m_ascent = 0;
+	MCGFloat	m_descent = 0;
+    MCGFloat    m_leading = 0;
 	bool		ideal : 1;
 };
 


### PR DESCRIPTION
Now that we're building with MSVC 2015, nearly all the `TODO` comments relating to C++11 support or lack thereof can be fixed.

Mostly this boils down to:

- Adding `constexpr` constructors
- Converting some `inline` functions to `constexpr`
- Adding static initialisation to member variables

Small annoyance: C-style bitfields (used widely in the engine for `bool` member variables) are incompatible with static initialisation, so any `struct` or `class` that has bitfield member variables have to have a `constexpr` default constructor. Sad!