### PR TITLE
[[ Bug 20478 ]] Fix crash on exit after using the commandName

### DIFF
--- a/docs/notes/bugfix-20478.md
+++ b/docs/notes/bugfix-20478.md
@@ -1,0 +1,1 @@
+# Prevent crash on quit when using the commandName

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -169,6 +169,10 @@ MC_EXEC_DEFINE_EVAL_METHOD(Engine, TargetAsObject, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(Engine, ErrorObjectAsObject, 1)
 MC_EXEC_DEFINE_EVAL_METHOD(Engine, FontfilesInUse, 1)
 
+MC_EXEC_DEFINE_EVAL_METHOD(Engine, CommandName, 1)
+MC_EXEC_DEFINE_EVAL_METHOD(Engine, CommandArguments, 1)
+MC_EXEC_DEFINE_EVAL_METHOD(Engine, CommandArgumentAtIndex, 2)
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct MCEngineNumberFormat
@@ -2170,3 +2174,26 @@ void MCEngineEvalIsNotStrictlyAnArray(MCExecContext& ctxt, MCValueRef value, boo
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void MCEngineEvalCommandName(MCExecContext& ctxt, MCStringRef& r_result)
+{
+    if (MCcommandname != nullptr)
+        r_result = MCValueRetain(MCcommandname);
+    else
+        r_result = MCValueRetain(kMCEmptyString);
+}
+
+void MCEngineEvalCommandArguments(MCExecContext& ctxt, MCArrayRef& r_result)
+{
+    r_result = MCValueRetain(MCcommandarguments);
+}
+
+void MCEngineEvalCommandArgumentAtIndex(MCExecContext& ctxt, uinteger_t t_index, MCStringRef& r_result)
+{
+    MCStringRef t_result = nullptr;
+    // If the index is wrong (< 0 or > argument count) then we return empty
+    if (!MCArrayFetchValueAtIndex(MCcommandarguments, t_index, (MCValueRef&)t_result))
+        t_result = kMCEmptyString;
+
+    r_result = MCValueRetain(t_result);
+}

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -2190,8 +2190,14 @@ void MCEngineEvalCommandArguments(MCExecContext& ctxt, MCArrayRef& r_result)
 
 void MCEngineEvalCommandArgumentAtIndex(MCExecContext& ctxt, uinteger_t t_index, MCStringRef& r_result)
 {
+    if (t_index == 0)
+    {
+        ctxt . LegacyThrow(EE_COMMANDARGUMENTS_BADPARAM);
+        return;
+    }
+    
     MCStringRef t_result = nullptr;
-    // If the index is wrong (< 0 or > argument count) then we return empty
+    // If the index > argument count then we return empty
     if (!MCArrayFetchValueAtIndex(MCcommandarguments, t_index, (MCValueRef&)t_result))
         t_result = kMCEmptyString;
 

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3847,6 +3847,10 @@ extern MCExecMethodInfo *kMCEngineGetAddressMethodInfo;
 extern MCExecMethodInfo *kMCEngineGetStacksInUseMethodInfo;
 extern MCExecMethodInfo *kMCEngineGetEditionTypeMethodInfo;
 
+extern MCExecMethodInfo *kMCEngineEvalCommandNameMethodInfo;
+extern MCExecMethodInfo *kMCEngineEvalCommandArgumentsMethodInfo;
+extern MCExecMethodInfo *kMCEngineEvalCommandArgumentAtIndexMethodInfo;
+
 void MCEngineEvalVersion(MCExecContext& ctxt, MCNameRef& r_name);
 void MCEngineEvalBuildNumber(MCExecContext& ctxt, integer_t& r_build_number);
 void MCEngineEvalPlatform(MCExecContext& ctxt, MCNameRef& r_name);
@@ -4019,6 +4023,10 @@ void MCEngineEvalIsStrictlyABinaryString(MCExecContext& ctxt, MCValueRef value, 
 void MCEngineEvalIsNotStrictlyABinaryString(MCExecContext& ctxt, MCValueRef value, bool& r_result);
 void MCEngineEvalIsStrictlyAnArray(MCExecContext& ctxt, MCValueRef value, bool& r_result);
 void MCEngineEvalIsNotStrictlyAnArray(MCExecContext& ctxt, MCValueRef value, bool& r_result);
+
+void MCEngineEvalCommandName(MCExecContext& ctxt, MCStringRef& r_result);
+void MCEngineEvalCommandArguments(MCExecContext& ctxt, MCArrayRef& r_result);
+void MCEngineEvalCommandArgumentAtIndex(MCExecContext& ctxt, uinteger_t t_index, MCStringRef& r_result);
 
 ///////////
 

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -583,7 +583,7 @@ void MCChunkOffset::compile(MCSyntaxFactoryRef ctxt)
 
 Parse_stat MCCommandArguments::parse(MCScriptPoint &sp, Boolean the)
 {
-    if (!get0or1param(sp, &argument_index, the))
+    if (!get0or1param(sp, &(&argument_index), the))
     {
         MCperror -> add(PE_FACTOR_BADPARAM, line, pos);
         return PS_ERROR;
@@ -596,32 +596,26 @@ void MCCommandArguments::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
 {
     // If no parameter has been provided, then we return the list of parameters
     //  as an array.
-    if (argument_index == NULL)
+    if (*argument_index == nullptr)
     {
-        MCExecValueTraits<MCArrayRef>::set(r_value, MCValueRetain(MCcommandarguments));
-        return;
+        MCEngineEvalCommandArguments(ctxt, r_value.arrayref_value);
+        r_value.type = kMCExecValueTypeArrayRef;
     }
     else
     {
-        integer_t t_index;
-        if (!ctxt . EvalExprAsInt(argument_index, EE_COMMANDARGUMENTS_BADPARAM, t_index))
+        uinteger_t t_index;
+        if (!ctxt . EvalExprAsUInt(*argument_index, EE_COMMANDARGUMENTS_BADPARAM, t_index))
             return;
 
-        MCStringRef t_value;
-        // If the index is wrong (< 0 or > argument count) then we return empty
-        if (!MCArrayFetchValueAtIndex(MCcommandarguments, t_index, (MCValueRef&)t_value))
-            t_value = kMCEmptyString;
-
-        MCExecValueTraits<MCStringRef>::set(r_value, MCValueRetain(t_value));
+        MCEngineEvalCommandArgumentAtIndex(ctxt, t_index, r_value . stringref_value);
+        r_value.type = kMCExecValueTypeStringRef;
     }
 }
 
 void MCCommandName::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
 {
-    if (MCcommandname != NULL)
-        MCExecValueTraits<MCStringRef>::set(r_value, MCcommandname);
-    else
-        MCExecValueTraits<MCStringRef>::set(r_value, kMCEmptyString);
+    MCEngineEvalCommandName(ctxt, r_value.stringref_value);
+    r_value.type = kMCExecValueTypeStringRef;
 }
 
 MCDirectories::~MCDirectories()

--- a/engine/src/funcs.h
+++ b/engine/src/funcs.h
@@ -507,9 +507,12 @@ public:
 
 class MCCommandArguments : public MCFunction
 {
-    MCExpression* argument_index;
+    MCAutoPointer<MCExpression> argument_index;
 public:
-    MCCommandArguments() { argument_index = NULL; }
+    MCCommandArguments() :
+        argument_index(nullptr)
+    {
+    }
     virtual Parse_stat parse(MCScriptPoint &sp, Boolean the);
     virtual void eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value);
 };

--- a/tests/lcs/core/engine/_commandname.lc
+++ b/tests/lcs/core/engine/_commandname.lc
@@ -1,0 +1,3 @@
+#!
+get the commandName
+quit 0

--- a/tests/lcs/core/engine/_commandname.livecodescript
+++ b/tests/lcs/core/engine/_commandname.livecodescript
@@ -1,0 +1,5 @@
+script "_commandName"
+on startup
+    get the commandName
+    quit 0
+end startup

--- a/tests/lcs/core/engine/commandargs.livecodescript
+++ b/tests/lcs/core/engine/commandargs.livecodescript
@@ -33,3 +33,21 @@ on TestCommandName
    TestRunStack tOptions, tStackToRun
    TestAssert "command name does not crash on quit", the result is empty
 end TestCommandName
+
+command _TestCommandArgumentsZeroIndexError
+	return commandArguments(0)
+end _TestCommandArgumentsZeroIndexError
+
+command _TestCommandArgumentsNegativeIndexError
+	return commandArguments(-1)
+end _TestCommandArgumentsNegativeIndexError
+
+on TestCommandArguments
+	TestAssertThrow "command arguments invalid index (0) throws", \
+		_TestCommandArgumentsZeroIndexError, the long id of me, \
+		EE_COMMANDARGUMENTS_BADPARAM
+		
+	TestAssertThrow "command arguments invalid index (-1) throws", \
+		_TestCommandArgumentsNegativeIndexError, the long id of me, \
+		EE_COMMANDARGUMENTS_BADPARAM		
+end TestCommandArguments

--- a/tests/lcs/core/engine/commandargs.livecodescript
+++ b/tests/lcs/core/engine/commandargs.livecodescript
@@ -1,0 +1,35 @@
+script "CoreEngineCommandArgs"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestCommandName
+    -- Bug 20478: run a subprocess in which we get the commandName and
+    -- then quit, to test that it no longer crashes
+   local tStackToRun, tOptions
+   put the effective filename of me into tStackToRun
+   set the itemdelimiter to slash
+   if the environment is "server" then
+      put "_commandname.lc" into item -1 of tStackToRun
+   else
+      put "_commandname.livecodescript" into item -1 of tStackToRun
+      if the environment contains "command line" then
+         put "-ui" into tOptions
+      end if
+   end if
+   TestRunStack tOptions, tStackToRun
+   TestAssert "command name does not crash on quit", the result is empty
+end TestCommandName


### PR DESCRIPTION
- Fix the missing retain when fetching the commandName
- Fix a memory leak in the MCCommandArguments class
- Refactor the MCCommandArguments and MCCommandName classes so that
  their functionality is implemented in the engine module
- Add test for crash