### PR TITLE
iconSVG add icon/current family feature

### DIFF
--- a/extensions/libraries/iconsvg/iconsvg.lcb
+++ b/extensions/libraries/iconsvg/iconsvg.lcb
@@ -1606,7 +1606,7 @@ library is able to access SVG paths.
 
 >Note:  The icon name is accepted in the form "name" or "family/name".  
 If no family is specified, then the current family is searched first.  
-If not found, other families are serched for the provided name.
+If not found, other families are searched for the provided name.
 
 Related: iconNames(handler), iconNamesForFamily(handler)
 */
@@ -1636,7 +1636,7 @@ icons for which this library is able to access SVG paths.
 
 >Note:  The icon name is accepted in the form "name" or "family/name".  
 If no family is specified, then the current family is searched first.  
-If not found, other families are serched for the provided name.
+If not found, other families are searched for the provided name.
 
 Related: iconNames(handler), iconNamesForFamily(handler)
 */

--- a/extensions/libraries/iconsvg/iconsvg.lcb
+++ b/extensions/libraries/iconsvg/iconsvg.lcb
@@ -31,6 +31,7 @@ metadata _ide is "true"
 private variable sFontArray as Array
 private variable sNamesArray as Array
 private variable sInitialised as optional Boolean
+private variable sCurrentFamily as String
 
 private constant kDefaultFamily is "fontawesome"
 private constant kDefaultUserFamily is "custom"
@@ -39,6 +40,7 @@ private handler ensureInitialised()
 	if sInitialised is nothing then
 		initialiseIcons()
 		put true into sInitialised
+		put kDefaultFamily into sCurrentFamily
 	end if
 end handler
 
@@ -1417,13 +1419,13 @@ private handler initialiseIcons() returns nothing
 end handler
 
 /**
-Summary: Returns the available icons in the default icon family.
+Summary: Returns the available icons in the current icon family.
 
 Returns(String): The icon names for which SVG paths are available, one per line.
 
 Description:
 The <iconNames> handler returns the names of the icons in the library's
-default icon family.
+current icon family.
 
 Call <iconSVGPathFromName> or <iconCodepointFromName> to retrieve either the
 SVG path string or codepoint corresponding to the icon with this name.
@@ -1436,18 +1438,18 @@ public handler iconNames() returns String
 	ensureInitialised()
 
 	variable tNames as String
-	combine sNamesArray[kDefaultFamily] with newline into tNames
+	combine sNamesArray[sCurrentFamily] with newline into tNames
 
 	return tNames
 end handler
 
 /**
-Summary: Return the available icons in the default icon family.
+Summary: Return the available icons in the current icon family.
 
 Returns(List): The icon names for which SVG paths are available.
 
 Description:
-Return an LCB list of the icon names in the iconsvg library's default
+Return an LCB list of the icon names in the iconsvg library's current
 icon family.
 
 For each icon name, the SVG path string can be obtained with
@@ -1460,7 +1462,7 @@ References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
 */
 public handler iconList() returns List
 	ensureInitialised()
-	return sNamesArray[kDefaultFamily]
+	return sNamesArray[sCurrentFamily]
 end handler
 
 /**
@@ -1559,12 +1561,12 @@ private handler resolveIconName(in pName as String) returns optional List
 		end if
 	end if
 
-	-- If there's no family part, search for the name in the default family,
+	-- If there's no family part, search for the name in the current family,
 	-- followed by all other available families
 	if tFamily is nothing then
 		put pName into tName
-		if pName is among the keys of sFontArray[kDefaultFamily] then
-			put kDefaultFamily into tFamily
+		if pName is among the keys of sFontArray[sCurrentFamily] then
+			put sCurrentFamily into tFamily
 		else
 			repeat for each key tKey in sFontArray
 				if pName is among the keys of sFontArray[tKey] then
@@ -1666,7 +1668,7 @@ public handler iconListMatching(in pSearch as String) returns List
 	variable tName as String
 	variable tNamePrefix as String
 	repeat for each key tFamily in sFontArray
-		if tFamily is kDefaultFamily then
+		if tFamily is sCurrentFamily then
 			put "" into tNamePrefix
 		else
 			put tFamily & "/" into tNamePrefix
@@ -1682,20 +1684,20 @@ public handler iconListMatching(in pSearch as String) returns List
 end handler
 
 /**
-Summary: Return the available icon data in the default icon family.
+Summary: Return the available icon data in the current icon family.
 
 pSearch: String used to search icon names
-Returns(Array): The default icon family's data (name, SVG path, codepoint).
+Returns(Array): The current icon family's data (name, SVG path, codepoint).
 
 Description:
-Return an LCB array of the icon data in the iconsvg library's default
+Return an LCB array of the icon data in the iconsvg library's current
 icon family.
 
 References: iconList(handler), iconNames(handler)
 */
 public handler iconData() returns Array
 	ensureInitialised()
