### PR TITLE
[Bug 18447] Moved misplaced text in iconGravity dictionary entry

### DIFF
--- a/docs/dictionary/property/iconGravity.lcdoc
+++ b/docs/dictionary/property/iconGravity.lcdoc
@@ -22,8 +22,7 @@ set the iconGravity of button "next" to "top"
 Value (enum):
 A string representing the desired layout of the icon of the button.
 
--   (empty): This property has no effect and placement of the icon
-    follows previous engine rules (default)
+-   (empty): This property has no effect and placement of the icon follows previous engine rules (default)
 -   left: Renders the icon at the middle left side of the button.
 -   top: Renders the icon at the middle top of the button.
 -   right: Renders the icon at the middle right of the button.

--- a/docs/notes/bugfix-18447.md
+++ b/docs/notes/bugfix-18447.md
@@ -1,0 +1,1 @@
+# Moved misplaced text in iconGravity dictionary entry


### PR DESCRIPTION
Removed newline to fix problem where half of the information for the (empty) value would appear above the list of value.