### PR TITLE
[[ Bug 19486 ]] Foreign handler bind failure should throw an error

### DIFF
--- a/docs/notes/19486.md
+++ b/docs/notes/19486.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Virtual Machine
+## Foreign Function Interface
+
+# [19486] Failure to bind foreign handlers should provide meaningful error

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -202,10 +202,10 @@ MCTypeInfoRef kMCJavaJRENotSupportedErrorTypeInfo;
 
 bool MCJavaPrivateErrorsInitialize()
 {
-    if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.java.NativeMethodIdError"), MCNAME("java"), MCSTR("JNI exeception thrown when getting native method id"), kMCJavaNativeMethodIdErrorTypeInfo))
+    if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.java.NativeMethodIdError"), MCNAME("java"), MCSTR("JNI exception thrown when getting native method id"), kMCJavaNativeMethodIdErrorTypeInfo))
         return false;
     
-    if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.java.NativeMethodCallError"), MCNAME("java"), MCSTR("JNI exeception thrown when calling native method"), kMCJavaNativeMethodCallErrorTypeInfo))
+    if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.java.NativeMethodCallError"), MCNAME("java"), MCSTR("JNI exception thrown when calling native method"), kMCJavaNativeMethodCallErrorTypeInfo))
         return false;
     
     if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.java.BindingStringSignatureError"), MCNAME("java"), MCSTR("Java binding string does not match foreign handler signature"), kMCJavaBindingStringSignatureErrorTypeInfo))
@@ -1289,7 +1289,9 @@ bool MCJavaPrivateCallJNIMethod(MCNameRef p_class_name, void *p_method_id, int p
     // exceptions
     if (s_env -> ExceptionCheck() == JNI_TRUE)
     {
+#ifdef _DEBUG
         s_env -> ExceptionDescribe();
+#endif
         
         // Failure to clear the exception causes a crash when the JNI is
         // next used.
@@ -1440,7 +1442,9 @@ void* MCJavaPrivateGetMethodId(MCNameRef p_class_name, MCStringRef p_method_name
     // exceptions
     if (s_env -> ExceptionCheck() == JNI_TRUE)
     {
+#ifdef _DEBUG
         s_env -> ExceptionDescribe();
+#endif
         
         // Failure to clear the exception causes a crash when the JNI is
         // next used.

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -835,6 +835,9 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
                 return MCScriptThrowUnableToResolveForeignHandlerError(p_instance,
                                                                        p_handler);
             }
+            
+            MCErrorReset();
+            
 			*r_bound = false;
 			
 			return true;

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -750,7 +750,15 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
                                        *t_function);
 		if (t_pointer == nullptr)
 		{
-			return false;
+            if (r_bound == nullptr)
+            {
+                return MCScriptThrowUnableToResolveForeignHandlerError(p_instance,
+                                                                       p_handler);
+            }
+            
+            *r_bound = false;
+            
+			return true;
 		}
 		
 		p_handler -> native . function = t_pointer;
@@ -799,11 +807,20 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 		if (!MCJavaCheckSignature(t_signature,
 		                          *t_arguments,
 		                          *t_return,
-		                          p_handler -> java . call_type))
-            return false;
+		                          p_handler -> java . call_type) ||
+            !MCJavaVMInitialize())
+        {
+            if (r_bound == nullptr)
+            {
+                return false;
+            }
+            
+            MCErrorReset();
         
-        if (!MCJavaVMInitialize())
-            return false;
+            *r_bound = false;
+        
+            return true;
+        }
 		
         void *t_method_id = MCJavaGetMethodId(*t_class_name, *t_function, *t_arguments, *t_return, p_handler -> java . call_type);
         
@@ -815,7 +832,8 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 		{
 			if (r_bound == nullptr)
 			{
-                return false;
+                return MCScriptThrowUnableToResolveForeignHandlerError(p_instance,
+                                                                       p_handler);
             }
 			*r_bound = false;
 			

--- a/tests/_testlib.lcb
+++ b/tests/_testlib.lcb
@@ -11,26 +11,34 @@ public constant ThisModule is "com.livecode.__INTERNAL._testlib"
 public handler type Thunk() returns optional any
 
 public handler MCUnitTestHandlerThrows(in pHandler as any, in pDescription as String) returns nothing
-	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, true, false, "")
+	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, nothing, true, false, "")
+end handler
+
+public handler MCUnitTestHandlerThrowsNamed(in pHandler as any, in pErrorName, in pDescription as String) returns nothing
+	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, pErrorName, true, false, "")
 end handler
 
 public handler MCUnitTestHandlerThrowsBroken(in pHandler as any, in pDescription as String, in pReason as String) returns nothing
-	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, true, true, pReason)
+	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, nothing, true, true, pReason)
 end handler
 
 public handler MCUnitTestHandlerDoesntThrow(in pHandler as any, in pDescription as String) returns nothing
-	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, false, false, "")
+	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, nothing, false, false, "")
 end handler
 
 public handler MCUnitTestHandlerDoesntThrowBroken(in pHandler as any, in pDescription as String, in pReason as String) returns nothing
