### PR TITLE
Clean up several build warnings

### DIFF
--- a/engine/src/bitmapeffectblur.cpp
+++ b/engine/src/bitmapeffectblur.cpp
@@ -795,9 +795,6 @@ void MCBitmapEffectBoxBlur::Process(uint8_t *mask)
 			t_top = MCU_max(-t_pass->radius, t_pass->top - y); // min offset from kernel midpoint
 			t_bottom = MCU_min(t_pass->bottom - y - 1, t_pass->radius); // max offset from kernel midpoint
 
-			int32_t t_vcount;
-			t_vcount = t_bottom - t_top + 1;
-
 			t_pass->buffer_needrow = t_bottom + y ;
 
 			CalculateRows(t_pass_index);

--- a/engine/src/customprinter.cpp
+++ b/engine/src/customprinter.cpp
@@ -115,22 +115,6 @@ static MCCustomPrinterTransform MCCustomPrinterTransformFromMCGAffineTransform(c
 	return t_transform;
 }
 
-static MCCustomPrinterImageType MCCustomPrinterImageTypeFromMCGRasterFormat(MCGRasterFormat p_format)
-{
-	switch (p_format)
-	{
-	case kMCGRasterFormat_ARGB:
-		return kMCCustomPrinterImageRawARGB;
-	case kMCGRasterFormat_xRGB:
-		return kMCCustomPrinterImageRawXRGB;
-	case kMCGRasterFormat_A:
-	case kMCGRasterFormat_U_ARGB:
-    default:
-		// Unsupported
-        MCUnreachableReturn(kMCCustomPrinterImageNone);
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCCustomPrinterImageFromMCGImage(MCGImageRef p_image, MCCustomPrinterImage &r_image, void *&r_pixel_cache)

--- a/engine/src/graphicscontext.cpp
+++ b/engine/src/graphicscontext.cpp
@@ -1350,12 +1350,6 @@ void MCGraphicsContext::drawimage(const MCImageDescriptor& p_image, int2 sx, int
     else
         t_scale_x = t_scale_y = 1.0;
     
-    MCGFloat t_stop, t_sleft, t_sright, t_sbottom;
-    t_sleft = t_src_center . origin . x;
-    t_stop = t_src_center . origin . y;
-    t_sright = t_src_center . origin . x + t_src_center . size . width;
-    t_sbottom = t_src_center . origin . y + t_src_center . size . height;
-    
     MCGFloat t_top, t_left, t_right, t_bottom;
     t_left = MCMax(0.0f, t_src_center . origin . x);
     t_top = MCMax(0.0f, t_src_center . origin . y);

--- a/engine/src/internal_development.cpp
+++ b/engine/src/internal_development.cpp
@@ -562,9 +562,6 @@ void MCInternalObjectListenerGetListeners(MCExecContext& ctxt, MCStringRef*& r_l
     MCObjectHandle t_current_object;
 	t_current_object = ctxt . GetObject() -> GetHandle();
 	
-	MCObjectListener *t_prev_listener;
-	t_prev_listener = nil;
-	
 	MCObjectListener *t_listener;
 	t_listener = s_object_listeners;
     
@@ -575,8 +572,6 @@ void MCInternalObjectListenerGetListeners(MCExecContext& ctxt, MCStringRef*& r_l
 
         MCObjectListenerTarget *t_target;
         t_target = nil;
-        MCObjectListenerTarget *t_prev_target;
-        t_prev_target = nil;
         
         if (t_listener -> object . IsValid())
         {
@@ -593,7 +588,6 @@ void MCInternalObjectListenerGetListeners(MCExecContext& ctxt, MCStringRef*& r_l
             }
         }
         
-        t_prev_listener = t_listener;
         t_listener = t_listener -> next;
 	}
     t_listeners . Take(r_listeners, r_count);

--- a/engine/src/internal_development.cpp
+++ b/engine/src/internal_development.cpp
@@ -738,8 +738,6 @@ public:
             return;
         }
 		
-		MCObjectListener *t_prev_listener;
-		t_prev_listener = nil;
 		MCObjectListener *t_listener;
 		t_listener = nil;
 		
@@ -750,15 +748,12 @@ public:
 		{
 			if (t_listener -> object == t_object_handle)
 				break;
-			t_prev_listener = t_listener;
 		}
 		
 		if (t_listener != nil)
 		{
 			MCObjectListenerTarget *t_target;
 			t_target = nil;
-			MCObjectListenerTarget *t_prev_target;
-			t_prev_target = nil;
 			
 			MCObjectHandle t_target_object;
             t_target_object = ctxt . GetObjectHandle();
@@ -773,7 +768,6 @@ public:
                     t_changed = true;
                     break;
 				}
-				t_prev_target = t_target;
 			}
             
             if (t_changed)

--- a/engine/src/internal_development.cpp
+++ b/engine/src/internal_development.cpp
@@ -457,9 +457,6 @@ void MCInternalObjectListenerMessagePendingListeners(void)
         
 		MCobjectpropertieschanged = False;
 		
-		MCObjectListener *t_prev_listener;
-		t_prev_listener = nil;
-		
 		MCObjectListener *t_listener;
 		t_listener = s_object_listeners;
 		while(t_listener != nil)
@@ -479,8 +476,6 @@ void MCInternalObjectListenerMessagePendingListeners(void)
 					t_listener -> object -> getstringprop(ctxt, 0, P_LONG_ID, False, &t_string);
 					MCObjectListenerTarget *t_target;
 					t_target = nil;
-					MCObjectListenerTarget *t_prev_target;
-					t_prev_target = nil;	
 					
 					double t_new_time;
 					t_new_time = MCS_time();
@@ -543,15 +538,12 @@ void MCInternalObjectListenerMessagePendingListeners(void)
                                 t_changed = true;
                             }
 								
-                            t_prev_target = t_target;
 							t_target = t_target -> next;
 						}
 					}
 					else
 						t_listener -> object -> signallistenerswithmessage(t_properties_changed);
 				}
