### PR TITLE
[[ LCBLicenseCheck ]] Add check license statement

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -993,6 +993,13 @@
 			'src/engine.lcb',
 			'src/widget.lcb',
 		],
+        
+        # Engine LCB files containing syntax which don't require compiling into
+        # the engine.
+        'engine_syntax_only_lcb_files':
+        [
+            'src/license.lcb',
+        ],
 		
 		# Other engine LCB files
 		'engine_other_lcb_files':

--- a/engine/src/externalv1.cpp
+++ b/engine/src/externalv1.cpp
@@ -2802,9 +2802,9 @@ MCExternalError MCExternalLicenseCheckEdition(unsigned int p_options, unsigned i
         return kMCExternalErrorFailed;
     }
     
-    MCAutoValueRef t_value;
+    MCValueRef t_value;
     if (MClicenseparameters . addons != nil &&
-        MCArrayFetchValue(MClicenseparameters . addons, false, *t_key_as_nameref, &t_value))
+        MCArrayFetchValue(MClicenseparameters . addons, false, *t_key_as_nameref, t_value))
     {
         return kMCExternalErrorNone;
     }

--- a/engine/src/license.h
+++ b/engine/src/license.h
@@ -158,4 +158,18 @@ inline bool MCEditionStringFromLicenseClass(MCLicenseClass p_class, MCStringRef 
     return false;
 }
 
+inline bool MCEditionStringToLicenseClass(MCStringRef p_edition, MCLicenseClass &r_class)
+{
+    for(uindex_t t_index = 0; t_index < sizeof(s_class_map) / sizeof(s_class_map[0]); ++t_index)
+    {
+        if (MCStringIsEqualToCString(p_edition, s_class_map[t_index].edition_string, kMCCompareCaseless))
+        {
+            r_class = s_class_map[t_index].license_class;
+            return true;
+        }
+    }
+    
+    return false;
+}
+
 #endif

--- a/engine/src/license.lcb
+++ b/engine/src/license.lcb
@@ -1,0 +1,101 @@
+/* Copyright (C) 2017 LiveCode Ltd.
+
+ This file is part of LiveCode.
+
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/**
+This library provides license entitlement related operations for LiveCode Builder (commercial only).
+
+Tags: License
+*/
+
+module com.livecode.commercial.license
+
+use com.livecode.foreign
+
+public foreign handler MCLicenseCheckEdition(in pEdition as String, out rLicensed as CBool) returns nothing binds to "<builtin>"
+public foreign handler MCLicenseCheckExtension(in pExtension as String, out rLicensed as CBool) returns nothing binds to "<builtin>"
+public foreign handler MCLicenseCheckExtensionFeature(in pExtension as String, in pFeature as String, out rLicensed as CBool) returns nothing binds to "<builtin>"
+public foreign handler MCLicenseEnsureExtension(in pExtension as String) returns nothing binds to "<builtin>"
+public foreign handler MCLicenseEnsureExtensionFeature(in pExtension as String, in pFeature as String) returns nothing binds to "<builtin>"
+public foreign handler MCLicenseEnsureExtensionFeatureOrEdition(in pExtension as String, in pFeature as String, in pEdition as String) returns nothing binds to "<builtin>"
+public foreign handler MCLicenseEnsureExtensionOrEdition(in pExtension as String, in pEdition as String) returns nothing binds to "<builtin>"
+
+/**
+Summary:    Throws if license is not satisfied
+
+Example:
+ensure license for edition "indy"
+
+Example:
+ensure license for extension "com.foo.bar" or edition "indy"
+
+Example:
+ensure license for feature "baz" of extension "com.foo.bar" or edition "indy"
+
+Description:
+Causes an error to be thrown if the license requirement is not satisfied. All
+further calls to the module will then also cause an error to be thrown.
+
+Tags: License
+*/
+syntax EnsureLicense is statement
+    "ensure" "license" "for" [ "feature" <Feature: Expression> "of" ] "extension" <Extension: Expression> [ "or" "edition" <Edition: Expression> ]
+begin
+    MCLicenseEnsureExtension(Extension)
+    MCLicenseEnsureExtensionFeature(Feature, Extension)
+    MCLicenseEnsureExtensionFeatureOrEdition(Feature, Extension, Edition)
+    MCLicenseEnsureExtensionOrEdition(Extension, Edition)
+end syntax
+
+/**
+Summary:    Returns true if licensed
+
+Example:
+variable tLicensed as Boolean
+put licensed for extension "com.foo.bar" into tLicensed
+put licensed for feature "baz" of extension "com.foo.bar" into tLicensed
+
+Description:
+Returns true if the license includes the named extension or extension
+and feature.
+
+Tags: License
+*/
+syntax LicensedExtension is prefix operator with function chunk precedence
+    "licensed" "for" [ "feature" <Feature: Expression> "of" ] "extension" <Extension: Expression>
+begin
+    MCLicenseCheckExtension(Extension, output)
+    MCLicenseCheckExtensionFeature(Feature, Extension, output)
+end syntax
+
+/**
+Summary:    Returns true if licensed
+
+Example:
+variable tLicensed as Boolean
+put licensed for edition "business" into tLicensed
+
+Description:
+Returns true if the license is for the named editon or greater.
+
+Tags: License
+*/
+syntax LicensedEdition is prefix operator with function chunk precedence
+    "licensed" "for" "edition" <Edition: Expression>
+begin
+    MCLicenseCheckEdition(Edition, output)
+end syntax
+
+end module

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -976,7 +976,7 @@ MCEngineEvalMyResourcesFolder(MCStringRef& r_folder)
         return;
     }
 }
