### PR TITLE
[[ Bug 20663 ]] Adjust segmented control corner radius based on orientation

### DIFF
--- a/extensions/widgets/segmented/notes/20663.md
+++ b/extensions/widgets/segmented/notes/20663.md
@@ -1,0 +1,1 @@
+# [20663] Adjust corner radius based on control orientation

--- a/extensions/widgets/segmented/segmented.lcb
+++ b/extensions/widgets/segmented/segmented.lcb
@@ -295,7 +295,11 @@ public handler OnPaint()
 	if mGeometryIsChanged then
 		calculateExtents()
 		-- update mPerimeter and mLines variables if the geometry has changed
-		put (the trunc of my height)/5 into mRadius
+		if mIsHorizontal then
+			put (the trunc of my height)/5 into mRadius
+		else
+			put (the trunc of my width)/5 into mRadius
+		end if
 		updatePerimeter()
 		updateLines()
 	end if


### PR DESCRIPTION
The segmented control is hard coded for the corner radius to be 1/5 of the height.  When changing to a vertical orientation, width should be used.