### PR TITLE
[Bug 19730] Fix relative path resolution of images in Mac standalones

### DIFF
--- a/docs/notes/bugfix-19730.md
+++ b/docs/notes/bugfix-19730.md
@@ -1,0 +1,1 @@
+# Fix resolution of relative paths of images in Mac standalones

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3524,7 +3524,6 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 
             if (MCNameIsEqualTo(p_type, MCN_resources, kMCCompareCaseless))
             {
-                MCAutoStringRef t_resources_folder;
                 if (!MCS_apply_redirect(*t_engine_folder, false, r_folder))
                     return False;
             }

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -920,7 +920,7 @@ static bool MCS_apply_redirect(MCStringRef p_path, bool p_is_file, MCStringRef& 
     t_path_range = MCRangeMake(t_engine_path_length + 1, UINDEX_MAX);
     
     // AL-2014-09-19: Range argument to MCStringFormat is a pointer to an MCRange.
-    /* UNCHECKED */ MCStringFormat(&t_new_path, "%*@/Resources/_MacOS%*@", &t_cmd_range, MCcmd, &t_path_range, p_path);
+    /* UNCHECKED */ MCStringFormat(&t_new_path, "%*@/Resources/_MacOS/%*@", &t_cmd_range, MCcmd, &t_path_range, p_path);
     
     if (p_is_file && !MCS_file_exists_at_path(*t_new_path))
         return false;
@@ -3512,8 +3512,17 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 
             if (MCNameIsEqualTo(p_type, MCN_resources, kMCCompareCaseless))
             {
-                if (!MCS_apply_redirect(*t_engine_folder, false, r_folder))
+                MCAutoStringRef t_resources_folder;
+                if (!MCS_apply_redirect(*t_engine_folder, false, &t_resources_folder))
                     return False;
+                
+                if (MCStringEndsWith(*t_resources_folder, MCSTR("/"), kMCCompareExact))
+                {
+                    MCStringCopySubstring(*t_resources_folder, MCRangeMake(0, MCStringGetLength(*t_resources_folder) - 1), r_folder);
+                }
+                else
+                    r_folder = MCValueRetain(*t_resources_folder);
+                
             }
             else
                 r_folder = MCValueRetain(*t_engine_folder);

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -915,26 +915,25 @@ static bool MCS_apply_redirect(MCStringRef p_path, bool p_is_file, MCStringRef& 
     
     // Construct the new path from the path after MacOS/ inside Resources/_macos.
     MCAutoStringRef t_new_path;
-    MCRange t_cmd_range, t_path_range;
-    t_cmd_range = MCRangeMake(0, t_engine_path_length - 6);
-	
+	MCRange t_cmd_range = MCRangeMake(0, t_engine_path_length - 6);
 	uindex_t t_path_end = MCStringGetLength(p_path);
+	bool t_success = true;
+	
 	if (MCStringGetCodepointAtIndex(p_path, t_path_end) == '/')
 		t_path_end--;
 	
-	t_path_range = MCRangeMakeMinMax(t_engine_path_length + 1, t_path_end);
-	
 	if (t_engine_path_length == t_path_end)
 	{
-		MCStringFormat(&t_new_path, "%*@/Resources/_MacOS", &t_cmd_range, MCcmd);
+		t_success = MCStringFormat(&t_new_path, "%*@/Resources/_MacOS", &t_cmd_range, MCcmd);
 	}
 	else
 	{
+	    MCRange t_path_range = MCRangeMakeMinMax(t_engine_path_length + 1, t_path_end);
 		// AL-2014-09-19: Range argument to MCStringFormat is a pointer to an MCRange.
-		MCStringFormat(&t_new_path, "%*@/Resources/_MacOS/%*@", &t_cmd_range, MCcmd, &t_path_range, p_path);
+		t_success = MCStringFormat(&t_new_path, "%*@/Resources/_MacOS/%*@", &t_cmd_range, MCcmd, &t_path_range, p_path);
 	}
 	
-    if (p_is_file && !MCS_file_exists_at_path(*t_new_path))
+    if (!t_success || (p_is_file && !MCS_file_exists_at_path(*t_new_path)))
         return false;
 
     r_redirected = MCValueRetain(*t_new_path);

--- a/tests/lcs/core/files/files.livecodescript
+++ b/tests/lcs/core/files/files.livecodescript
@@ -127,8 +127,7 @@ on TestSpecialFolderPath
    put specialFolderPath("resources") into tResources
    if the platform is "macos" and the environment is "standalone" then
       // Standalone on Mac have their non-executable resource in a specific folder
-      set the itemDelimiter to slash
-      TestAssert "Resources folder on standalone Mac app in is  Resources/_MacOS", item -2 to -1 of tResources is "Resources/_MacOS"
+      TestAssert "Resources folder on standalone Mac app in is  Resources/_MacOS", tResources ends with "Resources/_MacOS"
    else if the environment is "mobile" then
       testAssert "Resources and Engine specialfolderPaths are the same on mobile", tResources is tEngine
    else


### PR DESCRIPTION
On a standalone, the function `specialfolderpath("resources")` returned incorrectly a path with a trailing slash (bug 18619). The removal of this slash in this PR https://github.com/livecode/livecode/pull/5098/files broke the resolution of relative paths of images on standalones. 

This patch fixes the resolution of relative paths of images on standalones and ensures that `specialfolderpath("resources")` does not return a path with a trailing slash.