### PR TITLE
[[ Bug 21019 ]] Implement mobileSetFullScreenRectForOrientations

### DIFF
--- a/docs/dictionary/command/mobileSetAllowedOrientations.lcdoc
+++ b/docs/dictionary/command/mobileSetAllowedOrientations.lcdoc
@@ -49,5 +49,4 @@ the configured list.
 References: mobileLockOrientation (command),
 mobileUnlockOrientation (command), mobileAllowedOrientations (function),
 mobileDeviceOrientation (function), mobileOrientation (function),
-orientationChanged (message)
-
+orientationChanged (message), mobileSetFullScreenRectForOrientations (command)

--- a/docs/dictionary/command/mobileSetFullScreenRectForOrientations.lcdoc
+++ b/docs/dictionary/command/mobileSetFullScreenRectForOrientations.lcdoc
@@ -1,0 +1,56 @@
+Name: mobileSetFullScreenRectForOrientations
+
+Type: command
+
+Syntax: mobileSetAllowedOrientations <orientations>[, <rect>]
+
+Summary:
+Set the list of allowed orientations.
+
+Introduced: 8.1.10
+
+OS: ios, android
+
+Platforms: mobile
+
+Example:
+mobileSetFullScreenRectForOrientations "portrait,portrait upside down","0,0,375,667"
+mobileSetFullScreenRectForOrientations "landscape left,landscape right","0,0,667,375"
+
+Parameters:
+orientations (enum):
+A comma delimited list consisting of at least one of:
+
+- "portrait"
+- "portrait upside down"
+- "landscape left"
+- "landscape right"
+
+rect:
+A comma delimited rect for the stack to be set to. If not set the rect for
+the specified orientations will be cleared.
+
+
+Description:
+Use the <mobileSetFullScreenRectForOrientations> command to set the rect
+to resize the stack to when the orientation changes and the stack has its
+<fullscreenMode> set.
+
+Normally when a <fullscreenMode> is set the stack is not resized and does
+receive the <resizeStack> message. The rect is set after the <orientationChanged>
+message is sent. If the rect for the new orientation is different to the
+current stack rect the <resizeStack> message will be sent once the new
+rect is applied.
+
+The setting take affect the next time an orientation change is applied.
+The interface orientation only changes if the new orientation is among
+the <mobileAllowedOrientations>.
+
+>*Note:* Due to the limitation of the Android operating system,
+> landscape left and portrait upside-down are only supported on Android
+> 2.3 and later.
+
+References: mobileLockOrientation (command), mobileSetAllowedOrientations (command),
+mobileUnlockOrientation (command), mobileAllowedOrientations (function),
+mobileDeviceOrientation (function), mobileOrientation (function),
+orientationChanged (message), resizeStack (message)

--- a/docs/dictionary/function/mobileAllowedOrientations.lcdoc
+++ b/docs/dictionary/function/mobileAllowedOrientations.lcdoc
@@ -42,5 +42,4 @@ of the orientations the application supports.
 References: mobileSetAllowedOrientations (command),
 mobileLockOrientation (command), mobileUnlockOrientation (command),
 mobileDeviceOrientation (function), mobileOrientation (function),
-orientationChanged (message)
-
+orientationChanged (message), mobileSetFullScreenRectForOrientations (command)

--- a/docs/dictionary/function/mobileOrientation.lcdoc
+++ b/docs/dictionary/function/mobileOrientation.lcdoc
@@ -45,5 +45,4 @@ interface.
 References: mobileSetAllowedOrientations (command),
 mobileLockOrientation (command), mobileUnlockOrientation (command),
 mobileDeviceOrientation (function), mobileAllowedOrientations (function),
-orientationChanged (message)
-
+orientationChanged (message), mobileSetFullScreenRectForOrientations (command)

--- a/docs/dictionary/message/orientationChanged.lcdoc
+++ b/docs/dictionary/message/orientationChanged.lcdoc
@@ -41,5 +41,4 @@ milliseconds(command)> command.
 References: mobileSetAllowedOrientations (command),
 mobileLockOrientation (command), mobileUnlockOrientation (command),
 mobileAllowedOrientations (function), mobileDeviceOrientation (function),
-mobileOrientation (function), resizeStack (message)
-
+mobileOrientation (function), resizeStack (message), mobileSetFullScreenRectForOrientations (command)

--- a/docs/notes/bugfix-21019.md
+++ b/docs/notes/bugfix-21019.md
@@ -1,0 +1,5 @@
+# Support resizing stacks for orientation changes in fullscreen modes
+
+A new mobile command `mobileSetFullScreenRectForOrientations` has been
+implemented to allow stacks that use the `fullscreenMode` property to
+be resized when the device orientation changes.

--- a/engine/src/exec-orientation.cpp
+++ b/engine/src/exec-orientation.cpp
@@ -29,6 +29,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "mblsyntax.h"
 #include "exec.h"
 
