### PR TITLE
[[ SosBehavior ]] Serialize behavior in script-only-stack format

### DIFF
--- a/docs/dictionary/property/scriptOnly.lcdoc
+++ b/docs/dictionary/property/scriptOnly.lcdoc
@@ -49,17 +49,19 @@ The name or ID of the stack.
 
 Description:
 A <scriptOnly> stack will save just the script with a single header line
-declaring the stack name. Any other objects or properties of the stack
-will not be written to disk.
+declaring the stack name. If the stack has a <stack> <behavior>, the 
+name of the behavior stack is also saved to the header line. Any other 
+objects or properties of the stack will not be written to disk.
 
 The <scriptOnly> property has been added to enable scripts to detect and
 set the file format of the stack. Without this property it is not
 possible to detect the file format the stack is being saved in without
 examining the file itself.
 
->*Warning:* <scriptOnly> stacks only save the stack name and script. Any
-> property changes and objects created while the stack is open will not
-> exist the next time the stack is opened.
+>*Warning:* <scriptOnly> stacks only save the stack name, script and 
+> stack behavior. Any other type of behavior, or property changes and 
+> objects created while the stack is open will not exist the next time
+> the stack is opened.
 
 >*Note:* Script only stacks are unable to be password protected. In
 > order to password protect a script only stack use the following
@@ -68,7 +70,7 @@ examining the file itself.
     set the scriptOnly of stack "Secrets" to false
     set the password of stack "Secrets" to field "Password"
 
-References:create stack (command), stack (object)
+References:create stack (command), stack (object), behavior (property)
 
 Tags: objects
 

--- a/docs/glossary/s/script-only-stack.lcdoc
+++ b/docs/glossary/s/script-only-stack.lcdoc
@@ -1,0 +1,21 @@
+Name: script only stack
+
+Type: glossary
+
+Description:
+A <script only stack> is a <stack> whose on-disk representation is just 
+a <text file> with a header line:
+
+	script "StackName"
+	
+and, optionally with a <behavior> <stack> reference:
+
+	script "StackName" with behavior "BehaviorName"
+
+Anything else in the file is the <script> of the <script only stack>.
+
+References: text file (glossary), stack (glossary), script (property), 
+behavior (property)
+
+Tags: objects
+

--- a/docs/glossary/s/stack-file.lcdoc
+++ b/docs/glossary/s/stack-file.lcdoc
@@ -6,9 +6,11 @@ Type: glossary
 
 Description:
 A LiveCode <file>, containing a <main stack> and (optionally) one or
-more <substack|substacks>.
+more <substack|substacks>. A stack file is either binary, or a text 
+file (a <script only stack>).
 
-References: file (glossary), substack (glossary), main stack (glossary)
+References: file (glossary), substack (glossary), main stack (glossary),
+script only stack (glossary)	
 
 Tags: file system
 

--- a/docs/glossary/s/stack-version.lcdoc
+++ b/docs/glossary/s/stack-version.lcdoc
@@ -5,9 +5,9 @@ Synonyms: stack format, stack file format, stack file version
 Type: glossary
 
 Description:
-When saving a <stack> using the <save> <command>, it is possible to save
-with a specific version of LiveCode's stack <file> format. This is
-useful when saving a stack so that it can be saved in an older
+When saving a binary <stack> using the <save> <command>, it is possible 
+to save with a specific version of LiveCode's stack <file> format. This 
+is useful when saving a binary stack so that it can be saved in an older
 <version|version of LiveCode>, but it should be used with caution.
 
 **Warning:** Using a non-default <stack version> could result in data

--- a/docs/notes/feature-script_only_stack_behavior.md
+++ b/docs/notes/feature-script_only_stack_behavior.md
@@ -1,0 +1,7 @@
+# Script only stacks with behavior
+Script only stacks can now store a stack behavior as part of the file
+format. A 'with behavior' clause is added to the header of a script
+only stack, if it has a behavior property which references a stack.
+
+When a script-only-stack with such a clause is loaded, the behavior
+is set as part of the loading.

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -523,16 +523,10 @@ IO_stat MCDispatch::readstartupstack(IO_handle stream, MCStack*& r_stack)
     // crash when searching substacks.
     stacks = t_stack;
     
