### PR TITLE
[Dictionary] - after, before, cursor to deleteStack.

### DIFF
--- a/docs/dictionary/command/delete-URL.lcdoc
+++ b/docs/dictionary/command/delete-URL.lcdoc
@@ -39,7 +39,8 @@ to delete, in the form of a URL.
 The result:
 If the file or directory is successfully deleted, the result <function>
 is set to empty. Otherwise, the <result> <function> returns an error
-message. >*Important:* If a <blocking> operation involving a <URL>
+message. 
+>*Important:* If a <blocking> operation involving a <URL>
 (using the <put> <command> to <upload> a <URL>, the <post> <command>,
 the <delete URL> <command>, or a <statement> that gets an <ftp> or
 <http> <URL>) is going on, no other <blocking> <URL> operation can start
@@ -66,7 +67,7 @@ name and password is valid, you will almost always need a user name and
 password to use the <delete URL> <command>.
 
 >*Note:*  When used with an <ftp> or <http> <URL>, the <delete URL>
-> <command> is <blocking> : that is, the <handler> pauses until LiveCode
+> <command> is <blocking>: that is, the <handler> pauses until LiveCode
 > is finished deleting the <URL>. Since deleting a file from a server
 > may take some time due to network lag, the <delete URL> <command> may
 > take long enough to be noticeable to the user.
@@ -90,10 +91,10 @@ delete file (command), delete folder (command),
 function (control structure), result (function),
 LiveCode custom library (glossary), application (glossary),
 standalone application (glossary), statement (glossary),
-delete folder (glossary), blocking (glossary),
+blocking (glossary),
 Standalone Application Settings (glossary), command (glossary),
 expression (glossary), main stack (glossary), group (glossary),
-delete file (glossary), local file (glossary), server (glossary),
+local file (glossary), server (glossary),
 upload (glossary), folder (glossary), message (glossary),
 handler (glossary), binfile (keyword), ftp (keyword), file (keyword),
 URL (keyword), http (keyword), put (library), library (library),

--- a/docs/dictionary/control_st/after.lcdoc
+++ b/docs/dictionary/control_st/after.lcdoc
@@ -40,16 +40,10 @@ path. It gets to an object with a behavior script:
 
 1. The engine looks at the behavior script of the target object - If a
    before mouseDown handler is present, it executes it.
-
-
 2. The engine next looks at the object script - If an on mouseDown
    handler is present, it executes it.
-
-
 3. The engine now looks at the behavior script - If an <after> mouseDown
    handler is present, it executes it.
-
-
 4. The engine finally looks at the object script - If a pass mouseDown
    or no mouseDown handler is present, it moves on to the parent object.
 

--- a/docs/dictionary/control_st/before.lcdoc
+++ b/docs/dictionary/control_st/before.lcdoc
@@ -40,16 +40,10 @@ path. It gets to an object with a behavior script:
 
 1. The engine looks at the behavior script of the target object - If a
    <before> mouseDown handler is present, it executes it.
-
-
 2. The engine next looks at the object script - If an on mouseDown
    handler is present, it executes it.
-
-
 3. The engine now looks at the behavior script - If an after mouseDown
    handler is present, it executes it.
-
-
 4. The engine finally looks at the object script - If a pass mouseDown
    or no mouseDown handler is present, it moves on to the parent object.
 

--- a/docs/dictionary/message/cutKey.lcdoc
+++ b/docs/dictionary/message/cutKey.lcdoc
@@ -33,8 +33,8 @@ means that the <cutKey> <message> is not received by a <stack> if it's
 running in the <development environment>, To test a <cutKey> <handler>,
 choose Development → Suspend Development Tools from the menubar.
 
-<cutKey> <message> is sent when the user presses Command-X (on <Mac
-OS|Mac OS systems>), Control-X (on <Windows|Windows systems>),
+<cutKey> <message> is sent when the user presses Command-X (on 
+<Mac OS|Mac OS systems>), Control-X (on <Windows|Windows systems>),
 Shift-Delete (on <Unix|Unix systems>), or the keyboard Cut key.
 
 The message is sent to the active (focused) control, or to the current

