### PR TITLE
[[ Bug 20124 ]] Add thread affinity for iOS

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -393,6 +393,8 @@ component Extensions
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.native.android.field
 	into [[ToolsFolder]]/Extensions place
+		rfolder macosx:packaged_extensions/com.livecode.widget.native.ios.button
+	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.browser
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.widget.clock

--- a/config/crosscompile.gypi
+++ b/config/crosscompile.gypi
@@ -81,10 +81,11 @@
 								{
 									'toolset_os': '<(host_os)',
 									'toolset_arch': '<(host_arch)',
+                                    
 								},
 								{
 									'toolset_os': '<(OS)',
-									'toolset_arch': '<(target_arch)',
+                                    'toolset_arch': '<(target_arch)',
 								},
 							],
 						],
@@ -99,6 +100,24 @@
 		
 		'target_conditions':
 		[
+            [
+                '_toolset == "host"',
+                {
+                    'defines':
+                    [
+                        'CROSS_COMPILE_HOST',
+                    ],
+                },
+            ],
+            [
+                '_toolset == "target"',
+                {
+                    'defines':
+                    [
+                        'CROSS_COMPILE_TARGET',
+                    ],
+                },
+            ],
 			[
 				'host_and_target != 0',
 				{

--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -444,10 +444,10 @@ Note: No bridging of types will occur when passing a parameter in the non-fixed
 section of a variadic argument list. You must ensure the arguments you pass there
 are of the appropriate foreign type (e.g. CInt, CDouble).
 
-There are a number of types defined in the foreign module which map to
-the appropriate foreign type when used in foreign handler signatures.
+There are a number of types defined in the foreign, java and objc modules which
+map to the appropriate foreign type when used in foreign handler signatures.
 
-There are the standard machine types:
+There are the standard machine types (defined in the foreign module):
 
  - Bool maps to an 8-bit boolean
  - Int8/SInt8 and UInt8 map to 8-bit integers
@@ -457,7 +457,7 @@ There are the standard machine types:
  - IntSize/SIntSize and UIntSize map to the integer size needed to hold a memory size
  - IntPtr/SIntPtr and UIntPtr map to the integer size needed to hold a pointer
 
-There are the standard C primitive types:
+There are the standard C primitive types (defined in the foreign module)
 
  - CBool maps to 'bool'
  - CChar, CSChar and CUChar map to 'char', 'signed char' and 'unsigned char'
@@ -468,7 +468,21 @@ There are the standard C primitive types:
  - CFloat maps to 'float'
  - CDouble maps to 'double'
 
-There are aliases for the Java primitive types:
+There are types specific to Obj-C types (defined in the objc module):
+
+  - ObjcObject wraps an obj-c 'id', i.e. a pointer to an objective-c object
+  - ObjcId maps to 'id'
+  - ObjcRetainedId maps to 'id', and should be used where a foreign handler
+    argument expects a +1 reference count, or where a foreign handler returns
+    an id with a +1 reference count.
+
+Note: When an ObjcId is converted to ObjcObject, the id is retained;
+when an ObjcObject converted to an ObjcId, the id is not retained. Conversely,
+when an ObjcRetainedId is converted to an ObjcObject, the object takes the
++1 reference count (so does not retain); when an ObjcObject is put into an
+ObjcRetainedId, a +1 reference count is taken (so does retain).
+
+There are aliases for the Java primitive types (defined in the java module)
 
  - JBoolean maps to Bool
  - JByte maps to Int8
@@ -515,8 +529,8 @@ If an out parameter is of a Ref type, then it must be a copy (on exit)
 If an inout parameter is of a Ref type, then its existing value must be
 released, and replaced by a copy (on exit).
 
-The binding string for foreign handlers is prefixed by a language, 
-currently either C or Java.
+The binding string for foreign handlers is language-specific and currently
+supported forms are explained in the following sections.
 
 Foreign handlers' bound symbols are resolved on first use and an error
 is thrown if the symbol cannot be found.
@@ -525,18 +539,11 @@ Foreign handlers are always considered unsafe, and thus may only be called
 from unsafe context - i.e. from within an unsafe handler, or unsafe statement
 block.
 
-> **Note:** The current foreign handler definition is an initial
-> version, mainly existing to allow binding to implementation of the
-> syntax present in the standard language modules. It will be expanded
-> and improved in a subsequent version to make it very easy to import
-> and use functions (and types) from other languages including
-> Objective-C (on Mac and iOS) and Java (on Android).
-
 #### The C binding string
 
 The C binding string has the following form:
 
-    "c:[library>][class.]function[!calling]"
+    "c:[library>][class.]function[!calling][?thread]"
 
 Here *library* specifies the name of the library to bind to (if no
 library is specified a symbol from the engine executable is assumed).
@@ -560,6 +567,26 @@ Here *calling* specifies the calling convention which can be one of:
 All but `default` are Win32-only, and on Win32 `default` maps to
 `cdecl`. If a Win32-only calling convention is specified on a
 non-Windows platform then it is taken to be `default`.
+
+Here *thread* is either empty or `ui`. The `ui` form is used to determine
+whether the method should be run on the UI thread (currently only applicable
+on Android and iOS).
+
+#### The Obj-C binding string
+
+The Obj-C binding string has the following form:
+
+    "objc:class.(+|-)method[?thread]"
+
+Here *class* specifies the name of the class containing the method to bind to.
+
+Here *method* specifies the method name to bind to in standard Obj-C selector
+form, e.g. addTarget:action:forControlEvents:. If the method is a class method
+then prefix it with '+', if it is an instance method then prefix it with '-'.
+
+Here *thread* is either empty or `ui`. The `ui` form is used to determine
+whether the method should be run on the UI thread (currently only applicable
+on Android and iOS).
 
 #### The Java binding string
 
@@ -665,8 +692,9 @@ Instance and nonvirtual calling conventions require instances of the given
 Java class, so the foreign handler declaration will always require a Java
 object parameter.
 
-Here, *thread* is either empty or `ui`. The `ui` form is used on 
-Android when binding to methods that must be run on the UI thread. 
+Here, *thread* is either empty or `ui`. The `ui` form is used to determine
+whether the method should be run on the UI thread (currently only applicable
+on Android and iOS).
 
 > **Warning:** At the moment it is not advised to use callbacks that may be
 > executed on arbitrary threads, as this is likely to cause your application

--- a/docs/lcb/notes/20090.md
+++ b/docs/lcb/notes/20090.md
@@ -1,0 +1,6 @@
+# LiveCode Builder Language
+
+## Foreign Function Interface
+
+* Obj-C exceptions thrown from calls to obj-c foreign handlers will now be caught
+  and rethrown as an LCB error.

--- a/docs/lcb/notes/20124.md
+++ b/docs/lcb/notes/20124.md
@@ -1,0 +1,5 @@
+# LiveCode Builder Language
+
+## Foreign Function Interface
+
+* It is now possible to specify the thread to be used in Obj-C foreign handlers. This is done by appending `?<thread>` to the end of the binding string. Currently the only supported value is `ui`, for running the handler on the iOS main thread, as opposed to the engine thread.

--- a/engine/src/mblandroidlcb.cpp
+++ b/engine/src/mblandroidlcb.cpp
@@ -35,52 +35,13 @@
 
 extern jobject MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_name, jobjectArray p_args);
 
-#ifdef TARGET_SUBPLATFORM_ANDROID
-struct remote_call_t
-{
-    jlong p_handler;
-    jstring p_method_name;
-    jobjectArray p_args;
-    jobject *t_return;
-};
-
-static void remote_call_func(void *p_context)
-{
-    auto ctxt = static_cast<remote_call_t *>(p_context);
-    *(ctxt->t_return) = MCJavaPrivateDoNativeListenerCallback(ctxt->p_handler,
-                                                              ctxt->p_method_name,
-                                                              ctxt->p_args);
-}
-#endif
-
 extern "C" JNIEXPORT jobject JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong handler, jstring p_method, jobjectArray p_args) __attribute__((visibility("default")));
 
 JNIEXPORT jobject JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong p_handler, jstring p_method_name, jobjectArray p_args)
 {
-    jobject t_global_return = nullptr;
-#ifdef TARGET_SUBPLATFORM_ANDROID
-    extern bool MCAndroidIsOnEngineThread(void);
-    if (!MCAndroidIsOnEngineThread())
-    {
-        // Take globalrefs of java objects we need to persist after
-        // jumping threads
-        p_args = static_cast<jobjectArray>(env->NewGlobalRef(p_args));
-        p_method_name = static_cast<jstring>(env->NewGlobalRef(p_method_name));
-        typedef void (*co_yield_callback_t)(void *);
-        extern void co_yield_to_engine_and_call(co_yield_callback_t callback, void *context);
-        remote_call_t t_context = {p_handler, p_method_name, p_args, &t_global_return};
-        co_yield_to_engine_and_call(remote_call_func, &t_context);
-        env->DeleteGlobalRef(p_args);
-        env->DeleteGlobalRef(p_method_name);
-    }
-    else
-    {
-#endif
-        t_global_return = MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
-#ifdef TARGET_SUBPLATFORM_ANDROID
-    }
-#endif
-    
+    jobject t_result =
+            MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
+
     // At the moment we have no way of dealing with any errors thrown in
     // the course of handling or attempting to handle the native listener
     // callback, so
@@ -93,17 +54,7 @@ JNIEXPORT jobject JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeL
         MCsystem->Debug(*t_string);
     }
     
