### PR TITLE
[Dictionary] Update answer folder

### DIFF
--- a/docs/dictionary/command/answer-folder.lcdoc
+++ b/docs/dictionary/command/answer-folder.lcdoc
@@ -33,12 +33,12 @@ If you specify empty, no prompt appears.
 
 defaultPath:
 The name and location of the folder whose contents are listed when the
-dialog box appears. If no defaultPath is specified, the dialog box lists
-the contents of the last folder you used with a file dialog box.
+<dialog box> appears. If no defaultPath is specified, the <dialog box> lists
+the contents of the last <folder> you used with a <file dialog box>.
 
 It:
-The absolute file path of the folder the user selects is placed in the
-it <variable>.
+The absolute file path of the <folder> the user selects is placed in the
+<it> <variable>.
 
 The result:
 If the user cancels the <dialog box|dialog>, the <it> <variable> is set
@@ -48,17 +48,17 @@ Description:
 Use the <answer folder> <command> when you want the user to choose a
 <folder> --for example, as a destination for <export|exported> <files>.
 
-If the as sheet form is used, the dialog box appears as a sheet on OS X
+If the as sheet form is used, the <dialog box> appears as a sheet on OS X
 systems. On other systems, the as sheet form has no effect and the
-dialog box appears normally. Attempting to open a sheet from within
+<dialog box> appears normally. Attempting to open a sheet from within
 another sheet displays the second stack as a <modal dialog box> instead.
-To give a dialog box a prompt when using the as sheet form a non-empty
+To give a <dialog box> a prompt when using the as sheet form a non-empty
 title must be provided. This will cause the prompt to appear in the same
 place it would if as sheet was not being used.
 
 If the systemFileSelector <property> is set to false, LiveCode's
-built-in <dialog box> is used instead of the operating system's <file
-dialog box|standard file dialog>.
+built-in <dialog box> is used instead of the operating system's 
+<file dialog box|standard file dialog>.
 
 Changes:
 The answer folder...as sheet form was introduced in version 2.0.


### PR DESCRIPTION
General: Added angle brackets to terms where other instances of those terms had them.
Description: Put `<file dialog box|standard file dialog>` on one line to fix the link.