### PR TITLE
[[ Bug 21469 ]] Recursively sign frameworks in iOS apps

### DIFF
--- a/docs/notes/bugfix-21469.md
+++ b/docs/notes/bugfix-21469.md
@@ -1,0 +1,1 @@
+# Ensure iOS apps with embedded frameworks are correctly signed

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -801,7 +801,8 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       --try
       -- Perform the codesigning of the main bundle
       local tResult
-      put shell("/usr/bin/codesign --verbose -f -s" && quote & tCertificate & quote && \
+      __CodesignFrameworks pAppBundle, tCertificate, tEntitlementsFile
+      put shell("/usr/bin/codesign --deep --verbose -f -s" && quote & tCertificate & quote && \
             "--entitlements" && quote & tEntitlementsFile & quote && \
             quote & pAppBundle & quote) into tResult
       -- MM-2012-10-25: [[ Bug ]] try catch finally oddness meant that any errors here were being ignored.
@@ -816,6 +817,23 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       
    end if
 end revSaveAsMobileStandaloneMain
+
+private command __CodesignFrameworks pPath, pCertificate, pEntitlements
+   local tFrameworks
+   put folders(pPath) into tFrameworks
+   filter tFrameworks with "*.framework"
+   repeat for each line tFramework in tFrameworks
+      __CodesignFrameworks pPath & "/" & tFramework & "/Frameworks", pCertificate, pEntitlements
+      
+      local tResult
+      put shell("/usr/bin/codesign --deep --verbose -f -s" && quote & pCertificate & quote && \
+            "--entitlements" && quote & pEntitlements & quote && \
+            quote & pPath & "/" & tFramework & quote) into tResult
+      if not (tResult contains "signed bundle" or tResult contains "signed app bundle") then
+         throw "codesigning failed with" && tResult
+      end if
+   end repeat
+end __CodesignFrameworks
 
 command revSaveAsMobileDeployer pDeployAppBundle, pAppBundle, pAppName, pAppId, pAppExecutables
    create folder pDeployAppBundle


### PR DESCRIPTION
This patch ensures embedded frameworks are correctly signed by recursively
signing any framework bundles in the app bundle before signing the app
itself.