### PR TITLE
[Bug 19891] [Bug 19893] Fix some inconsistencies in the player object.

### DIFF
--- a/docs/notes/bugfix-19891.md
+++ b/docs/notes/bugfix-19891.md
@@ -1,0 +1,1 @@
+# Ensure player controller thumb shows within the allowed range

--- a/docs/notes/bugfix-19893.md
+++ b/docs/notes/bugfix-19893.md
@@ -1,0 +1,1 @@
+# Ensure player respects startTime in reverse playback

--- a/docs/notes/bugfix-19972.md
+++ b/docs/notes/bugfix-19972.md
@@ -1,0 +1,1 @@
+# Make sure setting playRate to negative does have an effect when player has reached the end of movie

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -2933,7 +2933,6 @@ MCRectangle MCPlayer::getcontrollerpartrect(const MCRectangle& p_rect, int p_par
             MCPlayerDuration t_current_time, t_duration;
             t_current_time = getmoviecurtime();
             t_duration = getduration();
-			
 			t_current_time = MCMin(t_current_time, t_duration);
 			
             MCRectangle t_well_rect;
@@ -3497,13 +3496,9 @@ void MCPlayer::handle_mstilldown(int p_which)
     {
         case kMCPlayerControllerPartScrubForward:
         {
-            MCPlayerDuration t_current_time, t_duration;
-            t_current_time = getmoviecurtime();
-            t_duration = getduration();
-            
-            t_current_time = MCMin(t_current_time, t_duration);
-            
-            double t_rate;
+			MCPlayerDuration t_current_time = MCMin(getmoviecurtime(), getduration());
+
+			double t_rate;
             if (m_inside)
             {
                 t_rate = 2.0;
@@ -3518,14 +3513,9 @@ void MCPlayer::handle_mstilldown(int p_which)
             
         case kMCPlayerControllerPartScrubBack:
         {
-            MCPlayerDuration t_current_time, t_duration;
-            t_current_time = getmoviecurtime();
-            t_duration = getduration();
-            
-            if (t_current_time < 0.0)
-                t_current_time = 0.0;
-            
-            double t_rate;
+			MCPlayerDuration t_current_time = MCMax(getmoviecurtime(), 0.0);
+
+			double t_rate;
             if (m_inside)
             {
                 t_rate = -2.0;

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1308,9 +1308,7 @@ MCPlayerDuration MCPlayer::getmoviecurtime()
 
 void MCPlayer::setcurtime(MCPlayerDuration newtime, bool notify)
 {
-    MCPlatformPlayerDuration t_duration = getduration();
-    if (newtime > t_duration)
-        newtime = t_duration;
+    newtime = MCMin(newtime, getduration());
 	lasttime = newtime;
 	if (m_platform_player != nil && hasfilename())
     {
@@ -2935,10 +2933,9 @@ MCRectangle MCPlayer::getcontrollerpartrect(const MCRectangle& p_rect, int p_par
             MCPlayerDuration t_current_time, t_duration;
             t_current_time = getmoviecurtime();
             t_duration = getduration();
-            
-            if (t_current_time > t_duration)
-                t_current_time = t_duration;
-            
+			
+			t_current_time = MCMin(t_current_time, t_duration);
+			
             MCRectangle t_well_rect;
             t_well_rect = getcontrollerpartrect(p_rect, kMCPlayerControllerPartWell);
             
@@ -3504,8 +3501,7 @@ void MCPlayer::handle_mstilldown(int p_which)
             t_current_time = getmoviecurtime();
             t_duration = getduration();
             
-            if (t_current_time > t_duration)
-                t_current_time = t_duration;
+            t_current_time = MCMin(t_current_time, t_duration);
             
             double t_rate;
             if (m_inside)

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1308,6 +1308,9 @@ MCPlayerDuration MCPlayer::getmoviecurtime()
 
 void MCPlayer::setcurtime(MCPlayerDuration newtime, bool notify)
 {
+    MCPlatformPlayerDuration t_duration = getduration();
+    if (newtime > t_duration)
+        newtime = t_duration;
 	lasttime = newtime;
 	if (m_platform_player != nil && hasfilename())
     {
@@ -2932,6 +2935,9 @@ MCRectangle MCPlayer::getcontrollerpartrect(const MCRectangle& p_rect, int p_par
             MCPlayerDuration t_current_time, t_duration;
             t_current_time = getmoviecurtime();
             t_duration = getduration();
+            
+            if (t_current_time > t_duration)
+                t_current_time = t_duration;
             
             MCRectangle t_well_rect;
             t_well_rect = getcontrollerpartrect(p_rect, kMCPlayerControllerPartWell);


### PR DESCRIPTION
Addresses the following issues:

1. `startTime` was not respected in reverse playback (i.e. when `rate < 0`)
2. the controller thumb could appear after the end of the controller rect
