### PR TITLE
[[ Bug 19536 ]] Fix menu not closing when clicking on other side

### DIFF
--- a/docs/notes/bugfix-19536.md
+++ b/docs/notes/bugfix-19536.md
@@ -1,0 +1,1 @@
+# Fix menu not being dismissed when user clicks on location greater than menu right or bottom

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -1373,7 +1373,7 @@ Boolean MCButton::mup(uint2 which, bool p_release)
                 // We also need to close the menu if the button release happened
                 // outside of the menu tree.
                 bool t_outside = true;
-                MCObject* t_menu = this;
+                MCObject* t_menu = menu;
                 while (t_outside && t_menu != NULL)
                 {
                     // Check whether the click was inside the menu (the rect


### PR DESCRIPTION
This patch  fixes a bugh where the stack of the button with the menu
was being used to determine if the user clicked away from the menu
rather than the menu stack itself. This was causing the menu to only
dismiss if the use clicked in a location less than the top left of the
button.