### PR TITLE
[[ Bug 20925 ]] Rebind dragboard when starting drag

### DIFF
--- a/docs/notes/bugfix-20925.md
+++ b/docs/notes/bugfix-20925.md
@@ -1,0 +1,1 @@
+# Fix crash when repeatedly dragging

--- a/engine/src/desktop.cpp
+++ b/engine/src/desktop.cpp
@@ -440,7 +440,10 @@ void MCPlatformHandleMouseUp(MCPlatformWindowRef p_window, uint32_t p_button, ui
 
 void MCPlatformHandleMouseDrag(MCPlatformWindowRef p_window, uint32_t p_button)
 {
-	MCdispatcher -> wmdrag(p_window);
+    MCAutoRefcounted<MCRawClipboard> t_dragboard(MCRawClipboard::CreateSystemDragboard());
+    MCdragboard->Rebind(t_dragboard);
+    
+    MCdispatcher -> wmdrag(p_window);
 }
 
 void MCPlatformHandleMouseRelease(MCPlatformWindowRef p_window, uint32_t p_button, bool p_was_menu)


### PR DESCRIPTION
This patch rebinds the system dragboard when starting a drag so that
stale pasteboard items do not get pushed to the OS.