### PR TITLE
[[ LCIDLC ]] Fix multi-line comments

### DIFF
--- a/lcidlc/src/Scanner.cpp
+++ b/lcidlc/src/Scanner.cpp
@@ -203,16 +203,20 @@ static void ScannerSkipMultilineComment(ScannerRef self)
 	while(!ScannerIsEndPrefix(self))
 	{
 		if (ScannerIsNewlinePrefix(self))
+		{
 			ScannerSkipNewline(self);
+		}
 		else if (ScannerIsMultilineCommentSuffix(self))
 		{
 			self -> input_frontier += 2;
 			self -> input_column += 2;
 			break;
 		}
-		
-		self -> input_frontier += 1;
-		self -> input_column += 1;
+		else
+		{
+			self->input_frontier += 1;
+			self->input_column += 1;
+		}
 	}
 }
 


### PR DESCRIPTION
The lcidlc multi-line comment parser was advancing too far when
encountering a newline because it was advancing past the newline then
advancing again during the loop without re-checking the frontier char
and therefore missing possible multiple newlines or the first char of
an end of minlti-line comment suffix.