### PR TITLE
[[ Bug 20991 ]] Use win32 in code library path

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -24,6 +24,10 @@
 				{
 					'platform_id': 'universal-<(OS)-<(target_sdk)',
 				},
+				'(OS == "win")',
+				{
+				'platform_id': '<(uniform_arch)-win32',
+				},
 				{
 					'platform_id': '<(uniform_arch)-<(OS)',
 				},

--- a/docs/notes/bugfix-20991.md
+++ b/docs/notes/bugfix-20991.md
@@ -1,0 +1,1 @@
+# Use `win32` instead of `win` in code library path to conform to platform id spec

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2473,7 +2473,7 @@ private command __UpdateSettingsFromCodeFolder pPath, pCodeFolderName, pPlatform
          if pPlatform is "MacOSX" then
             put "mac" into pPlatform
          else if pPlatform is "Windows" then
-            put "win" into pPlatform
+            put "win32" into pPlatform
          end if
          
          if pPlatform is among the items of "mac,ios" then


### PR DESCRIPTION
The platform ID spec has `win32` rather than `win` in the
as the OS name. This patch fixes the code library path to
conform to the spec.