### PR TITLE
[[ Bug 21109 ]] Limit clipboard clear setting fullClipboardData["text"]

### DIFF
--- a/docs/dictionary/property/fullClipboardData.lcdoc
+++ b/docs/dictionary/property/fullClipboardData.lcdoc
@@ -63,7 +63,10 @@ The `rtftext`, `htmltext`, `styles` and `styledtext` properties are
 handled specially by LiveCode: adding any one of them will cause the 
 rest (plus `text`) to be automatically generated and added. You can 
 query the keys of the <fullClipboardData> to determine what types of 
-data are on the <clipboard(glossary)>.
+data are on the <clipboard(glossary)>. When setting the `text` property
+the clipboard (with the exception of private data) is cleared if it
+includes any of these properties. This is to allow setting plain text
+only.
 
 If you require lower-level access to the <clipboard(glossary)>, see the 
 <rawClipboardData> <property>.

--- a/docs/notes/bugfix-21109.md
+++ b/docs/notes/bugfix-21109.md
@@ -1,0 +1,1 @@
+# Ensure when setting `the fullClipboardData["text"]` to only clear the clipboard if it contains styled text and do not clear private data

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -257,7 +257,10 @@ bool MCClipboard::AddText(MCStringRef p_string)
     // Clear contents to ensure that the clipboard does not end up
     // containing data from different copy events.
     // i.e. the HTML/RTF representation would be left untouched
-    Clear();
+    if (HasLiveCodeStyledTextOrCompatible())
+    {
+        m_clipboard->Clear();
+    }
     
     // Get the first item on the clipboard
     MCAutoRefcounted<MCRawClipboardItem> t_item = GetItem();

--- a/tests/lcs/core/engine/clipboard.livecodescript
+++ b/tests/lcs/core/engine/clipboard.livecodescript
@@ -260,3 +260,23 @@ on TestClipboardTextOnlyOnRawClipboard
    set the fullClipboardData to empty
    unlock the clipboard
 end TestClipboardTextOnlyOnRawClipboard
+
+on TestClipboardSettingTextDoesntClearPrivateData
+  lock clipboard
+  set the fullclipboarddata to empty
+  set the fullclipboarddata["private"] to "foo"
+  set the fullclipboardData["htmltext"] to "<p>foo</p>"
+  set the fullclipboarddata["text"] to "bar"
+  unlock clipboard
+  TestAssert "Setting fullclipboard text does not clear private data", the fullclipboarddata["private"] is "foo"
+end TestClipboardSettingTextDoesntClearPrivateData
+   
+on TestClipboardSettingTextOnlyClearsWhenCurrentlyHasStyled
+  lock clipboard
+  set the fullclipboarddata to empty
+  set the fullClipboardData["png"] to _TinyPNG()
+  set the fullclipboarddata["text"] to "bar"
+  unlock clipboard
+  TestAssert "Setting fullclipboard text does not clear unless it is currently styled", \
+         "png" is among the lines of the keys of the fullClipboardData and fullClipboardData["png"] is _TinyPNG()
+end TestClipboardSettingTextOnlyClearsWhenCurrentlyHasStyled


### PR DESCRIPTION
This patch ensures the clipboard is cleared only when necessary when setting
`the fullClipboardData["text"]`. It also ensures that private data is never
cleared. Additionally the clearing of the clipboard when there are styled
text representations and the text representation is set is now documented
as part of the interaction between the styled and plain text representations
placed on the clipboard.