### PR TITLE
Ensure you can use Xcode9.2 if 10.12.6 <= MacOS version < 10.13

### DIFF
--- a/ide-support/revdeploylibraryios.livecodescript
+++ b/ide-support/revdeploylibraryios.livecodescript
@@ -42,7 +42,9 @@ function deployGetIphoneOSes
    else if tMacVersion < 101206 then
       put empty into tList[1]
       answer error "To use Xcode 9.2, you need to upgrade your Mac to MacOS Sierra 10.12.6"
-    else if tMacVersion < 101302 then
+   else if tMacVersion < 101300 then
+      put "11.2,9.2" into tList[1]
+   else if tMacVersion < 101302 then
       put empty into tList[1]
       answer error "To use Xcode 9.3, you need to upgrade your Mac to MacOS High Sierra 10.13.2"
    else


### PR DESCRIPTION
Xcode 9.3 requires MacOS 10.13.2+
Xcode 9.2 requires MacOS 10.12.6+

So make sure that in each OS version we use the most recent supported Xcode version