### PR TITLE
[Bug 17540] Fix crash in LiveCode on Mac with -h

### DIFF
--- a/docs/notes/bugfix-17540.md
+++ b/docs/notes/bugfix-17540.md
@@ -1,0 +1,1 @@
+# Fix crash on Mac when displaying IDE usage message

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -69,10 +69,26 @@ void MCPlatformHandleApplicationStartup(int p_argc, MCStringRef *p_argv, MCStrin
 		r_error_message = nil;
 		return;
 	}
-	
-	r_error_code = -1;
-    if (MCValueGetTypeCode(MCresult -> getvalueref()) == kMCValueTypeCodeString)
+
+    r_error_code = -1;
+
+    if (MCresult == nullptr)
+    {
+        /* TODO[2017-04-05] X_init() failed before initialising global
+         * variables.  This could be because something horrible happened, or it
+         * could be because it found "-h" in the arguments.  It's better to
+         * quit without an error message than to crash, but it the future it
+         * would be good to distinguish between the two. */
+        r_error_message = MCValueRetain(kMCEmptyString);
+    }
+    else if (MCValueGetTypeCode(MCresult -> getvalueref()) == kMCValueTypeCodeString)
+    {
         r_error_message = (MCStringRef)MCValueRetain(MCresult->getvalueref());
+    }
+    else
+    {
+        r_error_message = MCValueRetain(MCSTR("Unknown error occurred"));
+    }
 }
 
 void MCPlatformHandleApplicationShutdown(int& r_exit_code)


### PR DESCRIPTION
When `X_init()` fails, the Mac engine constructs an startup error
message using the contents of `MCresult`.  One of the reasons that
`X_init()` might fail is when it encounters `-h` in the command-
line arguments.  In this case, the Mac engine was crashing while
trying to access `MCresult`.

`X_open()` is responsible for initialising `MCresult`, and it is
called with the command-line arguments that are left over after the
engine has processed them.  When `-h` is encountered, `X_open()` is
never called.

This patch slightly improves the situation by ensuring that
`MCPlatformHandleApplicationStartup()` checks that `MCresult` is
initialised before attempting to retrieve its contents.  However,
it would be better to more clearly distinguish between printing the
usage message as requested and an actual error.