### PR TITLE
[[ Bug 20763 ]] Finish MCObjectVisitor implementation

### DIFF
--- a/docs/notes/bugfix-20763.md
+++ b/docs/notes/bugfix-20763.md
@@ -1,0 +1,1 @@
+# Fix crash when deleting datagrid then undoing

--- a/engine/src/aclip.cpp
+++ b/engine/src/aclip.cpp
@@ -171,6 +171,11 @@ const char *MCAudioClip::gettypestring()
 	return MCaudiostring;
 }
 
+bool MCAudioClip::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnAudioClip(this);
+}
+
 void MCAudioClip::timer(MCNameRef mptr, MCParameter *params)
 {
     // PM-2014-11-11: [[ Bug 13950 ]] Make sure looping audioClip can be stopped

--- a/engine/src/aclip.h
+++ b/engine/src/aclip.h
@@ -85,7 +85,9 @@ public:
 	virtual const char *gettypestring();
 
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
-	
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual void timer(MCNameRef mptr, MCParameter *params);
 
 	virtual Boolean del(bool p_check_flag);

--- a/engine/src/cpalette.cpp
+++ b/engine/src/cpalette.cpp
@@ -56,6 +56,11 @@ const char *MCColors::gettypestring()
 	return MCcolorstring;
 }
 
+bool MCColors::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnControl(this);
+}
+
 static void getcells(uint2 &xcells, uint2 &ycells)
 {
 	switch (MCscreen->getdepth())

--- a/engine/src/cpalette.h
+++ b/engine/src/cpalette.h
@@ -43,6 +43,9 @@ public:
 	virtual ~MCColors();
 	virtual Chunk_term gettype() const;
 	virtual const char *gettypestring();
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual Boolean mfocus(int2 x, int2 y);
 	virtual Boolean mdown(uint2 which);
 	virtual Boolean mup(uint2 which, bool p_release);

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -174,6 +174,11 @@ MCDispatch::~MCDispatch()
     MCValueRelease(m_library_mapping);
 }
 
+bool MCDispatch::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnObject(this);
+}
+
 bool MCDispatch::isdragsource(void)
 {
 	return m_drag_source;

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -70,6 +70,7 @@ public:
     
     virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
     
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
 	
 	virtual void timer(MCNameRef mptr, MCParameter *params);
 	

--- a/engine/src/eps.cpp
+++ b/engine/src/eps.cpp
@@ -116,6 +116,11 @@ const char *MCEPS::gettypestring()
 	return MCepsstring;
 }
 
+bool MCEPS::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnEps(this);
+}
+
 Boolean MCEPS::mdown(uint2 which)
 {
 	if (state & CS_MFOCUSED)

--- a/engine/src/eps.h
+++ b/engine/src/eps.h
@@ -58,6 +58,9 @@ public:
 	virtual ~MCEPS();
 	virtual Chunk_term gettype() const;
 	virtual const char *gettypestring();
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual Boolean mdown(uint2 which);
 	virtual Boolean mup(uint2 which, bool p_release);
 	virtual void applyrect(const MCRectangle &nrect);

--- a/engine/src/graphic.cpp
+++ b/engine/src/graphic.cpp
@@ -231,6 +231,11 @@ const char *MCGraphic::gettypestring()
 	return MCgraphicstring;
 }
 
+bool MCGraphic::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnGraphic(this);
+}
+
 Boolean MCGraphic::mfocus(int2 x, int2 y)
 {
 	if (!(flags & F_VISIBLE || showinvisible())

--- a/engine/src/graphic.h
+++ b/engine/src/graphic.h
@@ -93,7 +93,9 @@ public:
 	virtual const char *gettypestring();
 
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
-
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual Boolean mfocus(int2 x, int2 y);
 	virtual Boolean mdown(uint2 which);
 	virtual Boolean mup(uint2 which, bool p_release);

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -232,6 +232,11 @@ const char *MCImage::gettypestring()
 	return MCimagestring;
 }
 
+bool MCImage::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnImage(this);
+}
+
 void MCImage::open()
 {
 	MCControl::open();

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -412,7 +412,9 @@ public:
 	virtual Chunk_term gettype() const;
 	virtual const char *gettypestring();
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
-
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual void open();
 	virtual void close();
 	virtual Boolean mfocus(int2 x, int2 y);

--- a/engine/src/magnify.cpp
+++ b/engine/src/magnify.cpp
@@ -45,6 +45,11 @@ Chunk_term MCMagnify::gettype() const
 	return CT_MAGNIFY;
 }
 
