### PR TITLE
[[ Docs ]] Improve variadic syntax declarations

### DIFF
--- a/docs/dictionary/command/local.lcdoc
+++ b/docs/dictionary/command/local.lcdoc
@@ -2,7 +2,7 @@ Name: local
 
 Type: command
 
-Syntax: local <variableName> [= <value>] [, ...]
+Syntax: local <variableName> [= <value>] [, <variableName> [= <value>] ...]
 
 Summary:
 <declare|Declares> one or more <local variable|local variables> and

--- a/docs/dictionary/command/mobileControlDo.lcdoc
+++ b/docs/dictionary/command/mobileControlDo.lcdoc
@@ -4,7 +4,7 @@ Synonyms: iphonecontroldo
 
 Type: command
 
-Syntax: mobileControlDo <idOrName>, <action>, ...action specific parameters...
+Syntax: mobileControlDo <idOrName>, <action> [, <actionParameter> ...]
 
 Summary:
 Execute specific behaviors of native mobile controls created using
@@ -42,6 +42,7 @@ The id or name of the control.
 action (enum):
 The name of the <action> to perform. See Description for complete <action> listing.
 
+actionParameter: Additional parameter required for the action.
 
 Description:
 Use the <mobileControlDo> command to execute behaviors specific to a

--- a/docs/dictionary/command/mobilePick.lcdoc
+++ b/docs/dictionary/command/mobilePick.lcdoc
@@ -4,7 +4,7 @@ Synonyms: iphonepick
 
 Type: command
 
-Syntax: mobilePick <optionList>, <initialIndex> [, <optionList>, <initialIndex>, ...] [, <style> ] [, <button>] [, <view>]
+Syntax: mobilePick <optionList1>, <initialIndex1> [, <optionList2>, <initialIndex2> ...] [, <style> ] [, <button>] [, <view>]
 
 Summary:
 Presents the user with a native list picker dialog.
@@ -38,11 +38,14 @@ mobilePick tDays, 2, tMonths, 3, "checkmark"
 answer the result with "Okay"
 
 Parameters:
-optionList:
+optionList1:
 A return delimited list of options.
 
-initialIndex:
+initialIndex1:
 The (1-based) index of the item to be initially highlighted.
+
+optionList2:
+initialIndex2:
 
 style:
 The type of display used. On the iPad if "checkmark" is specified a

--- a/docs/dictionary/command/visual-effect.lcdoc
+++ b/docs/dictionary/command/visual-effect.lcdoc
@@ -2,8 +2,7 @@ Name: visual effect
 
 Type: command
 
-Syntax: visual [effect] <effectName> [<speed>] [to <finalImage>] 
-[with sound <audioClip>] [and <param> <value> and ...]
+Syntax: visual [effect] <effectName> [<speed>] [to <finalImage>] [with sound <audioClip>] [and <param> <value> ...]
 
 Summary:
 Adds a visual effect transition.

--- a/docs/dictionary/function/libUrlFormData.lcdoc
+++ b/docs/dictionary/function/libUrlFormData.lcdoc
@@ -2,7 +2,7 @@ Name: libURLFormData
 
 Type: function
 
-Syntax: libURLFormData(<key_1>, <value_1>, ..., <key_n>, <value_n>)
+Syntax: libURLFormData(<key1>, <value1> [, <key2>, <value2> ...])
 
 Summary:
 <libURLFormData> formats data in the standard format suitable for
@@ -26,16 +26,10 @@ post it to url "http://www.someserver.com/cgi-bin/form.pl"
 -- In this case, the data posted to the url will look like this: name=John&message=Hello
 
 Parameters:
-key_1:
-
-
-value_1:
-
-
-key_n:
-
-
-value_n:
+key1:
+value1:
+key2:
+value2:
 
 
 Description:

--- a/docs/dictionary/function/libUrlMultipartFormData.lcdoc
+++ b/docs/dictionary/function/libUrlMultipartFormData.lcdoc
@@ -2,9 +2,9 @@ Name: libURLMultipartFormData
 
 Type: function
 