-    // Turn global ref'd return into a local ref for this env, so it
-    // can be garbage-collected
-    
-    jobject t_return = nullptr;
-    if (t_global_return != nullptr)
-    {
-        t_return = env->NewLocalRef(t_global_return);
-        env->DeleteGlobalRef(t_global_return);
-    }
-    
-    return t_return;
+    return t_result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -214,6 +214,11 @@ void MCIPhoneCallOnMainFiber(void (*handler)(void *), void *context)
 	MCFiberCall(s_main_fiber, handler, context);
 }
 
+bool MCIPhoneIsOnMainFiber(void)
+{
+    return MCFiberIsCurrentThread(s_main_fiber);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 Boolean MCScreenDC::open(void)

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -29,6 +29,7 @@
 				'widgets/androidbutton/androidbutton.lcb',
 				'widgets/androidfield/androidfield.lcb',
 				'widgets/macbutton/macbutton.lcb',
+				'widgets/iosbutton/iosbutton.lcb',
 				'widgets/browser/browser.lcb',
 				#’widgets/chart/chart.lcb',
 				#'widgets/checkbox/checkbox.lcb',

--- a/extensions/widgets/iosbutton/iosbutton.lcb
+++ b/extensions/widgets/iosbutton/iosbutton.lcb
@@ -1,0 +1,262 @@
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/**
+Name: iOS Native Button
+
+Description: 
+This widget is a native push button on iOS.
+
+Name: enabled
+
+Syntax: 
+set the enabled of <widget> to {true | false}
+get the enabled of <widget>
+
+Description:
+Use the <enabled> property to enable or disable the native button. When
+disabled, the button has a greyed out appearance and does not accept 
+clicks or touches.
+*/
+widget com.livecode.widget.native.ios.button
+
+use com.livecode.foreign
+use com.livecode.objc
+use com.livecode.widget
+use com.livecode.canvas
+use com.livecode.engine
+use com.livecode.library.widgetutils
+
+metadata version is "1.0.0"
+metadata author is "LiveCode"
+metadata title is "iOS Native Button"
+metadata svgicon is "M 535.66797 241.55273 C 491.1077 241.55273 455.23438 277.42605 455.23438 321.98633 L 455.23438 913.65039 C 455.23438 958.21066 491.1077 994.08398 535.66797 994.08398 L 2014.5762 994.08398 C 2059.1364 994.08398 2095.0098 958.21066 2095.0098 913.65039 L 2095.0098 321.98633 C 2095.0098 277.42605 2059.1364 241.55273 2014.5762 241.55273 L 535.66797 241.55273 z M 1155.1543 304.32422 C 1293.7311 304.30837 1399.8223 413.6262 1399.8223 613.28906 C 1399.8223 831.92443 1278.4507 931.3125 1145.5957 931.3125 C 1009.8798 931.3125 899.97656 823.80972 899.97656 622.33203 C 899.97656 415.4574 1013.7086 304.32422 1155.1543 304.32422 z M 1637.668 305.20508 C 1689.1647 305.20508 1728.013 319.66027 1746.082 332.30859 L 1738.9023 347.9043 C 1723.5436 337.0708 1682.0317 323.26562 1636.875 323.26562 C 1535.6646 323.26562 1491.5781 399.7417 1491.5781 456.04102 C 1491.5781 533.80129 1551.8559 559.80417 1629.5527 596.8457 C 1719.89 641.10692 1767.7656 680.13793 1767.7656 765.07031 C 1767.7656 856.31896 1702.7239 930.38477 1587.082 930.38477 C 1539.1912 930.38477 1484.0899 914.13108 1456.9863 893.34375 L 1465.0605 875.2832 C 1494.8824 895.15914 1546.3559 914.35352 1590.625 914.35352 C 1674.646 914.35352 1749.3711 855.57405 1749.3711 769.05664 C 1749.3711 688.7683 1699.5944 646.87616 1615.082 610.88867 C 1539.4457 578.68139 1471.4414 543.72442 1471.4414 457.89648 C 1471.4414 368.46267 1541.9021 305.20508 1637.668 305.20508 z M 1156.1758 325.58008 C 999.78351 325.58008 917.99023 456.01743 917.99023 617.80664 C 917.99023 783.58214 998.33285 912.36328 1146.4355 912.36328 C 1295.5685 912.36328 1381.1035 779.61907 1381.1035 615.91992 C 1381.1035 464.11624 1312.5681 325.58008 1156.1758 325.58008 z M 799.93164 336.48438 C 810.31342 336.48438 816.91406 344.97176 816.91406 355.35352 C 816.91406 366.19495 810.31315 374.21484 798.98828 374.21484 C 789.55751 374.21484 782.48047 366.19495 782.48047 355.35352 C 782.48047 344.97176 790.02537 336.48438 799.93164 336.48438 z M 790.80859 488.61328 L 808.58398 488.61328 L 808.58398 922.26953 L 790.80859 922.26953 L 790.80859 488.61328 z"
+
+constant kSvgIcon is "M4.621 6.965c0 1.368-.833 2.38-2.262 2.38-1.19 0-2.083-1.012-2.083-2.38 0-1.31.952-2.381 2.202-2.381 1.31 0 2.143 1.071 2.143 2.381zM1.327 78.5V23.78H3.57V78.5H1.327zM78.174 39.512c0 27.588-15.315 40.129-32.079 40.129-17.125 0-30.993-13.565-30.993-38.988C15.102 14.549 29.453.526 47.301.526 64.787.524 78.174 14.318 78.174 39.512zm-60.799.57C17.375 61 27.513 77.25 46.201 77.25c18.818 0 29.611-16.75 29.611-37.406 0-19.155-8.648-36.636-28.382-36.636S17.375 19.667 17.375 40.082zM86.406 72.571c3.763 2.508 10.258 4.93 15.844 4.93 10.602 0 20.031-7.417 20.031-18.334 0-10.131-6.281-15.417-16.945-19.958-9.544-4.064-18.125-8.475-18.125-19.305 0-11.285 8.891-19.267 20.975-19.267 6.498 0 11.4 1.824 13.68 3.42l-.906 1.968c-1.938-1.367-7.176-3.109-12.874-3.109-12.771 0-18.334 9.65-18.334 16.754 0 9.812 7.606 13.093 17.41 17.767 11.399 5.585 17.44 10.51 17.44 21.227 0 11.514-8.207 20.86-22.799 20.86-6.043 0-12.996-2.051-16.416-4.674l1.019-2.279z"
+
+/**
+Syntax:
+set the label of <widget> to <pLabel>
+get the label of <widget>
+
+Summary: The label displayed by the button.
+
+Value (string): The string to use as the button label
+
+Example:
+    set the label of widget "iOS Button" to "Click me!"
+
+Description:
+The <label> property is the label displayed by the button.
+*/
+
+property label get mLabel set SetLabel
+metadata label.editor is "com.livecode.pi.string"
+metadata label.default is ""
+
+private variable mLabel as String
+private variable mButtonView as optional ObjcObject
+private variable mButtonProxy as optional ObjcObject
+
+private handler IsIOS() returns Boolean
+    return the operating system is "ios"
+end handler
+
+/**/
+
+public handler OnCreate()
+	put "" into mLabel
+end handler
+
+public handler OnDestroy()
+	put nothing into mButtonView
+end handler
+
+/**/
+
+public handler OnOpen()
+    if IsIOS() then
+        unsafe
+            CreateButtonView()
+        end unsafe
+    end if
+end handler
+
+public handler OnClose()
+    if IsIOS() then
+        unsafe
+            DestroyButtonView()
+        end unsafe
+    end if
+end handler
+
+/**/
+
+constant kBorderWidth is 5
+private handler expandRectangle(in pRect as Rectangle, in pExp as Number) returns Rectangle
+    return rectangle [ the left of pRect - pExp, the top of pRect - pExp, the right of pRect + pExp, the bottom of pRect + pExp]
+end handler
+
+public handler OnPaint()
+	if IsIOS() then
+		return
+	end if
+
+    // Draw placeholder image - the icon
+    variable tFillPaint as Paint
+    variable tStrokePaint as Paint
+    put solid paint with color [0.875, 0.875, 0.875] into tFillPaint
+    put solid paint with color [0.75, 0.75, 0.75] into tStrokePaint
+    variable tBounds as Rectangle
+    put my bounds into tBounds
+    set the paint of this canvas to tFillPaint
+    fill rectangle path of tBounds on this canvas
+    set the paint of this canvas to tStrokePaint
+    set the stroke width of this canvas to kBorderWidth
+    set the join style of this canvas to "bevel"
+    stroke rectangle path of expandRectangle(tBounds, -kBorderWidth / 2) on this canvas
+    variable tPath as Path
+    put path kSvgIcon into tPath
+    constrainPathToRect(expandRectangle(tBounds, -2 * kBorderWidth), tPath)
+    fill tPath on this canvas
+    // Draw the control name
+    put solid paint with color [1, 1, 1, 0.1] into tFillPaint
+    put solid paint with color [0.25, 0.25, 0.25] into tStrokePaint
+    variable tNameString as String
+    if mLabel is empty then
+        put my name into tNameString
+    else
+        put mLabel into tNameString
+    end if
+    set the font of this canvas to my font
+    
+    variable tTextBounds as Rectangle
+    put the image bounds of text tNameString on this canvas into tTextBounds
+    translate this canvas by [ the width of tBounds / 2, the height of tBounds / 2]
+    translate this canvas by [ -(the width of tTextBounds / 2), the height of tTextBounds / 2]
+    set the paint of this canvas to tFillPaint
+    
+    variable tRect as Rectangle
+    put expandRectangle(tTextBounds, kBorderWidth) into tRect
+    fill rounded rectangle path of tRect with radius 5 on this canvas
+    set the paint of this canvas to solid paint with color [0.0, 0.0, 0.0]
+    fill text tNameString at center of tRect on this canvas
+end handler
+
+/**/
+
+public handler OnSave(out rProperties as Array)
+	put mLabel into rProperties["label"]
+end handler
+
+public handler OnLoad(in pProperties as Array)
+	put pProperties["label"] into mLabel
+end handler
+
+/**/
+
+public handler OnParentPropertyChanged()
+    unsafe
+        UpdateButtonView()
+    end unsafe
+end handler
+
+/**/
+
+private handler SetLabel(in pLabel as String) returns nothing
+	put pLabel into mLabel
+	unsafe
+        UpdateButtonView()
+	end unsafe
+    redraw all
+end handler
+
+/****/
+
+private handler ButtonActionCallback(in pSender as ObjcObject, in pContext as optional any) returns nothing
+	post "mouseUp"
+
+    // Wake the engine to deal with the posted signal
+    MCEngineRunloopBreakWait()
+end handler
+
+/****/
+
+private type NSUInteger is CULong
+private foreign handler ObjC_UIButtonButtonWithType(in pType as NSUInteger) returns ObjcId binds to "objc:UIButton.+buttonWithType:?ui"
+private foreign handler ObjC_UIButtonSetTitleForState(in pObj as ObjcId, in pTitle as ObjcId, in pState as NSUInteger) returns nothing binds to "objc:UIButton.-setTitle:forState:?ui"
+private foreign handler ObjC_UIButtonSetEnabled(in pObj as ObjcId, in pEnabled as CBool) returns nothing binds to "objc:UIButton.-setEnabled:?ui"
+private foreign handler ObjC_UIButtonGetTitleLabel(in pObj as ObjcId) returns ObjcId binds to "objc:UIButton.-titleLabel?ui"
+private foreign handler ObjC_UILabelSetFont(in pObj as ObjcId, in pFont as ObjcId) returns nothing binds to "objc:UILabel.-setFont:?ui"
+private foreign handler ObjC_UIButtonAddTargetActionForControlEvents(in pObj as ObjcId, in pTarget as ObjcId, in pAction as UIntPtr, in pControlEvents as NSUInteger) returns nothing binds to "objc:UIButton.-addTarget:action:forControlEvents:?ui"
+
+private foreign handler MCCanvasFontGetHandle(in pFont as Font, out rHandle as ObjcId) returns nothing binds to "<builtin>"
+
+private unsafe handler CreateButtonView() returns nothing
+	variable tButtonView as ObjcObject
+
+    /* For a standard push button we need:
+     *   type to be UIButtonTypeSystem = 1 */
+	put ObjC_UIButtonButtonWithType(1) into tButtonView
+
+    set my native layer to PointerFromObjcObject(tButtonView)
+	put tButtonView into mButtonView
+
+	put ObjcProxyGetTarget(ButtonActionCallback, nothing) into mButtonProxy
+
+    /* For a push button action we need:
+     *   controlEvents to be UIControlEventTouchUpInside = 1 << 6 */
+    ObjC_UIButtonAddTargetActionForControlEvents(mButtonView, mButtonProxy, ObjcProxyGetAction(), 1 shifted left by 6 bitwise)
+
+	UpdateButtonView()
+end handler
+
+private unsafe handler DestroyButtonView() returns nothing
+	set my native layer to nothing
+	put nothing into mButtonView
+	put nothing into mButtonProxy
+end handler
+
+private unsafe handler UpdateButtonView() returns nothing
+	if mButtonView is nothing then
+		return
+	end if
+	
+    /* Set the enabled state of the button to the host property. */
+    ObjC_UIButtonSetEnabled(mButtonView, my enabled)
+
+    /* Set the font of the button to the host property. */
+    variable tFontToUse as ObjcObject
+    MCCanvasFontGetHandle(my font, tFontToUse)
+    ObjC_UILabelSetFont(ObjC_UIButtonGetTitleLabel(mButtonView), tFontToUse)
+
+    /* Set the label of the button to mLabel, if not empty; otherwise to the
+     * name of the host. */
+    variable tLabelToUse as String
+    if mLabel is the empty string then
+        put my name into tLabelToUse
+    else
+        put mLabel into tLabelToUse
+    end if
+
+    /* We use UIControlStateNormal = 0 */
+	ObjC_UIButtonSetTitleForState(mButtonView, StringToNSString(tLabelToUse), 0)
+end handler
+
+/**/
+
+end widget

--- a/extensions/widgets/iosbutton/notes/feature-ios_native_button.md
+++ b/extensions/widgets/iosbutton/notes/feature-ios_native_button.md
@@ -1,0 +1,14 @@
+# iOS Native Button
+
+A new widget has been added which is a native button view on iOS. On
+all other platforms it presents a placeholder image with the iOS 
+logo.
+
+## Properties
+
+* **enabled** - The enabled state of the button
+* **label** - The label to display
+
+## Messages
+
+* **mouseUp** - sent when the button is clicked

--- a/extensions/widgets/macbutton/notes/feature-mac_native_button.md
+++ b/extensions/widgets/macbutton/notes/feature-mac_native_button.md
@@ -1,0 +1,14 @@
+# macOS Native Button
+
+A new widget has been added which is a native button view on macOS. On
+all other platforms it presents a placeholder image with the macOS 
+logo.
+
+## Properties
+
+* **enabled** - The enabled state of the button
+* **label** - The label to display
+
+## Messages
+
+* **mouseUp** - sent when the button is clicked

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3050,8 +3050,19 @@ MC_DLLEXPORT bool MCHandlerCreate(MCTypeInfoRef typeinfo, const MCHandlerCallbac
 MC_DLLEXPORT void *MCHandlerGetContext(MCHandlerRef handler);
 MC_DLLEXPORT const MCHandlerCallbacks *MCHandlerGetCallbacks(MCHandlerRef handler);
     
+/* Invoke the given handler with the specified arguments. If an error is thrown
+ * then false is returned.
+ * Note: The normal version must be called from the engine thread. Use
+ *       ExternalInvoke if the current thread is unknown. */
 MC_DLLEXPORT bool MCHandlerInvoke(MCHandlerRef handler, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
+MC_DLLEXPORT bool MCHandlerExternalInvoke(MCHandlerRef handler, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
+
+/* Invoke the given handler with the specified arguments. If an error is thrown
+ * then the error object is returned.
+ * Note: The normal version must be called from the engine thread. Use
+ *       ExternalInvoke if the current thread is unknown. */
 MC_DLLEXPORT /*copy*/ MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef handler, MCProperListRef& x_arguments, MCValueRef& r_value);
+MC_DLLEXPORT /*copy*/ MCErrorRef MCHandlerTryToExternalInvokeWithList(MCHandlerRef handler, MCProperListRef& x_arguments, MCValueRef& r_value);
     
 MC_DLLEXPORT bool MCHandlerGetFunctionPtr(MCHandlerRef handler, void*& r_func_ptr);
 

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -58,6 +58,52 @@ bool MCHandlerInvoke(MCHandlerRef self, MCValueRef *p_arguments, uindex_t p_argu
     return self -> callbacks -> invoke(MCHandlerGetContext(self), p_arguments, p_argument_count, r_value);
 }
 
+#if (defined(TARGET_SUBPLATFORM_IPHONE) || defined(TARGET_SUBPLATFORM_ANDROID)) && !defined(CROSS_COMPILE_HOST)
+struct MCHandlerInvokeTrampolineContext
+{
+    MCHandlerRef self;
+    MCValueRef *p_arguments;
+    uindex_t p_argument_count;
+    MCValueRef r_value;
+    bool return_value;
+};
+
+static void MCHandlerInvokeTrampoline(void *p_context)
+{
+    auto ctxt = static_cast<MCHandlerInvokeTrampolineContext *>(p_context);
+    ctxt->return_value = MCHandlerInvoke(ctxt->self, ctxt->p_arguments, ctxt->p_argument_count, ctxt->r_value);
+}
+#endif
+
+MC_DLLEXPORT_DEF
+bool MCHandlerExternalInvoke(MCHandlerRef self, MCValueRef *p_arguments, uindex_t p_argument_count, MCValueRef& r_value)
+{
+#if defined(TARGET_SUBPLATFORM_ANDROID) && !defined(CROSS_COMPILE_HOST)
+    extern bool MCAndroidIsOnEngineThread(void);
+    if (!MCAndroidIsOnEngineThread())
+    {
+        typedef void (*co_yield_callback_t)(void *);
+        extern void co_yield_to_android_and_call(co_yield_callback_t callback, void *context);
+        MCHandlerInvokeTrampolineContext t_context = {self, p_arguments, p_argument_count, r_value, true};
+        co_yield_to_android_and_call(MCHandlerInvokeTrampoline, &t_context);
+        return t_context.return_value;
+    }
+#elif defined(TARGET_SUBPLATFORM_IPHONE) && !defined(CROSS_COMPILE_HOST)
+    extern bool MCIPhoneIsOnMainFiber(void);
+    if (!MCIPhoneIsOnMainFiber())
+    {
+        extern void MCIPhoneRunOnMainFiber(void (*)(void *), void *);
+        MCHandlerInvokeTrampolineContext t_context = {self, p_arguments, p_argument_count, r_value, true};
+        MCIPhoneRunOnMainFiber(MCHandlerInvokeTrampoline, &t_context);
+        return t_context.return_value;
+    }
+#endif
+    
+    __MCAssertIsHandler(self);
+    MCAssert(p_arguments != nil || p_argument_count == 0);
+    return self -> callbacks -> invoke(MCHandlerGetContext(self), p_arguments, p_argument_count, r_value);
+}
+
 MC_DLLEXPORT_DEF
 MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef self, MCProperListRef& x_arguments, MCValueRef& r_value)
 {
@@ -73,6 +119,40 @@ MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef self, MCProperListRef& x_ar
         t_args[i] = MCValueRetain(MCProperListFetchElementAtIndex(x_arguments, i));
     
     if (!MCHandlerInvoke(self, t_args . Ptr(), t_args . Size(), r_value))
+        goto error_exit;
+    
+    if (!t_args . TakeAsProperList(Out(t_out_args)))
+        goto error_exit;
+    
+    MCValueAssign(x_arguments, t_out_args . Take());
+    
+    return nil;
+    
+error_exit:
+    r_value = nil;
+    
+    MCErrorRef t_error;
+    if (!MCErrorCatch(t_error))
+        return nil;
+    
+    return t_error;
+}
+
+MC_DLLEXPORT_DEF
+MCErrorRef MCHandlerTryToExternalInvokeWithList(MCHandlerRef self, MCProperListRef& x_arguments, MCValueRef& r_value)
+{
+    __MCAssertIsHandler(self);
+    __MCAssertIsProperList(x_arguments);
+    MCAutoValueRefArray t_args;
+    MCAutoProperListRef t_out_args;
+    
+    if (!t_args . New(MCProperListGetLength(x_arguments)))
+        goto error_exit;
+    
+    for(uindex_t i = 0; i < MCProperListGetLength(x_arguments); i++)
+        t_args[i] = MCValueRetain(MCProperListFetchElementAtIndex(x_arguments, i));
+    
+    if (!MCHandlerExternalInvoke(self, t_args . Ptr(), t_args . Size(), r_value))
         goto error_exit;
     
     if (!t_args . TakeAsProperList(Out(t_out_args)))

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -1849,8 +1849,8 @@ jobject MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_
         return nullptr;
     
     MCErrorRef t_error =
-        MCHandlerTryToInvokeWithList(static_cast<MCHandlerRef>(t_handler),
-                                     t_mutable_list, &t_result);
+        MCHandlerTryToExternalInvokeWithList(static_cast<MCHandlerRef>(t_handler),
+                                             t_mutable_list, &t_result);
     jobject t_return = nullptr;
     if (*t_result != nil)
     {
@@ -1869,7 +1869,7 @@ jobject MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_
     if (t_error != nil)
         MCErrorThrow(t_error);
     
-    return s_env->NewGlobalRef(t_return);
+    return s_env->NewLocalRef(t_return);
 }
 #else
 

--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -310,7 +310,7 @@ MC_DLLEXPORT_DEF void *MCObjcObjectGetAutoreleasedId(const MCObjcObjectRef p_obj
     }
     
     MCAutoValueRef t_result;
-    if (!MCHandlerInvoke(m_handler, t_args, m_context != nullptr ? 2 : 1, &t_result))
+    if (!MCHandlerExternalInvoke(m_handler, t_args, m_context != nullptr ? 2 : 1, &t_result))
     {
         return;
     }

--- a/libscript/libscript.gyp
+++ b/libscript/libscript.gyp
@@ -29,6 +29,7 @@
 			'src/script-object.cpp',
 			'src/script-package.cpp',
 			'src/script-execute.cpp',
+			'src/script-execute-objc.mm',
 			'src/script-error.cpp',
 		],
 	},
@@ -73,6 +74,15 @@
 			
 			'conditions':
 			[
+				[
+					'OS != "mac" and OS != "ios"',
+					{
+						'sources!':
+						[
+							'src/script-execute-objc.mm',
+						],
+					},
+				],
 				[
 					'OS == "linux" or OS == "android"',
 					{

--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -370,6 +370,15 @@ MCScriptThrowJavaBindingNotSupported(void)
 }
 
 bool
+MCScriptThrowForeignExceptionError(MCStringRef p_reason)
+{
+    return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
+                                 "reason",
+                                 p_reason,
+                                 nil);
+}
+
+bool
 MCScriptThrowObjCBindingNotSupported(void)
 {
 	return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,

--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -352,11 +352,11 @@ MCScriptThrowUnableToLoadForiegnLibraryError(void)
 }
 
 bool
-MCScriptThrowUnknownJavaThreadError(void)
+MCScriptThrowUnknownThreadAffinityError(void)
 {
     return MCErrorCreateAndThrow(kMCGenericErrorTypeInfo,
                                  "reason",
-                                 MCSTR("unknown thread for java binding"),
+                                 MCSTR("unknown thread affinity specified in binding string"),
                                  nil);
 }
 

--- a/libscript/src/script-execute-objc.mm
+++ b/libscript/src/script-execute-objc.mm
@@ -1,0 +1,47 @@
+/* Copyright (C) 2017 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "libscript/script.h"
+#include "script-private.h"
+
+#include "ffi.h"
+
+#include "foundation-auto.h"
+
+#include <Foundation/Foundation.h>
+
+#include "script-execute.hpp"
+
+bool MCScriptCallObjCCatchingErrors(ffi_cif *p_cif, void (*p_function)(), void *p_result_ptr, void **p_arg_ptrs)
+{
+    @try
+    {
+        ffi_call(p_cif, p_function, p_result_ptr, p_arg_ptrs);
+        return true;
+    }
+    @catch (NSException *exception)
+    {
+        MCAutoStringRef t_reason;
+        if (!MCStringCreateWithCFString((CFStringRef)[exception reason], &t_reason))
+        {
+            return false;
+        }
+        
+        return MCScriptThrowForeignExceptionError(*t_reason);
+    }
+    
+    return false;
+}

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -40,37 +40,20 @@ static void __MCScriptDropValueRef(void *p_value)
 	MCValueRelease(*(MCValueRef *)p_value);
 }
 
-#ifdef TARGET_SUBPLATFORM_ANDROID
-struct remote_call_t
-{
-    MCScriptForeignHandlerDefinition *p_handler;
-    MCTypeInfoRef p_handler_signature;
-    void *p_result_slot_ptr;
-    void **m_argument_values;
-    uindex_t m_argument_count;
-};
-
-static void remote_call_func(void *p_context)
-{
-    extern void *MCAndroidGetSystemJavaEnv();
-    auto ctxt = static_cast<remote_call_t *>(p_context);
-
-    extern bool MCJavaPrivateCallJNIMethodOnEnv(void *p_env, MCNameRef p_class, void *p_method_id, int p_call_type, MCTypeInfoRef p_signature, void *r_return, void **p_args, uindex_t p_arg_count);
-
-    MCJavaPrivateCallJNIMethodOnEnv(MCAndroidGetSystemJavaEnv(),
-                             ctxt -> p_handler -> java . class_name,
-                             ctxt -> p_handler -> java . method_id,
-                             ctxt -> p_handler -> java . call_type,
-                             ctxt -> p_handler_signature,
-                             ctxt -> p_result_slot_ptr,
-                             ctxt -> m_argument_values,
-                             ctxt -> m_argument_count);
-}
-#endif
-
 class MCScriptForeignInvocation
 {
 public:
+    struct CallTrampolineContext
+    {
+        MCScriptForeignInvocation* invocation;
+        MCScriptForeignHandlerDefinition *handler;
+        MCTypeInfoRef signature;
+        void *result_slot_ptr;
+        bool return_value;
+    };
+    
+    /**/
+
 	MCScriptForeignInvocation(void)
 		: m_argument_count(0),
 		  m_storage_frontier(0)
@@ -173,175 +156,238 @@ public:
 		return true;
 	}
 	
-	// Call
+    /**/
+    
+    bool CallJava(MCScriptForeignHandlerDefinition *p_handler,
+                  MCTypeInfoRef p_handler_signature,
+                  void *p_result_slot_ptr)
+    {
+        if (p_handler->thread_affinity != kMCScriptThreadAffinityDefault)
+        {
+#if defined(TARGET_SUBPLATFORM_ANDROID) && !defined(CROSS_COMPILE_HOST)
+            extern void *MCAndroidGetSystemJavaEnv();
+            extern bool MCJavaPrivateCallJNIMethodOnEnv(void *p_env, MCNameRef p_class, void *p_method_id, int p_call_type, MCTypeInfoRef p_signature, void *r_return, void **p_args, uindex_t p_arg_count);
+            
+            return MCJavaPrivateCallJNIMethodOnEnv(MCAndroidGetSystemJavaEnv(),
+                                                   p_handler->java.class_name,
+                                                   p_handler->java.method_id,
+                                                   p_handler->java.call_type,
+                                                   p_handler_signature,
+                                                   p_result_slot_ptr,
+                                                   m_argument_values,
+                                                   m_argument_count);
+#endif
+        }
+        
+        return MCJavaCallJNIMethod(p_handler->java.class_name,
+                                   p_handler->java.method_id,
+                                   p_handler->java.call_type,
+                                   p_handler_signature,
+                                   p_result_slot_ptr,
+                                   m_argument_values,
+                                   m_argument_count);
+    }
+    
+    /**/
+    
+    bool CallC(MCScriptForeignHandlerDefinition *p_handler,
+			   MCTypeInfoRef p_handler_signature,
+			   void *p_result_slot_ptr)
+    {
+        MCAssert(p_handler->language == kMCScriptForeignHandlerLanguageC);
+        
+        if (!MCHandlerTypeInfoIsVariadic(p_handler_signature))
+        {
+            ffi_call((ffi_cif *)p_handler ->c.function_cif,
+                     (void(*)())p_handler ->c.function,
+                     p_result_slot_ptr,
+                     m_argument_values);
+        }
+        else
+        {
+            ffi_cif *t_fixed_cif = (ffi_cif *)p_handler->c.function_cif;
+            ffi_cif t_cif;
+            if (ffi_prep_cif_var(&t_cif,
+                                 t_fixed_cif->abi,
+                                 t_fixed_cif->nargs,
+                                 m_argument_count,
+                                 t_fixed_cif->rtype,
+                                 m_argument_types) != FFI_OK)
+            {
+                return MCErrorThrowGeneric(MCSTR("unexpected libffi failure"));
+            }
+            
+            ffi_call(&t_cif,
+                     (void(*)())p_handler ->c.function,
+                     p_result_slot_ptr,
+                     m_argument_values);
+        }
+        
+        return true;
+    }
+
+    /**/
+    
+    bool CallObjC(MCScriptForeignHandlerDefinition *p_handler,
+                  MCTypeInfoRef p_handler_signature,
+                  void *p_result_slot_ptr)
+    {
+#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
+        /* At this point we have a argument values array which will match
+         * the LCB signature - depending on the call type we need to modify
+         * it. */
+        void *t_objc_values[kMaxArguments];
+        if (p_handler->objc.call_type == kMCScriptForeignHandlerObjcCallTypeInstanceMethod)
+        {
+            /* In the case of an instance method call, we need to insert
+             * the method pointer as the second argument. */
+            if (m_argument_count + 1 >= kMaxArguments)
+            {
+                return MCErrorThrowOutOfMemory();
+            }
+            t_objc_values[0] = m_argument_values[0];
+            t_objc_values[1] = &p_handler->objc.objc_selector;
+            for(uindex_t i = 1; i < m_argument_count; i++)
+                t_objc_values[i + 1] = m_argument_values[i];
+        }
+        else if (p_handler->objc.call_type == kMCScriptForeignHandlerObjcCallTypeClassMethod)
+        {
+            /* In the case of a class method call, we need to insert both
+             * the class, and method pointer as the first two arguments. */
+            if (m_argument_count + 2 >= kMaxArguments)
+            {
+                return MCErrorThrowOutOfMemory();
+            }
+            
+            t_objc_values[0] = &p_handler->objc.objc_class;
+            t_objc_values[1] = &p_handler->objc.objc_selector;
+            for(uindex_t i = 0; i < m_argument_count; i++)
+                t_objc_values[i + 2] = m_argument_values[i];
+        }
+        
+        /* There are different variants of objc_msgSend we need to use
+         * depending on architecture and return type:
+         *   struct return
+         *     all: _stret
+         *   float return
+         *     arm: no difference
+         *     i386: _fpret
+         *     x86-64: no difference
+         *   double return
+         *     arm: no difference
+         *     i386: _fpret
+         *     x86-64: no difference
+         *   long double
+         *     arm: no difference
+         *     i386: _fpret
+         *     x86-64: _fpret
+         *   _Complex long double (TODO)
+         *     arm: no difference
+         *     i386: no difference
+         *     x86-64: _fp2ret
+         */
+         
+        ffi_cif *t_cif = (ffi_cif *)p_handler->objc.function_cif;
+        void (*t_objc_msgSend)() = nullptr;
+#if defined(__ARM__)
+        if (t_cif->rtype->type == FFI_TYPE_STRUCT)
+            t_objc_msgSend = (void(*)())objc_msgSend_stret;
+        else
+            t_objc_msgSend = (void(*)())objc_msgSend;
+#elif defined(__X86_64__)
+        if (t_cif->rtype->type == FFI_TYPE_STRUCT)
+            t_objc_msgSend = (void(*)())objc_msgSend_stret;
+        else if (t_cif->rtype->type == FFI_TYPE_LONGDOUBLE)
+            t_objc_msgSend = (void(*)())objc_msgSend_fpret;
+        else
+            t_objc_msgSend = (void(*)())objc_msgSend;
+#elif defined(__I386__)
+        if (t_cif->rtype->type == FFI_TYPE_STRUCT)
+            t_objc_msgSend = (void(*)())objc_msgSend_stret;
+        else if (t_cif->rtype->type == FFI_TYPE_FLOAT ||
+                 t_cif->rtype->type == FFI_TYPE_DOUBLE ||
+                 t_cif->rtype->type == FFI_TYPE_LONGDOUBLE)
+            t_objc_msgSend = (void(*)())objc_msgSend_fpret;
+        else
+            t_objc_msgSend = (void(*)())objc_msgSend;
+#endif
+        ffi_call(t_cif,
+                 (void(*)())objc_msgSend,
+                 p_result_slot_ptr,
+                 t_objc_values);
+        
+        return true;
+#else
+        return true;
+#endif
+    }
+
+    bool CallAny(MCScriptForeignHandlerDefinition *p_handler,
+                 MCTypeInfoRef p_handler_signature,
+                 void *p_result_slot_ptr)
+    {
+        switch(p_handler->language)
+        {
+            case kMCScriptForeignHandlerLanguageJava:
+                return CallJava(p_handler, p_handler_signature, p_result_slot_ptr);
+            
+            case kMCScriptForeignHandlerLanguageC:
+                return CallC(p_handler, p_handler_signature, p_result_slot_ptr);
+                
+            case kMCScriptForeignHandlerLanguageBuiltinC:
+                ((void(*)(void*, void**))p_handler->builtin_c.function)(p_result_slot_ptr,
+                                                                        m_argument_values);
+                return true;
+                
+            case kMCScriptForeignHandlerLanguageObjC:
+                return CallObjC(p_handler, p_handler_signature, p_result_slot_ptr);
+            
+            case kMCScriptForeignHandlerLanguageUnknown:
+                MCUnreachableReturn(false);
+        }
+        
+        return false;
+    }
+    
+    static void CallAnyTrampoline(void *p_context)
+    {
+        auto ctxt = static_cast<CallTrampolineContext *>(p_context);
+        ctxt->return_value = ctxt->invocation->CallObjC(ctxt->handler,
+                                                        ctxt->signature,
+                                                        ctxt->result_slot_ptr);
+    }
+    
+	// Call the foreign handler, taking into account which thread it must run
+    // on.
 	bool Call(MCScriptForeignHandlerDefinition *p_handler,
 			  MCTypeInfoRef p_handler_signature,
 			  void *p_result_slot_ptr)
-	{
-        switch(p_handler->language)
+    {
+        /* If the handler has a thread affinity which is non-default, then on split
+         * thread engines (android / ios) we must do the actual call on the other
+         * thread. */
+        if (p_handler->thread_affinity != kMCScriptThreadAffinityDefault)
         {
-        case kMCScriptForeignHandlerLanguageJava:
-#ifdef TARGET_SUBPLATFORM_ANDROID
-            extern bool MCAndroidIsOnSystemThread();
-            if (p_handler->java.thread != kMCJavaThreadUI || MCAndroidIsOnSystemThread())
+#if defined(TARGET_SUBPLATFORM_IPHONE) && !defined(CROSS_COMPILE_HOST)
+            extern void MCIPhoneRunOnMainFiber(void (*)(void *), void *);
+            CallTrampolineContext t_context = { this, p_handler, p_handler_signature, p_result_slot_ptr, true };
+            MCIPhoneRunOnMainFiber(CallAnyTrampoline, &t_context);
+            return t_context.return_value;
+#elif defined(TARGET_SUBPLATFORM_ANDROID) && !defined(CROSS_COMPILE_HOST)
+            typedef void (*co_yield_callback_t)(void *);
+            extern void co_yield_to_android_and_call(co_yield_callback_t callback, void *context);
+            CallTrampolineContext t_context = { this, p_handler, p_handler_signature, p_result_slot_ptr, true };
+            co_yield_to_android_and_call(CallAnyTrampoline, &t_context);
+            return t_context.return_value;
 #endif
-            {
-                MCJavaCallJNIMethod(p_handler->java.class_name,
-                                    p_handler->java.method_id,
-                                    p_handler->java.call_type,
-                                    p_handler_signature,
-                                    p_result_slot_ptr,
-                                    m_argument_values,
-                                    m_argument_count);
-            }
-#ifdef TARGET_SUBPLATFORM_ANDROID
-            else
-            {
-                typedef void (*co_yield_callback_t)(void *);
-                extern void co_yield_to_android_and_call(co_yield_callback_t callback, void *context);
-                remote_call_t t_context =
-                {
-                    p_handler,
-                    p_handler_signature,
-                    p_result_slot_ptr,
-                    m_argument_values,
-                    m_argument_count
-                };
-                co_yield_to_android_and_call(remote_call_func, &t_context);
-            }
-#endif
-            break;
-        
-        case kMCScriptForeignHandlerLanguageC:
-            if (!MCHandlerTypeInfoIsVariadic(p_handler_signature))
-            {
-                ffi_call((ffi_cif *)p_handler ->c.function_cif,
-                         (void(*)())p_handler ->c.function,
-                         p_result_slot_ptr,
-                         m_argument_values);
-            }
-            else
-            {
-                ffi_cif *t_fixed_cif = (ffi_cif *)p_handler->c.function_cif;
-                ffi_cif t_cif;
-                if (ffi_prep_cif_var(&t_cif,
-                                     t_fixed_cif->abi,
-                                     t_fixed_cif->nargs,
-                                     m_argument_count,
-                                     t_fixed_cif->rtype,
-                                     m_argument_types) != FFI_OK)
-                {
-                    return MCErrorThrowGeneric(MCSTR("unexpected libffi failure"));
-                }
-                
-                ffi_call(&t_cif,
-                         (void(*)())p_handler ->c.function,
-                         p_result_slot_ptr,
-                         m_argument_values);
-            }
-            break;
-            
-        case kMCScriptForeignHandlerLanguageBuiltinC:
-            ((void(*)(void*, void**))p_handler->builtin_c.function)(p_result_slot_ptr,
-                    m_argument_values);
-            break;
-        
-        case kMCScriptForeignHandlerLanguageObjC:
-#if defined(_MACOSX) || defined(TARGET_SUBPLATFORM_IPHONE)
-        {
-            /* At this point we have a argument values array which will match
-             * the LCB signature - depending on the call type we need to modify
-             * it. */
-            void *t_objc_values[kMaxArguments];
-            if (p_handler->objc.call_type == kMCScriptForeignHandlerObjcCallTypeInstanceMethod)
-            {
-                /* In the case of an instance method call, we need to insert
-                 * the method pointer as the second argument. */
-                if (m_argument_count + 1 >= kMaxArguments)
-                {
-                    return MCErrorThrowOutOfMemory();
-                }
-                t_objc_values[0] = m_argument_values[0];
-                t_objc_values[1] = &p_handler->objc.objc_selector;
-                for(uindex_t i = 1; i < m_argument_count; i++)
-                    t_objc_values[i + 1] = m_argument_values[i];
-            }
-            else if (p_handler->objc.call_type == kMCScriptForeignHandlerObjcCallTypeClassMethod)
-            {
-                /* In the case of a class method call, we need to insert both
-                 * the class, and method pointer as the first two arguments. */
-                if (m_argument_count + 2 >= kMaxArguments)
-                {
-                    return MCErrorThrowOutOfMemory();
-                }
-                
-                t_objc_values[0] = &p_handler->objc.objc_class;
-                t_objc_values[1] = &p_handler->objc.objc_selector;
-                for(uindex_t i = 0; i < m_argument_count; i++)
-                    t_objc_values[i + 2] = m_argument_values[i];
-            }
-            
-            /* There are different variants of objc_msgSend we need to use
-             * depending on architecture and return type:
-             *   struct return
-             *     all: _stret
-             *   float return
-             *     arm: no difference
-             *     i386: _fpret
-             *     x86-64: no difference
-             *   double return
-             *     arm: no difference
-             *     i386: _fpret
-             *     x86-64: no difference
-             *   long double
-             *     arm: no difference
-             *     i386: _fpret
-             *     x86-64: _fpret
-             *   _Complex long double (TODO)
-             *     arm: no difference
-             *     i386: no difference
-             *     x86-64: _fp2ret
-             */
-             
-            ffi_cif *t_cif = (ffi_cif *)p_handler->objc.function_cif;
-            void (*t_objc_msgSend)() = nullptr;
-#if defined(__ARM__)
-            if (t_cif->rtype->type == FFI_TYPE_STRUCT)
-                t_objc_msgSend = (void(*)())objc_msgSend_stret;
-            else
-                t_objc_msgSend = (void(*)())objc_msgSend;
-#elif defined(__X86_64__)
-            if (t_cif->rtype->type == FFI_TYPE_STRUCT)
-                t_objc_msgSend = (void(*)())objc_msgSend_stret;
-            else if (t_cif->rtype->type == FFI_TYPE_LONGDOUBLE)
-                t_objc_msgSend = (void(*)())objc_msgSend_fpret;
-            else
-                t_objc_msgSend = (void(*)())objc_msgSend;
-#elif defined(__I386__)
-            if (t_cif->rtype->type == FFI_TYPE_STRUCT)
-                t_objc_msgSend = (void(*)())objc_msgSend_stret;
-            else if (t_cif->rtype->type == FFI_TYPE_FLOAT ||
-                     t_cif->rtype->type == FFI_TYPE_DOUBLE ||
-                     t_cif->rtype->type == FFI_TYPE_LONGDOUBLE)
-                t_objc_msgSend = (void(*)())objc_msgSend_fpret;
-            else
-                t_objc_msgSend = (void(*)())objc_msgSend;
-#endif
-            ffi_call(t_cif,
-                     (void(*)())objc_msgSend,
-                     p_result_slot_ptr,
-                     t_objc_values);
         }
-#endif
-        break;
-            
-        case kMCScriptForeignHandlerLanguageUnknown:
-            MCUnreachableReturn(false);
-            break;
-		}
-		
-		return true;
-	}
+        
+        /* Either thread affinity is default, or the platform does not have split
+         * threads. */
+        return CallAny(p_handler,
+                       p_handler_signature,
+                       p_result_slot_ptr);
+    }
     
 	// Take the contents of a slot - this stops the invocation
 	// cleaning up the taken slot.

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -311,12 +311,13 @@ public:
         else
             t_objc_msgSend = (void(*)())objc_msgSend;
 #endif
-        ffi_call(t_cif,
-                 (void(*)())objc_msgSend,
-                 p_result_slot_ptr,
-                 t_objc_values);
-        
-        return true;
+        /* We must use a wrapper function written in an obj-c++ source file so that
+         * we can capture any obj-c exceptions. */
+        extern bool MCScriptCallObjCCatchingErrors(ffi_cif*, void (*)(), void *, void **);
+        return MCScriptCallObjCCatchingErrors(t_cif,
+                                              (void(*)())objc_msgSend,
+                                              p_result_slot_ptr,
+                                              t_objc_values);
 #else
         return true;
 #endif

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -362,19 +362,25 @@ enum MCScriptForeignHandlerLanguage
     kMCScriptForeignHandlerLanguageJava,
 };
 
