### PR TITLE
[[ Bug 19593 ]] Ensure 'type' works correctly for accented chars

### DIFF
--- a/docs/notes/bugfix-19593.md
+++ b/docs/notes/bugfix-19593.md
@@ -1,9 +1,9 @@
 # Type should work with accented characters
 
-Type type command now handles Unicode characters in a manner
-consistent with normal keyboard entry. If a unicode character
+The `type` command now handles Unicode characters in a manner
+consistent with normal keyboard entry. If a Unicode character
 is typed and it has a native mapping, then it is propagated as
 a keypress with the keycode being the code of the character. If
 it has no native mapping, it is propagated with keycode equal
-to the unicode codepoint with bit 22 set to 1. In either case
+to the Unicode codepoint with bit 22 set to 1. In either case
 the string value of the keypress is the Unicode codepoint.

--- a/docs/notes/bugfix-19593.md
+++ b/docs/notes/bugfix-19593.md
@@ -1,0 +1,9 @@
+# Type should work with accented characters
+
+Type type command now handles Unicode characters in a manner
+consistent with normal keyboard entry. If a unicode character
+is typed and it has a native mapping, then it is propagated as
+a keypress with the keycode being the code of the character. If
+it has no native mapping, it is propagated with keycode equal
+to the unicode codepoint with bit 22 set to 1. In either case
+the string value of the keypress is the Unicode codepoint.

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1757,10 +1757,23 @@ void MCInterfaceExecType(MCExecContext& ctxt, MCStringRef p_typing, uint2 p_modi
 			keysym |= 0xFF00;
 			t_string = kMCEmptyString;
 		}
-		else if (keysym > 0x7F)
-			keysym |= XK_Class_codepoint;
 		else
         {
+            /* If the character is in the BMP *and* it has a native mapping then
+             * we use the mapped native char as the keycode. This makes things
+             * consistent with normal keyboard entry. Any non-native unicode char
+             * will pass through with a keycode with the XK_Class_codepoint bit
+             * set. */
+            unichar_t t_bmp_codepoint = t_cp_char & 0xFFFF;
+            char_t t_native_char = 0;
+            if (t_cp_char <= 0xFFFF &&
+                MCUnicodeMapToNative(&t_bmp_codepoint, 1, t_native_char))
+            {
+                keysym = t_native_char;
+            }
+            else if (keysym > 0x7F)
+                keysym |= XK_Class_codepoint;
+		
             MCStringCopySubstring(p_typing, MCRangeMake(i, t_cp_length), &t_char);
 			t_string = *t_char;
         }

--- a/tests/lcs/core/interface/type.livecodescript
+++ b/tests/lcs/core/interface/type.livecodescript
@@ -1,0 +1,51 @@
+script "CoreType"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestType
+	create stack "Test"
+	set the defaultStack to "Test"
+	set the script of stack "Test" to \
+		"on rawKeyDown pKeyCode; set the uKeyCode of me to pKeyCode; pass rawKeyDown; end rawKeyDown" & return & \
+		"on keyDown pChar; set the uChar of me to pChar pass keyDown; end keyDown"
+	TestAssert "stack script compiled okay", the result is empty
+
+	type "a"
+	TestAssert "type ascii char 'a' maps correctly", \
+			the uKeyCode of stack "Test" is charToNum("a") and \
+			the uChar of stack "Test" is "a"
+
+	type "A"
+	TestAssert "type ascii char 'A' maps correctly", \
+			the uKeyCode of stack "Test" is charToNum("A") and \
+			the uChar of stack "Test" is "A"
+
+	type numToCodepoint(0x00E9) -- code for lower case E-acute
+	TestAssert "type native char" && numToCodepoint(0x00E9) && "maps correctly", \
+			the uKeyCode of stack "Test" is charToNum(numToCodepoint(0x00E9)) and \
+			the uChar of stack "Test" is numToCodepoint(0x00E9)
+
+	type numToCodepoint(0x431) -- code for Cyrillic Be
+	TestAssert "type bmp char" && numToCodepoint(0x431) && "maps correctly", \
+			the uKeyCode of stack "Test" is (0x431 bitOr 2^24) and \
+			the uChar of stack "Test" is numToCodepoint(0x431) 
+
+	type numToCodepoint(0x1D110) -- code for music fermata
+	TestAssert "type smp char" && numToCodepoint(0x1D110) && "maps correctly", \
+			the uKeyCode of stack "Test" is (0x1D110 bitOr 2^24) and \
+			the uChar of stack "Test" is numToCodepoint(0x1D110) 
+end TestType


### PR DESCRIPTION
This patch ensure that the 'type' command uses the same logic as
normal keyboard entry. If a typed char is mappable to native, then
its keycode is the native code for the char; otherwise the keycode
is the unicode codepoint value with bit 24 set. In both cases, the
key string is the unicode character.