### PR TITLE
[Dictionary] Changes from mobileCanMakePurchase to mobileLocationAuthorizationStatus

### DIFF
--- a/docs/dictionary/command/mobileComposeHtmlMail.lcdoc
+++ b/docs/dictionary/command/mobileComposeHtmlMail.lcdoc
@@ -69,7 +69,7 @@ Set by <mobileComposeHtmlMail> to indicate its results.
 
 Description:
 Use the <mobileComposeHtmlMail> <command> to create an HTML email
-message with attachments from within a <stack on iOS or Android>.
+message with attachments from within a <stack> on iOS or Android.
 
 This command interfaces with the iOS and Android mail composition
 interface 
@@ -100,7 +100,7 @@ function. This returns true if the mail client is configured.
 References: revMail (command), revGoURL (command),
 revMailUnicode (command), mobileComposeUnicodeMail (command),
 mobileComposeMail (command), mobileCanSendMail (function),
-command (glossary), stack on iOS or Android (object)
+command (glossary), stack (object)
 
 Tags: networking
 

--- a/docs/dictionary/command/mobileComposeUnicodeMail.lcdoc
+++ b/docs/dictionary/command/mobileComposeUnicodeMail.lcdoc
@@ -69,7 +69,7 @@ Set by <mobileComposeUnicodeMail> to indicate its results.
 
 Description:
 Use the <mobileComposeUnicodeMail> <command> to create a unicode email
-message with attachments from within a <stack on iOS or Android>.
+message with attachments from within a <stack> on iOS or Android.
 
 This command interfaces with the iOS and Android mail composition
 interface 
@@ -100,7 +100,7 @@ function. This returns true if the mail client is configured.
 References: revMail (command), revGoURL (command),
 revMailUnicode (command), mobileComposeMail (command),
 mobileComposeHtmlMail (command), mobileCanSendMail (function),
-command (glossary), stack on iOS or Android (object)
+command (glossary), stack (object)
 
 Tags: networking
 

--- a/docs/dictionary/command/mobileControlCreate.lcdoc
+++ b/docs/dictionary/command/mobileControlCreate.lcdoc
@@ -54,7 +54,7 @@ cannot be an integer.
 
 The result:
 The unique (numeric) id for the new control is returned in
-<the result>.
+<result|the result>.
 
 Description:
 Low-level support has been added for creating and manipulating some 
@@ -64,12 +64,15 @@ Native mobile iOS and Android controllers can only be created
 dynamically in script. 
 
 To destroy a native control use: <mobileControlDelete> 
+
 To configure a native control use: <mobileControlSet> 
+
 To read a property of a native control use: <mobileControlGet> 
+
 To control the behavior of a native control use: <mobileControlDo> 
 
 References: mobileControlDelete (command), mobileControlDo (command),
-mobileControlSet (command), mobileControlGet (command),
+mobileControlSet (command),
 mobileControlGet (function), mobileControlTarget (function),
-the result (function), mobileControls (function)
+result (function), mobileControls (function)
 

--- a/docs/dictionary/command/mobileCreateLocalNotification.lcdoc
+++ b/docs/dictionary/command/mobileCreateLocalNotification.lcdoc
@@ -50,8 +50,8 @@ The id of the local notification that is created is returned by the
 
 Description:
 Use the <mobileCreateLocalNotification> <command> to schedule a Local
-Notification with the operating system from within a <stack on iOS or
-Android>. 
+Notification with the operating system from within a <stack> on iOS or
+Android. 
 
 This command schedules Local Notifications with the iOS or Android
 operating sytem and delivers the <alertPayload> to the application. The
@@ -61,7 +61,7 @@ message.
 References: mobileCancelAllLocalNotifications (command),
 mobileCancelLocalNotification (command), result (function),
 command (glossary), localNotificationReceived (message),
-stack on iOS or Android (object)
+stack (object)
 
 Tags: networking
 

--- a/docs/dictionary/function/mobileCanMakePurchase.lcdoc
+++ b/docs/dictionary/function/mobileCanMakePurchase.lcdoc
@@ -24,8 +24,8 @@ end if
 Returns (enum):
 Returns a boolean result:
 
--   true: in:app purchases can be made
--   false: in:app purchases cannot be made
+-   true: in-app purchases can be made
+-   false: in-app purchases cannot be made
 
 
 Description:

