### PR TITLE
[[ Bug 19474 ]] Improve script object description

### DIFF
--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -674,8 +674,8 @@ static hash_t __MCScriptObjectHash(MCValueRef p_value)
 
 static bool __MCScriptObjectDescribe(MCValueRef p_value, MCStringRef& r_description)
 {
-    __MCScriptObjectImpl *self;
-    self = (__MCScriptObjectImpl *)MCValueGetExtraBytesPtr(p_value);
+    auto self =
+            reinterpret_cast<__MCScriptObjectImpl *>(MCValueGetExtraBytesPtr(p_value));
     
     if (!self->handle.IsValid())
     {

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -674,8 +674,25 @@ static hash_t __MCScriptObjectHash(MCValueRef p_value)
 
 static bool __MCScriptObjectDescribe(MCValueRef p_value, MCStringRef& r_description)
 {
-    r_description = MCSTR("<script object>");
-    return true;
+    __MCScriptObjectImpl *self;
+    self = (__MCScriptObjectImpl *)MCValueGetExtraBytesPtr(p_value);
+    
+    if (!self->handle.IsValid())
+    {
+        return MCStringCopy(MCSTR("<deleted script object>"),
+                            r_description);
+    }
+    
+    MCAutoValueRef t_object_name;
+    if (!self->handle->names(P_LONG_NAME_NO_FILENAME,
+                             &t_object_name))
+    {
+        return false;
+    }
+    
+    return MCStringFormat(r_description,
+                          "<script object %@>",
+                          *t_object_name);
 }
 
 static MCValueCustomCallbacks kMCScriptObjectCustomValueCallbacks =

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2352,10 +2352,11 @@ bool MCObject::getnameproperty(Properties which, uint32_t p_part_id, MCValueRef&
         case P_ABBREV_ID:
             return MCStringFormat(r_name, "%s id %d", itypestring, obj_id);
             
-            // The stack object has its own version of long * which we check for here. We
-            // could make 'names()' virtual and do this that way, but since there shouldn't
-            // really be an exception to how id is formatted (and there won't be for any
-            // future object types) we handle it here.
+        // The stack object has its own version of long * which we check for here. We
+        // could make 'names()' virtual and do this that way, but since there shouldn't
+        // really be an exception to how id is formatted (and there won't be for any
+        // future object types) we handle it here.
+        case P_LONG_NAME_NO_FILENAME:
         case P_LONG_NAME:
         case P_LONG_ID:
             if (gettype() == CT_STACK)
@@ -2365,7 +2366,11 @@ bool MCObject::getnameproperty(Properties which, uint32_t p_part_id, MCValueRef&
                 
                 MCStringRef t_filename;
                 t_filename = t_this -> getfilename();
-                if (MCStringIsEmpty(t_filename))
+                
+                /* If the property type is 'NO_FILENAME' then we resolve the name
+                 * of the mainstack, and not its filename. */
+                if (MCStringIsEmpty(t_filename) ||
+                    which == P_LONG_NAME_NO_FILENAME)
                 {
                     if (MCdispatcher->ismainstack(t_this))
                     {

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1738,6 +1738,8 @@ enum Properties {
     
     P_SCRIPT_STATUS,
     
+    P_LONG_NAME_NO_FILENAME,
+    
     __P_LAST,
 };
 


### PR DESCRIPTION
This patch changes the description of a script object from
`<deleted object>` and `<script object>` to `<deleted script object>`
and `<script object OBJECT_LONG_NAME>`.