### PR TITLE
[[ Bug 19967 ]] Add `send script <script> to <obj>` syntax

### DIFF
--- a/docs/dictionary/command/send.lcdoc
+++ b/docs/dictionary/command/send.lcdoc
@@ -2,7 +2,7 @@ Name: send
 
 Type: command
 
-Syntax: send <message> [ to <object> [in <time> [seconds | ticks | milliseconds]] ]
+Syntax: send [script] <message> [ to <object> [in <time> [seconds | ticks | milliseconds]] ]
 
 Summary:
 Sends a <message> to an <object(glossary)>.
@@ -34,6 +34,9 @@ on timerIncrement
    send "timerIncrement" to me in 1 seconds
 end timerIncrement
 
+Example:
+send script "answer the short name of me" to stack "Message Box"
+
 Parameters:
 message:
 An expression that evaluates to a message name, possibly including
@@ -64,12 +67,34 @@ one <word> (for example, if it includes <parameter|parameters>, or if it
 is a multi-word command), it must be enclosed in <double quote|double
 quotes>. 
 
-Any parameters are evaluated before they are passed to the <send>
-<command>. For example, the following statement sends the <mouseUp>
-<message> with 2 as the first parameter:
+If the `script` form is used, the <message> is simply sent unmodified to the 
+<object>. Otherwise, any parameters are evaluated before they are passed to the 
+<send> <command>. For example, suppose there is a stack named "Stack" with 
+script
+    
+    on doAnswer pParam
+       answer pParam
+    end doAnswer
 
-    send "mouseUp 1+1" to button "Example"
+    function myName
+       return the short name of me
+    end myName
+    
+and a button on the stack named "Button" with script
 
+    on mouseUp
+       send "doAnswer myName()" to this stack
+       send script "doAnswer myName()" to this stack
+    end mouseUp
+
+    function myName
+       return the short name of me
+    end myName
+
+clicking the button would result in an answer dialog first saying "Button" as the
+`myName` function would be evaluated in the button context, then "Stack" as 
+using the `script` form would result in the `myName` function being evaluated in the 
+stack context.
 
 When the send command is used the stack containing the target handler
 temporarily becomes the defaultStack. All object references in the
@@ -77,6 +102,8 @@ temporarily becomes the defaultStack. All object references in the
 defaultStack. Therefore references within the message that refer to
 "this card" or "this stack" will be referring to the card or stack where
 the target handler is located.
+
+It is a parse error to specify a time when using the `script` form.
 
 >*Important:*  Specifying a <time> can affect the order in which
 > <statement|statements> are <execute|executed>. If you don't specify a

--- a/docs/notes/feature-send_script.md
+++ b/docs/notes/feature-send_script.md
@@ -1,0 +1,34 @@
+# Send script form of send command
+The syntax 
+
+	send script <script> to <obj>
+
+has been added to allow a chunk of script to be executed in the context 
+of an object without any attempted evaluation of parameters that occurs 
+with the original form of the send command.
+
+For example, suppose there is a stack named "Stack" with script
+    
+    on doAnswer pParam
+       answer pParam
+    end doAnswer
+
+    function myName
+       return the short name of me
+    end myName
+    
+and a button on the stack named "Button" with script
+
+    on mouseUp
+       send "doAnswer myName()" to this stack
+       send script "doAnswer myName()" to this stack
+    end mouseUp
+
+    function myName
+       return the short name of me
+    end myName
+
+clicking the button would result in an answer dialog first saying "Button" as the
+`myName` function would be evaluated in the button context, then "Stack" as 
+using the `script` form would result in the `myName` function being evaluated in the 
+stack context.

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1099,6 +1099,7 @@ class MCMessage : public MCStatement
 	Boolean program;
 	Boolean reply;
 	Boolean send;
+    Boolean script;
 public:
     MCMessage(Boolean p_send) :
         message(nullptr),
@@ -1107,7 +1108,8 @@ public:
         in(nullptr),
         units(F_TICKS),
         program(False),
-        reply(True)
+        reply(True),
+        script(False)
 	{
         send = p_send;
     }

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1091,25 +1091,26 @@ public:
 
 class MCMessage : public MCStatement
 {
-	MCExpression *message;
-	MCExpression *eventtype;
-	MCChunk *target;
-	MCExpression *in;
+	MCAutoPointer<MCExpression> message;
+	MCAutoPointer<MCExpression> eventtype;
+	MCAutoPointer<MCChunk> target;
+	MCAutoPointer<MCExpression> in;
 	Functions units;
 	Boolean program;
 	Boolean reply;
-protected:
 	Boolean send;
 public:
-	MCMessage()
+    MCMessage(Boolean p_send) :
+        message(nullptr),
+        eventtype(nullptr),
+        target(nullptr),
+        in(nullptr),
+        units(F_TICKS),
+        program(False),
+        reply(True)
 	{
-		message = eventtype = NULL;
-		target = NULL;
-		in = NULL;
-		program = False;
-		reply = True;
-	}
-	virtual ~MCMessage();
+        send = p_send;
+    }
 	virtual Parse_stat parse(MCScriptPoint &);
     virtual void exec_ctxt(MCExecContext &ctxt);
 	virtual void compile(MCSyntaxFactoryRef);
