### PR TITLE
[[ Bug 21304 ]] Clear unshared data when compacting stack

### DIFF
--- a/docs/notes/bugfix-21304.md
+++ b/docs/notes/bugfix-21304.md
@@ -1,0 +1,1 @@
+# Clear unshared data when compacting stack

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -719,7 +719,7 @@ Boolean MCStack::checkid(uint4 cardid, uint4 controlid)
 		}
 		while (cptr != cards);
 	}
-	if (curcard != NULL)
+	if (curcard != NULL && curcard->getid() == cardid)
 		return curcard->checkid(controlid);
 	return False;
 }


### PR DESCRIPTION
`MCField::compactdata` iterates over all of the data stored for each field.  If not shared, then there is data for each card where the object had existed.  Due to the way `MCStack::checkid` was constructed, if the card was not found then the check was done against the current card.  This has an unintended effect of keeping all field data around for deleted cards if the owning group is on the current card.

This change ensures that the `cardid` is always checked to be sure it matches the card before checking to see if the group is on the card.  Due to the way the code is constructed in the Field and Button side, the `cardid` will never be 0.