### PR TITLE
Force targetSdkVersion to API 26

### DIFF
--- a/engine/rsrc/android-manifest.xml
+++ b/engine/rsrc/android-manifest.xml
@@ -6,7 +6,7 @@
           ${INSTALL_LOCATION}>
 ${PUSH_PERMISSIONS}
 ${USES_PERMISSION}${USES_FEATURE}
-  <uses-sdk android:minSdkVersion="${MIN_SDK_VERSION}" android:targetSdkVersion="${MIN_SDK_VERSION}"/>
+  <uses-sdk android:minSdkVersion="${MIN_SDK_VERSION}" android:targetSdkVersion="26"/>
   <supports-screens
       android:largeScreens="true"
       android:normalScreens="true"


### PR DESCRIPTION
This is a temporary patch, forcing targetSdkVersion to 26, to comply with the new rules for app submission to the Play Store. In the future we can add a dropdown in the Standalone Settings, to allow users to choose a different targetSdkVersion, in case they don't intend to submit the app to the Play Store.