### PR TITLE
[[ Bug 19384 ]] Set JAVA_HOME on startup in standalone

### DIFF
--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2031,6 +2031,8 @@ command revSBUpdateDeployParams pStack, pTarget, pStandaloneSettings, @xDeployPa
    -- auxiliary_stackfiles key might not be empty
    put pStandaloneSettings["auxiliary_stackfiles"] into tAuxiliaryStackfiles
    
+   appendToStringList "revInternal_SetJAVA_HOME", tStartupScript
+   
    # AL-2015-04-12: [[ Standalone Extensions ]] Add chosen extensions to the standalone inclusions
    # AL-2015-07-21: [[ Standalone Extensions ]] Automatically include dependecies, and load in order
    repeat for each line tExtension in revIDEExtensionsOrderByDependency(pStandaloneSettings["extensions"])


### PR DESCRIPTION
This patch adds a command call to the standalone startup script to the
to set JAVA_HOME if it's not set and it's possible to do so.