### PR TITLE
[[ Bug 19973 ]] Allow binding to interface callbacks with non-void return

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -595,19 +595,23 @@ The foreign handler binding to such a function takes a value that should
 either be a `Handler` or an `Array` - if it is a `Handler`, the specified 
 listener should only have one available callback. If the listener has 
 multiple callbacks, an array can be used to assign handlers to each. Each 
-key in the array must match the name of a callback in the listener.
+key in the array must match the name of a callback in the listener. The 
+specified handlers must match the callback's parameters and return type, 
+using JObject where primitive type parameters are used.
+
 Overloaded methods in the interface are not currently supported.
 
 For example:
 
-	handler type ClickCallback(in pView as JObject)
+	handler type ClickCallback(in pView as JObject) returns nothing
 
 	foreign handler _JNI_OnClickListener(in pHandler as ClickCallback) returns JObject binds to "java:android.view.View$OnClickListener>interface()"
 
 	foreign handler _JNI_SetOnClickListener(in pButton as JObject, in pListener as JObject) returns nothing binds to "java:android.view.View>setOnClickListener(Landroid/view/View$OnClickListener;)V"	
 	
-	public handler ButtonClicked(in pView as JObject)
-		-- do something on button click
+	public handler ButtonClicked(in pView as JObject) returns nothing
+		post "buttonClicked"
+		MCEngineRunloopBreakWait()
 	end handler
 	
 	public handler SetOnClickListenerCallback(in pButton as JObject)
@@ -620,14 +624,15 @@ For example:
 	
 or
 
-	handler type MouseEventCallback(in pMouseEvent as JObject)
+	handler type MouseEventCallback(in pMouseEvent as JObject) returns nothing
 
 	foreign handler _JNI_MouseListener(in pCallbacks as Array) returns JObject binds to "java:java.awt.event.MouseListener>interface()"
 
 	foreign handler _JNI_SetMouseListener(in pJButton as JObject, in pListener as JObject) returns nothing binds to "java:java.awt.Component>addMouseListener(Ljava/awt/event/MouseListener;)V"	
 	
-	public handler MouseEntered(in pEvent as JObject)
-		-- do something on mouse entter
+	public handler MouseEntered(in pEvent as JObject) returns nothing
+		post "mouseEnter"
+		MCEngineRunloopBreakWait()
 	end handler
 	
 	public handler MouseExited(in pEvent as JObject)

--- a/docs/lcb/notes/19973.md
+++ b/docs/lcb/notes/19973.md
@@ -1,0 +1,8 @@
+# LiveCode Builder Language
+## Android Listener support
+The interface callback return value should now match that 
+of the invoked handler, i.e. if it returns void, the LCB
+handler should return nothing, otherwise it should return
+JObject.
+
+# [19973] Allow bind to interface callbacks with non-void return

--- a/engine/src/java/com/runrev/android/LCBInvocationHandler.java
+++ b/engine/src/java/com/runrev/android/LCBInvocationHandler.java
@@ -42,9 +42,8 @@ public class LCBInvocationHandler extends Object implements InvocationHandler
 	
 	public Object invoke(Object proxy, Method method, Object[] args)
 	{
-		doNativeListenerCallback(m_handler_ptr, method.getName(), args);
-		return proxy;
+		return doNativeListenerCallback(m_handler_ptr, method.getName(), args);
 	}
 	
-	public static native void doNativeListenerCallback(long handler, String method_name, Object[] args);
+	public static native Object doNativeListenerCallback(long handler, String method_name, Object[] args);
 }

--- a/engine/src/mblandroidlcb.cpp
+++ b/engine/src/mblandroidlcb.cpp
@@ -33,7 +33,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern void MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_name, jobjectArray p_args);
+extern jobject MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_name, jobjectArray p_args);
 
 #ifdef TARGET_SUBPLATFORM_ANDROID
 struct remote_call_t
@@ -41,19 +41,23 @@ struct remote_call_t
     jlong p_handler;
     jstring p_method_name;
     jobjectArray p_args;
+    jobject *t_return;
 };
 
 static void remote_call_func(void *p_context)
 {
     auto ctxt = static_cast<remote_call_t *>(p_context);
-    MCJavaPrivateDoNativeListenerCallback(ctxt->p_handler, ctxt->p_method_name, ctxt->p_args);
+    *(ctxt->t_return) = MCJavaPrivateDoNativeListenerCallback(ctxt->p_handler,
+                                                              ctxt->p_method_name,
+                                                              ctxt->p_args);
 }
 #endif
 
-extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong handler, jstring p_method, jobjectArray p_args) __attribute__((visibility("default")));
+extern "C" JNIEXPORT jobject JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong handler, jstring p_method, jobjectArray p_args) __attribute__((visibility("default")));
 
-JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong p_handler, jstring p_method_name, jobjectArray p_args)
+JNIEXPORT jobject JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeListenerCallback(JNIEnv *env, jobject object, jlong p_handler, jstring p_method_name, jobjectArray p_args)
 {
+    jobject t_global_return = nullptr;
 #ifdef TARGET_SUBPLATFORM_ANDROID
     extern bool MCAndroidIsOnEngineThread(void);
     if (!MCAndroidIsOnEngineThread())
@@ -64,7 +68,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeList
         p_method_name = static_cast<jstring>(env->NewGlobalRef(p_method_name));
         typedef void (*co_yield_callback_t)(void *);
         extern void co_yield_to_engine_and_call(co_yield_callback_t callback, void *context);
-        remote_call_t t_context = {p_handler, p_method_name, p_args};
+        remote_call_t t_context = {p_handler, p_method_name, p_args, &t_global_return};
         co_yield_to_engine_and_call(remote_call_func, &t_context);
         env->DeleteGlobalRef(p_args);
         env->DeleteGlobalRef(p_method_name);
@@ -72,7 +76,7 @@ JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeList
     else
     {
 #endif
-        MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
+        t_global_return = MCJavaPrivateDoNativeListenerCallback(p_handler, p_method_name, p_args);
 #ifdef TARGET_SUBPLATFORM_ANDROID
     }
 #endif
@@ -89,6 +93,17 @@ JNIEXPORT void JNICALL Java_com_runrev_android_LCBInvocationHandler_doNativeList
         MCsystem->Debug(*t_string);
     }
     
+    // Turn global ref'd return into a local ref for this env, so it
+    // can be garbage-collected
+    
+    jobject t_return = nullptr;
+    if (t_global_return != nullptr)
+    {
+        t_return = env->NewLocalRef(t_global_return);
+        env->DeleteGlobalRef(t_global_return);
+    }
+    
+    return t_return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/extensions/widgets/androidbutton/androidbutton.lcb
+++ b/extensions/widgets/androidbutton/androidbutton.lcb
@@ -98,7 +98,7 @@ foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject binds 
 foreign handler _JNI_AddButtonView(in pParentView as JObject, in pChildView as JObject) returns nothing binds to "java:android.view.ViewGroup>addView(Landroid/view/View;)V?ui"
 
 // Handlers for adding click listener
-handler type ClickCallback(in pView as JObject)
+handler type ClickCallback(in pView as JObject) returns nothing
 foreign handler _JNI_OnClickListener(in pHandler as ClickCallback) returns JObject binds to "java:android.view.View$OnClickListener>interface()"
 foreign handler _JNI_SetOnClickListener(in pButton as JObject, in pListener as JObject) returns nothing binds to "java:android.view.View>setOnClickListener(Landroid/view/View$OnClickListener;)V?ui"
 
@@ -196,7 +196,7 @@ public handler OnClose()
     put false into mOpen
 end handler
 
-public handler ButtonClicked(in pView as JObject)
+public handler ButtonClicked(in pView as JObject) returns nothing
 	post "mouseUp"
 	
 	// Wake the engine to deal with the posted signal

--- a/extensions/widgets/androidfield/androidfield.lcb
+++ b/extensions/widgets/androidfield/androidfield.lcb
@@ -151,6 +151,7 @@ private variable mDataDetectorTypes as String
 private variable mMultiline as Boolean
 private variable mEditable as Boolean
 private variable mScrollingEnabled as Boolean
