### PR TITLE
[Dictionary] loadedExtensions to lookAndFeel

### DIFF
--- a/docs/dictionary/command/local.lcdoc
+++ b/docs/dictionary/command/local.lcdoc
@@ -43,9 +43,9 @@ Use the <local> <command> to define a <local variable> for a <handler>,
 or to define a <script local variable> that is shared between all the
 <handler|handlers> in a <script>.
 
-The <local> <declare|declaration> is optional. You can use a <local
-variable> without <declare|declaring> it first in the <handler>. In this
-case, the <local variable> can be used only within that <handler>.
+The <local> <declare|declaration> is optional. You can use a 
+<local variable> without <declare|declaring> it first in the <handler>. 
+In this case, the <local variable> can be used only within that <handler>.
 
 The <local> <command> can appear anywhere in a <handler>. However,
 <variable> <declare|declarations> are usually placed at the beginning of
@@ -53,8 +53,8 @@ a <handler>. This makes them easier to find and as local variables are
 created at the point in the script where they are declared it will
 ensure the variable isn't used before the declaration.
 
-You can also use the <local> <command> to create a <script local
-variable>. <script local variable|Script local variables> can be used by
+You can also use the <local> <command> to create a <script local variable>. 
+<script local variable|Script local variables> can be used by
 any <handler> in that <script>, without needing to be <declare|declared>
 in the <handler> itself, and their <value|values> are maintained from
 <handler> to <handler>. You create a <script local variable> by using

--- a/docs/dictionary/command/lock-error-dialogs.lcdoc
+++ b/docs/dictionary/command/lock-error-dialogs.lcdoc
@@ -21,9 +21,9 @@ Example:
 if the environment is among the lines of userEnv then lock error dialogs
 
 Description:
-Use the <lock error dialogs> <command> to <handle> <execution
-error|execution errors> in a custom handler, rather than allowing
-LiveCode to display the standard error window.
+Use the <lock error dialogs> <command> to <handle> 
+<execution error|execution errors> in a custom handler, rather than 
+allowing LiveCode to display the standard error window.
 
 The <lock error dialogs> <command> sets the <lockErrorDialogs>
 <property> to true.

--- a/docs/dictionary/command/lock-messages.lcdoc
+++ b/docs/dictionary/command/lock-messages.lcdoc
@@ -5,9 +5,10 @@ Type: command
 Syntax: lock messages
 
 Summary:
-Sets the <lockMessages> <property> to true, preventing <setProp
-trigger|setProp triggers>, <getProp call|getProp calls>, and certain
-<message|messages> from being sent.
+Sets the <lockMessages> <property> to true, preventing 
+<setProp trigger|setProp triggers>, 
+<getProp call|getProp calls>, and certain <message|messages> from 
+being sent.
 
 Introduced: 1.0
 

--- a/docs/dictionary/function/loadedExtensions.lcdoc
+++ b/docs/dictionary/function/loadedExtensions.lcdoc
@@ -19,8 +19,7 @@ Example:
 put the loadedExtensions
 
 Example:
-if "com.livecode.extensions.livecode.switchButton" is among the lines \
-      of the loadedExtensions then
+if "com.livecode.extensions.livecode.switchButton" is among the lines of the loadedExtensions then
     create widget as "com.livecode.extensions.livecode.switchButton"
 end if    
 
@@ -29,11 +28,11 @@ The <loadedExtensions> <function> <return|returns> a list of the loaded
 <LiveCode Builder extension|extensions>, one per <line>.
 
 Description:
-Use the <loadedExtensions> <function> to find out which <LiveCode
-Builder extension|extensions> are loaded, in order to determine (for
-<library extension|libraries>) if its public handlers are available in
-the message path, or (for <widget|widgets>) if it is available to create
-with the <create widget> <command>.
+Use the <loadedExtensions> <function> to find out which 
+<LiveCode Builder extension|extensions> are loaded, in order to determine 
+(for <library extension|libraries>) if its public handlers are available 
+in the message path, or (for <widget|widgets>) if it is available to 
+create with the <create widget> <command>.
 
 Each line of the list returned by the <loadedExtensions> <function> is
 the <kind> of the corresponding <LiveCode Builder extension|extension>.
@@ -41,8 +40,8 @@ the <kind> of the corresponding <LiveCode Builder extension|extension>.
 References: create widget (command), load extension (command),
 unload extension (command), function (glossary), return (glossary),
 LiveCode Builder extension (glossary),
-library LiveCode Builder extension (glossary), line (keyword),
-widget (object), kind (property)
+LiveCode Builder extension (glossary), command (glossary), 
+line (keyword), widget (object), kind (property)
 
 Tags: extensions
 

