### PR TITLE
[Dictionary] From mobileGetLocationHistory to mobileStartTrakingSensor

### DIFF
--- a/docs/dictionary/command/mobilePickMedia.lcdoc
+++ b/docs/dictionary/command/mobilePickMedia.lcdoc
@@ -76,15 +76,17 @@ to select multiple items on iOS, the user has to select the Done button,
 once all of the selections have been made.
 
 The remaining arguments specify the type of media items the user should
-> be allowed to select from the iPod library. On Android, it is not
-> necessary to specify any arguments. The application that is launched
-> is in control of the audio media types that are to be selected.
+be allowed to select from the iPod library. On Android, it is not
+necessary to specify any arguments. The application that is launched
+is in control of the audio media types that are to be selected.
 >*Note:* <mobilePickMedia> does not return anything for m4p files or
 > iCloud files that are not physically on the device, even if they are
 > displayed in the picker itself.
+
 >*Note:* On iOS, <mobilePickMedia> returns references to the iTunes data
 > store on the iOS device. These media references can only be played
 > with the <mobilePlaySoundOnChannel> command.
+
 >*Note:* <mobilePickMedia> is not available on the iOS simulator.
 
 References: mobilePlaySoundOnChannel (command), mobilePick (command),

--- a/docs/dictionary/command/mobilePickPhoto.lcdoc
+++ b/docs/dictionary/command/mobilePickPhoto.lcdoc
@@ -23,15 +23,13 @@ mobilePickPhoto "front camera", 250, 250
 
 Parameters:
 source (enum):
-The source for the image. One of:
+The source for the image.
 
-- "library"
-- "album"
-- "camera"
-
-
--   "rear camera": iOS only
--   "front camera": iOS only
+- "library":
+- "album":
+- "camera":
+- "rear camera": iOS only
+- "front camera": iOS only
 
 
 maxwidth:

--- a/docs/dictionary/command/mobilePlaySoundOnChannel.lcdoc
+++ b/docs/dictionary/command/mobilePlaySoundOnChannel.lcdoc
@@ -33,8 +33,6 @@ channel:
 The name of the channel to play the sound on.
 
 type (enum):
-One of:
-
 -   "now": The sound is played immediately, replacing any current sound
     (and queued sound) on the channel.
 -   "next": The sound is queued to play immediately after the current

--- a/docs/dictionary/command/mobileSetLocationHistoryLimit.lcdoc
+++ b/docs/dictionary/command/mobileSetLocationHistoryLimit.lcdoc
@@ -66,10 +66,10 @@ the last sample in the history). e.g.
 
 
 References: mobileStopTrackingSensor (command),
-mobileStartTrackingSensor (command), function (control structure),
+mobileStartTrackingSensor (command),
 mobileGetLocationHistory (function),
 mobileGetLocationHistoryLimit (function),
 mobileSensorAvailable (function), mobileSensorReading (function),
-mobileLocationAuthorizationStatus (function), array (glossary), 
+mobileLocationAuthorizationStatus (function),
 locationChanged (message), trackingError (message)
 

--- a/docs/dictionary/command/mobileSetLocationHistoryLimit.lcdoc
+++ b/docs/dictionary/command/mobileSetLocationHistoryLimit.lcdoc
@@ -57,21 +57,19 @@ sample provided with the <locationChanged> event (which will always be
 the last sample in the history). e.g.
 
     on locationChanged
-
-    local tHistory
-    put mobileGetLocationHistory() into tHistory
-    repeat for each element tSample in tHistory
-
-    processLocationChanged tSample
-
-    end repeat
+        local tHistory
+        put mobileGetLocationHistory() into tHistory
+        repeat for each element tSample in tHistory
+            processLocationChanged tSample
+        end repeat
     end locationChanged
 
 
 References: mobileStopTrackingSensor (command),
