### PR TITLE
[[Bugfix 19619]] Add color to the clock widget

### DIFF
--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -19,9 +19,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 This widget consists of an analogue clock. The clock has day and night style displays which
 are used depending on the time. The period interpreted as day by the clock is controlled by
 a pair of constants kStartDay and kEndDay, currently set at 6 and 20 respectively. Thus the
-clock will display in night style between the hours of 8pm and 6am. The only settable property
-implemented by this clock widget is the timeZone, an integer which adjusts the time displayed
-relative to universal time (UTC).
+clock will display in night style between the hours of 8pm and 6am. The style of the clock,
+can be controlled by setting the appropriate colors of the different components. For daytime
+this is through the dayNumberColor, dayHourHandColor, dayMinuteHandColor, daySecondHandColor
+and dayFaceColor properties. There are equivalent properties for the night style. The time
+displayed by the clock can differ from the current system local time by setting the timeZone
+property, an integer which adjusts the time displayed relative to universal time (UTC).
 */
 
 -- declaring extension as widget, followed by identifier
@@ -39,7 +42,7 @@ use com.livecode.library.widgetutils
 -- adding metadata to ensure the extension displays correctly in livecode
 metadata title is "Clock"
 metadata author is "LiveCode"
-metadata version is "1.0.3"
+metadata version is "1.1.3"
 metadata preferredSize is "76,76"
 metadata svgicon is "M31.7,0C14.2,0,0,14.2,0,31.7s14.2,31.7,31.7,31.7s31.7-14.2,31.7-31.7S49.2,0,31.7,0z M30.2,3.2h2.8v7.3h-2.8V3.2zM10.4,33.1H3.1v-2.8h7.3V33.1z M12.5,52.9l-2-2l5.2-5.2l2,2L12.5,52.9z M15.7,17.7l-5.2-5.2l2-2l5.2,5.2L15.7,17.7z M33.1,60.2h-2.8v-7.3h2.8V60.2z M42.3,45.4L31.8,34.9c0,0-0.1,0-0.1,0c-1.7,0-3-1.3-3-3c0-1.1,0.6-2.1,1.6-2.6V12.9h2.8v16.3c0.9,0.5,1.6,1.5,1.6,2.6c0,0.2,0,0.4-0.1,0.5L45,42.8L42.3,45.4z M50.8,52.9l-5.2-5.2l2-2l5.2,5.2L50.8,52.9z M47.7,17.7l-2-2l5.2-5.2l2,2L47.7,17.7z M52.9,33.1v-2.8h7.3v2.8H52.9z"
 
@@ -307,6 +310,7 @@ end handler
 public handler OnLoad(in pProperties as Array)
 	put pProperties["timeZone"] into mTimeZone
 
+	--these properties were added in version 1.1.3
 	if "dayNumberColor" is among the keys of pProperties then
 		put stringToColor(pProperties["dayNumberColor"]) into mDayNumberColor
 	else

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -150,6 +150,41 @@ metadata nightHourHandColor.default is "255,255,255"
 metadata nightHourHandColor.section is "Colors"
 metadata nightHourHandColor.label is "Hour hand color (night)"
 
