### PR TITLE
[[ Bug 19929 ]] Fix crash with invalid MCmousestackptr

### DIFF
--- a/docs/notes/bugfix-19929.md
+++ b/docs/notes/bugfix-19929.md
@@ -1,0 +1,1 @@
+# Fix crash when using click command with invalid mouse stack or click stack

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -373,11 +373,15 @@ void MCUIDC::setmouseloc(MCStack *p_target, MCPoint p_loc)
 
 void MCUIDC::getmouseloc(MCStack *&r_target, MCPoint &r_loc)
 {
-	r_target = MCmousestackptr;
-	r_loc = MCPointMake(MCmousex, MCmousey);
-
-	if (MCmousestackptr)
-		r_loc = MCmousestackptr->stacktowindowloc(r_loc);
+    r_loc = MCPointMake(MCmousex, MCmousey);
+    
+    if (MCmousestackptr)
+    {
+        r_target = MCmousestackptr;
+        r_loc = MCmousestackptr->stacktowindowloc(r_loc);
+    }
+    else
+        r_target = nil;
 }
 
 void MCUIDC::setclickloc(MCStack *p_target, MCPoint p_loc)
@@ -395,11 +399,15 @@ void MCUIDC::setclickloc(MCStack *p_target, MCPoint p_loc)
 
 void MCUIDC::getclickloc(MCStack *&r_target, MCPoint &r_loc)
 {
-	r_target = MCclickstackptr;
-	r_loc = MCPointMake(MCclicklocx, MCclicklocy);
-
-	if (MCclickstackptr)
-		r_loc = MCclickstackptr->stacktowindowloc(r_loc);
+    r_loc = MCPointMake(MCclicklocx, MCclicklocy);
+    
+    if (MCclickstackptr)
+    {
+        r_target = MCclickstackptr;
+        r_loc = MCclickstackptr->stacktowindowloc(r_loc);
+    }
+    else
+        r_target = nil;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch fixes a crash when using the click command and the mouse
stack is invalid. The fix was also applied to getclickloc due to the
likelihood a similar crash could occur there.

(cherry picked from commit 32e29f65925a341ebdf9198ca1d94b0e6a5e7e86)