### PR TITLE
[Bug 17401] Audit MCRangeMake() usage

### DIFF
--- a/engine/src/aclip.cpp
+++ b/engine/src/aclip.cpp
@@ -471,7 +471,7 @@ Boolean MCAudioClip::import(MCStringRef fname, IO_handle stream)
     uindex_t t_sep;
     MCStringRef t_fname;
     if (MCStringLastIndexOfChar(fname, PATH_SEPARATOR, UINDEX_MAX, kMCCompareExact, t_sep))
-        /* UNCHECKED */ MCStringCopySubstring(fname, MCRangeMake(t_sep + 1, MCStringGetLength(fname) - (t_sep + 1)), t_fname);
+        /* UNCHECKED */ MCStringCopySubstring(fname, MCRangeMakeMinMax(t_sep + 1, MCStringGetLength(fname)), t_fname);
     else
         t_fname = MCValueRetain(fname);
     

--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -858,7 +858,7 @@ bool MCBlock::fit(coord_t x, coord_t maxwidth, findex_t& r_break_index, bool& r_
 		else*/
         {
             MCRange t_range;
-            t_range = MCRangeMake(initial_i, i - initial_i);
+            t_range = MCRangeMakeMinMax(initial_i, i);
             // MM-2014-04-16: [[ Bug 11964 ]] Pass through the transform of the stack to make sure the measurment is correct for scaled text.
             t_width_float += MCFontMeasureTextSubstringFloat(m_font,  parent->GetInternalStringRef(), t_range, parent -> getparent() -> getstack() -> getdevicetransform());
         }
@@ -1074,7 +1074,7 @@ void MCBlock::drawstring(MCDC *dc, coord_t x, coord_t p_cell_left, coord_t p_cel
             // FG-2014-07-16: [[ Bug 12539 ]] Make sure not to draw tab characters
 			coord_t t_width;
 			MCRange t_range;
-			t_range = MCRangeMake(t_index, t_next_index - t_index);
+			t_range = MCRangeMakeMinMax(t_index, t_next_index);
             if (length > 0 && parent->GetCodepointAtIndex(t_next_index - 1) == '\t')
                 t_range.length--;
             t_width = MCFontMeasureTextSubstringFloat(m_font, parent->GetInternalStringRef(), t_range, parent -> getparent() -> getstack() -> getdevicetransform());
@@ -1765,7 +1765,7 @@ coord_t MCBlock::getsubwidth(MCDC *dc, coord_t x /* IGNORED */, findex_t i, find
 					break;
 				
 				MCRange t_range;
-				t_range = MCRangeMake(sptr, eptr - sptr);
+				t_range = MCRangeMakeMinMax(sptr, eptr);
                 // MM-2014-04-16: [[ Bug 11964 ]] Pass through the transform of the stack to make sure the measurment is correct for scaled text.
                 twidth += MCFontMeasureTextSubstringFloat(m_font, parent->GetInternalStringRef(), t_range, parent -> getparent() -> getstack() -> getdevicetransform());
 

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -2201,7 +2201,7 @@ MCRange MCButton::getmenurange()
 		if (!MCStringFind(menustring, t_search, MCSTR("\n"), kMCStringOptionCompareExact, &t_temp))
 		{
 			if (++i == menuhistory)
-				return MCRangeMake(sptr, t_length - sptr);
+				return MCRangeMakeMinMax(sptr, t_length);
 			else
 				return MCRangeMake(0, 0);
 			break;
@@ -2214,7 +2214,7 @@ MCRange MCButton::getmenurange()
 	}
 	while (i < menuhistory);
 		
-	return MCRangeMake(sptr, t_search.offset - sptr);
+	return MCRangeMakeMinMax(sptr, t_search.offset);
 }
 
 void MCButton::makemenu(sublist *bstack, int2 &stackdepth, uint2 menuflags, MCFontRef fontref)
@@ -2728,7 +2728,7 @@ void MCButton::openmenu(Boolean grab)
 			
 			MCAutoStringRef t_label;
 			/* UNCHECKED */ MCStringCopySubstring(t_menustring, 
-												  MCRangeMake(t_offset, t_new_offset - t_offset),
+												  MCRangeMakeMinMax(t_offset, t_new_offset),
 												  &t_label);
 			MCValueAssign(label, *t_label);
 			flags |= F_LABEL;

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -1984,7 +1984,7 @@ void MCSubwindow::exec_ctxt(MCExecContext &ctxt)
 						{
 							MCStringCopySubstring(*t_position_data, MCRangeMake(0, t_delimiter), &t_position);
 							t_delimiter++;
-							MCStringCopySubstring(*t_position_data, MCRangeMake(t_delimiter, MCStringGetLength(*t_position_data) - t_delimiter), &t_alignment);
+							MCStringCopySubstring(*t_position_data, MCRangeMakeMinMax(t_delimiter, MCStringGetLength(*t_position_data)), &t_alignment);
 						}
                         // AL-2014-04-07: [[ Bug 12138 ]] 'drawer ... at <position>' codepath resulted in t_position uninitialised
                         else

--- a/engine/src/date.cpp
+++ b/engine/src/date.cpp
@@ -871,7 +871,7 @@ void MCD_dateformat(MCExecContext &ctxt, Properties p_length, MCStringRef& r_dat
 	if (t_char == '!' || t_char == '^')
 	{
 		MCAutoStringRef t_new;
-		/* UNCHECKED */ MCStringCopySubstring(t_format, MCRangeMake(1, MCStringGetLength(t_format) - 1), &t_new);
+		/* UNCHECKED */ MCStringCopySubstring(t_format, MCRangeMakeMinMax(1, MCStringGetLength(t_format)), &t_new);
 		MCValueAssign(t_format, *t_new);
 	}
 

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -777,11 +777,11 @@ void MCPlatformHandleTextInputQueryTextRanges(MCPlatformWindowRef p_window, MCRa
 	int4 si, ei;
 	MCactivefield -> selectedmark(False, si, ei, False);
 	MCactivefield -> unresolvechars(0, si, ei);
-	r_selected_range = MCRangeMake(si, ei - si);
+	r_selected_range = MCRangeMakeMinMax(si, ei);
 	if (MCactivefield -> getcompositionrange(si, ei))
 	{
 		MCactivefield -> unresolvechars(0, si, ei);
-		r_marked_range = MCRangeMake(si, ei - si);
+		r_marked_range = MCRangeMakeMinMax(si, ei);
 	}
 	else
 		r_marked_range = MCRangeMake(UINDEX_MAX, 0);
@@ -831,7 +831,7 @@ void MCPlatformHandleTextInputQueryTextRect(MCPlatformWindowRef p_window, MCRang
 	t_bottom_right = MCactivefield -> getstack() -> stacktowindowloc(MCPointMake(t_rect . x + t_rect . width, t_rect . y + t_rect . height));
 	
 	r_first_line_rect = MCRectangleMake(t_top_left . x, t_top_left . y, t_bottom_right . x - t_top_left . x, t_bottom_right . y - t_top_left . y);
-	r_actual_range = MCRangeMake(t_si, t_ei - t_si);
+	r_actual_range = MCRangeMakeMinMax(t_si, t_ei);
 }
 
 void MCPlatformHandleTextInputQueryText(MCPlatformWindowRef p_window, MCRange p_range, unichar_t*& r_chars, uindex_t& r_char_count, MCRange& r_actual_range)
@@ -855,7 +855,7 @@ void MCPlatformHandleTextInputQueryText(MCPlatformWindowRef p_window, MCRange p_
 	MCactivefield -> unresolvechars(0, t_si, t_ei);
     
     /* UNCHECKED */ MCStringConvertToUnicode(*t_text, r_chars, r_char_count);
-    r_actual_range = MCRangeMake(t_si, t_ei - t_si);
+    r_actual_range = MCRangeMakeMinMax(t_si, t_ei);
 }
 
 void MCPlatformHandleTextInputInsertText(MCPlatformWindowRef p_window, unichar_t *p_chars, uindex_t p_char_count, MCRange p_replace_range, MCRange p_selection_range, bool p_mark)

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -963,7 +963,7 @@ IO_stat MCDispatch::loadfile(MCStringRef p_name, MCStack *&sptr)
         MCAutoStringRef t_leaf_name;
 		uindex_t t_leaf_index;
 		if (MCStringLastIndexOfChar(p_name, PATH_SEPARATOR, UINDEX_MAX, kMCStringOptionCompareExact, t_leaf_index))
-			/* UNCHECKED */ MCStringCopySubstring(p_name, MCRangeMake(t_leaf_index + 1, MCStringGetLength(p_name) - (t_leaf_index + 1)), &t_leaf_name);
+			/* UNCHECKED */ MCStringCopySubstring(p_name, MCRangeMakeMinMax(t_leaf_index + 1, MCStringGetLength(p_name)), &t_leaf_name);
 		else
 			t_leaf_name = p_name;
 		if ((stream = MCS_open(*t_leaf_name, kMCOpenFileModeRead, True, False, 0)) != NULL)
@@ -2110,7 +2110,7 @@ bool MCDispatch::loadexternal(MCStringRef p_external)
     
 	if (MCStringLastIndexOfChar(p_external, '/', t_ext_length, kMCStringOptionCompareExact, t_slash_index))
     {
-		if (!MCStringCopySubstring(p_external, MCRangeMake(t_slash_index + 1, t_ext_length - t_slash_index - 1), t_external_leaf))
+		if (!MCStringCopySubstring(p_external, MCRangeMakeMinMax(t_slash_index + 1, t_ext_length), t_external_leaf))
             return false;
     }
     else

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -1393,7 +1393,7 @@ public:
 
                 if (!MCStringCreateMutable(0, &t_tilde_path) ||
                     !MCStringAppend(*t_tilde_path, *t_pw_dir) ||
-                    !MCStringAppendSubstring(*t_tilde_path, p_path, MCRangeMake(t_user_end, MCStringGetLength(p_path) - t_user_end)))
+                    !MCStringAppendSubstring(*t_tilde_path, p_path, MCRangeMakeMinMax(t_user_end, MCStringGetLength(p_path))))
                     return false;
             }
             else

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3847,7 +3847,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
             else
             {
                 MCAutoStringRef t_username;
-                if (!MCStringCopySubstring(p_path, MCRangeMake(1, t_user_end - 1), &t_username))
+                if (!MCStringCopySubstring(p_path, MCRangeMakeMinMax(1, t_user_end), &t_username))
                     return false;
                 MCAutoStringRefAsUTF8String t_utf8_username;
                 /* UNCHECKED */ t_utf8_username . Lock(*t_username);
@@ -3858,7 +3858,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
             {
                 if (!MCStringCreateMutable(0, &t_tilde_path) ||
                     !MCStringAppendNativeChars(*t_tilde_path, (char_t*)t_password->pw_dir, MCCStringLength(t_password->pw_dir)) ||
-                    !MCStringAppendSubstring(*t_tilde_path, p_path, MCRangeMake(t_user_end, MCStringGetLength(p_path) - t_user_end)))
+                    !MCStringAppendSubstring(*t_tilde_path, p_path, MCRangeMakeMinMax(t_user_end, MCStringGetLength(p_path))))
                     return false;
             }
             else
@@ -4636,7 +4636,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         bool t_is_path;
         if (MCStringBeginsWithCString(p_document, (const char_t*)"file:", kMCStringOptionCompareCaseless))
         {
-            MCStringCopySubstring(p_document, MCRangeMake(5, MCStringGetLength(p_document) - 5), &t_url);
+            MCStringCopySubstring(p_document, MCRangeMakeMinMax(5, MCStringGetLength(p_document)), &t_url);
             t_is_path = true;
         }
         else

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -114,7 +114,7 @@ static void legacy_path_to_nt_path(MCStringRef p_legacy, MCStringRef &r_nt)
 		MCStringRef t_temp;
 		/* UNCHECKED */ MCStringCreateMutable(0, t_temp);
 		/* UNCHECKED */ MCStringAppend(t_temp, MCSTR("\\\\?\\UNC\\"));
-		/* UNCHECKED */ MCStringAppendSubstring(t_temp, p_legacy, MCRangeMake(2, MCStringGetLength(p_legacy) - 2));
+		/* UNCHECKED */ MCStringAppendSubstring(t_temp, p_legacy, MCRangeMakeMinMax(2, MCStringGetLength(p_legacy)));
 		/* UNCHECKED */ MCStringCopyAndRelease(t_temp, r_nt);
 	}
 	else
@@ -131,13 +131,13 @@ static void nt_path_to_legacy_path(MCStringRef p_nt, MCStringRef &r_legacy)
 	if (MCStringBeginsWithCString(p_nt, (const char_t*)"\\\\?\\UNC\\", kMCStringOptionCompareCaseless))
 	{
 		MCStringRef t_temp;
-		/* UNCHECKED */ MCStringMutableCopySubstring(p_nt, MCRangeMake(8, MCStringGetLength(p_nt) - 8), t_temp);
+		/* UNCHECKED */ MCStringMutableCopySubstring(p_nt, MCRangeMakeMinMax(8, MCStringGetLength(p_nt)), t_temp);
 		/* UNCHECKED */ MCStringPrepend(t_temp, MCSTR("\\\\"));
 		/* UNCHECKED */ MCStringCopyAndRelease(t_temp, r_legacy);
 	}
 	else if (MCStringBeginsWithCString(p_nt, (const char_t*)"\\\\?\\", kMCStringOptionCompareCaseless))
 	{
-		/* UNCHECKED */ MCStringCopySubstring(p_nt, MCRangeMake(4, MCStringGetLength(p_nt) - 4), r_legacy);
+		/* UNCHECKED */ MCStringCopySubstring(p_nt, MCRangeMakeMinMax(4, MCStringGetLength(p_nt)), r_legacy);
 	}
 	else
 	{
@@ -338,9 +338,9 @@ bool MCS_registry_split_key(MCStringRef p_path, MCStringRef& r_root, MCStringRef
 		if (MCStringFirstIndexOfChar(p_path, '\\', 0, kMCStringOptionCompareExact, t_path_offset))
 		{
 			if (t_value_offset > t_path_offset)
-				t_success = t_success && MCStringCopySubstring(p_path, MCRangeMake(t_path_offset + 1, t_value_offset - t_path_offset - 1), r_key);
+				t_success = t_success && MCStringCopySubstring(p_path, MCRangeMakeMinMax(t_path_offset + 1, t_value_offset), r_key);
 		}
-		t_success = t_success && MCStringCopySubstring(p_path, MCRangeMake(t_value_offset + 1, t_length - t_value_offset - 1), r_value);
+		t_success = t_success && MCStringCopySubstring(p_path, MCRangeMakeMinMax(t_value_offset + 1, t_length), r_value);
 	}
 	return t_success && MCStringCopySubstring(p_path, MCRangeMake(0, t_path_offset), r_root);
 }
@@ -702,7 +702,7 @@ bool dns_servers_from_registry(MCListRef& r_list)
 		if (t_chars[i] == ' ' || t_chars[i] == ',' || t_chars[i] == '\n')
 		{
 			MCAutoStringRef t_substring;
-			if (!MCStringCopySubstring(t_string, MCRangeMake(t_start, i - t_start), &t_substring) || 
+			if (!MCStringCopySubstring(t_string, MCRangeMakeMinMax(t_start, i), &t_substring) || 
 					!MCListAppend(*t_list, *t_substring))
 				return false;
 			t_start = i + 1;
@@ -711,7 +711,7 @@ bool dns_servers_from_registry(MCListRef& r_list)
 	if (t_start < t_char_count)
 	{
 		MCAutoStringRef t_final_string;
-		if (!MCStringCopySubstring(t_string, MCRangeMake(t_start, MCStringGetLength(t_string) - t_start), &t_final_string) ||
+		if (!MCStringCopySubstring(t_string, MCRangeMakeMinMax(t_start, MCStringGetLength(t_string)), &t_final_string) ||
 			!MCListAppend(*t_list, *t_final_string))
 			return false;
 	}

--- a/engine/src/eps.cpp
+++ b/engine/src/eps.cpp
@@ -504,7 +504,7 @@ Boolean MCEPS::import(MCStringRef fname, IO_handle stream)
 	uindex_t t_sep;
     MCStringRef t_fname;
     if (MCStringLastIndexOfChar(fname, PATH_SEPARATOR, UINDEX_MAX, kMCCompareExact, t_sep))
-        /* UNCHECKED */ MCStringCopySubstring(fname, MCRangeMake(t_sep + 1, MCStringGetLength(fname) - (t_sep + 1)), t_fname);
+        /* UNCHECKED */ MCStringCopySubstring(fname, MCRangeMakeMinMax(t_sep + 1, MCStringGetLength(fname)), t_fname);
     else
         t_fname = MCValueRetain(fname);
     

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -346,7 +346,7 @@ void MCArraysExecCombineByColumn(MCExecContext& ctxt, MCArrayRef p_array, MCStri
 						if (MCStringFind(t_strings[i], MCRangeMake(t_next_row_indices[i], UINDEX_MAX), t_row_delimiter, ctxt.GetStringComparisonType(), &t_cell_range))
 						{
 							// We found a row delimiter, so we stop the copy range before it and update the next index from which to look
-							t_success = MCListAppendSubstring(*t_row, t_strings[i], MCRangeMake(t_next_row_indices[i], t_cell_range . offset - t_next_row_indices[i]));
+							t_success = MCListAppendSubstring(*t_row, t_strings[i], MCRangeMakeMinMax(t_next_row_indices[i], t_cell_range . offset));
 							t_next_row_indices[i] = t_cell_range . offset + t_cell_range . length;
 						}
 						else
@@ -479,7 +479,7 @@ void MCArraysExecSplitByColumn(MCExecContext& ctxt, MCStringRef p_string, MCArra
             
             // Check that a string has been created to store this column
             MCRange t_range;
-            t_range = MCRangeMake(t_cell_offset, t_cell_found . offset - t_cell_offset);
+            t_range = MCRangeMakeMinMax(t_cell_offset, t_cell_found . offset);
             if (t_temp_array[t_column_index] == nil)
             {
                 t_success = MCStringCreateMutable(0, t_temp_array[t_column_index]);
@@ -928,7 +928,7 @@ bool MCArraysSplitIndexes(MCNameRef p_key, integer_t*& r_indexes, uindex_t& r_co
             t_finish = t_string_len;
 		
         MCAutoStringRef t_substring;
-        if (!MCStringCopySubstring(t_string, MCRangeMake(t_start, t_finish - t_start), &t_substring))
+        if (!MCStringCopySubstring(t_string, MCRangeMakeMinMax(t_start, t_finish), &t_substring))
 			return false;
 		
         MCAutoNumberRef t_number;

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -746,7 +746,7 @@ void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCValueRef p_value, int p_
                 if (!MCDataMutableCopyAndRelease((MCDataRef)p_var . mark . text, &t_data))
                     return;
                 
-                /* UNCHECKED */ MCDataReplace(*t_data, MCRangeMake(p_var . mark . start, p_var . mark . finish - p_var . mark . start), (MCDataRef)p_value);
+                /* UNCHECKED */ MCDataReplace(*t_data, MCRangeMakeMinMax(p_var . mark . start, p_var . mark . finish), (MCDataRef)p_value);
                 p_var . variable -> set(ctxt, *t_data, kMCVariableSetInto);
             }
             else
@@ -755,7 +755,7 @@ void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCValueRef p_value, int p_
                 //  can take advantage of the fact that z has only one reference. Otherwise it requires a copy
                 MCValueRelease(p_var . mark . text);
                 
-                p_var . variable -> replace(ctxt, (MCDataRef)p_value, MCRangeMake(p_var . mark . start, p_var . mark . finish - p_var . mark . start));
+                p_var . variable -> replace(ctxt, (MCDataRef)p_value, MCRangeMakeMinMax(p_var . mark . start, p_var . mark . finish));
             }
         }
         else
@@ -789,7 +789,7 @@ void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCValueRef p_value, int p_
                 if (!MCStringMutableCopyAndRelease((MCStringRef)p_var . mark . text, &t_string))
                     return;
             
-                /* UNCHECKED */ MCStringReplace(*t_string, MCRangeMake(p_var . mark . start, p_var . mark . finish - p_var . mark . start), *t_value_string);
+                /* UNCHECKED */ MCStringReplace(*t_string, MCRangeMakeMinMax(p_var . mark . start, p_var . mark . finish), *t_value_string);
                 p_var . variable -> set(ctxt, *t_string, kMCVariableSetInto);
             }
             else
@@ -798,7 +798,7 @@ void MCEngineExecPutIntoVariable(MCExecContext& ctxt, MCValueRef p_value, int p_
                 //  can take advantage of the fact that z has only one reference. Otherwise it requires a copy
                 MCValueRelease(p_var . mark . text);
                 
-                p_var . variable -> replace(ctxt, *t_value_string, MCRangeMake(p_var . mark . start, p_var . mark . finish - p_var . mark . start));
+                p_var . variable -> replace(ctxt, *t_value_string, MCRangeMakeMinMax(p_var . mark . start, p_var . mark . finish));
             }
         }
 	}
@@ -1084,12 +1084,12 @@ void MCEngineExecDeleteVariableChunks(MCExecContext& ctxt, MCVariableChunkPtr *p
         if (!ctxt . EvalExprAsMutableStringRef(p_chunks[i] . variable, EE_ENGINE_DELETE_BADVARCHUNK, &t_string))
             return;
 
-        if (MCStringReplace(*t_string, MCRangeMake(p_chunks[i] . mark . start, p_chunks[i] . mark . finish - p_chunks[i] . mark . start), kMCEmptyString))
+        if (MCStringReplace(*t_string, MCRangeMakeMinMax(p_chunks[i] . mark . start, p_chunks[i] . mark . finish), kMCEmptyString))
         {
             p_chunks[i] . variable -> set(ctxt, *t_string, kMCVariableSetInto);
         } */
         // SN-2014-04-11 [[ FasterVariables ]] Deletiong of the content of a variable is now done without copying
-        p_chunks[i] . variable -> deleterange(ctxt, MCRangeMake(p_chunks[i] . mark . start, p_chunks[i] . mark . finish - p_chunks[i] . mark . start));
+        p_chunks[i] . variable -> deleterange(ctxt, MCRangeMakeMinMax(p_chunks[i] . mark . start, p_chunks[i] . mark . finish));
 	}
 }
 
@@ -1315,7 +1315,7 @@ static void MCEngineSplitScriptIntoMessageAndParameters(MCExecContext& ctxt, MCS
         
         if (t_offset == t_length || t_char == ',')
         {
-            t_exp_range = MCRangeMake(t_start_offset, t_offset - t_start_offset);
+            t_exp_range = MCRangeMakeMinMax(t_start_offset, t_offset);
 
             MCAutoStringRef t_expression;
             /* UNCHECKED */ MCStringCopySubstring(p_script, t_exp_range, &t_expression);

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -2318,7 +2318,7 @@ void MCFilesExecWriteToStream(MCExecContext& ctxt, IO_handle p_stream, MCStringR
 					len = 0;
 				}
 				MCAutoStringRef s;
-				/* UNCHECKED */ MCStringCopySubstring(p_data, MCRangeMake(t_start_pos, t_data_pos - t_start_pos), &s); 
+				/* UNCHECKED */ MCStringCopySubstring(p_data, MCRangeMakeMinMax(t_start_pos, t_data_pos), &s); 
 				real8 n;
 				if (!MCTypeConvertStringToReal(*s, n))
 				{

--- a/engine/src/exec-filters.cpp
+++ b/engine/src/exec-filters.cpp
@@ -336,7 +336,7 @@ static bool MCU_gettemplate(MCStringRef format, uindex_t &x_offset, unichar_t &c
             // No ending curly brace: error
             return false;
         
-        /* UNCHECKED */ MCStringCopySubstring(format, MCRangeMake(x_offset, t_brace_end - x_offset), &t_encoding_string);
+        /* UNCHECKED */ MCStringCopySubstring(format, MCRangeMakeMinMax(x_offset, t_brace_end), &t_encoding_string);
         
         x_offset = t_brace_end + 1;
         

--- a/engine/src/exec-interface-field.cpp
+++ b/engine/src/exec-interface-field.cpp
@@ -136,7 +136,7 @@ static void MCInterfaceFieldRangesParse(MCExecContext& ctxt, MCStringRef p_input
             break;
         
 		if (t_success)
-            t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_uintx2_string);
+            t_success = MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_uintx2_string);
 		
 		if (t_success)
 			t_success = MCU_stoui4x2(*t_uintx2_string, t_range . start, t_range . end);

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -817,7 +817,7 @@ static void MCInterfaceTextStyleParse(MCExecContext& ctxt, MCStringRef p_input, 
 		while (MCStringGetNativeCharAtIndex(p_input, t_old_offset) == ' ')
 			t_old_offset++;
 
-		t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_text_style);
+		t_success = MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_text_style);
 
 		if (t_success)
 		{
@@ -2366,7 +2366,7 @@ void MCObject::SetColors(MCExecContext& ctxt, MCStringRef p_input)
 		else if (t_new_offset > t_old_offset)
 		{
 			MCInterfaceNamedColor t_color;
-			t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_color_string);
+			t_success = MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_color_string);
 			if (t_success)
 			{
 				MCInterfaceNamedColorParse(ctxt, *t_color_string, t_color);
@@ -2720,7 +2720,7 @@ void MCObject::SetPatterns(MCExecContext& ctxt, MCStringRef p_patterns)
 		
 		if (t_new_offset > t_old_offset)
 		{
-			t_success = MCStringCopySubstring(p_patterns, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_pattern);
+			t_success = MCStringCopySubstring(p_patterns, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_pattern);
 			if (t_success)
 				t_success = MCU_stoui4(*t_pattern, t_id);
 			if (t_success)

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -144,48 +144,49 @@ static void MCInterfaceDecorationParse(MCExecContext& ctxt, MCStringRef p_input,
 					t_end_pos = MCStringGetLength(p_input) + 1;
 				else
 					t_end_pos = t_comma + 1;
-				
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCtitlestring), kMCCompareCaseless))
+
+                MCRange t_range = MCRangeMakeMinMax(t_start_pos, t_end_pos - 1);
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCtitlestring), kMCCompareCaseless))
 				{
 					decorations |= WD_TITLE;
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCmenustring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCmenustring), kMCCompareCaseless))
 				{
 					decorations |= WD_MENU | WD_TITLE;
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCminimizestring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCminimizestring), kMCCompareCaseless))
 				{
 					decorations |= WD_MINIMIZE | WD_TITLE;
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCmaximizestring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCmaximizestring), kMCCompareCaseless))
 				{
 					decorations |= WD_MAXIMIZE | WD_TITLE;
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCclosestring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCclosestring), kMCCompareCaseless))
 				{
 					decorations |= WD_CLOSE | WD_TITLE;
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCmetalstring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCmetalstring), kMCCompareCaseless))
 				{
 					decorations |= WD_METAL; //metal can not have title
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCutilitystring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCutilitystring), kMCCompareCaseless))
 				{
 					decorations |= WD_UTILITY;
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCnoshadowstring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCnoshadowstring), kMCCompareCaseless))
 				{
 					decorations |= WD_NOSHADOW;
 					continue;
 				}
