### PR TITLE
[[ ObjcDelegates ]] Enable creation of objc delegates implementing protocol methods

### DIFF
--- a/docs/lcb/notes/feature-objc_delegates.md
+++ b/docs/lcb/notes/feature-objc_delegates.md
@@ -1,0 +1,103 @@
+# LiveCode Builder Language
+## Objective-C delegate support
+Handlers `CreateObjcDelegate` and `CreateObjcDelegateWithContext` have 
+been added to the objc module which allow the creation of custom 
+delegate objects with LCB implementations of protocol methods.
+   
+In order to create a delegate to handle a particular protocol method, 
+pass in the protocol name as the first argument and the mapping from 
+method names to LCB handlers as the second argument. For example, to 
+create a selectionChanged message for an `NSTextView`, we need to create 
+a handler
+
+	private handler DidChangeSelection(in pNotification as ObjcObject) returns nothing
+		post "selectionChanged"
+	end handler
+
+and create a `NSTextViewDelegate`:
+
+	variable tDelegate as optional ObjcObject
+	put CreateObjcDelegate( \
+		"NSTextViewDelegate", \ 	
+		{"textViewDidChangeSelection:": DidChangeSelection}, \
+		) into tDelegate
+	if tDelegate is not nothing then
+		put tDelegate into mTextViewDelegate
+	end if
+	
+Optionally, a context parameter can be passed in at delegate creation
+time:
+
+	put CreateObjcDelegateWithContext( \
+		"NSTextViewDelegate", \ 	
+		{"textViewDidChangeSelection:": DidChangeSelectionContext}, \
+		tContext) into tDelegate
+		
+	if tDelegate is not nothing then
+		put tDelegate into mTextViewDelegate
+	end if
+
+In this case the context variable will be passed as first argument of 
+the corresponding LCB callback:
+
+	private handler DidChangeSelectionContext(in pContext, in pNotification as ObjcObject) returns nothing
+		post "selectionChanged" with [pContext]
+	end handler
+
+Some protocols consist of purely optional methods. In this case the 
+information about the protocol's methods are not available from the 	
+objective-c runtime API. For this eventuality there are also handlers
+`CreateObjcInformalDelegate` and `CreateObjcInformalDelegateWithContext`.
+
+These handlers take a list of foreign handlers as their first argument
+instead of a protocol name. The foreign handlers' information is used to
+resolve incoming selectors so that the desired LCB callback is called. 
+For example the `NSSoundDelegate` protocol has only one method, and it 
+is optional, 
+
+	- (void)sound:(NSSound *)sound didFinishPlaying:(BOOL)aBool;
+
+So in order to create an `NSSoundDelegate`, we need to create a list of
+foreign handlers, in this case just the following:
+
+	foreign handler NSSoundDidFinishPlaying(in pSound as ObjcId, in pDidFinish as CSChar) binds to "objc:.-sound:didFinishPlaying:"
+	
+and create the informal delegate
+	
+	handler DidSoundFinish(in pSound as ObjcId, in pDidFinish as Boolean) returns nothing
+		if pDidFinish then
+			post "soundFinished"
+		end if
+	end handler
+	
+	foreign handler Objc_SetSoundDelegate(in pSound as ObjcId, in pDelegate as ObjcId) returns nothing \
+		binds to "objc:NSSound.-setDelegate:"
+	...
+	
+	variable tDelegate as optional ObjcObject
+	put CreateObjcInformalDelegate( \
+		[NSSoundDidFinishPlaying], \ 	
+		{"textViewDidChangeSelection:": DidChangeSelection}) \
+		into tDelegate
+	end if
+	if tDelegate is not nothing then
+		put tDelegate into mSoundDelegate
+		Objc_SetSoundDelegate(tSound, tDelegate)
+	end if
+
+> *Note:* Delegate properties are usually 'assigned' rather than 
+> 'retained', so it is necessary to store them in module variables 
+> until they are no longer needed. Generally the pattern required is
+> as follows:
+
+	handler OnOpen()
+		-- Create native view and set native layer
+		-- Set native view delegate property
+		-- Store view and delegate in module vars
+	end handler
+
+	handler OnClose()
+		-- Set native view delegate property to nothing
+		-- Put nothing into view and delegate module vars
+		-- Set native layer to nothing
+	end handler

--- a/libfoundation/include/foundation-objc.h
+++ b/libfoundation/include/foundation-objc.h
@@ -31,5 +31,5 @@ NSData *MCDataConvertToAutoreleasedNSData(MCDataRef data);
 #endif
 
 extern MCTypeInfoRef kMCObjcDelegateCallbackSignatureErrorTypeInfo;
-
+extern MCTypeInfoRef kMCObjcDelegateMappingErrorTypeInfo;
 #endif

