### PR TITLE
[[ TileCache ]] Selection Layer

### DIFF
--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -56,6 +56,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "vclip.h"
 #include "redraw.h"
 #include "widget.h"
+#include "graphics_util.h"
 
 #include "globals.h"
 #include "mctheme.h"
@@ -665,8 +666,10 @@ Boolean MCCard::mfocus(int2 x, int2 y)
 
 				MCRedrawUnlockScreen();
 
-				// MW-2011-08-19: [[ Layers ]] Ensure the selection rect is updated.
-				layer_selectedrectchanged(oldrect, selrect);
+                /* The set of selected controls has changed so dirty the old
+                 * rect, and the new. */
+				dirtyselection(oldrect);
+                dirtyselection(selrect);
 			}
 			message_with_args(MCM_mouse_move, x, y);
 			return true;
@@ -918,8 +921,10 @@ Boolean MCCard::mup(uint2 which, bool p_release)
 				if (state & CS_SIZE)
 				{
 					state &= ~CS_SIZE;
-					// MW-2011-08-18: // MW-2011-08-19: [[ Layers ]] Ensure the selection rect is updated.
-					layer_dirtyrect(selrect);
+                    
+                    /* The selection marquee has finished, so update the selection
+                     * layer. */
+                    dirtyselection(selrect);
 					
 					// MM-2012-11-05: [[ Object selection started/ended message ]]
 					if (m_selecting_objects)
@@ -3028,78 +3033,51 @@ void MCCard::drawbackground(MCContext *p_context, const MCRectangle &p_dirty)
 	p_context->fillrect(p_dirty);
 }
 
-// IM-2013-09-13: [[ RefactorGraphics ]] Factor out card selection rect drawing to separate method
-void MCCard::drawselectionrect(MCContext *p_context)
-{
-    drawmarquee(p_context, selrect);
-}
-
-void MCCard::drawselectedchildren(MCDC *dc)
+/* The card's drawselection method first renders the selections of all children
+ * and then renders the marquee. */
+void MCCard::drawselection(MCContext *p_context, const MCRectangle& p_dirty)
 {
     MCObjptr *tptr = objptrs;
     if (tptr == nil)
         return;
+
     do
     {
         MCControl *t_control = tptr->getref();
-        if (t_control != nullptr)
+        if (t_control != nullptr &&
+            t_control->getopened() != 0 &&
+            (t_control->getflag(F_VISIBLE) || showinvisible()))
         {
-            if (tptr -> getref() -> getstate(CS_SELECTED))
-                tptr->getref()->drawselected(dc);
-        
-            if (tptr -> getrefasgroup() != nil)
-                tptr -> getrefasgroup() -> drawselectedchildren(dc);
+            t_control->drawselection(p_context, p_dirty);
         }
             
         tptr = tptr->next();
     }
     while (tptr != objptrs);
+    
+    if (getstate(CS_SIZE))
+    {
+        drawmarquee(p_context, selrect);
+    }
 }
 
 void MCCard::dirtyselection(const MCRectangle &p_rect)
 {
-	// redraw marquee rect
-	// selrect with 0 width or height will still draw a 1px line, so increase rect size to account for this.
-	layer_dirtyrect(MCU_reduce_rect(p_rect, -1));
-	
-	// redraw selection handles
-	MCRectangle t_handles[8];
-	MCControl::sizerects(p_rect, t_handles);
-
-	for (uint32_t i = 0; i < 8; i++)
-		layer_dirtyrect(t_handles[i]);
-}
-
-bool MCCard::updatechildselectedrect(MCRectangle& x_rect)
-{
-    bool t_updated;
-    t_updated = false;
+    MCRectangle t_rect = MCU_reduce_rect(p_rect, -(1 + MCsizewidth / 2));
     
-    MCObjptr *t_objptr = objptrs;
-    if (t_objptr == nil)
-        return t_updated;
-    do
+    MCTileCacheRef t_tilecache = getstack()->view_gettilecache();
+    if (t_tilecache != nullptr)
     {
-        MCControl *t_control;
-        t_control = t_objptr -> getref();
+        MCGAffineTransform t_transform =
+                getstack()->getdevicetransform();
         
-        if (t_control -> getstate(CS_SELECTED))
-        {
-            x_rect = MCU_union_rect(t_control -> geteffectiverect(), x_rect);
-            t_updated = true;
-        }
+        MCRectangle32 t_device_rect =
+                MCRectangle32GetTransformedBounds(t_rect, t_transform);
         
-        if (t_control -> gettype() == CT_GROUP)
-        {
-            MCGroup *t_group = static_cast<MCGroup *>(t_control);
-            t_updated = t_updated | t_group -> updatechildselectedrect(x_rect);
-        }
-        
-        t_objptr = t_objptr->next();
+        MCTileCacheUpdateScenery(t_tilecache, m_fg_layer_id, t_device_rect);
     }
-    while (t_objptr != objptrs);
     
-    return t_updated;
+    layer_dirtyrect(t_rect);
 }
 
 void MCCard::draw(MCDC *dc, const MCRectangle& dirty, bool p_isolated)
