### PR TITLE
[[ Bug 19754 ]] Enhance TreeView numeric sort to sort non-numbers

### DIFF
--- a/extensions/widgets/treeview/notes/19754.md
+++ b/extensions/widgets/treeview/notes/19754.md
@@ -1,0 +1,1 @@
+# [19754] Enhance TreeView numeric sort to sort non-numbers alphabetically

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -83,7 +83,7 @@ use com.livecode.library.widgetutils
 use com.livecode.foreign
 
 metadata author is "LiveCode"
-metadata version is "2.0.2"
+metadata version is "2.0.3"
 metadata title is "Tree View"
 metadata svgicon is "M152.4,249.7c-6.4,0-11.8,4.3-13.5,10.1h-10v-26.7h10c1.7,5.8,7.1,10.1,13.5,10.1c7.8,0,14.1-6.3,14.1-14.1s-6.3-14.1-14.1-14.1c-6.4,0-11.8,4.3-13.5,10.1h-10v-16.1c8.4-1.8,14.8-9.3,14.8-18.3c0-10.4-8.4-18.8-18.8-18.8s-18.8,8.4-18.8,18.8c0,9,6.3,16.5,14.7,18.3v58.8h18c1.7,5.8,7.1,10.1,13.5,10.1c7.8,0,14.1-6.3,14.1-14.1S160.2,249.7,152.4,249.7z M128.7,202h-7.5v-7.5h-7.5V187h7.5v-7.5h7.5v7.5h7.5v7.5h-7.5V202z"
 metadata _ide is "true"

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1289,8 +1289,8 @@ end handler
 
 -- Sorts numerically, converting strings to numbers where possible
 private handler CompareKeysNumeric(in pLeft as any, in pRight as any) returns Integer
-	variable tLeft as optional Number
-	variable tRight as optional Number
+	variable tLeft as optional any
+	variable tRight as optional any
 	
 	if pLeft is a number then
 		put pLeft into tLeft
@@ -1305,15 +1305,20 @@ private handler CompareKeysNumeric(in pLeft as any, in pRight as any) returns In
 	end if
 
 	if tRight is tLeft then
-		return 0
-	end if
+		-- Either both values are non-numbers or the numbers match but
+		-- hash as separate entries due to leading/trailing zeros
+		-- (e.g. 01.10).  In either case, sort the actual values.
+		put pLeft into tLeft
+		put pRight into tRight
+
+	else -- always group numbers ahead of non-numbers
+		if tRight is nothing then
+			return -1
+		end if
 		
-	if tRight is nothing then
-		return -1
-	end if
-	
-	if tLeft is nothing then
-		return 1
+		if tLeft is nothing then
+			return 1
+		end if
 	end if
 	
 	if tLeft < tRight then


### PR DESCRIPTION
Updated `CompareKeysNumeric` handler so that if both values are non-numbers, then it will sort them instead of returning 0.  Completely removed the 0 return value since keys may not be duplicates.  In the case of numbers that have the same numeric value, sort based on the text representation to have a consistent result (e.g. always have 02 come before 2).  In the case of a descending sort, all numbers remain grouped at the top of the list.