### PR TITLE
Merge develop 8.2 18.12.2017

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2017-11-3"
+constant kMergExtVersion = "2017-12-14"
 constant kTSNetVersion = "1.3.3"
 
 local sEngineDir

--- a/docs/dictionary/command/revSetCardProfile.lcdoc
+++ b/docs/dictionary/command/revSetCardProfile.lcdoc
@@ -10,9 +10,9 @@ its <object|objects>.
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 revSetCardProfile "MetallicLook"
@@ -51,11 +51,11 @@ of the <current card> of the specified <stack> and all the
 a <property profile|profile> with the specified <profileName>, the
 <object|object's> <properties> are not changed.
 
->*Important:*  The <revSetCardProfile> <command> is part of the <Profile
-> library>. To ensure that the <command> works in a <standalone
-> application>, in the Profiles section on the General screen of the
-> <Standalone Application Settings> window, make sure you choose to
-> include profiles in your application.
+>*Important:*  The <revSetCardProfile> <command> is part of the
+> <Profile library>. To ensure that the <command> works in a
+> <standalone application>, in the Profiles section on the General
+> screen of the <Standalone Application Settings> window, make sure you
+> choose to include profiles in your application.
 
 References: revSetStackFileProfile (command), object (glossary),
 property (glossary), current card (glossary),

--- a/docs/dictionary/command/revSetCardProfile.lcdoc
+++ b/docs/dictionary/command/revSetCardProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Changes the current <property profile|profile> used for a <card> and all
 its <object|objects>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/command/revSetStackFileProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackFileProfile.lcdoc
@@ -10,9 +10,9 @@ a <stack file> and all their <object|objects>.
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 revSetStackFileProfile "Brights"
@@ -53,10 +53,10 @@ specified <profileName>, the <object|object's> <properties> are not
 changed. 
 
 >*Important:*  The <revSetStackFileProfile> <command> is part of the
-> <Profile library>. To ensure that the <command> works in a <standalone
-> application>, in the Profiles section on the General screen of the
-> <Standalone Application Settings> window, make sure you choose to
-> include profiles in your application.
+> <Profile library>. To ensure that the <command> works in a 
+> <standalone application>, in the Profiles section on the General 
+> screen of the <Standalone Application Settings> window, make sure you
+> choose to include profiles in your application.
 
 References: revSetCardProfile (command), revSetStackProfile (command),
 stacks (function), object (glossary), property (glossary),

--- a/docs/dictionary/command/revSetStackFileProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackFileProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Changes the current <property profile|profile> used for all <stacks> in
 a <stack file> and all their <object|objects>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/command/revSetStackProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Changes the current <property profile|profile> used for a <stack> and
 all its <object|objects>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android

--- a/docs/dictionary/command/revSetStackProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackProfile.lcdoc
@@ -10,9 +10,9 @@ all its <object|objects>.
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 revSetStackProfile "LargeFonts","Preferences"
@@ -50,10 +50,10 @@ profile|profile> with the specified <profileName>, the <object|object's>
 <properties> are not changed.
 
 >*Important:*  The <revSetStackProfile> <command> is part of the
-> <Profile library>. To ensure that the <command> works in a <standalone
-> application>, in the Profiles section on the General screen of the
-> <Standalone Application Settings> window, make sure you choose to
-> include profiles in your application.
+> <Profile library>. To ensure that the <command> works in a 
+> <standalone application>, in the Profiles section on the General 
+> screen of the <Standalone Application Settings> window, make sure you
+> choose to include profiles in your application.
 
 References: revSetStackFileProfile (command), object (glossary),
 property (glossary), Standalone Application Settings (glossary),

--- a/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
+++ b/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
@@ -9,6 +9,8 @@ A special <global|global variable> that specifies whether to
 automatically create a <property profile|profile> when you
 switch to a new profile.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android
@@ -42,6 +44,6 @@ changed in the Preferences dialog box:
 
 References: answer (command), ask (command), object (glossary),
 property (glossary), variable (glossary), property profile (glossary),
-global (glossary), properties (property)
+global (glossary), properties (property), Profile library (library)
 
 Tags: windowing

