### PR TITLE
Send & Call With Args & Send & Call Widget

### DIFF
--- a/docs/dictionary/command/call.lcdoc
+++ b/docs/dictionary/command/call.lcdoc
@@ -2,7 +2,7 @@ Name: call
 
 Type: command
 
-Syntax: call <handlerName> [of <objectRef>] [ with <argumentList> ]
+Syntax: call [widget] <handlerName> [of <objectRef>] [ with <argumentList> ]
 
 Summary:
 <execute|Executes> the specified <handler> in any <object(glossary)|object's>
@@ -66,6 +66,10 @@ especially if some <parameter|parameters> contain
 <double quote|double quotes>, it may be simpler to put the <message> 
 name and <parameter|parameters> into a <variable>, then use the name of 
 the <variable> in the <call> <statement>.
+
+Use the call widget form of the command to call a public handler of a
+widget rather than a handler in the object script. Including parameters
+in the <handlerName> is not supported when using the call widget form.
 
 References: command (glossary), defaultStack (property), do (command), 
 double quote (glossary), execute (glossary), handler (glossary), 

--- a/docs/dictionary/command/call.lcdoc
+++ b/docs/dictionary/command/call.lcdoc
@@ -82,3 +82,6 @@ statement (glossary), trap (glossary), value (function),
 variable (glossary)
 
 Tags: messages
+
+Changes: 
+In LiveCode 9.5 the with argumentList and call widget syntax was added.

--- a/docs/dictionary/command/call.lcdoc
+++ b/docs/dictionary/command/call.lcdoc
@@ -2,7 +2,7 @@ Name: call
 
 Type: command
 
-Syntax: call <handlerName> [of <objectRef>]
+Syntax: call <handlerName> [of <objectRef>] [ with <argumentList> ]
 
 Summary:
 <execute|Executes> the specified <handler> in any <object(glossary)|object's>
@@ -20,15 +20,26 @@ call "mouseUp"
 Example:
 call "mouseUp" of button 1 of card 1
 
+Example:
+call "SaveFile" of button "save" with tFileName
+
 Parameters:
 handlerName:
-Any handler in the script of the specified object, along with
-any parameters that handler requires, separated by commas. The entire 
-handler including parameters must be enclosed in quotes.
+Any handler in the script of the specified object. Parameters that the handler
+requires may be included in the handlerName separated by commas or in the
+argumentList.
 
 objectRef:
 Any <object reference>. If no object is specified, LiveCode uses
 the current object.
+
+argumentList:
+A comma separated list of expressions containing the arguments to send.
+Arrays are expressions and are valid to send as arguments. 
+
+>**Note:** The argumentList is an alternative to including parameters
+> in the handlerName. If used then it is assumed no parameters are listed
+> in the handlerName.
 
 Description:
 Use the <call> <command> to use a <handler> that's not in the normal 

--- a/docs/dictionary/command/send.lcdoc
+++ b/docs/dictionary/command/send.lcdoc
@@ -2,7 +2,7 @@ Name: send
 
 Type: command
 
-Syntax: send [script] <message> [ to <object> [in <time> [{seconds | ticks | milliseconds}] ] ]
+Syntax: send <message> [ to <object> [in <time> [{seconds | ticks | milliseconds}] ] ] [ with <argumentList> ]
 
 Syntax: send script <message> [ to <object> ]
 
@@ -20,6 +20,9 @@ send "mouseDown" to button "next"
 
 Example:
 send "mouseDown" to button "text" of stack "project2"
+
+Example:
+send "SaveFile" to button "save" with tFileName
 
 Example:
 # A simple timer using send example
@@ -51,6 +54,14 @@ time, you must also specify an object.
 
 time (integer):
 If you don't specify a unit of time, the default of ticks is used.
+
+argumentList:
+A comma separated list of expressions containing the arguments to send.
+Arrays are expressions and are valid to send as arguments. 
+
+>**Note:** The argumentList is an alternative to including parameters
+> in the message. If used then it is assumed no parameters are listed
+> in the message.
 
 The result:
 If you specify a <time>, the <message> is sent to the <object(glossary)>

--- a/docs/dictionary/command/send.lcdoc
+++ b/docs/dictionary/command/send.lcdoc
@@ -2,7 +2,7 @@ Name: send
 
 Type: command
 
-Syntax: send <message> [ to <object> [in <time> [{seconds | ticks | milliseconds}] ] ] [ with <argumentList> ]
+Syntax: send [widget] <message> [ to <object> [in <time> [{seconds | ticks | milliseconds}] ] ] [ with <argumentList> ]
 
 Syntax: send script <message> [ to <object> ]
 
@@ -133,6 +133,10 @@ It is a parse error to specify a time when using the `script` form.
 > want to delay the <message> or when the <handler> you want to execute
 > is not in the <message path>.
 
+Use the send widget form of the command to send a public handler of a
+widget rather than a handler in the object script. Including parameters
+in the <handlerName> is not supported when using the send widget form.
+
 References: debugDo (command), dispatch (command), call (command),
 cancel (command), function (control structure), result (function),
 pendingMessages (function), object (glossary), literal string (glossary),
@@ -144,3 +148,6 @@ word (keyword), mouseUp (message), callbacks (property),
 backgroundBehavior (property)
 
 Tags: messages
+
+Changes: 
+In LiveCode 9.5 the with argumentList and send widget syntax was added.

--- a/docs/notes/feature-callwidget.md
+++ b/docs/notes/feature-callwidget.md
@@ -1,7 +1,13 @@
-# Call Widget
+# Call & Send Widget
 
-The call command can now be used to call a public widget handler directly.
-This is useful if a widget should perform an action rather than get or set
-a property value. To call a widget handler use the syntax:
+The call and send commands can now be used to execute a public widget handler
+directly. This is useful if a widget should perform an action rather than
+get or set a property value. 
+
+To call a widget handler use the syntax:
 
     call widget <handername> of <widget reference> with <argumentList>
