### PR TITLE
[[ Bug 15302 ]] Fix "occured"

### DIFF
--- a/docs/notes/bugfix-15302.md
+++ b/docs/notes/bugfix-15302.md
@@ -1,0 +1,1 @@
+# Fix common misspelling of occurred

--- a/engine/include/customprinter.h
+++ b/engine/include/customprinter.h
@@ -337,7 +337,7 @@ public:
 
 	// Return the error string describing the reason for 'false' being returned
 	// from one of the action methods. 'nil' should be returned if no error
-	// has occured.
+	// has occurred.
 	virtual const char *GetError(void) = 0;
 
 	// Start a new document with the given details as present in the
@@ -345,7 +345,7 @@ public:
 	virtual bool BeginDocument(const MCCustomPrinterDocument& document) = 0;
 
 	// Cancel the current document - this should have the same effect as if
-	// an error occured, but obviously no error should be set.
+	// an error occurred, but obviously no error should be set.
 	virtual void AbortDocument(void) = 0;
 
 	// Mark the end of a document.

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -454,7 +454,7 @@ void MCButton::open()
     MCControl::open();
 
 	// MW-2011-02-08: [[ Bug 9382 ]] Make sure we reset icons when opening and the state
-	//   has changed (i.e. background transition has occured).
+	//   has changed (i.e. background transition has occurred).
 	uint32_t t_old_state;
 	t_old_state = state;
 	switch(gethilite(0))

--- a/engine/src/customprinter.cpp
+++ b/engine/src/customprinter.cpp
@@ -232,7 +232,7 @@ private:
 	// can be used.
 	MCPrinterRectangle m_page_rect;
 
-	// If this is true, an error has occured during execute
+	// If this is true, an error has occurred during execute
 	bool m_execute_error;
 
 	// The untransformed rect and scale of current composite region
