### PR TITLE
[Dictionary] Changes from exit to file

### DIFF
--- a/docs/dictionary/command/export-snapshot.lcdoc
+++ b/docs/dictionary/command/export-snapshot.lcdoc
@@ -2,9 +2,7 @@ Name: export snapshot
 
 Type: command
 
-Syntax: export snapshot {[from rect[angle] <rectangle>] [of <object>] | from <object> 
-[{with | without} effects]} [at size <size>] [{with|and} metadata <metadata>] 
-to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
+Syntax: export snapshot {[from rect[angle] <rectangle>] [of <object>] | from <object> [{with | without} effects]} [at size <size>] [{with|and} metadata <metadata>] to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
 
 Summary:
 Creates a picture file from a portion of the screen.

--- a/docs/dictionary/command/export-snapshot.lcdoc
+++ b/docs/dictionary/command/export-snapshot.lcdoc
@@ -2,7 +2,9 @@ Name: export snapshot
 
 Type: command
 
-Syntax: export snapshot {[from rect[angle] <rectangle>] [of <object(glossary)>] | from <object> [{with | without} effects]} [at size <size>] [{with|and} metadata <metadata>] to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
+Syntax: export snapshot {[from rect[angle] <rectangle>] [of <object>] | from <object> 
+[{with | without} effects]} [at size <size>] [{with|and} metadata <metadata>] 
+to {file <filePath> | <container>} [as <format>] [with mask <maskFile>]
 
 Summary:
 Creates a picture file from a portion of the screen.
@@ -126,7 +128,7 @@ expression evaluating to a control reference.
 
 To export a snapshot of an object in iOS use the form:
 
-    <export snapshot> from [rectangle rect of] <object(glossary)> 
+    <export snapshot> from [rectangle rect of] object 
 
 To export a snapshot of the screen in iOS use the form:
 

--- a/docs/dictionary/command/export-widget.lcdoc
+++ b/docs/dictionary/command/export-widget.lcdoc
@@ -6,7 +6,7 @@ Syntax: export <widget> to array <arrayVar>
 
 Summary:
 Exports the state of the given widget in a form which can be imported
-using <import widget | import widget from array>.
+using <import widget|import widget from array>.
 
 Introduced: 8.0
 

--- a/docs/dictionary/command/export-with-palette.lcdoc
+++ b/docs/dictionary/command/export-with-palette.lcdoc
@@ -2,17 +2,21 @@ Name: export with palette
 
 Type: command
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with standard palette
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
+<container>} as {gif | png} with standard palette
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with optimized palette
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
+<container>} as {gif | png} with optimized palette
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with <colorCount> color [optimized] palette
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
+<container>} as {gif | png} with <colorCount> color [optimized] palette
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with palette <colorList>
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
+<container>} as {gif | png} with palette <colorList>
 
 Summary:
-<export|Exports> the <selected> <image> as a <PBM>, <JPEG>, <GIF>, BMP
-or <PNG (glossary)> <file>.
+<export|Exports> the <selected> <image> as a <PBM>, <JPEG>, <GIF>, <BMP>
+or <PNG> <file>.
 
 Introduced: 4.5
 
@@ -87,8 +91,7 @@ dontDither property.
 > palette makes no sense.
 
 References: export (command), export snapshot (command), import (command),
-JPEG (glossary), GIF (glossary), export (glossary), PBM (glossary),
-container (glossary), PNG (glossary), command (glossary), file (keyword),
-image (keyword), paint (keyword), as (keyword), JPEGQuality (property),
-selected (property)
-
+BMP (glossary), command (glossary), container (glossary), export (glossary), 
+GIF (glossary), JPEG (glossary), PBM (glossary), PNG (glossary), 
+as (keyword), file (keyword), image (keyword), paint (keyword), URL (keyword),
+defaultFolder (property), JPEGQuality (property), selected (property)

--- a/docs/dictionary/command/export-with-palette.lcdoc
+++ b/docs/dictionary/command/export-with-palette.lcdoc
@@ -2,17 +2,13 @@ Name: export with palette
 
 Type: command
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
-<container>} as {gif | png} with standard palette
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with standard palette
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
-<container>} as {gif | png} with optimized palette
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with optimized palette
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
-<container>} as {gif | png} with <colorCount> color [optimized] palette
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with <colorCount> color [optimized] palette
 
-Syntax: export <image> [with metadata <metadata>] to {file <filePath> | 
-<container>} as {gif | png} with palette <colorList>
+Syntax: export <image> [with metadata <metadata>] to {file <filePath> | <container>} as {gif | png} with palette <colorList>
 
 Summary:
 <export|Exports> the <selected> <image> as a <PBM>, <JPEG>, <GIF>, <BMP>

--- a/docs/dictionary/control_st/exit-repeat.lcdoc
+++ b/docs/dictionary/control_st/exit-repeat.lcdoc
@@ -19,7 +19,9 @@ if x &gt; 0 then exit repeat
 
 Description:
 Use the <exit repeat> <control structure> to skip the rest of a <repeat>
-<loop>. Form:The <exit repeat> <statement> appears on a line by itself,
+<loop>. 
+
+**Form:** The <exit repeat> <statement> appears on a line by itself,
 anywhere inside a <repeat> <control structure>.
 
 After an <exit repeat> <statement>, none of the remaining
@@ -30,15 +32,22 @@ any more <loop|loops> are skipped. The <handler> <resume|resumes>
 
 Usually, <exit repeat> is used within an <if> <control structure>, so
 that the <loop> stops if a condition is true and continues if the