-enum MCJavaThread {
-    kMCJavaThreadDefault,
-    kMCJavaThreadUI
+/* MCScriptThreadAffinity describes which thread a foreign handler should be
+ * executed on. This applies to Android and iOS, where a handler can either be
+ * run on the default (engine) thread, or the UI (main) thread. */
+enum MCScriptThreadAffinity
+{
+    kMCScriptThreadAffinityDefault,
+    kMCScriptThreadAffinityUI,
 };
 
 /* MCScriptForeignHandlerObjcCallType describes how to call the objective-c
  * method. */
 enum MCScriptForeignHandlerObjcCallType
 {
-    /* Call the method using method_invoke on the instance */
+    /* Call the method using method_invoke on the instance (on the default
+     * thread) */
     kMCScriptForeignHandlerObjcCallTypeInstanceMethod,
     
-    /* Call the method using method_invoke on the class instance */
+    /* Call the method using method_invoke on the class instance (on the default
+     * thread) */
     kMCScriptForeignHandlerObjcCallTypeClassMethod,
 };
 
@@ -383,7 +389,8 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
     MCStringRef binding;
     
     // Bound function information - not pickled.
-    MCScriptForeignHandlerLanguage language;
+    MCScriptForeignHandlerLanguage language : 8;
+    MCScriptThreadAffinity thread_affinity : 8;
     union
     {
         struct
@@ -397,7 +404,7 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
         } builtin_c;
         struct
         {
-            MCScriptForeignHandlerObjcCallType call_type;
+            MCScriptForeignHandlerObjcCallType call_type : 8;
             void *objc_class;
             void *objc_selector;
             void *function_cif;
@@ -407,7 +414,6 @@ struct MCScriptForeignHandlerDefinition: public MCScriptCommonHandlerDefinition
             MCNameRef class_name;
             void *method_id;
             int call_type : 8;
-            int thread : 8;
         } java;
     };
 };
