### PR TITLE
[[ Build ]] Workaround for --deps changed-order issue

### DIFF
--- a/util/build-extensions.sh
+++ b/util/build-extensions.sh
@@ -70,7 +70,7 @@ readonly lc_compile=$3
 shift 3
 
 # Find the dependency/build ordering of the extensions
-readonly build_order=$(${lc_compile} --modulepath ${module_dir} --deps changed-order -- $@)
+readonly build_order=$(${lc_compile} --modulepath ${module_dir} --deps order -- $@)
 
 # Loop over the extensions that need to be (re-)built
 for ext in ${build_order} ; do


### PR DESCRIPTION
This patch works around an issue with --deps changed-order that causes
scriptitems not to build. See bug 19813. It will re-build all extensions
until that bug is resolved.