### PR TITLE
libfoundation: Missing pieces from hash func unification

### DIFF
--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -197,4 +197,21 @@ MCSpan<ElementType> MCDataGetSpan(MCDataRef p_data)
 	return MCMakeSpan(t_ptr, t_length);
 }
 
+/* ----------------------------------------------------------------
+ * Span-based overloads for pointer+range libfoundation functions
+ * ---------------------------------------------------------------- */
+
+MC_DLLEXPORT
+hash_t MCHashBytes(MCSpan<const byte_t> bytes);
+
+MC_DLLEXPORT
+hash_t MCHashBytesStream(hash_t previous,
+                         MCSpan<const byte_t> bytes);
+
+MC_DLLEXPORT
+hash_t MCHashNativeChars(MCSpan<const char_t> chars);
+
+MC_DLLEXPORT
+hash_t MCHashChars(MCSpan<const unichar_t> chars);
+
 #endif /* !__MC_FOUNDATION_SPAN_H__ */

--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -214,4 +214,24 @@ hash_t MCHashNativeChars(MCSpan<const char_t> chars);
 MC_DLLEXPORT
 hash_t MCHashChars(MCSpan<const unichar_t> chars);
 
+template <typename ElementType>
+inline hash_t MCHashSpan(MCSpan<ElementType> p_span)
+{
+    /* TODO[C++11] Enable this assertion once all our C++ compilers support it. */
+    /* static_assert(std::is_trivially_copyable<ElementType>::value,
+           "MCHashObjectSpan can only be used with trivially copyable types"); */
+    return MCHashBytes(p_span.data(), p_span.sizeBytes());
+}
+
+template <typename ElementType>
+inline hash_t MCHashSpanStream(hash_t p_previous,
+                               MCSpan<ElementType> p_span)
+{
+    /* TODO[C++11] Enable this assertion once all our C++ compilers support it. */
+    /* static_assert(std::is_trivially_copyable<ElementType>::value,
+           "MCHashObjectSpanStream can only be used with trivially copyable types"); */
+    return MCHashBytesStream(p_previous,
+                             p_span.data(), p_span.sizeBytes());
+}
+
 #endif /* !__MC_FOUNDATION_SPAN_H__ */

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -19,6 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "foundation-private.h"
 #include "foundation-hash.h"
+#include "foundation-string-hash.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -265,6 +266,26 @@ hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t length)
     MCHashBytesContext t_context(p_start);
     t_context.consume(reinterpret_cast<const byte_t *>(p_bytes), length);
     return t_context;
+}
+
+template <typename CodeUnit>
+static hash_t hash_chars(CodeUnit *p_chars, size_t char_count)
+{
+    MCHashCharsContext t_context;
+    while (char_count-- > 0) t_context.consume(*p_chars++);
+    return t_context;
+}
+
+MC_DLLEXPORT_DEF
+hash_t MCHashNativeChars(const char_t *chars, size_t char_count)
+{
+    return hash_chars(chars, char_count);
+}
+
+MC_DLLEXPORT_DEF
+hash_t MCHashChars(const unichar_t *chars, size_t char_count)
+{
+    return hash_chars(chars, char_count);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -267,6 +267,4 @@ hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t length)
     return t_context;
 }
 
-#undef ELF_STEP
-
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <foundation.h>
+#include <foundation-auto.h>
 #include <foundation-stdlib.h>
 
 #include "foundation-private.h"
@@ -261,11 +262,23 @@ hash_t MCHashBytes(const void *p_bytes, size_t length)
 }
 
 MC_DLLEXPORT_DEF
+hash_t MCHashBytes(MCSpan<const byte_t> p_bytes)
+{
+    return MCHashBytes(p_bytes.data(), p_bytes.size());
+}
+
+MC_DLLEXPORT_DEF
 hash_t MCHashBytesStream(hash_t p_start, const void *p_bytes, size_t length)
 {
     MCHashBytesContext t_context(p_start);
     t_context.consume(reinterpret_cast<const byte_t *>(p_bytes), length);
     return t_context;
+}
+
+MC_DLLEXPORT_DEF
+hash_t MCHashBytesStream(hash_t p_start, MCSpan<const byte_t> p_bytes)
+{
+    return MCHashBytesStream(p_start, p_bytes.data(), p_bytes.size());
 }
 
 template <typename CodeUnit>
@@ -283,9 +296,21 @@ hash_t MCHashNativeChars(const char_t *chars, size_t char_count)
 }
 
 MC_DLLEXPORT_DEF
+hash_t MCHashNativeChars(MCSpan<const char_t> p_chars)
+{
+    return hash_chars(p_chars.data(), p_chars.size());
+}
+
+MC_DLLEXPORT
 hash_t MCHashChars(const unichar_t *chars, size_t char_count)
 {
     return hash_chars(chars, char_count);
+}
+
+MC_DLLEXPORT_DEF
+hash_t MCHashChars(MCSpan<const unichar_t> p_chars)
+{
+    return hash_chars(p_chars.data(), p_chars.size());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-hash.h
+++ b/libfoundation/src/foundation-hash.h
@@ -128,4 +128,47 @@ public:
     }
 };
 
