### PR TITLE
[Bug 21217] Prevent crash when calling quit from a stack with a non empty imagesource 

### DIFF
--- a/docs/notes/bugfix-21217.md
+++ b/docs/notes/bugfix-21217.md
@@ -1,0 +1,1 @@
+# Prevent crash when calling quit from a stack with a non empty imagesource 

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -2875,17 +2875,20 @@ bool MCField::imagechanged(MCImage *p_image, bool p_deleting)
 	bool t_used = false;
 	MCParagraph *t_para = paragraphs;
 
-	do
+	if (t_para != NULL)
 	{
-		t_used = t_para->imagechanged(p_image, p_deleting) || t_used;
-		t_para = t_para->next();
-	}
-	while (t_para != paragraphs);
-
-	if (t_used)
-	{
-		do_recompute(true);
-		layer_redrawall();
+		do
+		{
+			t_used = t_para->imagechanged(p_image, p_deleting) || t_used;
+			t_para = t_para->next();
+		}
+		while (t_para != paragraphs);
+		
+		if (t_used)
+		{
+			do_recompute(true);
+			layer_redrawall();
+		}
 	}
 
 	return t_used;


### PR DESCRIPTION
I could not reproduce the crash with a simple stack.

(`t_para` was NULL when the crash occurred)