### PR TITLE
[[ Bug 19877 ]] Accept connections in ephemeral port range

### DIFF
--- a/docs/dictionary/command/accept.lcdoc
+++ b/docs/dictionary/command/accept.lcdoc
@@ -31,6 +31,10 @@ on connectionMade pIPAddress
    put "Connection made:" && pIPAddress
 end connectionMade
 
+Example:
+accept connections on port 0 with message "connectionMade"
+put it into tPort
+
 Parameters:
 callbackMessage:
 The name of a message to be sent when a connection is made or a datagram
@@ -38,6 +42,14 @@ is received.
 
 portNumber:
 The TCP port number on which to accept connections.
+
+The result:
+An error message if the socket could not be opened.
+
+It:
+The actual port that was bound. In the case of accepting connections
+on port 0 the operating system will assign a free port in its ephemeral
+port range.
 
 Description:
 Use the <accept> <command> when running a <server>, to accept <TCP>

--- a/docs/notes/bugfix-19877.md
+++ b/docs/notes/bugfix-19877.md
@@ -1,0 +1,7 @@
+# Add support for accepting socket connections on a port in the ephemeral port range
+
+When accepting connections on port 0 the OS will assign an available
+port within it's ephemeral port range. The accept command now names the
+socket with the bound port number rather than 0 so that the bound port
+will appear in the value of the openSockets function and sets the it
+variable to the port number.

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -603,13 +603,17 @@ void MCNetworkExecPerformAcceptConnections(MCExecContext& ctxt, uint2 p_port, MC
 {
 	// MW-2005-01-28: Fix bug 2412 - accept doesn't clear the result.
 	MCresult -> clear();
-
+    ctxt . SetItToValue(kMCEmptyData);
+    
 	if (!ctxt . EnsureNetworkAccessIsAllowed())
 		return;
 
 	MCSocket *s = MCS_accept(p_port, ctxt . GetObject(), p_message, p_datagram ? True : False, p_secure ? True : False, p_with_verification ? True : False, kMCEmptyString);
 	if (s != NULL)
+    {
         MCSocketsAppendToSocketList(s);
+        ctxt . SetItToValue(s -> name);
+    }
 }
 
 void MCNetworkExecAcceptConnectionsOnPort(MCExecContext& ctxt, uint2 p_port, MCNameRef p_message)

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -1198,6 +1198,23 @@ MCSocket *MCS_accept(uint2 port, MCObject *object, MCNameRef message, Boolean da
 		listen(sock, SOMAXCONN);
 #endif
     
+    if (0 == port)
+    {
+        socklen_t addrsize = sizeof(addr);
+        if (getsockname(sock, (sockaddr *)&addr, &addrsize) < 0)
+        {
+            MCresult->sets("can't get bound port");
+#if defined(_WINDOWS_DESKTOP) || defined(_WINDOWS_SERVER)
+            closesocket(sock);
+#else
+            close(sock);
+#endif
+            return NULL;
+        }
+        
+        port =  MCSwapInt16NetworkToHost(((struct sockaddr_in *)&addr)->sin_port);
+    }
+    
     // AL-2015-01-05: [[ Bug 14287 ]] Create name using the number of chars written to the string.
     uindex_t t_length;
     /* UNCHECKED */ MCAutoPointer<char_t[]> t_port_chars = new (nothrow) char_t[U2L];

--- a/tests/lcs/core/network/network.livecodescript
+++ b/tests/lcs/core/network/network.livecodescript
@@ -195,3 +195,25 @@ on TestOpenSocketFromWithAddressAndPortUsingLocalServer
    close socket "127.0.0.1:8009"
    close socket "8009"
 end TestOpenSocketFromWithAddressAndPortUsingLocalServer
+
+on TestAcceptConnectionsInEphemeralPortRange
+   -- in lieu of coming up with a per-OS/config list of ephemeral ranges
+   -- we will just test if the port opened is greater than 1024 which
+   -- is the bare minimum for BSD sockets then try and connect to it
+   local tPort
+   accept connections on port "0" with message "connectedPlaceHolder"
+   put it into tPort
+   
+   TestAssert "accept on port 0 binds to socket in ephemeral port range", tPort > 1024
+   TestAssert "ephemeral port is in the open sockets", tPort is among the lines of the openSockets
+   TestAssert "Port 0 is not in the open sockets", 0 is not among the lines of the openSockets
+   
+   local tSocket
+   put "127.0.0.1:" & tPort into tSocket
+   
+   open socket to tSocket
+   TestAssert "open socket to ephemeral port", tSocket is among the lines of the openSockets
+   
+   close socket tSocket
+   close socket tPort
+end TestAcceptConnectionsInEphemeralPortRange


### PR DESCRIPTION
This patch adds support for accepting connections in the ephermeral
port range by setting the socket name to the bound port when accepting
connections on port 0 and returning the socket name in the it variable.