### PR TITLE
[[ Bug 20640 ]] [Docs] Update orientation docs for iPhone X

### DIFF
--- a/docs/dictionary/command/mobileSetAllowedOrientations.lcdoc
+++ b/docs/dictionary/command/mobileSetAllowedOrientations.lcdoc
@@ -46,6 +46,10 @@ the configured list.
 > landscape left and portrait upside-down are only supported on Android
 > 2.3 and later.
 
+>*Note:* The iPhone X model doesn’t currently support upside-down portrait 
+> mode. Other Apple iPad and iPhone devices continue to support both
+> standard and upside-down portait and landscape orientations.
+
 References: mobileLockOrientation (command),
 mobileUnlockOrientation (command), mobileAllowedOrientations (function),
 mobileDeviceOrientation (function), mobileOrientation (function),

--- a/docs/dictionary/function/mobileAllowedOrientations.lcdoc
+++ b/docs/dictionary/function/mobileAllowedOrientations.lcdoc
@@ -39,6 +39,10 @@ of the orientations the application supports.
 > landscape left and portrait upside-down are only supported on Android
 > 2.3 and later.
 
+>*Note:* The iPhone X model doesn’t currently support upside-down portrait 
+> mode. Other Apple iPad and iPhone devices continue to support both
+> standard and upside-down portait and landscape orientations.
+
 References: mobileSetAllowedOrientations (command),
 mobileLockOrientation (command), mobileUnlockOrientation (command),
 mobileDeviceOrientation (function), mobileOrientation (function),

--- a/docs/dictionary/function/mobileDeviceOrientation.lcdoc
+++ b/docs/dictionary/function/mobileDeviceOrientation.lcdoc
@@ -45,6 +45,10 @@ of the device.
 > landscape left and portrait upside-down are only supported on Android
 > 2.3 and later.
 
+>*Note:* The iPhone X model doesn’t currently support upside-down portrait 
+> mode. Other Apple iPad and iPhone devices continue to support both
+> standard and upside-down portait and landscape orientations.
+
 References: mobileSetAllowedOrientations (command),
 mobileLockOrientation (command), mobileUnlockOrientation (command),
 mobileAllowedOrientations (function), mobileOrientation (function),

--- a/docs/dictionary/function/mobileOrientation.lcdoc
+++ b/docs/dictionary/function/mobileOrientation.lcdoc
@@ -42,6 +42,10 @@ interface.
 > landscape left and portrait upside-down are only supported on Android
 > 2.3 and later.
 
+>*Note:* The iPhone X model doesn’t currently support upside-down portrait 
+> mode. Other Apple iPad and iPhone devices continue to support both
+> standard and upside-down portait and landscape orientations.
+
 References: mobileSetAllowedOrientations (command),
 mobileLockOrientation (command), mobileUnlockOrientation (command),
 mobileDeviceOrientation (function), mobileAllowedOrientations (function),


### PR DESCRIPTION
iPhone X no longer supports upside-down portrait mode.