### PR TITLE
[[ Bug 19420 ]] Fix crash on resume in commercial android engine

### DIFF
--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -856,6 +856,8 @@ void X_clear_globals(void)
     
     MChooks = nil;
 
+    memset(&MClicenseparameters, 0, sizeof(MCLicenseParameters));
+    
 #if defined(MCSSL)
     MCSocketsInitialize();
 #endif


### PR DESCRIPTION
Ensure MClicenseparameters struct is cleared in X_clear_globals
so that it does not contain any dangling pointers when android
apps are resumed.