### PR TITLE
[[ Bug 19307 ]] Invalidate children of deleted object

### DIFF
--- a/docs/notes/bugfix-19307.md
+++ b/docs/notes/bugfix-19307.md
@@ -1,0 +1,1 @@
+# Prevent crash when saving standalone while player is playing

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -497,6 +497,18 @@ Boolean MCControl::del(bool p_check_flag)
 	if (getselected())
 		getcard()->dirtyselection(rect);
 
+    // IM-2012-05-16 [[ BZ 10212 ]] deleting the dragtarget control in response
+    // to a 'dragdrop' message would leave these globals pointing to the deleted
+    // object, leading to an infinite loop if the target was a field
+    if (MCdragdest == this)
+    {
+        MCdragdest = nil;
+        MCdropfield = nil;
+    }
+    
+    if (MCdragsource == this)
+        MCdragsource = nil;
+    
 	switch (parent->gettype())
 	{
         case CT_STACK:
@@ -519,18 +531,6 @@ Boolean MCControl::del(bool p_check_flag)
         default:
             MCUnreachable();
 	}
-
-    // IM-2012-05-16 [[ BZ 10212 ]] deleting the dragtarget control in response
-    // to a 'dragdrop' message would leave these globals pointing to the deleted
-    // object, leading to an infinite loop if the target was a field
-    if (MCdragdest == this)
-    {
-        MCdragdest = nil;
-        MCdropfield = nil;
-    }
-    
-    if (MCdragsource == this)
-        MCdragsource = nil;
     
     // MCObject now does things on del(), so we must make sure we finish by
     // calling its implementation.

--- a/engine/src/desktop-stack.cpp
+++ b/engine/src/desktop-stack.cpp
@@ -254,27 +254,10 @@ void MCStack::stop_externals()
 	Boolean oldlock = MClockmessages;
 	MClockmessages = True;
 	
