### PR TITLE
[[ Feature ]] Set it when importing snapshots

### DIFF
--- a/docs/dictionary/command/import-snapshot.lcdoc
+++ b/docs/dictionary/command/import-snapshot.lcdoc
@@ -6,7 +6,7 @@ Syntax: import snapshot [from rect[angle] <rectangle>] [of <object>] [(with | wi
 
 Summary:
 Creates an <image> of a portion of the screen, portion of a stack or a
-specific object.
+specific object and sets <it> to the long id of the created <image>.
 
 Introduced: 1.0
 
@@ -57,7 +57,8 @@ Use the <import snapshot> <command> to place a screenshot in the
 <current stack>.
 
 The <import snapshot> <command> creates a new <image> in the center of
-the <current card> and places the snapshot in the <image>.
+the <current card> and places the snapshot in the <image> and sets 
+the <it> variable to long id of the created <image>.
 
 iOS supports both the object and screen snapshot variants of the <import
 snapshot> command. In the screen snapshot case, coordinates are given
@@ -116,7 +117,7 @@ To import a snapshot of the screen in iOS use the form:
 References: select (command), export snapshot (command), import (command),
 property (glossary), current stack (glossary), current card (glossary),
 command (glossary), image (keyword), cursor (property),
-paintCompression (property), windowID (property)
+paintCompression (property), windowID (property), it (property)
 
 Tags: multimedia
 

--- a/docs/notes/bugfix-18754.md
+++ b/docs/notes/bugfix-18754.md
@@ -1,0 +1,1 @@
+# Set the it when importing snapshots

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3746,9 +3746,17 @@ void MCInterfaceExecImportSnapshot(MCExecContext& ctxt, MCStringRef p_display, M
             // IM-2013-08-01: [[ ResIndependence ]] pass image scale when setting bitmap
             iptr->setbitmap(t_bitmap, 1.0f, true);
             iptr->attach(OP_CENTER, false);
+            MCAutoValueRef t_id;
+            iptr -> names(P_LONG_ID, &t_id);
+            ctxt . SetItToValue(*t_id);
         }
         
         MCImageFreeBitmap(t_bitmap);
+    }
+    else
+    {
+        ctxt . LegacyThrow(EE_SNAPSHOT_FAILED);
+        return ;
     }
 }
 void MCInterfaceExecImportSnapshotOfScreen(MCExecContext& ctxt, MCRectangle *p_region, MCPoint *p_size)
@@ -3796,6 +3804,9 @@ void MCInterfaceExecImportSnapshotOfObject(MCExecContext& ctxt, MCObject *p_targ
         // IM-2013-08-01: [[ ResIndependence ]] pass image scale when setting bitmap
         iptr->setbitmap(t_bitmap, 1.0f, true);
         iptr->attach(OP_CENTER, false);
+        MCAutoValueRef t_id;
+        iptr -> names(P_LONG_ID, &t_id);
+        ctxt . SetItToValue(*t_id);
     }
     
     MCImageFreeBitmap(t_bitmap);
@@ -3881,7 +3892,7 @@ void MCInterfaceExecImportImage(MCExecContext& ctxt, MCStringRef p_filename, MCS
 			MCInterfaceExecImportGetStream(ctxt, p_mask_filename, t_mask_stream);
 		if (p_mask_filename == nil || t_mask_stream != NULL)
 		{
-			MCtemplateimage->setparent(p_container);
+			MCtemplateimage->setparent(nullptr);
 			MCImage *t_image = (MCImage *)MCtemplateimage->clone(False, OP_NONE, false);
 			MCtemplateimage->setparent(NULL);
 			t_image->setflag(True, F_I_ALWAYS_BUFFER);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2731,6 +2731,9 @@ enum Exec_errors
 
 	// {EE-0894} no target object
     EE_NOTARGET,
+    
+    // {EE-0895} snapshot: no screen
+    EE_SNAPSHOT_FAILED,
 };
 
 extern const char *MCexecutionerrors;

--- a/tests/lcs/core/interface/snapshot.livecodescript
+++ b/tests/lcs/core/interface/snapshot.livecodescript
@@ -1,0 +1,44 @@
+script "CoreInterfaceSnapshot"
+/*
+Copyright (C) 2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestImportScreenSnapshotFromRect
+    if the environment is "command line" then
+      return "SKIP GUI-only tests"
+    end if
+    import snapshot from rectangle 100,100,500,400
+    
+    TestAssert "test set it", it is the long id of the last image
+end TestImportScreenSnapshotFromRect
+
+on TestImportSnapshotFromObject
+    create button "b1"
+
+    import snapshot from button "b1"
+
+    TestAssert "long id of new image is long id of it",  the long id of it is the long id of the last image
+    TestAssertBroken "long id of image is it", it is the long id of the last image
+end TestImportSnapshotFromObject
+
+on TestImportSnapshotFromRectOfObject
+   create field "field 1"
+   set the rect of field "field 1" to 0,0,100,100
+   
+   import snapshot from rectangle 0,0,100,100 of field "field 1"
+   TestAssert "long id of new image is long id of it",  the long id of it is the long id of the last image
+   TestAssertBroken "long id of image is it", it is the long id of the last image
+end TestImportSnapshotFromRectOfObject


### PR DESCRIPTION
Now when you import snapshots, the "it" variable is set to the long id of the created image