### PR TITLE
[[ Bug 10947 ]] Fix dynamic path behavior

### DIFF
--- a/docs/notes/bugfix-10947.md
+++ b/docs/notes/bugfix-10947.md
@@ -1,0 +1,1 @@
+# Fix hypercard-compatibility dynamic path behavior

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1573,11 +1573,11 @@ Exec_stat MCStack::handle(Handler_type htype, MCNameRef message, MCParameter *pa
 	// object.
 	Exec_stat stat;
 	stat = ES_NOT_HANDLED;
-	if (!MCdynamicpath || MCdynamiccard->getparent() != this)
+	if (!MCdynamicpath || MCdynamiccard->getparent() == this)
 		stat = handleself(htype, message, params);
 	else if (passing_object != nil)
 	{
-		// MW-2011-06-20:  If dynamic path is enabled, and this stack is the parent
+		// MW-2011-06-20:  If dynamic path is enabled, and this stack is not the parent
 		//   of the dynamic card then instead of passing through this stack, we pass
 		//   through the dynamic card (which will then pass through this stack).
 		MCdynamicpath = False;


### PR DESCRIPTION
The hypercard compatibility dynamic path behavior should be invoked
if there is a dynamic card and the currently handling stack is
*not* the parent of the dynamic card