-	return sFontArray[kDefaultFamily]
+	return sFontArray[sCurrentFamily]
 end handler
 
 /**
@@ -1810,6 +1812,41 @@ public handler addIconsForFamily(in pFamily as String, in pIconData as Array) re
 	
 	put the keys of sFontArray[pFamily] into sNamesArray[pFamily]
 	sort sNamesArray[pFamily] in ascending order
+end handler
+
+/**
+Summary: Return the current icon family.
+
+Returns(String): The current icon family.
+
+Description:
+Returns the iconsvg library's current icon family.  Handlers that do not specify
+an icon family will use the current icon family.  "fontawesome" is the
+current family when the library is first initialized.
+
+References: iconData(handler), iconList(handler), iconNames(handler)
+*/
+public handler getCurrentIconFamily() returns String
+	return sCurrentFamily
+end handler
+
+/**
+Summary: Set the current icon family.
+
+pFamily: The icon family.
+
+Description:
+Sets the iconsvg library's current icon family.  Handlers that do not specify
+an icon family will use the current icon family.
+
+References: iconData(handler), iconList(handler), iconNames(handler)
+*/
+public handler setCurrentIconFamily(in pFamily as String) returns nothing
+	if pFamily is not among the keys of sFontArray then
+		throw "Icon family '" & pFamily & "' does not exist."
+	end if
+	
+	put pFamily into sCurrentFamily
 end handler
 
 end library

--- a/extensions/libraries/iconsvg/iconsvg.lcb
+++ b/extensions/libraries/iconsvg/iconsvg.lcb
@@ -23,7 +23,7 @@ library com.livecode.library.iconsvg
 
 use com.livecode.engine
 
-metadata version is "1.1.0"
+metadata version is "1.2.0"
 metadata author is "LiveCode"
 metadata title is "Icon SVG Library"
 metadata _ide is "true"
@@ -33,6 +33,7 @@ private variable sNamesArray as Array
 private variable sInitialised as optional Boolean
 
 private constant kDefaultFamily is "fontawesome"
+private constant kDefaultUserFamily is "custom"
 
 private handler ensureInitialised()
 	if sInitialised is nothing then
@@ -551,10 +552,10 @@ private handler initialiseIconsFontAwesome1() returns Array
 end handler
 
 private handler initialiseIconsFontAwesome2() returns Array
-    variable tArray as Array
-    put {} into tArray
+	variable tArray as Array
+	put {} into tArray
 
