### PR TITLE
[[ LCB ]] FFI Aggregate support

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -436,6 +436,14 @@ statement blocks.
 A foreign handler definition binds an identifier to a handler defined in
 foreign code.
 
+The last parameter in a foreign handler declaration may be '...' to indicate
+that the handler is variadic. This allows binding to C functions such as
+sprintf.
+
+Note: No bridging of types will occur when passing a parameter in the non-fixed
+section of a variadic argument list. You must ensure the arguments you pass there
+are of the appropriate foreign type (e.g. CInt, CDouble).
+
 There are a number of types defined in the foreign module which map to
 the appropriate foreign type when used in foreign handler signatures.
 

--- a/docs/lcb/notes/19991.md
+++ b/docs/lcb/notes/19991.md
@@ -1,0 +1,11 @@
+# LiveCode Builder Language
+
+## Variadic foreign C functions
+
+* It is now possible to bind to variadic C functions:
+  foreign handler printf(in pFormat as Pointer, ...) returns CInt binds to "<builtin>"
+  In this case, the '...' must be the last parameter, and there must be at
+  least one fixed parameter.
+
+# [19991] Add support for variadic foreign C functions.
+

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1745,7 +1745,6 @@ MC_DLLEXPORT bool MCBuiltinTypeInfoCreate(MCValueTypeCode typecode, MCTypeInfoRe
 enum MCForeignPrimitiveType
 {
     kMCForeignPrimitiveTypeVoid,
-    kMCForeignPrimitiveTypeBool,
     kMCForeignPrimitiveTypeUInt8,
     kMCForeignPrimitiveTypeSInt8,
     kMCForeignPrimitiveTypeUInt16,
@@ -1757,30 +1756,31 @@ enum MCForeignPrimitiveType
     kMCForeignPrimitiveTypeFloat32,
     kMCForeignPrimitiveTypeFloat64,
     kMCForeignPrimitiveTypePointer,
+    kMCForeignPrimitiveTypeAggregate,
 };
 
 struct MCForeignTypeDescriptor
 {
     size_t size;
+    size_t alignment;
+    MCForeignPrimitiveType primitive;
     MCTypeInfoRef basetype;
     MCTypeInfoRef bridgetype;
-    MCForeignPrimitiveType *layout;
-    uindex_t layout_size;
-    bool (*initialize)(void *contents);
-    void (*finalize)(void *contents);
-    bool (*defined)(void *contents);
-    bool (*move)(void *source, void *target);
-    bool (*copy)(void *source, void *target);
-    bool (*equal)(void *left, void *right, bool& r_equal);
-    bool (*hash)(void *contents, hash_t& r_hash);
-    bool (*doimport)(void *contents, bool release, MCValueRef& r_value);
-    bool (*doexport)(MCValueRef value, bool release, void *contents);
-	bool (*describe)(void *contents, MCStringRef & r_desc);
-    
     /* The promotedtype typeinfo is the type to which this type must be promoted
      * when passed through variadic parameters. The 'promote' method does the
      * promotion. */
     MCTypeInfoRef promotedtype;
+    bool (*initialize)(void *contents);
+    void (*finalize)(void *contents);
+    bool (*defined)(void *contents);
+    bool (*move)(const MCForeignTypeDescriptor *desc, void *source, void *target);
+    bool (*copy)(const MCForeignTypeDescriptor *desc, void *source, void *target);
+    bool (*equal)(const MCForeignTypeDescriptor *desc, void *left, void *right, bool& r_equal);
+    bool (*hash)(const MCForeignTypeDescriptor *desc, void *contents, hash_t& r_hash);
+    bool (*doimport)(void *contents, bool release, MCValueRef& r_value);
+    bool (*doexport)(MCValueRef value, bool release, void *contents);
+	bool (*describe)(const MCForeignTypeDescriptor *desc, void *contents, MCStringRef & r_desc);
+    
     /* Promote the value in contents as necessary. The slot ptr must be big enough
      * to hold the promotedtype. */
     void (*promote)(void *contents);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1776,6 +1776,14 @@ struct MCForeignTypeDescriptor
     bool (*doimport)(void *contents, bool release, MCValueRef& r_value);
     bool (*doexport)(MCValueRef value, bool release, void *contents);
 	bool (*describe)(void *contents, MCStringRef & r_desc);
+    
+    /* The promotedtype typeinfo is the type to which this type must be promoted
+     * when passed through variadic parameters. The 'promote' method does the
+     * promotion. */
+    MCTypeInfoRef promotedtype;
+    /* Promote the value in contents as necessary. The slot ptr must be big enough
+     * to hold the promotedtype. */
+    void (*promote)(void *contents);
 };
 
 MC_DLLEXPORT bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *descriptor, MCTypeInfoRef& r_typeinfo);
@@ -1866,6 +1874,7 @@ enum MCHandlerTypeFieldMode
 	kMCHandlerTypeFieldModeIn,
 	kMCHandlerTypeFieldModeOut,
 	kMCHandlerTypeFieldModeInOut,
+    kMCHandlerTypeFieldModeVariadic,
 };
 
 struct MCHandlerTypeFieldInfo
@@ -1890,12 +1899,16 @@ MC_DLLEXPORT bool MCForeignHandlerTypeInfoCreate(const MCHandlerTypeFieldInfo *f
 
 // Returns true if the handler is of foreign type.
 MC_DLLEXPORT bool MCHandlerTypeInfoIsForeign(MCTypeInfoRef typeinfo);
+
+// Returns true if the handler is variadic.
+MC_DLLEXPORT bool MCHandlerTypeInfoIsVariadic(MCTypeInfoRef typeinfo);
     
 // Get the return type of the handler. A return-type of kMCNullTypeInfo means no
 // value is returned.
 MC_DLLEXPORT MCTypeInfoRef MCHandlerTypeInfoGetReturnType(MCTypeInfoRef typeinfo);
 
-// Get the number of parameters the handler takes.
+// Get the number of parameters the handler takes. If the handler is variadic,
+// this returns the number of fixed parameters.
 MC_DLLEXPORT uindex_t MCHandlerTypeInfoGetParameterCount(MCTypeInfoRef typeinfo);
 
 // Return the mode of the index'th parameter.

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -131,6 +131,9 @@ MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSIntTypeInfo() { return kMCSIntTypeInfo;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static_assert(sizeof(int) == 4,
+              "Assumption that int is 4 bytes in size not valid");
+
 template <typename CType, typename Enable = void>
 struct compute_primitive_type
 {
@@ -210,39 +213,54 @@ struct bool_type_desc_t {
     using bridge_type = MCBooleanRef;
     static constexpr MCTypeInfoRef& bridge_type_info() { return kMCBooleanTypeInfo; }
     static constexpr auto& hash_func = MCHashBool;
+    
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCUInt32TypeInfo; }
 };
 
 struct uint8_type_desc_t: public integral_type_desc_t<uint8_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCUInt8TypeInfo; }
     static constexpr auto describe_format = "<foreign 8-bit unsigned integer %u>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCUInt32TypeInfo; }
 };
 struct sint8_type_desc_t: public integral_type_desc_t<int8_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCSInt8TypeInfo; }
     static constexpr auto describe_format = "<foreign 8-bit signed integer %d>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCSInt32TypeInfo; }
 };
 struct uint16_type_desc_t: public integral_type_desc_t<uint16_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCUInt16TypeInfo; }
     static constexpr auto describe_format = "<foreign 16-bit unsigned integer %u>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCUInt32TypeInfo; }
 };
 struct sint16_type_desc_t: public integral_type_desc_t<int16_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCSInt16TypeInfo; }
     static constexpr auto describe_format = "<foreign 16-bit signed integer %d>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCSInt32TypeInfo; }
 };
 struct uint32_type_desc_t: public integral_type_desc_t<uint32_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCUInt32TypeInfo; }
     static constexpr auto describe_format = "<foreign 32-bit unsigned integer %u>";
