### PR TITLE
[[ Android API ]] Use API 19

### DIFF
--- a/config.py
+++ b/config.py
@@ -396,7 +396,7 @@ def validate_android_tools(opts):
 
     ndk_ver = opts['ANDROID_NDK_VERSION']
     if opts['ANDROID_PLATFORM'] is None:
-        opts['ANDROID_PLATFORM'] = 'android-17'
+        opts['ANDROID_PLATFORM'] = 'android-19'
 
     if opts['ANDROID_NDK'] is None:
         ndk = guess_android_tooldir('android-ndk')

--- a/docs/development/build-android.md
+++ b/docs/development/build-android.md
@@ -42,7 +42,7 @@ Create a standalone toolchain (this simplifies setting up the build environment)
 
 ````bash
 android-ndk-r14/build/tools/make_standalone_toolchain.py \
-    --arch arm --api 9 \
+    --arch arm --api 19 \
     --install-dir ${HOME}/android/toolchain/standalone
 ````
 
@@ -85,7 +85,7 @@ AR="${BINDIR}/${TRIPLE}-ar"
 
 # Android platform information
 ANDROID_NDK_VERSION=r14
-ANDROID_PLATFORM=android-17
+ANDROID_PLATFORM=android-19
 ANDROID_NDK=${TOOLCHAIN}/android-ndk-r14
 ANDROID_SDK=${TOOLCHAIN}/android-sdk-linux
 ANDROID_BUILD_TOOLS=25.0.2

--- a/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
@@ -806,4 +806,12 @@ public class ExtVideoView extends SurfaceView implements MediaPlayerControl {
     public boolean canSeekForward() {
         return mCanSeekForward;
     }
+    
+    @Override
+    public int getAudioSessionId() {
+      if (mMediaPlayer != null) {
+          return mMediaPlayer.getAudioSessionId();
+      }
+      return 0;
+    }
 }

--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -192,7 +192,7 @@ function deployIsValidSDK pPath
    
    // We need API 15 in order to be able to give the value 'screenSize' to the manifest variable configChanges
    // That was introduced in the API 13, but the SDK manager only have API 15 nowadays
-   if there is no folder (pPath & slash & "platforms/android-15") then
+   if there is no folder (pPath & slash & "platforms/android-19") then
       --return "could not find install of SDK level 8, make sure it has been installed with the Android SDK Manager"
       return false
    end if
@@ -326,7 +326,7 @@ function pathToRootClasses pRoot
    if pRoot is empty then
       put sAndroidRoot into pRoot
    end if
-   return pRoot & slash & "platforms/android-15/android.jar"
+   return pRoot & slash & "platforms/android-19/android.jar"
 end pathToRootClasses
 
 function pathToSDKClasses pRoot

--- a/prebuilt/scripts/android.inc
+++ b/prebuilt/scripts/android.inc
@@ -1,6 +1,6 @@
 # Android options
 ANDROID_NDK=${ANDROID_NDK:-"${HOME}/android/toolchain/android-ndk"}
-ANDROID_PLATFORM=${ANDROID_PLATFORM:-android-17}
+ANDROID_PLATFORM=${ANDROID_PLATFORM:-android-19}
 
 # Has a full, custom toolchain been specified?
 #  AR, CC, CXX, LINK, OBJCOPY, RANLIB, STRIP


### PR DESCRIPTION
This patch updates android to build against `android-19` to allow
for the browser widget `PrintToPDF` function.

(cherry picked from commit 7fdc634428db178d8bad45be35177aa0109074f7)

We will need to setup an android-19 builder on vulcan before this will work