### PR TITLE
[Bug 20507] Ensure Y is respected in 'read from socket X for Y'

### DIFF
--- a/docs/notes/bugfix-20507.md
+++ b/docs/notes/bugfix-20507.md
@@ -1,0 +1,1 @@
+# Ensure Y is respected in 'read from socket X for Y'

--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -651,7 +651,7 @@ void MCNetworkExecReadFromSocket(MCExecContext& ctxt, MCNameRef p_socket, uint4 
             t_data = MCS_read_socket(MCsockets[t_index], ctxt, p_count, *t_sentinel, p_message);
         }
 		else
-			t_data = MCS_read_socket(MCsockets[t_index], ctxt, 0, nil, p_message);
+			t_data = MCS_read_socket(MCsockets[t_index], ctxt, p_count, nil, p_message);
 
 		if (p_message == NULL)
 		{


### PR DESCRIPTION
When there is no sentinel string, `MCS_read_socket` should be called with `p_count` and not `0`. This was introduced in the LC7 refactoring