@@ -273,7 +273,7 @@ bool MCCustomMetaContext::render(MCCustomPrintingDevice *p_device, const MCPrint
 
 bool MCCustomMetaContext::candomark(MCMark *p_mark)
 {
-	// If an error has occured during this execution, just return true to minimize
+	// If an error has occurred during this execution, just return true to minimize
 	// unnecessary rasterization (this is to make up for a lack of error handling
 	// during the super-classes execution process).
 	if (m_execute_error)
@@ -377,7 +377,7 @@ bool MCCustomMetaContext::candomark(MCMark *p_mark)
 
 void MCCustomMetaContext::domark(MCMark *p_mark)
 {
-	// If an error has occured, we do nothing.
+	// If an error has occurred, we do nothing.
 	if (m_execute_error)
 		return;
 

--- a/engine/src/deploy.h
+++ b/engine/src/deploy.h
@@ -453,7 +453,7 @@ enum MCDeployError
 	/* An error occurred while creating the startup stack */
 	kMCDeployErrorEmscriptenBadStack,
 	
-	/* An error occured with the pre-deploy step */
+	/* An error occurred with the pre-deploy step */
 	kMCDeployErrorTrialBannerError,
 
 	// SIGN ERRORS
@@ -472,19 +472,19 @@ enum MCDeployError
 	// The password did not match
 	kMCDeployErrorBadPassword,
 
-	// An error occured while building the signature
+	// An error occurred while building the signature
 	kMCDeployErrorBadSignature,
 
-	// An error occured while trying to convert a string
+	// An error occurred while trying to convert a string
 	kMCDeployErrorBadString,
 
-	// An error occured while trying to compute the hash
+	// An error occurred while trying to compute the hash
 	kMCDeployErrorBadHash,
 
-	// An error occured while trying to fetch a timestamp
+	// An error occurred while trying to fetch a timestamp
 	kMCDeployErrorTimestampFailed,
 
-	// An error occured decoding the timestamp response
+	// An error occurred decoding the timestamp response
 	kMCDeployErrorBadTimestamp,
 
 

--- a/engine/src/deploy_capsule.cpp
+++ b/engine/src/deploy_capsule.cpp
@@ -391,7 +391,7 @@ static bool MCDeployCapsuleFilterFlush(MCDeployCapsuleFilterState& self)
 		self . stream . next_in = self . input;
 	}
 
-	// If a buf error occured, we either need more space, or more input
+	// If a buf error occurred, we either need more space, or more input
 	if (t_result == Z_BUF_ERROR)
 	{
 		// If the input buffer is not maxed out, return as we need more input

--- a/engine/src/deploy_linux.cpp
+++ b/engine/src/deploy_linux.cpp
@@ -798,7 +798,7 @@ Exec_stat MCDeployToELF(const MCDeployParameters& p_params, bool p_is_android)
 	uint32_t t_end_offset, t_end_size;
 	if (t_success)
 	{
-		// Compute the shift that will have occured to any post-project sections
+		// Compute the shift that will have occurred to any post-project sections
 		int32_t t_project_delta, t_payload_delta;
 		t_project_delta = t_project_size - t_project_section -> sh_size;
 		if (t_payload_section != NULL)

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -5621,7 +5621,7 @@ bool MCS_mac_elevation_bootstrap_main(int argc, char *argv[])
 	// And finally exec to the new process (this does not return if successful).
 	execvp(t_args[0], t_args);
 	
-	// If we get this far then an error has occured :o(
+	// If we get this far then an error has occurred :o(
 	return false;
 }
 

--- a/engine/src/dskw32main.cpp
+++ b/engine/src/dskw32main.cpp
@@ -285,7 +285,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 		DisplayStartupErrorAndExit();
 
 	// Now we loop continually until quit. If 'X_main_loop' returns without quitting
-	// it means a stack size change request has occured.
+	// it means a stack size change request has occurred.
 	while(!MCquit)
 	{
 		// Create ourselves a new fiber with appropriate stack size

--- a/engine/src/environment/stackbehavior.livecodescript
+++ b/engine/src/environment/stackbehavior.livecodescript
@@ -166,7 +166,7 @@ on startup pTest
                end if
                return sHomePath
             default
-               -- Some other error occured, so fall through to activation.
+               -- Some other error occurred, so fall through to activation.
                put "The license for this version has become corrupted, please activate to continue." into sActivateReason
                break
          end switch
@@ -464,7 +464,7 @@ command performFacelessActivation
          break
          
       default
-         write "An unknown error occured." & return to stdout
+         write "An unknown error occurred." & return to stdout
          quit 12
    end switch
    
@@ -640,7 +640,7 @@ private command automaticActivationList
    
    -- Act on the response for 'nolicenses'
    if tPostResult["result"] is "nolicenses" then
-      put "An error occured while processing the request. Please try again." into sActivateError
+      put "An error occurred while processing the request. Please try again." into sActivateError
       return "error"
    end if
    
@@ -666,7 +666,7 @@ private command automaticActivationList
          end if
          exit to top   
       default
-         -- Some other error occured, so fall through to activation.
+         -- Some other error occurred, so fall through to activation.
          automaticActivationSetProtocolError "invalid"
          return "error"
          break
@@ -686,7 +686,7 @@ private command leaveRemoteOperation
 end leaveRemoteOperation
 
 private command automaticActivationSetPostError pPostError
-   put "An error occured while attempting to contact the server. Please try again later." into sActivateError
+   put "An error occurred while attempting to contact the server. Please try again later." into sActivateError
 end automaticActivationSetPosterror
 
 private command automaticActivationSetProtocolError pError
@@ -717,7 +717,7 @@ private command automaticActivationSetProtocolError pError
          break
       case "nolicense"
          -- some sort of backend mismatch problem
-         put "An error occured generating the license key. Please try again." into sActivateError
+         put "An error occurred generating the license key. Please try again." into sActivateError
          break
       case "disabled"
          -- account disabled
@@ -730,7 +730,7 @@ private command automaticActivationSetProtocolError pError
       case "invalid"
       default
          -- bad request
-         put "An error has occured while contacting the server. Please try again." into sActivateError
+         put "An error has occurred while contacting the server. Please try again." into sActivateError
          break
    end switch
 end automaticActivationSetProtocolError

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -761,7 +761,7 @@ bool MCExtensionConvertFromScriptType(MCExecContext& ctxt, MCTypeInfoRef p_as_ty
 // Ensure that if the input value is a name it comes out as a string.
 // Ensure that if the input value is an array, all elements that are names (recursed)
 // come out as strings.
-// If r_output is nil, then no mutation occured; otherwise it is the mutated value.
+// If r_output is nil, then no mutation occurred; otherwise it is the mutated value.
 static bool __script_ensure_names_are_strings(MCValueRef p_input, MCValueRef& r_output)
 {
     if (MCValueGetTypeCode(p_input) == kMCValueTypeCodeName)

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2639,13 +2639,13 @@ enum Exec_errors
     // AL-2015-07-07: The following error codes are 8.0 specific so should have their numbers
     //  incremented whenever new codes are merged up from below.
     // MW-2014-12-10: [[ Extensions ]] The error codes used to indicate an extension error.
-    // {EE-0863} extension: error occured with domain
+    // {EE-0863} extension: error occurred with domain
     EE_EXTENSION_ERROR_DOMAIN,
-    // {EE-0864} extension: error occured with description
+    // {EE-0864} extension: error occurred with description
     EE_EXTENSION_ERROR_DESCRIPTION,
-    // {EE-0865} extension: error occured with file
+    // {EE-0865} extension: error occurred with file
     EE_EXTENSION_ERROR_FILE,
-    // {EE-0866} extension: error occured with line
+    // {EE-0866} extension: error occurred with line
     EE_EXTENSION_ERROR_LINE,
     
     // {EE-0867} load: error in extension expression

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -137,7 +137,7 @@ enum MCInterfaceFieldCursorMovement
     kMCFieldCursorMovementLogical,
 };
 
-// MW-2012-02-20: [[ FieldExport ]] The event that occured to cause the callback.
+// MW-2012-02-20: [[ FieldExport ]] The event that occurred to cause the callback.
 enum MCFieldExportEventType
 {
 	kMCFieldExportEventBeginParagraph,

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -1443,7 +1443,7 @@ void MCField::startselection(int2 x, int2 y, Boolean words)
 						selectedmark(False, si, ei, False);
 						if (ti >= si && ti < ei && si != ei)
 						{
-							// Here we mark the fact a mouse-down has occured in
+							// Here we mark the fact a mouse-down has occurred in
 							// the selection. This is used in mdrag to work out
 							// whether to initiate a drag-drop operation.
 							state |= CS_SOURCE_TEXT;

--- a/engine/src/ijpg.cpp
+++ b/engine/src/ijpg.cpp
@@ -818,7 +818,7 @@ bool MCJPEGImageLoader::LoadFrames(MCBitmapFrame *&r_frames, uint32_t &r_count)
 		MCMemoryDeallocate(t_row_buffer);
 
     // SN-2015-07-07: [[ Bug 15569 ]] Ensure that we do not touch the image if
-    //  an error occured on decompression.
+    //  an error occurred on decompression.
     if (t_success && m_orientation != 0)
 		apply_exif_orientation(m_orientation, t_frame->image);
 

--- a/engine/src/lnxelevate.cpp
+++ b/engine/src/lnxelevate.cpp
@@ -269,7 +269,7 @@ bool MCSystemOpenElevatedProcess(MCStringRef p_command, int32_t& r_pid, int32_t&
 		// Shouldn't return.
 		execvp(t_argv[0], (char * const *) t_argv);
 
-		// If we get here an error occured. We just exit with '-1' since the parent
+		// If we get here an error occurred. We just exit with '-1' since the parent
 		// will detect termination of the child.
 		_exit(-1);
 	}

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -1605,7 +1605,7 @@ void MCMacPlatformHandleMousePress(uint32_t p_button, bool p_new_state)
 		uint32_t t_event_time;
 		t_event_time = MCPlatformGetEventTime();
 		
-		// If the click occured within the double click time and double click
+		// If the click occurred within the double click time and double click
 		// radius *and* if the button is the same as the last clicked button
 		// then increment the click count.
 		if (t_event_time - s_mouse_last_click_time < MCdoubletime &&

--- a/engine/src/mac-menu.mm
+++ b/engine/src/mac-menu.mm
@@ -215,7 +215,7 @@ enum MCShadowedItemTags
         s_menu_item_selected = true;
     }
     
-    // SN-2014-11-06: [[ Bug 13836 ]] s_menu_select_occured was not used.
+    // SN-2014-11-06: [[ Bug 13836 ]] s_menu_select_occurred was not used.
 }
 
 - (BOOL)validateMenuItem: (NSMenuItem *)item
@@ -414,10 +414,10 @@ void MCMacPlatformPopQuittingState()
 // has been selected.
 bool MCMacPlatformIsInQuittingState(void)
 {
-	bool t_occured;
-	t_occured = s_quit_selected;
+	bool t_occurred;
+	t_occurred = s_quit_selected;
 	s_quit_selected = false;
-	return t_occured;
+	return t_occurred;
 }
 
 void MCMacPlatformLockMenuSelect(void)

--- a/engine/src/mbliphonebrowser.mm
+++ b/engine/src/mbliphonebrowser.mm
@@ -748,7 +748,7 @@ public:
 	
 	void Dispatch(void)
 	{
-		// MW-2011-11-03: [[ LoadRequested ]] If a load occured, then post a load requested
+		// MW-2011-11-03: [[ LoadRequested ]] If a load occurred, then post a load requested
 		//   event.
 		if (m_target -> HandleLoadRequest(m_request, m_type, m_notify))
 			MCEventQueuePostCustom(new MCNativeBrowserLoadRequestEvent(m_target, m_request, m_type, true));

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -2248,7 +2248,7 @@ static long post_connection_check(SSL *ssl, char *host)
 	int t_idx = -1;
 
 	if (!(cert = SSL_get_peer_certificate(ssl)) || !host)
-		goto err_occured;
+		goto err_occurred;
 
 	while (NULL != (t_alt_names = (STACK_OF(GENERAL_NAME)*)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, &t_idx)))
 	{
@@ -2269,13 +2269,13 @@ static long post_connection_check(SSL *ssl, char *host)
 	{
 		data[255] = 0;
 		if (!ssl_match_identity(data, host))
-			goto err_occured;
+			goto err_occurred;
 	}
 
 	X509_free(cert);
 	return SSL_get_verify_result(ssl);
 
-err_occured:
+err_occurred:
 	if (cert)
 		X509_free(cert);
 

--- a/engine/src/osxprinter.cpp
+++ b/engine/src/osxprinter.cpp
@@ -1033,7 +1033,7 @@ MCPrinterDialogResult MCMacOSXPrinter::DoDialog(bool p_window_modal, Window p_ow
         
         if (t_result == kMCPlatformPrintDialogResultError)
         {
-            PDEBUG(stderr, "DoDialog: Error occured\n");
+            PDEBUG(stderr, "DoDialog: Error occurred\n");
             t_err = PRINTER_DIALOG_RESULT_ERROR;
         }
         else if (t_result == kMCPlatformPrintDialogResultSuccess)

--- a/engine/src/osxtheme.mm
+++ b/engine/src/osxtheme.mm
@@ -568,7 +568,7 @@ static Widget_Part HitTestScrollControls(const MCWidgetInfo &winfo, int2 mx,int2
 	fillTrackDrawInfo(winfo,ttdi,drect);
 	Boolean inScrollbarArrow = False;
 	ControlPartCode partCode;
-	// scrollbar needs to check first if mouse-down occured in arrows
+	// scrollbar needs to check first if mouse-down occurred in arrows
 	if (ttdi.kind == kThemeScrollBar || ttdi.kind == kThemeSmallScrollBar)
 	{
 		// MW-2008-11-02: [[ Bug ]] If this scrollbar is rendered as a little arrows control, then

--- a/engine/src/printer.h
+++ b/engine/src/printer.h
@@ -57,7 +57,7 @@ class MCPrinterDevice
 public:
 	virtual ~MCPrinterDevice(void) {};
 
-	// Return a descriptive string of the last printer error that occured. This
+	// Return a descriptive string of the last printer error that occurred. This
 	// call should return NULL if ERROR has not been returned by any method of
 	// the object.
 	//
@@ -68,7 +68,7 @@ public:
 
 	// Cancel the current document.
 	//
-	// If an error has occured with printing, ERROR should be returned, else
+	// If an error has occurred with printing, ERROR should be returned, else
 	// CANCEL should be returned.
 	//
 	virtual MCPrinterResult Cancel(void) = 0;
@@ -77,7 +77,7 @@ public:
 	//
 	// If this call succeeds, SUCCESS should be returned.
 	// If the job has been cancelled, CANCEL should be returned.
-	// If a printer error has occured, ERROR should be returned.
+	// If a printer error has occurred, ERROR should be returned.
 	//
 	virtual MCPrinterResult Show(void) = 0;
 
@@ -89,7 +89,7 @@ public:
 	// If the call succeeds, SUCCESS should be returned and r_context will be
 	// a valid graphics context.
 	// If the job has been cancelld, CANCEL should be returned.
-	// If a printer error has occured, ERROR should be returned.
+	// If a printer error has occurred, ERROR should be returned.
 	//
 	virtual MCPrinterResult Begin(const MCPrinterRectangle& p_src_rect, const MCPrinterRectangle& p_dst_rect, MCContext*& r_context) = 0;
 
@@ -98,7 +98,7 @@ public:
 	//
 	// If the call succeeds, SUCCESS should be returned.
 	// If the job has been cancelled, CANCEL should be returned.
-	// If a printer error has occured, ERROR should be returned.
+	// If a printer error has occurred, ERROR should be returned.
 	//
 	virtual MCPrinterResult End(MCContext *p_context) = 0;
 
@@ -108,7 +108,7 @@ public:
 	//
 	// If the call succeeds, SUCCESS should be returned.
 	// If the job has been cancelled, CANCEL should be returned.
-	// If a printer error has occured, ERROR should be returned.
+	// If a printer error has occurred, ERROR should be returned.
 	//
 	virtual MCPrinterResult Anchor(const char *name, double x, double y) = 0;
 
@@ -118,7 +118,7 @@ public:
 	//
 	// If the call succeeds, SUCCESS should be returned.
 	// If the job has been cancelled, CANCEL should be returned.
-	// If a printer error has occured, ERROR should be returned.
+	// If a printer error has occurred, ERROR should be returned.
 	virtual MCPrinterResult Link(const char *destination, const MCPrinterRectangle& area, MCPrinterLinkType type) = 0;
 
 	// Make a bookmark with the given title, nested at the given depth.
@@ -127,7 +127,7 @@ public:
 	//
 	// If the call succeeds, SUCCESS should be returned.
 	// If the job has been cancelled, CANCEL should be returned.
-	// If a printer error has occured, ERROR should be returned.
+	// If a printer error has occurred, ERROR should be returned.
 	//
 	virtual MCPrinterResult Bookmark(const char *title, double x, double y, int depth, bool closed) = 0;
 };
@@ -362,7 +362,7 @@ protected:
 	//
 	// The return value should reflect the starting state of the device object
 	// note that a valid device object must be returned regardless of whether
-	// a printer error, or cancellation occured.
+	// a printer error, or cancellation occurred.
 	//
 	virtual MCPrinterResult DoBeginPrint(MCStringRef p_document, MCPrinterDevice*& r_device) = 0;
 

--- a/engine/src/scrolbar.cpp
+++ b/engine/src/scrolbar.cpp
@@ -342,7 +342,7 @@ Boolean MCScrollbar::mdown(uint2 which)
 			{
 				getwidgetthemeinfo(winfo);
 				Widget_Part wpart = MCcurtheme->hittest(winfo,mx,my,rect);
-				// scrollbar needs to check first if mouse-down occured in arrows
+				// scrollbar needs to check first if mouse-down occurred in arrows
 				switch (wpart)
 				{
 				case WTHEME_PART_ARROW_DEC:

--- a/engine/src/tilecache.cpp
+++ b/engine/src/tilecache.cpp
@@ -129,7 +129,7 @@ struct MCTileCacheFrontier
 
 struct MCTileCache
 {
-	// If false, an error has occured while processing an operation on the
+	// If false, an error has occurred while processing an operation on the
 	// tilecache. It must be flushed before it can be used again.
 	bool valid : 1;
 	

--- a/engine/src/tilecachegl.cpp
+++ b/engine/src/tilecachegl.cpp
@@ -302,7 +302,7 @@ bool MCTileCacheOpenGLCompositor_EndTiling(void *p_context)
 	// Flush any empty textures.
 	MCTileCacheOpenGLCompositorFlushSuperTiles(self, false);
 	
-	// If an OpenGL error occured, then return false.
+	// If an OpenGL error occurred, then return false.
 	GLenum t_error;
 	t_error = glGetError();
 	if (t_error != GL_NO_ERROR)

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -364,7 +364,7 @@ public:
 	
 	uint4 getdisplays(MCDisplay const *& p_displays, bool effective);
 	
-	// IM-2014-01-28: [[ HiDPI ]] Update the currently held display info, returning whether or not an changes have occured
+	// IM-2014-01-28: [[ HiDPI ]] Update the currently held display info, returning whether or not an changes have occurred
 	void updatedisplayinfo(bool &r_changed);
 
 	// IM-2014-01-24: [[ HiDPI ]] Clear the currently held display information. Should be called
@@ -499,7 +499,7 @@ public:
 	// as soon as something notable happens. If an abort/quit occurs while the
 	// wait is occuring, True will be returned.
 	virtual Boolean wait(real8 duration, Boolean dispatch, Boolean anyevent);
-	// Notify any current wait loop that something has occured that it might
+	// Notify any current wait loop that something has occurred that it might
 	// not be aware of. This will cause any OS loop to be exited and events
 	// and such to be processed. If the wait was called with 'anyevent' True
 	// then it will cause termination of the wait.
@@ -561,7 +561,7 @@ public:
 	// with the data.
 	//
 	// The method returns the actual result of the drag-drop operation - DRAG_ACTION_NONE meaning
-	// that no drop occured.
+	// that no drop occurred.
 	//
 	virtual MCDragAction dodragdrop(Window w, MCDragActionSet p_allowed_actions, MCImage *p_image, const MCPoint *p_image_offset);
 	

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -724,7 +724,7 @@ end syntax
 /**
 Summary:        Determines the number of successive clicks within the click distance.
 
-Returns:        The number of clicks which have occured since the initial click within the standard 'click distance' from the original point.
+Returns:        The number of clicks which have occurred since the initial click within the standard 'click distance' from the original point.
 
 Example:
     variable tClickCount as integer

--- a/ide-support/revdeploylibraryios.livecodescript
+++ b/ide-support/revdeploylibraryios.livecodescript
@@ -103,7 +103,7 @@ end deployListTargets
 
 -- Invoked when the Deploy/Simulate button is clicked on the menubar
 command deployDo pTargetStack, pSimulator, pAppBundle
-   -- The error that occured (if any)
+   -- The error that occurred (if any)
    local tError, tRunningTest
    put empty into tError
    

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -326,7 +326,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       if tManifest is empty then
          put url ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "Manifest.xml")) into tManifest
       end if
-      // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occured
+      // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occurred
       if the result is not empty then
          throw "Cannot find the template Manifest"
       end if
@@ -668,7 +668,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       
       -- Engine to use
       put mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "Standalone") into tDeploy["engine"]
-      // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occured
+      // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occurred
       if there is no file tDeploy["engine"] then
          throw "Could not find standalone engine"
       end if
@@ -780,7 +780,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       if pSettings["android,include revsecurity"] then
          put url ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "revsecurity")) into url ("binfile:" & tArmLibsBuildFolder & slash & "librevsecurity.so")
          
-         // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occured
+         // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occurred
          if the result is not empty then
             throw "Could not find revsecurity library"
          end if
@@ -794,7 +794,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
             next repeat
          end if
          put url ("binfile:" & mapFilePath(revMobileRuntimeFolder(pTarget) & slash & tEntry)) into url ("binfile:" & tArmLibsBuildFolder & slash & "lib" & tEntry & ".so")
-         // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occured
+         // SN-2015-01-22: [[ Bug 13213 ]] Throw an error in case an error occurred
          if the result is not empty then
             throw "Could not find " & tEntry && "library"
          end if

--- a/lcidlc/include/LiveCode.h
+++ b/lcidlc/include/LiveCode.h
@@ -46,7 +46,7 @@ extern "C" {
 
 typedef enum LCError
 {
-	// No errors occured, the operation succeeded.
+	// No errors occurred, the operation succeeded.
 	kLCErrorNone = 0,
 	
 	// Memory ran out while performing the operation.
@@ -504,7 +504,7 @@ typedef struct __LCObject *LCObjectRef;
 // Errors:
 //   OutOfMemory - memory ran out while attempting to perform the operation
 //   NoObjectId - the 'chunk' parameter was nil
-//   MalformedObjectChunk - a parse error occured processing 'chunk'
+//   MalformedObjectChunk - a parse error occurred processing 'chunk'
 //   CouldNotResolveObject - the object referred to by 'chunk' could not be found
 // Context Safety:
 //   Must be called from dispatch context.

--- a/libexternalv1/include/external.h
+++ b/libexternalv1/include/external.h
@@ -82,7 +82,7 @@ typedef struct __MCObject *MCObjectRef;
 // generated while using the externals interface.
 typedef enum MCError
 {
-	// No errors occured, the operation succeeded.
+	// No errors occurred, the operation succeeded.
 	kMCErrorNone = 0,
 
 	// Memory ran out while performing the operation.
@@ -297,10 +297,10 @@ typedef enum MCInvokeStatus
 	// The script was successfully executed.
 	kMCInvokeStatusSuccess = 0,
 	
-	// A parse error occured while compiling the script
+	// A parse error occurred while compiling the script
 	kMCInvokeStatusParseError = 1,
 	
-	// An execution error occured while running the script
+	// An execution error occurred while running the script
 	kMCInvokeStatusExecutionError = 2
 };
 	

--- a/toolchain/gentle/gentle/main.c
+++ b/toolchain/gentle/gentle/main.c
@@ -34,7 +34,7 @@ main (argc, argv)
    
    ROOT ();
    
-   /* --PATCH-- */ exit(ErrorOccured);
+   /* --PATCH-- */ exit(ErrorOccurred);
 }
 
 /*----------------------------------------------------------------------------*/

--- a/toolchain/gentle/gentle/main.c
+++ b/toolchain/gentle/gentle/main.c
@@ -18,7 +18,7 @@
 #  define sep '\\'
 #endif
 
-int ErrorOccured = 0;
+int ErrorOccurred = 0;
 
 static scanargs();
 

--- a/toolchain/gentle/gentle/msg.c
+++ b/toolchain/gentle/gentle/msg.c
@@ -39,7 +39,7 @@ SetOption_ALERT()
 
 /*----------------------------------------------------------------------------*/
 
-/* --PATCH-- */ extern int ErrorOccured;
+/* --PATCH-- */ extern int ErrorOccurred;
 
 MESSAGE(msg, pos)
    char *msg;

--- a/toolchain/gentle/gentle/msg.c
+++ b/toolchain/gentle/gentle/msg.c
@@ -80,7 +80,7 @@ MESSAGE(msg, pos)
    printpos(pos);
    printf("%s\n", msg);
     /* --PATCH-- */ // exit(1);
-    /* --PATCH-- */ ErrorOccured = 1;
+    /* --PATCH-- */ ErrorOccurred = 1;
     
 #endif
 


### PR DESCRIPTION
Correct the spelling error of "occured" to "occurred".  Most of the corrections were in comments.  A few were in strings.  6 changes were to actual code, but were self contained within each function (engine\src\mac-menu.mm and engine\src\opensslsocket.cpp).

7 changes to stack script of engine\src\Environment.rev - all were comments or strings.

2 changes in toolchain/gentle/gentle (int ErrorOccured / extern int ErrorOccured)

Did not fix error in revcapture.h since ErrorOccured(void) is part of a struct (MCCaptureSessionDelegate) and could not be certain it wasn't referenced somewhere else.