-#ifndef _MOBILE
-	// Make sure parent script references are up to date.
-	if (s_loaded_parent_script_reference)
-		t_stack -> resolveparentscripts();
-#else
 	// Mark the stack as needed parentscript resolution. This is done after
 	// aux stacks have been loaded.
 	if (s_loaded_parent_script_reference)
 		t_stack -> setextendedstate(True, ECS_USES_PARENTSCRIPTS);
-#endif
     
     r_stack = t_stack;
 	return IO_NORMAL;
@@ -562,6 +556,11 @@ IO_stat MCDispatch::readscriptonlystartupstack(IO_handle stream, uindex_t p_leng
     // We are reading the startup stack, so this becomes the root of the
     // stack list.
     stacks = t_stack;
+    
+    // Mark the stack as needed parentscript resolution. This is done after
+    // aux stacks have been loaded.
+    if (s_loaded_parent_script_reference)
+        t_stack -> setextendedstate(True, ECS_USES_PARENTSCRIPTS);
     
     r_stack = t_stack;
     return IO_NORMAL;

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -56,6 +56,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "stacksecurity.h"
 #include "scriptpt.h"
 #include "widget-events.h"
+#include "parentscript.h"
 
 #include "exec.h"
 #include "exec-interface.h"
@@ -716,6 +717,28 @@ static MCStack* script_only_stack_from_bytes(uint8_t *p_bytes,
         return nullptr;
     }
     
+    // If 'with' is next then parse the behavior reference.
+    MCNewAutoNameRef t_behavior_name;
+    if (sp.skip_token(SP_REPEAT, TT_UNDEFINED, RF_WITH) == PS_NORMAL)
+    {
+        // Ensure 'behavior' is next 
+        if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_PARENT_SCRIPT) != PS_NORMAL)
+        {
+            return nullptr;
+        }
+        
+        // Read the behavior name
+        if (sp.next(t_type) != PS_NORMAL || t_type != ST_LIT)
+        {
+            return nullptr;
+        }
+        
+        if (!MCNameClone(sp.gettoken_nameref(), &t_behavior_name))
+        {
+            return nullptr;
+        }
+    }
+
     // Parse end of line.
     Parse_stat t_stat;
     t_stat = sp . next(t_type);
@@ -762,6 +785,12 @@ static MCStack* script_only_stack_from_bytes(uint8_t *p_bytes,
     
     // Set its name.
     t_stack -> setname(*t_script_name);
+    
+    // If we parsed a behavior reference, then set it.
+    if (*t_behavior_name != nullptr)
+    {
+        t_stack->setparentscript_onload(0, *t_behavior_name);
+    }
     
     return t_stack;
 }
@@ -1142,8 +1171,22 @@ IO_stat MCDispatch::dosavescriptonlystack(MCStack *sptr, const MCStringRef p_fna
         // Ensure script isn't encrypted if a password was removed in session
         sptr -> unsecurescript(sptr);
         
-        // Write out the standard script stack header, and then the script itself
-		MCStringFormat(&t_script_body, "script \"%@\"\n%@", sptr -> getname(), sptr->_getscript());
+        // Write out the standard script stack header with behavior reference 
+        // (if applicable) and then the script itself
+        MCParentScript *t_parent_script = sptr->getparentscript();
+        if (t_parent_script != nullptr &&
+            t_parent_script->GetObjectId() == 0)
+        {
+            MCStringFormat(&t_script_body,
+                           "script \"%@\" with behavior \"%@\"\n%@",
+                           sptr->getname(),
+                           t_parent_script->GetObjectStack(),
+                           sptr->_getscript());
+        }
+        else
+        {
+            MCStringFormat(&t_script_body, "script \"%@\"\n%@", sptr -> getname(), sptr->_getscript());
+        }
 
 		// Convert line endings - but only if the native line ending isn't CR!
 #ifndef __CR__

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -840,6 +840,10 @@ IO_stat MCDispatch::startup(void)
 		
 		MCCapsuleClose(t_capsule);
 		
+        // Resolve parent scripts *after* we've loaded aux stacks.
+        if (t_info . stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
+            t_info . stack -> resolveparentscripts();
+        
 		t_mainstack = t_info . stack;
 	}
 	else if (MCnstacks > 1 && MClicenseparameters . license_class == kMCLicenseClassCommunity)

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -4051,12 +4051,11 @@ IO_stat MCObject::extendedload(MCObjectInputStream& p_stream, uint32_t version, 
 
 		if (t_stat == IO_NORMAL)
 		{
-			parent_script = MCParentScript::Acquire(this, t_id, t_stack);
-			if (parent_script == NULL)
-				t_stat = IO_ERROR;
-
-			s_loaded_parent_script_reference = true;
-		}
+            if (!setparentscript_onload(t_id, t_stack))
+            {
+                t_stat = IO_ERROR;
+            }
+        }
 
 		MCNameDelete(t_stack);
 	}
