### PR TITLE
[[ Bug 19743 ]] Fix crash in MCVariable::synchronise

### DIFF
--- a/docs/notes/bugfix-19743.md
+++ b/docs/notes/bugfix-19743.md
@@ -1,0 +1,1 @@
+# Fix crash when checking a watched variable on a deleted object

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1086,7 +1086,7 @@ void MCVariable::synchronize(MCExecContext& ctxt, bool p_notify)
 		uint2 i;
 		for (i = 0 ; i < MCnwatchedvars ; i++)
 		{
-			if ((!MCwatchedvars[i].object.IsBound() || MCwatchedvars[i].object == ctxt.GetObject()) 
+			if ((!MCwatchedvars[i].object.IsValid() || MCwatchedvars[i].object == ctxt.GetObject())
 				&& (!MCwatchedvars[i].handlername.IsSet() 
 					|| (ctxt.GetHandler() != nil && ctxt.GetHandler()->hasname(*MCwatchedvars[i].handlername)))
 				&& hasname(*MCwatchedvars[i].varname))


### PR DESCRIPTION
The watched variable target object was being checked for IsBound
rather than IsValid. This caused a crash on a deleted object.

(cherry picked from commit cc8b4c9068e6a70a9f850878f78d2432f195c2c0)