### PR TITLE
[[ Bug 19688 ]] Throw parse error with 'put the <objProp>'

### DIFF
--- a/docs/dictionary/command/get.lcdoc
+++ b/docs/dictionary/command/get.lcdoc
@@ -14,7 +14,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-get the colors
+get the colors of button 1
 
 Example:
 get 2 * 25 * pi -- gets area of circle with radius 25

--- a/docs/notes/bugfix-19688.md
+++ b/docs/notes/bugfix-19688.md
@@ -1,0 +1,1 @@
+# Ensure 'put the objProp' causes a parse error

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1741,10 +1741,10 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 					{
 						delete newfact;
 						*this = thesp;
-						if (MCexplicitvariables)
+						if (doingthe)
 						{
 							MCerrorlock--;
-							MCperror->add(PE_EXPRESSION_NOTLITERAL, *this);
+							MCperror->add(PE_PROPERTY_NOTOF, *this);
 							return PS_ERROR;
 						}
 						newfact = new MCLiteral(gettoken_nameref());

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1741,7 +1741,7 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 					{
 						delete newfact;
 						*this = thesp;
-						if (doingthe)
+						if (doingthe || MCexplicitvariables)
 						{
 							MCerrorlock--;
 							MCperror->add(PE_PROPERTY_NOTOF, *this);

--- a/tests/lcs/parser/parser.livecodescript
+++ b/tests/lcs/parser/parser.livecodescript
@@ -1,0 +1,45 @@
+﻿script "TestLCSParser"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/* TODO 15/05/2017: Turn these tests into an LCS parser test when merging
+up into develop branch */
+
+private command __CompileCheck pMessage
+   local tCompileTest, tCompileResult
+   --checks to see if the message compiles
+   lock messages
+   create script only stack "compilationTest"
+   put "on compileTest" & return & pMessage & return \ 
+      & "end compileTest" into tCompileTest
+   set the script of stack "compilationTest" to tCompileTest
+   put the result into tCompileResult
+   delete stack "compilationTest"
+   unlock messages
+   repeat for each line tError in tCompileResult
+      if item 2 of tError is not 0 then
+         return tError
+      end if
+   end repeat
+
+   return empty
+end __CompileCheck
+
+on TestBug19688
+	__CompileCheck "get the width"
+   TestAssert "'get the <objprop>' parse error", the result is not empty
+end TestBug19688


### PR DESCRIPTION
Previously `put the <objProp>` would result in an <objProp> string
literal being created, e.g. `put the width` results in "width" in
the message box. This patch ensures that the "Properties: expecting
'of'" parse error is thrown.