### PR TITLE
[Dictionary] Changes from endFrame to executionContexts

### DIFF
--- a/docs/dictionary/function/eventAltKey.lcdoc
+++ b/docs/dictionary/function/eventAltKey.lcdoc
@@ -42,9 +42,9 @@ The terminology varies depending on platform. Users of different
 operating systems may know this key as the Option key (Mac OS systems),
 Meta key (Unix systems), or Alt key (Windows systems).
 
-  **Warning**: the value of this function is undefined after performing
-  a wait operation; it may no longer be the same as the value when the
-  event was dispatched.
+> **Warning**: the value of this function is undefined after performing
+> a wait operation; it may no longer be the same as the value when the
+> event was dispatched.
 
 
 References: return (constant), function (control structure),

--- a/docs/dictionary/function/eventAltKey.lcdoc
+++ b/docs/dictionary/function/eventAltKey.lcdoc
@@ -42,7 +42,7 @@ The terminology varies depending on platform. Users of different
 operating systems may know this key as the Option key (Mac OS systems),
 Meta key (Unix systems), or Alt key (Windows systems).
 
-  **warning**: the value of this function is undefined after performing
+  **Warning**: the value of this function is undefined after performing
   a wait operation; it may no longer be the same as the value when the
   event was dispatched.
 

--- a/docs/dictionary/function/eventCapsLockKey.lcdoc
+++ b/docs/dictionary/function/eventCapsLockKey.lcdoc
@@ -33,9 +33,9 @@ If you want to check the state of the Caps Lock key at the current time,
 rather than when the event was dispatched, use the <capsLockKey>
 <function>. 
 
-  **Warning**: the value of this function is undefined after performing
-  a wait operation; it may no longer be the same as the value when the
-  event was dispatched.
+> **Warning**: the value of this function is undefined after performing
+> a wait operation; it may no longer be the same as the value when the
+> event was dispatched.
 
 
 References: keysDown (function), return (glossary)

--- a/docs/dictionary/function/eventCapsLockKey.lcdoc
+++ b/docs/dictionary/function/eventCapsLockKey.lcdoc
@@ -33,7 +33,7 @@ If you want to check the state of the Caps Lock key at the current time,
 rather than when the event was dispatched, use the <capsLockKey>
 <function>. 
 
-  **warning**: the value of this function is undefined after performing
+  **Warning**: the value of this function is undefined after performing
   a wait operation; it may no longer be the same as the value when the
   event was dispatched.
 

--- a/docs/dictionary/function/eventCommandKey.lcdoc
+++ b/docs/dictionary/function/eventCommandKey.lcdoc
@@ -39,7 +39,7 @@ On Unix and Windows systems, the <eventCommandKey> function
 <function(control structure)>: the two <function(glossary)|functions>
 are synonyms.
 
-  **warning**: the value of this function is undefined after performing
+  **Warning**: the value of this function is undefined after performing
   a wait operation; it may no longer be the same as the value when the
   event was dispatched.
 

--- a/docs/dictionary/function/eventCommandKey.lcdoc
+++ b/docs/dictionary/function/eventCommandKey.lcdoc
@@ -39,9 +39,9 @@ On Unix and Windows systems, the <eventCommandKey> function
 <function(control structure)>: the two <function(glossary)|functions>
 are synonyms.
 
-  **Warning**: the value of this function is undefined after performing
-  a wait operation; it may no longer be the same as the value when the
-  event was dispatched.
+> **Warning**: the value of this function is undefined after performing
+> a wait operation; it may no longer be the same as the value when the
+> event was dispatched.
 
 
 References: function (control structure), controlKey (function),

--- a/docs/dictionary/function/eventControlKey.lcdoc
+++ b/docs/dictionary/function/eventControlKey.lcdoc
@@ -39,9 +39,9 @@ On Unix and Windows systems, the eventCommandKey function
 <function(control structure)>: the two <function(glossary)|functions>
 are synonyms.
 
-  **Warning**: the value of this function is undefined after performing
-  a wait operation; it may no longer be the same as the value when the
-  event was dispatched.
+> **Warning**: the value of this function is undefined after performing
+> a wait operation; it may no longer be the same as the value when the
+> event was dispatched.
 
 
 References: down (constant), left (constant), up (constant),

--- a/docs/dictionary/function/eventControlKey.lcdoc
+++ b/docs/dictionary/function/eventControlKey.lcdoc
@@ -39,7 +39,7 @@ On Unix and Windows systems, the eventCommandKey function
 <function(control structure)>: the two <function(glossary)|functions>
 are synonyms.
 
