### PR TITLE
[[ Bug 19335 ]] Add sized integer types to LCB

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -430,31 +430,47 @@ statement blocks.
     ForeignHandlerDefinition
       : 'foreign' 'handler' <Name: Identifier> '(' [ ParameterList ] ')' [ 'returns' <ReturnType: Type> ) ] 'binds' 'to' <Binding: String>
 
-    ForeignType
-      : Type
-      | 'CBool'
-      | 'CInt'
-      | 'CUInt'
-      | 'CFloat'
-      | 'CDouble'
-
 A foreign handler definition binds an identifier to a handler defined in
 foreign code.
 
-Foreign handler definitions can contain more types in their parameters
-than elsewhere - those specified in the ForeignType clause. These allow
-low-level types to be specified making it easier to interoperate.
+There are a number of types defined in the foreign module which map to
+the appropriate foreign type when used in foreign handler signatures.
 
-Foreign types map to high-level types as follows:
+There are the standard C primitive types:
 
- - bool maps to boolean
- - int and uint map to integer (number)
- - float and double map to real (number)
+ - CBool maps to 'bool'
+ - CChar and CUChar map to 'char' and 'unsigned char'
+ - CShort and CUShort map to 'short' and 'unsigned short'
+ - CInt and CUInt map to 'int' and 'unsigned int'
+ - CLong and CULong map to 'long' and 'unsigned long'
+ - CLongLong and CULongLong map to 'long long' and 'unsigned long long'
+ - CFloat maps to 'float'
+ - CDouble maps to 'double'
 
-This mapping means that a foreign handler with a bool parameter say,
-will accept a boolean from LiveCode Builder code when called.
+There are the standard sized integer types:
 
-At present, only C and Java binding is allowed and follow these rules:
+ - Int8 and UInt8 map to 8-bit integers
+ - Int16 and UInt16 map to 16-bit integers
+ - Int32 and UInt32 map to 32-bit integers
+ - Int64 and UInt64 map to 64-bit integers
+ - IntSize and UIntSize map to the integer size needed to hold a memory size
+ - IntPtr and UIntPtr map to the integer size needed to hold a pointer
+
+There are aliases for the Java primitive types:
+
+ - JBoolean maps to CBool
+ - JByte maps to Int8
+ - JShort maps to Int16
+ - JInt maps to Int32
+ - JLong maps to Int64
+
+All the primitive types above will implicitly convert between corresponding
+high level types:
+
+  - CBool converts to and from Boolean
+  - All integer and real types convert to and from Number
+
+Other LCB types pass as follows into foreign handlers:
 
  - any type passes an MCValueRef
  - nothing type passes as the null pointer
@@ -466,12 +482,11 @@ At present, only C and Java binding is allowed and follow these rules:
  - Data type passes an MCDataRef
  - Array type passes an MCArrayRef
  - List type passes an MCProperListRef
- - Pointer type passes a void *
- - CBool type passes a bool (i.e. an int - pre-C99).
- - CInt type passes an int
- - CUInt type passes an unsigned int
- - CFloat type passes a float
- - CDouble type passes a double
+
+Finally, the Pointer type passes as void * to foreign handlers. If you want
+a pointer which can be null, then use optional Pointer - LCB will throw an
+error if there is an attempt to map from the null pointer value to a slot
+with a non-optional Pointer type.
 
 Modes map as follows:
 

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -436,39 +436,40 @@ foreign code.
 There are a number of types defined in the foreign module which map to
 the appropriate foreign type when used in foreign handler signatures.
 
+There are the standard machine types:
+
+ - Bool maps to an 8-bit boolean
+ - Int8/SInt8 and UInt8 map to 8-bit integers
+ - Int16/SInt16 and UInt16 map to 16-bit integers
+ - Int32/SInt32 and UInt32 map to 32-bit integers
+ - Int64/SInt64 and UInt64 map to 64-bit integers
+ - IntSize/SIntSize and UIntSize map to the integer size needed to hold a memory size
+ - IntPtr/SIntPtr and UIntPtr map to the integer size needed to hold a pointer
+
 There are the standard C primitive types:
 
  - CBool maps to 'bool'
- - CChar and CUChar map to 'char' and 'unsigned char'
- - CShort and CUShort map to 'short' and 'unsigned short'
- - CInt and CUInt map to 'int' and 'unsigned int'
- - CLong and CULong map to 'long' and 'unsigned long'
- - CLongLong and CULongLong map to 'long long' and 'unsigned long long'
+ - CChar, CSChar and CUChar map to 'char', 'signed char' and 'unsigned char'
+ - CShort/CSShort and CUShort map to 'signed short' and 'unsigned short'
+ - CInt/CSInt and CUInt map to 'signed int' and 'unsigned int'
+ - CLong/CSLong and CULong map to 'signed long' and 'unsigned long'
+ - CLongLong/CSLongLong and CULongLong map to 'signed long long' and 'unsigned long long'
  - CFloat maps to 'float'
  - CDouble maps to 'double'
 
-There are the standard sized integer types:
-
- - Int8 and UInt8 map to 8-bit integers
- - Int16 and UInt16 map to 16-bit integers
- - Int32 and UInt32 map to 32-bit integers
- - Int64 and UInt64 map to 64-bit integers
- - IntSize and UIntSize map to the integer size needed to hold a memory size
- - IntPtr and UIntPtr map to the integer size needed to hold a pointer
-
 There are aliases for the Java primitive types:
 
- - JBoolean maps to CBool
+ - JBoolean maps to Bool
  - JByte maps to Int8
  - JShort maps to Int16
  - JInt maps to Int32
  - JLong maps to Int64
 
-All the primitive types above will implicitly convert between corresponding
+All the primitive types above will implicitly bridge between corresponding
 high level types:
 
-  - CBool converts to and from Boolean
-  - All integer and real types convert to and from Number
+  - CBool and Bool bridge to and from Boolean
+  - All integer and real types bridge to and from Number
 
 Other LCB types pass as follows into foreign handlers:
 

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -464,6 +464,8 @@ There are aliases for the Java primitive types:
  - JShort maps to Int16
  - JInt maps to Int32
  - JLong maps to Int64
+ - JFloat maps to Float32
+ - JDouble maps to Float64
 
 All the primitive types above will implicitly bridge between corresponding
 high level types:

--- a/docs/lcb/notes/feature-sized_ints.md
+++ b/docs/lcb/notes/feature-sized_ints.md
@@ -12,6 +12,6 @@ version: 9.0.0-dp-7
   CUInt, CSLong, CULong, CSLongLong and CULongLong have been added.
   These all map to their corresponding C counterparts.
 
-* The Java integer primtive types JByte, JShort, JInt, JLong,
+* The Java integer primtive types JBoolean, JByte, JShort, JInt, JLong,
   JFloat and JDouble have been added. These map to int8_t,
   int16_t, int32_t, int64_t, float and double.

--- a/docs/lcb/notes/feature-sized_ints.md
+++ b/docs/lcb/notes/feature-sized_ints.md
@@ -4,12 +4,12 @@ version: 9.0.0-dp-7
 # LiveCode Builder Standard Library
 ## Foreign function interface
 
-* The foreign sized integer types Int8, UInt8, Int16, UInt16,
-  Int32, UInt32, Int64 and UInt64 have been added. These all map
-  to their corresponding foreign counterparts.
+* The machine types Bool, SIntSize, UIntSize, SIntPtr, UIntPtr, SInt8, UInt8,
+  SInt16, UInt16, SInt32, UInt32, SInt64 and UInt64 have been added. These all
+  map to their corresponding foreign counterparts.
 
-* The C integer types CChar, CUChar, CShort, CUShort, CInt,
-  CUInt, CLong, CULong, CLongLong and CULongLong have been added.
+* The C types CBool, CChar, CSChar, CUChar, CSShort, CUShort, CSInt,
+  CUInt, CSLong, CULong, CSLongLong and CULongLong have been added.
   These all map to their corresponding C counterparts.
 
 * The Java integer primtive types JByte, JShort, JInt, JLong,

