### PR TITLE
[[ MyPixelScale ]] Implement my pixel scale expression

### DIFF
--- a/docs/lcb/notes/feature-my_pixel_scale.md
+++ b/docs/lcb/notes/feature-my_pixel_scale.md
@@ -1,0 +1,9 @@
+# LiveCode Builder Host Library
+## Widget library
+
+A new expression `my pixel scale` has been implemented. Use the widget's
+pixel scale to calculate the size of an image to draw. For example,
+when drawing an image to `my bounds` create an image sized using
+`my width * my pixel scale, my height * my pixel scale` otherwise the image will be
+stretched to match the pixel scale. The pixel scale is a per-window/screen property
+so may change if the user moves a window to a new screen.

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -316,6 +316,14 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMyPaint(uinteger_t p_type, MCCanvasP
     MCCanvasSolidPaintMakeWithColor(kMCCanvasColorBlack, (MCCanvasSolidPaintRef&)r_paint);
 }
 
+extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMyPixelScale(MCCanvasFloat& r_pixel_scale)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    r_pixel_scale = MCWidgetGetHost(MCcurrentwidget)->getstack()->view_getbackingscale();
+}
+
 extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMousePosition(bool p_current, MCCanvasPointRef& r_point)
 {
     if (!MCWidgetEnsureCurrentWidget())

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -520,6 +520,7 @@ public foreign handler MCWidgetGetMyFont(out rFont as Font) returns nothing bind
 public foreign handler MCWidgetGetMyEnabled(out rEnabled as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetMyDisabled(out rDisabled as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetMyPaint(in pPaintType as CUInt, out rPaint as Paint) returns nothing binds to "<builtin>"
+public foreign handler MCWidgetGetMyPixelScale(out rPixelScale as CanvasFloat) returns nothing binds to "<builtin>"
 
 /**
 Summary:	Returns the widget script object.
@@ -652,6 +653,24 @@ syntax MyPaint is expression
             "focus" <mPaintType=7> ) "paint"
 begin
     MCWidgetGetMyPaint(mPaintType, output)
+end syntax
+
+/**
+Summary:    Returns the scaling factor of pixels for the widget
+
+Description:
+Use the widget's pixel scale to calculate the size of an image to draw. For example,
+when drawing an image to `my bounds` create an image sized using
+`my width * my pixel scale, my height * my pixel scale` otherwise the image will be
+stretched to match the pixel scale. The pixel scale is a per-window/screen property
+so may change if the user moves a window to a new screen.
+
+Returns:    The current scaling factor of pixels for the widget
+*/
+syntax MyPixelScale is expression
+    "my" "pixel" "scale"
+begin
+    MCWidgetGetMyPixelScale(output)
 end syntax
 
 // ---------- Synchronous and asynchronous ("current") event information ---------- //


### PR DESCRIPTION
This patch implements `my pixel scale` as an expression for
widgets to determine the current backing scale of the stack
they are on.