### PR TITLE
[[ Windows ]] Add 'main window' hook and enable/disable on modal

### DIFF
--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -106,6 +106,8 @@ bool X_init(const X_init_options& p_options)
 
     void *t_bottom;
     MCstackbottom = (char *)&t_bottom;
+
+    MCmainwindowcallback = p_options.main_window_callback;
 	
 #ifdef _WINDOWS_DESKTOP
 	// MW-2011-07-26: Make sure errno pointer is initialized - this won't be

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -511,6 +511,9 @@ MCArrayRef MCcommandarguments;
 
 MCHook *MChooks = nil;
 
+// The main window callback to compute the window to parent root modal dialogs to (if any)
+MCMainWindowCallback MCmainwindowcallback = nullptr;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern MCUIDC *MCCreateScreenDC(void);

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -439,6 +439,11 @@ extern char *MCsysencoding;
 extern MCLocaleRef kMCBasicLocale;
 extern MCLocaleRef kMCSystemLocale;
 
+// A callback to invoke to fetch the current mainwindow to use for modal dialog
+// parenting.
+typedef void *(*MCMainWindowCallback)(void);
+extern MCMainWindowCallback MCmainwindowcallback;
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  LIFECYCLE
@@ -453,6 +458,9 @@ struct X_init_options
     
     /* Specifies the base folder to use to resolve relative library paths */
     MCStringRef app_code_path = nullptr;
+
+    /* Specifies the root main window of the application */
+    MCMainWindowCallback main_window_callback = nullptr;
 };
 
 /* These are the main lifecycle functions. They are implemented separately for

--- a/engine/src/w32dc.h
+++ b/engine/src/w32dc.h
@@ -163,6 +163,9 @@ class MCScreenDC : public MCUIDC
 
 	HANDLE m_srgb_profile;
 
+    int m_main_window_depth = 0;
+    HWND m_main_window_current = nullptr;
+
 protected:
 	static uint4 pen_inks[];
 	static uint4 image_inks[];


### PR DESCRIPTION
This patch adds a 'main_window' callback which is used to choose
which window to disable and enable when a modal dialog stack is
started on Windows.