### PR TITLE
[[DO NOT MERGE]] Revert "[[ Bug 19587 ]] Relax object execution lock"

### DIFF
--- a/docs/notes/bugfix-19587.md
+++ b/docs/notes/bugfix-19587.md
@@ -1,8 +1,0 @@
-# Fix deletion of the target in safe cases
-
-You can now safely 'delete the target' as long as there are
-no handlers on the stack owned by the target.
-
-After deleting 'the target', 'the target' will become
-empty which will result in an execution error when an attempt
-is made to dereference it.

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -256,15 +256,6 @@ Exec_stat MCDispatch::handle(Handler_type htype, MCNameRef mess, MCParameter *pa
 
 		if (oldstat == ES_PASS && stat == ES_NOT_HANDLED)
 			stat = ES_PASS;
-        
-        if (stat == ES_PASS || stat == ES_NOT_HANDLED)
-        {
-            if (!MCtargetptr.IsValid())
-            {
-                stat = ES_NORMAL;
-                t_has_passed = false;
-            }
-        }
 	}
 
 //#ifdef TARGET_SUBPLATFORM_IPHONE
@@ -294,15 +285,6 @@ Exec_stat MCDispatch::handle(Handler_type htype, MCNameRef mess, MCParameter *pa
     {
         extern Exec_stat MCEngineHandleLibraryMessage(MCNameRef name, MCParameter *params);
         stat = MCEngineHandleLibraryMessage(mess, params);
-        
-        if (stat == ES_PASS || stat == ES_NOT_HANDLED)
-        {
-            if (!MCtargetptr.IsValid())
-            {
-                stat = ES_NORMAL;
-                t_has_passed = false;
-            }
-        }
     }
     
 	if (MCmessagemessages && stat != ES_PASS && MCtargetptr)

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1226,13 +1226,24 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int p_handler_type, MCNameRef p_m
 	MCdynamicpath = MCdynamiccard.IsValid();
 	if (t_stat == ES_PASS || t_stat == ES_NOT_HANDLED)
     {
-        switch(t_stat = t_object -> handle((Handler_type)p_handler_type, p_message, p_parameters, t_object.Get()))
+        /* If the target object was deleted in the frontscript, prevent
+         * normal message dispatch as if the frontscript did not pass the
+         * message. */
+        if (t_object)
         {
-        case ES_ERROR:
-            ctxt . LegacyThrow(EE_DISPATCH_BADCOMMAND, p_message);
-            break;
-        default:
-            break;
+            MCObjectExecutionLock t_object_lock(t_object);
+            switch(t_stat = t_object -> handle((Handler_type)p_handler_type, p_message, p_parameters, t_object.Get()))
+            {
+            case ES_ERROR:
+                ctxt . LegacyThrow(EE_DISPATCH_BADCOMMAND, p_message);
+                break;
+            default:
+                break;
+            }
+        }
+        else
+        {
+            t_stat = ES_NORMAL;
         }
     }
 	

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -1137,14 +1137,6 @@ Exec_stat MCObject::handleself(Handler_type p_handler_type, MCNameRef p_message,
 		if (t_stat == ES_ERROR || t_stat == ES_EXIT_ALL)
 			return t_stat;
 	}
-    
-    if (t_stat == ES_PASS || t_stat == ES_NOT_HANDLED)
-    {
-        if (!MCtargetptr.IsValid())
-        {
-            t_main_stat = ES_NORMAL;
-        }
-    }
 
 	// Return the result of executing the main handler in the object
 	return t_main_stat;
@@ -2089,8 +2081,7 @@ Exec_stat MCObject::dispatch(Handler_type p_type, MCNameRef p_message, MCParamet
         MCAssert(!MCtargetptr || MCtargetptr.IsBoundTo(this));
         if (MCtargetptr)
         {
-            // MAY-DELETE: Handle the message - this (MCtargetptr) might be unbound
-            // after this call if it is deleted.
+            MCObjectExecutionLock t_target_lock(this);
             t_stat = handle(p_type, p_message, p_params, this);
         }
         else
@@ -2172,8 +2163,8 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
                  * frontscript did not pass the message. */
                 if (t_self_handle)
                 {
-                    // MAY-DELETE: Handle the message - this might be unbound after
-                    // this call if it is deleted.
+                    MCObjectExecutionLock t_self_lock(this);
+                    // PASS STATE FIX
                     Exec_stat oldstat = stat;
                     stat = handle(HT_MESSAGE, mess, paramptr, this);
                     if (oldstat == ES_PASS && stat == ES_NOT_HANDLED)

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -351,8 +351,7 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
             MCAssert(!MCtargetptr || MCtargetptr.IsBoundTo(this));
             if (MCtargetptr)
             {
-                // MAY-DELETE: Handle the message - this/MCtargetptr might be unbound after
-                // this call if it is deleted.
+                MCObjectExecutionLock t_self_lock(this);
                 t_stat = handle(HT_GETPROP, t_getprop_name, &p1, this);
             }
             else
@@ -456,8 +455,7 @@ Exec_stat MCObject::sendsetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
             MCAssert(!MCtargetptr || MCtargetptr.IsBoundTo(this));
             if (MCtargetptr)
             {
-                // MAY-DELETE: Handle the message - this/MCtargetptr might be unbound after
-                // this call if it is deleted.
+                MCObjectExecutionLock t_self_lock(this);
                 t_stat = handle(HT_SETPROP, t_setprop_name, &p1, this);
             }
             else

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1596,13 +1596,6 @@ Exec_stat MCStack::handle(Handler_type htype, MCNameRef message, MCParameter *pa
 		stat = m_externals -> Handle(this, htype, message, params);
 		if (oldstat == ES_PASS && stat == ES_NOT_HANDLED)
 			stat = ES_PASS;
-        if (stat == ES_PASS || stat == ES_NOT_HANDLED)
-        {
-            if (!MCtargetptr.IsValid())
-            {
-                stat = ES_NORMAL;
-            }
-        }
 	}
 
 	// MW-2011-06-30: Cleanup of message path - this clause handles the transition

--- a/tests/lcs/core/engine/target.livecodescript
+++ b/tests/lcs/core/engine/target.livecodescript
@@ -19,23 +19,22 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 on TestSetup
    create button "script"
    set the script of button "script" to "on doSomething; delete the target; pass doSomething; end doSomething"
-
+   
    create button "test"
 end TestSetup
 
 on TestDeleteTargetInFrontScript
    insert the script of button "script" into front
-   dispatch "doSomething" to button "test"
+   set the script of button "test" to "on doSomething; send __TestDeletedCallback; end doSomething"
+   __TestDeleteTarget
    TestAssert "Delete target in frontscript", there is no button "test"
-   TestAssert "Delete target in frontscript blocks message", it is "handled"
+   TestAssert "Delete target in frontscript blocks message", sDeleted is not true
    remove the script of button "script" from front
 end TestDeleteTargetInFrontScript
 
 on TestDeleteTargetInBackScript
    insert the script of button "script" into back
-   dispatch "doSomething" to button "test"
-   TestAssert "Delete target in backscript", there is no button "test"
-   TestAssert "Delete target in backscript blocks message", it is "handled"
+   TestAssertThrow "Delete target in backscript", "__TestDeleteTarget", the long id me, 347
    remove the script of button "script" from back
 end TestDeleteTargetInBackScript
 
@@ -46,14 +45,15 @@ on TestDeleteTargetInBehavior
 end TestDeleteTargetInBehavior
 
 on TestDeleteTargetInOwner
-   set the script of the owner of btn "test" to "on doSomething; delete the target; pass doSomething; end doSomething"
-   dispatch "doSomething" to button "test"
-   TestAssert "Delete target in owner", there is no button "test"
-   TestAssert "Delete target in owner blocks message", it is "handled"
+   set the script of the owner of btn "test" to "on doSomething; delete the target; end doSomething"
+   TestAssertThrow "Delete target in owner", "__TestDeleteTarget", the long id me, 347
 end TestDeleteTargetInOwner
-
-/**/
 
 on __TestDeleteTarget
    send "doSomething" to button "test"
 end __TestDeleteTarget
+
+local sDeleted
+on __TestDeletedCallback
+   put true into sDeleted
+end __TestDeletedCallback


### PR DESCRIPTION
Reverts livecode/livecode#5441

The PR https://github.com/livecode/livecode/pull/5441 is *probably* the reason why the installer fails on Windows. 

So I am reverting the original patch to see if this is the case.