### PR TITLE
[[ Bug 19753 ]] Prevent TreeView chunk out of range error on Linux

### DIFF
--- a/extensions/widgets/treeview/notes/19753.md
+++ b/extensions/widgets/treeview/notes/19753.md
@@ -1,0 +1,1 @@
+# [19753] Prevent chunk out of range error on Linux when clicking selection

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -466,7 +466,7 @@ public handler OnCreate() returns nothing
 	put my width into mViewWidth	
 	
 	put 0 into mHoverRow
-    put "" into mHoverIcon
+	put "" into mHoverIcon
 	put 0 into mViewTopPosition
 	put true into mFrameBorder	
 	initialiseScrollbar()	
@@ -619,9 +619,9 @@ end handler
 private handler paintFirstRow(in pTop as Real)
 	// Apply any style to this data item
 	variable tStyle as String
-    put "" into tStyle
-    
-    variable tHover as Boolean
+	put "" into tStyle
+
+	variable tHover as Boolean
 	put mHoverRow is 1 into tHover
 		
 	variable tPath as Path	
@@ -848,6 +848,10 @@ public handler OnMouseScroll(in pDeltaX as Real, in pDeltaY as Real) returns not
 end handler
 
 public handler OnClick() returns nothing
+	if mHoverRow < 1 then
+		put yPosToRowNumber(the y of the mouse position) into mHoverRow
+	end if
+
 	// If the first row was clicked then add a new element
 	if mHoverRow is 1 then
 		addBaseLevelElement()


### PR DESCRIPTION
In the TreeView widget on Linux, the `mHoverRow` variable can get set to 0 and cause clicks to generate a "chunk out of range" error.  Added a check to the top of the `OnClick` handler to detect this condition and set the value if needed.  This solves an additional issue where if the widget is on a window that does not have focus, then the `mHoverRow` variable would not get set until the mouse moved after the click that brings the window forward.