### PR TITLE
[[ Bug ]] Throw error if changing behavior of executing object

### DIFF
--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1703,6 +1703,12 @@ void MCObject::SetParentScript(MCExecContext& ctxt, MCStringRef new_parent_scrip
 	//   error.
 	if (new_parent_script == nil || MCStringGetLength(new_parent_script) == 0)
 	{
+        if (parent_script != NULL && scriptdepth != 0)
+        {
+            // can't clear a behavior while script is executing
+            ctxt . LegacyThrow(EE_OBJECT_SCRIPTEXECUTING);
+            return;
+        }
 		if (parent_script != NULL)
 			parent_script -> Release();
 		parent_script = NULL;
@@ -1773,6 +1779,13 @@ void MCObject::SetParentScript(MCExecContext& ctxt, MCStringRef new_parent_scrip
 		//
 		if (parent_script == NULL || parent_script -> GetParent() -> GetObject() != t_object)
 		{
+            if (parent_script != NULL && scriptdepth != 0)
+            {
+                // can't change a behavior while script is executing unless
+                // there was previously no behavior set
+                ctxt . LegacyThrow(EE_OBJECT_SCRIPTEXECUTING);
+                return;
+            }
 			// We have the target object, so extract its rugged id. That is the
 			// (id, stack, mainstack) triple. Note that mainstack is NULL if the
 			// object lies on a mainstack.

--- a/tests/lcs/core/engine/behavior.livecodescript
+++ b/tests/lcs/core/engine/behavior.livecodescript
@@ -1,0 +1,40 @@
+﻿script "CoreEngineBehavior"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+on TestChangeBehaviorWhileExecuting
+   create stack "test"
+   set the defaultStack to "test"
+   create button "child"
+   set the script of button "child" to "on Foo;Bar;end Foo"
+   create button "parent"
+   set the script of button "parent" to "on Bar;Baz;end Bar"
+   set the behavior of button "child" to the long id of button "parent"
+   set the script of stack "test" to "on Baz;set the behavior of button " & quote & "child" & quote & " to the long id of button " & quote & "parent"& quote &";end Baz"
+   TestAssertDoesNotThrow "can set behavior while it may be executing if it is empty", "Foo", \
+      the long id of button "child"
+   
+   TestAssertDoesNotThrow "can set behavior while it may be executing if it is the same", "Foo", \
+      the long id of button "child"
+   
+   -- wait 0 milliseconds;throw 0 added to test the crash if the error is not thrown
+   set the script of stack "test" to "on Baz;set the behavior of button " & quote & "child" & quote & " to empty;wait 0 milliseconds;throw 0;end Baz"  
+   TestAssertThrow "can't set behavior while it may be executing", "Foo", \
+      the long id of button "child", "EE_OBJECT_SCRIPTEXECUTING"
+   delete stack "test"
+end TestChangeBehaviorWhileExecuting


### PR DESCRIPTION
This patch ensures that an error will be thrown when setting a
behavior on an executing object if new behavior is a different
object. There is no error if the object did not have a behavior
because it is not possible that the behavior script is executing.