### PR TITLE
[[ Bug 19536 ]] Ensure parent is submenu

### DIFF
--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -1384,7 +1384,9 @@ Boolean MCButton::mup(uint2 which, bool p_release)
                     
                     // Move to the parent menu, if it exists
                     if (t_menu->getstack()->getparent()    // Stack's parent
-                        && t_menu->getstack()->getparent()->gettype() == CT_BUTTON)
+                        && t_menu->getstack()->getparent()->gettype() == CT_BUTTON
+						&& t_menu->getstack()->getparent()->getstack()->getparent()
+						&& t_menu->getstack()->getparent()->getstack()->getparent()->gettype() == CT_BUTTON)
                     {
                         // This is a submenu
                         t_menu = t_menu->getstack()->getparent();


### PR DESCRIPTION
This patch checks that the parent of the parent of a menu is a button.
This will be the case if it is a submenu and we should continue iterating
the menu tree to confirm the click was outside a menu.