### PR TITLE
[[ Bug 15565 ]] Add missing create syntax forms

### DIFF
--- a/docs/dictionary/command/create-card.lcdoc
+++ b/docs/dictionary/command/create-card.lcdoc
@@ -47,7 +47,7 @@ stack>.
 
 The new card is placed after the current card. If <stackName>
 is specified, it will be placed in <stackName>, otherwise 
-in defualtStack When the <card> is created, you go to the new <card>.
+in the <defaultStack>. When the <card> is created, you go to the new <card>.
 
 Any groups on the current card whose backgroundBehavior is set to true
 will be placed on the newly-created <card> automatically.

--- a/docs/dictionary/command/create-card.lcdoc
+++ b/docs/dictionary/command/create-card.lcdoc
@@ -4,7 +4,7 @@ Synonyms: new card
 
 Type: command
 
-Syntax: create card [<cardName>]
+Syntax: create card [<cardName>] [in stack <stack>]
 
 Summary:
 Makes a new <card> with the same <background> (s) as the <current card>.
@@ -24,10 +24,18 @@ create card "Main"
 Example:
 create card (field "ouput")
 
+Example:
+create card "Main" in stack "Stack"
+
 Parameters:
 cardName:
 The name property of the new card. If you don't specify a cardName, the
 new card's name is empty.
+
+stack:
+A reference or and expression that evaluates to a reference to a
+stack. If you specify a stack, the card will be a member of that
+stack, otherwise it will be a member of the <defaultStack>.
 
 It:
 The <create card> <command> places the <ID> <property> of the newly
@@ -37,15 +45,12 @@ Description:
 Use the <create card> <command> to add a new <card> to the <current
 stack>. 
 
-The new card is placed after the current card in the defaultStack. When
-the <card> is created, you go to the new <card>.
+The new card is placed after the current card. If <stackName>
+is specified, it will be placed in <stackName>, otherwise 
+in defualtStack When the <card> is created, you go to the new <card>.
 
 Any groups on the current card whose backgroundBehavior is set to true
 will be placed on the newly-created <card> automatically.
-
->*Tip:* To create a <card> in a specific <stack>, first set the
-> <defaultStack> to the <stack> where you want to create the new <card>
-> : 
 
 References: clone (command), create (command), place (command),
 create stack (command), property (glossary), current card (glossary),

--- a/docs/dictionary/command/create-widget.lcdoc
+++ b/docs/dictionary/command/create-widget.lcdoc
@@ -2,7 +2,7 @@ Name: create widget
 
 Type: command
 
-Syntax: create [invisible] widget [<controlName>] as <widgetKind> [in <group>]
+Syntax: create [invisible] widget [<controlName>] as <widgetKind> [in {<group>|<card>}]
 
 Summary:
 Create a <widget> control of the specified <kind>.
@@ -39,6 +39,12 @@ the current card. If you specify a group, the new <widget> is a member
 of the <group>, and exists on each <card> that has the <group>. If you
 don't specify a <group>, the <widget> is created on the current <card>
 and appears only on that <card>.
+
+card:
+A reference or an expression that evaluates to a reference to a card.
+If you specify a card, the new <widget> is a member of the <card>. 
+If you specify neither a <group> nor a <card>, the <widget> 
+is created on the current <card> and appears only on that <card>.
 
 It:
 The <create widget> command places the ID property of the newly created

--- a/docs/dictionary/command/create.lcdoc
+++ b/docs/dictionary/command/create.lcdoc
@@ -4,7 +4,7 @@ Synonyms: new
 
 Type: command
 
-Syntax: create [invisible] <objectType> [<objectName>] [in <group>]
+Syntax: create [invisible] <objectType> [<objectName>] [in {group|card}]
 
 Summary:
 Creates a new object on the current card.
@@ -20,6 +20,9 @@ create button "Click Me"
 
 Example:
 create invisible field in group 1
+
+Example:
+create button "Click me" in card "Card1"
 
 Parameters:
 objectType (enum):
@@ -40,8 +43,13 @@ group:
 A reference or and expression that evaluates to a reference to a
 group on the current card. If you specify a group, the new object is a 
 member of the group, and exists on each card that has the group. If you 