-  **warning**: the value of this function is undefined after performing
+  **Warning**: the value of this function is undefined after performing
   a wait operation; it may no longer be the same as the value when the
   event was dispatched.
 

--- a/docs/dictionary/function/eventOptionKey.lcdoc
+++ b/docs/dictionary/function/eventOptionKey.lcdoc
@@ -43,7 +43,7 @@ The terminology varies depending on platform. Users of different
 operating systems may know this key as the Option key (Mac OS systems),
 Meta key (Unix systems), or Alt key (Windows systems).
 
-  **warning**: the value of this function is undefined after performing
+  **Warning**: the value of this function is undefined after performing
   a wait operation; it may no longer be the same as the value when the
   event was dispatched.
 

--- a/docs/dictionary/function/eventOptionKey.lcdoc
+++ b/docs/dictionary/function/eventOptionKey.lcdoc
@@ -43,9 +43,9 @@ The terminology varies depending on platform. Users of different
 operating systems may know this key as the Option key (Mac OS systems),
 Meta key (Unix systems), or Alt key (Windows systems).
 
-  **Warning**: the value of this function is undefined after performing
-  a wait operation; it may no longer be the same as the value when the
-  event was dispatched.
+> **Warning**: the value of this function is undefined after performing
+> a wait operation; it may no longer be the same as the value when the
+> event was dispatched.
 
 
 References: return (constant), function (control structure),

--- a/docs/dictionary/function/eventShiftKey.lcdoc
+++ b/docs/dictionary/function/eventShiftKey.lcdoc
@@ -33,7 +33,7 @@ If you want to check the state of the <Shift key> at the current time,
 rather than when the event was dispatched, use the <shiftKey>
 <function>. 
 
-  **warning**: the value of this function is undefined after performing
+  **Warning**: the value of this function is undefined after performing
   a wait operation; it may no longer be the same as the value when the
   event was dispatched.
 

--- a/docs/dictionary/function/eventShiftKey.lcdoc
+++ b/docs/dictionary/function/eventShiftKey.lcdoc
@@ -33,9 +33,9 @@ If you want to check the state of the <Shift key> at the current time,
 rather than when the event was dispatched, use the <shiftKey>
 <function>. 
 
-  **Warning**: the value of this function is undefined after performing
-  a wait operation; it may no longer be the same as the value when the
-  event was dispatched.
+> **Warning**: the value of this function is undefined after performing
+> a wait operation; it may no longer be the same as the value when the
+> event was dispatched.
 
 
 References: left (constant), function (control structure),

--- a/docs/dictionary/keyword/english.lcdoc
+++ b/docs/dictionary/keyword/english.lcdoc
@@ -30,10 +30,13 @@ You can use the <english> <keyword> in combination with the <long>,
 must come before the <long>, <abbreviated>, or <short> <keyword>.
 
 A long English <date> looks like this: Thursday, June 22, 2000
+
 An abbreviated English <date> looks like this: Thu, Jan 22, 2000
+
 A short English <date> looks like this: 1/22/00
 
 A long English <time> looks like this: 11:22:47 AM
+
 An abbreviated English <time> or <short> English <time> looks like this:
 11:22 AM
 

--- a/docs/dictionary/message/errorDialog.lcdoc
+++ b/docs/dictionary/message/errorDialog.lcdoc
@@ -46,10 +46,10 @@ You can look up the description of an error using this line of code:
 > release to release.
 
 If the <lockErrorDialogs> <property> is true, the <errorDialog> <message>
-is sent to the <object(glossary)> that set the <lockErrorDialogs>.,
+is sent to the <object(glossary)> that set the <lockErrorDialogs>,
 rather than to the <object(glossary)> whose <script> contained the
-error. (The <lockErrorDialogs> can be set to true either by setting the
-<property> directly, or with the <lock error dialogs> <command>.)
+error. The <lockErrorDialogs> can be set to true either by setting the
+<property> directly, or with the <lock error dialogs> <command>.
 
 >*Note:* The <errorDialog> message is only sent while Script Debug mode
 > is turned off. To toggle Script Debug mode, click on the Development

--- a/docs/dictionary/property/endFrame.lcdoc
+++ b/docs/dictionary/property/endFrame.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: endFrame
 
 Summary:
-The <endFrame> <property> is not implemented and is <reserved
-word|reserved>.
+The <endFrame> <property> is not implemented and is 
+<reserved word|reserved>.
 
 Introduced: 1.0
 

