### PR TITLE
[[ Bug 19869 ]] Only include private handlers of the target

### DIFF
--- a/docs/notes/bugfix-19869.md
+++ b/docs/notes/bugfix-19869.md
@@ -1,0 +1,1 @@
+# The effective revAvailableHandlers only includes private handlers of the target

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -4511,7 +4511,7 @@ void MCObject::GetRevAvailableHandlers(MCExecContext& ctxt, uindex_t& r_count, M
         return;
     }
     
-    hlist -> enumerate(ctxt, true, r_count, r_handlers);
+    hlist -> enumerate(ctxt, true, true, r_count, r_handlers);
 }
 
 void MCObject::GetEffectiveRevAvailableHandlers(MCExecContext& ctxt, uindex_t& r_count, MCStringRef*& r_handlers)
@@ -4570,7 +4570,7 @@ void MCObject::GetEffectiveRevAvailableHandlers(MCExecContext& ctxt, uindex_t& r
                 t_handler_array = nil;
                 uindex_t t_count;
                 
-                t_first = t_handler_list -> enumerate(ctxt, t_first, t_count, t_handler_array);
+                t_first = t_handler_list -> enumerate(ctxt, t_object_ref->getobject() == this, t_first, t_count, t_handler_array);
             
                 for (uindex_t i = 0; i < t_count; i++)
                     t_handlers . Push(t_handler_array[i]);

--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -647,7 +647,7 @@ static const char *s_handler_types[] =
     "A",
 };
 
-static bool enumerate_handlers(MCExecContext& ctxt, const char *p_type, MCHandlerArray& p_handlers, uindex_t& r_count, MCStringRef*& r_handlers, bool p_first = false, MCObject *p_object = nil)
+static bool enumerate_handlers(MCExecContext& ctxt, bool p_include_private, const char *p_type, MCHandlerArray& p_handlers, uindex_t& r_count, MCStringRef*& r_handlers, bool p_first = false, MCObject *p_object = nil)
 {
     MCAutoArray<MCStringRef> t_handlers;
     MCAutoStringRef t_long_id;
@@ -655,6 +655,11 @@ static bool enumerate_handlers(MCExecContext& ctxt, const char *p_type, MCHandle
 	{
 		MCHandler *t_handler;
 		t_handler = p_handlers . get()[j];
+        
+        if (t_handler->isprivate() && !p_include_private)
+        {
+            continue;
+        }
         
 		MCStringRef t_string;
         const char *t_format;
@@ -686,7 +691,7 @@ static bool enumerate_handlers(MCExecContext& ctxt, const char *p_type, MCHandle
 	return p_first;
 }
 
-bool MCHandlerlist::enumerate(MCExecContext& ctxt, bool p_first, uindex_t& r_count, MCStringRef*& r_handlers)
+bool MCHandlerlist::enumerate(MCExecContext& ctxt, bool p_include_private, bool p_first, uindex_t& r_count, MCStringRef*& r_handlers)
 {
 	// OK-2008-07-23 : Added parent object reference for script editor.
 	MCObject *t_object;
@@ -700,7 +705,7 @@ bool MCHandlerlist::enumerate(MCExecContext& ctxt, bool p_first, uindex_t& r_cou
         t_handler_array = nil;
         uindex_t t_count;
         
-        p_first = enumerate_handlers(ctxt, s_handler_types[i], handlers[i], t_count, t_handler_array, p_first, t_object);
+        p_first = enumerate_handlers(ctxt, p_include_private, s_handler_types[i], handlers[i], t_count, t_handler_array, p_first, t_object);
         for (uindex_t j = 0; j < t_count; j++)
             t_handlers . Push(t_handler_array[j]);
         

--- a/engine/src/hndlrlst.h
+++ b/engine/src/hndlrlst.h
@@ -131,7 +131,7 @@ public:
 
 	uint2 getnglobals(void);
 	MCVariable *getglobal(uint2 p_index);
-    bool enumerate(MCExecContext& ctxt, bool p_first, uindex_t& r_count, MCStringRef*& r_handlers);
+    bool enumerate(MCExecContext& ctxt, bool p_include_private, bool p_first, uindex_t& r_count, MCStringRef*& r_handlers);
 	
 	uint2 getnvars(void)
 	{

--- a/tests/lcs/core/engine/reflection.livecodescript
+++ b/tests/lcs/core/engine/reflection.livecodescript
@@ -18,14 +18,14 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestSetup
 	create button "IsolatedBehavior"
-	set the script of it to "command myBehaviorHandler; end myBehaviorHandler"
+	set the script of it to "command myBehaviorHandler; end myBehaviorHandler; private command myPrivateBehaviorHandler; end myPrivateBehaviorHandler"
 
 	create button "ChainedBehavior"
 	set the script of it to "command myChainedBehaviorHandler; end myChainedBehaviorHandler"
 	set the behavior of it to the long id of button "IsolatedBehavior"
 
 	create button "TestButton"
-	set the script of it to "command myHandler; end myHandler"
+	set the script of it to "command myHandler; end myHandler; private command myPrivateHandler; end myPrivateHandler"
 end TestSetup
 
 on TestTeardown
@@ -37,11 +37,15 @@ end TestTeardown
 on TestRevAvailableHandlers
 	set the behavior of button "TestButton" to the long id of button "IsolatedBehavior"
 	TestAssert "lists handlers only in object script", the revAvailableHandlers of button "TestButton" contains " myHandler "
+	TestAssert "lists private handlers only in object script", the revAvailableHandlers of button "TestButton" contains " myPrivateHandler "
 end TestRevAvailableHandlers
 
 on TestRevEffectiveAvailableHandlersBehavior
 	set the behavior of button "TestButton" to the long id of button "IsolatedBehavior"
+	TestAssert "lists object's handlers", the effective revAvailableHandlers of button "TestButton" contains " myHandler "
+	TestAssert "lists object's private handlers", the effective revAvailableHandlers of button "TestButton" contains " myPrivateHandler "
 	TestAssert "lists object's behavior handlers", the effective revAvailableHandlers of button "TestButton" contains " myBehaviorHandler "
+	TestAssert "does not list object's behavior private handlers", not (the effective revAvailableHandlers of button "TestButton" contains " myPrivateBehaviorHandler ")
 end TestRevEffectiveAvailableHandlersBehavior
 
 on TestRevEffectiveAvailableHandlersChainedBehavior


### PR DESCRIPTION
This patch makes sure that only private handlers of the target
are included in 'the effective revAvailableHandlers'.

This means that it only returns handlers which are accessible
from the target's script.