### PR TITLE
[Dictionary] Changes from is not strictly to libURLSetStatusCallback

### DIFF
--- a/docs/dictionary/command/libURLSetStatusCallback.lcdoc
+++ b/docs/dictionary/command/libURLSetStatusCallback.lcdoc
@@ -152,8 +152,7 @@ callback (glossary), command (glossary), control structure (glossary),
 main stack (glossary), Standalone Application Settings (glossary),
 upload (glossary), download (glossary), server (glossary),
 HTTP (glossary), handler (glossary), URL (keyword), ftp (keyword),
-item (keyword), http (keyword), libURLftpUpload (library),
-libURLDownloadToFile (library), library (library),
+item (keyword), http (keyword), library (library), 
 Internet library (library), startup (message), openBackground (message),
 preOpenStack (message), openStack (message), preOpenCard (message)
 

--- a/docs/dictionary/function/libURLLastHTTPHeaders.lcdoc
+++ b/docs/dictionary/function/libURLLastHTTPHeaders.lcdoc
@@ -35,9 +35,9 @@ You can set the <httpHeaders> <property> to send custom headers in
 addition to the default headers. Whenever LiveCode contacts a <web
 server> to <download> a page (with the <load> <command> or by using a
 <URL> in an <expression>) or to post data (with the <post> <command>),
-the contents of the <httpHeaders> <property> is sent to the <web
-server>. The <libURLLastHTTPHeaders> <function> returns the last set of
-custom headers used.
+the contents of the <httpHeaders> <property> is sent to the 
+<web server>. The <libURLLastHTTPHeaders> <function> returns the last 
+set of custom headers used.
 
 >*Important:* The <libURLLastHTTPHeaders> <function> is part of the 
 > <Internet library>. To ensure that the <function> works in a 

--- a/docs/dictionary/function/libURLftpCommand.lcdoc
+++ b/docs/dictionary/function/libURLftpCommand.lcdoc
@@ -52,8 +52,8 @@ three-digit code, followed by any other relevant information.
 
 Description:
 Use the <libURLftpCommand> <function> to communicate with an <FTP>
-<server> and perform tasks that are not implemented in the <Internet
-library>. 
+<server> and perform tasks that are not implemented in the 
+<Internet library>. 
 
 The ability to send any FTP command to an FTP server is a powerful
 function that can enable you to provide full support for all FTP

--- a/docs/dictionary/keyword/it.lcdoc
+++ b/docs/dictionary/keyword/it.lcdoc
@@ -6,7 +6,7 @@ Syntax: it
 
 Summary:
 A special <local variable> that is used with commands such as <get>,
-<read from file>, <convert>, ask, and <answer>.
+<read from file>, <convert>, <ask>, and <answer>.
 
 Introduced: 1.0
 
@@ -24,15 +24,16 @@ Description:
 Use the <it> <keyword> to get the result of certain <command|commands>,
 or as a handy temporary storage place.
 
-The <it> <keyword> designates a special <local variable>. <It> can be
+The <it> <keyword> designates a special <local variable>. <it|It> can be
 used like any other <local variable>: you can put a <value> into <it>,
 or put <it> into another <container>.
 
-The commands that use the <it> <variable> are:  <answer>, <answer
-color>, <answer effect>, <answer file>, <answer folder>, <ask>, <ask
-file>, <ask password>, <clone>, <convert>, <copy>, <create>, <get>,
-<paste>, <post>, <read from driver>, <read from file>, <read from
-process>, <read from socket>, <request>, and <request appleEvent>.
+The commands that use the <it> <variable> are:  <answer>, 
+<answer color>, <answer effect>, <answer file>, <answer folder>, <ask>, 
+<ask file>, <ask password>, <clone>, <convert>, <copy>, <create>, <get>,
+<paste>, <post>, <read from driver>, <read from file>, 
+<read from process>, <read from socket>, <request>, and 
+<request appleEvent>.
 
 Unlike other local variables, <it> can change even if you don't
 explicitly change its <value>. Certain <command|commands> use it to

--- a/docs/dictionary/keyword/item.lcdoc
+++ b/docs/dictionary/keyword/item.lcdoc
@@ -5,8 +5,8 @@ Type: keyword
 Syntax: item
 
 Summary:
-Designates a comma-<delimit|delimited> <string> as part of a <chunk
-expression>. 
+Designates a comma-<delimit|delimited> <string> as part of a 
+<chunk expression>. 
 
 Introduced: 1.0
 

--- a/docs/dictionary/keyword/last.lcdoc
+++ b/docs/dictionary/keyword/last.lcdoc
@@ -23,8 +23,8 @@ put the last line of it after field "Answers"
 Description:
 The <last> <keyword> can be used to specify any <object(glossary)> whose
 <number> <property> is equal to the number of <object|objects> of that
-type. It can also be used to designate the last <chunk> in a <chunk
-expression>. 
+type. It can also be used to designate the last <chunk> in a 
+<chunk expression>. 
 
 The last control is the topmost control on a card. The last button is
 the topmost button, and similarly for other types of controls.

--- a/docs/dictionary/operator/is-not-strictly.lcdoc
+++ b/docs/dictionary/operator/is-not-strictly.lcdoc
@@ -35,8 +35,9 @@ Use the <is not strictly> operator to determine what the true type of
 a value is not.  The true type of a value is the representation which
 the engine is currently holding for it, without performing any
 implicit type coercion. The true type of a value can be one of the
-following:- nothing: no value, typically seen as <empty>
+following:
 
+- nothing: no value, typically seen as <empty>
 - boolean: either true or false, typically seen as the result of a
   comparison operator
 - integer: a number with no fractional part

--- a/docs/glossary/k/keyboard-equivalent.lcdoc
+++ b/docs/glossary/k/keyboard-equivalent.lcdoc
@@ -6,8 +6,8 @@ keyboard equivalent
 Type: glossary
 
 Description:
-A key (or <key combination>) that acts as a shortcut to choose a <menu
-item> or <button>.
+A key (or <key combination>) that acts as a shortcut to choose a 
+<menu item> or <button>.
 
 References: button (glossary), menu item (glossary),
 key combination (glossary)

--- a/docs/glossary/l/library-extension.lcdoc
+++ b/docs/glossary/l/library-extension.lcdoc
@@ -6,11 +6,10 @@ Type: glossary
 
 Description:
 A <library extension> is an extension to the LiveCode environment
-written in the <LiveCode Builder language>. When a <library
-extension|library> is loaded has its public handlers added to the bottom
-of the <message path>. These public handlers can be called in <LiveCode>
-in exactly the same way as script handlers.
+written in the <LiveCode Builder language>. When a 
+<library> is loaded it has its public handlers added 
+to the bottom of the <message path>. These public handlers can be 
+called in <LiveCode> in exactly the same way as script handlers.
 
 References: LiveCode Builder language (glossary), LiveCode (glossary),
-message path (glossary)
-
+message path (glossary), library (library)

--- a/docs/glossary/l/library.lcdoc
+++ b/docs/glossary/l/library.lcdoc
@@ -9,8 +9,8 @@ A repository of code that is available to be used by other routines.
 LiveCode includes several <custom libraries> you can include in your
 applications. 
 
-You can make the <script> of any <stack> into a library with the <start
-using> <command>, or make any <object|object's> <script> into a library
+You can make the <script> of any <stack> into a library with the 
+<start using> <command>, or make any <object|object's> <script> into a library
 using the <insert script> <command>.
 
 References: start using (command), insert script (command),


### PR DESCRIPTION
operator/is-not-strictly.lcdoc : Moved a list item to have it display correctly.
keyword/it.lcdoc : Fixed broken links
keyword/item.lcdoc : Fixed broken link.
glossary/k/keyboard-equivalent.lcdoc : Fixed broken link
message/keyDown.lcdoc : Fixed broken link. Fixed broken reference
keyword/last.lcdoc - Fixed broken link.
command/launch-url-in-widget.lcdoc - Fixed broken link.
glossary/l/library-extension.lcdoc - Fixed broken link.
glossary/l/library.lcdoc - Fixed broken link.
function/libURLftpCommand.lcdoc - Fixed broken link.
function/libURLLastHTTPHeaders.lcdoc - Fixed broken links.
command/libURLSetStatusCallback.lcdoc - Removed non-existent references.