### PR TITLE
[[ Bug 20856 ]] Enable sub-pixel positioning in CoreText rendering

### DIFF
--- a/docs/notes/bugfix-20856.md
+++ b/docs/notes/bugfix-20856.md
@@ -1,0 +1,1 @@
+# Use sub-pixel positioning when rendering text on iOS/Mac.

--- a/libgraphics/src/coretext-skia.cpp
+++ b/libgraphics/src/coretext-skia.cpp
@@ -268,6 +268,9 @@ void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uin
     // Ensure we use anti-aliasing
     t_paint.setAntiAlias(true);
     
+    // Ensure we use subpixel positioning
+    t_paint.setSubpixelText(true);
+    
     // We are going to draw text by glyph ID rather than by codeunit
     t_paint.setTextEncoding(SkPaint::kGlyphID_TextEncoding);
     


### PR DESCRIPTION
This patch ensures that the 'setSubpixelText' flag is set to true
in the Skia paint used to render text on the CoreText implementation
of libgraphics text operations.

This change only effects the visual presentation of text - the metrics
(as seen by anything higher up) is unchanged. Previously Skia would
have been aligning the individual glyphs to device pixel boundaries
resulting in a subtle misplacement, noticeable when comparing with
the same text rendered in other CoreText using applications.