### PR TITLE
[[ FFI ]] Obj-C

### DIFF
--- a/docs/notes/bugfix-19945.md
+++ b/docs/notes/bugfix-19945.md
@@ -1,0 +1,1 @@
+# Mac native layer snapshots are offset by 1 pixel

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -236,6 +236,11 @@ int32_t MCFontGetSize(MCFontRef self)
 	return self->size;
 }
 
+void *MCFontGetHandle(MCFontRef self)
+{
+    return self->fontstruct->fid;
+}
+
 bool MCFontHasPrinterMetrics(MCFontRef self)
 {
 	// MW-2013-12-19: [[ Bug 11559 ]] If the font has a nil font, do nothing.

--- a/engine/src/font.h
+++ b/engine/src/font.h
@@ -52,6 +52,7 @@ void MCFontRelease(MCFontRef font);
 MCNameRef MCFontGetName(MCFontRef font);
 MCFontStyle MCFontGetStyle(MCFontRef font);
 int32_t MCFontGetSize(MCFontRef font);
+void *MCFontGetHandle(MCFontRef font);
 
 bool MCFontHasPrinterMetrics(MCFontRef font);
 

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -4798,6 +4798,12 @@ void MCCanvasFontSetSize(uinteger_t p_size, MCCanvasFontRef &x_font)
 	MCCanvasFontSetProps(x_font, t_name, t_style, p_size);
 }
 
