### PR TITLE
[20357] Ensure a points list does not contain -32768,-32768 for empty line

### DIFF
--- a/docs/notes/bugfix-20357.md
+++ b/docs/notes/bugfix-20357.md
@@ -1,0 +1,1 @@
+# Ensure the points list is displayed correctly, without showning -32768,-32768 for empty line

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1441,13 +1441,14 @@ static bool MCPropertyFormatList(Formatter p_format,
     if (!MCListCreateMutable(p_delimiter, &t_list))
         return false;
 
-    for (uindex_t i = 0; i < p_count; ++i)
-    {
-        MCAutoStringRef t_formatted;
+	for (uindex_t i = 0; i < p_count; ++i)
+	{
+		MCAutoStringRef t_formatted;
 		if (!p_format(p_list[i], &t_formatted))
-            return false;
+			return false;
 		if (!MCListAppend(*t_list, *t_formatted))
-			return false;	}
+			return false;
+	}
 
     return MCListCopyAsString(*t_list, r_string);
 }

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -1432,6 +1432,7 @@ static bool MCPropertyFormatList(Formatter p_format,
                                  Element *p_list,
                                  uindex_t p_count,
                                  char_t p_delimiter,
+								 bool p_is_point_list,
                                  MCStringRef &r_string)
 {
     if (p_count == 0)
@@ -1446,9 +1447,16 @@ static bool MCPropertyFormatList(Formatter p_format,
         MCAutoStringRef t_formatted;
         if (!p_format(p_list[i], &t_formatted))
             return false;
-        if (!MCListAppend(*t_list, *t_formatted))
-            return false;
-    }
+		
+		if (p_is_point_list && ((MCPoint*)p_list)[i].x == MININT2 && ((MCPoint*)p_list)[i].y == MININT2)
+		{
+			if (!MCListAppend(*t_list, kMCEmptyString))
+				return false;
+		}
+		else
+			if (!MCListAppend(*t_list, *t_formatted))
+				return false;
+	}
 
     return MCListCopyAsString(*t_list, r_string);
 }
@@ -1457,26 +1465,26 @@ static bool MCPropertyFormatUIntList(uinteger_t *p_list, uindex_t p_count, char_
 {
     auto t_format =
         [](uinteger_t& x, MCStringRef& s) { return MCStringFormat(s, "%d", x); };
-    return MCPropertyFormatList(t_format, p_list, p_count, p_delimiter, r_string);
+    return MCPropertyFormatList(t_format, p_list, p_count, p_delimiter, false, r_string);
 }
 
 static bool MCPropertyFormatDoubleList(double *p_list, uindex_t p_count, char_t p_delimiter, MCStringRef& r_string)
 {
     auto t_format =
         [](double& x, MCStringRef& s) { return MCStringFormat(s, "%f", x); };
-    return MCPropertyFormatList(t_format, p_list, p_count, p_delimiter, r_string);
+    return MCPropertyFormatList(t_format, p_list, p_count, p_delimiter, false, r_string);
 }
 
 static bool MCPropertyFormatStringList(MCStringRef *p_list, uindex_t p_count, char_t p_delimiter, MCStringRef& r_string)
 {
-    return MCPropertyFormatList(MCStringCopy, p_list, p_count, p_delimiter, r_string);
+    return MCPropertyFormatList(MCStringCopy, p_list, p_count, p_delimiter, false, r_string);
 }
 
 static bool MCPropertyFormatPointList(MCPoint *p_list, uindex_t p_count, char_t p_delimiter, MCStringRef& r_string)
 {
     auto t_format =
-        [](MCPoint& p, MCStringRef& s) { return MCStringFormat(s, "%d,%d", p.x, p.y); };
-    return MCPropertyFormatList(t_format, p_list, p_count, p_delimiter, r_string);
+        [](MCPoint& p, MCStringRef& s) {return MCStringFormat(s, "%d,%d", p.x, p.y); };
+    return MCPropertyFormatList(t_format, p_list, p_count, p_delimiter, true, r_string);
 }
 
 static bool MCPropertyParseLooseUIntList(MCStringRef p_input, char_t p_delimiter, uindex_t& r_count, uinteger_t*& r_list)

--- a/tests/lcs/core/graphics/points.livecodescript
+++ b/tests/lcs/core/graphics/points.livecodescript
@@ -1,0 +1,34 @@
+script "CoreGraphicsPoints"
+
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+on TestPolygonPoints
+ local tPoints, tA, tB
+ put "69,226" & CR & "40,257" & CR & "56,285" into tA
+ put "40,272" & CR & "71,226" & CR & "93,250" into tB
+ 
+ create graphic "myGraphic"
+ -- CRs in a points list are used to separate different subpolygons
+ set the points of graphic "myGraphic" to tA & CR & CR & CR & CR & tB
+ put the points of graphic "myGraphic" into tPoints
+ -- We should only get one empty line
+ TestAssert "point list with multiple CRs", tPoints is tA & CR & CR & tB
+ delete graphic "myGraphic"
+end TestPolygonPoints
+


### PR DESCRIPTION
In commit https://github.com/livecode/livecode/commit/c8c271fdabf77eeae7c38b65ac97984cb568133e, the function `MCPropertyFormatPointList` was refactored, and no longer replaced `(MININT2,MININT2)` with an empty line.

This patch ensures this is no longer the case