### PR TITLE
[[Bugfix 14721]] Implement 'go visible <stack>' as an antonym to 'go invisible'

### DIFF
--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -4,11 +4,11 @@ Synonyms: open
 
 Type: command
 
-Syntax: go [invisible] [to] <card> [of <stack>] [{as <mode> |in [a] new window|in <window>}]
+Syntax: go [{visible | invisible}] [to] <card> [of <stack>] [{as <mode> |in [a] new window|in <window>}]
 
-Syntax: go [invisible] [to] {first | prev[ious]| next | last | any} [marked] [<card>]
+Syntax: go [{visible | invisible}] [to] {first | prev[ious]| next | last | any} [marked] [<card>]
 
-Syntax: go [invisible] [to] {recent | start | finish | home} <card>
+Syntax: go [{visible | invisible}] [to] {recent | start | finish | home} <card>
 
 Syntax: go {forward | forth | back[ward]} [<number>]
 
@@ -35,6 +35,9 @@ go back 7
 
 Example:
 go invisible stack "Preferences"
+
+Example:
+go visible stack "Script-only stack"
 
 Example:
 local tStackFile, tStackFolder
@@ -153,12 +156,21 @@ among the previously-visited cards:
   form moves forward in the recent cards list. "forward" and "forth" are
   synonyms. 
 
+If you use the <go> visible form, the stack is made visible after being
+opened. (When going to a stack, this form sets the stack's <visible>
+<property> to true.) Use this form of the <go> command to display a
+script-only stack without explicitly setting the <visible (property)>
+in the <openStack> or <preOpenStack> handlers.
 
 If you use the <go> invisible form, the window or card change does not
 show on the screen. (When going to a stack, this form sets the stack's
 <visible> <property> to false.) Use this form of the <go> command to open
 a stack without displaying it on screen. To display the stack later, use
 the <show> <command> or set its <visible (property)>to true.
+
+Note that if a stack’s <visible> property is set in either the <openStack>
+or <preOpenStack> handlers, then this will override the expected behaviour
+of the <go> visible and <go> invisible forms.
 
 Any visual effects that have been queued with the visual effect command
 are displayed when the <go> command is executed (unless the screen is

--- a/docs/notes/Bugfix-14721.md
+++ b/docs/notes/Bugfix-14721.md
@@ -1,0 +1,1 @@
+# Implement 'go visible <stack>' as an antonym to 'go invisible'

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1738,7 +1738,7 @@ class MCGo : public MCStatement
 	Window_mode mode;
 	Boolean marked;
 	Boolean visible;
-	Boolean explicit_visibility = False;
+	MCGoStackVisibility visibilityType = kImplicit;
 	Boolean thisstack;
 	
 	MCChunk *widget;

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1738,7 +1738,7 @@ class MCGo : public MCStatement
 	Window_mode mode;
 	Boolean marked;
 	Boolean visible;
-	MCGoStackVisibility visibilityType = kImplicit;
+	MCInterfaceExecGoVisibility visibilityType = kMCInterfaceExecGoVisibilityImplicit;
 	Boolean thisstack;
 	
 	MCChunk *widget;

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1738,6 +1738,7 @@ class MCGo : public MCStatement
 	Window_mode mode;
 	Boolean marked;
 	Boolean visible;
+	Boolean explicit_visibility = False;
 	Boolean thisstack;
 	
 	MCChunk *widget;

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1737,8 +1737,7 @@ class MCGo : public MCStatement
 	MCExpression *window;
 	Window_mode mode;
 	Boolean marked;
-	Boolean visible;
-	MCInterfaceExecGoVisibility visibilityType = kMCInterfaceExecGoVisibilityImplicit;
+	MCInterfaceExecGoVisibility visibility_type;
 	Boolean thisstack;
 	
 	MCChunk *widget;
@@ -1751,7 +1750,7 @@ public:
 		window(nil),
 		mode(WM_LAST),
         marked(False),
-        visible(True),
+        visibility_type(kMCInterfaceExecGoVisibilityImplicit),
         thisstack(False),
 		widget(nil),
         direction(CT_BACKWARD)

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -111,14 +111,10 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 	Chunk_term lterm = CT_UNDEFINED;
 
 	initpoint(sp);
-	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_INVISIBLE) == PS_NORMAL) {
-		visible = False;
-		explicit_visibility = True;
-	}
-	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_VISIBLE) == PS_NORMAL) {
-		visible = True;
-		explicit_visibility = True;
-	}
+	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_INVISIBLE) == PS_NORMAL)
+		visibilityType = kExplicitInvisible;
+	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_VISIBLE) == PS_NORMAL)
+		visibilityType = kExplicitVisible;
 	while (True)
 	{
 		if (sp.next(type) != PS_NORMAL)
@@ -750,9 +746,9 @@ void MCGo::exec_ctxt(MCExecContext &ctxt)
 		}
 	}
 	else if (window != nil)
