### PR TITLE
[[ Bug 20238 ]] Make Dropbox result limit an integer

### DIFF
--- a/extensions/script-libraries/dropbox/dropbox.livecodescript
+++ b/extensions/script-libraries/dropbox/dropbox.livecodescript
@@ -5180,6 +5180,9 @@ private function __list_revisions_POST pPath,pLimit
    #--limit UInt64 The maximum number of revision entries returned. The default for this field is 10.
    {"path":"/apps/MyApp/seasons.docx","limit": 10}
    */
+   if pLimit is not an integer then 
+      put 1000 into pLimit
+   end if
    return __CB(__Q("path") & ":" &  __Q(pPath) & "," &__Q("limit") & ":" & pLimit)
 end __list_revisions_POST
 
@@ -5375,8 +5378,10 @@ private function __list_folder_members_POST pSharedFolderId,pActions,pLimit
    --
    { "shared_folder_id": "84528192421","actions": [], "limit": 1000}
    */
-   if pLimit is empty then put "1000" into pLimit
-   return __CB(__Q("shared_folder_id") & ":" &  __Q(pSharedFolderId) & "," & __Q("actions") & ":" & __List(pActions)& "," & __Q("limit") & ":" &  __Q(pLimit) )
+   if pLimit is not an integer then
+      put 1000 into pLimit
+   end if
+   return __CB(__Q("shared_folder_id") & ":" &  __Q(pSharedFolderId) & "," & __Q("actions") & ":" & __List(pActions)& "," & __Q("limit") & ":" &  pLimit )
 end __list_folder_members_POST
 
 private function __list_folder_members_continue_POST pCursor
@@ -5403,8 +5408,10 @@ private function __list_folders_POST pLimit,pActions
    unshare Void Stop sharing this folder.
    {"limit": 100, "actions": []}
    */
-   if pLimit is empty then put "1000" into pLimit
-   return __CB(__Q("limit") & ":" &  __Q(pLimit) & "," & __Q("actions") & ":" & __List(pActions))
+   if pLimit is not an integer then
+      put 1000 into pLimit
+   end if
+   return __CB(__Q("limit") & ":" &  pLimit & "," & __Q("actions") & ":" & __List(pActions))
 end __list_folders_POST
 
 private function __list_folders_continue_POST pCursor
@@ -5422,8 +5429,10 @@ private function __list_mountable_folders_POST pLimit,pActions
    actions List of (FolderAction)? Folder actions to query. This field is optional.
    FolderAction (open union) 
    */
-   if pLimit is empty then put "1000" into pLimit
-   return __CB(__Q("limit") & ":" &  __Q(pLimit) & "," & __Q("actions") & ":" & __List(pActions))
+   if pLimit is not an integer then
+      put 1000 into pLimit
+   end if
+   return __CB(__Q("limit") & ":" &  pLimit & "," & __Q("actions") & ":" & __List(pActions))
 end __list_mountable_folders_POST
 
 private function __list_mountable_folders_continue_POST pCursor

--- a/extensions/script-libraries/dropbox/notes/20238.md
+++ b/extensions/script-libraries/dropbox/notes/20238.md
@@ -1,0 +1,1 @@
+# [20238] Ensure request limit is an integer


### PR DESCRIPTION
Dropbox is expecting the result limit for listing requests to be
an integer, however, the library was sending a string. This patch
ensures the limit is an integer and sends it as one.