### PR TITLE
[[ WidgetFocus ]] Implement widget focus

### DIFF
--- a/docs/lcb/notes/feature-widget_focus.md
+++ b/docs/lcb/notes/feature-widget_focus.md
@@ -1,0 +1,12 @@
+# LiveCode Builder Host Library
+## Widget library
+
+New statements have been implemented to manage widget focus.
+
+- `focus in` - Set the keyboard focus to the widget
+- `focus out` - Focus on no control
+- `focus next` - Focus on the next control with traversal on
+- `focus previous` - Focus on the previous control with traversal on
+
+Additionally the messages `OnFocusEnter` and `OnFocusLeave` have been
+implemented to allow a widget to handle focus changes.

--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -110,9 +110,11 @@ public foreign handler MCBrowserDictionaryGetDictionary(in pDictionary as MCBrow
 
 public foreign handler type MCBrowserRequestCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pType as MCBrowserRequestType, in pState as MCBrowserRequestState, in pFrame as CBool, in pUrl as ZStringUTF8, in pError as optional ZStringUTF8) returns nothing
 public foreign handler type MCBrowserJavaScriptCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pHandler as ZStringUTF8, in pParams as MCBrowserListRef) returns nothing
+public foreign handler type MCBrowserFocusCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef) returns nothing
 
 public foreign handler MCBrowserSetRequestHandler(in pBrowser as MCBrowserRef, in pCallback as MCBrowserRequestCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 public foreign handler MCBrowserSetJavaScriptHandler(in pBrowser as MCBrowserRef, in pCallback as MCBrowserJavaScriptCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+public foreign handler MCBrowserSetFocusHandler(in pBrowser as MCBrowserRef, in pCallback as MCBrowserFocusCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 
 --------------------------------------------------------------------------------
 

--- a/engine/src/java/com/runrev/android/libraries/LibBrowser.java
+++ b/engine/src/java/com/runrev/android/libraries/LibBrowser.java
@@ -228,6 +228,8 @@ class LibBrowserWebView extends WebView
 						if (!v.hasFocus())
 						{
 							v.requestFocus();
+                            doFocus();
+                            wakeEngineThread();
 						}
 						break;
 				}
@@ -649,4 +651,5 @@ class LibBrowserWebView extends WebView
 	public native void doFinishedLoading(String url);
 	public native void doLoadingError(String url, String error);
 	public native void doUnsupportedScheme(String url);
+    public native void doFocus();
 }

--- a/engine/src/widget-events.cpp
+++ b/engine/src/widget-events.cpp
@@ -187,27 +187,19 @@ void MCWidgetEventManager::event_close(MCWidget* p_widget)
 
 void MCWidgetEventManager::event_kfocus(MCWidget* p_widget)
 {
-    // WIDGET-TODO: Reinstate FocusEnter
-    
-#if WIDGET_KEYBOARD_FOCUS
     // Keyboard focus has changed
     m_keyboard_focus = p_widget;
     
-    p_widget->OnFocusEnter();
-#endif
+    bubbleEvent(p_widget, MCWidgetOnFocusEnter);
 }
 
 void MCWidgetEventManager::event_kunfocus(MCWidget* p_widget)
 {
-    // WIDGET-TODO: Reinstate FocusLeave
-    
-#if WIDGET_KEYBOARD_FOCUS
     // Keyboard focus has changed
     // TODO: does the unfocus *always* happen before the next focus?
     m_keyboard_focus = nil;
     
-    p_widget->OnFocusLeave();
-#endif
+    bubbleEvent(p_widget, MCWidgetOnFocusLeave);
 }
 
 Boolean MCWidgetEventManager::event_kdown(MCWidget* p_widget, MCStringRef p_text, KeySym p_key)

--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -469,6 +469,16 @@ bool MCWidgetBase::OnClick(bool& r_bubble)
     return DispatchBubbly(MCNAME("OnClick"), nil, 0, r_bubble);
 }
 