-		MCInterfaceExecGoCardInWindow(ctxt, cptr, *t_window, visible == True, explicit_visibility == True, thisstack == True);
+		MCInterfaceExecGoCardInWindow(ctxt, cptr, *t_window, visibilityType, thisstack == True);
 	else
-        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visible == True, explicit_visibility == True, thisstack == True);
+        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visibilityType, thisstack == True);
 }
 
 MCHide::~MCHide()

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -111,8 +111,14 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 	Chunk_term lterm = CT_UNDEFINED;
 
 	initpoint(sp);
-	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_INVISIBLE) == PS_NORMAL)
+	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_INVISIBLE) == PS_NORMAL) {
 		visible = False;
+		explicit_visibility = True;
+	}
+	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_VISIBLE) == PS_NORMAL) {
+		visible = True;
+		explicit_visibility = True;
+	}
 	while (True)
 	{
 		if (sp.next(type) != PS_NORMAL)
@@ -744,9 +750,9 @@ void MCGo::exec_ctxt(MCExecContext &ctxt)
 		}
 	}
 	else if (window != nil)
-		MCInterfaceExecGoCardInWindow(ctxt, cptr, *t_window, visible == True, thisstack == True);
+		MCInterfaceExecGoCardInWindow(ctxt, cptr, *t_window, visible == True, explicit_visibility == True, thisstack == True);
 	else
-        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visible == True, thisstack == True);
+        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visible == True, explicit_visibility == True, thisstack == True);
 }
 
 MCHide::~MCHide()

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -112,9 +112,9 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 
 	initpoint(sp);
 	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_INVISIBLE) == PS_NORMAL)
-		visibilityType = kExplicitInvisible;
+		visibilityType = kMCInterfaceExecGoVisibilityExplicitInvisible;
 	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_VISIBLE) == PS_NORMAL)
-		visibilityType = kExplicitVisible;
+		visibilityType = kMCInterfaceExecGoVisibilityExplicitVisible;
 	while (True)
 	{
 		if (sp.next(type) != PS_NORMAL)

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -112,9 +112,9 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 
 	initpoint(sp);
 	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_INVISIBLE) == PS_NORMAL)
-		visibilityType = kMCInterfaceExecGoVisibilityExplicitInvisible;
+		visibility_type = kMCInterfaceExecGoVisibilityExplicitInvisible;
 	if (sp.skip_token(SP_FACTOR, TT_PROPERTY, P_VISIBLE) == PS_NORMAL)
-		visibilityType = kMCInterfaceExecGoVisibilityExplicitVisible;
+		visibility_type = kMCInterfaceExecGoVisibilityExplicitVisible;
 	while (True)
 	{
 		if (sp.next(type) != PS_NORMAL)
@@ -746,9 +746,9 @@ void MCGo::exec_ctxt(MCExecContext &ctxt)
 		}
 	}
 	else if (window != nil)
-		MCInterfaceExecGoCardInWindow(ctxt, cptr, *t_window, visibilityType, thisstack == True);
+		MCInterfaceExecGoCardInWindow(ctxt, cptr, *t_window, visibility_type, thisstack == True);
 	else
