### PR TITLE
[[ Bug 19474 ]] Make sure unnamed objects use id form

### DIFF
--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2431,7 +2431,7 @@ bool MCObject::getnameproperty(Properties which, uint32_t p_part_id, MCValueRef&
             //   but *only* for this control (continue with names the rest of the way).
             Properties t_which_requested;
             t_which_requested = which;
-            if (which == P_LONG_NAME && isunnamed())
+            if ((which == P_LONG_NAME || which == P_LONG_NAME_NO_FILENAME) && isunnamed())
                 which = P_LONG_ID;
             if (parent)
             {

--- a/tests/lcs/core/engine/_extension.lcb
+++ b/tests/lcs/core/engine/_extension.lcb
@@ -1,5 +1,6 @@
 library com.livecode.lcs_tests.core.extension
 
+use com.livecode.engine
 use com.livecode.lcs_tests.core.extension.support
 
 public handler TestExtensionBridgeNames_ExecuteScript()
@@ -66,6 +67,18 @@ end handler
 
 public handler TestExtensionLog_Array()
 	log {"a": 1}
+end handler
+
+public handler TestExtensionLog_ScriptObject()
+	resolve script object "button 1"
+	log the result
+end handler
+
+public handler TestExtensionLog_DeletedScriptObject()
+	variable tScriptObject as ScriptObject
+	resolve script object "button 1" into tScriptObject
+	execute script "delete button 1"
+	log tScriptObject
 end handler
 
 end library

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -241,3 +241,32 @@ on TestExtensionLogString
 	wait for 0 with messages
 	TestAssert "extension log string", sLastLog is quote & "log" & quote
 end TestExtensionLogString
+
+on TestExtensionLogScriptObject
+  // resolve script object "button 1"
+  // log the result
+  create button
+  get TestExtensionLog_ScriptObject()
+  wait for 0 with messages
+  TestDiagnostic sLastLog
+  TestAssert "extension log unnamed scriptobject", \
+              sLastLog is format("<script object button id %d of card id %d of stack %s>", \
+                                  the id of button 1, \
+                                  the id of this card, \
+                                  quote & the short name of this stack & quote)
+
+  set the name of button 1 to "foo"
+  get TestExtensionLog_ScriptObject()
+  wait for 0 with messages
+  TestDiagnostic sLastLog
+  TestAssert "extension log named scriptobject", \
+              sLastLog is format("<script object button %s of card id %d of stack %s>", \
+                                  quote & the short name of button 1 & quote, \
+                                  the id of this card, \
+                                  quote & the short name of this stack & quote)
+
+  get TestExtensionLog_DeletedScriptObject()
+  wait for 0 with messages
+  TestDiagnostic sLastLog
+  TestAssert "extension log deleted scriptobject", sLastLog is "<deleted script object>"
+end TestExtensionLogScriptObject


### PR DESCRIPTION
This patch ensures that when a script object requests the long
name of an object, it uses the id form when an object is unnamed.

The problem was caused by adding a new name mode (LONG_NAME_NO_FILENAME)
but not testing for that when deciding what form of name to use for
an unnamed object.