### PR TITLE
[[ Bug 20811 ]] Make 'encoding' analyse the specified range of text

### DIFF
--- a/docs/notes/bugfix-20811.md
+++ b/docs/notes/bugfix-20811.md
@@ -1,0 +1,10 @@
+# Make the encoding property of field char chunks more useful
+
+The 'encoding' char-level field property will now return native
+if all chars in the chunk can be encoded in the native encoding,
+and unicode otherwise.
+
+This means that the property will now return the identical value
+as it did in 6.7 and before, assuming that the field text hadn't
+had its encoding changed by script (via the textFont ',unicode'
+flag).

--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -1786,16 +1786,23 @@ void MCField::SetVisitedOfCharChunk(MCExecContext& ctxt, uint32_t p_part_id, int
     SetCharPropOfCharChunk< PodFieldPropType<bool> >(ctxt, this, false, p_part_id, si, ei, &MCBlock::SetVisited,p_value);
 }
 
-void MCField::GetEncodingOfCharChunk(MCExecContext& ctxt, uint32_t p_part_id, int32_t si, int32_t ei, intenum_t &r_encoding)
+void MCField::GetEncodingOfCharChunk(MCExecContext& ctxt, uint32_t p_part_id, int32_t p_start, int32_t p_finish, intenum_t& r_encoding)
 {
-    intenum_t t_encoding;
-    bool t_mixed;
-    GetParagraphPropOfCharChunk< PodFieldPropType<intenum_t> >(ctxt, this, p_part_id, si, ei, &MCParagraph::GetEncoding, t_mixed, t_encoding);
-
-    if (!t_mixed)
-        r_encoding = t_encoding;
+    MCAutoStringRef t_value;
+    if (!exportastext(p_part_id, p_start, p_finish, &t_value))
+    {
+        ctxt.Throw();
+        return;
+    }
+     
+    if (MCStringCanBeNative(*t_value))
+    {
+        r_encoding = 0;
+    }
     else
-        r_encoding = 2;
+    {
+        r_encoding = 1;
+    }
 }
 
 void MCField::GetFlaggedOfCharChunk(MCExecContext& ctxt, uint32_t p_part_id, int32_t si, int32_t ei, bool& r_mixed, bool& r_value)

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -1168,7 +1168,6 @@ MCExecEnumTypeElementInfo _kMCInterfaceEncodingElementInfo[] =
 {
 	{ MCnativestring, 0, true },
 	{ MCunicodestring, 1, true },
-	{ MCmixedstring, 2, true },
 };
 
 MCExecEnumTypeInfo _kMCInterfaceEncodingTypeInfo =

--- a/tests/lcs/core/field/encoding.livecodescript
+++ b/tests/lcs/core/field/encoding.livecodescript
@@ -1,0 +1,35 @@
+script "CoreFieldEncoding"
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestEncodingOfCharChunk
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   create field "TestField"
+   put "a" & numToCodepoint(0x1d11e) into field "TestField"
+
+   TestAssert "encoding of native field chunk is 'native'", \
+      the encoding of char 1 to 1 of field "TestField" is "native"
+
+   TestAssert "encoding of non-native field chunk is 'unicode'", \
+      the encoding of char 2 to 2 of field "TestField" is "unicode"
+
+   TestAssert "encoding of mixed field chunk is 'unicode'", \
+      the encoding of char 1 to 2 of field "TestField" is "unicode"
+      
+end TestEncodingOfCharChunk


### PR DESCRIPTION
The encoding char-level field property now uses MCStringCanBeNative
to determine if a range of text has the 'native' encoding, or is
'unicode' encoding. This gives it parity to the property in 6.7 and
before.