### PR TITLE
[Bug 17412] Moved revDeleteFile command to revCommonLibrary

### DIFF
--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -1524,12 +1524,6 @@ private command revCopyFiles pDirectory, pStackPath
    end repeat
 end revCopyFiles
 
-private command revDeleteFile pWhich
-   close file pWhich
-   if the platform is "MacOS" then put empty into URL ("resfile:"&pWhich)
-   put empty into URL ("binfile:"&pWhich)
-   delete file pWHich
-end revDeleteFile
 
 #####################################################################
 #


### PR DESCRIPTION
Depends on https://github.com/livecode/livecode-ide/pull/1599

This patch removes the implementation of `revDeleteFile` from `revsaveasstandalone`, and PR https://github.com/livecode/livecode-ide/pull/1599 puts it in `revCommonLibrary`, since this command is called from other places (e.g. in `revideextensionlibrary` when uninstalling an extension)