@@ -4134,6 +4133,18 @@ IO_stat MCObject::extendedload(MCObjectInputStream& p_stream, uint32_t version, 
 	return t_stat;
 }
 
+bool MCObject::setparentscript_onload(uint32_t p_id, MCNameRef p_stack)
+{
+    parent_script = MCParentScript::Acquire(this, p_id, p_stack);
+    if (parent_script == NULL)
+    {
+        return false;
+    }
+    
+    s_loaded_parent_script_reference = true;
+    
+    return true;
+}
 
 // MW-2008-10-28: [[ ParentScripts ]] This method attempts to resolve the
 //   parentscript reference for this object (if any).

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -971,6 +971,10 @@ public:
 	// is no parentScript, it returns NULL - note that this is an MCParentScript,
 	// not an MCParentScriptUse.
 	MCParentScript *getparentscript(void) const;
+    
+    // Set the parentScript of the object at load time of it (used by the script
+    // only stack loader).
+    bool setparentscript_onload(uint32_t p_id, MCNameRef p_stack);
 
 	// MW-2009-01-28: [[ Inherited parentScripts ]]
 	// This method returns false if there was not enough memory to complete the

--- a/tests/ide-support/standalonebuilder/_support.livecodescript
+++ b/tests/ide-support/standalonebuilder/_support.livecodescript
@@ -51,7 +51,7 @@ on StandaloneBuilderCleanupStandalones
 	revDeleteFolder tTargetFolder	
 end StandaloneBuilderCleanupStandalones
 
-on StandaloneBuilderSaveAsStandalone pStack	
+on StandaloneBuilderSaveAsStandalone pStack, @rPath
 	local tBuildPlatform
 	put GetBuildPlatform() into tBuildPlatform
 	
@@ -69,6 +69,8 @@ on StandaloneBuilderSaveAsStandalone pStack
 	local tResult
 	revDoSaveAsStandalone pStack, tTargetFolder
 	put the result into tResult
+
+	put StandaloneBuilderExecutable(pStack) into rPath
 
 	TestDiagnostic tResult	
 	return tResult
@@ -107,3 +109,64 @@ function StandaloneBuilderResources pStack
     end switch
     return tResources
 end StandaloneBuilderResources