--- a/docs/lcb/notes/feature-sized_ints.md
+++ b/docs/lcb/notes/feature-sized_ints.md
@@ -1,0 +1,17 @@
+---
+version: 9.0.0-dp-7
+---
+# LiveCode Builder Standard Library
+## Foreign function interface
+
+* The foreign sized integer types Int8, UInt8, Int16, UInt16,
+  Int32, UInt32, Int64 and UInt64 have been added. These all map
+  to their corresponding foreign counterparts.
+
+* The C integer types CChar, CUChar, CShort, CUShort, CInt,
+  CUInt, CLong, CULong, CLongLong and CULongLong have been added.
+  These all map to their corresponding C counterparts.
+
+* The Java integer primtive types JByte, JShort, JInt, JLong,
+  JFloat and JDouble have been added. These map to int8_t,
+  int16_t, int32_t, int64_t, float and double.

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1281,6 +1281,9 @@ extern "C" {
 //   the same from version to version. In particular, never serialize a hash
 //   value - recompute on unserialization of the object.
 
+// Return a hash for the given bool.
+MC_DLLEXPORT hash_t MCHashBool(bool);
+
 // Return a hash for the given integer.
 MC_DLLEXPORT hash_t MCHashInteger(integer_t);
 MC_DLLEXPORT hash_t MCHashUInteger(uinteger_t);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1544,24 +1544,47 @@ MC_DLLEXPORT MCTypeInfoRef MCListTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT MCTypeInfoRef MCProperListTypeInfo(void) ATTRIBUTE_PURE;
 
 MC_DLLEXPORT extern MCTypeInfoRef kMCBoolTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCIntTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCUIntTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignBoolTypeInfo(void) ATTRIBUTE_PURE;
+
 MC_DLLEXPORT extern MCTypeInfoRef kMCFloatTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCDoubleTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCPointerTypeInfo;
-
-MC_DLLEXPORT MCTypeInfoRef MCForeignBoolTypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignUIntTypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignIntTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT MCTypeInfoRef MCForeignFloatTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT MCTypeInfoRef MCForeignDoubleTypeInfo(void) ATTRIBUTE_PURE;
+
+MC_DLLEXPORT extern MCTypeInfoRef kMCPointerTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignPointerTypeInfo(void) ATTRIBUTE_PURE;
+
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt8TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCInt8TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt16TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCInt16TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt32TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCInt32TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt64TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCInt64TypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt8TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignInt8TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt16TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignInt16TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt32TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignInt32TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt64TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignInt64TypeInfo(void) ATTRIBUTE_PURE;
 
 MC_DLLEXPORT extern MCTypeInfoRef kMCSizeTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCSSizeTypeInfo;
-
 MC_DLLEXPORT MCTypeInfoRef MCForeignSizeTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT MCTypeInfoRef MCForeignSSizeTypeInfo(void) ATTRIBUTE_PURE;
+
+MC_DLLEXPORT extern MCTypeInfoRef kMCCULongTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCLongTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCULongTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCLongTypeInfo(void) ATTRIBUTE_PURE;
+
+MC_DLLEXPORT extern MCTypeInfoRef kMCUIntTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCIntTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUIntTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignIntTypeInfo(void) ATTRIBUTE_PURE;
 
 //////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1546,6 +1546,23 @@ MC_DLLEXPORT MCTypeInfoRef MCProperListTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT extern MCTypeInfoRef kMCBoolTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignBoolTypeInfo(void) ATTRIBUTE_PURE;
 
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt8TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSInt8TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt16TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSInt16TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt32TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSInt32TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUInt64TypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSInt64TypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt8TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSInt8TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt16TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSInt16TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt32TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSInt32TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUInt64TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSInt64TypeInfo(void) ATTRIBUTE_PURE;
+
 MC_DLLEXPORT extern MCTypeInfoRef kMCFloatTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCDoubleTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignFloatTypeInfo(void) ATTRIBUTE_PURE;
@@ -1554,37 +1571,46 @@ MC_DLLEXPORT MCTypeInfoRef MCForeignDoubleTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT extern MCTypeInfoRef kMCPointerTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignPointerTypeInfo(void) ATTRIBUTE_PURE;
 
-MC_DLLEXPORT extern MCTypeInfoRef kMCUInt8TypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCInt8TypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCUInt16TypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCInt16TypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCUInt32TypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCInt32TypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCUInt64TypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCInt64TypeInfo;
-MC_DLLEXPORT MCTypeInfoRef MCForeignUInt8TypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignInt8TypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignUInt16TypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignInt16TypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignUInt32TypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignInt32TypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignUInt64TypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignInt64TypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUIntSizeTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSIntSizeTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUIntSizeTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSIntSizeTypeInfo(void) ATTRIBUTE_PURE;
 
-MC_DLLEXPORT extern MCTypeInfoRef kMCSizeTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCSSizeTypeInfo;
-MC_DLLEXPORT MCTypeInfoRef MCForeignSizeTypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignSSizeTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT extern MCTypeInfoRef kMCUIntPtrTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSIntPtrTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignUIntPtrTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSIntPtrTypeInfo(void) ATTRIBUTE_PURE;
 
+MC_DLLEXPORT extern MCTypeInfoRef kMCCBoolTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCBoolTypeInfo(void) ATTRIBUTE_PURE;
+
+MC_DLLEXPORT extern MCTypeInfoRef kMCCCharTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCUCharTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCSCharTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCUShortTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCSShortTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCUIntTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCSIntTypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCCULongTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCCLongTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCSLongTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCULongLongTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCCSLongLongTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCCharTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCUCharTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCSCharTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCUShortTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCSShortTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCUIntTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCSIntTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT MCTypeInfoRef MCForeignCULongTypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignCLongTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCSLongTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCULongLongTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignCSLongLongTypeInfo(void) ATTRIBUTE_PURE;
 
 MC_DLLEXPORT extern MCTypeInfoRef kMCUIntTypeInfo;
-MC_DLLEXPORT extern MCTypeInfoRef kMCIntTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCSIntTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignUIntTypeInfo(void) ATTRIBUTE_PURE;
-MC_DLLEXPORT MCTypeInfoRef MCForeignIntTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignSIntTypeInfo(void) ATTRIBUTE_PURE;
 
 //////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1289,6 +1289,8 @@ MC_DLLEXPORT hash_t MCHashInteger(integer_t);
 MC_DLLEXPORT hash_t MCHashUInteger(uinteger_t);
 MC_DLLEXPORT hash_t MCHashSize(ssize_t);
 MC_DLLEXPORT hash_t MCHashUSize(size_t);
+MC_DLLEXPORT hash_t MCHashInt64(int64_t);
+MC_DLLEXPORT hash_t MCHashUInt64(uint64_t);
 
 // Return a hash value for the given double - note that (hopefully!) hashing
 // an integer stored as a double will be the same as hashing the integer.

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2987,6 +2987,9 @@ MC_DLLEXPORT bool MCErrorThrowGenericWithMessage(MCStringRef message, ...);
 //  FOREIGN DEFINITIONS
 //
 
+MC_DLLEXPORT extern MCTypeInfoRef kMCForeignImportErrorTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCForeignExportErrorTypeInfo;
+
 MC_DLLEXPORT bool MCForeignValueCreate(MCTypeInfoRef typeinfo, void *contents, MCForeignValueRef& r_value);
 MC_DLLEXPORT bool MCForeignValueCreateAndRelease(MCTypeInfoRef typeinfo, void *contents, MCForeignValueRef& r_value);
 

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -9,6 +9,7 @@
 		'module_test_sources':
 		[
 			'test/environment.cpp',
+            'test/test_foreign.cpp',
 			'test/test_hash.cpp',
 			'test/test_string.cpp',
 			'test/test_typeconvert.cpp',

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -239,12 +239,25 @@ MCHashSize (ssize_t i)
 	return MCHashInt(i);
 }
 
+MC_DLLEXPORT_DEF
 hash_t
 MCHashUSize (size_t i)
 {
 	return MCHashInt(i);
 }
 
+MC_DLLEXPORT_DEF
+hash_t
+MCHashInt64(int64_t i)
+{
+	return MCHashInt(i);
+}
+
+hash_t
+MCHashUInt64(uint64_t i)
+{
+	return MCHashInt(i);
+}
 MC_DLLEXPORT_DEF
 hash_t MCHashPointer(const void *p)
 {

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -214,6 +214,12 @@ void MCMemoryDeleteArray(void *p_array)
 ////////////////////////////////////////////////////////////////////////////////
 
 MC_DLLEXPORT_DEF
+hash_t MCHashBool(bool b)
+{
+    return hash_t(b);
+}
+
+MC_DLLEXPORT_DEF
 hash_t MCHashInteger(integer_t i)
 {
 	return MCHashInt(i);

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -173,8 +173,7 @@ struct clong_type_desc_t: public integral_type_desc_t<long> {
          kMCForeignPrimitiveTypeSInt64 :
          kMCForeignPrimitiveTypeSInt32);
     static constexpr auto& type_info = kMCCLongTypeInfo;
-    static constexpr auto describe_format = "<foreign long integer %li>";
-    static constexpr auto& hash_func = MCHashInteger;
+    static constexpr auto describe_format = "<foreign long integer %ld>";
 };
 
 struct uint_type_desc_t: public integral_type_desc_t<uinteger_t> {
@@ -189,7 +188,7 @@ struct int_type_desc_t: public integral_type_desc_t<integer_t> {
                   "Unsupported size for integer_t");
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt32;
     static constexpr auto& type_info = kMCIntTypeInfo;
-    static constexpr auto describe_format = "<foreign integer %i>";
+    static constexpr auto describe_format = "<foreign integer %d>";
     static constexpr auto& hash_func = MCHashInteger;
 };
 struct size_type_desc_t: public integral_type_desc_t<size_t>  {
@@ -201,7 +200,6 @@ struct size_type_desc_t: public integral_type_desc_t<size_t>  {
          kMCForeignPrimitiveTypeUInt32);
     static constexpr auto& type_info = kMCSizeTypeInfo;
     static constexpr auto describe_format = "<foreign size %zu>";
-    static constexpr auto& hash_func = MCHashUSize;
 };
 struct ssize_type_desc_t: public integral_type_desc_t<ssize_t>  {
     static_assert(SSIZE_MAX == INT64_MAX || SSIZE_MAX == INT32_MAX,
@@ -212,21 +210,20 @@ struct ssize_type_desc_t: public integral_type_desc_t<ssize_t>  {
          kMCForeignPrimitiveTypeSInt32);
     static constexpr auto& type_info = kMCSSizeTypeInfo;
     static constexpr auto describe_format = "<foreign signed size %zd>";
-    static constexpr auto& hash_func = MCHashSize;
 };
 
 struct float_type_desc_t: public numeric_type_desc_t<float> {
     using c_type = float;
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeFloat32;
     static constexpr auto& type_info = kMCFloatTypeInfo;
-    static constexpr auto describe_format = "<foreign float %g>";
+    static constexpr auto describe_format = "<foreign float %lg>";
     static constexpr auto& hash_func = MCHashDouble;
 };
 struct double_type_desc_t: public numeric_type_desc_t<double> {
     using c_type = double;
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeFloat64;
     static constexpr auto& type_info = kMCDoubleTypeInfo;
-    static constexpr auto describe_format = "<foreign double %g>";
+    static constexpr auto describe_format = "<foreign double %lg>";
     static constexpr auto& hash_func = MCHashDouble;
 };
 
@@ -241,8 +238,8 @@ struct pointer_type_desc_t {
     static constexpr auto& hash_func = MCHashPointer;
 };
 
-MCTypeInfoRef kMCForeignImportErrorTypeInfo;
-MCTypeInfoRef kMCForeignExportErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCForeignImportErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCForeignExportErrorTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -622,7 +619,7 @@ struct DoImport<
         }
         else
         {
-            return __throw_numeric_overflow<IntType>(kMCForeignExportErrorTypeInfo);
+            return __throw_numeric_overflow<IntType>(kMCForeignImportErrorTypeInfo);
         }
     }
 };
