### PR TITLE
[Bug 19649] Fix formatting of multiple hex numbers

### DIFF
--- a/docs/notes/bugfix-19649.md
+++ b/docs/notes/bugfix-19649.md
@@ -1,0 +1,1 @@
+# Correctly parse multiple bytes escaped as hex in the format function

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -1064,7 +1064,7 @@ void MCStringsEvalFormat(MCExecContext& ctxt, MCStringRef p_format, MCValueRef* 
                     /* UNCHECKED */ MCNumberParseUnicodeChars(t_hexa_num, 4, &t_number);
 
                     t_result_char = MCNumberFetchAsUnsignedInteger(*t_number);
-                    format += 2;
+                    format++;
 				}
 				break;
 			default:

--- a/tests/lcs/core/strings/format.livecodescript
+++ b/tests/lcs/core/strings/format.livecodescript
@@ -1,0 +1,21 @@
+﻿script "CoreStringsFormat"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestFormatMultipleHex
+   TestAssert "Format multiple hex", format("\xaa\xbb") is numToByte(0xaa)&numToByte(0xbb)
+end TestFormatMultipleHex


### PR DESCRIPTION
Previously a string with multiple hex numbers such as the following
\xaa\xbb would be formatted incorrectly because the parser would
be moved past the second escape slash and therefore not detect the
second number. This patch advances the pointer a single byte within
the hex block allowing the main block to advance again to the next
escape slash.