### PR TITLE
[[ System ]] Fix SetTheContentsOfFile on Win32

### DIFF
--- a/libfoundation/src/system-file-w32.cpp
+++ b/libfoundation/src/system-file-w32.cpp
@@ -267,7 +267,7 @@ __MCSFileSetContents (MCStringRef p_native_path,
 
 	/* FIXME Possibly inefficient */
 	MCStreamRef t_stream = NULL;
-	if (!__MCSFileCreateStream (*t_temp_native_path, kMCSFileOpenModeRead,
+	if (!__MCSFileCreateStream (*t_temp_native_path, kMCSFileOpenModeWrite,
 	                            t_stream))
 		goto error_cleanup;
 


### PR DESCRIPTION
This patch corrects the open mode used to create the stream in
MCSFileSetContents.