### PR TITLE
[[ Graphics ]] Align API with SVG

### DIFF
--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -450,11 +450,11 @@ enum MCGGradientFunction
 static const intenum_t kMCGGradientFunctionCount = 7;
 
 
-enum MCGGradientTileMode
+enum MCGGradientSpreadMethod
 {
-	kMCGGradientTileModeClamp,
-	kMCGGradientTileModeRepeat,
-	kMCGGradientTileModeMirror,	
+	kMCGGradientSpreadMethodPad,
+	kMCGGradientSpreadMethodReflect,
+	kMCGGradientSpreadMethodRepeat,
 };
 
 enum MCGMaskFormat
@@ -926,6 +926,7 @@ void MCGContextClipToRegion(MCGContextRef self, MCGRegionRef p_region);
 // Fill attributes
 void MCGContextSetFillRule(MCGContextRef context, MCGFillRule rule);
 void MCGContextSetFillOpacity(MCGContextRef context, MCGFloat opacity);
+void MCGContextSetFillNone(MCGContextRef context);
 void MCGContextSetFillRGBAColor(MCGContextRef context, MCGFloat red, MCGFloat green, MCGFloat blue, MCGFloat alpha);
 void MCGContextSetFillPattern(MCGContextRef context, MCGImageRef image, MCGAffineTransform transform, MCGImageFilter filter);
 void MCGContextSetFillGradient(MCGContextRef context, MCGGradientFunction function, const MCGFloat* stops, const MCGColor* colors, uindex_t ramp_length, bool mirror, bool wrap, uint32_t repeats, MCGAffineTransform transform, MCGImageFilter filter);
@@ -933,6 +934,7 @@ void MCGContextSetFillPaintStyle(MCGContextRef context, MCGPaintStyle style);
 
 // Stroke attributes
 void MCGContextSetStrokeOpacity(MCGContextRef context, MCGFloat opacity);
+void MCGContextSetStrokeNone(MCGContextRef context);
 void MCGContextSetStrokeRGBAColor(MCGContextRef context, MCGFloat red, MCGFloat green, MCGFloat blue, MCGFloat alpha);
 void MCGContextSetStrokePattern(MCGContextRef context, MCGImageRef image, MCGAffineTransform transform, MCGImageFilter filter);
 void MCGContextSetStrokeGradient(MCGContextRef context, MCGGradientFunction function, const MCGFloat* stops, const MCGColor* colors, uindex_t ramp_length, bool mirror, bool wrap, uint32_t repeats, MCGAffineTransform transform, MCGImageFilter filter);
@@ -997,24 +999,14 @@ void MCGContextFillAndStroke(MCGContextRef context);
 // Intersects the current clipping path with the current path; the inside of the current
 // path is determined with the current fill rule. This discards the path.
 void MCGContextClip(MCGContextRef context);
-// Replace the current path by one thickened using the current stroke attributes.
-void MCGContextThicken(MCGContextRef context);
-// Replace the current path by one entirely consisting of moveto, lineto and close commands.
-void MCGContextFlatten(MCGContextRef context);
-// Replace the current path by one consisting of no overlapping subpaths or self
-// intersections. Interior is determined by current fill rule.
-void MCGContextSimplify(MCGContextRef context);
 
 void MCGContextDrawPixels(MCGContextRef context, const MCGRaster& raster, MCGRectangle dst_rect, MCGImageFilter filter);
 void MCGContextDrawImage(MCGContextRef context, MCGImageRef image, MCGRectangle dst_rect, MCGImageFilter filter);
 void MCGContextDrawImageWithCenter(MCGContextRef context, MCGImageRef image, MCGRectangle image_center, MCGRectangle dst_rect, MCGImageFilter filter);
 void MCGContextDrawRectOfImage(MCGContextRef self, MCGImageRef p_image, MCGRectangle p_src, MCGRectangle p_dst, MCGImageFilter p_filter);
-void MCGContextDrawDeviceMask(MCGContextRef context, MCGMaskRef mask, int32_t tx, int32_t ty);
 
 bool MCGContextCopyImage(MCGContextRef context, MCGImageRef &r_image);
 
