### PR TITLE
[Bug 19080] Do not show linking warnings when building iOS standalones

### DIFF
--- a/docs/notes/bugfix-19080.md
+++ b/docs/notes/bugfix-19080.md
@@ -1,0 +1,1 @@
+# Do not show linking warnings when building iOS standalones

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -425,7 +425,7 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
             -- MM-2013-09-23: [[ iOS7 Support ]] Use g++ instead of llvm-g++-4.2. XCode 5.0 uses llvm 5.0.
             -- g++ appears to be sym-linked to the appropriate compiler in all SDKS.
             -- SN-2015-02-19: [[ Bug 14625 ]] The minimum iOS version is bound to the architecture
-            get shell("g++ -arch " & tArch && "-miphoneos-version-min=" & tiPhoneMinVersion[tArch] && quote & "@" & tLinkOptionsFile & quote)
+            get shell("g++ -arch " & tArch && "-miphoneos-version-min=" & tiPhoneMinVersion[tArch] && " -w " & quote & "@" & tLinkOptionsFile & quote)
             
             put tArchSpecificEngineFile & space after tArchSpecificEngineList
             delete file tLinkOptionsFile


### PR DESCRIPTION
The included externals (i.e. `revZip`) are always built with the latest iOS SDK. However, when the iOS standalone has a minimum iOS version (as specified in the standalone settings) older than the latest iOS, you should get a **warning**. The warning must have the following form (this is the output from the shell command that does the linking):

```
ld: warning: object file (/path/to/object/fileA) was built for newer iOS version (X) than being linked (Y)
ld: warning: object file (/path/to/object/fileB) was built for newer iOS version (X) than being linked (Y)
```

The standalone builder already copes with that kind of warnings like this:
```
repeat for each line tLine in pLinkingOutput
      // Discard Xcode 7 new warnings like:
      // ld: warning: object file (<path_to_exe) was built for newer iOS version (9.0) than being linked (7.0)
      // ld: warning: ignoring linker optimzation..
  if not (tLine begins with "ld: warning:") then
     return false
  end if
end repeat
```

HOWEVER, under unknown circumstances, the output from shell command can be like that:
```
ld: warning: ld: warning:object file (/path/to/object/fileA) was built for newer iOS version (X) than being linked (Y)
object file (/path/to/object/fileB) was built for newer iOS version (X) than being linked (Y)
```
So the existing check for this kind of warnings can fail.

This patch adds the `"-w"` flag (—> ignore warnings) to the shell command that does the linking.