### PR TITLE
[[Bug 20497]] Dictionary: send command missing script syntax

### DIFF
--- a/docs/dictionary/command/send.lcdoc
+++ b/docs/dictionary/command/send.lcdoc
@@ -4,6 +4,8 @@ Type: command
 
 Syntax: send <message> [ to <object> [in <time> [{seconds | ticks | milliseconds}] ] ]
 
+Syntax: send script <message> [ to <object> ]
+
 Summary:
 Sends a <message> to an <object(glossary)>.
 

--- a/docs/notes/bugfix-20497.md
+++ b/docs/notes/bugfix-20497.md
@@ -1,0 +1,1 @@
+# Correct dictionary entry for send (missing script syntax)


### PR DESCRIPTION
Commit 2c66bdb removed the script form of the send syntax.  As a result, the new autocomplete feature will not offer the script form of the command (in 8.2DP1).

In 9.0DP9, there is an earlier version of the entry which creates too many suggestions (it allows "in time" for the script form).