### PR TITLE
[Bug 18150] Add format string param to date function & convert command

### DIFF
--- a/docs/dictionary/command/convert.lcdoc
+++ b/docs/dictionary/command/convert.lcdoc
@@ -133,6 +133,17 @@ US date and time formats are used.
 The internet date, seconds, and <dateItems> formats are invariant and do
 not change according to the user's preferences.
 
+Specifying a from format is optional, however, when parsing the date it
+will be assumed to be in a US (<english>) <date> format. For example
+assuming a non-US locale:
+
+    -- 8th of May, 2017
+    put "8/5/2017" into tDate 
+    convert tDate to dateItems 
+    -- 2017,8,5,0,0,0,7 = 5th of Aug, 2017
+    convert tDate from system date to dateItems
+    -- 2017,5,8,0,0,0,2 = 8th of May, 2017
+
 >*Note:* The <convert> command assumes all dates / times are in local
 > time except for 'the seconds', which is taken to be universal time.
 

--- a/docs/dictionary/command/convert.lcdoc
+++ b/docs/dictionary/command/convert.lcdoc
@@ -29,6 +29,18 @@ Example:
 convert the date && the time to seconds
 put it
 
+Example:
+local tDate
+put 1494192899 into tDate
+convert tDate from seconds to "%Y-%m-%d"
+-- 2017-05-08
+
+Example:
+local tDate
+put "20170507T205054+1000" into tDate
+convert tDate from "%Y%m%dT%H%M%S%z" to dateItems
+-- 2017,5,7,20,50,54,1
+
 Parameters:
 dateAndTime (string):
 A string or container with a date, a time, or a date and time separated
@@ -51,7 +63,27 @@ can request only one format.
 - "internet date":   Thu, 17 Feb 2017 22:13:21 -0500
 - "seconds":   the number of seconds since the start of the epoch
 - "dateItems":   2017,2,17,22,13,21,5
+- a <string> containing one or more formatting incantations, each of
+  which describes a part of the requested date <format>. The possible
+  incantations are as follows:
 
+    * `%a` - Abbreviated weekday name:  the abbreviated day of the week,
+    as reported by the <weekdayNames> function
+    * `%A` - Full weekday name:  the full day of the week, as reported
+    by the weekdayNames function
+    * `%b` Abbreviated month name:  the abbreviated month name, as
+    reported by the monthNames function
+    * `%B` - Full month name:  the full month name, as reported by the
+    monthNames function 
+    * `%d` - Day of the month:  the day of the month as a number
+    * `%m` - Month number:  the number of the month
+    * `%y` - Two-digit year:  the year as a two-digit number
+    * `%Y` - Four-digit year:  This incantation indicates the year as a
+    four-digit number (including the century)
+    * `%w` - Day of the week:  A number between 1 and 7
+    * if `#` is after `%` then any leading zeros are not
+    included in the format. For example for the first of the month the
+    format `%d` would be `01` while the format `%#d` would be `1`.
 
 It:
 If the <dateAndTime> is a <container>, the converted date and time is
@@ -110,6 +142,14 @@ not change according to the user's preferences.
 >*Note:* The range of dates that the <convert> <command> can handle is
 > limited by the operating system's date routines. In particular,
 > Windows systems are limited to dates after 1/1/1970.
+
+>*Note:* It is possible to create an ambiguous date format string that
+> will not convert correctly. For example, the format `%#m%#d` would
+> create a date `112` for both the 12th of January and the 2nd of
+> November.
+
+Changes:
+The ability to use date formatting strings was added in version 9.0.
 
 References: sort container (command), time (function),
 dateFormat (function), milliseconds (function), date (function),

--- a/docs/dictionary/function/date.lcdoc
+++ b/docs/dictionary/function/date.lcdoc
@@ -6,7 +6,7 @@ Syntax: the [{ long | abbr[ev[iated]] | short }] [{ english | system | internet 
 
 Syntax: the [internet] [{ english | system }] date
 
-Syntax: date()
+Syntax: date([<dateFormat>])
 
 Summary:
 <return|Returns> the current date.
@@ -25,6 +25,9 @@ put the internet date into dateHeader
 
 Example:
 put the long system date into field "Today's Date"
+
+Example:
+put date("%Y-%m-%d") -- 2017-05-08
 
 Returns:
 If the useSystemDate <property> is set to true or if you specify the
@@ -57,6 +60,29 @@ The internet date form returns the following parts, separated by spaces:
           colons 
         * the four-digit time zone relative to UTC (Greenwich) time.
 
+Parameters:
+
+dateFormat (optional string): a <string> containing one or more
+formatting incantations, each of which describes a part of the requested
+date <format>. The possible incantations are as follows:
+
+* `%a` - Abbreviated weekday name:  the abbreviated day of the week, as reported
+by the <weekdayNames> function
+* `%A` - Full weekday name:  the full day of the week, as reported by the
+weekdayNames function
+* `%b` Abbreviated month name:  the abbreviated month name, as reported by the
+monthNames function
+* `%B` - Full month name:  the full month name, as reported by the monthNames
+function 
+* `%d` - Day of the month:  the day of the month as a number
+* `%m` - Month number:  the number of the month
+* `%y` - Two-digit year:  the year as a two-digit number
+* `%Y` - Four-digit year:  This incantation indicates the year as a four-digit
+number (including the century)
+* `%w` - Day of the week:  A number between 1 and 7
+* if `#` is after `%` then any leading zeros are not included
+in the format. For example for the first of the month the format `%d`
+would be `01` while the format `%#d` would be `1`.
 
 Description:
 Use the <date> <function> to display the current date to the user, or to
@@ -71,6 +97,8 @@ The ability to use the date format preferred by the user was introduced
 in version 1.1. In previous versions, the date function, along with the
 time function, consistently used the standard U.S. format, even if the
 operating system's settings specified another language or date format.
+
+The ability to use date formatting strings was added in version 9.0.
 
 References: convert (command), function (control structure),
 dateFormat (function), milliseconds (function), format (function),

--- a/docs/dictionary/function/dateFormat.lcdoc
+++ b/docs/dictionary/function/dateFormat.lcdoc
@@ -28,37 +28,23 @@ The <dateFormat> <function> returns a <string> containing one or more
 formatting incantations, each of which describes a part of the requested
 date <format>. The possible incantations are as follows:
 
-%a
-Abbreviated weekday name:  the abbreviated day of the week, as reported
+* `%a` - Abbreviated weekday name:  the abbreviated day of the week, as reported
 by the <weekdayNames> function
-
-%A
-Full weekday name:  the full day of the week, as reported by the
+* `%A` - Full weekday name:  the full day of the week, as reported by the
 weekdayNames function
-
-%b
-Abbreviated month name:  the abbreviated month name, as reported by the
+* `%b` Abbreviated month name:  the abbreviated month name, as reported by the
 monthNames function
-
-%B
-Full month name:  the full month name, as reported by the monthNames
+* `%B` - Full month name:  the full month name, as reported by the monthNames
 function 
-
-%d
-Day of the month:  the day of the month as a number
-
-%m
-Month number:  the number of the month
-
-%y
-Two-digit year:  the year as a two-digit number
-
-%Y
-Four-digit year:  This incantation indicates the year as a four-digit
+* `%d` - Day of the month:  the day of the month as a number
+* `%m` - Month number:  the number of the month
+* `%y` - Two-digit year:  the year as a two-digit number
+* `%Y` - Four-digit year:  This incantation indicates the year as a four-digit
 number (including the century)
-
-%w
-Day of the week:  A number between 1 and 7
+* `%w` - Day of the week:  A number between 1 and 7
+* if `#` is after `%` then any leading zeros are not included
+in the format. For example for the first of the month the format `%d`
+would be `01` while the format `%#d` would be `1`.
 
 >*Note:* The <dateFormat> differs from other date/time functionality in
 > that the default is to return information relative to the system

--- a/docs/notes/bugfix-11865.md
+++ b/docs/notes/bugfix-11865.md
@@ -1,0 +1,1 @@
+# Document the use of `#` in date format strings

--- a/docs/notes/bugfix-18150.md
+++ b/docs/notes/bugfix-18150.md
@@ -1,0 +1,17 @@
+# The ability to use date format strings has been added to the date function and convert command
+
+Use the date function with a format string parameter to obtain a date string in a format that is
+not currently supported. For example:
+
+```
+put date("%Y%m%dT%H%M%S%z") into tDate -- 20170507T205054+1000
+```
+
+Use the convert function with a format string to convert from, to or between formats that are
+not currently supported with syntax. For example:
+
+```    
+put "20170507T205054+1000" into tDate
+convert tDate from "%Y%m%dT%H%M%S%z" to dateItems
+-- tDate is now 2017,5,7,20,50,54,1
+```

--- a/docs/notes/bugfix-9893.md
+++ b/docs/notes/bugfix-9893.md
@@ -1,0 +1,1 @@
+# Clarify use of english date when converting dates without specifying a from format

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -67,8 +67,10 @@ class MCConvert : public MCStatement
 	MCExpression *source;
 	Convert_form fform;
 	Convert_form fsform;
+    MCExpression *m_from_format;
 	Convert_form pform;
 	Convert_form sform;
+    MCExpression *m_to_format;
 public:
 	MCConvert()
 	{
@@ -76,15 +78,17 @@ public:
 		source = NULL;
 		fform = CF_UNDEFINED;
 		fsform = CF_UNDEFINED;
+        m_from_format = NULL;
 		pform = CF_UNDEFINED;
 		sform = CF_UNDEFINED;
+        m_to_format = NULL;
 	}
 	virtual ~MCConvert();
 	virtual Parse_stat parse(MCScriptPoint &);
 	virtual void exec_ctxt(MCExecContext &);
 	virtual void compile(MCSyntaxFactoryRef);
 	Parse_stat parsedtformat(MCScriptPoint &sp, Convert_form &firstform,
-	                         Convert_form &secondform);
+	                         Convert_form &secondform, MCExpression *&r_format);
 };
 
 class MCDo : public MCStatement

