### PR TITLE
Remove support for i386 iPhoneSimulator  enhancement

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -554,45 +554,15 @@ component Runtime.Android
 //////////
 
 component Runtime.iOS
-	into "[[ToolsFolder]]/Runtime/iOS/Simulator-6_1" place
-		executable ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone
-		executable ios:iphonesimulator6.1/revsecurity.ios-extension as RevSecurity
-		executable ios:iphonesimulator6.1/revpdfprinter.ios-extension as RevPdfPrinter
-		executable ios:iphonesimulator6.1/revzip.ios-extension as RevZip
-		executable ios:iphonesimulator6.1/revxml.ios-extension as RevXml
-		executable ios:iphonesimulator6.1/revdb.ios-extension as RevDb
-		executable ios:iphonesimulator6.1/dbsqlite.ios-extension as DbSqlite
-		executable ios:iphonesimulator6.1/dbmysql.ios-extension as DbMysql
-		file ios:iphonesimulator6.1/mobile-template.plist as "Settings.plist"
-		file ios:iphonesimulator6.1/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
-		file ios:iphonesimulator6.1/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"
-		file ios:iphonesimulator6.1/mobile-disable-ats-template.plist as "DisableATS.plist"
-		file ios:iphonesimulator6.1/Default-568h@2x.png as "Default4InchSplash.png" base ios:Default-568h@2x.png
-		file ios:iphonesimulator6.1/fontmap as "fontmap"
-	into "[[ToolsFolder]]/Runtime/iOS/Simulator-7_1" place
-		executable ios:iphonesimulator7.1/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
-		executable ios:iphonesimulator7.1/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator6.1/revsecurity.dylib
-		executable ios:iphonesimulator7.1/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator6.1/revpdfprinter.dylib
-		executable ios:iphonesimulator7.1/revzip.ios-extension as RevZip base ios:iphonesimulator6.1/revzip.dylib
-		executable ios:iphonesimulator7.1/revxml.ios-extension as RevXml base ios:iphonesimulator6.1/revxml.dylib
-		executable ios:iphonesimulator7.1/revdb.ios-extension as RevDb base ios:iphonesimulator6.1/revdb.dylib
-		executable ios:iphonesimulator7.1/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator6.1/dbsqlite.dylib
-		executable ios:iphonesimulator7.1/dbmysql.ios-extension as DbMysql base ios:iphonesimulator6.1/dbmysql.dylib
-		file ios:iphonesimulator7.1/mobile-template.plist as "Settings.plist"
-		file ios:iphonesimulator7.1/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
-		file ios:iphonesimulator7.1/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"
-		file ios:iphonesimulator7.1/mobile-disable-ats-template.plist as "DisableATS.plist"
-		file ios:iphonesimulator7.1/Default-568h@2x.png as "Default4InchSplash.png" base ios:Default-568h@2x.png
-		file ios:iphonesimulator7.1/fontmap as "fontmap"
 	into "[[ToolsFolder]]/Runtime/iOS/Simulator-8_2" place
