### PR TITLE
[[ Bug 20759 ]] Add `NSPhotoLibraryAddUsageDescription`

### DIFF
--- a/docs/notes/bugfix-20759.md
+++ b/docs/notes/bugfix-20759.md
@@ -1,0 +1,1 @@
+# Fix crash saving images to iOS photo library

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -95,6 +95,8 @@
 	<string>This application requires access to your Reminders</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This application requires access to Photo Library</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>This application requires access to read the user's health data</string>
 	<key>NSHealthUpdateUsageDescription</key>


### PR DESCRIPTION
This patch adds `NSPhotoLibraryAddUsageDescription` to the iOS plist
template. This key is required when building against iOS 10+ and saving
to the photo library.