+/**
+Syntax: set the dayMinuteHandColor of <widget> to <color>
+Syntax: get the dayMinuteHandColor of <widget>
+
+Summary: Determines the color of the minute hand on the clock during the day
+
+Description:
+Use the <dayMinuteHandColor> property to get or set the color of the minute
+hand of the clock during the day. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property dayMinuteHandColor get getDayMinuteHandColor set setDayMinuteHandColor
+metadata dayMinuteHandColor.editor is "com.livecode.pi.color"
+metadata dayMinuteHandColor.default is "0,0,0"
+metadata dayMinuteHandColor.section is "Colors"
+metadata dayMinuteHandColor.label is "Minute hand color (day)"
+
+/**
+Syntax: set the nightMinuteHandColor of <widget> to <color>
+Syntax: get the nightMinuteHandColor of <widget>
+
+Summary: Determines the color of the minute hand on the clock during the night
+
+Description:
+Use the <nightMinuteHandColor> property to get or set the color of the minute
+hand of the clock during the night. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property nightMinuteHandColor get getNightMinuteHandColor set setNightMinuteHandColor
+metadata nightMinuteHandColor.editor is "com.livecode.pi.color"
+metadata nightMinuteHandColor.default is "255,255,255"
+metadata nightMinuteHandColor.section is "Colors"
+metadata nightMinuteHandColor.label is "Minute hand color (night)"
 --
 
 -- private instance variables
@@ -163,6 +198,8 @@ private variable mDayNumberColor as Color
 private variable mNightNumberColor as Color
 private variable mDayHourHandColor as Color
 private variable mNightHourHandColor as Color
+private variable mDayMinuteHandColor as Color
+private variable mNightMinuteHandColor as Color
 --
 
 -- constants
@@ -181,6 +218,8 @@ public handler OnSave(out rProperties as Array)
 	put colorToString(mNightNumberColor,true) into rProperties["nightNumberColor"]
 	put colorToString(mDayHourHandColor,true) into rProperties["dayHourHandColor"]
 	put colorToString(mNightHourHandColor,true) into rProperties["nightHourHandColor"]
+	put colorToString(mDayMinuteHandColor,true) into rProperties["dayMinuteHandColor"]
+	put colorToString(mNightMinuteHandColor,true) into rProperties["nightMinuteHandColor"]
 end handler
 
 public handler OnLoad(in pProperties as Array)
@@ -205,6 +244,16 @@ public handler OnLoad(in pProperties as Array)
 		put stringToColor(pProperties["nightHourHandColor"]) into mNightHourHandColor
 	else
 		put color kWhite into mNightHourHandColor
+	end if
+	if "dayMinuteHandColor" is among the keys of pProperties then
+		put stringToColor(pProperties["dayMinuteHandColor"]) into mDayMinuteHandColor
+	else
+		put color kBlack into mDayMinuteHandColor
+	end if
+	if "nightMinuteHandColor" is among the keys of pProperties then
+		put stringToColor(pProperties["nightMinuteHandColor"]) into mNightMinuteHandColor
+	else
+		put color kWhite into mNightMinuteHandColor
 	end if
 end handler
 
@@ -380,6 +429,13 @@ private handler getPaint(in pObject as String) returns Paint
 			return solid paint with color kBlack
 		end if
 
+	else if pObject is "minute hand" then
+		if mIsDay is true then
+			return solid paint with mDayMinuteHandColor
+		else
+			return solid paint with mNightMinuteHandColor
+		end if
+
 	else if pObject is "second hand" or pObject is "inner nub" then
 		return solid paint with color kRed
 
@@ -502,6 +558,24 @@ end handler
 
 public handler setNightHourHandColor(in pColor as String)
 	put stringToColor(pColor) into mNightHourHandColor
+	redraw all
+end handler
+
+public handler getDayMinuteHandColor() returns String
+	return colorToString(mDayMinuteHandColor, true)
+end handler
+
+public handler setDayMinuteHandColor(in pColor as String)
+	put stringToColor(pColor) into mDayMinuteHandColor
+	redraw all
+end handler
+
+public handler getNightMinuteHandColor() returns String
+	return colorToString(mNightMinuteHandColor, true)
+end handler
+
+public handler setNightMinuteHandColor(in pColor as String)
+	put stringToColor(pColor) into mNightMinuteHandColor
 	redraw all
 end handler
 

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -185,6 +185,42 @@ metadata nightMinuteHandColor.editor is "com.livecode.pi.color"
 metadata nightMinuteHandColor.default is "255,255,255"
 metadata nightMinuteHandColor.section is "Colors"
 metadata nightMinuteHandColor.label is "Minute hand color (night)"
+
+/**
+Syntax: set the daySecondHandColor of <widget> to <color>
+Syntax: get the daySecondHandColor of <widget>
+
+Summary: Determines the color of the second hand on the clock during the day
+
+Description:
+Use the <daySecondHandColor> property to get or set the color of the second
+hand of the clock during the day. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property daySecondHandColor get getDaySecondHandColor set setDaySecondHandColor
+metadata daySecondHandColor.editor is "com.livecode.pi.color"
+metadata daySecondHandColor.default is "255,0,0"
+metadata daySecondHandColor.section is "Colors"
+metadata daySecondHandColor.label is "Second hand color (day)"
+
+/**
+Syntax: set the nightSecondHandColor of <widget> to <color>
+Syntax: get the nightSecondHandColor of <widget>
+
+Summary: Determines the color of the second hand on the clock during the night
+
+Description:
+Use the <nightSecondHandColor> property to get or set the color of the second
+hand of the clock during the night. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property nightSecondHandColor get getNightSecondHandColor set setNightSecondHandColor
+metadata nightSecondHandColor.editor is "com.livecode.pi.color"
+metadata nightSecondHandColor.default is "255,0,0"
+metadata nightSecondHandColor.section is "Colors"
+metadata nightSecondHandColor.label is "Second hand color (night)"
 --
 
 -- private instance variables
@@ -200,6 +236,8 @@ private variable mDayHourHandColor as Color
 private variable mNightHourHandColor as Color
 private variable mDayMinuteHandColor as Color
 private variable mNightMinuteHandColor as Color
+private variable mDaySecondHandColor as Color
+private variable mNightSecondHandColor as Color
 --
 
 -- constants
@@ -220,6 +258,8 @@ public handler OnSave(out rProperties as Array)
 	put colorToString(mNightHourHandColor,true) into rProperties["nightHourHandColor"]
 	put colorToString(mDayMinuteHandColor,true) into rProperties["dayMinuteHandColor"]
 	put colorToString(mNightMinuteHandColor,true) into rProperties["nightMinuteHandColor"]
+	put colorToString(mDaySecondHandColor,true) into rProperties["daySecondHandColor"]
+	put colorToString(mNightSecondHandColor,true) into rProperties["nightSecondHandColor"]
 end handler
 
 public handler OnLoad(in pProperties as Array)
@@ -255,6 +295,16 @@ public handler OnLoad(in pProperties as Array)
 	else
 		put color kWhite into mNightMinuteHandColor
 	end if
+	if "daySecondHandColor" is among the keys of pProperties then
+		put stringToColor(pProperties["daySecondHandColor"]) into mDaySecondHandColor
+	else
+		put color kRed into mDaySecondHandColor
+	end if
+	if "nightSecondHandColor" is among the keys of pProperties then
+		put stringToColor(pProperties["nightSecondHandColor"]) into mNightSecondHandColor
+	else
+		put color kRed into mNightMinuteHandColor
+	end if
 end handler
 
 -- called when widget is created
@@ -267,6 +317,10 @@ public handler OnCreate()
 	put color kWhite into mNightNumberColor
 	put color kBlack into mDayHourHandColor
 	put color kWhite into mNightHourHandColor
+	put color kBlack into mDayMinuteHandColor
+	put color kWhite into mNightMinuteHandColor
+	put color kRed into mDaySecondHandColor
+	put color kRed into mNightSecondHandColor
 end handler
 
 public handler OnOpen()
@@ -437,7 +491,11 @@ private handler getPaint(in pObject as String) returns Paint
 		end if
 
 	else if pObject is "second hand" or pObject is "inner nub" then
-		return solid paint with color kRed
+		if mIsDay is true then
+			return solid paint with mDaySecondHandColor
+		else
+			return solid paint with mNightSecondHandColor
+		end if
 
 	else if pObject is "numbers" then
 		if mIsDay is true then
@@ -576,6 +634,24 @@ end handler
 
 public handler setNightMinuteHandColor(in pColor as String)
 	put stringToColor(pColor) into mNightMinuteHandColor
+	redraw all
+end handler
+
+public handler getDaySecondHandColor() returns String
+	return colorToString(mDaySecondHandColor, true)
+end handler
+
+public handler setDaySecondHandColor(in pColor as String)
+	put stringToColor(pColor) into mDaySecondHandColor
+	redraw all
+end handler
+
+public handler getNightSecondHandColor() returns String
+	return colorToString(mNightSecondHandColor, true)
+end handler
+
+public handler setNightSecondHandColor(in pColor as String)
+	put stringToColor(pColor) into mNightSecondHandColor
 	redraw all
 end handler
 

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -313,53 +313,33 @@ public handler OnLoad(in pProperties as Array)
 	--these properties were added in version 1.1.3
 	if "dayNumberColor" is among the keys of pProperties then
 		put stringToColor(pProperties["dayNumberColor"]) into mDayNumberColor
-	else
-		put color kBlack into mDayNumberColor
 	end if
 	if "nightNumberColor" is among the keys of pProperties then
 		put stringToColor(pProperties["nightNumberColor"]) into mNightNumberColor
-	else
-		put color kWhite into mNightNumberColor
 	end if
 	if "dayHourHandColor" is among the keys of pProperties then
 		put stringToColor(pProperties["dayHourHandColor"]) into mDayHourHandColor
-	else
-		put color kBlack into mDayHourHandColor
 	end if
 	if "nightHourHandColor" is among the keys of pProperties then
 		put stringToColor(pProperties["nightHourHandColor"]) into mNightHourHandColor
-	else
-		put color kWhite into mNightHourHandColor
 	end if
 	if "dayMinuteHandColor" is among the keys of pProperties then
 		put stringToColor(pProperties["dayMinuteHandColor"]) into mDayMinuteHandColor
-	else
-		put color kBlack into mDayMinuteHandColor
 	end if
 	if "nightMinuteHandColor" is among the keys of pProperties then
 		put stringToColor(pProperties["nightMinuteHandColor"]) into mNightMinuteHandColor
-	else
-		put color kWhite into mNightMinuteHandColor
 	end if
 	if "daySecondHandColor" is among the keys of pProperties then
 		put stringToColor(pProperties["daySecondHandColor"]) into mDaySecondHandColor
-	else
-		put color kRed into mDaySecondHandColor
 	end if
 	if "nightSecondHandColor" is among the keys of pProperties then
 		put stringToColor(pProperties["nightSecondHandColor"]) into mNightSecondHandColor
-	else
-		put color kRed into mNightMinuteHandColor
 	end if
 	if "dayFaceColor" is among the keys of pProperties then
 		put stringToColor(pProperties["dayFaceColor"]) into mDayFaceColor
-	else
-		put color [224/255,224/255,224/255,0.25] into mDayFaceColor
 	end if
 	if "nightFaceColor" is among the keys of pProperties then
 		put stringToColor(pProperties["nightFaceColor"]) into mNightFaceColor
-	else
-		put color kBlack into mNightMinuteHandColor
 	end if
 end handler
 

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -221,6 +221,44 @@ metadata nightSecondHandColor.editor is "com.livecode.pi.color"
 metadata nightSecondHandColor.default is "255,0,0"
 metadata nightSecondHandColor.section is "Colors"
 metadata nightSecondHandColor.label is "Second hand color (night)"
+
+/**
+Syntax: set the dayFaceColor of <widget> to <color>
+Syntax: get the dayFaceColor of <widget>
+
+Summary: Determines the color of the face of the clock during the day
+
+Description:
+Use the <dayFaceColor> property to get or set the color of the face
+of the clock during the day. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property dayFaceColor get getDayFaceColor set setDayFaceColor
+metadata dayFaceColor.editor is "com.livecode.pi.color"
+metadata dayFaceColor.default is "224,224,224,64"
+metadata dayFaceColor.section is "Colors"
+metadata dayFaceColor.label is "Face color (day)"
+
+/**
+Syntax: set the nightFaceColor of <widget> to <color>
+Syntax: get the nightFaceColor of <widget>
+
+Summary: Determines the color of the face of the clock during the night
+
+Description:
+Use the <nightFaceColor> property to get or set the color of the face
+of the clock during the night. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property nightFaceColor get getNightFaceColor set setNightFaceColor
+metadata nightFaceColor.editor is "com.livecode.pi.color"
+metadata nightFaceColor.default is "0,0,0"
+metadata nightFaceColor.section is "Colors"
+metadata nightFaceColor.label is "Face color (night)"
+
+
 --
 
 -- private instance variables
@@ -238,6 +276,8 @@ private variable mDayMinuteHandColor as Color
 private variable mNightMinuteHandColor as Color
 private variable mDaySecondHandColor as Color
 private variable mNightSecondHandColor as Color
+private variable mDayFaceColor as Color
+private variable mNightFaceColor as Color
 --
 
 -- constants
@@ -260,6 +300,8 @@ public handler OnSave(out rProperties as Array)
 	put colorToString(mNightMinuteHandColor,true) into rProperties["nightMinuteHandColor"]
 	put colorToString(mDaySecondHandColor,true) into rProperties["daySecondHandColor"]
 	put colorToString(mNightSecondHandColor,true) into rProperties["nightSecondHandColor"]
+	put colorToString(mDayFaceColor,true) into rProperties["dayFaceColor"]
+	put colorToString(mNightFaceColor,true) into rProperties["nightFaceColor"]
 end handler
 
 public handler OnLoad(in pProperties as Array)
@@ -305,6 +347,16 @@ public handler OnLoad(in pProperties as Array)
 	else
 		put color kRed into mNightMinuteHandColor
 	end if
+	if "dayFaceColor" is among the keys of pProperties then
+		put stringToColor(pProperties["dayFaceColor"]) into mDayFaceColor
+	else
+		put color [224/255,224/255,224/255,0.25] into mDayFaceColor
+	end if
+	if "nightFaceColor" is among the keys of pProperties then
+		put stringToColor(pProperties["nightFaceColor"]) into mNightFaceColor
+	else
+		put color kBlack into mNightMinuteHandColor
+	end if
 end handler
 
 -- called when widget is created
@@ -321,6 +373,8 @@ public handler OnCreate()
 	put color kWhite into mNightMinuteHandColor
 	put color kRed into mDaySecondHandColor
 	put color kRed into mNightSecondHandColor
+	put color [224/255,224/255,224/255,0.25] into mDayFaceColor
+	put color kBlack into mNightFaceColor
 end handler
 
 public handler OnOpen()
@@ -478,9 +532,10 @@ private handler getPaint(in pObject as String) returns Paint
 
 	if pObject is "clock face" then
 		if mIsDay is true then
-			return solid paint with color [224/255, 224/255, 224/255, 0.25]
+
+			return solid paint with mDayFaceColor
 		else
-			return solid paint with color kBlack
+			return solid paint with mNightFaceColor
 		end if
 
 	else if pObject is "minute hand" then
@@ -652,6 +707,24 @@ end handler
 
 public handler setNightSecondHandColor(in pColor as String)
 	put stringToColor(pColor) into mNightSecondHandColor
+	redraw all
+end handler
+
+public handler getDayFaceColor() returns String
+	return colorToString(mDayFaceColor, true)
+end handler
+
+public handler setDayFaceColor(in pColor as String)
+	put stringToColor(pColor) into mDayFaceColor
+	redraw all
+end handler
+
+public handler getNightFaceColor() returns String
+	return colorToString(mNightFaceColor, true)
+end handler
+
+public handler setNightFaceColor(in pColor as String)
+	put stringToColor(pColor) into mNightFaceColor
 	redraw all
 end handler
 

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -538,7 +538,7 @@ private handler getPaint(in pObject as String) returns Paint
 			return solid paint with mNightFaceColor
 		end if
 
-	else if pObject is "minute hand" then
+	else if pObject is "minute hand" or pObject is "outer nub" then
 		if mIsDay is true then
 			return solid paint with mDayMinuteHandColor
 		else
@@ -564,13 +564,6 @@ private handler getPaint(in pObject as String) returns Paint
 			return solid paint with mDayHourHandColor
 		else
 			return solid paint with mNightHourHandColor
-		end if
-
-	else
-		if mIsDay is true then
-			return solid paint with color kBlack
-		else
-			return solid paint with color kWhite
 		end if
 
 	end if

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -33,6 +33,7 @@ use com.livecode.canvas
 use com.livecode.widget
 use com.livecode.engine
 use com.livecode.math
+use com.livecode.library.widgetutils
 --
 
 -- adding metadata to ensure the extension displays correctly in livecode
@@ -76,6 +77,43 @@ UTC that the clock should display.
 property timeZone		get mTimeZone		set setTimeZone
 metadata timeZone.editor is "com.livecode.pi.timezone"
 metadata timeZone.label is "Timezone"
+
+/**
+Syntax: set the dayNumberColor of <widget> to <color>
+Syntax: get the dayNumberColor of <widget>
+
+Summary: Determines the color of the numbers on the clock during the day
+
+Description:
+Use the <dayNumberColor> property to get or set the text color of the numbers
+on the face of the clock during the day. To determine if the clock is
+displaying its daytime or night-time colors use the read-only property
+<isDay>.
+*/
+property dayNumberColor get getDayNumberColor set setDayNumberColor
+metadata dayNumberColor.editor is "com.livecode.pi.color"
+metadata dayNumberColor.default is "0,0,0"
+metadata dayNumberColor.section is "Colors"
+metadata dayNumberColor.label is "Number color (day)"
+
+/**
+Syntax: set the nightNumberColor of <widget> to <color>
+Syntax: get the nightNumberColor of <widget>
+
+Summary: Determines the color of the numbers on the clock during the night
+
+Description:
+Use the <nightNumberColor> property to get or set the text color of the numbers
+on the face of the clock during the night. To determine if the clock is
+displaying its daytime or night-time colors use the read-only property
+<isDay>.
+*/
+property nightNumberColor get getNightNumberColor set setNightNumberColor
+metadata nightNumberColor.editor is "com.livecode.pi.color"
+metadata nightNumberColor.default is "255,255,255"
+metadata nightNumberColor.section is "Colors"
+metadata nightNumberColor.label is "Number color (night)"
+
 --
 
 -- private instance variables