-    put the empty array into tArray["hand left"]
+	put the empty array into tArray["hand left"]
 	put "M1376 1408L1408 1408 1408 768 1376 768Q1341 768 1308.5 756 1276 744 1246 719 1216 694 1196 673 1176 652 1147 619 1145 616 1143.5 614.5 1142 613 1139.5 610 1137 607 1135 605 1063 524 1023 460 1009 438 985 392 984 389 974.5 369.5 965 350 956 333.5 947 317 936 298 925 279 914.5 267.5 904 256 896 256 825 256 780.5 286.5 736 317 736 384 736 427 751 468.5 766 510 784 536.5 802 563 817 591.5 832 620 832 640L256 640Q206 640 167 678.5 128 717 128 768 128 820 166 858 204 896 256 896L587 896Q572 913 562 943.5 552 974 552 999 552 1068 605 1118 587 1150 587 1187 587 1224 604.5 1260.5 622 1297 652 1313 648 1337 648 1369 648 1454 696.5 1495 745 1536 832 1536 916 1536 1015 1504 1114 1472 1209 1440 1304 1408 1376 1408ZM1664 1344Q1664 1318 1645 1299 1626 1280 1600 1280 1574 1280 1555 1299 1536 1318 1536 1344 1536 1370 1555 1389 1574 1408 1600 1408 1626 1408 1645 1389 1664 1370 1664 1344ZM1792 768L1792 1408Q1792 1461 1754.5 1498.5 1717 1536 1664 1536L1376 1536Q1317 1536 1153 1595 963 1664 836 1664 694 1664 606 1586.5 518 1509 519 1369L520 1364Q459 1288 459 1186 459 1164 462 1143 429 1086 425 1024L256 1024Q151 1024 75.5 948 0 872 0 767 0 664 76 588 152 512 256 512L630 512Q608 452 608 384 608 262 689.5 195 771 128 896 128 934 128 965.5 145.5 997 163 1020.5 195 1044 227 1061 258 1078 289 1098 330 1118 371 1131 392 1166 447 1231 521 1233 524 1245 538 1257 552 1264 559.5 1271 567 1284.5 581 1298 595 1308.5 603.5 1319 612 1331 621.5 1343 631 1354.5 635.5 1366 640 1376 640L1664 640Q1717 640 1754.5 677.5 1792 715 1792 768Z" into tArray["hand left"]["svg"]
 	put "f0a5" into tArray["hand left"]["codepoint"]
 	put the empty array into tArray["hand right"]
@@ -1391,15 +1392,15 @@ end handler
 private handler initialiseIcons() returns nothing
 	variable tFamily
 	variable tName
-    variable tTempArray as Array
+	variable tTempArray as Array
 
 	put {} into sFontArray
 	put initialiseIconsIDE() into sFontArray["ide"]
-    put initialiseIconsFontAwesome1() into sFontArray["fontawesome"]
-    put initialiseIconsFontAwesome2() into tTempArray
-    repeat for each key tName in tTempArray
-        put tTempArray[tName] into sFontArray["fontawesome"][tName]
-    end repeat
+	put initialiseIconsFontAwesome1() into sFontArray["fontawesome"]
+	put initialiseIconsFontAwesome2() into tTempArray
+	repeat for each key tName in tTempArray
+		put tTempArray[tName] into sFontArray["fontawesome"][tName]
+	end repeat
 
 	put {} into sNamesArray
 	repeat for each key tFamily in sFontArray
@@ -1428,7 +1429,8 @@ Call <iconSVGPathFromName> or <iconCodepointFromName> to retrieve either the
 SVG path string or codepoint corresponding to the icon with this name.
 
 References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
-	iconList(handler)
+	iconFamilies(handler), iconList(handler), iconListForFamily(handler),
+	iconNamesForFamily(handler)
 */
 public handler iconNames() returns String
 	ensureInitialised()
@@ -1453,11 +1455,86 @@ For each icon name, the SVG path string can be obtained with
 <iconCodepointFromName>.
 
 References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
-	iconNames(handler)
+	iconFamilies(handler), iconListForFamily(handler), iconNames(handler),
+	iconNamesForFamily(handler)
 */
 public handler iconList() returns List
 	ensureInitialised()
 	return sNamesArray[kDefaultFamily]
