### PR TITLE
[[ Bug 21467 ]] Implement mobileSetKeyboardDisplay

### DIFF
--- a/docs/dictionary/command/mobileSetKeyboardDisplay.lcdoc
+++ b/docs/dictionary/command/mobileSetKeyboardDisplay.lcdoc
@@ -1,0 +1,40 @@
+Name: mobileSetKeyboardDisplay
+
+Type: command
+
+Syntax: mobileSetKeyboardDisplay <mode>
+
+Summary:
+Configures the mode in which the keyboard is displayed
+
+Introduced: 9.1
+
+OS: ios, android
+
+Platforms: mobile
+
+Example:
+mobileSetKeyboardDisplay "pan"
+
+Example:
+mobileSetKeyboardDisplay "over"
+
+Parameters:
+mode (enum):
+The mode of keyboard display to use. One of:
+
+-   "over": Display the keyboard over the current stack rect. Over is the default
+keyboard display mode
+-   "pan": Pan the stack up so that the rect of the foucused object will be
+visible above the keyboard
+
+Description:
+Use the <mobileSetKeyboardDisplay> command to configure the move of
+keyboard display.
+
+The <mobileSetKeyboardDisplay> setting takes affect the next time the keyboard is
+shown. It does not affect the current keyboard, if it is being displayed. 
+
+References: keyboardDeactivated (message), keyboardActivated (message), 
+mobileGetKeyboardDisplay (function)
+

--- a/docs/dictionary/function/mobileGetKeyboardDisplay.lcdoc
+++ b/docs/dictionary/function/mobileGetKeyboardDisplay.lcdoc
@@ -1,0 +1,36 @@
+Name: mobileGetKeyboardDisplay
+
+Type: function
+
+Syntax: mobileSetKeyboardDisplay()
+
+Summary:
+Get the mode in which the keyboard is displayed
+
+Introduced: 9.1
+
+OS: ios, android
+
+Platforms: mobile
+
+Example:
+on keyboardActivated
+   if mobileGetKeyboardDisplay() is "over" then
+      layoutUI
+   end if
+end keyboardActivated
+
+Returns (enum):
+The mode of keyboard display to use. One of:
+
+-   "over": Display the keyboard over the current stack rect
+-   "pan": Pan the stack up so that the rect of the foucused object will be
+visible above the keyboard
+
+Description:
+Use the <mobileSetKeyboardDisplay> command to configure the move of
+keyboard display.
+
+References: keyboardDeactivated (message), keyboardActivated (message), 
+mobileSetKeyboardDisplay (command)
+

--- a/docs/notes/bugfix-21467.md
+++ b/docs/notes/bugfix-21467.md
@@ -1,0 +1,10 @@
+# New mobileSetKeyboardDisplay and mobileGetKeyboardDisplay handlers
+
+A new command `mobileSetKeyboardDisplay` has been added to support a `pan` mode
+where the view is panned up if the currently focused field control is not visible
+when the keyboard is shown. Use `mobileGetKeyboardDisplay` to get the current
+mode. There are two modes supported:
+
+- `over` - the default where the keyboard displays over the stack
+- `pan` - the view is panned up the minimum amount required to ensure the
+foucused field is visible.

--- a/engine/src/exec-misc.cpp
+++ b/engine/src/exec-misc.cpp
@@ -224,8 +224,26 @@ void MCMiscSetKeyboardReturnKey(MCExecContext& ctxt, intenum_t p_keyboard_return
 {
     if (MCSystemSetKeyboardReturnKey(p_keyboard_return_key))
         return;
+
+    ctxt.Throw();
+}
+
+static intenum_t s_current_keyboard_display = 0;
+
+void MCMiscExecSetKeyboardDisplay(MCExecContext& ctxt, intenum_t p_mode)
+{
+    if (MCSystemSetKeyboardDisplay(p_mode))
+    {
+        s_current_keyboard_display = p_mode;
+        return;
+    }
     
     ctxt.Throw();
+}
+
+void MCMiscExecGetKeyboardDisplay(MCExecContext& ctxt, intenum_t& r_mode)
+{
+    r_mode = s_current_keyboard_display;
 }
 
 void MCMiscGetPreferredLanguages(MCExecContext& ctxt, MCStringRef& r_languages)

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4016,6 +4016,8 @@ void MCMiscExecHideStatusBar(MCExecContext& ctxt);
 
 void MCMiscSetKeyboardType(MCExecContext& ctxt, intenum_t p_keyboard_type);
 void MCMiscSetKeyboardReturnKey(MCExecContext& ctxt, intenum_t p_keyboard_return_key);
+void MCMiscExecSetKeyboardDisplay(MCExecContext& ctxt, intenum_t p_mode);
+void MCMiscExecGetKeyboardDisplay(MCExecContext& ctxt, intenum_t& r_mode);
 
 void MCMiscGetPreferredLanguages(MCExecContext& ctxt, MCStringRef& r_preferred_languages);
 void MCMiscGetCurrentLocale(MCExecContext& ctxt, MCStringRef& r_current_locale);

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -609,6 +609,40 @@ public class Engine extends View implements EngineApi
         imm.showSoftInput(this, InputMethodManager.SHOW_FORCED);
 		updateKeyboardVisible(true);
     }