-	MCPlayer *tptr = MCplayers;
-	
-#ifdef FEATURE_PLATFORM_PLAYER
-    while(tptr != NULL)
-    {
-        if (tptr -> getstack() == this)
-            tptr -> playstop();
-        tptr = tptr -> getnextplayer();
-    }
-#else
-	while (tptr != NULL)
-	{
-		if (tptr->getstack() == this)
-		{
-			if (tptr->playstop())
-				tptr = MCplayers; // was removed, start search over
-		}
-		else
-			tptr = tptr->getnextplayer();
-	}
-#endif
+    MCPlayer::SyncPlayers(this, nil);
+    
+    MCPlayer::StopPlayers(this);
+    
 	destroywindowshape();
 	
 	MClockmessages = oldlock;

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -1332,7 +1332,7 @@ void MCPlatformHandleTextInputAction(MCPlatformWindowRef p_window, MCPlatformTex
 
 static MCPlayer *find_player(MCPlatformPlayerRef p_player)
 {
-	for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
+	for(MCPlayerHandle t_player = MCplayers; t_player.IsValid(); t_player = t_player -> getnextplayer())
 	{
 		if (t_player -> getplatformplayer() == p_player)
             return t_player;

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -336,7 +336,9 @@ void MCDispatch::removestack(MCStack *sptr)
 void MCDispatch::destroystack(MCStack *sptr, Boolean needremove)
 {
 	if (needremove)
-		removestack(sptr);
+    {
+        sptr -> dodel();
+    }
 	if (sptr == MCstaticdefaultstackptr)
 		MCstaticdefaultstackptr = stacks;
 	if (sptr == MCdefaultstackptr)

--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -806,16 +806,4 @@ void MCGroup::GetClipsToRect(MCExecContext& ctxt, bool& r_clips_to_rect)
 void MCGroup::SetVisible(MCExecContext &ctxt, uinteger_t part, bool setting)
 {
 	MCControl::SetVisible(ctxt, part, setting);
-#ifdef PLATFORM_PLAYER
-	for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-	{
-		if (t_player -> getparent() == this)
-		{
-			if (setting)
-				t_player -> attachplayer();
-			else
-				t_player -> detachplayer();
-		}
-	}
-#endif
 }

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4555,14 +4555,7 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 			oldstack->kunfocus();
 			t_stack->close();
 			
-			MCPlayer *tptr = MCplayers;
-			while (tptr != NULL)
-			{
-				MCPlayer *oldptr = tptr;
-				tptr = tptr->getnextplayer();
-				if (oldptr->getstack() == oldstack)
-					oldptr->close();
-			}
+            MCPlayer::ClosePlayers(oldstack);
 
 			if (!t_stack->takewindow(oldstack))
 			{

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -2646,16 +2646,7 @@ void MCInterfaceEvalVideoClipOfStackByName(MCExecContext& ctxt, MCObjectPtr p_st
     if (!static_cast<MCStack *>(p_stack . object) -> getAVname(CT_VIDEO_CLIP, p_name, t_clip))
     {
         IO_cleanprocesses();
-        MCPlayer *tptr = MCplayers;
-        while (tptr != NULL)
-        {
-            if (tptr -> hasname(p_name))
-            {
-                t_clip = tptr;
-                break;
-            }
-            tptr = tptr->getnextplayer();
-        }
+        t_clip = MCPlayer::FindPlayerByName(p_name);
     }
     
     if (t_clip != nil)

--- a/engine/src/exec-multimedia.cpp
+++ b/engine/src/exec-multimedia.cpp
@@ -213,16 +213,16 @@ void MCMultimediaEvalMovie(MCExecContext& ctxt, MCStringRef& r_string)
 	{
 		t_success = MCListCreateMutable('\n', &t_list);
 
-		MCPlayer *tptr = MCplayers;
-		while (t_success && tptr != NULL)
+		MCPlayerHandle t_player = MCplayers;
+		while (t_success && t_player.IsValid())
 		{
-			if (tptr->isdisposable())
+			if (t_player->isdisposable())
 			{
 				MCAutoValueRef t_string;
-				t_success = tptr->names(P_NAME, &t_string) && MCListAppend(*t_list, *t_string);
+				t_success = t_player->names(P_NAME, &t_string) && MCListAppend(*t_list, *t_string);
 				t_playing = true;
 			}
-			tptr = tptr->getnextplayer();
+			t_player = t_player->getnextplayer();
 		}
 	}
 	if (t_success)
@@ -442,39 +442,24 @@ void MCMultimediaExecAnswerRecord(MCExecContext &ctxt)
 MCPlayer* MCMultimediaExecGetClip(MCStringRef p_clip, int p_chunk_type)
 {
 	IO_cleanprocesses();
-	MCPlayer *tptr;
 	// Lookup the name we are searching for. If it doesn't exist, then no object can
 	// have it as a name.
-	tptr = nil;
 	if (p_chunk_type == CT_EXPRESSION)
 	{
         // AL-2014-05-27: [[ Bug 12517 ]] MCNameLookup does not increase the ref count
-		MCNameRef t_obj_name;
-		t_obj_name = MCNameLookup(p_clip);
-		if (t_obj_name != nil)
-		{
-			tptr = MCplayers;
-			while (tptr != NULL)
-			{
-				if (tptr -> hasname(t_obj_name))
-					break;
-				tptr = tptr->getnextplayer();
-			}
-		}
+		return MCPlayer::FindPlayerByName(MCNameLookup(p_clip));
 	}
-	else if (p_chunk_type == CT_ID)
+	
+    if (p_chunk_type == CT_ID)
 	{
-		tptr = MCplayers;
-		uint4 t_id;
-		MCU_stoui4(p_clip, t_id);
-		while (tptr != NULL)
-		{
-			if (tptr -> getaltid() == t_id)
-				break;
-			tptr = tptr->getnextplayer();
-		}
+        uint4 t_id;
+        if (!MCU_stoui4(p_clip, t_id))
+            return nullptr;
+
+        return MCPlayer::FindPlayerById(t_id);
 	}
-	return tptr;
+
+    MCUnreachableReturn(nullptr);
 }
 
 void MCMultimediaExecLoadVideoClip(MCExecContext& ctxt, MCStack *p_target, int p_chunk_type, MCStringRef p_filename, bool p_looping, MCPoint *p_at, MCStringRef p_options, bool p_prepare)
@@ -871,15 +856,9 @@ void MCMultimediaSetPlayLoudness(MCExecContext& ctxt, uinteger_t p_loudness)
     if (MCSystemSetPlayLoudness(p_loudness))
         return;
 #endif
-    if (MCplayers)
-    {
-        MCPlayer *tptr = MCplayers;
-        while (tptr != NULL)
-        {
-            tptr->setvolume(p_loudness);
-            tptr = tptr->getnextplayer();
-        }
-    }
+    
+    MCPlayer::SetPlayersVolume(p_loudness);
+    
     MCS_setplayloudness(p_loudness);
 
 	MCtemplateaudio -> SetPlayLoudness(ctxt, p_loudness);

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -103,10 +103,6 @@ MCPropertyInfo MCGroup::kProperties[] =
     // MERG-2013-08-12: [[ ClipsToRect ]] If true group clips to the set rect rather than the rect of children
     DEFINE_RW_OBJ_PROPERTY(P_CLIPS_TO_RECT, Bool, MCGroup, ClipsToRect)
     // PM-2015-07-02: [[ Bug 13262 ]] Make sure we attach/detach the player when showing/hiding a group that has a player
-#ifdef PLATFORM_PLAYER
-    DEFINE_WO_OBJ_PART_PROPERTY(P_VISIBLE, Bool, MCGroup, Visible)
-    DEFINE_WO_OBJ_PART_PROPERTY(P_INVISIBLE, Bool, MCGroup, Invisible)
-#endif
 };
 
 MCObjectPropertyTable MCGroup::kPropertyTable =

--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -111,15 +111,17 @@ void IO_cleanprocesses()
 #ifdef X11
 			if (MCprocesses[i].mode == OM_VCLIP)
 			{
-				MCPlayer *tptr = MCplayers;
-				while (tptr != NULL)
+				MCPlayerHandle t_player = MCplayers;
+				while (t_player.IsValid())
 				{
-					if (MCNameIsEqualToCString(MCprocesses[i].name, tptr->getcommand(), kMCCompareExact))
+					if (MCNameIsEqualToCString(MCprocesses[i].name,
+                                               t_player->getcommand(),
+                                               kMCCompareExact))
 					{
-						tptr->playstop(); // removes from linked list
+						t_player->playstop(); // removes from linked list
 						break;
 					}
-					tptr = tptr->getnextplayer();
+					t_player = t_player->getnextplayer();
 				}
 			}
 #endif

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -861,6 +861,19 @@ void MCObject::removereferences()
     MCscreen->cancelmessageobject(this, NULL);
     removefrom(MCfrontscripts);
     removefrom(MCbackscripts);
+    
+    // If the object is marked as being used as a parentScript, flush the parentScript
+    // table so we don't get any dangling pointers.
+    if (m_is_parent_script)
+    {
+        MCParentScript::FlushObject(this);
+        m_is_parent_script = false;
+    }
+    
+    // This object is in the process of being deleted; invalidate any weak refs
+    // and prevent any new ones from being created.
+    m_weak_proxy->Clear();
+    m_weak_proxy = nil;
 }
 
 bool MCObject::isdeletable(bool p_check_flag)
@@ -877,19 +890,6 @@ bool MCObject::isdeletable(bool p_check_flag)
 
 Boolean MCObject::del(bool p_check_flag)
 {
-    // If the object is marked as being used as a parentScript, flush the parentScript
-    // table so we don't get any dangling pointers.
-	if (m_is_parent_script)
-	{
-		MCParentScript::FlushObject(this);
-        m_is_parent_script = false;
-    }
-	
-	// This object is in the process of being deleted; invalidate any weak refs
-	// and prevent any new ones from being created.
-	m_weak_proxy->Clear();
-	m_weak_proxy = nil;
-	
 	return True;
 }
 

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -3114,9 +3114,8 @@ MCImageBitmap *MCObject::snapshot(const MCRectangle *p_clip, const MCPoint *p_si
 		t_context -> setfunction(GXblendSrcOver);
 
         // PM-2014-11-11: [[ Bug 13970 ]] Make sure each player is buffered correctly for export snapshot
-        for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-            t_player -> syncbuffering(t_context);
-            
+        MCPlayer::SyncPlayers(getstack(), t_context);
+        
 #ifdef FEATURE_PLATFORM_PLAYER
         MCPlatformWaitForEvent(0.0, true);
 #endif

--- a/engine/src/objptr.cpp
+++ b/engine/src/objptr.cpp
@@ -80,7 +80,7 @@ void MCObjptr::setparent(MCObject *newparent)
 MCObjectHandle MCObjptr::Get()
 {
     // If the object pointer hasn't yet been bound, resolve it using the ID
-    if (!m_objptr.IsBound())
+    if (!m_objptr.IsBound() && m_parent . IsValid())
     {
         // Note that this may return null if the control doesn't exist
         m_objptr = m_parent->getstack()->getcontrolid(CT_LAYER, m_id);

--- a/engine/src/player-legacy.cpp
+++ b/engine/src/player-legacy.cpp
@@ -124,12 +124,8 @@ MCPlayer::MCPlayer(const MCPlayer &sref) : MCControl(sref)
 
 MCPlayer::~MCPlayer()
 {
-	// OK-2009-04-30: [[Bug 7517]] - Ensure the player is actually closed before deletion, otherwise dangling references may still exist.
-	while (opened)
-		close();
-	
-	playstop();
-	
+    removefromplayers();
+    
 #ifdef FEATURE_MPLAYER
 	if ( m_player != NULL )
 		delete m_player ;
@@ -655,7 +651,7 @@ Boolean MCPlayer::playstop()
     
 	freetmp();
     
-	if (!MCplayers)
+	if (MCplayers)
 	{
 		if (MCplayers == this)
 			MCplayers = nextplayer;

--- a/engine/src/player-legacy.h
+++ b/engine/src/player-legacy.h
@@ -130,6 +130,9 @@ public:
 	// MW-2011-09-06: [[ Redraw ]] Added 'sprite' option - if true, ink and opacity are not set.
 	virtual void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite);
     
+    virtual void removereferences(void);
+    void removefromplayers(void);
+    
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);

--- a/engine/src/player-legacy.h
+++ b/engine/src/player-legacy.h
@@ -98,9 +98,9 @@ public:
 	MCPlayer(const MCPlayer &sref);
 	virtual ~MCPlayer();
     
-    MCPlayer *getnextplayer()
+    MCPlayerHandle getnextplayer()
     {
-        return (MCPlayer*)nextplayer;
+        return nextplayer;
     }
     
 	// virtual functions from MCObject
@@ -473,7 +473,18 @@ public:
     
     virtual void GetDontUseQT(MCExecContext& ctxt, bool &p_dont_use_qt);
     virtual void SetDontUseQT(MCExecContext& ctxt, bool r_dont_use_qt);
-};
+    
+    // MCplayers handling
+    static void StopPlayers(MCStack* p_stack);
+    static void SyncPlayers(MCStack* p_stack, MCContext* p_context);
+    static void ClosePlayers(MCStack* p_stack);
+    static void SetPlayersVolume(uinteger_t p_volume);
+    
+    static MCPlayer* FindPlayerByName(MCNameRef p_name);
+    static MCPlayer* FindPlayerById(uint32_t p_id);
+    
 #endif // FEATURE_PLATFORM_PLAYER
+};
+
 
 #endif // PLAYER_LEGACY_H

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -875,7 +875,9 @@ MCPlayer::MCPlayer(const MCPlayer &sref) : MCControl(sref)
 }
 
 MCPlayer::~MCPlayer()
-{    
+{
+    removefromplayers();
+    
 	if (m_platform_player != nil)
 		MCPlatformPlayerRelease(m_platform_player);
     

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -875,29 +875,7 @@ MCPlayer::MCPlayer(const MCPlayer &sref) : MCControl(sref)
 }
 
 MCPlayer::~MCPlayer()
-{
-	// OK-2009-04-30: [[Bug 7517]] - Ensure the player is actually closed before deletion, otherwise dangling references may still exist.
-	while (opened)
-		close();
-	
-	playstop();
-    
-    // MW-2014-07-16: [[ Bug ]] Remove the player from the player's list.
-	if (MCplayers)
-	{
-		if (MCplayers == this)
-			MCplayers = nextplayer;
-		else
-		{
-			MCPlayer *tptr = MCplayers;
-			while (tptr->nextplayer && tptr->nextplayer != this)
-				tptr = tptr->nextplayer;
-			if (tptr->nextplayer == this)
-                tptr->nextplayer = nextplayer;
-		}
-	}
-	nextplayer = nil;
-    
+{    
 	if (m_platform_player != nil)
 		MCPlatformPlayerRelease(m_platform_player);
     
@@ -1736,22 +1714,6 @@ Boolean MCPlayer::playstop()
     redrawcontroller();
     
 	freetmp();
-    
-    /*
-	if (MCplayers != NULL)
-	{
-		if (MCplayers == this)
-			MCplayers = nextplayer;
-		else
-		{
-			MCPlayer *tptr = MCplayers;
-			while (tptr->nextplayer != NULL && tptr->nextplayer != this)
-				tptr = tptr->nextplayer;
-			if (tptr->nextplayer == this)
-                tptr->nextplayer = nextplayer;
-		}
-	}
-	nextplayer = NULL;*/
     
 	if (disposable)
 	{

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -133,6 +133,9 @@ public:
 	// MW-2011-09-06: [[ Redraw ]] Added 'sprite' option - if true, ink and opacity are not set.
 	virtual void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite);
     
+    virtual void removereferences(void);
+    void removefromplayers(void);
+    
 	// virtual functions from MCControl
 	IO_stat load(IO_handle stream, uint32_t version);
 	IO_stat extendedload(MCObjectInputStream& p_stream, uint32_t version, uint4 p_length);

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -96,9 +96,9 @@ public:
 	MCPlayer(const MCPlayer &sref);
 	virtual ~MCPlayer();
     
-    MCPlayer *getnextplayer()
+    MCPlayerHandle getnextplayer()
     {
-        return (MCPlayer*)nextplayer;
+        return nextplayer;
     }
     
 	// virtual functions from MCObject    
@@ -431,6 +431,17 @@ public:
     void detachplayer(void);
     
     void setmirrored(bool p_mirrored);
+    
+    // MCplayers handling
+    static void StopPlayers(MCStack* p_stack);
+    static void SyncPlayers(MCStack* p_stack, MCContext* p_context);
+    static void ClosePlayers(MCStack* p_stack);
+    static void AttachPlayers(MCStack* p_stack);
+    static void DetachPlayers(MCStack* p_stack);
+    static void SetPlayersVolume(uinteger_t p_volume);
+    
+    static MCPlayer* FindPlayerByName(MCNameRef p_name);
+    static MCPlayer* FindPlayerById(uint32_t p_id);
 };
 #endif
 

--- a/engine/src/player-srv-stubs.cpp
+++ b/engine/src/player-srv-stubs.cpp
@@ -86,12 +86,6 @@ MCPlayer::MCPlayer(const MCPlayer &sref) : MCControl(sref)
 
 MCPlayer::~MCPlayer()
 {
-	// OK-2009-04-30: [[Bug 7517]] - Ensure the player is actually closed before deletion, otherwise dangling references may still exist.
-	while (opened)
-		close();
-	
-	playstop();
-	
 	MCValueRelease(filename);
 	MCValueRelease(userCallbackStr);
 }

--- a/engine/src/player-srv-stubs.cpp
+++ b/engine/src/player-srv-stubs.cpp
@@ -86,6 +86,8 @@ MCPlayer::MCPlayer(const MCPlayer &sref) : MCControl(sref)
 
 MCPlayer::~MCPlayer()
 {
+    removefromplayers();
+    
 	MCValueRelease(filename);
 	MCValueRelease(userCallbackStr);
 }

--- a/engine/src/player.cpp
+++ b/engine/src/player.cpp
@@ -24,6 +24,8 @@
 #include "player.h"
 #include "exec.h"
 
+#include "globals.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 MCPropertyInfo MCPlayer::kProperties[] =
@@ -77,4 +79,36 @@ MCObjectPropertyTable MCPlayer::kPropertyTable =
 	sizeof(kProperties) / sizeof(kProperties[0]),
 	&kProperties[0],
 };
+
+void MCPlayer::removereferences()
+{
+    // OK-2009-04-30: [[Bug 7517]] - Ensure the player is actually closed before deletion, otherwise dangling references may still exist.
+    while (opened)
+        close();
+    
+    playstop();
+    
+    removefromplayers();
+    
+    MCObject::removereferences();
+}
+
+void MCPlayer::removefromplayers()
+{
+    if (MCplayers)
+    {
+        if (MCplayers == this)
+            MCplayers = nextplayer;
+        else
+        {
+            MCPlayer *tptr = MCplayers;
+            while (tptr->nextplayer.IsBound() && tptr->nextplayer != this)
+                tptr = tptr->nextplayer;
+            
+            if (tptr->nextplayer == this)
+                tptr->nextplayer = nextplayer;
+        }
+     }
+     nextplayer = nullptr;
+}
 

--- a/engine/src/player.cpp
+++ b/engine/src/player.cpp
@@ -88,8 +88,6 @@ void MCPlayer::removereferences()
     
     playstop();
     
-    removefromplayers();
-    
     MCObject::removereferences();
 }
 
@@ -102,13 +100,122 @@ void MCPlayer::removefromplayers()
         else
         {
             MCPlayer *tptr = MCplayers;
-            while (tptr->nextplayer.IsBound() && tptr->nextplayer != this)
+            while (tptr->nextplayer.IsValid() && tptr->nextplayer != this)
                 tptr = tptr->nextplayer;
             
-            if (tptr->nextplayer == this)
+            if (tptr->nextplayer.IsValid() && tptr->nextplayer == this)
                 tptr->nextplayer = nextplayer;
         }
      }
      nextplayer = nullptr;
 }
 
+void MCPlayer::SyncPlayers(MCStack* p_stack, MCContext *p_context)
+{
+    for(MCPlayerHandle t_player = MCplayers;
+        t_player.IsValid();
+        t_player = t_player -> getnextplayer())
+    {
+        if (p_stack == nullptr ||
+            t_player -> getstack() == p_stack)
+            t_player -> syncbuffering(p_context);
+    }
+}
+
+#ifdef FEATURE_PLATFORM_PLAYER
+void MCPlayer::DetachPlayers(MCStack* p_stack)
+{
+    for(MCPlayerHandle t_player = MCplayers;
+        t_player.IsValid();
+        t_player = t_player -> getnextplayer())
+    {
+        if (t_player -> getstack() == p_stack)
+            t_player -> detachplayer();
+    }
+}
+
+void MCPlayer::AttachPlayers(MCStack* p_stack)
+{
+    for(MCPlayerHandle t_player = MCplayers;
+        t_player.IsValid();
+        t_player = t_player -> getnextplayer())
+    {
+        if (t_player -> getstack() == p_stack)
+            t_player -> attachplayer();
+    }
+}
+#endif
+
+void MCPlayer::StopPlayers(MCStack* p_stack)
+{
+    MCPlayerHandle t_player = MCplayers;
+    while(t_player.IsValid())
+    {
+        if (t_player -> getstack() == p_stack)
+        {
+#ifdef FEATURE_PLATFORM_PLAYER
+            t_player->playstop();
+#else
+            if (t_player->playstop())
+            {
+                // player was removed from list, start search over
+                t_player = MCplayers;
+                continue;
+            }
+                
+#endif
+        }
+        t_player = t_player->getnextplayer();
+    }
+}
+
+void MCPlayer::ClosePlayers(MCStack* p_stack)
+{
+    MCPlayerHandle t_player = MCplayers;
+    while(t_player.IsValid())
+    {
+        MCPlayer *oldptr = t_player;
+        t_player = t_player->getnextplayer();
+        if (oldptr->getstack() == p_stack)
+            oldptr->close();
+    }
+}
+
+MCPlayer* MCPlayer::FindPlayerByName(MCNameRef p_name)
+{
+    MCPlayerHandle t_player = MCplayers;
+    while (t_player.IsValid())
+    {
+        if (t_player -> hasname(p_name))
+        {
+            return t_player;
+        }
+        t_player = t_player->getnextplayer();
+    }
+    
+    return nil;
+}
+
+MCPlayer* MCPlayer::FindPlayerById(uint32_t p_id)
+{
+    MCPlayerHandle t_player = MCplayers;
+    while (t_player.IsValid())
+    {
+        if (t_player -> getaltid() == p_id)
+        {
+            return t_player;
+        }
+        t_player = t_player->getnextplayer();
+    }
+    return nil;
+}
+
+void MCPlayer::SetPlayersVolume(uinteger_t p_volume)
+{
+    MCPlayerHandle t_player = MCplayers;
+    while (t_player.IsValid())
+    {
+        t_player -> setvolume(p_volume);
+        t_player = t_player->getnextplayer();
+    }
+}

--- a/engine/src/printer.cpp
+++ b/engine/src/printer.cpp
@@ -37,11 +37,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "mode.h"
 
-// SN-2014-08-25: [[ Bug 13187 ]] Added for the MCplayers' syncbuffering call
-#ifdef FEATURE_PLATFORM_PLAYER
-#include "platform.h"
-#endif
-
 extern char *strndup(const char *p_string, unsigned int p_length);
 
 MCPrinter::MCPrinter(void)
@@ -732,9 +727,7 @@ void MCPrinter::DoPrint(MCCard *p_card, const MCRectangle& p_src, const MCRectan
 		SetStatusFromResult(m_device -> Begin(t_src_printer_rect, t_dst_printer_rect, t_context));
         
         // SN-2014-08-25: [[ Bug 13187 ]] MCplayers' syncbuffering relocated
-        for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-            if (t_player -> getstack() == p_card -> getstack())
-                t_player -> syncbuffering(t_context);
+        MCPlayer::SyncPlayers(p_card->getstack(), t_context);
 #ifdef FEATURE_PLATFORM_PLAYER
         MCPlatformWaitForEvent(0.0, true);
 #endif

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1394,66 +1394,8 @@ Boolean MCStack::del(bool p_check_flag)
 	
     notifyattachments(kMCStackAttachmentEventDeleting);
     
-	if (MCdispatcher->ismainstack(this))
-	{
-		MCdispatcher->removestack(this);
-	}
-        else if (MCdispatcher->is_transient_stack(this))
-        {
-                MCdispatcher->remove_transient_stack(this);
-        }
-	else if (parent->gettype() == CT_STACK)
-	{
-		remove(parent.GetAs<MCStack>()->substacks);
-		// MW-2012-09-07: [[ Bug 10372 ]] If the stack no longer has substacks then make sure we
-		//   undo the extraopen.
-		if (parent.GetAs<MCStack>()->substacks == nil)
-			parent.GetAs<MCStack>()->extraclose(true);
-	}
-        else
-        {
-                // One of the above conditions should always be true
-                MCUnreachable();
-        }
-
-    if (MCtopstackptr == this)
-    {
-        MCtopstackptr = nil;
-        MCstacks->top(nil);
-    }
-    if (MCstaticdefaultstackptr == this)
-		MCstaticdefaultstackptr = MCtopstackptr;
-	if (MCdefaultstackptr == this)
-		MCdefaultstackptr = MCstaticdefaultstackptr;
-
-	// MW-2008-10-28: [[ ParentScripts ]] If this stack has its 'has parentscripts'
-	//   flag set, flush the parentscripts table.
-	if (getextendedstate(ECS_HAS_PARENTSCRIPTS))
-		MCParentScript::FlushStack(this);
-    
-    if (needs != NULL)
-    {
-        while (nneeds--)
-            needs[nneeds]->removelink(this);
-        
-        delete needs;
-        needs = NULL;
-    }
-    
     removereferences();
-    
-    uint2 i = 0;
-    while (i < MCnusing)
-        if (MCusing[i] == this)
-        {
-            MCnusing--;
-            uint2 j;
-            for (j = i ; j < MCnusing ; j++)
-                MCusing[j] = MCusing[j + 1];
-        }
-        else
-            i++;
-    
+        
     // MCObject now does things on del(), so we must make sure we finish by
     // calling its implementation.
     return MCObject::del(true);
@@ -1500,6 +1442,64 @@ void MCStack::removereferences()
         }
         while(t_card != cards);
     }
+    
+    if (MCdispatcher->ismainstack(this))
+    {
+        MCdispatcher->removestack(this);
+    }
+    else if (MCdispatcher->is_transient_stack(this))
+    {
+        MCdispatcher->remove_transient_stack(this);
+    }
+    else if (parent->gettype() == CT_STACK)
+    {
+        remove(parent.GetAs<MCStack>()->substacks);
+        // MW-2012-09-07: [[ Bug 10372 ]] If the stack no longer has substacks then make sure we
+        //   undo the extraopen.
+        if (parent.GetAs<MCStack>()->substacks == nil)
+            parent.GetAs<MCStack>()->extraclose(true);
+    }
+    else
+    {
+        // One of the above conditions should always be true
+        MCUnreachable();
+    }
+    
+    if (MCtopstackptr == this)
+    {
+        MCtopstackptr = nil;
+        MCstacks->top(nil);
+    }
+    if (MCstaticdefaultstackptr == this)
+        MCstaticdefaultstackptr = MCtopstackptr;
+    if (MCdefaultstackptr == this)
+        MCdefaultstackptr = MCstaticdefaultstackptr;
+    
+    // MW-2008-10-28: [[ ParentScripts ]] If this stack has its 'has parentscripts'
+    //   flag set, flush the parentscripts table.
+    if (getextendedstate(ECS_HAS_PARENTSCRIPTS))
+        MCParentScript::FlushStack(this);
+    
+    if (needs != NULL)
+    {
+        while (nneeds--)
+            needs[nneeds]->removelink(this);
+        
+        delete needs;
+        needs = NULL;
+    }
+
+    uint2 i = 0;
+    while (i < MCnusing)
+        if (MCusing[i] == this)
+        {
+            MCnusing--;
+            uint2 j;
+            for (j = i ; j < MCnusing ; j++)
+                MCusing[j] = MCusing[j + 1];
+        }
+        else
+            i++;
     
     MCObject::removereferences();
 }

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -555,12 +555,6 @@ MCStack::~MCStack()
 	MCValueRelease(title);
 	MCValueRelease(titlestring);
 
