### PR TITLE
[[ ObjcFFI ]] Add dynamic instance method binding

### DIFF
--- a/docs/lcb/notes/feature-dynamic_instance_method_binding.md
+++ b/docs/lcb/notes/feature-dynamic_instance_method_binding.md
@@ -1,0 +1,16 @@
+# LiveCode Builder Language
+## Objective-C dynamic instance method binding
+It is now possible to bind to instance methods dynamically, by leaving
+empty the name of the class in the binding string. In particular this 
+enables calling protocol-defined instance methods on class instances,
+which was not previously possible. 
+
+For example, to directly call the `NSAlertDelegate` method 
+`alertShowHelp:` on an `NSAlert` instance:
+
+	-- bind to delegate protocol method
+	foreign handler NSAlertDelegateShowHelp(in pTarget as ObjcId, in pAlert as ObjcId) binds to "objc:.-alertShowHelp:"
+	...
+	-- call alertShowHelp on an NSAlert, passing the alert itself as the
+	-- first parameter.
+	NSAlertDelegateShowHelp(tAlert, tAlert)

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -983,16 +983,28 @@ __MCScriptResolveForeignFunctionBindingForObjC(MCScriptInstanceRef p_instance,
     }
 
     bool t_valid = true;
+    bool t_is_dynamic = MCStringIsEmpty(*t_class);
     
     /* Lookup the class, to make sure it exists. */
     Class t_objc_class = nullptr;
     if (t_valid)
     {
-        t_objc_class = objc_getClass(*t_class_cstring);
-        if (t_objc_class == nullptr)
+        if (t_is_dynamic)
         {
-            /* ERROR: should be class not found */
-            t_valid = false;
+            if (t_is_class)
+            {
+                /* ERROR: should be can't dynamically bind to class methods */
+                t_valid = false;
+            }
+        }
+        else
+        {
+            t_objc_class = objc_getClass(*t_class_cstring);
+            if (t_objc_class == nullptr)
+            {
+                /* ERROR: should be class not found */
+                t_valid = false;
+            }
         }
     }
     
@@ -1007,7 +1019,7 @@ __MCScriptResolveForeignFunctionBindingForObjC(MCScriptInstanceRef p_instance,
     }
     
     /* Get the Method - either class or instance - from the class */
-    if (t_valid)
+    if (t_valid && !t_is_dynamic)
     {
         if (!t_is_class)
         {

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -200,4 +200,38 @@ public handler TestObjcDynamicPropertyBinding()
 	test "dynamic objc getter binds" when NSUserNotificationGetTitle is not nothing
 end handler
 
+--------
+
+foreign handler DynamicGetInt(in pObject as ObjcId) returns CInt \ 
+	binds to "objc:.-intValue"
+
+public handler TestDynamicInstanceMethodBinding()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "obj-c dynamic instance method binding" \
+			because "not implemented on" && the operating system
+		return
+	end if
+
+	unsafe 
+		variable tNumber as ObjcObject
+		put NSNumberCreateWithInt(10) into tNumber
+	
+		test "dynamic method binds" when DynamicGetInt is not nothing
+		test "dynamic method call succeeds" when DynamicGetInt(tNumber) is 10
+	end unsafe
+end handler
+
+foreign handler DynamicAlloc() returns ObjcRetainedId \ 
+	binds to "objc:.+alloc"
+	
+public handler TestDynamicClassMethodBindingFails()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "obj-c dynamic class method binding fails" \
+			because "not implemented on" && the operating system
+		return
+	end if
+
+	test "dynamic class method binding fails" when DynamicAlloc is nothing
+end handler
+
 end module


### PR DESCRIPTION
Previously it was not possible to bind to certain instance methods,
eg those defined in a protocol. This patch allows the `class` field
of the binding string to be empty, in which case the method is
resolved just as a selector, able to be called on an class instance.