### PR TITLE
[[ Bug 18293 ]] Clear MCmenuobjectptr

### DIFF
--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -412,6 +412,9 @@ void MCButton::removelink(MCObject *optr)
 {
 	if (menu.IsBound() && optr == menu)
     {
+        if (this == MCmenuobjectptr)
+            MCmenuobjectptr = nil;
+        
         MCValueAssign(menuname, kMCEmptyName);
         menu = nil;
     }


### PR DESCRIPTION
The patch for bug 18293 leaves the button as the menu object
but the popup stack has been deleted. This means the button
can not be deleted itself. This patch checks if the button
is the menu object when a menu is being deleted and sets
`MCmenuobjectptr` to `nil`.

(cherry picked from commit 167281c65d36f2cbd3901a6e965ef230fa5f1482)