### PR TITLE
[Bug 19352] Fix crash when getting the urlResponse

### DIFF
--- a/docs/notes/bugfix-19352.md
+++ b/docs/notes/bugfix-19352.md
@@ -1,0 +1,1 @@
+# Fix crash when getting the urlResponse

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -791,7 +791,7 @@ void MCNetworkGetUrlResponse(MCExecContext& ctxt, MCStringRef& r_value)
 {
 	// MW-2008-08-12: Add access to the MCurlresult internal global variable
 	//   this is set by libURL after doing DELETE, POST, PUT or GET type queries.
-	r_value = (MCStringRef)MCValueRetain(MCurlresult -> getvalueref());
+    ctxt.ConvertToString(MCurlresult -> getvalueref(), r_value);
 }
 
 void MCNetworkGetFtpProxy(MCExecContext& ctxt, MCStringRef& r_value)


### PR DESCRIPTION
Force-fetching `MCurlresult -> getvalueref()` as a MCStringRef caused random memory access and then a crash.