### PR TITLE
[[ Bug 20592 ]] Add uuid field to deploy parameters

### DIFF
--- a/docs/notes/bugfix-20592.md
+++ b/docs/notes/bugfix-20592.md
@@ -1,0 +1,1 @@
+# Ensure iOS standalones are treated as unique by fingerprint scanning

--- a/engine/src/deploy.cpp
+++ b/engine/src/deploy.cpp
@@ -367,6 +367,12 @@ bool MCDeployParameters::InitWithArray(MCExecContext &ctxt, MCArrayRef p_array)
 									  kMCStringOptionCompareCaseless))
 		banner_class = kMCLicenseClassProfessionalEvaluation;
 	
+    
+    if (!ctxt.CopyOptElementAsString(p_array, MCNAME("uuid"), false, t_temp_string))
+        return false;
+    MCValueAssign(uuid, t_temp_string);
+    MCValueRelease(t_temp_string);
+    
     return true;
 }
 

--- a/engine/src/deploy.h
+++ b/engine/src/deploy.h
@@ -119,6 +119,8 @@ struct MCDeployParameters
 	// The data for the banner stackfile.
 	MCDataRef banner_stackfile;
 	
+    // When building for Mac/iOS, there is a UUID field which can be set.
+    MCStringRef uuid;
 	
 	MCDeployParameters()
 	{
@@ -151,6 +153,8 @@ struct MCDeployParameters
 		banner_timeout = 0;
 		banner_stackfile = MCValueRetain(kMCEmptyData);
         banner_class = kMCLicenseClassNone;
+        
+        uuid = MCValueRetain(kMCEmptyString);
 	}
 	
 	~MCDeployParameters()
@@ -174,6 +178,7 @@ struct MCDeployParameters
         MCValueRelease(library);
         MCMemoryDeleteArray(min_os_versions);
 		MCValueRelease(banner_stackfile);
+        MCValueRelease(uuid);
 	}
 	
 	// Creates using an array of parameters
@@ -455,6 +460,9 @@ enum MCDeployError
 	
 	/* An error occurred with the pre-deploy step */
 	kMCDeployErrorTrialBannerError,
+    
+    /* The uuid field was invalid */
+    kMCDeployErrorInvalidUuid,
 
 	// SIGN ERRORS
 

--- a/engine/src/deploy_file.cpp
+++ b/engine/src/deploy_file.cpp
@@ -316,6 +316,9 @@ const char *MCDeployErrorToString(MCDeployError p_error)
 		
 		case kMCDeployErrorTrialBannerError:
 			return "could not create trial banner";
+            
+        case kMCDeployErrorInvalidUuid:
+            return "invalid uuid";
 
 		case kMCDeployErrorNoCertificate:
 			return "could not load certificate";

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -570,6 +570,9 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
    
    -- delete the last LF
    delete last char of tDeploy["fontmappings"]
+
+   -- Make sure the standalone is generated with a unique uuid
+   put uuid() into tDeploy["uuid"]
    
    try
       _internal deploy ios tDeploy

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -701,6 +701,9 @@ command revSaveAsMacStandalone pStack, pRestoreFileName, pFolder
          put return & "revInternal__SetSmallAppIcon" && sStandaloneSettingsA["OSX,smallappicon"] after tDeployInfo["startup_script"]
       end if
       
+      -- Add a random uuid to use in the executable's uuid load command.
+      put uuid() into tDeployInfo["uuid"]
+
       revStandaloneDeployWithParams tTarget, tStackSourceFile, tDeployInfo
       
       -- Make sure we finish off the bundle contents
@@ -2489,7 +2492,7 @@ command revStandaloneDeployWithParams pTarget, pStackFilePath, pDeployInfo
    delete stack pStackFilePath
    unlock screen
    unlock messages
-   
+
    -- Actually do the standalone engine build - we probably need some sort of
    -- error handling here :oD
    revStandaloneProgress "Attaching engine..."


### PR DESCRIPTION
This patch adds a uuid field to the deploy parameters which can
be specified with the deploy command.

When specified, iOS and Mac deployments will place the specified
uuid into the Mach-O UUID load command. This is required to ensure
services such as fingerprint authentication works correctly.