### PR TITLE
[[ Bug 20490 ]] Fix crash on High Sierra when closing color dialog

### DIFF
--- a/docs/notes/bugfix-20490.md
+++ b/docs/notes/bugfix-20490.md
@@ -1,0 +1,1 @@
+# Fix crash when closing color dialog on macOS High Sierra


### PR DESCRIPTION
This patch fixes a retain/release problem in the color dialog
code. High Sierra now executes some system functionality using
blocks on other threads internally. This change meant that the
a dealloc/release error was now occuring due to a autorelease
pool flush.