+
+To send a widget handler use the syntax:
+
+    send widget <handername> to <widget reference> [in <time> [{seconds | ticks | milliseconds}] with <argumentList>

--- a/docs/notes/feature-callwidget.md
+++ b/docs/notes/feature-callwidget.md
@@ -1,0 +1,7 @@
+# Call Widget
+
+The call command can now be used to call a public widget handler directly.
+This is useful if a widget should perform an action rather than get or set
+a property value. To call a widget handler use the syntax:
+
+    call widget <handername> of <widget reference> with <argumentList>

--- a/docs/notes/feature-withargs.md
+++ b/docs/notes/feature-withargs.md
@@ -1,0 +1,12 @@
+# Send and call with parameters
+
+The `send` and `call` commands have been enhanced to use the `with parameterList`
+syntax similar to the `dispatch` command. If parameters are included in
+the parameter list then the message string is evaluated directly as a
+handler name. As a result an execution error will throw if parameters
+are specified in both the parameter list and the message string.
+
+The new syntax is in the following forms:
+
+    send <message> [ to <object> [in <time> [{seconds | ticks | milliseconds}] ] ] [ with param1 [... ,paramN]]
+    call <message> [ of <object> [ with param1 [... ,paramN]]

--- a/engine/src/aclip.cpp
+++ b/engine/src/aclip.cpp
@@ -176,7 +176,7 @@ bool MCAudioClip::visit_self(MCObjectVisitor* p_visitor)
     return p_visitor -> OnAudioClip(this);
 }
 
-void MCAudioClip::timer(MCNameRef mptr, MCParameter *params)
+void MCAudioClip::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
     // PM-2014-11-11: [[ Bug 13950 ]] Make sure looping audioClip can be stopped
 #ifndef FEATURE_PLATFORM_AUDIO

--- a/engine/src/aclip.h
+++ b/engine/src/aclip.h
@@ -88,7 +88,7 @@ public:
     
     virtual bool visit_self(MCObjectVisitor *p_visitor);
     
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget);
 
 	virtual Boolean del(bool p_check_flag);
 	virtual void paste(void);

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -1647,7 +1647,7 @@ Boolean MCButton::doubleup(uint2 which)
 }
 
 #ifdef _MAC_DESKTOP
-void MCButton::timer(MCNameRef mptr, MCParameter *params)
+void MCButton::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_internal))
 	{
@@ -1660,7 +1660,7 @@ void MCButton::timer(MCNameRef mptr, MCParameter *params)
 		}
 	}
 	else
-		MCControl::timer(mptr, params);
+		MCControl::timer(mptr, params, p_widget);
 }
 #endif
 

--- a/engine/src/button.h
+++ b/engine/src/button.h
@@ -197,7 +197,7 @@ public:
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
 #ifdef _MAC_DESKTOP
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget = false);
 #endif
 
 	virtual uint2 gettransient() const;

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1051,7 +1051,7 @@ Boolean MCCard::doubleup(uint2 which)
 	return True;
 }
 
-void MCCard::timer(MCNameRef mptr, MCParameter *params)
+void MCCard::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_idle))
 	{

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -89,7 +89,7 @@ public:
 	virtual Boolean mup(uint2 which, bool p_release);
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget);
 
 	virtual Boolean del(bool p_check_flag);
 	virtual void paste(void);

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1059,6 +1059,7 @@ class MCMessage : public MCStatement
 	Boolean reply;
 	Boolean send;
     Boolean script;
+    Boolean widget;
 public:
     MCMessage(Boolean p_send) :
         message(nullptr),
@@ -1069,8 +1070,9 @@ public:
         units(F_TICKS),
         program(False),
         reply(True),
-        script(False)
-	{
+        script(False),
+        widget(False)
+    {
         send = p_send;
     }
 	virtual Parse_stat parse(MCScriptPoint &);

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1053,7 +1053,8 @@ class MCMessage : public MCStatement
 	MCAutoPointer<MCExpression> eventtype;
 	MCAutoPointer<MCChunk> target;
 	MCAutoPointer<MCExpression> in;
-	Functions units;
+    MCParameter *params;
+    Functions units;
 	Boolean program;
 	Boolean reply;
 	Boolean send;
@@ -1064,6 +1065,7 @@ public:
         eventtype(nullptr),
         target(nullptr),
         in(nullptr),
+        params(nullptr),
         units(F_TICKS),
         program(False),
         reply(True),
@@ -1073,6 +1075,7 @@ public:
     }
 	virtual Parse_stat parse(MCScriptPoint &);
     virtual void exec_ctxt(MCExecContext &ctxt);
+    ~MCMessage(void);
 };
 
 class MCCall : public MCMessage

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -556,6 +556,10 @@ Parse_stat MCMessage::parse(MCScriptPoint &sp)
         }
         MCerrorlock--;
     }
+    else if (!send && sp.skip_token(SP_FACTOR, TT_CHUNK, CT_WIDGET) == PS_NORMAL)
+    {
+        widget = True;
+    }
 
     if (!script && sp.parseexp(False, True, &(&message)) != PS_NORMAL)
     {
@@ -663,6 +667,15 @@ void MCMessage::exec_ctxt(MCExecContext &ctxt)
 		else
 			t_target_ptr = nil;
         
+        if (widget)
+        {
+            if (t_target_ptr == nullptr || t_target_ptr->object->gettype() != CT_WIDGET)
+            {
+                ctxt.LegacyThrow(EE_SEND_BADTARGET);
+                return;
+            }
+        }
+        
         // Evaluate the parameter list
         bool t_success, t_can_debug;
         MCParameter *tptr = params;
@@ -713,7 +726,7 @@ void MCMessage::exec_ctxt(MCExecContext &ctxt)
             if (!script)
             {
                 if (!send)
-                    MCEngineExecCall(ctxt, *t_message, t_target_ptr, params);
+                    MCEngineExecCall(ctxt, *t_message, t_target_ptr, params, widget);
                 else
                     MCEngineExecSend(ctxt, *t_message, t_target_ptr, params);
             }

--- a/engine/src/cmdse.cpp
+++ b/engine/src/cmdse.cpp
@@ -556,7 +556,7 @@ Parse_stat MCMessage::parse(MCScriptPoint &sp)
         }
         MCerrorlock--;
     }
-    else if (!send && sp.skip_token(SP_FACTOR, TT_CHUNK, CT_WIDGET) == PS_NORMAL)
+    else if (sp.skip_token(SP_FACTOR, TT_CHUNK, CT_WIDGET) == PS_NORMAL)
     {
         widget = True;
     }
@@ -717,7 +717,7 @@ void MCMessage::exec_ctxt(MCExecContext &ctxt)
             if (!ctxt . EvalExprAsDouble(*in, EE_SEND_BADINEXP, t_delay))
                 return;
 
