### PR TITLE
[[ Mention Bot ]] Restrict to livecode organisation

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,3 @@
+{
+  "requiredOrgs": ["livecode"]
+}


### PR DESCRIPTION
Ensure @mention-bot only chooses people from the livecode organisation to suggest as reviewers.