### PR TITLE
Travis more helpful errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ install: (cd prebuilt && ./fetch-libraries.sh linux)
 # the default test suite.
 script: >
   if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then
-      make all-linux && make check-linux
+      make all-linux;
+      make check-linux V=1 || travis_terminate 1;
   fi
 
 addons:

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -126,6 +126,9 @@ private command doRun pInfo
    put tLogForWriting into url ("binfile:" & kLogFilename)
    
    if TesterTapGetWorstResult(tAnalysis) is "FAIL" then
+      if $V is not empty then
+         write tLogForWriting to stdout
+   	  end if
       quit 1
    end if
 end doRun


### PR DESCRIPTION
This patch ensures that if make check-linux fails on Travis, the
entire test log is dumped to stdout.