### PR TITLE
[[ Bug 20142 ]] Prevent index errors when expanding TreeView buffer

### DIFF
--- a/extensions/widgets/treeview/notes/20142.md
+++ b/extensions/widgets/treeview/notes/20142.md
@@ -1,0 +1,1 @@
+# [20142] Prevent index errors when expanding TreeView buffer beyond 1000 keys 

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1272,12 +1272,13 @@ private handler setValueOnPath(in pPath as List, in pValue as any, inout xArray 
 end handler
 
 private handler getValueOnPath(in pPath as List, in pArray as Array) returns any
-	if the number of elements in pPath is 1 then
+	if pPath is the empty list then
+		return pArray
+	else if (element 1 of pPath) is not among the keys of pArray then
+		return the empty array
+	else if the number of elements in pPath is 1 then
 		return pArray[element 1 of pPath]
 	else
-		if (element 1 of pPath) is not among the keys of pArray then
-			return the empty array
-		end if
 		return getValueOnPath(element 2 to -1 of pPath, pArray[element 1 of pPath])
 	end if
 end handler
@@ -1348,7 +1349,11 @@ private handler addToListBuffer(in pAt as Integer, in pElement as Array, inout x
 	put pElement["more_data"] into tSorted
 	
 	variable tPath as List
-	put element 1 to -2 of pElement["path"] into tPath
+	if the number of elements in pElement["path"] is 1 then
+		put the empty list into tPath
+	else
+		put element 1 to -2 of pElement["path"] into tPath
+	end if
 	
 	variable tArray as Array
 	put getValueOnPath(tPath, mData) into tArray
@@ -1408,11 +1413,10 @@ private handler calculateMoreElements(in pLimit as Integer, in pLevel as Integer
 			else if pArray[tKey] is a number then
 				format pArray[tKey] as string into tString
 			else if pArray[tKey] is a data then
-                if not ConvertToString(pArray[tKey], tString) then
-                    put "Can't display value" into tString
-                end if
-            else
-
+				if not ConvertToString(pArray[tKey], tString) then
+					put "Can't display value" into tString
+				end if
+			else
 				put "Can't display value" into tString
 			end if	
 			put tString into tElement["string_value"]


### PR DESCRIPTION
The process to load additional data didn't properly account for level 0 `more_data` expansions beyond 1000 keys.

`addToListBuffer` trims one level off of a path, but did not account for the first level.  Added an `if` block to return an empty list if the path only contains a single item.

`getValueOnPath` did not account for an empty list (which needs to return the whole array) which happens when the base list contains more then 1000 items.  Also moved the key validation check to before the first use of the key.

Converted spaces to tabs in a section of `calculateMoreElements` and corrected indent levels.