### PR TITLE
libfoundation: Add MCNarrowCast and MCNarrow templates

### DIFF
--- a/engine/src/bsdiff_build.cpp
+++ b/engine/src/bsdiff_build.cpp
@@ -56,9 +56,6 @@ bool MCBsDiffBuild(MCBsDiffInputStream *p_old_stream, MCBsDiffInputStream *p_new
 
 #define MIN(x,y) (((x)<(y)) ? (x) : (y))
 
-#if !defined(__LINUX__) && !defined(_OFF_T)
-typedef int32_t off_t;
-#endif
 typedef uint8_t u_char;
 
 static void split(off_t *I,off_t *V,off_t start,off_t len,off_t h)

--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -39,7 +39,7 @@ inline bool MCUnicodeCodepointToSurrogates(codepoint_t p_codepoint,
 {
     if (p_codepoint < 0x10000)
     {
-        r_leading = unichar_t(p_codepoint); /* safe narrowing */
+        r_leading = MCNarrowCast<unichar_t>(p_codepoint);
         r_trailing = 0;
         return false;
     }

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -707,6 +707,43 @@ using std::nothrow;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
+//  NARROWING CONVERSIONS
+//
+
+#include <utility>
+#include <type_traits>
+
+/* A searchable way to do narrowing casts of numeric values (e.g. from
+ * uint32_t to uint8_t or from uindex_t to std::ptrdiff_t).  Use in
+ * preference to a C-style cast or a raw static_cast.  Should be used
+ * when you're totally certain that overflow/underflow has been
+ * logically ruled out elsewhere. */
+template <typename To, typename From>
+inline constexpr To MCNarrowCast(From p_from) noexcept
+{
+    return static_cast<To>(std::forward<From>(p_from));
+}
+
+/* Checked narrowing conversion of numeric values.  Use when there's a
+ * possibility that the input value might not fit into the output
+ * type, and you want to check.  Note that this is safe to use in
+ * generic/template code; if To can represent all values of From, it
+ * optimises to nothing.*/
+template <typename To, typename From>
+inline bool MCNarrow(From p_from, To& r_result)
+{
+    To t_to = static_cast<To>(p_from);
+    if (static_cast<From>(t_to) != p_from)
+        return false;
+    if ((std::is_signed<From>::value != std::is_signed<To>::value) &&
+        ((t_to < To{}) != (p_from < From{})))
+        return false;
+    r_result = t_to;
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
 //  MINIMUM FUNCTIONS
 //
 

--- a/libfoundation/src/foundation-stream.cpp
+++ b/libfoundation/src/foundation-stream.cpp
@@ -112,23 +112,14 @@ static bool __MCMemoryInputStreamTell(MCStreamRef p_stream, filepos_t& r_positio
 {
 	__MCMemoryInputStream *self;
 	self = (__MCMemoryInputStream *)MCStreamGetExtraBytesPtr(p_stream);
-	r_position = self -> pointer;
-	return true;
+    return MCNarrow(self->pointer, r_position);
 }
 
 static bool __MCMemoryInputStreamSeek(MCStreamRef p_stream, filepos_t p_position)
 {
-    /* This type is large enough to hold both the maximum value of
-     * filepos_t and the maximum value of a size_t. */
-    using file_size_t = decltype(filepos_t{} + size_t{});
-
 	__MCMemoryInputStream *self;
 	self = (__MCMemoryInputStream *)MCStreamGetExtraBytesPtr(p_stream);
-	if (p_position < 0
-        || /*NARROWING*/file_size_t(p_position) > self -> length)
-		return false;
-	self -> pointer = (size_t)p_position;
-	return true;
+    return MCNarrow(p_position, self->pointer);
 }
 
 static MCStreamCallbacks kMCMemoryInputStreamCallbacks =

--- a/libfoundation/test/test_typeconvert.cpp
+++ b/libfoundation/test/test_typeconvert.cpp
@@ -22,6 +22,30 @@
 #include "foundation.h"
 #include "foundation-auto.h"
 
+TEST(typeconvert, narrowcast)
+{
+    /* MCNarrowCast never does any checking */
+    EXPECT_EQ(MCNarrowCast<int>(4.0), 4);
+    EXPECT_EQ(MCNarrowCast<int>(4.5), 4);
+}
+
+TEST(typeconvert, narrow)
+{
+    uint8_t dummy_uint8_t = 0;
+    EXPECT_TRUE(MCNarrow(INT8_MAX, dummy_uint8_t));
+    EXPECT_EQ(dummy_uint8_t, INT8_MAX);
+    EXPECT_FALSE(MCNarrow(UINT8_MAX + 1, dummy_uint8_t));
+    EXPECT_EQ(dummy_uint8_t, INT8_MAX); /* Unmodified */
+    EXPECT_FALSE(MCNarrow(INT8_MIN, dummy_uint8_t));
+    EXPECT_EQ(dummy_uint8_t, INT8_MAX); /* Unmodified */
+
+    int dummy_int_t = 0;
+    EXPECT_TRUE(MCNarrow(3.0, dummy_int_t));
+    EXPECT_EQ(dummy_int_t, 3);
+    EXPECT_FALSE(MCNarrow(-1.5, dummy_int_t));
+    EXPECT_EQ(dummy_int_t, 3); /* Unmodified */
+}
+
 TEST(typeconvert, string_integer)
 //
 // Checks string-to-integer conversion


### PR DESCRIPTION
Add two new template functions to libfoundation:

- `MCNarrowCast` is a cast-like function template that takes a numeric value of one type and converts it to another, with no checking.  It is intended to be when performing deliberate narrowing.  In the past we have used "normal" C-style casts, `static_cast`, or constructor-style numeric casts to perform this, but these don't convey "I am deliberately narrowing this numeric value" and are hard to search for.

- `MCNarrow` converts a numeric value to a different numeric type, but checks that the conversion didn't lose any information.  This can be used instead of hand-coding explicit range checks. It optimises away entirely if the target type can represent all values of the input type.

Note that it's now possible to use `MCNarrow` to check numeric conversions without needing to know anything about the exact numeric types involved.