### PR TITLE
[[ Bug 16941 ]] Implement escaped literals

### DIFF
--- a/engine/src/keywords.cpp
+++ b/engine/src/keywords.cpp
@@ -216,7 +216,7 @@ Parse_stat MCLocaltoken::parse(MCScriptPoint &sp)
                 
                 // MW-2014-11-06: [[ Bug 3680 ]] If now, explicitvariables is on and we don't have a literal or
                 //   a number, its an error.
-                if (MCexplicitvariables && type != ST_LIT && type != ST_NUM)
+                if (MCexplicitvariables && type != ST_LIT && type != ST_ESCLIT && type != ST_NUM)
                 {
 					if (constant)
 						MCperror->add(PE_CONSTANT_BADINIT, sp);

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -46,7 +46,7 @@ uint8_t type_table[256] =
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //     ^X      ^Y      ^Z      ^[
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //     ^\      ^]      ^^      ^_
     ST_SPC,  ST_OP,   ST_LIT,  ST_COM,  //              !       "       #
-    ST_ID,   ST_OP,   ST_OP,   ST_ID,   //      $       %       &       '
+    ST_ID,   ST_OP,   ST_OP,   ST_ESCLIT,   //      $       %       &       '
     ST_LP,   ST_RP,   ST_OP,   ST_OP,   //      (       )       *       +
     ST_SEP,  ST_MIN,  ST_NUM,  ST_OP,   //      ,       -       .       /
     ST_NUM,  ST_NUM,  ST_NUM,  ST_NUM,  //      0       1       2       3
@@ -114,7 +114,7 @@ uint8_t unicode_type_table[256] =
     ST_ID,          ST_ID,          ST_ID,          ST_ID,          //     ^X      ^Y      ^Z      ^[
     ST_ID,          ST_ID,          ST_ID,          ST_ID,          //     ^\      ^]      ^^      ^_
     ST_SPC,         ST_OP,          ST_LIT,         ST_COM,         //              !       "       #
-    ST_ID,          ST_OP,          ST_OP,          ST_ID,          //      $       %       &       '
+    ST_ID,          ST_OP,          ST_OP,          ST_ESCLIT,          //      $       %       &       '
     ST_LP,          ST_RP,          ST_OP,          ST_OP,          //      (       )       *       +
     ST_SEP,         ST_MIN,         ST_NUM,         ST_OP,          //      ,       -       .       /
     ST_NUM,         ST_NUM,         ST_NUM,         ST_NUM,         //      0       1       2       3

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -2155,6 +2155,7 @@ enum {
     ST_ID,
     ST_ESC,
     ST_LIT,
+    ST_ESCLIT,
 	ST_LC,
     ST_RC,
     

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1792,6 +1792,9 @@ enum Parse_errors
 	
     // {PE-0582} send: can't send script in time
     PE_SEND_SCRIPTINTIME,
+    
+    // {PE-0583} Script: error parsing escape sequences in literal
+    PE_PARSE_BADLIT_ESCAPE,
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -379,6 +379,12 @@ MCNameRef MCScriptPoint::gettoken_nameref(void)
                                 continue;
                         }
                         break;
+                    case '\n':
+                        t_result_char = *t_format++;
+                        while (*t_format == ' ' || *t_format == '\t')
+                            t_format++;
+                        t_format--;
+                        break;
                     default:
                         if (isdigit(*t_format))
                         {
@@ -1341,7 +1347,8 @@ Parse_stat MCScriptPoint::next(Symbol_type &type)
                     advance(2);
                 else
                 {
-                    if (newtype == ST_EOL || newtype == ST_EOF)
+                    if (((type == ST_LIT || !t_escaping) && newtype == ST_EOL) ||
+                        newtype == ST_EOF)
                     {
                         MCperror->add(PE_PARSE_BADLIT, *this);
                         return PS_ERROR;

--- a/engine/src/visual.cpp
+++ b/engine/src/visual.cpp
@@ -89,7 +89,7 @@ Parse_stat MCVisualEffect::parse(MCScriptPoint &sp)
 		if (sp.next(type) != PS_NORMAL)
 			return PS_NORMAL;
 			
-		if (type != ST_ID && type != ST_LIT)
+		if (type != ST_ID && type != ST_LIT && type != ST_ESCLIT)
 		{
 			sp.backup();
 			// MW-2005-05-08: [[CoreImage]] We've reached the end of the command so return and


### PR DESCRIPTION
This patch implements escaped literals wrapped in single
quotes. For example:

    put 'foo\n"bar"'

Equals:

    foo
    "bar"

This patch has the side effect that `'` is no longer an
acceptable char in an identifier.

Just leaving this here for discussion at the moment. Paging @runrevmark 