### PR TITLE
[[ ExtensionsCode ]] Add support for jar files in extension code folders

### DIFF
--- a/docs/notes/feature-java_extensions_native_code.md
+++ b/docs/notes/feature-java_extensions_native_code.md
@@ -1,0 +1,11 @@
+# Include .jar files from extensions code folders
+The standalone builder will now look for jar files in 
+`<path to extension>/code/jvm-android` and update the `jarFiles` 
+standalone setting accordingly when building for android. It will 
+also look for them in `<path to extension>/code/jvm` for code 
+inclusions on all platforms that support java.
+
+So in order to include compile java classes in an extension and
+access them from LCB, simply put the .jar files into the appropriate
+folder (`code/jvm-android` if the jar depends on the android API,
+and `code/jvm` otherwise). 

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2302,8 +2302,40 @@ command revSBUpdateForDependencies pPlatform, @xSettings
          put revIDEExtensionProperty(tExtension, tRequiredMetadata) into tIsRequired
          put tIsRequired into xSettings["android,device capabilities"][tFeature]
       end repeat
+      
+      revSBUpdateExtensionCodeInclusions tExtension, pPlatform, xSettings
    end repeat
 end revSBUpdateForDependencies
+
+command revSBUpdateExtensionCodeInclusions pExtension, pPlatform, @xSettings
+   local tExtCodeFolder, tCodeFolders
+   put revIDEExtensionProperty(pExtension, "install_path") & \
+         slash & "code" into tExtCodeFolder
+   put folders(tExtCodeFolder) into tCodeFolders
+   repeat for each line tCodeFolder in tCodeFolders
+      __UpdateSettingsFromCodeFolder tExtCodeFolder, tCodeFolder, pPlatform, xSettings
+   end repeat
+end revSBUpdateExtensionCodeInclusions
+
+private command __UpdateSettingsFromCodeFolder pPath, pCodeFolderName, pPlatform, @xSettings
+   local tFiles, tFolderPath
+   put pPath & slash & pCodeFolderName into tFolderPath
+   put files(tFolderPath) into tFiles
+   switch pCodeFolderName
+      case "jvm-android"
+         if pPlatform is "android" then
+            repeat for each line tLine in tFiles
+               appendToStringList tFolderPath & slash & tLine, xSettings["jarFiles"]
+            end repeat
+         end if
+         break
+      case "jvm"
+         repeat for each line tLine in tFiles
+            appendToStringList tFolderPath & slash & tLine, xSettings["jarFiles"]
+         end repeat
+         break
+   end switch
+end __UpdateSettingsFromCodeFolder
 
 command revSBSanitiseExternalsList pTarget, @xExternals
    local tAvailableExternals, tFixedExternals, tValidExternals, tPlatform


### PR DESCRIPTION
Look for jar files in <path to extension>/code/jvm-android for android-only
code inclusions and in code/jvm for code inclusions on all platforms.