### PR TITLE
[[Bug 21488]] Fix automatic architecture detection on some Linux systems

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -43,6 +43,10 @@ guess_linux_arch_script := \
 	case `uname -p` in \
 	    x86_64) echo x86_64 ;; \
 	    x86|i*86) echo x86 ;; \
+	    unknown) case `uname -m` in \
+	        x86_64) echo x86_64 ;; \
+                x86|i*86) echo x86 ;; \
+	    esac ;; \
 	esac
 guess_linux_arch := $(shell $(guess_linux_arch_script))
 

--- a/docs/notes/bugfix-21488.md
+++ b/docs/notes/bugfix-21488.md
@@ -1,0 +1,1 @@
+# Fix automatic architecture detection on some Linux systems


### PR DESCRIPTION
Fixed [bug 21488](https://quality.livecode.com/show_bug.cgi?id=21488), where on some Linux systems the Makefile is unable to automatically determine the architecture to build for. This is due to the Makefile using `uname -p`, which can return `unknown` in some cases.

Fixed by adding an additional case statement into the Makefile that checks `uname -m` if `unknown` is returned from `uname -p`.