### PR TITLE
[[ Bug 19313 ]] Set fdata paragraphs' parent while saving

### DIFF
--- a/docs/notes/bugfix-19313.md
+++ b/docs/notes/bugfix-19313.md
@@ -1,0 +1,1 @@
+# Fix crash when saving field with fdata

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -3683,7 +3683,7 @@ IO_stat MCButton::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_
 	{
 		do
 		{
-			if ((stat = tptr->save(stream, OT_BDATA, p_part, p_version)) != IO_NORMAL)
+			if ((stat = tptr->save(stream, OT_BDATA, p_part, nil, p_version)) != IO_NORMAL)
 				return stat;
 			tptr = (MCCdata *)tptr->next();
 		}

--- a/engine/src/cdata.cpp
+++ b/engine/src/cdata.cpp
@@ -191,16 +191,13 @@ IO_stat MCCdata::save(IO_handle stream, Object_type type, uint4 p_part, MCObject
 		}
 		else
 		{
-            // Ensure field's saved MCCdata paragraphs have a parent
-            if (p_parent != nil)
-                MCAssert(p_parent -> gettype() == CT_FIELD);
-            
 			MCParagraph *tptr = (MCParagraph *)data;
 			if (tptr != NULL)
 				do
 				{
+                    // Ensure field's saved MCCdata paragraphs have a parent when needed
                     if (p_parent != nil)
-                        tptr -> setparent(static_cast<MCField *>(p_parent));
+                        tptr -> setparent(MCObjectCast<MCField>(p_parent));
 					if ((stat = tptr->save(stream, p_part, p_version)) != IO_NORMAL)
 						return stat;
 					tptr = (MCParagraph *)tptr->next();

--- a/engine/src/cdata.cpp
+++ b/engine/src/cdata.cpp
@@ -164,7 +164,7 @@ IO_stat MCCdata::load(IO_handle stream, MCObject *parent, uint32_t version)
 	return IO_NORMAL;
 }
 
-IO_stat MCCdata::save(IO_handle stream, Object_type type, uint4 p_part, uint32_t p_version)
+IO_stat MCCdata::save(IO_handle stream, Object_type type, uint4 p_part, MCObject *p_parent, uint32_t p_version)
 {
 	IO_stat stat;
 
@@ -191,10 +191,16 @@ IO_stat MCCdata::save(IO_handle stream, Object_type type, uint4 p_part, uint32_t
 		}
 		else
 		{
+            // Ensure field's saved MCCdata paragraphs have a parent
+            if (p_parent != nil)
+                MCAssert(p_parent -> gettype() == CT_FIELD);
+            
 			MCParagraph *tptr = (MCParagraph *)data;
 			if (tptr != NULL)
 				do
 				{
+                    if (p_parent != nil)
+                        tptr -> setparent(static_cast<MCField *>(p_parent));
 					if ((stat = tptr->save(stream, p_part, p_version)) != IO_NORMAL)
 						return stat;
 					tptr = (MCParagraph *)tptr->next();

--- a/engine/src/cdata.h
+++ b/engine/src/cdata.h
@@ -35,7 +35,7 @@ public:
 	MCCdata(const MCCdata &fref, MCField* p_new_owner);
 	~MCCdata();
 	IO_stat load(IO_handle stream, MCObject *parent, uint32_t version);
-	IO_stat save(IO_handle stream, Object_type type, uint4 p_part, uint32_t p_version);
+	IO_stat save(IO_handle stream, Object_type type, uint4 p_part, MCObject *parent, uint32_t p_version);
 	uint4 getid();
 	void setid(uint4 newid);
 	MCParagraph *getparagraphs();

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -2634,7 +2634,7 @@ IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t
 			MCCdata *tptr;
 			tptr = getcarddata(fdata, 0, False);
 			if (tptr != NULL)
-				if ((stat = tptr -> save(stream, OT_FDATA, 0, p_version)) != IO_NORMAL)
+				if ((stat = tptr -> save(stream, OT_FDATA, 0, this, p_version)) != IO_NORMAL)
 					return stat;
 		}
 		else
@@ -2642,7 +2642,7 @@ IO_stat MCField::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t
 			MCCdata *tptr = fdata;
 			do
 			{
-				if ((stat = tptr->save(stream, OT_FDATA, p_part, p_version)) != IO_NORMAL)
+				if ((stat = tptr->save(stream, OT_FDATA, p_part, this, p_version)) != IO_NORMAL)
 					return stat;
 				tptr = tptr->next();
 			}


### PR DESCRIPTION
If a field on a cloned card or stack is unopened, its fdata
paragraphs may never be assigned a parent. Set the parent before
saving, so that parent font atts can be accessed and preventing
a crash.