+
+command StandaloneBuilderTestCreateAndSaveStackAsStandalone pDescription, pStackFilename, pScript, pSettingsA
+   local tStackID
+   create stack
+   put it into tStackID
+   set the script of tStackId to pScript
+   repeat for each key tKey in pSettingsA
+      set the cRevStandaloneSettings[tKey] of tStackId to \
+         pSettingsA[tKey]
+   end repeat
+	
+   StandaloneBuilderTestSaveStackAsStandalone pDescription, \
+      pStackFileName, tStackId
+end StandaloneBuilderTestCreateAndSaveStackAsStandalone
+
+command StandaloneBuilderTestSaveStackAsStandalone pDescription, pStackFilename, pStackID
+   local tStackName
+   put the short name of pStackID into tStackName   
+   
+   set the filename of pStackID to pStackFilename
+   save stack tStackName as pStackFilename
+   
+   revIDESaveStack pStackID	
+
+   local tExePath
+   _TestBuildStandalone pStackFilename, tExePath
+   if the result is not empty then
+      TestAssert "building standalone", false
+      exit StandaloneBuilderTestSaveStackAsStandalone
+   end if
+   
+   TestAssert "building standalone", true
+    
+   TestDiagnostic "location" && tExePath
+   
+   TestAssert "standalone in expected location", there is a file tExePath
+   
+   local tResult, tShellCmd
+   put quote & tExePath & quote into tShellCmd
+   if the environment contains "command line" then
+      put " -ui" after tShellCmd
+   end if
+   get shell(tShellCmd)
+   put the result into tResult
+   
+   if tResult is not empty then
+      TestDiagnostic "standalone quit with" && tResult & ":" && it
+   end if
+      
+   TestAssert pDescription, tResult is empty
+end StandaloneBuilderTestSaveStackAsStandalone
+
+private command _TestBuildStandalone pStackPath, @rStandalonePath
+	local tStackName, tResult
+	put the short name of stack pStackPath into tStackName
+	
+	TestDiagnostic "Building standalone -" && pStackPath
+	
+	StandaloneBuilderSaveAsStandalone tStackName, rStandalonePath
+	return the result
+end _TestBuildStandalone

--- a/tests/ide-support/standalonebuilder/_support.livecodescript
+++ b/tests/ide-support/standalonebuilder/_support.livecodescript
@@ -110,19 +110,26 @@ function StandaloneBuilderResources pStack
     return tResources
 end StandaloneBuilderResources
 
-command StandaloneBuilderTestCreateAndSaveStackAsStandalone pDescription, pStackFilename, pScript, pSettingsA
-   local tStackID
-   create stack
-   put it into tStackID
-   set the script of tStackId to pScript
+private command _TestCreateAndSaveStackAsStandalone pDescription, pStackId, pStackFilename, pScript, pSettingsA
+   set the script of pStackId to pScript
    repeat for each key tKey in pSettingsA
-      set the cRevStandaloneSettings[tKey] of tStackId to \
+      set the cRevStandaloneSettings[tKey] of pStackId to \
          pSettingsA[tKey]
    end repeat
 	
    StandaloneBuilderTestSaveStackAsStandalone pDescription, \
-      pStackFileName, tStackId
+      pStackFileName, pStackId
+end _TestCreateAndSaveStackAsStandalone
+
+command StandaloneBuilderTestCreateAndSaveStackAsStandalone pDescription, pStackFilename, pScript, pSettingsA
+   create stack
+   _TestCreateAndSaveStackAsStandalone pDescription, it, pStackFilename, pScript, pSettingsA
 end StandaloneBuilderTestCreateAndSaveStackAsStandalone
+
+command StandaloneBuilderTestCreateAndSaveScriptOnlyStackAsStandalone pDescription, pStackFilename, pScript, pSettingsA
+   create script only stack
+   _TestCreateAndSaveStackAsStandalone pDescription, it, pStackFilename, pScript, pSettingsA
+end StandaloneBuilderTestCreateAndSaveScriptOnlyStackAsStandalone
 
 command StandaloneBuilderTestSaveStackAsStandalone pDescription, pStackFilename, pStackID
    local tStackName

--- a/tests/ide-support/standalonebuilder/execution.livecodescript
+++ b/tests/ide-support/standalonebuilder/execution.livecodescript
@@ -62,7 +62,8 @@ private command _TestBuildStandalone pStackPath
 	
 	TestDiagnostic "Building standalone -" && pStackPath
 	
-	StandaloneBuilderSaveAsStandalone tStackName
+	local tExePath
+	StandaloneBuilderSaveAsStandalone tStackName, tExePath
 	put the result into tResult
 	
 	TestAssert tStackName && "- builds successfully", tResult is empty

--- a/tests/ide-support/standalonebuilder/extensions.livecodescript
+++ b/tests/ide-support/standalonebuilder/extensions.livecodescript
@@ -76,46 +76,9 @@ private command _TestBuildStandaloneWithWidget pDir, pWidget
    set the cWidgetKind of tStackID to pWidget
    set the cRevStandaloneSettings["extensions"] of tStackID to pWidget
    