+end handler
+
+/**
+Summary: Returns the available icons families.
+
+Returns(String): The icon family names for which SVG paths are available, one per line.
+
+Description:
+The <iconFamilies> handler returns the names of the families in the icon library.
+
+References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
+	iconList(handler), iconListForFamily(handler),
+	iconNames(handler), iconNamesForFamily(handler)
+*/
+public handler iconFamilies() returns String
+	ensureInitialised()
+
+	variable tFamilies as String
+	combine the keys of sFontArray with newline into tFamilies
+
+	return tFamilies
+end handler
+
+/**
+Summary: Returns the available icons in the specified icon family.
+
+pFamily: The name of the icon family
+Returns(String): The icon names for which SVG paths are available, one per line.
+
+Description:
+The <iconNamesForFamily> handler returns the names of the icons in the 
+library of the specified icon family.
+
+Call <iconSVGPathFromName> or <iconCodepointFromName> to retrieve either the
+SVG path string or codepoint corresponding to the icon with this name.
+
+References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
+	iconFamilies(handler), iconList(handler), iconListForFamily(handler)
+*/
+public handler iconNamesForFamily(in pFamily as String) returns String
+	ensureInitialised()
+	if pFamily is not among the keys of sFontArray then
+		return ""
+	else
+		variable tNames as String
+		combine sNamesArray[pFamily] with newline into tNames
+		return tNames
+	end if
+end handler
+
+/**
+Summary: Return the available icons in the specified icon family.
+
+pFamily: The name of the icon family
+Returns(List): The icon names for which SVG paths are available.
+
+Description:
+Return an LCB list of the icon names of the specified family in the 
+iconsvg library.
+
+For each icon name, the SVG path string can be obtained with
+<iconSVGPathFromName> or its corresponding codepoint with
+<iconCodepointFromName>.
+
+References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
+	iconFamilies(handler), iconNames(handler), iconNamesForFamily(handler)
+*/
+public handler iconListForFamily(in pFamily as String) returns List
+	ensureInitialised()
+	if pFamily is not among the keys of sFontArray then
+		return the empty list
+	else
+		return sNamesArray[pFamily]
+	end if
 end handler
 
 private handler resolveIconName(in pName as String) returns optional List
@@ -1561,30 +1638,178 @@ public handler iconCodepointFromName(in pName as String) returns String
 	return sFontArray[tResolved[1]][tResolved[2]]["codepoint"]
 end handler
 
-/*
--- FIXME must be updated to cope with multi-family implementation
+/**
+Summary: Return the available icons in any icon family that match the 
+search string.
+
+Returns(List): The icon names for which SVG paths are available matching 
+the search string.
+
+Description:
+Return an LCB list of the icon names in any iconsvg library that match 
+the search string.
+
+For each icon name, the SVG path string can be obtained with
+<iconSVGPathFromName> or its corresponding codepoint with
+<iconCodepointFromName>.
+
+References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
+	iconList(handler), iconListForFamily(handler)
+*/
 public handler iconListMatching(in pSearch as String) returns List
 	ensureInitialised()
 
 	variable tMatches as List
 	put the empty list into tMatches
 
+	variable tFamily as String
 	variable tName as String
-	repeat for each element tName in sNamesList
-		if tName contains pSearch then
-			push tName onto tMatches
+	variable tNamePrefix as String
+	repeat for each key tFamily in sFontArray
+		if tFamily is kDefaultFamily then
+			put "" into tNamePrefix
+		else
+			put tFamily & "/" into tNamePrefix
 		end if
+		repeat for each element tName in sNamesArray[tFamily]
+			if tName contains pSearch then
+				push (tNamePrefix & tName) onto tMatches
+			end if
+		end repeat
 	end repeat
 
 	return tMatches
 end handler
 
--- FIXME must be updated to cope with multi-family implementation
-public handler iconData() returns Array
-    ensureInitialised()
+/**
+Summary: Return the available icon data in the default icon family.
 
-	return sFontArray
-end handler
+pSearch: String used to search icon names
+Returns(Array): The default icon family's data (name, SVG path, codepoint).
+
+Description:
+Return an LCB array of the icon data in the iconsvg library's default
+icon family.
+
+References: iconList(handler), iconNames(handler)
 */
