### PR TITLE
[[ TileCache ]] Cleanup

### DIFF
--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -3058,16 +3058,23 @@ void MCCard::drawselectedchildren(MCDC *dc)
 
 void MCCard::dirtyselection(const MCRectangle &p_rect)
 {
+    MCRectangle t_marquee_rect = MCU_reduce_rect(p_rect, -1);
+    
 	// redraw marquee rect
 	// selrect with 0 width or height will still draw a 1px line, so increase rect size to account for this.
-	layer_dirtyrect(MCU_reduce_rect(p_rect, -1));
+	layer_dirtyrect(t_marquee_rect);
 	
 	// redraw selection handles
 	MCRectangle t_handles[8];
 	MCControl::sizerects(p_rect, t_handles);
 
 	for (uint32_t i = 0; i < 8; i++)
+    {
 		layer_dirtyrect(t_handles[i]);
+        t_marquee_rect = MCU_union_rect(t_marquee_rect, t_handles[i]);
+    }
+    
+    layer_selectedrectchanged(t_marquee_rect, t_marquee_rect);
 }
 
 bool MCCard::updatechildselectedrect(MCRectangle& x_rect)

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -41,9 +41,9 @@ protected:
 	MCCdata *savedata;
 
 	// MW-2011-08-26: [[ TileCache ]] The layer id of the background.
-	uint32_t m_bg_layer_id;
+	MCTileCacheLayerId m_bg_layer_id;
 	// MW-2011-09-23: [[ TileCache ]] The layer id of the foreground (selection rect).
-	uint32_t m_fg_layer_id;
+	MCTileCacheLayerId m_fg_layer_id;
 	
 	// MM-2012-11-05: [[ Object selection started/ended message ]]
 	bool m_selecting_objects : 1;

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -18,6 +18,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define	CARD_H
 
 #include "object.h"
+#include "tilecache.h"
 
 typedef MCObjectProxy<MCCard>::Handle MCCardHandle;
 
@@ -245,12 +246,8 @@ public:
 
 	// MW-2011-08-26: [[ TileCache ]] Render all layers into the stack's tilecache.
 	void render(void);
-
-	// IM-2013-09-13: [[ RefactorGraphics ]] add tilecache_ prefix to render methods to make their purpose clearer
-	// MW-2011-09-23: [[ TileCache ]] Render the card's bg layer.
-	static bool tilecache_render_background(void *context, MCContext *target, const MCRectangle& dirty);
-	// MW-2011-09-23: [[ TileCache ]] Render the card's fg layer.
-	static bool tilecache_render_foreground(void *context, MCContext *target, const MCRectangle& dirty);
+    bool render_background(MCContext* p_dc, const MCRectangle& p_dirty);
+    bool render_foreground(MCContext* p_dc, const MCRectangle& p_dirty);
 
 	// MW-2012-06-08: [[ Relayer ]] This method returns the control on the card with
 	//   the given layer. If nil is returned the control doesn't exist.

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -213,19 +213,14 @@ public:
 	void updateselection(MCControl *cptr, const MCRectangle &oldrect, const MCRectangle &selrect, MCRectangle &drect);
 
 	int2 getborderwidth(void);
+    
 	void drawcardborder(MCDC *dc, const MCRectangle &dirty);
-	
-	// IM-2013-09-13: [[ RefactorGraphics ]] render the card background
 	void drawbackground(MCContext *p_context, const MCRectangle &p_dirty);
-	// IM-2013-09-13: [[ RefactorGraphics ]] render the card selection rect
-	void drawselectionrect(MCContext *);
-    void drawselectedchildren(MCDC *dc);
+	void drawselection(MCContext *, const MCRectangle& dirty);
 	
 	// IM-2016-09-26: [[ Bug 17247 ]] request redraw of the area occupied by
 	//      selection marquee + handles
 	void dirtyselection(const MCRectangle &p_rect);
-	
-    bool updatechildselectedrect(MCRectangle& x_rect);
     
 	Exec_stat openbackgrounds(bool p_is_preopen, MCCard *p_other);
 	Exec_stat closebackgrounds(MCCard *p_other);
@@ -241,8 +236,6 @@ public:
 	void layer_removed(MCControl *control, MCObjptr *previous, MCObjptr *next);
 	// MW-2011-08-19: [[ Layers ]] The viewport displayed in the stack has changed.
 	void layer_setviewport(int32_t x, int32_t y, int32_t width, int32_t height);
-	// MW-2011-09-23: [[ Layers ]] The selected rectangle has changed.
-	void layer_selectedrectchanged(const MCRectangle& old_rect, const MCRectangle& new_rect);
 
 	// MW-2011-08-26: [[ TileCache ]] Render all layers into the stack's tilecache.
 	void render(void);

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -991,10 +991,14 @@ void MCControl::sizerects(const MCRectangle &p_object_rect, MCRectangle r_rects[
 			}
 }
 
