### PR TITLE
[[Bug 20516]] segmented control - orientation change issue

### DIFF
--- a/extensions/widgets/segmented/notes/20516.md
+++ b/extensions/widgets/segmented/notes/20516.md
@@ -1,0 +1,1 @@
+# [20516] Switching orientation did not properly redraw widget.

--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -1290,6 +1290,7 @@ end handler
 
 public handler SetHorizontal(in pHorizontal as Boolean) returns nothing
 	put pHorizontal into mIsHorizontal
+	put true into mGeometryIsChanged
 	redraw all
 end handler
 


### PR DESCRIPTION
When changing the orientation of the widget, the internals of the shape are not being recalculated and drawn properly (until some other event changes the geometry).  The `SetHorizontal` handler needed to mark the geometry as being changed.