### PR TITLE
[[ Bug 19528 ]] Allow 'relaunch' handler to be in behavior

### DIFF
--- a/docs/notes/bugfix-19528.md
+++ b/docs/notes/bugfix-19528.md
@@ -1,0 +1,1 @@
+# Allow 'relaunch' message to be in behavior of main stack

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1597,7 +1597,7 @@ bool MCModeHandleRelaunch(MCStringRef &r_id)
 {
 #ifdef _WINDOWS
 	bool t_do_relaunch;
-    t_do_relaunch = MCdefaultstackptr -> hashandler(HT_MESSAGE, MCM_relaunch) == True;
+    t_do_relaunch = MCdefaultstackptr -> handlesmessage(MCM_relaunch) == True;
     /* UNCHECKED */ MCStringCopy(MCNameGetString(MCdefaultstackptr -> getname()), r_id);
     return t_do_relaunch;
 #else

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -1130,7 +1130,7 @@ bool MCModeHandleRelaunch(MCStringRef &r_id)
 {
 #ifdef _WINDOWS
 	bool t_do_relaunch;
-	t_do_relaunch = MCdefaultstackptr -> hashandler(HT_MESSAGE, MCM_relaunch) == True;
+	t_do_relaunch = MCdefaultstackptr -> handlesmessage(MCM_relaunch) == True;
 	/* UNCHECKED */ MCStringCopy(MCNameGetString(MCdefaultstackptr -> getname()), r_id);
 	return t_do_relaunch;
 #else


### PR DESCRIPTION
This patch uses handlesmessage() rather than hashandler() to
determine whether to send the 'relaunch' message. This means that
the handler can now be in a behavior of the mainstack, and not
just in the stack script.