### PR TITLE
libfoundation: Add a new MCValueLog() utility function

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1507,6 +1507,11 @@ MC_DLLEXPORT bool MCValueInterAndRelease(MCValueRef value, MCValueRef& r_unique_
 // Fetch the 'extra bytes' field for the given custom value.
 inline void *MCValueGetExtraBytesPtr(MCValueRef value) { return ((uint8_t *)value) + kMCValueCustomHeaderSize; }
 
+#if defined(_DEBUG)
+// Emit a debug log message containing the description of the value
+MC_DLLEXPORT void MCValueLog(MCValueRef);
+#endif
+
 //////////
 
 }

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -36,21 +36,25 @@ void __MCAssert(const char *p_file, uint32_t p_line, const char *p_message)
 	_CrtDbgReport(_CRT_ASSERT, p_file, p_line, NULL, "%s", p_message);
 }
 
+static void MCLogV(const char *p_file,
+                     uint32_t p_line,
+                     const char *p_format,
+                     va_list p_format_args)
+{
+    MCAutoStringRef t_message, t_string;
+    MCAutoStringRefAsWString t_wstring;
+    /* UNCHECKED */ MCStringFormatV(&t_message, p_format, p_format_args);
+    /* UNCHECKED */ MCStringFormat(&t_string, "[%u] %@\n",
+                                   GetCurrentProcessId(), *t_message);
+    /* UNCHECKED */ t_wstring.Lock(*t_string);
+    _CrtDbgReportW(_CRT_WARN, p_file, p_line, NULL, *t_wstring);
+}
+
 void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
 {
-	MCAutoStringRef t_string;
-	
-	va_list t_args;
 	va_start(t_args, p_format);
-	MCStringFormatV(&t_string, p_format, t_args);
+    MCLogV(p_file, p_line, p_format, t_args);
 	va_end(t_args);
-
-	char *t_cstring;
-	if (MCStringConvertToCString(*t_string, t_cstring))
-	{
-		_CrtDbgReport(_CRT_WARN, p_file, p_line, NULL, "[%u] %s\n", GetCurrentProcessId(), t_cstring);
-		MCMemoryDeallocate(t_cstring);
-	}
 }
 
 void __MCLogWithTrace(const char *p_file, uint32_t p_line, const char *p_format, ...)
@@ -77,20 +81,10 @@ void __MCLogWithTrace(const char *p_file, uint32_t p_line, const char *p_format,
 			s_sym_setoptions(SYMOPT_LOAD_LINES);
 		}
 	}
-	
-	MCAutoStringRef t_string;
-	
-	va_list t_args;
-	va_start(t_args, p_format);
-	MCStringFormatV(&t_string, p_format, t_args);
-	va_end(t_args);
-	
-	char *t_cstring;
-	if (MCStringConvertToCString(*t_string, t_cstring))
-	{
-		_CrtDbgReport(_CRT_WARN, p_file, p_line, NULL, "[%u] %s\n", GetCurrentProcessId(), t_cstring);
-		MCMemoryDeallocate(t_cstring);
-	}
+
+    va_start(t_args, p_format);
+    MCLogV(p_file, p_line, p_format, t_args);
+    va_end(t_args);
 
 	if (s_sym_from_addr != nil)
 	{

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -209,26 +209,31 @@ void __MCAssert(const char *p_file, uint32_t p_line, const char *p_message)
     abort();
 }
 
-void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
+static void MCLogV(const char *p_file, uint32_t p_line,
+                   const char *p_format, va_list p_args)
 {
 	MCAutoStringRef t_string;
-	
-	va_list t_args;
-	va_start(t_args, p_format);
-	MCStringFormatV(&t_string, p_format, t_args);
-	va_end(t_args);
-	
-	char *t_cstring;
-	if (MCStringConvertToCString(*t_string, t_cstring))
-	{
-		fprintf(stderr, "%s\n", t_cstring);
-		MCMemoryDeallocate(t_cstring);
-	}
+    /* UNCHECKED */ MCStringFormatV(&t_string, p_format, p_args);
+
+    MCAutoStringRefAsSysString t_string_sys;
+    /* UNCHECKED */ t_string_sys.Lock(*t_string);
+    fprintf(stderr, "%s\n", *t_string_sys);
+}
+
+void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
+{
+    va_list t_args;
+    va_start(t_args, p_format);
+    MCLogV(p_file, p_line, p_format);
+    va_end(t_args);
 }
 
 void __MCLogWithTrace(const char *p_file, uint32_t p_line, const char *p_format, ...)
 {
-	__MCLog(p_file, p_line, p_format);
+    va_list t_args;
+    va_start(t_args, p_format);
+    MCLogV(p_file, p_line, p_format);
+    va_end(t_args);
 }
 
 #endif

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -190,7 +190,8 @@ void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
 
 void __MCUnreachable(void)
 {
-	fprintf(stderr, "**** UNREACHABLE CODE EXECUTED ****\n");
+    __android_log_print(ANDROID_LOG_ERROR, "revandroid",
+                        "**** UNREACHABLE CODE EXECUTED ****");
 	abort();
 }
 

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -133,38 +133,31 @@ void __MCAssert(const char *p_file, uint32_t p_line, const char *p_message)
     abort();
 }
 
