### PR TITLE
[bugfix 19165] tweak formatting choose.lcdoc

### DIFF
--- a/docs/dictionary/command/choose.lcdoc
+++ b/docs/dictionary/command/choose.lcdoc
@@ -36,8 +36,7 @@ toolName (enum):
 -   curve: draw a curved line in an image 
 -   regular polygon: draw a regular polygon shape in an image 
 -   dropper: pick up a color from an image
--   browse: perform actions such as clicking buttons and typing in
-    fields 
+-   browse: perform actions such as clicking buttons and typing in fields 
 -   pointer: select, move, or resize objects
 -   button: create all styles of button objects
 -   field: create all styles of field objects

--- a/docs/notes/bugfix-19165.lcdoc
+++ b/docs/notes/bugfix-19165.lcdoc
@@ -1,0 +1,1 @@
+# Tweak formating on choose command doc removing return in browse param to remove word fields from top of param list.


### PR DESCRIPTION
Fix Browse tool name param to remove word 'fields' from top of tool name list.