-        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visibilityType, thisstack == True);
+        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visibility_type, thisstack == True);
 }
 
 MCHide::~MCHide()

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4329,7 +4329,7 @@ void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_t
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, MCGoStackVisibility p_visibility_type)
+void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, MCInterfaceExecGoVisibility p_visibility_type)
 {
 	
 	if (p_card == nil)
@@ -4453,13 +4453,13 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 	MCtrace = False;
 
 	// MW-2007-02-11: [[ Bug 4029 ]] - 'go invisible' fails to close stack window if window already open
-	if (p_visibility_type != kImplicit)
+	if (p_visibility_type != kMCInterfaceExecGoVisibilityImplicit)
 	{
 		if (t_stack -> getwindow() != NULL)
 			MCscreen -> closewindow(t_stack -> getwindow());
-		if (p_visibility_type == kExplicitVisible)
+		if (p_visibility_type == kMCInterfaceExecGoVisibilityExplicitVisible)
 			t_stack->setflag(true, F_VISIBLE);
-		if (p_visibility_type == kExplicitInvisible)
+		if (p_visibility_type == kMCInterfaceExecGoVisibilityExplicitInvisible)
 			t_stack->setflag(false, F_VISIBLE);
 	}
 
@@ -4543,12 +4543,12 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 		ctxt . Throw();
 }
 
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCGoStackVisibility p_visibility_type, bool p_this_stack)
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack)
 {
 	MCInterfaceExecGo(ctxt, p_card, nil, p_mode, p_this_stack, p_visibility_type);
 }
 
-void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCGoStackVisibility p_visibility_type, bool p_this_stack)
+void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack)
 {
 	MCInterfaceExecGo(ctxt, p_card, p_window, WM_MODELESS, p_this_stack, p_visibility_type);
 }
@@ -4576,7 +4576,7 @@ void MCInterfaceExecGoHome(MCExecContext& ctxt, MCCard *p_card)
 		MCdefaultstackptr->close();
 		MCdefaultstackptr->checkdestroy();
 	}
-	MCGoStackVisibility visibilityType = kImplicit;
+	MCInterfaceExecGoVisibility visibilityType = kMCInterfaceExecGoVisibilityImplicit;
 	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, visibilityType);
 }
 

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4576,8 +4576,7 @@ void MCInterfaceExecGoHome(MCExecContext& ctxt, MCCard *p_card)
 		MCdefaultstackptr->close();
 		MCdefaultstackptr->checkdestroy();
 	}
-	MCInterfaceExecGoVisibility visibilityType = kMCInterfaceExecGoVisibilityImplicit;
-	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, visibilityType);
+	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, MCInterfaceExecGoVisibility(kMCInterfaceExecGoVisibilityImplicit));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4329,7 +4329,7 @@ void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_t
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, bool p_visible)
+void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, bool p_visible, bool p_explicit_visibility)
 {
 	if (p_card == nil)
     {
@@ -4452,11 +4452,11 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 	MCtrace = False;
 
 	// MW-2007-02-11: [[ Bug 4029 ]] - 'go invisible' fails to close stack window if window already open
-	if (!p_visible && t_stack -> getflag(F_VISIBLE))
+	if (p_explicit_visibility)
 	{
 		if (t_stack -> getwindow() != NULL)
 			MCscreen -> closewindow(t_stack -> getwindow());
-		t_stack->setflag(False, F_VISIBLE);
+		t_stack->setflag(p_visible, F_VISIBLE);
 	}
 
 	// MW-2011-02-27: [[ Bug ]] Make sure that if we open as a sheet, we have a parent pointer!
@@ -4539,14 +4539,14 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 		ctxt . Throw();
 }
 
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, bool p_visible, bool p_this_stack)
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, bool p_visible, bool p_explicit_visibility, bool p_this_stack)
 {
-	MCInterfaceExecGo(ctxt, p_card, nil, p_mode, p_this_stack, p_visible);
+	MCInterfaceExecGo(ctxt, p_card, nil, p_mode, p_this_stack, p_visible, p_explicit_visibility);
 }
 
-void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, bool p_visible, bool p_this_stack)
+void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, bool p_visible, bool p_explicit_visibility, bool p_this_stack)
 {
-	MCInterfaceExecGo(ctxt, p_card, p_window, WM_MODELESS, p_this_stack, p_visible);
+	MCInterfaceExecGo(ctxt, p_card, p_window, WM_MODELESS, p_this_stack, p_visible, p_explicit_visibility);
 }
 
 void MCInterfaceExecGoRecentCard(MCExecContext& ctxt)
