### PR TITLE
[[ Bug 20321 ]] Truncate custom ask dialog arguments at NUL

### DIFF
--- a/docs/notes/bugfix-20321.md
+++ b/docs/notes/bugfix-20321.md
@@ -1,0 +1,7 @@
+# Fix treatment of NUL containing arguments in ask dialogs
+
+Prior to 7, any arguments passed to LiveCode provided ask dialogs
+(e.g. ask question) containing NUL would be truncated at the NUL. After
+7, any such arguments would cause incorrect calling of the ask dialog.
+The pre-7 behavior has been resurrected, meaning that trailing NUL
+bytes in arguments passed to ask dialogs will be ignored.


### PR DESCRIPTION
This patch resurrects the pre-7 behavior where custom ask dialog
arguments would be truncated at the first NUL.