### PR TITLE
[Dictionary] menubar to mobileClearTouches

### DIFF
--- a/docs/dictionary/command/mobileCancelAllLocalNotifications.lcdoc
+++ b/docs/dictionary/command/mobileCancelAllLocalNotifications.lcdoc
@@ -18,15 +18,15 @@ mobileCancelAllLocalNotifications
 
 Description:
 Use the <mobileCancelAllLocalNotifications> <command> to cancel all
-Local Notification with the operating system from within a <stack on iOS
-or Android>.
+Local Notification with the operating system from within a <stack> on iOS
+or Android.
 
 This command cancels all Local Notifications with the iOS operating
 sytem. 
 
 References: mobileCreateLocalNotification (command),
 mobileCancelLocalNotification (command), command (glossary),
-stack on iOS or Android (object)
+stack (object)
 
 Tags: networking
 

--- a/docs/dictionary/command/mobileClearTouches.lcdoc
+++ b/docs/dictionary/command/mobileClearTouches.lcdoc
@@ -30,20 +30,18 @@ the point of calling, all pending touch interactions are removed from
 the event queue.
 
 <mobileClearTouches> also cancels any existing mouse or touch sequences,
-meaning that you (and the engine) will not receive a mouseUp,
-mouseRelease, touchEnd or touchCancel message for any current
+meaning that you (and the engine) will not receive a <mouseUp>,
+<mouseRelease>, <touchEnd> or <touchCancel> message for any current
 interactions. 
 
 A good example of when this command might be useful is when playing an
 instructional sound:
 
-on tellUserInstructions
-
-    play specialFolderPath("engine") & slash & "Instruction_1.mp3"
-    wait until the sound is "done"
-    mobileClearTouches
-
-end tellUserInstructions
+    on tellUserInstructions
+        play specialFolderPath("engine") & slash & "Instruction_1.mp3"
+        wait until the sound is "done"
+        mobileClearTouches
+    end tellUserInstructions
 
 Here, if the <mobileClearTouches> call was not made, any touch events
 the user created while the sound was playing would be queued and then be

--- a/docs/dictionary/function/menuButton.lcdoc
+++ b/docs/dictionary/function/menuButton.lcdoc
@@ -29,9 +29,10 @@ The <menuButton> <function> <return|returns> the <name> <property> of
 the <button>. You create a stack menu by laying out the menu items as
 buttons in a stack window, then setting the menuName <property> of a
 <button> in another <stack> to the menu stack's name. Clicking the
-<button> displays the menu stack as a <menu>. If you use the same <stack
-menu> as the <menuName> of more than one <button>, the <menuButton>
-tells you which button the user clicked to display the <stack menu>.
+<button> displays the menu stack as a <menu>. If you use the same 
+<stack menu> as the <menuName> of more than one <button>, the 
+<menuButton> tells you which button the user clicked to display the 
+<stack menu>.
 
 For example, suppose you create a stack menu listing all your mailboxes,
 and display it when clicking both a "Delete" button and an "Open"

--- a/docs/dictionary/function/messageDigest.lcdoc
+++ b/docs/dictionary/function/messageDigest.lcdoc
@@ -33,7 +33,7 @@ Example:
 put textEncode("My very large data", "UTF-8") into tOriginal
 put messageDigest(tOriginal, "SHA3-256") into tChecksum
 -- ... some time later ...
-put textEncode("My very laRge data", "UTF-8") into tLoaded
+put textEncode("My very large data", "UTF-8") into tLoaded
 if messageDigest(tLoaded, "SHA3-256") is not tChecksum then
    put "The data changed and may be corrupted!"
 end if
@@ -87,7 +87,7 @@ function returns; for example, if you specify the "SHA3-256"
 | Name  | <digestType> | Notes
 | ----- | ------------ | -----
 | MD5   | "MD5"        | MD5 is cryptographically broken and unsuitable for further use.  Do not use for security-critical purposes, unless required for backward compatibility with existing systems.
-| SHA-1 | "SHA-1"      | SHA-1 has been severely weakened and there are practical approaches for generating collisions.  Do not use for security-critical purposes, enless required for backward compatibility with existing systems.
+| SHA-1 | "SHA-1"      | SHA-1 has been severely weakened and there are practical approaches for generating collisions.  Do not use for security-critical purposes, unless required for backward compatibility with existing systems.
 | SHA-2 | "SHA-224", "SHA-256", "SHA-384", "SHA-512" | SHA-2 has been found to have some minor weaknesses.
 | SHA-3 | "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512" | SHA-3 has no known weaknesses
 

