### PR TITLE
[Bug] Fix messageDigest parser crash

### DIFF
--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -3178,6 +3178,7 @@ MCMessageDigestFunc::parse(MCScriptPoint &sp,
         freeexps(t_params, t_param_count);
 
         MCperror->add(PE_MESSAGEDIGEST_BADPARAM, sp);
+        return PS_ERROR;
     }
 
     m_data.Reset(t_params[0]);


### PR DESCRIPTION
When editing scripts if the parser failed to parse the expressions
required for the messageDigest function they were being freed but
the function was not returning and therefore continued on to
assign the freed expressions to the instance vars. This patch
returns PS_ERROR appropriately when the parser fails.