-void MCControl::drawselected(MCDC *dc)
+void MCControl::drawselection(MCDC *dc, const MCRectangle& p_dirty)
 {
-    if (!opened || !(getflag(F_VISIBLE) || showinvisible()))
+    MCAssert(getopened() != 0 && (getflag(F_VISIBLE) || showinvisible()));
+    
+    if (!getselected())
+    {
         return;
+    }
     
 	if (MCdragging)
 		return;

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -44,6 +44,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "bitmapeffect.h"
 #include "graphicscontext.h"
 #include "graphics_util.h"
+#include "redraw.h"
 
 #include "exec.h"
 
@@ -428,10 +429,6 @@ void MCControl::select()
 	state |= CS_SELECTED;
 	kunfocus();
 
-	// MW-2011-09-23: [[ Layers ]] Mark the layer attrs as having changed - the selection
-	//   setting can influence the layer type.
-	m_layer_attr_changed = true;
-
 	// MW-2011-08-18: [[ Layers ]] Invalidate the whole object.
 	layer_redrawall();
 	
@@ -442,10 +439,6 @@ void MCControl::deselect()
 {
 	if (state & CS_SELECTED)
 	{
-		// MW-2011-09-23: [[ Layers ]] Mark the layer attrs as having changed - the selection
-		//   setting can influence the layer type.
-		m_layer_attr_changed = true;
-
 		// MW-2011-08-18: [[ Layers ]] Invalidate the whole object.
 		layer_redrawall();
         
@@ -616,6 +609,177 @@ void MCControl::undo(Ustruct *us)
 void MCControl::draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite)
 {
 	fprintf(stderr, "Control: ERROR tried to draw control id %d\n", obj_id);
+}
+
+void MCControl::render(MCTileCacheRef p_tilecache, bool p_reset, const MCGAffineTransform& p_transform, const MCRectangle& p_visible_rect)
+{
+    /* If we are resetting, then we reset the old layer id and mode to the
+     * defaults. */
+    if (p_reset)
+    {
+        m_layer_id = 0;
+        m_layer_mode = kMCLayerModeHintStatic;
+    }
+
+    /* If the layer is static but has a non copy/srcOver blend mode then we must
+     * make it dynamic as the blend has to applied singularly to that layer. */
+    MCLayerModeHint t_new_layer_mode = kMCLayerModeHintDynamic;
+    if (m_layer_mode_hint == kMCLayerModeHintStatic &&
+        (ink == GXcopy || ink == GXblendSrcOver))
+    {
+        t_new_layer_mode = kMCLayerModeHintStatic;
+    }
+    else if (gettype() == CT_GROUP && m_layer_mode_hint == kMCLayerModeHintScrolling)
+    {
+        /* Groups can only be scrolling if they are unadorned */
+        bool t_is_unadorned = !getflag(F_HSCROLLBAR | F_VSCROLLBAR | F_SHOW_NAME | F_SHOW_BORDER);
+        
+        /* TODO: Work out why this is needed... */
+        if (t_is_unadorned)
+        {
+            uint16_t t_index;
+            // IM-2014-05-02: [[ Bugfix 12044 ]] An opaque group is unadorned if its background is a color and it disallows overscroll
+            t_is_unadorned = !getflag(F_OPAQUE) || (getcindex(DI_BACK, t_index) && !getflag(F_UNBOUNDED_HSCROLL | F_UNBOUNDED_VSCROLL));
+        }
+        
+        /* If we are unadorned, then we can scroll! */
+        if (t_is_unadorned)
+        {
+            t_new_layer_mode = kMCLayerModeHintScrolling;
+        }
+    }
+    
+    /* The region of the layer is the effective rect, or contentrect if scrolling */
+    /* The clip of the layer is either the empty rect if the control is not
+     * visible, or the region. */
+    MCRectangle t_layer_region;
+    MCRectangle t_layer_clip;
+    if (!getflag(F_VISIBLE) && !showinvisible())
+    {
+        t_layer_region = MCU_make_rect(0, 0, 0, 0);
+        t_layer_clip = t_layer_region;
+    }
+    else if (t_new_layer_mode != kMCLayerModeHintScrolling)
+    {
+        t_layer_region = geteffectiverect();
+        t_layer_clip = t_layer_region;
+    }
+    else
+    {
+        t_layer_region = layer_getcontentrect();
+        t_layer_clip = geteffectiverect();
+    }
+    
+    /* The clip must be further restricted by the current visible rect */
+    t_layer_clip = MCU_intersect_rect(t_layer_clip, p_visible_rect);
+    
+    /***/
+    
+    /* Compute the opacity of the layer */
+    bool t_is_opaque = false;
+    if (MCBitmapEffectsIsInteriorOnly(getbitmapeffects()))
+    {
+        switch(gettype())
+        {
+        case CT_GROUP:
+			t_is_opaque = getflag(F_OPAQUE) &&
+				!getflag(F_HSCROLLBAR | F_VSCROLLBAR | F_SHOW_NAME | F_SHOW_BORDER);
+            break;
+        case CT_FIELD:
+            t_is_opaque = getflag(F_OPAQUE) &&
+                !getflag(F_HSCROLLBAR | F_VSCROLLBAR | F_SHOW_BORDER | F_SHADOW) && (extraflags & EF_NO_FOCUS_BORDER) != 0;
+            break;
+        default:
+            break;
+        }
+    }
+
+    /* Set up the layer to pass to tilecache */
+    MCTileCacheLayer t_layer;
+    t_layer.id = m_layer_id;
+    t_layer.region = MCRectangle32GetTransformedBounds(t_layer_region, p_transform);
+    t_layer.clip = MCRectangle32GetTransformedBounds(t_layer_clip, p_transform);
+    t_layer.is_opaque = t_is_opaque;
+    t_layer.opacity = getopacity();
+    t_layer.ink = getink();
+    t_layer.context = this;
+    
+    /* If the layer mode is dynamic, then we render as a sprite; otherwise we
+     * render as scenery. */
+    if (t_new_layer_mode != kMCLayerModeHintStatic)
+    {
+        /* If this was previously a scenery layer, then remove it */
+        if (m_layer_id != 0 && m_layer_mode == kMCLayerModeHintStatic)
+        {
+            MCTileCacheRemoveScenery(p_tilecache, t_layer.id, t_layer.region);
+            t_layer.id = 0;
+        }
+        
+        /* Use the sprite variant of the callback */
+        t_layer.callback = MCRedrawRenderDeviceSpriteLayer<MCControl, &MCControl::render_sprite_layer>;
+        
+        /* Render as a sprite layer */
+        MCTileCacheRenderSprite(p_tilecache, t_layer);
+    }
+    else
+    {
+        /* If this was previously a scenery layer, then remove it */
+        if (m_layer_id != 0 && m_layer_mode != kMCLayerModeHintStatic)
+        {
+            MCTileCacheRemoveSprite(p_tilecache, t_layer.id);
+            t_layer.id = 0;
+        }
+        
+        /* Scenery layer regions must be clipped to the clip (else bug 11349) */
+        t_layer.region = MCRectangle32Intersect(t_layer.region, t_layer.clip);
+        
+        /* Use the scenery variant of the callback */
+        t_layer.callback = MCRedrawRenderDeviceSceneryLayer<MCControl, &MCControl::render_scenery_layer>;
+        
+        /* Render as a scenery layer */
+        MCTileCacheRenderScenery(p_tilecache, t_layer);
+    }
+    
+    /* Update the id and mode */
+    m_layer_id = t_layer.id;
+    m_layer_mode = t_new_layer_mode;
+}
+
+bool MCControl::render_sprite_layer(MCContext *p_target, const MCRectangle& p_rectangle)
+{
+    MCRectangle t_control_rect;
+    if (layer_isscrolling())
+    {
+        t_control_rect = layer_getcontentrect();
+    }
+    else
+    {
+        t_control_rect = geteffectiverect();
+    }
+    
+    MCRectangle t_dirty_rect = MCU_intersect_rect(t_control_rect,
+                                                  MCU_offset_rect(p_rectangle,
+                                                                  t_control_rect.x, t_control_rect.y));
+    
+    if (MCU_empty_rect(t_dirty_rect))
+    {
+        return true;
+    }
+    
+	p_target -> setorigin(-t_control_rect . x, -t_control_rect . y);
+	p_target -> cliprect(t_dirty_rect);
+	p_target -> setfunction(GXcopy);
+	p_target -> setopacity(255);
+
+	draw(p_target, t_dirty_rect, false, true);
+    
+    return true;
+}
+
+bool MCControl::render_scenery_layer(MCContext *p_target, const MCRectangle& p_rectangle)
+{
+    redraw(p_target, p_rectangle);
+    return true;
 }
 
 IO_stat MCControl::save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version)
@@ -1615,10 +1779,6 @@ Exec_stat MCControl::setsbprop(Properties which, bool p_enable,
 				if (opened)
 					setsbrects();
 			}
-
-			// MW-2011-09-21: [[ Layers ]] Changing the property affects the
-			//   object's adorned status.
-			m_layer_attr_changed = true;
 		}
 		break;
 	case P_VSCROLLBAR:
@@ -1658,10 +1818,6 @@ Exec_stat MCControl::setsbprop(Properties which, bool p_enable,
 				if (opened)
 					setsbrects();
 			}
-
-			// MW-2011-09-21: [[ Layers ]] Changing the property affects the
-			//   object's adorned status.
-			m_layer_attr_changed = true;
 		}
 		break;
 			

--- a/engine/src/edittool.cpp
+++ b/engine/src/edittool.cpp
@@ -128,9 +128,8 @@ bool MCGradientEditTool::mfocus(int2 x, int2 y)
 		return false;
 	}
 
