### PR TITLE
[[ Feature ]] SVG Support

### DIFF
--- a/engine/src/graphicscontext.cpp
+++ b/engine/src/graphicscontext.cpp
@@ -1232,6 +1232,10 @@ void MCGraphicsContext::fillpath(MCPath *path, bool p_evenodd)
 
 void MCGraphicsContext::drawpict(uint1 *data, uint4 length, bool embed, const MCRectangle& drect, const MCRectangle& crect)
 {
+    MCGContextSave(m_gcontext);
+    MCGContextClipToRect(m_gcontext, MCRectangleToMCGRectangle(crect));
+    MCGContextPlayback(m_gcontext, MCRectangleToMCGRectangle(drect), data, length);
+    MCGContextRestore(m_gcontext);
 }
 
 void MCGraphicsContext::draweps(real8 sx, real8 sy, int2 angle, real8 xscale, real8 yscale, int2 tx, int2 ty,

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -70,6 +70,7 @@
 				'script-libraries/oauth2/oauth2.livecodescript',
 				'script-libraries/getopt/getopt.livecodescript',
 				'script-libraries/mime/mime.livecodescript',
+				'script-libraries/drawing/drawing.livecodescript',
 				'script-libraries/dropbox/dropbox.livecodescript',
 				'script-libraries/diff/diff.livecodescript',
 				'script-libraries/messageauthentication/messageauthentication.livecodescript',

--- a/extensions/script-libraries/drawing/drawing-svg-specification.txt
+++ b/extensions/script-libraries/drawing/drawing-svg-specification.txt
@@ -1,0 +1,176 @@
+element
+	property fill <paint>|inherit default black
+	property fill-rule nonzero|evenodd|inherit default nonzero
+	property fill-opacity <opacity>|inherit default 1
+	property stroke <paint>|inherit default none
+	property stroke-width <length>|inherit default 1
+	property stroke-linecap butt|round|square|inherit default butt
+	property stroke-linejoin miter|round|bevel|inherit default miter
+	property stroke-miterlimit <miterlimit>|inherit default 4
+	property stroke-dasharray <dasharray>|inherit default none
+	property stroke-dashoffset <length>|inherit default 0
+	property stroke-opacity <opacity>|inherit default 1
+
+element svg
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute version 1.0|1.1|1.2 nullable 
+	attribute baseProfile none|full|basic|tiny default none
+	attribute x <coordinate> default 0
+	attribute y <coordinate> default 0
+	attribute width <size> default 100%
+	attribute height <size> default 100%
+	attribute viewBox <normalized-rectangle>|none default none
+	attribute preserveAspectRatio <preserve-aspect-ratio> default "xMidYMid meet"
+
+element defs
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+
+element use
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute x <coordinate> default 0
+	attribute y <coordinate> default 0
+	attribute href <reference> nullable
+	attribute xlink:href <reference> nullable
+
+element g
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+
+element rect
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute x <coordinate> default 0
+	attribute y <coordinate> default 0
+	attribute width <nonnegative-length> default 0
+	attribute height <nonnegative-length> default 0
+	attribute rx <nonnegative-length> nullable
+	attribute ry <nonnegative-length> nullable
+	apply fill
+	apply fill-rule
+	apply fill-opacity
+	apply stroke
+	apply stroke-width
+	apply stroke-linecap
+	apply stroke-linejoin
+	apply stroke-miterlimit
+	apply stroke-dasharray
+	apply stroke-dashoffset
+	apply stroke-opacity
+
+element circle
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute cx <coordinate> default 0
+	attribute cy <coordinate> default 0
+	attribute r <nonnegative-length> default 0
+	apply fill
+	apply fill-rule
+	apply fill-opacity
+	apply stroke
+	apply stroke-width
+	apply stroke-linecap
+	apply stroke-linejoin
+	apply stroke-miterlimit
+	apply stroke-dasharray
+	apply stroke-dashoffset
+	apply stroke-opacity
+
+element ellipse
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute cx <coordinate> default 0
+	attribute cy <coordinate> default 0
+	attribute rx <nonnegative-length> default 0
+	attribute ry <nonnegative-length> default 0
+	apply fill
+	apply fill-rule
+	apply fill-opacity
+	apply stroke
+	apply stroke-width
+	apply stroke-linecap
+	apply stroke-linejoin
+	apply stroke-miterlimit
+	apply stroke-dasharray
+	apply stroke-dashoffset
+	apply stroke-opacity
+
+element line
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute x1 <coordinate> default 0
+	attribute y1 <coordinate> default 0
+	attribute x2 <coordinate> default 0
+	attribute y2 <coordinate> default 0
+	apply fill
+	apply fill-rule
+	apply fill-opacity
+	apply stroke
+	apply stroke-width
+	apply stroke-linecap
+	apply stroke-linejoin
+	apply stroke-miterlimit
+	apply stroke-dasharray
+	apply stroke-dashoffset
+	apply stroke-opacity
+
+element polyline
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute points <points> default ""
+	apply fill
+	apply fill-rule
+	apply fill-opacity
+	apply stroke
+	apply stroke-width
+	apply stroke-linecap
+	apply stroke-linejoin
+	apply stroke-miterlimit
+	apply stroke-dasharray
+	apply stroke-dashoffset
+	apply stroke-opacity
+
+element polygon
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute points <points> default ""
+	apply fill
+	apply fill-rule
+	apply fill-opacity
+	apply stroke
+	apply stroke-width
+	apply stroke-linecap
+	apply stroke-linejoin
+	apply stroke-miterlimit
+	apply stroke-dasharray
+	apply stroke-dashoffset
+	apply stroke-opacity
+
+element path
+	attribute id <identifier> nullable
+	attribute style <text> nullable
+	attribute transform <transform> nullable
+	attribute d <path> default ""
+	attribute pathLength <nonnegative-length> nullable
+	apply fill
+	apply fill-rule
+	apply fill-opacity
+	apply stroke
+	apply stroke-width
+	apply stroke-linecap
+	apply stroke-linejoin
+	apply stroke-miterlimit
+	apply stroke-dasharray
+	apply stroke-dashoffset
+	apply stroke-opacity
+

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -1,0 +1,2970 @@
+﻿script "com.livecode.library.drawing"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on extensionInitialize
+   if the target is not me then
+      pass extensionInitialize
+   end if
+   
+   insert the script of me into back
+   
+   if the environment contains "development" then
+      set the _ideoverride of me to true
+   end if
+   
+   svgSpecLoad
+end extensionInitialize
+
+on extensionFinalize
+   if the target is not me then
+      pass extensionFinalize
+   end if
+   
+   remove the script of me from back
+end extensionFinalize
+
+/**
+Title: Drawing Library
+
+Version: 0.0.0
+
+Author: LiveCode
+
+Description:
+This script library implements an SVG compiler for turning SVG files into
+'drawing metafiles'. A simple and efficient binary format for representing
+complex vector graphics, supported directly by the LiveCode image object.
+*/
+
+/******************************************************************************/
+
+/**
+Compile an SVG XML file to a drawing metafile.
+
+Example:
+on mouseUp
+	set the text of image 1 to drawingSvgCompileFile("clock.svg")
+end mouseUp
+
+Description:
+Use <drawingSvgCompileFile> to build a binary string representing an SVG file
+which can be used as the 'text' of an image object for display.
+
+The SVG XML file is parsed using revXML and then stripped of all attributes
+and elements not currently understood by the SVG compiler. The resulting SVG
+is then converted to a lower-level form and encoded. This form can be used
+as the text of an image.
+
+The following SVG features are currently supported:
+
+  - 'svg' elements (percentage width/height only allowed on the root element)
+  - 'g' and 'defs' elements
+  - 'use' elements
+  - 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon' and 'path' elements
+  - 'fill', 'fill-opacity', fill-rule' properties
+  - 'stroke', 'stroke-opacity', stroke-width', 'stroke-dash-array',
+    'stroke-dash-offset', 'stroke-line-cap', 'stroke-line-join' and
+    'stroke-miter-limit' properties
+  - absolute unit specifiers in, cm, mm, pt, pc, px
+
+Currently, only solid colors of with following forms are supported:
+
+  - &#35;rgb
+  - &#35;rrggbb
+  - rgb(rrr, ggg, bbb)
+  - black/silver/gray/white/maroon/red/purple/fuchsia
+  - green/lime/olive/yellow/navy/blue/teal/aqua
+
+The rendering of an SVG file inside an image object respects the width, height,
+viewBox and preserveAspectRatio attributes on the root SVG node in the document.
+
+If the width and height attributes are specified, and they are not percentages,
+then they are taken to be the formattedWidth/Height of the image object. In this
+case the SVG will always display at that fixed size, clipped to the rect of the
+image.
+
+If the width and height attributes are not specified, or are percentages, and
+a viewBox attribute is specified then the width and height of the viewBox are
+taken to be the formattedWidth/Height of the image object. In this case the SVG
+will scale to fit within the rect of the image object, respecting the setting
+of the SVG's preserveAspectRatio attribute.
+
+Finally if the width and height are not specified, or are percentages and there
+is no viewBox attribute then the intrinsic width and height are taken to be
+256.
+
+Note: The drawing binary format is not currently considered stable and is
+subject to change until the end of the RC cycle for 9. At present it is advised
+that SVG files be compiled as needed when developing in the IDE, and then
+compiled ahead-of-time when building a standalone.
+
+Parameters:
+
+pXmlFile (string):
+The filename of the SVG XML file to load.
+
+Returns (data):
+A binary string containing the encoded drawing - this can be used as the text
+of an image directly.
+
+The result:
+An error string if an error occurred.
+
+References: drawingSvgCompile (function)
+*/
+function drawingSvgCompileFile pXmlFile
+	/* Convert the XML file to the LiveCode array structure. */
+	local tArray
+
+	try
+		lock screen
+		put xmlImportFromFile(pXmlFile) into tArray
+		return svgImportFromArray(tArray) for value
+	catch tError
+		return tError for error
+	finally
+		unlock screen
+	end try
+end drawingSvgCompileFile
+
+/**
+Compile an SVG XML file to a drawing metafile.
+
+Example:
+on mouseUp
+	set the text of image 1 to drawingSvgCompile(url ("file:clock.svg"))
+end mouseUp
+
+Description:
+Use <drawingSvgCompile> to build a binary string representing an SVG file
+which can be used as the 'text' of an image object for display.
+
+The text of the SVG XML document is parsed using revXML and then stripped of all
+attributes and elements not currently understood by the SVG compiler. The
+resulting SVG is then converted to a lower-level form and encoded. This form can
+be used as the text of an image.
+
+The following SVG features are currently supported:
+
+  - 'svg' elements (percentage width/height only allowed on the root element)
+  - 'g' and 'defs' elements
+  - 'use' elements
+  - 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon' and 'path' elements
+  - 'fill', 'fill-opacity', fill-rule' properties
+  - 'stroke', 'stroke-opacity', stroke-width', 'stroke-dash-array',
+    'stroke-dash-offset', 'stroke-line-cap', 'stroke-line-join' and
+    'stroke-miter-limit' properties
+  - absolute unit specifiers in, cm, mm, pt, pc, px
+
+Currently, only solid colors of with following forms are supported:
+
+  - &#35;rgb
+  - &#35;rrggbb
+  - rgb(rrr, ggg, bbb)
+  - black/silver/gray/white/maroon/red/purple/fuchsia
+  - green/lime/olive/yellow/navy/blue/teal/aqua
+
+The rendering of an SVG file inside an image object respects the width, height,
+viewBox and preserveAspectRatio attributes on the root SVG node in the document.
+
+If the width and height attributes are specified, and they are not percentages,
+then they are taken to be the formattedWidth/Height of the image object. In this
+case the SVG will always display at that fixed size, clipped to the rect of the
+image.
+
+If the width and height attributes are not specified, or are percentages, and
+a viewBox attribute is specified then the width and height of the viewBox are
+taken to be the formattedWidth/Height of the image object. In this case the SVG
+will scale to fit within the rect of the image object, respecting the setting
+of the SVG's preserveAspectRatio attribute.
+
+Finally if the width and height are not specified, or are percentages and there
+is no viewBox attribute then the intrinsic width and height are taken to be
+256.
+
+Note: The drawing binary format is not currently considered stable and is
+subject to change until the end of the RC cycle for 9. At present it is advised
+that SVG files be compiled as needed when developing in the IDE, and then
+compiled ahead-of-time when building a standalone.
+
+Parameters:
+
+pXmlText (string):
+The text of the SVG XML document to compile.
+
+Returns (data):
+A binary string containing the encoded drawing - this can be used as the text
+of an image directly.
+
+The result:
+An error string if an error occurred.
+
+References: drawingSvgCompileFile (function)
+*/
+function drawingSvgCompile pXmlText
+	/* Convert the XML file to the LiveCode array structure. */
+	local tArray
+
+	try
+		lock screen
+		put xmlImportFromText(pXmlText) into tArray
+		return svgImportFromArray(tArray) for value
+	catch tError
+		return tError for error
+	finally
+		unlock screen
+	end try
+end drawingSvgCompile
+
+private function svgImportFromArray pXmlArray
+	local tArray
+	put pXmlArray into tArray
+
+	/* Processing of the input documents runs using a 'context' array. This
+	 * is threaded through all the recursive processing functions, holding
+	 * information about what is being processed (for error handling) and also
+	 * any state which is computed as the processing phrases progress. */
+	local tContext
+	put empty into tContext
+
+	/* First process the svg array, transforming it to a state it can be
+	 * compiled. Each process operation takes tArray as a reference parameter
+	 * so they can update the array in place. */
+
+	/* Remove all elements from the tree which are not understood. */
+	_svgTrim tContext, tArray
+
+	/* Parse the values of all features, including those specified in any inline
+	 * style attributes. Any features which are not applicable to the specifying
+	 * element are removed, and any required attributes are set with their
+	 * default values (required, unset properties are set during cascade). */
+	_svgParse tContext, tArray
+
+	/* Create a map from element id attribute to label. */
+	_svgMap tContext, tArray
+
+	/* Flatten all 'use' elements, replacing them with their referenced
+	 * elements. */
+	_svgFlatten tContext, tArray
+
+	/* Perform the property cascade, assigning appropriate inherited values
+	 * to all properties which apply to a given element. */
+	local tPropertyDefaults
+	put svgSpecGetPropertyDefaults() into tPropertyDefaults
+	repeat for each key tPropertyName in tPropertyDefaults
+		get _svgParseFeatureValue(tContext, "", tPropertyName, tPropertyDefaults[tPropertyName])
+	end repeat
+	_svgCascade tContext, tPropertyDefaults, tArray
+
+	/* Now all processing has been done we can perform the final phase of
+	 * compiling the svg document. */
+
+	/* Compile the processed array, converting its tree structure into a linear
+	 * sequence of graphics operations. */
+	_svgCompile tContext, tArray
+
+
+	/* Encode the operations array in a form suitable for processing by LCB */
+	local tDrawing
+	_svgEncode tContext, tDrawing
+
+	return tDrawing
+end svgImportFromArray
+
+/*******************************************************************************
+ *
+ *  SVG PROCESS OPERATIONS
+ *
+ ******************************************************************************/
+
+/* _svgTrim iterates over the document array, removing any elements which are
+ * are not understood. */
+private command _svgTrim @xContext, @xElement
+	local tElementType
+	put xElement["type"] into tElementType
+
+	/* Push the node's path segment onto the current context so errors can be
+	 * adequately placed. */
+	_svgContextEnter xContext, xElement
+
+	/* If the element type is known, we recurse to its children then process
+	 * the resulting sequence to remove holes */
+	if tElementType is empty then
+		put empty into xElement
+	else if svgSpecIsElement(tElementType) then
+		if xElement["content"] is an array then
+			local tNewContent
+			repeat for each element tChildElement in xElement["content"]
+				/* If a node type is unknown, then _svgTrim will set
+				 * tChildElement to empty. */
+				_svgTrim xContext, tChildElement
+
+				/* If the node survived the cut, then repush it onto a new
+				 * sequence - this removes any holes. */
+				if tChildElement is an array then
+					seqPushOntoBack tNewContent, tChildElement
+				end if
+			end repeat
+			/* Replace the original content of the element with the new content. */
+			put tNewContent into xElement["content"]
+		end if
+	else
+		_svgContextUnknownElementError xContext, tElementType
+		put empty into xElement
+	end if
+
+	/* Pop the node's path segment from the current context. */
+	_svgContextLeave xContext, xElement
+end _svgTrim
+
+/* _svgParse iterates over the document tree, parsing feature values on each
+ * element. Any inline style features are expanded and the resulting feature
+ * values are parsed. Any attributes which are not applicable to the current
+ * element are removed, but properties remain as they will cascade to child
+ * elements in a later processing phase. Finally, any missing non-nullable
+ * attributes are set with their default value. */
+private command _svgParse @xContext, @xElement
+ 	local tElementType
+	put xElement["type"] into tElementType
+
+	/* Push the element's path segment onto the current context so errors can be
+	 * adequately reported. */
+	_svgContextEnter xContext, xElement
+
+	/* Iterate through all features on the element, parsing the values of each
+	 * one. If a feature is not settable on the element it is removed. If a
+	 * feature's value fails to parse then it is removed.
+	 * Note: In general, SVG treats invalid feature values as if the feature is
+	 * not explicitly present; this allows the defaulting mechanism to take
+	 * place in that instance. */
+	repeat for each key tFeatureName in xElement["features"]
+		/* Features which are not settable on the current element are
+		 * removed. */
+		if not svgSpecIsFeatureSettableOnElement(tFeatureName, tElementType) then
+			delete variable xElement["features"][tFeatureName]
+			_svgContextUnknownFeatureError xContext, tFeatureName, tElementType
+			next repeat
+		end if
+
+		/* Parse the feature's value. If the parsing fails, then it is removed. */
+		if not _svgParseFeatureValue(xContext, tElementType, tFeatureName, xElement["features"][tFeatureName]) then
+			delete variable xElement["features"][tFeatureName]
+			_svgContextInvalidValueForFeatureError xContext, tFeatureName, tElementType
+			next repeat
+		end if
+	end repeat
+
+	/* If the element has a 'style' attribute, then process that now. The style
+	 * string is parsed, any properties which are not settable on the element
+	 * are removed and the rest have their values parsed. Any properties which
+	 * are successfully parsed in this manner are then added as properties to the
+	 * element (this is because properties specified in inline style attributes
+	 * take precedence over those which are specified in the element). */
+	if "style" is among the keys of xElement["features"] then
+		local tStyleProperties
+		put xElement["features"]["style"] into tStyleProperties
+		if _svgParseStyleAttributeValue(tStyleProperties) then
+			repeat for each key tPropertyName in tStyleProperties
+				/* Properties which are not settable to the current element are
+				 * ignored. */
+				if not svgSpecIsPropertySettableOnElement(tPropertyName, tElementType) then
+					_svgContextUnknownStylePropertyError xContext, tPropertyName, tElementType
+					next repeat
+				end if
+
+				/* Parse the property's value. If parsing fails, then the property
+				 * is ignored. */
+				if not _svgParseFeatureValue(xContext, tElementType, tPropertyName, tStyleProperties[tPropertyName]) then
+					_svgContextInvalidValueForStylePropertyError xContext, tPropertyName, tElementType
+					next repeat
+				end if
+
+				/* Apply the property to the element's features. */
+				put tStyleProperties[tPropertyName] into xElement["features"][tPropertyName]
+			end repeat
+		else
+			_svgContextInvalidValueForStyleError xContext
+		end if
+
+		/* The style attribute has been processed, so can now be removed. */
+		delete variable xElement["features"]["style"]
+	end if
+
+	/* Iterate through all applicable attributes for an element, and ensure
+	 * that all are defined (applying the default value of any which have not
+	 * been specified). */
+	repeat for each key tAttributeName in svgSpecGetApplicableAttributesOfElement(tElementType)
+		/* If the attribute has already been specified on the node, then there
+		 * is nothing to do. */
+		if tAttributeName is among the keys of xElement["features"] then
+			next repeat
+		end if
+
+		/* If the attribute is not required, then there is nothing to do. */
+		if not svgSpecIsAttributeRequiredForElement(tElementType, tAttributeName) then
+			next repeat
+		end if
+
+		/* Set the attribute to its default value. */
+		put svgSpecGetAttributeDefaultForElement(tElementType, tAttributeName) into xElement["features"][tAttributeName]
+
+		/* Parse the default value (which should never be an error...). */
+		if not _svgParseFeatureValue(xContext, tElementType, tAttributeName, xElement["features"][tAttributeName]) then
+			_svgContextInvalidDefaultValueError xContext, tAttributeName, tElementType
+			delete variable xElement["features"][tAttributeName]
+		end if
+	end repeat
+
+	/* Now that the element has been processed, process the features of each
+	 * child element (if any). */
+	if xElement["content"] is an array then
+		repeat with tIndex = 1 to the number of elements in xElement["content"]
+			_svgParse xContext, xElement["content"][tIndex]
+		end repeat
+	end if
+
+	/* Pop the element's path segment from the context. */
+	_svgContextLeave xContext, xElement
+end _svgParse
+
+/* _svgMap creates a mapping from id to element with that id so that hrefs
+ * within the document can be resolved. */
+private command _svgMap @xContext, @xElement
+	/* Push the node's path segment onto the current context so errors can be
+	 * adequately placed. */
+	_svgContextEnter xContext, xElement
+
+	if "id" is among the keys of xElement["features"] then
+		if not _svgContextDefine(xContext, xElement["features"]["id"], xElement) then
+			_svgContextElementAlreadyDefinedError xContext, xElement["features"]["id"]
+		end if
+	end if
+
+	/* Now all the processing for this node has been done, we to process each
+	 * child, in order. */
+	if xElement["content"] is an array then
+		repeat with tIndex = 1 to the number of elements in xElement["content"]
+			_svgMap xContext, xElement["content"][tIndex]
+		end repeat
+	end if
+
+	/* Pop the node's path segment from the current context. */
+	_svgContextLeave xContext, xElement
+end _svgMap
+
+/* _svgFlatten deep copies all used elements into their place in the document.
+ * Note: Due to LiveCode's copy-on-write semantics, this deep-copying doesn't
+ * actually cost anything. */
+private command _svgFlatten @xContext, @xElement
+	/* Push the node's path segment onto the current context so errors can be
+	 * adequately placed. */
+	_svgContextEnter xContext, xElement
+
+	/* Only process 'use' nodes. */
+	if xElement["type"] is "use" then
+		/* Fetch the id from the xlink:href attribute. A missing attribute, or
+		 * an empty id result in nothing happening. */
+		local tId
+		put xElement["features"]["xlink:href"] into tId
+		if tId is empty then
+			put xElement["features"]["href"] into tId
+		end if
+		if tId is not empty then
+			local tReferencedElement
+			if _svgContextLookup(xContext, tId, tReferencedElement) then
+				/* Flatten the referenced element, this will flatten any 'use'
+				 * elements within it.
+				 * Note: This currently does not guard against circularity! */
+				_svgFlatten xContext, tReferencedElement
+
+				/* A 'use' node is turned into a 'g' node with the referenced
+				 * elements content. */
+				put tReferencedElement into xElement["content"][1]
+				put "g" into xElement["type"]
+
+				/* Apply a translation defined by the x, y attributes on the use
+				 * element. */
+				local tTransform
+				put "translate" into tTransform[1]
+				put xElement["features"]["x"] into tTransform[2]
+				put xElement["features"]["y"] into tTransform[3]
+				seqPushOntoBack xElement["features"]["transform"], tTransform
+
+				/* Remove any attributes which are specific to the use node. */
+				delete variable xElement["features"]["x"]
+				delete variable xElement["features"]["y"]
+				delete variable xElement["features"]["xml:base"]
+				delete variable xElement["features"]["xlink:href"]
+				delete variable xElement["features"]["href"]
+			else
+				_svgContextElementNotDefinedError xContext, tId
+			end if
+		end if
+	end if
+	
+	/* Now all the processing for this element has been done, we process each
+	 * child, in order. */
+	if xElement["content"] is an array then
+		repeat with tIndex = 1 to the number of elements in xElement["content"]
+			_svgFlatten xContext, xElement["content"][tIndex]
+		end repeat
+	end if
+
+	/* Pop the node's path segment from the current context. */
+	_svgContextLeave xContext, xElement
+end _svgFlatten
+
+/* _svgProcessCascade performs the CSS-style cascade of property values down
+ * through the elements. */
+private command _svgCascade @xContext, pProperties, @xElement
+	local tElementType
+	put xElement["type"] into tElementType
+
+	/* Push the element's path segment onto the current context so errors can be
+	 * adequately placed. */
+	_svgContextEnter xContext, xElement
+
+	/* Iterate through all the properties and ensure that all which are applicable
+	 * to the element are set on the element. If an applicable property is not
+	 * set on an element, then it is either set to the inherited property (if
+	 * the property is inheritable), or to the property default (if the property
+	 * is not inheritable). If an applicable property on an element has the value
+	 * 'inherit', then it is updated with the parent property value; otherwise
+	 * the properties array passed to child elements is updated with the new
+	 * value. */
+	repeat for each key tPropertyName in pProperties
+		if svgSpecIsPropertyApplicableToElement(tPropertyName, tElementType) then
+			if tPropertyName is not among the keys of xElement["features"] then
+				if svgSpecIsPropertyInheritable(tPropertyName) then
+					put pProperties[tPropertyName] into xElement["features"][tPropertyName]
+				else
+					put svgSpecGetDefaultValueForProperty(tPropertyName) into xElement["features"][tPropertyName]
+					get _svgParseFeatureValue(xContext, empty, tPropertyName, xElement["features"][tPropertyName])
+					put xElement["features"][tPropertyName] into pProperties[tPropertyName]
+				end if
+			else if xElement["features"][tPropertyName] is "inherit" then
+				put pProperties[tPropertyName] into xElement["features"][tPropertyName]
+			else
+				put xElement["features"][tPropertyName] into pProperties[tPropertyName]
+			end if
+		else
+			/* The property is not directly applicable to the element, but if it
+			 * is set on it and it is not 'inherit' then update the properties
+			 * array to pass to child elements. */
+			if tPropertyName is among the keys of xElement["features"] and \
+				xElement["features"][tPropertyName] is not "inherit" then
+				put xElement["features"][tPropertyName] into pProperties[tPropertyName]
+				delete variable xElement["features"][tPropertyName]
+			end if
+		end if
+	end repeat
+
+	/* Now all the processing for this node has been done, we to process each
+	 * child, in order. */
+	if xElement["content"] is an array then
+		repeat with tIndex = 1 to the number of elements in xElement["content"]
+			_svgCascade xContext, pProperties, xElement["content"][tIndex]
+		end repeat
+	end if
+
+	/* Pop the node's path segment from the current context. */
+	_svgContextLeave xContext, xElement
+end _svgCascade
+
+/*******************************************************************************
+ *
+ *  SVG COMPILE OPERATIONS
+ *
+ ******************************************************************************/
+
+private command _svgCompile @xContext, pRootElement
+	put pRootElement["features"]["width"] into xContext["drawing-width"]
+	put pRootElement["features"]["height"] into xContext["drawing-height"]
+	put pRootElement["features"]["viewBox"] into xContext["drawing-viewbox"]
+	put pRootElement["features"]["preserveAspectRatio"] into xContext["drawing-par"]
+	delete variable pRootElement["features"]["viewBox"]
+	delete variable pRootElement["features"]["preserveAspectRatio"]
+
+	_svgCompileElement xContext, pRootElement
+end _svgCompile
+
+private command _svgCompileElement @xContext, pElement
+	/* Skip any elements which don't require compilation */
+	switch pElement["type"]
+	case "defs"
+	case "use"
+		exit _svgCompileElement
+	end switch
+
+	/* Save the current feature state */
+	_svgContextSave xContext
+
+	/* Compile features into the feature state. */
+	_svgCompileFeatures xContext, pElement
+
+	/* Dispatch to appropriate compile operations based on element type. */
+	switch pElement["type"]
+	case "svg"
+		_svgCompileSvg xContext, pElement
+		break
+	case "g"
+		repeat for each element tChildElement in pElement["content"]
+			_svgCompileElement xContext, tChildElement
+		end repeat
+		break
+	case "rect"
+		_svgCompileRectangle xContext, pElement
+		break
+	case "circle"
+		_svgCompileCircle xContext, pElement
+		break
+	case "ellipse"
+		_svgCompileEllipse xContext, pElement
+		break
+	case "line"
+		_svgCompileLine xContext, pElement
+		break
+	case "polyline"
+		_svgCompilePolyline xContext, pElement
+		break
+	case "polygon"
+		_svgCompilePolygon xContext, pElement
+		break
+	case "path"
+		_svgCompilePath xContext, pElement
+		break
+	default
+		_InternalError format("unhandled element type '%s'", pElement["type"])
+		break
+	end switch
+
+	/* Restore the feature state */
+	_svgContextRestore xContext
+end _svgCompileElement
+
+/* _svgCompileFeatures loops through all features defined on element and sets
+ * the feature state of the context to their 'compiled' values. The compiled
+ * values for the features are such that equivalence can be checked by
+ * simple equality. */
+private command _svgCompileFeatures @xContext, pElement
+	repeat for each key tFeatureName in pElement["features"]
+		local tFeatureValue
+		put empty into tFeatureValue
+
+		switch tFeatureName
+		case "transform"
+			local tTransform
+			put _svgContextGetState(xContext, "transform") into tTransform
+			seqAppend tTransform, pElement["features"]["transform"]
+			_svgCompileTransform xContext, tTransform, tFeatureValue
+			break
+		case "fill"
+		case "stroke"
+			_svgCompilePaint xContext, pElement["features"][tFeatureName], tFeatureValue
+			break
+		case "fill-opacity"
+		case "fill-rule"
+		case "stroke-opacity"
+		case "stroke-width"
+		case "stroke-linejoin"
+		case "stroke-linecap"
+		case "stroke-miterlimit"
+		case "stroke-dashoffset"
+		case "stroke-dasharray"
+			put pElement["features"][tFeatureName] into tFeatureValue
+			break
+		default
+			/* Ignore any features which aren't pertinent to compilation */
+			next repeat
+		end switch
+		_svgContextSetState xContext, tFeatureName, tFeatureValue
+	end repeat
+end _svgCompileFeatures
+
+private command _svgCompileTransform @xContext, pTransform, @rCompiledTransform
+	local tWidth, tHeight, tMatrix
+	put xContext["root-width"] into tWidth
+	put xContext["root-height"] into tHeight
+	put _svgTransformIdentity() into tMatrix
+
+	repeat for each element tTransform in pTransform
+		local tNextMatrix
+		switch tTransform[1]
+		case "viewport"
+			local tVpWidth, tVpHeight, tVpX, tVpY, tVbWidth, tVbHeight, tVbX, tVbY, tPar
+			put tTransform[2] into tVpX
+			put tTransform[3] into tVpY
+			put tTransform[4] into tVpWidth
+			put tTransform[5] into tVpHeight
+			put tTransform[6] into tVbX
+			put tTransform[7] into tVbY
+			put tTransform[8] into tVbWidth
+			put tTransform[9] into tVbHeight
+			put tTransform[10] into tPar
+
+			/* Resolve percentage sizes */
+			if tVpWidth < 0 then
+				put -tVpWidth * tWidth into tVpWidth
+			end if
+			if tVpHeight < 0 then
+				put -tVpHeight * tHeight into tVpHeight
+			end if
+
+			/* If the new vp sizes are not percentages then we can build a matrix
+			 * else we must emit a separate transform */
+			if tVpWidth >= 0 and tVpHeight >= 0 then
+				local tVScaleX, tVScaleY, tVTranslateX, tVTranslateY
+
+				put tVpWidth / tVbWidth into tVScaleX
+				put tVpHeight / tVbHeight into tVScaleY
+
+				if word 2 of tPar is "meet" then
+					put min(tVScaleX, tVScaleY) into tVScaleX
+					put tVScaleX into tVScaleY
+				else if word 2 of tPar is "slice" then
+					put max(tVScaleX, tVScaleY) into tVScaleX
+					put tVScaleX into tVScaleY
+				end if
+
+				put tVpX - (tVbX * tVScaleX) into tVTranslateX
+				put tVpY - (tVbY * tVScaleY) into tVTranslateY
+
+				if tPar contains "xMid" then
+					add (tVpWidth - tVbWidth * tVScaleX) / 2 to tVTranslateX
+				else if tPar contains "xMax" then
+					add (tVpWidth - tVbWidth * tVScaleX) to tVTranslateX
+				end if
+
+				if tPar contains "yMid" then
+					add (tVpHeight - tVbHeight * tVScaleY) / 2 to tVTranslateY
+				else if tPar contains "yMax" then
+					add (tVpHeight - tVbHeight * tVScaleY) to tVTranslateY
+				end if
+				
+				put _svgTransformTranslate(tVTranslateX, tVTranslateY) into tNextMatrix
+				put _svgTransformConcat(tNextMatrix, _svgTransformScale(tVScaleX, tVScaleY)) into tNextMatrix
+			else
+				if not _svgTransformIsIdentity(tMatrix) then
+					seqPushOntoBack rCompiledTransform, _svgTransformFlatten(tMatrix)
+				end if
+				put tVpWidth into tTransform[4]
+				put tVpHeight into tTransform[5]
+				seqPushOntoBack rCompiledTransform, tTransform
+				put _svgTransformIdentity() into tMatrix
+				put _svgTransformIdentity() into tNextMatrix
+			end if
+
+			put tVpWidth into tWidth
+			put tVpHeight into tHeight
+			break
+		case "matrix"
+			put _svgTransformMatrix(tTransform[2], tTransform[3], tTransform[4], tTransform[5], tTransform[6], tTransform[7]) into tNextMatrix
+			break
+		case "translate"
+			put _svgTransformTranslate(tTransform[2], tTransform[3]) into tNextMatrix
+			break
+		case "scale"
+			put _svgTransformScale(tTransform[2], tTransform[3]) into tNextMatrix
+			break
+		case "rotate"
+			put _svgTransformTranslate(-tTransform[3], -tTransform[4]) into tNextMatrix
+			put _svgTransformConcat(tNextMatrix, _svgTransformRotate(tTransform[2])) into tNextMatrix
+			put _svgTransformConcat(tNextMatrix, _svgTransformTranslate(tTransform[3], tTransform[4])) into tNextMatrix
+			break
+		case "skewX"
+			put _svgTransformSkew(tTransform[2], 0) into tNextMatrix
+			break
+		case "skewY"
+			put _svgTransformSkew(0, tTransform[2]) into tNextMatrix
+			break
+		default
+			_InternalError format("unknown transform '%s'", pTransform[1])
+			break
+		end switch
+		put _svgTransformConcat(tMatrix, tNextMatrix) into tMatrix 
+	end repeat
+	if not _svgTransformIsIdentity(tMatrix) then
+		seqPushOntoBack rCompiledTransform, _svgTransformFlatten(tMatrix)
+	end if
+end _svgCompileTransform
+
+private command _svgCompilePaint @xContext, pPaint, @rCompiledPaint
+	put empty into rCompiledPaint
+	switch pPaint["type"]
+	case "none"
+		put "none" into rCompiledPaint[1]
+		break
+	case "color"
+		put "color" into rCompiledPaint[1]
+		put pPaint["red"] into rCompiledPaint[2]
+		put pPaint["green"] into rCompiledPaint[3]
+		put pPaint["blue"] into rCompiledPaint[4]
+		break
+	case "reference"
+		_svgCompilePaint xContext, pPaint["fallback"], rCompiledPaint
+		break
+	default
+		put "none" into rCompiledPaint[1]
+	end switch
+end _svgCompilePaint
+
+private command _svgCompileSvg @xContext, pElement
+	local tX, tY, tWidth, tHeight, tViewBox, tPreserveAspectRatio
+	put pElement["features"]["x"] into tX
+	put pElement["features"]["y"] into tY
+	put pElement["features"]["width"] into tWidth
+	put pElement["features"]["height"] into tHeight
+	put pElement["features"]["viewBox"] into tViewBox
+	put pElement["features"]["preserveAspectRatio"] into tPreserveAspectRatio
+
+	_svgContextSave xContext
+
+	if tViewBox is an array then
+		local tViewportTransform
+		put "viewport" into tViewportTransform[1]
+		put tX into tViewportTransform[2]
+		put tY into tViewportTransform[3]
+		put tWidth into tViewportTransform[4]
+		put tHeight into tViewportTransform[5]
+		put tViewBox[1] into tViewportTransform[6]
+		put tViewBox[2] into tViewportTransform[7]
+		put tViewBox[3] into tViewportTransform[8]
+		put tViewBox[4] into tViewportTransform[9]
+		put tPreserveAspectRatio into tViewportTransform[10]
+
+		put tWidth into xContext["root-width"]
+		put tHeight into xContext["root-height"]
+
+		local tTransform, tCompiledTransform
+		put _svgContextGetState(xContext, "transform") into tTransform
+		seqPushOntoBack tTransform, tViewportTransform
+		_svgCompileTransform xContext, tTransform, tCompiledTransform
+		_svgContextSetState xContext, "transform", tCompiledTransform
+	else
+		put tWidth into xContext["root-width"]
+		put tHeight into xContext["root-height"]
+	end if
+
+	repeat for each element tChildElement in pElement["content"]
+		_svgCompileElement xContext, tChildElement
+	end repeat
+
+	_svgContextRestore xContext
+end _svgCompileSvg
+
+private command _svgCompileRectangle @xContext, pElement
+	local tX, tY, tWidth, tHeight, tRx, tRy
+	put pElement["features"]["x"] into tX
+	put pElement["features"]["y"] into tY
+	put pElement["features"]["width"] into tWidth
+	put pElement["features"]["height"] into tHeight
+	put pElement["features"]["rx"] into tRx
+	put pElement["features"]["ry"] into tRy
+	if tRx is empty then
+		put tRy into tRx
+	else if tRy is empty then
+		put tRx into tRy
+	end if
+
+	if tRx is empty then
+		put 0 into tRx
+	end if
+
+	if tRy is empty then
+		put 0 into tRy
+	end if
+
+	_svgCompileShape xContext, "rect", tX, tY, tWidth, tHeight, tRx, tRy
+end _svgCompileRectangle
+
+private command _svgCompileCircle @xContext, pElement
+	local tCx, tCy, tR
+	put pElement["features"]["cx"] into tCx
+	put pElement["features"]["cy"] into tCy
+	put pElement["features"]["r"] into tR
+	_svgCompileShape xContext, "circle", tCx, tCy, tR
+end _svgCompileCircle
+
+private command _svgCompileEllipse @xContext, pElement
+	local tCx, tCy, tRx, tRy
+	put pElement["features"]["cx"] into tCx
+	put pElement["features"]["cy"] into tCy
+	put pElement["features"]["rx"] into tRx
+	put pElement["features"]["rx"] into tRy
+	_svgCompileShape xContext, "ellipse", tCx, tCy, tRx, tRy
+end _svgCompileEllipse
+
+private command _svgCompileLine @xContext, pElement
+	local tX1, tY1, tX2, tY2
+	put pElement["features"]["x1"] into tX1
+	put pElement["features"]["y1"] into tY1
+	put pElement["features"]["x2"] into tX2
+	put pElement["features"]["y2"] into tY2
+	_svgCompileShape xContext, "line", tX1, tY1, tX2, tY2
+end _svgCompileLine
+
+private command _svgCompilePolyline @xContext, pElement
+	local tPoints
+	put pElement["features"]["points"] into tPoints
+	_svgCompileShape xContext, "polyline", tPoints
+end _svgCompilePolyline
+
+private command _svgCompilePolygon @xContext, pElement
+	local tPoints
+	put pElement["features"]["points"] into tPoints
+	_svgCompileShape xContext, "polygon", tPoints
+end _svgCompilePolygon
+
+private command _svgCompilePath @xContext, pElement
+	local tD
+	put pElement["features"]["d"] into tD
+	_svgCompileShape xContext, "path", tD
+end _svgCompilePath
+
+private command _svgCompileShape @xContext, pType
+	local tOperation
+	put pType into tOperation[1]
+	if param(3) is an array then
+		put param(3) into tOperation[2]
+	else
+		repeat with tIndex = 3 to paramCount()
+			put param(tIndex) into tOperation[2][tIndex - 2]
+		end repeat
+	end if
+
+	_svgCompileState xContext
+
+	_svgContextEmit xContext, tOperation
+end _svgCompileShape
+
+private command _svgCompileState @xContext
+	local tCurrentState, tLastState
+	put _svgContextGetCurrentState(xContext) into tCurrentState
+	put _svgContextGetLastState(xContext) into tLastState
+
+	/* This can be optimized to not emit fill/stroke properties if the fill
+	 * or stroke is none, or the opacity is 0. */
+
+	repeat for each key tStateName in tCurrentState
+		if tCurrentState[tStateName] is tLastState[tStateName] then
+			next repeat
+		end if
+
+		local tOperation
+		put empty into tOperation
+
+		put tStateName into tOperation[1]
+		seqPushOntoBack tOperation, tCurrentState[tStateName]
+
+		_svgContextEmit xContext, tOperation
+	end repeat
+	_svgContextSetLastState xContext, tCurrentState
+end _svgCompileState
+
+/*******************************************************************************
+ *
+ *  SVG ENCODE OPERATIONS
+ *
+ ******************************************************************************/
+
+/* The kMCGDrawing constants are taken from those defined in the
+ * libgraphics/drawing.cpp file and must always match. */
+
+constant kMCGDrawingIdent = "LCD"
+constant kMCGDrawingVersion = 0
+
+constant kMCGDrawingOpcodeEnd = 0
+constant kMCGDrawingOpcodeTransform = 1
+constant kMCGDrawingOpcodeFillPaint = 2
+constant kMCGDrawingOpcodeFillOpacity = 3
+constant kMCGDrawingOpcodeFillRule = 4
+constant kMCGDrawingOpcodeStrokePaint = 5
+constant kMCGDrawingOpcodeStrokeOpacity = 6
+constant kMCGDrawingOpcodeStrokeWidth = 7
+constant kMCGDrawingOpcodeStrokeLineJoin = 8
+constant kMCGDrawingOpcodeStrokeLineCap = 9
+constant kMCGDrawingOpcodeStrokeDashArray = 10
+constant kMCGDrawingOpcodeStrokeDashOffset = 11
+constant kMCGDrawingOpcodeStrokeMiterLimit = 12
+constant kMCGDrawingOpcodeRectangle = 13
+constant kMCGDrawingOpcodeCircle = 14
+constant kMCGDrawingOpcodeEllipse = 15
+constant kMCGDrawingOpcodeLine = 16
+constant kMCGDrawingOpcodePolyline = 17
+constant kMCGDrawingOpcodePolygon = 18
+constant kMCGDrawingOpcodePath = 19
+
+constant kMCGDrawingTransformOpcodeEnd = 0
+constant kMCGDrawingTransformOpcodeAffine = 1
+//constant kMCGDrawingTransformOpcodeViewport = 2
+
+constant kMCGDrawingPaintOpcodeEnd = 0
+constant kMCGDrawingPaintOpcodeSolidColor = 1
+
+constant kMCGDrawingFillRuleOpcodeNonZero = 0
+constant kMCGDrawingFillRuleOpcodeEvenOdd = 1
+
+constant kMCGDrawingStrokeLineJoinOpcodeBevel = 0
+constant kMCGDrawingStrokeLineJoinOpcodeRound = 1
+constant kMCGDrawingStrokeLineJoinOpcodeMiter = 2
+
+constant kMCGDrawingStrokeLineCapOpcodeButt = 0
+constant kMCGDrawingStrokeLineCapOpcodeRound = 1
+constant kMCGDrawingStrokeLineCapOpcodeSquare = 2
+
+constant kMCGDrawingPathOpcodeEnd = 0
+constant kMCGDrawingPathOpcodeMoveTo = 1
+constant kMCGDrawingPathOpcodeRelativeMoveTo = 2
+constant kMCGDrawingPathOpcodeLineTo = 3
+constant kMCGDrawingPathOpcodeRelativeLineTo = 4
+constant kMCGDrawingPathOpcodeHorizontalTo = 5
+constant kMCGDrawingPathOpcodeRelativeHorizontalTo = 6
+constant kMCGDrawingPathOpcodeVerticalTo = 7
+constant kMCGDrawingPathOpcodeRelativeVerticalTo = 8
+constant kMCGDrawingPathOpcodeCubicTo = 9
+constant kMCGDrawingPathOpcodeRelativeCubicTo = 10
+constant kMCGDrawingPathOpcodeSmoothCubicTo = 11
+constant kMCGDrawingPathOpcodeRelativeSmoothCubicTo = 12
+constant kMCGDrawingPathOpcodeQuadraticTo= 13
+constant kMCGDrawingPathOpcodeRelativeQuadraticTo = 14
+constant kMCGDrawingPathOpcodeSmoothQuadraticTo = 15
+constant kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo = 16
+constant kMCGDrawingPathOpcodeArcTo = 17
+constant kMCGDrawingPathOpcodeRelativeArcTo = 18
+constant kMCGDrawingPathOpcodeReflexArcTo = 19
+constant kMCGDrawingPathOpcodeRelativeReflexArcTo = 20
+constant kMCGDrawingPathOpcodeReverseArcTo = 21
+constant kMCGDrawingPathOpcodeRelativeReverseArcTo = 22
+constant kMCGDrawingPathOpcodeReverseReflexArcTo = 23
+constant kMCGDrawingPathOpcodeRelativeReverseReflexArcTo = 24
+constant kMCGDrawingPathOpcodeCloseSubpath = 25
+constant kMCGDrawingPathOpcodeBearing = 26
+
+constant kMCGDrawingPreserveAspectRatioOpcodeNone = 0
+constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMinMeet = 1
+constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMinMeet = 2
+constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinMeet = 3
+constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMidMeet = 4
+constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMidMeet = 5
+constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidMeet = 6
+constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxMeet = 7
+constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxMeet = 8
+constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet = 9
+constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMinSlice = 10
+constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMinSlice = 11
+constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinSlice = 12
+constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMidSlice = 13
+constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMidSlice = 14
+constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidSlice = 15
+constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxSlice = 16
+constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxSlice = 17
+constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxSlice = 18
+
+private command _svgEncode @xContext, @rDrawing
+	put empty into xContext["opcodes"]
+	put empty into xContext["scalars"]
+	repeat for each element tOperation in xContext["operations"]
+		local tCommand, tArgument
+		put tOperation[1] into tCommand
+		put tOperation[2] into tArgument
+		switch tCommand
+		case "transform"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeTransform
+			_svgEncodeTransform xContext, tArgument
+			break
+		case "fill"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeFillPaint
+			_svgEncodePaint xContext, tArgument
+			break
+		case "fill-opacity"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeFillOpacity, tArgument
+			break
+		case "fill-rule"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeFillRule
+			if tArgument is "nonzero" then
+				_svgEncodeOp xContext, kMCGDrawingFillRuleOpcodeNonZero
+			else if tArgument is "evenodd" then
+				_svgEncodeOp xContext, kMCGDrawingFillRuleOpcodeEvenOdd
+			else
+				_InternalError format("unknown fill-rule '%s'", tArgument)
+			end if
+			break
+		case "stroke"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokePaint
+			_svgEncodePaint xContext, tArgument
+			break
+		case "stroke-opacity"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeOpacity, tArgument
+			break
+		case "stroke-width"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeWidth, tArgument
+			break
+		case "stroke-linejoin"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeLineJoin
+			switch tArgument
+			case "bevel"
+				_svgEncodeOp xContext, kMCGDrawingStrokeLineJoinOpcodeBevel
+				break
+			case "round"
+				_svgEncodeOp xContext, kMCGDrawingStrokeLineJoinOpcodeRound
+				break
+			case "miter"
+				_svgEncodeOp xContext, kMCGDrawingStrokeLineJoinOpcodeMiter
+				break
+			end switch
+			break
+		case "stroke-linecap"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeLineCap
+			switch tArgument
+			case "butt"
+				_svgEncodeOp xContext, kMCGDrawingStrokeLineCapOpcodeButt
+				break
+			case "round"
+				_svgEncodeOp xContext, kMCGDrawingStrokeLineCapOpcodeRound
+				break
+			case "square"
+				_svgEncodeOp xContext, kMCGDrawingStrokeLineCapOpcodeSquare
+				break
+			end switch
+			break
+		case "stroke-dasharray"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeDashArray, tArgument
+			break
+		case "stroke-dashoffset"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeDashOffset, tArgument
+			break
+		case "stroke-miterlimit"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeMiterLimit, tArgument
+			break
+		case "rect"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeRectangle, tArgument[1], tArgument[2], tArgument[3], tArgument[4], tArgument[5], tArgument[6]
+			break
+		case "circle"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeCircle, tArgument[1], tArgument[2], tArgument[3]
+			break
+		case "ellipse"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeEllipse, tArgument[1], tArgument[2], tArgument[3], tArgument[4]
+			break
+		case "line"
+			_svgEncodeOp xContext, kMCGDrawingOpcodeLine, tArgument[1], tArgument[2], tArgument[3], tArgument[4]
+			break
+		case "polyline"
+			_svgEncodeOp xContext, kMCGDrawingOpcodePolyline, tArgument
+			break
+		case "polygon"
+			_svgEncodeOp xContext, kMCGDrawingOpcodePolygon, tArgument
+			break
+		case "path"
+			_svgEncodeOp xContext, kMCGDrawingOpcodePath
+			_svgEncodePath xContext, tArgument
+			break
+		default
+			_InternalError format("unknown command '%s'", tOperation[1])
+			break
+		end switch
+	end repeat
+
+	_svgEncodeOp xContext, kMCGDrawingOpcodeEnd
+
+	local tDrawing
+	put binaryEncode("A3C", kMCGDrawingIdent, kMCGDrawingVersion) into tDrawing
+
+	local tFlags, tExtraScalars, tExtraOpcodes
+	put 0 into tFlags
+	if xContext["drawing-width"] <> -1 then
+		put tFlags bitOr 1 into tFlags
+		put binaryEncode("f", xContext["drawing-width"]) after tExtraScalars
+	end if
+	if xContext["drawing-height"] <> -1 then
+		put tFlags bitOr 2 into tFlags
+		put binaryEncode("f", xContext["drawing-height"]) after tExtraScalars
+	end if
+	if xContext["drawing-viewbox"] is an array then
+		put tFlags bitOr 4 into tFlags
+		put binaryEncode("ffff", xContext["drawing-viewbox"][1], xContext["drawing-viewbox"][2], xContext["drawing-viewbox"][3], xContext["drawing-viewbox"][4]) after tExtraScalars
+		put numToByte(_svgEncodePreserveAspectRatio(xContext["drawing-par"])) after tExtraOpcodes
+	end if
+	put binaryEncode("I", tFlags) after tDrawing
+	put binaryEncode("I", (the number of bytes in tExtraScalars + the number of bytes in xContext["scalars"]) div 4) after tDrawing
+	put tExtraScalars after tDrawing
+	put xContext["scalars"] after tDrawing
+	put binaryEncode("I", the number of bytes in xContext["opcodes"] + the number of bytes in tExtraOpcodes) after tDrawing
+	put tExtraOpcodes after tDrawing
+	put xContext["opcodes"] after tDrawing
+	put tDrawing into rDrawing
+end _svgEncode
+
+private function _svgEncodeIndex pIndex
+	local tValue
+	put empty into tValue
+	repeat while pIndex >= 128
+		put numToByte(128 + (pIndex mod 128)) after tValue
+		put pIndex div 128 into pIndex
+	end repeat
+	put numToByte(pIndex mod 128) after tValue
+	return tValue
+end _svgEncodeIndex
+
+private command _svgEncodeOp @xContext, pOpcode
+	local tParams
+	repeat with i = 3 to the paramCount
+		put param(i) into tParams[i - 2]
+	end repeat
+	_svgEncodeOpV xContext, pOpcode, tParams
+end _svgEncodeOp
+
+private command _svgEncodeOpV @xContext, pOpcode, pArguments
+	put numToByte(pOpcode) after xContext["opcodes"]
+	repeat for each element tArgument in pArguments
+		if tArgument is an array or tArgument is empty then
+			put _svgEncodeIndex(the number of elements in tArgument) after xContext["opcodes"]
+			repeat for each element tElement in tArgument
+				if tElement is not a number then
+					_InternalError format("invalid scalar value '%s' in list", tArgument)
+				end if
+				put binaryEncode("f", tElement) after xContext["scalars"]
+			end repeat
+		else if tArgument is a number then
+			put binaryEncode("f", tArgument) after xContext["scalars"]
+		else
+			_InternalError format("invalid scalar value '%s'", tArgument)
+		end if
+	end repeat
+end _svgEncodeOpV
+
+private command _svgEncodePaint @xContext, pPaint
+	if pPaint[1] is "none" then
+	else if pPaint[1] is "color" then
+		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeSolidColor, pPaint[2], pPaint[3], pPaint[4]
+	else
+		_InternalError format("unknown paint '%s'", pPaint[1])
+	end if
+	_svgEncodeOp xContext, kMCGDrawingPaintOpcodeEnd
+end _svgEncodePaint
+
+private function _svgEncodePreserveAspectRatio pPar
+	local tParOp
+	switch word 1 of pPar
+	case "none"
+		put kMCGDrawingPreserveAspectRatioOpcodeNone into tParOp
+		break
+	case "xMinYMin"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMinYMinMeet into tParOp
+		break
+	case "xMidYMin"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMidYMinMeet into tParOp
+		break
+	case "xMaxYMin"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinMeet into tParOp
+		break
+	case "xMinYMid"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMinYMidMeet into tParOp
+		break
+	case "xMidYMid"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMidYMidMeet into tParOp
+		break
+	case "xMaxYMid"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidMeet into tParOp
+		break
+	case "xMinYMax"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxMeet into tParOp
+		break
+	case "xMidYMax"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxMeet into tParOp
+		break
+	case "xMaxYMax"
+		put kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet into tParOp
+		break
+	end switch
+	if word 2 of pPar is "slice" then
+		put tParOp - kMCGDrawingPreserveAspectRatioXMinYMinMeet + \
+						kMCGDrawingPreserveAspectRatioXMinYMinSlice into tParOp
+	end if
+	return tParOp
+end _svgEncodePreserveAspectRatio
+
+private command _svgEncodeTransform @xContext, pTransform
+	repeat for each element tTransform in pTransform
+		switch tTransform[1]
+		case "matrix"
+			_svgEncodeOp xContext, kMCGDrawingTransformOpcodeAffine, tTransform[2], tTransform[3], tTransform[4], tTransform[5], tTransform[6], tTransform[7]
+			break
+		case "viewport"
+			_InternalError format("dynamic viewport transform not supported")
+
+			_svgEncodeOp xContext, kMCGDrawingTransformOpcodeViewport, tTransform[2], tTransform[3], tTransform[4], tTransform[5], tTransform[6], tTransform[7], tTransform[8], tTransform[9]
+			_svgEncodeOp xContext, _svgEncodePreserveAspectRatio(tTransform[10])
+			break
+		default
+			_InternalError format("unknown transform '%s'", tTransform[1])
+		end switch
+	end repeat
+	_svgEncodeOp xContext, kMCGDrawingTransformOpcodeEnd
+end _svgEncodeTransform
+
+private command _svgEncodePath @xContext, pPath
+	local tScalarIndex
+	set the caseSensitive to true
+	put 1 into tScalarIndex
+	repeat for each char tCommand in pPath["commands"]
+		local tScalars
+		put pPath["scalars"][tScalarIndex] into tScalars
+		add 1 to tScalarIndex
+
+		local tOpcode
+		switch tCommand
+		case "M"
+			put kMCGDrawingPathOpcodeMoveTo into tOpcode
+			break
+		case "m"
+			put kMCGDrawingPathOpcodeRelativeMoveTo into tOpcode
+			break
+		case "Z"
+		case "z"
+			put kMCGDrawingPathOpcodeCloseSubpath into tOpcode
+			break
+		case "L"
+			put kMCGDrawingPathOpcodeLineTo into tOpcode
+			break
+		case "l"
+			put kMCGDrawingPathOpcodeRelativeLineTo into tOpcode
+			break
+		case "H"
+			put kMCGDrawingPathOpcodeHorizontalTo into tOpcode
+			break
+		case "h"
+			put kMCGDrawingPathOpcodeRelativeHorizontalTo into tOpcode
+			break
+		case "V"
+			put kMCGDrawingPathOpcodeVerticalTo into tOpcode
+			break
+		case "v"
+			put kMCGDrawingPathOpcodeRelativeVerticalTo into tOpcode
+			break
+		case "C"
+			put kMCGDrawingPathOpcodeCubicTo into tOpcode
+			break
+		case "c"
+			put kMCGDrawingPathOpcodeRelativeCubicTo into tOpcode
+			break
+		case "S"
+			put kMCGDrawingPathOpcodeSmoothCubicTo into tOpcode
+			break
+		case "s"
+			put kMCGDrawingPathOpcodeRelativeSmoothCubicTo into tOpcode
+			break
+		case "Q"
+			put kMCGDrawingPathOpcodeQuadraticTo into tOpcode
+			break
+		case "q"
+			put kMCGDrawingPathOpcodeRelativeQuadraticTo into tOpcode
+			break
+		case "T"
+			put kMCGDrawingPathOpcodeSmoothQuadraticTo into tOpcode
+			break
+		case "t"
+			put kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo into tOpcode
+			break
+		case "A"
+			if tScalars[4] is "0" then
+				if tScalars[5] is "0" then
+					put kMCGDrawingPathOpcodeArcTo into tOpcode
+				else
+					put kMCGDrawingPathOpcodeReverseArcTo into tOpcode
+				end if
+			else
+				if tScalars[5] is "0" then
+					put kMCGDrawingPathOpcodeReflexArcTo into tOpcode
+				else
+					put kMCGDrawingPathOpcodeReverseReflexArcTo into tOpcode
+				end if
+			end if
+			put tScalars[6] into tScalars[4]
+			put tScalars[7] into tScalars[5]
+			delete variable tScalars[6]
+			delete variable tScalars[7]
+			break
+		case "a"
+			if tScalars[4] is "0" then
+				if tScalars[5] is "0" then
+					put kMCGDrawingPathOpcodeRelativeArcTo into tOpcode
+				else
+					put kMCGDrawingPathOpcodeRelativeReverseArcTo into tOpcode
+				end if
+			else
+				if tScalars[5] is "0" then
+					put kMCGDrawingPathOpcodeRelativeReflexArcTo into tOpcode
+				else
+					put kMCGDrawingPathOpcodeRelativeReverseReflexArcTo into tOpcode
+				end if
+			end if
+			put tScalars[6] into tScalars[4]
+			put tScalars[7] into tScalars[5]
+			delete variable tScalars[6]
+			delete variable tScalars[7]
+			break
+		end switch
+		_svgEncodeOpV xContext, tOpcode, tScalars
+	end repeat
+	_svgEncodeOp xContext, kMCGDrawingPathOpcodeEnd
+end _svgEncodePath
+
+/*******************************************************************************
+ *
+ *  SVG TRANSFORM OPERATIONS
+ *
+ ******************************************************************************/
+
+private function _svgTransformIsIdentity pT
+	return pT is _svgTransformIdentity()
+end _svgTransformIsIdentity
+
+private function _svgTransformMatrix pA, pB, pC, pD, pE, pF
+	local tR
+	put pA into tR[1,1]
+	put pC into tR[1,2]
+	put pE into tR[1,3]
+	put pB into tR[2,1]
+	put pD into tR[2,2]
+	put pF into tR[2,3]
+	put 0 into tR[3,1]
+	put 0 into tR[3,2]
+	put 1 into tR[3,3]
+	return tR
+end _svgTransformMatrix
+
+private function _svgTransformIdentity
+	return _svgTransformMatrix(1, 0, 0, 1, 0, 0)
+end _svgTransformIdentity
+
+private function _svgTransformTranslate pTx, pTy
+	return _svgTransformMatrix(1, 0, 0, 1, pTx, pTy)
+end _svgTransformTranslate
+
+private function _svgTransformScale pSx, pSy
+	return _svgTransformMatrix(pSx, 0, 0, pSy, 0, 0)
+end _svgTransformScale
+
+private function _svgTransformRotate pAngle
+	local tRadians
+	put pAngle * pi / 180 into tRadians
+	return _svgTransformMatrix(cos(tRadians), sin(tRadians), -sin(tRadians), cos(tRadians), 0, 0)
+end _svgTransformRotate
+
+private function _svgTransformSkew pXa, pYa
+	return _svgTransformMatrix(1, tan(pYa * pi / 180), tan(pXa * pi / 180), 1, 0, 0)
+end _svgTransformSkew
+
+private function _svgTransformConcat pLeft, pRight
+	return matrixMultiply(pLeft, pRight)
+end _svgTransformConcat
+
+private function _svgTransformUnflatten pFlatMatrix
+	return _svgTransformMatrix(pFlatMatrix[2], pFlatMatrix[3], pFlatMatrix[4], pFlatMatrix[5], pFlatMatrix[6], pFlatMatrix[7])
+end _svgTransformUnflatten
+
+private function _svgTransformFlatten pMatrix
+	local tS
+	put "matrix" into tS[1]
+	put pMatrix[1,1] into tS[2]
+	put pMatrix[2,1] into tS[3]
+	put pMatrix[1,2] into tS[4]
+	put pMatrix[2,2] into tS[5]
+	put pMatrix[1,3] into tS[6]
+	put pMatrix[2,3] into tS[7]
+	return tS
+end _svgTransformFlatten
+
+/*******************************************************************************
+ *
+ *  SVG VALUE PARSING OPERATIONS
+ *
+ ******************************************************************************/
+
+private function _svgParseFeatureValue @xContext, pElementType, pFeatureName, @xValue
+	/* The syntax of a value is represented as a sequence of possible values
+	 * or patterns. */
+	local tType
+	put svgSpecGetFeatureTypeForElement(pFeatureName, pElementType) into tType
+
+	repeat for each element tVariant in tType
+		if not (tVariant begins with "<") then
+			if xValue is tVariant then
+				return true
+			end if
+		else
+			switch tVariant
+			case "<identifier>"
+				if _svgParseIdentifierValue(xValue) then
+					return true
+				end if
+				break
+			case "<boolean>"
+				if _svgParseBooleanValue(xValue) then
+					return true
+				end if
+				break
+			case "<text>"
+				if _svgParseTextValue(xValue) then
+					return true
+				end if
+				break
+			case "<transform>"
+				if _svgParseTransformValue(xValue) then
+					return true
+				end if
+				break
+			case "<paint>"
+				if _svgParsePaintValue(xValue) then
+					return true
+				end if
+				break
+			case "<color>"
+				if _svgParseColorValue(xValue) then
+					return true
+				end if
+				break
+			case "<coordinate>"
+			case "<length>"
+				if _svgParseLengthValue(xValue) then
+					return true
+				end if
+				break
+			case "<size>"
+				if _svgParseSizeValue(xValue) then
+					return true
+				end if
+				break
+			case "<nonnegative-length>"
+				if _svgParseNonNegativeLengthValue(xValue) then
+					return true
+				end if
+				break
+			case "<number>"
+				if _svgParseNumberValue(xValue) then
+					return true
+				end if
+				break
+			case "<path>"
+				if _svgParsePathValue(xValue) then
+					return true
+				end if
+				break
+			case "<rectangle>"
+				if _svgParseRectangleValue(xValue) then
+					return true
+				end if
+				break
+			case "<normalized-rectangle>"
+				if _svgParseNormalizedRectangleValue(xValue) then
+					return true
+				end if
+				break
+			case "<reference>"
+				if _svgParseReferenceValue(xValue) then
+					return true
+				end if
+				break
+			case "<miterlimit>"
+				if _svgParseMiterLimitValue(xValue) then
+					return true
+				end if
+				break
+			case "<opacity>"
+				if _svgParseOpacityValue(xValue) then
+					return true
+				end if
+				break
+			case "<dasharray>"
+				if _svgParseDashArrayValue(xValue) then
+					return true
+				end if
+				break
+			case "<points>"
+				if _svgParsePointsValue(xValue) then
+					return true
+				end if
+				break
+			case "<preserve-aspect-ratio>"
+				if _svgParsePreserveAspectRatio(xValue) then
+					return true
+				end if
+				break
+			default
+				_log format("unimplemented value pattern '%s'", tVariant)
+				break
+			end switch
+		end if
+	end repeat
+
+	return false
+end _svgParseFeatureValue
+
+private function _svgParseStyleAttributeValue @xValue
+	local tStyle
+	split xValue by ";"
+	repeat for each element tAttr in xValue
+		split tAttr by ":"
+		put word 1 to -1 of tAttr[2] into tStyle[word 1 to -1 of tAttr[1]]
+	end repeat
+	put tStyle into xValue
+	return true
+end _svgParseStyleAttributeValue
+
+private function _svgParsePreserveAspectRatio @xValue
+	if xValue is "none" then
+		return true
+	end if
+	if word 1 of xValue is among the items of "xMinYMin,xMidYMin,xMaxYMin,xMinYMid,xMidYMid,xMaxYMid,xMinYMax,xMidYMax,xMaxYMax" then
+		if word 2 of xValue is empty then
+			put " meet" after xValue
+		end if
+		if word 2 of xValue is among the items of "slice,meet" then
+			return true
+		end if
+	end if
+	return false
+end _svgParsePreserveAspectRatio
+
+/* The <color> type represents a color:
+ *
+ *   color
+ *     : #rgb
+ *     | #rrggbb
+ *     | rgb(rrr, ggg, bbb)
+ *     | rgb(R%, G%, B%)
+ *     | black | silver | gray | white | maroon | red | purple | fuchsia |
+ *     | green | lime | olive | yellow | navy | blue | teal | aqua
+ *
+ */
+private function _svgParseColorValue @xValue
+	local tRed, tGreen, tBlue
+	if matchText(xValue, "^\#[0-9a-zA-Z]{3}$") then
+		put baseConvert(char 2 of xValue, 16, 10) / 15 into tRed
+		put baseConvert(char 3 of xValue, 16, 10) / 15 into tGreen
+		put baseConvert(char 4 of xValue, 16, 10) / 15 into tBlue
+	else if matchText(xValue, "^\#[0-9a-zA-Z]{6}$") then
+		put baseConvert(char 2 to 3 of xValue, 16, 10) / 255 into tRed
+		put baseConvert(char 4 to 5 of xValue, 16, 10) / 255 into tGreen
+		put baseConvert(char 6 to 7 of xValue, 16, 10) / 255 into tBlue
+	else if xValue is "black" then
+		put 0 into tRed; put 0 into tGreen; put 0 into tBlue
+	else if xValue is "silver" then
+		put 192 into tRed; put 192 into tGreen; put 192 into tBlue
+	else if xValue is "gray" then
+		put 128 into tRed; put 128 into tGreen; put 128 into tBlue
+	else if xValue is "white" then
+		put 255 into tRed; put 255 into tGreen; put 255 into tBlue
+	else if xValue is "maroon" then
+		put 128 into tRed; put 0 into tGreen; put 0 into tBlue
+	else if xValue is "red" then
+		put 255 into tRed; put 0 into tGreen; put 0 into tBlue
+	else if xValue is "purple" then
+		put 128 into tRed; put 0 into tGreen; put 128 into tBlue
+	else if xValue is "fuchsia" then
+		put 255 into tRed; put 0 into tGreen; put 255 into tBlue
+	else if xValue is "green" then
+		put 0 into tRed; put 128 into tGreen; put 0 into tBlue
+	else if xValue is "lime" then
+		put 0 into tRed; put 255 into tGreen; put 0 into tBlue
+	else if xValue is "olive" then
+		put 128 into tRed; put 128 into tGreen; put 0 into tBlue
+	else if xValue is "yellow" then
+		put 255 into tRed; put 255 into tGreen; put 0 into tBlue
+	else if xValue is "navy" then
+		put 0 into tRed; put 0 into tGreen; put 128 into tBlue
+	else if xValue is "blue" then
+		put 0 into tRed; put 0 into tGreen; put 255 into tBlue
+	else if xValue is "teal" then
+		put 0 into tRed; put 128 into tGreen; put 128 into tBlue
+	else if xValue is "aqua" then
+		put 0 into tRed; put 255 into tGreen; put 255 into tBlue
+	else if matchText(xValue, "^rgb\s*\(\s*([0-9]+)\s*\,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)$", tRed, tGreen, tBlue) then
+		divide tRed by 255
+		divide tGreen by 255
+		divide tBlue by 255
+	else
+		return false
+	end if
+
+	put "color" into xValue["type"]
+	put tRed + 0 into xValue["red"]
+	put tGreen + 0 into xValue["green"]
+	put tBlue + 0 into xValue["blue"]
+	return true
+end _svgParseColorValue
+
+private command _svgNormalizeLength @xValue, pUnit
+	switch pUnit
+	case "px"
+		break
+	case "pt"
+		put xValue * 96 / 72 into xValue
+		break
+	case "pc"
+		put xValue * 96 / 6 into xValue
+		break
+	case "in"
+		put xValue * 96 into xValue
+		break
+	case "q"
+		put xValue * 96 / (40 * 2.54) into xValue
+		break
+	case "mm"
+		put xValue * 96 / 25.4 into xValue
+		break
+	case "cm"
+		put xValue * 96 / 2.54 into xValue
+		break
+	end switch
+end _svgNormalizeLength
+
+private function _svgParseLengthValue @xValue
+	local tValue, tValueUnit
+	put word 1 to -1 of xValue into xValue
+	repeat for each item tUnit in "in,cm,mm,pt,pc,px"
+		if xValue ends with tUnit then
+			delete char -(the length of tUnit) to -1 of xValue
+			put tUnit into tValueUnit
+			exit repeat
+		end if
+	end repeat
+	if _svgParseNumberValue(xValue) then
+		_svgNormalizeLength xValue, tValueUnit
+		return true
+	end  if
+	return false
+end _svgParseLengthValue
+
+private function _svgParseSizeValue @xValue
+	local tValue, tValueUnit
+	put word 1 to -1 of xValue into xValue
+	repeat for each item tUnit in "in,cm,mm,pt,pc,px,%"
+		if xValue ends with tUnit then
+			delete char -(the length of tUnit) to -1 of xValue
+			put tUnit into tValueUnit
+			exit repeat
+		end if
+	end repeat
+	if _svgParseNumberValue(xValue) then
+		/* TODO: Handle unit in an appropriate way. */
+		if tValueUnit is "%" then
+			put -xValue / 100 into xValue
+		else
+			_svgNormalizeLength xValue, tValueUnit
+		end if
+		return true
+	end  if
+	return false
+end _svgParseSizeValue
+
+private function _svgParseNonNegativeLengthValue @xValue
+	local tValue, tUnit
+	if _svgParseLengthValue(xValue) then
+		if xValue >= 0 then
+			return true
+		end if
+	end if
+	return false
+end _svgParseNonNegativeLengthValue
+
+private function _svgParseNumberValue @xValue
+	if xValue is a number then
+		put xValue + 0 into xValue
+		return true
+	end if
+	return false
+end _svgParseNumberValue
+
+private function _svgParseNonNegativeNumberValue @xValue
+	if _svgParseNumberValue(xValue) then
+		if xValue >= 0 then
+			return true
+		end if
+	end if
+	return false
+end _svgParseNonNegativeNumberValue
+
+private function _svgParsePathValue @xValue
+	local tPath
+	put empty into tPath
+
+	local tString
+	put xValue into tString
+
+	local tValid
+	put _svgPathParseSpace(tPath, tString) into tValid
+	repeat while tValid and tString is not empty
+		put _svgPathParseCommand(tPath, tString) into tValid
+	end repeat
+
+	if not tValid then
+		return false
+	end if
+
+	put tPath into xValue
+
+	return true
+end _svgParsePathValue
+
+private function _svgPathParseSpace @xPath, @xString
+	repeat while char 1 of xString is among the chars of (tab & space & return & numToChar(13))
+		delete char 1 of xString
+	end repeat
+	return true
+end _svgPathParseSpace
+
+private function _svgPathParseCommaSpace @xPath, @xString
+	if char 1 of xString is comma then
+		delete char 1 of xString
+		return _svgPathParseSpace(xPath, xString)
+	end if
+
+	if not _svgPathParseSpace(xPath, xString) then
+		return false
+	end if
+
+	if char 1 of xString is comma then
+		delete char 1 of xString
+	end if
+
+	return _svgPathParseSpace(xPath, xString)
+end _svgPathParseCommaSpace
+
+private function _svgPathParseCommand @xPath, @xString
+	switch char 1 of xString
+	case "z"
+		return _svgPathParseEmptyCommand(xPath, xString)
+	case "m"
+	case "l"
+	case "t"
+		return _svgPathParseCoordinatePairCommand(xPath, xString, 1)
+	case "h"
+	case "v"
+		return _svgPathParseCoordinateCommand(xPath, xString)
+	case "s"
+	case "q"
+		return _svgPathParseCoordinatePairCommand(xPath, xString, 2)
+	case "c"
+		return _svgPathParseCoordinatePairCommand(xPath, xString, 3)
+	case "a"
+		return _svgPathParseArcCommand(xPath, xString)
+	end switch
+	return false
+end _svgPathParseCommand
+
+private function _svgPathParseEmptyCommand @xPath, @xString
+	local tCommand
+	put char 1 of xString into tCommand
+	delete char 1 of xString
+
+	put tCommand after xPath["commands"]
+	seqPushOntoBack xPath["scalars"], empty
+
+	return _svgPathParseSpace(xPath, xString)
+end _svgPathParseEmptyCommand
+
+private function _svgPathParseCoordinatePairCommand @xPath, @xString, pArity
+	local tCommand
+	put char 1 of xString into tCommand
+	delete char 1 of xString
+
+	local tValid
+	put _svgPathParseSpace(xPath, xString) into tValid
+	repeat while tValid and char 1 of xString is among the chars of "0123456789+-."
+		put tCommand after xPath["commands"]
+		seqPushOntoBack xPath["scalars"], empty
+		repeat pArity times
+			if tValid then put _svgPathParseCoordinatePair(xPath, xString) into tValid
+			if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+		end repeat
+
+		set the caseSensitive to true
+		if tCommand is "m" then
+			put "l" into tCommand
+		else if tCommand is "M" then
+			put "L" into tCommand
+		end if
+		set the caseSensitive to false
+	end repeat
+
+	return tValid
+end _svgPathParseCoordinatePairCommand
+
+private function _svgPathParseCoordinateCommand @xPath, @xString
+	local tCommand
+	put char 1 of xString into tCommand
+	delete char 1 of xString
+
+	local tValid
+	put _svgPathParseSpace(xPath, xString) into tValid
+	repeat while tValid and char 1 of xString is among the chars of "0123456789+-."
+		put tCommand after xPath["commands"]
+		seqPushOntoBack xPath["scalars"], empty
+		if tValid then put _svgPathParseCoordinate(xPath, xString) into tValid
+		if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+	end repeat
+
+	return tValid
+end _svgPathParseCoordinateCommand
+
+private function _svgPathParseArcCommand @xPath, @xString
+	local tCommand
+	put char 1 of xString into tCommand
+	delete char 1 of xString
+
+	local tValid
+	put _svgPathParseSpace(xPath, xString) into tValid
+	repeat while tValid and char 1 of xString is among the chars of "0123456789+-."
+		put tCommand after xPath["commands"]
+		seqPushOntoBack xPath["scalars"], empty
+		if tValid then put _svgPathParseCoordinatePair(xPath, xString) into tValid
+		if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+		if tValid then put _svgPathParseCoordinate(xPath, xString) into tValid
+		if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+		if tValid then put _svgPathParseFlag(xPath, xString) into tValid
+		if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+		if tValid then put _svgPathParseFlag(xPath, xString) into tValid
+		if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+		if tValid then put _svgPathParseCoordinatePair(xPath, xString) into tValid
+		if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+	end repeat
+
+	return tValid
+end _svgPathParseArcCommand
+
+private function _svgPathParseCoordinatePair @xPath, @xString
+	local tValid
+	put _svgPathParseCoordinate(xPath, xString) into tValid
+	if tValid then put _svgPathParseCommaSpace(xPath, xString) into tValid
+	if tValid then put _svgPathParseCoordinate(xPath, xString) into tValid
+	return tValid
+end _svgPathParseCoordinatePair
+
+private function _svgPathParseCoordinate @xPath, @xString
+	return _svgPathParseNumber(xPath, xString)
+end _svgPathParseCoordinate
+
+private function _svgPathParseFlag @xPath, @xString
+	if char 1 of xString is among the chars of "01" then
+		seqPushOntoBack xPath["scalars"][the number of elements in xPath["scalars"]], char 1 of xString
+		delete char 1 of xString
+		return true
+	end if
+	return false
+end _svgPathParseFlag
+
+private function _svgPathParseNumber @xPath, @xString
+	local tNumber
+	if char 1 of xString is among the chars of "+-" then
+		put char 1 of xString after tNumber
+		delete char 1 of xString
+	end if
+	repeat while char 1 of xString is among the chars of "0123456789"
+		put char 1 of xString after tNumber
+		delete char 1 of xString
+	end repeat
+	if char 1 of xString is "." then
+		put char 1 of xString after tNumber
+		delete char 1 of xString
+		repeat while char 1 of xString is among the chars of "0123456789"
+			put char 1 of xString after tNumber
+			delete char 1 of xString
+		end repeat
+	end if
+	if char 1 of xString is "e" then
+		put char 1 of xString after tNumber
+		delete char 1 of xString
+		if char 1 of xString is among the chars of "+-" then
+			put char 1 of xString after tNumber
+			delete char 1 of xString
+		end if
+		repeat while char 1 of xString is among the chars of "0123456789"
+			put char 1 of xString after tNumber
+			delete char 1 of xString
+		end repeat
+	end if
+	if tNumber is not a number then
+		return false
+	end if
+	seqPushOntoBack xPath["scalars"][the number of elements in xPath["scalars"]], tNumber
+	return true
+end _svgPathParseNumber
+
+private function _svgParseRectangleValue @xValue
+	replace comma with space in xValue
+	if the number of words in xValue is not 4 then
+		return false
+	end if
+	local tRectangle
+	repeat for each word tCoordinate in xValue
+		if not _svgParseLengthValue(tCoordinate) then
+			return false
+		end if
+		seqPushOntoBack tRectangle, tCoordinate
+	end repeat
+	put tRectangle into xValue
+	return true
+end _svgParseRectangleValue
+
+private function _svgParseNormalizedRectangleValue @xValue
+	if not _svgParseRectangleValue(xValue) then
+		return false
+	end if
+	/* If the width or height of the rectangle is negative, then we treat the
+	 * rectangle as 0 size. */
+	if xValue[3] begins with "-" or xValue[4] begins with "-" then
+		put 0 into xValue[3]
+		put 0 into xValue[4]
+	end if
+	return true
+end _svgParseNormalizedRectangleValue
+
+/* The <transform> type represents an affine transform:
+ *
+ *   transform: <transform-list> | <transform-ref> | none
+ *
+ *   transform-list
+ *     : matrix(<a> <b> <c> <d> <e> <f>)
+ *     | translate(<tx> [<ty>])
+ *     | scale(<sx> [<sx>])
+ *     | rotate(<angle> [<cx> <cy>])
+ *     | skewX(<angle>)
+ *     | skewY(<angle>)
+ *
+ *   transform-ref
+ *     : ref(svg [<x> <y>])
+ *
+ * The individual transforms are separated by whitespace or comma.
+ */
+private function _svgParseTransformValue @xValue
+	replace comma with space in xValue
+	replace "(" with " ( " in xValue
+	replace ")" with " ) " in xValue
+
+	local tTransforms
+	repeat while xValue is not empty
+		local tType
+		put word 1 of xValue into tType
+		if tType is not among the items of "matrix,translate,scale,rotate,skewX,skewY" then
+			return false
+		end if
+		if word 2 of xValue is not "(" then
+			return false
+		end if
+
+		local tValues
+		put empty into tValues
+		repeat with tIndex = 3 to the number of words in xValue
+			if word tIndex of xValue is ")" then
+				exit repeat
+			end if
+			if word tIndex of xValue is not a number then
+				exit repeat
+			end if
+			seqPushOntoBack tValues, word tIndex of xValue
+		end repeat
+		delete word 1 to tIndex of xValue
+
+		local tArity
+		put the number of elements in tValues into tArity
+		
+		switch tType
+		case "matrix"
+			if tArity is not 6 then
+				return false
+			end if
+			break
+		case "translate"
+			if tArity is not 2 then
+				if tArity is not 1 then
+					return false
+				end if
+				seqPushOntoBack tValues, 0
+			end if
+			break
+		case "scale"
+			if tArity is not 2 then
+				if tArity is not 1 then
+					return false
+				end if
+				seqPushOntoBack tValues, tValues[1]
+			end if
+			break
+		case "rotate"
+			if tArity is not 3 then
+				if tArity is not 1 then
+					return false
+				end if
+				seqPushOntoBack tValues, 0
+				seqPushOntoBack tValues, 0
+			end if
+			break
+		case "skewX"
+		case "skewY"
+			if tArity is not 1 then
+				return false
+			end if
+		end switch
+
+		local tTransform
+		put tType into tTransform[1]
+		seqAppend tTransform, tValues
+		seqPushOntoBack tTransforms, tTransform
+	end repeat
+
+	put tTransforms into xValue
+
+	return true
+end _svgParseTransformValue
+
+/* The <paint> type represents a paint:
+ *
+ *   paint
+ *     : none
+ *     | currentColor
+ *     | <color>
+ *     | <reference> [ none | currentColor | <color> ]
+ *     | <system paint>
+ *
+ */
+private function _svgParsePaintValue @xValue
+	if xValue is "none" then
+		put "none" into xValue["type"]
+		return true
+	end if
+
+	if xValue is "currentColor" then
+		put "current" into xValue["type"]
+		return true
+	end if
+
+	if _svgParseColorValue(xValue) then
+		return true
+	end if
+
+	local tId, tBackup
+	if matchText(xValue, "^url\s*\(\s*#([a-zA-Z][a-zA-Z0-9]*)\s*\)(.*)$", tId, tBackup) then
+		put word 1 to -1 of tBackup into tBackup
+		if tBackup is not empty and \
+			tBackup is not "none" and \
+			tBackup is not "currentColor" and \
+			not _svgParseColorValue(tBackup) then
+			return false
+		end if
+		if tBackup is empty then
+			put "none" into tBackup
+		end if
+		put "reference" into xValue["type"]
+		put tId into xValue["id"]
+		put tBackup into xValue["fallback"]
+		return true
+	end if
+
+	if xValue is among the items of \
+		("ActiveBorder,ActiveCaption,AppWorkspace,Background,ButtonFace,ButtonHighlight," & \
+			"ButtonShadow,ButtonText,CaptionText,GrayText,Highlight,HighlightText,InactiveBorder," & \
+			"InactiveCaption,InactiveCaptionTextx,InfoBackground,InfoText,Menu,MenuTextx,Scrollbar," & \
+			"ThreeDDarkShadow,ThreeDFace,ThreeDHighlight,ThreeDLightShadow,ThreeDShadow,Window," & \
+			"WindowFrame,WindowText") then
+		put xValue into xValue["id"]
+		put "system" into xValue["type"]
+		return true
+	end if
+
+	return false
+end _svgParsePaintValue
+
+private function _svgParseReferenceValue @xValue
+	local tId
+	if matchText(xValue, "^url\s*\(\s*#([a-zA-Z][a-zA-Z0-9]*)\s*\)$", tId) then
+		put tId into xValue
+		return true
+	end if
+
+	if xValue begins with "#" then
+		put char 2 to -1 of xValue into xValue
+		return true
+	end if
+
+	return false
+end _svgParseReferenceValue
+
+private function _svgParseTextValue @xValue
+	return true
+end _svgParseTextValue
+
+private function _svgParseMiterLimitValue @xValue
+	if _svgParseNonNegativeNumberValue(xValue) and \
+		xValue >= 1 then
+		return true
+	end if
+	return false
+end _svgParseMiterLimitValue
+
+private function _svgParseIdentifierValue @xValue
+	if matchText(xValue, "[_a-zA-Z][_0-9a-zA-Z]*") then
+		return true
+	end if
+	return false
+end _svgParseIdentifierValue
+
+private function _svgParseBooleanValue @xValue
+	if xValue is among the items of "true,false" then
+		put xValue is "true" into xValue
+		return true
+	end if
+	return false
+end _svgParseBooleanValue
+
+private function _svgParsePointsValue @xValue
+	replace comma with space in xValue
+
+	if (the number of words in xValue) mod 2 is 1 then
+		return false
+	end if
+
+	local tPoints
+	repeat for each word tCoordinate in xValue
+		if not _svgParseLengthValue(tCoordinate) then
+			return false
+		end if
+		seqPushOntoBack tPoints, tCoordinate
+	end repeat
+	put tPoints into xValue
+
+	return true
+end _svgParsePointsValue
+
+/* The <opacity> type is a number between 0.0 and 1.0, any values outside of
+ * this range are clamped. */
+private function _svgParseOpacityValue @xValue
+	if _svgParseNumberValue(xValue) then
+		put max(min(xValue, 1.0), 0.0) into xValue
+		return true
+	end if
+
+	return false
+end _svgParseOpacityValue
+
+private function _svgParseDashArrayValue @xValue
+	if xValue is "none" then
+		put empty into xValue
+		return true
+	end if
+
+	local tLengths
+	put empty into tLengths
+	replace comma with space in xValue
+	repeat for each word tLength in xValue
+		if not _svgParseNonNegativeLengthValue(tLength) then
+			return false
+		end if
+		seqPushOntoBack tLengths, tLength
+	end repeat
+
+	put tLengths into xValue
+	return true
+end _svgParseDashArrayValue
+
+/*******************************************************************************
+ *
+ *  SVG CONTEXT OPERATIONS
+ *
+ ******************************************************************************/
+
+/* _svgContextEnter pushes the (XML) path to the element onto the path stack.
+ * This is used to report the location of any errors / warnings. */
+private command _svgContextEnter @xContext, pNode
+	seqPushOntoBack xContext["path"], format("%s[%u]", pNode["type"], pNode["index"])
+end _svgContextEnter
+
+/* _svgContextLeave pops the most recent element from the path stack. */
+private command _svgContextLeave @xContext, pNode
+	seqPopFromBack xContext["path"]
+end _svgContextLeave
+
+/* _svgContextDefine maps pId to the specified element in an internal mapping.
+ * If the id is already defined, the false is returned; otherwise true.
+ * The element is a copy, not a reference so redefinition is required if the
+ * source element changed. */
+private function _svgContextDefine @xContext, pId, pElement
+	if pId is among the keys of xContext["ids"] then
+		return false
+	end if
+
+	put pElement into xContext["ids"][pId]
+	return true
+end _svgContextDefine
+
+/* _svgContextLookup lookups an element with id pId. If one is found it is
+ * returned in rElement and true is returned, otherwise false is returned. */
+private function _svgContextLookup @xContext, pId, @rElement
+	if pId is not among the keys of xContext["ids"] then
+		return false
+	end if
+
+	put xContext["ids"][pId] into rElement
+	return true
+end _svgContextLookup
+
+private command _svgContextSave @xContext
+	seqPushOntoBack xContext["state"], seqLast(xContext["state"])
+end _svgContextSave
+
+private command _svgContextRestore @xContext
+	seqPopFromBack xContext["state"]
+end _svgContextRestore
+
+private command _svgContextSetState @xContext, pState, pValue
+	put pValue into xContext["state"][the number of elements in xContext["state"]][pState]
+end _svgContextSetState
+
+private function _svgContextGetState pContext, pState
+	return pContext["state"][the number of elements in pContext["state"]][pState]
+end _svgContextGetState
+
+private function _svgContextGetCurrentState pContext
+	return seqLast(pContext["state"])
+end _svgContextGetCurrentState
+
+private function _svgContextGetLastState pContext
+	return pContext["last-state"]
+end _svgContextGetLastState
+
+private command _svgContextSetLastState @xContext, pState
+	put pState into xContext["last-state"]
+end _svgContextSetLastState
+
+private command _svgContextEmit @xContext, pOperation
+	seqPushOntoBack xContext["operations"], pOperation
+end _svgContextEmit
+
+/* _svgContextUnknownElementError formats an appropriate error message for when
+ * encountering an unknown element. */
+private command _svgContextUnknownElementError @xContext, pElementType
+	_svgContextError xContext, format("element type '%s' unknown - ignoring", pElementType)
+end _svgContextUnknownElementError
+
+/* _svgContextUnknownElementError formats an appropriate error message for when
+ * encountering an unknown element. */
+private command _svgContextUnknownFeatureError @xContext, pFeatureName, pElementType
+	_svgContextError xContext, format("feature '%s' on element type '%s' unknown - ignoring", pFeatureName, pElementType)
+end _svgContextUnknownFeatureError
+
+private command _svgContextUnknownStylePropertyError @xContext, pFeatureName, pElementType
+	_svgContextError xContext, format("style property '%s' on element type '%s' unknown - ignoring", pFeatureName, pElementType)
+end _svgContextUnknownStylePropertyError
+
+private command _svgContextInvalidValueForFeatureError @xContext, pFeatureName, pElementType
+	_svgContextError xContext, format("invalid value for feature '%s' on element '%s' - ignoring", pFeatureName, pElementType)
+end _svgContextInvalidValueForFeatureError
+
+private command _svgContextInvalidDefaultValueError @xContext, pFeatureName, pElementType
+	_svgContextError xContext, format("invalid default value for feature '%s' on element '%s' - ignoring", pFeatureName, pElementType)
+end _svgContextInvalidDefaultValueError
+
+private command _svgContextElementAlreadyDefinedError @xContext, pId
+	_svgContextError xContext, format("element with id '%s' already defined - ignoring redefinition", pId)
+end _svgContextElementAlreadyDefinedError
+
+private command _svgContextElementNotDefinedError @xContext, pId
+	_svgContextError xContext, format("element with id '%s' not defined - ignoring reference", pId)
+end _svgContextElementNotDefinedError
+
+/* _svgContextError reports an error message, augmenting it with the current
+ * path in the context. */
+private command _svgContextError @xContext, pMessage
+	get xContext["path"]
+	combine it with slash
+	_log format("[SVG ERROR] %s: %s", it, pMessage)
+end _svgContextError
+
+/*******************************************************************************
+ *
+ *  SVG SPECIFICATION OPERATIONS
+ *
+ ******************************************************************************/
+
+/* sSvgSpec is an array holding information about how to parse SVG documents.
+ *
+ * The 'elements' key maps element name to an array describing the element.
+ * All elements have a 'name' key.
+ *
+ * The element with the empty name has a key 'property' which contains a map
+ * from property name to a feature array.
+ *
+ * All other elements have an 'attribute' and a 'property' key. The 'attribute'
+ * key contains a map from attribute name to a feature array. This describes all
+ * the attributes which are applicable to the element.  The 'property' key
+ * contains an array, the keys of which describe the properties which apply to
+ * the element.
+ *
+ * A feature array has a 'name' key holding the feature's name, a 'type' key
+ * holding the feature's type, a 'nullable' key which determines whether the
+ * attribute can be missing, and a 'default' key (if nullable is false) holding
+ * the default value of the attribute.
+ *
+ * Note: We use the element with no name as a store for the actual property
+ * definitions. This works because (unlike attributes) properties are global,
+ * whereas attributes are local to the element.
+ */
+local sSvgSpec
+
+/* svgSpecIsElement returns true if pElement is the name of a known element. */
+private function svgSpecIsElement pElement
+	return pElement is among the keys of sSvgSpec["elements"]
+end svgSpecIsElement
+
+/* svgSpecIsProperty returns true if pProperty is the name of a known property. */
+private function svgSpecIsProperty pProperty
+	return pProperty is among the keys of sSvgSpec["elements"][""]["property"]
+end svgSpecIsProperty
+
+/* svgSpecIsPropertyInheritable returns true if the value of a property cascades
+ * to children when the property is unset, or whether it has the default
+ * set when unset. */
+private function svgSpecIsPropertyInheritable pProperty
+	/* All properties are inheritable at the moment */
+	return true --sSvgSpec["elements"][""]["property"][pProperty]["inheritable"]
+end svgSpecIsPropertyInheritable
+
+/* svgSpecGetApplicableAttributesOfElement returns an array whose keys are the
+ * attributes which apply to the given element. */
+private function svgSpecGetApplicableAttributesOfElement pElement
+	get the keys of sSvgSpec["elements"][pElement]["attribute"]
+	split it by return as set
+	return it
+end svgSpecGetApplicableAttributesOfElement
+
+/* svgSpecIsAttributeApplicableToElement returns true if pAttribute applies to
+ * pElement. */
+private function svgSpecIsAttributeApplicableToElement pAttribute, pElement
+	return pAttribute is among the keys of sSvgSpec["elements"][pElement]["attribute"]
+end svgSpecIsAttributeApplicableToElement
+
+/* svgSpectIsAttributeRequiredForElement returns true if the pAttribute is a
+ * nullable attribute on pElement. */
+private function svgSpecIsAttributeRequiredForElement pElement, pAttribute
+	return not sSvgSpec["elements"][pElement]["attribute"][pAttribute]["nullable"]
+end svgSpecIsAttributeRequiredForElement
+
+/* svgSpecGetAttributeDefaultForElement returns the default value for attribute
+ * pAttribute on pElement. */
+private function svgSpecGetAttributeDefaultForElement pElement, pAttribute
+	return sSvgSpec["elements"][pElement]["attribute"][pAttribute]["default"]
+end svgSpecGetAttributeDefaultForElement
+
+/* svgSpecGetPropertyDefaults returns an array mapping property name to
+ * property default value. This is used as the start of the property cascade. */
+private function svgSpecGetPropertyDefaults
+	local tDefaults
+	repeat for each element tProperty in sSvgSpec["elements"][""]["property"]
+		put tProperty["default"] into tDefaults[tProperty["name"]]
+	end repeat
+	return tDefaults
+end svgSpecGetPropertyDefaults
+
+private function svgSpecGetDefaultValueForProperty pProperty
+	return sSvgSpec["elements"][""]["property"][pProperty]["default"]
+end svgSpecGetDefaultValueForProperty
+
+/* svgSpecIsPropertyApplicableToElement returns true if pProperty applies to
+ * pElement. */
+private function svgSpecIsPropertyApplicableToElement pProperty, pElement
+	return pProperty is among the keys of sSvgSpec["elements"][pElement]["property"]
+end svgSpecIsPropertyApplicableToElement
+
+/* svgSpecIsPropertySettableOnElement returns true if pProperty can be set on
+ * pElement. There are some properties (such as 'fill') which are actually
+ * attributes in SMIL, so SMIL nodes don't allow the fill property to be set. */
+private function svgSpecIsPropertySettableOnElement pProperty, pElement
+	return svgSpecIsProperty(pProperty)
+end svgSpecIsPropertySettableOnElement
+
+/* svgSpecIsFeatureApplicableToElement returns true if pFeature can be set on
+ * elements of type pElement. */
+private function svgSpecIsFeatureSettableOnElement pFeature, pElement
+	return svgSpecIsPropertySettableOnElement(pFeature, pElement) or \
+			svgSpecIsAttributeApplicableToElement(pFeature, pElement)
+end svgSpecIsFeatureSettableOnElement
+
+/* svgSpecGetFeatureTypeForElement returns the type of the given attribute
+ * pFeature on pElement; or if pFeature is a property, the type of the property. */
+private function svgSpecGetFeatureTypeForElement pFeature, pElement
+	get sSvgSpec["elements"][pElement]["attribute"][pFeature]["type"]
+	if it is empty then
+		get sSvgSpec["elements"][""]["property"][pFeature]["type"]
+	end if
+	return it
+end svgSpecGetFeatureTypeForElement
+
+/* svgSpecLoad loads and parses a description of attributes, and the node types
+ * they apply to. */
+private command svgSpecLoad
+	/* If the sSvgSpec variable is already an array, then the specification has
+	 * already been loaded. */
+	if sSvgSpec is an array then
+		exit svgSpecLoad
+	end if
+
+	/* Load the svg specification text file. */
+	local tSpecText
+	put url ("file:" & _GetResourcesPath() & slash & "drawing-svg-specification.txt") into tSpecText
+	if the result is not empty then
+		_svgSpecError 0, "failed to read specification"
+	end if
+
+	/* Keep track of the current row being processed, and also the current part
+	 * which is being parsed. */
+	local tCurrentRow, tCurrentElement
+	put 0 into tCurrentRow
+	put empty into tCurrentElement
+	repeat for each line tLine in tSpecText
+		/* Keep a running count of the row */
+		add 1 to tCurrentRow
+
+		/* Ignore any comment lines (those beginning with '#'). */
+		if word 1 of tLine begins with "#" then
+			next repeat
+		end if
+
+		/* Ignore any empty lines. */
+		if word 1 to -1 of tLine is empty then
+			next repeat
+		end if
+
+		/* The type of line we are parsing is determined by the first word. */
+		local tLineType
+		put word 1 of tLine into tLineType
+
+		/* An 'element' line finishes the current element (if any) and sets
+		 * things up to parse a new one. */
+		if tLineType is "element" then
+			/* If there is an element currently being processed, then record it
+			 * in the sSvgSpec array. */
+			if tCurrentElement is an array then
+				put tCurrentElement into sSvgSpec["elements"][tCurrentElement["name"]]
+				put empty into tCurrentElement
+			end if
+
+			/* Element lines have at most two words. */
+			if the number of words in tLine > 2 then
+				_svgSpecError tCurrentRow, format("invalid element clause")
+				next repeat
+			end if
+
+			/* The second word of the element line is the element name, and this
+			 * must not have been used before. */
+			if word 2 of tLine is among the keys of sSvgSpec["elements"] then
+				_svgSpecError tCurrentRow, format("element '%s' already defined", word 2 of tLine)
+				next repeat
+			end if
+
+			/* Record the name of the new element. */
+			put word 2 of tLine into tCurrentElement["name"]
+			
+			next repeat
+		end if
+		
+		/* The 'property' and 'attribute' lines have the same format and define
+		 * a feature. */
+		if tLineType is "property" or tLineType is "attribute" then
+			/* If there is no current element, then there is nothing to attach
+			 * the feature to. */
+			if tCurrentElement is not an array then
+				_svgSpecError tCurrentRow, "no current element"
+				next repeat
+			end if
+			
+			/* Properties must only be defined against the element with no
+			 * name. */
+			if tLineType is "property" and \
+				tCurrentElement["name"] is not empty then
+				_svgSpecError tCurrentRow, "properties must be defined in the unnamed element"
+				next repeat
+			end if
+
+			/* The syntax of a feature is:
+			 *   (property | attribute ) <name> <type> (nullable | default <value>)
+			 * So a feature line must have at least 4 words */
+			if the number of words in tLine < 4 then
+				_svgSpecError tCurrentRow, "invalid feature clause (too few words)"
+				next repeat
+			end if
+
+			/* Extract the name of the feature from the second word, and the
+			 * type of the feature from the third. */
+			local tFeature
+			put word 2 of tLine into tFeature["name"]
+			put word 3 of tLine into tFeature["type"]
+
+			/* The type of a feature is a '|' delimited list of options. */
+			split tFeature["type"] by "|"
+
+			/* Extract the nullable / default clause from the line. */
+			if word 4 of tLine is "default" then
+				/* The feature has a default value, so we expect exactly 5 words
+				 * in the line. */
+				if the number of words in tLine is not 5 then
+					_svgSpecError tCurrentRow, "invalid feature clause (wrong number of words)"
+					next repeat
+				end if
+
+				/* The fifth word is the feature default value. */
+				put word 5 of tLine into tFeature["default"]
+
+				/* We allow the default value to be a quoted string, mainly as
+				 * some values have the empty string as default, so remove the
+				 * quotes, if present. */
+				if tFeature["default"] begins with quote then
+					if char -1 of tFeature["default"] is not quote then
+						_svgSpecError tCurrentRow, "invalid feature clause (missing end quote on default value)"
+						next repeat
+					end if
+
+					put char 2 to -2 of tFeature["default"] into tFeature["default"]
+				end if
+
+				/* If a feature has a default value, then it is not nullable. */
+				put false into tFeature["nullable"]
+			else if word 4 of tLine is "nullable" then
+				/* The feature has been marked as nullable, so mark it as such. */
+				put true into tFeature["nullable"]
+			end if
+
+			/* The name of a feature must be unique in the current element. */
+			if tFeature["name"] is among the keys of tCurrentElement[tLineType] then
+				_svgSpecError tCurrentRow, format("feature '%s' already defined for current element", tFeature["name"])
+				next repeat
+			end if
+
+			/* Add the feature to the current element's feature map. */
+			put tFeature into tCurrentElement[tLineType][tFeature["name"]]
+			
+			next repeat
+		end if
+
+		/* The 'apply' line marks an element as consuming the specified
+		 * property. */
+		if tLineType is "apply" then
+			/* There must be a current element for apply to make sense. */
+			if tCurrentElement is not an array then
+				_svgSpecError tCurrentRow, "no current element"
+				next repeat
+			end if
+
+			/* Apply clauses are only allowed on named elements. */
+			if tCurrentElement["name"] is empty then
+				_svgSpecError tCurrentRow, "'apply' can only be used on named elements"
+				next repeat
+			end if
+
+			/* For named elements, the property array is a set of applicable
+			 * properties. */
+			put true into tCurrentElement["property"][word 2 of tLine]
+			
+			next repeat
+		end if
+
+		/* At this point the line type must be unknown. */
+		_svgSpecError tCurrentRow, format("unknown line type '%s'", tLineType)
+	end repeat
+
+	/* Make sure the last element is recorded in the spec array. */
+	if tCurrentElement is an array then
+		put tCurrentElement into sSvgSpec["elements"][tCurrentElement["name"]]
+	end if
+end svgSpecLoad
+
+private command _svgSpecLoadPart pPart
+	if pPart["type"] is not "element" then
+		if "value" is not among the keys of pPart or \
+			"animatable" is not among the keys of pPart or \
+			"inheritable" is not among the keys of pPart then
+			_svgSpecError pPart["row"], format("incomplete %s definition", pPart["type"])
+		end if
+	end if
+
+	if pPart["name"] is among the keys of sSvgSpec[pPart["type"]] then
+		_svgSpecError pPart["row"], format("%s with name '%s' already definted", pPart["type"], pPart["name"])
+	end if
+
+	if "implemented" is not among the keys of pPart then
+		put true into pPart["implemented"]
+	end if
+
+	put pPart into sSvgSpec[pPart["type"]][pPart["name"]]
+end _svgSpecLoadPart
+
+private command _svgSpecError pRow, pMessage
+	_log format("[SPEC ERROR] row %d: %s", pRow, pMessage)
+	throw "svgerr,error loading svg specification"
+end _svgSpecError
+
+/*******************************************************************************
+ *
+ *  XML OPERATIONS
+ *
+ ******************************************************************************/
+
+/* xmlImportFromFile converts an XML document into a LiveCode array, with array
+ * structure suitable for parsing SVG XML files (and other, similar W3C-defined
+ * XML document formats).
+ *
+ * Each text XML element is mapped to a string.
+ *
+ * Each non-text XML element is mapped to an array with 3 keys:
+ *   - type: the xml element tag (e.g. svg)
+ *   - index: the index of the element type in the parent
+ *   - features: an array mapping feature name to value
+ *   - content: either a string if there is a single text node, or an XML
+ *     element array
+ *
+ * Note: We use the term 'features' here, rather than 'attributes' as SVG uses
+ * XML attributes to specify both SVG attributes and SVG properties.
+ *
+ * For example:
+ *
+ *   <?xml version="1.0"?>
+ *   <svg xmlns="http://www.w3.org/2000/svg" version="1.2" baseProfile="tiny">
+ *   <desc>Demonstrates use of a default namespace prefix for elements.</desc>
+ *   <rect width="7" height="3"/>
+ *   </svg>
+ *
+ * Will be imported as the follow array:
+ *
+ *   svg:
+ *     attributes:
+ *       xmlns: http://www.w3.org/2000/svg
+ *       version: 1.2
+ *       baseProfile: tiny
+ *     index: 1
+ *     content:
+ *       1:
+ *         desc:
+ *           index: 1
+ *           content: Demonstrates use of a default namespace prefix for elements.
+ *       2:
+ *         rect:
+ *           index: 1
+ *           features:
+ *             width: 7
+ *             height: 3
+ *
+ * Any XML errors (generated by libxml) will be thrown; otherwise an array will
+ * be returned in the above structure.
+ */
+private function xmlImportFromFile pXMLFile
+   local tArray
+   
+   local tTreeId
+   put revCreateXMLTreeFromFileWithNamespaces(pXMLFile, true, true, false) into tTreeId
+   
+   if tTreeId begins with "xmlerr," then
+      throw tTreeId
+   end if
+   
+   try
+      local tRootNode
+      put revXMLRootNode(tTreeId) into tRootNode
+      if tRootNode begins with "xmlerr," then
+         throw tRootNode
+      end if
+      
+      put _xmlImportNode(tTreeId, revXMLRootNode(tTreeId)) into tArray
+      
+   finally
+      revDeleteXMLTree tTreeId
+   end try
+   
+   return tArray
+end xmlImportFromFile
+
+private function xmlImportFromText pXMLText
+   local tArray
+   
+   local tTreeId
+   put revCreateXMLTreeWithNamespaces(pXMLText, true, true, false) into tTreeId
+   
+   if tTreeId begins with "xmlerr," then
+      throw tTreeId
+   end if
+   
+   try
+      local tRootNode
+      put revXMLRootNode(tTreeId) into tRootNode
+      if tRootNode begins with "xmlerr," then
+         throw tRootNode
+      end if
+      
+      put _xmlImportNode(tTreeId, revXMLRootNode(tTreeId)) into tArray
+      
+   finally
+      revDeleteXMLTree tTreeId
+   end try
+   
+   return tArray
+end xmlImportFromText
+
+/* _xmlImportNodeType extracts the XML node tag and index from the path provided
+ * by libXML. */
+private command _xmlImportNodeTypeAndIndex pNode, @rType, @rIndex
+	set the itemDelimiter to "/"
+	get the last item of pNode
+	set the itemDelimiter to "["
+	put item 1 of it into rType
+	put char 1 to -2 of item 2 of it into rIndex
+	if rIndex is empty then
+		put 1 into rIndex
+	end if
+end _xmlImportNodeTypeAndIndex
+
+/* _xmlImportNode is the name recursive function which imports an XML node in
+ * the LiveCode array structure. */
+private function _xmlImportNode pTreeId, pNode
+   /* Extract the node type and index from the pNode path */
+   local tArray
+   _xmlImportNodeTypeAndIndex pNode, tArray["type"], tArray["index"]
+   
+   -- First extract the attributes, these go into an 'attribute' field
+   -- as an array mapping attribute name to value
+   local tAttributes
+   put revXMLAttributes(pTreeId, pNode, "=", return) into tAttributes
+   if tAttributes begins with "xmlerr," then
+      throw tAttributes
+   end if
+   split tAttributes by return and "="
+   put tAttributes into tArray["features"]
+   
+   -- Get the list of child nodes
+   local tChildNodes
+   put revXMLChildNames(pTreeId, pNode, return, empty, true, true) into tChildNodes
+   if tChildNodes begins with "xmlerr," then
+      throw tChildNodes
+   end if
+   
+   /* If the list of child nodes of the element is not empty, then we
+    * recursively import each child node into a sequence; otherwise the node
+    * only contains text (or has no content) which we import as a string. */
+   local tContent
+   if tChildNodes is not empty then
+      local tChildIndex
+      put 1 into tChildIndex
+      repeat for each line tChildLeaf in tChildNodes
+         put _xmlImportNode(pTreeId, pNode & slash & tChildLeaf) into tContent[tChildIndex]
+         add 1 to tChildIndex
+      end repeat
+   else
+      put revXMLNodeContents(pTreeId, pNode) into tContent
+      if tContent begins with "xmlerr," then
+         throw tContent
+      end if
+   end if
+
+   /* The content of the node, whether it be just a string or a sequence of
+    * other nodes is placed in the 'content' key of the resulting node array. */
+   put tContent into tArray["content"]
+   
+   return tArray
+end _xmlImportNode
+
+/*******************************************************************************
+ *
+ *  SEQUENCE OPERATIONS
+ *
+ ******************************************************************************/
+
+private command seqPushOntoBack @xSeq, pValue
+	put pValue into xSeq[the number of elements in xSeq + 1]
+end seqPushOntoBack
+
+private command seqPopFromBack @xSeq
+	delete variable xSeq[the number of elements in xSeq]
+end seqPopFromBack
+
+private command seqAppend @xSeq, pOther
+	repeat for each element tElement in pOther
+		seqPushOntoBack xSeq, tElement
+	end repeat
+end seqAppend
+
+private function seqLast pSeq
+	return pSeq[the number of elements in pSeq]
+end seqLast
+
+/*******************************************************************************
+ *
+ *  INTERNAL OPERATIONS
+ *
+ ******************************************************************************/
+
+private function _GetResourcesPath
+   set the itemDelimiter to slash
+   return item 1 to -2 of the filename of me
+end _GetResourcesPath
+
+private function _ArrayToString pArray, pPrefix
+   local tString
+   if "1" is among the keys of pArray then
+      local tIndex
+      put 1 into tIndex
+      repeat for each element tElement in pArray
+         put pPrefix & "[" & tIndex & "]" & space after tString
+         if tElement is an array then
+            put return & _ArrayToString(tElement, pPrefix & "  ") after tString
+         else
+            put tElement after tString
+         end if
+         put return after tString
+         add 1 to tIndex
+      end repeat
+   else
+      repeat for each key tKey in pArray
+         put pPrefix & tKey & ":" & space after tString
+         if pArray[tKey] is an array then
+            put return & _ArrayToString(pArray[tKey], pPrefix & "  ") after tString
+         else
+            put pArray[tKey] after tString
+         end if
+         put return after tString
+      end repeat
+   end if
+   delete the last char of tString
+   return tString
+end _ArrayToString
+
+private command _InternalError pMessage
+	throw pMessage
+end _InternalError
+
+private command _LogArray pArray
+	if the environment is "command line" then
+		_Log _ArrayToString(pArray)
+	end if
+end _LogArray
+
+private command _Log pMessage
+	if the environment is "command line" then
+		write pMessage & return to stderr
+	else
+		--put pMessage & return after msg
+	end if
+end _Log
+
+/******************************************************************************/

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -1015,6 +1015,8 @@ void MCGContextDrawPlatformText(MCGContextRef context, const unichar_t *text, ui
 MCGFloat MCGContextMeasurePlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform);
 bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform, MCGRectangle &r_bounds);
 
