### PR TITLE
[[ Bug 19550 ]] Add support for symbolic links in standalone builds

### DIFF
--- a/docs/notes/bugfix-19550.md
+++ b/docs/notes/bugfix-19550.md
@@ -1,0 +1,1 @@
+# Add support for symbolic links in Mac/Linux standalone applications

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -2549,7 +2549,17 @@ command revRedirectMacOSResourcesRecurse pSourceFolder, pTargetFolder
       if revRedirectMacOSResourcesIsExecutable(pSourceFolder & slash & tFile) then
          next repeat
       end if
-      rename (pSourceFolder & slash & tFile) to (pTargetFolder & slash & tFile)
+      switch the platform
+         case "macos"
+         case "linux"
+            get shell("mv" && quote & pSourceFolder & slash & tFile & quote && \
+                  quote & pTargetFolder & slash & tFile & quote)
+            break
+         case "windows"
+            --following line does not work properly for symlink folders
+            rename (pSourceFolder & slash & tFile) to (pTargetFolder & slash & tFile)
+            break
+      end switch
    end repeat
    
    local tFolder

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -258,7 +258,7 @@ private command __revSBCopyFolder pSource, pTarget, pCallback, pCallbackTarget, 
                   exit repeat
                end if
             end if
-            if the platform is "macos" then -- stat it and set some flags
+            if the platform is "macos" or the platform is "Linux" then -- stat it and set some flags
                local tUser, tGroup
                set the itemDelimiter to "/"
                set the defaultFolder to pSource & "/" & item 1 to -2 of tResource
@@ -297,6 +297,10 @@ private command __revSBCopyFolder pSource, pTarget, pCallback, pCallbackTarget, 
    
    set the defaultFolder to tOldFolder
    
+   if tResult is not empty then
+      revStandaloneAddWarning tResult & ":" && quote & pSource & quote
+   end if
+   
    return tResult
 end __revSBCopyFolder
 
@@ -310,9 +314,14 @@ private command __revSBCopyFile pSourceFile, pTargetFile, pCallback, pCallbackTa
    local tOldFolder, tSize, tPermissions, tUser, tGroup, tFileType
    local tResult
    
+   local tSourceFileIsLink
    if tResult is empty then
       if there is no file pSourceFile then
-         put "cannot find source file" into tResult
+         if __readlink(pSourceFile) is not empty then
+            put true into tSourceFileIsLink
+         else
+            put "cannot find source file" into tResult
+         end if
       end if
    end if
    
@@ -348,51 +357,63 @@ private command __revSBCopyFile pSourceFile, pTargetFile, pCallback, pCallbackTa
       end if
    end if
    
-   if tResult is empty then
-      open file pTargetFile for binary write
-      if the result is not empty then
-         put "cannot create target file" into tResult
-      end if
-   end if
-   
-   if tResult is empty then
-      open file pSourceFile for binary read
-      if the result is not empty then
-         put "cannot read from source file", the result into tResult
-      end if
-   end if
-   
-   local tAmountCopied
-   if tResult is empty then
-      if pCallbackTarget is not empty and there is a pCallbackTarget then
-         send pCallback && 0, tSize to pCallbackTarget
-      end if
-      repeat forever
-         read from file pSourceFile for 1048576
-         if the result is not empty and the result is not "eof" then
-            put "cannot read from source file", the result into tResult
-            exit repeat
+   if tSourceFileIsLink then
+      if tResult is empty then
+         # __readlink only works for MacOS and Linux so no need for a switch here
+         get shell("cp -a" && quote & pSourceFile & quote && \
+               quote & pTargetfile & quote)
+         if it is not empty then
+            put "cannot copy symbolic link" into tResult
          end if
-         if it is empty then
-            exit repeat
-         end if
-         write it to file pTargetFile
+         # Copying a symbolic link takes no time, so do not send a callback.
+      end if
+   else # regular file
+      if tResult is empty then
+         open file pTargetFile for binary write
          if the result is not empty then
-            put "cannot write to target file" into tResult
-            exit repeat
+            put "cannot create target file" into tResult
          end if
-         add the number of chars of it to tAmountCopied
+      end if
+      
+      if tResult is empty then
+         open file pSourceFile for binary read
+         if the result is not empty then
+            put "cannot read from source file", the result into tResult
+         end if
+      end if
+      
+      local tAmountCopied
+      if tResult is empty then
          if pCallbackTarget is not empty and there is a pCallbackTarget then
-            send pCallback && tAmountCopied, tSize to pCallbackTarget
+            send pCallback && 0, tSize to pCallbackTarget
          end if
-      end repeat
-   end if
-   
-   if pTargetFile is among the lines of the openFiles then
-      close file pTargetFile
-   end if
-   if pSourceFile is among the lines of the openFiles then
-      close file pSourceFile
+         repeat forever
+            read from file pSourceFile for 1048576
+            if the result is not empty and the result is not "eof" then
+               put "cannot read from source file", the result into tResult
+               exit repeat
+            end if
+            if it is empty then
+               exit repeat
+            end if
+            write it to file pTargetFile
+            if the result is not empty then
+               put "cannot write to target file" into tResult
+               exit repeat
+            end if
+            add the number of chars of it to tAmountCopied
+            if pCallbackTarget is not empty and there is a pCallbackTarget then
+               send pCallback && tAmountCopied, tSize to pCallbackTarget
+            end if
+         end repeat
+      end if
+      
+      if pTargetFile is among the lines of the openFiles then
+         close file pTargetFile
+      end if
+      if pSourceFile is among the lines of the openFiles then
+         close file pSourceFile
+      end if
    end if
    
    # OK-2007-11-30 : Modified to work for Linux too

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -316,12 +316,10 @@ private command __revSBCopyFile pSourceFile, pTargetFile, pCallback, pCallbackTa
    
    local tSourceFileIsLink
    if tResult is empty then
-      if there is no file pSourceFile then
-         if __readlink(pSourceFile) is not empty then
-            put true into tSourceFileIsLink
-         else
-            put "cannot find source file" into tResult
-         end if
+      if __readlink(pSourceFile) is not empty then
+         put true into tSourceFileIsLink
+      else if there is no file pSourceFile then
+         put "cannot find source file" into tResult
       end if
    end if
    


### PR DESCRIPTION
`__revSBCopyFolder` / `__revSBCopyFile` silently failed when attempting to copy directory structures that contain symbolic links.  The reason they failed was that `there is a file` returns false for symbolic *directory* links.

While adding symbolic link support, `rename` was discovered to not properly handle symbolic links to directories.  Instead of renaming the link, it would rename the referenced directory.

`__revSBCopyFolder`
- Updated folder owner/permission copy to include Linux
- Added code to return a warning if copy not successful

`__revSBCopyFile`
- Used `__readlink` to determine if a file is a link
- Added code to use `cp -a` to properly copy symbolic links
- Wrapped the existing code in an if/then/else block to handle regular files

`revRedirectMacOSResourcesRecurse`
- Use `mv` to rename files on Mac/Linux to properly handle symbolic links

Due to the indentation, the diff looks like more changed than it did.  Lines 360-370 of the new file are the lines that were added.  Lines 371-416 are just indented 3 spaces.  Line 417 of the new file is the closing `end if` for the block that was added.