### PR TITLE
[Bug 20144] Corrected hiliteChanged dictionary entry for the switch button extension.

### DIFF
--- a/docs/notes/bugfix-20144.md
+++ b/docs/notes/bugfix-20144.md
@@ -1,0 +1,1 @@
+# Corrected hiliteChanged dictionary entry for the switch button extension.

--- a/extensions/widgets/switchbutton/switchbutton.lcb
+++ b/extensions/widgets/switchbutton/switchbutton.lcb
@@ -26,7 +26,7 @@ Summary: Sent when the switch is changed to either the on or off position
 Example:
 on hiliteChanged
 	set the visible of group 1 to the highlight of me
-end switchChanged
+end hiliteChanged
 
 Description:
 Handle the hiliteChanged message in the widget's object script to respond to


### PR DESCRIPTION
Fixed dictionary error for hiliteChanged for the switch button widget extension.