--- a/docs/dictionary/message/deleteGraphic.lcdoc
+++ b/docs/dictionary/message/deleteGraphic.lcdoc
@@ -35,9 +35,8 @@ stack <script>, effectively prevents a <graphic> from being deleted by
 the user:
 
     on deleteGraphic
-    beep
-    send "undo" to this card in 5 milliseconds
-
+        beep
+        send "undo" to this card in 5 milliseconds
     end deleteGraphic
 
 

--- a/docs/dictionary/message/deleteImage.lcdoc
+++ b/docs/dictionary/message/deleteImage.lcdoc
@@ -35,9 +35,8 @@ stack <script>, effectively prevents an <image> from being deleted by
 the user:
 
     on deleteImage
-    beep
-    send "undo" to this card in 5 milliseconds
-
+        beep
+        send "undo" to this card in 5 milliseconds
     end deleteImage
 
 

--- a/docs/dictionary/message/deleteKey.lcdoc
+++ b/docs/dictionary/message/deleteKey.lcdoc
@@ -18,9 +18,9 @@ Platforms: desktop, server, mobile
 
 Example:
 on deleteKey -- clear the entire field
-  if word 1 of the name of the target is "field" then
-    put empty into the target
-  end if
+    if word 1 of the name of the target is "field" then
+        put empty into the target
+    end if
 end deleteKey
 
 Description:
@@ -31,14 +31,13 @@ The message is sent to the active (focused) control, or to the current
 card if no control is focused.
 
 The forward delete key is not the same as the backspace or delete key:
-
-        * The forward delete key is usually to the right of the main
-          keyboard layout, and may be labeled with the word "Delete" or
-          a left-facing arrow. Pressing it sends a <deleteKey>
-          <message>. 
-       * The backspace key is usually on the main keyboard above the
-         Return key, and is may be labeled "Backspace" or "Delete".
-         Pressing it sends a <backspaceKey> <message>.
+* The forward delete key is usually to the right of the main
+  keyboard layout, and may be labeled with the word "Delete" or
+  a left-facing arrow. Pressing it sends a <deleteKey>
+  <message>. 
+* The backspace key is usually on the main keyboard above the
+  Return key, and is may be labeled "Backspace" or "Delete".
+  Pressing it sends a <backspaceKey> <message>.
 
 
 References: message (glossary), active control (glossary),

--- a/docs/dictionary/message/deletePlayer.lcdoc
+++ b/docs/dictionary/message/deletePlayer.lcdoc
@@ -35,9 +35,8 @@ stack <script>, effectively prevents a <player> from being deleted by
 the user:
 
     on deletePlayer
-    beep
-    send "undo" to this card in 5 milliseconds
-
+        beep
+        send "undo" to this card in 5 milliseconds
     end deletePlayer
 
 

--- a/docs/dictionary/message/deleteStack.lcdoc
+++ b/docs/dictionary/message/deleteStack.lcdoc
@@ -17,12 +17,12 @@ Platforms: desktop, server, mobile
 
 Example:
 on deleteStack -- warn the user
-  if the mainStack of the owner of the target \
-     is not the owner of the target then -- it's a substack
-    answer "This stack will be permanently deleted the" && \
-       "next time you save the file."
-  end if
-  pass deleteStack
+    if the mainStack of the owner of the target \
+      is not the owner of the target then -- it's a substack
+        answer "This stack will be permanently deleted the" && \
+          "next time you save the file."
+    end if
+    pass deleteStack
 end deleteStack
 
 Description:

--- a/docs/dictionary/property/cursor.lcdoc
+++ b/docs/dictionary/property/cursor.lcdoc
@@ -34,31 +34,31 @@ the text under the <mouse pointer> is editable.
 
 LiveCode looks for the specified image in the following order:
 
-1) The stack of the current object's behavior (if applicable)
-2) The stack of the owner of the current object's behavior (if
-applicable) ...
-n) The stack of the current object's stack's behavior (if applicable)
-A) The current object's stack
-B) The current object's stack's mainstack (if a substack)
-C) The current object's stack's mainstacks substacks
-D) The list of open stacks, in order they were loaded
+1. The stack of the current object's behavior (if applicable)
+2. The stack of the owner of the current object's behavior (if
+applicable)
+3. The stack of the current object's stack's behavior (if applicable)
+4. The current object's stack
+5. The current object's stack's mainstack (if a substack)
+6. The current object's stack's mainstacks substacks
+7. The list of open stacks, in order they were loaded
 
 LiveCode includes several built-in cursors whose names you can use in
 place of their image IDs.
 
 The built-in cursors and their recommended uses are:
 
