### PR TITLE
[[Dictionary]] touchMove minor update

### DIFF
--- a/docs/dictionary/message/touchMove.lcdoc
+++ b/docs/dictionary/message/touchMove.lcdoc
@@ -18,7 +18,7 @@ local sLastX
 on touchMove pTouchID, pTouchX, pTouchY
    -- sLastX[pTouchID] will be empty when the first move
    -- message for pTouchID is sent
-   if sLastX[pTouchID] is not empty and
+   if sLastX[pTouchID] is not empty and \
          pTouchX > sLastX[pTouchID] then
       -- user has moved to the right
    end if

--- a/docs/dictionary/message/touchMove.lcdoc
+++ b/docs/dictionary/message/touchMove.lcdoc
@@ -14,10 +14,15 @@ OS: ios, android
 Platforms: mobile
 
 Example:
-on touchMove pTouchID, pX, pY
-   if pX &gt; lastX then
-     -- user has moved to the right
+local sLastX
+on touchMove pTouchID, pTouchX, pTouchY
+   -- sLastX[pTouchID] will be empty when the first move
+   -- message for pTouchID is sent
+   if sLastX[pTouchID] is not empty and
+         pTouchX > sLastX[pTouchID] then
+      -- user has moved to the right
    end if
+   put pTouchX into sLastX[pTouchID]
 end touchMove
 
 Parameters:
@@ -30,14 +35,14 @@ pTouchX:
 The horizontal coordinate of the touchPosition
 
 pTouchY:
-The vertical coordinate of the touchPostition
+The vertical coordinate of the touchPosition
 
 Description:
 Handle the <touchMove> message if you want to perform some action when
 the user changes the touch position without ending the touch or if you
 want to keep continuous track of the touch position.
 
-The <touchMove> message is sent to the control which recived the
+The <touchMove> message is sent to the control which received the
 <touchStart> message to begin the touch sequence.
 
 The <pTouchID> parameter is a number which uniquely identifies a sequence
@@ -49,7 +54,7 @@ or more <touchMove> messages and finish with either a <touchEnd> or a
 No two touch sequences will have the same id, and it is possible to have
 multiple (interleaving) such sequences occurring at once. This allows
 handling of more than one physical touch at once and, for example,
-allows you to track two fingers moving on the iPhone's screen.
+allows you to track two fingers moving on the device screen.
 
 The sequence of touch messages is tied to the control in which the touch
 started, in much the same way mouse messages are tied to the object a
@@ -57,6 +62,10 @@ mouse down starts in. The test used to determine what object a touch
 starts in is identical to that used to determine whether the pointer is
 inside a control. In particular, invisible and disabled controls will
 not considered viable candidates.
+
+Since the current touch position is reported for each move message, the
+previous position will need to be tracked to calculate direction and/or
+distance moved.
 
 References: touchRelease (message), touchStart (message),
 touchEnd (message)


### PR DESCRIPTION
Updated the example to demonstrate tracking multiple touches.
Updated example to clarify that previous locations are user tracked.
Made a couple spelling corrections.
Changed `iPhone's` to `device` to generalize the entry.
Added a statement that the previous positions need to be tracked.