@@ -85,6 +123,8 @@ private variable mCurrentTime 	as List
 private variable mRadius as Number
 private variable mCentre as List
 private variable mFontSize 		as Real
+private variable mDayNumberColor as Color
+private variable mNightNumberColor as Color
 --
 
 -- constants
@@ -99,10 +139,23 @@ public handler OnSave(out rProperties as Array)
 	put the empty array into rProperties
 
 	put mTimeZone into rProperties["timeZone"]
+	put colorToString(mDayNumberColor,true) into rProperties["dayNumberColor"]
+	put colorToString(mNightNumberColor,true) into rProperties["nightNumberColor"]
 end handler
 
 public handler OnLoad(in pProperties as Array)
 	put pProperties["timeZone"] into mTimeZone
+
+	if "dayNumberColor" is among the keys of pProperties then
+		put stringToColor(pProperties["dayNumberColor"]) into mDayNumberColor
+	else
+		put color kBlack into mDayNumberColor
+	end if
+	if "nightNumberColor" is among the keys of pProperties then
+		put stringToColor(pProperties["nightNumberColor"]) into mNightNumberColor
+	else
+		put color kBlack into mNightNumberColor
+	end if
 end handler
 
 -- called when widget is created
@@ -111,6 +164,8 @@ public handler OnCreate()
 	put false into mIsDay
 	put [0,0,0] into mCurrentTime
 	put 12 into mFontSize
+	put color kBlack into mDayNumberColor
+	put color kWhite into mNightNumberColor
 end handler
 
 public handler OnOpen()
@@ -276,6 +331,13 @@ private handler getPaint(in pObject as String) returns Paint
 	else if pObject is "second hand" or pObject is "inner nub" then
 		return solid paint with color kRed
 
+	else if pObject is "numbers" then
+		if mIsDay is true then
+			return solid paint with mDayNumberColor
+		else
+			return solid paint with mNightNumberColor
+		end if
+
 	else
 		if mIsDay is true then
 			return solid paint with color kBlack
@@ -345,6 +407,24 @@ public handler setTimeZone(in pTimeZone as optional Number) returns nothing
 
 	put pTimeZone into mTimeZone
 	put getTimeComponents() into mCurrentTime
+	redraw all
+end handler
+
+public handler getDayNumberColor() returns String
+	return colorToString(mDayNumberColor, true)
+end handler
+
+public handler setDayNumberColor(in pColor as String)
+	put stringToColor(pColor) into mDayNumberColor
+	redraw all
+end handler
+
+public handler getNightNumberColor() returns String
+	return colorToString(mNightNumberColor, true)
+end handler
+
+public handler setNightNumberColor(in pColor as String)
+	put stringToColor(pColor) into mNightNumberColor
 	redraw all
 end handler
 

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -114,6 +114,42 @@ metadata nightNumberColor.default is "255,255,255"
 metadata nightNumberColor.section is "Colors"
 metadata nightNumberColor.label is "Number color (night)"
 
