### PR TITLE
[[ Docs ]] Add some message associations

### DIFF
--- a/docs/dictionary/message/arrowKey.lcdoc
+++ b/docs/dictionary/message/arrowKey.lcdoc
@@ -8,9 +8,9 @@ Summary:
 the <active (focused) control(glossary)>, or to the <current card> if no
 <control> is <focus|focused>, when the user presses an arrow key.
 
-Associations: button
-
 Introduced: 1.0
+
+Associations: card,field
 
 OS: mac, windows, linux
 

--- a/docs/dictionary/message/backspaceKey.lcdoc
+++ b/docs/dictionary/message/backspaceKey.lcdoc
@@ -8,7 +8,7 @@ Summary:
 Sent to the <active (focused) control(glossary)>, or to the <current
 card> if no <control> is <focus|focused>.
 
-Associations: button
+Associations: card,field
 
 Introduced: 1.0
 

--- a/docs/dictionary/message/commandKeyDown.lcdoc
+++ b/docs/dictionary/message/commandKeyDown.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Sent when a Command <key combination> (Control-key on <Unix> or
 <Windows>) is pressed.
 
+Associations: card,field
+
 Introduced: 1.0
 
 OS: mac, windows, linux

--- a/docs/dictionary/message/controlKeyDown.lcdoc
+++ b/docs/dictionary/message/controlKeyDown.lcdoc
@@ -7,6 +7,8 @@ Syntax: controlKeyDown <keyName>
 Summary:
 Sent when a Control <key combination> is pressed.
 
+Associations: card,field
+
 Introduced: 1.0
 
 OS: mac, linux

--- a/docs/dictionary/message/deleteKey.lcdoc
+++ b/docs/dictionary/message/deleteKey.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Sent to the <active (focused) control(glossary)>, or to the <current
 card> if there is no <active control>.
 
+Associations: card,field
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/enterKey.lcdoc
+++ b/docs/dictionary/message/enterKey.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Sent when the user presses the Enter key, if there is no text
 <selection>. 
 
+Associations: card,field
+
 Introduced: 1.0
 
 OS: mac, windows, linux

--- a/docs/dictionary/message/escapeKey.lcdoc
+++ b/docs/dictionary/message/escapeKey.lcdoc
@@ -7,6 +7,8 @@ Syntax: escapeKey
 Summary:
 Sent when the user presses the <Escape key>.
 
+Associations: card, field
+
 Introduced: 1.0
 
 OS: mac, windows, linux

--- a/docs/dictionary/message/focusIn.lcdoc
+++ b/docs/dictionary/message/focusIn.lcdoc
@@ -9,6 +9,8 @@ Sent to a <control> when it becomes <active (focused)(glossary)>.
 
 Introduced: 1.0
 
+Associations: button,field
+
 OS: mac, windows, linux, ios, android
 
 Platforms: desktop, server, mobile

--- a/docs/dictionary/message/focusOut.lcdoc
+++ b/docs/dictionary/message/focusOut.lcdoc
@@ -7,6 +7,8 @@ Syntax: focusOut
 Summary:
 Sent to a <button> or <field> when it becomes inactive (loses <focus>).
 
+Associations: button,field
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/keyDown.lcdoc
+++ b/docs/dictionary/message/keyDown.lcdoc
@@ -7,6 +7,8 @@ Syntax: keyDown <keyName>
 Summary:
 Sent when the user presses a key.
 
+Associations: card,field
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/keyUp.lcdoc
+++ b/docs/dictionary/message/keyUp.lcdoc
@@ -7,6 +7,8 @@ Syntax: keyUp <keyname>
 Summary:
 Sent when the user releases a pressed key.
 
+Associations: card,field
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseDoubleDown.lcdoc
+++ b/docs/dictionary/message/mouseDoubleDown.lcdoc
@@ -7,6 +7,9 @@ Syntax: mouseDoubleDown <mouseButtonNumber>
 Summary:
 Sent when the user <double-click|double-clicks>.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseDoubleUp.lcdoc
+++ b/docs/dictionary/message/mouseDoubleUp.lcdoc
@@ -8,6 +8,9 @@ Summary:
 Sent when the user <double-click|double-clicks> and the <mouse button>
 is released.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseDown.lcdoc
+++ b/docs/dictionary/message/mouseDown.lcdoc
@@ -7,6 +7,9 @@ Syntax: mouseDown <mouseButtonNumber>
 Summary:
 Sent when the user presses the <mouse button>.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseEnter.lcdoc
+++ b/docs/dictionary/message/mouseEnter.lcdoc
@@ -7,6 +7,9 @@ Syntax: mouseEnter
 Summary:
 Sent when the <mouse pointer> moves into an <object(glossary)>.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseLeave.lcdoc
+++ b/docs/dictionary/message/mouseLeave.lcdoc
@@ -7,6 +7,9 @@ Syntax: mouseLeave
 Summary:
 Sent when the <mouse pointer> moves out of an <object(glossary)>.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseMove.lcdoc
+++ b/docs/dictionary/message/mouseMove.lcdoc
@@ -7,6 +7,9 @@ Syntax: mouseMove <newMouseH>, <newMouseV>
 Summary:
 Sent when the user moves the mouse.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseRelease.lcdoc
+++ b/docs/dictionary/message/mouseRelease.lcdoc
@@ -8,6 +8,9 @@ Summary:
 Sent when the user releases the mouse outside the <control> that was
 clicked. 
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseStillDown.lcdoc
+++ b/docs/dictionary/message/mouseStillDown.lcdoc
@@ -7,6 +7,9 @@ Syntax: mouseStillDown <mouseButtonNumber>
 Summary:
 Sent periodically while the <mouse button> is being held down.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseUp.lcdoc
+++ b/docs/dictionary/message/mouseUp.lcdoc
@@ -7,6 +7,9 @@ Syntax: mouseUp <mouseButtonNumber>
 Summary:
 Sent when the user releases the <mouse button>.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/mouseWithin.lcdoc
+++ b/docs/dictionary/message/mouseWithin.lcdoc
@@ -8,6 +8,9 @@ Summary:
 Sent periodically to an <object(glossary)> while the <mouse pointer> is
 within its borders.
 
+Associations: stack, card, field, button, graphic, scrollbar, player,
+image
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/message/returnKey.lcdoc
+++ b/docs/dictionary/message/returnKey.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Sent to the active <object(glossary)> when there is no text <selection>
 and the user presses the Return key.
 
+Assocations: card, field
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android


### PR DESCRIPTION
The default handler mechanism looks at the associated object types
when choosing which handlers to present as options to add to
scripts. This patch adds some associations to make this feature
work slightly more as expected.