### PR TITLE
[[ Bug 19672 ]] Add string params to error throws

### DIFF
--- a/docs/notes/bugfix-19672.md
+++ b/docs/notes/bugfix-19672.md
@@ -1,0 +1,1 @@
+# Prevent crash on throwing certain errors

--- a/libfoundation/src/foundation-record.cpp
+++ b/libfoundation/src/foundation-record.cpp
@@ -31,11 +31,16 @@ static bool __check_conformance(MCTypeInfoRef p_typeinfo, const MCValueRef *p_va
     }
     
     if (x_offset + p_typeinfo -> record . field_count > p_value_count)
-        return MCErrorThrowGeneric(nil);
+        return MCErrorThrowGeneric(MCSTR("record does not conform to target type: not enough fields"));
     
     for(uindex_t i = 0; i < p_typeinfo -> record . field_count; i++)
         if (MCTypeInfoConforms(MCValueGetTypeInfo(p_values[x_offset + i]), p_typeinfo -> record . fields[i] . type))
-            return MCErrorThrowGeneric(nil);
+            return MCErrorThrowGenericWithMessage(MCSTR("record field %{field} does not conform to target type %{type}"),
+                                                  "field",
+                                                  p_values[x_offset + i],
+                                                  "type",
+                                                  p_typeinfo->record.fields[i].type,
+                                                  nullptr);
     
     return true;
 }

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -461,7 +461,10 @@ bool MCNamedTypeInfoBind(MCTypeInfoRef self, MCTypeInfoRef p_target)
 	MCAssert(MCTypeInfoIsNamed(self));
 	__MCAssertIsTypeInfo(p_target);
     if (self -> named . typeinfo != nil)
-        return MCErrorThrowGeneric(nil);
+        return MCErrorThrowGenericWithMessage(MCSTR("Can't bind typeinfo %{name}: already bound to %{self}"),
+                                              "name", p_target->named.name,
+                                              "self", self->named.name,
+                                              nullptr);
     
     self -> named . typeinfo = MCValueRetain(p_target);
     
@@ -474,7 +477,7 @@ bool MCNamedTypeInfoUnbind(MCTypeInfoRef self)
 	MCAssert(MCTypeInfoIsNamed(self));
 
     if (self -> named . typeinfo == nil)
-        return MCErrorThrowGeneric(nil);
+        return MCErrorThrowGeneric(MCSTR("Can't unbind typeinfo: not bound"));
     
     MCValueRelease(self -> named . typeinfo);
     self -> named . typeinfo = nil;
@@ -488,7 +491,7 @@ bool MCNamedTypeInfoResolve(MCTypeInfoRef self, MCTypeInfoRef& r_bound_type)
 	MCAssert(MCTypeInfoIsNamed(self));
 
     if (self -> named . typeinfo == nil)
-        return MCErrorThrowGeneric(nil);
+        return MCErrorThrowGeneric(MCSTR("Can't resolve typeinfo: not bound"));
     
     r_bound_type = self -> named . typeinfo;
     

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -1404,7 +1404,7 @@ static bool MCScriptPrepareForeignFunction(MCScriptInstanceRef p_instance, MCScr
     t_signature = p_instance -> module -> types[p_handler -> type] -> typeinfo;
     
     if (!MCHandlerTypeInfoGetLayoutType(t_signature, t_abi, p_handler -> function_cif))
-        return MCErrorThrowGeneric(nil);
+        return MCErrorThrowGeneric(MCSTR("Failed to fetch handler layout type"));
     
     if (!p_throw)
         r_bound = true;


### PR DESCRIPTION
`MCErrorThrowGeneric(nil)`, if called, will cause an assertion failure
in debug mode (`MCAssertIsString`) and a crash in Release mode where
the string is dereferenced. This patch adds suitable error strings.