### PR TITLE
[[ Bug 19484 ]] Add 'embedded' Environment type

### DIFF
--- a/engine/src/mode.h
+++ b/engine/src/mode.h
@@ -32,6 +32,7 @@ enum
 	kMCModeEnvironmentTypePlayer,
 	kMCModeEnvironmentTypeServer,
 	kMCModeEnvironmentTypeMobile,
+    kMCModeEnvironmentTypeEmbedded,
 };
 
 


### PR DESCRIPTION
This patch adds kMCModeEnvironmentTypeEmbedded to the MCModeEnvironmentType
enum.