### PR TITLE
[[ Bug 21417 ]] Remove externals list from emscripten deploy params

### DIFF
--- a/docs/notes/bugfix-21417.md
+++ b/docs/notes/bugfix-21417.md
@@ -1,0 +1,1 @@
+# Don't include any externals in emscripten standalones

--- a/ide-support/revsaveasemscriptenstandalone.livecodescript
+++ b/ide-support/revsaveasemscriptenstandalone.livecodescript
@@ -202,7 +202,10 @@ private command storeDeployedStack pZip, pDeployPath, pBuildFolder, pMainStack, 
    put tTempStackPath into pDeployParams["stackfile"]
    put tTempDeployPath into pDeployParams["output"]
    put empty into pDeployParams["engine"]
-   
+
+   // Externals are not yet supported in emscripten builds
+   put empty into pDeployParams["externals"]
+
    ---------- Perform standalone deployment
    logDebug "deploy", "Deploying standalone"
    


### PR DESCRIPTION
Now that the deploy command is used on emscripten, we need to
empty the externals deploy param as they are not supported for
emscripten builds.