### PR TITLE
[[ Aggregates ]] Add aggregate support to LCB

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -1182,3 +1182,63 @@ conforms to the following rules:
 
 Examples of foreign handlers which can be considered safe are all the foreign
 handlers which bind to syntax in the LCB standard library.
+
+### Foreign Aggregate Types
+
+C-style aggregates (e.g. structs) can now be accessed from LCB via the new
+aggregate parameterized type. This allows calling foreign functions which has
+arguments taking aggregates by value, or has an aggregate return value.
+
+Aggregate types are foreign types and can be used in C and Obj-C foreign
+handler definitions. They bridge to and from the List type, allowing an
+aggregate's contents to be viewed as a sequence of discrete values.
+
+Aggregate types are defined using a `foreign type` clause and binding string.
+e.g.
+
+    public foreign type NSRect binds to "MCAggregateTypeInfo:qqqq"
+
+The structure of the aggregate is defined by using a sequence of type codes
+after the ':', each type code represents a specific foreign (C) type:
+
+| Char | Type         |
+| ---- | ------------ |
+|  a   | CBool        |
+|  b   | CChar        |
+|  c   | CUChar       |
+|  C   | CSChar       |
+|  d   | CUShort      |
+|  D   | CSShort      |
+|  e   | CUInt        |
+|  E   | CSInt        |
+|  f   | CULong       |
+|  F   | CSLong       |
+|  g   | CULongLong   |
+|  G   | CSLongLong   |
+|  h   | UInt8        |
+|  H   | SInt8        |
+|  i   | UInt16       |
+|  I   | SInt16       |
+|  j   | UInt32       |
+|  J   | SInt32       |
+|  k   | UInt64       |
+|  K   | SInt64       |
+|  l   | UIntPtr      |
+|  L   | SIntPtr      | 
+|  m   | UIntSize     |  
+|  M   | SIntSize     |  
+|  n   | Float        |
+|  N   | Double       |
+|  o   | LCUInt       |
+|  O   | LCSInt       |
+|  p   | NaturalUInt  |
+|  P   | NaturalSInt  |
+|  q   | NaturalFloat |
+|  r   | Pointer      |
+
+When importing an aggregate to a List, each field in the aggregate is also
+bridged, except for Pointer types which are left as Pointer. When exporting
+an aggregate from a List, each element is bridged to the target field type.
+
+*Note*: Any foreign type binding to an aggregate must be public otherwise the
+type will not work correctly.

--- a/docs/lcb/notes/20325.md
+++ b/docs/lcb/notes/20325.md
@@ -1,0 +1,10 @@
+# LiveCode Builder Language
+
+## Foreign aggregate support (experimental)
+
+* It is now possible to bind to C functions and Obj-C methods which take
+  simple structs by-value, or return a struct by-value. For full details see
+  the 'Foreign Aggregate Types' section of the language reference.
+
+# [20325] Add support for foreign aggregates
+

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -772,7 +772,7 @@ bool MCExtensionConvertToScriptType(MCExecContext& ctxt, MCValueRef& x_value)
 
             // Import the type
             MCValueRef t_imported;
