### PR TITLE
[[ Bug 18309 ]] Implement filter where expression

### DIFF
--- a/docs/dictionary/command/filter.lcdoc
+++ b/docs/dictionary/command/filter.lcdoc
@@ -6,6 +6,8 @@ Syntax: filter [{lines | items | keys | elements} of] <filterSource> {with| with
 
 Syntax: filter [{lines | items | keys | elements} of] <filterSource> {with| without | [not] matching} regex [pattern] <regexPattern> [into <targetContainer>]
 
+Syntax: filter [{lines | items | keys | elements} of] <filterSource> where <whereExpression> [into <targetContainer>]
+
 Summary:
 Filters each line, item, key or element in a source container or expression,
 removing the lines, items, keys or elements that do or don't match a pattern.
@@ -53,6 +55,21 @@ put false into tArray["bar"]
 filter elements of tArray without "f*"
 put the keys of tArray is "foo"
 
+Example:
+create field "Numbers"
+put "123,234,345,456,567,678,789" into field "Numbers"
+filter items of field "Numbers" where each >= 300 and each <= 500
+-- field contains "345,456,567"
+
+Example:
+command FilterIt pValue
+   filter lines of pValue where checkLine(each)
+end FilterIt
+
+function checkLine pLine
+   return item 1 of pLine > item 2 of pLine
+end checkLine
+
 Parameters:
 filterSource:
 An expression that evaluates to a string, array, or a container.
@@ -68,6 +85,9 @@ guide for more info on regex usage.
 
 targetContainer:
 An expression that evaluates to a container.
+
+whereExpression:
+An expression that evaluates to a boolean.
 
 It:
 If the filter command is used on a <filterSource> which is not
@@ -134,6 +154,9 @@ character which is not a, b or c (upper or lower case)
 If no <targetContainer> is specified, and you filter a <container>, 
 the <container> contents will be replaced by the filtered result.
 
+When using the where form of the <filter> command the <each> keyword may
+be used in the <whereExpression> for the value to be filtered.
+
 Changes:
 The <filter>...without form was added in version 2.1.1. In previous
 versions, the <filter> command could be used only to retrieve lines that
@@ -147,11 +170,12 @@ could be used only for a container. The <filter>...[not] matching form
 was added in version 6.1 to clarify the pattern handling. The
 <filter>...into form was added in version 6.1. In previous versions, the
 filter command always replaced the contents of the original container.
-Filtering of array keys and elements was added in version 8.1.
+Filtering of array keys and elements was added in version 8.1. The where
+form of the filter command was added in version 9.5.
 
 References: replace (command), sort (command), matchChunk (function),
 matchText (function), replaceText (function), it (keyword),
 caseSensitive (property), container (glossary), expression (glossary),
-regular expression (glossary)
+regular expression (glossary), each (keyword)
 
 Tags: text processing

--- a/docs/dictionary/command/filter.lcdoc
+++ b/docs/dictionary/command/filter.lcdoc
@@ -2,9 +2,9 @@ Name: filter
 
 Type: command
 
-Syntax: filter [{lines | items | keys | elements} of] <filterSource> {with| without | [not] matching} [wildcard pattern] <wildcardPattern> [into <targetContainer>]
+Syntax: filter [{lines | items | keys | elements} of] <filterSource> {with| without | [not] matching} [wildcard] [pattern] <wildcardPattern> [into <targetContainer>]
 
-Syntax: filter [{lines | items | keys | elements} of] <filterSource> {with| without | [not] matching} regex pattern <regexPattern> [into <targetContainer>]
+Syntax: filter [{lines | items | keys | elements} of] <filterSource> {with| without | [not] matching} regex [pattern] <regexPattern> [into <targetContainer>]
 
 Summary:
 Filters each line, item, key or element in a source container or expression,

--- a/docs/notes/bugfix-18309.md
+++ b/docs/notes/bugfix-18309.md
@@ -1,0 +1,8 @@
+# Implement filter where clause
+
+A new clause has been added to the filter command to filter where an expression
+evaluates to true. For example:
+
+    put "foo,bar,baz" into tList
+    filter items of tList where each begins with "b"
+    -- tList contains "bar,baz"

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -883,12 +883,6 @@ MCFilter::~MCFilter()
 // JS-2013-07-01: [[ EnhancedFilter ]] Rewritten to support new filter syntax.
 Parse_stat MCFilter::parse(MCScriptPoint &sp)
 {
-	// Syntax :
-	//   filter [ { lines | items | keys | elements } of ] <container_or_exp>
-	//          { with | without | [ not ] matching }
-	//          [ { wildcard | regex } [ pattern ] ] <pattern>
-	//          [ into <container> ]
-	//
 	Parse_errors t_error;
 	t_error = PE_UNDEFINED;
     

--- a/engine/src/cmdsf.cpp
+++ b/engine/src/cmdsf.cpp
@@ -942,20 +942,28 @@ Parse_stat MCFilter::parse(MCScriptPoint &sp)
 		else if (sp.skip_token(SP_FACTOR, TT_UNOP, O_NOT) == PS_NORMAL
 				 && sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_MATCHING) == PS_NORMAL)
 			discardmatches = True;
+        else if (sp.skip_token(SP_MARK, TT_UNDEFINED, MC_WHERE) == PS_NORMAL)
+        {
+            discardmatches = False;
+            matchmode = MA_EXPRESSION;
+        }
 		else
 			t_error = PE_FILTER_NOWITH;
 	}
 
 	// Now look for the optional pattern match mode
