### PR TITLE
[Dictionary] Update bottomPattern

### DIFF
--- a/docs/dictionary/property/bottomPattern.lcdoc
+++ b/docs/dictionary/property/bottomPattern.lcdoc
@@ -43,15 +43,15 @@ the color of the shadowed edge of the <object(glossary)>.
 
 Pattern images can be color or black-and-white.
 
->*Cross-platform note:*  To be used as a pattern on <Mac OS|Mac OS
-> systems>, an <image> must be 128x128 <pixels> or less, and both its
+>*Cross-platform note:*  To be used as a pattern on <Mac OS|Mac OS systems>,
+> an <image> must be 128x128 <pixels> or less, and both its
 > <height> and <width> must be a power of 2. To be used on <Windows> and
 > <Unix|Unix systems>, <height> and <width> must be divisible by 8. To
 > be used as a fully cross-platform pattern, both an image's dimensions
 > should be one of 8, 16, 32, 64, or 128.
 
-The <bottomPattern> of <control(object)|controls> is drawn starting at
-the <control(object)|control's> upper right corner: if the
+The <bottomPattern> of <control(glossary)|controls> is drawn starting at
+the <control(glossary)|control's> upper right corner: if the
 <control(keyword)> is moved, the pattern does not shift.
 
 Setting the <bottomPattern> of an <object(glossary)> to empty allows the
@@ -110,18 +110,18 @@ depending on the <object type>:
 If an object's <bottomPattern> is set, the pattern is shown instead of
 the color specified by the <bottomColor>.
 
-References: group (command), stacks (function), object (glossary),
-property (glossary), audio clip (glossary), Windows (glossary),
-object type (glossary), Mac OS (glossary), keyword (glossary),
-Unix (glossary), video clip (glossary), current stack (glossary),
-effective (keyword), field (keyword), image (keyword), button (keyword),
-card (keyword), scrollbar (keyword), player (keyword), graphic (keyword),
-control (keyword), EPS (object), field (object), stack (object),
-control (object), textStyle (property), pixels (property),
-hiliteBorder (property), threeDHilite (property), patterns (property),
-width (property), topPattern (property), height (property),
-threeD (property), hilitePattern (property), foregroundPattern (property),
-owner (property), shadowPattern (property), bottomColor (property)
+References: group (command), stacks (function), audio clip (glossary),
+control (glossary), current stack (glossary), keyword (glossary),
+Mac OS (glossary), object (glossary), object type (glossary),
+property (glossary), Unix (glossary), video clip (glossary),
+Windows (glossary), button (keyword), card (keyword), control (keyword),
+effective (keyword), field (keyword), graphic (keyword), image (keyword),
+player (keyword), scrollbar (keyword), EPS (object), field (object),
+stack (object), bottomColor (property), foregroundPattern (property),
+height (property), hiliteBorder (property), hilitePattern (property),
+owner (property), patterns (property), pixels (property),
+shadowPattern (property), textStyle (property), threeD (property),
+threeDHilite (property), topPattern (property), width (property)
 
 Tags: ui
 


### PR DESCRIPTION
Fixed broken link in Cross-platform note.
Changed all instances of `control (object)` to `control (glossary)`
Sorted references alphabetically