### PR TITLE
[[ WidgetContext ]] Update widget context on entry/exit to widget han…

### DIFF
--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -214,6 +214,9 @@ MCWidgetBase *MCWidgetAsBase(MCWidgetRef widget);
 MCWidgetRoot *MCWidgetAsRoot(MCWidgetRef widget);
 MCWidgetChild *MCWidgetAsChild(MCWidgetRef widget);
 
+void *MCWidgetEnter(MCScriptInstanceRef instance, void *host_ptr);
+void MCWidgetLeave(MCScriptInstanceRef instance, void *host_ptr, void *cookie);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern MCWidgetRef MCcurrentwidget;

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -111,6 +111,10 @@ void MCWidget::bind(MCNameRef p_kind, MCValueRef p_rep)
     bool t_success;
     t_success = true;
     
+    // Make sure we set the widget barrier callbacks - this should be done in
+    // module init for 'extension' when we have such a mechanism.
+    MCScriptSetWidgetBarrierCallbacks(MCWidgetEnter, MCWidgetLeave);
+    
     // Create a new root widget.
     if (t_success)
         t_success = MCWidgetCreateRoot(this, p_kind, m_widget);

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -43,12 +43,17 @@ typedef bool (*MCScriptForEachBuiltinModuleCallback)(void *p_context, MCScriptMo
 
 typedef bool (*MCScriptLoadLibraryCallback)(MCScriptModuleRef module, MCStringRef name, MCSLibraryRef& r_library);
 
+typedef void *(*MCScriptWidgetEnterCallback)(MCScriptInstanceRef instance, void *host_ptr);
+typedef void (*MCScriptWidgetLeaveCallback)(MCScriptInstanceRef instance, void *host_ptr, void* p_cookie);
+
 bool MCScriptInitialize(void);
 void MCScriptFinalize(void);
 
 bool MCScriptForEachBuiltinModule(MCScriptForEachBuiltinModuleCallback p_callback, void *p_context);
 
 void MCScriptSetLoadLibraryCallback(MCScriptLoadLibraryCallback callback);
+
+void MCScriptSetWidgetBarrierCallbacks(MCScriptWidgetEnterCallback entry_callback, MCScriptWidgetLeaveCallback leave_callback);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -255,6 +260,13 @@ MCScriptInstanceRef MCScriptRetainInstance(MCScriptInstanceRef instance);
 
 // Release a instance.
 void MCScriptReleaseInstance(MCScriptInstanceRef instance);
+
+// Sets a private pointer unused by libscript, but passed to the entry/exit
+// callbacks.
+void MCScriptSetInstanceHostPtr(MCScriptInstanceRef instance, void *state_ptr);
+
+// Gets the host ptr.
+void *MCScriptGetInstanceHostPtr(MCScriptInstanceRef instance);
 
 // Get the module of an instance.
 MCScriptModuleRef MCScriptGetModuleOfInstance(MCScriptInstanceRef instance);

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -504,6 +504,9 @@ struct MCScriptInstance: public MCScriptObject
     // MCHandlerRef. The MCHandlerRefs are freed when the instance is freed.
     MCScriptHandlerValue *handlers;
     uindex_t handler_count;
+    
+    // The private host ptr, ignored by libscript but can be used by the host.
+    void *host_ptr;
 };
 
 void


### PR DESCRIPTION
…dlers

This patch moves the code which stacks up the current widget state
from widget-ref.cpp to callbacks invoked by libscript.

Before a widget handler is called, the Entry callback is called
allowing MCcurrentwidget and the execution lock to be taken.

After a widget handler is called, the Leave callback is called
allowing MCcurrentwidget to be reset and execution lock to be
removed.