### PR TITLE
[[ Bug 20061 ]] Save m_rep in unbound widget

### DIFF
--- a/docs/notes/bugfix-20061.md
+++ b/docs/notes/bugfix-20061.md
@@ -1,0 +1,1 @@
+# Ensure data is not lost when opening and saving a stack with a widget that is not loaded

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -807,6 +807,8 @@ IO_stat MCWidget::save(IO_handle p_stream, uint4 p_part, bool p_force_ext, uint3
     MCAutoValueRef t_rep;
     if (m_widget != nil)
         MCWidgetOnSave(m_widget, &t_rep);
+    else
+        t_rep = m_rep;
     
     // If the rep is nil, then an error must have been thrown, so we still
     // save, but without any state for this widget.
@@ -1006,11 +1008,22 @@ void MCWidget::GetKind(MCExecContext& ctxt, MCNameRef& r_kind)
 void MCWidget::GetState(MCExecContext& ctxt, MCArrayRef& r_state)
 {
     MCAutoValueRef t_value;
-    if (!MCWidgetOnSave(m_widget,
-                        &t_value))
+    if (!m_widget && m_rep)
     {
-        r_state = MCValueRetain(kMCEmptyArray);
-        return;
+        if (!MCValueCopy(m_rep, &t_value))
+        {
+            r_state = MCValueRetain(kMCEmptyArray);
+            return;
+        }
+    }
+    else
+    {
+        if (!MCWidgetOnSave(m_widget,
+                            &t_value))
+        {
+            r_state = MCValueRetain(kMCEmptyArray);
+            return;
+        }
     }
     
     if (!MCExtensionConvertToScriptType(ctxt, InOut(t_value)))

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -321,12 +321,26 @@ on TestLoadExtension pName
 
 end TestLoadExtension
 
+private function __GetCaller
+   get item 1 to -3 of line -3 of the executionContexts
+   if there is not an it then
+      delete item -1 of it
+   end if
+   return it
+end __GetCaller
+
+private function __StackOfObject pLongID
+   local tOffset
+   put wordOffset("stack",pLongID) into tOffset
+   return word tOffset to -1 of pLongID
+end __StackOfObject
+
 -- This loads an extension whose lcb source sits in the same folder as the
 -- current test.
 on TestLoadAuxillaryExtension pName
 	local tBasePath, tExtraPath
 	set the itemDelimiter to slash
-	put item 1 to -2 of the filename of this stack into tBasePath
+	put item 1 to -2 of the effective filename of __StackOfObject(__GetCaller()) into tBasePath
 	repeat while the last item of tBasePath is not "tests"
 		put item -1 of tBasePath & slash before tExtraPath
 		delete the last item of tBasePath

--- a/tests/lcs/core/engine/_widget_save.lcb
+++ b/tests/lcs/core/engine/_widget_save.lcb
@@ -1,0 +1,17 @@
+widget com.livecode.lcs_tests.core.widget_save
+
+private variable mInfo as String
+
+property savedInfo get mInfo set mInfo
+
+public handler OnSave(out rProperties as Array)
+   put mInfo into rProperties["info"]
+end handler
+
+public handler OnLoad(in pProperties as Array)
+   if "info" is among the keys of pProperties then
+      put pProperties["info"] into mInfo
+   end if
+end handler
+
+end widget

--- a/tests/lcs/core/engine/widget.livecodescript
+++ b/tests/lcs/core/engine/widget.livecodescript
@@ -83,3 +83,33 @@ on TestWidgetThrowInOnCreate
 
    delete stack "WidgetThrowOnSaveTest"
 end TestWidgetThrowInOnCreate
+
+on TestWidgetRetainRep
+   create stack "WidgetRetainRepTest"
+   set the defaultStack to "WidgetRetainRepTest"
+
+   local tWidget
+   put "com.livecode.lcs_tests.core.widget_save" into tWidget["$kind"]
+   put uuid() into tWidget["$state"]["info"]
+   import widget from array tWidget
+
+   local tOut
+   export widget 1 to array tOut
+   TestAssert "Rep retained in export on failed bind", tOut["$state"]["info"] is tWidget["$state"]["info"]
+   
+   local tPath
+   put the tempName into tPath
+   save stack "WidgetRetainRepTest" as tPath
+   delete stack "WidgetRetainRepTest"
+   
+   TestLoadAuxillaryExtension "_widget_save"
+   
+   go stack tPath
+   
+   local tInfo
+   put the savedInfo of widget 1 of stack "WidgetRetainRepTest" into tInfo
+   TestAssert "Rep retained in save on failed bind", tInfo is tWidget["$state"]["info"]
+   
+   delete stack "WidgetRetainRepTest"
+   delete file tPath
+end TestWidgetRetainRep


### PR DESCRIPTION
When a widget bind fails we retain the loaded rep. This patch
ensures that that the retained rep is saved instead of a null
rep.