### PR TITLE
[[ Addons ]] Include addon license array in standalones

### DIFF
--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -385,34 +385,51 @@ static bool MCDeployWriteDefinePrologueSection(const MCDeployParameters& p_param
 
 static bool MCDeployWriteDefineLicenseSection(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)
 {
-	// The edition byte encoding is development/standalone engine pair
-	// specific.
-	unsigned char t_edition;
-	switch(MClicenseparameters . license_class)
-	{
-		case kMCLicenseClassNone:
-			t_edition = 0;
-			break;
-			
-		case kMCLicenseClassCommunity:
-			t_edition = 1;
-			break;
-		
-		case kMCLicenseClassEvaluation:
-		case kMCLicenseClassCommercial:
-			t_edition = 2;
-			break;
-			
-		case kMCLicenseClassProfessionalEvaluation:
-		case kMCLicenseClassProfessional:
-			t_edition = 3;
-			break;
-	}
-	
-	return MCDeployCapsuleDefine(p_capsule,
+	bool t_success = true;
+    
+    IO_handle t_stream_handle;
+    t_stream_handle = nullptr;
+    if (t_success)
+    {
+        t_stream_handle = MCS_fakeopenwrite();
+        t_success = t_stream_handle != nullptr;
+    }
+    
+    if (t_success)
+    {
+        t_success = IO_write_uint1((uint1)MClicenseparameters . license_class, t_stream_handle) == IO_NORMAL;
+    }
+    
+    if (t_success && MClicenseparameters . addons != nullptr)
+    {
+        t_success = IO_write_valueref_new(MClicenseparameters . addons, t_stream_handle) == IO_NORMAL;
+    }
+    
+    //////////
+    
+    void *t_buffer;
+    size_t t_length = 0;
+    t_buffer = nullptr;
+    if (t_success)
+    {
+        t_success = MCS_closetakingbuffer(t_stream_handle, t_buffer, t_length) == IO_NORMAL;
+    }
+    
+    
+    if (t_success)
+    {
+        t_success = MCDeployCapsuleDefine(p_capsule,
 								 kMCCapsuleSectionTypeLicense,
-								 &t_edition,
-								 sizeof(t_edition));
+								 &t_buffer,
+								 uint32_t(t_length));
+    }
+    
+    if (t_buffer != nullptr)
+    {
+        free(t_buffer);
+    }
+    
+    return t_success;
 }
 
 static bool MCDeployWriteDefineBannerSecion(const MCDeployParameters& p_params, MCDeployCapsuleRef p_capsule)

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -2808,6 +2808,37 @@ static MCExternalError MCExternalInterfaceQuery(MCExternalInterfaceQueryTag op, 
 
 MCExternalError MCExternalLicenseCheckEdition(unsigned int p_options, unsigned int p_min_edition)
 {
+    MCAutoStringRef t_key;
+    
+    uint32_t t_index;
+    if (MCCStringFirstIndexOf(s_current_external->GetName(), '.', t_index))
+    {
+        if (!MCStringCreateWithCString(s_current_external->GetName(), &t_key))
+        {
+            return kMCExternalErrorFailed;
+        }
+    }
+    else
+    {
+        if (!MCStringFormat(&t_key, "com.livecode.external.%s", s_current_external->GetName()))
+        {
+            return kMCExternalErrorFailed;
+        }
+    }
+    
+    MCNewAutoNameRef t_key_as_nameref;
+    if (!MCNameCreate(*t_key, &t_key_as_nameref))
+    {
+        return kMCExternalErrorFailed;
+    }
+    
+    MCAutoValueRef t_value;
+    if (MClicenseparameters . addons != nil &&
+        MCArrayFetchValue(MClicenseparameters . addons, false, *t_key_as_nameref, &t_value))
+    {
+        return kMCExternalErrorNone;
+    }
+    
 	unsigned int t_current_edition;
 	switch(MClicenseparameters . license_class)
 	{
@@ -2819,7 +2850,11 @@ MCExternalError MCExternalLicenseCheckEdition(unsigned int p_options, unsigned i
 			t_current_edition = kMCExternalLicenseTypeCommunity;
 			break;
 		
-		case kMCLicenseClassEvaluation:
+        case kMCLicenseClassCommunityPlus:
+            t_current_edition = kMCExternalLicenseTypeCommunityPlus;
+            break;
+            
+        case kMCLicenseClassEvaluation:
 		case kMCLicenseClassCommercial:
 			t_current_edition = kMCExternalLicenseTypeIndy;
 			break;
@@ -2834,7 +2869,8 @@ MCExternalError MCExternalLicenseCheckEdition(unsigned int p_options, unsigned i
 			break;
 	}
 	
-	if (t_current_edition < p_min_edition)
+	if (kMCExternalLicenseTypeNone == p_min_edition ||
+        t_current_edition < p_min_edition)
 	{
 		s_current_external -> SetWasLicensed(false);
 		return kMCExternalErrorUnlicensed;

--- a/engine/src/externalv1.h
+++ b/engine/src/externalv1.h
@@ -303,7 +303,8 @@ enum MCExternalLicenseType
 {
 	kMCExternalLicenseTypeNone = 0,
 	kMCExternalLicenseTypeCommunity = 1000,
-	kMCExternalLicenseTypeIndy = 2000,
+    kMCExternalLicenseTypeCommunityPlus = 1500,
+    kMCExternalLicenseTypeIndy = 2000,
 	kMCExternalLicenseTypeBusiness = 3000,
 };
 

--- a/engine/src/license.h
+++ b/engine/src/license.h
@@ -47,11 +47,12 @@ enum
     kMCLicenseDeployToHTML5 = 1 << 10,
 };
 
-enum
+enum MCLicenseClass
 {
 	kMCLicenseClassNone,
 	kMCLicenseClassCommunity,
-	kMCLicenseClassEvaluation,
+    kMCLicenseClassCommunityPlus,
+    kMCLicenseClassEvaluation,
 	kMCLicenseClassCommercial,
 	kMCLicenseClassProfessionalEvaluation,
 	kMCLicenseClassProfessional,

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1282,9 +1282,11 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
 			
 	case kMCCapsuleSectionTypeLicense:
 	{
-		// Just read the edition byte and ignore it in installer mode.
-		char t_edition_byte;
-		if (IO_read(&t_edition_byte, 1, p_stream) != IO_NORMAL)
+		// Just read the license info and ignore it in installer mode.
+		uint8_t t_class;
+        MCAutoValueRef t_addons;
+        if (IO_read(&t_class, 1, p_stream) != IO_NORMAL ||
+            (p_length > 1 && IO_read_valueref_new(&t_addons, p_stream) != IO_NORMAL))
 		{
 			MCresult -> sets("failed to read license");
 			return false;

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -425,26 +425,22 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
     
     case kMCCapsuleSectionTypeLicense:
     {
-        char t_edition_byte;
-        if (IO_read(&t_edition_byte, 1, p_stream) != IO_NORMAL)
+        uint8_t t_class;
+        MCAutoValueRef t_addons;
+        if (IO_read(&t_class, 1, p_stream) != IO_NORMAL ||
+            (p_length > 1 && IO_read_valueref_new(&t_addons, p_stream) != IO_NORMAL))
         {
             MCresult -> sets("failed to read license");
             return false;
         }
-
-        bool t_success;
-        t_success = true;
         
-        // The edition encoding is engine version / IDE engine version
-        // specific - for now its just a byte with value 0-3.
-        if (t_edition_byte == 1)
-            MClicenseparameters . license_class = kMCLicenseClassCommunity;
-        else if (t_edition_byte == 2)
-            MClicenseparameters . license_class = kMCLicenseClassCommercial;
-        else if (t_edition_byte == 3)
-            MClicenseparameters . license_class = kMCLicenseClassProfessional;
-        else
-            MClicenseparameters . license_class = kMCLicenseClassNone;
+        MClicenseparameters.license_class = (MCLicenseClass)t_class;
+
+        if (t_addons.IsSet())
+        {
+            MCValueAssign(MClicenseparameters . addons, static_cast<MCArrayRef>(*t_addons));
+        }
+        
     }
     break;
 			

--- a/lcidlc/include/LiveCode.h
+++ b/lcidlc/include/LiveCode.h
@@ -426,7 +426,9 @@ enum
 	
 enum
 {
+    kLCLicenseEditionNone = 0,
     kLCLicenseEditionCommunity = 1000,
+    kLCLicenseEditionCommunityPlus = 1500,
     kLCLicenseEditionIndy = 2000,
     kLCLicenseEditionBusiness = 3000,
 };


### PR DESCRIPTION
This patch includes the addon license array in the standalone license
capsule and also adds community plus to the enum.