### PR TITLE
[[ AndroidButton ]] Fix several issues with native button

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -379,7 +379,7 @@ component Documentation
 
 component Extensions
 	into [[ToolsFolder]]/Extensions place
-		rfolder macosx:packaged_extensions/com.livecode.widget.androidbutton
+		rfolder macosx:packaged_extensions/com.livecode.widget.native.android.button
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.browser
 	into [[ToolsFolder]]/Extensions place

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -162,7 +162,7 @@ static void co_leave_engine(void);
 static void co_yield_to_engine(void);
 static void co_yield_to_android(void);
 static bool co_yield_to_android_and_wait(double sleep, bool wake_on_event);
-static void co_yield_to_android_and_call(co_yield_callback_t callback, void *context);
+void co_yield_to_android_and_call(co_yield_callback_t callback, void *context);
 
 static void revandroid_scheduleWakeUp(JNIEnv *env, jobject object, int32_t timeout, bool breakable);
 static void revandroid_invalidate(JNIEnv *env, jobject object, int32_t left, int32_t top, int32_t right, int32_t bottom);
@@ -1451,7 +1451,7 @@ static void co_yield_to_engine(void)
 	}
 }
 
-static void co_yield_to_engine_and_call(co_yield_callback_t callback, void *context)
+void co_yield_to_engine_and_call(co_yield_callback_t callback, void *context)
 {
 	void *t_stack;
 	s_yield_callback = callback;
@@ -1491,7 +1491,7 @@ static bool co_yield_to_android_and_wait(double p_sleep, bool p_wake_on_event)
 	return s_schedule_wakeup_was_broken;
 }
 