@@ -3127,18 +3105,14 @@ void MCCard::draw(MCDC *dc, const MCRectangle& dirty, bool p_isolated)
 		}
 		while (tptr != objptrs);
 	}
-    
-    // Draw the selection outline and handles on top of everything
-    drawselectedchildren(dc);
-    
+
 	dc -> setopacity(255);
 	dc -> setfunction(GXcopy);
 
 	if (t_draw_cardborder)
 		drawcardborder(dc, dirty);
 	
-	if (getstate(CS_SIZE))
-		drawselectionrect(dc);
+    drawselection(dc, dirty);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -216,15 +216,14 @@ public:
 	
 	// IM-2013-09-13: [[ RefactorGraphics ]] render the card background
 	void drawbackground(MCContext *p_context, const MCRectangle &p_dirty);
-	// IM-2013-09-13: [[ RefactorGraphics ]] render the card selection rect
-	void drawselectionrect(MCContext *);
-    void drawselectedchildren(MCDC *dc);
-	
+    
+    /* The drawselection method renders the 'selection layer' - i.e. all the
+     * selection decorations for all controls on the card. */
+    void drawselection(MCContext *p_context, const MCRectangle& p_dirty);
+    
 	// IM-2016-09-26: [[ Bug 17247 ]] request redraw of the area occupied by
 	//      selection marquee + handles
 	void dirtyselection(const MCRectangle &p_rect);
-	
-    bool updatechildselectedrect(MCRectangle& x_rect);
     
 	Exec_stat openbackgrounds(bool p_is_preopen, MCCard *p_other);
 	Exec_stat closebackgrounds(MCCard *p_other);
@@ -240,8 +239,6 @@ public:
 	void layer_removed(MCControl *control, MCObjptr *previous, MCObjptr *next);
 	// MW-2011-08-19: [[ Layers ]] The viewport displayed in the stack has changed.
 	void layer_setviewport(int32_t x, int32_t y, int32_t width, int32_t height);
-	// MW-2011-09-23: [[ Layers ]] The selected rectangle has changed.
-	void layer_selectedrectchanged(const MCRectangle& old_rect, const MCRectangle& new_rect);
 
 	// MW-2011-08-26: [[ TileCache ]] Render all layers into the stack's tilecache.
 	void render(void);

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -428,13 +428,6 @@ void MCControl::select()
 	state |= CS_SELECTED;
 	kunfocus();
 
-	// MW-2011-09-23: [[ Layers ]] Mark the layer attrs as having changed - the selection
-	//   setting can influence the layer type.
-	m_layer_attr_changed = true;
-
-	// MW-2011-08-18: [[ Layers ]] Invalidate the whole object.
-	layer_redrawall();
-	
 	getcard()->dirtyselection(rect);
 }
 
