### PR TITLE
Reinstate -Wno-error=maybe-uninitialized

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -71,6 +71,7 @@
 					'-Wno-unused-parameter',	# Just contributes build noise
 					'-Werror=return-type',
 					'-Werror=uninitialized',
+					'-Wno-error=maybe-uninitialized',
 					'-Werror=conversion-null',
 					'-Werror=empty-body',
 				],


### PR DESCRIPTION
Removing this results in *new* "maybe-uninitialized" errors coming up each time we do a `release-commercial` build. 

Since it seems there is no way to catch *all* such errors at once and fix them, reinstate this flag for now.