### PR TITLE
Cleanup code that uses MCStringGetCString(), part 2

### DIFF
--- a/engine/src/deploy_windows.cpp
+++ b/engine/src/deploy_windows.cpp
@@ -1116,9 +1116,13 @@ static bool add_version_info_entry(void *p_context, MCArrayRef p_array, MCNameRe
             !t_bytes . Push('\0'))
             return false;
 	}
-	
+
+    MCAutoStringRefAsCString t_key_str;
+    if (!t_key_str.Lock(MCNameGetString(p_key)))
+        return false;
+
     MCWindowsVersionInfo *t_string;
-    return MCWindowsVersionInfoAdd((MCWindowsVersionInfo *)p_context, MCNameGetCString(p_key), true, t_bytes . Ptr(), t_bytes . Size(), t_string);
+    return MCWindowsVersionInfoAdd((MCWindowsVersionInfo *)p_context, *t_key_str, true, t_bytes . Ptr(), t_bytes . Size(), t_string);
 }
 
 static bool MCWindowsResourcesAddVersionInfo(MCWindowsResources& self, MCArrayRef p_info)

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -2013,9 +2013,9 @@ void MCEngineDoEvalUuid(MCExecContext& ctxt, MCStringRef p_namespace_id, MCStrin
     }
     
     if (p_is_md5)
-        MCUuidGenerateMD5(t_namespace, MCStringGetOldString(p_name), t_uuid);
+        MCUuidGenerateMD5(t_namespace, p_name, t_uuid);
     else
-        MCUuidGenerateSHA1(t_namespace, MCStringGetOldString(p_name), t_uuid);
+        MCUuidGenerateSHA1(t_namespace, p_name, t_uuid);
     
     if (MCEngineUuidToStringRef(t_uuid, r_uuid))
         return;

--- a/engine/src/exec-nativecontrol.cpp
+++ b/engine/src/exec-nativecontrol.cpp
@@ -50,13 +50,18 @@ MC_EXEC_DEFINE_GET_METHOD(NativeControl, ControlList, 1)
 
 //////////
 
