### PR TITLE
[[ Bug 20931 ]] Bridge values in LCB assign-array and assign-list ops

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -1060,7 +1060,8 @@ Result expressions are not assignable.
       : '[' [ <Elements: ExpressionList> ] ']'
 
 A list expression evaluates all the elements in the expression list from
-left to right and constructs a list value with them as elements.
+left to right and constructs a list value with them as elements. Each 
+expression is converted to `optional any` when constructing the list.
 
 The elements list is optional, so the empty list can be specified as
 *[]*.
@@ -1078,7 +1079,8 @@ List expressions are not assignable.
 
 An array expression evaluates all of the key and value expressions
 from left to right, and constructs an **Array** value as appropriate.
-Each key expression must evaluate to a **String**.
+Each key expression must evaluate to a **String**. Each value expression 
+is converted to `optional any` when constructing the array.
 
 The contents are optional, so the empty array can be written as `{}`.
 

--- a/docs/lcb/notes/20931.md
+++ b/docs/lcb/notes/20931.md
@@ -1,0 +1,9 @@
+# LiveCode Builder Virtual Machine
+## Array and list assign ops
+
+Previously there was a difference between constructing a list or array
+using `push` or `put` and using list or array assigment expressions `[]` 
+and `{}`, namely values were converted to `optional any` only in the 
+latter case. For consistency, they are now converted in both cases.
+
+# [20931] Values should bridge to optional any in array and list assign

--- a/libscript/src/script-execute.hpp
+++ b/libscript/src/script-execute.hpp
@@ -179,7 +179,16 @@ public:
 	// Leave the LCB VM. If a execution completed successfully then true is
 	// returned, otherwise false is returned.
 	bool Leave(void);
-	
+    
+    // Attempt to bridge the input value. If the input value is foreign and
+    // the foreign type is bridgeable, doimport is used to create the output
+    // value. Otherwise, the input value is retained and returned as the output
+    // value.
+    // Note: This is a specialization of Convert where the to_type is 'optional
+    // any'.
+    bool Bridge(MCValueRef value,
+                MCValueRef& r_bridged_value);
+    
 	// Attempt to convert the input value to the specified type. If the conversion
 	// cannot be performed because the type does not conform, then 'true' will
 	// be returned, but r_new_value will be nil; allowing the context to throw

--- a/tests/lcb/compiler/frontend/variadic.compilertest
+++ b/tests/lcb/compiler/frontend/variadic.compilertest
@@ -42,14 +42,69 @@ end module
 %ERROR "Variadic parameters only allowed in foreign handlers" AT BEFORE_VARIADIC
 %ENDTEST
 
+%% Variadic arguments must be an explicitly-typed variable
+%TEST VariadicNotAllowedImplicitlyTypedArgument
+module compiler_test
+__safe foreign handler TestVariadic(in pA as any, ...) returns nothing binds to ""
+handler CallVariadic()
+	TestVariadic("pA", %{BEFORE_IMPLICIT_ARG}1)
+end handler
+end module
+%EXPECT PASS
+%ERROR "Variadic arguments must be an explicitly-typed variable" AT BEFORE_IMPLICIT_ARG
+%ENDTEST
+
+%% Variadic arguments can be local variables
+%TEST VariadicArgumentModuleLocal
+module compiler_test
+__safe foreign handler TestVariadic(in pA as any, ...) returns nothing binds to ""
+handler CallVariadic()
+	variable tVar as Integer
+	TestVariadic("pA", tVar)
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Variadic arguments can be module locals
+%TEST VariadicArgumentModuleLocal
+module compiler_test
+private variable mVar as Integer
+__safe foreign handler TestVariadic(in pA as any, ...) returns nothing binds to ""
+handler CallVariadic()
+	TestVariadic("pA", mVar)
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%% Variadic arguments can be parameter variables
+%TEST VariadicArgumentParameterVariable
+module compiler_test
+__safe foreign handler TestVariadic(in pA as any, ...) returns nothing binds to ""
+handler CallVariadic(in pVar as Integer)
+	TestVariadic("pA", pVar)
+end handler
+end module
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
 %% You can have 0 to any number of variadic arguments
 %TEST VariadicParametersAnyCount
 module compiler_test
 __safe foreign handler TestVariadic(in pA as any, ...) returns nothing binds to ""
 handler CallVariadic()
