### PR TITLE
[Bug 19965] Fix error in S/B when adding a stack file that has substacks

### DIFF
--- a/docs/notes/bugfix-19965.md
+++ b/docs/notes/bugfix-19965.md
@@ -1,0 +1,1 @@
+# Fix error when building a standalone if the added stackfiles have substacks

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -916,8 +916,10 @@ private command __RecursiveStackFileList pStack, @xStackFiles
    repeat for each key tStack in tStackFiles
       if there is not a stack tStackFiles[tStack] then put tFileName before tStackFiles[tStack]
       if there is a stack tStackFiles[tStack] then
-         appendToStringList the effective fileName of stack tStackFiles[tStack], xStackFiles
-         __RecursiveStackFileList tStack, xStackFiles
+         if the effective fileName of stack  tStackFiles[tStack] is not among the lines of xStackFiles then
+            appendToStringList the effective fileName of stack tStackFiles[tStack], xStackFiles
+            __RecursiveStackFileList tStack, xStackFiles
+         end if
       end if
    end repeat
    repeat for each line tStack in the substacks of stack pStack

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -916,8 +916,10 @@ private command __RecursiveStackFileList pStack, @xStackFiles
    repeat for each key tStack in tStackFiles
       if there is not a stack tStackFiles[tStack] then put tFileName before tStackFiles[tStack]
       if there is a stack tStackFiles[tStack] then
-         if the effective fileName of stack  tStackFiles[tStack] is not among the lines of xStackFiles then
-            appendToStringList the effective fileName of stack tStackFiles[tStack], xStackFiles
+         local tEffectiveFilename
+         put the effective fileName of stack  tStackFiles[tStack] into tEffectiveFilename
+         if tEffectiveFilename is not among the lines of xStackFiles then
+            appendToStringList tEffectiveFilename, xStackFiles
             __RecursiveStackFileList tStack, xStackFiles
          end if
       end if


### PR DESCRIPTION
The missing termination condition was causing `xStackFiles` to grow continuously and finally LC to throw a recursion limit error.