### PR TITLE
[Bug 16758] Fix crash when attempting to set a graphic to have more than 65535 points

### DIFF
--- a/docs/notes/bugfix-16758.md
+++ b/docs/notes/bugfix-16758.md
@@ -1,0 +1,1 @@
+# Fixed bug causing crash when setting 65535 points to a graphic

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -736,6 +736,7 @@ void MCGraphic::SetMarkerPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* 
     if (p_count > 65535)
     {
         ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+        return;
     }
     
     if (p_count == 0)

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -820,6 +820,12 @@ void MCGraphic::GetPoints(MCExecContext& ctxt, uindex_t& r_count, MCPoint*& r_po
 
 void MCGraphic::SetPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points)
 {
+    if (p_count >= 65535)
+    {
+        ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+        return;
+    }
+    
     if (oldpoints != nil)
     {
         delete oldpoints;
@@ -864,6 +870,13 @@ void MCGraphic::GetRelativePoints(MCExecContext& ctxt, uindex_t& r_count, MCPoin
 
 void MCGraphic::SetRelativePoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points)
 {
+    if (p_count >= 65535)
+    {
+        ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+        return;
+    }
+        
+    
     if (oldpoints != nil)
     {
         delete oldpoints;

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -485,7 +485,14 @@ void MCGraphic::SetMarkerOpaque(MCExecContext& ctxt, bool setting)
 	if (changeflag(setting, F_MARKER_OPAQUE))
 	{
 		if (flags & F_MARKER_OPAQUE)
-			closepolygon(markerpoints, nmarkerpoints);
+        {
+            bool t_succ = closepolygon(markerpoints, nmarkerpoints);
+            if (!t_succ)
+            {
+                ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+                return;
+            }
+        }
 		Redraw();
 	}
 }
@@ -630,7 +637,14 @@ void MCGraphic::SetFilled(MCExecContext& ctxt, bool setting)
 	if (changeflag(setting, F_OPAQUE))
 	{
 		if (flags & F_OPAQUE)
-			closepolygon(realpoints, nrealpoints);
+        {
+            bool t_succ = closepolygon(realpoints, nrealpoints);
+            if (!t_succ)
+            {
+                ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+                return;
+            }
+        }
 		Redraw();
 	}
 }
@@ -698,6 +712,12 @@ void MCGraphic::SetGradientStrokeProperty(MCExecContext& ctxt, MCNameRef p_prop,
 
 void MCGraphic::DoCopyPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points, uindex_t& r_count, MCPoint*& r_points)
 {
+    if (p_count > 65535)
+    {
+        ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+        return;
+    }
+    
     MCAutoArray<MCPoint> t_points;
     
     for (uindex_t i = 0; i < p_count; i++)
@@ -713,6 +733,11 @@ void MCGraphic::GetMarkerPoints(MCExecContext& ctxt, uindex_t& r_count, MCPoint*
 
 void MCGraphic::SetMarkerPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points)
 {
+    if (p_count > 65535)
+    {
+        ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+    }
+    
     if (p_count == 0)
         flags &= ~F_MARKER_DRAWN;
     else
@@ -724,7 +749,14 @@ void MCGraphic::SetMarkerPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* 
     }
     
     if (flags & F_MARKER_DRAWN && flags & F_MARKER_OPAQUE)
-        closepolygon(markerpoints, nmarkerpoints);
+    {
+        bool t_succ = closepolygon(markerpoints, nmarkerpoints);
+        if (!t_succ)
+        {
+            ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+            return;
+        }
+    }
     
     // SN-2014-06-02 [[ Bug 12576 ]] drawing_bug_when_rotating_graphic
     // Ensure that the functions which might change the size of the graphic redraw the former rectangle
@@ -820,7 +852,7 @@ void MCGraphic::GetPoints(MCExecContext& ctxt, uindex_t& r_count, MCPoint*& r_po
 
 void MCGraphic::SetPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points)
 {
-    if (p_count >= 65535)
+    if (p_count > 65535)
     {
         ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
         return;
@@ -836,7 +868,14 @@ void MCGraphic::SetPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_poin
     nrealpoints = (uint2)t_new_count;
     
     if (flags & F_OPAQUE)
-        closepolygon(realpoints, nrealpoints);
+    {
+        bool t_succ = closepolygon(realpoints, nrealpoints);
+        if (!t_succ)
+        {
+            ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+            return;
+        }
+    }
     
     // SN-2014-06-02 [[ Bug 12576 ]] drawing_bug_when_rotating_graphic
     // The rectangle might change, we need to redraw what was the previous size.
@@ -870,7 +909,7 @@ void MCGraphic::GetRelativePoints(MCExecContext& ctxt, uindex_t& r_count, MCPoin
 
 void MCGraphic::SetRelativePoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points)
 {
-    if (p_count >= 65535)
+    if (p_count > 65535)
     {
         ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
         return;
@@ -887,12 +926,24 @@ void MCGraphic::SetRelativePoints(MCExecContext& ctxt, uindex_t p_count, MCPoint
     
     uindex_t t_new_count;
     DoCopyPoints(ctxt, p_count, p_points, t_new_count, realpoints);
+    if (t_new_count > 65535)
+    {
+        ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+        return;
+    }
     nrealpoints = (uint2)t_new_count;
     
     MCU_offset_points(realpoints, nrealpoints, trect.x, trect.y);
     
     if (flags & F_OPAQUE)
-        closepolygon(realpoints, nrealpoints);
+    {
+        bool t_succ = closepolygon(realpoints, nrealpoints);
+        if (!t_succ)
+        {
+            ctxt . LegacyThrow(EE_GRAPHIC_TOOMANYPOINTS);
+            return;
+        }
+    }
     
     // SN-2014-06-02 [[ Bug 12576 ]] drawing_bug_when_rotating_graphic
     // Ensure that the functions which might change the size of the graphic redraw the former rectangle

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2734,6 +2734,9 @@ enum Exec_errors
     
     // {EE-0895} image: cannot change image while being edited
     EE_IMAGE_MUTABLELOCK,
+    
+    // {EE-0896} graphic : too many points
+    EE_GRAPHIC_TOOMANYPOINTS,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -745,15 +745,15 @@ void MCGraphic::draw_arrow(MCDC *dc, MCPoint &p1, MCPoint &p2)
 	dc->fillpolygon(pts, 3);
 }
 
-void MCGraphic::draw_lines(MCDC *dc, MCPoint *pts, uint2 npts)
+void MCGraphic::draw_lines(MCDC *dc, MCPoint *pts, uindex_t npts)
 {
-	uint2 i = 0;
+	uindex_t i = 0;
 	while (i < npts)
 	{
-		bool t_degenerate;
+        bool t_degenerate;
 		t_degenerate = true;
 		
-		uint2 count = 0;
+		uindex_t count = 0;
 		while (i + count < npts && pts[count + i].x != MININT2)
 		{
 			if (count > 0 &&
@@ -1016,7 +1016,7 @@ void MCGraphic::delpoints()
 	}
 }
 
-void MCGraphic::closepolygon(MCPoint *&pts, uint2 &npts)
+bool MCGraphic::closepolygon(MCPoint *&pts, uint2 &npts)
 {
 	if (getstyleint(flags) == F_POLYGON && npts > 1)
 	{
@@ -1051,9 +1051,16 @@ void MCGraphic::closepolygon(MCPoint *&pts, uint2 &npts)
         if (t_has_trailing_break)
             t_count++;
 		
+        uindex_t t_check = (uindex_t) npts + (uindex_t) t_count;
+        
+        if (t_check > 65535)
+        {
+            return false;
+        }
+        
         if (t_count)
 		{
-			MCPoint *newpts = new MCPoint[npts+t_count] ;
+            MCPoint *newpts = new MCPoint[npts+t_count] ;
 			startpt = pts ;
 			MCPoint *currentpt = newpts ;
 			*(currentpt++) = pts[0] ;
@@ -1085,6 +1092,7 @@ void MCGraphic::closepolygon(MCPoint *&pts, uint2 &npts)
 			oldpoints = NULL;
 		}
 	}
+    return true;
 }
 
 MCStringRef MCGraphic::getlabeltext()
@@ -1147,7 +1155,7 @@ void MCGraphic::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool
 		// MDW-2014-06-18: [[ rect_points ]] refactored
 		uindex_t t_count;
 		/* UNCHECKED */ get_points_for_regular_polygon(points, t_count);
-		npoints = t_count;
+        npoints = t_count;
 	}
 	if (points == NULL && getstyleint(flags) == F_OVAL)
 	{
@@ -1458,7 +1466,13 @@ void MCGraphic::setpoint(uint4 i, int2 x, int2 y, bool redraw)
 		if (redraw)
 		{
 			if (flags & F_OPAQUE)
-				closepolygon(realpoints, nrealpoints);
+            {
+                bool t_succ = closepolygon(realpoints, nrealpoints);
+                if (!t_succ)
+                {
+                    return;
+                }
+            }
 			compute_minrect();
 			if (rect.x != drect.x || rect.y != drect.y
 					|| rect.width != drect.width || rect.height != drect.height)

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -745,10 +745,10 @@ void MCGraphic::draw_arrow(MCDC *dc, MCPoint &p1, MCPoint &p2)
 	dc->fillpolygon(pts, 3);
 }
 
-void MCGraphic::draw_lines(MCDC *dc, MCPoint *pts, uindex_t npts)
+void MCGraphic::draw_lines(MCDC *dc, MCPoint *pts, uint2 npts)
 {
 	uindex_t i = 0;
-	while (i < npts)
+	while (i < uindex_t(npts))
 	{
         bool t_degenerate;
 		t_degenerate = true;
@@ -1031,15 +1031,15 @@ bool MCGraphic::closepolygon(MCPoint *&pts, uint2 &npts)
             npts -= 1;
         }
             
-		uint2 i ;
+		uindex_t i ;
 		uint2 t_count = 0 ;
 		MCPoint *startpt = pts ;
         
 		for (i=1; i<=npts; i++)
 		{
-			if ((i==npts) || (pts[i].x == MININT2))
+            if ((i==npts) || (pts[i].x == MININT2))
 			{
-				if (pts[i - 1].x != startpt->x || pts[i - 1].y != startpt->y)
+            	if (pts[i - 1].x != startpt->x || pts[i - 1].y != startpt->y)
 				{
 					t_count++ ;
 				}

--- a/engine/src/graphic.h
+++ b/engine/src/graphic.h
@@ -119,7 +119,7 @@ public:
 	// MCGraphic functions
 	uint2 get_arrow_size();
 	void draw_arrow(MCDC *dc, MCPoint &p1, MCPoint &p2);
-	void draw_lines(MCDC *dc, MCPoint *pts, uint2 npts);
+	void draw_lines(MCDC *dc, MCPoint *pts, uindex_t npts);
 	void fill_polygons(MCDC *dc, MCPoint *pts, uint2 npts);
 	void compute_extents(MCPoint *pts, uint2 npts, int2 &minx, int2 &miny,
 	                     int2 &maxx, int2 &maxy);
@@ -128,7 +128,7 @@ public:
 	void compute_minrect();
 	virtual MCRectangle geteffectiverect(void) const;
 	void delpoints();
-	void closepolygon(MCPoint *&pts, uint2 &npts);
+	bool closepolygon(MCPoint *&pts, uint2 &npts);
 	MCStringRef getlabeltext();
 	void drawlabel(MCDC *dc, int2 sx, int sy, uint2 twidth, const MCRectangle &srect, const MCStringRef& s, uint2 fstyle);
 

--- a/engine/src/graphic.h
+++ b/engine/src/graphic.h
@@ -119,7 +119,7 @@ public:
 	// MCGraphic functions
 	uint2 get_arrow_size();
 	void draw_arrow(MCDC *dc, MCPoint &p1, MCPoint &p2);
-	void draw_lines(MCDC *dc, MCPoint *pts, uindex_t npts);
+	void draw_lines(MCDC *dc, MCPoint *pts, uint2 npts);
 	void fill_polygons(MCDC *dc, MCPoint *pts, uint2 npts);
 	void compute_extents(MCPoint *pts, uint2 npts, int2 &minx, int2 &miny,
 	                     int2 &maxx, int2 &maxy);

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -1302,7 +1302,7 @@ Boolean MCU_parsepoints(MCPoint *&points, uindex_t &noldpoints, MCStringRef data
     // nativize first.
     
 	Boolean allvalid = True;
-	uint2 npoints = 0;
+	uindex_t npoints = 0;
 	uint4 l = MCStringGetLength(data);
     MCAutoPointer<char> t_data;
     /* UNCHECKED */ MCStringConvertToCString(data, &t_data);

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -289,6 +289,8 @@ on TestGraphicPointOverflow
 		put tError into tE1
 	end try
 
+	TestAssert "throws (points)", item 1 of line 1 of tE1 is "0896"
+	
 	try 
 		create graphic "g1"
 		set the markerPoints of it to tPoints
@@ -296,6 +298,8 @@ on TestGraphicPointOverflow
 		put tError into tE2
 	end try
 
+	TestAssert "throws (markerPoints)", item 1 of line 1 of tE2 is "0896"
+	
 	try
 		create graphic "g2"
 		set the relativePoints of it to tPoints
@@ -303,6 +307,8 @@ on TestGraphicPointOverflow
 		put tError into tE3
 	end try
 
+	TestAssert "throws (relativePoints)", item 1 of line 1 of tE3 is "0896"
+	
 	create graphic "g3"
 	set the filled of graphic "g3" to false
 	set the style of graphic "g3" to "polygon"
@@ -314,21 +320,63 @@ on TestGraphicPointOverflow
 		put tError into tE4
 	end try
 
+	TestAssert "throws (switchOpaque)", item 1 of line 1 of tE4 is "0896"
+	TestAssert "internal object unchanged (switchOpaque)", the filled of graphic "g3" is false
+
+	local tClosedPoints
+
 	create graphic "g4"
 	set the style of graphic "g4" to "polygon"
 	set the filled of graphic "g4" to true
 	set the points of graphic "g4" to line 1 to 65534 of tPoints
+
+	put the points of graphic "g4" into tClosedPoints
 
 	try
 		set the points of graphic "g4" to line 1 to 65535 of tPoints
 	catch tError
 		put tError into tE5
 	end try
-
-	TestAssert "didn't throw", true
-	TestAssert "throws (points)", item 1 of line 1 of tE1 is "0896"
-	TestAssert "throws (markerPoints)", item 1 of line 1 of tE2 is "0896"
-	TestAssert "throws (relativePoints)", item 1 of line 1 of tE3 is "0896"
-	TestAssert "throws (switchOpaque)", item 1 of line 1 of tE4 is "0896"
 	TestAssert "throws (setOpaque)", item 1 of line 1 of tE5 is "0896"
+	TestAssert "internal object unchanged (setOpaque)", the points of graphic "g4" is tClosedPoints
+
+	local tClosedRelativePoints,tE6
+
+	create graphic "g5"
+	set the style of graphic "g5" to "polygon"
+	set the filled of graphic "g5" to true
+	set the relativePoints of graphic "g5" to line 1 to 65534 of tPoints
+	
+	TestAssert "points added", the number of lines in the points of graphic "g5" is 65535
+	put the points of graphic "g5" into tClosedRelativePoints
+
+	try
+		set the points of graphic "g5" to line 1 to 65535 of tPoints
+	catch tError
+		put tError into tE6
+	end try
+
+	TestAssert "throws (set relative opaque)", item 1 of line 1 of tE6 is "0896"
+	TestAssert "internal object unchanged (set relative opaque)", the points of graphic "g5" is tClosedRelativePoints
+
+	local tClosedMarkerPoints, tE7
+
+	create graphic "g6"
+	set the style of graphic "g6" to "polygon"
+	set the markerFilled of graphic "g6" to true
+	set the markerPoints of graphic "g6" to line 1 to 65534 of tPoints
+
+	put the points of graphic "g6" into tClosedMarkerPoints
+
+	try
+		set the markerPoints of graphic "g6" to line 1 to 65535 of tPoints
+	catch tError
+		put tError into tE7
+	end try
+
+	TestAssert "throws (set marker opaque)", tE7 is not empty
+	TestAssert "internal object unchanged (set marker opaque)", the points of graphic "g6" is tClosedMarkerPoints
+
+	_TestGraphicsPointOverflowNoThrow
+	TestAssert "didn't throw", true
 end TestGraphicPointOverflow

--- a/tests/lcs/core/graphics/graphics.livecodescript
+++ b/tests/lcs/core/graphics/graphics.livecodescript
@@ -250,3 +250,85 @@ on TestTeardown
 	end if
 end TestTeardown
 
+
+command _TestGraphicsPointOverflowNoThrow
+	local tPoints
+
+	repeat with i = 1 to 256
+		repeat with j = 1 to 256
+			if i is 256 and j is 256 then
+				exit repeat 
+				exit repeat
+			end if
+			put (i,j) & cr after tPoints
+		end repeat
+	end repeat
+
+	TestAssert "the number of gen points is correct", the number of lines in tPoints is 65535
+
+	create graphic
+	set the points of it to tPoints
+	set the markerPoints of it to tPoints
+end _TestGraphicsPointOverflowNoThrow
+
+on TestGraphicPointOverflow
+	local tE1, tE2, tE3, tE4, tE5, tPoints
+
+	repeat with i = 1 to 256
+		repeat with j = 1 to 256
+			put (i,j) & cr after tPoints
+		end repeat
+	end repeat
+
+	TestAssert "generated correct number of points", the number of lines in tPoints is 65536
+
+	try
+		create graphic 
+		set the points of it to tPoints
+	catch tError
+		put tError into tE1
+	end try
+
+	try 
+		create graphic "g1"
+		set the markerPoints of it to tPoints
+	catch tError
+		put tError into tE2
+	end try
+
+	try
+		create graphic "g2"
+		set the relativePoints of it to tPoints
+	catch tError
+		put tError into tE3
+	end try
+
+	create graphic "g3"
+	set the filled of graphic "g3" to false
+	set the style of graphic "g3" to "polygon"
+	set the points of graphic "g3" to line 1 to 65535 of tPoints
+
+	try
+		set the filled of graphic "g3" to true
+	catch tError
+		put tError into tE4
+	end try
+
+	create graphic "g4"
+	set the style of graphic "g4" to "polygon"
+	set the filled of graphic "g4" to true
+	set the points of graphic "g4" to line 1 to 65534 of tPoints
+
+	try
+		set the points of graphic "g4" to line 1 to 65535 of tPoints
+	catch tError
+		put tError into tE5
+	end try
+
+	TestAssert "didn't throw", true
+	TestAssert "throws (points)", item 1 of line 1 of tE1 is "0896"
+	TestAssert "throws (markerPoints)", item 1 of line 1 of tE2 is "0896"
+	TestAssert "throws (relativePoints)", item 1 of line 1 of tE3 is "0896"
+	TestAssert "throws (switchOpaque)", item 1 of line 1 of tE4 is "0896"
+	TestAssert "throws (setOpaque)", item 1 of line 1 of tE5 is "0896"
+end TestGraphicPointOverflow


### PR DESCRIPTION
Added some new restrictions on graphics, explicitly throwing errors when trying to set more than 65535 points to a graphic. Also fixed crash relating to this issue.