### PR TITLE
[[ Bug 21203 ]] Only post hiliteChanged when value actually changes

### DIFF
--- a/extensions/widgets/switchbutton/notes/21203.md
+++ b/extensions/widgets/switchbutton/notes/21203.md
@@ -1,0 +1,1 @@
+# [21203] Only post hiliteChanged when value actually changes

--- a/extensions/widgets/switchbutton/switchbutton.lcb
+++ b/extensions/widgets/switchbutton/switchbutton.lcb
@@ -501,16 +501,23 @@ public handler OnMouseUp() returns nothing
 		return
 	end if
 
+	variable tPostMessage as Boolean
 	if mMouseHasMoved then
+		put mSwitchIsInOnPosition is not mSwitchIsOn into tPostMessage
 		setSwitch(mSwitchIsInOnPosition)
 		put false into mMouseHasMoved
 	else
 		if the click position is within mClickableRect then
+			put true into tPostMessage
 			setSwitch(not(mSwitchIsOn))
+		else
+			put false into tPostMessage
 		end if
 	end if
 
-	post "hiliteChanged"
+	if tPostMessage is true then
+		post "hiliteChanged"
+	end if
 	put false into mIsPressed
 end handler
 
@@ -519,10 +526,14 @@ public handler OnMouseRelease() returns nothing
 		return
 	end if
 
+	variable tPostMessage as Boolean
 	if mMouseHasMoved then
+		put mSwitchIsInOnPosition is not mSwitchIsOn into tPostMessage
 		setSwitch(mSwitchIsInOnPosition)
 		put false into mMouseHasMoved
-		post "hiliteChanged"
+		if tPostMessage is true then
+			post "hiliteChanged"
+		end if
 		put false into mIsPressed
 	end if
 end handler


### PR DESCRIPTION
Switch Button widget posted the `hiliteChanged` message whenever a click was registered within the rect of the widget.  It also would post the message in other instances where the value didn't actually change (dragged the switch on and then back off for example).

Added code to detect if the value was being changed and only issue the message when the value actually changes.