### PR TITLE
[Dictionary] Documentation changes from diskSpace to dragMove.

### DIFF
--- a/docs/dictionary/command/do.lcdoc
+++ b/docs/dictionary/command/do.lcdoc
@@ -21,7 +21,7 @@ Example:
 do "go next card"
 
 Example:
-do "put"  x  "into tNumberOfRecords" 
+do "put" && x && "into tNumberOfRecords" 
 -- might become "put 3 into tNumberOfRecords"
 
 Example:
@@ -54,8 +54,12 @@ any result returned by the script language is placed in the <result>. On
 Windows systems, the <result> function will return the value of the
 global variable called "result" in the script that was executed (or
 empty if no such variable was defined). For example the following code
-will produce a dialog box containing "2" :. answer the result. If you
-attempt to specify an <alternateLanguageName> on a <Unix> <system>, the
+will produce a dialog box containing "2": 
+
+    do "result = 1 + 1" as "vbscript"
+    answer the result
+
+If you attempt to specify an <alternateLanguageName> on a <Unix> <system>, the
 <do> <command> is not executed, and the <result> is set to
 "alternate language not found". Any scripts on Windows which contain
 references to WScript will fail to run as WScript objects do not exist
@@ -70,8 +74,6 @@ container or the return value from a function.
 Using the <do> <command> is slower than directly <execute|executing> the
 <command|commands>, because each <statement> must be <compile|compiled>
 every time the <do> <command> is executed.
-
-do "result = 1 + 1" as "vbscript"
 
 >*Important:* If using the do as <alternateLanguageName> form, any paths
 > used in the <statementList> must be in the native format of the
@@ -88,14 +90,14 @@ added in LiveCode 2.9.
 Changes:
 The <alternateLanguageName> option was introduced in version 1.1. In
 previous versions, it was not possible to include AppleScript or other
-<Open Scripting Architecture (OSA)|OSA> languages in a <LiveCode>
+<Open Scripting Architecture|OSA> languages in a <LiveCode>
 <handler>. 
 
 References: debugDo (command), breakpoint (command), local (command),
 call (command), result (function),
-alternateLanguages (function), system (glossary), LiveCode (glossary),
+alternateLanguages (function), LiveCode (glossary),
 handler (glossary), execute (glossary), statement (glossary),
 Unix (glossary), compile (glossary), command (glossary),
-Open Scripting Architecture (OSA) (glossary), message box (keyword),
-as (keyword)
+Open Scripting Architecture (glossary), message box (keyword),
+as (keyword), system (keyword)
 

--- a/docs/dictionary/function/diskSpace.lcdoc
+++ b/docs/dictionary/function/diskSpace.lcdoc
@@ -54,7 +54,7 @@ by 1024^3:
             default
                 return the diskSpace
                 break
-         end switch
+        end switch
     end humanReadableDiskSpace
 
 

--- a/docs/dictionary/function/diskSpace.lcdoc
+++ b/docs/dictionary/function/diskSpace.lcdoc
@@ -40,26 +40,21 @@ to megabytes (M), divide by 1024^2. To convert to gigabytes (G), divide
 by 1024^3:
 
     function humanReadableDiskSpace theUnits
-    set the caseSensitive to false
-    switch char 1 of theUnits
-    case "k"
-
-    return the diskSpace div 1024
-    break
-    case "m"
-
-    return the diskSpace div (1024^2)
-    break
-    case "g"
-
-    return the diskSpace div (1024^3)
-    break
-    default
-
-    return the diskSpace
-    break
-    end switch
-
+        set the caseSensitive to false
+        switch char 1 of theUnits
+            case "k"
+    	        return the diskSpace div 1024
+    	        break
+            case "m"
+                return the diskSpace div (1024^2)
+                break
+            case "g"
+                return the diskSpace div (1024^3)
+                break
+            default
+                return the diskSpace
+                break
+         end switch
     end humanReadableDiskSpace
 
 

--- a/docs/dictionary/message/dragDrop.lcdoc
+++ b/docs/dictionary/message/dragDrop.lcdoc
@@ -5,8 +5,8 @@ Type: message
 Syntax: dragDrop
 
 Summary:
-Sent to the <object(glossary)> where data was dropped when a <drag and
-drop> finishes.
+Sent to the <object(glossary)> where data was dropped when a 
+<drag and drop> finishes.
 
 Introduced: 2.0
 
@@ -44,20 +44,18 @@ To prevent an unlocked field from accepting a drag and drop, trap the
 the field that does not contain a <pass> <control structure>:
 
     on dragDrop -- in script of field or one of its owners
-    -- do nothing, but trap the message
-
+        -- do nothing, but trap the message
     end dragDrop
 
 
 On the other hand, if you want to perform some action when text is
 dropped into an unlocked field, you need to pass the <dragDrop>
-<message> once you're done with it in order to allow the drop to take
-place: 
+<message> once you're done with it in order to allow the drop to 
+take place: 
 
     on dragDrop
-    set the cursor to 9023
-    pass dragDrop -- needed for drop to occur
-
+        set the cursor to 9023
+        pass dragDrop -- needed for drop to occur
     end dragDrop
 
 

--- a/docs/dictionary/message/dragEnter.lcdoc
+++ b/docs/dictionary/message/dragEnter.lcdoc
@@ -36,9 +36,9 @@ If two controls overlap, a <dragEnter> <message> is sent whenever the
 <control> that is completely hidden by another <control> on top of it
 will never receive a <dragEnter> <message>.
 
->*Tip:*  Use the <mouseLoc> function to determine where the <mouse
-> pointer> is. Use the <target> <function> to determine which <control>
-> the <mouse pointer> has entered.
+>*Tip:*  Use the <mouseLoc> function to determine where the 
+> <mouse pointer> is. Use the <target> <function> to determine which 
+> <control> the <mouse pointer> has entered.
 
 References: function (control structure), mouseLoc (function),
 target (function), property (glossary), control (glossary),

--- a/docs/dictionary/message/dragLeave.lcdoc
+++ b/docs/dictionary/message/dragLeave.lcdoc
@@ -22,8 +22,8 @@ on dragLeave -- remove any outline around the drop no-longer-target
 end dragLeave
 
 Description:
-Handle the <dragLeave> <message> to update a <control> when the <mouse
-pointer> moves outside it during drag and drop.
+Handle the <dragLeave> <message> to update a <control> when the 
+<mouse pointer> moves outside it during drag and drop.
 
 The <dragLeave> <message> is sent only when a <drag and drop> operation
 is in progress.

--- a/docs/dictionary/message/dragMove.lcdoc
+++ b/docs/dictionary/message/dragMove.lcdoc
@@ -17,17 +17,17 @@ Platforms: desktop, server
 
 Example:
 on dragMove -- in a field script
-  -- set the cursor so it shows you can only drop onto a link:
-  if the textStyle of the mouseChunk contains "link"
-  then set the cursor to the ID of image "Drop Here"
-  else set the cursor to the ID of image "Dont Drop"
+    -- set the cursor so it shows you can only drop onto a link
+    if the textStyle of the mouseChunk contains "link"
+    then set the cursor to the ID of image "Drop Here"
+    else set the cursor to the ID of image "Dont Drop"
 end dragMove
 
 Description:
 Handle the <dragMove> <message> if you want to perform some action (such
 as updating a status display) when the user moves the mouse while
-dragging, or if you want to keep continuous track of the <mouse
-pointer|mouse pointer's> position during a <drag and drop>.
+dragging, or if you want to keep continuous track of the 
+<mouse pointer|mouse pointer's> position during a <drag and drop>.
 
 The <dragMove> <message> is sent to the <control> the <mouse pointer> is
 over, or to the <card> if no <control> is under the <mouse pointer>.

--- a/docs/dictionary/property/dontUseNS.lcdoc
+++ b/docs/dictionary/property/dontUseNS.lcdoc
@@ -36,21 +36,22 @@ this feature and use the old-style modal dialog boxes for file actions,
 set the <dontUseNS> <property> to true.
 
 The setting of this property affects all file dialog boxes used in
