### PR TITLE
Bugfix 20556

### DIFF
--- a/extensions/script-libraries/dropbox/dropbox.livecodescript
+++ b/extensions/script-libraries/dropbox/dropbox.livecodescript
@@ -4970,7 +4970,7 @@ private function __get_current_account_POST
    /*
    No parameters.
    */
-   return ""
+   return "null"
 end __get_current_account_POST
 
 private function __get_space_usage_POST

--- a/extensions/script-libraries/dropbox/notes/20556.md
+++ b/extensions/script-libraries/dropbox/notes/20556.md
@@ -1,0 +1,1 @@
+# [20556] dropboxGetCurrentAccount changed to overcome a quirk in Dropbox's v2 API that was causing an error to be returned


### PR DESCRIPTION
Dropbox doesn't like the way LC posts "" instead of null.  Gerard in the original library got around this by actually sending the word "null", which works for some reason.  Note that none of the other commands that take a null post are bothered by LC's POST "" technique.