### PR TITLE
[[ Bug 16309 ]] Fixed bug causing crash of IDE when trying to remove …

### DIFF
--- a/docs/notes/bugfix-16309.md
+++ b/docs/notes/bugfix-16309.md
@@ -1,0 +1,1 @@
+# Fixed crash of IDE when trying to remove front scripts

--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -2028,7 +2028,16 @@ void MCRemove::exec_ctxt(MCExecContext& ctxt)
         }
 		
 		if (script)
-			MCEngineExecRemoveScriptOfObjectFrom(ctxt, optr . object, where == IP_FRONT);
+        {
+            MCStringRef t_script_name;
+            optr . object->GetName(ctxt, t_script_name);
+            if (MCStringContains(t_script_name, MCSTR("revfrontscript"), 3))
+            {
+                ctxt . LegacyThrow(EE_REMOVE_IDEFRONTSCRIPT);
+                return ;
+            }
+            MCEngineExecRemoveScriptOfObjectFrom(ctxt, optr . object, where == IP_FRONT);
+        }
 		else
 		{
 			if (optr . object->gettype() != CT_GROUP)

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2737,6 +2737,9 @@ enum Exec_errors
     
     // {EE-0896} graphic : too many points
     EE_GRAPHIC_TOOMANYPOINTS,
+    
+    // {EE-0897} remove : cannot remove IDE front scripts
+    EE_REMOVE_IDEFRONTSCRIPT,
 };
 
 extern const char *MCexecutionerrors;


### PR DESCRIPTION
…the IDE front scripts

Now I think one might argue whether we should throw an execution error when trying to remove the IDE front scripts (it is absolutely natural that the IDE will be broken after one does that, so fixing the bug somehow means preventing users from doing that). My gut tells me this is the way to go, because one may have code that accidentally tries to remove them, so it might make sense to give the user an idea of "hey your code does something funny, look at it again". To be fair, it is a simple change to make if we just want it to prevent from removing and not throw an error.