### PR TITLE
[[ Bug 21074 ]] revDocsFormatLibraryArrayAsJSON omits dictionary data

### DIFF
--- a/docs/notes/bugfix-21074.md
+++ b/docs/notes/bugfix-21074.md
@@ -1,0 +1,1 @@
+# revDocsFormatLibraryArrayAsJSON omits dictionary data

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -2156,7 +2156,7 @@ end revDocsCreateAPIJSON
 
 function revDocsFormatLibraryArrayAsJSON pLibraryA
    local tDocContent
-   put revDocsFormatLibraryDocArrayAsJSON(pLibraryA["name"], pLibraryA["doc"]) \
+   put revDocsFormatLibraryDocArrayAsJSON(pLibraryA) \
          into tDocContent
    return revDocsCreateAPIJSON(pLibraryA["display name"], pLibraryA["name"], \
          pLibraryA["author"], tDocContent)


### PR DESCRIPTION
`revDocsFormatLibraryDocArrayAsJSON` expects `pLibraryA` but is being passed `(pLibraryA["name"], pLibraryA["doc"])`
This caused the returned JSON to just contain the name and an empty doc array.

Function is used in `revDocsFormatLibrariesArrayAsJSON` (which is not used)
Function is used in `revDocsFormatDocTextAsJSON` which is in turn used by `revDocsFormatDocFileAsJSON` (which is not used) and `revDocsFormatAPIAsJSON` which is used by `revIDEInstallAPI`