### PR TITLE
[[ Bug 18583 ]] Oracle DB driver missing from business edition

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -807,8 +807,6 @@ component Databases.Linux
 	declare dbdriver "ODBC" using dbodbc.so
 	declare dbdriver "PostgreSQL" using dbpostgresql.so
 	declare dbdriver "SqLite" using dbsqlite.so
-	if TargetEdition is "Business" then
-		declare dbdriver "Oracle" using dboracle.so
 
 //////////
 
@@ -820,15 +818,11 @@ component Databases.Windows
 		executable windows:dbodbc.dll
 		executable windows:dbpostgresql.dll
 		executable windows:dbsqlite.dll
-		if TargetEdition is "Business" then
-			executable windows:dboracle.dll
 	declare external "Database" using revdb.dll
 	declare dbdriver "MySQL" using dbmysql.dll
 	declare dbdriver "ODBC" using dbodbc.dll
 	declare dbdriver "PostgreSQL" using dbpostgresql.dll
 	declare dbdriver "SqLite" using dbsqlite.dll
-	if TargetEdition is "Business" then
-		declare dbdriver "Oracle" using dboracle.dll
 	
 //////////
 
@@ -840,15 +834,11 @@ component Databases.MacOSX
 		executable macosx:dbodbc.bundle
 		executable macosx:dbpostgresql.bundle
 		executable macosx:dbsqlite.bundle
-		if TargetEdition is "Business" then
-			executable macosx:dboracle.bundle
 	declare external "Database" using revdb.bundle
 	declare dbdriver "MySQL" using dbmysql.bundle
 	declare dbdriver "ODBC" using dbodbc.bundle
 	declare dbdriver "PostgreSQL" using dbpostgresql.bundle
 	declare dbdriver "SqLite" using dbsqlite.bundle
-	if TargetEdition is "Business" then
-		declare dbdriver "Oracle" using dboracle.bundle
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -807,7 +807,7 @@ component Databases.Linux
 	declare dbdriver "ODBC" using dbodbc.so
 	declare dbdriver "PostgreSQL" using dbpostgresql.so
 	declare dbdriver "SqLite" using dbsqlite.so
-	ifnot TargetEdition is "Community" then
+	if TargetEdition is "Business" then
 		declare dbdriver "Oracle" using dboracle.so
 
 //////////
@@ -820,14 +820,14 @@ component Databases.Windows
 		executable windows:dbodbc.dll
 		executable windows:dbpostgresql.dll
 		executable windows:dbsqlite.dll
-		ifnot TargetEdition is "Community" then
-			executable private:oracle_libraries/dboracle.dll
+		if TargetEdition is "Business" then
+			executable windows:dboracle.dll
 	declare external "Database" using revdb.dll
 	declare dbdriver "MySQL" using dbmysql.dll
 	declare dbdriver "ODBC" using dbodbc.dll
 	declare dbdriver "PostgreSQL" using dbpostgresql.dll
 	declare dbdriver "SqLite" using dbsqlite.dll
-	ifnot TargetEdition is "Community" then
+	if TargetEdition is "Business" then
 		declare dbdriver "Oracle" using dboracle.dll
 	
 //////////
@@ -840,14 +840,14 @@ component Databases.MacOSX
 		executable macosx:dbodbc.bundle
 		executable macosx:dbpostgresql.bundle
 		executable macosx:dbsqlite.bundle
-		ifnot TargetEdition is "Community" then
-			executable private:oracle_libraries/dboracle.bundle
+		if TargetEdition is "Business" then
+			executable macosx:dboracle.bundle
 	declare external "Database" using revdb.bundle
 	declare dbdriver "MySQL" using dbmysql.bundle
 	declare dbdriver "ODBC" using dbodbc.bundle
 	declare dbdriver "PostgreSQL" using dbpostgresql.bundle
 	declare dbdriver "SqLite" using dbsqlite.bundle
-	ifnot TargetEdition is "Community" then
+	if TargetEdition is "Business" then
 		declare dbdriver "Oracle" using dboracle.bundle
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/docs/notes/bugfix-18583.md
+++ b/docs/notes/bugfix-18583.md
@@ -1,1 +1,0 @@
-# Oracle DB driver missing from business edition

--- a/docs/notes/bugfix-18583.md
+++ b/docs/notes/bugfix-18583.md
@@ -1,0 +1,1 @@
+# Oracle DB driver missing from business edition


### PR DESCRIPTION
The oracle driver appears to be output into the standard bin folder
(rather than in the private repo folder). The installer manifest has
been updated to reflect this, as well modified to ensure the oracle
driver is included in business only (and not indy).