### PR TITLE
[[ Installer ]] Fix behavior resolution in installer

### DIFF
--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1355,6 +1355,10 @@ IO_stat MCDispatch::startup(void)
 		
 		t_stack -> extraopen(false);
 		
+        // Resolve parent scripts *after* we've loaded aux stacks.
+        if (t_stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
+            t_stack -> resolveparentscripts();
+
 		MCscreen->resetcursors();
 		MCImage::init();
 		send_startup_message();
@@ -1416,6 +1420,10 @@ IO_stat MCDispatch::startup(void)
 	MCCapsuleClose(t_capsule);
 
 	t_info . stack -> extraopen(false);
+    
+    // Resolve parent scripts *after* we've loaded aux stacks.
+    if (t_info . stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
+        t_info . stack -> resolveparentscripts();
 
 	MCscreen->resetcursors();
 	MCtemplateimage->init();


### PR DESCRIPTION
This patch fixs behavior resolution in the installer that was broken due
to a previous patch changing the timing of behavior resolution for the
startup stack.