### PR TITLE
Changes from files to foregroundPattern

### DIFF
--- a/docs/dictionary/command/flip.lcdoc
+++ b/docs/dictionary/command/flip.lcdoc
@@ -2,10 +2,10 @@ Name: flip
 
 Type: command
 
-Syntax: flip [<image>] {horizontal | vertical}
+Syntax: flip [image] {horizontal | vertical}
 
 Summary:
-<change> </change>selected</a> part of an <image>.
+Invert an <image> horizontally or vertically.
 
 Introduced: 1.1
 
@@ -29,8 +29,8 @@ Any image reference.
 Description:
 Use the <flip> <command> to turn an <image> over.
 
-Theform flips the image vertically, swapping its top and bottom. Theform
-flips the image side to side, swapping its right and left.
+vertical flips the image vertically, swapping its top and bottom. 
+horizontal flips the image side to side, swapping its right and left.
 
 If you don't specify an <image>, the portion currently selected with the
 Select <paint tool> is flipped.
@@ -39,9 +39,9 @@ The flipping operation is its own inverse: flipping an image twice in
 the same direction restores it to its original appearance.
 
 >*Important:* Flipping a <referenced control|referenced image> changes
-> its orientation only temporarily. The next time the <referenced
-> control|referenced image> is displayed, its original orientation
-> returns. 
+> its orientation only temporarily. The next time the 
+> <referenced control|referenced image> is displayed, its original 
+> orientation returns. 
 
 References: choose (command), crop (command), revRotatePoly (command),
 command (glossary), referenced control (glossary), paint tool (glossary),

--- a/docs/dictionary/command/flip.lcdoc
+++ b/docs/dictionary/command/flip.lcdoc
@@ -2,7 +2,7 @@ Name: flip
 
 Type: command
 
-Syntax: flip [image] {horizontal | vertical}
+Syntax: flip [<imageRef>] {horizontal | vertical}
 
 Summary:
 Invert an <image> horizontally or vertically.
@@ -23,14 +23,14 @@ Example:
 flip image "Logo" horizontal
 
 Parameters:
-image:
+imageRef:
 Any image reference.
 
 Description:
 Use the <flip> <command> to turn an <image> over.
 
-vertical flips the image vertically, swapping its top and bottom. 
-horizontal flips the image side to side, swapping its right and left.
+The vertical form flips the image vertically, swapping its top and bottom. 
+The horizontal form flips the image side to side, swapping its right and left.
 
 If you don't specify an <image>, the portion currently selected with the
 Select <paint tool> is flipped.

--- a/docs/dictionary/function/files.lcdoc
+++ b/docs/dictionary/function/files.lcdoc
@@ -62,8 +62,8 @@ included in the list only if they refer to a <file>.
 
 ### Short form
 
-When the <files> is called as a <function>, or without the `<long>` or
-`<long|detailed>` modifiers, it <return(glossary)|returns> only the <file>
+When the <files> is called as a <function>, or without the `long` or
+`detailed` modifiers, it <return(glossary)|returns> only the <file>
 names as a string with one file name per line.
 
 > *Note:* On some <platform|platforms>, file names are permitted to
@@ -73,7 +73,7 @@ names as a string with one file name per line.
 
 ### Long form
 
-`the <long> files` and `the <long|detailed> files` are synonyms.  When 
+`the long files` and `the detailed files` are synonyms.  When 
 the <files> <function> is called in this form, the <return(glossary)>
 value is a list of files with detailed file attributes.
 
@@ -82,8 +82,8 @@ attributes, as follows:
 
 1. **Name**.  The file name is URL-encoded.  To obtain the name as
    plain text, use the <URLDecode> function.
-2. **Size**, in bytes.  On OS X systems, this is the size of the <data
-   fork>.
+2. **Size**, in bytes.  On OS X systems, this is the size of the 
+   <data fork>.
 3. **Resource fork size**, in bytes.  (OS X only).
 4. **Creation date**, in seconds.  (OS X and Windows only).
 5. **Last modification date**, in seconds.

--- a/docs/dictionary/function/focusedObject.lcdoc
+++ b/docs/dictionary/function/focusedObject.lcdoc
@@ -31,8 +31,8 @@ receives any keystrokes that are typed by the user or created by the
 <type> <command>.
 
 The <focusedObject> can be any <control> on the <current card>. If no
-<object(glossary)> has the <focus>, the <focusedObject> is the <current
-card>. 
+<object(glossary)> has the <focus>, the <focusedObject> is the 
+<current card>. 
 
 References: focus (command), type (command), function (control structure),
 object (glossary), property (glossary), current card (glossary),

