### PR TITLE
[Bug 16586] Fix backColor of graphics created in legacy themed stacks

### DIFF
--- a/docs/notes/bugfix-16586.md
+++ b/docs/notes/bugfix-16586.md
@@ -1,0 +1,1 @@
+# Fixed bug setting the background color of graphics created in legacy themed stacks to grey

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -198,6 +198,7 @@ void MCGraphic::initialise(void)
 	minrect.height = 0;
 
 	m_stroke_miter_limit = 10.0;
+    m_theme_type = kMCPlatformControlTypeGraphic;
 }
 
 void MCGraphic::finalise(void)

--- a/engine/src/mac-theme.mm
+++ b/engine/src/mac-theme.mm
@@ -299,7 +299,11 @@ bool MCPlatformGetControlThemePropColor(MCPlatformControlType p_type, MCPlatform
                         t_is_pattern = true;
                         t_color = [NSColor windowBackgroundColor];
                         break;
-                        
+                    case kMCPlatformControlTypeGraphic:
+                        if (p_state & kMCPlatformControlStateCompatibility)
+                        {
+                            return false;
+                        }
                     default:
                         // controlColor is a pattern
                         t_is_pattern = true;

--- a/engine/src/platform.h
+++ b/engine/src/platform.h
@@ -1248,7 +1248,8 @@ enum MCPlatformControlType
     kMCPlatformControlTypeSpinArrows,   // Up-down arrows for value adjustment
     kMCPlatformControlTypeTooltip,      // Tooltip popups
     kMCPlatformControlTypeWindow,       // Windows can have theming props too
-    kMCPlatformControlTypeMessageBox    // Pop-up alert dialogue
+    kMCPlatformControlTypeMessageBox,    // Pop-up alert dialogue
+    kMCPlatformControlTypeGraphic,      // Graphic
 };
 
 typedef unsigned int MCPlatformControlState;

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -250,3 +250,12 @@ on TestTeardown
 	end if
 end TestTeardown
 
+on TestLegacyThemeGraphics
+	create stack
+	set the theme of this stack to legacy
+
+	create graphic "g"
+
+	TestAssert "see the actual color is empty", the backColor of graphic "g" is empty
+	TestAssert "see the effective color is white", the effective backColor of graphic "g" is white 
+end TestLegacyThemeGraphics


### PR DESCRIPTION
Added kMCPlatformControlStateGraphic and set it in the constructor of MCGraphic so that the legacy theme is applied to Graphics when it is applied to the parent stack.