### PR TITLE
[[ AndroidListeners ]] Add support for Android listener callbacks in LCB

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -581,10 +581,10 @@ interface. This effectively allows LCB handlers to be registered as the
 targets for java interface callbacks, such as event listeners.
 
 The foreign handler binding to such a function takes a value that should 
-either be a `Handler` or an `Array` - if it is a `Handler`, the handler 
-will be called for all callbacks from the specified listener. An array
-can be used to assign different handlers to differently named callbacks
-to the specified listener.
+either be a `Handler` or an `Array` - if it is a `Handler`, the specified 
+listener should only have one available callback. If the listener has 
+multiple callbacks, an array can be used to assign handlers to each. Each 
+key in the array must match the name of a callback in the listener.
 
 For example:
 

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -644,6 +644,10 @@ Instance and nonvirtual calling conventions require instances of the given
 Java class, so the foreign handler declaration will always require a Java
 object parameter.
 
+> **Warning:** At the moment it is not advised to use callbacks that may be
+> executed on arbitrary threads, as this is likely to cause your application
+> to crash.
+
 ### Properties
 
     PropertyDefinition

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -585,6 +585,7 @@ either be a `Handler` or an `Array` - if it is a `Handler`, the specified
 listener should only have one available callback. If the listener has 
 multiple callbacks, an array can be used to assign handlers to each. Each 
 key in the array must match the name of a callback in the listener.
+Overloaded methods in the interface are not currently supported.
 
 For example:
 

--- a/docs/lcb/notes/feature-android_listeners.md
+++ b/docs/lcb/notes/feature-android_listeners.md
@@ -15,7 +15,8 @@ The foreign handler binding to such a function takes a value that should
 either be a `Handler` or an `Array` - if it is a `Handler`, the specified 
 listener should only have one available callback. If the listener has 
 multiple callbacks, an array can be used to assign handlers to each. Each 
-key in the array must match the name of a callback in the listener.  
+key in the array must match the name of a callback in the listener. 
+Overloaded methods in the interface are not currently supported.
 
 For example:
 

--- a/docs/lcb/notes/feature-android_listeners.md
+++ b/docs/lcb/notes/feature-android_listeners.md
@@ -11,11 +11,11 @@ The syntax is as follows:
 
 	foreign handler _JNI_CreateListener(in pMapping) returns JObject binds to "java:listener.class.path>interface()"
 
-The foreign handler binding to such a function takes a value that should 
-either be a `Handler` or an `Array` - if it is a `Handler`, the handler 
-will be called for all callbacks from the specified listener. An array
-can be used to assign different handlers to differently named callbacks
-to the specified listener.
+The foreign handler binding to such a function takes a value that should
+either be a `Handler` or an `Array` - if it is a `Handler`, the specified 
+listener should only have one available callback. If the listener has 
+multiple callbacks, an array can be used to assign handlers to each. Each 
+key in the array must match the name of a callback in the listener.  
 
 For example:
 

