### PR TITLE
[[ Feature ]] Array Literals

### DIFF
--- a/benchmarks/lcs/array/literals.livecodescript
+++ b/benchmarks/lcs/array/literals.livecodescript
@@ -19,10 +19,16 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 constant kRepetitions = 1000000
 
 command BenchmarkSequenceLiterals
+   local tOne, tTwo, tThree, tFour
+   put 1 + 0 into tOne
+   put 2 + 0 into tTwo
+   put 3 + 0 into tThree
+   put 4 + 0 into tFour
+
    local tLegacyLiteral
-   BenchmarkStartTiming "LegacyCreation"
+   BenchmarkStartTiming "LegacyConstantCreation"
    repeat kRepetitions times
-      get empty
+      put empty into tLegacyLiteral
       put true into tLegacyLiteral[1]
       put 1 into tLegacyLiteral[2]
       put pi into tLegacyLiteral[3]
@@ -35,9 +41,25 @@ command BenchmarkSequenceLiterals
    end repeat
    BenchmarkStopTiming
 
+   BenchmarkStartTiming "LegacyDynamicCreation"
+   repeat kRepetitions times
+      put empty into tLegacyLiteral
+      put _Identity(true) into tLegacyLiteral[tOne]
+      put _Identity(1) into tLegacyLiteral[tTwo]
+      put _Identity(pi) into tLegacyLiteral[tThree]
+      put _Identity("Hello") into tLegacyLiteral[tFour]
+   end repeat
+   BenchmarkStopTiming
+
    BenchmarkStartTiming "ConstantCreation"
    repeat kRepetitions times
       get [ true, 1, pi, "Hello", false, 2, pi, "World!", [ true, 1, pi, "Hello", false, 2, pi, "World!" ] ]
+   end repeat
+   BenchmarkStopTiming
+
+   BenchmarkStartTiming "DynamicCreation"
+   repeat kRepetitions times
+      get [ _Identity(true), _Identity(1), _Identity(pi), _Identity("Hello") ]
    end repeat
    BenchmarkStopTiming
 
@@ -49,3 +71,7 @@ command BenchmarkSequenceLiterals
    end repeat
    BenchmarkStopTiming
 end BenchmarkSequenceLiterals
+
+function _Identity pValue
+   return pValue
+end _Identity

--- a/benchmarks/lcs/array/literals.livecodescript
+++ b/benchmarks/lcs/array/literals.livecodescript
@@ -1,0 +1,51 @@
+script "ArrayLiterals"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+constant kRepetitions = 1000000
+
+command BenchmarkSequenceLiterals
+   local tLegacyLiteral
+   BenchmarkStartTiming "LegacyCreation"
+   repeat kRepetitions times
+      get empty
+      put true into tLegacyLiteral[1]
+      put 1 into tLegacyLiteral[2]
+      put pi into tLegacyLiteral[3]
+      put "Hello" into tLegacyLiteral[4]
+      put false into tLegacyLiteral[5]
+      put 2 into tLegacyLiteral[6]
+      put pi into tLegacyLiteral[7]
+      put "World!" into tLegacyLiteral[8]
+      put it into tLegacyLiteral[9]
+   end repeat
+   BenchmarkStopTiming
+
+   BenchmarkStartTiming "ConstantCreation"
+   repeat kRepetitions times
+      get [ true, 1, pi, "Hello", false, 2, pi, "World!", [ true, 1, pi, "Hello", false, 2, pi, "World!" ] ]
+   end repeat
+   BenchmarkStopTiming
+
+   local tConstantLiteral
+   put [ true, 1, pi, "Hello", false, 2, pi, "World!", [ true, 1, pi, "Hello", false, 2, pi, "World!" ] ] into tConstantLiteral
+   BenchmarkStartTiming "ConstantComparison"
+   repeat kRepetitions times
+      get tConstantLiteral is [ true, 1, pi, "Hello", false, 2, pi, "World!", [ true, 1, pi, "Hello", false, 2, pi, "World!" ] ]
+   end repeat
+   BenchmarkStopTiming
+end BenchmarkSequenceLiterals

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -24,6 +24,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "util.h"
 #include "uidc.h"
 #include "variable.h"
+#include "chunk.h"
 
 // general commands in cmds.cc
 

--- a/engine/src/constant.cpp
+++ b/engine/src/constant.cpp
@@ -25,6 +25,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "syntax.h"
 