+    
+    @Override
+    public void getFocusedRect(Rect r_rect)
+    {
+        Rect t_rect = doGetFocusedRect();
+        
+        if (t_rect == null)
+        {
+            super.getFocusedRect(r_rect);
+        }
+        else
+        {
+            r_rect.set(t_rect);
+        }
+    }
+    
+    private static final int KEYBOARD_DISPLAY_OVER = 0;
+    private static final int KEYBOARD_DISPLAY_PAN = 1;
+    
+    public void setKeyboardDisplay(int p_mode)
+    {
+        if (p_mode == KEYBOARD_DISPLAY_PAN)
+        {
+            getActivity()
+                .getWindow()
+                .setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+        }
+        else if (p_mode == KEYBOARD_DISPLAY_OVER)
+        {
+            getActivity()
+                .getWindow()
+                .setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        }
+    }
 
     public void hideKeyboard()
     {
@@ -3705,6 +3739,8 @@ public class Engine extends View implements EngineApi
 	public static native void doReconfigure(int x, int y, int w, int h, Bitmap bitmap);
 
     public static native String doGetCustomPropertyValue(String set, String property);
+    
+    public static native Rect doGetFocusedRect();
 
 	// MW-2013-08-07: [[ ExternalsApiV5 ]] Native wrapper around MCScreenDC::wait
 	//   used by runActivity() API.

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -2003,6 +2003,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doMediaDone(JNI
 extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doMediaCanceled(JNIEnv *env, jobject object) __attribute__((visibility("default")));
 extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doKeyboardShown(JNIEnv *env, jobject object, int height) __attribute__((visibility("default")));
 extern "C" JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doKeyboardHidden(JNIEnv *env, jobject object) __attribute__((visibility("default")));
+extern "C" JNIEXPORT jobject JNICALL Java_com_runrev_android_Engine_doGetFocusedRect(JNIEnv *env, jobject object) __attribute__((visibility("default")));
 
 JNIEXPORT void JNICALL Java_com_runrev_android_Engine_doCreate(JNIEnv *env, jobject object, jobject activity, jobject container, jobject view)
 {
@@ -3027,6 +3028,58 @@ JNIEXPORT jstring JNICALL Java_com_runrev_android_Engine_doGetCustomPropertyValu
     }
 
     return t_js;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+JNIEXPORT jobject JNICALL Java_com_runrev_android_Engine_doGetFocusedRect(JNIEnv *env, jobject object)
+{
+    MCObject *t_object = nullptr;
+    if (MCactivefield.IsValid())
+    {
+        t_object = MCactivefield;
+    }
+    
+    if (t_object == nullptr)
+    {
+        t_object = MCdefaultstackptr->getcard()->getkfocused();
+    }
+    
+    if (t_object == nullptr)
+    {
+        t_object = MCdefaultstackptr->getcard();
+    }
+    
+    if (t_object == nullptr)
+    {
+        return nullptr;
+    }
+    
+    MCRectangle t_object_rect = t_object -> getrect();
+    MCGAffineTransform t_transform = MCdefaultstackptr->getdevicetransform();
+    
+    MCRectangle t_transformed_object_rect =
+            MCRectangleGetTransformedBounds(t_object_rect, t_transform);
+    
+    jclass t_class = env->FindClass("android/graphics/Rect");
+    if (t_class == nullptr)
+    {
+        return nullptr;
+    }
+    
+    jmethodID t_constructor = env->GetMethodID(t_class, "<init>", "(IIII)V");
+    if (t_constructor == nullptr)
+    {
+        return nullptr;
+    }
+    jobject t_rect = env->NewObject(t_class,
+                                    t_constructor,
+                                    t_transformed_object_rect.x,
+                                    t_transformed_object_rect.y,
+                                    t_transformed_object_rect.x + t_transformed_object_rect.width,
+                                    t_transformed_object_rect.y + t_transformed_object_rect.height);
+
+    return t_rect;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mblandroidmisc.cpp
+++ b/engine/src/mblandroidmisc.cpp
@@ -707,6 +707,13 @@ bool MCSystemSetKeyboardReturnKey(intenum_t p_type)
     return false;
 }
 
+
+bool MCSystemSetKeyboardDisplay(intenum_t p_type)
+{
+    MCAndroidEngineRemoteCall("setKeyboardDisplay", "vi", nullptr, p_type);
+    return true;
+}
+
 // SN-2014-12-18: [[ Bug 13860 ]] Parameter added in case it's a filename, not raw data, in the DataRef
 bool MCSystemExportImageToAlbum(MCStringRef& r_save_result, MCDataRef p_raw_data, MCStringRef p_file_name, MCStringRef p_file_extension, bool p_is_raw_data)
 {

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -3057,6 +3057,62 @@ Exec_stat MCHandleSetKeyboardReturnKey (void *context, MCParameter *p_parameters
     return ES_ERROR;
 }
 
+static const char *s_keyboard_display_names[] =
+{
+    "over", "pan", nil
+};
+
+
+Exec_stat MCHandleSetKeyboardDisplay(void *context, MCParameter *p_parameters)
+{
+    MCExecContext ctxt(nil, nil, nil);
+    ctxt.SetTheResultToEmpty();
+    
+    MCAutoStringRef t_mode_string;
+    if (!MCParseParameters(p_parameters, "x", &(&t_mode_string)))
+    {
+        return ES_ERROR;
+    }
+    
+    bool t_success = true;
+    
+    intenum_t t_mode = 0;
+    for (uint32_t i = 0; s_keyboard_display_names[i] != nil; i++)
+    {
+        if (MCStringIsEqualToCString(*t_mode_string, s_keyboard_display_names[i], kMCCompareCaseless))
+        {
+            t_mode = i;
+            break;
+        }
+    }
+    
+    MCMiscExecSetKeyboardDisplay(ctxt, t_mode);
+    
+    if (!ctxt.HasError())
+    {
+        return ES_NORMAL;
+    }
+    
+    return ES_ERROR;
+}
+
+Exec_stat MCHandleGetKeyboardDisplay(void *context, MCParameter *p_parameters)
+{
+    MCExecContext ctxt(nil, nil, nil);
+    ctxt.SetTheResultToEmpty();
+    
+    intenum_t t_mode;
+    MCMiscExecGetKeyboardDisplay(ctxt, t_mode);
+    
+    if (!ctxt.HasError())
+    {
+        ctxt.SetTheResultToStaticCString(s_keyboard_display_names[t_mode]);
+        return ES_NORMAL;
+    }
+    
+    return ES_ERROR;
+}
+
 Exec_stat MCHandlePreferredLanguages(void *context, MCParameter* p_parameters)
 {
     MCExecContext ctxt(nil, nil, nil);
@@ -4686,6 +4742,9 @@ static const MCPlatformMessageSpec s_platform_messages[] =
 	{false, "mobileIsNFCEnabled", MCHandleIsNFCEnabled, nil},
 	{false, "mobileEnableNFCDispatch", MCHandleEnableNFCDispatch, nil},
 	{false, "mobileDisableNFCDispatch", MCHandleDisableNFCDispatch, nil},
+    
+    {false, "mobileSetKeyboardDisplay", MCHandleSetKeyboardDisplay, nil},
+    {false, "mobileGetKeyboardDisplay", MCHandleGetKeyboardDisplay, nil},
     
 	{nil, nil, nil}    
 };

--- a/engine/src/mbliphoneapp.h
+++ b/engine/src/mbliphoneapp.h
@@ -67,6 +67,12 @@ enum MCIPhoneApplicationStatus
 	kMCIPhoneApplicationStatusShutdown,
 };
 
+enum MCIPhoneKeyboardDisplayMode
+{
+    kMCIPhoneKeyboardDisplayModeOver,
+    kMCIPhoneKeyboardDisplayModePan,
+};
+
 @interface MCIPhoneApplication : NSObject <UIApplicationDelegate>
 {
 	// The actual application object (remember this object is only a delegate!).
@@ -132,6 +138,8 @@ enum MCIPhoneApplicationStatus
     bool m_pending_launch_url;
     // We need to know if the application is active before we can send a message
     bool m_did_become_active;
+
+    MCIPhoneKeyboardDisplayMode m_keyboard_display;
 }
 
 //////////
@@ -227,6 +235,8 @@ enum MCIPhoneApplicationStatus
 - (void)configureKeyboardType: (UIKeyboardType)newKeyboardType;
 // Configure the type of return key.
 - (void)configureReturnKeyType: (UIReturnKeyType)newReturnKeyType;
+// Configure the keyboard display.
+- (void)configureKeyboardDisplay: (MCIPhoneKeyboardDisplayMode)p_mode;
 
 // Get the set of allowed orientations.
 - (uint32_t)allowedOrientations;
@@ -393,6 +403,7 @@ void MCIPhoneSwitchViewToOpenGL(void);
 UIKeyboardType MCIPhoneGetKeyboardType(void);
 void MCIPhoneSetKeyboardType(UIKeyboardType type);
 void MCIPhoneSetReturnKeyType(UIReturnKeyType type);
+void MCIPhoneSetKeyboardDisplay(MCIPhoneKeyboardDisplayMode p_mode);
 UIInterfaceOrientation MCIPhoneGetOrientation(void);
 bool MCIPhoneIsEmbedded(void);
 void MCIPhoneBreakWait(void);

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -25,6 +25,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <unistd.h>
 
 #include "mbliphoneview.h"
+#include "graphics_util.h"
 
 #include "mblnotification.h"
 #import <sys/utsname.h>
@@ -272,7 +273,9 @@ static UIDeviceOrientation patch_device_orientation(id self, SEL _cmd)
     {
         MCmajorosversion += [[t_sys_version_array objectAtIndex:2] intValue];
     }
-
+    
+    m_keyboard_display = kMCIPhoneKeyboardDisplayModeOver;
+    
 	// We are done (successfully) so return ourselves.
 	return self;
 }
@@ -821,12 +824,82 @@ void MCiOSFilePostProtectedDataUnavailableEvent();
 
     // MM-2012-02-26: [[ Bug 10677 ]] Keyboard dimensions do not take into account orientation.
     //  We want height here, so assume the keyboard is always wider than it is taller and take the min of the two.
-	MCIPhoneHandleKeyboardWillActivate(MCMin(t_size . height, t_size . width));
+    CGFloat t_height = MCMin(t_size . height, t_size . width);
+    MCIPhoneHandleKeyboardWillActivate(t_height);
+    
+    if (m_keyboard_display == kMCIPhoneKeyboardDisplayModePan)
+    {
+        MCObject *t_object = nullptr;
+        if (MCactivefield.IsValid())
+        {
+            t_object = MCactivefield;
+        }
+        
+        if (t_object == nullptr)
+        {
+            t_object = MCdefaultstackptr->getcard()->getkfocused();
+        }
+        
+        CGRect t_focused_rect;
+        if (t_object != nullptr)
+        {
+            MCRectangle t_object_rect = t_object -> getrect();
+            MCGAffineTransform t_transform = t_object->getstack()->getroottransform();
+            
+            MCRectangle t_transformed_object_rect =
+                    MCRectangleGetTransformedBounds(t_object_rect, t_transform);
+            t_focused_rect = MCRectangleToCGRect(t_transformed_object_rect);
+        }
+        else
+        {
+            UIView *t_responder = [[m_main_controller rootView] com_runrev_livecode_findFirstResponder];
+            if (t_responder == nil)
+            {
+                return;
+            }
+            
+            t_focused_rect = t_responder.frame;
+        }
+        
+        UIView* t_view = [m_main_controller rootView];
+        CGRect t_frame = t_view.frame;
+        
+        CGFloat t_pan = t_frame.size.height - t_height - (t_focused_rect.origin.y + t_focused_rect.size.height);
+        
+        // if the focused rect is high we don't want to pan the top of it out of view
+        if (t_pan < -t_focused_rect.origin.y)
+        {
+            t_pan = -t_focused_rect.origin.y;
+        }
+        
+        if (t_pan > 0)
+        {
+            // no need to pan
+            return;
+        }
+        
+        [UIView beginAnimations: @"panrootviewup" context: nil];
+        [UIView setAnimationBeginsFromCurrentState: YES];
+        [UIView setAnimationDuration: 0.2f];
+        t_frame.origin.y = t_pan;
+        t_view.frame = t_frame;
+        [UIView commitAnimations];
+    }
 }
 
 - (void)keyboardWillDeactivate:(NSNotification *)notification
 {
 	MCIPhoneHandleKeyboardWillDeactivate();
+    
+    UIView* t_view = [m_main_controller rootView];
+    if (t_view.frame.origin.y != 0)
+    {
+        [UIView beginAnimations: @"panrootviewdown" context: nil];
+        [UIView setAnimationBeginsFromCurrentState: YES];
+        [UIView setAnimationDuration: 0.2f];
+        t_view.frame = CGRectOffset(t_view.frame, 0, -t_view.frame.origin.y);
+        [UIView commitAnimations];
+    }
 }
 
 - (void)keyboardDidActivate:(NSNotification *)notification