-	MCRectangle t_old_effectiverect;
-	t_old_effectiverect = graphic -> geteffectiverect();
-
+    graphic->getcard()->dirtyselection(drawrect());
+    
 	switch (m_gradient_edit_point)
 	{
 	case 0:
@@ -190,9 +189,10 @@ bool MCGradientEditTool::mfocus(int2 x, int2 y)
 
 	gradient->old_origin.x = MININT2;
 	gradient->old_origin.y = MININT2;
-
-	// MW-2011-08-18: [[ Layers ]] Notify the graphic its effective rect has changed and invalidate all.
-	graphic -> layer_effectiverectchangedandredrawall(t_old_effectiverect);
+    
+    graphic->getcard()->dirtyselection(drawrect());
+    
+    graphic->MayChangeContent();
 
 	graphic->message_with_args(MCM_mouse_move, x, y);
 
@@ -269,39 +269,6 @@ MCRectangle MCGradientEditTool::drawrect()
 	gradient_rects(rects);
 	drect = MCU_union_rect(rects[0], rects[1]);
 	return MCU_union_rect(drect, rects[2]);
-}
-
-MCRectangle MCGradientEditTool::minrect()
-{
-	int4 minx, miny, maxx, maxy;
-	minx = MAXINT4;  miny = MAXINT4;
-	maxx = MININT4;  maxy = MININT4;
-
-	MCRectangle rect = {MININT2,MININT2,0,0};
-
-	if (gradient != NULL)
-	{
-		minx = MCU_min(gradient->origin.x, gradient->primary.x);
-		maxx = MCU_max(gradient->origin.x, gradient->primary.x);
-
-		minx = MCU_min(minx, gradient->secondary.x);
-		maxx = MCU_max(maxx, gradient->secondary.x);
-
-		miny = MCU_min(gradient->origin.y, gradient->primary.y);
-		maxy = MCU_max(gradient->origin.y, gradient->primary.y);
-
-		miny = MCU_min(miny, gradient->secondary.y);
-		maxy = MCU_max(maxy, gradient->secondary.y);
-
-		if (minx <= maxx && miny <= maxy)
-		{
-			rect.x = minx;
-			rect.y = miny;
-			rect.width = maxx - minx ;
-			rect.height = maxy - miny;
-		}
-	}
-	return rect;
 }
 
 MCPolygonEditTool::MCPolygonEditTool(MCGraphic *p_graphic) :
@@ -491,10 +458,4 @@ MCRectangle MCPolygonEditTool::drawrect()
 		drect = MCU_union_rect(drect, t_rects[i]);
 	}
 	return drect;
-}
-
-MCRectangle MCPolygonEditTool::minrect()
-{
-	MCRectangle rect = {MININT2,MININT2,0,0};
-	return rect;
 }

--- a/engine/src/edittool.h
+++ b/engine/src/edittool.h
@@ -40,7 +40,6 @@ public:
 	virtual void drawhandles(MCDC *dc) = 0;
 	virtual uint4 handle_under_point(int2 x, int2 y) = 0;
 	virtual MCRectangle drawrect() = 0;
-	virtual MCRectangle minrect() = 0;
 	virtual MCEditMode type() = 0;
 };
 
@@ -53,7 +52,6 @@ public:
 	void drawhandles(MCDC *dc);
 	uint4 handle_under_point(int2 x, int2 y);
 	MCRectangle drawrect();
-	MCRectangle minrect();
 	MCEditMode type();
 
 	MCGradientEditTool(MCGraphic *p_graphic, MCGradientFill *p_gradient, MCEditMode p_mode);
@@ -76,7 +74,6 @@ public:
 	void drawhandles(MCDC *dc);
 	uint4 handle_under_point(int2 x, int2 y);
 	MCRectangle drawrect();
-	MCRectangle minrect();
 	MCEditMode type();
 
 	MCPolygonEditTool(MCGraphic *p_graphic);

--- a/engine/src/exec-interface-button.cpp
+++ b/engine/src/exec-interface-button.cpp
@@ -337,8 +337,6 @@ void MCButton::SetStyle(MCExecContext& ctxt, intenum_t p_style)
 	default:
 		break;
 	}
-	// MW-2011-09-21: [[ Layers ]] Make sure the layerattrs are recomputed.
-	m_layer_attr_changed = true;
 	Redraw();
 }
 
@@ -373,9 +371,6 @@ void MCButton::SetArmBorder(MCExecContext& ctxt, bool setting)
 {
 	if (changeflag(setting, F_ARM_BORDER))
 	{
-		// MW-2011-09-21: [[ Layers ]] Changing the armBorder property
-		//   affects the layer attrs.
-		m_layer_attr_changed = true;
 		Redraw();
 	}
 }
@@ -400,9 +395,6 @@ void MCButton::SetHiliteBorder(MCExecContext& ctxt, bool setting)
 {
 	if (changeflag(setting, F_HILITE_BORDER))
 	{
-		// MW-2011-09-21: [[ Layers ]] Changing the hiliteBorder property
-		//   affects the layer attrs.
-		m_layer_attr_changed = true;
 		Redraw();
 	}
 }
@@ -589,9 +581,6 @@ void MCButton::SetShowIcon(MCExecContext& ctxt, bool setting)
 {
 	if (changeflag(setting, F_SHOW_ICON))
 	{
-		// MW-2011-09-21: [[ Layers ]] Changing the showIcon property
-		//   affects the layer attrs.
-		m_layer_attr_changed = true;
 		Redraw();
 	}
 }
@@ -605,9 +594,6 @@ void MCButton::SetShowName(MCExecContext& ctxt, bool setting)
 {
 	if (changeflag(setting, F_SHOW_NAME))
 	{
-		// MW-2011-09-21: [[ Layers ]] Changing the showName property
-		//   affects the layer attrs.
-		m_layer_attr_changed = true;
 		Redraw();
 	}
 }

--- a/engine/src/exec-interface-control.cpp
+++ b/engine/src/exec-interface-control.cpp
@@ -176,10 +176,6 @@ void MCControl::DoSetHScrollbar(MCExecContext& ctxt, MCScrollbar*& hsb, uint2& s
 		if (opened)
 			setsbrects();
 	}
-
-	// MW-2011-09-21: [[ Layers ]] Changing the property affects the
-	//   object's adorned status.
-	m_layer_attr_changed = true;
 }
 void MCControl::DoSetVScrollbar(MCExecContext& ctxt, MCScrollbar*& vsb, uint2& sbw)
 {
@@ -209,10 +205,6 @@ void MCControl::DoSetVScrollbar(MCExecContext& ctxt, MCScrollbar*& vsb, uint2& s
 		if (opened)
 			setsbrects();
 	}
-
-	// MW-2011-09-21: [[ Layers ]] Changing the property affects the
-	//   object's adorned status.
-	m_layer_attr_changed = true;
 }
 
 void MCControl::DoSetScrollbarWidth(MCExecContext& ctxt, uint2& sbw, uinteger_t p_width)
@@ -334,7 +326,6 @@ void MCControl::SetLayerMode(MCExecContext& ctxt, intenum_t p_mode)
 	// to redraw.
 	if (t_mode != m_layer_mode_hint)
 	{
-		m_layer_attr_changed = true;
 		m_layer_mode_hint = t_mode;
 		Redraw();
 	}
@@ -374,36 +365,6 @@ void MCControl::GetMargins(MCExecContext& ctxt, MCInterfaceMargins& r_margins)
         r_margins . margins[2] = rightmargin;
         r_margins . margins[3] = bottommargin;
     }
