### PR TITLE
[[ Bug 20363 ]] Always add DIB format to clipboard for images

### DIFF
--- a/docs/notes/bugfix-20363.md
+++ b/docs/notes/bugfix-20363.md
@@ -1,0 +1,1 @@
+# Update DIB format when image placed on Windows clipboard

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -921,79 +921,76 @@ bool MCWin32RawClipboardItem::AddRepresentation(MCStringRef p_type, MCDataRef p_
         MCWin32RawClipboardCommon::CopyAtomForType(p_type) == MCWin32RawClipboardCommon::CopyAtomForType(MCSTR("GIF")) ||
         MCWin32RawClipboardCommon::CopyAtomForType(p_type) == MCWin32RawClipboardCommon::CopyAtomForType(MCSTR("JFIF")))
     {
-        if (!HasRepresentation(MCSTR("CF_DIBV5")))
+        MCAutoDataRef t_data;
+
+	    IO_handle t_stream = 
+                MCS_fakeopen((const char *)MCDataGetBytePtr(p_bytes), MCDataGetLength(p_bytes));
+        if (t_stream == nullptr)
         {
-            MCAutoDataRef t_data;
+            return false;
+        }
 
-	        IO_handle t_stream = 
-                    MCS_fakeopen((const char *)MCDataGetBytePtr(p_bytes), MCDataGetLength(p_bytes));
-            if (t_stream == nullptr)
-            {
-                return false;
-            }
-
-            MCBitmapFrame *t_frames = nullptr;
-            uindex_t t_frame_count = 0;
-            if (!MCImageDecode(t_stream, t_frames, t_frame_count))
-            {
-                MCS_close(t_stream);
-                return false;
-            }
-
+        MCBitmapFrame *t_frames = nullptr;
+        uindex_t t_frame_count = 0;
+        if (!MCImageDecode(t_stream, t_frames, t_frame_count))
+        {
             MCS_close(t_stream);
+            return false;
+        }
 
-            MCImageBitmap *t_bitmap = t_frames[0].image;
-            size_t t_stride = t_bitmap->width * 4;
+        MCS_close(t_stream);
 
-            size_t t_dib_size = sizeof(BITMAPV5HEADER) + t_bitmap->height * t_stride;
-            void *t_dib = malloc(t_dib_size);
-            if (t_dib == nullptr)
-            {
-                MCImageFreeFrames(t_frames, t_frame_count);
-                return false;
-            }
-            
-	        BITMAPV5HEADER *t_header = (BITMAPV5HEADER*)t_dib;
-	        MCMemoryClear(t_header, sizeof(BITMAPV5HEADER));
-	        t_header -> bV5Size = sizeof(BITMAPV5HEADER);
-	        t_header -> bV5Width = t_bitmap->width;
-	        t_header -> bV5Height = t_bitmap->height;
-	        t_header -> bV5Planes = 1;
-	        t_header -> bV5BitCount = 32;
-	        t_header -> bV5Compression = BI_RGB;
-	        t_header -> bV5SizeImage = 0;
-	        t_header -> bV5XPelsPerMeter = 0;
-	        t_header -> bV5YPelsPerMeter = 0;
-	        t_header -> bV5ClrUsed = 0;
-	        t_header -> bV5ClrImportant = 0;
-	        t_header -> bV5AlphaMask = 0xFF000000;
-	        t_header -> bV5RedMask =   0x00FF0000;
-	        t_header -> bV5GreenMask = 0x0000FF00;
-	        t_header -> bV5BlueMask =  0x000000FF;
-	        t_header -> bV5CSType = LCS_WINDOWS_COLOR_SPACE;
-            
-	        uint8_t *t_dst_ptr = (uint8_t*)t_dib + sizeof(BITMAPV5HEADER);
-	        uint8_t *t_src_ptr = (uint8_t*)t_bitmap->data + (t_bitmap->height - 1) * t_bitmap->stride;
+        MCImageBitmap *t_bitmap = t_frames[0].image;
+        size_t t_stride = t_bitmap->width * 4;
 
-	        for (uindex_t y = 0; y < t_bitmap->height; y++)
-	        {
-		        MCMemoryCopy(t_dst_ptr, t_src_ptr, t_stride);
-		        t_dst_ptr += t_stride;
-		        t_src_ptr -= t_bitmap->stride;
-	        }
-            
+        size_t t_dib_size = sizeof(BITMAPV5HEADER) + t_bitmap->height * t_stride;
+        void *t_dib = malloc(t_dib_size);
+        if (t_dib == nullptr)
+        {
             MCImageFreeFrames(t_frames, t_frame_count);
+            return false;
+        }
+            
+	    BITMAPV5HEADER *t_header = (BITMAPV5HEADER*)t_dib;
+	    MCMemoryClear(t_header, sizeof(BITMAPV5HEADER));
+	    t_header -> bV5Size = sizeof(BITMAPV5HEADER);
+	    t_header -> bV5Width = t_bitmap->width;
+	    t_header -> bV5Height = t_bitmap->height;
+	    t_header -> bV5Planes = 1;
+	    t_header -> bV5BitCount = 32;
+	    t_header -> bV5Compression = BI_RGB;
+	    t_header -> bV5SizeImage = 0;
+	    t_header -> bV5XPelsPerMeter = 0;
+	    t_header -> bV5YPelsPerMeter = 0;
+	    t_header -> bV5ClrUsed = 0;
+	    t_header -> bV5ClrImportant = 0;
+	    t_header -> bV5AlphaMask = 0xFF000000;
+	    t_header -> bV5RedMask =   0x00FF0000;
+	    t_header -> bV5GreenMask = 0x0000FF00;
+	    t_header -> bV5BlueMask =  0x000000FF;
+	    t_header -> bV5CSType = LCS_WINDOWS_COLOR_SPACE;
+            
+	    uint8_t *t_dst_ptr = (uint8_t*)t_dib + sizeof(BITMAPV5HEADER);
+	    uint8_t *t_src_ptr = (uint8_t*)t_bitmap->data + (t_bitmap->height - 1) * t_bitmap->stride;
 
-            if (!MCDataCreateWithBytesAndRelease(static_cast<byte_t *>(t_dib), t_dib_size, &t_data))
-            {
-                free(t_dib);
-                return false;
-            }
+	    for (uindex_t y = 0; y < t_bitmap->height; y++)
+	    {
+		    MCMemoryCopy(t_dst_ptr, t_src_ptr, t_stride);
+		    t_dst_ptr += t_stride;
+		    t_src_ptr -= t_bitmap->stride;
+	    }
+            
+        MCImageFreeFrames(t_frames, t_frame_count);
 
-            if (!AddRepresentation(MCSTR("CF_DIBV5"), *t_data))
-            {
-                return false;
-            }
+        if (!MCDataCreateWithBytesAndRelease(static_cast<byte_t *>(t_dib), t_dib_size, &t_data))
+        {
+            free(t_dib);
+            return false;
+        }
+
+        if (!AddRepresentation(MCSTR("CF_DIBV5"), *t_data))
+        {
+            return false;
         }
     }
 


### PR DESCRIPTION
This patch ensures that the CF_DIBV5 format is always added when
a PNG, GIF or JPEG image is added to the clipboard on Windows.

Note: This breaks the idea of the raw clipboard slightly as it
means formats are not entirely separable at that level. However
one can work around that by setting the DIB format *after* the
PNG, JPEG or GIF format. Ideally, synthesized formats would be
added at clipboard unlock and derived from the explicitly set
formats and only if they are not explicitly set.