### PR TITLE
[[ Bug 18955 ]] Fix crash when using file dialogs from browser widget

### DIFF
--- a/docs/notes/bugfix-18955.md
+++ b/docs/notes/bugfix-18955.md
@@ -1,0 +1,1 @@
+# Fix crash when using HTML file input dialog in browser widget

--- a/revbrowser/src/osxbrowser.mm
+++ b/revbrowser/src/osxbrowser.mm
@@ -270,9 +270,6 @@ static NSRect RectToNSRect(NSWindow *p_window, Rect p_rect)
 	}
 }
 
-@end
-@implementation NSObject (WebUIDelegate)
-
 - (void)webView:(WebView *)sender runJavaScriptAlertPanelWithMessage:(NSString *)message
 {
     // Create and display an alert panel
@@ -298,6 +295,8 @@ static NSRect RectToNSRect(NSWindow *p_window, Rect p_rect)
 
 - (void)webView:(WebView *)sender runOpenPanelForFileButtonWithResultListener:(id<WebOpenPanelResultListener>)resultListener
 {
+    NSAutoreleasePool* t_pool = [[NSAutoreleasePool alloc] init];
+    
     // Create an open-file panel that allows a single file to be chosen
     NSOpenPanel* t_dialog = [NSOpenPanel openPanel];
     [t_dialog setCanChooseDirectories:NO];
@@ -323,7 +322,7 @@ static NSRect RectToNSRect(NSWindow *p_window, Rect p_rect)
         [resultListener cancel];
     }
     
-    [t_dialog release];
+    [t_pool release];
 }
 
 @end


### PR DESCRIPTION
This patch fixes a crash when using the HTML file dialog from within
a browser widget or revbrowser.

The crash was caused by releasing an auto-released object, rather than
ensuring it the object was created in an auto-release pool.

The direct category addition to NSObject in revbrowser for the WebUIDelegate
methods have been removed and placed in the adapter class in revbrowser
instead and the necessary code has been replicated in MCWebUIDelegate for the
Mac browser implementation in libbrowser ensuring the two can work
separately.