### PR TITLE
[[ Bug 19399 ]] Dont use dlopen on startup on Emscripten

### DIFF
--- a/docs/notes/bugfix-19399.md
+++ b/docs/notes/bugfix-19399.md
@@ -1,0 +1,1 @@
+# Prevent crash on startup of emscripten engine

--- a/engine/src/em-dc-mainloop.cpp
+++ b/engine/src/em-dc-mainloop.cpp
@@ -145,6 +145,12 @@ X_init(int argc,
 
 	/* ---------- More globals */
 
+	/* executable file name */
+	if (!MCsystem->PathFromNative(argv[0], MCcmd))
+	{
+		goto error_cleanup;
+	}
+
 	/* Locales */
 	if (!MCLocaleCreateWithName(MCSTR("en_US"), kMCBasicLocale))
 	{

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -229,11 +229,14 @@ static MCHookNativeControlsDescriptor s_native_control_desc =
 
 void MCS_common_init(void)
 {
+#if !defined(__EMSCRIPTEN__)
     MCSAutoLibraryRef t_self;
     MCSLibraryCreateWithAddress(reinterpret_cast<void *>(MCS_common_init),
                                 &t_self);
     MCSLibraryCopyPath(*t_self,
                        MCcmd);
+#endif
+    
     
 	MCsystem -> Initialize();    
     MCsystem -> SetErrno(errno);


### PR DESCRIPTION
To make this work we need to use the MAIN_MODULE flag which is
incompatible with ALLOW_MEMORY_GROWTH