### PR TITLE
[[ Build ]] Ensure git_revision is correct

### DIFF
--- a/config.py
+++ b/config.py
@@ -474,6 +474,13 @@ def core_gyp_args(opts):
     if opts['BUILD_EDITION'] == 'commercial':
         args.append(os.path.join('..', 'livecode-commercial.gyp'))
 
+    # Get the current git hash from the appropriate repository
+    if opts['BUILD_EDITION'] == 'commercial':
+        git_revision = subprocess.check_output(['git', '-C', '..', 'rev-parse', 'HEAD'])
+    else:
+        git_revision = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+    args.append('-Dgit_revision=' + git_revision)
+
     args.append('-Duniform_arch=' + opts['UNIFORM_ARCH'])
 
     return args

--- a/config/version.gypi
+++ b/config/version.gypi
@@ -6,7 +6,5 @@
 		'version_point': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_POINT_VERSION <(DEPTH)/version)",
 		'version_build': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_REVISION <(DEPTH)/version)",
 		'version_string': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_SHORT_VERSION <(DEPTH)/version)",
-
-		'git_revision': '<!(git rev-parse HEAD)',
 	},
 }


### PR DESCRIPTION
This patch computes the git_revision of the build at config time
by setting the git_revision git variable in the command line args
passed to gyp from config.py.

The git revision for a community build is that of the livecode
repository; for a commercial build it is that of the livecode-private
repository.