### PR TITLE
Update .gitignore to exclude more build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,12 @@ encryptedstack.cpp
 encryptedstack.h
 stacksecurity_encrypted.cpp
 util/perfect/perfect.linux-*
-extensions/*/*/*.xml
-extensions/*/*/*.lci
-extensions/*/*/*.lcm
-extensions/*/*/*.lce
-extensions/*/*/api.lcdoc
+**/extensions/*/*/*.xml
+**/extensions/*/*/*.lci
+**/extensions/*/*/*.lcm
+**/extensions/*/*/*.lce
+**/extensions/*/*/api.lcdoc
+*/src/.lci/*
 
 # Compiled source and intermediates #
 ###################


### PR DESCRIPTION
Added/modified lines to remove additional files from being recognized as
candidates for committing to the repository.

`tests/lcs/extensions/...` - By adding `**` the the front of the
extensions exclusions, it will catch these files as well

`engine/src/.lci/*` and `libscript/src/.lci/*`