--- a/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
+++ b/docs/dictionary/keyword/gRevAutoCreateProfiles.lcdoc
@@ -1,0 +1,47 @@
+Name: gRevAutoCreateProfiles
+
+Type: keyword
+
+Syntax: gRevAutoCreateProfiles
+
+Summary:
+A special <global|global variable> that specifies whether to 
+automatically create a <property profile|profile> when you
+switch to a new profile.
+
+Introduced: 2.0
+
+OS: mac, windows, linux, ios, android
+
+Platforms: desktop, server, mobile
+
+Example:
+global gRevAutoCreateProfiles
+put true into gRevAutoCreateProfiles
+set the revProfile of me to "NewProfile"
+
+Description:
+Set the <gRevAutoCreateProfiles> <variable> to true when adding a
+new <property profile|profile>.  When false, attempts to change to a
+profile that does not exist are ignored.
+
+Each object can have one or more profiles, which include settings for
+each property in the object's <property|properties>. The
+<gRevAutoCreateProfiles> <variable> controls what happens when you set
+an <object|object's> <property profile|profile> to one that does not
+currently exist.  If true, then the new <property profile|profile> will
+be created.
+
+The <gRevAutoCreateProfiles> <global|global variable> can also be
+changed in the Preferences dialog box:
+
+1. Choose LiveCode → Preferences from the menubar.
+2. Choose "Property Profiles" from the menu at the top.
+3. Click "Create profiles automatically".
+
+
+References: answer (command), ask (command), object (glossary),
+property (glossary), variable (glossary), property profile (glossary),
+global (glossary), properties (property)
+
+Tags: windowing

--- a/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
+++ b/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
@@ -11,14 +11,12 @@ changes to the current <property profile|profile> when you switch
 
 Introduced: 2.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 global gRevProfileReadOnly
-
-Example:
 if gRevProfileReadOnly is false then switchToLargeFonts
 
 Description:
@@ -43,7 +41,7 @@ in the Preferences dialog box:
 
 1. Choose LiveCode → Preferences from the menubar.
 2. Choose "Property Profiles" from the menu at the top.
-3. Click "Don't save changes in profile".
+3. Click "Don't save settings when switching profiles".
 
 
 References: answer (command), ask (command), object (glossary),
@@ -51,4 +49,3 @@ property (glossary), variable (glossary), property profile (glossary),
 global (glossary), properties (property)
 
 Tags: windowing
-

--- a/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
+++ b/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
@@ -9,6 +9,8 @@ A special <global|global variable> that specifies whether to save
 changes to the current <property profile|profile> when you switch
 <property profile|profiles>.
 
+Associations: profile library
+
 Introduced: 2.0
 
 OS: mac, windows, linux, ios, android
@@ -46,6 +48,6 @@ in the Preferences dialog box:
 
 References: answer (command), ask (command), object (glossary),
 property (glossary), variable (glossary), property profile (glossary),
-global (glossary), properties (property)
+global (glossary), properties (property), Profile library (library)
 
 Tags: windowing

--- a/docs/dictionary/property/revProfile.lcdoc
+++ b/docs/dictionary/property/revProfile.lcdoc
@@ -8,6 +8,8 @@ Summary:
 Specifies the current <property profile|profile> for an
 <object(glossary)>. 
 
+Associations: profile library
+
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android
@@ -64,7 +66,7 @@ References: revSetStackFileProfile (command), object (glossary),
 property (glossary), custom property (glossary),
 backgroundColor (glossary), property profile (glossary), button (object),
 customPropertySets (property), gRevAutoCreateProfiles (keyword),
-gRevProfileReadOnly (keyword)
+gRevProfileReadOnly (keyword), Profile library (library)
 
 Tags: properties
 

--- a/docs/dictionary/property/revProfile.lcdoc
+++ b/docs/dictionary/property/revProfile.lcdoc
@@ -10,9 +10,9 @@ Specifies the current <property profile|profile> for an
 
 Introduced: 1.0
 
-OS: mac, windows, linux
+OS: mac, windows, linux, ios, android
 
-Platforms: desktop, server
+Platforms: desktop, server, mobile
 
 Example:
 set the revProfile of button "OK" to "French"
@@ -40,15 +40,14 @@ stored in the object's current profile. If you later switch back to that
 profile, the stored values are restored. For example, if you create a
 profile named "Fluffy" for a button, then set the button's
 backgroundColor <property> to "pink", that setting of the
