### PR TITLE
[[ Bug 19478 ]] Add 'filemaker' as valid deploy target

### DIFF
--- a/engine/src/license.h
+++ b/engine/src/license.h
@@ -45,6 +45,7 @@ enum
 	kMCLicenseDeployToIOSEmbedded = 1 << 8,
 	kMCLicenseDeployToAndroidEmbedded = 1 << 9,
     kMCLicenseDeployToHTML5 = 1 << 10,
+    kMCLicenseDeployToFileMaker = 1 << 11,
 };
 
 enum

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1360,6 +1360,7 @@ void MCModeSetRevLicenseLimits(MCExecContext& ctxt, MCArrayRef p_settings)
             { "ios-embedded", kMCLicenseDeployToIOSEmbedded },
             { "android-embedded", kMCLicenseDeployToIOSEmbedded },
             { "html5", kMCLicenseDeployToHTML5 },
+            { "filemaker", kMCLicenseDeployToFileMaker },
         };
         
         MClicenseparameters . deploy_targets = 0;
@@ -1437,6 +1438,7 @@ void MCModeGetRevLicenseInfo(MCExecContext& ctxt, MCStringRef& r_info)
         "iOS Embedded",
         "Android Embedded",
         "HTML5",
+        "FileMaker",
     };
     
     bool t_success;


### PR DESCRIPTION
This patch adds 'filemaker' as a valid deploy target present in
a LiveCode license.