### PR TITLE
[[ Bug 20678 ]] Take ownership of clipboard for private item

### DIFF
--- a/docs/notes/bugfix-20678.md
+++ b/docs/notes/bugfix-20678.md
@@ -1,0 +1,1 @@
+# Ensure that when the clipboard only has private data it will be updated when the system clipboard changes

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -169,8 +169,27 @@ MCWin32RawClipboardItem* MCWin32RawClipboardCommon::CreateNewItem()
 	if (m_item != NULL)
 		return NULL;
 
+	// clear the clipboard and take ownership
+	HRESULT t_result = OleSetClipboard(nullptr);
+
+	// Clipboard is now clean
+	if (t_result != S_OK)
+	{
+		return nullptr;
+	}
+
+	// Fetch the current clipboard IDataObject
+	IDataObject* t_contents;
+	t_result = OleGetClipboard(&t_contents);
+
+	// Clipboard is now clean
+	if (t_result != S_OK)
+	{
+		return nullptr;
+	}
+
 	// Create a new data item
-	m_item = new (nothrow) MCWin32RawClipboardItem(this);
+	m_item = new (nothrow) MCWin32RawClipboardItem(this, t_contents);
 	m_item->Retain();
 	return m_item;
 }
@@ -780,17 +799,6 @@ bool MCWin32RawClipboardNull::FlushData()
 {
 	// This clipboard is non-functional
 	return true;
-}
-
-
-MCWin32RawClipboardItem::MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_clipboard) :
-  MCRawClipboardItem(),
-  m_clipboard(p_clipboard),
-  m_object_is_external(false),
-  m_object(NULL),
-  m_reps()
-{
-	;
 }
 
 MCWin32RawClipboardItem::MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_clipboard, IDataObject* p_object) :

--- a/engine/src/w32-clipboard.h
+++ b/engine/src/w32-clipboard.h
@@ -97,7 +97,6 @@ private:
 	// Lifetime is managed entirely by the parent MCWin32RawClipboard
 	friend class MCWin32RawClipboardCommon;
 	friend class MCWin32RawClipboard;
-	MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_parent);
 	MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_parent, IDataObject* p_external_data);
 	~MCWin32RawClipboardItem();
 


### PR DESCRIPTION
This patch ensures that we retain a ref of the windows clipboard when
we add private data thus allowing us to use the clipboard reference when
are checking if it has been mutated.