### PR TITLE
[[ Engine ]] Minor tweaks

### DIFF
--- a/engine/src/mcerror.h
+++ b/engine/src/mcerror.h
@@ -46,6 +46,7 @@ public:
 	void append(MCError& string);
 	void copystringref(MCStringRef s, Boolean t);
 	bool copyasstringref(MCStringRef &r_string);
+	bool isthrown(void) const {return thrown;}
 	void clear();
 	Boolean isempty()
 	{

--- a/engine/src/notify.cpp
+++ b/engine/src/notify.cpp
@@ -547,3 +547,8 @@ void MCNotifyPing(bool p_high_priority)
 #error Threading API not specified
 #endif
 }
+
+bool MCNotifyPending(void)
+{
+	return s_notifications != nil || s_safe_notifications != nil;
+}

--- a/engine/src/notify.h
+++ b/engine/src/notify.h
@@ -34,4 +34,7 @@ bool MCNotifyDispatch(bool safe);
 // MW-2013-06-14: [[ DesktopPingWait ]] Wake up any currently running 'wait'.
 void MCNotifyPing(bool p_high_priority);
 
+// Returns true if there is a pending notification
+bool MCNotifyPending(void);
+
 #endif

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -1322,6 +1322,16 @@ bool MCUIDC::addusermessage(MCObject* optr, MCNameRef name, real8 time, MCParame
     return true;
 }
 
+bool MCUIDC::hasmessagestodispatch(void)
+{
+    if (m_messages.GetCount() == 0)
+    {
+        return false;
+    }
+    
+    return m_messages[0].m_time <= MCS_time();
+}
+
 // MW-2014-04-16: [[ Bug 11690 ]] Rework pending message handling to take advantage
 //   of messages[] now being a sorted list.
 Boolean MCUIDC::handlepending(real8& curtime, real8& eventtime, Boolean dispatch)

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -672,6 +672,9 @@ public:
     //   engine sent messages. The former are subject to a limit to stop pending message queue overflow.
     bool addusermessage(MCObject *optr, MCNameRef name, real8 time, MCParameter *params);
     
+    // Returns true if there are any pending messages to dispatch right now.
+    bool hasmessagestodispatch(void);
+    
 	Boolean handlepending(real8 &curtime, real8 &eventtime, Boolean dispatch);
 	Boolean getlockmoves() const;
 	void setlockmoves(Boolean b);
@@ -691,6 +694,7 @@ public:
 	bool getcolornames(MCStringRef&);
 	void getpaletteentry(uint4 n, MCColor &c);
 
+    
 	Boolean hasmessages()
 	{
 		return m_messages.GetCount() != 0;


### PR DESCRIPTION
This patch contains a number of internal additions to some engine classes: to do with introspecting on whether there are pending messages about to dispatch, and whether an error was thrown by the`throw` command or the engine.