### PR TITLE
[[ Bug 19962 ]] Various fixes and updates to lc-compile-ffi-java

### DIFF
--- a/docs/lcb/notes/feature-jchar.md
+++ b/docs/lcb/notes/feature-jchar.md
@@ -1,0 +1,5 @@
+# LiveCode Builder Standard Library
+## Foreign function interface
+
+* The Java integer primtive type JChar has been added. 
+  This maps to uint16_t.

--- a/libscript/src/java.lcb
+++ b/libscript/src/java.lcb
@@ -36,6 +36,7 @@ use com.livecode.foreign
 
 public type JBoolean is Bool
 public type JByte is Int8
+public type JChar is UInt16
 public type JShort is Int16
 public type JInt is Int32
 public type JLong is Int64

--- a/toolchain/lc-compile-ffi-java/src/generate.g
+++ b/toolchain/lc-compile-ffi-java/src/generate.g
@@ -267,7 +267,7 @@
 
 'rule' OutputMethodBindingStringInstance(ClassType, MethodName, Signature, InstanceModifier):
         TypeToQualifiedName(ClassType -> QualifiedClass)
-		OutputWriteI(" binds to \"java:", QualifiedClass, ">")
+		OutputWriteI(" \\\nbinds to \"java:", QualifiedClass, ">")
 		OutputWriteI("", MethodName, "")
 		OutputJavaSignature(Signature)
         (|
@@ -281,7 +281,7 @@
 
 	'rule' OutputConstructorBindingString(ClassType, MethodName, Signature):
         TypeToQualifiedName(ClassType -> QualifiedClass)
-		OutputWriteI(" binds to \"java:", QualifiedClass, ">")
+		OutputWriteI(" \\\nbinds to \"java:", QualifiedClass, ">")
 		OutputWrite("new")
 		OutputJavaSignature(Signature)
 		OutputWrite("\"")
@@ -290,7 +290,7 @@
 
 	'rule' OutputSetVariableBindingString(ClassType, FieldName, VarType, InstanceModifier):
         TypeToQualifiedName(ClassType -> QualifiedClass)
-		OutputWriteI(" binds to \"java:", QualifiedClass, ">")
+		OutputWriteI(" \\\nbinds to \"java:", QualifiedClass, ">")
 		OutputWriteI("set.", FieldName, "")
 		OutputWrite("(")
         OutputJavaTypeCode(VarType)
@@ -306,7 +306,7 @@
 
 	'rule' OutputGetVariableBindingString(ClassType, FieldName, VarType, InstanceModifier):
         TypeToQualifiedName(ClassType -> QualifiedClass)
-		OutputWriteI(" binds to \"java:", QualifiedClass, ">")
+		OutputWriteI(" \\\nbinds to \"java:", QualifiedClass, ">")
 		OutputWriteI("get.", FieldName, "")
 		OutputWrite("(")
         OutputWrite(")")

--- a/toolchain/lc-compile-ffi-java/src/generate.g
+++ b/toolchain/lc-compile-ffi-java/src/generate.g
@@ -324,7 +324,7 @@
 		OutputWrite("(")
         OutputJavaParams(Params)
         OutputWrite(")")
-        OutputJavaTypeCode(ReturnType)
+        OutputJavaReturnTypeCode(ReturnType)
 		
 'action' OutputJavaParams(PARAMETERLIST)
 
@@ -959,6 +959,15 @@
         OutputJavaArrayTypeCode(Type, Dimension)
 
     'rule' OutputJavaTypeCode(nil):
+
+-- Ensure return type code is always specified as V if returning nothing
+'action' OutputJavaReturnTypeCode(TYPE)
+
+    'rule' OutputJavaReturnTypeCode(nil):
+        OutputWrite("V")
+
+    'rule' OutputJavaReturnTypeCode(Type):
+        OutputJavaTypeCode(Type)
 
 'action' OutputJavaArrayTypeCode(TYPE, INT)
 

--- a/toolchain/lc-compile-ffi-java/src/generate.g
+++ b/toolchain/lc-compile-ffi-java/src/generate.g
@@ -808,28 +808,28 @@
 'action' GenerateJavaType(TYPE)
 
     'rule' GenerateJavaType(byte):
-        OutputWrite("CInt")
+        OutputWrite("JByte")
 
     'rule' GenerateJavaType(short):
-        OutputWrite("CInt")
+        OutputWrite("JShort")
 
     'rule' GenerateJavaType(int):
-        OutputWrite("CInt")
+        OutputWrite("JInt")
 
     'rule' GenerateJavaType(long):
-        OutputWrite("CInt")
+        OutputWrite("JLong")
 
     'rule' GenerateJavaType(float):
-        OutputWrite("CFloat")
+        OutputWrite("JFloat")
 
     'rule' GenerateJavaType(double):
-        OutputWrite("CDouble")
+        OutputWrite("JDouble")
 
     'rule' GenerateJavaType(boolean):
-        OutputWrite("CBool")
+        OutputWrite("JBoolean")
 
     'rule' GenerateJavaType(char):
-        OutputWrite("CInt")
+        OutputWrite("JChar")
 
     'rule' GenerateJavaType(string):
         OutputWrite("JString")

--- a/toolchain/lc-compile-ffi-java/src/generate.g
+++ b/toolchain/lc-compile-ffi-java/src/generate.g
@@ -104,7 +104,7 @@
             ResolveIdName(Id -> RealName)
         |)
         
