### PR TITLE
[[ Bug 18899 ]] Make sure current module is updated

### DIFF
--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -315,10 +315,12 @@ struct MCScriptBytecodeOp_Invoke
 		{
 			case kMCScriptDefinitionKindHandler:
 			{
+                MCScriptModuleRef t_previous = MCScriptSetCurrentModule(t_resolved_instance->module);
 				ctxt.PushFrame(t_resolved_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_resolved_definition),
 							   t_result_reg,
 				               t_arguments);
+                MCScriptSetCurrentModule(t_previous);
 			}
 			break;
 				
@@ -526,10 +528,12 @@ private:
 		{
 			case kMCScriptDefinitionKindHandler:
 			{
+                MCScriptModuleRef t_previous = MCScriptSetCurrentModule(t_handler_instance->module);
 				ctxt.PushFrame(t_handler_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_handler_def),
 							   p_result_reg,
 				               p_argument_regs);
+                MCScriptSetCurrentModule(t_previous);
 			}
 			break;
 				

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -26,7 +26,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// This is the module of the most recent LCB stack frame on the current thread's
+// This is the module of themost recent LCB stack frame on the current thread's
 // stack. It is set before and after a foreign handler call so that the native
 // code can get some element of context.
 static MCScriptModuleRef s_current_module = nil;
@@ -232,7 +232,9 @@ __MCScriptCallHandlerDefinitionInInstance(MCScriptInstanceRef self,
         }
     }
 
-	MCScriptExecuteContext t_execute_ctxt;
+    MCScriptModuleRef t_previous = MCScriptSetCurrentModule(self->module);
+	
+    MCScriptExecuteContext t_execute_ctxt;
 	t_execute_ctxt.Enter(self,
 						 p_handler_def,
 	                     MCMakeSpan(p_arguments, p_argument_count),
@@ -252,6 +254,8 @@ __MCScriptCallHandlerDefinitionInInstance(MCScriptInstanceRef self,
                                     t_cookie);
         }
     }
+    
+    MCScriptSetCurrentModule(t_previous);
 
 	if (!t_execute_ctxt.Leave())
 	{
@@ -1200,6 +1204,13 @@ MCScriptEvaluateHandlerInInstanceInternal(MCScriptInstanceRef p_instance,
 MCScriptModuleRef MCScriptGetCurrentModule(void)
 {
 	return s_current_module;
+}
+
+MCScriptModuleRef MCScriptSetCurrentModule(MCScriptModuleRef p_module)
+{
+    MCScriptModuleRef t_previous = s_current_module;
+    s_current_module = p_module;
+    return t_previous;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -510,6 +510,8 @@ struct MCScriptInstance: public MCScriptObject
     void *host_ptr;
 };
 
+MCScriptModuleRef MCScriptSetCurrentModule(MCScriptModuleRef module);
+
 void
 MCScriptDestroyInstance(MCScriptInstanceRef instance);
 


### PR DESCRIPTION
This patch ensures that the current module global is updated
whenever a new frame is created on the LCB stack.

This fixes an issue with 'image from resource file' not working.

Note: I'm not entirely happy with this as SetCurrentModule is being used in three places. This is similar to the widget context thing so I'm wondering if there's a better abstraction here.