### PR TITLE
[[ Bug 20196 ]] Ensure missing extension produces warning

### DIFF
--- a/docs/notes/bugfix-20196.md
+++ b/docs/notes/bugfix-20196.md
@@ -1,0 +1,1 @@
+# Build standalone successfully, but emit warning when extension is missing

--- a/ide-support/revsaveasemscriptenstandalone.livecodescript
+++ b/ide-support/revsaveasemscriptenstandalone.livecodescript
@@ -243,12 +243,15 @@ end appendToStringList
 
 private command storeExtensions pZip, pExtensionsListA, pExtensionsPath
    -- Store each extension's data
-   local tModulesList, tKind
+   local tModulesList, tKind, tSourceType
    repeat for each element tExtension in pExtensionsListA
       put tExtension["id"] into tKind
-      if revIDEExtensionProperty(tKind, "source_type") is "lcb" then
+      put revIDEExtensionProperty(tKind, "source_type") into tSourceType
+      if tSourceType is "lcb" then
          storeExtensionByKind pZip, tKind, pExtensionsPath
          appendToStringList tKind, tModulesList
+      else if tSourceType is not "lcs" then
+         revStandaloneAddWarning "Extension" && tKind && "not found"
       end if
    end repeat
    

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2158,13 +2158,16 @@ command revSBUpdateDeployParams pStack, pTarget, pStandaloneSettings, @xDeployPa
    
    # AL-2015-04-12: [[ Standalone Extensions ]] Add chosen extensions to the standalone inclusions
    # AL-2015-07-21: [[ Standalone Extensions ]] Automatically include dependecies, and load in order
+   local tValidExtensionsA
    repeat for each element tExtensionDataA in pStandaloneSettings["extensions_computed"]
       local tExtensionFileDataA
       put revIDEExtensionFileData(tExtensionDataA["id"]) into tExtensionFileDataA
       if tExtensionFileDataA["type"] is "lcb" then
          appendToStringList tExtensionFileDataA["file"], tModules
-      else
+      else if tExtensionFileDataA["type"] is "lcs" then
          __LoadStackOnStartup tExtensionDataA["id"], tAuxiliaryStackFiles, tStartupScript, tGeneratedStartupScript
+      else
+         revStandaloneAddWarning "Extension" && tExtensionDataA["id"] && "not found"
       end if
    end repeat
    

--- a/tests/ide-support/standalonebuilder/_support.livecodescript
+++ b/tests/ide-support/standalonebuilder/_support.livecodescript
@@ -147,6 +147,8 @@ command StandaloneBuilderTestSaveStackAsStandalone pDescription, pStackFilename,
    end if
       
    TestAssert pDescription, tResult is empty
+   
+   TestDiagnostic revStandaloneGetWarnings()
 end StandaloneBuilderTestSaveStackAsStandalone
 
 private command _TestBuildStandalone pStackPath, @rStandalonePath

--- a/tests/ide-support/standalonebuilder/inclusion.livecodescript
+++ b/tests/ide-support/standalonebuilder/inclusion.livecodescript
@@ -71,3 +71,37 @@ private command _TestStandaloneWithInclusion pStackFilename, pItem
    StandaloneBuilderTestCreateAndSaveStackAsStandalone tDesc, \
       pStackFilename, tScript
 end _TestStandaloneWithInclusion
+
+private function _TestScriptOnlyMainstackPass
+	local tScript
+	put "on startup" & return after tScript
+	put "quit 0" & return after tScript
+	put "end startup" & return after tScript
+	return tScript
+end _TestScriptOnlyMainstackPass
+
+on TestMissingInclusionWarning
+   local tDir
+   set the itemdelimiter to slash
+   set the defaultfolder to item 1 to -2 of the filename of me
+
+   put "_TestSavingStandalone" into tDir
+   
+   create folder tDir
+   
+   local tFilename, tScript, tSettings, tExtension
+   put the folder & "/" & tDir & "/stack.livecodescript" into tFilename   
+   put _TestScriptOnlyMainstackPass() into tScript
+   put "com.livecode.widget.non-existent" into tExtension
+   put tExtension into tSettings["extensions"]
+   
+   local tDesc
+   put "standalone with missing extension builds" into tDesc
+   StandaloneBuilderTestCreateAndSaveScriptOnlyStackAsStandalone tDesc, \
+      tFilename, tScript, tSettings
+      
+   TestAssert "standalone with missing extension warning", \
+      revStandaloneGetWarnings() contains tExtension
+
+   revDeleteFolder tDir
+end TestMissingInclusionWarning


### PR DESCRIPTION
When there is an extension listed in the standalone settings that
doesn't actually exist, don't fail to build, just warn afterward
that the extension wasn't found.