### PR TITLE
[[ Bug 19543 ]] Dictionary improperly parses hard wrapped lines

### DIFF
--- a/docs/notes/bugfix-19543.md
+++ b/docs/notes/bugfix-19543.md
@@ -1,0 +1,1 @@
+# Dictionary improperly parses hard wrapped lines where word is followed by colon

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -928,6 +928,8 @@ private function __arrayElementRegex
    return "^ *([\w" & quote & "]+) *(?:\(( *(?:optional |in |out |inout )?<?\w*>?) *\))? *: *(.*)"
 end __arrayElementRegex
 
+constant kAlwaysRecognizeAsElement = "Description"
+
 function revDocsExtractElementsWithRegex pText, pRegex
    local tElementRegex
    put pRegex into tElementRegex
@@ -993,10 +995,9 @@ function revDocsExtractElementsWithRegex pText, pRegex
          --BWM-2017-11-22: [[ Bug 19543 ]] A word (optionaly with something that looks like 
          --a ParamType) immediately following content should be treated as part of that
          --content instead of a new element.
-         --Always recognize certain elements: Description,
          if word 1 of tAfterElement is empty and tAccumulatedContent is not empty and \
                tInternalBlankLines is 0 and tInMultipleLineElement and \
-               tNextElementName is not among the items of ",Description" then
+               tNextElementName is not among the items of kAlwaysRecognizeAsElement then
             put tLine & return after tAccumulatedContent
             next repeat
          end if

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -954,6 +954,8 @@ function revDocsExtractElementsWithRegex pText, pRegex
    repeat for each line tLine in pText
       # Variables to store regex matches
       local tNextElementName, tParamType, tAfterElement
+      # Variable to keep track of whether element contains multiple lines
+      local tInMultipleLineElement
       
       get word 1 of tLine
       if tInArrayDescription then
@@ -987,7 +989,17 @@ function revDocsExtractElementsWithRegex pText, pRegex
             add 1 to tInternalBlankLines
          end if
          next repeat
-      else if matchText(tLine, tElementRegex, tNextElementName, tParamType, tAfterElement) then   
+      else if matchText(tLine, tElementRegex, tNextElementName, tParamType, tAfterElement) then
+         --BWM-2017-11-22: [[ Bug 19543 ]] A word (optionaly with something that looks like 
+         --a ParamType) immediately following content should be treated as part of that
+         --content instead of a new element.
+         --Always recognize certain elements: Description,
+         if word 1 of tAfterElement is empty and tAccumulatedContent is not empty and \
+               tInternalBlankLines is 0 and tInMultipleLineElement and \
+               tNextElementName is not among the items of ",Description" then
+            put tLine & return after tAccumulatedContent
+            next repeat
+         end if
          if tAccumulatedContent is not empty and tElementCount is 0 then
             add 1 to tElementCount
          end if
@@ -1018,6 +1030,7 @@ function revDocsExtractElementsWithRegex pText, pRegex
          if word 1 of tAfterElement is not empty then
             put word 1 to -1 of tAfterElement & return into tAccumulatedContent
          end if
+         put false into tInMultipleLineElement
       else
          # AL-2015-09-03: [[ Bug 15866 ]] Include internal blank lines in content
          repeat tInternalBlankLines
@@ -1025,6 +1038,7 @@ function revDocsExtractElementsWithRegex pText, pRegex
          end repeat
          put 0 into tInternalBlankLines
          put tLine & return after tAccumulatedContent
+         put true into tInMultipleLineElement
       end if
    end repeat
    


### PR DESCRIPTION
When a paragraph ends with a colon and the last word falls on a new line then that word is parsed as a new element.  Due to the way the regex is parsed, something inside parenthesis before the colon could also trigger this bug.

The proposed fix:  Unless there is a preceding blank line, assume that this term is part of the existing content.  If there is no content, then assume it is indeed a new element.  An exception is if the element contains the content on the same line, in that case a new element can start on the next line.  Some LCB documentation has "Description:" immediately following another multi-line element without a blank line (i.e. examples).  Added a check that can be extended if other elements are found that need to be treated as an exception.

I ran a diff on the built_api.js from before my change and after.  There are 584 lines of changes.  Not all of them are evident in the dictionary viewer.  (Only the first 128 lines are for ~32 actual changes, the rest were due to reordering of svgpath and svgspinner in the JSON.)

Some entries fixed by the change:
- open printing
- open printing to pdf
- switch