### PR TITLE
[Dictionary] Changes from licenced to load extension

### DIFF
--- a/docs/dictionary/command/load-extension.lcdoc
+++ b/docs/dictionary/command/load-extension.lcdoc
@@ -31,13 +31,13 @@ filePath:
 The path to a compiled <LiveCode Builder extension> file.
 
 moduleData:
-Binary data that constitutes a valid compiled <LiveCode Builder
-extension>. 
+Binary data that constitutes a valid compiled 
+<LiveCode Builder extension>. 
 
 resourcePath:
-The path to use for any operations in the <LiveCode Builder
-extension|extensions> that use resource files (eg 'image from resource
-file'). 
+The path to use for any operations in the 
+<LiveCode Builder extension|extensions> 
+that use resource files (eg 'image from resource file'). 
 
 The result:
 If the <load extension> <command> succeeds, the <result> is empty.
@@ -45,11 +45,11 @@ Otherwise the <result> contains an error message describing why the
 extension could not be loaded.
 
 Description:
-Use the <load extension> <command> to load a <LiveCode Builder
-extension>. If the extension is a library, its public handlers will be
-added to the bottom of the message path. If it is a widget, it will be
-available as a control in the tools palette to drag out, or to create
-with the <create widget> <command>.
+Use the <load extension> <command> to load a 
+<LiveCode Builder extension>. If the extension is a library, its 
+public handlers will be added to the bottom of the message path. 
+If it is a widget, it will be available as a control in the tools 
+palette to drag out, or to create with the <create widget> <command>.
 
 If the <moduleData> or the data loaded from <filePath> contains more
 than one LiveCode Builder module, then the first module is treated as

--- a/docs/dictionary/command/load.lcdoc
+++ b/docs/dictionary/command/load.lcdoc
@@ -45,8 +45,8 @@ order to speed up access when using it in an <expression> with the
 <URL> <keyword>.
 
 To use a file that has been downloaded by the <load> <command>, refer
-to it using the <URL> <keyword> as usual. When you request the original
-<URL>, LiveCode uses the <cache|cached> <file> automatically.
+to it using the <URL> <keyword> as usual. When you request the 
+original <URL>, LiveCode uses the <cache|cached> <file> automatically.
 
 The <callbackMessage> is sent to the <object(glossary)> whose <script> 
 contains the <load> <command>, after the <URL> is <load|loaded>, so you 
@@ -75,8 +75,7 @@ URL even if it is not in the cache, so use of the <load> <command> is
 optional.
 
 >*Note:* Cached <files> consume memory. To release this memory after
-> you 
-are finished with a <URL>, use the <unload (command)> <command> to 
+> you are finished with a <URL>, use the <unload (command)> <command> to 
 remove it from the <cache>.
 
 >*Important:*  The <load> <command> is part of the 
@@ -108,21 +107,19 @@ remove it from the <cache>.
 > appropriately.
 
 References: unload (command), libURLftpUpload (command),
-libURLDownloadToFile (command), get (command), load (command),
+libURLDownloadToFile (command), get (command),
 group (command), function (control structure),
 libURLLastRHHeaders (function), URLEncode (function), files (function),
 libURLErrorData (function), URLStatus (function), cachedURLs (function),
 object (glossary), LiveCode custom library (glossary),
 application (glossary), standalone application (glossary),
 load (glossary), cache (glossary), command (glossary),
-standalone desktop application (glossary), main stack (glossary),
-expression (glossary), keyword (glossary),
-Standalone Application Settings (glossary), download (glossary),
-message (glossary), parameter (glossary), handler (glossary),
-url (keyword), file (keyword), Internet library (library),
-library (library), startup (message), openBackground (message),
-preOpenStack (message), openStack (message), preOpenCard (message),
-script (property)
+main stack (glossary), expression (glossary), keyword (glossary), 
+download (glossary), message (glossary), parameter (glossary), 
+handler (glossary), URL (keyword), file (keyword), 
+Internet library (library), library (library), startup (message), 
+openBackground (message), preOpenStack (message), openStack (message), 
+preOpenCard (message), script (property)
 
 Tags: networking
 

--- a/docs/dictionary/function/licensed.lcdoc
+++ b/docs/dictionary/function/licensed.lcdoc
@@ -36,7 +36,7 @@ limitations are described by the <scriptLimits> <function>.
 > <function> returns true.
 
 References: edit (command), function (control structure),
-mcLicense (function), revLicenseType (function), scriptLimits (function),
+revLicenseType (function), scriptLimits (function),
 development environment (glossary), return (glossary),
 standalone application (glossary)
 

--- a/docs/dictionary/function/ln.lcdoc
+++ b/docs/dictionary/function/ln.lcdoc
@@ -43,8 +43,7 @@ To find the logarithm of a number in any base, use the following
 function: 
 
     function logarithm theBase,theNumber
-    return ln(theNumber)/ln(theBase)
-
+        return ln(theNumber)/ln(theBase)
     end logarithm
 
 

--- a/docs/dictionary/keyword/line.lcdoc
+++ b/docs/dictionary/keyword/line.lcdoc
@@ -5,10 +5,10 @@ Type: keyword
 Syntax: line
 
 Summary:
-Designates a return-<delimit|delimited> <string> as part of a <chunk
-expression>. It also designates the <paint tool> used to draw line
-shapes and specifies, through the <style> <property>, that a <graphic>
-is a line.
+Designates a return-<delimit|delimited> <string> as part of a 
+<chunk expression>. It also designates the <paint tool> used to draw 
+line shapes and specifies, through the <style> <property>, that a 
+<graphic> is a line.
 
 Introduced: 1.0
 
@@ -44,8 +44,8 @@ Setting the <style> of a <graphic(keyword)> to "line" makes the
 unlike painted lines, can be changed and reshaped: use the <points>
 <property> to change the line's angle and position.
 
->*Note:* To avoid script errors, enclose the word "line" in <double
-> quote|double quotes> when you use it to indicate a
+>*Note:* To avoid script errors, enclose the word "line" in 
+> <double quote|double quotes> when you use it to indicate a
 > <graphic(object)|graphic's> <style>. This prevents <LiveCode> from
 > getting confused about whether you mean the line style, or the
 > contents of a line in a <container>.

--- a/docs/dictionary/property/listBehavior.lcdoc
+++ b/docs/dictionary/property/listBehavior.lcdoc
@@ -7,8 +7,8 @@ Type: property
 Syntax: set the listBehavior of <field> to {true | false}
 
 Summary:
-Specifies whether a <lock|locked> <field> behaves as a <list
-field|clickable list>.
+Specifies whether a <lock|locked> <field> behaves as a 
+<list field|clickable list>.
 
 Associations: field
 

--- a/docs/dictionary/property/listStyle.lcdoc
+++ b/docs/dictionary/property/listStyle.lcdoc
@@ -20,7 +20,7 @@ set the listStyle of line 1 of field 1 to "disc"
 
 Parameters:
 style (enum):
-The style of bullet to use for the line of text in the list. One of:
+The style of bullet to use for the line of text in the list.
 
 -   "disc": A solid round bullet.
 -   "circle": A ring.

--- a/docs/glossary/l/LiveCode-Builder-extension.lcdoc
+++ b/docs/glossary/l/LiveCode-Builder-extension.lcdoc
@@ -5,9 +5,9 @@ Synonyms: lcb extension
 Type: glossary
 
 Description:
-An extension to the LiveCode environment written in the <LiveCode
-Builder language>. The extension can be either a <widget> or a <library
-extension|library>. 
+An extension to the LiveCode environment written in the 
+<LiveCode Builder language>. The extension can be either a <widget> or 
+a <library extension|library>. 
 
 A <widget> when loaded is a <control> that can be created on the <stack>
 by dragging it out from the tools palette, or using the <create widget>

--- a/docs/glossary/l/LiveCode-Builder-language.lcdoc
+++ b/docs/glossary/l/LiveCode-Builder-language.lcdoc
@@ -5,48 +5,48 @@ Synonyms: livecode builder language, lcb, lcb language, livecode builder
 Type: glossary
 
 Description:
-<LiveCode Builder> is a variant of the current <LiveCode> scripting
-language which has been designed for 'systems' building. It is
+**LiveCode Builder** is a variant of the current <LiveCode|LiveCode
+scripting language> which has been designed for 'systems' building. It is
 statically compiled with optional static typing and direct foreign code
 interconnect (allowing easy access to APIs written in other languages).
 The compiled bytecode can then be packaged together with any required
 resources (icons, documentation, images, etc) into a .lce extension
 package. 
 
-Unlike most languages, <LiveCode Builder> has been designed around the
+Unlike most languages, **LiveCode Builder** has been designed around the
 idea of extensible syntax. Indeed, the core language is very small -
 comprising declarations and control structures - with the majority of
 the language syntax and functionality being defined in modules.
 
 The syntax will be familiar to anyone who has coded with
-<LiveCode|LiveCode Script>, however <LiveCode Builder> is a great deal
+<LiveCode|LiveCode Script>, however **LiveCode Builder** is a great deal
 more strict - the reason being it is intended that it will eventually be
 compilable to machine code with the performance and efficiency you'd
 expect from any 'traditional' programming language. Indeed, over time we
 hope to move the majority of implementation of the whole LiveCode system
-over to being written in <LiveCode Builder>.
+over to being written in **LiveCode Builder**.
 
-There are two types of extensions which can be written in <LCB>:
+There are two types of extensions which can be written in LCB:
 <widget|widgets> and <library extension|libraries>. All installed
 <LiveCode Builder extension|extensions> appear in the new Extension
 Manager stack, which can be opened from the Tools menu.
 
 An <library extension|LCB library> is a new way of adding functions to
-the <LiveCode> <message path>. Public handlers in loaded <library
-extension|LCB libraries> are available to call from <LiveCode Script>.
+the <LiveCode> <message path>. Public handlers in loaded 
+<library extension|LCB libraries> are available to call from 
+<LiveCode|LiveCode Script>.
 
 A <widget> is a new type of custom <control> which, once compiled and
 packaged, can be loaded into the <IDE>. Using the <widget> is no
-different from any of the classic <LiveCode> controls you've been used
+different from any of the classic LiveCode controls you've been used
 to. Simply drag it onto a <stack> and start interacting with it as you
 would any another <control>.
 
-For detailed information about using <LCB>, please consult the Extending
-LiveCode guide, and explore the <LCB> API by selecting <LiveCode
-Builder> from the API dropdown menu.
+For detailed information about using LCB, please consult the Extending
+LiveCode guide, and explore the LCB API by selecting 
+**LiveCode Builder** from the API dropdown menu.
 
-References: widget (glossary), LiveCode (glossary),
-LiveCode Builder extension (glossary), library extension (glossary),
-control (glossary), stack (glossary), IDE (glossary),
-message path (glossary)
+References: LiveCode (glossary), LiveCode Builder extension (glossary), 
+library extension (glossary), control (glossary), stack (glossary), 
+IDE (glossary), message path (glossary), widget (object)
 

--- a/docs/glossary/l/LiveCode-custom-library.lcdoc
+++ b/docs/glossary/l/LiveCode-custom-library.lcdoc
@@ -19,7 +19,7 @@ LiveCode <development environment>.
 > to include the <library> in your <standalone application|standalone>.
 
 References: property (glossary), custom function (glossary),
-libraries (glossary), Standalone Application Settings (glossary),
+Standalone Application Settings (glossary), 
 development environment (glossary), standalone application (glossary),
 command (glossary), stack (glossary), library (library)
 


### PR DESCRIPTION
unction/licenced.lcdoc - Removed non-existent reference.
keyword/line.lcdoc - Fixed broken links
property/listBehavior.lcdoc - Fixed broken link
property/listStyle.lcdoc - Removed redundant text; “One of the following:” gets inserted before the list anyway.
glossary/l/LiveCode-Builder-extension.lcdoc - Fixed broken links.
glossary/l/Livecode-Builder-language.lcdoc - Gave bold markup to`LiveCode Builder`, a synonym of this entry, where it had been put in angle brackets - won’t display at all as is, won’t display as bold just by putting `LiveCode Builder language|` at the beginning. Changed `widget (glossary)`, a synonym of `control (glossary)`, to `widget (object)`.
glossary/l/LiveCode-custom-library.lcdoc - Removed non-existent reference.
function/ln.lcdoc - Reformatted code block
command/load.lcdoc - Removed self reference and non-existent reference. Changed case of `URL` reference owing to case-sensitivity issue affecting the rest of the entry.
command/load-extension.lcdoc - Fixed broken links.