-<backgroundColor> <property> is stored with the Fluffy <property
-profile|profile>. If you later set the <button|button's> <property
-profile|profile> to "Fluffy", the pink color is restored.
+<backgroundColor> <property> is stored with the Fluffy
+<property profile|profile>. If you later set the <button|button's>
+<property profile|profile> to "Fluffy", the pink color is restored.
 
 If the <profileName> does not exist for the <object(glossary)>, setting
-the <property profile|profile> either causes an error or creates a new
+the <property profile|profile> either fails silently or creates a new
 <property profile|profile> with that name for the <object(glossary)>.
-You change this setting in the "Property Profiles" pane of the
-Preferences window.
+You change this setting using the <gRevAutoCreateProfiles> <variable>.
 
 (The <revProfile> <property> is implemented as a <custom property>, part
 of the "cRevGeneral" <custom property> set. For this reason, you can
@@ -61,20 +60,11 @@ cRevGeneral["profile"].)
 > Settings window, make sure you choose to include profiles in your
 > application. 
 
->*Note:* When included in a standalone application, the Profile library
-> is implemented as a hidden group and made available when the group
-> receives its first openBackground message. During the first part of
-> the application startup process, before this message is sent, the
-> <revProfile> property is not yet available. This may affect attempts
-> to use this property in startup, preOpenStack, openStack, or
-> preOpenCard hand in the main stack. Once the application has finished
-> starting up, the library is available and the <revProfile> property
-> can be used in any handler.
-
 References: revSetStackFileProfile (command), object (glossary),
 property (glossary), custom property (glossary),
 backgroundColor (glossary), property profile (glossary), button (object),
-customPropertySets (property)
+customPropertySets (property), gRevAutoCreateProfiles (keyword),
+gRevProfileReadOnly (keyword)
 
 Tags: properties
 

--- a/docs/dictionary/property/stackFiles.lcdoc
+++ b/docs/dictionary/property/stackFiles.lcdoc
@@ -82,8 +82,10 @@ call the <stack|stack's> <handler|handlers>, use the <start using> or
 
 References: call (glossary), command (glossary), 
 defaultFolder (property), file path (glossary), 
-filename of stack (property), folder (glossary), handler (glossary), insert script (command), library (library), line (keyword), 
-LiveCode (glossary), load (glossary), loaded into memory (glossary), long (keyword), main stack (glossary), mainStack (property), 
+filename of stack (property), folder (glossary), handler (glossary), 
+insert script (command), library (library), line (keyword), 
+LiveCode (glossary), load (glossary), loaded into memory (glossary), 
+long (keyword), main stack (glossary), mainStack (property), 
 mainStacks (function), name (property), object (glossary), 
 properties (property), property (glossary), 
 relative file path (glossary), script (glossary), stack (object), 

--- a/docs/dictionary/property/stackFiles.lcdoc
+++ b/docs/dictionary/property/stackFiles.lcdoc
@@ -17,7 +17,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-set the stackFiles of this stack to "My Dialog,Custom Dialogs.rev"
+set the stackFiles of this stack to "My Dialog,Custom Dialogs.livecode"
 
 Value:
 The <stackFiles> of a <stack> is a list of stack references, one per
@@ -47,31 +47,30 @@ For example, if your stack contains a statement like this, the stack
 "Customers" must either be loaded into memory, or be listed in the
 <stackFiles>, in order for LiveCode to know where it is:
 
-```get the width of field "Text" of card "Data" of stack "Customers"```
+    get the width of field "Text" of card "Data" of stack "Customers" 
 
 
 In this example, if the "Customers" stack is not open and isn't in the
 <stackFiles>, the <statement> must refer to it by its full <long>
 <name>, including its <file path>:
 
-``` get the width of field "Text" of card "Data" of stack "Customers" \
-
-    of stack "/Volumes/Data/Business.rev" ```
+    get the width of field "Text" of card "Data" of stack "Customers" \
+       of stack "/Volumes/Data/Business.livecode" 
 
 
 Using the <stackFiles> lets you simply specify the <stack|stack's> name,
 instead of including its <file path> everywhere you refer to an
 <object(glossary)> in the <stack>.
 
-The <stackFiles> of a <main stack> is inherited by its <substacks> : if
+The <stackFiles> of a <main stack> is inherited by its <substacks>: if
 a <handler> in a <substack> refers to a <stack> that's not
 <load|loaded>, LiveCode checks the <stackFiles> of both the <substack>
 and its <main stack>.
 
 >*Important:*  <relative file path|Relative file paths> in the
 > <stackFiles> start from the <folder> that the <stack> is in, rather
