### PR TITLE
[[ Bug 19866 ]] Emit (null) for %@ when parameter is nullptr

### DIFF
--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -1204,7 +1204,9 @@ bool MCStringFormatV(MCStringRef& r_string, const char *p_format, va_list p_args
 			t_value = va_arg(p_args, MCValueRef);
 			
 			MCAutoStringRef t_string;
-			if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeString)
+			if (t_value == nullptr)
+                t_string = MCSTR("(null)");
+            else if (MCValueGetTypeCode(t_value) == kMCValueTypeCodeString)
 				t_string = (MCStringRef)t_value;
             else
 				/* UNCHECKED */ MCValueCopyDescription (t_value, &t_string);

--- a/libfoundation/test/test_string.cpp
+++ b/libfoundation/test/test_string.cpp
@@ -123,6 +123,16 @@ TEST(string, format_stringref_with_range)
 	ASSERT_STREQ(MCStringGetCString(*t_string), "hello");
 }
 
+TEST(string, format_null_valueref)
+//
+// Checks that a nullptr valueref maps to (null) [ Bug 19866 ]
+//
+{	MCAutoStringRef t_string;
+
+	ASSERT_TRUE(MCStringFormat(&t_string, "%@", nullptr));
+	ASSERT_STREQ(MCStringGetCString(*t_string), "(null)");
+}
+
 TEST(string, format_everything)
 //
 // Checks formatting with lots of different options


### PR DESCRIPTION
This patch changes MCStringFormat so that if %@ is encountered and
the corresponding parameter is nullptr, it emits (null) rather than
crashing.