### PR TITLE
[[ Bug 19948 ]] Fix LCB sector command

### DIFF
--- a/engine/src/image_rep_mutable.cpp
+++ b/engine/src/image_rep_mutable.cpp
@@ -1466,8 +1466,8 @@ MCRectangle MCMutableImageRep::drawoval()
 	t_center.y = newrect.y + 0.5 * newrect.height;
 
 	MCGSize t_radii;
-	t_radii.width = newrect.width;
-	t_radii.height = newrect.height;
+	t_radii.width = newrect.width * 0.5;
+	t_radii.height = newrect.height * 0.5;
 
 	MCGPathRef t_path = nil;
 	/* UNCHECKED */ MCGPathCreateMutable(t_path);

--- a/libgraphics/src/path.cpp
+++ b/libgraphics/src/path.cpp
@@ -488,8 +488,8 @@ void MCGPathAddArc(MCGPathRef self, MCGPoint p_center, MCGSize p_radii, MCGFloat
 		{
 			// Use Skia implementation
 			SkRect t_bounds;
-			t_bounds = SkRect::MakeXYWH(MCGCoordToSkCoord(p_center . x - (p_radii . width * 0.5f)), MCGCoordToSkCoord(p_center . y - (p_radii . height * 0.5f)),
-			                            MCGFloatToSkScalar(p_radii . width), MCGFloatToSkScalar(p_radii . height));
+			t_bounds = SkRect::MakeXYWH(MCGCoordToSkCoord(p_center . x - p_radii . width), MCGCoordToSkCoord(p_center . y - p_radii . height),
+			                            MCGFloatToSkScalar(p_radii . width * 2.0), MCGFloatToSkScalar(p_radii . height * 2.0));
 			self -> path -> addArc(t_bounds, MCGFloatToSkScalar(p_start_angle), MCGFloatToSkScalar(p_finish_angle - p_start_angle));
 		}
 	}


### PR DESCRIPTION
This patch reverts a change made to fix Bug 17969 - moving the
fix to the paint tools code in MCImageMutableRep.