-            MCEngineExecSendInTime(ctxt, *t_message, t_target, t_delay, units, params);
+            MCEngineExecSendInTime(ctxt, *t_message, t_target, t_delay, units, params, widget);
 		}
         else
         {
@@ -728,7 +728,7 @@ void MCMessage::exec_ctxt(MCExecContext &ctxt)
                 if (!send)
                     MCEngineExecCall(ctxt, *t_message, t_target_ptr, params, widget);
                 else
-                    MCEngineExecSend(ctxt, *t_message, t_target_ptr, params);
+                    MCEngineExecSend(ctxt, *t_message, t_target_ptr, params, widget);
             }
             else
             {

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -377,7 +377,7 @@ Boolean MCControl::doubleup(uint2 which)
 	return True;
 }
 
-void MCControl::timer(MCNameRef mptr, MCParameter *params)
+void MCControl::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_idle))
 	{

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -2194,7 +2194,7 @@ void MCDispatch::remove_transient_stack(MCStack *sptr)
 	sptr->remove(m_transient_stacks);
 }
 
-void MCDispatch::timer(MCNameRef p_message, MCParameter *p_parameters)
+void MCDispatch::timer(MCNameRef p_message, MCParameter *p_parameters, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(p_message, MCM_internal))
 	{

--- a/engine/src/dispatch.h
+++ b/engine/src/dispatch.h
@@ -72,7 +72,7 @@ public:
     
     virtual bool visit_self(MCObjectVisitor *p_visitor);
 	
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget);
 	
 	// dummy cut function for checking licensing
 	virtual Boolean cut(Boolean home);

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1288,7 +1288,7 @@ static void MCEngineSendOrCall(MCExecContext& ctxt, MCStringRef p_script, MCObje
     
     if (p_widget)
     {
-        stat = MCInterfaceExecCallWidget(ctxt, *t_message, reinterpret_cast<MCWidget*>(optr), t_params);
+        stat = MCInterfaceExecCallWidget(ctxt, *t_message, reinterpret_cast<MCWidget*>(optr), t_params, p_is_send);
     }
     else
     {
@@ -1376,9 +1376,9 @@ cleanup:
 	MClockmessages = oldlock;
 }
 
-void MCEngineExecSend(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr *p_target, MCParameter *p_params)
+void MCEngineExecSend(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr *p_target, MCParameter *p_params, bool p_widget)
 {
-	MCEngineSendOrCall(ctxt, p_script, p_target, true, p_params, false);
+	MCEngineSendOrCall(ctxt, p_script, p_target, true, p_params, p_widget);
 }
 
 void MCEngineExecCall(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr *p_target, MCParameter *p_params, bool p_widget)
@@ -1412,11 +1412,11 @@ void MCEngineExecSendScript(MCExecContext& ctxt, MCStringRef p_script, MCObjectP
 	MClockmessages = oldlock;
 }
 
-void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr p_target, double p_delay, int p_units, MCParameter * p_params)
+void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef p_script, MCObjectPtr p_target, double p_delay, int p_units, MCParameter * p_params, bool p_widget)
 {
 	MCNewAutoNameRef t_message;
 	MCParameter *t_params = nullptr;
-    if (p_params == nullptr)
+    if (!p_widget && p_params == nullptr)
     {
         MCEngineSplitScriptIntoMessageAndParameters(ctxt, p_script, &t_message, t_params);
     }
@@ -1471,7 +1471,7 @@ void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef p_script, MCObjectP
     // AL-2014-07-22: [[ Bug 12846 ]] Copy bugfix to refactored code
     // MW-2014-05-28: [[ Bug 12463 ]] If we cannot add the pending message, then throw an
     //   error.
-	if (MCscreen->addusermessage(p_target . object, *t_message, MCS_time() + p_delay, t_params))
+	if (MCscreen->addusermessage(p_target . object, *t_message, MCS_time() + p_delay, t_params, p_widget))
         return;
     
     ctxt . LegacyThrow(EE_SEND_TOOMANYPENDING, *t_message);

--- a/engine/src/exec-interface-widget.cpp
+++ b/engine/src/exec-interface-widget.cpp
@@ -20,6 +20,7 @@
 #include "widget-ref.h"
 
 #include "exec.h"
+#include "param.h"
 
 #include "exec-interface.h"
 
@@ -52,3 +53,17 @@ void MCInterfaceExecDoInWidget(MCExecContext& ctxt, MCStringRef p_script, MCWidg
 	
 	MCWidgetPost(p_widget->getwidget(), MCNAME("OnDo"), *t_list);
 }
+
+Exec_stat MCInterfaceExecCallWidget(MCExecContext& ctxt, MCNameRef p_message, MCWidget *p_widget, MCParameter *p_parameters)
+{
+
+    if (p_widget->getwidget() == nullptr)
+    {
+        ctxt.LegacyThrow(EE_INVOKE_EXTENSIONNOTFOUND);
+        return ES_ERROR;
+    }
+
+    return MCWidgetCall(ctxt, p_widget->getwidget(), p_message, p_parameters);
+    
+}
+

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2776,6 +2776,7 @@ void MCInterfaceExecGoBackInWidget(MCExecContext& ctxt, MCWidget *p_widget);
 void MCInterfaceExecGoForwardInWidget(MCExecContext& ctxt, MCWidget *p_widget);
 void MCInterfaceExecLaunchUrlInWidget(MCExecContext& ctxt, MCStringRef p_url, MCWidget *p_widget);
 void MCInterfaceExecDoInWidget(MCExecContext& ctxt, MCStringRef p_script, MCWidget *p_widget);
+Exec_stat MCInterfaceExecCallWidget(MCExecContext& ctxt, MCNameRef p_handler, MCWidget *p_widget, MCParameter *p_params);
 
 ///////////
 
@@ -3053,7 +3054,7 @@ void MCEngineExecDispatch(MCExecContext& ctxt, int handler_type, MCNameRef messa
 void MCEngineExecSend(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params);
 void MCEngineExecSendScript(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
 void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef script, MCObjectPtr target, double p_delay, int p_units, MCParameter *params);
-void MCEngineExecCall(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params);
+void MCEngineExecCall(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params, bool p_widget);
 
 void MCEngineExecLockErrors(MCExecContext& ctxt);
 void MCEngineExecLockMessages(MCExecContext& ctxt);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3050,10 +3050,10 @@ void MCEngineExecStopUsingStack(MCExecContext& ctxt, MCStack *p_stack);
 void MCEngineExecStopUsingStackByName(MCExecContext& ctxt, MCStringRef p_name);
 
 void MCEngineExecDispatch(MCExecContext& ctxt, int handler_type, MCNameRef message, MCObjectPtr *target, MCParameter *params);
-void MCEngineExecSend(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
+void MCEngineExecSend(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params);
 void MCEngineExecSendScript(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
-void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef script, MCObjectPtr target, double p_delay, int p_units);
-void MCEngineExecCall(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
+void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef script, MCObjectPtr target, double p_delay, int p_units, MCParameter *params);
+void MCEngineExecCall(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params);
 
 void MCEngineExecLockErrors(MCExecContext& ctxt);
 void MCEngineExecLockMessages(MCExecContext& ctxt);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2776,7 +2776,7 @@ void MCInterfaceExecGoBackInWidget(MCExecContext& ctxt, MCWidget *p_widget);
 void MCInterfaceExecGoForwardInWidget(MCExecContext& ctxt, MCWidget *p_widget);
 void MCInterfaceExecLaunchUrlInWidget(MCExecContext& ctxt, MCStringRef p_url, MCWidget *p_widget);
 void MCInterfaceExecDoInWidget(MCExecContext& ctxt, MCStringRef p_script, MCWidget *p_widget);
-Exec_stat MCInterfaceExecCallWidget(MCExecContext& ctxt, MCNameRef p_handler, MCWidget *p_widget, MCParameter *p_params);
+Exec_stat MCInterfaceExecCallWidget(MCExecContext& ctxt, MCNameRef p_handler, MCWidget *p_widget, MCParameter *p_params, bool p_is_send);
 
 ///////////
 
@@ -3051,9 +3051,9 @@ void MCEngineExecStopUsingStack(MCExecContext& ctxt, MCStack *p_stack);
 void MCEngineExecStopUsingStackByName(MCExecContext& ctxt, MCStringRef p_name);
 
 void MCEngineExecDispatch(MCExecContext& ctxt, int handler_type, MCNameRef message, MCObjectPtr *target, MCParameter *params);
-void MCEngineExecSend(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params);
+void MCEngineExecSend(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params, bool p_widget);
 void MCEngineExecSendScript(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target);
-void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef script, MCObjectPtr target, double p_delay, int p_units, MCParameter *params);
+void MCEngineExecSendInTime(MCExecContext& ctxt, MCStringRef script, MCObjectPtr target, double p_delay, int p_units, MCParameter *params, bool p_widget);
 void MCEngineExecCall(MCExecContext& ctxt, MCStringRef script, MCObjectPtr *target, MCParameter *p_params, bool p_widget);
 
 void MCEngineExecLockErrors(MCExecContext& ctxt);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2778,7 +2778,13 @@ enum Exec_errors
     EE_BAD_PERMISSION_NAME,
     
     // {EE-0910} Property: value is not a data
-    EE_PROPERTY_NOTADATA
+    EE_PROPERTY_NOTADATA,
+    
+    // {EE-0911} call: handler not found
+    EE_INVOKE_HANDLERNOTFOUND,
+    
+    // {EE-0912} call: extension not found
+    EE_INVOKE_EXTENSIONNOTFOUND,
     
 };
 

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -1353,7 +1353,7 @@ Boolean MCField::doubleup(uint2 which)
 	return MCControl::doubleup(which);
 }
 
