### PR TITLE
[[ ImageFormat ]] Make image in format

### DIFF
--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -2079,6 +2079,7 @@ public foreign handler MCCanvasImageMakeWithPath(in pPath as String, out rImage 
 public foreign handler MCCanvasImageMakeWithResourceFile(in pResourcePath as String, out rImage as Image) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasImageMakeWithData(in pData as Data, out rImage as Image) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasImageMakeWithPixels(in pWidth as LCInt, in pHeight as LCInt, in pPixels as Data, out rImage as Image) returns nothing binds to "<builtin>"
+public foreign handler MCCanvasImageMakeWithPixelsInFormat(in pWidth as LCInt, in pHeight as LCInt, in pPixels as Data, in pFormat as LCInt, out rImage as Image) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasImageMakeWithPixelsWithSizeAsList(in pSize as List, in pPixels as Data, out rImage as Image) returns nothing binds to "<builtin>"
 
 //////////

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -1907,13 +1907,20 @@ void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &r_image)
 }
 
 // Input should be unpremultiplied ARGB pixels
+
 MC_DLLEXPORT_DEF
 void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCCanvasImageRef &r_image)
+{
+    MCCanvasImageMakeWithPixelsInFormat(p_width, p_height, p_pixels, kMCGPixelFormatARGB, r_image);
+}
+
+MC_DLLEXPORT_DEF
+void MCCanvasImageMakeWithPixelsInFormat(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCGPixelFormat p_format, MCCanvasImageRef &r_image)
 {
 	MCImageRep *t_image_rep;
 	t_image_rep = nil;
 	
-	if (!MCImageRepCreateWithPixels(p_pixels, p_width, p_height, kMCGPixelFormatARGB, false, t_image_rep))
+	if (!MCImageRepCreateWithPixels(p_pixels, p_width, p_height, p_format, false, t_image_rep))
 	{
 		MCCanvasThrowError(kMCCanvasImageRepPixelsErrorTypeInfo);
 		return;

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -299,6 +299,7 @@ extern "C" MC_DLLEXPORT void MCCanvasTransformMultiply(MCCanvasTransformRef p_le
 extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithPath(MCStringRef p_path, MCCanvasImageRef &x_image);
 extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithData(MCDataRef p_data, MCCanvasImageRef &x_image);
 extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithPixels(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCCanvasImageRef &x_image);
+extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithPixelsInFormat(integer_t p_width, integer_t p_height, MCDataRef p_pixels, MCGPixelFormat p_format, MCCanvasImageRef &x_image);
 extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithPixelsWithSizeAsList(MCProperListRef p_size, MCDataRef p_pixels, MCCanvasImageRef &x_image);
 extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithResourceFile(MCStringRef p_resource, MCCanvasImageRef &r_image);
 


### PR DESCRIPTION
This patch adds a function to the canvas module to make an image
from a pixel buffer in a specified format e.g BGRA, ARGB etc