### PR TITLE
[[ Bug 19804 ]] Fix crash on Windows in -ui mode due to font usage

### DIFF
--- a/docs/notes/bugfix-19804.md
+++ b/docs/notes/bugfix-19804.md
@@ -1,0 +1,2 @@
+# Ensure fonts work in-ui mode on Windows
+

--- a/engine/src/w32flst.cpp
+++ b/engine/src/w32flst.cpp
@@ -197,11 +197,7 @@ MCFontnode::MCFontnode(MCNameRef fname, uint2 &size, uint2 style, Boolean printe
 	reqstyle = style;
 	reqprinter = printer;
 	font = new (nothrow) MCFontStruct;
-	if (MCnoui)
-	{
-		memset(font, 0, sizeof(MCFontStruct));
-		return;
-	}
+
 	LOGFONTW logfont;
 	memset(&logfont, 0, sizeof(LOGFONTW));
 

--- a/libgraphics/src/directwrite-skia.cpp
+++ b/libgraphics/src/directwrite-skia.cpp
@@ -292,22 +292,25 @@ MCGFloat __MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_
 	
 	// Create a text format object describing the font
 	IDWriteTextFormat* t_format = MCGDWTextFormatFromHFONT(static_cast<HFONT>(p_font.fid), p_font.size);
+    if (t_format != nullptr)
+    {
+	    // Create a text layout for the string and this font
+	    IDWriteTextLayout* t_layout = nil;
+	    if (SUCCEEDED(s_DWFactory->CreateTextLayout(p_text, p_length / sizeof(unichar_t), t_format, INFINITY, INFINITY, &t_layout)))
+	    {
+		    // Get the text metrics for the layout
+		    DWRITE_TEXT_METRICS t_metrics;
+		    if (SUCCEEDED(t_layout->GetMetrics(&t_metrics)))
+		    {
+			    t_width = t_metrics.widthIncludingTrailingWhitespace;
+		    }
 
-	// Create a text layout for the string and this font
-	IDWriteTextLayout* t_layout = nil;
-	if (SUCCEEDED(s_DWFactory->CreateTextLayout(p_text, p_length / sizeof(unichar_t), t_format, INFINITY, INFINITY, &t_layout)))
-	{
-		// Get the text metrics for the layout
-		DWRITE_TEXT_METRICS t_metrics;
-		if (SUCCEEDED(t_layout->GetMetrics(&t_metrics)))
-		{
-			t_width = t_metrics.widthIncludingTrailingWhitespace;
-		}
-	}
+            t_layout->Release();
+	    }
 
-	// Release the created objects and return
-	t_layout->Release();
-	t_format->Release();
+	    t_format->Release();
+    }
+
 	return t_width;
 }
 


### PR DESCRIPTION
This patch ensures HFONT objects are still created on Windows in
-ui mode. Furthemore it ensures that if there is no HFONT (for some
reason), the libgraphics MeasureText API will not crash.

(Previously it was crashing due to trying to Release() a nullptr
COM object)