### PR TITLE
[[ Bug 20510 ]] Fix crash in revDatabaseTableNames

### DIFF
--- a/docs/notes/bugfix-20510.md
+++ b/docs/notes/bugfix-20510.md
@@ -1,0 +1,1 @@
+# Fix crash on Windows when using revDatabaseTableNames()

--- a/revdb/src/dbmysql.h
+++ b/revdb/src/dbmysql.h
@@ -52,6 +52,7 @@ protected:
 class DBConnection_MYSQL: public CDBConnection
 {
 public:
+    DBConnection_MYSQL(): m_internal_buffer(nullptr) {}
 	~DBConnection_MYSQL() {disconnect();}
 	Bool connect(char **args, int numargs);
 	void disconnect();
@@ -67,10 +68,11 @@ public:
 	void getTables(char *buffer, int *bufsize);
 	int getConnectionType(void) { return -1; }
 	int getVersion(void) { return 2; }
-    large_buffer_t *m_internal_buffer;
 protected:
 	bool BindVariables(MYSQL_STMT *p_statement, DBString *p_arguments, int p_argument_count, int *p_placeholders, int p_placeholder_count, MYSQL_BIND **p_bind);
 	bool ExecuteQuery(char *p_query, DBString *p_arguments, int p_argument_count);
 	MYSQL mysql;
+private:
+    large_buffer_t *m_internal_buffer;
 };
 #endif

--- a/revdb/src/dbpostgresql.h
+++ b/revdb/src/dbpostgresql.h
@@ -123,6 +123,7 @@ protected:
 class DBConnection_POSTGRESQL: public CDBConnection
 {
 public:
+    DBConnection_POSTGRESQL(): m_internal_buffer(nullptr) {}
 	~DBConnection_POSTGRESQL() {disconnect();}
 	Bool connect(char **args, int numargs);
 	void disconnect();


### PR DESCRIPTION
This patch ensures the m_internal_buffer instance var introduced
in the MySQL and PostgreSQL drivers to fix the length limit of
the revDatabaseTableNames call is initialized to nullptr when
the connection is created.