### PR TITLE
[[ Bugfix 19837 ]] Fix pending message object deletion crash

### DIFF
--- a/docs/notes/bugfix-19837.md
+++ b/docs/notes/bugfix-19837.md
@@ -1,0 +1,1 @@
+# Fix crash due to deletion of object with pending message

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -109,7 +109,7 @@ KeySym MCKeySymToLower(KeySym p_key);
 
 typedef struct
 {
-	MCObject *object;
+	MCObjectHandle *objecthandle;
 	MCNameRef message;
 	real8 time;
 	MCParameter *params;


### PR DESCRIPTION
This patch changes an MCObject* to MCObjectHandle in MCPendingMessage
to stop a crash from sending a message to deleted objects.