-void MCField::timer(MCNameRef mptr, MCParameter *params)
+void MCField::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_internal))
 	{
@@ -1390,7 +1390,7 @@ void MCField::timer(MCNameRef mptr, MCParameter *params)
 			}
 		}
 		else
-			MCControl::timer(mptr, params);
+			MCControl::timer(mptr, params, p_widget);
 }
 
 void MCField::select()

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -306,7 +306,7 @@ public:
 	virtual Boolean mup(uint2 which, bool p_release);
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget);
 	virtual void select();
 	virtual uint2 gettransient() const;
 	virtual void applyrect(const MCRectangle &nrect);

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -529,7 +529,7 @@ Boolean MCImage::doubleup(uint2 which)
 	return MCControl::doubleup(which);
 }
 
-void MCImage::timer(MCNameRef mptr, MCParameter *params)
+void MCImage::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_internal))
 	{
@@ -608,7 +608,7 @@ void MCImage::timer(MCNameRef mptr, MCParameter *params)
 			}
 		}
 		else
-			MCControl::timer(mptr, params);
+			MCControl::timer(mptr, params, p_widget);
 }
 
 void MCImage::applyrect(const MCRectangle &nrect)

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -422,7 +422,7 @@ public:
 	virtual Boolean mup(uint2 which, bool p_release);
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget);
 	virtual void applyrect(const MCRectangle &nrect);
 
 	virtual void select();

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -114,7 +114,7 @@ public:
 	virtual void munfocus();
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget);
 	virtual uint2 gettransient() const;
 
 	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -780,7 +780,7 @@ Boolean MCObject::doubleup(uint2 which)
 	return False;
 }
 
-void MCObject::timer(MCNameRef mptr, MCParameter *params)
+void MCObject::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_idle))
 	{

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -674,7 +674,7 @@ public:
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
 	
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget = false);
 	virtual uint2 gettransient() const;
 	virtual void applyrect(const MCRectangle &nrect);
 	void setrect(const MCRectangle &p_rect);

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1798,6 +1798,10 @@ enum Parse_errors
     
     // {PE-0584} out of memory
     PE_OUTOFMEMORY,
+    
+    // {PE-0585} send: bad parameters
+    PE_SEND_BADPARAMS,
+    
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/player-legacy.cpp
+++ b/engine/src/player-legacy.cpp
@@ -310,7 +310,7 @@ void MCPlayer::applyrect(const MCRectangle &nrect)
 #endif
 }
 
-void MCPlayer::timer(MCNameRef mptr, MCParameter *params)
+void MCPlayer::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
     if (MCNameIsEqualToCaseless(mptr, MCM_play_stopped))
     {
@@ -336,7 +336,7 @@ void MCPlayer::timer(MCNameRef mptr, MCParameter *params)
         }
     }
     
-	MCControl::timer(mptr, params);
+	MCControl::timer(mptr, params, p_widget);
 }
 
 // MW-2011-09-23: Make sure we sync the buffer state at this point, rather than

--- a/engine/src/player-legacy.h
+++ b/engine/src/player-legacy.h
@@ -122,7 +122,7 @@ public:
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
 	virtual void applyrect(const MCRectangle &nrect);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget = false);
     
 	// MW-2011-09-23: [[ Bug ]] Implement buffer / unbuffer at the point of
 	//   selection to stop redraw issues.

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1085,7 +1085,7 @@ MCRectangle MCPlayer::GetNativeViewRect(const MCRectangle &p_object_rect)
 	return getvideorect(p_object_rect);
 }
 
