### PR TITLE
[[ Bug 19772 ]] Foreign handlers get repeatedly bound

### DIFF
--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -893,7 +893,9 @@ __MCScriptPrepareForeignFunction(MCScriptInstanceRef p_instance,
 			return false;
 		}
 		
-		p_handler->is_bound = t_bound;
+        // If t_bound_ptr == nullptr, then if we get here we will be bound.
+        // Otherwise, whether we are bound or not depends on t_bound.
+		p_handler->is_bound = t_bound_ptr != nullptr ? t_bound : true;
 	}
 	
 	// If we are 'try to bind' and the foreign binding failed, then


### PR DESCRIPTION
This patch ensures that the 'bound' boolean instance var of
a foreign handler definition is correctly updated after being
successfully bound. Previously, this was not set correctly
meaning that every call to a foreign handler would cause it to
be rebound.