-don't specify a group, the object is created on the current card and 
-appears only on that card.
+don't specify neither a group nor a card, the object is created on the 
+current card and appears only on that card.
+
+card:
+A reference or and expression that evaluates to a reference to a
+card. If you specify a card, the control will be a member of that
+card, otherwise it will be a member of the current card.
 
 It:
 The <create> command places the ID property of the newly created
@@ -88,6 +96,11 @@ not in standalone applications.
     set the defaultStack to "My Stack"
     create button "My Button"
 
+or create the control in a card attached to the specific stack:
+
+    create stack "Specific stack"
+    create card "Example Card" in stack "Specific stack"
+    create button "My Button" in card "Example Card"
 
 References: create stack (command), create card (command),
 templateButton (keyword), lockMessages (property),

--- a/docs/dictionary/command/create.lcdoc
+++ b/docs/dictionary/command/create.lcdoc
@@ -4,7 +4,7 @@ Synonyms: new
 
 Type: command
 
-Syntax: create [invisible] <objectType> [<objectName>] [in {group|card}]
+Syntax: create [invisible] <objectType> [<objectName>] [in {<group>|<card>}]
 
 Summary:
 Creates a new object on the current card.
@@ -43,7 +43,7 @@ group:
 A reference or and expression that evaluates to a reference to a
 group on the current card. If you specify a group, the new object is a 
 member of the group, and exists on each card that has the group. If you 
-don't specify neither a group nor a card, the object is created on the 
+specify neither a group nor a card, the object is created on the 
 current card and appears only on that card.
 
 card:

--- a/docs/notes/feature-create-in.md
+++ b/docs/notes/feature-create-in.md
@@ -1,0 +1,3 @@
+# Additional forms of create command
+- Create <card> in <stack> now works correctly
+- You can now create <control> in <card> as well as in <group>

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1406,13 +1406,16 @@ void MCCard::kfocusset(MCControl *target)
 	}
 }
 
-MCCard *MCCard::clone(Boolean attach, Boolean controls)
+MCCard *MCCard::clone(Boolean attach, Boolean controls, MCStack *p_parent)
 {
 	clean();
 	MCCard *newcptr = new (nothrow) MCCard(*this);
-	newcptr->parent = MCdefaultstackptr;
+    if (p_parent == nullptr)
+    {
+        p_parent = MCdefaultstackptr;
+    }
+	newcptr->parent = p_parent;
 	Boolean diffstack = getstack() != MCdefaultstackptr;
-
 	if (controls)
 	{
 		if (objptrs != NULL)

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -136,7 +136,7 @@ public:
 	IO_stat loadobjects(IO_handle stream, uint32_t version);
 
 	void kfocusset(MCControl *target);
-	MCCard *clone(Boolean attach, Boolean controls);
+	MCCard *clone(Boolean attach, Boolean controls, MCStack *p_parent=nullptr);
 	void clonedata(MCCard *source);
 	void replacedata(MCStack *source);
 	Exec_stat relayer(MCControl *optr, uint2 newlayer);

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -136,7 +136,7 @@ public:
 	IO_stat loadobjects(IO_handle stream, uint32_t version);
 
 	void kfocusset(MCControl *target);
-	MCCard *clone(Boolean attach, Boolean controls, MCStack *p_parent=nullptr);
+	MCCard *clone(Boolean attach, Boolean controls, MCStack *p_parent = nullptr);
 	void clonedata(MCCard *source);
 	void replacedata(MCStack *source);
 	Exec_stat relayer(MCControl *optr, uint2 newlayer);

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -614,7 +614,20 @@ void MCCreate::exec_ctxt(MCExecContext& ctxt)
             }
                 break;
             case CT_CARD:
-                MCInterfaceExecCreateCard(ctxt, *t_new_name, visible == False);
+            {
+                MCObject *parent = nil;
+                if (container != nil)
+                {
+                    uint32_t parid;
+                  
+                    if (!container->getobj(ctxt, parent, parid, True) || parent->gettype() != CT_STACK)
+                    {
+                        ctxt . LegacyThrow(EE_CREATE_BADBGORCARD);
+                        return;
+                    }
+                }
+                MCInterfaceExecCreateCard(ctxt, *t_new_name, static_cast<MCStack *>(parent), visible==False);
+            }
                 break;
             case CT_WIDGET:
             {

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -643,13 +643,14 @@ void MCCreate::exec_ctxt(MCExecContext& ctxt)
                 {
                     uint32_t parid;
                     
-                    if (!container->getobj(ctxt, parent, parid, True) || parent->gettype() != CT_GROUP)
+                    if (!container->getobj(ctxt, parent, parid, True) 
+							|| (parent->gettype() != CT_GROUP && parent->gettype() != CT_CARD))
                     {
                         ctxt . LegacyThrow(EE_CREATE_BADBGORCARD);
                         return;
                     }
                 }
-                MCInterfaceExecCreateWidget(ctxt, *t_new_name, *t_kind, (MCGroup *)parent, visible == False);
+                MCInterfaceExecCreateWidget(ctxt, *t_new_name, *t_kind, parent, visible == False);
                 break;
             }
             default:
@@ -666,7 +667,7 @@ void MCCreate::exec_ctxt(MCExecContext& ctxt)
                         return;
                     }
                 }
