### PR TITLE
[Bug 19509] Make LC work with the latest version of Android Studio

### DIFF
--- a/docs/notes/bugfix-19509.md
+++ b/docs/notes/bugfix-19509.md
@@ -1,0 +1,1 @@
+# Make sure Android Studio works with LiveCode

--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -169,7 +169,8 @@ function deployIsValidJDK pPath
       return false
    end if
    
-   if not pPath contains "jdk1.8" then
+   // newer versions of SDK Tools require Java 8
+   if pathToSDKClasses() contains "sdklib-" and not pPath contains "jdk1.8" then
       answer error "The version of Java installed in your system is not compatible with the current version of Android SDK Tools. Please install Java 8 to continue."
       return false
    end if
@@ -330,6 +331,7 @@ function pathToSDKClasses pRoot
       return pRoot & slash & "tools/lib/sdklib.jar"
    else
       filter tLibs with "sdklib-[0-9]*" into tSdkLib
+      if tSdkLib is empty then return empty
       return pRoot & "/tools/lib/" & tSdkLib
    end if
 end pathToSDKClasses

--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -169,6 +169,11 @@ function deployIsValidJDK pPath
       return false
    end if
    
+   if not pPath contains "jdk1.8" then
+      answer error "The version of Java installed in your system is not compatible with the current version of Android SDK Tools. Please install Java 8 to continue."
+      return false
+   end if
+   
    return true
 end deployIsValidJDK
 
@@ -319,8 +324,25 @@ function pathToSDKClasses pRoot
    if pRoot is empty then
       put sAndroidRoot into pRoot
    end if
-   return pRoot & slash & "tools/lib/sdklib.jar"
+   local tLibs,tSdkLib
+   put files(pRoot&"/tools/lib") into tLibs
+   if tLibs contains "sdklib.jar" then 
+      return pRoot & slash & "tools/lib/sdklib.jar"
+   else
+      filter tLibs with "sdklib-[0-9]*" into tSdkLib
+      return pRoot & "/tools/lib/" & tSdkLib
+   end if
 end pathToSDKClasses
+
+function pathToCommonClasses pRoot
+   if pRoot is empty then
+      put sAndroidRoot into pRoot
+   end if
+   local tCommonLib
+   filter files(pRoot&"/tools/lib") with "common-*" into tCommonLib
+   if tCommonLib is empty then return empty
+   return pRoot & slash & "tools/lib/" & tCommonLib
+end pathToCommonClasses
 
 private function searchTools pRoot, pCommand
    // search the shared tools folder

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -53,6 +53,14 @@ private command buildAPK pUnalignedApkFile, pUnsignedParam, pAssetArchive, pClas
       put ":" into tSep
    end if
    
+   // We need the 'common' classes to fix the following exception
+   /*
+   Exception in thread "main" java.lang.NoClassDefFoundError: com/android/prefs/AndroidLocation
+	at com.android.sdklib.internal.build.DebugKeyProvider.getDefaultKeyStoreOsPath(DebugKeyProvider.java:122)
+	at com.android.sdklib.build.ApkBuilder.getDebugKeystore(ApkBuilder.java:944)
+	at com.android.sdklib.build.ApkBuilderMain.main(ApkBuilderMain.java:129)
+    Caused by: java.lang.ClassNotFoundException: com.android.prefs.AndroidLocation
+   */
    executeShellCommand pathToJava(), "-Xmx128M", "-classpath", pathToSDKClasses() & tSep & pathToCommonClasses(), "com.android.sdklib.build.ApkBuilderMain", pUnalignedApkFile, pUnsignedParam, "-v", "-z", pAssetArchive, "-f", pClassesFile, "-nf", pLibsBuildFolder
    put the result into tResult
    return tResult

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -46,9 +46,14 @@ end pathIsRelative
 
 // IM-2013-05-21: [[ BZ 10904 ]] This function replicates the functionality of the apkbuilder script which has now been removed from the Android SDK platform tools
 private command buildAPK pUnalignedApkFile, pUnsignedParam, pAssetArchive, pClassesFile, pLibsBuildFolder
-   local tResult
+   local tResult, tSep
+   if the platform is "Win32" then 
+      put ";" into tSep
+   else
+      put ":" into tSep
+   end if
    
-   executeShellCommand pathToJava(), "-Xmx128M", "-classpath", pathToSDKClasses(), "com.android.sdklib.build.ApkBuilderMain", pUnalignedApkFile, pUnsignedParam, "-v", "-z", pAssetArchive, "-f", pClassesFile, "-nf", pLibsBuildFolder
+   executeShellCommand pathToJava(), "-Xmx128M", "-classpath", pathToSDKClasses() & tSep & pathToCommonClasses(), "com.android.sdklib.build.ApkBuilderMain", pUnalignedApkFile, pUnsignedParam, "-v", "-z", pAssetArchive, "-f", pClassesFile, "-nf", pLibsBuildFolder
    put the result into tResult
    return tResult
 end buildAPK
@@ -1160,6 +1165,11 @@ private function pathToSDKClasses pRoot
    dispatch function "pathToSDKClasses" to stack "revDeployLibraryAndroid" with pRoot
    return the result
 end pathToSDKClasses
+
+private function pathToCommonClasses pRoot
+   dispatch function "pathToCommonClasses" to stack "revDeployLibraryAndroid" with pRoot
+   return the result
+end pathToCommonClasses
 
 private function pathToAapt pRoot
    // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated


### PR DESCRIPTION
This patch ensures that LiveCode can work with the latest version of Android Studio, and it is backwards compatible with older versions of the SDK tools.
Tested on OSX and Windows.