### PR TITLE
[Cleanup] Reduce memory footprint of regex cache

### DIFF
--- a/engine/src/exec-network.cpp
+++ b/engine/src/exec-network.cpp
@@ -843,6 +843,7 @@ void MCNetworkSetDefaultNetworkInterface(MCExecContext& ctxt, MCStringRef p_valu
 		t_net_int_regex = MCR_compile(MCSTR("\\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\b"), true /* casesensitive */);
 		int t_net_int_valid;
 		t_net_int_valid = MCR_exec(t_net_int_regex, p_value, MCRangeMake(0, MCStringGetLength(p_value)));
+		delete t_net_int_regex;
 		if (t_net_int_valid != 0)
 		{
 			delete MCdefaultnetworkinterface;

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -767,6 +767,8 @@ void MCStringsEvalMatchText(MCExecContext& ctxt, MCStringRef p_string, MCStringR
             t_match_index = 0;
     }
     
+	delete t_compiled;
+	
     if (t_success)
         return;
     
@@ -816,6 +818,8 @@ void MCStringsEvalMatchChunk(MCExecContext& ctxt, MCStringRef p_string, MCString
             t_match_index = 0;
     }
     
+	delete t_compiled;
+	
     if (t_success)
     {
         if ((p_result_count & 1) == 1)
@@ -847,6 +851,7 @@ void MCStringsEvalReplaceText(MCExecContext& ctxt, MCStringRef p_string, MCStrin
     MCAutoStringRef t_unicode_string;
     if (!MCStringUnicodeCopy(p_string, &t_unicode_string))
     {
+		delete t_compiled;
         ctxt.Throw();
         return;
     }
@@ -884,6 +889,8 @@ void MCStringsEvalReplaceText(MCExecContext& ctxt, MCStringRef p_string, MCStrin
             break;
     }
     
+	delete t_compiled;
+	
     MCAutoStringRef t_post_match;
     if (t_success)
         t_success = MCStringCopySubstring(p_string, MCRangeMakeMinMax(t_source_offset, t_source_length), &t_post_match) &&

--- a/engine/src/patternmatcher.cpp
+++ b/engine/src/patternmatcher.cpp
@@ -88,6 +88,12 @@ MCRegexMatcher::MCRegexMatcher(MCStringRef p_pattern, MCArrayRef p_array, MCStri
     m_compiled = NULL;
 }
 
+MCRegexMatcher::~MCRegexMatcher()
+{
+    if (m_compiled != NULL)
+        delete m_compiled;
+}
+
 // JS-2013-07-01: [[ EnhancedFilter ]] Implementation of pattern matching classes.
 bool MCRegexMatcher::compile(MCStringRef& r_error)
 {

--- a/engine/src/patternmatcher.h
+++ b/engine/src/patternmatcher.h
@@ -47,6 +47,7 @@ protected:
 public:
     MCRegexMatcher(MCStringRef p_pattern, MCStringRef p_string, MCStringOptions p_options);
     MCRegexMatcher(MCStringRef p_pattern, MCArrayRef p_array, MCStringOptions p_options);
+    virtual ~MCRegexMatcher();
     virtual bool compile(MCStringRef& r_error);
     virtual bool match(MCRange p_range);
     virtual bool match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key);
@@ -58,7 +59,7 @@ class MCWildcardMatcher : public MCPatternMatcher
 public:
     MCWildcardMatcher(MCStringRef p_pattern, MCStringRef p_string, MCStringOptions p_options);
     MCWildcardMatcher(MCStringRef p_pattern, MCArrayRef p_array, MCStringOptions p_options);
-    ~MCWildcardMatcher();
+    virtual ~MCWildcardMatcher();
     virtual bool compile(MCStringRef& r_error);
     virtual bool match(MCRange p_range);
     virtual bool match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key);

--- a/engine/src/regex.h
+++ b/engine/src/regex.h
@@ -31,6 +31,12 @@ typedef struct
 	void *re_pcre;
 	size_t re_nsub;
 	size_t re_erroffset;
+	// JS-2013-07-01: [[ EnhancedFilter ]] The pattern associated with the compiled
+	//   regexp (used by the cache).
+	MCStringRef re_pattern;
+	// JS-2013-07-01: [[ EnhancedFilter ]] The flags used to compile the pattern
+	//   (used to implement caseSensitive option).
+	int re_flags;
 }
 regex_t;
 
@@ -49,13 +55,7 @@ regmatch_t;
 
 typedef struct _regexp
 {
-	regex_t rexp;
-	// JS-2013-07-01: [[ EnhancedFilter ]] The pattern associated with the compiled
-	//   regexp (used by the cache).
-    MCStringRef pattern;
-	// JS-2013-07-01: [[ EnhancedFilter ]] The flags used to compile the pattern
-	//   (used to implement caseSensitive option).
-    int flags;
+	regex_t *rexp;
 	uint2 nsubs;
 	regmatch_t matchinfo[NSUBEXP];
 }
@@ -66,7 +66,7 @@ regexp;
 regexp *MCR_compile(MCStringRef exp, bool casesensitive);
 int MCR_exec(regexp *prog, MCStringRef string, MCRange p_range);
 void MCR_copyerror(MCStringRef &r_error);
-void MCR_free(regexp *prog);
+void MCR_free(regex_t *prog);
 
 // JS-2013-07-01: [[ EnhancedFilter ]] Clear out the PCRE cache.
 void MCR_clearcache();


### PR DESCRIPTION
Original implementation retained the `matchinfo` data as a part of the regex cache.  This results in a potential of `20 x 50 x 2 x sizeof(int)` bytes being consumed.

Moved the fields needed for the cache to work (`re_pattern` and `re_flags`) into the `regex_t` data structure and changed the cache to an array of same.  Updated type references to switch where needed.  Type/struct changes only impacted `regex.cpp` and `regex.h`

Updated functions that used the `regexp` type to release memory after use.
Added destructor to `MCRegexMatcher` in `patternmatcher.cpp/h`

Wrapped some of the function calls in `regex.cpp` to one parameter per line to make them easier to read.