+/* ----------------------------------------------------------------
+ * Object representation hashing
+ * ---------------------------------------------------------------- */
+
+/* These functions are compatible with `MCHashBytes()` and
+ * `MCHashBytesStream()`, and are used when it's desirable to hash a
+ * single value's C++ object representation.  They are only enabled
+ * for TriviallyCopyable types, i.e. types where the value
+ * representation is a subset of the object representation. */
+
+template <typename T>
+inline hash_t MCHashObject(T p_object)
+{
+    /* TODO[C++11] Enable this assertion once all our C++ compilers support it. */
+    /* static_assert(std::is_trivially_copyable<T>::value,
+           "MCHashObject can only be used with trivially copyable types"); */
+    return MCHashBytes(reinterpret_cast<const void*>(&p_object),
+                       sizeof(p_object));
+}
+
+template <typename T>
+inline hash_t MCHashObjectStream(hash_t p_start,
+                                 T p_object)
+{
+    /* TODO[C++11] Enable this assertion once all our C++ compilers support it. */
+    /* static_assert(std::is_trivially_copyable<T>::value,
+           "MCHashObjectStream can only be used with trivially copyable types"); */
+    return MCHashBytesStream(p_start,
+                             reinterpret_cast<const void*>(&p_object),
+                             sizeof(p_object));
+}
+
+/* Hash multiple objects of possibly-differing types into a hash
+ * stream. */
+template <typename Head, typename... Tail>
+inline hash_t MCHashObjectStream(hash_t p_start,
+                                 Head p_object,
+                                 Tail ... p_others)
+{
+    return MCHashObjectStream(MCHashObjectStream(p_start, p_object),
+                              p_others ...);
+}
+
 #endif /*!MC_FOUNDATION_HASH_H*/

--- a/libfoundation/src/foundation-record.cpp
+++ b/libfoundation/src/foundation-record.cpp
@@ -17,6 +17,7 @@
 #include <foundation.h>
 
 #include "foundation-private.h"
+#include "foundation-hash.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -362,15 +363,11 @@ hash_t __MCRecordHash(__MCRecord *self)
     hash_t t_hash;
     t_hash = 0;
 
-	hash_t t_typeinfo_hash;
-	t_typeinfo_hash = MCHashPointer(self -> typeinfo);
-	t_hash = MCHashBytesStream(t_hash, &t_typeinfo_hash, sizeof(hash_t));
+	t_hash = MCHashObjectStream(t_hash, MCHashPointer(self->typeinfo));
 
     for(uindex_t i = 0; i < __MCRecordTypeInfoGetFieldCount(t_resolved_typeinfo); i++)
     {
-        hash_t t_element_hash;
-        t_element_hash = MCValueHash(self -> fields[i]);
-        t_hash = MCHashBytesStream(t_hash, &t_element_hash, sizeof(hash_t));
+        t_hash = MCHashObjectStream(t_hash, MCValueHash(self -> fields[i]));
     }
     return t_hash;
 }

--- a/libfoundation/test/test_hash.cpp
+++ b/libfoundation/test/test_hash.cpp
@@ -93,21 +93,20 @@ TEST(hash, pointer)
 
 TEST(hash, bytes)
 {
-    const char k_zeros[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0};
-    const char k_order[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    const byte_t k_zeros[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0};
+    const byte_t k_order[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
-    EXPECT_EQ(MCHashBytes(k_zeros, sizeof(k_zeros)), {0});
-    EXPECT_EQ(MCHashBytes(k_order, sizeof(k_order)), {107654892});
+    EXPECT_EQ(MCHashBytes(k_zeros), {0});
+    EXPECT_EQ(MCHashBytes(k_order), {107654892});
     /* Check that hashing isn't length-dependent */
     EXPECT_NE(MCHashBytes(k_order, sizeof(k_order) / 2),
-              MCHashBytes(k_order, sizeof(k_order)));
+              MCHashBytes(k_order));
 
     auto t_random_bytes_hash = [](hash_t& h) -> hash_t {
         MCAutoDataRef t_bytes;
         if (!MCSRandomData(256, &t_bytes))
             return false;
-        h = MCHashBytes(MCDataGetBytePtr(*t_bytes),
-                        MCDataGetLength(*t_bytes));
+        h = MCHashBytes(MCDataGetSpan<const byte_t>(*t_bytes));
         return true;
     };
     hash_t t_left, t_right;


### PR DESCRIPTION
This PR adds some missing pieces from #5278.

- Clean up some leftover dead code
- Actually implement `MCHashNativeChars()` and `MCHashChars()`
- Add span-based overloads of hash functions

This also adds new `MCHashObject<T>()` and `MCHashObjectStream<T...>()` templates which tidy up pretty much every use of `MCHashBytesStream()` in libfoundation.