### PR TITLE
[[ Bug 20288 ]] Copy CEF process on Win

### DIFF
--- a/libbrowser/libbrowser.gyp
+++ b/libbrowser/libbrowser.gyp
@@ -254,10 +254,10 @@
                                     'copies':
                                     [
                                         {
-                                            'destination':'<(PRODUCT_DIR)/CEF/',
+                                            'destination':'<(PRODUCT_DIR)\CEF',
                                             'files':
                                             [
-                                                '<(PRODUCT_DIR)/libbrowser-cefprocess.exe',
+                                                '<(PRODUCT_DIR)\libbrowser-cefprocess.exe',
                                             ],
                                         },
                                     ],


### PR DESCRIPTION
This patch changes slash to backslash in the copies block of for
libbrowser-cefprocess.exe. It is unclear why slash does not work
for this target because it does work for revbrowser-cefprocess.exe.