### PR TITLE
[[ LCB ]] Make sure 'describe' field of ZStringUTF8 is nullptr

### DIFF
--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -333,6 +333,7 @@ extern "C" bool com_livecode_foreign_Initialize(void)
     d . hash = __cstring_hash;
     d . doimport = __nativecstring_import;
     d . doexport = __nativecstring_export;
+    d . describe = nullptr;
     if (!__build_typeinfo("com.livecode.foreign.NativeCString", &d, kMCNativeCStringTypeInfo))
         return false;
 
@@ -351,6 +352,7 @@ extern "C" bool com_livecode_foreign_Initialize(void)
 	d . hash = __wstring_hash;
 	d . doimport = __wstring_import;
 	d . doexport = __wstring_export;
+    d . describe = nullptr;
 	if (!__build_typeinfo("com.livecode.foreign.WString", &d, kMCWStringTypeInfo))
 		return false;
 
@@ -369,6 +371,7 @@ extern "C" bool com_livecode_foreign_Initialize(void)
 	d . hash = __cstring_hash;
 	d . doimport = __utf8string_import;
 	d . doexport = __utf8string_export;
+    d . describe = nullptr;
 	if (!__build_typeinfo("com.livecode.foreign.UTF8String", &d, kMCUTF8StringTypeInfo))
 		return false;
 	


### PR DESCRIPTION
This patch fixes a crash due to the 'describe' field in the foreign
descriptor for the ZString foreign types being uninitialized.