### PR TITLE
[[ Prebuilts ]] Quote paths to allow spaces

### DIFF
--- a/prebuilt/scripts/lib_versions.inc
+++ b/prebuilt/scripts/lib_versions.inc
@@ -2,8 +2,8 @@
 
 script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-OpenSSL_VERSION=$(cat ${script_dir}/../versions/openssl)
-ICU_VERSION=$(cat ${script_dir}/../versions/icu)
-ICU_VERSION_MAJOR=$(cat ${script_dir}/../versions/icu_major)
-Curl_VERSION=$(cat ${script_dir}/../versions/curl)
-CEF_VERSION=$(cat ${script_dir}/../versions/cef)
+OpenSSL_VERSION=$(cat "${script_dir}/../versions/openssl")
+ICU_VERSION=$(cat "${script_dir}/../versions/icu")
+ICU_VERSION_MAJOR=$(cat "${script_dir}/../versions/icu_major")
+Curl_VERSION=$(cat "${script_dir}/../versions/curl")
+CEF_VERSION=$(cat "${script_dir}/../versions/cef")


### PR DESCRIPTION
The script that fetches the prebuilt versions does not quote the
path it runs cat on. This causes prebuilt fetch to fail if a user
name (or other path component) has a space in it.