+#include <map>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 static MCExecSetTypeElementInfo _kMCOrientationOrientationsElementInfo[] =
@@ -76,6 +78,10 @@ MCExecEnumTypeInfo *kMCOrientationOrientationTypeInfo = &_kMCOrientationOrientat
 
 ////////////////////////////////////////////////////////////////////////////////
 
+std::map<intenum_t,MCRectangle> s_fullscreen_orientation_rects;
+
+////////////////////////////////////////////////////////////////////////////////
+
 void MCOrientationGetDeviceOrientation(MCExecContext& ctxt, intenum_t& r_orientation)
 {
 	MCOrientation t_orientation;
@@ -117,6 +123,36 @@ void MCOrientationExecLockOrientation(MCExecContext& ctxt)
 void MCOrientationExecUnlockOrientation(MCExecContext& ctxt)
 {
 	MCSystemUnlockOrientation();
+}
+
+void MCOrientationSetRectForOrientations(MCExecContext& ctxt, intset_t p_orientations, MCRectangle *p_rect)
+{
+    for (uindex_t i = 0; i < kMCOrientationOrientationTypeInfo -> count ; i++)
+    {
+        intenum_t t_orientation_bit = kMCOrientationOrientationTypeInfo -> elements[i].value;
+        if ((p_orientations & (1 << t_orientation_bit)) != 0)
+        {
+            if (p_rect != nullptr)
+            {
+                s_fullscreen_orientation_rects[t_orientation_bit] = *p_rect;
+            }
+            else
+            {
+                s_fullscreen_orientation_rects.erase(t_orientation_bit);
+            }
+        }
+    }
+}
+
+bool MCOrientationGetRectForOrientation(intenum_t p_orientation, MCRectangle& r_rect)
+{
+    if (s_fullscreen_orientation_rects.find(p_orientation) == s_fullscreen_orientation_rects.end())
+    {
+        return false;
+    }
+    
+    r_rect = s_fullscreen_orientation_rects[p_orientation];
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -5222,6 +5222,8 @@ void MCOrientationSetAllowedOrientations(MCExecContext& ctxt, intset_t p_orienta
 void MCOrientationGetOrientationLocked(MCExecContext& ctxt, bool& r_locked);
 void MCOrientationExecLockOrientation(MCExecContext& ctxt);
 void MCOrientationExecUnlockOrientation(MCExecContext& ctxt);
+void MCOrientationSetRectForOrientations(MCExecContext& ctxt, intset_t p_orientations, MCRectangle *p_rect);
+bool MCOrientationGetRectForOrientation(intenum_t p_orientation, MCRectangle& r_rect);
 
 ///////////
 

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -407,7 +407,7 @@ bool MCScreenDC::platform_getdisplays(bool p_effective, MCDisplay *&r_displays, 
 // IM-2014-01-31: [[ HiDPI ]] Display info updating not yet implemented on Android
 bool MCScreenDC::platform_displayinfocacheable(void)
 {
-	return false;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2156,6 +2156,9 @@ JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doReconfigure(JNIEnv *env,
 	
 	s_android_bitmap_loc_x = x;
 	s_android_bitmap_loc_y = y;
+    
+    bool t_updated;
+    static_cast<MCScreenDC *>(MCscreen) -> updatedisplayinfo(t_updated);
 
 	// MW-2011-10-01: [[ Bug 9772 ]] If we are resizing, we do a 'fit window', else
 	//   we yield to engine.

--- a/engine/src/stackview.cpp
+++ b/engine/src/stackview.cpp
@@ -426,11 +426,21 @@ void MCStack::view_calculate_viewports(const MCRectangle &p_stack_rect, MCRectan
 	// IM-2014-01-16: [[ StackScale ]] append scale transform to fullscreenmode transform
 	r_transform = MCGAffineTransformConcat(view_get_stack_transform(t_mode, MCGRectangleGetIntegerBounds(t_scaled_rect), t_view_rect), t_transform);
 }
+
+#if defined(_MOBILE)
+#include "mblsyntax.h"
+#endif
 	
 void MCStack::view_update_transform(bool p_ensure_onscreen)
 {
 	MCRectangle t_view_rect;
 	MCGAffineTransform t_transform;
+    
+#if defined(_MOBILE)
+    MCOrientation t_orientation;
+    MCSystemGetOrientation(t_orientation);
+    MCOrientationGetRectForOrientation(t_orientation ,m_view_requested_stack_rect);
+#endif
 	
 	// IM-2014-01-16: [[ StackScale ]] Use utility method to calculate new values
 	view_calculate_viewports(m_view_requested_stack_rect, m_view_adjusted_stack_rect, t_view_rect, t_transform);


### PR DESCRIPTION
This patch implements a new mobile command to set the fullscreen rect
for a given list of comma separated orientations. This allows a fullscreen
stack to chance its rect automatically when the orientation changes and
handle the resizeStack message to layout controls for the new width and height.