### PR TITLE
[[ Bug 19693 ]] Ensure platform player is destroyed on close

### DIFF
--- a/docs/notes/bugfix-19693.md
+++ b/docs/notes/bugfix-19693.md
@@ -1,0 +1,1 @@
+# Ensure closed players use no system resources

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -86,8 +86,6 @@ private:
     bool m_scrub_forward_is_pressed : 1;
     bool m_modify_selection_while_playing : 1;
 
-    bool m_should_recreate : 1;
-
 	static MCPropertyInfo kProperties[];
     static MCObjectPropertyTable kPropertyTable;
 


### PR DESCRIPTION
This patch ensures that the MCPlatformPlayer object is destroyed
when the player object is closed. This ensures that system resources
do not get used whilst the player is not being used.