--- a/docs/dictionary/property/endValue.lcdoc
+++ b/docs/dictionary/property/endValue.lcdoc
@@ -33,14 +33,14 @@ If the style of the <scrollbar(keyword)> is scale, the <endValue> is the
 to the bottom (for a vertical <scrollbar(keyword)>) or right (for a
 horizontal <scrollbar(keyword)>).
 
-If the style of the <scrollbar(keyword)> is scrollbar or progress, then
-when the scrollbar thumb is all the way to the end of the
+If the style of the <scrollbar(keyword)> is "scrollbar" or "progress", 
+then when the <scrollbar thumb> is all the way to the end of the
 <scrollbar(keyword)>, the <thumbPosition> is the
 <scrollbar(object)|scrollbar's> <endValue> minus the <thumbSize>.
 
 Setting the <endValue> to a <value> less than the
-<scrollbar(object)|scrollbar's> <thumbSize> <lock|locks> the <scrollbar
-thumb> to the top (or left) of the <scrollbar(keyword)>, preventing
+<scrollbar(object)|scrollbar's> <thumbSize> <lock|locks> the 
+<scrollbar thumb> to the top (or left) of the <scrollbar(keyword)>, preventing
 scrolling. 
 
 References: scrollbarFactor (constant), value (function),

--- a/docs/dictionary/property/executionContexts.lcdoc
+++ b/docs/dictionary/property/executionContexts.lcdoc
@@ -8,7 +8,6 @@ Summary:
 Reports information on the current state of the running application.
 
 Introduced: 1.1
-Important:The value of the <executionContexts> may be changed in future versions of LiveCode, it is not recommended to write code that depends on its contents.
 
 OS: mac, windows, linux, ios, android
 
@@ -39,6 +38,10 @@ object and handler that called the current handler, this information is
 available as: line -2 of the executionContexts.
 
 The <executionContexts> property is read-only and cannot be set.
+
+> *Important:* The value of the <executionContexts> may be changed in future 
+> versions of LiveCode, it is not recommended to write code that depends on 
+> its contents.
 
 References: errorDialog (message)
 

--- a/docs/glossary/e/engine.lcdoc
+++ b/docs/glossary/e/engine.lcdoc
@@ -5,12 +5,12 @@ Synonyms: engine
 Type: glossary
 
 Description:
-The back-end software that powers the LiveCode <development
-environment>, as well as <standalone application|standalone
-applications> created with LiveCode.
+The back-end software that powers the LiveCode 
+<development environment>, as well as 
+<standalone application|standalone applications> created with LiveCode.
 
-The engine includes the <LiveCode> <compile|compiler>, the <object
-hierarchy>, and <object(glossary)> display routines.
+The engine includes the <LiveCode> <compile|compiler>, the 
+<object hierarchy>, and <object(glossary)> display routines.
 
 References: object hierarchy (glossary), LiveCode (glossary),
 standalone application (glossary), compile (glossary),

--- a/docs/glossary/e/error.lcdoc
+++ b/docs/glossary/e/error.lcdoc
@@ -6,8 +6,8 @@ Type: glossary
 
 Description:
 A problem or mistake in a program or <handler>, which prevents it from
-being <compile|compiled> (<compile error>) or from running (<execution
-error>). 
+being <compile|compiled> (<compile error>) or from running 
+(<execution error>). 
 
 References: handler (glossary), compile error (glossary),
 compile (glossary), execution error (glossary)


### PR DESCRIPTION
property/endFrame.lcdoc - Fixed broken link.
property/endValue.lcdoc - Fixed broken link. Added quotes to style values mentioned in description for clarity and because they are required in strict compilation mode.
glossary/e/engine.lcdoc - Fixed broken links.
keyword/english.lcdoc - Add line breaks to date format examples.
glossary/e/error.lcdoc - Fixed broken links.
message/errorDialog.lcdoc - Removed punctuation.
function/eventAltKey.lcdoc - Capitalised the first letter of `warning:`.
function/eventCapsLockKey.lcdoc - Capitalised the first letter of `warning:`
function/eventCommandKey.lcdoc - Capitalised the first letter of `warning:`
function/eventControlKey.lcdoc - Capitalised the first letter of `warning:`
function/eventOptionKey.lcdoc - Capitalised the first letter of `warning:`
function/eventShiftKey.lcdoc - Capitalised the first letter of `warning:`
property/executionContexts.lcdoc - Moved `Important:` sentence to keep it from displaying on the same line as the version introduced line.