-                MCInterfaceExecCreateControl(ctxt, *t_new_name, otype, (MCGroup *)parent, visible == False);
+                MCInterfaceExecCreateControl(ctxt, *t_new_name, otype, parent, visible == False);
             }
                 break;
             }

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -660,7 +660,7 @@ void MCCreate::exec_ctxt(MCExecContext& ctxt)
                     uint4 parid;
 
                     if (!container->getobj(ctxt, parent, parid, True)
-                            || parent->gettype() != CT_GROUP)
+                            || (parent->gettype() != CT_GROUP && parent->gettype() != CT_CARD) )
                     {
                         ctxt . LegacyThrow(EE_CREATE_BADBGORCARD);
                         return;

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -226,7 +226,7 @@ MC_EXEC_DEFINE_EXEC_METHOD(Interface, PopupStack, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Interface, PopupStackByName, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Interface, CreateStack, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Interface, CreateStackWithGroup, 3)
-MC_EXEC_DEFINE_EXEC_METHOD(Interface, CreateCard, 2)
+MC_EXEC_DEFINE_EXEC_METHOD(Interface, CreateCard, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Interface, CreateControl, 4)
 MC_EXEC_DEFINE_EXEC_METHOD(Interface, Clone, 3)
 MC_EXEC_DEFINE_EXEC_METHOD(Interface, Find, 3)
@@ -3272,23 +3272,31 @@ void MCInterfaceExecCreateStackWithGroup(MCExecContext& ctxt, MCGroup *p_group_t
 	MCInterfaceExecCreateStack(ctxt, p_group_to_copy, p_new_name, p_force_invisible, true);
 }
 
-void MCInterfaceExecCreateCard(MCExecContext& ctxt, MCStringRef p_new_name, bool p_force_invisible)
+
+void MCInterfaceExecCreateCard(MCExecContext& ctxt, MCStringRef p_new_name, MCStack *p_parent, bool p_force_invisible)
 {
-	if (MCdefaultstackptr->islocked())
-	{
-		ctxt . LegacyThrow(EE_CREATE_LOCKED);
-		return;
-	}
-
-	MCdefaultstackptr->stopedit();
-	MCObject *t_object = MCtemplatecard->clone(True, False);
-
-	if (p_new_name != nil)
-		t_object->setstringprop(ctxt, 0, P_NAME, False, p_new_name);
-	
-	MCAutoValueRef t_id;
-	t_object->names(P_LONG_ID, &t_id);
-	ctxt . SetItToValue(*t_id);
+    if (p_parent == nullptr)
+    {
+        p_parent = MCdefaultstackptr;
+    }
+    
+    if (p_parent->islocked())
+    {
+    		ctxt . LegacyThrow(EE_CREATE_LOCKED);
+    		return;
+    }
+    
+    p_parent->stopedit();
+    MCObject *t_object = MCtemplatecard->clone(True, False,p_parent);
+    
+    if (p_new_name != nil)
+    {
+     	t_object->setstringprop(ctxt, 0, P_NAME, False, p_new_name);
+    }
+    
+    MCAutoValueRef t_id;
+    t_object->names(P_LONG_ID, &t_id);
+    ctxt . SetItToValue(*t_id);
 }
 
 MCControl* MCInterfaceExecCreateControlGetObject(MCExecContext& ctxt, int p_type, MCGroup *&r_parent)

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3330,7 +3330,10 @@ MCControl* MCInterfaceExecCreateControlGetObject(MCExecContext& ctxt, int p_type
 
 void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCObject *p_container, bool p_force_invisible)
 {
-    if (MCdefaultstackptr->islocked())
+    
+    MCStack *t_current_stack = p_container == nullptr ? MCdefaultstackptr : p_container->getstack();
+    
+    if (t_current_stack->islocked())
 	{
 		ctxt . LegacyThrow(EE_CREATE_LOCKED);
 		return;
@@ -3367,9 +3370,12 @@ void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, i
 	ctxt . SetItToValue(*t_id);
 }
 
-void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MCNameRef p_kind, MCGroup* p_container, bool p_force_invisible)
+void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MCNameRef p_kind, MCObject* p_container, bool p_force_invisible)
 {
-    if (MCdefaultstackptr->islocked())
+    
+    MCStack *t_current_stack = p_container == nullptr ? MCdefaultstackptr : p_container->getstack();
+    
+    if (t_current_stack->islocked())
     {
         ctxt . LegacyThrow(EE_CREATE_LOCKED);
         return;

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3299,7 +3299,7 @@ void MCInterfaceExecCreateCard(MCExecContext& ctxt, MCStringRef p_new_name, MCSt
     ctxt . SetItToValue(*t_id);
 }
 
-MCControl* MCInterfaceExecCreateControlGetObject(MCExecContext& ctxt, int p_type, MCGroup *&r_parent)
+MCControl* MCInterfaceExecCreateControlGetObject(MCExecContext& ctxt, int p_type, MCObject *&r_parent)
 {
 	switch (p_type)
 	{
@@ -3328,9 +3328,9 @@ MCControl* MCInterfaceExecCreateControlGetObject(MCExecContext& ctxt, int p_type
 	}
 }
 
-void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCGroup *p_container, bool p_force_invisible)
+void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCObject *p_container, bool p_force_invisible)
 {
-	if (MCdefaultstackptr->islocked())
+    if (MCdefaultstackptr->islocked())
 	{
 		ctxt . LegacyThrow(EE_CREATE_LOCKED);
 		return;

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3121,7 +3121,7 @@ void MCInterfaceExecCreateScriptOnlyStack(MCExecContext& ctxt, MCStringRef p_new
 void MCInterfaceExecCreateStackWithGroup(MCExecContext& ctxt, MCGroup *p_group_to_copy, MCStringRef p_new_name, bool p_force_invisible);
 void MCInterfaceExecCreateCard(MCExecContext& ctxt, MCStringRef p_new_name, MCStack *p_parent, bool p_force_invisible);
 void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCObject *p_container, bool p_force_invisible);
-void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MCNameRef p_kind, MCGroup *p_container, bool p_force_invisible);
+void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MCNameRef p_kind, MCObject *p_container, bool p_force_invisible);
 
 void MCInterfaceExecClone(MCExecContext& ctxt, MCObject *p_target, MCStringRef p_new_name, bool p_force_invisible);
 

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3120,7 +3120,7 @@ void MCInterfaceExecCreateStack(MCExecContext& ctxt, MCStack *p_owner, MCStringR
 void MCInterfaceExecCreateScriptOnlyStack(MCExecContext& ctxt, MCStringRef p_new_name);
 void MCInterfaceExecCreateStackWithGroup(MCExecContext& ctxt, MCGroup *p_group_to_copy, MCStringRef p_new_name, bool p_force_invisible);
 void MCInterfaceExecCreateCard(MCExecContext& ctxt, MCStringRef p_new_name, MCStack *p_parent, bool p_force_invisible);
-void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCGroup *p_container, bool p_force_invisible);
+void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCObject *p_container, bool p_force_invisible);
 void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MCNameRef p_kind, MCGroup *p_container, bool p_force_invisible);
 
 void MCInterfaceExecClone(MCExecContext& ctxt, MCObject *p_target, MCStringRef p_new_name, bool p_force_invisible);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3119,7 +3119,7 @@ void MCInterfaceExecPopupStackByName(MCExecContext& ctxt, MCNameRef p_target, MC
 void MCInterfaceExecCreateStack(MCExecContext& ctxt, MCStack *p_owner, MCStringRef p_new_name, bool p_force_invisible);
 void MCInterfaceExecCreateScriptOnlyStack(MCExecContext& ctxt, MCStringRef p_new_name);
 void MCInterfaceExecCreateStackWithGroup(MCExecContext& ctxt, MCGroup *p_group_to_copy, MCStringRef p_new_name, bool p_force_invisible);
-void MCInterfaceExecCreateCard(MCExecContext& ctxt, MCStringRef p_new_name, bool p_force_invisible);
+void MCInterfaceExecCreateCard(MCExecContext& ctxt, MCStringRef p_new_name, MCStack *p_parent, bool p_force_invisible);
 void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCGroup *p_container, bool p_force_invisible);
 void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MCNameRef p_kind, MCGroup *p_container, bool p_force_invisible);
 