+MC_DLLEXPORT_DEF
+void MCCanvasFontGetHandle(MCCanvasFontRef p_font, void*& r_handle)
+{
+    r_handle = MCFontGetHandle(MCCanvasFontGetMCFont(p_font));
+}
+
 // Operations
 
 MCCanvasRectangleRef MCCanvasFontMeasureTextTypographicBoundsWithTransform(MCStringRef p_text, MCCanvasFontRef p_font, const MCGAffineTransform &p_transform)

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -500,6 +500,7 @@ extern "C" MC_DLLEXPORT void MCCanvasFontGetItalic(MCCanvasFontRef p_font, bool 
 extern "C" MC_DLLEXPORT void MCCanvasFontSetItalic(bool p_italic, MCCanvasFontRef &x_font);
 extern "C" MC_DLLEXPORT void MCCanvasFontGetSize(MCCanvasFontRef p_font, uinteger_t &r_size);
 extern "C" MC_DLLEXPORT void MCCanvasFontSetSize(uinteger_t p_size, MCCanvasFontRef &x_font);
+extern "C" MC_DLLEXPORT void MCCanvasFontGetHandle(MCCanvasFontRef p_font, void*& r_handle);
 
 // Operations
 extern "C" MC_DLLEXPORT void MCCanvasFontMeasureTextTypographicBounds(MCStringRef p_text, MCCanvasFontRef p_font, MCCanvasRectangleRef& r_rect);

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -125,8 +125,7 @@ bool MCNativeLayerMac::doPaint(MCGContextRef p_context)
 		return false;
     
     // Draw the image
-    // FG-2014-10-10: a y offset of 1 is needed to keep things lined up, for some reason...
-    MCGRectangle rect = {{0, 1}, {MCGFloat(t_raster.width), MCGFloat(t_raster.height)}};
+    MCGRectangle rect = {{0, 0}, {MCGFloat(t_raster.width), MCGFloat(t_raster.height)}};
     MCGContextDrawImage(p_context, t_gimage, rect, kMCGImageFilterNone);
     MCGImageRelease(t_gimage);
     

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -102,15 +102,17 @@ void MCNativeLayerMac::doDetach()
 
 bool MCNativeLayerMac::doPaint(MCGContextRef p_context)
 {
+    NSRect t_bounds = [m_view bounds];
+    
     // Get an image rep suitable for storing the cached bitmap
     if (m_cached == nil)
     {
-        m_cached = [[m_view bitmapImageRepForCachingDisplayInRect:[m_view bounds]] retain];
+        m_cached = [[m_view bitmapImageRepForCachingDisplayInRect:t_bounds] retain];
     }
     
     // Draw the widget
     bzero([m_cached bitmapData], [m_cached bytesPerRow] * [m_cached pixelsHigh]);
-    [m_view cacheDisplayInRect:[m_view bounds] toBitmapImageRep:m_cached];
+    [m_view cacheDisplayInRect:t_bounds toBitmapImageRep:m_cached];
     
     // Turn the NSBitmapImageRep into something we can actually draw
     MCGRaster t_raster;
@@ -124,8 +126,9 @@ bool MCNativeLayerMac::doPaint(MCGContextRef p_context)
     if (!MCGImageCreateWithRasterNoCopy(t_raster, t_gimage))
 		return false;
     
-    // Draw the image
-    MCGRectangle rect = {{0, 0}, {MCGFloat(t_raster.width), MCGFloat(t_raster.height)}};
+    // Draw the image - we use the bounds width/height as the cached bitmap
+    // might be retina sized (NSBitmapImageRep has not concept of resolution)
+    MCGRectangle rect = {{0, 0}, {MCGFloat(t_bounds.size.width), MCGFloat(t_bounds.size.height)}};
     MCGContextDrawImage(p_context, t_gimage, rect, kMCGImageFilterNone);
     MCGImageRelease(t_gimage);
     

--- a/engine/src/native-layer.cpp
+++ b/engine/src/native-layer.cpp
@@ -82,6 +82,16 @@ void MCNativeLayer::OnDetach()
 
 bool MCNativeLayer::OnPaint(MCGContextRef p_context)
 {
+    /* We must make sure that any geometry changes are in sync if we are
+     * rendering to context, but are not visible */
+    if (m_can_render_to_context && m_defer_geometry_changes)
+    {
+        doSetViewportGeometry(m_deferred_viewport_rect);
+        doSetGeometry(m_deferred_rect);
+        m_viewport_rect = m_deferred_viewport_rect;
+        m_rect = m_deferred_rect;
+		m_defer_geometry_changes = false;
+    }
 	return doPaint(p_context);
 }
 

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -970,6 +970,18 @@ Boolean MCWidget::maskrect(const MCRectangle& p_rect)
 	return drect.width != 0 && drect.height != 0;
 }
 
+void MCWidget::SetName(MCExecContext& ctxt, MCStringRef p_name)
+{
+    MCNewAutoNameRef t_old_name = getname();
+
+    MCControl::SetName(ctxt, p_name);
+    
+    if (!MCNameIsEqualTo(*t_old_name, getname(), kMCStringOptionCompareExact))
+    {
+        recompute();
+    }
+}
+
 void MCWidget::SetDisabled(MCExecContext& ctxt, uint32_t p_part_id, bool p_flag)
 {
     bool t_is_disabled;

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -191,6 +191,7 @@ public:
 	virtual void OnOpen();
 	virtual void OnClose();
 	
+    virtual void SetName(MCExecContext& ctxt, MCStringRef p_name);
     virtual void SetDisabled(MCExecContext& ctxt, uint32_t part, bool flag);
     
     void GetKind(MCExecContext& ctxt, MCNameRef& r_kind);

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -27,6 +27,7 @@
 				'libraries/json/json.lcb',
 
 				'widgets/androidbutton/androidbutton.lcb',
+				'widgets/macbutton/macbutton.lcb',
 				'widgets/browser/browser.lcb',
 				#’widgets/chart/chart.lcb',
 				#'widgets/checkbox/checkbox.lcb',

--- a/extensions/widgets/macbutton/macbutton.lcb
+++ b/extensions/widgets/macbutton/macbutton.lcb
@@ -1,0 +1,265 @@
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/**
+Name: Mac Native Button
+
+Description: 
+This widget is a native push button on Mac.
+
+Name: enabled
+
+Syntax: 
+set the enabled of <widget> to {true | false}
+get the enabled of <widget>
+
+Description:
+Use the <enabled> property to enable or disable the native button. When
+disabled, the button has a greyed out appearance and does not accept 
+clicks or touches.
+*/
+widget com.livecode.widget.native.mac.button
+
+use com.livecode.foreign
+use com.livecode.objc
+use com.livecode.widget
+use com.livecode.canvas
+use com.livecode.engine
+use com.livecode.library.widgetutils
+
+metadata version is "1.0.0"
+metadata author is "LiveCode"
+metadata title is "Mac Native Button"
+metadata svgicon is "m -19.375905,-4.8110434 c -1.108001,0 -2,0.892 -2,2 l 0,15.4453124 c 0,1.108 0.891999,2 2,2 l 27.5722648,0 c 1.108,0 2.0000002,-0.892 2.0000002,-2 l 0,-15.4453124 c 0,-1.108 -0.8920002,-2 -2.0000002,-2 l -27.5722648,0 z m 6.857421,2.3847656 13.8593751,0 c 0.588,0 1.0664531,0.4812187 1.0644531,1.0742188 l 0,9.8437501 c 0,0.594 -0.4764531,1.074219 -1.0644531,1.074219 l -5.3203125,0 c 0,0 0.5936093,2.1484369 3.22460934,2.1484369 l 0,0.537109 -3.49218744,0 -4.5683598,0 -1.8789057,0 0,-0.537109 c 2.5589997,0 3.4921873,-2.1484369 3.4921873,-2.1484369 l -5.3164063,0 c -0.589,-10e-7 -1.066406,-0.480219 -1.066406,-1.074219 l 0,-9.8437501 c 0,-0.593 0.477406,-1.0742188 1.066406,-1.0742188 z m 0.07617,1.1425781 0,9.1074219 13.7070312,0 0,-9.1074219 -13.7070312,0 z m 7.8105468,1.12890629 c 0.04,0.364 -0.1062656,0.7291875 -0.3222656,0.9921875 -0.217,0.26200001 -0.5709219,0.46450001 -0.9199219,0.43750001 -0.047,-0.35600001 0.128125,-0.72598441 0.328125,-0.95898441 0.225,-0.262 0.6020625,-0.4577031 0.9140625,-0.4707031 z m -0.00586,1.50195311 c 0.202,0.008 0.7707688,0.080281 1.1347656,0.6132813 -0.028,0.019 -0.6779219,0.3956406 -0.6699219,1.1816406 0.009,0.938 0.8220313,1.2508594 0.8320313,1.2558594 -0.008,0.021 -0.1296882,0.4448126 -0.4296876,0.8828125 -0.2579999,0.3770001 -0.5262187,0.7537187 -0.9492187,0.7617187 -0.415,0.008 -0.5474375,-0.2460937 -1.0234375,-0.2460937 -0.475,0 -0.6245782,0.2379062 -1.0175781,0.2539062 -0.4080001,0.015 -0.7185154,-0.4081561 -0.9785159,-0.7851562 -0.533,-0.7709999 -0.941531,-2.1769532 -0.394531,-3.1269532 0.272,-0.471 0.7581563,-0.7693437 1.2851562,-0.7773437 0.4,-0.007 0.7794376,0.2695313 1.0234376,0.2695313 0.246,0 0.7054999,-0.3322032 1.1875,-0.2832032 z M -5.5887964,8.147941 c -0.331,0 -0.5996094,0.2676561 -0.5996094,0.5976561 0,0.331 0.2686093,0.599609 0.5996094,0.599609 0.33,10e-7 0.5986093,-0.268609 0.5996093,-0.599609 10e-8,-0.33 -0.2696093,-0.5976561 -0.5996093,-0.5976561 z"
+
+constant kSvgIcon is "M14.926,0.656H1.067C0.478,0.656,0,1.137,0,1.73v9.844c0,0.594,0.478,1.074,1.067,1.074h5.316 c0,0-0.934,2.149-3.493,2.149v0.537h1.88h4.568h3.493v-0.537c-2.631,0-3.226-2.149-3.226-2.149h5.32 c0.588,0,1.065-0.48,1.065-1.074V1.73C15.992,1.137,15.514,0.656,14.926,0.656z M7.996,12.427c-0.331,0-0.599-0.268-0.599-0.599 c0-0.33,0.268-0.598,0.599-0.598c0.33,0,0.599,0.268,0.599,0.598C8.594,12.159,8.326,12.427,7.996,12.427z M14.849,10.906H1.143 V1.798H14.85L14.849,10.906L14.849,10.906zM6.824,9.133c0.393-0.016,0.542-0.255,1.017-0.255c0.476,0,0.609,0.255,1.024,0.247 C9.288,9.117,9.556,8.74,9.814,8.363c0.3-0.438,0.423-0.862,0.431-0.883c-0.01-0.005-0.824-0.317-0.833-1.255 c-0.008-0.786,0.642-1.163,0.67-1.182C9.718,4.51,9.149,4.437,8.947,4.429C8.465,4.38,8.005,4.713,7.759,4.713 c-0.244,0-0.623-0.277-1.023-0.27C6.209,4.451,5.724,4.75,5.452,5.221c-0.547,0.95-0.14,2.356,0.393,3.127 C6.105,8.725,6.416,9.148,6.824,9.133z M8.953,2.928c-0.312,0.013-0.689,0.208-0.914,0.47c-0.2,0.233-0.376,0.604-0.329,0.96 c0.349,0.027,0.704-0.177,0.921-0.439C8.847,3.656,8.993,3.292,8.953,2.928z"
+
+/**
+Syntax:
+set the label of <widget> to <pLabel>
+get the label of <widget>
+
+Summary: The label displayed by the button.
+
+Value (string): The string to use as the button label
+
+Example:
+    set the label of widget "Mac Button" to "Click me!"
+
+Description:
+The <label> property is the label displayed by the button.
+*/
+
+property label get mLabel set SetLabel
+metadata label.editor is "com.livecode.pi.string"
+metadata label.default is ""
+
+private variable mLabel as String
+private variable mButtonView as optional ObjcObject
+private variable mButtonProxy as optional ObjcObject
+
+private handler IsMac() returns Boolean
+    return the operating system is "mac"
+end handler
+
+/**/
+
+public handler OnCreate()
+	put "" into mLabel
+end handler
+
+public handler OnDestroy()
+	put nothing into mButtonView
+end handler
+
+/**/
+
+public handler OnOpen()
+    if IsMac() then
+        unsafe
+            CreateButtonView()
+        end unsafe
+    end if
+end handler
+
+public handler OnClose()
+    if IsMac() then
+        unsafe
+            DestroyButtonView()
+        end unsafe
+    end if
+end handler
+
+/**/
+
+constant kBorderWidth is 5
+private handler expandRectangle(in pRect as Rectangle, in pExp as Number) returns Rectangle
+    return rectangle [ the left of pRect - pExp, the top of pRect - pExp, the right of pRect + pExp, the bottom of pRect + pExp]
+end handler
+
+public handler OnPaint()
+	if IsMac() then
+		return
+	end if
+
+    // Draw placeholder image - the icon
+    variable tFillPaint as Paint
+    variable tStrokePaint as Paint
+    put solid paint with color [0.875, 0.875, 0.875] into tFillPaint
+    put solid paint with color [0.75, 0.75, 0.75] into tStrokePaint
+    variable tBounds as Rectangle
+    put my bounds into tBounds
+    set the paint of this canvas to tFillPaint
+    fill rectangle path of tBounds on this canvas
+    set the paint of this canvas to tStrokePaint
+    set the stroke width of this canvas to kBorderWidth
+    set the join style of this canvas to "bevel"
+    stroke rectangle path of expandRectangle(tBounds, -kBorderWidth / 2) on this canvas
+    variable tPath as Path
+    put path kSvgIcon into tPath
+    constrainPathToRect(expandRectangle(tBounds, -2 * kBorderWidth), tPath)
+    fill tPath on this canvas
+    // Draw the control name
+    put solid paint with color [1, 1, 1, 0.1] into tFillPaint
+    put solid paint with color [0.25, 0.25, 0.25] into tStrokePaint
+    variable tNameString as String
+    if mLabel is empty then
+        put my name into tNameString
+    else
+        put mLabel into tNameString
+    end if
+    set the font of this canvas to my font
+    
+    variable tTextBounds as Rectangle
+    put the image bounds of text tNameString on this canvas into tTextBounds
+    translate this canvas by [ the width of tBounds / 2, the height of tBounds / 2]
+    translate this canvas by [ -(the width of tTextBounds / 2), the height of tTextBounds / 2]
+    set the paint of this canvas to tFillPaint
+    
+    variable tRect as Rectangle
+    put expandRectangle(tTextBounds, kBorderWidth) into tRect
+    fill rounded rectangle path of tRect with radius 5 on this canvas
+    set the paint of this canvas to solid paint with color [0.0, 0.0, 0.0]
+    fill text tNameString at center of tRect on this canvas
+end handler
+
+/**/
+
+public handler OnSave(out rProperties as Array)
+	put mLabel into rProperties["label"]
+end handler
+
+public handler OnLoad(in pProperties as Array)
+	put pProperties["label"] into mLabel
+end handler
+
+/**/
+
+public handler OnParentPropertyChanged()
+    unsafe
+        UpdateButtonView()
+    end unsafe
+end handler
+
+/**/
+
+private handler SetLabel(in pLabel as String) returns nothing
+	put pLabel into mLabel
+	unsafe
+		UpdateButtonView()
+	end unsafe
+    redraw all
+end handler
+
+/****/
+
+private handler ButtonActionCallback(in pSender as ObjcObject, in pContext as optional any) returns nothing
+	post "mouseUp"
+end handler
+
+/****/
+
+private type NSUInteger is CULong
+private foreign handler ObjC_NSButtonAlloc() returns ObjcRetainedId binds to "objc:NSButton.+alloc"
+private foreign handler ObjC_NSButtonInit(in pObj as ObjcId) returns ObjcId binds to "objc:NSButton.-init"
+private foreign handler ObjC_NSButtonSetEnabled(in pObj as ObjcId, in pEnabled as CBool) returns nothing binds to "objc:NSButton.-setEnabled:"
+private foreign handler ObjC_NSButtonSetFont(in pObj as ObjcId, in pFont as ObjcId) returns nothing binds to "objc:NSButton.-setFont:"
+private foreign handler ObjC_NSButtonSetButtonType(in pObj as ObjcId, in pStyle as NSUInteger) returns nothing binds to "objc:NSButton.-setButtonType:"
+private foreign handler ObjC_NSButtonSetBezelStyle(in pObj as ObjcId, in pStyle as NSUInteger) returns nothing binds to "objc:NSButton.-setBezelStyle:"
+private foreign handler ObjC_NSButtonSetBordered(in pObj as ObjcId, in pBordered as CBool) returns nothing binds to "objc:NSButton.-setBordered:"
+private foreign handler ObjC_NSButtonSetTitle(in pObj as ObjcId, in pTitle as ObjcId) returns nothing binds to "objc:NSButton.-setTitle:"
+private foreign handler ObjC_NSButtonSetTarget(in pObj as ObjcId, in pTarget as ObjcId) returns nothing binds to "objc:NSButton.-setTarget:"
+private foreign handler ObjC_NSButtonSetAction(in pObj as ObjcId, in pAction as UIntPtr) returns nothing binds to "objc:NSButton.-setAction:"
+
+private foreign handler MCCanvasFontGetHandle(in pFont as Font, out rHandle as ObjcId) returns nothing binds to "<builtin>"
+
+private unsafe handler CreateButtonView()
+	variable tButtonView as ObjcObject
+	put ObjC_NSButtonAlloc() into tButtonView
+	put ObjC_NSButtonInit(tButtonView) into tButtonView
+
+    /* For a standard push button we need:
+     *   buttonType to be NSMomentaryPushInButton = 7
+     *   bezelStyle to be NSRoundedBezelStyle = 1
+     *   bordered to be true */
+    ObjC_NSButtonSetButtonType(tButtonView, 7)
+    ObjC_NSButtonSetBezelStyle(tButtonView, 1)
+    ObjC_NSButtonSetBordered(tButtonView, true)
+
+    set my native layer to PointerFromObjcObject(tButtonView)
+	put tButtonView into mButtonView
+
+	put ObjcProxyGetTarget(ButtonActionCallback, nothing) into mButtonProxy
+	ObjC_NSButtonSetTarget(mButtonView, mButtonProxy)
+	ObjC_NSButtonSetAction(mButtonView, ObjcProxyGetAction())
+
+	UpdateButtonView()
+end handler
+
+private unsafe handler DestroyButtonView()
+	set my native layer to nothing
+	put nothing into mButtonView
+	put nothing into mButtonProxy
+end handler
+
+private unsafe handler UpdateButtonView()
+	if mButtonView is nothing then
+		return
+	end if
+	
+    /* Set the enabled state of the button to the host property. */
+    ObjC_NSButtonSetEnabled(mButtonView, my enabled)
+
+    /* Set the font of the button to the host property. */
+    variable tFontToUse as ObjcObject
+    MCCanvasFontGetHandle(my font, tFontToUse)
+    ObjC_NSButtonSetFont(mButtonView, tFontToUse)
+
+    /* Set the label of the button to mLabel, if not empty; otherwise to the
+     * name of the host. */
+    variable tLabelToUse as String
+    if mLabel is the empty string then
+        put my name into tLabelToUse
+    else
+        put mLabel into tLabelToUse
+    end if
+	ObjC_NSButtonSetTitle(mButtonView, StringToNSString(tLabelToUse))
+end handler
+
+/**/
+
+end widget

--- a/libfoundation/include/foundation-objc.h
+++ b/libfoundation/include/foundation-objc.h
@@ -21,11 +21,13 @@
 #include <foundation.h>
 #endif
 
+#ifdef __OBJC__
 #import <Foundation/NSString.h>
 #import <Foundation/NSData.h>
 
 NSString *MCStringConvertToAutoreleasedNSString(MCStringRef string);
 NSString *MCNameConvertToAutoreleasedNSString(MCNameRef name);
 NSData *MCDataConvertToAutoreleasedNSData(MCDataRef data);
+#endif
 
 #endif

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -677,6 +677,7 @@ typedef struct __MCStream *MCStreamRef;
 typedef struct __MCProperList *MCProperListRef;
 typedef struct __MCForeignValue *MCForeignValueRef;
 typedef struct __MCJavaObject *MCJavaObjectRef;
+typedef struct __MCObjcObject *MCObjcObjectRef;
 
 // Forward declaration
 typedef struct __MCLocale* MCLocaleRef;
@@ -3415,6 +3416,58 @@ MC_DLLEXPORT bool MCProperListEndsWithList(MCProperListRef list, MCProperListRef
 MC_DLLEXPORT bool MCProperListIsListOfType(MCProperListRef list, MCValueTypeCode p_type);
 MC_DLLEXPORT bool MCProperListIsHomogeneous(MCProperListRef list, MCValueTypeCode& r_type);
     
+////////////////////////////////////////////////////////////////////////////////
+//
+//  OBJC DEFINITIONS
+//
+
+/* The ObjcObject type manages the lifetime of the obj-c object it contains.
+ * Specifcally, it sends 'release' to the object when the ObjcObject is dropped */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcObjectTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcObjectTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcId type describes an id which is passed into, or out of an obj-c
+ * method with no implicit action on its reference count. */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcIdTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcIdTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcRetainedId type describes an id which is passed into, or out of an
+ * obj-c method and is expected to already have been retained. (i.e. the
+ * caller or callee expects to receive it with +1 ref count). */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcRetainedIdTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcRetainedIdTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcAutoreleasedId type describes an id which has been placed in the
+ * innermost autorelease pool before being returned to the caller. */
+MC_DLLEXPORT extern MCTypeInfoRef kMCObjcAutoreleasedIdTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCObjcAutoreleasedIdTypeInfo(void) ATTRIBUTE_PURE;
+
+/* The ObjcObjectCreateWithId function creates an ObjcObject out of a raw id
+ * value, retaining it to make sure it owns a reference to it. */
+MC_DLLEXPORT bool MCObjcObjectCreateWithId(void *value, MCObjcObjectRef& r_obj);
+
+/* The ObjcObjectCreateWithId function creates an ObjcObject out of a raw id
+ * value, taking a +1 reference count from it (i.e. it assumes the value has
+ * already been retained before being called). */
+MC_DLLEXPORT bool MCObjcObjectCreateWithRetainedId(void *value, MCObjcObjectRef& r_obj);
+
+/* The ObjcObjectCreateWithAutoreleasedId function creates an ObjcObject out of
+ * a raw id value which is in the innermost autorelease pool. Currently this
+ * means that it retains it. */
+MC_DLLEXPORT bool MCObjcObjectCreateWithAutoreleasedId(void *value, MCObjcObjectRef& r_obj);
+
+/* The ObjcObjectGetId function returns the raw id value contained within
+ * an ObjcObject. The retain count of the id remains unchanged. */
+MC_DLLEXPORT void *MCObjcObjectGetId(MCObjcObjectRef obj);
+
+/* The ObjcObjectGetRetainedId function returns the raw id value contained within
+ * an ObjcObject. The id is retained before being returned. */
+MC_DLLEXPORT void *MCObjcObjectGetRetainedId(MCObjcObjectRef obj);
+
+/* The ObjcObjectGetAutoreleasedId function returns the raw id value contained within
+ * an ObjcObject. The id is autoreleased before being returned. */
+MC_DLLEXPORT void *MCObjcObjectGetAutoreleasedId(MCObjcObjectRef obj);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 enum MCPickleFieldType

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1745,7 +1745,6 @@ MC_DLLEXPORT bool MCBuiltinTypeInfoCreate(MCValueTypeCode typecode, MCTypeInfoRe
 enum MCForeignPrimitiveType
 {
     kMCForeignPrimitiveTypeVoid,
-    kMCForeignPrimitiveTypeBool,
     kMCForeignPrimitiveTypeUInt8,
     kMCForeignPrimitiveTypeSInt8,
     kMCForeignPrimitiveTypeUInt16,

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -159,9 +159,15 @@
 				[
 					'OS != "mac" and OS != "ios"',
 					{
+                        'sources':
+                        [
+                            'src/foundation-objc-dummy.cpp',
+                        ],
+                    
 						'sources!':
 						[
 							'src/foundation-string-cf.cpp',
+                            'src/foundation-objc.mm',
 						],
 					},
 				],

--- a/libfoundation/src/foundation-core.cpp
+++ b/libfoundation/src/foundation-core.cpp
@@ -87,6 +87,9 @@ bool MCInitialize(void)
     if (!__MCJavaInitialize())
         return false;
     
+    if (!__MCObjcInitialize())
+        return false;
+
 	return true;
 }
 
@@ -108,7 +111,8 @@ void MCFinalize(void)
 	__MCStringFinalize();
     __MCUnicodeFinalize();
     __MCJavaFinalize();
-    
+    __MCObjcFinalize();
+
     // Finalize values last
 	__MCValueFinalize();
 }

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -134,6 +134,9 @@ MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignSIntTypeInfo() { return kMCSIntTypeInfo;
 static_assert(sizeof(int) == 4,
               "Assumption that int is 4 bytes in size not valid");
 
+static_assert(sizeof(bool) == 1,
+              "Assumption that bool is 1 byte in size not valid");
+
 template <typename CType, typename Enable = void>
 struct compute_primitive_type
 {
@@ -205,7 +208,7 @@ struct integral_type_desc_t: public numeric_type_desc_t<CType> {
 
 struct bool_type_desc_t {
     using c_type = bool;
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeBool;
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt8;
     static constexpr MCTypeInfoRef& base_type_info() { return kMCNullTypeInfo; }
     static constexpr MCTypeInfoRef& type_info() { return kMCBoolTypeInfo; }
     static constexpr auto is_optional = false;

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -121,8 +121,8 @@ MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCUIntTypeInfo() { return kMCCUIntTypeInf
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSIntTypeInfo() { return kMCCSIntTypeInfo; }
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongTypeInfo() { return kMCCULongTypeInfo; }
 MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongTypeInfo() { return kMCCSLongTypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongLongTypeInfo() { return kMCCULongTypeInfo; }
-MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongLongTypeInfo() { return kMCCSLongTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCULongLongTypeInfo() { return kMCCULongLongTypeInfo; }
+MC_DLLEXPORT_DEF MCTypeInfoRef MCForeignCSLongLongTypeInfo() { return kMCCSLongLongTypeInfo; }
 
 /**/
 

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -596,6 +596,9 @@ void __MCStreamFinalize(void);
 bool __MCJavaInitialize(void);
 void __MCJavaFinalize(void);
 
+bool __MCObjcInitialize(void);
+void __MCObjcFinalize(void);
+
 /* Default implementations of each of the function members of struct &
  * MCValueCustomCallbacks */
 MCTypeInfoRef __MCCustomValueResolveTypeInfo(__MCValue *p_value);

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -551,14 +551,6 @@ static ffi_type *__map_primitive_type(MCForeignPrimitiveType p_type)
     {
         case kMCForeignPrimitiveTypeVoid:
             return &ffi_type_void;
-        case kMCForeignPrimitiveTypeBool:
-            if (sizeof(bool) == 1)
-                return &ffi_type_uint8;
-            if (sizeof(bool) == 2)
-                return &ffi_type_uint16;
-            if (sizeof(bool) == 4)
-                return &ffi_type_uint32;
-            return &ffi_type_uint64;
         case kMCForeignPrimitiveTypeUInt8:
             return &ffi_type_uint8;
         case kMCForeignPrimitiveTypeSInt8:

--- a/libscript/src/objc.lcb
+++ b/libscript/src/objc.lcb
@@ -1,0 +1,156 @@
+/* Copyright (C) 2017 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/**
+This module provides utility handlers for converting to and from Obj-C types.
+
+*/
+module com.livecode.objc
+
+use com.livecode.foreign
+
+/****/
+
+public foreign type ObjcObject binds to "MCObjcObjectTypeInfo"
+public foreign type ObjcId binds to "MCObjcIdTypeInfo"
+public foreign type ObjcRetainedId binds to "MCObjcRetainedIdTypeInfo"
+public foreign type ObjcAutoreleasedId binds to "MCObjcAutoreleasedIdTypeInfo"
+
+/****/
+
+private foreign handler MCStringCreateWithCFString(in pNSString as ObjcId, out rString as String) returns CBool binds to "MCStringCreateWithCFString"
+private foreign handler MCStringConvertToCFStringRef(in pString as String, out rNSString as ObjcRetainedId) returns CBool binds to "MCStringConvertToCFStringRef"
+
+/**/
+
+/**
+Summary:    Convert a String into an Objective-C string
+
+Parameters:
+pString: The String to convert
+
+Returns:
+A Objective-C object of type NSString
+
+Description
+Use <StringToNSString> to convert a variable of type String to an Objective-C
+string object (NSString).
+
+*/
+public handler StringToNSString(in pString as String) returns ObjcObject
+	variable tNSString as ObjcRetainedId
+	unsafe
+		MCStringConvertToCFStringRef(pString, tNSString)
+	end unsafe
+	return tNSString
+end handler
+
+/**
+Summary:    Convert a Objective-C string into a String
+
+Parameters:
+pObjcString: The NSString to convert
+
+Returns:
+A String value
+
+Description
+Use <StringFromNSString> to convert an Objective-C string object (NSString) to
+a variable of type String.
+
+*/
+public handler StringFromNSString(in pObjcString as ObjcObject) returns String
+	variable tString as String
+	unsafe
+		MCStringCreateWithCFString(pObjcString, tString)
+	end unsafe
+	return tString
+end handler
+
+/****/
+
+public handler type ObjcActionProxyHandler(in pSender as ObjcObject, in pContext as optional any) returns nothing
+
+private foreign handler MCObjcObjectCreateActionProxy(in pHandler as optional any, in pValue as optional any) returns ObjcObject binds to "MCObjcObjectCreateActionProxy"
+private foreign handler MCObjcObjectGetActionProxySelector() returns UIntPtr binds to "MCObjcObjectGetActionProxySelector"
+
+public handler ObjcProxyGetTarget(in pHandler as ObjcActionProxyHandler, in pContext as optional any) returns ObjcObject
+	unsafe
+		return MCObjcObjectCreateActionProxy(pHandler, pContext)
+	end unsafe
+end handler
+
+public handler ObjcProxyGetAction() returns UIntPtr
+	unsafe
+		return MCObjcObjectGetActionProxySelector()
+	end unsafe
+end handler
+
+/**/
+
+/****/
+
+private foreign handler _MCObjcObjectCreateWithId_AsPointer(in pPointer as optional Pointer) returns ObjcObject binds to "MCObjcObjectCreateWithId"
+private foreign handler _MCObjcObjectGetId_AsPointer(in pObject as ObjcObject) returns optional Pointer binds to "MCObjcObjectGetId"
+
+/**/
+
+/**
+Summary:    Convert a Pointer into an ObjcObject
+
+Parameters:
+pPointer: The Pointer to convert
+
+Returns:
+An ObjcObject wrapping the Pointer
+	 
+Description:
+Use <PointerToObjcObject> to convert a variable of type Pointer to one of type
+ObjcObject.
+*/
+public handler PointerToObjcObject(in pPointer as optional Pointer) returns ObjcObject
+	variable tObject as ObjcObject
+	unsafe
+		put _MCObjcObjectCreateWithId_AsPointer(pPointer) into tObject
+	end unsafe
+	return tObject
+end handler
+
+/**
+Summary:    Convert an ObjcObject into a Pointer
+
+Parameters:
+pObjcObject: The ObjcObject to convert
+
+Returns:
+The Pointer wrapped by the ObjcObject
+	 
+Description:
+Use <PointerFromObjcObject> to convert a variable of type ObjcObject to one of
+type Pointer.
+*/
+public handler PointerFromObjcObject(in pObjcObject as ObjcObject) returns optional Pointer
+	variable tPointer as Pointer
+	unsafe
+		put _MCObjcObjectGetId_AsPointer(pObjcObject) into tPointer
+	end unsafe
+	return tPointer
+end handler
+
+/****/
+
+end module
+

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1932,10 +1932,10 @@ MCScriptMapTypeToForeignPrimitiveTypeInModule(MCScriptModuleBuilderRef self, uin
             { "SInt64", kMCScriptForeignPrimitiveTypeSInt64 },
             { "UInt64", kMCScriptForeignPrimitiveTypeUInt64 },
             
-            { "CSIntSize", kMCScriptForeignPrimitiveTypeSIntSize },
-            { "CUIntSize", kMCScriptForeignPrimitiveTypeUIntSize },
-            { "CSIntPtr", kMCScriptForeignPrimitiveTypeSIntPtr },
-            { "CUIntPtr", kMCScriptForeignPrimitiveTypeUIntPtr },
+            { "SIntSize", kMCScriptForeignPrimitiveTypeSIntSize },
+            { "UIntSize", kMCScriptForeignPrimitiveTypeUIntSize },
+            { "SIntPtr", kMCScriptForeignPrimitiveTypeSIntPtr },
+            { "UIntPtr", kMCScriptForeignPrimitiveTypeUIntPtr },
             
             { "CBool", kMCScriptForeignPrimitiveTypeCBool },
             { "CChar", kMCScriptForeignPrimitiveTypeCChar },

--- a/libscript/src/script-builder.cpp
+++ b/libscript/src/script-builder.cpp
@@ -1964,6 +1964,12 @@ MCScriptMapTypeToForeignPrimitiveTypeInModule(MCScriptModuleBuilderRef self, uin
             /* Java FFI Types */
             { "JObject", kMCScriptForeignPrimitiveTypePointer },
             
+            /* ObjC FFI Types */
+            { "ObjcObject", kMCScriptForeignPrimitiveTypePointer },
+            { "ObjcId", kMCScriptForeignPrimitiveTypePointer },
+            { "ObjcRetainedId", kMCScriptForeignPrimitiveTypePointer },
+            { "ObjcAutoreleasedId", kMCScriptForeignPrimitiveTypePointer },
+            
             /* Extra Foundation Types */
             { "Stream", kMCScriptForeignPrimitiveTypePointer },
             

--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -361,20 +361,20 @@ MCScriptThrowUnknownJavaThreadError(void)
 }
 
 bool
-MCScriptThrowJavaBindingNotImplemented(void)
-{
-	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
-								 "reason",
-								 MCSTR("java binding not implemented yet"),
-								 nil);
-}
-
-bool
 MCScriptThrowJavaBindingNotSupported(void)
 {
 	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
 								 "reason",
 								 MCSTR("java binding not supported on this platform"),
+								 nil);
+}
+
+bool
+MCScriptThrowObjCBindingNotSupported(void)
+{
+	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
+								 "reason",
+								 MCSTR("objc binding not supported on this platform"),
 								 nil);
 }
 

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -259,6 +259,9 @@ void MCScriptDestroyModule(MCScriptModuleRef self)
                 break;
             case kMCScriptForeignHandlerLanguageBuiltinC:
                 break;
+            case kMCScriptForeignHandlerLanguageObjC:
+                MCMemoryDelete(t_def->objc.function_cif);
+                break;
             case kMCScriptForeignHandlerLanguageJava:
                 MCValueRelease(t_def->java.class_name);
                 break;

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -355,6 +355,9 @@ enum MCScriptForeignHandlerLanguage
     /* The handler has a lc-compile generated shim, so can be called directly */
     kMCScriptForeignHandlerLanguageBuiltinC,
     
+    /* The handler should be called using objc_msgSend */
+    kMCScriptForeignHandlerLanguageObjC,
+    
     /* The handler should be called using the JNI */
     kMCScriptForeignHandlerLanguageJava,
 };
@@ -362,6 +365,17 @@ enum MCScriptForeignHandlerLanguage
 enum MCJavaThread {
     kMCJavaThreadDefault,
     kMCJavaThreadUI
+};
+
+/* MCScriptForeignHandlerObjcCallType describes how to call the objective-c
+ * method. */
+enum MCScriptForeignHandlerObjcCallType
+{
+    /* Call the method using method_invoke on the instance */
+    kMCScriptForeignHandlerObjcCallTypeInstanceMethod,
+    
+    /* Call the method using method_invoke on the class instance */
+    kMCScriptForeignHandlerObjcCallTypeClassMethod,
 };
 
 struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
@@ -381,6 +395,13 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
         {
             void *function;
         } builtin_c;
+        struct
+        {
+            MCScriptForeignHandlerObjcCallType call_type;
+            void *objc_class;
+            void *objc_selector;
+            void *function_cif;
+        } objc;
         struct
         {
             MCNameRef class_name;
@@ -654,7 +675,7 @@ bool
 MCScriptThrowUnableToLoadForiegnLibraryError(void);
 
 bool
-MCScriptThrowJavaBindingNotImplemented(void);
+MCScriptThrowObjCBindingNotSupported(void);
 
 bool
 MCScriptThrowJavaBindingNotSupported(void);

--- a/libscript/stdscript-sources.gypi
+++ b/libscript/stdscript-sources.gypi
@@ -29,6 +29,7 @@
 			'src/stream.lcb',
 			'src/string.lcb',
 			'src/system.lcb',
+			'src/objc.lcb',
 			'src/type.lcb',
 			'src/type-convert.lcb',
 			'src/unittest.lcb',

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -1,0 +1,104 @@
+module __VMTEST.interop_objc
+
+use com.livecode.foreign
+use com.livecode.objc
+use com.livecode.__INTERNAL._testlib
+
+---------
+
+__safe foreign handler NSObjectAlloc() returns ObjcRetainedId binds to "objc:NSObject.+alloc"
+
+__safe foreign handler NSNumberCreateWithInt(in pInt as CInt) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithInt:"
+__safe foreign handler NSNumberGetIntValue(in pObj as ObjcId) returns CInt binds to "objc:NSNumber.intValue"
+__safe foreign handler NSNumberCreateWithLongLong(in pInt as CLongLong) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithLongLong:"
+__safe foreign handler NSNumberGetLongLongValue(in pObj as ObjcId) returns CLongLong binds to "objc:NSNumber.longLongValue"
+__safe foreign handler NSNumberCreateWithFloat(in pInt as CFloat) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithFloat:"
+__safe foreign handler NSNumberGetFloatValue(in pObj as ObjcId) returns CFloat binds to "objc:NSNumber.floatValue"
+__safe foreign handler NSNumberCreateWithDouble(in pInt as CDouble) returns ObjcAutoreleasedId binds to "objc:NSNumber.+numberWithDouble:"
+__safe foreign handler NSNumberGetDoubleValue(in pObj as ObjcId) returns CDouble binds to "objc:NSNumber.doubleValue"
+
+---------
+
+-- NEED TO CHECK class and instance methods, existant and non-existant
+-- also protocols and superclasses.
+
+__safe foreign handler CreateObjCObjectDoesntExist() returns ObjcId binds to "objc:NSObject.-foobar"
+
+private handler TestObjcInterop_NonExistantObjC()
+    CreateObjCObjectDoesntExist()
+end handler
+
+private handler TestObjcInterop_ExistantObjC()
+	variable tObj as ObjcObject
+	put NSObjectAlloc() into tObj
+end handler
+
+public handler TestObjcInterop_Binding()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "objc binding succeeds" because "not implemented on" && the operating system
+		return
+	end if
+
+  	MCUnitTestHandlerThrowsNamed(TestObjcInterop_NonExistantObjC, "livecode.lang.ForeignHandlerBindingError", "Failure to bind to non-existant objc function throws error")
+  	MCUnitTestHandlerDoesntThrow(TestObjcInterop_ExistantObjC, "Binding to existant objc function does not throw error")
+
+  	test "Non-existant objc function gives nothing as handler value" when CreateObjCObjectDoesntExist is nothing
+  	test "Existant objc function gives non-nothing as handler value" when NSObjectAlloc is not nothing
+end handler
+
+---------
+
+__safe foreign handler NSObjectGetRetainCount(in pObj as ObjcId) returns CULong binds to "objc:NSObject.-retainCount"
+__safe foreign handler NSObjectGetSelf(in pObj as ObjcId) returns ObjcId binds to "objc:NSObject.-self"
+
+public handler TestObjInterop_ObjcObjectLifetime()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "objc binding succeeds" because "not implemented on" && the operating system
+		return
+	end if
+
+	/* Test that ObjcRetainedId gives its reference to ObjcObject */
+	variable tObjcObjectFromRetainedId as ObjcObject
+	put NSObjectAlloc() into tObjcObjectFromRetainedId
+	test "retained id into objc object doesn't retain" when NSObjectGetRetainCount(tObjcObjectFromRetainedId) is 1
+
+	/* Test that ObjcId copies its reference to ObjcObject */
+	variable tObjcObjectFromId as ObjcObject
+	put NSObjectGetSelf(tObjcObjectFromRetainedId) into tObjcObjectFromId
+	test "id into objc object retains" when NSObjectGetRetainCount(tObjcObjectFromId) is 2
+
+	/* Test that ObjcAutoreleasedId copies its reference to ObjcObject */
+	variable tObjcObjectFromAutoreleasedId as ObjcObject
+	put NSNumberCreateWithDouble(3.14159) into tObjcObjectFromAutoreleasedId
+	test "autoreleased id into objc object retains" when NSObjectGetRetainCount(tObjcObjectFromAutoreleasedId) is 2
+end handler
+
+---------
+
+
+public handler TestObjInterop_RoundtripNumber()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "objc binding succeeds" because "not implemented on" && the operating system
+		return
+	end if
+
+	variable tIntObj as ObjcObject
+	put NSNumberCreateWithInt(314159) into tIntObj
+	test "NSNumber roundtrip CInt" when NSNumberGetIntValue(tIntObj) is 314159
+
+	variable tLongLongObj as ObjcObject
+	put NSNumberCreateWithLongLong(314159) into tLongLongObj
+	test "NSNumber roundtrip CLongLong" when NSNumberGetLongLongValue(tLongLongObj) is 314159
+
+	variable tFloatObj as ObjcObject
+	put NSNumberCreateWithFloat(314159) into tFloatObj
+	test "NSNumber roundtrip CFloat" when NSNumberGetFloatValue(tFloatObj) is 314159
+
+	variable tDoubleObj as ObjcObject
+	put NSNumberCreateWithDouble(314159) into tDoubleObj
+	test "NSNumber roundtrip CDouble" when NSNumberGetDoubleValue(tDoubleObj) is 314159
+end handler
+
+--------
+
+end module


### PR DESCRIPTION
This patch contains the basic support for Obj-C FFI in LCB.

It provides an ObjcObject type (non-foreign) and ObjcRetainedId, ObjcId and ObjcAutoreleasedId foreign types to help manage lifetimes of objects.

Foreign handlers can now use 'objc' as the language, and in that case can bind to both instance and class methods of Objective-C objects.

There is also basic support for 'proxy' objects, allowing LCB to use the Target-Action pattern used ubiquitously in Cocoa and CocoaTouch.

The current implementation has been used to implement a basic native Mac button - which will send a mouseUp message when clicked, and allows the label to be set. The button also hooks into enabled and font host properties.