### PR TITLE
[[ Bug 21121 ]] Use temp directory for CEF cache

### DIFF
--- a/engine/src/widget-ref.cpp
+++ b/engine/src/widget-ref.cpp
@@ -1059,6 +1059,11 @@ bool MCWidgetRoot::IsRoot(void) const
 
 MCWidget *MCWidgetRoot::GetHost(void) const
 {
+	if (!m_host.IsValid())
+	{
+		return nullptr;
+	}
+
     return m_host;
 }
 

--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -191,7 +191,7 @@ public:
     virtual bool CopyFont(MCFontRef& r_font);
     
 private:
-    MCWidget *m_host;
+    MCWidgetHandle m_host;
 };
 
 class MCWidgetChild: public MCWidgetBase

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -456,8 +456,10 @@ public handler OnCreate()
 end handler
 
 --
-
-variable mOpenComplete as Boolean
+constant kOpenStateClosed is 0
+constant kOpenStateOpen is 1
+constant kOpenStateFailed is -1
+variable mOpenState as Number
 
 private unsafe handler InitBrowserView()
 	variable tParent as Pointer
@@ -467,6 +469,7 @@ private unsafe handler InitBrowserView()
 
 	variable tFactory as MCBrowserFactoryRef
 	if not MCBrowserFactoryGet(the empty string, tFactory) then
+		put kOpenStateFailed into mOpenState
 		throw "error getting browser factory"
 	end if
 
@@ -474,9 +477,11 @@ private unsafe handler InitBrowserView()
 	MCWidgetGetMyStackNativeDisplay(tDisplay)
 
 	if not MCBrowserFactoryCreateBrowser(tFactory, tDisplay, tParent, mBrowser) then
+		put kOpenStateFailed into mOpenState
 		throw "error creating browser"
 	end if
-
+	put kOpenStateOpen into mOpenState
+	
 	variable tBrowserView as Pointer
 	put MCBrowserGetNativeLayer(mBrowser) into tBrowserView
 	set my native layer to tBrowserView
@@ -488,18 +493,18 @@ private unsafe handler InitBrowserView()
 	MCBrowserSetJavaScriptHandler(mBrowser, OnJavaScriptCallback, nothing)
 
 	applyProperties(mProperties)
-	
-	put true into mOpenComplete
 end handler
 
 private unsafe handler FinalizeBrowserView()
-	if mOpenComplete then
+	if mOpenState is not kOpenStateClosed then
 		set my native layer to nothing
 
-		MCBrowserRelease(mBrowser)
-		put nothing into mBrowser
+		if mBrowser is not nothing then
+			MCBrowserRelease(mBrowser)
+			put nothing into mBrowser
+		end if
 		
-		put false into mOpenComplete
+		put kOpenStateClosed into mOpenState
 	else
 		schedule timer in 0.1 seconds
 	end if

--- a/extensions/widgets/browser/notes/21121.md
+++ b/extensions/widgets/browser/notes/21121.md
@@ -1,0 +1,1 @@
+# Ensure the browser widget does not create any cache folders in the current working directory

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -21,7 +21,7 @@
 #include "libbrowser_cef.h"
 
 #include <include/cef_app.h>
-
+#include <include/wrapper/cef_scoped_temp_dir.h>
 #include <list>
 #include <set>
 
@@ -270,6 +270,8 @@ static bool s_cefbrowser_initialised = false;
 
 static uint32_t s_instance_count = 0;
 
+static CefScopedTempDir s_temp_cache;
+
 void MCCefBrowserExternalInit(void)
 {
 	// set up static vars
@@ -501,12 +503,18 @@ bool MCCefInitialise(void)
     if (t_success)
         t_success = __MCCefBuildPath(t_library_path, kCefProcessName, &t_settings.browser_subprocess_path);
 #endif
-    
-    if (t_success)
-        t_success = __MCCefBuildPath(t_library_path, "locales", &t_settings.locales_dir_path);
-    if (t_success)
-        t_success = __MCCefBuildPath(t_library_path, "", &t_settings.resources_dir_path);
+
+	if (t_success)
+		t_success = __MCCefBuildPath(t_library_path, "locales", &t_settings.locales_dir_path);
+	if (t_success)
+		t_success = __MCCefBuildPath(t_library_path, "", &t_settings.resources_dir_path);
+
+	if (t_success)
+		t_success = s_temp_cache.CreateUniqueTempDir();
 	
+	if (t_success)
+		CefString(&t_settings.cache_path).FromString(s_temp_cache.GetPath());
+
 	CefRefPtr<CefApp> t_app = new (nothrow) MCCefBrowserApp();
 	
 	if (t_success)
@@ -566,9 +574,14 @@ void MCCefFinalise(void)
 {
 	if (!s_cef_initialised)
 		return;
+
+	if (s_temp_cache.IsValid())
+	{
+		s_temp_cache.Delete();
+	}
 	
 	CefShutdown();
-	
+
 	s_cef_initialised = false;
 }
 


### PR DESCRIPTION
This patch works around an issue where CEF creates a GPUCache directory
in the current working directory when there is no cache_path specified.
To work around this we create a temp directory for the cache path and
then delete it when tearing down CEF.