### PR TITLE
[[ FFI ]] Tidy up libscript FFI support

### DIFF
--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -316,6 +316,15 @@ MCScriptThrowUnableToResolveForeignHandlerError(MCScriptInstanceRef p_instance,
 }
 
 bool
+MCScriptThrowUnknownForeignLanguageError(void)
+{
+	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
+								 "reason",
+								 MCSTR("unknown language"),
+								 nil);
+}
+
+bool
 MCScriptThrowUnknownForeignCallingConventionError(void)
 {
 	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
@@ -334,38 +343,11 @@ MCScriptThrowMissingFunctionInForeignBindingError(void)
 }
 
 bool
-MCScriptThrowClassNotAllowedInCBindingError(void)
-{
-	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
-								 "reason",
-								 MCSTR("class not allowed in c binding string"),
-								 nil);
-}
-
-bool
 MCScriptThrowUnableToLoadForiegnLibraryError(void)
 {
 	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
 								 "reason",
 								 MCSTR("unable to load foreign library"),
-								 nil);
-}
-	
-bool
-MCScriptThrowCXXBindingNotImplemented(void)
-{
-	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
-								 "reason",
-								 MCSTR("c++ binding not implemented yet"),
-								 nil);
-}
-
-bool
-MCScriptThrowObjCBindingNotImplemented(void)
-{
-	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
-								 "reason",
-								 MCSTR("objc binding not implemented yet"),
 								 nil);
 }
 
@@ -384,15 +366,6 @@ MCScriptThrowJavaBindingNotSupported(void)
 	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
 								 "reason",
 								 MCSTR("java binding not supported on this platform"),
-								 nil);
-}
-
-bool
-MCScriptThrowObjCBindingNotSupported(void)
-{
-	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
-								 "reason",
-								 MCSTR("objc binding not supported on this platform"),
 								 nil);
 }
 

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -172,7 +172,7 @@ public:
         case kMCScriptForeignHandlerLanguageJava:
 #ifdef TARGET_SUBPLATFORM_ANDROID
             extern bool MCAndroidIsOnSystemThread();
