### PR TITLE
[[Bug 19422]] - Fixed missing parts of errorMode entry

### DIFF
--- a/docs/dictionary/property/errorMode.lcdoc
+++ b/docs/dictionary/property/errorMode.lcdoc
@@ -23,15 +23,10 @@ Parameters:
 mode (enum):
 Specifies the action to take when an error occurs. The mode types are:
 
--   "debugger": is for information only and indicates that the script is
-    being run in 'remote debug' mode. This is only relevant to the
-    on-rev engine
--   "inline": indicates that the error should be output into the stdout
-    stream. In this case, the engine assumes that the output is HTML and
-    puts the error messages in a 'pre' block
+-   "debugger": is for information only and indicates that the script is being run in 'remote debug' mode. This is only relevant to the on-rev engine
+-   "inline": indicates that the error should be output into the stdout stream. In this case, the engine assumes that the output is HTML and puts the error messages in a 'pre' block
 -   "stderr": specifies that the error should be written out to stderr
--   "quiet": indicates that nothing is output anywhere when an error
-    occurs 
+-   "quiet": indicates that nothing is output anywhere when an error occurs 
 
 
 Description:

--- a/docs/notes/bugfix-19422.md
+++ b/docs/notes/bugfix-19422.md
@@ -1,0 +1,1 @@
+# Fixed missing parts of errorMode entry


### PR DESCRIPTION
- Line breaks in the mode parameter caused the continuation lines not to show up as part of the bullet points; eliminated line breaks to work around this.