### PR TITLE
[[ Bug 20285 ]] Fix crash when getting invalid defaultstack handle

### DIFF
--- a/docs/notes/bugfix-20285.md
+++ b/docs/notes/bugfix-20285.md
@@ -1,0 +1,1 @@
+# Fix crash when dispatching to an object and the defaultStack has been deleted

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1192,7 +1192,7 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int p_handler_type, MCNameRef p_m
 		t_object = ctxt . GetObjectPtr();
 		
 	// Fetch current default stack and target settings
-	MCStackHandle t_old_stack(MCdefaultstackptr->GetHandle());
+	MCStackHandle t_old_stack = MCdefaultstackptr;
 	
 	// Cache the current 'this stack' (used to see if we should switch back
 	// the default stack).

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2203,7 +2203,7 @@ void MCInterfaceProcessToContainer(MCExecContext& ctxt, MCObjectPtr *p_objects, 
 		{
 			if (!p_cut)
 			{
-                MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+                MCStackHandle t_old_defaultstack = MCdefaultstackptr;
                 MCdefaultstackptr = static_cast<MCStack *>(p_dst . object);
 				MCdefaultstackptr -> stopedit();
 
@@ -2983,7 +2983,7 @@ void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p
         
 	// MW-2007-05-01: Reverting this as it causes problems :o(
 	//stackptr -> setflag(True, F_VISIBLE);
-    MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+    MCStackHandle t_old_defaultstack = MCdefaultstackptr;
     Boolean oldtrace = MCtrace;
 	MCtrace = False;
 	if (p_mode >= WM_MODELESS)
@@ -3172,7 +3172,7 @@ void MCInterfaceExecPopupStackByName(MCExecContext& ctxt, MCNameRef p_name, MCPo
 
 void MCInterfaceExecCreateStack(MCExecContext& ctxt, MCObject *p_object, MCStringRef p_new_name, bool p_force_invisible, bool p_with_group)
 {
-	MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+	MCStackHandle t_old_defaultstack = MCdefaultstackptr;
 	Boolean wasvisible = MCtemplatestack->isvisible();
 
 	/* Check that a specified parent stack has a usable name before
@@ -3384,7 +3384,7 @@ void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MC
 
 void MCInterfaceExecClone(MCExecContext& ctxt, MCObject *p_target, MCStringRef p_new_name, bool p_force_invisible)
 {
-    MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+    MCStackHandle t_old_defaultstack = MCdefaultstackptr;
     
 	MCObject *t_object = nil;
 	switch (p_target->gettype())

--- a/engine/src/mblandroidmisc.cpp
+++ b/engine/src/mblandroidmisc.cpp
@@ -472,6 +472,9 @@ public:
 
 void MCAndroidBackPressed()
 {
+    if (!MCdefaultstackptr.IsValid())
+        return;
+    
 	MCMessageEvent *t_event;
 	MCObjectHandle t_handle;
 	t_handle = MCdefaultstackptr->getcurcard()->GetHandle();
@@ -481,6 +484,9 @@ void MCAndroidBackPressed()
 
 void MCAndroidMenuKey()
 {
+    if (!MCdefaultstackptr.IsValid())
+        return;
+    
     MCMessageEvent *t_event;
     MCObjectHandle t_handle;
     t_handle = MCdefaultstackptr->getcurcard()->GetHandle();
@@ -490,6 +496,9 @@ void MCAndroidMenuKey()
 
 void MCAndroidSearchKey()
 {
+    if (!MCdefaultstackptr.IsValid())
+        return;
+    
     //MCLog("MCAndroidSearchKey()", nil);
     MCMessageEvent *t_event;
     MCObjectHandle t_handle;

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2067,7 +2067,7 @@ Exec_stat MCObject::conditionalmessage(uint32_t p_flag, MCNameRef p_message)
 Exec_stat MCObject::dispatch(Handler_type p_type, MCNameRef p_message, MCParameter *p_params)
 {
 	// Fetch current default stack and target settings
-	MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+	MCStackHandle t_old_defaultstack = MCdefaultstackptr;
     MCObjectPartHandle t_old_target = MCtargetptr;
 	
 	// Cache the current 'this stack' (used to see if we should switch back
@@ -2139,7 +2139,7 @@ Exec_stat MCObject::message(MCNameRef mess, MCParameter *paramptr, Boolean chang
 	void *t_deletion_cookie;
 	MCDeletedObjectsOnObjectSuspendDeletion(this, t_deletion_cookie);
 	
-	MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+	MCStackHandle t_old_defaultstack = MCdefaultstackptr;
     MCObjectPartHandle oldtargetptr = MCtargetptr;
 	if (changedefault)
 	{

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -337,7 +337,7 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		MCParameter p1;
 		p1.setvalueref_argument(t_param_name);
         
-        MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+        MCStackHandle t_old_defaultstack = MCdefaultstackptr;
         MCdefaultstackptr = getstack();
         MCObjectPartHandle oldtargetptr(this);
         swap(MCtargetptr, oldtargetptr);
@@ -441,7 +441,7 @@ Exec_stat MCObject::sendsetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		p1.setvalueref_argument(t_param_name);
 		p2.setvalueref_argument(p_value);
 		
-		MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+		MCStackHandle t_old_defaultstack = MCdefaultstackptr;
 		MCdefaultstackptr = getstack();
         MCObjectPartHandle oldtargetptr(this);
         swap(MCtargetptr, oldtargetptr);

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -299,7 +299,7 @@ MCControl *MCSellist::clone(MCObject *target)
 	MCSelnode *t_node = objects;
 	for (uint32_t i = 0; i < t_selobj_count; i++)
 	{
-		t_selobj_handles[i] = t_node->m_ref->GetHandle();
+		t_selobj_handles[i] = t_node->m_ref;
 		t_node = t_node->next();
 	}
 

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -883,7 +883,7 @@ bool MCWidgetBase::DoDispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_
 bool MCWidgetBase::Dispatch(MCNameRef p_event, MCValueRef *x_args, uindex_t p_arg_count, MCValueRef *r_result)
 {
 	MCStack *t_this_stack;
-	MCStackHandle t_old_defaultstack = MCdefaultstackptr->GetHandle();
+	MCStackHandle t_old_defaultstack = MCdefaultstackptr;
 	
 	// Preserve the host ptr we get across the dispatch so that
 	// we definitely return things to the way they were.


### PR DESCRIPTION
This patch is a workaround for a crash where a former defaultStack
has been deleted and it wasn't being checked for validity before
getting the handle. As the target ptr also was being stored and reset
at the same point this patch ensures they are also valid.