### PR TITLE
[[ API 26 ]] Use app platform 16 with target sdk 26

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ import subprocess
 BUILDBOT_PLATFORM_TRIPLES = (
     'x86-linux-debian8',
     'x86_64-linux-debian8',
-    'armv6-android-api26',
+    'armv6-android-sdk26_ndk16r15',
     'universal-mac-macosx10.9', # Minimum deployment target
     'universal-ios-iphoneos11.4',
     'universal-ios-iphoneos11.2',
@@ -119,7 +119,8 @@ def exec_gyp(args):
 def process_env_options(opts):
     vars = ('OS', 'PLATFORM', 'GENERATOR_OUTPUT', 'FORMATS', 'DEPTH',
         'WIN_MSVS_VERSION', 'XCODE_TARGET_SDK', 'XCODE_HOST_SDK',
-        'TARGET_ARCH', 'PERL', 'ANDROID_NDK_VERSION', 'ANDROID_PLATFORM',
+        'TARGET_ARCH', 'PERL', 'ANDROID_NDK_VERSION',
+        'ANDROID_NDK_PLATFORM_VERSION', 'ANDROID_PLATFORM',
         'ANDROID_SDK', 'ANDROID_NDK', 'ANDROID_BUILD_TOOLS',
         'ANDROID_TOOLCHAIN', 'ANDROID_API_VERSION',
         'AR', 'CC', 'CXX', 'LINK', 'OBJCOPY', 'OBJDUMP',
@@ -423,6 +424,9 @@ def validate_android_tools(opts):
             error('Android NDK not found; set $ANDROID_NDK')
         opts['ANDROID_NDK'] = ndk
 
+    if opts['ANDROID_NDK_PLATFORM_VERSION'] is None:
+        opts['ANDROID_NDK_PLATFORM_VERSION'] = '16'
+
     if opts['ANDROID_API_VERSION'] is None:
         opts['ANDROID_API_VERSION'] = '26'
      
@@ -539,6 +543,7 @@ def configure_android(opts):
 
     export_opts(opts, ('ANDROID_BUILD_TOOLS', 'ANDROID_NDK',
                        'ANDROID_PLATFORM', 'ANDROID_SDK',
+                       'ANDROID_NDK_VERSION', 'ANDROID_NDK_PLATFORM_VERSION',
                        'ANDROID_API_VERSION',
                        'JAVA_SDK', 'AR', 'CC', 'CXX', 'LINK', 'OBJCOPY',
                        'OBJDUMP', 'STRIP'))

--- a/config/android.gypi
+++ b/config/android.gypi
@@ -8,7 +8,9 @@
 			'java_sdk_path%': '<!(echo ${JAVA_SDK})',
 			'android_sdk_path%': '<!(echo ${ANDROID_SDK})',
 			'android_ndk_path%': '<!(echo ${ANDROID_NDK})',
-			'android_api_version%': '<!(echo ${ANDROID_API_VERSION})',			
+			'android_api_version%': '<!(echo ${ANDROID_API_VERSION})',
+			'android_ndk_platform_version%': '<!(echo ${ANDROID_NDK_PLATFORM_VERSION})',
+			'android_ndk_version%': '<!(echo ${ANDROID_NDK_VERSION})',
 			'android_platform%': '<!(echo ${ANDROID_PLATFORM})',
 			'android_build_tools%': '<!(echo ${ANDROID_BUILD_TOOLS})',
 		},
@@ -30,7 +32,7 @@
 		'strip':   '<!(echo ${STRIP:-strip})',
 
 		'android_ndk_path%': '<(android_ndk_path)',
-		'android_api_version%': '<(android_api_version)',
+		'android_subplatform%': 'sdk<(android_api_version)_ndk<(android_ndk_platform_version)<(android_ndk_version)',
 	},
 	
 	'target_defaults':

--- a/docs/development/build-android.md
+++ b/docs/development/build-android.md
@@ -42,7 +42,7 @@ Create a standalone toolchain (this simplifies setting up the build environment)
 
 ````bash
 android-ndk-r15/build/tools/make_standalone_toolchain.py \
-    --arch arm --api 26 \
+    --arch arm --api 16 --deprecated-headers \
     --install-dir ${HOME}/android/toolchain/standalone
 ````
 
@@ -81,6 +81,7 @@ AR="${BINDIR}/${TRIPLE}-ar"
 
 # Android platform information
 ANDROID_NDK_VERSION=r15
+ANDROID_NDK_PLATFORM_VERSION=16
 ANDROID_API_VERSION=26
 ANDROID_PLATFORM=android-${ANDROID_API_VERSION}
 ANDROID_NDK=${TOOLCHAIN}/android-ndk-${ANDROID_NDK_VERSION}
@@ -90,7 +91,8 @@ ANDROID_LIB_PATH=${TOOLCHAIN}/standalone/${TRIPLE}/lib
 
 export JAVA_SDK
 export CC CXX LINK AR
-export ANDROID_PLATFORM ANDROID_NDK ANDROID_SDK ANDROID_BUILD_TOOLS
+export ANDROID_PLATFORM ANDROID_NDK ANDROID_NDK_PLATFORM_VERSION
+export ANDROID_SDK ANDROID_BUILD_TOOLS
 export ANDROID_LIB_PATH ANDROID_API_VERSION
 ````
 

--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -17,7 +17,7 @@ LIBS_emscripten=( ICU )
 
 SUBPLATFORMS_ios=(iPhoneSimulator8.2 iPhoneSimulator9.2 iPhoneSimulator10.2 iPhoneSimulator11.2 iPhoneSimulator11.4 iPhoneOS9.2 iPhoneOS10.2 iPhoneOS11.2 iPhoneOS11.4)
 SUBPLATFORMS_win32=(v140_static_debug v140_static_release)
-SUBPLATFORMS_android=(api26)
+SUBPLATFORMS_android=(sdk26_ndk16r15)
 
 # Fetch settings
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/prebuilt/libicu.gyp
+++ b/prebuilt/libicu.gyp
@@ -184,7 +184,7 @@
 									{
 										'library_dirs':
 										[
-											'lib/android/<(target_arch)/api<(android_api_version)',
+											'lib/android/<(target_arch)/<(android_subplatform)',
 										],
 										
 										'libraries':

--- a/prebuilt/libopenssl.gyp
+++ b/prebuilt/libopenssl.gyp
@@ -121,7 +121,7 @@
 						{
 							'library_dirs':
 							[
-								'lib/android/<(target_arch)/api<(android_api_version)',
+								'lib/android/<(target_arch)/<(android_subplatform)',
 							],
 							
 							'libraries':


### PR DESCRIPTION
The NDK platform version used to compile the android engine needs
to be 16 at the moment, in order to continue to support older
devices (4.1 upwards)