+private variable mPassReturnKey as Boolean
 
 // Properties
 /**
@@ -472,6 +473,33 @@ field.
 property scrollingEnabled get GetScrollingEnabled set SetScrollingEnabled
 metadata scrollingEnabled.label is "Scrolling enabled"
 
+/**
+Syntax:
+set the passReturnKey of <widget> to {true|false}
+get the passReturnKey of <widget>
+
+Summary: Whether the return key adds a new line to the field
+
+Example:
+command createField
+   create widget as "com.livecode.widget.native.android.field"
+   set the passReturnKey of it to false
+end createField
+
+-- In the widget script
+on returnKey
+   answer "You entered" && the text of the target
+end returnKey
+
+Description:
+Use the <passReturnKey> property to control whether the
+native keyboard return key adds a new line to the field or
+not.
+*/
+property passReturnKey get mPassReturnKey set mPassReturnKey
+metadata passReturnKey.label is "Return key adds new line"
+metadata passReturnKey.default is "true"
+
 // Non-persistent
 /**
 Syntax:
@@ -527,6 +555,7 @@ public handler OnSave(out rProperties as Array)
    put mMultiline into rProperties["Multiline"]
    put mEditable into rProperties["Editable"]
    put mScrollingEnabled into rProperties["ScrollingEnabled"]
+   put mPassReturnKey into rProperties["PassReturnKey"]
 end handler
 
 // Set all persistent properties in OnLoad
@@ -545,6 +574,7 @@ public handler OnLoad(in pProperties as Array)
    put pProperties["Multiline"] into mMultiline
    put pProperties["Editable"] into mEditable
    put pProperties["ScrollingEnabled"] into mScrollingEnabled
+   put pProperties["PassReturnKey"] into mPassReturnKey
 end handler
 
 // Set up all the default values for properties in constants
@@ -575,6 +605,7 @@ public handler OnCreate()
    put true into mMultiline
    put true into mEditable
    put true into mScrollingEnabled
+   put true into mPassReturnKey
 end handler
 
 private handler InitView()
@@ -811,11 +842,11 @@ __safe foreign handler _JNI_TextWatcher_TextChangedListener(in pCallbacks as Arr
 __safe foreign handler _JNI_TextView_addTextChangedListener(in pObj as JObject, in pParam_watcher as JObject) returns nothing \
 	binds to "java:android.widget.TextView>addTextChangedListener(Landroid/text/TextWatcher;)V?ui"
 
-handler type EditorActionCallback(in pView as JObject, in pActionId as JObject, in pKeyEvent as JObject)
+handler type EditorActionCallback(in pView as JObject, in pActionId as JObject, in pKeyEvent as JObject) returns JObject
 __safe foreign handler _JNI_View_OnEditorActionListener(in pHandler as EditorActionCallback) returns JObject \
-   binds to "java:android.view.View$OnEditorActionListener>interface()"
+   binds to "java:android.widget.TextView$OnEditorActionListener>interface()"
 __safe foreign handler _JNI_TextView_setOnEditorActionListener(in pObj as JObject, in pParam_listener as JObject) returns nothing \
-	binds to "java:android.widget.TextView>setOnEditorActionListener(Landroid/view/View$OnEditorActionListener;)V?ui"
+	binds to "java:android.widget.TextView>setOnEditorActionListener(Landroid/widget/TextView$OnEditorActionListener;)V?ui"
 
 __safe foreign handler _JNI_TextView_append(in pObj as JObject, in pParam_text as JString) returns nothing \
 	binds to "java:android.widget.TextView>append(Ljava/lang/CharSequence;)V?ui"
@@ -1001,7 +1032,7 @@ end handler
 __safe foreign handler _JNI_BooleanValue(in pBoolean as JObject) returns JBoolean \
    binds to "java:java.lang.Boolean>booleanValue()Z"
 private variable mOldText as optional String
-handler OnFocusChange(in pView as JObject, in pHasFocus as JObject)
+handler OnFocusChange(in pView as JObject, in pHasFocus as JObject) returns nothing
    variable tHasFocus as Boolean
    put _JNI_BooleanValue(pHasFocus) into tHasFocus
 
@@ -1024,12 +1055,22 @@ handler OnFocusChange(in pView as JObject, in pHasFocus as JObject)
    MCEngineRunloopBreakWait()
 end handler
 
-handler OnEditorAction(in pView as JObject, in pActionId as JObject, in pKeyEvent as JObject)
+__safe foreign handler _JNI_Boolean_False() returns JObject \
+   binds to "java:java.lang.Boolean>get.FALSE()Ljava/lang/Boolean;!static"
+__safe foreign handler _JNI_Boolean_True() returns JObject \
+   binds to "java:java.lang.Boolean>get.TRUE()Ljava/lang/Boolean;!static"
+handler OnEditorAction(in pView as JObject, in pActionId as JObject, in pKeyEvent as JObject) returns JObject
    post "returnKey"
    MCEngineRunloopBreakWait()
+   // Return value determines whether the return key event is eaten
+   if mPassReturnKey then
+      return _JNI_Boolean_False()
+   else
+      return _JNI_Boolean_True()
+   end if
 end handler
 
-handler OnTextChanged(in pText as JObject, in pStart as JObject, in pLengthBefore as JObject, in pLengthAfter as JObject)
+handler OnTextChanged(in pText as JObject, in pStart as JObject, in pLengthBefore as JObject, in pLengthAfter as JObject) returns nothing
    post "textChanged"
    MCEngineRunloopBreakWait()
 end handler
@@ -1046,15 +1087,11 @@ handler SetListeners()
       into tTextChangedListener
    _JNI_TextView_addTextChangedListener(mNativeObj, tTextChangedListener)
 
-   // At the moment we can't support the returnKey message
-   // as the listener returns a Boolean values - see bug 19973
-/*
    // Add a listener for the returnKey action
    variable tEditorActionListener as JObject
    put _JNI_View_OnEditorActionListener(OnEditorAction) \
       into tEditorActionListener
    _JNI_TextView_setOnEditorActionListener(mNativeObj, tEditorActionListener)
-*/
 end handler
 
 // Set / get props

--- a/extensions/widgets/androidfield/notes/feature-pass_return_key.md
+++ b/extensions/widgets/androidfield/notes/feature-pass_return_key.md
@@ -1,0 +1,5 @@
+# Android native field widget
+## passReturnKey property
+* A `passReturnKey` property has been added to allow the user to control
+  whether the return key is passed to the field widget to add a new line
+  or not.


### PR DESCRIPTION
- Allow interface callbacks to return a value
- Fix some incorrect bindings in android field widget
- Reinstate returnKey message in android field widget
- Add `passReturnKey` property to android field widget to control passing of return key event
- Ensure LCB handlers bound to void interface callback methods return nothing