### PR TITLE
[[ Bug 19598 ]] Allow the same local port to be used for multiple con…

### DIFF
--- a/docs/notes/bugfix-19598.md
+++ b/docs/notes/bugfix-19598.md
@@ -1,0 +1,1 @@
+# Cannot accept and open sockets using the same local port on certain platforms


### PR DESCRIPTION
…nections on all platforms

On some platforms, the SO_REUSEADDR is insufficient to allow the same local port
to be used for multiple connections. On these platforms, the SO_REUSEPORT option
is now set.

More info can be found here:
http://stackoverflow.com/questions/14388706/socket-options-so-reuseaddr-and-so-reuseport-how-do-they-differ-do-they-mean-t/14388707#14388707

An assertion failure on socket read has also been fixed.