--- a/docs/dictionary/function/localNames.lcdoc
+++ b/docs/dictionary/function/localNames.lcdoc
@@ -25,10 +25,9 @@ Returns:
 The <localNames> <function> <return|returns> a <value> consisting of
 three lines:
 
-        1. Parameters passed to the current handler
-        2. Local variables created in the current handler
-        3. Local variables created in the current script but outside all
-           handlers. 
+1. Parameters passed to the current handler
+2. Local variables created in the current handler
+3. Local variables created in the current script but outside all handlers. 
 
 
 Description:

--- a/docs/dictionary/function/longFilePath.lcdoc
+++ b/docs/dictionary/function/longFilePath.lcdoc
@@ -7,8 +7,8 @@ Syntax: the longFilePath of <filePath>
 Syntax: longFilePath(<filePath>)
 
 Summary:
-<return|Returns> the long-format equivalent of an 8.3-format <file
-path>. 
+<return|Returns> the long-format equivalent of an 8.3-format 
+<file path>. 
 
 Introduced: 1.1
 

--- a/docs/dictionary/property/location.lcdoc
+++ b/docs/dictionary/property/location.lcdoc
@@ -39,11 +39,12 @@ Description:
 Use the <location> <property> to move an <object(glossary)> without
 resizing it, or to find out where an <object(glossary)> is.
 
-The <location> of a <stack> is in <absolute (screen)
-coordinates(glossary)>. The first <item> of a <card|card's> <location>
-<property> is equal to the width of stack div 2; the second item is is
-equal to the height of stack div 2. The <location> of a <group> or
-<control> is in <relative (window) coordinates(glossary)>.
+The <location> of a <stack> is in 
+<absolute coordinates|absolute (screen) coordinates>. The first <item> 
+of a  <card|card's> <location> <property> is equal to the width of 
+stack div 2; the second item is equal to the height of stack div 2. The 
+<location> of a <group> or <control> is in <relative coordinates|
+relative (window) coordinates>.
 
 In window coordinates, the point 0,0 is at the top left of the stack
 window. In screen coordinates, the point 0,0 is at the top left of the

--- a/docs/dictionary/property/lockMessages.lcdoc
+++ b/docs/dictionary/property/lockMessages.lcdoc
@@ -5,9 +5,9 @@ Type: property
 Syntax: set the lockMessages to {true | false}
 
 Summary:
-Specifies whether <setProp trigger|setProp triggers>, <getProp
-call|getProp calls>, and certain <built-in message|built-in messages>
-are sent automatically.
+Specifies whether <setProp trigger|setProp triggers>, 
+<getProp call|getProp calls>, and certain 
+<built-in message|built-in messages> are sent automatically.
 
 Introduced: 1.0
 
@@ -25,7 +25,7 @@ to false when no <handler|handlers> are <execute|executing>.
 
 Description:
 Use the <lockMessages> <property> to prevent unwanted <handler|handlers>
-from being <trigger|triggered>,or to speed up operations when
+from being <trigger|triggered>, or to speed up operations when
 <handler|handlers> that are normally run automatically are not needed.
 
 If the <lockMessages> <property> is set to true, the following are not sent:  

--- a/docs/dictionary/property/lockMoves.lcdoc
+++ b/docs/dictionary/property/lockMoves.lcdoc
@@ -34,12 +34,11 @@ moving, then set the <lockMoves> to false to begin the motion, as in the
 following example:
 
     on mouseUp
-    set the lockMoves to true
-    move button 1 to 300,200 in 2 seconds -- doesn't move yet
-    move field 2 to 0,0 in 2 seconds -- doesn't move yet
-    move graphic 3 to 0,400 in 2 seconds -- doesn't move yet
-    set the lockMoves to false -- all three objects start moving
-
+        set the lockMoves to true
+        move button 1 to 300,200 in 2 seconds -- doesn't move yet
+        move field 2 to 0,0 in 2 seconds -- doesn't move yet
+        move graphic 3 to 0,400 in 2 seconds -- doesn't move yet
+        set the lockMoves to false -- all three objects start moving
     end mouseUp
 
 

--- a/docs/dictionary/property/lockRecent.lcdoc
+++ b/docs/dictionary/property/lockRecent.lcdoc
@@ -5,8 +5,9 @@ Type: property
 Syntax: set the lockRecent to {true | false}
 
 Summary:
-Specifies whether visited <card|cards> are added to the <recent
-cards|recent cards list> used by go back, go forth, and go recent.
+Specifies whether visited <card|cards> are added to the 
+<recent cards|recent cards list> used by go back, go forth, and go 
+recent.
 
 Introduced: 1.0
 

