### PR TITLE
[[ Engine ]] Add the notion of an index name

### DIFF
--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -259,7 +259,7 @@ void MCGroup::SetHilitedButtonName(MCExecContext& ctxt, uint32_t part, MCStringR
                 // Clicking on the button attemps to hilite the option "title,menu,maximize,minimise,close"
                 // but only "title,menu,minimize,maximise,close" exists, returning a nil NameRef
                 MCNameRef t_nameref;
-                t_nameref = MCNameLookup(p_name);
+                t_nameref = MCNameLookupCaseless(p_name);
                 if (t_nameref != nil)
                     bptr->resethilite(part, bptr->hasname(t_nameref));
                 else

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -1169,7 +1169,7 @@ void MCStack::SetSubstacks(MCExecContext& ctxt, MCStringRef p_substacks)
 			{
 				// Lookup 't_name_string' as a name, if it doesn't exist it can't exist as a substack
 				// name.
-				&t_name = MCValueRetain(MCNameLookup(*t_name_string));
+				&t_name = MCValueRetain(MCNameLookupCaseless(*t_name_string));
 				if (*t_name != nil)
 				{
 					while (tsub -> hasname(*t_name))

--- a/engine/src/exec-multimedia.cpp
+++ b/engine/src/exec-multimedia.cpp
@@ -448,7 +448,7 @@ static MCPlayer* MCMultimediaExecGetClip(MCExecContext& ctxt, MCStringRef p_clip
 	{
         // AL-2014-05-27: [[ Bug 12517 ]] MCNameLookup does not increase the ref count
 		MCNameRef t_obj_name;
-		t_obj_name = MCNameLookup(p_clip);
+		t_obj_name = MCNameLookupCaseless(p_clip);
 		if (t_obj_name != nil)
 		{
 			tptr = MCplayers;

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -365,10 +365,35 @@ bool MCExecContext::ConvertToData(MCValueRef p_value, MCDataRef& r_data)
 
 bool MCExecContext::ConvertToName(MCValueRef p_value, MCNameRef& r_name)
 {
-    if (MCValueGetTypeCode(p_value) == kMCValueTypeCodeName)
+    switch(MCValueGetTypeCode(p_value))
     {
-        r_name = MCValueRetain((MCNameRef)p_value);
-        return true;
+        case kMCValueTypeCodeName:
+        {
+            r_name = MCValueRetain((MCNameRef)p_value);
+            return true;
+        }
+        
+        case kMCValueTypeCodeString:
+        {
+            return MCNameCreate((MCStringRef)p_value,
+                                r_name);
+        }
+            
+        case kMCValueTypeCodeNumber:
+        {
+            index_t t_index;
+            if (MCNumberStrictFetchAsIndex((MCNumberRef)p_value,
+                                           t_index))
+            {
+                return MCNameCreateWithIndex(t_index,
+                                             r_name);
+            }
+            else
+                break;
+        }
+            
+        default:
+            break;
     }
     
     MCAutoStringRef t_string;

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -1220,27 +1220,14 @@ bool MCNameIsEqualToOldString(MCNameRef p_left, const MCString& p_oldstring, MCC
 	return MCStringIsEqualToOldString(MCNameGetString(p_left), p_oldstring, p_options);
 }
 
-MCNameRef MCNameLookupWithCString(const char *cstring, MCCompareOptions options)
+MCNameRef MCNameLookupWithCStringCaseless(const char *cstring)
 {
 	MCStringRef t_string;
 	if (!MCStringCreateWithNativeChars((const char_t *)cstring, strlen(cstring), t_string))
 		return nil;
 
 	MCNameRef t_name;
-	t_name = MCNameLookup(t_string);
-	MCValueRelease(t_string);
-
-	return t_name;
-}
-
-MCNameRef MCNameLookupWithOldString(const MCString& string, MCCompareOptions options)
-{	
-	MCStringRef t_string;
-	if (!MCStringCreateWithNativeChars((const char_t *)string . getstring(), string . getlength(), t_string))
-		return nil;
-
-	MCNameRef t_name;
-	t_name = MCNameLookup(t_string);
+	t_name = MCNameLookupCaseless(t_string);
 	MCValueRelease(t_string);
 
 	return t_name;

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -92,8 +92,7 @@ bool MCNameIsEqualTo(MCNameRef left, MCNameRef right, MCCompareOptions options);
 bool MCNameIsEqualToCString(MCNameRef left, const char *cstring, MCCompareOptions options);
 bool MCNameIsEqualToOldString(MCNameRef left, const MCString& string, MCCompareOptions options);
 
-MCNameRef MCNameLookupWithCString(const char *cstring, MCCompareOptions options);
-MCNameRef MCNameLookupWithOldString(const MCString& string, MCCompareOptions options);
+MCNameRef MCNameLookupWithCStringCaseless(const char *cstring);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -799,7 +799,7 @@ Exec_stat MCStack::resubstack(MCStringRef p_data)
 			// If t_val doesn't exist as a name, it can't exist as a substack name.
 			// t_val is always a stringref (fetched from an MCSplitString array)
 			MCNameRef t_name;
-			t_name = MCNameLookup((MCStringRef)t_val);
+			t_name = MCNameLookupCaseless((MCStringRef)t_val);
 		
 			if (t_name != nil)
 				while (tsub -> hasname(t_name))

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -900,7 +900,7 @@ MCVariable *MCVariable::lookupglobal_cstring(const char *p_name)
 	// If we can't find an existing name, then there can be no global with
 	// name 'p_name'.
 	MCNameRef t_name;
-	t_name = MCNameLookupWithCString(p_name, kMCCompareCaseless);
+	t_name = MCNameLookupWithCStringCaseless(p_name);
 	if (t_name == nil)
 		return nil;
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1306,13 +1306,11 @@ MC_DLLEXPORT hash_t MCHashBytes(const void *bytes, size_t byte_count);
 // hashing sequence (byte_count should be a multiple of 4).
 MC_DLLEXPORT hash_t MCHashBytesStream(hash_t previous, const void *bytes, size_t byte_count);
 
-// Returns a hash value for the given sequence of native chars. The chars are
-// folded before being processed.
+// Returns a hash value for the given sequence of native chars.
 MC_DLLEXPORT hash_t MCHashNativeChars(const char_t *chars,
                                       size_t char_count);
 
-// Returns a hash value for the given sequence of code units. The chars are
-// normalized and folded before being processed.
+// Returns a hash value for the given sequence of code units.
 MC_DLLEXPORT hash_t MCHashChars(const unichar_t *chars,
                                 size_t char_count);
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1882,6 +1882,9 @@ MC_DLLEXPORT bool MCNumberIsReal(MCNumberRef number);
 MC_DLLEXPORT integer_t MCNumberFetchAsInteger(MCNumberRef number);
 MC_DLLEXPORT uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef number);
 MC_DLLEXPORT real64_t MCNumberFetchAsReal(MCNumberRef number);
+    
+MC_DLLEXPORT bool MCNumberStrictFetchAsIndex(MCNumberRef number,
+                                             index_t& r_index);
 
 MC_DLLEXPORT bool MCNumberParseOffsetPartial(MCStringRef p_string, uindex_t offset, uindex_t &r_chars_used, MCNumberRef &r_number);
 
@@ -1912,12 +1915,17 @@ MC_DLLEXPORT bool MCNameCreate(MCStringRef string, MCNameRef& r_name);
 MC_DLLEXPORT bool MCNameCreateWithChars(const unichar_t *chars, uindex_t count, MCNameRef& r_name);
 // Create a name using native chars.
 MC_DLLEXPORT bool MCNameCreateWithNativeChars(const char_t *chars, uindex_t count, MCNameRef& r_name);
-
+// Create a name using an integral index.
+MC_DLLEXPORT bool MCNameCreateWithIndex(index_t index, MCNameRef& r_name);
+    
 // Create a name using the given string, releasing the original.
 MC_DLLEXPORT bool MCNameCreateAndRelease(MCStringRef string, MCNameRef& r_name);
 
 // Looks for an existing name matching the given string.
 MC_DLLEXPORT MCNameRef MCNameLookupCaseless(MCStringRef string);
+
+// Looks for an existing name matching the given index.
+MC_DLLEXPORT MCNameRef MCNameLookupIndex(index_t index);
 
 // Returns a unsigned integer which can be used to order a table for a binary
 // search.

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2338,6 +2338,7 @@ MC_DLLEXPORT hash_t MCStringHash(MCStringRef string, MCStringOptions options);
 // Returns true if the two strings are equal, processing as appropriate according
 // to options.
 MC_DLLEXPORT bool MCStringIsEqualTo(MCStringRef string, MCStringRef other, MCStringOptions options);
+MC_DLLEXPORT bool MCStringIsEqualToChars(MCStringRef string, const unichar_t *chars, uindex_t char_count, MCStringOptions options);
 MC_DLLEXPORT bool MCStringIsEqualToNativeChars(MCStringRef string, const char_t *chars, uindex_t char_count, MCStringOptions options);
 MC_DLLEXPORT bool MCStringSubstringIsEqualToNativeChars(MCStringRef self, MCRange p_range, const char_t *p_chars, uindex_t p_char_count, MCStringOptions p_options);
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1917,7 +1917,7 @@ MC_DLLEXPORT bool MCNameCreateWithNativeChars(const char_t *chars, uindex_t coun
 MC_DLLEXPORT bool MCNameCreateAndRelease(MCStringRef string, MCNameRef& r_name);
 
 // Looks for an existing name matching the given string.
-MC_DLLEXPORT MCNameRef MCNameLookup(MCStringRef string);
+MC_DLLEXPORT MCNameRef MCNameLookupCaseless(MCStringRef string);
 
 // Returns a unsigned integer which can be used to order a table for a binary
 // search.

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -10,6 +10,7 @@
 		[
 			'test/environment.cpp',
 			'test/test_hash.cpp',
+            'test/test_name.cpp',
 			'test/test_proper-list.cpp',
 			'test/test_string.cpp',
 			'test/test_typeconvert.cpp',

--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -612,14 +612,15 @@ bool MCArrayFetchValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef& r_va
 {
 	__MCAssertIsArray(self);
 
-	char t_index_str[16];
-	sprintf(t_index_str, "%d", p_index);
+    MCNameRef t_key =
+            MCNameLookupIndex(p_index);
+    
+    if (t_key == nil)
+    {
+        return false;
+    }
 
-	MCNewAutoNameRef t_key;
-	if (!MCNameCreateWithNativeChars((const char_t *)t_index_str, strlen(t_index_str), &t_key))
-		return false;
-
-	return MCArrayFetchValue(self, true, *t_key, r_value);
+	return MCArrayFetchValue(self, true, t_key, r_value);
 }
 
 MC_DLLEXPORT_DEF
@@ -627,27 +628,30 @@ bool MCArrayStoreValueAtIndex(MCArrayRef self, index_t p_index, MCValueRef p_val
 {
 	__MCAssertIsArray(self);
 
-	char t_index_str[16];
-	sprintf(t_index_str, "%d", p_index);
-
 	MCNewAutoNameRef t_key;
-	if (!MCNameCreateWithNativeChars((const char_t *)t_index_str, strlen(t_index_str), &t_key))
+	if (!MCNameCreateWithIndex(p_index,
+                               &t_key))
+    {
 		return false;
-
+    }
+    
 	return MCArrayStoreValue(self, true, *t_key, p_value);
 }
 
 bool
 MCArrayRemoveValueAtIndex(MCArrayRef self, index_t p_index)
 {
-	char t_index_str[16];
-	sprintf(t_index_str, "%d", p_index);
-	MCNewAutoNameRef t_key;
-	if (!MCNameCreateWithNativeChars((const char_t *)t_index_str,
-									 strlen(t_index_str),
-									 &t_key))
-		return false;
-	return MCArrayRemoveValue(self, true, *t_key);
+    __MCAssertIsArray(self);
+    
+    MCNameRef t_key =
+            MCNameLookupIndex(p_index);
+    
+    if (t_key == nil)
+    {
+        return true;
+    }
+
+	return MCArrayRemoveValue(self, true, t_key);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -206,7 +206,7 @@ bool MCNameCreateAndRelease(MCStringRef p_string, MCNameRef& r_name)
 }
 
 MC_DLLEXPORT_DEF
-MCNameRef MCNameLookup(MCStringRef p_string)
+MCNameRef MCNameLookupCaseless(MCStringRef p_string)
 {
 	// Compute the hash of the characters, up to case.
 	hash_t t_hash;

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -261,7 +261,7 @@ bool MCNameCreate(MCStringRef p_string, MCNameRef& r_name)
 
 //////////
 
-// This comparator is used to search for native string in the name table.
+// This comparator is used to search for a native string in the name table.
 class __MCNameNativeCharsInput
 {
 public:
@@ -277,8 +277,9 @@ public:
     
     hash_t Hash(void) const
     {
-        return MCHashNativeChars(m_native_chars.data(),
-                                 m_native_chars.length());
+        return MCNativeCharsHash(m_native_chars.data(),
+                                 m_native_chars.length(),
+                                 kMCStringOptionCompareCaseless);
     }
     
     bool IsEquivalentTo(MCStringRef p_other_string) const
@@ -317,7 +318,7 @@ bool MCNameCreateWithNativeChars(const char_t *p_chars, uindex_t p_count, MCName
 
 //////////
 
-// This comparator is used to search for native string in the name table.
+// This comparator is used to search for a unicode string in the name table.
 class __MCNameCharsInput
 {
 public:
@@ -333,8 +334,9 @@ public:
     
     hash_t Hash(void) const
     {
-        return MCHashChars(m_chars.data(),
-                           m_chars.length());
+        return MCUnicodeHash(m_chars.data(),
+                             m_chars.length(),
+                             kMCUnicodeCompareOptionCaseless);
     }
     
     bool IsEquivalentTo(MCStringRef p_other_string) const
@@ -389,6 +391,8 @@ public:
     
     hash_t Hash(void) const
     {
+        /* We can use MCNativeCharsHash here as m_chars will be a sequence of
+         * digits which are already folded. */
         return MCHashNativeChars(m_chars,
                                  m_char_count);
     }

--- a/libfoundation/src/foundation-number.cpp
+++ b/libfoundation/src/foundation-number.cpp
@@ -99,6 +99,28 @@ uinteger_t MCNumberFetchAsUnsignedInteger(MCNumberRef self)
 	return self -> real >= 0.0 ? (uinteger_t)(self -> real + 0.5) : (uinteger_t)0.0;
 }
 
+MC_DLLEXPORT_DEF
+bool MCNumberStrictFetchAsIndex(MCNumberRef self,
+                                index_t& r_index)
+{
+    MCStaticAssert(sizeof(index_t) == sizeof(integer_t));
+    
+    if (MCNumberIsInteger(self))
+    {
+        r_index = self->integer;
+        return true;
+    }
+    
+    index_t t_as_int = (index_t)(self -> real);
+    if (self->real - t_as_int != 0.0)
+    {
+        return false;
+    }
+    
+    r_index = t_as_int;
+    return true;
+}
+
 compare_t MCNumberCompareTo(MCNumberRef self, MCNumberRef p_other_self)
 {
 	// First determine the storage types of both numbers.

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -618,6 +618,9 @@ char_t MCNativeCharUppercase(char_t c);
 // Format the given string - the return string is NUL formatted.
 bool MCNativeCharsFormatV(char_t*& r_string, uindex_t& r_size, const char *format, va_list args);
 
+// Hash the given string with the specified options.
+hash_t MCNativeCharsHash(const char_t *p_chars, uindex_t p_char_count, MCStringOptions p_options);
+
 //////////
 
 bool MCUnicodeCharsMapToNative(const unichar_t *uchars, uindex_t uchar_count, char_t *nchars, uindex_t& r_nchar_count, char_t invalid);

--- a/libfoundation/src/foundation-string-native.cpp.h
+++ b/libfoundation/src/foundation-string-native.cpp.h
@@ -1138,4 +1138,11 @@ bool MCNativeCharsFormatV(char_t*& r_string, uindex_t& r_size, const char *p_for
 	return true;
 }
 
+hash_t MCNativeCharsHash(const char_t *p_chars, uindex_t p_char_count, MCStringOptions p_options)
+{
+    return __MCNativeOp_Hash(p_chars,
+                             p_char_count,
+                             p_options);
+}
+
 ////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -2843,7 +2843,7 @@ hash_t MCStringHash(MCStringRef self, MCStringOptions p_options)
         self = self -> string;
     
     if (__MCStringIsNative(self))
-        return __MCNativeOp_Hash(self -> native_chars,
+        return MCNativeCharsHash(self -> native_chars,
                                  self -> char_count,
                                  p_options);
     

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -3007,6 +3007,32 @@ bool MCStringSubstringIsEqualToNativeChars(MCStringRef self, MCRange p_range, co
 }
 
 MC_DLLEXPORT_DEF
+bool MCStringIsEqualToChars(MCStringRef self, const unichar_t *p_chars, uindex_t p_char_count, MCStringOptions p_options)
+{
+    __MCAssertIsString(self);
+    MCAssert(nil != p_chars);
+    
+    if (__MCStringIsIndirect(self))
+        self = self -> string;
+    
+    bool self_native = __MCStringIsNative(self);
+    
+    const void *self_chars;
+    if (self_native)
+        self_chars = self -> native_chars;
+    else
+        self_chars = self -> chars;
+    
+    return MCUnicodeCompare(self_chars,
+                            self->char_count,
+                            self_native,
+                            p_chars,
+                            p_char_count,
+                            false,
+                            (MCUnicodeCompareOption)p_options) == 0;
+}
+
+MC_DLLEXPORT_DEF
 compare_t MCStringCompareTo(MCStringRef self, MCStringRef p_other, MCStringOptions p_options)
 {
 	__MCAssertIsString(self);

--- a/libfoundation/test/test_hash.cpp
+++ b/libfoundation/test/test_hash.cpp
@@ -137,10 +137,18 @@ MCAutoStringRef string_create_utf8(const char (&utf8)[N])
     return s;
 }
 
+template<size_t N>
+MCAutoStringRef string_create_native(const char (&native)[N])
+{
+    MCAutoStringRef s;
+    MCStringCreateWithNativeChars((const char_t *)native, N-1, &s);
+    return s;
+}
+
 TEST(hash, native_string)
 {
-    MCAutoStringRef t_mixed = string_create_utf8(u8"LiveCode");
-    MCAutoStringRef t_lower = string_create_utf8(u8"livecode");
+    MCAutoStringRef t_mixed = string_create_native("LiveCode");
+    MCAutoStringRef t_lower = string_create_native("livecode");
 
     /* Check a couple of specific values */
     EXPECT_EQ(string_hash_exact(kMCEmptyString), {2166136261});

--- a/libfoundation/test/test_name.cpp
+++ b/libfoundation/test/test_name.cpp
@@ -1,0 +1,52 @@
+/* Copyright (C) 2003-2015 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "gtest/gtest.h"
+
+#include "foundation.h"
+#include "foundation-auto.h"
+
+TEST(name, index_equiv_strings)
+{
+    static index_t s_test_indicies[] =
+    {
+        INT32_MIN + 32,
+        INT16_MIN,
+        INT8_MIN,
+        0,
+        INT8_MAX,
+        INT16_MAX,
+        INT32_MAX - 32,
+    };
+    for(size_t i = 0; i < sizeof(s_test_indicies) / sizeof(s_test_indicies[0]); i++)
+    {
+        for(int j = -32; j <= 32; j++)
+        {
+            int64_t t_full_index = s_test_indicies[i] + j;
+            index_t t_index = (index_t)t_full_index;
+            char_t t_index_str[32];
+            sprintf((char *)t_index_str, "%lld", t_full_index);
+            
+            // fprintf(stderr, "%lld, %d\n", t_full_index, t_index);
+            
+            MCNewAutoNameRef t_index_name, t_string_name;
+            ASSERT_TRUE(MCNameCreateWithIndex(t_index, &t_index_name));
+            ASSERT_TRUE(MCNameCreateWithNativeChars(t_index_str, strlen((char *)t_index_str), &t_string_name));
+            // fprintf(stderr, "%s, %s\n", MCStringGetCString(MCNameGetString(*t_index_name)), MCStringGetCString(MCNameGetString(*t_string_name)));
+            ASSERT_EQ(*t_index_name, *t_string_name);
+        }
+    }
+}

--- a/libfoundation/test/test_name.cpp
+++ b/libfoundation/test/test_name.cpp
@@ -19,7 +19,7 @@
 #include "foundation.h"
 #include "foundation-auto.h"
 
-TEST(name, index_equiv_strings)
+TEST(name, index_equal_string)
 {
     static index_t s_test_indicies[] =
     {
@@ -48,5 +48,76 @@ TEST(name, index_equiv_strings)
             // fprintf(stderr, "%s, %s\n", MCStringGetCString(MCNameGetString(*t_index_name)), MCStringGetCString(MCNameGetString(*t_string_name)));
             ASSERT_EQ(*t_index_name, *t_string_name);
         }
+    }
+}
+
+TEST(name, distinct_string)
+{
+    static constexpr const char *s_test_names[] =
+    {
+        "foo",
+        "bar",
+        "baz"
+        "foobar",
+        "foobaz",
+        "foobarbaz",
+    };
+    static constexpr size_t s_test_name_count = sizeof(s_test_names) / sizeof(s_test_names[0]);
+    
+    MCNewAutoNameRef t_names[s_test_name_count];
+    for(size_t i = 0; i < s_test_name_count; i++)
+    {
+        ASSERT_TRUE(MCNameCreateWithNativeChars((const char_t *)s_test_names[i], strlen(s_test_names[i]), &t_names[i]));
+        for(size_t j = 0; j < i; j++)
+            ASSERT_NE(*t_names[i], *t_names[j]);
+    }
+}
+
+TEST(name, equal_string)
+{
+    static constexpr const char *s_test_names[] =
+    {
+        "foo",
+        "foo",
+        "baz",
+        "baz",
+        "foobaz",
+        "foobaz",
+    };
+    static constexpr size_t s_test_name_count = sizeof(s_test_names) / sizeof(s_test_names[0]);
+    
+    MCNewAutoNameRef t_names[s_test_name_count];
+    for(size_t i = 0; i < s_test_name_count; i++)
+    {
+        ASSERT_TRUE(MCNameCreateWithNativeChars((const char_t *)s_test_names[i], strlen(s_test_names[i]), &t_names[i]));
+    }
+    for(size_t i = 0; i < s_test_name_count / 2; i++)
+    {
+        ASSERT_EQ(*t_names[i * 2], *t_names[i * 2 + 1]);
+    }
+}
+
+TEST(name, equiv_string)
+{
+    static constexpr const char *s_test_names[] =
+    {
+        "foo",
+        "FoO",
+        "baz",
+        "baZ",
+        "fooBaz",
+        "Foobaz",
+    };
+    static constexpr size_t s_test_name_count = sizeof(s_test_names) / sizeof(s_test_names[0]);
+    
+    MCNewAutoNameRef t_names[s_test_name_count];
+    for(size_t i = 0; i < s_test_name_count; i++)
+    {
+        ASSERT_TRUE(MCNameCreateWithNativeChars((const char_t *)s_test_names[i], strlen(s_test_names[i]), &t_names[i]));
+    }
+    for(size_t i = 0; i < s_test_name_count / 2; i++)
+    {
+        fprintf(stderr, "%s, %s\n", MCStringGetCString(MCNameGetString(*t_names[i * 2])), MCStringGetCString(MCNameGetString(*t_names[i * 2 + 1])));
+        ASSERT_TRUE(MCNameIsEqualTo(*t_names[i * 2], *t_names[i * 2 + 1]));
     }
 }


### PR DESCRIPTION
This patch (taking commits from #5100) adds the notion of an 'index name' - an MCNameRef whose string is a decimal integer in the range of index_t.

This speeds up storing and fetching integer keys in arrays by about a factor of 2 compared to previous 9 dps.