### PR TITLE
[[ Bug 21051 ]] Handle wchar_t size differences for ODBC

### DIFF
--- a/docs/notes/bugfix-21051.md
+++ b/docs/notes/bugfix-21051.md
@@ -1,0 +1,1 @@
+# Ensure revDataFromQuery on an ODBC database does not return incomplete unicode strings

--- a/revdb/src/dbodbc.h
+++ b/revdb/src/dbodbc.h
@@ -98,7 +98,7 @@ public:
 	int getConnectionType(void) { return -1; }
 protected:
 	void SetError(SQLHSTMT tcursor);
-	Bool BindVariables(SQLHSTMT tcursor, DBString *args, int numargs, int *paramsizes, PlaceholderMap *p_placeholder_map);
+	Bool BindVariables(SQLHSTMT tcursor, DBString *args, int numargs, SQLLEN *paramsizes, PlaceholderMap *p_placeholder_map);
 	bool ExecuteQuery(char *p_query, DBString *p_arguments, int p_argument_count, SQLHSTMT &p_statement, SQLRETURN &p_result);
 	bool handleDataAtExecutionParameters(SQLHSTMT p_statement);
 	bool useDataAtExecution(void);


### PR DESCRIPTION
This patch works around `wchar_t` size difference on unix machines which
was causing unicode results from ODBC databases to be truncated after the
first character due to null bytes.