-        OutputWrite("foreign handler ")
+        OutputWrite("__safe foreign handler ")
         OutputForeignHandlerName(Type, MethodName)
         OutputForeignHandlerSignatureWithParameter(Type, Signature, Modifiers)
         OutputMethodBindingString(Type, RealName, Signature, Modifiers)
@@ -120,7 +120,7 @@
             ResolveIdName(Id -> RealName)
         |)
         
-        OutputWrite("foreign handler ")
+        OutputWrite("__safe foreign handler ")
         OutputForeignHandlerName(Type, MethodName)
         OutputForeignSignatureWithReturnType(Type, Signature)
         OutputConstructorBindingString(Type, RealName, Signature)
@@ -146,7 +146,7 @@
 'action' GenerateForeignGetterOfClass(TYPE, NAME, TYPE, MODIFIER)
 	
 	'rule' GenerateForeignGetterOfClass(ClassType, Name, VarType, InstanceModifier)        
-		OutputWrite("foreign handler ")
+		OutputWrite("__safe foreign handler ")
         OutputForeignGetterName(ClassType, Name)
         OutputForeignGetterSignature(ClassType, Name, VarType, InstanceModifier)
         OutputGetVariableBindingString(ClassType, Name, VarType, InstanceModifier)
@@ -155,7 +155,7 @@
 'action' GenerateForeignSetterOfClass(TYPE, NAME, TYPE, MODIFIER)
 	
 	'rule' GenerateForeignSetterOfClass(ClassType, Name, VarType, InstanceModifier)        
-		OutputWrite("foreign handler ")
+		OutputWrite("__safe foreign handler ")
         OutputForeignSetterName(ClassType, Name)
         OutputForeignSetterSignature(ClassType, Name, VarType, InstanceModifier)
         OutputSetVariableBindingString(ClassType, Name, VarType, InstanceModifier)
@@ -447,13 +447,11 @@
 
     'rule' OutputCallForeignConstructor(ObjType, Name, signature(Params, nil))
      	OutputConvertToForeignParams(Params)
-		OutputWrite("\tunsafe\n\t\t")
-		OutputWrite("return ")
+		OutputWrite("\treturn ")
 		OutputForeignHandlerName(ObjType, Name)	
 		OutputWrite("(")
 		OutputForeignCallParams(Params)
 		OutputWrite(")\n")
-		OutputWrite("\tend unsafe\n")
 
 'action' OutputCallForeignHandlerParams(TYPE, NAME, PARAMETERLIST, MODIFIER)
 
