### PR TITLE
Update URL-scheme.lcdoc

### DIFF
--- a/docs/glossary/u/URL-scheme.lcdoc
+++ b/docs/glossary/u/URL-scheme.lcdoc
@@ -10,7 +10,7 @@ URL schemes supported by LiveCode include <http>, <ftp>, <file>,
 <resfile>, and <binfile>.
 
 References: URL (glossary), FTP (glossary), file (glossary),
-binfile (glossary), HTTP (glossary), resfile (glossary)
+binfile (keyword), HTTP (glossary), resfile (keyword)
 
 Tags: networking
 

--- a/docs/glossary/u/URL-scheme.lcdoc
+++ b/docs/glossary/u/URL-scheme.lcdoc
@@ -6,7 +6,7 @@ Type: glossary
 
 Description:
 A type of <URL>, specified by the part of the <URL> before the "://".
-URL schemes supported by LiveCode unclude <http>, <ftp>, <file>,
+URL schemes supported by LiveCode include <http>, <ftp>, <file>,
 <resfile>, and <binfile>.
 
 References: URL (glossary), FTP (glossary), file (glossary),


### PR DESCRIPTION
Include not Unclude, LOL. There is also issue on LC9 dp9 where binfile is not displayed at the end of the description for some reason but I don't see where that might be coming from here. Maybe ` binfile <binfile>`  is not setup as a valid keyword?