### PR TITLE
[[ Bug 19894 ]] Render caret with the correct blend mode

### DIFF
--- a/docs/notes/bugfix-19894.md
+++ b/docs/notes/bugfix-19894.md
@@ -1,0 +1,1 @@
+# Fix incorrect rendering of carets in fields

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -646,7 +646,11 @@ void MCField::drawcursor(MCContext *p_context, const MCRectangle &dirty)
 			// MW-2012-08-06: Use XOR to render the caret so it remains visible regardless
 			//   of background color (apart from 128,128,128!).
 			p_context->setforeground(p_context->getwhite());
-			p_context->setfunction(GXxor);
+            
+            /* The XOR blend is no longer supported, fortunately exlusion
+             * (and difference) are the same as XOR when the source is white or
+             * black. */
+			p_context->setfunction(GXblendExclusion);
 			
 			// MW-2012-09-19: [[ Bug 10393 ]] Draw the caret inside a layer to ensure the XOR
 			//   ink works correctly.


### PR DESCRIPTION
The caret has always been rendered using bitwise-xor blend
mode when rendering against an opaque background. However,
since the move to the new version of Skia we have had to
remove the 'legacy' blend modes.

Fortunately, when rendering white or black, using exclusion
or difference blend modes gives the same result as bitwise-
xor.

As exclusion is actually closer to bitwise-xor in general
(mathematically at least), this patch changes the use of
GXxor to GXblendExclusion in MCField::drawcursor.