### PR TITLE
[[ Extensions ]] Map extension native code using module name

### DIFF
--- a/docs/notes/feature-module_code_mapping.md
+++ b/docs/notes/feature-module_code_mapping.md
@@ -1,0 +1,1 @@
+# Allow separate modules to load distinct code with the same name


### PR DESCRIPTION
As it stands, separate extensions cannot load distinct native code
with the same leaf name. Prepending the module name to the mapping
source name allows this to be done.