-}
-
-void MCControl::SetInk(MCExecContext& ctxt, intenum_t ink)
-{
-    MCObject::SetInk(ctxt, ink);
-    m_layer_attr_changed = true;
-}
-
-void MCControl::SetShowBorder(MCExecContext& ctxt, bool setting)
-{
-    MCObject::SetShowBorder(ctxt, setting);
-    m_layer_attr_changed = true;
-}
-
-void MCControl::SetShowFocusBorder(MCExecContext& ctxt, bool setting)
-{
-    MCObject::SetShowFocusBorder(ctxt, setting);
-    m_layer_attr_changed = true;
-}
-
-void MCControl::SetOpaque(MCExecContext& ctxt, bool setting)
-{
-    MCObject::SetOpaque(ctxt, setting);
-    m_layer_attr_changed = true;
-}
-
-void MCControl::SetShadow(MCExecContext& ctxt, const MCInterfaceShadow& p_shadow)
-{
-    MCObject::SetShadow(ctxt, p_shadow);
-    m_layer_attr_changed = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -464,9 +425,6 @@ MCExecEnumTypeInfo *kMCInterfaceBitmapEffectSourceTypeInfo = &_kMCInterfaceBitma
 
 void MCControl::EffectRedraw(MCRectangle p_old_rect)
 {
-    // MW-2011-09-21: [[ Layers ]] Mark the attrs as needing redrawn.
-    m_layer_attr_changed = true;
-            
     // MW-2011-08-17: [[ Layers ]] Make sure any redraw needed due to effects
     //   changing occur.
     layer_effectschanged(p_old_rect);

--- a/engine/src/exec-interface-field.cpp
+++ b/engine/src/exec-interface-field.cpp
@@ -527,9 +527,6 @@ void MCField::SetStyle(MCExecContext& ctxt, intenum_t p_style)
 	}
 	if (flags != tflags)
 	{
-		// MW-2011-09-21: [[ Layers ]] Make sure we recompute the layer attrs since
-		//   various props have changed!
-		m_layer_attr_changed = true;
 		Redraw(true, t_oldx, t_oldy);
 	}
 }

--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -280,10 +280,6 @@ void MCGroup::SetShowName(MCExecContext& ctxt, bool setting)
 {
 	if (changeflag(setting, F_SHOW_NAME))
 	{
-		// MW-2011-09-21: [[ Layers ]] Changing the showName property
-		//   affects the layer attrs.
-		m_layer_attr_changed = true;
-
 		if (computeminrect(False))
 			Redraw();
 	}

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -294,9 +294,7 @@ Boolean MCGraphic::mfocus(int2 x, int2 y)
 			realpoints[nrealpoints - 1].x = mx;
 			realpoints[nrealpoints - 1].y = my;
 		}
-		MCRectangle drect = rect;
-		compute_minrect();
-		Redraw(drect);
+		MayChangeRect();
 		message_with_args(MCM_mouse_move, x, y);
         
         // AL-2015-07-15: [[ Bug 15605 ]] Notify property listener of the change in points property
@@ -429,6 +427,11 @@ Boolean MCGraphic::doubleup(uint2 which)
 
 void MCGraphic::applyrect(const MCRectangle &nrect)
 {
+    if (opened && m_edit_tool != nullptr)
+    {
+        getcard()->dirtyselection(m_edit_tool->drawrect());
+    }
+    
 	if (realpoints != NULL)
 	{
 		if (nrect.width != rect.width || nrect.height != rect.height)
@@ -480,6 +483,11 @@ void MCGraphic::applyrect(const MCRectangle &nrect)
 
 	rect = nrect;
 	delpoints();
+    
+    if (opened && m_edit_tool != nullptr)
+    {
+        getcard()->dirtyselection(m_edit_tool->drawrect());
+    }
 }
 
 void MCGraphic::setgradientrect(MCGradientFill *p_gradient, const MCRectangle &nrect)
@@ -990,21 +998,6 @@ void MCGraphic::compute_minrect()
 	}
 }
 
-MCRectangle MCGraphic::geteffectiverect(void) const
-{
-	MCRectangle t_effectiverect;
-	t_effectiverect = MCControl::geteffectiverect();
-
-	if (m_edit_tool != NULL)
-	{
-		MCRectangle t_tool_rect = m_edit_tool->drawrect();
-		if (t_tool_rect.width != 0 && t_tool_rect.height != 0)
-			t_effectiverect = MCU_union_rect(t_effectiverect, t_tool_rect);
-	}
-
-	return t_effectiverect;
-}
-
 void MCGraphic::delpoints()
 {
 	if (points != NULL)
@@ -1417,15 +1410,22 @@ void MCGraphic::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool
 			drawborder(dc, rect, borderwidth);
 	}
 
-	if (!p_isolated)
-	{
-		dc -> end();
-        
-        if (m_edit_tool != NULL)
-            m_edit_tool->drawhandles(dc);
-	}
-
+    if (!p_isolated)
+    {
+        dc->end();
+    }
+    
 	dc -> setquality(QUALITY_DEFAULT);
+}
+
+void MCGraphic::drawselection(MCDC *p_dc, const MCRectangle& p_dirty)
+{
+    MCControl::drawselection(p_dc, p_dirty);
+    
+    if (m_edit_tool != nullptr)
+    {
+        m_edit_tool->drawhandles(p_dc);
+    }
 }
 
 MCGradientFill *MCGraphic::getgradient()
@@ -1448,12 +1448,7 @@ void MCGraphic::setpoint(uint4 i, int2 x, int2 y, bool redraw)
 {
 	if (realpoints[i].x != x || realpoints[i].y != y)
 	{
-		MCRectangle drect = rect;
-
-		MCRectangle t_old_effective_rect;
-		t_old_effective_rect = geteffectiverect();
-
-		realpoints[i].x = x;
+        realpoints[i].x = x;
 		realpoints[i].y = y;
 
 		if (oldpoints != NULL)
@@ -1461,7 +1456,7 @@ void MCGraphic::setpoint(uint4 i, int2 x, int2 y, bool redraw)
 			delete oldpoints;
 			oldpoints = NULL;
 		}
-
+        
 		if (redraw)
 		{
 			if (flags & F_OPAQUE)
@@ -1472,25 +1467,8 @@ void MCGraphic::setpoint(uint4 i, int2 x, int2 y, bool redraw)
                     return;
                 }
             }
-			compute_minrect();
-			if (rect.x != drect.x || rect.y != drect.y
-					|| rect.width != drect.width || rect.height != drect.height)
-			{
-				if (m_fill_gradient != NULL)
-				{
-					m_fill_gradient->old_origin.x = MININT2;
-					m_fill_gradient->old_origin.y = MININT2;
-				}
-				if (resizeparent())
-					return;
-			}
-			Redraw(drect);
-			if (opened)
-			{
-				// MW-2011-08-18: [[ Layers ]] Notify of the change in effective rect and invalidate.
-				layer_effectiverectchangedandredrawall(t_old_effective_rect);
-			}
-		}
+			MayChangeRect();
+        }
 	}
 }
 

--- a/engine/src/graphic.h
+++ b/engine/src/graphic.h
@@ -112,6 +112,7 @@ public:
 
 	// MW-2011-09-06: [[ Redraw ]] Added 'sprite' option - if true, ink and opacity are not set.
 	virtual void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite);
+    virtual void drawselection(MCDC *dc, const MCRectangle& dirty);
 
 	virtual Boolean maskrect(const MCRectangle &srect);
 	virtual void fliph();
@@ -126,7 +127,6 @@ public:
 	MCRectangle expand_minrect(const MCRectangle &trect);
 	MCRectangle reduce_minrect(const MCRectangle &trect);
 	void compute_minrect();
-	virtual MCRectangle geteffectiverect(void) const;
 	void delpoints();
 	bool closepolygon(MCPoint *&pts, uint2 &npts);
 	MCStringRef getlabeltext();
@@ -155,8 +155,13 @@ public:
 	
 	////////// PROPERTY SUPPORT METHODS
 
