### PR TITLE
[[ Bug 20419 ]] Fix problems using accelRender on Android

### DIFF
--- a/docs/notes/bugfix-20419.md
+++ b/docs/notes/bugfix-20419.md
@@ -1,0 +1,1 @@
+# Fix accelRender issues on Android

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -895,7 +895,8 @@ public:
 		{
             MCGContextRef t_context;
             if (MCGContextCreateWithRaster(t_raster, t_context))
-			{
+            {
+                r_context = t_context;
                 r_raster = t_raster;
 				return true;
 			}


### PR DESCRIPTION
This patch fixes an unset out variable issue when locking the
Android OpenGL surface for rendering. This problem appears to
cause both rendering defects and crashes - which should be
fixed by this change.