+    static constexpr auto is_promotable = false;
 };
 struct sint32_type_desc_t: public integral_type_desc_t<int32_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCSInt32TypeInfo; }
     static constexpr auto describe_format = "<foreign 32-bit signed integer %d>";
+    static constexpr auto is_promotable = false;
 };
 struct uint64_type_desc_t: public integral_type_desc_t<uint64_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCUInt64TypeInfo; }
     static constexpr auto describe_format = "<foreign 64-bit unsigned integer %llu>";
+    static constexpr auto is_promotable = false;
 };
 struct sint64_type_desc_t: public integral_type_desc_t<int64_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCSInt64TypeInfo; }
     static constexpr auto describe_format = "<foreign 64-bit signed integer %lld>";
+    static constexpr auto is_promotable = false;
 };
 
 struct float_type_desc_t: public numeric_type_desc_t<float> {
@@ -251,6 +269,8 @@ struct float_type_desc_t: public numeric_type_desc_t<float> {
     static constexpr MCTypeInfoRef& type_info() { return kMCFloatTypeInfo; }
     static constexpr auto describe_format = "<foreign float %lg>";
     static constexpr auto& hash_func = MCHashDouble;
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCDoubleTypeInfo; }
 };
 struct double_type_desc_t: public numeric_type_desc_t<double> {
     using c_type = double;
@@ -258,6 +278,7 @@ struct double_type_desc_t: public numeric_type_desc_t<double> {
     static constexpr MCTypeInfoRef& type_info() { return kMCDoubleTypeInfo; }
     static constexpr auto describe_format = "<foreign double %lg>";
     static constexpr auto& hash_func = MCHashDouble;
+    static constexpr auto is_promotable = false;
 };
 
 struct pointer_type_desc_t {
@@ -269,24 +290,29 @@ struct pointer_type_desc_t {
     static constexpr auto describe_format = "<foreign pointer %p>";
     static constexpr MCTypeInfoRef& base_type_info() { return kMCNullTypeInfo; }
     static constexpr auto& hash_func = MCHashPointer;
+    static constexpr auto is_promotable = false;
 };
 
 struct uintsize_type_desc_t: public integral_type_desc_t<size_t>  {
     static constexpr MCTypeInfoRef& type_info() { return kMCUIntSizeTypeInfo; }
     static constexpr auto describe_format = "<foreign unsigned size %zu>";
+    static constexpr auto is_promotable = false;
 };
 struct sintsize_type_desc_t: public integral_type_desc_t<ssize_t>  {
     static constexpr MCTypeInfoRef& type_info() { return kMCSIntSizeTypeInfo; }
     static constexpr auto describe_format = "<foreign signed size %zd>";
+    static constexpr auto is_promotable = false;
 };
 
 struct uintptr_type_desc_t: public integral_type_desc_t<uintptr_t>  {
     static constexpr MCTypeInfoRef& type_info() { return kMCUIntPtrTypeInfo; }
     static constexpr auto describe_format = "<foreign unsigned intptr %zu>";
+    static constexpr auto is_promotable = false;
 };
 struct sintptr_type_desc_t: public integral_type_desc_t<intptr_t>  {
     static constexpr MCTypeInfoRef& type_info() { return kMCSIntPtrTypeInfo; }
     static constexpr auto describe_format = "<foreign signed intptr %zd>";
+    static constexpr auto is_promotable = false;
 };
 
 /**/
@@ -298,46 +324,62 @@ struct cbool_type_desc_t: public bool_type_desc_t
 struct cchar_type_desc_t: public integral_type_desc_t<char> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCCharTypeInfo; }
     static constexpr auto describe_format = "<foreign c char '%c'>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCSInt32TypeInfo; }
 };
 struct cuchar_type_desc_t: public integral_type_desc_t<unsigned char> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCUCharTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned char %u>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCUInt32TypeInfo; }
 };
 struct cschar_type_desc_t: public integral_type_desc_t<signed char> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCSCharTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed char %d>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCSInt32TypeInfo; }
 };
 struct cushort_type_desc_t: public integral_type_desc_t<unsigned short> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCUShortTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned short %u>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCUInt32TypeInfo; }
 };
 struct csshort_type_desc_t: public integral_type_desc_t<signed short> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCSShortTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed short %d>";
+    static constexpr auto is_promotable = true;
+    static constexpr MCTypeInfoRef& promoted_type_info() { return kMCSInt32TypeInfo; }
 };
 struct cuint_type_desc_t: public integral_type_desc_t<unsigned int> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCUIntTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned int %u>";
+    static constexpr auto is_promotable = false;
 };
 struct csint_type_desc_t: public integral_type_desc_t<signed int> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCSIntTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed int %d>";
+    static constexpr auto is_promotable = false;
 };
 struct culong_type_desc_t: public integral_type_desc_t<unsigned long> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCULongTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned long %lu>";
+    static constexpr auto is_promotable = false;
 };
 struct cslong_type_desc_t: public integral_type_desc_t<long> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCSLongTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed long %ld>";
+    static constexpr auto is_promotable = false;
 };
 struct culonglong_type_desc_t: public integral_type_desc_t<unsigned long long> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCULongLongTypeInfo; }
     static constexpr auto describe_format = "<foreign c unsigned long long %llu>";
