### PR TITLE
[[ Bug ]] Use Windows style paths for `/WHOLEARCHIVE`

### DIFF
--- a/engine/lcb-modules.gyp
+++ b/engine/lcb-modules.gyp
@@ -43,7 +43,7 @@
 								{
 									'AdditionalOptions':
 									[
-										'/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/engine_lcb_modules.lib',
+										'/WHOLEARCHIVE:<(PRODUCT_DIR)\lib\engine_lcb_modules.lib',
 									],
 								},
 							},


### PR DESCRIPTION
VS 2017 (15.4.1) breaks support for slash in paths in the
`/WHOLEARCHIVE` option. This path changes to use backslash
for this windows only path.