### PR TITLE
[Dictionary] Update altKey

### DIFF
--- a/docs/dictionary/function/altKey.lcdoc
+++ b/docs/dictionary/function/altKey.lcdoc
@@ -29,11 +29,12 @@ The <altKey> <function> <return|returns> down if the key is pressed and
 up if it's not.
 
 Description:
-Use the <altKey> <function(control structure)> to check whether the <Alt
-key>, <Meta key>, or Option key is being pressed. You can use <altKey>
-to add alternative capabilities to user actions such as clicking.
+Use the <altKey> <function(control structure)> to check whether the 
+<Alt key>, <Meta key>, or <Option key> is being pressed. You can use 
+<altKey> to add alternative capabilities to user actions such as 
+clicking.
 
-The <altKey>, <optionKey>, and metaKey <function(glossary)|functions>
+The <altKey>, <optionKey>, and <metaKey> <function(glossary)|functions>
 all <return> the same <value>. Which one to use is a matter of
 preference. The terminology varies depending on platform. Users of
 different operating systems may know this key as the Option key (Mac OS


### PR DESCRIPTION
Put `<Alt key>` on the same one line as it was linking to undefined.
Gave `Option key` angle brackets to match `<Alt key>` and `<Meta key>` in first paragraph of description.
Gave `metaKey` angle brackets to match `<altkey>` and `<optionkey>` in second paragraph of description.