### PR TITLE
[[ SVG ]] Improve paint server support

### DIFF
--- a/extensions/script-libraries/drawing/drawing-svg-specification.txt
+++ b/extensions/script-libraries/drawing/drawing-svg-specification.txt
@@ -200,10 +200,10 @@ element linearGradient
 	attribute id <identifier> nullable
 	attribute xml:id <identifier> nullable
 	attribute style <text> nullable
-	attribute x1 <coordinate> nullable
-	attribute y1 <coordinate> nullable
-	attribute x2 <coordinate> nullable
-	attribute y2 <coordinate> nullable
+	attribute x1 <percent-coordinate> nullable
+	attribute y1 <percent-coordinate> nullable
+	attribute x2 <percent-coordinate> nullable
+	attribute y2 <percent-coordinate> nullable
 	attribute gradientTransform <transform> nullable
 	attribute gradientUnits userSpaceOnUse|objectBoundingBox nullable
 	attribute spreadMethod pad|reflect|repeat nullable
@@ -214,9 +214,12 @@ element radialGradient
 	attribute id <identifier> nullable
 	attribute xml:id <identifier> nullable
 	attribute style <text> nullable
-	attribute cx <coordinate> nullable
-	attribute cy <coordinate> nullable
-	attribute r <length> nullable
+	attribute cx <percent-coordinate> nullable
+	attribute cy <percent-coordinate> nullable
+	attribute r <percent-length> nullable
+	attribute fx <percent-coordinate> nullable
+	attribute fy <percent-coordinate> nullable
+	attribute fr <percent-length> nullable
 	attribute gradientTransform <transform> nullable
 	attribute gradientUnits userSpaceOnUse|objectBoundingBox nullable
 	attribute spreadMethod pad|reflect|repeat nullable
@@ -231,4 +234,151 @@ element stop
 	apply stop-color
 	apply stop-opacity
 
