### PR TITLE
[[ LCB ]] Generalize bytecode op format

### DIFF
--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1315,7 +1315,7 @@ static uindex_t __measure_instruction(MCScriptModuleBuilderRef self, MCScriptByt
     uindex_t t_size;
     t_size = 1;
     
-    if (p_instruction -> arity >= 15)
+    if (p_instruction -> arity >= kMCScriptBytecodeOpArityMax)
         t_size += 1;
     
     if (p_instruction -> operation == kMCScriptBytecodeOpJump)
@@ -1567,10 +1567,10 @@ void MCScriptEndHandlerInModule(MCScriptModuleBuilderRef self)
         
         __emit_position(self, t_pos_address_offset + t_address, self -> instructions[i] . file, self -> instructions[i] . line);
         
-        __emit_bytecode_byte(self, (uint8_t)(t_op | (MCMin(t_arity, 15U) << 4)));
+        __emit_bytecode_byte(self, (uint8_t)(t_op | (MCMin(t_arity, kMCScriptBytecodeOpArityMax) << kMCScriptBytecodeOpArityShift)));
         
-        if (t_arity >= 15U)
-            __emit_bytecode_byte(self, uint8_t(t_arity - 15U));
+        if (t_arity >= kMCScriptBytecodeOpArityMax)
+            __emit_bytecode_byte(self, uint8_t(t_arity - kMCScriptBytecodeOpArityMax));
         
         for(uindex_t j = 0; j < t_arity; j++)
             __emit_bytecode_uint(self, t_operands[j]);

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -670,6 +670,17 @@ MCScriptCreateErrorExpectedError(MCErrorRef& r_error);
 // present then the instruction requires 15 + extension byte arguments up to a
 // maximum of 256.
 
+enum
+{
+    kMCScriptBytecodeOpCodeMask = 0x0f,
+    kMCScriptBytecodeOpCodeShift = 0,
+    kMCScriptBytecodeOpCodeMax = kMCScriptBytecodeOpCodeMask >> kMCScriptBytecodeOpCodeShift,
+    
+    kMCScriptBytecodeOpArityMask = 0xf0,
+    kMCScriptBytecodeOpArityShift = 4,
+    kMCScriptBytecodeOpArityMax = kMCScriptBytecodeOpArityMask >> kMCScriptBytecodeOpArityShift,
+};
+
 enum MCScriptBytecodeOp
 {
 	kMCScriptBytecodeOp__First,
@@ -793,14 +804,14 @@ MCScriptBytecodeDecodeOp(const byte_t*& x_bytecode_ptr,
 	
 	// The lower nibble is the bytecode operation.
 	MCScriptBytecodeOp t_op;
-	t_op = (MCScriptBytecodeOp)(t_op_byte & 0xf);
+	t_op = (MCScriptBytecodeOp)((t_op_byte & kMCScriptBytecodeOpCodeMask) >> kMCScriptBytecodeOpCodeShift);
 	
 	// The upper nibble is the arity.
 	uindex_t t_arity;
-	t_arity = (t_op_byte >> 4);
+	t_arity = (t_op_byte & kMCScriptBytecodeOpArityMask) >> kMCScriptBytecodeOpArityShift;
 	
 	// If the arity is 15, then overflow to a subsequent byte.
-	if (t_arity == 15)
+	if (t_arity == kMCScriptBytecodeOpArityMax)
 		t_arity += *x_bytecode_ptr++;
 	
 	r_op = t_op;


### PR DESCRIPTION
This patch defines constants which describe the layout of the
VM's bytecode op byte - allowing the number of bits devoted to
op code vs arity to change by altering the definition in the
script-private.h header.