### PR TITLE
[[ Bug 20875 ]] Return Typeface object from MCCanvasFontGetHandle on Android

### DIFF
--- a/docs/notes/bugfix-20875.md
+++ b/docs/notes/bugfix-20875.md
@@ -1,0 +1,16 @@
+# Return Typeface object from MCCanvasFontGetHandle on Android
+
+The canvas module's font handle is intended to return a pointer
+that can be used on the given platform to set the font of native
+views on that platform. In the case of android, the handle was
+a Skia Typeface pointer rather than a Typeface Java object.
+
+Now the returned pointer can be wrapped using PointerToJObject
+and used directly as the Typeface parameter in android java ffi
+calls (such as setTypeface).
+
+Note, the pointer returned by MCCanvasFontGetHandle is an 
+unwrapped jobject local ref, so can only be expected to live
+while the calling handler is running. If the Typeface object
+is required elsewhere, it must be wrapped using PointerToJObject
+and put in a module variable. 

--- a/engine/src/font.cpp
+++ b/engine/src/font.cpp
@@ -238,7 +238,14 @@ int32_t MCFontGetSize(MCFontRef self)
 
 void *MCFontGetHandle(MCFontRef self)
 {
+#ifdef TARGET_SUBPLATFORM_ANDROID
+    extern void* MCAndroidCustomFontCreateTypeface(MCStringRef, bool, bool);
+    return MCAndroidCustomFontCreateTypeface(MCNameGetString(self->name),
+                                             self->style & kMCFontStyleBold,
+                                             self->style & kMCFontStyleItalic);
+#else
     return self->fontstruct->fid;
+#endif
 }
 
 bool MCFontHasPrinterMetrics(MCFontRef self)

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -3244,6 +3244,14 @@ public class Engine extends View implements EngineApi
     
     ////////////////////////////////////////////////////////////////////////////////
     
+    public Object createTypefaceFromAsset(String path)
+    {
+        Log.i("revandroid", "createTypefaceFromAsset");
+        return Typeface.createFromAsset(getContext().getAssets(),path);
+    }
+    
+    ////////////////////////////////////////////////////////////////////////////////
+    
     private X509TrustManager getTrustManager()
     {
         if (m_trust_manager != null)

--- a/engine/src/mblandroidfont.cpp
+++ b/engine/src/mblandroidfont.cpp
@@ -518,6 +518,23 @@ static bool create_font_face_from_custom_font_name_and_style(MCStringRef p_name,
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void* MCAndroidCustomFontCreateTypeface(MCStringRef p_name, bool p_bold, bool p_italic)
+{
+    jobject t_typeface = nil;
+    
+    MCAndroidCustomFont *t_font = look_up_custom_font(p_name, p_bold, p_italic);
+    if (t_font != nil)
+    {
+        MCAutoStringRef t_font_path;
+        if (!MCStringFormat(&t_font_path, "%@%@", s_font_folder, t_font->path))
+            return nullptr;
+        MCAndroidEngineCall("createTypefaceFromAsset", "ox", &t_typeface, *t_font_path);
+    }
+
+    return t_typeface;
+}
+////////////////////////////////////////////////////////////////////////////////
+
 void *android_font_create(MCStringRef name, uint32_t size, bool bold, bool italic)
 {
 	MCAndroidFont *t_font = nil;


### PR DESCRIPTION
The canvas module's font handle is intended to return a pointer
that can be used on the given platform to set the font of native
views on that platform. In the case of androind, the handle was
a Skia Typeface pointer rather than a Typeface Java object.

Now the returned pointer can be wrapped using PointerToJObject
and used directly as the Typeface parameter in android java ffi
calls (such as setTypeface).