### PR TITLE
[Bugfix 14311]  add example to 'replace' command in dictionary

### DIFF
--- a/docs/dictionary/command/replace.lcdoc
+++ b/docs/dictionary/command/replace.lcdoc
@@ -25,6 +25,10 @@ replace somethingOld with "\" in it
 Example:
 replace ".com" with somethingNew in URL "file:stuff.txt"
 
+Example:
+put "12.34.56.78" into p
+replace "." with empty in char 4 to -1 of p  -- 12.345678
+
 Parameters:
 oldString (string):
 Any expression that evaluates to a string, and specifies the text to

--- a/docs/notes/bugfix-14311.md
+++ b/docs/notes/bugfix-14311.md
@@ -1,0 +1,1 @@
+# add example to replace command dictionary entry showing it can be used on a chunk within a string.

--- a/docs/notes/bugfix-19803.md
+++ b/docs/notes/bugfix-19803.md
@@ -1,0 +1,1 @@
+# Added selectionChanged association to player object

--- a/docs/notes/bugfix-19803.md
+++ b/docs/notes/bugfix-19803.md
@@ -1,1 +1,0 @@
-# Added selectionChanged association to player object


### PR DESCRIPTION
Add example to 'replace' command in dictionary showing it can be used on a chunk within a  string.