-> than starting from the <defaultFolder> as with other <relative file
-> path|relative paths> in <LiveCode>.
+> than starting from the <defaultFolder> as with other 
+> <relative file path|relative paths> in <LiveCode>.
 
 Placing a stack in the <stackFiles> lets <handler|handlers> in your
 <stack> refer to <object|objects> in the referenced <stack>, but does
@@ -81,16 +80,15 @@ To use a <stack> as a <library>, allowing your <handler|handlers> to
 call the <stack|stack's> <handler|handlers>, use the <start using> or
 <insert script> <command>.
 
-References: stacks (function), mainStacks (function), object (glossary),
-substack (glossary), start using (glossary), call (glossary),
-property (glossary), loaded into memory (glossary), load (glossary),
-file path (glossary), command (glossary), statement (glossary),
-LiveCode (glossary), main stack (glossary), relative file path (glossary),
-folder (glossary), script (glossary), handler (glossary), long (keyword),
-line (keyword), insert script (library), library (library),
-stack (object), substacks (property), properties (property),
-mainStack (property), defaultFolder (property), name (property),
-filename of stack (property)
+References: call (glossary), command (glossary), 
+defaultFolder (property), file path (glossary), 
+filename of stack (property), folder (glossary), handler (glossary), insert script (command), library (library), line (keyword), 
+LiveCode (glossary), load (glossary), loaded into memory (glossary), long (keyword), main stack (glossary), mainStack (property), 
+mainStacks (function), name (property), object (glossary), 
+properties (property), property (glossary), 
+relative file path (glossary), script (glossary), stack (object), 
+stacks (function), start using (command), statement (glossary), 
+substack (glossary), substacks (property)
 
 Tags: file system
 

--- a/docs/glossary/g/Geometry-library.lcdoc
+++ b/docs/glossary/g/Geometry-library.lcdoc
@@ -4,6 +4,8 @@ Synonyms: geometry libraries, geometry library
 
 Type: library
 
+Associations: geometry library
+
 Description:
 The <LiveCode custom library|LiveCode custom library> that supports the
 Geometry pane in the <property inspector>. The <revCacheGeometry> and
@@ -11,7 +13,7 @@ Geometry pane in the <property inspector>. The <revCacheGeometry> and
 
 References: revCacheGeometry (command), revUpdateGeometry (command),
 command (glossary), property inspector (glossary),
-LiveCode custom library (glossary)
+LiveCode custom library (glossary), geometry management (glossary)
 
 Tags: ui
 

--- a/docs/glossary/m/master-profile.lcdoc
+++ b/docs/glossary/m/master-profile.lcdoc
@@ -4,6 +4,8 @@ Synonyms: master profile, master property profile
 
 Type: glossary
 
+Associations: profile library
+
 Description:
 The default <property profile> of an <object(glossary)>. The master
 profile holds the <default> settings for the <object|object's>

--- a/docs/glossary/p/Profile-library.lcdoc
+++ b/docs/glossary/p/Profile-library.lcdoc
@@ -5,6 +5,8 @@ profile libraries
 
 Type: library
 
+Associations: profile library
+
 Description:
 The <LiveCode custom library|LiveCode custom library> that supports
 <property profile|property profiles>. The <property profile|profile>

--- a/docs/glossary/p/property-profile.lcdoc
+++ b/docs/glossary/p/property-profile.lcdoc
@@ -4,6 +4,8 @@ Synonyms: profile, property profile
 
 Type: glossary
 
+Associations: profile library
+
 Description:
 A set of <property> settings for an <object(glossary)>. You create and
 change an <object|object's> profiles using the Property Profiles pane in

--- a/docs/notes/bugfix-13825.md
+++ b/docs/notes/bugfix-13825.md
@@ -1,0 +1,1 @@
+# revSetStackProfile does not work on mobile

--- a/docs/notes/bugfix-18097.md
+++ b/docs/notes/bugfix-18097.md
@@ -1,0 +1,1 @@
+# Geometry manager does not work on mobile

