### PR TITLE
remove any generated doc files after running the IDE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,14 @@ all: all-$(guess_platform)
 check: check-$(guess_platform)
 
 # [[ MDW-2017-05-09 ]] feature_clean_target
+# [[ MDW-2017-12-18 ]] feature_clean_doc_data
 clean-linux:
 	rm -rf linux-*-bin
 	rm -rf build-linux-*
 	rm -rf prebuilt/fetched
 	rm -rf prebuilt/include
 	rm -rf prebuilt/lib
+	rm -rf ide/Documentation/html_viewer/resources/data
 	find . -name \*.lcb | xargs touch
 
 check-common-%:
@@ -102,7 +104,7 @@ endif
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:end:config"
 endif
-	
+
 compile-linux-%:
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:start:compile"
@@ -112,7 +114,7 @@ endif
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:end:compile"
 endif
-	
+
 check-linux-%:
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:start:testcpp"
@@ -164,7 +166,7 @@ endif
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:end:config"
 endif
-	
+
 compile-mac:
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:start:compile"
@@ -175,7 +177,7 @@ endif
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:end:compile"
 endif
-	  
+
 check-mac:
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:start:testcpp"


### PR DESCRIPTION
After compiling and launching the compiled build, the data directory is generated inside the resources directory. Git is not happy about this, so this patch deletes the generated files and the directory as part of the cleanup procedure before rebuilding on linux.

Note: apparently there were some stray trailing whitespaces cleaned up as well.