### PR TITLE
[[ JavaFFI ]] Use env var to set classpath of jvm instance

### DIFF
--- a/docs/notes/feature-java_classpath.md
+++ b/docs/notes/feature-java_classpath.md
@@ -1,0 +1,9 @@
+# Java CLASSPATH support
+
+Limited support is available for loading custom Java classes 
+and .jar files in the IDE on Mac and Linux. If the CLASSPATH 
+environment variable is set before the Java virtual machine 
+is initialised (i.e. before Java FFI is used), then any paths
+specified are added to the locations searched by the default
+class loader.
+

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -330,14 +330,25 @@ bool initialise_jvm()
     vm_args.version = JNI_VERSION_1_6;
     init_jvm_args(&vm_args);
     
+    const char *t_class_path = getenv("CLASSPATH");
+    if (t_class_path == nullptr)
+    {
+        t_class_path = "/usr/lib/java";
+    }
+    
+    char *t_option = strdup("-Djava.class.path=");
+    t_option = strcat(t_option, t_class_path);
+    
     JavaVMOption* options = new (nothrow) JavaVMOption[1];
-    options[0].optionString = const_cast<char*>("-Djava.class.path=/usr/lib/java");
+    options[0].optionString = t_option;
     
     vm_args.nOptions = 1;
     vm_args.options = options;
     vm_args.ignoreUnrecognized = false;
     
-    return create_jvm(&vm_args);
+    bool t_success = create_jvm(&vm_args);
+    free(t_option);
+    return t_success;
 #endif
     return true;
 }


### PR DESCRIPTION
This patch initialises the jvm on desktop platforms using the value
of environment variable CLASSPATH, thereby allowing classes in a
jar file to be used with LCB.

The CLASSPATH must be set before the first use of Java FFI