### PR TITLE
[[ Bug 19784 ]] Convert to and from java string correctly

### DIFF
--- a/docs/notes/bugfix-19784.md
+++ b/docs/notes/bugfix-19784.md
@@ -1,0 +1,1 @@
+# Convert between stringref and jstring correctly


### PR DESCRIPTION
Use unichar representation of strings for conversion, not cstrings.