### PR TITLE
[[ FFI ]] Objective-C FFI

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -677,6 +677,7 @@ typedef struct __MCStream *MCStreamRef;
 typedef struct __MCProperList *MCProperListRef;
 typedef struct __MCForeignValue *MCForeignValueRef;
 typedef struct __MCJavaObject *MCJavaObjectRef;
+typedef struct __MCObjcObject *MCObjcObjectRef;
 
 // Forward declaration
 typedef struct __MCLocale* MCLocaleRef;
@@ -1607,6 +1608,9 @@ MC_DLLEXPORT MCTypeInfoRef MCProperListTypeInfo(void) ATTRIBUTE_PURE;
 
 MC_DLLEXPORT extern MCTypeInfoRef kMCBoolTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignBoolTypeInfo(void) ATTRIBUTE_PURE;
+
+MC_DLLEXPORT extern MCTypeInfoRef kMCVoidTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignVoidTypeInfo(void) ATTRIBUTE_PURE;
 
 MC_DLLEXPORT extern MCTypeInfoRef kMCUInt8TypeInfo;
 MC_DLLEXPORT extern MCTypeInfoRef kMCSInt8TypeInfo;
@@ -3403,6 +3407,58 @@ MC_DLLEXPORT bool MCProperListEndsWithList(MCProperListRef list, MCProperListRef
 MC_DLLEXPORT bool MCProperListIsListOfType(MCProperListRef list, MCValueTypeCode p_type);
 MC_DLLEXPORT bool MCProperListIsHomogeneous(MCProperListRef list, MCValueTypeCode& r_type);
     
+////////////////////////////////////////////////////////////////////////////////
+//
+//  OBJC DEFINITIONS
+//
+
+/* The ObjcObject type manages the lifetime of the obj-c object it contains.
+ * Specifcally, it sends 'release' to the object when the ObjcObject is dropped */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcObjectTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcObjectTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcId type describes an id which is passed into, or out of an obj-c
+ * method with no implicit action on its reference count. */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcIdTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcIdTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcRetainedId type describes an id which is passed into, or out of an
+ * obj-c method and is expected to already have been retained. (i.e. the
+ * caller or callee expects to receive it with +1 ref count). */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcRetainedIdTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcRetainedIdTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcAutoreleasedId type describes an id which has been placed in the
+ * innermost autorelease pool before being returned to the caller. */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcAutoreleasedIdTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcAutoreleasedIdTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcObjectCreateWithId function creates an ObjcObject out of a raw id
+ * value, retaining it to make sure it owns a reference to it. */
+MC_DLLEXPORT bool MCObjcObjectCreateWithId(void *value, MCObjcObjectRef& r_obj);
+
+/* The ObjcObjectCreateWithId function creates an ObjcObject out of a raw id
+ * value, taking a +1 reference count from it (i.e. it assumes the value has
+ * already been retained before being called). */
+MC_DLLEXPORT bool MCObjcObjectCreateWithRetainedId(void *value, MCObjcObjectRef& r_obj);
+
+/* The ObjcObjectCreateWithAutoreleasedId function creates an ObjcObject out of
+ * a raw id value which is in the innermost autorelease pool. Currently this
+ * means that it retains it. */
+MC_DLLEXPORT bool MCObjcObjectCreateWithAutoreleasedId(void *value, MCObjcObjectRef& r_obj);
+
+/* The ObjcObjectGetId function returns the raw id value contained within
+ * an ObjcObject. The retain count of the id remains unchanged. */
+MC_DLLEXPORT void *MCObjcObjectGetId(MCObjcObjectRef obj);
+
+/* The ObjcObjectGetRetainedId function returns the raw id value contained within
+ * an ObjcObject. The id is retained before being returned. */
+MC_DLLEXPORT void *MCObjcObjectGetRetainedId(MCObjcObjectRef obj);
+
+/* The ObjcObjectGetAutoreleasedId function returns the raw id value contained within
+ * an ObjcObject. The id is autoreleased before being returned. */
+MC_DLLEXPORT void *MCObjcObjectGetAutoreleasedId(MCObjcObjectRef obj);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 enum MCPickleFieldType

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -87,6 +87,11 @@ bool MCInitialize(void)
     if (!__MCJavaInitialize())
         return false;
     
+#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
+    if (!__MCObjcInitialize())
+        return false;
+#endif
+    
 	return true;
 }
 
