### PR TITLE
[[ SVG ]] Shape Object

### DIFF
--- a/engine/src/internal.cpp
+++ b/engine/src/internal.cpp
@@ -227,6 +227,387 @@ private:
     MCExpression *m_path_string;
 };
 
+template<bool(*Op)(MCExecContext& ctxt, MCGShapeRef shape)>
+class MCInternalShape: public MCStatement
+{
+public:
+    MCInternalShape(void)
+    {
+        m_shape = nil;
+    }
+    
+    ~MCInternalShape(void)
+    {
+        delete m_shape;
+    }
+    
+    Parse_stat parse(MCScriptPoint& sp)
+    {
+        if (sp.parseexp(False, True, &m_shape) != PS_NORMAL)
+        {
+            MCperror -> add(PE_PUT_BADEXP, sp);
+            return PS_ERROR;
+        }
+        
+        return PS_NORMAL;
+    }
+    
+    void exec_ctxt(MCExecContext &ctxt)
+    {
+        MCAutoArrayRef t_array;
+        if (!ctxt.EvalExprAsArrayRef(m_shape, EE_PROPERTY_NOTANARRAY, &t_array))
+        {
+            ctxt.Throw();
+            return;
+        }
+        
+        MCGShapeRef t_shape = nullptr;
+        if (!execute(ctxt, *t_array, t_shape))
+        {
+            ctxt.Throw();
+            return;
+        }
+        
+        Op(ctxt, t_shape);
+        MCGShapeRelease(t_shape);
+    }
+    
+    bool execute(MCExecContext& ctxt, MCArrayRef p_array, MCGShapeRef& r_shape)
+    {
+        MCAutoStringRef t_type;
+        if (!ctxt.CopyElementAsString(p_array, MCNAME("type"), false, &t_type))
+        {
+            return false;
+        }
+        
+        MCGShapeRef t_shape = nullptr;
+        if (MCStringIsEqualToCString(*t_type, "rectangle", kMCStringOptionCompareCaseless))
+        {
+            MCGFloat t_x, t_y, t_width, t_height;
+            if (!parse_array(ctxt, p_array, "fx", &t_x, "fy", &t_y, "fwidth", &t_width, "fheight", &t_height, nullptr))
+            {
+                return false;
+            }
+            MCGShapeCreateRectangle(MCGRectangleMake(t_x, t_y, t_width, t_height), t_shape);
+        }
+        else if (MCStringIsEqualToCString(*t_type, "rounded-rectangle", kMCStringOptionCompareCaseless))
+        {
+            MCGFloat t_x, t_y, t_width, t_height, t_rx, t_ry;
+            if (!parse_array(ctxt, p_array, "fx", &t_x, "fy", &t_y, "fwidth", &t_width, "fheight", &t_height, "frx", &t_rx, "fry", &t_ry, nullptr))
+            {
+                return false;
+            }
+            MCGShapeCreateRoundedRectangle(MCGRectangleMake(t_x, t_y, t_width, t_height), MCGSizeMake(t_rx, t_ry), t_shape);
+        }
+        else if (MCStringIsEqualToCString(*t_type, "ellipse", kMCStringOptionCompareCaseless))
+        {
+            MCGFloat t_cx, t_cy, t_rx, t_ry;
+            if (!parse_array(ctxt, p_array, "fcx", &t_cx, "fcy", &t_cy, "frx", &t_rx, "fry", &t_ry, nullptr))
+            {
+                return false;
+            }
+            MCGShapeCreateEllipse(MCGPointMake(t_cx, t_cy), MCGSizeMake(t_rx, t_ry), t_shape);
+        }
+        else if (MCStringIsEqualToCString(*t_type, "line", kMCStringOptionCompareCaseless))
+        {
+            MCGFloat t_x1, t_y1, t_x2, t_y2;
+            if (!parse_array(ctxt, p_array, "fx1", &t_x1, "fy1", &t_y1, "fx2", &t_x2, "fy2", &t_y2, nullptr))
+            {
+                return false;
+            }
+            MCGShapeCreateLine(MCGPointMake(t_x1, t_y1), MCGPointMake(t_x2, t_y2), t_shape);
+        }
+        else if (MCStringIsEqualToCString(*t_type, "polyline", kMCStringOptionCompareCaseless))
+        {
+        }
+        else if (MCStringIsEqualToCString(*t_type, "polygon", kMCStringOptionCompareCaseless))
+        {
+        }
+        else if (MCStringIsEqualToCString(*t_type, "path", kMCStringOptionCompareCaseless))
+        {
+            MCAutoStringRef t_path_string;
+            if (!parse_array(ctxt, p_array, "sd", &(&t_path_string), nullptr))
+            {
+                return false;
+            }
+            
+            MCAutoValueRefBase<MCCanvasPathRef> t_canvas_path;
+            MCCanvasPathMakeWithInstructionsAsString(*t_path_string, &t_canvas_path);
+            if (MCErrorIsPending())
+            {
+                ctxt.Throw();
+                return false;
+            }
+            
+            MCGPathRef t_path = MCCanvasPathGetMCGPath(*t_canvas_path);
+            
+            MCGShapeCreatePath(t_path, t_shape);
+        }
+        else if (MCStringIsEqualToCString(*t_type, "transform", kMCStringOptionCompareCaseless))
+        {
+            MCAutoArrayRef t_shape_array;
+            MCGAffineTransform t_t;
+            if (!parse_array(ctxt, p_array, "ashape", &(&t_shape_array), "fa", &t_t.a, "fb", &t_t.b, "fc", &t_t.c, "fd", &t_t.d, "ftx", &t_t.tx, "fty", &t_t.ty, nullptr))
+            {
+                return false;
+            }
+            MCGShapeRef t_base_shape;
+            if (!execute(ctxt, *t_shape_array, t_base_shape))
+            {
+                return false;
+            }
+            MCGShapeTransform(t_base_shape, t_t, t_shape);
+            MCGShapeRelease(t_base_shape);
+        }
+        else if (MCStringIsEqualToCString(*t_type, "fill", kMCStringOptionCompareCaseless))
+        {
+            MCAutoArrayRef t_shape_array;
+            MCAutoStringRef t_rule_string;
+            if (!parse_array(ctxt, p_array, "ashape", &(&t_shape_array), "srule", &(&t_rule_string), nullptr))
+            {
+                return false;
+            }
+            MCGFillRule t_rule;
+            if (MCStringIsEqualToCString(*t_rule_string, "non-zero", kMCStringOptionCompareCaseless))
+            {
+                t_rule = kMCGFillRuleNonZero;
+            }
+            else if (MCStringIsEqualToCString(*t_rule_string, "even-odd", kMCStringOptionCompareCaseless))
+            {
+                t_rule = kMCGFillRuleEvenOdd;
+            }
+            else
+            {
+                return false;
+            }
+            MCGShapeRef t_base_shape;
+            if (!execute(ctxt, *t_shape_array, t_base_shape))
+            {
+                return false;
+            }
+            MCGShapeFill(t_base_shape, t_rule, t_shape);
+            MCGShapeRelease(t_base_shape);
+        }
+        else if (MCStringIsEqualToCString(*t_type, "dash", kMCStringOptionCompareCaseless))
+        {
+        }
+        else if (MCStringIsEqualToCString(*t_type, "thicken", kMCStringOptionCompareCaseless))
+        {
+            MCAutoArrayRef t_shape_array;
+            MCGFloat t_width, t_miter_limit;
+            MCAutoStringRef t_cap_string, t_join_string;
+            if (!parse_array(ctxt, p_array, "ashape", &(&t_shape_array), "fwidth", &t_width, "scap", &(&t_cap_string), "sjoin", &(&t_join_string), "fmiter-limit", &t_miter_limit, nullptr))
+            {
+                return false;
+            }
+            
+            MCGCapStyle t_cap;
+            if (MCStringIsEqualToCString(*t_cap_string, "butt", kMCStringOptionCompareCaseless))
+            {
+                t_cap = kMCGCapStyleButt;
+            }
+            else if (MCStringIsEqualToCString(*t_cap_string, "round", kMCStringOptionCompareCaseless))
+            {
+                t_cap = kMCGCapStyleRound;
+            }
+            else if (MCStringIsEqualToCString(*t_cap_string, "square", kMCStringOptionCompareCaseless))
+            {
+                t_cap = kMCGCapStyleSquare;
+            }
+            else
+            {
+                return false;
+            }
+            
+            MCGJoinStyle t_join;
+            if (MCStringIsEqualToCString(*t_join_string, "bevel", kMCStringOptionCompareCaseless))
+            {
+                t_join = kMCGJoinStyleBevel;
+            }
+            else if (MCStringIsEqualToCString(*t_join_string, "round", kMCStringOptionCompareCaseless))
+            {
+                t_join = kMCGJoinStyleRound;
+            }
+            else if (MCStringIsEqualToCString(*t_join_string, "miter", kMCStringOptionCompareCaseless))
+            {
+                t_join = kMCGJoinStyleMiter;
+            }
+            else
+            {
+                return false;
+            }
+            
+            MCGShapeRef t_base_shape;
+            if (!execute(ctxt, *t_shape_array, t_base_shape))
+            {
+                return false;
+            }
+            MCGShapeThicken(t_base_shape, t_width, t_cap, t_join, t_miter_limit, t_shape);
+            MCGShapeRelease(t_base_shape);
+        }
+        else
+        {
+            MCGShapeOperation t_op;
+            if (MCStringIsEqualToCString(*t_type, "union", kMCStringOptionCompareCaseless))
+            {
+                t_op = kMCGShapeOperationUnion;
+            }
+            else if (MCStringIsEqualToCString(*t_type, "intersect", kMCStringOptionCompareCaseless))
+            {
+                t_op = kMCGShapeOperationIntersect;
+            }
+            else if (MCStringIsEqualToCString(*t_type, "difference", kMCStringOptionCompareCaseless))
+            {
+                t_op = kMCGShapeOperationDifference;
+            }
+            else if (MCStringIsEqualToCString(*t_type, "xor", kMCStringOptionCompareCaseless))
+            {
+                t_op = kMCGShapeOperationXor;
+            }
+            else if (MCStringIsEqualToCString(*t_type, "append", kMCStringOptionCompareCaseless))
+            {
+                t_op = kMCGShapeOperationAppend;
+            }
+            else if (MCStringIsEqualToCString(*t_type, "extend", kMCStringOptionCompareCaseless))
+            {
+                t_op = kMCGShapeOperationExtend;
+            }
+            else
+            {
+                return false;
+            }
+            
+            MCAutoArrayRef t_left_array, t_right_array;
+            if (!parse_array(ctxt, p_array, "aleft", &(&t_left_array), "aright", &(&t_right_array), nullptr))
+            {
+                return false;
+            }
+            
+            MCGShapeRef t_left;
+            if (!execute(ctxt, *t_left_array, t_left))
+            {
+                return false;
+            }
+            
+            MCGShapeRef t_right;
+            if (!execute(ctxt, *t_right_array, t_right))
+            {
+                MCGShapeRelease(t_left);
+                return false;
+            }
+            
+            MCGShapeCombine(t_left, t_op, t_right, t_shape);
+            MCGShapeRelease(t_left);
+            MCGShapeRelease(t_right);
+        }
+        
+        if (t_shape == nullptr)
+        {
+            return false;
+        }
+        
+        r_shape = t_shape;
+        
+        return true;
+    }
+    
+    bool parse_array(MCExecContext& ctxt, MCArrayRef p_array, ...)
+    {
+        bool t_success = true;
+        
+        va_list t_args;
+        va_start(t_args, p_array);
+        while(t_success)
+        {
+            const char *t_tag = va_arg(t_args, const char *);
+            if (t_tag == nullptr)
+            {
+                break;
+            }
+
+            char t_type = t_tag[0];
+            const char *t_name = t_tag + 1;
+            
+            MCValueRef t_value;
+            if (!MCArrayFetchValue(p_array, false, MCNAME(t_name), t_value))
+            {
+                t_success = false;
+                break;
+            }
+            
+            switch(t_type)
+            {
+                case 'a':
+                    MCArrayRef *t_array_ptr;
+                    t_array_ptr = va_arg(t_args, MCArrayRef*);
+                    MCArrayRef t_array_value;
+                    if (!ctxt.ConvertToArray(t_value, t_array_value))
+                    {
+                        t_success = false;
+                        break;
+                    }
+                    *t_array_ptr = t_array_value;
+                    break;
+                case 'f':
+                    float *t_float_ptr;
+                    t_float_ptr = va_arg(t_args, float*);
+                    double t_float_value;
+                    if (!ctxt.ConvertToReal(t_value, t_float_value))
+                    {
+                        t_success = false;
+                        break;
+                    }
+                    *t_float_ptr = (float)t_float_value;
+                    break;
+                case 's':
+                    MCStringRef *t_string_ptr;
+                    t_string_ptr = va_arg(t_args, MCStringRef*);
+                    MCStringRef t_string_value;
+                    if (!ctxt.ConvertToString(t_value, t_string_value))
+                    {
+                        t_success = false;
+                        break;
+                    }
+                    *(MCStringRef *)t_string_ptr = t_string_value;
+                    break;
+                default:
+                    t_success = false;
+                    break;
+            }
+        }
+            
+        va_end(t_args);
+            
+        return t_success;
+    }
+    
+private:
+    MCExpression *m_shape;
+};
+
+bool MCGPathGetSVGData(MCGPathRef p_path, MCStringRef &r_string);
+static bool MCInternalShapeAsString(MCExecContext& ctxt, MCGShapeRef p_shape)
+{
+    MCGPathRef t_path;
+    if (!MCGShapeFlatten(p_shape, t_path))
+    {
+        return false;
+    }
+    
+    MCAutoStringRef t_path_string;
+    bool t_success = MCGPathGetSVGData(t_path, &t_path_string);
+    MCGPathRelease(t_path);
+    
+    if (!t_success)
+    {
+        return false;
+    }
+
+    ctxt.SetTheResultToValue(*t_path_string);
+    
+    return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template<class T> inline MCStatement *class_factory(void)
@@ -237,6 +618,7 @@ template<class T> inline MCStatement *class_factory(void)
 MCInternalVerbInfo MCinternalverbs_base[] =
 {
 	{ "vectorpath", "getbbox", class_factory<MCInternalVectorPathGetBBox> },
+    { "shape", "as_string", class_factory<MCInternalShape<MCInternalShapeAsString>> },
     { nullptr, nullptr, nullptr},
 };
 

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -26,6 +26,7 @@ typedef struct __MCGContext *MCGContextRef;
 typedef struct __MCGPath *MCGPathRef;
 typedef struct __MCGImage *MCGImageRef;
 typedef struct __MCGMask *MCGMaskRef;
+typedef class MCGShape *MCGShapeRef;
 
 typedef struct __MCGDashes *MCGDashesRef;
 typedef struct __MCGRegion *MCGRegionRef;
@@ -880,6 +881,42 @@ bool MCGPathGetBoundingBox(MCGPathRef path, MCGRectangle &r_bounds);
 
 typedef bool (*MCGPathIterateCallback)(void *p_context, MCGPathCommand p_command, MCGPoint *p_points, uint32_t p_point_count);
 bool MCGPathIterate(MCGPathRef p_path, MCGPathIterateCallback p_callback, void *p_context);
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool MCGShapeCreateRectangle(MCGRectangle p_rect, MCGShapeRef& r_shape);
+bool MCGShapeCreateRoundedRectangle(MCGRectangle p_rect, MCGSize p_radii, MCGShapeRef& r_shape);
+bool MCGShapeCreateEllipse(MCGPoint p_center, MCGSize p_radii, MCGShapeRef& r_shape);
+bool MCGShapeCreateLine(MCGPoint p_from, MCGPoint p_to, MCGShapeRef& r_shape);
+bool MCGShapeCreatePolyline(const MCGPoint* p_points, uindex_t p_arity, MCGShapeRef& r_shape);
+bool MCGShapeCreatePolygon(const MCGPoint* p_points, uindex_t p_arity, MCGShapeRef& r_shape);
+bool MCGShapeCreatePath(MCGPathRef p_path, MCGShapeRef& r_shape);
+
+MCGShapeRef MCGShapeRetain(MCGShapeRef p_shape);
+void MCGShapeRelease(MCGShapeRef p_shape);
+
+bool MCGShapeTransform(MCGShapeRef p_shape, MCGAffineTransform p_transform, MCGShapeRef& r_new_shape);
+bool MCGShapeFill(MCGShapeRef p_shape, MCGFillRule p_fill_rule, MCGShapeRef& r_new_shape);
+bool MCGShapeDash(MCGShapeRef p_shape, const MCGFloat *p_lengths, uindex_t p_arity, MCGFloat p_offset, MCGShapeRef& r_shape);
+bool MCGShapeThicken(MCGShapeRef p_shape, MCGFloat p_width, MCGCapStyle p_cap, MCGJoinStyle p_join, MCGFloat p_miter_limit, MCGShapeRef& r_shape);
+
+enum MCGShapeOperation
+{
+    kMCGShapeOperationAppend,
+    kMCGShapeOperationExtend,
+    kMCGShapeOperationUnion,
+    kMCGShapeOperationIntersect,
+    kMCGShapeOperationDifference,
+    kMCGShapeOperationXor,
+};
+
+bool MCGShapeCombine(MCGShapeRef p_shape, MCGShapeOperation p_operation, MCGShapeRef p_other_shape, MCGShapeRef& r_shape);
+
+bool MCGShapeMeasure(MCGShapeRef p_shape, MCGFloat& r_length);
+bool MCGShapeHull(MCGShapeRef p_shape, MCGRectangle& r_hull);
+bool MCGShapeBounds(MCGShapeRef p_shape, MCGRectangle& r_bounds);
+
+bool MCGShapeFlatten(MCGShapeRef p_shape, MCGPathRef& r_path);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libgraphics/src/graphics-internal.h
+++ b/libgraphics/src/graphics-internal.h
@@ -62,12 +62,12 @@ protected:
     }
 
 private:
-    virtual void Retain(void)
+    void Retain(void)
     {
         m_references += 1;
     }
     
-    virtual void Release(void)
+    void Release(void)
     {
         m_references -= 1;
         if (m_references == 0)
@@ -101,6 +101,20 @@ private:
     }
     
     template<typename T>
+    friend void MCGAssign(T& x_target, T p_source)
+    {
+        if (x_target == p_source)
+        {
+            return;
+        }
+        
+        MCGRetain(p_source);
+        MCGRelease(x_target);
+        
+        x_target = p_source;
+    }
+    
+    template<typename T>
     friend void MCGAssignAndRelease(T& x_target, T p_source)
     {
         if (x_target != nullptr)
@@ -112,6 +126,35 @@ private:
     }
     
     uint32_t m_references;
+};
+
+template<typename T>
+class MCGAuto
+{
+public:
+    MCGAuto(T p_ptr)
+    {
+        m_ptr = MCGRetain(p_ptr);
+    }
+    
+    ~MCGAuto(void)
+    {
+        MCGRelease(m_ptr);
+    }
+    
+    T& operator & (void)
+    {
+        MCAssert(m_ptr == nullptr);
+        return m_ptr;
+    }
+    
+    T operator * (void)
+    {
+        return m_ptr;
+    }
+    
+private:
+    T m_ptr = nullptr;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/src/path.cpp
+++ b/libgraphics/src/path.cpp
@@ -1176,6 +1176,21 @@ bool MCGPathIterate(MCGPathRef self, MCGPathIterateCallback p_callback, void *p_
 				t_point_count = 2;
 				break;
 				
+            case SkPath::kConic_Verb:
+                SkPoint t_conic_quads[5];
+                SkPath::ConvertConicToQuads(t_sk_points[0], t_sk_points[1], t_sk_points[2], t_iter.conicWeight(), t_conic_quads, 1);
+                t_points[0] = MCGPointFromSkPoint(t_conic_quads[1]);
+                t_points[1] = MCGPointFromSkPoint(t_conic_quads[2]);
+                if (!p_callback(p_context, kMCGPathCommandQuadCurveTo, t_points, 2))
+                {
+                    return false;
+                }
+                t_command = kMCGPathCommandQuadCurveTo;
+                t_points[0] = MCGPointFromSkPoint(t_conic_quads[3]);
+                t_points[1] = MCGPointFromSkPoint(t_conic_quads[4]);
+                t_point_count = 2;
+                break;
+                
 			case SkPath::kCubic_Verb:
 				t_command = kMCGPathCommandCubicCurveTo;
 				t_points[0] = MCGPointFromSkPoint(t_sk_points[1]);

--- a/libgraphics/src/shape.cpp
+++ b/libgraphics/src/shape.cpp
@@ -1,0 +1,448 @@
+/* Copyright (C) 2018 LiveCode Ltd.
+ 
+ This file is part of LiveCode.
+ 
+ LiveCode is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License v3 as published by the Free
+ Software Foundation.
+ 
+ LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "graphics.h"
+#include "graphics-internal.h"
+
+#include <SkPathOps.h>
+#include <SkStrokeRec.h>
+#include <SkPathMeasure.h>
+
+/******************************************************************************/
+
+template<typename T, typename ...ArgTs>
+bool MCGShapeNew(MCGShapeRef& r_obj, ArgTs... p_args)
+{
+    T *t_obj = new (nothrow) T(p_args...);
+    if (t_obj == nullptr)
+    {
+        return false;
+    }
+    r_obj = t_obj;
+    return true;
+}
+
+class MCGShape: public MCGObject
+{
+public:
+    virtual ~MCGShape(void) {}
+    
+    virtual bool Resolve(SkPath& r_path) = 0;
+};
+
+/**/
+
+class MCGRectangleShape: public MCGShape
+{
+public:
+    MCGRectangleShape(MCGRectangle p_rectangle)
+        : m_rectangle(p_rectangle)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        r_path.addRect(MCGRectangleToSkRect(m_rectangle));
+        return true;
+    }
+    
+private:
+    MCGRectangle m_rectangle;
+};
+
+bool MCGShapeCreateRectangle(MCGRectangle p_rect, MCGShapeRef& r_shape)
+{
+    return MCGShapeNew<MCGRectangleShape>(r_shape, p_rect);
+}
+
+/**/
+
+class MCGRoundedRectangleShape: public MCGShape
+{
+public:
+    MCGRoundedRectangleShape(MCGRectangle p_rectangle, MCGSize p_radii)
+        : m_rectangle(p_rectangle),
+          m_radii(p_radii)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        r_path.addRoundRect(MCGRectangleToSkRect(m_rectangle), m_radii.width, m_radii.height);
+        return true;
+    }
+
+private:
+    MCGRectangle m_rectangle;
+    MCGSize m_radii;
+};
+
+bool MCGShapeCreateRoundedRectangle(MCGRectangle p_rect, MCGSize p_radii, MCGShapeRef& r_shape)
+{
+    return MCGShapeNew<MCGRoundedRectangleShape>(r_shape, p_rect, p_radii);
+}
+
+/**/
+
+class MCGOvalShape: public MCGShape
+{
+public:
+    MCGOvalShape(MCGRectangle p_rectangle)
+        : m_rectangle(p_rectangle)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        r_path.addOval(MCGRectangleToSkRect(m_rectangle));
+        return true;
+    }
+    
+private:
+    MCGRectangle m_rectangle;
+};
+
+bool MCGShapeCreateEllipse(MCGPoint p_center, MCGSize p_radii, MCGShapeRef& r_shape)
+{
+    return MCGShapeNew<MCGOvalShape>(r_shape, MCGRectangleMake(p_center.x - p_radii.width, p_center.y - p_radii.height, p_radii.width * 2, p_radii.height * 2));
+}
+
+/**/
+
+class MCGLineShape: public MCGShape
+{
+public:
+    MCGLineShape(MCGPoint p_from, MCGPoint p_to)
+        : m_from(p_from), m_to(p_to)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        r_path.moveTo(m_from.x, m_from.y);
+        r_path.lineTo(m_to.x, m_to.y);
+        return true;
+    }
+    
+private:
+    MCGPoint m_from, m_to;
+};
+
+bool MCGShapeCreateLine(MCGPoint p_from, MCGPoint p_to, MCGShapeRef& r_shape)
+{
+    return MCGShapeNew<MCGLineShape>(r_shape, p_from, p_to);
+}
+
+/**/
+
+bool MCGShapeCreatePolyline(const MCGPoint* p_points, uindex_t p_arity, MCGShapeRef& r_shape);
+bool MCGShapeCreatePolygon(const MCGPoint* p_points, uindex_t p_arity, MCGShapeRef& r_shape);
+
+/**/
+
+class MCGPathShape: public MCGShape
+{
+public:
+    MCGPathShape(MCGPathRef p_path)
+    {
+        m_path = MCGPathRetain(p_path);
+    }
+    
+    ~MCGPathShape(void)
+    {
+        MCGPathRelease(m_path);
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        r_path = *m_path->path;
+        return true;
+    }
+
+private:
+    MCGPathRef m_path = nullptr;
+};
+
+bool MCGShapeCreatePath(MCGPathRef p_path, MCGShapeRef& r_shape)
+{
+    return MCGShapeNew<MCGPathShape>(r_shape, p_path);
+}
+    
+/**/
+
+class MCGTransformedShape: public MCGShape
+{
+public:
+    MCGTransformedShape(MCGShapeRef p_shape, MCGAffineTransform p_transform)
+        : m_shape(p_shape),
+          m_transform(p_transform)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        if (!(*m_shape)->Resolve(r_path))
+        {
+            return false;
+        }
+        
+        SkMatrix t_matrix;
+        MCGAffineTransformToSkMatrix(m_transform, t_matrix);
+        
+        r_path.transform(t_matrix);
+        
+        return true;
+    }
+
+private:
+    MCGAuto<MCGShapeRef> m_shape;
+    MCGAffineTransform m_transform;
+};
+
+bool MCGShapeTransform(MCGShapeRef p_shape, MCGAffineTransform p_transform, MCGShapeRef& r_new_shape)
+{
+    return MCGShapeNew<MCGTransformedShape>(r_new_shape, p_shape, p_transform);
+}
+
+/**/
+
+class MCGFilledShape: public MCGShape
+{
+public:
+    MCGFilledShape(MCGShapeRef p_shape, MCGFillRule p_fill_rule)
+        : m_shape(p_shape),
+          m_fill_rule(p_fill_rule)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        if (!(*m_shape)->Resolve(r_path))
+        {
+            return false;
+        }
+        
+        r_path.setFillType(m_fill_rule == kMCGFillRuleNonZero ? SkPath::kWinding_FillType : SkPath::kEvenOdd_FillType);
+        return Simplify(r_path, &r_path);
+    }
+    
+private:
+    MCGAuto<MCGShapeRef> m_shape;
+    MCGFillRule m_fill_rule;
+};
+
+bool MCGShapeFill(MCGShapeRef p_shape, MCGFillRule p_fill_rule, MCGShapeRef& r_new_shape)
+{
+    return MCGShapeNew<MCGFilledShape>(r_new_shape, p_shape, p_fill_rule);
+}
+
+/**/
+
+bool MCGShapeDash(MCGShapeRef p_shape, const MCGFloat *p_lengths, uindex_t p_arity, MCGFloat p_offset, MCGShapeRef& r_shape);
+
+/**/
+
+class MCGThickenedShape: public MCGShape
+{
+public:
+    MCGThickenedShape(MCGShapeRef p_shape, MCGFloat p_width, MCGCapStyle p_cap, MCGJoinStyle p_join, MCGFloat p_miter_limit)
+        : m_shape(p_shape),
+          m_width(p_width),
+          m_cap(p_cap),
+          m_join(p_join),
+          m_miter_limit(p_miter_limit)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        if (!(*m_shape)->Resolve(r_path))
+        {
+            return false;
+        }
+        
+        SkStrokeRec t_stroke(SkStrokeRec::kFill_InitStyle);
+        t_stroke.setResScale(16.0);
+        t_stroke.setStrokeStyle(m_width, false);
+        t_stroke.setStrokeParams(MCGCapStyleToSkCapStyle(m_cap),
+                                 MCGJoinStyleToSkJoinStyle(m_join),
+                                 m_miter_limit);
+        return t_stroke.applyToPath(&r_path, r_path);
+    }
+    
+private:
+    MCGAuto<MCGShapeRef> m_shape;
+    MCGFloat m_width;
+    MCGCapStyle m_cap;
+    MCGJoinStyle m_join;
+    MCGFloat m_miter_limit;
+};
+
+bool MCGShapeThicken(MCGShapeRef p_shape, MCGFloat p_width, MCGCapStyle p_cap, MCGJoinStyle p_join, MCGFloat p_miter_limit, MCGShapeRef& r_new_shape)
+{
+    return MCGShapeNew<MCGThickenedShape>(r_new_shape, p_shape, p_width, p_cap, p_join, p_miter_limit);
+}
+
+/**/
+
+class MCGCombinedShape: public MCGShape
+{
+public:
+    MCGCombinedShape(MCGShapeRef p_left, MCGShapeOperation p_operation, MCGShapeRef p_right)
+        : m_left(p_left),
+          m_right(p_right),
+          m_operation(p_operation)
+    {
+    }
+    
+    bool Resolve(SkPath& r_path)
+    {
+        if (!(*m_left)->Resolve(r_path))
+        {
+            return false;
+        }
+        
+        SkPath t_right;
+        if (!(*m_right)->Resolve(t_right))
+        {
+            return false;
+        
+        }
+        
+        SkPathOp t_op;
+        switch(m_operation)
+        {
+            case kMCGShapeOperationAppend:
+                r_path.addPath(t_right, SkPath::kAppend_AddPathMode);
+                return true;
+            case kMCGShapeOperationExtend:
+                r_path.addPath(t_right, SkPath::kExtend_AddPathMode);
+                return true;
+            case kMCGShapeOperationUnion:
+                t_op = kUnion_SkPathOp;
+                break;
+            case kMCGShapeOperationIntersect:
+                t_op = kIntersect_SkPathOp;
+                break;
+            case kMCGShapeOperationDifference:
+                t_op = kDifference_SkPathOp;
+                break;
+            case kMCGShapeOperationXor:
+                t_op = kXOR_SkPathOp;
+                break;
+        }
+        
+        return Op(r_path, t_right, t_op, &r_path);
+    };
+    
+private:
+    MCGAuto<MCGShapeRef> m_left;
+    MCGAuto<MCGShapeRef> m_right;
+    MCGShapeOperation m_operation;
+};
+
+bool MCGShapeCombine(MCGShapeRef p_shape, MCGShapeOperation p_operation, MCGShapeRef p_other_shape, MCGShapeRef& r_new_shape)
+{
+    return MCGShapeNew<MCGCombinedShape>(r_new_shape, p_shape, p_operation, p_other_shape);
+}
+
+/**/
+
+MCGShapeRef MCGShapeRetain(MCGShapeRef p_shape)
+{
+    MCGRetain(p_shape);
+    return p_shape;
+}
+
+void MCGShapeRelease(MCGShapeRef p_shape)
+{
+    MCGRelease(p_shape);
+}
+
+bool MCGShapeMeasure(MCGShapeRef p_shape, MCGFloat& r_length)
+{
+    SkPath t_path;
+    if (!p_shape->Resolve(t_path))
+    {
+        return false;
+    }
+    
+    SkPathMeasure t_measure(t_path, false);
+    
+    r_length = t_measure.getLength();
+    
+    return true;
+}
+
+bool MCGShapeHull(MCGShapeRef p_shape, MCGRectangle& r_hull)
+{
+    SkPath t_path;
+    if (!p_shape->Resolve(t_path))
+    {
+        return false;
+    }
+    
+    r_hull = MCGRectangleFromSkRect(t_path.getBounds());
+
+    return true;
+}
+
+bool MCGShapeBounds(MCGShapeRef p_shape, MCGRectangle& r_bounds)
+{
+    SkPath t_path;
+    if (!p_shape->Resolve(t_path))
+    {
+        return false;
+    }
+    
+    SkRect t_bounds;
+    if (!TightBounds(t_path, &t_bounds))
+    {
+        return false;
+    }
+    
+    r_bounds = MCGRectangleFromSkRect(t_bounds);
+    
+    return true;
+}
+
+bool MCGShapeFlatten(MCGShapeRef p_shape, MCGPathRef& r_path)
+{
+    SkPath t_sk_path;
+    if (!p_shape->Resolve(t_sk_path))
+    {
+        return false;
+    }
+    
+    MCGPathRef t_path;
+    if (!MCMemoryNew(t_path))
+    {
+        return false;
+    }
+    
+    t_path->is_valid = true;
+    t_path->is_mutable = false;
+    t_path->references = 1;
+    t_path->path = new (nothrow) SkPath(t_sk_path);
+    
+    r_path = t_path;
+    
+    return true;
+    
+}
+
+/******************************************************************************/
+


### PR DESCRIPTION
This patch contains an implementation of a graphics 'shape' abstraction in libgraphics, together with a simple internal call which turns a LC array representation of a shape expression into a shape object and then flattens it to a path.

The operations provided are boolean (union, intersection etc.), fill, dash, thicken, transform (some are yet to be implemented in the higher level internal call wrapper).

Unfortunately, there seems to be some numerical / intersection / collinearity issues in the version of the Skia PathOps we have. Simple expressions work, but when doing unions of thickened lines (in particular) there seem to be problems.