@@ -1118,18 +1119,16 @@ public:
 class MCCall : public MCMessage
 {
 public:
-	MCCall()
+    MCCall() : MCMessage(False)
 	{
-		send = False;
-	}
+    }
 };
 
 class MCSend : public MCMessage
 {
 public:
-	MCSend()
+    MCSend(): MCMessage(True)
 	{
-		send = True;
 	}
 };
 

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -642,19 +642,11 @@ void MCDispatchCmd::exec_ctxt(MCExecContext &ctxt)
     }
 }
 
-MCMessage::~MCMessage()
-{
-	delete message;
-	delete eventtype;
-	delete target;
-	delete in;
-}
-
 Parse_stat MCMessage::parse(MCScriptPoint &sp)
 {
 	initpoint(sp);
 
-	if (sp.parseexp(False, True, &message) != PS_NORMAL)
+	if (sp.parseexp(False, True, &(&message)) != PS_NORMAL)
 	{
 		MCperror->add(PE_SEND_BADEXP, sp);
 		return PS_ERROR;
@@ -665,14 +657,14 @@ Parse_stat MCMessage::parse(MCScriptPoint &sp)
 	if (sp.skip_token(SP_ASK, TT_UNDEFINED, AT_PROGRAM) == PS_NORMAL)
 	{
 		program = True;
-		if (sp.parseexp(False, True, &in) != PS_NORMAL)
+		if (sp.parseexp(False, True, &(&in)) != PS_NORMAL)
 		{
 			MCperror->add(PE_SEND_BADTARGET, sp);
 			return PS_ERROR;
 		}
 		if (sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_WITH) == PS_NORMAL
 		        && sp.skip_token(SP_COMMAND, TT_STATEMENT, S_REPLY) != PS_NORMAL)
-			if (sp.parseexp(False, True, &eventtype) != PS_NORMAL)
+			if (sp.parseexp(False, True, &(&eventtype)) != PS_NORMAL)
 			{
 				MCperror->add(PE_SEND_BADEVENTTYPE, sp);
 				return PS_ERROR;
@@ -692,7 +684,7 @@ Parse_stat MCMessage::parse(MCScriptPoint &sp)
 			MCperror->add(PE_SEND_BADTARGET, sp);
 			return PS_ERROR;
 		}
-		return gettime(sp, &in, units);
+		return gettime(sp, &(&in), units);
 	}
 	return PS_NORMAL;
 }
