### PR TITLE
[[ Bug 19658 ]] Make CEF work in Linux

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -721,20 +721,20 @@ component Externals.MacOSX
 //////////
 
 component Externals.CEF.Linux
-	into [[TargetFolder]]/CEF place
-		executable linux-[[TargetArchitecture]]:CEF/libcef.so
-		executable linux-[[TargetArchitecture]]:CEF/libffmpegsumo.so
-		executable linux-[[TargetArchitecture]]:CEF/libpdf.so
-		rfolder linux-[[TargetArchitecture]]:CEF/locales
-		file linux-[[TargetArchitecture]]:CEF/cef.pak
-		file linux-[[TargetArchitecture]]:CEF/cef_100_percent.pak
-		file linux-[[TargetArchitecture]]:CEF/cef_200_percent.pak
-		file linux-[[TargetArchitecture]]:CEF/cef_extensions.pak
+	into [[TargetFolder]]/Externals/CEF place
+		executable linux-[[TargetArchitecture]]:Externals/CEF/libcef.so
+		executable linux-[[TargetArchitecture]]:Externals/CEF/libffmpegsumo.so
+		executable linux-[[TargetArchitecture]]:Externals/CEF/libpdf.so
+		rfolder linux-[[TargetArchitecture]]:Externals/CEF/locales
+		file linux-[[TargetArchitecture]]:Externals/CEF/cef.pak
+		file linux-[[TargetArchitecture]]:Externals/CEF/cef_100_percent.pak
+		file linux-[[TargetArchitecture]]:Externals/CEF/cef_200_percent.pak
+		file linux-[[TargetArchitecture]]:Externals/CEF/cef_extensions.pak
 	// Horrible workaround for a libCEF bug
 	into [[TargetFolder]] place
-		file linux-[[TargetArchitecture]]:CEF/icudtl.dat
-		file linux-[[TargetArchitecture]]:CEF/natives_blob.bin
-		file linux-[[TargetArchitecture]]:CEF/snapshot_blob.bin
+		file linux-[[TargetArchitecture]]:icudtl.dat
+		file linux-[[TargetArchitecture]]:natives_blob.bin
+		file linux-[[TargetArchitecture]]:snapshot_blob.bin
 		executable linux-[[TargetArchitecture]]:revbrowser-cefprocess
 		executable linux-[[TargetArchitecture]]:libbrowser-cefprocess
 

--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -721,9 +721,7 @@ component Externals.MacOSX
 //////////
 
 component Externals.CEF.Linux
-	into [[TargetFolder]]/Externals/CEF place
-		executable linux-[[TargetArchitecture]]:revbrowser-cefprocess
-		executable linux-[[TargetArchitecture]]:libbrowser-cefprocess
+	into [[TargetFolder]]/CEF place
 		executable linux-[[TargetArchitecture]]:CEF/libcef.so
 		executable linux-[[TargetArchitecture]]:CEF/libffmpegsumo.so
 		executable linux-[[TargetArchitecture]]:CEF/libpdf.so
@@ -732,9 +730,6 @@ component Externals.CEF.Linux
 		file linux-[[TargetArchitecture]]:CEF/cef_100_percent.pak
 		file linux-[[TargetArchitecture]]:CEF/cef_200_percent.pak
 		file linux-[[TargetArchitecture]]:CEF/cef_extensions.pak
-		file linux-[[TargetArchitecture]]:CEF/icudtl.dat
-		file linux-[[TargetArchitecture]]:CEF/natives_blob.bin
-		file linux-[[TargetArchitecture]]:CEF/snapshot_blob.bin
 	// Horrible workaround for a libCEF bug
 	into [[TargetFolder]] place
 		file linux-[[TargetArchitecture]]:CEF/icudtl.dat

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -2255,7 +2255,7 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
          revAddMapping pPlatform, "CEF/libcef", "Externals/CEF/libcef"
          break
       case pPlatform contains "Linux"
-         put tCurrentLocation & slash & "Externals/CEF" into tCEFDest
+         put tCurrentLocation & slash & "CEF" into tCEFDest
          
          revSBEnsureFolder tCEFDest
          if the result is not empty then
@@ -2296,12 +2296,12 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
          end if
          
          repeat for each line tCEFFile in tCEFFiles
