### PR TITLE
[Bug 19285] libgraphics: Deprecate/spanify platform text API

### DIFF
--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -1010,6 +1010,10 @@ void MCGContextDrawPlatformText(MCGContextRef context, const unichar_t *text, ui
 MCGFloat MCGContextMeasurePlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform);
 [[deprecated]]
 bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform, MCGRectangle &r_bounds);
+void MCGContextDrawPlatformText(MCGContextRef context, MCSpan<const unichar_t> text, MCGPoint location, const MCGFont &font, bool p_rtl);
+// MM-2014-04-16: [[ Bug 11964 ]] Updated prototype to take transform parameter.
+MCGFloat MCGContextMeasurePlatformText(MCGContextRef context, MCSpan<const unichar_t> text, const MCGFont &p_font, const MCGAffineTransform &p_transform);
+bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef context, MCSpan<const unichar_t> text, const MCGFont &p_font, const MCGAffineTransform &p_transform, MCGRectangle &r_bounds);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -1003,9 +1003,12 @@ bool MCGContextCopyImage(MCGContextRef context, MCGImageRef &r_image);
 
 void MCGContextDrawText(MCGContextRef context, const char* text, uindex_t length, MCGPoint location, uint32_t font_size, void *typeface);
 MCGFloat MCGContextMeasureText(MCGContextRef context, const char *text, uindex_t length, uint32_t font_size, void *typeface);
+[[deprecated]]
 void MCGContextDrawPlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, MCGPoint location, const MCGFont &font, bool p_rtl);
 // MM-2014-04-16: [[ Bug 11964 ]] Updated prototype to take transform parameter.
+[[deprecated]]
 MCGFloat MCGContextMeasurePlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform);
+[[deprecated]]
 bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform, MCGRectangle &r_bounds);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -2803,6 +2803,15 @@ MCGFloat MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_te
 	return 0.0;
 }
 
+MCGFloat MCGContextMeasurePlatformText(MCGContextRef self,
+                                       MCSpan<const unichar_t> p_text,
+                                       const MCGFont &p_font,
+                                       const MCGAffineTransform &p_transform)
+{
+    return MCGContextMeasurePlatformText(self, p_text.data(), p_text.sizeBytes(),
+                                         p_font, p_transform);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCGContextCopyImage(MCGContextRef self, MCGImageRef &r_image)

--- a/libgraphics/src/coretext.cpp
+++ b/libgraphics/src/coretext.cpp
@@ -290,6 +290,16 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 	self -> is_valid = t_success;
 }
 
+void MCGContextDrawPlatformText(MCGContextRef self,
+                                MCSpan<const unichar_t> p_text,
+                                MCGPoint p_location,
+                                const MCGFont &p_font,
+                                bool p_rtl)
+{
+    MCGContextDrawPlatformText(self, p_text.data(), p_text.sizeBytes(),
+                               p_location, p_font, p_rtl);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 MCGFloat __MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, const MCGFont &p_font, const MCGAffineTransform &p_transform)
@@ -339,6 +349,20 @@ bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self, const unichar_
 		CFRelease(t_line);
 	
 	return t_success;
+}
+
+bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self,
+                                              MCSpan<const unichar_t> p_text,
+                                              const MCGFont &p_font,
+                                              const MCGAffineTransform &p_transform,
+                                              MCGRectangle &r_bounds)
+{
+    return MCGContextMeasurePlatformTextImageBounds(self,
+                                                    p_text.data(),
+                                                    p_text.sizeBytes(),
+                                                    p_font,
+                                                    p_transform,
+                                                    r_bounds);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/src/harfbuzztext.cpp
+++ b/libgraphics/src/harfbuzztext.cpp
@@ -387,6 +387,16 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 	self -> is_valid = true;
 }
 
+void MCGContextDrawPlatformText(MCGContextRef self,
+                                MCSpan<const unichar_t> p_text,
+                                MCGPoint p_location,
+                                const MCGFont &p_font,
+                                bool p_rtl)
+{
+    MCGContextDrawPlatformText(self, p_text.data(), p_text.sizeBytes(),
+                               p_location, p_font, p_rtl);
+}
+
 MCGFloat __MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, const MCGFont &p_font, const MCGAffineTransform &p_transform)
 {	
 	//if (!MCGContextIsValid(self))
@@ -458,3 +468,16 @@ bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self, const unichar_
 	return true;
 }
 
+bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self,
+                                              MCSpan<const unichar_t> p_text,
+                                              const MCGFont &p_font,
+                                              const MCGAffineTransform &p_transform,
+                                              MCGRectangle &r_bounds)
+{
+    return MCGContextMeasurePlatformTextImageBounds(self,
+                                                    p_text.data(),
+                                                    p_text.sizeBytes(),
+                                                    p_font,
+                                                    p_transform,
+                                                    r_bounds);
+}

--- a/libgraphics/src/lnxtext.cpp
+++ b/libgraphics/src/lnxtext.cpp
@@ -238,6 +238,16 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 	self -> is_valid = t_success;
 }
 
+void MCGContextDrawPlatformText(MCGContextRef self,
+                                MCSpan<const unichar_t> p_text,
+                                MCGPoint p_location,
+                                const MCGFont &p_font,
+                                bool p_rtl)
+{
+    MCGContextDrawPlatformText(self, p_text.data(), p_text.sizeBytes(),
+                               p_location, p_font, p_rtl);
+}
+
 MCGFloat __MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, const MCGFont &p_font, const MCGAffineTransform &p_transform)
 {	
 	// MW-2013-12-19: [[ Bug 11559 ]] Do nothing if no text support.
@@ -312,6 +322,20 @@ bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self, const unichar_
 	MCCStringFree(t_text);
 	
 	return t_success;
+}
+
+bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self,
+                                              MCSpan<const unichar_t> p_text,
+                                              const MCGFont &p_font,
+                                              const MCGAffineTransform &p_transform,
+                                              MCGRectangle &r_bounds)
+{
+    return MCGContextMeasurePlatformTextImageBounds(self,
+                                                    p_text.data(),
+                                                    p_text.sizeBytes(),
+                                                    p_font,
+                                                    p_transform,
+                                                    r_bounds);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/src/osxtext.cpp
+++ b/libgraphics/src/osxtext.cpp
@@ -439,6 +439,16 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 	self -> is_valid = t_success;
 }
 
+void MCGContextDrawPlatformText(MCGContextRef self,
+                                MCSpan<const unichar_t> p_text,
+                                MCGPoint p_location,
+                                const MCGFont &p_font,
+                                bool p_rtl)
+{
+    MCGContextDrawPlatformText(self, p_text.data(), p_text.sizeBytes(),
+                               p_location, p_font, p_rtl);
+}
+
 MCGFloat __MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, const MCGFont &p_font, const MCGAffineTransform &p_transform)
 {	
 	bool t_success;

--- a/libgraphics/src/w32text.cpp
+++ b/libgraphics/src/w32text.cpp
@@ -588,6 +588,16 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 	__MCGContextDrawPlatformTextScreen(self, p_text, p_length, p_location, p_font, p_rtl);
 }
 
+void MCGContextDrawPlatformText(MCGContextRef self,
+                                MCSpan<const unichar_t> p_text,
+                                MCGPoint p_location,
+                                const MCGFont &p_font,
+                                bool p_rtl)
+{
+    MCGContextDrawPlatformText(self, p_text.data(), p_text.sizeBytes(),
+                               p_location, p_font, p_rtl);
+}
+
 //////////
 
 // MM-2014-04-16: [[ Bug 11964 ]] Updated prototype to take transform parameter.
@@ -812,6 +822,20 @@ bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self, const unichar_
     AbortPath(s_measure_dc);
 
     return true;
+}
+
+bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self,
+                                              MCSpan<const unichar_t> p_text,
+                                              const MCGFont &p_font,
+                                              const MCGAffineTransform &p_transform,
+                                              MCGRectangle &r_bounds)
+{
+    return MCGContextMeasurePlatformTextImageBounds(self,
+                                                    p_text.data(),
+                                                    p_text.sizeBytes(),
+                                                    p_font,
+                                                    p_transform,
+                                                    r_bounds);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Several libgraphics functions take a pointer + length pair to receive a text buffer from their caller.

The pointer is a `unichar_t *`, but the length is expressed in bytes rather in `unichar_t` instances.  This makes it pretty hard to use the API correctly, and leads to silent bugs like the one fixed in #5203.

The affected functions include:

- `MCGContextDrawPlatformText`
- `MCGContextMeasurePlatformText`
- `MCGContextMeasurePlatformTextImageBounds`

This patch deprecates the pointer + byte-length API, and adds `MCSpan`-based API.