### PR TITLE
[[ Bug 20488 ]] Ensure put throws when expecting preposition

### DIFF
--- a/docs/dictionary/command/revBrowserSet.lcdoc
+++ b/docs/dictionary/command/revBrowserSet.lcdoc
@@ -26,7 +26,7 @@ Example:
 answer file "Please choose a file to display"
 if the result is not "cancel" then
   put it into tFile
-  put revBrowserSet tBrowserID,"url","file://" & tFile     
+  revBrowserSet tBrowserID,"url","file://" & tFile     
 end if
 
 Parameters:

--- a/docs/dictionary/property/scriptExecutionErrors.lcdoc
+++ b/docs/dictionary/property/scriptExecutionErrors.lcdoc
@@ -16,9 +16,9 @@ Platforms: desktop, server
 Example:
 -- Use of scriptExecutionErrors in a try statement
 on mouseUp
-  local tVar, tErr
+  local tErr
   try
-    put "foo" in tErr -- syntax error in this line
+    CommandThatDoesNotExist -- execution error in this line
   catch tErr
     put line (item 1 of tErr) of the scriptExecutionErrors
     -- reports details about the error

--- a/docs/notes/bugfix-20488.md
+++ b/docs/notes/bugfix-20488.md
@@ -1,0 +1,1 @@
+# Ensure the put command throws an error when a preposition is expected and not found

--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -844,8 +844,8 @@ Parse_stat MCPut::parse(MCScriptPoint &sp)
 		
 	if (sp.lookup(SP_FACTOR, te) != PS_NORMAL || te->type != TT_PREP)
 	{
-		sp.backup();
-		return PS_NORMAL;
+        MCperror->add(PE_PUT_BADPREP, sp);
+        return PS_ERROR;
 	}
 	prep = (Preposition_type)te->which;
 	if (prep != PT_BEFORE && prep != PT_INTO && prep != PT_AFTER)

--- a/tests/lcs/docs/validate-dictionary.livecodescript
+++ b/tests/lcs/docs/validate-dictionary.livecodescript
@@ -204,7 +204,7 @@ command __TestDocsLibraryArray pDocsPath, pLibrary, pTestSyntax
          tElement["display name"] is not among the words of "sessionName errorObject" then
          repeat for each element tValue in tElement["Example"]
             
-            if word 1 of tValue is among the words of "end case" then
+         if word 1 of tValue is among the words of "end case catch" then
                next repeat
             end if
             

--- a/tests/lcs/parser/put.parsertest
+++ b/tests/lcs/parser/put.parsertest
@@ -1,0 +1,24 @@
+%% Copyright (C) 2018 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%TEST PutPreposition
+on parse_test
+   local tFoo, tBar
+   put tFoo tBar %{AFTER_BADPREP}
+end parse_test
+%EXPECT PASS
+%ERROR PE_PUT_BADPREP AT AFTER_BADPREP
+%ENDTEST


### PR DESCRIPTION
This patch ensures that the put command throws an error if it parses
a token when expecting a preposition and it isn't one. Previously
the command backed up and returned normal resulting in the anomaly that
anything after `put <expression>` could be treated as a second statement
without a newline or `;` present.