### PR TITLE
[[ Bug 20310 ]] Check for DIB and DIBV5 clipboard formats

### DIFF
--- a/docs/notes/bugfix-20310.md
+++ b/docs/notes/bugfix-20310.md
@@ -1,0 +1,1 @@
+# Make pasting from MS Paint work

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -1122,8 +1122,13 @@ bool MCClipboard::CopyAsBMP(MCDataRef& r_bmp) const
 	// Copy and decode the BMP file
 	MCAutoDataRef t_bmp;
 	if (!CopyAsData(kMCRawClipboardKnownTypeWinDIBv5, &t_bmp))
-		return false;
-	
+    {
+        if (!CopyAsData(kMCRawClipboardKnownTypeWinDIB, &t_bmp))
+        {
+		    return false;
+	    }
+    }
+
 	MCDataRef t_decoded = m_clipboard->DecodeTransferredBMP(*t_bmp);
 	if (t_decoded == nil)
 		return false;


### PR DESCRIPTION
This patch ensures that both DIB and DIBv5 formats are searched
for when requesting 'image' from the fullClipboardData on Windows.

This fixes an issue with not being able to paste from MS Paint,
which produces the DIB format directly, rather than DIBv5.