-		executable ios:iphonesimulator8.2/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone base ios:iphonesimulator6.1/standalone-mobile[[BaseEditionTagLower]].app/standalone-mobile[[BaseEditionTagLower]]
-		executable ios:iphonesimulator8.2/revsecurity.ios-extension as RevSecurity base ios:iphonesimulator6.1/revsecurity.dylib
-		executable ios:iphonesimulator8.2/revpdfprinter.ios-extension as RevPdfPrinter base ios:iphonesimulator6.1/revpdfprinter.dylib
-		executable ios:iphonesimulator8.2/revzip.ios-extension as RevZip base ios:iphonesimulator6.1/revzip.dylib
-		executable ios:iphonesimulator8.2/revxml.ios-extension as RevXml base ios:iphonesimulator6.1/revxml.dylib
-		executable ios:iphonesimulator8.2/revdb.ios-extension as RevDb base ios:iphonesimulator6.1/revdb.dylib
-		executable ios:iphonesimulator8.2/dbsqlite.ios-extension as DbSqlite base ios:iphonesimulator6.1/dbsqlite.dylib
-		executable ios:iphonesimulator8.2/dbmysql.ios-extension as DbMysql base ios:iphonesimulator6.1/dbmysql.dylib
+		executable ios:iphonesimulator8.2/standalone-mobile[[BaseEditionTagLower]].ios-engine as Standalone
+		executable ios:iphonesimulator8.2/revsecurity.ios-extension as RevSecurity
+		executable ios:iphonesimulator8.2/revpdfprinter.ios-extension as RevPdfPrinter
+		executable ios:iphonesimulator8.2/revzip.ios-extension as RevZip
+		executable ios:iphonesimulator8.2/revxml.ios-extension as RevXml
+		executable ios:iphonesimulator8.2/revdb.ios-extension as RevDb
+		executable ios:iphonesimulator8.2/dbsqlite.ios-extension as DbSqlite
+		executable ios:iphonesimulator8.2/dbmysql.ios-extension as DbMysql
 		file ios:iphonesimulator8.2/mobile-template.plist as "Settings.plist"
 		file ios:iphonesimulator8.2/mobile-remote-notification-template.plist as "RemoteNotificationSettings.plist"
 		file ios:iphonesimulator8.2/mobile-url-scheme-template.plist as "URLSchemeSettings.plist"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ EMMAKE ?= emmake
 # Some magic to control which versions of iOS we try to build.  N.b. you may
 # also need to modify the buildbot configuration
 IPHONEOS_VERSIONS ?= 9.2 10.2
-IPHONESIMULATOR_VERSIONS ?= 6.1 7.1 8.2 9.2 10.2
+IPHONESIMULATOR_VERSIONS ?= 8.2 9.2 10.2
+SKIP_IPHONESIMULATOR_VERSIONS ?= 6.1 7.1
 
 IOS_SDKS ?= \
 	$(addprefix iphoneos,$(IPHONEOS_VERSIONS)) \
@@ -142,13 +143,13 @@ compile-ios-%:
 check-ios-%:
 	$(XCODEBUILD) -project "build-ios-$*$(BUILD_SUBDIR)/$(BUILD_PROJECT).xcodeproj" -configuration $(BUILDTYPE) -target check
 
-# Dummy targets to prevent our build system from building iOS 5.1 simulator
-config-ios-iphonesimulator5.1:
-	@echo "Skipping iOS simulator 5.1 (no longer supported)"
-compile-ios-iphonesimulator5.1:
-	@echo "Skipping iOS simulator 5.1 (no longer supported)"
-check-ios-iphonesimulator5.1:
-	@echo "Skipping iOS simulator 5.1 (no longer supported)"
+# Dummy targets to prevent our build system from building old iOS simulators
+$(addprefix config-ios-iphonesimulator,$(SKIP_IPHONESIMULATOR_VERSIONS)):
+	@echo "Skipping $@ (no longer supported)"
+$(addprefix compile-ios-iphonesimulator,$(SKIP_IPHONESIMULATOR_VERSIONS)):
+	@echo "Skipping $@ (no longer supported)"
+$(addprefix check-ios-iphonesimulator,$(SKIP_IPHONESIMULATOR_VERSIONS)):
+	@echo "Skipping $@ (no longer supported)"
 
 # Provide some synonyms for "latest iOS SDK"
 $(addsuffix -ios-iphoneos,all config compile check): %: %$(lastword $(IPHONEOS_VERSIONS))

--- a/config.py
+++ b/config.py
@@ -206,10 +206,7 @@ def guess_xcode_arch(target_sdk):
         else:
             return 'armv7 arm64'
     if sdk == 'iphonesimulator':
-        if int(ver) < 8:
-            return 'i386'
-        else:
-            return 'i386 x86_64'
+        return 'x86_64'
 
 def validate_target_arch(opts):
     if opts['TARGET_ARCH'] is None:

--- a/ide-support/revdeploylibraryios.livecodescript
+++ b/ide-support/revdeploylibraryios.livecodescript
@@ -18,7 +18,7 @@ local sDeviceSDKs
 -- SN-2015-03-24: [[ Bug 15037 ]] Add a consistent, strict list of the
 --  SDKs and device relying on the engines we provide in the shipped version
 function deployUsableIosSdk
-   return "6.1,7.1,8.2,9.2,10.2"
+   return "8.2,9.2,10.2"
 end deployUsableIosSdk
 
 // SN-2015-05-01: Return the pair iOS SDK / Xcode for the current MacOS version
