### PR TITLE
[[ Bug 15443 ]] Don't clobber macroman casing tables on mac

### DIFF
--- a/docs/notes/bugfix-15443.md
+++ b/docs/notes/bugfix-15443.md
@@ -1,0 +1,1 @@
+# Ensure caseless comparison of native strings works on Mac 

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -2811,25 +2811,6 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         
         _CurrentRuneLocale->__runetype[202] = _CurrentRuneLocale->__runetype[201];
         
-        // Initialize our case mapping tables. We always use the MacRoman locale.
-        CFStringRef t_raw;
-        CFMutableStringRef t_lower, t_upper;
-        CFIndex t_ignored;
-        MCuppercasingtable = new (nothrow) uint8_t[256];
-        MClowercasingtable = new (nothrow) uint8_t[256];
-        for(uindex_t i = 0; i < 256; ++i)
-            MCuppercasingtable[i] = uint8_t(i);
-        t_raw = CFStringCreateWithBytes(NULL, MCuppercasingtable, 256, kCFStringEncodingMacRoman, false);
-        t_lower = CFStringCreateMutableCopy(NULL, 0, t_raw);
-        t_upper = CFStringCreateMutableCopy(NULL, 0, t_raw);
-        CFStringLowercase(t_lower, NULL);
-        CFStringUppercase(t_upper, NULL);
-        CFStringGetBytes(t_lower, CFRangeMake(0, 256), kCFStringEncodingMacRoman, '?', false, MClowercasingtable, 256, &t_ignored);
-        CFStringGetBytes(t_upper, CFRangeMake(0, 256), kCFStringEncodingMacRoman, '?', false, MCuppercasingtable, 256, &t_ignored);
-        CFRelease(t_raw);
-        CFRelease(t_lower);
-        CFRelease(t_upper);
-        
         MCinfinity = HUGE_VAL;
         
         // SN-2014-10-08: [[ YosemiteUpdate ]] gestaltSystemVersion stops to 9 after any Minor/Bugfix >= 10
@@ -2920,6 +2901,25 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
             setlinebuf(stderr);
         }
 #endif // _MAC_SERVER
+
+        // Initialize our case mapping tables. We always use the MacRoman locale.
+        CFStringRef t_raw;
+        CFMutableStringRef t_lower, t_upper;
+        CFIndex t_ignored;
+        MCuppercasingtable = new (nothrow) uint8_t[256];
+        MClowercasingtable = new (nothrow) uint8_t[256];
+        for(uindex_t i = 0; i < 256; ++i)
+            MCuppercasingtable[i] = uint8_t(i);
+        t_raw = CFStringCreateWithBytes(NULL, MCuppercasingtable, 256, kCFStringEncodingMacRoman, false);
+        t_lower = CFStringCreateMutableCopy(NULL, 0, t_raw);
+        t_upper = CFStringCreateMutableCopy(NULL, 0, t_raw);
+        CFStringLowercase(t_lower, NULL);
+        CFStringUppercase(t_upper, NULL);
+        CFStringGetBytes(t_lower, CFRangeMake(0, 256), kCFStringEncodingMacRoman, '?', false, MClowercasingtable, 256, &t_ignored);
+        CFStringGetBytes(t_upper, CFRangeMake(0, 256), kCFStringEncodingMacRoman, '?', false, MCuppercasingtable, 256, &t_ignored);
+        CFRelease(t_raw);
+        CFRelease(t_lower);
+        CFRelease(t_upper);
         
         return true;
     }

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -233,18 +233,6 @@ void MCS_common_init(void)
     MCsystem -> SetErrno(errno);
 	
 	MCinfinity = HUGE_VAL;
-
-	// MW-2013-10-08: [[ Bug 11259 ]] We use our own tables on linux since
-	//   we use a fixed locale which isn't available on all systems.
-#if !defined(_LINUX_SERVER) && !defined(_LINUX_DESKTOP) && !defined(_WINDOWS_DESKTOP) && !defined(_WINDOWS_SERVER) && !defined(__EMSCRIPTEN__)
-	MCuppercasingtable = new (nothrow) uint1[256];
-	for(uint4 i = 0; i < 256; ++i)
-		MCuppercasingtable[i] = (uint1)toupper((uint1)i);
-	
-	MClowercasingtable = new (nothrow) uint1[256];
-	for(uint4 i = 0; i < 256; ++i)
-		MClowercasingtable[i] = (uint1)tolower((uint1)i);
-#endif
     
 #if defined(_IOS_MOBILE) || defined(_ANDROID_MOBILE)
     MCHookRegister(kMCHookGlobalHandlers, &s_global_handlers_desc);

--- a/tests/lcs/core/strings/filter.livecodescript
+++ b/tests/lcs/core/strings/filter.livecodescript
@@ -216,3 +216,10 @@ on TestBug16584
 	__testBug16584 true, "apple"
 	__testBug16584 false, "뤻뤼뤼뤾룜"	
 end TestBug16584
+
+on TestBug15443
+	local tTest
+	put "NÖJE" into tTest
+	filter tTest with "nöje"
+	TestAssert "filter macroman native bug 15443", tTest is not empty
+end TestBug15443


### PR DESCRIPTION
MCS_tolowercase and MCS_touppercase were returning incorrect values
for characters in the upper half of the native char set on mac due
to having the macroman casing tables clobbered by the utf-16 version.

The casing code on each platform is sufficiently different (it is
only shared by android and iOS, and linux and emscripten) that there
doesn't seem to be much point keeping it in MCS_common_init - each
platform was doing what it needed in MCSystemInterface::Initialize
anyway.

This patch also moves the macroman casing table construction outside
the #ifndef _MAC_SERVER block, as it is needed on Mac server.