-   revIDESaveStack tStackID
-   	 
-   _TestBuildStandalone tStackFilename
-   if the result is not empty then
-      TestAssert "building standalone", false
-      exit _TestBuildStandaloneWithWidget
-   end if
-   
-   TestAssert "building standalone", true
-   
-   local tExe
-   put StandaloneBuilderExecutable(tStackName) into tExe   
-   TestDiagnostic "location" && tExe
-   
-   TestAssert "standalone in expected location", there is a file tExe
-   
-   local tResult, tShellCmd
-   put quote & tExe & quote into tShellCmd
-   if the environment contains "command line" then
-      put " -ui" after tShellCmd
-   end if
-   
-   get shell(tShellCmd)
-   put the result into tResult
-   
-   if tResult is not empty then
-      TestDiagnostic "standalone quit with" && tResult & ":" && it
-   end if
-   
-   TestAssert "standalone with" && pWidget && "startup", \
-         tResult is empty
+   local tDesc
+   put "standalone with" && pWidget && "startup" into tDesc
+
+   StandaloneBuilderTestSaveStackAsStandalone tDesc, \
+      tStackFilename, tStackID
 end _TestBuildStandaloneWithWidget
-
-private command _TestBuildStandalone pStackPath
-	local tStackName, tResult
-	put the short name of stack pStackPath into tStackName
-	
-	TestDiagnostic "Building standalone -" && pStackPath
-	
-	StandaloneBuilderSaveAsStandalone tStackName
-	return the result
-end _TestBuildStandalone
-

--- a/tests/ide-support/standalonebuilder/inclusion.livecodescript
+++ b/tests/ide-support/standalonebuilder/inclusion.livecodescript
@@ -50,69 +50,24 @@ on TestStandaloneInclusions
    
    create folder tDir
    
-   local tStackName, tStackID
-   create stack
-   put it into tStackID
-   put the short name of tStackID into tStackName
-   
    local tStackFilename
    put the folder & "/" & tDir & "/stack.livecode" into tStackFilename
-   set the filename of tStackID to tStackFilename
    
    set the itemdelimiter to comma
    repeat for each item tItem in "xml,security,zip,sqlite"
-      _TestStandaloneWithInclusion tStackId, tStackFilename, tItem
+      _TestStandaloneWithInclusion tStackFilename, tItem
    end repeat
    
    revDeleteFolder tDir
 end TestStandaloneInclusions
 
-private command _TestStandaloneWithInclusion pStackId, pStackFilename, pItem
+private command _TestStandaloneWithInclusion pStackFilename, pItem
    local tScript
    put _TestScriptForInclusion(pItem) into tScript
-   
-   set the script of pStackId to tScript
-   revIDESaveStack pStackId
-   	 
-   _TestBuildStandalone pStackFilename
-   if the result is not empty then
-      TestAssert "building standalone", false
-      exit _TestStandaloneWithInclusion
-   end if
-   
-   TestAssert "building standalone", true
-   
-   local tStackName
-   put the short name of pStackId into tStackName
-   
-   local tExe
-   put StandaloneBuilderExecutable(tStackName) into tExe   
-   TestDiagnostic "location" && tExe
-   
-   TestAssert "standalone in expected location", there is a file tExe
-   
-   local tResult, tShellCmd
-   put quote & tExe & quote into tShellCmd
-   if the environment contains "command line" then
-      put " -ui" after tShellCmd
-   end if
-   get shell(tShellCmd)
-   put the result into tResult
-   
-   if tResult is not empty then
-      TestDiagnostic "standalone quit with" && tResult & ":" && it
-   end if
-      
-   TestAssert "standalone with" && pItem && "inclusion startup", \
-         tResult is empty
-end _TestStandaloneWithInclusion
 
-private command _TestBuildStandalone pStackPath
-	local tStackName, tResult
-	put the short name of stack pStackPath into tStackName
-	
-	TestDiagnostic "Building standalone -" && pStackPath
-	
-	StandaloneBuilderSaveAsStandalone tStackName
-	return the result
-end _TestBuildStandalone
+   local tDesc
+   put "standalone with" && pItem && "inclusion startup" into tDesc
+
+   StandaloneBuilderTestCreateAndSaveStackAsStandalone tDesc, \
+      pStackFilename, tScript
+end _TestStandaloneWithInclusion

