### PR TITLE
[19420] Prevent crash on Android when quitting and starting the app

### DIFF
--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -298,7 +298,7 @@ void __MCNameDestroy(__MCName *self)
 	// Find the previous link in the chain
 	__MCName *t_previous;
 	t_previous = nil;
-	for(__MCName *t_name = s_name_table[t_index]; t_name != self; t_name = t_name -> next)
+	for(__MCName *t_name = s_name_table[t_index]; t_name != nullptr && t_name != self; t_name = t_name -> next)
 		t_previous = t_name;
 
 	// Update the previous name's next field


### PR DESCRIPTION
`t_name` was `NULL`, causing null pointer dereference (and crash) when doing `t_name -> next`