-				if (MCStringSubstringIsEqualTo(p_input, MCRangeMake(t_start_pos, t_end_pos - t_start_pos - 1), MCSTR(MCforcetaskbarstring), kMCCompareCaseless))
+				if (MCStringSubstringIsEqualTo(p_input, t_range, MCSTR(MCforcetaskbarstring), kMCCompareCaseless))
 				{
 					decorations |= WD_FORCETASKBAR;
 					continue;
@@ -1159,7 +1160,7 @@ void MCStack::SetSubstacks(MCExecContext& ctxt, MCStringRef p_substacks)
 		if (!MCStringFirstIndexOfChar(p_substacks, '\n', t_old_offset, kMCCompareExact, t_new_offset))
 			t_new_offset = t_length;
 
-		t_success = MCStringCopySubstring(p_substacks, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_name_string);
+		t_success = MCStringCopySubstring(p_substacks, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_name_string);
 		if (t_success && t_new_offset > t_old_offset)
 		{
 			// If tsub is one of the existing substacks of the stack, it is set to

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2323,7 +2323,7 @@ void MCInterfaceExecDeleteObjectChunks(MCExecContext& ctxt, MCObjectChunkPtr *p_
 			p_chunks[i] . object -> getstringprop(ctxt, p_chunks[i] . part_id, P_TEXT, False, t_value);
 
 			/* UNCHECKED */ MCStringMutableCopyAndRelease(t_value, t_value);
-			/* UNCHECKED */ MCStringRemove(t_value, MCRangeMake(p_chunks[i] . mark . start, p_chunks[i] . mark . finish - p_chunks[i] . mark . start));
+			/* UNCHECKED */ MCStringRemove(t_value, MCRangeMakeMinMax(p_chunks[i] . mark . start, p_chunks[i] . mark . finish));
 			/* UNCHECKED */ MCStringCopyAndRelease(t_value, t_value);
 			p_chunks[i] . object -> setstringprop(ctxt, p_chunks[i] . part_id, P_TEXT, False, t_value);
 			MCValueRelease(t_value);
@@ -3570,7 +3570,7 @@ void MCInterfaceExecPutIntoObject(MCExecContext& ctxt, MCStringRef p_string, int
         if (ctxt . HasError() || !MCStringMutableCopy(*t_text, &t_string))
             return;
         
-        /* UNCHECKED */ MCStringReplace(*t_string, MCRangeMake(t_start, t_finish - t_start), p_string);
+        /* UNCHECKED */ MCStringReplace(*t_string, MCRangeMakeMinMax(t_start, t_finish), p_string);
         
         p_chunk . object -> setstringprop(ctxt, p_chunk . part_id, P_TEXT, False, *t_string);
 	}
@@ -3609,7 +3609,7 @@ void MCInterfaceExecPutIntoObject(MCExecContext& ctxt, MCExecValue p_value, int 
         if (ctxt . HasError())
             return;
         
-        /* UNCHECKED */ MCStringReplace(*t_string, MCRangeMake(t_start, t_finish - t_start), *t_string_value);
+        /* UNCHECKED */ MCStringReplace(*t_string, MCRangeMakeMinMax(t_start, t_finish), *t_string_value);
         
         p_chunk . object -> setstringprop(ctxt, p_chunk . part_id, P_TEXT, False, *t_string);
 	}

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -496,9 +496,9 @@ void MCNetworkExecDeleteUrl(MCExecContext& ctxt, MCStringRef p_target)
 		if (!ctxt . EnsureDiskAccessIsAllowed())
 			return;
 		if (MCStringBeginsWithCString(p_target, (const char_t*)"file:", kMCCompareCaseless))
-			MCStringCopySubstring(p_target, MCRangeMake(5, MCStringGetLength(p_target)-5), &t_filename);
+			MCStringCopySubstring(p_target, MCRangeMakeMinMax(5, MCStringGetLength(p_target)), &t_filename);
 		else
-			MCStringCopySubstring(p_target, MCRangeMake(8, MCStringGetLength(p_target)-8), &t_filename);
+			MCStringCopySubstring(p_target, MCRangeMakeMinMax(8, MCStringGetLength(p_target)), &t_filename);
 		if (!MCS_unlink(*t_filename))
 			ctxt . SetTheResultToStaticCString("can't delete that file");
 		else
@@ -507,7 +507,7 @@ void MCNetworkExecDeleteUrl(MCExecContext& ctxt, MCStringRef p_target)
 	else if (MCStringGetLength(p_target) > 8 &&
 		MCStringBeginsWithCString(p_target, (const char_t*)"resfile:", kMCCompareCaseless))
 	{
-		MCStringCopySubstring(p_target, MCRangeMake(8, MCStringGetLength(p_target)-8), &t_filename);
+		MCStringCopySubstring(p_target, MCRangeMakeMinMax(8, MCStringGetLength(p_target)), &t_filename);
 		MCS_saveresfile(*t_filename, kMCEmptyData);
 	}
 	else if (MCU_couldbeurl(MCStringGetOldString(p_target)))
@@ -758,7 +758,7 @@ void MCNetworkExecPutIntoUrl(MCExecContext& ctxt, MCValueRef p_value, int p_wher
         // SN-2015-05-19: [[ Bug 15368 ]] Insert the new string at the right
         //  position: might be after or before the chunk, not only into it.
         if (p_where == PT_INTO)
-            t_range = MCRangeMake(p_chunk . mark . start, p_chunk . mark . finish - p_chunk . mark . start);
+            t_range = MCRangeMakeMinMax(p_chunk . mark . start, p_chunk . mark . finish);
         else if (p_where == PT_BEFORE)
             t_range = MCRangeMake(p_chunk . mark . start, 0);
         else // p_where == PT_AFTER

--- a/engine/src/exec-pick.cpp
+++ b/engine/src/exec-pick.cpp
@@ -326,14 +326,14 @@ void MCPickExecPickOptionByIndex(MCExecContext &ctxt, int p_chunk_type, MCString
         
         while (t_success && MCStringFirstIndexOfChar(p_option_lists[i], t_delimiter, t_old_offset, kMCCompareCaseless, t_new_offset))
         {
-            t_success = MCStringCopySubstring(p_option_lists[i], MCRangeMake(t_old_offset, t_new_offset - t_old_offset), t_option);
+            t_success = MCStringCopySubstring(p_option_lists[i], MCRangeMakeMinMax(t_old_offset, t_new_offset), t_option);
             if (t_success)
                 t_options . Push(t_option);
             
             t_old_offset = t_new_offset + 1;
         }
         // Append the remaining part of the options
-        t_success = MCStringCopySubstring(p_option_lists[i], MCRangeMake(t_old_offset, MCStringGetLength(p_option_lists[i]) - t_old_offset), t_option);
+        t_success = MCStringCopySubstring(p_option_lists[i], MCRangeMakeMinMax(t_old_offset, MCStringGetLength(p_option_lists[i])), t_option);
         if (t_success)
             t_options . Push(t_option);
         

--- a/engine/src/exec-printing.cpp
+++ b/engine/src/exec-printing.cpp
@@ -251,17 +251,17 @@ static void MCPrintingPrinterPageRangeParse(MCExecContext& ctxt, MCStringRef p_i
 		t_found_comma = MCStringFirstIndexOfChar(p_input, ',', t_pos, kMCCompareExact, t_comma);
 		if (t_found_comma)
 		{
-			if (MCStringSubstringContains(p_input, MCRangeMake(t_pos, t_comma - t_pos), MCSTR("-"), kMCCompareExact))
+			if (MCStringSubstringContains(p_input, MCRangeMakeMinMax(t_pos, t_comma), MCSTR("-"), kMCCompareExact))
 			{
 				/* UNCHECKED */ MCStringFirstIndexOfChar(p_input, '-', t_pos, kMCCompareExact, t_dash);
 
 				MCAutoStringRef t_substring_from;
-				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMake(t_pos, t_dash - t_pos), &t_substring_from);
+				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_pos, t_dash), &t_substring_from);
 				t_error = !ctxt . ConvertToInteger(*t_substring_from, t_from);
 				t_pos = t_dash + 1;
 
 				MCAutoStringRef t_substring_to;
-				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMake(t_pos, t_comma - t_pos), &t_substring_to);
+				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_pos, t_comma), &t_substring_to);
 				t_error = !ctxt . ConvertToInteger(*t_substring_to, t_to);
 				t_pos = t_comma;
 			}
@@ -269,7 +269,7 @@ static void MCPrintingPrinterPageRangeParse(MCExecContext& ctxt, MCStringRef p_i
 			else
 			{
 				MCAutoStringRef t_substring;
-				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMake(t_pos, t_comma - t_pos), &t_substring);
+				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_pos, t_comma), &t_substring);
 				t_error = !ctxt . ConvertToInteger(*t_substring, t_from);
 				t_to = t_from;
 				t_pos = t_comma;