--- a/docs/notes/bugfix-20755.md
+++ b/docs/notes/bugfix-20755.md
@@ -1,0 +1,1 @@
+# Fix crash when calling iPhoneSetRemoteControlDisplay

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -1007,7 +1007,7 @@ bool MCSystemSetRemoteControlDisplayProperties(MCExecContext& ctxt, MCArrayRef p
                     MCAutoStringRef t_string;
                     if (!ctxt . ConvertToString(t_prop_value, &t_string))
                         continue;
-					t_value = [NSString stringWithMCStringRef: *t_string];
+					t_value = [[NSString stringWithMCStringRef: *t_string] retain];
                 }
 					break;
 				case kRCDPropTypeImage:
@@ -1057,6 +1057,8 @@ bool MCSystemSetRemoteControlDisplayProperties(MCExecContext& ctxt, MCArrayRef p
 	if (t_success)
 		[[s_info_center defaultCenter] setNowPlayingInfo: t_info_dict];
 	
+    [t_info_dict release];
+    
 	return ES_NORMAL;
 }
 

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -111,6 +111,14 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "android", tConfirm, pSettings
    
+   -- Manually include the mobile version of the common library
+   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   
+   -- Include profile library if needed
+   if pSettings["includeProfiles"] is not empty then 
+      revSBAddInclusion "Profiles", "scriptLibraries", pSettings
+   end if
+   
    -- Make sure old-style keys are retained, and updated with new information
    -- from inclusions pane of standalone settings GUI
    revSBConvertSettingsForPlatform pSettings, "android"

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -111,8 +111,8 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "android", tConfirm, pSettings
    
-   -- Manually include the mobile version of the common library
-   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   -- Manually include the common library
+   revSBAddInclusion "Common", "scriptLibraries", pSettings
    
    -- Include profile library if needed
    if pSettings["includeProfiles"] is not empty then 

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -104,8 +104,8 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "ios", tConfirm, pSettings
    
-   -- Manually include the mobile version of the common library
-   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   -- Manually include the common library
+   revSBAddInclusion "Common", "scriptLibraries", pSettings
    
    -- Include profile library if needed
    if pSettings["includeProfiles"] is not empty then 

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -99,12 +99,6 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       end if
    end if
    
-   -- Make sure all dependencies are included
-   revSBUpdateForDependencies pSettings
-   
-   -- Manually remove built-in implementations from detected script library inclusions
-   revSBRemoveInclusions pStack, "ios", tConfirm, pSettings
-   
    -- Manually include the common library
    revSBAddInclusion "Common", "scriptLibraries", pSettings
    
@@ -112,10 +106,6 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
    if pSettings["includeProfiles"] is not empty then 
       revSBAddInclusion "Profiles", "scriptLibraries", pSettings
    end if
-   
-   -- Make sure old-style keys are retained, and updated with new information
-   -- from inclusions pane of standalone settings GUI
-   revSBConvertSettingsForPlatform pSettings, "ios"
    
    -- Get the development root for device builds
    -- MM-2012-09-18: Rejiged the SDKs we use.  Things are now split up into sim, armv7, armv7, 

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -104,6 +104,14 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
    -- Manually remove built-in implementations from detected script library inclusions
    revSBRemoveInclusions pStack, "ios", tConfirm, pSettings
    
+   -- Manually include the mobile version of the common library
+   revSBAddInclusion "Mobile", "scriptLibraries", pSettings
+   
+   -- Include profile library if needed
+   if pSettings["includeProfiles"] is not empty then 
+      revSBAddInclusion "Profiles", "scriptLibraries", pSettings
+   end if
+   
    -- Make sure old-style keys are retained, and updated with new information
    -- from inclusions pane of standalone settings GUI
    revSBConvertSettingsForPlatform pSettings, "ios"


### PR DESCRIPTION
Conflicts:

In `engine/src/mbliphoneextra.mm`:

![screen shot 2017-12-18 at 12 09 30](https://user-images.githubusercontent.com/5111835/34105619-fa46497a-e3ec-11e7-978b-3dbc84eae48b.png)

Resolved this by keeping a combination of the two versions:

`t_value = [MCStringConvertToAutoreleasedNSString(*t_string) retain];`

In `ide-support/revsaveasiosstandalone.livecodescript`:

![screen shot 2017-12-18 at 12 11 48](https://user-images.githubusercontent.com/5111835/34105666-268e0c3e-e3ed-11e7-96f9-7baf20524bf7.png)

Resolved by keeping the `develop-8.2` version