@@ -109,6 +114,10 @@ void MCFinalize(void)
     __MCUnicodeFinalize();
     __MCJavaFinalize();
     
+#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
+    __MCObjcFinalize();
+#endif
+
     // Finalize values last
 	__MCValueFinalize();
 }

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -68,6 +68,7 @@ MC_DLLEXPORT_DEF MCTypeInfoRef kMCPointerTypeInfo;
  * type for CBool as (in theory) it could be any length, and not just a byte.
  */
 
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCVoidTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCBoolTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCCharTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCUCharTypeInfo;
@@ -121,8 +122,8 @@ MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCUIntTypeInfo() { return kMCCUIntTypeInf
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSIntTypeInfo() { return kMCCSIntTypeInfo; }
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongTypeInfo() { return kMCCULongTypeInfo; }
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongTypeInfo() { return kMCCSLongTypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongLongTypeInfo() { return kMCCULongTypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongLongTypeInfo() { return kMCCSLongTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongLongTypeInfo() { return kMCCULongLongTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongLongTypeInfo() { return kMCCSLongLongTypeInfo; }
 
 /**/
 

--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -19,6 +19,322 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCObjcObjectTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef MCObjcObjectTypeInfo() { return kMCObjcObjectTypeInfo; }
+
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCObjcIdTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef MCObjcIdTypeInfo() { return kMCObjcIdTypeInfo; }
+
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCObjcRetainedIdTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef MCObjcRetainedIdTypeInfo() { return kMCObjcRetainedIdTypeInfo; }
+
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCObjcAutoreleasedIdTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef MCObjcAutoreleasedIdTypeInfo() { return kMCObjcAutoreleasedIdTypeInfo; }
+
+struct __MCObjcObjectImpl
+{
+    id object;
+};
+
+static __MCObjcObjectImpl *__MCObjcObjectGet(MCValueRef p_obj)
+{
+    return static_cast<__MCObjcObjectImpl *>(MCValueGetExtraBytesPtr(p_obj));
+}
+
+static void __MCObjcObjectDestroy(MCValueRef p_value)
+{
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(p_value);
+    [t_impl->object release];
+}
+
+static bool __MCObjcObjectCopy(MCValueRef p_value, bool p_release, MCValueRef &r_copy)
+{
+    if (p_release)
+        r_copy = p_value;
+    else
+        r_copy = MCValueRetain(p_value);
+    
+    return true;
+}
+
+static bool __MCObjcObjectEqual(MCValueRef p_left, MCValueRef p_right)
+{
+    if (p_left == p_right)
+        return true;
+    
+    __MCObjcObjectImpl *t_left_impl = __MCObjcObjectGet(p_left);
+    __MCObjcObjectImpl *t_right_impl = __MCObjcObjectGet(p_right);
+    
+    return t_left_impl->object == t_right_impl->object;
+}
+
+static hash_t __MCObjcObjectHash(MCValueRef p_value)
+{
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(p_value);
+    return MCHashPointer(t_impl->object);
+}
+
+bool __MCObjcObjectDescribe(MCValueRef p_value, MCStringRef &r_desc)
+{
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(p_value);
+    return MCStringFormat(r_desc, "<objc object %p>", t_impl->object);
+}
+
+static MCValueCustomCallbacks kMCObjcObjectCustomValueCallbacks =
+{
+    false,
+    __MCObjcObjectDestroy,
+    __MCObjcObjectCopy,
+    __MCObjcObjectEqual,
+    __MCObjcObjectHash,
+    __MCObjcObjectDescribe,
+    
+    nullptr,
+    nullptr,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+/* The Id foreign value is a unmanaged wrapper around 'id' - basically like
+ * Pointer but with a bridge to ObjcObject which explicitly retains its value. */
+
+static void
+objc_id_finalize(void *contents)
+{
+}
+
+static bool
+objc_id_move(void *from, void *to)
+{
+    *static_cast<void **>(to) = *static_cast<void **>(from);
+    return true;
+}
+
+static bool
+objc_id_copy(void *from, void *to)
+{
+    *static_cast<void **>(to) = *static_cast<void **>(from);
+    return true;
+}
+
+static bool
+objc_id_equal(void *from, void *to, bool& r_equal)
+{
+    r_equal = *static_cast<void **>(to) == *static_cast<void **>(to);
+    return true;
+}
+
+static bool
+objc_id_hash(void *value, hash_t& r_hash)
+{
+    r_hash = MCHashPointer(*static_cast<void **>(value));
+    return true;
+}
+
+static bool
+objc_id_describe(void *value, MCStringRef& r_string)
+{
+    return MCStringFormat(r_string, "<objc strong id %p>", *static_cast<void **>(value));
+}
+
+static bool
+objc_retained_id_describe(void *value, MCStringRef& r_string)
+{
+    return MCStringFormat(r_string, "<objc retained id %p>", *static_cast<void **>(value));
+}
+
+static bool
+objc_autoreleased_id_describe(void *value, MCStringRef& r_string)
+{
+    return MCStringFormat(r_string, "<objc autoreleased id %p>", *static_cast<void **>(value));
+}
+
+static bool
+objc_id_import(void *contents, bool p_release, MCValueRef& r_value)
+{
+    MCAssert(!p_release);
+    return MCObjcObjectCreateWithId(*(void **)contents, (MCObjcObjectRef&)r_value);
+}
+
+static bool
+objc_id_export(MCValueRef p_value, bool p_release, void *contents)
+{
+    MCAssert(!p_release);
+    *(void **)contents = MCObjcObjectGetId((MCObjcObjectRef)p_value);
+    return true;
+}
+
+static bool
+objc_retained_id_import(void *contents, bool p_release, MCValueRef& r_value)
+{
+    MCAssert(!p_release);
+    return MCObjcObjectCreateWithRetainedId(*(void **)contents, (MCObjcObjectRef&)r_value);
+}
+
+static bool
+objc_retained_id_export(MCValueRef p_value, bool p_release, void *contents)
+{
+    MCAssert(!p_release);
+    *(void **)contents = MCObjcObjectGetRetainedId((MCObjcObjectRef)p_value);
+    return true;
+}
+
+static bool
+objc_autoreleased_id_import(void *contents, bool p_release, MCValueRef& r_value)
+{
+    MCAssert(!p_release);
+    return MCObjcObjectCreateWithAutoreleasedId(*(void **)contents, (MCObjcObjectRef&)r_value);
+}
+
+static bool
+objc_autoreleased_id_export(MCValueRef p_value, bool p_release, void *contents)
+{
+    MCAssert(!p_release);
+    *(void **)contents = MCObjcObjectGetAutoreleasedId((MCObjcObjectRef)p_value);
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+MC_DLLEXPORT_DEF bool MCObjcObjectCreateWithId(void *p_object, MCObjcObjectRef &r_object)
+{
+    MCObjcObjectRef t_obj;
+    if (!MCValueCreateCustom(kMCObjcObjectTypeInfo,
+                             sizeof(__MCObjcObjectImpl),
+                             t_obj))
+    {
+        return false;
+    }
+    
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(t_obj);
+    t_impl->object = [(id)p_object retain];
+    
+    r_object = t_obj;
+
+    return true;
+}
+
+MC_DLLEXPORT_DEF bool MCObjcObjectCreateWithRetainedId(void *p_object, MCObjcObjectRef &r_object)
+{
+    MCObjcObjectRef t_obj;
+    if (!MCValueCreateCustom(kMCObjcObjectTypeInfo,
+                             sizeof(__MCObjcObjectImpl),
+                             t_obj))
+    {
+        return false;
+    }
+    
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(t_obj);
+    t_impl->object = (id)p_object;
+
+    r_object = t_obj;
+    
+    return true;
+}
+
+MC_DLLEXPORT_DEF bool MCObjcObjectCreateWithAutoreleasedId(void *p_object, MCObjcObjectRef &r_object)
+{
+    return MCObjcObjectCreateWithId(p_object, r_object);
+}
+
+MC_DLLEXPORT_DEF void *MCObjcObjectGetId(const MCObjcObjectRef p_obj)
+{
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(p_obj);
+    return t_impl->object;
+}
+
+MC_DLLEXPORT_DEF void *MCObjcObjectGetRetainedId(const MCObjcObjectRef p_obj)
+{
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(p_obj);
+    return [(id)t_impl->object retain];
+}
+
+MC_DLLEXPORT_DEF void *MCObjcObjectGetAutoreleasedId(const MCObjcObjectRef p_obj)
+{
+    __MCObjcObjectImpl *t_impl = __MCObjcObjectGet(p_obj);
+    return [[(id)t_impl->object retain] autorelease];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool __MCObjcInitialize(void)
+{
+    if (!MCNamedCustomTypeInfoCreate(MCNAME("com.livecode.objc.ObjcObject"),
+                                     kMCNullTypeInfo,
+                                     &kMCObjcObjectCustomValueCallbacks,
+                                     kMCObjcObjectTypeInfo))
+    {
+        return false;
+    }
+    
+    MCForeignPrimitiveType t_prim_type = kMCForeignPrimitiveTypePointer;
+    MCForeignTypeDescriptor d =
+    {
+        sizeof(id),
+        kMCNullTypeInfo,
+        kMCObjcObjectTypeInfo,
+        &t_prim_type,
+        1,
+        nullptr, /* initialize */
+        objc_id_finalize, /* finalize */
+        nullptr, /* defined */
+        objc_id_move,
+        objc_id_copy,
+        objc_id_equal,
+        objc_id_hash,
+        objc_id_import,
+        objc_id_export,
+        objc_id_describe,
+    };
+    if (!MCNamedForeignTypeInfoCreate(MCNAME("com.livecode.objc.Id"),
+                                      &d,
+                                      kMCObjcIdTypeInfo))
+    {
+        return false;
+    }
+    
+    d.doimport = objc_retained_id_import;
+    d.doexport = objc_retained_id_export;
+    d.describe = objc_retained_id_describe;
+    if (!MCNamedForeignTypeInfoCreate(MCNAME("com.livecode.objc.RetainedId"),
+                                      &d,
+                                      kMCObjcRetainedIdTypeInfo))
+    {
+        return false;
+    }
+    
+    d.doimport = objc_autoreleased_id_import;
+    d.doexport = objc_autoreleased_id_export;
+    d.describe = objc_autoreleased_id_describe;
+    if (!MCNamedForeignTypeInfoCreate(MCNAME("com.livecode.objc.AutoreleasedId"),
+                                      &d,
+                                      kMCObjcAutoreleasedIdTypeInfo))
+    {
+        return false;
+    }
+    
+    return true;
+}
+
+void __MCObjcFinalize(void)
+{
+    MCValueRelease(kMCObjcIdTypeInfo);
+    MCValueRelease(kMCObjcRetainedIdTypeInfo);
+    MCValueRelease(kMCObjcAutoreleasedIdTypeInfo);
+    MCValueRelease(kMCObjcObjectTypeInfo);
+}
+
+extern "C" bool com_livecode_objc_Initialize(void)
+{
+    return true;
+}
+
+extern "C" void com_livecode_objc_Finalize(void)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 NSString *MCStringConvertToAutoreleasedNSString(MCStringRef p_string_ref)
 {
 	CFStringRef t_string;
@@ -50,3 +366,6 @@ void MCCFAutorelease(const void *p_object)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -591,6 +591,9 @@ void __MCStreamFinalize(void);
 bool __MCJavaInitialize(void);
 void __MCJavaFinalize(void);
 
+bool __MCObjcInitialize(void);
+void __MCObjcFinalize(void);
+
 /* Default implementations of each of the function members of struct &
  * MCValueCustomCallbacks */
 MCTypeInfoRef __MCCustomValueResolveTypeInfo(__MCValue *p_value);

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1204,7 +1204,9 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 			t_value = va_arg(p_args, MCValueRef);
 			
 			MCAutoStringRef t_string;
-			if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeString)
+			if (t_value == nullptr)
+                t_string = MCSTR("(null)");
+            else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeString)
 				t_string = (MCStringRef)t_value;
             else
 				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);

--- a/libscript/src/objc.lcb
+++ b/libscript/src/objc.lcb
@@ -1,4 +1,4 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2017 LiveCode Ltd.
  
  This file is part of LiveCode.
  
@@ -14,20 +14,18 @@
  You should have received a copy of the GNU General Public License
  along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-#ifndef __MC_FOUNDATION_OBJC__
-#define __MC_FOUNDATION_OBJC__
+/**
+This module provides utility handlers for converting to and from Obj-C types.
 
-#ifndef __MC_FOUNDATION__
-#include <foundation.h>
-#endif
+*/
+module com.livecode.objc
 
-#ifdef __OBJC__
-#import <Foundation/NSString.h>
-#import <Foundation/NSData.h>
+use com.livecode.foreign
 
-NSString *MCStringConvertToAutoreleasedNSString(MCStringRef string);
-NSString *MCNameConvertToAutoreleasedNSString(MCNameRef name);
-NSData *MCDataConvertToAutoreleasedNSData(MCDataRef data);
-#endif
+public foreign type ObjcObject binds to "MCObjcObjectTypeInfo"
+public foreign type ObjcId binds to "MCObjcIdTypeInfo"
+public foreign type ObjcRetainedId binds to "MCObjcRetainedIdTypeInfo"
+public foreign type ObjcAutoreleasedId binds to "MCObjcAutoreleasedIdTypeInfo"
 
-#endif
+end module
+

--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -316,6 +316,15 @@ MCScriptThrowUnableToResolveForeignHandlerError(MCScriptInstanceRef p_instance,
 }
 
 bool
+MCScriptThrowUnknownForeignLanguageError(void)
+{
+	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
+								 "reason",
+								 MCSTR("unknown language"),
+								 nil);
+}
+
+bool
 MCScriptThrowUnknownForeignCallingConventionError(void)
 {
 	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
@@ -330,15 +339,6 @@ MCScriptThrowMissingFunctionInForeignBindingError(void)
 	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
 								 "reason",
 								 MCSTR("no function specified in binding string"),
-								 nil);
-}
-
-bool
-MCScriptThrowClassNotAllowedInCBindingError(void)
-{
-	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
-								 "reason",
-								 MCSTR("class not allowed in c binding string"),
 								 nil);
 }
 

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -142,9 +142,9 @@ public:
         switch(p_handler->language)
         {
         case kMCScriptForeignHandlerLanguageJava:
-			MCJavaCallJNIMethod(p_handler -> java . class_name,
-								p_handler -> java . method_id,
-								p_handler -> java . call_type,
+			MCJavaCallJNIMethod(p_handler->java.class_name,
+								p_handler->java.method_id,
+								p_handler->java.call_type,
 								p_handler_signature,
 								p_result_slot_ptr,
 								m_argument_values,
@@ -152,19 +152,19 @@ public:
             break;
         
         case kMCScriptForeignHandlerLanguageC:
-			ffi_call((ffi_cif *)p_handler -> native . function_cif,
-					 (void(*)())p_handler -> native . function,
+			ffi_call((ffi_cif *)p_handler ->c.function_cif,
+					 (void(*)())p_handler ->c.function,
 					 p_result_slot_ptr,
 					 m_argument_values);
             break;
             
         case kMCScriptForeignHandlerLanguageBuiltinC:
-            ((void(*)(void*, void**))p_handler->native.function)(p_result_slot_ptr,
+            ((void(*)(void*, void**))p_handler->builtin_c.function)(p_result_slot_ptr,
                     m_argument_values);
             break;
         
         case kMCScriptForeignHandlerLanguageObjC:
-            return MCErrorThrowUnimplemented(MCSTR("objc ffi"));
+            return MCScriptThrowObjCBindingNotImplemented();
             
         case kMCScriptForeignHandlerLanguageUnknown:
             MCUnreachableReturn(false);

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -260,6 +260,7 @@ void MCScriptDestroyModule(MCScriptModuleRef self)
             case kMCScriptForeignHandlerLanguageBuiltinC:
                 break;
             case kMCScriptForeignHandlerLanguageObjC:
+                MCMemoryDelete(t_def->objc.function_cif);
                 break;
             case kMCScriptForeignHandlerLanguageJava:
                 MCValueRelease(t_def->java.class_name);

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -251,6 +251,20 @@ void MCScriptDestroyModule(MCScriptModuleRef self)
         {
             MCScriptForeignHandlerDefinition *t_def;
             t_def = static_cast<MCScriptForeignHandlerDefinition *>(self -> definitions[i]);
+            switch(t_def->language)
+            {
+            case kMCScriptForeignHandlerLanguageUnknown:
+                break;
+            case kMCScriptForeignHandlerLanguageC:
+                break;
+            case kMCScriptForeignHandlerLanguageBuiltinC:
+                break;
+            case kMCScriptForeignHandlerLanguageObjC:
+                break;
+            case kMCScriptForeignHandlerLanguageJava:
+                MCValueRelease(t_def->java.class_name);
+                break;
+            }
         }
     
     // Remove ourselves from the context slot owners list.

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -336,14 +336,32 @@ enum MCJavaCallType {
     MCJavaCallTypeStaticSetter
 };
 
+/* MCScriptForeignHandlerLanguage describes the type of foreign handler which
+ * has been bound - based on language. */
+enum MCScriptForeignHandlerLanguage
+{
+    /* The handler has not yet been bound, or failed to bind */
+    kMCScriptForeignHandlerLanguageUnknown,
+    
+    /* The handler should be called using libffi */
+    kMCScriptForeignHandlerLanguageC,
+    
+    /* The handler has a lc-compile generated shim, so can be called directly */
+    kMCScriptForeignHandlerLanguageBuiltinC,
+    
+    /* The handler should be called using objc_msgSend */
+    kMCScriptForeignHandlerLanguageObjC,
+    
+    /* The handler should be called using the JNI */
+    kMCScriptForeignHandlerLanguageJava,
+};
+
 struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
 {
     MCStringRef binding;
     
     // Bound function information - not pickled.
-    bool is_java: 1;
-    bool is_bound: 1;
-    bool is_builtin: 1;
+    MCScriptForeignHandlerLanguage language;
     
     union
     {

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -360,6 +360,17 @@ enum MCScriptForeignHandlerLanguage
     kMCScriptForeignHandlerLanguageJava,
 };
 
+/* MCScriptForeignHandlerObjcCallType describes how to call the objective-c
+ * method. */
+enum MCScriptForeignHandlerObjcCallType
+{
+    /* Call the method using method_invoke on the instance */
+    kMCScriptForeignHandlerObjcCallTypeInstanceMethod,
+    
+    /* Call the method using method_invoke on the class instance */
+    kMCScriptForeignHandlerObjcCallTypeClassMethod,
+};
+
 struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
 {
     MCStringRef binding;
@@ -380,7 +391,8 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
         } builtin_c;
         struct
         {
-            bool is_class_method;
+            MCScriptForeignHandlerObjcCallType call_type;
+            void *objc_class;
             void *objc_selector;
             void *function_cif;
         } objc;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -372,9 +372,18 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
         struct
         {
             void *function;
-            void *function_argtypes;
             void *function_cif;
-        } native;
+        } c;
+        struct
+        {
+            void *function;
+        } builtin_c;
+        struct
+        {
+            bool is_class_method;
+            void *objc_selector;
+            void *function_cif;
+        } objc;
         struct
         {
             MCNameRef class_name;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -333,7 +333,11 @@ enum MCJavaCallType {
     MCJavaCallTypeGetter,
     MCJavaCallTypeSetter,
     MCJavaCallTypeStaticGetter,
-    MCJavaCallTypeStaticSetter
+    MCJavaCallTypeStaticSetter,
+    
+    /* This value is used to indicate that the call type was not known - it is
+     * only used internally in libscript. */
+    MCJavaCallTypeUnknown = -1,
 };
 
 /* MCScriptForeignHandlerLanguage describes the type of foreign handler which
@@ -631,13 +635,13 @@ MCScriptThrowUnableToResolveForeignHandlerError(MCScriptInstanceRef instance,
 												MCScriptForeignHandlerDefinition *handler);
 
 bool
+MCScriptThrowUnknownForeignLanguageError(void);
+
+bool
 MCScriptThrowUnknownForeignCallingConventionError(void);
 
 bool
 MCScriptThrowMissingFunctionInForeignBindingError(void);
-
-bool
-MCScriptThrowClassNotAllowedInCBindingError(void);
 
 bool
 MCScriptThrowUnableToLoadForiegnLibraryError(void);

--- a/libscript/stdscript-sources.gypi
+++ b/libscript/stdscript-sources.gypi
@@ -29,6 +29,7 @@
 			'src/stream.lcb',
 			'src/string.lcb',
 			'src/system.lcb',
+			'src/objc.lcb',
 			'src/type.lcb',
 			'src/type-convert.lcb',
 			'src/unittest.lcb',

--- a/tests/lcb/vm/foreign-binding.lcb
+++ b/tests/lcb/vm/foreign-binding.lcb
@@ -32,34 +32,6 @@ end handler
 
 ---------
 
--- NEED TO CHECK class and instance methods, existant and non-existant
--- also protocols and superclasses.
-
-foreign handler CreateObjCObject() returns Pointer binds to "objc:NSObject.+alloc"
-foreign handler CreateObjCObjectDoesntExist() returns Pointer binds to "objc:NSObject.-foobar"
-
-private handler TestForeignBinding_NonExistantObjC()
-   unsafe
-      CreateObjCObjectDoesntExist()
-   end unsafe
-end handler
-
-private handler TestForeignBinding_ExistantObjC()
-   unsafe
-      CreateObjCObject()
-   end unsafe
-end handler
-
-public handler TestForeignBinding_ObjC()
-   MCUnitTestHandlerThrowsNamed(TestForeignBinding_NonExistantObjC, "livecode.lang.ForeignHandlerBindingError", "Failure to bind to non-existant objc function throws error")
-   MCUnitTestHandlerDoesntThrow(TestForeignBinding_ExistantObjC, "Binding to existant objc function does not throw error")
-
-   test "Non-existant objc function gives nothing as handler value" when CreateObjCObjectDoesntExist is nothing
-   test "Existant objc function gives non-nothing as handler value" when CreateObjCObject is not nothing
-end handler
-
----------
-
 foreign handler CreateJavaObject() returns JObject binds to "java:java.lang.Object>new()"
 foreign handler CreateJavaObjectDoesntExist() returns JObject binds to "java:java.lang.Object>new_doesnt_exist()"
 

--- a/tests/lcb/vm/foreign-binding.lcb
+++ b/tests/lcb/vm/foreign-binding.lcb
@@ -32,6 +32,34 @@ end handler
 
 ---------
 
+-- NEED TO CHECK class and instance methods, existant and non-existant
+-- also protocols and superclasses.
+
+foreign handler CreateObjCObject() returns Pointer binds to "objc:NSObject.+alloc"
+foreign handler CreateObjCObjectDoesntExist() returns Pointer binds to "objc:NSObject.-foobar"
+
+private handler TestForeignBinding_NonExistantObjC()
+   unsafe
+      CreateObjCObjectDoesntExist()
+   end unsafe
+end handler
+
+private handler TestForeignBinding_ExistantObjC()
+   unsafe
+      CreateObjCObject()
+   end unsafe
+end handler
+
+public handler TestForeignBinding_ObjC()
+   MCUnitTestHandlerThrowsNamed(TestForeignBinding_NonExistantObjC, "livecode.lang.ForeignHandlerBindingError", "Failure to bind to non-existant objc function throws error")
+   MCUnitTestHandlerDoesntThrow(TestForeignBinding_ExistantObjC, "Binding to existant objc function does not throw error")
+
+   test "Non-existant objc function gives nothing as handler value" when CreateObjCObjectDoesntExist is nothing
+   test "Existant objc function gives non-nothing as handler value" when CreateObjCObject is not nothing
+end handler
+
+---------
+
 foreign handler CreateJavaObject() returns JObject binds to "java:java.lang.Object>new()"
 foreign handler CreateJavaObjectDoesntExist() returns JObject binds to "java:java.lang.Object>new_doesnt_exist()"
 

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -1,0 +1,91 @@
+module __VMTEST.interop_objc
+
+use com.livecode.foreign
+use com.livecode.objc
+use com.livecode.__INTERNAL._testlib
+
+---------
+
+__safe foreign handler NSObjectAlloc() returns ObjcRetainedId binds to "objc:NSObject.+alloc"
+
+__safe foreign handler NSNumberCreateWithInt(in pInt as CInt) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithInt:"
+__safe foreign handler NSNumberGetIntValue(in pObj as ObjcId) returns CInt binds to "objc:NSNumber.intValue"
+__safe foreign handler NSNumberCreateWithLongLong(in pInt as CLongLong) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithLongLong:"
+__safe foreign handler NSNumberGetLongLongValue(in pObj as ObjcId) returns CLongLong binds to "objc:NSNumber.longLongValue"
+__safe foreign handler NSNumberCreateWithFloat(in pInt as CFloat) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithFloat:"
+__safe foreign handler NSNumberGetFloatValue(in pObj as ObjcId) returns CFloat binds to "objc:NSNumber.floatValue"
+__safe foreign handler NSNumberCreateWithDouble(in pInt as CDouble) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithDouble:"
+__safe foreign handler NSNumberGetDoubleValue(in pObj as ObjcId) returns CDouble binds to "objc:NSNumber.doubleValue"
+
+---------
+
+-- NEED TO CHECK class and instance methods, existant and non-existant
+-- also protocols and superclasses.
+
+__safe foreign handler CreateObjCObjectDoesntExist() returns ObjcId binds to "objc:NSObject.-foobar"
+
+private handler TestObjcInterop_NonExistantObjC()
+    CreateObjCObjectDoesntExist()
+end handler
+
+private handler TestObjcInterop_ExistantObjC()
+	variable tObj as ObjcObject
+	put NSObjectAlloc() into tObj
+end handler
+
+public handler TestObjcInterop_Binding()
+   MCUnitTestHandlerThrowsNamed(TestObjcInterop_NonExistantObjC, "livecode.lang.ForeignHandlerBindingError", "Failure to bind to non-existant objc function throws error")
+   MCUnitTestHandlerDoesntThrow(TestObjcInterop_ExistantObjC, "Binding to existant objc function does not throw error")
+
+   test "Non-existant objc function gives nothing as handler value" when CreateObjCObjectDoesntExist is nothing
+   test "Existant objc function gives non-nothing as handler value" when NSObjectAlloc is not nothing
+end handler
+
+---------
+
+__safe foreign handler NSObjectGetRetainCount(in pObj as ObjcId) returns CULong binds to "objc:NSObject.-retainCount"
+__safe foreign handler NSObjectGetSelf(in pObj as ObjcId) returns ObjcId binds to "objc:NSObject.-self"
+
+public handler TestObjInterop_ObjcObjectLifetime()
+	/* Test that ObjcRetainedId gives its reference to ObjcObject */
+	variable tObjcObjectFromRetainedId as ObjcObject
+	put NSObjectAlloc() into tObjcObjectFromRetainedId
+	test "retained id into objc object doesn't retain" when NSObjectGetRetainCount(tObjcObjectFromRetainedId) is 1
+
+	/* Test that ObjcId copies its reference to ObjcObject */
+	variable tObjcObjectFromId as ObjcObject
+	put NSObjectGetSelf(tObjcObjectFromRetainedId) into tObjcObjectFromId
+	test "id into objc object retains" when NSObjectGetRetainCount(tObjcObjectFromId) is 2
+
+	/* Test that ObjcAutoreleasedId copies its reference to ObjcObject */
+	variable tObjcObjectFromAutoreleasedId as ObjcObject
+	put NSNumberCreateWithDouble(3.14159) into tObjcObjectFromAutoreleasedId
+	test "autoreleased id into objc object retains" when NSObjectGetRetainCount(tObjcObjectFromAutoreleasedId) is 2
+end handler
+
+---------
+
+
+public handler TestObjInterop_RoundtripNumber()
+	variable tIntObj as ObjcObject
+	put NSNumberCreateWithInt(314159) into tIntObj
+	test "NSNumber roundtrip CInt" when NSNumberGetIntValue(tIntObj) is 314159
+
+	variable tLongLongObj as ObjcObject
+	put NSNumberCreateWithLongLong(314159) into tLongLongObj
+	test "NSNumber roundtrip CLongLong" when NSNumberGetLongLongValue(tLongLongObj) is 314159
+
+	variable tFloatObj as ObjcObject
+	put NSNumberCreateWithFloat(314159) into tFloatObj
+	test "NSNumber roundtrip CFloat" when NSNumberGetFloatValue(tFloatObj) is 314159
+
+	variable tDoubleObj as ObjcObject
+	put NSNumberCreateWithDouble(314159) into tDoubleObj
+	test "NSNumber roundtrip CDouble" when NSNumberGetDoubleValue(tDoubleObj) is 314159
+end handler
+
+--------
+
+
+
+end module


### PR DESCRIPTION
This patch implements objective-c FFI in LCB.

The current implementation uses three 'foreign value' types to describe the lifetime of Obj-C id types - these are unsafe, but become safe as long as they come from and are put into ObjcObject typed variables.

This could be fixed by either forcing bridging from those types when they go into a slot typed as 'any' / 'optional any'; or by reworking the foreign value methods to allow a 'copy constructor' and refining the action of import/export. This would then allow the three foreign value types to be implemented safely.

TODO:
  - struct types are required for many ObjC APIs
  - delegate creation
  - sort out safety of Id types
  - support for char* / const char* types in methods
  - check safety works with alloc then init using retainedId

Note: This is an st-git stack and needs cleaned up.