### PR TITLE
[Bug 19424] Fix getting 'the securityPermissions'

### DIFF
--- a/docs/notes/bugfix-19424.md
+++ b/docs/notes/bugfix-19424.md
@@ -1,0 +1,1 @@
+# Make sure getting `the securityPermissions` returns the expected result

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1732,7 +1732,7 @@ void MCEngineGetSecurityCategories(MCExecContext& ctxt, intset_t& r_value)
 
 void MCEngineGetSecurityPermissions(MCExecContext& ctxt, intset_t& r_value)
 {
-	r_value = MCsecuremode;
+	r_value = ~MCsecuremode;
 }
 
 void MCEngineSetSecurityPermissions(MCExecContext& ctxt, intset_t p_value)

--- a/tests/lcs/core/engine/globalproperties.livecodescript
+++ b/tests/lcs/core/engine/globalproperties.livecodescript
@@ -25,3 +25,11 @@ on TestSetReadOnlyProperty
 	TestAssertThrow "setting read-only global property throws", \
 		 "_TestSetReadOnlyProperty", the long id of me, kCantSetPropertyCode
 end TestSetReadOnlyProperty
+
+on TestGetSetSecurityPermissions
+   TestAssert "Getting default securityPermissions", the securityPermissions is the securityCategories
+   local tNewPermissions
+   put "disk,network" into tNewPermissions
+   set the securityPermissions to tNewPermissions
+   TestAssert "Getting new securityPermissions correctly", the securityPermissions is tNewPermissions
+end TestGetSetSecurityPermissions


### PR DESCRIPTION
Fix error when refactoring from LC 6 -> 7, that resulted in `the securityPermissions` returning the opposite value.