### PR TITLE
[[ Bug 21085 ]] Fix handling of unknown url scheme

### DIFF
--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -457,6 +457,8 @@ end handler
 
 --
 
+variable mOpenComplete as Boolean
+
 private unsafe handler InitBrowserView()
 	variable tParent as Pointer
 
@@ -486,13 +488,27 @@ private unsafe handler InitBrowserView()
 	MCBrowserSetJavaScriptHandler(mBrowser, OnJavaScriptCallback, nothing)
 
 	applyProperties(mProperties)
+	
+	put true into mOpenComplete
 end handler
 
 private unsafe handler FinalizeBrowserView()
-	set my native layer to nothing
+	if mOpenComplete then
+		set my native layer to nothing
 
-	MCBrowserRelease(mBrowser)
-	put nothing into mBrowser
+		MCBrowserRelease(mBrowser)
+		put nothing into mBrowser
+		
+		put false into mOpenComplete
+	else
+		schedule timer in 0.1 seconds
+	end if
+end handler
+
+public handler OnTimer()
+	unsafe
+		FinalizeBrowserView()
+	end unsafe
 end handler
 
 --

--- a/extensions/widgets/browser/notes/21085.md
+++ b/extensions/widgets/browser/notes/21085.md
@@ -1,0 +1,1 @@
+# [21085] Ensure browserUnhandledLoadRequest is sent for unknown protocols

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -1136,12 +1136,7 @@ public:
 		bool t_frame;
 		t_frame = !p_frame->IsMain();
 		
-		if (t_is_error)
-		{
-			if (t_error_code == ERR_UNKNOWN_URL_SCHEME)
-				m_owner->OnNavigationRequestUnhandled(t_frame, t_url_str);
-		}
-		else
+		if (!t_is_error)
 		{
 			if (!t_frame)
 				m_owner->OnNavigationBegin(t_frame, t_url_str);
@@ -1209,10 +1204,23 @@ public:
 	
 	virtual void OnLoadError(CefRefPtr<CefBrowser> p_browser, CefRefPtr<CefFrame> p_frame, CefLoadHandler::ErrorCode p_error_code, const CefString &p_error_text, const CefString &p_failed_url) OVERRIDE
 	{
-		// IM-2015-11-16: [[ Bug 16360 ]] Contrary to the CEF API docs, OnLoadEnd is NOT called after OnLoadError when the error code is ERR_ABORTED.
-		//    This occurs when requesting a new url be loaded when in the middle of loading the previous url, or when the url load is otherwise cancelled.
-		if (p_error_code != ERR_ABORTED)
+		if (p_error_code == ERR_UNKNOWN_URL_SCHEME)
+		{
+			bool t_frame;
+			t_frame = !p_frame->IsMain();
+
+			char *t_url_str = nullptr;
+			if (MCCefStringToUtf8String(p_failed_url, t_url_str))
+			{
+				m_owner->OnNavigationRequestUnhandled(t_frame, t_url_str);
+			}
+		}
+		else if (p_error_code != ERR_ABORTED)
+		{
+			// IM-2015-11-16: [[ Bug 16360 ]] Contrary to the CEF API docs, OnLoadEnd is NOT called after OnLoadError when the error code is ERR_ABORTED.
+			//    This occurs when requesting a new url be loaded when in the middle of loading the previous url, or when the url load is otherwise cancelled.
 			AddLoadErrorFrame(p_frame->GetIdentifier(), p_failed_url, p_error_text, p_error_code);
+		}
 	}
 	
 	// ContextMenuHandler interface


### PR DESCRIPTION
The updated version of CEF we are now using appears to handle
`ERR_UNKNOWN_URL_SCHEME` errors by calling `OnLoadError` immediately
while previousluy it called `OnLoadStart`. This patch handles the
error in `OnLoadError` to ensure `browserUnhandledLoadRequest` is
sent to the widget.