### PR TITLE
[[ Bug 9992 ]] Improve export/import snapshot from screen on iOS7+

### DIFF
--- a/docs/notes/bugfix-9992.md
+++ b/docs/notes/bugfix-9992.md
@@ -1,0 +1,5 @@
+# Improve export/import snapshot from screen on iOS
+
+The from screen form of export/import snapshot has been changed
+to use a different API on iOS7+, which allows a greater variety
+of native layers to be captured.

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -617,8 +617,19 @@ static void MCScreenDCDoSnapshot(void *p_env)
 										  -[window bounds].size.height * [[window layer] anchorPoint].y);
 					
 					// Render the layer hierarchy to the current context
-					[[window layer] renderInContext:t_img_context];
-					
+                    if ([window respondsToSelector: @selector(drawViewHierarchyInRect:afterScreenUpdates:)])
+                    {
+                        // This method is supported in iOS7+ and will capture many
+                        // native view's content.
+                        UIGraphicsPushContext(t_img_context);
+                        [window drawViewHierarchyInRect:[window bounds] afterScreenUpdates:YES];
+                        UIGraphicsPopContext();
+                    }
+                    else
+                    {
+                        [[window layer] renderInContext:t_img_context];
+					}
+                    
 					// Restore the context
 					CGContextRestoreGState(t_img_context);
 				}


### PR DESCRIPTION
This patch changes the API used to render the screen when doing a
screen snapshot on iOS7+. It will now use drawViewHierarchyInRect:afterScreenUpdates:
which enables a greater variety of types of UIView to be captured.