### PR TITLE
[[Bug 20703]] revDocsParseDescriptionOfEnum continuation parse error

### DIFF
--- a/docs/notes/bugfix-20703.md
+++ b/docs/notes/bugfix-20703.md
@@ -1,0 +1,1 @@
+# revDocsParseDescriptionOfEnum continuation line parse error

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -1880,6 +1880,9 @@ function revDocsParseDescriptionOfEnum pDescription
          put word 1 to -1 of tValue into tArray["enum"][tCount]["value"]
          put word 1 to -1 of tDescription into tArray["enum"][tCount]["description"]
          add 1 to tCount
+         put true into tInEnum
+      else if tInEnum then
+         put space & word 1 to -1 of tLine after tArray["enum"][tCount-1]["description"]
       else
          put tLine & return after tOutput
       end if


### PR DESCRIPTION
When enum description lines continued, the additional lines wound up getting added to the description.  The 2 sort docs showed the issue for the sortType of numeric.  The variable (`tInEnum`) was already defined in the function to perform the check, but was not implemented inside the repeat loop.

This update will allow docs with enums to be wrapped according to the specs (some that I checked that looked good in the release were all on one line even when much longer than 72 characters).