### PR TITLE
Update the executionContexts documentation

### DIFF
--- a/docs/dictionary/property/executionContexts.lcdoc
+++ b/docs/dictionary/property/executionContexts.lcdoc
@@ -16,16 +16,44 @@ Platforms: desktop, server, mobile
 
 Example:
 on errorDialog
+  local tContextArray
   local tHandler, tLineNumber, tObject
-  if item 4 of line -2 of the executionContexts is empty then
-    put item 1 of line -2 of the executionContexts into tObject
+
+  put parsedContext(line -2 of the executionContexts) into tContextArray
+
+  if tContextArray["behavior"] is empty then
+    put tContextArray["object"] into tObject
   else
-    put item 4 of line -2 of the executionContexts into tObject
+    put tContextArray["behavior"] into tObject
   end if
-  put item 2 of line -2 of the executionContexts into tHandler
-  put item 3 of line -2 of the executionContexts into tLineNumber
+  put tContextArray["handler"] into tHandler
+  put tContextArray["line"] into tLineNumber
   answer "An error occurred at line" && tLineNumber && "in handler" && tHandler && "of" && tObject
 end errorDialog
+
+local tKey = "object", tContextA
+function parsedContext pContextLine
+  repeat for each item tItem in pContextLine
+    if tContextA[tKey] is not empty then
+        put comma after tContextA[tKey]
+    end if
+    put tItem after tContextA[tKey]
+
+    switch tKey
+       case "object"
+           if exists(tContextA[tKey]) then
+                put "handler" into tKey
+           end if
+           break
+       case "handler"
+           put "line" into tKey
+           break
+        case "line"
+           put "behavior" into tKey
+           break
+    end switch
+  end repeat
+end parsedContext
 
 Value:
 The <executionContexts> is similar to a call stack, it consists of a

--- a/docs/dictionary/property/executionContexts.lcdoc
+++ b/docs/dictionary/property/executionContexts.lcdoc
@@ -33,7 +33,7 @@ end errorDialog
 
 function parsedContext pContextLine
   local tKey = "object", tContextA
-  
+
   repeat for each item tItem in pContextLine
     if tContextA[tKey] is not empty then
         put comma after tContextA[tKey]
@@ -64,7 +64,7 @@ Each context is a string of the following 3 or 4 comma-delimited items:
 1. object long id
 2. handler name
 3. line number
-4. behavior object long id [if the context is from a behavior script]
+4. behavior object long id if the context is from a behavior script
 
 Description:
 Use the <executionContexts> property to obtain information about the

--- a/docs/dictionary/property/executionContexts.lcdoc
+++ b/docs/dictionary/property/executionContexts.lcdoc
@@ -17,13 +17,13 @@ Platforms: desktop, server, mobile
 Example:
 on errorDialog
   local tHandler, tLineNumber, tObject
-  if item 4 of line -1 of the executionContexts is empty then
-    put item 1 of line -1 of the executionContexts into tObject
+  if item 4 of line -2 of the executionContexts is empty then
+    put item 1 of line -2 of the executionContexts into tObject
   else
-    put item 4 of line -1 of the executionContexts into tObject
+    put item 4 of line -2 of the executionContexts into tObject
   end if
-  put item 2 of line -1 of the executionContexts into tHandler
-  put item 3 of line -1 of the executionContexts into tLineNumber
+  put item 2 of line -2 of the executionContexts into tHandler
+  put item 3 of line -2 of the executionContexts into tLineNumber
   answer "An error occurred at line" && tLineNumber && "in handler" && tHandler && "of" && tObject
 end errorDialog
 

--- a/docs/dictionary/property/executionContexts.lcdoc
+++ b/docs/dictionary/property/executionContexts.lcdoc
@@ -25,7 +25,7 @@ Value:
 The <executionContexts> is similar to a call stack, it consists of a
 list of contexts, one per line, with the most recent context at the end.
 Each context is a string of the form:
-&lt;object-long-id&gt;,&lt;handler-name&gt;,&lt;line-number&gt; 
+&lt;object-long-id&gt;,&lt;handler-name&gt;,&lt;line-number&gt;,&lt;behavior-object-long-id&gt;
 
 Description:
 Use the <executionContexts> property to obtain information about the
@@ -38,7 +38,8 @@ A common use of the <executionContexts> is to obtain the name of the
 object and handler that called the current handler, this information is
 available as: line -2 of the executionContexts.
 
+Note that if the function call occurred in a behavior script, then the line number refers to the behavior script, not the target script.
+
 The <executionContexts> property is read-only and cannot be set.
 
 References: errorDialog (message)
-

--- a/docs/dictionary/property/executionContexts.lcdoc
+++ b/docs/dictionary/property/executionContexts.lcdoc
@@ -31,8 +31,9 @@ on errorDialog
   answer "An error occurred at line" && tLineNumber && "in handler" && tHandler && "of" && tObject
 end errorDialog
 
-local tKey = "object", tContextA
 function parsedContext pContextLine
+  local tKey = "object", tContextA
+  
   repeat for each item tItem in pContextLine
     if tContextA[tKey] is not empty then
         put comma after tContextA[tKey]

--- a/docs/dictionary/property/executionContexts.lcdoc
+++ b/docs/dictionary/property/executionContexts.lcdoc
@@ -16,16 +16,26 @@ Platforms: desktop, server, mobile
 
 Example:
 on errorDialog
-  local tHandler
-  put item -2 of line -2 of the executionContexts into tHandler
-  answer "An error occurred in the handler: " & tHandler
+  local tHandler, tLineNumber, tObject
+  if item 4 of line -1 of the executionContexts is empty then
+    put item 1 of line -1 of the executionContexts into tObject
+  else
+    put item 4 of line -1 of the executionContexts into tObject
+  end if
+  put item 2 of line -1 of the executionContexts into tHandler
+  put item 3 of line -1 of the executionContexts into tLineNumber
+  answer "An error occurred at line" && tLineNumber && "in handler" && tHandler && "of" && tObject
 end errorDialog
 
 Value:
 The <executionContexts> is similar to a call stack, it consists of a
 list of contexts, one per line, with the most recent context at the end.
-Each context is a string of the form:
-&lt;object-long-id&gt;,&lt;handler-name&gt;,&lt;line-number&gt;,&lt;behavior-object-long-id&gt;
+Each context is a string of the following 3 or 4 comma-delimited items:
+
+1. object long id
+2. handler name
+3. line number
+4. behavior object long id [if the context is from a behavior script]
 
 Description:
 Use the <executionContexts> property to obtain information about the
@@ -38,7 +48,7 @@ A common use of the <executionContexts> is to obtain the name of the
 object and handler that called the current handler, this information is
 available as: line -2 of the executionContexts.
 
-Note that if the function call occurred in a behavior script, then the line number refers to the behavior script, not the target script.
+>**Note:** if the function call occurred in a behavior script, then the line number refers to the behavior script, not the target script.
 
 The <executionContexts> property is read-only and cannot be set.
 


### PR DESCRIPTION
The content of the executionContexts changed with the introduction of behavior scripts. This patch updates the documentation with the behavior object parameter.

Note: this is the first time I've submitted a PR for an lcdoc file, so I'm not sure if I've got the annotations in proper form. I assume the attribution comment doesn't apply because it would appear in the docs, and because the documentation doesn't work in linux I can't test the file myself.