### PR TITLE
[Dictionary] Changes from gray to hilitedButtonID

### DIFF
--- a/docs/dictionary/command/group.lcdoc
+++ b/docs/dictionary/command/group.lcdoc
@@ -11,8 +11,6 @@ Associations: group
 
 Introduced: 1.0
 
-Changed: 8.1
-
 OS: mac, windows, linux, ios, android
 
 Platforms: desktop, server, mobile

--- a/docs/dictionary/command/hide-groups.lcdoc
+++ b/docs/dictionary/command/hide-groups.lcdoc
@@ -31,8 +31,8 @@ single <word>. This makes <grouped text> handy to use for <hypertext> or
 
 The <hide groups> <command> sets the <global> <underlineLinks>
 <property> to false. It does not affect the <stack> <underlineLinks>
-<property>, so if a <stack|stack's> <underlineLinks> is true, <hide
-groups> does not remove the underlining in that <stack>.
+<property>, so if a <stack|stack's> <underlineLinks> is true, 
+<hide groups> does not remove the underlining in that <stack>.
 
 References: show groups (command), hide menubar (command),
 global (command), clickChunk (function), mouseChunk (function),

--- a/docs/dictionary/keyword/gRevAppIcon.lcdoc
+++ b/docs/dictionary/keyword/gRevAppIcon.lcdoc
@@ -53,10 +53,10 @@ the <image> <ID> is 3445, you can place the following
 Thereafter, the <ask>, <ask password>, and <answer> <command|commands>
 will use the <image> you specified.
 
->*Note:* If you specify an iconType in the <answer>, <ask>, or <ask
-> password> <command>, the image specified by the <gRevSmallAppIcon>
-> <variable> appears instead, along with the standard icon specified by
-> the iconType.
+>*Note:* If you specify an iconType in the <answer>, <ask>, or 
+> <ask password> <command>, the image specified by the 
+> <gRevSmallAppIcon> <variable> appears instead, along with the 
+> standard icon specified by the iconType.
 
 References: answer (command), ask (command), ask password (command),
 dialog box (glossary), OS X (glossary), variable (glossary),

--- a/docs/dictionary/keyword/gray.lcdoc
+++ b/docs/dictionary/keyword/gray.lcdoc
@@ -23,12 +23,12 @@ Description:
 Use the <gray> <keyword> to transition to a blank gray background in a
 sequence of visual effects.
 
-Visual effects can be stacked in a sequence by using several <visual
-effect> <command|commands> in succession. If the last transition ends
-with showing the destination card, and all except the last one shows an
-intermediate image (such as a solid gray color), the effect is enhanced.
-You show a solid gray color at the end of a transition by using the
-<gray> <keyword>.
+Visual effects can be stacked in a sequence by using several 
+<visual effect> <command|commands> in succession. If the last transition 
+ends with showing the destination card, and all except the last one shows 
+an intermediate image (such as a solid gray color), the effect is 
+enhanced. You show a solid gray color at the end of a transition by 
+using the <gray> <keyword>.
 
 The gray background is actually a checkerboard pattern of alternating
 black and white pixels.

--- a/docs/dictionary/object/group.lcdoc
+++ b/docs/dictionary/object/group.lcdoc
@@ -7,8 +7,7 @@ Type: object
 Syntax: group
 
 Summary:
-A <control(keyword)> that contains other <control(object)|controls>.
-
+A <control(keyword)> that contains other <control(glossary)|controls>.
 Introduced: 1.0
 
 OS: mac, windows, linux, ios, android
@@ -42,7 +41,7 @@ lowest-layered group on the current card.
 
 References: property (glossary), radio button (glossary),
 menu bar (glossary), object type (glossary), card (keyword),
-control (keyword), templateGroup (keyword), scrollbar (object),
+control (glossary), templateGroup (keyword), scrollbar (object),
 control (object), showName (property)
 
 Tags: objects

