### PR TITLE
[[ Bug 20328 ]] Fix memory leak in typeinfo deallocation

### DIFF
--- a/libfoundation/src/foundation-typeinfo.cpp
+++ b/libfoundation/src/foundation-typeinfo.cpp
@@ -1187,6 +1187,7 @@ void __MCTypeInfoDestroy(__MCTypeInfo *self)
         MCValueRelease(self -> foreign . descriptor . basetype);
         MCValueRelease(self -> foreign . descriptor . bridgetype);
         MCMemoryDeleteArray(self -> foreign . descriptor . layout);
+        MCValueRelease(self->foreign.descriptor.promotedtype);
     }
     else if (t_ext_typecode == kMCValueTypeCodeRecord)
     {


### PR DESCRIPTION
This patch ensures that the promotedtype field of a foreign
typeinfo is released on dealloc of the typeinfo.