-    
+
 ////////////////////////////////////////////////////////////////////////////////
     
 static bool

--- a/libscript/include/libscript/script.h
+++ b/libscript/include/libscript/script.h
@@ -249,6 +249,12 @@ uint32_t MCScriptGetRetainCountOfModule(MCScriptModuleRef module);
 // Gets the module ptr for the most recent LCB stack frame on the current thread's stack.
 MCScriptModuleRef MCScriptGetCurrentModule(void);
 
+// Sets the licensed state of a module
+void MCScriptSetModuleLicensed(MCScriptModuleRef self, bool p_licensed);
+
+// Gets the licensed state of a module
+bool MCScriptIsModuleLicensed(MCScriptModuleRef self);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // Create an instance of the given module. If the module is single-instance it

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -225,6 +225,9 @@ __MCScriptCallHandlerDefinitionInInstance(MCScriptInstanceRef self,
 										  uindex_t p_argument_count,
 										  MCValueRef* r_value)
 {
+    if (!self->module->licensed)
+        return MCErrorThrowGeneric(MCSTR("extension not licensed"));
+    
     void *t_cookie = nullptr;
     
     if (self->module->module_kind == kMCScriptModuleKindWidget)

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -427,6 +427,9 @@ bool MCScriptCreateModuleFromStream(MCStreamRef stream, MCScriptModuleRef& r_mod
     if (!MCScriptCreateObject(kMCScriptObjectKindModule, t_module))
         return false;
     
+    // initialize licensed state
+    t_module->licensed = true;
+    
     // If the unpickling fails, there's nothing we can do.
     if (!MCPickleRead(stream, kMCScriptModulePickleInfo, t_module))
     {
@@ -550,6 +553,18 @@ bool MCScriptIsModuleALibrary(MCScriptModuleRef self)
 bool MCScriptIsModuleAWidget(MCScriptModuleRef self)
 {
     return self -> module_kind == kMCScriptModuleKindWidget;
+}
+
+void
+MCScriptSetModuleLicensed(MCScriptModuleRef self, bool p_licensed)
+{
+    self->licensed = p_licensed;
+}
+
+bool
+MCScriptIsModuleLicensed(MCScriptModuleRef self)
+{
+    return self->licensed;
 }
 
 bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -493,7 +493,9 @@ struct MCScriptModule: public MCScriptObject
     bool is_usable : 1;
     // During the check for usability, this var is true - not pickled
     bool is_in_usable_check : 1;
-    
+    // The module is licensed for use - not pickled
+    bool licensed : 1;
+
     // (computed) The number of slots needed by an instance - not pickled
     uindex_t slot_count;
     

--- a/toolchain/lc-compile/src/lc-compile-sources.gypi
+++ b/toolchain/lc-compile/src/lc-compile-sources.gypi
@@ -10,6 +10,7 @@
 		'all_syntax_files':
 		[
 			'<@(engine_syntax_lcb_files)',
+            '<@(engine_syntax_only_lcb_files)',
 			'<@(stdscript_syntax_lcb_files)',
 		],
 		


### PR DESCRIPTION
This patch adds a `check license for edition` statement that
checks an extension is running on an an engine for either the
minimum edition specified or with the addon explicitly licensed.
If it is not licensed a flag is set on the module and calling
handlers on any script instances will throw an error until
the module is licensed.