### PR TITLE
[Bug 9092] - Fixed typo in revPrintField entry

### DIFF
--- a/docs/dictionary/command/revPrintField.lcdoc
+++ b/docs/dictionary/command/revPrintField.lcdoc
@@ -56,7 +56,7 @@ Instead, use a form that evaluates to a field reference, like this:
 The <revPrintField> <command> is equivalent to <select|selecting> the
 <field> and choosing File → Print Field… from the menubar.
 
-If the field contains any expressions of the form &expression%&gt;, the
+If the field contains any expressions of the form &lt;%expression%&gt;, the
 expression is <evaluate|evaluated> and replaced with the value before
 the <field> is printed. For example, if the <field> contains the text
 Today's date is &lt;%the long date%&gt; the printed text reads Today's

--- a/docs/notes/bugfix-9092.md
+++ b/docs/notes/bugfix-9092.md
@@ -1,0 +1,1 @@
+# Fixed typo in the revPrintField dictionary entry.


### PR DESCRIPTION
Changed &expression%> to read <%expression%>