### PR TITLE
[Bug 17097] libfoundation: Add MCMemoryClearSecure()

### DIFF
--- a/libfoundation/include/foundation-span.h
+++ b/libfoundation/include/foundation-span.h
@@ -209,6 +209,13 @@ inline MCSpan<ElementType> MCDataGetSpan(MCDataRef p_data)
  * Span-based overloads for pointer+range libfoundation functions
  * ---------------------------------------------------------------- */
 
+template <typename ElementType>
+inline void MCMemoryClearSecure(MCSpan<ElementType> x_span)
+{
+    MCMemoryClearSecure(reinterpret_cast<byte_t*>(x_span.data()),
+                        x_span.sizeBytes());
+}
+
 MC_DLLEXPORT
 hash_t MCHashBytes(MCSpan<const byte_t> bytes);
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -998,6 +998,11 @@ extern "C" {
 // Clear the given block of memory to all 0's.
 inline void MCMemoryClear(void *dst, size_t size) { memset(dst, 0, size); }
 
+// Clear the given block of memory to all 0's, ensuring that the
+// compiler never optimises it out.  Use this when clearing sensitive
+// data from memory.
+MC_DLLEXPORT void MCMemoryClearSecure(byte_t* dst, size_t size);
+
 // Fill the given block of memory with the given (byte) value.
 inline void MCMemoryFill(void *dst, size_t size, uint8_t value) { memset(dst, value, size); }
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1030,6 +1030,14 @@ template <typename T> void inline MCMemoryClear(T&p_struct)
 	MCMemoryClear(&p_struct, sizeof(T));
 }
 
+// Securely clear the memory of the given structure to all 0's
+template <typename T>
+void inline MCMemoryClearSecure(T& p_struct)
+{
+    MCMemoryClearSecure(reinterpret_cast<byte_t*>(&p_struct),
+                        sizeof(p_struct));
+}
+
 // Re-initialise an object to its default-constructed state
 template <typename T> void inline MCMemoryReinit(T& p_object)
 {


### PR DESCRIPTION
Add a new function, `MCMemoryClearSecure()`, that's equivalent to
`MCMemoryClear()` but with the guarantee that it will never be
optimised out.

On Windows, this uses the standard `SecureZeroMemory()` library
function.

On other platforms, this uses `MCMemoryClear()` (i.e. `memset()`), but
with an additional memory barrier that prevents the call to `memset()`
from being optimised out.  Typical assembly generated in `Release`
mode:

```asm
push	rbx
mov	rdx, rsi
xor	esi, esi
mov	rbx, rdi
call	memset
pop	rbx
ret
```