### PR TITLE
[[ Bug 19502 ]] Correct error stack from erroneous library handler call

### DIFF
--- a/docs/notes/bugfix-19502.md
+++ b/docs/notes/bugfix-19502.md
@@ -1,0 +1,2 @@
+# Make sure calling LCB library handlers produces correct error stack
+

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -471,6 +471,7 @@ Exec_stat MCEngineHandleLibraryMessage(MCNameRef p_message, MCParameter *p_param
             
             if (!MCExtensionConvertFromScriptType(*MCECptr, t_arg_type, t_value))
             {
+                MCECptr->LegacyThrow(EE_INVOKE_TYPEERROR);
                 MCValueRelease(t_value);
                 t_success = false;
                 break;
@@ -489,13 +490,6 @@ Exec_stat MCEngineHandleLibraryMessage(MCNameRef p_message, MCParameter *p_param
         }
         
         t_param = t_param -> getnext();
-    }
-	
-    // If the above looped failed with t_success == false, then a type
-    // conversion error occurred.
-    if (!t_success)
-    {
-        MCECptr->LegacyThrow(EE_INVOKE_TYPEERROR);
     }
     
 	// Too many parameters error.

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -184,14 +184,24 @@ on TestAssertBroken pDescription, pExpectTrue, pReasonBroken
    _TestOutput pExpectTrue, pDescription, "TODO", pReasonBroken
 end TestAssertBroken
 
-on TestAssertThrow pDescription, pHandler, pTarget, pErrorCode, pParam
+on TestAssertThrow pDescription, pHandler, pTarget, pErrorCodes, pParam
    local tError
    try
       dispatch pHandler to pTarget with pParam
-    catch tError
-    end try
+   catch tError
+   end try
 
-    TestAssert pDescription, pErrorCode is item 1 of line 1 of tError
+   TestDiagnostic tError
+
+   local tSuccess
+   put true into tSuccess
+   repeat for each item tErrorCode in pErrorCodes
+      put tSuccess and \
+             (tErrorCode is item 1 of the first line of tError) into tSuccess
+      delete the first line of tError
+   end repeat
+
+   TestAssert pDescription, tSuccess
 end TestAssertThrow
 
 on ErrorDialog executionError, parseError

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -38,7 +38,7 @@ end TestSetup
 
 private command buildMultiModuleExtension pInputs, pOutput
     -- Build a multi-module extension
-    local tBasename, tBytecode, tFile
+    local tBasename, tBytecode, tFile, tResult
     repeat for each item tBasename in pInputs
        put merge("[[kBytecodePath]]/[[tBasename]].lcm") into tFile
        put url("binfile:" & tFile) after tBytecode
@@ -146,20 +146,26 @@ command CallLibraryHandlerWithTooManyParams
 end CallLibraryHandlerWithTooManyParams
 
 on TestExtensionLibraryHandlerCallErrors
+   /* In all cases in this test we expect the error stack to be:
+    *    <specific error>
+    *    219, ...
+    * Here '219' is the error in handler error which the call to the actual
+    * TestExtensionLibraryHandler function will generate. */
+
    TestAssertThrow "library handler call throws correct error on type error", \
          "CallLibraryHandlerWithString", \
          the long id of me, \
-         896
+         (896, 219)
 
    TestAssertThrow "library handler call throws correct error on too few args error", \
          "CallLibraryHandlerWithTooFewParams", \
          the long id of me, \
-         885
+         (885, 219)
 
    TestAssertThrow "library handler call throws correct error on too many args error", \
          "CallLibraryHandlerWithTooManyParams", \
          the long id of me, \
-         886
+         (886, 219)
 end TestExtensionLibraryHandlerCallErrors
 
 //////////


### PR DESCRIPTION
This patch ensures that either there is only one of 'too few arguments',
'too many arguments' or 'type error' erros on the error stack if a
handler call fails whilst binding parameters.