-	if (t_error == PE_UNDEFINED)
+	if (t_error == PE_UNDEFINED && matchmode == MA_UNDEFINED)
 	{
 		if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_REGEX) == PS_NORMAL)
 			matchmode = MA_REGEX;
-		else if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_WILDCARD) == PS_NORMAL)
+        else if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_WILDCARD) == PS_NORMAL)
 			matchmode = MA_WILDCARD;
-		// Skip the optional pattern keyword
+        // Skip the optional pattern keyword
 		sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_PATTERN);
 	}
+    
+    if (matchmode == MA_UNDEFINED)
+        matchmode = MA_WILDCARD;
 
 	// Now parse the pattern expression
 	if (t_error == PE_UNDEFINED && sp.parseexp(False, True, &pattern) != PS_NORMAL)
@@ -1000,8 +1008,11 @@ void MCFilter::exec_ctxt(MCExecContext &ctxt)
             return;
     }
     
-    if (!ctxt . EvalExprAsStringRef(pattern, EE_FILTER_CANTGETPATTERN, &t_pattern))
-        return;
+    if (matchmode != MA_EXPRESSION)
+    {
+        if (!ctxt . EvalExprAsStringRef(pattern, EE_FILTER_CANTGETPATTERN, &t_pattern))
+            return;
+    }
         
     MCAutoStringRef t_source_string;
     MCAutoArrayRef t_source_array;
@@ -1025,74 +1036,74 @@ void MCFilter::exec_ctxt(MCExecContext &ctxt)
     
     bool stat;
     
