### PR TITLE
[[ Foundation ]] Make ObjcId types nullable

### DIFF
--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -99,6 +99,19 @@ static MCValueCustomCallbacks kMCObjcObjectCustomValueCallbacks =
 /* The Id foreign value is a unmanaged wrapper around 'id' - basically like
  * Pointer but with a bridge to ObjcObject which explicitly retains its value. */
 
+static bool
+objc_id_initialize(void *contents)
+{
+    *(void **)contents = nullptr;
+    return true;
+}
+
+static bool
+objc_id_defined(void *contents)
+{
+    return *(void **)contents != nullptr;
+}
+
 static void
 objc_id_finalize(void *contents)
 {
@@ -389,9 +402,9 @@ bool __MCObjcInitialize(void)
         kMCObjcObjectTypeInfo,
         &p,
         1,
-        nullptr, /* initialize */
+        objc_id_initialize, /* initialize */
         objc_id_finalize, /* finalize */
-        nullptr, /* defined */
+        objc_id_defined, /* defined */
         objc_id_move,
         objc_id_copy,
         objc_id_equal,


### PR DESCRIPTION
This patch implements the 'initialize' and 'defined' foreign type
methods for the ObjcId types making a nullptr id map to nothing.

This change allows optional ObjcId (and others) to be used as
a nullable id - i.e. where a value could be an obj-c id or
nullptr.