### PR TITLE
[[ Bug 20503 ]] Map ISOSection key code to appropriate XK code

### DIFF
--- a/docs/notes/bugfix-20503.md
+++ b/docs/notes/bugfix-20503.md
@@ -1,0 +1,1 @@
+# Fix quote key not working with Turkish keyboard layout on Mac

--- a/engine/src/platform.h
+++ b/engine/src/platform.h
@@ -338,6 +338,7 @@ enum
 	
 	kMCPlatformKeyCodeGrave			= 0x0060,
 	
+	kMCPlatformKeyCodeISOSection	= 0x00A7,
 	
 	kMCPlatformKeyCodeBackspace		= 0xff08,
 	kMCPlatformKeyCodeTab			= 0xff09,
@@ -455,7 +456,6 @@ enum
 	kMCPlatformKeyCodeVolumeUp		= 0xfffe,
 	kMCPlatformKeyCodeVolumeDown	= 0xfffe,
 	kMCPlatformKeyCodeMute			= 0xfffe,
-	kMCPlatformKeyCodeISOSection	= 0xfffe,
 	kMCPlatformKeyCodeJISYen		= 0xfffe,
 	kMCPlatformKeyCodeJISUnderscore	= 0xfffe,
 	kMCPlatformKeyCodeJISKeypadComma= 0xfffe,


### PR DESCRIPTION
This patch ensure that the ISOSection keycode has the appropriate
(0xA9) mapping. This fixes an issue with the key to the left of
1 failing to work correctly.