### PR TITLE
[[ Bug 17098 ]] Ensure there is always a segment for each tab

### DIFF
--- a/docs/notes/bugfix-17098.md
+++ b/docs/notes/bugfix-17098.md
@@ -1,1 +1,5 @@
+---
+version: 8.1.7-rc-1
+---
+
 # Ensure cursor moves to end of last tab in line.

--- a/engine/src/line.cpp
+++ b/engine/src/line.cpp
@@ -414,7 +414,7 @@ findex_t MCLine::GetCursorIndex(coord_t cx, Boolean chunk, bool moving_forward)
         do
         {
             bptr = bptr->next();
-            
+
             // SN-2014-08-14: [[ Bug 13106 ]] We want the outside left edge
             coord_t origin = bptr->getorigin() + sgptr->GetLeft();
 
@@ -562,7 +562,14 @@ void MCLine::SegmentLine()
             // There was previously a comment here saying that creating the
             // empty block was a good thing. I have no idea why I wrote that...
             // Removed that behaviour as it breaks some things.
-            if ((t_offset + 1) < bptr->GetOffset() + bptr->GetLength())
+            // MW-2017-08-07: [[ Bug 17098 ]]
+            // If the block has a trailing tab *and is the last block* we need
+            // to make sure there is an empty block, otherwise we don't get a
+            // segment for a trailing tab which means caret alignment / placement
+            // doesn't work. This strategy seems to fix 17098 and not reintroduce
+            // bug 13887.
+            if ((t_offset + 1) < bptr->GetOffset() + bptr->GetLength() ||
+                (bptr == lastblock && bptr->HasTrailingTab()))
             {
                 bptr->split(t_offset + 1);
                 if (bptr == lastblock)


### PR DESCRIPTION
This patch ensures that if the last block on a line has a trailing
tab, then an empty block is added at the end so that an empty
segment is created.

This fixes the placement of the caret for non-left aligned tabs
when the last tab is empty.

At some point in the past an empty block was always created for
an empty tab segment - however this caused bug 13887. Only creating
the empty block for the very last segment seems to not reintroduce
that bug.

NOTE: This bug has a higher risk of introducing regressions than others. The
problem was introduced previously due to fixing Bug 13106. As it only ever
creates a trailing empty block, I *think* it should be fine. However, we should
flag this fix in the release notes clearly, and ask people to be observant over
imageSource / attribute gets from fields, and navigation when there are tabs
present.