### PR TITLE
[[ Bug 20013 ]] RevDB database types should be case insensitive.

### DIFF
--- a/docs/notes/bugfix-20013.md
+++ b/docs/notes/bugfix-20013.md
@@ -1,0 +1,1 @@
+# Database type passed to revOpenDatabase should be case insensitive

--- a/revdb/src/revdb.cpp
+++ b/revdb/src/revdb.cpp
@@ -291,26 +291,30 @@ DATABASEREC *LoadDatabaseDriver(const char *p_type)
 {
     DATABASEREC *t_database_rec = nullptr;
     
+    char t_type[32];
+    strcpy(t_type, p_type);
+    strlwr(t_type);
+
     if (revdbdriverpaths != nullptr)
     {
         t_database_rec = LoadDatabaseDriverInFolder(revdbdriverpaths, p_type);
     }
     else
     {
-        t_database_rec = LoadDatabaseDriverInFolder(".", p_type);
+        t_database_rec = LoadDatabaseDriverInFolder(".", t_type);
         
         
         if (t_database_rec == nullptr)
             t_database_rec = LoadDatabaseDriverInFolder("./Database Drivers",
-                                                        p_type);
+                                                        t_type);
 
         if (t_database_rec == nullptr)
             t_database_rec = LoadDatabaseDriverInFolder("./database_drivers",
-                                                        p_type);
+                                                        t_type);
 
         if (t_database_rec == nullptr)
             t_database_rec = LoadDatabaseDriverInFolder("./drivers",
-                                                        p_type);
+                                                        t_type);
     }
     
     if (t_database_rec != nullptr)

--- a/tests/lcs/core/database/case-senstive-db-type.livecodescript
+++ b/tests/lcs/core/database/case-senstive-db-type.livecodescript
@@ -1,0 +1,43 @@
+﻿script "case-senstive-db-type"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+local sDBDir
+
+on TestSetup
+   TestSkipIfNot "database", "sqlite"   
+   TestLoadExternal "revdb"
+   
+   put TestGetEngineRepositoryPath() & "/_tests/_build/case-sensitive-db-type" into sDBDir
+   create directory sDBDir
+end TestSetup
+
+on TestTeardown
+   delete directory sDBDir
+end TestTeardown
+
+on TestOpenDBWithMixedCaseForType
+   local tDBpath, tConnectionID
+   
+   put sDBDir & "/test1-sqlite.db" into tDBPath   
+   put revOpenDatabase("sqlite", tDBPath) into tConnectionID
+   TestAssert "open database of type sqlite" && tConnectionID, tConnectionID is an integer
+   
+   put sDBDir & "/test2-SQLite.db" into tDBPath   
+   put revOpenDatabase("SQLite", tDBPath) into tConnectionID
+   TestAssert "open database of type SQLite" && tConnectionID, tConnectionID is an integer   
+end TestOpenDBWithMixedCaseForType


### PR DESCRIPTION
The database type passed to revOpenDatabase is used by revdb to
find the appropriate driver. Make sure we convert the type to
lowercase in order to find the correct driver in case sensitive
systems (the driver file names are all lowercase).

This bug was introduced in https://github.com/livecode/livecode/commit/8d0e05a1723b8fb8e8734f05248c5f59bc476c9e