-    if (container == nil && target == nil)
+    if (chunktype == CT_LINE || chunktype == CT_ITEM)
     {
+        MCAutoStringRef t_output_string;
         
-        if (chunktype == CT_LINE || chunktype == CT_ITEM)
-        {
-            if (matchmode == MA_REGEX)
-                MCStringsExecFilterRegexIntoIt(ctxt, *t_source_string, *t_pattern, discardmatches == True, chunktype == CT_LINE);
-            else
-                MCStringsExecFilterWildcardIntoIt(ctxt, *t_source_string, *t_pattern, discardmatches == True, chunktype == CT_LINE);
-        }
+        if (matchmode == MA_REGEX)
+            MCStringsExecFilterRegex(ctxt, *t_source_string, *t_pattern, discardmatches == True, chunktype == CT_LINE, &t_output_string);
+        else if (matchmode == MA_EXPRESSION)
+            MCStringsExecFilterExpression(ctxt, *t_source_string, pattern, discardmatches == True, chunktype == CT_LINE, &t_output_string);
         else
+            MCStringsExecFilterWildcard(ctxt, *t_source_string, *t_pattern, discardmatches == True, chunktype == CT_LINE, &t_output_string);
+        
+        if (*t_output_string != nil)
         {
-            if (matchmode == MA_REGEX)
-                MCArraysExecFilterRegexIntoIt(ctxt, *t_source_array, *t_pattern, discardmatches == True, chunktype == CT_KEY);
+            if (target != nil)
+                stat = target -> set(ctxt, PT_INTO, *t_output_string);
+            else if (container != nil)
+                stat = container -> set(ctxt, PT_INTO, *t_output_string);
             else
-                MCArraysExecFilterWildcardIntoIt(ctxt, *t_source_array, *t_pattern, discardmatches == True, chunktype == CT_KEY);
+            {
+                ctxt . SetItToValue(*t_output_string);
+                stat = true;
+            }
+                
+            if (!stat)
+            {
+                ctxt . LegacyThrow(EE_FILTER_CANTSET);
+                return;
+            }
+        }
+        else if (target == nil && container == nil)
+        {
+            ctxt . SetItToEmpty();
         }
     }
     else
     {
-        if (chunktype == CT_LINE || chunktype == CT_ITEM)
-        {
-            MCAutoStringRef t_output_string;
-            
-            if (matchmode == MA_REGEX)
-                MCStringsExecFilterRegex(ctxt, *t_source_string, *t_pattern, discardmatches == True, chunktype == CT_LINE, &t_output_string);
-            else
-                MCStringsExecFilterWildcard(ctxt, *t_source_string, *t_pattern, discardmatches == True, chunktype == CT_LINE, &t_output_string);
-            
-            if ((target != nil || container != nil) && *t_output_string != nil)
-            {
-                if (target != nil)
-                    stat = target -> set(ctxt, PT_INTO, *t_output_string);
-                else
-                    stat = container -> set(ctxt, PT_INTO, *t_output_string);
-                
-                if (!stat)
-                {
-                    ctxt . LegacyThrow(EE_FILTER_CANTSET);
-                    return;
-                }
-            }
-
-        }
+        MCAutoArrayRef t_output_array;
+        
+        if (matchmode == MA_REGEX)
+            MCArraysExecFilterRegex(ctxt, *t_source_array, *t_pattern, discardmatches == True, chunktype == CT_KEY, &t_output_array);
+        else if (matchmode == MA_EXPRESSION)
+            MCArraysExecFilterExpression(ctxt, *t_source_array, pattern, discardmatches == True, chunktype == CT_KEY, &t_output_array);
         else
+            MCArraysExecFilterWildcard(ctxt, *t_source_array, *t_pattern, discardmatches == True, chunktype == CT_KEY, &t_output_array);
+        
+        if (*t_output_array != nil)
         {
-            MCAutoArrayRef t_output_array;
-            
-            if (matchmode == MA_REGEX)
-                MCArraysExecFilterRegex(ctxt, *t_source_array, *t_pattern, discardmatches == True, chunktype == CT_KEY, &t_output_array);
+            if (target != nil)
+                stat = target -> set(ctxt, PT_INTO, *t_output_array);
+            else if (container != nil)
+                stat = container -> set(ctxt, PT_INTO, *t_output_array);
             else
-                MCArraysExecFilterWildcard(ctxt, *t_source_array, *t_pattern, discardmatches == True, chunktype == CT_KEY, &t_output_array);
-            
-            if ((target != nil || container != nil) && *t_output_array != nil)
             {
-                if (target != nil)
-                    stat = target -> set(ctxt, PT_INTO, *t_output_array);
-                else
-                    stat = container -> set(ctxt, PT_INTO, *t_output_array);
-                
-                if (!stat)
-                {
-                    ctxt . LegacyThrow(EE_FILTER_CANTSET);
-                    return;
-                }
+                ctxt . SetItToValue(*t_output_array);
+                stat = true;
             }
-
+            
+            if (!stat)
+            {
+                ctxt . LegacyThrow(EE_FILTER_CANTSET);
+                return;
+            }
         }
+        else if (target == nil && container == nil)
+        {
+            ctxt . SetItToEmpty();
+        }
+
     }
     
     if (ctxt . HasError())

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -1415,26 +1415,12 @@ void MCArraysExecFilterRegex(MCExecContext& ctxt, MCArrayRef p_source, MCStringR
     MCArraysExecFilter(ctxt, p_source, p_without, &t_matcher, p_match_keys, r_result);
 }
 
