### PR TITLE
[[ Bug ]] Resolve behaviors for auxiliary stacks

### DIFF
--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -926,7 +926,10 @@ void MCDispatch::processstack(MCStringRef p_openpath, MCStack* &x_stack)
     // this - so we just ignore the result for now (note that all the 'load'
     // methods *fail* to check for no-memory errors!).
     if (s_loaded_parent_script_reference)
+    {
         x_stack -> resolveparentscripts();
+        x_stack -> setextendedstate(True, ECS_USES_PARENTSCRIPTS);
+    }
 }
 
 // MW-2012-02-17: [[ LogFonts ]] Actually load the stack file (wrapped by readfile
@@ -2788,3 +2791,22 @@ bool MCDispatch::recomputefonts(MCFontRef, bool p_force)
     
     return true;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+void MCDispatch::resolveparentscripts()
+{
+    if (stacks != NULL)
+    {
+        MCStack* t_stack = stacks;
+        do
+        {
+            if (t_stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
+                t_stack -> resolveparentscripts();
+            
+            t_stack = t_stack->next();
+        }
+        while(t_stack != stacks);
+    }
+}
+

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -305,6 +305,7 @@ public:
     // if required.
     void processstack(MCStringRef p_openpath, MCStack* &x_stack);
     
+    void resolveparentscripts(void);
 private:
 	// MW-2012-02-17: [[ LogFonts ]] Actual method which performs a load stack. This
 	//   is wrapped by readfile to handle logical font table.

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1341,10 +1341,8 @@ IO_stat MCDispatch::startup(void)
 		
 		t_stack -> extraopen(false);
 		
-        // Resolve parent scripts *after* we've loaded aux stacks.
-        if (t_stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
-            t_stack -> resolveparentscripts();
-
+        MCdispatcher->resolveparentscripts();
+        
 		MCscreen->resetcursors();
 		MCImage::init();
 		send_startup_message();
@@ -1406,13 +1404,7 @@ IO_stat MCDispatch::startup(void)
 
 	t_info . stack -> extraopen(false);
     
-    // Resolve parent scripts *after* we've loaded aux stacks.
-    if (t_info . stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
-        t_info . stack -> resolveparentscripts();
-
-    // Resolve parent scripts
-    if (t_info . stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
-        t_info . stack -> resolveparentscripts();
+    MCdispatcher->resolveparentscripts();
     
 	MCscreen->resetcursors();
 	MCtemplateimage->init();

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -586,10 +586,8 @@ IO_stat MCDispatch::startup(void)
 		
 		t_stack -> extraopen(false);
 		
-		// Resolve parent scripts *after* we've loaded aux stacks.
-		if (t_stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
-			t_stack -> resolveparentscripts();
-		
+        MCdispatcher->resolveparentscripts();
+        
 		MCscreen->resetcursors();
 		MCImage::init();
 		
@@ -685,10 +683,8 @@ IO_stat MCDispatch::startup(void)
 	{
 		t_info . stack -> extraopen(false);
 	
-		// Resolve parent scripts *after* we've loaded aux stacks.
-		if (t_info . stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
-			t_info . stack -> resolveparentscripts();
-		
+        MCdispatcher->resolveparentscripts();
+        
 		MCscreen->resetcursors();
 		MCImage::init();
 	}
@@ -893,11 +889,7 @@ IO_stat MCDispatch::startup(void)
 		
 		MCCapsuleClose(t_capsule);
 		
-        // Resolve parent scripts *after* we've loaded aux stacks.
-        if (t_info . stack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
-            t_info . stack -> resolveparentscripts();
-        
-		t_mainstack = t_info . stack;
+        t_mainstack = t_info . stack;
 	}
 	else if (MCnstacks > 1 && MClicenseparameters . license_class == kMCLicenseClassCommunity)
 	{
@@ -992,9 +984,7 @@ IO_stat MCDispatch::startup(void)
 	// Now open the main stack.
 	t_mainstack-> extraopen(false);
     
-    // Resolve parent scripts *after* we've loaded aux stacks.
-    if (t_mainstack -> getextendedstate(ECS_USES_PARENTSCRIPTS))
-        t_mainstack -> resolveparentscripts();
+    MCdispatcher->resolveparentscripts();
     
 	send_startup_message();
 	if (!MCquit)


### PR DESCRIPTION
This patch moves the post auxiliary and mainstack load behavior
resolution to an MCDispatch method that iterates all stacks and
resolves those that need resolving. This reslves a probem with the
datagrid library behaviors not resolving their parent behaviors
correctly.