### PR TITLE
[[ Bug 16131, 17323 ]] Linux backdrop issues

### DIFF
--- a/docs/notes/bugfix-16131.md
+++ b/docs/notes/bugfix-16131.md
@@ -1,0 +1,1 @@
+# Ensure backdrop is sized to fill the screen on Linux

--- a/docs/notes/bugfix-17323.md
+++ b/docs/notes/bugfix-17323.md
@@ -1,0 +1,1 @@
+# Ensure backdrop window is behind all other windows on Linux

--- a/engine/src/linux.stubs
+++ b/engine/src/linux.stubs
@@ -226,6 +226,7 @@ gdk libgdk-x11-2.0.so.0
 	gdk_window_show: (pointer) -> ()
 	gdk_window_show_unraised: (pointer) -> ()
 	gdk_window_raise: (pointer) -> ()
+	gdk_window_lower: (pointer) -> ()
 	gdk_window_iconify: (pointer) -> ()
 	gdk_window_deiconify: (pointer) -> ()
 	gdk_window_set_title: (pointer, pointer) -> ()

--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -1405,8 +1405,9 @@ void MCScreenDC::enablebackdrop(bool p_hard)
         gdk_window_set_decorations(backdrop, GdkWMDecoration(0));
         gdk_window_set_skip_taskbar_hint(backdrop, TRUE);
         gdk_window_set_skip_pager_hint(backdrop, TRUE);
-        gdk_window_fullscreen(backdrop);
-        gdk_window_show_unraised(backdrop);
+	gdk_window_move_resize(backdrop, 0, 0, device_getwidth(), device_getheight());
+        gdk_window_lower(backdrop);
+	gdk_window_show_unraised(backdrop);
 	}
 	else
 	{


### PR DESCRIPTION
This patch fixes two linux backdrop issues:

- Bug 16131 - `gdk_window_fullscreen` is not guaranted to fullscreen
the window and does nothing if the window is already fullscreen. On
Ubuntu this was showing the behavior of fullscreening the first time
and showing as the window size on subsequent times
- Bug 17323 - `gdk_window_show_unraised` is being used to show the
backdrop but there is no guarantee the backdrop window is already
above other windows. This patch lowers the window before it is shown
unraised to ensure it is the lowest window in the application.