-            revSBCopyFileToFolder tCefResources & slash & tCEFFile, tCurrentLocation, "revStandaloneProgressCallback", the long id of me
+            revSBCopyFileToFolder tCefResources & slash & ".." & slash & tCEFFile, tCurrentLocation, "revStandaloneProgressCallback", the long id of me
             if the result is not empty then
                revStandaloneAddWarning "Linux, external failed to copy:" && quote & tCefResources & slash & tCEFFile & quote
             end if
          end repeat
-         revAddMapping pPlatform, "CEF/libcef", "Externals/CEF/libcef"
+         --revAddMapping pPlatform, "CEF/libcef", "Externals/CEF/libcef"
          break
       default
          break

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -2217,10 +2217,10 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
    // AL-2015-03-13: [[ Bug 14936 ]] Switch where case takes an expression should not switch on a value
    local tCurrentLocation, tCEFResources, tCEFDest
    set the itemdel to slash
-   put (item 1 to -2 of tExternalPath) & "/CEF" into tCEFResources
    put item 1 to -2 of pStandalonePath into tCurrentLocation
    switch
       case pPlatform = "Windows"
+         put (item 1 to -2 of tExternalPath) & "/CEF" into tCEFResources
          put tCurrentLocation & slash & "Externals/CEF" into tCEFDest
          
          revSBEnsureFolder tCEFDest
@@ -2255,7 +2255,8 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
          revAddMapping pPlatform, "CEF/libcef", "Externals/CEF/libcef"
          break
       case pPlatform contains "Linux"
-         put tCurrentLocation & slash & "CEF" into tCEFDest
+         put (item 1 to -2 of tExternalPath) & "/Externals/CEF" into tCEFResources
+         put tCurrentLocation & slash & "Externals/CEF" into tCEFDest
          
          revSBEnsureFolder tCEFDest
          if the result is not empty then
@@ -2265,14 +2266,14 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
          // make sure we only copy the required helper process executable
          put revListFiles(tCEFResources) into tCEFFiles
          filter lines of tCEFFiles not matching "*-cefprocess"
-
+         
          // The following files need to be placed alongside the executable
          local tCefTopLevelFiles = "icudtl.dat,natives_blob.bin,snapshot_blob.bin"
          replace comma with return in tCefTopLevelFiles
          repeat for each line tFile in tCefTopLevelFiles
             filter lines of tCEFFiles not matching tFile
          end repeat
-
+         
          // Copy files to CEF resource folder.
          repeat for each line tCEFFile in tCEFFiles
             revSBCopyFileToFolder tCefResources & slash & tCEFFile, tCEFDest, "revStandaloneProgressCallback", the long id of me
@@ -2285,7 +2286,7 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
          if the result is not empty then
             revStandaloneAddWarning "Linux, external failed to copy:" && quote & tCefResources & slash & "locales" & quote
          end if
-
+         
          // Copy files to standalone folder
          put tCefTopLevelFiles & return into tCEFFiles
          if pCopyRevBrowserResources then
@@ -2296,12 +2297,12 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
          end if
          
          repeat for each line tCEFFile in tCEFFiles
-            revSBCopyFileToFolder tCefResources & slash & ".." & slash & tCEFFile, tCurrentLocation, "revStandaloneProgressCallback", the long id of me
+            revSBCopyFileToFolder tCefResources & slash & ".." & slash & ".." & slash & tCEFFile, tCurrentLocation, "revStandaloneProgressCallback", the long id of me
             if the result is not empty then
                revStandaloneAddWarning "Linux, external failed to copy:" && quote & tCefResources & slash & tCEFFile & quote
             end if
          end repeat
-         --revAddMapping pPlatform, "CEF/libcef", "Externals/CEF/libcef"
+         revAddMapping pPlatform, "CEF/libcef", "Externals/CEF/libcef"
          break
       default
          break

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -2255,7 +2255,11 @@ private command revCopyCEFResources pPlatform, pStandalonePath, pCopyRevBrowserR
          revAddMapping pPlatform, "CEF/libcef", "Externals/CEF/libcef"
          break
       case pPlatform contains "Linux"
-         put (item 1 to -2 of tExternalPath) & "/Externals/CEF" into tCEFResources
+         if revEnvironmentIsInstalled() then
+            put (item 1 to -2 of tExternalPath) & "/CEF" into tCEFResources
+         else
+            put (item 1 to -2 of tExternalPath) & "/Externals/CEF" into tCEFResources
+         end if
          put tCurrentLocation & slash & "Externals/CEF" into tCEFDest
          
          revSBEnsureFolder tCEFDest

--- a/libbrowser/libbrowser.gyp
+++ b/libbrowser/libbrowser.gyp
@@ -143,22 +143,6 @@
 						},
 					},
 				],
