### PR TITLE
[[ Bug 20286 ]] Add tool property of image - EXPERIMENT

### DIFF
--- a/engine/src/exec-interface-image.cpp
+++ b/engine/src/exec-interface-image.cpp
@@ -900,3 +900,32 @@ void MCImage::GetMetadataProperty(MCExecContext& ctxt, MCNameRef p_prop, MCExecV
     }
     
 }
+
+void MCImage::GetTool(MCExecContext& ctxt, MCStringRef& r_tool)
+{
+    if (m_tool != T_UNDEFINED)
+    {
+        r_tool = MCSTR("pencil");
+        return;
+    }
+    
+    r_tool = MCValueRetain(kMCEmptyString);
+}
+
+void MCImage::SetTool(MCExecContext& ctxt, MCStringRef p_tool_str)
+{
+    if (MCStringIsEmpty(p_tool_str))
+    {
+        m_tool = T_UNDEFINED;
+        return;
+    }
+    
+    if (MCStringIsEqualToCString(p_tool_str, "pencil", kMCStringOptionCompareCaseless))
+    {
+        m_tool = T_PENCIL;
+        return;
+    }
+    
+    ctxt.LegacyThrow(EE_CHOOSE_BADTOOL);
+}
+

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -104,7 +104,7 @@ MCPropertyInfo MCImage::kProperties[] =
 	DEFINE_RW_OBJ_PROPERTY(P_ANGLE, Int16, MCImage, Angle)
     DEFINE_RW_OBJ_PROPERTY(P_CENTER_RECTANGLE, OptionalRectangle, MCImage, CenterRectangle)
     DEFINE_RO_OBJ_RECORD_PROPERTY(P_METADATA, MCImage, Metadata)
-
+    DEFINE_RW_OBJ_PROPERTY(P_TOOL, OptionalString, MCImage, Tool)
 };
 
 MCObjectPropertyTable MCImage::kPropertyTable =
@@ -147,7 +147,6 @@ MCImage::MCImage()
     
     // MM-2014-07-31: [[ ThreadedRendering ]] Used to ensure the image animate message is only posted from a single thread.
     m_animate_posted = false;
-    
 }
 
 MCImage::MCImage(const MCImage &iref) : MCControl(iref)

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -357,6 +357,9 @@ private:
 	int2 irepeatcount;
 	uint1 resizequality;
 	MCStringRef filename;
+    
+    Tool m_tool = T_UNDEFINED;
+    
 	static int2 magmx;
 	static int2 magmy;
 	static MCRectangle magrect;
@@ -400,7 +403,6 @@ private:
 	bool setdata(void *p_data, uindex_t p_size);
 	
 	void notifyneeds(bool p_deleting);
-	
 
 	static MCPropertyInfo kProperties[];
 	static MCObjectPropertyTable kPropertyTable;
@@ -480,6 +482,11 @@ public:
 	{
 		return resizequalitytoimagefilter(resizequality);
 	}
+
+    Tool gettool(void) const
+    {
+        return m_tool;
+    }
 
 	void setframe(int32_t p_newframe);
 	void advanceframe();
@@ -687,6 +694,9 @@ public:
     void SetCenterRectangle(MCExecContext& ctxt, MCRectangle *p_rectangle);
     void GetCenterRectangle(MCExecContext& ctxt, MCRectangle *&r_rectangle);
     void GetMetadataProperty(MCExecContext& ctxt, MCNameRef p_prop, MCExecValue& r_value);
+    
+    void GetTool(MCExecContext& ctxt, MCStringRef& r_tool);
+    void SetTool(MCExecContext& ctxt, MCStringRef p_tool);
     
     virtual void SetBlendLevel(MCExecContext& ctxt, uinteger_t level);
 	virtual void SetInk(MCExecContext& ctxt, intenum_t ink);

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -288,6 +288,15 @@ Tool MCStack::gettool(MCObject *optr) const
 {
 	if (MCcurtool == T_HELP)
 		return T_HELP;
+    
+    if (optr->gettype() == CT_IMAGE)
+    {
+        Tool t_tool = static_cast<MCImage *>(optr)->gettool();
+        if (t_tool != T_UNDEFINED)
+        {
+            return t_tool;
+        }
+    }
 
 	// MW-2008-01-30: [[ Bug 5749 ]] Recurse up the object tree to see if any
 	//   parent of the object (up to card level) has CANT_SELECT set, if so


### PR DESCRIPTION
This patch is an experiment to see how well a tool property of images
would work.

As posed, it is quite straight-forward, but there are some details to
pin down. For example, when should the image's tool be used? How should
the IDE use it in edit mode - should it?

At the moment tool property of an image can only be 'pencil' and that
overrides any global tool other than 'help'. This means that if an
image has its tool property set in the IDE, in both browse and edit
mode the image is editable.

Also, cursor changes don't currently occur which makes it even more
confusing. (Although this is just an experiment - so I've not poked
too deeply!)