### PR TITLE
[[ Widget ]] Add 'trigger all' statement to widget module

### DIFF
--- a/docs/lcb/notes/feature-widget_trigger_all.md
+++ b/docs/lcb/notes/feature-widget_trigger_all.md
@@ -1,0 +1,13 @@
+# LiveCode Builder Host Library
+## Widget library
+New syntax has been added to enable property triggers to be 
+fired directly from within a widget: trigger all.
+
+At the moment the only property trigger that exists is the 
+‘property listening’ mechanism available in the IDE. You should 
+use ‘trigger all’ after a widget property has changed internally 
+(for example because something in a native layer has changed) so 
+that the IDE can be notified that the property has changed.
+
+In the future single property variants and other types of trigger 
+may be introduced.

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -654,6 +654,22 @@ void MCWidgetBase::RedrawRect(MCGRectangle *p_area)
     MCWidgetAsBase(t_owner) -> RedrawRect(p_area);
 }
 
+void MCWidgetBase::TriggerAll()
+{
+    if (IsRoot())
+    {
+        GetHost() -> signallisteners(P_CUSTOM);
+        return;
+    }
+    
+    MCWidgetRef t_owner;
+    t_owner = GetOwner();
+    if (t_owner == nil)
+        return;
+    
+    MCWidgetAsBase(t_owner) -> TriggerAll();
+}
+
 bool MCWidgetBase::CopyChildren(MCProperListRef& r_children)
 {
     if (m_children == nil)
@@ -1362,6 +1378,11 @@ bool MCWidgetSetAnnotation(MCWidgetRef self, MCNameRef p_annotation, MCValueRef 
 void MCWidgetRedrawAll(MCWidgetRef self)
 {
     return MCWidgetAsBase(self) -> RedrawRect(nil);
+}
+
+void MCWidgetTriggerAll(MCWidgetRef self)
+{
+    return MCWidgetAsBase(self) -> TriggerAll();
 }
 
 bool MCWidgetPost(MCWidgetRef self, MCNameRef p_event, MCProperListRef p_args)

--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -89,6 +89,7 @@ public:
     void ScheduleTimerIn(double timeout);
     void CancelTimer(void);
     void RedrawRect(MCGRectangle *area);
+    void TriggerAll();
     
     bool CopyChildren(MCProperListRef& r_children);
     void PlaceWidget(MCWidgetRef child, MCWidgetRef relative_to, bool put_below);

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -135,6 +135,14 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetEvalInEditMode(bool& r_in_edit_mode)
     r_in_edit_mode = MCcurtool != T_BROWSE;
 }
 
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecTriggerAll(void)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    MCWidgetTriggerAll(MCcurrentwidget);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMyScriptObject(MCScriptObjectRef& r_script_object)

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -98,6 +98,7 @@ bool MCWidgetPost(MCWidgetRef widget, MCNameRef event, MCProperListRef args);
 void MCWidgetRedrawAll(MCWidgetRef widget);
 void MCWidgetScheduleTimerIn(MCWidgetRef widget, double timeout);
 void MCWidgetCancelTimer(MCWidgetRef widget);
+void MCWidgetTriggerAll(MCWidgetRef widget);
 
 void MCWidgetCopyChildren(MCWidgetRef widget, MCProperListRef& r_children);
 void MCWidgetPlaceWidget(MCWidgetRef widget, MCWidgetRef child, MCWidgetRef relative_to, bool put_below);

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -379,6 +379,7 @@ public foreign handler MCWidgetExecRedrawAll() returns nothing binds to "<builti
 public foreign handler MCWidgetExecScheduleTimerIn(in pTime as CDouble) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetExecCancelTimer() returns nothing binds to "<builtin>"
 public foreign handler MCWidgetEvalInEditMode(out rInEditMode as CBool) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetExecTriggerAll() returns nothing binds to "<builtin>"
 
 /**
 Summary:	Redraws the widget.
@@ -462,6 +463,27 @@ syntax IsEditMode is expression
   "in" "edit" "mode"
 begin
   MCWidgetEvalInEditMode(output)
+end syntax
+
+/**
+Summary:	Causes all of a widget's property triggers to be fired.
+
+Example:
+	handler TextChangedCallback()
+        UpdateTextProperty()
+        trigger all
+	end handler
+
+Description:
+Use trigger all to cause all triggers for all a widget's properties to 
+be fired, for example when user action causes a native widget's 
+properties to change, to signal the property change to the IDE.
+*/
+
+syntax TriggerAll is statement
+  "trigger" "all"
+begin
+  MCWidgetExecTriggerAll()
 end syntax
 
 

--- a/tests/ide-support/development/_widget_propertychanged.lcb
+++ b/tests/ide-support/development/_widget_propertychanged.lcb
@@ -1,0 +1,10 @@
+widget com.livecode.idesupport_tests.development.widget_propertychanged
+
+use com.livecode.widget
+use com.livecode.engine
+
+public handler OnSave(out rProperties as Array)
+	trigger all
+end handler
+
+end widget

--- a/tests/ide-support/development/propertychanged.livecodescript
+++ b/tests/ide-support/development/propertychanged.livecodescript
@@ -80,3 +80,29 @@ on TestPutPropertyChanged
 		end repeat
 	end repeat
 end TestPutPropertyChanged
+
+on TestWidgetPropertyChanged
+   TestSkipIfNot "lcb"
+   TestLoadAuxiliaryExtension "_widget_propertychanged"
+   
+   create stack
+   set the defaultStack to the short name of it
+   local tObj
+   create widget as "com.livecode.idesupport_tests.development.widget_propertychanged"
+   put it into tObj
+
+   revIDESubscribe "idePropertyChanged", tObj
+   put empty into sTarget
+   
+   local tOut
+   -- export causes OnSave handler to be run
+   -- our widget OnSave handler calls `trigger all`
+   export widget 1 to array tOut
+   
+   local tParams
+   put tObj into tParams[1]
+   TestRepeat "trigger all triggers propertyChanged", IsTargetCorrect, \
+         the long id of me, 10, tParams
+   
+   revIDEUnsubscribe "idePropertyChanged", "", tObj
+end TestWidgetPropertyChanged


### PR DESCRIPTION
At the moment, trigger all causes the property listeners to be
signalled of a property change. In the future there may be additional
triggers applied to a widget's properties that can be triggered
using this syntax.