### PR TITLE
[[Bug 19206]] Clipboard always converts plain text to styled text

### DIFF
--- a/docs/dictionary/property/clipboardData.lcdoc
+++ b/docs/dictionary/property/clipboardData.lcdoc
@@ -88,12 +88,18 @@ places the text "Hello World" on the <clipboard(glossary)>:
 
     set the clipboardData["text"] to "Hello World"
 
+The above statement will only place plain text on the clipboard, similar
+to using the copy command from a text only editor.
+
+    set the clipboardData["html"] to "&lt;p&gt;Hello World&lt;/p&gt;"
 
 The above statement is equivalent to selecting the text "Hello World"
-in a field and choosing Edit menu, or to using the <copy> command. The
-data you place on the <clipboard(glossary)> is accessible to your
-application using the <paste> command, and to other applications (that
-support pasting text) using the application's Paste menu item.
+in a field and choosing Copy Text from the Edit menu, or to using the 
+<copy> command (chunk of field syntax) since styled text is placed on 
+the clipboard by default. The data you place on the 
+<clipboard(glossary)> is accessible to your application using the 
+<paste> command, and to other applications (that support pasting text) 
+using the application's Paste menu item.
 
 >*Tip:*  To quickly find out what kind of data is on the clipboard, use 
 the <clipboard> function.

--- a/docs/dictionary/property/fullClipboardData.lcdoc
+++ b/docs/dictionary/property/fullClipboardData.lcdoc
@@ -59,9 +59,9 @@ another app, the <clipboard(glossary)> will be automatically cleared
 when written to. If you want to do this explicitly, use 
 `set the fullClipboardData to empty`.
 
-The `text`, `rtftext`, `htmltext`, `styles` and `styledtext` 
-properties are handled specially by LiveCode: adding any one of them 
-will cause the rest to be automatically generated and added. You can 
+The `rtftext`, `htmltext`, `styles` and `styledtext` properties are 
+handled specially by LiveCode: adding any one of them will cause the 
+rest (plus `text`) to be automatically generated and added. You can 
 query the keys of the <fullClipboardData> to determine what types of 
 data are on the <clipboard(glossary)>.
 

--- a/docs/dictionary/property/rawClipboardData.lcdoc
+++ b/docs/dictionary/property/rawClipboardData.lcdoc
@@ -56,18 +56,15 @@ This property should only be used if you require low-level access; the
 
 As a low-level feature, platform differences are not hidden. In 
 particular, the form of the keys of the <rawClipboardData> are 
-platform-specific, but can be summarised as:
+platform-specific, but can be summarized as:
 
  - Windows: arbitrary strings but keys of the form CF_xxx correspond to 
-
-    the <clipboard(glossary)> formats defined by Windows itself
- - OSX: Uniform Type Identifiers (UTIs) with an extension: 
-
-    OSTypes/MIME-types can be used by prefixing the key with
-    com.apple.ostype:/public.mime-type: 
+   the <clipboard(glossary)> formats defined by Windows itself
+ - OSX: Uniform Type Identifiers (UTIs) with an extension. 
+   OSTypes/MIME-types can be used by prefixing the key with
+   com.apple.ostype:/public.mime-type: 
  - Linux: arbitrary strings (X11 atoms) but, by convention, MIME types 
-
-    are used
+   are used
 
 
 >*Tip:* All contents of the <rawClipboardData> are binary - use the 

--- a/docs/notes/bugfix-19206.md
+++ b/docs/notes/bugfix-19206.md
@@ -1,0 +1,7 @@
+# clipboard always converts plain text to styled text
+
+Whenever `text` was placed on the clipboard, it was first converted to
+LiveCode styled text and then put on the clipboard as styled text, RTF,
+HTML, and plain text.  This introduced errors when pasting to other
+applications since they would prefer the HTML version which made the
+text appear double spaced.


### PR DESCRIPTION
Whenever `text` was placed on the clipboard, it was first converted to LiveCode styled text and then put on the clipboard as styled text, RTF, HTML, and plain text.  This introduced errors when pasting to other applications since they would prefer the HTML version which made the text appear double spaced.

Updated `MCClipboard::AddText` such that is will clear the clipboard and only place the plain text representations on the clipboard.  The clipboard needed to be cleared to avoid the HTML/RTF from a previous copy being left on the clipboard which would cause issues when attempting to paste.

Updated related documentation to clarify that placing styled text on the clipboard will convert to the other representations, but plain text will not.  Using the copy text menu command will take styled text as will the copy command (chunk of field syntax).