### PR TITLE
[[ Bug 19779 ]] Don't special case nil signature in 'put into <invoke>' syntax

### DIFF
--- a/docs/lcb/notes/19779.md
+++ b/docs/lcb/notes/19779.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+## lc-compile
+
+# [19779] fix bytecode generation for 'set my native layer' syntax

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -425,9 +425,8 @@ private unsafe handler InitBrowserView()
 
 	variable tBrowserView as Pointer
 	put MCBrowserGetNativeLayer(mBrowser) into tBrowserView
-
-	// set my native layer to tBrowserView
-	MCWidgetSetMyNativeLayer(tBrowserView)
+	set my native layer to tBrowserView
+	
 	// tell native layer that we can't render a snapshot of the browser view.
 	MCWidgetSetMyNativeLayerCanRenderToContext(false)
 
@@ -438,8 +437,7 @@ private unsafe handler InitBrowserView()
 end handler
 
 private unsafe handler FinalizeBrowserView()
-	//set my native layer to nothing
-	MCWidgetSetMyNativeLayer(nothing)
+	set my native layer to nothing
 
 	MCBrowserRelease(mBrowser)
 	put nothing into mBrowser

--- a/toolchain/lc-compile/src/generate.g
+++ b/toolchain/lc-compile/src/generate.g
@@ -1467,15 +1467,12 @@
     'rule' GenerateInvoke_AssignArgument(ResultReg, ContextReg, Invoke:invoke(_, Invokes, Arguments)):
         EmitGetRegisterAttachedToExpression(Invoke -> InputReg)
         GenerateDefinitionGroupForInvokes(Invokes, assign, Arguments -> Index, Signature)
-        [|
-            ne(Signature, nil)
-            EmitCreateRegister(-> IgnoredResultReg)
-            EmitBeginInvoke(Index, ContextReg, IgnoredResultReg)
-            EmitContinueInvoke(InputReg)
-            GenerateInvoke_EmitInvokeArguments(Arguments)
-            EmitEndInvoke()
-            EmitDestroyRegister(IgnoredResultReg)
-        |]
+        EmitCreateRegister(-> IgnoredResultReg)
+        EmitBeginInvoke(Index, ContextReg, IgnoredResultReg)
+        EmitContinueInvoke(InputReg)
+        GenerateInvoke_EmitInvokeArguments(Arguments)
+        EmitEndInvoke()
+        EmitDestroyRegister(IgnoredResultReg)
         GenerateInvoke_AssignArguments(ResultReg, ContextReg, Signature, Arguments)
         
     'rule' GenerateInvoke_AssignArgument(ResultReg, ContextReg, Slot:slot(_, Id)):


### PR DESCRIPTION
Bytecode generation for the syntax 'set my native layer to tPointer' skipped
the actual invocation step because it has no parameters other than tPointer.
This patch removes the unneeded special code path for this case.