### PR TITLE
[[ Bug 20633 ]] Ensure zero length blocks are skipped on get

### DIFF
--- a/docs/notes/bugfix-20633.md
+++ b/docs/notes/bugfix-20633.md
@@ -1,0 +1,1 @@
+# Ensure vtab doesn't interfere with styling

--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -614,6 +614,11 @@ template<typename T> void GetCharPropOfCharChunk(MCExecContext& ctxt, MCField *p
         t_firstblock = sptr -> getblocks();
         t_block = sptr -> indextoblock(si, False);
         
+        while(t_block->next() != t_firstblock && t_block->GetLength() == 0)
+        {
+            t_block = t_block->next();
+        }
+        
         for(;;)
         {
             if (t_first)

--- a/tests/lcs/core/field/htmlText.livecodescript
+++ b/tests/lcs/core/field/htmlText.livecodescript
@@ -54,3 +54,18 @@ on TestSurrogateRoundtrip
 
    delete stack "Test"
 end TestSurrogateRoundtrip
+
+// Regression test for bug 20633 - note the bug here was that a NUL block is
+// created which causes the 'char' reference to be wrong.
+on TestAnnotationsAndVTab
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   create field "TestField"
+
+   set the htmlText of field "TestField" to format("<p><a href=\"#Anchor1\">Anchor1&#11;</a><a href=\"#Anchor2\">Anchor2&#11;</a></p>")
+   TestAssert "linkText on VTab does not elide with next linkText", the linkText of char 9 of field "TestField" is "#Anchor2"
+
+   set the htmlText of field "TestField" to format("<p><span metadata=\"#Anchor1\">Anchor1&#11;</span><span metadata=\"#Anchor2\">Anchor2&#11;</span></p>")
+   TestAssert "metadata on VTab does not elide with next metadata", the metadata of char 9 of field "TestField" is "#Anchor2"
+end TestAnnotationsAndVTab


### PR DESCRIPTION
This patch ensures that any zero length blocks are skipped before
resolving a GetCharProp call on the field.

An explicit line break (vtab) in a paragraph causes an empty
block to be created as a sentinal for the end of the line.