### PR TITLE
[[ Bug 19783 ]] Clear errors at end of try

### DIFF
--- a/docs/dictionary/control_st/pass.lcdoc
+++ b/docs/dictionary/control_st/pass.lcdoc
@@ -2,7 +2,7 @@ Name: pass
 
 Type: control structure
 
-Syntax: pass <messageName> [to top]
+Syntax: pass { <messageName> [to top] | error }
 
 Summary:
 Stops the current <handler> and <pass|passes> the <message> to the next
@@ -75,14 +75,19 @@ message path, use the <exit> <control structure> instead. To halt the
 current <handler> and return a result, use the <return> <control
 structure> instead.
 
+Use the <pass> error form to <pass> an error from within the catch or
+finally <statement|statements> of a <try> <control structure>. <Pass>
+error can not be used outside of a <try> <control structure>.
+
 >*Important:*  You cannot use the <pass> <command> to pass a <message>
 > that was originally sent with the <send> <command>.
 
 Changes:
 The pass...to top form was added in version 2.1.
+The pass error form was added in version 9.0
 
 References: call (command), send (command), return (constant),
-pass (control structure), exit (control structure),
+try (control structure), exit (control structure),
 setProp (control structure), if (control structure), pass (glossary),
 engine (glossary), built-in message (glossary), property (glossary),
 statement (glossary), execute (glossary), command (glossary),

--- a/docs/dictionary/control_st/try.lcdoc
+++ b/docs/dictionary/control_st/try.lcdoc
@@ -5,8 +5,8 @@ Type: control structure
 Syntax:
 try
    <statementList>
-catch <errorVariable>
-   <errorStatementsList>
+[ catch <errorVariable>
+   <errorStatementsList> ]
 [ finally
    <cleanupStatementsList> ]
 end try

--- a/docs/dictionary/control_st/try.lcdoc
+++ b/docs/dictionary/control_st/try.lcdoc
@@ -77,6 +77,9 @@ or not there is an <error>. Since the <finally> section is always
 deleting <variable|variables>. The <finally> section is an optional part
 of the <try> <control structure|structure>.
 
+Use the <pass> error <statement> to <pass> the error from the catch or
+finally statements of the <try> <control structure>.
+
 >*Note:* The <try> <control structure> is implemented internally as a
 > <command> and appears in the <commandNames>.
 

--- a/docs/notes/bugfix-13482.md
+++ b/docs/notes/bugfix-13482.md
@@ -1,0 +1,1 @@
+# Document optional catch clause in try control structure

--- a/docs/notes/bugfix-19783.md
+++ b/docs/notes/bugfix-19783.md
@@ -1,0 +1,1 @@
+# Ensure any errors are cleared from the error stack after a try control structure

--- a/docs/notes/bugfix-19810.md
+++ b/docs/notes/bugfix-19810.md
@@ -1,0 +1,1 @@
+# Add pass error command for use in the try control structure

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -715,6 +715,9 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
 	Exec_stat stat;
 	Exec_stat retcode = ES_NORMAL;
 	MCtrylock++;