+public handler iconData() returns Array
+	ensureInitialised()
+	return sFontArray[kDefaultFamily]
+end handler
+
+/**
+Summary: Return the available icon data in the specified icon family.
+
+pFamily: The name of the icon family
+Returns(Array): The specified icon family's data (name, SVG path, codepoint).
+
+Description:
+Return an LCB array of the icon data in the iconsvg library's specified
+icon family.
+
+References: iconFamilies(handler), iconListForFamily(handler), 
+iconNamesForFamily(handler)
+*/
+public handler iconDataForFamily(in pFamily as String) returns Array
+	ensureInitialised()
+	if pFamily is not among the keys of sFontArray then
+		return {}
+	else
+		return sFontArray[pFamily]
+	end if
+end handler
+
+/**
+Summary: Add an icon to the iconsvg library.
+
+pName: The name of the icon.  By default, new icons are added to the 
+"custom" family.  The family may be specified by including the family 
+name and a "/" before the icon name (`bootstrap/adjust`).
+pSVG: The SVG path for the icon.
+pCodepoint: The codepoint for the icon.
+
+Description:
+Add an icon to the iconsvg library.  By default, new icons are added to
+the "custom" family.  The family may be specified by including the 
+family name and a "/" before the icon name (`bootstrap/adjust`).
+
+References: addIconsForFamily(handler), iconFamilies(handler), 
+iconList(handler), iconListForFamily(handler), 
+iconNames(handler), iconNamesForFamily(handler)
+*/
+public handler addIcon(in pName as String, in pSVG as String, \
+							  in pCodepoint as String) returns nothing
+	ensureInitialised()
+
+	variable tSlashOffset as Number
+	variable tFamily as optional String
+	variable tName as String
+
+	put the last index of "/" in pName into tSlashOffset
+
+	-- If there's a family part, extract it
+	if tSlashOffset is not 0 then
+		if tSlashOffset < the number of chars in pName then
+			put char tSlashOffset + 1 to -1 of pName into tName
+		else
+			put "" into tName
+		end if
+		if tSlashOffset - 1 is not 0 then
+			put char 1 to tSlashOffset - 1 of pName into tFamily
+		else
+			put "" into tFamily
+		end if
+		if tName is "" or tFamily is "" then
+			throw "Icon name invalid (slash separates family and name): '" & pName & "'"
+		end if
+	end if
+
+	if tFamily is nothing then
+		put kDefaultUserFamily into tFamily
+		put pName into tName
+	end if
+
+	if tFamily is not among the keys of sFontArray then
+		put the empty array into sFontArray[tFamily]
+	end if
+
+	put the empty array into sFontArray[tFamily][tName]
+	put pSVG into sFontArray[tFamily][tName]["svg"]
+	put pCodepoint into sFontArray[tFamily][tName]["codepoint"]
+
+	put the keys of sFontArray[tFamily] into sNamesArray[tFamily]
+	sort sNamesArray[tFamily] in ascending order
+end handler
+
+/**
+Summary: Add icons to the iconsvg library.
+
+pFamily: The family for the icons.
+pIconData: The icon data.  Each key is an icon name with
+a key for the SVG data and a key for the codepoint.
+
+Description:
+Add icons to the iconsvg library.
+
+References: addIcon(handler), iconFamilies(handler), 
+iconList(handler), iconListForFamily(handler), 
+iconNames(handler), iconNamesForFamily(handler)
+*/
+public handler addIconsForFamily(in pFamily as String, in pIconData as Array) returns nothing
+	ensureInitialised()
+
+	if pFamily is not among the keys of sFontArray then
+		put the empty array into sFontArray[pFamily]
+	end if
+
+	variable tName
+	repeat for each key tName in pIconData
+		put pIconData[tName] into sFontArray[pFamily][tName]
+	end repeat
+	
+	put the keys of sFontArray[pFamily] into sNamesArray[pFamily]
+	sort sNamesArray[pFamily] in ascending order
+end handler
 
 end library

--- a/extensions/libraries/iconsvg/iconsvg.lcb
+++ b/extensions/libraries/iconsvg/iconsvg.lcb
@@ -1644,6 +1644,7 @@ end handler
 Summary: Return the available icons in any icon family that match the 
 search string.
 
+pSearch: The string used to search icon names.
 Returns(List): The icon names for which SVG paths are available matching 
 the search string.
 

