### PR TITLE
[[ Bug 19936 ]] Always create a window mask on Mac

### DIFF
--- a/docs/notes/bugfix-19936.md
+++ b/docs/notes/bugfix-19936.md
@@ -1,0 +1,1 @@
+# Ensure window masks with no transparency still work on Mac

--- a/engine/src/desktop-image.cpp
+++ b/engine/src/desktop-image.cpp
@@ -45,9 +45,6 @@ MCWindowShape *MCImage::makewindowshape(const MCGIntegerSize &p_size)
 	t_success = lockbitmap(true, true, &p_size, t_bitmap);
 	
 	if (t_success)
-		t_success = MCImageBitmapHasTransparency(t_bitmap);
-	
-	if (t_success)
 	{
 		t_width = t_bitmap->width;
 		t_height = t_bitmap->height;


### PR DESCRIPTION
This patch fixes a bug which prevented using an image with no
transparency as a window shape. This is because it was not
creating a mask on mac if the image had no transparency, an
artifact from the port from Cocoa where (prior to that) an
image with no transparency would use a region based window mask
which Cocoa doesn't support.