--- a/tests/lcs/core/interface/stack.livecodescript
+++ b/tests/lcs/core/interface/stack.livecodescript
@@ -32,6 +32,7 @@ on TestCreateControlInCard
 	create stack "Temp"
 
 	create card "Other"
+	create card "Other2"
 
 	create button "Test" in card "Other"
 
@@ -40,10 +41,10 @@ end TestCreateControlInCard
 
 on TestCreateControlInStack	
 	create stack "Temp"
+	create stack "Temp2"
 
 	create card "Other" in stack "Temp"
 
-	put there is a card "Other"
 
 	TestAssert "test if the card was created in the correct stack" , there is a card "Other" of stack "Temp"
 end TestCreateControlInStack

--- a/tests/lcs/core/interface/stack.livecodescript
+++ b/tests/lcs/core/interface/stack.livecodescript
@@ -28,3 +28,22 @@ on TestStackNameProp
 	TestAssert "Variable used to set stack name is unmodified", tVar is "Test 1,2,3"
 end TestStackNameProp
 
+on TestCreateControlInCard	
+	create stack "Temp"
+
+	create card "Other"
+
+	create button "Test" in card "Other"
+
+	TestAssert "test if the button was created in the correct card" , there is a button "Test" of card "Other"
+end TestCreateControlInCard
+
+on TestCreateControlInStack	
+	create stack "Temp"
+
+	create card "Other" in stack "Temp"
+
+	put there is a card "Other"
+
+	TestAssert "test if the card was created in the correct stack" , there is a card "Other" of stack "Temp"
+end TestCreateControlInStack

