### PR TITLE
Changes from formattedHeight to getResource

### DIFF
--- a/docs/dictionary/command/get.lcdoc
+++ b/docs/dictionary/command/get.lcdoc
@@ -17,7 +17,7 @@ Example:
 get the colors of button 1
 
 Example:
-get 2 * 25 * pi -- gets area of circle with radius 25
+get 2 * 25 * pi -- gets circumference of circle with radius 25
 
 Example:
 get message -- evaluates expression in message box

--- a/docs/dictionary/control_st/getProp.lcdoc
+++ b/docs/dictionary/control_st/getProp.lcdoc
@@ -101,12 +101,10 @@ For example, the following <getProp> <handler> implements a virtual
 <property> of a <field> that contains a list of numbers:
 
     getProp columnAverage
-    repeat for each line thisNumber of me
-
-    add thisNumber to fieldTotal
-    end repeat
-    return fieldTotal/the number of lines of me
-
+        repeat for each line thisNumber of me
+            add thisNumber to fieldTotal
+        end repeat
+        return fieldTotal/the number of lines of me
     end columnAverage
 
 

--- a/docs/dictionary/function/getResource.lcdoc
+++ b/docs/dictionary/function/getResource.lcdoc
@@ -45,7 +45,7 @@ If the <filePath> does not exist, the <result> is set to
 <resource fork>, the <result> is set to "can't open resource fork". If
 the filePath contains a <resource fork> but does not contain the
 specified resource, the result is set to
-"can't find specified resource<a/>". 
+"can't find specified resource". 
 
 Description:
 Use the <getResource> <function> to get the contents of a resource.

--- a/docs/dictionary/keyword/fourth.lcdoc
+++ b/docs/dictionary/keyword/fourth.lcdoc
@@ -20,8 +20,8 @@ Example:
 put empty into the fourth char of thisName
 
 Description:
-Use the <fourth> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <fourth> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <fourth> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 4. It can also be used to designate the

--- a/docs/dictionary/keyword/from.lcdoc
+++ b/docs/dictionary/keyword/from.lcdoc
@@ -30,9 +30,9 @@ Description:
 Use the <from> <keyword> to complete a <command> that requires it.
 
 The <from> <keyword> is used with the <convert>, <drag>, <import>,
-<import snapshot>, <move>, print card, <read from file>, <read from
-process>, <read from socket>, <remove>, <remove script>, <request>, and
-<subtract> <command|commands>.
+<import snapshot>, <move>, print card, <read from file>, 
+<read from process>, <read from socket>, <remove>, <remove script>, 
+<request>, and <subtract> <command|commands>.
 
 References: read from file (command), import snapshot (command),
 convert (command), move (command), remove script (command),

--- a/docs/dictionary/keyword/ftp.lcdoc
+++ b/docs/dictionary/keyword/ftp.lcdoc
@@ -35,25 +35,26 @@ If an error occurs during transfer of the data, the error is placed in
 the result <function>. The first <word> returned by the <result>
 <function> is "error", followed (where appropriate) by the text of the
 error message returned by the FTP <server>, including the server
-response code. >*Important:* If a <blocking> operation involving a <URL>
-(using the <put> <command> to <upload> a <URL>, the <post> <command>,
-the <delete URL> <command>, or a <statement> that gets an <ftp> or
-<http> <URL>) is going on, no other <blocking> <URL> operation can start
-until the previous one is finished. If you attempt to use a <URL> in an
-<expression>, or put data into a <URL>, while another <blocking> <URL>
-operation is in progress, the <result> is set to
-"Error Previous request not completed". Downloading a URL does not
-prevent other messages from being sent during the download: the current
-handler is blocked during the download, but other handlers are not. This
-means that if, for example, your application has a button that downloads
-a URL, the user might click the button again (or click another <button>
-that <download|downloads> another <URL>) while the first <URL> is still
-being <download|downloaded>. In this case, the second <download> is not
-performed and the <result> is set to
-"Error Previous request not completed." To avoid this problem, you can
-set a <flag> while a URL is being <download|downloaded>, and check that
-<flag> when trying to <download> <URL|URLs> to make sure that there is
-not already a current <download> in progress.
+response code. 
+> *Important:* If a <blocking> operation involving a <URL>
+> (using the <put> <command> to <upload> a <URL>, the <post> <command>,
+> the <delete URL> <command>, or a <statement> that gets an <ftp> or
+> <http> <URL>) is going on, no other <blocking> <URL> operation can start
+> until the previous one is finished. If you attempt to use a <URL> in an
+> <expression>, or put data into a <URL>, while another <blocking> <URL>
+> operation is in progress, the <result> is set to
+> "Error Previous request not completed". Downloading a URL does not
+> prevent other messages from being sent during the download: the current
+> handler is blocked during the download, but other handlers are not. This
+> means that if, for example, your application has a button that downloads
+> a URL, the user might click the button again (or click another <button>
+> that <download|downloads> another <URL>) while the first <URL> is still
+> being <download|downloaded>. In this case, the second <download> is not
+> performed and the <result> is set to
+> "Error Previous request not completed." To avoid this problem, you can
+> set a <flag> while a URL is being <download|downloaded>, and check that
+> <flag> when trying to <download> <URL|URLs> to make sure that there is
+> not already a current <download> in progress.
 
 Description:
 Use the <ftp> <keyword> to upload or download <files> to or from an