-void MCPlayer::timer(MCNameRef mptr, MCParameter *params)
+void MCPlayer::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
     if (MCNameIsEqualToCaseless(mptr, MCM_play_started))
     {
@@ -1128,7 +1128,7 @@ void MCPlayer::timer(MCNameRef mptr, MCParameter *params)
         handle_mstilldown(Button1);
         MCscreen -> addtimer(this, MCM_internal, MCblinkrate);
     }
-    MCControl::timer(mptr, params);
+    MCControl::timer(mptr, params, p_widget);
 }
 
 void MCPlayer::toolchanged(Tool p_new_tool)

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -117,7 +117,7 @@ public:
 	virtual Boolean mup(uint2 which, bool p_release);
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget = false);
 
 	// IM-2016-06-01: [[ Bug 17700 ]] Override toolchanged to pause player when editing
     virtual void toolchanged(Tool p_new_tool);

--- a/engine/src/player-srv-stubs.cpp
+++ b/engine/src/player-srv-stubs.cpp
@@ -254,7 +254,7 @@ void MCPlayer::applyrect(const MCRectangle &nrect)
 {
 }
 
-void MCPlayer::timer(MCNameRef mptr, MCParameter *params)
+void MCPlayer::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
     if (MCNameIsEqualToCaseless(mptr, MCM_play_stopped))
     {
@@ -279,7 +279,7 @@ void MCPlayer::timer(MCNameRef mptr, MCParameter *params)
             layer_redrawall();
         }
     }
-	MCControl::timer(mptr, params);
+	MCControl::timer(mptr, params, p_widget);
 }
 
 // MW-2011-09-23: Make sure we sync the buffer state at this point, rather than

--- a/engine/src/scrolbar.cpp
+++ b/engine/src/scrolbar.cpp
@@ -605,7 +605,7 @@ void MCScrollbar::applyrect(const MCRectangle &nrect)
 }
 
 
-void MCScrollbar::timer(MCNameRef mptr, MCParameter *params)
+void MCScrollbar::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_internal) ||
 		MCNameIsEqualToCaseless(mptr, MCM_internal2))
@@ -699,7 +699,7 @@ void MCScrollbar::timer(MCNameRef mptr, MCParameter *params)
 #endif
 	}
 	else
-		MCControl::timer(mptr, params);
+		MCControl::timer(mptr, params, p_widget);
 }
 
 MCControl *MCScrollbar::clone(Boolean attach, Object_pos p, bool invisible)

--- a/engine/src/scrolbar.h
+++ b/engine/src/scrolbar.h
@@ -96,7 +96,7 @@ public:
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
 	virtual void applyrect(const MCRectangle &nrect);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget = false);
 
 	// MW-2011-09-06: [[ Redraw ]] Added 'sprite' option - if true, ink and opacity are not set.
 	virtual void draw(MCDC *dc, const MCRectangle &dirty, bool p_isolated, bool p_sprite);

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1199,7 +1199,7 @@ Boolean MCStack::doubleup(uint2 which)
 	return curcard->doubleup(which);
 }
 
-void MCStack::timer(MCNameRef mptr, MCParameter *params)
+void MCStack::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 	if (MCNameIsEqualToCaseless(mptr, MCM_internal))
 	{

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -353,7 +353,7 @@ public:
 	virtual Boolean mup(uint2 which, bool p_release);
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget = false);
 	virtual void applyrect(const MCRectangle &nrect);
 
     virtual void removereferences(void);

--- a/engine/src/tooltip.cpp
+++ b/engine/src/tooltip.cpp
@@ -58,7 +58,7 @@ void MCTooltip::close(void)
 	MCStack::close();
 }
 
-void MCTooltip::timer(MCNameRef mptr, MCParameter *params)
+void MCTooltip::timer(MCNameRef mptr, MCParameter *params, bool p_widget)
 {
 #ifndef _MOBILE
 	if (MCNameIsEqualToCaseless(mptr, MCM_internal))

--- a/engine/src/tooltip.h
+++ b/engine/src/tooltip.h
@@ -45,7 +45,7 @@ public:
 	MCTooltip();
 	virtual ~MCTooltip();
 	virtual void close(void);
-	virtual void timer(MCNameRef mptr, MCParameter *params);
+	virtual void timer(MCNameRef mptr, MCParameter *params, bool p_widget = false);
 	virtual void render(MCContext *target, const MCRectangle& dirty);
 
 	void mousemove(int2 x, int2 y, MCCard *c);

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -116,18 +116,20 @@ public:
     real64_t            m_time = 0;
     MCParameter*        m_params = nullptr;
     uint32_t            m_id = 0;
+    bool                m_widget = false;
 
     constexpr MCPendingMessage() = default;
 
     MCPendingMessage(const MCPendingMessage& other) = default;
 
     // [[ C++11 ]] Replace with `MCPendingMessage(MCObject*, MCNameRef, real64_t, MCParameter*, uint32_t) = default;`
-    MCPendingMessage(MCObject* p_object, MCNameRef p_message, real64_t p_time, MCParameter* p_params, uint32_t p_id) :
+    MCPendingMessage(MCObject* p_object, MCNameRef p_message, real64_t p_time, MCParameter* p_params, uint32_t p_id, bool p_widget) :
       m_object(p_object),
       m_message(p_message),
       m_time(p_time),
       m_params(p_params),
-      m_id(p_id)
+      m_id(p_id),
+      m_widget(p_widget)
     {
     }
 
@@ -138,6 +140,7 @@ public:
         m_time = other.m_time;
         m_params = other.m_params;
         m_id = other.m_id;
+        m_widget = other.m_widget;
         
         return *this;
     }
@@ -540,7 +543,7 @@ public:
 	virtual uint2 querymods();
 	virtual Boolean getmouse(uint2 button, Boolean& r_abort);
     virtual Boolean getmouseclick(uint2 button, Boolean& r_abort);
-    virtual void addmessage(MCObject *optr, MCNameRef name, real8 time, MCParameter *params);
+    virtual void addmessage(MCObject *optr, MCNameRef name, real8 time, MCParameter *params, bool p_widget = false);
     virtual void delaymessage(MCObject *optr, MCNameRef name, MCStringRef p1 = nil, MCStringRef p2 = nil);
 	
     // When called, all modal loops should be exited and control should return
