### PR TITLE
[[ Build ]] Prune tags before checking for build dupe

### DIFF
--- a/buildbot.mk
+++ b/buildbot.mk
@@ -182,6 +182,8 @@ dist-tools-commercial:
 # Ensure that the version for which we're trying to build installers
 # hasn't already been tagged.
 dist-tools-version-check:
+	@git tag -l | xargs git tag -d; \
+	@git fetch --tags; \
 	@if git rev-parse refs/tags/$(BUILD_SHORT_VERSION) \
 	        >/dev/null 2>&1 ; then \
 	  echo; \


### PR DESCRIPTION
If a tag is renamed, we need to refresh the tag list before checking
if it has been used for a release before. It is not possible to
use --prune for tags, so we delete them _all_ and refetch.