@@ -442,13 +435,6 @@ void MCControl::deselect()
 {
 	if (state & CS_SELECTED)
 	{
-		// MW-2011-09-23: [[ Layers ]] Mark the layer attrs as having changed - the selection
-		//   setting can influence the layer type.
-		m_layer_attr_changed = true;
-
-		// MW-2011-08-18: [[ Layers ]] Invalidate the whole object.
-		layer_redrawall();
-        
 		getcard()->dirtyselection(rect);
 
         state &= ~(CS_SELECTED | CS_MOVE | CS_SIZE | CS_CREATE);
@@ -869,10 +855,14 @@ void MCControl::sizerects(const MCRectangle &p_object_rect, MCRectangle r_rects[
 			}
 }
 
-void MCControl::drawselected(MCDC *dc)
+void MCControl::drawselection(MCDC *dc, const MCRectangle& p_dirty)
 {
-    if (!opened || !(getflag(F_VISIBLE) || showinvisible()))
+    MCAssert(getopened() != 0 && (getflag(F_VISIBLE) || showinvisible()));
+    
+    if (!getselected())
+    {
         return;
+    }
     
 	if (MCdragging)
 		return;

--- a/engine/src/edittool.cpp
+++ b/engine/src/edittool.cpp
@@ -128,8 +128,8 @@ bool MCGradientEditTool::mfocus(int2 x, int2 y)
 		return false;
 	}
 
-	MCRectangle t_old_effectiverect;
-	t_old_effectiverect = graphic -> geteffectiverect();
+    /* Dirty the current edit tool draw rect in the selection layer. */
+    graphic->getcard()->dirtyselection(drawrect());
 
 	switch (m_gradient_edit_point)
 	{
@@ -191,8 +191,11 @@ bool MCGradientEditTool::mfocus(int2 x, int2 y)
 	gradient->old_origin.x = MININT2;
 	gradient->old_origin.y = MININT2;
 
-	// MW-2011-08-18: [[ Layers ]] Notify the graphic its effective rect has changed and invalidate all.
-	graphic -> layer_effectiverectchangedandredrawall(t_old_effectiverect);
+    /* Dirty the new edit tool draw rect in the selection layer. */
+    graphic->getcard()->dirtyselection(drawrect());
+    
+    /* Mark the graphic's content as needing redrawn. */
+    graphic->layer_redrawall();
 
 	graphic->message_with_args(MCM_mouse_move, x, y);
 
@@ -269,39 +272,6 @@ MCRectangle MCGradientEditTool::drawrect()
 	gradient_rects(rects);
 	drect = MCU_union_rect(rects[0], rects[1]);
 	return MCU_union_rect(drect, rects[2]);
-}
-
-MCRectangle MCGradientEditTool::minrect()
-{
-	int4 minx, miny, maxx, maxy;
-	minx = MAXINT4;  miny = MAXINT4;
-	maxx = MININT4;  maxy = MININT4;
-
-	MCRectangle rect = {MININT2,MININT2,0,0};
-
-	if (gradient != NULL)
-	{
-		minx = MCU_min(gradient->origin.x, gradient->primary.x);
-		maxx = MCU_max(gradient->origin.x, gradient->primary.x);
-
-		minx = MCU_min(minx, gradient->secondary.x);
-		maxx = MCU_max(maxx, gradient->secondary.x);
-
-		miny = MCU_min(gradient->origin.y, gradient->primary.y);
-		maxy = MCU_max(gradient->origin.y, gradient->primary.y);
-
-		miny = MCU_min(miny, gradient->secondary.y);
-		maxy = MCU_max(maxy, gradient->secondary.y);
-
-		if (minx <= maxx && miny <= maxy)
-		{
-			rect.x = minx;
-			rect.y = miny;
-			rect.width = maxx - minx ;
-			rect.height = maxy - miny;
-		}
-	}
-	return rect;
 }
 
 MCPolygonEditTool::MCPolygonEditTool(MCGraphic *p_graphic) :
@@ -491,10 +461,4 @@ MCRectangle MCPolygonEditTool::drawrect()
 		drect = MCU_union_rect(drect, t_rects[i]);
 	}
 	return drect;
-}
-
-MCRectangle MCPolygonEditTool::minrect()
-{
-	MCRectangle rect = {MININT2,MININT2,0,0};
-	return rect;
 }