@@ -62,13 +63,13 @@ Internet site.
 The URL scheme "ftp" indicates information located on an FTP server. An
 <ftp> <URL> consists of the following parts:
 
-        1. The string "ftp://"
-        2. An optional user name and password, separated by a colon (:)
-           and followed by "@"
-        3. The name of the server
-        4. An optional port number preceded by a colon (:)
-        5. The name and location of a file or directory, starting with a
-           slash (/)
+1. The string "ftp://"
+2. An optional user name and password, separated by a colon (:)
+   and followed by "@"
+3. The name of the server
+4. An optional port number preceded by a colon (:)
+5. The name and location of a file or directory, starting with a
+   slash (/)
 
 
 If you don't specify a port number, port 21 is used. (This is the
@@ -90,24 +91,25 @@ standard port for FTP.)
     put "jim" into userName
     put "jsmith@example.org" into userPassword
     put "ftp://" & userName & ":" & URLEncode(userPassword) \
-
-    & "@ftp.example.com/title.txt" into fileURLToGet
-
+      & "@ftp.example.com/title.txt" into fileURLToGet
     get URL fileURLToGet
 
 
 Here are some examples of valid <ftp> <URL|URLs>:
-ftp://ftp.example.org/directory/ -- list of files and folders in a
-directory ftp://ftp.example.org/directory/file.exe -- a file on the
-server ftp://user:password@ftp.example.org/myfile -- a file accessed by
-a password ftp://ftp.example.com:3992/somefile -- using a nonstandard
+- ftp://ftp.example.org/directory/ -- list of files and folders in a
+directory 
+- ftp://ftp.example.org/directory/file.exe -- a file on the
+server 
+- ftp://user:password@ftp.example.org/myfile -- a file accessed by
+a password 
+- ftp://ftp.example.com:3992/somefile -- using a nonstandard
 FTP port
 
-An <ftp> <URL> is a <container>, and you can use the <expression> URL
-ftpURL in any statement where any other <container> type is used. When
-you get the <value> of an <ftp> <URL>, LiveCode <download|downloads> the
-<URL> from the <server>. (If you have previously <cache|cached> the URL
-with the <load> <command>, it fetches the <URL> from the <cache>.)
+An <ftp> <URL> is a <container>, and you can use the <expression> 
+`URL ftpURL` in any statement where any other <container> type is used. 
+When you get the <value> of an <ftp> <URL>, LiveCode <download|downloads> 
+the <URL> from the <server>. (If you have previously <cache|cached> the 
+URL with the <load> <command>, it fetches the <URL> from the <cache>.)
 
 A URL that ends with a slash (/) designates a directory (rather than a
 file). An <ftp> <URL> to a <folder|directory> evaluates to a listing of
@@ -135,17 +137,14 @@ concludes. If the user clicks the button again while the download is
 still going on, the handler simply beeps:
 
     on mouseUp
-
-    global downloadInProgress
-    if downloadInProgress then
-
-    beep
-    exit mouseUp
-
-    end if
-    put true into downloadInProgress -- about to start
-    put URL (field "FTP URL to get") into field "Command Result"
-    put false into downloadInProgress -- finished
+        global downloadInProgress
+        if downloadInProgress then
+           beep
+           exit mouseUp
+        end if
+        put true into downloadInProgress -- about to start
+        put URL (field "FTP URL to get") into field "Command Result"
+        put false into downloadInProgress -- finished
     end mouseUp
 
 
@@ -189,8 +188,7 @@ container (glossary), URL (glossary), server (glossary),
 keyword (glossary), application (glossary), handler (glossary),
 word (glossary), expression (glossary), download (glossary),
 URL (keyword), file (keyword), ftp (keyword), button (keyword),