--- a/tests/ide-support/standalonebuilder/savingstandalone.livecodescript
+++ b/tests/ide-support/standalonebuilder/savingstandalone.livecodescript
@@ -72,8 +72,10 @@ on TestSavingStandalone
    set the cModified of tStackID to false
    
    revIDESaveStack tStackID
-	 
-   _TestBuildStandalone tStackFilename
+
+   local tExe
+   _TestBuildStandalone tStackFilename, tExe
+
    if the result is not empty then
       TestAssert "building standalone", false
       exit TestSavingStandalone
@@ -81,17 +83,7 @@ on TestSavingStandalone
 
    TestAssert "building standalone", true
    TestAssert "standalone state reloaded", the cModified of stack tStackName is not true
-   
-   local tFolder
-   put the cFolder of stack tStackName into tFolder
-   
-   local tExe
-   if the platform is "MacOS" then 
-      put tFolder & tStackName & ".app/Contents/MacOS/" \ 
-      		& tStackName into tExe
-   else
-      put tFolder & tStackName into tExe
-   end if
+
    
    TestDiagnostic "location" && tExe
    TestAssert "standalone in expected location", there is a file tExe
@@ -107,12 +99,12 @@ on TestSavingStandalone
    revDeleteFolder tDir
 end TestSavingStandalone
 
-private command _TestBuildStandalone pStackPath
+private command _TestBuildStandalone pStackPath, @rPath
 	local tStackName, tResult
 	put the short name of stack pStackPath into tStackName
 	
 	TestDiagnostic "Building standalone -" && pStackPath
 	
-	StandaloneBuilderSaveAsStandalone tStackName
+	StandaloneBuilderSaveAsStandalone tStackName, rPath
 	return the result
 end _TestBuildStandalone

--- a/tests/ide-support/standalonebuilder/script-only.livecodescript
+++ b/tests/ide-support/standalonebuilder/script-only.livecodescript
@@ -41,17 +41,15 @@ private function _TestScriptOnlyStandaloneStackScript
 	return tScript
 end _TestScriptOnlyStandaloneStackScript
 
-private function _TestScriptOnlyAuxiliaryStackStackScript
+private function _TestScriptOnlyAuxiliaryMainstackScript
 	local tScript
-	put "on openStack" & return after tScript
-	put "if (there is a stack" && quote & "revLibUrl" & quote \
-		& ") then quit 0" & return after tScript
-	put "write" && quote & "included aux stack not present" & quote \ 
-	   && "to stdout" & return after tScript
+	put "on startup" & return after tScript
+	put "if there is a stack" && quote & "aux" & quote && \
+		"then quit 0" & return after tScript
 	put "quit 1" & return after tScript
-	put "end openStack" & return after tScript
+	put "end startup" & return after tScript
 	return tScript
-end _TestScriptOnlyAuxiliaryStackStackScript
+end _TestScriptOnlyAuxiliaryMainstackScript
 
 private command _TestScriptOnlyDeployStack pWhich
    local tDir
@@ -62,21 +60,29 @@ private command _TestScriptOnlyDeployStack pWhich
    
    create folder tDir
    
-   local tStackFilename, tScript, tSettings
+   local tSOSFilename, tScript, tSettings, tFilename
+   put the folder & "/" & tDir & "/stack.livecodescript" into tSOSFilename   
    if pWhich is "mainstack" then
-	  put the folder & "/" & tDir & "/stack.livecodescript" into tStackFilename   
 	  put _TestScriptOnlyStandaloneStackScript() into tScript
+	  put tSOSFilename into tFilename
    else if pWhich is "auxiliary" then
-   	  put the folder & "/" & tDir & "/stack.livecode" into tStackFilename   
-	  put _TestScriptOnlyAuxiliaryStackStackScript() into tScript
-	  put "Internet" into tSettings["scriptLibraries"]
-	  put "select" into tSettings["inclusions"]
+      create script only stack "aux"
+      save stack "aux" as tSOSFilename
+      
+   	  put the folder & "/" & tDir & "/stack.livecode" into tFilename   
+	  put _TestScriptOnlyAuxiliaryMainstackScript() into tScript
+	  put tSOSFilename into tSettings["auxiliary_stackfiles"]
    end if
    
    local tDesc
    put "standalone with script-only" && pWhich && "startup" into tDesc