--- a/engine/src/date.cpp
+++ b/engine/src/date.cpp
@@ -748,6 +748,18 @@ void MCD_date(MCExecContext &ctxt, Properties p_format, MCStringRef &r_date)
 	datetime_format(t_locale, t_date_format, t_datetime, r_date);
 }
 
+void MCD_date_of_format(MCExecContext &ctxt, MCStringRef p_format, MCStringRef &r_date)
+{
+    MCDateTime t_datetime;
+    MCS_getlocaldatetime(t_datetime);
+    
+    const MCDateTimeLocale *t_locale;
+    t_locale = g_basic_locale;
+    
+    datetime_format(t_locale, p_format, t_datetime, r_date);
+}
+
+
 void MCD_time(MCExecContext &ctxt, Properties p_format, MCStringRef &r_time)
 {
 	MCDateTime t_datetime;

--- a/engine/src/date.cpp
+++ b/engine/src/date.cpp
@@ -163,7 +163,7 @@ static bool match_prefix(MCStringRef const * p_table, uint4 p_table_length, MCSt
 	return false;
 }
 
-static bool match_number(MCStringRef p_input, uindex_t &x_offset, int4& r_number)
+static bool match_number(MCStringRef p_input, uindex_t &x_offset, uint8_t p_max_digits, int4& r_number)
 {
 	uindex_t t_length;
 	t_length = MCStringGetLength(p_input);
@@ -181,8 +181,11 @@ static bool match_number(MCStringRef p_input, uindex_t &x_offset, int4& r_number
 
 	int4 t_number;
 	t_number = 0;
-	while(x_offset <= t_length && isdigit(t_char))
+    
+    uint8_t t_found_digits = 0;
+    while(x_offset <= t_length && isdigit(t_char) && t_found_digits < p_max_digits)
 	{
+        t_found_digits++;
 		t_number = t_number * 10 + t_char - '0';
 		t_char = MCStringGetCharAtIndex(p_input, x_offset++);
 	}
@@ -337,18 +340,18 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 				t_valid = true;
 			break;
 			case 'w':
-				if (!match_number(p_input, t_in_offset, t_dayofweek))
+				if (!match_number(p_input, t_in_offset, 1, t_dayofweek))
 					return false;
 				t_valid = true;
 			break;
 			case 'd':
-				if (!match_number(p_input, t_in_offset, t_day))
+				if (!match_number(p_input, t_in_offset, 2, t_day))
 					return false;
 				t_valid_dateitems |= DATETIME_ITEM_DAY;
 				t_valid = true;
 			break;
 			case 'm':
-				if (!match_number(p_input, t_in_offset, t_month))
+				if (!match_number(p_input, t_in_offset, 2, t_month))
 					return false;
 				t_valid_dateitems |= DATETIME_ITEM_MONTH;
 				t_valid = true;
@@ -356,7 +359,10 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 			case 'y':
 			case 'Y':
 			{
-				if (!match_number(p_input, t_in_offset, t_year))
+                uint8_t t_max_digits = 4;
+                if ('y' == t_char)
+                    t_max_digits = 2;
+				if (!match_number(p_input, t_in_offset, t_max_digits, t_year))
 				{
 					if (t_loose_components)
 						t_skip = true; // Year specification is optional, so skip to the next specifier
@@ -379,13 +385,13 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 			}
 			break;
 			case 'J':
-				if (!match_number(p_input, t_in_offset, t_hour))
+				if (!match_number(p_input, t_in_offset, 2, t_hour))
 					return false;
 				t_valid_dateitems |= DATETIME_ITEM_HOUR;
 				t_valid = true;
 			break;
 			case 'I':
-				if (!match_number(p_input, t_in_offset, t_hour))
+				if (!match_number(p_input, t_in_offset, 2, t_hour))
 					return false;
 				if (t_hour == 12)
 					t_hour = 0;
@@ -393,19 +399,19 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 				t_valid = true;
 			break;
 			case 'H':
-				if (!match_number(p_input, t_in_offset, t_hour))
+				if (!match_number(p_input, t_in_offset, 2, t_hour))
 					return false;
 				t_valid_dateitems |= DATETIME_ITEM_HOUR;
 				t_valid = true;
 			break;
 			case 'M':
-				if (!match_number(p_input, t_in_offset, t_minute))
+				if (!match_number(p_input, t_in_offset, 2, t_minute))
 					return false;
 				t_valid_dateitems |= DATETIME_ITEM_MINUTE;
 				t_valid = true;
 			break;
 			case 'S':
-				if (!match_number(p_input, t_in_offset, t_second))
+				if (!match_number(p_input, t_in_offset, 2, t_second))
 					return false;
 				t_valid_dateitems |= DATETIME_ITEM_SECOND;
 				t_valid = true;
@@ -418,7 +424,7 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 				t_valid = true;
 			break;
 			case 'z':
-				if (!match_number(p_input, t_in_offset, t_bias)) // TOO LOOSE!
+				if (!match_number(p_input, t_in_offset, 4, t_bias)) // TOO LOOSE!
 					return false;
 				t_bias = (t_bias / 100) * 60 + (t_bias % 100);
 				t_valid = true;
@@ -508,21 +514,33 @@ static bool datetime_parse(const MCDateTimeLocale *p_locale, int4 p_century_cuto
 
 	if ((t_valid_dateitems & DATETIME_ITEM_SECOND) != 0)
 		r_datetime . second = t_second;
+    else
+        r_datetime . second = 0;
 
 	if ((t_valid_dateitems & DATETIME_ITEM_MINUTE) != 0)
 		r_datetime . minute = t_minute;
+    else
+        r_datetime . minute = 0;
 
 	if ((t_valid_dateitems & DATETIME_ITEM_HOUR) != 0)
 		r_datetime . hour = t_hour;
+    else
+        r_datetime . hour = 0;
 
 	if ((t_valid_dateitems & DATETIME_ITEM_DAY) != 0)
 		r_datetime . day = t_day;
+    else
+        r_datetime . day = 0;
 
 	if ((t_valid_dateitems & DATETIME_ITEM_MONTH) != 0)
 		r_datetime . month = t_month;
+    else
+        r_datetime . month = 0;
 
 	if ((t_valid_dateitems & DATETIME_ITEM_YEAR) != 0)
 		r_datetime . year = t_year;
+    else
+        r_datetime . year = 0;
 
 	x_offset = t_in_offset;
 	r_valid_dateitems |= t_valid_dateitems;
@@ -1018,7 +1036,7 @@ static bool convert_parse_time(MCExecContext &ctxt, const MCDateTimeLocale *p_lo
 	return false;
 }
 
-bool MCD_convert_to_datetime(MCExecContext &ctxt, MCValueRef p_input, Convert_form p_primary_from, Convert_form p_secondary_from, MCDateTime &r_datetime)
+bool MCD_convert_to_datetime(MCExecContext &ctxt, MCValueRef p_input, Convert_form p_primary_from, Convert_form p_secondary_from, MCStringRef p_from_format, MCDateTime &r_datetime)
 {
     bool t_success = true;
     
@@ -1027,240 +1045,264 @@ bool MCD_convert_to_datetime(MCExecContext &ctxt, MCValueRef p_input, Convert_fo
 	// Make sure 'empty' is not a date
 	if (MCValueIsEmpty(p_input))
 		return false;
-	
-	uindex_t t_offset = 0;
+    
+    uindex_t t_offset = 0;
 
-	real64_t t_seconds;
-	if (p_primary_from != CF_UNDEFINED)
-	{
+    if (NULL != p_from_format)
+    {
+        int t_valid_dateitems;
+        t_valid_dateitems = 0;
+        
+        MCAutoStringRef t_string;
+        if (!ctxt.ConvertToString(p_input, &t_string))
+            return false;
+        
+        if (!datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, p_from_format, *t_string, t_offset, t_datetime, t_valid_dateitems) || MCStringIsEmpty(*t_string))
+            return false;
+        
+        if (!datetime_validate(t_datetime))
+            return false;
+        
+        t_datetime . minute -= t_datetime . bias;
+        t_datetime . bias = 0;
+        
+        datetime_normalize(t_datetime);
+    }
+    else
+    {
+    
+        real64_t t_seconds;
+        if (p_primary_from != CF_UNDEFINED)
+        {
 
-		if (p_primary_from == CF_SECONDS)
-		{
-			if (!ctxt.ConvertToReal(p_input, t_seconds))
-				return false;
+            if (p_primary_from == CF_SECONDS)
+            {
+                if (!ctxt.ConvertToReal(p_input, t_seconds))
+                    return false;
 
-			t_success = MCS_secondstodatetime(t_seconds, t_datetime);
-		}
-		else if (p_primary_from == CF_DATEITEMS)
-		{
-			int t_valid_dateitems;
-			t_valid_dateitems = 0;
-            
-			MCAutoStringRef t_string;
-			if (!ctxt.ConvertToString(p_input, &t_string))
-				return false;
-			
-			if (!datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_items_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) || MCStringIsEmpty(*t_string))
-				return false;
-            
-			datetime_normalize(t_datetime);
-            
-			t_success = MCS_datetimetouniversal(t_datetime);
-		}
-		else if (p_primary_from == CF_INTERNET_DATE)
-		{
-			int t_valid_dateitems;
-			t_valid_dateitems = 0;
-            
-			MCAutoStringRef t_string;
-			if (!ctxt.ConvertToString(p_input, &t_string))
-				return false;
-			
-			if (!datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_internet_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) || MCStringIsEmpty(*t_string))
-				return false;
-            
-			if (!datetime_validate(t_datetime))
-				return false;
-            
-			t_datetime . minute -= t_datetime . bias;
-			t_datetime . bias = 0;
-            
-			datetime_normalize(t_datetime);
-		}
-		else
-		{
-			const MCDateTimeLocale *t_locale;
-			MCStringRef t_date_format;
-            
-			int t_valid_dateitems;
-			t_valid_dateitems = 0;
-            
-			MCAutoStringRef t_string;
-			if (!ctxt.ConvertToString(p_input, &t_string))
-				return false;
-			
-			bool t_is_time;
-			t_is_time = MCD_decompose_convert_format(ctxt, p_primary_from, t_locale, t_date_format);
-			if (t_is_time && !convert_parse_time(ctxt, t_locale, *t_string, t_offset, t_datetime, t_valid_dateitems))
-				return false;
-			else if (!t_is_time && !datetime_parse(t_locale, ctxt.GetCutOff(), true, t_date_format, *t_string, t_offset, t_datetime, t_valid_dateitems))
-				return false;
-            
-			if (p_secondary_from != CF_UNDEFINED)
-			{
-				t_is_time = MCD_decompose_convert_format(ctxt, p_secondary_from, t_locale, t_date_format);
-				if (t_is_time && !convert_parse_time(ctxt, t_locale, *t_string, t_offset, t_datetime, t_valid_dateitems))
-					return false;
-				else if (!t_is_time && !datetime_parse(t_locale, ctxt.GetCutOff(), true, t_date_format, *t_string, t_offset, t_datetime, t_valid_dateitems))
-					return false;
-			}
-			
-            // AL-2014-03-04: [[ Bug 12104 ]] If we have more to parse here, then parsing failed.
-			if (MCStringGetLength(*t_string) > t_offset)
-				return false;
-            
-			if ((t_valid_dateitems & DATETIME_ITEM_DATE) != DATETIME_ITEM_DATE)
-			{
-				MCDateTime t_today;
-				MCS_getlocaldatetime(t_today);
+                t_success = MCS_secondstodatetime(t_seconds, t_datetime);
+            }
+            else if (p_primary_from == CF_DATEITEMS)
+            {
+                int t_valid_dateitems;
+                t_valid_dateitems = 0;
                 
-				if ((t_valid_dateitems & DATETIME_ITEM_DAY) == 0)
-					t_datetime . day = t_today . day;
+                MCAutoStringRef t_string;
+                if (!ctxt.ConvertToString(p_input, &t_string))
+                    return false;
                 
-				if ((t_valid_dateitems & DATETIME_ITEM_MONTH) == 0)
-					t_datetime . month = t_today . month;
+                if (!datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_items_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) || MCStringIsEmpty(*t_string))
+                    return false;
                 
-				if ((t_valid_dateitems & DATETIME_ITEM_YEAR) == 0)
-					t_datetime . year = t_today . year;
-			}
-            
-			if ((t_valid_dateitems & DATETIME_ITEM_HOUR) == 0)
-			{
-				t_datetime . hour = 0;
-				t_datetime . minute = 0;
-				t_datetime . second = 0;
-				t_datetime . bias = 0;
-			}
-			else if ((t_valid_dateitems & DATETIME_ITEM_SECOND) == 0)
-				t_datetime . second = 0;
-			
-			if (!datetime_validate(t_datetime))
-				return false;
-            
-			t_success = MCS_datetimetouniversal(t_datetime);
-		}
-	}
-	else if (ctxt.ConvertToReal(p_input, t_seconds))
-	{
-		if (t_seconds < SECONDS_MIN || t_seconds > SECONDS_MAX)
-			return false;
-        
-		t_success = MCS_secondstodatetime(t_seconds, t_datetime);
-	}
-	else if (!MCValueIsEmpty(p_input))
-	{
-		const MCDateTimeLocale *t_locale;
-		if (ctxt.GetUseSystemDate())
-			t_locale = MCS_getdatetimelocale();
-		else
-			t_locale = g_basic_locale;
-        
-		int t_valid_dateitems;
-		t_valid_dateitems = 0;
-        
-		// Order for dates:
-		//   long date
-		//   abbrev date
-		//   short date
-		//
-		// Order for times:
-		//   long time
-		//   short time
-		//   long time 24
-		//   short time 24
-        
-		MCAutoStringRef t_string;
-		if (!ctxt.ConvertToString(p_input, &t_string))
-			return false;
-		
-		if (datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_items_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) && !MCStringIsEmpty(*t_string))
-		{
-			datetime_normalize(t_datetime);
-			t_success = MCS_datetimetouniversal(t_datetime);
-		}
-		else if (datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_internet_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) && MCStringIsEmpty(*t_string))
-		{
-			if (!datetime_validate(t_datetime))
-				return false;
-            
-			t_datetime . minute -= t_datetime . bias;
-			t_datetime . bias = 0;
-            
-			datetime_normalize(t_datetime);
-		}
-		else
-		{
-			bool t_date_valid;
-			bool t_time_valid;
-            
-			t_date_valid = false;
-			t_time_valid = false;
-			
-			uindex_t t_length;
-			t_length = MCStringGetLength(*t_string);
-			while(t_offset < t_length && !(t_date_valid && t_time_valid))
-			{
-				bool t_changed;
-				t_changed = false;
+                datetime_normalize(t_datetime);
                 
-				if (!t_date_valid)
-				{
-					for(uint4 t_format = 0; t_format < 3; ++t_format)
-						if (datetime_parse(t_locale, ctxt.GetCutOff(), true, t_locale -> date_formats[2 - t_format], *t_string, t_offset, t_datetime, t_valid_dateitems))
-						{
-							t_date_valid = true;
-							t_changed = true;
-							break;
-						}
-				}
+                t_success = MCS_datetimetouniversal(t_datetime);
+            }
+            else if (p_primary_from == CF_INTERNET_DATE)
+            {
+                int t_valid_dateitems;
+                t_valid_dateitems = 0;
                 
-				if (!t_time_valid)
-				{
-					if (convert_parse_time(ctxt, t_locale, *t_string, t_offset, t_datetime, t_valid_dateitems))
-					{
-						t_time_valid = true;
-						t_changed = true;
-					}
-				}
+                MCAutoStringRef t_string;
+                if (!ctxt.ConvertToString(p_input, &t_string))
+                    return false;
                 
-				if (!t_changed)
-					break;
-			}
+                if (!datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_internet_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) || MCStringIsEmpty(*t_string))
+                    return false;
+                
+                if (!datetime_validate(t_datetime))
+                    return false;
+                
+                t_datetime . minute -= t_datetime . bias;
+                t_datetime . bias = 0;
+                
+                datetime_normalize(t_datetime);
+            }
+            else
+            {
+                const MCDateTimeLocale *t_locale;
+                MCStringRef t_date_format;
+                
+                int t_valid_dateitems;
+                t_valid_dateitems = 0;
+                
+                MCAutoStringRef t_string;
+                if (!ctxt.ConvertToString(p_input, &t_string))
+                    return false;
+                
+                bool t_is_time;
+                t_is_time = MCD_decompose_convert_format(ctxt, p_primary_from, t_locale, t_date_format);
+                if (t_is_time && !convert_parse_time(ctxt, t_locale, *t_string, t_offset, t_datetime, t_valid_dateitems))
+                    return false;
+                else if (!t_is_time && !datetime_parse(t_locale, ctxt.GetCutOff(), true, t_date_format, *t_string, t_offset, t_datetime, t_valid_dateitems))
+                    return false;
+                
+                if (p_secondary_from != CF_UNDEFINED)
+                {
+                    t_is_time = MCD_decompose_convert_format(ctxt, p_secondary_from, t_locale, t_date_format);
+                    if (t_is_time && !convert_parse_time(ctxt, t_locale, *t_string, t_offset, t_datetime, t_valid_dateitems))
+                        return false;
+                    else if (!t_is_time && !datetime_parse(t_locale, ctxt.GetCutOff(), true, t_date_format, *t_string, t_offset, t_datetime, t_valid_dateitems))
+                        return false;
+                }
+                
+                // AL-2014-03-04: [[ Bug 12104 ]] If we have more to parse here, then parsing failed.
+                if (MCStringGetLength(*t_string) > t_offset)
+                    return false;
+                
+                if ((t_valid_dateitems & DATETIME_ITEM_DATE) != DATETIME_ITEM_DATE)
+                {
+                    MCDateTime t_today;
+                    MCS_getlocaldatetime(t_today);
+                    
+                    if ((t_valid_dateitems & DATETIME_ITEM_DAY) == 0)
+                        t_datetime . day = t_today . day;
+                    
+                    if ((t_valid_dateitems & DATETIME_ITEM_MONTH) == 0)
+                        t_datetime . month = t_today . month;
+                    
+                    if ((t_valid_dateitems & DATETIME_ITEM_YEAR) == 0)
+                        t_datetime . year = t_today . year;
+                }
+                
+                if ((t_valid_dateitems & DATETIME_ITEM_HOUR) == 0)
+                {
+                    t_datetime . hour = 0;
+                    t_datetime . minute = 0;
+                    t_datetime . second = 0;
+                    t_datetime . bias = 0;
+                }
+                else if ((t_valid_dateitems & DATETIME_ITEM_SECOND) == 0)
+                    t_datetime . second = 0;
+                
+                if (!datetime_validate(t_datetime))
+                    return false;
+                
+                t_success = MCS_datetimetouniversal(t_datetime);
+            }
+        }
+        else if (ctxt.ConvertToReal(p_input, t_seconds))
+        {
+            if (t_seconds < SECONDS_MIN || t_seconds > SECONDS_MAX)
+                return false;
             
-			if (t_offset < t_length)
-				return false;
+            t_success = MCS_secondstodatetime(t_seconds, t_datetime);
+        }
+        else if (!MCValueIsEmpty(p_input))
+        {
+            const MCDateTimeLocale *t_locale;
+            if (ctxt.GetUseSystemDate())
+                t_locale = MCS_getdatetimelocale();
+            else
+                t_locale = g_basic_locale;
             
-			if ((t_valid_dateitems & DATETIME_ITEM_DATE) != DATETIME_ITEM_DATE)
-			{
-				MCDateTime t_today;
-				MCS_getlocaldatetime(t_today);
-                
-				if ((t_valid_dateitems & DATETIME_ITEM_DAY) == 0)
-					t_datetime . day = t_today . day;
-                
-				if ((t_valid_dateitems & DATETIME_ITEM_MONTH) == 0)
-					t_datetime . month = t_today . month;
-                
-				if ((t_valid_dateitems & DATETIME_ITEM_YEAR) == 0)
-					t_datetime . year = t_today . year;
-			}
+            int t_valid_dateitems;
+            t_valid_dateitems = 0;
             
-			if ((t_valid_dateitems & DATETIME_ITEM_HOUR) == 0)
-			{
-				t_datetime . hour = 0;
-				t_datetime . minute = 0;
-				t_datetime . second = 0;
-				t_datetime . bias = 0;
-			}
-			else if ((t_valid_dateitems & DATETIME_ITEM_SECOND) == 0)
-				t_datetime . second = 0;
-			
-			if (!datetime_validate(t_datetime))
-				return false;
+            // Order for dates:
+            //   long date
+            //   abbrev date
+            //   short date
+            //
+            // Order for times:
+            //   long time
+            //   short time
+            //   long time 24
+            //   short time 24
             
-			t_success = MCS_datetimetouniversal(t_datetime);
-		}
-	}
+            MCAutoStringRef t_string;
+            if (!ctxt.ConvertToString(p_input, &t_string))
+                return false;
+            
+            if (datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_items_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) && !MCStringIsEmpty(*t_string))
+            {
+                datetime_normalize(t_datetime);
+                t_success = MCS_datetimetouniversal(t_datetime);
+            }
+            else if (datetime_parse(g_basic_locale, ctxt.GetCutOff(), false, MCSTR(s_internet_date_format), *t_string, t_offset, t_datetime, t_valid_dateitems) && MCStringIsEmpty(*t_string))
+            {
+                if (!datetime_validate(t_datetime))
+                    return false;
+                
+                t_datetime . minute -= t_datetime . bias;
+                t_datetime . bias = 0;
+                
+                datetime_normalize(t_datetime);
+            }
+            else
+            {
+                bool t_date_valid;
+                bool t_time_valid;
+                
+                t_date_valid = false;
+                t_time_valid = false;
+                
+                uindex_t t_length;
+                t_length = MCStringGetLength(*t_string);
+                while(t_offset < t_length && !(t_date_valid && t_time_valid))
+                {
+                    bool t_changed;
+                    t_changed = false;
+                    
+                    if (!t_date_valid)
+                    {
+                        for(uint4 t_format = 0; t_format < 3; ++t_format)
+                            if (datetime_parse(t_locale, ctxt.GetCutOff(), true, t_locale -> date_formats[2 - t_format], *t_string, t_offset, t_datetime, t_valid_dateitems))
+                            {
+                                t_date_valid = true;
+                                t_changed = true;
+                                break;
+                            }
+                    }
+                    
+                    if (!t_time_valid)
+                    {
+                        if (convert_parse_time(ctxt, t_locale, *t_string, t_offset, t_datetime, t_valid_dateitems))
+                        {
+                            t_time_valid = true;
+                            t_changed = true;
+                        }
+                    }
+                    
+                    if (!t_changed)
+                        break;
+                }
+                
+                if (t_offset < t_length)
+                    return false;
+                
+                if ((t_valid_dateitems & DATETIME_ITEM_DATE) != DATETIME_ITEM_DATE)
+                {
+                    MCDateTime t_today;
+                    MCS_getlocaldatetime(t_today);
+                    
+                    if ((t_valid_dateitems & DATETIME_ITEM_DAY) == 0)
+                        t_datetime . day = t_today . day;
+                    
+                    if ((t_valid_dateitems & DATETIME_ITEM_MONTH) == 0)
+                        t_datetime . month = t_today . month;
+                    
+                    if ((t_valid_dateitems & DATETIME_ITEM_YEAR) == 0)
+                        t_datetime . year = t_today . year;
+                }
+                
+                if ((t_valid_dateitems & DATETIME_ITEM_HOUR) == 0)
+                {
+                    t_datetime . hour = 0;
+                    t_datetime . minute = 0;
+                    t_datetime . second = 0;
+                    t_datetime . bias = 0;
+                }
+                else if ((t_valid_dateitems & DATETIME_ITEM_SECOND) == 0)
+                    t_datetime . second = 0;
+                
+                if (!datetime_validate(t_datetime))
+                    return false;
+                
+                t_success = MCS_datetimetouniversal(t_datetime);
+            }
+        }
+    }
     
     if (t_success)
         r_datetime = t_datetime;
