### PR TITLE
[[ Bug 19652 ]] Refresh player when mirroring changes

### DIFF
--- a/docs/notes/bugfix-19652.md
+++ b/docs/notes/bugfix-19652.md
@@ -1,0 +1,1 @@
+# Refresh player on windows when mirroring property is set

--- a/engine/src/w32-ds-player.cpp
+++ b/engine/src/w32-ds-player.cpp
@@ -1129,6 +1129,15 @@ bool MCWin32DSPlayer::SetMirrored(bool p_mirrored)
 	if (!SUCCEEDED(t_mc9->SetOutputRect(0, &t_rect)))
 		return false;
 
+	if (m_state != kMCWin32DSPlayerRunning)
+	{
+		MCPlatformPlayerDuration t_duration;
+		if (GetCurrentPosition(t_duration))
+		{
+			SetCurrentPosition(t_duration);
+		}
+	}
+
 	m_mirrored = p_mirrored;
 	return true;
 }


### PR DESCRIPTION
This patch ensures that the player is refreshed when the mirroring
property changes. Previously there was no visible change until the
video was played.