### PR TITLE
[Bug] Provide mechanism to not handle signals

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -671,7 +671,7 @@ public:
         return nil;
     }
 
-    virtual bool Initialize(void)
+    virtual bool Initialize(bool p_handle_signals)
     {
         IO_stdin = MCsystem -> OpenFd(0, kMCOpenFileModeRead);
         IO_stdout = MCsystem -> OpenFd(1, kMCOpenFileModeWrite);

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -2777,34 +2777,38 @@ static bool MCS_getentries_for_folder(MCStringRef p_folder, MCSystemListFolderEn
 
 struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 {
-	virtual bool Initialize(void)
+	virtual bool Initialize(bool p_handle_signals)
     {
         IO_stdin = MCsystem -> OpenFd(0, kMCOpenFileModeRead);
         IO_stdout = MCsystem -> OpenFd(1, kMCOpenFileModeWrite);
         IO_stderr = MCsystem -> OpenFd(2, kMCOpenFileModeWrite);
-        struct sigaction action;
-        memset((char *)&action, 0, sizeof(action));
-        action.sa_handler = handle_signal;
-        action.sa_flags = SA_RESTART;
-        sigaction(SIGHUP, &action, NULL);
-        sigaction(SIGINT, &action, NULL);
-        sigaction(SIGQUIT, &action, NULL);
-        sigaction(SIGIOT, &action, NULL);
-        sigaction(SIGPIPE, &action, NULL);
-        sigaction(SIGALRM, &action, NULL);
-        sigaction(SIGTERM, &action, NULL);
-        sigaction(SIGUSR1, &action, NULL);
-        sigaction(SIGUSR2, &action, NULL);
-        sigaction(SIGFPE, &action, NULL);
-        action.sa_flags |= SA_NOCLDSTOP;
-        sigaction(SIGCHLD, &action, NULL);
         
-        // MW-2009-01-29: [[ Bug 6410 ]] Make sure we cause the handlers to be reset to
-        //   the OS default so CrashReporter will kick in.
-        action.sa_flags = SA_RESETHAND;
-        sigaction(SIGSEGV, &action, NULL);
-        sigaction(SIGILL, &action, NULL);
-        sigaction(SIGBUS, &action, NULL);
+        if (p_handle_signals)
+        {
+            struct sigaction action;
+            memset((char *)&action, 0, sizeof(action));
+            action.sa_handler = handle_signal;
+            action.sa_flags = SA_RESTART;
+            sigaction(SIGHUP, &action, NULL);
+            sigaction(SIGINT, &action, NULL);
+            sigaction(SIGQUIT, &action, NULL);
+            sigaction(SIGIOT, &action, NULL);
+            sigaction(SIGPIPE, &action, NULL);
+            sigaction(SIGALRM, &action, NULL);
+            sigaction(SIGTERM, &action, NULL);
+            sigaction(SIGUSR1, &action, NULL);
+            sigaction(SIGUSR2, &action, NULL);
+            sigaction(SIGFPE, &action, NULL);
+            action.sa_flags |= SA_NOCLDSTOP;
+            sigaction(SIGCHLD, &action, NULL);
+            
+            // MW-2009-01-29: [[ Bug 6410 ]] Make sure we cause the handlers to be reset to
+            //   the OS default so CrashReporter will kick in.
+            action.sa_flags = SA_RESETHAND;
+            sigaction(SIGSEGV, &action, NULL);
+            sigaction(SIGILL, &action, NULL);
+            sigaction(SIGBUS, &action, NULL);
+        }
         
         MCValueAssign(MCshellcmd, MCSTR("/bin/sh"));
         

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -124,7 +124,7 @@ bool X_init(const X_init_options& p_options)
 	////
 
 #ifndef _WINDOWS_DESKTOP
-	MCS_init();
+	MCS_init(p_options.should_handle_signals);
 #endif
 	
 	////

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -1484,7 +1484,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
         return nil;
     }
     
-	virtual bool Initialize(void)
+	virtual bool Initialize(bool p_handle_signals)
 	{
 		IO_stdin = MCsystem -> OpenFd(STD_INPUT_HANDLE, kMCOpenFileModeRead);
 		IO_stdout = MCsystem -> OpenFd(STD_OUTPUT_HANDLE, kMCOpenFileModeWrite);

--- a/engine/src/em-system.h
+++ b/engine/src/em-system.h
@@ -38,7 +38,7 @@ public:
 	virtual MCServiceInterface *QueryService(MCServiceType type);
 
 	/* ---------- Start up and tear down */
-	virtual bool Initialize(void);
+	virtual bool Initialize(bool p_handle_signals);
 	virtual void Finalize(void);
 
 	/* ---------- System error handling */

--- a/engine/src/globals.h
+++ b/engine/src/globals.h
@@ -461,6 +461,9 @@ struct X_init_options
 
     /* Specifies the root main window of the application */
     MCMainWindowCallback main_window_callback = nullptr;
+    
+    /* Specifies whether the process should register to handle signals */
+    bool should_handle_signals = true;
 };
 
 /* These are the main lifecycle functions. They are implemented separately for

--- a/engine/src/mblandroid.h
+++ b/engine/src/mblandroid.h
@@ -27,7 +27,7 @@ struct MCAndroidSystem: public MCSystemInterface
 {
     virtual MCServiceInterface *QueryService(MCServiceType type);
     
-	virtual bool Initialize(void);
+	virtual bool Initialize(bool p_handle_signals);
 	virtual void Finalize(void);
 	
 	virtual void Debug(MCStringRef p_string);

--- a/engine/src/mbliphone.h
+++ b/engine/src/mbliphone.h
@@ -28,7 +28,7 @@ struct MCIPhoneSystem: public MCSystemInterface
 public:
     virtual MCServiceInterface *QueryService(MCServiceType type);
     
-	virtual bool Initialize(void);
+	virtual bool Initialize(bool p_handle_signals);
 	virtual void Finalize(void);
 	
 	virtual void Debug(MCStringRef p_string);

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -42,7 +42,7 @@ enum MCSRegistryValueType
 
 
 extern void MCS_preinit();
-extern void MCS_init();
+extern void MCS_init(bool p_handle_signals);
 extern void MCS_shutdown();
 extern void MCS_seterrno(int value);
 extern int MCS_geterrno(void);

--- a/engine/src/srvmain.cpp
+++ b/engine/src/srvmain.cpp
@@ -389,7 +389,7 @@ bool X_init(const X_init_options& p_options)
 
 	////
     
-	MCS_init();
+	MCS_init(p_options.should_handle_signals);
 
     /* Set up MCcmd correctly - this is the path to the loadable object
      * containing this folder. */

--- a/engine/src/srvwindows.cpp
+++ b/engine/src/srvwindows.cpp
@@ -1199,7 +1199,7 @@ struct MCWindowsSystem: public MCSystemInterface
 
 	//////////////////
 	
-	bool Initialize(void)
+	bool Initialize(bool p_handle_signals)
 	{
 		WORD request = MAKEWORD(1, 1);
 		WSADATA t_data;

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -227,9 +227,18 @@ static MCHookNativeControlsDescriptor s_native_control_desc =
 };
 #endif
 
-void MCS_common_init(void)
+void MCS_common_init(bool p_handle_signals)
 {
-	MCsystem -> Initialize();    
+	MCsystem -> Initialize(p_handle_signals);
+
+#if !defined(__EMSCRIPTEN__)
+    MCSAutoLibraryRef t_self;
+    MCSLibraryCreateWithAddress(reinterpret_cast<void *>(MCS_common_init),
+                                &t_self);
+    MCSLibraryCopyPath(*t_self,
+                       MCcmd);
+#endif
+    
     MCsystem -> SetErrno(errno);
 	
 	MCinfinity = HUGE_VAL;
@@ -279,34 +288,36 @@ void MCS_preinit()
 #endif
 }
 
-void MCS_init()
+void MCS_init(bool p_handle_signals)
 {
     // Do the pre-init if not already complete
     if (MCsystem == nil)
         MCS_preinit();
     
 #ifdef _SERVER
+    if (p_handle_signals)
+    {
 #ifndef _WINDOWS_SERVER
-	signal(SIGUSR1, handle_signal);
-	signal(SIGUSR2, handle_signal);
-	signal(SIGBUS, handle_signal);
-	signal(SIGHUP, handle_signal);
-	signal(SIGQUIT, handle_signal);
-	signal(SIGCHLD, handle_signal);
-	signal(SIGALRM, handle_signal);
-	signal(SIGPIPE, handle_signal);
+        signal(SIGUSR1, handle_signal);
+        signal(SIGUSR2, handle_signal);
+        signal(SIGBUS, handle_signal);
+        signal(SIGHUP, handle_signal);
+        signal(SIGQUIT, handle_signal);
+        signal(SIGCHLD, handle_signal);
+        signal(SIGALRM, handle_signal);
+        signal(SIGPIPE, handle_signal);
 #endif
 	
-	signal(SIGTERM, handle_signal);
-	signal(SIGILL, handle_signal);
-	signal(SIGSEGV, handle_signal);
-	signal(SIGINT, handle_signal);
-	signal(SIGABRT, handle_signal);
-	signal(SIGFPE, handle_signal);
-    
+        signal(SIGTERM, handle_signal);
+        signal(SIGILL, handle_signal);
+        signal(SIGSEGV, handle_signal);
+        signal(SIGINT, handle_signal);
+        signal(SIGABRT, handle_signal);
+        signal(SIGFPE, handle_signal);
+    }
 #endif // _SERVER
 
-	MCS_common_init();
+	MCS_common_init(p_handle_signals);
 }
 
 void MCS_shutdown(void)

--- a/engine/src/system.h
+++ b/engine/src/system.h
@@ -472,7 +472,7 @@ struct MCSystemInterface
 {
     virtual MCServiceInterface *QueryService(MCServiceType type) = 0;
     
-	virtual bool Initialize(void) = 0;
+	virtual bool Initialize(bool p_handle_signals) = 0;
 	virtual void Finalize(void) = 0;
 	
 	virtual void Debug(MCStringRef p_string) = 0;


### PR DESCRIPTION
In some circumstances the process should not register to handle
signals when initialsed. This patch proves that mechansm via an
additional field in X_init_options