### PR TITLE
Revert "[[Bug 18305]] Add Synonyms to Dictionary (#5669)"

### DIFF
--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -250,7 +250,7 @@ function revDocsParseDictionaryToLibraryArray pRootDir
    local tCount
    put 1 into tCount
    
-   local tText, tLibraryA, tParsedA, tDisplayName, tSynonymA
+   local tText, tLibraryA, tParsedA
    
    repeat for each item tRoot in (tDictionaryRoot & "," & tGlossaryRoot)
       repeat for each line tLine in folders(tRoot)
@@ -268,22 +268,6 @@ function revDocsParseDictionaryToLibraryArray pRootDir
             put revDocsParseDocText(tText, tFullPath) into tParsedA
             put tParsedA["doc"][1] into tLibraryA[tCount]
             add 1 to tCount
-            -- BWM fix for Bug 18305
-            -- add an additional entry to dictionary for each synonym to allow keyword search
-            if tParsedA["doc"][1]["Synonyms"] is not empty then
-               put tParsedA["doc"][1]["display name"] into tDisplayName
-               put tParsedA["doc"][1]["Synonyms"] into tSynonymA
-               repeat for each element tSynonymName in tSynonymA
-                  if tSynonymName is tDisplayName then next repeat -- glossary entries include themselves
-                  put tParsedA["doc"][1] into tLibraryA[tCount]
-                  put tSynonymName into tLibraryA[tCount]["display name"]
-                  if tParsedA["doc"][1]["Type"] is not "glossary" then
-                     put " (Synonym of " & tDisplayName & ")" after tLibraryA[tCount]["display name"]
-                  end if
-                  add 1 to tCount
-               end repeat
-            end if
-            -- end fix for Bug 18305
          end repeat
       end repeat
    end repeat


### PR DESCRIPTION
This reverts commit d72f1632e7302c856246143942437b981c88c854.
Due to a regression where search terms such as "mobile" will display the "iphone" synonyms first and give the impression that those are the preferred entries.  Changes are being made to the IDE (dictionary viewer) to implement the synonym search there.

This code also caused issues with duplicates being displayed in the new Autocomplete feature.