### PR TITLE
[[ Bug 17639 ]] Fix vertical placement of caret on wrapped lines

### DIFF
--- a/docs/notes/bugfix-17639.md
+++ b/docs/notes/bugfix-17639.md
@@ -1,0 +1,2 @@
+# Fix vertical placement of caret on long wrapped lines
+

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -692,15 +692,15 @@ void MCField::replacecursor(Boolean force, Boolean goal)
 		indextoparagraph(paragraphs,compsi,compei);
 		// MW-2012-01-25: [[ ParaStyles ]] Request the cursor-rect of the line
 		//   not including any space above/below.
-		drectp = focusedparagraph->getsplitcursorrect(compsi, fixedheight, false, true);
-        drects = focusedparagraph->getsplitcursorrect(compsi, fixedheight, false, false);
+		drectp = focusedparagraph->getcursorrect(compsi, fixedheight, false, kMCParagraphCursorTypePrimary);
+        drects = focusedparagraph->getcursorrect(compsi, fixedheight, false, kMCParagraphCursorTypeSecondary);
 	}
 	else
 	{
 		// MW-2012-01-25: [[ ParaStyles ]] Request the cursor-rect of the line
 		//   not including any space above/below.
-		drectp = focusedparagraph->getsplitcursorrect(-1, fixedheight, false, true);
-        drects = focusedparagraph->getsplitcursorrect(-1, fixedheight, false, false);
+		drectp = focusedparagraph->getcursorrect(-1, fixedheight, false, kMCParagraphCursorTypePrimary);
+        drects = focusedparagraph->getcursorrect(-1, fixedheight, false, kMCParagraphCursorTypeSecondary);
 	}
 	positioncursor(force, goal, drects, focusedy, false);
     positioncursor(force, goal, drectp, focusedy, true);

--- a/engine/src/paragraf.cpp
+++ b/engine/src/paragraf.cpp
@@ -3177,7 +3177,7 @@ void MCParagraph::marklines(findex_t si, findex_t ei)
 
 // MW-2012-01-25: [[ ParaStyles ]] The 'include_space' parameter, if true, means that
 //   the returned rect will take into account space before and after.
