### PR TITLE
[Bug] Fix crash during close

### DIFF
--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1266,6 +1266,9 @@ bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 
 int X_close(void)
 {
+    // MW-2012-02-23: [[ FontRefs ]] Finalize the font module.
+    MCFontFinalize();
+    
     /* Finalize all builtin extensions */
     MCExtensionFinalize();
 
@@ -1493,8 +1496,6 @@ int X_close(void)
 	
 	// MW-2012-02-23: [[ LogFonts ]] Finalize the font table module.
 	MCLogicalFontTableFinalize();
-	// MW-2012-02-23: [[ FontRefs ]] Finalize the font module.
-	MCFontFinalize();
 	
 	// MM-2013-09-03: [[ RefactorGraphics ]] Initialize graphics library.
 	MCGraphicsFinalize();


### PR DESCRIPTION
This patch moves MCFontFinalize to the head of X_close as
it depends on MCsystem and other resources that were being
deleted before it was called.