### PR TITLE
Cleanup code that uses MCStringGetCString(), part 1

### DIFF
--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -3509,23 +3509,13 @@ cleanup:
 			MCresult -> sets("alternate language not found");
 		else
 		{
-			MCAutoStringRefAsUTF8String t_utf8;
-			/* UNCHECKED */ t_utf8.Lock(p_script);
-			
 			MCAutoStringRef t_result;
-			MCAutoStringRef t_string;
-			/* UNCHECKED */ MCStringCreateWithCString(*t_utf8, &t_string);
-			t_environment -> Run(*t_string, &t_result);
+			t_environment -> Run(p_script, &t_result);
 			t_environment -> Release();
 
 			if (*t_result != nil)
 			{
-				MCAutoDataRef t_data;
-				MCAutoStringRef t_native;
-				MCDataCreateWithBytes((const byte_t*)MCStringGetCString(*t_result), MCStringGetLength(*t_result), &t_data);
-
-				MCStringDecode(*t_data, kMCStringEncodingUTF8, false, &t_native);
-				MCresult -> setvalueref(*t_native);
+				MCresult -> setvalueref(*t_result);
 			}
 			else
 				MCresult -> sets("execution error");

--- a/engine/src/sysspec-url.cpp
+++ b/engine/src/sysspec-url.cpp
@@ -556,7 +556,11 @@ static bool MCS_posturl_callback(void *p_context, MCSystemUrlStatus p_status, co
 	if (p_status == kMCSystemUrlStatusError)
     {
         MCAutoDataRef t_err;
-        MCDataCreateWithBytes((const byte_t *)MCStringGetCString((MCStringRef)p_data), MCStringGetLength((MCStringRef)p_data), &t_err);
+        if (!MCStringEncode(static_cast<MCStringRef>(const_cast<void*>(p_data)),
+                            kMCStringEncodingNative,
+                            false,
+                            &t_err))
+            return false;
 		MCValueAssign(context -> data, *t_err);
     }
 	else if (p_status == kMCSystemUrlStatusLoading)

--- a/engine/src/w32script.cpp
+++ b/engine/src/w32script.cpp
@@ -595,13 +595,9 @@ void MCWindowsActiveScriptEnvironment::Finalize(void)
 
 void MCWindowsActiveScriptEnvironment::Run(MCStringRef p_script, MCStringRef& r_out)
 {
-	LPOLESTR t_ole_script;
-	char *temp;
-	/* UNCHECKED */ MCStringConvertToCString(p_script, temp);
-	t_ole_script = ConvertUTF8ToOLESTR(temp);
-	delete temp;
-	if (t_ole_script == NULL)
-		return;
+    MCAutoStringRefAsWString t_script;
+    if (!t_script.Lock(p_script))
+        return;
 
 	EXCEPINFO t_exception = { 0 };
 
@@ -609,15 +605,14 @@ void MCWindowsActiveScriptEnvironment::Run(MCStringRef p_script, MCStringRef& r_
 	t_result = S_OK;
 
 	if (t_result == S_OK)
-		t_result = m_parser -> ParseScriptText(t_ole_script, NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISVISIBLE, NULL, &t_exception);
+		t_result = m_parser -> ParseScriptText(*t_script, NULL, NULL, NULL, 0, 0, SCRIPTTEXT_ISVISIBLE, NULL, &t_exception);
 
 	IDispatch *t_lang_dispatch;
 	t_lang_dispatch = NULL;
 	if (t_result == S_OK)
 		t_result = m_environment -> GetScriptDispatch(NULL, &t_lang_dispatch);
 
-	char *t_return_value;
-	t_return_value = NULL;
+    MCAutoStringRef t_return_value;
 	if (t_result == S_OK)
 	{
 		HRESULT t_var_result;
@@ -645,34 +640,27 @@ void MCWindowsActiveScriptEnvironment::Run(MCStringRef p_script, MCStringRef& r_
 				t_result = VariantChangeType(&t_function_result, &t_function_result, VARIANT_ALPHABOOL, VT_BSTR);
 				if (t_result == S_OK)
 				{
-					t_return_value = ConvertBSTRToUTF8(t_function_result . bstrVal);
-					if (t_return_value == NULL)
-						t_result = E_OUTOFMEMORY;
+                    if (!MCStringCreateWithBSTR(t_function_result . bstrVal,
+                                                &t_return_value))
+                        t_result = E_OUTOFMEMORY;
 				}
 				VariantClear(&t_function_result);
 			}
 		}
 		else
-			t_return_value = strdup("");
+			t_return_value = kMCEmptyString;
 	}
 
 
 	if (t_result != S_OK)
 	{
-		if (t_return_value != NULL)
-		{
-			delete t_return_value;
-			t_return_value = NULL;
-		}
+        t_return_value = kMCEmptyString;
 	}
 
 	if (t_lang_dispatch != NULL)
 		t_lang_dispatch -> Release();
 
-	if (t_ole_script != NULL)
-		delete t_ole_script;
-
-	/* UNCHECKED */ MCStringCreateWithCString(t_return_value, r_out);
+    r_out = t_return_value.Take();
 	return;
 }
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2145,6 +2145,11 @@ MC_DLLEXPORT bool MCStringCreateWithPascalString(const unsigned char* pascal_str
 MC_DLLEXPORT bool MCStringCreateWithSysString(const char *sys_string, MCStringRef &r_string);
 #endif
 
+#if defined(__WINDOWS__)
+// Create a string from a Windows BSTR
+MC_DLLEXPORT bool MCStringCreateWithBSTR(const BSTR p_bstr, MCStringRef& r_string);
+#endif
+
 // Creates a string from existing strings. The first variant exists to provide
 // an optimised implementation in the (very common) case of only two strings.
 MC_DLLEXPORT bool MCStringCreateWithStrings(MCStringRef& r_string, MCStringRef p_one, MCStringRef p_two);

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -6820,6 +6820,23 @@ __MCStringCreateWithStrings(MCStringRef& r_string, bool p_has_separator, unichar
     return t_success;
 }
 
+////////////////////////////////////////////////////////////////////////
+
+#if defined(__WINDOWS__)
+
+MC_DLLEXPORT_DEF bool
+MCStringCreateWithBSTR(const BSTR p_bstr,
+                       MCStringRef& r_string)
+{
+    return MCStringCreateWithChars(p_bstr,
+                                   SysStringLen(p_bstr),
+                                   r_string);
+}
+
+#endif /*__WINDOWS__*/
+
+////////////////////////////////////////////////////////////////////////
+
 MC_DLLEXPORT_DEF
 bool
 MCStringCreateWithStrings(MCStringRef& r_string, MCStringRef p_one, MCStringRef p_two)


### PR DESCRIPTION
`MCStringGetCString()` is problematic because it silently forces any string that it's called for to native representation, even if that results in data loss.

This patch refactors some hairy code that uses `MCStringGetCString()` unnecessarily.