### PR TITLE
[Bug 19280] Correctly include standard script-only libraries

### DIFF
--- a/docs/notes/bugfix-19280.md
+++ b/docs/notes/bugfix-19280.md
@@ -1,0 +1,1 @@
+# Include core script-only libraries in standalones

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1631,13 +1631,7 @@ private command __InitialiseScriptLibraries
    local tLibraries
    put __ScriptLibraries() into tLibraries
    repeat for each line tLine in tLibraries
-      local tLibrary
-      put tLine into tLibrary["id"]
-      put tLine into tLibrary["title"]
-      put "script library" into tLibrary["type"]
-      put revSBAllDesktopPlatforms() & comma & \ 
-            revSBAllMobilePlatforms() into tLibrary["platforms"]
-      addToList tLibrary, sScriptLibraries
+      revSBAddAvailableLibrary revSBStackNameFromScriptLibraryName(tLine), tLine
    end repeat
 end __InitialiseScriptLibraries
 


### PR DESCRIPTION
In commit cca833b1ddfa, the standalone builder stopped correctly
mangling the names of the built-in script libraries (in particular the
'Geometry' library).  This patch (suggested by @livecodeali) ensures
that inclusion information is generated correctly for built-in script
libraries.