### PR TITLE
[[ Bug 20315 ]] Throw edition does not support password error

### DIFF
--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -48,6 +48,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "exec-interface.h"
 #include "osspec.h"
 #include "stackfileformat.h"
+#include "mcerror.h"
 
 //////////
 
@@ -2156,16 +2157,28 @@ void MCStack::SetTextStyle(MCExecContext& ctxt, const MCInterfaceTextStyle& p_st
     MCRedrawDirtyScreen();
 }
 
-void MCStack::GetPassword(MCExecContext& ctxt, MCDataRef& r_value)
+void MCStack::GetPassword(MCExecContext& ctxt, MCValueRef& r_value)
 {
 	r_value = MCValueRetain(kMCEmptyData);
 }
 
-void MCStack::GetKey(MCExecContext& ctxt, bool& r_value)
+void MCStack::SetPassword(MCExecContext &ctxt, MCValueRef p_password)
+{
+    MCeerror->add(EE_STACK_PASSWORD_NOT_SUPPORTED, 0, 0);
+    ctxt . Throw();
+}
+
+void MCStack::GetKey(MCExecContext& ctxt, MCValueRef& r_value)
 {
     // OK-2010-02-11: [[Bug 8610]] - Passkey property more useful if it returns
     //   whether or not the script is available.
-    r_value = iskeyed();
+    r_value = MCValueRetain(iskeyed() ? kMCTrue : kMCFalse);
+}
+
+void MCStack::SetKey(MCExecContext &ctxt, MCValueRef p_password)
+{
+    MCeerror->add(EE_STACK_PASSWORD_NOT_SUPPORTED, 0, 0);
+    ctxt . Throw();
 }
 
 // SN-2014-06-25: [[ IgnoreMouseEvents ]] Setter and getter for the P_IGNORE_MOUSE_EVENTS property

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2737,6 +2737,9 @@ enum Exec_errors
     
     // {EE-0896} graphic : too many points
     EE_GRAPHIC_TOOMANYPOINTS,
+
+    // {EE-0897} stack: password protecting stacks not supported in this edition
+    EE_STACK_PASSWORD_NOT_SUPPORTED,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -190,8 +190,8 @@ MCPropertyInfo MCStack::kProperties[] =
    	// IM-2013-09-23: [[ FullscreenMode ]] Add stack fullscreenMode property
     DEFINE_RW_OBJ_ENUM_PROPERTY(P_FULLSCREENMODE, InterfaceStackFullscreenMode, MCStack, FullscreenMode)
     
-    DEFINE_RO_OBJ_PROPERTY(P_KEY, Bool, MCStack, Key)
-    DEFINE_RO_OBJ_PROPERTY(P_PASSWORD, BinaryString, MCStack, Password)
+    DEFINE_RW_OBJ_PROPERTY(P_KEY, Any, MCStack, Key)
+    DEFINE_RW_OBJ_PROPERTY(P_PASSWORD, Any, MCStack, Password)
     
     // IM-2014-01-07: [[ StackScale ]] Add stack scalefactor property
     DEFINE_RW_OBJ_PROPERTY(P_SCALE_FACTOR, Double, MCStack, ScaleFactor)

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -1232,8 +1232,10 @@ public:
 	void GetCompositorCacheLimit(MCExecContext& ctxt, uinteger_t*& p_size);
 	void SetCompositorCacheLimit(MCExecContext& ctxt, uinteger_t* p_size);
 
-	void GetPassword(MCExecContext& ctxt, MCDataRef& r_value);
-    void GetKey(MCExecContext& ctxt, bool& r_value);
+	void GetPassword(MCExecContext& ctxt, MCValueRef& r_value);
+    void SetPassword(MCExecContext &ctxt, MCValueRef p_password);
+    void GetKey(MCExecContext& ctxt, MCValueRef& r_value);
+    void SetKey(MCExecContext &ctxt, MCValueRef p_password);
     
     // SN-2014-06-25: [[ IgnoreMouseEvents ]] Setter and getter added
     void SetIgnoreMouseEvents(MCExecContext &ctxt, bool p_ignore);

--- a/tests/lcs/core/engine/password.livecodescript
+++ b/tests/lcs/core/engine/password.livecodescript
@@ -30,10 +30,10 @@ on TestPassword
    TestAssert "stack initial passKey true", the passKey of stack "foo"
    
    TestAssertThrow "can't set password in community", \ 
-      "SetPasswordOnStack", the long id of me, "EE_OBJECT_SETNOPROP"
+      "SetPasswordOnStack", the long id of me, "EE_STACK_PASSWORD_NOT_SUPPORTED"
    
    TestAssertThrow "can't set passKey in community", \
-      "SetPasskeyOnStack", the long id of me, "EE_OBJECT_SETNOPROP"
+      "SetPasskeyOnStack", the long id of me, "EE_STACK_PASSWORD_NOT_SUPPORTED"
    
    delete stack "foo"
 end TestPassword


### PR DESCRIPTION
This patch adds an error for editions that do not support password
protection and throws. Previously community threw a less informative
no property error.