### PR TITLE
[[ SVG ]] Add support for 'currentColor' paint type

### DIFF
--- a/engine/src/idraw.cpp
+++ b/engine/src/idraw.cpp
@@ -38,6 +38,25 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void MCImage::getcurrentcolor(MCGPaintRef& r_paint)
+{
+    MCColor t_color;
+    MCPatternRef t_pattern = nil;
+    int2 x, y;
+    if (getforecolor(DI_BACK, false, false, t_color, t_pattern, x, y, CONTEXT_TYPE_SCREEN, this, false))
+    {
+        MCGPaintCreateWithSolidColor(t_color.red / 65535.0f, t_color.green / 65535.0f, t_color.blue / 65535.0f, 1.0f, r_paint);
+    }
+    else if (t_pattern != nullptr)
+    {
+        r_paint = nullptr;
+    }
+    else
+    {
+        r_paint = nullptr;
+    }
+}
+
 bool MCImage::get_rep_and_transform(MCImageRep *&r_rep, bool &r_has_transform, MCGAffineTransform &r_transform)
 {
 	// IM-2013-11-05: [[ RefactorGraphics ]] Use resampled image rep for best-quality scaling
@@ -137,7 +156,12 @@ void MCImage::drawme(MCDC *dc, int2 sx, int2 sy, uint2 sw, uint2 sh, int2 dx, in
                 uindex_t t_data_size;
                 t_vector_rep->GetData(t_data, t_data_size);
                 
-                MCGContextPlaybackRectOfDrawing(t_gcontext, MCMakeSpan((const byte_t*)t_data, t_data_size), MCGRectangleMake(0, 0, t_rep_width, t_rep_height), MCGRectangleMake(dx - sx, dy - sy, t_rep_width, t_rep_height));
+                MCGPaintRef t_current_color;
+                getcurrentcolor(t_current_color);
+                
+                MCGContextPlaybackRectOfDrawing(t_gcontext, MCMakeSpan((const byte_t*)t_data, t_data_size), MCGRectangleMake(0, 0, t_rep_width, t_rep_height), MCGRectangleMake(dx - sx, dy - sy, t_rep_width, t_rep_height), t_current_color);
+                
+                MCGPaintRelease(t_current_color);
                 
                 MCGContextRestore(t_gcontext);
                 

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -2011,7 +2011,12 @@ bool MCImage::lockbitmap(bool p_premultiplied, bool p_update_transform, const MC
             uindex_t t_data_size;
             t_vector_rep->GetData(t_data, t_data_size);
             
-            MCGContextPlaybackRectOfDrawing(t_context, MCMakeSpan((const byte_t*)t_data, t_data_size), MCGRectangleMake(0, 0, t_width, t_height), MCGRectangleMake(0, 0, t_size.width, t_size.height));
+            MCGPaintRef t_current_color;
+            getcurrentcolor(t_current_color);
+            
+            MCGContextPlaybackRectOfDrawing(t_context, MCMakeSpan((const byte_t*)t_data, t_data_size), MCGRectangleMake(0, 0, t_width, t_height), MCGRectangleMake(0, 0, t_size.width, t_size.height), t_current_color);
+            
+            MCGPaintRelease(t_current_color);
         }
         
         MCGContextRelease(t_context);

--- a/engine/src/image.h
+++ b/engine/src/image.h
@@ -483,6 +483,8 @@ public:
 		return resizequalitytoimagefilter(resizequality);
 	}
 
+    void getcurrentcolor(MCGPaintRef& r_current_color);
+    
 	void setframe(int32_t p_newframe);
 	void advanceframe();
 

--- a/engine/src/image_rep.cpp
+++ b/engine/src/image_rep.cpp
@@ -913,7 +913,7 @@ void MCImageRepUnlockRaster(MCImageRep *p_image_rep, uint32_t p_index, MCImageBi
 	p_image_rep->UnlockBitmap(p_index, p_raster);
 }
 
-void MCImageRepRender(MCImageRep *p_image_rep, MCGContextRef p_gcontext, uint32_t p_index, MCGRectangle p_src_rect, MCGRectangle p_dst_rect, MCGImageFilter p_filter)
+void MCImageRepRender(MCImageRep *p_image_rep, MCGContextRef p_gcontext, uint32_t p_index, MCGRectangle p_src_rect, MCGRectangle p_dst_rect, MCGImageFilter p_filter, MCGPaintRef p_current_color)
 {
     if (p_image_rep->GetType() == kMCImageRepVector)
     {
@@ -923,7 +923,7 @@ void MCImageRepRender(MCImageRep *p_image_rep, MCGContextRef p_gcontext, uint32_
         uindex_t t_data_size;
         t_vector_rep->GetData(t_data, t_data_size);
         
-        MCGContextPlaybackRectOfDrawing(p_gcontext, MCMakeSpan((const byte_t*)t_data, t_data_size), p_src_rect, p_dst_rect);
+        MCGContextPlaybackRectOfDrawing(p_gcontext, MCMakeSpan((const byte_t*)t_data, t_data_size), p_src_rect, p_dst_rect, p_current_color);
     }
     else
     {

--- a/engine/src/module-canvas-internal.h
+++ b/engine/src/module-canvas-internal.h
@@ -195,6 +195,8 @@ struct __MCCanvasImpl
 	const MCCanvasProperties &props() const { return prop_stack[prop_index]; }
 	
 	MCGContextRef context;
+    
+    MCGPaintRef last_paint;
 };
 
 __MCCanvasImpl *MCCanvasGet(MCCanvasRef p_canvas);

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -64,7 +64,7 @@ void MCImageRepUnlock(MCImageRep *p_image_rep, uint32_t p_index, MCGImageFrame &
 bool MCImageRepLockRaster(MCImageRep *p_image_rep, uint32_t p_index, MCGFloat p_density, MCImageBitmap *&r_raster);
 void MCImageRepUnlockRaster(MCImageRep *p_image_rep, uint32_t p_index, MCImageBitmap *p_raster);
 
-void MCImageRepRender(MCImageRep *p_image_rep, MCGContextRef p_gcontext, uint32_t p_index, MCGRectangle p_src_rect, MCGRectangle p_dst_rect, MCGImageFilter p_filter);
+void MCImageRepRender(MCImageRep *p_image_rep, MCGContextRef p_gcontext, uint32_t p_index, MCGRectangle p_src_rect, MCGRectangle p_dst_rect, MCGImageFilter p_filter, MCGPaintRef p_current_color);
 
 //////////
 

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -823,6 +823,9 @@ private command _svgCompilePaint @xContext, pPaint, @rCompiledPaint
 	case "none"
 		put "none" into rCompiledPaint[1]
 		break
+	case "current"
+		put "current" into rCompiledPaint[1]
+		break
 	case "color"
 		put "color" into rCompiledPaint[1]
 		put pPaint["red"] into rCompiledPaint[2]
@@ -1308,6 +1311,7 @@ constant kMCGDrawingPaintOpcodeSolidColor = 1
 constant kMCGDrawingPaintOpcodeLinearGradient = 2
 constant kMCGDrawingPaintOpcodeRadialGradient = 3
 constant kMCGDrawingPaintOpcodeConicalGradient = 4
+constant kMCGDrawingPaintOpcodeCurrentColor = 5
 
 constant kMCGDrawingSpreadMethodOpcodePad = 0
 constant kMCGDrawingSpreadMethodOpcodeReflect = 1
@@ -1516,6 +1520,8 @@ end _svgEncodeScalars
 private command _svgEncodePaint @xContext, pPaint
 	if pPaint[1] is "none" then
 		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeNone
+	else if pPaint[1] is "current" then
+		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeCurrentColor
 	else if pPaint[1] is "color" then
 		_svgEncodeOp xContext, kMCGDrawingPaintOpcodeSolidColor, pPaint[2], pPaint[3], pPaint[4], pPaint[5]
 	else if pPaint[1] is "linear" or pPaint[1] is "radial" or pPaint[1] is "conical" then

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -30,6 +30,8 @@ typedef struct __MCGMask *MCGMaskRef;
 typedef struct __MCGDashes *MCGDashesRef;
 typedef struct __MCGRegion *MCGRegionRef;
 
+typedef class MCGPaint *MCGPaintRef;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // Pixel format (32bit)
@@ -783,6 +785,16 @@ void MCGraphicsCompact(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool MCGPaintCreateWithNone(MCGPaintRef& r_paint);
+bool MCGPaintCreateWithSolidColor(MCGFloat p_red, MCGFloat p_green, MCGFloat p_blue, MCGFloat p_alpha, MCGPaintRef& r_paint);
+bool MCGPaintCreateWithPattern(MCGImageRef p_image, MCGAffineTransform p_transform, MCGImageFilter p_filter, MCGPaintRef& r_paint);
+bool MCGPaintCreateWithGradient(MCGGradientFunction function, const MCGFloat* stops, const MCGColor* colors, uindex_t ramp_length, bool mirror, bool wrap, uint32_t repeats, MCGAffineTransform transform, MCGImageFilter filter, MCGPaintRef& r_paint);
+
+MCGPaintRef MCGPaintRetain(MCGPaintRef paint);
+void MCGPaintRelease(MCGPaintRef paint);
+
+////////////////////////////////////////////////////////////////////////////////
+
 // Create new image with pixel data copied from raster
 bool MCGImageCreateWithRaster(const MCGRaster& raster, MCGImageRef& r_image);
 
@@ -937,6 +949,7 @@ void MCGContextClipToRegion(MCGContextRef self, MCGRegionRef p_region);
 // Fill attributes
 void MCGContextSetFillRule(MCGContextRef context, MCGFillRule rule);
 void MCGContextSetFillOpacity(MCGContextRef context, MCGFloat opacity);
+void MCGContextSetFillPaint(MCGContextRef context, MCGPaintRef paint);
 void MCGContextSetFillNone(MCGContextRef context);
 void MCGContextSetFillRGBAColor(MCGContextRef context, MCGFloat red, MCGFloat green, MCGFloat blue, MCGFloat alpha);
 void MCGContextSetFillPattern(MCGContextRef context, MCGImageRef image, MCGAffineTransform transform, MCGImageFilter filter);
@@ -945,6 +958,7 @@ void MCGContextSetFillPaintStyle(MCGContextRef context, MCGPaintStyle style);
 
 // Stroke attributes
 void MCGContextSetStrokeOpacity(MCGContextRef context, MCGFloat opacity);
+void MCGContextSetStrokePaint(MCGContextRef context, MCGPaintRef paint);
 void MCGContextSetStrokeNone(MCGContextRef context);
 void MCGContextSetStrokeRGBAColor(MCGContextRef context, MCGFloat red, MCGFloat green, MCGFloat blue, MCGFloat alpha);
 void MCGContextSetStrokePattern(MCGContextRef context, MCGImageRef image, MCGAffineTransform transform, MCGImageFilter filter);
@@ -1023,7 +1037,7 @@ void MCGContextDrawPlatformText(MCGContextRef context, const unichar_t *text, ui
 MCGFloat MCGContextMeasurePlatformText(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform);
 bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef context, const unichar_t *text, uindex_t length, const MCGFont &p_font, const MCGAffineTransform &p_transform, MCGRectangle &r_bounds);
 
-void MCGContextPlaybackRectOfDrawing(MCGContextRef context, MCSpan<const byte_t> p_drawing, MCGRectangle p_src, MCGRectangle p_dst);
+void MCGContextPlaybackRectOfDrawing(MCGContextRef context, MCSpan<const byte_t> p_drawing, MCGRectangle p_src, MCGRectangle p_dst, MCGPaintRef p_current_color);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/libgraphics/src/utils.cpp
+++ b/libgraphics/src/utils.cpp
@@ -1179,3 +1179,143 @@ bool MCGAffineTransformFromPoints(const MCGPoint p_src[3], const MCGPoint p_dst[
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+bool MCGPaintCreateWithNone(MCGPaintRef& r_paint)
+{
+    r_paint = nullptr;
+    return true;
+}
+
+bool MCGPaintCreateWithSolidColor(MCGFloat p_red, MCGFloat p_green, MCGFloat p_blue, MCGFloat p_alpha, MCGPaintRef& r_paint)
+{
+    return MCGSolidColor::Create(p_red, p_green, p_blue, p_alpha, (MCGSolidColorRef&)r_paint);
+}
+
+bool MCGPaintCreateWithPattern(MCGImageRef p_image, MCGAffineTransform p_transform, MCGImageFilter p_filter, MCGPaintRef& r_paint)
+{
+    return MCGPattern::Create(p_image, p_transform, p_filter, (MCGPatternRef&)r_paint);
+}
+
+bool MCGPaintCreateWithGradient(MCGGradientFunction p_function, const MCGFloat* p_stops, const MCGColor* p_colors, uindex_t p_ramp_length, bool p_mirror, bool p_wrap, uint32_t p_repeats, MCGAffineTransform p_transform, MCGImageFilter p_filter, MCGPaintRef& r_paint)
+{
+    bool t_success = true;
+    MCGRampRef t_ramp = nullptr;
+    MCGGradientRef t_gradient = nullptr;
+    
+    /* If the gradient is Skia-supported and the image filter is none, then use
+     * Skia shaders, else use our generalized gradient shader. */
+    if (p_function < kMCGLegacyGradientDiamond && p_filter == kMCGImageFilterNone)
+    {
+        MCGGradientSpreadMethod t_spread = kMCGGradientSpreadMethodPad;
+        MCGFloat t_gradient_scale = 1.0;
+        size_t t_repeats = MCMax(1, p_repeats);
+        if (p_wrap)
+        {
+            t_spread = kMCGGradientSpreadMethodRepeat;
+        }
+        if (t_repeats == 1 && !p_mirror)
+        {
+            if (!MCGRamp::Create(p_stops, p_colors, p_ramp_length, t_ramp))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (p_wrap && p_mirror && p_function != kMCGGradientFunctionSweep)
+            {
+                t_gradient_scale = 2.0 / t_repeats;
+                t_repeats = 2;
+            }
+            
+            size_t t_length = p_ramp_length * t_repeats;
+            MCGFloat t_scale = MCGFloat(1) / t_repeats;
+            MCAutoArray<MCGColor> t_colors;
+            MCAutoArray<MCGFloat> t_stops;
+            if (!t_colors.Extend(t_length) ||
+                !t_stops.Extend(t_length))
+            {
+                return false;
+            }
+            
+            for(size_t i = 0; i < t_repeats; i++)
+            {
+                // Offset added to stops
+                MCGFloat t_offset = t_scale * i;
+                
+                // If mirrored, odd-numbered repeats need to be handled specially
+                if (p_mirror && (i % 2))
+                {
+                    // Copy the colours and stops in reverse order
+                    for (uindex_t j = 0; j < p_ramp_length; j++)
+                    {
+                        t_colors[i * p_ramp_length + j] = p_colors[p_ramp_length - j - 1];
+                        t_stops[i * p_ramp_length + j] = t_offset + t_scale * (1 - p_stops[p_ramp_length - j - 1]);
+                    }
+                }
+                else
+                {
+                    // Copy the colours and stops in original order
+                    for (uindex_t j = 0; j < p_ramp_length; j++)
+                    {
+                        t_colors[i * p_ramp_length + j] = p_colors[j];
+                        t_stops[i * p_ramp_length + j] = t_offset + t_scale * p_stops[j];
+                    }
+                }
+            }
+            
+            if (!MCGRamp::Create(t_stops.Ptr(), t_colors.Ptr(), t_length, t_ramp))
+            {
+                return false;
+            }
+        }
+        
+        switch(p_function)
+        {
+            case kMCGLegacyGradientXY:
+            case kMCGLegacyGradientSpiral:
+            case kMCGLegacyGradientSqrtXY:
+            case kMCGLegacyGradientDiamond:
+                t_success = false;
+                break;
+            case kMCGGradientFunctionLinear:
+                t_success = MCGLinearGradient::Create({0, 0}, {t_gradient_scale, 0}, t_ramp, t_spread, p_transform, t_gradient);
+                break;
+            case kMCGGradientFunctionRadial:
+                t_success = MCGRadialGradient::Create({0, 0}, t_gradient_scale, t_ramp, t_spread, p_transform, t_gradient);
+                break;
+            case kMCGGradientFunctionSweep:
+                t_success = MCGSweepGradient::Create({0, 0}, t_ramp, t_spread, p_transform, t_gradient);
+                break;
+        }
+    }
+    else
+    {
+        if (!MCGRamp::Create(p_stops, p_colors, p_ramp_length, t_ramp))
+        {
+            return false;
+        }
+        
+        t_success = MCGGeneralizedGradient::Create(p_function, t_ramp, p_mirror, p_wrap, p_repeats, p_transform, p_filter, t_gradient);
+    }
+    
+    if (t_success)
+    {
+        r_paint = t_gradient;
+    }
+    
+    MCGRelease(t_ramp);
+    
+    return t_success;
+}
+
+MCGPaintRef MCGPaintRetain(MCGPaintRef paint)
+{
+    MCGRetain(paint);
+    return paint;
+}
+
+void MCGPaintRelease(MCGPaintRef paint)
+{
+    MCGRelease(paint);
+}


### PR DESCRIPTION
This patch adds support for the SVG 'currentColor' paint type.

The backgroundColor property of an image containing a drawing is
used as the value for 'currentColor' when painting the drawing.

In implementing this feature, more progress towards cleaning up the
management of paints internally has been done. New public libgraphics
constructors for solid color, pattern and gradient paints have been
added, and these are now used by the canvas API and internally.