### PR TITLE
Add param that suppresses success message when building standalone

### DIFF
--- a/docs/notes/feature-suppress_standalone_success_msg.md
+++ b/docs/notes/feature-suppress_standalone_success_msg.md
@@ -1,0 +1,5 @@
+# Add param that suppresses success message when building standalone
+
+By default `revSaveAsStandalone` displays the message `answer information "Standalone application saved successfully."` when it is done. You can turn off this message by setting the test environment to true but doing so suppresses all error messages and other feedback as well.
+
+I am calling `revSaveAsStandalone` from my own scripts multiple times and want feedback and error reporting but not the success message. Adding an additional parameter to `revSaveAsStandalone` that suppress the success message would allow this.

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -137,7 +137,7 @@ private function getBuildFolder pStack, pFolder, pSettings
    return tFolder
 end getBuildFolder
 
-on revSaveAsStandalone pStack, pFolder, pPreview
+on revSaveAsStandalone pStack, pFolder, pPreview, pSuppressSuccessMsg
    global gREVStackStatus
    
    if pStack = empty then
@@ -237,7 +237,7 @@ on revSaveAsStandalone pStack, pFolder, pPreview
    if revStandaloneGetWarnings() is not empty and tError is empty then
       set the cWarnings of stack "revBuildResults" to revStandaloneGetWarnings()
    else
-      if not revSBSuppressDialogs() and tError is empty then
+      if not revSBSuppressDialogs() and pSuppressSuccessMsg is not true and tError is empty then
          answer information "Standalone application saved successfully."
       end if
       


### PR DESCRIPTION
By default `revSaveAsStandalone` displays the message `answer information "Standalone application saved successfully."` when it is done. You can turn off this message by setting the test environment to true but doing so suppresses all error messages and other feedback as well.

I am calling `revSaveAsStandalone` from my own scripts multiple times and want feedback and error reporting but not the success message. Adding an additional parameter to `revSaveAsStandalone` that suppress the success message would allow this.