### PR TITLE
[[ Bug 18010 ]] Add optional 'kind' parameter to files/folders

### DIFF
--- a/docs/dictionary/function/files.lcdoc
+++ b/docs/dictionary/function/files.lcdoc
@@ -4,7 +4,7 @@ Type: function
 
 Syntax: the [{ detailed | long }] files
 
-Syntax: files([<targetFolder>])
+Syntax: files([<targetFolder>[, <outputKind>]])
 
 Summary:
 List the files in a folder.
@@ -38,6 +38,9 @@ filter tDiskContents["the defaultFolder"] without ".."
 Parameters:
 targetFolder (String):
 The folder path to search.
+outputKind (enum):
+- empty: Use the short form
+- "detailed": Use the long/detailed form
 
 Returns (String):
 A list of file names or file information, with one

--- a/docs/dictionary/function/folders.lcdoc
+++ b/docs/dictionary/function/folders.lcdoc
@@ -4,7 +4,7 @@ Type: function
 
 Syntax: the [{ detailed | long }] folders
 
-Syntax: folders([<targetFolder>])
+Syntax: folders([<targetFolder>[, <outputKind>]])
 
 Summary:
 List the subfolders in a folder.
@@ -32,6 +32,9 @@ filter tDiskContents["the defaultFolder"] without ".."
 Parameters:
 targetFolder (String):
 The folder path to search.
+outputKind (enum):
+- empty: Use the short form
+- "detailed": Use the long/detailed form
 
 Returns (String):
 A list of folder names or folder information, with

--- a/docs/notes/bugfix-18010.md
+++ b/docs/notes/bugfix-18010.md
@@ -1,0 +1,7 @@
+# Add optional 'kind' parameter to files/folders
+
+The files and folders functions can now take an optional
+second parameter 'kind'. The kind parameter can be either
+empty or "detailed". If empty, the normal (short) form of
+the function is returned, otherwise the detailed (long)
+form of the function is returned.

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -53,15 +53,12 @@ MCExecEnumTypeInfo *kMCFilesEofEnumTypeInfo = &_kMCFilesEofEnumTypeInfo;
 
 //////////
 
-void MCFilesEvalDirectories(MCExecContext & ctxt,
-                            MCStringRef & r_string)
-{
-	MCFilesEvalDirectoriesOfDirectory(ctxt, nil, r_string);
-}
-
-void MCFilesEvalDirectoriesOfDirectory(MCExecContext& ctxt,
-                                       MCStringRef p_directory,
-                                       MCStringRef& r_string)
+void
+MCFilesEvalFileItemsOfDirectory(MCExecContext& ctxt,
+                                MCStringRef p_directory,
+                                bool p_files,
+                                bool p_detailed,
+                                MCStringRef& r_string)
 {
 	if (MCsecuremode & MC_SECUREMODE_DISK)
 	{
@@ -69,33 +66,7 @@ void MCFilesEvalDirectoriesOfDirectory(MCExecContext& ctxt,
 		return;
 	}
 	MCAutoListRef t_list;
-	if (MCS_getentries(p_directory, false, false, &t_list))
-	{
-		MCListCopyAsString(*t_list, r_string);
-	}
-	else
-	{
-		MCStringCopy(kMCEmptyString, r_string);
-	}
-}
-
-void MCFilesEvalFiles(MCExecContext & ctxt,
-                      MCStringRef & r_string)
-{
-	MCFilesEvalFilesOfDirectory(ctxt, nil, r_string);
-}
-
-void MCFilesEvalFilesOfDirectory(MCExecContext& ctxt,
-                                 MCStringRef p_directory,
-                                 MCStringRef& r_string)
-{
-	if (MCsecuremode & MC_SECUREMODE_DISK)
-	{
-		ctxt . LegacyThrow(EE_DISK_NOPERM);
-		return;
-	}
-	MCAutoListRef t_list;
-	if (MCS_getentries(p_directory, true, false, &t_list))
+	if (MCS_getentries(p_directory, p_files, p_detailed, &t_list))
 	{
 		MCListCopyAsString(*t_list, r_string);
 	}

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3148,10 +3148,7 @@ void MCEngineEvalCommandArgumentAtIndex(MCExecContext& ctxt, uinteger_t t_index,
 
 ///////////
 
-void MCFilesEvalDirectories(MCExecContext& ctxt, MCStringRef& r_string);
-void MCFilesEvalDirectoriesOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, MCStringRef& r_string);
-void MCFilesEvalFiles(MCExecContext& ctxt, MCStringRef& r_string);
-void MCFilesEvalFilesOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, MCStringRef& r_string);
+void MCFilesEvalFileItemsOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, bool p_files, bool p_detailed, MCStringRef& r_string);
 void MCFilesEvalDiskSpace(MCExecContext& ctxt, real64_t& r_result);
 void MCFilesEvalDriverNames(MCExecContext& ctxt, MCStringRef& r_string);
 void MCFilesEvalDrives(MCExecContext& ctxt, MCStringRef& r_string);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2761,6 +2761,12 @@ enum Exec_errors
 
     // {EE-0904} stack: password protecting stacks not supported in this edition
     EE_STACK_PASSWORD_NOT_SUPPORTED,
