### PR TITLE
[[ Bug 21434 ]] Force bitmap view visible for visual effects

### DIFF
--- a/docs/notes/bugfix-21434.md
+++ b/docs/notes/bugfix-21434.md
@@ -1,0 +1,1 @@
+# Fix visual effects not working when acceleratedRendering is true on Android

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -2251,7 +2251,8 @@ public class Engine extends View implements EngineApi
     
 	public void showBitmapView()
 	{
-		ensureBitmapViewVisibility();
+        // force visible for visual effects
+		m_bitmap_view.setVisibility(View.VISIBLE);
 	}
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch fixes a regresion from a previous patch that changed the behavior
of the `showBitmapView` method to only set the visibility of `m_bitmap_view` to
visible if the OpenGL view is not visible. This interfered with visual effects
as they uset the bitmap view rather than OpenGL view.