-        * none: Hides the cursor
-        * busy: Use repeatedly during a long handler
-        * watch: Use during a moderately long handler
-        * arrow: Use for <select|selecting> objects
-        * cross: Use for painting, drawing, or <select|selecting> a
-          <point> or small area
-        * hand: Use for clicking <hypertext> links
-        * iBeam: Use for <select|selecting> text in a field
-        * plus: Use for <select|selecting> <items> such as spreadsheet
-          cells 
-        * help: Use for getting online help
+* none: Hides the cursor
+* busy: Use repeatedly during a long handler
+* watch: Use during a moderately long handler
+* arrow: Use for <select|selecting> objects
+* cross: Use for painting, drawing, or <select|selecting> a
+  <point> or small area
+* hand: Use for clicking <hypertext> links
+* iBeam: Use for <select|selecting> text in a field
+* plus: Use for <select|selecting> <items> such as spreadsheet
+  cells 
+* help: Use for getting online help
 
 
 The busy cursor is a rotating beach ball. Each time you use the
@@ -68,9 +68,8 @@ rotation. For example, the following statements cause the
 running: 
 
     repeat until someCondition is true
-    set the cursor to busy -- spins a bit further
-    doSomething -- insert whatever you want the loop to do here
-
+        set the cursor to busy -- spins a bit further
+        doSomething -- insert whatever you want the loop to do here
     end repeat
 
 
@@ -119,7 +118,7 @@ download (glossary), cursor (glossary), hypertext (glossary),
 mouse pointer (glossary), command (glossary), image (keyword),
 field (keyword), items (keyword), point (keyword), stack (object),
 image (object), cursor (property), yHot (property), lockCursor (property),
- (property), ID (property)
+ID (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/customProperties.lcdoc
+++ b/docs/dictionary/property/customProperties.lcdoc
@@ -65,8 +65,8 @@ following:
 References: set (command), command (glossary), setProp (control structure),
 propertyNames (function), object (glossary), property (glossary),
 key (glossary), value (glossary), custom property (glossary),
-statement (glossary), customPropertySet (glossary),
-custom property set (glossary), array (glossary), properties (property)
+statement (glossary), custom property set (glossary), array (glossary), 
+customPropertySet (property), properties (property)
 
 Tags: properties
 

--- a/docs/dictionary/property/decorations.lcdoc
+++ b/docs/dictionary/property/decorations.lcdoc
@@ -31,7 +31,7 @@ The result:
 > won't include a title bar, even if it had one initially. To set a
 > stack to metal appearance while showing a title bar with close,
 > minimize, and maximize box, you need to set all the decorations at
-> once:. 
+> once. 
 
 Value:
 The <decorations> of a <stack> is one of the following:
@@ -50,17 +50,16 @@ Description:
 Use the <decorations> <property> to change the appearance of windows.
 
 You can specify one or more of the following decorations:
-
-        * title: Shows the window's title bar
-        * minimize: Shows the minimize (iconify) box in the title bar
-        * maximize: Shows the maximize (zoom) box in the title bar
-        * close: Shows the close box in the title bar
-        * menu: Shows the menu bar in the window (<Unix> and <Windows>
-          only) 
-        * system: Shows the window as a system window (OS X, Unix, and
-          Windows only)
-        * noShadow: Remove the window's drop shadow (OS X only)
-        * metal: Shows the window with a textured appearance (OS X only)
+* title: Shows the window's title bar
+* minimize: Shows the minimize (iconify) box in the title bar
+* maximize: Shows the maximize (zoom) box in the title bar
+* close: Shows the close box in the title bar
+* menu: Shows the menu bar in the window (<Unix> and <Windows>
+  only) 
+* system: Shows the window as a system window (OS X, Unix, and
+  Windows only)
+* noShadow: Remove the window's drop shadow (OS X only)
+* metal: Shows the window with a textured appearance (OS X only)
 
 
 >*Note:* The "metal" and "system" options are not compatible. If you set
@@ -88,8 +87,7 @@ and "maximize" options in a <stack|stack's> <decorations> sets the
 corresponding <property> to true.
 
     set the decorations of stack "Test" to \
-
-    "metal,title,close,minimize,maximize"
+        "metal,title,close,minimize,maximize"
 
 
 This applies only to the <decorations> property. If you use the

--- a/docs/dictionary/property/defaultCursor.lcdoc
+++ b/docs/dictionary/property/defaultCursor.lcdoc
@@ -21,14 +21,14 @@ The <defaultCursor> is the <ID> of an <image> to use for a
 <cursor(property)>. LiveCode looks for the specified image in the
 following order:
 
-1) The stack of the current object's <behavior> (if applicable)
-2) The stack of the owner of the current object's <behavior> (if
-applicable) ...
-n) The stack of the current object's stack's <behavior> (if applicable)
-A) The current object's stack
-B) The current object's stack's mainstack (if a substack)
-C) The current object's stack's mainstacks substacks
-D) The list of open stacks, in order they were loaded
+1. The stack of the current object's <behavior> (if applicable)
+2. The stack of the owner of the current object's <behavior> (if
+applicable)
+3. The stack of the current object's stack's <behavior> (if applicable)
+4. The current object's stack
+5. The current object's stack's mainstack (if a substack)
+6. The current object's stack's mainstacks substacks
+7. The list of open stacks, in order they were loaded
 
 Description:
 Use the <defaultCursor> <property> to change the <cursor(property)> used

