### PR TITLE
C++ style guide updates: lambdas and ternary ops

### DIFF
--- a/docs/development/C++-style.md
+++ b/docs/development/C++-style.md
@@ -182,6 +182,13 @@ See also [C++ Feature Usage Guidelines for LiveCode](C++-features.md).
 * Avoid using the ternary `/*condition*/ ? /*if_true*/ : /*if_false*/`
   operator.
 
+* When writing lambda expressions, try to avoid return type
+  specification; use inference or, if necessary, cast or construct a
+  value in the `return` statement.
+
+      auto t_valid_handle =
+          [](const ObjectHandle& p_obj) { return bool{p_obj}; }
+
 ## Code layout, indentation and whitespace
 
 * Use spaces for indentation and alignment, with 4 spaces per level of

--- a/docs/development/C++-style.md
+++ b/docs/development/C++-style.md
@@ -180,7 +180,21 @@ See also [C++ Feature Usage Guidelines for LiveCode](C++-features.md).
   functions or templates instead.
 
 * Avoid using the ternary `/*condition*/ ? /*if_true*/ : /*if_false*/`
-  operator.
+  operator.  You may need to use one when initialising a `const`
+  value.  However, when the condition or the true/false values require
+  large expressions, or when there are more than two possible values,
+  an immediately-invoked function expression can do the job more
+  clearly:
+
+      const auto&& t_value = [&, this]() {
+          if (/*condition*/)
+          {
+              return /* compute value if true */;
+          }
+          else
+          {
+              return /* compute value if false */;
+          })();
 
 * When writing lambda expressions, try to avoid return type
   specification; use inference or, if necessary, cast or construct a


### PR DESCRIPTION
This patch makes two small changes to the C++ coding style guide:

1. For initialisation of const variables, which cannot be assigned after initialisation, it's often helpful to use a ternary expression:

   ```c++
   const MCObjectHandle t_found = m_values.empty() ? nullptr : m_values.front();
   ```

   The only other ways to do this are by moving the conditional initialisation expression into its own function or method, or to use an Immediately-Invoked Function Expression (IIFE). IIFE isn't much more attractive, but it's still _much_ better than a really complex ternary expression with more than two options.

   ```c++
   const MCObjectHandle t_found = [this] {
           if (m_values.empty())
               return MCObjectHandle{};
           else
               return m_values.front();
       }();
   ```

2. C++ lambda expressions can optionally specify a return type in trailing return type syntax.  However, every compiler we use is capable of inferring the return type from `return` statements and warning about any inconsistencies.  It's probably better not to use explicit return type declaration for lambda expressions, and allow inference from `return` statements, adding casts or conversions as necessary.