-	void Redraw(MCRectangle drect);
-	void Redraw(void);
+    /* MayChangeContent should be called by any property change which only affects
+     * the pixels being rendered */
+	void MayChangeContent(void);
+    
+    /* MayChangeRect should be called by any property which could cause a change to
+     * the rect of the control and possibly selection layer */
+    void MayChangeRect(void);
 
 	void DoGetLabel(MCExecContext& ctxt, bool to_unicode, bool effective, MCStringRef r_string);
 	void DoSetLabel(MCExecContext& ctxt, bool to_unicode, MCStringRef p_label);
@@ -242,5 +247,8 @@ public:
 	virtual void SetBackColor(MCExecContext& ctxt, const MCInterfaceNamedColor& color);
     virtual void SetForePattern(MCExecContext& ctxt, uinteger_t* pattern);
     virtual void SetBackPattern(MCExecContext& ctxt, uinteger_t* pattern);
+    
+private:
+    void SetPointsCommon(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points, bool p_relative);
 };
 #endif

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2152,54 +2152,31 @@ void MCGroup::boundcontrols()
 	}
 }
 
-void MCGroup::drawselectedchildren(MCDC *dc)
+void MCGroup::drawselection(MCDC *p_context, const MCRectangle& p_dirty)
 {
-    if (!opened || !(getflag(F_VISIBLE) || showinvisible()))
-        return;
+    MCAssert(getopened() != 0 && (getflag(F_VISIBLE) || showinvisible()));
     
     MCControl *t_control = controls;
     if (t_control == nil)
         return;
-    do
-    {
-        if (t_control -> getstate(CS_SELECTED))
-            t_control -> drawselected(dc);
-        
-        if (t_control -> gettype() == CT_GROUP)
-            static_cast<MCGroup *>(t_control) -> drawselectedchildren(dc);
-        
-        t_control = t_control -> next();
-    }
-    while (t_control != controls);
-}
-
-bool MCGroup::updatechildselectedrect(MCRectangle& x_rect)
-{
-    bool t_updated;
-    t_updated = false;
     
-    MCControl *t_control = controls;
-    if (t_control == nil)
-        return t_updated;
     do
     {
-        if (t_control -> getstate(CS_SELECTED))
+        if (t_control != nullptr &&
+             t_control->getopened() != 0 &&
+             (t_control->getflag(F_VISIBLE) || showinvisible()))
         {
-            x_rect = MCU_union_rect(t_control -> geteffectiverect(), x_rect);
-            t_updated = true;
-        }
-        
-        if (t_control -> gettype() == CT_GROUP)
-        {
-            MCGroup *t_group = static_cast<MCGroup *>(t_control);
-            t_updated = t_updated | t_group -> updatechildselectedrect(x_rect);
+            t_control->drawselection(p_context, p_dirty);
         }
         
         t_control = t_control -> next();
     }
     while (t_control != controls);
     
-    return t_updated;
+    if (getselected())
+    {
+        MCControl::drawselection(p_context, p_dirty);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -153,8 +153,7 @@ public:
     
     virtual bool isdeletable(bool p_check_flag);
     
-    void drawselectedchildren(MCDC *dc);
-    bool updatechildselectedrect(MCRectangle& x_rect);
+    virtual void drawselection(MCDC *dc, const MCRectangle& p_dirty);
     
 	MCControl *findchildwithid(Chunk_term type, uint4 p_id);
 

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -81,9 +81,6 @@ protected:
 	// MW-2011-09-21: [[ Layers ]] Whether the layer should be considered
 	//   completely opaque.
 	bool m_layer_is_opaque : 1;
-	// MW-2011-09-21: [[ Layers ]] Whether the layer's content is simple
-	//   enough that it can be passed directly (images, buttons with icons).
-	bool m_layer_is_direct : 1;
 	// MW-2011-09-21: [[ Layers ]] Whether the layer's object is unadorned
 	//   (i.e. has no scrollbars, borders, effects etc.).
 	bool m_layer_is_unadorned : 1;

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -74,16 +74,9 @@ protected:
 	// MW-2011-09-21: [[ Layers ]] The effective layerMode as used in the
 	//   last frame.
 	MCLayerModeHint m_layer_mode : 3;
-	// MW-2011-09-21: [[ Layers ]] Whether the layer is top-level or not.
-	//   A layer is considered top-level if it's parent is a group, or all
-	//   it's ancestors (up to card) are of 'container' type.
-	bool m_layer_is_toplevel : 1;
 	// MW-2011-09-21: [[ Layers ]] Whether the layer should be considered
 	//   completely opaque.
 	bool m_layer_is_opaque : 1;
-	// MW-2011-09-21: [[ Layers ]] Whether the layer's object is unadorned
-	//   (i.e. has no scrollbars, borders, effects etc.).
-	bool m_layer_is_unadorned : 1;
 	// MW-2011-09-21: [[ Layers ]] Whether the layer is a sprite or scenery
 	//   layer.
 	bool m_layer_is_sprite : 1;

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -67,20 +67,11 @@ protected:
 	// MW-2011-08-24: [[ Layers ]] The layer id of the control.
 	MCTileCacheLayerId m_layer_id;
 	
-	// MW-2011-09-21: [[ Layers ]] Whether something about the control has
-	//   changed requiring a recompute the layer attributes.
-	bool m_layer_attr_changed : 1;
 	// MW-2011-09-21: [[ Layers ]] The layerMode as specified by the user
 	MCLayerModeHint m_layer_mode_hint : 3;
 	// MW-2011-09-21: [[ Layers ]] The effective layerMode as used in the
 	//   last frame.
 	MCLayerModeHint m_layer_mode : 3;
-	// MW-2011-09-21: [[ Layers ]] Whether the layer should be considered
-	//   completely opaque.
-	bool m_layer_is_opaque : 1;
-	// MW-2011-09-21: [[ Layers ]] Whether the layer is a sprite or scenery
-	//   layer.
-	bool m_layer_is_sprite : 1;
 
 	static int2 defaultmargin;
 	static int2 xoffset;
@@ -119,6 +110,12 @@ public:
 
 	// MW-2011-09-06: [[ Redraw ]] Added 'sprite' option - if true, ink and opacity are not set.
 	virtual void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite) = 0;
+    
+    /* The 'render' method implements layer-based rendering for use with tilecache. */
+    virtual void render(MCTileCacheRef p_tilecache,
+                        bool p_reset,
+                        const MCGAffineTransform& p_transform,
+                        const MCRectangle& p_visible_rect);
 
 	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);
 	virtual Boolean kfocusset(MCControl *target);
@@ -152,6 +149,9 @@ public:
 	void attach(Object_pos p, bool invisible);
 
 	void redraw(MCDC *dc, const MCRectangle &dirty);
+    
+    bool render_sprite_layer(MCContext *p_target, const MCRectangle& p_rectangle);
+    bool render_scenery_layer(MCContext *p_target, const MCRectangle& p_rectangle);
 
 	// IM-2016-09-26: [[ Bug 17247 ]] Return rect of selection handles for the given object rect
 	static void sizerects(const MCRectangle &p_object_rect, MCRectangle rects[8]);
@@ -236,21 +236,17 @@ public:
 	// MW-2011-09-22: [[ Layers ]] Returns the layer mode hint.
 	MCLayerModeHint layer_getmodehint(void) { return m_layer_mode_hint; }
 	// MW-2011-11-24: [[ LayerMode Save ]] Sets the layer mode hint (used by object unpickling).
-	void layer_setmodehint(MCLayerModeHint p_mode) { m_layer_mode_hint = p_mode; m_layer_attr_changed = true; }
+	void layer_setmodehint(MCLayerModeHint p_mode) { m_layer_mode_hint = p_mode; }
 	// MW-2011-09-21: [[ Layers ]] Calculates the effective layer mode.
