### PR TITLE
[[ Bug 19797 ]] Implement put before msg in Emscripten

### DIFF
--- a/docs/notes/bugfix-19797.md
+++ b/docs/notes/bugfix-19797.md
@@ -1,0 +1,1 @@
+# Implement put before msg in HTML5

--- a/engine/src/em-osspec-misc.cpp
+++ b/engine/src/em-osspec-misc.cpp
@@ -54,9 +54,12 @@ MCS_put(MCExecContext &ctxt, MCSPutKind p_kind, MCStringRef p_string)
 	bool t_success;
 	switch (p_kind)
 	{
-	case kMCSPutOutput:
 	case kMCSPutBeforeMessage:
-	case kMCSPutIntoMessage:
+        // SN-2014-04-11 [[ FasterVariable ]] parameter updated to use the new 'set' operation on variables
+        t_success = MCmb -> set(ctxt, p_string, kMCVariableSetBefore);
+        break;
+    case kMCSPutOutput:
+    case kMCSPutIntoMessage:
 		t_success = MCmb -> set(ctxt, p_string);
 		break;
 	case kMCSPutAfterMessage:


### PR DESCRIPTION
This patch adds the missing implementation of put before msg. Previously
put before would put into and clobber the existing msg.

(cherry picked from commit e00b0d2567c4dd09e576e69f83976a858cf3cd03)