### PR TITLE
[[ Bug 19537 ]] Allow currently debugging stack to execute

### DIFF
--- a/docs/notes/bugfix-19537.md
+++ b/docs/notes/bugfix-19537.md
@@ -1,0 +1,1 @@
+# Allow currently debugging stack to execute other handlers and remain debugging

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -928,20 +928,8 @@ Exec_stat MCObject::exechandler(MCHandler *hptr, MCParameter *params)
 	
 	lockforexecution();
     MCExecContext ctxt(this, hlist, hptr);
-	if (MCtracestackptr && MCtracereturn)
-	{
-		Boolean oldtrace = MCtrace;
-		if (MCtracestackptr == getstack())
-			MCtrace = True;
-		stat = hptr->exec(ctxt, params);
-		if (MCtrace && !oldtrace)
-		{
-			MCB_done(ctxt);
-			MCtrace = False;
-		}
-	}
-	else
-		stat = hptr->exec(ctxt, params);
+
+    stat = hptr->exec(ctxt, params);
 	if (stat == ES_ERROR)
 	{
 		// MW-2011-06-23: [[ SERVER ]] If the handler has a file index, it


### PR DESCRIPTION
This patch allows the stack being debugged line-by-line to have
its handlers executed in the course of debugging.