--- a/docs/dictionary/keyword/middle.lcdoc
+++ b/docs/dictionary/keyword/middle.lcdoc
@@ -25,8 +25,8 @@ Example:
 select the middle line of field 22
 
 Description:
-Use the <middle> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <middle> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <middle> <keyword> can be used to specify any <object(glossary)>. It
 can also be used in a <chunk expression> to designate the middle <chunk>

--- a/docs/dictionary/keyword/minimize.lcdoc
+++ b/docs/dictionary/keyword/minimize.lcdoc
@@ -5,8 +5,8 @@ Type: keyword
 Syntax: minimize
 
 Summary:
-Used with the <decorations> <property> to indicate whether the <minimize
-button> appears in a window's <title bar>.
+Used with the <decorations> <property> to indicate whether the 
+<minimize button> appears in a window's <title bar>.
 
 Introduced: 1.0
 
@@ -24,7 +24,7 @@ on or off.
 Setting a stack's <decorations> <property> to <minimize> automatically
 includes 'title' in the value of the <decorations>, turning on the
 <systemWindow|window>'s <title bar>. The name on the <title bar> can be set 
- +using the <systemWindow|window>'s <label> property.
+using the <systemWindow|window>'s <label> property.
 
 On Windows systems, the <menu> <decorations|decoration> must be set along with
 <minimize> : you cannot use <minimize> without including <menu>.

--- a/docs/dictionary/message/menuPick.lcdoc
+++ b/docs/dictionary/message/menuPick.lcdoc
@@ -97,8 +97,8 @@ References: pulldown (command), property (glossary),
 tabbed button (glossary), menu item (glossary), handler (glossary),
 message (glossary), menu (glossary), button menu (glossary),
 parameter (glossary), character (keyword), menu (keyword),
-button (keyword), button (object), menuName (property),
-menuHistory (property)
+button (keyword), button (object), label (property), 
+ menuName (property), menuHistory (property)
 
 Tags: menus
 

--- a/docs/dictionary/property/menuHistory.lcdoc
+++ b/docs/dictionary/property/menuHistory.lcdoc
@@ -39,15 +39,15 @@ If the button's menuMode is "tabbed", setting its <menuHistory> also
 changes the active tab.
 
 If the button's menuMode is "option", setting its <menuHistory> changes
-the <label>. It also determines which <menu item> is under the <mouse
-pointer> when the <menu> next appears. Make sure to set the
+the <label>. It also determines which <menu item> is under the 
+<mouse pointer> when the <menu> next appears. Make sure to set the
 <menuHistory> <property> of an option menu whenever you change the
 current choice, so that the choice is under the <mouse pointer> when the
 user clicks the menu.
 
->*Note:* The effect of the <menuHistory> <property> in <cascading
-> menu|cascading menus> is ambiguous. Avoid setting or relying on the
-> <menuHistory> of a <cascading menu>.
+>*Note:* The effect of the <menuHistory> <property> in 
+> <cascading menu|cascading menus> is ambiguous. Avoid setting or relying 
+> on the <menuHistory> of a <cascading menu>.
 
 References: pulldown (command), menuButton (function),
 selectedText (function), property (glossary), message (glossary),

--- a/docs/dictionary/property/menuMode.lcdoc
+++ b/docs/dictionary/property/menuMode.lcdoc
@@ -41,13 +41,11 @@ You can also associate a stack with the button, using the <menuName>
   contents as a <menu item> in a normal pulldown menu. Use this
   <menuMode> for <button(object)|buttons> that are grouped into a
   <menubar>. 
-
-
-    Setting a button's <menuMode> to "pulldown" has the same result as
-    creating the equivalent <menu item|menu items> (as
-    <button(object)|buttons>) in a <stack>, then using the <pulldown>
-    command to display the <stack> as a <menu>.
-
+  
+  Setting a button's <menuMode> to "pulldown" has the same result as
+  creating the equivalent <menu item|menu items> (as
+  <button(object)|buttons>) in a <stack>, then using the <pulldown>
+  command to display the <stack> as a <menu>.
 
   **Note:** On <Mac OS> and <OS X|OS X systems>, pulldown menus in a
   window are drawn by the standard operating system routines if the
