### PR TITLE
[[ Bug 20308 ]] Fix 64-bit Mach-O section writing

### DIFF
--- a/docs/notes/bugfix-20308.md
+++ b/docs/notes/bugfix-20308.md
@@ -1,0 +1,1 @@
+# Fix iOS 64-bit Mach-O structure

--- a/engine/src/deploy_macosx.cpp
+++ b/engine/src/deploy_macosx.cpp
@@ -1312,7 +1312,7 @@ template<typename T> bool MCDeployToMacOSXMainBody(const MCDeployParameters& p_p
 		t_old_project_offset = t_project_segment -> fileoff;
 		t_project_segment -> filesize = t_project_size;
 		t_project_segment -> vmsize = t_project_size;
-		((section *)(t_project_segment + 1))[0] . size = t_project_size;
+		((typename T::section *)(t_project_segment + 1))[0] . size = t_project_size;
         
 		if (t_payload_segment != nil)
 		{
@@ -1321,7 +1321,7 @@ template<typename T> bool MCDeployToMacOSXMainBody(const MCDeployParameters& p_p
 			t_old_payload_offset = t_payload_segment -> fileoff;
 			t_payload_segment -> filesize = t_payload_size;
 			t_payload_segment -> vmsize = t_payload_size;
-			((section *)(t_payload_segment + 1))[0] . size = t_payload_size;
+			((typename T::section *)(t_payload_segment + 1))[0] . size = t_payload_size;
 			relocate_segment_command<T>(t_project_segment, (t_payload_segment -> fileoff + t_payload_size) - t_old_project_offset, (t_payload_segment -> fileoff + t_payload_size) - t_old_project_offset);
 		}
 		


### PR DESCRIPTION
This patch ensures that section_64 is used when updating the project
section in a 64-bit Mach-O deployment. Previously, section was being
used which resulted in the fields being slightly wrong. The latter has
never affected execution, but has started to affect tools such as
'otool' which are now doing more validation.

Note: This bug is fixed against release-8.1.6, to allow us to do a 8.1.6-gm-2 (Mac only) to fix this issue as there are people unable to submit to the AppStore.