### PR TITLE
[[ Bug 18899 ]] Fix image from resource path

### DIFF
--- a/docs/lcb/notes/18899.md
+++ b/docs/lcb/notes/18899.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Host Library
+## Canvas library
+
+# [18899] Fix load image from resource file 

--- a/libscript/src/script-bytecode.hpp
+++ b/libscript/src/script-bytecode.hpp
@@ -315,10 +315,12 @@ struct MCScriptBytecodeOp_Invoke
 		{
 			case kMCScriptDefinitionKindHandler:
 			{
+                MCScriptModuleRef t_previous = MCScriptSetCurrentModule(t_resolved_instance->module);
 				ctxt.PushFrame(t_resolved_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_resolved_definition),
 							   t_result_reg,
 				               t_arguments);
+                MCScriptSetCurrentModule(t_previous);
 			}
 			break;
 				
@@ -526,10 +528,12 @@ private:
 		{
 			case kMCScriptDefinitionKindHandler:
 			{
+                MCScriptModuleRef t_previous = MCScriptSetCurrentModule(t_handler_instance->module);
 				ctxt.PushFrame(t_handler_instance,
 							   static_cast<MCScriptHandlerDefinition *>(t_handler_def),
 							   p_result_reg,
 				               p_argument_regs);
+                MCScriptSetCurrentModule(t_previous);
 			}
 			break;
 				

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -26,7 +26,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// This is the module of the most recent LCB stack frame on the current thread's
+// This is the module of themost recent LCB stack frame on the current thread's
 // stack. It is set before and after a foreign handler call so that the native
 // code can get some element of context.
 static MCScriptModuleRef s_current_module = nil;
@@ -232,7 +232,9 @@ __MCScriptCallHandlerDefinitionInInstance(MCScriptInstanceRef self,
         }
     }
 
-	MCScriptExecuteContext t_execute_ctxt;
+    MCScriptModuleRef t_previous = MCScriptSetCurrentModule(self->module);
+	
+    MCScriptExecuteContext t_execute_ctxt;
 	t_execute_ctxt.Enter(self,
 						 p_handler_def,
 	                     MCMakeSpan(p_arguments, p_argument_count),
@@ -252,6 +254,8 @@ __MCScriptCallHandlerDefinitionInInstance(MCScriptInstanceRef self,
                                     t_cookie);
         }
     }
+    
+    MCScriptSetCurrentModule(t_previous);
 
 	if (!t_execute_ctxt.Leave())
 	{
@@ -1275,6 +1279,13 @@ MCScriptEvaluateHandlerInInstanceInternal(MCScriptInstanceRef p_instance,
 MCScriptModuleRef MCScriptGetCurrentModule(void)
 {
 	return s_current_module;
+}
+
+MCScriptModuleRef MCScriptSetCurrentModule(MCScriptModuleRef p_module)
+{
+    MCScriptModuleRef t_previous = s_current_module;
+    s_current_module = p_module;
+    return t_previous;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -538,6 +538,8 @@ struct MCScriptInstance: public MCScriptObject
     void *host_ptr;
 };
 
+MCScriptModuleRef MCScriptSetCurrentModule(MCScriptModuleRef module);
+
 void
 MCScriptDestroyInstance(MCScriptInstanceRef instance);
 

--- a/tests/lcs/core/engine/_canvas.lcb
+++ b/tests/lcs/core/engine/_canvas.lcb
@@ -8,4 +8,11 @@ public handler CanvasTestPixelHeight()
 	return the pixel height of tCanvas is 100
 end handler
 
+public handler CanvasTestImageFromResourceFile()
+	variable tImage as Image
+	put image from resource file "tiny.png" into tImage
+	
+	return not (the pixels of tImage is empty)
+end handler
+
 end library

--- a/tests/lcs/core/engine/canvas.livecodescript
+++ b/tests/lcs/core/engine/canvas.livecodescript
@@ -17,7 +17,11 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestSetup
-    load extension from file "../_tests/_build/lcs/core/engine/_canvas.lcm"
+    set the itemdelimiter to slash
+    local tFolder
+    put item 1 to -2 of the effective filename of me into tFolder
+
+    load extension from file tFolder & "/_canvas.lcm" with resource path tFolder
     if the result is not empty then
        throw "Failed to load test support extension:" && the result
     end if
@@ -27,3 +31,8 @@ on TestCanvasGetPixelHeight
 	TestAssert "canvas pixel height returned correctly", \
 		CanvasTestPixelHeight()
 end TestCanvasGetPixelHeight
+
+on TestCanvasImageFromResourceFile
+	TestAssert "canvas image from resource file not empty", \
+		CanvasTestImageFromResourceFile()
+end TestCanvasImageFromResourceFile

--- a/tests/lcs/core/engine/canvas.livecodescript
+++ b/tests/lcs/core/engine/canvas.livecodescript
@@ -21,7 +21,8 @@ on TestSetup
     local tFolder
     put item 1 to -2 of the effective filename of me into tFolder
 
-    load extension from file tFolder & "/_canvas.lcm" with resource path tFolder
+    load extension from file "../_tests/_build/lcs/core/engine/_canvas.lcm" \
+       with resource path tFolder
     if the result is not empty then
        throw "Failed to load test support extension:" && the result
     end if


### PR DESCRIPTION
This patch ensures that the current module global is updated
whenever a new frame is created on the LCB stack.

This fixes an issue with 'image from resource file' not working.