### PR TITLE
[[ Tests ]] Add LCS parser test runner and tests

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -2,11 +2,12 @@
 
 Tests are small programs that check that a particular, specific function works correctly.  They are run automatically to check whether LiveCode works properly.  They're really useful for ensuring that changes to one part of LiveCode don't break other things!
 
-The main LiveCode engine repository contains four sets of tests ("test suites"):
+The main LiveCode engine repository contains the following sets of tests ("test suites"):
 
 * **LiveCode Script tests:** script-only stacks that are run using the LiveCode standalone engine.  They test features of the LiveCode Script language.
 * **LiveCode Builder tests:** LCB modules that are run using the **lc-run** tool.   They test features of the LCB core language and standard library.
 * **LiveCode Builder Compiler Frontend tests:** Fragments of LCB code which are run through the compiler and check that the compile succeeds, or emits the correct warnings or errors.
+* **LiveCode Script parser tests:** Fragments of LCS code which are run through the parser and check that the compile succeeds, or emits the correct warnings or errors.
 * **C++ tests:** low-level tests written in C++ using [Google Test](https://github.com/google/googletest).  These perform low-level checks for things that can't be tested any other way.
 
 ## Running the Tests
@@ -162,6 +163,52 @@ For example, to check whether the scope of variables within 'repeat forever' sta
 When compiled, lc-compile will emit an error on the 'put' line because tInnerVariable is not declared at that point. This matches the specified '%ERROR' assertion and so the test will pass (i.e. the compiler is correctly identifying the fact that tInnerVariable is not declared outside of the scope of the 'repeat forever' construct).
 
 To help debug compiler tests, set the LCC_VERBOSE environment variable to 1 before running the compiler test. This will cause the compiler testrunner to emit diagnostic information, including the full output of the compile command which is being run.
+
+### LiveCode Script Parser Tests
+
+The syntax for LiveCode Script parser tests is the same as that of the 
+LCB compiler frontent tests above. LCS parser test files all have the 
+extension '.parsertest'.
+
+Expected errors are referred to by their name in the parse errors 
+enumeration. For example the following tests the variable shadowing 
+parse error "local: name shadows another variable or constant":
+
+	%TEST ShadowVariable
+	local sVar
+	local %{BEFORE_SHADOW}sVar
+	%EXPECT PASS
+	%ERROR PE_LOCAL_SHADOW AT BEFORE_SHADOW
+	%ENDTEST
+
+The directive `%SET` can be used to specify the value of global properties
+used when running the test. In particular, it can be used to set the 
+value of the `explicitvariables` property. If the `explicitvariables` 
+property is not set then the test will be run with it set to `true` and 
+to `false`, and the test will fail if the result differs. For example:
+
+	%TEST CommentedContinuation
+	on compiler_test
+	-- comment \
+ 	with%{SYNTAX} continuation character
+	end compiler_test
+	%EXPECT PASS
+	%ERROR PE_EXPRESSION_NOTLITERAL AT SYNTAX
+	%ENDTEST
+
+will fail with "error: test ambiguity with explicit vars".
+
+	%TEST CommentedContinuationExplicit
+	%SET explicitvariables true
+	on compiler_test
+	-- comment \
+	with %{SYNTAX}continuation character
+	end compiler_test
+	%EXPECT PASS
+	%ERROR PE_EXPRESSION_NOTLITERAL AT SYNTAX
+	%ENDTEST
+
+will succeed.
 
 ### C++ tests with Google Test
 

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1637,7 +1637,7 @@ enum Parse_errors
 	PE_RESOLVE_BADOBJECT,
 	
 	// MERG-2013-10-04: [[ EditScriptAt ]] edit script of object at.
-    // {EE-0536} edit script: no at expression
+    // {PE-0536} edit script: no at expression
 	PE_EDIT_NOAT,
 	
 	// MW-2013-11-14: [[ AssertCmd ]] Parsing errors for assert command.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,6 +45,14 @@ LCC_CMD = $(LCS_ENGINE) -ui $(LCC_COMPILERTESTRUNNER) run
 
 LCC_LOG = _compiler_test_suite.log
 
+########## LiveCode Script Parser test parameters
+
+LCP_COMPILERTESTRUNNER ?= $(top_srcdir)/tests/_parsertestrunner.livecodescript
+
+LCP_CMD = $(LCS_ENGINE) -ui $(LCP_COMPILERTESTRUNNER) run
+
+LCP_LOG = _parser_test_suite.log
+
 ########## lc-run test params
 
 LC_RUN_TESTS ?= $(top_srcdir)/tests/_lcruntests.livecodescript
@@ -68,7 +76,7 @@ LC_COMPILE_FFI_JAVA_LOG = _lc-compile-ffi-java_test_suite.log
 
 .DEFAULT: check
 
-check: lcs-check lcb-check compiler-check lc-compile-ffi-java-check
+check: lcs-check lcb-check compiler-check lc-compile-ffi-java-check lcs-parser-check
 
 clean:
 	-rm -rf $(TEST_DIR) $(LCS_LOG) $(LCB_LOG)
@@ -149,6 +157,17 @@ compiler-check: $(LC_COMPILE)
 	export LCC_VERBOSE="$(LCC_VERBOSE)"; \
 	export TEST_SUITE_LOG_FILE="$(LCC_LOG)"; \
 	cmd="$(LCC_CMD)"; \
+	echo "$$cmd" $(_PRINT_RULE); \
+	$$cmd
+	
+################################################################
+# LCS parser tests
+################################################################
+
+lcs-parser-check:
+	@rm -f $(LCP_LOG)
+	export LCC_VERBOSE="$(LCC_VERBOSE)"; \
+	cmd="$(LCP_CMD)"; \
 	echo "$$cmd" $(_PRINT_RULE); \
 	$$cmd
 

--- a/tests/_compilertestrunnerbehavior.livecodescript
+++ b/tests/_compilertestrunnerbehavior.livecodescript
@@ -199,16 +199,16 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
    if the result is not empty then
       throw format("can't open file '%s'", pScriptFile)
    end if
-
+   
    local tScript
    read from file pScriptFile until end
    put it into tScript
-
+   
    close file pScriptFile
-
+   
    -- First extract the test block we are wanting to run
    local tLine, tLineNumber, tTestLineNumber, tState
-   local tName, tCode, tExpectation, tExpectationReason, tAssertions, tPositions
+   local tName, tCode, tExpectation, tExpectationReason, tAssertions, tPositions, tSet, tSetCount
    put empty into tLine
    put 0 into tLineNumber
    put 0 into tTestLineNumber
@@ -219,26 +219,28 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
    put empty into tExpectationReason
    put empty into tAssertions
    put empty into tPositions
+   put empty into tSet
+   put 0 into tSetCount
    repeat for each line tLine in tScript
       add 1 to tLineNumber
-
+      
       local tIsDirective
       put false into tIsDirective
       if tState is "code" then
          if word 1 of tLine begins with "%" and \
                not (word 1 of tLine begins with "%{") then
-               put true into tIsDirective
+            put true into tIsDirective
          end if
       else
          if word 1 of tLine begins with "%" then
             put true into tIsDirective
          end if
       end if
-
+      
       if tIsDirective then
          local tToken
          put word 1 of tLine into tToken
-
+         
          if tToken is "%%" then
             -- We don't allow comment directives inside code blocks
             if tState is "code" then
@@ -251,7 +253,7 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
             if tState is not empty then
                reportCompilerTestError pScriptFile, tLineNumber, "%TEST directive not allowed inside test block"
             end if
-
+            
             -- We've started a new test clause, so record the name and move to
             -- code state.
             reportCompilerTestDiag format("found test '%s' at line %d", word 2 of tLine, tLineNumber)
@@ -261,23 +263,24 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
             put empty into tExpectation
             put empty into tAssertions
             put empty into tPositions
-            put "code" into tState
+            put "set" into tState
+            put 0 into tSetCount
          else if tToken is "%EXPECT" then
             -- We only allow %EXPECT directives after code blocks
             if tState is not "code" then
                reportCompilerTestError pScriptFile, tLineNumber, "%EXPECT directive only allowed after code block"
             end if
-
+            
             -- If the expectation isn't one of PASS, FAIL, XFAIL, SKIP then it
             -- is an error
             if word 2 of tLine is not among the items of "PASS,FAIL,SKIP" then
                reportCompilerTestError pScriptFile, tLineNumber, format("invalid expectation '%s'", word 2 of tLine)
             end if
-
+            
             if word 3 of tLine contains "#" then
                reportCompilerTestError pScriptFile, tLineNumber, format("expectation reason cannot contain '#'")
             end if
-
+            
             -- Record the expectation, and move to assertions state.
             put word 2 of tLine into tExpectation
             put word 3 of tLine into tExpectationReason
@@ -290,40 +293,40 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
             if tState is not "assertions" then
                reportCompilerTestError pScriptFile, tLineNumber, "assertion directive outside of assertion block"
             end if
-
+            
             if tToken is "%SUCCESS" then
                if the number of words in tLine is not 1 then
                   reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %SUCCESS"
                end if
-
+               
                reportCompilerTestDiag format("found assert success at line %d", tLineNumber)
                put "success" & return after tAssertions
             else if tToken is "%WARNING" then
                if (the number of words in tLine is 4 and \
-                        word 3 of tLine is "AT") then
-
+                     word 3 of tLine is "AT") then
+                  
                   -- Check that the position exists
                   if tPositions[word 4 of tLine] is empty then
                      reportCompilerTestError pScriptFile, tLineNumber, format("unknown position '%s'", word 4 of tLine)
                   end if
