### PR TITLE
[[ Bug 21396 ]] Fix crash on startup in iOS 12 beta

### DIFF
--- a/docs/notes/bugfix-21396.md
+++ b/docs/notes/bugfix-21396.md
@@ -1,0 +1,1 @@
+# Fix crash on startup in iOS 12 beta

--- a/engine/src/cgimageutil.cpp
+++ b/engine/src/cgimageutil.cpp
@@ -114,7 +114,7 @@ bool MCGRasterCreateCGDataProvider(const MCGRaster &p_raster, const MCGIntegerRe
 	t_width = p_src_rect.size.width;
 	t_height = p_src_rect.size.height;
 	
-	const uint8_t *t_src_ptr = (uint8_t*)MCGRasterGetPixelPtr(p_raster, t_x, t_y);
+	uint8_t *t_src_ptr = (uint8_t*)MCGRasterGetPixelPtr(p_raster, t_x, t_y);
 	
 	uint32_t t_dst_stride;
 	
@@ -125,8 +125,10 @@ bool MCGRasterCreateCGDataProvider(const MCGRaster &p_raster, const MCGIntegerRe
 	if (!p_copy)
 	{
 		t_dst_stride = p_raster.stride;
-		t_data_provider = CGDataProviderCreateWithData(nil, t_src_ptr, t_height * p_raster.stride, nil);
+		t_data_provider = CGDataProviderCreateWithData(nil, t_src_ptr, t_height * p_raster.stride, __CGDataProviderDeallocate);
 		t_success = t_data_provider != nil;
+        if (!t_success)
+            MCMemoryDeallocate(t_src_ptr);
 	}
 	else
 	{

--- a/engine/src/mac-cursor.mm
+++ b/engine/src/mac-cursor.mm
@@ -137,7 +137,7 @@ void MCPlatformCreateCustomCursor(MCImageBitmap *p_image, MCPoint p_hotspot, MCP
 	t_cursor -> is_standard = false;
 	
 	CGImageRef t_cg_image;
-	/* UNCHECKED */ MCImageBitmapToCGImage(p_image, false, false, t_cg_image);
+	/* UNCHECKED */ MCImageBitmapToCGImage(p_image, true, false, t_cg_image);
 	
 	// Convert the CGImage into an NSIMage
 	NSImage *t_cursor_image;

--- a/engine/src/mac-surface.mm
+++ b/engine/src/mac-surface.mm
@@ -317,7 +317,6 @@ void MCMacPlatformSurface::Unlock(void)
         // IM-2014-10-03: [[ Bug 13432 ]] Render with copy blend mode to replace destination alpha with the source alpha.
         MCMacRenderRasterToCG(m_cg_context, t_dst_rect, m_raster, MCGRectangleMake(0, 0, m_raster.width, m_raster.height), 1.0, kMCGBlendModeCopy);
         
-        free(m_raster . pixels);
         m_raster . pixels = nil;
     }
 


### PR DESCRIPTION
This patch fixes an issue where the view layer appears to be retaining the
`CGDataProvider` from an image when it is drawn via `CGContextDrawImage`.
As we were freeing the raster directly after the draw the `CALayer` could not
access it from the `CGDataProvider` when rendering causing a crash.

This patch therefore changes the behavior of `MCGRasterCreateCGDataProvider`
where previously when calling it with the copy parameter `false` it would be
left to the caller to free the buffer the data provider now takes ownership
of it and it is freed via the data provider free callback. As a consequence
of the change custom cursor creation on mac now copies the buffer for
simplicity.