+/**
+Syntax: set the dayHourHandColor of <widget> to <color>
+Syntax: get the dayHourHandColor of <widget>
+
+Summary: Determines the color of the hour hand on the clock during the day
+
+Description:
+Use the <dayHourHandColor> property to get or set the color of the hour
+hand of the clock during the day. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property dayHourHandColor get getDayHourHandColor set setDayHourHandColor
+metadata dayHourHandColor.editor is "com.livecode.pi.color"
+metadata dayHourHandColor.default is "0,0,0"
+metadata dayHourHandColor.section is "Colors"
+metadata dayHourHandColor.label is "Hour hand color (day)"
+
+/**
+Syntax: set the nightHourHandColor of <widget> to <color>
+Syntax: get the nightHourHandColor of <widget>
+
+Summary: Determines the color of the numbers on the clock during the night
+
+Description:
+Use the <nightHourHandColor> property to get or set the text color of the numbers
+on the face of the clock during the night. To determine if the clock is
+displaying its daytime or night-time colors, use the read-only property
+<isDay>.
+*/
+property nightHourHandColor get getNightHourHandColor set setNightHourHandColor
+metadata nightHourHandColor.editor is "com.livecode.pi.color"
+metadata nightHourHandColor.default is "255,255,255"
+metadata nightHourHandColor.section is "Colors"
+metadata nightHourHandColor.label is "Hour hand color (night)"
+
 --
 
 -- private instance variables
@@ -125,6 +161,8 @@ private variable mCentre as List
 private variable mFontSize 		as Real
 private variable mDayNumberColor as Color
 private variable mNightNumberColor as Color
+private variable mDayHourHandColor as Color
+private variable mNightHourHandColor as Color
 --
 
 -- constants
@@ -141,6 +179,8 @@ public handler OnSave(out rProperties as Array)
 	put mTimeZone into rProperties["timeZone"]
 	put colorToString(mDayNumberColor,true) into rProperties["dayNumberColor"]
 	put colorToString(mNightNumberColor,true) into rProperties["nightNumberColor"]
+	put colorToString(mDayHourHandColor,true) into rProperties["dayHourHandColor"]
+	put colorToString(mNightHourHandColor,true) into rProperties["nightHourHandColor"]
 end handler
 
 public handler OnLoad(in pProperties as Array)
@@ -156,6 +196,16 @@ public handler OnLoad(in pProperties as Array)
 	else
 		put color kBlack into mNightNumberColor
 	end if
+	if "dayHourHandColor" is among the keys of pProperties then
+		put stringToColor(pProperties["dayHourHandColor"]) into mDayHourHandColor
+	else
+		put color kBlack into mDayHourHandColor
+	end if
+	if "nightHourHandColor" is among the keys of pProperties then
+		put stringToColor(pProperties["nightHourHandColor"]) into mNightHourHandColor
+	else
+		put color kWhite into mNightHourHandColor
+	end if
 end handler
 
 -- called when widget is created
@@ -166,6 +216,8 @@ public handler OnCreate()
 	put 12 into mFontSize
 	put color kBlack into mDayNumberColor
 	put color kWhite into mNightNumberColor
+	put color kBlack into mDayHourHandColor
+	put color kWhite into mNightHourHandColor
 end handler
 
 public handler OnOpen()
@@ -338,6 +390,13 @@ private handler getPaint(in pObject as String) returns Paint
 			return solid paint with mNightNumberColor
 		end if
 
+	else if pObject is "hour hand" then
+		if mIsDay is true then
+			return solid paint with mDayHourHandColor
+		else
+			return solid paint with mNightHourHandColor
+		end if
+
 	else
 		if mIsDay is true then
 			return solid paint with color kBlack
@@ -425,6 +484,24 @@ end handler
 
 public handler setNightNumberColor(in pColor as String)
 	put stringToColor(pColor) into mNightNumberColor
+	redraw all
+end handler
+
+public handler getDayHourHandColor() returns String
+	return colorToString(mDayHourHandColor, true)
+end handler
+
+public handler setDayHourHandColor(in pColor as String)
+	put stringToColor(pColor) into mDayHourHandColor
+	redraw all
+end handler
+
+public handler getNightHourHandColor() returns String
+	return colorToString(mNightHourHandColor, true)
+end handler
+
+public handler setNightHourHandColor(in pColor as String)
+	put stringToColor(pColor) into mNightHourHandColor
 	redraw all
 end handler
 

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -42,7 +42,7 @@ use com.livecode.library.widgetutils
 -- adding metadata to ensure the extension displays correctly in livecode
 metadata title is "Clock"
 metadata author is "LiveCode"
-metadata version is "1.1.3"
+metadata version is "1.1.0"
 metadata preferredSize is "76,76"
 metadata svgicon is "M31.7,0C14.2,0,0,14.2,0,31.7s14.2,31.7,31.7,31.7s31.7-14.2,31.7-31.7S49.2,0,31.7,0z M30.2,3.2h2.8v7.3h-2.8V3.2zM10.4,33.1H3.1v-2.8h7.3V33.1z M12.5,52.9l-2-2l5.2-5.2l2,2L12.5,52.9z M15.7,17.7l-5.2-5.2l2-2l5.2,5.2L15.7,17.7z M33.1,60.2h-2.8v-7.3h2.8V60.2z M42.3,45.4L31.8,34.9c0,0-0.1,0-0.1,0c-1.7,0-3-1.3-3-3c0-1.1,0.6-2.1,1.6-2.6V12.9h2.8v16.3c0.9,0.5,1.6,1.5,1.6,2.6c0,0.2,0,0.4-0.1,0.5L45,42.8L42.3,45.4z M50.8,52.9l-5.2-5.2l2-2l5.2,5.2L50.8,52.9z M47.7,17.7l-2-2l5.2-5.2l2,2L47.7,17.7z M52.9,33.1v-2.8h7.3v2.8H52.9z"
 
@@ -310,7 +310,7 @@ end handler
 public handler OnLoad(in pProperties as Array)
 	put pProperties["timeZone"] into mTimeZone
 
-	--these properties were added in version 1.1.3
+	--these properties were added in version 1.1.0
 	if "dayNumberColor" is among the keys of pProperties then
 		put pProperties["dayNumberColor"] into mDayNumberColor
 	end if

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -94,8 +94,8 @@ displaying its daytime or night-time colors use the read-only property
 <isDay>.
 */
 property dayNumberColor get getDayNumberColor set setDayNumberColor
-metadata dayNumberColor.editor is "com.livecode.pi.color"
-metadata dayNumberColor.default is "0,0,0"
+metadata dayNumberColor.editor is "com.livecode.pi.colorwithalpha"
+metadata dayNumberColor.default is "0,0,0,255"
 metadata dayNumberColor.section is "Colors"
 metadata dayNumberColor.label is "Number color (day)"
 
@@ -112,8 +112,8 @@ displaying its daytime or night-time colors use the read-only property
 <isDay>.
 */
 property nightNumberColor get getNightNumberColor set setNightNumberColor
-metadata nightNumberColor.editor is "com.livecode.pi.color"
-metadata nightNumberColor.default is "255,255,255"
+metadata nightNumberColor.editor is "com.livecode.pi.colorwithalpha"
+metadata nightNumberColor.default is "255,255,255,255"
 metadata nightNumberColor.section is "Colors"
 metadata nightNumberColor.label is "Number color (night)"
 
@@ -130,8 +130,8 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property dayHourHandColor get getDayHourHandColor set setDayHourHandColor
-metadata dayHourHandColor.editor is "com.livecode.pi.color"
-metadata dayHourHandColor.default is "0,0,0"
+metadata dayHourHandColor.editor is "com.livecode.pi.colorwithalpha"
+metadata dayHourHandColor.default is "0,0,0,255"
 metadata dayHourHandColor.section is "Colors"
 metadata dayHourHandColor.label is "Hour hand color (day)"
 
