### PR TITLE
[Bug 20849] Fix crash saving images to iOS device photo library

### DIFF
--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -122,6 +122,8 @@
 	<string>This application requires access to your Reminders</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This application requires access to Photo Library</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>This application requires access to read the user's health data</string>
 	<key>NSHealthUpdateUsageDescription</key>


### PR DESCRIPTION
This bug was previously fixed for iOS simulator. This patch fixes it for iOS device too.