### PR TITLE
[Bug 19646] Restore lockIdleTimer's value when camera is dismissed

### DIFF
--- a/docs/notes/bugfix-19646.md
+++ b/docs/notes/bugfix-19646.md
@@ -1,0 +1,1 @@
+# Make sure using mobile camera does not change the value of mobileLockIdleTimer


### PR DESCRIPTION
It seems that internally `UIImagePickerController` sets `UIApplication.idleTimerDisabled` to YES to keep the camera from sleeping. When finished, the `UIImagePickerController` sets `UIApplication.idleTimerDisabled` back to NO. Instead, it only should do this if the value was previously NO.
 
This patch deals with this issue by restoring the original value of the `UIApplication.idleTimerDisabled` once the `UIImagePickerController` has finished.  