### PR TITLE
Bugfix 21458 - Document "number of elements of tArray"

### DIFF
--- a/docs/dictionary/function/number.lcdoc
+++ b/docs/dictionary/function/number.lcdoc
@@ -59,7 +59,7 @@ Any stack reference.
 textString (string):
 Any string or expression that evaluates to a string.
 
-array (array):
+arrayExpr (array):
 Any array or expression that evaluates to an array.
 
 Returns(integer):

--- a/docs/dictionary/function/number.lcdoc
+++ b/docs/dictionary/function/number.lcdoc
@@ -14,6 +14,8 @@ Syntax: the number of [marked] cards [{in | of} <stackRef>]
 
 Syntax: the number of {char[acters] | items | words | lines} {in | of} <textString>
 
+Syntax: the number of elements {in|of} <array>
+
 Summary:
 <return|Returns> the number of <object|objects> of a certain kind, or
 the number of <chunk|chunks> in a <string>.
@@ -57,6 +59,9 @@ Any stack reference.
 textString (string):
 Any string or expression that evaluates to a string.
 
+array (array):
+The name of an array
+
 Returns(integer):
 The <number> <function> <return|returns> a <non-negative> <integer>.
 
@@ -99,7 +104,7 @@ function (control structure), length (function), property (glossary),
 current card (glossary), return (glossary), group (glossary),
 nest (glossary), chunk (glossary), read-only (glossary),
 expression (glossary), non-negative (glossary), object (glossary),
-string (keyword), control (keyword), integer (keyword), control (object),
+string (keyword), control (keyword), integer (keyword), stack (object),
 backgroundBehavior (property), layer (property)
 
 Tags: text processing

--- a/docs/dictionary/function/number.lcdoc
+++ b/docs/dictionary/function/number.lcdoc
@@ -14,7 +14,7 @@ Syntax: the number of [marked] cards [{in | of} <stackRef>]
 
 Syntax: the number of {char[acters] | items | words | lines} {in | of} <textString>
 
-Syntax: the number of elements {in|of} <array>
+Syntax: the number of elements {in | of} <arrayExpr>
 
 Summary:
 <return|Returns> the number of <object|objects> of a certain kind, or
@@ -60,7 +60,7 @@ textString (string):
 Any string or expression that evaluates to a string.
 
 array (array):
-The name of an array
+Any array or expression that evaluates to an array.
 
 Returns(integer):
 The <number> <function> <return|returns> a <non-negative> <integer>.

--- a/docs/notes/bugfix-21458.md
+++ b/docs/notes/bugfix-21458.md
@@ -1,0 +1,1 @@
+# Added "the number of elements of array" to the syntax in the entry for the number.


### PR DESCRIPTION
Added missing syntax to the entry for the number.
Changed references to remove non-existent entry and add in one used elsewhere in the entry.