### PR TITLE
[[ Bug 20565 ]] Fix linux fullscreen window manager issues

### DIFF
--- a/docs/notes/bugfix-20565.md
+++ b/docs/notes/bugfix-20565.md
@@ -1,0 +1,1 @@
+# Fix setting stack to fullscreen hides all other stacks on Linux

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -267,7 +267,7 @@ void MCStack::sethints()
     
     gdk_window_set_type_hint(window, t_type_hint);
     
-    if ((mode >= WM_PULLDOWN && mode <= WM_LICENSE) || getextendedstate(ECS_FULLSCREEN))
+    if ((mode >= WM_PULLDOWN && mode <= WM_LICENSE))
     {
         gdk_window_set_override_redirect(window, TRUE);
     }
@@ -454,6 +454,8 @@ void MCStack::sethints()
 	{
 		gdk_window_set_keep_above(window, TRUE);
 	}
+	
+	MCstacks->restack(this);
 }
 
 void MCStack::destroywindowshape()


### PR DESCRIPTION
This patch removes the setting of `gdk_window_set_override_redirect`
from Linux fullscreen windows. This setting was causing the window
manager to not present other windows appropriately over the fullscreen
window. The docs note this setting should only be used for short lived
windows. This patch has the effect on ubuntu that the fullscreen window
is behind the launcher, however, this is far better than modal dialogs
being behind the fullscreen window. We are still using
`gdk_window_fullscreen` and our fullscreen property docs are very similar
to the documented behavior of that.