### PR TITLE
[Bug 20030] Use the hex code of the cert in iOS codesign step instead of cert name

### DIFF
--- a/docs/notes/bugfix-20030.md
+++ b/docs/notes/bugfix-20030.md
@@ -1,0 +1,1 @@
+# Ensure the S/B always uses a valid certificate when codesigning iOS standalones

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -618,14 +618,19 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       put revGetMobileProfileInfo(pSettings["ios,profile"]) into tProfileInfo
       
       -- Get the list of valid identities that are available
-      local tValidIdentities
+      local tValidIdentities,tValidIdentitiesHEX
       get shell("/usr/bin/security -q find-identity -v")
       if the last line of it contains "valid identities found" then
          delete the last line of it
+         -- "it" now is of the form:
+         -- 1) Certificate1IdHEX "Certificate1NameString"
+         -- 2) Certificate2IdHEX "Certificate2NameString"
          repeat for each line tIdentity in it
             put char 2 to -2 of the last word of tIdentity & return after tValidIdentities
+            put char 1 to -1 of the second word of tIdentity & return after tValidIdentitiesHEX
          end repeat
          delete the last char of tValidIdentities
+         delete the last char of tValidIdentitiesHEX
       else
          put empty into tValidIdentities
       end if
@@ -634,7 +639,9 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       put empty into tCertificate
       repeat for each line tIdentity in tProfileInfo["identities"]
          if tIdentity is among the lines of tValidIdentities then
-            put tIdentity into tCertificate
+            local tFound
+            put lineoffset(tIdentity,tValidIdentities) into tFound
+            put line tFound of tValidIdentitiesHEX into tCertificate
             exit repeat
          end if
       end repeat

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -618,19 +618,16 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       put revGetMobileProfileInfo(pSettings["ios,profile"]) into tProfileInfo
       
       -- Get the list of valid identities that are available
-      local tValidIdentities,tValidIdentitiesHEX
-      get shell("/usr/bin/security -q find-identity -v")
+      local tValidIdentities
+      get shell("/usr/bin/security -q find-identity -v -p codesigning")
       if the last line of it contains "valid identities found" then
          delete the last line of it
          -- "it" now is of the form:
          -- 1) Certificate1IdHEX "Certificate1NameString"
          -- 2) Certificate2IdHEX "Certificate2NameString"
          repeat for each line tIdentity in it
-            put char 2 to -2 of the last word of tIdentity & return after tValidIdentities
-            put char 1 to -1 of the second word of tIdentity & return after tValidIdentitiesHEX
+            put the second word of tIdentity into tValidIdentities[char 2 to -2 of the last word of tIdentity]
          end repeat
-         delete the last char of tValidIdentities
-         delete the last char of tValidIdentitiesHEX
       else
          put empty into tValidIdentities
       end if
@@ -638,10 +635,8 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       -- Use the first one we can that is in the profile
       put empty into tCertificate
       repeat for each line tIdentity in tProfileInfo["identities"]
-         if tIdentity is among the lines of tValidIdentities then
-            local tFound
-            put lineoffset(tIdentity,tValidIdentities) into tFound
-            put line tFound of tValidIdentitiesHEX into tCertificate
+         if tValidIdentities[tIdentity] is not empty then
+            put tValidIdentities[tIdentity] into tCertificate
             exit repeat
          end if
       end repeat
@@ -1277,7 +1272,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    
    -- MM-2011-09-28: The orientations settings have now been adjusted.  The standalone builder should wipe out
    -- any old oreintation settings.  If the user has not visited the new standalone builder then the new settings will not
-   -- be presesnt and the old settings will still be there.  If this is the case, port old settings.
+   -- be present and the old settings will still be there.  If this is the case, port old settings.
    --
    local tIPhoneOrientation, tIPadOrientations
    if pSettings["ios,initial orientation"] is not empty  then


### PR DESCRIPTION
The S/B used the name of the certificate to codesign the iOS standalone. This could cause a segmentation fault in case there were more than one certificates with the same name installed (e.g. one expired and one valid).

This patch ensures the codesign step uses the certificate HEX id, which is unique.