### PR TITLE
Update Android build documentation & scripts

### DIFF
--- a/INSTALL-android.md
+++ b/INSTALL-android.md
@@ -2,7 +2,7 @@
 
 ![LiveCode Community Logo](http://livecode.com/wp-content/uploads/2015/02/livecode-logo.png)
 
-Copyright © 2015 LiveCode Ltd., Edinburgh, UK
+Copyright © 2015-2017 LiveCode Ltd., Edinburgh, UK
 
 ## Dependencies
 
@@ -19,11 +19,17 @@ LiveCode requires both the Android Software Development Kit (SDK) and Native Dev
 Extract both the NDK and SDK to a suitable directory, e.g. `~/android/toolchain`.  For example, you would run:
 
 ````bash
-mkdir -p ~/android/toolchain
+mkdir -p ~/android/toolchain/android-sdk-linux
 cd ~/android/toolchain
 
-tar -xf ~/Downloads/android-sdk_r24.1.2-linux.tgz
-7z x ~/Downloads/android-ndk-r10e-linux-x86_64.bin
+wget https://dl.google.com/android/repository/android-ndk-r14-linux-x86_64.zip
+wget https://dl.google.com/android/repository/tools_r25.2.3-linux.zip
+
+unzip android-ndk-r14-linux-x86_64.zip
+
+pushd android-sdk-linux
+unzip tools_r25.2.3-linux.zip
+popd
 ````
 
 Update the SDK:
@@ -35,16 +41,15 @@ Update the SDK:
 Create a standalone toolchain (this simplifies setting up the build environment):
 
 ````bash
-android-ndk-r10e/build/tools/make-standalone-toolchain.sh \
-    --toolchain=arm-linux-androideabi-clang3.5 \
-    --platform=android-10 \
-    --install-dir=${HOME}/android/toolchain/standalone
+android-ndk-r14/build/tools/make_standalone_toolchain.py \
+    --arch arm --api 17 --stl libc++ \
+    --install-dir ${HOME}/android/toolchain/standalone
 ````
 
 Add a couple of symlinks to allow the engine configuration script to find the Android toolchain:
 
 ````bash
-ln -s android-ndk-r10e android-ndk
+ln -s android-ndk-r14 android-ndk
 ln -s android-sdk-linux android-sdk
 ````
 
@@ -75,11 +80,11 @@ LINK="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -fuse-ld=bfd"
 AR="${BINDIR}/${TRIPLE}-ar"
 
 # Android platform information
-ANDROID_NDK_VERSION=r10e
-ANDROID_PLATFORM=android-10
-ANDROID_NDK=${TOOLCHAIN}/android-ndk-r10e
+ANDROID_NDK_VERSION=r14
+ANDROID_PLATFORM=android-17
+ANDROID_NDK=${TOOLCHAIN}/android-ndk-r14
 ANDROID_SDK=${TOOLCHAIN}/android-sdk-linux
-ANDROID_BUILD_TOOLS=23.0.1
+ANDROID_BUILD_TOOLS=25.0.2
 
 export JAVA_SDK
 export CC CXX LINK AR
@@ -112,7 +117,7 @@ Otherwise, you'll need to build a target in the gyp-generated makefiles:
 
 **Note:** The following information is provided for reference purposes.  It should be possible to build LiveCode for Android on any modern Linux desktop distribution or recent version of Mac OS.
 
-The Linux build environment used for compiling LiveCode for Android is based on Debian Wheezy x86-64, with the following additional packages installed:
+The Linux build environment used for compiling LiveCode for Android is based on Debian Jessie x86-64, with the following additional packages installed:
 
 * git
 * bzip2
@@ -121,3 +126,5 @@ The Linux build environment used for compiling LiveCode for Android is based on 
 * python
 * build-essential
 * openjdk-7-jdk
+* flex
+* bison

--- a/config.py
+++ b/config.py
@@ -382,7 +382,7 @@ def guess_android_build_tools(sdkdir):
 
 def validate_android_tools(opts):
     if opts['ANDROID_NDK_VERSION'] is None:
-        opts['ANDROID_NDK_VERSION'] = 'r10d'
+        opts['ANDROID_NDK_VERSION'] = 'r14'
 
     ndk_ver = opts['ANDROID_NDK_VERSION']
     if opts['ANDROID_PLATFORM'] is None:


### PR DESCRIPTION
Update the Android build documentation & build scripts to reflect the different
download files and file layouts of the official Android build tools, and to use
more appropriate (i.e. recent) versions of everything.

Replaces #5145.