### PR TITLE
[[ Bug 21302 ]] Make message box 'put' immune to 'lock messsages'

### DIFF
--- a/docs/notes/bugfix-21302.md
+++ b/docs/notes/bugfix-21302.md
@@ -1,0 +1,1 @@
+# Make message box 'put' statements immune to 'lock messages'

--- a/engine/src/debug.cpp
+++ b/engine/src/debug.cpp
@@ -140,6 +140,9 @@ void MCB_setmsg(MCExecContext &ctxt, MCStringRef p_string)
     
     if (t_target != nil)
     {
+		Boolean oldlock = MClockmessages;
+		MClockmessages = False;
+
         MCAutoStringRef t_handler;
         t_handler = MCNameGetString(ctxt.GetHandler()->getname());
         MCParameter *t_handler_parameter = new (nothrow) MCParameter;
@@ -165,6 +168,8 @@ void MCB_setmsg(MCExecContext &ctxt, MCStringRef p_string)
         
         if (t_added)
             MCnexecutioncontexts--;
+
+		MClockmessages = oldlock;
     }
     
     if (t_stat == ES_NOT_HANDLED || t_stat == ES_PASS)


### PR DESCRIPTION
Wrap the sending of the message in `MCB_setmsg` with setting `MClockmessages` to `false` and then restoring to original value.