-mobileStartTrackingSensor (command), mobileGetLocationHistory (function),
+mobileStartTrackingSensor (command), function (control structure),
+mobileGetLocationHistory (function),
 mobileGetLocationHistoryLimit (function),
 mobileSensorAvailable (function), mobileSensorReading (function),
-mobileLocationAuthorizationStatus (function), locationChanged (message),
-trackingError (message)
+mobileLocationAuthorizationStatus (function), array (glossary), 
+locationChanged (message), trackingError (message)
 

--- a/docs/dictionary/command/mobileStartTrackingSensor.lcdoc
+++ b/docs/dictionary/command/mobileStartTrackingSensor.lcdoc
@@ -33,9 +33,9 @@ loosely (enum):
 How accurate the readings from sensors should be. The default value is
 false 
 
--   "true": readings are determined without using accurate(but power
+-   "true": readings are determined without using accurate (but power
     consuming) sources such as GPS.
--   "false": readings are determined using accurate(but power consuming)
+-   "false": readings are determined using accurate (but power consuming)
     sources such as GPS.
 
 

--- a/docs/dictionary/function/mobileGetLocationHistory.lcdoc
+++ b/docs/dictionary/function/mobileGetLocationHistory.lcdoc
@@ -74,6 +74,6 @@ References: mobileSetLocationHistoryLimit (command),
 mobileStopTrackingSensor (command), mobileStartTrackingSensor (command),
 mobileGetLocationHistoryLimit (function),
 mobileSensorAvailable (function), mobileSensorReading (function),
-mobileLocationAuthorizationStatus (function), array (glossary), 
+mobileLocationAuthorizationStatus (function),
 locationChanged (message), trackingError (message)
 

--- a/docs/dictionary/function/mobileGetLocationHistory.lcdoc
+++ b/docs/dictionary/function/mobileGetLocationHistory.lcdoc
@@ -19,50 +19,30 @@ local tHistory
 put mobileGetLocationHistory() into tHistory
 
 Returns (array):
-A numerically keyed <array> of all accumulated samples
+A numerically keyed, nested <array> of all accumulated samples
 since the last time it was called with lower indices being older 
-samples. Calling the function clears the internal history. The default 
-history limit is 1 - meaning that only one sample is ever kept at a 
+samples. Each index of the <array> has the following keys:
+ - "horizontal accuracy": the maximum error in meters of the
+position indicated by longitude and latitude
+ - "latitude": the latitude of the current location, measured in degrees
+relative to the equator. Positive values indicate positions in the 
+Northern Hemisphere, negative values in the Southern.
+ - "longitude": the longitude of the current location, measured in
+degrees relative to the zero meridian. Positive values extend east
+of the meridian, negative values extend west.
+ - "altitude": the distance in meters of the height of the device 
+relative to sea level. Positive values extend upward of sea level,
+negative values downward.
+ - "timestamp": the time at which the measurement was taken, in
+seconds since 1970.
+
+Calling the function clears the internal history. The default 
+history limit is 1, meaning that only one sample is ever kept at a 
 time. If an application wants historical access to all samples, then it 
 should set the location history limit using the 
-<mobileSetLocationistoryLimit> <command> to the maximum number of 
+<mobileSetLocationHistoryLimit> <command> to the maximum number of 
 samples it ever wants to record, or 0 to record the entire history 
 (between calls to <mobileGetLocationHistory>).
-
-{
-
--    (integer) : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--   : 
--    (real) : 
--   : 
--   : 
--   : 
-
-}
 
 
 Description:
@@ -82,14 +62,11 @@ sample provided with the <locationChanged> event (which will always be
 the last sample in the history). e.g.
 
     on locationChanged
-
-    local tHistory
-    put mobileGetLocationHistory() into tHistory
-    repeat for each element tSample in tHistory
-
-    processLocationChanged tSample
-
-    end repeat
+        local tHistory
+        put mobileGetLocationHistory() into tHistory
+        repeat for each element tSample in tHistory
+            processLocationChanged tSample
+        end repeat
     end locationChanged
 
 
@@ -97,6 +74,6 @@ References: mobileSetLocationHistoryLimit (command),
 mobileStopTrackingSensor (command), mobileStartTrackingSensor (command),
 mobileGetLocationHistoryLimit (function),
 mobileSensorAvailable (function), mobileSensorReading (function),
-mobileLocationAuthorizationStatus (function), locationChanged (message),
-trackingError (message)
+mobileLocationAuthorizationStatus (function), array (glossary), 
+locationChanged (message), trackingError (message)
 

--- a/docs/dictionary/function/mobileOrientation.lcdoc
+++ b/docs/dictionary/function/mobileOrientation.lcdoc
@@ -19,8 +19,7 @@ Example:
 put mobileOrientation() into theInterfaceOrientation
 
 Returns (enum):
-The <mobileDeviceOrientation> function returns one of
-
+The <mobileDeviceOrientation> function returns a string value.
 -   portrait: the device is being held upward with the home button at
     the bottom
 -   portrait upside down: the device is being held upward with the home

--- a/docs/dictionary/function/mobilePixelDensity.lcdoc
+++ b/docs/dictionary/function/mobilePixelDensity.lcdoc
@@ -32,8 +32,8 @@ density on Android.
 
 The <mobilePixelDensity> function returns the scale of the device screen
 (relative to a non-Retinal display on iOS), this is 2 on a retina
-display and 1 otherwise. On Android this function return the Display
-Metrics. 
+display and 1 otherwise. On Android this function returns the display
+metrics. 
 
 References: iphoneUseDeviceResolution (command),
 iphoneDeviceScale (function), iphoneDeviceResolution (function)

--- a/docs/dictionary/function/mobilePreferredLanguages.lcdoc
+++ b/docs/dictionary/function/mobilePreferredLanguages.lcdoc
@@ -23,9 +23,12 @@ answer "The user prefers" && line 1 of tLanguages
 Returns:
 The <mobilePreferredLanguages> function returns a list of language tags
 in order of user preference, highest first, one per line. For example:
+
 EN
+
 FR
-DE.
+
+DE
 
 Description:
 Use <mobilePreferredLanguages> to get a list of preferred user

--- a/docs/dictionary/function/mobileSoundChannelStatus.lcdoc
+++ b/docs/dictionary/function/mobileSoundChannelStatus.lcdoc
@@ -22,7 +22,7 @@ Example:
 put mobileSoundChannelStatus() into tChannelStatus
 
 Returns (enum):
-The <mobileSoundChannelStatus> function returns one of:
+The <mobileSoundChannelStatus> function returns a string value.
 
 -   stopped: there is no sound currently playing, nor any sound
     scheduled to be playing


### PR DESCRIPTION
function/mobileGetLocationHistory.lcdoc - Replaced a series of colons with a better explanation of what is in the array returned by this function (borrowed from mobileGetCurrentLocation). Added a reference and fixed some other links.
function/mobileOrientation.lcdoc - Removed the first “One of” and described the function’s return value type in its place.
command/mobilePickMedia.lcdoc - Fixed formatting of notes to separate them from the rest of the text and each other.
command/mobilePickPhoto.lcdoc - United list of parameters.
function/mobilePixelDensity.lcdoc - Spelling errors.
command/mobilePlaySoundOnChannel.lcdoc - Removed redundant “One of”
function/mobilePreferredLanguages.lcdoc - Changed return value example to more accurately resemble what it is supposed to be.
command/mobileSetLocationHistoryLimit.lcdoc - Reformatted code example, added `array`  and `function` to the references to so that links to them display in Description.
function/mobileSoundChannelStatus.lcdoc - Replaced extraneous `One of` with (guessed) return value type.
command/mobileStartTrackingSensor.lcdoc - Minor grammar correction.