+bool MCMagnify::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnControl(this);
+}
+
 void MCMagnify::open()
 {
 	MCObject::open();

--- a/engine/src/magnify.h
+++ b/engine/src/magnify.h
@@ -40,6 +40,9 @@ public:
 	// virtual functions from MCObject
 	virtual ~MCMagnify();
 	virtual Chunk_term gettype() const;
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual void open();
 	virtual void close();
 	virtual Boolean kfocusnext(Boolean top);

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -54,6 +54,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "styledtext.h"
 #include "flst.h"
 #include "widget.h"
+#include "eps.h"
+#include "graphic.h"
 
 #include "globals.h"
 #include "mctheme.h"
@@ -5370,6 +5372,16 @@ bool MCObjectVisitor::OnScrollbar(MCScrollbar *p_scrollbar)
 bool MCObjectVisitor::OnPlayer(MCPlayer *p_player)
 {
 	return OnControl(p_player);
+}
+
+bool MCObjectVisitor::OnEps(MCEPS *p_eps)
+{
+    return OnControl(p_eps);
+}
+
+bool MCObjectVisitor::OnGraphic(MCGraphic *p_graphic)
+{
+    return OnControl(p_graphic);
 }
 
 bool MCObjectVisitor::OnStyledText(MCStyledText *p_styled_text)

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -196,6 +196,8 @@ struct MCObjectVisitor
 	virtual bool OnImage(MCImage *p_image);
 	virtual bool OnScrollbar(MCScrollbar *p_scrollbar);
 	virtual bool OnPlayer(MCPlayer *p_player);
+    virtual bool OnGraphic(MCGraphic *p_graphic);
+    virtual bool OnEps(MCEPS *p_eps);
 	virtual bool OnParagraph(MCParagraph *p_paragraph);
 	virtual bool OnBlock(MCBlock *p_block);
 	virtual bool OnStyledText(MCStyledText *p_styled_text);
@@ -668,7 +670,7 @@ public:
     virtual const MCObjectPropertyTable *getmodepropertytable(void) const { return &kModePropertyTable; }
 	
 	virtual bool visit(MCObjectVisitorOptions p_options, uint32_t p_part, MCObjectVisitor *p_visitor);
-	virtual bool visit_self(MCObjectVisitor *p_visitor);
+    virtual bool visit_self(MCObjectVisitor *p_visitor) = 0;
 	virtual bool visit_children(MCObjectVisitorOptions p_options, uint32_t p_part, MCObjectVisitor *p_visitor);
 
 	virtual IO_stat save(IO_handle stream, uint4 p_part, bool p_force_ext, uint32_t p_version);

--- a/engine/src/player-legacy.h
+++ b/engine/src/player-legacy.h
@@ -106,6 +106,8 @@ public:
 	// virtual functions from MCObject
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
     
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual Chunk_term gettype() const;
 	virtual const char *gettypestring();
     

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -102,6 +102,8 @@ public:
 	// virtual functions from MCObject    
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
     
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual Chunk_term gettype() const;
 	virtual const char *gettypestring();
     

--- a/engine/src/player.cpp
+++ b/engine/src/player.cpp
@@ -80,6 +80,11 @@ MCObjectPropertyTable MCPlayer::kPropertyTable =
 	&kProperties[0],
 };
 
+bool MCPlayer::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnPlayer(this);
+}
+
 void MCPlayer::removereferences()
 {
     // OK-2009-04-30: [[Bug 7517]] - Ensure the player is actually closed before deletion, otherwise dangling references may still exist.

--- a/engine/src/scrolbar.cpp
+++ b/engine/src/scrolbar.cpp
@@ -139,6 +139,11 @@ const char *MCScrollbar::gettypestring()
 	return MCscrollbarstring;
 }
 
+bool MCScrollbar::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnScrollbar(this);
+}
+
 void MCScrollbar::open()
 {
 	MCControl::open();

--- a/engine/src/scrolbar.h
+++ b/engine/src/scrolbar.h
@@ -84,7 +84,9 @@ public:
 	virtual Chunk_term gettype() const;
 	virtual const char *gettypestring();
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
-
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	virtual void open();
 	virtual Boolean kdown(MCStringRef p_string, KeySym key);
 	virtual Boolean mfocus(int2 x, int2 y);

--- a/engine/src/vclip.cpp
+++ b/engine/src/vclip.cpp
@@ -92,6 +92,11 @@ const char *MCVideoClip::gettypestring()
 	return MCvideostring;
 }
 
+bool MCVideoClip::visit_self(MCObjectVisitor* p_visitor)
+{
+    return p_visitor -> OnVideoClip(this);
+}
+
 Boolean MCVideoClip::del(bool p_check_flag)
 {
     if (!isdeletable(p_check_flag))

--- a/engine/src/vclip.h
+++ b/engine/src/vclip.h
@@ -52,7 +52,9 @@ public:
 	virtual void paste(void);
 
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
-
+    
+    virtual bool visit_self(MCObjectVisitor *p_visitor);
+    
 	MCVideoClip *clone();
 	bool getfile(MCStringRef& r_file);
 	real8 getscale()

--- a/tests/lcs/core/interface/group.livecodescript
+++ b/tests/lcs/core/interface/group.livecodescript
@@ -54,12 +54,14 @@ on TestGroupUndo_Bug20642
    create stack "Test"
    set the defaultStack to "Test"
 
-   create button "A"
-   select button "A"
-   group
-   select the last group
-   delete
-   undo
-
-   TestAssert "Undo grouped button deletion does not crash", the short name of button "A" is "A"
+   repeat for each item tControlType in "button,graphic,image,scrollbar,eps,player,field,group"
+      do format("create %s \"A\"", tControlType)
+      select control "A"
+      group
+      select it
+      delete
+      undo
+      TestAssert format("Undo grouped %s deletion does not crash", tControlType), the short name of control "A" is "A"
+      delete the first group
+   end repeat
 end TestGroupUndo_Bug20642


### PR DESCRIPTION
This patch adds the remaining On<Control> handlers for the missing
control types, and adds appropriate 'visit_self' methods to all
descendents of MCObject. The MCObject::visit_self method is now
pure, requiring an implementation in every subclass.