### PR TITLE
Revert "[Bug 16551]  Ensure "hilitedButtonName" returns the name of the hilited button"

### DIFF
--- a/docs/notes/bugfix-16551.md
+++ b/docs/notes/bugfix-16551.md
@@ -1,1 +1,0 @@
-# Ensure the "hilitedButtonName" returns the name of the hilited button

--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -238,11 +238,11 @@ void MCGroup::SetHilitedButtonId(MCExecContext& ctxt, uint32_t part, integer_t p
 
 void MCGroup::GetHilitedButtonName(MCExecContext& ctxt, uint32_t part, MCStringRef& r_name)
 {
-    MCButton *bptr = gethilitedbutton(part);
-    if (bptr != NULL)
-        bptr -> GetName(ctxt, r_name);
-    else
-        r_name = MCValueRetain(kMCEmptyString);
+	MCButton *bptr = gethilitedbutton(part);
+	if (bptr != NULL)
+		r_name = MCValueRetain(MCNameGetString(bptr->getname()));
+	else
+		r_name = MCValueRetain(kMCEmptyString);
 }
 
 void MCGroup::SetHilitedButtonName(MCExecContext& ctxt, uint32_t part, MCStringRef p_name)

--- a/tests/lcs/core/interface/interface-button-props.livecodescript
+++ b/tests/lcs/core/interface/interface-button-props.livecodescript
@@ -42,19 +42,19 @@ on TestHighlightedButtonID
 	TestAssert "button 1 of group 1 is unhilited", not the hilite of button 1
 	hilite button 1
 	TestAssert "hilitedbuttonid is button 1 of group 1", the hilitedbuttonid of group 1 is the short id of button 1
-	TestAssert "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1
+	TestAssertBroken "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1, "bug 16551"
 
 	unhilite button 1
 	TestAssert "button 1 of group 1 is unhilited", not the hilite of button 1
 	hilite button 2
 	TestAssert "hilitedbuttonid is button 2 of group 1", the hilitedbuttonid of group 1 is the short id of button 2
-	TestAssert "hilitedbuttonname is button 2 of group 1", the hilitedbuttonname of group 1 is the short name of button 2
+	TestAssertBroken "hilitedbuttonname is button 2 of group 1", the hilitedbuttonname of group 1 is the short name of button 2, "bug 16551"
 
 	dehilite button 2
 	TestAssert "button 2 of group 1 is unhilited", not the hilite of button 2
 	set the hilitedbuttonid of group 1 to the short id of button 1
 	TestAssert "hilitedbuttonid is button 1 of group 1", the hilitedbuttonid of group 1 is the short id of button 1
-	TestAssert "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1
+	TestAssertBroken "hilitedbuttonname is button 1 of group 1", the hilitedbuttonname of group 1 is the short name of button 1, "bug 16551"
 end TestHighlightedButtonID
 
 on TestHighlightBorder


### PR DESCRIPTION
Reverts livecode/livecode#6079

Reverting this patch because it broke the standalone settings:

`put the hilitedButtonName of group "inclusions"` now returns:

`button "Search"` instead of just `"Search"`