### PR TITLE
Minor tweaks

### DIFF
--- a/engine/src/w32dcs.cpp
+++ b/engine/src/w32dcs.cpp
@@ -312,6 +312,9 @@ Boolean MCScreenDC::close(Boolean force)
 	timeEndPeriod(1);
 	opened = 0;
 
+	DestroyWindow(invisiblehwnd);
+	invisiblehwnd = NULL;
+
 	return True;
 }
 

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -83,8 +83,6 @@ MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef self, MCProperListRef& x_ar
     return nil;
     
 error_exit:
-    MCValueRelease(x_arguments);
-    x_arguments = nil;
     r_value = nil;
     
     MCErrorRef t_error;


### PR DESCRIPTION
This patch contains two small tweaks:

   - it corrects a failure to release an HWND when closing MCScreenDC

   - it corrects MCHandlerTryToInvoke in the case an error occurs
