### PR TITLE
[[ Bug 20677 ]] Fix crash calling mobilePickPhoto

### DIFF
--- a/docs/notes/bugfix-20677.md
+++ b/docs/notes/bugfix-20677.md
@@ -1,0 +1,1 @@
+# Fix crash calling mobilePickPhoto with no source parameter

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -3915,6 +3915,11 @@ Exec_stat MCHandlePickPhoto(void *p_context, MCParameter *p_parameters)
 		p_parameters -> eval_argument(ctxt, &t_value);
         /* UNCHECKED */ ctxt . ConvertToString(*t_value, &t_source);
 	}
+    
+    if (!t_source.IsSet())
+    {
+        return ES_ERROR;
+    }
 	
 	MCPhotoSourceType t_photo_source;
 	bool t_is_take;


### PR DESCRIPTION
This patch fixes a crash where `t_source` may be used but unset if
the handler was not called with the parameter.