### PR TITLE
[[Bug 17794]] - add syntax entry including "else if" and "end if" in "if" control structure

### DIFF
--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -15,7 +15,7 @@ end if
 
 Summary:
 A <conditional statement> following an <if> or an optional series of
-<condtional statement|conditional statments> following an <else if>
+<condtional statement|conditional statments> following an <else if|else if>
 that if true will <execute> the <statement list|statementList>
 that follows that <conditional statement>.  If none of the
 <condtional statement|conditional statments> are true then the

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -22,8 +22,8 @@ an <else> keyword the <statement> or <statementlist|statement list> following th
 <keyword> is executed.
 
 The <if> <control structure> may contain one or more <else if> <keyword|keywords> which have a
-<conditional expression|condition>. If the <conditional expression|condition> one of these evaluates to be
-true then the <statment|statement> or <statementlist|statement list> following that <else if|else if>
+<condition|conditional expression>. If the <condition|conditional expression> for one of these evaluates to be
+true then the <statment|statement> or <statementlist|statement list> following that <else if>
 <keyword> is executed. 
 
 If the <if> <control structure> contains

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -14,8 +14,11 @@ end if
 
 
 Summary:
-<execute|Executes> a list of <statement|statements> if a condition is
-true. 
+A <conditional statement> or series of <condtional statement|conditional statments> that
+if true will <execute> the <statement list|statementList> that follows that 
+<conditional statement>.  If none of the <condtional statement|conditional statments> are 
+true then the <statement list|elseStatementList> following the <else> keyword, if present,
+will execute.
 
 Introduced: 1.0
 
@@ -36,9 +39,11 @@ end if
 
 Parameters:
 condition (bool):
-Any <expression>. (If the <condition> <evaluate|evaluates> to the true, the <statement|statements> execute for that <if>
-clause.) if the <condition> <evaluate|evaluates> to false, the statement or <statementList> is
-skipped. 
+Any <expression>. (If the <condition> <evaluate|evaluates> to true, 
+the <statement|statements> execute for that <condition>.
+If the <condition> <evaluate|evaluates> to false, the <statement> or 
+<statement list|statementList> following that <condition> is
+skipped.)
 
 statement|statementList:
 Of one or more <LiveCode> <statement|statements>, and can also include
@@ -56,8 +61,8 @@ Of one or more <LiveCode> <statement|statements>, and can also include
 structures>. 
 
 Description:
-Use the <if> <control structure> to <execute> a <statementList|statement> 
-(or list of <statementList|statements>) only under certain circumstances. 
+Use the <if> <control structure> to <execute> a <statement>
+(or <list of statements|statementList>) only under certain circumstances. 
 
 The <if> <control structure> always begins with the <word> if. There are four forms of the <if> <control structure>:
 

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -110,8 +110,8 @@ which follows it is <execute|executed>.
 
 If the <if> <control structure> contains one or more <else if>
 <keyword|keywords> which have a <condition|conditional expression>,
-and, one of those <condition|conditional expressions> evaluates to be
-true, then, the respective <elseIfstatement|else if statement> or
+and one of those <condition|conditional expressions> evaluates to be
+true, then the respective <elseIfstatement|else if statement> or
 <elseIfstatementlist|else if statement list> following that
 <else if> <keyword> is executed.
 

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -14,14 +14,14 @@ end if
 
 
 Summary:
-Evaluates a <conditional expression|condition> to determine if it is true
-and if so <execute|executes> a subsequent <statment|statement> or <statementlist|statement list>.
+Evaluates a <condition|conditional expression> to determine if it is true
+and if so <execute|executes> a subsequent <statement> or <statementlist|statement list>.
 
 If the <conditional expression|condition> is false and the <if> <control structure> contains
-an <else> keyword the <statement|statement> or <statementlist|statement list> following the <else>
+an <else> keyword the <statement> or <statementlist|statement list> following the <else>
 <keyword> is executed.
 
-The  <if> <control structure> may contain 1 or more <else if|else if> <keyword|keywords> which have a
+The <if> <control structure> may contain one or more <else if> <keyword|keywords> which have a
 <conditional expression|condition>. If the <conditional expression|condition> one of these evaluates to be
 true then the <statment|statement> or <statementlist|statement list> following that <else if|else if>
 <keyword> is executed. 
@@ -51,7 +51,7 @@ condition (bool):
 Any <expression>. (If the <condition> <evaluate|evaluates> to true, 
 the <statement|statements> execute for that <condition>.
 If the <condition> <evaluate|evaluates> to false, the <statement> or 
-<statement list|statementList> following that <condition> is
+<statementlist|statement list> following that <condition> is
 skipped.)
 
 statementList:
@@ -71,9 +71,9 @@ structures>.
 
 Description:
 Use the <if> <control structure> to <execute> a <statement>
-(or <list of statements|statementList>) only under certain circumstances. 
+(or <statementlist|list of statements>) only under certain circumstances. 
 