@@ -148,8 +148,8 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property nightHourHandColor get getNightHourHandColor set setNightHourHandColor
-metadata nightHourHandColor.editor is "com.livecode.pi.color"
-metadata nightHourHandColor.default is "255,255,255"
+metadata nightHourHandColor.editor is "com.livecode.pi.colorwithalpha"
+metadata nightHourHandColor.default is "255,255,255,255"
 metadata nightHourHandColor.section is "Colors"
 metadata nightHourHandColor.label is "Hour hand color (night)"
 
@@ -166,8 +166,8 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property dayMinuteHandColor get getDayMinuteHandColor set setDayMinuteHandColor
-metadata dayMinuteHandColor.editor is "com.livecode.pi.color"
-metadata dayMinuteHandColor.default is "0,0,0"
+metadata dayMinuteHandColor.editor is "com.livecode.pi.colorwithalpha"
+metadata dayMinuteHandColor.default is "0,0,0,255"
 metadata dayMinuteHandColor.section is "Colors"
 metadata dayMinuteHandColor.label is "Minute hand color (day)"
 
@@ -184,8 +184,8 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property nightMinuteHandColor get getNightMinuteHandColor set setNightMinuteHandColor
-metadata nightMinuteHandColor.editor is "com.livecode.pi.color"
-metadata nightMinuteHandColor.default is "255,255,255"
+metadata nightMinuteHandColor.editor is "com.livecode.pi.colorwithalpha"
+metadata nightMinuteHandColor.default is "255,255,255,255"
 metadata nightMinuteHandColor.section is "Colors"
 metadata nightMinuteHandColor.label is "Minute hand color (night)"
 
@@ -202,8 +202,8 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property daySecondHandColor get getDaySecondHandColor set setDaySecondHandColor
-metadata daySecondHandColor.editor is "com.livecode.pi.color"
-metadata daySecondHandColor.default is "255,0,0"
+metadata daySecondHandColor.editor is "com.livecode.pi.colorwithalpha"
+metadata daySecondHandColor.default is "255,0,0,255"
 metadata daySecondHandColor.section is "Colors"
 metadata daySecondHandColor.label is "Second hand color (day)"
 
@@ -220,8 +220,8 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property nightSecondHandColor get getNightSecondHandColor set setNightSecondHandColor
-metadata nightSecondHandColor.editor is "com.livecode.pi.color"
-metadata nightSecondHandColor.default is "255,0,0"
+metadata nightSecondHandColor.editor is "com.livecode.pi.colorwithalpha"
+metadata nightSecondHandColor.default is "255,0,0,255"
 metadata nightSecondHandColor.section is "Colors"
 metadata nightSecondHandColor.label is "Second hand color (night)"
 
@@ -238,7 +238,7 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property dayFaceColor get getDayFaceColor set setDayFaceColor
-metadata dayFaceColor.editor is "com.livecode.pi.color"
+metadata dayFaceColor.editor is "com.livecode.pi.colorwithalpha"
 metadata dayFaceColor.default is "224,224,224,64"
 metadata dayFaceColor.section is "Colors"
 metadata dayFaceColor.label is "Face color (day)"
@@ -256,8 +256,8 @@ displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
 property nightFaceColor get getNightFaceColor set setNightFaceColor
-metadata nightFaceColor.editor is "com.livecode.pi.color"
-metadata nightFaceColor.default is "0,0,0"
+metadata nightFaceColor.editor is "com.livecode.pi.colorwithalpha"
+metadata nightFaceColor.default is "0,0,0,255"
 metadata nightFaceColor.section is "Colors"
 metadata nightFaceColor.label is "Face color (night)"
 

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -136,11 +136,11 @@ metadata dayHourHandColor.label is "Hour hand color (day)"
 Syntax: set the nightHourHandColor of <widget> to <color>
 Syntax: get the nightHourHandColor of <widget>
 
-Summary: Determines the color of the numbers on the clock during the night
+Summary: Determines the color of the hour hand on the clock during the night
 
 Description:
-Use the <nightHourHandColor> property to get or set the text color of the numbers
-on the face of the clock during the night. To determine if the clock is
+Use the <nightHourHandColor> property to get or set the color of the hour
+hand of the clock during the night. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
@@ -194,7 +194,7 @@ public handler OnLoad(in pProperties as Array)
 	if "nightNumberColor" is among the keys of pProperties then
 		put stringToColor(pProperties["nightNumberColor"]) into mNightNumberColor
 	else
-		put color kBlack into mNightNumberColor
+		put color kWhite into mNightNumberColor
 	end if
 	if "dayHourHandColor" is among the keys of pProperties then
 		put stringToColor(pProperties["dayHourHandColor"]) into mDayHourHandColor

--- a/extensions/widgets/clock/clock.lcb
+++ b/extensions/widgets/clock/clock.lcb
@@ -93,7 +93,7 @@ on the face of the clock during the day. To determine if the clock is
 displaying its daytime or night-time colors use the read-only property
 <isDay>.
 */
-property dayNumberColor get getDayNumberColor set setDayNumberColor
+property dayNumberColor get mDayNumberColor set setDayNumberColor
 metadata dayNumberColor.editor is "com.livecode.pi.colorwithalpha"
 metadata dayNumberColor.default is "0,0,0,255"
 metadata dayNumberColor.section is "Colors"
@@ -111,7 +111,7 @@ on the face of the clock during the night. To determine if the clock is
 displaying its daytime or night-time colors use the read-only property
 <isDay>.
 */
-property nightNumberColor get getNightNumberColor set setNightNumberColor
+property nightNumberColor get mNightNumberColor set setNightNumberColor
 metadata nightNumberColor.editor is "com.livecode.pi.colorwithalpha"
 metadata nightNumberColor.default is "255,255,255,255"
 metadata nightNumberColor.section is "Colors"
@@ -129,7 +129,7 @@ hand of the clock during the day. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property dayHourHandColor get getDayHourHandColor set setDayHourHandColor
+property dayHourHandColor get mDayHourHandColor set setDayHourHandColor
 metadata dayHourHandColor.editor is "com.livecode.pi.colorwithalpha"
 metadata dayHourHandColor.default is "0,0,0,255"
 metadata dayHourHandColor.section is "Colors"
@@ -147,7 +147,7 @@ hand of the clock during the night. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property nightHourHandColor get getNightHourHandColor set setNightHourHandColor
+property nightHourHandColor get mNightHourHandColor set setNightHourHandColor
 metadata nightHourHandColor.editor is "com.livecode.pi.colorwithalpha"
 metadata nightHourHandColor.default is "255,255,255,255"
 metadata nightHourHandColor.section is "Colors"
@@ -165,7 +165,7 @@ hand of the clock during the day. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property dayMinuteHandColor get getDayMinuteHandColor set setDayMinuteHandColor
+property dayMinuteHandColor get mDayMinuteHandColor set setDayMinuteHandColor
 metadata dayMinuteHandColor.editor is "com.livecode.pi.colorwithalpha"
 metadata dayMinuteHandColor.default is "0,0,0,255"
 metadata dayMinuteHandColor.section is "Colors"
@@ -183,7 +183,7 @@ hand of the clock during the night. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property nightMinuteHandColor get getNightMinuteHandColor set setNightMinuteHandColor
+property nightMinuteHandColor get mNightMinuteHandColor set setNightMinuteHandColor
 metadata nightMinuteHandColor.editor is "com.livecode.pi.colorwithalpha"
 metadata nightMinuteHandColor.default is "255,255,255,255"
 metadata nightMinuteHandColor.section is "Colors"
@@ -201,7 +201,7 @@ hand of the clock during the day. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property daySecondHandColor get getDaySecondHandColor set setDaySecondHandColor
+property daySecondHandColor get mDaySecondHandColor set setDaySecondHandColor
 metadata daySecondHandColor.editor is "com.livecode.pi.colorwithalpha"
 metadata daySecondHandColor.default is "255,0,0,255"
 metadata daySecondHandColor.section is "Colors"
@@ -219,7 +219,7 @@ hand of the clock during the night. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property nightSecondHandColor get getNightSecondHandColor set setNightSecondHandColor
+property nightSecondHandColor get mNightSecondHandColor set setNightSecondHandColor
 metadata nightSecondHandColor.editor is "com.livecode.pi.colorwithalpha"
 metadata nightSecondHandColor.default is "255,0,0,255"
 metadata nightSecondHandColor.section is "Colors"