+bool MCWidgetBase::OnFocusEnter(bool& r_bubble)
+{
+    return DispatchBubbly(MCNAME("OnFocusEnter"), nil, 0, r_bubble);
+}
+
+bool MCWidgetBase::OnFocusLeave(bool& r_bubble)
+{
+    return DispatchBubbly(MCNAME("OnFocusLeave"), nil, 0, r_bubble);
+}
+
 bool MCWidgetBase::OnMouseScroll(coord_t p_delta_x, coord_t p_delta_y, bool& r_bubble)
 {
     MCAutoValueRefArray t_args;
@@ -1377,6 +1387,16 @@ bool MCWidgetOnMouseCancel(MCWidgetRef self, bool& r_bubble)
 bool MCWidgetOnClick(MCWidgetRef self, bool& r_bubble)
 {
     return MCWidgetAsBase(self) -> OnClick(r_bubble);
+}
+
+bool MCWidgetOnFocusEnter(MCWidgetRef self, bool& r_bubble)
+{
+    return MCWidgetAsBase(self) -> OnFocusEnter(r_bubble);
+}
+
+bool MCWidgetOnFocusLeave(MCWidgetRef self, bool& r_bubble)
+{
+    return MCWidgetAsBase(self) -> OnFocusLeave(r_bubble);
 }
 
 bool MCWidgetOnMouseScroll(MCWidgetRef self, real32_t p_delta_x, real32_t p_delta_y, bool& r_bubble)

--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -75,6 +75,9 @@ public:
     
     bool OnClick(bool& r_bubble);
     
+    bool OnFocusEnter(bool& r_bubble);
+    bool OnFocusLeave(bool& r_bubble);
+    
     bool HandlesTouchEvents(void);
     bool OnTouchStart(bool& r_bubble);
     bool OnTouchMove(bool& r_bubble);

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -895,6 +895,52 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMyStackNativeDisplay(void *&r_displa
 
 ////////////////////////////////////////////////////////////////////////////////
 
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecFocusIn(void)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    MCWidget * t_widget = MCWidgetGetHost(MCcurrentwidget);
+    
+    t_widget->getcard()->kfocusset(t_widget);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecFocusOut(void)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    MCWidget * t_widget = MCWidgetGetHost(MCcurrentwidget);
+    
+    t_widget->getcard()->kunfocus();
+#ifdef _MOBILE
+    // Make sure the IME is forced closed if explicitly asked to be.
+    MCscreen -> closeIME();
+#endif
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecFocusNext(void)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    MCWidget * t_widget = MCWidgetGetHost(MCcurrentwidget);
+    
+    t_widget->getcard()->kfocusnext(False);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecFocusPrevious(void)
+{
+    if (!MCWidgetEnsureCurrentWidget())
+        return;
+    
+    MCWidget * t_widget = MCWidgetGetHost(MCcurrentwidget);
+    
+    t_widget->getcard()->kfocusprev(False);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 static void __MCWidgetDestroy(MCValueRef p_value)
 {
     MCWidgetBase *t_widget;

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -82,6 +82,9 @@ bool MCWidgetOnMouseUp(MCWidgetRef widget, bool& r_bubble);
 bool MCWidgetOnMouseCancel(MCWidgetRef widget, bool& r_bubble);
 bool MCWidgetOnClick(MCWidgetRef widget, bool& r_bubble);
 
+bool MCWidgetOnFocusEnter(MCWidgetRef widget, bool& r_bubble);
+bool MCWidgetOnFocusLeave(MCWidgetRef widget, bool& r_bubble);
+
 bool MCWidgetOnMouseScroll(MCWidgetRef widget, real32_t delta_x, real32_t delta_y, bool& r_bubble);
 
 bool MCWidgetHandlesTouchEvents(MCWidgetRef p_widget);

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -308,12 +308,16 @@ Name: OnFocusEnter
 Type: message
 Syntax: OnFocusEnter
 Summary: Sent when the widget gains focus.
+References: OnFocusLeave(message), FocusPrevious(statement),
+FocusNext(statement), FocusOut(statement), FocusIn(statement)
 
 
 Name: OnFocusLeave
 Type: message
 Syntax: OnFocusLeave
 Summary: Sent when the widget loses focus.
+References: OnFocusEnter(message), FocusPrevious(statement),
+FocusNext(statement), FocusOut(statement), FocusIn(statement)
 
 
 Name: OnKeyPress
@@ -1770,5 +1774,82 @@ public foreign handler MCWidgetGetNativeLayerCanRenderToContext(in pWidget as Wi
 public foreign handler MCWidgetSetNativeLayerCanRenderToContext(in pCanRender as CBool, in pWidget as Widget) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetGetMyNativeLayerCanRenderToContext(out rCanRender as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetSetMyNativeLayerCanRenderToContext(in pCanRender as CBool) returns nothing binds to "<builtin>"
+
+public foreign handler MCWidgetExecFocusIn() returns nothing binds to "<builtin>"
+public foreign handler MCWidgetExecFocusOut() returns nothing binds to "<builtin>"
+public foreign handler MCWidgetExecFocusNext() returns nothing binds to "<builtin>"
+public foreign handler MCWidgetExecFocusPrevious() returns nothing binds to "<builtin>"
+
+/**
+Summary:    Focus in on the widget.
+
+Description:
+Use focus in to take the object focus from the focused object. This is particularly
+useful for native views that may not pass events to the engine allowing it to
+determine focus changes.
+
+References: OnFocusEnter(message), OnFocusLeave(message), FocusPrevious(statement),
+FocusNext(statement), FocusOut(statement)
+*/
+
+syntax FocusIn is statement
+    "focus" "in"
+begin
+    MCWidgetExecFocusIn()
+end syntax
+
+/**
+Summary:    Remove the focus from the widget.
+
+Description:
+Use focus out to take the object focus from the widget. This is particularly
+useful for native views that may not pass events to the engine allowing it to
+determine focus changes.
+
+References: OnFocusEnter(message), OnFocusLeave(message), FocusPrevious(statement),
+FocusNext(statement), FocusIn(statement)
+*/
+
+syntax FocusOut is statement
+    "focus" "out"
+begin
+    MCWidgetExecFocusOut()
+end syntax
+
+/**
+Summary:    Focus on the next control with traversalOn true
+
+Description:
+Use focus next to focus on the next control with traversalOn true. This is particularly
+useful for native views that may not pass events to the engine allowing it to
+determine focus changes.
+
+References: OnFocusEnter(message), OnFocusLeave(message), FocusPrevious(statement),
+FocusOut(statement), FocusIn(statement)
+*/
+
+syntax FocusNext is statement
+    "focus" "next"
+begin
+    MCWidgetExecFocusNext()
+end syntax
+
+/**
+Summary:    Focus on the previous control with traversalOn true
+
+Description:
+Use focus previous to focus on the previous control with traversalOn true. This is
+particularly useful for native views that may not pass events to the engine allowing it to
+determine focus changes.
+
+References: OnFocusEnter(message), OnFocusLeave(message), FocusNext(statement),
+FocusOut(statement), FocusIn(statement)
+*/
+
+syntax FocusPrevious is statement
+    "focus" "previous"
+begin
+    MCWidgetExecFocusPrevious()
+end syntax
 
 end module

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -491,6 +491,7 @@ private unsafe handler InitBrowserView()
 
 	MCBrowserSetRequestHandler(mBrowser, OnBrowserRequestCallback, nothing)
 	MCBrowserSetJavaScriptHandler(mBrowser, OnJavaScriptCallback, nothing)
+	MCBrowserSetFocusHandler(mBrowser, OnFocusCallback, nothing)
 
 	applyProperties(mProperties)
 end handler
@@ -538,6 +539,19 @@ public handler OnClose()
 	put false into mOpened
 end handler
 
+constant kHasFocusJS is "function f(){if (document.hasFocus() && document.activeElement !== null && document.activeElement !== document.body && document.activeElement !== document.documentElement) return 'true'; } f();"
+constant kRemoveFocusJS is "document.activeElement.blur();"
+
+public handler OnFocusLeave()
+	if browserEvaluateJavascript(kHasFocusJS) is "true" then
+		browserEvaluateJavascript(kRemoveFocusJS)
+	end if
+end handler
+
+private handler OnFocusCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef) returns nothing
+	focus in
+end handler
+
 ----------
 
 private handler Capitalize(in pString as String) returns String
@@ -583,6 +597,10 @@ private handler OnBrowserRequestCallback(in pContext as optional Pointer, in pBr
 
 	if pType is kMCBrowserRequestTypeNavigate and pState is kMCBrowserRequestStateBegin and not pFrame then
 		updateUrlProperty(pUrl)
+	end if
+
+	if browserEvaluateJavascript(kHasFocusJS) is "true" then
+		focus in
 	end if
 
 	post tMessage to mScriptObject with tArgs

--- a/extensions/widgets/browser/notes/19023.md
+++ b/extensions/widgets/browser/notes/19023.md
@@ -1,0 +1,1 @@
+# [19023] Ensure browser grabs and releases focus appropriately

--- a/libbrowser/include/libbrowser.h
+++ b/libbrowser/include/libbrowser.h
@@ -59,6 +59,12 @@ public:
 	virtual void OnJavaScriptCall(MCBrowser *p_browser, const char *p_handler, MCBrowserListRef p_params) = 0;
 };
 
+class MCBrowserFocusHandler : public MCBrowserRefCounted
+{
+public:
+    virtual void OnFocus(MCBrowser *p_browser) = 0;
+};
+
 // Properties
 enum MCBrowserProperty
 {
@@ -88,7 +94,8 @@ class MCBrowser : public MCBrowserRefCounted
 public:
 	virtual void SetEventHandler(MCBrowserEventHandler *p_handler) = 0;
 	virtual void SetJavaScriptHandler(MCBrowserJavaScriptHandler *p_handler) = 0;
-	
+    virtual void SetFocusHandler(MCBrowserFocusHandler *p_handler) = 0;
+    
 	virtual void *GetNativeLayer() = 0;
 	
 	virtual bool GetRect(MCBrowserRect &r_rect) = 0;
@@ -277,9 +284,11 @@ enum MCBrowserRequestState
 
 typedef void (*MCBrowserRequestCallback)(void *p_context, MCBrowserRef p_browser, MCBrowserRequestType p_type, MCBrowserRequestState p_state, bool p_in_frame, const char *p_url, const char *p_error);
 typedef void (*MCBrowserJavaScriptCallback)(void *p_context, MCBrowserRef p_browser, const char *p_handler, MCBrowserListRef p_params);
+typedef void (*MCBrowserFocusCallback)(void *p_context, MCBrowserRef p_browser);
 
 MC_BROWSER_DLLEXPORT bool MCBrowserSetRequestHandler(MCBrowserRef p_browser, MCBrowserRequestCallback p_callback, void *p_context);
 MC_BROWSER_DLLEXPORT bool MCBrowserSetJavaScriptHandler(MCBrowserRef p_browser, MCBrowserJavaScriptCallback p_callback, void *p_context);
+MC_BROWSER_DLLEXPORT bool MCBrowserSetFocusHandler(MCBrowserRef p_browser, MCBrowserFocusCallback p_callback, void *p_context);
 
 }
 

--- a/libbrowser/src/libbrowser_android.cpp
+++ b/libbrowser/src/libbrowser_android.cpp
@@ -1035,6 +1035,16 @@ JNIEXPORT void JNICALL Java_com_runrev_android_libraries_LibBrowserWebView_doUns
 		MCCStringFree(t_url);
 }
 
+extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_libraries_LibBrowserWebView_doFocus(JNIEnv *env, jobject object) __attribute__((visibility("default")));
+JNIEXPORT void JNICALL Java_com_runrev_android_libraries_LibBrowserWebView_doFocus(JNIEnv *env, jobject object)
+{
+    MCBrowser *t_browser;
+    if (MCBrowserFindWithJavaView(env, object, t_browser))
+    {
+        ((MCAndroidWebViewBrowser*)t_browser)->OnFocus();
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class MCAndroidWebViewBrowserFactory : public MCBrowserFactory

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -735,7 +735,7 @@ struct MCCefErrorInfo
 	CefLoadHandler::ErrorCode error_code;
 };
 
-class MCCefBrowserClient : public CefClient, CefLifeSpanHandler, CefRequestHandler, /* CefDownloadHandler ,*/ CefLoadHandler, CefContextMenuHandler, CefDragHandler
+class MCCefBrowserClient : public CefClient, CefLifeSpanHandler, CefRequestHandler, /* CefDownloadHandler ,*/ CefLoadHandler, CefContextMenuHandler, CefDragHandler, CefFocusHandler
 {
 private:
 	int m_browser_id;
@@ -824,7 +824,8 @@ public:
 	virtual CefRefPtr<CefLoadHandler> GetLoadHandler() OVERRIDE { return this; }
 	virtual CefRefPtr<CefContextMenuHandler> GetContextMenuHandler() OVERRIDE { return this; }
 	virtual CefRefPtr<CefDragHandler> GetDragHandler() OVERRIDE { return this; }
-	
+    virtual CefRefPtr<CefFocusHandler> GetFocusHandler() OVERRIDE { return this; }
+    
 	void AddIgnoreUrl(const CefString &p_url)
 	{
 		m_ignore_urls.insert(p_url);
@@ -1249,6 +1250,16 @@ public:
 			p_model->Clear();
 	}
 	
+    // CefFocusHandler interface
+    
+    virtual void OnGotFocus(CefRefPtr<CefBrowser> browser) OVERRIDE
+    {
+        if (nil == m_owner)
+            return;
+        
+        m_owner -> OnFocus();
+    }
+    
 	IMPLEMENT_REFCOUNTING(MCCefBrowserClient)
 };
 

--- a/libbrowser/src/libbrowser_internal.h
+++ b/libbrowser/src/libbrowser_internal.h
@@ -30,7 +30,10 @@ typedef bool (*MCBrowserIterateCallback)(MCBrowser *p_browser, void *p_context);
 class MCBrowserBase : public MCBrowser
 {
 public:
-	MCBrowserBase() : m_event_handler(nil), m_javascript_handler(nil)
+	MCBrowserBase()
+        : m_event_handler(nil),
+        m_javascript_handler(nil),
+        m_focus_handler(nil)
 	{
 	}
 	
@@ -40,10 +43,12 @@ public:
 	
 	void SetEventHandler(MCBrowserEventHandler *p_handler);
 	void SetJavaScriptHandler(MCBrowserJavaScriptHandler *p_handler);
+    void SetFocusHandler(MCBrowserFocusHandler *p_handler);
 
 	MCBrowserEventHandler *GetEventHandler(void);
 	MCBrowserJavaScriptHandler *GetJavaScriptHandler(void);
-	
+    MCBrowserFocusHandler *GetFocusHandler(void);
+    
 	virtual void OnNavigationBegin(bool p_in_frame, const char *p_url);
 	virtual void OnNavigationComplete(bool p_in_frame, const char *p_url);
 	virtual void OnNavigationFailed(bool p_in_frame, const char *p_url, const char *p_error);
@@ -51,9 +56,11 @@ public:
 	virtual void OnDocumentLoadComplete(bool p_in_frame, const char *p_url);
 	virtual void OnDocumentLoadFailed(bool p_in_frame, const char *p_url, const char *p_error);
 	
-	virtual void OnNavigationRequestUnhandled(bool p_in_frame, const char *p_url);
-	
-	virtual void OnJavaScriptCall(const char *p_handler, MCBrowserListRef p_params);
+    virtual void OnNavigationRequestUnhandled(bool p_in_frame, const char *p_url);
+    
+    virtual void OnFocus();
+    
+    virtual void OnJavaScriptCall(const char *p_handler, MCBrowserListRef p_params);
 	
 	static bool BrowserListAdd(MCBrowser *p_browser);
 	static void BrowserListRemove(MCBrowser *p_browser);
@@ -71,6 +78,7 @@ private:
 	
 	MCBrowserEventHandler *m_event_handler;
 	MCBrowserJavaScriptHandler *m_javascript_handler;
+    MCBrowserFocusHandler *m_focus_handler;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libbrowser/src/libbrowser_osx_webview.mm
+++ b/libbrowser/src/libbrowser_osx_webview.mm
@@ -373,7 +373,11 @@ bool MCJSObjectToBrowserValue(JSContextRef p_context, JSObjectRef p_object, MCBr
 
 @interface MCWebUIDelegate : NSObject
 {
+    MCWebViewBrowser *m_instance;
 }
+- (id)initWithInstance:(MCWebViewBrowser *)instance;
+- (void)dealloc;
+- (void)webView:(WebView *)sender makeFirstResponder:(NSResponder *)responder;
 
 - (NSUInteger)webView:(WebView *)webView dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo;
 - (NSUInteger)webView:(WebView *)webView dragSourceActionMaskForPoint:(NSPoint)point;
@@ -975,7 +979,7 @@ bool MCWebViewBrowser::Init(void)
 		
 		if (t_success)
 		{
-			m_ui_delegate = [[MCWebUIDelegate alloc] init];
+			m_ui_delegate = [[MCWebUIDelegate alloc] initWithInstance: this];
 			t_success = m_ui_delegate != nil;
 		}
 		
@@ -1183,8 +1187,29 @@ bool MCWebViewBrowser::Init(void)
 
 @implementation MCWebUIDelegate
 
-- (WebView *)webView:(WebView *)webView
-            createWebViewWithRequest:(NSURLRequest *)request
+- (id)initWithInstance:(MCWebViewBrowser*)instance
+{
+    self = [super init];
+    if (self == nil)
+        return nil;
+    
+    m_instance = instance;
+    
+    return self;
+}
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+- (void)webView:(WebView *)sender makeFirstResponder:(NSResponder *)responder
+{
+    [[sender window] makeFirstResponder:responder];
+    m_instance->OnFocus();
+}
+
+- (WebView *)webView:(WebView *)webView createWebViewWithRequest:(NSURLRequest *)request
 {
     [[webView frameLoadDelegate] setPendingRequest: false];
     [[webView mainFrame] loadRequest:request];

--- a/libbrowser/src/libbrowser_uiwebview.h
+++ b/libbrowser/src/libbrowser_uiwebview.h
@@ -47,6 +47,7 @@ public:
 	
 	bool AttachJSHandlers();
 
+    bool GetView(UIWebView *&r_view);
 protected:
 	bool GetUrl(char *& r_url);
 	
@@ -70,7 +71,6 @@ protected:
 	UIScrollView *GetScrollView(void);
 	
 private:
-	bool GetView(UIWebView *&r_view);
 	
 	bool SyncJavaScriptHandlers(NSArray *p_handlers);
 	


### PR DESCRIPTION
This patch implements `focus {in | out | next | previous}`
in addition to re-implementing `OnFocusEnter` and `OnFocusLeave`
messages.