-http (keyword), library (library), delete URL (library),
-libURLSetFTPListCommand (library), Internet library (library),
+http (keyword), library (library), Internet library (library),
 startup (message), openBackground (message), preOpenStack (message),
 openStack (message), preOpenCard (message)
 

--- a/docs/dictionary/property/formattedHeight.lcdoc
+++ b/docs/dictionary/property/formattedHeight.lcdoc
@@ -44,8 +44,8 @@ If you specify an image or player, the <formattedHeight> <property>
 reports the original un-scaled height of the <image> or movie.
 
 If you specify an object in a group, the value reported is the
-<formattedHeight> that <object(glossary)> requires for the <current
-card>, so if you want to get the <formattedHeight> of a
+<formattedHeight> that <object(glossary)> requires for the 
+<current card>, so if you want to get the <formattedHeight> of a
 <field(object)|field's> text on a certain <card>, you must go to that
 <card> first.
 

--- a/docs/dictionary/property/formattedRect.lcdoc
+++ b/docs/dictionary/property/formattedRect.lcdoc
@@ -32,12 +32,15 @@ Use the <formattedRect> <property> to find the boundary of a <group> or
 If you specify a card or group, the <formattedRect> reports the smallest
 rectangle that encloses all the <object(glossary)> in that <group> or
 <card>. (<object|Objects> whose <visible> <property> is false are
-ignored.) The four <items> in the rectangle are: 1:horizontal distance
-from the left edge of the stack to the left edge of the rectangle
-2:vertical distance from the top edge of the stack to the top edge of
-the rectangle 3:horizontal distance from the left edge of the stack to
-the right edge of the rectangle 4:vertical distance from the top edge of
-the stack to the bottom edge of the rectangle
+ignored.) The four <items> in the rectangle are: 
+1. horizontal distance from the left edge of the stack to the left 
+edge of the rectangle
+2. vertical distance from the top edge of the stack to the top edge of
+the rectangle 
+3. horizontal distance from the left edge of the stack to the right edge 
+of the rectangle 
+4. vertical distance from the top edge of the stack to the bottom edge 
+of the rectangle
 
 The <formattedRect> of a <chunk> in a <field> is the smallest rectangle
 that encloses the entire <chunk>.

--- a/docs/dictionary/property/formattedWidth.lcdoc
+++ b/docs/dictionary/property/formattedWidth.lcdoc
@@ -45,8 +45,8 @@ false, the <formattedWidth> reports the minimum width required to keep
 the current line breaks.
 
 If you specify an object in a group, the value reported is the
-<formattedWidth> that <object(glossary)> requires for the <current
-card>, so if you want to get the <formattedWidth> of a
+<formattedWidth> that <object(glossary)> requires for the 
+<current card>, so if you want to get the <formattedWidth> of a
 <field(object)|field's> text on a certain <card>, you must go to that
 <card> first.
 

--- a/docs/dictionary/property/frameCount.lcdoc
+++ b/docs/dictionary/property/frameCount.lcdoc
@@ -23,8 +23,8 @@ The <frameCount> of an <image> is a <non-negative> <integer>.
 This property is read-only and cannot be set.
 
 Description:
-Use the <frameCount> <property> to determine the length of a <animated
-GIF|GIF animation>.
+Use the <frameCount> <property> to determine the length of a 
+<animated GIF|GIF animation>.
 
 If the image is not an animated GIF, its <frameCount> is zero.
 

--- a/docs/dictionary/property/frameRate.lcdoc
+++ b/docs/dictionary/property/frameRate.lcdoc
@@ -18,8 +18,8 @@ set the frameRate of videoClip 1 to 100
 
 Value:
 The <frameRate> of a <video clip> is a <non-negative> <integer>.
-By default, the <frameRate> <property> of newly created <video
-clip|video clips> is set to zero.
+By default, the <frameRate> <property> of newly created 
+<video clip|video clips> is set to zero.
 
 Description:
 Use the <frameRate> <property> to speed up or slow down a movie.


### PR DESCRIPTION
property/formattedHeight.lcdoc - Fixed broken link.
property/formattedRect.lcdoc - Formatted ordered list.
property/formattedWidth.lcdoc - Fixed broken link.
keyword/fourth.lcdoc - Fixed broken link.
property/frameCount.lcdoc - Fixed broken link.
property/frameRate.lcdoc - Fixed broken link.
keyword/from.lcdoc - Fixed broken link.
keyword/ftp.lcdoc - Formatting. Removed non-existent entries.
command/get.lcdoc - Correction on what 2πr calculates.
control_st/getProp.lcdoc - Formatting.
function/getResource.lcdoc - Removed unnecessary HTML.
