### PR TITLE
Correct lazy initialisation of GDK clipboard support

### DIFF
--- a/engine/src/lnx-clipboard.cpp
+++ b/engine/src/lnx-clipboard.cpp
@@ -552,12 +552,13 @@ bool MCLinuxRawClipboard::HasGDK()
 #ifndef _SERVER
     // Only try to initialise GDK once
     static bool s_try_gdk = false;
-    static bool s_has_gdk = !MCnoui && initialise_weak_link_X11()
-    && initialise_weak_link_gobject()
-    && initialise_weak_link_gdk();
+    static bool s_has_gdk = false;
     if (!s_try_gdk)
     {
         s_try_gdk = true;
+        s_has_gdk = !MCnoui && initialise_weak_link_X11()
+            && initialise_weak_link_gobject()
+            && initialise_weak_link_gdk();
         if (s_has_gdk)
             gdk_init(0, NULL);
     }


### PR DESCRIPTION
In Release mode, `MCLinuxRawClipboard::HasGDK()` was generating
incorrect code, causing a strange behaviour and crashes in raw
clipboard handling on Linux.

Previously, the weak link initialisation expression was located in the
static initialiser of the `s_has_gdk` static variable.  Static
initialisers are only guaranteed to be executed at least once at some
point, and where dynamic function calls are required, the C++ compiler
has to insert some complicated machinery to make sure that the
initialisation doesn't occur multiple times.

Something about the way that GCC 6.3.1 chose to optimise `HasGDK()`
was causing it to always return `false`.  This caused a bunch of
problems including crashes on IDE startup.

Moving weak link initialisation out of the static initialiser
expression allows the C++ compiler to inline `HasGDK()` without having
to insert a bunch of complicated synchronisation intrinsics, and also
fixes the crash.