### PR TITLE
[[ Travis ]] Work around issue with new Ubuntu Trusty images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@
 sudo: required
 dist: trusty
 
+# FIXME: This will not work from September 2017
+group: deprecated-2017Q2
+
 # Build on both Linux and OSX
 os:
   - linux


### PR DESCRIPTION
This is a temporary fix that will expire in September 2017