--- a/libfoundation/include/foundation-objc.h
+++ b/libfoundation/include/foundation-objc.h
@@ -30,4 +30,6 @@ NSString *MCNameConvertToAutoreleasedNSString(MCNameRef name);
 NSData *MCDataConvertToAutoreleasedNSData(MCDataRef data);
 #endif
 
+extern MCTypeInfoRef kMCObjcDelegateCallbackSignatureErrorTypeInfo;
+
 #endif

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3060,12 +3060,19 @@ MC_DLLEXPORT bool MCRecordIterate(MCRecordRef record, uintptr_t& x_iterator, MCN
 //  HANDLER DEFINITIONS
 //
 
+enum MCHandlerQueryType
+{
+    kMCHandlerQueryTypeNone,
+    kMCHandlerQueryTypeObjcSelector,
+};
+    
 struct MCHandlerCallbacks
 {
     size_t size;
     void (*release)(void *context);
     bool (*invoke)(void *context, MCValueRef *arguments, uindex_t argument_count, MCValueRef& r_value);
 	bool (*describe)(void *context, MCStringRef& r_desc);
+    bool (*query)(void *context, MCHandlerQueryType type, void *r_info);
 };
 
 MC_DLLEXPORT bool MCHandlerCreate(MCTypeInfoRef typeinfo, const MCHandlerCallbacks *callbacks, void *context, MCHandlerRef& r_handler);

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -3552,6 +3552,24 @@ MC_DLLEXPORT void *MCObjcObjectGetRetainedId(MCObjcObjectRef obj);
  * an ObjcObject. The id is autoreleased before being returned. */
 MC_DLLEXPORT void *MCObjcObjectGetAutoreleasedId(MCObjcObjectRef obj);
 
+/* Create an ObjcObject containing an instance of the com_livecode_MCObjcFormalDelegate class,
+ * mapping protocol methods to MCHandlerRefs, with
+ * a context parameter. */
+MC_DLLEXPORT bool MCObjcCreateDelegateWithContext(MCStringRef p_protocol_name, MCArrayRef p_handler_mapping, MCValueRef p_context, MCObjcObjectRef& r_object);
+
+/* Create an ObjcObject containing an instance of  the com_livecode_MCObjcFormalDelegate class,
+ * mapping protocol methods to MCHandlerRefs. */
+MC_DLLEXPORT bool MCObjcCreateDelegate(MCStringRef p_protocol_name, MCArrayRef p_handler_mapping, MCObjcObjectRef& r_object);
+
+/* Create an ObjcObject containing an instance of  the com_livecode_MCObjcInformalDelegate class,
+ * mapping informal protocol methods specified as a list of foreign handler to MCHandlerRefs, with
+ * a context parameter. */
+MC_DLLEXPORT bool MCObjcCreateInformalDelegateWithContext(MCProperListRef p_foreign_handlers, MCArrayRef p_handler_mapping, MCValueRef p_context, MCObjcObjectRef& r_object);
+    
+/* Create an ObjcObject containing an instance of  the com_livecode_MCObjcInformalDelegate class,
+ * mapping informal protocol methods specified as a list of foreign handler to MCHandlerRefs. */
+MC_DLLEXPORT bool MCObjcCreateInformalDelegate(MCProperListRef p_foreign_handlers, MCArrayRef p_handler_mapping, MCObjcObjectRef& r_object);
+    
 ////////////////////////////////////////////////////////////////////////////////
 
 enum MCPickleFieldType

--- a/libfoundation/src/foundation-objc-dummy.cpp
+++ b/libfoundation/src/foundation-objc-dummy.cpp
@@ -276,6 +276,32 @@ MC_DLLEXPORT_DEF uintptr_t MCObjcObjectGetActionProxySelector(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+extern "C" MC_DLLEXPORT_DEF
+bool MCObjcCreateDelegateWithContext(MCStringRef p_protocol_name, MCArrayRef p_handler_mapping, MCValueRef p_context, MCObjcObjectRef& r_object)
+{
+    return false;
+}
+
+extern "C" MC_DLLEXPORT_DEF
+bool MCObjcCreateDelegate(MCStringRef p_protocol_name, MCArrayRef p_handler_mapping, MCObjcObjectRef& r_object)
+{
+    return false;
+}
+
+extern "C" MC_DLLEXPORT_DEF
+bool MCObjcCreateInformalDelegateWithContext(MCProperListRef p_foreign_handlers, MCArrayRef p_handler_mapping, MCValueRef p_context, MCObjcObjectRef& r_object)
+{
+	return false;
+}
+
+extern "C" MC_DLLEXPORT_DEF
+bool MCObjcCreateInformalDelegate(MCProperListRef p_foreign_handlers, MCArrayRef p_handler_mapping, MCObjcObjectRef& r_object)
+{
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 bool __MCObjcInitialize(void)
 {
     if (!MCNamedCustomTypeInfoCreate(MCNAME("com.livecode.objc.ObjcObject"),

--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -383,7 +383,12 @@ MC_DLLEXPORT_DEF uintptr_t MCObjcObjectGetActionProxySelector(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#if defined(__MAC__)
 #include <AppKit/AppKit.h>
+#else
+#import <Foundation/NSInvocation.h>
+#import <Foundation/NSMethodSignature.h>
+#endif
 #include <objc/runtime.h>
 
 @interface com_livecode_MCObjcDelegate: NSObject

--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -791,7 +791,10 @@ static MCHandlerRef _fetch_handler_for_selector(SEL p_selector, MCArrayRef p_map
 {
     // Check the handler mapping to see if this delegate wants to handle
     // the incoming selector
-    return [self handlerFromSelector:aSelector] != nullptr;
+    if ([self handlerFromSelector:aSelector] != nullptr)
+        return YES;
+    
+    return [super respondsToSelector:aSelector];
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector

--- a/libfoundation/src/foundation-objc.mm
+++ b/libfoundation/src/foundation-objc.mm
@@ -1085,9 +1085,10 @@ bool MCObjcCreateInformalDelegateWithContext(MCProperListRef p_foreign_handlers,
             return false;
         
         SEL t_selector = nullptr;
-        t_callbacks->query(MCHandlerGetContext(t_handler),
-                           kMCHandlerQueryTypeObjcSelector,
-                           &t_selector);
+        if (!t_callbacks->query(MCHandlerGetContext(t_handler),
+                                kMCHandlerQueryTypeObjcSelector,
+                                &t_selector))
+            return false;
         
         if (t_selector == nullptr)
             return false;

--- a/libscript/src/objc.lcb
+++ b/libscript/src/objc.lcb
@@ -354,5 +354,260 @@ end handler
 
 /****/
 
-end module
+private foreign handler _MCObjcCreateDelegate(in pProtocol as String, in pHandlerMapping as Array, out rDelegate as ObjcObject) returns CBool \
+    binds to "MCObjcCreateDelegate"
 
+/**
+Create an Objective-C object with LCB implementations of methods of a protocol.
+
+Example:
+handler ControlIsValidObjectCallback(in pControl as ObjcId, in pObject as ObjcId) returns CSChar
+    return 1
+end handler
+
+public handler GetNSControlTextEditingDelegate() returns ObjcObject
+    return CreateObjcDelegate("NSControlTextEditingDelegate", \
+                              { "control:isValidObject:": \
+                                ControlIsValidObjectCallback })
+end handler
+
+Parameters:
+pProtocol: The name of the protocol
+pHandlerMapping: A mapping from the protocol's selector names to LCB handlers
+
+Returns: An Objective-C object which calls the appropriate LCB handler
+on receiving any of the specified selectors. 
+
+Description:
+Use the <CreateObjcDelegate> handler to create instances of Objective-C 
+delegate classes with LCB implementations of protocol methods. Once 
+created these can be set in the usual way on an instance of the 
+appropriate class (by binding to `-setDelegate:`), typically so that 
+callbacks triggered by user interaction with a widget can be handled in
+LCB.
+
+If any context is required to be passed as a parameter to the callback,
+use <CreateObjcDelegateWithContext>.
+
+Some protocols consist of purely optional methods. In this case the 
+information about the protocol's methods are not available from the     
+objective-c runtime API. In this situation <CreateObjcInformalDelegate> 
+should be used instead.
+
+References:
+CreateObjcDelegateWithContext (handler), 
+CreateObjcInformalDelegate (handler), 
+CreateObjcInformalDelegateWithContext (handler)
+
+*/
+public handler CreateObjcDelegate(in pProtocol as String, in pHandlerMapping as Array) returns optional ObjcObject
+    unsafe
+        variable tObj as ObjcObject
+        if _MCObjcCreateDelegate(pProtocol, pHandlerMapping, tObj) then
+            return tObj
+        end if
+        return nothing
+    end unsafe
+end handler
+
+private foreign handler _MCObjcCreateDelegateWithContext(in pProtocol as String, in pHandlerMapping as Array, in pContext as optional any, out rDelegate as ObjcObject) returns CBool \
+    binds to "MCObjcCreateDelegateWithContext"    
+
+/**
+Create an Objective-C object with LCB implementations of methods of a protocol.
+
+Example:
+handler NumberOfItemsInMenuCallback(in pContext as String, in pMenu as ObjcId) returns CLong
+    -- pContext is the tag for this menu
+    return the number of elements in mMenuArray[pContext]
+end handler
+
+public handler GetNSMenuDelegate(in pMenuTag as String) returns ObjcObject
+    return CreateObjcDelegateWithContext("NSMenuDelegate", \
+                                           { "numberOfItemsInMenu:": \
+                                           NumberOfItemsInMenuCallback }, \
+                                           pMenuTag)
+end handler
+        
+Parameters:
+pProtocol: The name of the protocol
+pHandlerMapping: A mapping from the protocol's selector names to LCB handlers
+pContext: Any context required in the callback.
+
+Returns: An Objective-C object which calls the appropriate LCB handler
+on receiving any of the specified selectors. 
+
+Description:
+Use the <CreateObjcDelegateWithContext> handler to create instances of 
+Objective-C delegate classes with LCB implementations of protocol 
+methods. Once created these can be set in the usual way on an instance 
+of the appropriate class (by binding to `-setDelegate:`), typically so 
+that callbacks triggered by user interaction with a widget can be
+handled in LCB.
+
+If no context is required to be passed as a parameter to the callback,
+use <CreateObjcDelegate>.
+
+Some protocols consist of purely optional methods. In this case the 
+information about the protocol's methods are not available from the     
+objective-c runtime API. In this situation 
+<CreateObjcInformalDelegateWithContext> should be used instead.
+
+References:
+CreateObjcDelegate (handler), CreateObjcInformalDelegate (handler), 
+CreateObjcInformalDelegateWithContext (handler)
+
+*/
+public handler CreateObjcDelegateWithContext(in pProtocol as String, in pHandlerMapping as Array, in pContext as any) returns optional ObjcObject
+    unsafe
+        variable tObj as ObjcObject
+        if _MCObjcCreateDelegateWithContext(pProtocol, pHandlerMapping, \
+                                           pContext, tObj) then
+            return tObj
+        end if
+        return nothing
+    end unsafe
+end handler        
+        
+private foreign handler _MCObjcCreateInformalDelegate(in pProtocol as List, in pHandlerMapping as Array, out rDelegate as ObjcObject) returns CBool \
+    binds to "MCObjcCreateInformalDelegate"
+
+/**
+Create an Objective-C object with LCB implementations of methods of an informal protocol.
+
+Example:
+foreign handler Objc_NSPortMessageGetMsgId(in pMessage as ObjcId) returns UInt32 \
+    binds to "objc:NSPort.-msgid"
+    
+handler HandlePortMessageCallback(in pMessage as ObjcId) returns nothing
+    post "portMessage" with [Objc_NSPortMessageGetMsgId(pMessage)]
+end handler
+    
+foreign handler Objc_NSPortDelegateHandlePortMessage(in pTarget as ObjcId, in pPortMessage as ObjcId) returns nothing \
+    binds to "objc:.-handlePortMessage:"
+        
+public handler GetNSPortDelegate()
+    return CreateObjcInformalDelegate([Objc_NSPortDelegateHandlePortMessage], \
+                                      { "handlePortMessage:": \
+                                        HandlePortMessageCalback })
+end handler
+
+Parameters:
+pProtocol: A list of foreign handlers which bind to protocol methods
+pHandlerMapping: A mapping from the protocol's selector names to LCB handlers
+
+Returns: An Objective-C object which calls the appropriate LCB handler
+on receiving any of the specified selectors. 
+
+Description:
+Use the <CreateObjcInformalDelegate> handler to create instances of 
+Objective-C delegate classes with LCB implementations of protocol 
+methods, when the Protocol object cannot be found at runtime. This 
+occurs for example when all of the protocol methods are optional. 
+
+Instead of a protocol name (as with <CreateObjcDelegate>), the 
+<pProtocol> argument of <CreateObjcInformalDelegate> must be a proper 
+list of foreign handlers for each of the methods of the protocol for 
+which LCB callbacks are provided in the <pHandlerMapping> array.
+
+Once created an informal delegate can be set in the usual way on an 
+instance of the appropriate class (by binding to `-setDelegate:`), 
+typically so that callbacks triggered by user interaction with a widget 
+can be handled in LCB.
+
+If any context is required to be passed as a parameter to the callback,
+use <CreateObjcInformalDelegateWithContext>.
+
+If the protocol can be resolved at runtime, it is generally easier to 
+use the <CreateObjcDelegate> handler.
+
+References:
+CreateObjcDelegate (handler), CreateObjcDelegateWithContext (handler), 
+CreateObjcInformalDelegateWithContext (handler)
+
+*/    
+public handler CreateObjcInformalDelegate(in pProtocol as List, in pHandlerMapping as Array) returns optional ObjcObject
+    unsafe
+        variable tObj as ObjcObject
+        if _MCObjcCreateInformalDelegate(pProtocol, pHandlerMapping, \
+                                        tObj) then
+            return tObj
+        end if
+        return nothing
+    end unsafe
+end handler    
+    
+private foreign handler _MCObjcCreateInformalDelegateWithContext(in pProtocol as List, in pHandlerMapping as Array, in pContext as optional any, out rDelegate as ObjcObject) returns CBool \
+    binds to "MCObjcCreateInformalDelegateWithContext"    
+
+/**
+Create an Objective-C object with LCB implementations of methods of an informal protocol.
+
+Example:
+foreign handler Objc_NSPortMessageGetMsgId(in pMessage as ObjcId) returns UInt32 \
+    binds to "objc:NSPort.-msgid"
+    
+handler HandlePortMessageCallback(in pPortIndex as Integer, in pMessage as ObjcId) returns nothing
+    post "portMessage" with [mPortList[pPortIndex]["name"], \
+                             Objc_NSPortMessageGetMsgId(pMessage)]
+end handler
+    
+foreign handler Objc_NSPortDelegateHandlePortMessage(in pTarget as ObjcId, in pPortMessage as ObjcId) returns nothing \
+    binds to "objc:.-handlePortMessage:"
+        
+public handler GetNSPortDelegate(in pPortIndex as Integer)
+    return CreateObjcInformalDelegateWithContext([Objc_NSPortDelegateHandlePortMessage], \
+                                                 { "handlePortMessage:": \
+                                                   HandlePortMessageCalback }, \
+                                                 pPortIndex)
+end handler
+
+Parameters:
+pProtocol: A list of foreign handlers which bind to protocol methods
+pHandlerMapping: A mapping from the protocol's selector names to LCB handlers
+
+Returns: An Objective-C object which calls the appropriate LCB handler
+on receiving any of the specified selectors. 
+
+Description:
+Use the <CreateObjcInformalDelegateWithContext> handler to create instances of 
+Objective-C delegate classes with LCB implementations of protocol 
+methods, when the Protocol object cannot be found at runtime. This 
+occurs for example when all of the protocol methods are optional. 
+
+Instead of a protocol name (as with <CreateObjcDelegateWithContext>), 
+the <pProtocol> argument of <CreateObjcInformalDelegateWithContext> must 
+be a proper list of foreign handlers for each of the methods of the 
+protocol for which LCB callbacks are provided in the <pHandlerMapping> 
+array.
+
+Once created an informal delegate can be set in the usual way on an 
+instance of the appropriate class (by binding to `-setDelegate:`), 
+typically so that callbacks triggered by user interaction with a widget 
+can be handled in LCB.
+
+If no context is required to be passed as a parameter to the callback,
+use <CreateObjcInformalDelegate>.
+
+If the protocol can be resolved at runtime, it is generally easier to 
+use the <CreateObjcDelegateWithContext> handler.
+
+References:
+CreateObjcDelegate (handler), CreateObjcDelegateWithContext (handler), 
+CreateObjcInformalDelegate (handler)
+
+*/    
+public handler CreateObjcInformalDelegateWithContext(in pProtocol as List, in pHandlerMapping as Array, in pContext as any) returns optional ObjcObject
+    unsafe
+        variable tObj as ObjcObject
+        if _MCObjcCreateInformalDelegateWithContext(pProtocol, \
+                                                   pHandlerMapping, \
+                                                   pContext, \
+                                                   tObj) then
+            return tObj
+        end if
+        return nothing
+    end unsafe
+end handler    
+
+end module

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -1558,12 +1558,44 @@ __MCScriptInternalHandlerDescribe(void *p_context,
 	return MCStringFormat(r_description, "%@.%@()", t_module_name, t_handler_name);
 }
 
+static bool
+__MCScriptInternalHandlerQuery(void *p_context,
+                               MCHandlerQueryType p_query,
+                               void *r_info)
+{
+    if (p_query != kMCHandlerQueryTypeObjcSelector)
+    {
+        return false;
+    }
+ 
+    __MCScriptInternalHandlerContext *context =
+        (__MCScriptInternalHandlerContext *)p_context;
+    
+    if (context->definition->kind != kMCScriptDefinitionKindForeignHandler)
+    {
+        return false;
+    }
+    
+    auto t_definition =
+        static_cast<MCScriptForeignHandlerDefinition *>(context->definition);
+    
+    if (t_definition->language != kMCScriptForeignHandlerLanguageObjC)
+    {
+        return false;
+    }
+    
+    *(void **)r_info = t_definition->objc.objc_selector;
+    
+    return true;
+}
+
 static MCHandlerCallbacks __kMCScriptInternalHandlerCallbacks =
 {
 	sizeof(__MCScriptInternalHandlerContext),
 	__MCScriptInternalHandlerRelease,
 	__MCScriptInternalHandlerInvoke,
-	__MCScriptInternalHandlerDescribe
+	__MCScriptInternalHandlerDescribe,
+    __MCScriptInternalHandlerQuery,
 };
 
 static bool

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -232,6 +232,240 @@ public handler TestDynamicClassMethodBindingFails()
 	end if
 
 	test "dynamic class method binding fails" when DynamicAlloc is nothing
+end handler 
+
+--------
+
+handler _TestNativeReturnTypeConvert(in pParam as ObjcObject, in pParam2 as ObjcObject) returns Integer
+    return 1
 end handler
 
+foreign handler Objc_NSControlIsValidObject(in pTarget as ObjcId, in pControl as ObjcId, in pObject as ObjcId) returns CSChar binds to "objc:.-control:isValidObject:"
+
+foreign handler Objc_NSControlAlloc() returns ObjcRetainedId \
+    binds to "objc:AppKit.framework>NSControl.+alloc"
+
+public handler TestDelegateNativeReturnType()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc delegate returns valid bridge type" \
+            because "not implemented on" && the operating system
+        return
+    end if
+    
+    plan 2 tests
+    
+    variable tDelegate as optional ObjcObject
+    unsafe
+        variable tControl as ObjcObject
+        put Objc_NSControlAlloc() into tControl
+        
+        put CreateObjcDelegate("NSControlTextEditingDelegate", \
+                               { "control:isValidObject:": \
+                                 _TestNativeReturnTypeConvert }) \
+            into tDelegate
+
+        test "create delegate succeeds" when tDelegate is not nothing
+        test "delegate converts to native return type" when \     
+            Objc_NSControlIsValidObject(tDelegate, tControl, tControl) is 1
+    end unsafe
+end handler
+
+foreign handler Objc_NSMenuAlloc() returns ObjcRetainedId \
+    binds to "objc:AppKit.framework>NSMenu.+alloc"
+    
+foreign handler Objc_NSMenuNumberOfItems(in pTarget as ObjcId, in pMenu as ObjcId) returns CLong binds to "objc:.-numberOfItemsInMenu:"
+
+handler _TestForeignReturnType(in pParam as ObjcObject) returns CLong
+    return 1
+end handler
+
+public handler TestDelegateForeignReturnType()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc delegate returns correct foreign type" \
+            because "not implemented on" && the operating system
+        return
+    end if
+    
+    plan 2 tests
+    
+    variable tDelegate as optional ObjcObject
+    unsafe
+        variable tMenu as ObjcObject
+        put Objc_NSMenuAlloc() into tMenu
+        
+        put CreateObjcDelegate("NSMenuDelegate", \
+                               { "numberOfItemsInMenu:": \
+                                 _TestForeignReturnType }) \
+            into tDelegate
+
+        test "create delegate succeeds" when tDelegate is not nothing
+        test "delegate returns foreign type" when \     
+            Objc_NSMenuNumberOfItems(tDelegate, tMenu) is 1
+    end unsafe
+end handler
+
+handler _TestDelegateBadSignatureCallback(in pParam as ObjcObject) returns String
+    return ""
+end handler
+
+private handler _TestDelegateBadSignature()
+    CreateObjcDelegate("NSMenuDelegate", \
+                       { "numberOfItemsInMenu:": \
+                         _TestDelegateBadSignatureCallback })
+end handler
+
+private handler _TestDelegateContextBadSignature()
+    // Correct signature for no-context delegate
+    CreateObjcDelegateWithContext("NSMenuDelegate", \
+                                  { "numberOfItemsInMenu:": \
+                                      _TestForeignReturnType }, \
+                                  "")
+end handler
+
+public handler TestDelegateBadSignature()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc delegate error returning invalid bridge type" \
+            because "not implemented on" && the operating system
+        return
+    end if
+
+    MCUnitTestHandlerThrowsNamed(_TestDelegateBadSignature, \
+                                "livecode.objc.DelegateCallbackSignatureError", \
+                                "Creating delegate throws error when callback has incorrect signature")
+end handler
+
+public handler TestDelegateContextBadSignature()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc delegate error no context parameter" \
+            because "not implemented on" && the operating system
+        return
+    end if
+
+    MCUnitTestHandlerThrowsNamed(_TestDelegateContextBadSignature, \
+                                "livecode.objc.DelegateCallbackSignatureError", \
+                                "Creating delegate throws error when callback omits context parameter")
+end handler
+
+foreign handler Objc_NSPortDelegateHandlePortMessage(in pTarget as ObjcId, in pPortMessage as ObjcId) returns nothing \
+    binds to "objc:.-handlePortMessage:"
+
+foreign handler Objc_NSPortMessageAlloc() returns ObjcRetainedId \
+    binds to "objc:Foundation.framework>NSPortMessage.+alloc"
+    
+private variable mCalled as Boolean
+handler _SetTestDelegateMethodCalled(in pValue as Boolean)
+    put pValue into mCalled
+end handler
+
+handler _GetTestDelegateMethodCalled()
+    return mCalled
+end handler
+
+handler _TestDelegateMethodCalled(in pParam as ObjcObject) returns nothing
+    _SetTestDelegateMethodCalled(true) 
+end handler
+    
+public handler TestInformalDelegateVoidReturn()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc informal delegatevoid return type" \
+            because "not implemented on" && the operating system
+        return
+    end if
+    
+    _SetTestDelegateMethodCalled(false)
+    
+    plan 2 tests
+    
+    variable tDelegate as optional ObjcObject
+    unsafe
+        variable tPortMessage as ObjcObject
+        put Objc_NSPortMessageAlloc() into tPortMessage
+        
+        put CreateObjcInformalDelegate([Objc_NSPortDelegateHandlePortMessage], \
+                                       { "handlePortMessage:": \
+                                         _TestDelegateMethodCalled }) \
+            into tDelegate
+
+        test "create delegate succeeds" when tDelegate is not nothing
+        
+        Objc_NSPortDelegateHandlePortMessage(tDelegate, tPortMessage)
+        test "delegate method void return" when \     
+            _GetTestDelegateMethodCalled()
+    end unsafe
+end handler
+
+handler _TestDelegateMethodCalledWithContext(in pContext as Boolean, in pParam as ObjcObject) returns nothing
+    _SetTestDelegateMethodCalled(pContext) 
+end handler
+
+public handler TestInformalDelegateWithContext()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc informal delegate with context" \
+            because "not implemented on" && the operating system
+        return
+    end if
+    
+    _SetTestDelegateMethodCalled(false)
+    
+    plan 2 tests
+    
+    variable tDelegate as optional ObjcObject
+    unsafe
+        variable tPortMessage as ObjcObject
+        put Objc_NSPortMessageAlloc() into tPortMessage
+        
+        put CreateObjcInformalDelegateWithContext([Objc_NSPortDelegateHandlePortMessage], \
+                                                  { "handlePortMessage:": \
+                                                    _TestDelegateMethodCalledWithContext }, \
+                                                  true) \
+			into tDelegate
+
+        test "create delegate succeeds" when tDelegate is not nothing
+
+        Objc_NSPortDelegateHandlePortMessage(tDelegate, tPortMessage)
+        test "delegate method called with context" when \     
+            _GetTestDelegateMethodCalled()
+    end unsafe
+end handler
+
+handler _TestInformalDelegateBadSignatureCallback(in pParam as ObjcObject) returns String
+    return ""
+end handler
+
+private handler _TestInformalDelegateBadSignature()
+    CreateObjcInformalDelegate([Objc_NSPortDelegateHandlePortMessage], \
+                               { "handlePortMessage:": \
+                                 _TestInformalDelegateBadSignatureCallback })
+end handler
+
+private handler _TestInformalDelegateContextBadSignature()
+    // Correct signature for no-context delegate
+    CreateObjcInformalDelegateWithContext([Objc_NSPortDelegateHandlePortMessage], \
+                                          { "numberOfItemsInMenu:": \
+                                            _TestDelegateMethodCalled }, \
+                                           "")
+end handler
+
+public handler TestInformalDelegateBadSignature()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc informal delegate error returning invalid type" \
+            because "not implemented on" && the operating system
+        return
+    end if
+
+    MCUnitTestHandlerThrowsNamed(_TestInformalDelegateBadSignature, \
+                                "livecode.objc.DelegateCallbackSignatureError", \
+                                "Creating informal delegate throws error when callback has incorrect signature")
+end handler
+
+public handler TestInformalDelegateContextBadSignature()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "return NSRange struct succeeds" because "not implemented on" && the operating system
+        return
+    end if
+
+    MCUnitTestHandlerThrowsNamed(_TestInformalDelegateContextBadSignature, \
+                                "livecode.objc.DelegateCallbackSignatureError", \
+                                "Creating informal delegate throws error when callback omits context parameter")
+end handler
 end module

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -309,13 +309,25 @@ handler _TestDelegateBadSignatureCallback(in pParam as ObjcObject) returns Strin
 end handler
 
 private handler _TestDelegateBadSignature()
+	// Ensure NSMenuDelegate is available
+	unsafe
+	    variable tMenu as ObjcObject
+        put Objc_NSMenuAlloc() into tMenu
+	end unsafe
+	
     CreateObjcDelegate("NSMenuDelegate", \
                        { "numberOfItemsInMenu:": \
                          _TestDelegateBadSignatureCallback })
 end handler
 
 private handler _TestDelegateContextBadSignature()
-    // Correct signature for no-context delegate
+	// Ensure NSMenuDelegate is available
+	unsafe
+	    variable tMenu as ObjcObject
+        put Objc_NSMenuAlloc() into tMenu
+	end unsafe
+	
+    // Use correct signature for no-context delegate
     CreateObjcDelegateWithContext("NSMenuDelegate", \
                                   { "numberOfItemsInMenu:": \
                                       _TestForeignReturnType }, \
@@ -440,7 +452,7 @@ end handler
 
 private handler _TestInformalDelegateContextBadSignature()
     // Correct signature for no-context delegate
-    CreateObjcInformalDelegateWithContext([Objc_NSPortDelegateHandlePortMessage], \
+    CreateObjcInformalDelegateWithContext([Objc_NSMenuNumberOfItems], \
                                           { "numberOfItemsInMenu:": \
                                             _TestDelegateMethodCalled }, \
                                            "")
@@ -460,12 +472,74 @@ end handler
 
 public handler TestInformalDelegateContextBadSignature()
     if not the operating system is in ["mac", "ios"] then
-        skip test "return NSRange struct succeeds" because "not implemented on" && the operating system
-        return
+        skip test "objc informal delegate error omitting context param" \
+            because "not implemented on" && the operating system
     end if
 
     MCUnitTestHandlerThrowsNamed(_TestInformalDelegateContextBadSignature, \
                                 "livecode.objc.DelegateCallbackSignatureError", \
                                 "Creating informal delegate throws error when callback omits context parameter")
 end handler
+
+handler _TestFindBarViewCallback() returns ObjcId
+end handler
+
+handler _TestSetFindBarViewCallback(in pView as ObjcId) returns nothing
+end handler
+
+handler _TestIsFindBarVisibleCallback() returns CBool
+end handler
+
+handler _TestSetFindBarVisibleCallback(in pVisible as CBool) returns nothing
+end handler
+
+handler _TestFindBarViewDidChangeHeightCallback() returns nothing
+end handler
+
+private handler _TestDelegateMappedRequiredMethod()
+    CreateObjcDelegate("NSTextFinderBarContainer", \
+                       { "findBarView": \
+                         _TestFindBarViewCallback, \
+                         "setFindBarView:": \                       
+                         _TestSetFindBarViewCallback, \
+                         "isFindBarVisible": \
+                         _TestIsFindBarVisibleCallback, \
+                         "setFindBarVisible:": \
+                         _TestSetFindBarVisibleCallback, \
+                         "findBarViewDidChangeHeight": \
+                         _TestFindBarViewDidChangeHeightCallback })
+end handler
+
+private handler _TestDelegateUnmappedRequiredMethod()
+    CreateObjcDelegate("NSTextFinderBarContainer", \
+                       { "isFindBarVisible": \
+                         _TestIsFindBarVisibleCallback })
+end handler
+
+foreign handler NSTextFinderAlloc() returns ObjcRetainedId \
+	binds to "objc:AppKit.framework>NSTextFinder.+alloc"
+	
+foreign handler NSTextFinderInit(in pObj as ObjcId) returns ObjcId \
+	binds to "objc:NSTextFinder.-init"	
+
+public handler TestDelegateRequiredMethod()
+    if not the operating system is in ["mac", "ios"] then
+        skip test "objc delegate required method tests" \
+            because "not implemented on" && the operating system
+        return
+    end if
+    unsafe
+    	// Ensure NSTextFinder is loaded
+		variable tFinder as ObjcObject
+		put NSTextFinderAlloc() into tFinder
+		put NSTextFinderInit(tFinder) into tFinder
+    end unsafe
+    MCUnitTestHandlerDoesntThrow(_TestDelegateMappedRequiredMethod, \
+    							 "Creating delegate doesn't throw error when required protocol method is mapped")
+    
+    MCUnitTestHandlerThrowsNamed(_TestDelegateUnmappedRequiredMethod, \
+                                "livecode.objc.DelegateMappingError", \
+                                "Creating delegate throws error when required protocol method is not mapped")
+end handler
+
 end module

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -474,6 +474,7 @@ public handler TestInformalDelegateContextBadSignature()
     if not the operating system is in ["mac", "ios"] then
         skip test "objc informal delegate error omitting context param" \
             because "not implemented on" && the operating system
+        return
     end if
 
     MCUnitTestHandlerThrowsNamed(_TestInformalDelegateContextBadSignature, \


### PR DESCRIPTION
Add functions `MCObjcCreateDelegate` and `MCObjcCreateDelegateWithContext` which allow the creation of custom delegate objects with LCB implementations of protocol methods.