### PR TITLE
[[ Bug 21246 ]] Fix crash on windows clipboard

### DIFF
--- a/docs/notes/bugfix-21246.md
+++ b/docs/notes/bugfix-21246.md
@@ -1,0 +1,1 @@
+# Fix crash using windows clipboard

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -169,28 +169,10 @@ MCWin32RawClipboardItem* MCWin32RawClipboardCommon::CreateNewItem()
 	if (m_item != NULL)
 		return NULL;
 
-	// clear the clipboard and take ownership
-	HRESULT t_result = OleSetClipboard(nullptr);
-
-	// Clipboard is now clean
-	if (t_result != S_OK)
-	{
-		return nullptr;
-	}
-
-	// Fetch the current clipboard IDataObject
-	IDataObject* t_contents;
-	t_result = OleGetClipboard(&t_contents);
-
-	// Clipboard is now clean
-	if (t_result != S_OK)
-	{
-		return nullptr;
-	}
-
 	// Create a new data item
-	m_item = new (nothrow) MCWin32RawClipboardItem(this, t_contents);
+	m_item = new (nothrow) MCWin32RawClipboardItem(this);
 	m_item->Retain();
+	
 	return m_item;
 }
 
@@ -810,6 +792,18 @@ MCWin32RawClipboardItem::MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_cl
 {
 	if (m_object != nil)
 		m_object->AddRef();
+}
+
+MCWin32RawClipboardItem::MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_clipboard) :
+	MCRawClipboardItem(),
+	m_clipboard(p_clipboard),
+	m_object_is_external(false),
+	m_object(nullptr),
+	m_reps()
+{
+	// create data object and push it to the clipboard
+	IDataObject * t_contents = GetDataObject();
+	OleSetClipboard(t_contents);
 }
 
 MCWin32RawClipboardItem::~MCWin32RawClipboardItem()

--- a/engine/src/w32-clipboard.h
+++ b/engine/src/w32-clipboard.h
@@ -98,6 +98,7 @@ private:
 	friend class MCWin32RawClipboardCommon;
 	friend class MCWin32RawClipboard;
 	MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_parent, IDataObject* p_external_data);
+	MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_parent);
 	~MCWin32RawClipboardItem();
 
 	// Ensures that the representations have been loaded if the data is from


### PR DESCRIPTION
The patch for Bug 20678 caused a number of regressions on the windows
clipboard. Under certain circumstances this would cause a crash, however,
it also caused a failure to ush data to the clipboard. This patch reverts
the changes in that patch and fixes Bug 20678 in a way that does not cause
those regressions.