### PR TITLE
[Dictionary] Update and

### DIFF
--- a/docs/dictionary/operator/and.lcdoc
+++ b/docs/dictionary/operator/and.lcdoc
@@ -27,7 +27,7 @@ local myCount
 if the shiftKey is down and myCount > 1 then exit mouseUp
 
 Parameters:
-leftValue: (bool):
+leftValue (bool):
 leftValue is true or false, or an expression that evaluates to
 true or false.
 


### PR DESCRIPTION
Removed the first colon from `leftValue: (bool):` as the `(bool):` part was appearing in the wrong place in the entry and `rightValue (bool):`, which displays correctly, doesn't have it.