### PR TITLE
[[ Bug 19861 ]] Use default visual if RGBA not supported on Linux

### DIFF
--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -409,7 +409,10 @@ Boolean MCScreenDC::open()
             vis = gdk_screen_get_rgba_visual(t_screen);
             cmap = gdk_screen_get_rgba_colormap(t_screen);
         }
-        else
+        
+        // If getting the RGBA visual fails, or we are not composited, then
+        // use the default visual.
+        if (vis == nullptr)
         {
             // Get the default visual and colormap
             vis = gdk_screen_get_system_visual(t_screen);


### PR DESCRIPTION
On Linux it is possible for the window manager to claim to be composited
but not support RGBA visuals. In this case the default visual should be
used instead.

Note: Needs backported to develop-8.1