### PR TITLE
[[Bug 13825/18097]] Profile Manager/Geometry Manager on Mobile

### DIFF
--- a/docs/dictionary/command/revSetCardProfile.lcdoc
+++ b/docs/dictionary/command/revSetCardProfile.lcdoc
@@ -10,9 +10,9 @@ its <object|objects>.
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 revSetCardProfile "MetallicLook"
@@ -51,11 +51,11 @@ of the <current card> of the specified <stack> and all the
 a <property profile|profile> with the specified <profileName>, the
 <object|object's> <properties> are not changed.
 
->*Important:*  The <revSetCardProfile> <command> is part of the <Profile
-> library>. To ensure that the <command> works in a <standalone
-> application>, in the Profiles section on the General screen of the
-> <Standalone Application Settings> window, make sure you choose to
-> include profiles in your application.
+>*Important:*  The <revSetCardProfile> <command> is part of the
+> <Profile library>. To ensure that the <command> works in a
+> <standalone application>, in the Profiles section on the General
+> screen of the <Standalone Application Settings> window, make sure you
+> choose to include profiles in your application.
 
 References: revSetStackFileProfile (command), object (glossary),
 property (glossary), current card (glossary),

--- a/docs/dictionary/command/revSetCardProfile.lcdoc
+++ b/docs/dictionary/command/revSetCardProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Changes the current <property profile|profile> used for a <card> and all
 its <object|objects>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/command/revSetStackFileProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackFileProfile.lcdoc
@@ -10,9 +10,9 @@ a <stack file> and all their <object|objects>.
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 revSetStackFileProfile "Brights"
@@ -53,10 +53,10 @@ specified <profileName>, the <object|object's> <properties> are not
 changed. 
 
 >*Important:*  The <revSetStackFileProfile> <command> is part of the
-> <Profile library>. To ensure that the <command> works in a <standalone
-> application>, in the Profiles section on the General screen of the
-> <Standalone Application Settings> window, make sure you choose to
-> include profiles in your application.
+> <Profile library>. To ensure that the <command> works in a 
+> <standalone application>, in the Profiles section on the General 
+> screen of the <Standalone Application Settings> window, make sure you
+> choose to include profiles in your application.
 
 References: revSetCardProfile (command), revSetStackProfile (command),
 stacks (function), object (glossary), property (glossary),

--- a/docs/dictionary/command/revSetStackFileProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackFileProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Changes the current <property profile|profile> used for all <stacks> in
 a <stack file> and all their <object|objects>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/command/revSetStackProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Changes the current <property profile|profile> used for a <stack> and
 all its <object|objects>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/command/revSetStackProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackProfile.lcdoc
@@ -10,9 +10,9 @@ all its <object|objects>.
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 revSetStackProfile "LargeFonts","Preferences"
@@ -50,10 +50,10 @@ profile|profile> with the specified <profileName>, the <object|object's>
 <properties> are not changed.
 
 >*Important:*  The <revSetStackProfile> <command> is part of the
-> <Profile library>. To ensure that the <command> works in a <standalone
-> application>, in the Profiles section on the General screen of the
-> <Standalone Application Settings> window, make sure you choose to
-> include profiles in your application.
+> <Profile library>. To ensure that the <command> works in a 
+> <standalone application>, in the Profiles section on the General 
+> screen of the <Standalone Application Settings> window, make sure you
+> choose to include profiles in your application.
 
 References: revSetStackFileProfile (command), object (glossary),
 property (glossary), Standalone Application Settings (glossary),

--- a/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
+++ b/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
@@ -9,6 +9,8 @@ A special <global|global variable> that specifies whether to
 automatically create a <property profile|profile> when you
 switch to a new profile.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android
@@ -42,6 +44,6 @@ changed in the Preferences dialog box:
 
 References: answer (command), ask (command), object (glossary),
 property (glossary), variable (glossary), property profile (glossary),
-global (glossary), properties (property)
+global (glossary), properties (property), Profile library (library)
 
 Tags: windowing

--- a/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
+++ b/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
@@ -1,0 +1,47 @@
+Name: gRevAutoCreateProfiles
+
+Type: keyword
+
+Syntax: gRevAutoCreateProfiles
+
+Summary:
+A special <global|global variable> that specifies whether to 
+automatically create a <property profile|profile> when you
+switch to a new profile.
+
+Introduced: 2.0
+
+OS: mac, windows, linux, ios, android
+
+Platforms: desktop, server, mobile
+
+Example:
+global gRevAutoCreateProfiles
+put true into gRevAutoCreateProfiles
+set the revProfile of me to "NewProfile"
+
+Description:
+Set the <gRevAutoCreateProfiles> <variable> to true when adding a
+new <property profile|profile>.  When false, attempts to change to a
+profile that does not exist are ignored.
+
+Each object can have one or more profiles, which include settings for
+each property in the object's <property|properties>. The
+<gRevAutoCreateProfiles> <variable> controls what happens when you set
+an <object|object's> <property profile|profile> to one that does not
+currently exist.  If true, then the new <property profile|profile> will
+be created.
+
+The <gRevAutoCreateProfiles> <global|global variable> can also be
+changed in the Preferences dialog box:
+
+1. Choose LiveCode → Preferences from the menubar.
+2. Choose "Property Profiles" from the menu at the top.
+3. Click "Create profiles automatically".
+
+
+References: answer (command), ask (command), object (glossary),
+property (glossary), variable (glossary), property profile (glossary),
+global (glossary), properties (property)
+
+Tags: windowing

