### PR TITLE
[[ AndroidUtils ]] Add android utility library 

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -428,6 +428,8 @@ component Extensions
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.library.androidaudiorecorder
 	into [[ToolsFolder]]/Extensions place
+		rfolder macosx:packaged_extensions/com.livecode.library.androidutils
+	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.library.iconsvg
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.library.json

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -133,6 +133,7 @@
 			'sources':
 			[
 				'modules/widget-utils/widget-utils.lcb',
+				'modules/android-utils/android-utils.lcb',				
 				'modules/scriptitems/scriptitems.lcb',
 
 				'libraries/androidbgaudio/androidbgaudio.lcb',

--- a/extensions/libraries/androidbgaudio/androidbgaudio.lcb
+++ b/extensions/libraries/androidbgaudio/androidbgaudio.lcb
@@ -28,6 +28,7 @@ library com.livecode.library.androidbgaudio
 use com.livecode.foreign
 use com.livecode.java
 use com.livecode.engine
+use com.livecode.library.androidutils
 
 metadata version is "0.0.0"
 metadata author is "LiveCode"
@@ -36,7 +37,6 @@ metadata title is "Android Background Audio"
 ----
 
 __safe foreign handler _JNI_EngineGet() returns JObject binds to "java:com.runrev.android.Engine>getEngine()Lcom/runrev/android/Engine;!static"
-__safe foreign handler _JNI_EngineGetContext(in pEngine as JObject) returns JObject binds to "java:android.view.View>getContext()Landroid/content/Context;"
 
 __safe foreign handler _JNI_ContextGetAssets(in pContext as JObject) returns JObject \
 			binds to "java:android.content.Context>getAssets()Landroid/content/res/AssetManager;"
@@ -89,13 +89,15 @@ private handler mediaplayerSetDataSource(in pString as String)
 		return
 	end if
 
+   variable tContext as JObject
+   put ApplicationContext() into tContext
 	if pString begins with "asset://" then
 		variable tAssetFd as JObject
-		put _JNI_AssetManagerOpenFd(_JNI_ContextGetAssets(_JNI_EngineGetContext(_JNI_EngineGet())), StringToJString(char 9 to -1 of pString)) into tAssetFd
+		put _JNI_AssetManagerOpenFd(_JNI_ContextGetAssets(tContext), StringToJString(char 9 to -1 of pString)) into tAssetFd
 		_JNI_MediaPlayerSetDataSourceFd(mMediaPlayer, _JNI_AssetFileDescriptorGetFileDescriptor(tAssetFd))
 		_JNI_AssetFileDescriptorClose(tAssetFd)
 	else
-		_JNI_MediaPlayerSetDataSourceUri(mMediaPlayer, _JNI_EngineGetContext(_JNI_EngineGet()), _JNI_UriParse(StringToJString(pString)))
+		_JNI_MediaPlayerSetDataSourceUri(mMediaPlayer, tContext, _JNI_UriParse(StringToJString(pString)))
 	end if
 end handler
 

--- a/extensions/modules/android-utils/android-utils.lcb
+++ b/extensions/modules/android-utils/android-utils.lcb
@@ -1,0 +1,67 @@
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+/**
+A library of utility handlers for functions commonly needed by Android widgets.
+*/
+
+module com.livecode.library.androidutils
+
+use com.livecode.foreign
+use com.livecode.java
+use com.livecode.canvas
+use com.livecode.library.widgetutils
+
+metadata version is "1.0.0"
+metadata author is "LiveCode"
+metadata title is "Android Utilities"
+
+private handler ColorComponentToInt(in pComponent as Real) returns Integer
+    multiply pComponent by 255
+    round pComponent 
+    return pComponent
+end handler
+
+__safe foreign handler _JNI_GetColorFromARGB(in pA as JInt, in pR as JInt, in pG as JInt, in pB as JInt) returns JInt \
+	binds to "java:android.graphics.Color>argb(IIII)I!static"
+
+/**
+Summary: Convert a color string to an integer for Android
+
+Parameters:
+pString: The color string
+
+Description:
+Use the <StringToAndroidColor> handler to convert a string representing 
+a color to an integer that can be used with Android color APIs.
+*/	
+public handler StringToAndroidColor(in pString as String) returns Integer
+    variable tColor as Color
+    put stringToColor(pString) into tColor
+    
+    variable tA as Integer
+    variable tR as Integer
+    variable tG as Integer
+    variable tB as Integer
+    put ColorComponentToInt(the alpha of tColor) into tA
+    put ColorComponentToInt(the red of tColor) into tR
+    put ColorComponentToInt(the green of tColor) into tG
+    put ColorComponentToInt(the blue of tColor) into tB
+    
+    return _JNI_GetColorFromARGB(tA,tR,tG,tB)
+end handler
+end module

--- a/extensions/modules/android-utils/android-utils.lcb
+++ b/extensions/modules/android-utils/android-utils.lcb
@@ -74,12 +74,12 @@ __safe foreign handler _JNI_GetEngineContext(in pEngine as JObject) returns JObj
 Summary: Get the application Context
 
 Example:
-__safe foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject \
-	binds to "java:android.widget.Button>new(Landroid/content/Context;)?ui"
+	__safe foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject \
+		binds to "java:android.widget.Button>new(Landroid/content/Context;)?ui"
 
-handler NativeButtonView() returns JObject
-	return _JNI_CreateButton(ApplicationContext())
-end handler
+	handler NativeButtonView() returns JObject
+		return _JNI_CreateButton(ApplicationContext())
+	end handler
 
 Description:
 Use the <ApplicationContext> handler to fetch the current application's

--- a/extensions/modules/android-utils/android-utils.lcb
+++ b/extensions/modules/android-utils/android-utils.lcb
@@ -64,4 +64,28 @@ public handler StringToAndroidColor(in pString as String) returns Integer
     
     return _JNI_GetColorFromARGB(tA,tR,tG,tB)
 end handler
+
+__safe foreign handler _JNI_GetAndroidEngine() returns JObject \
+	binds to "java:com.runrev.android.Engine>getEngine()Lcom/runrev/android/Engine;!static"
+__safe foreign handler _JNI_GetEngineContext(in pEngine as JObject) returns JObject \
+	binds to "java:android.view.View>getContext()Landroid/content/Context;"
+
+/**
+Summary: Get the application Context
+
+Example:
+__safe foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject \
+	binds to "java:android.widget.Button>new(Landroid/content/Context;)?ui"
+
+handler NativeButtonView() returns JObject
+	return _JNI_CreateButton(ApplicationContext())
+end handler
+
+Description:
+Use the <ApplicationContext> handler to fetch the current application's
+Context object. 
+*/
+public handler ApplicationContext() returns JObject
+	return _JNI_GetEngineContext(_JNI_GetAndroidEngine())
+end handler
 end module

--- a/extensions/modules/android-utils/notes/feature-android_utils.md
+++ b/extensions/modules/android-utils/notes/feature-android_utils.md
@@ -1,0 +1,6 @@
+# Android Utility Module
+
+A new android utility module has been added. It currently
+contains one handler, StringToAndroidColor, which converts
+a string representing a color (optionally with alpha component)
+to an Android Color object.

--- a/extensions/modules/android-utils/notes/feature-android_utils.md
+++ b/extensions/modules/android-utils/notes/feature-android_utils.md
@@ -1,6 +1,7 @@
 # Android Utility Module
 
 A new android utility module has been added. It currently
-contains one handler, StringToAndroidColor, which converts
-a string representing a color (optionally with alpha component)
-to an Android Color object.
+contains two handlers:
+
+* `StringToAndroidColor`: convert a string representing a color (optionally with alpha component) to an Android Color object.
+* `ApplicationContext`: returns the current application Context object.

--- a/extensions/widgets/androidbutton/androidbutton.lcb
+++ b/extensions/widgets/androidbutton/androidbutton.lcb
@@ -95,8 +95,6 @@ metadata labelColor.section is "Colors"
 // Handlers for creating and attaching view
 __safe foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject \
 	binds to "java:android.widget.Button>new(Landroid/content/Context;)?ui"
-__safe foreign handler _JNI_AddButtonView(in pParentView as JObject, in pChildView as JObject) returns nothing \
-	binds to "java:android.view.ViewGroup>addView(Landroid/view/View;)V?ui"
 
 // Handlers for adding click listener
 handler type ClickCallback(in pView as JObject) returns nothing
@@ -143,18 +141,7 @@ end handler
 private handler InitButtonView()
 	// Create an android button using the Engine Context
     put _JNI_CreateButton(ApplicationContext()) into mButton
-    
-	// put my native window into tParent
-    variable tParent as Pointer
-    MCWidgetGetMyStackNativeView(tParent)
-    
-    // wrap the parent pointer
-    variable tParentObj as JObject
-    put PointerToJObject(tParent) into tParentObj
-    
-    // add the view
-    _JNI_AddButtonView(tParentObj, mButton)
-    
+        
     // get the pointer from the view and set the native layer
     variable tButtonPointer as Pointer
     put PointerFromJObject(mButton) into tButtonPointer

--- a/extensions/widgets/androidbutton/androidbutton.lcb
+++ b/extensions/widgets/androidbutton/androidbutton.lcb
@@ -42,6 +42,7 @@ use com.livecode.widget
 use com.livecode.canvas
 use com.livecode.engine
 use com.livecode.library.widgetutils
+use com.livecode.library.androidutils
 
 metadata version is "1.0.0"
 metadata author is "LiveCode"
@@ -114,8 +115,7 @@ __safe foreign handler _JNI_SetTextViewText(in pView as JObject, in pValue as JS
 	binds to "java:android.widget.TextView>setText(Ljava/lang/CharSequence;)V?ui"
 __safe foreign handler _JNI_SetTextViewTextColor(in pView as JObject, in pValue as JInt) returns nothing \
 	binds to "java:android.widget.TextView>setTextColor(I)V?ui"
-__safe foreign handler _JNI_GetColorFromARGB(in pA as JInt, in pR as JInt, in pG as JInt, in pB as JInt) returns JInt \
-	binds to "java:android.graphics.Color>argb(IIII)I!static"
+
 __safe foreign handler _JNI_SetTextViewEnabled(in pView as JObject, in pValue as JBoolean) returns nothing \
 	binds to "java:android.view.View>setEnabled(Z)V?ui"
 __safe foreign handler _JNI_SetTextViewTypeface(in pView as JObject, in pValue as JObject) returns nothing \
@@ -274,23 +274,8 @@ private handler ColorComponentToInt(in pComponent as Real) returns Integer
     return pComponent
 end handler
 
-private handler SetStringAndroidColor(in pString as String)
-    variable tColor as Color
-    put stringToColor(pString) into tColor
-    
-    variable tA as Integer
-    variable tR as Integer
-    variable tG as Integer
-    variable tB as Integer
-    put ColorComponentToInt(the alpha of tColor) into tA
-    put ColorComponentToInt(the red of tColor) into tR
-    put ColorComponentToInt(the green of tColor) into tG
-    put ColorComponentToInt(the blue of tColor) into tB
-    
-    variable tColorInt as Integer
-    put _JNI_GetColorFromARGB(tA,tR,tG,tB) into tColorInt
-    
-    _JNI_SetTextViewTextColor(mButton, tColorInt)  
+private handler SetStringAndroidColor(in pString as String)    
+    _JNI_SetTextViewTextColor(mButton, StringToAndroidColor(pString))  
 end handler
 
 end widget

--- a/extensions/widgets/androidbutton/androidbutton.lcb
+++ b/extensions/widgets/androidbutton/androidbutton.lcb
@@ -92,11 +92,6 @@ metadata labelColor.default is "0,0,0"
 metadata labelColor.editor is "com.livecode.pi.colorwithalpha"
 metadata labelColor.section is "Colors"
 
-__safe foreign handler _JNI_GetAndroidEngine() returns JObject \
-	binds to "java:com.runrev.android.Engine>getEngine()Lcom/runrev/android/Engine;!static"
-__safe foreign handler _JNI_GetEngineContext(in pEngine as JObject) returns JObject \
-	binds to "java:android.view.View>getContext()Landroid/content/Context;"
-
 // Handlers for creating and attaching view
 __safe foreign handler _JNI_CreateButton(in pContext as JObject) returns JObject \
 	binds to "java:android.widget.Button>new(Landroid/content/Context;)?ui"
@@ -147,12 +142,7 @@ end handler
 
 private handler InitButtonView()
 	// Create an android button using the Engine Context
-    variable tEngine as JObject
-    put _JNI_GetAndroidEngine() into tEngine
-    
-    variable tContext as JObject
-    put _JNI_GetEngineContext(tEngine) into tContext
-    put _JNI_CreateButton(tContext) into mButton
+    put _JNI_CreateButton(ApplicationContext()) into mButton
     
 	// put my native window into tParent
     variable tParent as Pointer

--- a/extensions/widgets/androidfield/androidfield.lcb
+++ b/extensions/widgets/androidfield/androidfield.lcb
@@ -129,10 +129,6 @@ metadata author is "LiveCode"
 metadata title is "Android Native Field"
 metadata svgicon is  "M28.06,4.95a.34.34,0,1,1,.34.34A.34.34,0,0,1,28.06,4.95Zm-3.45.34a.34.34,0,1,0-.34-.34A.34.34,0,0,0,24.6,5.29ZM36.25,2V17.24a2,2,0,0,1-2,2H2a2,2,0,0,1-2-2V2A2,2,0,0,1,2,0h32.3A2,2,0,0,1,36.25,2ZM22.39,6.8h8.23a3.76,3.76,0,0,0-2.1-3.31l.65-1.17a.13.13,0,0,0-.05-.18l-.06,0a.13.13,0,0,0-.11.07l-.66,1.19a4.43,4.43,0,0,0-3.56,0l-.66-1.19a.13.13,0,1,0-.23.13l.65,1.17A3.76,3.76,0,0,0,22.39,6.8ZM9.57,2.57H5v1.5H6.53v11H5v1.5H9.57v-1.5H8v-11H9.57ZM22,7.89a.92.92,0,0,0-1.84,0v3.84a.92.92,0,1,0,1.84,0Zm8.57-.76H22.39v6a1,1,0,0,0,1,1H24v2a.92.92,0,1,0,1.84,0v-2h1.23v2a.92.92,0,1,0,1.84,0v-2h.66a1,1,0,0,0,1-1Zm2.19.76a.92.92,0,0,0-1.84,0v3.84a.92.92,0,1,0,1.84,0Z"
 
-__safe foreign handler _JNI_GetAndroidEngine() returns JObject \
-   binds to "java:com.runrev.android.Engine>getEngine()Lcom/runrev/android/Engine;!static"
-__safe foreign handler _JNI_GetContext(in pView as JObject) returns JObject \
-   binds to "java:android.view.View>getContext()Landroid/content/Context;"
 __safe foreign handler _JNI_GetSystemService(in pContext as JObject, in pService as JString) returns JObject \
    binds to "java:android.content.Context>getSystemService(Ljava/lang/String;)Ljava/lang/Object;"
 
@@ -623,11 +619,8 @@ constant INPUT_METHOD_SERVICE is "input_method"
 
 private handler InitView()
 	// Create an android button using the Engine Context
-    variable tEngine as JObject
-    put _JNI_GetAndroidEngine() into tEngine
-
     variable tContext as JObject
-    put _JNI_GetContext(tEngine) into tContext
+    put ApplicationContext() into tContext
     put _JNI_CreateView(tContext) into mNativeObj
 
 	// put my native window into tParent
@@ -1394,6 +1387,8 @@ handler SetTypeface(in pFont as Font)
         PointerToJObject(tTypefacePtr))
 end handler
 
+__safe foreign handler _JNI_ViewGetContext(in pView as JObject) returns JObject \
+   binds to "java:android.view.View>getContext()Landroid/content/Context;"
 __safe foreign handler _JNI_GetResources(in pContext as JObject) returns JObject \
    binds to "java:android.content.Context>getResources()Landroid/content/res/Resources;"
 __safe foreign handler _JNI_GetDisplayMetrics(in pResources as JObject) returns JObject \
@@ -1405,7 +1400,7 @@ public handler GetTextSize() returns Integer
    put TextView_getTextSize(mNativeObj) into tTextSize
 
    variable tContext as JObject
-   put _JNI_GetContext(mNativeObj) into tContext
+   put _JNI_ViewGetContext(mNativeObj) into tContext
 
    variable tResources as JObject
    put _JNI_GetResources(tContext) into tResources

--- a/extensions/widgets/androidfield/androidfield.lcb
+++ b/extensions/widgets/androidfield/androidfield.lcb
@@ -135,8 +135,6 @@ __safe foreign handler _JNI_GetSystemService(in pContext as JObject, in pService
 // Handlers for creating and attaching view
 __safe foreign handler _JNI_CreateView(in pContext as JObject) returns JObject \
    binds to "java:android.widget.EditText>new(Landroid/content/Context;)V?ui"
-__safe foreign handler _JNI_AddView(in pParentView as JObject, in pChildView as JObject) returns nothing \
-   binds to "java:android.view.ViewGroup>addView(Landroid/view/View;)V?ui"
 
 private variable mNativeObj as optional JObject
 private variable mIMMObj as optional JObject
@@ -622,17 +620,6 @@ private handler InitView()
     variable tContext as JObject
     put ApplicationContext() into tContext
     put _JNI_CreateView(tContext) into mNativeObj
-
-	// put my native window into tParent
-    variable tParent as Pointer
-    MCWidgetGetMyStackNativeView(tParent)
-
-    // wrap the parent pointer
-    variable tParentObj as JObject
-    put PointerToJObject(tParent) into tParentObj
-
-    // add the view
-    _JNI_AddView(tParentObj, mNativeObj)
 
     // get the pointer from the view and set the native layer
     variable tPointer as Pointer

--- a/extensions/widgets/androidfield/androidfield.lcb
+++ b/extensions/widgets/androidfield/androidfield.lcb
@@ -121,6 +121,7 @@ use com.livecode.widget
 use com.livecode.canvas
 use com.livecode.engine
 use com.livecode.library.widgetutils
+use com.livecode.library.androidutils
 use com.livecode.library.scriptitems
 
 metadata version is "1.0.0"
@@ -1359,31 +1360,8 @@ public handler GetText() returns String
    return mText
 end handler
 
-__safe foreign handler _JNI_GetColorFromARGB(in pA as JInt, in pR as JInt, in pG as JInt, in pB as JInt) returns JInt \
-   binds to "java:android.graphics.Color>argb(IIII)I!static?ui"
-private handler SetStringAndroidColor(in pString as String)
-    variable tColor as Color
-    put stringToColor(pString) into tColor
-
-    variable tA as Integer
-    variable tR as Integer
-    variable tG as Integer
-    variable tB as Integer
-    put ColorComponentToInt(the alpha of tColor) into tA
-    put ColorComponentToInt(the red of tColor) into tR
-    put ColorComponentToInt(the green of tColor) into tG
-    put ColorComponentToInt(the blue of tColor) into tB
-
-    variable tColorInt as Integer
-    put _JNI_GetColorFromARGB(tA,tR,tG,tB) into tColorInt
-
-    _JNI_TextView_setTextColor(mNativeObj, tColorInt)
-end handler
-
-private handler ColorComponentToInt(in pComponent as Real) returns Integer
-    multiply pComponent by 255
-    round pComponent
-    return pComponent
+private handler SetStringAndroidColor(in pString as String)    
+    _JNI_TextView_setTextColor(mNativeObj, StringToAndroidColor(pString))  
 end handler
 
 public handler SetTextColor(in pColor as String)

--- a/extensions/widgets/androidfield/tests/properties.livecodescript
+++ b/extensions/widgets/androidfield/tests/properties.livecodescript
@@ -19,6 +19,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 on TestSetup
 	TestLoadExtension "com.livecode.library.widgetutils"
 	TestLoadExtension "com.livecode.library.scriptitems"
+	TestLoadExtension "com.livecode.library.androidutils"	
 	TestLoadExtension "com.livecode.widget.native.android.field"
 end TestSetup
 


### PR DESCRIPTION
Add an android utility module for handlers that are used in most android native extensions, namely:
* `StringToAndroidColor`: convert a string representing a color (optionally with alpha component) to an Android Color object.
* `ApplicationContext`: returns the current application Context object.