### PR TITLE
[[ Bug ]] Fix breakpoint delete crash

### DIFF
--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -292,9 +292,6 @@ MCObject::~MCObject()
 	if (parent_script != NULL)
 		parent_script -> Release();
 
-	// MW-2009-11-03: Clear all current breakpoints for this object
-	MCB_clearbreaks(this);
-
 	if (!MCerrorptr.IsValid() || MCerrorptr == this)
 		MCerrorptr = nil;
 	if (state & CS_SELECTED)
@@ -861,6 +858,9 @@ void MCObject::removereferences()
     MCscreen->cancelmessageobject(this, NULL);
     removefrom(MCfrontscripts);
     removefrom(MCbackscripts);
+    
+    // MW-2009-11-03: Clear all current breakpoints for this object
+    MCB_clearbreaks(this);
     
     // If the object is marked as being used as a parentScript, flush the parentScript
     // table so we don't get any dangling pointers.

--- a/tests/lcs/core/execution/object-deletion.livecodescript
+++ b/tests/lcs/core/execution/object-deletion.livecodescript
@@ -118,6 +118,21 @@ on __TestDeleteStack
       delete stack "test"
 end __TestDeleteStack
 
+on TestDeleteObjectWithBreakpoint
+   create stack "crash test"
+   set the script of stack "crash test" to \
+         "on Foo" & return & return & "get it" & return & "end Foo"
+   create stack "delete"
+   set the script of stack "delete" to \
+         "on Foo" & return & "delete stack " & quote & "crash test" & quote & return & "get it" & return & "end Foo"
+   set the breakpoints to \
+         the long id of stack "crash test",3 & return & \
+         the long id of stack "delete",3 
+   send "Foo" to stack "delete" in 0
+   wait 0 with messages
+   TestAssert "Delete object with breakpoint", true
+end TestDeleteObjectWithBreakpoint
+
 on TestTeardown
    if there is a stack "test" then
       delete stack "test"


### PR DESCRIPTION
This patch moves `MCB_clearbreaks` to `MCObject::removereferences` to ensure
that `MCbreakpoints` can not contain any invalid object references.