### PR TITLE
[Bug 19826] Fix iOS simulator deployment with Xcode 8.3.3

### DIFF
--- a/docs/notes/bugfix-19826.md
+++ b/docs/notes/bugfix-19826.md
@@ -1,0 +1,1 @@
+# Fix iOS simulator deployment with Xcode 8.3.3

--- a/revmobile/src/reviphone.mm
+++ b/revmobile/src/reviphone.mm
@@ -187,7 +187,8 @@ static bool fetch_named_simulator_root(const char *p_display_name, DTiPhoneSimul
 			if ([[t_candidate name] caseInsensitiveCompare: t_sdk_string] == NSOrderedSame ||
 				[[t_candidate identifier] caseInsensitiveCompare: t_sdk_string] == NSOrderedSame ||
 				[[t_candidate root] caseInsensitiveCompare: t_sdk_string] == NSOrderedSame ||
-				[[t_candidate versionString] caseInsensitiveCompare: t_sdk_string] == NSOrderedSame)
+				[[t_candidate versionString] caseInsensitiveCompare: t_sdk_string] == NSOrderedSame ||
+                [[t_candidate versionString] hasPrefix: t_sdk_string])
 			{
 				t_runtime = t_candidate;
 				t_root = [s_simulator_proxy getRootWithSimRuntime: t_runtime];


### PR DESCRIPTION
Starting from Xcode 8.3.3, the `versionString` property of `CoreSimulator.h` seems to return the minor `z` version too. So it returns `x.y.z`, in this case `"10.3.1"`, whereas LC searches for `x.y` version (it was searching for `"10.3"`).