--- a/docs/dictionary/property/lockScreen.lcdoc
+++ b/docs/dictionary/property/lockScreen.lcdoc
@@ -55,19 +55,17 @@ following pair of handlers draws everything while the display is still
 locked: 
 
     on mouseUp
-    lock screen    -- first lock
-    drawStuff      -- gets locked again and unlocked in drawStuff
-    show image "Sprite"
-    unlock screen  -- now unlocked - 2 locks balanced by 2 unlocks
-
+        lock screen    -- first lock
+        drawStuff      -- gets locked again and unlocked in drawStuff
+        show image "Sprite"
+        unlock screen  -- now unlocked - 2 locks balanced by 2 unlocks
     end mouseUp
 
 
     on drawStuff
-    lock screen    -- screen now locked twice
-    show field "Notify"
-    unlock screen  -- not unlocked yet - locked twice, unlocked once
-
+        lock screen    -- screen now locked twice
+        show field "Notify"
+        unlock screen  -- not unlocked yet - locked twice, unlocked once
     end drawStuff
 
 

--- a/docs/dictionary/property/longWindowTitles.lcdoc
+++ b/docs/dictionary/property/longWindowTitles.lcdoc
@@ -14,15 +14,15 @@ Platforms: desktop, server
 
 Description:
 In HyperCard, the <longWindowTitles> <property> determines whether a
-<stack window|stack window's> <title bar> shows the <absolute file
-path|full path> to a <stack>, or only the <stack|stack's> name. In
-LiveCode, the <stack|stack's> <label> <property> is shown as the window
-title; if the <label> is empty, the short version of the <stack|stack's>
-<name> <property> is shown.
+<stack window|stack window's> <title bar> shows the 
+<absolute file path|full path> to a <stack>, or only the <stack|stack's>
+name. In LiveCode, the <stack|stack's> <label> <property> is shown as the 
+window title; if the <label> is empty, the short version of the 
+<stack|stack's> <name> <property> is shown.
 
 A handler can set the <longWindowTitles> without causing a <error|script
 error>, but the actual window title is not changed. The <default> value
-is false<a/>.
+is false.
 
 References: property (glossary), LiveCode (glossary), error (glossary),
 stack window (glossary), absolute file path (glossary),

--- a/docs/dictionary/property/lookAndFeel.lcdoc
+++ b/docs/dictionary/property/lookAndFeel.lcdoc
@@ -36,9 +36,9 @@ on a <platform> other than the one you're developing on.
 
 The <lookAndFeel> <property> determines the <appearance> and <behavior>
 of <scrollbar|scrollbars>, <object(glossary)> borders,
-<checkbox|checkboxes> and <radio button|radio buttons>, and <button
-menu|button menus>. It also changes the <appearance> of the <active
-(focused) control(glossary)>.
+<checkbox|checkboxes> and <radio button|radio buttons>, and 
+<button menu|button menus>. It also changes the <appearance> of the 
+<active control|active (focused) control>.
 
 However, changing this property does not provide an exact representation
 of the appearance and behavior of the stack on the target platform. For
@@ -75,8 +75,8 @@ property (glossary), checkbox (glossary), behavior (glossary),
 Mac OS (glossary), user interface (glossary), OS X (glossary),
 appearance (glossary), Unix (glossary), radio button (glossary),
 active control (glossary), button menu (glossary), object (glossary),
-word (keyword), default (keyword), system (keyword), scrollbar (object),
-stack (object), control (object), emacsKeyBindings (property),
+control (glossary), word (keyword), default (keyword), system (keyword), 
+scrollbar (object), stack (object), emacsKeyBindings (property),
 activatePalettes (property), hiliteBorder (property)
 
 Tags: ui


### PR DESCRIPTION
function/loadedExtensions.lcdoc - Fixed broken links, fixed broken references. Added a reference to fix something else.
command/local.lcdoc - Fixed broken link, which had been causing half the entry to not appear.
function/localNames.lcdoc - Removed indentation from ordered list to have it not instead display as code.
property/location.lcdoc - Fixed grammatical error. Fixed broken link.
command/lock-error-dialogs.lcdoc - Fixed broken link
command/lock-messages.lcdoc - Fixed broken link
property/lockMessages.lcdoc - Fixed broken link
property/lockMoves.lcdoc - Reformatted code block
property/lockRecent.lcdoc - Fixed broken link
property/lockScreen.lcdoc - Reformatted code block
function/longFilePath.lcdoc - Fixed broken link
property/longWindowTitles.lcdoc - Fixed broken link
property/lookAndFeel.lcdoc - Fixed broken link, changed `control (object)` to `control (glossary)`