### PR TITLE
[[ Bug 19622 ]] Line continuations

### DIFF
--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -599,7 +599,7 @@ on revDocsExtractDocBlocks pText, pSource, @rAPIData, @rLibraryData
       
       # If we are in an entry, add the line to the current data
       if tInEntry then
-      # handle line continuations
+         # handle line continuations
          if char -2 of tData is "\" then
             delete char -2 to -1 of tData
          # ignore empty lines

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -599,9 +599,9 @@ on revDocsExtractDocBlocks pText, pSource, @rAPIData, @rLibraryData
       
       # If we are in an entry, add the line to the current data
       if tInEntry then
-	     # handle line continuations
-		 if char -2 of tData is "\" then
-		    delete char -2 to -1 of tData
+      # handle line continuations
+         if char -2 of tData is "\" then
+            delete char -2 to -1 of tData
          # ignore empty lines
          else if tFirstWord is empty then
             next repeat

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -598,9 +598,12 @@ on revDocsExtractDocBlocks pText, pSource, @rAPIData, @rLibraryData
       end if
       
       # If we are in an entry, add the line to the current data
-      if tInEntry then         
+      if tInEntry then
+	     # handle line continuations
+		 if char -2 of tData is "\" then
+		    delete char -2 to -1 of tData
          # ignore empty lines
-         if tFirstWord is empty then 
+         else if tFirstWord is empty then
             next repeat
          else if tFirstWord is "end" then
             put true into tEntryEnded

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -436,7 +436,7 @@ on revDocsExtractDocBlocks pText, pSource, @rAPIData, @rLibraryData
    put false into tInComment
    put false into tInEntry
    
-   local tFirstWord, tEntryData
+   local tFirstWord, tEntryData, tTrimLine
    local tComment, tData
    local tHandlerData, tPhraseData
    
@@ -608,7 +608,13 @@ on revDocsExtractDocBlocks pText, pSource, @rAPIData, @rLibraryData
          else if tFirstWord is "end" then
             put true into tEntryEnded
          end if
-         put tLine & return after tData
+         # continuation character can have spaces afterwards [[Bug 19927]]
+         # trim trailing spaces before adding
+         if matchText(tLine, "^(.*\\)\s*$", tTrimLine) then
+            put tTrimLine & return after tData
+         else
+            put tLine & return after tData
+         end if
       end if
       
       # If the entry is ended, convert all the collected data to a structured array


### PR DESCRIPTION
Line continuation characters are not handled in the main loop of revDocsExtractDocBlocks that adds lines to "tData".  They do get parsed for "syntax" type (revDocsUpdateModularSyntaxDocBlocks gets all of "tData"), but for "handler", "function", and "command" types, only the first line of "tData" gets passed (revDocsParseHandler, revDocsUpdateDocBlocks).  Proposed solution is that while in an entry, check the previous line for the continuation character.  If present, remove it and the return.  This causes the current line to be appended to the previous line in "tData".

I considered adding code to parse "tData" to revDocsUpdateDocBlocks, but it would have also been needed in revDocsParseHandler.  Rather than duplicate the code 2 additional times, it seemed simpler to add it in the main loop.  As a consequence, revDocsUpdateModularSyntaxDocBlocks could be shortened since the line continuations will already have been processed.  A third alternative would be to add a loop to the top of the "if tEntryEnded then" section of code to create a "tEntryLine" similar to the "tSyntaxLine" loop.
`local tCurrentLine, tEntryLine`
`put 1 into tCurrentLine`
`put line tCurrentLine of tData into tEntryLine`
`repeat while tEntryLine ends with "\"`
`   add 1 to tCurrentLine`
`   put line tCurrentLine of tData into char -1 of tEntryLine`
`end repeat`
"tEntryLine" would be passed instead of "line 1 of tData" (3 places).
The submitted code is the shortest option of the 3.