### PR TITLE
[[ Bug 21386 ]] Set clipsToBounds of native container layer

### DIFF
--- a/docs/notes/bugfix-21386.md
+++ b/docs/notes/bugfix-21386.md
@@ -1,0 +1,1 @@
+# Fix widgets with native layers not being clipped by their parent group rect on iOS

--- a/engine/src/native-layer-ios.mm
+++ b/engine/src/native-layer-ios.mm
@@ -225,7 +225,8 @@ bool MCNativeLayer::CreateNativeContainer(MCObject *p_object, void *&r_view)
 		return false;
 	
 	[t_view setAutoresizesSubviews:NO];
-	
+    [t_view setClipsToBounds:YES];
+    
 	r_view = t_view;
 	
 	return true;


### PR DESCRIPTION
iOS UIViews do not clip child views to their bounds by default so the
child view is drawn iv it is on screen regardless of whether portions
are outside the bounds of the parent view. This patch sets the clipsToBounds
property of native container layers so that they will clip to the rect
of the group as intended.