### PR TITLE
[[ Bug 20329 ]] Add natural int and float types

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -456,6 +456,10 @@ There are the standard machine types (defined in the foreign module):
  - Int64/SInt64 and UInt64 map to 64-bit integers
  - IntSize/SIntSize and UIntSize map to the integer size needed to hold a memory size
  - IntPtr/SIntPtr and UIntPtr map to the integer size needed to hold a pointer
+ - NaturalSInt and NaturalUInt map to 32-bit integers on 32-bit processors and
+   64-bit integers on 64-bit processors
+ - NaturalFloat maps to the 32-bit float type on 32-bit processors and the 64-bit
+   float (double) type on 64-bit processors
 
 There are the standard C primitive types (defined in the foreign module)
 

--- a/docs/lcb/notes/feature-natural_ints_float.md
+++ b/docs/lcb/notes/feature-natural_ints_float.md
@@ -1,0 +1,13 @@
+---
+version: 9.0.0-dp-9
+---
+# LiveCode Builder Standard Library
+## Foreign function interface
+
+* Natural integer types NaturalSInt and NaturalUInt have been added to the 
+  foreign module. These map to 32-bit or 64-bit integers, depending on the bitness
+  of the processor.
+
+* A natural float type NaturalFloat has been added to the foreign module. This
+  maps to float on 32-bit processors and double on 64-bit processors.
+

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1644,6 +1644,13 @@ MC_DLLEXPORT extern MCTypeInfoRef kMCSIntPtrTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignUIntPtrTypeInfo(void) ATTRIBUTE_PURE;
 MC_DLLEXPORT MCTypeInfoRef MCForeignSIntPtrTypeInfo(void) ATTRIBUTE_PURE;
 
+MC_DLLEXPORT extern MCTypeInfoRef kMCNaturalUIntTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCNaturalSIntTypeInfo;
+MC_DLLEXPORT extern MCTypeInfoRef kMCNaturalFloatTypeInfo;
+MC_DLLEXPORT MCTypeInfoRef MCForeignNaturalUIntTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignNaturalSIntTypeInfo(void) ATTRIBUTE_PURE;
+MC_DLLEXPORT MCTypeInfoRef MCForeignNaturalFloatTypeInfo(void) ATTRIBUTE_PURE;
+
 MC_DLLEXPORT extern MCTypeInfoRef kMCCBoolTypeInfo;
 MC_DLLEXPORT MCTypeInfoRef MCForeignCBoolTypeInfo(void) ATTRIBUTE_PURE;
 

--- a/libfoundation/test/test_foreign.cpp
+++ b/libfoundation/test/test_foreign.cpp
@@ -279,6 +279,15 @@ TEST(foreign, Double)
     test_numeric<double>(kMCDoubleTypeInfo, DBL_MIN, DBL_MAX, MCHashDouble, "<foreign double %lg>", MCNumberCreateWithReal);
 }
 
+TEST(foreign, NaturalFloat)
+{
+#ifdef __32_BIT__
+    test_numeric<float>(kMCNaturalFloatTypeInfo, FLT_MIN, FLT_MAX, MCHashDouble, "<foreign natural float %lg>", MCNumberCreateWithReal);
+#else
+    test_numeric<double>(kMCNaturalFloatTypeInfo, DBL_MIN, DBL_MAX, MCHashDouble, "<foreign natural float %lg>", MCNumberCreateWithReal);
+#endif
+}
+
 /* Integral Type Tests */
 
 template<typename T>
@@ -400,6 +409,9 @@ TEST_INTEGRAL(UIntSize, size_t, "unsigned size %zu")
 TEST_INTEGRAL(SIntSize, ssize_t, "signed size %zd")
 TEST_INTEGRAL(UIntPtr, uintptr_t, "unsigned intptr %zu")
 TEST_INTEGRAL(SIntPtr, intptr_t, "signed intptr %zd")
+
+TEST_INTEGRAL(NaturalUInt, uintptr_t, "natural unsigned integer %zu")
+TEST_INTEGRAL(NaturalSInt, intptr_t, "natural signed integer %zd")
 
 TEST_INTEGRAL(CChar, char, "c char '%c'");
 TEST_INTEGRAL(CUChar, unsigned char, "c unsigned char %u")

--- a/libscript/src/foreign.lcb
+++ b/libscript/src/foreign.lcb
@@ -51,6 +51,10 @@ public foreign type SIntPtr binds to "MCForeignSIntPtrTypeInfo"
 
 public type IntPtr is SIntPtr
 
+public foreign type NaturalUInt binds to "MCForeignNaturalUIntTypeInfo"
+public foreign type NaturalSInt binds to "MCForeignNaturalSIntTypeInfo"
+public foreign type NaturalFloat binds to "MCForeignNaturalFloatTypeInfo"
+
 ----------------------------------------------------------------
 -- C types
 ----------------------------------------------------------------


### PR DESCRIPTION
This patch adds 'natural' int and float types. These types are the
same width as the natural bit width of the processor.