### PR TITLE
[[ Engine ]] Add '_internal' as a command to all modes

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -269,6 +269,7 @@
 			'src/image_rep_resampled.cpp',
 			'src/imagebitmap.cpp',
 			'src/imageloader.cpp',
+            'src/internal.cpp',
 			'src/ipng.cpp',
 			'src/iquantization.cpp',
 			'src/iquantize_new.cpp',
@@ -829,7 +830,6 @@
 			'src/deploy_windows.cpp',
 			'src/deploysecurity.cpp',
 			'src/ide.cpp',
-			'src/internal.cpp',
 			'src/internal_development.cpp',
 			'src/mode_development.cpp',
 		],
@@ -845,7 +845,6 @@
 		'engine_installer_mode_source_files':
 		[
 			'src/bsdiff_apply.cpp',
-			'src/internal.cpp',
 			'src/mode_installer.cpp',
 			'src/mode_installer_lnx.cpp',
 			'src/mode_installer_osx.mm',

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -276,9 +276,7 @@ static LT ask_table[] =
 
 LT command_table[] =
     {
-#if defined(MODE_DEVELOPMENT) || defined(MODE_INSTALLER) || defined(_TEST)
 		{"_internal", TT_STATEMENT, S_INTERNAL},
-#endif
         {"accept", TT_STATEMENT, S_ACCEPT},
         {"add", TT_STATEMENT, S_ADD},
         {"answer", TT_STATEMENT, S_ANSWER},

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -683,8 +683,6 @@ MCStatement *MCModeNewCommand(int2 which)
 {
 	switch(which)
 	{
-	case S_INTERNAL:
-		return new MCInternal;
 	case S_REV_RELICENSE:
 		return new MCRevRelicense;
 	default:

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1602,14 +1602,6 @@ bool MCModeCanLoadHome(void)
 
 MCStatement *MCModeNewCommand(int2 which)
 {
-	switch(which)
-	{
-	case S_INTERNAL:
-		return new MCInternal;
-	default:
-		break;
-	}
-
 	return NULL;
 }
 

--- a/engine/src/mode_server.cpp
+++ b/engine/src/mode_server.cpp
@@ -52,6 +52,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "deploy.h"
 #include "capsule.h"
 #include "player.h"
+#include "internal.h"
 
 #include "srvscript.h"
 
@@ -429,3 +430,14 @@ void MCModePostSelectHook(fd_set& rfds, fd_set& wfds, fd_set& efds)
 }
 
 #endif
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Implementation of internal verbs
+//
+
+// The internal verb table used by the '_internal' command
+MCInternalVerbInfo MCinternalverbs[] =
+{
+	{ nil, nil, nil }
+};

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -55,6 +55,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "deploy.h"
 #include "capsule.h"
 #include "player.h"
+#include "internal.h"
 
 #if defined(_WINDOWS_DESKTOP)
 #include "prefix.h"
@@ -1367,3 +1368,14 @@ void MCModePostSelectHook(fd_set& rfds, fd_set& wfds, fd_set& efds)
 }
 
 #endif
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Implementation of internal verbs
+//
+
+// The internal verb table used by the '_internal' command
+MCInternalVerbInfo MCinternalverbs[] =
+{
+	{ nil, nil, nil }
+};

--- a/engine/src/newobj.cpp
+++ b/engine/src/newobj.cpp
@@ -28,6 +28,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "newobj.h"
 #include "answer.h"
 #include "ask.h"
+#include "internal.h"
 
 #include "mode.h"
 
@@ -35,6 +36,8 @@ MCStatement *MCN_new_statement(int2 which)
 {
 	switch (which)
 	{
+    case S_INTERNAL:
+        return new MCInternal;
 	case S_ACCEPT:
 		return new MCAccept;
 	case S_ADD:


### PR DESCRIPTION
This patch moves the _internal command creator to all modes, requiring
only MCinternalverbs to be defined on a per-mode basis.