@@ -703,15 +695,15 @@ void MCMessage::exec_ctxt(MCExecContext &ctxt)
 	if (program)
 	{
         MCAutoStringRef t_message;
-        if (!ctxt . EvalExprAsStringRef(message, EE_SEND_BADEXP, &t_message))
+        if (!ctxt . EvalExprAsStringRef(*message, EE_SEND_BADEXP, &t_message))
             return;
 
         MCAutoStringRef t_program;
-        if (!ctxt . EvalExprAsStringRef(in, EE_SEND_BADPROGRAMEXP, &t_program))
+        if (!ctxt . EvalExprAsStringRef(*in, EE_SEND_BADPROGRAMEXP, &t_program))
             return;
 
         MCAutoStringRef t_event_type;
-        if (!ctxt . EvalOptionalExprAsNullableStringRef(eventtype, EE_SEND_BADEXP, &t_event_type))
+        if (!ctxt . EvalOptionalExprAsNullableStringRef(*eventtype, EE_SEND_BADEXP, &t_event_type))
             return;
 
 		MCScriptingExecSendToProgram(ctxt, *t_message, *t_program, *t_event_type, reply == True);
@@ -719,12 +711,12 @@ void MCMessage::exec_ctxt(MCExecContext &ctxt)
 	else
 	{
         MCAutoStringRef t_message;
-        if (!ctxt . EvalExprAsStringRef(message, EE_SEND_BADEXP, &t_message))
+        if (!ctxt . EvalExprAsStringRef(*message, EE_SEND_BADEXP, &t_message))
             return;
 		
 		MCObjectPtr t_target;
 		MCObjectPtr *t_target_ptr;
-		if (target != nil)
+		if (*target != nil)
 		{
             if (!target -> getobj(ctxt, t_target, True))
 			{
@@ -736,11 +728,11 @@ void MCMessage::exec_ctxt(MCExecContext &ctxt)
 		else
 			t_target_ptr = nil;
 
-		if (in != nil)
+		if (*in != nil)
 		{
             double t_delay;
 
-            if (!ctxt . EvalExprAsDouble(in, EE_SEND_BADINEXP, t_delay))
+            if (!ctxt . EvalExprAsDouble(*in, EE_SEND_BADINEXP, t_delay))
                 return;
 
             MCEngineExecSendInTime(ctxt, *t_message, t_target, t_delay, units);

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -105,6 +105,7 @@ MC_EXEC_DEFINE_EXEC_METHOD(Engine, StopUsingStack, 1)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, StopUsingStackByName, 1)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, Dispatch, 4)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, Send, 2)
+MC_EXEC_DEFINE_EXEC_METHOD(Engine, SendScript, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, SendInTime, 4)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, Call, 2)
 MC_EXEC_DEFINE_EXEC_METHOD(Engine, LockErrors, 0)
@@ -1466,6 +1467,32 @@ void MCEngineExecSend(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr *p_
 void MCEngineExecCall(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr *p_target)
 {
 	MCEngineSendOrCall(ctxt, p_script, p_target, false);
+}
+
+void MCEngineExecSendScript(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr *p_target)
+{
+    MCObject *optr;
+    if (p_target == nil)
+        optr = ctxt . GetObject();
+    else
+        optr = p_target -> object;
+    
+    Boolean oldlock = MClockmessages;
+    MClockmessages = False;
+
+    Boolean added = False;
+    if (MCnexecutioncontexts < MAX_CONTEXTS)
+    {
+        MCexecutioncontexts[MCnexecutioncontexts++] = &ctxt;
+        added = True;
+    }
+    
+    if (optr->domess(p_script, false) == ES_ERROR)
+        ctxt . Throw();
+    
+	if (added)
+		MCnexecutioncontexts--;
+	MClockmessages = oldlock;
 }
 
 void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr p_target, double p_delay, int p_units)

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3792,6 +3792,7 @@ extern MCExecMethodInfo *kMCEngineExecStopUsingStackMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecStopUsingStackByNameMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecDispatchMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecSendMethodInfo;
+extern MCExecMethodInfo *kMCEngineExecSendScriptMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecSendInTimeMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecCallMethodInfo;
 extern MCExecMethodInfo *kMCEngineExecLockErrorsMethodInfo;
@@ -3924,6 +3925,7 @@ void MCEngineExecStopUsingStackByName(MCExecContext& ctxt, MCStringRef p_name);
 
 void MCEngineExecDispatch(MCExecContext& ctxt, int handler_type, MCNameRef message, MCObjectPtr *target, MCParameter *params);
 void MCEngineExecSend(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
+void MCEngineExecSendScript(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
 void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef script, MCObjectPtr target, double p_delay, int p_units);
 void MCEngineExecCall(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
 

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1774,6 +1774,9 @@ enum Parse_errors
 
 	// {PE-0574} folders: bad folder expression
 	PE_FOLDERS_BADPARAM,
+
+    // {PE-0575} send: can't send script in time
+    PE_SEND_SCRIPTINTIME,
 };
 
 extern const char *MCparsingerrors;

--- a/tests/lcs/core/engine/send.livecodescript
+++ b/tests/lcs/core/engine/send.livecodescript
@@ -33,6 +33,30 @@ on TestSendParams
 	TestAssert "send script with multiple params", the result is "2"
 end TestSendParams
 
+/*
+It is known that there is code in the wild relying on the following 
+(undocumented) form of the send command, so we add a test here to ensure 
+backwards compatibility until such a point as it is deemed possible or 
+necessary to break.
+*/
+on TestSendLegacy
+	local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	
+	local tButton
+	create button
+	put it into tButton
+	
+	local tSendScript
+	put "delete tButton" into tSendScript
+	
+	send tSendScript to tStack
+	TestAssert "send script as chunk of script legacy", \
+		there is not a button 1 of tStack
+end TestSendLegacy
+
 private function MessageExists pId
 	repeat for each line tLine in the pendingMessages
 		if item 1 of tLine is pId then
@@ -72,3 +96,37 @@ on TestSendDeleteMe
 
 	TestAssert "execute 'delete me' using send", there is not a stack it
 end TestSendDeleteMe
+
+on TestSendScript
+	local tStack
+	create stack
+	put it into tStack
+	set the defaultStack to the short name of tStack
+	create button
+	
+	local tSendScript
+	put "delete button 1 of me" into tSendScript
+	
+	send script tSendScript to tStack
+	TestAssert "send script to object", \
+		there is not a button 1 of tStack
+end TestSendScript
+
+on TestSendScriptEvaluation
+	local tVar
+	put "Something" into tVar
+	
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar pValue; set the cVar of me to pValue; end setVar"
+	-- tVar should be treated as UQL in target context
+	send script "setVar tVar" to tStack
+	TestAssert "send script param evaluated in target context", \
+		the cVar of tStack is "tVar"
+		
+	-- tVar should be evaluated in the current context
+	send "setVar tVar" to tStack
+	TestAssert "send param evaluated in current context", \
+		the cVar of tStack is "Something"
+end TestSendScriptEvaluation


### PR DESCRIPTION
The current send command attempts to evaluate parameters in the
current context before sending the message. In some cases this
is not desirable, and furthermore there are issues with the
evaluation of multiple parameters using the send command.

Since we can't break this backwards compatibility with the send
command, this patch adds a `send script` form of the command which
simply forwards the script to be sent unmodified to the target
object to be executed, using MCObject::domess.