### PR TITLE
[[ AndroidListeners ]] Use android UI thread for interface proxy call…

### DIFF
--- a/engine/src/mblandroidlcb.cpp
+++ b/engine/src/mblandroidlcb.cpp
@@ -56,12 +56,12 @@ JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeList
 {
 #ifdef TARGET_SUBPLATFORM_ANDROID
     extern bool MCAndroidIsOnSystemThread(void);
-    if (MCAndroidIsOnSystemThread())
+    if (!MCAndroidIsOnSystemThread())
     {
         typedef void (*co_yield_callback_t)(void *);
-        extern void co_yield_to_engine_and_call(co_yield_callback_t callback, void *context);
+        extern void co_yield_to_android_and_call(co_yield_callback_t callback, void *context);
         remote_call_t t_context = {p_handler, p_method_name, p_args};
-        co_yield_to_engine_and_call(remote_call_func, &t_context);
+        co_yield_to_android_and_call(remote_call_func, &t_context);
     }
     else
     {


### PR DESCRIPTION
…backs

All methods invoked using interface proxy callbacks (via the
LCBInvocation proxy) will ensure they are called on the ui thread.

This fixes a crash with the android native button widget, where the
listener was triggered on the UI thread from a click and the resulting
redraw of the button had an invalid pointer for the current JNI env.