### PR TITLE
[[ Bug 18526 ]] Enable command key shortcuts in color dialog

### DIFF
--- a/docs/notes/bugfix-18526.md
+++ b/docs/notes/bugfix-18526.md
@@ -1,0 +1,1 @@
+# Allow command key shortcuts to work in color dialog

--- a/engine/src/mac-menu.mm
+++ b/engine/src/mac-menu.mm
@@ -673,11 +673,6 @@ void MCMacPlatformUnlockMenuSelect(void)
 
 - (BOOL)performKeyEquivalent: (NSEvent *)event
 {
-    // SN-2014-12-05: [[ Bug 14019 ]] Forbid any Cmd-key reaction when the target is the colour picker
-    // (that colour picker is modal after all)
-    if ([[[event window] delegate] isKindOfClass: [MCColorPanelDelegate class]])
-        return NO;
-
 	// If the event is not targetted at one of our windows, we just let things
 	// flow as normal.
 	if (![[[event window] delegate] isKindOfClass: [MCWindowDelegate class]])


### PR DESCRIPTION
This patch ensures that the normal flow of command key processing
happens if the color dialog is showing.