### PR TITLE
Switch MCSellist to use std::vector

### DIFF
--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -818,7 +818,7 @@ Boolean MCCard::mdown(uint2 which)
 				MCexitall = False;
 
 				if (!(MCmodifierstate & MS_SHIFT))
-					MCselected->clear(True);
+					MCselected.clear(True);
 				state |= CS_SIZE;
 				startx = MCmousex;
 				starty = MCmousey;
@@ -1037,7 +1037,7 @@ Boolean MCCard::doubleup(uint2 which)
 					editscript();
 				else
 				{
-					MCselected->replace(this);
+					MCselected.replace(this);
 					message_with_valueref_args(MCM_mouse_double_up, MCSTR("1"));
 				}
 				break;
@@ -2906,9 +2906,9 @@ void MCCard::updateselection(MCControl *cptr, const MCRectangle &oldrect,
 		if (is != was)
 		{
 			if (is)
-				MCselected->add(cptr);
+				MCselected.add(cptr);
 			else
-				MCselected->remove(cptr);
+				MCselected.remove(cptr);
 
 			drect = MCU_union_rect(drect, cptr->getrect());
 			

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1130,8 +1130,6 @@ Boolean MCCard::del(bool p_check_flag)
 	    return False;
 	
     clean();
-    
-	MCselected->remove(this);
 	
 	// MW-2008-10-31: [[ ParentScripts ]] Make sure we close the controls
 	closecontrols();

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -237,7 +237,7 @@ Boolean MCControl::mfocus(int2 x, int2 y)
 	{
 		mx = x;
 		my = y;
-		MCselected->continuemove(x, y);
+		MCselected.continuemove(x, y);
 		// MM-2012-09-05: [[ Property Listener ]] Moving object using IDE. Make sure location property is flagged as changed.
 		signallisteners(P_LOCATION);
 		message_with_args(MCM_mouse_move, x, y);
@@ -553,8 +553,8 @@ void MCControl::paste(void)
 	if (getstack()->gettool(this) == T_POINTER && opened)
 	{
 		state |= CS_SELECTED;
-		MCselected->clear(False);
-		MCselected->add(this);
+		MCselected.clear(False);
+		MCselected.add(this);
 		// MW-2011-08-18: [[ Layers ]] Invalidate the whole object.
 		layer_redrawall();
 	}
@@ -590,7 +590,7 @@ void MCControl::undo(Ustruct *us)
 			MCrelayergrouped = oldrlg;
 			Boolean oldlock = MClockmessages;
 			MClockmessages = True;
-			MCselected->add(this);
+			MCselected.add(this);
 			MClockmessages = oldlock;
 			MCscreen->delaymessage(this, MCM_selected_object_changed);
 			us->type = UT_REPLACE;
@@ -1230,20 +1230,20 @@ void MCControl::start(Boolean canclone)
 	if (!(state & CS_SELECTED))
 	{
 		if (MCmodifierstate & MS_SHIFT)
-			MCselected->add(this);
+			MCselected.add(this);
 		else
-			MCselected->replace(this);
+			MCselected.replace(this);
 	}
 	else
 	{
 		if (MCmodifierstate & MS_SHIFT && sizehandles(mx, my) == 0)
 		{
-			MCselected->remove(this);
+			MCselected.remove(this);
 			return;
 		}
 		else
 		{
-			MCselected->top(this);
+			MCselected.top(this);
 		}
 	}
 	if (MCbuttonstate == 0)
@@ -1263,8 +1263,8 @@ void MCControl::start(Boolean canclone)
 				Boolean noshift = IsMacLF()
 				                  ? !(MCmodifierstate & (MS_SHIFT | MS_CONTROL))
 				                  : !(MCmodifierstate & (MS_SHIFT | MS_MOD1));
-				MCselected->startmove(mx, my, canclone && hascontrol
-				                      && noshift && !(state & CS_SIZE));
+				MCselected.startmove(mx, my, canclone && hascontrol
+				                     && noshift && !(state & CS_SIZE));
 			}
 			else
 			{
@@ -1291,7 +1291,7 @@ void MCControl::end(bool p_send_mouse_up, bool p_release)
 	state &= ~(CS_MOVE | CS_SIZE | CS_CREATE);
 	if (oldstate & CS_MOVE)
 	{
-		if (MCselected->endmove())
+		if (MCselected.endmove())
 			message(MCM_move_control);
 	}
 	else if (oldstate & CS_CREATE)

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -2255,8 +2255,8 @@ bool MCDispatch::dopaste(MCObject*& r_objptr, bool p_explicit)
 
 		if (t_objects != NULL)
 		{
-			MCselected -> clear(False);
-			MCselected -> lockclear();
+			MCselected.clear(False);
+			MCselected.lockclear();
 
 			while(t_objects != NULL)
 			{
@@ -2273,7 +2273,7 @@ bool MCDispatch::dopaste(MCObject*& r_objptr, bool p_explicit)
 					r_objptr = t_object;
 			}
 
-			MCselected -> unlockclear();
+			MCselected.unlockclear();
 	
 			return true;
 		}

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -3242,9 +3242,9 @@ void MCObject::SetSelected(MCExecContext& ctxt, bool setting)
 	if (setting != ((state & CS_SELECTED) != 0))
 	{
 		if (setting)
-			MCselected->add(this);
+			MCselected.add(this);
 		else
-			MCselected->remove(this);
+			MCselected.remove(this);
 	}
 }
 

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1154,7 +1154,7 @@ void MCInterfaceEvalSelectedImage(MCExecContext& ctxt, MCStringRef& r_string)
 void MCInterfaceEvalSelectedObject(MCExecContext& ctxt, MCStringRef& r_string)
 {
 	MCAutoListRef t_list;
-	if (MCselected->getids(&t_list) && MCListCopyAsString(*t_list, r_string))
+	if (MCselected.getids(&t_list) && MCListCopyAsString(*t_list, r_string))
 		return;
 
 	ctxt.Throw();
@@ -1967,7 +1967,7 @@ void MCInterfaceExecUngroupSelection(MCExecContext& ctxt)
 	if (MCtopstackptr)
 	{
 		MCObject *t_group;
-		t_group = MCselected->getfirst();
+		t_group = MCselected.getfirst();
 		if (t_group == NULL || t_group->gettype() != CT_GROUP)
 		{
 			ctxt . LegacyThrow(EE_UNGROUP_NOTAGROUP);
@@ -2110,7 +2110,7 @@ void MCInterfaceExecGroupControls(MCExecContext& ctxt, MCObjectPtr *p_controls, 
 void MCInterfaceExecGroupSelection(MCExecContext& ctxt)
 {
 	MCGroup *t_group = nil;
-	if (MCselected->group(ctxt.GetLine(), ctxt.GetPos(), t_group) != ES_NORMAL)
+	if (MCselected.group(ctxt.GetLine(), ctxt.GetPos(), t_group) != ES_NORMAL)
 	{
 		ctxt.Throw();
 		return;
@@ -2294,7 +2294,7 @@ void MCInterfaceExecDelete(MCExecContext& ctxt)
 	else if (MCactiveimage)
 		MCactiveimage->delimage();	
 	else
-		MCselected->del();
+		MCselected.del();
 }
 
 void MCInterfaceExecDeleteObjects(MCExecContext& ctxt, MCObjectPtr *p_objects, uindex_t p_object_count)
@@ -2435,7 +2435,7 @@ void MCInterfaceExecUnhiliteChunkOfButton(MCExecContext& ctxt, MCObjectChunkPtr 
 
 void MCInterfaceExecSelectEmpty(MCExecContext& ctxt)
 {
-	MCselected->clear(True);
+	MCselected.clear(True);
 	if (MCactivefield)
 	{
 		MCactivefield->unselect(False, True);
@@ -2553,9 +2553,9 @@ static void MCInterfaceExecSelectObject(MCExecContext& ctxt, MCObjectPtr p_objec
 	}
 
 	if (p_first)
-		MCselected -> clear(False);
+		MCselected.clear(False);
 
-	MCselected -> add(p_object . object);
+	MCselected.add(p_object . object);
 }
 
 void MCInterfaceExecSelectObjects(MCExecContext& ctxt, MCObjectPtr *p_objects, uindex_t p_object_count)
@@ -4180,7 +4180,7 @@ void MCInterfaceExecExportSnapshotOfObjectToFile(MCExecContext& ctxt, MCObject *
 
 MCImage* MCInterfaceExecExportSelectImage(MCExecContext& ctxt)
 {
-	MCObject *optr = MCselected->getfirst();
+	MCObject *optr = MCselected.getfirst();
 	if (optr == nil)
 	{
 		MCCard *cardptr = MCdefaultstackptr->getchild(CT_THIS, kMCEmptyString, CT_CARD);

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -1991,7 +1991,7 @@ void MCInterfaceGetSelectionHandleColor(MCExecContext& ctxt, MCInterfaceNamedCol
 void MCInterfaceSetSelectionHandleColor(MCExecContext& ctxt, const MCInterfaceNamedColor& p_color)
 {
 	set_interface_color(MCselectioncolor, MCselectioncolorname, p_color);
-	MCselected->redraw();
+	MCselected.redraw();
 }
 
 void MCInterfaceGetWindowBoundingRect(MCExecContext& ctxt, MCRectangle& r_value)
@@ -2272,7 +2272,7 @@ void MCInterfaceEvalHomeStackAsObject(MCExecContext& ctxt, MCObjectPtr& r_object
 void MCInterfaceEvalSelectedObjectAsObject(MCExecContext& ctxt, MCObjectPtr& r_object)
 {
     MCObject *t_object;
-    t_object = MCselected -> getfirst();
+    t_object = MCselected.getfirst();
     
     if (t_object != nil)
     {

--- a/engine/src/exec-pasteboard.cpp
+++ b/engine/src/exec-pasteboard.cpp
@@ -1095,7 +1095,7 @@ void MCPasteboardExecCopy(MCExecContext& ctxt)
 	else if (MCactiveimage)
 		MCactiveimage -> copyimage();
 	else
-		MCselected -> copy();
+		MCselected.copy();
 }
 
 void MCPasteboardExecCopyTextToClipboard(MCExecContext& ctxt, MCObjectChunkPtr p_target)
@@ -1115,7 +1115,7 @@ void MCPasteboardExecCut(MCExecContext& ctxt)
 	else if (MCactiveimage)
 		MCactiveimage -> cutimage();
 	else
-		MCselected -> cut();
+		MCselected.cut();
 }
 
 void MCPasteboardExecCutTextToClipboard(MCExecContext& ctxt, MCObjectChunkPtr p_target)

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -257,7 +257,7 @@ MCObjectHandle MCdragtargetptr;
 uint2 MCdragdelta = 4;
 
 MCUndolist *MCundos;
-MCSellist *MCselected;
+MCSellist MCselected;
 MCStacklist *MCstacks;
 MCStacklist *MCtodestroy;
 MCCardlist *MCrecent;
@@ -646,7 +646,6 @@ void X_clear_globals(void)
 	MCdragtargetptr = nil;
 	MCdragdelta = 4;
 	MCundos = nil;
-	MCselected = nil;
 	MCstacks = nil;
     MCtodestroy = nil;
 	MCrecent = nil;
@@ -1155,7 +1154,6 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
     MCclipboardlockcount = 0;
 	
 	MCundos = new (nothrow) MCUndolist;
-	MCselected = new (nothrow) MCSellist;
 	MCstacks = new (nothrow) MCStacklist(true);
 	// IM-2016-11-22: [[ Bug 18852 ]] Changes to MCtodestroy shouldn't affect MCtopstack
     MCtodestroy = new (nothrow) MCStacklist(false);
@@ -1272,7 +1270,7 @@ int X_close(void)
 	MCInterfaceFinalize(ctxt);
 
 	MCstacks->closeall();
-	MCselected->clear(False);
+	MCselected.clear(False);
     MCundos->freestate();
     
 	MCU_play_stop();
@@ -1349,7 +1347,7 @@ int X_close(void)
 
 	delete MCtemplateimage;
 	delete MCtemplatefield;
-	delete MCselected;
+    MCselected.clear(False);
     delete MCtodestroy;
 	delete MCstacks;
     

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -179,7 +179,7 @@ extern uint4 MCrecursionlimit;
 
 extern Boolean MCownselection;
 extern MCUndolist *MCundos;
-extern MCSellist *MCselected;
+extern MCSellist MCselected;
 extern MCStacklist *MCstacks;
 extern MCStacklist *MCtodestroy;
 extern MCCardlist *MCrecent;

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -370,7 +370,7 @@ Boolean MCImage::mdown(uint2 which)
 					{
 						state &= ~CS_SIZE;
 						state |= CS_MOVE;
-						MCselected->startmove(mx, my, False);
+						MCselected.startmove(mx, my, False);
 					}
 				}
 				break;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -297,8 +297,6 @@ MCObject::~MCObject()
 
 	if (MCerrorptr == this)
 		MCerrorptr = nil;
-	if (state & CS_SELECTED)
-		MCselected->remove(this);
 	IO_freeobject(this);
 	MCundos->freeobject(this);
 	delete hlist;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -398,7 +398,7 @@ void MCObject::close()
 	unmapfont();
 
 	if (state & CS_SELECTED)
-		MCselected->remove(this);
+		MCselected.remove(this);
 
     // MM-2012-05-32: [[ Bug ]] Make sure the closed object is not the drag target or source.  
     //      Causes crash on drag drop if target object no longer exists.

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -438,8 +438,19 @@ public:
         return MCObjectProxy<U>::Handle(static_cast<MCObjectProxy<U>*>(m_proxy));
     }
 #endif
-    
-    
+
+    /* Swap the contents of two object handles. Allows std::swap() to be
+     * used on MCObjectHandle instances of exactly the same type. */
+    void swap(Handle& x_other)
+    {
+	    std::swap(m_proxy, x_other.m_proxy);
+    }
+
+    friend void swap(Handle& x_left, Handle& x_right)
+    {
+	    x_left.swap(x_right);
+    }
+
 private:
     
     // The proxy for the object this is a handle to

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -131,7 +131,7 @@ void MCSellist::Clean()
     /* Remove any dead objects from the selected list. */
     m_objects.erase(
          std::remove_if(m_objects.begin(), m_objects.end(),
-                        [](const MCSelnode& node) -> bool { return !node; }),
+                        [](const MCSelnode& node) { return bool{!node}; }),
          m_objects.end());
 }
 
@@ -230,11 +230,11 @@ void MCSellist::sort()
 
     std::transform(m_objects.begin(), m_objects.end(),
                    t_items.begin(),
-                   [&](const MCSelnode& t_node) -> SortNode {
+                   [&](const MCSelnode& t_node) {
                        uint2 t_num {};
                        t_card->count(CT_LAYER, CT_UNDEFINED,
                                      t_node, t_num, True);
-                       return {t_node.Get(), t_num};
+                       return SortNode{t_node.Get(), t_num};
                    });
     m_objects.clear();
 
@@ -572,8 +572,8 @@ void MCSellist::continuemove(int2 x, int2 y)
 
     auto t_first_valid =
         std::find_if(m_objects.begin(), m_objects.end(),
-                     [](const MCSelnode& p_node) -> bool {
-                         return p_node;
+                     [](const MCSelnode& p_node) {
+                         return bool{p_node};
                      });
     for (auto&& t_iter = t_first_valid;
          t_iter != std::end(m_objects);

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -140,12 +140,7 @@ void MCSellist::clear(Boolean message)
 	if (locked)
 		return;
     
-    const MCObjectHandle optr = [this]() -> MCObjectHandle {
-        if (m_objects.empty())
-            return {};
-        else
-            return m_objects.back();
-    }();
+    const MCObjectHandle optr = m_objects.empty() ? MCObjectHandle{} : m_objects.back();
 
     m_objects.clear();
     

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2003-2017 LiveCode Ltd.
 
 This file is part of LiveCode.
 
@@ -38,58 +38,71 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "globals.h"
 
+#include <algorithm>
+#include <type_traits>
 
-class MCSellist::MCSelnode : public MCDLlist
+/* ---------------------------------------------------------------- */
+
+MCSellist::MCSelnode::MCSelnode() : MCObjectHandle() {}
+
+/* When constructing an MCSelnode with an object, mark the
+ * object as internally selected. */
+MCSellist::MCSelnode::MCSelnode(MCObjectHandle object)
+    : MCObjectHandle(object)
 {
-public:
-    
-    MCSelnode(MCObjectHandle object);
-    ~MCSelnode();
-    
-    MCDLlistAdaptorFunctions(MCSelnode);
-    
-    MCObjectHandle m_ref;
-};
-
-
-MCSellist::MCSelnode::MCSelnode(MCObjectHandle object) :
-  m_ref(object)
-{
-	if (m_ref)
-		m_ref->select();
+    if (IsValid())
+        Get()->select();
 }
 
+/* Allow move construction of an MCSelnode.  The object's
+ * selection state becomes "owned" by the newly-constructed
+ * MCSelnode.  The old MCSelnode has its object reference
+ * stolen, so it won't deselect the object when it's
+ * destroyed. */
+MCSellist::MCSelnode::MCSelnode(MCSelnode&& other)
+    : MCObjectHandle(std::forward<MCObjectHandle>(other))
+{}
+
+/* Allow move assignment, but ensure that object selection
+ * status is managed correctly. */
+MCSellist::MCSelnode&
+MCSellist::MCSelnode::operator=(MCSelnode&& other) {
+    if (IsValid()) Get()->deselect();
+    MCObjectHandle::operator=(nullptr);
+    swap(other);
+    return *this;
+}
+
+/* When destroying an MCSelnode with an object, mark the
+   object as internally deselected. */
 MCSellist::MCSelnode::~MCSelnode()
 {
-	if (m_ref)
-		m_ref->deselect();
+    if (IsValid()) Get()->deselect();
 }
 
-MCSellist::MCSellist() :
-  m_owner(nil),
-  objects(nil),
-  curobject(nil),
-  startx(0), starty(0),
-  lastx(0), lasty(0),
-  locked(false),
-  dropclone(false)
+/* ---------------------------------------------------------------- */
+
+MCSellist::MCSellist()
 {
+    static_assert(std::is_move_constructible<MCSelnode>::value,
+                  "MCSelnode is not move constructible");
+    static_assert(std::is_move_assignable<MCSelnode>::value,
+                  "MCSelnode is not move assignable");
+
+    static_assert(!std::is_copy_assignable<MCSelnode>::value,
+                  "MCSelnode is copy assignable");
+    static_assert(!std::is_copy_constructible<MCSelnode>::value,
+                  "MCSelnode is copy constructible");
 }
 
 MCSellist::~MCSellist()
 {
-	clear(False);
 }
 
 MCObjectHandle MCSellist::getfirst()
 {
-	if (objects != nil)
-	{
-		curobject = objects;
-		return curobject->m_ref;
-	}
-	else
-		return nil;
+    if (m_objects.empty()) return {};
+    return m_objects.front();
 }
 
 bool MCSellist::getids(MCListRef& r_list)
@@ -98,49 +111,28 @@ bool MCSellist::getids(MCListRef& r_list)
 	if (!MCListCreateMutable('\n', &t_list))
 		return false;
 
-	if (objects != nil)
-	{
-		MCSelnode *tptr = objects;
-		do
-		{
-			MCAutoValueRef t_string;
-            if (tptr->m_ref)
-            {
-                if (!tptr->m_ref->names(P_LONG_ID, &t_string))
-                    return false;
-                if (!MCListAppend(*t_list, *t_string))
-                    return false;
-            }
-			tptr = tptr->next();
-		}
-		while (tptr != objects);
-	}
+    for (const auto& t_node : m_objects)
+    {
+        if (t_node)
+        {
+            MCAutoValueRef t_string;
+            if (!t_node->names(P_LONG_ID, &t_string))
+                return false;
+            if (!MCListAppend(*t_list, *t_string))
+                return false;
+        }
+    }
 
 	return MCListCopy(*t_list, r_list);
 }
 
 void MCSellist::Clean()
 {
-    if (objects == nil)
-        return;
-    
-    // Remove any dead objects from the selected list
-    MCSelnode* t_cursor = objects;
-    do
-    {
-        if (!t_cursor->m_ref)
-        {
-            MCSelnode* t_next = t_cursor->next();
-            t_cursor->remove(objects);
-            delete t_cursor;
-            t_cursor = t_next;
-        }
-        else
-        {
-            t_cursor = t_cursor->next();
-        }
-    }
-    while (t_cursor != objects);
+    /* Remove any dead objects from the selected list. */
+    m_objects.erase(
+         std::remove_if(m_objects.begin(), m_objects.end(),
+                        [](const MCSelnode& node) -> bool { return !node; }),
+         m_objects.end());
 }
 
 void MCSellist::clear(Boolean message)
@@ -148,13 +140,14 @@ void MCSellist::clear(Boolean message)
 	if (locked)
 		return;
     
-	MCObjectHandle optr = nil;
-	while (objects != nil)
-	{
-		MCSelnode *nodeptr = objects->remove(objects);
-		optr = nodeptr->m_ref;
-		delete nodeptr;
-	}
+    const MCObjectHandle optr = [this]() -> MCObjectHandle {
+        if (m_objects.empty())
+            return {};
+        else
+            return m_objects.back();
+    }();
+
+    m_objects.clear();
     
 	if (message && optr)
 		optr->message(MCM_selected_object_changed);
@@ -162,23 +155,14 @@ void MCSellist::clear(Boolean message)
 
 void MCSellist::top(MCObject *objptr)
 {
-	Clean();
-    
-    if (objects != nil)
-	{
-		MCSelnode *tptr = objects;
-		do
-		{
-			if (tptr->m_ref == objptr)
-			{
-				tptr->remove(objects);
-				break;
-			}
-			tptr = tptr->next();
-		}
-		while (tptr != objects);
-		tptr->insertto(objects);
-	}
+    /* Find the requested object, then rotate its entry to the front
+     * of the selected list. */
+    const auto t_found =
+        std::find(m_objects.begin(), m_objects.end(), objptr);
+    if (t_found != m_objects.end())
+    {
+        std::rotate(m_objects.begin(), t_found, t_found+1);
+    }
 }
 
 void MCSellist::replace(MCObject *objptr)
@@ -192,17 +176,16 @@ void MCSellist::add(MCObject *objptr, bool p_sendmessage)
     // Ensure that the top object in the list isn't dead as we need to check its
     // type before adding a new object
     Clean();
-    
-    if (objects != NULL && (objptr->getstack() != objects->m_ref->getstack()
-	                        || objects->m_ref->gettype() < CT_GROUP))
+
+    if (!m_objects.empty() &&
+        (objptr->getstack() != m_objects.front()->getstack() ||
+         m_objects.front()->gettype() < CT_GROUP))
 		clear(False);
     
 	if (MCactivefield)
 		MCactivefield->unselect(True, True);
     
-	MCSelnode *nodeptr = new (nothrow) MCSelnode(objptr->GetHandle());
-
-	nodeptr->appendto(objects);
+    /* UNCHECKED */ m_objects.emplace_back(objptr->GetHandle());
     
 	if (p_sendmessage)
 		objptr->message(MCM_selected_object_changed);
@@ -210,131 +193,103 @@ void MCSellist::add(MCObject *objptr, bool p_sendmessage)
 
 void MCSellist::remove(MCObject *objptr, bool p_sendmessage)
 {
-	if (objects != NULL)
-	{
-		MCSelnode *tptr = objects;
-		do
-		{
-			if (tptr->m_ref == objptr)
-			{
-				tptr->remove(objects);
-				if (p_sendmessage)
-					tptr->m_ref->message(MCM_selected_object_changed);
-				delete tptr;
-				return;
-			}
-			tptr = tptr->next();
-		}
-		while (tptr != objects);
-	}
+    /* MCSellist::remove() is called recursively via
+     * MCSellist::del(). MCSellist::del() deletes from the end of the
+     * selection towards the start, so in that case it's optimal to
+     * search from the end of the selection.  In the case where
+     * remove() is being called for an arbitrary selected object, it
+     * doesn't make any difference whether we're searching from the
+     * start or the end.*/
+    const auto&& t_found =
+        std::find(m_objects.rbegin(), m_objects.rend(), objptr);
+    if (t_found != m_objects.rend())
+    {
+        if (p_sendmessage)
+            (*t_found)->message(MCM_selected_object_changed);
+        m_objects.erase(t_found.base(), t_found.base()+1);
+    }
 }
 
 void MCSellist::sort()
 {
     // Remove all dead objects from the list before sorting
     Clean();
-    
-    MCSelnode *optr = objects;
-	MCAutoArray<MCSortnode> items;
-	uint4 nitems = 0;
-	MCCard *cptr = optr->m_ref->getcard();
-	do
-	{
-		items.Extend(nitems + 1);
-		items[nitems].data = (void *)optr;
-		uint2 num = 0;
-		cptr->count(CT_LAYER, CT_UNDEFINED, optr->m_ref, num, True);
-		/* UNCHECKED */ MCNumberCreateWithUnsignedInteger(num, items[nitems].nvalue);
-		nitems++;
-		optr = optr->next();
-	}
-	while (optr != objects);
-	if (nitems > 1)
-	{
-        extern void MCStringsSort(MCSortnode *p_items, uint4 nitems, Sort_type p_dir, Sort_type p_form, MCStringOptions p_options);
-		MCStringsSort(items.Ptr(), nitems, ST_ASCENDING, ST_NUMERIC, kMCStringOptionCompareExact);
-		uint4 i;
-		MCSelnode *newobjects = NULL;
-		for (i = 0 ; i < nitems ; i++)
-		{
-			optr = (MCSelnode *)items[i].data;
-			optr->remove(objects);
-			optr->appendto(newobjects);
-		}
-		objects = newobjects;
-	}
+
+    if (m_objects.size() < 2)
+        return;
+
+    /* Create a list of object handles with their layer numbers. We do
+     * this because computing the layer number is relatively
+     * expensive. */
+    struct SortNode
+    {
+        SortNode() = default;
+        SortNode(MCObject* o, uint2 n) : m_object(o), m_num(n) {}
+        MCObject *m_object {};
+        uint2 m_num {};
+        bool operator<(const SortNode other) const { return m_num < other.m_num; }
+    };
+
+    /* UNCHECKED */ std::vector<SortNode> t_items {m_objects.size()};
+    MCCard *t_card = m_objects.front()->getcard();
+
+    std::transform(m_objects.begin(), m_objects.end(),
+                   t_items.begin(),
+                   [&](const MCSelnode& t_node) -> SortNode {
+                       uint2 t_num {};
+                       t_card->count(CT_LAYER, CT_UNDEFINED,
+                                     t_node, t_num, True);
+                       return {t_node.Get(), t_num};
+                   });
+    m_objects.clear();
+
+    /* Sort the object handles by layer number */
+    std::sort(t_items.begin(), t_items.end());
+
+    /* Rebuild the selection in the appropriate order */
+    for (const auto& t_sorted : t_items)
+        m_objects.emplace_back(MCObjectHandle(t_sorted.m_object));
 }
 
 uint32_t MCSellist::count()
 {
-	uint32_t t_count = 0;
-	MCSelnode *t_node = objects;
-	if (t_node != nil)
-	{
-		do
-		{
-            // Only count non-zombie objects
-            if (t_node->m_ref)
-                t_count++;
-            
-			t_node = t_node->next();
-		} while (t_node != objects);
-	}
-
-	return t_count;
+    return std::count_if(m_objects.begin(), m_objects.end(),
+                         [](const MCSelnode& t_node) {
+                             return static_cast<bool>(t_node);
+                         });
 }
 
 MCControl *MCSellist::clone(MCObject *target)
 {
-    // Remove any dead objects before trying to clone them
-    Clean();
-    
-    MCObjectHandle *t_selobj_handles = nil;
-	uint32_t t_selobj_count;
-	t_selobj_count = count();
+    /* Remove any dead objects before trying to clone them & sort
+     * what's left */
+    sort();
 
-	/* UNCHECKED */ MCMemoryNewArrayInit(t_selobj_count, t_selobj_handles);
-	sort();
+    /* Work through the selection, replacing each selected object's
+     * entry with its clone. */
+    MCControlHandle t_newtarget;
+    std::transform(
+        m_objects.begin(), m_objects.end(), m_objects.begin(),
+        [&](const MCSelnode& t_node) {
+            MCControl* t_clone =
+                t_node.GetAs<MCControl>()->clone(True, OP_NONE, false);
+            if (t_node == target)
+                t_newtarget = t_clone;
+            /* Deselect the original object; select the
+             * clone. */
+            return MCSelnode{MCObjectHandle(t_clone)};
+        });
 
-	MCSelnode *t_node = objects;
-	for (uint32_t i = 0; i < t_selobj_count; i++)
-	{
-		t_selobj_handles[i] = t_node->m_ref->GetHandle();
-		t_node = t_node->next();
-	}
-
-	clear(false);
-
-	MCControlHandle t_newtarget = nil;
-	for (uint32_t i = 0; i < t_selobj_count; i++)
-	{
-		if (t_selobj_handles[i].IsValid())
-		{
-			MCControl *t_control = t_selobj_handles[i].GetAs<MCControl>();
-			MCControl *t_clone = t_control->clone(True, OP_NONE, false);
-			t_clone->select();
-			if (t_control == target)
-				t_newtarget = t_clone->GetHandle();
-			t_control->deselect();
-			add(t_clone, false);
-		}
-	}
-	
-	MCControl *t_result;
-	t_result = nil;
 	if (t_newtarget.IsValid())
 	{
         t_newtarget->message(MCM_selected_object_changed);
         
         // Note that t_newtarget->Get() can change while executing the above message
         // hence we re-evaluate here.
-        t_result = t_newtarget;
+        return t_newtarget;
 	}
-	
-	// MW-2010-05-06: Make sure we clean up the temp array
-	MCMemoryDeleteArray(t_selobj_handles, t_selobj_count);
 
-	return t_result;
+	return nullptr;
 }
 
 Exec_stat MCSellist::group(uint2 line, uint2 pos, MCGroup*& r_group_ptr)
@@ -343,16 +298,17 @@ Exec_stat MCSellist::group(uint2 line, uint2 pos, MCGroup*& r_group_ptr)
     Clean();
     
     MCresult->clear(False);
-	if (objects != nil && objects->m_ref->gettype() <= CT_LAST_CONTROL
-	        && objects->m_ref->gettype() >= CT_GROUP)
+    if (!m_objects.empty() &&
+        m_objects.front()->gettype() <= CT_LAST_CONTROL &&
+        m_objects.front()->gettype() >= CT_GROUP)
 	{
-		MCObject *parent = objects->m_ref->getparent();
-		MCSelnode *tptr = objects;
-		do
+        MCObject *parent = m_objects.front()->getparent();
+        for (const auto& t_node : m_objects)
 		{
 			// MERG-2013-05-07: [[ Bug 10863 ]] If grouping a shared group, throw
 			//   an error.
-            if (tptr->m_ref->gettype() == CT_GROUP && tptr->m_ref.GetAs<MCGroup>()->isshared())
+            if (t_node->gettype() == CT_GROUP &&
+                t_node.GetAs<MCGroup>()->isshared())
             {
                 MCeerror->add(EE_GROUP_NOBG, line, pos);
 				return ES_ERROR;
@@ -360,44 +316,45 @@ Exec_stat MCSellist::group(uint2 line, uint2 pos, MCGroup*& r_group_ptr)
 			
 			// MERG-2013-05-07: [[ Bug 10863 ]] If the parent of all the objects
 			//   isn't the same, throw an error.
-			if (tptr->m_ref->getparent() != parent)
+            if (t_node->getparent() != parent)
 			{
                 MCeerror->add(EE_GROUP_DIFFERENTPARENT, line, pos);
 				return ES_ERROR;
             }
-			
-			tptr = tptr->next();
 		}
-		while (tptr != objects);
         
 		sort();
 		MCControl *controls = NULL;
-		while (objects != NULL)
+        for (auto&& t_iter : m_objects)
 		{
-			tptr = objects->remove(objects);
-			MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
-			delete tptr;
-			if (parent->gettype() == CT_CARD)
+            /* Steal each object reference from the selected list */
+            MCSelnode t_node = std::move(t_iter);
+
+            auto cptr = t_node.GetAs<MCControl>();
+            if (parent->gettype() == CT_CARD)
 			{
-				MCCard *card = (MCCard *)parent;
+                auto card = MCObjectCast<MCCard>(parent);
 				card->removecontrol(cptr, False, True);
 				card->getstack()->removecontrol(cptr);
 			}
 			else
 			{
-				MCGroup *group = (MCGroup *)parent;
+                auto group = MCObjectCast<MCGroup>(parent);
 				group->removecontrol(cptr, True);
 			}
 			cptr->appendto(controls);
 		}
-		MCGroup *gptr;
+        m_objects.clear();
+
+		MCGroup *gptr = nullptr;
 		if (MCsavegroupptr == NULL)
 			gptr = (MCGroup *)MCtemplategroup->clone(False, OP_NONE, false);
 		else
 			gptr = (MCGroup *)MCsavegroupptr->remove(MCsavegroupptr);
 		gptr->makegroup(controls, parent);
 
-		objects = new (nothrow) MCSelnode(MCObjectHandle(gptr));
+        /* UNCHECKED */ m_objects.emplace_back(
+                            MCObjectCast<MCObject>(gptr)->GetHandle());
 		gptr->message(MCM_selected_object_changed);
 		
 		r_group_ptr = gptr;
@@ -415,116 +372,119 @@ bool MCSellist::clipboard(bool p_is_cut)
     // Remove any dead objects before trying to put them on the clipboard
     Clean();
     
-    if (objects != NULL)
-	{
-		// First we construct the pickle of the list of selected objects
-		MCPickleContext *t_context;
+    if (m_objects.empty())
+        return false;
+
+    // First we construct the pickle of the list of selected objects
+    MCPickleContext *t_context;
 		
-        // AL-2014-02-14: [[ UnicodeFileFormat ]] When pickling for the clipboard, make sure it
-        //   includes 2.7, 5.5 and 7.0 stackfile formats.
-		t_context = MCObject::startpickling(true);
+    // AL-2014-02-14: [[ UnicodeFileFormat ]] When pickling for the clipboard, make sure it
+    //   includes 2.7, 5.5 and 7.0 stackfile formats.
+    t_context = MCObject::startpickling(true);
 
-		MCSelnode *t_node;
-		t_node = objects;
+    // OK-2008-08-06: [[Bug 6794]] - If no objects were copied because the stack was password protected,
+    // then don't write anything to the clipboard. Otherwise the MCClipboard function returns "objects",
+    // yet the clipboardData["objects"] will be empty.
+    bool t_objects_were_copied;
+    t_objects_were_copied = false;
 
-		// OK-2008-08-06: [[Bug 6794]] - If no objects were copied because the stack was password protected,
-		// then don't write anything to the clipboard. Otherwise the MCClipboard function returns "objects",
-		// yet the clipboardData["objects"] will be empty.
-		bool t_objects_were_copied;
-		t_objects_were_copied = false;
+    for (const auto& t_node : m_objects)
+    {
+        if (!t_node -> getstack() -> iskeyed())
+            MCresult -> sets("can't cut object (stack is password protected)");
+        else
+        {
+            MCObject::continuepickling(t_context, t_node,
+                                       t_node -> getcard() -> getid());
+            t_objects_were_copied = true;
+        }
+    }
 
-		do
-		{
-			if (!t_node -> m_ref -> getstack() -> iskeyed())
-				MCresult -> sets("can't cut object (stack is password protected)");
-			else
-			{
-				MCObject::continuepickling(t_context, t_node -> m_ref, t_node -> m_ref -> getcard() -> getid());
-				t_objects_were_copied = true;
-			}
+    bool t_success;
+    t_success = true;
 
-			t_node = t_node -> next();
-		}
-		while(t_node != objects);
+    MCAutoDataRef t_pickle;
+    MCObject::stoppickling(t_context, &t_pickle);
+    if (*t_pickle == nil)
+        t_success = false;
 
-		bool t_success;
-		t_success = true;
-
-		MCAutoDataRef t_pickle;
-		MCObject::stoppickling(t_context, &t_pickle);
-		if (*t_pickle == nil)
-			t_success = false;
-
-		// OK-2008-08-06: [[Bug 6794]] - Return here before writing to the clipboard to preserve the message in the result.
-		if (!t_objects_were_copied)
-			return false;
+    // OK-2008-08-06: [[Bug 6794]] - Return here before writing to the clipboard to preserve the message in the result.
+    if (!t_objects_were_copied)
+        return false;
 
 		// Now attempt to write it to the clipboard
-        if (!MCclipboard->Lock())
-            return false;
+	if (!MCclipboard->Lock())
+		return false;
 
-        // Clear the current contents of the clipboard
-        MCclipboard->Clear();
+	// Clear the current contents of the clipboard
+	MCclipboard->Clear();
         
-        // Add the serialised objects to the clipboard
-        if (t_success)
-            t_success = MCclipboard->AddLiveCodeObjects(*t_pickle);
+    // Add the serialised objects to the clipboard
+    if (t_success)
+        t_success = MCclipboard->AddLiveCodeObjects(*t_pickle);
     
-		// If we are pasting just one object and it is an image, add it to the
-        // clipboard as an image, too, so that other applications can paste it.
-		if (t_success)
-			if (objects == objects -> next() && objects -> m_ref -> gettype() == CT_IMAGE)
-			{
-                // Failure to add the image to the clipboard is ignored as
-                // (while sub-optimal), the paste was mostly successful.
-                MCAutoDataRef t_data;
-                objects->m_ref.GetAs<MCImage>()->getclipboardtext(&t_data);
-				if (*t_data != nil)
-                    MCclipboard->AddImage(*t_data);
-			}
+    // If we are pasting just one object and it is an image, add it to the
+    // clipboard as an image, too, so that other applications can paste it.
+    if (t_success)
+        if (m_objects.size() == 1 &&
+            m_objects.front() -> gettype() == CT_IMAGE)
+        {
+            const MCSelnode& t_node = m_objects.front();
+            // Failure to add the image to the clipboard is ignored as
+            // (while sub-optimal), the paste was mostly successful.
+            MCAutoDataRef t_data;
+            t_node.GetAs<MCImage>()->getclipboardtext(&t_data);
+            if (*t_data != nil)
+                MCclipboard->AddImage(*t_data);
+        }
 		
-        // Ensure out changes to the clipboard get pushed out to the OS
-        MCclipboard->Unlock();
+    // Ensure out changes to the clipboard get pushed out to the OS
+    MCclipboard->Unlock();
 
-		// If we succeeded remove the objects if its a cut operation
-		if (t_success)
-		{
-			if (p_is_cut)
-			{
-				MCStack *sptr = objects->m_ref->getstack();
-				while (objects != NULL)
-				{
-					MCSelnode *tptr = objects->remove(objects);
-					
-					// MW-2008-06-12: [[ Bug 6466 ]] Make sure we don't still delete an
-					//   object if the stack is protected.
-					if (tptr -> m_ref -> getstack() -> iskeyed())
-					{
-                        // Because we need to manipulate the object after it has
-                        // been 'deleted', take a strong reference to the object
-                        // here
-                        MCObject* t_obj = tptr->m_ref;
+    // If we succeeded remove the objects if its a cut operation
+    if (t_success)
+    {
+        if (p_is_cut)
+        {
+            MCStack *sptr = m_objects.front()->getstack();
+            /* Because MCObject::del() will call MCSellist::remove(),
+             * iterate backwards over the list of objects, making sure
+             * that when MCObject::del() is called the object is at
+             * the end of the list of selected objects.  See also
+             * comments in MCSellist::del(). */
+            while (!m_objects.empty())
+            {
+                MCObjectHandle t_node = m_objects.back();
+
+                // MW-2008-06-12: [[ Bug 6466 ]] Make sure we don't still delete an
+                //   object if the stack is protected.
+                if (t_node && t_node -> getstack() -> iskeyed())
+                {
+                    // Because we need to manipulate the object after it has
+                    // been 'deleted', take a strong reference to the object
+                    // here
+                    MCObject* t_obj = t_node.Get();
                         
-                        if (t_obj->del(true))
-                        {
-                            if (t_obj->gettype() == CT_STACK)
-                                MCtodestroy -> remove(MCObjectCast<MCStack>(t_obj));
-							t_obj->scheduledelete();
-                        }
-					}
+                    if (t_obj->del(true))
+                    {
+                        if (t_obj->gettype() == CT_STACK)
+                            MCtodestroy -> remove(MCObjectCast<MCStack>(t_obj));
+                        t_obj->scheduledelete();
+                    }
+                }
+                /* If the object couldn't be deleted, deselect it
+                 * anyway. */
+                if (!m_objects.empty() && m_objects.back() == t_node)
+                    m_objects.pop_back();
+            }
+            m_objects.clear();
+            sptr->message(MCM_selected_object_changed);
+        }
+    }
+    else
+        MCresult -> sets("can't write to clipboard");
 
-					delete tptr;
-				}
-				sptr->message(MCM_selected_object_changed);
-			}
-		}
-		else
-			MCresult -> sets("can't write to clipboard");
-
-		return true;
-	}
-
-	return false;
+    return true;
 }
 
 Boolean MCSellist::copy()
@@ -539,35 +499,50 @@ Boolean MCSellist::cut()
 
 Boolean MCSellist::del()
 {
-    if (!IsDeletable())
-        return False;
- 
-	if (nullptr == objects)
+    if (!IsDeletable() || m_objects.empty())
         return False;
 
     MCundos->freestate();
-    
-    MCStack *sptr = objects->m_ref->getstack();
-    while (objects != NULL)
+
+    MCStack *sptr = m_objects.front()->getstack();
+    /* When we delete an object, it removes itself from the selection,
+     * by calling MCSellist::remove().  This not only mutates the
+     * selection, but sends a message that may cause code to run that
+     * further invalidates the selection.  To cope with this,
+     * repeatedly delete the last object in the selection (because
+     * removing objects from the end of the selection is cheap), until
+     * the selection is empty. */
+    /* TODO[2017-04-10] Find some way to prevent user code from
+     * turning this into an infinite loop.  At the moment, a stack can
+     * respond to a deletion-triggered "selected object changed"
+     * message by creating a new object on itself and selecting it, ad
+     * infinitum. */
+    while (!m_objects.empty())
     {
-        MCSelnode *tptr = objects->remove(objects);
-        if (tptr->m_ref->gettype() >= CT_GROUP)
+        /* Can't move the object out of the selected list here.  If
+         * the object isn't the last item in m_objects when
+         * MCObject::del() is called, MCSellist::remove() will have to
+         * scan the whole of m_objects rather than getting an
+         * immediate hit.  That would balloon the cost of
+         * MCSellist::del() from O(N) to O(N^2). */
+        MCObjectHandle t_node = m_objects.back();
+        if (t_node && t_node->gettype() >= CT_GROUP)
         {
-            MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
+            MCControl *cptr = t_node.GetAs<MCControl>();
             uint2 num = 0;
             cptr->getcard()->count(CT_LAYER, CT_UNDEFINED, cptr, num, True);
-            
-            Ustruct *us = new (nothrow) Ustruct;
+
+            /* UNCHECKED */ Ustruct *us = new (nothrow) Ustruct;
             us->type = UT_DELETE;
             us->ud.layer = num;
             MCundos->savestate(cptr, us);
-            
-            if (cptr->del(true))
-            {
-                tptr->m_ref = nil;
-            }
+
+            cptr->del(true);
         }
-        delete tptr;
+        /* Deselect non-deletable selected objects rather than
+         * deleting thme. */
+        if (!m_objects.empty() && m_objects.back() == t_node)
+            m_objects.pop_back();
     }
     sptr->message(MCM_selected_object_changed);
     return True;
@@ -575,29 +550,18 @@ Boolean MCSellist::del()
 
 bool MCSellist::IsDeletable()
 {
-    if (nullptr == objects)
-        return false;
-    
-    // Clear all deleted objects first
     Clean();
-
-    MCSelnode *t_object = objects;
-    do
-    {
-        if (!t_object->m_ref->isdeletable(true))
-            return false;
-        
-        t_object = t_object->next();
-    }
-    while (t_object != objects);
-
-    return true;
+    return
+        std::all_of(m_objects.begin(), m_objects.end(),
+                    [](const MCSelnode& t_node) {
+                        return t_node->isdeletable(true);
+                    });
 }
 
 void MCSellist::startmove(int2 x, int2 y, Boolean canclone)
 {
-	if (objects == NULL)
-		return;
+    if (m_objects.empty())
+        return;
 	dropclone = canclone;
 	lastx = startx = x;
 	lasty = starty = y;
@@ -605,24 +569,31 @@ void MCSellist::startmove(int2 x, int2 y, Boolean canclone)
 
 void MCSellist::continuemove(int2 x, int2 y)
 {
-	if (objects == NULL)
-		return;
+    if (m_objects.empty())
+        return;
 
-	MCSelnode *tptr = objects;
 	int2 dx = lastx - startx;
 	int2 dy = lasty - starty;
-	do
-	{
-		if (tptr->m_ref)
+
+    auto t_first_valid =
+        std::find_if(m_objects.begin(), m_objects.end(),
+                     [](const MCSelnode& p_node) -> bool {
+                         return p_node;
+                     });
+    for (auto&& t_iter = t_first_valid;
+         t_iter != std::end(m_objects);
+         ++t_iter)
+    {
+        if (*t_iter)
 		{
-			MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
+			MCControl *cptr = (*t_iter).GetAs<MCControl>();
 			MCRectangle trect = cptr->getrect();
 			MCRectangle t_startrect = trect;
 			t_startrect.x -= dx;
 			t_startrect.y -= dy;
 			trect.x = t_startrect.x + (x - startx);
 			trect.y = t_startrect.y + (y - starty);
-			if (tptr == objects)
+			if (t_iter == t_first_valid)
 			{
 				MCU_snap(trect.x);
 				MCU_snap(trect.y);
@@ -650,62 +621,48 @@ void MCSellist::continuemove(int2 x, int2 y)
 				cptr->resizeparent();
 			}
 		}
-		tptr = tptr->next();
 	}
-	while (tptr != objects);
 	lastx = x;
 	lasty = y;
 }
 
 Boolean MCSellist::endmove()
 {
-	if (objects == NULL)
-		return False;
+    if (m_objects.empty())
+        return False;
     
 	if (startx == lastx && starty == lasty)
 		return False;
     
 	MCundos->freestate();
-	MCSelnode *tptr = objects;
-	do
-	{
-		if (tptr->m_ref)
-		{
-			MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
-			Ustruct *us = new (nothrow) Ustruct;
-			us->type = UT_MOVE;
-			us->ud.deltas.x = lastx - startx;
-			us->ud.deltas.y = lasty - starty;
-			MCundos->savestate(cptr, us);
-		}
-		tptr = tptr->next();
-	}
-	while (tptr != objects);
+
+    for (const auto& t_node : m_objects)
+    {
+        if (t_node)
+        {
+            auto cptr = t_node.GetAs<MCControl>();
+            /* UNCHECKED */ auto us = new (nothrow) Ustruct;
+            us->type = UT_MOVE;
+            us->ud.deltas.x = lastx - startx;
+            us->ud.deltas.y = lasty - starty;
+            MCundos->savestate(cptr, us);
+        }
+    }
 	return True;
 }
 
 void MCSellist::redraw()
 {
-	if (objects == NULL)
-		return;
-
-	// MW-2011-08-19: [[ Layers ]] Invalidate each object.
-	MCSelnode *tptr = objects;
-	do
-	{
-		if (tptr->m_ref)
-		{
-			MCControl *cptr = tptr->m_ref.GetAs<MCControl>();
-
-			// MW-2012-09-19: [[ Bug 10182 ]] Cards and stacks can be in the list
-			//   so make sure we treat those differently from controls!
-			if (cptr -> gettype() <= CT_CARD)
-				cptr -> getstack() -> dirtyall();
-			else
-			cptr -> layer_redrawall();
-		}
-
-		tptr = tptr->next();
-	}
-	while (tptr != objects);
+    // MW-2011-08-19: [[ Layers ]] Invalidate each object.
+    for (const auto& t_node : m_objects)
+    {
+        if (t_node)
+        {
+            auto cptr = t_node.GetAs<MCControl>();
+            if (cptr -> gettype() <= CT_CARD)
+                cptr -> getstack() -> dirtyall();
+            else
+                cptr -> layer_redrawall();
+        }
+    }
 }

--- a/engine/src/sellst.h
+++ b/engine/src/sellst.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/*                                                             -*-c++-*-
+Copyright (C) 2003-2017 LiveCode Ltd.
 
 This file is part of LiveCode.
 
@@ -20,22 +21,42 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef	SELLIST_H
 #define	SELLIST_H
 
-#include "dllst.h"
 #include "stack.h"
+
+#include <vector>
 
 class MCSellist
 {
 private:
-    
-    class MCSelnode;
-    
-	MCStackHandle m_owner;
-	MCSelnode *objects;
-	MCSelnode *curobject;
-	int2 startx, starty;
-	int2 lastx, lasty;
-	Boolean locked;
-	Boolean dropclone;
+    /* This class represents an entry in the list of selected objects.
+     * Whether or not an object is considered selected is directly
+     * linked to the lifetime of its MCSelnode. While an object has a
+     * corresponding MCSelnode, it's selected; once the MCSelnode is
+     * destroyed, the object is no longer selected. */
+    class MCSelnode : public MCObjectHandle
+    {
+    public:
+	    MCSelnode();
+        MCSelnode(MCObjectHandle object);
+        MCSelnode(MCSelnode&& other);
+
+        MCSelnode& operator=(MCSelnode&& other);
+
+        ~MCSelnode();
+
+        /* Prevent copying an MCSelnode, because to do so would mean
+         * that multiple MCSelnode instances "own" the object's
+         * selection state. */
+        MCSelnode(const MCSelnode& other) = delete;
+        MCSelnode& operator=(const MCSelnode& other) = delete;
+    };
+
+    MCStackHandle m_owner = nullptr;
+    std::vector<MCSelnode> m_objects {};
+    int2 startx = 0, starty = 0;
+    int2 lastx = 0, lasty = 0;
+    bool locked = false;
+    bool dropclone = false;
     
     void Clean();
     bool IsDeletable();

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -924,7 +924,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 				return True;
 			}
 			else
-				return MCselected->cut();
+				return MCselected.cut();
         }
 
 		if (MCactiveimage)
@@ -932,7 +932,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 			MCactiveimage->delimage();
 			return True;
 		}
-		return MCselected->del();
+		return MCselected.del();
 	case XK_BackSpace:
 		if (MCmodifierstate & MS_MOD1)
 			return MCundos->undo();
@@ -941,7 +941,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 			MCactiveimage->delimage();
 			return True;
 		}
-		return MCselected->del();
+		return MCselected.del();
 	case XK_osfUndo:
 		return MCundos->undo();
 	case XK_osfCut:
@@ -951,7 +951,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 			return True;
 		}
 		else
-			return MCselected->cut();
+			return MCselected.cut();
 	case XK_osfCopy:
 		if (MCactiveimage)
 		{
@@ -959,7 +959,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 			return True;
 		}
 		else
-			return MCselected->copy();
+			return MCselected.copy();
 	case XK_osfPaste:
 		MCdefaultstackptr = MCtopstackptr;
 		return MCdispatcher -> dopaste(optr);
@@ -975,7 +975,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 				MCactiveimage->copyimage();
 				return True;
 			}
-		return MCselected->copy();
+		return MCselected.copy();
 	case XK_Left:
 		if (mode >= WM_PULLDOWN || !MCnavigationarrows)
 			return False;
@@ -1034,7 +1034,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 				MCactiveimage->copyimage();
 				return True;
 			}
-			return MCselected->copy();
+			return MCselected.copy();
 		case XK_V:
 		case XK_v:
 			MCdefaultstackptr = MCtopstackptr;
@@ -1048,7 +1048,7 @@ Boolean MCStack::kdown(MCStringRef p_string, KeySym key)
 				MCactiveimage->cutimage();
 				return True;
 			}
-			return MCselected->cut();
+			return MCselected.cut();
 		case XK_Z:
 		case XK_z:
 			return MCundos->undo();

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -786,7 +786,7 @@ void MCStack::clearbackground()
 
 void MCStack::ungroup(MCGroup *source)
 {
-	MCselected->clear(True);
+	MCselected.clear(True);
 	MCControl *clist = source->getcontrols();
 	if (!curcard->removecontrol(source, False, True))
 		return;
@@ -806,7 +806,7 @@ void MCStack::ungroup(MCGroup *source)
 				tptr->setid(newid());
 			}
 			curcard->newcontrol(tptr, False);
-			MCselected->add(tptr);
+			MCselected.add(tptr);
 			tptr = tptr->next();
 		}
 		while (tptr != clist);
@@ -835,7 +835,7 @@ void MCStack::startedit(MCGroup *group)
 		stopedit();
 	else
 	{
-		MCselected->clear(True);
+		MCselected.clear(True);
 		kunfocus();
 	}
 	curcard->close();
@@ -889,7 +889,7 @@ void MCStack::stopedit()
 {
 	if (editing == NULL)
 		return;
-	MCselected->clear(True);
+	MCselected.clear(True);
 	curcard->close();
 	MCObjptr *clist = curcard->getrefs();
 	MCControl *oldcontrols = controls;
@@ -924,7 +924,7 @@ void MCStack::stopedit()
 	kfocus();
 	dirtywindowname();
 	if (gettool(this) == T_POINTER)
-		MCselected->add(oldediting);
+		MCselected.add(oldediting);
 }
 
 void MCStack::updatemenubar()

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -162,7 +162,7 @@ void MCU_resetprops(Boolean update)
 		if (MCdragging)
 		{
 			MCdragging = False;
-			MCselected->redraw();
+			MCselected.redraw();
 		}
 	}
 	MCerrorlock.Reset();
@@ -1858,7 +1858,7 @@ void MCU_choose_tool(MCExecContext& ctxt, MCStringRef p_input, Tool p_tool)
 
 	MCundos->freestate();
 	if (MCcurtool != T_POINTER)
-		MCselected->clear(True);
+		MCselected.clear(True);
 	if (MCactiveimage && MCcurtool != T_SELECT)
 		MCactiveimage->endsel();
 	MCeditingimage = nil;


### PR DESCRIPTION
This patch refactors `MCSellist` around `std::vector`.  Currently,
modern C++ practitioners recommend using `std::vector` over
`std::list`, and it's been suggested that there are very few
circumstances in which `std::vector` doesn't give better performance
due to improved cache locality.

This patch has several aspects that are worth noting:

- `MCSellist::MCSelnode` is an class that ensures that the extent of
  its target object's internal "selected" state exactly matches the
  lifetime of the `MCSelnode`.  This is achieved by using a move-only
  subclass of `MCObjectHandle`.  It would be possible to encapsulate
  an `MCObjectHandle` instead, but it's really convenient to have
  access to all of the methods defined on `MCObjectHandle` when
  working with selection nodes.

- We have to declare `m_objects` as a member variable of type
  `std::vector<MCSelnode>`, and that requires `MCSelnode` to be a
  complete type -- so the class definition has to be moved to the
  header file.  However, putting the implementations of all of the
  methods of `MCSelnode` into the source file keeps the compile-time
  cost of including the header down.

- We want to ensure that code that uses an `MCSellist` doesn't try to
  generate duplicate constructors/destructors for the `m_objects`
  vector.  To prevent that, we define empty constructors & destructors
  in the source file.  The body of the constructor is a great place to
  put `static_assert()` statements that check that `MCSelnode` is
  move-only.

- In general, the refactoring tries to use `<algorithm>` rather than
  hand writing collection operations.  A great example is
  `MCSellist::Clean()`, which can be reduced to two STL function calls
  and a trivial lambda expression.

- Using `std::vector` allows every `MCSelnode` instance to live either
  directly in the vector's underlying array, or on the stack.  There
  are no `MCSelnode` pointers used at all.  They are handled by value
  (on the stack) or by reference/const reference.
  `std::vector::emplace_back()` is a really important part of this: it
  allows the list to be expanded and an `MCSelnode` to be constructed
  directly in-place in a single operation.

- `MCSellist::clone()` has been optimised to update the selection
  in-place, by replacing each control's entry in the list with its
  clone.

- There's quite a lot of `auto` in this patch.  Iterator types are not
  generally conveniently writable.  The recommended way to write the
  loop variable in a range-based `for` is either `const auto&` when
  the loop variable shouldn't be mutable, and `auto&&` otherwise.

- ~~Because of the relationship between `MCSellist::del()` and
  `MCSellist::remove()`, there's some very careful semantics to ensure
  that `MCSellist::del()` doesn't end up being O(N^2) in the number of
  selected objects; specifically, both `MCSellist::del()` and
  `MCSellist::remove()` work backwards over the list of selected
  objects.~~