### PR TITLE
[Bug 19620] Update cursor when entering window

### DIFF
--- a/docs/notes/bugfix-19620.md
+++ b/docs/notes/bugfix-19620.md
@@ -1,0 +1,1 @@
+# Update cursor when entering window on windows

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -1108,7 +1108,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 		if (curinfo->live && !pms->isgrabbed() && LOWORD(lParam) != HTCLIENT)
 			return IsWindowUnicode(hwnd) ? DefWindowProcW(hwnd, msg, wParam, lParam) : DefWindowProcA(hwnd, msg, wParam, lParam);
 		MCmousestackptr = MCdispatcher->findstackd(dw);
-		if (!MCmousestackptr)
+		if (MCmousestackptr)
 		{
 			MCmousestackptr->resetcursor(True);
 			if (pms->getmousetimer() == 0)


### PR DESCRIPTION
This patch fixes a regression caused when `MCmousestackptr` was
changed to an object handle in commit 654bd575. In the diff
below `if (!MCmousestackptr)` should be `if (MCmousestackptr)`:

         MCmousestackptr = MCdispatcher->findstackd(dw);
    -    if (MCmousestackptr != NULL)
    +    if (!MCmousestackptr)
         {
             MCmousestackptr->resetcursor(True);