### PR TITLE
[[Bug 20335]] Mac folder dialog missing "add folder" button

### DIFF
--- a/docs/notes/bugfix-20335.md
+++ b/docs/notes/bugfix-20335.md
@@ -1,0 +1,1 @@
+# Mac folder dialog missing "add folder" button

--- a/engine/src/mac-dialog.mm
+++ b/engine/src/mac-dialog.mm
@@ -630,6 +630,9 @@ void MCPlatformBeginFolderOrFileDialog(MCPlatformFileDialogKind p_kind, MCPlatfo
         [t_panel setCanChooseFiles: NO];
         [t_panel setCanChooseDirectories: YES];
         [t_panel setAllowsMultipleSelection: NO];
+        
+        // MM-2012-03-01: [[ BUG 10046]] Make sure the "new folder" button is enabled for folder dialogs
+        [t_panel setCanCreateDirectories: YES];
     }
     
     if ([t_panel respondsToSelector:@selector(isAccessoryViewDisclosed)])


### PR DESCRIPTION
Commit 93b3d28 introduced a regression where the "add folder" button was removed from the folder dialog.
This issue was originally fixed 3/1/12 for bug 10046.