### PR TITLE
[[ Bug 19520 ]] Fix mirrored property on Mac

### DIFF
--- a/docs/notes/bugfix-19520.md
+++ b/docs/notes/bugfix-19520.md
@@ -1,0 +1,1 @@
+# Make sure mirrored property works correctly on Mac

--- a/engine/src/mac-av-player.mm
+++ b/engine/src/mac-av-player.mm
@@ -240,8 +240,8 @@ private:
     AVPlayerLayer *t_layer;
     t_layer = [AVPlayerLayer playerLayerWithPlayer: player];
     [t_layer setVideoGravity: AVLayerVideoGravityResize];
-    [self setLayer: t_layer];
     [self setWantsLayer: YES];
+    [self setLayer: t_layer];
     self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
 }
 
@@ -785,8 +785,8 @@ void MCAVFoundationPlayer::Load(MCStringRef p_filename_or_url, bool p_is_url)
     // Now set the player of the view.
     [m_view setPlayer: m_player];
 
-    m_view.layer.affineTransform = CGAffineTransformMakeScale(-1, 1);
-    
+    Synchronize();
+
     m_last_marker = UINT32_MAX;
 
     [[NSNotificationCenter defaultCenter] removeObserver: m_observer];
@@ -812,12 +812,12 @@ void MCAVFoundationPlayer::Mirror(void)
     
     CGAffineTransform t_flip_horizontally = CGAffineTransformConcat(t_transform1, t_transform2);
     
-    m_view.layer.affineTransform = t_flip_horizontally;
+    m_view.layer.sublayerTransform = CATransform3DMakeAffineTransform(t_flip_horizontally);
 }
 
 void MCAVFoundationPlayer::Unmirror(void)
 {
-    m_view.layer.affineTransform = CGAffineTransformMakeScale(1, 1);
+    m_view.layer.sublayerTransform = CATransform3DMakeAffineTransform(CGAffineTransformMakeScale(1, 1));
 }
 
 void MCAVFoundationPlayer::Synchronize(void)


### PR DESCRIPTION
This patch applies the mirror transform to layer.sublayerTransform
rather than layer.transform which ensures the player remains
mirrored.