### PR TITLE
[[ Bug ]] Use NULL instead of nullptr in lcidlc

### DIFF
--- a/lcidlc/src/InterfaceGenerate.cpp
+++ b/lcidlc/src/InterfaceGenerate.cpp
@@ -1709,7 +1709,7 @@ static bool InterfaceGenerateExports(InterfaceRef self, CoderRef p_coder)
 			NameGetCString(t_handler -> name),
 			NameGetCString(t_handler -> name));
 	}
-	CoderWriteLine(p_coder, "\t{ 0, nullptr, nullptr }\n};");
+	CoderWriteLine(p_coder, "\t{ 0, NULL, NULL }\n};");
 	
 	CoderWriteLine(p_coder, "");
 	


### PR DESCRIPTION
This patch changes to use `NULL` instead of `nullptr` as `nullptr` may
be undefined on sume supported languages.