### PR TITLE
[[ Bug 19457 ]] Fix crash when deleting selected objects

### DIFF
--- a/docs/notes/bugfix-19457.md
+++ b/docs/notes/bugfix-19457.md
@@ -1,0 +1,1 @@
+# Prevent crash when deleting selected objects with the backspace key

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1263,7 +1263,8 @@ int X_close(void)
 
 	MCstacks->closeall();
 	MCselected->clear(False);
-
+    MCundos->freestate();
+    
 	MCU_play_stop();
 #ifdef FEATURE_PLATFORM_RECORDER
     if (MCrecorder != nil)

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -540,36 +540,59 @@ Boolean MCSellist::cut()
 
 Boolean MCSellist::del()
 {
+    if (!IsDeletable())
+        return False;
+ 
+	if (nullptr == objects)
+        return False;
+
+    MCundos->freestate();
+    
+    MCStack *sptr = objects->m_ref->getstack();
+    while (objects != NULL)
+    {
+        MCSelnode *tptr = objects->remove(objects);
+        if (tptr->m_ref->gettype() >= CT_GROUP)
+        {
+            MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
+            uint2 num = 0;
+            cptr->getcard()->count(CT_LAYER, CT_UNDEFINED, cptr, num, True);
+            
+            Ustruct *us = new Ustruct;
+            us->type = UT_DELETE;
+            us->ud.layer = num;
+            MCundos->savestate(cptr, us);
+            
+            if (cptr->del(true))
+            {
+                tptr->m_ref = nil;
+            }
+        }
+        delete tptr;
+    }
+    sptr->message(MCM_selected_object_changed);
+    return True;
+}
+
+bool MCSellist::IsDeletable()
+{
+    if (nullptr == objects)
+        return false;
+    
     // Clear all deleted objects first
     Clean();
+
+    MCSelnode *t_object = objects;
+    do
+    {
+        if (!t_object->m_ref->isdeletable(true))
+            return false;
+        
+        t_object = t_object->next();
+    }
+    while (t_object != objects);
     
-    MCundos->freestate();
-	if (objects != NULL)
-	{
-		MCStack *sptr = objects->m_ref->getstack();
-		while (objects != NULL)
-		{
-			MCSelnode *tptr = objects->remove(objects);
-			if (tptr->m_ref->gettype() >= CT_GROUP)
-			{
-				MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
-				uint2 num = 0;
-				cptr->getcard()->count(CT_LAYER, CT_UNDEFINED, cptr, num, True);
-				if (cptr->del(true))
-				{
-					Ustruct *us = new Ustruct;
-					us->type = UT_DELETE;
-					us->ud.layer = num;
-					MCundos->savestate(cptr, us);
-					tptr->m_ref = nil;
-				}
-			}
-			delete tptr;
-		}
-		sptr->message(MCM_selected_object_changed);
-		return True;
-	}
-	return False;
+    return true;
 }
 
 void MCSellist::startmove(int2 x, int2 y, Boolean canclone)

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -156,8 +156,6 @@ void MCSellist::clear(Boolean message)
 		delete nodeptr;
 	}
     
-	MCundos->freestate();
-    
 	if (message && optr)
 		optr->message(MCM_selected_object_changed);
 }

--- a/engine/src/sellst.h
+++ b/engine/src/sellst.h
@@ -38,6 +38,7 @@ private:
 	Boolean dropclone;
     
     void Clean();
+    bool IsDeletable();
     
 public:
     

--- a/tests/lcs/core/interface/delete.livecodescript
+++ b/tests/lcs/core/interface/delete.livecodescript
@@ -38,3 +38,16 @@ on TestDeleteStackWithSubstack
 	
 	TestAssert "delete stack with substack no crash", true
 end TestDeleteStackWithSubstack
+
+on TestDeleteSelectedObjects
+	create stack
+	set the defaultStack to the short name of it
+	
+	create button
+	create field
+	select button 1 and field 1
+	
+	delete
+	
+	TestAssert "delete selected objects", the number of controls is 0
+end TestDeleteSelectedObjects

--- a/tests/lcs/core/interface/delete.livecodescript
+++ b/tests/lcs/core/interface/delete.livecodescript
@@ -51,3 +51,46 @@ on TestDeleteSelectedObjects
 	
 	TestAssert "delete selected objects", the number of controls is 0
 end TestDeleteSelectedObjects
+
+on TestDeleteSelectedCantDelete
+	create stack
+	set the defaultStack to the short name of it
+	
+	create button
+	
+	local tGroup
+	create group
+	put it into tGroup
+	
+	create field in tGroup
+	set the cantDelete of tGroup to true
+	
+	select button 1
+	delete
+	
+	select tGroup
+	delete
+	
+	local tThereIsAGroup
+	put there is a tGroup into tThereIsAGroup
+		
+	undo
+	
+	TestAssert "can't delete group with cantDelete true", tThereIsAGroup
+	TestAssert "undo previous delete after failed delete", there is a button 1
+end TestDeleteSelectedCantDelete
+
+on TestUndoAfterDeleteNothing
+	create stack
+	set the defaultStack to the short name of it
+	
+	create button
+	select button 1
+	delete
+
+	select empty
+	delete
+	undo
+	
+	TestAssert "undo previous delete after failed delete", there is a button 1
+end TestUndoAfterDeleteNothing


### PR DESCRIPTION
This also makes a couple of other improvements when deleting
selected objects:

- Check whether all controls can be deleted before deleting anything
- Don't clobber the undo queue when nothing actually happens on
deleting the selected objects