### PR TITLE
[[Bug 18305]] Add Synonyms to Dictionary

### DIFF
--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -279,9 +279,6 @@ function revDocsParseDictionaryToLibraryArray pRootDir
                   put tSynonymName into tLibraryA[tCount]["display name"]
                   if tParsedA["doc"][1]["Type"] is not "glossary" then
                      put " (Synonym of " & tDisplayName & ")" after tLibraryA[tCount]["display name"]
-                     -- dictionary searches 'display syntax' for matches, need to add synonym there for visibility
-                     -- only first entry is displayed, so add to second
-                     put tSynonymName after tLibraryA[tCount]["display syntax"][2]
                   end if
                   add 1 to tCount
                end repeat

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -279,6 +279,9 @@ function revDocsParseDictionaryToLibraryArray pRootDir
                   put tSynonymName into tLibraryA[tCount]["display name"]
                   if tParsedA["doc"][1]["Type"] is not "glossary" then
                      put " (Synonym of " & tDisplayName & ")" after tLibraryA[tCount]["display name"]
+                     -- dictionary searches 'display syntax' for matches, need to add synonym there for visibility
+                     -- only first entry is displayed, so add to second
+                     put tSynonymName after tLibraryA[tCount]["display syntax"][2]
                   end if
                   add 1 to tCount
                end repeat

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -250,7 +250,7 @@ function revDocsParseDictionaryToLibraryArray pRootDir
    local tCount
    put 1 into tCount
    
-   local tText, tLibraryA, tParsedA
+   local tText, tLibraryA, tParsedA, tDisplayName, tSynonymA
    
    repeat for each item tRoot in (tDictionaryRoot & "," & tGlossaryRoot)
       repeat for each line tLine in folders(tRoot)
@@ -268,6 +268,22 @@ function revDocsParseDictionaryToLibraryArray pRootDir
             put revDocsParseDocText(tText, tFullPath) into tParsedA
             put tParsedA["doc"][1] into tLibraryA[tCount]
             add 1 to tCount
+            -- BWM fix for Bug 18305
+            -- add an additional entry to dictionary for each synonym to allow keyword search
+            if tParsedA["doc"][1]["Synonyms"] is not empty then
+               put tParsedA["doc"][1]["display name"] into tDisplayName
+               put tParsedA["doc"][1]["Synonyms"] into tSynonymA
+               repeat for each element tSynonymName in tSynonymA
+                  if tSynonymName is tDisplayName then next repeat -- glossary entries include themselves
+                  put tParsedA["doc"][1] into tLibraryA[tCount]
+                  put tSynonymName into tLibraryA[tCount]["display name"]
+                  if tParsedA["doc"][1]["Type"] is not "glossary" then
+                     put " (Synonym of " & tDisplayName & ")" after tLibraryA[tCount]["display name"]
+                  end if
+                  add 1 to tCount
+               end repeat
+            end if
+            -- end fix for Bug 18305
          end repeat
       end repeat
    end repeat


### PR DESCRIPTION
LC 7 allowed searching for synonyms within the dictionary.  Implementation appears to have been by duplicating the dictionary entries for each synonym.  This fix will duplicate the dictionary entry for each synonym when the entries are built from the repository.  "Synonym of" is added to the display name of each non-glossary entry (glossary synonyms do not seem to mean that the terms mean the same thing - i.e. card button, card field, card control, card object).

The change is made in the "revDocsParseDictionaryToLibraryArray" handler.  On each pass through the loop, the resulting array is tested to see if the "Synonyms" key contains data.  If it does, then loop through each synonym and duplicate the entry (taking into account that glossary entries specify themselves as a synonym).  The display name is changed to the synonym and "Synonym of ..." is added as a cross-reference for non-glossary entries.