-The <if> <control structure> always begins with the <word> if. There
+The <if> <control structure> always begins with the word if. There
 are four forms of the <if> <control structure>:
 
     if condition then statementList [else elseStatementList]
@@ -108,12 +108,12 @@ if the <condition> evaluates to false and the <if> <control structure>
 contains an <else> <keyword>, the <elseStatement> or <elseStatementList>
 which follows it is <execute|executed>.
 
-If the <if> <control structure> contains 1 or more <else if>
-<keyword|keywords> which have a <conditional expression|condition>
-and one of those <conditional expression|conditions> evaluates to be
-true the respective <elseIfstatment|else if statement> or
+If the <if> <control structure> contains one or more <else if>
+<keyword|keywords> which have a <condition|conditional expression>,
+and, one of those <condition|conditional expressions> evaluates to be
+true, then, the respective <elseIfstatement|else if statement> or
 <elseIfstatementlist|else if statement list> following that
-<else if|else if> <keyword> is executed.
+<else if> <keyword> is executed.
 
 If one <if> <control structure> is nested inside another, use of the
 second form described above is recommended, since the other forms may

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -4,6 +4,15 @@ Type: control structure
 
 Syntax: if <condition> then <statementList> [else <elseStatementList>]
 
+Syntax:if <condition> then
+ <statementList>
+ [else if <condition> then
+   <elseifStatementList>]
+ [else 
+   <elseStatementList>]
+end if
+
+
 Summary:
 <execute|Executes> a list of <statement|statements> if a condition is
 true. 
@@ -27,16 +36,24 @@ end if
 
 Parameters:
 condition (bool):
+Any <expression>. (If the <condition> <evaluate|evaluates> to the true, the <statement|statements> execute for that <if>
+clause.) if the <condition> <evaluate|evaluates> to false, the statement or <statementList> is
+skipped. 
 
+statement|statementList:
+Of one or more <LiveCode> <statement|statements>, and can also include
+<if>, <switch>, <try>, or <repeat> <control structure|control
+structures>. 
 
-elseStatementList:
+elseIfStatement|elseIfStatementList:
+Of one or more <LiveCode> <statement|statements>, and can also include
+<if>, <switch>, <try>, or <repeat> <control structure|control
+structures>. 
 
-
-statementList:
-The <statementList> or <elseStatementList> consists of one or more LiveCode
-statements, and can also include if, switch, try, or repeat control
-structures. The statement or elseStatement consists of a single LiveCode
-statement. 
+elseStatement|elseStatementList:
+Of one or more <LiveCode> <statement|statements>, and can also include
+<if>, <switch>, <try>, or <repeat> <control structure|control
+structures>. 
 
 Description:
 Use the <if> <control structure> to <execute> a <statementList|statement> 

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -14,15 +14,20 @@ end if
 
 
 Summary:
-A <conditional statement> following an <if> or an optional series of
-<condtional statement|conditional statments> following an <else if|else if>
-that if true will <execute> the <statement list|statementList>
-that follows that <conditional statement>.  If none of the
-<condtional statement|conditional statments> are true then the
-<statement list|elseStatementList> following the <else> keyword,
-if present, will execute. If the <if> <control structure> contains
-more than one line the <if> <control structure> must end with an 
-<end if> keyword.
+Evaluates a <conditional expression|condition> to determine if it is true
+and if so <execute|executes> a subsequent <statment|statement> or <statementlist|statement list>.
+
+If the <conditional expression|condition> is false and the <if> <control structure> contains
+an <else> keyword the <statement|statement> or <statementlist|statement list> following the <else>
+<keyword> is executed.
+
+The  <if> <control structure> may contain 1 or more <else if|else if> <keyword|keywords> which have a
+<conditional expression|condition>. If the <conditional expression|condition> one of these evaluates to be
+true then the <statment|statement> or <statementlist|statement list> following that <else if|else if>
+<keyword> is executed. 
+
+If the <if> <control structure> contains
+more than one line then the <if> <control structure> must end with an <end if> keyword.
 
 Introduced: 1.0
 

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -14,11 +14,12 @@ end if
 
 
 Summary:
-A <conditional statement> or series of <condtional statement|conditional statments> that
-if true will <execute> the <statement list|statementList> that follows that 
-<conditional statement>.  If none of the <condtional statement|conditional statments> are 
-true then the <statement list|elseStatementList> following the <else> keyword, if present,
-will execute.
+A <conditional statement> following an <if> or an optional series of <condtional statement|conditional statments> 
+following an <else if> that if true will <execute> the <statement list|statementList> 
+that follows that <conditional statement>.  If none of the <condtional statement|conditional statments> 
+are true then the <statement list|elseStatementList> following the <else> keyword, if present,
+will execute. If the <if> <control structure> contains more than one line the <if><control structure> must end with an 
+<end if> keyword.
 
 Introduced: 1.0
 
@@ -114,5 +115,5 @@ a <switch> <control structure> instead.
 References: switch (control structure), commandNames (function),
 statement (glossary), command (glossary), evaluate (glossary),
 execute (glossary), control structure (glossary), then (keyword),