-
+                  
                   reportCompilerTestDiag format("found assert warning %s for position %s (with '%s') at line %d", word 2 of tLine, word 4 of tLine, word 6 of tLine, tLineNumber)
-
+                  
                   put "warning", word 2 of tLine, word 4 of tLine & return after tAssertions
                else
                   reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %WARNING <id> AT <position>"
                end if
             else if tToken is "%ERROR" then
                if (the number of words in tLine is 4 and \
-                        word 3 of tLine is "AT") then
-
+                     word 3 of tLine is "AT") then
+                  
                   -- Check that the position exists
                   if tPositions[word 4 of tLine] is empty then
                      reportCompilerTestError pScriptFile, tLineNumber, format("unknown position '%s'", word 4 of tLine)
                   end if
-
+                  
                   reportCompilerTestDiag format("found assert error %s for position %s at line %d", word 2 of tLine, word 4 of tLine, tLineNumber)
-
+                  
                   put "error", word 2 of tLine, word 4 of tLine & return after tAssertions
                else
                   reportCompilerTestError pScriptFile, tLineNumber, "incorrect syntax, expected: %ERROR <id> AT <position>"
@@ -335,24 +338,30 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
             if tState is not "assertions" then
                reportCompilerTestError pScriptFile, tLineNumber, "premature %ENDTEST directive"
             end if
