### PR TITLE
 [21271] Fix crash when setting markerpoints of a grc in repeat loop

### DIFF
--- a/docs/notes/bugfix-21271.md
+++ b/docs/notes/bugfix-21271.md
@@ -1,0 +1,1 @@
+# Fix crash when setting the markerpoints of a graphic in a repeat loop

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -781,6 +781,7 @@ void MCGraphic::SetMarkerPoints(MCExecContext& ctxt, uindex_t p_count, MCPoint* 
     {
         flags &= ~F_MARKER_DRAWN;
         delete[] markerpoints;
+		markerpoints = NULL;
         nmarkerpoints = 0;
     }
     else


### PR DESCRIPTION
After `delete[] markerpoints`, the pointer `markerpoints`  was not necessarily `NULL`, thus on a the next call to `delete[] markerpoints` a crash occured with `pointer being freed was not allocated`