### PR TITLE
[[ Bug 19687 ]] Preserve error from domess

### DIFF
--- a/docs/notes/bugfix-19687.md
+++ b/docs/notes/bugfix-19687.md
@@ -1,0 +1,1 @@
+# Preserve error from chunk-of-code send form

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1448,8 +1448,8 @@ static void MCEngineSendOrCall(MCExecContext& ctxt, MCStringRef p_script, MCObje
         else
             tptr = MCNameGetString(*t_message);
         
-        if ((stat = optr->domess(*tptr)) == ES_ERROR)
-            ctxt . LegacyThrow(EE_STATEMENT_BADCOMMAND, *t_message);
+        if (optr->domess(*tptr) == ES_ERROR)
+            ctxt . Throw();
 	}
 	else if (stat == ES_PASS)
 		stat = ES_NORMAL;

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1448,7 +1448,7 @@ static void MCEngineSendOrCall(MCExecContext& ctxt, MCStringRef p_script, MCObje
         else
             tptr = MCNameGetString(*t_message);
         
-        if (optr->domess(*tptr) == ES_ERROR)
+        if (optr->domess(*tptr, false) == ES_ERROR)
             ctxt . Throw();
 	}
 	else if (stat == ES_PASS)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2901,7 +2901,7 @@ void MCObject::drawdirectionaltext(MCDC *dc, int2 sx, int2 sy, MCStringRef p_str
 #endif
 }
 
-Exec_stat MCObject::domess(MCStringRef sptr)
+Exec_stat MCObject::domess(MCStringRef sptr, bool p_ignore_errors)
 {
 	MCAutoStringRef t_temp_script;
 	/* UNCHECKED */ MCStringFormat(&t_temp_script, "on message\n%@\nend message\n", sptr);
@@ -2931,8 +2931,12 @@ Exec_stat MCObject::domess(MCStringRef sptr)
     swap(MCtargetptr, oldtargetptr);
 	if (stat == ES_NORMAL)
 		return ES_NORMAL;
-
-	return ES_ERROR;
+    else
+    {
+        if (p_ignore_errors)
+            MCeerror->clear(); // clear out bogus error messages
+        return ES_ERROR;
+    }
 }
 
 void MCObject::eval(MCExecContext &ctxt, MCStringRef p_script, MCValueRef &r_value)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2931,11 +2931,8 @@ Exec_stat MCObject::domess(MCStringRef sptr)
     swap(MCtargetptr, oldtargetptr);
 	if (stat == ES_NORMAL)
 		return ES_NORMAL;
-	else
-	{
-		MCeerror->clear(); // clear out bogus error messages
-		return ES_ERROR;
-	}
+
+	return ES_ERROR;
 }
 
 void MCObject::eval(MCExecContext &ctxt, MCStringRef p_script, MCValueRef &r_value)

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -1069,7 +1069,7 @@ public:
     // SN-2014-04-16 [[ Bug 12078 ]] Buttons and tooltip label are not drawn in the text direction
     void drawdirectionaltext(MCDC *dc, int2 sx, int2 sy, MCStringRef p_string, MCFontRef font);
 
-	Exec_stat domess(MCStringRef sptr);
+	Exec_stat domess(MCStringRef sptr, bool p_ignore_errors = true);
 	void eval(MCExecContext& ctxt, MCStringRef p_script, MCValueRef& r_value);
 	// MERG 2013-9-13: [[ EditScriptChunk ]] Added at expression that's passed through as a second parameter to editScript
     void editscript(MCStringRef p_at = nil);

--- a/tests/lcs/core/engine/send.livecodescript
+++ b/tests/lcs/core/engine/send.livecodescript
@@ -55,3 +55,12 @@ on TestSendToSubobj
 
 	TestAssert "message canceled on delete", not MessageExists(tMsgId)
 end TestSendToSubobj
+
+on __SendError
+	send "--execute this" & return & "put the name of stack nonexistent"
+end __SendError
+
+on TestSendError
+	TestAssertThrow "send throws correct error", __SendError, \ 
+		the long id of me, 91
+end TestSendError


### PR DESCRIPTION
Previously, doing
	send "--execute this" & return & "put the name of stack nonexistent"
results in an incorrect execution error - 'Can't find handler "--"'. This
patch ensure the error percolates up from `domess` to the send exec method.