--- a/docs/dictionary/function/folders.lcdoc
+++ b/docs/dictionary/function/folders.lcdoc
@@ -67,8 +67,8 @@ included in the list only if they refer to a <folder>.
 
 ### Short form
 
-When the <folders> is called as a <function>, or without the `<long>` or
-`<long|detailed>` modifiers, it <return(glossary)|returns> only the <folder>
+When the <folders> is called as a <function>, or without the `long` or
+`detailed` modifiers, it <return(glossary)|returns> only the <folder>
 names as a string with one file name per line.
 
 > *Note:* On some <platform|platforms>, folder names are permitted to
@@ -78,7 +78,7 @@ names as a string with one file name per line.
 
 ### Long form
 
-`the <long> folders` and `the <long|detailed> folders` are synonyms.  When 
+`the long folders` and `the detailed folders` are synonyms.  When 
 the <folders> <function> is called in this form, the <return(glossary)>
 value is a list of folders with detailed file attributes.  Several of
 the attributes are provided only for compatibility with the <files>

--- a/docs/dictionary/keyword/first.lcdoc
+++ b/docs/dictionary/keyword/first.lcdoc
@@ -20,8 +20,8 @@ Example:
 put "a" into first character of theLetters
 
 Description:
-Use the <first> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <first> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <first> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 1. It can also be used to designate the

--- a/docs/dictionary/keyword/for.lcdoc
+++ b/docs/dictionary/keyword/for.lcdoc
@@ -26,10 +26,10 @@ Use the <for> <keyword> to specify a fixed number of
 
 The number may be a literal number, or an expression that evaluates to a
 number. (If the number is not an integer, it is rounded to the nearest
-integer.) Either way, the number is evaluated when the <repeat> <control
-structure> is entered, and is not re-<evaluate|evaluated> as a result of
-<statement|statements> in the <loop>. For example, if the <repeat>
-<control structure> begins with the line
+integer.) Either way, the number is evaluated when the <repeat> 
+<control structure> is entered, and is not re-<evaluate|evaluated> as a 
+result of <statement|statements> in the <loop>. For example, if the 
+<repeat> <control structure> begins with the line
 
     repeat for the number of cards
 
@@ -45,4 +45,3 @@ References: repeat (control structure), value (function), loop (glossary),
 iteration (glossary), execute (glossary), statement (glossary),
 keyword (glossary), control structure (glossary), evaluate (glossary),
 expression (glossary), until (keyword), while (keyword)
-

--- a/docs/dictionary/message/focusIn.lcdoc
+++ b/docs/dictionary/message/focusIn.lcdoc
@@ -5,7 +5,7 @@ Type: message
 Syntax: focusIn
 
 Summary:
-Sent to a <control> when it becomes <active(glossary)>(focused).
+Sent to a <control> when it becomes <active control|active> <focus|focused>.
 
 Introduced: 1.0
 
@@ -29,11 +29,10 @@ If the control is an unlocked field or a button whose menuMode is
 <focusIn> <message>.
 
 A locked field receives the <focusIn> <message> when the user tabs to it
-or otherwise makes it <active (focused)(glossary)>, or when text in it
-is <selected> by a <handler>.
+or otherwise makes it <active control(glossary)|active> <focus|focused>, 
+or when text in it is <selected> by a <handler>.
 
-References: focus (command), handler (glossary), focus (glossary),
-message (glossary), active control (glossary), control (keyword),
+References: handler (glossary), focus (glossary), message (glossary), active control (glossary), control (keyword), 
 openField (message), resume (message), selected (property)
 
 Tags: ui

--- a/docs/dictionary/message/focusOut.lcdoc
+++ b/docs/dictionary/message/focusOut.lcdoc
@@ -26,8 +26,6 @@ Description:
 Handle the <focusOut> <message> if you want to perform preparation or do
 other tasks when a <control> loses the <focus|keyboard focus>.
 
-&nbsp;
-
 If the control is an unlocked field or a button whose menuMode is
 "comboBox", the <closeField> or <exitField> <message> is sent to it
 instead of the <focusOut> <message>.

--- a/docs/dictionary/property/fileType.lcdoc
+++ b/docs/dictionary/property/fileType.lcdoc
@@ -6,8 +6,8 @@ Syntax: set the fileType to <creator> & <type>
 
 Summary:
 Specifies the <creator signature|creator> and <type signature|file type>
-for any non- <stack> <files> a <handler> creates on a <Mac OS> or <OS
-X|OS X system>.
+for any non- <stack> <files> a <handler> creates on a <Mac OS> or 
+<OS X|OS X system>.
 
 Introduced: 1.0
 
@@ -24,9 +24,9 @@ The <fileType> is an eight- <character> <string>. The first four
 <type signature|file type>.
 
 Description:
