### PR TITLE
[[ Bug 20282 ]] Ensure 'the engine folder' returns a LiveCode path

### DIFF
--- a/docs/notes/bugfix-20282.md
+++ b/docs/notes/bugfix-20282.md
@@ -1,0 +1,1 @@
+# Ensure 'the engine folder' returns a LiveCode path on Windows


### PR DESCRIPTION
This patch fixes an issue where 'the engine folder' would return a
native looking path on Windows. The use of MCcmd has been replaced
with a direct query of the executable module's filename.

Note: This fix is pertinent to 8 - a slightly different patch is needed for 9.