-LiveCode, including the dialogs displayed by the ask file, <answer
-file>, and <answer folder> <command|commands>, as well as <dialog
-box|dialog boxes> displayed by <menu item|menu items> such as "Save" and
-"Open Stack". 
+LiveCode, including the dialogs displayed by the <ask file>, 
+<answer file>, and <answer folder> <command|commands>, as well as 
+<dialog box|dialog boxes> displayed by <menu item|menu items> such as 
+"Save" and "Open Stack". 
 
 >*Warning:*  Navigation Services version 1.1.2 is part of <Mac OS>
 > version 8.6 and later. Earlier versions may optionally be installed on
 > systems with <Mac OS> versions 8.1 and 8.5. Versions of Navigation
-> Services earlier than 1.1.2 may not display <file dialog box|file
-> dialogs> correctly in LiveCode.
+> Services earlier than 1.1.2 may not display 
+> <file dialog box|file dialogs> correctly in LiveCode.
 
-References: ask file with type (command), answer file (command),
-answer folder (command), property (glossary), menu item (glossary),
-command (glossary), file dialog box (glossary), appearance (glossary),
-Mac OS (glossary), dialog box (glossary), behavior (glossary)
+References: ask file (command), ask file with type (command), 
+answer file (command), answer folder (command), property (glossary), 
+menu item (glossary), command (glossary), file dialog box (glossary), 
+appearance (glossary), Mac OS (glossary), dialog box (glossary), 
+behavior (glossary)
 
 Tags: windowing
 

--- a/docs/dictionary/property/dontUseQT.lcdoc
+++ b/docs/dictionary/property/dontUseQT.lcdoc
@@ -77,10 +77,10 @@ AVFoundation player on Windows.
 References: answer record (command), answer effect (command),
 show (command), hide (command), function (control structure),
 recordCompressionTypes (function), qtEffects (function),
-QTVersion (function), property (glossary), Windows (glossary),
+qtVersion (function), property (glossary), Windows (glossary),
 command (glossary), QuickTime (glossary), loaded into memory (glossary),
 Mac OS (glossary), stack (object), dontUseQTEffects (property),
-alwaysBuffer property (property)
+alwaysBuffer (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/property/dontUseQTEffects.lcdoc
+++ b/docs/dictionary/property/dontUseQTEffects.lcdoc
@@ -56,9 +56,9 @@ not include 64 bit support and therefore can not be supported on OS X 64
 bit builds of LiveCode.
 
 References: answer effect (command), show (command),
-unlock screen (command), hide (command), QTVersion (function),
+unlock screen (command), hide (command), qtVersion (function),
 property (glossary), command (glossary), QuickTime (glossary),
-stack window (glossary), dontUseQTEffects (property)
+stack window (glossary), dontUseQT (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/property/dragAction.lcdoc
+++ b/docs/dictionary/property/dragAction.lcdoc
@@ -24,12 +24,11 @@ end if
 
 Description:
 The <dragAction> property is used to indicate which action should be (or
-has been) performed on the data. It can be one of : none - the target
-application does not want the data move - the target application wants
-to move the data copy - the target application wants to copy the data
-
-    link - the target application wants to link the data
-
+has been) performed on the data. It can be one of: 
+* none - the target application does not want the data 
+* move - the target application wants to move the data 
+* copy - the target application wants to copy the data
+* link - the target application wants to link the data
 
 When acting as the source application, query the <dragAction> property
 in the <dragEnd (message)> handler to determine what action the target

--- a/docs/dictionary/property/dragData.lcdoc
+++ b/docs/dictionary/property/dragData.lcdoc
@@ -23,30 +23,27 @@ get URL the dragData["text"]
 
 Value:
 The <dragData> is an <array> with one or more of the following
-<element|elements>:. 
+<element|elements>:
+- text: The text being dragged (from 7.0, it includes as well 
+  the Unicode characters)
+- html: The styled text being dragged, in the same format as 
+  the htmlText
+- rtf: The styled text being dragged, in the same format as the
+  RTFText
+- Unicode: The text being dragged, in the same format as the 
+  unicodeText 
+- image: The data of an image in PNG, JPEG or GIF format
+- files: The name and location of the file or files being dragged, 
+  one per line
+- styles: Styled text in LiveCode internal styled text format 
+- private: An arbitrary application-defined string. This format will
+  only be visible within the same LiveCode process (i.e. when the
+  current application is acting as source and target for the current 
+  drag-drop operation)
 
 Description:
 Use the <dragData> <property> to find out what is being dragged or to
 change the data being dragged during the drag.
-
-        - text          The text being dragged (from 7.0, it includes as
-          well the Unicode characters)
-        - html         The styled text being dragged, in the same format
-          as the htmlText
-        - rtf              The styled text being dragged, in the same
-          format as the RTFText
-        - Unicode    The text being dragged, in the same format as the
-          unicodeText 
-        - image        The data of an image in PNG, JPEG or GIF format
-        - files           The name and location of the file or files
-          being dragged, one per line
-        - styles         Styled text in LiveCode internal styled text
-          format 
-        - private       An arbitrary application-defined string. This
-          format will only be visible within the same LiveCode process
-          (i.e. when the current application is acting as source and
-          target for the current drag-drop operation)
-
 
 If LiveCode is acting as the target of a drag-drop operation (i.e.
 during the context of a <dragEnter>, <dragMove>, <dragDrop> or

--- a/docs/dictionary/property/dragImage.lcdoc
+++ b/docs/dictionary/property/dragImage.lcdoc
@@ -34,14 +34,14 @@ it receives <dragEnd>.
 
 LiveCode looks for the specified image in the following order:
 
-1) The stack of the current object's <behavior> (if applicable)
-2) The stack of the owner of the current object's <behavior> (if
+1. The stack of the current object's <behavior> (if applicable)
+2. The stack of the owner of the current object's <behavior> (if
 applicable) ...
