### PR TITLE
[[ LCB ]] Additions to widget module functions

### DIFF
--- a/engine/src/emscripten.lcb
+++ b/engine/src/emscripten.lcb
@@ -33,7 +33,7 @@ foreign handler MCEmscriptenPointerToJSObject(in pPtr as Pointer, out rObj as JS
 __safe foreign handler MCEmscriptenEvaluateJavaScriptWithArguments(in pScript as String, in pArgs as List, out rResult as any) returns bool binds to "<builtin>"
 
 public handler type JSEventHandler(in pEvent as JSObject) returns nothing
-__safe foreign handler MCEmscriptenWrapJSEventHandler(in pHandler as JSEventHandler, out rRef as JSObject) returns bool binds to "<builtin>"
+__safe foreign handler MCEmscriptenWrapHandlerAsJSFunction(in pHandler as any, out rRef as JSObject) returns bool binds to "<builtin>"
 
 /**
 Summary:    Convert a JavaScript object value to a pointer
@@ -180,9 +180,9 @@ end handler
 Description:
 Use <HandlerAsJSFunction> to convert a handler reference to a JavaScript function object reference.
 */
-public handler HandlerAsJSFunction(in pHandler as JSEventHandler) returns JSObject
+public handler HandlerAsJSFunction(in pHandler as any) returns JSObject
 	variable tJSHandler as JSObject
-	MCEmscriptenWrapJSEventHandler(pHandler, tJSHandler)
+	MCEmscriptenWrapHandlerAsJSFunction(pHandler, tJSHandler)
 	return tJSHandler
 end handler
 

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -46,6 +46,8 @@ public foreign handler MCEngineEvalScriptObjectExists(in pObject as ScriptObject
 public foreign handler MCEngineEvalScriptObjectDoesNotExist(in pObject as ScriptObject, out rExists as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCEngineExecGetPropertyOfScriptObject(in pProperty as String, in pObject as ScriptObject, out rValue as any) returns nothing binds to "<builtin>"
 public foreign handler MCEngineExecSetPropertyOfScriptObject(in pValue as any, in pProperty as String, in pObject as ScriptObject) returns nothing binds to "<builtin>"
+public foreign handler MCEngineExecGetPropertyOfSetOfScriptObject(in pProperty as String, in pSet as String, in pObject as ScriptObject, out rValue as any) returns nothing binds to "<builtin>"
+public foreign handler MCEngineExecSetPropertyOfSetOfScriptObject(in pValue as any, in pProperty as String, in pSet as String, in pObject as ScriptObject) returns nothing binds to "<builtin>"
 public foreign handler MCEngineEvalOwnerOfScriptObject(in pObject as ScriptObject, out rParent as ScriptObject) returns nothing binds to "<builtin>"
 public foreign handler MCEngineEvalChildrenOfScriptObject(in pObject as ScriptObject, out rChildren as List) returns nothing binds to "<builtin>"
 public foreign handler MCEngineExecSendToScriptObject(in pIsFunction as CBool, in pMessage as String, in pTarget as ScriptObject) returns optional any binds to "<builtin>"
@@ -176,6 +178,7 @@ end syntax
 /**
 Summary:	The property of a script object.
 Property: 	The name of the property to manipulate
+Set:		The name of the custom property set to access
 Object:		An expression that evaluates to a <ScriptObject>.
 
 
@@ -189,6 +192,9 @@ Example:
 	set property "invisible" of the result to true
     get property "script" of my script object
 
+Example:
+	get property "customProp" of set "cMyCustomPropertySet" of my script object
+	
 Description:
 Use to manipulate properties of a script object.
 
@@ -205,6 +211,13 @@ syntax PropertyOfScriptObject is prefix operator with property precedence
 begin
     MCEngineExecGetPropertyOfScriptObject(Property, Object, output)
     MCEngineExecSetPropertyOfScriptObject(input, Property, Object)
+end syntax
+
+syntax PropertyOfSetOfScriptObject is prefix operator with property precedence
+    "property" <Property: Expression> "of" "set" <Set: Expression> "of" <Object: Expression>
+begin
+    MCEngineExecGetPropertyOfSetOfScriptObject(Property, Set, Object, output)
+    MCEngineExecSetPropertyOfSetOfScriptObject(input, Property, Set, Object)
 end syntax
 
 /**

--- a/engine/src/module-emscripten.cpp
+++ b/engine/src/module-emscripten.cpp
@@ -37,9 +37,12 @@ bool MCEmscriptenEvaluateJavaScriptWithArguments(MCStringRef p_script, MCProperL
 }
 
 extern "C" MC_DLLEXPORT_DEF
-bool MCEmscriptenWrapJSEventHandler(MCHandlerRef p_handler, MCJSObjectRef &r_wrapper)
+bool MCEmscriptenWrapHandlerAsJSFunction(MCValueRef p_handler, MCJSObjectRef &r_wrapper)
 {
-	return MCEmscriptenJSWrapHandler(p_handler, r_wrapper);
+	if (MCValueGetTypeCode(p_handler) != kMCValueTypeCodeHandler)
+		return MCErrorThrowGeneric(MCSTR("Invalid value - expected Handler ref"));
+		
+	return MCEmscriptenJSWrapHandler((MCHandlerRef)p_handler, r_wrapper);
 }
 
 #else // !defined(__EMSCRIPTEN__)
@@ -51,7 +54,7 @@ bool MCEmscriptenEvaluateJavaScriptWithArguments(MCStringRef p_script, MCProperL
 }
 
 extern "C" MC_DLLEXPORT_DEF
-bool MCEmscriptenWrapJSEventHandler(MCHandlerRef p_handler, MCJSObjectRef &r_wrapper)
+bool MCEmscriptenWrapHandlerAsJSFunction(MCHandlerRef p_handler, MCJSObjectRef &r_wrapper)
 {
 	return false;
 }

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -265,7 +265,7 @@ bool MCEngineEvalObjectOfScriptObject(MCScriptObjectRef p_object, MCObject *&r_o
 	return true;
 }
 
-MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id)
+MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id)
 {
 	Properties t_prop;
 	t_prop = parse_property_name(p_property);
@@ -274,11 +274,14 @@ MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_proper
 	
 	if (t_prop == P_CUSTOM)
 	{
-		MCNewAutoNameRef t_propset_name, t_propset_key;
-		t_propset_name = p_object -> getdefaultpropsetname();
-		if (!MCNameCreate(p_property, &t_propset_key))
+		MCNewAutoNameRef t_set_name, t_prop_name;
+		if (MCStringIsEmpty(p_set))
+			t_set_name = p_object -> getdefaultpropsetname();
+		else if (!MCNameCreate(p_set, &t_set_name))
 			return nil;
-		p_object -> getcustomprop(ctxt, *t_propset_name, *t_propset_key, nil, t_value);
+		if (!MCNameCreate(p_property, &t_prop_name))
+			return nil;
+		p_object -> getcustomprop(ctxt, *t_set_name, *t_prop_name, nil, t_value);
 	}
 	else
 		p_object -> getprop(ctxt, p_part_id, t_prop, nil, False, t_value);
@@ -299,7 +302,7 @@ MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_proper
 	return t_value_ref;
 }
 
-extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object, MCValueRef& r_value)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfSetOfScriptObject(MCStringRef p_property, MCStringRef p_set, MCScriptObjectRef p_object, MCValueRef& r_value)
 {
     if (!MCEngineEnsureScriptObjectAccessIsAllowed())
     {
@@ -316,11 +319,16 @@ extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringR
     MCExecContext ctxt(MCdefaultstackptr, nil, nil);
 
     // AL-2015-07-24: [[ Bug 15630 ]] Syntax binding dictates value returned as out parameter rather than directly
-	r_value = MCEngineGetPropertyOfObject(ctxt, p_property, t_object, t_part_id);
+	r_value = MCEngineGetPropertyOfObject(ctxt, p_set, p_property, t_object, t_part_id);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object, MCValueRef& r_value)
+{
+	MCEngineExecGetPropertyOfSetOfScriptObject(p_property, kMCEmptyString, p_object, r_value);
 }
 
 // IM-2015-02-23: [[ WidgetPopup ]] Factored-out function for setting the named property of an object to a value.
-void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value)
+void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value)
 {
     MCValueRef t_value_copy;
     t_value_copy = MCValueRetain(p_value);
@@ -341,14 +349,20 @@ void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MC
     
     if (t_prop == P_CUSTOM)
     {
-        MCNewAutoNameRef t_propset_name, t_propset_key;
-		t_propset_name = p_object -> getdefaultpropsetname();
-        if (!MCNameCreate(p_property, &t_propset_key))
-        {
-            MCValueRelease(t_value_copy);
-            return;
-        }
-		p_object -> setcustomprop(ctxt, *t_propset_name, *t_propset_key, nil, t_value);
+		MCNewAutoNameRef t_set_name, t_prop_name;
+		if (MCStringIsEmpty(p_set))
+			t_set_name = p_object -> getdefaultpropsetname();
+		else if (!MCNameCreate(p_set, &t_set_name))
+		{
+			MCValueRelease(t_value_copy);
+			return;
+		}
+		if (!MCNameCreate(p_property, &t_prop_name))
+		{
+			MCValueRelease(t_value_copy);
+			return;
+		}
+		p_object -> setcustomprop(ctxt, *t_set_name, *t_prop_name, nil, t_value);
     }
     else
 		p_object -> setprop(ctxt, p_part_id, t_prop, nil, False, t_value);
@@ -360,21 +374,26 @@ void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MC
     }
 }
 
-extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfScriptObject(MCValueRef p_value, MCStringRef p_property, MCScriptObjectRef p_object)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfSetOfScriptObject(MCValueRef p_value, MCStringRef p_property, MCStringRef p_set, MCScriptObjectRef p_object)
 {
-    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
-    {
-        return;
-    }
-    
+	if (!MCEngineEnsureScriptObjectAccessIsAllowed())
+	{
+		return;
+	}
+	
 	MCObject *t_object;
 	uint32_t t_part_id;
 	if (!MCEngineEvalObjectOfScriptObject(p_object, t_object, t_part_id))
 		return;
 	
-    MCExecContext ctxt(MCdefaultstackptr, nil, nil);
+	MCExecContext ctxt(MCdefaultstackptr, nil, nil);
 
-	MCEngineSetPropertyOfObject(ctxt, p_property, t_object, t_part_id, p_value);
+	MCEngineSetPropertyOfObject(ctxt, p_set, p_property, t_object, t_part_id, p_value);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfScriptObject(MCValueRef p_value, MCStringRef p_property, MCScriptObjectRef p_object)
+{
+	MCEngineExecSetPropertyOfSetOfScriptObject(p_value, p_property, kMCEmptyString, p_object);
 }
 
 extern "C" MC_DLLEXPORT_DEF void MCEngineEvalOwnerOfScriptObject(MCScriptObjectRef p_object, MCScriptObjectRef &r_owner)
@@ -562,9 +581,7 @@ void MCEngineDoPostToObjectWithArguments(MCStringRef p_message, MCObject *p_obje
     
     MCExecContext ctxt(MCdefaultstackptr, nil, nil);
     MCParameter *t_params;
-    MCValueRef t_result;
     t_params = nil;
-    t_result = nil;
     
     if (!MCEngineConvertToScriptParameters(ctxt, p_arguments, t_params))
         return;

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -279,7 +279,7 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		t_getprop_name = p_set_name, t_param_name = p_prop_name;
     
 	Exec_stat t_stat = ES_NOT_HANDLED;
-	if (!MClockmessages && (ctxt . GetObject() != this || !ctxt . GetHandler() -> hasname(t_getprop_name)))
+	if (!MClockmessages && (ctxt . GetObject() != this || ctxt.GetHandler() == nil || !ctxt . GetHandler() -> hasname(t_getprop_name)))
 	{
 		MCParameter p1;
 		p1.setvalueref_argument(t_param_name);

--- a/engine/src/widget-popup.cpp
+++ b/engine/src/widget-popup.cpp
@@ -57,8 +57,8 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id);
-extern void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value);
+extern MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id);
+extern void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value);
 
 class MCWidgetPopup: public MCStack
 {
@@ -188,7 +188,7 @@ private:
 		
 		while (MCArrayIterate(p_properties, t_iter, t_key, t_value))
 		{
-			MCEngineSetPropertyOfObject(ctxt, MCNameGetString(t_key), m_widget, 0, t_value);
+			MCEngineSetPropertyOfObject(ctxt, kMCEmptyString, MCNameGetString(t_key), m_widget, 0, t_value);
 			if (MCErrorIsPending())
 				return false;
 		}
@@ -230,7 +230,7 @@ private:
 	{
 		MCExecContext ctxt(MCdefaultstackptr, nil, nil);
 		MCAutoValueRef t_value;
-		t_value = MCEngineGetPropertyOfObject(ctxt, MCSTR("preferredSize"), m_widget, 0);
+		t_value = MCEngineGetPropertyOfObject(ctxt, kMCEmptyString, MCSTR("preferredSize"), m_widget, 0);
 		if (MCErrorIsPending())
 			return false;
 		

--- a/engine/src/widget-syntax.cpp
+++ b/engine/src/widget-syntax.cpp
@@ -143,6 +143,11 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetExecTriggerAll(void)
     MCWidgetTriggerAll(MCcurrentwidget);
 }
 
+extern "C" MC_DLLEXPORT_DEF void MCWidgetExecTriggerAllInWidget(MCWidgetRef p_widget)
+{
+	MCWidgetTriggerAll(p_widget);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMyScriptObject(MCScriptObjectRef& r_script_object)
@@ -474,6 +479,14 @@ extern "C" MC_DLLEXPORT_DEF void MCWidgetGetMouseButtonState(uinteger_t p_index,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+extern "C" MC_DLLEXPORT_DEF void MCWidgetEvalThisWidget(MCWidgetRef& r_widget)
+{
+	if (!MCWidgetEnsureCurrentWidget())
+		return;
+	
+	r_widget = MCValueRetain(MCcurrentwidget);
+}
 
 extern "C" MC_DLLEXPORT_DEF void MCWidgetEvalTheTarget(MCWidgetRef& r_widget)
 {

--- a/engine/src/widget.lcb
+++ b/engine/src/widget.lcb
@@ -394,6 +394,10 @@ use com.livecode.foreign
 use com.livecode.canvas
 use com.livecode.engine
 
+// ---------- Widget type definition ---------- //
+
+public foreign type Widget binds to "MCWidgetTypeInfo"
+
 // ---------- Widget commands ---------- //
 
 public foreign handler MCWidgetExecRedrawAll() returns nothing binds to "<builtin>"
@@ -401,6 +405,7 @@ public foreign handler MCWidgetExecScheduleTimerIn(in pTime as CDouble) returns 
 public foreign handler MCWidgetExecCancelTimer() returns nothing binds to "<builtin>"
 public foreign handler MCWidgetEvalInEditMode(out rInEditMode as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetExecTriggerAll() returns nothing binds to "<builtin>"
+public foreign handler MCWidgetExecTriggerAllInWidget(in pWidget as Widget) returns nothing binds to "<builtin>"
 
 /**
 Summary:	Redraws the widget.
@@ -488,11 +493,19 @@ end syntax
 
 /**
 Summary:	Causes all of a widget's property triggers to be fired.
+mWidget:	An expression that evaluates to a widget.
 
 Example:
 	handler TextChangedCallback()
         UpdateTextProperty()
         trigger all
+	end handler
+
+Example:
+	private variable mSelf as Widget
+	handler TextChangedCallback()
+		UpdateTextProperty()
+		trigger all in mSelf
 	end handler
 
 Description:
@@ -502,9 +515,10 @@ properties to change, to signal the property change to the IDE.
 */
 
 syntax TriggerAll is statement
-  "trigger" "all"
+  "trigger" "all" [ "in" <mWidget: Expression> ]
 begin
   MCWidgetExecTriggerAll()
+  MCWidgetExecTriggerAllInWidget(mWidget)
 end syntax
 
 
@@ -1164,8 +1178,7 @@ end syntax
 
 // annotation <name> of <widget>
 
-public foreign type Widget binds to "MCWidgetTypeInfo"
-
+public foreign handler MCWidgetEvalThisWidget(out rMe as optional Widget) returns nothing binds to "<builtin>"
 public foreign handler MCWidgetEvalTheTarget(out rTarget as optional Widget) returns nothing binds to "<builtin>"
 
 public foreign handler MCWidgetEvalMyChildren(out rChildWidgets as List) returns nothing binds to "<builtin>"
@@ -1256,6 +1269,42 @@ syntax TheTarget is expression
     "the" "target"
 begin
     MCWidgetEvalTheTarget(output)
+end syntax
+
+//
+
+/**
+Summary: Returns the current widget.
+Returns: A widget object.
+
+Example:
+
+-- In a widget
+private variable mSelf as Widget
+public handler OnCreate() returns nothing
+	-- Keep a reference to this widget
+	put this widget into mSelf
+
+	-- defined in separate module library
+	SetEventCallback(EventCallback)
+end handler
+
+-- may be called from another module library
+private handler EventCallback() returns nothing
+	-- update internal variables
+
+	-- notify ide of changes
+	trigger all in mSelf
+end handler
+
+Description:
+This widget evaluates to the current widget. This can be used to retain a reference for occasions where widget handlers may be called from another module, where the current widget may not be valid.
+*/
+
+syntax ThisWidget is expression
+	"this" "widget"
+begin
+	MCWidgetEvalThisWidget(output)
 end syntax
 
 //

--- a/ide-support/revsaveasemscriptenstandalone.livecodescript
+++ b/ide-support/revsaveasemscriptenstandalone.livecodescript
@@ -527,9 +527,7 @@ private function getPreparedStackAsData pStackFile, pBuildFolder
          put true into tCleanTempFile
          
          -- Clear standalone settings
-         if not revEnvironmentEditionProperty("open_source_required") then
-            set the customProperties["cRevStandaloneSettings"] of tStack to empty
-         else
+         if revEnvironmentEditionProperty("open_source_required") then
             -- For Community edition deployment to retain everything
             -- but the deployment password (which isn't relevant to
             -- Community edition anyway).  Keeping the deployment

--- a/libscript/src/script-module.cpp
+++ b/libscript/src/script-module.cpp
@@ -809,6 +809,9 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                 }
                 else
                 {
+#if defined(__EMSCRIPTEN__) // Skip foreign type constructor check on emscripten
+					t_typeinfo = kMCNullTypeInfo;
+#else
                     MCAutoStringRef t_type_func, t_args;
                     if (!MCStringDivideAtChar(t_type->binding, ':', kMCStringOptionCompareExact, &t_type_func, &t_args))
                     {
@@ -834,6 +837,7 @@ bool MCScriptEnsureModuleIsUsable(MCScriptModuleRef self)
                     {
                         goto error_cleanup;
                     }
+ #endif
                 }
             }
             break;

--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -357,7 +357,7 @@ static uindex_t s_emitted_builtin_count = 0;
 
 static MCStringRef EmittedBuiltinAdd(NameRef p_symbol_name, uindex_t p_type_index)
 {
-    if (!OutputFileAsC || OutputFileAsAuxC)
+    if (!(OutputFileAsC || OutputFileAsAuxC))
     {
         return MCNameGetString(to_mcnameref(p_symbol_name));
     }


### PR DESCRIPTION
Additions to builtin widget & emscripten modules to aid widget development:

- modify HandlerAsJSFunction to accept handlers with different signatures
- add optional `set` parameter to `property <name> of <scriptobject>` expression allowing access to values from specific custom property sets
- add `trigger all in <widget>` syntax to specify the widget object whose properties have changed
- add `this widget` expression to obtain a reference to the current widget object

Also fixes issues with resolving builtin foreign handlers in emscripten engine.
