### PR TITLE
[[ Bug 13935 ]] Ensure modal dialogs have parent on Linux

### DIFF
--- a/docs/notes/bugfix-13935.md
+++ b/docs/notes/bugfix-13935.md
@@ -1,0 +1,1 @@
+# Fix modal dialog opening behind other windows on Linux

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -162,9 +162,18 @@ void MCStack::setmodalhints()
 {
 	if (mode == WM_MODAL || mode == WM_SHEET)
 	{
+		Window t_window = nullptr;
 		if (mode == WM_SHEET)
-            gdk_window_set_transient_for(window, (mode == WM_SHEET) ? getparentwindow() : NULL);
-        gdk_window_set_modal_hint(window, TRUE);
+		{
+			t_window = getparentwindow();
+		}
+		
+		if (nullptr == t_window && MCtopstackptr.IsValid()) 
+		{
+			t_window = MCtopstackptr->getwindow();
+		}
+		gdk_window_set_transient_for(window, t_window);
+		gdk_window_set_modal_hint(window, TRUE);
 	}
 }
 


### PR DESCRIPTION
On linux modal dialogs need to have their parent set in order
for the window manager to keep them in front. This was only
being done for those opened as sheet. This patch will use the
sheet parent and fallback to using the topstack as the modal
parent.