-static bool MCParseRGBA(const MCString &p_data, bool p_require_alpha, uint1 &r_red, uint1 &r_green, uint1 &r_blue, uint1 &r_alpha)
+static bool MCParseRGBA(MCStringRef p_data, bool p_require_alpha, uint1 &r_red, uint1 &r_green, uint1 &r_blue, uint1 &r_alpha)
 {
 	bool t_success = true;
 	Boolean t_parsed;
 	uint2 r, g, b, a;
-	const char *t_data = p_data.getstring();
-	uint32_t l = p_data.getlength();
+
+    MCAutoStringRefAsCString t_data_str;
+    if (t_success)
+        t_success = t_data_str.Lock(p_data);
+    const char *t_data = *t_data_str;
+    uint32_t l = t_data_str.Size();
+
 	if (t_success)
 	{
 		r = MCU_max(0, MCU_min(255, MCU_strtol(t_data, l, ',', t_parsed)));
@@ -98,7 +103,7 @@ void MCNativeControlColorParse(MCExecContext& ctxt, MCStringRef p_input, MCNativ
 {
     uint8_t t_r8, t_g8, t_b8, t_a8;
     MCColor t_color;
-    if (MCParseRGBA(MCStringGetOldString(p_input), false, t_r8, t_g8, t_b8, t_a8))
+    if (MCParseRGBA(p_input, false, t_r8, t_g8, t_b8, t_a8))
     {
         r_output . r = (t_r8 << 8) | t_r8;
         r_output . g = (t_g8 << 8) | t_g8;

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -441,7 +441,7 @@ void MCNetworkExecUnloadUrl(MCExecContext& ctxt, MCStringRef p_url)
 void MCNetworkExecPostToUrl(MCExecContext& ctxt, MCValueRef p_data, MCStringRef p_url)
 // SJT-2014-09-11: [[ URLMessages ]] Send "postURL" messages on all platforms.
 {
-	if (MCU_couldbeurl(MCStringGetOldString(p_url)))
+	if (MCU_couldbeurl(p_url))
 	{
 		MCAutoDataRef t_data;
 
@@ -510,7 +510,7 @@ void MCNetworkExecDeleteUrl(MCExecContext& ctxt, MCStringRef p_target)
 		MCStringCopySubstring(p_target, MCRangeMakeMinMax(8, MCStringGetLength(p_target)), &t_filename);
 		MCS_saveresfile(*t_filename, kMCEmptyData);
 	}
-	else if (MCU_couldbeurl(MCStringGetOldString(p_target)))
+	else if (MCU_couldbeurl(p_target))
 	{
 		// Send "deleteURL" message
 		Boolean oldlock = MClockmessages;

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -592,11 +592,13 @@ static char *eval_expr(const char *arg1, const char *arg2,
 		*retval = xresFail;
 		return NULL;
     }
-	
-	MCAutoStringRef t_return;
-	/* UNCHECKED */ MCECptr->ConvertToString(*t_result, &t_return);
+
+    MCAutoStringRef t_result_string;
+    /* UNCHECKED */ MCECptr->ConvertToString(*t_result, &t_result_string);
+    char *t_return = nullptr;
+    /* UNCHECKED */ MCStringConvertToCString(*t_result_string, t_return);
 	*retval = xresSucc;
-    return MCStringGetOldString(*t_return).clone();
+    return t_return;
 }
 
 static char *get_global(const char *arg1, const char *arg2,

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -1151,11 +1151,6 @@ const char *MCNameGetCString(MCNameRef p_name)
 	return MCStringGetCString(MCNameGetString(p_name));
 }
 
-MCString MCNameGetOldString(MCNameRef p_name)
-{
-	return MCStringGetOldString(MCNameGetString(p_name));
-}
-
 bool MCNameGetAsIndex(MCNameRef p_name, index_t& r_index)
 {
     MCStringRef t_key;

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -706,14 +706,6 @@ bool MCStringCreateWithOldString(const MCString& p_old_string, MCStringRef& r_st
 	return MCStringCreateWithNativeChars((const char_t *)p_old_string . getstring(), p_old_string . getlength(), r_string);
 }
 
-MCString MCStringGetOldString(MCStringRef p_string)
-{
-    if (!MCStringIsNative(p_string))
-        MCStringNativize(p_string);
-    
-    return MCString((const char *)MCStringGetNativeCharPtr(p_string), MCStringGetLength(p_string));
-}
-
 bool MCStringIsEqualToOldString(MCStringRef p_string, const MCString& p_oldstring, MCCompareOptions p_options)
 {
 	return MCStringIsEqualToNativeChars(p_string, (const char_t *)p_oldstring . getstring(), p_oldstring . getlength(), p_options);

--- a/engine/src/foundation-legacy.cpp
+++ b/engine/src/foundation-legacy.cpp
@@ -1138,11 +1138,6 @@ bool MCNameClone(MCNameRef p_name, MCNameRef& r_new_name)
 	return true;
 }
 
-const char *MCNameGetCString(MCNameRef p_name)
-{
-	return MCStringGetCString(MCNameGetString(p_name));
-}
-
 bool MCNameGetAsIndex(MCNameRef p_name, index_t& r_index)
 {
     MCStringRef t_key;

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -85,7 +85,6 @@ bool MCNameClone(MCNameRef name, MCNameRef& r_new_name);
 bool MCNameGetAsIndex(MCNameRef name, index_t& r_index);
 
 const char *MCNameGetCString(MCNameRef name);
-MCString MCNameGetOldString(MCNameRef name);
 char MCNameGetCharAtIndex(MCNameRef name, uindex_t at);
 
 bool MCNameIsEqualTo(MCNameRef left, MCNameRef right, MCCompareOptions options);

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -38,7 +38,6 @@ bool MCValueConvertToStringForSave(MCValueRef value, MCStringRef& r_string);
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCStringCreateWithOldString(const MCString&, MCStringRef &r_string);
-MCString MCStringGetOldString(MCStringRef p_string);
 bool MCStringIsEqualToOldString(MCStringRef string, const MCString& oldstring, MCCompareOptions options);
 
 // Attempt to interpret the given string as a base-10 integer. It returns false

--- a/engine/src/foundation-legacy.h
+++ b/engine/src/foundation-legacy.h
@@ -83,7 +83,6 @@ bool MCNameClone(MCNameRef name, MCNameRef& r_new_name);
 
 bool MCNameGetAsIndex(MCNameRef name, index_t& r_index);
 
-const char *MCNameGetCString(MCNameRef name);
 char MCNameGetCharAtIndex(MCNameRef name, uindex_t at);
 
 bool MCNameIsEqualTo(MCNameRef left, MCNameRef right, MCCompareOptions options);

--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -2289,8 +2289,12 @@ IO_stat MCHcstak::read(IO_handle stream)
 				}
 				break;
 			default:
-				hcstat_append("Not converting %4.4s id %5d \"%s\"",
-				        (char *)&t_type, id, MCNameGetCString(*t_name));
+                {
+                    MCAutoStringRefAsCString t_name_str;
+                    /* UNCHECKED */ t_name_str.Lock(MCNameGetString(*t_name));
+                    hcstat_append("Not converting %4.4s id %5d \"%s\"",
+                                  (char *)&t_type, id, *t_name_str);
+                }
 				break;
 			}
 			objects += 12;

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -817,13 +817,6 @@ public:
 		return *_name;
 	}
 
-    /*
-	MCString getname_oldstring(void) const
-	{
-		return MCNameGetOldString(_name);
-	}
-    */
-
 	// Tests to see if the object has the given name, interpreting unnamed as
 	// the empty string.
 	bool hasname(MCNameRef p_other_name);

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -191,7 +191,7 @@ extern void MCU_dofunc(Functions func, uint4 nparams, real8 &n,
 	                       real8 tn, real8 oldn, MCSortnode *titems);
 // MW-2013-07-01: [[ Bug 10975 ]] This method returns true if the given string could be a url
 //   (as used by MCU_geturl, to determine whether to try and fetch via libUrl).
-extern bool MCU_couldbeurl(const MCString& potential_url);
+extern bool MCU_couldbeurl(MCStringRef potential_url);
 extern void MCU_puturl(MCExecContext& ctxt, MCStringRef p_target, MCValueRef p_data);
 extern uint1 MCU_unicodetocharset(uint2 uchar);
 extern uint1 MCU_languagetocharset(MCNameRef langname);

--- a/engine/src/uuid.cpp
+++ b/engine/src/uuid.cpp
@@ -59,7 +59,7 @@ bool MCUuidGenerateRandom(MCUuid& r_uuid)
 	return true;
 }
 
-void MCUuidGenerateMD5(const MCUuid& p_namespace_id, const MCString& p_name, MCUuid& r_uuid)
+void MCUuidGenerateMD5(const MCUuid& p_namespace_id, MCStringRef p_name, MCUuid& r_uuid)
 {
 	// Initialize an md5 context.
 	md5_state_t t_md5;
@@ -73,7 +73,10 @@ void MCUuidGenerateMD5(const MCUuid& p_namespace_id, const MCString& p_name, MCU
 	md5_append(&t_md5, t_namespace_bytes, sizeof(t_namespace_bytes));
 	
 	// Append the name bytes to the md5 stream.
-	md5_append(&t_md5, (const md5_byte_t *)p_name . getstring(), p_name . getlength());
+    MCAutoStringRefAsCString t_name;
+    /* UNCHECKED */ t_name.Lock(p_name);
+    md5_append(&t_md5, reinterpret_cast<const md5_byte_t*>(*t_name),
+               t_name.Size());
 	
 	// Extract the resulting digest from the md5 stream.
 	uint8_t t_uuid_bytes[16];
@@ -86,7 +89,7 @@ void MCUuidGenerateMD5(const MCUuid& p_namespace_id, const MCString& p_name, MCU
 	MCUuidBrand(r_uuid, 3);
 }
 
-void MCUuidGenerateSHA1(const MCUuid& p_namespace_id, const MCString& p_name, MCUuid& r_uuid)
+void MCUuidGenerateSHA1(const MCUuid& p_namespace_id, MCStringRef p_name, MCUuid& r_uuid)
 {
 	// Initialize an sha1 context.
 	sha1_state_t t_sha1;
@@ -100,7 +103,9 @@ void MCUuidGenerateSHA1(const MCUuid& p_namespace_id, const MCString& p_name, MC
 	sha1_append(&t_sha1, t_namespace_bytes, sizeof(t_namespace_bytes));
 	
 	// Append the name bytes to the sha1 stream.
-	sha1_append(&t_sha1, p_name . getstring(), p_name . getlength());
+    MCAutoStringRefAsCString t_name;
+    /* UNCHECKED */ t_name.Lock(p_name);
+    sha1_append(&t_sha1, *t_name, t_name.Size());
 	
 	// Extract the resulting digest from the sha1 stream.
 	uint8_t t_uuid_bytes[20];

--- a/engine/src/uuid.h
+++ b/engine/src/uuid.h
@@ -46,11 +46,11 @@ bool MCUuidGenerateRandom(MCUuid& r_uuid);
 
 // Generate a (non-random) type v3 UUID using the given name and namespace
 // id.
-void MCUuidGenerateMD5(const MCUuid& namespace_id, const MCString& name, MCUuid& r_uuid);
+void MCUuidGenerateMD5(const MCUuid& namespace_id, MCStringRef name, MCUuid& r_uuid);
 
 // Generate a (non-random) type v4 UUID using the given name and namespace
 // id.
-void MCUuidGenerateSHA1(const MCUuid& namespace_id, const MCString& name, MCUuid& r_uuid);
+void MCUuidGenerateSHA1(const MCUuid& namespace_id, MCStringRef name, MCUuid& r_uuid);
 
 // Convert a UUID to a string. The output buffer is expected to be at
 // least 37 bytes long.

--- a/engine/src/w32printer.cpp
+++ b/engine/src/w32printer.cpp
@@ -2124,7 +2124,9 @@ void MCWindowsPrinter::EncodeSettings(MCStringRef p_name, DEVMODEW* p_devmode, M
 
 	void *t_temp;
 	uint4 t_len;
-	t_dictionary . Set('NMEA', MCStringGetOldString(p_name));
+    MCAutoStringRefAsCString t_name;
+    /* UNCHECKED */ t_name.Lock(p_name);
+    t_dictionary . Set('NMEA', *t_name);
 	t_dictionary . Set('W32A', MCString((char *)p_devmode, p_devmode -> dmSize + p_devmode -> dmDriverExtra));
 	t_dictionary . Pickle(t_temp, t_len);
 


### PR DESCRIPTION
Removes several legacy string functions that depend on unsafe `MCStringNativize()` or `MCStringGetCString()`, after refactoring code to eliminate their use.

Removed:
- `MCNameGetOldString()`
- `MCStringGetOldString()`
- `MCNameGetCString()`

Refactored:
- `MCU_couldbeurl()`
- `MCUuidGenerateMD5()`
- `MCUuidGenerateSHA1()`
- `MCParseRGBA()`