@@ -1005,6 +1078,10 @@ void MCiOSFilePostProtectedDataUnavailableEvent();
 	[[[m_main_controller rootView] textView] setReturnKeyType: p_new_type];
 }
 
+- (void)configureKeyboardDisplay: (MCIPhoneKeyboardDisplayMode)p_mode
+{
+    m_keyboard_display = p_mode;
+}
 //////////
 
 - (uint32_t)allowedOrientations
@@ -1942,6 +2019,11 @@ UIKeyboardType MCIPhoneGetKeyboardType(void)
 void MCIPhoneSetReturnKeyType(UIReturnKeyType p_type)
 {
 	[[MCIPhoneApplication sharedApplication] configureReturnKeyType: p_type];
+}
+
+void MCIPhoneSetKeyboardDisplay(MCIPhoneKeyboardDisplayMode p_mode)
+{
+    [[MCIPhoneApplication sharedApplication] configureKeyboardDisplay: p_mode];
 }
 
 void MCIPhoneActivateKeyboard(void)

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -654,6 +654,12 @@ bool MCSystemSetKeyboardReturnKey(intenum_t p_type)
     return true;
 }
 
+bool MCSystemSetKeyboardDisplay(intenum_t p_type)
+{
+    MCIPhoneSetKeyboardDisplay((MCIPhoneKeyboardDisplayMode)p_type);
+    return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // SN-2014-12-11: [[ Merge-6.7.1-rc-4 ]]
 bool MCSystemGetIsVoiceOverRunning(bool &r_is_vo_running)

--- a/engine/src/mbliphonegfx.mm
+++ b/engine/src/mbliphonegfx.mm
@@ -63,11 +63,6 @@ static inline MCGRectangle MCGRectangleFromCGRect(CGRect p_rect)
 	return MCGRectangleMake(p_rect.origin.x, p_rect.origin.y, p_rect.size.width, p_rect.size.height);
 }
 
