### PR TITLE
[Dictionary] Update answer effect

### DIFF
--- a/docs/dictionary/command/answer-effect.lcdoc
+++ b/docs/dictionary/command/answer-effect.lcdoc
@@ -25,8 +25,8 @@ if the altKey is down then answer effect
 It:
 An encoded description of the visual effect the user chooses is placed
 in the it <variable>. You can either use the encoded description
-immediately, or store it (for example, in a <variable> or in a <custom
-property>) for later use. To display the effect, use the encoded
+immediately, or store it (for example, in a <variable> or in a 
+<custom property>) for later use. To display the effect, use the encoded
 description with the <visual effect> <command>, with the <unlock screen>
 <command>, or with the hide with visual effect or show with visual
 effect form of the <hide> or <show> <command>. If the user cancels the
@@ -58,7 +58,7 @@ bit builds of LiveCode.
 References: answer (command), visual effect (command),
 answer record (command), show (command), hide (command),
 unlock screen (command), function (control structure), result (function),
-QTEffects (function), dialog box (glossary), custom property (glossary),
+qtEffects (function), dialog box (glossary), custom property (glossary),
 variable (glossary), command (glossary), QuickTime (glossary),
 return (glossary), dontUseQTEffects (property), dontUseQT (property)
 


### PR DESCRIPTION
It: Put `<custom property>` on one line so that it no longer goes to undefined.
References: Changed capitalisation on `qtEffects (function)` to fix the link.