+    
+    MCAutoStringRef t_error;
+    
 	while (tspr != NULL)
 	{
 		if (MCtrace || MCnbreakpoints)
@@ -785,10 +788,9 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                         }
                         else
                         {
+                            MCeerror -> copyasstringref(&t_error);
                             if (errorvar != NULL)
                             {
-                                MCAutoStringRef t_error;
-                                MCeerror -> copyasstringref(&t_error);
                                 errorvar->evalvar(ctxt)->setvalueref(*t_error);
                             }
                             
@@ -807,7 +809,6 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                             //   before a state transition is made, thus we force it here.
                             if (catchstatements == NULL)
                             {
-                                MCeerror -> clear();
                                 tspr = finallystatements;
                                 state = TS_FINALLY;
                             }
@@ -817,16 +818,11 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                     tspr = tspr->getnext();
                 break;
             case ES_PASS:
-                if (state == TS_CATCH)
-                {
-                    MCAutoStringRef t_string;
-                    if (ctxt . ConvertToString(errorvar->evalvar(ctxt)->getvalueref(), &t_string))
-                    {
-                        MCeerror->copystringref(*t_string, False);
-                        MCeerror->add(EE_TRY_BADSTATEMENT, line, pos);
-                        stat = ES_ERROR;
-                    }
-                }
+            case ES_PASS_ERROR:
+                if (t_error.IsSet())
+                    MCeerror->copystringref(*t_error, False);
+                MCeerror->add(EE_TRY_BADSTATEMENT, line, pos);
+                stat = ES_ERROR;
             default:
                 if (state == TS_FINALLY)
                 {
@@ -877,6 +873,11 @@ void MCKeywordsExecPassAll(MCExecContext& ctxt)
 void MCKeywordsExecPass(MCExecContext& ctxt)
 {
 	ctxt . SetExecStat(ES_PASS);
+}
+
+void MCKeywordsExecPassError(MCExecContext& ctxt)
+{
+    ctxt . SetExecStat(ES_PASS_ERROR);
 }
 
 void MCKeywordsExecThrow(MCExecContext& ctxt, MCStringRef p_error)

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -830,8 +830,7 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
             default:
                 if (state == TS_FINALLY)
                 {
-                    MCeerror->clear();
-                    retcode = ES_NORMAL;
+                    retcode = stat;
                     tspr = NULL;
                 }
                 else

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -709,6 +709,9 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
 {
 	Try_state state = TS_TRY;
 	MCStatement *tspr = trystatements;
+    if (tspr == NULL)
+        tspr = finallystatements;
+    
 	Exec_stat stat;
 	Exec_stat retcode = ES_NORMAL;
 	MCtrylock++;

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -741,8 +741,11 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                 
                 if (tspr == NULL && state != TS_FINALLY)
                 {
-                    if (state == TS_CATCH)
-                        MCeerror->clear();
+                    // Everything has executed normally but there may have been an
+                    // error added on another event. The trylock needs refactoring to
+                    // ensure a trylock on one event can't cause issues in another
+                    // event.
+                    MCeerror->clear();
                     
                     tspr = finallystatements;
                     state = TS_FINALLY;

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -780,6 +780,7 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                         if (state != TS_TRY)
                         {
                             MCtrylock--;
+                            ctxt.SetExecStat(stat);
                             return;
                         }
                         else

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -752,7 +752,10 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                 }
                 break;
             case ES_ERROR:
+            case ES_NOT_FOUND:
+            case ES_NOT_HANDLED:
                 if ((MCtrace || MCnbreakpoints) && state != TS_TRY)
+                {
                     do
                     {
                         if (MCB_error(ctxt, tspr->getline(), tspr->getpos(), EE_TRY_BADSTATEMENT))
@@ -760,9 +763,10 @@ void MCKeywordsExecTry(MCExecContext& ctxt, MCStatement *trystatements, MCStatem
                         ctxt.IgnoreLastError();
                         tspr->exec_ctxt(ctxt);
                     }
-				while(MCtrace && (stat = ctxt . GetExecStat()) != ES_NORMAL);
+                    while(MCtrace && (stat = ctxt . GetExecStat()) != ES_NORMAL);
+                }
                 
-                if (stat == ES_ERROR)
+                if (stat == ES_ERROR || stat == ES_NOT_FOUND || stat == ES_NOT_HANDLED)
                 {
                     if (MCexitall)
                     {

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1819,6 +1819,7 @@ void MCKeywordsExecBreak(MCExecContext& ctxt);
 void MCKeywordsExecNext(MCExecContext& ctxt);
 void MCKeywordsExecPass(MCExecContext& ctxt);
 void MCKeywordsExecPassAll(MCExecContext& ctxt);
+void MCKeywordsExecPassError(MCExecContext& ctxt);
 void MCKeywordsExecThrow(MCExecContext& ctxt, MCStringRef string);
 void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, bool resolved, MCHandler *handler, MCParameter *params, MCNameRef name, uint2 line, uint2 pos, bool platform_message, bool is_function);
 

--- a/engine/src/keywords.h
+++ b/engine/src/keywords.h
@@ -127,10 +127,12 @@ public:
 class MCPass : public MCStatement
 {
 	Boolean all;
+    Boolean error;
 public:
 	MCPass()
 	{
 		all = False;
+        error = False;
 	}
 	virtual Parse_stat parse(MCScriptPoint &sp);
 	virtual void exec_ctxt(MCExecContext&);

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -196,7 +196,8 @@ enum Exec_stat {
     ES_PASS,
     ES_PASS_ALL,
     ES_NOT_HANDLED,
-    ES_NOT_FOUND
+    ES_NOT_FOUND,
+    ES_PASS_ERROR
 };
 
 enum Exit_to {

--- a/engine/src/scriptpt.h
+++ b/engine/src/scriptpt.h
@@ -63,6 +63,8 @@ class MCScriptPoint
 	Boolean in_tag;
 	// MW-2011-06-23: This is true if we backed up over a tag change point.
 	Boolean was_in_tag;
+    
+    bool m_can_pass_error = false;
 
 public:
 	MCScriptPoint(MCScriptPoint &sp);
@@ -185,6 +187,9 @@ public:
     codepoint_t getcodepointatindex(uindex_t index);
     
     void setcurptr(const unichar_t *ptr);
+    
+    bool getcanpasserror() { return m_can_pass_error; }
+    void setcanpasserror(bool p_can_pass_error) { m_can_pass_error = p_can_pass_error; }
 };
 #endif
 

--- a/tests/lcs/core/control/try.livecodescript
+++ b/tests/lcs/core/control/try.livecodescript
@@ -1,0 +1,275 @@
+﻿script "CoreControlTry"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestTry
+   try
+     try
+        NonExistantHandler1
+     catch tError
+        TestAssert "Catch catches error", true
+        TestAssert "Error is not empty in catch", line 1 of tError contains "NonExistantHandler1"
+        NonExistantHandler2
+     finally
+        TestAssert "Finally executes regardless of error in catch", true
+     end try
+  end try
+end TestTry
+
+on TestTryNoCatch
+  try
+  finally
+     TestAssert "Finally executes regardless of catch block", true
+  end try
+end TestTryNoCatch
+
+on TestTryNoCatchWithError
+  try
+     NonExistantHandler
+  finally
+     TestAssert "Finally executes regardless of no catch block with try error", true
+  end try
+end TestTryNoCatchWithError
+
+on TestTryMultipleEvents
+   if the environment is "command line" or the platform is "HTML5" then
+      TestSkip "Try execution context", "no type command available"
+      return empty
+   end if
+   
+   try
+      create stack "test"
+      set the defaultStack to "test"
+      create field "test"
+      set the script of field "test" to "on keyDown;NonExistantHandler1;end keyDown"
+      focus on field "test"
+      type "g"
+   catch tError1
+   end try
+   TestAssert "Errors from other events aren't caught", tError1 is empty
+   
+   try
+      NonExistantHandler2
+   catch tError2
+   end try
+   TestAssert "Errors from other events don't pollute caught error", line 1 of tError2 contains "NonExistantHandler2"
+end TestTryMultipleEvents
+
+on TestTryErrorInCatch
+   TestAssertThrow "Error in catch is thrown", "__TestTryErrorInCatch", the long id of me, "EE_STATEMENT_BADCOMMAND"
+   try
+      NonExistantHandler3
+   catch tError
+      TestAssert "Unthrown errors in catch are cleared", line 1 of tError contains "NonExistantHandler3"
+   end try
+end TestTryErrorInCatch
+
+on __TestTryErrorInCatch
+   try
+      NonExistantHandler1
+   catch tError
+      NonExistantHandler2
+   end try
+end __TestTryErrorInCatch
+
+on TestTryErrorInFinally
+   TestAssertThrow "Error in finally is thrown", "__TestTryErrorInFinally", the long id of me, "EE_STATEMENT_BADCOMMAND"
+   try
+      NonExistantHandler3
+   catch tError
+      TestAssert "Unthrown errors in finally are cleared", line 1 of tError contains "NonExistantHandler3"
+   end try
+   TestAssertThrow "Error in finally is thrown", "__TestTryErrorInFinallyNoTryStatements", the long id of me, "EE_STATEMENT_BADCOMMAND"
+end TestTryErrorInFinally
+
+on __TestTryErrorInFinally
+   try
+      NonExistantHandler1
+   finally
+      NonExistantHandler2
+   end try
+end __TestTryErrorInFinally
+
+on __TestTryErrorInFinallyNoTryStatements
+   try
+   finally
+      NonExistantHandler2
+   end try
+end __TestTryErrorInFinallyNoTryStatements
+
+on TestTryErrorNoCatch
+   try
+      NonExistantHandler
+   end try
+   TestAssert "Error in try with no catch ignored", true
+end TestTryErrorNoCatch
+
+on TestTryPassError
+   try
+      try
+         NonExistantHandler
+      catch tError1
+         pass error
+      end try
+   catch tError2
+      TestAssert "Error passed from catch", line 1 of tError2 contains "NonExistantHandler"
+   end try
+   
+   try
+      try
+         NonExistantHandler
+      finally
+         pass error
+      end try
+   catch tError3
+      TestAssert "Error passed from finally", line 1 of tError3 contains "NonExistantHandler"
+   end try
+end TestTryPassError
+
+
+on TestTryPassMutatedError
+   try
+      try
+         NonExistantHandler
+      catch tError
+         put "foobar" into tError
+         pass error
+      end try
+   catch tError1
+      TestAssert "Mutated error variable content not passed", line 1 of tError1 contains "NonExistantHandler"
+   end try
+end TestTryPassMutatedError
+
+
+on TestTryPassHandler
+   try
+      try
+         pass TestTryPassHandler
+      end try
+      NonExistantHandler
+   catch tError1
+   end try
+   TestAssertBroken "Handler passed from try", tError1 is empty, "Bug 19809"
+   
+   try
+      try
+         NonExistantHandler
+      catch tError2
+         pass TestTryPassHandler
+      end try
+   catch tError3
+   end try
+   TestAssertBroken "Handler passed from catch", tError3 is empty, "Bug 19809"
+
+   try
+      try
+         NonExistantHandler
+      finally
+         pass TestTryPassHandler
+      end try
+   catch tError4
+   end try
+   TestAssertBroken "Handler passed from finally", tError4 is empty, "Bug 19809"
+
+end TestTryPassHandler
+
+on TestTryPassHandlerToTop
+   try
+      pass TestTryPassHandlerToTop to top
+   finally
+      TestAssert "Finally executed when handler pass to top from try", true
+   end try
+   TestAssert "Handler passed to top from try", false
+end TestTryPassHandlerToTop
+
+on TestTryCatchPassHandlerToTop
+   try
+      NonExistantHandler
+   catch tError
+      pass TestTryCatchPassHandlerToTop to top
+   finally
+      TestAssert "Finally executed when handler pass to top from catch", true
+   end try
+   TestAssertBroken "Handler passed to top from catch", false
+end TestTryCatchPassHandlerToTop
+
+on TestTryFinallyPassHandlerToTop
+   try
+      NonExistantHandler
+   finally
+      pass TestTryFinallyPassHandlerToTop to top
+   end try
+   TestAssert "Handler passed to top from finally", false
+end TestTryFinallyPassHandlerToTop
+
+on TestTryExitHandler
+   try
+      exit TestTryExitHandler
+   finally
+      TestAssert "Finally executed when handler exits from try", true
+   end try
+   TestAssert "Handler exit from try", false
+end TestTryExitHandler
+
+on TestTryCatchExitHandler
+   try
+      NonExistantHandler
+   catch tError2
+      exit TestTryCatchExitHandler
+   finally
+      TestAssert "Finally executed when handler exits from catch", true
+   end try
+   TestAssertBroken "Handler exit from catch", false
+end TestTryCatchExitHandler
+
+on TestTryFinallyExitHandler
+   try
+      NonExistantHandler
+   finally
+      exit TestTryFinallyExitHandler
+   end try
+   TestAssert "Handler exit from finally", false
+end TestTryFinallyExitHandler
+
+on TestTryReturn
+   try
+      return empty
+   finally
+      TestAssert "Finally executed when return from try", true
+   end try
+   TestAssert "Return from try", false
+end TestTryReturn
+
+on TestTryCatchReturn
+   try
+      NonExistantHandler
+   catch tError
+      return empty
+   finally
+      TestAssert "Finally executed when return from catch", true
+   end try
+   TestAssertBroken "Return from catch", false
+end TestTryCatchReturn
+
+on TestTryFinallyReturn
+   try
+      NonExistantHandler
+   finally
+      return empty
+   end try
+   TestAssert "Return from finally", false
+end TestTryFinallyReturn


### PR DESCRIPTION
At the end of a try control structure any errors on the error
stack should be cleared. This was not happening if an error was
added to the error stack from some other context. Until we have
more context sensitive try locks and error stacks we should do
our best to clear any unthrown errors on the stack.