### PR TITLE
[[ Bug 20324 ]] Fix Windows drop files conversion

### DIFF
--- a/docs/notes/bugfix-20324.md
+++ b/docs/notes/bugfix-20324.md
@@ -1,0 +1,1 @@
+# Convert dropped file paths correctly on Windows

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -317,7 +317,7 @@ MCStringRef MCWin32RawClipboardCommon::DecodeTransferredFileList(MCDataRef p_dat
     
     // Split the file name list into individual paths
     MCAutoArrayRef t_native_paths;
-    if (!MCStringSplit(*t_decoded, MCSTR("\0"), NULL, kMCStringOptionCompareExact, &t_native_paths))
+    if (!MCStringSplit(*t_decoded, kMCNulString, NULL, kMCStringOptionCompareExact, &t_native_paths))
         return nullptr;
     
     uindex_t npaths = MCArrayGetCount(*t_native_paths);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1949,6 +1949,9 @@ MC_DLLEXPORT extern MCStringRef kMCLineEndString;
 // The default string for '\t'.
 MC_DLLEXPORT extern MCStringRef kMCTabString;
 
+// The default string for '\0'.
+MC_DLLEXPORT extern MCStringRef kMCNulString;
+
 /////////
 
 // Creates an MCStringRef wrapping the given constant c-string. Note that

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -6228,6 +6228,7 @@ MC_DLLEXPORT_DEF MCStringRef kMCMixedString;
 MC_DLLEXPORT_DEF MCStringRef kMCCommaString;
 MC_DLLEXPORT_DEF MCStringRef kMCLineEndString;
 MC_DLLEXPORT_DEF MCStringRef kMCTabString;
+MC_DLLEXPORT_DEF MCStringRef kMCNulString;
 
 bool __MCStringInitialize(void)
 {
@@ -6251,6 +6252,9 @@ bool __MCStringInitialize(void)
     
     if (!MCStringCreateWithNativeChars((const char_t *)"\t", 1, kMCTabString))
 		return false;
+        
+    if (!MCStringCreateWithNativeChars((const char_t *)"\0", 1, kMCNulString))
+		return false;
 
 	return true;
 }
@@ -6272,6 +6276,8 @@ void __MCStringFinalize(void)
     kMCLineEndString = nil;
     MCValueRelease(kMCTabString);
     kMCTabString = nil;
+    MCValueRelease(kMCNulString);
+    kMCNulString = nil;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch adds a kMCNulString foudation constant and uses it when
splitting the drop-files string in the Windows clipboard code.
Previously it was attempting to use MCSTR("\0") which won't work
as MCSTR's must be NUL-terminated.