--- a/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
+++ b/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
@@ -11,14 +11,12 @@ changes to the current <property profile|profile> when you switch
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 global gRevProfileReadOnly
-
-Example:
 if gRevProfileReadOnly is false then switchToLargeFonts
 
 Description:
@@ -43,7 +41,7 @@ in the Preferences dialog box:
 
 1. Choose LiveCode → Preferences from the menubar.
 2. Choose "Property Profiles" from the menu at the top.
-3. Click "Don't save changes in profile".
+3. Click "Don't save settings when switching profiles".
 
 
 References: answer (command), ask (command), object (glossary),
@@ -51,4 +49,3 @@ property (glossary), variable (glossary), property profile (glossary),
 global (glossary), properties (property)
 
 Tags: windowing
-

--- a/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
+++ b/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
@@ -9,6 +9,8 @@ A special <global|global variable> that specifies whether to save
 changes to the current <property profile|profile> when you switch
 <property profile|profiles>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android
@@ -46,6 +48,6 @@ in the Preferences dialog box:
 
 References: answer (command), ask (command), object (glossary),
 property (glossary), variable (glossary), property profile (glossary),
-global (glossary), properties (property)
+global (glossary), properties (property), Profile library (library)
 
 Tags: windowing

--- a/docs/dictionary/property/revProfile.lcdoc
+++ b/docs/dictionary/property/revProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Specifies the current <property profile|profile> for an
 <object(glossary)>. 
 
+Associations: profile library
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android
@@ -64,7 +66,7 @@ References: revSetStackFileProfile (command), object (glossary),
 property (glossary), custom property (glossary),
 backgroundColor (glossary), property profile (glossary), button (object),
 customPropertySets (property), gRevAutoCreateProfiles (keyword),
-gRevProfileReadOnly (keyword)
+gRevProfileReadOnly (keyword), Profile library (library)
 
 Tags: properties
 

--- a/docs/dictionary/property/revProfile.lcdoc
+++ b/docs/dictionary/property/revProfile.lcdoc
@@ -10,9 +10,9 @@ Specifies the current <property profile|profile> for an
 
 Introduced: 1.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 set the revProfile of button "OK" to "French"
@@ -40,15 +40,14 @@ stored in the object's current profile. If you later switch back to that
 profile, the stored values are restored. For example, if you create a
 profile named "Fluffy" for a button, then set the button's
 backgroundColor <property> to "pink", that setting of the
-<backgroundColor> <property> is stored with the Fluffy <property
-profile|profile>. If you later set the <button|button's> <property
-profile|profile> to "Fluffy", the pink color is restored.
+<backgroundColor> <property> is stored with the Fluffy
+<property profile|profile>. If you later set the <button|button's>
+<property profile|profile> to "Fluffy", the pink color is restored.
 
 If the <profileName> does not exist for the <object(glossary)>, setting
-the <property profile|profile> either causes an error or creates a new
+the <property profile|profile> either fails silently or creates a new
 <property profile|profile> with that name for the <object(glossary)>.
-You change this setting in the "Property Profiles" pane of the
-Preferences window.
+You change this setting using the <gRevAutoCreateProfiles> <variable>.
 
 (The <revProfile> <property> is implemented as a <custom property>, part
 of the "cRevGeneral" <custom property> set. For this reason, you can
@@ -61,20 +60,11 @@ cRevGeneral["profile"].)
 > Settings window, make sure you choose to include profiles in your
 > application. 
 
->*Note:* When included in a standalone application, the Profile library
-> is implemented as a hidden group and made available when the group
-> receives its first openBackground message. During the first part of
-> the application startup process, before this message is sent, the
-> <revProfile> property is not yet available. This may affect attempts
-> to use this property in startup, preOpenStack, openStack, or
-> preOpenCard hand in the main stack. Once the application has finished
-> starting up, the library is available and the <revProfile> property
-> can be used in any handler.
-
 References: revSetStackFileProfile (command), object (glossary),
 property (glossary), custom property (glossary),
 backgroundColor (glossary), property profile (glossary), button (object),
