### PR TITLE
[Dictionary] Various miscellaneous changes

### DIFF
--- a/docs/dictionary/constant/colon.lcdoc
+++ b/docs/dictionary/constant/colon.lcdoc
@@ -17,9 +17,9 @@ Example:
 replace slash with colon in tPath
 
 Description:
-Use the <colon> <constant> as an easier-to-read replacement for ":"
+Use the <colon> <constant (glossary)> as an easier-to-read replacement for ":"
 
-References: constant (command), character (keyword),
+References: constant (glossary), character (keyword),
 itemDelimiter (property)
 
 Tags: text processing

--- a/docs/dictionary/constant/comma.lcdoc
+++ b/docs/dictionary/constant/comma.lcdoc
@@ -22,7 +22,7 @@ if char 3 of it is comma then get field "Circus"
 Description:
 Use the <comma> <constant> as an easier-to-read replacement for ",".
 
-References: constant (command), character (keyword),  (operator),
+References: constant (command), character (keyword), &#44; (operator),
 itemDelimiter (property)
 
 Tags: text processing

--- a/docs/dictionary/function/colorNames.lcdoc
+++ b/docs/dictionary/function/colorNames.lcdoc
@@ -30,7 +30,7 @@ Use the <colorNames> <property> to check whether a particular color name
 can be used to specify <properties> such as <foregroundColor> and
 <backgroundColor>. 
 
-You can use the color names with the foregroundColor, <backgroundColor>,
+You can use the color names with the <foregroundColor>, <backgroundColor>,
 <focusColor>, <topColor>, <bottomColor>, <hiliteColor>, <borderColor>,
 <shadowColor>, <selectionHandleColor>, <accentColor>, <backdrop>,
 <brushColor>, and <penColor> <properties>.

--- a/docs/dictionary/function/commandArguments.lcdoc
+++ b/docs/dictionary/function/commandArguments.lcdoc
@@ -40,7 +40,7 @@ Parameters:
 index (integer):
 An integer greater than 0.
 If the index is greater than the number of arguments, then
-commandArguments returns empty. .
+commandArguments returns empty.
 
 Returns:
 Returns either a numeric array with all the commandline arguments if no

--- a/docs/dictionary/keyword/COMncolon.lcdoc
+++ b/docs/dictionary/keyword/COMncolon.lcdoc
@@ -5,9 +5,9 @@ Type: keyword
 Syntax: COMn:
 
 Summary:
-Used with the <open file>, <read from file>, <write to file>, and <close
-file> <command|commands>, to specify a COM <port> on <Windows|Windows
-systems>. 
+Used with the <open file>, <read from file>, <write to file>, and 
+<close file> <command|commands>, to specify a COM <port> on 
+<Windows|Windows systems>. 
 
 Introduced: 1.0
 

--- a/docs/dictionary/property/coloroverlay.lcdoc
+++ b/docs/dictionary/property/coloroverlay.lcdoc
@@ -29,8 +29,8 @@ The <colorOverlay> is an array style property, each key of the array
 controls a different <colorOverlay> parameter that will affect its final
 appearance. The easiest way to adjust these properties is by using the
 Graphic Effects card of the property inspector which has full control
-over each parameter. To control the effect by script use the following
-properties: 
+over each parameter. To control the effect by script use the 
+following properties: 
 
 colorOverlay["color"]
 

--- a/docs/dictionary/property/colors.lcdoc
+++ b/docs/dictionary/property/colors.lcdoc
@@ -34,10 +34,10 @@ Example:
 set the colors of this stack to the colors of stack "Home"
 
 Value:
-The <colors> of an <object(glossary)> is a list of <color
-reference|color references>, one per line. A color reference is any
-standard color name; or three comma-separated integers between zero and
-255, specifying the level of each of red, green, and blue; or an
+The <colors> of an <object(glossary)> is a list of 
+<color reference|color references>, one per line. A color reference is 
+any standard color name; or three comma-separated integers between zero 
+and 255, specifying the level of each of red, green, and blue; or an
 HTML-style color consisting of a hash mark (#) followed by three
 hexadecimal numbers, one for each of red, green, and blue.
 

--- a/docs/dictionary/property/columnDelimiter.lcdoc
+++ b/docs/dictionary/property/columnDelimiter.lcdoc
@@ -32,9 +32,9 @@ From LiveCode 7.0, <columnDelimiter> can be a string of one or several
 <tab>. 
 
 Description:
-Use the <columnDelimiter> property in conjunction with the <split
-command> to divide text into an array of columns or with the <combine
-command> to combine an array of columns into a string.
+Use the <columnDelimiter> property in conjunction with the <split>
+command to divide text into an array of columns or with the <combine>
+command to combine an array of columns into a string.
 
 From LiveCode 7.0, <columnDelimiter> can be a string of one or several
 <character|characters>. 
@@ -44,5 +44,5 @@ Since the <columnDelimiter> is a local property, its value is reset to
 only for the current handler and setting it in one handler does not
 affect its value in other handlers called.
 
-References: combine command (command), split (command),
-split command (command), character (keyword)
+References: combine (command), split (command), split (command), 
+character (keyword)

--- a/docs/dictionary/property/commandChar.lcdoc
+++ b/docs/dictionary/property/commandChar.lcdoc
@@ -15,8 +15,8 @@ OS: ios, android
 Platforms: desktop, server, mobile
 
 Description:
-In HyperCard, the <commandChar> <property> determines the Command <key
-combination> for a <menu item>.
+In HyperCard, the <commandChar> <property> determines the Command 
+<key combination> for a <menu item>.
 
 A handler can set the <commandChar> to any <value> without causing a
 <error|script error>, but the actual Command <key combination> is not

--- a/docs/glossary/c/compile-error.lcdoc
+++ b/docs/glossary/c/compile-error.lcdoc
@@ -10,9 +10,9 @@ A problem or mistake in a <handler> that prevents it from being
 <compile|compiled>. 
 
 Most often, compile errors are caused by incomplete or incorrect
-<control structure|control structures> (such as a <repeat> <control
-structure|structure> with no <end repeat>) or by punctuation errors
-(such as failing to <quote> a <literal string>).
+<control structure|control structures> (such as a <repeat> 
+<control structure|structure> with no <end repeat>) or by punctuation 
+errors (such as failing to <quote> a <literal string>).
 
 References: quote (constant), repeat (control structure),
 handler (glossary), literal string (glossary), compile (glossary),


### PR DESCRIPTION
Fixed broken link/text display issues in:
 - colon (constant)
 - comma (constant)
 - colorNames (function)
 - commandArguments (function)
 - COMncolon (keyword)
 - coloroverlay (property)
 - colors (property)
 - columnDelimiter (property)
 - commandChar (property)
 - compile error (glossary)