-void MCGContextDrawText(MCGContextRef context, const char* text, uindex_t length, MCGPoint location, uint32_t font_size, void *typeface);
-MCGFloat MCGContextMeasureText(MCGContextRef context, const char *text, uindex_t length, uint32_t font_size, void *typeface);
 void MCGContextDrawPlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, MCGPoint location, const MCGFont &font, bool p_rtl);
 // MM-2014-04-16: [[ Bug 11964 ]] Updated prototype to take transform parameter.
 MCGFloat MCGContextMeasurePlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform);

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -905,6 +905,9 @@ void MCGContextRestore(MCGContextRef context);
 void MCGContextSetFlatness(MCGContextRef context, MCGFloat flatness);
 void MCGContextSetShouldAntialias(MCGContextRef context, bool should_antialias);
 
+// Transform attribute
+void MCGContextSetTransform(MCGContextRef context, MCGAffineTransform p_transform);
+
 // Layer attributes and manipulation - bitmap effect options would be added here also.
 void MCGContextSetOpacity(MCGContextRef context, MCGFloat opacity);
 void MCGContextSetBlendMode(MCGContextRef context, MCGBlendMode mode);

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -940,6 +940,8 @@ void MCGContextSetStrokeWidth(MCGContextRef context, MCGFloat width);
 void MCGContextSetStrokeMiterLimit(MCGContextRef context, MCGFloat limit);
 void MCGContextSetStrokeJoinStyle(MCGContextRef context, MCGJoinStyle style);
 void MCGContextSetStrokeCapStyle(MCGContextRef context, MCGCapStyle style);
+void MCGContextSetStrokeDashOffset(MCGContextRef context, MCGFloat offset);
+void MCGContextSetStrokeDashArray(MCGContextRef context, const MCGFloat* lengths, uindex_t length_count);
 void MCGContextSetStrokeDashes(MCGContextRef context, MCGFloat phase, const MCGFloat *lengths, uindex_t arity);
 void MCGContextSetStrokePaintStyle(MCGContextRef context, MCGPaintStyle style);
 

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -1584,6 +1584,19 @@ void MCGContextSetStrokeCapStyle(MCGContextRef self, MCGCapStyle p_style)
 	self -> state -> stroke_attr . cap_style = p_style;
 }
 