@@ -237,7 +237,7 @@ of the clock during the day. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property dayFaceColor get getDayFaceColor set setDayFaceColor
+property dayFaceColor get mDayFaceColor set setDayFaceColor
 metadata dayFaceColor.editor is "com.livecode.pi.colorwithalpha"
 metadata dayFaceColor.default is "224,224,224,64"
 metadata dayFaceColor.section is "Colors"
@@ -255,7 +255,7 @@ of the clock during the night. To determine if the clock is
 displaying its daytime or night-time colors, use the read-only property
 <isDay>.
 */
-property nightFaceColor get getNightFaceColor set setNightFaceColor
+property nightFaceColor get mNightFaceColor set setNightFaceColor
 metadata nightFaceColor.editor is "com.livecode.pi.colorwithalpha"
 metadata nightFaceColor.default is "0,0,0,255"
 metadata nightFaceColor.section is "Colors"
@@ -271,40 +271,40 @@ private variable mCurrentTime 	as List
 private variable mRadius as Number
 private variable mCentre as List
 private variable mFontSize 		as Real
-private variable mDayNumberColor as Color
-private variable mNightNumberColor as Color
-private variable mDayHourHandColor as Color
-private variable mNightHourHandColor as Color
-private variable mDayMinuteHandColor as Color
-private variable mNightMinuteHandColor as Color
-private variable mDaySecondHandColor as Color
-private variable mNightSecondHandColor as Color
-private variable mDayFaceColor as Color
-private variable mNightFaceColor as Color
+private variable mDayNumberColor as String
+private variable mNightNumberColor as String
+private variable mDayHourHandColor as String
+private variable mNightHourHandColor as String
+private variable mDayMinuteHandColor as String
+private variable mNightMinuteHandColor as String
+private variable mDaySecondHandColor as String
+private variable mNightSecondHandColor as String
+private variable mDayFaceColor as String
+private variable mNightFaceColor as String
 --
 
 -- constants
 constant kStartDay is 6
 constant kEndDay is 20
-constant kWhite is [1,1,1]
-constant kBlack is [0,0,0]
-constant kRed is [1,0,0]
+constant kWhite is "255,255,255,255"
+constant kBlack is "0,0,0,255"
+constant kRed is "255,0,0,255"
 --
 
 public handler OnSave(out rProperties as Array)
 	put the empty array into rProperties
 
 	put mTimeZone into rProperties["timeZone"]
-	put colorToString(mDayNumberColor,true) into rProperties["dayNumberColor"]
-	put colorToString(mNightNumberColor,true) into rProperties["nightNumberColor"]
-	put colorToString(mDayHourHandColor,true) into rProperties["dayHourHandColor"]
-	put colorToString(mNightHourHandColor,true) into rProperties["nightHourHandColor"]
-	put colorToString(mDayMinuteHandColor,true) into rProperties["dayMinuteHandColor"]
-	put colorToString(mNightMinuteHandColor,true) into rProperties["nightMinuteHandColor"]
-	put colorToString(mDaySecondHandColor,true) into rProperties["daySecondHandColor"]
-	put colorToString(mNightSecondHandColor,true) into rProperties["nightSecondHandColor"]
-	put colorToString(mDayFaceColor,true) into rProperties["dayFaceColor"]
-	put colorToString(mNightFaceColor,true) into rProperties["nightFaceColor"]
+	put mDayNumberColor into rProperties["dayNumberColor"]
+	put mNightNumberColor into rProperties["nightNumberColor"]
+	put mDayHourHandColor into rProperties["dayHourHandColor"]
+	put mNightHourHandColor into rProperties["nightHourHandColor"]
+	put mDayMinuteHandColor into rProperties["dayMinuteHandColor"]
+	put mNightMinuteHandColor into rProperties["nightMinuteHandColor"]
+	put mDaySecondHandColor into rProperties["daySecondHandColor"]
+	put mNightSecondHandColor into rProperties["nightSecondHandColor"]
+	put mDayFaceColor into rProperties["dayFaceColor"]
+	put mNightFaceColor into rProperties["nightFaceColor"]
 end handler
 
 public handler OnLoad(in pProperties as Array)
@@ -312,34 +312,34 @@ public handler OnLoad(in pProperties as Array)
 
 	--these properties were added in version 1.1.3
 	if "dayNumberColor" is among the keys of pProperties then
-		put stringToColor(pProperties["dayNumberColor"]) into mDayNumberColor
+		put pProperties["dayNumberColor"] into mDayNumberColor
 	end if
 	if "nightNumberColor" is among the keys of pProperties then
-		put stringToColor(pProperties["nightNumberColor"]) into mNightNumberColor
+		put pProperties["nightNumberColor"] into mNightNumberColor
 	end if
 	if "dayHourHandColor" is among the keys of pProperties then
-		put stringToColor(pProperties["dayHourHandColor"]) into mDayHourHandColor
+		put pProperties["dayHourHandColor"] into mDayHourHandColor
 	end if
 	if "nightHourHandColor" is among the keys of pProperties then
-		put stringToColor(pProperties["nightHourHandColor"]) into mNightHourHandColor
+		put pProperties["nightHourHandColor"] into mNightHourHandColor
 	end if
 	if "dayMinuteHandColor" is among the keys of pProperties then
-		put stringToColor(pProperties["dayMinuteHandColor"]) into mDayMinuteHandColor
+		put pProperties["dayMinuteHandColor"] into mDayMinuteHandColor
 	end if
 	if "nightMinuteHandColor" is among the keys of pProperties then
-		put stringToColor(pProperties["nightMinuteHandColor"]) into mNightMinuteHandColor
+		put pProperties["nightMinuteHandColor"] into mNightMinuteHandColor
 	end if
 	if "daySecondHandColor" is among the keys of pProperties then
-		put stringToColor(pProperties["daySecondHandColor"]) into mDaySecondHandColor
+		put pProperties["daySecondHandColor"] into mDaySecondHandColor
 	end if
 	if "nightSecondHandColor" is among the keys of pProperties then
-		put stringToColor(pProperties["nightSecondHandColor"]) into mNightSecondHandColor
+		put pProperties["nightSecondHandColor"] into mNightSecondHandColor
 	end if
 	if "dayFaceColor" is among the keys of pProperties then
-		put stringToColor(pProperties["dayFaceColor"]) into mDayFaceColor
+		put pProperties["dayFaceColor"] into mDayFaceColor
 	end if
 	if "nightFaceColor" is among the keys of pProperties then
-		put stringToColor(pProperties["nightFaceColor"]) into mNightFaceColor
+		put pProperties["nightFaceColor"] into mNightFaceColor
 	end if
 end handler
 
@@ -349,16 +349,16 @@ public handler OnCreate()
 	put false into mIsDay
 	put [0,0,0] into mCurrentTime
 	put 12 into mFontSize
-	put color kBlack into mDayNumberColor
-	put color kWhite into mNightNumberColor
-	put color kBlack into mDayHourHandColor
-	put color kWhite into mNightHourHandColor
-	put color kBlack into mDayMinuteHandColor
-	put color kWhite into mNightMinuteHandColor
-	put color kRed into mDaySecondHandColor
-	put color kRed into mNightSecondHandColor
-	put color [224/255,224/255,224/255,0.25] into mDayFaceColor
-	put color kBlack into mNightFaceColor
+	put kBlack into mDayNumberColor
+	put kWhite into mNightNumberColor
+	put kBlack into mDayHourHandColor
+	put kWhite into mNightHourHandColor
+	put kBlack into mDayMinuteHandColor
+	put kWhite into mNightMinuteHandColor
+	put kRed into mDaySecondHandColor
+	put kRed into mNightSecondHandColor
+	put "224,224,224,64" into mDayFaceColor
+	put kBlack into mNightFaceColor
 end handler
 
 public handler OnOpen()
@@ -516,38 +516,37 @@ private handler getPaint(in pObject as String) returns Paint
 
 	if pObject is "clock face" then
 		if mIsDay is true then
-
-			return solid paint with mDayFaceColor
+			return solid paint with stringToColor(mDayFaceColor)
 		else
-			return solid paint with mNightFaceColor
+			return solid paint with stringToColor(mNightFaceColor)
 		end if
 
 	else if pObject is "minute hand" or pObject is "outer nub" then
 		if mIsDay is true then