-
+            
             if tAssertions is empty then
                reportCompilerTestError pScriptFile, tLineNumber, "no assertions specified"
             end if
-
+            
             if tAssertions contains "%SUCCESS" and \
-               tAssertions contains "%ERROR" then
+                  tAssertions contains "%ERROR" then
                reportCompilerTestError pScriptFile, tLineNumber, "both %SUCCESS and %ERROR not allowed in the same set of assertions"
             end if
-
+            
             -- If this is the test we are looking for, we are done
             if tName is pTest then
                exit repeat
             end if
-
+            
             -- Move back to initial state
             put empty into tName
             put empty into tState
+         else if tToken is "%SET" then
+            if tState is not "set" then
+               reportCompilerTestError pScriptFile, tLineNumber, "set directive must precede code"
+            end if
+            add 1 to tSetCount
+            put word 3 of tLine into tSet[word 2 of tLine]
          else
             -- We've encountered an illegal directive
             reportCompilerTestError pScriptFile, tLineNumber, format("unknown directive '%s'", tToken)
@@ -362,10 +371,11 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
          if word 1 to -1 of tLine is not empty then
             reportCompilerTestError pScriptFile, tLineNumber, "junk outside of test clause"
          end if
-      else if tState is "code" then
+      else if tState is "code" or tState is "set" then
+         put "code" into tState
          -- If we are in a code block, then accumulate the code line after
          -- processing for position directives %{...}.
