### PR TITLE
[[ Bug 20665 ]] Prevent duplicate and triplicate dict entries

### DIFF
--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -2001,7 +2001,7 @@ private command docsBuilderGetDictionaryFolders pEdition, @xFolders
    
    repeat for each item tEdition in "indy,business"
       if editionCompare(pEdition, tEdition) >= 0 then
-         addFolderToListIfExists RepoEditionDocsFolder(), true, xFolders
+         addFolderToListIfExists RepoEditionDocsFolder(tEdition), true, xFolders
       end if
    end repeat
 end docsBuilderGetDictionaryFolders


### PR DESCRIPTION
The edition was not being passed through to the function, meaning
the commnunity dict folder was added multiple times.