+    static constexpr auto is_promotable = false;
 };
 struct cslonglong_type_desc_t: public integral_type_desc_t<long long> {
     static constexpr MCTypeInfoRef& type_info() { return kMCCSLongLongTypeInfo; }
     static constexpr auto describe_format = "<foreign c signed long long %lld>";
+    static constexpr auto is_promotable = false;
 };
 
 struct uint_type_desc_t: public integral_type_desc_t<uinteger_t> {
@@ -346,6 +388,7 @@ struct uint_type_desc_t: public integral_type_desc_t<uinteger_t> {
     static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt32;
     static constexpr MCTypeInfoRef& type_info() { return kMCUIntTypeInfo; }
     static constexpr auto describe_format = "<foreign unsigned integer %u>";
+    static constexpr auto is_promotable = false;
 };
 struct sint_type_desc_t: public integral_type_desc_t<integer_t> {
     static_assert(INTEGER_MAX == INT32_MAX,
@@ -354,6 +397,7 @@ struct sint_type_desc_t: public integral_type_desc_t<integer_t> {
     static constexpr MCTypeInfoRef& type_info() { return kMCSIntTypeInfo; }
     static constexpr auto describe_format = "<foreign signed integer %d>";
     static constexpr auto& hash_func = MCHashInteger;
+    static constexpr auto is_promotable = false;
 };
 
 
@@ -558,6 +602,16 @@ struct DoImport
     }
 };
 
+template<typename TypeDesc, typename Enable = void>
+struct DoPromote
+{
+    static_assert(sizeof(typename TypeDesc::c_type) == 0, "Missing promote specialization");
+    static bool promote(void *contents)
+    {
+        return false;
+    }
+};
+
 template <typename TypeDesc>
 bool initialize(void *contents)
 {
@@ -636,6 +690,13 @@ bool doimport(void *contents, bool p_release, MCValueRef& r_value)
     static_assert(TypeDesc::is_bridgable, "This type is not bridgable");
     return DoImport<TypeDesc>::doimport(*static_cast<typename TypeDesc::c_type *>(contents),
                                         reinterpret_cast<typename TypeDesc::bridge_type&>(r_value));
+}
+
+template <typename TypeDesc>
+void promote(void *contents)
+{
+    static_assert(TypeDesc::is_promotable, "This type is not promotable");
+    return DoPromote<TypeDesc>::promote(contents);
 }
 
 /* ---------- bool specializations */
@@ -728,6 +789,16 @@ struct DoImport<
     }
 };
 
+template <typename RealType>
+struct DoPromote<
+    RealType, typename std::enable_if<std::is_floating_point<typename RealType::c_type>::value>::type>
+{
+    static void promote(void *contents)
+    {
+        *(double *)contents = *(typename RealType::c_type *)contents;
+    }
+};
+
 /* ---------- integer numeric specializations */
 
 template <typename IntType>
@@ -801,6 +872,28 @@ struct DoImport<
     }
 };
 
+template <typename IntType>
+struct DoPromote<
+    IntType, typename std::enable_if<std::is_integral<typename IntType::c_type>::value &&
+                                     std::is_signed<typename IntType::c_type>::value>::type>
+{
+    static void promote(void *contents)
+    {
+        *(int *)contents = *(typename IntType::c_type *)contents;
+    }
+};
+
+template <typename UIntType>
+struct DoPromote<
+    UIntType, typename std::enable_if<std::is_integral<typename UIntType::c_type>::value &&
+                                      std::is_unsigned<typename UIntType::c_type>::value>::type>
+{
+    static void promote(void *contents)
+    {
+        *(unsigned int *)contents = *(typename UIntType::c_type *)contents;
+    }
+};
+
 template <typename TypeDesc>
 class DescriptorBuilder {
 public:
@@ -830,11 +923,14 @@ public:
             hash<TypeDesc>,
             nullptr, /* doimport */
             nullptr, /* doexport */
-            describe<TypeDesc>
+            describe<TypeDesc>,
+            nullptr, /* promotedtype */
+            nullptr, /* promote */
         };
 
         setup_optional<TypeDesc>(d);
         setup_bridge<TypeDesc>(d);
+        setup_promote<TypeDesc>(d);
 
         MCAutoStringRef t_name_string;
         if (!MCStringCreateWithCString(p_name, &t_name_string))
@@ -879,7 +975,7 @@ private:
     }
 
     /* Setup the doimport() and doexport() methods depending on
-     * whether the ValueType is optional or not. */
+     * whether the ValueType is bridgeable or not. */
     template <typename BridgableType,
               typename std::enable_if<
                   BridgableType::is_bridgable, int>::type = 0>
@@ -899,6 +995,26 @@ private:
         d.doimport = nullptr;
         d.doexport = nullptr;
     }
+    
+    /* Setup the promote() methods depending on whether the ValueType is
+     * promoteable or not. */
+    template <typename PromotableType,
+              typename std::enable_if<
+                  PromotableType::is_promotable, int>::type = 0>
+    static void setup_promote(MCForeignTypeDescriptor& d)
+    {
+        d.promotedtype = PromotableType::promoted_type_info();
+        d.promote = promote<PromotableType>;
+    }
+
+    template <typename UnpromotableType,
+              typename std::enable_if<
+                  !UnpromotableType::is_promotable, int>::type = 0>
+    static void setup_promote(MCForeignTypeDescriptor& d)
+    {
+        d.promotedtype = kMCNullTypeInfo;
+        d.promote = nullptr;
+    }
 };
 
 } /* anonymous namespace */