-
+         
          -- We loop through the line, searching for %{...}, and accumulating the
          -- code in between as we go.
          local tPositionSkip
@@ -388,25 +398,25 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
                reportCompilerTestError pScriptFile, tLineNumber, "unterminated named position"
             end if
             add tPositionOffset to tPositionEndOffset
-
+            
             -- Check that the name is not empty
             local tPositionName
             put char tPositionOffset + 2 to tPositionEndOffset - 1 of tLine into tPositionName
             if tPositionName is empty then
                reportCompilerTestError pScriptFile, tLineNumber, "empty named position"
             end if
-
+            
             -- Check that the position hasn't already been defined
             if tPositions[tPositionName] is not empty then
                reportCompilerTestError pScriptFile, tLineNumber, "named position already defined"
             end if
-
+            
             reportCompilerTestDiag format("found position '%s' at line %d", tPositionName, tLineNumber)
-            put tLineNumber - tTestLineNumber + 1 into tPositions[tPositionName]
-
+            put tLineNumber - tTestLineNumber - tSetCount + 1 into tPositions[tPositionName]
+            
             put tPositionEndOffset + 1 into tPositionSkip
          end repeat
-
+         
          -- Add the newline to the code
          put return after tCode
       else if tState is "assertions" then
@@ -416,20 +426,21 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
          end if
       end if
    end repeat
-
+   
    if tName is empty then
       reportCompilerTestError pScriptFile, tLineNumber, format("test '%s' not found in file", pTest)
    end if
-
+   
    -- We now have the code for the test, the expectation and a list of
    -- assertions.
-
+   
    put tName into rCompilerTest["name"]
    put tCode into rCompilerTest["code"]
    put tPositions into rCompilerTest["positions"]
    put tExpectation into rCompilerTest["expectation"]
    put tExpectation into rCompilerTest["reason"]
    put tAssertions into rCompilerTest["assertions"]
+   put tSet into rCompilerTest["set"]
 end processCompilerTest
 
 private command reportCompilerTestError pFile, pLine, pMessage

