### PR TITLE
[[ Bug 20078 ]] Add 'my resources folder' to LCB

### DIFF
--- a/docs/lcb/notes/20078.md
+++ b/docs/lcb/notes/20078.md
@@ -1,0 +1,10 @@
+# LiveCode Builder Host Library
+
+## Engine library
+
+* Widgets and library modules can now get the path to
+  their resources folder using `my resources folder`.
+  If there is no resources folder attached to the calling
+  module, then nothing is returned.
+
+# [20078] Allow modules to access their resources folder

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -73,6 +73,8 @@ public foreign handler MCEngineEvalTheRowDelimiter(out rDelimiter as String) ret
 public foreign handler MCEngineEvalTheLineDelimiter(out rDelimiter as String) returns nothing binds to "<builtin>"
 public foreign handler MCEngineEvalTheItemDelimiter(out rDelimiter as String) returns nothing binds to "<builtin>"
 
+public foreign handler MCEngineEvalMyResourcesFolder(out pFile as optional String) returns nothing binds to "<builtin>"
+
 /**
 Summary:	Resolves a string to a script object.
 Object:		The string describing the script object.
@@ -556,6 +558,28 @@ syntax TheItemDelimiter is expression
     "the" "item" "delimiter"
 begin
     MCEngineEvalTheItemDelimiter(output)
+end syntax
+
+/**
+Summary:    Returns the resources folder for the current module
+
+Example:
+    -- Work out the filename of a file in the module's
+    -- resources folder.
+    variable tResourceFile as String
+    put my resources folder & "/foobar.txt" into tResourceFile
+
+Description:
+Returns the full path to the resources folder for the calling
+module. If there is no resources folder attached to the calling
+module, nothing is returned.
+
+Tags: Script Engine
+*/
+syntax MyResourcesFolder is expression
+    "my" "resources" "folder"
+begin
+    MCEngineEvalMyResourcesFolder(output)
 end syntax
 
 end module

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -40,6 +40,8 @@
 
 #include "module-engine.h"
 
+#include "libscript/script.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef struct __MCScriptObject *MCScriptObjectRef;
@@ -881,6 +883,28 @@ MCEngineEvalTheItemDelimiter(MCStringRef& r_del)
             MCECptr != nil ? MCECptr->GetItemDelimiter() : MCSTR(",");
     
     r_del = MCValueRetain(t_del);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+extern bool MCEngineLookupResourcePathForModule(MCScriptModuleRef p_module, MCStringRef &r_resource_path);
+
+extern "C" MC_DLLEXPORT_DEF void
+MCEngineEvalMyResourcesFolder(MCStringRef& r_folder)
+{
+    MCScriptModuleRef t_module = MCScriptGetCurrentModule();
+    if (t_module == nullptr)
+    {
+        r_folder = nullptr;
+        return;
+    }
+    
+    if (!MCEngineLookupResourcePathForModule(t_module,
+                                             r_folder))
+    {
+        r_folder = nullptr;
+        return;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/lcs/core/engine/_resources.lcb
+++ b/tests/lcs/core/engine/_resources.lcb
@@ -1,0 +1,9 @@
+library com.livecode.lcs_tests.core.resources
+
+use com.livecode.engine
+
+public handler ResourcesGetMyResourcesFolder() returns optional String
+	return my resources folder
+end handler
+
+end library

--- a/tests/lcs/core/engine/resources.livecodescript
+++ b/tests/lcs/core/engine/resources.livecodescript
@@ -1,0 +1,42 @@
+script "CoreEngineResources"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestModuleWithResourcesFolder
+    set the itemdelimiter to slash
+    local tFolder
+    put item 1 to -2 of the effective filename of me into tFolder
+    load extension from file "../_tests/_build/lcs/core/engine/_resources.lcm" \
+       with resource path tFolder
+
+    if the result is not empty then
+       throw "Failed to load test support extension:" && the result
+    end if
+
+    TestAssert "module with resources folder returns non-nothing", \
+		        ResourcesGetMyResourcesFolder() is not empty
+end TestModuleWithResourcesFolder
+
+on TestModuleWithoutResourcesFolder
+    load extension from file "../_tests/_build/lcs/core/engine/_resources.lcm"
+    if the result is not empty then
+       throw "Failed to load test support extension:" && the result
+    end if
+
+    TestAssert "module without resources folder returns nothing", \
+		        ResourcesGetMyResourcesFolder() is empty
+end TestModuleWithoutResourcesFolder


### PR DESCRIPTION
This patch adds 'my resources folder' syntax to LCB, returning
the resources folder for the calling module, or nothing if it
does not have one.