### PR TITLE
[[ Win64 ]] Fix output bin folder on Win32 64-bit

### DIFF
--- a/config/win32.gypi
+++ b/config/win32.gypi
@@ -8,7 +8,7 @@
 		# Set if the Gyp step is being run on a Unix-like host (i.e not Windows)
 		'unix_configure%': '0',
 		
-		'output_dir': '../win-<(target_arch)-bin',
+		'output_dir': '../win-<(uniform_arch)-bin',
 	},
 	
 	'target_defaults':


### PR DESCRIPTION
This patch ensure that uniform_arch is used rather than target_arch
when computing the win-*-bin output dir.