### PR TITLE
[[ Bug ]] Not all window handles are destroyed

### DIFF
--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -644,6 +644,10 @@ MCStack::~MCStack()
 	view_destroy();
 
 	release_window_buffer();
+
+    // Make sure we destroy the window
+    if (window != nullptr)
+        MCscreen->destroywindow(window);
 }
 
 Chunk_term MCStack::gettype() const


### PR DESCRIPTION
This patch ensures that a stack's window handle is destroyed if
it has not been by the time the end of MCStack::~MCStack is reached.