-            if (!t_desc->doimport(MCForeignValueGetContentsPtr(x_value), false, t_imported))
+            if (!t_desc->doimport(t_desc, MCForeignValueGetContentsPtr(x_value), false, t_imported))
                 return false;
 
             // Recursively convert to a script type

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -232,7 +232,7 @@ bool MCProperListGetNumberAtIndex(MCProperListRef p_list, uindex_t p_index, MCNu
         if (MCTypeInfoIsForeign(t_typeinfo))
         {
             const MCForeignTypeDescriptor* t_desc = MCForeignTypeInfoGetDescriptor(t_typeinfo);
-            if (t_desc->doimport(MCForeignValueGetContentsPtr(t_value), false, (MCValueRef&)r_number))
+            if (t_desc->doimport(t_desc, MCForeignValueGetContentsPtr(t_value), false, (MCValueRef&)r_number))
                 return true;
         }
     }

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1753,6 +1753,7 @@ MC_DLLEXPORT bool MCBuiltinTypeInfoCreate(MCValueTypeCode typecode, MCTypeInfoRe
 enum MCForeignPrimitiveType
 {
     kMCForeignPrimitiveTypeVoid,
+    kMCForeignPrimitiveTypeBool,
     kMCForeignPrimitiveTypeUInt8,
     kMCForeignPrimitiveTypeSInt8,
     kMCForeignPrimitiveTypeUInt16,

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1776,13 +1776,13 @@ struct MCForeignTypeDescriptor
     bool (*initialize)(void *contents);
     void (*finalize)(void *contents);
     bool (*defined)(void *contents);
-    bool (*move)(void *source, void *target);
-    bool (*copy)(void *source, void *target);
-    bool (*equal)(void *left, void *right, bool& r_equal);
-    bool (*hash)(void *contents, hash_t& r_hash);
-    bool (*doimport)(void *contents, bool release, MCValueRef& r_value);
-    bool (*doexport)(MCValueRef value, bool release, void *contents);
-	bool (*describe)(void *contents, MCStringRef & r_desc);
+    bool (*move)(const MCForeignTypeDescriptor* desc, void *source, void *target);
+    bool (*copy)(const MCForeignTypeDescriptor* desc, void *source, void *target);
+    bool (*equal)(const MCForeignTypeDescriptor* desc, void *left, void *right, bool& r_equal);
+    bool (*hash)(const MCForeignTypeDescriptor* desc, void *contents, hash_t& r_hash);
+    bool (*doimport)(const MCForeignTypeDescriptor* desc, void *contents, bool release, MCValueRef& r_value);
+    bool (*doexport)(const MCForeignTypeDescriptor* desc, MCValueRef value, bool release, void *contents);
+	bool (*describe)(const MCForeignTypeDescriptor* desc, void *contents, MCStringRef & r_desc);
     
     /* The promotedtype typeinfo is the type to which this type must be promoted
      * when passed through variadic parameters. The 'promote' method does the

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1750,7 +1750,7 @@ MC_DLLEXPORT bool MCBuiltinTypeInfoCreate(MCValueTypeCode typecode, MCTypeInfoRe
 
 //////////
 
-enum MCForeignPrimitiveType
+enum MCForeignPrimitiveType : uint8_t
 {
     kMCForeignPrimitiveTypeVoid,
     kMCForeignPrimitiveTypeBool,

--- a/libfoundation/src/foundation-foreign.cpp
+++ b/libfoundation/src/foundation-foreign.cpp
@@ -236,7 +236,7 @@ struct integral_type_desc_t: public numeric_type_desc_t<CType> {
 
 struct bool_type_desc_t {
     using c_type = bool;
-    static constexpr auto primitive_type = kMCForeignPrimitiveTypeUInt8;
+    static constexpr auto primitive_type = kMCForeignPrimitiveTypeBool;
     static constexpr MCTypeInfoRef& base_type_info() { return kMCNullTypeInfo; }
     static constexpr MCTypeInfoRef& type_info() { return kMCBoolTypeInfo; }
     static constexpr auto is_optional = false;

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -259,7 +259,7 @@ static void __exec_closure(ffi_cif *cif, void *ret, void **args, void *user_data
             {
                 if (t_descriptor -> bridgetype != kMCNullTypeInfo)
                 {
-                    if (!t_descriptor -> doimport(args[t_arg_index], false, t_value_args[t_arg_index]))
+                    if (!t_descriptor -> doimport(t_descriptor, args[t_arg_index], false, t_value_args[t_arg_index]))
                         goto cleanup;
                 }
                 else
@@ -287,7 +287,7 @@ static void __exec_closure(ffi_cif *cif, void *ret, void **args, void *user_data
         {
             const MCForeignTypeDescriptor *t_descriptor;
             t_descriptor = MCForeignTypeInfoGetDescriptor(t_resolved_return_type . type);
-            if (!t_descriptor -> doexport(t_value_result, false, ret))
+            if (!t_descriptor -> doexport(t_descriptor, t_value_result, false, ret))
                 goto cleanup;
         }
         else

--- a/libfoundation/src/foundation-objc-dummy.cpp
+++ b/libfoundation/src/foundation-objc-dummy.cpp
@@ -103,60 +103,60 @@ objc_id_finalize(void *contents)
 }
 
 static bool
-objc_id_move(void *from, void *to)
+objc_id_move(const MCForeignTypeDescriptor*, void *from, void *to)
 {
     *static_cast<void **>(to) = *static_cast<void **>(from);
     return true;
 }
 
 static bool
-objc_id_copy(void *from, void *to)
+objc_id_copy(const MCForeignTypeDescriptor*, void *from, void *to)
 {
     *static_cast<void **>(to) = *static_cast<void **>(from);
     return true;
 }
 
 static bool
-objc_id_equal(void *from, void *to, bool& r_equal)
+objc_id_equal(const MCForeignTypeDescriptor*, void *from, void *to, bool& r_equal)
 {
     r_equal = *static_cast<void **>(to) == *static_cast<void **>(to);
     return true;
 }
 
 static bool
-objc_id_hash(void *value, hash_t& r_hash)
+objc_id_hash(const MCForeignTypeDescriptor*, void *value, hash_t& r_hash)
 {
     r_hash = MCHashPointer(*static_cast<void **>(value));
     return true;
 }
 
 static bool
-objc_id_describe(void *value, MCStringRef& r_string)
+objc_id_describe(const MCForeignTypeDescriptor*, void *value, MCStringRef& r_string)
 {
     return MCStringFormat(r_string, "<objc id %p>", *static_cast<void **>(value));
 }
 
 static bool
-objc_retained_id_describe(void *value, MCStringRef& r_string)
+objc_retained_id_describe(const MCForeignTypeDescriptor*, void *value, MCStringRef& r_string)
 {
     return MCStringFormat(r_string, "<objc retained id %p>", *static_cast<void **>(value));
 }
 
 static bool
-objc_autoreleased_id_describe(void *value, MCStringRef& r_string)
+objc_autoreleased_id_describe(const MCForeignTypeDescriptor*, void *value, MCStringRef& r_string)
 {
     return MCStringFormat(r_string, "<objc autoreleased id %p>", *static_cast<void **>(value));
 }
 
 static bool
-objc_id_import(void *contents, bool p_release, MCValueRef& r_value)
+objc_id_import(const MCForeignTypeDescriptor*, void *contents, bool p_release, MCValueRef& r_value)
 {
     MCAssert(!p_release);
     return MCObjcObjectCreateWithId(*(void **)contents, (MCObjcObjectRef&)r_value);
 }
 
 static bool
-objc_id_export(MCValueRef p_value, bool p_release, void *contents)
+objc_id_export(const MCForeignTypeDescriptor*, MCValueRef p_value, bool p_release, void *contents)
 {
     MCAssert(!p_release);
     *(void **)contents = MCObjcObjectGetId((MCObjcObjectRef)p_value);
@@ -164,14 +164,14 @@ objc_id_export(MCValueRef p_value, bool p_release, void *contents)
 }
 
 static bool
-objc_retained_id_import(void *contents, bool p_release, MCValueRef& r_value)
+objc_retained_id_import(const MCForeignTypeDescriptor*, void *contents, bool p_release, MCValueRef& r_value)
 {
     MCAssert(!p_release);
     return MCObjcObjectCreateWithRetainedId(*(void **)contents, (MCObjcObjectRef&)r_value);
 }
 
 static bool
-objc_retained_id_export(MCValueRef p_value, bool p_release, void *contents)
+objc_retained_id_export(const MCForeignTypeDescriptor*, MCValueRef p_value, bool p_release, void *contents)
 {
     MCAssert(!p_release);
     *(void **)contents = MCObjcObjectGetRetainedId((MCObjcObjectRef)p_value);
@@ -179,14 +179,14 @@ objc_retained_id_export(MCValueRef p_value, bool p_release, void *contents)
 }
 
 static bool
-objc_autoreleased_id_import(void *contents, bool p_release, MCValueRef& r_value)
+objc_autoreleased_id_import(const MCForeignTypeDescriptor*, void *contents, bool p_release, MCValueRef& r_value)
 {
     MCAssert(!p_release);
     return MCObjcObjectCreateWithAutoreleasedId(*(void **)contents, (MCObjcObjectRef&)r_value);
 }
 
 static bool
-objc_autoreleased_id_export(MCValueRef p_value, bool p_release, void *contents)
+objc_autoreleased_id_export(const MCForeignTypeDescriptor*, MCValueRef p_value, bool p_release, void *contents)
 {
     MCAssert(!p_release);
     *(void **)contents = MCObjcObjectGetAutoreleasedId((MCObjcObjectRef)p_value);

--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -105,60 +105,60 @@ objc_id_finalize(void *contents)
 }
 
 static bool
-objc_id_move(void *from, void *to)
+objc_id_move(const MCForeignTypeDescriptor* desc, void *from, void *to)
 {
     *static_cast<void **>(to) = *static_cast<void **>(from);
     return true;
 }
 
 static bool
-objc_id_copy(void *from, void *to)
+objc_id_copy(const MCForeignTypeDescriptor* desc, void *from, void *to)
 {
     *static_cast<void **>(to) = *static_cast<void **>(from);
     return true;
 }
 
 static bool
-objc_id_equal(void *from, void *to, bool& r_equal)
+objc_id_equal(const MCForeignTypeDescriptor* desc, void *from, void *to, bool& r_equal)
 {
     r_equal = *static_cast<void **>(to) == *static_cast<void **>(to);
     return true;
 }
 
 static bool
-objc_id_hash(void *value, hash_t& r_hash)
+objc_id_hash(const MCForeignTypeDescriptor* desc, void *value, hash_t& r_hash)
 {
     r_hash = MCHashPointer(*static_cast<void **>(value));
     return true;
 }
 
 static bool
-objc_id_describe(void *value, MCStringRef& r_string)
+objc_id_describe(const MCForeignTypeDescriptor* desc, void *value, MCStringRef& r_string)
 {
     return MCStringFormat(r_string, "<objc id %p>", *static_cast<void **>(value));
 }
 
 static bool
-objc_retained_id_describe(void *value, MCStringRef& r_string)
+objc_retained_id_describe(const MCForeignTypeDescriptor* desc, void *value, MCStringRef& r_string)
 {
     return MCStringFormat(r_string, "<objc retained id %p>", *static_cast<void **>(value));
 }
 
 static bool
-objc_autoreleased_id_describe(void *value, MCStringRef& r_string)
+objc_autoreleased_id_describe(const MCForeignTypeDescriptor* desc, void *value, MCStringRef& r_string)
 {
     return MCStringFormat(r_string, "<objc autoreleased id %p>", *static_cast<void **>(value));
 }
 
 static bool
-objc_id_import(void *contents, bool p_release, MCValueRef& r_value)
+objc_id_import(const MCForeignTypeDescriptor* desc, void *contents, bool p_release, MCValueRef& r_value)
 {
     MCAssert(!p_release);
     return MCObjcObjectCreateWithId(*(void **)contents, (MCObjcObjectRef&)r_value);
 }
 
 static bool
-objc_id_export(MCValueRef p_value, bool p_release, void *contents)
+objc_id_export(const MCForeignTypeDescriptor* desc, MCValueRef p_value, bool p_release, void *contents)
 {
     MCAssert(!p_release);
     *(void **)contents = MCObjcObjectGetId((MCObjcObjectRef)p_value);
@@ -166,14 +166,14 @@ objc_id_export(MCValueRef p_value, bool p_release, void *contents)
 }
 
 static bool
-objc_retained_id_import(void *contents, bool p_release, MCValueRef& r_value)
+objc_retained_id_import(const MCForeignTypeDescriptor* desc, void *contents, bool p_release, MCValueRef& r_value)
 {
     MCAssert(!p_release);
     return MCObjcObjectCreateWithRetainedId(*(void **)contents, (MCObjcObjectRef&)r_value);
 }
 
 static bool
-objc_retained_id_export(MCValueRef p_value, bool p_release, void *contents)
+objc_retained_id_export(const MCForeignTypeDescriptor* desc, MCValueRef p_value, bool p_release, void *contents)
 {
     MCAssert(!p_release);
     *(void **)contents = MCObjcObjectGetRetainedId((MCObjcObjectRef)p_value);
@@ -181,14 +181,14 @@ objc_retained_id_export(MCValueRef p_value, bool p_release, void *contents)
 }
 
 static bool
-objc_autoreleased_id_import(void *contents, bool p_release, MCValueRef& r_value)
+objc_autoreleased_id_import(const MCForeignTypeDescriptor* desc, void *contents, bool p_release, MCValueRef& r_value)
 {
     MCAssert(!p_release);
     return MCObjcObjectCreateWithAutoreleasedId(*(void **)contents, (MCObjcObjectRef&)r_value);
 }
 
 static bool
-objc_autoreleased_id_export(MCValueRef p_value, bool p_release, void *contents)
+objc_autoreleased_id_export(const MCForeignTypeDescriptor* desc, MCValueRef p_value, bool p_release, void *contents)
 {
     MCAssert(!p_release);
     *(void **)contents = MCObjcObjectGetAutoreleasedId((MCObjcObjectRef)p_value);

--- a/libfoundation/src/foundation-proper-list.cpp
+++ b/libfoundation/src/foundation-proper-list.cpp
@@ -89,7 +89,8 @@ bool MCProperListCreateWithForeignValues(MCTypeInfoRef p_typeinfo, const void *p
         MCAutoValueRef t_value;
         if (t_descriptor->doimport != nil)
         {
-            if (!t_descriptor->doimport((void *)p_values,
+            if (!t_descriptor->doimport(t_descriptor,
+                                        (void *)p_values,
                                         false,
                                         &t_value))
             {

--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -551,6 +551,7 @@ static ffi_type *__map_primitive_type(MCForeignPrimitiveType p_type)
     {
         case kMCForeignPrimitiveTypeVoid:
             return &ffi_type_void;
+        case kMCForeignPrimitiveTypeBool:
         case kMCForeignPrimitiveTypeUInt8:
             return &ffi_type_uint8;
         case kMCForeignPrimitiveTypeSInt8:

--- a/libfoundation/test/test_foreign.cpp
+++ b/libfoundation/test/test_foreign.cpp
@@ -95,7 +95,7 @@ void check_export_raw(MCTypeInfoRef p_type_info, bool (*p_bridge)(W, U&), T p_va
     const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(p_type_info);
     EXPECT_TRUE(t_desc->doexport != nullptr);
     T t_exported_value;
-    EXPECT_TRUE(t_desc->doexport(*t_bridge_value, false, &t_exported_value));
+    EXPECT_TRUE(t_desc->doexport(t_desc, *t_bridge_value, false, &t_exported_value));
     EXPECT_EQ(t_exported_value, p_value);
 }
 
@@ -108,7 +108,7 @@ void check_integral_raw_export_overflow(MCTypeInfoRef p_type_info, MCTypeInfoRef
     EXPECT_TRUE(t_desc->doexport != nullptr);
     MCAutoForeignValueRef t_boxed_value;
     T t_exported_value = 0;
-    EXPECT_FALSE(t_desc->doexport(*t_bridge_value, false, &t_exported_value));
+    EXPECT_FALSE(t_desc->doexport(t_desc, *t_bridge_value, false, &t_exported_value));
     if (t_exported_value != 0)
     {
         MCAutoErrorRef t_error;
@@ -125,7 +125,7 @@ void check_import_raw(MCTypeInfoRef p_type_info, bool (*p_bridge)(W, U&), T p_va
     const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(p_type_info);
     EXPECT_TRUE(t_desc->doimport != nullptr);
     MCAutoValueRef t_imported_value;
-    EXPECT_TRUE(t_desc->doimport(&p_value, false, &t_imported_value));
+    EXPECT_TRUE(t_desc->doimport(t_desc, &p_value, false, &t_imported_value));
     if (t_imported_value.IsSet())
         EXPECT_TRUE(MCValueIsEqualTo(*t_imported_value, *t_bridge_value));
 }
@@ -136,7 +136,7 @@ void check_integral_raw_import_overflow(MCTypeInfoRef p_type_info, MCTypeInfoRef
     const MCForeignTypeDescriptor *t_desc = MCForeignTypeInfoGetDescriptor(p_type_info);
     EXPECT_TRUE(t_desc->doimport != nullptr);
     MCAutoValueRef t_imported_value;
-    EXPECT_FALSE(t_desc->doimport(&p_value, false, &t_imported_value));
+    EXPECT_FALSE(t_desc->doimport(t_desc, &p_value, false, &t_imported_value));
     if (!t_imported_value.IsSet())
     {
         MCAutoErrorRef t_error;

--- a/libscript/src/module-foreign.cpp
+++ b/libscript/src/module-foreign.cpp
@@ -71,7 +71,7 @@ static bool __cbuffer_defined(void *contents)
     return *(void **)contents != nil;
 }
 
-static bool __cbuffer_move(void *from, void *to)
+static bool __cbuffer_move(const MCForeignTypeDescriptor*, void *from, void *to)
 {
     *(void **)to = *(void **)from;
     return true;
@@ -79,7 +79,7 @@ static bool __cbuffer_move(void *from, void *to)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static bool __cstring_copy(void *from, void *to)
+static bool __cstring_copy(const MCForeignTypeDescriptor*, void *from, void *to)
 {
     if (*(void **)from == nil)
     {
@@ -103,7 +103,7 @@ static bool __cstring_copy(void *from, void *to)
     return true;
 }
 
-static bool __cstring_equal(void *left, void *right, bool& r_equal)
+static bool __cstring_equal(const MCForeignTypeDescriptor*, void *left, void *right, bool& r_equal)
 {
     if (*(void **)left == nil || *(void **)right == nil)
 		r_equal = (left == right);
@@ -112,7 +112,7 @@ static bool __cstring_equal(void *left, void *right, bool& r_equal)
 	return true;
 }
 
-static bool __cstring_hash(void *value, hash_t& r_hash)
+static bool __cstring_hash(const MCForeignTypeDescriptor*, void *value, hash_t& r_hash)
 {
     if (*(void **)value == nil)
     {
@@ -125,7 +125,7 @@ static bool __cstring_hash(void *value, hash_t& r_hash)
     return true;
 }
 
-static bool __nativecstring_import(void *contents, bool release, MCValueRef& r_value)
+static bool __nativecstring_import(const MCForeignTypeDescriptor*, void *contents, bool release, MCValueRef& r_value)
 {
     if (release)
         return MCStringCreateWithCStringAndRelease(*(char **)contents, (MCStringRef&)r_value);
@@ -133,7 +133,7 @@ static bool __nativecstring_import(void *contents, bool release, MCValueRef& r_v
     return MCStringCreateWithCString(*(const char **)contents, (MCStringRef&)r_value);
 }
 
-static bool __nativecstring_export(MCValueRef value, bool release, void *contents)
+static bool __nativecstring_export(const MCForeignTypeDescriptor*, MCValueRef value, bool release, void *contents)
 {
 	if (!MCForeignEvalStringNonNull ((MCStringRef) value))
 		return false;
@@ -162,7 +162,8 @@ __wstring_len (const unichar_t *value)
 }
 
 static bool
-__wstring_copy (void *from,
+__wstring_copy (const MCForeignTypeDescriptor*,
+                void *from,
                 void *to)
 {
 	if (nil == *(void **) from)
@@ -189,7 +190,8 @@ __wstring_copy (void *from,
 }
 
 static bool
-__wstring_equal (void *left,
+__wstring_equal (const MCForeignTypeDescriptor*,
+                 void *left,
                  void *right,
                  bool & r_equal)
 {
@@ -212,7 +214,8 @@ __wstring_equal (void *left,
 }
 
 static bool
-__wstring_hash (void *value,
+__wstring_hash (const MCForeignTypeDescriptor*,
+                void *value,
                 hash_t & r_hash)
 {
 	if (nil == *(void **)value)
@@ -227,7 +230,8 @@ __wstring_hash (void *value,
 }
 
 static bool
-__wstring_import (void *contents,
+__wstring_import (const MCForeignTypeDescriptor*,
+                  void *contents,
                   bool release,
                   MCValueRef & r_value)
 {
@@ -240,7 +244,8 @@ __wstring_import (void *contents,
 }
 
 static bool
-__wstring_export (MCValueRef value,
+__wstring_export (const MCForeignTypeDescriptor*,
+                  MCValueRef value,
                   bool release,
                   void *contents)
 {
@@ -262,9 +267,10 @@ __wstring_export (MCValueRef value,
 ////////////////////////////////////////////////////////////////////////////////
 
 static bool
-__utf8string_import (void *contents,
-				  bool release,
-				  MCValueRef & r_value)
+__utf8string_import (const MCForeignTypeDescriptor*,
+                     void *contents,
+                     bool release,
+                     MCValueRef & r_value)
 {
 	char *t_utf8string;
 	t_utf8string = *(char **) contents;
@@ -276,9 +282,10 @@ __utf8string_import (void *contents,
 }
 
 static bool
-__utf8string_export (MCValueRef value,
-				  bool release,
-				  void *contents)
+__utf8string_export (const MCForeignTypeDescriptor*,
+                     MCValueRef value,
+                     bool release,
+                     void *contents)
 {
 	if (!MCForeignEvalStringNonNull ((MCStringRef) value))
 		return false;

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -944,7 +944,8 @@ MCScriptExecuteContext::ConvertToResolvedType(MCValueRef p_value,
         // Import the contents of the foreign value as its bridge type. Note
         // that not all types can be imported (i.e there is no bridging type)
 		if (t_from_desc->doimport == nil ||
-            !t_from_desc->doimport(MCForeignValueGetContentsPtr(p_value),
+            !t_from_desc->doimport(t_from_desc,
+                                   MCForeignValueGetContentsPtr(p_value),
 								   false,
 								   r_new_value))
 		{
@@ -1089,7 +1090,8 @@ MCScriptExecuteContext::UnboxingConvert(MCValueRef p_value,
             // If the two foreign types are the same, copy the contents
             if (t_slot_desc == t_from_desc)
             {
-                if (!t_slot_desc->copy(MCForeignValueGetContentsPtr(p_value),
+                if (!t_slot_desc->copy(t_slot_desc,
+                                       MCForeignValueGetContentsPtr(p_value),
                                        x_slot_ptr))
                 {
                     Rethrow();
@@ -1104,8 +1106,8 @@ MCScriptExecuteContext::UnboxingConvert(MCValueRef p_value,
                 MCAssert(t_slot_desc->bridgetype == t_from_desc->bridgetype);
                 
                 MCAutoValueRef t_bridged_value;
-                if (!t_from_desc->doimport(MCForeignValueGetContentsPtr(p_value), false, &t_bridged_value) ||
-                    !t_slot_desc->doexport(*t_bridged_value, false, x_slot_ptr))
+                if (!t_from_desc->doimport(t_from_desc, MCForeignValueGetContentsPtr(p_value), false, &t_bridged_value) ||
+                    !t_slot_desc->doexport(t_slot_desc, *t_bridged_value, false, x_slot_ptr))
                 {
                     Rethrow();
                     return false;
@@ -1124,7 +1126,8 @@ MCScriptExecuteContext::UnboxingConvert(MCValueRef p_value,
 					return false;
 				}
 			}
-			else if (!t_slot_desc->doexport(p_value,
+			else if (!t_slot_desc->doexport(t_slot_desc,
+                                            p_value,
 											false,
 											x_slot_ptr))
 			{
@@ -1144,7 +1147,8 @@ MCScriptExecuteContext::UnboxingConvert(MCValueRef p_value,
             t_resolved_from_type.type != p_slot_type.type)
         {
             MCValueRef t_bridged_value;
-            if (!t_from_desc->doimport(MCForeignValueGetContentsPtr(p_value),
+            if (!t_from_desc->doimport(t_from_desc,
+                                       MCForeignValueGetContentsPtr(p_value),
                                        false,
                                        t_bridged_value))
             {

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -750,43 +750,75 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                 MCScriptForeignType *t_type;
                 t_type = static_cast<MCScriptForeignType *>(self -> types[i]);
                 
-                bool t_is_builtin = false;
-                void *t_symbol = nullptr;
-                integer_t t_ordinal = 0;
-                if (self->builtins != nullptr &&
-                    MCTypeConvertStringToLongInteger(t_type->binding, t_ordinal))
+                uindex_t t_offset = 0;
+                if (!MCStringFirstIndexOfChar(t_type->binding, ':', 0, kMCStringOptionCompareExact, t_offset))
                 {
-                    t_symbol = self->builtins[t_ordinal];
-                    t_is_builtin = true;
-                }
-                else
-                {
-                    t_symbol = MCSLibraryLookupSymbol(MCScriptGetLibrary(),
-                                                      t_type->binding);
-                    t_is_builtin = false;
-                }
-                
-                if (t_symbol == nullptr)
-                {
-                    MCErrorThrowGenericWithMessage(MCSTR("%{name} not usable - unable to resolve foreign type '%{type}'"),
-												   "name", self -> name,
-                                                   "type", t_type -> binding,
-                                                   nil);
-					goto error_cleanup;
-                }
+                    bool t_is_builtin = false;
+                    void *t_symbol = nullptr;
+                    integer_t t_ordinal = 0;
+                    if (self->builtins != nullptr &&
+                        MCTypeConvertStringToLongInteger(t_type->binding, t_ordinal))
+                    {
+                        t_symbol = self->builtins[t_ordinal];
+                        t_is_builtin = true;
+                    }
+                    else
+                    {
+                        t_symbol = MCSLibraryLookupSymbol(MCScriptGetLibrary(),
+                                                          t_type->binding);
+                        t_is_builtin = false;
+                    }
+                    
+                    if (t_symbol == nullptr)
+                    {
+                        MCErrorThrowGenericWithMessage(MCSTR("%{name} not usable - unable to resolve foreign type '%{type}'"),
+                                                       "name", self -> name,
+                                                       "type", t_type -> binding,
+                                                       nil);
+                        goto error_cleanup;
+                    }
 
-                /* The symbol is a function that returns a type info reference. */
-                if (t_is_builtin)
-                {
-                    MCTypeInfoRef t_typeinfo_bare;
-                    void (*t_type_func_builtin)(void*rv, void**av) = (void(*)(void*, void**))t_symbol;
-                    t_type_func_builtin(&t_typeinfo_bare, nullptr);
-                    t_typeinfo = t_typeinfo_bare;
+                    /* The symbol is a function that returns a type info reference. */
+                    if (t_is_builtin)
+                    {
+                        MCTypeInfoRef t_typeinfo_bare;
+                        void (*t_type_func_builtin)(void*rv, void**av) = (void(*)(void*, void**))t_symbol;
+                        t_type_func_builtin(&t_typeinfo_bare, nullptr);
+                        t_typeinfo = t_typeinfo_bare;
+                    }
+                    else
+                    {
+                        MCTypeInfoRef (*t_type_func)(void) = (MCTypeInfoRef (*)(void)) t_symbol;
+                        t_typeinfo = t_type_func();
+                    }
                 }
                 else
                 {
-                    MCTypeInfoRef (*t_type_func)(void) = (MCTypeInfoRef (*)(void)) t_symbol;
-                    t_typeinfo = t_type_func();
+                    MCAutoStringRef t_type_func, t_args;
+                    if (!MCStringDivideAtChar(t_type->binding, ':', kMCStringOptionCompareExact, &t_type_func, &t_args))
+                    {
+                        goto error_cleanup;
+                    }
+                    
+                    void *t_symbol =
+                            MCSLibraryLookupSymbol(MCScriptGetLibrary(),
+                                                   *t_type_func);
+                    if (t_symbol == nullptr)
+                    {
+                        MCErrorThrowGenericWithMessage(MCSTR("%{name} not usable - unable to resolve foreign type constructor '%{type}'"),
+                                                       "name", self -> name,
+                                                       "type", *t_type_func,
+                                                       nil);
+                        goto error_cleanup;
+                    }
+                    
+                    bool (*t_type_constructor)(MCStringRef p_binding, MCTypeInfoRef& r_typeinfo) =
+                            (bool(*)(MCStringRef, MCTypeInfoRef&))t_symbol;
+                    
+                    if (!t_type_constructor(*t_args, &t_typeinfo))
+                    {
+                        goto error_cleanup;
+                    }
                 }
             }
             break;

--- a/tests/lcb/vm/foreign-aggregate.lcb
+++ b/tests/lcb/vm/foreign-aggregate.lcb
@@ -1,0 +1,29 @@
+module __VMTEST.foreign_aggregate
+
+use com.livecode.foreign
+
+public foreign type AggregateAll binds to "MCAggregateTypeInfo:abcCdDeEfFgGhHiIjJkKlLmMnNoOpPq"
+constant kAggregateAll is \
+[ true, \
+  0, 0x7f, -0x7f, 0x7fff, -0x7fff, 0x7fffffff, -0x7fffffff, 0x7fffffff, -0x7fffffff, 0x7fffffff, -0x7fffffff, \
+  0x7f, -0x7f, 0x7fff, -0x7fff, 0x7fffffff, -0x7fffffff, 0x7fffffff, -0x7fffffff, \
+  0x7fffffff, -0x7fffffff, 0x7fffffff, -0x7fffffff, \
+  3.125, 3.14159647, \
+  0x7fffffff, -0x7fffffff, \
+  0x7fffffff, -0x7fffffff, \
+  3.14159 ]
+
+public handler TestForeignAggregate_Roundtrip()
+	variable tAggregate as AggregateAll
+	put kAggregateAll into tAggregate
+
+	variable tList as List
+	put tAggregate into tList
+
+	variable i as Integer
+	repeat with i from 1 up to the number of elements in kAggregateAll
+		test "aggregate type code " & char i of "abcCdDeEfFgGhHiIjJkKlLmMnNoOpPq" & " roundtrips" when tList[i] is kAggregateAll[i]
+	end repeat
+end handler
+
+end module

--- a/tests/lcb/vm/foreign-invoke.lcb
+++ b/tests/lcb/vm/foreign-invoke.lcb
@@ -51,8 +51,44 @@ public handler TestForeignInvoke_Varargs()
       free(tOutputBuffer)
    end unsafe
    test "sprintf works with no variadic arguments" when tString1 is "no formats"
-   test diagnostic tString2
    test "sprintf works with variadic arguments" when tString2 is "1000 1000000000 1000000000000000 3.5 7.5"
 end handler
+
+--------
+
+public foreign type NSRect binds to "MCAggregateTypeInfo:qqqq"
+__safe foreign handler NSContainsRect(in aRect as NSRect, in bRect as NSRect) returns CBool binds to "<builtin>"
+
+public foreign type RECT binds to "MCAggregateTypeInfo:JJJJ"
+public foreign type POINT binds to "MCAggregateTypeInfo:JJ"
+__safe foreign handler PtInRect(inout pLPRC as RECT, in pPoint as POINT) returns CBool binds to "user32>PtInRect!stdcall"
+
+public handler TestForeignInvoke_AggregateByValue()
+   if the operating system is in [ "mac", "ios" ] then
+      test "aggregate by value works (NSContainsRect)" when NSContainsRect([10, 10, 200, 200], [15, 15, 100, 100])
+   end if
+   if the operating system is in [ "linux", "android" ] then
+      -- TODO
+   end if
+   if the operating system is in [ "windows" ] then
+      variable tRect as RECT
+      put [10, 10, 200, 200] into tRect
+      test "aggregate by value works (PtInRect)" when PtInRect(tRect, [15, 15])
+   end if
+end handler
+
+--------
+
+public foreign type ldiv_t binds to "MCAggregateTypeInfo:FF"
+
+__safe foreign handler ldiv(in pNumer as CSLong, in pDenom as CSLong) returns ldiv_t binds to "<builtin>"
+
+public handler TestForeignInvoke_AggregateReturnValue()
+   variable tResult as List
+   put ldiv(10000000, 314159) into tResult
+   test "aggregate return value of ldiv is correct" when tResult[1] * 314159 + tResult[2] is 10000000
+end handler
+
+--------
 
 end module


### PR DESCRIPTION
This patch contains an implementation of aggregates (e.g. structs) in LCB.

It uses a parameterized typeinfo to allow an aggregate to be defined by a sequence of fields. The aggregate type bridges to/from a list type.

This seems to work as long as the aggregate type is 'public' - non-public types suffer from issues with checking the types at runtime... i.e. the problem with alias vs. named typeinfos which we really need to resolve.

This approach at least gives us the ability to pass and return 'flat' (aggregates which don't use pointers to other aggregates) structs to and from functions. Indeed, by using appropriate 'out' and 'inout' modes, we can also handle functions which take a pointer to struct, or mutate a pointer to a struct (although immense care is needed here!).