### PR TITLE
[Bug 13627] - Correct examples for mobileAddContact and mobileUpdateContact

### DIFF
--- a/docs/dictionary/command/mobileAddContact.lcdoc
+++ b/docs/dictionary/command/mobileAddContact.lcdoc
@@ -17,7 +17,7 @@ Example:
 put "Just adding this" into tContact["note"]
 put "Jobs Ave" into tContact["address"]["home"][1]["street"]
 put "Job City" into tContact["address"]["home"][1]["city"]
-put "test@livecode.com" into tContactData["email"]["home"][1]
+put "test@livecode.com" into tContact["email"]["home"][1]
 mobileAddContact tContact
 
 Parameters:

--- a/docs/dictionary/command/mobileAddContact.lcdoc
+++ b/docs/dictionary/command/mobileAddContact.lcdoc
@@ -18,7 +18,7 @@ put "Just adding this" into tContact["note"]
 put "Jobs Ave" into tContact["address"]["home"][1]["street"]
 put "Job City" into tContact["address"]["home"][1]["city"]
 put "test@livecode.com" into tContactData["email"]["home"][1]
-mobileUpdateContact tContact
+mobileAddContact tContact
 
 Parameters:
 contactArray (array):

--- a/docs/dictionary/command/mobileUpdateContact.lcdoc
+++ b/docs/dictionary/command/mobileUpdateContact.lcdoc
@@ -18,7 +18,7 @@ Example:
 put "Just adding this" into tContact["note"]
 put "Jobs Ave" into tContact["address"]["home"][1]["street"]
 put "Job City" into tContact["address"]["home"][1]["city"]
-put "test@livecode.com" into tContactData["email"]["home"][1]
+put "test@livecode.com" into tContact["email"]["home"][1]
 mobileUpdateContact tContact
 
 Parameters:

--- a/docs/notes/bugfix-13627.md
+++ b/docs/notes/bugfix-13627.md
@@ -1,0 +1,1 @@
+# Fixed error in example code in the mobileAddContact dictionary entry.

--- a/docs/notes/bugfix-13627.md
+++ b/docs/notes/bugfix-13627.md
@@ -1,1 +1,1 @@
-# Fixed error in example code in the mobileAddContact dictionary entry.
+# Fixed example code errors in the mobileAddContact and mobileUpdateContact dictionary entries.


### PR DESCRIPTION
Changed line referring to `tContactData` to `tContact` in the mobileAddContact and mobileUpdateContact dictionary entries.
Changed `mobileUpdateContact` call to `mobileAddContact` in the mobileAddContact dictionary entry.