### PR TITLE
[bugfix-15614] (Take two) Fix display issue with URLEncode code example

### DIFF
--- a/docs/dictionary/function/URLEncode.lcdoc
+++ b/docs/dictionary/function/URLEncode.lcdoc
@@ -35,7 +35,7 @@ formString (string):
 Returns:
 The <URLEncode> <function> <return|returns> the <formString>, with
 spaces converted to "+" and characters other than letters and numbers
-converted to their hexadecimal <Escape key|escape> representation.
+converted to their hexadecimal escape representation.
 
 Description:
 Use the <URLEncode> <function> to <encode> a <URL> so it can be safely
@@ -63,8 +63,8 @@ appears in the formString, it is converted to "%7E".
     end urlEncodeRFC
 
 References: post (command), function (control structure),
-hexadecimal (glossary), encode (glossary), Escape key (glossary),
-ASCII (glossary), return (glossary), server (glossary), URL (keyword),
+hexadecimal (glossary), encode (glossary), ASCII (glossary), 
+return (glossary), server (glossary), URL (keyword), 
 character (keyword), http (keyword), string (keyword)
 
 Tags: networking

--- a/docs/dictionary/function/URLEncode.lcdoc
+++ b/docs/dictionary/function/URLEncode.lcdoc
@@ -53,14 +53,14 @@ appears in the formString, it is converted to "%7E".
 > the string to UTF-8 and then after performing URLEncode, replace all
 > instances of "+" with "%20". For example:
 
-   function urlEncodeRFC pString
-      if pString is strictly a string then
-         put textEncode(pString,"UTF-8") into pString
-      end if
-      put URLEncode(pString) into pString
-      replace "+" with "%20" in pString
-      return pString
-   end urlEncodeRFC
+    function urlEncodeRFC pString
+        if pString is strictly a string then
+            put textEncode(pString,"UTF-8") into pString
+        end if
+        put URLEncode(pString) into pString
+        replace "+" with "%20" in pString
+        return pString
+    end urlEncodeRFC
 
 References: post (command), function (control structure),
 hexadecimal (glossary), encode (glossary), Escape key (glossary),


### PR DESCRIPTION
Added spaces to each line so that each indentation is four spaces wide instead of three.
Also removed references to Escape key - not the same thing as escape characters.