-				
-				[
-					'OS == "linux"',
-					{
-						'copies':
-						[
-						    {
-							'destination':'<(PRODUCT_DIR)/CEF/',
-							'files':
-							[
-							    '<(PRODUCT_DIR)/libbrowser-cefprocess',
-							],
-						    },
-						],
-					},
-				],
 
 				[
 					# Only the CEF platforms need libbrowser-cefprocess
@@ -306,7 +290,7 @@
                                     'ldflags':
                                     [
                                         '-Wl,--allow-shlib-undefined',
-                                        '-Wl,-rpath=\\$$ORIGIN/CEF',
+                                        '-Wl,-rpath=\\$$ORIGIN/Externals/CEF',
                                     ],
                                 },
                             ],

--- a/libbrowser/libbrowser.gyp
+++ b/libbrowser/libbrowser.gyp
@@ -306,7 +306,7 @@
                                     'ldflags':
                                     [
                                         '-Wl,--allow-shlib-undefined',
-                                        '-Wl,-rpath=\\$$ORIGIN',
+                                        '-Wl,-rpath=\\$$ORIGIN/CEF',
                                     ],
                                 },
                             ],

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -316,9 +316,101 @@ static const char *kCefPathSeparatorStr = "/";
 static const char kCefPathSeparator = '/';
 #endif
 
