### PR TITLE
[Bug 19404] Prevent crash when calling "play empty" on iOS

### DIFF
--- a/docs/notes/bugfix-19404.md
+++ b/docs/notes/bugfix-19404.md
@@ -1,0 +1,1 @@
+# Fix crash on iOS when calling `play empty` followed by `play path/to/audio/file`

--- a/engine/src/mbliphonesound.mm
+++ b/engine/src/mbliphonesound.mm
@@ -298,6 +298,9 @@ bool MCSystemGetPlayLoudness(uint2& r_loudness)
 
 bool MCSystemPlaySound(MCStringRef p_sound, bool p_looping)
 {
+    if (MCStringIsEmpty(p_sound))
+        return true;
+
 	if (s_sound_player_delegate != nil)
 	{
 		[s_sound_player_delegate dealloc];
@@ -305,9 +308,6 @@ bool MCSystemPlaySound(MCStringRef p_sound, bool p_looping)
 	}
 	
 	MCValueRelease(s_sound_file);
-	
-	if (MCStringIsEmpty(p_sound))
-		return true;
 	
     bool t_success;
     t_success = true;

--- a/engine/src/mbliphonesound.mm
+++ b/engine/src/mbliphonesound.mm
@@ -112,6 +112,7 @@ bool MCSystemSoundInitialize()
 bool MCSystemSoundFinalize()
 {
 	MCValueRelease(s_sound_file);
+    s_sound_file = nullptr;
 	return true;
 }
 
@@ -308,6 +309,7 @@ bool MCSystemPlaySound(MCStringRef p_sound, bool p_looping)
 	}
 	
 	MCValueRelease(s_sound_file);
+    s_sound_file = nullptr;
 	
     bool t_success;
     t_success = true;


### PR DESCRIPTION
Previously, if a `play empty` command was followed by a `play path/to/valid/audiofile`, a crash occurred because of overreleasing `s_sound_file`.
