### PR TITLE
[[ Bug 20733 ]] Allow binding to obj-c dynamic properties

### DIFF
--- a/docs/lcb/notes/20733.md
+++ b/docs/lcb/notes/20733.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Virtual Machine
+## Foreign Function Interface
+
+# [20733] Allow binding to dynamic obj-c property messages

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -185,4 +185,14 @@ public handler TestReturnNSRect()
 		tRectList is tRect
 end handler
 
+----------
+
+private foreign handler NSUserNotificationSetTitle(in Obj as ObjcId, in Title as ObjcId) returns nothing binds to "objc:NSUserNotification.-setTitle:"
+private foreign handler NSUserNotificationGetTitle(in Obj as ObjcId) returns ObjcId binds to "objc:NSUserNotification.title"
+
+public handler TestObjcDynamicPropertyBinding()
+	test "dynamic objc setter binds" when NSUserNotificationSetTitle is not nothing
+	test "dynamic objc getter binds" when NSUserNotificationGetTitle is not nothing
+end handler
+
 end module

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -191,6 +191,11 @@ private foreign handler NSUserNotificationSetTitle(in Obj as ObjcId, in Title as
 private foreign handler NSUserNotificationGetTitle(in Obj as ObjcId) returns ObjcId binds to "objc:NSUserNotification.title"
 
 public handler TestObjcDynamicPropertyBinding()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "objc property binding succeeds" because "not implemented on" && the operating system
+		return
+	end if
+
 	test "dynamic objc setter binds" when NSUserNotificationSetTitle is not nothing
 	test "dynamic objc getter binds" when NSUserNotificationGetTitle is not nothing
 end handler


### PR DESCRIPTION
This patch adds an extra check when making sure an obj-c message
is attached to a class instance. If a message such as ```set<name>:``` or
```<name>``` does not exist, then it checks for a suitable property
instead.