### PR TITLE
[[ LCB ]] Add ordinal binding for builtin modules

### DIFF
--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -535,6 +535,11 @@
 							},
 						},
 
+						'sources':
+						[
+							'<(PRODUCT_DIR)/obj.target/engine_lcb_modules/geni/engine_lcb_modules.o',
+						],
+
 						'sources!':
 						[
 							'src/dummy.cpp',

--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -2284,10 +2284,10 @@ end syntax
 // TODO - add resize operation? "resize <image> to <width>,<height>"
 // TODO - implement image operations
 
-public foreign handler MCCanvasImageTransform(inout xImage as Image, in pTransform as Transform) returns nothing binds to "<builtin>"
-public foreign handler MCCanvasImageScale(inout xImage as Image, in pScaleX as CanvasFloat, in pScaleY as CanvasFloat) returns nothing binds to "<builtin>"
-public foreign handler MCCanvasImageRotate(inout xImage as Image, in pRotation as CanvasFloat) returns nothing binds to "<builtin>"
-public foreign handler MCCanvasImageCrop(inout xImage as Image, in pRight as Rectangle) returns nothing binds to "<builtin>"
+// public foreign handler MCCanvasImageTransform(inout xImage as Image, in pTransform as Transform) returns nothing binds to "<builtin>"
+// public foreign handler MCCanvasImageScale(inout xImage as Image, in pScaleX as CanvasFloat, in pScaleY as CanvasFloat) returns nothing binds to "<builtin>"
+// public foreign handler MCCanvasImageRotate(inout xImage as Image, in pRotation as CanvasFloat) returns nothing binds to "<builtin>"
+// public foreign handler MCCanvasImageCrop(inout xImage as Image, in pRight as Rectangle) returns nothing binds to "<builtin>"
 
 //syntax TransformImage is statement
 //	"transform" <mImage: Expression> "by" <mTransform: Expression>
@@ -4865,7 +4865,7 @@ end syntax
 ////////////////////////////////////////////////////////////////////////////////
 
 public foreign handler MCCanvasThisCanvas(out rCanvas as Canvas) returns nothing binds to "<builtin>"
-public foreign handler MCCanvasPretendToAssignThisCanvas(in pCanvas as Canvas) returns nothing binds to "<builtin>"
+public foreign handler MCCanvasPretendToAssignToThisCanvas(in pCanvas as Canvas) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasNewCanvasWithSize(in pSize as List, out rCanvas as Canvas) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasGetPixelDataOfCanvas(in pCanvas as Canvas, out rData as Data) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasGetPixelHeightOfCanvas(in pCanvas as Canvas, out rHeight as LCUInt) returns nothing binds to "<builtin>"
@@ -4889,7 +4889,7 @@ syntax ThisCanvas is expression
     "this" "canvas"
 begin
     MCCanvasThisCanvas(output)
-    MCCanvasPretendToAssignThisCanvas(input)
+    MCCanvasPretendToAssignToThisCanvas(input)
 end syntax
 
 //////////

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -1766,6 +1766,7 @@ void MCCanvasTransformSkewWithList(MCCanvasTransformRef &x_transform, MCProperLi
 	MCCanvasTransformSkew(x_transform, t_skew.x, t_skew.y);
 }
 
+MC_DLLEXPORT_DEF
 void MCCanvasTransformMultiply(MCCanvasTransformRef p_left, MCCanvasTransformRef p_right, MCCanvasTransformRef &r_transform)
 {
 	MCGAffineTransform t_transform;

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -289,6 +289,7 @@ extern "C" MC_DLLEXPORT void MCCanvasTransformTranslate(MCCanvasTransformRef &x_
 extern "C" MC_DLLEXPORT void MCCanvasTransformTranslateWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
 extern "C" MC_DLLEXPORT void MCCanvasTransformSkew(MCCanvasTransformRef &x_transform, MCCanvasFloat p_x_skew, MCCanvasFloat p_y_skew);
 extern "C" MC_DLLEXPORT void MCCanvasTransformSkewWithList(MCCanvasTransformRef &x_transform, MCProperListRef p_list);
+extern "C" MC_DLLEXPORT void MCCanvasTransformMultiply(MCCanvasTransformRef p_left, MCCanvasTransformRef p_right, MCCanvasTransformRef &r_transform);
 
 //////////
 

--- a/engine/src/widget-popup.cpp
+++ b/engine/src/widget-popup.cpp
@@ -465,7 +465,7 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetExecClosePopupWithResult(MCValueRef p_r
 	s_widget_popup->close();
 }
 
-extern "C" MC_DLLEXPORT_DEF void MCWidgetExecClosePopup(MCValueRef p_result)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecClosePopup()
 {
 	MCWidgetExecClosePopupWithResult(kMCNull);
 }

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -646,7 +646,7 @@ public foreign handler MCWidgetGetClickButton(in pCurrent as CBool, out rButton 
 public foreign handler MCWidgetGetClickCount(in pCurrent as CBool, out rCount as CUInt) returns nothing binds to "<builtin>"
 
 --public foreign handler MCWidgetGetMouseButtonState(in pIndex as LCUInt, out rPressed /*as PressedState*/) returns nothing binds to "<builtin>"
-public foreign handler MCWidgetGetModifierKeys(in pCurrent as CBool, out rKeys as List) returns nothing binds to "<builtin>"
+--public foreign handler MCWidgetGetModifierKeys(in pCurrent as CBool, out rKeys as List) returns nothing binds to "<builtin>"
 
 /**
 Summary:		Determines the location of the mouse pointer relative to the widget.
@@ -1033,8 +1033,8 @@ public foreign handler MCWidgetExecPlaceWidget(in pChild as Widget) returns noth
 public foreign handler MCWidgetExecPlaceWidgetAt(in pChild as Widget, in pAtBottom as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetExecPlaceWidgetRelative(in pChild as Widget, in pIsBelow as CBool, in pOtherChild as Widget) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetExecUnplaceWidget(in pChild as Widget) returns nothing binds to "<builtin>"
-public foreign handler MCWidgetSnapshotWidget(in pChild as Widget) returns Image binds to "<builtin>"
-public foreign handler MCWidgetSnapshotWidgetAtSizeAsList(in pChild as Widget, in pSize as List) returns Image binds to "<builtin>"
+--public foreign handler MCWidgetSnapshotWidget(in pChild as Widget) returns Image binds to "<builtin>"
+--public foreign handler MCWidgetSnapshotWidgetAtSizeAsList(in pChild as Widget, in pSize as List) returns Image binds to "<builtin>"
 
 public foreign handler MCWidgetGetPropertyOfWidget(in pName as String, in pWidget as Widget, out rValue as optional any) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetSetPropertyOfWidget(in pValue as optional any, in pName as String, in pWidget as Widget) returns nothing binds to "<builtin>"
@@ -1045,13 +1045,17 @@ public foreign handler MCWidgetSetWidthOfWidget(in pWidth as CanvasFloat, in pWi
 public foreign handler MCWidgetGetHeightOfWidget(in pWidget as Widget, out rHeight as CanvasFloat) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetSetHeightOfWidget(in pHeight as CanvasFloat, in pWidget as Widget) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetLocationOfWidget(in pWidget as Widget, out rHeight as Point) returns nothing binds to "<builtin>"
-public foreign handler MCWidgetSetLocationOfWidget(in pHeight as CanvasFloat, in pWidget as Widget) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetSetLocationOfWidget(in pLocation as Point, in pWidget as Widget) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetEnabledOfWidget(in pWidget as Widget, out rEnabled as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetSetEnabledOfWidget(in pEnabled as CBool, in pWidget as Widget) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetDisabledOfWidget(in pWidget as Widget, out rDisabled as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetSetDisabledOfWidget(in pDisabled as CBool, in pWidget as Widget) returns nothing binds to "<builtin>"
+
+/*
+No implementation
 public foreign handler MCWidgetGetFontOfWidget(in pWidget as Widget, out rFont as optional Font) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetSetFontOfWidget(in pFont as optional Font, in pWidget as Widget) returns nothing binds to "<builtin>"
+*/
 
 public foreign handler MCWidgetGetAnnotationOfWidget(in pName as String, in pWidget as Widget, out rValue as optional any) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetSetAnnotationOfWidget(in pValue as optional any, in pName as String, in pWidget as Widget) returns nothing binds to "<builtin>"
@@ -1526,12 +1530,14 @@ Return a font which reflects the current (effective) settings of
 
 References: MyFont (expression)
 */
+/* No implementation
 syntax WidgetFontProperty is prefix operator with property precedence
 	"the" "font" "of" <Widget: Expression>
 begin
 	MCWidgetGetFontOfWidget(Widget, output)
 	MCWidgetSetFontOfWidget(input, Widget)
 end syntax
+*/
 
 //
 

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -412,6 +412,54 @@ void MCScriptEmitBytecodeInModuleA(MCScriptModuleBuilderRef builder, uindex_t op
 
 void MCScriptEmitPositionForBytecodeInModule(MCScriptModuleBuilderRef builder, MCNameRef file, uindex_t line);
 
+/* These methods are used to build shims for builtin foreign handlers. They
+   allow lc-compiles 'emit' module to get the details of a handler type. The
+   types returned are the raw types of the arguments after taking into account
+   mode which means we only (currently) need void, pointer, bool and the number
+   types (both fixed and C). We need to enumerate them all separately, as some
+   int types change depending on the architecture. */
+
+enum MCScriptForeignPrimitiveType
+{
+    kMCScriptForeignPrimitiveTypeUnknown,
+    kMCScriptForeignPrimitiveTypeVoid,
+    kMCScriptForeignPrimitiveTypePointer,
+    kMCScriptForeignPrimitiveTypeSInt8,
+    kMCScriptForeignPrimitiveTypeUInt8,
+    kMCScriptForeignPrimitiveTypeSInt16,
+    kMCScriptForeignPrimitiveTypeUInt16,
+    kMCScriptForeignPrimitiveTypeSInt32,
+    kMCScriptForeignPrimitiveTypeUInt32,
+    kMCScriptForeignPrimitiveTypeSInt64,
+    kMCScriptForeignPrimitiveTypeUInt64,
+    kMCScriptForeignPrimitiveTypeSIntSize,
+    kMCScriptForeignPrimitiveTypeUIntSize,
+    kMCScriptForeignPrimitiveTypeSIntPtr,
+    kMCScriptForeignPrimitiveTypeUIntPtr,
+    kMCScriptForeignPrimitiveTypeFloat32,
+    kMCScriptForeignPrimitiveTypeFloat64,
+    kMCScriptForeignPrimitiveTypeCBool,
+    kMCScriptForeignPrimitiveTypeCChar,
+    kMCScriptForeignPrimitiveTypeCSChar,
+    kMCScriptForeignPrimitiveTypeCUChar,
+    kMCScriptForeignPrimitiveTypeCSShort,
+    kMCScriptForeignPrimitiveTypeCUShort,
+    kMCScriptForeignPrimitiveTypeCSInt,
+    kMCScriptForeignPrimitiveTypeCUInt,
+    kMCScriptForeignPrimitiveTypeCSLong,
+    kMCScriptForeignPrimitiveTypeCULong,
+    kMCScriptForeignPrimitiveTypeCSLongLong,
+    kMCScriptForeignPrimitiveTypeCULongLong,
+    kMCScriptForeignPrimitiveTypeCFloat,
+    kMCScriptForeignPrimitiveTypeCDouble,
+    kMCScriptForeignPrimitiveTypeSInt,
+    kMCScriptForeignPrimitiveTypeUInt,
+};
+
+MCScriptForeignPrimitiveType MCScriptQueryForeignHandlerReturnTypeInModule(MCScriptModuleBuilderRef build, uindex_t type_index);
+uindex_t MCScriptQueryForeignHandlerParameterCountInModule(MCScriptModuleBuilderRef build, uindex_t type_index);
+MCScriptForeignPrimitiveType MCScriptQueryForeignHandlerParameterTypeInModule(MCScriptModuleBuilderRef build, uindex_t type_index, uindex_t arg_index);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #endif

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -171,8 +171,8 @@ bool MCScriptCreateModuleFromStream(MCStreamRef stream, MCScriptModuleRef& r_mod
 // Load a module from a blob
 MC_DLLEXPORT bool MCScriptCreateModuleFromData(MCDataRef data, MCScriptModuleRef & r_module);
 
-// Set initializer / finalizer
-void MCScriptSetModuleLifecycleFunctions(MCScriptModuleRef module, bool (*initializer)(void), void (*finalizer)(void));
+// Set initializer / finalizer / builtins
+void MCScriptConfigureBuiltinModule(MCScriptModuleRef module, bool (*initializer)(void), void (*finalizer)(void), void **builtins);
 
 // Lookup the module with the given name. Returns false if no such module exists.
 bool MCScriptLookupModule(MCNameRef name, MCScriptModuleRef& r_module);

--- a/libscript/src/binary.lcb
+++ b/libscript/src/binary.lcb
@@ -27,7 +27,9 @@ public foreign handler MCBinaryExecPutBytesAfter(in Source as Data, inout Target
 
 public foreign handler MCBinaryEvalConcatenateBytes(in Left as Data, in Right as Data, out Result as Data) returns nothing binds to "<builtin>"
 
+/* No implementation
 public foreign handler MCBinaryEvalContainsBytes(in Target as Data, in Needle as Data, out Value as CBool) returns nothing binds to "<builtin>"
+*/
 
 public foreign handler MCBinaryEvalIsEqualTo(in Left as Data, in Right as Data, out Value as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCBinaryEvalIsNotEqualTo(in Left as Data, in Right as Data, out Value as CBool) returns nothing binds to "<builtin>"

--- a/libscript/src/byte.lcb
+++ b/libscript/src/byte.lcb
@@ -28,12 +28,15 @@ public foreign handler MCByteEvalOffsetOfBytes(in IsLast as CBool, in Needle as 
 public foreign handler MCByteEvalOffsetOfBytesBefore(in IsLast as CBool, in Needle as Data, in Before as LCIndex, in Target as Data, out Offset as LCUIndex) returns nothing binds to "<builtin>"
 public foreign handler MCByteEvalOffsetOfBytesAfter(in IsLast as CBool, in Needle as Data, in After as LCIndex, in Target as Data, out Offset as LCUIndex) returns nothing binds to "<builtin>"
 
-public foreign handler MCByteEvalIsAmongTheBytesOf(in Needle as Data, in Target as Data, out Value as CBool) returns nothing binds to "<builtin>"
+// public foreign handler MCByteEvalIsAmongTheBytesOf(in Needle as Data, in Target as Data, out Value as CBool) returns nothing binds to "<builtin>"
 
 public foreign handler MCByteEvalContainsBytes(in Target as Data, in Needle as Data, out Value as CBool) returns nothing binds to "<builtin>"
-public foreign handler MCByteEvalIsInBytes(in Needle as Data, in Target as Data, out Value as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCByteEvalBeginsWithBytes(in Target as Data, in Needle as Data, out Value as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCByteEvalEndsWithBytes(in Target as Data, in Needle as Data, out Value as CBool) returns nothing binds to "<builtin>"
+
+/* No implementation
+public foreign handler MCByteEvalIsInBytes(in Needle as Data, in Target as Data, out Value as CBool) returns nothing binds to "<builtin>"
+*/
 
 public foreign handler MCByteFetchByteOf(in Index as LCIndex, in Target as Data, out Value as Data) returns nothing binds to "<builtin>"
 public foreign handler MCByteStoreByteOf(in Value as Data, in Index as LCIndex, inout Target as Data) returns nothing binds to "<builtin>"
@@ -169,11 +172,13 @@ Description:
 Tags: Binary
 */
 
+/* No implementation
 syntax ByteIsInData is neutral binary operator with comparison precedence
     <Needle: Expression> "is" "in" <Target: Expression>
 begin
     MCByteEvalIsInBytes(Needle, Target, output)
 end syntax
+*/
 
 --
 

--- a/libscript/src/char.lcb
+++ b/libscript/src/char.lcb
@@ -31,8 +31,10 @@ public foreign handler MCCharEvalNumberOfCharsIn(in Target as String, out Count 
 
 public foreign handler MCCharEvalIsAmongTheCharsOf(in Needle as String, in Target as String, out Value as CBool) returns nothing binds to "<builtin>"
 
+/* No implementation
 public foreign handler MCCharStoreBeforeCharOf(in Value as String, in Index as LCIndex, inout Target as String) returns nothing binds to "<builtin>"
 public foreign handler MCCharStoreAfterCharOf(in Value as String, in Index as LCIndex, inout Target as String) returns nothing binds to "<builtin>"
+*/
 
 public foreign handler MCCharEvalOffsetOfChars(in IsLast as CBool, in Needle as String, in Target as String, out Offset as LCUIndex) returns nothing binds to "<builtin>"
 public foreign handler MCCharEvalOffsetOfCharsBefore(in IsLast as CBool, in Needle as String, in Before as LCIndex, in Target as String, out Offset as LCUIndex) returns nothing binds to "<builtin>"

--- a/libscript/src/codeunit.lcb
+++ b/libscript/src/codeunit.lcb
@@ -29,8 +29,10 @@ public foreign handler MCCodeunitStoreCodeunitRangeOf(in Value as String, in Sta
 
 public foreign handler MCCodeunitEvalNumberOfCodeunitsIn(in Target as String, out Count as LCUIndex) returns nothing binds to "<builtin>"
 
+/* No implementation
 public foreign handler MCCodeunitStoreBeforeCodeunitOf(in Value as String, in Index as LCIndex, inout Target as String) returns nothing binds to "<builtin>"
 public foreign handler MCCodeunitStoreAfterCodeunitOf(in Value as String, in Index as LCIndex, inout Target as String) returns nothing binds to "<builtin>"
+*/
 
 public foreign handler MCCodeunitEvalOffsetOfCodeunits(in IsLast as CBool, in Needle as String, in Target as String, out Offset as LCUIndex) returns nothing binds to "<builtin>"
 public foreign handler MCCodeunitEvalOffsetOfCodeunitsBefore(in IsLast as CBool, in Needle as String, in Before as LCIndex, in Target as String, out Offset as LCUIndex) returns nothing binds to "<builtin>"

--- a/libscript/src/module-sort.cpp
+++ b/libscript/src/module-sort.cpp
@@ -186,7 +186,7 @@ extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListDescendingNumeric(MCProperLis
     MCSortExecSortListNumeric(x_target, true);
 }
 
-void MCSortExecSortListDateTime(MCProperListRef& x_target, bool p_descending)
+static void MCSortExecSortListDateTime(MCProperListRef& x_target, bool p_descending)
 {
     MCAutoProperListRef t_mutable_list;
     if (!MCProperListMutableCopy(x_target, &t_mutable_list))
@@ -201,12 +201,12 @@ void MCSortExecSortListDateTime(MCProperListRef& x_target, bool p_descending)
     MCValueAssign(x_target, *t_sorted_list);
 }
 
-void MCSortExecSortListAscendingDateTime(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListAscendingDateTime(MCProperListRef& x_target)
 {
     MCSortExecSortListDateTime(x_target, false);
 }
 
-void MCSortExecSortListDescendingDateTime(MCProperListRef& x_target)
+extern "C" MC_DLLEXPORT_DEF void MCSortExecSortListDescendingDateTime(MCProperListRef& x_target)
 {
    MCSortExecSortListDateTime(x_target, true);
 }

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1910,6 +1910,10 @@ MCScriptMapTypeToForeignPrimitiveTypeInModule(MCScriptModuleBuilderRef self, uin
             /* Foundation Types */
             { "undefined", kMCScriptForeignPrimitiveTypePointer },
             { "any", kMCScriptForeignPrimitiveTypePointer },
+            { "bool", kMCScriptForeignPrimitiveTypeCBool },
+            { "double", kMCScriptForeignPrimitiveTypeCDouble },
+            { "sint", kMCScriptForeignPrimitiveTypeSInt },
+            { "uint", kMCScriptForeignPrimitiveTypeUInt },
             
             { "Boolean", kMCScriptForeignPrimitiveTypePointer },
             { "Number", kMCScriptForeignPrimitiveTypePointer },

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1861,3 +1861,205 @@ void MCScriptEmitPositionForBytecodeInModule(MCScriptModuleBuilderRef self, MCNa
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+static MCScriptForeignPrimitiveType
+MCScriptMapTypeToForeignPrimitiveTypeInModule(MCScriptModuleBuilderRef self, uindex_t p_type_index, bool p_is_return_type = false)
+{
+    MCScriptType *t_type = self->module.types[p_type_index];
+    if (t_type->kind == kMCScriptTypeKindDefined)
+    {
+        auto t_def_type = static_cast<MCScriptDefinedType *>(t_type);
+        
+        MCNameRef t_name = nullptr;
+
+        MCScriptDefinition *t_def = self->module.definitions[t_def_type->index];
+        if (t_def->kind == kMCScriptDefinitionKindType)
+        {
+            uindex_t t_other_type_index = static_cast<MCScriptTypeDefinition *>(t_def)->type;
+            MCScriptType *t_other_type = self->module.types[t_other_type_index];
+            if (t_other_type->kind != kMCScriptTypeKindForeign)
+            {
+                return MCScriptMapTypeToForeignPrimitiveTypeInModule(self, t_other_type_index);
+            }
+            
+            t_name = self->module.definition_names[t_def_type->index];
+        }
+        else if (t_def->kind == kMCScriptDefinitionKindExternal)
+        {
+            const MCScriptImportedDefinition& t_imp_def = self->module.imported_definitions[static_cast<MCScriptExternalDefinition *>(t_def)->index];
+            t_name = t_imp_def.name;
+        }
+        else
+        {
+            MCLog("can't handle type of kind %d", t_def->kind);
+            return kMCScriptForeignPrimitiveTypeUnknown;
+        }
+        
+        if (p_is_return_type &&
+            MCStringIsEqualToCString(MCNameGetString(t_name),
+                                     "undefined",
+                                     kMCStringOptionCompareCaseless))
+        {
+            return kMCScriptForeignPrimitiveTypeVoid;
+        }
+        
+        /* This list must be kept up to date with all types which we bind to
+         * to in foreign handlers in the modules embedded in the engine. */
+        static struct { const char *name; MCScriptForeignPrimitiveType type; } s_ext_mappings[] =
+        {
+            /* Foundation Types */
+            { "undefined", kMCScriptForeignPrimitiveTypePointer },
+            { "any", kMCScriptForeignPrimitiveTypePointer },
+            
+            { "Boolean", kMCScriptForeignPrimitiveTypePointer },
+            { "Number", kMCScriptForeignPrimitiveTypePointer },
+            { "String", kMCScriptForeignPrimitiveTypePointer },
+            { "Data", kMCScriptForeignPrimitiveTypePointer },
+            { "Array", kMCScriptForeignPrimitiveTypePointer },
+            { "List", kMCScriptForeignPrimitiveTypePointer },
+            
+            /* Foreign C Types */
+            { "SInt8", kMCScriptForeignPrimitiveTypeSInt8 },
+            { "UInt8", kMCScriptForeignPrimitiveTypeUInt8 },
+            { "SInt16", kMCScriptForeignPrimitiveTypeSInt16 },
+            { "UInt16", kMCScriptForeignPrimitiveTypeUInt16 },
+            { "SInt32", kMCScriptForeignPrimitiveTypeSInt32 },
+            { "UInt32", kMCScriptForeignPrimitiveTypeUInt32 },
+            { "SInt64", kMCScriptForeignPrimitiveTypeSInt64 },
+            { "UInt64", kMCScriptForeignPrimitiveTypeUInt64 },
+            
+            { "CSIntSize", kMCScriptForeignPrimitiveTypeSIntSize },
+            { "CUIntSize", kMCScriptForeignPrimitiveTypeUIntSize },
+            { "CSIntPtr", kMCScriptForeignPrimitiveTypeSIntPtr },
+            { "CUIntPtr", kMCScriptForeignPrimitiveTypeUIntPtr },
+            
+            { "CBool", kMCScriptForeignPrimitiveTypeCBool },
+            { "CChar", kMCScriptForeignPrimitiveTypeCChar },
+            { "CSChar", kMCScriptForeignPrimitiveTypeCSChar },
+            { "CUChar", kMCScriptForeignPrimitiveTypeCUChar },
+            { "CSShort", kMCScriptForeignPrimitiveTypeCSShort },
+            { "CUShort", kMCScriptForeignPrimitiveTypeCUShort },
+            { "CSInt", kMCScriptForeignPrimitiveTypeCSInt },
+            { "CUInt", kMCScriptForeignPrimitiveTypeCUInt },
+            { "CSLong", kMCScriptForeignPrimitiveTypeCSLong },
+            { "CULong", kMCScriptForeignPrimitiveTypeCULong },
+            { "CULongLong", kMCScriptForeignPrimitiveTypeCSLongLong },
+            { "CULongLong", kMCScriptForeignPrimitiveTypeCULongLong },
+            { "CDouble", kMCScriptForeignPrimitiveTypeCDouble },
+            { "CFloat", kMCScriptForeignPrimitiveTypeCFloat },
+            { "LCSInt", kMCScriptForeignPrimitiveTypeSInt },
+            { "LCUInt", kMCScriptForeignPrimitiveTypeUInt },
+            
+            { "Float32", kMCScriptForeignPrimitiveTypeFloat32 },
+            { "Float64", kMCScriptForeignPrimitiveTypeFloat64 },
+            
+            { "Pointer", kMCScriptForeignPrimitiveTypePointer },
+            
+            { "ZStringUTF8", kMCScriptForeignPrimitiveTypePointer },
+            
+            /* Java FFI Types */
+            { "JObject", kMCScriptForeignPrimitiveTypePointer },
+            
+            /* Extra Foundation Types */
+            { "Stream", kMCScriptForeignPrimitiveTypePointer },
+            
+            /* Canvas Types */
+            { "Rectangle", kMCScriptForeignPrimitiveTypePointer },
+            { "Point", kMCScriptForeignPrimitiveTypePointer },
+            { "Image", kMCScriptForeignPrimitiveTypePointer },
+            { "Color", kMCScriptForeignPrimitiveTypePointer },
+            { "Paint", kMCScriptForeignPrimitiveTypePointer },
+            { "SolidPaint", kMCScriptForeignPrimitiveTypePointer },
+            { "Pattern", kMCScriptForeignPrimitiveTypePointer },
+            { "Gradient", kMCScriptForeignPrimitiveTypePointer },
+            { "GradientStop", kMCScriptForeignPrimitiveTypePointer },
+            { "Path", kMCScriptForeignPrimitiveTypePointer },
+            { "Effect", kMCScriptForeignPrimitiveTypePointer },
+            { "Font", kMCScriptForeignPrimitiveTypePointer },
+            { "Canvas", kMCScriptForeignPrimitiveTypePointer },
+            { "Transform", kMCScriptForeignPrimitiveTypePointer },
+            
+            /* Engine Types */
+            { "Widget", kMCScriptForeignPrimitiveTypePointer },
+            { "ScriptObject", kMCScriptForeignPrimitiveTypePointer },
+        };
+        
+        for(const auto t_mapping : s_ext_mappings)
+        {
+            if (MCStringIsEqualToCString(MCNameGetString(t_name), t_mapping.name, kMCStringOptionCompareCaseless))
+            {
+                return t_mapping.type;
+            }
+        }
+
+        return kMCScriptForeignPrimitiveTypeUnknown;
+    }
+    else if (t_type->kind == kMCScriptTypeKindForeign)
+    {
+        return kMCScriptForeignPrimitiveTypeUnknown;
+    }
+    else if (t_type->kind == kMCScriptTypeKindOptional)
+    {
+        return kMCScriptForeignPrimitiveTypePointer;
+    }
+    else if (t_type->kind == kMCScriptTypeKindForeignHandler ||
+             t_type->kind == kMCScriptTypeKindHandler)
+    {
+        return kMCScriptForeignPrimitiveTypePointer;
+    }
+    
+    return kMCScriptForeignPrimitiveTypeUnknown;
+}
+
+MCScriptForeignPrimitiveType
+MCScriptQueryForeignHandlerReturnTypeInModule(MCScriptModuleBuilderRef self, uindex_t p_type_index)
+{
+    if (self->module.types[p_type_index]->kind != kMCScriptTypeKindForeignHandler)
+    {
+        return kMCScriptForeignPrimitiveTypeUnknown;
+    }
+    
+    auto t_handler_type = static_cast<MCScriptHandlerType *>(self -> module . types[p_type_index]);
+    
+    return MCScriptMapTypeToForeignPrimitiveTypeInModule(self, t_handler_type->return_type, true);
+}
+
+uindex_t
+MCScriptQueryForeignHandlerParameterCountInModule(MCScriptModuleBuilderRef self, uindex_t p_type_index)
+{
+    if (self->module.types[p_type_index]->kind != kMCScriptTypeKindForeignHandler)
+    {
+        return 0;
+    }
+    
+    auto t_handler_type = static_cast<MCScriptHandlerType *>(self -> module . types[p_type_index]);
+    
+    return t_handler_type->parameter_count;
+
+}
+
+MCScriptForeignPrimitiveType
+MCScriptQueryForeignHandlerParameterTypeInModule(MCScriptModuleBuilderRef self, uindex_t p_type_index, uindex_t p_arg_index)
+{
+    if (self->module.types[p_type_index]->kind != kMCScriptTypeKindForeignHandler)
+    {
+        return kMCScriptForeignPrimitiveTypeUnknown;
+    }
+    
+    auto t_handler_type = static_cast<MCScriptHandlerType *>(self -> module . types[p_type_index]);
+    if (p_arg_index >= t_handler_type->parameter_count)
+    {
+        return kMCScriptForeignPrimitiveTypeUnknown;
+    }
+    
+    /* Non-in modes map to a primitive pointer type from the point of view of
+       FFI. */
+    if (t_handler_type->parameters[p_arg_index].mode != kMCScriptHandlerTypeParameterModeIn)
+    {
+        return kMCScriptForeignPrimitiveTypePointer;
+    }
+    
+    return MCScriptMapTypeToForeignPrimitiveTypeInModule(self, t_handler_type->parameters[p_arg_index].type);
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -149,7 +149,12 @@ public:
 								m_argument_values,
 								m_argument_count);
 		}
-		else
+		else if (p_handler->is_builtin)
+        {
+            ((void(*)(void*, void**))p_handler->native.function)(p_result_slot_ptr,
+                    m_argument_values);
+        }
+        else
 		{
 			ffi_call((ffi_cif *)p_handler -> native . function_cif,
 					 (void(*)())p_handler -> native . function,

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -647,6 +647,19 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 										ffi_abi& r_abi,
 										bool* r_bound)
 {
+    integer_t t_ordinal = 0;
+    if (p_instance->module->builtins != nullptr &&
+        MCTypeConvertStringToLongInteger(p_handler->binding, t_ordinal))
+    {
+        p_handler->native.function = p_instance->module->builtins[t_ordinal];
+        r_abi = FFI_DEFAULT_ABI;
+        if (r_bound != nullptr)
+        {
+            *r_bound = true;
+        }
+        return true;
+    }
+
 	MCStringRef t_rest;
 	t_rest = MCValueRetain(p_handler -> binding);
 	

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -652,6 +652,7 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
         MCTypeConvertStringToLongInteger(p_handler->binding, t_ordinal))
     {
         p_handler->native.function = p_instance->module->builtins[t_ordinal];
+        p_handler->is_builtin = true;
         r_abi = FFI_DEFAULT_ABI;
         if (r_bound != nullptr)
         {
@@ -782,6 +783,7 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 		}
 		
 		p_handler -> native . function = t_pointer;
+        p_handler->is_builtin = false;
 	}
 	else if (MCStringIsEqualToCString(*t_language,
 									  "cpp",
@@ -809,6 +811,7 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 	else if (MCStringIsEqualToCString(*t_language, "java", kMCStringOptionCompareExact))
     {
 		p_handler -> is_java = true;
+        p_handler->is_builtin = false;
 	
         p_handler -> java . call_type = __MCScriptGetJavaCallType(*t_class,
                                                                   *t_function,

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -500,12 +500,14 @@ MCScriptCreateModulesFromData(MCDataRef p_data,
 }
 
 void
-MCScriptSetModuleLifecycleFunctions(MCScriptModuleRef p_module,
-                                    bool (*p_initializer)(void),
-                                    void (*p_finalizer)(void))
+MCScriptConfigureBuiltinModule(MCScriptModuleRef p_module,
+                               bool (*p_initializer)(void),
+                               void (*p_finalizer)(void),
+                               void **p_builtins)
 {
     p_module->initializer = p_initializer;
     p_module->finalizer = p_finalizer;
+    p_module->builtins = p_builtins;
 }
 
 bool MCScriptLookupModule(MCNameRef p_name, MCScriptModuleRef& r_module)
@@ -734,8 +736,17 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                 t_type = static_cast<MCScriptForeignType *>(self -> types[i]);
                 
                 void *t_symbol = nullptr;
-                t_symbol = MCSLibraryLookupSymbol(MCScriptGetLibrary(),
-                                                  t_type->binding);
+                integer_t t_ordinal = 0;
+                if (self->builtins != nullptr &&
+                    MCTypeConvertStringToLongInteger(t_type->binding, t_ordinal))
+                {
+                    t_symbol = self->builtins[t_ordinal];
+                }
+                else
+                {
+                    t_symbol = MCSLibraryLookupSymbol(MCScriptGetLibrary(),
+                                                      t_type->binding);
+                }
                 
                 if (t_symbol == nullptr)
                 {

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -49,6 +49,7 @@ struct MCBuiltinModule
     long size;
     bool (*initializer)(void);
     void (*finalizer)(void);
+    void **builtins;
 };
 
 static MCBuiltinModule *s_builtin_modules = nil;
@@ -85,9 +86,10 @@ bool MCScriptInitialize(void)
         if (!MCScriptCreateModuleFromStream(t_stream, t_module->handle))
             return false;
         
-        MCScriptSetModuleLifecycleFunctions(t_module->handle,
-                                            t_module->initializer,
-                                            t_module->finalizer);
+        MCScriptConfigureBuiltinModule(t_module->handle,
+                                       t_module->initializer,
+                                       t_module->finalizer,
+                                       t_module->builtins);
         
         MCValueRelease(t_stream);
     }

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -449,6 +449,9 @@ struct MCScriptModule: public MCScriptObject
     // These are the native code initializer/finalizer (if any) -- not pickled
     bool (*initializer)(void);
     void (*finalizer)(void);
+    
+    // This is the ordinal mapping array (if any) -- not pickled
+    void **builtins;
 };
 
 bool MCScriptWriteRawModule(MCStreamRef stream, MCScriptModule *module);

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -342,6 +342,7 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
     // Bound function information - not pickled.
     bool is_java: 1;
     bool is_bound: 1;
+    bool is_builtin: 1;
     
     union
     {

--- a/libscript/src/string.lcb
+++ b/libscript/src/string.lcb
@@ -34,6 +34,7 @@ public foreign handler MCStringEvalConcatenateWithSpace(in Left as String, in Ri
 public foreign handler MCStringEvalLowercaseOf(in Source as String, out Result as String) returns nothing binds to "<builtin>"
 public foreign handler MCStringEvalUppercaseOf(in Source as String, out Result as String) returns nothing binds to "<builtin>"
 
+/* No implementation
 // The following all need some notion of context 
 public foreign handler MCStringEvalBeginsWith(in Source as String, in Prefix as String, out Result as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCStringEvalEndsWith(in Source as String, in Suffix as String, out Result as CBool) returns nothing binds to "<builtin>"
@@ -45,6 +46,7 @@ public foreign handler MCStringEvalLastOffset(in Needle as String, in Source as 
 public foreign handler MCStringEvalLastOffsetBefore(in Needle as String, in Before as LCIndex, in Source as String, out Result as LCIndex) returns nothing binds to "<builtin>"
 
 public foreign handler MCStringEvalContainsChars(in Source as String, in Needle as String, out Result as CBool) returns nothing binds to "<builtin>"
+*/
 
 public foreign handler MCStringEvalIsEqualTo(in Left as String, in Right as String, out Value as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCStringEvalIsNotEqualTo(in Left as String, in Right as String, out Value as CBool) returns nothing binds to "<builtin>"

--- a/util/emscripten-javascriptify.py
+++ b/util/emscripten-javascriptify.py
@@ -67,7 +67,9 @@ if options.has_key('whitelist'):
 
 command = emcc + optimisation_flags + cflags
 
-command.append(options['input'][0])
+for input in options['input']:
+    command.append(input)
+    
 command += ['-o', options['output'][0]]
 
 for setting in sorted(settings.keys()):


### PR DESCRIPTION
This patch adds the notion of a builtins array to builtin lcb modules (those generated using outputc mode).

The builtins array is a list of function pointers for all foreign handler definitions made in the collection of modules passed to lc-compile in --outputc mode. In this case, those foreign handler definitions are modified so that the binding string is an integer; then when resolving the binding (in libscript) the function pointer from the module's builtins array will be used, rather than trying to use dlsym.

The functions in the builtins array are shims which avoid the need to use ffi_call - which is a problem on emscripten.

With this patch, and the skia patches in thirdparty, this gets widgets working in the HTML5 - albeit not completely (some graphical elements don't seem to render, 'send in time' in widgets doesn't seem to work although event handling such as mouse clicks do).