-	MCLayerModeHint layer_geteffectivemode(void) { return layer_computeattrs(false); }
+	MCLayerModeHint layer_geteffectivemode(void) { return m_layer_mode; }
 	// MW-2011-09-07: [[ Layers ]] Returns the content rect of the layer (if scrolling).
 	MCRectangle layer_getcontentrect(void);
 
 	// MW-2011-09-21: [[ Layers ]] Returns whether the layer is a sprite or not.
-	bool layer_issprite(void) { return m_layer_is_sprite; }
+	bool layer_issprite(void) { return m_layer_mode != kMCLayerModeHintStatic; }
 	// MW-2011-09-21: [[ Layers ]] Returns whether the layer is scrolling or not.
 	bool layer_isscrolling(void) { return m_layer_mode == kMCLayerModeHintScrolling; }
-	// MW-2011-09-21: [[ Layers ]] Returns whether the layer is opaque or not.
-	bool layer_isopaque(void) { return m_layer_is_opaque; }
 
-	// MW-2011-09-21: [[ Layers ]] Make sure the layerMode attr's are accurate.
-	MCLayerModeHint layer_computeattrs(bool commit);
 	// MW-2011-09-21: [[ Layers ]] Reset the attributes to defaults.
 	void layer_resetattrs(void);
 
@@ -351,12 +347,6 @@ public:
     virtual void SetMargins(MCExecContext& ctxt, const MCInterfaceMargins& p_margins);
     void GetMargins(MCExecContext& ctxt, MCInterfaceMargins& r_margins);
     
-    virtual void SetInk(MCExecContext& ctxt, intenum_t ink);
-    virtual void SetShowBorder(MCExecContext& ctxt, bool setting);
-	virtual void SetShowFocusBorder(MCExecContext& ctxt, bool setting);
-    virtual void SetOpaque(MCExecContext& ctxt, bool setting);
-	virtual void SetShadow(MCExecContext& ctxt, const MCInterfaceShadow& p_shadow);
-
     void GetDropShadowProperty(MCExecContext& ctxt, MCNameRef index, MCExecValue& r_value);
     void SetDropShadowProperty(MCExecContext& ctxt, MCNameRef index, MCExecValue p_value);
     void GetInnerShadowProperty(MCExecContext& ctxt, MCNameRef index, MCExecValue& r_value);

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -22,6 +22,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define __CONTROL_H
 
 #include "object.h"
+#include "tilecache.h"
 
 // This enum describes the 'hint' that is applied to the object via
 // the 'layerMode' property. The engine uses this to derive the actual
@@ -64,7 +65,7 @@ protected:
 	MCBitmapEffectsRef m_bitmap_effects;
 
 	// MW-2011-08-24: [[ Layers ]] The layer id of the control.
-	uint32_t m_layer_id;
+	MCTileCacheLayerId m_layer_id;
 	
 	// MW-2011-09-21: [[ Layers ]] Whether something about the control has
 	//   changed requiring a recompute the layer attributes.
@@ -228,9 +229,9 @@ public:
 	void layer_dirtycontentrect(const MCRectangle& content_rect, bool update_card);
 
 	// MW-2011-08-24: [[ TileCache ]] Returns the current layer id.
-	uint32_t layer_getid(void) { return m_layer_id; }
+	MCTileCacheLayerId layer_getid(void) { return m_layer_id; }
 	// MW-2011-08-24: [[ TileCache ]] Set thes layer id.
-	void layer_setid(uint32_t p_id) { m_layer_id = p_id; }
+	void layer_setid(MCTileCacheLayerId p_id) { m_layer_id = p_id; }
 
 	// MW-2011-09-22: [[ Layers ]] Returns the layer mode hint.
 	MCLayerModeHint layer_getmodehint(void) { return m_layer_mode_hint; }

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -156,7 +156,8 @@ public:
 	// IM-2016-09-26: [[ Bug 17247 ]] Return rect of selection handles for the given object rect
 	static void sizerects(const MCRectangle &p_object_rect, MCRectangle rects[8]);
 	
-	void drawselected(MCDC *dc);
+	virtual void drawselection(MCDC *dc, const MCRectangle& p_dirty);
+    
 	void drawarrow(MCDC *dc, int2 x, int2 y, uint2 size,
 	               Arrow_direction dir, Boolean border, Boolean hilite);
 	void continuesize(int2 x, int2 y);

--- a/engine/src/player-legacy.cpp
+++ b/engine/src/player-legacy.cpp
@@ -930,12 +930,6 @@ void MCPlayer::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 		else
 			drawborder(dc, rect, borderwidth);
 	}
-	
-	if (!p_isolated)
-	{
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
-	}
     
 	if (!p_isolated)
 		dc -> end();

--- a/engine/src/player-srv-stubs.cpp
+++ b/engine/src/player-srv-stubs.cpp
@@ -769,12 +769,6 @@ void MCPlayer::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 		else
 			drawborder(dc, rect, borderwidth);
 	}
-	
-	if (!p_isolated)
-	{
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
-	}
     
 	if (!p_isolated)
 		dc -> end();

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -747,29 +747,6 @@ void MCCard::layer_setviewport(int32_t p_x, int32_t p_y, int32_t p_width, int32_
 		layer_dirtyrect(rect);
 }
 
