### PR TITLE
Merge develop 8.1 24.03.17

### DIFF
--- a/docs/notes/bugfix-19457.md
+++ b/docs/notes/bugfix-19457.md
@@ -1,0 +1,1 @@
+# Prevent crash when deleting selected objects with the backspace key

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1263,7 +1263,8 @@ int X_close(void)
 
 	MCstacks->closeall();
 	MCselected->clear(False);
-
+    MCundos->freestate();
+    
 	MCU_play_stop();
 #ifdef FEATURE_PLATFORM_RECORDER
     if (MCrecorder != nil)

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -540,36 +540,59 @@ Boolean MCSellist::cut()
 
 Boolean MCSellist::del()
 {
+    if (!IsDeletable())
+        return False;
+ 
+	if (nullptr == objects)
+        return False;
+
+    MCundos->freestate();
+    
+    MCStack *sptr = objects->m_ref->getstack();
+    while (objects != NULL)
+    {
+        MCSelnode *tptr = objects->remove(objects);
+        if (tptr->m_ref->gettype() >= CT_GROUP)
+        {
+            MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
+            uint2 num = 0;
+            cptr->getcard()->count(CT_LAYER, CT_UNDEFINED, cptr, num, True);
+            
+            Ustruct *us = new Ustruct;
+            us->type = UT_DELETE;
+            us->ud.layer = num;
+            MCundos->savestate(cptr, us);
+            
+            if (cptr->del(true))
+            {
+                tptr->m_ref = nil;
+            }
+        }
+        delete tptr;
+    }
+    sptr->message(MCM_selected_object_changed);
+    return True;
+}
+
+bool MCSellist::IsDeletable()
+{
+    if (nullptr == objects)
+        return false;
+    
     // Clear all deleted objects first
     Clean();
+
+    MCSelnode *t_object = objects;
+    do
+    {
+        if (!t_object->m_ref->isdeletable(true))
+            return false;
+        
+        t_object = t_object->next();
+    }
+    while (t_object != objects);
     
-    MCundos->freestate();
-	if (objects != NULL)
-	{
-		MCStack *sptr = objects->m_ref->getstack();
-		while (objects != NULL)
-		{
-			MCSelnode *tptr = objects->remove(objects);
-			if (tptr->m_ref->gettype() >= CT_GROUP)
-			{
-				MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
-				uint2 num = 0;
-				cptr->getcard()->count(CT_LAYER, CT_UNDEFINED, cptr, num, True);
-				if (cptr->del(true))
-				{
-					Ustruct *us = new Ustruct;
-					us->type = UT_DELETE;
-					us->ud.layer = num;
-					MCundos->savestate(cptr, us);
-					tptr->m_ref = nil;
-				}
-			}
-			delete tptr;
-		}
-		sptr->message(MCM_selected_object_changed);
-		return True;
-	}
-	return False;
+    return true;
 }
 
 void MCSellist::startmove(int2 x, int2 y, Boolean canclone)

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -156,8 +156,6 @@ void MCSellist::clear(Boolean message)
 		delete nodeptr;
 	}
     
-	MCundos->freestate();
-    
 	if (message && optr)
 		optr->message(MCM_selected_object_changed);
 }

--- a/engine/src/sellst.h
+++ b/engine/src/sellst.h
@@ -38,6 +38,7 @@ private:
 	Boolean dropclone;
     
     void Clean();
+    bool IsDeletable();
     
 public:
     

--- a/tests/lcs/core/interface/delete.livecodescript
+++ b/tests/lcs/core/interface/delete.livecodescript
@@ -38,3 +38,16 @@ on TestDeleteStackWithSubstack
 	
 	TestAssert "delete stack with substack no crash", true
 end TestDeleteStackWithSubstack
+
+on TestDeleteSelectedObjects
+	create stack
+	set the defaultStack to the short name of it
+	
+	create button
+	create field
+	select button 1 and field 1
+	
+	delete
+	
+	TestAssert "delete selected objects", the number of controls is 0
+end TestDeleteSelectedObjects

--- a/tests/lcs/core/interface/delete.livecodescript
+++ b/tests/lcs/core/interface/delete.livecodescript
@@ -51,3 +51,46 @@ on TestDeleteSelectedObjects
 	
 	TestAssert "delete selected objects", the number of controls is 0
 end TestDeleteSelectedObjects