-Use the <fileType> <property> to ensure that <files> that a <standalone
-application> creates are recognized by the operating system as belonging
-to the <standalone application|standalone>.
+Use the <fileType> <property> to ensure that <files> that a 
+<standalone application> creates are recognized by the operating system 
+as belonging to the <standalone application|standalone>.
 
 >*Important:*  The <type signature|file type> and <creator signature>
 > are <case-sensitive>.

--- a/docs/dictionary/property/filled.lcdoc
+++ b/docs/dictionary/property/filled.lcdoc
@@ -7,8 +7,8 @@ Type: property
 Syntax: set the filled [of <graphic>] to {true | false}
 
 Summary:
-Specifies whether <graphic|graphics> and shapes drawn with the <paint
-tool|paint tools> are filled or hollow.
+Specifies whether <graphic|graphics> and shapes drawn with the 
+<paint tool|paint tools> are filled or hollow.
 
 Associations: graphic
 
@@ -47,7 +47,7 @@ drawn, its <appearance> cannot be changed by changing the <global>
 > <graphic(keyword)> unless the <graphic(keyword)> is already
 > <selected>. To create a <graphic(keyword)> whose interior is
 > transparent, but clickable, set the <graphic(object)|graphic's>
-> <filled> <property> to true and its <ink> <property> to noOp<a/>.
+> <filled> <property> to true and its <ink> <property> to noOp.
 
 >*Note:* When applied to graphics, the <filled> property behaves as a
 > synonym for the <opaque> property.

--- a/docs/dictionary/property/focusColor.lcdoc
+++ b/docs/dictionary/property/focusColor.lcdoc
@@ -26,8 +26,8 @@ Example:
 set the focusColor of button "Help" to 128,128,255
 
 Value:
-The <focusColor> of an <object(glossary)> is any valid <color
-reference>. The <colorName> is any standard color name.
+The <focusColor> of an <object(glossary)> is any valid 
+<color reference>. The <colorName> is any standard color name.
 
 The <RGBColor> consists of three comma-separated <integer|integers>
 between zero and 255, specifying the level of each of red, green, and
@@ -45,8 +45,8 @@ Setting the <focusColor> of an <object(glossary)> to empty allows the
 <effective> <keyword> to find out what color is used for the
 <object(glossary)>, even if its own <focusColor> is empty.
 
-If the <focusColor> is not set for any <object(glossary)> in the <object
-hierarchy>, the system setting is used.
+If the <focusColor> is not set for any <object(glossary)> in the 
+<object hierarchy>, the system setting is used.
 
 The setting of the <focusColor> <property> has different effects,
 depending on the <object type>:

--- a/docs/dictionary/property/focusPattern.lcdoc
+++ b/docs/dictionary/property/focusPattern.lcdoc
@@ -6,7 +6,7 @@ Syntax: set the focusPattern of <object> to {<patternNumber> | <imageID> | empty
 
 Summary:
 Specifies the pattern used for an <object|object's> outline when it has
-the <insertion point> or is <active (focused)(glossary)>.
+the <insertion point> or is <explicit focus|active focused>.
 
 Associations: stack, card, field, button, graphic, scrollbar, player,
 image, group
@@ -36,20 +36,20 @@ By default, the <focusPattern> for all <object|objects> is empty.
 
 Description:
 Use the <focusPattern> <property> to specify the pattern used for the
-outline around an <active (focused) control(glossary)>.
+outline around an <active control|active (focused) control>.
 
 Pattern images can be color or black-and-white.
 
->*Cross-platform note:*  To be used as a pattern on <Mac OS|Mac OS
-> systems>, an <image> must be 128x128 <pixels> or less, and both its
-> <height> and <width> must be a power of 2. To be used on <Windows> and
-> <Unix|Unix systems>, <height> and <width> must be divisible by 8. To
-> be used as a fully cross-platform pattern, both an image's dimensions
-> should be one of 8, 16, 32, 64, or 128.
+>*Cross-platform note:*  To be used as a pattern on 
+> <Mac OS|Mac OS systems>, an <image> must be 128x128 <pixels> or less, 
+> and both its <height> and <width> must be a power of 2. To be used on
+> <Windows> and <Unix|Unix systems>, <height> and <width> must be 
+> divisible by 8. To be used as a fully cross-platform pattern, both an
+> image's dimensions should be one of 8, 16, 32, 64, or 128.
 
-The <focusPattern> of <control(object)|controls> is drawn starting at
-the <control(object)|control's> upper right corner: if the
-<control(keyword)> is moved, the pattern does not shift.
+The <focusPattern> of <control|controls> is drawn starting at
+the <control|control's> upper right corner: if the
+<control> is moved, the pattern does not shift.
 
 Setting the <focusPattern> of an <object(glossary)> to empty allows the
 <focusPattern> of the <object|object's> <owner> to show through. Use the
@@ -83,18 +83,18 @@ If an object's <focusPattern> is set, the pattern is shown instead of
 the color specified by the <focusColor>.
 
 The <focusPattern> <property> has no effect if the <lookAndFeel>
-<property> is set to Macintosh<a/>.
+<property> is set to Macintosh.
 
 References: focus (command), group (command), stacks (function),
 object (glossary), property (glossary), EPS (glossary),
 Windows (glossary), object type (glossary), insertion point (glossary),
 focus (glossary), Mac OS (glossary), keyword (glossary),
 active control (glossary), Unix (glossary), current stack (glossary),
-effective (keyword), field (keyword), image (keyword), button (keyword),
-card (keyword), scrollbar (keyword), player (keyword), graphic (keyword),
-control (keyword), videoClip (object), button (object), control (object),
-stack (object), audioClip (object), pixels (property), owner (property),
-height (property), style (property), width (property),
+explicit focus (glossary), effective (keyword), field (keyword), 
+image (keyword), button (keyword), card (keyword), scrollbar (keyword), 
+player (keyword), graphic (keyword), control (keyword), videoClip (object), 
+button (object), stack (object), audioClip (object), pixels (property), 
+owner (property), height (property), style (property), width (property),
 focusColor (property), lookAndFeel (property), traversalOn (property)
 
 Tags: ui

--- a/docs/dictionary/property/focusPixel.lcdoc
+++ b/docs/dictionary/property/focusPixel.lcdoc
@@ -9,7 +9,7 @@ Syntax: set the focusPixel of <object> to <colorNumber>
 Summary:
 Specifies which entry in the <color table> is used for the color of an
 <object|object's> outline when it has the <insertion point> or is
-<active (focused)(glossary)>.
+<explicit focus|active focused>.
 
 Associations: stack, card, field, button, graphic, scrollbar, player,
 image
@@ -43,7 +43,8 @@ The color table can be set by changing the colorMap <property>.
 References: object (glossary), property (glossary),
 color reference (glossary), insertion point (glossary), bit (glossary),
 color table (glossary), active control (glossary), bit depth (glossary),
-integer (keyword), borderPixel (property), focusColor (property)
+explicit focus (glossary), integer (keyword), borderPixel (property), 
+focusColor (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/fontFilesInUse.lcdoc
+++ b/docs/dictionary/property/fontFilesInUse.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: get the fontFilesInUse
 
 Summary:
-Reports the files that have been loaded into memory by the <start using
-font> <command>.
+Reports the files that have been loaded into memory by the 
+<start using font> <command>.
 
 Introduced: 6.5
 

--- a/docs/dictionary/property/foregroundPattern.lcdoc
+++ b/docs/dictionary/property/foregroundPattern.lcdoc
@@ -97,8 +97,8 @@ depending on the <object type>:
   border, which is outside the outline.)
 
 
-* The <foregroundPattern> of a <player>, <image>, <audio clip>, <video
-  clip>, or <EPS|EPS object> has no effect. If an object's
+* The <foregroundPattern> of a <player>, <image>, <audio clip>, 
+  <video clip>, or <EPS|EPS object> has no effect. If an object's
   <foregroundPattern> is set, the pattern is shown instead of the color
   specified by <foregroundColor>.
 


### PR DESCRIPTION
function/files.lcdoc - Removed links from backticked sections as they were displaying incorrectly. Fixed broken link.
property/fileType.lcdoc - Fixed broken links.
property/filled.lcdoc - Removed extraneous text.
keyword/first.lcdoc - Fixed broken link.
command/flip.lcdoc - Fixed broken link. Changed `Theform`s to read `vertical` and `horizontal` as appropriate. Rewrote summary. Removed angle brackets from syntax such that all other references to image would link to the image entry rather than be italicized.
property/focusColor.lcdoc - Fixed broken links.
function/focusedObject.lcdoc - Fixed broken link.
message/focusIn.lcdoc - Fixed broken links.
message/focusOut.lcdoc - Removed a paragraph that only contained a non-breaking space.
property/focusPattern.lcdoc - Fixed broken links. Removed non-existent reference. 
property/focusPixel.lcdoc - Fixed broken links.
function/folders.lcdoc - Removed links from backticked sections.
property/fontFilesInUse.lcdoc - Fixed broken link.
keyword/for.lcdoc - Fixed broken link.
property/foregroundPattern.lcdoc - Fixed broken link.