-static inline CGRect MCRectangleToCGRect(const MCRectangle &p_rect)
-{
-	return CGRectMake(p_rect.x, p_rect.y, p_rect.width, p_rect.height);
-}
-
 static inline MCRectangle MCRectangleFromCGRect(const CGRect &p_rect)
 {
 	return MCRectangleMake(p_rect.origin.x, p_rect.origin.y, p_rect.size.width, p_rect.size.height);

--- a/engine/src/mbliphoneview.h
+++ b/engine/src/mbliphoneview.h
@@ -31,6 +31,13 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static inline CGRect MCRectangleToCGRect(const MCRectangle &p_rect)
+{
+    return CGRectMake(p_rect.x, p_rect.y, p_rect.width, p_rect.height);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 @interface MCIPhoneRootView : UIView <UITextViewDelegate>
 {
 	// MW-2012-03-05: [[ ViewStack ]] The stack which is currently being displayed.

--- a/engine/src/mblsyntax.h
+++ b/engine/src/mblsyntax.h
@@ -441,6 +441,8 @@ bool MCSystemHideStatusBar();
 
 bool MCSystemSetKeyboardType(intenum_t p_type);
 bool MCSystemSetKeyboardReturnKey(intenum_t p_type);
+bool MCSystemSetKeyboardDisplay(intenum_t p_type);
+bool MCSystemGetKeyboardDisplay(intenum_t& r_type);
 
 bool MCSystemGetPreferredLanguages(MCStringRef& r_preferred_languages);
 bool MCSystemGetCurrentLocale(MCStringRef& r_current_locale);


### PR DESCRIPTION
This patch implements a new command `mobileSetKeyboardDisplay` and function
`mobileGetKeyboardDisplay` to govern the behavior of the keyboard on mobile
to pan the view up if necessary so the focused object is visible.