--- a/docs/dictionary/function/mobileControlGet.lcdoc
+++ b/docs/dictionary/function/mobileControlGet.lcdoc
@@ -48,11 +48,14 @@ Use the <mobileControlGet> function to get the value of
 **Global properties (All native mobile controls)**
 
 - "id": Returns the id of the control where the name is passed.
+
 - "name": Returns the name of the control where the id is passed.
+
 - "rect": Returns the bounds of the control, relative to the top-left of
 the card. For example "0,0,100,100".
 
 - "visible": Returns true if the control is visible.
+
 - "alpha": Returns the blendlevel of the control as an integer between 0
 and 255.
 
@@ -62,28 +65,33 @@ integer between 0 to 255.
 **Global properties (All native iOS controls)**
 
 - "opaque": Returns true if the control is opaque.
+
 - "ignoreVoiceOverSensitivity": Returns true if the control is
 accessible through Voice Over. Default value is false.
 
 **Browser Specific Properties**
 
 - "URL": returns the currently loaded URL of the webview.
+
 - "canAdvance": returns true if there is a next page in the history.
+
 - "canRetreat": Returns true if there is a previous page in the history.
+
 - "autoFit" (iOS Only): returns true if the page is scaled to fit the
 rect of the control
 
 - "delayRequests" (iOS Only): returns true | false
+
+
 - "dataDetectorTypes": returns a comma delimited list of the types of
 data that are automatically converted to clickable URLs. This is none 
 or more of the following:
-
   - "phone number" 
   - "calendar event" (iOS4.0+)
   - "link"
   - "address" (OS4.0+)
-  
-  
+
+
 - "allowsInlinePlayback" (iOS Only): returns true if the web-view allows
 media files to be played 'inline' in the page.
 
@@ -159,13 +167,14 @@ decelerates when a finger is lifted (maps to the UIScrollView
 decelerationRate property). This can be either normal, fast or a real
 number.
 
+
 - "indicatorStyle" (iOS Only): returns the style of indicators to
 display (maps to the UIScrollView indicatorStyle property). One of the
 following:
   - "default"
   - "white"
   - "black"
-  
+
   
 - "indicatorInsets" (iOS Only): returns how far from the edge of the
 scroller's bounds, the indicators are inset (maps to the UIScrollView
@@ -240,6 +249,7 @@ content. A value of 0.0 indicates playback is stopped, while a value of
 1.0 indicates normal speed. Positive values indicate forward playback,
 while negative values indicate reverse playback. This is real value.
 
+
 - "loadState" (iOS Only): returns the network load state of the player
 (maps to the native loadStateproperty). This is a comma delimited list
 of zero or more of the following:
@@ -253,7 +263,8 @@ automatically if the player runs out of data.
 
 - "playbackState" (iOS Only): returns the current playback state of the
 player (maps to the native playbackState property). This is one of the
-following:  - "stopped": playback is stopped and commences from the
+following:
+  - "stopped": playback is stopped and commences from the
 beginning when started.
   - "playing": playback is current underway.
   - "paused": playback is paused and resumes from the point it was
@@ -290,6 +301,7 @@ the control. This is a string value.
 - "fontSize": returns the size of the font used for text in the control.
 This is an integer value.
 
+
 - "textAlign": returns the alignment used for text in the control (maps
 to the native textAlignment property). One of:
   - "left"
@@ -312,6 +324,7 @@ that can be entered in the field. This is an integer value.
 automatically when editing begins (maps to the native
 clearsOnBeginEditing property). This is a boolean.
 
+
 - "clearButtonMode" (iOS Only): returns the display mode of the standard
 'clear' button overlay (maps to the native clearButtonMode property).
 This is one of the following:
@@ -332,6 +345,7 @@ following:  - "none": do not draw a border
 - "editing" (iOS Only): returns true if control is currently being
 edited (maps to the native editing property). This is a boolean value.
 
+
 - "autoCapitalizationType": returns when the shift-key is automatically
 enabled (maps to the native autocapitalizationType property). This is
 one of the following:
@@ -341,9 +355,11 @@ one of the following:
   - "all characters": the shift-key is enabled at the start of each
 character
 
+
 - "autoCorrectionType": returns whether auto-correct behavior is enabled
 (maps to the native autocorrectionType property). This is one of the
-following:  - "default": use the appropriate auto-correct behavior for
+following:
+  - "default": use the appropriate auto-correct behavior for
 the current script system
   - "no": disable auto-correct behavior
   - "yes": enable auto-correct behavior
