### PR TITLE
[Bug 19349] Fix relayer object to numbered layer

### DIFF
--- a/docs/notes/bugfix-19349.md
+++ b/docs/notes/bugfix-19349.md
@@ -1,0 +1,1 @@
+# Fix relayering by layer number

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1778,6 +1778,7 @@ Exec_stat MCCard::relayer(MCControl *optr, uint2 newlayer)
                     }
                     break;
                 }
+                t_insert_iter = t_insert_iter->next();
             }
             while (t_insert_iter != objptrs);
         }


### PR DESCRIPTION
In #5026, the relayering logic was modified to fix a possible
memory leak.  Unfortunately the list iteration was
implemented incorrectly, so relayering didn't work if the
target object for relayering wasn't the top object in the card.

Coverity-ID: 16369