-Syntax: libURLMultipartFormData(<formData>, key_1, value_1, ..., key_n, value_n)
+Syntax: libURLMultipartFormData(<formData>, <key1>, <value1> [, <key2>, <value2> ...])
 
-Syntax: libURLMultipartFormData(<formData>, array)
+Syntax: libURLMultipartFormData(<formData>, <array>)
 
 Syntax: libURLMultipartFormData(<formData>)
 
@@ -42,6 +42,11 @@ end if
 
 Parameters:
 formData: A variable, which will be filled with the form data.
+key1:
+value1:
+key2:
+value2:
+array:
 
 Returns:
 The function will return empty if successful, or an error message

--- a/docs/dictionary/function/revBrowserCallScript.lcdoc
+++ b/docs/dictionary/function/revBrowserCallScript.lcdoc
@@ -2,7 +2,7 @@ Name: revBrowserCallScript
 
 Type: function
 
-Syntax: revBrowserCallScript(<instanceId>, <functionName> [, <parameter1>, <parameter2>, ..., <parameterN>])
+Syntax: revBrowserCallScript(<instanceId>, <functionName> [, <functionParameter> ...])
 
 Summary:
 Calls a web script function in the current browser object
@@ -28,15 +28,9 @@ The integer identifier of a browser object
 functionName:
 The name of the web script function to call
 
-parameter1:
-The parameters parameter1  through to parameterN  contain the arguments
-to pass to the function (optional).
-
-parameter2:
-
-
-parameterN:
-
+functionParameter:
+One or more optional parameters may contain the arguments to pass to the
+function.
 
 Description:
 Use the <revBrowserCallScript> function to call a web script function in

--- a/docs/dictionary/function/revOpenDatabase.lcdoc
+++ b/docs/dictionary/function/revOpenDatabase.lcdoc
@@ -3,7 +3,6 @@ Name: revOpenDatabase
 Synonyms: revdb_connect
 
 Type: function
-Syntax: revOpenDatabase(<databaseType>, {<hostAddress>, <databaseName>, [<userName>],[<passWord>],{[<useSSL>], [<socketAddr>], [<rwTimeout>], [<autoReconnect>] | [<cursorType>] | [<sslOption>],...} | <filePath>,[<sqliteOptions>]})
 
 Syntax: revOpenDatabase("mysql", <hostAddress>, <databaseName>, [<userName>],[<passWord>],[<useSSL>], [<socketAddr>], [<rwTimeout>], [<autoReconnect>])
 
@@ -11,7 +10,7 @@ Syntax: revOpenDatabase("odbc", <hostAddress>, <databaseName>, [<userName>],[<pa
 
 Syntax: revOpenDatabase("sqlite",<filePath>,[<sqliteOptions>])
 
-Syntax: revOpenDatabase("postgresql", <hostAddress>, <databaseName>, [<userName>], [<passWord>], [<sslOption>],...)
+Syntax: revOpenDatabase("postgresql", <hostAddress>, <databaseName>, [<userName>], [<passWord>] [, <sslOption> ...])
 
 Syntax: revOpenDatabase("oracle", <hostAddress>, <databaseName>, [<userName>],[<passWord>])
 
@@ -121,17 +120,6 @@ order of the items in the options parameter is not important):
 -   "extensions": Enable loadable extensions for the connection.
 -   "binary": Places binary data into the database verbatim (without
     LiveCode encoding).
-
-
-databaseType (enum):
-A string specifying the database type to use. One of the following:
-
-- "mysql"
-- "oracle"
-- "odbc"
-- "postgresql"
-- "valentina"
-- "sqlite"
 
 
 filePath (string):

--- a/docs/guides/LiveCode Documentation Format Reference.md
+++ b/docs/guides/LiveCode Documentation Format Reference.md
@@ -59,7 +59,7 @@ An entry may have a number of Syntax elements, if there are variations within th
 
 The following can be used to specify livecode syntax:
 - [optional]
-- ... (repeated)
+- [repeated optional ...]
 - { variant 1 | variant 2 }
 - <parameterName>
 


### PR DESCRIPTION
The variadic syntax declarations were not very consisten with the
way they used `...` to describe addition optional parameters of the
same syntax. This patch attempts to make them consistent.