@@ -353,6 +369,7 @@ the current script system
 automatically enabled or disabled based on whether the control has
 content or not (maps to the native enablesReturnKeyAutomatically
 property). This is a boolean value.
+
 
 - "keyboardStyle" (iOS Only): returns what kind of appearance the
 keyboard has (maps to the native keyboardAppearance property). This is
@@ -422,15 +439,17 @@ the control. This is a string value.
 - "fontSize": returns the size of the font used for text in the control.
 This is an integer value.
 
+
 - "textAlign": returns the alignment used for text in the control (maps
 to the native textAlignment property). One of:
   - "left"
   - "center"
   - "right"
-  
-  
+
+
 - "editing" (iOS Only): returns true if control is currently being
 edited (maps to the native editing property). This is a boolean value.
+
 
 - "autoCapitalizationType": returns when the shift-key is automatically
 enabled (maps to the native autocapitalizationType property). This is
@@ -444,7 +463,8 @@ character
 
 - "autoCorrectionType": returns whether auto-correct behavior is enabled
 (maps to the native autocorrectionType property). This is one of the
-following:  - "default": use the appropriate auto-correct behavior for
+following:  
+  - "default": use the appropriate auto-correct behavior for
 the current script system
   - "no": disable auto-correct behavior
   - "yes": enable auto-correct behavior
@@ -454,6 +474,7 @@ the current script system
 automatically enabled or disabled based on whether the control has
 content or not (maps to the native enablesReturnKeyAutomatically
 property). This is a boolean value.
+
 
 - "keyboardStyle" (iOS Only): returns what kind of appearance the
 keyboard has (maps to the native keyboardAppearance property). This is
@@ -478,7 +499,8 @@ the native keyboardType property). This is one of the following:
   
 - "returnKeyType": returns what kind of return-key the keyboard has
 (maps to the native returnKeyType property). This is one of the
-following:  - "default": the normal return key
+following:
+  - "default": the normal return key
   - "go": the 'Go' return key
   - "google": the 'Google' return key
   - "join": the 'Join' return key
@@ -557,6 +579,7 @@ pagingEnabled property).
 decelerates when a finger is lifted (maps to the UIScrollView
 decelerationRate property). This can be either normal, fast or a real
 number.
+
 
 - "indicatorStyle" (iOS Only): returns the style of indicators to
 display (maps to the UIScrollView indicatorStyle property). One of the

--- a/docs/dictionary/function/mobileGetLaunchData.lcdoc
+++ b/docs/dictionary/function/mobileGetLaunchData.lcdoc
@@ -23,31 +23,24 @@ constant kActionView = "android.intent.action.VIEW"
 put mobileGetLaunchData() into tLaunchData
 
 if tLaunchData is an array and tLaunchData["action"] is kActionView then
-
    -- view content specified in tLaunchData["data"]
-
 else
-
    -- launched as main application
-
 end if
 
 Returns:
-Use the <mobileGetLaunchData> function to get the application launch
-parameters. The returned array will contain the information that is set
-by the launching application.
+Returns an array containing information set by the launcher of the
+application. 
 
 Description:
->Returns an array containing information set by the launcher of the
-> application. 
-
-The <mobileGetLaunchData> function returns the information that was set
+Use the <mobileGetLaunchData> function to get the application launch
+parameters. The returned array will contain the information that is set
 by the launching application. This can be used to perform specific
 actions supported by an application on the provided data.
 
-    >*Note:*  On Android, custom Intent filters can be specified in the
-    > manifest to allow an application to perform actions for other
-    > applications 
+>*Note:*  On Android, custom Intent filters can be specified in the
+> manifest to allow an application to perform actions for other
+> applications 
 
 When the application is launched to handle one of these actions, its
 launch Intent can be queried to determine what action was requested, and

--- a/docs/dictionary/function/mobileGetLocationHistoryLimit.lcdoc
+++ b/docs/dictionary/function/mobileGetLocationHistoryLimit.lcdoc
@@ -52,14 +52,11 @@ sample provided with the <locationChanged> event (which will always be
 the last sample in the history). e.g.
 
     on locationChanged
-
-    local tHistory
-    put mobileGetLocationHistory() into tHistory
-    repeat for each element tSample in tHistory
-
-    processLocationChanged tSample
-
-    end repeat
+        local tHistory
+        put mobileGetLocationHistory() into tHistory
+        repeat for each element tSample in tHistory
+            processLocationChanged tSample
+        end repeat
     end locationChanged
 
 
