### PR TITLE
[[ Bug 19994 ]] Clear substacks in destroystack

### DIFF
--- a/docs/notes/bugfix-19994.md
+++ b/docs/notes/bugfix-19994.md
@@ -1,0 +1,1 @@
+# Ensure startup stack substacks are cleanly removed from memory

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -363,6 +363,12 @@ void MCDispatch::destroystack(MCStack *sptr, Boolean needremove)
 {
 	if (needremove)
     {
+        MCStack *t_substacks = sptr -> getsubstacks();
+        while (t_substacks)
+        {
+            t_substacks -> dodel();
+            t_substacks = sptr -> getsubstacks();
+        }
         sptr -> dodel();
     }
 	if (sptr == MCstaticdefaultstackptr)


### PR DESCRIPTION
Prevously substacks were not being cleared correctly when the
startup stack was destroyed and therefore substacks that were
referenced were not cleanly removed.