@@ -4572,7 +4572,7 @@ void MCInterfaceExecGoHome(MCExecContext& ctxt, MCCard *p_card)
 		MCdefaultstackptr->close();
 		MCdefaultstackptr->checkdestroy();
 	}
-	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, true);
+	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, true, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4576,7 +4576,7 @@ void MCInterfaceExecGoHome(MCExecContext& ctxt, MCCard *p_card)
 		MCdefaultstackptr->close();
 		MCdefaultstackptr->checkdestroy();
 	}
-	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, MCInterfaceExecGoVisibility(kMCInterfaceExecGoVisibilityImplicit));
+	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, kMCInterfaceExecGoVisibilityImplicit);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4329,8 +4329,9 @@ void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_t
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, bool p_visible, bool p_explicit_visibility)
+void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, MCGoStackVisibility p_visibility_type)
 {
+	
 	if (p_card == nil)
     {
         if (MCresult -> isclear())
@@ -4452,11 +4453,14 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 	MCtrace = False;
 
 	// MW-2007-02-11: [[ Bug 4029 ]] - 'go invisible' fails to close stack window if window already open
-	if (p_explicit_visibility)
+	if (p_visibility_type != kImplicit)
 	{
 		if (t_stack -> getwindow() != NULL)
 			MCscreen -> closewindow(t_stack -> getwindow());
-		t_stack->setflag(p_visible, F_VISIBLE);
+		if (p_visibility_type == kExplicitVisible)
+			t_stack->setflag(true, F_VISIBLE);
+		if (p_visibility_type == kExplicitInvisible)
+			t_stack->setflag(false, F_VISIBLE);
 	}
 
 	// MW-2011-02-27: [[ Bug ]] Make sure that if we open as a sheet, we have a parent pointer!
@@ -4539,14 +4543,14 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 		ctxt . Throw();
 }
 
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, bool p_visible, bool p_explicit_visibility, bool p_this_stack)
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCGoStackVisibility p_visibility_type, bool p_this_stack)
 {
-	MCInterfaceExecGo(ctxt, p_card, nil, p_mode, p_this_stack, p_visible, p_explicit_visibility);
+	MCInterfaceExecGo(ctxt, p_card, nil, p_mode, p_this_stack, p_visibility_type);
 }
 
-void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, bool p_visible, bool p_explicit_visibility, bool p_this_stack)
+void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCGoStackVisibility p_visibility_type, bool p_this_stack)
 {
-	MCInterfaceExecGo(ctxt, p_card, p_window, WM_MODELESS, p_this_stack, p_visible, p_explicit_visibility);
+	MCInterfaceExecGo(ctxt, p_card, p_window, WM_MODELESS, p_this_stack, p_visibility_type);
 }
 
 void MCInterfaceExecGoRecentCard(MCExecContext& ctxt)
@@ -4572,7 +4576,8 @@ void MCInterfaceExecGoHome(MCExecContext& ctxt, MCCard *p_card)
 		MCdefaultstackptr->close();
 		MCdefaultstackptr->checkdestroy();
 	}
-	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, true, false);
+	MCGoStackVisibility visibilityType = kImplicit;
+	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, visibilityType);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2449,9 +2449,14 @@ void MCInterfaceExecReplaceInField(MCExecContext& ctxt, MCStringRef p_pattern, M
 
 void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_tool);
 