-	if (window != NULL && !(state & CS_FOREIGN_WINDOW))
-	{
-		stop_externals();
-		destroywindow();
-	}
-
 	// Clear and free the id cache before removing any controls
 	freeobjectidcache();
 	
@@ -1362,43 +1356,54 @@ bool MCStack::isdeletable(bool p_check_flag)
     return true;
 }
 
-Boolean MCStack::del(bool p_check_flag)
+Boolean MCStack::dodel()
 {
-    if (!isdeletable(p_check_flag))
-	   return False;
-
-	while (substacks)
-	{
-		if (!substacks -> del(false))
-			return False;
-	}
-	
     MCscreen->ungrabpointer();
     MCdispatcher->removemenu();
     
     setstate(True, CS_DELETE_STACK);
     
-	if (opened)
-	{
-		// MW-2007-04-22: [[ Bug 4203 ]] Coerce the flags to include F_DESTROY_WINDOW to ensure we don't
-		//   get system resource accumulation in a tight create/destroy loop.
-		flags |= F_DESTROY_WINDOW;
-		close();
-	}
-
-	if (curcard != NULL)
-		curcard->message(MCM_delete_stack);
-	else
-		if (cards != NULL)
-			cards->message(MCM_delete_stack);
-	
+    if (opened)
+    {
+        // MW-2007-04-22: [[ Bug 4203 ]] Coerce the flags to include F_DESTROY_WINDOW to ensure we don't
+        //   get system resource accumulation in a tight create/destroy loop.
+        flags |= F_DESTROY_WINDOW;
+        close();
+    }
+    
+    if (curcard != NULL)
+        curcard->message(MCM_delete_stack);
+    else
+        if (cards != NULL)
+            cards->message(MCM_delete_stack);
+    
     notifyattachments(kMCStackAttachmentEventDeleting);
+    
+    if (window != NULL && !(state & CS_FOREIGN_WINDOW))
+    {
+        stop_externals();
+        destroywindow();
+    }
     
     removereferences();
         
     // MCObject now does things on del(), so we must make sure we finish by
     // calling its implementation.
     return MCObject::del(true);
+}
+
+Boolean MCStack::del(bool p_check_flag)
+{
+    if (!isdeletable(p_check_flag))
+	   return False;
+
+    while (substacks)
+    {
+        if (!substacks -> del(false))
+            return False;
+    }
+    
+    return dodel();
 }
 
 void MCStack::removereferences()

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -354,6 +354,7 @@ public:
 	virtual void applyrect(const MCRectangle &nrect);
 
     virtual void removereferences(void);
