### PR TITLE
[Bug 19630] Fix setting the iphoneSetAudioCategory

### DIFF
--- a/docs/notes/bugfix-19630.md
+++ b/docs/notes/bugfix-19630.md
@@ -1,0 +1,1 @@
+# Make sure setting the iphoneSetAudioCategory is respected

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -2627,7 +2627,7 @@ Exec_stat MCHandleSetAudioCategory(void *context, MCParameter *p_parameters)
     t_category = kMCSoundAudioCategoryUnknown;
     if (t_success)
     {
-        MCSoundAudioCategoryFromString(*t_category_string);
+        t_category = MCSoundAudioCategoryFromString(*t_category_string);
     }
     
     if (t_success)


### PR DESCRIPTION
The return value of `MCSoundAudioCategoryFromString(*t_category_string)` was not taken into account, and this resulted in not being able to actually set the `iphoneSetAudioCategory`