-	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, false, true, pReason)
+	MCUnitTestHandlerThrowsImpl(pHandler, pDescription, nothing, false, true, pReason)
 end handler
 
 ----------------------------------------------------------------
 
 foreign handler MCHandlerTryToInvokeWithList(in Handler as any, inout Arguments as optional List, out Result as optional any) returns optional any binds to "<builtin>"
+foreign handler MCValueGetTypeInfo(in pValue as any) returns Pointer binds to "<builtin>"
+foreign handler MCNamedTypeInfoGetName(in pValue as Pointer) returns Pointer binds to "<builtin>"
+foreign handler MCNameGetString(in pValue as Pointer) returns Pointer binds to "<builtin>"
+foreign handler MCValueRetain(in pValue as Pointer) returns any binds to "<builtin>"
 
-handler MCUnitTestHandlerThrowsImpl(in pHandler as any, in pDescription as String, in pExpectThrow as Boolean, in pBroken as Boolean, in pReason as String) returns nothing
+handler MCUnitTestHandlerThrowsImpl(in pHandler as any, in pDescription as String, in pErrorName as optional String, in pExpectThrow as Boolean, in pBroken as Boolean, in pReason as String) returns nothing
 
 	variable tHandler as Thunk
 	put pHandler into tHandler
@@ -51,14 +59,24 @@ handler MCUnitTestHandlerThrowsImpl(in pHandler as any, in pDescription as Strin
 	if tHasError then
 		test diagnostic tMaybeError
 	end if
-	
+
 	variable tTestPass as Boolean
 	if pExpectThrow then
-		put tHasError into tTestPass
+		if pErrorName is not nothing then
+			if tHasError then
+				unsafe
+					put MCValueRetain(MCNameGetString(MCNamedTypeInfoGetName(MCValueGetTypeInfo(tMaybeError)))) is pErrorName into tTestPass
+				end unsafe
+			else
+				put false into tTestPass
+			end if
+		else
+			put tHasError into tTestPass
+		end if
 	else
 		put not tHasError into tTestPass
 	end if
-	
+
 	if pBroken then
 		broken test pDescription when tTestPass because pReason
 	else

--- a/tests/lcb/vm/foreign-binding.lcb
+++ b/tests/lcb/vm/foreign-binding.lcb
@@ -1,0 +1,58 @@
+module __VMTEST.foreign_binding
+
+use com.livecode.foreign
+use com.livecode.java
+use com.livecode.__INTERNAL._testlib
+
+---------
+
+foreign handler SomeCFunctionWhichDoesNotExist() returns nothing binds to "<builtin>"
+foreign handler MCValueCopyDescription(in pValue as any, out rDesc as String) returns CBool binds to "<builtin>"
+
+private handler TestForeignBinding_NonExistantC()
+   unsafe
+      SomeCFunctionWhichDoesNotExist()
+   end unsafe
+end handler
+
+private handler TestForeignBinding_ExistantC()
+   unsafe
+      variable tString as String
+      MCValueCopyDescription("", tString)
+   end unsafe
+end handler
+
+public handler TestForeignBinding_C()
+	MCUnitTestHandlerThrowsNamed(TestForeignBinding_NonExistantC, "livecode.lang.ForeignHandlerBindingError", "Failure to bind to non-existant C function throws error")
+   MCUnitTestHandlerDoesntThrow(TestForeignBinding_ExistantC, "Binding to existant C function does not throw error")
+
+   test "Non-existant C function gives nothing as handler value" when SomeCFunctionWhichDoesNotExist is nothing
+   test "Existant C function gives non-nothing as handler value" when MCValueCopyDescription is not nothing
+end handler
+
+---------
+
+foreign handler CreateJavaObject() returns JObject binds to "java:java.lang.Object>new()"
+foreign handler CreateJavaObjectDoesntExist() returns JObject binds to "java:java.lang.Object>new_doesnt_exist()"
+
+private handler TestForeignBinding_NonExistantJava()
+   unsafe
+      CreateJavaObjectDoesntExist()
+   end unsafe
+end handler
+
+private handler TestForeignBinding_ExistantJava()
+   unsafe
+      CreateJavaObject()
+   end unsafe
+end handler
+
+public handler TestForeignBinding_Java()
+	MCUnitTestHandlerThrowsNamed(TestForeignBinding_NonExistantJava, "livecode.lang.ForeignHandlerBindingError", "Failure to bind to non-existant java function throws error")
+   MCUnitTestHandlerDoesntThrow(TestForeignBinding_ExistantJava, "Binding to existant java function does not throw error")
+
+   test "Non-existant java function gives nothing as handler value" when CreateJavaObjectDoesntExist is nothing
+   test "Existant java function gives non-nothing as handler value" when CreateJavaObject is not nothing
+end handler
+
+end module

--- a/toolchain/lc-compile/src/outputfile.c
+++ b/toolchain/lc-compile/src/outputfile.c
@@ -28,7 +28,7 @@
 static const char *ImportedModuleDir[8];
 static int ImportedModuleDirCount = 0;
 static const char *s_interface_output_file = NULL;
-static const char *ImportedModuleNames[32];
+static const char *ImportedModuleNames[4096];
 static int ImportedModuleNameCount = 0;
 
 static int IsImportedModuleName(const char *p_name)


### PR DESCRIPTION
This patch ensures that if foreign handler binding fails, and the
bind was required, and not optional then an appropriate error
object is thrown.