### PR TITLE
[[ Engine ]] Minor tweaks again

### DIFF
--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -703,6 +703,26 @@ bool MCHandler::getparamnames(MCListRef& r_list)
 	return MCListCopy(*t_list, r_list);
 }
 
+bool MCHandler::getparamnames_as_properlist(MCProperListRef& r_list)
+{
+	MCAutoProperListRef t_list;
+	if (!MCProperListCreateMutable(&t_list))
+		return false;
+	
+	for (uinteger_t i = 0; i < npnames; i++)
+		if (!MCProperListPushElementOntoBack(*t_list, pinfo[i].name))
+			return false;
+	
+	if (!t_list.MakeImmutable())
+	{
+		return false;
+	}
+	
+	r_list = t_list.Take();
+	
+	return true;
+}
+
 bool MCHandler::getvariablenames(MCListRef& r_list)
 {
 	MCAutoListRef t_list;

--- a/engine/src/handler.h
+++ b/engine/src/handler.h
@@ -101,6 +101,7 @@ public:
 	Parse_stat newconstant(MCNameRef name, MCValueRef value);
 	void newglobal(MCNameRef name);
 	bool getparamnames(MCListRef& r_list);
+	bool getparamnames_as_properlist(MCProperListRef& r_list);
 	bool getvariablenames(MCListRef& r_list);
 	bool getglobalnames(MCListRef& r_list);
 	bool getvarnames(bool p_all, MCListRef& r_list);

--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -710,6 +710,38 @@ bool MCHandlerlist::enumerate(MCExecContext& ctxt, bool p_first, uindex_t& r_cou
 	return p_first;
 }
 
+bool MCHandlerlist::listconstants(MCHandlerlistListConstantsCallback p_callback, void *p_context)
+{
+	for(uint2 i = 0; i < nconstants; i++)
+	{
+		if (!p_callback(p_context,
+						&cinfo[i]))
+		{
+			return false;
+		}
+	}
+	
+	return true;
+}
+
+bool MCHandlerlist::listhandlers(MCHandlerlistListHandlersCallback p_callback, void *p_context)
+{
+	for(int t_type = HT_MIN; t_type < HT_MAX; t_type++)
+	{
+		for(uint2 i = 0; i < handlers[t_type].count(); i++)
+		{
+			if (!p_callback(p_context,
+							(Handler_type)(t_type),
+							handlers[t_type].get()[i]))
+			{
+				return false;
+			}
+		}
+	}
+	
+	return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void MCHandlerlist::compile(MCSyntaxFactoryRef ctxt)

--- a/engine/src/hndlrlst.h
+++ b/engine/src/hndlrlst.h
@@ -68,6 +68,9 @@ private:
 	static int compare_handler(const void *a, const void *b);
 };
 
+typedef bool (*MCHandlerlistListConstantsCallback)(void *p_context, MCHandlerConstantInfo *info);
+typedef bool (*MCHandlerlistListHandlersCallback)(void *p_context, Handler_type p_type, MCHandler*);
+
 class MCHandlerlist
 {
 	// MW-2012-08-08: [[ BeforeAfter ]] The before/after handlers are stored
@@ -132,6 +135,9 @@ public:
 	uint2 getnglobals(void);
 	MCVariable *getglobal(uint2 p_index);
     bool enumerate(MCExecContext& ctxt, bool p_first, uindex_t& r_count, MCStringRef*& r_handlers);
+	
+	bool listconstants(MCHandlerlistListConstantsCallback p_callback, void *p_context);
+	bool listhandlers(MCHandlerlistListHandlersCallback p_callback, void *p_context);
 	
 	uint2 getnvars(void)
 	{

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -126,7 +126,7 @@ void MCEngineScriptObjectAllowAccess(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static MCValueRef
+MCValueRef
 MCEngineEvalScriptResult (MCExecContext& ctxt)
 {
 	if (MCresult->isclear())
@@ -230,7 +230,7 @@ static Properties parse_property_name(MCStringRef p_name)
 	return P_CUSTOM;
 }
 
-static inline bool MCEngineEvalObjectOfScriptObject(MCScriptObjectRef p_object, MCObject *&r_object, uint32_t &r_part_id)
+bool MCEngineEvalObjectOfScriptObject(MCScriptObjectRef p_object, MCObject *&r_object, uint32_t &r_part_id)
 {
 	__MCScriptObjectImpl *t_script_object_imp;
 	t_script_object_imp = (__MCScriptObjectImpl *)MCValueGetExtraBytesPtr(p_object);
@@ -431,7 +431,7 @@ void MCEngineFreeScriptParameters(MCParameter* p_params)
 	}
 }
 
-static bool MCEngineConvertToScriptParameters(MCExecContext& ctxt, MCProperListRef p_arguments, MCParameter*& r_script_params)
+bool MCEngineConvertToScriptParameters(MCExecContext& ctxt, MCProperListRef p_arguments, MCParameter*& r_script_params)
 {
     MCAutoCustomPointer<MCParameter, MCEngineFreeScriptParameters> t_params;
     MCParameter *t_last_param = nullptr;

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -608,9 +608,16 @@ enum Functions {
     F_EVENT_SHIFT_KEY,
 };
 
+/* The HT_MIN and HT_MAX elements of the enum delimit the range of the handler
+ * arrays in MCHandlerlst so iteration over the type should be
+ * HT_MIN <= i <= HT_MAX */
 enum Handler_type {
+    
     HT_UNDEFINED = 0,
-    HT_MESSAGE,
+
+    HT_MIN,
+    
+    HT_MESSAGE = HT_MIN,
     HT_FUNCTION,
     HT_GETPROP,
     HT_SETPROP,

--- a/libscript/include/libscript/script-auto.h
+++ b/libscript/include/libscript/script-auto.h
@@ -145,6 +145,14 @@ public:
 		return m_values[p_index];
 	}
 
+    MCSpan<T> Release(void)
+    {
+        MCSpan<T> t_value = Span();
+        m_values = nullptr;
+        m_count = 0;
+        return t_value;
+    }
+
 private:
 	T *m_values;
 	uindex_t m_count;


### PR DESCRIPTION
This patch contains a number of internal additions to some engine classes: reflection methods on handlerlist and handler, making some MCEngine functions non-static, and adding Release to MCAutoScriptObjectRefArrayBase.