### PR TITLE
Bugfix 17416

### DIFF
--- a/engine/src/exec-pasteboard.cpp
+++ b/engine/src/exec-pasteboard.cpp
@@ -1261,7 +1261,7 @@ void MCPasteboardSetClipboardOrDragDataLegacy(MCExecContext& ctxt, MCNameRef p_i
     // clipboard under the appropriate type.
     //
     // If either of these is missing, do nothing but don't throw an error.
-	if (t_type != TRANSFER_TYPE_NULL && p_data != nil)
+	if (t_type != TRANSFER_TYPE_NULL && p_data != nil && !MCValueIsEmpty(p_data))
 	{
 		switch (t_type)
 		{

--- a/tests/lcs/core/engine/clipboard.livecodescript
+++ b/tests/lcs/core/engine/clipboard.livecodescript
@@ -219,3 +219,14 @@ on TestClipboardTextToStyled
    TestAssert "plain text should remain plain in htmltext", \
       the clipboardData["html"] is "<p>Hello World</p>"
 end TestClipboardTextToStyled
+
+on _SetToEmpty 
+
+   set clipboardData["image"] to empty
+
+end _SetToEmpty
+
+# This is a test for Bug 17416
+on TestCanSetClipboardImageToEmpty
+   TestAssertDoesNotThrow "Can set clipboardData image to empty", "_SetToEmpty", the long id of me
+end TestCanSetClipboardImageToEmpty


### PR DESCRIPTION
Fixed bug preventing users from setting clipboardData["image"] to empty