### PR TITLE
[[ Bug 19967 ]] Don't evaluate params in send domess form

### DIFF
--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1396,48 +1396,7 @@ static void MCEngineSendOrCall(MCExecContext& ctxt, MCStringRef p_script, MCObje
             goto cleanup;
         }
 
-        // The 'split into message and parameters' function above is used
-        // to ensure that all the parameters are evaluated in the current
-        // context (not the target). Since domess just takes a string, we
-        // convert the entire script back into a string with the params
-        // having been evaluated. This means in particular that variables
-        // containing arrays will not work here - they will be converted to
-        // the empty string.
-        
-        MCAutoListRef t_param_list;
-        MCListCreateMutable(',', &t_param_list);
-        MCParameter *t_param_ptr;
-        t_param_ptr = t_params;
-        
-        bool t_has_params;
-        t_has_params = t_params != nil;
-        while (t_param_ptr != NULL)
-        {
-            MCAutoValueRef t_value;
-            MCAutoStringRef t_value_string;
-            
-            if (!t_param_ptr->eval(ctxt, &t_value) ||
-                !ctxt . ConvertToString(*t_value, &t_value_string) ||
-                !MCListAppend(*t_param_list, *t_value_string))
-                goto cleanup;
-
-            t_param_ptr = t_param_ptr -> getnext();
-        }
-        
-        MCAutoStringRef tptr;
-        if (t_has_params)
-        {
-            MCAutoStringRef t_params_string;
-            if (!MCListCopyAsString(*t_param_list, &t_params_string) ||
-                !MCStringCreateWithStringsAndSeparator(&tptr, ' ',
-                                                       MCNameGetString(*t_message),
-                                                       *t_params_string))
-                goto cleanup;
-        }
-        else
-            tptr = MCNameGetString(*t_message);
-        
-        if (optr->domess(*tptr, false) == ES_ERROR)
+        if (optr->domess(p_script, false) == ES_ERROR)
             ctxt . Throw();
 	}
 	else if (stat == ES_PASS)

--- a/tests/lcs/core/engine/send.livecodescript
+++ b/tests/lcs/core/engine/send.livecodescript
@@ -33,6 +33,24 @@ on TestSendParams
 	TestAssert "send script with multiple params", the result is "2"
 end TestSendParams
 
+-- Bug 19967
+on TestSendParamsEvaluated
+	local tScript, tStack
+	put "on testParameters p1, p2; return p2; end testParameters" \
+		into tScript
+	create stack
+	put it into tStack
+	set the script of tStack to tScript
+	
+	local tSendScript
+	put "--ensure this is executed as script not a handler name" \
+		into tSendScript
+	put return & "testParameters 1," && quote & "2 3" & quote after tSendScript
+	
+	send tSendScript to tStack
+	TestAssert "send script with quoted params containing space", the result is "2 3"
+end TestSendParamsEvaluated
+
 private function MessageExists pId
 	repeat for each line tLine in the pendingMessages
 		if item 1 of tLine is pId then


### PR DESCRIPTION
Due to previous issues with the message box, various attempts were
made to fix things by tweaking the send command's evaluation
strategy. Now that the message box logic is cleaned up, we don't
actually need any param evaluation and can just forward the
script wholesale through domess.