-            if (!p_handler->is_ui_bound || MCAndroidIsOnSystemThread())
+            if (!p_handler->java.is_ui_bound || MCAndroidIsOnSystemThread())
 #endif
             {
                 MCJavaCallJNIMethod(p_handler->java.class_name,

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -687,63 +687,37 @@ static MCJavaCallType __MCScriptGetJavaCallType(MCStringRef p_class, MCStringRef
     if (MCStringIsEqualToCString(p_calling, "nonvirtual", kMCStringOptionCompareCaseless))
         return MCJavaCallTypeNonVirtual;
     
-    return MCJavaCallTypeInstance;
+    if (MCStringIsEmpty(p_calling) ||
+        MCStringIsEqualToCString(p_calling, "instance", kMCStringOptionCompareCaseless))
+        return MCJavaCallTypeInstance;
+
+    return MCJavaCallTypeUnknown;
 }
 
 static bool
-__MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
-										MCScriptForeignHandlerDefinition *p_handler,
-										ffi_abi& r_abi,
-										bool* r_bound)
+__MCScriptResolveForeignFunctionBindingForC(MCScriptInstanceRef p_instance,
+                                            MCScriptForeignHandlerDefinition *p_handler,
+                                            /* takes */ MCStringRef d_binding,
+                                            bool* r_bound)
 {
-    integer_t t_ordinal = 0;
-    if (p_instance->module->builtins != nullptr &&
-        MCTypeConvertStringToLongInteger(p_handler->binding, t_ordinal))
-    {
-        p_handler->native.function = p_instance->module->builtins[t_ordinal];
-        p_handler->is_builtin = true;
-        r_abi = FFI_DEFAULT_ABI;
-        if (r_bound != nullptr)
-        {
-            *r_bound = true;
-        }
-        return true;
-    }
-
-	MCStringRef t_rest;
-	t_rest = MCValueRetain(p_handler -> binding);
-	
-	MCAutoStringRef t_language;
 	MCAutoStringRef t_library;
-	MCAutoStringRef t_class;
-	MCAutoStringRef t_function_string;
+	MCAutoStringRef t_function;
 	MCAutoStringRef t_calling;
-	if (!__MCScriptSplitForeignBindingString(t_rest,
-											 ':',
-											 &t_language) ||
-		!__MCScriptSplitForeignBindingString(t_rest,
+	if (!__MCScriptSplitForeignBindingString(d_binding,
 											 '>',
 											 &t_library) ||
-		!__MCScriptSplitForeignBindingString(t_rest,
-											 '.',
-											 &t_class) ||
-		!MCStringDivideAtChar(t_rest,
+		!MCStringDivideAtChar(d_binding,
 							  '!',
 							  kMCStringOptionCompareExact,
-							  &t_function_string,
+							  &t_function,
 							  &t_calling))
 	{
-		MCValueRelease(t_rest);
+		MCValueRelease(d_binding);
 		return false;
 	}
-	
-	MCValueRelease(t_rest);
-	
-	MCAutoStringRef t_arguments, t_return, t_function;
-	if (!__split_function_signature(*t_function_string, &t_function, &t_arguments, &t_return))
-		return false;
-	
-	int t_cc;
+    MCValueRelease(d_binding);
+    
+    int t_cc;
 	if (!MCStringIsEmpty(*t_calling))
 	{
 		static const char *s_callconvs[] =
@@ -756,9 +730,6 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 			"cdecl",
 			"pascal",
 			"register",
-			"instance",
-			"static",
-			"nonvirtual",
 			nil
 		};
 		for(t_cc = 0; s_callconvs[t_cc] != nil; t_cc++)
@@ -776,161 +747,248 @@ __MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
 	}
 	else
 		t_cc = 0;
-	
+
 	if (MCStringIsEmpty(*t_function))
 	{
 		return MCScriptThrowMissingFunctionInForeignBindingError();
 	}
+    
+    /* TODO: This leaks a module handle if library is not empty (builtin) */
+    MCSLibraryRef t_module;
+    if (MCStringIsEmpty(*t_library))
+    {
+        t_module = MCScriptGetLibrary();
+    }
+    else
+    {
+        if (!MCScriptLoadLibrary(MCScriptGetModuleOfInstance(p_instance),
+                                 *t_library,
+                                 t_module))
+        {
+            if (r_bound == nil)
+            {
+                return MCScriptThrowUnableToLoadForiegnLibraryError();
+            }
+        
+            *r_bound = false;
+        
+            return true;
+        }
+    }
+    
+    /* Resolve the symbol from the module which we've loaded */
+    void *t_pointer =
+            MCSLibraryLookupSymbol(t_module,
+                                   *t_function);
+    
+    /* A nullptr pointer means that the symbol doesn't exist, so we either
+     * throw an error (if in 'must' bind mode - r_bound == nullptr) or
+     * indicate we succeeded, but the binding failed due to not finding the
+     * symbol (r_bound != nullptr). */
+    if (t_pointer == nullptr)
+    {
+        if (r_bound == nullptr)
+        {
+            return MCScriptThrowUnableToResolveForeignHandlerError(p_instance,
+                                                                   p_handler);
+        }
+        
+        *r_bound = false;
+        
+        return true;
+    }
+    
+    /* The ABI for all platforms is always DEFAULT, except on Win32 where
+     * it is specified as part of the signature. */
+    ffi_abi t_abi = FFI_DEFAULT_ABI;
+#ifdef _WIN32
+    t_abi = t_cc == 0 ? FFI_DEFAULT_ABI : (ffi_abi)t_cc;
+#endif
+
+    /* Now we must compute the libffi CIF for this C language handler. If
+     * this fails, it is an error - not a failure to bind - as it indicates
+     * OOM or something went wrong in libffi. */
+    if (!MCHandlerTypeInfoGetLayoutType(p_instance->module->types[p_handler->type]->typeinfo,
+                                        t_abi,
+                                        p_handler->c.function_cif))
+    {
+        /* The above call already throws an appropriate error, so we can
+         * just return false. */
+        return false;
+    }
+    
+    p_handler->language = kMCScriptForeignHandlerLanguageC;
+    p_handler->c.function = t_pointer;
+    
+    if (r_bound != nullptr)
+    {
+        *r_bound = true;
+    }
+    
+    return true;
+}
+
+static bool
+__MCScriptResolveForeignFunctionBindingForJava(MCScriptInstanceRef p_instance,
+                                               MCScriptForeignHandlerDefinition *p_handler,
+                                               /* takes */ MCStringRef d_binding,
+                                               bool p_is_ui,
+                                               bool* r_bound)
+{
+	MCAutoStringRef t_library;
+	MCAutoStringRef t_class;
+	MCAutoStringRef t_function_string;
+	MCAutoStringRef t_calling;
+	if (!__MCScriptSplitForeignBindingString(d_binding,
+											 '>',
+											 &t_library) ||
+		!__MCScriptSplitForeignBindingString(d_binding,
+											 '.',
+											 &t_class) ||
+		!MCStringDivideAtChar(d_binding,
+							  '!',
+							  kMCStringOptionCompareExact,
+							  &t_function_string,
+							  &t_calling))
+	{
+		MCValueRelease(d_binding);
+		return false;
+	}
+    MCValueRelease(d_binding);
+
+	MCAutoStringRef t_arguments, t_return, t_function;
+	if (!__split_function_signature(*t_function_string, &t_function, &t_arguments, &t_return))
+		return false;
+    
+    p_handler -> java . is_ui_bound = p_is_ui;
+    
+    p_handler -> java . call_type = __MCScriptGetJavaCallType(*t_class,
+                                                              *t_function,
+                                                              *t_calling);
+    if (p_handler->java.call_type == MCJavaCallTypeUnknown)
+    {
+        return MCScriptThrowUnknownForeignCallingConventionError();
+    }
+    
+    MCNewAutoNameRef t_class_name;
+    if (!MCNameCreate(*t_library, &t_class_name))
+        return false;
+    
+    p_handler -> java . class_name = MCValueRetain(*t_class_name);
+    
+    MCTypeInfoRef t_signature = p_instance -> module -> types[p_handler -> type] -> typeinfo;
+    
+    // Check that the java signature in the binding string is
+    // compatible with the types of the foreign handler
+    if (!MCJavaCheckSignature(t_signature,
+                              *t_arguments,
+                              *t_return,
+                              p_handler -> java . call_type) ||
+        !MCJavaVMInitialize())
+    {
+        if (r_bound == nullptr)
+        {
+            return false;
+        }
+        
+        MCErrorReset();
+    
+        *r_bound = false;
+    
+        return true;
+    }
+    
+    void *t_method_id = MCJavaGetMethodId(*t_class_name, *t_function, *t_arguments, *t_return, p_handler -> java . call_type);
+    
+    if (t_method_id != nullptr)
+    {
+        p_handler -> java . method_id = t_method_id;
+    }
+    else
+    {
+        if (r_bound == nullptr)
+        {
+            return MCScriptThrowUnableToResolveForeignHandlerError(p_instance,
+                                                                   p_handler);
+        }
+        
+        MCErrorReset();
+        
+        *r_bound = false;
+        
+        return true;
+    }
+    
+    p_handler->language = kMCScriptForeignHandlerLanguageJava;
+    
+    if (r_bound != nullptr)
+    {
+        *r_bound = true;
+    }
+    
+    return true;
+}
+
+static bool
+__MCScriptResolveForeignFunctionBinding(MCScriptInstanceRef p_instance,
+                                        MCScriptForeignHandlerDefinition *p_handler,
+										bool* r_bound)
+{
+    /* If the binding string is an integer, then it is a 'builtin-c' handler -
+     * a shim which has been generated by lc-compile in '--outputc' mode and
+     * compiled into the engine. */
+    integer_t t_ordinal = 0;
+    if (p_instance->module->builtins != nullptr &&
+        MCTypeConvertStringToLongInteger(p_handler->binding, t_ordinal))
+    {
+        p_handler->language = kMCScriptForeignHandlerLanguageBuiltinC;
+        p_handler->builtin_c.function = p_instance->module->builtins[t_ordinal];
+        if (r_bound != nullptr)
+        {
+            *r_bound = true;
+        }
+        return true;
+    }
+
+	MCStringRef t_rest;
+	t_rest = MCValueRetain(p_handler -> binding);
+	
+	MCAutoStringRef t_language;
+    if (!__MCScriptSplitForeignBindingString(t_rest,
+                                             ':',
+                                             &t_language))
+    {
+        MCValueRelease(t_rest);
+        return false;
+    }
 	
 	if (MCStringIsEmpty(*t_language) ||
 		MCStringIsEqualToCString(*t_language,
 								 "c",
 								 kMCStringOptionCompareExact))
 	{
-		if (!MCStringIsEmpty(*t_class))
-		{
-			return MCScriptThrowClassNotAllowedInCBindingError();
-		}
-		
-        /* TODO: This leaks a module handle if library is not empty (builtin) */
-        MCSLibraryRef t_module;
-        if (MCStringIsEmpty(*t_library))
-        {
-            t_module = MCScriptGetLibrary();
-        }
-        else
-        {
-		    if (!MCScriptLoadLibrary(MCScriptGetModuleOfInstance(p_instance),
-                                     *t_library,
-                                     t_module))
-		    {
-			    if (r_bound == nil)
-			    {
-				    return MCScriptThrowUnableToLoadForiegnLibraryError();
-			    }
-			
-			    *r_bound = false;
-			
-			    return true;
-		    }
-        }
-		
-		void *t_pointer =
-                MCSLibraryLookupSymbol(t_module,
-                                       *t_function);
-		if (t_pointer == nullptr)
-		{
-            if (r_bound == nullptr)
-            {
-                return MCScriptThrowUnableToResolveForeignHandlerError(p_instance,
-                                                                       p_handler);
-            }
-            
-            *r_bound = false;
-            
-			return true;
-		}
-		
-		p_handler -> native . function = t_pointer;
-        p_handler->is_builtin = false;
-	}
-	else if (MCStringIsEqualToCString(*t_language,
-									  "cpp",
-									  kMCStringOptionCompareExact))
-	{
-		return MCScriptThrowCXXBindingNotImplemented();
-	}
-	else if (MCStringIsEqualToCString(*t_language,
-									  "objc",
-									  kMCStringOptionCompareExact))
-	{
-#if !defined(_MACOSX) && !defined(TARGET_SUBPLATFORM_IPHONE)
-		if (r_bound == nil)
-		{
-			return MCScriptThrowObjCBindingNotSupported();
-		}
-		
-		*r_bound = false;
-		
-		return true;
-#else
-		return MCScriptThrowObjCBindingNotImplemented();
-#endif
+        return __MCScriptResolveForeignFunctionBindingForC(p_instance,
+                                                           p_handler,
+                                                           t_rest,
+                                                           r_bound);
 	}
 	else if (MCStringIsEqualToCString(*t_language, "java", kMCStringOptionCompareExact) ||
              MCStringIsEqualToCString(*t_language, "javaui", kMCStringOptionCompareExact))
     {
-        p_handler->is_ui_bound = MCStringIsEqualToCString(*t_language, "javaui", kMCStringOptionCompareExact);
+        bool t_is_ui_bound;
+        t_is_ui_bound = MCStringIsEqualToCString(*t_language,
+                                                 "javaui",
+                                                 kMCStringOptionCompareExact);
+        return __MCScriptResolveForeignFunctionBindingForJava(p_instance,
+                                                              p_handler,
+                                                              t_rest,
+                                                              t_is_ui_bound,
+                                                              r_bound);
+	}
     
-		p_handler -> is_java = true;
-        p_handler->is_builtin = false;
-	
-        p_handler -> java . call_type = __MCScriptGetJavaCallType(*t_class,
-                                                                  *t_function,
-                                                                  *t_calling);
-        
-		MCNewAutoNameRef t_class_name;
-		if (!MCNameCreate(*t_library, &t_class_name))
-			return false;
-		
-		p_handler -> java . class_name = MCValueRetain(*t_class_name);
-		
-		MCTypeInfoRef t_signature = p_instance -> module -> types[p_handler -> type] -> typeinfo;
-        
-        // Check that the java signature in the binding string is
-        // compatible with the types of the foreign handler
-		if (!MCJavaCheckSignature(t_signature,
-		                          *t_arguments,
-		                          *t_return,
-		                          p_handler -> java . call_type) ||
-            !MCJavaVMInitialize())
-        {
-            if (r_bound == nullptr)
-            {
-                return false;
-            }
-            
-            MCErrorReset();
-        
-            *r_bound = false;
-        
-            return true;
-        }
-		
-        void *t_method_id = MCJavaGetMethodId(*t_class_name, *t_function, *t_arguments, *t_return, p_handler -> java . call_type);
-        
-		if (t_method_id != nullptr)
-		{
-			p_handler -> java . method_id = t_method_id;
-		}
-		else
-		{
-			if (r_bound == nullptr)
-			{
-                return MCScriptThrowUnableToResolveForeignHandlerError(p_instance,
-                                                                       p_handler);
-            }
-            
-            MCErrorReset();
-            
-			*r_bound = false;
-			
-			return true;
-		}
-	}
+    MCValueRelease(t_rest);
 
-#ifdef _WIN32
-	r_abi = t_cc == 0 ? FFI_DEFAULT_ABI : (ffi_abi)t_cc;
-#else
-	r_abi = FFI_DEFAULT_ABI;
-#endif
-
-	if (r_bound != nullptr)
-	{
-		*r_bound = true;
-	}
-
-	return true;
+	return MCScriptThrowUnknownForeignLanguageError();
 }
 
 // This method attempts to bind a foreign function so it can be used. If
@@ -945,7 +1003,7 @@ __MCScriptPrepareForeignFunction(MCScriptInstanceRef p_instance,
 								 bool *r_bound)
 {
     // If the handler is already bound, then do nothing.
-    if (p_handler->is_bound)
+    if (p_handler->language != kMCScriptForeignHandlerLanguageUnknown)
     {
         if (r_bound != nullptr)
         {
@@ -958,10 +1016,8 @@ __MCScriptPrepareForeignFunction(MCScriptInstanceRef p_instance,
     // Attempt to resolve the foreign function binding. If r_bound == nullptr,
     // then this will fail if binding fails. If r_bound != nullptr, then *r_bound
     // will indicate whether the function was bound or not.
-	ffi_abi t_abi;
     if (!__MCScriptResolveForeignFunctionBinding(p_instance,
                                                  p_handler,
-                                                 t_abi,
                                                  r_bound))
     {
         return false;
@@ -974,24 +1030,6 @@ __MCScriptPrepareForeignFunction(MCScriptInstanceRef p_instance,
 	{
 		return true;
 	}
-
-    // If we get here then it means that the binding succeeded.
-	MCTypeInfoRef t_signature;
-	t_signature = p_instance->module->types[p_handler->type]->typeinfo;
-	
-	// Ask the handler typeinfo to construct its ffi 'cif'. If this fails
-	// then it will already have thrown (either OOM, or there was a problem
-	// with libffi!).
-	if (!p_handler -> is_java &&
-        !MCHandlerTypeInfoGetLayoutType(t_signature,
-										t_abi,
-										p_handler->native.function_cif))
-	{
-		return false;
-	}
-	
-	// The function can only be considered bound, if it gets to this point.
-    p_handler->is_bound = true;
     
 	return true;
 }

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -251,6 +251,18 @@ void MCScriptDestroyModule(MCScriptModuleRef self)
         {
             MCScriptForeignHandlerDefinition *t_def;
             t_def = static_cast<MCScriptForeignHandlerDefinition *>(self -> definitions[i]);
+            switch(t_def->language)
+            {
+            case kMCScriptForeignHandlerLanguageUnknown:
+                break;
+            case kMCScriptForeignHandlerLanguageC:
+                break;
+            case kMCScriptForeignHandlerLanguageBuiltinC:
+                break;
+            case kMCScriptForeignHandlerLanguageJava:
+                MCValueRelease(t_def->java.class_name);
+                break;
+            }
         }
     
     // Remove ourselves from the context slot owners list.

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -333,7 +333,28 @@ enum MCJavaCallType {
     MCJavaCallTypeGetter,
     MCJavaCallTypeSetter,
     MCJavaCallTypeStaticGetter,
-    MCJavaCallTypeStaticSetter
+    MCJavaCallTypeStaticSetter,
+    
+    /* This value is used to indicate that the call type was not known - it is
+     * only used internally in libscript. */
+    MCJavaCallTypeUnknown = -1,
+};
+
+/* MCScriptForeignHandlerLanguage describes the type of foreign handler which
+ * has been bound - based on language. */
+enum MCScriptForeignHandlerLanguage
+{
+    /* The handler has not yet been bound, or failed to bind */
+    kMCScriptForeignHandlerLanguageUnknown,
+    
+    /* The handler should be called using libffi */
+    kMCScriptForeignHandlerLanguageC,
+    
+    /* The handler has a lc-compile generated shim, so can be called directly */
+    kMCScriptForeignHandlerLanguageBuiltinC,
+    
+    /* The handler should be called using the JNI */
+    kMCScriptForeignHandlerLanguageJava,
 };
 
 struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
@@ -341,24 +362,24 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
     MCStringRef binding;
     
     // Bound function information - not pickled.
-    bool is_java: 1;
-    bool is_ui_bound : 1;
-    bool is_bound: 1;
-    bool is_builtin: 1;
-    
+    MCScriptForeignHandlerLanguage language;
     union
     {
         struct
         {
             void *function;
-            void *function_argtypes;
             void *function_cif;
-        } native;
+        } c;
+        struct
+        {
+            void *function;
+        } builtin_c;
         struct
         {
             MCNameRef class_name;
             void *method_id;
-            int call_type;
+            int call_type : 8;
+            bool is_ui_bound : 1;
         } java;
     };
 };
@@ -614,31 +635,22 @@ MCScriptThrowUnableToResolveForeignHandlerError(MCScriptInstanceRef instance,
 												MCScriptForeignHandlerDefinition *handler);
 
 bool
+MCScriptThrowUnknownForeignLanguageError(void);
+
+bool
 MCScriptThrowUnknownForeignCallingConventionError(void);
 
 bool
 MCScriptThrowMissingFunctionInForeignBindingError(void);
 
 bool
-MCScriptThrowClassNotAllowedInCBindingError(void);
-
-bool
 MCScriptThrowUnableToLoadForiegnLibraryError(void);
-
-bool
-MCScriptThrowCXXBindingNotImplemented(void);
-
-bool
-MCScriptThrowObjCBindingNotImplemented(void);
 
 bool
 MCScriptThrowJavaBindingNotImplemented(void);
 
 bool
 MCScriptThrowJavaBindingNotSupported(void);
-
-bool
-MCScriptThrowObjCBindingNotSupported(void);
 
 bool
 MCScriptCreateErrorExpectedError(MCErrorRef& r_error);


### PR DESCRIPTION
This patch tidies up the current implementation of FFI in libscript.

The type of foreign handler is now determined by the 'language'
field. This is set after successful parsing of the binding string and
can be one of 'C', 'BuiltinC' or 'Java'.

Parsing of the binding string has been split up into per-language
functions. The language prefix of the string is first parsed out, and
that is used to determine which further function to call.

The C++ and ObjC related errors and bindings have been removed as they
are both to be implemented via C bindings and therefore the distinction
is unnecessary.