### PR TITLE
[[ Build ]] Fix builds using --whole-archive

### DIFF
--- a/engine/lcb-modules.gyp
+++ b/engine/lcb-modules.gyp
@@ -66,7 +66,7 @@
 					},
 				],
                 [
-                    'OS == "android" or OS == "linux"',
+                    'OS == "linux"',
                     {
                         'direct_dependent_settings':
                         {


### PR DESCRIPTION
This patch fixes a build error on Android caused by making the
lcb module loader classes non-static.

As the Android engine is built as a shared library, it would
appear that this causes the non-static loader variables to
still be included even though they are not referenced. This was
causing double inclusion of the lcb modules as 'whole-archive' adds
the libraries as additional inputs, rather than affecting previously
included inputs.

In comparison, the Linux engine is built as an executable so in
release mode, the linker discards the non whole-archive lib (as none
of its vars are referenced) and then links it in again, this time
with whole-archive true.

The actual underlying issue here is that it is not possible to
express in gyp a static_library target which defines how it should
be incoporated into its dependees - it has to be done as an extra
linker option which causes both gyp's automatic use of it *and*
the use of it inside the whole-archive option.