### PR TITLE
[[ Bug 19416 ]] Refactor object message clear

### DIFF
--- a/docs/notes/bugfix-19416.md
+++ b/docs/notes/bugfix-19416.md
@@ -1,0 +1,1 @@
+# Ensure all object messages are cleared when obj or ancestor is deleted

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1158,7 +1158,7 @@ Boolean MCCard::del(bool p_check_flag)
 			}
 			else
 			{
-                optr->getref()->uncacheid();
+                optr->getref()->removereferences();
 				getstack()->removecontrol(optr->getref());
 			}
 			MCCdata *dptr = optr->getref()->getdata(obj_id, False);
@@ -1169,7 +1169,7 @@ Boolean MCCard::del(bool p_check_flag)
 		while (optr != objptrs);
 	}
     
-    uncacheid();
+    removereferences();
     
     // MCObject now does things on del(), so we must make sure we finish by
     // calling its implementation.

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -500,20 +500,20 @@ Boolean MCControl::del(bool p_check_flag)
 	switch (parent->gettype())
 	{
         case CT_STACK:
-            uncacheid();
+            removereferences();
             parent.GetAs<MCStack>()->removecontrol(this);
             break;
         
         case CT_CARD:
             if (!parent.GetAs<MCCard>()->removecontrol(this, False, True))
 				return False;
-            uncacheid();
+            removereferences();
 			getstack()->removecontrol(this);
 			break;
         
         case CT_GROUP:
 			parent.GetAs<MCGroup>()->removecontrol(this, True);
-            uncacheid();
+            removereferences();
 			break;
 
         default:

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -1031,20 +1031,20 @@ void MCGroup::applyrect(const MCRectangle &nrect)
 	}
 }
 
-void MCGroup::uncacheid()
+void MCGroup::removereferences()
 {
     if (controls != NULL)
     {
         MCControl *t_control;
         t_control = controls;
         do
-        {   t_control -> uncacheid();
+        {   t_control -> removereferences();
             t_control = t_control -> next();
         }
         while(t_control != controls);
     }
     
-    MCObject::uncacheid();
+    MCObject::removereferences();
 }
 
 bool MCGroup::isdeletable(bool p_check_flag)

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -92,7 +92,7 @@ public:
 	virtual Boolean doubleup(uint2 which);
 	virtual void applyrect(const MCRectangle &nrect);
 
-    virtual void uncacheid(void);
+    virtual void removereferences(void);
 	virtual Boolean del(bool p_check_flag);
 	virtual void recompute();
 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -853,10 +853,14 @@ void MCObject::deselect()
 	state &= ~CS_SELECTED;
 }
 
-void MCObject::uncacheid()
+void MCObject::removereferences()
 {
     if (m_in_id_cache)
         getstack()->uncacheobjectbyid(this);
+    
+    MCscreen->cancelmessageobject(this, NULL);
+    removefrom(MCfrontscripts);
+    removefrom(MCbackscripts);
 }
 
 bool MCObject::isdeletable(bool p_check_flag)
@@ -873,10 +877,6 @@ bool MCObject::isdeletable(bool p_check_flag)
 
 Boolean MCObject::del(bool p_check_flag)
 {
-    MCscreen->cancelmessageobject(this, NULL);
-    removefrom(MCfrontscripts);
-    removefrom(MCbackscripts);
-    
     // If the object is marked as being used as a parentScript, flush the parentScript
     // table so we don't get any dangling pointers.
 	if (m_is_parent_script)

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -672,7 +672,7 @@ public:
 	virtual void undo(Ustruct *us);
 	virtual void freeundo(Ustruct *us);
 
-    virtual void uncacheid(void);
+    virtual void removereferences(void);
     
 	// [[ C++11 ]] MSVC doesn't support typename here while other compilers require it
 #ifdef _MSC_VER

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1440,6 +1440,8 @@ Boolean MCStack::del(bool p_check_flag)
         needs = NULL;
     }
     
+    removereferences();
+    
     uint2 i = 0;
     while (i < MCnusing)
         if (MCusing[i] == this)
@@ -1455,6 +1457,51 @@ Boolean MCStack::del(bool p_check_flag)
     // MCObject now does things on del(), so we must make sure we finish by
     // calling its implementation.
     return MCObject::del(true);
+}
+
+void MCStack::removereferences()
+{
+    if (controls != NULL)
+    {
+        MCControl *t_control = controls;
+        do
+        {   t_control -> removereferences();
+            t_control = t_control -> next();
+        }
+        while(t_control != controls);
+    }
+    
+    if (aclips != NULL)
+    {
+        MCAudioClip *t_aclip = aclips;
+        do
+        {   t_aclip -> removereferences();
+            t_aclip = t_aclip -> next();
+        }
+        while(t_aclip != aclips);
+    }
+    
+    if (vclips != NULL)
+    {
+        MCVideoClip *t_vclip = vclips;
+        do
+        {   t_vclip -> removereferences();
+            t_vclip = t_vclip -> next();
+        }
+        while(t_vclip != vclips);
+    }
+    
+    if (cards != NULL)
+    {
+        MCCard *t_card = cards;
+        do
+        {   t_card -> removereferences();
+            t_card = t_card -> next();
+        }
+        while(t_card != cards);
+    }
+    
+    MCObject::removereferences();
 }
 
 void MCStack::paste(void)

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -353,6 +353,7 @@ public:
 	virtual void timer(MCNameRef mptr, MCParameter *params);
 	virtual void applyrect(const MCRectangle &nrect);
 
+    virtual void removereferences(void);
 	virtual Boolean del(bool p_check_flag);
     virtual bool isdeletable(bool p_check_flag);
     

--- a/tests/lcs/core/engine/send.livecodescript
+++ b/tests/lcs/core/engine/send.livecodescript
@@ -32,3 +32,26 @@ on TestSendParams
 	send tSendScript to tStack
 	TestAssert "send script with multiple params", the result is "2"
 end TestSendParams
+
+private function MessageExists pId
+	repeat for each line tLine in the pendingMessages
+		if item 1 of tLine is pId then
+			return true
+		end if
+	end repeat
+	return false
+end MessageExists
+
+
+on TestSendToSubobj
+	local tStack, tMsgId
+	create stack
+	put the short name of it into tStack
+	set the defaultStack to tStack
+	create button
+	send "mouseUp" to it in 5 millisecs
+	put the result into tMsgId
+	delete stack tStack
+
+	TestAssert "message canceled on delete", not MessageExists(tMsgId)
+end TestSendToSubobj


### PR DESCRIPTION
In order to fully purge the pending messages of messages for a given
object when the object is removed from the object tree, we must
recursively remove these messages for all children of the deleted
object.