-void MCCard::layer_selectedrectchanged(const MCRectangle& p_old_rect, const MCRectangle& p_new_rect)
-{
-	MCTileCacheRef t_tilecache;
-	t_tilecache = getstack() -> view_gettilecache();
-
-	if (t_tilecache != nil)
-	{
-		// IM-2013-08-21: [[ ResIndependence ]] Use device coords for tilecache operation
-		// IM-2013-09-30: [[ FullscreenMode ]] Use stack transform to get device coords
-		MCGAffineTransform t_transform;
-		t_transform = getstack()->getdevicetransform();
-		
-		MCRectangle32 t_new_device_rect, t_old_device_rect;
-		t_new_device_rect = MCRectangle32GetTransformedBounds(p_new_rect, t_transform);
-		t_old_device_rect = MCRectangle32GetTransformedBounds(p_old_rect, t_transform);
-		MCTileCacheUpdateScenery(t_tilecache, m_fg_layer_id, t_old_device_rect);
-        MCTileCacheUpdateScenery(t_tilecache, m_fg_layer_id, t_new_device_rect);
-	}
-
-	layer_dirtyrect(p_old_rect);
-	layer_dirtyrect(p_new_rect);
-}
-
 void MCCard::layer_dirtyrect(const MCRectangle& p_dirty_rect)
 {
 	getstack() -> dirtyrect(p_dirty_rect);
@@ -850,15 +827,8 @@ bool MCCard::render_background(MCContext *p_dc, const MCRectangle& p_dirty)
 
 bool MCCard::render_foreground(MCContext *p_dc, const MCRectangle& p_dirty)
 {
-    drawselectedchildren(p_dc);
-    
     drawcardborder(p_dc, p_dirty);
-    
-    if (getstate(CS_SIZE))
-    {
-        drawselectionrect(p_dc);
-    }
-    
+    drawselection(p_dc, p_dirty);
     return true;
 }
 

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -51,7 +51,6 @@ void MCControl::layer_resetattrs(void)
 {
 	m_layer_mode = kMCLayerModeHintStatic;
 	m_layer_is_opaque = false;
-	m_layer_is_unadorned = false;
 	m_layer_is_sprite = false;
 	m_layer_attr_changed = true;
 	m_layer_id = 0;
@@ -71,7 +70,6 @@ MCLayerModeHint MCControl::layer_computeattrs(bool p_commit)
 	{
 		m_layer_mode = kMCLayerModeHintStatic;
 		m_layer_is_opaque = false;
-		m_layer_is_unadorned = false;
 		m_layer_is_sprite = false;
 	}
 
@@ -226,7 +224,6 @@ MCLayerModeHint MCControl::layer_computeattrs(bool p_commit)
 	{
 		m_layer_mode = t_layer_mode;
 		m_layer_is_opaque = t_is_opaque;
-		m_layer_is_unadorned = t_is_unadorned;
 		m_layer_is_sprite = t_is_sprite;
 
 		// We've updated the layer attrs now - yay!

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -53,7 +53,6 @@ void MCControl::layer_resetattrs(void)
 	m_layer_is_opaque = false;
 	m_layer_is_unadorned = false;
 	m_layer_is_sprite = false;
-	m_layer_is_direct = false;
 	m_layer_attr_changed = true;
 	m_layer_id = 0;
 }
@@ -74,7 +73,6 @@ MCLayerModeHint MCControl::layer_computeattrs(bool p_commit)
 		m_layer_is_opaque = false;
 		m_layer_is_unadorned = false;
 		m_layer_is_sprite = false;
-		m_layer_is_direct = false;
 	}
 
 	// The opacity of a control depends on what flags it has set - in particular
@@ -223,19 +221,6 @@ MCLayerModeHint MCControl::layer_computeattrs(bool p_commit)
 	else
 		t_is_sprite = false;
 
-	// And now the direct attribute.
-	bool t_is_direct;
-	if (t_is_sprite)
-	{
-		// An unadorned image or button are direct.
-		if (t_is_unadorned && (gettype() == CT_IMAGE || gettype() == CT_BUTTON))
-			t_is_direct = true;
-		else
-			t_is_direct = false;
-	}
-	else
-		t_is_direct = false;
-
 	// Finally, sync the attribtues.
 	if (p_commit)
 	{
@@ -243,7 +228,6 @@ MCLayerModeHint MCControl::layer_computeattrs(bool p_commit)
 		m_layer_is_opaque = t_is_opaque;
 		m_layer_is_unadorned = t_is_unadorned;
 		m_layer_is_sprite = t_is_sprite;
-		m_layer_is_direct = t_is_direct;
 
 		// We've updated the layer attrs now - yay!
 		m_layer_attr_changed = false;

--- a/engine/src/redraw.h
+++ b/engine/src/redraw.h
@@ -17,6 +17,40 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #ifndef __MC_REDRAW__
 #define __MC_REDRAW__
 
+void MCRedrawBeginDeviceSceneryLayer(MCObject* obj, MCGContextRef gcontext, const MCRectangle32& p_rect, MCContext*& r_user_context, MCRectangle& r_user_rect);
+void MCRedrawEndDeviceSceneryLayer(MCContext* user_context);
+
+void MCRedrawBeginDeviceSpriteLayer(MCObject* obj, MCGContextRef gcontext, const MCRectangle32& p_rect, MCContext*& r_user_context, MCRectangle& r_user_rect);
+void MCRedrawEndDeviceSpriteLayer(MCContext* user_context);
+
+template<typename Object, bool (Object::*Method)(MCContext *target, const MCRectangle& region)>
+bool MCRedrawRenderDeviceSceneryLayer(void *p_context, MCGContextRef p_gcontext, const MCRectangle32& p_rectangle)
+{
+    bool t_success;
+    Object *t_this = static_cast<Object *>(p_context);
+    MCContext *t_user_context;
+    MCRectangle t_user_rect;
+    MCRedrawBeginDeviceSceneryLayer(t_this, p_gcontext, p_rectangle, t_user_context, t_user_rect);
+    t_success = (t_this->*Method)(t_user_context, t_user_rect);
+    MCRedrawEndDeviceSceneryLayer(t_user_context);
+    return t_success;
+}
+
+template<typename Object, bool (Object::*Method)(MCContext *target, const MCRectangle& region)>
+bool MCRedrawRenderDeviceSpriteLayer(void *p_context, MCGContextRef p_gcontext, const MCRectangle32& p_rectangle)
+{
+    bool t_success;
+    Object *t_this = static_cast<Object *>(p_context);
+    MCContext *t_user_context;
+    MCRectangle t_user_rect;
+    MCRedrawBeginDeviceSpriteLayer(t_this, p_gcontext, p_rectangle, t_user_context, t_user_rect);
+    t_success = (t_this->*Method)(t_user_context, t_user_rect);
+    MCRedrawEndDeviceSpriteLayer(t_user_context);
+    return t_success;
+}
+
+/****/
+
 bool MCRedrawIsScreenLocked(void);
 void MCRedrawSaveLockScreen(uint2& r_lock);
 void MCRedrawRestoreLockScreen(uint2 lock);

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -281,7 +281,7 @@ protected:
 	MCTileCacheRef m_view_tilecache;
 
 	// IM-2013-10-14: [[ FullscreenMode ]] The tilecache layer ID of the view background
-	uint32_t m_view_bg_layer_id;
+	MCTileCacheLayerId m_view_bg_layer_id;
 	
 	// MW-2011-08-19: [[ Redraw ]] The region of the view that needs to be
 	//   drawn to the screen on the next update.

--- a/engine/src/tilecache.cpp
+++ b/engine/src/tilecache.cpp
@@ -1068,7 +1068,7 @@ static void MCTileCacheFlushCellsContainingLayers(MCTileCacheRef self, uint32_t 
 		}
 }
 
-void MCTileCacheInsertScenery(MCTileCacheRef self, uint32_t p_before_layer, const MCRectangle32& p_region)
+void MCTileCacheInsertScenery(MCTileCacheRef self, MCTileCacheLayerId p_before_layer, const MCRectangle32& p_region)
 {
 	// If we are inserting at the start, there is nothing to do.
 	if (p_before_layer == 1)
@@ -1078,13 +1078,13 @@ void MCTileCacheInsertScenery(MCTileCacheRef self, uint32_t p_before_layer, cons
 	MCTileCacheFlushCellsContainingLayers(self, p_before_layer - 1, p_before_layer, p_region);
 }
 
-void MCTileCacheRemoveScenery(MCTileCacheRef self, uint32_t p_layer, const MCRectangle32& p_region)
+void MCTileCacheRemoveScenery(MCTileCacheRef self, MCTileCacheLayerId p_layer, const MCRectangle32& p_region)
 {
 	// When removing a scenery layer, we need only flush any tiles containing it.
 	MCTileCacheFlushCellsContainingLayers(self, p_layer, p_layer, p_region);
 }
 
-void MCTileCacheReshapeScenery(MCTileCacheRef self, uint32_t p_layer, const MCRectangle32& p_old_region, const MCRectangle32& p_new_region)
+void MCTileCacheReshapeScenery(MCTileCacheRef self, MCTileCacheLayerId p_layer, const MCRectangle32& p_old_region, const MCRectangle32& p_new_region)
 {
 	// Remove the layer for the old region.
 	MCTileCacheRemoveScenery(self, p_layer, p_old_region);
@@ -1092,7 +1092,7 @@ void MCTileCacheReshapeScenery(MCTileCacheRef self, uint32_t p_layer, const MCRe
 	MCTileCacheInsertScenery(self, p_layer + 1, p_new_region);
 }
 
-void MCTileCacheUpdateScenery(MCTileCacheRef self, uint32_t p_layer, const MCRectangle32& p_region)
+void MCTileCacheUpdateScenery(MCTileCacheRef self, MCTileCacheLayerId p_layer, const MCRectangle32& p_region)
 {
 	// When updating a scenery layer, we need only flush any tiles touching it and the update region.
 	MCTileCacheFlushCellsContainingLayers(self, p_layer, p_layer, p_region);
@@ -1311,7 +1311,7 @@ static bool MCTileCacheInsertSprite(MCTileCacheRef self, MCTileCacheRenderCallba
 	return true;
 }
 
-void MCTileCacheRemoveSprite(MCTileCacheRef self, uint32_t p_id)
+void MCTileCacheRemoveSprite(MCTileCacheRef self, MCTileCacheLayerId p_id)
 {
 	// Do nothing if the tilecache is invalid.
 	if (!self -> valid)
@@ -1336,7 +1336,7 @@ void MCTileCacheRemoveSprite(MCTileCacheRef self, uint32_t p_id)
 			MCTileCacheDirtyTile(self, *MCTileCacheGetSpriteCell(self, p_id, x, y));
 }
 
-void MCTileCacheScrollSprite(MCTileCacheRef self, uint32_t p_id, int32_t p_dx, int32_t p_dy)
+void MCTileCacheScrollSprite(MCTileCacheRef self, MCTileCacheLayerId p_id, int32_t p_dx, int32_t p_dy)
 {
 	// Do nothing if the tilecache is invalid.
 	if (!self -> valid)
@@ -1359,7 +1359,7 @@ void MCTileCacheScrollSprite(MCTileCacheRef self, uint32_t p_id, int32_t p_dx, i
 	t_sprite -> yorg -= p_dy;
 }
 
-void MCTileCacheUpdateSprite(MCTileCacheRef self, uint32_t p_id, const MCRectangle32& p_region)
+void MCTileCacheUpdateSprite(MCTileCacheRef self, MCTileCacheLayerId p_id, const MCRectangle32& p_region)
 {
 	// Do nothing if the tilecache is invalid.
 	if (!self -> valid)
@@ -1487,8 +1487,8 @@ void MCTileCacheEndFrame(MCTileCacheRef self)
 
 	// Some statistics
 #ifdef _DEBUG
-    //MCLog("Frame - %d sprite tiles, %d scenery tiles, %d active tiles, %d instructions, %d bytes",
-    //			self -> sprite_render_list . length, self -> scenery_render_list . length, self -> active_tile_count, self -> display_list_frontier, self -> cache_size);
+    MCLog("Frame - %d sprite tiles, %d scenery tiles, %d active tiles, %d instructions, %d bytes",
+    			self -> sprite_render_list . length, self -> scenery_render_list . length, self -> active_tile_count, self -> display_list_frontier, self -> cache_size);
 #endif
 }
 

--- a/engine/src/tilecache.h
+++ b/engine/src/tilecache.h
@@ -20,6 +20,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 // The tilecache opaque handle.
 typedef struct MCTileCache *MCTileCacheRef;
 
+// The tilecache layer id type
+typedef uint32_t MCTileCacheLayerId;
+
 // The callback type required to render layers.
 typedef bool (*MCTileCacheRenderCallback)(void *context, MCGContextRef target, const MCRectangle32& region);
 
@@ -88,7 +91,7 @@ enum MCTileCacheCompositorType
 struct MCTileCacheLayer
 {
 	// The previous id of the layer (or zero if new).
-	uint32_t id;
+	MCTileCacheLayerId id;
 	// The region the layer touches.
 	MCRectangle32 region;
 	// This should be true if the layer is completely opaque in region.
@@ -153,20 +156,20 @@ void MCTileCacheFlush(MCTileCacheRef self);
 void MCTileCacheCompact(MCTileCacheRef self);
 
 // A scenery layer has been inserted before the given layer touching the given region.
-void MCTileCacheInsertScenery(MCTileCacheRef self, uint32_t before_layer, const MCRectangle32& region);
+void MCTileCacheInsertScenery(MCTileCacheRef self, MCTileCacheLayerId before_layer, const MCRectangle32& region);
 // The given scenery layer touching the given region has been removed.
-void MCTileCacheRemoveScenery(MCTileCacheRef self, uint32_t layer, const MCRectangle32& region);
+void MCTileCacheRemoveScenery(MCTileCacheRef self, MCTileCacheLayerId layer, const MCRectangle32& region);
 // The given scenery layer has been reshaped from the old region to the new region.
-void MCTileCacheReshapeScenery(MCTileCacheRef self, uint32_t layer, const MCRectangle32& old_region, const MCRectangle32& new_region);
+void MCTileCacheReshapeScenery(MCTileCacheRef self, MCTileCacheLayerId layer, const MCRectangle32& old_region, const MCRectangle32& new_region);
 // The given scenery layer has changed within the given region.
-void MCTileCacheUpdateScenery(MCTileCacheRef self, uint32_t layer, const MCRectangle32& region);
+void MCTileCacheUpdateScenery(MCTileCacheRef self, MCTileCacheLayerId layer, const MCRectangle32& region);
 
 // The given sprite has been removed.
-void MCTileCacheRemoveSprite(MCTileCacheRef self, uint32_t id);
+void MCTileCacheRemoveSprite(MCTileCacheRef self, MCTileCacheLayerId id);
 // The given sprite has changed within the given region.
-void MCTileCacheUpdateSprite(MCTileCacheRef self, uint32_t id, const MCRectangle32& region);
+void MCTileCacheUpdateSprite(MCTileCacheRef self, MCTileCacheLayerId id, const MCRectangle32& region);
 // The given sprite's cached tiles are scrolled by the given amount.
-void MCTileCacheScrollSprite(MCTileCacheRef self, uint32_t id, int32_t dx, int32_t dy);
+void MCTileCacheScrollSprite(MCTileCacheRef self, MCTileCacheLayerId id, int32_t dx, int32_t dy);
 
 // Start processing a new frame.
 void MCTileCacheBeginFrame(MCTileCacheRef self);

--- a/engine/src/tilecache.h
+++ b/engine/src/tilecache.h
@@ -177,8 +177,6 @@ void MCTileCacheEndFrame(MCTileCacheRef self);
 void MCTileCacheRenderScenery(MCTileCacheRef self, MCTileCacheLayer& layer);
 // Render a sprite layer with the given parameters into the current frame.
 void MCTileCacheRenderSprite(MCTileCacheRef self, MCTileCacheLayer& layer);
-// Render a direct sprite layer with the given parameters into the current frame.
-void MCTileCacheRenderDirectSprite(MCTileCacheRef self, MCTileCacheLayer& layer, const void *color_bits, const void *alpha_bits);
 
 // Composite the current frame onto the given surface.
 bool MCTileCacheComposite(MCTileCacheRef self, MCStackSurface *surface, MCGRegionRef region);


### PR DESCRIPTION
This patch is a series of commits tidying up and refactoring parts of the tilecache / accelerated rendering mode.

As it stands it removes various unused instance methods related to layers, makes layer mode type computation live (removing the 'layer attr needs update' logic), and moves MCControl and MCCard related code into a more appropriate place using a virtual 'render' method. The next step is to make the render code per-control - taking the branching logic out of the MCControl render method for things like scrolling groups and also enabling a control to render multiple layers (this should remove the need for a scrolling layer mode entirely).

In addition, it fixes an issue with selection handles in accelRender mode - although that needs a little more tweaking - it probably makes more sense to have a separate 'selection' layer which is a sprite rather than scenery.

One thing which I noticed whilst doing this is that unbounded, opaque groups will not ever be scrolling - more investigation is needed here what goes wrong there as that is probably a significant reason why some scrolling groups on mobile suffer from poor performance.