### PR TITLE
[[ Bug 20792 ]] Send touch messages when scroller disabled

### DIFF
--- a/docs/dictionary/command/mobileControlSet.lcdoc
+++ b/docs/dictionary/command/mobileControlSet.lcdoc
@@ -178,7 +178,7 @@ scrollIndicatorInsets property). This is a comma-separated list of four
 integers, describing the left, top, right and bottom inset distances.
 For example "0,0,100,100".
 
-- "scrollingEnabled" (iOS Only): Determines whether touches on the
+- "scrollingEnabled": Determines whether touches on the
 scroller cause scrolling (maps to the UIScrollView scrollEnabled
 property). This is a boolean value.
 

--- a/docs/notes/bugfix-20792.md
+++ b/docs/notes/bugfix-20792.md
@@ -1,0 +1,1 @@
+# Send touch messages when android scroller `scrollingEnabled` is `false`

--- a/engine/src/java/com/runrev/android/nativecontrol/ScrollerControl.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/ScrollerControl.java
@@ -127,7 +127,10 @@ class ScrollerControl extends NativeControl
             {
                 // handle dispatching of touch events so we can send them to both scrollviews
                 if (!m_scrolling_enabled)
+                {
+                    NativeControlModule.getEngine().onTouchEvent(e);
                     return false;
+                }
                 
                 m_dispatching = true;
                 m_touch_canceled = false;


### PR DESCRIPTION
This patch ensures that touch messages are sent via the engine view
when the android scroller has its `scrollingEnabled` property set to
false.