### PR TITLE
[[ Bug 21105 ]] Ensure interface file is found

### DIFF
--- a/extensions/script-libraries/extension-utils/extension-utils.livecodescript
+++ b/extensions/script-libraries/extension-utils/extension-utils.livecodescript
@@ -1114,18 +1114,19 @@ function extensionFetchFolderDetails pFolder, pParseManifest
       put tModuleFiles into tDetailsA[kModuleFilesKey]
    end if
    
-   local tInterfaceFile
-   put pFolder & slash & tDetailsA[kNameKey] & ".lci" into tInterfaceFile
-   if there is a file tInterfaceFile then
-      put tInterfaceFile into tDetailsA[kInterfaceKey]
-   end if
-   
    # Fetch data from manifest
    local tManifest
    put pFolder & slash & "manifest.xml" into tManifest
    if pParseManifest is not false and \
          there is a file tManifest then
       union tDetailsA with extensionFetchMetadata(tManifest)
+   end if
+   
+   # Now we have the name, add the interface file
+   local tInterfaceFile
+   put pFolder & slash & tDetailsA[kNameKey] & ".lci" into tInterfaceFile
+   if there is a file tInterfaceFile then
+      put tInterfaceFile into tDetailsA[kInterfaceKey]
    end if
    
    return tDetailsA 

--- a/extensions/script-libraries/extension-utils/notes/21105.md
+++ b/extensions/script-libraries/extension-utils/notes/21105.md
@@ -1,0 +1,1 @@
+# [21105] Include interface file in package


### PR DESCRIPTION
The 'name' detail comes from the manifest, so wait until we have
it before finding the .lci file