### PR TITLE
[[ Bug 21496 ]] Ensure emscripten startup_script is suitable for capsule section

### DIFF
--- a/docs/notes/bugfix-21496.md
+++ b/docs/notes/bugfix-21496.md
@@ -1,0 +1,1 @@
+# Ensure emscripten aux stacks are loaded on startup

--- a/engine/rsrc/emscripten-startup-template.livecodescript
+++ b/engine/rsrc/emscripten-startup-template.livecodescript
@@ -1,4 +1,3 @@
-﻿script "__startup"
 constant kEngineVersion = "@ENGINE_VERSION@"
 
 -- Directories that engine expects to normally be present
@@ -7,41 +6,38 @@ constant kStandardFolders = "/tmp:/livecode:/boot:/boot/standalone:/boot/fonts"
 -- Directory containing the initial stack files
 constant kStartupFolder = "/boot/standalone"
 
-on startup
-   local tError, tFolder
-   try
-      ----------------------------------------------------------------
-      -- Create standard filesystem layout
-      set the itemdelimiter to ":"
-      repeat for each item tFolder in kStandardFolders
-         if there is not a folder tFolder then
-            create folder tFolder
-            if the result is not empty then
-               throw the result
-            end if
+local tError, tFolder
+try
+   ----------------------------------------------------------------
+   -- Create standard filesystem layout
+   set the itemdelimiter to ":"
+   repeat for each item tFolder in kStandardFolders
+      if there is not a folder tFolder then
+         create folder tFolder
+         if the result is not empty then
+            throw the result
          end if
-      end repeat
-      
-      -------------------------------------------------------------
-      -- Validate engine version
-      if the version is not kEngineVersion then
-         throw "Engine mismatch: found" && the version & ", expected" && kEngineVersion
       end if
-      
-      
-      @STARTUP_SCRIPT@
-      
-   catch tError
-   end try
-   
-   -- Set the initial working directory to the directory that contains
-   -- the initial stack.
-   set the defaultfolder to kStartupFolder
-   
-   -- Try to print something vaguely helpful to the the log
-   if tError is not empty then
-      write "startup failed:" && tError & return to stderr
+   end repeat
+
+   -------------------------------------------------------------
+   -- Validate engine version
+   if the version is not kEngineVersion then
+      throw "Engine mismatch: found" && the version & ", expected" && kEngineVersion
    end if
-   
-   return tError
-end startup
+
+
+   @STARTUP_SCRIPT@
+
+catch tError
+end try
+
+-- Try to print something vaguely helpful to the the log
+if tError is not empty then
+   write "startup failed:" && tError & return to stderr
+   throw tError
+end if
+
+-- Set the initial working directory to the directory that contains
+-- the initial stack.
+set the defaultfolder to kStartupFolder

--- a/ide-support/revsaveasemscriptenstandalone.livecodescript
+++ b/ide-support/revsaveasemscriptenstandalone.livecodescript
@@ -253,13 +253,9 @@ private function getStartupScript pGeneratedStartupScript
       throw tTemplateFile & ":" && the result
    end if
    close file tTemplateFile
-   
-   -- Trim to the actual script
-   delete line 1 of tScript
-      
+
    -- Make substitutions in the startup script
    replace "@ENGINE_VERSION@" with the version in tScript
-   replace "@MODULE_VERSION@" with extensionLCCompileVersion() in tScript
    replace "@STARTUP_SCRIPT@" with pGeneratedStartupScript in tScript
    return tScript
 end getStartupScript


### PR DESCRIPTION
Previously the emscripten startup script was a startup handler for
a boot stack. Now that emscripten deploy uses the deploy command
and capsule format, it needs to be a script snippet (that will
ultimately be placed in a generated `on message` handler which is
called on startup).