-   StandaloneBuilderTestCreateAndSaveStackAsStandalone tDesc, \
-      tStackFilename, tScript, tSettings
+   if pWhich is "mainstack" then
+      StandaloneBuilderTestCreateAndSaveScriptOnlyStackAsStandalone tDesc, \
+         tFilename, tScript, tSettings
+   else
+      StandaloneBuilderTestCreateAndSaveStackAsStandalone tDesc, \
+         tFilename, tScript, tSettings   
+   end if
 
    revDeleteFolder tDir
 end _TestScriptOnlyDeployStack

--- a/tests/ide-support/standalonebuilder/script-only.livecodescript
+++ b/tests/ide-support/standalonebuilder/script-only.livecodescript
@@ -86,3 +86,72 @@ on TestScriptOnlyDeployStacks
       _TestScriptOnlyDeployStack tItem
    end repeat
 end TestScriptOnlyDeployStacks
+
+private command _TestScriptOnlyBehaviorDeployStack pWhich
+   local tDir
+   set the itemdelimiter to slash
+   set the defaultfolder to item 1 to -2 of the filename of me
+
+   put "_TestSavingStandalone" into tDir
+   
+   create folder tDir
+   
+   local tStackFilename
+   -- in both cases we need an empty script-only stack with behavior
+   put the folder & "/" & tDir & "/stack.livecodescript" into tStackFilename
+   
+   local tBehaviorStack, tBehaviorStackFilename
+   put the folder & "/" & tDir & "/behaviorstack.livecodescript" into tBehaviorStackFilename
+   create script only stack "BehaviorStack" & pWhich
+   put it into tBehaviorStack
+   set the filename of it to tBehaviorStackFilename
+	     
+   local tScript, tSettings, tStackId
+   put _TestScriptOnlyStandaloneStackScript() into tScript
+   create script only stack "SOSWithBehavior" & pWhich
+   put it into tStackId
+   set the behavior of tStackId to tBehaviorStack
+   set the filename of stack tStackId to tStackFileName	     
+   if pWhich is "mainstack" then
+	  put tBehaviorStackFilename into tSettings["auxiliary_stackfiles"]
+	  
+   else if pWhich is "auxiliary" then
+   	  local tIntermediateBehavior
+   	  put tStackFileName into tIntermediateBehavior
+   	  save stack tIntermediateBehavior
+   	  
+   	  put the folder & "/" & tDir & "/stack.livecode" into tStackFilename   
+   	  create stack
+   	  set the filename of it to tStackFilename
+   	  set the behavior of it to the long id of stack \
+   	     tIntermediateBehavior
+
+	  put tBehaviorStackFilename & return & \
+         tIntermediateBehavior into tSettings["auxiliary_stackfiles"]
+   end if
+   
+   repeat for each key tKey in tSettings
+   	  set the cRevStandaloneSettings[tKey] of tStackId to \
+   	     tSettings[tKey]
+   end repeat
+   
+   set the script of tBehaviorStack to tScript
+   save stack tBehaviorStack
+   save stack tStackId
+   
+   local tDesc
+   put "standalone with script-only" && pWhich && " with behavior startup" into tDesc
+   	
+   StandaloneBuilderTestSaveStackAsStandalone tDesc, \
+      tStackFilename, tStackId
+
+   revDeleteFolder tDir
+end _TestScriptOnlyBehaviorDeployStack
+
+on TestScriptOnlyBehaviorMainstackDeploy
+   _TestScriptOnlyBehaviorDeployStack "Mainstack"
+end TestScriptOnlyBehaviorMainstackDeploy
+
+on TestScriptOnlyBehaviorAuxiliaryStackDeploy
+   _TestScriptOnlyBehaviorDeployStack "Auxiliary"
+end TestScriptOnlyBehaviorAuxiliaryStackDeploy