@@ -644,7 +641,7 @@ struct DoImport<
         }
         else
         {
-            return __throw_numeric_overflow<UIntType>(kMCForeignExportErrorTypeInfo);
+            return __throw_numeric_overflow<UIntType>(kMCForeignImportErrorTypeInfo);
         }
     }
 };

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -34,6 +34,15 @@ MC_DLLEXPORT_DEF MCTypeInfoRef kMCPointerTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCSizeTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCSSizeTypeInfo;
 
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt8TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt8TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt16TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt16TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt32TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt32TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt64TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt64TypeInfo;
+
 struct bool_type_desc_t {
     using c_type = bool;
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeBool;
@@ -59,6 +68,47 @@ struct numeric_type_desc_t {
 template<typename CType>
 struct integral_type_desc_t: public numeric_type_desc_t<CType> {
     static constexpr auto& hash_func = MCHashInt<CType>;
+};
+
+struct uint8_type_desc_t: public integral_type_desc_t<uint8_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt8;
+    static constexpr auto& type_info = kMCUInt8TypeInfo;
+    static constexpr auto describe_format = "<foreign 8-bit unsigned integer %u>";
+};
+struct int8_type_desc_t: public integral_type_desc_t<int8_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt8;
+    static constexpr auto& type_info = kMCInt8TypeInfo;
+    static constexpr auto describe_format = "<foreign 8-bit integer %d>";
+};
+struct uint16_type_desc_t: public integral_type_desc_t<uint16_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt16;
+    static constexpr auto& type_info = kMCUInt16TypeInfo;
+    static constexpr auto describe_format = "<foreign 16-bit unsigned integer %u>";
+};
+struct int16_type_desc_t: public integral_type_desc_t<int16_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt16;
+    static constexpr auto& type_info = kMCInt16TypeInfo;
+    static constexpr auto describe_format = "<foreign 16-bit integer %d>";
+};
+struct uint32_type_desc_t: public integral_type_desc_t<uint32_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt32;
+    static constexpr auto& type_info = kMCUInt32TypeInfo;
+    static constexpr auto describe_format = "<foreign 32-bit unsigned integer %u>";
+};
+struct int32_type_desc_t: public integral_type_desc_t<int32_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt32;
+    static constexpr auto& type_info = kMCInt32TypeInfo;
+    static constexpr auto describe_format = "<foreign 32-bit integer %d>";
+};
+struct uint64_type_desc_t: public integral_type_desc_t<uint64_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt64;
+    static constexpr auto& type_info = kMCUInt64TypeInfo;
+    static constexpr auto describe_format = "<foreign 64-bit unsigned integer %u>";
+};
+struct int64_type_desc_t: public integral_type_desc_t<int64_t> {
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt64;
+    static constexpr auto& type_info = kMCInt64TypeInfo;
+    static constexpr auto describe_format = "<foreign 64-bit integer %d>";
 };
 
 struct uint_type_desc_t: public integral_type_desc_t<uinteger_t> {
@@ -651,7 +701,15 @@ bool __MCForeignValueInitialize(void)
           DescriptorBuilder<double_type_desc_t>::create("__builtin__.double") &&
           DescriptorBuilder<pointer_type_desc_t>::create("__builtin__.pointer") &&
           DescriptorBuilder<size_type_desc_t>::create("__builtin__.size") &&
-          DescriptorBuilder<ssize_type_desc_t>::create("__builtin__ssize")))
+          DescriptorBuilder<ssize_type_desc_t>::create("__builtin__ssize") &&
+          DescriptorBuilder<uint8_type_desc_t>::create("__builtin__.uint8") &&
+          DescriptorBuilder<int8_type_desc_t>::create("__builtin__.int8") &&
+          DescriptorBuilder<uint16_type_desc_t>::create("__builtin__.uint16") &&
+          DescriptorBuilder<int16_type_desc_t>::create("__builtin__.int16") &&
+          DescriptorBuilder<uint32_type_desc_t>::create("__builtin__.uint32") &&
+          DescriptorBuilder<int32_type_desc_t>::create("__builtin__.int32") &&
+          DescriptorBuilder<uint64_type_desc_t>::create("__builtin__.uint64") &&
+          DescriptorBuilder<int64_type_desc_t>::create("__builtin__.int64")))
         return false;
 
     /* ---------- */

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -166,7 +166,7 @@ struct culong_type_desc_t: public integral_type_desc_t<unsigned long> {
     static constexpr auto describe_format = "<foreign unsigned long integer %lu>";
 };
 struct clong_type_desc_t: public integral_type_desc_t<long> {
-    static_assert(LONG_MAX == INT32_MAX || LONG_MAX == UINT64_MAX,
+    static_assert(LONG_MAX == INT32_MAX || LONG_MAX == INT64_MAX,
                   "Unsupported size for long");
     static constexpr auto primitive_type = 
         ((LONG_MAX == INT64_MAX) ?

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -25,67 +25,189 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// The C bool type
+/* Machine Types
+ *
+ * These types are what may be considered 'independent of any language'.
+ */
+
+/* The fundamental bool type - this is considered to be 1 byte in size. */
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCBoolTypeInfo;
 
-// The C float type
+/* The fundamental sized integer types */
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt8TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSInt8TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt16TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSInt16TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt32TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSInt32TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt64TypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSInt64TypeInfo;
+
+/* The fundamental binary floating-point types. */
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCFloatTypeInfo;
-// The C double type
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCDoubleTypeInfo;
 
-// The C void * type (with enforced non-nullptr check).
+/* The size_t and ssize_t types which are architecture / platform dependent. */
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUIntSizeTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSIntSizeTypeInfo;
+
+/* The uintptr_t and intptr_t types which are architecture / platform
+ * dependent. */
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCUIntPtrTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSIntPtrTypeInfo;
+
+/* The fundamental unmanaged pointer type (equivalent to void * in C). This
+ * uses the initialize and defined members of a foreign value description to 
+ * provide an element of safety against nullptr vs non-nullptr. */
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCPointerTypeInfo;
 
-// The standard sized integer types
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt8TypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt8TypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt16TypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt16TypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt32TypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt32TypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCUInt64TypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCInt64TypeInfo;
+/* C Types
+ *
+ * These types represent the C types which are relative to the compiler,
+ * platform and architecture the engine is compiled against. We have a distinct
+ * type for CBool as (in theory) it could be any length, and not just a byte.
+ */
 
-// The size_t and ssize_t types which are architecture / platform dependent
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCSizeTypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCSSizeTypeInfo;
-
-// The C unsigned long / long types which are architecture / platform dependent
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCBoolTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCCharTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCUCharTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCSCharTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCUShortTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCSShortTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCUIntTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCSIntTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCULongTypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCCLongTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCSLongTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCULongLongTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCSLongLongTypeInfo;
 
 // The uinteger_t and integer_t types, which are engine dependent
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCUIntTypeInfo;
-MC_DLLEXPORT_DEF MCTypeInfoRef kMCIntTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCSIntTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignBoolTypeInfo() { return kMCBoolTypeInfo; }
+
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt8TypeInfo() { return kMCUInt8TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSInt8TypeInfo() { return kMCSInt8TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt16TypeInfo() { return kMCUInt16TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSInt16TypeInfo() { return kMCSInt16TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt32TypeInfo() { return kMCUInt32TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSInt32TypeInfo() { return kMCSInt32TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt64TypeInfo() { return kMCUInt64TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSInt64TypeInfo() { return kMCSInt64TypeInfo; }
 
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignFloatTypeInfo() { return kMCFloatTypeInfo; }
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignDoubleTypeInfo() { return kMCDoubleTypeInfo; }
 
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignPointerTypeInfo() { return kMCPointerTypeInfo; }
 
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt8TypeInfo() { return kMCUInt8TypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignInt8TypeInfo() { return kMCInt8TypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt16TypeInfo() { return kMCUInt16TypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignInt16TypeInfo() { return kMCInt16TypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt32TypeInfo() { return kMCUInt32TypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignInt32TypeInfo() { return kMCInt32TypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUInt64TypeInfo() { return kMCUInt64TypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignInt64TypeInfo() { return kMCInt64TypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUIntSizeTypeInfo() { return kMCUIntSizeTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSIntSizeTypeInfo() { return kMCSIntSizeTypeInfo; }
 
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSizeTypeInfo() { return kMCSizeTypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSSizeTypeInfo() { return kMCSSizeTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUIntPtrTypeInfo() { return kMCUIntPtrTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSIntPtrTypeInfo() { return kMCSIntPtrTypeInfo; }
 
+/**/
+
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCBoolTypeInfo() { return kMCCBoolTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCCharTypeInfo() { return kMCCSCharTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCUCharTypeInfo() { return kMCCUCharTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSCharTypeInfo() { return kMCCSCharTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCUShortTypeInfo() { return kMCCUShortTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSShortTypeInfo() { return kMCCSShortTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCUIntTypeInfo() { return kMCCUIntTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSIntTypeInfo() { return kMCCSIntTypeInfo; }
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongTypeInfo() { return kMCCULongTypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCLongTypeInfo() { return kMCCLongTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongTypeInfo() { return kMCCSLongTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongLongTypeInfo() { return kMCCULongTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongLongTypeInfo() { return kMCCSLongTypeInfo; }
+
+/**/
 
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignUIntTypeInfo() { return kMCUIntTypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignIntTypeInfo() { return kMCIntTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSIntTypeInfo() { return kMCSIntTypeInfo; }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+template<typename CType>
+constexpr MCForeignPrimitiveType __compute_signed_primitive_type()
+{
+    static_assert(sizeof(CType) != 1 || sizeof(CType) != 2 ||
+                  sizeof(CType) != 4 || sizeof(CType) != 8,
+                  "Unsupported signed integer size");
+    return sizeof(CType) == 1 ? kMCForeignPrimitiveTypeSInt8 :
+            sizeof(CType) == 2 ? kMCForeignPrimitiveTypeSInt16 :
+            sizeof(CType) == 4 ? kMCForeignPrimitiveTypeSInt32 :
+            sizeof(CType) == 8 ? kMCForeignPrimitiveTypeSInt64 :
+            kMCForeignPrimitiveTypeVoid;
+};
+
+template<typename CType>
+constexpr MCForeignPrimitiveType __compute_unsigned_primitive_type()
+{
+    static_assert(sizeof(CType) != 1 || sizeof(CType) != 2 ||
+                  sizeof(CType) != 4 || sizeof(CType) != 8,
+                  "Unsupported unsigned integer size");
+    return sizeof(CType) == 1 ? kMCForeignPrimitiveTypeUInt8 :
+            sizeof(CType) == 2 ? kMCForeignPrimitiveTypeUInt16 :
+            sizeof(CType) == 4 ? kMCForeignPrimitiveTypeUInt32 :
+            sizeof(CType) == 8 ? kMCForeignPrimitiveTypeUInt64 :
+            kMCForeignPrimitiveTypeVoid;
+};
+
+template<typename CType> constexpr MCForeignPrimitiveType
+__compute_primitive_type(void)
+{
+    static_assert(sizeof(CType) == 0, "No mapping from CType to primitive type");
+    return kMCForeignPrimitiveTypeVoid;
+}
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<char>(void) { return __compute_signed_primitive_type<char>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<signed char>(void) { return __compute_signed_primitive_type<signed char>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<unsigned char>(void) { return __compute_unsigned_primitive_type<unsigned char>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<short>(void) { return __compute_signed_primitive_type<short>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<unsigned short>(void) { return __compute_unsigned_primitive_type<unsigned short>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<int>(void) { return __compute_unsigned_primitive_type<int>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<unsigned int>(void) { return __compute_unsigned_primitive_type<unsigned int>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<long>(void) { return __compute_unsigned_primitive_type<long>();; }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<unsigned long>(void) { return __compute_unsigned_primitive_type<unsigned long>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<long long>(void) { return __compute_unsigned_primitive_type<long long>(); }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<unsigned long long>(void) { return __compute_unsigned_primitive_type<unsigned long long>(); }
+
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<float>(void) { return kMCForeignPrimitiveTypeFloat32; }
+template<> constexpr MCForeignPrimitiveType
+__compute_primitive_type<double>(void) { return kMCForeignPrimitiveTypeFloat64; }
+
+template<typename CType>
+struct numeric_type_desc_t {
+    using c_type = CType;
+    static constexpr auto primitive_type = __compute_primitive_type<CType>();
+    static constexpr auto& base_type_info = kMCNullTypeInfo;
+    static constexpr auto is_optional = false;
+    static constexpr auto is_bridgable = true;
+    using bridge_type = MCNumberRef;
+    static constexpr auto& bridge_type_info = kMCNumberTypeInfo;
+};
+
+template<typename CType>
+struct integral_type_desc_t: public numeric_type_desc_t<CType> {
+    static constexpr auto& hash_func = MCHashInt<CType>;
+};
+
+/**/
 
 struct bool_type_desc_t {
     using c_type = bool;
@@ -99,117 +221,37 @@ struct bool_type_desc_t {
     static constexpr auto& hash_func = MCHashBool;
 };
 
-template<typename CType>
-struct numeric_type_desc_t {
-    using c_type = CType;
-    static constexpr auto& base_type_info = kMCNullTypeInfo;
-    static constexpr auto is_optional = false;
-    static constexpr auto is_bridgable = true;
-    using bridge_type = MCNumberRef;
-    static constexpr auto& bridge_type_info = kMCNumberTypeInfo;
-};
-
-template<typename CType>
-struct integral_type_desc_t: public numeric_type_desc_t<CType> {
-    static constexpr auto& hash_func = MCHashInt<CType>;
-};
-
 struct uint8_type_desc_t: public integral_type_desc_t<uint8_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt8;
     static constexpr auto& type_info = kMCUInt8TypeInfo;
     static constexpr auto describe_format = "<foreign 8-bit unsigned integer %u>";
 };
-struct int8_type_desc_t: public integral_type_desc_t<int8_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt8;
-    static constexpr auto& type_info = kMCInt8TypeInfo;
-    static constexpr auto describe_format = "<foreign 8-bit integer %d>";
+struct sint8_type_desc_t: public integral_type_desc_t<int8_t> {
+    static constexpr auto& type_info = kMCSInt8TypeInfo;
+    static constexpr auto describe_format = "<foreign 8-bit signed integer %d>";
 };
 struct uint16_type_desc_t: public integral_type_desc_t<uint16_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt16;
     static constexpr auto& type_info = kMCUInt16TypeInfo;
     static constexpr auto describe_format = "<foreign 16-bit unsigned integer %u>";
 };
-struct int16_type_desc_t: public integral_type_desc_t<int16_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt16;
-    static constexpr auto& type_info = kMCInt16TypeInfo;
-    static constexpr auto describe_format = "<foreign 16-bit integer %d>";
+struct sint16_type_desc_t: public integral_type_desc_t<int16_t> {
+    static constexpr auto& type_info = kMCSInt16TypeInfo;
+    static constexpr auto describe_format = "<foreign 16-bit signed integer %d>";
 };
 struct uint32_type_desc_t: public integral_type_desc_t<uint32_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt32;
     static constexpr auto& type_info = kMCUInt32TypeInfo;
     static constexpr auto describe_format = "<foreign 32-bit unsigned integer %u>";
 };
-struct int32_type_desc_t: public integral_type_desc_t<int32_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt32;
-    static constexpr auto& type_info = kMCInt32TypeInfo;
-    static constexpr auto describe_format = "<foreign 32-bit integer %d>";
+struct sint32_type_desc_t: public integral_type_desc_t<int32_t> {
+    static constexpr auto& type_info = kMCSInt32TypeInfo;
+    static constexpr auto describe_format = "<foreign 32-bit signed integer %d>";
 };
 struct uint64_type_desc_t: public integral_type_desc_t<uint64_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt64;
     static constexpr auto& type_info = kMCUInt64TypeInfo;
     static constexpr auto describe_format = "<foreign 64-bit unsigned integer %llu>";
 };
-struct int64_type_desc_t: public integral_type_desc_t<int64_t> {
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt64;
-    static constexpr auto& type_info = kMCInt64TypeInfo;
-    static constexpr auto describe_format = "<foreign 64-bit integer %lld>";
-};
-
-struct culong_type_desc_t: public integral_type_desc_t<unsigned long> {
-    static_assert(ULONG_MAX == UINT32_MAX || ULONG_MAX == UINT64_MAX,
-                  "Unsupported size for long");
-    static constexpr auto primitive_type = 
-        ((ULONG_MAX == UINT64_MAX) ?
-         kMCForeignPrimitiveTypeUInt64 :
-         kMCForeignPrimitiveTypeUInt32);
-    static constexpr auto& type_info = kMCCULongTypeInfo;
-    static constexpr auto describe_format = "<foreign unsigned long integer %lu>";
-};
-struct clong_type_desc_t: public integral_type_desc_t<long> {
-    static_assert(LONG_MAX == INT32_MAX || LONG_MAX == INT64_MAX,
-                  "Unsupported size for long");
-    static constexpr auto primitive_type = 
-        ((LONG_MAX == INT64_MAX) ?
-         kMCForeignPrimitiveTypeSInt64 :
-         kMCForeignPrimitiveTypeSInt32);
-    static constexpr auto& type_info = kMCCLongTypeInfo;
-    static constexpr auto describe_format = "<foreign long integer %ld>";
-};
-
-struct uint_type_desc_t: public integral_type_desc_t<uinteger_t> {
-    static_assert(UINTEGER_MAX == UINT32_MAX,
-                  "Unsupported size for uinteger_t");
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt32;
-    static constexpr auto& type_info = kMCUIntTypeInfo;
-    static constexpr auto describe_format = "<foreign unsigned integer %u>";
-};
-struct int_type_desc_t: public integral_type_desc_t<integer_t> {
-    static_assert(INTEGER_MAX == INT32_MAX,
-                  "Unsupported size for integer_t");
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt32;
-    static constexpr auto& type_info = kMCIntTypeInfo;
-    static constexpr auto describe_format = "<foreign integer %d>";
-    static constexpr auto& hash_func = MCHashInteger;
-};
-struct size_type_desc_t: public integral_type_desc_t<size_t>  {
-    static_assert(SIZE_MAX == UINT64_MAX || SIZE_MAX == UINT32_MAX,
-                  "Unsupported size for size_t");
-    static constexpr auto primitive_type =
-        ((SIZE_MAX == UINT64_MAX) ?
-         kMCForeignPrimitiveTypeUInt64 :
-         kMCForeignPrimitiveTypeUInt32);
-    static constexpr auto& type_info = kMCSizeTypeInfo;
-    static constexpr auto describe_format = "<foreign size %zu>";
-};
-struct ssize_type_desc_t: public integral_type_desc_t<ssize_t>  {
-    static_assert(SSIZE_MAX == INT64_MAX || SSIZE_MAX == INT32_MAX,
-                  "Unsupported size for ssize_t");
-    static constexpr auto primitive_type =
-        ((SSIZE_MAX == INT64_MAX) ?
-         kMCForeignPrimitiveTypeSInt64 :
-         kMCForeignPrimitiveTypeSInt32);
-    static constexpr auto& type_info = kMCSSizeTypeInfo;
-    static constexpr auto describe_format = "<foreign signed size %zd>";
+struct sint64_type_desc_t: public integral_type_desc_t<int64_t> {
+    static constexpr auto& type_info = kMCSInt64TypeInfo;
+    static constexpr auto describe_format = "<foreign 64-bit signed integer %lld>";
 };
 
 struct float_type_desc_t: public numeric_type_desc_t<float> {
@@ -237,6 +279,92 @@ struct pointer_type_desc_t {
     static constexpr auto& base_type_info = kMCNullTypeInfo;
     static constexpr auto& hash_func = MCHashPointer;
 };
+
+struct uintsize_type_desc_t: public integral_type_desc_t<size_t>  {
+    static constexpr auto& type_info = kMCUIntSizeTypeInfo;
+    static constexpr auto describe_format = "<foreign unsigned size %zu>";
+};
+struct sintsize_type_desc_t: public integral_type_desc_t<ssize_t>  {
+    static constexpr auto& type_info = kMCSIntSizeTypeInfo;
+    static constexpr auto describe_format = "<foreign signed size %zd>";
+};
+
+struct uintptr_type_desc_t: public integral_type_desc_t<uintptr_t>  {
+    static constexpr auto& type_info = kMCUIntPtrTypeInfo;
+    static constexpr auto describe_format = "<foreign unsigned intptr %zu>";
+};
+struct sintptr_type_desc_t: public integral_type_desc_t<intptr_t>  {
+    static constexpr auto& type_info = kMCSIntPtrTypeInfo;
+    static constexpr auto describe_format = "<foreign signed intptr %zd>";
+};
+
+/**/
+
+struct cbool_type_desc_t: public bool_type_desc_t
+{
+    static constexpr auto& type_info = kMCCBoolTypeInfo;
+};
+struct cchar_type_desc_t: public integral_type_desc_t<char> {
+    static constexpr auto& type_info = kMCCCharTypeInfo;
+    static constexpr auto describe_format = "<foreign c char '%c'>";
+};
+struct cuchar_type_desc_t: public integral_type_desc_t<unsigned char> {
+    static constexpr auto& type_info = kMCCUCharTypeInfo;
+    static constexpr auto describe_format = "<foreign c unsigned char %u>";
+};
+struct cschar_type_desc_t: public integral_type_desc_t<signed char> {
+    static constexpr auto& type_info = kMCCSCharTypeInfo;
+    static constexpr auto describe_format = "<foreign c signed char %d>";
+};
+struct cushort_type_desc_t: public integral_type_desc_t<unsigned short> {
+    static constexpr auto& type_info = kMCCUShortTypeInfo;
+    static constexpr auto describe_format = "<foreign c unsigned short %u>";
+};
+struct csshort_type_desc_t: public integral_type_desc_t<signed short> {
+    static constexpr auto& type_info = kMCCSShortTypeInfo;
+    static constexpr auto describe_format = "<foreign c signed short %d>";
+};
+struct cuint_type_desc_t: public integral_type_desc_t<unsigned int> {
+    static constexpr auto& type_info = kMCCUIntTypeInfo;
+    static constexpr auto describe_format = "<foreign c unsigned int %u>";
+};
+struct csint_type_desc_t: public integral_type_desc_t<signed int> {
+    static constexpr auto& type_info = kMCCSIntTypeInfo;
+    static constexpr auto describe_format = "<foreign c signed int %d>";
+};
+struct culong_type_desc_t: public integral_type_desc_t<unsigned long> {
+    static constexpr auto& type_info = kMCCULongTypeInfo;
+    static constexpr auto describe_format = "<foreign c unsigned long %lu>";
+};
+struct cslong_type_desc_t: public integral_type_desc_t<long> {
+    static constexpr auto& type_info = kMCCSLongTypeInfo;
+    static constexpr auto describe_format = "<foreign c signed long %ld>";
+};
+struct culonglong_type_desc_t: public integral_type_desc_t<unsigned long long> {
+    static constexpr auto& type_info = kMCCULongLongTypeInfo;
+    static constexpr auto describe_format = "<foreign c unsigned long long %llu>";
+};
+struct cslonglong_type_desc_t: public integral_type_desc_t<long long> {
+    static constexpr auto& type_info = kMCCSLongLongTypeInfo;
+    static constexpr auto describe_format = "<foreign c signed long long %lld>";
+};
+
+struct uint_type_desc_t: public integral_type_desc_t<uinteger_t> {
+    static_assert(UINTEGER_MAX == UINT32_MAX,
+                  "Unsupported size for uinteger_t");
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt32;
+    static constexpr auto& type_info = kMCUIntTypeInfo;
+    static constexpr auto describe_format = "<foreign unsigned integer %u>";
+};
+struct sint_type_desc_t: public integral_type_desc_t<integer_t> {
+    static_assert(INTEGER_MAX == INT32_MAX,
+                  "Unsupported size for integer_t");
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt32;
+    static constexpr auto& type_info = kMCSIntTypeInfo;
+    static constexpr auto describe_format = "<foreign signed integer %d>";
+    static constexpr auto& hash_func = MCHashInteger;
+};
+
 
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCForeignImportErrorTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCForeignExportErrorTypeInfo;
@@ -524,7 +652,7 @@ struct Describe<bool_type_desc_t>
 {
     static bool describe(bool p_value, MCStringRef& r_string)
     {
-        return MCStringFormat(r_string, p_value ? "<foreign true>" : "<foreign false>");
+        return MCStringFormat(r_string, p_value ? "<foreign bool true>" : "<foreign bool false>");
     }
 };
 
@@ -540,6 +668,37 @@ struct DoImport<bool_type_desc_t>
 
 template <>
 struct DoExport<bool_type_desc_t>
+{
+    static bool doexport(MCValueRef p_boxed_value, bool& r_value)
+    {
+        r_value = (p_boxed_value == kMCTrue);
+        return true;
+    }
+};
+
+/* We need to specialize describe for cbool because it returns fixed
+ * strings instead of using a format string. */
+template <>
+struct Describe<cbool_type_desc_t>
+{
+    static bool describe(bool p_value, MCStringRef& r_string)
+    {
+        return MCStringFormat(r_string, p_value ? "<foreign c bool true>" : "<foreign c bool false>");
+    }
+};
+
+template <>
+struct DoImport<cbool_type_desc_t>
+{
+    static bool doimport(bool p_value, MCBooleanRef& r_boxed_value)
+    {
+        r_boxed_value = MCValueRetain(p_value ? kMCTrue : kMCFalse);
+        return true;
+    }
+};
+
+template <>
+struct DoExport<cbool_type_desc_t>
 {
     static bool doexport(MCValueRef p_boxed_value, bool& r_value)
     {
@@ -755,21 +914,33 @@ bool __MCForeignValueInitialize(void)
     if (!(DescriptorBuilder<bool_type_desc_t>::create("__builtin__.bool") &&
           DescriptorBuilder<float_type_desc_t>::create("__builtin__.float") &&
           DescriptorBuilder<double_type_desc_t>::create("__builtin__.double") &&
-          DescriptorBuilder<pointer_type_desc_t>::create("__builtin__.pointer") &&
           DescriptorBuilder<uint8_type_desc_t>::create("__builtin__.uint8") &&
-          DescriptorBuilder<int8_type_desc_t>::create("__builtin__.int8") &&
+          DescriptorBuilder<sint8_type_desc_t>::create("__builtin__.sint8") &&
           DescriptorBuilder<uint16_type_desc_t>::create("__builtin__.uint16") &&
-          DescriptorBuilder<int16_type_desc_t>::create("__builtin__.int16") &&
+          DescriptorBuilder<sint16_type_desc_t>::create("__builtin__.sint16") &&
           DescriptorBuilder<uint32_type_desc_t>::create("__builtin__.uint32") &&
-          DescriptorBuilder<int32_type_desc_t>::create("__builtin__.int32") &&
+          DescriptorBuilder<sint32_type_desc_t>::create("__builtin__.sint32") &&
           DescriptorBuilder<uint64_type_desc_t>::create("__builtin__.uint64") &&
-          DescriptorBuilder<int64_type_desc_t>::create("__builtin__.int64") &&
-          DescriptorBuilder<size_type_desc_t>::create("__builtin__.size") &&
-          DescriptorBuilder<ssize_type_desc_t>::create("__builtin__ssize") &&
+          DescriptorBuilder<sint64_type_desc_t>::create("__builtin__.sint64") &&
+          DescriptorBuilder<uintsize_type_desc_t>::create("__builtin__.uintsize") &&
+          DescriptorBuilder<sintsize_type_desc_t>::create("__builtin__.sintsize") &&
+          DescriptorBuilder<uintptr_type_desc_t>::create("__builtin__.uintptr") &&
+          DescriptorBuilder<sintptr_type_desc_t>::create("__builtin__.sintptr") &&
+          DescriptorBuilder<pointer_type_desc_t>::create("__builtin__.pointer") &&
+          DescriptorBuilder<cbool_type_desc_t>::create("__builtin__.cbool") &&
+          DescriptorBuilder<cuchar_type_desc_t>::create("__builtin__.cuchar") &&
+          DescriptorBuilder<cschar_type_desc_t>::create("__builtin__.cschar") &&
+          DescriptorBuilder<cchar_type_desc_t>::create("__builtin__.cchar") &&
+          DescriptorBuilder<cushort_type_desc_t>::create("__builtin__.cushort") &&
+          DescriptorBuilder<csshort_type_desc_t>::create("__builtin__.csshort") &&
+          DescriptorBuilder<cuint_type_desc_t>::create("__builtin__.cuint") &&
+          DescriptorBuilder<csint_type_desc_t>::create("__builtin__.csint") &&
           DescriptorBuilder<culong_type_desc_t>::create("__builtin__.culong") &&
-          DescriptorBuilder<clong_type_desc_t>::create("__builtin__.clong") &&
+          DescriptorBuilder<cslong_type_desc_t>::create("__builtin__.cslong") &&
+          DescriptorBuilder<culonglong_type_desc_t>::create("__builtin__.culonglong") &&
+          DescriptorBuilder<cslonglong_type_desc_t>::create("__builtin__.cslonglong") &&
           DescriptorBuilder<uint_type_desc_t>::create("__builtin__.uint") &&
-          DescriptorBuilder<int_type_desc_t>::create("__builtin__.int")))
+          DescriptorBuilder<sint_type_desc_t>::create("__builtin__.sint")))
         return false;
 
     /* ---------- */
@@ -785,23 +956,36 @@ bool __MCForeignValueInitialize(void)
 void __MCForeignValueFinalize(void)
 {
     MCValueRelease(kMCBoolTypeInfo);
+    MCValueRelease(kMCUInt8TypeInfo);
+    MCValueRelease(kMCSInt8TypeInfo);
+    MCValueRelease(kMCUInt16TypeInfo);
+    MCValueRelease(kMCSInt16TypeInfo);
+    MCValueRelease(kMCUInt32TypeInfo);
+    MCValueRelease(kMCSInt32TypeInfo);
+    MCValueRelease(kMCUInt64TypeInfo);
+    MCValueRelease(kMCSInt64TypeInfo);
     MCValueRelease(kMCFloatTypeInfo);
     MCValueRelease(kMCDoubleTypeInfo);
+	MCValueRelease(kMCUIntSizeTypeInfo);
+	MCValueRelease(kMCSIntSizeTypeInfo);
+	MCValueRelease(kMCUIntPtrTypeInfo);
+	MCValueRelease(kMCSIntPtrTypeInfo);
     MCValueRelease(kMCPointerTypeInfo);
-    MCValueRelease(kMCUInt8TypeInfo);
-    MCValueRelease(kMCInt8TypeInfo);
-    MCValueRelease(kMCUInt16TypeInfo);
-    MCValueRelease(kMCInt16TypeInfo);
-    MCValueRelease(kMCUInt32TypeInfo);
-    MCValueRelease(kMCInt32TypeInfo);
-    MCValueRelease(kMCUInt64TypeInfo);
-    MCValueRelease(kMCInt64TypeInfo);
-	MCValueRelease(kMCSizeTypeInfo);
-	MCValueRelease(kMCSSizeTypeInfo);
+    
+	MCValueRelease(kMCCCharTypeInfo);
+	MCValueRelease(kMCCUCharTypeInfo);
+	MCValueRelease(kMCCSCharTypeInfo);
+	MCValueRelease(kMCCUShortTypeInfo);
+	MCValueRelease(kMCCSShortTypeInfo);
+	MCValueRelease(kMCCUIntTypeInfo);
+	MCValueRelease(kMCCSIntTypeInfo);
 	MCValueRelease(kMCCULongTypeInfo);
-	MCValueRelease(kMCCLongTypeInfo);
+	MCValueRelease(kMCCSLongTypeInfo);
+	MCValueRelease(kMCCULongLongTypeInfo);
+	MCValueRelease(kMCCSLongLongTypeInfo);
+    
     MCValueRelease(kMCUIntTypeInfo);
-    MCValueRelease(kMCIntTypeInfo);
+    MCValueRelease(kMCSIntTypeInfo);
 
 	MCValueRelease (kMCForeignImportErrorTypeInfo);
 	MCValueRelease (kMCForeignExportErrorTypeInfo);

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -186,11 +186,11 @@ template<typename CType>
 struct numeric_type_desc_t {
     using c_type = CType;
     static constexpr auto primitive_type = compute_primitive_type<CType>::value;
-    static constexpr auto& base_type_info = kMCNullTypeInfo;
+    static constexpr MCTypeInfoRef& base_type_info() { return kMCNullTypeInfo; }
     static constexpr auto is_optional = false;
     static constexpr auto is_bridgable = true;
     using bridge_type = MCNumberRef;
-    static constexpr auto& bridge_type_info = kMCNumberTypeInfo;
+    static constexpr MCTypeInfoRef& bridge_type_info() { return kMCNumberTypeInfo; }
 };
 
 template<typename CType>
@@ -203,59 +203,59 @@ struct integral_type_desc_t: public numeric_type_desc_t<CType> {
 struct bool_type_desc_t {
     using c_type = bool;
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeBool;
-    static constexpr auto& base_type_info = kMCNullTypeInfo;
-    static constexpr auto& type_info = kMCBoolTypeInfo;
+    static constexpr MCTypeInfoRef& base_type_info() { return kMCNullTypeInfo; }
+    static constexpr MCTypeInfoRef& type_info() { return kMCBoolTypeInfo; }
     static constexpr auto is_optional = false;
     static constexpr auto is_bridgable = true;
     using bridge_type = MCBooleanRef;
-    static constexpr auto& bridge_type_info = kMCBooleanTypeInfo;
+    static constexpr MCTypeInfoRef& bridge_type_info() { return kMCBooleanTypeInfo; }
     static constexpr auto& hash_func = MCHashBool;
 };
 
 struct uint8_type_desc_t: public integral_type_desc_t<uint8_t> {
-    static constexpr auto& type_info = kMCUInt8TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCUInt8TypeInfo; }
     static constexpr auto describe_format = "<foreign 8-bit unsigned integer %u>";
 };
 struct sint8_type_desc_t: public integral_type_desc_t<int8_t> {
-    static constexpr auto& type_info = kMCSInt8TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCSInt8TypeInfo; }
     static constexpr auto describe_format = "<foreign 8-bit signed integer %d>";
 };
 struct uint16_type_desc_t: public integral_type_desc_t<uint16_t> {
-    static constexpr auto& type_info = kMCUInt16TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCUInt16TypeInfo; }
     static constexpr auto describe_format = "<foreign 16-bit unsigned integer %u>";
 };
 struct sint16_type_desc_t: public integral_type_desc_t<int16_t> {
-    static constexpr auto& type_info = kMCSInt16TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCSInt16TypeInfo; }
     static constexpr auto describe_format = "<foreign 16-bit signed integer %d>";
 };
 struct uint32_type_desc_t: public integral_type_desc_t<uint32_t> {
-    static constexpr auto& type_info = kMCUInt32TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCUInt32TypeInfo; }
     static constexpr auto describe_format = "<foreign 32-bit unsigned integer %u>";
 };
 struct sint32_type_desc_t: public integral_type_desc_t<int32_t> {
-    static constexpr auto& type_info = kMCSInt32TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCSInt32TypeInfo; }
     static constexpr auto describe_format = "<foreign 32-bit signed integer %d>";
 };
 struct uint64_type_desc_t: public integral_type_desc_t<uint64_t> {
-    static constexpr auto& type_info = kMCUInt64TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCUInt64TypeInfo; }
     static constexpr auto describe_format = "<foreign 64-bit unsigned integer %llu>";
 };
 struct sint64_type_desc_t: public integral_type_desc_t<int64_t> {
-    static constexpr auto& type_info = kMCSInt64TypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCSInt64TypeInfo; }
     static constexpr auto describe_format = "<foreign 64-bit signed integer %lld>";
 };
 
 struct float_type_desc_t: public numeric_type_desc_t<float> {
     using c_type = float;
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeFloat32;
-    static constexpr auto& type_info = kMCFloatTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCFloatTypeInfo; }
     static constexpr auto describe_format = "<foreign float %lg>";
     static constexpr auto& hash_func = MCHashDouble;
 };
 struct double_type_desc_t: public numeric_type_desc_t<double> {
     using c_type = double;
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeFloat64;
-    static constexpr auto& type_info = kMCDoubleTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCDoubleTypeInfo; }
     static constexpr auto describe_format = "<foreign double %lg>";
     static constexpr auto& hash_func = MCHashDouble;
 };
@@ -265,27 +265,27 @@ struct pointer_type_desc_t {
     static constexpr auto primitive_type = kMCForeignPrimitiveTypePointer;
     static constexpr auto is_optional = true;
     static constexpr auto is_bridgable = false;
-    static constexpr auto& type_info = kMCPointerTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCPointerTypeInfo; }
     static constexpr auto describe_format = "<foreign pointer %p>";
-    static constexpr auto& base_type_info = kMCNullTypeInfo;
+    static constexpr MCTypeInfoRef& base_type_info() { return kMCNullTypeInfo; }
     static constexpr auto& hash_func = MCHashPointer;
 };
 
 struct uintsize_type_desc_t: public integral_type_desc_t<size_t>  {
-    static constexpr auto& type_info = kMCUIntSizeTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCUIntSizeTypeInfo; }
     static constexpr auto describe_format = "<foreign unsigned size %zu>";
 };
 struct sintsize_type_desc_t: public integral_type_desc_t<ssize_t>  {
-    static constexpr auto& type_info = kMCSIntSizeTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCSIntSizeTypeInfo; }
     static constexpr auto describe_format = "<foreign signed size %zd>";
 };
 
 struct uintptr_type_desc_t: public integral_type_desc_t<uintptr_t>  {
-    static constexpr auto& type_info = kMCUIntPtrTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCUIntPtrTypeInfo; }
     static constexpr auto describe_format = "<foreign unsigned intptr %zu>";
 };
 struct sintptr_type_desc_t: public integral_type_desc_t<intptr_t>  {
-    static constexpr auto& type_info = kMCSIntPtrTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCSIntPtrTypeInfo; }
     static constexpr auto describe_format = "<foreign signed intptr %zd>";
 };
 
@@ -293,50 +293,50 @@ struct sintptr_type_desc_t: public integral_type_desc_t<intptr_t>  {
 
 struct cbool_type_desc_t: public bool_type_desc_t
 {
-    static constexpr auto& type_info = kMCCBoolTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCBoolTypeInfo; }
 };
 struct cchar_type_desc_t: public integral_type_desc_t<char> {
-    static constexpr auto& type_info = kMCCCharTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCCharTypeInfo; }
     static constexpr auto describe_format = "<foreign c char '%c'>";
 };
 struct cuchar_type_desc_t: public integral_type_desc_t<unsigned char> {
-    static constexpr auto& type_info = kMCCUCharTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCUCharTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned char %u>";
 };
 struct cschar_type_desc_t: public integral_type_desc_t<signed char> {
-    static constexpr auto& type_info = kMCCSCharTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCSCharTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed char %d>";
 };
 struct cushort_type_desc_t: public integral_type_desc_t<unsigned short> {
-    static constexpr auto& type_info = kMCCUShortTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCUShortTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned short %u>";
 };
 struct csshort_type_desc_t: public integral_type_desc_t<signed short> {
-    static constexpr auto& type_info = kMCCSShortTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCSShortTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed short %d>";
 };
 struct cuint_type_desc_t: public integral_type_desc_t<unsigned int> {
-    static constexpr auto& type_info = kMCCUIntTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCUIntTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned int %u>";
 };
 struct csint_type_desc_t: public integral_type_desc_t<signed int> {
-    static constexpr auto& type_info = kMCCSIntTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCSIntTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed int %d>";
 };
 struct culong_type_desc_t: public integral_type_desc_t<unsigned long> {
-    static constexpr auto& type_info = kMCCULongTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCULongTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned long %lu>";
 };
 struct cslong_type_desc_t: public integral_type_desc_t<long> {
-    static constexpr auto& type_info = kMCCSLongTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCSLongTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed long %ld>";
 };
 struct culonglong_type_desc_t: public integral_type_desc_t<unsigned long long> {
-    static constexpr auto& type_info = kMCCULongLongTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCULongLongTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned long long %llu>";
 };
 struct cslonglong_type_desc_t: public integral_type_desc_t<long long> {
-    static constexpr auto& type_info = kMCCSLongLongTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCCSLongLongTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed long long %lld>";
 };
 
@@ -344,14 +344,14 @@ struct uint_type_desc_t: public integral_type_desc_t<uinteger_t> {
     static_assert(UINTEGER_MAX == UINT32_MAX,
                   "Unsupported size for uinteger_t");
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt32;
-    static constexpr auto& type_info = kMCUIntTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCUIntTypeInfo; }
     static constexpr auto describe_format = "<foreign unsigned integer %u>";
 };
 struct sint_type_desc_t: public integral_type_desc_t<integer_t> {
     static_assert(INTEGER_MAX == INT32_MAX,
                   "Unsupported size for integer_t");
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeSInt32;
-    static constexpr auto& type_info = kMCSIntTypeInfo;
+    static constexpr MCTypeInfoRef& type_info() { return kMCSIntTypeInfo; }
     static constexpr auto describe_format = "<foreign signed integer %d>";
     static constexpr auto& hash_func = MCHashInteger;
 };
@@ -501,7 +501,7 @@ static bool
 __throw_numeric_overflow(MCTypeInfoRef p_error)
 {
     return MCErrorCreateAndThrow(p_error,
-                                 "type", OverflowedType::type_info,
+                                 "type", OverflowedType::type_info(),
                                  "reason", MCSTR("numeric overflow"),
                                  nil);
 }
@@ -800,7 +800,7 @@ class DescriptorBuilder {
 public:
     static bool create(const char *p_name)
     {
-        MCTypeInfoRef& destination = TypeDesc::type_info;
+        MCTypeInfoRef& destination = TypeDesc::type_info();
 
         MCForeignPrimitiveType primitive =
             TypeDesc::primitive_type;
@@ -811,7 +811,7 @@ public:
          * below). */
         MCForeignTypeDescriptor d = {
             sizeof(typename TypeDesc::c_type),
-            TypeDesc::base_type_info,
+            TypeDesc::base_type_info(),
             nullptr, /* bridgetype */
             &primitive, /* layout */
             1, /* layout_size */
@@ -879,7 +879,7 @@ private:
                   BridgableType::is_bridgable, int>::type = 0>
     static void setup_bridge(MCForeignTypeDescriptor& d)
     {
-        d.bridgetype = BridgableType::bridge_type_info;
+        d.bridgetype = BridgableType::bridge_type_info();
         d.doimport = doimport<BridgableType>;
         d.doexport = doexport<BridgableType>;
     }

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -453,7 +453,7 @@ template <typename TypeDesc>
 bool defined(void *contents)
 {
     static_assert(TypeDesc::is_optional, "This type is not optional");
-    return *static_cast<typename TypeDesc::c_type *>(contents) == typename TypeDesc::c_type();
+    return *static_cast<typename TypeDesc::c_type *>(contents) != typename TypeDesc::c_type();
 }
 
 template <typename TypeDesc>
@@ -493,6 +493,7 @@ template <typename TypeDesc>
 bool doexport(MCValueRef p_value, bool p_release, void *contents)
 {
     static_assert(TypeDesc::is_bridgable, "This type is not bridgable");
+    
     if (!DoExport<TypeDesc>::doexport(static_cast<typename TypeDesc::bridge_type>(p_value),
                                       *static_cast<typename TypeDesc::c_type *>(contents)))
     {
@@ -511,8 +512,9 @@ template <typename TypeDesc>
 bool doimport(void *contents, bool p_release, MCValueRef& r_value)
 {
     static_assert(TypeDesc::is_bridgable, "This type is not bridgable");
-    return DoImport<TypeDesc>::doimport(*static_cast<typename TypeDesc::c_type *>(contents),
+    bool t_success = DoImport<TypeDesc>::doimport(*static_cast<typename TypeDesc::c_type *>(contents),
                                         reinterpret_cast<typename TypeDesc::bridge_type&>(r_value));
+    return t_success;
 }
 
 /* ---------- bool specializations */

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -628,9 +628,8 @@ template <typename TypeDesc>
 bool doimport(void *contents, bool p_release, MCValueRef& r_value)
 {
     static_assert(TypeDesc::is_bridgable, "This type is not bridgable");
-    bool t_success = DoImport<TypeDesc>::doimport(*static_cast<typename TypeDesc::c_type *>(contents),
+    return DoImport<TypeDesc>::doimport(*static_cast<typename TypeDesc::c_type *>(contents),
                                         reinterpret_cast<typename TypeDesc::bridge_type&>(r_value));
-    return t_success;
 }
 
 /* ---------- bool specializations */

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -44,8 +44,14 @@ int MCJavaMapTypeCode(MCStringRef p_type_code)
 
 static bool __GetExpectedTypeCode(MCTypeInfoRef p_type, MCJavaType& r_code)
 {
-    if (p_type == kMCIntTypeInfo)
+    if (p_type == kMCInt8TypeInfo)
+        r_code = kMCJavaTypeByte;
+    else if (p_type == kMCInt16TypeInfo)
+        r_code = kMCJavaTypeShort;
+    else if (p_type == kMCInt32TypeInfo)
         r_code = kMCJavaTypeInt;
+    else if (p_type == kMCInt64TypeInfo)
+        r_code = kMCJavaTypeLong;
     else if (p_type == kMCBoolTypeInfo)
         r_code = kMCJavaTypeBoolean;
     else if (p_type == kMCFloatTypeInfo)
@@ -79,11 +85,6 @@ static bool __MCTypeInfoConformsToJavaType(MCTypeInfoRef p_type, MCJavaType p_co
     MCJavaType t_code;
     if (!__GetExpectedTypeCode(p_type, t_code))
         return false;
-    
-    // Just allow long and int interchangeably for now
-    if (t_code == kMCJavaTypeInt &&
-        p_code == kMCJavaTypeLong)
-        return true;
     
     return t_code == p_code;
 }

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -44,13 +44,13 @@ int MCJavaMapTypeCode(MCStringRef p_type_code)
 
 static bool __GetExpectedTypeCode(MCTypeInfoRef p_type, MCJavaType& r_code)
 {
-    if (p_type == kMCInt8TypeInfo)
+    if (p_type == kMCSInt8TypeInfo)
         r_code = kMCJavaTypeByte;
-    else if (p_type == kMCInt16TypeInfo)
+    else if (p_type == kMCSInt16TypeInfo)
         r_code = kMCJavaTypeShort;
-    else if (p_type == kMCInt32TypeInfo)
+    else if (p_type == kMCSInt32TypeInfo)
         r_code = kMCJavaTypeInt;
-    else if (p_type == kMCInt64TypeInfo)
+    else if (p_type == kMCSInt64TypeInfo)
         r_code = kMCJavaTypeLong;
     else if (p_type == kMCBoolTypeInfo)
         r_code = kMCJavaTypeBoolean;

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -642,6 +642,7 @@ bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCType
     self -> foreign . descriptor . hash = p_descriptor -> hash;
     self -> foreign . descriptor . doimport = p_descriptor -> doimport;
     self -> foreign . descriptor . doexport = p_descriptor -> doexport;
+    self -> foreign . descriptor . describe = p_descriptor -> describe;
     
     if (!__MCForeignTypeInfoComputeLayoutType(self))
     {

--- a/libfoundation/test/test_foreign.cpp
+++ b/libfoundation/test/test_foreign.cpp
@@ -285,8 +285,8 @@ template<typename T>
 hash_t __hash_int(T p_value)
 {
     if (std::is_signed<T>::value)
-        return MCHashSize(p_value);
-    return MCHashUSize(p_value);
+        return MCHashInt64(p_value);
+    return MCHashUInt64(p_value);
 }
 
 template<typename T>
@@ -321,7 +321,7 @@ void test_integral(MCTypeInfoRef p_type_info, const char *p_format)
     bool t_check_import_min_overflow = false;
     bool t_check_import_max_overflow = false;
     
-    T t_min, t_max;
+    int64_t t_min, t_max;
     
     // For C integer types of less than 64-bits in size, we can represent the
     // whole range in MCNumberRefs. For 64-bit size integral types, we can only
@@ -411,7 +411,7 @@ TEST_INTEGRAL(CSInt, signed int, "c signed int %d")
 TEST_INTEGRAL(CULong, unsigned long, "c unsigned long %lu")
 TEST_INTEGRAL(CSLong, signed long, "c signed long %ld")
 TEST_INTEGRAL(CULongLong, unsigned long long, "c unsigned long long %llu")
-TEST_INTEGRAL(CSLongLong, signed long long, "c signed long long %ld")
+TEST_INTEGRAL(CSLongLong, signed long long, "c signed long long %lld")
 
 TEST_INTEGRAL(UInt, uinteger_t, "unsigned integer %u")
 TEST_INTEGRAL(SInt, integer_t, "signed integer %d")

--- a/libfoundation/test/test_foreign.cpp
+++ b/libfoundation/test/test_foreign.cpp
@@ -147,37 +147,48 @@ void check_integral_raw_import_overflow(MCTypeInfoRef p_type_info, MCTypeInfoRef
 
 /* Bool Type Tests */
 
-TEST(foreign, Bool)
+static void
+test_bool_type(MCTypeInfoRef p_type, const char *p_false, const char *p_true)
 {
     /* Check Copy */
-    check_creation<bool>(kMCBoolTypeInfo, false);
-    check_creation<bool>(kMCBoolTypeInfo, true);
+    check_creation<bool>(p_type, false);
+    check_creation<bool>(p_type, true);
 
     /* Check Equality */
-    check_equality<bool>(kMCBoolTypeInfo, false, false, true);
-    check_equality<bool>(kMCBoolTypeInfo, true, true, true);
-    check_equality<bool>(kMCBoolTypeInfo, false, true, false);
-    check_equality<bool>(kMCBoolTypeInfo, true, false, false);
+    check_equality<bool>(p_type, false, false, true);
+    check_equality<bool>(p_type, true, true, true);
+    check_equality<bool>(p_type, false, true, false);
+    check_equality<bool>(p_type, true, false, false);
 
     /* Check Hash */
-    check_hash<bool>(kMCBoolTypeInfo, false, MCHashBool);
-    check_hash<bool>(kMCBoolTypeInfo, true, MCHashBool);
+    check_hash<bool>(p_type, false, MCHashBool);
+    check_hash<bool>(p_type, true, MCHashBool);
 
     /* Check describe */
-    check_describe<bool>(kMCBoolTypeInfo, false, "<foreign false>");
-    check_describe<bool>(kMCBoolTypeInfo, true, "<foreign true>");
+    check_describe<bool>(p_type, false,p_false);
+    check_describe<bool>(p_type, true, p_true);
     
     /* Check export (via api) - from Boolean */
-    check_export<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, false);
-    check_export<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, true);
+    check_export<bool>(p_type, MCBooleanCreateWithBool, false);
+    check_export<bool>(p_type, MCBooleanCreateWithBool, true);
     
     /* Check export (direct) - from Boolean */
-    check_export_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, false);
-    check_export_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, true);
+    check_export_raw<bool>(p_type, MCBooleanCreateWithBool, false);
+    check_export_raw<bool>(p_type, MCBooleanCreateWithBool, true);
     
     /* Check import (direct) - to Boolean */
-    check_import_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, false);
-    check_import_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, true);
+    check_import_raw<bool>(p_type, MCBooleanCreateWithBool, false);
+    check_import_raw<bool>(p_type, MCBooleanCreateWithBool, true);
+}
+
+TEST(foreign, Bool)
+{
+    test_bool_type(kMCBoolTypeInfo, "<foreign bool false>", "<foreign bool true>");
+}
+
+TEST(foreign, CBool)
+{
+    test_bool_type(kMCCBoolTypeInfo, "<foreign c bool false>", "<foreign c bool true>");
 }
 
 /* Pointer Type Tests */
@@ -377,20 +388,31 @@ void test_integral(MCTypeInfoRef p_type_info, const char *p_format)
 }
 
 TEST_INTEGRAL(UInt8, uint8_t, "8-bit unsigned integer %u")
-TEST_INTEGRAL(Int8, int8_t, "8-bit integer %d")
+TEST_INTEGRAL(SInt8, int8_t, "8-bit signed integer %d")
 TEST_INTEGRAL(UInt16, uint16_t, "16-bit unsigned integer %u")
-TEST_INTEGRAL(Int16, int16_t, "16-bit integer %d")
+TEST_INTEGRAL(SInt16, int16_t, "16-bit signed integer %d")
 TEST_INTEGRAL(UInt32, uint32_t, "32-bit unsigned integer %u")
-TEST_INTEGRAL(Int32, int32_t, "32-bit integer %d")
+TEST_INTEGRAL(SInt32, int32_t, "32-bit signed integer %d")
 TEST_INTEGRAL(UInt64, uint64_t, "64-bit unsigned integer %llu")
-TEST_INTEGRAL(Int64, int64_t, "64-bit integer %lld")
+TEST_INTEGRAL(SInt64, int64_t, "64-bit signed integer %lld")
 
-TEST_INTEGRAL(Size, size_t, "size %zu")
-TEST_INTEGRAL(SSize, ssize_t, "signed size %zd")
+TEST_INTEGRAL(UIntSize, size_t, "unsigned size %zu")
+TEST_INTEGRAL(SIntSize, ssize_t, "signed size %zd")
+TEST_INTEGRAL(UIntPtr, uintptr_t, "unsigned intptr %zu")
+TEST_INTEGRAL(SIntPtr, intptr_t, "signed intptr %zd")
 
-TEST_INTEGRAL(CULong, unsigned long, "unsigned long integer %llu")
-TEST_INTEGRAL(CLong, long, "long integer %ld")
+TEST_INTEGRAL(CChar, char, "c char '%c'");
+TEST_INTEGRAL(CUChar, unsigned char, "c unsigned char %u")
+TEST_INTEGRAL(CSChar, signed char, "c signed char %d")
+TEST_INTEGRAL(CUShort, unsigned short, "c unsigned short %u")
+TEST_INTEGRAL(CSShort, signed short, "c signed short %d")
+TEST_INTEGRAL(CUInt, unsigned int, "c unsigned int %u")
+TEST_INTEGRAL(CSInt, signed int, "c signed int %d")
+TEST_INTEGRAL(CULong, unsigned long, "c unsigned long %lu")
+TEST_INTEGRAL(CSLong, signed long, "c signed long %ld")
+TEST_INTEGRAL(CULongLong, unsigned long long, "c unsigned long long %llu")
+TEST_INTEGRAL(CSLongLong, signed long long, "c signed long long %ld")
 
 TEST_INTEGRAL(UInt, uinteger_t, "unsigned integer %u")
-TEST_INTEGRAL(Int, integer_t, "integer %d")
+TEST_INTEGRAL(SInt, integer_t, "signed integer %d")
 

--- a/libfoundation/test/test_foreign.cpp
+++ b/libfoundation/test/test_foreign.cpp
@@ -1,0 +1,396 @@
+/* Copyright (C) 2017 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "gtest/gtest.h"
+
+#include "foundation.h"
+#include "foundation-auto.h"
+
+#include <limits>
+#include <type_traits>
+
+typedef MCAutoValueRefBase<MCForeignValueRef> MCAutoForeignValueRef;
+
+template<typename T>
+void check_creation(MCTypeInfoRef p_type_info, T p_value)
+{
+    MCAutoForeignValueRef t_boxed_value;
+    EXPECT_TRUE(MCForeignValueCreate(p_type_info, &p_value, &t_boxed_value));
+    EXPECT_EQ(*static_cast<T *>(MCForeignValueGetContentsPtr(*t_boxed_value)), p_value);
+}
+
+template<typename T>
+void check_equality(MCTypeInfoRef p_type_info, T p_left, T p_right, bool p_expected)
+{
+    MCAutoForeignValueRef t_left_box, t_right_box;
+    EXPECT_TRUE(MCForeignValueCreate(p_type_info, &p_left, &t_left_box));
+    EXPECT_TRUE(MCForeignValueCreate(p_type_info, &p_right, &t_right_box));
+    EXPECT_EQ(MCValueIsEqualTo(*t_left_box, *t_right_box), p_expected);
+}
+
+template<typename T, typename U = T>
+void check_hash(MCTypeInfoRef p_type_info, T p_value, hash_t (*p_hash_func)(U p_value))
+{
+    MCAutoForeignValueRef t_boxed_value;
+    EXPECT_TRUE(MCForeignValueCreate(p_type_info, &p_value, &t_boxed_value));
+    EXPECT_EQ(MCValueHash(*t_boxed_value), p_hash_func(p_value));
+}
+
+template<typename T>
+void check_describe(MCTypeInfoRef p_type_info, T p_value, const char *p_format_str)
+{
+    char t_format[256];
+    sprintf(t_format, p_format_str, p_value);
+    MCAutoForeignValueRef t_boxed_value;
+    EXPECT_TRUE(MCForeignValueCreate(p_type_info, &p_value, &t_boxed_value));
+    MCAutoStringRef t_description;
+    EXPECT_TRUE(MCValueCopyDescription(*t_boxed_value, &t_description));
+    if (t_description.IsSet())
+        EXPECT_STREQ(MCStringGetCString(*t_description), t_format);
+}
+    
+template<typename T, typename U, typename W = T>
+void check_export(MCTypeInfoRef p_type_info, bool (*p_bridge)(W, U&), T p_value)
+{
+    MCAutoValueRefBase<U> t_bridge_value;
+    EXPECT_TRUE(p_bridge(p_value, &t_bridge_value));
+    MCAutoForeignValueRef t_boxed_value;
+    EXPECT_TRUE(MCForeignValueExport(p_type_info, *t_bridge_value, &t_boxed_value));
+    if (t_boxed_value.IsSet())
+        EXPECT_EQ(*static_cast<T *>(MCForeignValueGetContentsPtr(*t_boxed_value)), p_value);
+}
+
+void check_integral_export_overflow(MCTypeInfoRef p_type_info, MCTypeInfoRef p_err_type_info, int64_t p_value)
+{
+    MCAutoNumberRef t_bridge_value;
+    EXPECT_TRUE(MCNumberCreateWithReal(p_value, &t_bridge_value));
+    MCAutoForeignValueRef t_boxed_value;
+    EXPECT_FALSE(MCForeignValueExport(p_type_info, *t_bridge_value, &t_boxed_value));
+    if (!t_boxed_value.IsSet())
+    {
+        MCAutoErrorRef t_error;
+        EXPECT_TRUE(MCErrorCatch(&t_error));
+        EXPECT_EQ(MCValueGetTypeInfo(*t_error), p_err_type_info);
+    }
+}
+
+template<typename T, typename U, typename W = T>
+void check_export_raw(MCTypeInfoRef p_type_info, bool (*p_bridge)(W, U&), T p_value)
+{
+    MCAutoValueRefBase<U> t_bridge_value;
+    EXPECT_TRUE(p_bridge(p_value, &t_bridge_value));
+    const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(p_type_info);
+    EXPECT_TRUE(t_desc->doexport != nullptr);
+    T t_exported_value;
+    EXPECT_TRUE(t_desc->doexport(*t_bridge_value, false, &t_exported_value));
+    EXPECT_EQ(t_exported_value, p_value);
+}
+
+template<typename T>
+void check_integral_raw_export_overflow(MCTypeInfoRef p_type_info, MCTypeInfoRef p_err_type_info, int64_t p_value)
+{
+    MCAutoNumberRef t_bridge_value;
+    EXPECT_TRUE(MCNumberCreateWithReal(p_value, &t_bridge_value));
+    const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(p_type_info);
+    EXPECT_TRUE(t_desc->doexport != nullptr);
+    MCAutoForeignValueRef t_boxed_value;
+    T t_exported_value = 0;
+    EXPECT_FALSE(t_desc->doexport(*t_bridge_value, false, &t_exported_value));
+    if (t_exported_value != 0)
+    {
+        MCAutoErrorRef t_error;
+        EXPECT_TRUE(MCErrorCatch(&t_error));
+        EXPECT_EQ(MCValueGetTypeInfo(*t_error), p_err_type_info);
+    }
+}
+
+template<typename T, typename U, typename W = T>
+void check_import_raw(MCTypeInfoRef p_type_info, bool (*p_bridge)(W, U&), T p_value)
+{
+    MCAutoValueRefBase<U> t_bridge_value;
+    EXPECT_TRUE(p_bridge(p_value, &t_bridge_value));
+    const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(p_type_info);
+    EXPECT_TRUE(t_desc->doimport != nullptr);
+    MCAutoValueRef t_imported_value;
+    EXPECT_TRUE(t_desc->doimport(&p_value, false, &t_imported_value));
+    if (t_imported_value.IsSet())
+        EXPECT_TRUE(MCValueIsEqualTo(*t_imported_value, *t_bridge_value));
+}
+
+template<typename T>
+void check_integral_raw_import_overflow(MCTypeInfoRef p_type_info, MCTypeInfoRef p_err_type_info, T p_value)
+{
+    const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(p_type_info);
+    EXPECT_TRUE(t_desc->doimport != nullptr);
+    MCAutoValueRef t_imported_value;
+    EXPECT_FALSE(t_desc->doimport(&p_value, false, &t_imported_value));
+    if (!t_imported_value.IsSet())
+    {
+        MCAutoErrorRef t_error;
+        EXPECT_TRUE(MCErrorCatch(&t_error));
+        EXPECT_EQ(MCValueGetTypeInfo(*t_error), p_err_type_info);
+    }
+}
+
+/* Bool Type Tests */
+
+TEST(foreign, Bool)
+{
+    /* Check Copy */
+    check_creation<bool>(kMCBoolTypeInfo, false);
+    check_creation<bool>(kMCBoolTypeInfo, true);
+
+    /* Check Equality */
+    check_equality<bool>(kMCBoolTypeInfo, false, false, true);
+    check_equality<bool>(kMCBoolTypeInfo, true, true, true);
+    check_equality<bool>(kMCBoolTypeInfo, false, true, false);
+    check_equality<bool>(kMCBoolTypeInfo, true, false, false);
+
+    /* Check Hash */
+    check_hash<bool>(kMCBoolTypeInfo, false, MCHashBool);
+    check_hash<bool>(kMCBoolTypeInfo, true, MCHashBool);
+
+    /* Check describe */
+    check_describe<bool>(kMCBoolTypeInfo, false, "<foreign false>");
+    check_describe<bool>(kMCBoolTypeInfo, true, "<foreign true>");
+    
+    /* Check export (via api) - from Boolean */
+    check_export<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, false);
+    check_export<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, true);
+    
+    /* Check export (direct) - from Boolean */
+    check_export_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, false);
+    check_export_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, true);
+    
+    /* Check import (direct) - to Boolean */
+    check_import_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, false);
+    check_import_raw<bool>(kMCBoolTypeInfo, MCBooleanCreateWithBool, true);
+}
+
+/* Pointer Type Tests */
+
+TEST(foreign, Pointer)
+{
+    const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(kMCPointerTypeInfo);
+    
+    /* Check Copy */
+    check_creation<void*>(kMCPointerTypeInfo, nullptr);
+    check_creation<void*>(kMCPointerTypeInfo, &kMCPointerTypeInfo);
+
+    /* Check Equality */
+    check_equality<void*>(kMCPointerTypeInfo, nullptr, nullptr, true);
+    check_equality<void*>(kMCPointerTypeInfo, &kMCPointerTypeInfo, &kMCPointerTypeInfo, true);
+    check_equality<void*>(kMCPointerTypeInfo, nullptr, &kMCPointerTypeInfo, false);
+    check_equality<void*>(kMCPointerTypeInfo, &kMCPointerTypeInfo, nullptr, false);
+
+    /* Check Hash */
+    check_hash<void*>(kMCPointerTypeInfo, nullptr, MCHashPointer);
+    check_hash<void*>(kMCPointerTypeInfo, &kMCPointerTypeInfo, MCHashPointer);
+
+    /* Check describe */
+    check_describe<void*>(kMCPointerTypeInfo, nullptr, "<foreign pointer %p>");
+    check_describe<void*>(kMCPointerTypeInfo, &kMCPointerTypeInfo, "<foreign pointer %p>");
+    
+    /* Check initialize */
+    ASSERT_NE(t_desc->initialize, nullptr);
+    if (t_desc->initialize != nullptr)
+    {
+        void *t_test = &kMCPointerTypeInfo;
+        ASSERT_TRUE(t_desc->initialize(&t_test));
+        ASSERT_EQ(t_test, nullptr);
+    }
+    
+    /* Check defined */
+    ASSERT_NE(t_desc->defined, nullptr);
+    if (t_desc->defined != nullptr)
+    {
+        void *t_test_null = nullptr;
+        ASSERT_FALSE(t_desc->defined(&t_test_null));
+        ASSERT_TRUE(t_desc->defined(&kMCPointerTypeInfo));
+    }
+}
+
+/* Real Type Tests */
+
+template<typename T, typename U, typename W = T>
+void test_numeric(MCTypeInfoRef p_type_info, T x, T y, hash_t (*p_hash)(W value), const char *p_format_str, bool (*p_bridge)(W value, U& r_bridged_value))
+{
+    check_creation<T>(p_type_info, x);
+    check_creation<T>(p_type_info, y);
+    
+    /* Check Equality */
+    check_equality<T>(p_type_info, x, x, true);
+    check_equality<T>(p_type_info, y, y, true);
+    check_equality<T>(p_type_info, x, y, false);
+    check_equality<T>(p_type_info, y, x, false);
+
+    /* Check Hash */
+    check_hash<T>(p_type_info, x, p_hash);
+    check_hash<T>(p_type_info, y, p_hash);
+
+    /* Check describe */
+    check_describe<T>(p_type_info, x, p_format_str);
+    check_describe<T>(p_type_info, y, p_format_str);
+    
+    /* Check export (via api) */
+    check_export<T>(p_type_info, p_bridge, x);
+    check_export<T>(p_type_info, p_bridge, y);
+    
+    /* Check export (direct) */
+    check_export_raw<T>(p_type_info, p_bridge, x);
+    check_export_raw<T>(p_type_info, p_bridge, y);
+    
+    /* Check import (direct) */
+    check_import_raw<T>(p_type_info, p_bridge, x);
+    check_import_raw<T>(p_type_info, p_bridge, y);
+}
+
+TEST(foreign, Float)
+{
+    test_numeric<float, MCNumberRef, double>(kMCFloatTypeInfo, FLT_MIN, FLT_MAX, MCHashDouble, "<foreign float %g>", MCNumberCreateWithReal);
+}
+
+TEST(foreign, Double)
+{
+    test_numeric<double>(kMCDoubleTypeInfo, DBL_MIN, DBL_MAX, MCHashDouble, "<foreign double %lg>", MCNumberCreateWithReal);
+}
+
+/* Integral Type Tests */
+
+template<typename T>
+hash_t __hash_int(T p_value)
+{
+    if (std::is_signed<T>::value)
+        return MCHashSize(p_value);
+    return MCHashUSize(p_value);
+}
+
+template<typename T>
+bool __bridge_int(T p_value, MCNumberRef& r_number)
+{
+    if (sizeof(T) > sizeof(integer_t))
+    {
+        return MCNumberCreateWithReal(p_value, r_number);
+    }
+
+    if (std::is_signed<T>::value)
+    {
+        return MCNumberCreateWithInteger(p_value, r_number);
+    }
+    
+    return MCNumberCreateWithUnsignedInteger(p_value, r_number);
+}
+
+#define TEST_INTEGRAL(name, type, format) \
+    TEST(foreign, name) \
+    { \
+        test_integral<type>(kMC##name##TypeInfo, "<foreign " format ">"); \
+    }
+
+#define INT_NUMBER_MIN -(1LL << std::numeric_limits<double>::digits)
+#define INT_NUMBER_MAX 1LL << std::numeric_limits<double>::digits
+
+template<typename T>
+void test_integral(MCTypeInfoRef p_type_info, const char *p_format)
+{
+    bool t_check_export_overflow = false;
+    bool t_check_import_min_overflow = false;
+    bool t_check_import_max_overflow = false;
+    
+    T t_min, t_max;
+    
+    // For C integer types of less than 64-bits in size, we can represent the
+    // whole range in MCNumberRefs. For 64-bit size integral types, we can only
+    // represent the exact integer range of double. Thus we compute the minimum
+    // and maximum values based on the type size and arity.
+    if (sizeof(T) <= 4)
+    {
+        t_min = std::numeric_limits<T>::min();
+        t_max = std::numeric_limits<T>::max();
+        t_check_export_overflow = true;
+        t_check_import_min_overflow = false;
+        t_check_import_max_overflow = false;
+    }
+    else
+    {
+        if (std::is_signed<T>::value)
+        {
+            t_min = INT_NUMBER_MIN;
+            t_check_import_min_overflow = true;
+        }
+        else
+        {
+            t_min = 0;
+            t_check_import_min_overflow = false;
+
+        }
+        
+        t_max = INT_NUMBER_MAX;
+        t_check_import_max_overflow = true;
+    }
+    
+    // Check all the base characteristics.
+    test_numeric<T, MCNumberRef>(p_type_info, t_min, t_max, __hash_int, p_format, __bridge_int);
+    
+    // If the minimum of the type is greater than the min integer number can
+    // hold, then check exporting a smaller value throws an error.
+    if (t_check_export_overflow)
+    {
+        check_integral_export_overflow(p_type_info, kMCForeignExportErrorTypeInfo, int64_t(t_min) - 1);
+        check_integral_raw_export_overflow<T>(p_type_info, kMCForeignExportErrorTypeInfo, int64_t(t_min) - 1);
+    }
+    
+    // If the maximum of the type is less than the max integer number can hold,
+    // then check exporting a larger value throws an error.
+    if (t_check_export_overflow)
+    {
+        check_integral_export_overflow(p_type_info, kMCForeignExportErrorTypeInfo, int64_t(t_max) + 1);
+        check_integral_raw_export_overflow<T>(p_type_info, kMCForeignExportErrorTypeInfo, int64_t(t_max) + 1);
+    }
+    
+    // If the minimum value of the type is less than the minimum integer number
+    // can hold, check importing a smaller value throws an error.
+    if (t_check_import_min_overflow)
+    {
+        check_integral_raw_import_overflow<T>(p_type_info, kMCForeignImportErrorTypeInfo, t_min - 1);
+    }
+    
+    // If the maximum value of the type is greater than the maximum integer
+    // number can hold, check importing a larger value throws an error.
+    if (t_check_import_max_overflow)
+    {
+        check_integral_raw_import_overflow<T>(p_type_info, kMCForeignImportErrorTypeInfo, t_max + 1);
+    }
+}
+
+TEST_INTEGRAL(UInt8, uint8_t, "8-bit unsigned integer %u")
+TEST_INTEGRAL(Int8, int8_t, "8-bit integer %d")
+TEST_INTEGRAL(UInt16, uint16_t, "16-bit unsigned integer %u")
+TEST_INTEGRAL(Int16, int16_t, "16-bit integer %d")
+TEST_INTEGRAL(UInt32, uint32_t, "32-bit unsigned integer %u")
+TEST_INTEGRAL(Int32, int32_t, "32-bit integer %d")
+TEST_INTEGRAL(UInt64, uint64_t, "64-bit unsigned integer %llu")
+TEST_INTEGRAL(Int64, int64_t, "64-bit integer %lld")
+
+TEST_INTEGRAL(Size, size_t, "size %zu")
+TEST_INTEGRAL(SSize, ssize_t, "signed size %zd")
+
+TEST_INTEGRAL(CULong, unsigned long, "unsigned long integer %llu")
+TEST_INTEGRAL(CLong, long, "long integer %ld")
+
+TEST_INTEGRAL(UInt, uinteger_t, "unsigned integer %u")
+TEST_INTEGRAL(Int, integer_t, "integer %d")
+

--- a/libscript/src/foreign.lcb
+++ b/libscript/src/foreign.lcb
@@ -17,48 +17,61 @@
 module com.livecode.foreign
 
 ----------------------------------------------------------------
--- Universal types
+-- Machine types
 ----------------------------------------------------------------
 
-public foreign type Pointer binds to "MCForeignPointerTypeInfo"
+public foreign type Bool binds to "MCForeignBoolTypeInfo"
+
+public foreign type UInt8 binds to "MCForeignUInt8TypeInfo"
+public foreign type SInt8 binds to "MCForeignSInt8TypeInfo"
+public foreign type UInt16 binds to "MCForeignUInt16TypeInfo"
+public foreign type SInt16 binds to "MCForeignSInt16TypeInfo"
+public foreign type UInt32 binds to "MCForeignUInt32TypeInfo"
+public foreign type SInt32 binds to "MCForeignSInt32TypeInfo"
+public foreign type UInt64 binds to "MCForeignUInt64TypeInfo"
+public foreign type SInt64 binds to "MCForeignSInt64TypeInfo"
+
+public type Int8 is SInt8
+public type Int16 is SInt16
+public type Int32 is SInt32
+public type Int64 is SInt64
 
 public foreign type Float32 binds to "MCForeignFloatTypeInfo"
 public foreign type Float64 binds to "MCForeignDoubleTypeInfo"
 
-----------------------------------------------------------------
--- Sized integral types
-----------------------------------------------------------------
+public foreign type Pointer binds to "MCForeignPointerTypeInfo"
 
-public foreign type UInt8 binds to "MCForeignUInt8TypeInfo"
-public foreign type Int8 binds to "MCForeignInt8TypeInfo"
-public foreign type UInt16 binds to "MCForeignUInt16TypeInfo"
-public foreign type Int16 binds to "MCForeignInt16TypeInfo"
-public foreign type UInt32 binds to "MCForeignUInt32TypeInfo"
-public foreign type Int32 binds to "MCForeignInt32TypeInfo"
-public foreign type UInt64 binds to "MCForeignUInt64TypeInfo"
-public foreign type Int64 binds to "MCForeignInt64TypeInfo"
+public foreign type UIntSize binds to "MCForeignUIntSizeTypeInfo"
+public foreign type SIntSize binds to "MCForeignSIntSizeTypeInfo"
 
-public foreign type UIntSize binds to "MCForeignSizeTypeInfo"
-public foreign type IntSize binds to "MCForeignSSizeTypeInfo"
+public type IntSize is SIntSize
 
-public type UIntPtr is UIntSize
-public type IntPtr is IntSize
+public foreign type UIntPtr binds to "MCForeignUIntPtrTypeInfo"
+public foreign type SIntPtr binds to "MCForeignSIntPtrTypeInfo"
+
+public type IntPtr is SIntPtr
 
 ----------------------------------------------------------------
 -- C types
 ----------------------------------------------------------------
 
-public foreign type CBool binds to "MCForeignBoolTypeInfo"
-public type CUChar is UInt8
-public type CChar is Int8
-public type CUShort is UInt16
-public type CShort is Int16
-public type CUInt is UInt32
-public type CInt is Int32
+public foreign type CBool binds to "MCForeignCBoolTypeInfo"
+public foreign type CChar binds to "MCForeignCCharTypeInfo"
+public foreign type CUChar binds to "MCForeignCUCharTypeInfo"
+public foreign type CSChar binds to "MCForeignCSCharTypeInfo"
+public foreign type CUShort binds to "MCForeignCUShortTypeInfo"
+public foreign type CSShort binds to "MCForeignCSShortTypeInfo"
+public foreign type CUInt binds to "MCForeignCUIntTypeInfo"
+public foreign type CSInt binds to "MCForeignCSIntTypeInfo"
 public foreign type CULong binds to "MCForeignCULongTypeInfo"
-public foreign type CLong binds to "MCForeignCLongTypeInfo"
-public type CULongLong is UInt64
-public type CLongLong is Int64
+public foreign type CSLong binds to "MCForeignCSLongTypeInfo"
+public foreign type CULongLong binds to "MCForeignCULongLongTypeInfo"
+public foreign type CSLongLong binds to "MCForeignCSLongLongTypeInfo"
+
+public type CShort is CSShort
+public type CInt is CSInt
+public type CLong is CSLong
+public type CLongLong is CSLongLong
 
 public type CFloat is Float32
 public type CDouble is Float64
@@ -67,10 +80,12 @@ public type CDouble is Float64
 -- LiveCode engine types
 ----------------------------------------------------------------
 
-public foreign type LCInt binds to "MCForeignIntTypeInfo"
+public foreign type LCSInt binds to "MCForeignSIntTypeInfo"
 public foreign type LCUInt binds to "MCForeignUIntTypeInfo"
 
-public type LCIndex is LCInt
+public type LCInt is LCSInt
+
+public type LCIndex is LCSInt
 public type LCUIndex is LCUInt
 
 ----------------------------------------------------------------

--- a/libscript/src/foreign.lcb
+++ b/libscript/src/foreign.lcb
@@ -22,22 +22,44 @@ module com.livecode.foreign
 
 public foreign type Pointer binds to "MCForeignPointerTypeInfo"
 
-public foreign type UInt32 binds to "MCForeignUIntTypeInfo"
-public foreign type Int32 binds to "MCForeignIntTypeInfo"
+public foreign type Float32 binds to "MCForeignFloatTypeInfo"
+public foreign type Float64 binds to "MCForeignDoubleTypeInfo"
+
+----------------------------------------------------------------
+-- Sized integral types
+----------------------------------------------------------------
+
+public foreign type UInt8 binds to "MCForeignUInt8TypeInfo"
+public foreign type Int8 binds to "MCForeignInt8TypeInfo"
+public foreign type UInt16 binds to "MCForeignUInt16TypeInfo"
+public foreign type Int16 binds to "MCForeignInt16TypeInfo"
+public foreign type UInt32 binds to "MCForeignUInt32TypeInfo"
+public foreign type Int32 binds to "MCForeignInt32TypeInfo"
+public foreign type UInt64 binds to "MCForeignUInt64TypeInfo"
+public foreign type Int64 binds to "MCForeignInt64TypeInfo"
 
 public foreign type UIntSize binds to "MCForeignSizeTypeInfo"
 public foreign type IntSize binds to "MCForeignSSizeTypeInfo"
 
-public foreign type Float32 binds to "MCForeignFloatTypeInfo"
-public foreign type Float64 binds to "MCForeignDoubleTypeInfo"
+public type UIntPtr is UIntSize
+public type IntPtr is IntSize
 
 ----------------------------------------------------------------
 -- C types
 ----------------------------------------------------------------
 
 public foreign type CBool binds to "MCForeignBoolTypeInfo"
-public type CInt is Int32
+public type CUChar is UInt8
+public type CChar is Int8
+public type CUShort is UInt16
+public type CShort is Int16
 public type CUInt is UInt32
+public type CInt is Int32
+public foreign type CULong binds to "MCForeignCULongTypeInfo"
+public foreign type CLong binds to "MCForeignCLongTypeInfo"
+public type CULongLong is UInt64
+public type CLongLong is Int64
+
 public type CFloat is Float32
 public type CDouble is Float64
 
@@ -45,10 +67,11 @@ public type CDouble is Float64
 -- LiveCode engine types
 ----------------------------------------------------------------
 
-public type LCInt is Int32
-public type LCUInt is UInt32
-public type LCIndex is Int32
-public type LCUIndex is UInt32
+public foreign type LCInt binds to "MCForeignIntTypeInfo"
+public foreign type LCUInt binds to "MCForeignUIntTypeInfo"
+
+public type LCIndex is LCInt
+public type LCUIndex is LCUInt
 
 ----------------------------------------------------------------
 -- Nul-terminated string pointer types

--- a/libscript/src/java.lcb
+++ b/libscript/src/java.lcb
@@ -39,8 +39,8 @@ public type JByte is Int8
 public type JShort is Int16
 public type JInt is Int32
 public type JLong is Int64
-public type JFloat is CFloat
-public type JDouble is CDouble
+public type JFloat is Float32
+public type JDouble is Float64
 
 public foreign type JObject binds to "MCJavaObjectTypeInfo"
 public type JString is JObject

--- a/libscript/src/java.lcb
+++ b/libscript/src/java.lcb
@@ -34,6 +34,14 @@ module com.livecode.java
 
 use com.livecode.foreign
 
+public type JBoolean is CBool
+public type JByte is Int8
+public type JShort is Int16
+public type JInt is Int32
+public type JLong is Int64
+public type JFloat is CFloat
+public type JDouble is CDouble
+
 public foreign type JObject binds to "MCJavaObjectTypeInfo"
 public type JString is JObject
 public type JByteArray is JObject

--- a/libscript/src/java.lcb
+++ b/libscript/src/java.lcb
@@ -34,7 +34,7 @@ module com.livecode.java
 
 use com.livecode.foreign
 
-public type JBoolean is CBool
+public type JBoolean is Bool
 public type JByte is Int8
 public type JShort is Int16
 public type JInt is Int32

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -585,7 +585,8 @@ MCScriptExecuteContext::CheckedFetchRegisterAsBool(uindex_t p_index)
     {
         t_value_as_bool = (t_value == kMCTrue);
     }
-    else if (MCValueGetTypeInfo(t_value) == kMCBoolTypeInfo)
+    else if (MCValueGetTypeInfo(t_value) == kMCBoolTypeInfo ||
+             MCValueGetTypeInfo(t_value) == kMCCBoolTypeInfo)
     {
         t_value_as_bool = *(bool *)MCForeignValueGetContentsPtr(t_value);
     }

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -148,8 +148,8 @@ bool MCScriptInitialize(void)
         MCScriptAddExportToModule(t_builder, t_bool_type_index);
         
         MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignIntTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("int"), t_type_index, t_def_index);
+        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignSIntTypeInfo"), t_type_index);
+        MCScriptAddTypeToModule(t_builder, MCNAME("sint"), t_type_index, t_def_index);
         MCScriptAddExportToModule(t_builder, t_def_index);
         
         uindex_t t_uint_type_index;

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -240,8 +240,8 @@ on TestLoadExtension pName
 
    if tExtensionFile is not empty then
       _TestLoadExtension tExtensionFolder, tExtensionFile
+      put the result into tError
    end if
-   put the result into tError
 
    if tError is not empty then
       write tError & return to stderr
@@ -340,7 +340,7 @@ on TestRepeat pDesc, pHandler, pTarget, pTimeOut, pParamsArray
 
     put false into tResult
 
-    local tTimer, tTimeout
+    local tTimer, tTimeout, tTimerStart
     put false into tTimeout
     put the millisecs into tTimerStart
 

--- a/tests/lcb/stdlib/java.lcb
+++ b/tests/lcb/stdlib/java.lcb
@@ -120,7 +120,7 @@ public handler TestGetConstant()
 		when tPiTrunc is 3
 end handler
 
-foreign handler CallJavaAdd(in pLeft as CInt, in pRight as CInt) returns CInt binds to "java:java.lang.Math>addExact(JJ)J!static"
+foreign handler CallJavaAdd(in pLeft as JLong, in pRight as JLong) returns JLong binds to "java:java.lang.Math>addExact(JJ)J!static"
 
 public handler TestCallStaticMethod()
 	variable tLeft as Number

--- a/tests/lcb/stdlib/java.lcb
+++ b/tests/lcb/stdlib/java.lcb
@@ -40,7 +40,7 @@ end handler
 
 foreign handler CreateJavaString(in pBytes as JByteArray) returns JString binds to "java:java.lang.String>new([B)"
 
-foreign handler MCDataCreateWithBytes(in pBytes as ZStringNative, in pCount as CUInt, out rData as Data) returns CBool binds to "<builtin>"
+foreign handler MCDataCreateWithBytes(in pBytes as ZStringNative, in pCount as CUInt, out rData as Data) returns JBoolean binds to "<builtin>"
 
 public handler TestCreateJString()
    	if not the operating system is in ["mac", "linux"] then
@@ -135,7 +135,7 @@ public handler TestCallStaticMethod()
 	test "call java class static method" when tResult is 2
 end handler
 
-foreign handler JavaStringIsEmpty(in pString as JString) returns CBool binds to "java:java.lang.String>isEmpty()Z"
+foreign handler JavaStringIsEmpty(in pString as JString) returns JBoolean binds to "java:java.lang.String>isEmpty()Z"
 
 public handler TestCallInstanceMethod()
 	variable tJavaString as JString
@@ -182,8 +182,8 @@ end handler
 
 foreign handler JavaCreateEmptyList() returns JObject binds to "java:java.util.LinkedList>new()"
 foreign handler JavaPeekList(in pList as JObject) returns JObject binds to "java:java.util.LinkedList>peek()Ljava/lang/Object;"
-foreign handler JavaAddList(in pList as JObject, in pToAdd as JObject) returns CBool binds to "java:java.util.LinkedList>add(Ljava/lang/Object;)Z"
-foreign handler JavaAddListOptional(in pList as JObject, in pToAdd as optional JObject) returns CBool binds to "java:java.util.LinkedList>add(Ljava/lang/Object;)Z"
+foreign handler JavaAddList(in pList as JObject, in pToAdd as JObject) returns JBoolean binds to "java:java.util.LinkedList>add(Ljava/lang/Object;)Z"
+foreign handler JavaAddListOptional(in pList as JObject, in pToAdd as optional JObject) returns JBoolean binds to "java:java.util.LinkedList>add(Ljava/lang/Object;)Z"
 
 public handler NullIntoOptionalJObject()
 	unsafe
@@ -233,7 +233,7 @@ public handler TestNullJObjectParam()
 	MCUnitTestHandlerThrows(NullParamJObject, "type mismatch when passing NULL as non-optional JObject")
 end handler
 
-foreign handler StringCodepointAt(in pSequence as JObject, in pIndex as CInt) returns CInt binds to "java:java.lang.Character>codePointAt(Ljava/lang/CharSequence;I)I!static"
+foreign handler StringCodepointAt(in pSequence as JObject, in pIndex as JInt) returns JInt binds to "java:java.lang.Character>codePointAt(Ljava/lang/CharSequence;I)I!static"
 
 public handler TestNativeTypeAfterObjectType()
 	unsafe

--- a/tests/lcb/stdlib/java.lcb
+++ b/tests/lcb/stdlib/java.lcb
@@ -40,7 +40,7 @@ end handler
 
 foreign handler CreateJavaString(in pBytes as JByteArray) returns JString binds to "java:java.lang.String>new([B)"
 
-foreign handler MCDataCreateWithBytes(in pBytes as ZStringNative, in pCount as CUInt, out rData as Data) returns JBoolean binds to "<builtin>"
+foreign handler MCDataCreateWithBytes(in pBytes as ZStringNative, in pCount as LCUIndex, out rData as Data) returns CBool binds to "<builtin>"
 
 public handler TestCreateJString()
    	if not the operating system is in ["mac", "linux"] then

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -90,14 +90,7 @@ extern "C" void EmitDefinedType(long index, long& r_type_index);
 extern "C" void EmitForeignType(long binding, long& r_type_index);
 extern "C" void EmitNamedType(NameRef module_name, NameRef name, long& r_new_index);
 extern "C" void EmitAliasType(NameRef name, long typeindex, long& r_new_index);
-extern "C" void EmitOptionalType(long index, long& r_new_index);
-extern "C" void EmitPointerType(long& r_new_index);
-extern "C" void EmitBoolType(long& r_new_index);
-extern "C" void EmitIntType(long& r_new_index);
-extern "C" void EmitUIntType(long& r_new_index);
-extern "C" void EmitFloatType(long& r_new_index);
-extern "C" void EmitDoubleType(long& r_new_index);
-extern "C" void EmitAnyType(long& r_new_index);
+extern "C" void EmitOptionalType(long index, long& r_new_index);extern "C" void EmitAnyType(long& r_new_index);
 extern "C" void EmitBooleanType(long& r_new_index);
 extern "C" void EmitIntegerType(long& r_new_index);
 extern "C" void EmitRealType(long& r_new_index);
@@ -1137,54 +1130,6 @@ void EmitOptionalType(long base_index, long& r_new_index)
     r_new_index = t_index;
 
     Debug_Emit("OptionalType(%ld -> %ld)", base_index, r_new_index);
-}
-
-void EmitPointerType(long& r_new_index)
-{
-    if (!define_builtin_typeinfo("Pointer", r_new_index))
-        return;
-
-    Debug_Emit("PointerType(-> %ld)", r_new_index);
-}
-
-void EmitBoolType(long& r_new_index)
-{
-    if (!define_builtin_typeinfo("CBool", r_new_index))
-        return;
-
-    Debug_Emit("BoolType(-> %ld)", r_new_index);
-}
-
-void EmitIntType(long& r_new_index)
-{
-    if (!define_builtin_typeinfo("CInt", r_new_index))
-        return;
-
-    Debug_Emit("IntType(-> %ld)", r_new_index);
-}
-
-void EmitUIntType(long& r_new_index)
-{
-    if (!define_builtin_typeinfo("CUint", r_new_index))
-        return;
-
-    Debug_Emit("UIntType(-> %ld)", r_new_index);
-}
-
-void EmitFloatType(long& r_new_index)
-{
-    if (!define_builtin_typeinfo("CFloat", r_new_index))
-        return;
-
-    Debug_Emit("FloatType(-> %ld)", r_new_index);
-}
-
-void EmitDoubleType(long& r_new_index)
-{
-    if (!define_builtin_typeinfo("CDouble", r_new_index))
-        return;
-
-    Debug_Emit("DoubleType(-> %ld)", r_new_index);
 }
 
 void EmitAnyType(long& r_new_index)

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -189,12 +189,6 @@
     EmitDefinedType
     EmitForeignType
     EmitOptionalType
-    EmitPointerType
-    EmitBoolType
-    EmitIntType
-    EmitUIntType
-    EmitFloatType
-    EmitDoubleType
     EmitAnyType
     EmitBooleanType
     EmitIntegerType
@@ -592,12 +586,6 @@
 'action' EmitOptionalType(INT -> INT)
 --'action' EmitNamedType(Module: NAME, Name: NAME -> INT)
 --'action' EmitAliasType(Name: NAME, TypeIndex: INT -> INT)
-'action' EmitPointerType(-> INT)
-'action' EmitBoolType(-> INT)
-'action' EmitIntType(-> INT)
-'action' EmitUIntType(-> INT)
-'action' EmitFloatType(-> INT)
-'action' EmitDoubleType(-> INT)
 'action' EmitAnyType(-> INT)
 'action' EmitBooleanType(-> INT)
 'action' EmitIntegerType(-> INT)


### PR DESCRIPTION
This patch adds the complete set of integer types both explicitly sized and C types. Furthermore it makes Java primitive type mappings more strict.