### PR TITLE
[[ Bug 20547 ]] Add support for user classes on android

### DIFF
--- a/docs/notes/bugfix-20547.md
+++ b/docs/notes/bugfix-20547.md
@@ -1,0 +1,1 @@
+# Allow user classes to to be included in android standalones

--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -492,6 +492,13 @@ function pathToJarSigner pRoot
    return pRoot & slash & "bin" & slash & executableName("jarsigner")
 end pathToJarSigner
 
+function pathToJar pRoot
+   if pRoot is empty then
+      put sJavaRoot into pRoot
+   end if
+   return pRoot & slash & "bin" & slash & executableName("jar")
+end pathToJar
+
 ////////////////////////////////////////////////////////////////////////////////
 
 private command configureJavaRootWindows

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -1213,38 +1213,34 @@ end doShellCommand
 
 ################################################################################
 
+constant kDeployLibrary = "revDeployLibraryAndroid"
 private function pathToRootClasses pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToRootClasses" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToRootClasses" to stack kDeployLibrary with pRoot
    return the result
 end pathToRootClasses
 
 private function pathToSDKClasses pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToSDKClasses" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToSDKClasses" to stack kDeployLibrary with pRoot
    return the result
 end pathToSDKClasses
 
 private function pathToCommonClasses pRoot
-   dispatch function "pathToCommonClasses" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToCommonClasses" to stack kDeployLibrary with pRoot
    return the result
 end pathToCommonClasses
 
 private function pathToAapt pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToAapt" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToAapt" to stack kDeployLibrary with pRoot
    return the result
 end pathToAapt
 
 private function pathToAdb pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToAdb" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToAdb" to stack kDeployLibrary with pRoot
    return the result
 end pathToAdb
 
 private function pathToZipAlign pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToZipAlign" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToZipAlign" to stack kDeployLibrary with pRoot
    return the result
 end pathToZipAlign
 
@@ -1260,28 +1256,29 @@ private function pathToRepoAndroidBinaries
 end pathToRepoAndroidBinaries
 
 private function pathToDex pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToDex" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToDex" to stack kDeployLibrary with pRoot
    return the result
 end pathToDex
 
 private function pathToJavaC pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToJavaC" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToJavaC" to stack kDeployLibrary with pRoot
    return the result
 end pathToJavaC
 
 private function pathToJava pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToJava" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToJava" to stack kDeployLibrary with pRoot
    return the result
 end pathToJava
 
 private function pathToJarSigner pRoot
-   // SN-2014-10-16: [[ ScriptifiedStack ]] Stack name updated
-   dispatch function "pathToJarSigner" to stack "revDeployLibraryAndroid" with pRoot
+   dispatch function "pathToJarSigner" to stack kDeployLibrary with pRoot
    return the result
 end pathToJarSigner
+
+private function pathToJar pRoot
+   dispatch function "pathToJar" to stack kDeployLibrary with pRoot
+   return the result
+end pathToJar
 
 ################################################################################
 

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -684,6 +684,17 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       end if
       put tBuildFolder & slash & "classes_app/" & tCompiledClassFilePath & "/AppProvider.class" & return after tBuiltClassFiles
       
+      local tFolder
+      put the folder into tFolder         
+      set the folder to tBuildFolder & slash & "classes_app"
+      repeat for each line tJarFile in pSettings["jarFiles"]
+         executeShellCommand pathToJar(), "xf", tJarFile
+         if the result is not empty then
+            throw "could not extract jar file" && tJarFile & return & the result 
+         end if
+      end repeat
+      set the folder to tFolder
+      
       local tClassesFile
       put tBuildFolder & slash & "classes.dex" into tClassesFile
       executeShellCommand pathToDex(), "--dex", "--output=" & quote & tClassesFile & quote, tClassesBuildFolder, tLiveCodeClassesFile

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -684,20 +684,14 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       end if
       put tBuildFolder & slash & "classes_app/" & tCompiledClassFilePath & "/AppProvider.class" & return after tBuiltClassFiles
       
-      local tFolder
-      put the folder into tFolder         
-      set the folder to tBuildFolder & slash & "classes_app"
+      set the itemdel to slash
       repeat for each line tJarFile in pSettings["jarFiles"]
-         executeShellCommand pathToJar(), "xf", tJarFile
-         if the result is not empty then
-            throw "could not extract jar file" && tJarFile & return & the result 
-         end if
+         put url ("binfile:" & tJarFile) into url ("binfile:" & tLibsBuildFolder & slash & item -1 of tJarFile)
       end repeat
-      set the folder to tFolder
       
       local tClassesFile
       put tBuildFolder & slash & "classes.dex" into tClassesFile
-      executeShellCommand pathToDex(), "--dex", "--output=" & quote & tClassesFile & quote, tClassesBuildFolder, tLiveCodeClassesFile
+      executeShellCommand pathToDex(), "--dex", "--output=" & quote & tClassesFile & quote, tClassesBuildFolder, tLiveCodeClassesFile, tLibsBuildFolder
       if the result is not empty then
          throw "could not encode class bundle"
       end if