-MCRectangle MCParagraph::getcursorrect(findex_t fi, uint2 fixedheight, bool p_include_space)
+MCRectangle MCParagraph::getcursorrect(findex_t fi, uint2 fixedheight, bool p_include_space, MCParagraphCursorType p_type)
 {
 	if (fi < 0)
 		fi = focusedindex;
@@ -3194,7 +3194,7 @@ MCRectangle MCParagraph::getcursorrect(findex_t fi, uint2 fixedheight, bool p_in
 
 	// MW-2012-01-08: [[ ParaStyles ]] Top of text starts after spacing above.
 	MCRectangle drect;
-	drect.y = 1 + t_space_above;
+	drect.y = int2(1 + t_space_above);
 
 	MCLine *lptr;
 	findex_t i, l;
@@ -3213,80 +3213,19 @@ MCRectangle MCParagraph::getcursorrect(findex_t fi, uint2 fixedheight, bool p_in
 		t_first_line = false;
 	};
 	if (fixedheight == 0)
-		drect.height = ceilf(lptr->GetHeight()) - 2;
+		drect.height = uint2(ceilf(lptr->GetHeight()) - 2);
 	else
 		drect.height = fixedheight - 2;
-	drect.x = lptr->GetCursorXPrimary(fi, moving_forward);
-	
-	// MW-2012-01-08: [[ ParaStyles ]] If we want the 'full height' of the
-	//   cursor (inc space), adjust appropriately depending on which line we are
-	//   on.
-	if (p_include_space)
-	{
-		if (t_first_line)
-		{
-			drect.y -= t_space_above;
-			drect.height += t_space_above;
-		}
-		if (lptr -> next() == lines)
-			drect.height += t_space_below;
+    if (p_type == kMCParagraphCursorTypeFull ||
+        p_type == kMCParagraphCursorTypePrimary)
+    {
+        drect.x = int2(lptr->GetCursorXPrimary(fi, moving_forward));
 	}
-    
-    // SN-2014-08-14: [[ Bug 13106 ]] Having a Vgrid discards the line offsets
-    if (!getvgrid())
-        drect.x += computelineoffset(lptr);
-
-	drect.width = cursorwidth;
-
-	return drect;
-}
-
-// MW-2012-01-25: [[ ParaStyles ]] The 'include_space' parameter, if true, means that
-//   the returned rect will take into account space before and after.
-MCRectangle MCParagraph::getsplitcursorrect(findex_t fi, uint2 fixedheight, bool p_include_space, bool primary)
-{
-	if (fi < 0)
-		fi = focusedindex;
-    
-	// MW-2005-08-31: If we get here even though we have no lines,
-	//   noflow to make up for it.
-	if (lines == NULL)
-		noflow();
-    
-	// MW-2012-01-08: [[ ParaStyles ]] Compute spacing before and after.
-	int32_t t_space_above, t_space_below;
-	t_space_above = computetopmargin();
-	t_space_below = computebottommargin();
-    
-	// MW-2012-01-08: [[ ParaStyles ]] Top of text starts after spacing above.
-	MCRectangle drect;
-	drect.y = t_space_above;
-    
-	MCLine *lptr;
-	findex_t i, l;
-	bool t_first_line;
-	lptr = lines;
-	lptr->GetRange(i, l);
-	t_first_line = true;
-	while (fi >= i + l && lptr->next() != lines)
-	{
-		if (fixedheight == 0)
-			drect.y += floorf(lptr->GetHeight());
-		else
-			drect.y += fixedheight;
-		lptr = lptr->next();
-		lptr->GetRange(i, l);
-		t_first_line = false;
-	};
-	if (fixedheight == 0)
-		drect.height = floorf(lptr->GetHeight()) - 2;
-	else
-		drect.height = fixedheight - 2;
-    if (primary)
-        drect.x = lptr->GetCursorXPrimary(fi, moving_forward);
     else
-        drect.x = lptr->GetCursorXSecondary(fi, moving_forward);
-	
+    {
+        drect.x = int2(lptr->GetCursorXSecondary(fi, moving_forward));
+    }
+    
 	// MW-2012-01-08: [[ ParaStyles ]] If we want the 'full height' of the
 	//   cursor (inc space), adjust appropriately depending on which line we are
 	//   on.
@@ -3304,20 +3243,20 @@ MCRectangle MCParagraph::getsplitcursorrect(findex_t fi, uint2 fixedheight, bool
     // SN-2014-08-14: [[ Bug 13106 ]] Having a Vgrid discards the line offsets
     if (!getvgrid())
         drect.x += computelineoffset(lptr);
-    
+
 	drect.width = cursorwidth;
-    
-    // Adjust the height
-    if (primary)
+
+    // Adjust the height - if primary or secondary cursor is requested.
+    if (p_type == kMCParagraphCursorTypePrimary)
     {
         drect.height /= 2;
     }
-    else
+    else if (p_type == kMCParagraphCursorTypeSecondary)
     {
         drect.y += drect.height/2;
         drect.height /= 2;
     }
-    
+
 	return drect;
 }
 

--- a/engine/src/paragraf.h
+++ b/engine/src/paragraf.h
@@ -133,6 +133,20 @@ struct MCParagraphAttrs
 
 class MCSegment;
 
+/* MCParagraphCursorType describes the type of cursor (caret) which can be
+ * requested when using 'getcursorrect'. */
+enum MCParagraphCursorType
+{
+    /* The full cursor rect, ignoring RTL split cursors. */
+    kMCParagraphCursorTypeFull,
+    
+    /* The primary part of an RTL cursor. */
+    kMCParagraphCursorTypePrimary,
+    
+    /* The secondary part of an RTL cursor. */
+    kMCParagraphCursorTypeSecondary,
+};
+
 // Don't change this until everything dealing with fields, paragraphs, etc
 // is capable of dealing with 32-bit offsets or things will break!
 #define PARAGRAPH_MAX_LEN	INT32_MAX
@@ -772,8 +786,7 @@ public:
 	//   MCField::fcenter
 	//   MCField::fmove
 	//   MCField::getcompositionrect
-	MCRectangle getcursorrect(findex_t fi, uint2 fixedheight, bool include_space);
-    MCRectangle getsplitcursorrect(findex_t fi, uint2 fixedheight, bool include_space, bool primary);
+	MCRectangle getcursorrect(findex_t fi, uint2 fixedheight, bool include_space, MCParagraphCursorType type = kMCParagraphCursorTypeFull);
 
 	// Compute the (x, y) location of the given index in the paragraph
 	// Called by:


### PR DESCRIPTION
This patch fixes the vertical 'drift' which previously occured
vertical when positioning the caret on soft-wrapped lines of a
paragraph.

The issue was caused by 'getsplitcursorrect' using floor, compared
to 'getcursorrect' using ceil - the two methods used essentially
the same code beyond that (hence why the error occurred in the first
place).

The getsplitcursorrect method has been removed, and the getcursorrect
method now has an extra parameter which specifies either full, primary
or secondary cursor. The cursor type parameter has a default of 'full'.