### PR TITLE
[[Bug 19637]] Don't display error message twice when building mobile standalone

### DIFF
--- a/docs/notes/bugfix-19637.md
+++ b/docs/notes/bugfix-19637.md
@@ -1,0 +1,2 @@
+# Errors building iOS standalones should only be reported once
+

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -25,8 +25,6 @@ command revSaveAsMobileStandalone pStack, pAppBundle, pTarget, pSettings
    catch tError
       if revTestEnvironment() then
          return tError
-      else
-         answer tError
       end if
    end try
    


### PR DESCRIPTION
The error is thrown a few lines down and the caller (`revSaveAsStandalone`) displays the error. Displaying the error once is enough.