@@ -279,17 +279,17 @@ static void MCPrintingPrinterPageRangeParse(MCExecContext& ctxt, MCStringRef p_i
 		else
 		{
 			//case dash found after t_pos
-			if (MCStringSubstringContains(p_input, MCRangeMake(t_pos, MCStringGetLength(p_input) - t_pos), MCSTR("-"), kMCCompareExact))
+			if (MCStringSubstringContains(p_input, MCRangeMakeMinMax(t_pos, MCStringGetLength(p_input)), MCSTR("-"), kMCCompareExact))
 			{
 				/* UNCHECKED */ MCStringFirstIndexOfChar(p_input, '-', t_pos, kMCCompareExact, t_dash);
 
 				MCAutoStringRef t_substring_from;
-				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMake(t_pos, t_dash - t_pos), &t_substring_from);
+				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_pos, t_dash), &t_substring_from);
 				t_error =  !ctxt . ConvertToInteger(*t_substring_from, t_from);
 				t_pos = t_dash + 1;
 
 				MCAutoStringRef t_substring_to;
-				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMake(t_pos, MCStringGetLength(p_input) - t_pos), &t_substring_to);
+				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_pos, MCStringGetLength(p_input)), &t_substring_to);
 				t_error = !ctxt . ConvertToInteger(*t_substring_to, t_to);
 				t_pos = MCStringGetLength(p_input);
 			}