-void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
+static void MCLogV(const char *p_file, uint32_t p_line,
+                   const char *p_format, va_list p_args)
 {
 	MCAutoStringRef t_string;
-	
-	va_list t_args;
-	va_start(t_args, p_format);
-	MCStringFormatV(&t_string, p_format, t_args);
-	va_end(t_args);
-	
-	char *t_cstring;
-	if (MCStringConvertToCString(*t_string, t_cstring))
-	{
-		fprintf(stderr, "[%d] %s\n", getpid(), t_cstring);
-		MCMemoryDeallocate(t_cstring);
-	}
+    /* UNCHECKED */ MCStringFormatV(&t_string, p_format, p_args);
+
+    MCAutoStringRefAsSysString t_string_sys;
+    /* UNCHECKED */ t_string_sys.Lock(*t_string);
+    fprintf(stderr, "[%d] %s\n", getpid(), *t_string_sys);
+}
+
+void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
+{
+    va_list t_args;
+    va_start(t_args, p_format);
+    MCLogV(p_file, p_line, p_format, t_args);
+    va_end(t_args);
 }
 
 void __MCLogWithTrace(const char *p_file, uint32_t p_line, const char *p_format, ...)
 {
-	MCAutoStringRef t_string;
-	
-	va_list t_args;
-	va_start(t_args, p_format);
-	MCStringFormatV(&t_string, p_format, t_args);
-	va_end(t_args);
-	
-	char *t_cstring;
-	if (MCStringConvertToCString(*t_string, t_cstring))
-	{
-		fprintf(stderr, "[%d] %s\n", getpid(), t_cstring);
-		MCMemoryDeallocate(t_cstring);
-	}
+    va_list t_args;
+    va_start(t_args, p_format);
+    MCLogV(p_file, p_line, p_format, t_args);
+    va_end(t_args);
 }
 
 #elif defined(TARGET_SUBPLATFORM_ANDROID)

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -180,15 +180,12 @@ void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
 
     va_list t_args;
     va_start(t_args, p_format);
-    MCStringFormatV(&t_string, p_format, t_args);
+    /* UNCHECKED */ MCStringFormatV(&t_string, p_format, t_args);
     va_end(t_args);
-	
-	char *t_cstring;
-	if (MCStringConvertToCString(*t_string, t_cstring))
-	{
-		__android_log_print(ANDROID_LOG_INFO, "revandroid", "%s", t_cstring);
-		MCMemoryDeallocate(t_cstring);
-    }
+
+    MCAutoStringRefAsSysString t_string_sys;
+    /* UNCHECKED */ t_string_sys.Lock(*t_string);
+    __android_log_print(ANDROID_LOG_INFO, "revandroid", "%s", *t_string_sys);
 }
 
 void __MCUnreachable(void)

--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <foundation.h>
+#include <foundation-auto.h>
 
 #ifdef HAVE_VALGRIND
 #  include <valgrind/memcheck.h>
@@ -378,6 +379,16 @@ bool MCValueCopyDescription(MCValueRef p_value, MCStringRef& r_desc)
 		return MCStringCopy (MCSTR("<unknown>"), r_desc);
 	}
 	MCUnreachableReturn(false);
+}
+
+MC_DLLEXPORT_DEF
+void MCValueLog(MCValueRef p_value)
+{
+    MCAutoStringRef t_desc;
+    if (MCValueCopyDescription(p_value, &t_desc))
+        MCLog("%p: %@", p_value, *t_desc);
+    else
+        MCLog("%p: Cannot describe", p_value);
 }
 
 //////////


### PR DESCRIPTION
This patch adds a new `MCValueLog()` function that can be used when
debugging LiveCode to inspect the contents of a libfoundation value.

Example of inspecting a string in a gdb session:

    (gdb) p MCValueLog(r_string)
    [24896] 0x2d7a750: "9.0.0-dp-7-"
    $5 = void

And an example of inspecting an array:

    (gdb) p MCValueLog(self)
    [24896] 0x2dd4290: {organization: "", time: "1492606028", name: "LiveCode Community User"}
    $11 = void

This is intended to replace the use of `MCStringGetCString()` for
debugging purposes.