--- a/docs/dictionary/property/HCAddressing.lcdoc
+++ b/docs/dictionary/property/HCAddressing.lcdoc
@@ -5,9 +5,9 @@ Type: property
 Syntax: set the HCAddressing of <stack> to {true | false}
 
 Summary:
-Determines whether <grouped control|grouped fields> and <card
-control|card buttons> are assumed if the <field> or <button|button's>
-<domain> is not specified.
+Determines whether <grouped control|grouped fields> and 
+<card control|card buttons> are assumed if the <field> or 
+<button|button's> <domain> is not specified.
 
 Associations: stack
 

--- a/docs/dictionary/property/height.lcdoc
+++ b/docs/dictionary/property/height.lcdoc
@@ -46,16 +46,16 @@ window tall enough.
 The <height> of an object cannot be set to zero. Attempting to do so
 will set the <height> to 1 instead.
 
->*Cross-platform note:*  On <Mac OS> and <OS X|OS X systems>, the <menu
-> bar> normally appears at the top of the screen, rather than inside the
-> <stack window>. If a <stack> contains a <menu bar> and the
-> <stack|stack's> <editMenus> <property> is set to false, the <stack
-> window> is automatically resized so that the <menu bar> <group> is not
-> visible in the window. In this case, the <height> of the <stack> is
-> the current height of the <stack window>., but the height of the card
-> is the height of the total content area of the <stack> (including the
-> hidden <menu bar> <group>). This is equal to the <height> of the
-> <stack> plus its <vScroll>.
+>*Cross-platform note:*  On <Mac OS> and <OS X|OS X systems>, the 
+> <menu bar> normally appears at the top of the screen, rather than 
+> inside the <stack window>. If a <stack> contains a <menu bar> and the
+> <stack|stack's> <editMenus> <property> is set to false, the 
+> <stack window> is automatically resized so that the <menu bar> 
+> <group> is not visible in the window. In this case, the <height> of 
+> the <stack> is the current height of the <stack window>, but the height 
+> of the card is the height of the total content area of the <stack> 
+> (including the hidden <menu bar> <group>). This is equal to the 
+> <height> of the <stack> plus its <vScroll>.
 
 You can set the <height> of a <card(keyword)>, but doing so has no
 effect and doesn't change the <card(object)|card's> <height> <property>.

--- a/docs/dictionary/property/hideConsoleWindows.lcdoc
+++ b/docs/dictionary/property/hideConsoleWindows.lcdoc
@@ -28,9 +28,9 @@ applications without the user seeing them.
 On Windows systems, when you run a command line program with the
 <launch> or <open process> <command>, a <console|console window>
 appears. If the <hideConsoleWindows> <property> is true, the window is
-not shown. (You can still use the <write to process> and <read from
-process> <command|commands> to send data to the program and get data
-from it.)
+not shown. (You can still use the <write to process> and 
+<read from process> <command|commands> to send data to the program and 
+get data from it.)
 
 The setting of this property affects Windows applications with a GUI as
 well as command line programs.

--- a/docs/dictionary/property/hiliteColor.lcdoc
+++ b/docs/dictionary/property/hiliteColor.lcdoc
@@ -75,9 +75,9 @@ depending on the <object type>:
 > <backgroundPattern> of the <button(keyword)> and all of its
 > <owner|owners> is empty. In this case, the <button(object)|button's>
 > <hiliteColor> has no effect. Otherwise, the <button(keyword)> is drawn
-> by LiveCode. If the <lookAndFeel> is "Appearance Manager", <button
-> menu|button menus> whose <menuMode> is set to "option" are always
-> drawn by the operating system, and the setting of the
+> by LiveCode. If the <lookAndFeel> is "Appearance Manager", 
+> <button menu|button menus> whose <menuMode> is set to "option" are 
+> always drawn by the operating system, and the setting of the
 > <button(object)|button's> <hiliteColor> does not affect them.
 
 * The <hiliteColor> of a <field(keyword)> determines the background