+MCExpressionAttrs MCConstant::getattrs(void) const
+{
+    return MCExpressionAttrs().SetIsConstant();
+}
+
 void MCConstant::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
 {
 	if (nvalue == BAD_NUMERIC)

--- a/engine/src/constant.h
+++ b/engine/src/constant.h
@@ -34,6 +34,8 @@ public:
 	{
 		MCValueRelease(svalue);	
 	}
+    
+    virtual MCExpressionAttrs getattrs(void) const;
 
     virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
 	

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2758,6 +2758,15 @@ enum Exec_errors
 
     // {EE-0903} snapshot: no screen
     EE_SNAPSHOT_FAILED,
+    
+    // {EE-0904} literal: error in value expression
+    EE_SEQLITERAL_BADEXPR,
+    
+    // {EE-0905} literal: error in key expression
+    EE_ARRLITERAL_BADKEYEXPR,
+    
+    // {EE-0906} literal: error in value expression
+    EE_ARRLITERAL_BADVALEXPR,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -55,6 +55,11 @@ MCExpression::~MCExpression()
 	delete right;
 }
 
+MCExpressionAttrs MCExpression::getattrs(void) const
+{
+    return {};
+}
+
 MCVarref *MCExpression::getrootvarref(void)
 {
 	return NULL;
@@ -412,6 +417,30 @@ void MCExpression::eval_typed(MCExecContext& ctxt, MCExecValueType p_type, void 
 		MCExecTypeConvertAndReleaseAlways(ctxt, t_value . type, &t_value , p_type, r_value);
 }
 
+bool MCExpression::constant_eval_typed(MCExecValueType p_type, void* r_value_ptr)
+{
+    MCerrorlock++;
+    
+    bool t_has_error = false;
+    
+    MCExecContext ctxt;
+    MCExecValue t_value;
+    eval_ctxt(ctxt, t_value);
+    if (!ctxt.HasError())
+    {
+        MCExecTypeConvertAndReleaseAlways(ctxt, t_value.type, &t_value, p_type, r_value_ptr);
+    }
+    else
+    {
+        ;
+    }
+    
+    t_has_error = ctxt.HasError();
+    
+    MCerrorlock--;
+    
+    return !t_has_error;
+}
 
 void MCExpression::initpoint(MCScriptPoint &sp)
 {

--- a/engine/src/express.h
+++ b/engine/src/express.h
@@ -26,6 +26,29 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "exec.h"
 #endif
 
+class MCExpressionAttrs
+{
+public:
+    bool IsConstant(void) const
+    {
+        return (m_flags & kIsConstant) != 0;
+    }
+
+    MCExpressionAttrs SetIsConstant(void)
+    {
+        m_flags |= kIsConstant;
+        return *this;
+    }
+    
+private:
+    enum
+    {
+        kIsConstant = 1 << 0,
+    };
+    
+    uint32_t m_flags = 0;
+};
+
 class MCExpression
 {
 protected:
@@ -39,10 +62,11 @@ protected:
 public:
 	MCExpression();
 	virtual ~MCExpression();
+
+    virtual MCExpressionAttrs getattrs(void) const;
 	
 	virtual Parse_stat parse(MCScriptPoint &, Boolean the);
 
-	
 	// Evaluate the expression as its natural type basic type (note that
 	// execvalue's cannot be set/enum/custom, they should all be resolved
 	// to the appropriate basic type first!). This form should be used for
@@ -81,6 +105,16 @@ public:
 	void eval_typed(MCExecContext& ctxt, MCExecValueType return_type, void* return_value);
 	
 	//////////
+    
+    template<typename T>
+    bool constant_eval(T& r_value)
+    {
+        return constant_eval_typed(MCExecValueTraits<T>::type_enum, &r_value);
+    }
+    
+    bool constant_eval_typed(MCExecValueType return_type, void* return_value_ptr);
+    
+    //////////
 	
 	void setrank(Factor_rank newrank)
 	{

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -877,6 +877,9 @@ static void tokenize(const unsigned char *p_text, uint4 p_length, uint4 p_in_nes
 				case ST_RP:
 				case ST_LB:
 				case ST_RB:
+                case ST_LC:
+                case ST_RC:
+                case ST_COL:
 				case ST_SEP:
 					t_char = next_valid_char(p_text, t_index);
 					t_class = COLOURIZE_CLASS_OPERATOR;
@@ -930,8 +933,6 @@ static void tokenize(const unsigned char *p_text, uint4 p_length, uint4 p_in_nes
 					t_end = t_index;
 				break;
 
-                case ST_LC:
-                case ST_RC:
                 case ST_EOF:
 				case ST_ERR:
 					t_char = next_valid_char(p_text, t_index);

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -51,7 +51,7 @@ uint8_t type_table[256] =
     ST_SEP,  ST_MIN,  ST_NUM,  ST_OP,   //      ,       -       .       /
     ST_NUM,  ST_NUM,  ST_NUM,  ST_NUM,  //      0       1       2       3
     ST_NUM,  ST_NUM,  ST_NUM,  ST_NUM,  //      4       5       6       7
-    ST_NUM,  ST_NUM,  ST_OP,   ST_SEMI, //      8       9       :       ;
+    ST_NUM,  ST_NUM,  ST_COL,   ST_SEMI, //      8       9       :       ;
     ST_OP,   ST_OP,   ST_OP,   ST_TAG,   //      <       =       >       ?
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      @       A       B       C
     ST_ID,   ST_ID,   ST_ID,   ST_ID,   //      D       E       F       G
@@ -119,7 +119,7 @@ uint8_t unicode_type_table[256] =
     ST_SEP,         ST_MIN,         ST_NUM,         ST_OP,          //      ,       -       .       /
     ST_NUM,         ST_NUM,         ST_NUM,         ST_NUM,         //      0       1       2       3
     ST_NUM,         ST_NUM,         ST_NUM,         ST_NUM,         //      4       5       6       7
-    ST_NUM,         ST_NUM,         ST_OP,          ST_SEMI,        //      8       9       :       ;
+    ST_NUM,         ST_NUM,         ST_COL,         ST_SEMI,        //      8       9       :       ;
     ST_OP,          ST_OP,          ST_OP,          ST_TAG,         //      <       =       >       ?
     ST_ID,          ST_ID,          ST_ID,          ST_ID,          //      @       A       B       C
     ST_ID,          ST_ID,          ST_ID,          ST_ID,          //      D       E       F       G

--- a/engine/src/literal.cpp
+++ b/engine/src/literal.cpp
@@ -26,6 +26,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "syntax.h"
 
+MCExpressionAttrs MCLiteral::getattrs(void) const
+{
+    return MCExpressionAttrs().SetIsConstant();
+}
+
 Parse_stat MCLiteral::parse(MCScriptPoint &sp, Boolean the)
 {
 	initpoint(sp);

--- a/engine/src/literal.cpp
+++ b/engine/src/literal.cpp
@@ -22,7 +22,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "literal.h"
 #include "scriptpt.h"
-
+#include "mcerror.h"
+#include "globals.h"
 
 #include "syntax.h"
 
@@ -51,4 +52,342 @@ void MCLiteral::compile(MCSyntaxFactoryRef ctxt)
 	MCSyntaxFactoryEndExpression(ctxt);
 }
 
+/**/
 
+MCSequenceLiteral::~MCSequenceLiteral(void)
+{
+    /* Iteratively advance to the next link, then delete the previous one. */
+    while(m_dynamic_values != nullptr)
+    {
+        DynamicValue *t_current = m_dynamic_values;
+        m_dynamic_values = m_dynamic_values->next;
+        delete t_current;
+    }
+}
+
+MCExpressionAttrs MCSequenceLiteral::getattrs(void) const
+{
+    /* If there are dynamic values, then the expression cannot be constant. */
+    if (m_dynamic_values != nullptr)
+    {
+        return {};
+    }
+    
+    /* If there are no dynamic values, then the expression is constant and its
+     * value is m_base_value. */
+    return MCExpressionAttrs().SetIsConstant();
+}
+
+Parse_stat MCSequenceLiteral::parse(MCScriptPoint& sp, Boolean the)
+{
+    initpoint(sp);
+    
+    /* The base value is created as a mutable array and will hold all constant
+     * values. */
+    MCAutoArrayRef t_base_value;
+    if (!MCArrayCreateMutable(&t_base_value))
+    {
+        MCperror->add(PE_OUTOFMEMORY, sp);
+        return PS_ERROR;
+    }
+    
+    /* The indicies start at 1 */
+    uindex_t t_index = 1;
+    
+    /* We keep track of the pointer to the slot holding the current head of
+     * chain - which begins with the head link in the MCSequenceLiteral ast. */
+    DynamicValue** t_values_head = &m_dynamic_values;
+    
+    /* Loop to match '[' { <expr> , ',' } ']' */
+    for(;;)
+    {
+        /* First match an expression - we want more than a single factor (first
+         * False), but we need to match ',' as part of the value list (second
+         * False). */
+        MCAutoPointer<MCExpression> t_value_exp;
+        if (sp.parseexp(False, False, &(&t_value_exp)) != PS_NORMAL)
+        {
+            MCperror->add(PE_SEQLITERAL_EXPEXPECTED, sp);
+            return PS_ERROR;
+        }
+        
+        /* If the node is constant, *and* it successfully evaluates then we
+         * can make it part of the base value. Otherwise we add it to the list
+         * of dynamic values to be evaluated at runtime. */
+        MCAutoValueRef t_constant_value;
+        if (t_value_exp->getattrs().IsConstant() &&
+            t_value_exp->constant_eval(&t_constant_value))
+        {
+            /* We must unique the constant value we get back as some constant
+             * exprs (e.g. MCConstant) use unboxed values if they can. */
+            if (!t_constant_value.MakeUnique() ||
+                !MCArrayStoreValueAtIndex(*t_base_value,
+                                          t_index,
+                                          *t_constant_value))
+            {
+                MCperror->add(PE_OUTOFMEMORY, sp);
+                return PS_ERROR;
+            }
+        }
+        else
+        {
+            /* Add a new DynamicValue link on to the head of the chain. */
+            *t_values_head = new(nothrow) DynamicValue(*t_values_head,
+                                                       t_index,
+                                                       *t_value_exp);
+            if (*t_values_head == nullptr)
+            {
+                MCperror->add(PE_OUTOFMEMORY, sp);
+                return PS_ERROR;
+            }
+            
+            /* As we've 'given' the t_value_exp ptr to the DynamicValue link,
+             * we need to release the auto-pointer manually. */
+            t_value_exp.Release();
+            
+            /* Update the head link to be the 'next' field of the newly appended
+             * link */
+            t_values_head = &(*t_values_head)->next;
+        }
+        
+        /* Check for either ',' or ']' */
+        Symbol_type t_sep_type;
+        if (sp.next(t_sep_type) != PS_NORMAL ||
+            (t_sep_type != ST_SEP && t_sep_type != ST_RB))
+        {
+            MCperror->add(PE_SEQLITERAL_SEPEXPECTED, sp);
+            return PS_ERROR;
+        }
+        
+        /* As soon as we encounter ']', we are done. */
+        if (t_sep_type == ST_RB)
+        {
+            break;
+        }
+
+        /* Move to the next index */
+        t_index += 1;
+    }
+    
+    /* If the base value array has at least one element we make it immutable
+     * and then unique it. This means that sequence literals which have the same
+     * base value, will share that value in memory. If the base value array has
+     * no elements, then we use the empty array. */
+    if (MCArrayGetCount(*t_base_value) != 0)
+    {
+        if (!t_base_value.MakeImmutable() ||
+            !t_base_value.MakeUnique())
+        {
+            MCperror->add(PE_OUTOFMEMORY, sp);
+            return PS_ERROR;
+        }
+        
+        /* We can just use assignment here as we are assigning auto pointer to
+         * auto pointer. A suitably clever C++ compiler will use the moving
+         * constructor. */
+        m_base_value.Reset(*t_base_value);
+    }
+    else
+    {
+        m_base_value = kMCEmptyArray;
+    }
+
+    return PS_ERROR;
+}
+
+void MCSequenceLiteral::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
+{
+    /* If there are no dynamic values then we are done - the value of the
+     * literal is the base value. */
+    if (m_dynamic_values == nullptr)
+    {
+        r_value . type = kMCExecValueTypeValueRef;
+        r_value . valueref_value = MCValueRetain(*m_base_value);
+        return;
+    }
+    
+    /* There are dynamic values, so we need to add them to a copy of the base
+     * value. */
+    MCAutoArrayRef t_literal;
+    if (!MCArrayMutableCopy(*m_base_value,
+                            &t_literal))
+    {
+        ctxt.LegacyThrow(EE_NO_MEMORY);
+        return;
+    }
+    
+    /* Loop through the singly-linked dynamic value list. */
+    for(DynamicValue *t_dynamic_value = m_dynamic_values;
+        t_dynamic_value != nullptr;
+        t_dynamic_value = t_dynamic_value->next)
+    {
+        /* First try to evaluate the expression. */
+        MCAutoValueRef t_value;
+        if (!ctxt.EvalExprAsValueRef(*t_dynamic_value->expr,
+                                     EE_SEQLITERAL_BADEXPR,
+                                     &t_value))
+        {
+            return;
+        }
+        
+        /* If evaluation succeeds, try to store the value */
+        if (!MCArrayStoreValueAtIndex(*t_literal,
+                                      t_dynamic_value->index,
+                                      *t_value))
+        {
+            ctxt.Throw();
+            return;
+        }
+    }
+    
+    /* Make sure the value is immutable */
+    if (!t_literal.MakeImmutable())
+    {
+        ctxt.Throw();
+        return;
+    }
+    
+    /* We are done - return the constructed literal as an ExecValue. */
+	r_value . type = kMCExecValueTypeValueRef;
+	r_value . valueref_value = t_literal.Take();
+}
+
+/**/
+
+MCArrayLiteral::~MCArrayLiteral(void)
+{
+    while(m_dynamic_values != nullptr)
+    {
+        DynamicValue *t_current = m_dynamic_values;
+        m_dynamic_values = m_dynamic_values->next;
+        delete t_current;
+    }
+}
+
+MCExpressionAttrs MCArrayLiteral::getattrs(void) const
+{
+    if (m_dynamic_values != nullptr)
+    {
+        return {};
+    }
+    
+    return MCExpressionAttrs().SetIsConstant();
+}
+
+Parse_stat MCArrayLiteral::parse(MCScriptPoint& sp, Boolean the)
+{
+    initpoint(sp);
+    
+    uindex_t t_index = 1;
+    DynamicValue** t_values_head = &m_dynamic_values;
+    for(;;)
+    {
+        MCAutoPointer<MCExpression> t_key_exp;
+        if (sp.parseexp(False, False, &(&t_key_exp)) != PS_NORMAL)
+        {
+            MCperror->add(PE_ARRLITERAL_KEYEXPEXPECTED, sp);
+            return PS_ERROR;
+        }
+        
+        Symbol_type t_col_type;
+        if (sp.next(t_col_type) != PS_NORMAL ||
+            t_col_type != ST_COL)
+        {
+            MCperror->add(PE_ARRLITERAL_COLEXPECTED, sp);
+            return PS_ERROR;
+        }
+    
+        MCAutoPointer<MCExpression> t_value_exp;
+        if (sp.parseexp(False, False, &(&t_value_exp)) != PS_NORMAL)
+        {
+            MCperror->add(PE_ARRLITERAL_VALEXPEXPECTED, sp);
+            return PS_ERROR;
+        }
+
+        *t_values_head = new(nothrow) DynamicValue(*t_values_head,
+                                                   true,
+                                                   *t_key_exp,
+                                                   true,
+                                                   *t_value_exp);
+        if (*t_values_head == nullptr)
+        {
+            MCperror->add(PE_OUTOFMEMORY, sp);
+            return PS_ERROR;
+        }
+        t_key_exp.Release();
+        t_value_exp.Release();
+        
+        Symbol_type t_sep_type;
+        if (sp.next(t_sep_type) != PS_NORMAL ||
+            (t_sep_type != ST_SEP && t_sep_type != ST_RC))
+        {
+            MCperror->add(PE_ARRLITERAL_SEPEXPECTED, sp);
+            return PS_ERROR;
+        }
+        
+        if (t_sep_type == ST_RC)
+        {
+            break;
+        }
+        
+        t_values_head = &(*t_values_head)->next;
+        t_index += 1;
+    }
+    
+    return PS_ERROR;
+}
+
+void MCArrayLiteral::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
+{
+    MCAutoArrayRef t_literal;
+    if (!MCArrayCreateMutable(&t_literal))
+    {
+        ctxt.LegacyThrow(EE_NO_MEMORY);
+        return;
+    }
+    for(DynamicValue *t_dynamic_value = m_dynamic_values;
+        t_dynamic_value != nullptr;
+        t_dynamic_value = t_dynamic_value->next)
+    {
+        MCNewAutoNameRef t_key;
+        if (t_dynamic_value->dynamic_key)
+        {
+            if (!ctxt.EvalExprAsNameRef(t_dynamic_value->dynamic_key,
+                                        EE_ARRLITERAL_BADKEYEXPR,
+                                        &t_key))
+            {
+                return;
+            }
+        }
+        else
+        {
+            t_key = t_dynamic_value->constant_key;
+        }
+    
+        MCAutoValueRef t_value;
+        if (!ctxt.EvalExprAsValueRef(t_dynamic_value->dynamic_value,
+                                     EE_ARRLITERAL_BADVALEXPR,
+                                     &t_value))
+        {
+            return;
+        }
+        
+        if (!MCArrayStoreValue(*t_literal,
+                               ctxt.GetCaseSensitive(),
+                               *t_key,
+                               *t_value))
+        {
+            ctxt.Throw();
+            return;
+        }
+    }
+    
+    if (!t_literal.MakeImmutable())
+    {
+        ctxt.Throw();
+        return;
+    }
+    
+	r_value . type = kMCExecValueTypeValueRef;
+	r_value . valueref_value = t_literal.Take();
+}

--- a/engine/src/literal.h
+++ b/engine/src/literal.h
@@ -35,6 +35,8 @@ public:
 		MCValueRelease(value);
 	}
 
+    virtual MCExpressionAttrs getattrs(void) const;
+    
     virtual Parse_stat parse(MCScriptPoint &, Boolean the);
     virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
 	virtual void compile(MCSyntaxFactoryRef ctxt);

--- a/engine/src/literal.h
+++ b/engine/src/literal.h
@@ -42,4 +42,115 @@ public:
 	virtual void compile(MCSyntaxFactoryRef ctxt);
 };
 
+/********/
+
+/* The MCSequenceLiteral class is the AST expression node for a numerically
+ * keyed array literal. e.g. [ 1, 2, "foo", "bar", myFunc(3) ]. */
+class MCSequenceLiteral: public MCExpression
+{
+    /* The DynamicValue struct represents a link in a singly-linked list of
+     * values that need to be evaluated at runtime, rather than compile time. */
+    struct DynamicValue
+    {
+        DynamicValue *next;
+        uindex_t index;
+        MCAutoPointer<MCExpression> expr;
+        
+        DynamicValue(DynamicValue* p_next, uindex_t p_index, MCExpression* p_expr)
+            : next(p_next),
+              index(p_index),
+              expr(p_expr)
+        {
+        }
+    };
+    
+    /* The m_base_value member holds all the compile-time evaluatable (constant)
+     * elements of the sequence literal. */
+    MCAutoArrayRef m_base_value;
+    
+    /* The m_dynamic_values member is the head ptr for the list of dynamic
+     * values. */
+    DynamicValue *m_dynamic_values = nullptr;
+    
+public:
+    /* We need an explicit constructor, as the m_dynamic_values list needs
+     * to be freed. */
+    ~MCSequenceLiteral(void);
+    
+    /* Sequence literals can be constant, so we override the 'getattrs' method
+     * so that we can indicate this. A sequence literal is constant if there are
+     * no dynamic values. */
+    virtual MCExpressionAttrs getattrs(void) const;
+    
+    /* The syntax of a sequence literal is '[' { <expr> , ',' } ']' */
+    virtual Parse_stat parse(MCScriptPoint& sp, Boolean the);
+    
+    /* The evaluation can return a constant literal directly, or for ones with
+     * dynamic values will need to evaluate each in turn and build a new one. */
+    virtual void eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value);
+};
+
+/********/
+
+class MCArrayLiteral: public MCExpression
+{
+    struct DynamicValue
+    {
+        DynamicValue *next;
+        bool key_is_dynamic : 1;
+        bool value_is_dynamic : 1;
+        union
+        {
+            MCExpression *dynamic_key;
+            MCNameRef constant_key;
+            void *key_ptr;
+        };
+        union
+        {
+            MCExpression *dynamic_value;
+            MCValueRef constant_value;
+            void *value_ptr;
+        };
+        
+        DynamicValue(DynamicValue *p_next, bool p_key_is_dynamic, void *p_key_ptr, bool p_value_is_dynamic, void *p_value_ptr)
+            : next(p_next),
+              key_is_dynamic(p_key_is_dynamic),
+              value_is_dynamic(p_value_is_dynamic),
+              key_ptr(p_key_ptr),
+              value_ptr(p_value_ptr)
+        {
+        }
+        
+        ~DynamicValue(void)
+        {
+            if (key_ptr != nullptr)
+            {
+                if (key_is_dynamic)
+                    delete dynamic_key;
+                else
+                    MCValueRelease(constant_key);
+            }
+            
+            if (value_ptr != nullptr)
+            {
+                if (value_is_dynamic)
+                    delete dynamic_value;
+                else
+                    MCValueRelease(constant_key);
+            }
+        }
+    };
+    
+    MCAutoArrayRef m_base_value;
+    DynamicValue *m_dynamic_values = nullptr;
+    
+public:
+    ~MCArrayLiteral(void);
+
+    virtual MCExpressionAttrs getattrs(void) const;
+    
+    virtual Parse_stat parse(MCScriptPoint& sp, Boolean the);
+    virtual void eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value);
+};
+
 #endif

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -2157,6 +2157,7 @@ enum {
     ST_LIT,
 	ST_LC,
     ST_RC,
+    ST_COL,
     
 	// MW-2009-03-03: The ST_DATA symbol type is a string that shoudl be treated
 	//   as an echoed literal - it represents the data between <?rev ?> blocks in

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1792,6 +1792,27 @@ enum Parse_errors
 	
     // {PE-0582} send: can't send script in time
     PE_SEND_SCRIPTINTIME,
+    
+    // {PE-0583} out of memory
+    PE_OUTOFMEMORY,
+    
+    // {PE-0584} literal: expression expected
+    PE_SEQLITERAL_EXPEXPECTED,
+    
+    // {PE-0585} literal: ',' or ']' expected
+    PE_SEQLITERAL_SEPEXPECTED,
+    
+    // {PE-0586} literal: expression for key expected
+    PE_ARRLITERAL_KEYEXPEXPECTED,
+    
+    // {PE-0587} literal: expression for value expected
+    PE_ARRLITERAL_VALEXPEXPECTED,
+    
+    // {PE-0588} literal: ':' expected
+    PE_ARRLITERAL_COLEXPECTED,
+    
+    // {PE-0589} literal: ',' or '}' expected
+    PE_ARRLITERAL_SEPEXPECTED,
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -1572,6 +1572,16 @@ Parse_stat MCScriptPoint::parseexp(Boolean single, Boolean items,
 				return PS_NORMAL;
 			}
 			break;
+        case ST_LC:
+            newfact = insertfactor(new MCArrayLiteral, curfact, top);
+            newfact->parse(*this, doingthe);
+            needfact = False;
+            break;
+        case ST_LB:
+            newfact = insertfactor(new MCSequenceLiteral, curfact, top);
+            newfact->parse(*this, doingthe);
+            needfact = False;
+            break;
 		default:
 			if (lookup(SP_FACTOR, te) == PS_NORMAL)
 			{

--- a/extensions/widgets/macbutton/macbutton.lcb
+++ b/extensions/widgets/macbutton/macbutton.lcb
@@ -189,6 +189,9 @@ end handler
 
 private handler ButtonActionCallback(in pSender as ObjcObject, in pContext as optional any) returns nothing
 	post "mouseUp"
+    
+    // Wake the engine to deal with the posted signal
+    MCEngineRunloopBreakWait()
 end handler
 
 /****/

--- a/libfoundation/include/foundation-auto.h
+++ b/libfoundation/include/foundation-auto.h
@@ -137,6 +137,17 @@ public:
         return t_value;
     }
     
+    // The MakeUnique method inters the value-ref so that it uses an existing
+    // uniqued value if present.
+    inline bool MakeUnique(void)
+    {
+        if (!MCValueInterAndRelease(m_value, m_value))
+        {
+            return false;
+        }
+        return true;
+    }
+    
     friend T In<>(const MCAutoValueRefBase<T>&);
     friend T& Out<>(MCAutoValueRefBase<T>&);
     friend T& InOut<>(MCAutoValueRefBase<T>&);

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -989,7 +989,7 @@ __MCScriptResolveForeignFunctionBindingForObjC(MCScriptInstanceRef p_instance,
     }
     
     /* Next we must compute the cif. */
-    MCAutoPointer<void> t_layout_cif;
+    MCAutoCustomPointer<void, MCMemoryDeallocate> t_layout_cif;
     ffi_cif *t_cif = nullptr;
     ffi_type *t_cif_return_type = nullptr;
     ffi_type **t_cif_arg_types = nullptr;

--- a/tests/lcs/core/array/_valueutils.lcb
+++ b/tests/lcs/core/array/_valueutils.lcb
@@ -1,0 +1,16 @@
+library com.livecode.lcs_tests.core.valueutils
+
+use com.livecode.foreign
+
+__safe foreign handler MCValueIsUnique(in pValue as any) returns CBool binds to "<builtin>"
+__safe foreign handler MCValueIsEqualTo(in pLeft as any, in pRight as any) returns CBool binds to "<builtin>"
+
+public handler IsValueUnique(in pValue as any)
+	return MCValueIsUnique(pValue)
+end handler
+
+public handler IsUniquelyEqualTo(in pLeft as any, in pRight as any)
+	return MCValueIsUnique(pLeft) and MCValueIsUnique(pRight) and MCValueIsEqualTo(pLeft, pRight)
+end handler
+
+end library

--- a/tests/lcs/core/array/literals.livecodescript
+++ b/tests/lcs/core/array/literals.livecodescript
@@ -1,0 +1,84 @@
+script "CoreArrayLiterals"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestSetup
+   TestSkipIfNot "lcb"
+   TestLoadAuxillaryExtension "_valueutils"
+   wait 1 second
+end TestSetup
+
+on TestSequenceLiteral
+	local tConstantLiteral
+	put [ true, 1, pi, "Hello", [ true, 1, pi, "Hello" ] ] into tConstantLiteral
+	TestAssert "constant literal creation works", tConstantLiteral[1] is true and \
+												  tConstantLiteral[2] is 1 and \
+												  tConstantLiteral[3] is pi and \
+												  tConstantLiteral[4] is "Hello" and \
+												  tConstantLiteral[5] is [ true, 1, pi, "Hello", [ true, 1, pi, "Hello" ] ]
+
+	--TestAssert "constant literal is interred", IsValueUnique(tConstantLiteral)
+	--TestAssert "constant literal is unique", IsUniquelyEqualTo(tConstantLiteral, [ true, 1, pi, "hello" ])
+
+	local tDynamicLiteral
+	put [ _Identity(true), _Identity(1), _Identity(pi), _Identity("Hello"), [ _Identity(true), _Identity(1), _Identity(pi), _Identity("Hello") ] ] into tDynamicLiteral
+	TestAssert "dynamic literal creation works", tDynamicLiteral[1] is true and \
+												 tDynamicLiteral[2] is 1 and \
+												 tDynamicLiteral[3] is pi and \
+												 tDynamicLiteral[4] is "Hello" and \
+												 tDynamicLiteral[5] is [ _Identity(true), _Identity(1), _Identity(pi), _Identity("Hello") ]
+
+	local tConstTime
+	put the long seconds into tConstTime
+	repeat 100000 times
+		--get [ true, 1, pi, "Hello", [ true, 1, pi, "Hello" ] ] is [ true, 1, pi, "Hello", [ true, 1, pi, "Hello" ] ]
+		get tConstantLiteral is tConstantLiteral --[ true, 1, pi, "Hello", [ true, 1, pi, "Hello" ] ]
+	end repeat
+	put the long seconds - tConstTime into tConstTime
+
+	local tDynTime
+	put the long seconds into tDynTime
+	repeat 100000 times
+		get tDynamicLiteral is [ true, 1, pi, "Hello", [ true, 1, pi, "Hello" ] ]
+	end repeat
+	put the long seconds - tDynTime into tDynTime
+
+	TestDiagnostic tConstTime && tDynTime
+end TestSequenceLiteral
+
+on TestArrayLiteral
+	local tDynamicLiteral
+	put { _Identity("true"): _Identity(true), \
+	      _Identity("1"): _Identity(1), \
+	      _Identity("pi"): _Identity(pi), \
+	      _Identity("Hello"): _Identity("Hello") } into tDynamicLiteral
+	TestAssert "dynamic literal creation works", tDynamicLiteral["true"] is true and \
+												 tDynamicLiteral["1"] is 1 and \
+												 tDynamicLiteral["pi"] is pi and \
+												 tDynamicLiteral["Hello"] is "Hello"
+end TestArrayLiteral
+
+/* _Identity just returns the input value. However, it has to be considered a
+ * dynamic function as it uses the message path. */
+function _Identity pValue
+	return pValue
+end _Identity
+
+function SeqToString pValue
+	combine pValue by comma
+	return pValue
+end SeqToString


### PR DESCRIPTION
This patch adds support for 'array literals' to LiveCode Script:
```
  put [ 1, 2, [ 3, 4, { "size" : the length of tOtherSeq } ] ] into tSeqVar
  put { "foo" : "bar", "baz" : "foo" , "bar": [ 1, 2, 3 ] } into tArrVar
```
Literals can be either completely constant, or completely dynamic, or a mixture of both.

In order to be able to detect constancy, a new (general) 'getattrs()' virtual method has been added to the MCExpression AST base class. This allows a node to be asked what attributes it has (the first being 'constant', but there are others which would be useful - like 'pure', or 'waitable'). The constant attribute is used to determine whether compile-time evaluation should be tried on the node - if the latter succeeds it is truly constant, if eval throws an error it is considered dynamic so the error will occur at runtime.

If a literal is constant, then the constant value is uniqued and is directly returned on eval. As the value is uniqued, the same literal can appear repeatedly, but only actually have one value in memory representing it.

If a literal is not constant, then it is stored as a (uniqued) base value with the constant key/values, along with a list of dynamic values. When a non-constant literal is evaluated, a new array value is built based on a copy of the base value; and the dynamic elements evaluated and added to it.

Note: This is an stg stack, hence the lack of commit messages as yet.

Note: Only seq literals can be constant at the moment - to do array literals needs some work to ensure that duplicate keys are handled appropriately. i.e. A duplicate dynamic key which appears before a constant identical key should be ignored, but used instead of a constant identical key if it appears after. This helps preserve a strict left-to-right evaluation order. There is an argument to be had for throwing an error with duplicate keys - although the dynamicity of caseSensitivity of keys suggests that for now, left-to-right evaluation and replacement if it occurs is probably the best path.