--- a/tests/ide-support/standalonebuilder/script-only.livecodescript
+++ b/tests/ide-support/standalonebuilder/script-only.livecodescript
@@ -62,71 +62,24 @@ private command _TestScriptOnlyDeployStack pWhich
    
    create folder tDir
    
-   local tStackName, tStackID
-
-   local tStackFilename
+   local tStackFilename, tScript, tSettings
    if pWhich is "mainstack" then
-      create script only stack
-   	  put it into tStackID
-      put the short name of tStackID into tStackName
 	  put the folder & "/" & tDir & "/stack.livecodescript" into tStackFilename   
-	  set the script of tStackID to _TestScriptOnlyStandaloneStackScript()
+	  put _TestScriptOnlyStandaloneStackScript() into tScript
    else if pWhich is "auxiliary" then
-      create stack
-   	  put it into tStackID
-      put the short name of tStackID into tStackName
    	  put the folder & "/" & tDir & "/stack.livecode" into tStackFilename   
-	  set the script of tStackID to _TestScriptOnlyAuxiliaryStackStackScript()
-	  set the cRevStandaloneSettings["scriptLibraries"] of tStackID to "Internet"
-	  set the cRevStandaloneSettings["inclusions"] of tStackID to "select"
+	  put _TestScriptOnlyAuxiliaryStackStackScript() into tScript
+	  put "Internet" into tSettings["scriptLibraries"]
+	  put "select" into tSettings["inclusions"]
    end if
    
-   set the filename of tStackID to tStackFilename
-   save stack tStackName as tStackFilename
-   
-   revIDESaveStack tStackID	
-
-   _TestBuildStandalone tStackFilename
-   if the result is not empty then
-      TestAssert "building standalone", false
-      exit _TestScriptOnlyDeployStack
-   end if
-   
-   TestAssert "building standalone", true
-   
-   local tExe
-   put StandaloneBuilderExecutable(tStackName) into tExe   
-   TestDiagnostic "location" && tExe
-   
-   TestAssert "standalone in expected location", there is a file tExe
-   
-   local tResult, tShellCmd
-   put quote & tExe & quote into tShellCmd
-   if the environment contains "command line" then
-      put " -ui" after tShellCmd
-   end if
-   get shell(tShellCmd)
-   put the result into tResult
-   
-   if tResult is not empty then
-      TestDiagnostic "standalone quit with" && tResult & ":" && it
-   end if
-      
-   TestAssert "standalone with script-only" && pWhich && "startup", \
-         tResult is empty
+   local tDesc
+   put "standalone with script-only" && pWhich && "startup" into tDesc
+   StandaloneBuilderTestCreateAndSaveStackAsStandalone tDesc, \
+      tStackFilename, tScript, tSettings
 
    revDeleteFolder tDir
 end _TestScriptOnlyDeployStack
-
-private command _TestBuildStandalone pStackPath
-	local tStackName, tResult
-	put the short name of stack pStackPath into tStackName
-	
-	TestDiagnostic "Building standalone -" && pStackPath
-	
-	StandaloneBuilderSaveAsStandalone tStackName
-	return the result
-end _TestBuildStandalone
 
 on TestScriptOnlyDeployStacks
    repeat for each item tItem in "mainstack,auxiliary"

--- a/tests/ide-support/standalonebuilder/stackfiles.livecodescript
+++ b/tests/ide-support/standalonebuilder/stackfiles.livecodescript
@@ -136,7 +136,8 @@ private command _TestStandaloneStackPath pWhich
    end if
    save stack "main"
    
-   StandaloneBuilderSaveAsStandalone "main"
+   local tExePath
+   StandaloneBuilderSaveAsStandalone "main", tExePath
    if the result is not empty then
       TestAssert "building standalone", false
       exit _TestStandaloneStackPath


### PR DESCRIPTION
This patch adds a 'with behavior' clause to the header of a script
only stack.

The clause is emitted if the stack has a behavior property which
references a stack.

When a script-only-stack with such a clause is loaded, the behavior
is set as part of the loading.

Note: This has been submitted against develop-8.1 as it is (essentially) a file format change which could impact our branching. However, if we aren't intending to use it in 8.1 (should it make the cut) then it should be rebased against develop.