### PR TITLE
[[ Bug 19713 ]] Synthesize DIBV5 from PNG, GIF and JPEG on Win32

### DIFF
--- a/docs/notes/bugfix-19713.md
+++ b/docs/notes/bugfix-19713.md
@@ -1,0 +1,5 @@
+# Synthesize an MS Paint compatible clipboard format for images
+
+The engine will (once again) synthesize a DIBV5 format when an image is
+copied to the clipboard. This will be a 32-bit RGBA DIB. Windows then
+automatically synthesizes a 24-bit RGB DIB format.

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -17,6 +17,12 @@
 
 #include "w32-clipboard.h"
 
+#include "globdefs.h"
+#include "filedefs.h"
+#include "mcio.h"
+#include "imagebitmap.h"
+#include "image.h"
+
 #include <ObjIdl.h>
 #include <ShlObj.h>
 
@@ -885,6 +891,90 @@ bool MCWin32RawClipboardItem::AddRepresentation(MCStringRef p_type, MCDataRef p_
 				return false;
 		}
 	}
+
+    // If we are adding a PNG, JPG or GIF image, then make sure we add a DIB
+    // too. Windows automatically synthesizes DIB from DIBV5.
+    if (MCWin32RawClipboardCommon::CopyAtomForType(p_type) == MCWin32RawClipboardCommon::CopyAtomForType(MCSTR("PNG")) ||
+        MCWin32RawClipboardCommon::CopyAtomForType(p_type) == MCWin32RawClipboardCommon::CopyAtomForType(MCSTR("GIF")) ||
+        MCWin32RawClipboardCommon::CopyAtomForType(p_type) == MCWin32RawClipboardCommon::CopyAtomForType(MCSTR("JFIF")))
+    {
+        if (!HasRepresentation(MCSTR("CF_DIBV5")))
+        {
+            MCAutoDataRef t_data;
+
+	        IO_handle t_stream = 
+                    MCS_fakeopen((const char *)MCDataGetBytePtr(p_bytes), MCDataGetLength(p_bytes));
+            if (t_stream == nullptr)
+            {
+                return false;
+            }
+
+            MCBitmapFrame *t_frames = nullptr;
+            uindex_t t_frame_count = 0;
+            if (!MCImageDecode(t_stream, t_frames, t_frame_count))
+            {
+                MCS_close(t_stream);
+                return false;
+            }
+
+            MCS_close(t_stream);
+
+            MCImageBitmap *t_bitmap = t_frames[0].image;
+            size_t t_stride = t_bitmap->width * 4;
+
+            size_t t_dib_size = sizeof(BITMAPV5HEADER) + t_bitmap->height * t_stride;
+            void *t_dib = malloc(t_dib_size);
+            if (t_dib == nullptr)
+            {
+                MCImageFreeFrames(t_frames, t_frame_count);
+                return false;
+            }
+            
+	        BITMAPV5HEADER *t_header = (BITMAPV5HEADER*)t_dib;
+	        MCMemoryClear(t_header, sizeof(BITMAPV5HEADER));
+	        t_header -> bV5Size = sizeof(BITMAPV5HEADER);
+	        t_header -> bV5Width = t_bitmap->width;
+	        t_header -> bV5Height = t_bitmap->height;
+	        t_header -> bV5Planes = 1;
+	        t_header -> bV5BitCount = 32;
+	        t_header -> bV5Compression = BI_RGB;
+	        t_header -> bV5SizeImage = 0;
+	        t_header -> bV5XPelsPerMeter = 0;
+	        t_header -> bV5YPelsPerMeter = 0;
+	        t_header -> bV5ClrUsed = 0;
+	        t_header -> bV5ClrImportant = 0;
+	        t_header -> bV5AlphaMask = 0xFF000000;
+	        t_header -> bV5RedMask =   0x00FF0000;
+	        t_header -> bV5GreenMask = 0x0000FF00;
+	        t_header -> bV5BlueMask =  0x000000FF;
+	        t_header -> bV5CSType = LCS_WINDOWS_COLOR_SPACE;
+            
+	        uint8_t *t_dst_ptr = (uint8_t*)t_dib + sizeof(BITMAPV5HEADER);
+	        uint8_t *t_src_ptr = (uint8_t*)t_bitmap->data + (t_bitmap->height - 1) * t_bitmap->stride;
+
+	        for (uindex_t y = 0; y < t_bitmap->height; y++)
+	        {
+		        MCMemoryCopy(t_dst_ptr, t_src_ptr, t_stride);
+		        t_dst_ptr += t_stride;
+		        t_src_ptr -= t_bitmap->stride;
+	        }
+            
+            MCImageFreeFrames(t_frames, t_frame_count);
+
+            if (!MCDataCreateWithBytesAndRelease(static_cast<byte_t *>(t_dib), t_dib_size, &t_data))
+            {
+                free(t_dib);
+                return false;
+            }
+
+            if (!AddRepresentation(MCSTR("CF_DIBV5"), *t_data))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 bool MCWin32RawClipboardItem::AddRepresentation(MCStringRef p_type, render_callback_t p_render, void* p_context)


### PR DESCRIPTION
This patch adds the automatic synthesis of a DIBV5 image format
from PNG, GIF or JPEG when copying an image to the clipboard.

This returns copy/paste compatibility to MS Paint and other Windows
apps which don't understand the PNG, GIF or JPEG formats (on the
clipboard).

NOTE: This is not pretty - but it works. The clipboard needs some work to allow render-on-demand format generation; and a more graceful way to handle auto-synthesis.