-static void co_yield_to_android_and_call(co_yield_callback_t callback, void *context)
+void co_yield_to_android_and_call(co_yield_callback_t callback, void *context)
 {
 	void *t_stack;
 	s_schedule_wakeup = false;
@@ -1949,6 +1949,11 @@ void *MCAndroidGetScriptJavaEnv(void)
 void *MCAndroidGetEngine(void)
 {
 	return s_android_view;
+}
+
+bool MCAndroidIsOnSystemThread(void)
+{
+    return s_android_ui_thread.IsCurrent();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mblandroidlcb.cpp
+++ b/engine/src/mblandroidlcb.cpp
@@ -35,11 +35,41 @@
 
 extern void MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_name, jobjectArray p_args);
 
+#ifdef TARGET_SUBPLATFORM_ANDROID
+struct remote_call_t
+{
+    jlong p_handler;
+    jstring p_method_name;
+    jobjectArray p_args;
+};
+
+static void remote_call_func(void *p_context)
+{
+    auto ctxt = static_cast<remote_call_t *>(p_context);
+    MCJavaPrivateDoNativeListenerCallback(ctxt->p_handler, ctxt->p_method_name, ctxt->p_args);
+}
+#endif
+
 extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong handler, jstring p_method, jobjectArray p_args) __attribute__((visibility("default")));
 
 JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong p_handler, jstring p_method_name, jobjectArray p_args)
 {
-    MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
+#ifdef TARGET_SUBPLATFORM_ANDROID
+    extern bool MCAndroidIsOnSystemThread(void);
+    if (MCAndroidIsOnSystemThread())
+    {
+        typedef void (*co_yield_callback_t)(void *);
+        extern void co_yield_to_engine_and_call(co_yield_callback_t callback, void *context);
+        remote_call_t t_context = {p_handler, p_method_name, p_args};
+        co_yield_to_engine_and_call(remote_call_func, &t_context);
+    }
+    else
+    {
+#endif
+        MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
+#ifdef TARGET_SUBPLATFORM_ANDROID
+    }
+#endif
     
     // At the moment we have no way of dealing with any errors thrown in
     // the course of handling or attempting to handle the native listener

--- a/extensions/widgets/androidbutton/androidbutton.lcb
+++ b/extensions/widgets/androidbutton/androidbutton.lcb
@@ -197,6 +197,9 @@ end handler
 
 public handler ButtonClicked(in pView as JObject)
 	post "mouseUp"
+	
+	// Wake the engine to deal with the posted signal
+	MCEngineRunloopBreakWait()
 end handler
 
 public handler OnClick()

--- a/extensions/widgets/androidbutton/androidbutton.lcb
+++ b/extensions/widgets/androidbutton/androidbutton.lcb
@@ -48,22 +48,23 @@ metadata title is "Android Native Button"
 
 /**
 Syntax:
-set the label of <widget> to <pLabel>
-get the label of <widget>
+set the buttonLabel of <widget> to <pLabel>
+get the buttonLabel of <widget>
 
 Summary: The label displayed by the button.
 
 Value (string): The string to use as the button label
 
 Example:
-    set the label of widget "Android Button" to "Click me!"
+    set the buttonLabel of widget "Android Button" to "Click me!"
 
 Description:
-The <label> property is the label displayed by the button.
+The <buttonLabel> property is the label displayed by the button.
 */
 
-property "label" get mLabel set SetLabel
-metadata enabled.dummy is ""
+property buttonLabel get mLabel set SetLabel
+metadata buttonLabel.editor is "com.livecode.pi.string"
+metadata buttonLabel.default is ""
 
 /**
 Syntax:

--- a/extensions/widgets/androidbutton/androidbutton.lcb
+++ b/extensions/widgets/androidbutton/androidbutton.lcb
@@ -48,23 +48,23 @@ metadata title is "Android Native Button"
 
 /**
 Syntax:
-set the buttonLabel of <widget> to <pLabel>
-get the buttonLabel of <widget>
+set the label of <widget> to <pLabel>
+get the label of <widget>
 
 Summary: The label displayed by the button.
 
 Value (string): The string to use as the button label
 
 Example:
-    set the buttonLabel of widget "Android Button" to "Click me!"
+    set the label of widget "Android Button" to "Click me!"
 
 Description:
-The <buttonLabel> property is the label displayed by the button.
+The <label> property is the label displayed by the button.
 */
 
-property buttonLabel get mLabel set SetLabel
-metadata buttonLabel.editor is "com.livecode.pi.string"
-metadata buttonLabel.default is ""
+property label get mLabel set SetLabel
+metadata label.editor is "com.livecode.pi.string"
+metadata label.default is ""
 
 /**
 Syntax:
@@ -93,19 +93,19 @@ foreign handler _JNI_GetAndroidEngine() returns JObject binds to "java:com.runre
 foreign handler _JNI_GetEngineContext(in pEngine as JObject) returns JObject binds to "java:android.view.View>getContext()Landroid/content/Context;"
 
 // Handlers for creating and attaching view
-foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject binds to "java:android.widget.Button>new(Landroid/content/Context;)"
-foreign handler _JNI_AddButtonView(in pParentView as JObject, in pChildView as JObject) returns nothing binds to "java:android.view.ViewGroup>addView(Landroid/view/View;)V"
+foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject binds to "javaui:android.widget.Button>new(Landroid/content/Context;)"
+foreign handler _JNI_AddButtonView(in pParentView as JObject, in pChildView as JObject) returns nothing binds to "javaui:android.view.ViewGroup>addView(Landroid/view/View;)V"
 
 // Handlers for adding click listener
 handler type ClickCallback(in pView as JObject)
 foreign handler _JNI_OnClickListener(in pHandler as ClickCallback) returns JObject binds to "java:android.view.View$OnClickListener>interface()"
-foreign handler _JNI_SetOnClickListener(in pButton as JObject, in pListener as JObject) returns nothing binds to "java:android.view.View>setOnClickListener(Landroid/view/View$OnClickListener;)V"
+foreign handler _JNI_SetOnClickListener(in pButton as JObject, in pListener as JObject) returns nothing binds to "javaui:android.view.View>setOnClickListener(Landroid/view/View$OnClickListener;)V"
 
 // Property setters
-foreign handler _JNI_SetTextViewText(in pView as JObject, in pValue as JString) returns nothing binds to "java:android.widget.TextView>setText(Ljava/lang/CharSequence;)V"
-foreign handler _JNI_SetTextViewTextColor(in pView as JObject, in pValue as JInt) returns nothing binds to "java:android.widget.TextView>setTextColor(I)V"
+foreign handler _JNI_SetTextViewText(in pView as JObject, in pValue as JString) returns nothing binds to "javaui:android.widget.TextView>setText(Ljava/lang/CharSequence;)V"
+foreign handler _JNI_SetTextViewTextColor(in pView as JObject, in pValue as JInt) returns nothing binds to "javaui:android.widget.TextView>setTextColor(I)V"
 foreign handler _JNI_GetColorFromARGB(in pA as JInt, in pR as JInt, in pG as JInt, in pB as JInt) returns JInt binds to "java:android.graphics.Color>argb(IIII)I!static"
-foreign handler _JNI_SetTextViewEnabled(in pView as JObject, in pValue as JBoolean) returns nothing binds to "java:android.view.View>setEnabled(Z)V"
+foreign handler _JNI_SetTextViewEnabled(in pView as JObject, in pValue as JBoolean) returns nothing binds to "javaui:android.view.View>setEnabled(Z)V"
 
 private variable mLabel as String
 private variable mColor as String

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -1400,6 +1400,16 @@ bool MCJavaCreateInterfaceProxy(MCNameRef p_class_name, MCTypeInfoRef p_signatur
     return true;
 }
 
+bool MCJavaPrivateCallJNIMethodOnEnv(void *p_env, MCNameRef p_class_name, void *p_method_id, int p_call_type, MCTypeInfoRef p_signature, void *r_return, void **p_args, uindex_t p_arg_count)
+{
+    JNIEnv *t_old_env;
+    t_old_env = s_env;
+    s_env = (JNIEnv *)p_env;
+    bool t_success = MCJavaPrivateCallJNIMethod(p_class_name, p_method_id, p_call_type, p_signature, r_return, p_args, p_arg_count);
+    s_env = t_old_env;
+    return t_success;
+}
+
 bool MCJavaPrivateCallJNIMethod(MCNameRef p_class_name, void *p_method_id, int p_call_type, MCTypeInfoRef p_signature, void *r_return, void **p_args, uindex_t p_arg_count)
 {
     if (p_method_id == nullptr)

--- a/libfoundation/src/foundation-java-private.h
+++ b/libfoundation/src/foundation-java-private.h
@@ -54,6 +54,7 @@ typedef struct __MCJavaObject *MCJavaObjectRef;
 
 
 bool MCJavaPrivateCallJNIMethod(MCNameRef p_class_name, void *p_method_id, int p_call_type, MCTypeInfoRef p_signature, void *r_return, void **p_args, uindex_t p_arg_count);
+bool MCJavaPrivateCallJNIMethodOnEnv(void *p_env, MCNameRef p_class_name, void *p_method_id, int p_call_type, MCTypeInfoRef p_signature, void *r_return, void **p_args, uindex_t p_arg_count);
 bool MCJavaPrivateObjectDescribe(MCValueRef p_value, MCStringRef &r_desc);
 bool MCJavaPrivateConvertJStringToStringRef(MCJavaObjectRef p_object, MCStringRef &r_string);
 bool MCJavaPrivateConvertStringRefToJString(MCStringRef p_string, MCJavaObjectRef &r_object);

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -857,8 +857,11 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 		return MCScriptThrowObjCBindingNotImplemented();
 #endif
 	}
-	else if (MCStringIsEqualToCString(*t_language, "java", kMCStringOptionCompareExact))
+	else if (MCStringIsEqualToCString(*t_language, "java", kMCStringOptionCompareExact) ||
+             MCStringIsEqualToCString(*t_language, "javaui", kMCStringOptionCompareExact))
     {
+        p_handler->is_ui_bound = MCStringIsEqualToCString(*t_language, "javaui", kMCStringOptionCompareExact);
+    
 		p_handler -> is_java = true;
         p_handler->is_builtin = false;
 	

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -342,6 +342,7 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
     
     // Bound function information - not pickled.
     bool is_java: 1;
+    bool is_ui_bound : 1;
     bool is_bound: 1;
     bool is_builtin: 1;
     


### PR DESCRIPTION
- Overriding the label property was causing problems. Renamed to `buttonLabel`
- Break wait loop after click callback
- Use correct folder name in package manifest