### PR TITLE
[[ Build ]] Tweak the way builtin modules are compiled

### DIFF
--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -151,11 +151,14 @@
 				
 				'../libfoundation/libfoundation.gyp:libFoundation',
 				'../libgraphics/libgraphics.gyp:libGraphics',
+
+				'lcb-modules.gyp:engine_lcb_modules',
 			],
 			
 			'sources':
 			[
 				'<@(engine_security_source_files)',
+				'>@(builtin_lcb_modules)',
 				'src/main.cpp',
 			],
 
@@ -195,7 +198,7 @@
 		{
 			'target_name': 'standalone',
 			'product_name': 'standalone-community',
-			
+
 			'includes':
 			[
 				'app-bundle-template.gypi',
@@ -210,10 +213,12 @@
 			[
 				'kernel-standalone.gyp:kernel-standalone',
 				'engine-common.gyp:security-community',
+				'lcb-modules.gyp:engine_lcb_modules',
 			],
 			
 			'sources':
 			[
+				'>@(builtin_lcb_modules)',
 				'src/dummy.cpp',
 				'rsrc/standalone.rc',
 			],
@@ -466,11 +471,6 @@
 							},
 						},
 
-						'sources':
-						[
-							'<(PRODUCT_DIR)/obj.target/engine_lcb_modules/geni/engine_lcb_modules.o',
-						],
-
 						'sources!':
 						[
 							'src/dummy.cpp',
@@ -532,12 +532,14 @@
 			[
 				'kernel-installer.gyp:kernel-installer',
 				'engine-common.gyp:security-community',
+				'lcb-modules.gyp:engine_lcb_modules',
 			],
 			
 			'sources':
 			[
 				'src/dummy.cpp',
 				'rsrc/installer.rc',
+				'>@(builtin_lcb_modules)',
 			],
 
 			'conditions':
@@ -622,12 +624,14 @@
 				'kernel-development.gyp:kernel-development',
 				'encode_environment_stack',
 				'engine-common.gyp:security-community',
+				'lcb-modules.gyp:engine_lcb_modules',
 			],
 			
 			'sources':
 			[
 				'<(SHARED_INTERMEDIATE_DIR)/src/startupstack.cpp',
 				'rsrc/development.rc',
+				'>@(builtin_lcb_modules)',
 			],
 
 			'conditions':
@@ -821,12 +825,14 @@
 						[
 							'kernel-standalone.gyp:kernel-standalone',
 							'engine-common.gyp:security-community',
+							'lcb-modules.gyp:engine-lcb-modules',
 						],
 			
 						'sources':
 						[
 							'src/dummy.cpp',
 							'src/main.cpp',
+							'>@(builtin_lcb_modules)',
 						],
 
 						'include_dirs':

