### PR TITLE
[[ LCB ]] Generate builtin module in --outputc mode

### DIFF
--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -92,166 +92,6 @@ bool MCScriptInitialize(void)
         MCValueRelease(t_stream);
     }
     
-    // This block builds the builtin module - which isn't possible to compile from
-    // source as the names of the types we are defining are currently part of the
-    // syntax of the language.
-    {
-        MCScriptModuleBuilderRef t_builder;
-        MCScriptBeginModule(kMCScriptModuleKindNone, MCNAME("__builtin__"), t_builder);
-        
-        uindex_t t_def_index, t_type_index;
-            
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCAnyTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("any"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        uindex_t t_null_type_index;
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_null_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCNullTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("undefined"), t_type_index, t_null_type_index);
-        MCScriptAddExportToModule(t_builder, t_null_type_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCBooleanTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("boolean"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCNumberTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("number"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        uindex_t t_string_type_index;
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_string_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCStringTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("string"), t_type_index, t_string_type_index);
-        MCScriptAddExportToModule(t_builder, t_string_type_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCDataTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("data"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCArrayTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("array"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCProperListTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("list"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        ////
-        
-        uindex_t t_bool_type_index;
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_bool_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignBoolTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("bool"), t_type_index, t_bool_type_index);
-        MCScriptAddExportToModule(t_builder, t_bool_type_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignSIntTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("sint"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        uindex_t t_uint_type_index;
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_uint_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignUIntTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("uint"), t_type_index, t_uint_type_index);
-        MCScriptAddExportToModule(t_builder, t_uint_type_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignFloatTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("float"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        uindex_t t_double_type_index;
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_double_type_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignDoubleTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("double"), t_type_index, t_double_type_index);
-        MCScriptAddExportToModule(t_builder, t_double_type_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindType, t_def_index);
-        MCScriptAddForeignTypeToModule(t_builder, MCSTR("MCForeignPointerTypeInfo"), t_type_index);
-        MCScriptAddTypeToModule(t_builder, MCNAME("pointer"), t_type_index, t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        ////
-        
-        uindex_t t_bool_type_def, t_uint_type_def, t_double_type_def, t_string_type_def, t_null_type_def;
-        MCScriptAddDefinedTypeToModule(t_builder, t_bool_type_index, t_bool_type_def);
-        MCScriptAddDefinedTypeToModule(t_builder, t_uint_type_index, t_uint_type_def);
-        MCScriptAddDefinedTypeToModule(t_builder, t_double_type_index, t_double_type_def);
-        MCScriptAddDefinedTypeToModule(t_builder, t_null_type_index, t_null_type_def);
-        MCScriptAddDefinedTypeToModule(t_builder, t_string_type_index, t_string_type_def);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
-        MCScriptBeginHandlerTypeInModule(t_builder, t_bool_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeInOut, MCNAME("count"), t_uint_type_def);
-        MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
-        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatCounted"), t_type_index, MCSTR("MCScriptBuiltinRepeatCounted"), t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
-        MCScriptBeginHandlerTypeInModule(t_builder, t_bool_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("limit"), t_double_type_def);
-        MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
-        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatUpToCondition"), t_type_index, MCSTR("MCScriptBuiltinRepeatUpToCondition"), t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
-        MCScriptBeginHandlerTypeInModule(t_builder, t_double_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("step"), t_double_type_def);
-        MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
-        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatUpToIterate"), t_type_index, MCSTR("MCScriptBuiltinRepeatUpToIterate"), t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
-        MCScriptBeginHandlerTypeInModule(t_builder, t_bool_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("limit"), t_double_type_def);
-        MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
-        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatDownToCondition"), t_type_index, MCSTR("MCScriptBuiltinRepeatDownToCondition"), t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
-        MCScriptBeginHandlerTypeInModule(t_builder, t_double_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("counter"), t_double_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("step"), t_double_type_def);
-        MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
-        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("RepeatDownToIterate"), t_type_index, MCSTR("MCScriptBuiltinRepeatDownToIterate"), t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        MCScriptAddDefinitionToModule(t_builder, kMCScriptDefinitionKindForeignHandler, t_def_index);
-        MCScriptBeginHandlerTypeInModule(t_builder, t_null_type_def);
-        MCScriptContinueHandlerTypeInModule(t_builder, kMCScriptHandlerTypeParameterModeIn, MCNAME("reason"), t_string_type_def);
-        MCScriptEndHandlerTypeInModule(t_builder, t_type_index);
-        MCScriptAddForeignHandlerToModule(t_builder, MCNAME("Throw"), t_type_index, MCSTR("MCScriptBuiltinThrow"), t_def_index);
-        MCScriptAddExportToModule(t_builder, t_def_index);
-        
-        ////
-        
-        MCStreamRef t_stream;
-        MCMemoryOutputStreamCreate(t_stream);
-        MCScriptEndModule(t_builder, t_stream);
-        
-        void *t_buffer;
-        size_t t_size;
-        MCMemoryOutputStreamFinish(t_stream, t_buffer, t_size);
-        MCValueRelease(t_stream);
-        
-		if (!MCMemoryInputStreamCreate(t_buffer, t_size, t_stream))
-			return false;
-        if (!MCScriptCreateModuleFromStream(t_stream, s_builtin_module))
-            return false;
-        
-        MCValueRelease(t_stream);
-    }
-    
     // This block creates all the default errors
     {
 		if (!MCNamedErrorTypeInfoCreate(MCNAME("livecode.lang.VariableUsedBeforeAssignedError"), MCNAME("runtime"), MCSTR("Variables must be assigned before being used - variable %{variable} in %{module}.%{handler}"), kMCScriptVariableUsedBeforeAssignedErrorTypeInfo))
@@ -298,6 +138,15 @@ bool MCScriptInitialize(void)
     s_load_library_callback = nullptr;
     
     return true;
+}
+
+extern "C" bool __builtin___Initialize(void)
+{
+    return true;
+}
+
+extern "C" void __builtin___Finalize(void)
+{
 }
 
 void MCScriptFinalize(void)

--- a/toolchain/lc-compile.1.md
+++ b/toolchain/lc-compile.1.md
@@ -35,6 +35,13 @@ is not specified, then **lc-compile** may additionally generate an interface
   _OUTFILE_, which should be the path to a `.c` file.  If _OUTFILE_ already
   exists, it will be overwritten.
 
+* --outputauxc _OUTFILE_:
+  Generate LiveCode bytecode as a static array(s) embedded in C source code in
+  _OUTFILE_, which should be the path to a `.c` file.  If _OUTFILE_ already
+  exists, it will be overwritten.
+  This is the same as --outputc mode, except that it does not emit the 'builtin'
+  module (so should be used for additional sets of C embedded modules).
+
 * --deps [_DEPSMODE_]:
   Generate dependency information on standard output.  _DEPSMODE_ may
   be `order`, `changed-order`, or `make`.  If _DEPSMODE_ is omitted,
@@ -56,7 +63,7 @@ is not specified, then **lc-compile** may additionally generate an interface
 * --:
   Stop processing options.  This is useful in case _LCBFILE_ begins with `--`.
 
-The `--output` and `--outputc` options cannot be used together.
+The `--output` and `--outputc` / `--outputauxc` options cannot be used together.
 
 ## DEPENDENCY INFORMATION
 

--- a/toolchain/lc-compile/src/main.c
+++ b/toolchain/lc-compile/src/main.c
@@ -31,6 +31,7 @@ static int s_is_bootstrap = 0;
 
 extern enum DependencyModeType DependencyMode;
 extern int OutputFileAsC;
+extern int OutputFileAsAuxC;
 extern int OutputFileAsBytecode;
 
 int IsBootstrapCompile(void)
@@ -105,6 +106,9 @@ usage(int status)
 "      --modulepath PATH      Search PATH for module interface files.\n"
 "      --output OUTFILE       Filename for bytecode output.\n"
 "      --outputc OUTFILE      Filename for C source code output.\n"
+"      --outputauxc OUTFILE   Filename for C source code output in auxillary mode.\n"
+"                             This generates an auxillary set of C source code\n"
+"                             modules, which do *not* include the builtin module.\n"
 "      --deps make            Generate lci file dependencies in make format for\n"
 "                             the input source files.\n"
 "      --deps order           Generate the order the input source files should be\n"
@@ -177,6 +181,7 @@ static void full_main(int argc, char *argv[])
                 SetOutputBytecodeFile(argv[++argi]);
                 OutputFileAsBytecode = 1;
                 OutputFileAsC = 0;
+                OutputFileAsAuxC = 0;
                 have_output_file = 1;
                 continue;
             }
@@ -184,6 +189,16 @@ static void full_main(int argc, char *argv[])
             {
                 SetOutputCodeFile(argv[++argi]);
                 OutputFileAsC = 1;
+                OutputFileAsAuxC = 0;
+                OutputFileAsBytecode = 0;
+                have_output_file = 1;
+                continue;
+            }
+            if (0 == strcmp(opt, "--outputauxc") && optarg)
+            {
+                SetOutputCodeFile(argv[++argi]);
+                OutputFileAsC = 1;
+                OutputFileAsAuxC = 1;
                 OutputFileAsBytecode = 0;
                 have_output_file = 1;
                 continue;


### PR DESCRIPTION
This patch moves the creation of the 'builtin' module from the
initialization of libscript, to --outputc mode in lc-compile.

Additionally, it adds '--outputauxc' to lc-compile, which is to
be used for additional sets of embedded C modules, as it does not
generate the builtin module.