### PR TITLE
[[ Bug 20631 ]] Don't use NFC if not available

### DIFF
--- a/docs/notes/bugfix-20631.md
+++ b/docs/notes/bugfix-20631.md
@@ -1,0 +1,1 @@
+# Fix crash when launching android app from local notification

--- a/engine/src/java/com/runrev/android/NFCModule.java
+++ b/engine/src/java/com/runrev/android/NFCModule.java
@@ -83,7 +83,10 @@ public class NFCModule
 	
 	public void onNewIntent(Intent p_intent)
 	{
-		handleIntent(p_intent);
+        if (isAvailable())
+        {
+            handleIntent(p_intent);
+        }
 	}
 	
 	public boolean isAvailable()


### PR DESCRIPTION
This patch ensures that intents are not processed by the NFC module
unless nfc is available as this can cause a null pointer exception
when accessing members of the NfcAdapter class.