### PR TITLE
[Bug 20434] Add usage description when accessing health data

### DIFF
--- a/docs/notes/bugfix-20434.md
+++ b/docs/notes/bugfix-20434.md
@@ -1,0 +1,1 @@
+# Fix crash on iOS when the app uses HealthKit

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -122,5 +122,9 @@
 	<string>This application requires access to your Reminders</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>This application requires access to read the user's health data</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>This application requires access to update the user's health data</string>
 </dict>
 </plist>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -95,5 +95,9 @@
 	<string>This application requires access to your Reminders</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>This application requires access to read the user's health data</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>This application requires access to update the user's health data</string>
 </dict>
 </plist>


### PR DESCRIPTION
If the app is built against iOS 10.x SDK, you are required to add a <key-value> pair in the plist if the app is accessing privacy-sensitive data. Some pairs had already been added (when accessing camera, contacts, calendar  etc), but the health-related ones were omitted. This was causing a crash.