### PR TITLE
[Dictionary] lossless compression to md5Digest

### DIFF
--- a/docs/dictionary/function/macToISO.lcdoc
+++ b/docs/dictionary/function/macToISO.lcdoc
@@ -7,9 +7,9 @@ Syntax: the macToISO of <macString>
 Syntax: macToISO(<macString>)
 
 Summary:
-<return|Returns> the equivalent of a <Mac OS> <character
-set|character-set> <string>, translated into the Windows Latin 1<
-character set(glossary)>.
+<return|Returns> the equivalent of a <Mac OS> 
+<character set|character-set> <string>, translated into the Windows 
+Latin 1 <character set(glossary)>.
 
 Introduced: 1.0
 

--- a/docs/dictionary/function/mainStacks.lcdoc
+++ b/docs/dictionary/function/mainStacks.lcdoc
@@ -7,8 +7,8 @@ Syntax: the mainStacks
 Syntax: mainStacks()
 
 Summary:
-<return|Returns> a list of the <main stack|main stacks> that are <loaded
-into memory>.
+<return|Returns> a list of the <main stack|main stacks> that are 
+<loaded into memory>.
 
 Introduced: 1.0
 

--- a/docs/dictionary/function/md5Digest.lcdoc
+++ b/docs/dictionary/function/md5Digest.lcdoc
@@ -26,8 +26,8 @@ Parameters:
 message(data): A <binary data> string.
 
 Returns:
-Returns the message digest of the <message> as a 16 <byte> <binary
-data> string.
+Returns the message digest of the <message> as a 16 <byte> 
+<binary data> string.
 
 Description:
 Compute a message digest of <message> using the MD5 cryptographic

--- a/docs/dictionary/keyword/LPT1colon.lcdoc
+++ b/docs/dictionary/keyword/LPT1colon.lcdoc
@@ -5,9 +5,9 @@ Type: keyword
 Syntax: LPT1:
 
 Summary:
-Used with the <open file>, <read from file>, <write to file>, and <close
-file> <command|commands> to specify the line printer (parallel) <port>
-on <Windows|Windows systems>.
+Used with the <open file>, <read from file>, <write to file>, and 
+<close file> <command|commands> to specify the line printer (parallel) 
+<port> on <Windows|Windows systems>.
 
 Introduced: 2.0
 

--- a/docs/dictionary/message/mainStackChanged.lcdoc
+++ b/docs/dictionary/message/mainStackChanged.lcdoc
@@ -34,9 +34,9 @@ the new stack file. This means that (if the substack does not trap the
 message) the <mainStackChanged> message is received by the new main
 stack, and can be handled in the main stack's script.
 
-The <mainStackChanged> <message> is used by the LiveCode <development
-environment>, so if you <handle> this <message>, be sure to <pass> it at
-the end of the <handler>.
+The <mainStackChanged> <message> is used by the LiveCode 
+<development environment>, so if you <handle> this <message>, be sure to 
+<pass> it at the end of the <handler>.
 
 References: pass (control structure), substack (glossary),
 stack file (glossary), message (glossary), handler (glossary),

--- a/docs/dictionary/property/margins.lcdoc
+++ b/docs/dictionary/property/margins.lcdoc
@@ -46,9 +46,9 @@ to that number of pixels. If four integers are provided, the object's
 top, left, bottom, and right margins are set to each one respectively:
 
 * item 1 of the <margins> <property> is equal to the leftMargin
-*  2 of the <margins> is equal to the topMargin
-*  3 of the <margins> is equal to the rightMargin
-*  4 is equal to the bottomMargin
+* item 2 of the <margins> is equal to the topMargin
+* item 3 is equal to the rightMargin
+* item 4 is equal to the bottomMargin
 
 
 If the lookAndFeel is set to "Motif", <control(object)|controls> require
@@ -70,11 +70,11 @@ The <margins> setting of an <image>, <player>, or <scrollbar> has no
 effect. 
 
 References: group (command), object (glossary), property (glossary),
-pixel (glossary), group (glossary), Unix (glossary),
+pixel (glossary), group (glossary), Unix (glossary), control (glossary)
 active control (glossary), non-negative (glossary), integer (glossary),
 image (keyword), integer (keyword), button (keyword), scrollbar (keyword),
 graphic (keyword), player (keyword), field (keyword), control (keyword),
-field (object), control (object), topMargin (property), pixels (property),
+field (object), topMargin (property), pixels (property),
 formattedWidth (property), textAlign (property),
 formattedHeight (property), wideMargins (property),
 boundingRect (property), rectangle (property), rightMargin (property),

--- a/docs/glossary/l/lossless-compression.lcdoc
+++ b/docs/glossary/l/lossless-compression.lcdoc
@@ -6,10 +6,10 @@ Type: glossary
 
 Description:
 A type of <compress|compression> technique, used for pictures, that
-retains all the picture's original information. Unlike <lossy
-compression> methods, lossless compression allows the picture to be
-repeatedly compressed and uncompressed without reducing the quality of
-the image.
+retains all the picture's original information. Unlike 
+<lossy compression> methods, lossless compression allows the picture to 
+be repeatedly compressed and uncompressed without reducing the quality 
+of the image.
 
 References: compress (glossary), lossy compression (glossary)
 

--- a/docs/glossary/m/MacBinary.lcdoc
+++ b/docs/glossary/m/MacBinary.lcdoc
@@ -6,9 +6,9 @@ Type: glossary
 
 Description:
 A <format> for transferring a <Mac OS> <file> from one system to
-another. The MacBinary <format> preserves the <data fork> and <resource
-fork> of the file, as well as additional information such as the
-<file|file's> <type signature> and <creator signature>.
+another. The MacBinary <format> preserves the <data fork> and 
+<resource fork> of the file, as well as additional information such 
+as the <file|file's> <type signature> and <creator signature>.
 
 References: file (glossary), type signature (glossary),
 resource fork (glossary), format (glossary), data fork (glossary),

--- a/docs/glossary/m/master-profile.lcdoc
+++ b/docs/glossary/m/master-profile.lcdoc
@@ -9,8 +9,8 @@ Associations: profile library
 Description:
 The default <property profile> of an <object(glossary)>. The master
 profile holds the <default> settings for the <object|object's>
-<property|properties>, which are used if no other <property
-profile|profile> is active.
+<property|properties>, which are used if no other 
+<property profile|profile> is active.
 
 References: default (glossary), property (glossary),
 property profile (glossary), object (glossary)


### PR DESCRIPTION
glossary/l/lossless-compression.lcdoc - Fixed broken link.
keyword/LPT1colon.lcdoc - Fixed broken link
glossary/m/MacBinary.lcdoc - Fixed broken link
function/macToISO.lcdoc - Fixed broken links
message/mainStackChanged.lcdoc - Fixed broken link
function/mainStacks.lcdoc - Fixed broken link
property/margins.lcdoc - Changed `control (object)` to `control (glossary)`. Added the word `item` to each bullet point on the list of `<margins>` items as the spacing suggested they simply disappeared at some point.
glossary/m/master-profile.lcdoc - Fixed broken link
function/md5Digest - Fixed broken link