@@ -67,6 +64,6 @@ References: mobileSetLocationHistoryLimit (command),
 mobileStopTrackingSensor (command), mobileStartTrackingSensor (command),
 mobileGetLocationHistory (function), mobileSensorAvailable (function),
 mobileSensorReading (function),
-mobileLocationAuthorizationStatus (function), locationChanged (message),
-trackingError (message)
+mobileLocationAuthorizationStatus (function), array (function),
+function (glossary), locationChanged (message), trackingError (message)
 

--- a/docs/dictionary/function/mobileGetNotificationDetails.lcdoc
+++ b/docs/dictionary/function/mobileGetNotificationDetails.lcdoc
@@ -26,13 +26,17 @@ the id number of the notification
 
 Returns (array):
 The <mobileGetNotificationDetails> function returns an array containing
-the following entries: body - the text that is to be displayed on the
+the following entries: 
+ - body - the text that is to be displayed on the
 notification dialog (iOS) or statusbar entry (Android) when the
-application is not running title - the button text on the notification
-dialog (iOS) or the title of the statusbar entry (Android) payload - the
+application is not running 
+ - title - the button text on the notification
+dialog (iOS) or the title of the statusbar entry (Android) 
+ - payload - the 
 text presented to the app via the <localNotificationReceived> message
-play sound - boolean indicating if a sound is to be played when the
-notification is received badge value - the number value which should be
+ - play sound - boolean indicating if a sound is to be played when the
+notification is received 
+ - badge value - the number value which should be
 displayed on the app logo (iOS) or on the status bar icon (Android) when
 the notification is received. No number is displayed if this is 0
 (zero). 

--- a/docs/dictionary/function/mobileLocationAuthorizationStatus.lcdoc
+++ b/docs/dictionary/function/mobileLocationAuthorizationStatus.lcdoc
@@ -26,16 +26,16 @@ Returns (enum):
 The <mobileLocationAuthorizationStatus> function returns one of the
 following strings:
 
--   notDetermined: User has not yet made a choice with regards to this
+ -  "notDetermined" - User has not yet made a choice with regards to this
     application. 
--   restricted: The application is not authorized to use location
+ -  "restricted" - The application is not authorized to use location
     services. 
--   denied: User has explicitly denied authorization for this
+ -  "denied" - User has explicitly denied authorization for this
     application, or location services are disabled in settings
--   authorizedAlways: User has granted authorization to use their
+ -  "authorizedAlways" - User has granted authorization to use their
     location at any time, including monitoring for regions, visits, or
     significant location changes.
--   authorizedWhenInUse: User has granted authorization to use their
+ -  "authorizedWhenInUse" - User has granted authorization to use their
     location only when the app is visible to them. Authorization to use
     launch APIs has not been granted
 


### PR DESCRIPTION
function/mobileCanMakePurchase.lcdoc - Fixed punctuation.
command/mobileComposeHtmlMail.lcdoc - Changed `stack on iOS or Android (object)` to a similar-sounding entry that exists.
command/mobileComposeUnicodeMail.lcdoc - Changed `stack on iOS or Android (object)` to a similar-sounding entry that exists.
command/mobileControlCreate.lcdoc - Fixed/removed links to thing that don’t exist. Reformatted some text to have appropriate spacing.
function/mobileControlGet.lcdoc - Reformatted lists to appear to have consistent spacing.
function/mobileControlSet.lcdoc - Copied property list from mobileControlGet so that they would be ordered and formatted the same way.
command/mobileCreateLocalNotification.lcdoc - Changed instances of `stack on iOS or Android` to `stack` where it was causing problems.
function/mobileCurrentLocation.lcdoc - Fixed punctuation.
command/mobileExportImageToAlbum.lcdoc - Added spaces after dashes separating error values and descriptions of them; looks a little better this way.
function/mobileGetLaunchData.lcdoc - Rearranged text that appeared to be swapped around. Removed redundancies. Removed extraneous newlines.
function/mobileGetLocationHistoryLimit.lcdoc - Added references as appropriate. Reformatted code block.
function/mobileGetNotificationDetails.lcdoc - Reformatted unordered list to display correctly.
function/mobileLocationAuthorizationStatus - Prevented return description from saying “one of the following” twice.