### PR TITLE
[[Bug 20515]] Segmented control widget highlights off

### DIFF
--- a/extensions/widgets/segmented/notes/20515.md
+++ b/extensions/widgets/segmented/notes/20515.md
@@ -1,0 +1,1 @@
+# [20515] Prevent segmented control fill from ending one pixel to the left/bottom of segment.

--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -379,7 +379,7 @@ end handler
 -- vertical pixel span to a whole number of pixels, in such a way that
 -- the input span is always fully contained within the output span.
 handler hintLower(in pBound as Number) returns Number
-	return the floor of (pBound)
+	return the ceiling of (pBound - 0.5)
 end handler
 handler hintUpper(in pBound as Number) returns Number
 	return the floor of (pBound + 0.5)

--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -379,7 +379,7 @@ end handler
 -- vertical pixel span to a whole number of pixels, in such a way that
 -- the input span is always fully contained within the output span.
 handler hintLower(in pBound as Number) returns Number
-	return the floor of (pBound - 0.5)
+	return the floor of (pBound)
 end handler
 handler hintUpper(in pBound as Number) returns Number
 	return the floor of (pBound + 0.5)


### PR DESCRIPTION
`hintLower` handler should not subtract 0.5 from pBound.  This was resulting in an un-highlighted line one pixel wide at the right/bottom side of a cell depending on how the rounding went.