### PR TITLE
[[ Bug 21099 ]] Fix crash closing browser

### DIFF
--- a/extensions/widgets/browser/notes/21099.md
+++ b/extensions/widgets/browser/notes/21099.md
@@ -1,0 +1,1 @@
+# [21099] Fix crash when closing browser widget

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -921,19 +921,6 @@ public:
 		MCCefIncrementInstanceCount();
 	}
 	
-	virtual bool DoClose(CefRefPtr<CefBrowser> p_browser) OVERRIDE
-	{
-		// We handle browser closing here to stop CEF sending WM_CLOSE to the stack window
-		if (p_browser->GetIdentifier() == m_browser_id)
-		{
-			// Close the browser window
-			if (m_owner != nil)
-				m_owner->PlatformCloseBrowserWindow(p_browser);
-		}
-		
-		return CefLifeSpanHandler::DoClose(p_browser);
-	}
-	
 	virtual void OnBeforeClose(CefRefPtr<CefBrowser> p_browser) OVERRIDE
 	{
 		if (m_owner != nil)

--- a/libbrowser/src/libbrowser_cef.h
+++ b/libbrowser/src/libbrowser_cef.h
@@ -133,7 +133,6 @@ public:
 	// Platform-specific methods
 	
 	virtual void PlatformConfigureWindow(CefWindowInfo &r_info) = 0;
-	virtual void PlatformCloseBrowserWindow(CefRefPtr<CefBrowser> p_browser) = 0;
 	
 	virtual bool PlatformGetRect(MCBrowserRect &r_rect) = 0;
 	virtual bool PlatformSetRect(const MCBrowserRect &p_rect) = 0;

--- a/libbrowser/src/libbrowser_cef_lnx.cpp
+++ b/libbrowser/src/libbrowser_cef_lnx.cpp
@@ -32,7 +32,6 @@ public:
 	bool GetXWindow(Window &r_window);
 
 	virtual void PlatformConfigureWindow(CefWindowInfo &r_info);
-	virtual void PlatformCloseBrowserWindow(CefRefPtr<CefBrowser> p_browser);
 	virtual bool PlatformGetNativeLayer(void *&r_layer);
 
 	virtual bool PlatformSetVisible(bool p_visible);
@@ -189,20 +188,6 @@ bool MCCefLinuxBrowser::PlatformGetAuthCredentials(bool p_is_proxy, const CefStr
 {
 	/* TODO - implement */
 	return false;
-}
-
-//////////
-
-void MCCefLinuxBrowser::PlatformCloseBrowserWindow(CefRefPtr<CefBrowser> p_browser)
-{
-	Window t_window;
-	t_window = p_browser->GetHost()->GetWindowHandle();
-	
-	Display *t_display;
-	if (!GetXDisplay(t_display))
-		return;
-	
-	XDestroyWindow(t_display, t_window);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libbrowser/src/libbrowser_cef_win.cpp
+++ b/libbrowser/src/libbrowser_cef_win.cpp
@@ -51,7 +51,6 @@ public:
 	bool GetHWND(HWND &r_hwnd);
 
 	virtual void PlatformConfigureWindow(CefWindowInfo &r_info);
-	virtual void PlatformCloseBrowserWindow(CefRefPtr<CefBrowser> p_browser);
 
 	virtual bool PlatformGetNativeLayer(void *&r_layer);	
 
@@ -98,16 +97,6 @@ void MCCefWin32Browser::PlatformConfigureWindow(CefWindowInfo &r_info)
 	::SetRect(&t_rect, 0, 0, 1, 1);
 
 	r_info.SetAsChild(m_parent_window, t_rect);
-}
-
-void MCCefWin32Browser::PlatformCloseBrowserWindow(CefRefPtr<CefBrowser> p_browser)
-{
-	HWND t_win;
-	t_win = p_browser->GetHost()->GetWindowHandle();
-
-	//SetParent(t_win, HWND_MESSAGE);
-	//CloseWindow(t_win);
-	DestroyWindow(t_win);
 }
 
 bool MCCefWin32Browser::PlatformGetNativeLayer(void *&r_layer)


### PR DESCRIPTION
A previous patch allowed CEF to complete browser closing by returning
`false` in the `DoClose` callback. This allowed CEF to cleanup the render
process for the browser. The patch should have also removed the browser
window destruction allowing CEF to do that. This caused a crash on some
versions of Windows.