--- a/docs/lcb/notes/feature-android_listeners.md
+++ b/docs/lcb/notes/feature-android_listeners.md
@@ -1,0 +1,65 @@
+# LiveCode Builder Language
+## Android Listener support
+An binding string variant has been added which allows the user to 
+create an interface proxy - that is an instance of a generic 
+Proxy class for a given interface. 
+
+This effectively allows LCB handlers to be registered as the targets 
+for java interface callbacks, such as event listeners.
+
+The syntax is as follows:
+
+	foreign handler _JNI_CreateListener(in pMapping) returns JObject binds to "java:listener.class.path>interface()"
+
+The foreign handler binding to such a function takes a value that should 
+either be a `Handler` or an `Array` - if it is a `Handler`, the handler 
+will be called for all callbacks from the specified listener. An array
+can be used to assign different handlers to differently named callbacks
+to the specified listener.
+
+For example:
+
+	handler type ClickCallback(in pView as JObject)
+
+	foreign handler _JNI_OnClickListener(in pHandler as ClickCallback) returns JObject binds to "java:android.view.View$OnClickListener>interface()"
+
+	foreign handler _JNI_SetOnClickListener(in pButton as JObject, in pListener as JObject) returns nothing binds to "java:android.view.View>setOnClickListener(Landroid/view/View$OnClickListener;)V"	
+	
+	public handler ButtonClicked(in pView as JObject)
+		-- do something on button click
+	end handler
+	
+	public handler SetOnClickListenerCallback(in pButton as JObject)
+		unsafe
+			variable tListener as JObject
+			put _JNI_OnClickListener(ButtonClicked) into tListener
+			_JNI_SetOnClickListener(pButton, tListener)
+		end unsafe
+	end handler
+	
+or
+
+	handler type MouseEventCallback(in pMouseEvent as JObject)
+
+	foreign handler _JNI_MouseListener(in pCallbacks as Array) returns JObject binds to "java:java.awt.event.MouseListener>interface()"
+
+	foreign handler _JNI_SetMouseListener(in pJButton as JObject, in pListener as JObject) returns nothing binds to "java:java.awt.Component>addMouseListener(Ljava/awt/event/MouseListener;)V"	
+	
+	public handler MouseEntered(in pEvent as JObject)
+		-- do something on mouse entter
+	end handler
+	
+	public handler MouseExited(in pEvent as JObject)
+		-- do something on mouse entter
+	end handler
+	
+	public handler SetMouseListenerCallbacks(in pJButton as JObject)
+		variable tArray as Array
+		put MouseEntered into tArray["mouseEntered"]
+		put MouseExited into tArray["mouseExited"]
+		unsafe
+			variable tListener as JObject
+			put _JNI_MouseListener(tArray) into tListener
+			_JNI_SetMouseListener(pJButton, tListener)
+		end unsafe
+	end handler

--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -900,6 +900,7 @@
 			'src/java/com/runrev/android/Engine.java',
 			'src/java/com/runrev/android/EngineApi.java',
 			'src/java/com/runrev/android/EngineReceiver.java',
+			'src/java/com/runrev/android/LCBInvocationHandler.java',
 			'src/java/com/runrev/android/LiveCodeActivity.java',
 			'src/java/com/runrev/android/NetworkModule.java',
 			'src/java/com/runrev/android/NFCModule.java',

--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -444,6 +444,7 @@
 			'src/mblandroidinput.cpp',
 			'src/mblandroidio.cpp',
 			'src/mblandroidjava.cpp',
+			'src/mblandroidlcb.cpp',
 			'src/mblandroidmail.cpp',
 			'src/mblandroidmediapick.cpp',
 			'src/mblandroidmisc.cpp',

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -83,12 +83,18 @@
 							'src/mblcamera.cpp',
 						],
 										
-						# Force the entry point to be included in the output
+						
 						'link_settings':
 						{
 							'ldflags':
 							[
-								'-Wl,--undefined,Java_com_runrev_android_Engine_doCreate'
+								# Force the entry point to be included in the output
+								'-Wl,--undefined,Java_com_runrev_android_Engine_doCreate',
+								
+								# mblandroidlcb.cpp contains nothing other than the LCB Invocation Handler 
+								# native callback function, so force the symbol to be included as otherwise it
+								# will be discarded by the linker because nothing in the file is used statically
+								'-Wl,--undefined,Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback',
 							],
 						},
 					},