@@ -907,15 +1023,17 @@ private:
 
 bool __MCForeignValueInitialize(void)
 {
-    if (!(DescriptorBuilder<bool_type_desc_t>::create("__builtin__.bool") &&
-          DescriptorBuilder<float_type_desc_t>::create("__builtin__.float") &&
+    /* We must initialized uint32, sint32 and double first as they are used as
+     * promotions. */
+    if (!(DescriptorBuilder<uint32_type_desc_t>::create("__builtin__.uint32") &&
+          DescriptorBuilder<sint32_type_desc_t>::create("__builtin__.sint32") &&
           DescriptorBuilder<double_type_desc_t>::create("__builtin__.double") &&
+          DescriptorBuilder<bool_type_desc_t>::create("__builtin__.bool") &&
+          DescriptorBuilder<float_type_desc_t>::create("__builtin__.float") &&
           DescriptorBuilder<uint8_type_desc_t>::create("__builtin__.uint8") &&
           DescriptorBuilder<sint8_type_desc_t>::create("__builtin__.sint8") &&
           DescriptorBuilder<uint16_type_desc_t>::create("__builtin__.uint16") &&
           DescriptorBuilder<sint16_type_desc_t>::create("__builtin__.sint16") &&
-          DescriptorBuilder<uint32_type_desc_t>::create("__builtin__.uint32") &&
-          DescriptorBuilder<sint32_type_desc_t>::create("__builtin__.sint32") &&
           DescriptorBuilder<uint64_type_desc_t>::create("__builtin__.uint64") &&
           DescriptorBuilder<sint64_type_desc_t>::create("__builtin__.sint64") &&
           DescriptorBuilder<uintsize_type_desc_t>::create("__builtin__.uintsize") &&

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -55,6 +55,7 @@ enum
 {
     kMCTypeInfoTypeCodeMask = 0xff,
     kMCTypeInfoFlagHandlerIsForeign = 1 << 8,
+    kMCTypeInfoFlagHandlerIsVariadic = 1 << 9,
     
     // We use typecodes well above the fixed ones we have to
     // indicate 'special' typeinfo (i.e. those with no real

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -116,7 +116,13 @@ struct __MCTypeInfo: public __MCValue
         struct
         {
             MCForeignTypeDescriptor descriptor;
-            void *ffi_layout_type;
+            struct
+            {
+                size_t size;
+                unsigned short alignment;
+                unsigned short type;
+                void *unused;
+            } layout;
         } foreign;
     };
 };

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -545,75 +545,41 @@ MCTypeInfoRef MCOptionalTypeInfoGetBaseTypeInfo(MCTypeInfoRef p_base)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static ffi_type *__map_primitive_type(MCForeignPrimitiveType p_type)
+static int __map_primitive_type(MCForeignPrimitiveType p_type)
 {
     switch(p_type)
     {
         case kMCForeignPrimitiveTypeVoid:
-            return &ffi_type_void;
-        case kMCForeignPrimitiveTypeBool:
-            if (sizeof(bool) == 1)
-                return &ffi_type_uint8;
-            if (sizeof(bool) == 2)
-                return &ffi_type_uint16;
-            if (sizeof(bool) == 4)
-                return &ffi_type_uint32;
-            return &ffi_type_uint64;
+            return FFI_TYPE_VOID;
         case kMCForeignPrimitiveTypeUInt8:
-            return &ffi_type_uint8;
+            return FFI_TYPE_UINT8;
         case kMCForeignPrimitiveTypeSInt8:
-            return &ffi_type_sint8;
+            return FFI_TYPE_SINT8;
         case kMCForeignPrimitiveTypeUInt16:
-            return &ffi_type_uint16;
+            return FFI_TYPE_UINT16;
         case kMCForeignPrimitiveTypeSInt16:
-            return &ffi_type_sint16;
+            return FFI_TYPE_SINT16;
         case kMCForeignPrimitiveTypeUInt32:
-            return &ffi_type_uint32;
+            return FFI_TYPE_UINT32;
         case kMCForeignPrimitiveTypeSInt32:
-            return &ffi_type_sint32;
+            return FFI_TYPE_SINT32;
         case kMCForeignPrimitiveTypeUInt64:
-            return &ffi_type_uint64;
+            return FFI_TYPE_UINT64;
         case kMCForeignPrimitiveTypeSInt64:
-            return &ffi_type_sint64;
+            return FFI_TYPE_SINT64;
         case kMCForeignPrimitiveTypeFloat32:
-            return &ffi_type_float;
+            return FFI_TYPE_FLOAT;
         case kMCForeignPrimitiveTypeFloat64:
-            return &ffi_type_double;
+            return FFI_TYPE_DOUBLE;
         case kMCForeignPrimitiveTypePointer:
-            return &ffi_type_pointer;
+            return FFI_TYPE_POINTER;
+        case kMCForeignPrimitiveTypeAggregate:
+            return FFI_TYPE_STRUCT;
     }
     
     MCUnreachable();
     
-    return nil;
-}
-
-static bool __MCForeignTypeInfoComputeLayoutType(MCTypeInfoRef self)
-{
-    // If the typeinfo has a layout size of size 1, then it is just a value.
-    if (self -> foreign . descriptor . layout_size == 1)
-        self -> foreign . ffi_layout_type = __map_primitive_type(self -> foreign . descriptor . layout[0]);
-    else
-    {
-        ffi_type *t_type;
-        if (!MCMemoryNew(t_type))
-            return false;
-        if (!MCMemoryNewArray(self -> foreign . descriptor . layout_size + 1, t_type -> elements))
-        {
-            MCMemoryDelete(t_type);
-            return false;
-        }
-        
-        t_type -> alignment = 0;
-        t_type -> type = FFI_TYPE_STRUCT;
-        for(uindex_t i = 0; i < self -> foreign . descriptor . layout_size; i++)
-            t_type -> elements[i] = __map_primitive_type(self -> foreign . descriptor . layout[i]);
-        t_type -> elements[self -> foreign . descriptor . layout_size] = NULL;
-        
-        self -> foreign . ffi_layout_type = t_type;
-    }
-    
-    return true;
+    return 0;
 }
 
 MC_DLLEXPORT_DEF
@@ -625,18 +591,12 @@ bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCType
     if (!__MCValueCreate(kMCValueTypeCodeTypeInfo, self))
         return false;
     
-    if (!MCMemoryNewArray(p_descriptor -> layout_size, self -> foreign . descriptor . layout, self -> foreign . descriptor . layout_size))
-	{
-		MCValueRelease (self);
-        return false;
-	}
-    
     self -> flags |= kMCTypeInfoTypeIsForeign;
     
     self -> foreign . descriptor . size = p_descriptor -> size;
     self -> foreign . descriptor . basetype = MCValueRetain(p_descriptor -> basetype);
     self -> foreign . descriptor . bridgetype = MCValueRetain(p_descriptor -> bridgetype);
-    MCMemoryCopy(self -> foreign . descriptor . layout, p_descriptor -> layout, p_descriptor -> layout_size * sizeof(self -> foreign . descriptor . layout[0]));
+    self -> foreign . descriptor . primitive = p_descriptor->primitive;
     self -> foreign . descriptor . initialize = p_descriptor -> initialize;
     self -> foreign . descriptor . finalize = p_descriptor -> finalize;
     self -> foreign . descriptor . defined = p_descriptor -> defined;
@@ -650,11 +610,10 @@ bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCType
     self -> foreign . descriptor . promotedtype = MCValueRetain(p_descriptor->promotedtype);
     self -> foreign . descriptor . promote = p_descriptor -> promote;
     
-    if (!__MCForeignTypeInfoComputeLayoutType(self))
-    {
-        MCValueRelease(self);
-        return false;
-    }
+    self->foreign.layout.size = self->foreign.descriptor.size;
+    self->foreign.layout.alignment = self->foreign.descriptor.alignment;
+    self->foreign.layout.type = __map_primitive_type(self->foreign.descriptor.primitive);
+    self->foreign.layout.unused = nullptr;
     
     if (MCValueInterAndRelease(self, r_typeinfo))
         return true;
@@ -683,7 +642,7 @@ void *MCForeignTypeInfoGetLayoutType(MCTypeInfoRef unresolved_self)
 
 	MCAssert(MCTypeInfoIsForeign(self));
 
-    return self -> foreign . ffi_layout_type;
+    return &self -> foreign . layout;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1188,7 +1147,7 @@ void __MCTypeInfoDestroy(__MCTypeInfo *self)
     {
         MCValueRelease(self -> foreign . descriptor . basetype);
         MCValueRelease(self -> foreign . descriptor . bridgetype);
-        MCMemoryDeleteArray(self -> foreign . descriptor . layout);
+        MCValueRelease(self->foreign.descriptor.promotedtype);
     }
     else if (t_ext_typecode == kMCValueTypeCodeRecord)
     {

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -647,6 +647,8 @@ bool MCForeignTypeInfoCreate(const MCForeignTypeDescriptor *p_descriptor, MCType
     self -> foreign . descriptor . doimport = p_descriptor -> doimport;
     self -> foreign . descriptor . doexport = p_descriptor -> doexport;
     self -> foreign . descriptor . describe = p_descriptor -> describe;
+    self -> foreign . descriptor . promotedtype = MCValueRetain(p_descriptor->promotedtype);
+    self -> foreign . descriptor . promote = p_descriptor -> promote;
     
     if (!__MCForeignTypeInfoComputeLayoutType(self))
     {
@@ -803,6 +805,14 @@ static bool MCCommonHandlerTypeInfoCreate(bool p_is_foreign, const MCHandlerType
     for (index_t i = 0; i < p_field_count; ++i)
     {
 	    __MCAssertIsTypeInfo(p_fields[i].type);
+        
+        if (p_fields[i].mode == kMCHandlerTypeFieldModeVariadic)
+        {
+            p_field_count = i;
+            self->flags |= kMCTypeInfoFlagHandlerIsVariadic;
+            break;
+        }
+        
         self -> handler . fields[i] . type = MCValueRetain(p_fields[i] . type);
         self -> handler . fields[i] . mode = p_fields[i] . mode;
     }
@@ -842,6 +852,17 @@ bool MCHandlerTypeInfoIsForeign(MCTypeInfoRef unresolved_self)
     MCAssert(MCTypeInfoIsHandler(self));
 
     return (self -> flags & kMCTypeInfoFlagHandlerIsForeign) != 0;
+}
+
+MC_DLLEXPORT_DEF
+bool MCHandlerTypeInfoIsVariadic(MCTypeInfoRef unresolved_self)
+{
+    MCTypeInfoRef self;
+    self = __MCTypeInfoResolve(unresolved_self);
+
+    MCAssert(MCTypeInfoIsHandler(self));
+
+    return (self -> flags & kMCTypeInfoFlagHandlerIsVariadic) != 0;
 }
 
 MC_DLLEXPORT_DEF

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -347,6 +347,7 @@ enum MCScriptHandlerTypeParameterMode
     kMCScriptHandlerTypeParameterModeIn,
     kMCScriptHandlerTypeParameterModeOut,
     kMCScriptHandlerTypeParameterModeInOut,
+    kMCScriptHandlerTypeParameterModeVariadic,
     
     kMCScriptHandlerTypeParameterMode__Last
 };

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -71,7 +71,7 @@ static bool __cbuffer_defined(void *contents)
     return *(void **)contents != nil;
 }
 
-static bool __cbuffer_move(void *from, void *to)
+static bool __cbuffer_move(const MCForeignTypeDescriptor*, void *from, void *to)
 {
     *(void **)to = *(void **)from;
     return true;
@@ -79,7 +79,7 @@ static bool __cbuffer_move(void *from, void *to)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static bool __cstring_copy(void *from, void *to)
+static bool __cstring_copy(const MCForeignTypeDescriptor*, void *from, void *to)
 {
     if (*(void **)from == nil)
     {
@@ -103,7 +103,7 @@ static bool __cstring_copy(void *from, void *to)
     return true;
 }
 
-static bool __cstring_equal(void *left, void *right, bool& r_equal)
+static bool __cstring_equal(const MCForeignTypeDescriptor*, void *left, void *right, bool& r_equal)
 {
     if (*(void **)left == nil || *(void **)right == nil)
 		r_equal = (left == right);
@@ -112,7 +112,7 @@ static bool __cstring_equal(void *left, void *right, bool& r_equal)
 	return true;
 }
 
-static bool __cstring_hash(void *value, hash_t& r_hash)
+static bool __cstring_hash(const MCForeignTypeDescriptor*, void *value, hash_t& r_hash)
 {
     if (*(void **)value == nil)
     {
@@ -162,7 +162,8 @@ __wstring_len (const unichar_t *value)
 }
 
 static bool
-__wstring_copy (void *from,
+__wstring_copy (const MCForeignTypeDescriptor*,
+                void *from,
                 void *to)
 {
 	if (nil == *(void **) from)
@@ -189,7 +190,8 @@ __wstring_copy (void *from,
 }
 
 static bool
-__wstring_equal (void *left,
+__wstring_equal (const MCForeignTypeDescriptor*,
+                 void *left,
                  void *right,
                  bool & r_equal)
 {
@@ -212,7 +214,8 @@ __wstring_equal (void *left,
 }
 
 static bool
-__wstring_hash (void *value,
+__wstring_hash (const MCForeignTypeDescriptor*,
+                void *value,
                 hash_t & r_hash)
 {
 	if (nil == *(void **)value)
@@ -316,14 +319,11 @@ static bool __build_typeinfo(const char *p_name, MCForeignTypeDescriptor *p_desc
 
 extern "C" bool com_livecode_foreign_Initialize(void)
 {
-    MCForeignPrimitiveType p;
     MCForeignTypeDescriptor d;
     d . size = sizeof(char *);
     d . basetype = kMCNullTypeInfo;
     d . bridgetype = kMCStringTypeInfo;
-    p = kMCForeignPrimitiveTypePointer;
-    d . layout = &p;
-    d . layout_size = 1;
+    d . primitive = kMCForeignPrimitiveTypePointer;
     d . initialize = __cbuffer_initialize;
     d . finalize = __cbuffer_finalize;
     d . defined = __cbuffer_defined;
@@ -342,9 +342,7 @@ extern "C" bool com_livecode_foreign_Initialize(void)
 	d . size = sizeof(unichar_t *);
 	d . basetype = kMCNullTypeInfo;
 	d . bridgetype = kMCStringTypeInfo;
-	p = kMCForeignPrimitiveTypePointer;
-	d . layout = &p;
-	d . layout_size = 1;
+	d . primitive = kMCForeignPrimitiveTypePointer;
 	d . initialize = __cbuffer_initialize;
 	d . finalize = __cbuffer_finalize;
 	d . defined = __cbuffer_defined;
@@ -363,9 +361,7 @@ extern "C" bool com_livecode_foreign_Initialize(void)
 	d . size = sizeof(char *);
 	d . basetype = kMCNullTypeInfo;
 	d . bridgetype = kMCStringTypeInfo;
-	p = kMCForeignPrimitiveTypePointer;
-	d . layout = &p;
-	d . layout_size = 1;
+	d . primitive = kMCForeignPrimitiveTypePointer;
 	d . initialize = __cbuffer_initialize;
 	d . finalize = __cbuffer_finalize;
 	d . defined = __cbuffer_defined;

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -334,6 +334,8 @@ extern "C" bool com_livecode_foreign_Initialize(void)
     d . doimport = __nativecstring_import;
     d . doexport = __nativecstring_export;
     d . describe = nullptr;
+    d . promotedtype = kMCNullTypeInfo;
+    d . promote = nullptr;
     if (!__build_typeinfo("com.livecode.foreign.NativeCString", &d, kMCNativeCStringTypeInfo))
         return false;
 
@@ -353,6 +355,8 @@ extern "C" bool com_livecode_foreign_Initialize(void)
 	d . doimport = __wstring_import;
 	d . doexport = __wstring_export;
     d . describe = nullptr;
+    d . promotedtype = kMCNullTypeInfo;
+    d . promote = nullptr;
 	if (!__build_typeinfo("com.livecode.foreign.WString", &d, kMCWStringTypeInfo))
 		return false;
 
@@ -372,6 +376,8 @@ extern "C" bool com_livecode_foreign_Initialize(void)
 	d . doimport = __utf8string_import;
 	d . doexport = __utf8string_export;
     d . describe = nullptr;
+    d . promotedtype = kMCNullTypeInfo;
+    d . promote = nullptr;
 	if (!__build_typeinfo("com.livecode.foreign.UTF8String", &d, kMCUTF8StringTypeInfo))
 		return false;
 	

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -949,7 +949,8 @@ MCScriptExecuteContext::UnboxingConvert(MCValueRef p_value,
             // If the two foreign types are the same, copy the contents
             if (t_slot_desc == t_from_desc)
             {
-                if (!t_slot_desc->copy(MCForeignValueGetContentsPtr(p_value),
+                if (!t_slot_desc->copy(t_slot_desc,
+                                       MCForeignValueGetContentsPtr(p_value),
                                        x_slot_ptr))
                 {
                     Rethrow();

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -18,6 +18,8 @@
 
 #include "script-private.h"
 
+class MCScriptForeignInvocation;
+
 class MCScriptExecuteContext
 {
 public:
@@ -140,6 +142,22 @@ public:
 	// no return value.
 	void PopFrame(uindex_t result_reg);
 	
+    // Accumulate a non-fixed var-arg arg into the invocation.
+    bool InvokeForeignVarArgument(MCScriptForeignInvocation& invocation,
+                                  MCScriptInstanceRef instance,
+                                  MCScriptForeignHandlerDefinition *handler_def,
+                                  uindex_t arg_index,
+                                  uindex_t arg_reg);
+    
+    // Accumulate a fixed arg into the invocation.
+    bool InvokeForeignArgument(MCScriptForeignInvocation& p_invocation,
+                               MCScriptInstanceRef p_instance,
+                               MCScriptForeignHandlerDefinition *p_handler_def,
+                               uindex_t arg_index,
+                               MCHandlerTypeFieldMode mode,
+                               MCTypeInfoRef type,
+                               uindex_t arg_reg);
+    
 	// Invoke a foreign function with the given arguments, taken from registers
 	// returning the value into the result register.
 	void InvokeForeign(MCScriptInstanceRef instance,

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -184,6 +184,8 @@ struct MCScriptHandlerTypeParameter
 			return kMCHandlerTypeFieldModeOut;
 		case kMCScriptHandlerTypeParameterModeInOut:
 			return kMCHandlerTypeFieldModeInOut;
+		case kMCScriptHandlerTypeParameterModeVariadic:
+			return kMCHandlerTypeFieldModeVariadic;
 		default:
 			MCUnreachableReturn(kMCHandlerTypeFieldModeIn);
 		}

--- a/tests/_compilertestrunnerbehavior.livecodescript
+++ b/tests/_compilertestrunnerbehavior.livecodescript
@@ -108,10 +108,15 @@ private command runCompilerTest pInfo, pScriptFile, pTest
    local tCommandLine
    
    -- First we need to process the specified test in script file
-   
+
    local tTestInfo
-   processCompilerTest pInfo, pScriptFile, pTest, tTestInfo
-   
+   try
+      processCompilerTest pInfo, pScriptFile, pTest, tTestInfo
+   catch tError
+      write tError & return to stderr
+      quit 1
+   end try
+
    local tCompilerOutput, tCompilerExitStatus
    dispatch "CompilerTestRunner_DoRunTest" to me with tTestInfo, tCompilerOutput, tCompilerExitStatus
    reportCompilerTestDiag tCompilerOutput
@@ -426,7 +431,7 @@ private command processCompilerTest pInfo, pScriptFile, pTest, @rCompilerTest
          end if
       end if
    end repeat
-   
+
    if tName is empty then
       reportCompilerTestError pScriptFile, tLineNumber, format("test '%s' not found in file", pTest)
    end if

--- a/tests/lcb/compiler/frontend/variadic.compilertest
+++ b/tests/lcb/compiler/frontend/variadic.compilertest
@@ -1,0 +1,59 @@
+%% Copyright (C) 2017 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%% Variadic parameter must be the last in the parameter list
+%TEST VariadicLastInForeignHandler
+module compiler_test
+foreign handler TestVariadic(in pA as any, ...) returns nothing binds to ""
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Variadic parameter must be the last in the parameter list
+%TEST VariadicNotLastInForeignHandler
+module compiler_test
+foreign handler TestVariadic(in pA as any, %{BEFORE_VARIADIC}..., in pB as any) returns nothing binds to ""
+end module
+%EXPECT PASS
+%ERROR "Variadic parameter must be the last" AT BEFORE_VARIADIC
+%ENDTEST
+
+%% Variadic parameters are not allowed in non-foreign handlers
+%TEST VariadicNotAllowedInNonForeign
+module compiler_test
+handler TestVariadic(in pA as any, %{BEFORE_VARIADIC}...) returns nothing
+end handler
+end module
+%EXPECT PASS
+%ERROR "Variadic parameters only allowed in foreign handlers" AT BEFORE_VARIADIC
+%ENDTEST
+
+%% You can have 0 to any number of variadic arguments
+%TEST VariadicParametersAnyCount
+module compiler_test
+__safe foreign handler TestVariadic(in pA as any, ...) returns nothing binds to ""
+handler CallVariadic()
+	TestVariadic(1)
+	TestVariadic(1, 2)
+	TestVariadic(1, 2, 3)
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%%%ERROR "Too few arguments for specified handler" AT BEFORE_ZERO

--- a/tests/lcb/vm/foreign-invoke.lcb
+++ b/tests/lcb/vm/foreign-invoke.lcb
@@ -55,4 +55,12 @@ public handler TestForeignInvoke_Varargs()
    test "sprintf works with variadic arguments" when tString2 is "1000 1000000000 1000000000000000 3.5 7.5"
 end handler
 
+--
+
+foreign type NSRect binds to "MCAggregateTypeInfo:OOOO"
+
+public handler TestForeignInvoke_Aggregate()
+   variable tRect as NSRect
+end handler
+
 end module

--- a/tests/lcb/vm/foreign-invoke.lcb
+++ b/tests/lcb/vm/foreign-invoke.lcb
@@ -18,4 +18,41 @@ public handler TestForeignInvoke_OptionalPointerResult()
    test "non-nullptr maps to non-nothing for optional Pointer" when tNonNullNativeCharPtr is not nothing
 end handler
 
+--
+
+foreign handler malloc(in pSize as UIntSize) returns Pointer binds to "<builtin>"
+foreign handler free(in pBlock as Pointer) returns nothing binds to "<builtin>"
+foreign handler sprintf(in pTarget as Pointer, in pFormat as ZStringNative, ...) returns CInt binds to "<builtin>"
+foreign handler MCStringCreateWithCString(in pCString as Pointer, out rString as String) returns CBool binds to "<builtin>"
+
+public handler TestForeignInvoke_Varargs()
+   variable tString1 as String
+   variable tString2 as String
+   unsafe
+      variable tOutputBuffer as Pointer
+      put malloc(4096) into tOutputBuffer
+
+      sprintf(tOutputBuffer, "no formats")
+      MCStringCreateWithCString(tOutputBuffer, tString1)
+
+      variable tInt as SInt16
+      variable tLong as SInt32
+      variable tLongLong as SInt64
+      variable tFloat as CFloat
+      variable tDouble as CDouble
+      put 1000 into tInt
+      put 1000000000 into tLong
+      put tLong * 1000000 into tLongLong
+      put 3.5 into tFloat
+      put 7.5 into tDouble
+      sprintf(tOutputBuffer, "%d %ld %lld %.1f %.1lf", tInt, tLong, tLongLong, tFloat, tDouble)
+      MCStringCreateWithCString(tOutputBuffer, tString2)
+
+      free(tOutputBuffer)
+   end unsafe
+   test "sprintf works with no variadic arguments" when tString1 is "no formats"
+   test diagnostic tString2
+   test "sprintf works with variadic arguments" when tString2 is "1000 1000000000 1000000000000000 3.5 7.5"
+end handler
+
 end module

--- a/toolchain/lc-compile/src/bind.g
+++ b/toolchain/lc-compile/src/bind.g
@@ -238,7 +238,7 @@
     'rule' DeclareParameters(parameterlist(parameter(_, _, Name, _), Tail)):
         DeclareId(Name)
         DeclareParameters(Tail)
-        
+
     'rule' DeclareParameters(nil):
         -- do nothing
 
@@ -334,7 +334,7 @@
     'rule' DefineParameters(ModuleId, parameterlist(parameter(_, _, Name, Type), Tail)):
         DefineSymbolId(Name, ModuleId, inferred, parameter, Type)
         DefineParameters(ModuleId, Tail)
-        
+
     'rule' DefineParameters(ModuleId, nil):
         -- do nothing
 
@@ -904,7 +904,8 @@
     'rule' DumpBindings(PARAMETER'parameter(_, _, Name, Type)):
         DumpId("parameter", Name)
         DumpBindings(Type)
-        
+
+
     'rule' DumpBindings(STATEMENT'variable(_, Name, Type)):
         DumpId("local variable", Name)
         DumpBindings(Type)

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -112,6 +112,7 @@ extern "C" void EmitBeginForeignHandlerType(intptr_t return_type_index);
 extern "C" void EmitHandlerTypeInParameter(NameRef name, intptr_t type_index);
 extern "C" void EmitHandlerTypeOutParameter(NameRef name, intptr_t type_index);
 extern "C" void EmitHandlerTypeInOutParameter(NameRef name, intptr_t type_index);
+extern "C" void EmitHandlerTypeVariadicParameter(NameRef name);
 extern "C" void EmitEndHandlerType(intptr_t& r_index);
 extern "C" void EmitHandlerParameter(NameRef name, intptr_t type_index, intptr_t& r_index);
 extern "C" void EmitHandlerVariable(NameRef name, intptr_t type_index, intptr_t& r_index);
@@ -1537,6 +1538,13 @@ void EmitHandlerTypeOutParameter(NameRef name, intptr_t type_index)
 void EmitHandlerTypeInOutParameter(NameRef name, intptr_t type_index)
 {
     EmitHandlerTypeParameter(kMCHandlerTypeFieldModeInOut, name, type_index);
+}
+
+void EmitHandlerTypeVariadicParameter(NameRef name)
+{
+    intptr_t type_index;
+    EmitListType(type_index);
+    EmitHandlerTypeParameter(kMCHandlerTypeFieldModeVariadic, name, type_index);
 }
 
 void EmitEndHandlerType(intptr_t& r_type_index)

--- a/toolchain/lc-compile/src/grammar.g
+++ b/toolchain/lc-compile/src/grammar.g
@@ -513,6 +513,11 @@
 
     'rule' Parameter(-> parameter(Position, in, Name, Type)):
         Identifier(-> Name) @(-> Position) OptionalTypeClause(-> Type)
+
+    'rule' Parameter(-> parameter(Position, variadic, Name, unspecified)):
+        "..." @(-> Position)
+        MakeNameLiteral("" -> Identifier)
+		AssignId(Position, Identifier, nil -> Name)
         
 'nonterm' Mode(-> MODE)
 

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -209,6 +209,7 @@
     EmitHandlerTypeInParameter
     EmitHandlerTypeOutParameter
     EmitHandlerTypeInOutParameter
+    EmitHandlerTypeVariadicParameter
     EmitEndHandlerType
     EmitHandlerParameter
     EmitHandlerVariable
@@ -353,6 +354,8 @@
     Error_BytecodeNotAllowedInSafeContext
     Error_UnsafeHandlerCallNotAllowedInSafeContext
     Error_InvalidNameForNamespace
+    Error_VariadicParametersOnlyAllowedInForeignHandlers
+    Error_VariadicParameterMustBeLast
 
     Warning_MetadataClausesShouldComeAfterUseClauses
     Warning_DeprecatedTypeName
@@ -612,6 +615,7 @@
 'action' EmitHandlerTypeInParameter(Name: NAME, Type: INT)
 'action' EmitHandlerTypeOutParameter(Name: NAME, Type: INT)
 'action' EmitHandlerTypeInOutParameter(Name: NAME, Type: INT)
+'action' EmitHandlerTypeVariadicParameter(Name: NAME)
 'action' EmitEndHandlerType(-> INT)
 
 'action' EmitHandlerParameter(Name: NAME, Type: INT -> Index: INT)
@@ -779,6 +783,9 @@
 
 'action' Error_BytecodeNotAllowedInSafeContext(Position: POS)
 'action' Error_UnsafeHandlerCallNotAllowedInSafeContext(Position: POS, Identifier: NAME)
+
+'action' Error_VariadicParametersOnlyAllowedInForeignHandlers(Position: POS)
+'action' Error_VariadicParameterMustBeLast(Position: POS)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)

--- a/toolchain/lc-compile/src/types.g
+++ b/toolchain/lc-compile/src/types.g
@@ -39,6 +39,7 @@
     NAME DOUBLE
     SYNTAXPRECEDENCE
     BYTECODE
+    QueryExpressionListLength
 
 --------------------------------------------------------------------------------
 
@@ -126,6 +127,7 @@
     in
     out
     inout
+    variadic
 
 'type' BYTECODE
     sequence(Left: BYTECODE, Right: BYTECODE)
@@ -375,5 +377,15 @@
 
 'type' NAME
 'type' DOUBLE
+
+--------------------------------------------------------------------------------
+
+'action' QueryExpressionListLength(EXPRESSIONLIST -> INT)
+
+    'rule' QueryExpressionListLength(expressionlist(_, Tail) -> TailCount + 1)
+        QueryExpressionListLength(Tail -> TailCount)
+
+    'rule' QueryExpressionListLength(nil -> 0)
+        -- nothing
 
 --------------------------------------------------------------------------------

--- a/toolchain/libcompile/src/literal.c
+++ b/toolchain/libcompile/src/literal.c
@@ -912,6 +912,13 @@ IsNameValidForNamespace(NameRef p_id)
     
     GetStringOfNameLiteral (p_id, &t_id);
     
+    /* Empty names are always fine (as they are only allowed in specific
+     * contexts) */
+    if (*t_id == '\0')
+    {
+        return 1;
+    }
+    
     /* Must not start with a digit */
     if (t_id[0] >= '0' &&
         t_id[0] <= '9')
@@ -931,6 +938,13 @@ IsNameSuitableForDefinition (NameRef p_id)
 	size_t i;
 
 	GetStringOfNameLiteral (p_id, &t_id);
+
+    /* Empty names are always fine (as they are only allowed in specific
+     * contexts) */
+    if (*t_id == '\0')
+    {
+        return 1;
+    }
 
     for(i = 0; '\0' != t_id[i]; ++i)
     {

--- a/toolchain/libcompile/src/report.c
+++ b/toolchain/libcompile/src/report.c
@@ -401,6 +401,9 @@ DEFINE_ERROR(IllegalNumberOfArgumentsForOpcode, "Wrong number of arguments for o
 DEFINE_ERROR(BytecodeNotAllowedInSafeContext, "Bytecode blocks can only be present in unsafe context")
 DEFINE_ERROR_I(UnsafeHandlerCallNotAllowedInSafeContext, "Unsafe handler '%s' can only be called in unsafe context")
 
+DEFINE_ERROR(VariadicParameterMustBeLast, "Variadic parameter must be the last")
+DEFINE_ERROR(VariadicParametersOnlyAllowedInForeignHandlers, "Variadic parameters only allowed in foreign handlers")
+
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(intptr_t p_position) { _Warning(p_position, Message); }
 #define DEFINE_WARNING_I(Name, Message) \


### PR DESCRIPTION
This is the beginnings of aggregate support in C bindings for LCB.

The only information required to pass an aggregate (by value) is its size and alignment. Depending on the size will determine whether it gets spilled into the stack, or cut up into registers (the details of which are handled by libffi).

In order to support aggregates, this patch adds the ability to use a 'foreign type constructor' in the foreign type clause:
```
  foreign type MyForeignType is "MCForeignTypeInfo:<binding>"
```
The MCForeignTypeInfo symbol must be a function which constructs a new (parameterized) typeinfo from the binding string.

An aggregate is then a sequence of types specified as a format string. For example 'OOOO' would mean four doubles with natural alignment. The purpose of the Aggregate type is merely to be able to describe the sequence of fields in a block of memory - allowing such a thing to be described in an architecture independent manner (i.e. it allows the issue of things like size_t and void* being different sizes on 32-bit vs 64-bit platforms to be handled transparently). Access to an aggregate will be via a new 'Address' type - representing a memory location; and collection of 'Peek' and 'Poke' functions allowing specific (foreign) types to be fetched and stored at an address.

This (very) low-level support will allow glue code to be written which maps from C structs and arrays to LCB Arrays and Lists. It will be possible to autogenerate these shims in the majority of cases, but by having the individual low-level operations exposed, it means more complex structures can be hand-wrapped.

NOTE: This is still in its early stages, although the type constructor logic is there; as is an initial implementation of the aggregate type family. This PR currently contains the ffi-varargs branch, as it depends on it (hence why it is a lot larger than it should be!).