### PR TITLE
[[ Android ]] Fix linker used to link android

### DIFF
--- a/config.py
+++ b/config.py
@@ -434,7 +434,7 @@ def validate_android_tools(opts):
                  '-target arm-linux-androideabi -march=armv6 -integrated-as')
     android_tool('clang++', 'CXX',
                  '-target arm-linux-androideabi -march=armv6 -integrated-as')
-    android_tool('clang++', 'LINK',
+    android_tool('clang', 'LINK',
                  '-target arm-linux-androideabi -march=armv6 -integrated-as -fuse-ld=bfd')
     android_tool('objcopy', 'OBJCOPY')
     android_tool('objdump', 'OBJDUMP')


### PR DESCRIPTION
This patch adjusts the setting of the LINK environment variable
when building android to use clang, rather than clang++. This
should remove the dependence on libc++_shared which has crept in
when using clang++ with NDK r14+.