### PR TITLE
[Bug 21368] Ensure device can register for and receive remote notifications on Android

### DIFF
--- a/docs/notes/bugfix-21368.md
+++ b/docs/notes/bugfix-21368.md
@@ -1,0 +1,1 @@
+# Ensure push notifications work on Android when targetSdkVersion=26


### PR DESCRIPTION
Tested on Android 5.x, 7.x and 8.x.

Note that when the targetSdkVersion is 21+ then the notification icon *must* be transparent, otherwise it is shown as a solid white rectangle. 