### PR TITLE
[[ Bug 19094 ]] Certain unicode chars render incorrectly on android 7

### DIFF
--- a/docs/notes/bugfix-19094.md
+++ b/docs/notes/bugfix-19094.md
@@ -1,0 +1,1 @@
+# Certain unicode characters render incorrectly on Android 7


### PR DESCRIPTION
It appears that font fallback is no longer supported in the current
version of Skia. So, if harbuzz returns no glyph for a range of text,
shape that range again using a fallback font.