@@ -297,7 +297,7 @@ static void MCPrintingPrinterPageRangeParse(MCExecContext& ctxt, MCStringRef p_i
 			else
 			{
 				MCAutoStringRef t_substring;
-				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMake(t_pos, MCStringGetLength(p_input) - t_pos), &t_substring);
+				/* UNCHECKED */ MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_pos, MCStringGetLength(p_input)), &t_substring);
 				t_error = !ctxt . ConvertToInteger(*t_substring, t_from);
 				t_to = t_from;
 				t_pos = t_comma;

--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -243,7 +243,7 @@ void MCStringsMarkTextChunkInRange(MCExecContext& ctxt, MCStringRef p_string, MC
             MCRange t_found_range;
             
             // calculate the start of the (p_first)th line or item
-            while (p_first && MCStringFind(p_string, MCRangeMake(t_offset, t_length - t_offset), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
+            while (p_first && MCStringFind(p_string, MCRangeMakeMinMax(t_offset, t_length), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
             {
                 p_first--;
                 t_offset = t_found_range . offset + t_found_range . length;
@@ -262,7 +262,7 @@ void MCStringsMarkTextChunkInRange(MCExecContext& ctxt, MCStringRef p_string, MC
             // calculate the length of the next p_count lines / items
             while (p_count--)
             {
-                if (t_offset > t_end_index || !MCStringFind(p_string, MCRangeMake(t_offset, t_length - t_offset), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
+                if (t_offset > t_end_index || !MCStringFind(p_string, MCRangeMakeMinMax(t_offset, t_length), t_delimiter, ctxt . GetStringComparisonType(), &t_found_range))
                 {
                     r_end = t_length;
                     break;
@@ -300,7 +300,7 @@ void MCStringsMarkTextChunkInRange(MCExecContext& ctxt, MCStringRef p_string, MC
             while (p_first)
             {
                 t_pg_offset = t_offset;
-                t_newline_found = MCStringFirstIndexOfCharInRange(p_string, '\n', MCRangeMake(t_offset, t_length - t_offset), kMCCompareExact, t_offset);
+                t_newline_found = MCStringFirstIndexOfCharInRange(p_string, '\n', MCRangeMakeMinMax(t_offset, t_length), kMCCompareExact, t_offset);
                 // AL-2014-07-21: [[ Bug 12162 ]] Ignore PS when calculating paragraph chunk.                
                 t_pg_found = false; /*MCStringFirstIndexOfChar(p_string, 0x2029, t_pg_offset, kMCCompareExact, t_pg_offset);*/
                 
@@ -328,8 +328,8 @@ void MCStringsMarkTextChunkInRange(MCExecContext& ctxt, MCStringRef p_string, MC
                 // AL-2014-05-26: [[ Bug 12527 ]] Make sure both newline and pg char are found if both present
                 if (t_offset <= t_end_index)
                 {
-                    t_newline_found = MCStringFirstIndexOfCharInRange(p_string, '\n', MCRangeMake(t_offset, t_length - t_offset), kMCCompareExact, t_offset);
-                    t_pg_found = MCStringFirstIndexOfCharInRange(p_string, 0x2029, MCRangeMake(t_pg_offset, t_length - t_pg_offset), kMCCompareExact, t_pg_offset);
+                    t_newline_found = MCStringFirstIndexOfCharInRange(p_string, '\n', MCRangeMakeMinMax(t_offset, t_length), kMCCompareExact, t_offset);
+                    t_pg_found = MCStringFirstIndexOfCharInRange(p_string, 0x2029, MCRangeMakeMinMax(t_pg_offset, t_length), kMCCompareExact, t_pg_offset);
                 }
                 else
                 {
@@ -513,11 +513,11 @@ void MCStringsGetTextChunk(MCExecContext& ctxt, MCStringRef p_source, Chunk_term
     
     if (!p_eval_mutable)
     {
-        MCStringCopySubstring(p_source, MCRangeMake(t_start, t_end - t_start), r_result);
+        MCStringCopySubstring(p_source, MCRangeMakeMinMax(t_start, t_end), r_result);
     }
     else
     {
-        MCStringMutableCopySubstring(p_source, MCRangeMake(t_start, t_end - t_start), r_result);
+        MCStringMutableCopySubstring(p_source, MCRangeMakeMinMax(t_start, t_end), r_result);
     }
 }
 
@@ -545,7 +545,7 @@ void MCStringsSetTextChunk(MCExecContext& ctxt, MCStringRef p_source, Prepositio
             MCStringInsert(x_target, t_start, p_source);
             break;
         case PT_INTO:
-            MCStringReplace(x_target, MCRangeMake(t_start, t_end - t_start), p_source);
+            MCStringReplace(x_target, MCRangeMakeMinMax(t_start, t_end), p_source);
             break;
         case PT_AFTER:
             MCStringInsert(x_target, t_end, p_source);
@@ -743,7 +743,7 @@ void MCStringsExecSetCharsOfTextByOrdinal(MCExecContext& ctxt, MCStringRef p_sou
 
 void MCStringsGetTextChunk(MCExecContext& ctxt, MCStringRef p_source, integer_t p_start, integer_t p_end, MCStringRef& r_result)
 {
-    MCStringCopySubstring(p_source, MCRangeMake(p_start, p_end - p_start), r_result);
+    MCStringCopySubstring(p_source, MCRangeMakeMinMax(p_start, p_end), r_result);
 }
 
 void MCStringsEvalTextChunkByRange(MCExecContext& ctxt, MCStringRef p_source, Chunk_term p_chunk_type, integer_t p_first, integer_t p_last, integer_t& x_start, integer_t& x_end, MCStringRef& r_result)
@@ -925,7 +925,7 @@ void MCStringsMarkTextChunkByRange(MCExecContext& ctxt, Chunk_term p_chunk_type,
 {
     // The incoming indices are for codeunits
     MCRange t_cu_range;
-    t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
+    t_cu_range = MCRangeMakeMinMax(x_mark . start, x_mark . finish);
 
     uinteger_t t_first, t_chunk_count;
     MCStringsGetExtentsByRangeInRange(ctxt, p_chunk_type, p_first, p_last, x_mark . text, &t_cu_range, t_first, t_chunk_count);
@@ -945,7 +945,7 @@ void MCStringsMarkTextChunkByOrdinal(MCExecContext& ctxt, Chunk_term p_chunk_typ
 {
     // The incoming indices are for codeunits
     MCRange t_cu_range;
-    t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
+    t_cu_range = MCRangeMakeMinMax(x_mark . start, x_mark . finish);
     
     uinteger_t t_first, t_chunk_count;
     MCStringsGetExtentsByOrdinalInRange(ctxt, p_chunk_type, p_ordinal_type, x_mark . text, &t_cu_range, t_first, t_chunk_count);
@@ -1073,7 +1073,7 @@ void MCStringsMarkBytesOfTextByRange(MCExecContext& ctxt, integer_t p_first, int
 {
     // The incoming indices are for codeunits
     MCRange t_cu_range;
-    t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
+    t_cu_range = MCRangeMakeMinMax(x_mark . start, x_mark . finish);
     
     // AL-2014-09-10: [[ Bug 13400 ]] Keep marked strings the correct type where possible
     if (MCValueGetTypeCode(x_mark . text) != kMCValueTypeCodeData)
@@ -1098,7 +1098,7 @@ void MCStringsMarkBytesOfTextByOrdinal(MCExecContext& ctxt, Chunk_term p_ordinal
 {
     // The incoming indices are for codeunits
     MCRange t_cu_range;
-    t_cu_range = MCRangeMake(x_mark . start, x_mark . finish - x_mark . start);
+    t_cu_range = MCRangeMakeMinMax(x_mark . start, x_mark . finish);
     
     // AL-2014-09-10: [[ Bug 13400 ]] Keep marked strings the correct type where possible
     if (MCValueGetTypeCode(x_mark . text) != kMCValueTypeCodeData)

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -122,7 +122,7 @@ bool MCStringsSplit(MCStringRef p_string, codepoint_t p_separator, MCStringRef*&
 	{
 		if (!t_strings.Extend(t_count + 1))
 			return false;
-		if (!MCStringCopySubstring(p_string, MCRangeMake(t_current, t_found - t_current), t_strings[t_count++]))
+		if (!MCStringCopySubstring(p_string, MCRangeMakeMinMax(t_current, t_found), t_strings[t_count++]))
 			return false;
         
 		t_current = t_found + 1;
@@ -130,7 +130,7 @@ bool MCStringsSplit(MCStringRef p_string, codepoint_t p_separator, MCStringRef*&
     
 	if (!t_strings.Extend(t_count + 1))
 		return false;
-	if (!MCStringCopySubstring(p_string, MCRangeMake(t_current, MCStringGetLength(p_string) - t_current), t_strings[t_count++]))
+	if (!MCStringCopySubstring(p_string, MCRangeMakeMinMax(t_current, MCStringGetLength(p_string)), t_strings[t_count++]))
 		return false;
     
 	t_strings.Take(r_strings, r_count);
@@ -150,7 +150,7 @@ bool MCStringsSplit(MCStringRef p_string, MCStringRef p_separator, MCStringRef*&
 	{
 		if (!t_strings.Extend(t_count + 1))
 			return false;
-		if (!MCStringCopySubstring(p_string, MCRangeMake(t_current, t_found - t_current), t_strings[t_count++]))
+		if (!MCStringCopySubstring(p_string, MCRangeMakeMinMax(t_current, t_found), t_strings[t_count++]))
 			return false;
 
 		t_current = t_found + MCStringGetLength(p_separator);
@@ -158,7 +158,7 @@ bool MCStringsSplit(MCStringRef p_string, MCStringRef p_separator, MCStringRef*&
 
 	if (!t_strings.Extend(t_count + 1))
 		return false;
-	if (!MCStringCopySubstring(p_string, MCRangeMake(t_current, MCStringGetLength(p_string) - t_current), t_strings[t_count++]))
+	if (!MCStringCopySubstring(p_string, MCRangeMakeMinMax(t_current, MCStringGetLength(p_string)), t_strings[t_count++]))
 		return false;
 
 	t_strings.Take(r_strings, r_count);
@@ -916,7 +916,7 @@ void MCStringsEvalReplaceText(MCExecContext& ctxt, MCStringRef p_string, MCStrin
     uindex_t t_source_length = MCStringGetLength(p_string);
     uindex_t t_source_offset = 0;
     
-    while (t_success && t_source_offset < t_source_length && MCR_exec(t_compiled, p_string, MCRangeMake(t_source_offset, MCStringGetLength(p_string) - (t_source_offset))))
+    while (t_success && t_source_offset < t_source_length && MCR_exec(t_compiled, p_string, MCRangeMakeMinMax(t_source_offset, MCStringGetLength(p_string))))
     {
         uindex_t t_start = t_compiled->matchinfo[0].rm_so;
         uindex_t t_end = t_compiled->matchinfo[0].rm_eo;
@@ -943,7 +943,7 @@ void MCStringsEvalReplaceText(MCExecContext& ctxt, MCStringRef p_string, MCStrin
     
     MCAutoStringRef t_post_match;
     if (t_success)
-        t_success = MCStringCopySubstring(p_string, MCRangeMake(t_source_offset, t_source_length - t_source_offset), &t_post_match) &&
+        t_success = MCStringCopySubstring(p_string, MCRangeMakeMinMax(t_source_offset, t_source_length), &t_post_match) &&
             MCStringAppend(*t_result, *t_post_match);
     
     if (t_success)
@@ -2269,7 +2269,7 @@ void MCStringsSortAddItem(MCExecContext &ctxt, MCSortnode *items, uint4 &nitems,
                     
                     MCAutoStringRef t_numeric_part;
                     if (t_end != t_start &&
-                        MCStringCopySubstring(*t_string, MCRangeMake(t_start, t_end - t_start), &t_numeric_part) &&
+                        MCStringCopySubstring(*t_string, MCRangeMakeMinMax(t_start, t_end), &t_numeric_part) &&
                         ctxt . ConvertToNumber(*t_numeric_part, items[nitems].nvalue))
                         break;
                 }
@@ -2581,7 +2581,7 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
                     
                     MCAutoStringRef t_numeric_part;
                     if (t_end == t_start ||
-                        !MCStringCopySubstring(*t_string, MCRangeMake(t_start, t_end - t_start), &t_numeric_part) ||
+                        !MCStringCopySubstring(*t_string, MCRangeMakeMinMax(t_start, t_end), &t_numeric_part) ||
                         !ctxt . ConvertToReal(*t_numeric_part, t_numbers[i]))
                     {
                         t_numbers[i] = -MAXREAL8;

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1519,7 +1519,7 @@ static bool MCPropertyParseLooseUIntList(MCStringRef p_input, char_t p_delimiter
 			uinteger_t t_d;
         
 			if (t_success)
-				t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_uint_string);
+				t_success = MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_uint_string);
 			
 			if (t_success)
 				t_success = MCU_stoui4(*t_uint_string, t_d);
@@ -1577,7 +1577,7 @@ static bool MCPropertyParseLooseDoubleList(MCStringRef p_input, char_t p_delimit
 			double t_d;
 			
             if (t_success)
-                t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_double_string);
+                t_success = MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_double_string);
             
             if (t_success)
                 t_success = MCTypeConvertStringToReal(*t_double_string, t_d);
@@ -1625,7 +1625,7 @@ static bool MCPropertyParseStringList(MCStringRef p_input, char_t p_delimiter, u
 			t_new_offset = t_length;
         
 		if (t_success)
-            t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), t_string);
+            t_success = MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_old_offset, t_new_offset), t_string);
 		
 		if (t_success)
 			t_success = t_list . Push(t_string);
@@ -1684,7 +1684,7 @@ static bool MCPropertyParsePointList(MCStringRef p_input, char_t p_delimiter, ui
         else
         {
             if (t_success)
-                t_success = MCStringCopySubstring(p_input, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_point_string);
+                t_success = MCStringCopySubstring(p_input, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_point_string);
             
             if (t_success)
                 MCU_stoi2x2(*t_point_string, t_point . x, t_point . y);

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -2297,7 +2297,7 @@ findex_t MCField::countchars(uint32_t p_part_id, findex_t si, findex_t ei)
         // Count the number of chars in this paragraph. The only paragraph
         // with a non-zero si valus is the first paragraph.
         MCRange t_cu_range, t_char_range;
-        t_cu_range = MCRangeMake(si, t_pg->gettextlength() - si);
+        t_cu_range = MCRangeMakeMinMax(si, t_pg->gettextlength());
         // SN-2014-09-11: [[ Bug 13361 ]] We need to remove the codeunits we skipped in the paragraph before counting.
         ei -= si;
         si = 0;
@@ -2318,7 +2318,7 @@ findex_t MCField::countchars(uint32_t p_part_id, findex_t si, findex_t ei)
     if (!t_stop)
     {
         MCRange t_char_range, t_cu_range;
-        t_cu_range = MCRangeMake(si, ei - si);
+        t_cu_range = MCRangeMakeMinMax(si, ei);
         /* UNCHECKED */ MCStringUnmapIndices(t_pg->GetInternalStringRef(), kMCCharChunkTypeGrapheme, t_cu_range, t_char_range);
         t_count += t_char_range.length;
     }

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -191,7 +191,7 @@ Boolean MCField::find(MCExecContext &ctxt, uint4 cardid, Find_mode mode,
 			{
 				uindex_t t_length = MCStringGetLength(tpgptr->GetInternalStringRef());
 				MCRange t_range, t_where;
-				t_range = MCRangeMake(oldoffset, t_length - oldoffset);
+				t_range = MCRangeMakeMinMax(oldoffset, t_length);
 				while (MCStringFind(tpgptr->GetInternalStringRef(), t_range, tofind, 
 									ctxt.GetStringComparisonType(),
 									&t_where))
@@ -588,7 +588,7 @@ Exec_stat MCField::settext(uint4 parid, MCStringRef p_text, Boolean formatted)
 
             MCStringRef t_paragraph_text;
             if (t_pos != t_start)
-                MCStringCopySubstring(p_text, MCRangeMake(t_start, t_pos - t_start), t_paragraph_text);
+                MCStringCopySubstring(p_text, MCRangeMakeMinMax(t_start, t_pos), t_paragraph_text);
             else
                 t_paragraph_text = MCValueRetain(kMCEmptyString);
 

--- a/engine/src/fieldstyledtext.cpp
+++ b/engine/src/fieldstyledtext.cpp
@@ -672,7 +672,7 @@ void MCField::parsestyledtextblockarray(MCArrayRef p_block_value, MCParagraph*& 
 
 		// We now add the range initial...final as a block.
         MCAutoStringRef t_substring;
-        MCStringCopySubstring(*t_temp, MCRangeMake(t_text_initial_start_index, t_text_end_index - t_text_initial_start_index), &t_substring);
+        MCStringCopySubstring(*t_temp, MCRangeMakeMinMax(t_text_initial_start_index, t_text_end_index), &t_substring);
 		parsestyledtextappendblock(t_paragraph, *t_style_entry, *t_substring, *t_metadata);
 
 		// And, if we need a new paragraph, add it.

--- a/engine/src/filepath.cpp
+++ b/engine/src/filepath.cpp
@@ -85,7 +85,7 @@ bool MCPathAppend(MCStringRef p_base, MCStringRef p_path, MCStringRef &r_new)
 				return false;
 	}
 	
-	if (!MCStringAppendSubstring(*t_new, p_path, MCRangeMake(t_offset, MCStringGetLength(p_path) - t_offset)))
+	if (!MCStringAppendSubstring(*t_new, p_path, MCRangeMakeMinMax(t_offset, MCStringGetLength(p_path))))
 		return false;
 	
 	return MCStringCopy(*t_new, r_new);

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -897,7 +897,7 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
 			//   fontname.
 			uindex_t t_offset;
 			if (MCStringFirstIndexOfChar(data, ',', 0, kMCCompareExact, t_offset))
-				/* UNCHECKED */ MCStringCopySubstring(data, MCRangeMake(t_offset + 1, MCStringGetLength(data) - (t_offset + 1)), fname);
+				/* UNCHECKED */ MCStringCopySubstring(data, MCRangeMakeMinMax(t_offset + 1, MCStringGetLength(data)), fname);
 			else
 				fname = MCValueRetain(data);
 		}
@@ -948,7 +948,7 @@ Exec_stat MCF_parsetextatts(Properties which, MCStringRef data,
                         t_end_pos = t_comma;
                     
                     MCAutoStringRef tdata;
-                    /* UNCHECKED */ MCStringCopySubstring(data, MCRangeMake(t_start_pos, t_end_pos - t_start_pos), &tdata);
+                    /* UNCHECKED */ MCStringCopySubstring(data, MCRangeMakeMinMax(t_start_pos, t_end_pos), &tdata);
                     t_end_pos++;
                     if (MCF_setweightstring(style, *tdata))
 						continue;

--- a/engine/src/handler.cpp
+++ b/engine/src/handler.cpp
@@ -126,7 +126,7 @@ Parse_stat MCHandler::newparam(MCScriptPoint& sp)
 	else
 	{
 		t_is_reference = true;
-		/* UNCHECKED */ MCStringCopySubstring(t_token, MCRangeMake(1, MCStringGetLength(t_token) - 1), &t_token_name);
+		/* UNCHECKED */ MCStringCopySubstring(t_token, MCRangeMakeMinMax(1, MCStringGetLength(t_token)), &t_token_name);
 	}
 
 	MCNameRef t_name;

--- a/engine/src/iimport.cpp
+++ b/engine/src/iimport.cpp
@@ -361,7 +361,7 @@ IO_stat MCImage::import(MCStringRef newname, IO_handle stream, IO_handle mstream
             uindex_t t_offset;
             if (MCStringLastIndexOfChar(newname, PATH_SEPARATOR, UINDEX_MAX, kMCCompareExact, t_offset))
             {
-                /* UNCHECKED */ MCStringCopySubstring(newname, MCRangeMake(t_offset + 1, MCStringGetLength(newname) - t_offset - 1), t_name);
+                /* UNCHECKED */ MCStringCopySubstring(newname, MCRangeMakeMinMax(t_offset + 1, MCStringGetLength(newname)), t_name);
                 /* UNCHECKED */ MCNameCreate(t_name, &t_name_nameref);
             }
             else

--- a/engine/src/image_rep_densitymapped.cpp
+++ b/engine/src/image_rep_densitymapped.cpp
@@ -359,7 +359,7 @@ bool MCImageSplitScaledFilename(MCStringRef p_filename, MCStringRef &r_base, MCS
 	else
 	{
 		MCAutoStringRef t_label;
-        /* UNCHECKED */ MCStringCopySubstring(p_filename, MCRangeMake(t_label_start, t_ext_start - t_label_start), &t_label);
+        /* UNCHECKED */ MCStringCopySubstring(p_filename, MCRangeMakeMinMax(t_label_start, t_ext_start), &t_label);
         
         t_has_scale = MCImageGetScaleForLabel(*t_label, t_scale);
 		
@@ -372,7 +372,7 @@ bool MCImageSplitScaledFilename(MCStringRef p_filename, MCStringRef &r_base, MCS
 	
 	MCAutoStringRef t_base, t_extension;
     t_success = MCStringCopySubstring(p_filename, MCRangeMake(0, t_label_start), &t_base)
-    && MCStringCopySubstring(p_filename, MCRangeMake(t_ext_start, t_length - t_ext_start), &t_extension);
+    && MCStringCopySubstring(p_filename, MCRangeMakeMinMax(t_ext_start, t_length), &t_extension);
 	
 	if (t_success)
 	{

--- a/engine/src/lnxans.cpp
+++ b/engine/src/lnxans.cpp
@@ -668,7 +668,7 @@ int MCA_ask_file_with_types(MCStringRef p_title, MCStringRef p_prompt, MCStringR
             else
             {
                 MCAutoStringRef t_tmp_folder;
-                MCStringCopySubstring(p_initial, MCRangeMake(t_last_slash + 1, MCStringGetLength(p_initial) - (t_last_slash+1)), &t_name);
+                MCStringCopySubstring(p_initial, MCRangeMakeMinMax(t_last_slash + 1, MCStringGetLength(p_initial)), &t_name);
                 MCStringCopySubstring(p_initial, MCRangeMake(0, t_last_slash), &t_tmp_folder);
 
                 if (MCS_exists(*t_tmp_folder, False))

--- a/engine/src/mblandroidfont.cpp
+++ b/engine/src/mblandroidfont.cpp
@@ -210,7 +210,7 @@ void MCAndroidCustomFontsLoad()
         if (!MCStringFirstIndexOfChar(*t_file_list, '\n', t_old_offset, kMCCompareExact, t_offset))
             break;
             
-        t_success = MCStringCopySubstring(*t_file_list, MCRangeMake(t_old_offset, t_offset - t_old_offset), &t_file);
+        t_success = MCStringCopySubstring(*t_file_list, MCRangeMakeMinMax(t_old_offset, t_offset), &t_file);
         
         if (t_success)
         {
@@ -222,7 +222,7 @@ void MCAndroidCustomFontsLoad()
             if (!MCStringFirstIndexOfChar(*t_file_list, '\n', ++t_old_offset, kMCCompareExact, t_offset))
                 t_offset = t_length;
             
-           t_success = MCStringCopySubstring(*t_file_list, MCRangeMake(t_old_offset, t_offset - t_old_offset), &t_is_folder_string);
+           t_success = MCStringCopySubstring(*t_file_list, MCRangeMakeMinMax(t_old_offset, t_offset), &t_is_folder_string);
         }
     
         if (t_success)

--- a/engine/src/mblandroidfs.cpp
+++ b/engine/src/mblandroidfs.cpp
@@ -54,7 +54,7 @@ bool path_to_apk_path(MCStringRef p_path, MCStringRef &r_apk_path)
     if (MCStringGetNativeCharAtIndex(p_path, MCStringGetLength(MCcmd)) == '/')
         t_start++;
         
-    return MCStringCopySubstring(p_path, MCRangeMake(t_start, MCStringGetLength(p_path) - t_start), r_apk_path);
+    return MCStringCopySubstring(p_path, MCRangeMakeMinMax(t_start, MCStringGetLength(p_path)), r_apk_path);
 }
 
 bool path_from_apk_path(MCStringRef p_apk_path, MCStringRef& r_path)

--- a/engine/src/menuparse.cpp
+++ b/engine/src/menuparse.cpp
@@ -465,7 +465,7 @@ void ParseMenuItemAccelerator(MCStringRef p_string, uindex_t &x_offset, MCMenuIt
 		&& (t_length - t_tag) > 1)
 	{
 		MCStringRef t_tag_str = nil;
-		/* UNCHECKED */ MCStringCopySubstring(p_string, MCRangeMake(t_tag + 1, t_length - t_tag - 1), t_tag_str);
+		/* UNCHECKED */ MCStringCopySubstring(p_string, MCRangeMakeMinMax(t_tag + 1, t_length), t_tag_str);
 		MCValueAssign(p_menuitem->tag, t_tag_str);
 		MCValueRelease(t_tag_str);
 		
@@ -516,7 +516,7 @@ void ParseMenuItemAccelerator(MCStringRef p_string, uindex_t &x_offset, MCMenuIt
 		else if ((t_length - x_offset) > 1)
 		{
 			MCStringRef t_key_string;
-			MCStringCopySubstring(p_string, MCRangeMake(x_offset, t_length - x_offset), t_key_string);
+			MCStringCopySubstring(p_string, MCRangeMakeMinMax(x_offset, t_length), t_key_string);
 			t_key = MCLookupAcceleratorKeysym(t_key_string);
 			if (t_key != 0)
 				MCValueAssign(t_keyname, t_key_string);

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -1152,7 +1152,7 @@ void MCObject::GetRevAvailableVariables(MCExecContext& ctxt, MCNameRef p_key, MC
         return;
     }
     
-    if (!MCStringCopySubstring(t_key, MCRangeMake(t_comma_offset + 1, MCStringGetLength(t_key) - t_comma_offset - 1), &t_handler_name))
+    if (!MCStringCopySubstring(t_key, MCRangeMakeMinMax(t_comma_offset + 1, MCStringGetLength(t_key)), &t_handler_name))
     {
         ctxt . Throw();
         return;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -1739,10 +1739,10 @@ Boolean MCObject::setpatterns(MCStringRef data)
 	{
 		MCAutoStringRef t_substring;
         if (!MCStringFirstIndexOfChar(data, '\n', t_start_pos, kMCCompareExact, t_end_pos))
-            MCStringCopySubstring(data, MCRangeMake(t_start_pos, MCStringGetLength(data) - t_start_pos), &t_substring);
+            MCStringCopySubstring(data, MCRangeMakeMinMax(t_start_pos, MCStringGetLength(data)), &t_substring);
         else
         {
-            MCStringCopySubstring(data, MCRangeMake(t_start_pos, t_end_pos - t_start_pos), &t_substring);
+            MCStringCopySubstring(data, MCRangeMakeMinMax(t_start_pos, t_end_pos), &t_substring);
             t_start_pos = t_end_pos + 1;
         }
             

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -2168,9 +2168,9 @@ Boolean MCSocket::sslconnect()
 
     uindex_t t_pos;
     if (MCStringFirstIndexOfChar(*t_hostname, ':', 0, kMCCompareExact, t_pos))
-        /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMake(t_pos, MCStringGetLength(*t_hostname) - t_pos));
+        /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMakeMinMax(t_pos, MCStringGetLength(*t_hostname)));
     else if (MCStringFirstIndexOfChar(*t_hostname, '|', 0, kMCCompareExact, t_pos))
-        /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMake(t_pos, MCStringGetLength(*t_hostname) - t_pos));
+        /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMakeMinMax(t_pos, MCStringGetLength(*t_hostname)));
 
     MCAutoPointer<char> t_host;
     /* UNCHECKED */ MCStringConvertToCString(*t_hostname, &t_host);
@@ -2374,9 +2374,9 @@ Boolean MCSocket::sslaccept()
             /* UNCHECKED */ MCStringMutableCopy(MCNameGetString(name), &t_hostname);
             uindex_t t_pos;
             if (MCStringFirstIndexOfChar(*t_hostname, ':', 0, kMCCompareExact, t_pos))
-                /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMake(t_pos, MCStringGetLength(*t_hostname) - t_pos));
+                /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMakeMinMax(t_pos, MCStringGetLength(*t_hostname)));
             else if (MCStringFirstIndexOfChar(*t_hostname, '|', 0, kMCCompareExact, t_pos))
-                /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMake(t_pos, MCStringGetLength(*t_hostname) - t_pos));
+                /* UNCHECKED */ MCStringRemove(*t_hostname, MCRangeMakeMinMax(t_pos, MCStringGetLength(*t_hostname)));
 			
 #if defined(TARGET_SUBPLATFORM_IPHONE) || defined(TARGET_SUBPLATFORM_ANDROID)
             // MM-2015-06-04: [[ MobileSockets ]] On the mobile platforms we verify the certificate ourselves rather than using OpenSSL

--- a/engine/src/osxcoreimage.cpp
+++ b/engine/src/osxcoreimage.cpp
@@ -157,7 +157,7 @@ bool MCCoreImageEffectBegin(const char *p_name, MCGImageRef p_source_a, MCGImage
 					if (!MCStringFirstIndexOfChar(t_argument -> value, ',', t_pos, kMCCompareExact, t_comma))
 						t_comma = t_length;
 					MCAutoStringRef t_substring;
-					if (!MCStringCopySubstring(t_argument -> value, MCRangeMake(t_pos, t_comma - t_pos), &t_substring))
+					if (!MCStringCopySubstring(t_argument -> value, MCRangeMakeMinMax(t_pos, t_comma), &t_substring))
 						t_success = false;
 
 					if (!MCStringToDouble(*t_substring, t_vector[t_count]))
@@ -186,7 +186,7 @@ bool MCCoreImageEffectBegin(const char *p_name, MCGImageRef p_source_a, MCGImage
 				if (MCStringBeginsWith(t_argument -> value, MCSTR("id "), kMCStringOptionCompareCaseless))
                 {
                     MCAutoStringRef t_id;
-                    /* UNCHECKED */ MCStringCopySubstring(t_argument -> value, MCRangeMake(3, MCStringGetLength(t_argument -> value) - 3), &t_id); 
+                    /* UNCHECKED */ MCStringCopySubstring(t_argument -> value, MCRangeMakeMinMax(3, MCStringGetLength(t_argument -> value)), &t_id); 
                     integer_t t_int;
                     /* UNCHECKED */ MCStringToInteger(*t_id, t_int);
 					t_image = (MCImage *)(MCdefaultstackptr -> getobjid(CT_IMAGE, t_int));

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -1992,7 +1992,7 @@ void MCParagraph::split(findex_t p_position)
     pgptr->m_text.Reset();
 	if (!MCStringIsEmpty(*m_text))
 	{
-        MCRange t_range = MCRangeMake(p_position, MCStringGetLength(*m_text) - p_position);
+        MCRange t_range = MCRangeMakeMinMax(p_position, MCStringGetLength(*m_text));
 		/* UNCHECKED */ MCStringMutableCopySubstring(*m_text, t_range, &pgptr->m_text);
         /* UNCHECKED */ MCStringSubstring(*m_text, MCRangeMake(0, p_position));
 	}
@@ -2167,7 +2167,7 @@ void MCParagraph::deletestring(findex_t si, findex_t ei, MCFieldStylingMode p_st
 	}
 	
 	// Excise the deleted range from the paragraph text
-	/* UNCHECKED */ MCStringRemove(*m_text, MCRangeMake(si, ei-si));
+	/* UNCHECKED */ MCStringRemove(*m_text, MCRangeMakeMinMax(si, ei));
 
 	// Eliminate any zero length blocks *after* one we might have ensured
 	// is present for styling purposes.
@@ -2304,7 +2304,7 @@ Boolean MCParagraph::finsertnew(MCStringRef p_string)
 		{
             // We found a line-break, so insert it into the current paragraph and then split at
 			// the end.
-			MCRange t_range = MCRangeMake(t_index, t_nextpara - t_index - 1);
+			MCRange t_range = MCRangeMakeMinMax(t_index, t_nextpara - 1);
             t_paragraph -> finsertnobreak(p_string, t_range);
 			t_paragraph -> split();
 			t_paragraph = t_paragraph -> next();
@@ -2318,7 +2318,7 @@ Boolean MCParagraph::finsertnew(MCStringRef p_string)
 		{
 			// We didn't find a line-break, so insert the string into the current paragraph and
 			// we must be done.
-			t_paragraph -> finsertnobreak(p_string, MCRangeMake(t_index, t_length - t_index));
+			t_paragraph -> finsertnobreak(p_string, MCRangeMakeMinMax(t_index, t_length));
 			t_index = t_length;
 		}
 	}
@@ -2384,7 +2384,7 @@ int2 MCParagraph::fdelete(Field_translations type, MCParagraph *&undopgptr)
         // Get the bit of text we need to decompose and do so
         MCAutoStringRef t_composed, t_decomposed;
         MCRange t_range;
-        t_range = MCRangeMake(t_charstart, t_charend - t_charstart);
+        t_range = MCRangeMakeMinMax(t_charstart, t_charend);
         /* UNCHECKED */ MCStringCopySubstring(*m_text, t_range, &t_composed);
         /* UNCHECKED */ MCStringNormalizedCopyNFD(*t_composed, &t_decomposed);
         

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -2245,7 +2245,7 @@ void MCPlayer::SynchronizeUserCallbacks(void)
         
         // SN-2014-07-28: [[ Bug 12984 ]] MCNumberParseOffset expects the string to finish after the number
         MCAutoStringRef t_callback_substring;
-        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_start_index, t_comma_index - t_start_index), &t_callback_substring);
+        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMakeMinMax(t_start_index, t_comma_index), &t_callback_substring);
         
         // SN-2014-07-28: [[ Bug 12984 ]] Mimic the strtol behaviour in case of a parsing failure
         if (MCNumberParse(*t_callback_substring, &t_time))
@@ -2266,7 +2266,7 @@ void MCPlayer::SynchronizeUserCallbacks(void)
             if (isspace(MCStringGetCharAtIndex(*t_callback, t_space_index)))
             {
                 MCAutoStringRef t_param;
-                /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_space_index, t_end_index - t_space_index), &t_param);
+                /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMakeMinMax(t_space_index, t_end_index), &t_param);
                 /* UNCHECKED */ MCNameCreate(*t_param, m_callbacks[m_callback_count - 1] . parameter);
                 break;
             }
@@ -2274,14 +2274,14 @@ void MCPlayer::SynchronizeUserCallbacks(void)
         }
         
         MCAutoStringRef t_message;
-        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_callback_index, t_space_index - t_callback_index), &t_message);
+        /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMakeMinMax(t_callback_index, t_space_index), &t_message);
         /* UNCHECKED */ MCNameCreate(*t_message, m_callbacks[m_callback_count - 1] . message);
         
         // If no parameter is specified, use the time.
         if (m_callbacks[m_callback_count - 1] . parameter == nil)
         {
             MCAutoStringRef t_param;
-            /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMake(t_start_index, t_comma_index - t_start_index), &t_param);
+            /* UNCHECKED */ MCStringCopySubstring(*t_callback, MCRangeMakeMinMax(t_start_index, t_comma_index), &t_param);
             /* UNCHECKED */ MCNameCreate(*t_param, m_callbacks[m_callback_count - 1] . parameter);
         }
 		

--- a/engine/src/property.cpp
+++ b/engine/src/property.cpp
@@ -1221,7 +1221,7 @@ bool MCProperty::resolveprop(MCExecContext& ctxt, Properties& r_which, MCNameRef
                 t_end_offset--;
             }
             
-            if (!MCStringCopySubstring(*t_string, MCRangeMake(t_offset + 1, t_end_offset - t_offset - 1), &t_icarray))
+            if (!MCStringCopySubstring(*t_string, MCRangeMakeMinMax(t_offset + 1, t_end_offset), &t_icarray))
                 return false;
         }
         else

--- a/engine/src/srvcgi.cpp
+++ b/engine/src/srvcgi.cpp
@@ -698,7 +698,7 @@ static bool cgi_store_control_value(MCVariable *p_variable, MCNameRef p_raw_key,
         else
         {
             // We have a named key, we just add the name to the path.
-            if (!MCStringCopySubstring(t_raw_key_str, MCRangeMake(t_subkey_start, t_subkey_end - t_subkey_start), &t_subkey_str))
+            if (!MCStringCopySubstring(t_raw_key_str, MCRangeMakeMinMax(t_subkey_start, t_subkey_end), &t_subkey_str))
                 return false;
         }
 
@@ -786,7 +786,7 @@ static void cgi_store_data_urlencoded(MCVariable *p_variable, MCDataRef p_data, 
         MCAutoDataRef t_key;
         MCNewAutoNameRef t_key_as_name;
         MCAutoStringRef t_key_as_string;
-        cgi_unescape_url(p_data, MCRangeMake(t_encoded_index, t_encoded_key_end - t_encoded_index), &t_key);
+        cgi_unescape_url(p_data, MCRangeMakeMinMax(t_encoded_index, t_encoded_key_end), &t_key);
 
         // The key should be native
         /* UNCHECKED */ MCStringCreateWithNativeChars((char_t*)MCDataGetBytePtr(*t_key), MCDataGetLength(*t_key), &t_key_as_string);
@@ -800,7 +800,7 @@ static void cgi_store_data_urlencoded(MCVariable *p_variable, MCDataRef p_data, 
 				t_encoded_value_end--;
 		
         MCAutoDataRef t_value;
-        cgi_unescape_url(p_data, MCRangeMake(t_encoded_value_index, t_encoded_value_end - t_encoded_value_index), &t_value);
+        cgi_unescape_url(p_data, MCRangeMakeMinMax(t_encoded_value_index, t_encoded_value_end), &t_value);
 
 		// MM-2011-07-13: Added p_native_encoding flag that specifies if the text should 
 		//   be converted from the outputTextEncoding to the native character set.

--- a/engine/src/srvmac.cpp
+++ b/engine/src/srvmac.cpp
@@ -522,7 +522,7 @@ struct MCMacSystem: public MCSystemInterface
 			else
 			{
 				MCAutoStringRef t_username;
-				if (!MCStringCopySubstring(p_path, MCRangeMake(1U, t_user_end - 1U), &t_username))
+				if (!MCStringCopySubstring(p_path, MCRangeMakeMinMax(1U, t_user_end), &t_username))
 					return false;
 
 				t_password = getpwnam(MCStringGetCString(*t_username));
@@ -532,7 +532,7 @@ struct MCMacSystem: public MCSystemInterface
 			{
 				if (!MCStringCreateMutable(0, &t_tilde_path) ||
 					!MCStringAppendNativeChars(*t_tilde_path, (const char_t *)t_password->pw_dir, MCCStringLength(t_password->pw_dir)) ||
-					!MCStringAppendSubstring(*t_tilde_path, p_path, MCRangeMake(t_user_end, MCStringGetLength(p_path) - t_user_end)))
+					!MCStringAppendSubstring(*t_tilde_path, p_path, MCRangeMakeMinMax(t_user_end, MCStringGetLength(p_path))))
 					return false;
 			}
 			else

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1741,7 +1741,7 @@ bool MCStack::resolve_relative_path(MCStringRef p_path, MCStringRef& r_resolved)
             // If the relative path begins with "./" or ".\", we must remove this, otherwise
 			// certain system calls will get confused by the path.
 			if (MCStringBeginsWith(p_path, MCSTR("./"), kMCCompareExact) || MCStringBeginsWith(p_path, MCSTR(".\\"), kMCCompareExact))
-				/* UNCHECKED */ MCStringAppendSubstring(*t_new_filename, p_path, MCRangeMake(2, MCStringGetLength(p_path) - 2));
+				/* UNCHECKED */ MCStringAppendSubstring(*t_new_filename, p_path, MCRangeMakeMinMax(2, MCStringGetLength(p_path)));
 			else
 				/* UNCHECKED */ MCStringAppend(*t_new_filename, p_path);
             
@@ -1773,7 +1773,7 @@ bool MCStack::resolve_relative_path_to_default_folder(MCStringRef p_path, MCStri
     MCS_getcurdir(&t_cur_dir);
 
     MCRange t_range;
-    t_range = MCRangeMake(t_start_index, MCStringGetLength(p_path) - t_start_index);
+    t_range = MCRangeMakeMinMax(t_start_index, MCStringGetLength(p_path));
     return MCStringFormat(r_resolved, "%@/%*@", *t_cur_dir, &t_range, p_path);
 }
 

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -2648,7 +2648,7 @@ bool MCStack::stringtostackfiles(MCStringRef d_strref, MCStackfile **sf, uint2 &
 		if (!MCStringFirstIndexOfChar(d_strref, '\n', t_old_offset, kMCCompareExact, t_new_offset))
 			t_new_offset = t_length;
         
-		t_success = MCStringCopySubstring(d_strref, MCRangeMake(t_old_offset, t_new_offset - t_old_offset), &t_line);
+		t_success = MCStringCopySubstring(d_strref, MCRangeMakeMinMax(t_old_offset, t_new_offset), &t_line);
 		if (t_success && t_new_offset > t_old_offset)
 		{
 			MCAutoStringRef t_stack_name;

--- a/engine/src/sysspec-url.cpp
+++ b/engine/src/sysspec-url.cpp
@@ -43,7 +43,7 @@ bool MCSystemStripUrl(MCStringRef p_url, MCStringRef &r_stripped)
 	while (t_end > t_start && is_whitespace(MCStringGetNativeCharAtIndex(p_url, t_end - 1)))
 		t_end--;
 	
-	return MCStringCopySubstring(p_url, MCRangeMake(t_start, t_end - t_start), r_stripped);
+	return MCStringCopySubstring(p_url, MCRangeMakeMinMax(t_start, t_end), r_stripped);
 }
 
 bool MCSystemProcessUrl(MCStringRef p_url, MCSystemUrlOperation p_operations, MCStringRef &r_processed_url)

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -2283,17 +2283,17 @@ void MCU_geturl(MCExecContext& ctxt, MCStringRef p_url, MCValueRef &r_output)
 	MCAutoStringRef t_filename;
 	if (MCStringGetLength(p_url) > 5 && MCStringBeginsWithCString(p_url, (const char_t*)"file:", kMCCompareCaseless))
 	{
-		MCStringCopySubstring(p_url, MCRangeMake(5, MCStringGetLength(p_url)-5), &t_filename);
+		MCStringCopySubstring(p_url, MCRangeMakeMinMax(5, MCStringGetLength(p_url)), &t_filename);
 		MCS_loadtextfile(*t_filename, (MCStringRef&)r_output);
 	}
 	else if (MCStringGetLength(p_url) > 8 && MCStringBeginsWithCString(p_url, (const char_t*)"binfile:", kMCCompareCaseless))
 	{
-		MCStringCopySubstring(p_url, MCRangeMake(8, MCStringGetLength(p_url)-8), &t_filename);
+		MCStringCopySubstring(p_url, MCRangeMakeMinMax(8, MCStringGetLength(p_url)), &t_filename);
 		MCS_loadbinaryfile(*t_filename, (MCDataRef&)r_output);
 	}
 	else if (MCStringGetLength(p_url) > 8 && MCStringBeginsWithCString(p_url, (const char_t*)"resfile:", kMCCompareCaseless))
 	{
-		MCStringCopySubstring(p_url, MCRangeMake(8, MCStringGetLength(p_url)-8), &t_filename);
+		MCStringCopySubstring(p_url, MCRangeMakeMinMax(8, MCStringGetLength(p_url)), &t_filename);
 		MCS_loadresfile(*t_filename, (MCStringRef&)r_output);
 	}
 	else if (MCU_couldbeurl(MCStringGetOldString(p_url)))
@@ -2344,14 +2344,14 @@ void MCU_puturl(MCExecContext &ctxt, MCStringRef p_url, MCValueRef p_data)
 	{
 		MCAutoStringRef t_path, t_data;
 		/* UNCHECKED */ ctxt . ConvertToString(p_data, &t_data);
-		/* UNCHECKED */ MCStringCopySubstring(p_url, MCRangeMake(5, MCStringGetLength(p_url) - 5), &t_path);
+		/* UNCHECKED */ MCStringCopySubstring(p_url, MCRangeMakeMinMax(5, MCStringGetLength(p_url)), &t_path);
 		MCS_savetextfile(*t_path, *t_data);
 	}
 	else if (MCStringBeginsWithCString(p_url, (const char_t*)"binfile:", kMCCompareCaseless))
 	{
 		MCAutoStringRef t_path;
 		MCAutoDataRef t_data;
-		/* UNCHECKED */ MCStringCopySubstring(p_url, MCRangeMake(8, MCStringGetLength(p_url) - 8), &t_path);
+		/* UNCHECKED */ MCStringCopySubstring(p_url, MCRangeMakeMinMax(8, MCStringGetLength(p_url)), &t_path);
 		/* UNCHECKED */ ctxt.ConvertToData(p_data, &t_data);
 		MCS_savebinaryfile(*t_path, *t_data);
 	}
@@ -2359,7 +2359,7 @@ void MCU_puturl(MCExecContext &ctxt, MCStringRef p_url, MCValueRef p_data)
 	{
 		MCAutoStringRef t_path;
 		MCAutoDataRef t_data;
-		/* UNCHECKED */ MCStringCopySubstring(p_url, MCRangeMake(8, MCStringGetLength(p_url) - 8), &t_path);
+		/* UNCHECKED */ MCStringCopySubstring(p_url, MCRangeMakeMinMax(8, MCStringGetLength(p_url)), &t_path);
 		/* UNCHECKED */ ctxt.ConvertToData(p_data, &t_data);
 		MCS_saveresfile(*t_path, *t_data);
 	}

--- a/engine/src/vclip.cpp
+++ b/engine/src/vclip.cpp
@@ -143,7 +143,7 @@ Boolean MCVideoClip::import(MCStringRef fname, IO_handle fstream)
     uindex_t t_last_slash;
     MCStringRef t_path;
     if (MCStringLastIndexOfChar(fname, PATH_SEPARATOR, UINDEX_MAX, kMCCompareExact, t_last_slash))
-        /* UNCHECKED */ MCStringCopySubstring(fname, MCRangeMake(t_last_slash + 1, MCStringGetLength(fname) - t_last_slash - 1), t_path);
+        /* UNCHECKED */ MCStringCopySubstring(fname, MCRangeMakeMinMax(t_last_slash + 1, MCStringGetLength(fname)), t_path);
     else
         t_path = MCValueRetain(fname);
     

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -504,7 +504,7 @@ MCDataRef MCWin32RawClipboardCommon::EncodeBMPForTransfer(MCDataRef p_bmp) const
 	// Strip the BITMAPFILEHEADER structure from the BMP and pass the BMP in its in-memory form
 	MCAutoDataRef t_data;
 	size_t t_offset = sizeof(BITMAPFILEHEADER);
-	if (!MCDataCopyRange(p_bmp, MCRangeMake(t_offset, MCDataGetLength(p_bmp) - t_offset), &t_data))
+	if (!MCDataCopyRange(p_bmp, MCRangeMakeMinMax(t_offset, MCDataGetLength(p_bmp)), &t_data))
 		return nil;
 	return *t_data;
 }

--- a/engine/src/w32ans.cpp
+++ b/engine/src/w32ans.cpp
@@ -366,7 +366,7 @@ static int MCA_do_file_dialog(MCStringRef p_title, MCStringRef p_prompt, MCStrin
 			else
 			{
 				if (t_last_slash < MCStringGetLength(*t_fixed_path) - 1)
-					/* UNCHECKED */ MCStringCopySubstring(*t_fixed_path, MCRangeMake(t_last_slash + 1, MCStringGetLength(*t_fixed_path) - (t_last_slash + 1)), &t_initial_file);
+					/* UNCHECKED */ MCStringCopySubstring(*t_fixed_path, MCRangeMakeMinMax(t_last_slash + 1, MCStringGetLength(*t_fixed_path)), &t_initial_file);
 
 				MCAutoStringRef t_folder_split;
 				// SN-2014-10-29: [[ Bug 13850 ]] The length is t_last_slash, not t_last_slash - 1
@@ -698,7 +698,7 @@ static int MCA_do_file_dialog(MCStringRef p_title, MCStringRef p_prompt, MCStrin
 			t_end = UINDEX_MAX;
 			/* UNCHECKED */ MCStringFirstIndexOfChar(p_filter, '\0', t_offset, kMCStringOptionCompareExact, t_end);
             
-			/* UNCHECKED */ MCStringCopySubstring(p_filter, MCRangeMake(t_offset, t_end-t_offset), r_result);
+			/* UNCHECKED */ MCStringCopySubstring(p_filter, MCRangeMakeMinMax(t_offset, t_end), r_result);
 		}
 
 		t_result = 0;

--- a/engine/src/w32icon.cpp
+++ b/engine/src/w32icon.cpp
@@ -363,12 +363,12 @@ static HMENU create_icon_menu(MCStringRef p_menu)
 		}
 
 		MCValueRelease(t_item->m_name);
-		/* UNCHECKED */ MCStringCopySubstring(p_menu, MCRangeMake(t_item_start, t_tag_sep - t_item_start), t_item->m_name);
+		/* UNCHECKED */ MCStringCopySubstring(p_menu, MCRangeMakeMinMax(t_item_start, t_tag_sep), t_item->m_name);
 
 		if (t_tag_sep != t_item_end)
 		{
 			MCValueRelease(t_item->m_tag);
-			/* UNCHECKED */ MCStringCopySubstring(p_menu, MCRangeMake(t_tag_sep + 1, t_item_end - t_tag_sep - 1), t_item->m_tag);
+			/* UNCHECKED */ MCStringCopySubstring(p_menu, MCRangeMakeMinMax(t_tag_sep + 1, t_item_end), t_item->m_tag);
 		}
 
 		t_item -> depth = t_item_start - t_offset;

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -1166,7 +1166,7 @@ public:
 	bool Resize(uindex_t p_new_size)
 	{
 		if (p_new_size < m_size)
-			FreeElements(MCRangeMake(p_new_size, m_size - p_new_size));
+			FreeElements(MCRangeMakeMinMax(p_new_size, m_size));
 		
 		return MCMemoryResizeArray(p_new_size, m_ptr, m_size);
 	}

--- a/libfoundation/src/foundation-chunk.cpp
+++ b/libfoundation/src/foundation-chunk.cpp
@@ -542,7 +542,7 @@ bool MCTextChunkIterator_Delimited::Next()
     MCRange t_found_range;
     // calculate the length of the line / item
     // AL-2015-02-10: [[ Bug 14532 ]] Use restricted range for delimiter search
-    if (!MCStringFind(m_text, MCRangeMake(t_offset, m_length - t_offset), m_delimiter, m_options, &t_found_range))
+    if (!MCStringFind(m_text, MCRangeMakeMinMax(t_offset, m_length), m_delimiter, m_options, &t_found_range))
     {
         m_range . length = m_length - m_range . offset;
         m_exhausted = true;
@@ -569,7 +569,7 @@ bool MCTextChunkIterator_Delimited::IsAmong(MCStringRef p_needle)
         // Otherwise we need to find p_needle and check to see if there is a delimiter either side.
         // This is because of the case where the delimiter is within p_needle - e.g.
         // "a,b" is among the items of "a,b,c,d" should return true.
-        return MCChunkIsAmongTheChunksOfRange(p_needle, m_text, m_delimiter, m_options, MCRangeMake(m_range . offset, m_length - m_range . offset));
+        return MCChunkIsAmongTheChunksOfRange(p_needle, m_text, m_delimiter, m_options, MCRangeMakeMinMax(m_range . offset, m_length));
     }
     
     while (Next())
@@ -614,12 +614,12 @@ uindex_t MCTextChunkIterator_Delimited::ChunkOffset(MCStringRef p_needle, uindex
     if (!MCStringIsEmpty(p_needle))
     {
         uindex_t t_found_offset;
-        if (!MCChunkOffsetOfChunkInRange(m_text, p_needle, m_delimiter, p_whole_matches, m_options, MCRangeMake(m_range . offset, m_length - m_range . offset), t_found_offset))
+        if (!MCChunkOffsetOfChunkInRange(m_text, p_needle, m_delimiter, p_whole_matches, m_options, MCRangeMakeMinMax(m_range . offset, m_length), t_found_offset))
             return 0;
         
         // Count the number of delimiters between the start of the first chunk
         // and the start of the found string.
-        t_chunk_offset += MCStringCount(m_text, MCRangeMake(m_range . offset, t_found_offset - m_range . offset), m_delimiter, m_options);
+        t_chunk_offset += MCStringCount(m_text, MCRangeMakeMinMax(m_range . offset, t_found_offset), m_delimiter, m_options);
         
         // AL-2015-07-20: [[ Bug 15618 ]] If the chunk found is outside the specified range, return 0 (not found)
         if (p_end_offset != nil && t_chunk_offset > *p_end_offset)
@@ -637,12 +637,12 @@ uindex_t MCTextChunkIterator_Delimited::ChunkOffset(MCStringRef p_needle, uindex
         
         if (p_whole_matches)
         {
-            if (MCStringSubstringIsEqualTo(m_text, MCRangeMake(m_range . offset, m_length - m_range . offset), p_needle, m_options))
+            if (MCStringSubstringIsEqualTo(m_text, MCRangeMakeMinMax(m_range . offset, m_length), p_needle, m_options))
                 return t_chunk_offset;
         }
         else
         {
-            if (MCStringSubstringContains(m_text, MCRangeMake(m_range . offset, m_length - m_range . offset), p_needle, m_options))
+            if (MCStringSubstringContains(m_text, MCRangeMakeMinMax(m_range . offset, m_length), p_needle, m_options))
                 return t_chunk_offset;
         }
         t_chunk_offset++;

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -143,7 +143,7 @@ static bool __MCJavaCallNeedsClassInstance(MCJavaCallType p_type)
 static bool __RemoveSurroundingParentheses(MCStringRef p_in, MCStringRef& r_out)
 {
     return MCStringCopySubstring(p_in,
-                                 MCRangeMake(1, MCStringGetLength(p_in) - 2),
+                                 MCRangeMakeMinMax(1, MCStringGetLength(p_in) - 1),
                                  r_out);
 }
 

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1918,7 +1918,7 @@ bool MCStringMapIndices(MCStringRef self, MCBreakIteratorType p_type, MCLocaleRe
         t_end = MCStringGetLength(self);
     
     MCRange t_units;
-    t_units = MCRangeMake(t_start, t_end - t_start);
+    t_units = MCRangeMakeMinMax(t_start, t_end);
     
     // All done
     r_out_range = t_units;
@@ -1965,7 +1965,7 @@ bool MCStringMapGraphemeIndices(MCStringRef self, MCRange p_grapheme_range, MCRa
     if (t_end == kMCLocaleBreakIteratorDone)
         t_end = MCStringGetLength(self);
     
-    r_cu_range = MCRangeMake(t_start, t_end - t_start);
+    r_cu_range = MCRangeMakeMinMax(t_start, t_end);
     return true;
 }
 
@@ -2017,7 +2017,7 @@ bool MCStringMapTrueWordIndices(MCStringRef self, MCLocaleRef p_locale, MCRange 
         ;
     
     MCRange t_units;
-    t_units = MCRangeMake(t_start, t_word_range . offset + t_word_range . length - t_start);
+    t_units = MCRangeMakeMinMax(t_start, t_word_range . offset + t_word_range . length);
     
     // All done
     MCLocaleBreakIteratorRelease(t_iter);
@@ -3376,7 +3376,7 @@ bool MCStringFirstIndexOfStringInRange(MCStringRef self, MCStringRef p_needle, M
 MC_DLLEXPORT_DEF
 bool MCStringFirstIndexOfChar(MCStringRef self, codepoint_t p_needle, uindex_t p_after, MCStringOptions p_options, uindex_t& r_offset)
 {
-    return MCStringFirstIndexOfCharInRange(self, p_needle, MCRangeMake(p_after, self -> char_count - p_after), p_options, r_offset);
+    return MCStringFirstIndexOfCharInRange(self, p_needle, MCRangeMakeMinMax(p_after, self -> char_count), p_options, r_offset);
 }
 
 MC_DLLEXPORT_DEF
@@ -3702,7 +3702,7 @@ bool MCStringDivideAtIndex(MCStringRef self, uindex_t p_offset, MCStringRef& r_h
 		return false;
 	
 	MCStringRef t_tail;
-	if (!MCStringCopySubstring(self, MCRangeMake(p_offset + 1, MCStringGetLength(self) - p_offset - 1), t_tail))
+	if (!MCStringCopySubstring(self, MCRangeMakeMinMax(p_offset + 1, MCStringGetLength(self)), t_tail))
 	{
 		MCValueRelease(t_head);
 		return false;
@@ -3808,7 +3808,7 @@ static bool __MCStringSkip(MCStringRef self,
     while(p_count > 0)
     {
         if (!__MCStringFind(self,
-                            MCRangeMake(t_start, t_finish - t_start),
+                            MCRangeMakeMinMax(t_start, t_finish),
                             p_needle,
                             p_options,
                             &t_last))
@@ -3867,7 +3867,7 @@ static uindex_t __MCStringCount(MCStringRef self,
     MCRange t_last;
     t_last = MCRangeMake(t_start, 0);
     while(__MCStringFind(self,
-                         MCRangeMake(t_start, t_finish - t_start),
+                         MCRangeMakeMinMax(t_start, t_finish),
                          p_needle,
                          p_options,
                          &t_last))
@@ -3931,7 +3931,7 @@ static bool __MCStringDelimitedOffset(MCStringRef self,
     // we are done.
     MCRange t_found_range;
     if (!__MCStringFind(self,
-                        MCRangeMake(t_start, t_finish - t_start),
+                        MCRangeMakeMinMax(t_start, t_finish),
                         p_needle,
                         p_options,
                         &t_found_range))
@@ -3940,7 +3940,7 @@ static bool __MCStringDelimitedOffset(MCStringRef self,
     // We must now search for delimiters in the substring between the end of the
     // previous delimiter and the start of the found range.
     t_delimiter_count += __MCStringCount(self,
-                                         MCRangeMake(t_start, t_found_range . offset - t_start),
+                                         MCRangeMakeMinMax(t_start, t_found_range . offset),
                                          p_delimiter,
                                          p_options,
                                          &t_prev_delimiter);

--- a/libfoundation/src/system-library-static.hpp
+++ b/libfoundation/src/system-library-static.hpp
@@ -188,8 +188,8 @@ class __MCSLibraryHandleStatic
         
         MCAutoStringRef t_leaf_name;
         if (!MCStringCopySubstring(p_native_path,
-                                   MCRangeMake(t_last_separator,
-                                               t_first_extension - t_last_separator),
+                                   MCRangeMakeMinMax(t_last_separator,
+                                                     t_first_extension),
                                    &t_leaf_name))
         {
             return false;


### PR DESCRIPTION
In the past, there was a crash caused by calling `MCRangeMake()` in the form `MCRangeMake(A, B-A)` where `A > B`.  `MCRangeMakeMinMax()` prevents this bug, by taking two offsets as arguments rather than an offset and a length, and setting the length to 0 if the end offset is before the start offset.

This patch tediously rewrites all calls of the form `MCRangeMake(start, end-start)` to `MCRangeMakeMinMax(start, end)`, which is considerably clearer and less repetitive.