### PR TITLE
[[ Bug 19476 ]] Add MCProperListCreateWithForeignValues

### DIFF
--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -180,6 +180,14 @@ operator+(typename MCSpan<ElementType>::IndexType n,
 	return rhs + n;
 }
 
+/* TODO[C++17] Remove when we have class and struct template type inference */
+template<typename ElementType, size_t N>
+constexpr MCSpan<ElementType>
+MCMakeSpan(ElementType (&arr)[N])
+{
+    return MCSpan<ElementType>(arr, N);
+}
+
 template <typename ElementType>
 constexpr MCSpan<ElementType>
 MCMakeSpan(ElementType *p_ptr,
@@ -189,12 +197,21 @@ MCMakeSpan(ElementType *p_ptr,
 }
 
 template <typename ElementType = byte_t>
-MCSpan<ElementType> MCDataGetSpan(MCDataRef p_data)
+inline MCSpan<ElementType> MCDataGetSpan(MCDataRef p_data)
 {
 	MCAssert(MCDataGetLength(p_data) % sizeof(ElementType) == 0);
 	auto t_ptr = reinterpret_cast<ElementType*>(MCDataGetBytePtr(p_data));
 	size_t t_length = MCDataGetLength(p_data) / sizeof(ElementType);
 	return MCMakeSpan(t_ptr, t_length);
+}
+
+template <typename ElementType>
+inline bool MCProperListCreateWithForeignValues(MCTypeInfoRef p_typeinfo, const MCSpan<ElementType> p_values, MCProperListRef& r_list)
+{
+    return MCProperListCreateWithForeignValues(p_typeinfo,
+                                               p_values.data(),
+                                               p_values.length(),
+                                               r_list);
 }
 
 #endif /* !__MC_FOUNDATION_SPAN_H__ */

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3169,6 +3169,12 @@ MC_DLLEXPORT extern MCProperListRef kMCEmptyProperList;
 // Create an immutable list containing the given values.
 MC_DLLEXPORT bool MCProperListCreate(const MCValueRef *values, uindex_t length, MCProperListRef& r_list);
 
+// Create an immutable list containing valuerefs built from a sequence of
+// raw values. The raw values should be sequential in memory, size(type) apart.
+// If the foreign type does not bridge (has no import method), then a boxed
+// foreign value is created (MCForeignValueRef).
+MC_DLLEXPORT bool MCProperListCreateWithForeignValues(MCTypeInfoRef type, const void *values, uindex_t length, MCProperListRef& r_list);
+
 // Create an empty mutable list.
 MC_DLLEXPORT bool MCProperListCreateMutable(MCProperListRef& r_list);
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3173,7 +3173,7 @@ MC_DLLEXPORT bool MCProperListCreate(const MCValueRef *values, uindex_t length, 
 // raw values. The raw values should be sequential in memory, size(type) apart.
 // If the foreign type does not bridge (has no import method), then a boxed
 // foreign value is created (MCForeignValueRef).
-MC_DLLEXPORT bool MCProperListCreateWithForeignValues(MCTypeInfoRef type, const void *values, uindex_t length, MCProperListRef& r_list);
+MC_DLLEXPORT bool MCProperListCreateWithForeignValues(MCTypeInfoRef type, const void *values, uindex_t value_count, MCProperListRef& r_list);
 
 // Create an empty mutable list.
 MC_DLLEXPORT bool MCProperListCreateMutable(MCProperListRef& r_list);

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -59,6 +59,7 @@
 				'include/foundation-locale.h',
 				'include/foundation-math.h',
 				'include/foundation-objc.h',
+                'include/foundation-span.h',
 				'include/foundation-stdlib.h',
 				'include/foundation-system.h',
 				'include/foundation-text.h',

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -10,6 +10,7 @@
 		[
 			'test/environment.cpp',
 			'test/test_hash.cpp',
+			'test/test_proper-list.cpp',
 			'test/test_string.cpp',
 			'test/test_typeconvert.cpp',
             'test/test_system-library.cpp',

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -665,6 +665,7 @@ __MCAssertResolvedTypeInfo(MCTypeInfoRef x, bool (*p)(MCTypeInfoRef))
 #define __MCAssertIsMutableData(x)   MCAssert(MCDataIsMutable(x))
 
 #define __MCAssertIsErrorTypeInfo(x) __MCAssertResolvedTypeInfo(x, MCTypeInfoIsError)
+#define __MCAssertIsForeignTypeInfo(x) __MCAssertResolvedTypeInfo(x, MCTypeInfoIsForeign)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -70,8 +70,11 @@ bool MCProperListCreate(const MCValueRef *p_values, uindex_t p_length, MCProperL
 }
 
 MC_DLLEXPORT_DEF
-bool MCProperListCreateWithForeignValues(MCTypeInfoRef p_type, const void *p_values, uindex_t p_length, MCProperListRef& r_list)
+bool MCProperListCreateWithForeignValues(MCTypeInfoRef p_typeinfo, const void *p_values, uindex_t p_value_count, MCProperListRef& r_list)
 {
+    __MCAssertIsForeignTypeInfo(p_typeinfo);
+    MCAssert(p_values != nullptr || p_value_count == 0);
+
     MCAutoProperListRef t_list;
     if (!MCProperListCreateMutable(&t_list))
     {
@@ -79,9 +82,9 @@ bool MCProperListCreateWithForeignValues(MCTypeInfoRef p_type, const void *p_val
     }
 
     const MCForeignTypeDescriptor *t_descriptor =
-            MCForeignTypeInfoGetDescriptor(p_type);
+            MCForeignTypeInfoGetDescriptor(p_typeinfo);
 
-    while(p_length > 0)
+    while(p_value_count > 0)
     {
         MCAutoValueRef t_value;
         if (t_descriptor->doimport != nil)
@@ -95,7 +98,7 @@ bool MCProperListCreateWithForeignValues(MCTypeInfoRef p_type, const void *p_val
         }
         else
         {
-            if (!MCForeignValueCreate(p_type,
+            if (!MCForeignValueCreate(p_typeinfo,
                                       (void *)p_values,
                                       (MCForeignValueRef&)&t_value))
             {
@@ -109,7 +112,7 @@ bool MCProperListCreateWithForeignValues(MCTypeInfoRef p_type, const void *p_val
             return false;
         }
 
-        p_length -= 1;
+        p_value_count -= 1;
         p_values = (byte_t *)p_values + t_descriptor->size;
     }
 

--- a/libfoundation/test/test_proper-list.cpp
+++ b/libfoundation/test/test_proper-list.cpp
@@ -1,0 +1,59 @@
+/* Copyright (C) 2003-2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "gtest/gtest.h"
+
+#include "foundation.h"
+#include "foundation-auto.h"
+
+TEST(properlist, createwithforeignvalues_bridgable)
+{
+    float t_floats[] = { 1.1, 2.1, 3.1, 5, 10 };
+    size_t t_float_count = sizeof(t_floats) / sizeof(t_floats[0]);
+    
+    MCAutoProperListRef t_float_list;
+    ASSERT_TRUE(MCProperListCreateWithForeignValues(kMCFloatTypeInfo, t_floats, t_float_count, &t_float_list));
+    ASSERT_EQ(MCProperListGetLength(*t_float_list), t_float_count);
+    for(size_t i = 0; i < t_float_count; i++)
+    {
+        MCValueRef t_element = MCProperListFetchElementAtIndex(*t_float_list, i);
+        ASSERT_EQ(MCValueGetTypeInfo(t_element), kMCNumberTypeInfo);
+        if (MCValueGetTypeInfo(t_element) == kMCNumberTypeInfo)
+        {
+            ASSERT_EQ(MCNumberFetchAsReal((MCNumberRef)t_element), t_floats[i]);
+        }
+    }
+}
+
+TEST(properlist, createwithforeignvalues_unbridgable)
+{
+    float t_floats[] = { 1.1, 2.1, 3.1, 5, 10 };
+    void *t_pointers[] = { nullptr, &t_floats[1], nullptr, &t_floats[2] };
+    size_t t_pointer_count = sizeof(t_pointers) / sizeof(t_pointers[0]);
+    
+    MCAutoProperListRef t_pointer_list;
+    ASSERT_TRUE(MCProperListCreateWithForeignValues(kMCPointerTypeInfo, t_pointers, t_pointer_count, &t_pointer_list));
+    ASSERT_EQ(MCProperListGetLength(*t_pointer_list), t_pointer_count);
+    for(size_t i = 0; i < t_pointer_count; i++)
+    {
+        MCValueRef t_element = MCProperListFetchElementAtIndex(*t_pointer_list, i);
+        ASSERT_EQ(MCValueGetTypeInfo(t_element), kMCPointerTypeInfo);
+        if (MCValueGetTypeInfo(t_element) == kMCPointerTypeInfo)
+        {
+            ASSERT_EQ(*static_cast<void **>(MCForeignValueGetContentsPtr(((MCForeignValueRef)t_element))), t_pointers[i]);
+        }
+    }
+}

--- a/libfoundation/test/test_proper-list.cpp
+++ b/libfoundation/test/test_proper-list.cpp
@@ -17,6 +17,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "gtest/gtest.h"
 
 #include "foundation.h"
+#include "foundation-span.h"
 #include "foundation-auto.h"
 
 TEST(properlist, createwithforeignvalues_bridgable)
@@ -25,7 +26,7 @@ TEST(properlist, createwithforeignvalues_bridgable)
     size_t t_float_count = sizeof(t_floats) / sizeof(t_floats[0]);
     
     MCAutoProperListRef t_float_list;
-    ASSERT_TRUE(MCProperListCreateWithForeignValues(kMCFloatTypeInfo, t_floats, t_float_count, &t_float_list));
+    ASSERT_TRUE(MCProperListCreateWithForeignValues(kMCFloatTypeInfo, MCMakeSpan(t_floats), &t_float_list));
     ASSERT_EQ(MCProperListGetLength(*t_float_list), t_float_count);
     for(size_t i = 0; i < t_float_count; i++)
     {
@@ -45,7 +46,7 @@ TEST(properlist, createwithforeignvalues_unbridgable)
     size_t t_pointer_count = sizeof(t_pointers) / sizeof(t_pointers[0]);
     
     MCAutoProperListRef t_pointer_list;
-    ASSERT_TRUE(MCProperListCreateWithForeignValues(kMCPointerTypeInfo, t_pointers, t_pointer_count, &t_pointer_list));
+    ASSERT_TRUE(MCProperListCreateWithForeignValues(kMCPointerTypeInfo, MCMakeSpan(t_pointers), &t_pointer_list));
     ASSERT_EQ(MCProperListGetLength(*t_pointer_list), t_pointer_count);
     for(size_t i = 0; i < t_pointer_count; i++)
     {


### PR DESCRIPTION
This patch adds a constructor for proper lists which takes a
sequence of foreign value contents (e.g. uint8_t[]) and converts
them into a proper list. If the values are bridgeable then it does
bridging, otherwise it just stores boxes.

Note: No release note because it is an internal API addition.