### PR TITLE
[Dictionary] Update audioClip

### DIFF
--- a/docs/dictionary/object/audioClip.lcdoc
+++ b/docs/dictionary/object/audioClip.lcdoc
@@ -52,7 +52,7 @@ since it has no user interface and cannot be owned by a <card>.)
 
 To play an audioClip, use the syntax 
 
-    play audioClip <filename_of_audioclip>
+    play audioClip &lt;filename_of_audioclip&gt;
     
 
 Or the syntax


### PR DESCRIPTION
Changed an example at the bottom of the entry so that it half of it isn't absent when viewed in the dictionary.