### PR TITLE
[[ Bug 19679 ]] Use bfd linker on android

### DIFF
--- a/config/android-settings.gypi
+++ b/config/android-settings.gypi
@@ -25,7 +25,7 @@
 	
 	'ldflags':
 	[
-		'fuse-ld=bfd',
+		'-fuse-ld=bfd',
 	],
 	
 	'target_conditions':

--- a/config/android-settings.gypi
+++ b/config/android-settings.gypi
@@ -23,6 +23,11 @@
 		'-fno-rtti',
 	],
 	
+	'ldflags':
+	[
+		'fuse-ld=bfd',
+	],
+	
 	'target_conditions':
 	[
 		[


### PR DESCRIPTION
When the gold linker is used to link Standalone-Community
(librevandroid.so) the dynamic section is ordered differently
which appears to cause a 'missing PT_DYNAMIC' error when building
android standalones. Using the bfd linker instead fixes this issue.