### PR TITLE
[[ Bug 20323 ]] Remove deprecated externals from mergExt

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2017-4-6"
+constant kMergExtVersion = "2017-9-4"
 constant kTSNetVersion = "1.3.1"
 
 local sEngineDir

--- a/docs/notes/bugfix-20323.md
+++ b/docs/notes/bugfix-20323.md
@@ -1,0 +1,11 @@
+# Remove legacy mergExt externals
+
+The following mergExt deprecated externals are no longer included in
+LiveCode.
+
+- mergAES - we have revsecurity based encryption for mobile
+- mergDropbox & mergDropboxSync - these use the now abandoned by Dropbox
+(v1 API). We have a script library available for v2 API.
+- mergSocket - we have sockets in the engine for mobile
+- mergZXing - no longer supportable as the ZXing project no longer
+supports iOS. Use mergAVCam for barcode capture instead.


### PR DESCRIPTION
This patch also adds edition elements to all the mergExt docs.