### PR TITLE
 [19900] Ensure tsNet can be unloaded

### DIFF
--- a/docs/notes/bugfix-19900.md
+++ b/docs/notes/bugfix-19900.md
@@ -1,0 +1,1 @@
+# Ensure tsNet external can be unloaded

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2371,17 +2371,17 @@ private command __InitialiseInclusionDependencies
    revSBAddDependencyForInclusion "scriptLibraries", "XMLRPC", "scriptLibraries", "XML"
 end __InitialiseInclusionDependencies
 
-command revSBAddDependencyForInclusion pInclusionType, pInclusion, pDependenyType, pDependeny, pPlatforms
+command revSBAddDependencyForInclusion pInclusionType, pInclusion, pDependencyType, pDependency, pPlatforms
    if pPlatforms is empty then
       put revSBAllPlatforms() into pPlatforms
    end if
    repeat for each item tPlatform in pPlatforms
-      put true into sDependencies[pInclusionType][pInclusion][pDependenyType][pDependeny][tPlatform]
+      put true into sDependencies[pInclusionType][pInclusion][pDependencyType][pDependency][tPlatform]
    end repeat
 end revSBAddDependencyForInclusion
 
-command revSBRemoveDependencyForInclusion pInclusion, pInclusionType, pDependeny, pDependenyType
-   delete variable sDependencies[pInclusionType][pInclusion][pDependenyType][pDependeny]
+command revSBRemoveDependencyForInclusion pInclusionType, pInclusion, pDependencyType, pDependency
+   delete variable sDependencies[pInclusionType][pInclusion][pDependencyType][pDependency]
 end revSBRemoveDependencyForInclusion
 
 command revSBUpdateForDependencies pPlatform, pArchs, pSDK, @xSettings


### PR DESCRIPTION
The `revSBRemoveDependencyForInclusion` command is called in 2 places:

on `extensionFinalize` in the script of stack `revhtml5urllibrary`:
`revSBRemoveDependencyForInclusion "scriptLibraries", "Internet", "scriptLibraries", "html5url"`

on `revUnloadLibrary` of stack `tsNetLibURL`:
`revSBRemoveDependencyForInclusion "scriptLibraries", "Internet", "externals", "tsNet"`

However both these calls do not match the current signature of `revSBRemoveDependencyForInclusion`, thus the dependencies were never removed.

Instead of changing the order of the params in these 2 calls, this patch changes the order of params in the actual signature of the command, so as to be consistent with the signature of the opposite command, i.e. the `revSBAddDependencyForInclusion` one.