### PR TITLE
[Bug 14861] LCB: Add "reverse _" syntax for sequence types (String, List, Data)

### DIFF
--- a/docs/lcb/notes/14861.md
+++ b/docs/lcb/notes/14861.md
@@ -1,0 +1,9 @@
+# LiveCode Builder Standard Library
+
+## Sequence operations
+
+* New syntax has been added for reversing the contents of sequence
+  types (`List`, `String` and `Data`).  The `reverse <Value>`
+  statement reverses the order of the sequence.
+
+# [14861] Add "reverse _" syntax for sequence types

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -96,6 +96,12 @@ public:
 	{
 		return m_value;
 	}
+
+    inline T operator -> (void) const
+    {
+        MCAssert(m_value != nullptr);
+        return m_value;
+    }
     
 	bool IsSet() const
 	{

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2651,6 +2651,8 @@ MC_DLLEXPORT bool MCDataRemove(MCDataRef r_data, MCRange p_range);
 MC_DLLEXPORT bool MCDataReplace(MCDataRef r_data, MCRange p_range, MCDataRef p_new_data);
 MC_DLLEXPORT bool MCDataReplaceBytes(MCDataRef r_data, MCRange p_range, const byte_t *p_new_data, uindex_t p_byte_count);
 
+MC_DLLEXPORT bool MCDataReverse(MCDataRef);
+
 MC_DLLEXPORT bool MCDataPad(MCDataRef data, byte_t byte, uindex_t count);
 
 MC_DLLEXPORT bool MCDataContains(MCDataRef p_data, MCDataRef p_needle);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2144,6 +2144,11 @@ MC_DLLEXPORT bool MCStringMutableCopySubstringAndRelease(MCStringRef string, MCR
 
 /////////
 
+// Copy a string, reversing its contents
+MC_DLLEXPORT bool MCStringCopyReversed(MCStringRef string, MCStringRef& r_reversed);
+
+/////////
+
 // Returns true if the string is mutable
 MC_DLLEXPORT bool MCStringIsMutable(const MCStringRef string);
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3221,6 +3221,8 @@ MC_DLLEXPORT bool MCProperListSort(MCProperListRef list, bool p_reverse, MCPrope
 typedef compare_t (*MCProperListCompareElementCallback)(void *context, const MCValueRef left, const MCValueRef right);
 MC_DLLEXPORT bool MCProperListStableSort(MCProperListRef list, bool p_reverse, MCProperListCompareElementCallback p_callback, void *context);
 
+MC_DLLEXPORT bool MCProperListReverse(MCProperListRef list);
+
 // Fetch the first element of the list. The returned value is not retained.
 MC_DLLEXPORT MCValueRef MCProperListFetchHead(MCProperListRef list);
 MC_DLLEXPORT // Fetch the last element of the list. The returned value is not retained.

--- a/libfoundation/src/foundation-data.cpp
+++ b/libfoundation/src/foundation-data.cpp
@@ -694,6 +694,20 @@ bool MCDataPad(MCDataRef self, byte_t p_byte, uindex_t p_count)
 }
 
 MC_DLLEXPORT_DEF
+bool MCDataReverse(MCDataRef self)
+{
+    MCAssert(MCDataIsMutable(self));
+
+    // Ensure the data ref is not indirect
+    if (__MCDataIsIndirect(self))
+        if (!__MCDataResolveIndirect(self))
+            return false;
+
+    MCInplaceReverse(self->bytes, self->byte_count);
+    return true;
+}
+
+MC_DLLEXPORT_DEF
 compare_t MCDataCompareTo(MCDataRef p_left, MCDataRef p_right)
 {
 	__MCAssertIsData(p_left);

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -667,5 +667,26 @@ __MCAssertResolvedTypeInfo(MCTypeInfoRef x, bool (*p)(MCTypeInfoRef))
 #define __MCAssertIsErrorTypeInfo(x) __MCAssertResolvedTypeInfo(x, MCTypeInfoIsError)
 
 ////////////////////////////////////////////////////////////////////////////////
+// ALGORITHM TEMPLATES
+//
+
+/* Efficiently reverse the order of elements in an array, in-place.
+ * The algorithm works from the middle of the array outwards, swapping
+ * the elements at each end.  The ElementType must be swappable,
+ * either by being trivially copyable or by implementing a
+ * std::swap()-compatible swap operation that can be found by ADL. */
+/* TODO[C++11] Obsolete this macro by using std::reverse from
+ * <algorithm>.  Would require MCSpan to support STL iteration. */
+template <typename ElementType, typename IndexType>
+inline void MCInplaceReverse(ElementType* x_elements, IndexType p_num_elements)
+{
+    using std::swap;
+    MCAssert(x_elements != nullptr || p_num_elements == 0);
+    for (auto t_count = p_num_elements/2; t_count > 0; --t_count)
+        swap(x_elements[t_count - 1],
+             x_elements[p_num_elements - t_count]);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 #endif

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -19,7 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 
 #include <stdio.h>
-
+#include <utility>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -897,6 +897,20 @@ bool MCProperListIsHomogeneous(MCProperListRef self, MCValueTypeCode& r_type)
     return false;
 }
 
+MC_DLLEXPORT_DEF
+bool MCProperListReverse(MCProperListRef self)
+{
+    MCAssert(MCProperListIsMutable(self));
+
+    // Ensure the list ref is not indirect
+    if (__MCProperListIsIndirect(self))
+        if (!__MCProperListResolveIndirect(self))
+            return false;
+
+    MCInplaceReverse(self->list, self->length);
+    return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void __MCProperListDestroy(__MCProperList *self)

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1513,7 +1513,11 @@ bool MCStringCopyReversed(MCStringRef self, MCStringRef& r_new_string)
          * unichar_t codeunits items per grapheme.  In this case, we
          * reverse by iterating over the contents of the original
          * string, copying the graphemes into the new string. */
-        MCStringRef t_original = __MCStringIsIndirect(self) ? self->string : self;
+        MCStringRef t_original = self;
+        if (__MCStringIsIndirect(t_original))
+        {
+            t_original = t_original->string;    
+        }
 
         /* Start of the next grapheme to copy, in the input string */
         uindex_t t_from = 0;

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1476,6 +1476,75 @@ bool MCStringMutableCopySubstringAndRelease(MCStringRef self, MCRange p_range, M
 ////////////////////////////////////////////////////////////////////////////////
 
 MC_DLLEXPORT_DEF
+bool MCStringCopyReversed(MCStringRef self, MCStringRef& r_new_string)
+{
+    __MCAssertIsString(self);
+
+    if (MCStringGetLength(self) < 2)
+        return MCStringCopy(self, r_new_string);
+
+    /* Make a deep copy of the input string. */
+    /* TODO[2017-03-29] This could be optimised by _not_ copying the
+     * actual string buffer contents during the deep copy, but
+     * reversing directly from the input string's internal buffer to
+     * the result string's buffer. */
+    MCAutoStringRef t_result;
+    if (!MCStringMutableCopy(self, &t_result))
+        return false;
+    if (__MCStringIsIndirect(*t_result))
+        if (!__MCStringResolveIndirect(*t_result))
+            return false;
+
+    if (__MCStringIsNative(*t_result))
+    {
+        /* Native strings have one char_t per grapheme, so they can be
+         * reversed in-place. */
+        MCInplaceReverse(t_result->native_chars, t_result->char_count);
+    }
+    else if (__MCStringIsTrivial(*t_result))
+    {
+        /* Trivial strings have one unichar_t per grapheme, so they
+         * can be reversed in-place. */
+        MCInplaceReverse(t_result->chars, t_result->char_count);
+    }
+    else
+    {
+        /* These strings have some potentially-unbounded number of
+         * unichar_t codeunits items per grapheme.  In this case, we
+         * reverse by iterating over the contents of the original
+         * string, copying the graphemes into the new string. */
+        MCStringRef t_original = __MCStringIsIndirect(self) ? self->string : self;
+
+        /* Start of the next grapheme to copy, in the input string */
+        uindex_t t_from = 0;
+        uindex_t t_length = t_original->char_count;
+
+        while (t_from < t_length)
+        {
+            /* Find the end of the current grapheme */
+            uindex_t t_grapheme_end =
+                MCStringGraphemeBreakIteratorAdvance(t_original, t_from);
+
+            if (t_grapheme_end == kMCLocaleBreakIteratorDone)
+                t_grapheme_end = t_length;
+
+            MCAssert(t_grapheme_end <= t_length);
+
+            MCMemoryCopy(t_result->chars + t_length - t_grapheme_end,
+                         t_original->chars + t_from,
+                         (t_grapheme_end - t_from) * sizeof(*t_result->chars));
+
+            t_from = t_grapheme_end;
+        }
+    }
+
+    r_new_string = t_result.Take();
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+MC_DLLEXPORT_DEF
 bool MCStringIsMutable(const MCStringRef self)
 {
 	__MCAssertIsString(self);

--- a/libscript/src/byte.lcb
+++ b/libscript/src/byte.lcb
@@ -432,6 +432,37 @@ begin
 	MCDataExecRandomBytes(Count, output)
 end syntax
 
+--
+
+public foreign handler MCDataExecReverseBytesOf(inout Target as Data) \
+		returns nothing binds to "<builtin>"
+
+/**
+Summary:	Reverse binary data
+Target:	A binary data string
+
+Example:
+	variable tForward
+	put 5 random bytes into tForward
+
+	variable tReversed
+	put tForward into tReversed
+	reverse tReversed
+
+	expect that the first byte of tForward is the last byte of tReversed
+	expect that the last byte of tForward is the first byte of tReversed
+
+Description:
+Reverses the order of bytes in the <Target>.
+
+Tags: Binary
+*/
+syntax ReverseBytesOf is statement
+	"reverse" <Target: Expression>
+begin
+	MCDataExecReverseBytesOf(Target)
+end syntax
+
 ----------------------------------------------------------------
 -- Conversion between bytes and numbers
 ----------------------------------------------------------------

--- a/libscript/src/char.lcb
+++ b/libscript/src/char.lcb
@@ -535,17 +535,15 @@ Summary:        Repeat over the chars of a string
 Iterand:        A string container.
 
 Example:
-	variable tString as String
-	put "stressed" into tString
-	
-	variable tReversed as String
 	variable tChar as String
-	put "" into tReversed
-	repeat for each char tChar in tString
-		put tChar before tReversed
+	variable tSpaceCount as Number
+	repeat for each char tChar in \
+			"the quick brown fox jumps over the lazy dog"
+		if tChar is " " then
+			add 1 to tSpaceCount
+		end if
 	end repeat
-
-    // tReversed is "desserts"
+	expect that tSpaceCount is 8
 
 Description:
 Use repeat for each to perform an operation on each char of a string. On each iteration, the <Iterand> will contain the next char of the string being iterated over.

--- a/libscript/src/char.lcb
+++ b/libscript/src/char.lcb
@@ -559,6 +559,32 @@ begin
     MCCharRepeatForEachChar(iterator, Iterand, container)
 end syntax
 
+--
+
+public foreign handler MCStringExecReverseCharsOf(inout Target as String) \
+		returns nothing binds to "<builtin>"
+
+/**
+Summary:	Reverse a string
+Target:	A string
+
+Example:
+	variable tString
+	put "abcdef" into tString
+	reverse tString
+	expect that tString is "fedcba"
+
+Description:
+Reverses the order of characters in the <Target>.
+
+Tags: Strings
+*/
+syntax ReverseCharsOf is statement
+	"reverse" <Target: Expression>
+begin
+	MCStringExecReverseCharsOf(Target)
+end syntax
+
 ----------------------------------------------------------------
 
 /**

--- a/libscript/src/list.lcb
+++ b/libscript/src/list.lcb
@@ -1098,4 +1098,30 @@ begin
     MCListEvalConcatenate(Left, Right, output)
 end syntax
 
+----------------------------------------------------------------
+
+public foreign handler MCListExecReverseElementsOf(inout Target as List) \
+		returns nothing binds to "<builtin>"
+
+/**
+Summary:	Reverse a list
+Target:	A list
+
+Example:
+	variable tList
+	put [1, 2, 3] into tList
+	reverse tList
+	expect that tList is [3, 2, 1]
+
+Description:
+Reverses the order of elements in the <Target>.
+
+Tags: Lists
+*/
+syntax ReverseElementsOfList is statement
+	"reverse" <Target: Expression>
+begin
+	MCListExecReverseElementsOf(Target)
+end syntax
+
 end module

--- a/libscript/src/module-byte.cpp
+++ b/libscript/src/module-byte.cpp
@@ -224,6 +224,21 @@ MCDataExecRandomBytes (uindex_t p_count, MCDataRef & r_data)
 ////////////////////////////////////////////////////////////////////////////////
 
 extern "C" MC_DLLEXPORT_DEF void
+MCDataExecReverseBytesOf(MCDataRef &x_data)
+{
+    MCAutoDataRef t_data;
+    if (!MCDataMutableCopy(x_data, &t_data))
+        return;
+    if (!MCDataReverse(*t_data))
+        return;
+    if (!t_data.MakeImmutable())
+        return;
+    MCValueAssign(x_data, *t_data);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+extern "C" MC_DLLEXPORT_DEF void
 MCByteEvalByteWithCode (uinteger_t p_value,
                         MCDataRef & r_data)
 {

--- a/libscript/src/module-char.cpp
+++ b/libscript/src/module-char.cpp
@@ -272,6 +272,15 @@ extern "C" MC_DLLEXPORT_DEF bool MCCharRepeatForEachChar(void*& x_iterator, MCSt
     return true;
 }
 
+extern "C" MC_DLLEXPORT_DEF void
+MCStringExecReverseCharsOf(MCStringRef &x_string)
+{
+    MCStringRef t_reversed = nullptr;
+    if (!MCStringCopyReversed(x_string, t_reversed))
+        return;
+    MCValueAssign(x_string, t_reversed);
+}
+
 ////////////////////////////////////////////////////////////////
 
 extern "C" MC_DLLEXPORT_DEF void MCStringEvalCodeOfChar(MCStringRef p_string, uinteger_t& r_code)

--- a/libscript/src/module-list.cpp
+++ b/libscript/src/module-list.cpp
@@ -630,6 +630,21 @@ MCListEvalConcatenate(MCProperListRef p_left,
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+extern "C" MC_DLLEXPORT_DEF void
+MCListExecReverseElementsOf(MCProperListRef& x_list)
+{
+    MCAutoProperListRef t_list;
+    if (!MCProperListMutableCopy(x_list, &t_list))
+        return;
+    if (!MCProperListReverse(*t_list))
+        return;
+    if (!t_list.MakeImmutable())
+        return;
+    MCValueAssign(x_list, *t_list);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 extern "C" bool com_livecode_list_Initialize(void)
 {
     return true;

--- a/tests/lcb/stdlib/byte.lcb
+++ b/tests/lcb/stdlib/byte.lcb
@@ -273,6 +273,40 @@ return
 end handler
 
 ----------------------------------------------------------------
+-- Other manipulations
+----------------------------------------------------------------
+
+public handler TestReverse()
+	variable kFOdd
+	put EncodeUTF8("abc") into kFOdd
+	variable kROdd
+	put EncodeUTF8("cba") into kROdd
+	variable kFEven
+	put EncodeUTF8("0123") into kFEven
+	variable kREven
+	put EncodeUTF8("3210") into kREven
+
+	variable tReversed
+
+	put kFOdd into tReversed
+	reverse tReversed
+	test "reverse in-place (odd)" when tReversed is kROdd
+	reverse tReversed
+	test "rereverse in-place (odd)" when tReversed is kFOdd
+
+	put kFEven into tReversed
+	reverse tReversed
+	test "reverse in-place (even)" when tReversed is kREven
+	reverse tReversed
+	test "rereverse in-place (even)" when tReversed is kFEven
+
+	put the empty data into tReversed
+	reverse tReversed
+	test "reverse in-place (empty)" when tReversed is empty
+
+end handler
+
+----------------------------------------------------------------
 -- Helper functions
 ----------------------------------------------------------------
 

--- a/tests/lcb/stdlib/char.lcb
+++ b/tests/lcb/stdlib/char.lcb
@@ -406,6 +406,37 @@ public handler TestRepeatChar()
 	test "repeatchar (count)" when tCount is 3
 end handler
 
+handler TestReverse_Inplace(in pDesc as String, \
+		in pForward as String, in pReverse as String)
+
+	variable tReversed
+	put pForward into tReversed
+
+	reverse tReversed
+	test diagnostic tReversed
+	test "reverse in-place (" & pDesc & ")" when tReversed is pReverse
+
+	reverse tReversed
+	test diagnostic tReversed
+	test "rereverse in-place (" & pDesc & ")" when tReversed is pForward
+end handler
+
+public handler TestReverse()
+	TestReverse_Inplace("empty", "", "")
+	TestReverse_Inplace("native, odd", "abc", "cba")
+	TestReverse_Inplace("native, even", "abcd", "dcba")
+	TestReverse_Inplace("trivial, odd", \
+			"\u{039a}\u{03b1}\u{03bb}\u{03b7}\u{03bc}\u{03ad}\u{03c1}\u{03b1}!", \
+			"!\u{03b1}\u{03c1}\u{03ad}\u{03bc}\u{03b7}\u{03bb}\u{03b1}\u{039a}")
+	TestReverse_Inplace("trivial, even", \
+			"\u{039a}\u{03b1}\u{03bb}\u{03b7}\u{03bc}\u{03ad}\u{03c1}\u{03b1}", \
+			"\u{03b1}\u{03c1}\u{03ad}\u{03bc}\u{03b7}\u{03bb}\u{03b1}\u{039a}")
+	TestReverse_Inplace("BMP variation selector, 1", "a\u{fe0e}", "a\u{fe0e}")
+	TestReverse_Inplace("BMP variation selector, even", \
+			"\u{2b55}\u{fe0f}\u{25ef}", "\u{25ef}\u{2b55}\u{fe0f}")
+	TestReverse_Inplace("SMP, odd", "a\u{1d11e}c", "c\u{1d11e}a")
+end handler
+
 ----------------------------------------------------------------
 
 handler TestCharWithCode_Negative()

--- a/tests/lcb/stdlib/list.lcb
+++ b/tests/lcb/stdlib/list.lcb
@@ -714,8 +714,33 @@ public handler TestOffsetBeforeZero()
 	test "last offset before (+ve, 0)" when the last offset of [true,false] before 0 in tList is tNoBefore
 end handler
 
+----------------------------------------------------------------
+
 public handler TestConcat()
 	test "concat" when ["x"] & ["y"] is ["x", "y"]
+end handler
+
+----------------------------------------------------------------
+
+public handler TestReverse()
+	variable tReversed
+
+	put [1, 2, 3] into tReversed
+	reverse tReversed
+	test "reverse in-place (odd)" when tReversed is [3, 2, 1]
+	reverse tReversed
+	test "rereverse in-place (odd)" when tReversed is [1, 2, 3]
+
+
+	put [1, 2, 3, 4] into tReversed
+	reverse tReversed
+	test "reverse in-place (even)" when tReversed is [4, 3, 2, 1]
+	reverse tReversed
+	test "rereverse in-place (even)" when tReversed is [1, 2, 3, 4]
+
+	put [] into tReversed
+	reverse tReversed
+	test "reverse in-place (empty)" when tReversed is empty
 end handler
 
 end module


### PR DESCRIPTION
This patch adds in-place `reverse _` syntax to LCB for sequence types (`List`, `String` and `Data`).

```
variable tList
put [1, 2, 3] into tList
reverse tList
expect that tList is [3, 2, 1]
```

There are several components:

- An `MCInplaceReverse()` template function for libfoundation internal use that supports any type that has a `swap()` operation
- In-place `MCProperListReverse()` and `MCDataReverse()` functions which operate on mutable values
- `MCStringCopyReverse()`, which creates a copy of a string with the order of its _graphemes_ reversed
- LCB syntax definitions, documentation, examples and unit tests