### PR TITLE
[18243] Ensure horizontal 2 finger scrolling now respects System Settings

### DIFF
--- a/docs/notes/bugfix-18243.md
+++ b/docs/notes/bugfix-18243.md
@@ -1,0 +1,1 @@
+# Ensure horizontal two finger scrolling on Linux respects the system settings

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -621,11 +621,11 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                                         break;
                                         
                                     case GDK_SCROLL_LEFT:
-                                        mfocused->kdown(kMCEmptyString, XK_WheelLeft);
+                                        mfocused->kdown(kMCEmptyString, XK_WheelRight);
                                         break;
                                         
                                     case GDK_SCROLL_RIGHT:
-                                        mfocused->kdown(kMCEmptyString, XK_WheelRight);
+                                        mfocused->kdown(kMCEmptyString, XK_WheelLeft);
                                         break;
                                 }
                             }

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -611,7 +611,7 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                             {
                                 switch (t_event->scroll.direction)
                                 {
-                                    // GDK events are named for the 'natural scrolling' version
+                                    // GDK events are named for the 'natural scrolling' version and interpreted according to system settings
                                     case GDK_SCROLL_UP:
                                         mfocused->kdown(kMCEmptyString, XK_WheelDown);
                                         break;

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -611,7 +611,7 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                             {
                                 switch (t_event->scroll.direction)
                                 {
-                                    // Up and down are switched. For some reason...
+                                    // GDK events are named for the 'natural scrolling' version
                                     case GDK_SCROLL_UP:
                                         mfocused->kdown(kMCEmptyString, XK_WheelDown);
                                         break;


### PR DESCRIPTION
Vertical two finger scrolling on Linux does respect the System Settings (regarding "natural" scrolling or not)
However, horizontal scrolling did not. This patch fixes this problem, tested on Ubuntu 16.04.