### PR TITLE
Revert "[[ Emscripten ]] Fix unresolved foreign handlers in certain modules"

### DIFF
--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -357,7 +357,7 @@ static uindex_t s_emitted_builtin_count = 0;
 
 static MCStringRef EmittedBuiltinAdd(NameRef p_symbol_name, uindex_t p_type_index)
 {
-    if (!(OutputFileAsC || OutputFileAsAuxC))
+    if (!OutputFileAsC || OutputFileAsAuxC)
     {
         return MCNameGetString(to_mcnameref(p_symbol_name));
     }


### PR DESCRIPTION
This reverts commit 14dbe69b512a14eb7d70ac766f8f2021c0a36a53.

It should fix the build error when building the FM Plugin