--- a/docs/dictionary/property/defaultFolder.lcdoc
+++ b/docs/dictionary/property/defaultFolder.lcdoc
@@ -55,14 +55,14 @@ the same <folder> without having to include the <absolute file path|full
 path>. 
 
 The <defaultFolder> <property> specifies the <folder> LiveCode uses as
-the <current folder|current directory> when resolving <relative file
-path|relative paths> (except for <relative file path|relative paths>
-specified in the <stackFiles> <property>).
+the <current folder|current directory> when resolving 
+<relative file path|relative paths> (except for <relative file path|
+relative paths> specified in the <stackFiles> <property>).
 
 If you specify a <file> without giving its 
 <absolute file path|full path>, LiveCode looks for
-the file in the <defaultFolder>. If you specify a <relative file
-path|relative path>, the <defaultFolder> is <prepend|prepended> to it to
+the file in the <defaultFolder>. If you specify a <relative file path|
+relative path>, the <defaultFolder> is <prepend|prepended> to it to
 create the <absolute file path|full path>.
 
 You cannot delete the current <defaultFolder>.


### PR DESCRIPTION
control_st/after.lcdoc - Removed extra lines in ordered list so that all the lines after the first no longer say 1.
control_st/before.lcdoc - Removed extra lines in ordered list so that all the lines after the first no longer say 1.
property/cursor.lcdoc - Changed numbering and such for an ordered list to display correctly. Changed spacing of code example. Removed whitespace to have an unordered list display correctly.
property/customProperties.lcdoc - Changed a reference to customPropertySets from glossary to property so that all other links to customPropertySets will stop trying to find an entry that doesn’t exist.
message/cutKey.lcdoc - Fixed broken link.
property/decorations.lcdoc - Removed whitespace to have an unordered list display correctly. Removed extraneous line from a code example.
keyword/default.lcdoc - Fixed broken link.
property/defaultCursor.lcdoc - Changed numbering and such for an ordered list to display correctly.
property/defaultFolder.lcdoc - Fixed broken links.
command/delete-URL.lcdoc - Removed references to non-existent dictionary entries `delete file` and `delete folder`. Changed some formatting.
message/deleteGraphic.lcdoc - Changed spacing of code example.
message/deleteImage.lcdoc - Changed spacing of code example.
message/deleteKey.lcdoc - Removed whitespace to have an unordered list display correctly. Changed spacing of code example.
message/deleteStack.lcdoc - Changed spacing of code example.