### PR TITLE
[[ Bug 20578 ]] Fix replaceText performance regression

### DIFF
--- a/docs/notes/bugfix-20578.md
+++ b/docs/notes/bugfix-20578.md
@@ -1,0 +1,1 @@
+# Fix performance regression in replaceText

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -906,6 +906,16 @@ void MCStringsEvalReplaceText(MCExecContext& ctxt, MCStringRef p_string, MCStrin
         ctxt.LegacyThrow(EE_REPLACETEXT_BADPATTERN);
         return;
     }
+    
+    /* MCR_exec needs to use a unicode string as we use PCRE compiled with 16-bit
+     * unit support. We copy the string here so that we aren't re-copying each
+     * call to MCR_exec. */
+    MCAutoStringRef t_unicode_string;
+    if (!MCStringUnicodeCopy(p_string, &t_unicode_string))
+    {
+        ctxt.Throw();
+        return;
+    }
 
     bool t_success = true;
     
@@ -917,7 +927,7 @@ void MCStringsEvalReplaceText(MCExecContext& ctxt, MCStringRef p_string, MCStrin
 	MCStringRef t_substring;
 	t_substring = nil;
     
-    while (t_success && t_source_offset < t_source_length && MCR_exec(t_compiled, p_string, MCRangeMake(t_source_offset, MCStringGetLength(p_string) - (t_source_offset))))
+    while (t_success && t_source_offset < t_source_length && MCR_exec(t_compiled, *t_unicode_string, MCRangeMake(t_source_offset, MCStringGetLength(p_string) - (t_source_offset))))
     {
         uindex_t t_start = t_compiled->matchinfo[0].rm_so;
         uindex_t t_end = t_compiled->matchinfo[0].rm_eo;


### PR DESCRIPTION
In order to fix Bug 19005 it was necessary to perform a UnicodeCopy
on the input string to MCR_exec which is used by the replaceText()
function.

However, the replaceText function calls MCR_exec multiple times
which means that complete copy of the input string is being
performed many times unnecessarily.

This patch performs a UnicodeCopy of the string before the call
to MCR_exec, meaning it is only copied once for an entire replaceText
operation.