### PR TITLE
Add build identifer to revbuild.h

### DIFF
--- a/engine/engine-common.gyp
+++ b/engine/engine-common.gyp
@@ -30,6 +30,7 @@
 					[
 						'<@(perl)',
 						'../util/encode_version.pl',
+						'-<(git_revision)',
 						'.',
 						'<(SHARED_INTERMEDIATE_DIR)',
 					],

--- a/engine/include/revbuild.h.in
+++ b/engine/include/revbuild.h.in
@@ -32,4 +32,5 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define MC_BUILD_FILE_SHORT_VERSION MC_BUILD_ENGINE_SHORT_VERSION
 #define MC_BUILD_FILE_LONG_VERSION MC_BUILD_ENGINE_LONG_VERSION
 
+#define MC_BUILD_IDENTIFIER "$BUILD_REVISION$GIT_REVISION"
 #endif

--- a/util/encode_version.pl
+++ b/util/encode_version.pl
@@ -9,8 +9,9 @@ sub trim
 	return $trimmed;
 }
 
-my $inputDir = $ARGV[0];
-my $outputDir = $ARGV[1];
+my $gitRevision = $ARGV[0];
+my $inputDir = $ARGV[1];
+my $outputDir = $ARGV[2];
 
 # Open the file containing the variables
 open VARIABLES, "<" . $inputDir . "/../version"
@@ -35,6 +36,8 @@ foreach $variable (@variables)
 	my $varValue = trim($parts[1]);
 	$output =~ s/\$${varName}/${varValue}/g;
 }
+
+$output =~ s/\$GIT_REVISION/${gitRevision}/g;
 
 # Create the output file
 open OUTPUT, ">" . $outputDir . "/include/revbuild.h"


### PR DESCRIPTION
This commit adds MC_BUILD_IDENTIFIER to revbuild.h as a
concatenation of the build number and commit hash.