@@ -935,13 +929,18 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    repeat for each line tEntry in tExternals
       if there is a file (tArmLibsBuildFolder & slash & "lib" & tEntry & ".so") then delete file (tArmLibsBuildFolder & slash & "lib" & tEntry & ".so")
    end repeat
+   set the itemDelimiter to slash
+   repeat for each line tJarFile in pSettings["jarFiles"]
+      if there is a file (tLibsBuildFolder & slash & item -1 of tJarFile) then 
+         delete file (tLibsBuildFolder & slash & item -1 of tJarFile)
+      end if
+   end repeat
    if there is a folder tArmLibsBuildFolder then delete folder tArmLibsBuildFolder
    if there is a folder tLibsBuildFolder then delete folder tLibsBuildFolder
    if there is a file tClassesFile then delete file tClassesFile
    repeat for each line tClassFile in tBuiltClassFiles
       if there is a file tClassFile then delete file tClassFile
    end repeat
-   set the itemDelimiter to slash
    repeat while there is a folder (tBuildFolder & slash & "classes_app" & slash & tCompiledClassFilePath)
       delete folder (tBuildFolder & slash & "classes_app" & slash & tCompiledClassFilePath)
       if the result is not empty then

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -1211,7 +1211,7 @@ static jclass MCJavaPrivateFindClass(MCNameRef p_class_name)
                                                 "findClass",
                                                 "(Ljava/lang/String;)Ljava/lang/Class;");
     
-    jobejct t_class = s_env->CallObjectMethod(t_class_loader,
+    jobject t_class = s_env->CallObjectMethod(t_class_loader,
                                               t_find_class,
                                               t_class_string);
     if (t_class != nullptr)

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -1194,35 +1194,32 @@ static jclass MCJavaPrivateFindClass(MCNameRef p_class_name)
 {
     // The system class loader does not know about LC's android engine
     // classes. We cache the android engine class loader on startup and
-    // call its findClass method to find any classes named
-    // com.runrev.android.<Class>. For all other classes we just use
-    // the JNIEnv FindClass method & system class loader.
-    if (MCStringBeginsWith(MCNameGetString(p_class_name),
-                           MCSTR("com.runrev.android"),
-                           kMCStringOptionCompareExact))
-    {
+    // call its findClass method to find any classes in the com.runrev.android
+    // package, or any custom classes that have been included.
+    // For all other classes we just use the JNIEnv FindClass method &
+    // system class loader.
 #if defined(TARGET_SUBPLATFORM_ANDROID)
-        jstring t_class_string;
-        if (!__MCJavaStringToJString(MCNameGetString(p_class_name), t_class_string))
-            return nullptr;
-        
-        extern void* MCAndroidGetClassLoader(void);
-        jobject t_class_loader = static_cast<jobject>(MCAndroidGetClassLoader());
-        
-        jclass t_class_loader_class = s_env->FindClass("java/lang/ClassLoader");
-        jmethodID t_find_class = s_env->GetMethodID(t_class_loader_class,
-                                                    "findClass",
-                                                    "(Ljava/lang/String;)Ljava/lang/Class;");
-        
-        jobject t_class = s_env->CallObjectMethod(t_class_loader,
-                                                  t_find_class,
-                                                  t_class_string);
-        
-        return static_cast<jclass>(t_class);
-#else
+    jstring t_class_string;
+    if (!__MCJavaStringToJString(MCNameGetString(p_class_name), t_class_string))
         return nullptr;
+    
+    extern void* MCAndroidGetClassLoader(void);
+    jobject t_class_loader = static_cast<jobject>(MCAndroidGetClassLoader());
+    
+    jclass t_class_loader_class = s_env->FindClass("java/lang/ClassLoader");
+    jmethodID t_find_class = s_env->GetMethodID(t_class_loader_class,
+                                                "findClass",
+                                                "(Ljava/lang/String;)Ljava/lang/Class;");
+    
+    jobejct t_class = s_env->CallObjectMethod(t_class_loader,
+                                              t_find_class,
+                                              t_class_string);
+    if (t_class != nullptr)
+        return static_cast<jclass>(t_class);
+    
+    // Clear the ClassNotFoundException
+    s_env -> ExceptionClear();
 #endif
-    }
     
     MCAutoStringRef t_class_path;
     if (!MCJavaClassNameToPathString(p_class_name, &t_class_path))


### PR DESCRIPTION
This PR adds support for including jar files on android. We do this by unjarring any files in the cRevStandaloneSettings["jarFiles"] of the target stack and dexes them up with the generated classes. 

Access to the classes from LCB in the standalone is provided by lifting the restriction on the class path of classes for which the android app class loader is used to load classes for LCB foreign bindings (the default class loader just loads java stdlib classes).