### PR TITLE
[Dictionary] Update return.lcdoc

### DIFF
--- a/docs/glossary/r/return.lcdoc
+++ b/docs/glossary/r/return.lcdoc
@@ -8,7 +8,7 @@ Description:
 To send a <value> back to the <handler> that <call|called> a
 <function>. 
 
-Also, the carriage return character, ASCII 13.
+Also, the line feed character, ASCII 10.
 
 References: handler (glossary), function (glossary), value (glossary),
 call (glossary)


### PR DESCRIPTION
Changed entry to match what the return (constant) entry says; return is not ASCII 13. Using `codepointToNum(return)` backs this up.