-condition is false. This example stops the <loop> when the user presses
-the mouse button:
+condition is false. This example reads a file in chunks and stops the
+<loop> when it encounters the end of file or if the file is empty:
 
-    repeat with x = 1 to the number of cards
-    go card x
-    if the mouse is down then exit repeat -- bail out
-
+    constant kChunk = 1024
+    open file tFile for binary read
+    repeat
+        read from file tFile for kChunk
+        put the result into tResult
+        if tResult is empty or tResult is "eof" then
+            ProcessFileChunk it
+        end if
+        if tResult is not empty then
+             exit repeat
+        end if
     end repeat
-
+    close file tFile
 
 References: exit (control structure), next repeat (control structure),
 repeat (control structure), if (control structure), handler (glossary),

--- a/docs/dictionary/control_st/exit.lcdoc
+++ b/docs/dictionary/control_st/exit.lcdoc
@@ -29,7 +29,9 @@ The name of the handler in which the exit control structure appears.
 Description:
 Use the <exit> <control structure> to skip the rest of a
 <handler|handler's> <statement|statements> without <return|returning> a
-result. Form:The <exit> <statement> appears on a line by itself,
+result. 
+
+**Form:** The <exit> <statement> appears on a line by itself,
 anywhere inside a <handler>.
 
 You can use an <exit> <control structure> in a <message handler>,

--- a/docs/dictionary/function/exp10.lcdoc
+++ b/docs/dictionary/function/exp10.lcdoc
@@ -7,7 +7,7 @@ Syntax: the exp10 of <number>
 Syntax: exp10(<number>)
 
 Summary:
-<return|Returns> the <decimal> exponential of a number.
+<return|Returns> the decimal exponential of a number.
 
 Introduced: 1.0
 
@@ -35,10 +35,10 @@ The expression exp10(number) is equal to 10^number.
 
 If <number> is a positive <integer>, exp10(number) is a 1 followed by
 <number> zeros. If <number> is a <negative> <integer>, exp10(number) is
-a decimal point followed by <number> -1 zeros and a one.
+a decimal point followed by <number>-1 zeros and a one.
 
 References: exp (function), negative (glossary), return (glossary),
-decimal (glossary), integer (keyword)
+integer (keyword)
 
 Tags: math
 

--- a/docs/dictionary/keyword/file.lcdoc
+++ b/docs/dictionary/keyword/file.lcdoc
@@ -30,9 +30,9 @@ Description:
 Use the <file> <keyword> to work with <text file|text files>.
 
 The <file> <URL scheme|scheme> indicates a <text file> which is located
-on the user's system. The <file> is specified by either a <absolute file
-path|full path> starting with "/", or a <relative file path|relative
-path> starting from the <defaultFolder>.
+on the user's system. The <file> is specified by either a 
+<absolute file path|full path> starting with "/", or a 
+<relative file path|relative path> starting from the <defaultFolder>.
 
 A URL container can be used anywhere another container type is used.
 
@@ -40,8 +40,8 @@ Different operating systems use different characters to mark the end of
 a line. Mac OS and OS X use a return character (ASCII 13), Unix systems
 use a linefeed character (ASCII 10), and Windows systems use a return
 followed by a linefeed. When you use a <file> <URL> as a <container>,
-LiveCode automatically uses the current system's standard <end-of-line
-marker> and LiveCode's linefeed character.
+LiveCode automatically uses the current system's standard 
+<end-of-line marker> and LiveCode's linefeed character.
 
 >*Tip:*  To put data into, or get data from, a <binary file>, use the
 > <binfile> <keyword> instead.

--- a/docs/dictionary/message/exitField.lcdoc
+++ b/docs/dictionary/message/exitField.lcdoc
@@ -42,8 +42,8 @@ is sent instead of <exitField>. This means that if you want to take an
 action when the selection is removed from a field--whether the field has
 changed or not--you must handle both <closeField> and <exitField>.
 
->*Note:* If the field's contents were changed by script using the <put
-> command>, then exitField will still be sent. <closeField> is only sent
+>*Note:* If the field's contents were changed by script using the <put>
+> command, then exitField will still be sent. <closeField> is only sent
 > when the contents are changed by the user.
 
 References: put (command), select (command),

--- a/docs/glossary/e/explicit-focus.lcdoc
+++ b/docs/glossary/e/explicit-focus.lcdoc
@@ -6,8 +6,8 @@ active-focus, explicit-focus
 Type: glossary
 
 Description:
-A mode in which you have to click a window to make it the <active
-window>. 
+A mode in which you have to click a window to make it the 
+<active window>. 
 
 Also called "active focus" or "click-to-type focus".
 


### PR DESCRIPTION
control_st/exit.lcdoc - Fixed broken link. Made `Form:` more visible. 
control_st/exit-repeat.lcdoc - Made `Form:` more visible. Replaced example with that from 9.0’s entry.
message/exitField.lcdoc - Fixed broken link.
function/exp10.lcdoc - Removed angle brackets from `decimal` and removed `decimal` from references; entry does not exist.
glossary/e/explicit-focus.lcdoc - Fixed broken link.
command/export-snapshot.lcdoc - Changed `<object(glossary)>` to `object` in a couple of places as one wasn’t displaying correctly and the other was causing everything else not to display correctly.
command/export-widget.lcdoc - Fixed broken link.
command/export-with-palette.lcdoc - Fixed broken links, added absent references and a link for BMP.
keyword/file.lcdoc - Fixed broken links.