### PR TITLE
[[ Bug 19538 ]] Fixed bug preventing users to select txt of len 65535

### DIFF
--- a/docs/notes/bugfix-19538.md
+++ b/docs/notes/bugfix-19538.md
@@ -1,0 +1,1 @@
+# Fixed bug preventing users from selecting text of length 65535

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -946,7 +946,7 @@ Exec_stat MCField::seltext(findex_t si, findex_t ei, Boolean focus, Boolean upda
 		sethilitedlines(NULL, 0);
 		drect = rect;
 	}
-	uint2 l;
+	findex_t l;
 	do
 	{
 		l = pgptr->gettextlengthcr();

--- a/tests/lcs/core/field/hilitedlines.livecodescript
+++ b/tests/lcs/core/field/hilitedlines.livecodescript
@@ -73,9 +73,9 @@ end TestNonContiguousSelection
 on TestCanSelectTextOf65535Length
     createField
 
-    put repeatedString("abcde",13107) into kFieldName
+    put format("%065535d",0) into field kFieldName
 
-    select chars 1 to -1 of kFieldName
+    select char 1 to -1 of field kFieldName
 
-    TestAssert true    
+    TestAssert "no crash implies correctly selected text" , true    
 end TestCanSelectTextOf65535Length

--- a/tests/lcs/core/field/hilitedlines.livecodescript
+++ b/tests/lcs/core/field/hilitedlines.livecodescript
@@ -69,3 +69,13 @@ on TestNonContiguousSelection
    set the hilitedLines of field kFieldName to empty
    TestAssert "selectedText of a list field without selected lines", the hilitedLines of field kFieldName is empty
 end TestNonContiguousSelection
+
+on TestCanSelectTextOf65535Length
+    createField
+
+    put repeatedString("abcde",13107) into kFieldName
+
+    select chars 1 to -1 of kFieldName
+
+    TestAssert true    
+end TestCanSelectTextOf65535Length


### PR DESCRIPTION
Fixed bug preventing users to select txt of len 65535