### PR TITLE
[[ Bug 19271 ]] Expand range of 'random()' to 53-bits

### DIFF
--- a/docs/notes/bugfix-19271.md
+++ b/docs/notes/bugfix-19271.md
@@ -1,1 +1,1 @@
-# Increased random function input limit to 2^53 - 1
+# Increased random function input limit to 2^53

--- a/docs/notes/bugfix-19271.md
+++ b/docs/notes/bugfix-19271.md
@@ -1,0 +1,1 @@
+# Increased random function input limit to 2^53 - 1

--- a/engine/src/exec-math.cpp
+++ b/engine/src/exec-math.cpp
@@ -528,7 +528,7 @@ void MCMathEvalRandom(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 	p_in = floor(p_in + 0.5);
 	// MW-2007-07-03: [[ Bug 4506 ]] - Large integers result in negative numbers
 	// being generated.
-	if (p_in < 1.0 || p_in >= 4294967296.0)
+	if (p_in < 1.0 || p_in >= DBL_INT_MAX)
 	{
 		ctxt.LegacyThrow(EE_RANDOM_BADSOURCE);
 		return;

--- a/engine/src/exec-math.cpp
+++ b/engine/src/exec-math.cpp
@@ -528,7 +528,7 @@ void MCMathEvalRandom(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 	p_in = floor(p_in + 0.5);
 	// MW-2007-07-03: [[ Bug 4506 ]] - Large integers result in negative numbers
 	// being generated.
-	if (p_in < 1.0 || p_in >= DBL_INT_MAX)
+	if (p_in < 1.0 || p_in > DBL_INT_MAX)
 	{
 		ctxt.LegacyThrow(EE_RANDOM_BADSOURCE);
 		return;

--- a/engine/src/typedefs.h
+++ b/engine/src/typedefs.h
@@ -17,8 +17,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef __MC_TYPEDEFS__
 #define __MC_TYPEDEFS__
 
-// IEEE floating-point limits
-
 // Old-style integer definitions and limits
 
 typedef unsigned char   uint1;

--- a/engine/src/typedefs.h
+++ b/engine/src/typedefs.h
@@ -19,39 +19,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 // IEEE floating-point limits
 
-#ifndef DBL_EPSILON
-#define DBL_EPSILON     2.2204460492503131e-016 /* smallest such that 1.0+DBL_EPSILON != 1.0 */
-#endif
-
-#ifndef DBL_DIG
-#define DBL_DIG         15                      /* # of decimal digits of precision */
-#define DBL_MANT_DIG    53                      /* # of bits in mantissa */
-#define DBL_MAX         1.7976931348623158e+308 /* max value */
-#define DBL_MAX_10_EXP  308                     /* max decimal exponent */
-#define DBL_MAX_EXP     1024                    /* max binary exponent */
-#define DBL_MIN         2.2250738585072014e-308 /* min positive value */
-#define DBL_MIN_10_EXP  (-307)                  /* min decimal exponent */
-#define DBL_MIN_EXP     (-1021)                 /* min binary exponent */
-#endif
-
-#define _DBL_RADIX      2                       /* exponent radix */
-
-#ifndef FLT_DIG
-#define FLT_DIG         6                       /* # of decimal digits of precision */
-#define FLT_EPSILON     1.192092896e-07F        /* smallest such that 1.0+FLT_EPSILON != 1.0 */
-#define FLT_GUARD       0
-#define FLT_MANT_DIG    24                      /* # of bits in mantissa */
-#define FLT_MAX         3.402823466e+38F        /* max value */
-#define FLT_MAX_10_EXP  38                      /* max decimal exponent */
-#define FLT_MAX_EXP     128                     /* max binary exponent */
-#define FLT_MIN         1.175494351e-38F        /* min positive value */
-#define FLT_MIN_10_EXP  (-37)                   /* min decimal exponent */
-#define FLT_MIN_EXP     (-125)                  /* min binary exponent */
-#define FLT_NORMALIZE   0
-#define FLT_RADIX       2                       /* exponent radix */
-#define FLT_ROUNDS      1                       /* addition rounding: near */
-#endif
-
 // Old-style integer definitions and limits
 
 typedef unsigned char   uint1;

--- a/libfoundation/include/foundation-stdlib.h
+++ b/libfoundation/include/foundation-stdlib.h
@@ -24,6 +24,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
+#include <float.h>
 
 extern "C" __declspec(noalias) void __cdecl free(void *memory);
 extern "C" __declspec(noalias) void * __cdecl malloc(size_t size);
@@ -50,6 +51,7 @@ extern "C" double __cdecl fmod(double x, double y);
 #include <math.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <float.h>
 
 #endif
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2007,6 +2007,10 @@ MC_DLLEXPORT extern MCNumberRef kMCZero;
 MC_DLLEXPORT extern MCNumberRef kMCOne;
 MC_DLLEXPORT extern MCNumberRef kMCMinusOne;
 
+#define DBL_INT_MAX     (1LL << DBL_MANT_DIG)   /* the maximum integer faithfully representable by a double */
+#define DBL_INT_MIN     (-DBL_INT_MAX)          /* the minimum integer faithfully representable by a double */
+
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  NAME DEFINITIONS

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -742,8 +742,8 @@ struct DoExport<
         // First check that the value is within the contiguous integer range
         // of doubles. If that succeeds, then check it fits within the target
         // integer type.
-        if (t_value < double(-(1LL << std::numeric_limits<double>::digits)) ||
-            t_value > double(1LL << std::numeric_limits<double>::digits) ||
+        if (t_value < double(DBL_INT_MIN) ||
+            t_value > double(DBL_INT_MAX) ||
             t_value < double(std::numeric_limits<typename IntType::c_type>::min()) ||
             t_value > double(std::numeric_limits<typename IntType::c_type>::max()))
         {
@@ -767,8 +767,8 @@ struct DoImport<
         {
             return MCNumberCreateWithInteger(integer_t(p_value), r_boxed_value);
         }
-        else if (p_value >= -(1LL << std::numeric_limits<double>::digits) &&
-                 p_value <= (1LL << std::numeric_limits<double>::digits))
+        else if (p_value >= DBL_INT_MIN &&
+                 p_value <= (DBL_INT_MAX))
         {
             return MCNumberCreateWithReal(double(p_value), r_boxed_value);
         }

--- a/tests/lcs/core/math/math.livecodescript
+++ b/tests/lcs/core/math/math.livecodescript
@@ -927,7 +927,7 @@ on _RandomMaxLimitTestThrows
 	
 	local rN1
 
-	put rand(tN1) into rN1
+	put random(tN1) into rN1
 	
 end _RandomMaxLimitTestThrows
 
@@ -939,7 +939,7 @@ on _RandomMaxLimitTestNoThrow
 
 	put 2^53 - 1 into tN1
 
-	put rand(tN1) into rN1
+	put random(tN1) into rN1
 
 end _RandomMaxLimitTestNoThrow
 
@@ -948,7 +948,7 @@ on TestRandomGenLimits
 	TestAssertThrow "checks if bad input to random throws exception" , "_RandomMaxLimitTestThrows" , \
 		the long id of me , 469
 
-	TestAssertNoThrow "checks if correct input to random doesn't throw exception" \ 
+	TestAssertDoesNotThrow "checks if correct input to random doesn't throw exception" \ 
 		, "_RandomMaxLimitTestNoThrow" , the long id of me
 
 end TestRandomGenLimits

--- a/tests/lcs/core/math/math.livecodescript
+++ b/tests/lcs/core/math/math.livecodescript
@@ -925,6 +925,8 @@ on _RandomMaxLimitTestThrows
 
 	put 2^53 into tX
 	
+	-- this loop computes the next representable 
+	-- double after 2^53
 	repeat with i = 1 to 128
   		if tX + i - tX is not 0 then
      		exit repeat

--- a/tests/lcs/core/math/math.livecodescript
+++ b/tests/lcs/core/math/math.livecodescript
@@ -918,3 +918,37 @@ repeat with i = 1 to 10
 end repeat
 
 end TestMathArrayWrapArray
+
+on _RandomMaxLimitTestThrows
+
+	local tN1, tN2
+
+	put 2^53 into tN1
+	
+	local rN1
+
+	put rand(tN1) into rN1
+	
+end _RandomMaxLimitTestThrows
+
+
+
+on _RandomMaxLimitTestNoThrow
+
+	local tN1, tN2
+
+	put 2^53 - 1 into tN1
+
+	put rand(tN1) into rN1
+
+end _RandomMaxLimitTestNoThrow
+
+on TestRandomGenLimits
+
+	TestAssertThrow "checks if bad input to random throws exception" , "_RandomMaxLimitTestThrows" , \
+		the long id of me , 469
+
+	TestAssertNoThrow "checks if correct input to random doesn't throw exception" \ 
+		, "_RandomMaxLimitTestNoThrow" , the long id of me
+
+end TestRandomGenLimits

--- a/tests/lcs/core/math/math.livecodescript
+++ b/tests/lcs/core/math/math.livecodescript
@@ -937,7 +937,7 @@ on _RandomMaxLimitTestNoThrow
 
 	local tN1, tN2
 
-	put 2^53 - 1 into tN1
+	put 2^53 into tN1
 
 	put random(tN1) into rN1
 

--- a/tests/lcs/core/math/math.livecodescript
+++ b/tests/lcs/core/math/math.livecodescript
@@ -921,9 +921,17 @@ end TestMathArrayWrapArray
 
 on _RandomMaxLimitTestThrows
 
-	local tN1, tN2
+	local tX, tN2
 
-	put 2^53 + 2 into tN1
+	put 2^53 into tX
+	
+	repeat with i = 1 to 128
+  		if tX + i - tX is not 0 then
+     		exit repeat
+  		end if
+	end repeat
+	
+	put tX+i into tX
 	
 	local rN1
 

--- a/tests/lcs/core/math/math.livecodescript
+++ b/tests/lcs/core/math/math.livecodescript
@@ -923,7 +923,7 @@ on _RandomMaxLimitTestThrows
 
 	local tN1, tN2
 
-	put 2^53 into tN1
+	put 2^53 + 2 into tN1
 	
 	local rN1
 


### PR DESCRIPTION
Defined constants for limits of integer representation as double and increased input limit of random function to 2^53 - 1