+
+on TestDeleteSelectedCantDelete
+	create stack
+	set the defaultStack to the short name of it
+	
+	create button
+	
+	local tGroup
+	create group
+	put it into tGroup
+	
+	create field in tGroup
+	set the cantDelete of tGroup to true
+	
+	select button 1
+	delete
+	
+	select tGroup
+	delete
+	
+	local tThereIsAGroup
+	put there is a tGroup into tThereIsAGroup
+		
+	undo
+	
+	TestAssert "can't delete group with cantDelete true", tThereIsAGroup
+	TestAssert "undo previous delete after failed delete", there is a button 1
+end TestDeleteSelectedCantDelete
+
+on TestUndoAfterDeleteNothing
+	create stack
+	set the defaultStack to the short name of it
+	
+	create button
+	select button 1
+	delete
+
+	select empty
+	delete
+	undo
+	
+	TestAssert "undo previous delete after failed delete", there is a button 1
+end TestUndoAfterDeleteNothing

--- a/tests/lcs/core/interface/relayer.livecodescript
+++ b/tests/lcs/core/interface/relayer.livecodescript
@@ -1,0 +1,277 @@
+﻿script "CoreInterfaceRelayer"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSetLayerToTopAndBottom
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	
+	local tButton
+	create button
+	put it into tButton
+	
+	local tField
+	create field
+	put it into tField
+	
+	set the layer of tField to bottom
+	
+	TestAssert "set layer to bottom", the layer of tField is 1
+		
+	set the layer of tField to top
+	
+	TestAssert "set layer to top", the layer of tField is (the number of controls)
+	
+end TestSetLayerToTopAndBottom
+
+on TestSetLayerToLayerOfControl
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	
+	create graphic
+	
+	local tButton
+	create button
+	put it into tButton
+	
+	local tField
+	create field
+	put it into tField
+	
+	local tButtonLayer
+	put the layer of tButton into tButtonLayer
+	set the layer of tField to tButtonLayer
+	
+	TestAssert "set layer to layer of control", the layer of tField is tButtonLayer
+end TestSetLayerToLayerOfControl
+
+on TestSetLayerToLayerOfGroup
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	
+	local tGroup
+	create group
+	put it into tGroup
+	
+	local tField
+	create field
+	put it into tField
+
+	set the relayerGroupedControls to false	
+	set the layer of tField to the layer of tGroup
+	
+	// Replaces group in layers, so should end up on bottom layer where
+	// group was
+	TestAssert "set layer to layer of group with relayer grouped true - " \
+		& "layer value", the layer of tField is (the layer of tGroup - 1)
+	TestAssert "set layer to layer of group with relayer grouped true - " \
+		& "field owner", the long id of the owner of tField is the long \
+		id of this card of tStack
+	
+	set the relayerGroupedControls to true
+	set the layer of tField to the layer of tGroup
+	
+	// Setting to layer of target group relayers into group as bottom
+	// control in group 
+	TestAssert "set layer to layer of group with relayer grouped true - " \
+		& "layer value", the layer of tField is (the layer of tGroup) + 1
+	TestAssert "set layer to layer of group with relayer grouped true - " \
+		& "field owner", the long id of the owner of tField is the long \
+		id of tGroup
+end TestSetLayerToLayerOfGroup
+
+on TestSetLayerToLayerOfGroupedControl
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	
+	local tGroup
+	create group
+	put it into tGroup
+	
+	local tButton
+	create button in tGroup
+	put it into tButton
+	
+	local tField
+	create field
+	put it into tField
+	
+	set the relayerGroupedControls to false
+	set the layer of tField to the layer of tButton
+	
+	TestAssert "set layer to layer of grouped control with relayer " \
+		& "grouped false - layer value", the layer of tField is (the \ 
+		layer of tButton) + 1
+	TestAssert "set layer to layer of grouped control with relayer " \
+		& "grouped false - field owner", the long id of the owner of tField is the long \
+		id of this card of tStack
+	
+	set the relayerGroupedControls to true
+	set the layer of tField to the layer of tButton
+	
+	TestAssert "set layer to layer of grouped control with relayer " \
+		& "grouped true - layer value", the layer of tField is (the \ 
+		layer of tButton) - 1
+	TestAssert "set layer to layer of grouped control with relayer " \
+		& "grouped true - field owner", the long id of the owner of tField is the long \
+		id of tGroup
+end TestSetLayerToLayerOfGroupedControl
+
+on TestSetLayerToLayerOfGroupedControlNotFirst
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+
+	create graphic
+	
+	local tGroup
+	create group
+	put it into tGroup
+
+	create button in tGroup
+
+	// Create second control in group
+	local tButton
+	create button in tGroup
+	put it into tButton
+	
+	local tField
+	create field
+	put it into tField
+	
+	set the relayerGroupedControls to true
+	set the layer of tField to the layer of tButton
+	
+	TestAssert "set layer to layer of second grouped control" \
+		& " with relayer grouped true - layer value", \ 
+		the layer of tField is the layer of tButton - 1
+	TestAssert "sset layer to layer of second grouped control" \
+		& " with relayer grouped true - field owner", \ 
+		the long id of the owner of tField is tGroup
+end TestSetLayerToLayerOfGroupedControlNotFirst
+
+// The following tests are needed as a result of the code that implements
+// this behavior: http://quality.livecode.com/show_bug.cgi?id=19455
+// Should be removed when bug 19455 is resolved.
+on TestSetLayerToLayerOfGroupedControlAnomaly
+	repeat for each item tDesc in "on bottom layer,not on bottom layer"
+		_TestSetLayerToLayerOfGroupedControlAnomaly tDesc
+	end repeat
+end TestSetLayerToLayerOfGroupedControlAnomaly
+
+private command _TestSetLayerToLayerOfGroupedControlAnomaly pDesc
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+
+	// A distinct code path is taken in the case where the layer of a
+	// control is set to the layer of any control in a group except the 
+	// first, where the outer group is on the bottom layer.
+	if pDesc is not "on bottom layer" then
+		create graphic
+	end if
+	
+	local tGroup
+	create group
+	put it into tGroup
+
+	create button in tGroup
+
+	// Create second control in group
+	local tButton
+	create button in tGroup
+	put it into tButton
+	
+	local tField
+	create field
+	put it into tField
+	
+	set the relayerGroupedControls to false
+	set the layer of tField to the layer of tButton
+	
+	TestAssert "set layer to layer of second grouped control of outer group " \
+		& pDesc & " with relayer grouped false - layer value", \ 
+		the layer of tField is the layer of tGroup - 1
+	TestAssert "set layer to layer of second grouped control of outer group " \
+		& pDesc & " with relayer grouped false - field owner", \ 
+		the long id of the owner of tField is the long id of this card of tStack
+end _TestSetLayerToLayerOfGroupedControlAnomaly
+
+command _TestSetLayerOfGroupedControlError pControl
+	set the relayerGroupedControls to false
+	set the layer of pControl to "bottom"
+end _TestSetLayerOfGroupedControlError
+
+on TestSetLayerOfGroupedControl 
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	
+	local tGroup
+	create group
+	put it into tGroup
+	
+	local tButton
+	create button in tGroup
+	put it into tButton
+	
+	TestAssertThrow "set layer of grouped control with relayerGroupedControls false", \
+		"_TestSetLayerOfGroupedControlError", the long id of me, 345, tButton
+		
+	set the relayerGroupedControls to true
+	set the layer of tButton to "bottom"
+	-- Long id of button will change
+	
+	TestAssert "set layer of grouped control with relayerGroupedControls true " \ 
+		& "- layer value", the layer of button 1 is 1
+		
+	TestAssert "set layer of grouped control with relayerGroupedControls true " \ 
+		& "- owner", the long id of the owner of button 1 is the long id of \ 
+		this card of tStack
+end TestSetLayerOfGroupedControl
+
+on TestSetLayerOfControlOutOfRange
+    local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	
+	local tButton
+	create button
+	put it into tButton
+	
+	local tField
+	create field
+	put it into tField
+	
+	set the layer of tButton to 10000
+	
+	TestAssert "layer property clamped to feasible values", \
+		the layer of tButton is (the layer of tField) + 1
+end TestSetLayerOfControlOutOfRange
+ 


### PR DESCRIPTION
Conflict in engine/src/sellst.cpp, due to a `new (nothrow)` in develop.
Resolved by keeping develop-8.1 version, but adding `(nothrow)` back into the `new Ustruct`.