### PR TITLE
[[ Bug 20425 ]] Fix internal extract for 64-bit Mach-O files

### DIFF
--- a/engine/src/deploy_macosx.cpp
+++ b/engine/src/deploy_macosx.cpp
@@ -2747,7 +2747,7 @@ template<typename T> static bool MCDeployExtractArchCallbackBody(MCDeployExtract
 	t_section = nil;
 	for(uint32_t i = 0; i < t_header . ncmds; i++)
 	{
-		if (t_commands[i] -> cmd != LC_SEGMENT)
+        if (t_commands[i] -> cmd != T::seg_load_command)
 			continue;
 		
 		typename T::segment_command *t_segment;


### PR DESCRIPTION
This patch ensures that the section extraction code searches for
the correct load command in 64-bit slices.

(cherry picked from commit 951a48a9009e102e167ca8ffaa5f315f96e4300e)

PS: Needed for Xcode9/iOS11 support