@@ -65,11 +63,10 @@ You can also associate a stack with the button, using the <menuName>
   contents as a <menu item> in a <popup menu>. The <menu> appears at the
   <point> of the mouse click.
 
-
-    Setting a button's <menuMode> to "popup" has the same result as
-    creating the equivalent <menu item|menu items> (as
-    <button(object)|buttons>) in a <stack>, then using the <popup>
-    <command> to display the <stack> as a <menu>.
+  Setting a button's <menuMode> to "popup" has the same result as
+  creating the equivalent <menu item|menu items> (as
+  <button(object)|buttons>) in a <stack>, then using the <popup>
+  <command> to display the <stack> as a <menu>.
 
 
 * "tabbed":  Displays the <button(object)|button's> contents as a
@@ -82,27 +79,23 @@ You can also associate a stack with the button, using the <menuName>
 
 
     on menuPick newTab,oldTab -- sent when user clicks a tab
-
-    lock screen -- hide the swap
-    hide group oldTab
-    show group newTab
-    unlock screen
-
+        lock screen -- hide the swap
+        hide group oldTab
+        show group newTab
+        unlock screen
     end menuPick
 
 
 * "comboBox":  Displays the <button(object)|button's> contents as a
   drop-down scrolling list, with an editable <field> at the top.
 
-
   **Note:** If a <button(object)|button's> <menuMode> is set to
   "comboBox", the <button(keyword)> receives <field> <message|messages>.
   For example, when the user clicks in the editable <field(object)>, an
   <openField> <message> is sent to the <button(keyword)>.
 
-
 * "option":  Displays an option menu (when the <lookAndFeel> <property>
-  is set to "Motif" ), a drop-down list (when the <lookAndFeel>
+  is set to "Motif"), a drop-down list (when the <lookAndFeel>
   <property> is set to "Windows 95" ), or a Mac-style <popup menu> (when
   the <lookAndFeel> <property> is set to "Appearance Manager" or
   "Macintosh" ). Setting a <button(object)|button's> <menuMode> to
@@ -123,11 +116,11 @@ popup menu (glossary), stack menu (glossary), appearance (glossary),
 field (glossary), cascading menu (glossary), line (glossary),
 property (glossary), command (glossary), tabbed button (glossary),
 behavior (glossary), handle (glossary), palette (glossary),
-message (glossary), Mac OS (glossary), OS X (glossary),
+message (glossary), Mac OS (glossary), OS X (glossary), control (glossary),
 dialog box (glossary), menu bar (glossary), menu (glossary),
 point (glossary), menu item (glossary), card (glossary), file (keyword),
 button (keyword), text (keyword), popup (keyword), openField (message),
-menuPick (message), stack (object), control (object), button (object),
+menuPick (message), stack (object), button (object),
 menuLines (property), showBorder (property), menuName (property),
 menubar (property), borderWidth (property), lookAndFeel (property),
 titleWidth (property)

--- a/docs/dictionary/property/menubar.lcdoc
+++ b/docs/dictionary/property/menubar.lcdoc
@@ -24,8 +24,8 @@ By default, the <menubar> of newly created <stacks> is set to empty.
 
 Description:
 Use the <menubar> <property> to specify which <menus> appear in the
-<menu bar> on <Mac OS|Mac OS systems> when a <stack> is the <active
-window>. 
+<menu bar> on <Mac OS|Mac OS systems> when a <stack> is the 
+<active window>. 
 
 On Mac OS systems, the menu bar appears at the top of the screen. On
 Unix and Windows systems, the menu bar appears at the top of the stack
@@ -34,10 +34,11 @@ whose menuMode <property> is set to "pulldown" ; these <button|buttons>
 are then grouped to form a <menu bar>.)
 
 The <menubar> is the <group(command)> that contains the <button|buttons>
-used to build the <menu bar>. This <menu bar> is used when the <stack
-window> is active, replacing the <defaultMenubar>. If the <menubar> of a
-<stack> is empty, the <stack> does not have its own custom <menu bar>,
-and the <defaultMenubar> is used when the <stack> is active.
+used to build the <menu bar>. This <menu bar> is used when the 
+<stack window> is active, replacing the <defaultMenubar>. If the 
+<menubar> of a <stack> is empty, the <stack> does not have its own 
+custom <menu bar>, and the <defaultMenubar> is used when the <stack> is 
+active.
 
 On Mac OS systems, when a stack's <menubar> <property> is set, the
 <stack> is scrolled and resized on <Mac OS|Mac OS systems> so that the

