### PR TITLE
[[ Bug 19635 ]] Fix native layer placement on Mac

### DIFF
--- a/docs/notes/bugfix-19635.md
+++ b/docs/notes/bugfix-19635.md
@@ -1,0 +1,5 @@
+# Ensure browser widgets are in the correct location
+
+Browser widgets in nested groups now remain in the correct location
+rather than shifting down vertically out of sync with everything
+else.

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -348,6 +348,8 @@ void MCGroup::geometrychanged(const MCRectangle &p_rect)
 
 void MCGroup::viewportgeometrychanged(const MCRectangle &p_rect)
 {
+    MCControl::viewportgeometrychanged(p_rect);
+
 	MCRectangle t_viewport;
 	t_viewport = MCU_intersect_rect(p_rect, getrect());
 

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -1529,25 +1529,8 @@ static void map_key_event(NSEvent *event, MCPlatformKeyCode& r_key_code, codepoi
 
 - (void)setFrameSize: (NSSize)size
 {
-	CGFloat t_height_diff = size.height - [self frame].size.height;
-	
 	[super setFrameSize: size];
-	
-	// IM-2014-03-28: [[ Bug 12046 ]] Adjust subviews upward to retain same height from top of view
-	NSArray *t_subviews;
-	t_subviews = [self subviews];
-	for (uint32_t i = 0; i < [t_subviews count]; i++)
-	{
-		NSView *t_subview;
-		t_subview = [t_subviews objectAtIndex:i];
-		
-		NSPoint t_origin;
-		t_origin = [t_subview frame].origin;
-		t_origin.y += t_height_diff;
-		
-		[t_subview setFrameOrigin:t_origin];
-	}
-	
+    
 	if ([self window] == nil)
 		return;
 	
@@ -1654,16 +1637,18 @@ static void map_key_event(NSEvent *event, MCPlatformKeyCode& r_key_code, codepoi
 		NSView *t_subview;
 		t_subview = [t_subviews objectAtIndex:i];
 		
-		// Don't adjust the app view, as it gets resized below.
-		if (t_subview != m_window->GetView())
-		{
+        // Adjust any layers added by externals (revbrowser).
+        if ([t_subview respondsToSelector:@selector(com_runrev_livecode_nativeViewId)])
+        {
 			NSPoint t_origin;
 			t_origin = [t_subview frame].origin;
-			t_origin.y += t_height_diff;
+			
+            t_origin.y += t_height_diff;
 			
 			[t_subview setFrameOrigin:t_origin];
 		}
 	}
+    
 	MCMacPlatformWindow *t_window = m_window;
     if (t_window != nil)
         [t_window -> GetView() setFrameSize: size];

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -135,22 +135,27 @@ bool MCNativeLayerMac::doPaint(MCGContextRef p_context)
 
 NSRect MCNativeLayerMac::calculateFrameRect(const MCRectangle &p_rect)
 {
-	int32_t t_gp_height;
+	// IM-2017-04-20: [[ Bug 19327 ]] Transform rect to ui view coords
+	MCRectangle t_view_rect;
+	t_view_rect = MCRectangleGetTransformedBounds(p_rect, m_object->getstack()->getviewtransform());
 	
-	NSWindow *t_window = getStackWindow();
-	if (t_window != nil)
-		t_gp_height = (int32_t)[[t_window contentView] frame].size.height;
-	else
-		t_gp_height = m_object->getcard()->getrect().height;
-	
+    MCRectangle t_parent_view_rect;
+    t_parent_view_rect = MCRectangleGetTransformedBounds(m_object->getparent()->getrect(), m_object->getstack()->getviewtransform());
+    
+    // First compute rect of this object relative to parent
+    t_view_rect.y -= t_parent_view_rect.y;
+    t_view_rect.x -= t_parent_view_rect.x;
+    
+    // Now compute the (y-inverted) NSView rect
 	NSRect t_rect;
-	t_rect = NSMakeRect(p_rect.x, t_gp_height - (p_rect.y + p_rect.height), p_rect.width, p_rect.height);
+	t_rect = NSMakeRect(t_view_rect.x, t_parent_view_rect.height - (t_view_rect.y + t_view_rect.height), t_view_rect.width, t_view_rect.height);
 	
 	return t_rect;
 }
 
 void MCNativeLayerMac::doSetViewportGeometry(const MCRectangle &p_rect)
 {
+    doSetGeometry(m_object->getrect());
 }
 
 void MCNativeLayerMac::doSetGeometry(const MCRectangle &p_rect)
@@ -252,48 +257,13 @@ MCNativeLayer* MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_view
 
 //////////
 
-// IM-2015-12-16: [[ NativeLayer ]] Keep the coordinate system of group contents the same as
-//                the top-level window view by keeping its bounds the same as its frame.
-//                This allows us to place contents in terms of window coords without having to
-//                adjust for the location of the group container.
 @interface com_runrev_livecode_MCContainerView: NSView
-
-- (void)setFrameOrigin:(NSPoint)newOrigin;
-- (void)setFrameSize:(NSSize)newSize;
 
 @end
 
 @compatibility_alias MCContainerView com_runrev_livecode_MCContainerView;
 
 @implementation com_runrev_livecode_MCContainerView
-
-- (void)setFrameOrigin:(NSPoint)newOrigin
-{
-    /* By default, NSViews don't adjust the positions or sizes of their
-     * contents when their geometry changes.  There is an autoresizing
-     * behaviour that we could turn on, but we don't because it doesn't have
-     * the properties that we require for a LiveCode group.  It's therefore
-     * necessary to manually nudge subviews around when the position of a
-     * container view is adjusted. */
-    NSPoint t_origin = [self frame].origin;
-    NSPoint t_delta = {newOrigin.x - t_origin.x, newOrigin.y - t_origin.y};
-
-    for (NSView *t_subview in [self subviews])
-    {
-        NSPoint t_suborigin = [t_subview frame].origin;
-        [t_subview setFrameOrigin: {t_suborigin.x + t_delta.x,
-                                    t_suborigin.y + t_delta.y}];
-    }
-
-	[super setFrameOrigin:newOrigin];
-	[self setBoundsOrigin:newOrigin];
-}
-
-- (void)setFrameSize:(NSSize)newSize
-{
-	[super setFrameSize:newSize];
-	[self setBoundsSize:newSize];
-}
 
 @end
 


### PR DESCRIPTION
This patch fixes an issue where if a native layer is in a group
then it would not update its y location correctly.

Previously, there was code in our NSView subclasses to deal
with the vertical height of the viewport changing (Cocoa's coord
system is bottom-left relative).

This code has been removed, and has been replaced by a call to
doSetGeometry() in doSetViewportGeometry() in the Mac native view
class.

Additionally, a missing call to MCControl::viewportchanged has been
added to MCGroup::viewportchanged.

There is a revbrowser-specific 'hack' in the MCWindowContainerView
class still - which ensures a revbrowser layer will remain at the
correct y-location when the height of a window changes.