### PR TITLE
[[ Bug 20349 ]] Fix crash deleting the focused object

### DIFF
--- a/docs/notes/bugfix-20349.md
+++ b/docs/notes/bugfix-20349.md
@@ -1,0 +1,1 @@
+# Fix crash when deleting the focused object

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -47,7 +47,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "exec.h"
 
-MCControl *MCControl::focused;
+MCControlHandle MCControl::focused;
 int2 MCControl::defaultmargin = 4;
 int2 MCControl::xoffset;
 int2 MCControl::yoffset;
@@ -126,8 +126,8 @@ MCControl::MCControl(const MCControl &cref) : MCObject(cref)
 
 MCControl::~MCControl()
 {
-	if (focused == this)
-		focused = NULL;
+	if (focused.IsBoundTo(this))
+		focused = nullptr;
     
 	MCscreen->stopmove(this, False);
 
@@ -155,9 +155,10 @@ void MCControl::open()
 void MCControl::close()
 {
 	// MW-2008-01-09: [[ Bug 5739 ]] Changing group layer cancels mousedown
-	if (opened == 1)
-		if (focused == this)
-			focused = NULL;
+	if (opened == 1 && focused.IsBoundTo(this))
+    {
+        focused = nullptr;
+    }
 	MCObject::close();
 }
 
@@ -263,7 +264,7 @@ Boolean MCControl::mfocus(int2 x, int2 y)
     
 	if (is || state & CS_MFOCUSED)
 	{
-		if (focused == this || getstack() -> gettool(this) == T_POINTER)
+		if (focused.IsBoundTo(this) || getstack() -> gettool(this) == T_POINTER)
 		{
 			if (MCdispatcher -> isdragtarget())
 				message_with_args(MCM_drag_move, x, y);
@@ -300,7 +301,7 @@ Boolean MCControl::mfocus(int2 x, int2 y)
 
 void MCControl::munfocus()
 {
-	if (focused == this)
+	if (focused.IsBoundTo(this))
 	{
 		if (state & CS_MFOCUSED)
 		{
@@ -1358,8 +1359,11 @@ void MCControl::newmessage()
 
 void MCControl::enter()
 {
-	if (focused != NULL && focused != this)
-		leave();
+    if (focused.IsValid() && !focused.IsBoundTo(this))
+    {
+    	leave();
+    }
+    
 	if (MCdispatcher -> isdragtarget())
 	{
 		MCdragaction = DRAG_ACTION_NONE;
@@ -1392,27 +1396,33 @@ void MCControl::enter()
 
 void MCControl::leave()
 {
-	MCControl *oldfocused = focused;
+	MCControlHandle oldfocused = focused;
 	if (MCdispatcher -> isdragtarget())
 	{
 		// MW-2013-08-08: [[ Bug 10655 ]] If oldfocused is a field and has dragText set,
 		//   then make sure we unset it (otherwise the caret will continue moving around
 		//   on mouseMove).
-		if (oldfocused->gettype() == CT_FIELD
+		if (oldfocused.IsValid())
+        {
+            if (oldfocused->gettype() == CT_FIELD
 		        && oldfocused -> getstate(CS_DRAG_TEXT))
-		{
-			MCField *fptr = (MCField *)oldfocused;
-			fptr->removecursor();
-			getstack()->clearibeam();
-			oldfocused->state &= ~(CS_DRAG_TEXT | CS_IBEAM);
-		}
-		oldfocused->message(MCM_drag_leave);
+            {
+                MCField *fptr = oldfocused.GetAs<MCField>();
+                fptr->removecursor();
+                getstack()->clearibeam();
+                oldfocused->state &= ~(CS_DRAG_TEXT | CS_IBEAM);
+            }
+            oldfocused->message(MCM_drag_leave);
+        }
 		MCdragaction = DRAG_ACTION_NONE;
 		MCdragdest = nil;
 	}
-	else
+	else if (oldfocused.IsValid())
+    {
 		oldfocused->message(MCM_mouse_leave);
-	focused = NULL;
+    }
+    
+    focused = nullptr;
 }
 
 Boolean MCControl::sbfocus(int2 x, int2 y, MCScrollbar *hsb, MCScrollbar *vsb)

--- a/engine/src/exec-interface-control.cpp
+++ b/engine/src/exec-interface-control.cpp
@@ -274,7 +274,7 @@ void MCControl::SetToolTip(MCExecContext& ctxt, MCStringRef p_tooltip)
 	
 	MCValueAssign(tooltip, p_tooltip);
 	
-	if (focused == this)
+	if (focused.IsBoundTo(this))
 		MCtooltip->settip(tooltip);
 }
 

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -446,7 +446,7 @@ void MCField::setparagraphs(MCParagraph *newpgptr, uint4 parid, findex_t p_start
 
         uint4 oldstate = state;
         bool t_refocus;
-        if (focused == this)
+        if (focused.IsBoundTo(this))
             t_refocus = true;
         else
             t_refocus = false;

--- a/engine/src/ifile.cpp
+++ b/engine/src/ifile.cpp
@@ -347,7 +347,7 @@ void MCImage::reopen(bool p_newfile, bool p_lock_size)
 		return;
 	uint4 oldstate = state & (CS_NO_MESSAGES | CS_SELECTED
 	                          | CS_MFOCUSED | CS_KFOCUSED);
-	MCControl *oldfocused = focused;
+	MCControlHandle oldfocused = focused;
 
 	state &= ~CS_SELECTED;
 	uint2 opencount = opened;
@@ -380,7 +380,7 @@ void MCImage::reopen(bool p_newfile, bool p_lock_size)
 
 	state |= oldstate;
 
-	if (oldfocused == this)
+	if (oldfocused.IsBoundTo(this))
 		focused = this;
 
 	// MW-2011-08-17: [[ Layers ]] Notify of the change in rect and invalidate.

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -94,7 +94,7 @@ protected:
 	static int2 defaultmargin;
 	static int2 xoffset;
 	static int2 yoffset;
-	static MCControl *focused;
+	static MCControlHandle focused;
 	static double aspect;
 
 	static MCPropertyInfo kProperties[];
@@ -265,7 +265,11 @@ public:
 
 	static MCControl *getfocused()
 	{
-		return focused;
+        if (focused.IsValid())
+        {
+            return focused;
+        }
+        return nullptr;
 	}
 
 	uint32_t getstyle()

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -1049,8 +1049,8 @@ void MCWidget::SetFocused(bool p_setting)
 {
     if (p_setting)
         focused = this;
-    else if (focused == this)
-        focused = nil;
+    else if (focused.IsBoundTo(this))
+        focused = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch changes `MCControl::focused` to a `MCControlHandle` so we
can check it is valid before use.

Should I rebase this to develop-8.1