### PR TITLE
[[ Bug 10881 ]] Fix keyboard panning view when acceleratedRendering true

### DIFF
--- a/docs/notes/bugfix-10881.md
+++ b/docs/notes/bugfix-10881.md
@@ -1,0 +1,1 @@
+# Fix view moving up when acceleratedRendering is true

--- a/engine/src/java/com/runrev/android/LiveCodeActivity.java
+++ b/engine/src/java/com/runrev/android/LiveCodeActivity.java
@@ -74,7 +74,7 @@ public class LiveCodeActivity extends Activity
 												  ViewGroup.LayoutParams.MATCH_PARENT));
         
         // prevent soft keyboard from resizing our view when shown
-        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
 	}
 
 	@Override


### PR DESCRIPTION
This patch changes the use of `SOFT_INPUT_ADJUST_RESIZE` to
`SOFT_INPUT_ADJUST_NOTHING` when the keyboard is presented. The OpenGLView was
not resizing and as a result was being pushed up by the keyboard and then
not returning. Additionally it is unnecesary to resize and therefore reconfigure
the bitmap when the keyboard is presented.