### PR TITLE
[[ Script ]] Fix throwing of 'property used before assigned' error

### DIFF
--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -52,7 +52,8 @@ MCScriptThrowPropertyUsedBeforeAssignedError(MCScriptInstanceRef p_instance,
 								 p_instance->module->name,
 								 "property",
 								 MCScriptGetNameOfDefinitionInModule(p_instance->module,
-																		   p_property_def));
+																		   p_property_def),
+                                 nil);
 }
 
 bool


### PR DESCRIPTION
This patch ensures that the key / value list passed to MCErrorCreateAndThrow
in the PropertyUsedBeforeAssigned throw function is nullptr terminated.