-enum MCGoStackVisibility { kImplicit, kExplicitVisible, kExplicitInvisible };
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCGoStackVisibility p_visibility_type, bool p_this_stack);
-void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCGoStackVisibility p_visibility_type, bool p_this_stack);
+enum MCInterfaceExecGoVisibility
+{
+	kMCInterfaceExecGoVisibilityImplicit,
+	kMCInterfaceExecGoVisibilityExplicitVisible,
+	kMCInterfaceExecGoVisibilityExplicitInvisible
+};
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack);
+void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack);
 void MCInterfaceExecGoRecentCard(MCExecContext& ctxt);
 void MCInterfaceExecGoCardRelative(MCExecContext& ctxt, bool p_forward, real8 p_amount);
 void MCInterfaceExecGoCardEnd(MCExecContext& ctxt, bool p_is_start);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2449,8 +2449,9 @@ void MCInterfaceExecReplaceInField(MCExecContext& ctxt, MCStringRef p_pattern, M
 
 void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_tool);
 
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, bool p_visible, bool p_explicit_visibility, bool p_this_stack);
-void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, bool p_visible, bool p_explicit_visibility, bool p_this_stack);
+enum MCGoStackVisibility { kImplicit, kExplicitVisible, kExplicitInvisible };
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCGoStackVisibility p_visibility_type, bool p_this_stack);
+void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCGoStackVisibility p_visibility_type, bool p_this_stack);
 void MCInterfaceExecGoRecentCard(MCExecContext& ctxt);
 void MCInterfaceExecGoCardRelative(MCExecContext& ctxt, bool p_forward, real8 p_amount);
 void MCInterfaceExecGoCardEnd(MCExecContext& ctxt, bool p_is_start);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2449,8 +2449,8 @@ void MCInterfaceExecReplaceInField(MCExecContext& ctxt, MCStringRef p_pattern, M
 
 void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_tool);
 
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, bool p_visible, bool p_this_stack);
-void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, bool p_visible, bool p_this_stack);
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, bool p_visible, bool p_explicit_visibility, bool p_this_stack);
+void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, bool p_visible, bool p_explicit_visibility, bool p_this_stack);
 void MCInterfaceExecGoRecentCard(MCExecContext& ctxt);
 void MCInterfaceExecGoCardRelative(MCExecContext& ctxt, bool p_forward, real8 p_amount);
 void MCInterfaceExecGoCardEnd(MCExecContext& ctxt, bool p_is_start);

--- a/tests/lcs/core/interface/go.livecodescript
+++ b/tests/lcs/core/interface/go.livecodescript
@@ -55,14 +55,19 @@ on TestGoCardUnquotedName
 end TestGoCardUnquotedName
 
 local sStackFileName
-command _TestCreateStack pBinary
+command _TestCreateStack pBinary pVisible
    local tStack
    put "stackToGo" into tStack
    
    if pBinary then
       create stack tStack
+      set the visible of stack tStack to pVisible
    else
       create script only stack tStack
+      if pVisible then
+         put "on preOpenStack" & return & "set the visible of me to" && pVisible & return & "end preOpenStack" into tScript
+         set the script of stack tStack to tScript
+      end if
    end if
    
    put the tempname into sStackFileName
@@ -78,7 +83,7 @@ end _TestCleanupStack
 command _TestGoStackUrl pWhich
    TestSkipIfNot "write"
    local tStack
-   _TestCreateStack pWhich is "binary"
+   _TestCreateStack pWhich is "binary", true
    put it into tStack
    go url ("file:" & sStackFileName)
    TestDiagnostic the result
@@ -117,3 +122,75 @@ on TestGoToCard
 	TestAssert "openCard sent to opened card", the cOpened of card 1
 	TestAssert "closeCard sent to closed card", the cClosed of card 2
 end TestGoToCard
