### PR TITLE
[[ Bug 21228 ]] Clear display cache when presenting keyboard

### DIFF
--- a/docs/notes/bugfix-21228.md
+++ b/docs/notes/bugfix-21228.md
@@ -1,0 +1,1 @@
+# Ensure android working screenrect is updated when the keyboard is presented

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -2295,7 +2295,8 @@ struct MCKeyboardActivatedEvent: public MCCustomEvent
 	
 	void Dispatch(void)
 	{
-		MCdefaultstackptr -> getcurcard() -> message(MCM_keyboard_activated);
+        MCscreen -> cleardisplayinfocache();
+        MCdefaultstackptr -> getcurcard() -> message(MCM_keyboard_activated);
 	}
 	
 private:
@@ -2311,7 +2312,8 @@ struct MCKeyboardDeactivatedEvent: public MCCustomEvent
 	
 	void Dispatch(void)
 	{
-		MCdefaultstackptr -> getcurcard() -> message(MCM_keyboard_deactivated);
+        MCscreen -> cleardisplayinfocache();
+        MCdefaultstackptr -> getcurcard() -> message(MCM_keyboard_deactivated);
 	}
 };
 


### PR DESCRIPTION
This patch ensures that the display cache is cleared when the keyboard
is activated and deactivated allowing the working screenrect to update
appropriately.