### PR TITLE
[[ Emscripten ]] Ensure emscripten engine runs

### DIFF
--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1266,6 +1266,9 @@ void send_relaunch(void)
 #endif
 }
 
+// Important: This function is on the emterpreter whitelist. If its
+// signature function changes, the mangled name must be updated in
+// em-whitelist.json
 void send_startup_message(bool p_do_relaunch = true)
 {
 	if (p_do_relaunch)

--- a/engine/src/dskmain.cpp
+++ b/engine/src/dskmain.cpp
@@ -339,6 +339,9 @@ bool X_init(const X_init_options& p_options)
 	return true;
 }
 
+// Important: This function is on the emterpreter whitelist. If its
+// signature function changes, the mangled name must be updated in
+// em-whitelist.json
 bool X_main_loop_iteration()
 {
     void *t_bottom;

--- a/engine/src/em-dc-mainloop.cpp
+++ b/engine/src/em-dc-mainloop.cpp
@@ -126,6 +126,9 @@ X_initialize_mcappcodepath(const X_init_options& p_options)
                           nullptr);
 }
 
+// Important: This function is on the emterpreter whitelist. If its
+// signature function changes, the mangled name must be updated in
+// em-whitelist.json
 bool
 X_init(const X_init_options& p_options)
 {

--- a/engine/src/em-dc.cpp
+++ b/engine/src/em-dc.cpp
@@ -171,6 +171,10 @@ MCScreenDC::GetCurrentStack()
  * Event loop
  * ================================================================ */
 
+// Important: This function is on the emterpreter whitelist. If its
+// signature function changes, the mangled name must be updated in
+// em-whitelist.json
+
 /* Returns true if quit is requested, or from any inner main loop. */
 Boolean
 MCScreenDC::wait(real64_t p_duration,

--- a/engine/src/em-whitelist.json
+++ b/engine/src/em-whitelist.json
@@ -1,12 +1,12 @@
 [
     "^_main$",
-    "^__Z6X_initiPP10__MCStringiS1_$",
+    "^__Z6X_initRK14X_init_options$",
     "^__Z6X_openiPP10__MCStringS1_$",
     "^__ZN10MCDispatch7startupEv$",
     "^__Z20send_startup_messageb",
     "^__Z13platform_mainiPPcS0_$",
     "^__Z21X_main_loop_iterationv$",
-    "^__ZN10MCScreenDC4waitEdhh$",
+    "^__ZN10MCScreenDC4waitEdbb$",
 
     "^_MCEventQueueDispatch$",
     "^__ZL25MCEventQueueDispatchEventP7MCEvent$",

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -255,6 +255,9 @@ void MCEventQueueFinalize(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Important: This function is on the emterpreter whitelist. If its
+// signature function changes, the mangled name must be updated in
+// em-whitelist.json
 static void MCEventQueueDispatchEvent(MCEvent *p_event)
 {
 	MCEvent *t_event;

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1053,6 +1053,9 @@ X_open_environment_variables(MCStringRef envp[])
 
 /* ---------------------------------------------------------------- */
 
+// Important: This function is on the emterpreter whitelist. If its
+// signature function changes, the mangled name must be updated in
+// em-whitelist.json
 bool X_open(int argc, MCStringRef argv[], MCStringRef envp[])
 {
 	MCperror = new (nothrow) MCError();

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -738,6 +738,9 @@ MCDispatch::startup()
 
 #else
 
+// Important: This function is on the emterpreter whitelist. If its
+// signature function changes, the mangled name must be updated in
+// em-whitelist.json
 IO_stat MCDispatch::startup(void)
 {
     char *t_mccmd;

--- a/libfoundation/src/foundation-debug.cpp
+++ b/libfoundation/src/foundation-debug.cpp
@@ -232,7 +232,7 @@ void __MCLog(const char *p_file, uint32_t p_line, const char *p_format, ...)
 {
     va_list t_args;
     va_start(t_args, p_format);
-    MCLogV(p_file, p_line, p_format);
+    MCLogV(p_file, p_line, p_format, t_args);
     va_end(t_args);
 }
 
@@ -240,7 +240,7 @@ void __MCLogWithTrace(const char *p_file, uint32_t p_line, const char *p_format,
 {
     va_list t_args;
     va_start(t_args, p_format);
-    MCLogV(p_file, p_line, p_format);
+    MCLogV(p_file, p_line, p_format, t_args);
     va_end(t_args);
 }
 


### PR DESCRIPTION
This patch fixes issues with the emscripten engine running, due to incorrect mangled names on the emterpreter whitelist. It also adds warnings above said functions in case the signatures change in future. 

Also it fixes an `MCLogV` compile error that I saw locally (although it doesn't seem to be preventing the build on vulcan.