### PR TITLE
[[ Bug 19429 ]] Fix inclusion of dbdrivers in Desktop standalones

### DIFF
--- a/docs/notes/bugfix-19429.md
+++ b/docs/notes/bugfix-19429.md
@@ -1,0 +1,2 @@
+# Fix issue with database driver inclusion in standalones on Desktop
+

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -2176,6 +2176,11 @@ end revAddExternal
 
 constant kSeparator = ":"
 private command revAddMapping pPlatform, pName, pLocation
+   -- The name comes in without 'db' in front of it for the existing database
+   -- drivers, but it needs to be 'db*'.
+   if pName is among the items of "sqlite,postgres,odbc,mysql,oracle" then
+      put "db" before pName
+   end if
    if sStandaloneSettingsA[pPlatform & ",library"] is not empty then put return after sStandaloneSettingsA[pPlatform & ",library"]
    put pName & kSeparator & "./" & pLocation after sStandaloneSettingsA[pPlatform & ",library"]
 end revAddMapping


### PR DESCRIPTION
This patch maps 'sqlite' and such to 'dbsqlite' in revAddMapping
in the desktop standalone builder. This ensures the name of the
module in the mapping array in the standalone is what is expected
for it to work.

Note: A test for this is already in the ide tests, however it was always succeeding due to an incorrect check - that is fixed in a separate PR in the ide repo.