@@ -662,7 +665,7 @@ public:
 	void cancelmessageid(uint4 id);
 	void cancelmessageobject(MCObject *optr, MCNameRef name, MCValueRef param = nil);
     bool listmessages(MCExecContext& ctxt, MCListRef& r_list);
-    void doaddmessage(MCObject *optr, MCNameRef name, real8 time, uint4 id, MCParameter *params = nil);
+    void doaddmessage(MCObject *optr, MCNameRef name, real8 time, uint4 id, MCParameter *params = nil, bool p_widget = false);
     size_t doshiftmessage(size_t index, real8 newtime);
     
     void addsubtimer(MCObject *target, MCValueRef subtarget, MCNameRef name, uint4 delay);
@@ -670,7 +673,7 @@ public:
 
     // MW-2014-05-28: [[ Bug 12463 ]] This is used by 'send in time' - separating user sent messages from
     //   engine sent messages. The former are subject to a limit to stop pending message queue overflow.
-    bool addusermessage(MCObject *optr, MCNameRef name, real8 time, MCParameter *params);
+    bool addusermessage(MCObject *optr, MCNameRef name, real8 time, MCParameter *params, bool p_widget);
     
     // Returns true if there are any pending messages to dispatch right now.
     bool hasmessagestodispatch(void);

--- a/engine/src/widget-ref.h
+++ b/engine/src/widget-ref.h
@@ -91,6 +91,7 @@ public:
     bool SetAnnotation(MCNameRef annotation, MCValueRef value);
     
     bool Post(MCNameRef event, MCProperListRef args);
+    Exec_stat Call(MCExecContext& ctxt, MCNameRef p_message, MCParameter* p_params);
     
     void ScheduleTimerIn(double timeout);
     void CancelTimer(void);

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -336,8 +336,20 @@ MCObject* MCWidget::hittest(int32_t x, int32_t y)
     return nil;
 }
 