--- a/extensions/libraries/iconsvg/iconsvg.lcb
+++ b/extensions/libraries/iconsvg/iconsvg.lcb
@@ -1421,7 +1421,8 @@ end handler
 /**
 Summary: Returns the available icons in the current icon family.
 
-Returns(String): The icon names for which SVG paths are available, one per line.
+Returns(String): The icon names for which SVG paths are available, 
+one per line.
 
 Description:
 The <iconNames> handler returns the names of the icons in the library's
@@ -1599,9 +1600,15 @@ pName: The name of the icon
 Returns: The SVG path to draw the icon with name <pName>
 
 Description:
-Returns the SVG path for the icon with name <pName>. Use the <iconNames> handler to obtain the names of the icons for which this library is able to access SVG paths.
+Returns the SVG path for the icon with name <pName>. Use the 
+<iconNames> handler to obtain the names of the icons for which this 
+library is able to access SVG paths.
 
-Related: iconNames(handler)
+>Note:  The icon name is accepted in the form "name" or "family/name".  
+If no family is specified, then the current family is searched first.  
+If not found, other families are serched for the provided name.
+
+Related: iconNames(handler), iconNamesForFamily(handler)
 */
 public handler iconSVGPathFromName(in pName as String) returns String
 	ensureInitialised()
@@ -1617,16 +1624,21 @@ public handler iconSVGPathFromName(in pName as String) returns String
 end handler
 
 /**
-Returns the codepoint corresponding to the given icon in the fontawesome font.
+Returns the codepoint corresponding to the given icon in the current font.
 
 pName: The name of the icon
 Returns: The codepoint of the icon with name <pName>
 
 Description:
-Returns the codepoint corresponding to the icon with name <pName> in the fontawesome font.
-Use the <iconNames> handler to obtain the names of the icons for which this library is able to access SVG paths.
+Returns the codepoint corresponding to the icon with name <pName> in the 
+current font.  Use the <iconNames> handler to obtain the names of the 
+icons for which this library is able to access SVG paths.
 
-Related: iconNames(handler)
+>Note:  The icon name is accepted in the form "name" or "family/name".  
+If no family is specified, then the current family is searched first.  
+If not found, other families are serched for the provided name.
+
+Related: iconNames(handler), iconNamesForFamily(handler)
 */
 public handler iconCodepointFromName(in pName as String) returns String
 	ensureInitialised()
@@ -1641,7 +1653,47 @@ public handler iconCodepointFromName(in pName as String) returns String
 end handler
 
 /**
-Summary: Return the available icons in any icon family that match the 
+Summary: Return the available icons in all icon families that match the 
+search string.
+
+pSearch: The string used to search icon names.
+Returns(Array): Each key is a family that contained icon matches to the 
+search string.  Each value is a list of the icon matches.
+
+Description:
+Returns an array of families with icon names matching the search string.
+Each value is a list of the icon matches.
+
+For each icon name, the SVG path string can be obtained with
+<iconSVGPathFromName> or its corresponding codepoint with
+<iconCodepointFromName>.
+
+References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
+	iconList(handler), iconListForFamily(handler)
+*/
+public handler iconArrayMatchingInAllFamilies(in pSearch as String) returns Array
+	ensureInitialised()
+
+	variable tMatches as Array
+	put the empty array into tMatches
+	
+	variable tList as List
+	put the empty list into tList
+
+	variable tFamily as String
+	repeat for each key tFamily in sFontArray
+		put _iconListMatching(pSearch, tFamily) into tList
+		if tList is not the empty list then
+			put the empty list into tMatches[tFamily]
+			put tList into tMatches[tFamily]
+		end if
+	end repeat
+
+	return tMatches
+end handler
+
+/**
+Summary: Return the available icons in the current icon family that match the 
 search string.
 
 pSearch: The string used to search icon names.
@@ -1649,7 +1701,7 @@ Returns(List): The icon names for which SVG paths are available matching
 the search string.
 
 Description:
-Return an LCB list of the icon names in any iconsvg library that match 
+Return an LCB list of the icon names in the current icon family that match 
 the search string.
 
 For each icon name, the SVG path string can be obtained with
@@ -1662,23 +1714,18 @@ References: iconSVGPathFromName(handler), iconCodepointFromName(handler),
 public handler iconListMatching(in pSearch as String) returns List
 	ensureInitialised()
 
+	return _iconListMatching(pSearch, sCurrentFamily)
+end handler
+
+private handler _iconListMatching(in pSearch as String, in pFamily as String) returns List
 	variable tMatches as List
 	put the empty list into tMatches
 
-	variable tFamily as String
 	variable tName as String
-	variable tNamePrefix as String
-	repeat for each key tFamily in sFontArray
-		if tFamily is sCurrentFamily then
-			put "" into tNamePrefix
-		else
-			put tFamily & "/" into tNamePrefix
+	repeat for each element tName in sNamesArray[pFamily]
+		if tName contains pSearch then
+			push tName onto tMatches
 		end if
-		repeat for each element tName in sNamesArray[tFamily]
-			if tName contains pSearch then
-				push (tNamePrefix & tName) onto tMatches
-			end if
-		end repeat
 	end repeat
 
 	return tMatches
@@ -1687,7 +1734,6 @@ end handler
 /**
 Summary: Return the available icon data in the current icon family.
 
-pSearch: String used to search icon names
 Returns(Array): The current icon family's data (name, SVG path, codepoint).
 
 Description:
@@ -1711,7 +1757,8 @@ Description:
 Return an LCB array of the icon data in the iconsvg library's specified
 icon family.
 
-References: iconFamilies(handler), iconListForFamily(handler), 
+References: addIconFamily(handler), deleteIconFamily(handler), 
+iconFamilies(handler), iconListForFamily(handler), 
 iconNamesForFamily(handler)
 */
 public handler iconDataForFamily(in pFamily as String) returns Array