-	TestVariadic(1)
-	TestVariadic(1, 2)
-	TestVariadic(1, 2, 3)
+	TestVariadic("pA")
+
+	variable tX as Integer
+	variable tY as Integer
+	variable tZ as Integer
+	TestVariadic("pA", tX)
+	TestVariadic("pA", tX, tY)
+	TestVariadic("pA", tX, tY, tZ)
 end handler
 end module
 %EXPECT PASS

--- a/tests/lcb/vm/assign-ops.lcb
+++ b/tests/lcb/vm/assign-ops.lcb
@@ -38,7 +38,7 @@ public handler TestAssignListOpForeignBridge()
 		put false into tVar
 	
 		variable tValue as Pointer	
-		put MCProperListFetchElementAtIndex([tVar], 1) into tValue
+		put MCProperListFetchElementAtIndex([tVar], 0) into tValue
 	
 		test "foreign value bridged to optional any in list assign" \
 			when not __IsForeignValue(tValue)

--- a/tests/lcb/vm/assign-ops.lcb
+++ b/tests/lcb/vm/assign-ops.lcb
@@ -1,0 +1,48 @@
+module __VMTEST.assign_ops
+
+use com.livecode.foreign
+
+foreign handler MCValueGetTypeInfo(in pValue as Pointer) returns Pointer binds to "<builtin>"
+
+foreign handler MCTypeInfoIsForeign(in pTypeInfo as Pointer) returns CBool binds to "<builtin>"
+
+foreign handler MCArrayFetchValue(in pArray as Array, in pCaseSensitive as CBool, in pKey as Pointer, out rValue as Pointer) returns CBool binds to "<builtin>"
+
+foreign handler MCNameCreate(in pString as String, out rName as Pointer) returns CBool binds to "<builtin>"
+
+foreign handler MCProperListFetchElementAtIndex(in pList as List, in pIndex as LCUIndex) returns Pointer binds to "<builtin>"
+
+unsafe handler __IsForeignValue(in pValue as Pointer) returns Boolean
+	return MCTypeInfoIsForeign(MCValueGetTypeInfo(pValue))
+end handler
+
+public handler TestAssignArrayOpForeignBridge()
+	unsafe
+		variable tVar as CBool
+		put false into tVar
+
+		variable tKey as Pointer
+		MCNameCreate("key", tKey)
+	
+		variable tValue as Pointer
+		MCArrayFetchValue({"key": tVar}, false, tKey, tValue)
+
+		test "foreign value bridged to optional any in array assign" \
+			when not __IsForeignValue(tValue)
+	end unsafe
+end handler
+
+public handler TestAssignListOpForeignBridge()
+	unsafe
+		variable tVar as CBool
+		put false into tVar
+	
+		variable tValue as Pointer	
+		put MCProperListFetchElementAtIndex([tVar], 1) into tValue
+	
+		test "foreign value bridged to optional any in list assign" \
+			when not __IsForeignValue(tValue)
+	end unsafe
+end handler
+
+end module

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1463,7 +1463,7 @@
 
     -- variadic parameter 'sticks' and matches the rest of the argument list
     'rule' CheckCallArguments(Position, ParamRest:parameterlist(parameter(_, variadic, _, _), _), expressionlist(Argument, ArgRest)):
-        CheckExpressionIsEvaluatable(Argument)
+        CheckExpressionIsExplicitlyTypedVariable(Argument)
         CheckCallArguments(Position, ParamRest, ArgRest)
 
     'rule' CheckCallArguments(Position, parameterlist(parameter(_, variadic, _, _), _), nil):
@@ -1506,6 +1506,20 @@
             CheckExpressionIsAssignable(Argument)
         |]
         CheckInvokeArguments(Position, SigTail, Arguments)
