### PR TITLE
[[ Bug 20411 ]] Correct call to objc_msgSend

### DIFF
--- a/docs/notes/bugfix-20411.md
+++ b/docs/notes/bugfix-20411.md
@@ -1,0 +1,1 @@
+# Fix crash when using Obj-C FFI on iOS

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -1147,9 +1147,8 @@ __MCScriptResolveForeignFunctionBindingForObjC(MCScriptInstanceRef p_instance,
      * make. */
     if (t_valid)
     {
-        if (ffi_prep_cif_var(t_cif,
+        if (ffi_prep_cif(t_cif,
                              FFI_DEFAULT_ABI,
-                             2,
                              t_arg_count,
                              t_cif_return_type,
                              t_cif_arg_types) != FFI_OK)


### PR DESCRIPTION
Whilst 'objc_msgSend' and friends are declared as variadic, they
aren't actually variadic functions.

The objc_msgSend functions forward the call to the appropriate
message, meaning that they must be called with the prototype of the
message and not variadically.

This difference was not seen on x86 processors where the difference
between variadic and non-variadic functions is much less; on ARM
however there is a significant difference, resulting in the obj-c
FFI not working in many cases on iOS devices.