### PR TITLE
[[ Bug 19950 ]] Fix crash on invalid object in event queue

### DIFF
--- a/docs/notes/bugfix-19950.md
+++ b/docs/notes/bugfix-19950.md
@@ -1,0 +1,1 @@
+# Fix crash due to invalid object in event queue

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -316,8 +316,11 @@ static void MCEventQueueDispatchEvent(MCEvent *p_event)
 	case kMCEventTypeWindowReshape:
     {
 		MCStackHandle t_stack = t_event->window.stack;
-		t_stack->view_setbackingscale(t_event->window.scale);
-		t_stack->view_configure(true);
+        if (t_stack.IsValid())
+        {
+            t_stack->view_setbackingscale(t_event->window.scale);
+            t_stack->view_configure(true);
+        }
 		break;
     }
 			
@@ -916,10 +919,14 @@ bool MCEventQueuePostWindowReshape(MCStack *p_stack, MCGFloat p_backing_scale)
 	t_event = nil;
 	for(MCEvent *t_new_event = s_first_event; t_new_event != nil; t_new_event = t_new_event -> next)
     {
-		if (t_new_event -> type == kMCEventTypeWindowReshape
-			&& MCStackHandle(t_new_event->window.stack) == p_stack)
+        MCStackHandle t_stack = t_new_event->window.stack;
+        if (t_stack.IsValid())
         {
-			t_event = t_new_event;
+            if (t_new_event -> type == kMCEventTypeWindowReshape
+                && t_stack == p_stack)
+            {
+                t_event = t_new_event;
+            }
         }
     }
 

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1506,6 +1506,11 @@ void MCStack::removereferences()
         else
             i++;
     
+    // COCOA-TODO: Remove dependence on ifdef
+#if !defined(_MAC_DESKTOP)
+    MCEventQueueFlush(this);
+#endif
+    
     MCObject::removereferences();
 }
 


### PR DESCRIPTION
This patch ensures that stacks are flushed from the event queue when
they are removed from the object tree. It also ensures that object
handles are checked for validity before use where the crash occured
in MCEventQueuePostWindowReshape.

(cherry picked from commit 8d3c45b53385bbb96d71625dd8243a31b62b0b6b)