### PR TITLE
[[ Bug 20282 ]] Ensure 'the engine folder' returns a LiveCode path (develop)

### DIFF
--- a/docs/notes/bugfix-20282.md
+++ b/docs/notes/bugfix-20282.md
@@ -1,0 +1,1 @@
+# Ensure 'the engine folder' returns a LiveCode path on Windows

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -1945,22 +1945,11 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
         else if (MCNameIsEqualTo(p_type, MCN_engine, kMCCompareCaseless)
                  || MCNameIsEqualTo(p_type, MCN_resources, kMCCompareCaseless))
         {
-            /* MCcmd is in LiveCode format, but this function actuall returns native
-             * paths so we just replicate what GetExecutablePath() does. */
-		    WCHAR* wcFileNameBuf = new WCHAR[MAX_PATH+1];
-		    DWORD dwFileNameLen = GetModuleFileNameW(NULL, wcFileNameBuf, MAX_PATH+1);
-		
-            WCHAR* t_last_slash = wcsrchr(wcFileNameBuf, '\\');
-            if (t_last_slash != nullptr)
-            {
-                *t_last_slash = '\0';
-            }
-            
-		    if (!MCStringCreateWithWStringAndRelease((unichar_t*)wcFileNameBuf, &t_native_path))
-            {
-                delete wcFileNameBuf;
-                return false;
-            }
+            MCSAutoLibraryRef t_self;
+            MCSLibraryCreateWithAddress(reinterpret_cast<void *>(legacy_path_to_nt_path),
+                                        &t_self);
+            MCSLibraryCopyNativePath(*t_self,
+                                     &t_native_path);
 
             t_wasfound = True;
         }

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -1945,12 +1945,24 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
         else if (MCNameIsEqualTo(p_type, MCN_engine, kMCCompareCaseless)
                  || MCNameIsEqualTo(p_type, MCN_resources, kMCCompareCaseless))
         {
-            uindex_t t_last_slash;
+            /* MCcmd is in LiveCode format, but this function actuall returns native
+             * paths so we just replicate what GetExecutablePath() does. */
+		    WCHAR* wcFileNameBuf = new WCHAR[MAX_PATH+1];
+		    DWORD dwFileNameLen = GetModuleFileNameW(NULL, wcFileNameBuf, MAX_PATH+1);
+		
+            WCHAR* t_last_slash = wcsrchr(wcFileNameBuf, '\\');
+            if (t_last_slash != nullptr)
+            {
+                *t_last_slash = '\0';
+            }
             
-            if (!MCStringLastIndexOfChar(MCcmd, '/', UINDEX_MAX, kMCStringOptionCompareExact, t_last_slash))
-                t_last_slash = MCStringGetLength(MCcmd);
-            
-            return MCStringCopySubstring(MCcmd, MCRangeMake(0, t_last_slash), r_folder) ? True : False;
+		    if (!MCStringCreateWithWStringAndRelease((unichar_t*)wcFileNameBuf, &t_native_path))
+            {
+                delete wcFileNameBuf;
+                return false;
+            }
+
+            t_wasfound = True;
         }
         else
         {

--- a/libfoundation/include/system-library.h
+++ b/libfoundation/include/system-library.h
@@ -81,6 +81,13 @@ MCSLibraryCreateWithAddress(void *p_address,
  * static type, this returns the path of the loadable object which the library
  * is linked into. */
 MC_DLLEXPORT bool
+MCSLibraryCopyNativePath(MCSLibraryRef p_library,
+                         MCStringRef& r_path);
+
+/* Copy the full (non-native) path to the specified library. If the library is of
+ * static type, this returns the path of the loadable object which the library
+ * is linked into. */
+MC_DLLEXPORT bool
 MCSLibraryCopyPath(MCSLibraryRef p_library,
                    MCStringRef& r_path);
 

--- a/libfoundation/src/system-library.cpp
+++ b/libfoundation/src/system-library.cpp
@@ -291,6 +291,13 @@ MCSLibraryCreateWithAddress(void *p_address,
 }
 
 MC_DLLEXPORT_DEF bool
+MCSLibraryCopyNativePath(MCSLibraryRef p_library,
+                         MCStringRef& r_path)
+{
+    return __MCSLibraryGetImpl(p_library).CopyNativePath(r_path);
+}
+
+MC_DLLEXPORT_DEF bool
 MCSLibraryCopyPath(MCSLibraryRef p_library,
                    MCStringRef& r_path)
 {


### PR DESCRIPTION
This patch changes the implementation of fetching the engine folder
to be consistent with how 9+ computes MCcmd. In particular, it uses
the filename of the module containing the engine rather than the
global executable module.

Note: This is based on #5881 from develop-8.1 - that should be merged up before merging this PR.