### PR TITLE
[[ Bug 20961 ]] Reset the menu object when swapping menus

### DIFF
--- a/docs/notes/bugfix-20961.md
+++ b/docs/notes/bugfix-20961.md
@@ -1,0 +1,1 @@
+# Clear the menu object when moving from one menu to another

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -911,6 +911,10 @@ Boolean MCButton::mfocus(int2 x, int2 y)
 						bptr->message_with_args(MCM_mouse_down, menubutton);
                         MCRedrawUnlockScreen();
 						bptr->findmenu();
+                        if (menudepth == 0)
+                        {
+                            MCmenuobjectptr = nullptr;
+                        }
 						bptr->openmenu(False);
 						return True;
 					}


### PR DESCRIPTION
This patch resets `MCmenuobjectptr` to `null` when changing from one
menu to another. This allows `openmenu` to set it to the new button and
and for `closemenu` to correctly set it to `null`. Previously
`MCmenuobjectptr` was left referring to the first button and therefore
not cleared on `closemenu` and leaving the button in an unable to delete
state.