### PR TITLE
[[ Bug 19720 ]] Fix itemCount error in segmented widget

### DIFF
--- a/extensions/widgets/segmented/notes/19720.md
+++ b/extensions/widgets/segmented/notes/19720.md
@@ -1,0 +1,3 @@
+# Segment count
+
+# [16241] Runtime error when changing itemCount by more than one

--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -687,23 +687,36 @@ end handler
 constant kDefaultSegmentIcon is "circle"
 constant kDefaultSegmentLabel is "Label"
 constant kDefaultSegmentMinWidth is 50
-private handler updateProperties() returns nothing
-	variable tX as Integer
-	
-	if (the number of elements in mSegmentLabels) < mNumSegments then
-		repeat with tX from 1 up to (mNumSegments-(the number of elements in mSegmentLabels))
-			push (kDefaultSegmentLabel && tX formatted as string) onto back of mSegmentLabels
-		end repeat
-	else if (the number of elements in mSegmentLabels) > mNumSegments then
-		repeat with tX from 1 up to (the number of elements in mSegmentLabels)-mNumSegments
-			delete element (tX + mNumSegments) of mSegmentLabels
-		end repeat
+
+private handler adjustList(inout xList as List, in pNewCount as Integer, in pDefault as any)
+	variable tOldCount as Integer
+	put the number of elements in xList into tOldCount
+	if pNewCount < tOldCount then
+		deleteElementsFromList(xList, tOldCount - pNewCount)
+	else
+		addElementsToList(xList, pNewCount - tOldCount, pDefault)
 	end if
-	
-	if (the number of elements in mSegmentNames) < mNumSegments then
-		variable tNumber as Number
-		put the number of elements in mSegmentNames into tNumber 
-		repeat with tX from 1 up to (mNumSegments-(the number of elements in mSegmentNames))
+end handler
+
+private handler deleteElementsFromList(inout xList as List, in pCount as Integer)
+	delete element -pCount to -1 of xList
+end handler
+
+private handler addElementsToList(inout xList as List, in pCount as Integer, in pDefault as any)
+	repeat pCount times
+		push pDefault onto back of xList
+	end repeat
+end handler
+
+private handler updateProperties() returns nothing
+	variable tNumNames as Integer
+	put the number of elements in mSegmentNames into tNumNames	
+	if mNumSegments < tNumNames then
+		deleteElementsFromList(mSegmentNames,tNumNames - mNumSegments)
+	else
+		variable tNumber as Integer
+		put tNumNames into tNumber
+		repeat (mNumSegments - tNumNames) times
 			variable tName as String
 			add 1 to tNumber
 			put "segment" & tNumber formatted as string into tName
@@ -713,42 +726,12 @@ private handler updateProperties() returns nothing
 			end repeat
 			push tName onto back of mSegmentNames
 		end repeat
-	else if (the number of elements in mSegmentNames) > mNumSegments then
-		repeat with tX from 1 up to (the number of elements in mSegmentNames)-mNumSegments
-			delete element (tX + mNumSegments) of mSegmentNames
-		end repeat
 	end if
 		
-	if (the number of elements in mSegmentIcons) < mNumSegments then
-		repeat with tX from 1 up to (mNumSegments-(the number of elements in mSegmentIcons))
-			push kDefaultSegmentIcon onto back of mSegmentIcons
-		end repeat
-	else if (the number of elements in mSegmentIcons) > mNumSegments then
-		repeat with tX from 1 up to (the number of elements in mSegmentIcons)-mNumSegments
-			delete element (tX + mNumSegments) of mSegmentIcons
-		end repeat
-	end if
-	
-	if (the number of elements in mSelectedIcons) < mNumSegments then
-		repeat with tX from 1 up to (mNumSegments-(the number of elements in mSelectedIcons))
-			push kDefaultSegmentIcon onto back of mSelectedIcons
-		end repeat
-	else if (the number of elements in mSelectedIcons) > mNumSegments then
-		repeat with tX from 1 up to (the number of elements in mSelectedIcons)-mNumSegments
-			delete element (tX + mNumSegments) of mSelectedIcons
-		end repeat
-	end if
-	
-	if (the number of elements in mSegmentMinWidth) < mNumSegments then
-		repeat with tX from 1 up to (mNumSegments-(the number of elements in mSegmentMinWidth))
-			push kDefaultSegmentMinWidth onto back of mSegmentMinWidth
-		end repeat
-	else if (the number of elements in mSegmentMinWidth) > mNumSegments then
-		repeat with tX from 1 up to (the number of elements in mSegmentMinWidth)-mNumSegments
-			delete element (tX + mNumSegments) of mSegmentMinWidth
-		end repeat
-	end if
-	
+	adjustList(mSegmentLabels, mNumSegments, kDefaultSegmentLabel)
+	adjustList(mSegmentIcons, mNumSegments, kDefaultSegmentIcon)
+	adjustList(mSelectedIcons, mNumSegments, kDefaultSegmentIcon)
+	adjustList(mSegmentMinWidth, mNumSegments, kDefaultSegmentMinWidth)
 end handler
 
 private handler fetchWidth(in pSegment as Integer) returns Real

--- a/extensions/widgets/segmented/tests/properties.livecodescript
+++ b/extensions/widgets/segmented/tests/properties.livecodescript
@@ -1,0 +1,34 @@
+script "SegmentedControlProperties"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSetup
+	TestLoadExtension "com.livecode.library.iconSVG"
+	TestLoadExtension "com.livecode.library.widgetutils"
+	TestLoadExtension "com.livecode.widget.segmented"
+end TestSetup
+
+-- Bug 19720
+on TestSetItemCount
+	create stack
+	create widget as "com.livecode.widget.segmented"
+	set the itemCount of it to 1
+	TestAssert "set segment count", the itemCount of it is 1
+	
+	set the itemCount of it to 5
+	TestAssert "set segment count", the itemCount of it is 5
+end TestSetItemCount


### PR DESCRIPTION
The logic for changing the itemCount of the segmented widget was
flawed, causing chunk range runtime errors.

This patch fixes the logic and cleans up the code.