-			return solid paint with mDayMinuteHandColor
+			return solid paint with stringToColor(mDayMinuteHandColor)
 		else
-			return solid paint with mNightMinuteHandColor
+			return solid paint with stringToColor(mNightMinuteHandColor)
 		end if
 
 	else if pObject is "second hand" or pObject is "inner nub" then
 		if mIsDay is true then
-			return solid paint with mDaySecondHandColor
+			return solid paint with stringToColor(mDaySecondHandColor)
 		else
-			return solid paint with mNightSecondHandColor
+			return solid paint with stringToColor(mNightSecondHandColor)
 		end if
 
 	else if pObject is "numbers" then
 		if mIsDay is true then
-			return solid paint with mDayNumberColor
+			return solid paint with stringToColor(mDayNumberColor)
 		else
-			return solid paint with mNightNumberColor
+			return solid paint with stringToColor(mNightNumberColor)
 		end if
 
 	else if pObject is "hour hand" then
 		if mIsDay is true then
-			return solid paint with mDayHourHandColor
+			return solid paint with stringToColor(mDayHourHandColor)
 		else
-			return solid paint with mNightHourHandColor
+			return solid paint with stringToColor(mNightHourHandColor)
 		end if
 
 	end if
@@ -615,93 +614,53 @@ public handler setTimeZone(in pTimeZone as optional Number) returns nothing
 	redraw all
 end handler
 
-public handler getDayNumberColor() returns String
-	return colorToString(mDayNumberColor, true)
-end handler
-
 public handler setDayNumberColor(in pColor as String)
-	put stringToColor(pColor) into mDayNumberColor
+	put pColor into mDayNumberColor
 	redraw all
-end handler
-
-public handler getNightNumberColor() returns String
-	return colorToString(mNightNumberColor, true)
 end handler
 
 public handler setNightNumberColor(in pColor as String)
-	put stringToColor(pColor) into mNightNumberColor
+	put pColor into mNightNumberColor
 	redraw all
-end handler
-
-public handler getDayHourHandColor() returns String
-	return colorToString(mDayHourHandColor, true)
 end handler
 
 public handler setDayHourHandColor(in pColor as String)
-	put stringToColor(pColor) into mDayHourHandColor
+	put pColor into mDayHourHandColor
 	redraw all
-end handler
-
-public handler getNightHourHandColor() returns String
-	return colorToString(mNightHourHandColor, true)
 end handler
 
 public handler setNightHourHandColor(in pColor as String)
-	put stringToColor(pColor) into mNightHourHandColor
+	put pColor into mNightHourHandColor
 	redraw all
-end handler
-
-public handler getDayMinuteHandColor() returns String
-	return colorToString(mDayMinuteHandColor, true)
 end handler
 
 public handler setDayMinuteHandColor(in pColor as String)
-	put stringToColor(pColor) into mDayMinuteHandColor
+	put pColor into mDayMinuteHandColor
 	redraw all
-end handler
-
-public handler getNightMinuteHandColor() returns String
-	return colorToString(mNightMinuteHandColor, true)
 end handler
 
 public handler setNightMinuteHandColor(in pColor as String)
-	put stringToColor(pColor) into mNightMinuteHandColor
+	put pColor into mNightMinuteHandColor
 	redraw all
-end handler
-
-public handler getDaySecondHandColor() returns String
-	return colorToString(mDaySecondHandColor, true)
 end handler
 
 public handler setDaySecondHandColor(in pColor as String)
-	put stringToColor(pColor) into mDaySecondHandColor
+	put pColor into mDaySecondHandColor
 	redraw all
-end handler
-
-public handler getNightSecondHandColor() returns String
-	return colorToString(mNightSecondHandColor, true)
 end handler
 
 public handler setNightSecondHandColor(in pColor as String)
-	put stringToColor(pColor) into mNightSecondHandColor
+	put pColor into mNightSecondHandColor
 	redraw all
-end handler
-
-public handler getDayFaceColor() returns String
-	return colorToString(mDayFaceColor, true)
 end handler
 
 public handler setDayFaceColor(in pColor as String)
-	put stringToColor(pColor) into mDayFaceColor
+	put pColor into mDayFaceColor
 	redraw all
 end handler
 
-public handler getNightFaceColor() returns String
-	return colorToString(mNightFaceColor, true)
-end handler
-
 public handler setNightFaceColor(in pColor as String)
-	put stringToColor(pColor) into mNightFaceColor
+	put pColor into mNightFaceColor
 	redraw all
 end handler
 

--- a/extensions/widgets/clock/docs/guide/guide.md
+++ b/extensions/widgets/clock/docs/guide/guide.md
@@ -19,11 +19,22 @@ Alternatively it can be created in script using:
 
 ## Clock Display
 
-When the clock is displaying an AM time, the hands are dark on a light 
-background, and when displaying a PM time, the hands are light on a dark 
-background. 
+The clock has two different styles, depending on whether it is day or
+night. By default the hands are dark on a light background when displaying
+a time at night (between 8PM and 6AM), and the hands are light on a dark
+background when displaying a time during the day.
 
 ![AM PM clocks](images/clocks.png)
 
-The read-only property `isDay` also reflects whether the current time is 
+These colors can be customised using the `dayNumberColor`, `dayHourHandColor`, `dayMinuteHandColor`, `daySecondHandColor` and `dayFaceColor` properties,
+and the equivalent properties for night.
+
+The read-only property `isDay` also reflects whether the current time is
 AM or PM.
+
+The time displayed by the clock can differ from the current system local time by setting the timeZone property, an integer which adjusts the time displayed relative to universal time (UTC). For instance, to set the clock to display
+a time that is 6 hours ahead of UCT time ("+06:00"):
+
+`set the timeZone of widget "Clock" to 21600`
+
+as 21600 seconds is 6 hours.

--- a/extensions/widgets/clock/notes/19619.md
+++ b/extensions/widgets/clock/notes/19619.md
@@ -1,4 +1,4 @@
 ---
-version: 9.0.0-dp1
+version: 9.1.0-dp1
 ---
 # [19619] Add color to the clock widget

--- a/extensions/widgets/clock/notes/19619.md
+++ b/extensions/widgets/clock/notes/19619.md
@@ -1,0 +1,4 @@
+---
+version: 9.0.0-dp1
+---
+# [19619] Add color to the clock widget

--- a/extensions/widgets/clock/tests/properties.livecodescript
+++ b/extensions/widgets/clock/tests/properties.livecodescript
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestSetup
+	TestLoadExtension "com.livecode.library.widgetutils"
 	TestLoadExtension "com.livecode.widget.clock"
 	create widget "testClock" as "com.livecode.widget.clock"
 end TestSetup
@@ -38,3 +39,63 @@ on TestSettingLocalTimeZone
  	set the timeZone of widget "testClock" to ""
 	TestAssert "timeZone successfully set to local", the timeZone of widget "testClock" is ""
 end TestSettingLocalTimeZone