@@ -683,7 +689,7 @@ bool
 MCScriptThrowJavaBindingNotSupported(void);
 
 bool
-MCScriptThrowUnknownJavaThreadError(void);
+MCScriptThrowUnknownThreadAffinityError(void);
 
 bool
 MCScriptCreateErrorExpectedError(MCErrorRef& r_error);

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -683,6 +683,9 @@ bool
 MCScriptThrowUnableToLoadForiegnLibraryError(void);
 
 bool
+MCScriptThrowForeignExceptionError(MCStringRef p_reason);
+
+bool
 MCScriptThrowObjCBindingNotSupported(void);
 
 bool

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -75,7 +75,6 @@ end handler
 
 ---------
 
-
 public handler TestObjInterop_RoundtripNumber()
 	if not the operating system is in ["mac", "ios"] then
 		skip test "objc binding succeeds" because "not implemented on" && the operating system
@@ -100,5 +99,26 @@ public handler TestObjInterop_RoundtripNumber()
 end handler
 
 --------
+
+__safe foreign handler MCHandlerTryToInvokeWithList(in Handler as any, inout Arguments as optional List, out Result as optional any) returns optional any binds to "<builtin>"
+__safe foreign handler NSArrayFirstObject(in pObj as ObjcId) returns ObjcId binds to "objc:NSArray.firstObject"
+
+private handler __CallNSNumberMethodOnNSString(in pString as ObjcObject) returns optional any
+	return NSArrayFirstObject(pString)
+end handler
+
+public handler TestObjcInterop_CatchObjcException()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "objc exception handler succeeds" because "not implemented on" && the operating system
+		return
+	end if
+
+	variable tArguments as List
+	variable tResult as optional any
+	put [ StringToNSString("foo") ] into tArguments
+	test "objc exception is caught" when MCHandlerTryToInvokeWithList(__CallNSNumberMethodOnNSString, tArguments, tResult) is not nothing
+end handler
+
+---------
 
 end module


### PR DESCRIPTION
This patch generalizes the idea of 'thread affinity' introduced
to Java FFI for Android, to cover Obj-C and C foreign handlers as
well.

Java specific types and functions have been renamed to be more general
MCScriptThreadAffinity enum based - and the Java code refactored to
use it.

Two C defines CROSS_COMPILE_TARGET and CROSS_COMPILE_HOST have been
added, which one depends on whether the target is being compiled
in host or target mode. This is required as GYP generates Xcode
projects which build HOST using TARGET defines (e.g. lc-compile is
compiled for Mac as if it were targetting iOS).

There are now External variants of the HandlerInvoke APIs which
will ensure that the HandlerRef is called on the engine thread, and
the Obj-C and Java interop code which may call handlers from the
ui thread now use them.

Similarly, thread jumping is now done either at the point of handler
invocation in LCB, or at the point of external HandlerRef invocation
from outside of LCB. Essentially, LCB always presumes it is running
code on the engine thread (like LCS does).

NOTE: This patch also contains the commit implementing catching of obj-c
exceptions - I suggest reviewing the two commits separately.