### PR TITLE
Add selectionChanged association to player object

### DIFF
--- a/docs/dictionary/message/selectionChanged.lcdoc
+++ b/docs/dictionary/message/selectionChanged.lcdoc
@@ -7,7 +7,7 @@ Syntax: selectionChanged
 Summary:
 Sent to a <field> or <player> when the <selection> is changed.
 
-Associations: field
+Associations: field, player
 
 Introduced: 1.0
 

--- a/docs/notes/bugfix-19083.md
+++ b/docs/notes/bugfix-19083.md
@@ -1,0 +1,1 @@
+# Added selectionChanged association to player object


### PR DESCRIPTION
Saw this bug in This week in LiveCode 81 as an 'Easy' fix.  Thought I would give it a try to see if I could find the doc and make the change necessary. 

 Bug #19083 selectionChanged does not appear in the player object page of the dictionary.

Just followed the suggestion from bug reporter patrice.guyot@irit.fr

Added player as an association in selectionChanged message