### PR TITLE
[[Bug 19615]] Fix mangled references

### DIFF
--- a/docs/dictionary/command/quit.lcdoc
+++ b/docs/dictionary/command/quit.lcdoc
@@ -31,8 +31,8 @@ Description:
 Use the <quit> <command> to exit LiveCode (or a <standalone
 application>). 
 
-Once issued, the <quit> <command> triggers a <shutdownRequest message>.
-If the <shutdownRequest message> is not passed then the quit will be
+Once issued, the <quit> <command> triggers a <shutdownRequest> <message>.
+If the <shutdownRequest> <message> is not passed then the quit will be
 blocked (i.e. the program won't close).
 
 If you want to check a condition or ask the user for confirmation before
@@ -48,7 +48,7 @@ deciding whether to quit, use an <if> <control structure>:
     end getMeOuttaHere
 
 
-To force a quit without sending a <shutdownRequest message> use: 
+To force a quit without sending a <shutdownRequest> <message> use: 
 
     lock messages 
     quit
@@ -57,8 +57,7 @@ To force a quit without sending a <shutdownRequest message> use:
 References: kill (command), close process (command),
 if (control structure), application (glossary), command (glossary),
 standalone application (glossary), control structure (glossary),
-shutdownRequest (message), shutdownRequest message (message),
+shutdownRequest (message), message (glossary),
 shutdown (message)
 
 Tags: windowing
-

--- a/docs/notes/bugfix-19615.md
+++ b/docs/notes/bugfix-19615.md
@@ -1,0 +1,1 @@
+# Fixed references in the quit dictionary entry


### PR DESCRIPTION
 - Copied fixed references from 9.0's quit entry over to 8.1