### PR TITLE
[[ Bug 21234 ]] Dictionary: revDataFromQuery / revQueryDatabase

### DIFF
--- a/docs/dictionary/function/revDataFromQuery.lcdoc
+++ b/docs/dictionary/function/revDataFromQuery.lcdoc
@@ -28,7 +28,8 @@ Example:
 get revDataFromQuery(comma, return, tConnectionId, tQuery)
 
 Example:
-get revDataFromQuery(tab, return, tConnectionId, "SELECT * FROM myTable WHERE id = :1", "tCustomerDetails[id]")
+get revDataFromQuery(tab, return, tConnectionId, \
+"SELECT * FROM myTable WHERE id = :1", "tCustomerDetails[id]")
 
 Parameters:
 columnDelim:
@@ -86,40 +87,40 @@ name in the variablesList for each of these placeholders. For example,
 if you have two <variable|variables> called "valueX" and "valueY", you
 can use a <SQLQuery> that includes placeholders as follows:
 
-get revDataFromQuery(, , myID,"SELECT x,y FROM test WHERE x = :1 AND y =
-:2", "valueX", "valueY" )
+    get revDataFromQuery(, , myID, "SELECT x,y FROM test " && \
+    "WHERE x = :1 AND y = :2", "valueX", "valueY" )
 
 The content of the variable valueX is substituted for the ":1" in the
 <SQLQuery> (in both places where ":1" appears), and the content of
 valueY is substituted for ":2".
 
-To pass binary data in a variable in the variablesList, <prepend> "*b"
+To pass binary data in a variable in the variablesList, <prepend> `"*b"`
 to the variable name. The <revDataFromQuery> <function> strips the
-binary marker "*b" and passes it to the database as binary data, rather
+binary marker `"*b"` and passes it to the database as binary data, rather
 than text data.
 
-local tImageData
-put the text of image "MyImage" into tImageData
-get revDataFromQuery(, , myID,
-"SELECT size FROM images WHERE imagedata = :1", "*btImageData" )
+    local tImageData
+    put the text of image "MyImage" into tImageData
+    get revDataFromQuery(, , myID, \
+    "SELECT size FROM images WHERE imagedata = :1", "*btImageData" )
 
 You can also use the name of a numerically indexed array, instead of a
 list of variable names. In this case, the elements of the array are
 substituted for the corresponding placeholders. To pass binary data in
-an array element, prepend "*b" to the element's value.
+an array element, prepend `"*b"` to the element's value.
 
-local tImageDataArray
-put "*b" & the text of image "MyImage" into tImageDataArray[1]
-get revDataFromQuery(, , myId,
-"SELECT size FROM images WHERE imagedata = :1", "tImageDataArray" )
+    local tImageDataArray
+    put "*b" & the text of image "MyImage" into tImageDataArray[1]
+    get revDataFromQuery(, , myId, \
+    "SELECT size FROM images WHERE imagedata = :1", "tImageDataArray" )
 
 To pass an asterisk as part of the query, substitute a percent sign (%).
 For example, to use the query
-"SELECT * FROM Customers WHERE Cust.Name Like '*Inc.'", use a statement
+`"SELECT * FROM Customers WHERE Cust.Name Like '*Inc.'"`, use a statement
 like the following:
 
-get revDataFromQuery(2,
-"SELECT * FROM Customers WHERE Cust.Name Like '%Inc.'" )
+    get revDataFromQuery(2, \
+    "SELECT * FROM Customers WHERE Cust.Name Like '%Inc.'" )
 
 If the query is not successful, the <revDataFromQuery> <function>
 <return|returns> an error message beginning with the <string>

--- a/docs/dictionary/function/revQueryDatabase.lcdoc
+++ b/docs/dictionary/function/revQueryDatabase.lcdoc
@@ -20,16 +20,18 @@ Platforms: desktop, server, mobile
 Security: disk, network
 
 Example:
-revQueryDatabase(2,"SELECT * FROM EmpStats")
+revQueryDatabase(2, "SELECT * FROM EmpStats")
 
 Example:
-revQueryDatabase(currentDB,field "Query")
+revQueryDatabase(currentDB, field "Query")
 
 Example:
-revQueryDatabase(the database of me,myQuery,"myVar1","myVar2","myVar3")
+revQueryDatabase(the database of me, myQuery, "myVar1", "myVar2", \
+"myVar3")
 
 Example:
-revQueryDatabase(tConnectionId, tQuery, "tInputData[id]", "tInputData[name]")
+revQueryDatabase(tConnectionId, tQuery, "tInputData[id]", \
+"tInputData[name]")
 
 Parameters:
 databaseID:
@@ -69,8 +71,8 @@ name in the <variablesList> for each of these placeholders. For example,
 if you have two <variable|variables> called "valueX" and "valueY", you
 can use a <SQLQuery> that includes placeholders as follows:
 
-    get revQueryDatabase(myID,"SELECT * FROM empStats WHERE id=:1 OR
-    stat_id=:1 OR population=:2","valueX","valueY")
+    get revQueryDatabase(myID, "SELECT * FROM empStats WHERE id=:1" && \
+    "OR stat_id=:1 OR population=:2", "valueX", "valueY")
 
 
 The content of the variable valueX is substituted for the ":1" in the
@@ -82,20 +84,20 @@ If you specify an <arrayName> rather than a list of ordinary
 corresponding <element(keyword)> of the <array> for each of the
 placeholders in the <SQL query|query>:
 
-    get revQueryDatabase(myID,"SELECT :1,:2 FROM empStats WHERE
-    1",myArray) 
+    get revQueryDatabase(myID, "SELECT :1,:2 FROM empStats WHERE" && \
+    "id=:1", "myArray") 
 
 
 The content of the element myArray[1] is substituted for the ":1" in the
 <SQLQuery> (in both places where ":1" appears), and the content of
 myArray[2] is substituted for ":2".
 
-To pass binary data in a variable in the <variablesList>, <prepend> "*b"
+To pass binary data in a variable in the <variablesList>, <prepend> `"*b"`
 to the variable name. The <revQueryDatabase> <function> strips the
-binary marker "*b" and passes it to the database as binary data, rather
+binary marker `"*b"` and passes it to the database as binary data, rather
 than text data. To pass <binary file|binary data> in an <array>
-<element(keyword)>, prepend "*b" to the <element(glossary)|element's>
-value. 
+<element(keyword)>, prepend `"*b"` to the <element(glossary)|element's>
+value.  See <revDataFromQuery> for binary data examples.
 
 >*Tip:*  To execute a <SQL query> that does not return a <record set
 > (database cursor)(glossary)> (such as INSERT or DELETE), use the
@@ -121,10 +123,10 @@ you can check whether the query was successful by checking whether the
 Changes:
 The revQueryDatabase synonym was added in version 2.0.
 
-References: command (glossary), revCloseCursor (command),
-revExecuteSQL (command), function (control structure),
-revQueryIsAtStart (function), LiveCode custom library (glossary),
-variable (glossary), element (glossary),
+References: command (glossary), revCloseCursor (command), 
+revDataFromQuery (function), revExecuteSQL (command), 
+function (control structure), revQueryIsAtStart (function), 
+LiveCode custom library (glossary), variable (glossary), element (glossary),
 standalone application (glossary), binary file (glossary),
 array (glossary), prepend (glossary), SQL query (glossary),
 record set (database cursor) (glossary), return value (glossary),

--- a/docs/notes/bugfix-21234.md
+++ b/docs/notes/bugfix-21234.md
@@ -1,0 +1,1 @@
+# Dictionary: revDataFromQuery / revQueryDatabase updates


### PR DESCRIPTION
Correct example issue listed in bug 21234 (missing "ID=:")
Fixed missing `"*b"` from both documents (was treated as italics markers)
Added cross reference from `revQueryDatabase` to `revDataFromQuery` for binary data examples.
Converted multi-line examples into functional code (proper line continuations)
Hard wrapped some examples that were wrapping at odd places in the dictionary.
Indented some examples so they get treated as code.
Added spaces after commas in examples for readability.