### PR TITLE
Xcode 9.3 fixes

### DIFF
--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -233,7 +233,7 @@ enum
 
 static OSErr preDispatchAppleEvent(const AppleEvent *p_event, AppleEvent *p_reply, SRefCon p_context)
 {
-    return [[NSApp delegate] preDispatchAppleEvent: p_event withReply: p_reply];
+    return [(com_runrev_livecode_MCApplicationDelegate*)[NSApp delegate] preDispatchAppleEvent: p_event withReply: p_reply];
 }
 
 - (OSErr)preDispatchAppleEvent: (const AppleEvent *)p_event withReply: (AppleEvent *)p_reply

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -1176,7 +1176,7 @@ void MCPlatformGetScreenPixelScale(uindex_t p_index, MCGFloat& r_scale)
 	NSScreen *t_screen;
 	t_screen = [[NSScreen screens] objectAtIndex: p_index];
 	if ([t_screen respondsToSelector: @selector(backingScaleFactor)])
-		r_scale = objc_msgSend_fpret_type<CGFloat>(t_screen, @selector(backingScaleFactor));
+		r_scale = static_cast<MCGFloat>([t_screen backingScaleFactor]);
 	else
 		r_scale = 1.0f;
 }

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -678,20 +678,4 @@ bool MCMacPlatformIsEventCheckingEnabled(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// The function pointer for objc_msgSend_fpret needs to be cast in order
-// to get the correct return type, otherwise we can get strange results
-// on x86_64 because "long double" return values are returned in
-// different registers to "float" or "double".
-extern "C" void objc_msgSend_fpret(void);
-template <class R, class... Types> R objc_msgSend_fpret_type(id p_id, SEL p_sel, Types... p_params)
-{
-    // Cast the obj_msgSend_fpret function to the correct type
-    R (*t_send)(id, SEL, ...) = reinterpret_cast<R (*)(id, SEL, ...)> (&objc_msgSend_fpret);
-    
-    // Perform the call
-    return t_send(p_id, p_sel, p_params...);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 #endif

--- a/engine/src/mac-surface.mm
+++ b/engine/src/mac-surface.mm
@@ -328,7 +328,7 @@ MCGFloat MCMacPlatformSurface::GetBackingScaleFactor(void)
 {
 	if ([m_window -> GetHandle() respondsToSelector: @selector(backingScaleFactor)])
     {
-        return objc_msgSend_fpret_type<CGFloat>(m_window -> GetHandle(), @selector(backingScaleFactor));
+        return static_cast<MCGFloat>([m_window -> GetHandle() backingScaleFactor]);
     }
 	return 1.0f;
 }


### PR DESCRIPTION
These patches resolve build errors when building with Xcode 9.3. An alternative to removing `objc_msgSend_fpret_type` entirely is to remove just the extern declaration and include `<objc/objc-runtime.h>` instead.