@@ -1268,7 +1310,7 @@ bool MCD_convert_to_datetime(MCExecContext &ctxt, MCValueRef p_input, Convert_fo
     return t_success;
 }
 
-bool MCD_convert_from_datetime(MCExecContext &ctxt, MCDateTime p_datetime, Convert_form p_primary_to, Convert_form p_secondary_to, MCValueRef &r_output)
+bool MCD_convert_from_datetime(MCExecContext &ctxt, MCDateTime p_datetime, Convert_form p_primary_to, Convert_form p_secondary_to, MCStringRef p_to_format, MCValueRef &r_output)
 {
     bool t_success = true;
     
@@ -1297,28 +1339,35 @@ bool MCD_convert_from_datetime(MCExecContext &ctxt, MCDateTime p_datetime, Conve
 			return False;
         
 		const MCDateTimeLocale *t_locale;
-		MCAutoStringRef t_date_format;
+        MCStringRef t_buffer;
         
-		MCStringRef t_buffer;
+        if (NULL != p_to_format)
+        {
+            t_locale = g_basic_locale;
+            datetime_format(t_locale, p_to_format, p_datetime, t_buffer);
+        }
+        else
+        {
+            MCAutoStringRef t_date_format;
+            MCD_decompose_convert_format(ctxt, p_primary_to, t_locale, &t_date_format);
+            
+            datetime_format(t_locale, *t_date_format, p_datetime, t_buffer);
         
-		MCD_decompose_convert_format(ctxt, p_primary_to, t_locale, &t_date_format);
-		datetime_format(t_locale, *t_date_format, p_datetime, t_buffer);
-		
+            if (p_secondary_to != CF_UNDEFINED)
+            {
+                MCAutoStringRef t_secondary_format;
+                MCStringRef t_buffer_secondary;
+                MCD_decompose_convert_format(ctxt, p_secondary_to, t_locale, &t_secondary_format);
+                datetime_format(t_locale, *t_secondary_format, p_datetime, t_buffer_secondary);
+                
+                MCStringRef t_new;
+                /* UNCHECKED */ MCStringFormat(t_new, "%@ %@", t_buffer, t_buffer_secondary);
+                MCValueRelease(t_buffer);
+                MCValueRelease(t_buffer_secondary);
+                t_buffer = t_new;
+            }
+        }
         
-		if (p_secondary_to != CF_UNDEFINED)
-		{
-            MCAutoStringRef t_secondary_format;
-			MCStringRef t_buffer_secondary;
-			MCD_decompose_convert_format(ctxt, p_secondary_to, t_locale, &t_secondary_format);
-			datetime_format(t_locale, *t_secondary_format, p_datetime, t_buffer_secondary);
-			
-			MCStringRef t_new;
-			/* UNCHECKED */ MCStringFormat(t_new, "%@ %@", t_buffer, t_buffer_secondary);
-			MCValueRelease(t_buffer);
-			MCValueRelease(t_buffer_secondary);
-			t_buffer = t_new;
-		}
-		
         // AL-2014-03-04: [[ Bug 12104 ]] The result should be empty if conversion is successful.
 		//ctxt.SetTheResultToValue(t_buffer);
 		r_output = t_buffer;
@@ -1327,7 +1376,7 @@ bool MCD_convert_from_datetime(MCExecContext &ctxt, MCDateTime p_datetime, Conve
     return t_success;
 }
 
-bool MCD_convert(MCExecContext &ctxt, MCValueRef p_input, Convert_form p_primary_from, Convert_form p_secondary_from, Convert_form p_primary_to, Convert_form p_secondary_to, MCStringRef &r_converted)
+bool MCD_convert(MCExecContext &ctxt, MCValueRef p_input, Convert_form p_primary_from, Convert_form p_secondary_from, MCStringRef p_from_format, Convert_form p_primary_to, Convert_form p_secondary_to, MCStringRef p_to_format, MCStringRef &r_converted)
 {
 	bool t_success;
 	t_success = true;
@@ -1335,11 +1384,11 @@ bool MCD_convert(MCExecContext &ctxt, MCValueRef p_input, Convert_form p_primary
 	// MM-2012-03-01: [[ BUG 10006]] Primaries and secondaries mixed up
 	MCDateTime t_datetime;
 
-	t_success = MCD_convert_to_datetime(ctxt, p_input, p_primary_from, p_secondary_from, t_datetime);
+	t_success = MCD_convert_to_datetime(ctxt, p_input, p_primary_from, p_secondary_from, p_from_format, t_datetime);
 
 	MCAutoValueRef t_output;
     if (t_success)
-        t_success = MCD_convert_from_datetime(ctxt, t_datetime, p_primary_to, p_secondary_to, &t_output);
+        t_success = MCD_convert_from_datetime(ctxt, t_datetime, p_primary_to, p_secondary_to, p_to_format, &t_output);
 	
 	MCAutoStringRef t_string;
 	if (t_success)

--- a/engine/src/date.h
+++ b/engine/src/date.h
@@ -209,6 +209,7 @@ extern bool MCDateTimeInitialize();
 extern bool MCDateTimeFinalize();
 
 extern void MCD_date(MCExecContext& ctxt, Properties p_format, MCStringRef& r_date);
+extern void MCD_date_of_format(MCExecContext &ctxt, MCStringRef p_format, MCStringRef &r_date);
 extern void MCD_time(MCExecContext& ctxt, Properties p_format, MCStringRef& r_time);
 extern bool MCD_monthnames(MCExecContext& ctxt, Properties p_format, MCListRef& r_list);
 extern bool MCD_weekdaynames(MCExecContext& ctxt, Properties p_format, MCListRef& r_list);

--- a/engine/src/date.h
+++ b/engine/src/date.h
@@ -216,13 +216,21 @@ extern bool MCD_weekdaynames(MCExecContext& ctxt, Properties p_format, MCListRef
 extern void MCD_dateformat(MCExecContext& ctxt, Properties p_format, MCStringRef& r_dateformat);
 
 extern bool MCD_convert(MCExecContext& ctxt, MCValueRef p_input,
-						Convert_form p_primary_from, Convert_form p_secondary_from,
-						Convert_form p_primary_to, Convert_form p_secondary_to,
+						Convert_form p_primary_from, Convert_form p_secondary_from, MCStringRef p_from_format,
+						Convert_form p_primary_to, Convert_form p_secondary_to, MCStringRef p_to_format,
 						MCStringRef& r_converted);
 
-extern bool MCD_convert_to_datetime(MCExecContext& ctxt, MCValueRef p_input, Convert_form p_primary_from, Convert_form p_secondary_from, MCDateTime &r_datetime);
-extern bool MCD_convert_from_datetime(MCExecContext& ctxt, MCDateTime p_datetime, Convert_form p_primary_from, Convert_form p_secondary_from, MCValueRef &r_output);
+extern bool MCD_convert_to_datetime(MCExecContext &ctxt, MCValueRef p_input, Convert_form p_primary_from, Convert_form p_secondary_from, MCStringRef p_from_format, MCDateTime &r_datetime);
+inline bool MCD_convert_to_datetime(MCExecContext& ctxt, MCValueRef p_input, Convert_form p_primary_from, Convert_form p_secondary_from, MCDateTime &r_datetime)
+{
+    return MCD_convert_to_datetime(ctxt, p_input, p_primary_from, p_secondary_from, NULL, r_datetime);
+}
 
+extern bool MCD_convert_from_datetime(MCExecContext& ctxt, MCDateTime p_datetime, Convert_form p_primary_from, Convert_form p_secondary_from, MCStringRef p_from_format, MCValueRef &r_output);
+inline bool MCD_convert_from_datetime(MCExecContext& ctxt, MCDateTime p_datetime, Convert_form p_primary_from, Convert_form p_secondary_from, MCValueRef &r_output)
+{
+    return MCD_convert_from_datetime(ctxt, p_datetime, p_primary_from, p_secondary_from, NULL, r_output);
+}
 extern void MCD_getlocaleformats();
 
 #endif

--- a/engine/src/exec-datetime.cpp
+++ b/engine/src/exec-datetime.cpp
@@ -113,8 +113,9 @@ void MCDateTimeEvalWeekDayNames(MCExecContext& ctxt, MCStringRef& r_string)
 void MCDateTimeEvalIsADate(MCExecContext& ctxt, MCValueRef p_value, bool& r_result)
 {
 	MCAutoStringRef t_string, t_converted;
-	r_result = ctxt.ConvertToString(p_value, &t_string) && MCD_convert(ctxt, *t_string, CF_UNDEFINED, CF_UNDEFINED,
-					   CF_SECONDS, CF_UNDEFINED, &t_converted);
+	r_result = ctxt.ConvertToString(p_value, &t_string) &&
+               MCD_convert(ctxt, *t_string, CF_UNDEFINED, CF_UNDEFINED, NULL,
+					   CF_SECONDS, CF_UNDEFINED, NULL, &t_converted);
 }
 
 void MCDateTimeEvalIsNotADate(MCExecContext& ctxt, MCValueRef p_value, bool& r_result)
@@ -125,9 +126,9 @@ void MCDateTimeEvalIsNotADate(MCExecContext& ctxt, MCValueRef p_value, bool& r_r
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCDateTimeExecConvert(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, int p_to_first, int p_to_second, MCStringRef &r_output)
+void MCDateTimeExecConvert(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, MCStringRef p_from_format, int p_to_first, int p_to_second, MCStringRef p_to_format, MCStringRef &r_output)
 {
-	if (!MCD_convert(ctxt, p_input, (Convert_form)p_from_first, (Convert_form)p_from_second, (Convert_form)p_to_first, (Convert_form)p_to_second, r_output))
+	if (!MCD_convert(ctxt, p_input, (Convert_form)p_from_first, (Convert_form)p_from_second, p_from_format, (Convert_form)p_to_first, (Convert_form)p_to_second, p_to_format, r_output))
 	{
 		MCStringCopy(p_input, r_output);
 		ctxt .SetTheResultToStaticCString("invalid date");
@@ -136,10 +137,10 @@ void MCDateTimeExecConvert(MCExecContext &ctxt, MCStringRef p_input, int p_from_
     else
         ctxt . SetTheResultToEmpty();
 }
-void MCDateTimeExecConvertIntoIt(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, int p_to_first, int p_to_second)
+void MCDateTimeExecConvertIntoIt(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, MCStringRef p_from_format, int p_to_first, int p_to_second, MCStringRef p_to_format)
 {
 	MCAutoStringRef t_output;
-	MCDateTimeExecConvert(ctxt, p_input, p_from_first, p_from_second, p_to_first, p_to_second, &t_output);
+	MCDateTimeExecConvert(ctxt, p_input, p_from_first, p_from_second, p_from_format, p_to_first, p_to_second, p_to_format, &t_output);
 	ctxt . SetItToValue(*t_output);
 }
 

--- a/engine/src/exec-datetime.cpp
+++ b/engine/src/exec-datetime.cpp
@@ -34,6 +34,7 @@ MC_EXEC_DEFINE_EVAL_METHOD(DateTime, Milliseconds, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(DateTime, Seconds, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(DateTime, Ticks, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(DateTime, Date, 1)
+MC_EXEC_DEFINE_EVAL_METHOD(DateTime, DateOfFormat, 2)
 MC_EXEC_DEFINE_EVAL_METHOD(DateTime, Time, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(DateTime, DateFormat, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(DateTime, MonthNames, 1)
@@ -74,6 +75,11 @@ void MCDateTimeEvalTicks(MCExecContext& ctxt, real64_t& r_ticks)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void MCDateTimeEvalDateOfFormat(MCExecContext& ctxt, MCStringRef p_format, MCStringRef& r_string)
+{
+    MCDateTimeGetDateOfFormat(ctxt, p_format, r_string);
+}
 
 void MCDateTimeEvalDate(MCExecContext& ctxt, MCStringRef& r_string)
 {
@@ -154,6 +160,11 @@ void MCDateTimeSetTwelveTime(MCExecContext &ctxt, bool p_value)
 void MCDateTimeGetDate(MCExecContext &ctxt, Properties p_type, MCStringRef& r_value)
 {
 	MCD_date(ctxt, p_type, r_value);
+}
+
+void MCDateTimeGetDateOfFormat(MCExecContext &ctxt, MCStringRef p_format, MCStringRef& r_value)
+{
+    MCD_date_of_format(ctxt, p_format, r_value);
 }
 
 void MCDateTimeGetTime(MCExecContext &ctxt, Properties p_type, MCStringRef& r_value)

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -2232,7 +2232,8 @@ void MCStringsSortAddItem(MCExecContext &ctxt, MCSortnode *items, uint4 &nitems,
 	switch (form)
 	{
         case ST_DATETIME:
-            if (t_success && MCD_convert(ctxt, *t_output, CF_UNDEFINED, CF_UNDEFINED, CF_SECONDS, CF_UNDEFINED, &t_converted))
+            if (t_success &&
+                MCD_convert(ctxt, *t_output, CF_UNDEFINED, CF_UNDEFINED, NULL, CF_SECONDS, CF_UNDEFINED, NULL, &t_converted))
                 if (ctxt.ConvertToNumber(*t_converted, items[nitems].nvalue))
                     break;
             

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4496,6 +4496,7 @@ extern MCExecMethodInfo *kMCDateTimeEvalMillisecondsMethodInfo;
 extern MCExecMethodInfo *kMCDateTimeEvalSecondsMethodInfo;
 extern MCExecMethodInfo *kMCDateTimeEvalTicksMethodInfo;
 extern MCExecMethodInfo *kMCDateTimeEvalDateMethodInfo;
+extern MCExecMethodInfo *kMCDateTimeEvalDateOfFormatMethodInfo;
 extern MCExecMethodInfo *kMCDateTimeEvalTimeMethodInfo;
 extern MCExecMethodInfo *kMCDateTimeEvalDateFormatMethodInfo;
 extern MCExecMethodInfo *kMCDateTimeEvalMonthNamesMethodInfo;
@@ -4523,6 +4524,7 @@ void MCDateTimeEvalSeconds(MCExecContext& ctxt, real64_t& r_seconds);
 void MCDateTimeEvalTicks(MCExecContext& ctxt, real64_t& r_ticks);
 
 void MCDateTimeEvalDate(MCExecContext& ctxt, MCStringRef& r_string);
+void MCDateTimeEvalDateOfFormat(MCExecContext& ctxt, MCStringRef p_format, MCStringRef& r_string);
 void MCDateTimeEvalTime(MCExecContext& ctxt, MCStringRef& r_string);
 
 void MCDateTimeEvalDateFormat(MCExecContext& ctxt, MCStringRef& r_string);
@@ -4539,6 +4541,7 @@ void MCDateTimeGetTwelveTime(MCExecContext &ctxt, bool& r_value);
 void MCDateTimeSetTwelveTime(MCExecContext &ctxt, bool p_value);
 
 void MCDateTimeGetDate(MCExecContext &ctxt, Properties p_type, MCStringRef& r_value);
+void MCDateTimeGetDateOfFormat(MCExecContext &ctxt, MCStringRef p_format, MCStringRef& r_value);
 void MCDateTimeGetTime(MCExecContext &ctxt, Properties p_type, MCStringRef& r_value);
 void MCDateTimeGetMilliseconds(MCExecContext &ctxt, double& r_value);
 void MCDateTimeGetLongMilliseconds(MCExecContext &ctxt, double& r_value);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4534,8 +4534,8 @@ void MCDateTimeEvalWeekDayNames(MCExecContext& ctxt, MCStringRef& r_string);
 void MCDateTimeEvalIsADate(MCExecContext& ctxt, MCValueRef p_value, bool& r_result);
 void MCDateTimeEvalIsNotADate(MCExecContext& ctxt, MCValueRef p_value, bool& r_result);
 
-void MCDateTimeExecConvert(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, int p_to_first, int p_to_second, MCStringRef &r_output);
-void MCDateTimeExecConvertIntoIt(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, int p_to_first, int p_to_second);
+void MCDateTimeExecConvert(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, MCStringRef p_from_format, int p_to_first, int p_to_second, MCStringRef p_to_format, MCStringRef &r_output);
+void MCDateTimeExecConvertIntoIt(MCExecContext &ctxt, MCStringRef p_input, int p_from_first, int p_from_second, MCStringRef p_from_format, int p_to_first, int p_to_second, MCStringRef p_to_format);
 
 void MCDateTimeGetTwelveTime(MCExecContext &ctxt, bool& r_value);
 void MCDateTimeSetTwelveTime(MCExecContext &ctxt, bool p_value);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2749,6 +2749,9 @@ enum Exec_errors
 
     // {EE-0900} messageDigest: error in message data parameter
     EE_MESSAGEDIGEST_BADDATA,
+    
+    // {EE-0901} date: error in format parameter
+    EE_DATE_BADFORMAT,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -648,6 +648,63 @@ void MCCommandName::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
         MCExecValueTraits<MCStringRef>::set(r_value, kMCEmptyString);
 }
 
+MCDate::~MCDate()
+{
+    delete m_format;
+}
+
+Parse_stat
+MCDate::parse(MCScriptPoint & sp, Boolean p_is_the)
+{
+    if (p_is_the)
+    {
+        initpoint(sp);
+    }
+    else
+    {
+        if (PS_NORMAL != get0or1param(sp, &m_format, p_is_the))
+        {
+            MCperror->add(PE_FOLDERS_BADPARAM, sp);
+            return PS_ERROR;
+        }
+    }
+    return PS_NORMAL;
+}
+
+void
+MCDate::eval_ctxt(MCExecContext & ctxt, MCExecValue & r_value)
+{
+    r_value.type = kMCExecValueTypeStringRef;
+    
+    if (m_format) {
+        MCAutoStringRef t_format;
+        if (!ctxt.EvalExprAsStringRef(m_format, EE_DATE_BADFORMAT, &t_format))
+            return;
+        
+        MCDateTimeEvalDateOfFormat(ctxt, *t_format, r_value.stringref_value);
+    }
+    else
+    {
+        MCDateTimeEvalDate(ctxt, r_value.stringref_value);
+    }
+}
+
+void
+MCDate::compile(MCSyntaxFactoryRef ctxt)
+{
+    MCSyntaxFactoryBeginExpression(ctxt, line, pos);
+    if (nil != m_format)
+    {
+        m_format -> compile(ctxt);
+        MCSyntaxFactoryEvalMethod(ctxt, kMCDateTimeEvalDateOfFormatMethodInfo);
+    }
+    else
+    {
+        MCSyntaxFactoryEvalMethod(ctxt, kMCDateTimeEvalDateMethodInfo);
+    }
+    MCSyntaxFactoryEndExpression(ctxt);
+}
+
 MCDirectories::~MCDirectories()
 {
 	delete m_folder;

--- a/engine/src/funcs.h
+++ b/engine/src/funcs.h
@@ -578,12 +578,19 @@ public:
 	virtual MCExecMethodInfo *getmethodinfo(void) const { return kMCInterfaceEvalControlKeyMethodInfo; }
 };
 
-class MCDate : public MCConstantFunctionCtxt<MCStringRef, MCDateTimeEvalDate>
+class MCDate : public MCFunction
 {
 public:
-	// virtual Exec_stat eval(MCExecPoint &);
-	virtual MCExecMethodInfo *getmethodinfo(void) const { return kMCDateTimeEvalDateMethodInfo; }
+    MCDate() : m_format(nil) {}
+    virtual ~MCDate();
+    virtual Parse_stat parse(MCScriptPoint &, Boolean p_is_the);
+    virtual void eval_ctxt(MCExecContext &, MCExecValue &);
+    virtual void compile(MCSyntaxFactoryRef);
 
+    // virtual Exec_stat eval(MCExecPoint &);
+    virtual MCExecMethodInfo *getmethodinfo(void) const { return kMCDateTimeEvalDateMethodInfo; }
+private:
+    MCExpression *m_format;
 };
 
 class MCDateFormat : public MCConstantFunctionCtxt<MCStringRef, MCDateTimeEvalDateFormat>

--- a/engine/src/srvcgi.cpp
+++ b/engine/src/srvcgi.cpp
@@ -1765,7 +1765,7 @@ static bool cgi_send_cookies(void)
 			MCAutoNumberRef t_num;
 			MCAutoStringRef t_string;
 			/* UNCHECKED */ MCNumberCreateWithInteger(MCservercgicookies[i].expires, &t_num);
-			t_success = MCD_convert(ctxt, *t_num, CF_SECONDS, CF_UNDEFINED, CF_INTERNET_DATE, CF_UNDEFINED, &t_string);
+			t_success = MCD_convert(ctxt, *t_num, CF_SECONDS, CF_UNDEFINED, NULL, CF_INTERNET_DATE, CF_UNDEFINED, NULL, &t_string);
 			if (t_success)
 			{
 				t_success = MCCStringAppendFormat(t_cookie_header, "; Expires=%s", MCStringGetCString(*t_string));

--- a/tests/lcs/core/datetime/datetime.livecodescript
+++ b/tests/lcs/core/datetime/datetime.livecodescript
@@ -1,4 +1,4 @@
-script "DateTime"
+﻿script "DateTime"
 /*
 Copyright (C) 2017 LiveCode Ltd.
 
@@ -18,13 +18,30 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 
 on TestLongTime24Hours
- local tDateItems
- set the twelveHourTime to false
- put "2017,3,28,2,0,0,3" into tDateItems
- convert tDateItems to long time
-
- TestAssert "Test 24-hour format 1", char 1 to 2 of tDateItems is a number
- TestAssert "Test 24-hour format 2", char 3 of tDateItems is ":"
- TestAssert "Test 24-hour format 3", tDateItems is "02:00:00"
+   local tDateItems
+   set the twelveHourTime to false
+   put "2017,3,28,2,0,0,3" into tDateItems
+   convert tDateItems to long time
+   
+   TestAssert "Test 24-hour format 1", char 1 to 2 of tDateItems is a number
+   TestAssert "Test 24-hour format 2", char 3 of tDateItems is ":"
+   TestAssert "Test 24-hour format 3", tDateItems is "02:00:00"
 end TestLongTime24Hours
 
+on TestDateFormat
+   TestAssert "Date with format string", date("%#m/%#d/%y") is the short english date
+end TestDateFormat
+
+on TestDateFormatConvert
+   local tSeconds, tInternetFormat, tInternetSyntax
+   put the seconds into tSeconds
+   put tSeconds into tInternetFormat
+   put tSeconds into tInternetSyntax
+   
+   convert tInternetSyntax from seconds to internet date
+   convert tInternetFormat from seconds to "!%a, %#d %b %Y %H:%M:%S %z"
+   TestAssert "Internet date and format conversions match", tInternetFormat is tInternetSyntax
+   
+   convert tInternetFormat from "!%a, %#d %b %Y %H:%M:%S %z" to seconds
+   TestAssert "Internet format conversions round trips", tInternetFormat is tSeconds
+end TestDateFormatConvert


### PR DESCRIPTION
This patch adds an additional optional parameter to the
date function allowing a format string to be specified.

Currently in order to format the current datetime in
a format that is not natively supported the user needs
to get the date in one of the supported formats,
convert to dateItems and then format in the required format.