### PR TITLE
[[ Bug 19742 ]] Fix crash when deleting object

### DIFF
--- a/docs/notes/bugfix-19742.md
+++ b/docs/notes/bugfix-19742.md
@@ -1,0 +1,1 @@
+# Fix crash when deleting an object when a socket has a reference to a deleted object

--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -161,7 +161,9 @@ real8 IO_cleansockets(real8 ctime)
 					s->revents->timeout = ctime + MCsockettimeout;
 				if (s->wevents != NULL)
 					s->wevents->timeout = ctime + MCsockettimeout;
-				MCscreen->delaymessage(s->object, MCM_socket_timeout, MCNameGetString(s->name));
+                
+                if (s->object.IsValid())
+                    MCscreen->delaymessage(s->object, MCM_socket_timeout, MCNameGetString(s->name));
 			}
 			if (s->wevents != NULL && s->wevents->timeout < etime)
 				etime = s->wevents->timeout;
@@ -187,7 +189,8 @@ void IO_freeobject(MCObject *o)
 	while (i < MCnsockets)
 #if 1
 	{
-		if (MCsockets[i]->object == o)
+		if (!MCsockets[i]->object.IsValid() ||
+            MCsockets[i]->object == o)
 			MCsockets[i]->doclose();
 		i++;
 	}


### PR DESCRIPTION
A socket may have a reference to an invalid target object. This patch
ensures the objects are checked for validity before use.

(cherry picked from commit e6ceed770c163d2d6818e10b2fc65075506eff85)