--- a/engine/src/java/com/runrev/android/LCBInvocationHandler.java
+++ b/engine/src/java/com/runrev/android/LCBInvocationHandler.java
@@ -1,0 +1,50 @@
+/* Copyright (C) 2003-2017 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+package com.runrev.android;
+
+import java.lang.*;
+import java.lang.reflect.*;
+
+public class LCBInvocationHandler extends Object implements InvocationHandler
+{
+	long m_handler_ptr;
+	
+	public LCBInvocationHandler(long p_handler)
+	{
+		m_handler_ptr = p_handler;
+	}
+	
+	public static Object getProxy(Class<?> p_interface, long p_handler)
+	{
+		InvocationHandler t_inv_handler = new LCBInvocationHandler(p_handler);
+
+		Object t_proxy =
+			Proxy.newProxyInstance(p_interface.getClassLoader(),
+								   new Class[] { p_interface },
+								   t_inv_handler);						   
+								   
+		return t_proxy;
+	}
+	
+	public Object invoke(Object proxy, Method method, Object[] args)
+	{
+		doNativeListenerCallback(m_handler_ptr, method.getName(), args);
+		return proxy;
+	}
+	
+	public static native void doNativeListenerCallback(long handler, String method_name, Object[] args);
+}

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -95,7 +95,7 @@ static jmethodID s_openglview_configure_method = 0;
 // function.
 static JavaVM *s_java_vm = nullptr;
 // The JNIEnv for the android UI thread.
-static JNIEnv *s_android_ui_env;
+static JNIEnv *s_android_ui_env = nullptr;
 // The JNI environment pointer *for our auxiliary thread*. This only has lifetime
 // as long as 'mobile_main' is running.
 static JNIEnv *s_java_env = nullptr;

--- a/engine/src/mblandroidlcb.cpp
+++ b/engine/src/mblandroidlcb.cpp
@@ -29,6 +29,7 @@
 #include "mblandroidutil.h"
 
 #include "mblsyntax.h"
+#include "system.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -39,6 +40,19 @@ extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_d
 JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong p_handler, jstring p_method_name, jobjectArray p_args)
 {
     MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
+    
+    // At the moment we have no way of dealing with any errors thrown in
+    // the course of handling or attempting to handle the native listener
+    // callback, so
+    MCAutoErrorRef t_error;
+    if (MCErrorCatch(&t_error))
+    {
+        MCAutoStringRef t_string;
+        /* UNCHECKED */ MCStringFormat(&t_string, "%@", *t_error);
+        
+        MCsystem->Debug(*t_string);
+    }
+    
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mblandroidlcb.cpp
+++ b/engine/src/mblandroidlcb.cpp
@@ -1,0 +1,44 @@
+/* Copyright (C) 2017 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "prefix.h"
+
+#include "globdefs.h"
+#include "filedefs.h"
+#include "objdefs.h"
+#include "parsedef.h"
+
+#include "globals.h"
+#include "object.h"
+#include "mbldc.h"
+
+#include "mblandroid.h"
+#include "mblandroidutil.h"
+
+#include "mblsyntax.h"
+
+////////////////////////////////////////////////////////////////////////////////
+
+extern void MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_name, jobjectArray p_args);
+
+extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong handler, jstring p_method, jobjectArray p_args) __attribute__((visibility("default")));
+
+JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong p_handler, jstring p_method_name, jobjectArray p_args)
+{
+    MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -214,6 +214,7 @@ typedef MCAutoValueRefBase<MCTypeInfoRef> MCAutoTypeInfoRef;
 typedef MCAutoMutableValueRefBase<MCRecordRef, MCRecordMutableCopyAndRelease, MCRecordCopyAndRelease> MCAutoRecordRef;
 typedef MCAutoValueRefBase<MCErrorRef> MCAutoErrorRef;
 typedef MCAutoMutableValueRefBase<MCProperListRef, MCProperListMutableCopyAndRelease, MCProperListCopyAndRelease> MCAutoProperListRef;
+typedef MCAutoValueRefBase<MCJavaObjectRef> MCAutoJavaObjectRef;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -423,6 +423,39 @@ static bool __MCJavaDataToJByteArray(MCDataRef p_data, jbyteArray& r_byte_array)
     return true;
 }
 
+static bool __MCJavaProperListFromJObjectArray(jobjectArray p_obj_array, MCProperListRef& r_list)
+{
+    MCJavaDoAttachCurrentThread();
+    
+    if (p_obj_array == nullptr)
+    {
+        r_list = MCValueRetain(kMCEmptyProperList);
+        return true;
+    }
+    
+    MCAutoProperListRef t_list;
+    if (!MCProperListCreateMutable(&t_list))
+        return false;
+    
+    uint32_t t_size = s_env -> GetArrayLength(p_obj_array);
+    
+    for (uint32_t i = 0; i < t_size; i++)
+    {
+        MCAutoValueRef t_value;
+        
+        jobject t_object = s_env -> GetObjectArrayElement(p_obj_array, i);
+        
+        MCAutoJavaObjectRef t_obj;
+        if (!MCJavaObjectCreate(t_object, &t_obj))
+            return false;
+
+        if (!MCProperListPushElementOntoBack(*t_list, *t_obj))
+            return false;
+    }
+    
+    return MCProperListCopy(*t_list, r_list);
+}
+
 bool MCJavaObjectCreateGlobalRef(jobject p_object, MCJavaObjectRef &r_object)
 {
     MCAssert(p_object != nullptr);

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -467,21 +467,21 @@ static bool __MCJavaProperListFromJObjectArray(jobjectArray p_obj_array, MCPrope
     return MCProperListCopy(*t_list, r_list);
 }
 
-bool MCJavaObjectCreateGlobalRef(jobject p_object, MCJavaObjectRef &r_object)
+void* MCJavaPrivateGlobalRef(void *p_object)
 {
-    MCAssert(p_object != nullptr);
-    void *t_obj_ptr = s_env -> NewGlobalRef(p_object);
-    return MCJavaObjectCreate(t_obj_ptr, r_object);
+    MCJavaDoAttachCurrentThread();
+    jobject t_obj = static_cast<jobject>(p_object);
+    return static_cast<void *>(s_env->NewGlobalRef(t_obj));
 }
 
-bool MCJavaObjectCreateNullableGlobalRef(jobject p_object, MCJavaObjectRef &r_object)
+bool MCJavaObjectCreateNullable(jobject p_object, MCJavaObjectRef &r_object)
 {
     if (p_object == nullptr)
     {
         r_object = nullptr;
         return true;
     }
-    return MCJavaObjectCreateGlobalRef(p_object, r_object);
+    return MCJavaObjectCreate(p_object, r_object);
 }
 
 static jstring MCJavaGetJObjectClassName(jobject p_obj)
@@ -567,7 +567,7 @@ static bool __JavaJNIInstanceMethodResult(jobject p_instance, jmethodID p_method
                 s_env -> CallObjectMethodA(p_instance, p_method_id, p_params);
             
             MCJavaObjectRef t_result_value;
-            if (!MCJavaObjectCreateNullableGlobalRef(t_result, t_result_value))
+            if (!MCJavaObjectCreateNullable(t_result, t_result_value))
                 return false;
             *(static_cast<MCJavaObjectRef *>(r_result)) = t_result_value;
             return true;
@@ -649,7 +649,7 @@ static bool __JavaJNIStaticMethodResult(jclass p_class, jmethodID p_method_id, j
                 s_env -> CallStaticObjectMethodA(p_class, p_method_id, p_params);
             
             MCJavaObjectRef t_result_value;
-            if (!MCJavaObjectCreateNullableGlobalRef(t_result, t_result_value))
+            if (!MCJavaObjectCreateNullable(t_result, t_result_value))
                 return false;
             *(static_cast<MCJavaObjectRef *>(r_result)) = t_result_value;
             return true;
@@ -731,7 +731,7 @@ static bool __JavaJNINonVirtualMethodResult(jobject p_instance, jclass p_class, 
                 s_env -> CallNonvirtualObjectMethodA(p_instance, p_class, p_method_id, p_params);
             
             MCJavaObjectRef t_result_value;
-            if (!MCJavaObjectCreateNullableGlobalRef(t_result, t_result_value))
+            if (!MCJavaObjectCreateNullable(t_result, t_result_value))
                 return false;
             *(static_cast<MCJavaObjectRef *>(r_result)) = t_result_value;
             return true;
@@ -813,7 +813,7 @@ static bool __JavaJNIGetFieldResult(jobject p_instance, jfieldID p_field_id, int
                 s_env -> GetObjectField(p_instance, p_field_id);
             
             MCJavaObjectRef t_result_value;
-            if (!MCJavaObjectCreateNullableGlobalRef(t_result, t_result_value))
+            if (!MCJavaObjectCreateNullable(t_result, t_result_value))
                 return false;
             *(static_cast<MCJavaObjectRef *>(r_result)) = t_result_value;
             return true;
@@ -894,7 +894,7 @@ static bool __JavaJNIGetStaticFieldResult(jclass p_class, jfieldID p_field_id, i
                 s_env -> GetStaticObjectField(p_class, p_field_id);
             
             MCJavaObjectRef t_result_value;
-            if (!MCJavaObjectCreateNullableGlobalRef(t_result, t_result_value))
+            if (!MCJavaObjectCreateNullable(t_result, t_result_value))
                 return false;
             *(static_cast<MCJavaObjectRef *>(r_result)) = t_result_value;
             return true;
@@ -1084,7 +1084,7 @@ static bool __JavaJNIConstructorResult(jclass p_class, jmethodID p_method_id, jv
     jobject t_result = s_env -> NewObjectA(p_class, p_method_id, p_params);
     
     MCJavaObjectRef t_result_value;
-    if (!MCJavaObjectCreateGlobalRef(t_result, t_result_value))
+    if (!MCJavaObjectCreate(t_result, t_result_value))
         return false;
     *(static_cast<MCJavaObjectRef *>(r_result)) = t_result_value;
 
@@ -1381,7 +1381,7 @@ bool MCJavaCreateInterfaceProxy(MCNameRef p_class_name, MCTypeInfoRef p_signatur
                                                     t_handler);
     
     MCJavaObjectRef t_result_value;
-    if (!MCJavaObjectCreateNullableGlobalRef(t_proxy, t_result_value))
+    if (!MCJavaObjectCreateNullable(t_proxy, t_result_value))
         return false;
     
     *(static_cast<MCJavaObjectRef *>(r_result)) = t_result_value;
@@ -1586,7 +1586,7 @@ bool MCJavaPrivateConvertStringRefToJString(MCStringRef p_string, MCJavaObjectRe
     if (!__MCJavaStringToJString(p_string, t_string))
         return false;
     
-    return MCJavaObjectCreateGlobalRef(t_string, r_object);
+    return MCJavaObjectCreate(t_string, r_object);
 }
 
 bool MCJavaPrivateConvertJStringToStringRef(MCJavaObjectRef p_object, MCStringRef &r_string)
@@ -1601,7 +1601,7 @@ bool MCJavaPrivateConvertDataRefToJByteArray(MCDataRef p_data, MCJavaObjectRef &
     if (!__MCJavaDataToJByteArray(p_data, t_array))
         return false;
     
-    return MCJavaObjectCreateGlobalRef(t_array, r_object);
+    return MCJavaObjectCreate(t_array, r_object);
 }
 
 bool MCJavaPrivateConvertJByteArrayToDataRef(MCJavaObjectRef p_object, MCDataRef &r_data)
@@ -1843,5 +1843,10 @@ void MCJavaPrivateDestroyObject(MCJavaObjectRef p_object)
 bool MCJavaPrivateGetJObjectClassName(MCJavaObjectRef p_object, MCStringRef &r_name)
 {
     return false;
+}
+
+void* MCJavaPrivateGlobalRef(void *p_object)
+{
+    return p_object;
 }
 #endif

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -1171,6 +1171,11 @@ static bool MCJavaClassNameToPathString(MCNameRef p_class_name, MCStringRef& r_s
 
 static jclass MCJavaPrivateFindClass(MCNameRef p_class_name)
 {
+    // The system class loader does not know about LC's android engine
+    // classes. We cache the android engine class loader on startup and
+    // call its findClass method to find any classes named
+    // com.runrev.android.<Class>. For all other classes we just use
+    // the JNIEnv FindClass method & system class loader.
     if (MCStringBeginsWith(MCNameGetString(p_class_name),
                            MCSTR("com.runrev.android"),
                            kMCStringOptionCompareExact))

--- a/libfoundation/src/foundation-java-private.h
+++ b/libfoundation/src/foundation-java-private.h
@@ -9,6 +9,7 @@ enum MCJavaCallType {
     MCJavaCallTypeStatic,
     MCJavaCallTypeNonVirtual,
     MCJavaCallTypeConstructor,
+    MCJavaCallTypeInterfaceProxy,
     MCJavaCallTypeGetter,
     MCJavaCallTypeSetter,
     MCJavaCallTypeStaticGetter,

--- a/libfoundation/src/foundation-java-private.h
+++ b/libfoundation/src/foundation-java-private.h
@@ -65,6 +65,8 @@ void MCJavaPrivateDestroyObject(MCJavaObjectRef p_object);
 bool MCJavaPrivateCheckSignature(MCTypeInfoRef p_signature, MCStringRef p_args, MCStringRef p_return, int p_call_type);
 bool MCJavaPrivateGetJObjectClassName(MCJavaObjectRef p_object, MCStringRef &r_name);
 
+void* MCJavaPrivateGlobalRef(void *p_object);
+
 bool MCJavaPrivateErrorThrow(MCTypeInfoRef p_error);
 bool MCJavaPrivateErrorsInitialize();
 void MCJavaPrivateErrorsFinalize();

--- a/libfoundation/src/foundation-java-private.h
+++ b/libfoundation/src/foundation-java-private.h
@@ -58,6 +58,7 @@ bool MCJavaPrivateConvertJStringToStringRef(MCJavaObjectRef p_object, MCStringRe
 bool MCJavaPrivateConvertStringRefToJString(MCStringRef p_string, MCJavaObjectRef &r_object);
 bool MCJavaPrivateConvertDataRefToJByteArray(MCDataRef p_string, MCJavaObjectRef &r_object);
 bool MCJavaPrivateConvertJByteArrayToDataRef(MCJavaObjectRef p_object, MCDataRef &r_string);
+
 void* MCJavaPrivateGetMethodId(MCNameRef p_class_name, MCStringRef p_method_name, MCStringRef p_arguments, MCStringRef p_return, int p_call_type);
 void MCJavaPrivateDestroyObject(MCJavaObjectRef p_object);
 bool MCJavaPrivateCheckSignature(MCTypeInfoRef p_signature, MCStringRef p_args, MCStringRef p_return, int p_call_type);

--- a/libfoundation/src/foundation-java-private.h
+++ b/libfoundation/src/foundation-java-private.h
@@ -74,5 +74,6 @@ extern MCTypeInfoRef kMCJavaNativeMethodCallErrorTypeInfo;
 extern MCTypeInfoRef kMCJavaBindingStringSignatureErrorTypeInfo;
 extern MCTypeInfoRef kMCJavaCouldNotInitialiseJREErrorTypeInfo;
 extern MCTypeInfoRef kMCJavaJRENotSupportedErrorTypeInfo;
+extern MCTypeInfoRef kMCJavaInterfaceCallbackSignatureErrorTypeInfo;
 
 #endif

--- a/libfoundation/src/foundation-java.cpp
+++ b/libfoundation/src/foundation-java.cpp
@@ -128,8 +128,12 @@ MC_DLLEXPORT_DEF bool MCJavaObjectCreate(void *p_object, MCJavaObjectRef &r_obje
     if (!MCValueCreateCustom(kMCJavaObjectTypeInfo,
                              sizeof(__MCJavaObjectImpl), t_obj))
         return false;
-
-    *MCJavaObjectGet(t_obj) = MCJavaObjectImplMake(p_object);
+    
+    void *t_global_ref = nullptr;
+    if (p_object != nullptr)
+        t_global_ref = MCJavaPrivateGlobalRef(p_object);
+    
+    *MCJavaObjectGet(t_obj) = MCJavaObjectImplMake(t_global_ref);
     r_object = t_obj;
 
     return true;

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -610,6 +610,9 @@ static MCJavaCallType __MCScriptGetJavaCallType(MCStringRef p_class, MCStringRef
     if (MCStringIsEqualToCString(p_function, "new", kMCStringOptionCompareExact))
         return MCJavaCallTypeConstructor;
     
+    if (MCStringIsEqualToCString(p_function, "interface", kMCStringOptionCompareExact))
+        return MCJavaCallTypeInterfaceProxy;
+    
     bool t_is_static =
         MCStringIsEqualToCString(p_calling, "static", kMCStringOptionCompareCaseless);
     

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -329,6 +329,7 @@ enum MCJavaCallType {
     MCJavaCallTypeStatic,
     MCJavaCallTypeNonVirtual,
     MCJavaCallTypeConstructor,
+    MCJavaCallTypeInterfaceProxy,
     MCJavaCallTypeGetter,
     MCJavaCallTypeSetter,
     MCJavaCallTypeStaticGetter,


### PR DESCRIPTION
This patch adds a binding string variant for Android which allows the user to create an interface proxy - that is an instance of a generic Proxy class for a given interface.
This effectively allows LCB handlers to be registered as the targets for java interface callbacks, such as event listeners.

Either a Handler or an Array can be registered for a given listener- if it is a Handler, the specified listener should only have one available callback. If the listener has multiple callbacks, an array can be used to assign handlers to each. Each key in the array must match the name of a callback in the listener.

We do this by creating a class `LCBInvocationHandler` derived from the InvocationHandler interface, which can create a Proxy object for any given interface. When listener callbacks are invoked on the specified interface, the invocation handler's 'invoke' method is invoked. This calls back into the engine which tries to invoke the selected LCB handler with the jobject arguments passed to the native invoke method.