+color aliceblue 240 248 255
+color antiquewhite 250 235 215
+color aqua 0 255 255
+color aquamarine 127 255 212
+color azure 240 255 255
+color beige 245 245 220
+color bisque 255 228 196
+color black 0 0 0
+color blanchedalmond 255 235 205
+color blue 0 0 255
+color blueviolet 138 43 226
+color brown 165 42 42
+color burlywood 222 184 135
+color cadetblue 95 158 160
+color chartreuse 127 255 0
+color chocolate 210 105 30
+color coral 255 127 80
+color cornflowerblue 100 149 237
+color cornsilk 255 248 220
+color crimson 220 20 60
+color cyan 0 255 255
+color darkblue 0 0 139
+color darkcyan 0 139 139
+color darkgoldenrod 184 134 11
+color darkgray 169 169 169
+color darkgreen 0 100 0
+color darkgrey 169 169 169
+color darkkhaki 189 183 107
+color darkmagenta 139 0 139
+color darkolivegreen 85 107 47
+color darkorange 255 140 0
+color darkorchid 153 50 204
+color darkred 139 0 0
+color darksalmon 233 150 122
+color darkseagreen 143 188 143
+color darkslateblue 72 61 139
+color darkslategray 47 79 79
+color darkslategrey 47 79 79
+color darkturquoise 0 206 209
+color darkviolet 148 0 211
+color deeppink 255 20 147
+color deepskyblue 0 191 255
+color dimgray 105 105 105
+color dimgrey 105 105 105
+color dodgerblue 30 144 255
+color firebrick 178 34 34
+color floralwhite 255 250 240
+color forestgreen 34 139 34
+color fuchsia 255 0 255
+color gainsboro 220 220 220
+color ghostwhite 248 248 255
+color gold 255 215 0
+color goldenrod 218 165 32
+color gray 128 128 128
+color grey 128 128 128
+color green 0 128 0
+color greenyellow 173 255 47
+color honeydew 240 255 240
+color hotpink 255 105 180
+color indianred 205 92 92
+color indigo 75 0 130
+color ivory 255 255 240
+color khaki 240 230 140
+color lavender 230 230 250
+color lavenderblush 255 240 245
+color lawngreen 124 252 0
+color lemonchiffon 255 250 205
+color lightblue 173 216 230
+color lightcoral 240 128 128
+color lightcyan 224 255 255
+color lightgoldenrodyellow 250 250 210
+color lightgray 211 211 211
+color lightgreen 144 238 144
+color lightgrey 211 211 211
+color lightpink 255 182 193
+color lightsalmon 255 160 122
+color lightseagreen 32 178 170
+color lightskyblue 135 206 250
+color lightslategray 119 136 153
+color lightslategrey 119 136 153
+color lightsteelblue 176 196 222
+color lightyellow 255 255 224
+color lime 0 255 0
+color limegreen 50 205 50
+color linen 250 240 230
+color magenta 255 0 255
+color maroon 128 0 0
+color mediumaquamarine 102 205 170
+color mediumblue 0 0 205
+color mediumorchid 186 85 211
+color mediumpurple 147 112 219
+color mediumseagreen 60 179 113
+color mediumslateblue 123 104 238
+color mediumspringgreen 0 250 154
+color mediumturquoise 72 209 204
+color mediumvioletred 199 21 133
+color midnightblue 25 25 112
+color mintcream 245 255 250
+color mistyrose 255 228 225
+color moccasin 255 228 181
+color navajowhite 255 222 173
+color navy 0 0 128
+color oldlace 253 245 230
+color olive 128 128 0
+color olivedrab 107 142 35
+color orange 255 165 0
+color orangered 255 69 0
+color orchid 218 112 214
+color palegoldenrod 238 232 170
+color palegreen 152 251 152
+color paleturquoise 175 238 238
+color palevioletred 219 112 147
+color papayawhip 255 239 213
+color peachpuff 255 218 185
+color peru 205 133 63
+color pink 255 192 203
+color plum 221 160 221
+color powderblue 176 224 230
+color purple 128 0 128
+color red 255 0 0
+color rosybrown 188 143 143
+color royalblue 65 105 225
+color saddlebrown 139 69 19
+color salmon 250 128 114
+color sandybrown 244 164 96
+color seagreen 46 139 87
+color seashell 255 245 238
+color sienna 160 82 45
+color silver 192 192 192
+color skyblue 135 206 235
+color slateblue 106 90 205
+color slategray 112 128 144
+color slategrey 112 128 144
+color snow 255 250 250
+color springgreen 0 255 127
+color steelblue 70 130 180
+color tan 210 180 140
+color teal 0 128 128
+color thistle 216 191 216
+color tomato 255 99 71
+color turquoise 64 224 208
+color violet 238 130 238
+color wheat 245 222 179
+color white 255 255 255
+color whitesmoke 245 245 245
+color yellow 255 255 0
+color yellowgreen 154 205 50
 

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -85,13 +85,14 @@ The following SVG features are currently supported:
   - 'stop-color' and 'stop-opacity' gradient ramp properties
   - absolute unit specifiers in, cm, mm, pt, pc, px
 
-Currently, only solid colors of with following forms are supported:
+Color values of the following forms are supported:
 
   - &#35;rgb
   - &#35;rrggbb
   - rgb(rrr, ggg, bbb)