--- a/engine/kernel-development.gyp
+++ b/engine/kernel-development.gyp
@@ -12,7 +12,7 @@
 		'module_test_sources':
 		[
 			'<@(engine_test_source_files)',
-			'<(SHARED_INTERMEDIATE_DIR)/src/startupstack.cpp',
+			'src/dummystartupstack.cpp',
 		],
 		'module_test_include_dirs':
 		[

--- a/engine/kernel-server.gyp
+++ b/engine/kernel-server.gyp
@@ -47,7 +47,10 @@
 			
 			'dependencies':
 			[
-				'../libexternal/libexternal.gyp:libExternal',
+				'../libfoundation/libfoundation.gyp:libFoundation',
+				'../libgraphics/libgraphics.gyp:libGraphics',
+				'../libscript/libscript.gyp:libScript',
+				'../libscript/libscript.gyp:stdscript',
 				
 				'../prebuilt/libcurl.gyp:libcurl',
 				'../prebuilt/libopenssl.gyp:libopenssl',

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -14,9 +14,9 @@
 			'dependencies':
 			[
 				'../libfoundation/libfoundation.gyp:libFoundation',
-				#'../libexternal/libexternal.gyp:libExternal',
 				'../libgraphics/libgraphics.gyp:libGraphics',
 				'../libscript/libscript.gyp:libScript',
+				'../libscript/libscript.gyp:stdscript',
 				
 				'../libbrowser/libbrowser.gyp:libbrowser',
 
@@ -31,8 +31,6 @@
 
 				'engine-common.gyp:encode_version',
 				'engine-common.gyp:quicktime_stubs',
-				
-				'lcb-modules.gyp:engine_lcb_modules',
 			],
 			
 			'include_dirs':

--- a/engine/lcb-modules.gyp
+++ b/engine/lcb-modules.gyp
@@ -10,18 +10,22 @@
 	[
 		{
 			'target_name': 'engine_lcb_modules',
-			'type': 'static_library',
+			'type': 'none',
 			
 			'dependencies':
 			[
-				'../libscript/libscript.gyp:stdscript',
-				'../toolchain/lc-compile/lc-compile.gyp:lc-compile',
+				'../toolchain/lc-compile/lc-compile.gyp:lc-compile#host',
 			],
 			
 			'all_dependent_settings':
 			{
 				'variables':
 				{
+					'builtin_lcb_modules':
+					[
+						'<(SHARED_INTERMEDIATE_DIR)/engine_lcb_modules.cpp',
+					],
+
 					'dist_aux_files':
 					[
 						# Gyp will only use a recursive xcopy on Windows if the path ends with '/'
@@ -29,60 +33,6 @@
 					],
 				},
 			},
-							
-			'conditions':
-			[
-				[
-					'OS == "win"',
-					{
-						'all_dependent_settings':
-						{
-							'msvs_settings':
-							{
-								'VCLinkerTool':
-								{
-									'AdditionalOptions':
-									[
-										'/WHOLEARCHIVE:<(PRODUCT_DIR)\lib\engine_lcb_modules.lib',
-									],
-								},
-							},
-						},
-					},
-				],
-				[
-					'OS == "mac" or OS == "ios"',
-					{
-						'all_dependent_settings':
-						{
-							'xcode_settings':
-							{
-								'OTHER_LDFLAGS':
-								[
-									'-force_load <(PRODUCT_DIR)/libengine_lcb_modules.a',
-								],
-							},
-						},
-					},
-				],
-                [
-                    'OS == "android" or OS == "linux"',
-                    {
-                        'direct_dependent_settings':
-                        {
-                            'link_settings':
-                            {
-                                'ldflags':
-                                [
-                                    '-Wl,--whole-archive',
-                                    '-Wl,<(PRODUCT_DIR)/obj.target/engine/libengine_lcb_modules.a',
-                                    '-Wl,--no-whole-archive',
-                                ],
-                            },
-                        },
-                    },
-                ],
-			],
 
 			'actions':
 			[
@@ -98,10 +48,23 @@
 						'<@(stdscript_syntax_lcb_files)',
 						'<@(stdscript_other_lcb_files)',
 					],
-					
+								
+					'conditions':
+					[
+						[
+							'OS != "mac"',
+							{
+								'outputs':
+								[
+									'<(PRODUCT_DIR)/modules/',
+								],
+							},
+						],
+					],
+
 					'outputs':
 					[
-						'<(INTERMEDIATE_DIR)/engine_lcb_modules.cpp',
+						'<(SHARED_INTERMEDIATE_DIR)/engine_lcb_modules.cpp',
                         
   						# A specific output file is required here to ensure that
   						# all build systems create the output directory while
@@ -116,7 +79,7 @@
 						'--bootstrap',
 						'--inputg', '../toolchain/lc-compile/src/grammar.g',
 						'--outputi', '<(PRODUCT_DIR)/modules/lci',
-						'--outputc', '<(INTERMEDIATE_DIR)/engine_lcb_modules.cpp',
+						'--outputc', '<(SHARED_INTERMEDIATE_DIR)/engine_lcb_modules.cpp',
 						'<@(_inputs)',
 					],
 				},

--- a/engine/src/dummystartupstack.cpp
+++ b/engine/src/dummystartupstack.cpp
@@ -1,0 +1,8 @@
+extern "C"
+{
+
+char *MCstartupstack;
+unsigned int MCstartupstack_length;
+
+}
+

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -40,23 +40,24 @@
 				'cross-platform-extension-dependencies',
 			],
 			
-			'all_dependent_settings':
-			{
-				'variables':
-				{
-					'dist_aux_files':
-					[
-						# Gyp will only use a recursive xcopy on Windows if the path ends with '/'
-						'<(PRODUCT_DIR)/packaged_extensions/',
-					],
-				},
-			},
 			
 			'conditions':
 			[
 			    [
                     'mobile == 0',
                     {
+						'all_dependent_settings':
+						{
+							'variables':
+							{
+								'dist_aux_files':
+								[
+									# Gyp will only use a recursive xcopy on Windows if the path ends with '/'
+									'<(PRODUCT_DIR)/packaged_extensions/',
+								],
+							},
+						},
+
                         'dependencies':
                         [
 							'lcs-extensions',
@@ -96,9 +97,22 @@
 					'extension': 'livecodescript',
 					'message': 'Building script extension <(RULE_INPUT_NAME)',
 										
+					'conditions':
+					[
+						[
+							'OS != "mac"',
+							{
+								'outputs':
+								[
+									'<(PRODUCT_DIR)/packaged_extensions/',
+								],
+							},
+						],
+					],
+
 					'outputs':
 					[
-						'<(PRODUCT_DIR)/packaged_extensions/com.livecode.library.<(RULE_INPUT_ROOT)/<(RULE_INPUT_ROOT).livecodescript',
+						'<(PRODUCT_DIR)/packaged_extensions/com.livecode.library.<(RULE_INPUT_ROOT)/<(RULE_INPUT_ROOT).livecodescript',	
 					],
 					          
 					'action':


### PR DESCRIPTION
This patch changes the gyp files for the engine build so that
builtin engine modules are compiled into the end-point exe/lib
rather than into a static library.

It also fixes some dependency issues with packaged_extensions and
modules which means '-jN' on make based systems should work
correctly.