### PR TITLE
[[ WidgetTouch ]] Add support for touch events in widgets

### DIFF
--- a/docs/notes/lcb/feature-widget_touch.md
+++ b/docs/notes/lcb/feature-widget_touch.md
@@ -1,0 +1,38 @@
+# LiveCode Builder Host Library
+
+## Widget Touch Handlers
+
+Widgets can now handle the following touch messages:
+
+- `OnTouchStart` - sent when the touch first starts
+- `OnTouchMove` - sent when the touch moves
+- `OnTouchFinish` - sent when the touch ends without being canceled
+- `OnTouchCancel` - sent when the touch is canceled
+
+When a widget hit tests as the target for the first of a sequence of
+touches and implements one of the touch event handlers it will receive all
+events for the sequence otherwise it will not receive any. A sequence of
+touches begins with the start of the first touch until there are no more
+active touches.
+
+While a widget is the target for touch events the touch messages will not
+be sent to the LCS object unless the widget posts them. If the widget
+becomes invisible, or is closed whilst active touches are present
+`OnTouchCancel` is sent for all of them.
+
+The currently active touch (the one which caused the event to
+bubble) can be found by using `the touch id`, and its
+position using `the touch position`. The id is an integer beginning with
+1 and incremented for each touch in the sequence. It is unrelated to the
+id parameter for LCS touch messages.
+
+The number of touches currently in progress can be found by using
+`the number of touches` and the position of a given touch using
+`the position of touch tID`. A list of currently active touch IDs can
+be found using `the touch ids`.
+
+Note: Due to the way touch messages are currently processed above
+the widget event system, widgets will receive mouse messages and
+then touch messages. To make a widget which works on both Desktop
+and Mobile, and wants touches on Mobile, the widget must have both
+mouse and touch handlers, and check for platform in the mouse handlers.

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -1281,16 +1281,21 @@ static void handle_touch(MCStack *p_stack, MCEventTouchPhase p_phase, uint32_t p
         if (!s_touches_for_widget)
         {
             t_target = p_stack -> getcurcard() -> hittest(t_touch_loc.x, t_touch_loc.y);
-            if (t_touch->next == nullptr &&
-                t_target->gettype() == CT_WIDGET)
+            if (t_target != nullptr)
             {
-                t_widget_first = true;
+                if (t_touch->next == nullptr &&
+                    t_target->gettype() == CT_WIDGET)
+                {
+                    t_widget_first = true;
+                }
+            
+                t_touch -> target = t_target -> GetHandle();
             }
-            t_touch -> target = t_target -> GetHandle();
         }
         else
         {
             t_target = s_touches -> target;
+            t_touch -> target = t_target -> GetHandle();
         }
         
         s_touches = t_touch;

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -1273,7 +1273,7 @@ static void handle_touch(MCStack *p_stack, MCEventTouchPhase p_phase, uint32_t p
         t_touch = new (nothrow) MCTouch;
         t_touch -> next = s_touches;
         t_touch -> id = p_id;
-        
+
         /* If the touch sequence isn't for widgets, then we must find a control
          * to send the event to. In this case, if this is the first touch in 
          * a sequence *and* the target is a widget, we must allow the widget

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -1286,9 +1286,12 @@ static void handle_touch(MCStack *p_stack, MCEventTouchPhase p_phase, uint32_t p
             {
                 t_widget_first = true;
             }
+            t_touch -> target = t_target -> GetHandle();
         }
-        
-        t_touch -> target = t_target -> GetHandle();
+        else
+        {
+            t_target = s_touches -> target;
+        }
         
         s_touches = t_touch;
     }

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -98,8 +98,9 @@ MCWidgetEventManager* MCwidgeteventmanager = nil;
 
 struct MCWidgetEventManager::MCWidgetTouchEvent
 {
+    bool m_active;
     uinteger_t  m_id;
-    MCWidgetRef m_widget;
+    uinteger_t  m_index;
     coord_t     m_x;
     coord_t     m_y;
 };
@@ -138,9 +139,11 @@ MCWidgetEventManager::MCWidgetEventManager() :
   m_doubleclick_time(MCdoubletime),
   m_doubleclick_distance(MCdoubledelta),
   m_check_mouse_focus(false),
-  m_touches()
+  m_touches(),
+  m_touch_count(0),
+  m_touched_widget(nullptr),
+  m_touch_id(0)
 {
-    
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -174,6 +177,9 @@ void MCWidgetEventManager::event_close(MCWidget* p_widget)
             MCValueAssignOptional(m_mouse_focus, nil);
         }
     }
+    
+    /* Issue a cancel touches event. */
+    event_cancel_touches(p_widget->getwidget());
     
     MCWidgetOnClose(p_widget -> getwidget());
 }
@@ -445,6 +451,12 @@ void MCWidgetEventManager::event_layerchanged(MCWidget* p_widget)
 
 void MCWidgetEventManager::event_visibilitychanged(MCWidget* p_widget, bool p_visible)
 {
+    /* Issue a cancel touches event if we are going invisible */
+    if (!p_visible)
+    {
+        event_cancel_touches(p_widget->getwidget());
+    }
+            
     MCWidgetOnVisibilityChanged(p_widget -> getwidget(), p_visible);
 }
 
@@ -496,25 +508,120 @@ void MCWidgetEventManager::event_paint(MCWidget *p_widget, MCGContextRef p_gcont
     MCWidgetOnPaint(p_widget -> getwidget(), p_gcontext);
 }
 
-void MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEventTouchPhase p_phase, int2 p_x, int2 p_y)
+Bool MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEventTouchPhase p_phase, int2 p_x, int2 p_y)
 {
+    if (!widgetIsInRunMode(p_widget))
+    {
+        return False;
+    }
+    
+    /* If a touch is just starting, and this is the first touch then we need
+     * to compute the touched widget. */
+    MCWidgetRef t_touched_widget = m_touched_widget;
+    if (p_phase == kMCEventTouchPhaseBegan)
+    {
+        if (t_touched_widget == nullptr)
+        {
+            t_touched_widget = hitTest(p_widget->getwidget(), p_x, p_y);
+        }
+    }
+    
+    /* If we don't have a touched widget, then ignore the touch. */
+    if (t_touched_widget == nullptr)
+    {
+        return False;
+    }
+    
+    /* See if there is already a slot for the given touch. If none is found
+     * and this is not a begin, we ignore it - otherwise we create one. */
+    uinteger_t t_slot;
+    if (!findTouchSlotById(p_id, t_slot))
+    {
+        if (p_phase == kMCEventTouchPhaseBegan)
+        {
+            t_slot = allocateTouchSlot();
+            m_touches[t_slot].m_id = p_id;
+        }
+        else
+        {
+            return False;
+        }
+    }
+    else if (p_phase == kMCEventTouchPhaseBegan)
+    {
+        /* This shouldn't happen - it would mean we are getting two began
+         * phases for the same touch, so we ignore it. */
+        return False;
+    }
+    
+    /* Assign the touched widget (which will be the same as the widget which
+     * was touched by the first touch in a sequence - i.e. the first touched
+     * widget grabs all touches. */
+    MCValueAssign(m_touched_widget, t_touched_widget);
+    
+    /* Update the position information in the touch. */
+    m_touches[t_slot].m_x = p_x;
+    m_touches[t_slot].m_y = p_y;
+    
+    /* Update the 'current' touch id - i.e the touch which is pertinent to
+     * this event. */
+    m_touch_id = p_id;
+    
+    /* Process the specific kind of touch. */
     switch (p_phase)
     {
         case kMCEventTouchPhaseBegan:
-            touchBegin(p_widget, p_id, p_x, p_y);
+            bubbleEvent(m_touched_widget, MCWidgetOnTouchStart);
             break;
             
         case kMCEventTouchPhaseMoved:
-            touchMove(p_widget, p_id, p_x, p_y);
+            bubbleEvent(m_touched_widget, MCWidgetOnTouchMove);
             break;
             
         case kMCEventTouchPhaseEnded:
-            touchEnd(p_widget, p_id, p_x, p_y);
+            bubbleEvent(m_touched_widget, MCWidgetOnTouchFinish);
             break;
             
         case kMCEventTouchPhaseCancelled:
-            touchCancel(p_widget, p_id, p_x, p_y);
+            bubbleEvent(m_touched_widget, MCWidgetOnTouchCancel);
             break;
+    }
+    
+    /* The touch id is only valid whilst an event is happening */
+    m_touch_id = 0;
+    
+    /* If the phase ends the touch, then free the slot and release the touched
+     * widget if there are no other touches. */
+    if (p_phase == kMCEventTouchPhaseEnded ||
+        p_phase == kMCEventTouchPhaseCancelled)
+    {
+        freeTouchSlot(t_slot);
+        if (m_touch_count == 0)
+        {
+            MCValueAssignOptional(m_touched_widget, nullptr);
+        }
+    }
+    
+    return True;
+}
+
+void MCWidgetEventManager::event_cancel_touches(MCWidgetRef p_widget)
+{
+    /* If there is a touched widget, and the p_widget is an ancestor of it then
+     * we must make sure all touches are cancelled. */
+    if (m_touched_widget != nullptr &&
+        MCWidgetIsAncestorOf(p_widget, m_touched_widget))
+    {
+        /* Loop through all touches and cancel the active ones. This will also
+         * cause m_touched_widget to be unset after the last active touch is
+         * cancelled. */
+        for(uindex_t i = 0; i < m_touches.Size(); i++)
+        {
+            if (m_touches[i].m_active)
+            {
+                event_touch(MCWidgetGetHost(p_widget), m_touches[i].m_id, kMCEventTouchPhaseCancelled, m_touches[i].m_x, m_touches[i].m_y);
+            }
+        }
     }
 }
 
