### PR TITLE
[Dictionary] Changes from dragSource to end try

### DIFF
--- a/docs/dictionary/command/drawer.lcdoc
+++ b/docs/dictionary/command/drawer.lcdoc
@@ -59,9 +59,9 @@ different locations on that side:
     drawer "Colors" at left of this stack aligned to bottom
 
 
->*Cross-platform note:*  On <Mac OS>, <Unix>, and <Windows|Windows
-> systems>, <drawer(glossary)|drawers> are not supported, so the
-> <drawer> <command> opens the <stack> as a <palette> instead. The
+>*Cross-platform note:*  On <Mac OS>, <Unix>, and 
+> <Windows|Windows systems>, <drawer(glossary)|drawers> are not supported, 
+> so the <drawer> <command> opens the <stack> as a <palette> instead. The
 > <palette> uses the current <rectangle> of the <stack> and does not
 > resize or move it.
 

--- a/docs/dictionary/command/edit.lcdoc
+++ b/docs/dictionary/command/edit.lcdoc
@@ -5,8 +5,8 @@ Type: command
 Syntax: edit [the] script of <object> [at line,column]
 
 Summary:
-Opens the <script> of an <object(glossary)> in the <development
-environment>. 
+Opens the <script> of an <object(glossary)> in the 
+<development environment>. 
 
 Introduced: 1.0
 

--- a/docs/dictionary/function/dragSource.lcdoc
+++ b/docs/dictionary/function/dragSource.lcdoc
@@ -32,8 +32,8 @@ Description:
 Use the <dragSource> <function> to find out which <object(glossary)>,
 and which <object type>, is being dragged from.
 
-The <dragSource> <function> only <return|returns> a value while a <drag
-and drop> is in progress. Otherwise, the <dragSource> <function>
+The <dragSource> <function> only <return|returns> a value while a 
+<drag and drop> is in progress. Otherwise, the <dragSource> <function>
 <return|returns> empty.
 
 References: function (control structure), target (function),

--- a/docs/dictionary/function/driverNames.lcdoc
+++ b/docs/dictionary/function/driverNames.lcdoc
@@ -21,9 +21,9 @@ Example:
 put firstItems(the driverNames) into menu "Choose a driver:"
 
 Returns:
-The <driverNames> <function> <return|returns> a list of <device
-driver|drivers>, one per <line>. Each <line> consists of three <items>,
-separated by commas:
+The <driverNames> <function> <return|returns> a list of 
+<device driver|drivers>, one per <line>. Each <line> consists of 
+three <items>, separated by commas:
 
 1. The name of the driver.
 2. The name and location of the TTY device file for the driver.
@@ -41,8 +41,8 @@ driver|drivers> can be used with the <open driver>, <read from driver>,
 <write to driver>, and <close driver> <command|commands>.
 
 Usually, you use the callout file name--the third item in the line for
-the driver you want--with the open driver, <read from driver>, <write to
-driver>, and <close driver> <command|commands>.
+the driver you want--with the open driver, <read from driver>, 
+<write to driver>, and <close driver> <command|commands>.
 
 References: open driver (command), write to driver (command),
 read from driver (command), close driver (command),

--- a/docs/dictionary/keyword/effective.lcdoc
+++ b/docs/dictionary/keyword/effective.lcdoc
@@ -73,7 +73,7 @@ The <effective> <keyword> can be used with the following inherited
 * rectangle property
 
 
-* <layerMode> < property(property)>
+* <layerMode> property
 
 
 >*Note:* The <effective> keyword is implemented internally as a property
@@ -81,7 +81,7 @@ The <effective> <keyword> can be used with the following inherited
 > in an expression, nor with the set com.
 
 References: object (glossary), property (glossary), keyword (glossary),
-substack (glossary), layerMode (glossary), font (glossary),
+substack (glossary), font (glossary),
 inheritance (glossary), card (keyword), rectangle (keyword),
 button (keyword), button (object), borderPattern (property),
 foregroundColor (property), threeDHilite (property),

--- a/docs/dictionary/keyword/eighth.lcdoc
+++ b/docs/dictionary/keyword/eighth.lcdoc
@@ -17,8 +17,8 @@ Example:
 send the eighth item of messagesList to the eighth card
 
 Description:
-Use the <eighth> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <eighth> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <eighth> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 8. It can also be used to designate the