@@ -1737,7 +1784,7 @@ Add an icon to the iconsvg library.  By default, new icons are added to
 the "custom" family.  The family may be specified by including the 
 family name and a "/" before the icon name (`bootstrap/adjust`).
 
-References: addIconsForFamily(handler), iconFamilies(handler), 
+References: addIconFamily(handler), iconFamilies(handler), 
 iconList(handler), iconListForFamily(handler), 
 iconNames(handler), iconNamesForFamily(handler)
 */
@@ -1786,7 +1833,7 @@ public handler addIcon(in pName as String, in pSVG as String, \
 end handler
 
 /**
-Summary: Add icons to the iconsvg library.
+Summary: Add an icon family to the iconsvg library.
 
 pFamily: The family for the icons.
 pIconData: The icon data.  Each key is an icon name with
@@ -1795,11 +1842,15 @@ a key for the SVG data and a key for the codepoint.
 Description:
 Add icons to the iconsvg library.
 
-References: addIcon(handler), iconFamilies(handler), 
-iconList(handler), iconListForFamily(handler), 
+> Note:  If the family already exists, then the data will be merged.
+Icons with matching names will be replaced.
+To replace a family, use <deleteIconFamily> first.
+
+References: addIcon(handler), deleteIconFamily(handler), 
+iconFamilies(handler), iconList(handler), iconListForFamily(handler), 
 iconNames(handler), iconNamesForFamily(handler)
 */
-public handler addIconsForFamily(in pFamily as String, in pIconData as Array) returns nothing
+public handler addIconFamily(in pFamily as String, in pIconData as Array) returns nothing
 	ensureInitialised()
 
 	if pFamily is not among the keys of sFontArray then
@@ -1825,7 +1876,8 @@ Returns the iconsvg library's current icon family.  Handlers that do not specify
 an icon family will use the current icon family.  "fontawesome" is the
 current family when the library is first initialized.
 
-References: iconData(handler), iconList(handler), iconNames(handler)
+References: addIconFamily(handler), iconData(handler), 
+iconFamilies(handler), iconList(handler), iconNames(handler)
 */
 public handler getCurrentIconFamily() returns String
 	return sCurrentFamily
@@ -1840,7 +1892,8 @@ Description:
 Sets the iconsvg library's current icon family.  Handlers that do not specify
 an icon family will use the current icon family.
 
-References: iconData(handler), iconList(handler), iconNames(handler)
+References: addIconFamily(handler), iconData(handler), 
+iconFamilies(handler), iconList(handler), iconNames(handler)
 */
 public handler setCurrentIconFamily(in pFamily as String) returns nothing
 	if pFamily is not among the keys of sFontArray then
@@ -1848,6 +1901,31 @@ public handler setCurrentIconFamily(in pFamily as String) returns nothing
 	end if
 	
 	put pFamily into sCurrentFamily
+end handler
+
+/**
+Summary: Delete an icon family from the iconsvg library.
+
+pFamily: The family to delete.
+
+Description:
+Delete an icon family from the iconsvg library.
+
+> Note:  The current icon family may not be deleted.
+
+References: addIconFamily(handler), iconFamilies(handler), 
+iconListForFamily(handler), iconNamesForFamily(handler)
+*/
+public handler deleteIconFamily(in pFamily as String) returns nothing
+	if pFamily is not among the keys of sFontArray then
+		throw "Icon family '" & pFamily & "' does not exist."
+	end if
+	if pFamily is sCurrentFamily then
+		throw "Cannot delete the current icon family:  '" & pFamily & "'."
+	end if
+
+	delete sFontArray[pFamily]
+	delete sNamesArray[pFamily]
 end handler
 
 end library

--- a/extensions/libraries/iconsvg/notes/feature-addicon.md
+++ b/extensions/libraries/iconsvg/notes/feature-addicon.md
@@ -1,0 +1,15 @@
+# Add icon
+
+* Icons can be added individually.  The default family is "custom".  Added icons
+  can specify the family in the name using the form "family/name".
+
+* Multiple icons can be added using an array (same format that `iconData()` returns).
+  The family must be specified.
+
+New handlers:
+* `iconFamilies()` - returns a list of current icon families in the library
+* `iconNamesForFamily()` - returns a string list of icon names for a specified family
+* `iconListForFamily()` - returns a LCB list of icon names for a specified family
+* `iconDataForFamily()` - returns LCB array of icon data for a specified family
+* `addIcon()` - add an icon to the iconsvg library
+* `addIconsForFamily()` - add a family of icons to the iconsvg library

--- a/extensions/libraries/iconsvg/notes/feature-addicon.md
+++ b/extensions/libraries/iconsvg/notes/feature-addicon.md
@@ -1,10 +1,13 @@
-# Add icon
+# Add icon / Set current family
 
 * Icons can be added individually.  The default family is "custom".  Added icons
   can specify the family in the name using the form "family/name".
 
 * Multiple icons can be added using an array (same format that `iconData()` returns).
   The family must be specified.
+
+* The current icon family can now be set.  This allows existing tools in the IDE to
+  show icons from any loaded family.
 
 New handlers:
 * `iconFamilies()` - returns a list of current icon families in the library
@@ -13,3 +16,7 @@ New handlers:
 * `iconDataForFamily()` - returns LCB array of icon data for a specified family
 * `addIcon()` - add an icon to the iconsvg library
 * `addIconsForFamily()` - add a family of icons to the iconsvg library
+* `getCurrentIconFamily()` - get the family used as default (i.e. for iconPicker)
+* `setCurrentIconFamily()` - set the family to be used as default (i.e. for iconPicker)
+* `deleteIconFamily()` - remove a family from the library
+* `iconArrayMatchingInAllFamilies()` - search for icon matches among all families


### PR DESCRIPTION
- convert several space indents to tab

Fixed/added docs:
- iconListMatching() - return LCB list of icon names that match a search string
- iconData() - return LCB array of default family icon data

Added the following handlers:
- iconFamilies() - returns a list of current icon families in the library
- iconNamesForFamily() - returns a string list of icon names for a specified family
- iconListForFamily() - returns a LCB list of icon names for a specified family
- iconDataForFamily() - returns LCB array of icon data for a specified family
- addIcon() - add an icon to the iconsvg library
- addIconsForFamily() - add a family of icons to the iconsvg library
- getCurrentIconFamily() - get the family used as default (i.e. for iconPicker)
- setCurrentIconFamily() - set the family to be used as default (i.e. for iconPicker)
- deleteIconFamily() - remove a family from the library
- iconArrayMatchingInAllFamilies() - search for icon matches among all families