### PR TITLE
[[ Teardown ]] Ensure loaded fonts are released on quit

### DIFF
--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -79,6 +79,10 @@ bool MCFontInitialize(void)
 
 void MCFontFinalize(void)
 {
+    while(s_loaded_fonts != nullptr)
+    {
+        MCFontUnload(s_loaded_fonts->path);
+    }
 }
 
 bool MCFontCreate(MCNameRef p_name, MCFontStyle p_style, int32_t p_size, MCFontRef& r_font)

--- a/engine/src/w32dc.cpp
+++ b/engine/src/w32dc.cpp
@@ -166,7 +166,7 @@ bool MCScreenDC::unloadfont(MCStringRef p_path, bool p_globally, void *r_loaded_
     bool t_success = true;
     DWORD t_private = NULL;
     
-    if (p_globally)
+    if (!p_globally)
         t_private = FR_PRIVATE;
     
     MCAutoStringRefAsWString t_wide_path;


### PR DESCRIPTION
This patch ensures that any fonts loaded using 'start using font'
are unloaded on engine exit.