--- a/tests/lcs/core/interface/stack.livecodescript
+++ b/tests/lcs/core/interface/stack.livecodescript
@@ -39,7 +39,7 @@ on TestCreateControlInCard
 	TestAssert "test if the button was created in the correct card" , there is a button "Test" of card "Other"
 end TestCreateControlInCard
 
-on TestCreateControlInStack	
+on TestCreateCardInStack	
 	create stack "Temp"
 	create stack "Temp2"
 
@@ -47,4 +47,33 @@ on TestCreateControlInStack
 
 
 	TestAssert "test if the card was created in the correct stack" , there is a card "Other" of stack "Temp"
-end TestCreateControlInStack
+end TestCreateCardInStack
+
+on TestCreateWidgetInCard
+	create stack "Temp"
+
+	create card "Other" in stack "Temp"
+	create card "Other 2"
+
+	create widget "My Navbar" as "com.livecode.widget.navbar" in card "Other" of stack "Temp"
+
+	TestAssert "test if the widget was created in the correct card", there is a widget "My Navbar" of card "Other" of stack "Temp"
+end TestCreateWidgetInCard
+
+on TestCreateControlInContainerWithDefaultStackLocked
+	create stack "Temp"
+	
+	set the cantModify of stack "Temp" to true
+	
+	create stack "Temp2"
+	
+	set the defaultStack to "Temp2"
+	
+	create group "Bar"
+	
+	set the defaultStack to "Temp"
+	
+	create button "Foo" in group "Bar" of stack "Temp2"
+
+	TestAssert "testing no exceptions were thrown" , true
+end TestCreateControlInContainerWithDefaultStackLocked


### PR DESCRIPTION
I have added the following (i.e. these are now accepted statements)

create card .. in stack ...
create control ... in card ... 

where the stack and card are not the default stack/card

