### PR TITLE
[[ Bug 20489 ]] Remove revVideoGrabber

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -725,13 +725,11 @@ component Externals.Linux
 component Externals.Windows
 	into [[TargetFolder]]/Externals place
 		executable windows:revspeech.dll
-		executable windows:revvideograbber.dll
 		executable windows:revxml.dll
 		executable windows:revbrowser.dll
 		executable windows:revzip.dll
 		executable windows:revfont.dll
 	declare external "Speech" using revspeech.dll
-	declare external "Video Grabber" using revvideograbber.dll
 	declare external "XML" using revxml.dll
 	declare external "Browser" using revbrowser.dll
 	declare external "Revolution Zip" using revzip.dll
@@ -742,13 +740,11 @@ component Externals.Windows
 component Externals.MacOSX
 	into [[TargetFolder]]/Externals place
 		executable macosx:revspeech.bundle
-		executable macosx:revvideograbber.bundle
 		executable macosx:revxml.bundle
 		executable macosx:revbrowser.bundle
 		executable macosx:revzip.bundle
 		executable macosx:revfont.bundle
 	declare external "Speech" using revspeech.bundle
-	declare external "Video Grabber" using revvideograbber.bundle
 	declare external "XML" using revxml.bundle
 	declare external "Browser" using revbrowser.bundle
 	declare external "Revolution Zip" using revzip.bundle

--- a/docs/notes/bugfix-20489.md
+++ b/docs/notes/bugfix-20489.md
@@ -1,0 +1,1 @@
+# Remove revVideoGrabber external from IDE as it can no longer be supported

--- a/docs/notes/issues.md
+++ b/docs/notes/issues.md
@@ -7,4 +7,4 @@
 * The browser widget does not work on 32-bit Linux.
 
 * 64-bit standalones for Mac OS X do not have support for audio
-  recording or the revVideoGrabber external.
+  recording.

--- a/livecode.gyp
+++ b/livecode.gyp
@@ -71,7 +71,6 @@
 							'revmobile/revmobile.gyp:external-revandroid',
 							'revmobile/revmobile.gyp:external-reviphone',
 							'revspeech/revspeech.gyp:external-revspeech',
-							'revvideograbber/revvideograbber.gyp:external-revvideograbber',
 							
 							# Server externals
 							'revdb/revdb.gyp:external-revdb-server',


### PR DESCRIPTION
This patch removes revVideoGrabber from the packager and as a build
dependency as it can no longer be supported.