--- a/tests/_parsertestrunner.livecodescript
+++ b/tests/_parsertestrunner.livecodescript
@@ -1,0 +1,189 @@
+﻿script "ParserTestRunner"
+/*
+Copyright (C) 2016 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+private function getTestRunnerBehavior
+   -- Compute the filename of the test runner
+   local tTestsPath, tStack
+   set the itemdelimiter to "/"
+   put item 1 to -2 of the effective filename of me into tTestsPath
+   put tTestsPath & "/_compilertestrunnerbehavior.livecodescript" into tStack
+   return the long id of stack tStack
+end getTestRunnerBehavior
+
+on startup
+   local tTestRunner
+   put getTestRunnerBehavior() into tTestRunner
+   set the behavior of me to tTestRunner
+   
+   try
+      CompilerTestRunnerMain
+   catch tError
+      write "ERROR: " & tError & return to stderr
+   end try
+   quit 0
+end startup
+
+----------------------------------------------------------------
+-- Top-level actions
+----------------------------------------------------------------
+
+command CompilerTestRunner_DoUsage pStatus
+   write "Usage: _parsertestrunner.livecodescript run [SCRIPT [COMMAND]]" & return to stderr
+   quit pStatus
+end CompilerTestRunner_DoUsage
+
+private function DoCompile pScript
+   local tCompilerOutput, tStackName
+   lock messages
+   create stack
+   put the short name of it into tStackName
+   set the script of it to pScript
+   put the result into tCompilerOutput
+   delete stack tStackName
+   unlock messages
+   return tCompilerOutput
+end DoCompile
+
+constant kExplicitVarsError = "error: test ambiguity with explicit vars"
+command CompilerTestRunner_DoRunTest pTestInfo, @rOutput, @rExitStatus
+   -- Attempt to parse the code from the file
+   reportCompilerTestDiagWithLineNumbers pTestInfo["code"]
+
+   local tCompilerOutput, tCompilerExitStatus
+    
+   -- Try to execute the compilation
+   local tRestoreState
+   repeat for each key tProp in pTestInfo["set"]
+	  do "set the" && tProp && "to" && pTestInfo["set"][tProp]
+   end repeat
+   
+   -- Ensure explicitvars is not significant if it hasn't been set 
+   if "explicitvariables" is not among the keys of pTestInfo["set"] then
+      local tExplicitOutput, tNonExplicitOutput
+      set the explicitvars to true
+      put DoCompile(pTestInfo["code"]) into tExplicitOutput
+      set the explicitvars to false
+      put DoCompile(pTestInfo["code"]) into tNonExplicitOutput
+      if tExplicitOutput is tNonExplicitOutput then
+         put tExplicitOutput into tCompilerOutput
+      else 
+         put kExplicitVarsError into tCompilerOutput
+      end if      
+   else
+      put DoCompile(pTestInfo["code"]) into tCompilerOutput
+   end if
+   
+   if tCompilerOutput is empty then
+      put 0 into tCompilerExitStatus
+   else
+      put 1 into tCompilerExitStatus
+   end if
+   
+   put tCompilerOutput into rOutput
+   put tCompilerExitStatus into rExitStatus
+end CompilerTestRunner_DoRunTest
+
+function CompilerTestRunner_FileExtension
+   return "parsertest"
+end CompilerTestRunner_FileExtension
+
+local sErrorMap
+private command __BuildErrorMap
+   if sErrorMap is not empty then
+      exit __BuildErrorMap
+   end if
+   	
+   local tSourceFile
+   put TestGetEngineRepositoryPath() & slash & "engine/src/parseerrors.h" \
+         into tSourceFile
+   		
+   local tSource
+   put textDecode(url("binfile:" & tSourceFile), "utf-8") into tSource
+   
+   local tErrorMap, tCurrentCode, tCodeFound
+   put false into tCodeFound
+   repeat for each line tLine in tSource
+      if tLine is empty then next repeat
+      if word 1 of tLine begins with "PE_UNDEFINED" then next repeat
+      
+      local tCode
+      if matchText(tLine, ".*\/\/ \{PE-([0-9]{4})\}.*", tCode) then
+         put tCode into tCurrentCode
+         put true into tCodeFound
+         next repeat
+      end if
+      if word 1 of tLine begins with "PE_" then
+         if tCodeFound is false then
+            if tCurrentCode is empty then 
+               throw "no parse error code found:" && tLine
+            else
+               throw "duplicate parse error code" && tCurrentCode && "found:" && tLine
+            end if
+            
+         end if
+         put item 1 of (word 1 of tLine) into tErrorMap[tCurrentCode]
+         put false into tCodeFound
+      end if
+   end repeat
+   put tErrorMap into sErrorMap
+end __BuildErrorMap
+
+function CompilerTestRunner_DoesOutputSatisfyAssertion pCompilerOutput, pCompilerExitCode, pAssertion, pTestInfo
+   __BuildErrorMap
+   
+   if pCompilerOutput is kExplicitVarsError then
+      return false
+   end if
+   
+   if item 1 of pAssertion is "success" then
+      return pCompilerExitCode is 0
+   end if
+   
+   local tAssertionType, tErrorDescription, tAssertionPos
+   put item 1 of pAssertion into tAssertionType
+   put item 2 of pAssertion into tErrorDescription
+   put item 3 of pAssertion into tAssertionPos
+   
+   local tOutputLine
+   put line 1 of pCompilerOutput into tOutputLine
+   
+   -- The format of the error line is:
+   --   <code>,<line>,<col>
+   local tFile, tLine, tColumn, tCode, tMessage
+   put format("%04d", item 1 of tOutputLine) into tCode
+   put item 2 of tOutputLine into tLine
+   put item 3 of tOutputLine into tColumn
+   
+   -- If the assertion type doesn't match, continue
+   if tAssertionType is not "error" then
+      return false
+   end if
+   
+   -- If the assertion message is not within the message, continue
+   if tErrorDescription is not sErrorMap[tCode] then
+      return false
+   end if
+   
+   -- If the position does not match, continue
+   if pTestInfo["positions"][tAssertionPos] is not tLine then
+      return false
+   end if
+   	 
+   -- If we get here, we have a match so are successful!
+   return true
+end CompilerTestRunner_DoesOutputSatisfyAssertion

--- a/tests/_testrunnerbehavior.livecodescript
+++ b/tests/_testrunnerbehavior.livecodescript
@@ -206,7 +206,7 @@ end TestRunnerInvokeTestCommand
 ----------------------------------------------------------------
 
 -- Add the test runner library stack to the backscripts
-constant kRunLibraries = "_testerlib"
+constant kRunLibraries = "_testerlib,_testlib"
 command TestRunnerRunLoadLibraries
    TestRunnerLoadLibraries kRunLibraries
 end TestRunnerRunLoadLibraries

--- a/tests/lcs/parser/comments.parsertest
+++ b/tests/lcs/parser/comments.parsertest
@@ -1,0 +1,54 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%% Single line // comments
+%TEST SingleLineCommentSlashes
+on compiler_test
+// this should not be compiled
+end compiler_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Single line -- comments
+%TEST SingleLineCommentDashes
+on compiler_test
+-- this should not be compiled
+end compiler_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Block /* ... */ comments
+%TEST BlockComment
+on compiler_test
+/*
+this should not be compiled
+*/
+end compiler_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Block comments that extend over multiple lines do
+%% not terminate the line they are on.
+%TEST ContinuationMultilineComment
+on /*
+*/ compiler_test
+end compiler_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST

--- a/tests/lcs/parser/line-continuation.parsertest
+++ b/tests/lcs/parser/line-continuation.parsertest
@@ -1,0 +1,66 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%% Continuation characters allow long lines of code to be spread
+%% across multiple lines in the source file by escaping the following
+%% newline character.
+%TEST Continuation
+on \
+		compiler_test
+end compiler_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Line continuation characters can't occur within a line, because
+%% they consume a following newline.
+%TEST ContinuationNoNewline
+on \ compiler_test
+%{CONTINUATION_IN_LINE}end compiler_test
+%EXPECT PASS
+%ERROR PE_HANDLER_BADNAME AT CONTINUATION_IN_LINE
+%ENDTEST
+
+%% A backslash followed by a comment is a line continuation.
+%TEST ContinuationPreComment
+on \ -- test
+   compiler_test
+end compiler_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Line comments consume all characters up to the following newline
+%% and therefore cannot be continued
+%TEST CommentedContinuationExplicit
+%SET explicitvariables true
+on compiler_test
+-- comment \
+with %{SYNTAX}continuation character
+end compiler_test
+%EXPECT PASS
+%ERROR PE_EXPRESSION_NOTLITERAL AT SYNTAX
+%ENDTEST
+
+%TEST CommentedContinuation
+%SET explicitvariables false
+on compiler_test
+-- comment \
+with continuation %{SYNTAX}character
+end compiler_test
+%EXPECT PASS
+%ERROR PE_STATEMENT_BADSEP AT SYNTAX
+%ENDTEST

--- a/tests/lcs/parser/numeric-literals.parsertest
+++ b/tests/lcs/parser/numeric-literals.parsertest
@@ -1,0 +1,24 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%% Further junk after an integer is interpreted as an 
+%% attempt to define a second constant, hence ',' is 
+%% expected 
+%TEST DecimalIntegerLiterals
+constant InvalidSuffix = %{BEFORE_SUFFIX}100foo
+%EXPECT PASS
+%ERROR PE_STATEMENT_NOTSEP AT BEFORE_SUFFIX
+%ENDTEST

--- a/tests/lcs/parser/variables.parsertest
+++ b/tests/lcs/parser/variables.parsertest
@@ -1,0 +1,22 @@
+%% Copyright (C) 2016 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%TEST ShadowVariable
+local sVar
+local %{BEFORE_SHADOW}sVar
+%EXPECT PASS
+%ERROR PE_LOCAL_SHADOW AT BEFORE_SHADOW
+%ENDTEST


### PR DESCRIPTION
Allows LCS parser tests to be written in the same style as LCB compiler tests.