### PR TITLE
[Bug 20755] Fix crash when calling iPhoneSetRemoteControlDisplay

### DIFF
--- a/docs/notes/bugfix-20755.md
+++ b/docs/notes/bugfix-20755.md
@@ -1,0 +1,1 @@
+# Fix crash when calling iPhoneSetRemoteControlDisplay

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -1007,7 +1007,7 @@ bool MCSystemSetRemoteControlDisplayProperties(MCExecContext& ctxt, MCArrayRef p
                     MCAutoStringRef t_string;
                     if (!ctxt . ConvertToString(t_prop_value, &t_string))
                         continue;
-					t_value = [NSString stringWithMCStringRef: *t_string];
+					t_value = [[NSString stringWithMCStringRef: *t_string] retain];
                 }
 					break;
 				case kRCDPropTypeImage:
@@ -1057,6 +1057,8 @@ bool MCSystemSetRemoteControlDisplayProperties(MCExecContext& ctxt, MCArrayRef p
 	if (t_success)
 		[[s_info_center defaultCenter] setNowPlayingInfo: t_info_dict];
 	
+    [t_info_dict release];
+    
 	return ES_NORMAL;
 }
 


### PR DESCRIPTION
PR submitted on behalf of @runrevmark.

It fixes a crash because of an over-release of `t_value`, as well as a memory leak caused by not releasing `t_info_dict`