### PR TITLE
Do not throw an error if livecode-private/docs/business folder is not found

### DIFF
--- a/builder/docs_builder.livecodescript
+++ b/builder/docs_builder.livecodescript
@@ -2001,7 +2001,7 @@ private command docsBuilderGetDictionaryFolders pEdition, @xFolders
    
    repeat for each item tEdition in "indy,business"
       if editionCompare(pEdition, tEdition) >= 0 then
-         addFolderToListIfExists RepoEditionDocsFolder(tEdition), true, xFolders
+         addFolderToListIfExists RepoEditionDocsFolder(tEdition), tEdition is "indy", xFolders
       end if
    end repeat
 end docsBuilderGetDictionaryFolders


### PR DESCRIPTION
In branch `develop-8.1`, `livecode-private/docs/` folder does have a subfolder `"indy"` but does not have a subfolder `"business"`.

Thus the docs builder should throw a warning, not an error, if this folder (`"business"`) is not found.

This was the case before the refactor in PR: https://github.com/livecode/livecode/pull/6111/files (see old line 2011 in file `builder/docs_builder.livecodescript`

So, the second param of `addFolderToListIfExists` should be `true` only when the edition is indy.