-else (keyword), end if (keyword), word (keyword)
+else (keyword), else if (keyword), end if (keyword), word (keyword)
 

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -5,7 +5,7 @@ Type: control structure
 Syntax: if <condition> then <statementList> [else <elseStatementList>]
 
 Syntax:if <condition> then
- <statementList>
+   <statementList>
  [else if <condition> then
    <elseifStatementList>]
  [else 
@@ -81,7 +81,7 @@ are four forms of the <if> <control structure>:
 This form may have a line break before the words `then` or `else` or both.
 
     if condition then
-        statementList 
+       statementList 
     [else
        elseStatementList]
     end if

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -21,7 +21,7 @@ that follows that <conditional statement>.  If none of the
 <condtional statement|conditional statments> are true then the
 <statement list|elseStatementList> following the <else> keyword,
 if present, will execute. If the <if> <control structure> contains
-more than one line the <if><control structure> must end with an 
+more than one line the <if> <control structure> must end with an 
 <end if> keyword.
 
 Introduced: 1.0
@@ -49,17 +49,17 @@ If the <condition> <evaluate|evaluates> to false, the <statement> or
 <statement list|statementList> following that <condition> is
 skipped.)
 
-statement|statementList:
+statementList:
 Of one or more <LiveCode> <statement|statements>, and can also include
 <if>, <switch>, <try>, or <repeat> <control structure|control
 structures>. 
 
-elseIfStatement|elseIfStatementList:
+elseIfStatementList:
 Of one or more <LiveCode> <statement|statements>, and can also include
 <if>, <switch>, <try>, or <repeat> <control structure|control
 structures>. 
 
-elseStatement|elseStatementList:
+elseStatementList:
 Of one or more <LiveCode> <statement|statements>, and can also include
 <if>, <switch>, <try>, or <repeat> <control structure|control
 structures>. 

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -14,11 +14,14 @@ end if
 
 
 Summary:
-A <conditional statement> following an <if> or an optional series of <condtional statement|conditional statments> 
-following an <else if> that if true will <execute> the <statement list|statementList> 
-that follows that <conditional statement>.  If none of the <condtional statement|conditional statments> 
-are true then the <statement list|elseStatementList> following the <else> keyword, if present,
-will execute. If the <if> <control structure> contains more than one line the <if><control structure> must end with an 
+A <conditional statement> following an <if> or an optional series of
+<condtional statement|conditional statments> following an <else if>
+that if true will <execute> the <statement list|statementList>
+that follows that <conditional statement>.  If none of the
+<condtional statement|conditional statments> are true then the
+<statement list|elseStatementList> following the <else> keyword,
+if present, will execute. If the <if> <control structure> contains
+more than one line the <if><control structure> must end with an 
 <end if> keyword.
 
 Introduced: 1.0
@@ -65,14 +68,15 @@ Description:
 Use the <if> <control structure> to <execute> a <statement>
 (or <list of statements|statementList>) only under certain circumstances. 
 
-The <if> <control structure> always begins with the <word> if. There are four forms of the <if> <control structure>:
+The <if> <control structure> always begins with the <word> if. There
+are four forms of the <if> <control structure>:
 
     if condition then statementList [else elseStatementList]
 
 This form may have a line break before the words `then` or `else` or both.
 
     if condition then
-       statementList 
+        statementList 
     [else
        elseStatementList]
     end if

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -104,9 +104,16 @@ If the <condition> <evaluate|evaluates> to true, the statement or
 <evaluate|evaluates> to false, the statement or <statementList> is
 skipped. 
 
-If the <if> <control structure> contains an <else> clause, the
-elseStatement or <elseStatementList> is <execute|executed> if the
-<condition> is false.
+if the <condition> evaluates to false and the <if> <control structure>
+contains an <else> <keyword>, the <elseStatement> or <elseStatementList>
+which follows it is <execute|executed>.
+
+If the <if> <control structure> contains 1 or more <else if>
+<keyword|keywords> which have a <conditional expression|condition>
+and one of those <conditional expression|conditions> evaluates to be
+true the respective <elseIfstatment|else if statement> or
+<elseIfstatementlist|else if statement list> following that
+<else if|else if> <keyword> is executed.
 
 If one <if> <control structure> is nested inside another, use of the
 second form described above is recommended, since the other forms may

--- a/docs/notes/bugfix-17794.md
+++ b/docs/notes/bugfix-17794.md
@@ -1,0 +1,1 @@
+#Add syntax section that includes "else if" and "end if" and edit Summary, Description and Parameters to reflect that.


### PR DESCRIPTION
I have added a syntax entry in the "if" control structure documentation and have modified the Summary and Description entries to include those terms as well.   Also added descriptions to the Parameter entries.

This may need further changes.  

- In the Description it mentions 4 forms of the if control structure showing various places that a line break is needed but in the dictionary they are displayed on one line.  The lines should be formatted with the line breaks included.  What is the best way to do that?

- The 4 forms don't include else if keywords.  Should a form be added to show those?