+void MCGContextSetStrokeDashOffset(MCGContextRef self, MCGFloat p_offset)
+{
+    MCGContextSetStrokeDashes(self,
+                              p_offset,
+                              self->state->stroke_attr.dashes != nullptr ? self->state->stroke_attr.dashes->lengths : nullptr,
+                              self->state->stroke_attr.dashes != nullptr ? self->state->stroke_attr.dashes->count : 0);
+}
+
+void MCGContextSetStrokeDashArray(MCGContextRef self, const MCGFloat *p_lengths, uindex_t p_arity)
+{
+    MCGContextSetStrokeDashes(self, self->state->stroke_attr.dashes != nullptr ? self->state->stroke_attr.dashes->phase : 0, p_lengths, p_arity);
+}
+
 void MCGContextSetStrokeDashes(MCGContextRef self, MCGFloat p_phase, const MCGFloat *p_lengths, uindex_t p_arity)
 {	
 	if (!MCGContextIsValid(self))
@@ -1597,8 +1610,7 @@ void MCGContextSetStrokeDashes(MCGContextRef self, MCGFloat p_phase, const MCGFl
 		MCGDashesRelease(self -> state -> stroke_attr . dashes);
 		self -> state -> stroke_attr . dashes = NULL;
 		
-		if (p_arity > 0)
-			t_success = MCGDashesCreate(p_phase, p_lengths, p_arity, self -> state -> stroke_attr . dashes);
+        t_success = MCGDashesCreate(p_phase, p_lengths, p_arity, self -> state -> stroke_attr . dashes);
 	}	
 		
 	self -> is_valid = t_success;	

--- a/libgraphics/src/graphics-internal.h
+++ b/libgraphics/src/graphics-internal.h
@@ -262,6 +262,9 @@ typedef struct __MCGContextState *MCGContextStateRef;
 
 struct __MCGContextState
 {
+    MCGAffineTransform  base_transform;
+    MCGAffineTransform  transform;
+
 	MCGFloat			opacity;
 	MCGBlendMode		blend_mode;
 	MCGFloat			flatness;

--- a/libgraphics/src/graphics-internal.h
+++ b/libgraphics/src/graphics-internal.h
@@ -36,43 +36,225 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef struct __MCGPattern *MCGPatternRef;
+typedef class MCGObject *MCGObjectRef;
 
-struct __MCGPattern
+class MCGObject
 {
-	MCGImageRef			pattern;
-	MCGAffineTransform	transform;
-	MCGImageFilter		filter;
-	uint32_t			references;
-};
+public:
+#ifdef _DEBUG
+    static size_t s_object_count;
+#endif
 
-bool MCGPatternCreate(MCGImageRef image, MCGAffineTransform transform, MCGImageFilter filter, MCGPatternRef& r_pattern);
-MCGPatternRef MCGPatternRetain(MCGPatternRef pattern);
-void MCGPatternRelease(MCGPatternRef pattern);
-bool MCGPatternToSkShader(MCGPatternRef pattern, sk_sp<SkShader>& r_shader);
+    MCGObject(void)
+        : m_references(1)
+    {
+#ifdef _DEBUG
+        s_object_count += 1;
+#endif
+    }
+
+protected:
+    virtual ~MCGObject(void)
+    {
+#ifdef _DEBUG
+        s_object_count -= 1;
+#endif
+    }
+
+private:
+    virtual void Retain(void)
+    {
+        m_references += 1;
+    }
+    
+    virtual void Release(void)
+    {
+        m_references -= 1;
+        if (m_references == 0)
+        {
+            delete this;
+        }
+    }
+    
+    template<typename T>
+    friend T MCGRetain(T p_object)
+    {
+        if (p_object == nullptr)
+        {
+            return nullptr;
+        }
+        
+        p_object->Retain();
+        
+        return p_object;
+    }
+    
+    template<typename T>
+    friend void MCGRelease(T p_object)
+    {
+        if (p_object == nullptr)
+        {
+            return;
+        }
+        
+        p_object->Release();
+    }
+    
+    template<typename T>
+    friend void MCGAssignAndRelease(T& x_target, T p_source)
+    {
+        if (x_target != nullptr)
+        {
+            x_target->Release();
+        }
+        
+        x_target = p_source;
+    }
+    
+    uint32_t m_references;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef struct __MCGGradient *MCGGradientRef;
+typedef class MCGPaint *MCGPaintRef;
 
-struct __MCGGradient
+class MCGPaint: public MCGObject
 {
-	MCGGradientFunction	function;	
-	MCGColor            *colors;
-	MCGFloat			*stops;
-	uindex_t			ramp_length;	
-	bool				mirror;
-	bool				wrap;
-	uint32_t			repeats;	
-	SkMatrix            transform;
-	MCGImageFilter		filter;	
-	uint32_t			references;
+public:
+    virtual bool Apply(SkPaint& r_paint) = 0;
 };
 
-bool MCGGradientCreate(MCGGradientFunction function, const MCGFloat* stops, const MCGColor* colors, uindex_t ramp_length, bool mirror, bool wrap, uint32_t repeats, MCGAffineTransform transform, MCGImageFilter filter, MCGGradientRef& r_gradient);
-MCGGradientRef MCGGradientRetain(MCGGradientRef gradient);
-void MCGGradientRelease(MCGGradientRef gradient);
-bool MCGGradientToSkShader(MCGGradientRef gradient, MCGRectangle clip, sk_sp<SkShader>& r_shader);
+////////////////////////////////////////////////////////////////////////////////
+
+typedef class MCGSolidColor *MCGSolidColorRef;
+
+class MCGSolidColor: public MCGPaint
+{
+public:
+    virtual bool Apply(SkPaint& r_paint);
+    
+    static bool Create(MCGFloat p_red, MCGFloat p_green, MCGFloat p_blue, MCGFloat p_alpha, MCGSolidColorRef& r_solid_color);
+    
+private:
+    MCGColor m_color;
+};
+
+extern MCGSolidColorRef kMCGBlackSolidColor;
+
+////////////////////////////////////////////////////////////////////////////////
+
+typedef class MCGPattern *MCGPatternRef;
+
+class MCGPattern: public MCGPaint
+{
+public:
+    virtual ~MCGPattern(void);
+    
+    virtual bool Apply(SkPaint& r_paint);
+    
+    static bool Create(MCGImageRef image, MCGAffineTransform transform, MCGImageFilter filter, MCGPatternRef& r_pattern);
+    
+private:
+	MCGImageRef			m_image;
+	MCGAffineTransform	m_transform;
+	MCGImageFilter		m_filter;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+typedef class MCGRamp *MCGRampRef;
+
+class MCGRamp: public MCGObject
+{
+public:
+    virtual ~MCGRamp(void);
+
+    static bool Create(const MCGFloat *p_stops, const MCGColor *p_colors, size_t p_ramp_length, MCGRampRef& r_ramp);
+
+    const SkScalar* GetStops(void) const { return m_stops; }
+    const SkColor* GetColors(void) const { return m_colors; }
+    size_t GetLength(void) const { return m_ramp_length; }
+
+private:
+    SkScalar *m_stops = nullptr;
+    SkColor *m_colors = nullptr;
+    size_t m_ramp_length = 0;
+};
+
+typedef class MCGGradient *MCGGradientRef;
+
+class MCGGradient: public MCGPaint
+{
+public:
+    virtual ~MCGGradient(void);
+
+protected:
+    MCGRampRef m_ramp = nullptr;
+    MCGGradientSpreadMethod m_spread_method;
+	MCGAffineTransform m_transform;
+};
+
+typedef class MCGGeneralizedGradient *MCGGeneralizedGradientRef;
+
+class MCGGeneralizedGradient: public MCGGradient
+{
+public:
+    virtual bool Apply(SkPaint& r_paint);
+
+    static bool Create(MCGGradientFunction function, MCGRampRef ramp, bool mirror, bool wrap, uint32_t repeats, MCGAffineTransform transform, MCGImageFilter filter, MCGGradientRef& r_gradient);
+    
+private:
+	MCGGradientFunction	m_function;
+	uint32_t			m_repeats;
+    MCGImageFilter		m_filter;
+    bool m_mirror;
+    bool m_wrap;
+    
+    friend class MCGGeneralizedGradientShader;
+};
+
+extern bool MCGGeneralizedGradientShaderApply(MCGGeneralizedGradientRef p_gradient, SkPaint& r_paint);
+
+typedef class MCGLinearGradient *MCGLinearGradientRef;
+
+class MCGLinearGradient: public MCGGradient
+{
+public:
+    virtual bool Apply(SkPaint& r_paint);
+    
+    static bool Create(MCGPoint p_from, MCGPoint p_to, MCGRampRef p_ramp, MCGGradientSpreadMethod p_spread_method, MCGAffineTransform p_transform, MCGGradientRef& r_gradient);
+    
+private:
+    MCGPoint m_from;
+    MCGPoint m_to;
+};
+
+typedef class MCGRadialGradient *MCGRadialGradientRef;
+
+class MCGRadialGradient: public MCGGradient
+{
+public:
+    virtual bool Apply(SkPaint& r_paint);
+
+    static bool Create(MCGPoint p_focal_point, MCGFloat p_radius, MCGRampRef p_ramp, MCGGradientSpreadMethod p_tile_mode, MCGAffineTransform p_transform, MCGGradientRef& r_gradient);
+    
+private:
+    MCGFloat m_radius;
+    MCGPoint m_focal_point;
+};
+
+typedef class MCGSweepGradient *MCGSweepGradientRef;
+
+class MCGSweepGradient: public MCGGradient
+{
+public:
+    virtual bool Apply(SkPaint& r_paint);
+
+    static bool Create(MCGPoint p_center, MCGRampRef p_ramp, MCGGradientSpreadMethod p_tile_mode, MCGAffineTransform p_transform, MCGGradientRef& r_gradient);
+    
+private:
+    MCGPoint m_center;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -85,18 +267,14 @@ struct __MCGContextState
 	MCGFloat			flatness;
 	bool				should_antialias;
 	
-	MCGColor			fill_color;
+    MCGPaintRef         fill_paint;
 	MCGFloat			fill_opacity;
 	MCGFillRule			fill_rule;
-	MCGPatternRef		fill_pattern;
-	MCGGradientRef		fill_gradient;
 	MCGPaintStyle		fill_style;
 	
-	MCGColor			stroke_color;
+    MCGPaintRef         stroke_paint;
 	MCGFloat			stroke_opacity;
 	MCGStrokeAttr		stroke_attr;
-	MCGPatternRef		stroke_pattern;
-	MCGGradientRef		stroke_gradient;
 	MCGPaintStyle		stroke_style;
 	
 	bool				is_layer_begin_pt;
@@ -442,6 +620,8 @@ void *MCGCacheTableGet(MCGCacheTableRef cache_table, void *key, uint32_t key_len
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool MCGContextSetupFill(MCGContextRef p_context, SkPaint& r_paint);
+
 // MM-2014-04-16: [[ Bug 11964 ]] Updated prototype to take transform parameter.
 MCGFloat __MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, const MCGFont &p_font, const MCGAffineTransform &p_transform);
 
@@ -462,45 +642,6 @@ void MCGBlendModesFinalize(void);
 struct __MCGRegion
 {
 	SkRegion region;
-};
-
-////////////////////////////////////////////////////////////////////////////////
-
-typedef struct MCGradientAffineCombiner MCGradientCombiner_t;
-
-class MCGLegacyGradientShader : public SkShader
-{
-public:
-    MCGLegacyGradientShader(MCGGradientRef gradient_ref, MCGRectangle clip);
-    ~MCGLegacyGradientShader();
-
-    class MCGLegacyGradientShaderContext : public SkShader::Context
-    {
-    public:
-        MCGLegacyGradientShaderContext(const MCGLegacyGradientShader& shader, const ContextRec& rec, MCGGradientRef gradient_ref, MCGRectangle clip);
-        ~MCGLegacyGradientShaderContext();
-
-        virtual void shadeSpan(int x, int y, SkPMColor dstC[], int count) override;
-
-    private:
-        int32_t					m_y;
-        MCGradientCombiner_t	*m_gradient_combiner;
-
-        typedef SkShader::Context INHERITED;
-    };
-
-    SK_TO_STRING_OVERRIDE()
-    SK_DECLARE_PUBLIC_FLATTENABLE_DESERIALIZATION_PROCS(MCGLegacyGradientShader)
-
-protected:
-    size_t onContextSize(const ContextRec&) const override;
-    Context* onCreateContext(const ContextRec&, void* storage) const override;
-
-private:
-    MCGGradientRef			m_gradient_ref;
-    MCGRectangle			m_clip;
-
-    typedef SkShader::Context INHERITED;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/src/harfbuzztext.cpp
+++ b/libgraphics/src/harfbuzztext.cpp
@@ -368,14 +368,14 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 		return;	
     
     SkPaint t_paint;
-    t_paint . setStyle(SkPaint::kFill_Style);
-    t_paint . setAntiAlias(true);
-    t_paint . setColor(MCGColorToSkColor(self -> state -> fill_color));
+    if (!MCGContextSetupFill(self, t_paint))
+    {
+        self->is_valid = false;
+        return;
+    }
+    
     t_paint . setTextSize(p_font . size);
     t_paint . setTextEncoding(SkPaint::kGlyphID_TextEncoding);
-    
-    SkBlendMode t_blend_mode = MCGBlendModeToSkBlendMode(self -> state -> blend_mode);
-    t_paint.setBlendMode(t_blend_mode);
     
     MCGlyphRun *t_glyph_runs;
     uindex_t t_count;

--- a/libgraphics/src/lnxtext.cpp
+++ b/libgraphics/src/lnxtext.cpp
@@ -215,27 +215,28 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
 		
 		pango_ft2_render_layout_line(&t_ftbitmap, t_line, -(t_clipped_bounds . x - t_text_bounds . x), -(t_clipped_bounds . y - t_text_bounds . y) - t_text_bounds . y);
 		
-		SkPaint t_paint;
-		t_paint . setStyle(SkPaint::kFill_Style);	
-		t_paint . setAntiAlias(self -> state -> should_antialias);
-		t_paint . setColor(MCGColorToSkColor(self -> state -> fill_color));
-		
-		SkBlendMode t_blend_mode = MCGBlendModeToSkBlendMode(self->state->blend_mode);
-		t_paint.setBlendMode(t_blend_mode);
+        // The paint containing the fill settings
+        SkPaint t_paint;
+        if (MCGContextSetupFill(self, t_paint))
+        {
+            SkImageInfo t_info = SkImageInfo::MakeA8(t_clipped_bounds.width, t_clipped_bounds.height);
+            
+            SkBitmap t_bitmap;
+            t_bitmap.setInfo(t_info);
+            t_bitmap.setPixels(t_data);
 
-		SkImageInfo t_info = SkImageInfo::MakeA8(t_clipped_bounds.width, t_clipped_bounds.height);
-		
-		SkBitmap t_bitmap;
-		t_bitmap.setInfo(t_info);
-		t_bitmap.setPixels(t_data);
-
-		self->layer->canvas->save();
-		self->layer->canvas->resetMatrix();
-		self->layer->canvas->drawBitmap(t_bitmap,
-						t_clipped_bounds.x + t_device_location.x,
-						t_clipped_bounds.y + t_device_location.y,
-						&t_paint);
-		self->layer->canvas->restore();
+            self->layer->canvas->save();
+            self->layer->canvas->resetMatrix();
+            self->layer->canvas->drawBitmap(t_bitmap,
+                            t_clipped_bounds.x + t_device_location.x,
+                            t_clipped_bounds.y + t_device_location.y,
+                            &t_paint);
+            self->layer->canvas->restore();
+        }
+        else
+        {
+            self->is_valid = false;
+        }
 	}
     
 	MCMemoryDelete(t_data);

--- a/libgraphics/src/path.cpp
+++ b/libgraphics/src/path.cpp
@@ -1083,32 +1083,6 @@ void MCGPathCloseSubpath(MCGPathRef self)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCGPathThicken(MCGPathRef self, const MCGStrokeAttr& p_attr, MCGPathRef& r_thick_path)
-{
-	if (!MCGPathIsValid(self))
-		return;
-	
-	// TODO: Implement
-}
-
-void MCGPathFlatten(MCGPathRef self, MCGFloat p_flatness, MCGPathRef& r_flat_path)
-{
-	if (!MCGPathIsValid(self))
-		return;
-	
-	// TODO: Implement
-}
-
-void MCGPathSimplify(MCGPathRef self, MCGPathRef& r_simple_path)
-{
-	if (!MCGPathIsValid(self))
-		return;
-	
-	// TODO: Implement
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 bool MCGPathGetBoundingBox(MCGPathRef self, MCGRectangle &r_bounds)
 {
 	if (!MCGPathIsValid(self))


### PR DESCRIPTION
This patch contains a number of changes to libgraphics to assist with SVG support.

In particular, it:

- implements FillOpacity and StrokeOpacity
- adds separate setters for DashArray and DashOffset
- adds a Transform setter (which changes the transform to apply since last Save)
- reworks patterns/gradients/colors to be ref-counted Paint objects internally
- adds setters to set the fill and stroke paint to None
- integrates 'legacy' gradient support direct into a Skia shader
- uses our gradient code when 'good' quality gradients are requested
