### PR TITLE
Remove -Wno-error=maybe-uninitialized

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -71,7 +71,6 @@
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
 					'-Werror=uninitialized',
-					'-Wno-error=maybe-uninitialized',
 					'-Werror=conversion-null',
 					'-Werror=empty-body',
 				],

--- a/engine/src/bitmapeffect.cpp
+++ b/engine/src/bitmapeffect.cpp
@@ -678,10 +678,6 @@ bool MCBitmapEffectsGetProperty(MCExecContext& ctxt, MCBitmapEffectsRef& self, M
 		t_effect = &self -> effects[t_type];
 	else
 		t_effect = nil;
-    
-    MCBitmapEffectProperty t_prop;
-    if (!MCNameIsEmpty(p_index) && MCBitmapEffectLookupProperty(t_type, p_index, t_prop) != ES_NORMAL)
-        return false;
 
     if (t_is_array)
     {
@@ -716,6 +712,10 @@ bool MCBitmapEffectsGetProperty(MCExecContext& ctxt, MCBitmapEffectsRef& self, M
     }
     else
     {
+        MCBitmapEffectProperty t_prop;
+        if (MCBitmapEffectLookupProperty(t_type, p_index,
+                                         t_prop) != ES_NORMAL)
+            return false;
         MCBitmapEffectFetchProperty(ctxt, t_effect, t_prop, r_value);
         return true;
     }
@@ -983,7 +983,6 @@ bool MCBitmapEffectsSetProperty(MCExecContext& ctxt, MCBitmapEffectsRef& self, M
 		return true;
     }
     
-    MCBitmapEffectProperty t_prop;
     MCBitmapEffect effect;
     bool t_dirty;
     
@@ -1002,10 +1001,6 @@ bool MCBitmapEffectsSetProperty(MCExecContext& ctxt, MCBitmapEffectsRef& self, M
         // regardless.
         t_dirty = true;
     }
-    
-    // Lookup the property and ensure it is appropriate for our type.
-    if (!MCNameIsEmpty(p_index) && MCBitmapEffectLookupProperty(t_type, p_index, t_prop) != ES_NORMAL)
-        return false;
     
     if (t_is_array)
     {
@@ -1037,8 +1032,15 @@ bool MCBitmapEffectsSetProperty(MCExecContext& ctxt, MCBitmapEffectsRef& self, M
         
     }
     else
+    {
+        MCBitmapEffectProperty t_prop;
+        if (MCBitmapEffectLookupProperty(t_type, p_index,
+                                         t_prop) != ES_NORMAL)
+            return false;
+
         MCBitmapEffectStoreProperty(ctxt, effect, t_prop, p_value, t_dirty);
-    
+    }
+
     if (t_dirty)
     {
         // If we are currently empty, then allocate a new object

--- a/engine/src/block.cpp
+++ b/engine/src/block.cpp
@@ -169,7 +169,7 @@ IO_stat MCBlock::load(IO_handle stream, uint32_t version, bool is_ext)
 
 	// MW-2012-03-04: [[ StackFile5500 ]] If this is an extended block, then work out
 	//   where to skip to when all the attrs currently recognized have been read.
-	int64_t t_attr_end;
+	int64_t t_attr_end = 0;
 	if (is_ext)
 	{
 		// Read the size.

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -377,7 +377,7 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 
 		// MW-2009-06-14: We will assume (perhaps unwisely) that is 'opaque' is set
 		//   then the background is now, completely opaque.
-		bool t_was_opaque;
+		bool t_was_opaque = false;
 		if (getflag(F_OPAQUE))
 			t_was_opaque = dc -> changeopaque(true);
 

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -858,7 +858,7 @@ void MCIdeDeploy::exec_ctxt(MCExecContext& ctxt)
 		t_has_error = true;
 	}
 	
-	uint32_t t_platform;
+	uint32_t t_platform = PLATFORM_NONE;
 	switch(m_platform)
 	{
 		case PLATFORM_MACOSX:

--- a/engine/src/deploy_linux.cpp
+++ b/engine/src/deploy_linux.cpp
@@ -548,8 +548,7 @@ static bool MCDeployToLinuxReadProgramHeaders(MCDeployFileRef p_file, typename T
 template<typename T>
 static bool MCDeployToLinuxReadString(MCDeployFileRef p_file, typename T::Shdr& p_string_header, uint32_t p_index, char*& r_string)
 {
-	bool t_success;
-	t_success = true;
+	bool t_success = true;
 
 	// First check that the index is valid
 	if (p_index >= p_string_header . sh_size)
@@ -558,11 +557,9 @@ static bool MCDeployToLinuxReadString(MCDeployFileRef p_file, typename T::Shdr& 
 	// As the string table does not contain any string lengths and they are
 	// just NUL terminated, we must gradually load portions until a NUL is
 	// reached.
-	char *t_buffer;
-	uint32_t t_length;
-	t_buffer = NULL;
-	t_length = 0;
-
+	char *t_buffer = nullptr;
+	uint32_t t_length = 0;
+    
 	while(t_success)
 	{
 		// Compute how much data to read - this is either the fixed chunk
@@ -688,17 +685,15 @@ Exec_stat MCDeployToELF(const MCDeployParameters& p_params, bool p_is_android)
 	t_payload_section = NULL;
 	for(uint32_t i = 0; t_success && i < t_header . e_shnum && t_project_section == NULL; i++)
 	{
-		char *t_section_name;
-		t_success = MCDeployToLinuxReadString<T>(t_engine, t_section_headers[t_header . e_shstrndx], t_section_headers[i] . sh_name, t_section_name);
+        MCAutoPointer<char> t_section_name;
+		t_success = MCDeployToLinuxReadString<T>(t_engine, t_section_headers[t_header . e_shstrndx], t_section_headers[i] . sh_name, &t_section_name);
 
 		// Notice that we compare 9 bytes, this is to ensure we match .project
 		// only and not .project<otherchar> (i.e. we match the NUL char).
-		if (t_success && memcmp(t_section_name, ".project", 9) == 0)
+		if (t_success && memcmp(*t_section_name, ".project", 9) == 0)
 			t_project_section = &t_section_headers[i];
-		if (t_success && memcmp(t_section_name, ".payload", 9) == 0)
+		if (t_success && memcmp(*t_section_name, ".payload", 9) == 0)
 			t_payload_section = &t_section_headers[i];
-		
-		delete t_section_name;
 	}
 
 	if (t_success && t_project_section == NULL)

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -2522,7 +2522,7 @@ void MCField::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 
 	// MW-2009-06-14: If the field is opaque, then render the contents with that
 	//   marked.
-	bool t_was_opaque;
+	bool t_was_opaque = false;
 	if (getflag(F_OPAQUE))
 		t_was_opaque = dc -> changeopaque(true);
 	drawrect(dc, dirty);

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -701,7 +701,7 @@ Exec_stat MCField::settextindex(uint4 parid, findex_t si, findex_t ei, MCStringR
 	MCParagraph *t_initial_pgptr;
 	t_initial_pgptr = pgptr;
 	
-	int32_t t_initial_height;
+	int32_t t_initial_height = 0;
 	if (opened && fptr == fdata)
 		t_initial_height = t_initial_pgptr -> getheight(fixedheight);
 	
@@ -780,7 +780,7 @@ Exec_stat MCField::settextindex(uint4 parid, findex_t si, findex_t ei, MCStringR
 	// MM-2014-04-09: [[ Bug 12088 ]] Get the width of the paragraph before insertion and layout.
 	//  If as a result of the update the width of the field has changed, we need to recompute.
     // MW-2014-06-06: [[ Bug 12385 ]] Don't do anything layout related if not open.
-	int2 t_initial_width;
+	int2 t_initial_width = 0;
     if (opened != 0)
         t_initial_width = pgptr -> getwidth();
 	

--- a/engine/src/graphicscontext.cpp
+++ b/engine/src/graphicscontext.cpp
@@ -782,10 +782,10 @@ void MCGraphicsContext::setgradient(MCGradientFill *p_gradient)
 				break;
 		}
 		
-		MCGFloat *t_stops;
-		/* UNCHECKED */ MCMemoryNewArray(p_gradient -> ramp_length, t_stops);
-		MCGColor *t_colors;
-		/* UNCHECKED */ MCMemoryNewArray(p_gradient -> ramp_length, t_colors);
+		/* UNCHECKED */ MCAutoPointer<MCGFloat[]> t_stops =
+			new MCGFloat[p_gradient->ramp_length]();
+		/* UNCHECKED */ MCAutoPointer<MCGColor[]> t_colors =
+			new MCGColor[p_gradient->ramp_length]();
 		for (uint32_t i = 0; i < p_gradient -> ramp_length; i++)
 		{
 			t_stops[i] = (MCGFloat) p_gradient -> ramp[i] . offset / STOP_INT_MAX;
@@ -800,11 +800,8 @@ void MCGraphicsContext::setgradient(MCGradientFill *p_gradient)
 		t_transform . tx = p_gradient -> origin . x;
 		t_transform . ty = p_gradient -> origin . y;
 
-		MCGContextSetFillGradient(m_gcontext, t_function, t_stops, t_colors, p_gradient -> ramp_length, p_gradient -> mirror, p_gradient -> wrap, p_gradient -> repeat, t_transform, t_filter);
-		MCGContextSetStrokeGradient(m_gcontext, t_function, t_stops, t_colors, p_gradient -> ramp_length, p_gradient -> mirror, p_gradient -> wrap, p_gradient -> repeat, t_transform, t_filter);
-		
-		MCMemoryDeleteArray(t_stops);
-		MCMemoryDeleteArray(t_colors);
+		MCGContextSetFillGradient(m_gcontext, t_function, t_stops.Get(), t_colors.Get(), p_gradient -> ramp_length, p_gradient -> mirror, p_gradient -> wrap, p_gradient -> repeat, t_transform, t_filter);
+		MCGContextSetStrokeGradient(m_gcontext, t_function, t_stops.Get(), t_colors.Get(), p_gradient -> ramp_length, p_gradient -> mirror, p_gradient -> wrap, p_gradient -> repeat, t_transform, t_filter);
 	}
 }
 
@@ -1011,19 +1008,17 @@ void MCGraphicsContext::drawlines(MCPoint *points, uint2 npoints, bool p_closed)
 	else
 	{	
 		// MM-2013-11-14: [[ Bug 11457 ]] Adjust lines and polygons to make sure antialiased lines don't draw across pixels.	
-		MCGPoint *t_points;
-		/* UNCHECKED */ MCMemoryNewArray(npoints, t_points);
+		/* UNCHECKED */ MCAutoPointer<MCGPoint[]> t_points =
+			new MCGPoint[npoints]();
 		for (uint32_t i = 0; i < npoints; i++)
 			t_points[i] = MCPointToMCGPoint(points[i], 0.5f);
 		
 		MCGContextBeginPath(m_gcontext);
 		if (p_closed)
-			MCGContextAddPolygon(m_gcontext, t_points, npoints);
+			MCGContextAddPolygon(m_gcontext, t_points.Get(), npoints);
 		else
-			MCGContextAddPolyline(m_gcontext, t_points, npoints);	
+			MCGContextAddPolyline(m_gcontext, t_points.Get(), npoints);
 		MCGContextStroke(m_gcontext);
-		
-		MCMemoryDeleteArray(t_points);
 	}
 }
 
@@ -1031,16 +1026,14 @@ void MCGraphicsContext::fillpolygon(MCPoint *points, uint2 npoints)
 {
 	// MM-2013-11-26: [[ Bug 11501 ]] Adjust lines and polygons to make sure antialiased lines don't draw across pixels.
 	//  Here the adjust is 0.25 - not the same path as draw lines but appears to solve the issue where the fill interfers with the stroke.
-	MCGPoint *t_points;
-	/* UNCHECKED */ MCMemoryNewArray(npoints, t_points);
+	/* UNCHECKED */ MCAutoPointer<MCGPoint[]> t_points =
+		new MCGPoint[npoints]();
 	for (uint32_t i = 0; i < npoints; i++)
 		t_points[i] = MCPointToMCGPoint(points[i], 0.25f);
 	
 	MCGContextBeginPath(m_gcontext);
-	MCGContextAddPolygon(m_gcontext, t_points, npoints);	
+	MCGContextAddPolygon(m_gcontext, t_points.Get(), npoints);
 	MCGContextFill(m_gcontext);
-	
-	MCMemoryDeleteArray(t_points);	
 }
 
 static MCGRectangle MCGRectangleInset(const MCGRectangle &p_rect, MCGFloat p_inset)

--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -674,9 +674,9 @@ MCCdata *MCHctext::buildf(MCHcstak *hcsptr, MCField *parent)
 		string = MCU_empty();
 	char *eptr = string;
 	MCParagraph *paragraphs = NULL;
-	const char *tname;
-	uint2 tsize;
-	uint2 tstyle;
+	const char *tname = nullptr;
+	uint2 tsize = 0;
+	uint2 tstyle = 0;
 	uint2 aindex = 2;
 	uint2 aoffset = 0;
 	uint2 alength = 0;

--- a/engine/src/ibmp.cpp
+++ b/engine/src/ibmp.cpp
@@ -633,7 +633,8 @@ bool bmp_read_rle4_image(IO_handle p_stream, uindex_t &x_bytes_read, MCImageBitm
 			else
 			{
 				// absolute mode
-				uint8_t t_byte, t_upper, t_lower;
+				uint8_t t_byte, t_upper;
+				uint8_t t_lower = 0;
 				
 				uint8_t t_run_buffer[128];
 				uint32_t t_run_bytes;
@@ -1556,7 +1557,7 @@ bool MCNetPBMImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count
 	uindex_t t_token_size;
 	
 	bool t_binary;
-	uindex_t t_depth;
+	uindex_t t_depth = 1;
 	uindex_t t_channel_count = 1;
 	uindex_t t_stride;
 

--- a/engine/src/idraw.cpp
+++ b/engine/src/idraw.cpp
@@ -285,8 +285,10 @@ void MCImage::drawwithgravity(MCDC *dc, MCRectangle r, MCGravity p_gravity)
 	t_old_opacity = dc -> getopacity();
 	dc -> setopacity(blendlevel * 255 / 100);
 
-    int2 dx, dy;
-    uint2 dw, dh;
+	int2 dx = 0;
+	int2 dy = 0;
+	uint2 dw = 0;
+	uint2 dh = 0;
     
     switch(p_gravity)
     {

--- a/engine/src/igif.cpp
+++ b/engine/src/igif.cpp
@@ -288,7 +288,7 @@ bool MCGIFImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 	// restoration info
 	MCImageBitmap *t_restore_image = nil;
 	int t_disposal_mode = DISPOSAL_UNSPECIFIED;
-	MCRectangle t_disposal_region;
+	MCRectangle t_disposal_region = kMCEmptyRectangle;
 
 	// The list of frames.
 	MCBitmapFrame *t_frames = nil;

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -845,7 +845,7 @@ void MCImage::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool p
 		}
 	}
 
-	bool t_need_group;
+	bool t_need_group = false;
 	if (!p_isolated)
 	{
 		// MW-2009-06-10: [[ Bitmap Effects ]]

--- a/engine/src/imagelist.cpp
+++ b/engine/src/imagelist.cpp
@@ -371,7 +371,7 @@ MCPatternRef MCImageList::allocpat(uint4 id, MCObject *optr)
 	if (newim == nil)
 		return nil;
 	
-	MCPatternRef pat;
+	MCPatternRef pat = nullptr;
 	MCImageListNode *tptr = images;
 	if (tptr != nil)
 		do
@@ -384,7 +384,7 @@ MCPatternRef MCImageList::allocpat(uint4 id, MCObject *optr)
 	
 	/* UNCHECKED */ tptr = new (nothrow) MCImageListNode(newim);
 	tptr->appendto(images);
-	tptr->allocimage(newim, pat);
+	/* UNCHECKED */ tptr->allocimage(newim, pat);
 	return pat;
 }
 

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -868,8 +868,8 @@ MCSocket *MCS_open_socket(MCNameRef name, MCNameRef from, Boolean datagram, MCOb
 		}
 		else
 		{
-			MCOpenSocketCallbackInfo *t_info;
-			MCMemoryNew(t_info);
+			MCOpenSocketCallbackInfo *t_info = nullptr;
+			/* UNCHECKED */ MCMemoryNew(t_info);
 			t_info->m_socket = s;
 			s->resolve_state = kMCSocketStateResolving;
 			if (!MCS_name_to_sockaddr(MCNameGetString(s->name), &t_info->m_sockaddr, open_socket_resolve_callback, t_info))

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -609,7 +609,7 @@ Parse_stat MCScriptPoint::next(Symbol_type &type)
 		in_tag = True;
 		
 		// Stores the length of the <? tag (if found)
-		uint32_t t_tag_length;
+		uint32_t t_tag_length = 0;
         
 		// Loop until a NUL char, or we find '<?rev'
 		bool t_in_comment;
@@ -1049,7 +1049,7 @@ Parse_stat MCScriptPoint::next(Symbol_type &type)
 		in_tag = True;
 		
 		// Stores the length of the <? tag (if found)
-		uint32_t t_tag_length;
+		uint32_t t_tag_length = 0;
 
 		// Loop until a NUL char, or we find '<?rev'
 		bool t_in_comment;

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -119,7 +119,7 @@ bool MCVariable::encode(void *&r_buffer, uindex_t& r_size)
     }
     else if (MCExecTypeIsNumber(value . type))
     {
-        double t_value;
+        double t_value = 0.0;
         if (value . type == kMCExecValueTypeUInt)
             t_value = (double)value . uint_value;
         else if (value . type == kMCExecValueTypeUInt)

--- a/libfoundation/src/foundation-locale.cpp
+++ b/libfoundation/src/foundation-locale.cpp
@@ -1004,7 +1004,7 @@ bool MCLocaleBreakIteratorCreate(MCLocaleRef p_locale, MCBreakIteratorType p_typ
     MCAssert(p_locale != nil);
     
     // Create the iterator with the requested type
-    icu::BreakIterator *t_iter;
+    icu::BreakIterator *t_iter = nullptr;
     UErrorCode t_error = U_ZERO_ERROR;
     switch (p_type)
     {


### PR DESCRIPTION
"GCC is able to detect places where stack values are used without being initialised. In some cases, the compiler isn't totally certain that they don't get initialised, so it emits a "maybe-uninitialized" warning rather than an definite "uninitialized" warning. Unfortunately, many of these places are not false positives."