### PR TITLE
[Bugfix 15614] Replace URLEncode example

### DIFF
--- a/docs/dictionary/function/URLEncode.lcdoc
+++ b/docs/dictionary/function/URLEncode.lcdoc
@@ -25,6 +25,7 @@ Example:
 URLEncode("Test string $$") -- returns "Test+string+%24%24"
 
 Example:
+local tGoodURL
 put "http://www.example.net/" & URLEncode("A File Name with spaces.html") into tGoodURL
 
 Parameters:

--- a/docs/dictionary/function/URLEncode.lcdoc
+++ b/docs/dictionary/function/URLEncode.lcdoc
@@ -25,7 +25,7 @@ Example:
 URLEncode("Test string $$") -- returns "Test+string+%24%24"
 
 Example:
-put URLEncode("http://www.example.net/document.html") into newURL
+put "http://www.example.net/" & URLEncode("A File Name with spaces.html") into tGoodURL
 
 Parameters:
 formString (string):
@@ -45,7 +45,7 @@ Letters and numbers (alphanumeric characters) are not transformed by the
 characters is a percent sign followed by two <hexadecimal> digits. For
 example, the <ASCII|ASCII value> of the <character> ~ is 126; the
 hexadecimal equivalent of 126 is 7E. So wherever the <character> ~
-<a/>appears in the formString, it is converted to "%7E".
+appears in the formString, it is converted to "%7E".
 
 References: post (command), function (control structure),
 hexadecimal (glossary), encode (glossary), Escape key (glossary),

--- a/docs/dictionary/function/URLEncode.lcdoc
+++ b/docs/dictionary/function/URLEncode.lcdoc
@@ -47,6 +47,20 @@ example, the <ASCII|ASCII value> of the <character> ~ is 126; the
 hexadecimal equivalent of 126 is 7E. So wherever the <character> ~
 appears in the formString, it is converted to "%7E".
 
+>*Note:* The URLEncode function does not conform to RFC3986. In order 
+> to produce a string that does conform to it, you would first encode
+> the string to UTF-8 and then after performing URLEncode, replace all
+> instances of "+" with "%20". For example:
+
+   function urlEncodeRFC pString
+      if pString is strictly a string then
+         put textEncode(pString,"UTF-8") into pString
+      end if
+      put URLEncode(pString) into pString
+      replace "+" with "%20" in pString
+      return pString
+   end urlEncodeRFC
+
 References: post (command), function (control structure),
 hexadecimal (glossary), encode (glossary), Escape key (glossary),
 ASCII (glossary), return (glossary), server (glossary), URL (keyword),

--- a/docs/notes/bugfix-15614.md
+++ b/docs/notes/bugfix-15614.md
@@ -1,0 +1,1 @@
+# Fixed incorrect example in the dictionary entry for URLEncode.


### PR DESCRIPTION
Replaced example in URLEncode with one that only encodes the part of the URL that ought to be encoded.