-  - black/silver/gray/white/maroon/red/purple/fuchsia
-  - green/lime/olive/yellow/navy/blue/teal/aqua
+  - standard SVG 1.1 named colors (https://www.w3.org/TR/SVG/types.html#ColorKeywords)
+
+Radial gradients support focal point (fx, fy) and SVG2's focal radius (fr).
 
 The rendering of an SVG file inside an image object respects the width, height,
 viewBox and preserveAspectRatio attributes on the root SVG node in the document.
@@ -180,13 +181,14 @@ The following SVG features are currently supported:
   - 'stop-color' and 'stop-opacity' gradient ramp properties
   - absolute unit specifiers in, cm, mm, pt, pc, px
 
-Currently, only solid colors of with following forms are supported:
+Color values of the following forms are supported:
 
   - &#35;rgb
   - &#35;rrggbb
   - rgb(rrr, ggg, bbb)
-  - black/silver/gray/white/maroon/red/purple/fuchsia
-  - green/lime/olive/yellow/navy/blue/teal/aqua
+  - standard SVG 1.1 named colors (https://www.w3.org/TR/SVG/types.html#ColorKeywords)
+
+Radial gradients support focal point (fx, fy) and SVG2's focal radius (fr).
 
 The rendering of an SVG file inside an image object respects the width, height,
 viewBox and preserveAspectRatio attributes on the root SVG node in the document.
@@ -861,6 +863,7 @@ private command _svgCompilePartialPaint @xContext, @xPaint, pBBox
 	switch xPaint[1]
 	case "linear"
 	case "radial"
+	case "conical"
 		_svgCompileTransform xContext, xPaint[3], pBBox, xPaint[3]
 		break
 	default
@@ -889,6 +892,50 @@ private command _svgCompilePaintServer @xContext, pId, pFallback, @rCompiledPain
 			put tGradient["spreadMethod"] into rCompiledPaint[2]
 			if tGradient["gradientUnits"] is "objectBoundingBox" then
 				put "bbox" into rCompiledPaint[3][1][1]
+
+				/* Percentage values in the coordinates of the gradient are
+				 * relative to the bbox */
+				repeat for each item tCoordKey in "x1,x2,y1,y2,r,cx,cy,fr,fx,fy"
+					if tGradient[tCoordKey] ends with "%" then
+						put (char 1 to -2 of tGradient[tCoordKey]) / 100 into tGradient[tCoordKey]
+					end if
+				end repeat
+			else
+				/* Percentage values in the x coords are relative to the viewport
+				 * width. */
+				repeat for each item tCoordKey in "x1,x2,cx,fx"
+					if tGradient[tCoordKey] ends with "%" then
+						if xContext["root-width"] < 0 then
+							throw "viewport relative grad coords not supported"
+						end if
+						put xContext["root-width"] * (char 1 to -2 of tGradient[tCoordKey]) / 100 into tGradient[tCoordKey]
+					end if
+				end repeat
+
+				/* Percentage values in the y coords are relative to the viewport
+				 * height. */
+				repeat for each item tCoordKey in "y1,y2,cy,fy"
+					if tGradient[tCoordKey] ends with "%" then
+						if xContext["root-height"] < 0 then
+							throw "viewport relative grad coords not supported"
+						end if
+						put xContext["root-height"] * (char 1 to -2 of tGradient[tCoordKey]) / 100 into tGradient[tCoordKey]
+					end if
+				end repeat
+
+				/* Percentage values in the r coords are relative to the viewport
+				 * normalize diagonal (sqrt(w^2+h^2)/sqrt(2)). */
+				repeat for each item tCoordKey in "r,fr"
+					if tGradient[tCoordKey] ends with "%" then
+						if xContext["root-height"] < 0 or \
+							xContext["root-width"] < 0 then
+							throw "viewport relative grad coords not supported"
+						end if
+						local tRootDiagonal
+						put sqrt(xContext["root-width"]^2 + xContext["root-height"]^2) / sqrt(2) into tRootDiagonal
+						put tRootDiagonal * (char 1 to -2 of tGradient[tCoordKey]) / 100 into tGradient[tCoordKey]
+					end if
+				end repeat
 			end if
 			seqAppend rCompiledPaint[3], tGradient["gradientTransform"]
 			local tVectorMatrix
@@ -911,6 +958,20 @@ private command _svgCompilePaintServer @xContext, pId, pFallback, @rCompiledPain
 			seqPushOntoBack rCompiledPaint[3], tVectorMatrix
 			put tGradient["colors"] into rCompiledPaint[4]
 			put tGradient["offsets"] into rCompiledPaint[5]
+
+			/* If the focal point matches the center point and the focal
+			 * radius is 0 then this is a 'radial' gradient. Otherwise it is a
+			 * two-point-conical gradient and the focal point/center must
+			 * be mapped into the coordinate system created by the center
+			 * point and radius. */
+			if tGradient["fr"] is not 0 or \
+				tGradient["fx"] is not tGradient["cx"] or \
+				tGradient["fy"] is not tGradient["cy"] then
+				put "conical" into rCompiledPaint[1]
+				put (tGradient["fx"] - tGradient["cx"]) / tGradient["r"] into rCompiledPaint[6]
+				put (tGradient["fy"] - tGradient["cy"]) / tGradient["r"] into rCompiledPaint[7]
+				put tGradient["fr"] / tGradient["r"] into rCompiledPaint[8]
+			end if
 			return empty
 		default
 			break
@@ -931,11 +992,14 @@ private command _svgCompileResolveGradient @xContext, pElement, @rGradient
 	else
 		put 0 into rGradient["x1"]
 		put 0 into rGradient["y1"]
-		put 1 into rGradient["x2"]
+		put "100%" into rGradient["x2"]
 		put 0 into rGradient["y2"]
-		put 0.5 into rGradient["cx"]
-		put 0.5 into rGradient["cy"]
-		put 0.5 into rGradient["r"]
+		put "50%" into rGradient["cx"]
+		put "50%" into rGradient["cy"]
+		put "50%" into rGradient["r"]
+		put "50%" into rGradient["fx"]
+		put "50%" into rGradient["fy"]
+		put 0 into rGradient["fr"]
 		put "objectBoundingBox" into rGradient["gradientUnits"]
 		put empty into rGradient["gradientTransform"]
 		put "pad" into rGradient["spreadMethod"]
@@ -943,7 +1007,7 @@ private command _svgCompileResolveGradient @xContext, pElement, @rGradient
 		put empty into rGradient["offsets"]
 	end if
 
-	repeat for each item tProp in "x1,y1,x2,y2,cx,cy,r,gradientUnits,gradientTransform,spreadMethod"
+	repeat for each item tProp in "x1,y1,x2,y2,cx,cy,r,fx,fy,fr,gradientUnits,gradientTransform,spreadMethod"
 		if tProp is among the keys of pElement["features"] then
 			put pElement["features"][tProp] into rGradient[tProp]
 		end if
@@ -1218,6 +1282,7 @@ constant kMCGDrawingPaintOpcodeEnd = 0
 constant kMCGDrawingPaintOpcodeSolidColor = 1
 constant kMCGDrawingPaintOpcodeLinearGradient = 2
 constant kMCGDrawingPaintOpcodeRadialGradient = 3
+constant kMCGDrawingPaintOpcodeConicalGradient = 4
 
 constant kMCGDrawingSpreadMethodOpcodePad = 0
 constant kMCGDrawingSpreadMethodOpcodeReflect = 1
@@ -1458,20 +1523,28 @@ private command _svgEncodeIndex @xContext, pIndex
 end _svgEncodeIndex
 
 private command _svgEncodeScalars @xContext, pScalars
-	repeat for each element tScalar in pScalars
-		put binaryEncode("f", tScalar) after xContext["scalars"]
-	end repeat
+	if pScalars is an array then
+		repeat for each element tScalar in pScalars
+			put binaryEncode("f", tScalar) after xContext["scalars"]
+		end repeat
+	else
+		repeat with i = 2 to the paramCount
+			put binaryEncode("f", param(i)) after xContext["scalars"]
+		end repeat
+	end if
 end _svgEncodeScalars
 
 private command _svgEncodePaint @xContext, pPaint
 	if pPaint[1] is "none" then
 	else if pPaint[1] is "color" then
 		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeSolidColor, pPaint[2], pPaint[3], pPaint[4], pPaint[5]
-	else if pPaint[1] is "linear" or pPaint[1] is "radial" then
+	else if pPaint[1] is "linear" or pPaint[1] is "radial" or pPaint[1] is "conical" then
 		if pPaint[1] is "linear" then
-		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeLinearGradient
-		else
-		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeRadialGradient
+			_svgEncodeOp xContext, kMCGDrawingPaintOpcodeLinearGradient
+		else if pPaint[1] is "radial" then
+			_svgEncodeOp xContext, kMCGDrawingPaintOpcodeRadialGradient
+		else if pPaint[1] is "conical" then
+			_svgEncodeOp xContext, kMCGDrawingPaintOpcodeConicalGradient
 		end if
 		switch pPaint[2]
 		case "pad"
@@ -1488,6 +1561,9 @@ private command _svgEncodePaint @xContext, pPaint
 		_svgEncodeIndex xContext, the number of elements in pPaint[5]
 		_svgEncodeScalars xContext, pPaint[4]
 		_svgEncodeScalars xContext, pPaint[5]
+		if pPaint[1] is "conical" then
+			_svgEncodeScalars xContext, pPaint[6], pPaint[7], pPaint[8]
+		end if
 	else
 		_InternalError format("unknown paint '%s'", pPaint[1])
 	end if
@@ -1844,6 +1920,15 @@ private function _svgParseFeatureValue @xContext, pElementType, pFeatureName, @x
 					return true
 				end if
 				break
+			case "<percent-coordinate>"
+				if _svgParsePercentCoordinateValue(xValue) then
+					return true
+				end if
+				break
+			case "<percent-length>"
+				if _svgParsePercentLengthValue(xValue) then
+					return true
+				end if
 			default
 				_log format("unimplemented value pattern '%s'", tVariant)
 				break
@@ -1910,39 +1995,8 @@ private function _svgParseColorValue @xValue
 		put baseConvert(char 4 to 5 of xValue, 16, 10) / 255 into tGreen
 		put baseConvert(char 6 to 7 of xValue, 16, 10) / 255 into tBlue
 	else
-		if xValue is "black" then
-			put 0 into tRed; put 0 into tGreen; put 0 into tBlue
-		else if xValue is "silver" then
-			put 192 into tRed; put 192 into tGreen; put 192 into tBlue
-		else if xValue is "gray" then
-			put 128 into tRed; put 128 into tGreen; put 128 into tBlue
-		else if xValue is "white" then
-			put 255 into tRed; put 255 into tGreen; put 255 into tBlue
-		else if xValue is "maroon" then
-			put 128 into tRed; put 0 into tGreen; put 0 into tBlue
-		else if xValue is "red" then
-			put 255 into tRed; put 0 into tGreen; put 0 into tBlue
-		else if xValue is "purple" then
-			put 128 into tRed; put 0 into tGreen; put 128 into tBlue
-		else if xValue is "fuchsia" then
-			put 255 into tRed; put 0 into tGreen; put 255 into tBlue
-		else if xValue is "green" then
-			put 0 into tRed; put 128 into tGreen; put 0 into tBlue
-		else if xValue is "lime" then
-			put 0 into tRed; put 255 into tGreen; put 0 into tBlue
-		else if xValue is "olive" then
-			put 128 into tRed; put 128 into tGreen; put 0 into tBlue
-		else if xValue is "yellow" then
-			put 255 into tRed; put 255 into tGreen; put 0 into tBlue
-		else if xValue is "navy" then
-			put 0 into tRed; put 0 into tGreen; put 128 into tBlue
-		else if xValue is "blue" then
-			put 0 into tRed; put 0 into tGreen; put 255 into tBlue
-		else if xValue is "teal" then
-			put 0 into tRed; put 128 into tGreen; put 128 into tBlue
-		else if xValue is "aqua" then
-			put 0 into tRed; put 255 into tGreen; put 255 into tBlue
-		else if not matchText(xValue, "^rgb\s*\(\s*([0-9]+)\s*\,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)$", tRed, tGreen, tBlue) then
+		if not svgSpecGetColor(xValue, tRed, tGreen, tBlue) and \
+			not matchText(xValue, "^rgb\s*\(\s*([0-9]+)\s*\,\s*([0-9]+)\s*,\s*([0-9]+)\s*\)$", tRed, tGreen, tBlue) then
 			return false
 		end if
 		divide tRed by 255
@@ -1955,6 +2009,7 @@ private function _svgParseColorValue @xValue
 	put tGreen + 0 into xValue["green"]
 	put tBlue + 0 into xValue["blue"]
 	put 1 into xValue["alpha"]
+
 	return true
 end _svgParseColorValue
 
@@ -1999,6 +2054,26 @@ private function _svgParseLengthValue @xValue
 	end  if
 	return false
 end _svgParseLengthValue
+
+private function _svgParsePercentLengthValue @xValue
+	if _svgParseLengthValue(xValue) then
+		return true
+	end if
+
+	put word 1 to -1 of xValue into xValue
+	if char -1 of xValue is "%" then
+		delete the last char of xValue
+		if _svgParseLengthValue(xValue) then
+			put "%" after xValue
+			return true
+		end if
+	end if
+	return false
+end _svgParsePercentLengthValue
+
+private function _svgParsePercentCoordinateValue @xValue
+	return _svgParsePercentLengthValue(xValue)
+end _svgParsePercentCoordinateValue
 
 private function _svgParseSizeValue @xValue
 	local tValue, tValueUnit
@@ -2698,6 +2773,18 @@ private function svgSpecIsProperty pProperty
 	return pProperty is among the keys of sSvgSpec["elements"][""]["property"]
 end svgSpecIsProperty
 
+/* svgSpecGetColor returns the color values for the given named color and
+ * returns true if found, false otherwise. */
+private function svgSpecGetColor pColor, @rRed, @rGreen, @rBlue
+	if pColor is not among the keys of sSvgSpec["colors"] then
+		return false
+	end if
+	put sSvgSpec["colors"][pColor]["red"] into rRed
+	put sSvgSpec["colors"][pColor]["green"] into rGreen
+	put sSvgSpec["colors"][pColor]["blue"] into rBlue
+	return true
+end svgSpecGetColor
+
 /* svgSpecIsPropertyInheritable returns true if the value of a property cascades
  * to children when the property is unset, or whether it has the default
  * set when unset. */
@@ -2955,6 +3042,38 @@ private command svgSpecLoad
 			 * properties. */
 			put true into tCurrentElement["property"][word 2 of tLine]
 			
+			next repeat
+		end if
+
+		/* The 'color' line defines a named color */
+		if tLineType is "color" then
+			/* Color lines are: 'color' <name> <red> <green> <blue> */
+			local tColorName, tColorRed, tColorGreen, tColorBlue
+			put word 2 of tLine into tColorName
+			put word 3 of tLine into tColorRed
+			put word 4 of tLine into tColorGreen
+			put word 5 of tLine into tColorBlue
+
+			/* The color must not be previously defined */
+			if tColorName is among the keys of sSvgSpec["colors"] then
+				_svgSpecError tCurrentRow, format("color '%s' previously defined", tColorName)
+				next repeat
+			end if
+
+			/* The three color values must all be numbers */
+			if tColorRed is not a number or \
+				tColorGreen is not a number or \
+				tColorBlue is not a number then
+				_svgSpecError tCurrentRow, "invalid color values specified"
+				next repeat
+			end if
+
+			/* Clamp the color values (out of range values should probably be
+			 * an error) and put them into the colors key of the spec array. */
+			put min(max(tColorRed, 0), 255) into sSvgSpec["colors"][tColorName]["red"]
+			put min(max(tColorGreen, 0), 255) into sSvgSpec["colors"][tColorName]["green"]
+			put min(max(tColorBlue, 0), 255) into sSvgSpec["colors"][tColorName]["blue"]
+
 			next repeat
 		end if
 

--- a/libgraphics/src/graphics-internal.h
+++ b/libgraphics/src/graphics-internal.h
@@ -241,8 +241,24 @@ public:
     static bool Create(MCGPoint p_focal_point, MCGFloat p_radius, MCGRampRef p_ramp, MCGGradientSpreadMethod p_tile_mode, MCGAffineTransform p_transform, MCGGradientRef& r_gradient);
     
 private:
+    MCGPoint m_focal_point;
+    MCGFloat m_radius;
+};
+
+typedef class MCGConicalGradient *MCGConicalGradientRef;
+
+class MCGConicalGradient: public MCGGradient
+{
+public:
+    virtual bool Apply(SkPaint& r_paint);
+    
+    static bool Create(MCGPoint p_center_point, MCGFloat p_radius, MCGPoint p_focal_point, MCGFloat p_focal_radius, MCGRampRef p_ramp, MCGGradientSpreadMethod p_tile_mode, MCGAffineTransform p_transform, MCGGradientRef& r_gradient);
+    
+private:
+    MCGPoint m_center_point;
     MCGFloat m_radius;
     MCGPoint m_focal_point;
+    MCGFloat m_focal_radius;
 };
 
 typedef class MCGSweepGradient *MCGSweepGradientRef;

--- a/libgraphics/src/utils.cpp
+++ b/libgraphics/src/utils.cpp
@@ -317,6 +317,55 @@ bool MCGRadialGradient::Apply(SkPaint& r_paint)
 
 /**/
 
+bool MCGConicalGradient::Create(MCGPoint p_center_point, MCGFloat p_radius, MCGPoint p_focal_point, MCGFloat p_focal_radius, MCGRampRef p_ramp, MCGGradientSpreadMethod p_spread_method, MCGAffineTransform p_transform, MCGGradientRef& r_gradient)
+{
+    MCGConicalGradientRef t_gradient = new (nothrow) MCGConicalGradient;
+    if (t_gradient == nullptr)
+    {
+        return false;
+    }
+    
+    t_gradient->m_center_point = p_center_point;
+    t_gradient->m_radius = p_radius;
+    t_gradient->m_focal_point = p_focal_point;
+    t_gradient->m_focal_radius = p_focal_radius;
+    t_gradient->m_ramp = MCGRetain(p_ramp);
+    t_gradient->m_spread_method = p_spread_method;
+    t_gradient->m_transform = p_transform;
+    
+    r_gradient = t_gradient;
+    
+    return true;
+}
+
+bool MCGConicalGradient::Apply(SkPaint& r_paint)
+{
+	SkMatrix t_transform;
+    MCGAffineTransformToSkMatrix(m_transform, t_transform);
+
+    sk_sp<SkShader> t_shader =
+            SkGradientShader::MakeTwoPointConical(MCGPointToSkPoint(m_center_point),
+                                                  m_radius,
+                                                  MCGPointToSkPoint(m_focal_point),
+                                                  m_focal_radius,
+                                                  m_ramp->GetColors(),
+                                                  m_ramp->GetStops(),
+                                                  m_ramp->GetLength(),
+                                                  MCGGradientSpreadMethodToSkTileMode(m_spread_method),
+                                                  0,
+                                                  &t_transform);
+    if (t_shader == nullptr)
+    {
+        return false;
+    }
+
+    r_paint.setShader(t_shader);
+    
+    return true;
+}
+
+/**/
+
 bool MCGSweepGradient::Create(MCGPoint p_center, MCGRampRef p_ramp, MCGGradientSpreadMethod p_spread_method, MCGAffineTransform p_transform, MCGGradientRef& r_gradient)
 {
     MCGSweepGradientRef t_gradient = new (nothrow) MCGSweepGradient;


### PR DESCRIPTION
This patch improves paint support in the drawing format and svg compiler.

It adds the full range of named colors from SVG1.1 (now specified in the
svg specification file).

It adds support for percentage values in gradient coordinates and radii
for both the object bbox case and the viewport case, where the current
viewport is fixed size.

Finally it adds support for conical gradients - i.e. radial gradients
which have a focal point and optional focal radius.