### PR TITLE
[Bug 19541] Fix clipboard `IsEmpty()`

### DIFF
--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -149,7 +149,6 @@ void MCWin32RawClipboardCommon::Clear()
 	if (m_item)
 		m_item->Release();
 	m_item = NULL;
-	CreateNewItem();
 }
 
 bool MCWin32RawClipboardCommon::IsExternalData() const


### PR DESCRIPTION
A previous patch added `CreateNewItem()` to the raw
clipboard `Clear()` method. This is incorrect as
a cleared clipboard is distinct from a clipboard
containing a single item with a `NULL` `m_object`.

The error caused a regression in the drag behavior
that uses the clipboard `IsEmpty()` method to
determine if a drag has started.