--- a/docs/dictionary/property/mimeText.lcdoc
+++ b/docs/dictionary/property/mimeText.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: mimeText
 
 Summary:
-The <mimeText> <property> is not implemented and is <reserved
-word|reserved>.
+The <mimeText> <property> is not implemented and is 
+<reserved word|reserved>.
 
 Associations: field
 

--- a/docs/dictionary/property/minHeight.lcdoc
+++ b/docs/dictionary/property/minHeight.lcdoc
@@ -47,14 +47,15 @@ If the stack's <resizable> <property> is false, the setting of this
 > false (that is, if the <stack window> is scrolled up so the menubar
 > buttons are not visible in the window), the <minHeight> does not
 > include the height of the <menu bar>. However, on <Windows> and
-> <Unix|Unix systems>, the <minHeight> includes the height of the <menu
-> bar>, since on these platforms the <menu bar> is in the <stack
-> window>. This means that if you set a <minHeight> for a <stack> that
-> contains a <menu bar>, you may need to adjust it depending on
-> <platform> so that the <minHeight> on <Unix> and <Windows|Windows
-> systems> includes the height of the <menu bar>, while the <minHeight>
-> on <Mac OS> and <OS X|OS X systems> does not. (The standard height of
-> <menu bar|menu bars> created with the <Menu Builder> is 21 pixels.)
+> <Unix|Unix systems>, the <minHeight> includes the height of the 
+> <menu bar>, since on these platforms the <menu bar> is in the 
+> <stack window>. This means that if you set a <minHeight> for a <stack> 
+> that contains a <menu bar>, you may need to adjust it depending on
+> <platform> so that the <minHeight> on <Unix> and 
+> <Windows|Windows systems> includes the height of the <menu bar>, 
+> while the <minHeight> on <Mac OS> and <OS X|OS X systems> does not. 
+> (The standard height of <menu bar|menu bars> created with the 
+> <Menu Builder> is 21 pixels.)
 
 >*Note:* The current architecture uses 16-bit signed integers for all
 > co-ordinates, which means that the value range is -32768 to 32767.

--- a/docs/dictionary/property/minimizeBox.lcdoc
+++ b/docs/dictionary/property/minimizeBox.lcdoc
@@ -32,8 +32,8 @@ box in a window's title bar.
 The terminology varies depending on platform. The <minimizeBox>
 <property> determines whether the <collapse box> (<Mac OS|Mac OS
 systems>), <minimize button|minimize box> (OS X and <Windows|Windows
-systems>) or <iconify> box (<Unix|Unix systems>) appears in a <stack
-window|stack window's> <title bar>.
+systems>) or <iconify> box (<Unix|Unix systems>) appears in a 
+<stack window|stack window's> <title bar>.
 
 >*Note:* On <OS X|OS X systems>, if the <minimizeBox> <property> is
 > false, the <minimize button|minimize box> is disabled rather than


### PR DESCRIPTION
property/menubar.lcdoc - Fixed broken links.
function/menuButton.lcdoc - Fixed broken link.
property/menuHistory.lcdoc - Fixed broken links.
property/menuMode.lcdoc - Corrected display issues. Changed `control (object)` to `control (glossary)` - there is no such entry.
message/menuPick.lcdoc - Added `label (property)` to references to have its mention in the description display correctly.
function/messageDigest.lcdoc - Corrected spelling. Changed a string in an example to match exactly the string used earlier in the example, since the point of the example is to show how this function can be used to detect corruption/alteration of data, not that two almost identical strings produce unidentical hashes.
keyword/middle.lcdoc - Fixed broken link.
property/mimeText.lcdoc - Fixed broken link.
property/minHeight.lcdoc - Fixed broken links and as a result the cross-platform note’s display problems also.
keyword/minimize.lcdoc - Removed random plus sign from text.
property/minimizeBox.lcdoc - Fixed broken link.
command/mobileCancelAllLocalNotifications.lcdoc - Changed `stack on iOS or Android (object)` to `stack (object)` - no idea what else this could have been.
command/mobileClearTouches.lcdoc - Formatted code block.