@@ -572,6 +679,9 @@ void MCWidgetEventManager::widget_disappearing(MCWidgetRef p_widget)
     if (m_mouse_grab != nil &&
         MCWidgetIsAncestorOf(p_widget, m_mouse_grab))
         mouseCancel(p_widget, 0);
+    
+    /* Cancel any touches */
+    event_cancel_touches(p_widget);
 }
 
 void MCWidgetEventManager::widget_sync(void)
@@ -633,6 +743,44 @@ void MCWidgetEventManager::GetAsynchronousClickPosition(coord_t& r_x, coord_t& r
     r_x = MCclicklocx;
     r_y = MCclicklocy;
 }
+
+uindex_t MCWidgetEventManager::GetTouchCount(void)
+{
+    return m_touch_count;
+}
+
+bool MCWidgetEventManager::GetActiveTouch(integer_t& r_index)
+{
+    if (m_touch_id == 0)
+    {
+        return false;
+    }
+    
+    uindex_t t_slot;
+    if (!findTouchSlotById(m_touch_id, t_slot))
+    {
+        return false;
+    }
+    
+    r_index = m_touches[t_slot].m_index;
+    
+    return true;
+}
+
+bool MCWidgetEventManager::GetTouchPosition(integer_t p_index, MCPoint& r_point)
+{
+    uinteger_t t_slot;
+    if (!findTouchSlotByIndex(p_index, t_slot))
+    {
+        return false;
+    }
+    
+    r_point.x = m_touches[t_slot].m_x;
+    r_point.y = m_touches[t_slot].m_y;
+    
+    return false;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -919,199 +1067,59 @@ bool MCWidgetEventManager::keyUp(MCWidgetRef p_widget, MCStringRef p_string, Key
 #endif
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
-void MCWidgetEventManager::touchBegin(MCWidgetRef p_widget, uinteger_t p_id, coord_t p_x, coord_t p_y)
-{
-    // WIDGET-TODO: Reinstate touchBegin
-#if WIDGET_TOUCH_MESSAGES
-    // Check whether this touch already exists within our touch event list
-    uinteger_t t_slot;
-    if (findTouchSlot(p_id, t_slot))
-    {
-        // Already exists. This ought not to happen... ignore the event.
-        return;
-    }
-    
-    // Allocate a slot to store the event details
-    t_slot = allocateTouchSlot();
-    m_touches[t_slot].m_id = p_id;
-    m_touches[t_slot].m_widget = p_widget;
-    m_touches[t_slot].m_x = p_x;
-    m_touches[t_slot].m_y = p_y;
-    
-    if (!widgetIsInRunMode(p_widget))
-        return;
-    
-    // Send an event to the widget
-    if (p_widget->handlesTouches())
-        p_widget->OnTouchStart(p_id, p_x, p_y, 0.0, 0.0);
-    else if (p_id == 1)
-    {
-        mouseMove(p_widget, p_x, p_y);
-        mouseDown(p_widget, 1);
-    }
-#endif
-}
-
-void MCWidgetEventManager::touchMove(MCWidgetRef p_widget, uinteger_t p_id, coord_t p_x, coord_t p_y)
-{
-    // WIDGET-TODO: Reinstate touchMove
-#if WIDGET_TOUCH_MESSAGES
-    // Does this touch event exist in the list yet? If not, create it. (This
-    // might happen if a touch starts on a non-widget MCControl and later moves
-    // onto a widget).
-    uinteger_t t_slot;
-    if (!findTouchSlot(p_id, t_slot))
-    {
-        touchBegin(p_widget, p_id, p_x, p_y);
-        /* UNCHECKED */ findTouchSlot(p_id, t_slot);
-    }
-    else
-    {
-        // Pre-existing touch. Check for enter/leave events.
-        if (m_touches[t_slot].m_widget != p_widget)
-        {
-            touchLeave(m_touches[t_slot].m_widget, p_id);
-            m_touches[t_slot].m_widget = p_widget;
-            touchEnter(p_widget, p_id);
-        }
-        
-        // Update the touch status
-        m_touches[t_slot].m_x = p_x;
-        m_touches[t_slot].m_y = p_y;
-        
-        if (!widgetIsInRunMode(p_widget))
-            return;
-        
-        // Send a move event
-        if (p_widget->handlesTouches())
-            p_widget->OnTouchMove(p_id, p_x, p_y, 0, 0);
-        else if (p_id == 1)
-        {
-            mouseMove(p_widget, p_x, p_y);
-        }
-    }
-#endif
-}
-
-void MCWidgetEventManager::touchEnd(MCWidgetRef p_widget, uinteger_t p_id, coord_t p_x, coord_t p_y)
-{
-    // WIDGET-TODO: Reinstate touchEnd
-#if WIDGET_TOUCH_MESSAGES
-    // Ignore the event if this touch has not been registered
-    uinteger_t t_slot;
-    if (!findTouchSlot(p_id, t_slot))
-        return;
-    
-    // Update touch status
-    m_touches[t_slot].m_x = p_x;
-    m_touches[t_slot].m_y = p_y;
-    
-    if (!widgetIsInRunMode(p_widget))
-        return;
-    
-    // Send a touch finish event
-    if (p_widget->handlesTouches())
-        p_widget->OnTouchFinish(p_id, p_x, p_y);
-    else if (p_id == 1)
-    {
-        mouseMove(p_widget, p_x, p_y);
-        mouseUp(p_widget, 1);
-    }
-    
-    // Delete the event
-    freeTouchSlot(t_slot);
-#endif
-}
-
-void MCWidgetEventManager::touchCancel(MCWidgetRef p_widget, uinteger_t p_id, coord_t p_x, coord_t p_y)
-{
-    // WIDGET-TODO: Reinstate touchCancel
-#if WIDGET_TOUCH_MESSAGES
-    // Ignore the event if this touch has not been registered
-    uinteger_t t_slot;
-    if (!findTouchSlot(p_id, t_slot))
-        return;
-    
-    // Update touch status
-    m_touches[t_slot].m_x = p_x;
-    m_touches[t_slot].m_y = p_y;
-    
-    if (!widgetIsInRunMode(p_widget))
-        return;
-    
-    // Send a touch cancel event
-    if (p_widget->handlesTouches())
-        p_widget->OnTouchCancel(p_id);
-    else if (p_id == 1)
-    {
-        mouseMove(p_widget, p_x, p_y);
-        mouseRelease(p_widget, 1);
-    }
-    
-    // Delete the event
-    freeTouchSlot(t_slot);
-#endif
-}
-
-void MCWidgetEventManager::touchEnter(MCWidgetRef p_widget, uinteger_t p_id)
-{
-    // WIDGET-TODO: Reinstate touchEnter
-#if WIDGET_TOUCH_MESSAGES
-    if (!widgetIsInRunMode(p_widget))
-        return;
-    
-    if (p_widget->handlesTouches())
-        p_widget->OnTouchEnter(p_id);
-    else if (p_id == 1)
-    {
-        mouseEnter(p_widget);
-    }
-#endif
-}
-
-void MCWidgetEventManager::touchLeave(MCWidgetRef p_widget, uinteger_t p_id)
-{
-    // WIDGET-TODO: Reinstate touchLeave
-#if WIDGET_TOUCH_MESSAGES
-    if (!widgetIsInRunMode(p_widget))
-        return;
-    
-    if (p_widget->handlesTouches())
-        p_widget->OnTouchLeave(p_id);
-    else if (p_id == 1)
-    {
-        mouseLeave(p_widget);
-    }
-#endif
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
 uinteger_t MCWidgetEventManager::allocateTouchSlot()
 {
     // Search the list for an empty slot
-    for (uinteger_t i = 0; i < m_touches.Size(); i++)
+    uinteger_t i = 0;
+    for (; i < m_touches.Size(); i++)
     {
-        // Look for a slot with no widget
-        if (m_touches[i].m_widget == nil)
+        // Look for a slot which is not active.
+        if (!m_touches[i].m_active)
         {
-            return i;
+            break;
         }
     }
     
-    // No empty slots found. Extend the array.
-    /* UNCHECKED */ m_touches.Extend(m_touches.Size() + 1);
-    return m_touches.Size() - 1;
+    if (i == m_touches.Size())
+    {
+        // No empty slots found. Extend the array.
+        i = m_touches.Size();
+        /* UNCHECKED */ m_touches.Extend(i + 1);
+    }
+    
+    m_touches[i].m_active = true;
+    m_touches[i].m_index = ++m_touch_count;
+    
+    return i;
 }
 
-bool MCWidgetEventManager::findTouchSlot(uinteger_t p_id, uinteger_t& r_which)
+bool MCWidgetEventManager::findTouchSlotById(uinteger_t p_id, uinteger_t& r_which)
 {
     // Search the list for a touch event with the given ID
     for (uinteger_t i = 0; i < m_touches.Size(); i++)
     {
-        if (m_touches[i].m_id == p_id)
+        if (m_touches[i].m_active &&
+            m_touches[i].m_id == p_id)
+        {
+            r_which = i;
+            return true;
+        }
+    }
+    
+    // Could not find any touch event with that ID
+    return false;
+}
+
+bool MCWidgetEventManager::findTouchSlotByIndex(uinteger_t p_index, uinteger_t& r_which)
+{
+    // Search the list for a touch event with the given ID
+    for (uinteger_t i = 0; i < m_touches.Size(); i++)
+    {
+        if (m_touches[i].m_active &&
+            m_touches[i].m_index == p_index)
         {
             r_which = i;
             return true;
@@ -1125,7 +1133,8 @@ bool MCWidgetEventManager::findTouchSlot(uinteger_t p_id, uinteger_t& r_which)
 void MCWidgetEventManager::freeTouchSlot(uinteger_t p_which)
 {
     // Mark as free by clearing the widget pointer for the event
-    m_touches[p_which].m_widget = nil;
+    m_touches[p_which].m_active = false;
+    m_touch_count -= 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -1148,6 +1148,8 @@ uinteger_t MCWidgetEventManager::allocateTouchSlot()
     m_touches[i].m_active = true;
     m_touches[i].m_index = ++m_touch_sequence;
     
+    m_touch_count += 1;
+    
     return i;
 }
 

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -533,6 +533,13 @@ Bool MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEven
         return False;
     }
     
+    /* If we have a touched widget, but it doesn't want touch, let default
+     * processing occur. */
+    if (!MCWidgetHandlesTouchEvents(t_touched_widget))
+    {
+        return False;
+    }
+    
     /* See if there is already a slot for the given touch. If none is found
      * and this is not a begin, we ignore it - otherwise we create one. */
     uinteger_t t_slot;

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -787,7 +787,7 @@ bool MCWidgetEventManager::GetTouchPosition(integer_t p_index, MCPoint& r_point)
     r_point.x = m_touches[t_slot].m_x;
     r_point.y = m_touches[t_slot].m_y;
     
-    return false;
+    return true;
 }
 
 static compare_t _MCSortWidgetTouchIndexes(const MCValueRef *p_left, const MCValueRef *p_right)

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -509,11 +509,11 @@ void MCWidgetEventManager::event_paint(MCWidget *p_widget, MCGContextRef p_gcont
     MCWidgetOnPaint(p_widget -> getwidget(), p_gcontext);
 }
 
-Bool MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEventTouchPhase p_phase, int2 p_x, int2 p_y)
+bool MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEventTouchPhase p_phase, int2 p_x, int2 p_y)
 {
     if (!widgetIsInRunMode(p_widget))
     {
-        return False;
+        return false;
     }
     
     /* If a touch is just starting, and this is the first touch then we need
@@ -530,14 +530,14 @@ Bool MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEven
     /* If we don't have a touched widget, then ignore the touch. */
     if (t_touched_widget == nullptr)
     {
-        return False;
+        return false;
     }
     
     /* If we have a touched widget, but it doesn't want touch, let default
      * processing occur. */
     if (!MCWidgetHandlesTouchEvents(t_touched_widget))
     {
-        return False;
+        return false;
     }
     
     /* See if there is already a slot for the given touch. If none is found
@@ -552,14 +552,14 @@ Bool MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEven
         }
         else
         {
-            return False;
+            return false;
         }
     }
     else if (p_phase == kMCEventTouchPhaseBegan)
     {
         /* This shouldn't happen - it would mean we are getting two began
          * phases for the same touch, so we ignore it. */
-        return False;
+        return false;
     }
     
     /* Assign the touched widget (which will be the same as the widget which
@@ -611,7 +611,7 @@ Bool MCWidgetEventManager::event_touch(MCWidget* p_widget, uint32_t p_id, MCEven
         }
     }
     
-    return True;
+    return true;
 }
 
 void MCWidgetEventManager::event_cancel_touches(MCWidgetRef p_widget)

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -1142,7 +1142,6 @@ uinteger_t MCWidgetEventManager::allocateTouchSlot()
     if (i == m_touches.Size())
     {
         // No empty slots found. Extend the array.
-        i = m_touches.Size();
         /* UNCHECKED */ m_touches.Extend(i + 1);
     }
     

--- a/engine/src/widget-events.h
+++ b/engine/src/widget-events.h
@@ -101,6 +101,7 @@ public:
     uindex_t GetTouchCount(void);
     bool GetActiveTouch(integer_t& r_index);
     bool GetTouchPosition(integer_t p_index, MCPoint& r_point);
+    bool GetTouchIDs(MCProperListRef& r_touch_ids);
     
 private:
     void TriggerEvent(MCWidgetRef widget, MCWidgetEventTriggerType type, MCNameRef event);
@@ -136,6 +137,7 @@ private:
     struct MCWidgetTouchEvent;
     MCAutoArray<MCWidgetTouchEvent> m_touches;
     uindex_t m_touch_count;
+    uindex_t m_touch_sequence;
     MCWidgetRef m_touched_widget;
     uindex_t m_touch_id;
     

--- a/engine/src/widget-events.h
+++ b/engine/src/widget-events.h
@@ -61,7 +61,7 @@ public:
     void event_visibilitychanged(MCWidget*, bool);
     
     // Non-MCControl event for handling touches
-    Bool event_touch(MCWidget*, uint32_t p_id, MCEventTouchPhase, int2 p_x, int2 p_y);
+    bool event_touch(MCWidget*, uint32_t p_id, MCEventTouchPhase, int2 p_x, int2 p_y);
     void event_cancel_touches(MCWidgetRef widget);
     
     // Non-MCControl events called by platform-specific gesture recognition

--- a/engine/src/widget-events.h
+++ b/engine/src/widget-events.h
@@ -61,7 +61,8 @@ public:
     void event_visibilitychanged(MCWidget*, bool);
     
     // Non-MCControl event for handling touches
-    void event_touch(MCWidget*, uint32_t p_id, MCEventTouchPhase, int2 p_x, int2 p_y);
+    Bool event_touch(MCWidget*, uint32_t p_id, MCEventTouchPhase, int2 p_x, int2 p_y);
+    void event_cancel_touches(MCWidgetRef widget);
     
     // Non-MCControl events called by platform-specific gesture recognition
     void event_gesture_begin(MCWidget*);    // Suppress touch events until end
@@ -96,6 +97,11 @@ public:
     void GetAsynchronousMousePosition(coord_t& r_x, coord_t& r_y) const;
     void GetAsynchronousClickPosition(coord_t& r_x, coord_t& r_y) const;
     
+    // Returns touch state
+    uindex_t GetTouchCount(void);
+    bool GetActiveTouch(integer_t& r_index);
+    bool GetTouchPosition(integer_t p_index, MCPoint& r_point);
+    
 private:
     void TriggerEvent(MCWidgetRef widget, MCWidgetEventTriggerType type, MCNameRef event);
     
@@ -129,6 +135,9 @@ private:
     // State for touch events
     struct MCWidgetTouchEvent;
     MCAutoArray<MCWidgetTouchEvent> m_touches;
+    uindex_t m_touch_count;
+    MCWidgetRef m_touched_widget;
+    uindex_t m_touch_id;
     
     // Common functions for mouse gesture processing
     MCWidgetRef hitTest(MCWidgetRef, coord_t x, coord_t y);
@@ -145,17 +154,10 @@ private:
     bool keyDown(MCWidgetRef, MCStringRef, KeySym);
     bool keyUp(MCWidgetRef, MCStringRef, KeySym);
     
-    // Common functions for touch gesture processing
-    void touchBegin(MCWidgetRef, uinteger_t p_id, coord_t p_x, coord_t p_y);
-    void touchMove(MCWidgetRef, uinteger_t p_id, coord_t p_x, coord_t p_y);
-    void touchEnd(MCWidgetRef, uinteger_t p_id, coord_t p_x, coord_t p_y);
-    void touchCancel(MCWidgetRef, uinteger_t p_id, coord_t p_x, coord_t p_y);
-    void touchEnter(MCWidgetRef, uinteger_t p_id);
-    void touchLeave(MCWidgetRef, uinteger_t p_id);
-    
     // Utility functions for managing touch events
     uinteger_t allocateTouchSlot();
-    bool findTouchSlot(uinteger_t p_id, uinteger_t& r_which);
+    bool findTouchSlotById(uinteger_t p_id, uinteger_t& r_which);
+    bool findTouchSlotByIndex(uinteger_t p_index, uinteger_t& r_which);
     void freeTouchSlot(uinteger_t p_which);
     
     // Indicates whether the given widget is in run mode or not

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -484,6 +484,26 @@ bool MCWidgetBase::OnMouseScroll(coord_t p_delta_x, coord_t p_delta_y, bool& r_b
     return DispatchBubbly(MCNAME("OnMouseScroll"), t_args . Ptr(), t_args . Count(), r_bubble);
 }
 
+bool MCWidgetBase::OnTouchStart(bool& r_bubble)
+{
+    return DispatchBubbly(MCNAME("OnTouchStart"), nil, 0, r_bubble);
+}
+
+bool MCWidgetBase::OnTouchMove(bool& r_bubble)
+{
+    return DispatchBubbly(MCNAME("OnTouchMove"), nil, 0, r_bubble);
+}
+
+bool MCWidgetBase::OnTouchFinish(bool& r_bubble)
+{
+    return DispatchBubbly(MCNAME("OnTouchFinish"), nil, 0, r_bubble);
+}
+
+bool MCWidgetBase::OnTouchCancel(bool& r_bubble)
+{
+    return DispatchBubbly(MCNAME("OnTouchCancel"), nil, 0, r_bubble);
+}
+
 bool MCWidgetBase::OnGeometryChanged(void)
 {
     return Dispatch(MCNAME("OnGeometryChanged"));
@@ -1338,6 +1358,26 @@ bool MCWidgetOnClick(MCWidgetRef self, bool& r_bubble)
 bool MCWidgetOnMouseScroll(MCWidgetRef self, real32_t p_delta_x, real32_t p_delta_y, bool& r_bubble)
 {
     return MCWidgetAsBase(self) -> OnMouseScroll(p_delta_x, p_delta_y, r_bubble);
+}
+
+bool MCWidgetOnTouchStart(MCWidgetRef self, bool& r_bubble)
+{
+    return MCWidgetAsBase(self)->OnTouchStart(r_bubble);
+}
+
+bool MCWidgetOnTouchMove(MCWidgetRef self, bool& r_bubble)
+{
+    return MCWidgetAsBase(self)->OnTouchMove(r_bubble);
+}
+
+bool MCWidgetOnTouchFinish(MCWidgetRef self, bool& r_bubble)
+{
+    return MCWidgetAsBase(self)->OnTouchFinish(r_bubble);
+}
+
+bool MCWidgetOnTouchCancel(MCWidgetRef self, bool& r_bubble)
+{
+    return MCWidgetAsBase(self)->OnTouchCancel(r_bubble);
 }
 
 bool MCWidgetOnGeometryChanged(MCWidgetRef self)

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -484,6 +484,25 @@ bool MCWidgetBase::OnMouseScroll(coord_t p_delta_x, coord_t p_delta_y, bool& r_b
     return DispatchBubbly(MCNAME("OnMouseScroll"), t_args . Ptr(), t_args . Count(), r_bubble);
 }
 
+bool MCWidgetBase::HandlesTouchEvents(void)
+{
+    if (HasHandler(MCNAME("OnTouchStart")) ||
+        HasHandler(MCNAME("OnTouchMove")) ||
+        HasHandler(MCNAME("OnTouchFinish")) ||
+        HasHandler(MCNAME("OnTouchCancel")))
+    {
+        return true;
+    }
+    
+    MCWidgetRef t_owner = GetOwner();
+    if (t_owner != nullptr)
+    {
+        return MCWidgetHandlesTouchEvents(t_owner);
+    }
+    
+    return false;
+}
+
 bool MCWidgetBase::OnTouchStart(bool& r_bubble)
 {
     return DispatchBubbly(MCNAME("OnTouchStart"), nil, 0, r_bubble);
@@ -1358,6 +1377,13 @@ bool MCWidgetOnClick(MCWidgetRef self, bool& r_bubble)
 bool MCWidgetOnMouseScroll(MCWidgetRef self, real32_t p_delta_x, real32_t p_delta_y, bool& r_bubble)
 {
     return MCWidgetAsBase(self) -> OnMouseScroll(p_delta_x, p_delta_y, r_bubble);
+}
+
+/* TOUCH MESSAGE METHODS */
+
+bool MCWidgetHandlesTouchEvents(MCWidgetRef self)
+{
+    return MCWidgetAsBase(self)->HandlesTouchEvents();
 }
 
 bool MCWidgetOnTouchStart(MCWidgetRef self, bool& r_bubble)

--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -75,6 +75,11 @@ public:
     
     bool OnClick(bool& r_bubble);
     
+    bool OnTouchStart(bool& r_bubble);
+    bool OnTouchMove(bool& r_bubble);
+    bool OnTouchFinish(bool& r_bubble);
+    bool OnTouchCancel(bool& r_bubble);
+    
     bool OnGeometryChanged(void);
     bool OnLayerChanged();
     bool OnParentPropertyChanged(void);

--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -75,6 +75,7 @@ public:
     
     bool OnClick(bool& r_bubble);
     
+    bool HandlesTouchEvents(void);
     bool OnTouchStart(bool& r_bubble);
     bool OnTouchMove(bool& r_bubble);
     bool OnTouchFinish(bool& r_bubble);

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -380,6 +380,63 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetClickCount(bool p_current, unsigned 
 
 ////////////////////////////////////////////////////////////////////////////////
 
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetTouchIndex(MCValueRef& r_index)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    integer_t t_index;
+    if (!MCwidgeteventmanager->GetActiveTouch(t_index))
+    {
+        r_index = MCValueRetain(kMCNull);
+        return;
+    }
+    
+    MCNumberCreateWithInteger(t_index, (MCNumberRef&)r_index);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetTouchPosition(MCValueRef& r_point)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    integer_t t_index;
+    MCPoint t_position;
+    if (!MCwidgeteventmanager->GetActiveTouch(t_index) ||
+        !MCwidgeteventmanager->GetTouchPosition(t_index, t_position))
+    {
+        r_point = MCValueRetain(kMCNull);
+        return;
+    }
+
+    /* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(MCWidgetMapPointFromGlobal(MCcurrentwidget, MCPointToMCGPoint(t_position)), (MCCanvasPointRef&)r_point);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetNumberOfTouches(uinteger_t& r_count)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    r_count = MCwidgeteventmanager->GetTouchCount();
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetPositionOfTouch(integer_t p_id, MCValueRef& r_point)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    MCPoint t_position;
+    if (!MCwidgeteventmanager->GetTouchPosition(p_id, t_position))
+    {
+        r_point = MCValueRetain(kMCNull);
+        return;
+    }
+    
+    /* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(MCWidgetMapPointFromGlobal(MCcurrentwidget, MCPointToMCGPoint(t_position)), (MCCanvasPointRef&)r_point);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 typedef struct __MCPressedState* MCPressedStateRef;
 MCTypeInfoRef kMCPressedState;
 

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -380,19 +380,19 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetClickCount(bool p_current, unsigned 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern "C" MC_DLLEXPORT_DEF void MCWidgetGetTouchIndex(MCValueRef& r_index)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetTouchId(MCValueRef& r_id)
 {
     if (!MCWidgetEnsureCurrentWidget())
         return;
     
-    integer_t t_index;
-    if (!MCwidgeteventmanager->GetActiveTouch(t_index))
+    integer_t t_id;
+    if (!MCwidgeteventmanager->GetActiveTouch(t_id))
     {
-        r_index = MCValueRetain(kMCNull);
+        r_id = MCValueRetain(kMCNull);
         return;
     }
     
-    MCNumberCreateWithInteger(t_index, (MCNumberRef&)r_index);
+    MCNumberCreateWithInteger(t_id, (MCNumberRef&)r_id);
 }
 
 extern "C" MC_DLLEXPORT_DEF void MCWidgetGetTouchPosition(MCValueRef& r_point)
@@ -400,10 +400,10 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetTouchPosition(MCValueRef& r_point)
     if (!MCWidgetEnsureCurrentWidget())
         return;
     
-    integer_t t_index;
+    integer_t t_id;
     MCPoint t_position;
-    if (!MCwidgeteventmanager->GetActiveTouch(t_index) ||
-        !MCwidgeteventmanager->GetTouchPosition(t_index, t_position))
+    if (!MCwidgeteventmanager->GetActiveTouch(t_id) ||
+        !MCwidgeteventmanager->GetTouchPosition(t_id, t_position))
     {
         r_point = MCValueRetain(kMCNull);
         return;
@@ -420,13 +420,13 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetNumberOfTouches(uinteger_t& r_count)
     r_count = MCwidgeteventmanager->GetTouchCount();
 }
 
-extern "C" MC_DLLEXPORT_DEF void MCWidgetGetPositionOfTouch(integer_t p_index, MCValueRef& r_point)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetPositionOfTouch(integer_t p_id, MCValueRef& r_point)
 {
     if (!MCWidgetEnsureCurrentWidget())
         return;
     
     MCPoint t_position;
-    if (!MCwidgeteventmanager->GetTouchPosition(p_index, t_position))
+    if (!MCwidgeteventmanager->GetTouchPosition(p_id, t_position))
     {
         r_point = MCValueRetain(kMCNull);
         return;

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -420,19 +420,35 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetNumberOfTouches(uinteger_t& r_count)
     r_count = MCwidgeteventmanager->GetTouchCount();
 }
 
-extern "C" MC_DLLEXPORT_DEF void MCWidgetGetPositionOfTouch(integer_t p_id, MCValueRef& r_point)
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetPositionOfTouch(integer_t p_index, MCValueRef& r_point)
 {
     if (!MCWidgetEnsureCurrentWidget())
         return;
     
     MCPoint t_position;
-    if (!MCwidgeteventmanager->GetTouchPosition(p_id, t_position))
+    if (!MCwidgeteventmanager->GetTouchPosition(p_index, t_position))
     {
         r_point = MCValueRetain(kMCNull);
         return;
     }
     
     /* UNCHECKED */ MCCanvasPointCreateWithMCGPoint(MCWidgetMapPointFromGlobal(MCcurrentwidget, MCPointToMCGPoint(t_position)), (MCCanvasPointRef&)r_point);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetTouchIDs(MCValueRef& r_touch_ids)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    MCAutoProperListRef t_touch_ids;
+    if (!MCwidgeteventmanager->GetTouchIDs(&t_touch_ids) ||
+        MCProperListIsEmpty(*t_touch_ids))
+    {
+        r_touch_ids = MCValueRetain(kMCNull);
+        return;
+    }
+    
+    r_touch_ids = t_touch_ids.Take();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -84,6 +84,11 @@ bool MCWidgetOnClick(MCWidgetRef widget, bool& r_bubble);
 
 bool MCWidgetOnMouseScroll(MCWidgetRef widget, real32_t delta_x, real32_t delta_y, bool& r_bubble);
 
+bool MCWidgetOnTouchStart(MCWidgetRef p_widget, bool& r_bubble);
+bool MCWidgetOnTouchMove(MCWidgetRef p_widget, bool& r_bubble);
+bool MCWidgetOnTouchFinish(MCWidgetRef p_widget, bool& r_bubble);
+bool MCWidgetOnTouchCancel(MCWidgetRef p_widget, bool& r_bubble);
+
 bool MCWidgetOnGeometryChanged(MCWidgetRef widget);
 bool MCWidgetOnLayerChanged(MCWidgetRef widget);
 bool MCWidgetOnParentPropertyChanged(MCWidgetRef widget);

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -84,6 +84,7 @@ bool MCWidgetOnClick(MCWidgetRef widget, bool& r_bubble);
 
 bool MCWidgetOnMouseScroll(MCWidgetRef widget, real32_t delta_x, real32_t delta_y, bool& r_bubble);
 
+bool MCWidgetHandlesTouchEvents(MCWidgetRef p_widget);
 bool MCWidgetOnTouchStart(MCWidgetRef p_widget, bool& r_bubble);
 bool MCWidgetOnTouchMove(MCWidgetRef p_widget, bool& r_bubble);
 bool MCWidgetOnTouchFinish(MCWidgetRef p_widget, bool& r_bubble);

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -663,10 +663,11 @@ public foreign handler MCWidgetGetClickPosition(in pCurrent as CBool, out rLocat
 public foreign handler MCWidgetGetClickButton(in pCurrent as CBool, out rButton as CUInt) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetClickCount(in pCurrent as CBool, out rCount as CUInt) returns nothing binds to "<builtin>"
 
-public foreign handler MCWidgetGetTouchIndex(out rId as optional Integer) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetTouchIndex(out rIndex as optional Integer) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetTouchPosition(out rLocation as optional Point) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetNumberOfTouches(out rCount as CUInt) returns nothing binds to "<builtin>"
-public foreign handler MCWidgetGetPositionOfTouch(in pId as Integer, out rLocation as optional Point) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetPositionOfTouch(in pIndex as Integer, out rLocation as optional Point) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetTouchIDs(out tIDs as optional List) returns nothing binds to "<builtin>"
 
 --public foreign handler MCWidgetGetMouseButtonState(in pIndex as LCUInt, out rPressed /*as PressedState*/) returns nothing binds to "<builtin>"
 --public foreign handler MCWidgetGetModifierKeys(in pCurrent as CBool, out rKeys as List) returns nothing binds to "<builtin>"
@@ -777,28 +778,28 @@ begin
 end syntax*/
 
 /**
-Summary:        The index of the current touch
+Summary: The id of the current touch
 
-Returns:        An integer index for the current touch
+Returns: An integer id for the current touch
 
 Example:
-   variable tIndex as Number
-   put the touch index into tIndex
+   variable tID as Number
+   put the touch id into tID
 
    variable tPosition as Point
-   put the position of touch tIndex into tPosition
+   put the position of touch tID into tPosition
 */
 
 syntax TheTouchIndex is expression
-    "the" "touch" "index"
+    "the" "touch" "id"
 begin
     MCWidgetGetTouchIndex(output)
 end syntax
 
 /**
-Summary:        The location of the current touch
+Summary: The location of the current touch
 
-Returns:        The position of the current touch relative to the widget
+Returns: The position of the current touch relative to the widget
 
 Example:
    variable tPosition as Point
@@ -819,9 +820,9 @@ begin
 end syntax
 
 /**
-Summary:        The number of touches
+Summary: The number of touches
 
-Returns:       The number of currently active touches
+Returns: The number of currently active touches
 
 Example:
    if the number of touches is 2 then
@@ -836,22 +837,42 @@ begin
 end syntax
 
 /**
-Summary:        The location of a specific touch
+Summary: The location of a specific touch
 
-Returns:       The positon of a specific touch index relative to the widget
+Returns: The positon of a specific touch id relative to the widget
 
 Example:
-   variable tIndex as Number
-   put the touch index into tIndex
+   variable tID as Number
+   put the touch id into tID
 
    variable tPosition as Point
-   put the position of touch tIndex into tPosition
+   put the position of touch tID into tPosition
 
 */
 syntax TheLocationOfTouch is prefix operator with property precedence
     "the" "position" "of" "touch" <Id: Expression>
 begin
     MCWidgetGetPositionOfTouch(Id, output)
+end syntax
+
+/**
+Summary: The touch IDs
+
+Returns: The a list of currently active touch IDs
+
+Example:
+variable tIDs as optional List
+put the touch ids into tIDs
+if tIDs is not nothing then
+    variable tPosition as Point
+    put the position of touch tIDs[1] into tPosition
+end if
+
+*/
+syntax TheTouchIDs is expression
+    "the" "touch" "ids"
+begin
+    MCWidgetGetTouchIDs(output)
 end syntax
 
 -- FIXME not actually implemented

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -642,6 +642,11 @@ public foreign handler MCWidgetGetClickPosition(in pCurrent as CBool, out rLocat
 public foreign handler MCWidgetGetClickButton(in pCurrent as CBool, out rButton as CUInt) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetClickCount(in pCurrent as CBool, out rCount as CUInt) returns nothing binds to "<builtin>"
 
+public foreign handler MCWidgetGetTouchIndex(out rId as optional Integer) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetTouchPosition(out rLocation as optional Point) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetNumberOfTouches(out rCount as CUInt) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetPositionOfTouch(in pId as Integer, out rLocation as optional Point) returns nothing binds to "<builtin>"
+
 --public foreign handler MCWidgetGetMouseButtonState(in pIndex as LCUInt, out rPressed /*as PressedState*/) returns nothing binds to "<builtin>"
 --public foreign handler MCWidgetGetModifierKeys(in pCurrent as CBool, out rKeys as List) returns nothing binds to "<builtin>"
 
@@ -749,6 +754,30 @@ syntax TheMouseButtonState is expression
 begin
     MCWidgetGetMouseButtonState(Index, output)
 end syntax*/
+
+syntax TheTouchIndex is expression
+    "the" "touch" "index"
+begin
+    MCWidgetGetTouchIndex(output)
+end syntax
+
+syntax TheTouchLocation is expression
+    "the" "touch" "position"
+begin
+    MCWidgetGetTouchPosition(output)
+end syntax
+
+syntax TheNumberOfTouches is expression
+    "the" "number" "of" "touches"
+begin
+    MCWidgetGetNumberOfTouches(output)
+end syntax
+
+syntax TheLocationOfTouch is prefix operator with property precedence
+    "the" "position" "of" "touch" <Id: Expression>
+begin
+    MCWidgetGetPositionOfTouch(Id, output)
+end syntax
 
 -- FIXME not actually implemented
 /*

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -663,10 +663,10 @@ public foreign handler MCWidgetGetClickPosition(in pCurrent as CBool, out rLocat
 public foreign handler MCWidgetGetClickButton(in pCurrent as CBool, out rButton as CUInt) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetClickCount(in pCurrent as CBool, out rCount as CUInt) returns nothing binds to "<builtin>"
 
-public foreign handler MCWidgetGetTouchIndex(out rIndex as optional Integer) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetTouchId(out rId as optional Integer) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetTouchPosition(out rLocation as optional Point) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetNumberOfTouches(out rCount as CUInt) returns nothing binds to "<builtin>"
-public foreign handler MCWidgetGetPositionOfTouch(in pIndex as Integer, out rLocation as optional Point) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetPositionOfTouch(in pId as Integer, out rLocation as optional Point) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetTouchIDs(out tIDs as optional List) returns nothing binds to "<builtin>"
 
 --public foreign handler MCWidgetGetMouseButtonState(in pIndex as LCUInt, out rPressed /*as PressedState*/) returns nothing binds to "<builtin>"
@@ -790,10 +790,10 @@ Example:
    put the position of touch tID into tPosition
 */
 
-syntax TheTouchIndex is expression
+syntax TheTouchId is expression
     "the" "touch" "id"
 begin
-    MCWidgetGetTouchIndex(output)
+    MCWidgetGetTouchId(output)
 end syntax
 
 /**

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -281,7 +281,28 @@ Summary: Sent when the mouse pointer continues to hover outside of the widget's 
 Name: OnTouchStart
 Type: message
 Syntax: OnTouchStart
-Summary: Sent when a touch event begins within the widget's rect.
+Summary: Sent when the widget is the target for touch events and a touch is started.
+
+Description:
+The widget becomes the target for touch events when the first touch is
+within its rect. The widget remains the target for touch events until
+all touches end or are cancelled.
+
+Name: OnTouchMove
+Type: message
+Syntax: OnTouchMove
+Summary: Sent to the target for touch events when a touch moves.
+
+Name: OnTouchFinish
+Type: message
+Syntax: OnTouchFinish
+Summary: Sent to the target for touch events when a touch event ends.
+
+Name: OnTouchCancel
+Type: message
+Syntax: OnTouchCancel
+Summary: Sent to the target for touch events when a touch event is cancelled.
+
 
 Name: OnFocusEnter
 Type: message
@@ -755,24 +776,78 @@ begin
     MCWidgetGetMouseButtonState(Index, output)
 end syntax*/
 
+/**
+Summary:        The index of the current touch
+
+Returns:        An integer index for the current touch
+
+Example:
+   variable tIndex as Number
+   put the touch index into tIndex
+
+   variable tPosition as Point
+   put the position of touch tIndex into tPosition
+*/
+
 syntax TheTouchIndex is expression
     "the" "touch" "index"
 begin
     MCWidgetGetTouchIndex(output)
 end syntax
 
+/**
+Summary:        The location of the current touch
+
+Returns:        The position of the current touch relative to the widget
+
+Example:
+   variable tPosition as Point
+   put the touch position into tPosition
+
+   variable tRect as Rectangle
+   put my bounds into tRect
+
+   if tPosition is within tRect then
+      // touch position is within the widget bounds
+   end if
+
+*/
 syntax TheTouchLocation is expression
     "the" "touch" "position"
 begin
     MCWidgetGetTouchPosition(output)
 end syntax
 
+/**
+Summary:        The number of touches
+
+Returns:       The number of currently active touches
+
+Example:
+   if the number of touches is 2 then
+      // pinch gesture
+   end if
+
+*/
 syntax TheNumberOfTouches is expression
     "the" "number" "of" "touches"
 begin
     MCWidgetGetNumberOfTouches(output)
 end syntax
 
+/**
+Summary:        The location of a specific touch
+
+Returns:       The positon of a specific touch index relative to the widget
+
+Example:
+   variable tIndex as Number
+   put the touch index into tIndex
+
+   variable tPosition as Point
+   put the position of touch tIndex into tPosition
+
+*/
 syntax TheLocationOfTouch is prefix operator with property precedence
     "the" "position" "of" "touch" <Id: Expression>
 begin

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2017,6 +2017,8 @@ MC_DLLEXPORT bool MCNumberCreateWithInteger(integer_t value, MCNumberRef& r_numb
 MC_DLLEXPORT bool MCNumberCreateWithUnsignedInteger(uinteger_t value, MCNumberRef& r_number);
 MC_DLLEXPORT bool MCNumberCreateWithReal(real64_t value, MCNumberRef& r_number);
 
+MC_DLLEXPORT compare_t MCNumberCompareTo(MCNumberRef self, MCNumberRef p_other_self);
+
 MC_DLLEXPORT bool MCNumberIsInteger(MCNumberRef number);
 MC_DLLEXPORT bool MCNumberIsReal(MCNumberRef number);
 


### PR DESCRIPTION
This patch implements OnTouch(Start|Finish|Move|Cancel) in widgets.

The widget which hit-tests for the first touch in a sequence grabs
all touches in that sequence. The event handlers take no arguments, but instead the
full touch state is available through syntax. If the widget
becomes invisible, or is closed whilst active touches are present
Cancel is sent for all of them.

The currently active touch (the one which caused the event to
bubble) can be found by using ```the touch index```, and its
position using ```the touch position```.

The number of touches currently in progress can be found by using
```the number of touches``` and the position of a given touch using
```the position of touch tIndex```.

Note: Due to the way touch messages are currently processed above
the widget event system, widgets will receive mouse messages and
*then* touch messages. To make a widget which works on both Desktop
and Mobile, and wants touches on Mobile, the widget must have both
mouse and touch handlers, and check for platform in the mouse handlers.