### PR TITLE
[[ Bug ]] Fix test extension loading

### DIFF
--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -1287,9 +1287,13 @@ function revDocsParseDocFileToLibraryArray pFile, pLibraryName, pAuthor
 end revDocsParseDocFileToLibraryArray
 
 function revDocsParseDocTextToLibraryArray pFile, pText, pLibraryName, pAuthor
-  local tOverridesA
-   put pLibraryName into tOverridesA["display name"]
-   put pAuthor into tOverridesA["author"]
+   local tOverridesA
+   if pLibraryName is not empty then
+      put pLibraryName into tOverridesA["display name"]
+   end if
+   if pAuthor is not empty then
+      put pAuthor into tOverridesA["author"]
+   end if 
    return revDocsParseDocText(pText, pFile, "", tOverridesA)
 end revDocsParseDocTextToLibraryArray
 
@@ -1370,12 +1374,12 @@ function revDocsParseDocText pText, pFilename, pDefaults, pOverrides
       switch it
          case "Name"
          case empty
-            exit repeat
-         case "Title"       
+            exit repeat     
          case "Library"
             put tElementsA[tStartNum]["content"] into tParsedA["library"]
             add 1 to tStartNum
             break
+         case "Title"  
          case "Summary"
          case "Description"
          case "Author"

--- a/tests/ide-support/standalonebuilder/java.livecodescript
+++ b/tests/ide-support/standalonebuilder/java.livecodescript
@@ -39,8 +39,8 @@ end __GetExtFolder
 
 private command __InstallExtension
    revIDEExtensionLoad sExtensionName, \
-         __GetExtFolder(), \
-         "0.0.0", "installed", "", "true"
+         __GetExtFolder(), "0.0.0", "installed", \
+         "", "true", "javatest.lcb"
 end __InstallExtension
 
 on TestTeardown

--- a/tests/ide-support/standalonebuilder/resources.livecodescript
+++ b/tests/ide-support/standalonebuilder/resources.livecodescript
@@ -38,8 +38,8 @@ end __GetExtFolder
 
 private command __InstallExtension
    revIDEExtensionLoad sExtensionName, \
-         __GetExtFolder(), \
-         "0.0.0", "installed", "", "true"
+         __GetExtFolder(), "0.0.0", "installed", \
+         "", "true", "resourcestest.lcb"
 end __InstallExtension
 
 on TestTeardown


### PR DESCRIPTION
The extensions library script had a slightly modified API - we need
to pass the source file in the test extensions when loading so that
they are treated as lcb extensions.