### PR TITLE
libfoundation: Unify & improve fast hash functions

### DIFF
--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -23,10 +23,34 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-codepoint_t MCUnicodeSurrogatesToCodepoint(uint16_t first, uint16_t second);
-// We assume that the unichar_t pointer already has enough memory to handle the addition of the surrogate pair
-// Returns true in case the codepoint actually generated a surrogate pair
-bool MCUnicodeCodepointToSurrogates(codepoint_t t_codepoint, unichar_t* r_surrogates);
+constexpr inline codepoint_t
+MCUnicodeSurrogatesToCodepoint(uint16_t first, uint16_t second)
+{
+    return 0x10000 + ((first & 0x3FF) << 10) + (second & 0x3FF);
+}
+
+/* Split p_codepoint into a surrogate pair, storing the leading
+ * component in r_leading and the trailing component in
+ * r_trailing.  If p_codepoint is in the BMP, set r_leading
+ * to p_codepoint, clear r_trailing, and return false. */
+inline bool MCUnicodeCodepointToSurrogates(codepoint_t p_codepoint,
+                                           unichar_t& r_leading,
+                                           unichar_t& r_trailing)
+{
+    if (p_codepoint < 0x10000)
+    {
+        r_leading = unichar_t(p_codepoint); /* safe narrowing */
+        r_trailing = 0;
+        return false;
+    }
+    else
+    {
+        p_codepoint -= 0x10000;
+        r_leading = 0xD800 + (p_codepoint >> 10);
+        r_trailing = 0xDC00 + (p_codepoint & 0x3FF);
+        return true;
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1301,6 +1301,16 @@ MC_DLLEXPORT hash_t MCHashBytes(const void *bytes, size_t byte_count);
 // hashing sequence (byte_count should be a multiple of 4).
 MC_DLLEXPORT hash_t MCHashBytesStream(hash_t previous, const void *bytes, size_t byte_count);
 
+// Returns a hash value for the given sequence of native chars. The chars are
+// folded before being processed.
+MC_DLLEXPORT hash_t MCHashNativeChars(const char_t *chars,
+                                      size_t char_count);
+
+// Returns a hash value for the given sequence of code units. The chars are
+// normalized and folded before being processed.
+MC_DLLEXPORT hash_t MCHashChars(const unichar_t *chars,
+                                size_t char_count);
+
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -9,6 +9,7 @@
 		'module_test_sources':
 		[
 			'test/environment.cpp',
+			'test/test_hash.cpp',
 			'test/test_string.cpp',
 			'test/test_typeconvert.cpp',
             'test/test_system-library.cpp',

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -18,6 +18,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <foundation-stdlib.h>
 
 #include "foundation-private.h"
+#include "foundation-hash.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -212,129 +213,58 @@ void MCMemoryDeleteArray(void *p_array)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// These hash functions are taken from CoreFoundation - if they are good enough
-// for Apple, they should be good enough for us :)
-
-#define HASHFACTOR 2654435761U
-
-/* Templates for hashing arbitrary-sized integers */
-template <typename T>
-static inline hash_t
-MCHashUInt(T i)
-{
-	hash_t h = 0;
-	for (unsigned int o = 0; o < sizeof(T); o += sizeof(hash_t))
-		h += HASHFACTOR * (hash_t) (i >> (o << 3));
-	return h;
-}
-
-template <typename T>
-static inline hash_t
-MCHashInt(T i)
-{
-	return MCHashUInt((i >= 0) ? i : (-i));
-}
-
 MC_DLLEXPORT_DEF
 hash_t MCHashInteger(integer_t i)
 {
-	return MCHashInt (i);
+	return MCHashInt(i);
 }
 
 MC_DLLEXPORT_DEF
 hash_t
 MCHashUInteger (uinteger_t i)
 {
-	return MCHashUInt(i);
+	return MCHashInt(i);
 }
 
 MC_DLLEXPORT_DEF
 hash_t
 MCHashSize (ssize_t i)
 {
-	return MCHashInt (i);
+	return MCHashInt(i);
 }
 
 hash_t
 MCHashUSize (size_t i)
 {
-	return MCHashUInt (i);
+	return MCHashInt(i);
 }
 
 MC_DLLEXPORT_DEF
 hash_t MCHashPointer(const void *p)
 {
-	return MCHashUInt((uintptr_t) p);
+	return MCHashInt(reinterpret_cast<uintptr_t>(p));
 }
 
 MC_DLLEXPORT_DEF
 hash_t MCHashDouble(double d)
 {
-	double i;
-	if (d < 0)
-		d = -d;
-	i = floor(d + 0.5);
-	
-	hash_t t_integral_hash;
-	t_integral_hash = HASHFACTOR * (hash_t)fmod(i, (double)UINT32_MAX);
-
-	return (hash_t)(t_integral_hash + (hash_t)((d - i) * UINT32_MAX));
+    return MCHashFloatingPoint(d);
 }
-
-#define ELF_STEP(B) T1 = (H << 4) + B; T2 = T1 & 0xF0000000; if (T2) T1 ^= (T2 >> 24); T1 &= (~T2); H = T1;
 
 MC_DLLEXPORT_DEF
 hash_t MCHashBytes(const void *p_bytes, size_t length)
 {
-	MCAssert(nil != p_bytes || 0 == length);
-
-	uint8_t *bytes = (uint8_t *)p_bytes;
-
-    /* The ELF hash algorithm, used in the ELF object file format */
-    uint32_t H = 0, T1, T2;
-    int32_t rem = length;
-
-    while (3 < rem)
-	{
-		ELF_STEP(bytes[length - rem]);
-		ELF_STEP(bytes[length - rem + 1]);
-		ELF_STEP(bytes[length - rem + 2]);
-		ELF_STEP(bytes[length - rem + 3]);
-		rem -= 4;
-    }
-
-    switch (rem)
-	{
-    case 3:  ELF_STEP(bytes[length - 3]);
-    case 2:  ELF_STEP(bytes[length - 2]);
-    case 1:  ELF_STEP(bytes[length - 1]);
-    case 0:  ;
-    }
-
-    return H;
+    MCHashBytesContext t_context;
+    t_context.consume(reinterpret_cast<const byte_t *>(p_bytes), length);
+    return t_context;
 }
 
 MC_DLLEXPORT_DEF
 hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t length)
 {
-	MCAssert(p_bytes != nil || length == 0);
-    MCAssert((length % 4) == 0);
-    uint8_t *bytes = (uint8_t *)p_bytes;
-    
-    /* The ELF hash algorithm, used in the ELF object file format */
-    uint32_t H = p_start, T1, T2;
-    int32_t rem = length;
-    
-    while (3 < rem)
-	{
-		ELF_STEP(bytes[length - rem]);
-		ELF_STEP(bytes[length - rem + 1]);
-		ELF_STEP(bytes[length - rem + 2]);
-		ELF_STEP(bytes[length - rem + 3]);
-		rem -= 4;
-    }
-    
-    return H;
+    MCHashBytesContext t_context(p_start);
+    t_context.consume(reinterpret_cast<const byte_t *>(p_bytes), length);
+    return t_context;
 }
 
 #undef ELF_STEP

--- a/libfoundation/src/foundation-hash.h
+++ b/libfoundation/src/foundation-hash.h
@@ -1,0 +1,129 @@
+/*                                                                     -*-c++-*-
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef MC_FOUNDATION_HASH_H
+#define MC_FOUNDATION_HASH_H
+
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+/* ----------------------------------------------------------------
+ * Integer hashes
+ * ---------------------------------------------------------------- */
+
+// These hash functions are taken from CoreFoundation - if they are good enough
+// for Apple, they should be good enough for us :)
+
+static const hash_t kMCHashFactor = 2654435761U;
+
+template<typename ValueType, typename Enable = void>
+struct MCHashIntImpl { static_assert(sizeof(ValueType) == 0); };
+
+// Hash an arbitrary sized Int - the hash code generated is
+// independent on the number of bytes representing the integer or the
+// sign of the integer.
+template<typename Integer>
+inline hash_t MCHashInt(Integer i)
+{
+    return MCHashIntImpl<Integer>::hash(i);
+}
+
+/* Specialization of integer hashing for any size of unsigned integer. */
+template<typename Unsigned>
+struct MCHashIntImpl<
+    Unsigned, typename std::enable_if<std::is_unsigned<Unsigned>::value>::type>
+{
+    static hash_t hash(Unsigned i)
+    {
+        hash_t h = 0;
+        for (decltype(sizeof(Unsigned)) o = 0;
+             o < sizeof(Unsigned);
+             o += sizeof(hash_t))
+            h += kMCHashFactor * hash_t(i >> (o << 3));
+        return h;
+    }
+};
+
+/* Specialization of integer hashing for any size of signed integer. */
+template<typename Signed>
+struct MCHashIntImpl<
+    Signed, typename std::enable_if<std::is_signed<Signed>::value>::type>
+{
+    static hash_t hash(Signed i)
+    {
+        using Unsigned = typename std::make_unsigned<Signed>::type;
+        return MCHashInt<Unsigned>(i >= 0 ? i : -i);
+    }
+};
+
+/* ----------------------------------------------------------------
+ * Floating-point hashes
+ * ---------------------------------------------------------------- */
+
+// Hash a floating point value - the hash code generated is
+// independent of the number of bytes representing the value and if
+// the value is an integer it will be the same as using MCHashInt.
+template <typename FloatingPoint>
+inline hash_t MCHashFloatingPoint(FloatingPoint f)
+{
+    if (f < 0)
+        f = -f;
+
+    double truncated = std::floor(f + 0.5);
+    hash_t t_int_hash = MCHashInt(hash_t(std::fmod(truncated, UINT32_MAX)));
+    return t_int_hash + hash_t((truncated - f) * UINT32_MAX);
+}
+
+/* ----------------------------------------------------------------
+ * Byte sequence hashing
+ * ---------------------------------------------------------------- */
+
+/* The ELF hash algorithm used in the ELF object file format. */
+class MCHashBytesContext
+{
+    hash_t m_hash = 0;
+
+    void step(byte_t p_byte)
+    {
+        uint32_t T1 = (m_hash << 4) + p_byte;
+        uint32_t T2 = T1 & 0xF0000000;
+        if (T2)
+        {
+            T1 ^= (T2 >> 24);
+        }
+        T1 &= ~T2;
+        m_hash = T1;
+    }
+
+public:
+    constexpr MCHashBytesContext() = default;
+
+    constexpr MCHashBytesContext(hash_t p_initial_hash)
+    : m_hash(p_initial_hash)
+    {}
+
+    operator hash_t() const { return m_hash; }
+
+    void consume(const byte_t *p_bytes,
+                 size_t p_length)
+    {
+        while (p_length--) step(*p_bytes++);
+    }
+};
+
+#endif /*!MC_FOUNDATION_HASH_H*/

--- a/libfoundation/src/foundation-hash.h
+++ b/libfoundation/src/foundation-hash.h
@@ -32,7 +32,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 static const hash_t kMCHashFactor = 2654435761U;
 
 template<typename ValueType, typename Enable = void>
-struct MCHashIntImpl { static_assert(sizeof(ValueType) == 0); };
+struct MCHashIntImpl {
+    static_assert(sizeof(ValueType) == 0,
+                  "Missing MCHashImpl specialization"); };
 
 // Hash an arbitrary sized Int - the hash code generated is
 // independent on the number of bytes representing the integer or the

--- a/libfoundation/src/foundation-string-hash.h
+++ b/libfoundation/src/foundation-string-hash.h
@@ -1,0 +1,97 @@
+/*                                                                     -*-c++-*-
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef MC_FOUNDATION_STRING_HASH_H
+#define MC_FOUNDATION_STRING_HASH_H
+
+#include <foundation-hash.h>
+#include <foundation-unicode.h>
+
+/* Anonymous namespace to ensure that the functions defined here don't
+ * get any external linkage. */
+namespace {
+
+/* ----------------------------------------------------------------
+ * Character sequence hashing
+ * ---------------------------------------------------------------- */
+
+/* Uses the Fowler-Noll-Vo FNV-1a hash */
+
+class MCHashCharsContext
+{
+    static const hash_t kPrime = (sizeof(hash_t) == sizeof(uint64_t) ?
+                                  1099511628211ULL : 16777619UL);
+    static const hash_t kOffset = (sizeof(hash_t) == sizeof(uint64_t) ?
+                                   14695981039346656037ULL : 2166136261UL);
+
+    hash_t m_hash = kOffset;
+
+    // Perform a single step for a unicode code unit representable as a single
+    // byte.
+    void step(char_t p_char)
+    {
+        m_hash ^= p_char;
+        m_hash *= kPrime;
+        m_hash *= kPrime;
+    }
+
+    // Peform a single step for a two-byte code unit
+    void step(unichar_t p_char)
+    {
+        // Hash the lower byte
+        m_hash ^= p_char & 0xFF;
+        m_hash *= kPrime;
+
+        // Hash the upper byte
+        m_hash ^= p_char >> 8;
+        m_hash *= kPrime;
+    }
+
+public:
+    constexpr MCHashCharsContext() = default;
+
+    constexpr MCHashCharsContext(hash_t p_initial_hash)
+    : m_hash(p_initial_hash)
+    {}
+
+    operator hash_t() const { return m_hash; }
+
+    /* Hash single code units */
+    void consume(char_t c) { step(c); }
+    void consume(unichar_t u) { step(u); }
+
+    /* Hash a full codepoint, treating it as a single codeunit if it
+     * falls in the BMP and as two codeunits otherwise. */
+    void consume(codepoint_t p_codepoint)
+    {
+        unichar_t t_leading = 0;
+        unichar_t t_trailing = 0;
+        if (!MCUnicodeCodepointToSurrogates(p_codepoint, t_leading, t_trailing))
+        {
+            step(t_leading);
+        }
+        else
+        {
+            step(t_leading);
+            step(t_trailing);
+        }
+    }
+};
+
+} /* anonymous namespace */
+
+#endif /* !MC_FOUNDATION_STRING_HASH_H */

--- a/libfoundation/src/foundation-string-native.cpp.h
+++ b/libfoundation/src/foundation-string-native.cpp.h
@@ -17,6 +17,7 @@
 #include <foundation.h>
 #include <foundation-auto.h>
 #include <foundation-unicode.h>
+#include <foundation-string-hash.h>
 
 #include "foundation-private.h"
 
@@ -449,47 +450,10 @@ static inline hash_t
 __MCNativeStr_Hash(const char_t *p_chars,
                    size_t p_char_count)
 {
-#ifdef __LARGE__
-    // 64-bit variant
-    const uint64_t kPrime = 1099511628211ULL;
-    const uint64_t kOffset = 14695981039346656037ULL;
-    uint64_t t_hash = kOffset;
-    
+    MCHashCharsContext t_context;
     while (p_char_count--)
-    {
-        uint16_t t_char;
-        t_char = (uint16_t)MCUnicodeCharMapFromNative(CharFold(*p_chars++));
-        
-        // Hash the byte
-        t_hash ^= t_char & 0xFF;
-        t_hash *= kPrime;
-        
-        // Hash the second byte of the unichar
-        t_hash ^= t_char >> 8;
-        t_hash *= kPrime;
-    }
-    return t_hash;
-#else
-    // 32-bit variant
-    const uint32_t kPrime = 16777619UL;
-    const uint32_t kOffset = 2166136261UL;
-    uint32_t t_hash = kOffset;
-    
-    while (p_char_count--)
-    {
-        uint16_t t_char;
-        t_char = (uint16_t)MCUnicodeCharMapFromNative(CharFold(*p_chars++));
-        
-        // Hash the byte
-        t_hash ^= t_char & 0xFF;
-        t_hash *= kPrime;
-        
-        // Hash the second byte of the unichar
-        t_hash ^= t_char >> 8;
-        t_hash *= kPrime;
-    }
-    return t_hash;
-#endif
+        t_context.consume(MCUnicodeCharMapFromNative(CharFold(*p_chars++)));
+    return t_context;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-text.cpp
+++ b/libfoundation/src/foundation-text.cpp
@@ -271,7 +271,8 @@ codepoint_t MCTextFilter_NormalizeNFC::GetNextCodepoint()
         if (m_StateLength == 0)
         {
             // Check whether the codepoint we got is a surrogate pair
-            if (MCUnicodeCodepointToSurrogates(t_cp, &(m_State[m_StateLength])))
+            if (MCUnicodeCodepointToSurrogates(t_cp, m_State[m_StateLength],
+                                               m_State[m_StateLength + 1]))
                 m_StateLength++;
             
             m_StateLength++;
@@ -287,7 +288,8 @@ codepoint_t MCTextFilter_NormalizeNFC::GetNextCodepoint()
         else
         {
             // Check whether the codepoint we got is a surrogate pair
-            if (MCUnicodeCodepointToSurrogates(t_cp, &(m_State[m_StateLength])))
+            if (MCUnicodeCodepointToSurrogates(t_cp, m_State[m_StateLength],
+                                               m_State[m_StateLength+1]))
                 m_StateLength++;
             
             m_StateLength++;
@@ -353,7 +355,9 @@ codepoint_t MCTextFilter_NormalizeNFC::GetNextCodepointReverse()
         if (m_StateLength == 0)
         {
             // Check whether the codepoint we got is a surrogate pair
-            if (MCUnicodeCodepointToSurrogates(t_cp, &(m_State[kMCTextFilterMaxNormLength - 2])))
+            if (MCUnicodeCodepointToSurrogates(t_cp,
+                                               m_State[kMCTextFilterMaxNormLength - 2],
+                                               m_State[kMCTextFilterMaxNormLength - 1]))
                 m_StateLength++;
             else
                 m_State[kMCTextFilterMaxNormLength - 1] = m_State[kMCTextFilterMaxNormLength - 2];
@@ -366,7 +370,10 @@ codepoint_t MCTextFilter_NormalizeNFC::GetNextCodepointReverse()
         else
         {
             // Check whether the codepoint we got is a surrogate pair
-            if (MCUnicodeCodepointToSurrogates(t_cp, &(m_State[kMCTextFilterMaxNormLength - m_StateLength - 2])))
+            if (MCUnicodeCodepointToSurrogates(t_cp,
+                                               m_State[kMCTextFilterMaxNormLength - m_StateLength - 2],
+                                               m_State[kMCTextFilterMaxNormLength - m_StateLength - 1]))
+                
                 m_StateLength++;
             else
                 m_State[kMCTextFilterMaxNormLength - m_StateLength - 1] = m_State[kMCTextFilterMaxNormLength - m_StateLength - 2];

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -151,28 +151,6 @@ void __MCUnicodeFinalize()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-codepoint_t MCUnicodeSurrogatesToCodepoint(uint16_t p_lead, uint16_t p_trail)
-{
-    return 0x10000 + ((p_lead & 0x3FF) << 10) + (p_trail & 0x3FF);
-}
-
-bool MCUnicodeCodepointToSurrogates(codepoint_t t_codepoint, unichar_t* r_surrogates)
-{
-    if (t_codepoint < 0x10000)
-    {
-        *r_surrogates = (unichar_t)t_codepoint;
-        return false;
-    }
-    else
-    {
-        r_surrogates[0] = (((t_codepoint - 0x10000) & 0xFFC00) >> 10) + 0xD800;
-        r_surrogates[1] = (t_codepoint & 0x3FF) + 0xDC00;
-        return true;
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 bool MCUnicodeGetBinaryProperty(codepoint_t p_codepoint, MCUnicodeProperty p_property)
 {
     return !!u_hasBinaryProperty(p_codepoint, MCUnicodePropToICUProp[p_property]);

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -25,6 +25,7 @@
 
 #include "foundation-auto.h"
 #include "foundation-text.h"
+#include "foundation-string-hash.h"
 
 #include <limits>
 
@@ -1254,56 +1255,14 @@ hash_t MCUnicodeHash(const unichar_t *p_string, uindex_t p_string_length, MCUnic
     // Create a filter for the string
     MCAutoPointer<MCTextFilter> t_filter =
 			MCTextFilterCreate(p_string, p_string_length, kMCStringEncodingUTF16, p_option);
-    
-    // Fowler-Noll-Vo 1a hash function
-    if (sizeof(hash_t) == sizeof(uint64_t))
-    {
-        // 64-bit variant
-        const uint64_t kPrime = 1099511628211ULL;
-        const uint64_t kOffset = 14695981039346656037ULL;
-        uint64_t t_hash = kOffset;
-        
-        while (t_filter->HasData())
-        {
-            unichar_t t_char;
-            t_char = t_filter->GetNextCodepoint();
-            t_filter->AdvanceCursor();
-            
-            // Hash the first byte of the codeunit
-            t_hash ^= t_char & 0xFF;
-            t_hash *= kPrime;
-            
-            // Hash the second byte of the codeunit
-            t_hash ^= t_char >> 8;
-            t_hash *= kPrime;
-        }
-        
-        return t_hash;
-    }
-    else
-    {
-        // 32-bit variant
-        const uint32_t kPrime = 16777619UL;
-        const uint32_t kOffset = 2166136261UL;
-        uint32_t t_hash = kOffset;
-        
-        while (t_filter->HasData())
-        {
-            unichar_t t_char;
-            t_char = t_filter->GetNextCodepoint();
-            t_filter->AdvanceCursor();
-            
-            // Hash the first byte of the codeunit
-            t_hash ^= t_char & 0xFF;
-            t_hash *= kPrime;
-            
-            // Hash the second byte of the codeunit
-            t_hash ^= t_char >> 8;
-            t_hash *= kPrime;
-        }
 
-        return t_hash;
+    MCHashCharsContext t_context;
+    while (t_filter->HasData())
+    {
+        t_context.consume(t_filter->GetNextCodepoint());
+        t_filter->AdvanceCursor();
     }
+    return t_context;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/test/test_hash.cpp
+++ b/libfoundation/test/test_hash.cpp
@@ -1,0 +1,188 @@
+/* Copyright (C) 2003-2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "gtest/gtest.h"
+
+#include "foundation.h"
+#include "foundation-auto.h"
+#include "foundation-unicode.h"
+#include "foundation-system.h"
+
+#include <limits>
+
+static_assert(sizeof(hash_t) == sizeof(uint32_t),
+              "Update hash tests for this hash size");
+
+/* ----------------------------------------------------------------
+ * Numeric hashes
+ * ---------------------------------------------------------------- */
+
+template <typename T>
+T random_pos_int()
+{
+    return std::numeric_limits<T>::max() * MCSRandomReal();
+}
+
+TEST(hash, integer)
+{
+    auto t_uinteger = random_pos_int<uinteger_t>();
+    EXPECT_EQ(MCHashUInteger(0), {0});
+    EXPECT_EQ(MCHashUInteger(1), 2654435761U);
+    EXPECT_NE(MCHashUInteger(t_uinteger), MCHashUInteger(0));
+
+    auto t_integer = random_pos_int<integer_t>();
+    EXPECT_EQ(MCHashInteger(t_integer), MCHashUInteger(t_integer));
+    EXPECT_EQ(MCHashInteger(-t_integer), MCHashInteger(t_integer));
+    EXPECT_EQ(MCHashInteger(INT_MIN), MCHashUInteger(uinteger_t(INT_MAX) + 1));
+
+    EXPECT_EQ(MCHashUSize(t_uinteger), MCHashUInteger(t_uinteger));
+
+    auto t_usize =
+        (random_pos_int<size_t>() & ~size_t(UINT_MAX)) | size_t(t_uinteger);
+    if (sizeof(t_usize) != sizeof(t_uinteger))
+        EXPECT_NE(MCHashUSize(t_usize), MCHashUInteger(t_uinteger));
+
+    auto t_ssize = random_pos_int<ssize_t>();
+    EXPECT_EQ(MCHashSize(t_ssize), MCHashUSize(t_ssize));
+    EXPECT_EQ(MCHashSize(-t_ssize), MCHashSize(t_ssize));
+    EXPECT_EQ(MCHashSize(SSIZE_MIN), MCHashUSize(size_t(SSIZE_MAX) + 1));
+}
+
+TEST(hash, floating_point)
+{
+    EXPECT_EQ(MCHashDouble(0), MCHashUInteger(0));
+
+    auto t_uinteger = random_pos_int<uinteger_t>();
+    double t_intpart = t_uinteger;    EXPECT_EQ(MCHashDouble(t_intpart), MCHashUInteger(t_uinteger));
+    EXPECT_EQ(MCHashDouble(-t_intpart), MCHashUInteger(t_uinteger));
+
+    auto t_fraction = MCSRandomReal();
+    EXPECT_NE(MCHashDouble(t_fraction), MCHashUInteger(0));
+    EXPECT_EQ(MCHashDouble(t_fraction), MCHashDouble(-t_fraction));
+
+    auto t_double = t_fraction + t_intpart;
+    EXPECT_NE(MCHashDouble(t_double), MCHashDouble(t_intpart));
+    EXPECT_NE(MCHashDouble(t_double), MCHashDouble(t_fraction));
+    EXPECT_EQ(MCHashDouble(-t_double), MCHashDouble(t_double));
+}
+
+TEST(hash, pointer)
+{
+    EXPECT_EQ(MCHashPointer(nullptr), MCHashUInteger(0));
+
+    bool t_target = false;
+    EXPECT_NE(MCHashPointer(&t_target), MCHashPointer(nullptr));
+}
+
+/* ----------------------------------------------------------------
+ * Blob hashes
+ * ---------------------------------------------------------------- */
+
+TEST(hash, bytes)
+{
+    const char k_zeros[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0};
+    const char k_order[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+    EXPECT_EQ(MCHashBytes(k_zeros, sizeof(k_zeros)), {0});
+    EXPECT_EQ(MCHashBytes(k_order, sizeof(k_order)), {107654892});
+    /* Check that hashing isn't length-dependent */
+    EXPECT_NE(MCHashBytes(k_order, sizeof(k_order) / 2),
+              MCHashBytes(k_order, sizeof(k_order)));
+
+    auto t_random_bytes_hash = [](hash_t& h) -> hash_t {
+        MCAutoDataRef t_bytes;
+        if (!MCSRandomData(256, &t_bytes))
+            return false;
+        h = MCHashBytes(MCDataGetBytePtr(*t_bytes),
+                        MCDataGetLength(*t_bytes));
+        return true;
+    };
+    hash_t t_left, t_right;
+    ASSERT_TRUE(t_random_bytes_hash(t_left) && t_random_bytes_hash(t_right));
+    EXPECT_NE(t_left, t_right);
+}
+
+/* ----------------------------------------------------------------
+ * String hashes
+ * ---------------------------------------------------------------- */
+
+hash_t string_hash_exact(MCStringRef s)
+{
+    return MCStringHash(s, kMCStringOptionCompareExact);
+}
+
+hash_t string_hash_caseless(MCStringRef s)
+{
+    return MCStringHash(s, kMCStringOptionCompareCaseless);
+}
+
+template<size_t N>
+MCAutoStringRef string_create_utf8(const char (&utf8)[N])
+{
+    MCAutoStringRef s;
+    MCStringCreateWithBytes(reinterpret_cast<const byte_t*>(&utf8),
+                            N-1, kMCStringEncodingUTF8, false, &s);
+    return s;
+}
+
+TEST(hash, native_string)
+{
+    MCAutoStringRef t_mixed = string_create_utf8(u8"LiveCode");
+    MCAutoStringRef t_lower = string_create_utf8(u8"livecode");
+
+    /* Check a couple of specific values */
+    EXPECT_EQ(string_hash_exact(kMCEmptyString), {2166136261});
+    EXPECT_EQ(string_hash_exact(*t_mixed), {2613309534});
+
+    /* Check folded vs non-folded */
+    EXPECT_NE(string_hash_exact(*t_mixed), string_hash_exact(*t_lower));
+    EXPECT_EQ(string_hash_caseless(*t_mixed),  string_hash_caseless(*t_lower));
+}
+
+TEST(hash, unicode_string)
+{
+    MCAutoStringRef t_cat =         string_create_utf8(u8"\U0001F63A");
+    MCAutoStringRef t_private_use = string_create_utf8(u8"\U0000F63A");
+    MCAutoStringRef t_unibyte =     string_create_utf8(u8"\U0000003A");
+    MCAutoStringRef t_lambda =      string_create_utf8(u8"\U000003BB");
+
+    MCAutoStringRef t_bmp_mixed =
+        string_create_utf8(u8"\u039a\u03b1\u03bb\u03b7\u03bc\u03ad\u03c1\u03b1");
+    MCAutoStringRef t_bmp_lower =
+        string_create_utf8(u8"\u03ba\u03b1\u03bb\u03b7\u03bc\u03ad\u03c1\u03b1");
+
+    MCAutoStringRef t_nonbmp_mixed =
+        string_create_utf8(u8"\U0001F984 Friendship is Magic!");
+    MCAutoStringRef t_nonbmp_lower =
+        string_create_utf8(u8"\U0001F984 friendship is magic!");
+
+    /* Check a specific value */
+    EXPECT_EQ(string_hash_exact(*t_lambda), {2244387611});
+
+    /* Check that upper bytes of codepoints are included in hash */
+    EXPECT_NE(string_hash_exact(*t_private_use), string_hash_exact(*t_unibyte));
+    EXPECT_NE(string_hash_exact(*t_cat), string_hash_exact(*t_private_use));
+
+    /* Check folded vs non-folded */
+    EXPECT_NE(string_hash_exact(*t_bmp_mixed),
+              string_hash_exact(*t_bmp_lower));
+    EXPECT_EQ(string_hash_caseless(*t_bmp_mixed),
+              string_hash_caseless(*t_bmp_lower));
+    EXPECT_NE(string_hash_exact(*t_nonbmp_mixed),
+              string_hash_exact(*t_nonbmp_lower));
+    EXPECT_EQ(string_hash_caseless(*t_nonbmp_mixed),
+              string_hash_caseless(*t_nonbmp_mixed));
+}

--- a/libfoundation/test/test_string.cpp
+++ b/libfoundation/test/test_string.cpp
@@ -147,7 +147,8 @@ static void check_bidi_of_surrogate_range(int p_lower, int p_upper)
 		ASSERT_TRUE(t_pua_chars.Resize(t_size * 2));
     for(int i = 0; i < t_size; i++)
     {
-        MCUnicodeCodepointToSurrogates(i + p_lower, t_pua_chars.Ptr() + i * 2);
+        MCUnicodeCodepointToSurrogates(i + p_lower,
+                                       t_pua_chars[i*2], t_pua_chars[i*2 + 1]);
     }
 
 		MCAutoArray<uint8_t> t_props;


### PR DESCRIPTION
Adapted from #5100. This patch:

- allows Unicode codepoint conversion to/from surrogate pairs to be inlined
- refactors the libfoundation hash functions to make them more easily reusable by putting inlinable implementations in two new private headers
- adds plenty of tests
- fixes a bug where the upper 16 bits of a non-BMP Unicode codepoint were not included in the hash