-void MCArraysExecFilterWildcardIntoIt(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_match_keys)
+void MCArraysExecFilterExpression(MCExecContext& ctxt, MCArrayRef p_source, MCExpression* p_expression, bool p_without, bool p_match_keys, MCArrayRef &r_result)
 {
-    MCAutoArrayRef t_result;
-    MCArraysExecFilterWildcard(ctxt, p_source, p_pattern, p_without, p_match_keys, &t_result);
+    // Create the pattern matcher
+    MCExpressionMatcher t_matcher(p_expression, p_source, ctxt . GetStringComparisonType());
     
-    if (*t_result != nil)
-        ctxt . SetItToValue(*t_result);
-    else
-        ctxt . SetItToEmpty();
-}
-
-void MCArraysExecFilterRegexIntoIt(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_match_keys)
-{
-    MCAutoArrayRef t_result;
-    MCArraysExecFilterRegex(ctxt, p_source, p_pattern, p_without, p_match_keys, &t_result);
-    
-    if (*t_result != nil)
-        ctxt . SetItToValue(*t_result);
-    else
-        ctxt . SetItToEmpty();
+    MCArraysExecFilter(ctxt, p_source, p_without, &t_matcher, p_match_keys, r_result);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-array.cpp
+++ b/engine/src/exec-array.cpp
@@ -1395,31 +1395,24 @@ void MCArraysExecFilter(MCExecContext& ctxt, MCArrayRef p_source, bool p_without
 void MCArraysExecFilterWildcard(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_match_keys, MCArrayRef &r_result)
 {
     // Create the pattern matcher
-    MCPatternMatcher *t_matcher;
-    t_matcher = new (nothrow) MCWildcardMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+    MCWildcardMatcher t_matcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
-    MCArraysExecFilter(ctxt, p_source, p_without, t_matcher, p_match_keys, r_result);
-    
-    delete t_matcher;
+    MCArraysExecFilter(ctxt, p_source, p_without, &t_matcher, p_match_keys, r_result);
 }
 
 void MCArraysExecFilterRegex(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_match_keys, MCArrayRef &r_result)
 {
     // Create the pattern matcher
-    MCPatternMatcher *t_matcher;
-    t_matcher = new (nothrow) MCRegexMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+    MCRegexMatcher t_matcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
     MCAutoStringRef t_regex_error;
-    if (!t_matcher -> compile(&t_regex_error))
+    if (!t_matcher.compile(&t_regex_error))
     {
-        delete t_matcher;
         ctxt . LegacyThrow(EE_MATCH_BADPATTERN);
         return;
     }
     
-    MCArraysExecFilter(ctxt, p_source, p_without, t_matcher, p_match_keys, r_result);
-    
-    delete t_matcher;
+    MCArraysExecFilter(ctxt, p_source, p_without, &t_matcher, p_match_keys, r_result);
 }
 
 void MCArraysExecFilterWildcardIntoIt(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_match_keys)

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -1942,7 +1942,7 @@ void MCStringsExecFilterDelimited(MCExecContext& ctxt, MCStringRef p_source, boo
             t_chunk_range . length = t_found_range . offset - t_last_offset;
         }
         
-        if (t_success && (p_matcher -> match(t_chunk_range) != p_without))
+        if (t_success && (p_matcher -> match(ctxt, t_chunk_range) != p_without))
         {
             MCAutoStringRef t_line;
             t_success = MCStringCopySubstring(p_source, t_chunk_range, &t_line) && MCListAppend(*t_output, *t_line);
@@ -1986,26 +1986,12 @@ void MCStringsExecFilterRegex(MCExecContext& ctxt, MCStringRef p_source, MCStrin
     MCStringsExecFilterDelimited(ctxt, p_source, p_without, p_lines ? ctxt . GetLineDelimiter() : ctxt . GetItemDelimiter(), &t_matcher, r_result);
 }
 
-void MCStringsExecFilterWildcardIntoIt(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines)
+void MCStringsExecFilterExpression(MCExecContext& ctxt, MCStringRef p_source, MCExpression* p_expression, bool p_without, bool p_lines, MCStringRef &r_result)
 {
-    MCAutoStringRef t_result;
-    MCStringsExecFilterWildcard(ctxt, p_source, p_pattern, p_without, p_lines, &t_result);
+    // Create the pattern matcher
+    MCExpressionMatcher t_matcher(p_expression, p_source, ctxt . GetStringComparisonType());
     
-    if (*t_result != nil)
-        ctxt . SetItToValue(*t_result);
-    else
-        ctxt . SetItToEmpty();
-}
-
-void MCStringsExecFilterRegexIntoIt(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines)
-{
-    MCAutoStringRef t_result;
-    MCStringsExecFilterRegex(ctxt, p_source, p_pattern, p_without, p_lines, &t_result);
-
-    if (*t_result != nil)
-        ctxt . SetItToValue(*t_result);
-    else
-        ctxt . SetItToEmpty();
+    MCStringsExecFilterDelimited(ctxt, p_source, p_without, p_lines ? ctxt . GetLineDelimiter() : ctxt . GetItemDelimiter(), &t_matcher, r_result);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -1966,31 +1966,24 @@ void MCStringsExecFilterDelimited(MCExecContext& ctxt, MCStringRef p_source, boo
 void MCStringsExecFilterWildcard(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines, MCStringRef &r_result)
 {
     // Create the pattern matcher
-	MCPatternMatcher *matcher;
-    matcher = new (nothrow) MCWildcardMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+	MCWildcardMatcher t_matcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
-    MCStringsExecFilterDelimited(ctxt, p_source, p_without, p_lines ? ctxt . GetLineDelimiter() : ctxt . GetItemDelimiter(), matcher, r_result);
-    
-    delete matcher;
+    MCStringsExecFilterDelimited(ctxt, p_source, p_without, p_lines ? ctxt . GetLineDelimiter() : ctxt . GetItemDelimiter(), &t_matcher, r_result);
 }
 
 void MCStringsExecFilterRegex(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines, MCStringRef &r_result)
 {
 	// Create the pattern matcher
-	MCPatternMatcher *matcher;
-    matcher = new (nothrow) MCRegexMatcher(p_pattern, p_source, ctxt . GetStringComparisonType());
+	MCRegexMatcher t_matcher(p_pattern, p_source, ctxt . GetStringComparisonType());
     
     MCAutoStringRef t_regex_error;
-    if (!matcher -> compile(&t_regex_error))
+    if (!t_matcher.compile(&t_regex_error))
     {
-        delete matcher;
         ctxt . LegacyThrow(EE_MATCH_BADPATTERN);
         return;
     }
     
-    MCStringsExecFilterDelimited(ctxt, p_source, p_without, p_lines ? ctxt . GetLineDelimiter() : ctxt . GetItemDelimiter(), matcher, r_result);
-    
-    delete matcher;
+    MCStringsExecFilterDelimited(ctxt, p_source, p_without, p_lines ? ctxt . GetLineDelimiter() : ctxt . GetItemDelimiter(), &t_matcher, r_result);
 }
 
 void MCStringsExecFilterWildcardIntoIt(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines)

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1854,9 +1854,7 @@ void MCArraysEvalIsNotAmongTheKeysOf(MCExecContext& ctxt, MCNameRef p_key, MCArr
 
 void MCArraysExecFilterWildcard(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines, MCArrayRef &r_result);
 void MCArraysExecFilterRegex(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines, MCArrayRef &r_result);
-void MCArraysExecFilterWildcardIntoIt(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines);
-void MCArraysExecFilterRegexIntoIt(MCExecContext& ctxt, MCArrayRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines);
-
+void MCArraysExecFilterExpression(MCExecContext& ctxt, MCArrayRef p_source, MCExpression* p_expression, bool p_without, bool p_lines, MCArrayRef &r_result);
 
 ///////////
 
@@ -2060,8 +2058,7 @@ void MCStringsExecReplace(MCExecContext& ctxt, MCStringRef p_pattern, MCStringRe
 
 void MCStringsExecFilterWildcard(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines, MCStringRef &r_result);
 void MCStringsExecFilterRegex(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines, MCStringRef &r_result);
-void MCStringsExecFilterWildcardIntoIt(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines);
-void MCStringsExecFilterRegexIntoIt(MCExecContext& ctxt, MCStringRef p_source, MCStringRef p_pattern, bool p_without, bool p_lines);
+void MCStringsExecFilterExpression(MCExecContext& ctxt, MCStringRef p_source, MCExpression* p_expression, bool p_without, bool p_lines, MCStringRef &r_result);
 
 void MCStringsEvalIsAscii(MCExecContext& ctxt, MCValueRef p_string, bool& r_result);
 void MCStringsEvalIsNotAscii(MCExecContext& ctxt, MCValueRef p_string, bool& r_result);

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -730,7 +730,8 @@ enum Mark_constants {
 enum Match_mode {
     MA_UNDEFINED,
     MA_WILDCARD,
-    MA_REGEX
+    MA_REGEX,
+    MA_EXPRESSION
 };
 
 enum Move_mode {

--- a/engine/src/patternmatcher.cpp
+++ b/engine/src/patternmatcher.cpp
@@ -42,14 +42,18 @@
 
 MCPatternMatcher::MCPatternMatcher(MCStringRef p_pattern, MCStringRef p_string, MCStringOptions p_options)
 {
-    m_pattern = MCValueRetain(p_pattern);
+    m_pattern = p_pattern;
+    if (m_pattern != nil)
+        MCValueRetain(m_pattern);
     m_string_source = MCValueRetain(p_string);
     m_options = p_options;
     m_array_source = nil;
 }
 MCPatternMatcher::MCPatternMatcher(MCStringRef p_pattern, MCArrayRef p_array, MCStringOptions p_options)
 {
-    m_pattern = MCValueRetain(p_pattern);
+    m_pattern = p_pattern;
+    if (m_pattern != nil)
+        MCValueRetain(m_pattern);
     m_array_source = MCValueRetain(p_array);
     m_options = p_options;
     m_string_source = nil;
@@ -109,7 +113,7 @@ bool MCRegexMatcher::compile(MCStringRef& r_error)
     return true;
 }
 
-bool MCRegexMatcher::match(MCRange p_range)
+bool MCRegexMatcher::match(MCExecContext& ctxt, MCRange p_range)
 {
     // if appropriate, normalize the source string.
     // AL-2014-07-11: [[ Bug 12797 ]] Compare options correctly and normalize the source, not the pattern
@@ -125,7 +129,7 @@ bool MCRegexMatcher::match(MCRange p_range)
     
 }
 
-bool MCRegexMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key)
+bool MCRegexMatcher::match(MCExecContext& ctxt, MCNameRef p_key, bool p_match_key)
 {
     MCAutoStringRef t_string;
     MCAutoStringRef t_normalized_source;
@@ -282,7 +286,7 @@ static bool MCStringsWildcardMatchNative(const char *s, uindex_t s_length, const
     return p_index == p_length;
 }
 
-bool MCWildcardMatcher::match(MCRange p_source_range)
+bool MCWildcardMatcher::match(MCExecContext& ctxt, MCRange p_source_range)
 {
     if (m_native)
     {
@@ -297,7 +301,7 @@ bool MCWildcardMatcher::match(MCRange p_source_range)
     return MCStringWildcardMatch(m_string_source, p_source_range, m_pattern, m_options);
 }
 
-bool MCWildcardMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key)
+bool MCWildcardMatcher::match(MCExecContext& ctxt, MCNameRef p_key, bool p_match_key)
 {
     MCAutoStringRef t_string;
     if (p_match_key)
@@ -313,3 +317,71 @@ bool MCWildcardMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_
     
     return MCStringWildcardMatch(*t_string, MCRangeMake(0, MCStringGetLength(*t_string)), m_pattern, m_options);
 }
+
+
+MCExpressionMatcher::MCExpressionMatcher(MCExpression* p_expression, MCStringRef p_string, MCStringOptions p_options)
+    : MCPatternMatcher(nil, p_string, p_options)
+{
+    m_expression = p_expression;
+}
+
+MCExpressionMatcher::MCExpressionMatcher(MCExpression* p_expression, MCArrayRef p_array, MCStringOptions p_options)
+    : MCPatternMatcher(nil, p_array, p_options)
+{
+    m_expression = p_expression;
+}
+
+MCExpressionMatcher::~MCExpressionMatcher()
+{
+}
+
+bool MCExpressionMatcher::compile(MCStringRef& r_error)
+{
+    // expression patterns are not compiled
+    return true;
+}
+
+bool MCExpressionMatcher::match(MCExecContext& ctxt, MCRange p_source_range)
+{
+    MCAutoStringRef t_string;
+    if (!MCStringCopySubstring(m_string_source, p_source_range, &t_string))
+        return false;
+    
+    MCeach->set(ctxt, *t_string);
+    
+    MCerrorlock++;
+    bool t_match, t_success;
+    t_success = ctxt . EvalExprAsBool(m_expression, EE_UNDEFINED, t_match);
+    MCerrorlock--;
+    
+    if (!t_success)
+        return t_success;
+    
+    return t_match;
+}
+
+bool MCExpressionMatcher::match(MCExecContext& ctxt, MCNameRef p_key, bool p_match_key)
+{
+    if (p_match_key)
+    {
+        MCeach->set(ctxt, p_key);
+    }
+    else
+    {
+        MCValueRef t_element;
+        if (!MCArrayFetchValue(m_array_source, m_options == kMCStringOptionCompareCaseless, p_key, t_element))
+            return false;
+        MCeach->set(ctxt, t_element);
+    }
+    
+    MCerrorlock++;
+    bool t_match, t_success;
+    t_success = ctxt . EvalExprAsBool(m_expression, EE_UNDEFINED, t_match);
+    MCerrorlock--;
+    
+    if (!t_success)
+        return t_success;
+    
+    return t_match;
+}
+

--- a/engine/src/patternmatcher.h
+++ b/engine/src/patternmatcher.h
@@ -32,8 +32,8 @@ public:
     MCPatternMatcher(MCStringRef p_pattern, MCArrayRef p_array, MCStringOptions p_options);
     virtual ~MCPatternMatcher();
     virtual bool compile(MCStringRef& r_error) = 0;
-    virtual bool match(MCRange p_range) = 0;
-    virtual bool match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key) = 0;
+    virtual bool match(MCExecContext& ctxt, MCRange p_range) = 0;
+    virtual bool match(MCExecContext& ctxt, MCNameRef p_key, bool p_match_key) = 0;
     MCStringRef getstringsource()
     {
         return m_string_source;
@@ -49,8 +49,8 @@ public:
     MCRegexMatcher(MCStringRef p_pattern, MCArrayRef p_array, MCStringOptions p_options);
     virtual ~MCRegexMatcher();
     virtual bool compile(MCStringRef& r_error);
-    virtual bool match(MCRange p_range);
-    virtual bool match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key);
+    virtual bool match(MCExecContext& ctxt, MCRange p_range);
+    virtual bool match(MCExecContext& ctxt, MCNameRef p_key, bool p_match_key);
 };
 
 class MCWildcardMatcher : public MCPatternMatcher
@@ -61,8 +61,22 @@ public:
     MCWildcardMatcher(MCStringRef p_pattern, MCArrayRef p_array, MCStringOptions p_options);
     virtual ~MCWildcardMatcher();
     virtual bool compile(MCStringRef& r_error);
-    virtual bool match(MCRange p_range);
-    virtual bool match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key);
+    virtual bool match(MCExecContext& ctxt, MCRange p_range);
+    virtual bool match(MCExecContext& ctxt, MCNameRef p_key, bool p_match_key);
+protected:
+    static bool match(const char *s, const char *p, Boolean cs);
+};
+
+class MCExpressionMatcher : public MCPatternMatcher
+{
+    MCExpression * m_expression;
+public:
+    MCExpressionMatcher(MCExpression* p_expression, MCStringRef p_string, MCStringOptions p_options);
+    MCExpressionMatcher(MCExpression* p_expression, MCArrayRef p_array, MCStringOptions p_options);
+    virtual ~MCExpressionMatcher();
+    virtual bool compile(MCStringRef& r_error);
+    virtual bool match(MCExecContext& ctxt, MCRange p_range);
+    virtual bool match(MCExecContext& ctxt, MCNameRef p_key, bool p_match_key);
 protected:
     static bool match(const char *s, const char *p, Boolean cs);
 };

--- a/tests/lcs/core/array/filter.livecodescript
+++ b/tests/lcs/core/array/filter.livecodescript
@@ -299,6 +299,24 @@ on TestFilterRegex
 	filter keys of tSource with regex pattern "f.*" into tTest
 	TestAssert "filter keys of array with regex", the keys of tTest is "foo"
 	
+	put "foo" into tSource["foo"]
+	put "bar" into tSource["bar"]
+	
 	filter elements of tSource with regex pattern "f.*" into tTest
 	TestAssert "filter elements of array with regex", the keys of tTest is "foo"
 end TestFilterRegex
+
+on TestFilterExpression
+	local tSource, tTest
+	put "foo" into tSource["foo"]
+	put "bar" into tSource["bar"]
+	
+	filter keys of tSource where each begins with "f" into tTest
+	TestAssert "filter keys of array where expression", the keys of tTest is "foo"
+	
+	put "foo" into tSource["foo"]
+	put "bar" into tSource["bar"]
+	
+	filter elements of tSource where each begins with "f" into tTest
+	TestAssert "filter elements of array where expression", the keys of tTest is "foo"
+end TestFilterExpression

--- a/tests/lcs/core/strings/filter.livecodescript
+++ b/tests/lcs/core/strings/filter.livecodescript
@@ -223,3 +223,11 @@ on TestBug15443
 	filter tTest with "nöje"
 	TestAssert "filter macroman native bug 15443", tTest is not empty
 end TestBug15443
+
+on TestFilterExpression
+	local tSource, tTest
+	put "foo,bar,baz" into tSource
+	
+	filter items of tSource where each begins with "f" into tTest
+	TestAssert "filter items of string", tTest is "foo"
+end TestFilterExpression


### PR DESCRIPTION
This patch implements filter with expression using the global `each` in
the same way as the sort command.