--- a/docs/dictionary/property/hilitedButton.lcdoc
+++ b/docs/dictionary/property/hilitedButton.lcdoc
@@ -42,12 +42,13 @@ currently <highlight|highlighted>. If the <hilitedButton> is 1, the
 Setting the <hilitedButton> of a <group> sets the <hilite> <property> of
 the rest of the <button(object)|buttons> to false.
 
-The <hilitedButton> <property> is most useful in <radio
-button|radio-button clusters>. In a <radio button|radio-button cluster>,
-only one <button(keyword)> can be <highlight|highlighted> at once:
-clicking another <button(keyword)> unhighlights the first one. The
-<radioBehavior> <property> of a <group> of <button(object)|buttons>
-specifies whether they act as a <radio button|radio-button cluster>.
+The <hilitedButton> <property> is most useful in 
+<radio button|radio-button clusters>. In a 
+<radio button|radio-button cluster>, only one <button(keyword)> can be 
+<highlight|highlighted> at once: clicking another <button(keyword)> 
+unhighlights the first one. The <radioBehavior> <property> of a <group> 
+of <button(object)|buttons> specifies whether they act as a 
+<radio button|radio-button cluster>.
 
 The <hilitedButton>, <hilitedButtonName(property)>, and
 <hilitedButtonID(property)> <property|properties> all refer in different
@@ -55,8 +56,8 @@ ways to the same <button(object)>. When any of them changes, all of them
 change. 
 
 References: hilite (command), group (command), selectedButton (function),
-property (glossary), highlight (glossary), hilitedButtonName (glossary),
-radioBehavior (glossary), radio button (glossary), layer (glossary),
+property (glossary), highlight (glossary), hilitedButtonName (property),
+radioBehavior (property), radio button (glossary), layer (glossary),
 integer (keyword), button (keyword), button (object),
 hilitedButtonName (property), hilitedButtonID (property)
 

--- a/docs/dictionary/property/hilitedButtonID.lcdoc
+++ b/docs/dictionary/property/hilitedButtonID.lcdoc
@@ -50,10 +50,9 @@ The <hilitedButton(property)>, <hilitedButtonName(property)>, and
 the same <button(object)>. When any of them changes, all of them change.
 
 References: hilite (command), group (command), property (glossary),
-highlight (glossary), hilitedButtonName (glossary),
-radio button (glossary), radioBehavior (glossary), button (keyword),
-button (object), hilitedButton(property) hilitedButtonName (property),
-ID (property)
+highlight (glossary), radio button (glossary), radioBehavior (property), 
+button (keyword), button (object), hilitedButton (property), 
+hilitedButtonName (property), ID (property)
 
 Tags: ui
 

--- a/docs/glossary/g/grouped-control.lcdoc
+++ b/docs/glossary/g/grouped-control.lcdoc
@@ -6,7 +6,7 @@ grouped object
 Type: glossary
 
 Description:
-A <control>, such as a <button> or <field,> that is part of a <group>.
+A <control>, such as a <button> or <field>, that is part of a <group>.
 
 References: control (glossary), button (glossary), field (glossary),
 group (glossary)


### PR DESCRIPTION
keyword/gray.lcdoc - Fixed broken link.
keyword/gRevAppIcon.lcdoc - Fixed broken link.
object/group.lcdoc - Changed control(object) to control(glossary)
command/group.lcdoc - Removed Changed section; dictionary doesn’t seem to recognise it.
glossary/g/grouped-control - Fixed broken link.
property/HCAddressing.lcdoc - Fixed broken link.
property/height.lcdoc - Fixed broken links.
command/hide-groups.lcdoc - Fixed broken link.
property/hiliteColor.lcdoc - Fixed broken link
property/hilitedButton.lcdoc - Fixed broken link, changed some references to properties to be marked as properties instead of glossary entries.
property/hilitedButtonID.lcdoc - Added missing comma separator for references, removed redundant and incorrectly marked reference, changed a reference to be marked as property instead of a glossary entry.