### PR TITLE
[[ Build ]] Ensure git_revision is correct

### DIFF
--- a/config.py
+++ b/config.py
@@ -473,6 +473,8 @@ def core_gyp_args(opts):
 
     if opts['BUILD_EDITION'] == 'commercial':
         args.append(os.path.join('..', 'livecode-commercial.gyp'))
+        
+    args.append('-Dbuild_edition=' + opts['BUILD_EDITION'])
 
     args.append('-Duniform_arch=' + opts['UNIFORM_ARCH'])
 

--- a/config/version.gypi
+++ b/config/version.gypi
@@ -7,6 +7,17 @@
 		'version_build': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_REVISION <(DEPTH)/version)",
 		'version_string': "<!(perl <(DEPTH)/util/decode_version.pl BUILD_SHORT_VERSION <(DEPTH)/version)",
 
-		'git_revision': '<!(git rev-parse HEAD)',
+		'conditions':
+		[
+			[
+				'build_edition == "commercial"',
+				{
+					'git_revision': '<!(git -C <(DEPTH)/.. rev-parse HEAD)',
+				},
+				{
+					'git_revision': '<!(git -C <(DEPTH) rev-parse HEAD)',
+				},
+			],
+		],
 	},
 }


### PR DESCRIPTION
This patch ensures that the git_revision for commerical builds
is that of the private repo; whilst the git_revision for community
builds is that of the public repo.

This is achieved by getting config.py to set a build_edition variable
in gyp and then a condition in version.gypi which fetchs the git
revision from .. if commercial and . if community.