### PR TITLE
[[ Drawing ]] Fallback to relative resource path

### DIFF
--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -3271,14 +3271,14 @@ end seqLast
  ******************************************************************************/
 
 private function _GetResourcesPath
-   if the environment begins with "development" then
+   local tResourcesFolder
+   -- in the mapping, tResourcesFolder begins with ./
+   put char 3 to -1 of revLibraryMapping[the short name of me  & slash & "resources"] \
+         into tResourcesFolder
+   if tResourcesFolder is empty then
       set the itemDelimiter to slash
       return item 1 to -2 of the filename of me & slash & "resources"
    else
-      local tResourcesFolder
-      -- in the mapping, tResourcesFolder begins with ./
-      put char 3 to -1 of revLibraryMapping[the short name of me  & slash & "resources"] \
-            into tResourcesFolder
       put specialFolderPath("resources") & slash before tResourcesFolder
       return tResourcesFolder
    end if

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -3273,8 +3273,10 @@ end seqLast
 private function _GetResourcesPath
    local tResourcesFolder
    -- in the mapping, tResourcesFolder begins with ./
-   put char 3 to -1 of revLibraryMapping[the short name of me  & slash & "resources"] \
-         into tResourcesFolder
+   try
+      put char 3 to -1 of revLibraryMapping[the short name of me & \
+         slash & "resources"] into tResourcesFolder
+   end try
    if tResourcesFolder is empty then
       set the itemDelimiter to slash
       return item 1 to -2 of the filename of me & slash & "resources"


### PR DESCRIPTION
This patch ensures that if there is no library mapping set for the resource
path in the current environment (whether IDE or not) that the fallback is to
return the path relative to the stack file. This allows the library to be
loaded in environmentes where it was not included in standalone building.