+void MCGContextPlayback(MCGContextRef context, MCGRectangle p_dst_rect, const void *p_drawing, size_t p_drawing_byte_size);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // Transforms

--- a/libgraphics/libgraphics.gyp
+++ b/libgraphics/libgraphics.gyp
@@ -43,6 +43,7 @@
 				'src/utils.cpp',
 				'src/SkStippleMaskFilter.cpp',
 				'src/legacygradients.cpp',
+				'src/drawing.cpp',
 			],
 			
 			'conditions':

--- a/libgraphics/src/drawing.cpp
+++ b/libgraphics/src/drawing.cpp
@@ -1,0 +1,2240 @@
+/* Copyright (C) 2003-2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "graphics.h"
+#include "graphics-internal.h"
+
+/******************************************************************************/
+
+inline MCGPoint MCGPointReflect(const MCGPoint &origin, const MCGPoint &point)
+{
+	return MCGPointMake(origin.x - (point.x - origin.x), origin.y - (point.y - origin.y));
+}
+
+/*******************************************************************************
+ *
+ * DRAWING FORMAT - VERSION 0
+ *
+ * A drawing is a simple bytecode format for representing graphics expressed
+ * using SVG. It consists of a header, followed by a sequence of bytecodes
+ * encoded in bytes, and a sequence of scalars encoded as floats.
+ *
+ * The format is such that it requires no extra data structures at runtime
+ * except whilst rendering.
+ *
+ * The header has the following format:
+ *   uint8_t[4] ident = 'L', 'C', 'D', 0
+ *   uint32_t flags
+ *     has_width : bit 0
+ *     has_height : bit 1
+ *     has_viewport : bit 2
+ *   uint32_t scalar_count
+ *   float[scalar_count] scalars
+ *   uint32_t opcode_count
+ *   uint8_t[opcode_count] opcodes
+ *
+ * The ident field is used to identify a drawing, allowing simple 'sniffing' of
+ * the first four bytes to help determine the format.
+ *
+ * The last byte of the ident field is the version of the format - currently 0.
+ * This will be incremented each time the format changes in a backwards
+ * incompatible way.
+ *
+ * The has_width flag determines whether the drawing has specified an intrinsic
+ * width != 100% (i.e. width of container). If set to true, then the width
+ * will be available as a size scalar.
+ *
+ * The has_height flag determines whether the drawing has specified an intrinsic
+ * height != 100% (i.e. height of container). If set to true, then the height
+ * will be available as a size scalar.
+ *
+ * The has_viewport flag determines whether the drawing has specified a viewbox
+ * and preserve aspect ratio setting. If set to true, then the viewbox will be
+ * available as two coordinate scalars, followed by two length scalars, and the
+ * aspect ratio setting will be available as a PreserveAspectRatio opcode.
+ *
+ * There are several kinds of scalar which may be present:
+ *
+ *   - coordinate : any scalar value
+ *
+ *   - unit : a value between 0 and 1
+ *
+ *   - length : a value greater or equal to 0
+ *
+ *   - positive : a value greater or equal to 1
+ *
+ *   - size : a value greater or equal to -1; values less than 0 represent
+ *     a percentage (divided by -100), values greater or equal to 0 represent
+ *     absolute values.
+ *
+ */
+
+enum : uint8_t
+{
+    kMCGDrawingIdent0 = 'L',
+    kMCGDrawingIdent1 = 'C',
+    kMCGDrawingIdent2 = 'D',
+    kMCGDrawingVersion = 0,
+};
+
+/* MCGDrawingHeaderFlags is a bit set indicating which 'initialization' fields
+ * are present in the drawing. */
+enum MCGDrawingHeaderFlags : uint32_t
+{
+    /* The drawing has a width specified which is not 100% */
+    kMCGDrawingHeaderFlagHasWidthBit = 1 << 0,
+    
+    /* The drawing has a height specified which is not 100% */
+    kMCGDrawingHeaderFlagHasHeightBit = 1 << 1,
+    
+    /* The drawing has a viewport specified (viewBox and preserveAspectRatio) */
+    kMCGDrawingHeaderFlagHasViewportBit = 1 << 2,
+    
+    /* The mask to use to check no undefined flags are set. */
+    kMCGDrawingHeaderFlagValidMask = 0x07,
+};
+
+/* MCGDrawingHeader defines the layout of a drawing's header.
+ *
+ * Note: The definition is partial as the scalar_count and opcode_count are
+ * not fixed. */
+struct MCGDrawingHeader
+{
+    uint8_t ident[4];
+    uint32_t flags;
+    uint32_t scalar_count;
+//  float[scalar_count] scalars;
+//  uint32_t opcode_count;
+//  uint8_t[opcode_count] opcodes;
+};
+
+/* MAIN OPCODES */
+
+/* MCGDrawingOpcode defines the main opcodes which appear in the opcode stream.
+ */
+enum MCGDrawingOpcode : uint8_t
+{
+    /* End defines the end of an opcode stream */
+    kMCGDrawingOpcodeEnd = 0,
+    
+    /* Transform defines a transform attribute change. The transform is defined
+     * by a following transform opcode stream. */
+    kMCGDrawingOpcodeTransform = 1,
+    
+    /* FillPaint defines a fill-paint attribute change. The paint is defined by
+     * a following paint opcode stream. */
+    kMCGDrawingOpcodeFillPaint = 2,
+    
+    /* FillOpacity defines a fill-opacity attribute change. The opacity is
+     * defined by a unit scalar. */
+    kMCGDrawingOpcodeFillOpacity = 3,
+    
+    /* FillRule defines a fill-rule attribute change. The fill rule is defined
+     * by a FillRule opcode. */
+    kMCGDrawingOpcodeFillRule = 4,
+    
+    /* StrokePaint defines a stroke-paint attribute change. The paint is defined
+     * by a following paint opcode stream. */
+    kMCGDrawingOpcodeStrokePaint = 5,
+    
+    /* StrokeOpacity defines a stroke-opacity attribute change. The opacity is
+     * defined by a unit length scalar. */
+    kMCGDrawingOpcodeStrokeOpacity = 6,
+    
+    /* StrokeWidth defines a stroke-width attribute change. The stroke-width is
+     * defined by a length scalar. */
+    kMCGDrawingOpcodeStrokeWidth = 7,
+    
+    /* StrokeLineJoin defines a stroke-line-join attribute change. The
+     * stroke-line-join is defined by a StrokeLineJoin opcode. */
+    kMCGDrawingOpcodeStrokeLineJoin = 8,
+    
+    /* StrokeLineCap defines a stroke-line-cap attribute change. The
+     * stroke-line-cap is defined by a StrokeLineCap opcode. */
+    kMCGDrawingOpcodeStrokeLineCap = 9,
+    
+    /* StrokeDashArray defines a stroke-dash-array attribute change. The
+     * stroke-dash-array is defined by a length scalar array. */
+    kMCGDrawingOpcodeStrokeDashArray = 10,
+    
+    /* StrokeDashOffset defines a stroke-dash-offset attribute change. The
+     * stroke-dash-offset is defined by a length scalar. */
+    kMCGDrawingOpcodeStrokeDashOffset = 11,
+    
+    /* StrokeMiterLimit defines a stroke-miter-limit attribute change. The
+     * stroke-miter-limit is defined by a positive length scalar. */
+    kMCGDrawingOpcodeStrokeMiterLimit = 12,
+    
+    /* Rectangle defines a rectangle shape. The rectangle is defined as:
+     *   x, y: coordinate scalars
+     *   width, height: length scalars
+     *   rx, ry: length scalars */
+    kMCGDrawingOpcodeRectangle = 13,
+    
+    /* Circle defines a circle shape. The circle is defined as:
+     *   x, y: coordinate scalars
+     *   r: length scalar */
+    kMCGDrawingOpcodeCircle = 14,
+    
+    /* Ellipse defines an ellipse shape. The ellipse is defined as:
+     *   x, y: coordinate scalars
+     *   rx, ry: length scalars */
+    kMCGDrawingOpcodeEllipse = 15,
+    
+    /* Line defines a line shape. The line is defined as:
+     *   x1, y1: coordinate scalars
+     *   x2, y2: coordinate scalars */
+    kMCGDrawingOpcodeLine = 16,
+    
+    /* Polyline defines a polyline shape. The polyline is defined as an array
+     * of coordinate scalar pairs. */
+    kMCGDrawingOpcodePolyline = 17,
+    
+    /* Polyline defines a polygon shape. The polygon is defined as an array
+     * of coordinate scalar pairs. */
+    kMCGDrawingOpcodePolygon = 18,
+    
+    /* Path defines a path shape. The path is defined by a path opcode stream.
+     */
+    kMCGDrawingOpcodePath = 19,
+    
+    /* _Last is used for range checking on the main opcodes. */
+    kMCGDrawingOpcode_Last = kMCGDrawingOpcodePath,
+};
+
+/* PRESERVE ASPECT RATIO OPCODES */
+
+/* MCGDrawingPreserveAspectRatioOpcode defines the settings of the preserve-
+ * aspect-ratio attribute. */
+enum MCGDrawingPreserveAspectRatioOpcode : uint8_t
+{
+    kMCGDrawingPreserveAspectRatioOpcodeNone = 0,
+    kMCGDrawingPreserveAspectRatioOpcodeXMinYMinMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMidYMinMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMinYMidMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMidYMidMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet,
+    kMCGDrawingPreserveAspectRatioOpcodeXMinYMinSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMidYMinSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMinYMidSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMidYMidSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxSlice,
+    kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxSlice,
+    
+    kMCGDrawingPreserveAspectRatioOpcode_Last = kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxSlice,
+};
+
+inline bool MCGDrawingPreserveAspectRatioIsMeet(MCGDrawingPreserveAspectRatioOpcode o)
+{
+    return o >= kMCGDrawingPreserveAspectRatioOpcodeXMinYMinMeet &&
+           o <= kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet;
+}
+
+inline bool MCGDrawingPreserveAspectRatioIsSlice(MCGDrawingPreserveAspectRatioOpcode o)
+{
+    return o >= kMCGDrawingPreserveAspectRatioOpcodeXMinYMinSlice &&
+           o <= kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxSlice;
+}
+
+inline bool MCGDrawingPreserveAspectRatioIsXMid(MCGDrawingPreserveAspectRatioOpcode o)
+{
+    switch(o)
+    {
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMinMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMidMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMinSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMidSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxSlice:
+        return true;
+    default:
+        break;
+    }
+    
+    return false;
+}
+
+inline bool MCGDrawingPreserveAspectRatioIsXMax(MCGDrawingPreserveAspectRatioOpcode o)
+{
+    switch(o)
+    {
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxSlice:
+        return true;
+    default:
+        break;
+    }
+    
+    return false;
+}
+
+inline bool MCGDrawingPreserveAspectRatioIsYMid(MCGDrawingPreserveAspectRatioOpcode o)
+{
+    switch(o)
+    {
+    case kMCGDrawingPreserveAspectRatioOpcodeXMinYMidMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMidMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMinYMidSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMidSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidSlice:
+        return true;
+    default:
+        break;
+    }
+    
+    return false;
+}
+
+inline bool MCGDrawingPreserveAspectRatioIsYMax(MCGDrawingPreserveAspectRatioOpcode o)
+{
+    switch(o)
+    {
+    case kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxSlice:
+    case kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxSlice:
+        return true;
+    default:
+        break;
+    }
+    
+    return false;
+}
+
+/* TRANSFORM OPCODES */
+
+/* MCGDrawingTransformOpcode defines the opcodes used to build a transform. The
+ * sequence of specified transforms is concatenated with the identity transform
+ * to build a transformation matrix. */
+enum MCGDrawingTransformOpcode : uint8_t
+{
+    /* End terminates a sequence of concatenated transforms */
+    kMCGDrawingTransformOpcodeEnd = 0,
+    
+    /* Affine defines a general affine transformation. It is defined by 6
+     * scalars - a b c d tx ty. */
+    kMCGDrawingTransformOpcodeAffine = 1,
+    
+    /* _Last is used for range checking on the transform opcodes. */
+    kMCGDrawingTransformOpcode_Last = kMCGDrawingTransformOpcodeAffine,
+};
+
+/* PAINT OPCODES */
+
+/* MCGDrawingPaintOpcode defines the opcodes used to build a paint. Currently
+ * only a single paint is allowed, but in the future multiple paints will be
+ * allowed (resulting in the shape being drawn with each paint in turn) to
+ * align with that feature in the SVG2 spec. */
+enum MCGDrawingPaintOpcode : uint8_t
+{
+    /* End terminates a sequence of overlaid paints. */
+    kMCGDrawingPaintOpcodeEnd = 0,
+    
+    /* SolidColor defines a solid color paint. It is defined by 3 scalars -
+     * red green blue. */
+    kMCGDrawingPaintOpcodeSolidColor = 1,
+    
+    /* _Last is used for range checking on the paint opcodes. */
+    kMCGDrawingPaintOpcode_Last = kMCGDrawingPaintOpcodeSolidColor,
+};
+
+/* FILL RULE OPCODES */
+
+/* MCGDrawingFillRuleOpcode defines the opcodes used to specify the fill-rule
+ * attribute. */
+enum MCGDrawingFillRuleOpcode : uint8_t
+{
+    /* NonZero indicates that the non-zero winding rule should be used. */
+    kMCGDrawingFillRuleOpcodeNonZero = 0,
+    
+    /* EvenOdd indicates that the even-odd rule should be used. */
+    kMCGDrawingFillRuleOpcodeEvenOdd = 1,
+    
+    /* _Last is used for range checking on the fill rule opcodes. */
+    kMCGDrawingFillRuleOpcode_Last = kMCGDrawingFillRuleOpcodeEvenOdd,
+};
+
+/* LINE JOIN OPCODES */
+
+/* MCGDrawingStrokeLineJoinOpcode defines the opcodes used to specify the
+ * stroke-line-join attribute. */
+enum MCGDrawingStrokeLineJoinOpcode : uint8_t
+{
+    /* Bevel indicates that the bevel line join should be used. A bevel line
+     * join uses a single line segment between the outer points of a join. */
+    kMCGDrawingStrokeLineJoinOpcodeBevel = 0,
+    
+    /* Round indicates that the round line join should be used. A round line
+     * join uses a circular arc between the outer points of a join. */
+    kMCGDrawingStrokeLineJoinOpcodeRound = 1,
+    
+    /* Miter indicates that the miter line join should be used. A miter line
+     * join extends the outer edges of a join so they meet in a point. Miter
+     * joins fallback to a bevel join if the ratio of the angle and size between
+     * them exceeds the miter-limit. */
+    kMCGDrawingStrokeLineJoinOpcodeMiter = 2,
+    
+    /* _Last is used for range checking on the line join opcodes. */
+    kMCGDrawingStrokeLineJoinOpcode_Last = kMCGDrawingStrokeLineJoinOpcodeMiter
+};
+
+/* LINE CAP OPCODES */
+
+/* MCGDrawingStrokeLineCapOpcode defines the opcodes used to specify the
+ * stroke-line-cap attribute. */
+enum MCGDrawingStrokeLineCapOpcode : uint8_t
+{
+    /* Butt indicates that the butt line cap should be used. A butt line cap
+     * adds no cap to the ends of stroked lines. */
+    kMCGDrawingStrokeLineCapOpcodeButt = 0,
+    
+    /* Round indicates that the round line cap should be used. A round line cap
+     * adds a half circle of diameter the stroke width to the ends of stroked
+     * lines. */
+    kMCGDrawingStrokeLineCapOpcodeRound = 1,
+    
+    /* Square indicates that the square line cap should be used. A square line
+     * cap adds a half square of size the stroke width to the ends of stroked
+     * lines. */
+    kMCGDrawingStrokeLineCapOpcodeSquare = 2,
+    
+    /* _Last is used for range checking on the line cap opcodes. */
+    kMCGDrawingStrokeLineCapOpcode_Last = kMCGDrawingStrokeLineCapOpcodeSquare
+};
+
+/* PATH OPCODES */
+
+/* MGDrawingPathOpcodes defines the opcodes used to specify a path shape. */
+enum MCGDrawingPathOpcode : uint8_t
+{
+    /* End terminates a path definition. */
+    kMCGDrawingPathOpcodeEnd = 0,
+    
+    kMCGDrawingPathOpcodeMoveTo = 1,
+    kMCGDrawingPathOpcodeRelativeMoveTo = 2,
+    kMCGDrawingPathOpcodeLineTo = 3,
+    kMCGDrawingPathOpcodeRelativeLineTo = 4,
+    kMCGDrawingPathOpcodeHorizontalTo = 5,
+    kMCGDrawingPathOpcodeRelativeHorizontalTo = 6,
+    kMCGDrawingPathOpcodeVerticalTo = 7,
+    kMCGDrawingPathOpcodeRelativeVerticalTo = 8,
+    kMCGDrawingPathOpcodeCubicTo = 9,
+    kMCGDrawingPathOpcodeRelativeCubicTo = 10,
+    kMCGDrawingPathOpcodeSmoothCubicTo = 11,
+    kMCGDrawingPathOpcodeRelativeSmoothCubicTo = 12,
+    kMCGDrawingPathOpcodeQuadraticTo= 13,
+    kMCGDrawingPathOpcodeRelativeQuadraticTo = 14,
+    kMCGDrawingPathOpcodeSmoothQuadraticTo = 15,
+    kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo = 16,
+    kMCGDrawingPathOpcodeArcTo = 17,
+    kMCGDrawingPathOpcodeRelativeArcTo = 18,
+    kMCGDrawingPathOpcodeReflexArcTo = 19,
+    kMCGDrawingPathOpcodeRelativeReflexArcTo = 20,
+    kMCGDrawingPathOpcodeReverseArcTo = 21,
+    kMCGDrawingPathOpcodeRelativeReverseArcTo = 22,
+    kMCGDrawingPathOpcodeReverseReflexArcTo = 23,
+    kMCGDrawingPathOpcodeRelativeReverseReflexArcTo = 24,
+    kMCGDrawingPathOpcodeCloseSubpath = 25,
+    kMCGDrawingPathOpcodeBearing = 26,
+    
+    kMCGDrawingPathOpcode_Last = kMCGDrawingPathOpcodeBearing,
+};
+
+inline bool MCGDrawingPathOpcodeIsRelativeArc(MCGDrawingPathOpcode p_opcode)
+{
+    switch(p_opcode)
+    {
+    case kMCGDrawingPathOpcodeRelativeArcTo:
+    case kMCGDrawingPathOpcodeRelativeReflexArcTo:
+    case kMCGDrawingPathOpcodeRelativeReverseArcTo:
+    case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+inline bool MCGDrawingPathOpcodeIsReflexArc(MCGDrawingPathOpcode p_opcode)
+{
+    switch(p_opcode)
+    {
+    case kMCGDrawingPathOpcodeReflexArcTo:
+    case kMCGDrawingPathOpcodeRelativeReflexArcTo:
+    case kMCGDrawingPathOpcodeReverseReflexArcTo:
+    case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+inline bool MCGDrawingPathOpcodeIsReverseArc(MCGDrawingPathOpcode p_opcode)
+{
+    switch(p_opcode)
+    {
+    case kMCGDrawingPathOpcodeReverseArcTo:
+    case kMCGDrawingPathOpcodeRelativeReverseArcTo:
+    case kMCGDrawingPathOpcodeReverseReflexArcTo:
+    case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+/**/
+
+struct MCGDrawingVisitor
+{
+    void TransformBegin(void);
+    void TransformAffine(MCGFloat a, MCGFloat b, MCGFloat c, MCGFloat d, MCGFloat tx, MCGFloat ty);
+    void TransformViewport(MCGFloat min_x, MCGFloat min_y, MCGFloat width, MCGFloat height, MCGDrawingPreserveAspectRatioOpcode par);
+    void TransformEnd(void);
+    
+    void PaintBegin(bool is_stroke);
+    void PaintNone(void);
+    void PaintSolidColor(MCGFloat red, MCGFloat green, MCGFloat blue);
+    void PaintEnd(void);
+    
+    void PathBegin(void);
+    void PathMoveTo(bool is_relative, MCGFloat x, MCGFloat y);
+    void PathLineTo(bool is_relative, MCGFloat x, MCGFloat y);
+    void PathHorizontalTo(bool is_relative, MCGFloat x);
+    void PathVerticalTo(bool is_relative, MCGFloat y);
+    void PathCubicTo(bool is_relative, MCGFloat ax, MCGFloat ay, MCGFloat bx, MCGFloat by, MCGFloat x, MCGFloat y);
+    void PathSmoothCubicTo(bool is_relative, MCGFloat bx, MCGFloat by, MCGFloat x, MCGFloat y);
+    void PathQuadraticTo(bool is_relative, MCGFloat ax, MCGFloat ay, MCGFloat x, MCGFloat y);
+    void PathSmoothQuadraticTo(bool is_relative, MCGFloat x, MCGFloat y);
+    void PathArcTo(bool is_relative, bool is_reflex, bool is_reverse, MCGFloat cx, MCGFloat cy, MCGFloat rotation, MCGFloat x, MCGFloat y);
+    void PathCloseSubpath(void);
+    void PathBearing(MCGFloat angle);
+    void PathEnd(void);
+    
+    void FillOpacity(MCGFloat opacity);
+    void FillRule(MCGFillRule fill_rule);
+    
+    void StrokeOpacity(MCGFloat opacity);
+    void StrokeWidth(MCGFloat width);
+    void StrokeLineJoin(MCGJoinStyle join_style);
+    void StrokeLineCap(MCGCapStyle cap_style);
+    void StrokeDashArray(size_t count, const MCGFloat* lengths);
+    void StrokeDashOffset(MCGFloat offset);
+    void StrokeMiterLimit(MCGFloat miter_limit);
+    
+    void Rectangle(MCGFloat x, MCGFloat y, MCGFloat width, MCGFloat height, MCGFloat rx, MCGFloat ry);
+    void Circle(MCGFloat cx, MCGFloat cy, MCGFloat r);
+    void Ellipse(MCGFloat cx, MCGFloat cy, MCGFloat rx, MCGFloat ry);
+    void Line(MCGFloat x1, MCGFloat y1, MCGFloat x2, MCGFloat y2);
+    void Polyline(size_t count, const MCGFloat* coordinates);
+    void Polygon(size_t count, const MCGFloat* coordinates);
+};
+
+/* DRAWING CONTEXT */
+
+/* MCGDrawingStatus is used to indicate the current status of playback of a
+ * drawing. */
+enum MCGDrawingStatus
+{
+    /* None indicates that there are no problems with the drawing so far. */
+    kMCGDrawingStatusNone,
+    
+    /* InvalidDrawing indicates that the drawing data is malformed and cannot
+     * be unpacked. */
+    kMCGDrawingStatusInvalidDrawing,
+    
+    /* InvalidIdent indicates that the 3 main ident bytes do not match 'LCD'. */
+    kMCGDrawingStatusInvalidIdent,
+    
+    /* InvalidVersion indicates that the version is not recognised. */
+    kMCGDrawingStatusInvalidVersion,
+    
+    /* InvalidFlags indicates that flags which are not defined have been set. */
+    kMCGDrawingStatusInvalidFlags,
+    
+    /* InvalidWidth indicates that the width scalar could not be unpacked. */
+    kMCGDrawingStatusInvalidWidth,
+    
+    /* InvalidHeight indicates that the height scalar could not be unpacked. */
+    kMCGDrawingStatusInvalidHeight,
+    
+    /* InvalidViewport indicates that the viewport (viewBox and preserveAspectRatio)
+     * could not be unpacked. */
+    kMCGDrawingStatusInvalidViewport,
+    
+    /* ScalarOverflow indicates that more scalars are required than are present.
+     */
+    kMCGDrawingStatusScalarOverflow,
+    
+    /* OpcodeOverflow indicates that more opcodes are required than are present.
+     */
+    kMCGDrawingStatusOpcodeOverflow,
+    
+    /* InvalidOpcode indicates that an undefined main opcode has been
+     * encountered. */
+    kMCGDrawingStatusInvalidOpcode,
+    
+    /* InvalidPathOpcode indicates that an undefined path opcode has been
+     * encountered. */
+    kMCGDrawingStatusInvalidPathOpcode
+    ,
+    /* InvalidPaintOpcode indicates that an undefined paint opcode has been
+     * encountered. */
+    kMCGDrawingStatusInvalidPaintOpcode,
+    
+    /* InvalidTransformOpcode indicates that an undefined transform opcode has
+     * been encountered. */
+    kMCGDrawingStatusInvalidTransformOpcode,
+    
+    /* InvalidFillRuleOpcode indicates that an undefined fill rule opcode has
+     * been encountered. */
+    kMCGDrawingStatusInvalidFillRuleOpcode,
+    
+    /* InvalidStrokeLineJoinOpcode indicates that an undefined line join opcode
+     * has been encountered. */
+    kMCGDrawingStatusInvalidStrokeLineJoinOpcode,
+    
+    /* InvalidStrokeLineCapOpcode indicates that an undefined line cap opcode
+     * has been encountered. */
+    kMCGDrawingStatusInvalidStrokeLineCapOpcode,
+    
+    /* InvalidPreserveAspectRatioOpcode indicates that an undefined preserve
+     * aspect ratio opcode has been encountered. */
+    kMCGDrawingStatusInvalidPreserveAspectRatioOpcode,
+    
+    /* InvalidPointArray indicates that a point array with an odd number of
+     * scalars has been encountered. */
+    kMCGDrawingStatusInvalidPointArray,
+};
+
+/* MCGDrawingByteStream is a simple class which wraps a byte array, allowing
+ * decoding of individual and sequences of specific types. It is used to unpack
+ * the drawing header. */
+class MCGDrawingByteStream
+{
+public:
+    MCGDrawingByteStream(const void *p_bytes, size_t p_byte_count)
+        : m_bytes(p_bytes),
+          m_byte_count(p_byte_count)
+    {
+    }
+
+    /* Returns true if there are no more bytes to process. */
+    bool IsFinished(void) const
+    {
+        return m_byte_count == 0;
+    }
+
+    /* Singleton attempts to unpack a single field of type T. It returns true
+     * if successful, or false if there are not enough bytes (sizeof(T)). */
+    template<typename T>
+    bool Singleton(T& r_singleton)
+    {
+        size_t t_singleton_size = sizeof(T);
+        
+        if (m_byte_count < t_singleton_size)
+        {
+            return false;
+        }
+        
+        auto t_singleton_ptr = static_cast<const T *>(m_bytes);
+        r_singleton = *t_singleton_ptr;
+        
+        m_bytes = t_singleton_ptr + 1;
+        m_byte_count -= t_singleton_size;
+        
+        return true;
+    }
+    
+    /* Array attempts to unpack p_count fields of type T. It returns true if
+     * successful, or false if there are not enough bytes (sizeof(T) * p_count).
+     */
+    template<typename T>
+    bool Sequence(size_t p_count, T*& r_seq)
+    {
+        size_t t_seq_size = p_count * sizeof(T);
+        
+        if (m_byte_count < t_seq_size)
+        {
+            return false;
+        }
+        
+        auto t_seq_ptr = static_cast<const T *>(m_bytes);
+        r_seq = t_seq_ptr;
+        
+        m_bytes = t_seq_ptr + p_count;
+        m_byte_count -= t_seq_size;
+        
+        return true;
+    }
+
+private:
+    const void *m_bytes;
+    size_t m_byte_count;
+};
+
+/* MCGDrawingContext is a class which implements a visitor pattern over a
+ * drawing. It unpacks the header on construction, and then allows execution
+ * of the drawing by calling 'Execute' and passing a suitably defined Visitor
+ * type. */
+class MCGDrawingContext
+{
+public:
+    /* MCGDrawingContext is the main constructor. It attempts to unpack the
+     * drawing header, and sets up for main execution. If an error occurs
+     * with setting up, the status field is set appropriately. */
+    MCGDrawingContext(const void *p_drawing_bytes, size_t p_drawing_byte_count)
+    {
+        MCGDrawingByteStream t_stream(p_drawing_bytes, p_drawing_byte_count);
+        
+        /* Unpack the header. If the size of the provided data does not match
+         * what is expected by unpacking the data, then it is an
+         * 'InvalidDrawing' */
+        uint8_t t_ident_0, t_ident_1, t_ident_2, t_ident_version;
+        uint32_t t_flags;
+        if (!t_stream.Singleton(t_ident_0) ||
+            !t_stream.Singleton(t_ident_1) ||
+            !t_stream.Singleton(t_ident_2) ||
+            !t_stream.Singleton(t_ident_version) ||
+            !t_stream.Singleton(t_flags) ||
+            !t_stream.Singleton(m_scalar_count) ||
+            !t_stream.Sequence(m_scalar_count, m_scalars) ||
+            !t_stream.Singleton(m_opcode_count) ||
+            !t_stream.Sequence(m_opcode_count, m_opcodes) ||
+            !t_stream.IsFinished())
+        {
+            m_status = kMCGDrawingStatusInvalidDrawing;
+            return;
+        }
+        
+        /* Check the ident field is correct. */
+        if (t_ident_0 != kMCGDrawingIdent0 ||
+            t_ident_1 != kMCGDrawingIdent1 ||
+            t_ident_2 != kMCGDrawingIdent2)
+        {
+            m_status = kMCGDrawingStatusInvalidIdent;
+            return;
+        }
+        
+        /* Check the version field is correct. */
+        if (t_ident_version != kMCGDrawingVersion)
+        {
+            m_status = kMCGDrawingStatusInvalidVersion;
+            return;
+        }
+        
+        /* Check the flags field is correct. */
+        if ((t_flags & ~kMCGDrawingHeaderFlagValidMask) != 0)
+        {
+            m_status = kMCGDrawingStatusInvalidFlags;
+            return;
+        }
+        
+        /* Process the width, if present. If the width is not present, then
+         * it is taken to be '100%' (-1). */
+        if ((t_flags & kMCGDrawingHeaderFlagHasWidthBit) != 0)
+        {
+            if (!Scalar(m_width))
+            {
+                m_status = kMCGDrawingStatusInvalidWidth;
+                return;
+            }
+        }
+        
+        /* Process the height, if present. If the height is not present, then
+         * it is taken to be '100%' (-1). */
+        if ((t_flags & kMCGDrawingHeaderFlagHasHeightBit) != 0)
+        {
+            if (!Scalar(m_height))
+            {
+                m_status = kMCGDrawingStatusInvalidHeight;
+                return;
+            }
+        }
+        
+        /* Process the viewport, if present. */
+        if ((t_flags & kMCGDrawingHeaderFlagHasViewportBit) != 0)
+        {
+            if (!Rectangle(m_viewbox) ||
+                !PreserveAspectRatioOpcode(m_preserve_aspect_ratio))
+            {
+                m_status = kMCGDrawingStatusInvalidViewport;
+                return;
+            }
+            
+            m_has_viewport = true;
+        }
+    }
+    
+    /* IsRunning() returns true if the execution has encountered no problems.
+     */
+    bool IsRunning(void) const
+    {
+        return m_status == kMCGDrawingStatusNone;
+    }
+    
+    /* Opcode attempts to read the next opcode as a main opcode. */
+    bool Opcode(MCGDrawingOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingOpcode,
+                             kMCGDrawingOpcode_Last,
+                             kMCGDrawingStatusInvalidOpcode>(r_opcode);
+    }
+    
+    /* TransformOpcode attempts to read the next opcode as a transform opcode. */
+    bool TransformOpcode(MCGDrawingTransformOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingTransformOpcode,
+                             kMCGDrawingTransformOpcode_Last,
+                             kMCGDrawingStatusInvalidTransformOpcode>(r_opcode);
+    }
+    
+    /* PaintOpcode attempts to read the next opcode as a paint opcode. */
+    bool PaintOpcode(MCGDrawingPaintOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingPaintOpcode,
+                             kMCGDrawingPaintOpcode_Last,
+                             kMCGDrawingStatusInvalidPaintOpcode>(r_opcode);
+    }
+    
+    /* PathOpcode attempts to read the next opcode as a path opcode. */
+    bool PathOpcode(MCGDrawingPathOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingPathOpcode,
+                             kMCGDrawingPathOpcode_Last,
+                             kMCGDrawingStatusInvalidPathOpcode>(r_opcode);
+    }
+    
+    /* FillRuleOpcode attempts to read the next opcode as a fill rule opcode. */
+    bool FillRuleOpcode(MCGDrawingFillRuleOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingFillRuleOpcode,
+                             kMCGDrawingFillRuleOpcode_Last,
+                             kMCGDrawingStatusInvalidFillRuleOpcode>(r_opcode);
+    }
+    
+    /* StrokeLineJoin attempts to read the next opcode as a line join opcode. */
+    bool StrokeLineJoinOpcode(MCGDrawingStrokeLineJoinOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingStrokeLineJoinOpcode,
+                             kMCGDrawingStrokeLineJoinOpcode_Last,
+                             kMCGDrawingStatusInvalidStrokeLineJoinOpcode>(r_opcode);
+    }
+    
+    /* StrokeLineCape attempts to read the next opcode as a line cap opcode. */
+    bool StrokeLineCapOpcode(MCGDrawingStrokeLineCapOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingStrokeLineCapOpcode,
+                             kMCGDrawingStrokeLineCapOpcode_Last,
+                             kMCGDrawingStatusInvalidStrokeLineCapOpcode>(r_opcode);
+    }
+    
+    /* PreserveAspectRatioOpcode attempts to read the next opcode as a 
+     * preserve aspect ratio opcode. */
+    bool PreserveAspectRatioOpcode(MCGDrawingPreserveAspectRatioOpcode& r_opcode)
+    {
+        return GeneralOpcode<MCGDrawingPreserveAspectRatioOpcode,
+                             kMCGDrawingPreserveAspectRatioOpcode_Last,
+                             kMCGDrawingStatusInvalidPreserveAspectRatioOpcode>(r_opcode);
+    }
+    
+    /* Count attempts to read an non-negative integer from the opcode stream.
+     * Non-negative integers are encoded as a sequence of bytes, most
+     * significant byte first. The top bit of each byte is used to indicate
+     * whether there is another following. */
+    bool Count(size_t& r_count)
+    {
+        /* Start the read count at zero, each byte will be accumulated into it
+         */
+        size_t t_count = 0;
+    
+        /* Opcode bytes are processed until we reach a termination condition. */
+        for(;;)
+        {
+            /* If the end of the opcode stream is reached, then indicate 
+             * overflow. */
+            if (m_pc == m_opcode_count)
+            {
+                m_status = kMCGDrawingStatusOpcodeOverflow;
+                return false;
+            }
+            
+            /* Fetch the next limb of the integer and increment the pc. */
+            uint8_t t_next_limb = m_opcodes[m_pc++];
+            
+            /* Accumulate the limb into the current count, making sure to mask
+             * out the top bit of the limb. */
+            t_count = (t_count << 8) | (t_next_limb & 0x7f);
+            
+            /* If the top bit of the limb is zero, then the integer is complete.
+             */
+            if ((t_next_limb & 0x40) == 0)
+            {
+                break;
+            }
+        }
+    
+        /* Return the accumulated integer. */
+        r_count = t_count;
+    
+        return true;
+    }
+    
+    /* Scalar attempts to read the next scalar from the scalar stream. If the
+     * end of the scalar stream has been reached, ScalarOverflow is indicated
+     * and false is returned. Otherwise, the next scalar is placed in r_scalar
+     * and true is returned. */
+    bool Scalar(MCGFloat& r_scalar)
+    {
+        /* If the scalar counter is at the end of the scalar stream, then
+         * indicate ScalarOverflow and return false. */
+        if (m_sc == m_scalar_count)
+        {
+            m_status = kMCGDrawingStatusScalarOverflow;
+            return false;
+        }
+        
+        /* Place the next scalar in r_scalar and increment the scalar counter. */
+        r_scalar = m_scalars[m_sc++];
+        
+        return true;
+    }
+    
+    /* Scalars attempts to read p_count scalars from the scalar stream. If there
+     * are not enough scalars left then ScalarOverflow is indicated and false is
+     * returned. Otherwise, the pointer to the base of the scalars is returned
+     * in r_scalars and true is returned. */
+    bool Scalars(size_t p_count, const MCGFloat*& r_scalars)
+    {
+        /* If there are not enough scalars left to satisfy the request then
+         * indicate ScalarOverflow and return false. */
+        if (m_sc + p_count > m_scalar_count)
+        {
+            m_status = kMCGDrawingStatusScalarOverflow;
+            return false;
+        }
+        
+        /* Place the base of the scalar array in r_scalars. */
+        r_scalars = m_scalars + m_sc;
+        
+        /* Increment the scalar counter */
+        m_sc += p_count;
+        
+        return true;
+    }
+    
+    /* LengthScalars attempts to read p_count length scalars - a length scalar
+     * is non-negative scalar. */
+    bool LengthScalars(size_t p_count, const MCGFloat*& r_scalars)
+    {
+        return Scalars(p_count, r_scalars);
+    }
+    
+    /* CoordinateScalars attempts to read p_count coordinate scalars. */
+    bool CoordinateScalars(size_t p_count, const MCGFloat*& r_scalars)
+    {
+        return Scalars(p_count, r_scalars);
+    }
+    
+    /* Coordinate scalar attempte to read a single coordinate scalar. */
+    bool CoordinateScalar(MCGFloat& r_coord_scalar)
+    {
+        return Scalar(r_coord_scalar);
+    }
+    
+    /* UnitScalar attempts to read a single unit scalar - a unit scalar is a
+     * scalar in the range [0, 1]. */
+    bool UnitScalar(MCGFloat& r_unit_scalar)
+    {
+        return Scalar(r_unit_scalar);
+    }
+    
+    /* LengthScalar attempts to read a single length scalar. */
+    bool LengthScalar(MCGFloat& r_length_scalar)
+    {
+        return Scalar(r_length_scalar);
+    }
+    
+    /* PositiveScalar attempts to read a single positive scalar - a positive
+     * scalar is a scalar in the range [1, +inf). */
+    bool PositiveScalar(MCGFloat& r_positive_scalar)
+    {
+        return Scalar(r_positive_scalar);
+    }
+    
+    /* AngleScalar attempts to read a single angle scalar. */
+    bool AngleScalar(MCGFloat& r_angle_scalar)
+    {
+        return Scalar(r_angle_scalar);
+    }
+    
+    /* Rectangle attempts to read a rectangle defined as four scalars - x, y
+     * width, height. */
+    bool Rectangle(MCGRectangle& r_rect)
+    {
+        if (!CoordinateScalar(r_rect.origin.x) ||
+            !CoordinateScalar(r_rect.origin.y) ||
+            !LengthScalar(r_rect.size.width) ||
+            !LengthScalar(r_rect.size.height))
+        {
+            return false;
+        }
+        return true;
+    }
+    
+    /* LengthArray attempts to read an array of scalars, using a count fetched
+     * from the opcode stream. */
+    bool LengthArray(size_t& r_count, const MCGFloat*& r_lengths)
+    {
+        if (!Count(r_count))
+        {
+            return false;
+        }
+        
+        if (!Scalars(r_count, r_lengths))
+        {
+            return false;
+        }
+        
+        return true;
+    }
+    
+    /* PointArray attempts to read an array of coordinate scalar pairs, using
+     * a count fetched from the opcode stream. Currently the count encoded in
+     * the opcode stream indicates the number of scalars, not points. If the
+     * fetched count is odd, then InvalidPointArray is indicated and false is
+     * returned. */
+    bool PointArray(size_t& r_point_count, const MCGPoint*& r_points)
+    {
+        /* Read the number of scalars to expect from the opcode stream. */
+        size_t t_scalar_count;
+        if (!Count(t_scalar_count))
+        {
+            return false;
+        }
+        
+        /* Check that the count is even. */
+        if (t_scalar_count % 2 != 0)
+        {
+            m_status = kMCGDrawingStatusInvalidPointArray;
+            return false;
+        }
+        
+        /* Fetch t_scalar_count scalars from the scalar stream. */
+        const MCGFloat* t_scalars;
+        if (!CoordinateScalars(t_scalar_count, t_scalars))
+        {
+            return false;
+        }
+        
+        /* The number of points is half the number of scalars. */
+        r_point_count = t_scalar_count / 2;
+        
+        /* MCGPoint is a pair of scalars, so use a reinterpret cast to change
+         * the view of the scalars to MCGPoints. */
+        r_points = reinterpret_cast<const MCGPoint*>(t_scalars);
+        
+        return true;
+    }
+    
+    /* Execute runs the drawing program using VisitorT to perform the
+     * operations. The rect into which the drawing should be 'rendered' is
+     * indicated in p_dst_rect. */
+    template<typename VisitorT>
+    void Execute(VisitorT& visitor, MCGRectangle p_dst_rect);
+    
+private:
+     /* GeneralOpcode reads the next opcode from the opcode stream. If there is
+     * no opcode then OpcodeOverflow is flagged and false is returned. The
+     * retrieved opcode is checked to ensure it is defined (that is bounded by
+     * LastV) and if it is not, then StatusV is flagged and false is returned.
+     * Otherwise, the opcode is placed in r_opcode and true is returned. */
+    template<typename T, T LastV, MCGDrawingStatus StatusV>
+    bool GeneralOpcode(T& r_opcode)
+    {
+        /* If the program counter is at the end of the opcode stream, then there
+         * is no opcode to fetch, so flag Overflow. */
+        if (m_pc == m_opcode_count)
+        {
+            m_status = kMCGDrawingStatusOpcodeOverflow;
+            return false;
+        }
+        
+        /* Fetch the next opcode as opcode type T and advance the program
+         * counter by one. */
+        T t_opcode = T(m_opcodes[m_pc++]);
+        
+        /* Check that the opcode is in bounds for the opcode type. */
+        if (t_opcode > LastV)
+        {
+            m_status = StatusV;
+            return false;
+        }
+        
+        r_opcode = t_opcode;
+        
+        return true;
+    }
+
+    /* ExecuteTransform runs a transform opcode stream into the provided
+     * visitor. */
+    template<typename VisitorT>
+    void ExecuteTransform(VisitorT& visitor);
+    
+    /* ExecutePaint runs a paint opcode stream into the provided
+     * visitor. */
+    template<typename VisitorT>
+    void ExecutePaint(VisitorT& visitor, bool is_stroke);
+    
+    /* ExecutePath runs a path opcode stream into the provided
+     * visitor. */
+    template<typename VisitorT>
+    void ExecutePath(VisitorT& visitor);
+     
+    /**/
+    
+    /* m_status indicates the current state of the context. If this is not
+     * None, then an error has occured. */
+    MCGDrawingStatus m_status = kMCGDrawingStatusNone;
+    
+    /* m_pc indicates the current position in the opcode stream. */
+    uindex_t m_pc = 0;
+    
+    /* m_sc indicates the current position in the scalar stream. */
+    uindex_t m_sc = 0;
+    
+    /* m_opcodes / m_opcode_count define the (const) array of opcodes which are
+     * defined by the drawing. */
+    const byte_t *m_opcodes = nullptr;
+    uindex_t m_opcode_count = 0;
+    
+    /* m_scalars / m_scalar_count define the (const) array of scalars which are
+     * defined by the drawing. */
+    const MCGFloat *m_scalars = nullptr;
+    uindex_t m_scalar_count = 0;
+    
+    /* m_width is the unpacked width field from the drawing. This is initialized
+     * on construction of the context. */
+    MCGFloat m_width = -1.0f;
+    
+    /* m_height is the unpacked height field from the drawing. This is initialized
+     * on construction of the context. */
+    MCGFloat m_height = -1.0f;
+    
+    /* m_has_viewport is true if the drawing defined a viewport in the header.
+     * This is initialized on construction of the context. */
+    bool m_has_viewport = false;
+    
+    /* m_viewbox is the unpacked viewbox field from the drawing. This is
+     * initialized on construction of the context. */
+    MCGRectangle m_viewbox = {};
+    
+    /* m_preserve_aspect_ratio is the unpacked preserve aspect ratio field from
+     * the drawing. This is initialized on construction of the context. */
+    MCGDrawingPreserveAspectRatioOpcode m_preserve_aspect_ratio = kMCGDrawingPreserveAspectRatioOpcodeNone;
+};
+
+/* The (template based) implementation of the Execute method. */
+template<typename VisitorT>
+void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_dst_rect)
+{
+    /* If the drawing's width is negative, then it means the width of the
+     * drawing was specified as a percentage (represented as a scalar in the
+     * range [-1, 0)) of the requested destination rectangle width. Otherwise
+     * the width is absolute. */
+    if (m_width < 0)
+    {
+        p_dst_rect.size.width *= -m_width;
+    }
+    else
+    {
+        p_dst_rect.size.width = m_width;
+    }
+    
+    /* If the drawing's height is negative, then it means the height of the
+     * drawing was specified as a percentage (represented as a scalar in the
+     * range [-1, 0)) of the requested destination rectangle height. Otherwise
+     * the height is absolute. */
+    if (m_height < 0)
+    {
+        p_dst_rect.size.height *= -m_height;
+    }
+    else
+    {
+        p_dst_rect.size.height = m_height;
+    }
+    
+    /* Start the visitor, passing in the destination rectangle and viewport
+     * details so it can configure an initial transform. */
+    p_visitor.Start(p_dst_rect, m_has_viewport ? &m_viewbox : nullptr, m_preserve_aspect_ratio);
+    
+    /* Loop until the status ceases to be None. */
+    while(m_status == kMCGDrawingStatusNone)
+    {
+        /* Fetch the next (main) opcode. */
+        MCGDrawingOpcode t_opcode;
+        if (!Opcode(t_opcode))
+        {
+            break;
+        }
+        
+        /* If End is encountered, then the drawing is finished so break. */
+        if (t_opcode == kMCGDrawingOpcodeEnd)
+        {
+            break;
+        }
+        
+        /* Dispatch to the appropriate method for each opcode. */
+        switch(t_opcode)
+        {
+            /* End has already been handled, so this shouldn't happen. */
+            case kMCGDrawingOpcodeEnd:
+            {
+                MCUnreachable();
+            }
+            break;
+               
+            /* Transform opcodes require executing a transform opcode stream. */
+            case kMCGDrawingOpcodeTransform:
+            {
+                ExecuteTransform(p_visitor);
+            }
+            break;
+            
+            /* FillPaint / StrokePaint require executing a paint opcode stream.
+             * The attribute to apply is passed to the visitor after the paint
+             * has been executed. */
+            case kMCGDrawingOpcodeFillPaint:
+            case kMCGDrawingOpcodeStrokePaint:
+            {
+                ExecutePaint(p_visitor, t_opcode == kMCGDrawingOpcodeStrokePaint);
+            }
+            break;
+                
+            /* FillOpacity / StrokeOpacity set the corresponding attribute. */
+            case kMCGDrawingOpcodeFillOpacity:
+            case kMCGDrawingOpcodeStrokeOpacity:
+            {
+                /* Fetch the requested opacity as a unit scalar. */
+                MCGFloat t_opacity;
+                if (!UnitScalar(t_opacity))
+                {
+                    break;
+                }
+                
+                /* Visit the appropriate method depending on which opcode was
+                 * encountered. */
+                if (t_opcode == kMCGDrawingOpcodeFillOpacity)
+                {
+                    p_visitor.FillOpacity(t_opacity);
+                }
+                else
+                {
+                    p_visitor.StrokeOpacity(t_opacity);
+                }
+            }
+            break;
+            
+            /* FillRule visits the FillRule method of the visitor. */
+            case kMCGDrawingOpcodeFillRule:
+            {
+                /* Fetch the fill rule opcode to apply. */
+                MCGDrawingFillRuleOpcode t_fill_rule_opcode;
+                if (!FillRuleOpcode(t_fill_rule_opcode))
+                {
+                    break;
+                }
+                
+                /* Determine the fill rule type from the opcode. */
+                MCGFillRule t_fill_rule;
+                switch(t_fill_rule_opcode)
+                {
+                    case kMCGDrawingFillRuleOpcodeNonZero:
+                        t_fill_rule = kMCGFillRuleNonZero;
+                        break;
+                    case kMCGDrawingFillRuleOpcodeEvenOdd:
+                        t_fill_rule = kMCGFillRuleEvenOdd;
+                        break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.FillRule(t_fill_rule);
+            }    
+            break;
+            
+            /* StrokeWidth visits the StrokeWidth method of the visitor. */
+            case kMCGDrawingOpcodeStrokeWidth:
+            {
+                /* Fetch the requested width as a length scalar. */
+                MCGFloat t_width;
+                if (!LengthScalar(t_width))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.StrokeWidth(t_width);
+            }
+            break;
+            
+            /* StrokeLineJoin visits the StrokeLineJoin method of the visitor. */
+            case kMCGDrawingOpcodeStrokeLineJoin:
+            {
+                /* Fetch the requested line join as a LineJoin opcode. */
+                MCGDrawingStrokeLineJoinOpcode t_line_join_opcode;
+                if (!StrokeLineJoinOpcode(t_line_join_opcode))
+                {
+                    break;
+                }
+                
+                /* Determine the join style from the opcode. */
+                MCGJoinStyle t_join_style;
+                switch(t_line_join_opcode)
+                {
+                    case kMCGDrawingStrokeLineJoinOpcodeBevel:
+                        t_join_style = kMCGJoinStyleBevel;
+                        break;
+                    case kMCGDrawingStrokeLineJoinOpcodeRound:
+                        t_join_style = kMCGJoinStyleRound;
+                        break;
+                    case kMCGDrawingStrokeLineJoinOpcodeMiter:
+                        t_join_style = kMCGJoinStyleMiter;
+                        break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.StrokeLineJoin(t_join_style);
+            }    
+            break;
+                
+            /* StrokeLineCap visits the StrokeLineCap method of the visitor. */
+            case kMCGDrawingOpcodeStrokeLineCap:
+            {
+                /* Fetch the requested line cap as a LineCapOpcode. */
+                MCGDrawingStrokeLineCapOpcode t_line_cap_opcode;
+                if (!StrokeLineCapOpcode(t_line_cap_opcode))
+                {
+                    break;
+                }
+                
+                /* Determine the cap style from the opcode. */
+                MCGCapStyle t_cap_style;
+                switch(t_line_cap_opcode)
+                {
+                    case kMCGDrawingStrokeLineCapOpcodeButt:
+                        t_cap_style = kMCGCapStyleButt;
+                        break;
+                    case kMCGDrawingStrokeLineCapOpcodeRound:
+                        t_cap_style = kMCGCapStyleRound;
+                        break;
+                    case kMCGDrawingStrokeLineCapOpcodeSquare:
+                        t_cap_style = kMCGCapStyleSquare;
+                        break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.StrokeLineCap(t_cap_style);
+            }    
+            break;
+                
+            /* StrokeDashArray visits the StrokeDashArray method of the visitor.
+             */
+            case kMCGDrawingOpcodeStrokeDashArray:
+            {
+                /* Fetch the requested dash array as a length array (the count
+                 * is encoded in the opcode stream). */
+                size_t t_length_count;
+                const MCGFloat* t_lengths;
+                if (!LengthArray(t_length_count, t_lengths))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.StrokeDashArray(t_length_count, t_lengths);
+            }
+            break;
+            
+            /* StrokeDashOffset visits the StrokeDashOffset method of the
+             * visitor. */
+            case kMCGDrawingOpcodeStrokeDashOffset:
+            {
+                /* Fetch the requested dash offset as a length scalar. */
+                MCGFloat t_offset;
+                if (!LengthScalar(t_offset))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.StrokeDashOffset(t_offset);
+            }
+            break;
+                
+            /* StrokeMiterLimit visits the StrokeMiterLimit method of the
+             * visitor. */
+            case kMCGDrawingOpcodeStrokeMiterLimit:
+            {
+                /* Fetch the requested miter limit as a positive scalar. */
+                MCGFloat t_miter_limit;
+                if (!PositiveScalar(t_miter_limit))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.StrokeMiterLimit(t_miter_limit);
+            }
+            break;
+            
+            /* Rectangle visits the Rectangle method of the visitor. */
+            case kMCGDrawingOpcodeRectangle:
+            {
+                /* Fetch the requested (rounded) rectangle's geometry. The
+                 * geometry is encoded as scalars:
+                 *   x, y : coordinate scalars
+                 *   width, height : length scalars
+                 *   rx, ry : length scalars
+                 */
+                MCGFloat t_x, t_y, t_width, t_height, t_rx, t_ry;
+                if (!CoordinateScalar(t_x) || !CoordinateScalar(t_y) ||
+                    !LengthScalar(t_width) || !LengthScalar(t_height) ||
+                    !LengthScalar(t_rx) || !LengthScalar(t_ry))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.Rectangle(t_x, t_y, t_width, t_height, t_rx, t_ry);
+            }
+            break;
+                
+            /* Circle visits the Circle method of the visitor. */
+            case kMCGDrawingOpcodeCircle:
+            {
+                /* Fetch the requested circle's geometry. The geometry is
+                 * encoded as scalars:
+                 *   cx, cy : coordinate scalars
+                 *   r : length scalar
+                 */
+                MCGFloat t_cx, t_cy, t_r;
+                if (!CoordinateScalar(t_cx) || !CoordinateScalar(t_cy) ||
+                    !LengthScalar(t_r))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.Circle(t_cx, t_cy, t_r);
+            }
+            break;
+            
+            /* Ellipse visits the Ellipse method of the visitor. */
+            case kMCGDrawingOpcodeEllipse:
+            {
+                /* Fetch the requested ellipse's geometry. The geometry is
+                 * encoded as scalars:
+                 *   cx, cy : coordinate scalars
+                 *   rx, ry : length scalars
+                 */
+                MCGFloat t_cx, t_cy, t_rx, t_ry;
+                if (!CoordinateScalar(t_cx) || !CoordinateScalar(t_cy) ||
+                    !LengthScalar(t_rx) || !LengthScalar(t_ry))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.Ellipse(t_cx, t_cy, t_rx, t_ry);
+            }
+            break;
+                
+            /* Line visits the Line method of the visitor. */
+            case kMCGDrawingOpcodeLine:
+            {
+                /* Fetch the requested line's geometry. The geometry is
+                 * encoded as scalars:
+                 *   x1, y1 : coordinate scalars
+                 *   x2, y2 : coordinate scalars
+                 */
+                MCGFloat t_x1, t_y1, t_x2, t_y2;
+                if (!CoordinateScalar(t_x1) || !CoordinateScalar(t_y1) ||
+                    !CoordinateScalar(t_x2) || !CoordinateScalar(t_y2))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.Line(t_x1, t_y1, t_x2, t_y2);
+            }
+            break;
+                
+            /* Polygon/Polyline visit the Polygon/Polyline methods of the
+             * visitor. */
+            case kMCGDrawingOpcodePolygon:
+            case kMCGDrawingOpcodePolyline:
+            {
+                /* Fetch the requested shape's geometry. The geometry is 
+                 * encoded as a point array - the number of points (reflected
+                 * as scalar count) in the opcode stream. */
+                size_t t_point_count;
+                const MCGPoint* t_points;
+                if (!PointArray(t_point_count, t_points))
+                {
+                    break;
+                }
+                
+                /* Visit the appropriate visitor method depending on the opcode.
+                 */
+                if (t_opcode == kMCGDrawingOpcodePolygon)
+                {
+                    p_visitor.Polygon(t_point_count, t_points);
+                }
+                else
+                {
+                    p_visitor.Polyline(t_point_count, t_points);
+                }
+            }
+            break;
+            
+            /* Path executes a path opcode stream, causing appropriate Path
+             * methods to be visited in the visitor. The path visit is bounded
+             * by a visit of PathBegin and PathEnd. */
+            case kMCGDrawingOpcodePath:
+            {
+                ExecutePath(p_visitor);
+            }
+            break;
+        }
+    }
+    
+    /* Tell the visitor that visiting has terminated - whether an error occurred
+     * or not is flagged by the bool parameter. (None means no error, everything
+     * else means error). */
+    p_visitor.Finish(m_status == kMCGDrawingStatusNone);
+}
+
+/* The (template based) implementation of the ExecuteTransform method. */
+template<typename VisitorT>
+void MCGDrawingContext::ExecuteTransform(VisitorT& p_visitor)
+{
+    p_visitor.TransformBegin();
+    
+    while(IsRunning())
+    {
+        MCGDrawingTransformOpcode t_opcode;
+        if (!TransformOpcode(t_opcode))
+        {
+            break;
+        }
+        
+        if (t_opcode == kMCGDrawingTransformOpcodeEnd)
+        {
+            p_visitor.TransformEnd();
+            break;
+        }
+        
+        switch(t_opcode)
+        {
+            case kMCGDrawingTransformOpcodeEnd:
+                MCUnreachable();
+                break;
+                
+            case kMCGDrawingTransformOpcodeAffine:
+            {
+                MCGFloat t_a, t_b, t_c, t_d, t_tx, t_ty;
+                if (!Scalar(t_a) ||
+                    !Scalar(t_b) ||
+                    !Scalar(t_c) ||
+                    !Scalar(t_d) ||
+                    !Scalar(t_tx) ||
+                    !Scalar(t_ty))
+                {
+                    break;
+                }
+                p_visitor.TransformAffine(t_a, t_b, t_c, t_d, t_tx, t_ty);
+            }
+            break;
+        }
+    }
+}
+
+/* The (template based) implementation of the ExecutePaint method. */
+template<typename VisitorT>
+void MCGDrawingContext::ExecutePaint(VisitorT& p_visitor, bool p_is_stroke)
+{
+    p_visitor.PaintBegin(p_is_stroke);
+    
+    while(IsRunning())
+    {
+        MCGDrawingPaintOpcode t_opcode;
+        if (!PaintOpcode(t_opcode))
+        {
+            break;
+        }
+        
+        if (t_opcode == kMCGDrawingPaintOpcodeEnd)
+        {
+            p_visitor.PaintEnd();
+            break;
+        }
+        
+        switch(t_opcode)
+        {
+            case kMCGDrawingPaintOpcodeEnd:
+                MCUnreachable();
+                break;
+                
+            case kMCGDrawingPaintOpcodeSolidColor:
+                MCGFloat t_red, t_green, t_blue;
+                if (!UnitScalar(t_red) ||
+                    !UnitScalar(t_green) ||
+                    !UnitScalar(t_blue))
+                {
+                    break;
+                }
+                p_visitor.PaintSolidColor(t_red, t_green, t_blue);
+                break;
+        }
+    }
+}
+
+/* The (template based) implementation of the ExecutePath method. */
+template<typename VisitorT>
+void MCGDrawingContext::ExecutePath(VisitorT& p_visitor)
+{
+    p_visitor.PathBegin();
+    
+    while(IsRunning())
+    {
+        MCGDrawingPathOpcode t_opcode;
+        if (!PathOpcode(t_opcode))
+        {
+            break;
+        }
+        
+        if (t_opcode == kMCGDrawingPathOpcodeEnd)
+        {
+            p_visitor.PathEnd();
+            break;
+        }
+        
+        switch(t_opcode)
+        {
+            case kMCGDrawingPathOpcodeEnd:
+            {
+                MCUnreachable();
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeMoveTo:
+            case kMCGDrawingPathOpcodeRelativeMoveTo:
+            {
+                MCGFloat t_x, t_y;
+                if (!CoordinateScalar(t_x) ||
+                    !CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                p_visitor.PathMoveTo(t_opcode == kMCGDrawingPathOpcodeRelativeMoveTo, t_x, t_y);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeLineTo:
+            case kMCGDrawingPathOpcodeRelativeLineTo:
+            {
+                MCGFloat t_x, t_y;
+                if (!CoordinateScalar(t_x) ||
+                    !CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                p_visitor.PathLineTo(t_opcode == kMCGDrawingPathOpcodeRelativeLineTo, t_x, t_y);
+            }
+            break; 
+            
+            case kMCGDrawingPathOpcodeHorizontalTo:
+            case kMCGDrawingPathOpcodeRelativeHorizontalTo:
+            {
+                MCGFloat t_x;
+                if (!CoordinateScalar(t_x))
+                {
+                    break;
+                }
+                p_visitor.PathHorizontalTo(t_opcode == kMCGDrawingPathOpcodeRelativeHorizontalTo, t_x);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeVerticalTo:
+            case kMCGDrawingPathOpcodeRelativeVerticalTo:
+            {
+                MCGFloat t_y;
+                if (!CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                p_visitor.PathVerticalTo(t_opcode == kMCGDrawingPathOpcodeRelativeVerticalTo, t_y);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeCubicTo:
+            case kMCGDrawingPathOpcodeRelativeCubicTo:
+            {
+                MCGFloat t_ax, t_ay, t_bx, t_by, t_x, t_y;
+                if (!CoordinateScalar(t_ax) || !CoordinateScalar(t_ay) ||
+                    !CoordinateScalar(t_bx) || !CoordinateScalar(t_by) ||
+                    !CoordinateScalar(t_x) || !CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                p_visitor.PathCubicTo(t_opcode == kMCGDrawingPathOpcodeRelativeCubicTo, t_ax, t_ay, t_bx, t_by, t_x, t_y);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeSmoothCubicTo:
+            case kMCGDrawingPathOpcodeRelativeSmoothCubicTo:
+            {
+                MCGFloat t_bx, t_by, t_x, t_y;
+                if (!CoordinateScalar(t_bx) || !CoordinateScalar(t_by) ||
+                    !CoordinateScalar(t_x) || !CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                p_visitor.PathSmoothCubicTo(t_opcode == kMCGDrawingPathOpcodeRelativeSmoothCubicTo, t_bx, t_by, t_x, t_y);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeQuadraticTo:
+            case kMCGDrawingPathOpcodeRelativeQuadraticTo:
+            {
+                MCGFloat t_ax, t_ay, t_x, t_y;
+                if (!CoordinateScalar(t_ax) || !CoordinateScalar(t_ay) ||
+                    !CoordinateScalar(t_x) || !CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                p_visitor.PathQuadraticTo(t_opcode == kMCGDrawingPathOpcodeRelativeQuadraticTo, t_ax, t_ay, t_x, t_y);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeSmoothQuadraticTo:
+            case kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo:
+            {
+                MCGFloat t_x, t_y;
+                if (!CoordinateScalar(t_x) || !CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                p_visitor.PathSmoothQuadraticTo(t_opcode == kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo, t_x, t_y);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeArcTo:
+            case kMCGDrawingPathOpcodeRelativeArcTo:
+            case kMCGDrawingPathOpcodeReflexArcTo:
+            case kMCGDrawingPathOpcodeRelativeReflexArcTo:
+            case kMCGDrawingPathOpcodeReverseArcTo:
+            case kMCGDrawingPathOpcodeRelativeReverseArcTo:
+            case kMCGDrawingPathOpcodeReverseReflexArcTo:
+            case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
+            {
+                MCGFloat t_rx, t_ry, t_rotation, t_x, t_y;
+                if (!LengthScalar(t_rx) || !LengthScalar(t_ry) ||
+                    !AngleScalar(t_rotation) ||
+                    !CoordinateScalar(t_x) || !CoordinateScalar(t_y))
+                {
+                    break;
+                }
+                
+                bool t_is_relative =
+                        MCGDrawingPathOpcodeIsRelativeArc(t_opcode);
+                bool t_is_reflex =
+                        MCGDrawingPathOpcodeIsReflexArc(t_opcode);
+                bool t_is_reverse =
+                        MCGDrawingPathOpcodeIsReverseArc(t_opcode);
+                p_visitor.PathArcTo(t_is_relative, t_is_reflex, t_is_reverse, t_rx, t_ry, t_rotation, t_x, t_y);
+            }
+            break;
+                
+            case kMCGDrawingPathOpcodeBearing:
+            {
+                MCGFloat t_angle;
+                if (!AngleScalar(t_angle))
+                {
+                    break;
+                }
+                p_visitor.PathBearing(t_angle);
+            }
+            break;
+            
+            case kMCGDrawingPathOpcodeCloseSubpath:
+            {
+                p_visitor.PathCloseSubpath();
+            }
+            break;
+        }
+    }
+}
+
+/******************************************************************************/
+
+/* MCGDrawingRenderVisitor implements a visitor for the Execute method(s)
+ * required by MCGDrawingContext. It performs rendering of a drawing using
+ * a MCGContext. */
+struct MCGDrawingRenderVisitor
+{
+    MCGContextRef gcontext = nullptr;
+
+    /**/
+    
+    bool paint_is_for_stroke = false;
+    bool paint_set = false;
+    MCGAffineTransform current_transform;
+    
+    MCGPoint first_point = {0, 0};
+    MCGPoint last_point = {0, 0};
+    MCGPoint last_control_point = {0, 0};
+    MCGDrawingPathOpcode last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+    
+    /**/
+    
+    MCGPoint Point(bool p_is_relative, MCGFloat p_x, MCGFloat p_y)
+    {
+        if (p_is_relative)
+        {
+            return MCGPointMake(last_point.x + p_x, last_point.y + p_y);
+        }
+        return MCGPointMake(p_x, p_y);
+    }
+    
+    MCGPoint HorizontalPoint(bool p_is_relative, MCGFloat p_x)
+    {
+        if (p_is_relative)
+        {
+            return MCGPointMake(last_point.x + p_x, last_point.y);
+        }
+        return MCGPointMake(p_x, last_point.y);
+    }
+    
+    MCGPoint VerticalPoint(bool p_is_relative, MCGFloat p_y)
+    {
+        if (p_is_relative)
+        {
+            return MCGPointMake(last_point.x, last_point.y + p_y);
+        }
+        return MCGPointMake(last_point.x, p_y);
+    }
+    
+    /**/
+    
+    void TransformBegin(void)
+    {
+        current_transform = MCGAffineTransformMakeIdentity();
+    }
+    
+    void TransformAffine(MCGFloat a, MCGFloat b, MCGFloat c, MCGFloat d, MCGFloat tx, MCGFloat ty)
+    {
+        current_transform = MCGAffineTransformConcat(current_transform,
+                                                     MCGAffineTransformMake(a, b, c, d, tx, ty));
+    }
+
+    void TransformEnd(void)
+    {
+        MCGContextSetTransform(gcontext, current_transform);
+    }    
+    
+    /**/
+    
+    void PaintBegin(bool p_is_stroke)
+    {
+        paint_is_for_stroke = p_is_stroke;
+        paint_set = false;
+    }
+    
+    void PaintNone(void)
+    {
+        if (paint_set)
+        {
+            return;
+        }
+        
+        if (!paint_is_for_stroke)
+        {
+            MCGContextSetFillNone(gcontext);
+        }
+        else
+        {
+            MCGContextSetStrokeNone(gcontext);
+        }
+        
+        paint_set = true;
+    }
+    
+    void PaintSolidColor(MCGFloat p_red, MCGFloat p_green, MCGFloat p_blue)
+    {
+        if (paint_set)
+        {
+            return;
+        }
+        
+        if (!paint_is_for_stroke)
+        {
+            MCGContextSetFillRGBAColor(gcontext, p_red, p_green, p_blue, 1.0);
+        }
+        else
+        {
+            MCGContextSetStrokeRGBAColor(gcontext, p_red, p_green, p_blue, 1.0);
+        }
+        
+        paint_set = true;
+    }
+    
+    void PaintEnd(void)
+    {
+        if (!paint_set)
+        {
+            PaintNone();
+        }
+    }
+    
+    /**/
+    
+    void PathBegin(void)
+    {
+        MCGContextBeginPath(gcontext);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+        first_point = last_point = MCGPointMake(0.0, 0.0);
+    }
+    
+    void PathMoveTo(bool p_is_relative, MCGFloat p_x, MCGFloat p_y)
+    {
+        MCGPoint t_point = Point(p_is_relative, p_x, p_y);
+        MCGContextMoveTo(gcontext, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+        first_point = last_point = t_point;
+    }
+    
+    void PathLineTo(bool p_is_relative, MCGFloat p_x, MCGFloat p_y)
+    {
+        MCGPoint t_point = Point(p_is_relative, p_x, p_y);
+        MCGContextLineTo(gcontext, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+        last_point = t_point;
+    }
+    
+    void PathHorizontalTo(bool p_is_relative, MCGFloat p_x)
+    {
+        MCGPoint t_point = HorizontalPoint(p_is_relative, p_x);
+        MCGContextLineTo(gcontext, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+        last_point = t_point;
+    }
+    
+    void PathVerticalTo(bool p_is_relative, MCGFloat p_y)
+    {
+        MCGPoint t_point = VerticalPoint(p_is_relative, p_y);
+        MCGContextLineTo(gcontext, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+        last_point = t_point;
+    }
+    
+    void PathCubicTo(bool p_is_relative, MCGFloat p_ax, MCGFloat p_ay, MCGFloat p_bx, MCGFloat p_by, MCGFloat p_x, MCGFloat p_y)
+    {
+        MCGPoint t_a = Point(p_is_relative, p_ax, p_ay);
+        MCGPoint t_b = Point(p_is_relative, p_bx, p_by);
+        MCGPoint t_point = Point(p_is_relative, p_x, p_y);
+        MCGContextCubicTo(gcontext, t_a, t_b, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeCubicTo;
+        last_control_point = t_b;
+        last_point = t_point;
+    }
+    
+    void PathSmoothCubicTo(bool p_is_relative, MCGFloat p_bx, MCGFloat p_by, MCGFloat p_x, MCGFloat p_y)
+    {
+        MCGPoint t_a;
+        if (last_curve_opcode == kMCGDrawingPathOpcodeCubicTo)
+        {
+            t_a = MCGPointReflect(last_point, last_control_point);
+        }
+        else
+        {
+            t_a = last_point;
+        }
+        
+        MCGPoint t_b = Point(p_is_relative, p_bx, p_by);
+        MCGPoint t_point = Point(p_is_relative, p_x, p_y);
+        MCGContextCubicTo(gcontext, t_a, t_b, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeCubicTo;
+        last_control_point = t_b;
+        last_point = t_point;
+    }
+    
+    void PathQuadraticTo(bool p_is_relative, MCGFloat p_ax, MCGFloat p_ay, MCGFloat p_x, MCGFloat p_y)
+    {
+        MCGPoint t_a = Point(p_is_relative, p_ax, p_ay);
+        MCGPoint t_point = Point(p_is_relative, p_x, p_y);
+        MCGContextQuadraticTo(gcontext, t_a, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeQuadraticTo;
+        last_control_point = t_a;
+        last_point = t_point;
+    }
+    
+    void PathSmoothQuadraticTo(bool p_is_relative, MCGFloat p_x, MCGFloat p_y)
+    {
+        MCGPoint t_a;
+        if (last_curve_opcode == kMCGDrawingPathOpcodeQuadraticTo)
+        {
+            t_a = MCGPointReflect(last_point, last_control_point);
+        }
+        else
+        {
+            t_a = last_point;
+        }
+        
+        MCGPoint t_point = Point(p_is_relative, p_x, p_y);
+        MCGContextQuadraticTo(gcontext, t_a, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeCubicTo;
+        last_control_point = t_a;
+        last_point = t_point;
+    }
+    
+    void PathArcTo(bool p_is_relative, bool p_is_reflex, bool p_is_reverse, MCGFloat p_rx, MCGFloat p_ry, MCGFloat p_rotation, MCGFloat p_x, MCGFloat p_y)
+    {
+        MCGSize t_radii = MCGSizeMake(p_rx, p_ry);
+        MCGPoint t_point = Point(p_is_relative, p_x, p_y);
+        MCGContextArcTo(gcontext, t_radii, p_rotation, p_is_reflex, p_is_reverse, t_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+        last_point = t_point;
+    }
+    
+    void PathCloseSubpath(void)
+    {
+        MCGContextCloseSubpath(gcontext);
+        last_point = first_point;
+    }
+    
+    void PathBearing(MCGFloat p_angle)
+    {
+    }
+    
+    void PathEnd(void)
+    {
+        MCGContextFillAndStroke(gcontext);
+    }
+    
+    /**/
+    
+    void Start(MCGRectangle p_viewport, const MCGRectangle* p_viewbox, MCGDrawingPreserveAspectRatioOpcode p_par)
+    {
+        MCGContextSave(gcontext);
+        MCGContextSetShouldAntialias(gcontext, true);
+        
+        if (p_viewbox != nullptr)
+        {
+            float t_scale_x, t_scale_y;
+            if (p_viewbox->size.width != 0)
+            {
+                t_scale_x = p_viewport.size.width / p_viewbox->size.width;
+            }
+            else
+            {
+                t_scale_x = 0;
+            }
+            
+            if (p_viewbox->size.height != 0)
+            {
+                t_scale_y = p_viewport.size.height / p_viewbox->size.height;
+            }
+            else
+            {
+                t_scale_y = 0;
+            }
+            
+            if (MCGDrawingPreserveAspectRatioIsMeet(p_par))
+            {
+                t_scale_x = t_scale_y = MCMin(t_scale_x, t_scale_y);
+            }
+            else if (MCGDrawingPreserveAspectRatioIsSlice(p_par))
+            {
+                t_scale_x = t_scale_y = MCMax(t_scale_x, t_scale_y);
+            }
+            
+            float t_translate_x, t_translate_y;
+            t_translate_x = p_viewport.origin.x - (p_viewbox->origin.x * t_scale_x);
+            t_translate_y = p_viewport.origin.y - (p_viewbox->origin.y * t_scale_y);
+            
+            if (MCGDrawingPreserveAspectRatioIsXMid(p_par))
+            {
+                t_translate_x += (p_viewport.size.width - p_viewbox->size.width * t_scale_x) / 2;
+            }
+            else if (MCGDrawingPreserveAspectRatioIsXMax(p_par))
+            {
+                t_translate_x += (p_viewport.size.width - p_viewbox->size.width * t_scale_x);
+            }
+            
+            if (MCGDrawingPreserveAspectRatioIsYMid(p_par))
+            {
+                t_translate_y += (p_viewport.size.height - p_viewbox->size.height * t_scale_y) / 2;
+            }
+            else if (MCGDrawingPreserveAspectRatioIsYMax(p_par))
+            {
+                t_translate_y += (p_viewport.size.height - p_viewbox->size.height * t_scale_y);
+            }
+            
+            MCGContextConcatCTM(gcontext,
+                                MCGAffineTransformPostScale(MCGAffineTransformMakeTranslation(t_translate_x, t_translate_y),
+                                                            t_scale_x, t_scale_y));
+        }
+        else
+        {
+            MCGContextTranslateCTM(gcontext, p_viewport.origin.x, p_viewport.origin.y);
+        }
+        
+        MCGContextSave(gcontext);
+    }
+    
+    void Finish(bool p_error)
+    {
+        MCGContextRestore(gcontext);
+        MCGContextRestore(gcontext);
+    }
+    
+    void FillOpacity(MCGFloat p_opacity)
+    {
+        MCGContextSetFillOpacity(gcontext, p_opacity);
+    }
+    
+    void FillRule(MCGFillRule p_fill_rule)
+    {
+        MCGContextSetFillRule(gcontext, p_fill_rule);
+    }
+    
+    void StrokeOpacity(MCGFloat p_opacity)
+    {
+        MCGContextSetStrokeOpacity(gcontext, p_opacity);
+    }
+    
+    void StrokeWidth(MCGFloat p_width)
+    {
+        MCGContextSetStrokeWidth(gcontext, p_width);
+    }
+    
+    void StrokeLineJoin(MCGJoinStyle p_join_style)
+    {
+        MCGContextSetStrokeJoinStyle(gcontext, p_join_style);
+    }
+    
+    void StrokeLineCap(MCGCapStyle p_cap_style)
+    {
+        MCGContextSetStrokeCapStyle(gcontext, p_cap_style);
+    }
+    
+    void StrokeDashArray(size_t p_count, const MCGFloat* p_lengths)
+    {
+        MCGContextSetStrokeDashArray(gcontext, p_lengths, p_count);
+    }
+    
+    void StrokeDashOffset(MCGFloat p_offset)
+    {
+        MCGContextSetStrokeDashOffset(gcontext, p_offset);
+    }
+    
+    void StrokeMiterLimit(MCGFloat p_miter_limit)
+    {
+        MCGContextSetStrokeMiterLimit(gcontext, p_miter_limit);
+    }
+    
+    void Rectangle(MCGFloat p_x, MCGFloat p_y, MCGFloat p_width, MCGFloat p_height, MCGFloat p_rx, MCGFloat p_ry)
+    {
+        if (p_rx == 0.0 && p_ry == 0.0)
+        {
+            MCGContextAddRectangle(gcontext, MCGRectangleMake(p_x, p_y, p_width, p_height));
+        }
+        else
+        {
+            MCGContextAddRoundedRectangle(gcontext, MCGRectangleMake(p_x, p_y, p_width, p_height), MCGSizeMake(p_rx, p_ry));
+        }
+        MCGContextFillAndStroke(gcontext);
+    }
+    
+    void Circle(MCGFloat p_cx, MCGFloat p_cy, MCGFloat p_r)
+    {
+        MCGContextAddEllipse(gcontext, MCGPointMake(p_cx, p_cy), MCGSizeMake(p_r, p_r), 0.0);
+        MCGContextFillAndStroke(gcontext);
+    }
+    
+    void Ellipse(MCGFloat p_cx, MCGFloat p_cy, MCGFloat p_rx, MCGFloat p_ry)
+    {
+        MCGContextAddEllipse(gcontext, MCGPointMake(p_cx, p_cy), MCGSizeMake(p_rx, p_ry), 0.0);
+        MCGContextFillAndStroke(gcontext);
+    }
+    
+    void Line(MCGFloat p_x1, MCGFloat p_y1, MCGFloat p_x2, MCGFloat p_y2)
+    {
+        MCGContextAddLine(gcontext, MCGPointMake(p_x1, p_y1), MCGPointMake(p_x2, p_y2));
+        MCGContextFillAndStroke(gcontext);
+    }
+    
+    void Polyline(size_t p_count, const MCGPoint* p_points)
+    {
+        MCGContextAddPolyline(gcontext, p_points, uindex_t(p_count));
+        MCGContextFillAndStroke(gcontext);
+    }
+    
+    void Polygon(size_t p_count, const MCGPoint* p_points)
+    {
+        MCGContextAddPolygon(gcontext, p_points, uindex_t(p_count));
+        MCGContextFillAndStroke(gcontext);
+    }
+};
+
+/* MCGContextPlayback renders the specified drawing into p_dst_rect of p_gcontext. */
+void MCGContextPlayback(MCGContextRef p_gcontext, MCGRectangle p_dst_rect, const void *p_drawing, size_t p_drawing_byte_size)
+{
+    MCGDrawingRenderVisitor t_render_visitor;
+    t_render_visitor.gcontext = p_gcontext;
+    
+    MCGDrawingContext t_context(p_drawing, p_drawing_byte_size);
+    t_context.Execute(t_render_visitor, p_dst_rect);
+}
+
+/******************************************************************************/


### PR DESCRIPTION
This patch is an st-git stack containing changes which bring basic SVG display support to LiveCode.

It introduces a new 'drawing' abstraction in libgraphics, which is a simple bytecode format for representing compiled vector graphics files.

Initially, the implementation comes with a compiler (written in livecode script) which turns an SVG file into a drawing.

The drawing format has been designed to be efficient in both size and execution - indeed, a compiled drawing can be mapped into memory and executed directly without any runtime data structures required.

The patch is split into three commits:

  - the libgraphics drawing.cpp file containing the implementation of rendering of drawings

  - the (small) engine changes, adding drawings as a recognised 'metafile' format in the image object

  - the drawing livecodescript library containing the SVG to drawing compiler