-n) The stack of the current object's stack's <behavior> (if applicable)
-A) The current object's stack
-B) The current object's stack's mainstack (if a substack)
-C) The current object's stack's mainstacks substacks
-D) The list of open stacks, in order they were loaded
+3. The stack of the current object's stack's <behavior> (if applicable)
+4. The current object's stack
+5. The current object's stack's mainstack (if a substack)
+6. The current object's stack's mainstacks substacks
+7. The list of open stacks, in order they were loaded
 
 Changes:
 The order in which LiveCode searches for drag images was changed in

--- a/docs/dictionary/property/dragImageOffset.lcdoc
+++ b/docs/dictionary/property/dragImageOffset.lcdoc
@@ -16,14 +16,16 @@ OS: mac, windows
 Platforms: desktop, server
 
 Example:
-set the dragImageOffset  to 12,10
+set the dragImageOffset to 12,10
 
 Example:
-set the dragImageOffset to (0.5 * the width of image "Drag Image"), (0.5 * the height of image "Drag Image")
+set the dragImageOffset to \
+    (0.5 * the width of image "Drag Image"), \
+    (0.5 * the height of image "Drag Image")
 
 Value:
 The <dragImageOffset> is two comma-separated integers in the format
-<horizontalDistance>, <verticalDistance>. These may be negative. The
+horizontalDistance, verticalDistance. These may be negative. The
 default value is empty, which is equivalent to 0,0. If the dragImage
 property is not set, or set to a non-existant image, this property has
 no effect.


### PR DESCRIPTION
function/diskSpace.lcdoc - Adjusted formatting of code example.
command/do.lcdoc - Fixed broken links. Edited code example. Reunited two split halves of a code example and made it display correctly.
property/dontUseNS.lcdoc - Fixed broken links.
property/dontUseQT.lcdoc - Fixed broken links.
property/dontUseQTEffects.lcdoc - Fixed broken link. Changed self reference to `dontUseQT`
property/dragAction.lcdoc - Formatted unordered list to display correctly.
property/dragData.lcdoc - Moved and formatted unordered list to display correctly.
message/dragDrop.lcdoc - Fixed broken link, changed formatting of code examples.
message/dragEnter.lcdoc - Fixed broken link.
property/dragImage.lcdoc - Changed numbering of ordered list to display correctly.
property/dragImageOffset.lcdoc - Edited code example to not run on one line for so long, removed angle brackets from output values in Value as they wouldn’t display otherwise.
message/dragLeave.lcdoc - Fixed broken link.
message/dragMove.lcdoc - Fixed broken link.