### PR TITLE
[ bug 20113] Exists reference to there is a (operator)

### DIFF
--- a/docs/dictionary/function/exists.lcdoc
+++ b/docs/dictionary/function/exists.lcdoc
@@ -43,13 +43,12 @@ You can also specify a chunk of a container, but in this case the
 <exists> <function> always <return|returns> true.
 
 >*Tip:*  To find out whether a <file> or <folder> exists, or whether a
-> <process> is running, use the <there is a operator>.
+> <process> is running, use the <there is a (operator)>.
 
 References: function (control structure), isNumber (function),
 folder (glossary), current card (glossary), return (glossary),
 process (glossary), object (glossary), file (keyword), image (object),
-there is a operator (operator), there is a (operator),
-there is no (operator), owner (property)
+there is a (operator), there is no (operator), owner (property)
 
 Tags: objects
 

--- a/docs/dictionary/function/exists.lcdoc
+++ b/docs/dictionary/function/exists.lcdoc
@@ -43,7 +43,7 @@ You can also specify a chunk of a container, but in this case the
 <exists> <function> always <return|returns> true.
 
 >*Tip:*  To find out whether a <file> or <folder> exists, or whether a
-> <process> is running, use the <there is a (operator)>.
+> <process> is running, use the <there is a> operator.
 
 References: function (control structure), isNumber (function),
 folder (glossary), current card (glossary), return (glossary),

--- a/docs/notes/bugfix-20113.md
+++ b/docs/notes/bugfix-20113.md
@@ -1,0 +1,1 @@
+# Fixed there is a operator reference


### PR DESCRIPTION
Fixed missing () in tip section to there is a (operator)
Fixed duplicate reference to there is a operator (operator) in Related section