@@ -46,7 +46,7 @@ function deployGetIphoneOSes
 end deployGetIphoneOSes
 
 function deployGetIosMinimumVersions
-   return "6.0,6.1,7.0,7.1,8.0,8.1,8.2,8.3,8.4,9.0,9.1,9.2,9.3,10.0,10.1,10.2"
+   return "8.0,8.1,8.2,8.3,8.4,9.0,9.1,9.2,9.3,10.0,10.1,10.2"
 end deployGetIosMinimumVersions
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -14,7 +14,8 @@ LIBS_ios=( OpenSSL ICU )
 LIBS_win32=( OpenSSL Curl ICU CEF )
 LIBS_linux=( OpenSSL Curl ICU CEF )
 LIBS_emscripten=( ICU )
-SUBPLATFORMS_ios=(iPhoneSimulator6.1 iPhoneSimulator7.1 iPhoneSimulator8.2 iPhoneSimulator9.2 iPhoneSimulator10.2 iPhoneOS9.2 iPhoneOS10.2)
+
+SUBPLATFORMS_ios=(iPhoneSimulator8.2 iPhoneSimulator9.2 iPhoneSimulator10.2 iPhoneOS9.2 iPhoneOS10.2)
 SUBPLATFORMS_win32=(v140_static_debug v140_static_release)
 
 # Fetch settings

--- a/prebuilt/scripts/ios.inc
+++ b/prebuilt/scripts/ios.inc
@@ -23,20 +23,14 @@ function addiOS {
 XCODES_DIR="${HOME}/Builds/Platforms"
 
 # Detect iOS variants
-if [ -e "${XCODES_DIR}/Xcode_4_6_2" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_4_6_2/Xcode.app/Contents/Developer" iPhoneSimulator 6.1 i386
-fi
-if [ -e "${XCODES_DIR}/Xcode_5_1_1" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_5_1_1/Xcode.app/Contents/Developer" iPhoneSimulator 7.1 i386
-fi
 if [ -e "${XCODES_DIR}/Xcode_6_2_0" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_6_2_0/Xcode.app/Contents/Developer" iPhoneSimulator 8.2 "i386 x86_64"
+	addiOS "${XCODES_DIR}/Xcode_6_2_0/Xcode.app/Contents/Developer" iPhoneSimulator 8.2 "x86_64"
 fi
 if [ -e "${XCODES_DIR}/Xcode_7_2_0" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_7_2_0/Xcode.app/Contents/Developer" iPhoneSimulator 9.2 "i386 x86_64"
+	addiOS "${XCODES_DIR}/Xcode_7_2_0/Xcode.app/Contents/Developer" iPhoneSimulator 9.2 "x86_64"
 	addiOS "${XCODES_DIR}/Xcode_7_2_0/Xcode.app/Contents/Developer" iPhoneOS 9.2 "armv7 arm64"
 fi
 if [ -e "${XCODES_DIR}/Xcode_8_2_0" ] ; then
-	addiOS "${XCODES_DIR}/Xcode_8_2_0/Xcode.app/Contents/Developer" iPhoneSimulator 10.2 "i386 x86_64"
+	addiOS "${XCODES_DIR}/Xcode_8_2_0/Xcode.app/Contents/Developer" iPhoneSimulator 10.2 "x86_64"
 	addiOS "${XCODES_DIR}/Xcode_8_2_0/Xcode.app/Contents/Developer" iPhoneOS 10.2 "armv7 arm64"
 fi

--- a/tools/setup_xcode_sdks.py
+++ b/tools/setup_xcode_sdks.py
@@ -3,7 +3,7 @@
 # Update these lists if you need different SDK versions!
 
 iphoneos_versions = ["10.2", "9.2"]
-iphonesimulator_versions = ["10.2", "9.2", "8.2", "7.1", "6.1"]
+iphonesimulator_versions = ["10.2", "9.2", "8.2"]
 macosx_versions = ["10.9", "10.6"]
 
 # This tool creates the symlinks required for Xcode builds of LiveCode.


### PR DESCRIPTION
As planned, we are dropping support for iPhoneSimulator < 8.2 in LiveCode 9. This gives us the opportunity to also drop i386 iPhoneSimulator support, which is great because it means our iPhoneSimulator engines will be quicker to compile and take up much less space in the installer.