### PR TITLE
[[ Engine ]] Add variant of params() which returns a sequence

### DIFF
--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2989,6 +2989,7 @@ void MCEngineEvalVariableNames(MCExecContext& ctxt, MCStringRef& r_string);
 void MCEngineEvalParam(MCExecContext& ctxt, integer_t p_index, MCValueRef& r_value);
 void MCEngineEvalParamCount(MCExecContext& ctxt, integer_t& r_count);
 void MCEngineEvalParams(MCExecContext& ctxt, MCStringRef& r_string);
+void MCEngineEvalParamsRange(MCExecContext& ctxt, integer_t p_start, integer_t p_finish, MCArrayRef& r_seq);
 
 void MCEngineEvalResult(MCExecContext& ctxt, MCValueRef& r_value);
 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2777,6 +2777,11 @@ enum Exec_errors
     // {EE-0909} android permission: bad permission name
     EE_BAD_PERMISSION_NAME,
     
+    // {EE-0910} params: bad start index
+    EE_PARAMS_BADSTART,
+    
+    // {EE-0911} params: bad finish index
+    EE_PARAMS_BADFINISH,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -1081,7 +1081,40 @@ Parse_stat MCParamCount::parse(MCScriptPoint &sp, Boolean the)
 
 Parse_stat MCParams::parse(MCScriptPoint &sp, Boolean the)
 {
-	return MCFunction::parse(sp, the);
+    if (!the)
+    {
+        if (get0or1or2params(sp, &(&start), &(&finish), the) != PS_NORMAL)
+        {
+            MCperror->add
+            (PE_MOUSE_BADPARAM, sp);
+            return PS_ERROR;
+        }
+    }
+    else
+        initpoint(sp);
+    
+    return PS_NORMAL;
+}
+
+void MCParams::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
+{
+    if (*start == nullptr)
+    {
+        MCEngineEvalParams(ctxt, r_value.stringref_value);
+        r_value.type = kMCExecValueTypeStringRef;
+        return;
+    }
+    
+    integer_t t_start;
+    if (!ctxt.EvalExprAsInt(*start, EE_PARAMS_BADSTART, t_start))
+        return;
+    
+    integer_t t_finish;
+    if (!ctxt.EvalOptionalExprAsInt(*finish, -1, EE_PARAMS_BADFINISH, t_finish))
+        return;
+    
+    MCEngineEvalParamsRange(ctxt, t_start, t_finish, r_value.arrayref_value);
+    r_value.type = kMCExecValueTypeArrayRef;
 }
 
 MCReplaceText::~MCReplaceText()

--- a/engine/src/funcs.h
+++ b/engine/src/funcs.h
@@ -1196,10 +1196,13 @@ public:
 	virtual Parse_stat parse(MCScriptPoint &, Boolean the);
 };
 
-class MCParams : public MCConstantFunctionCtxt<MCStringRef, MCEngineEvalParams>
+class MCParams : public MCFunction
 {
+    MCAutoPointer<MCExpression> start;
+    MCAutoPointer<MCExpression> finish;
 public:
-	virtual Parse_stat parse(MCScriptPoint &, Boolean the);
+    virtual Parse_stat parse(MCScriptPoint &, Boolean the);
+    virtual void eval_ctxt(MCExecContext &, MCExecValue &);
 };
 
 class MCPeerAddress : public MCUnaryFunctionCtxt<MCNameRef, MCStringRef, MCNetworkEvalPeerAddress, EE_HOSTADDRESS_BADSOCKET, PE_PEERADDRESS_BADSOCKET>