+
+'action' CheckExpressionIsExplicitlyTypedVariable(EXPRESSION)
+
+    'rule' CheckExpressionIsExplicitlyTypedVariable(slot(Position, Id)):
+        -- Only expressions binding to a slot which has a specified type are
+        -- 'explicitly typed'
+        QueryKindOfSymbolId(Id -> variable)
+        QuerySymbolId(Id -> Info)
+        Info'Type -> Type
+        ne(Type, unspecified)
+
+    'rule' CheckExpressionIsExplicitlyTypedVariable(Expr):
+        GetExpressionPosition(Expr -> Position)
+        Error_VariadicArgumentNotExplicitlyTyped(Position)
 
 'action' CheckExpressionIsEvaluatable(EXPRESSION)
 

--- a/toolchain/lc-compile/src/check.g
+++ b/toolchain/lc-compile/src/check.g
@@ -1512,7 +1512,20 @@
     'rule' CheckExpressionIsExplicitlyTypedVariable(slot(Position, Id)):
         -- Only expressions binding to a slot which has a specified type are
         -- 'explicitly typed'
-        QueryKindOfSymbolId(Id -> variable)
+        QueryKindOfSymbolId(Id -> Kind)
+
+        -- Expression must be a variable of some kind, i.e. one of:
+        (|
+            -- A local variable
+            eq(Kind, local)
+        ||
+            -- A parameter variable
+            eq(Kind, parameter)
+        ||
+            -- A module local variable
+            eq(Kind, variable)
+        |)
+
         QuerySymbolId(Id -> Info)
         Info'Type -> Type
         ne(Type, unspecified)

--- a/toolchain/lc-compile/src/support.g
+++ b/toolchain/lc-compile/src/support.g
@@ -357,6 +357,7 @@
     Error_InvalidNameForNamespace
     Error_VariadicParametersOnlyAllowedInForeignHandlers
     Error_VariadicParameterMustBeLast
+    Error_VariadicArgumentNotExplicitlyTyped
 
     Warning_MetadataClausesShouldComeAfterUseClauses
     Warning_DeprecatedTypeName
@@ -788,6 +789,7 @@
 
 'action' Error_VariadicParametersOnlyAllowedInForeignHandlers(Position: POS)
 'action' Error_VariadicParameterMustBeLast(Position: POS)
+'action' Error_VariadicArgumentNotExplicitlyTyped(Position: POS)
 
 'action' Warning_MetadataClausesShouldComeAfterUseClauses(Position: POS)
 'action' Warning_DeprecatedTypeName(Position: POS, NewType: STRING)

--- a/toolchain/libcompile/src/report.c
+++ b/toolchain/libcompile/src/report.c
@@ -403,6 +403,7 @@ DEFINE_ERROR_I(UnsafeHandlerCallNotAllowedInSafeContext, "Unsafe handler '%s' ca
 
 DEFINE_ERROR(VariadicParameterMustBeLast, "Variadic parameter must be the last")
 DEFINE_ERROR(VariadicParametersOnlyAllowedInForeignHandlers, "Variadic parameters only allowed in foreign handlers")
+DEFINE_ERROR(VariadicArgumentNotExplicitlyTyped, "Variadic arguments must be an explicitly-typed variable")
 
 #define DEFINE_WARNING(Name, Message) \
     void Warning_##Name(intptr_t p_position) { _Warning(p_position, Message); }


### PR DESCRIPTION
This patch fixes a bug where the behavior of code built using the
[ ... ] and { ... } syntax in LCB is different from that when using
explicit code.

A new method 'Bridge' has been added to the VM's execute context.
This method performs a 'convert to optional any' on the input value
resulting in bridgeable foreign values being imported, and all other
values being retained.

This method is now called on the input values in the assign-list
and assign-array opcodes meaning that foreign values being built
into lists will bridge.

Additionally, an extra compiler check has been added to variadic
arguments (i.e. arguments to the variadic portion of a C variadic
handler). This check restricts such arguments to being variable
identifiers where the variable has an explicit type declaration.
This is necessary to ensure that code explicitly states the type
which is being passed in variadic positions as there is no other
means for the compiler or the VM to know what the type should be.