### PR TITLE
[[ Bug 18848 ]] Ensure error from subwindow command propagates

### DIFF
--- a/docs/notes/bugfix-18848.md
+++ b/docs/notes/bugfix-18848.md
@@ -1,0 +1,1 @@
+# Ensure error whilst doing subwindow command propagates to caller

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2988,7 +2988,10 @@ void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p
 		added = True;
 	}
     
-	p_target->openrect(p_rect, (Window_mode)p_mode, p_parent, (Window_position)p_at, (Object_pos)p_aligned);
+	if (p_target->openrect(p_rect, (Window_mode)p_mode, p_parent, (Window_position)p_at, (Object_pos)p_aligned) != ES_NORMAL)
+    {
+        ctxt.Throw();
+    }
 
 	if (MCwatchcursor)
 	{

--- a/tests/lcs/core/interface/subwindow.livecodescript
+++ b/tests/lcs/core/interface/subwindow.livecodescript
@@ -1,0 +1,27 @@
+script "CoreInterfaceSubwindow"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSubwindowPropagatesErrors
+	create stack "TestStack"
+	set the script of stack "TestStack" to "on openStack; throw red; end openStack"
+	try
+		palette stack "TestStack"
+	catch tError
+	end try
+	TestAssert "Error during subwindow propagates to caller", tError is "red"
+end TestSubwindowPropagatesErrors


### PR DESCRIPTION
This patch ensures that the return value of openrect() is checked
in ExecSubwindow and friends, and marks the context as having an
error if it returns ES_ERROR.