+    Boolean dodel(void);
 	virtual Boolean del(bool p_check_flag);
     virtual bool isdeletable(bool p_check_flag);
     

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -2288,9 +2288,7 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
     
 #ifdef FEATURE_PLATFORM_PLAYER
     // PM-2014-10-13: [[ Bug 13569 ]] Detach all players before any messages are sent
-    for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-        if (t_player -> getstack() == curcard -> getstack())
-            t_player -> detachplayer();
+    MCPlayer::DetachPlayers(curcard -> getstack());
 #endif
 		
 	// MW-2008-10-31: [[ ParentScripts ]] Send preOpenControl appropriately
@@ -2315,9 +2313,7 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
 
 #ifdef FEATURE_PLATFORM_PLAYER
     // PM-2014-10-13: [[ Bug 13569 ]] after any messages are sent, attach all players previously detached
-    for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-        if (t_player -> getstack() == curcard -> getstack())
-            t_player -> attachplayer();
+    MCPlayer::AttachPlayers(curcard -> getstack());
 #endif
 	if (mode == WM_PULLDOWN || mode == WM_POPUP || mode == WM_CASCADE || (mode == WM_OPTION && MClook != LF_WIN95))
 	{
@@ -2946,12 +2942,7 @@ void MCStack::view_surface_redrawwindow(MCStackSurface *p_surface, MCGRegionRef 
 	t_tilecache = view_gettilecache();
 	
     // SN-2014-08-25: [[ Bug 13187 ]] MCplayers's syncbuffering relocated
-    for(MCPlayerHandle t_player = MCplayers; t_player.IsValid(); t_player = t_player -> getnextplayer())
-	{
-        	if (t_player -> getstack() == this)
-            	t_player -> syncbuffering(nil);
-	}
-    
+    MCPlayer::SyncPlayers(this, nil);
 	if (t_tilecache == nil || !MCTileCacheIsValid(t_tilecache))
 	{
         MCGIntegerRectangle t_bounds;

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1162,9 +1162,7 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
         {
 #ifdef FEATURE_PLATFORM_PLAYER
             // PM-2014-10-13: [[ Bug 13569 ]] Detach all players before any messages are sent
-            for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-                if (t_player -> getstack() == curcard -> getstack())
-                    t_player -> detachplayer();
+            MCPlayer::DetachPlayers(this);
 #endif
                 
             t_error = curcard->message(MCM_preopen_card) == ES_ERROR || curcard != card || !opened;
@@ -1175,9 +1173,7 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
             t_error = curcard -> opencontrols(true) == ES_ERROR || curcard != card || !opened;
 #ifdef FEATURE_PLATFORM_PLAYER
             // PM-2014-10-13: [[ Bug 13569 ]] after any messages are sent, attach all players previously detached
-             for(MCPlayer *t_player = MCplayers; t_player != nil; t_player = t_player -> getnextplayer())
-                 if (t_player -> getstack() == curcard -> getstack())
-                    t_player -> attachplayer();
+             MCPlayer::AttachPlayers(this);
 #endif
         }
         

--- a/engine/src/stacklst.cpp
+++ b/engine/src/stacklst.cpp
@@ -112,7 +112,7 @@ void MCStacklist::destroy()
 		while (stacks != NULL)
 		{
 			MCStacknode *tptr = stacks->remove(stacks);
-			MCdispatcher->destroystack(tptr->getstack(), True);
+			tptr -> getstack() -> del(false);
 			delete tptr;
 		}
 		MClockmessages = oldstate;

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -1876,8 +1876,7 @@ void MCU_choose_tool(MCExecContext& ctxt, MCStringRef p_input, Tool p_tool)
     }
     
     // MW-2014-04-24: [[ Bug 12249 ]] Prod each player to make sure its buffered correctly for the new tool.
-    for(MCPlayer *t_player = MCplayers; t_player != NULL; t_player = t_player -> getnextplayer())
-        t_player -> syncbuffering(nil);
+    MCPlayer::SyncPlayers(nil, nil);
     
     MCdispatcher -> foreachstack(_MCStackNotifyToolChange, nil);
     

--- a/engine/src/w32stack.cpp
+++ b/engine/src/w32stack.cpp
@@ -640,15 +640,8 @@ void MCStack::stop_externals()
 {
 	Boolean oldlock = MClockmessages;
 	MClockmessages = True;
-	MCPlayer *tptr = MCplayers;
-	while (tptr != NULL)
-	{
-		MCPlayer *t_next = tptr->getnextplayer();
-		if (tptr->getstack() == this)
-			tptr->playstop();
-
-		tptr = t_next;
-	}
+    
+    MCPlayer::StopPlayers(this);
 
 	if (!MCnoui && window != DNULL)
 	{


### PR DESCRIPTION
When an object is deleted, all its children should be inaccessible
from the point of view of the object tree, so recursively invalidate
all the weak proxies as necessary.

Also ensure that players are closed and stopped when a parent is
deleted.