### PR TITLE
[[ Bug 19927 ]] Allow ignorable whitespace after continuation char

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -79,7 +79,10 @@ A LiveCode builder statement or declaration can be continued onto
 multiple lines of code by placing the line continuation character `\`
 at the end each line.
 
-- **Line continuation**: \\(\n|\r\n|\r)
+- **Line continuation**: \\[\t ]*(\n|\r\n|\r)
+
+> **Note:** Tab and space characters are allowed after the `\` and before the
+> newline, but no other characters.
 
 > **Note:** A line continuation cannot occur within a comment.
 

--- a/docs/lcb/notes/19927.md
+++ b/docs/lcb/notes/19927.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Tools
+## lc-compile
+
+# [19927] Allow ignorable whitespace after continuation chars

--- a/tests/lcb/compiler/frontend/line-continuation.compilertest
+++ b/tests/lcb/compiler/frontend/line-continuation.compilertest
@@ -25,6 +25,15 @@ end module
 %SUCCESS
 %ENDTEST
 
+%% Continuation characters may be followed by any number of spaces and tabs
+%TEST ContinuationWhiteSpace
+module \ 	 	
+		compiler_test
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
 %% Line continuation characters can't occur within a line, because
 %% they consume a following newline.
 %TEST ContinuationNoNewline

--- a/toolchain/lc-compile/src/SEPARATOR.t
+++ b/toolchain/lc-compile/src/SEPARATOR.t
@@ -1,4 +1,4 @@
-\\(\n|\r|\r\n) {
+\\[ \t]*(\n|\r|\r\n) {
     AdvanceCurrentPosition(1);
     AdvanceCurrentPositionToNextRow();
 }


### PR DESCRIPTION
This patch modifies the SEPARATOR rule in lc-compile's tokenizer
so that any number of ignorable whitespace (tabs and spaces) can
appear after the continuation char, but before the newline char.