--- a/tests/lcs/core/engine/params.livecodescript
+++ b/tests/lcs/core/engine/params.livecodescript
@@ -1,0 +1,90 @@
+script "CoreEngineCommandParams"
+/*
+Copyright (C) 2017 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+command TestParams
+	local tExpectedParams
+	put format("params") into tExpectedParams
+	TestAssert "params() returns stringified params", _TestParams(1, "foo", empty) is format("_TestParams(\"1\",\"foo\",\"\")")
+
+	local tExpectedAllParams
+	put 1 into tExpectedAllParams[1]
+	put "foo" into tExpectedAllParams[2]
+	put "bar" into tExpectedAllParams[3]
+	put empty into tExpectedAllParams[4]
+	TestAssert "params(1) returns all params", _TestParamsFromOne(1, "foo", "bar", empty) is tExpectedAllParams
+	TestAssert "params(2) returns no params when one passed", _TestParamsFromTwo(1) is empty
+	TestAssert "params(1, the paramCount) returns all params", _TestParamsFromOneToParamCount(1, "foo", "bar", empty) is tExpectedAllParams
+	TestAssert "params(-the paramCount) returns all params", _TestParamsFromMinusParamCount(1, "foo", "bar", empty) is tExpectedAllParams
+	TestAssert "params(-the paramCount, -1) returns all params", _TestParamsFromMinusParamCountToMinusOne(1, "foo", "bar", empty) is tExpectedAllParams
+	TestAssert "params(0, the paramCount + 1) returns all params", _TestParamsFromZeroToParamCountPlusOne(1, "foo", "bar", empty) is tExpectedAllParams
+
+	local tExpectedMiddleParams
+	put "foo" into tExpectedMiddleParams[1]
+	put "bar" into tExpectedMiddleParams[2]
+	TestAssert "params(2, 3) returns middle two params", _TestParamsFromTwoToThree(1, "foo", "bar", empty) is tExpectedMiddleParams
+	TestAssert "params(-3, -2) returns middle two params", _TestParamsFromMinusThreeToMinusTwo(1, "foo", "bar", empty) is tExpectedMiddleParams
+	
+	TestAssert "params(3, 2) returns no params", _TestParamsFromThreeToTwo(1, "foo", "bar", empty) is empty
+	TestAssert "params(-2, -3) returns no params", _TestParamsFromMinusTwoToMinusThree(1, "foo", "bar", empty) is empty
+
+	TestAssert "params(2, 3) returns no params when none passed", _TestParamsFromTwoToThree() is empty
+end TestParams
+
+private function _TestParams
+	return the params
+end _TestParams
+
+private function _TestParamsFromOne
+	return params(1)
+end _TestParamsFromOne
+
+private function _TestParamsFromTwo
+	return params(2)
+end _TestParamsFromTwo
+
+private function _TestParamsFromOneToParamCount
+	return params(1, the paramCount)
+end _TestParamsFromOneToParamCount
+
+private function _TestParamsFromMinusParamCount
+	return params(-the paramCount)
+end _TestParamsFromMinusParamCount
+
+private function _TestParamsFromMinusParamCountToMinusOne
+	return params(-the paramCount, -1)
+end _TestParamsFromMinusParamCountToMinusOne
+
+private function _TestParamsFromZeroToParamCountPlusOne
+	return params(0, the paramCount + 1)
+end _TestParamsFromZeroToParamCountPlusOne
+
+private function _TestParamsFromTwoToThree
+	return params(2, 3)
+end _TestParamsFromTwoToThree
+
+private function _TestParamsFromMinusThreeToMinusTwo
+	return params(-3, -2)
+end _TestParamsFromMinusThreeToMinusTwo
+
+private function _TestParamsFromThreeToTwo
+	return params(3, 2)
+end _TestParamsFromThreeToTwo
+
+private function _TestParamsFromMinusTwoToMinusThree
+	return params(-2, -3)
+end _TestParamsFromMinusTwoToMinusThree


### PR DESCRIPTION
This patch adds a variant of the params function.

The params function can now take 0, 1 or 2 parameters.

Calling it with zero parameters has the same behavior as before -
it returns a stringified version of the call that was made.

Calling it with two parameters returns a range of parameters
as a numerically sequenced array. The first parameter indicates the
starting index (from 1), and the second parameter indicates the
finishing index (from 1). Both parameters may be negative, in which
case they are interpreted as being relative to 'the paramCount' in
the same way negative chunk indicies work.

If only one parameter is specified, the second is taken to be -1.