### PR TITLE
[[ Emscripten ]] Implement GetNativeWindowHandle for emscripten

### DIFF
--- a/engine/src/em-dc.cpp
+++ b/engine/src/em-dc.cpp
@@ -231,6 +231,11 @@ MCScreenDC::uinttowindow(uintptr_t p_uint, Window &r_window)
 	return True;
 }
 
+void *MCScreenDC::GetNativeWindowHandle(Window p_window)
+{
+    return (void*)dtouint(p_window);
+}
+
 bool
 MCScreenDC::platform_getwindowgeometry(Window p_window,
                                        MCRectangle & r_rect)

--- a/engine/src/em-dc.h
+++ b/engine/src/em-dc.h
@@ -76,6 +76,7 @@ public:
 
 	uintptr_t dtouint(Drawable d);
 	Boolean uinttowindow(uintptr_t, Window &w);
+    void* GetNativeWindowHandle(Window p_window);
 
 	/* ---------- Display management */
 


### PR DESCRIPTION
If this is not implemented, `MCWidgetGetMyStackNativeView` returns
nil.