--- a/docs/dictionary/keyword/end-repeat.lcdoc
+++ b/docs/dictionary/keyword/end-repeat.lcdoc
@@ -17,8 +17,8 @@ Example:
 end repeat
 
 Description:
-Use the <end repeat> <keyword> to mark the end of a <repeat> <control
-structure>. 
+Use the <end repeat> <keyword> to mark the end of a <repeat> 
+<control structure>. 
 
 The <end repeat> <keyword> occurs on a line by itself.
 

--- a/docs/dictionary/keyword/end-switch.lcdoc
+++ b/docs/dictionary/keyword/end-switch.lcdoc
@@ -17,8 +17,8 @@ Example:
 end switch
 
 Description:
-Use the <end switch> <keyword> to mark the end of a <switch> <control
-structure>. 
+Use the <end switch> <keyword> to mark the end of a <switch> 
+<control structure>. 
 
 The <end switch> <keyword> occurs on a line by itself.
 

--- a/docs/dictionary/keyword/end-try.lcdoc
+++ b/docs/dictionary/keyword/end-try.lcdoc
@@ -17,8 +17,8 @@ Example:
 end try
 
 Description:
-Use the <end try> <keyword> to mark the end of a <try> <control
-structure>. 
+Use the <end try> <keyword> to mark the end of a <try> 
+<control structure>. 
 
 The <end try> <keyword> occurs on a line by itself.
 

--- a/docs/dictionary/message/dragStart.lcdoc
+++ b/docs/dictionary/message/dragStart.lcdoc
@@ -29,8 +29,8 @@ it and then drags the mouse pointer at least <dragDelta> pixels from its
 original position.
 
 Use this handler to initiate a drag-drop operation if required.  An
-operation can be initiated by setting a data-type of the <dragData
-property>. 
+operation can be initiated by setting a data-type of the 
+<dragData> property. 
 
 LiveCode automatically handles the mechanics of dragging and dropping
 text between and within unlocked fields. To support this type of drag
@@ -49,8 +49,8 @@ a <pass> <control structure>:
 
 References: click (command), pass (control structure),
 control structure (glossary), handler (glossary), message (glossary),
