### PR TITLE
[Bug 11146] Ensure initial orientation respects device orientation when in landscape

### DIFF
--- a/docs/notes/bugfix-11146.md
+++ b/docs/notes/bugfix-11146.md
@@ -1,0 +1,1 @@
+# Ensure that the initial orientation is not upside down on Android when "portrait" is selected.

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -346,9 +346,16 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       else
          replace "${THEME}" with "@android:style/Theme.NoTitleBar" in tManifest
       end if
-      replace "${ORIENTATION}" with pSettings["android,initial orientation"] in tManifest
-      replace "${MIN_SDK_VERSION}" with pSettings["android,minimum version"] in tManifest
       
+      local tInitialOrientation
+      put pSettings["android,initial orientation"] into tInitialOrientation
+      if tInitialOrientation is "landscape" then
+         put "sensorLandscape" into tInitialOrientation
+      end if
+      replace "${ORIENTATION}" with tInitialOrientation in tManifest
+      
+      replace "${MIN_SDK_VERSION}" with pSettings["android,minimum version"] in tManifest
+     
       local tUsesFeature, tUsesPermission, tFeatures, tPermissions, tAd
       repeat for each key tFeature in pSettings["android,device capabilities"]
          put "  <uses-feature android:name="&quote&"android."&tFeature&quote&" android:required="&quote&"${REQUIRED}"&quote&" />" into tUsesFeature


### PR DESCRIPTION
Use `"sensorLandscape"` instead of `"landscape"` in the Android manifest, since this respects the device actual orientation (e.g. it rotates the app view accordingly if the device orientation is either `landscape left` or `landscape right`)