### PR TITLE
[[ Bug 19479 ]] Make modals close automatically on Cmd-.

### DIFF
--- a/docs/notes/bugfix-19479.md
+++ b/docs/notes/bugfix-19479.md
@@ -1,0 +1,11 @@
+# Cmd-. does not affect modal dialogs
+
+Previously using the abort-script keyboard combination (Cmd-. on Mac) would
+cause an abort error to be thrown. However, this would be silently swallowed
+by any modal command (or equivalent) meaning that unusable modal dialogs
+would be uncloseable, requiring the need to restart the IDE / engine.
+
+This has been fixed by making Cmd-. cause an automatic 'close this stack'
+when it occurs in a modal loop and allowInterrupts is true, and the current
+stack has cantAbort set to false.
+


### PR DESCRIPTION
This patch causes modal dialogs to be automatically closed if a
script abort occurs. This stops the possibility of the IDE getting
locked up due to a broken modal script.

If allowInterrupts is false, or the stack has cantAbort set to true
then the behavior is unaffected (i.e. Cmd-. will have no effect).

Note: This uncovers Bug 19480 in the message box