-				
-				t_prev_listener = t_listener;
 			}
 			
             t_listener = t_listener -> next;

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -57,7 +57,9 @@ bool MCForeignValueCreate(MCTypeInfoRef p_typeinfo, void *p_contents, MCForeignV
     t_resolved_typeinfo = __MCTypeInfoResolve(p_typeinfo);
     
     __MCForeignValue *t_value;
-    if (!__MCValueCreate(kMCValueTypeCodeForeignValue, sizeof(__MCForeignValue) + t_resolved_typeinfo -> foreign . descriptor . size, (__MCValue*&)t_value))
+    if (!__MCValueCreateExtended(kMCValueTypeCodeForeignValue,
+                                 t_resolved_typeinfo -> foreign . descriptor . size,
+                                 t_value))
         return false;
     
     if (!t_resolved_typeinfo -> foreign . descriptor . copy(p_contents, t_value + 1))
@@ -82,7 +84,9 @@ bool MCForeignValueCreateAndRelease(MCTypeInfoRef p_typeinfo, void *p_contents, 
     t_resolved_typeinfo = __MCTypeInfoResolve(p_typeinfo);
     
     __MCForeignValue *t_value;
-    if (!__MCValueCreate(kMCValueTypeCodeForeignValue, sizeof(__MCForeignValue) + t_resolved_typeinfo -> foreign . descriptor . size, (__MCValue*&)t_value))
+    if (!__MCValueCreateExtended(kMCValueTypeCodeForeignValue,
+                                 t_resolved_typeinfo -> foreign . descriptor . size,
+                                 t_value))
         return false;
     
     if (!t_resolved_typeinfo -> foreign . descriptor . move(p_contents, t_value + 1))
@@ -107,7 +111,9 @@ bool MCForeignValueExport(MCTypeInfoRef p_typeinfo, MCValueRef p_value, MCForeig
     t_resolved_typeinfo = __MCTypeInfoResolve(p_typeinfo);
     
     __MCForeignValue *t_value;
-    if (!__MCValueCreate(kMCValueTypeCodeForeignValue, sizeof(__MCForeignValue) + t_resolved_typeinfo -> foreign . descriptor . size, (__MCValue*&)t_value))
+    if (!__MCValueCreateExtended(kMCValueTypeCodeForeignValue,
+                                 t_resolved_typeinfo -> foreign . descriptor . size,
+                                 t_value))
         return false;
 
     if (t_resolved_typeinfo->foreign.descriptor.doexport == nil ||

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -33,7 +33,10 @@ bool MCHandlerCreate(MCTypeInfoRef p_typeinfo, const MCHandlerCallbacks *p_callb
     // start of this is a field 'context' in the struct so we must adjust for its
     // length.
     __MCHandler *self;
-    if (!__MCValueCreate(kMCValueTypeCodeHandler, (sizeof(__MCHandler) - sizeof(self -> context)) + p_callbacks -> size, (__MCValue*&)self))
+    if (!__MCValueCreateExtended(kMCValueTypeCodeHandler,
+         /* prevent overflow */  MCMin(p_callbacks -> size - sizeof(self->context),
+                                       p_callbacks -> size),
+                                 self))
         return false;
     
     MCMemoryCopy(MCHandlerGetContext(self), p_context, p_callbacks -> size);

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -316,7 +316,7 @@ bool initialise_jvm()
     init_jvm_args(&vm_args);
     
     JavaVMOption* options = new (nothrow) JavaVMOption[1];
-    options[0].optionString = "-Djava.class.path=/usr/lib/java";
+    options[0].optionString = const_cast<char*>("-Djava.class.path=/usr/lib/java");
     
     vm_args.nOptions = 1;
     vm_args.options = options;

--- a/libfoundation/src/foundation-java-private.h
+++ b/libfoundation/src/foundation-java-private.h
@@ -36,7 +36,7 @@ typedef struct
 }
 java_type_map;
 
-static java_type_map type_map[] =
+static const java_type_map type_map[] =
 {
     {"V", kMCJavaTypeVoid},
     {"Z", kMCJavaTypeBoolean},

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -445,6 +445,7 @@ extern const uindex_t __kMCValueHashTableSizes[];
 extern const uindex_t __kMCValueHashTableCapacities[];
 
 bool __MCValueCreate(MCValueTypeCode type_code, size_t size, __MCValue*& r_value);
+
 void __MCValueDestroy(__MCValue *value);
 
 bool __MCValueImmutableCopy(__MCValue *value, bool release, __MCValue*& r_new_value);
@@ -460,6 +461,20 @@ template<class T> inline bool __MCValueCreate(MCValueTypeCode p_type_code, T*& r
 	if (__MCValueCreate(p_type_code, sizeof(T), t_value))
 		return r_value = (T *)t_value, true;
 	return false;
+}
+
+/* Allocate a value ref structure that has enough space to hold an
+ * instance of ValueType, possibly with some extra space tacked on the
+ * end. */
+template <typename ValueType>
+inline bool __MCValueCreateExtended(MCValueTypeCode p_type_code,
+                                    size_t p_extra_space,
+                                    ValueType*& r_value)
+{
+    __MCValue* t_new = nullptr;
+    if (__MCValueCreate(p_type_code, sizeof(ValueType) + p_extra_space, t_new))
+        return r_value = static_cast<ValueType*>(t_new), r_value != nullptr;
+    return false;
 }
 
 //////////

--- a/libfoundation/src/foundation-stream.cpp
+++ b/libfoundation/src/foundation-stream.cpp
@@ -118,9 +118,14 @@ static bool __MCMemoryInputStreamTell(MCStreamRef p_stream, filepos_t& r_positio
 
 static bool __MCMemoryInputStreamSeek(MCStreamRef p_stream, filepos_t p_position)
 {
+    /* This type is large enough to hold both the maximum value of
+     * filepos_t and the maximum value of a size_t. */
+    using file_size_t = decltype(filepos_t{} + size_t{});
+
 	__MCMemoryInputStream *self;
 	self = (__MCMemoryInputStream *)MCStreamGetExtraBytesPtr(p_stream);
-	if (p_position < 0 || p_position > self -> length)
+	if (p_position < 0
+        || /*NARROWING*/file_size_t(p_position) > self -> length)
 		return false;
 	self -> pointer = (size_t)p_position;
 	return true;


### PR DESCRIPTION
This doesn't fix any bugs, but it does add a more ergonomic API for allocating value refs with extra space.