--- a/engine/src/edittool.h
+++ b/engine/src/edittool.h
@@ -40,7 +40,6 @@ public:
 	virtual void drawhandles(MCDC *dc) = 0;
 	virtual uint4 handle_under_point(int2 x, int2 y) = 0;
 	virtual MCRectangle drawrect() = 0;
-	virtual MCRectangle minrect() = 0;
 	virtual MCEditMode type() = 0;
 };
 
@@ -53,7 +52,6 @@ public:
 	void drawhandles(MCDC *dc);
 	uint4 handle_under_point(int2 x, int2 y);
 	MCRectangle drawrect();
-	MCRectangle minrect();
 	MCEditMode type();
 
 	MCGradientEditTool(MCGraphic *p_graphic, MCGradientFill *p_gradient, MCEditMode p_mode);
@@ -76,7 +74,6 @@ public:
 	void drawhandles(MCDC *dc);
 	uint4 handle_under_point(int2 x, int2 y);
 	MCRectangle drawrect();
-	MCRectangle minrect();
 	MCEditMode type();
 
 	MCPolygonEditTool(MCGraphic *p_graphic);

--- a/engine/src/graphic.h
+++ b/engine/src/graphic.h
@@ -114,6 +114,10 @@ public:
 
 	// MW-2011-09-06: [[ Redraw ]] Added 'sprite' option - if true, ink and opacity are not set.
 	virtual void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite);
+    
+    /* The drawselection method of the graphic renders any editMode decorations
+     * which have been requested. */
+    virtual void drawselection(MCDC *dc, const MCRectangle& dirty);
 
 	virtual Boolean maskrect(const MCRectangle &srect);
 	virtual void fliph();
@@ -128,7 +132,6 @@ public:
 	MCRectangle expand_minrect(const MCRectangle &trect);
 	MCRectangle reduce_minrect(const MCRectangle &trect);
 	void compute_minrect();
-	virtual MCRectangle geteffectiverect(void) const;
 	void delpoints();
 	bool closepolygon(MCPoint *&pts, uint2 &npts);
 	MCStringRef getlabeltext();
@@ -167,6 +170,8 @@ public:
     void DoSetGradientFill(MCExecContext& ctxt, MCGradientFill*& p_fill, Draw_index p_di, MCNameRef p_prop, MCExecValue p_value);
     
     void DoCopyPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points, uindex_t& r_count, MCPoint*& r_points);
+    
+    void SetPointsCommon(MCExecContext& ctxt, uindex_t p_count, MCPoint* p_points, bool p_is_relative);
 
 	////////// PROPERTY ACCESSORS
 

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -2156,54 +2156,31 @@ void MCGroup::boundcontrols()
 	}
 }
 