-dragEnter (message), dragData (property), dragData property (property),
-dragImageOffset (property), dragAction (property), dragDelta (property)
+dragEnter (message), dragData (property), dragImageOffset (property), 
+dragAction (property), dragDelta (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/dropshadow.lcdoc
+++ b/docs/dictionary/property/dropshadow.lcdoc
@@ -33,71 +33,32 @@ The <dropShadow> is an array style property, each key of the array
 controls a different <dropShadow> parameter that will affect its final
 appearance. The easiest way to adjust these properties is by using the
 Graphic Effects card of the property inspector which has full control
-over each parameter. To control the effect by script use the following
-properties: 
-
-dropShadow["color"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The color of the shadow, in the format
-red,green,blue where each value is between 0 and 255.
-
-dropShadow["blendMode"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;How the shadow is blended with objects
-behind it. This is one of the following values:
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- "normal" :
-the shadow is laid over the background.
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- "multiply"
-: this results in a darkening effect
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-
-"colorDodge" : this results in a lightening effect
-
-dropShadow["opacity"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;How opaque the shadow is. The value is
+over each parameter. To control the effect by script use the 
+following properties: 
+* dropShadow["color"] - The color of the shadow, in the format 
+red, green, blue where each value is between 0 and 255.
+* dropShadow["blendMode"] - How the shadow is blended with objects behind it. 
+This is one of the following values:
+  * "normal": the shadow is laid over the background.
+  * "multiply": this results in a darkening effect
+  * "colorDodge" : this results in a lightening effect
+* dropShadow["opacity"] - How opaque the shadow is. The value is
 between 0 (fully transparent) and 255 (fully opaque).
-
-dropShadow["filter"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Which algorithm is used to render the
+* dropShadow["filter"] - Which algorithm is used to render the
 shadow. This is one of the following options:
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"gaussian" :
-highest quality (and slowest)
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"box3pass" :
-high quality.
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"box2pass" :
-medium quality
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"box1pass" :
-low quality (and fastest)
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;When using the "colorDodge" blend mode, it
-is recommended that you set the filter mode to "gaussian".
-
-dropShadow["size"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The size of the shadow, i.e. how large the
-shadow is. This is between 0 and 255.
-
-dropShadow["spread"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This controls where the effect begins to
+  * "gaussian": highest quality (and slowest)
+  * "box3pass": high quality.
+  * "box2pass": medium quality
+  * "box1pass": low quality (and fastest)
+<p style="margin-left: -2.75em">When using the "colorDodge" blend mode, 
+it is recommended that you set the filter mode to "gaussian".</p>
+* dropShadow["size"] - The size of the shadow, i.e. how large the shadow is. 
+This is between 0 and 255.
+* dropShadow["spread"] - This controls where the effect begins to
 blend. This is between 0 and 255.
-
-dropShadow["distance"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This controls how far the shadow is offset
+* dropShadow["distance"] - This controls how far the shadow is offset
 from the object. This is between 0 and 359.
-
-dropShadow["angle"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The controls the direction the shadow is
+* dropShadow["angle"] - The controls the direction the shadow is
 cast in. This is between 0 and 360.
 
 References: innerShadow (property), innerGlow (property),

--- a/docs/dictionary/property/editBackground.lcdoc
+++ b/docs/dictionary/property/editBackground.lcdoc
@@ -28,8 +28,8 @@ set to false.
 
 Description:
 Use the <editBackground> <property> to edit the first <group> on the
-<current card>, or to find out whether the <stack> is in <group-editing
-mode>. 
+<current card>, or to find out whether the <stack> is in 
+<group-editing mode>. 
 
 If the <editBackground> <property> is set to true, any newly created
 <object|objects> become part of the <group> being edited. If the

--- a/docs/dictionary/property/effectRate.lcdoc
+++ b/docs/dictionary/property/effectRate.lcdoc
@@ -22,7 +22,7 @@ set the effectRate to 5000 -- quite s-s-s-l-l-l-o-o-o-w-w-w...
 Value:
 You can specify five speeds with the visual effect <command> : very
 fast, fast, normal, slow, or very slow. The <effectRate> <property>
-specifies how long a very slow <a/>visual effect takes.
+specifies how long a very slow visual effect takes.
 
 Description:
 Use the <effectRate> <property> to fine-tune the speed of visual

--- a/docs/dictionary/property/emacsKeyBindings.lcdoc
+++ b/docs/dictionary/property/emacsKeyBindings.lcdoc
@@ -28,13 +28,12 @@ and prefer to use its standard keystrokes for text editing.
 Emacs is a text editor which is popular among Unix users. It uses
 keystrokes and key combinations different from the standard LiveCode
 keys. For example:
-
-        * Control-V moves the insertion point down a page
-        * Control-Y pastes the contents of the clipboard
-        * Control-A moves the insertion point to the beginning of the
-          line 
-        * Control-F moves the insertion point forward one character
-        * Delete backspaces over the previous character
+* Control-V moves the insertion point down a page
+* Control-Y pastes the contents of the clipboard
+* Control-A moves the insertion point to the beginning of the
+line 
+* Control-F moves the insertion point forward one character
+* Delete backspaces over the previous character
 
 
 (For a complete list of supported key bindings, see the Emacs Key

--- a/docs/glossary/e/editable-window.lcdoc
+++ b/docs/glossary/e/editable-window.lcdoc
@@ -5,8 +5,8 @@ Synonyms: editable window, editable stack window
 Type: glossary
 
 Description:
-The normal style of window, as opposed to <palette|palettes> or <modal
-dialog box|modal> and <modeless dialog box|modeless dialog boxes>.
+The normal style of window, as opposed to <palette|palettes> or 
+<modal dialog box|modal> and <modeless dialog box|modeless dialog boxes>.
 <control|Controls> in editable windows can be <select|selected> with the
 pointer tool.
 


### PR DESCRIPTION
function/dragSource.lcdoc - Fixed broken link.
message/dragStart.lcdoc - Fixed broken link. Removed non-existent reference.
function/driverNames.lcdoc - Fixed broken links.
property/dropShadow.lcdoc - Changed list of properties to resemble a normal unordered list.
command/edit.lcdoc - Fixed broken link.
glossary/editable-window.lcdoc - Fixed broken link.
property/editBackground.lcdoc - Fixed broken link.
keyword/effective.lcdoc - Fixed broken link.
property/effectRate.lcdoc - Removed extraneous html tag.
keyword/eighth.lcdoc - Fixed broken link.
property/emacsKeyBindings.lcdoc - Removed white space from list of keybinds to make resemble a normal unordered list.
keyword/end-repeat.lcdoc - Fixed broken link.
keyword/end-switch.lcdoc - Fixed broken link.
