### PR TITLE
[[ Bug 20089 ]] Fix memory leak in obj-c action proxies

### DIFF
--- a/docs/lcb/notes/20089.md
+++ b/docs/lcb/notes/20089.md
@@ -1,0 +1,3 @@
+# LiveCode Builder Standard Library
+
+# [20089] Ensure obj-c action proxy objects are deallocated correctly

--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -266,6 +266,8 @@ MC_DLLEXPORT_DEF void *MCObjcObjectGetAutoreleasedId(const MCObjcObjectRef p_obj
     MCValueRef m_context;
 }
 - (id)initWithHandlerRef:(MCHandlerRef)aHandler context:(MCValueRef)aContext;
+- (void)dealloc;
+
 - (void)action:(id)sender;
 @end
 
@@ -280,6 +282,16 @@ MC_DLLEXPORT_DEF void *MCObjcObjectGetAutoreleasedId(const MCObjcObjectRef p_obj
     m_context = aContext != nullptr ? MCValueRetain(aContext) : nullptr;
     
     return self;
+}
+
+- (void)dealloc
+{
+    MCValueRelease(m_handler);
+    if (m_context != nullptr)
+    {
+        MCValueRelease(m_context);
+    }
+    [super dealloc];
 }
 
 - (void)action:(id)sender


### PR DESCRIPTION
This patch ensures that the Obj-C class used to implement the
action proxy object has an appropriate dealloc method.