### PR TITLE
[[ Travis ]] Fix Travis trigger issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script: |
       ;;
   esac
 
-  if [[ -z "${COVERITY_SCAN_BRANCH}" ]]; then
+  if [[ "${COVERITY_SCAN_BRANCH}" != "1" ]]; then
     mkdir -p "${LICENSE_DIR}" &&
     touch "${LICENSE_DIR}/livecode-firstrun.lcf" &&
     make all-${BUILD_PLATFORM} &&


### PR DESCRIPTION
Travis builds *from* the livecode repo do not actually run, because `[[ -z "${COVERITY_SCAN_BRANCH}" ]]` is not true. It seems that `${COVERITY_SCAN_BRANCH}` is actually `0` in this case.