### PR TITLE
[Bug 19318] Fix loading custom props from pre-7.0 stack files

### DIFF
--- a/docs/notes/bugfix-19318.md
+++ b/docs/notes/bugfix-19318.md
@@ -1,0 +1,1 @@
+# Fix loading custom properties from pre-7.0 stack formats

--- a/engine/src/objectpropsets.h
+++ b/engine/src/objectpropsets.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2017 LiveCode Ltd.
 
 This file is part of LiveCode.
 
@@ -107,6 +107,9 @@ private:
     /* Always returns a valid array, even if m_props isn't set.  The
      * returned array is _not_ owned by the caller */
     MCArrayRef fetch_nocopy() const;
+    /* Returns the contents array, creating it if necessary.  If
+     * creation fails, returns an unset array reference. */
+    MCAutoArrayRef fetch_ensure();
 
 	MCObjectPropertySet *m_next;
 	MCNewAutoNameRef m_name;


### PR DESCRIPTION
When loading legacy custom properties, they should be _added_ to the
current contents of the custom property set instead of replacing it.

This patch adds a new private `fetch_ensure()` method that returns the
internal array of the object property set, populating it with a new
empty array if necessary.