### PR TITLE
[[ Bug 19523 ]] Make sure registers are destroyed during codegen

### DIFF
--- a/docs/lcb/notes/19523.md
+++ b/docs/lcb/notes/19523.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+## lc-compile
+
+# [19523] Make sure all created registers are destroyed

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -196,6 +196,8 @@ struct AttachedReg
 
 static AttachedReg *s_attached_regs = nil;
 
+void EmitCheckNoRegisters(void);
+
 //////////
 
 //static MCTypeInfoRef *s_typeinfos = nil;
@@ -839,6 +841,9 @@ void EmitBeginUnsafeHandlerDefinition(long p_index, PositionRef p_position, Name
 
 void EmitEndHandlerDefinition(void)
 {
+    /* Check that registers have all been destroyed */
+    EmitCheckNoRegisters();
+    
     if (s_attached_regs != nil)
     {
         for(AttachedReg *t_reg = s_attached_regs; t_reg != NULL; t_reg = t_reg -> next)
@@ -1349,6 +1354,25 @@ void EmitDestroyRegister(long regindex)
     s_registers[regindex] = 0;
 
     Debug_Emit("DestroyRegister(%ld)", regindex);
+}
+
+void EmitCheckNoRegisters(void)
+{
+    bool t_all_destroyed = true;
+    if (s_register_count > 0)
+    {
+        for(uindex_t i = 0; i < s_register_count; i++)
+            if (s_registers[i] != 0)
+            {
+                t_all_destroyed = false;
+                Debug_Emit("Register %d not destroyed", i);
+            }
+    }
+    
+    if (!t_all_destroyed)
+    {
+        Fatal_InternalInconsistency("handler generation finished without destroying all registers");
+    }
 }
 
 //////////

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1133,8 +1133,9 @@
         
         EmitJump(RepeatHead)
         
-        EmitDestroyRegister(IteratorReg)
         EmitDestroyRegister(TargetReg)
+        EmitDestroyRegister(IterationVarTempReg)
+        EmitDestroyRegister(IteratorReg)
 
         EmitResolveLabel(RepeatTail)
 
@@ -1192,6 +1193,7 @@
     'rule' GenerateBody(Result, Context, get(Position, Value)):
         GenerateExpression(Result, Context, Value -> Reg)
         EmitAssign(Result, Reg)
+        EmitDestroyRegister(Reg)
 
     'rule' GenerateBody(Result, Context, invoke(Position, Invokes, Arguments)):
         EmitPosition(Position)


### PR DESCRIPTION
This patch adds two validity checks to the code generation phase of
lc-compile:

  - all registers must be destroyed when a handler is finished
    being generated

  - the bytecode of a module must validate correctly for the
    compilation to succeed

These checks uncovered two places where DestroyRegister() was not
being called: in the codegen rule for the 'get' command, and in
the codegen rule for the 'repeat for each' command.

Note: There is no explicit test for this - any test which uses a codegen rule which is not destroying all registers, will now fail with an 'internal inconsistency' error.