### PR TITLE
[[ Bug 19979 ]] Use explicit file names in extract-docs

### DIFF
--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -77,23 +77,17 @@
 				'../extensions/script-libraries/diff/diff.livecodescript',
 				'../extensions/script-libraries/messageauthentication/messageauthentication.livecodescript',
 			],
-			
-			'actions':
+            
+            'rules':
 			[
 				{
-					'action_name': 'extract_docs_from_stacks',
-					'message': 'Extracting docs from stacks',
-					
-					'inputs':
-					[
-						'../util/extract-docs.livecodescript',
-						'../ide-support/revdocsparser.livecodescript',
-						'<@(_sources)',
-					],
+					'rule_name': 'extract-docs-from-stack',
+					'extension': 'livecodescript',
+					'message': 'Extracting docs from script-only stack <(RULE_INPUT_NAME)',
 					
 					'outputs':
 					[
-						'<(PRODUCT_DIR)/extracted_docs',
+						'<(PRODUCT_DIR)/extracted_docs/com.livecode.script-library.<(RULE_INPUT_ROOT).lcdoc',
 					],
 					
 					'action':
@@ -102,7 +96,7 @@
 						'../util/extract-docs.livecodescript',
 						'../ide-support/revdocsparser.livecodescript',
 						'<(PRODUCT_DIR)/extracted_docs',
-						'<@(_sources)',
+						'<(RULE_INPUT_PATH)',
 					],
 				},
 			],


### PR DESCRIPTION
This patch changes the extract docs target to use explicit file names
as output so that the commercial equivalent of the target can add
files into the extracted docs directory without the build tools thinking
that the target output exists and skipping the target.