-customPropertySets (property)
+customPropertySets (property), gRevAutoCreateProfiles (keyword),
+gRevProfileReadOnly (keyword)
 
 Tags: properties
 

--- a/docs/glossary/g/Geometry-library.lcdoc
+++ b/docs/glossary/g/Geometry-library.lcdoc
@@ -4,6 +4,8 @@ Synonyms: geometry libraries, geometry library
 
 Type: library
 
+Associations: geometry library
+
 Description:
 The <LiveCode custom library|LiveCode custom library> that supports the
 Geometry pane in the <property inspector>. The <revCacheGeometry> and
@@ -11,7 +13,7 @@ Geometry pane in the <property inspector>. The <revCacheGeometry> and
 
 References: revCacheGeometry (command), revUpdateGeometry (command),
 command (glossary), property inspector (glossary),
-LiveCode custom library (glossary)
+LiveCode custom library (glossary), geometry management (glossary)
 
 Tags: ui
 

--- a/docs/glossary/m/master-profile.lcdoc
+++ b/docs/glossary/m/master-profile.lcdoc
@@ -4,6 +4,8 @@ Synonyms: master profile, master property profile
 
 Type: glossary
 
+Associations: profile library
+
 Description:
 The default <property profile> of an <object(glossary)>. The master
 profile holds the <default> settings for the <object|object's>

--- a/docs/glossary/p/Profile-library.lcdoc
+++ b/docs/glossary/p/Profile-library.lcdoc
@@ -5,6 +5,8 @@ profile libraries
 
 Type: library
 
+Associations: profile library
+
 Description:
 The <LiveCode custom library|LiveCode custom library> that supports
 <property profile|property profiles>. The <property profile|profile>

--- a/docs/glossary/p/property-profile.lcdoc
+++ b/docs/glossary/p/property-profile.lcdoc
@@ -4,6 +4,8 @@ Synonyms: profile, property profile
 
 Type: glossary
 
+Associations: profile library
+
 Description:
 A set of <property> settings for an <object(glossary)>. You create and
 change an <object|object's> profiles using the Property Profiles pane in

--- a/docs/notes/bugfix-13825.md
+++ b/docs/notes/bugfix-13825.md
@@ -1,0 +1,1 @@
+# revSetStackProfile does not work on mobile

--- a/docs/notes/bugfix-18097.md
+++ b/docs/notes/bugfix-18097.md
@@ -1,0 +1,1 @@
+# Geometry manager does not work on mobile

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -111,6 +111,14 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "android", tConfirm, pSettings
    
+   -- Manually include the mobile version of the common library
+   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   
+   -- Include profile library if needed
+   if pSettings["includeProfiles"] is not empty then 
+      revSBAddInclusion "Profiles", "scriptLibraries", pSettings
+   end if
+   
    -- Make sure old-style keys are retained, and updated with new information
    -- from inclusions pane of standalone settings GUI
    revSBConvertSettingsForPlatform pSettings, "android"

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -111,8 +111,8 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "android", tConfirm, pSettings
    
-   -- Manually include the mobile version of the common library
-   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   -- Manually include the common library
+   revSBAddInclusion "Common", "scriptLibraries", pSettings
    
    -- Include profile library if needed
    if pSettings["includeProfiles"] is not empty then 

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -104,8 +104,8 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "ios", tConfirm, pSettings
    
-   -- Manually include the mobile version of the common library
-   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   -- Manually include the common library
+   revSBAddInclusion "Common", "scriptLibraries", pSettings
    
    -- Include profile library if needed
    if pSettings["includeProfiles"] is not empty then 

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -104,6 +104,14 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "ios", tConfirm, pSettings
    
+   -- Manually include the mobile version of the common library
+   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   
+   -- Include profile library if needed
+   if pSettings["includeProfiles"] is not empty then 
+      revSBAddInclusion "Profiles", "scriptLibraries", pSettings
+   end if
+   
    -- Make sure old-style keys are retained, and updated with new information
    -- from inclusions pane of standalone settings GUI
    revSBConvertSettingsForPlatform pSettings, "ios"


### PR DESCRIPTION
Profile Manager (PM) and Geometry Manager (GM) do not work on mobile due to missing library code in the standalone that is built.

GM depends on a handler present in the common library (REVTargetStack).  That library was not being loaded on mobile.  There is a good bit of code in that library that is not applicable to mobile.  There is a separate PR to ~~add a mobile~~ update the common library ~~with just the applicable code~~.  This one includes the code in the built applications.

PM depends on getprop/setprop handlers in the common library.  Same solution as for GM.

The code that included the PM library itself was not included in the standalone builder scripts for mobile.  That code is included in this PR for both iOS and Android.

The documentation for PM did not include iphone and android (mobile).  Relevant docs are updated and some small corrections made.