### PR TITLE
[[ Bug 19771 ]] Fix incorrect validation method for JumpIf

### DIFF
--- a/docs/lcb/notes/19771.md
+++ b/docs/lcb/notes/19771.md
@@ -1,0 +1,1 @@
+# Fix bytecode generation error caused by incorrect validation of JumpIf opcode.

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -121,7 +121,7 @@ struct MCScriptBytecodeOp_JumpIf
 		ctxt.CheckArity(2);
 		ctxt.CheckRegister(ctxt.GetArgument(0));
 		ctxt.CheckAddress(ctxt.GetAddress() +
-						  ctxt.GetSignedArgument(0));
+						  ctxt.GetSignedArgument(1));
 	}
 	
 	static void Execute(MCScriptExecuteContext& ctxt)


### PR DESCRIPTION
The validator for the JumpIf bytecode was using the wrong
argument to compute the address. This has been fixed.