### PR TITLE
[[ SVG ]] Revision 3

### DIFF
--- a/engine/src/graphicscontext.cpp
+++ b/engine/src/graphicscontext.cpp
@@ -1232,10 +1232,6 @@ void MCGraphicsContext::fillpath(MCPath *path, bool p_evenodd)
 
 void MCGraphicsContext::drawpict(uint1 *data, uint4 length, bool embed, const MCRectangle& drect, const MCRectangle& crect)
 {
-    MCGContextSave(m_gcontext);
-    MCGContextClipToRect(m_gcontext, MCRectangleToMCGRectangle(crect));
-    MCGContextPlayback(m_gcontext, MCRectangleToMCGRectangle(drect), MCMakeSpan(static_cast<const byte_t*>(data), length));
-    MCGContextRestore(m_gcontext);
 }
 
 void MCGraphicsContext::draweps(real8 sx, real8 sy, int2 angle, real8 xscale, real8 yscale, int2 tx, int2 ty,

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -518,7 +518,7 @@ public:
 	// in idraw.cc
 	void drawme(MCDC *dc, int2 sx, int2 sy, uint2 sw, uint2 sh, int2 dx, int2 dy, uint2 dw, uint2 dh);
 	void drawcentered(MCDC *dc, int2 x, int2 y, Boolean reverse);
-    void drawnodata(MCDC *dc, MCRectangle drect, uint2 sw, uint2 sh, int2 dx, int2 dy, uint2 dw, uint2 dh);
+    void drawnodata(MCDC *dc, uint2 sw, uint2 sh, int2 dx, int2 dy, uint2 dw, uint2 dh);
 
     void drawwithgravity(MCDC *dc, MCRectangle rect, MCGravity gravity);
 

--- a/engine/src/image_rep.h
+++ b/engine/src/image_rep.h
@@ -301,15 +301,13 @@ public:
 	uint32_t GetDataCompression();
 
 	uindex_t GetFrameCount() { return 1; }
-
+    
 	//////////
 
 	void GetData(void *&r_data, uindex_t &r_size)
 	{
 		r_data = m_data, r_size = m_size;
 	}
-
-	bool Render(MCDC *p_context, bool p_embed, MCRectangle &p_image_rect, MCRectangle &p_clip_rect);
 
 protected:
 	bool LoadImageFrames(MCBitmapFrame *&r_frames, uindex_t &r_frame_count, bool &r_frames_premultiplied);
@@ -464,7 +462,7 @@ bool MCImageRepCreateReferencedWithSearchKey(MCStringRef p_filename, MCStringRef
 
 bool MCImageRepGetReferenced(MCStringRef p_filename, MCImageRep *&r_rep);
 bool MCImageRepGetResident(const void *p_data, uindex_t p_size, MCImageRep *&r_rep);
-bool MCImageRepGetVector(void *p_data, uindex_t p_size, MCImageRep *&r_rep);
+bool MCImageRepGetVector(const void *p_data, uindex_t p_size, MCImageRep *&r_rep);
 bool MCImageRepGetCompressed(MCImageCompressedBitmap *p_compressed, MCImageRep *&r_rep);
 bool MCImageRepGetDensityMapped(MCStringRef p_filename, MCImageRep *&r_rep);
 

--- a/engine/src/image_rep_encoded.cpp
+++ b/engine/src/image_rep_encoded.cpp
@@ -273,12 +273,6 @@ MCVectorImageRep::~MCVectorImageRep()
 	MCMemoryDeallocate(m_data);
 }
 
-bool MCVectorImageRep::Render(MCDC *p_context, bool p_embed, MCRectangle &p_image_rect, MCRectangle &p_clip_rect)
-{
-	p_context->drawpict((uint8_t*)m_data, m_size, p_embed, p_image_rect, p_clip_rect);
-	return true;
-}
-
 bool MCVectorImageRep::LoadImageFrames(MCBitmapFrame *&r_frames, uindex_t &r_frame_count, bool &r_frames_premultiplied)
 {
 	/* OVERHAUL - REVISIT - should be able to render into an image context

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -5795,23 +5795,7 @@ void MCCanvasDrawRectOfImage(MCCanvasRef p_canvas, MCCanvasImageRef p_image, con
 	
 	MCCanvasApplyChanges(*t_canvas);
 
-	MCGImageFrame t_frame;
-	
-	MCGFloat t_scale;
-	t_scale = MCGAffineTransformGetEffectiveScale(MCGContextGetDeviceTransform(t_canvas->context));
-	
-	if (MCImageRepLock(t_image, 0, t_scale, t_frame))
-	{
-		MCGAffineTransform t_transform;
-		t_transform = MCGAffineTransformMakeScale(1.0 / t_frame.x_scale, 1.0 / t_frame.y_scale);
-		
-		MCGRectangle t_src_rect;
-		t_src_rect = MCGRectangleScale(p_src_rect, t_frame.x_scale, t_frame.y_scale);
-		
-		MCGContextDrawRectOfImage(t_canvas->context, t_frame.image, t_src_rect, p_dst_rect, t_canvas->props().image_filter);
-		
-		MCImageRepUnlock(t_image, 0, t_frame);
-	}
+    MCImageRepRender(t_image, t_canvas->context, 0, p_src_rect, p_dst_rect, t_canvas->props().image_filter);
 }
 
 MC_DLLEXPORT_DEF

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -64,6 +64,8 @@ void MCImageRepUnlock(MCImageRep *p_image_rep, uint32_t p_index, MCGImageFrame &
 bool MCImageRepLockRaster(MCImageRep *p_image_rep, uint32_t p_index, MCGFloat p_density, MCImageBitmap *&r_raster);
 void MCImageRepUnlockRaster(MCImageRep *p_image_rep, uint32_t p_index, MCImageBitmap *p_raster);
 
+void MCImageRepRender(MCImageRep *p_image_rep, MCGContextRef p_gcontext, uint32_t p_index, MCGRectangle p_src_rect, MCGRectangle p_dst_rect, MCGImageFilter p_filter);
+
 //////////
 
 bool MCImageRepGetTransformed(MCImageRep *p_image_rep, const MCGAffineTransform &p_transform, const MCGSize *p_output_size, MCGImageFilter p_resize_quality, MCImageRep *&r_transformed);

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -616,12 +616,62 @@ end _svgCascade
  ******************************************************************************/
 
 private command _svgCompile @xContext, pRootElement
-	put pRootElement["features"]["width"] into xContext["drawing-width"]
-	put pRootElement["features"]["height"] into xContext["drawing-height"]
-	put pRootElement["features"]["viewBox"] into xContext["drawing-viewbox"]
-	put pRootElement["features"]["preserveAspectRatio"] into xContext["drawing-par"]
-	delete variable pRootElement["features"]["viewBox"]
-	delete variable pRootElement["features"]["preserveAspectRatio"]
+	/* If the root element is an 'svg' then there's not much we can do! */
+	if pRootElement["type"] is not "svg" then
+		throw "root element is not svg"
+	end if
+
+	/* Unpack the root element's attributes. */
+	local tWidth, tHeight, tViewBox, tPar
+	put pRootElement["features"]["width"] into tWidth
+	put pRootElement["features"]["height"] into tHeight
+	put pRootElement["features"]["viewBox"] into tViewBox
+	put pRootElement["features"]["preserveAspectRatio"] into tPar
+
+	/* At this point we might find:
+	 *   1) Absolute width/height
+	 *   2) Percent width/height
+	 *   3) A viewBox
+	 *
+	 * We need an absolute width/height to present as size of the drawing. This
+	 * is used to determine how things can scale, and the 'natural' mapping to
+	 * pixels.
+	 *
+	 * If the width/height are relative (they default to 100% if not specified)
+	 * then they are taken as percentage sizes of the viewBox width/height.
+	 *
+	 * If there is no viewBox in that case, then the viewBox is taken to be
+	 * the point bbox of all non-relatively specified elements, or a fixed size
+	 * of 256 if that bbox is empty.
+	 */
+
+	/* If we have a viewBox, then all is straight-forward. We use that to
+	 * generate absolute width/height. Otherwise, if the width/height are relative
+	 * we must do bbox computations. */
+	if tViewBox is an array then
+		if tWidth < 0 then
+			put -tWidth * tViewBox[3] into tWidth
+		end if
+
+		if tHeight < 0 then
+			put -tHeight * tViewBox[4] into tHeight
+		end if
+	else if tWidth < 0 or tHeight < 0 then
+		throw "relative width/height with no viewBox not supported yet"
+	end if
+
+	/* At this point we have an absolute width/height, so update the features
+	 * of the root element. */
+	put tWidth into pRootElement["features"]["width"]
+	put tHeight into pRootElement["features"]["height"]
+
+	/* Set the initial root-width/height. */
+	put tWidth into xContext["root-width"]
+	put tHeight into xContext["root-height"]
+
+	/* Set the drawing size */
+	put tWidth into xContext["drawing-width"]
+	put tHeight into xContext["drawing-height"]
 
 	_svgCompileElement xContext, pRootElement
 end _svgCompile
@@ -723,81 +773,12 @@ private command _svgCompileFeatures @xContext, pElement
 end _svgCompileFeatures
 
 private command _svgCompileTransform @xContext, pTransform, pBBox, @rCompiledTransform
-	local tWidth, tHeight, tMatrix
-	put xContext["root-width"] into tWidth
-	put xContext["root-height"] into tHeight
+	local tMatrix
 	put _svgTransformIdentity() into tMatrix
 
 	repeat for each element tTransform in pTransform
 		local tNextMatrix
 		switch tTransform[1]
-		case "viewport"
-			local tVpWidth, tVpHeight, tVpX, tVpY, tVbWidth, tVbHeight, tVbX, tVbY, tPar
-			put tTransform[2] into tVpX
-			put tTransform[3] into tVpY
-			put tTransform[4] into tVpWidth
-			put tTransform[5] into tVpHeight
-			put tTransform[6] into tVbX
-			put tTransform[7] into tVbY
-			put tTransform[8] into tVbWidth
-			put tTransform[9] into tVbHeight
-			put tTransform[10] into tPar
-
-			/* Resolve percentage sizes */
-			if tVpWidth < 0 then
-				put -tVpWidth * tWidth into tVpWidth
-			end if
-			if tVpHeight < 0 then
-				put -tVpHeight * tHeight into tVpHeight
-			end if
-
-			/* If the new vp sizes are not percentages then we can build a matrix
-			 * else we must emit a separate transform */
-			if tVpWidth >= 0 and tVpHeight >= 0 then
-				local tVScaleX, tVScaleY, tVTranslateX, tVTranslateY
-
-				put tVpWidth / tVbWidth into tVScaleX
-				put tVpHeight / tVbHeight into tVScaleY
-
-				if word 2 of tPar is "meet" then
-					put min(tVScaleX, tVScaleY) into tVScaleX
-					put tVScaleX into tVScaleY
-				else if word 2 of tPar is "slice" then
-					put max(tVScaleX, tVScaleY) into tVScaleX
-					put tVScaleX into tVScaleY
-				end if
-
-				put tVpX - (tVbX * tVScaleX) into tVTranslateX
-				put tVpY - (tVbY * tVScaleY) into tVTranslateY
-
-				if tPar contains "xMid" then
-					add (tVpWidth - tVbWidth * tVScaleX) / 2 to tVTranslateX
-				else if tPar contains "xMax" then
-					add (tVpWidth - tVbWidth * tVScaleX) to tVTranslateX
-				end if
-
-				if tPar contains "yMid" then
-					add (tVpHeight - tVbHeight * tVScaleY) / 2 to tVTranslateY
-				else if tPar contains "yMax" then
-					add (tVpHeight - tVbHeight * tVScaleY) to tVTranslateY
-				end if
-				
-				put _svgTransformTranslate(tVTranslateX, tVTranslateY) into tNextMatrix
-				put _svgTransformConcat(tNextMatrix, _svgTransformScale(tVScaleX, tVScaleY)) into tNextMatrix
-			else
-				if not _svgTransformIsIdentity(tMatrix) then
-					seqPushOntoBack rCompiledTransform, _svgTransformFlatten(tMatrix)
-				end if
-				put tVpWidth into tTransform[4]
-				put tVpHeight into tTransform[5]
-				seqPushOntoBack rCompiledTransform, tTransform
-				put _svgTransformIdentity() into tMatrix
-				put _svgTransformIdentity() into tNextMatrix
-			end if
-
-			put tVpWidth into tWidth
-			put tVpHeight into tHeight
-			break
 		case "matrix"
 			put _svgTransformMatrix(tTransform[2], tTransform[3], tTransform[4], tTransform[5], tTransform[6], tTransform[7]) into tNextMatrix
 			break
@@ -1040,35 +1021,72 @@ private command _svgCompileSvg @xContext, pElement
 
 	_svgContextSave xContext
 
-	if tViewBox is an array then
-		local tViewportTransform
-		put "viewport" into tViewportTransform[1]
-		put tX into tViewportTransform[2]
-		put tY into tViewportTransform[3]
-		put tWidth into tViewportTransform[4]
-		put tHeight into tViewportTransform[5]
-		put tViewBox[1] into tViewportTransform[6]
-		put tViewBox[2] into tViewportTransform[7]
-		put tViewBox[3] into tViewportTransform[8]
-		put tViewBox[4] into tViewportTransform[9]
-		put tPreserveAspectRatio into tViewportTransform[10]
+	/* The SVG element establishes a new viewport so we must compute that
+	 * transform here. */
+	local tOldWidth, tOldHeight
+	put xContext["root-width"] into tOldWidth
+	put xContext["root-height"] into tOldHeight
 
-		put tWidth into xContext["root-width"]
-		put tHeight into xContext["root-height"]
-
-		local tTransform, tCompiledTransform
-		put _svgContextGetState(xContext, "transform") into tTransform
-		seqPushOntoBack tTransform, tViewportTransform
-		_svgCompileTransform xContext, tTransform, empty, tCompiledTransform
-		_svgContextSetState xContext, "transform", tCompiledTransform
-	else
-		put tWidth into xContext["root-width"]
-		put tHeight into xContext["root-height"]
+	/* If the new width/height are relative, resolve them. */
+	if tWidth < 0 then
+		put tWidth * tOldWidth into tWidth
 	end if
+	if tHeight < 0 then
+		put tHeight * tOldHeight into tHeight
+	end if
+
+	/* If there is a viewBox, then we must compute the viewBox transform. */
+	if tViewBox is an array then
+		local tVScaleX, tVScaleY, tVTranslateX, tVTranslateY
+
+		put tWidth / tViewBox[3] into tVScaleX
+		put tHeight / tViewBox[4] into tVScaleY
+
+		if word 2 of tPreserveAspectRatio is "meet" then
+			put min(tVScaleX, tVScaleY) into tVScaleX
+			put tVScaleX into tVScaleY
+		else if word 2 of tPreserveAspectRatio is "slice" then
+			put max(tVScaleX, tVScaleY) into tVScaleX
+			put tVScaleX into tVScaleY
+		end if
+
+		put tX - (tViewBox[1] * tVScaleX) into tVTranslateX
+		put tY - (tViewBox[2] * tVScaleY) into tVTranslateY
+
+		if tPreserveAspectRatio contains "xMid" then
+			add (tWidth - tViewBox[3] * tVScaleX) / 2 to tVTranslateX
+		else if tPreserveAspectRatio contains "xMax" then
+			add (tWidth - tViewBox[3] * tVScaleX) to tVTranslateX
+		end if
+
+		if tPreserveAspectRatio contains "yMid" then
+			add (tHeight - tViewBox[4] * tVScaleY) / 2 to tVTranslateY
+		else if tPreserveAspectRatio contains "yMax" then
+			add (tHeight - tViewBox[4] * tVScaleY) to tVTranslateY
+		end if
+		
+		local tViewportMatrix
+		put _svgTransformTranslate(tVTranslateX, tVTranslateY) into tViewportMatrix
+		put _svgTransformConcat(tViewportMatrix, _svgTransformScale(tVScaleX, tVScaleY)) into tViewportMatrix
+
+		local tTransform
+		put _svgContextGetState(xContext, "transform") into tTransform
+		seqPushOntoBack tTransform, _svgTransformFlatten(tViewportMatrix)
+		_svgCompileTransform xContext, tTransform, empty, tTransform
+		_svgContextSetState xContext, "transform", tTransform
+	end if
+
+	/* Update the root width/height */
+	put tWidth into xContext["root-width"]
+	put tHeight into xContext["root-height"]
 
 	repeat for each element tChildElement in pElement["content"]
 		_svgCompileElement xContext, tChildElement
 	end repeat
+
+	/* Restore the old root width/height */
+	put tOldWidth into xContext["root-width"]
+	put tOldHeight into xContext["root-height"]
 
 	_svgContextRestore xContext
 end _svgCompileSvg
@@ -1331,26 +1349,6 @@ constant kMCGDrawingPathOpcodeReverseReflexArcTo = 23
 constant kMCGDrawingPathOpcodeRelativeReverseReflexArcTo = 24
 constant kMCGDrawingPathOpcodeCloseSubpath = 25
 
-constant kMCGDrawingPreserveAspectRatioOpcodeNone = 0
-constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMinMeet = 1
-constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMinMeet = 2
-constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinMeet = 3
-constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMidMeet = 4
-constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMidMeet = 5
-constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidMeet = 6
-constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxMeet = 7
-constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxMeet = 8
-constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet = 9
-constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMinSlice = 10
-constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMinSlice = 11
-constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinSlice = 12
-constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMidSlice = 13
-constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMidSlice = 14
-constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidSlice = 15
-constant kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxSlice = 16
-constant kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxSlice = 17
-constant kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxSlice = 18
-
 private command _svgEncode @xContext, @rDrawing
 	put empty into xContext["opcodes"]
 	put empty into xContext["scalars"]
@@ -1459,28 +1457,10 @@ private command _svgEncode @xContext, @rDrawing
 
 	local tDrawing
 	put binaryEncode("A3C", kMCGDrawingIdent, kMCGDrawingVersion) into tDrawing
-
-	local tFlags, tExtraScalars, tExtraOpcodes
-	put 0 into tFlags
-	if xContext["drawing-width"] <> -1 then
-		put tFlags bitOr 1 into tFlags
-		put binaryEncode("f", xContext["drawing-width"]) after tExtraScalars
-	end if
-	if xContext["drawing-height"] <> -1 then
-		put tFlags bitOr 2 into tFlags
-		put binaryEncode("f", xContext["drawing-height"]) after tExtraScalars
-	end if
-	if xContext["drawing-viewbox"] is an array then
-		put tFlags bitOr 4 into tFlags
-		put binaryEncode("ffff", xContext["drawing-viewbox"][1], xContext["drawing-viewbox"][2], xContext["drawing-viewbox"][3], xContext["drawing-viewbox"][4]) after tExtraScalars
-		put numToByte(_svgEncodePreserveAspectRatio(xContext["drawing-par"])) after tExtraOpcodes
-	end if
-	put binaryEncode("I", tFlags) after tDrawing
-	put binaryEncode("I", (the number of bytes in tExtraScalars + the number of bytes in xContext["scalars"]) div 4) after tDrawing
-	put tExtraScalars after tDrawing
+	put binaryEncode("ff", xContext["drawing-width"], xContext["drawing-height"]) after tDrawing
+	put binaryEncode("I", (the number of bytes in xContext["scalars"]) div 4) after tDrawing
 	put xContext["scalars"] after tDrawing
-	put binaryEncode("I", the number of bytes in xContext["opcodes"] + the number of bytes in tExtraOpcodes) after tDrawing
-	put tExtraOpcodes after tDrawing
+	put binaryEncode("I", the number of bytes in xContext["opcodes"]) after tDrawing
 	put xContext["opcodes"] after tDrawing
 	put tDrawing into rDrawing
 end _svgEncode
@@ -1575,55 +1555,11 @@ private command _svgEncodePaint @xContext, pPaint
 	_svgEncodeOp xContext, kMCGDrawingPaintOpcodeEnd
 end _svgEncodePaint
 
-private function _svgEncodePreserveAspectRatio pPar
-	local tParOp
-	switch word 1 of pPar
-	case "none"
-		put kMCGDrawingPreserveAspectRatioOpcodeNone into tParOp
-		break
-	case "xMinYMin"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMinYMinMeet into tParOp
-		break
-	case "xMidYMin"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMidYMinMeet into tParOp
-		break
-	case "xMaxYMin"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMaxYMinMeet into tParOp
-		break
-	case "xMinYMid"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMinYMidMeet into tParOp
-		break
-	case "xMidYMid"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMidYMidMeet into tParOp
-		break
-	case "xMaxYMid"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMaxYMidMeet into tParOp
-		break
-	case "xMinYMax"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMinYMaxMeet into tParOp
-		break
-	case "xMidYMax"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMidYMaxMeet into tParOp
-		break
-	case "xMaxYMax"
-		put kMCGDrawingPreserveAspectRatioOpcodeXMaxYMaxMeet into tParOp
-		break
-	end switch
-	if word 2 of pPar is "slice" then
-		put tParOp - kMCGDrawingPreserveAspectRatioOpcodeXMinYMinMeet + \
-						kMCGDrawingPreserveAspectRatioOpcodeXMinYMinSlice into tParOp
-	end if
-	return tParOp
-end _svgEncodePreserveAspectRatio
-
 private command _svgEncodeTransform @xContext, pTransform
 	repeat for each element tTransform in pTransform
 		switch tTransform[1]
 		case "matrix"
 			_svgEncodeOp xContext, kMCGDrawingTransformOpcodeAffine, tTransform[2], tTransform[3], tTransform[4], tTransform[5], tTransform[6], tTransform[7]
-			break
-		case "viewport"
-			_InternalError format("dynamic viewport transform not supported")
 			break
 		default
 			_InternalError format("unknown transform '%s'", tTransform[1])

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -616,7 +616,7 @@ end _svgCascade
  ******************************************************************************/
 
 private command _svgCompile @xContext, pRootElement
-	/* If the root element is an 'svg' then there's not much we can do! */
+	/* If the root element isn't an 'svg' then there's not much we can do! */
 	if pRootElement["type"] is not "svg" then
 		throw "root element is not svg"
 	end if

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -1139,7 +1139,7 @@ private command _svgCompileLine @xContext, pElement
 	put pElement["features"]["y1"] into tY1
 	put pElement["features"]["x2"] into tX2
 	put pElement["features"]["y2"] into tY2
-	_svgCompileShape xContext, "line", __svgBoxLine(tX1, tY1, tX2, tY2), tX1, tY1, tX2, tY2
+	_svgCompileShape xContext, "line", _svgBoxLine(tX1, tY1, tX2, tY2), tX1, tY1, tX2, tY2
 end _svgCompileLine
 
 private command _svgCompilePolyline @xContext, pElement
@@ -1157,6 +1157,7 @@ end _svgCompilePolygon
 private command _svgCompilePath @xContext, pElement
 	local tD
 	put pElement["features"]["d"] into tD
+
 	_svgCompileShape xContext, "path", _svgBoxPath(tD), tD["array"]
 end _svgCompilePath
 
@@ -1291,17 +1292,18 @@ constant kMCGDrawingOpcodeStrokeDashArray = 10
 constant kMCGDrawingOpcodeStrokeDashOffset = 11
 constant kMCGDrawingOpcodeStrokeMiterLimit = 12
 constant kMCGDrawingOpcodeRectangle = 13
-constant kMCGDrawingOpcodeCircle = 14
-constant kMCGDrawingOpcodeEllipse = 15
-constant kMCGDrawingOpcodeLine = 16
-constant kMCGDrawingOpcodePolyline = 17
-constant kMCGDrawingOpcodePolygon = 18
-constant kMCGDrawingOpcodePath = 19
+constant kMCGDrawingOpcodeRoundedRectangle = 14
+constant kMCGDrawingOpcodeCircle = 15
+constant kMCGDrawingOpcodeEllipse = 16
+constant kMCGDrawingOpcodeLine = 17
+constant kMCGDrawingOpcodePolyline = 18
+constant kMCGDrawingOpcodePolygon = 19
+constant kMCGDrawingOpcodePath = 20
 
-constant kMCGDrawingTransformOpcodeEnd = 0
+constant kMCGDrawingTransformOpcodeIdentity = 0
 constant kMCGDrawingTransformOpcodeAffine = 1
 
-constant kMCGDrawingPaintOpcodeEnd = 0
+constant kMCGDrawingPaintOpcodeNone = 0
 constant kMCGDrawingPaintOpcodeSolidColor = 1
 constant kMCGDrawingPaintOpcodeLinearGradient = 2
 constant kMCGDrawingPaintOpcodeRadialGradient = 3
@@ -1324,30 +1326,18 @@ constant kMCGDrawingStrokeLineCapOpcodeSquare = 2
 
 constant kMCGDrawingPathOpcodeEnd = 0
 constant kMCGDrawingPathOpcodeMoveTo = 1
-constant kMCGDrawingPathOpcodeRelativeMoveTo = 2
-constant kMCGDrawingPathOpcodeLineTo = 3
-constant kMCGDrawingPathOpcodeRelativeLineTo = 4
-constant kMCGDrawingPathOpcodeHorizontalTo = 5
-constant kMCGDrawingPathOpcodeRelativeHorizontalTo = 6
-constant kMCGDrawingPathOpcodeVerticalTo = 7
-constant kMCGDrawingPathOpcodeRelativeVerticalTo = 8
-constant kMCGDrawingPathOpcodeCubicTo = 9
-constant kMCGDrawingPathOpcodeRelativeCubicTo = 10
-constant kMCGDrawingPathOpcodeSmoothCubicTo = 11
-constant kMCGDrawingPathOpcodeRelativeSmoothCubicTo = 12
-constant kMCGDrawingPathOpcodeQuadraticTo= 13
-constant kMCGDrawingPathOpcodeRelativeQuadraticTo = 14
-constant kMCGDrawingPathOpcodeSmoothQuadraticTo = 15
-constant kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo = 16
-constant kMCGDrawingPathOpcodeArcTo = 17
-constant kMCGDrawingPathOpcodeRelativeArcTo = 18
-constant kMCGDrawingPathOpcodeReflexArcTo = 19
-constant kMCGDrawingPathOpcodeRelativeReflexArcTo = 20
-constant kMCGDrawingPathOpcodeReverseArcTo = 21
-constant kMCGDrawingPathOpcodeRelativeReverseArcTo = 22
-constant kMCGDrawingPathOpcodeReverseReflexArcTo = 23
-constant kMCGDrawingPathOpcodeRelativeReverseReflexArcTo = 24
-constant kMCGDrawingPathOpcodeCloseSubpath = 25
+constant kMCGDrawingPathOpcodeLineTo = 2
+constant kMCGDrawingPathOpcodeHorizontalTo = 3
+constant kMCGDrawingPathOpcodeVerticalTo = 4
+constant kMCGDrawingPathOpcodeCubicTo = 5
+constant kMCGDrawingPathOpcodeSmoothCubicTo = 6
+constant kMCGDrawingPathOpcodeQuadraticTo= 7
+constant kMCGDrawingPathOpcodeSmoothQuadraticTo = 8
+constant kMCGDrawingPathOpcodeArcTo = 9
+constant kMCGDrawingPathOpcodeReflexArcTo = 10
+constant kMCGDrawingPathOpcodeReverseArcTo = 11
+constant kMCGDrawingPathOpcodeReverseReflexArcTo = 12
+constant kMCGDrawingPathOpcodeCloseSubpath = 13
 
 private command _svgEncode @xContext, @rDrawing
 	put empty into xContext["opcodes"]
@@ -1426,7 +1416,11 @@ private command _svgEncode @xContext, @rDrawing
 			_svgEncodeOp xContext, kMCGDrawingOpcodeStrokeMiterLimit, tArgument
 			break
 		case "rect"
-			_svgEncodeOp xContext, kMCGDrawingOpcodeRectangle, tArgument[1], tArgument[2], tArgument[3], tArgument[4], tArgument[5], tArgument[6]
+			if tArgument[5] is 0 and tArgument[6] is 0 then
+				_svgEncodeOp xContext, kMCGDrawingOpcodeRectangle, tArgument[1], tArgument[2], tArgument[3], tArgument[4]
+			else
+				_svgEncodeOp xContext, kMCGDrawingOpcodeRoundedRectangle, tArgument[1], tArgument[2], tArgument[3], tArgument[4], tArgument[5], tArgument[6]
+			end if
 			break
 		case "circle"
 			_svgEncodeOp xContext, kMCGDrawingOpcodeCircle, tArgument[1], tArgument[2], tArgument[3]
@@ -1521,6 +1515,7 @@ end _svgEncodeScalars
 
 private command _svgEncodePaint @xContext, pPaint
 	if pPaint[1] is "none" then
+		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeNone
 	else if pPaint[1] is "color" then
 		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeSolidColor, pPaint[2], pPaint[3], pPaint[4], pPaint[5]
 	else if pPaint[1] is "linear" or pPaint[1] is "radial" or pPaint[1] is "conical" then
@@ -1552,11 +1547,18 @@ private command _svgEncodePaint @xContext, pPaint
 	else
 		_InternalError format("unknown paint '%s'", pPaint[1])
 	end if
-	_svgEncodeOp xContext, kMCGDrawingPaintOpcodeEnd
 end _svgEncodePaint
 
 private command _svgEncodeTransform @xContext, pTransform
-	repeat for each element tTransform in pTransform
+	if the number of elements in pTransform > 1 then
+		throw "internal error - transform list length is not 1"
+	end if
+
+	if the number of elements in pTransform is 0 then
+		_svgEncodeOp xContext, kMCGDrawingTransformOpcodeIdentity
+	else
+		local tTransform
+		put pTransform[1] into tTransform
 		switch tTransform[1]
 		case "matrix"
 			_svgEncodeOp xContext, kMCGDrawingTransformOpcodeAffine, tTransform[2], tTransform[3], tTransform[4], tTransform[5], tTransform[6], tTransform[7]
@@ -1564,11 +1566,14 @@ private command _svgEncodeTransform @xContext, pTransform
 		default
 			_InternalError format("unknown transform '%s'", tTransform[1])
 		end switch
-	end repeat
-	_svgEncodeOp xContext, kMCGDrawingTransformOpcodeEnd
+	end if
 end _svgEncodeTransform
 
 private command _svgEncodePath @xContext, pPath
+	local tLastX, tLastY
+	put 0 into tLastX
+	put 0 into tLastY
+
 	local tScalarIndex
 	set the caseSensitive to true
 	put 1 into tScalarIndex
@@ -1579,58 +1584,90 @@ private command _svgEncodePath @xContext, pPath
 
 		local tOpcode
 		switch tCommand
+		case "m"
+			add tLastX to tScalars[1]
+			add tLastY to tScalars[2]
 		case "M"
 			put kMCGDrawingPathOpcodeMoveTo into tOpcode
+			put tScalars[1] into tLastX
+			put tScalars[2] into tLastY
 			break
-		case "m"
-			put kMCGDrawingPathOpcodeRelativeMoveTo into tOpcode
-			break
+
 		case "Z"
 		case "z"
 			put kMCGDrawingPathOpcodeCloseSubpath into tOpcode
 			break
+
+		case "l"
+			add tLastX to tScalars[1]
+			add tLastY to tScalars[2]
 		case "L"
 			put kMCGDrawingPathOpcodeLineTo into tOpcode
+			put tScalars[1] into tLastX
+			put tScalars[2] into tLastY
 			break
-		case "l"
-			put kMCGDrawingPathOpcodeRelativeLineTo into tOpcode
-			break
+
+		case "h"
+			add tLastX to tScalars[1]
 		case "H"
 			put kMCGDrawingPathOpcodeHorizontalTo into tOpcode
+			put tScalars[1] into tLastX
 			break
-		case "h"
-			put kMCGDrawingPathOpcodeRelativeHorizontalTo into tOpcode
-			break
+
+		case "v"
+			add tLastY to tScalars[1]
 		case "V"
 			put kMCGDrawingPathOpcodeVerticalTo into tOpcode
+			put tScalars[1] into tLastY
 			break
-		case "v"
-			put kMCGDrawingPathOpcodeRelativeVerticalTo into tOpcode
-			break
+
+		case "c"
+			add tLastX to tScalars[1]
+			add tLastY to tScalars[2]
+			add tLastX to tScalars[3]
+			add tLastY to tScalars[4]
+			add tLastX to tScalars[5]
+			add tLastY to tScalars[6]
 		case "C"
 			put kMCGDrawingPathOpcodeCubicTo into tOpcode
+			put tScalars[5] into tLastX
+			put tScalars[6] into tLastY
 			break
-		case "c"
-			put kMCGDrawingPathOpcodeRelativeCubicTo into tOpcode
-			break
+
+		case "s"
+			add tLastX to tScalars[1]
+			add tLastY to tScalars[2]
+			add tLastX to tScalars[3]
+			add tLastY to tScalars[4]
 		case "S"
 			put kMCGDrawingPathOpcodeSmoothCubicTo into tOpcode
+			put tScalars[3] into tLastX
+			put tScalars[4] into tLastY
 			break
-		case "s"
-			put kMCGDrawingPathOpcodeRelativeSmoothCubicTo into tOpcode
-			break
+
+		case "q"
+			add tLastX to tScalars[1]
+			add tLastY to tScalars[2]
+			add tLastX to tScalars[3]
+			add tLastY to tScalars[4]
 		case "Q"
 			put kMCGDrawingPathOpcodeQuadraticTo into tOpcode
+			put tScalars[3] into tLastX
+			put tScalars[4] into tLastY
 			break
-		case "q"
-			put kMCGDrawingPathOpcodeRelativeQuadraticTo into tOpcode
-			break
+
+		case "t"
+			add tLastX to tScalars[1]
+			add tLastY to tScalars[2]
 		case "T"
 			put kMCGDrawingPathOpcodeSmoothQuadraticTo into tOpcode
+			put tScalars[1] into tLastX
+			put tScalars[2] into tLastY
 			break
-		case "t"
-			put kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo into tOpcode
-			break
+
+		case "a"
+			add tLastX to tScalars[6]
+			add tLastY to tScalars[7]
 		case "A"
 			if tScalars[4] is "0" then
 				if tScalars[5] is "0" then
@@ -1649,25 +1686,8 @@ private command _svgEncodePath @xContext, pPath
 			put tScalars[7] into tScalars[5]
 			delete variable tScalars[6]
 			delete variable tScalars[7]
-			break
-		case "a"
-			if tScalars[4] is "0" then
-				if tScalars[5] is "0" then
-					put kMCGDrawingPathOpcodeRelativeArcTo into tOpcode
-				else
-					put kMCGDrawingPathOpcodeRelativeReverseArcTo into tOpcode
-				end if
-			else
-				if tScalars[5] is "0" then
-					put kMCGDrawingPathOpcodeRelativeReflexArcTo into tOpcode
-				else
-					put kMCGDrawingPathOpcodeRelativeReverseReflexArcTo into tOpcode
-				end if
-			end if
-			put tScalars[6] into tScalars[4]
-			put tScalars[7] into tScalars[5]
-			delete variable tScalars[6]
-			delete variable tScalars[7]
+			put tScalars[4] into tLastX
+			put tScalars[5] into tLastY
 			break
 		end switch
 		_svgEncodeOpV xContext, tOpcode, tScalars

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -1023,7 +1023,7 @@ void MCGContextDrawPlatformText(MCGContextRef context, const unichar_t *text, ui
 MCGFloat MCGContextMeasurePlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform);
 bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform, MCGRectangle &r_bounds);
 
-void MCGContextPlayback(MCGContextRef context, MCGRectangle p_dst_rect, MCSpan<const byte_t> p_drawing);
+void MCGContextPlaybackRectOfDrawing(MCGContextRef context, MCSpan<const byte_t> p_drawing, MCGRectangle p_src, MCGRectangle p_dst);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libgraphics/src/drawing.cpp
+++ b/libgraphics/src/drawing.cpp
@@ -230,36 +230,42 @@ enum MCGDrawingOpcode : uint8_t
     
     /* Rectangle defines a rectangle shape. The rectangle is defined as:
      *   x, y: coordinate scalars
+     *   width, height: length scalars */
+    kMCGDrawingOpcodeRectangle = 13,
+    
+    /* RoundedRectangle defines a rounded rectangle shape. The rounded rectangle
+     * is defined as:
+     *   x, y: coordinate scalars
      *   width, height: length scalars
      *   rx, ry: length scalars */
-    kMCGDrawingOpcodeRectangle = 13,
+    kMCGDrawingOpcodeRoundedRectangle = 14,
     
     /* Circle defines a circle shape. The circle is defined as:
      *   x, y: coordinate scalars
      *   r: length scalar */
-    kMCGDrawingOpcodeCircle = 14,
+    kMCGDrawingOpcodeCircle = 15,
     
     /* Ellipse defines an ellipse shape. The ellipse is defined as:
      *   x, y: coordinate scalars
      *   rx, ry: length scalars */
-    kMCGDrawingOpcodeEllipse = 15,
+    kMCGDrawingOpcodeEllipse = 16,
     
     /* Line defines a line shape. The line is defined as:
      *   x1, y1: coordinate scalars
      *   x2, y2: coordinate scalars */
-    kMCGDrawingOpcodeLine = 16,
+    kMCGDrawingOpcodeLine = 17,
     
     /* Polyline defines a polyline shape. The polyline is defined as an array
      * of coordinate scalar pairs. */
-    kMCGDrawingOpcodePolyline = 17,
+    kMCGDrawingOpcodePolyline = 18,
     
     /* Polyline defines a polygon shape. The polygon is defined as an array
      * of coordinate scalar pairs. */
-    kMCGDrawingOpcodePolygon = 18,
+    kMCGDrawingOpcodePolygon = 19,
     
     /* Path defines a path shape. The path is defined by a path opcode stream.
      */
-    kMCGDrawingOpcodePath = 19,
+    kMCGDrawingOpcodePath = 20,
     
     /* _Last is used for range checking on the main opcodes. */
     kMCGDrawingOpcode_Last = kMCGDrawingOpcodePath,
@@ -267,13 +273,11 @@ enum MCGDrawingOpcode : uint8_t
 
 /* TRANSFORM OPCODES */
 
-/* MCGDrawingTransformOpcode defines the opcodes used to build a transform. The
- * sequence of specified transforms is concatenated with the identity transform
- * to build a transformation matrix. */
+/* MCGDrawingTransformOpcode defines the opcodes used to build a transform. */
 enum MCGDrawingTransformOpcode : uint8_t
 {
-    /* End terminates a sequence of concatenated transforms */
-    kMCGDrawingTransformOpcodeEnd = 0,
+    /* Identity defines the identity transform */
+    kMCGDrawingTransformOpcodeIdentity = 0,
     
     /* Affine defines a general affine transformation. It is defined by 6
      * scalars - a b c d tx ty. */
@@ -285,14 +289,11 @@ enum MCGDrawingTransformOpcode : uint8_t
 
 /* PAINT OPCODES */
 
-/* MCGDrawingPaintOpcode defines the opcodes used to build a paint. Currently
- * only a single paint is allowed, but in the future multiple paints will be
- * allowed (resulting in the shape being drawn with each paint in turn) to
- * align with that feature in the SVG2 spec. */
+/* MCGDrawingPaintOpcode defines the opcodes used to build a paint. */
 enum MCGDrawingPaintOpcode : uint8_t
 {
-    /* End terminates a sequence of overlaid paints. */
-    kMCGDrawingPaintOpcodeEnd = 0,
+    /* None defines no paint. */
+    kMCGDrawingPaintOpcodeNone = 0,
     
     /* SolidColor defines a solid color paint. It is defined by 4 unit scalars -
      * red green blue alpha. */
@@ -401,57 +402,28 @@ enum MCGDrawingPathOpcode : uint8_t
     kMCGDrawingPathOpcodeEnd = 0,
     
     kMCGDrawingPathOpcodeMoveTo = 1,
-    kMCGDrawingPathOpcodeRelativeMoveTo = 2,
-    kMCGDrawingPathOpcodeLineTo = 3,
-    kMCGDrawingPathOpcodeRelativeLineTo = 4,
-    kMCGDrawingPathOpcodeHorizontalTo = 5,
-    kMCGDrawingPathOpcodeRelativeHorizontalTo = 6,
-    kMCGDrawingPathOpcodeVerticalTo = 7,
-    kMCGDrawingPathOpcodeRelativeVerticalTo = 8,
-    kMCGDrawingPathOpcodeCubicTo = 9,
-    kMCGDrawingPathOpcodeRelativeCubicTo = 10,
-    kMCGDrawingPathOpcodeSmoothCubicTo = 11,
-    kMCGDrawingPathOpcodeRelativeSmoothCubicTo = 12,
-    kMCGDrawingPathOpcodeQuadraticTo= 13,
-    kMCGDrawingPathOpcodeRelativeQuadraticTo = 14,
-    kMCGDrawingPathOpcodeSmoothQuadraticTo = 15,
-    kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo = 16,
-    kMCGDrawingPathOpcodeArcTo = 17,
-    kMCGDrawingPathOpcodeRelativeArcTo = 18,
-    kMCGDrawingPathOpcodeReflexArcTo = 19,
-    kMCGDrawingPathOpcodeRelativeReflexArcTo = 20,
-    kMCGDrawingPathOpcodeReverseArcTo = 21,
-    kMCGDrawingPathOpcodeRelativeReverseArcTo = 22,
-    kMCGDrawingPathOpcodeReverseReflexArcTo = 23,
-    kMCGDrawingPathOpcodeRelativeReverseReflexArcTo = 24,
-    kMCGDrawingPathOpcodeCloseSubpath = 25,
+    kMCGDrawingPathOpcodeLineTo = 2,
+    kMCGDrawingPathOpcodeHorizontalTo = 3,
+    kMCGDrawingPathOpcodeVerticalTo = 4,
+    kMCGDrawingPathOpcodeCubicTo = 5,
+    kMCGDrawingPathOpcodeSmoothCubicTo = 6,
+    kMCGDrawingPathOpcodeQuadraticTo= 7,
+    kMCGDrawingPathOpcodeSmoothQuadraticTo = 8,
+    kMCGDrawingPathOpcodeArcTo = 9,
+    kMCGDrawingPathOpcodeReflexArcTo = 10,
+    kMCGDrawingPathOpcodeReverseArcTo = 11,
+    kMCGDrawingPathOpcodeReverseReflexArcTo = 12,
+    kMCGDrawingPathOpcodeCloseSubpath = 13,
     
     kMCGDrawingPathOpcode_Last = kMCGDrawingPathOpcodeCloseSubpath,
 };
-
-inline bool MCGDrawingPathOpcodeIsRelativeArcTo(MCGDrawingPathOpcode p_opcode)
-{
-    switch(p_opcode)
-    {
-    case kMCGDrawingPathOpcodeRelativeArcTo:
-    case kMCGDrawingPathOpcodeRelativeReflexArcTo:
-    case kMCGDrawingPathOpcodeRelativeReverseArcTo:
-    case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
-        return true;
-    default:
-        break;
-    }
-    return false;
-}
 
 inline bool MCGDrawingPathOpcodeIsReflexArcTo(MCGDrawingPathOpcode p_opcode)
 {
     switch(p_opcode)
     {
     case kMCGDrawingPathOpcodeReflexArcTo:
-    case kMCGDrawingPathOpcodeRelativeReflexArcTo:
     case kMCGDrawingPathOpcodeReverseReflexArcTo:
-    case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
         return true;
     default:
         break;
@@ -464,9 +436,7 @@ inline bool MCGDrawingPathOpcodeIsReverseArcTo(MCGDrawingPathOpcode p_opcode)
     switch(p_opcode)
     {
     case kMCGDrawingPathOpcodeReverseArcTo:
-    case kMCGDrawingPathOpcodeRelativeReverseArcTo:
     case kMCGDrawingPathOpcodeReverseReflexArcTo:
-    case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
         return true;
     default:
         break;
@@ -1101,13 +1071,96 @@ public:
                 break;
         }
 
-        if (!ExecuteTransform(r_gradient.transform))
+        if (!Transform(r_gradient.transform))
         {
             return false;
         }
         if (!Ramp(r_gradient.ramp))
         {
             return false;
+        }
+        
+        return true;
+    }
+    
+    bool Transform(MCGAffineTransform& r_transform)
+    {
+        MCGDrawingTransformOpcode t_opcode;
+        if (!TransformOpcode(t_opcode))
+        {
+            return false;
+        }
+        
+        switch(t_opcode)
+        {
+            case kMCGDrawingTransformOpcodeIdentity:
+                r_transform = MCGAffineTransformMakeIdentity();
+                break;
+                
+            case kMCGDrawingTransformOpcodeAffine:
+                if (!AffineTransform(r_transform))
+                {
+                    return false;
+                }
+                break;
+        }
+        
+        return true;
+    }
+    
+    bool Paint(MCGDrawingPaint& r_paint)
+    {
+        MCGDrawingPaintOpcode t_opcode;
+        if (!PaintOpcode(t_opcode))
+        {
+            return false;
+        }
+        
+        switch(t_opcode)
+        {
+            case kMCGDrawingPaintOpcodeNone:
+                r_paint.type = kMCGDrawingPaintTypeNone;
+                break;
+                
+            case kMCGDrawingPaintOpcodeSolidColor:
+                r_paint.type = kMCGDrawingPaintTypeSolidColor;
+                if (!SolidColor(r_paint.solid_color))
+                {
+                    return false;
+                }
+                break;
+            
+            case kMCGDrawingPaintOpcodeLinearGradient:
+                r_paint.type = kMCGDrawingPaintTypeLinearGradient;
+                if (!Gradient(r_paint.gradient))
+                {
+                    return false;
+                }
+                break;
+                
+            case kMCGDrawingPaintOpcodeRadialGradient:
+                r_paint.type = kMCGDrawingPaintTypeRadialGradient;
+                if (!Gradient(r_paint.gradient))
+                {
+                    return false;
+                }
+                break;
+                
+            case kMCGDrawingPaintOpcodeConicalGradient:
+                r_paint.type = kMCGDrawingPaintTypeConicalGradient;
+                if (!Gradient(r_paint.gradient))
+                {
+                    return false;
+                }
+                if (!Point(r_paint.conical_gradient.focal_point))
+                {
+                    return false;
+                }
+                if (!LengthScalar(r_paint.conical_gradient.focal_radius))
+                {
+                    return false;
+                }
+                break;
         }
         
         return true;
@@ -1151,13 +1204,6 @@ private:
         
         return true;
     }
-
-    /* ExecuteTransform runs a transform opcode stream to generate an affine
-     * transform. */
-    bool ExecuteTransform(MCGAffineTransform& r_transform);
-    
-    /* ExecutePaint runs a paint opcode stream to generate a paint struct. */
-    bool ExecutePaint(MCGDrawingPaint& r_paint);
     
     /* ExecutePath runs a path opcode stream into the provided
      * visitor. */
@@ -1237,7 +1283,7 @@ void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_src_rect, MC
             case kMCGDrawingOpcodeTransform:
             {
                 MCGAffineTransform t_transform;
-                if (!ExecuteTransform(t_transform))
+                if (!Transform(t_transform))
                 {
                     break;
                 }
@@ -1252,7 +1298,7 @@ void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_src_rect, MC
             case kMCGDrawingOpcodeStrokePaint:
             {
                 MCGDrawingPaint t_paint;
-                if (!ExecutePaint(t_paint))
+                if (!Paint(t_paint))
                 {
                     break;
                 }
@@ -1449,6 +1495,25 @@ void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_src_rect, MC
                  * geometry is encoded as scalars:
                  *   x, y : coordinate scalars
                  *   width, height : length scalars
+                 */
+                MCGRectangle t_bounds;
+                if (!Rectangle(t_bounds))
+                {
+                    break;
+                }
+                
+                /* Visit the visitor method. */
+                p_visitor.Rectangle(t_bounds);
+            }
+            break;
+            
+            /* RoundedRectangle visits the RoundedRectangle method of the visitor. */
+            case kMCGDrawingOpcodeRoundedRectangle:
+            {
+                /* Fetch the requested (rounded) rectangle's geometry. The
+                 * geometry is encoded as scalars:
+                 *   x, y : coordinate scalars
+                 *   width, height : length scalars
                  *   rx, ry : length scalars
                  */
                 MCGRectangle t_bounds;
@@ -1460,7 +1525,7 @@ void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_src_rect, MC
                 }
                 
                 /* Visit the visitor method. */
-                p_visitor.Rectangle(t_bounds, t_radii);
+                p_visitor.RoundedRectangle(t_bounds, t_radii);
             }
             break;
                 
@@ -1570,118 +1635,6 @@ void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_src_rect, MC
     p_visitor.Finish(m_status != kMCGDrawingStatusNone);
 }
 
-/* The implementation of the ExecuteTransform method. */
-bool MCGDrawingContext::ExecuteTransform(MCGAffineTransform& r_transform)
-{
-    MCGAffineTransform t_transform = MCGAffineTransformMakeIdentity();
-
-    while(IsRunning())
-    {
-        MCGDrawingTransformOpcode t_opcode;
-        if (!TransformOpcode(t_opcode))
-        {
-            return false;
-        }
-        
-        if (t_opcode == kMCGDrawingTransformOpcodeEnd)
-        {
-            break;
-        }
-        
-        switch(t_opcode)
-        {
-            case kMCGDrawingTransformOpcodeEnd:
-                MCUnreachable();
-                break;
-                
-            case kMCGDrawingTransformOpcodeAffine:
-            {
-                MCGAffineTransform t_affine_transform;
-                if (!AffineTransform(t_affine_transform))
-                {
-                    return false;
-                }
-                t_transform = MCGAffineTransformConcat(t_transform, t_affine_transform);
-            }
-            break;
-        }
-    }
-    
-    r_transform = t_transform;
-    
-    return true;
-}
-
-/* The implementation of the ExecutePaint method. */
-bool MCGDrawingContext::ExecutePaint(MCGDrawingPaint& r_paint)
-{
-    MCGDrawingPaint t_paint;
-    while(IsRunning())
-    {
-        MCGDrawingPaintOpcode t_opcode;
-        if (!PaintOpcode(t_opcode))
-        {
-            break;
-        }
-        
-        if (t_opcode == kMCGDrawingPaintOpcodeEnd)
-        {
-            break;
-        }
-        
-        switch(t_opcode)
-        {
-            case kMCGDrawingPaintOpcodeEnd:
-                MCUnreachable();
-                break;
-                
-            case kMCGDrawingPaintOpcodeSolidColor:
-                t_paint.type = kMCGDrawingPaintTypeSolidColor;
-                if (!SolidColor(t_paint.solid_color))
-                {
-                    return false;
-                }
-                break;
-            
-            case kMCGDrawingPaintOpcodeLinearGradient:
-                t_paint.type = kMCGDrawingPaintTypeLinearGradient;
-                if (!Gradient(t_paint.gradient))
-                {
-                    return false;
-                }
-                break;
-                
-            case kMCGDrawingPaintOpcodeRadialGradient:
-                t_paint.type = kMCGDrawingPaintTypeRadialGradient;
-                if (!Gradient(t_paint.gradient))
-                {
-                    return false;
-                }
-                break;
-                
-            case kMCGDrawingPaintOpcodeConicalGradient:
-                t_paint.type = kMCGDrawingPaintTypeConicalGradient;
-                if (!Gradient(t_paint.gradient))
-                {
-                    return false;
-                }
-                if (!Point(t_paint.conical_gradient.focal_point))
-                {
-                    return false;
-                }
-                if (!LengthScalar(t_paint.conical_gradient.focal_radius))
-                {
-                    return false;
-                }
-                break;
-        }
-    }
-    
-    r_paint = t_paint;
-    
-    return true;
-}
-
 /* The (template based) implementation of the ExecutePath method. */
 template<typename VisitorT>
 void MCGDrawingContext::ExecutePath(VisitorT& p_visitor)
@@ -1711,59 +1664,50 @@ void MCGDrawingContext::ExecutePath(VisitorT& p_visitor)
             break;
                 
             case kMCGDrawingPathOpcodeMoveTo:
-            case kMCGDrawingPathOpcodeRelativeMoveTo:
             {
                 MCGPoint t_point;
                 if (!Point(t_point))
                 {
                     break;
                 }
-                p_visitor.PathMoveTo(t_opcode == kMCGDrawingPathOpcodeRelativeMoveTo,
-                                     t_point);
+                p_visitor.PathMoveTo(t_point);
             }
             break;
                 
             case kMCGDrawingPathOpcodeLineTo:
-            case kMCGDrawingPathOpcodeRelativeLineTo:
             {
                 MCGPoint t_point;
                 if (!Point(t_point))
                 {
                     break;
                 }
-                p_visitor.PathLineTo(t_opcode == kMCGDrawingPathOpcodeRelativeLineTo,
-                                     t_point);
+                p_visitor.PathLineTo(t_point);
             }
             break; 
             
             case kMCGDrawingPathOpcodeHorizontalTo:
-            case kMCGDrawingPathOpcodeRelativeHorizontalTo:
             {
                 MCGFloat t_x;
                 if (!CoordinateScalar(t_x))
                 {
                     break;
                 }
-                p_visitor.PathHorizontalTo(t_opcode == kMCGDrawingPathOpcodeRelativeHorizontalTo,
-                                           t_x);
+                p_visitor.PathHorizontalTo(t_x);
             }
             break;
                 
             case kMCGDrawingPathOpcodeVerticalTo:
-            case kMCGDrawingPathOpcodeRelativeVerticalTo:
             {
                 MCGFloat t_y;
                 if (!CoordinateScalar(t_y))
                 {
                     break;
                 }
-                p_visitor.PathVerticalTo(t_opcode == kMCGDrawingPathOpcodeRelativeVerticalTo,
-                                         t_y);
+                p_visitor.PathVerticalTo(t_y);
             }
             break;
                 
             case kMCGDrawingPathOpcodeCubicTo:
-            case kMCGDrawingPathOpcodeRelativeCubicTo:
             {
                 MCGPoint t_a, t_b, t_point;
                 if (!Point(t_a) ||
@@ -1772,15 +1716,13 @@ void MCGDrawingContext::ExecutePath(VisitorT& p_visitor)
                 {
                     break;
                 }
-                p_visitor.PathCubicTo(t_opcode == kMCGDrawingPathOpcodeRelativeCubicTo,
-                                      t_a,
+                p_visitor.PathCubicTo(t_a,
                                       t_b,
                                       t_point);
             }
             break;
                 
             case kMCGDrawingPathOpcodeSmoothCubicTo:
-            case kMCGDrawingPathOpcodeRelativeSmoothCubicTo:
             {
                 MCGPoint t_a, t_b, t_point;
                 if (!Point(t_b) ||
@@ -1788,14 +1730,12 @@ void MCGDrawingContext::ExecutePath(VisitorT& p_visitor)
                 {
                     break;
                 }
-                p_visitor.PathSmoothCubicTo(t_opcode == kMCGDrawingPathOpcodeRelativeSmoothCubicTo,
-                                            t_b,
+                p_visitor.PathSmoothCubicTo(t_b,
                                             t_point);
             }
             break;
                 
             case kMCGDrawingPathOpcodeQuadraticTo:
-            case kMCGDrawingPathOpcodeRelativeQuadraticTo:
             {
                 MCGPoint t_a, t_point;
                 if (!Point(t_a) ||
@@ -1803,33 +1743,26 @@ void MCGDrawingContext::ExecutePath(VisitorT& p_visitor)
                 {
                     break;
                 }
-                p_visitor.PathQuadraticTo(t_opcode == kMCGDrawingPathOpcodeRelativeQuadraticTo,
-                                          t_a,
+                p_visitor.PathQuadraticTo(t_a,
                                           t_point);
             }
             break;
                 
             case kMCGDrawingPathOpcodeSmoothQuadraticTo:
-            case kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo:
             {
                 MCGPoint t_point;
                 if (!Point(t_point))
                 {
                     break;
                 }
-                p_visitor.PathSmoothQuadraticTo(t_opcode == kMCGDrawingPathOpcodeRelativeSmoothQuadraticTo,
-                                                t_point);
+                p_visitor.PathSmoothQuadraticTo(t_point);
             }
             break;
                 
             case kMCGDrawingPathOpcodeArcTo:
-            case kMCGDrawingPathOpcodeRelativeArcTo:
             case kMCGDrawingPathOpcodeReflexArcTo:
-            case kMCGDrawingPathOpcodeRelativeReflexArcTo:
             case kMCGDrawingPathOpcodeReverseArcTo:
-            case kMCGDrawingPathOpcodeRelativeReverseArcTo:
             case kMCGDrawingPathOpcodeReverseReflexArcTo:
-            case kMCGDrawingPathOpcodeRelativeReverseReflexArcTo:
             {
                 MCGSize t_radii;
                 MCGFloat t_rotation;
@@ -1841,8 +1774,7 @@ void MCGDrawingContext::ExecutePath(VisitorT& p_visitor)
                     break;
                 }
                 
-                p_visitor.PathArcTo(MCGDrawingPathOpcodeIsRelativeArcTo(t_opcode),
-                                    MCGDrawingPathOpcodeIsReflexArcTo(t_opcode),
+                p_visitor.PathArcTo(MCGDrawingPathOpcodeIsReflexArcTo(t_opcode),
                                     MCGDrawingPathOpcodeIsReverseArcTo(t_opcode),
                                     t_radii,
                                     t_rotation,
@@ -1876,31 +1808,14 @@ struct MCGDrawingRenderVisitor
     MCGDrawingPathOpcode last_curve_opcode = kMCGDrawingPathOpcodeEnd;
     
     /**/
-    
-    MCGPoint Point(bool p_is_relative, MCGPoint p_point)
+
+    MCGPoint HorizontalPoint(MCGFloat p_x)
     {
-        if (p_is_relative)
-        {
-            return MCGPointMake(last_point.x + p_point.x, last_point.y + p_point.y);
-        }
-        return p_point;
-    }
-    
-    MCGPoint HorizontalPoint(bool p_is_relative, MCGFloat p_x)
-    {
-        if (p_is_relative)
-        {
-            return MCGPointMake(last_point.x + p_x, last_point.y);
-        }
         return MCGPointMake(p_x, last_point.y);
     }
     
-    MCGPoint VerticalPoint(bool p_is_relative, MCGFloat p_y)
+    MCGPoint VerticalPoint(MCGFloat p_y)
     {
-        if (p_is_relative)
-        {
-            return MCGPointMake(last_point.x, last_point.y + p_y);
-        }
         return MCGPointMake(last_point.x, p_y);
     }
     
@@ -1914,55 +1829,50 @@ struct MCGDrawingRenderVisitor
         first_point = last_point = MCGPointMake(0.0, 0.0);
     }
     
-    void PathMoveTo(bool p_is_relative, MCGPoint p_point)
+    void PathMoveTo(MCGPoint p_point)
     {
-        MCGPoint t_point = Point(p_is_relative, p_point);
-        MCGContextMoveTo(gcontext, t_point);
+        MCGContextMoveTo(gcontext, p_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeEnd;
-        first_point = last_point = t_point;
+        first_point = last_point = p_point;
     }
     
-    void PathLineTo(bool p_is_relative, MCGPoint p_point)
+    void PathLineTo(MCGPoint p_point)
     {
-        MCGPoint t_point = Point(p_is_relative, p_point);
+        MCGContextLineTo(gcontext, p_point);
+        
+        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
+        last_point = p_point;
+    }
+    
+    void PathHorizontalTo(MCGFloat p_x)
+    {
+        MCGPoint t_point = HorizontalPoint(p_x);
         MCGContextLineTo(gcontext, t_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeEnd;
         last_point = t_point;
     }
     
-    void PathHorizontalTo(bool p_is_relative, MCGFloat p_x)
+    void PathVerticalTo(MCGFloat p_y)
     {
-        MCGPoint t_point = HorizontalPoint(p_is_relative, p_x);
+        MCGPoint t_point = VerticalPoint(p_y);
         MCGContextLineTo(gcontext, t_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeEnd;
         last_point = t_point;
     }
     
-    void PathVerticalTo(bool p_is_relative, MCGFloat p_y)
+    void PathCubicTo(MCGPoint p_a, MCGPoint p_b, MCGPoint p_point)
     {
-        MCGPoint t_point = VerticalPoint(p_is_relative, p_y);
-        MCGContextLineTo(gcontext, t_point);
-        
-        last_curve_opcode = kMCGDrawingPathOpcodeEnd;
-        last_point = t_point;
-    }
-    
-    void PathCubicTo(bool p_is_relative, MCGPoint p_a, MCGPoint p_b, MCGPoint p_point)
-    {
-        MCGPoint t_a = Point(p_is_relative, p_a);
-        MCGPoint t_b = Point(p_is_relative, p_b);
-        MCGPoint t_point = Point(p_is_relative, p_point);
-        MCGContextCubicTo(gcontext, t_a, t_b, t_point);
+        MCGContextCubicTo(gcontext, p_a, p_b, p_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeCubicTo;
-        last_control_point = t_b;
-        last_point = t_point;
+        last_control_point = p_b;
+        last_point = p_point;
     }
     
-    void PathSmoothCubicTo(bool p_is_relative,  MCGPoint p_b, MCGPoint p_point)
+    void PathSmoothCubicTo(MCGPoint p_b, MCGPoint p_point)
     {
         MCGPoint t_a;
         if (last_curve_opcode == kMCGDrawingPathOpcodeCubicTo)
@@ -1974,27 +1884,23 @@ struct MCGDrawingRenderVisitor
             t_a = last_point;
         }
         
-        MCGPoint t_b = Point(p_is_relative, p_b);
-        MCGPoint t_point = Point(p_is_relative, p_point);
-        MCGContextCubicTo(gcontext, t_a, t_b, t_point);
+        MCGContextCubicTo(gcontext, t_a, p_b, p_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeCubicTo;
-        last_control_point = t_b;
-        last_point = t_point;
+        last_control_point = p_b;
+        last_point = p_point;
     }
     
-    void PathQuadraticTo(bool p_is_relative, MCGPoint p_a, MCGPoint p_point)
+    void PathQuadraticTo(MCGPoint p_a, MCGPoint p_point)
     {
-        MCGPoint t_a = Point(p_is_relative, p_a);
-        MCGPoint t_point = Point(p_is_relative, p_point);
-        MCGContextQuadraticTo(gcontext, t_a, t_point);
+        MCGContextQuadraticTo(gcontext, p_a, p_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeQuadraticTo;
-        last_control_point = t_a;
-        last_point = t_point;
+        last_control_point = p_a;
+        last_point = p_point;
     }
     
-    void PathSmoothQuadraticTo(bool p_is_relative, MCGPoint p_point)
+    void PathSmoothQuadraticTo(MCGPoint p_point)
     {
         MCGPoint t_a;
         if (last_curve_opcode == kMCGDrawingPathOpcodeQuadraticTo)
@@ -2006,21 +1912,19 @@ struct MCGDrawingRenderVisitor
             t_a = last_point;
         }
         
-        MCGPoint t_point = Point(p_is_relative, p_point);
-        MCGContextQuadraticTo(gcontext, t_a, t_point);
+        MCGContextQuadraticTo(gcontext, t_a, p_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeCubicTo;
         last_control_point = t_a;
-        last_point = t_point;
+        last_point = p_point;
     }
     
-    void PathArcTo(bool p_is_relative, bool p_is_reflex, bool p_is_reverse, MCGSize p_radii, MCGFloat p_rotation, MCGPoint p_point)
+    void PathArcTo(bool p_is_reflex, bool p_is_reverse, MCGSize p_radii, MCGFloat p_rotation, MCGPoint p_point)
     {
-        MCGPoint t_point = Point(p_is_relative, p_point);
-        MCGContextArcTo(gcontext, p_radii, p_rotation, p_is_reflex, p_is_reverse, t_point);
+        MCGContextArcTo(gcontext, p_radii, p_rotation, p_is_reflex, p_is_reverse, p_point);
         
         last_curve_opcode = kMCGDrawingPathOpcodeEnd;
-        last_point = t_point;
+        last_point = p_point;
     }
     
     void PathCloseSubpath(void)
@@ -2112,19 +2016,18 @@ struct MCGDrawingRenderVisitor
         MCGContextSetStrokeMiterLimit(gcontext, p_miter_limit);
     }
     
-    void Rectangle(MCGRectangle p_rect, MCGSize p_radii)
+    void Rectangle(MCGRectangle p_rect)
     {
-        if (p_radii.width == 0 && p_radii.height == 0)
-        {
-            MCGContextAddRectangle(gcontext, p_rect);
-        }
-        else
-        {
-            MCGContextAddRoundedRectangle(gcontext, p_rect, p_radii);
-        }
+        MCGContextAddRectangle(gcontext, p_rect);
         MCGContextFillAndStroke(gcontext);
     }
     
+    void RoundedRectangle(MCGRectangle p_rect, MCGSize p_radii)
+    {
+        MCGContextAddRoundedRectangle(gcontext, p_rect, p_radii);
+        MCGContextFillAndStroke(gcontext);
+    }
+
     void Circle(MCGPoint p_center, MCGFloat p_r)
     {
         MCGContextAddEllipse(gcontext, p_center, MCGSizeMake(p_r, p_r), 0.0);

--- a/libgraphics/src/drawing.cpp
+++ b/libgraphics/src/drawing.cpp
@@ -1117,7 +1117,7 @@ public:
      * operations. The rect into which the drawing should be 'rendered' is
      * indicated in p_dst_rect. */
     template<typename VisitorT>
-    void Execute(VisitorT& visitor, MCGRectangle p_dst_rect);
+    void Execute(VisitorT& visitor, MCGRectangle p_src_rect, MCGRectangle p_dst_rect);
     
 private:
      /* GeneralOpcode reads the next opcode from the opcode stream. If there is
@@ -1195,7 +1195,7 @@ private:
 
 /* The (template based) implementation of the Execute method. */
 template<typename VisitorT>
-void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_dst_rect)
+void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_src_rect, MCGRectangle p_dst_rect)
 {
     /* If the width / height are zero. Then do nothing. */
     if (m_width == 0.0 ||
@@ -1205,7 +1205,7 @@ void MCGDrawingContext::Execute(VisitorT& p_visitor, MCGRectangle p_dst_rect)
     }
 
     /* Start the visitor. */
-    p_visitor.Start(MCGRectangleMake(0, 0, m_width, m_height), p_dst_rect);
+    p_visitor.Start(p_src_rect, p_dst_rect);
     
     /* Loop until the status ceases to be None. */
     while(m_status == kMCGDrawingStatusNone)
@@ -2228,14 +2228,13 @@ private:
     }
 };
 
-/* MCGContextPlayback renders the specified drawing into p_dst_rect of p_gcontext. */
-void MCGContextPlayback(MCGContextRef p_gcontext, MCGRectangle p_dst_rect, MCSpan<const byte_t> p_drawing)
+void MCGContextPlaybackRectOfDrawing(MCGContextRef p_gcontext, MCSpan<const byte_t> p_drawing, MCGRectangle p_src_rect, MCGRectangle p_dst_rect)
 {
     MCGDrawingRenderVisitor t_render_visitor;
     t_render_visitor.gcontext = p_gcontext;
     
     MCGDrawingContext t_context(p_drawing);
-    t_context.Execute(t_render_visitor, p_dst_rect);
+    t_context.Execute(t_render_visitor, p_src_rect, p_dst_rect);
 }
 
 /******************************************************************************/


### PR DESCRIPTION
This patch contains a number of improvements / fixes to the drawing / svg support:

- The viewport defined by a drawing is now completely static. This means that a drawing always has an easily accessible and well defined width/height.

- Drawing-style images now rotate, can be rendered from LCB and work correctly as icons.

- The drawing format has been refined, simplifying opcodes and removing unnecessary ones.