+    
+    // {EE-0905} files: error in kind parameter
+    EE_FILES_BADKIND,
+    
+    // {EE-0906} folders: error in kind parameter
+    EE_FOLDERS_BADKIND,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -125,34 +125,41 @@ Parse_stat MCExpression::get0params(MCScriptPoint &sp)
 	return PS_NORMAL;
 }
 
+Parse_stat MCExpression::gettheparam(MCScriptPoint& sp, Boolean single, MCExpression** exp)
+{
+    initpoint(sp);
+    if (sp.skip_token(SP_FACTOR, TT_OF) != PS_NORMAL)
+        return PS_NORMAL;
+    if (sp.parseexp(single, False, exp) != PS_NORMAL)
+    {
+        MCperror->add
+        (PE_FACTOR_BADPARAM, sp);
+        return PS_ERROR;
+    }
+	return PS_NORMAL;
+}
+
 Parse_stat MCExpression::get0or1param(MCScriptPoint &sp, MCExpression **exp,
                                       Boolean the)
 {
 	if (the)
 	{
-		initpoint(sp);
-		if (sp.skip_token(SP_FACTOR, TT_OF) != PS_NORMAL)
-			return PS_NORMAL;
-		if (sp.parseexp(False, False, exp) != PS_NORMAL)
-		{
-			MCperror->add
-			(PE_FACTOR_BADPARAM, sp);
-			return PS_ERROR;
-		}
+        return gettheparam(sp, False, exp);
 	}
-	else
-	{
-		MCExpression *earray[MAX_EXP];
-		uint2 ecount = 0;
-		if (getexps(sp, earray, ecount) != PS_NORMAL || ecount > 1)
-		{
-			freeexps(earray, ecount);
-			return PS_ERROR;
-		}
-		else
-			if (ecount == 1)
-				*exp = earray[0];
+
+    MCExpression *earray[MAX_EXP];
+    uint2 ecount = 0;
+    if (getexps(sp, earray, ecount) != PS_NORMAL || ecount > 1)
+    {
+        freeexps(earray, ecount);
+        return PS_ERROR;
+    }
+    
+    if (ecount == 1)
+    {
+        *exp = earray[0];
 	}
+    
 	return PS_NORMAL;
 }
 
@@ -161,32 +168,47 @@ Parse_stat MCExpression::get1param(MCScriptPoint &sp, MCExpression **exp,
 {
 	if (the)
 	{
-		initpoint(sp);
-		if (sp.skip_token(SP_FACTOR, TT_OF) != PS_NORMAL)
-		{
-			MCperror->add
-			(PE_FACTOR_NOOF, sp);
-			return PS_ERROR;
-		}
-		if (sp.parseexp(True, False, exp) != PS_NORMAL)
-		{
-			MCperror->add
-			(PE_FACTOR_BADPARAM, sp);
-			return PS_ERROR;
-		}
+        return gettheparam(sp, True, exp);
 	}
-	else
+    
+    MCExpression *earray[MAX_EXP];
+    uint2 ecount = 0;
+    if (getexps(sp, earray, ecount) != PS_NORMAL || ecount != 1)
+    {
+        freeexps(earray, ecount);
+        return PS_ERROR;
+    }
+    
+    *exp = earray[0];
+	
+    return PS_NORMAL;
+}
+
+Parse_stat MCExpression::get0or1or2params(MCScriptPoint &sp, MCExpression **exp1,
+                                            MCExpression **exp2, Boolean the)
+{
+	if (the)
 	{
-		MCExpression *earray[MAX_EXP];
-		uint2 ecount = 0;
-		if (getexps(sp, earray, ecount) != PS_NORMAL || ecount != 1)
-		{
-			freeexps(earray, ecount);
-			return PS_ERROR;
-		}
-		else
-			*exp = earray[0];
+        return gettheparam(sp, False, exp1);
 	}
+    
+    MCExpression *earray[MAX_EXP];
+    uint2 ecount = 0;
+    if (getexps(sp, earray, ecount) != PS_NORMAL || ecount > 2)
+    {
+        freeexps(earray, ecount);
+        return PS_ERROR;
+    }
+    
+    if (ecount > 0)
+    {
+        *exp1 = earray[0];
+        if (ecount > 1)
+        {
+            *exp2 = earray[1];
+        }
+    }
+    
 	return PS_NORMAL;
 }
 
@@ -195,33 +217,24 @@ Parse_stat MCExpression::get1or2params(MCScriptPoint &sp, MCExpression **exp1,
 {
 	if (the)
 	{
-		initpoint(sp);
-		if (sp.skip_token(SP_FACTOR, TT_OF) != PS_NORMAL)
-		{
-			MCperror->add
-			(PE_FACTOR_NOOF, sp);
-			return PS_ERROR;
-		}
-		if (sp.parseexp(True, False, exp1) != PS_NORMAL)
-		{
-			MCperror->add
-			(PE_FACTOR_BADPARAM, sp);
-			return PS_ERROR;
-		}
+        return gettheparam(sp, True, exp1);
 	}
-	else
-	{
-		MCExpression *earray[MAX_EXP];
-		uint2 ecount = 0;
-		if (getexps(sp, earray, ecount) != PS_NORMAL || ecount < 1 || ecount > 2)
-		{
-			freeexps(earray, ecount);
-			return PS_ERROR;
-		}
-		*exp1 = earray[0];
-		if (ecount == 2)
-			*exp2 = earray[1];
-	}
+    
+    MCExpression *earray[MAX_EXP];
+    uint2 ecount = 0;
+    if (getexps(sp, earray, ecount) != PS_NORMAL || ecount < 1 || ecount > 2)
+    {
+        freeexps(earray, ecount);
+        return PS_ERROR;
+    }
+    
+    *exp1 = earray[0];
+    
+    if (ecount == 2)
+    {
+        *exp2 = earray[1];
+    }
+    
 	return PS_NORMAL;
 }
 

--- a/engine/src/express.h
+++ b/engine/src/express.h
@@ -115,6 +115,8 @@ public:
 	Parse_stat get0params(MCScriptPoint &);
 	Parse_stat get0or1param(MCScriptPoint &sp, MCExpression **exp, Boolean the);
 	Parse_stat get1param(MCScriptPoint &, MCExpression **exp, Boolean the);
+    Parse_stat get0or1or2params(MCScriptPoint &, MCExpression **e1,
+                                MCExpression **e2, Boolean the);
 	Parse_stat get1or2params(MCScriptPoint &, MCExpression **e1,
 	                         MCExpression **e2, Boolean the);
 	Parse_stat get2params(MCScriptPoint &, MCExpression **e1, MCExpression **e2);
@@ -133,6 +135,11 @@ public:
 	Parse_stat getparams(MCScriptPoint &spt, MCParameter **params);
 	void initpoint(MCScriptPoint &);
 	static bool compare_array_element(void *context, MCArrayRef array, MCNameRef key, MCValueRef value);
+    
+private:
+    /* The single parameter is parsed to the 'single' argument of parseexp -
+     * for 0 param fetches this is False, for others this is True. */
+    Parse_stat gettheparam(MCScriptPoint& sp, Boolean single, MCExpression** exp);
 };
 
 class MCFuncref : public MCExpression

--- a/engine/src/funcs.h
+++ b/engine/src/funcs.h
@@ -533,17 +533,6 @@ public:
     virtual ~MCDecompress(){}
 };
 
-class MCDirectories : public MCFunction
-{
-public:
-	MCDirectories() : m_folder(nil) {}
-	virtual ~MCDirectories();
-	virtual Parse_stat parse(MCScriptPoint &, Boolean p_is_the);
-	virtual void eval_ctxt(MCExecContext &, MCExecValue &);
-private:
-	MCExpression *m_folder;
-};
-
 class MCDiskSpace : public MCConstantFunctionCtxt<double, MCFilesEvalDiskSpace>
 {
 public:
@@ -670,15 +659,17 @@ public:
     virtual ~MCExtents(){}
 };
 
-class MCTheFiles : public MCFunction
+class MCFileItems : public MCFunction
 {
 public:
-	MCTheFiles() : m_folder(nil) {}
-	virtual ~MCTheFiles();
+	MCFileItems(bool p_files) : m_folder(nil), m_kind(nullptr), m_files(p_files)  {}
+	virtual ~MCFileItems();
 	virtual Parse_stat parse(MCScriptPoint &, Boolean p_is_the);
 	virtual void eval_ctxt(MCExecContext &, MCExecValue &);
 private:
 	MCExpression *m_folder;
+    MCExpression *m_kind;
+    bool m_files;
 };
 
 class MCFlushEvents : public MCUnaryFunctionCtxt<MCNameRef, MCStringRef, MCInterfaceEvalFlushEvents, EE_FLUSHEVENTS_BADTYPE, PE_FLUSHEVENTS_BADPARAM>

--- a/engine/src/newobj.cpp
+++ b/engine/src/newobj.cpp
@@ -433,7 +433,7 @@ MCExpression *MCN_new_function(int2 which)
 	case F_DELETE_RESOURCE:
 		return new MCDeleteResource;
 	case F_DIRECTORIES:
-		return new MCDirectories;
+		return new MCFileItems(false);
 	case F_DISK_SPACE:
 		return new MCDiskSpace;
 	case F_DNS_SERVERS:
@@ -475,7 +475,7 @@ MCExpression *MCN_new_function(int2 which)
 	case F_EXTENTS:
 		return new MCExtents;
 	case F_FILES:
-		return new MCTheFiles;
+		return new MCFileItems(true);
 	case F_FLUSH_EVENTS:
 		return new MCFlushEvents;
 	case F_FOCUSED_OBJECT:

--- a/tests/lcs/core/files/folders.livecodescript
+++ b/tests/lcs/core/files/folders.livecodescript
@@ -44,6 +44,8 @@ on TestFilesOfFolder
 
    TestAssert "list non-current directory", tTestFile is among the lines of files(tFolder)
 
+   TestAssert "list non-current directory (detailed)", the number of items in line 1 of files(tFolder, "detailed") > 1
+
    local tOldFolder
    put the defaultFolder into tOldFolder
    set the defaultFolder to tFolder
@@ -63,6 +65,8 @@ on TestFoldersOfFolder
    TestDiagnostic the result
 
    TestAssert "list non-current directory", tTestFolder is among the lines of folders(tFolder)
+
+   TestAssert "list non-current directory (detailed)", the number of items in line 2 of folders(tFolder, "detailed") > 1
 
    local tOldFolder
    put the defaultFolder into tOldFolder


### PR DESCRIPTION
This patch unifies the implementation of files() and folders()
and adds an optional second parameter 'kind'. The kind parameter
can be empty or "detailed". If it is detailed then the 'detailed'
variant of the request is made, otherwise the normal variant
is made.