### PR TITLE
[[ Bug 19064 ]] Load builtin extension modules at engine startup

### DIFF
--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -317,10 +317,27 @@ void MCEngineExecLoadExtension(MCExecContext& ctxt, MCStringRef p_filename, MCSt
     MCEngineLoadExtensionFromData(ctxt, *t_data, p_resource_path);
  }
 
+/* This function frees the given loaded extension. It must have already been
+ * removed from the global MCextensions lists. */
+static void
+__MCEngineFreeExtension(MCLoadedExtension *p_extension)
+{
+    if (p_extension -> instance != nil)
+        MCScriptReleaseInstance(p_extension -> instance);
+    MCScriptReleaseModule(p_extension -> module);
+    MCValueRelease(p_extension -> module_name);
+    MCValueRelease(p_extension -> resource_path);
+    MCMemoryDelete(p_extension);
+}
+
 void MCEngineExecUnloadExtension(MCExecContext& ctxt, MCStringRef p_module_name)
 {
     MCNewAutoNameRef t_name;
-    MCNameCreate(p_module_name, &t_name);
+    if (!MCNameCreate(p_module_name, &t_name))
+    {
+        ctxt.Throw();
+        return;
+    }
     
     for(MCLoadedExtension *t_previous = nil, *t_ext = MCextensions; t_ext != nil; t_previous = t_ext, t_ext = t_ext -> next)
         if (MCNameIsEqualTo(t_ext -> module_name, *t_name))
@@ -355,19 +372,18 @@ void MCEngineExecUnloadExtension(MCExecContext& ctxt, MCStringRef p_module_name)
 				ctxt . SetTheResultToCString("module in use");
 				return;
 			}
-			
-            if (t_ext -> instance != nil)
-                MCScriptReleaseInstance(t_ext -> instance);
-            MCScriptReleaseModule(t_ext -> module);
-            MCValueRelease(t_ext -> module_name);
-			MCValueRelease(t_ext -> resource_path);
+            
+            /* Unlink the extension from the global linked-list */
             if (t_previous != nil)
                 t_previous -> next = t_ext -> next;
             else
                 MCextensions = t_ext -> next;
-            MCMemoryDelete(t_ext);
             
+            /* Makes sure the global handler list is refreshed on next use */
             MCextensionschanged = true;
+            
+            /* Free the extension struct and things it owns */
+            __MCEngineFreeExtension(t_ext);
             
 			return;
         }
@@ -1434,5 +1450,36 @@ static bool __script_try_to_convert_to_foreign(MCExecContext& ctxt, MCTypeInfoRe
     
     return true;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool
+MCExtensionInitialize(void)
+{
+    return MCScriptForEachBuiltinModule([](void *p_context, MCScriptModuleRef p_module) {
+        if (MCScriptIsModuleALibrary(p_module) ||
+            MCScriptIsModuleAWidget(p_module))
+        {
+            return MCEngineAddExtensionFromModule(p_module);
+        }
+
+        return true;
+    }, nullptr);
+}
+
+void
+MCExtensionFinalize(void)
+{
+    while(MCextensions != nullptr)
+    {
+        /* Unlink the extension from the global list */
+        MCLoadedExtension *t_ext = MCextensions;
+        MCextensions = MCextensions->next;
+        
+        /* Free the extensions */
+        __MCEngineFreeExtension(t_ext);
+    }
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -5594,6 +5594,9 @@ void MCNFCExecDisableNFCDispatch(MCExecContext& ctxt);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool MCExtensionInitialize(void);
+void MCExtensionFinalize(void);
+
 bool MCExtensionConvertToScriptType(MCExecContext& ctxt, MCValueRef& x_value);
 bool MCExtensionConvertFromScriptType(MCExecContext& ctxt, MCTypeInfoRef p_type, MCValueRef& x_value);
 

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1238,6 +1238,13 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 	
     MCwidgeteventmanager = new (nothrow) MCWidgetEventManager;
     
+    /* Now that the script engine state has been initialized, we can load all
+     * builtin extensions. */
+    if (!MCExtensionInitialize())
+    {
+        return false;
+    }
+    
 	// MW-2009-07-02: Clear the result as a startup failure will be indicated
 	//   there.
 	MCresult -> clear();
@@ -1249,6 +1256,9 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 
 int X_close(void)
 {
+    /* Finalize all builtin extensions */
+    MCExtensionFinalize();
+
 	// MW-2008-01-18: [[ Bug 5711 ]] Make sure we disable the backdrop here otherwise we
 	//   get crashiness on Windows due to hiding the backdrop calling WindowProc which
 	//   attempts to access stacks that have been deleted...

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -39,10 +39,14 @@ typedef MCScriptInstance *MCScriptInstanceRef;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+typedef bool (*MCScriptForEachBuiltinModuleCallback)(void *p_context, MCScriptModuleRef p_module);
+
 typedef bool (*MCScriptLoadLibraryCallback)(MCScriptModuleRef module, MCStringRef name, MCSLibraryRef& r_library);
 
 bool MCScriptInitialize(void);
 void MCScriptFinalize(void);
+
+bool MCScriptForEachBuiltinModule(MCScriptForEachBuiltinModuleCallback p_callback, void *p_context);
 
 void MCScriptSetLoadLibraryCallback(MCScriptLoadLibraryCallback callback);
 

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -338,6 +338,21 @@ bool MCScriptLoadLibrary(MCScriptModuleRef p_module, MCStringRef p_name, MCSLibr
                                     r_library);
 }
 
+bool
+MCScriptForEachBuiltinModule(MCScriptForEachBuiltinModuleCallback p_callback,
+                             void *p_context)
+{
+    for(MCBuiltinModule *t_module = s_builtin_modules; t_module != nullptr; t_module = t_module -> next)
+    {
+        if (!p_callback(p_context, t_module->handle))
+        {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
 MCSLibraryRef MCScriptGetLibrary(void)
 {
     return s_libscript_library;


### PR DESCRIPTION
This patch loads any builtin modules which are library or widget
extensions on startup of the script engine.

At present they are loaded in X_open, before the mainstack is
processed and unloaded in X_close, before anything else.

Note: There's no way to test this at the moment as we don't have
any builtin extension modules.

Note: No release note as this is an internal engine change.