### PR TITLE
[[ LicenseClass ]] Reuse license class <-> string conversions

### DIFF
--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -801,8 +801,7 @@ void MCIdeDeploy::exec_ctxt(MCExecContext& ctxt)
 
 	// If the banner_class field is set and we are not a trial license, we
 	// override the license class with that specified.
-	uint32_t t_license_class;
-	t_license_class = kMCLicenseClassNone;
+	MCLicenseClass t_license_class = kMCLicenseClassNone;
 	if (MClicenseparameters . license_class == kMCLicenseClassCommercial)
 	{
 		// If we have a commercial license, then we only allow a commercial

--- a/engine/src/deploy.h
+++ b/engine/src/deploy.h
@@ -111,7 +111,7 @@ struct MCDeployParameters
 	
 	// This can be set to commercial or professional trial. In that
 	// case, the standalone will be built in that mode.
-	uint32_t banner_class;
+	MCLicenseClass banner_class;
 	
 	// The timeout for the banner that's displayed before startup.
 	uint32_t banner_timeout;

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -50,6 +50,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "libscript/script.h"
 
+#include "license.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 
 MC_EXEC_DEFINE_EVAL_METHOD(Engine, Version, 1)
@@ -2063,32 +2065,12 @@ void MCEngineEvalSHA1Uuid(MCExecContext& ctxt, MCStringRef p_namespace_id, MCStr
 
 void MCEngineGetEditionType(MCExecContext& ctxt, MCStringRef& r_edition)
 {
-    bool t_success;
-    switch (MClicenseparameters.license_class)
+    if (!MCStringFromLicenseClass(MClicenseparameters.license_class,
+                                     true,
+                                     r_edition))
     {
-        case kMCLicenseClassCommunity:
-            t_success = MCStringCreateWithCString("community", r_edition);
-            break;
-			
-		case kMCLicenseClassEvaluation:
-        case kMCLicenseClassCommercial:
-            t_success = MCStringCreateWithCString("commercial", r_edition);
-            break;
-			
-		case kMCLicenseClassProfessionalEvaluation:
-        case kMCLicenseClassProfessional:
-            t_success = MCStringCreateWithCString("professional", r_edition);
-            break;
-            
-        default:
-            t_success = false;
-            break;
+        ctxt . Throw();
     }
-    
-    if (t_success)
-        return;
-    
-    ctxt . Throw();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/license.h
+++ b/engine/src/license.h
@@ -63,7 +63,7 @@ struct MCLicenseParameters
     MCStringRef license_token;
     MCStringRef license_name;
     MCStringRef license_organization;
-	uint32_t license_class;
+	MCLicenseClass license_class;
 	uint4 license_multiplicity;
 
 	uint4 script_limit;
@@ -78,5 +78,52 @@ struct MCLicenseParameters
 
 extern MCLicenseParameters MClicenseparameters;
 extern Boolean MCenvironmentactive;
+
+static const struct { const char *tag; MCLicenseClass value; } s_class_map[] =
+{
+    { "community", kMCLicenseClassCommunity },
+    { "communityplus", kMCLicenseClassCommunityPlus },
+    { "evaluation", kMCLicenseClassEvaluation },
+    { "commercial", kMCLicenseClassCommercial },
+    { "professional evaluation", kMCLicenseClassProfessionalEvaluation },
+    { "professional", kMCLicenseClassProfessional },
+    { "", kMCLicenseClassNone }
+};
+
+inline bool MCStringToLicenseClass(MCStringRef p_class, MCLicenseClass &r_class)
+{
+    for(uindex_t t_index = 0; t_index < sizeof(s_class_map) / sizeof(s_class_map[0]); ++t_index)
+    {
+        if (MCStringIsEqualToCString(p_class, s_class_map[t_index].tag, kMCCompareCaseless))
+        {
+            r_class = s_class_map[t_index].value;
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+inline bool MCStringFromLicenseClass(MCLicenseClass p_class, bool p_simplified, MCStringRef &r_class)
+{
+    if (p_simplified && p_class == kMCLicenseClassEvaluation)
+    {
+        p_class = kMCLicenseClassCommercial;
+    }
+    else if (p_simplified && p_class == kMCLicenseClassProfessionalEvaluation)
+    {
+        p_class = kMCLicenseClassProfessional;
+    }
+    
+    for(uindex_t t_index = 0; t_index < sizeof(s_class_map) / sizeof(s_class_map[0]); ++t_index)
+    {
+        if (s_class_map[t_index].value == p_class)
+        {
+            return MCStringCreateWithCString(s_class_map[t_index].tag, r_class);
+        }
+    }
+    
+    return false;
+}
 
 #endif

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -295,31 +295,16 @@ void MCStack::sethints()
 		|| t_env == kMCModeEnvironmentTypeInstaller
 		|| t_env == kMCModeEnvironmentTypeServer)
 	{
-		const char *t_edition_name;
-		switch (MClicenseparameters.license_class)
-		{
-		case kMCLicenseClassProfessionalEvaluation:
-		case kMCLicenseClassProfessional:
-			t_edition_name = "business";
-				break;
-		case kMCLicenseClassEvaluation:
-		case kMCLicenseClassCommercial:
-			t_edition_name = "indy";
-			break;
-		case kMCLicenseClassNone:
-		case kMCLicenseClassCommunity:
-		default:
-			t_edition_name = "community";
-			break;
-		}
-
-		if (MCStringCreateMutable(0, &t_app_name))
+        
+        MCAutoStringRef t_edition_name;
+        if (MCStringCreateMutable(0, &t_app_name) &&
+            MCStringFromLicenseClass(MClicenseparameters.license_class, true, &t_edition_name))
 		{
 			bool t_success = true;
 			if (t_env == kMCModeEnvironmentTypeEditor)
-				t_success = MCStringAppendFormat(*t_app_name, "%s%s_%s", MCapplicationstring, t_edition_name, MC_BUILD_ENGINE_SHORT_VERSION);
+				t_success = MCStringAppendFormat(*t_app_name, "%s%@_%s", MCapplicationstring, *t_edition_name, MC_BUILD_ENGINE_SHORT_VERSION);
 			else
-				t_success = MCStringAppendFormat(*t_app_name, "%s%s_%@_%s", MCapplicationstring, t_edition_name, MCModeGetEnvironment(), MC_BUILD_ENGINE_SHORT_VERSION);
+				t_success = MCStringAppendFormat(*t_app_name, "%s%@_%@_%s", MCapplicationstring, *t_edition_name, MCModeGetEnvironment(), MC_BUILD_ENGINE_SHORT_VERSION);
 				
 			if (t_success)
 			{


### PR DESCRIPTION
This patch moves license class to string conversion to inline functions
of license.h to simplify maintenance. It also adds the `communityplus`
`editionType` string.