+#if defined(TARGET_PLATFORM_LINUX)
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+static bool get_link_size(const char *p_path, uint32_t &r_size)
+{
+    if (p_path == nil)
+        return false;
+    
+    struct stat t_stat;
+    if (lstat(p_path, &t_stat) == -1)
+        return false;
+    
+    r_size = t_stat.st_size;
+    return true;
+}
+
+static bool get_link_path(const char *p_link, char *&r_path)
+{
+    bool t_success;
+    t_success = true;
+    
+    char *t_buffer;
+    t_buffer = nil;
+    uint32_t t_buffer_size;
+    t_buffer_size = 0;
+    
+    uint32_t t_link_size;
+    t_success = get_link_size(p_link, t_link_size);
+    
+    while (t_success && t_link_size + 1 > t_buffer_size)
+    {
+        t_buffer_size = t_link_size + 1;
+        t_success = MCBrowserMemoryReallocate(t_buffer, t_buffer_size, t_buffer);
+        
+        if (t_success)
+        {
+            int32_t t_read;
+            t_read = readlink(p_link, t_buffer, t_buffer_size);
+            
+            t_success = t_read >= 0;
+            t_link_size = t_read;
+        }
+    }
+    
+    if (t_success)
+    {
+        t_buffer[t_link_size] = '\0';
+        r_path = t_buffer;
+    }
+    else
+        MCBrowserMemoryDeallocate(t_buffer);
+    
+    return t_success;
+}
+
+static bool get_exe_path_from_proc_fs(char *&r_path)
+{
+    return get_link_path("/proc/self/exe", r_path);
+}
+
+//////////
+
+const char *__MCCefPlatformGetExecutableFolder(void)
+{
+    static char *s_exe_path = nil;
+    
+    if (s_exe_path == nil)
+    {
+        bool t_success;
+        t_success = get_exe_path_from_proc_fs(s_exe_path);
+        if (t_success)
+        {
+            // remove library component from path
+            uint32_t t_index;
+            if (MCCStringLastIndexOf(s_exe_path, '/', t_index))
+                s_exe_path[t_index] = '\0';
+        }
+    }
+    
+    return s_exe_path;
+}
+#endif
+
 static bool __MCCefGetLibraryPath(char*& r_path)
 {
     void *t_module = nullptr;
+    /* TODO[Bug 19381] Try libcef in the root folder to to workaround
+     * placement issues on Linux. */
+    /*if (t_module == nullptr)
+        t_module = MCSupportLibraryLoad("./libcef");*/
     if (t_module == nullptr)
         t_module = MCSupportLibraryLoad("./CEF/libcef");
     /* TODO[Bug 19381] On Linux and Windows, the in-git-checkout
@@ -408,8 +500,14 @@ bool MCCefInitialise(void)
 	t_settings.log_severity = LOGSEVERITY_DISABLE;
 	
     bool t_success = true;
+#ifdef TARGET_PLATFORM_LINUX
+    if (t_success)
+        t_success = __MCCefBuildPath(__MCCefPlatformGetExecutableFolder(), kCefProcessName, &t_settings.browser_subprocess_path);
+#else
     if (t_success)
         t_success = __MCCefBuildPath(t_library_path, kCefProcessName, &t_settings.browser_subprocess_path);
+#endif
+    
     if (t_success)
         t_success = __MCCefBuildPath(t_library_path, "locales", &t_settings.locales_dir_path);
     if (t_success)

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -407,10 +407,6 @@ const char *__MCCefPlatformGetExecutableFolder(void)
 static bool __MCCefGetLibraryPath(char*& r_path)
 {
     void *t_module = nullptr;
-    /* TODO[Bug 19381] Try libcef in the root folder to to workaround
-     * placement issues on Linux. */
-    /*if (t_module == nullptr)
-        t_module = MCSupportLibraryLoad("./libcef");*/
     if (t_module == nullptr)
         t_module = MCSupportLibraryLoad("./CEF/libcef");
     /* TODO[Bug 19381] On Linux and Windows, the in-git-checkout

--- a/prebuilt/libcef.gyp
+++ b/prebuilt/libcef.gyp
@@ -130,13 +130,13 @@
                                 'destination': '<(PRODUCT_DIR)/',
                                 'files':
                                 [
-                                    'lib/linux/<(target_arch)/natives_blob.bin',
-                                    'lib/linux/<(target_arch)/snapshot_blob.bin',
-                                    'lib/linux/<(target_arch)/icudtl.dat',
+                                    'lib/linux/<(target_arch)/CEF/natives_blob.bin',
+                                    'lib/linux/<(target_arch)/CEF/snapshot_blob.bin',
+                                    'lib/linux/<(target_arch)/CEF/icudtl.dat',
                                 ],
                             },
                             {
-                                'destination': '<(PRODUCT_DIR)/CEF',
+                                'destination': '<(PRODUCT_DIR)/Externals/CEF',
                                 'files':
                                 [
                                     'lib/linux/<(target_arch)/CEF/cef.pak',
@@ -148,7 +148,7 @@
                                 ],
                             },
                             {
-                                'destination': '<(PRODUCT_DIR)/CEF/locales',
+                                'destination': '<(PRODUCT_DIR)/Externals/CEF/locales',
                                 'files':
                                 [
                                     'lib/linux/<(target_arch)/CEF/locales/am.pak',
@@ -211,7 +211,13 @@
 					    {
 						    'variables':
 						    {
-							    'dist_aux_files': [ 'lib/linux/<(target_arch)/CEF/', ],
+							    'dist_aux_files':
+                                [
+                                    '<(PRODUCT_DIR)/Externals/',
+                                    '<(PRODUCT_DIR)/natives_blob.bin',
+                                    '<(PRODUCT_DIR)/snapshot_blob.bin',
+                                    '<(PRODUCT_DIR)/icudtl.dat',
+                                ],
 						    },
 					    },
 				    },

--- a/prebuilt/libcef.gyp
+++ b/prebuilt/libcef.gyp
@@ -130,9 +130,9 @@
                                 'destination': '<(PRODUCT_DIR)/',
                                 'files':
                                 [
-                                    'lib/linux/<(target_arch)/CEF/natives_blob.bin',
-                                    'lib/linux/<(target_arch)/CEF/snapshot_blob.bin',
-                                    'lib/linux/<(target_arch)/CEF/icudtl.dat',
+                                    'lib/linux/<(target_arch)/natives_blob.bin',
+                                    'lib/linux/<(target_arch)/snapshot_blob.bin',
+                                    'lib/linux/<(target_arch)/icudtl.dat',
                                 ],
                             },
                             {

--- a/revbrowser/revbrowser.gyp
+++ b/revbrowser/revbrowser.gyp
@@ -133,7 +133,7 @@
                         'copies':
                         [
                             {
-                                'destination':'<(PRODUCT_DIR)/CEF/',
+                                'destination':'<(PRODUCT_DIR)/',
                                 'files':
                                 [
                                     '<(PRODUCT_DIR)/revbrowser-cefprocess',


### PR DESCRIPTION
This patch changes the layout of the CEF files so that things will
run from the -bin folder when building from source, from the IDE
and in Standalones.

Note: This is still not quite right - but getting there - there is a problem with the placement of the various files. Basically the *-cefprocess files, icudat and *.bin files must be next to the LiveCode executable; whilst libcef and other resources can be in a subfolder. However, when running from the bin folder, the subfolder is CEF, and not Externals/CEF.

Depends on: https://github.com/livecode/livecode-thirdparty/pull/103