+
+on TestGetDefaultFaceColor
+   TestAssert "dayFaceColor on creation is 224,224,224,64", the dayFaceColor of widget "testClock" is "224,224,224,64"
+   TestAssert "nightFaceColor on creation is black", the nightFaceColor of widget "testClock" is "0,0,0,255"
+end TestGetDefaultFaceColor
+
+on TestSettingFaceColor
+   set the dayFaceColor of widget "testClock" to "0,255,0"
+   TestAssert "dayFaceColor sucessfully set to non-default", the dayFaceColor of widget "testClock" is "0,255,0,255"
+   set the nightFaceColor of widget "testClock" to "0,0,255"
+   TestAssert "nightFaceColor sucessfully set to non-default", the nightFaceColor of widget "testClock" is "0,0,255,255"
+end TestSettingFaceColor
+
+on TestDefaultSecondHandColor
+   TestAssert "daySecondHandColor on creation is red", the daySecondHandColor of widget "testClock" is "255,0,0,255"
+   TestAssert "nightSecondHandColor on creation is red", the nightSecondHandColor of widget "testClock" is "255,0,0,255"
+end TestDefaultSecondHandColor
+
+on TestSettingSecondHandColor
+   set the daySecondHandColor of widget "testClock" to "0,255,0"
+   TestAssert "daySecondHandColor sucessfully set to non-default", the daySecondHandColor of widget "testClock" is "0,255,0,255"
+   set the nightSecondHandColor of widget "testClock" to "0,0,255"
+   TestAssert "nightSecondHandColor sucessfully set to non-default", the nightSecondHandColor of widget "testClock" is "0,0,255,255"
+end TestSettingSecondHandColor
+
+on TestDefaultMinuteHandColor
+   TestAssert "dayMinuteHandColor on creation is black", the dayMinuteHandColor of widget "testClock" is "0,0,0,255"
+   TestAssert "nightMinuteHandColor on creation is white", the nightMinuteHandColor of widget "testClock" is "255,255,255,255"
+end TestDefaultMinuteHandColor
+
+on TestSettingMinuteHandColor
+   set the dayMinuteHandColor of widget "testClock" to "0,255,0"
+   TestAssert "dayMinuteHandColor sucessfully set to non-default", the dayMinuteHandColor of widget "testClock" is "0,255,0,255"
+   set the nightMinuteHandColor of widget "testClock" to "0,0,255"
+   TestAssert "nightMinuteHandColor sucessfully set to non-default", the nightMinuteHandColor of widget "testClock" is "0,0,255,255"
+end TestSettingMinuteHandColor
+
+on TestDefaultHourHandColor
+   TestAssert "dayHourHandColor on creation is black", the dayHourHandColor of widget "testClock" is "0,0,0,255"
+   TestAssert "nightHourHandColor on creation is white", the nightHourHandColor of widget "testClock" is "255,255,255,255"
+end TestDefaultHourHandColor
+
+on TestSettingHourHandColor
+   set the dayHourHandColor of widget "testClock" to "0,255,0"
+   TestAssert "dayHourHandColor sucessfully set to non-default", the dayHourHandColor of widget "testClock" is "0,255,0,255"
+   set the nightHourHandColor of widget "testClock" to "0,0,255"
+   TestAssert "nightHourHandColor sucessfully set to non-default", the nightHourHandColor of widget "testClock" is "0,0,255,255"
+end TestSettingHourHandColor
+
+on TestDefaultNumberColor
+   TestAssert "dayNumberColor on creation is black", the dayNumberColor of widget "testClock" is "0,0,0,255"
+   TestAssert "nightNumberColor on creation is white", the nightNumberColor of widget "testClock" is "255,255,255,255"
+end TestDefaultNumberColor
+
+on TestSettingNumberColor
+   set the dayNumberColor of widget "testClock" to "0,255,0"
+   TestAssert "dayNumberColor sucessfully set to non-default", the dayNumberColor of widget "testClock" is "0,255,0,255"
+   set the nightNumberColor of widget "testClock" to "0,0,255"
+   TestAssert "nightNumberColor sucessfully set to non-default", the nightNumberColor of widget "testClock" is "0,0,255,255"
+end TestSettingNumberColor

--- a/extensions/widgets/clock/tests/properties.livecodescript
+++ b/extensions/widgets/clock/tests/properties.livecodescript
@@ -46,9 +46,9 @@ on TestGetDefaultFaceColor
 end TestGetDefaultFaceColor
 
 on TestSettingFaceColor
-   set the dayFaceColor of widget "testClock" to "0,255,0"
+   set the dayFaceColor of widget "testClock" to "0,255,0,255"
    TestAssert "dayFaceColor sucessfully set to non-default", the dayFaceColor of widget "testClock" is "0,255,0,255"
-   set the nightFaceColor of widget "testClock" to "0,0,255"
+   set the nightFaceColor of widget "testClock" to "0,0,255,255"
    TestAssert "nightFaceColor sucessfully set to non-default", the nightFaceColor of widget "testClock" is "0,0,255,255"
 end TestSettingFaceColor
 
@@ -58,9 +58,9 @@ on TestDefaultSecondHandColor
 end TestDefaultSecondHandColor
 
 on TestSettingSecondHandColor
-   set the daySecondHandColor of widget "testClock" to "0,255,0"
+   set the daySecondHandColor of widget "testClock" to "0,255,0,255"
    TestAssert "daySecondHandColor sucessfully set to non-default", the daySecondHandColor of widget "testClock" is "0,255,0,255"
-   set the nightSecondHandColor of widget "testClock" to "0,0,255"
+   set the nightSecondHandColor of widget "testClock" to "0,0,255,255"
    TestAssert "nightSecondHandColor sucessfully set to non-default", the nightSecondHandColor of widget "testClock" is "0,0,255,255"
 end TestSettingSecondHandColor
 
@@ -70,9 +70,9 @@ on TestDefaultMinuteHandColor
 end TestDefaultMinuteHandColor
 
 on TestSettingMinuteHandColor
-   set the dayMinuteHandColor of widget "testClock" to "0,255,0"
+   set the dayMinuteHandColor of widget "testClock" to "0,255,0,255"
    TestAssert "dayMinuteHandColor sucessfully set to non-default", the dayMinuteHandColor of widget "testClock" is "0,255,0,255"
-   set the nightMinuteHandColor of widget "testClock" to "0,0,255"
+   set the nightMinuteHandColor of widget "testClock" to "0,0,255,255"
    TestAssert "nightMinuteHandColor sucessfully set to non-default", the nightMinuteHandColor of widget "testClock" is "0,0,255,255"
 end TestSettingMinuteHandColor
 
@@ -82,9 +82,9 @@ on TestDefaultHourHandColor
 end TestDefaultHourHandColor
 
 on TestSettingHourHandColor
-   set the dayHourHandColor of widget "testClock" to "0,255,0"
+   set the dayHourHandColor of widget "testClock" to "0,255,0,255"
    TestAssert "dayHourHandColor sucessfully set to non-default", the dayHourHandColor of widget "testClock" is "0,255,0,255"
-   set the nightHourHandColor of widget "testClock" to "0,0,255"
+   set the nightHourHandColor of widget "testClock" to "0,0,255,255"
    TestAssert "nightHourHandColor sucessfully set to non-default", the nightHourHandColor of widget "testClock" is "0,0,255,255"
 end TestSettingHourHandColor
 
@@ -94,8 +94,8 @@ on TestDefaultNumberColor
 end TestDefaultNumberColor
 
 on TestSettingNumberColor
-   set the dayNumberColor of widget "testClock" to "0,255,0"
+   set the dayNumberColor of widget "testClock" to "0,255,0,255"
    TestAssert "dayNumberColor sucessfully set to non-default", the dayNumberColor of widget "testClock" is "0,255,0,255"
-   set the nightNumberColor of widget "testClock" to "0,0,255"
+   set the nightNumberColor of widget "testClock" to "0,0,255,255"
    TestAssert "nightNumberColor sucessfully set to non-default", the nightNumberColor of widget "testClock" is "0,0,255,255"
 end TestSettingNumberColor

--- a/tests/lcs/core/engine/extension.livecodescript
+++ b/tests/lcs/core/engine/extension.livecodescript
@@ -20,6 +20,7 @@ local sTestExtension
 on TestSetup
    TestSkipIfNot "lcb"
    
+   TestLoadExtension "com.livecode.library.widgetutils" --required for clock
     TestLoadExtension "com.livecode.library.json"
     TestLoadExtension "com.livecode.widget.clock"
 

--- a/tests/lcs/core/files/save.livecodescript
+++ b/tests/lcs/core/files/save.livecodescript
@@ -37,6 +37,7 @@ command TestSetup
    create invisible stack "widget"
    put it into sTestStackWidget
    set the defaultstack to sTestStackWidget
+   TestLoadExtension "com.livecode.library.widgetutils" --required for clock
    TestLoadExtension "com.livecode.widget.clock"
    create widget as "com.livecode.widget.clock"
    


### PR DESCRIPTION
I've added several new properties to the clock widget to allow for the colors of the various components (numbers, second hand, minute hand, hour hand, face) to be changed. In total there are ten new properties: five for the day and five for night.

I did consider trying to use existing LiveCode properties such as the backgroundColor for the face color and the foregroundColor for the number color, but this was complicated by the clock having day and night modes which meant that either the colors would be inverted at night (potentially leading to an ugly appearance - particularly because the night mode cannot be disabled) or a separate set of properties would be created for the night. In the end I decided on going for a whole new set of properties that could be named consistently.

I've updated both the tests and the documentation for the clock widget to include these new properties.