### PR TITLE
[[ Bug 20240 ]] Fix text selection not contiguous

### DIFF
--- a/docs/notes/bugfix-20240.md
+++ b/docs/notes/bugfix-20240.md
@@ -1,0 +1,1 @@
+# Fix text selection occasionally not being contiguous

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -477,8 +477,12 @@ void MCField::setparagraphs(MCParagraph *newpgptr, uint4 parid, findex_t p_start
         else
             t_lastpgptr = newpgptr -> prev();
 
+        // Ensure the point at which the paragraph will be split is at p_start
         t_insert_paragraph->setselectionindex(p_start, p_start, False, False);
         t_insert_paragraph->split();
+        // Now ensure the selection for the initial paragraph is unset
+        t_insert_paragraph->setselectionindex(PARAGRAPH_MAX_LEN, PARAGRAPH_MAX_LEN, False, False);
+        
         t_insert_paragraph->append(newpgptr);
         // SN-2014-20-06: [[ Bug 12303 ]] Refactoring of the bugfix
         t_insert_paragraph->join(p_preserve_zero_length_styles);


### PR DESCRIPTION
This patch fixes a bug where `MCField::setparagraphs` was calling
`MCParagraph::setselectionindex` to clear the current selection with
field indexes rather than paragraph indexes. Additionally to clear
the selection it should call `setselectionindex` with `PARAGRAPH_MAX_LEN`
as is done elsewhere.

@runrevmark @livecodeali this patch does appear to resolve my reliable recipe but not Panos's which I believe is both different and less dangerous as it only occurs if you do things one normally wouldn't do.

PS this is some confusing code! So... I could be *way* off mark with this fix however I'm really not sure why that api would be called with field indexes nor why it wouldn't do the same thing as when clearing the selection elsewhere...