+
+on _TestGoInvisibleVisibleStack pMode pWhich pVisible
+   TestSkipIfNot "write"
+   local tStack
+   _TestCreateStack pWhich is "binary", pVisible is "visible"
+   put it into tStack
+   do "go" && pMode && "stack sStackFilename"
+   TestDiagnostic the result
+   if pMode is empty then
+      put pVisible into pExpectedVisibility
+   else if pMode is "invisible" and pWhich is "script only" and pVisible is "visible" then
+      --a special case:
+      --a visible script only stack will be visible even if go invisible
+      --is used because the stack becomes visible by a "set the visible..."
+      --line in preOpenStack or openStack. So the setting of the visibility
+      --by the engine will be overridden when the stack is opened
+      put "visible" into pExpectedVisibility
+   else
+      put pMode into pExpectedVisibility
+   end if
+   TestAssert "go" && pMode && "on a" && pVisible && pWhich && "stack opened", there is a stack tStack
+   TestAssert "go" && pMode && "on a" && pVisible && pWhich && "stack is" && pExpectedVisibility, the visible of stack tStack is (pExpectedVisibility is "visible")
+   _TestCleanupStack
+end _TestGoInvisibleVisibleStack
+
+on TestGoVisibleOnVisibleBinary
+   _TestGoInvisibleVisibleStack "visible", "binary", "visible"
+end TestGoVisibleOnVisibleBinary
+
+on TestGoVisibleOnInvisibleBinary
+   _TestGoInvisibleVisibleStack "visible", "binary", "invisible"
+end TestGoVisibleOnInvisibleBinary
+
+on TestGoVisibleOnVisibleScriptOnly
+   _TestGoInvisibleVisibleStack "visible", "script only", "visible"
+end TestGoVisibleOnVisibleScriptOnly
+
+on TestGoVisibleOnInvisibleScriptOnly
+   _TestGoInvisibleVisibleStack "visible", "script only", "invisible"
+end TestGoVisibleOnInvisibleScriptOnly
+
+on TestGoInvisibleOnVisibleBinary
+   _TestGoInvisibleVisibleStack "invisible", "binary", "visible"
+end TestGoInvisibleOnVisibleBinary
+
+on TestGoInvisibleOnInvisibleBinary
+   _TestGoInvisibleVisibleStack "invisible", "binary", "invisible"
+end TestGoInvisibleOnInvisibleBinary
+
+on TestGoInvisibleOnVisibleScriptOnly
+   _TestGoInvisibleVisibleStack "invisible", "script only", "visible"
+end TestGoInvisibleOnVisibleScriptOnly
+
+on TestGoInvisibleOnInvisibleScriptOnly
+   _TestGoInvisibleVisibleStack "invisible", "script only", "invisible"
+end TestGoInvisibleOnInvisibleScriptOnly
+
+on TestGoRegularOnVisibleBinary
+   _TestGoInvisibleVisibleStack "", "binary", "visible"
+end TestGoRegularOnVisibleBinary
+
+on TestGoRegularOnInvisibleBinary
+   _TestGoInvisibleVisibleStack "", "binary", "invisible"
+end TestGoRegularOnInvisibleBinary
+
+on TestGoRegularOnVisibleScriptOnly
+   _TestGoInvisibleVisibleStack "", "script only", "visible"
+end TestGoRegularOnVisibleScriptOnly
+
+on TestGoRegularOnInvisibleScriptOnly
+   _TestGoInvisibleVisibleStack "", "script only", "invisible"
+end TestGoRegularOnInvisibleScriptOnly

--- a/tests/lcs/core/interface/go.livecodescript
+++ b/tests/lcs/core/interface/go.livecodescript
@@ -55,7 +55,7 @@ on TestGoCardUnquotedName
 end TestGoCardUnquotedName
 
 local sStackFileName
-command _TestCreateStack pBinary pVisible
+command _TestCreateStack pBinary, pVisible
    local tStack
    put "stackToGo" into tStack
    
@@ -123,7 +123,7 @@ on TestGoToCard
 	TestAssert "closeCard sent to closed card", the cClosed of card 2
 end TestGoToCard
 
-on _TestGoInvisibleVisibleStack pMode pWhich pVisible
+on _TestGoInvisibleVisibleStack pMode, pWhich, pVisible
    TestSkipIfNot "write"
    local tStack
    _TestCreateStack pWhich is "binary", pVisible is "visible"

--- a/tests/lcs/parser/go.parsertest
+++ b/tests/lcs/parser/go.parsertest
@@ -1,0 +1,39 @@
+%% Copyright (C) 2018 LiveCode Ltd.
+%%
+%% This file is part of LiveCode.
+%%
+%% LiveCode is free software; you can redistribute it and/or modify it under
+%% the terms of the GNU General Public License v3 as published by the Free
+%% Software Foundation.
+%%
+%% LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+%% WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+%% for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with LiveCode.  If not see <http://www.gnu.org/licenses/>.
+
+%TEST GoRegularStack
+on parse_test
+	go stack "sample"
+end parse_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST GoVisibleStack
+on parse_test
+	go visible stack "sample"
+end parse_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST
+
+%TEST GoVisibleStack
+on parse_test
+	go invisible stack "sample"
+end parse_test
+%EXPECT PASS
+%SUCCESS
+%ENDTEST


### PR DESCRIPTION
The go visible command has been added, along with a new parser test for the go command (seemingly it did not have any parser tests before?). The documentation and functional tests have been updated to take account of the new option.