### PR TITLE
[[ Win32 ]] Use MSVS 2017 to build windows

### DIFF
--- a/buildbot.py
+++ b/buildbot.py
@@ -183,7 +183,7 @@ class UniqueMspdbsrv(object):
         os.environ['_MSPDBSRV_ENDPOINT_'] = str(uuid.uuid4())
 
         mspdbsrv_exe = os.path.join(config.get_program_files_x86(),
-            'Microsoft Visual Studio 10.0\\Common7\\IDE\\mspdbsrv.exe')
+            'Microsoft Visual Studio\\2017\\BuildTools\\VC\\Tools\\MSVC\\14.10.25017\\bin\\HostX86\\x86\\mspdbsrv.exe')
         args = [mspdbsrv_exe, '-start', '-shutdowntime', '-1']
         print(' '.join(args))
         self.proc = subprocess.Popen(args, close_fds=True)

--- a/config.py
+++ b/config.py
@@ -346,6 +346,8 @@ def validate_windows_tools(opts):
         opts['QUICKTIME_SDK'] = guess_quicktime_sdk()
 
     if opts['WIN_MSVS_VERSION'] is None:
+    	# TODO [2017-04-11]: This should be 2017, but it is not 
+    	# compatible with our gyp as is.
         opts['WIN_MSVS_VERSION'] = '2015'
 
 ################################################################

--- a/config/win32.gypi
+++ b/config/win32.gypi
@@ -28,6 +28,11 @@
 		# Don't assume a Cygwin environment when invoking actions
 		'msvs_cygwin_shell': 0,
 		
+		# TODO [2017-04-11]: Remove these overrides when we can use 	
+		# -Gmsvs_version=2017
+		"msvs_target_platform_version" : "10.0.14393.0",
+		"msbuild_toolset" : "v141",
+		
 		'configurations':
 		{
 			'Debug':

--- a/make.cmd
+++ b/make.cmd
@@ -29,9 +29,9 @@ if /I "%BUILD_PLATFORM%"=="win-x86" (
     @set MSBUILD_PLATFORM=Win32
 )
 
-@rem Try to build with VS 2015 build tools by default
-if not defined VSINSTALLDIR set VSINSTALLDIR=%ProgramFilesBase%\Microsoft Visual Studio 14.0\
-call "%VSINSTALLDIR%VC\vcvarsall.bat" %VSCMD_ARG_TGT_ARCH%
+@rem Try to build with VS 2017 build tools by default
+if not defined VSINSTALLDIR set VSINSTALLDIR=%ProgramFilesBase%\Microsoft Visual Studio\2017\BuildTools\
+call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" %VSCMD_ARG_TGT_ARCH%
 
 @if "%1" NEQ "" set MSBUILD_TARGET_ARG=/t:%1
 

--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -16,7 +16,7 @@ LIBS_linux=( OpenSSL Curl ICU CEF )
 LIBS_emscripten=( ICU )
 
 SUBPLATFORMS_ios=(iPhoneSimulator8.2 iPhoneSimulator9.2 iPhoneSimulator10.2 iPhoneOS9.2 iPhoneOS10.2)
-SUBPLATFORMS_win32=(v140_static_debug v140_static_release)
+SUBPLATFORMS_win32=(v141_static_debug v141_static_release)
 
 # Fetch settings
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
This patch works around gyp issues with MSVS 2017 by continuing to
use `-Gmsvs_version=2015` but overriding the `msvs_target_platform_version`
and `msbuild_toolset` variables.