-void MCWidget::timer(MCNameRef p_message, MCParameter *p_parameters)
+void MCWidget::timer(MCNameRef p_message, MCParameter *p_parameters, bool p_widget)
 {
+    if (p_widget)
+    {
+        if (m_widget != nil)
+        {
+            MCExecContext ctxt(this, nil, nil);
+            Exec_stat stat = MCInterfaceExecCallWidget(ctxt, p_message, this, p_parameters, true);
+            if (stat == ES_ERROR)
+            {
+                senderror();
+            }
+        }
+    }
     if (p_message == MCM_internal)
     {
         if (m_widget != nil)
@@ -345,7 +357,7 @@ void MCWidget::timer(MCNameRef p_message, MCParameter *p_parameters)
     }
     else
     {
-        MCControl::timer(p_message, p_parameters);
+        MCControl::timer(p_message, p_parameters, p_widget);
     }
 }
 

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -100,6 +100,7 @@ bool MCWidgetCopyAnnotation(MCWidgetRef widget, MCNameRef annotation, MCValueRef
 bool MCWidgetSetAnnotation(MCWidgetRef widget, MCNameRef annotation, MCValueRef value);
 
 bool MCWidgetPost(MCWidgetRef widget, MCNameRef event, MCProperListRef args);
+Exec_stat MCWidgetCall(MCExecContext& ctxt, MCWidgetRef self, MCNameRef p_message, MCParameter* p_parameters);
 
 void MCWidgetRedrawAll(MCWidgetRef widget);
 void MCWidgetScheduleTimerIn(MCWidgetRef widget, double timeout);

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -167,7 +167,7 @@ public:
 	
     virtual MCObject* hittest(int32_t x, int32_t y);
     
-	virtual void timer(MCNameRef p_message, MCParameter *p_parameters);
+	virtual void timer(MCNameRef p_message, MCParameter *p_parameters, bool p_widget = false);
 
 	virtual void recompute(void);
     

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -681,14 +681,14 @@ on revDocsExtractDocBlocks pText, pSource, @rAPIData, @rLibraryData
                   break
                case "handler"
                   revDocsParseHandler line 1 of tData, tHandlerData
-                  revDocsUpdateDocBlocks true, "handler", line 1 of tData, tComment, tAPIData
+                  revDocsUpdateDocBlocks true, tIsWidget, "handler", line 1 of tData, tComment, tAPIData
                   break
                case "function"
                case "command"
                   if tIsLCIDL then
                      revDocsUpdateDocBlocksForLCIDL  tEntryData["name"], tEntryData["type"], tData, tComment, tAPIData
                   else
-                     revDocsUpdateDocBlocks false, tEntryData["type"], line 1 of tData, tComment, tAPIData
+                     revDocsUpdateDocBlocks false, tIsWidget, tEntryData["type"], line 1 of tData, tComment, tAPIData
                   end if
                   break
                case "type"
@@ -1757,7 +1757,7 @@ command revDocsUpdateModularSyntaxDocBlocks pData, pComment, pHandlersA, pPhrase
    put tEntryName into xDataA[tEntryName]["name"]
 end revDocsUpdateModularSyntaxDocBlocks
 
-command revDocsUpdateDocBlocks pModular, pType, pLine, pComment, @xDataA
+command revDocsUpdateDocBlocks pModular, pIsWidget, pType, pLine, pComment, @xDataA
    if pComment is empty then
       exit revDocsUpdateDocBlocks
    end if
@@ -1802,9 +1802,13 @@ command revDocsUpdateDocBlocks pModular, pType, pLine, pComment, @xDataA
    end repeat
    delete the last char of tParamsSyntax
    if pType is "function" or pType is "handler" then
-      put "(" before tParamsSyntax
-      put ")" after tParamsSyntax
-      put tEntryName & tParamsSyntax into tSyntax
+      if pIsWidget then
+         put "call widget" && quote & tEntryName & quote && "of <widget> with" && tParamsSyntax into tSyntax
+      else
+         put "(" before tParamsSyntax
+         put ")" after tParamsSyntax
+         put tEntryName & tParamsSyntax into tSyntax
+      end if
    else
       put tEntryName && tParamsSyntax into tSyntax
    end if

--- a/tests/lcs/core/engine/_widget_call.lcb
+++ b/tests/lcs/core/engine/_widget_call.lcb
@@ -1,4 +1,6 @@
-library com.livecode.lcs_tests.core.widget_call
+widget com.livecode.lcs_tests.core.widget_call
+
+use com.livecode.engine
 
 public handler TestWidget_Foo() returns String
 	return "Bar"
@@ -12,4 +14,13 @@ public handler TestWidget_FooOutArg(out rArg as String) returns nothing
 	put "Bar" into rArg
 end handler
 
-end library
+public handler TestWidget_DefaultStack() returns String
+	execute script "return the defaultStack"
+	return the result
+end handler
+
+public handler TestWidget_SetProp(in pProp as String, in pValue as String) returns nothing
+	set property pProp of my script object to pValue
+end handler
+
+end widget

--- a/tests/lcs/core/engine/_widget_call.lcb
+++ b/tests/lcs/core/engine/_widget_call.lcb
@@ -1,0 +1,15 @@
+library com.livecode.lcs_tests.core.widget_call
+
+public handler TestWidget_Foo() returns String
+	return "Bar"
+end handler
+
+public handler TestWidget_FooArg(in pArg as String) returns String
+	return "Bar" & pArg
+end handler
+
+public handler TestWidget_FooOutArg(out rArg as String) returns nothing
+	put "Bar" into rArg
+end handler
+
+end library

--- a/tests/lcs/core/engine/call.livecodescript
+++ b/tests/lcs/core/engine/call.livecodescript
@@ -1,0 +1,74 @@
+﻿script "CoreEngineCall"
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestCallWithArgs
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar pValue; set the cVar of me to pValue; end setVar"
+	
+	local tVar
+	put uuid() into tVar
+	call "setVar" of tStack with tVar
+	TestAssert "call with args", \
+		the cVar of tStack is tVar
+end TestCallWithArgs
+
+on TestCallWithArgsInMessage
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar pValue; set the cVar of me to pValue; end setVar"
+	
+	local tVar
+	put uuid() into tVar
+	call "setVar tVar" of tStack
+	TestAssert "call with args in message", \
+		the cVar of tStack is tVar
+end TestCallWithArgsInMessage
+
+on _TestCallWithArgsInMessageAndExplicit
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar pValue; set the cVar of me to pValue; end setVar"
+	
+	local tVar
+	put uuid() into tVar
+	call "setVar tVar" of tStack with tVar
+end _TestCallWithArgsInMessageAndExplicit
+
+on TestCallWithArgsInMessageAndExplicit
+	TestAssertThrow "call with args in message and explicit throws", \
+		"_TestCallWithArgsInMessageAndExplicit", the long id of me, \
+		"EE_HANDLER_BADSTATEMENT"
+end TestCallWithArgsInMessageAndExplicit
+
+on TestCallWithArgsByReference
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar @xValue; put uuid() into xValue; end setVar"
+	
+	local tVar, tCheckVar
+	put uuid() into tVar
+	put tVar into tCheckVar
+	call "setVar" of tStack with tVar
+	TestAssert "call with args by reference", \
+		tVar is not tCheckVar
+end TestCallWithArgsByReference

--- a/tests/lcs/core/engine/call.livecodescript
+++ b/tests/lcs/core/engine/call.livecodescript
@@ -72,3 +72,42 @@ on TestCallWithArgsByReference
 	TestAssert "call with args by reference", \
 		tVar is not tCheckVar
 end TestCallWithArgsByReference
+
+on TestCallWidget
+	TestSkipIfNot "lcb"
+   TestLoadAuxiliaryExtension "_widget_call"
+   
+	create stack "WidgetCall"
+   set the defaultStack to "WidgetCall"
+
+   create widget "Test" as "com.livecode.lcs_tests.core.widget_call"
+   
+	call widget "TestWidget_Foo" of widget "Test"
+	TestAssert "call widget", the result is "Bar"
+		
+	call widget "TestWidget_FooArg" of widget "Test" with "Baz"
+	TestAssert "call widget with args", the result is "BarBaz"
+	
+	local tArg
+	put "Baz" into tArg
+	call widget "TestWidget_FooOutArg" of widget "Test" with tArg
+	TestAssert "call widget with out arg", tArg is "Bar"
+	
+	TestAssertThrow "call widget with non-existant handler", \
+		"_TestCallWithNonExistantHandler", the long id of me, \
+		"EE_INVOKE_HANDLERNOTFOUND"
+		
+	create widget "Test2" as "com.livecode.lcs_tests.core.widget_call_non_existant"
+	
+	TestAssertThrow "call widget with extension not loaded", \
+		"_TestCallWithNonExistantExtension", the long id of me, \
+		"EE_INVOKE_EXTENSIONNOTFOUND"
+end TestCallWidget
+
+on _TestCallWithNonExistantHandler
+	call widget "TestWidget_DoesNotExist" of widget "Test" of stack "WidgetCall"
+end _TestCallWithNonExistantHandler
+
+on _TestCallWithNonExistantExtension
+	call widget "TestWidget_DoesNotExist" of widget "Test2" of stack "WidgetCall"
+end _TestCallWithNonExistantExtension

--- a/tests/lcs/core/engine/call.livecodescript
+++ b/tests/lcs/core/engine/call.livecodescript
@@ -102,6 +102,10 @@ on TestCallWidget
 	TestAssertThrow "call widget with extension not loaded", \
 		"_TestCallWithNonExistantExtension", the long id of me, \
 		"EE_INVOKE_EXTENSIONNOTFOUND"
+		
+	set the defaultStack to the short name of me
+	call widget "TestWidget_DefaultStack" of widget "Test" of stack "WidgetCall"
+	TestAssert "call widget does not change defaultstack", the result is the defaultStack	
 end TestCallWidget
 
 on _TestCallWithNonExistantHandler

--- a/tests/lcs/core/engine/send.livecodescript
+++ b/tests/lcs/core/engine/send.livecodescript
@@ -85,7 +85,7 @@ on __SendError
 end __SendError
 
 on TestSendError
-	TestAssertThrow "send throws correct error", __SendError, \ 
+	TestAssertThrow "send throws correct error", "__SendError", \ 
 		the long id of me, "EE_CHUNK_NOSTACK"
 end TestSendError
 
@@ -130,3 +130,63 @@ on TestSendScriptEvaluation
 	TestAssert "send param evaluated in current context", \
 		the cVar of tStack is "Something"
 end TestSendScriptEvaluation
+
+on TestSendWithArgs
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar pValue; set the cVar of me to pValue; end setVar"
+	
+	local tVar
+	put uuid() into tVar
+	send "setVar" to tStack with tVar
+	TestAssert "send with args", \
+		the cVar of tStack is tVar
+end TestSendWithArgs
+
+on TestSendInTimeWithArgs
+	TestSkipIfNot "wait"
+	
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar pValue; set the cVar of me to pValue; end setVar"
+	
+	local tVar
+	put uuid() into tVar
+	send "setVar" to tStack in 0 with tVar
+	wait 50 milliseconds with messages
+	TestAssert "send in time with args", \
+		the cVar of tStack is tVar
+end TestSendInTimeWithArgs
+
+on _TestSendWithArgsInMessageAndExplicit
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar pValue; set the cVar of me to pValue; end setVar"
+	
+	local tVar
+	put uuid() into tVar
+	send "setVar tVar" to tStack with tVar
+end _TestSendWithArgsInMessageAndExplicit
+
+on TestSendWithArgsInMessageAndExplicit
+	TestAssertThrow "send with args in message and explicit throws", \
+		"_TestSendWithArgsInMessageAndExplicit", the long id of me, \
+		"EE_HANDLER_BADSTATEMENT"
+end TestSendWithArgsInMessageAndExplicit
+
+on TestSendWithArgsByReference
+	local tStack
+	create stack 
+	put it into tStack
+	set the script of tStack to "on setVar @xValue; put uuid() into xValue; end setVar"
+	
+	local tVar, tCheckVar
+	put uuid() into tVar
+	put tVar into tCheckVar
+	send "setVar" to tStack with tVar
+	TestAssert "send with args by reference", \
+			tVar is not tCheckVar
+end TestSendWithArgsByReference

--- a/tests/lcs/core/engine/send.livecodescript
+++ b/tests/lcs/core/engine/send.livecodescript
@@ -155,7 +155,7 @@ on TestSendInTimeWithArgs
 	local tVar
 	put uuid() into tVar
 	send "setVar" to tStack in 0 with tVar
-	wait 50 milliseconds with messages
+	wait 0 milliseconds with messages
 	TestAssert "send in time with args", \
 		the cVar of tStack is tVar
 end TestSendInTimeWithArgs
@@ -190,3 +190,69 @@ on TestSendWithArgsByReference
 	TestAssert "send with args by reference", \
 			tVar is not tCheckVar
 end TestSendWithArgsByReference
+
+on TestSendWidget
+	TestSkipIfNot "lcb"
+   TestLoadAuxiliaryExtension "_widget_call"
+   
+	create stack "WidgetCall"
+   set the defaultStack to "WidgetCall"
+
+   create widget "Test" as "com.livecode.lcs_tests.core.widget_call"
+   
+	send widget "TestWidget_Foo" to widget "Test"
+	TestAssert "send widget", the result is "Bar"
+		
+	send widget "TestWidget_FooArg" to widget "Test" with "Baz"
+	TestAssert "send widget with args", the result is "BarBaz"
+	
+	local tArg
+	put "Baz" into tArg
+	send widget "TestWidget_FooOutArg" to widget "Test" with tArg
+	TestAssert "send widget with out arg", tArg is "Bar"
+	
+	TestAssertThrow "send widget with non-existant handler", \
+		"_TestSendWithNonExistantHandler", the long id of me, \
+		"EE_INVOKE_HANDLERNOTFOUND"
+		
+	create widget "Test2" as "com.livecode.lcs_tests.core.widget_call_non_existant"
+	
+	TestAssertThrow "send widget with extension not loaded", \
+		"_TestSendWithNonExistantExtension", the long id of me, \
+		"EE_INVOKE_EXTENSIONNOTFOUND"
+		
+	set the defaultStack to the short name of me
+	send widget "TestWidget_DefaultStack" to widget "Test" of stack "WidgetCall"
+	TestAssert "send widget changes defaultstack", the result is the name of stack "WidgetCall"
+end TestSendWidget
+
+on _TestSendWithNonExistantHandler
+	send widget "TestWidget_DoesNotExist" to widget "Test" of stack "WidgetCall"
+end _TestSendWithNonExistantHandler
+
+on _TestSendWithNonExistantExtension
+	send widget "TestWidget_DoesNotExist" to widget "Test2" of stack "WidgetCall"
+end _TestSendWithNonExistantExtension
+
+on TestSendWidgetInTimeWithArgs
+	TestSkipIfNot "wait"
+	TestSkipIfNot "lcb"
+   TestLoadAuxiliaryExtension "_widget_call"
+   
+	create stack "WidgetCall"
+   set the defaultStack to "WidgetCall"
+
+   create widget "Test" as "com.livecode.lcs_tests.core.widget_call"
+   
+	local tVar
+	put uuid() into tVar
+	send widget "TestWidget_SetProp" to widget "Test" with "uUUID", tVar
+	TestAssert "send widget in time with args", \
+			the uUUID of widget "Test" is tVar
+	
+	put uuid() into tVar
+	send widget "TestWidget_SetProp" to widget "Test" in 0 with "uUUID", tVar
+	wait 50 milliseconds with messages
+	TestAssert "send widget in time with args", \
+			the uUUID of widget "Test" is tVar
+end TestSendWidgetInTimeWithArgs

--- a/tests/lcs/docs/docsparser.livecodescript
+++ b/tests/lcs/docs/docsparser.livecodescript
@@ -68,3 +68,22 @@ on TestBug17523
    
    TestAssert "property name has quotes stripped", tArray["doc"][1]["display name"] is "testProp"
 end TestBug17523
+
+on TestPublicWidgetHandlerSyntax
+   local tModule
+   put "widget com.livecode.testdocs" into tModule
+   put return & "/**" after tModule
+   put return & "Summary: Test" after tModule
+   put return & "*/" after tModule
+   put return & "public handler Foo(in pBar as String) returns nothing" after tModule
+   put return & "end handler" after tModule
+   put return & "end widget" after tModule
+   
+   local tParsed
+   put revDocsGenerateDocsFileFromText(tModule, "") into tParsed
+   
+   local tArray
+   put revDocsParseDocTextToLibraryArray("", tParsed, "", "") into tArray
+   
+   TestAssert "public widget handler syntax uses call", tArray["doc"][1]["syntax"][1] begins with "call widget"
+end TestPublicWidgetHandlerSyntax


### PR DESCRIPTION
The first patch implements an optional `with argumentList` syntax for send
and call commands as an alternative to specifying parameters within
the message string.

The second patch builds on the first by implementing `call widget` to allow calling a widget public handler.

The third patch implements `send widget` doing the correct defaultStack fiddling during execution and also allowing for send in time.