@@ -488,56 +486,56 @@
 		OutputConvertToForeignParams(Params)
         (|
             where(ReturnType -> nil)
-            OutputWrite("\tunsafe\n\t\t")
+            OutputWrite("\t")
             OutputCallForeignHandlerParams(ObjType, Name, Params, InstanceModifier)
 			OutputWrite("\n")
-            OutputWrite("\tend unsafe\n")
         ||
-            OutputWrite("\tvariable tJNIResult as ")
             (|
                 RequiresConversion(ReturnType)
+                OutputWrite("\tvariable tJNIResult as ")
                 GenerateJavaType(ReturnType)
+                OutputWrite("\n\tput ")
+                OutputCallForeignHandlerParams(ObjType, Name, Params, InstanceModifier)
+                OutputWrite(" into tJNIResult\n")
+                OutputWrapperReturn(ReturnType)
             ||
-                GenerateType(ReturnType)
+                OutputWrite("\treturn ")
+                OutputCallForeignHandlerParams(ObjType, Name, Params, InstanceModifier)
             |)
-            OutputWrite("\n\tunsafe\n")
-            OutputWrite("\t\tput ")
-            OutputCallForeignHandlerParams(ObjType, Name, Params, InstanceModifier)
-            OutputWrite(" into tJNIResult\n")
-            OutputWrite("\tend unsafe\n")
-			OutputWrapperReturn(ReturnType)
 			OutputWrite("\n")
         |)
+
+'action' OutputForeignGetter(TYPE, NAME, MODIFIER)
+
+    'rule' OutputForeignGetter(ObjType, Name, class):
+        OutputForeignGetterName(ObjType, Name)
+        OutputWrite("(pObj)")
+
+    'rule' OutputForeignGetter(ObjType, Name, Instance):
+        OutputForeignGetterName(ObjType, Name)
+        OutputWrite("()")
 
 'action' OutputCallForeignGetter(TYPE, NAME, TYPE, MODIFIER)
 
 	'rule' OutputCallForeignGetter(ObjType, Name, Type, InstanceModifier)
-            OutputWrite("\tvariable tJNIResult as ")
             (|
                 RequiresConversion(Type)
+                OutputWrite("\tvariable tJNIResult as ")
                 GenerateJavaType(Type)
+                OutputWrite("\n\tput ")
+                OutputForeignGetter(ObjType, Name, InstanceModifier)
+                OutputWrite(" into tJNIResult\n")
+                OutputWrapperReturn(Type)
             ||
-                GenerateType(Type)
+                OutputWrite("\treturn ")
+                OutputForeignGetter(ObjType, Name, InstanceModifier)
             |)
-            OutputWrite("\n\tunsafe\n")
-            OutputWrite("\t\tput ")
-            OutputForeignGetterName(ObjType, Name)
-            OutputWrite("(")
-            (|
-            	where(InstanceModifier -> class)
-            ||
-            	OutputWrite("pObj")            
-            |)
-            OutputWrite(")")
-            OutputWrite(" into tJNIResult\n")
-            OutputWrite("\tend unsafe\n")
-			OutputWrapperReturn(Type)
-			
+
 'action' OutputCallForeignSetter(TYPE, NAME, TYPE, MODIFIER)
 
 	'rule' OutputCallForeignSetter(ObjType, Name, Type, InstanceModifier)
 			OutputConvertToForeignParameter(Name, Type)
-            OutputWrite("\tunsafe\n\t\t")
+            OutputWrite("\t")
             OutputForeignSetterName(ObjType, Name)
             OutputWrite("(")
             (|
@@ -552,7 +550,7 @@
         	    OutputWriteI("pParam_", Name, "")
 	        |)
             OutputWrite(")")            
-            OutputWrite("\n\tend unsafe\n")
+            OutputWrite("\n")
 
 'action' OutputConvertToForeignParams(PARAMETERLIST)
 


### PR DESCRIPTION
- Fix return type code in binding strings
- Add line continuation before 'binds to' in foreign handlers
- Use java types for foreign handler binding output
- Mark generated java foreign handlers as safe