### PR TITLE
[[ Bug 19681 ]] Ensure targetptr check is only done if valid before

### DIFF
--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -246,6 +246,10 @@ Exec_stat MCDispatch::handle(Handler_type htype, MCNameRef mess, MCParameter *pa
 
 	if ((stat == ES_NOT_HANDLED || stat == ES_PASS) && m_externals != nil)
 	{
+        // TODO[19681]: This can be removed when all engine messages are sent with
+        // target.
+        bool t_target_was_valid = MCtargetptr.IsValid();
+    
 		Exec_stat oldstat = stat;
 		stat = m_externals -> Handle(this, htype, mess, params);
 
@@ -259,7 +263,7 @@ Exec_stat MCDispatch::handle(Handler_type htype, MCNameRef mess, MCParameter *pa
         
         if (stat == ES_PASS || stat == ES_NOT_HANDLED)
         {
-            if (!MCtargetptr.IsValid())
+            if (t_target_was_valid && !MCtargetptr.IsValid())
             {
                 stat = ES_NORMAL;
                 t_has_passed = false;
@@ -292,12 +296,16 @@ Exec_stat MCDispatch::handle(Handler_type htype, MCNameRef mess, MCParameter *pa
 
     if ((stat == ES_NOT_HANDLED || stat == ES_PASS))
     {
+        // TODO[19681]: This can be removed when all engine messages are sent with
+        // target.
+        bool t_target_was_valid = MCtargetptr.IsValid();
+        
         extern Exec_stat MCEngineHandleLibraryMessage(MCNameRef name, MCParameter *params);
         stat = MCEngineHandleLibraryMessage(mess, params);
         
         if (stat == ES_PASS || stat == ES_NOT_HANDLED)
         {
-            if (!MCtargetptr.IsValid())
+            if (t_target_was_valid && !MCtargetptr.IsValid())
             {
                 stat = ES_NORMAL;
                 t_has_passed = false;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -1077,6 +1077,10 @@ Exec_stat MCObject::handleself(Handler_type p_handler_type, MCNameRef p_message,
 	Exec_stat t_stat;
 	t_stat = ES_NOT_HANDLED;
 
+    // TODO[19681]: This can be removed when all engine messages are sent with
+    // target.
+    bool t_target_was_valid = MCtargetptr.IsValid();
+    
 	MCObjectExecutionLock self_lock(this);
 
 	// Make sure this object has its script compiled.
@@ -1140,7 +1144,7 @@ Exec_stat MCObject::handleself(Handler_type p_handler_type, MCNameRef p_message,
     
     if (t_stat == ES_PASS || t_stat == ES_NOT_HANDLED)
     {
-        if (!MCtargetptr.IsValid())
+        if (t_target_was_valid && !MCtargetptr.IsValid())
         {
             t_main_stat = ES_NORMAL;
         }

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1592,13 +1592,17 @@ Exec_stat MCStack::handle(Handler_type htype, MCNameRef message, MCParameter *pa
 
 	if (((passing_object != nil && stat == ES_PASS) || stat == ES_NOT_HANDLED) && m_externals != nil)
 	{
+        // TODO[19681]: This can be removed when all engine messages are sent with
+        // target.
+        bool t_target_was_valid = MCtargetptr.IsValid();
+        
 		Exec_stat oldstat = stat;
 		stat = m_externals -> Handle(this, htype, message, params);
 		if (oldstat == ES_PASS && stat == ES_NOT_HANDLED)
 			stat = ES_PASS;
         if (stat == ES_PASS || stat == ES_NOT_HANDLED)
         {
-            if (!MCtargetptr.IsValid())
+            if (t_target_was_valid && !MCtargetptr.IsValid())
             {
                 stat = ES_NORMAL;
             }


### PR DESCRIPTION
This patch only checkes the targetptr after a step in the message
path if it was not valid before the step was performed. This ensures
that any messages which are sent with no target (such as relaunch)
still function as before.