### PR TITLE
[[ Bug 19599 ]] Fix incorrect use of x / y in Win32 printer

### DIFF
--- a/docs/notes/bugfix-19599.md
+++ b/docs/notes/bugfix-19599.md
@@ -1,0 +1,1 @@
+# Ensure correct source rect is used for 'print card from lt to rb'

--- a/engine/src/w32printer.cpp
+++ b/engine/src/w32printer.cpp
@@ -1289,8 +1289,8 @@ MCPrinterResult MCWindowsPrinterDevice::Begin(const MCPrinterRectangle& p_src_re
 	// Calculate the convex integer hull of the source rectangle.
 	//
 	MCRectangle t_src_rect_hull;
-	t_src_rect_hull . x = (int4)floor(p_src_rect . top);
-	t_src_rect_hull . y = (int4)floor(p_src_rect . left);
+	t_src_rect_hull . x = (int4)floor(p_src_rect . left);
+	t_src_rect_hull . y = (int4)floor(p_src_rect . top);
 	t_src_rect_hull . width = (int4)(ceil(p_src_rect . right) - floor(p_src_rect . left));
 	t_src_rect_hull . height = (int4)(ceil(p_src_rect . bottom) - floor(p_src_rect . top));
 


### PR DESCRIPTION
This patch corrects a x / y reversal error in the Begin method
of MCWindowsPrinterDevice resulting in the wrong source rect being
mapped to the destination rect.