-void MCGroup::drawselectedchildren(MCDC *dc)
+void MCGroup::drawselection(MCDC *p_context, const MCRectangle& p_dirty)
 {
-    if (!opened || !(getflag(F_VISIBLE) || showinvisible()))
-        return;
+    MCAssert(getopened() != 0 && (getflag(F_VISIBLE) || showinvisible()));
     
     MCControl *t_control = controls;
     if (t_control == nil)
         return;
-    do
-    {
-        if (t_control -> getstate(CS_SELECTED))
-            t_control -> drawselected(dc);
-        
-        if (t_control -> gettype() == CT_GROUP)
-            static_cast<MCGroup *>(t_control) -> drawselectedchildren(dc);
-        
-        t_control = t_control -> next();
-    }
-    while (t_control != controls);
-}
-
-bool MCGroup::updatechildselectedrect(MCRectangle& x_rect)
-{
-    bool t_updated;
-    t_updated = false;
     
-    MCControl *t_control = controls;
-    if (t_control == nil)
-        return t_updated;
     do
     {
-        if (t_control -> getstate(CS_SELECTED))
+        if (t_control != nullptr &&
+             t_control->getopened() != 0 &&
+             (t_control->getflag(F_VISIBLE) || showinvisible()))
         {
-            x_rect = MCU_union_rect(t_control -> geteffectiverect(), x_rect);
-            t_updated = true;
-        }
-        
-        if (t_control -> gettype() == CT_GROUP)
-        {
-            MCGroup *t_group = static_cast<MCGroup *>(t_control);
-            t_updated = t_updated | t_group -> updatechildselectedrect(x_rect);
+            t_control->drawselection(p_context, p_dirty);
         }
         
         t_control = t_control -> next();
     }
     while (t_control != controls);
     
-    return t_updated;
+    if (getselected())
+    {
+        MCControl::drawselection(p_context, p_dirty);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -153,8 +153,9 @@ public:
     
     virtual bool isdeletable(bool p_check_flag);
     
-    void drawselectedchildren(MCDC *dc);
-    bool updatechildselectedrect(MCRectangle& x_rect);
+    /* The drawselection method of the group recurses to draw all child control
+     * selection decorations. */
+    virtual void drawselection(MCDC *dc, const MCRectangle& p_dirty);
     
 	MCControl *findchildwithid(Chunk_term type, uint4 p_id);
 

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -165,7 +165,10 @@ public:
 	// IM-2016-09-26: [[ Bug 17247 ]] Return rect of selection handles for the given object rect
 	static void sizerects(const MCRectangle &p_object_rect, MCRectangle rects[8]);
 	
-	void drawselected(MCDC *dc);
+    /* The drawselection method should render any selection / edit related
+     * decorations the control currently has. */
+	virtual void drawselection(MCDC *dc, const MCRectangle& p_dirty);
+    
 	void drawarrow(MCDC *dc, int2 x, int2 y, uint2 size,
 	               Arrow_direction dir, Boolean border, Boolean hilite);
 	void continuesize(int2 x, int2 y);

--- a/engine/src/player-legacy.cpp
+++ b/engine/src/player-legacy.cpp
@@ -933,12 +933,8 @@ void MCPlayer::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 	
 	if (!p_isolated)
 	{
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
-	}
-    
-	if (!p_isolated)
 		dc -> end();
+	}
 }
 
     

--- a/engine/src/player-srv-stubs.cpp
+++ b/engine/src/player-srv-stubs.cpp
@@ -772,12 +772,8 @@ void MCPlayer::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 	
 	if (!p_isolated)
 	{
-		if (getstate(CS_SELECTED))
-			drawselected(dc);
-	}
-    
-	if (!p_isolated)
 		dc -> end();
+	}
 }
 
 //  Redraw Management

--- a/engine/src/tilecache.cpp
+++ b/engine/src/tilecache.cpp
@@ -1487,8 +1487,8 @@ void MCTileCacheEndFrame(MCTileCacheRef self)
 
 	// Some statistics
 #ifdef _DEBUG
-    //MCLog("Frame - %d sprite tiles, %d scenery tiles, %d active tiles, %d instructions, %d bytes",
-    //			self -> sprite_render_list . length, self -> scenery_render_list . length, self -> active_tile_count, self -> display_list_frontier, self -> cache_size);
+    MCLog("Frame - %d sprite tiles, %d scenery tiles, %d active tiles, %d instructions, %d bytes",
+    			self -> sprite_render_list . length, self -> scenery_render_list . length, self -> active_tile_count, self -> display_list_frontier, self -> cache_size);
 #endif
 }
 


### PR DESCRIPTION
This patch ensures that all selection related decorations (i.e.
size handles and edit-tool handlers) are drawn in the card's
foreground layer, and any changes to their appearance causes
that layer to be dirtied in the appropriate places.

This fixes a number of rendering issues with selection handles
both in accelerated rendering mode and outside of it.