### PR TITLE
[[ Bug 20563 ]] Support fetching binary data synchronously over HTTP …

### DIFF
--- a/docs/notes/bugfix-20563.md
+++ b/docs/notes/bugfix-20563.md
@@ -1,0 +1,1 @@
+# HTML 5 engine does not support fetching binary data using get URL


### PR DESCRIPTION
…when using emscripten engine.

Synchronous XMLHTTPRequests don't support fetching binary data.
This patch attempts to work around this by telling browsers to treat
the data as plain text, using a call tooverrideMimeType. However,
it's not ideal, is potentially quite inefficient and future browser
support is not gaurenteed. Indeed, synchronous XMLHTTPRequests are
set to be deprecated by browsers at some point, so this may require
further thought in the future.