### PR TITLE
[[ Bug 21503 ]] Tree widget - prevent value removal on key addition

### DIFF
--- a/extensions/widgets/treeview/notes/21503.md
+++ b/extensions/widgets/treeview/notes/21503.md
@@ -1,0 +1,1 @@
+# [21503] Prevent value removal on key addition

--- a/extensions/widgets/treeview/notes/21503.md
+++ b/extensions/widgets/treeview/notes/21503.md
@@ -1,1 +1,1 @@
-# [21503] Prevent value removal on key addition
+# [21503] Prevent accidental value removal on key addition

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1509,6 +1509,20 @@ private handler addKey(in pListElt as Integer, in pPath as List, in pLevel as In
 	if tElement is an array then
 		createNewKey(xArray[pPath[pLevel + 1]])
 	else
+		if tElement is not "" then
+			variable tPrompt as String
+			combine pPath with "]["
+			put "The array element at path [" & the result & "] is not empty. " & \
+					"Would you like to replace it with an empty array or " & \
+					"move it to the first element?" into tPrompt
+			execute script "answer \q" & tPrompt & \
+					"\q with Cancel or Replace or Move; return it"
+			if the result is "Replace" then
+				put "" into tElement
+			else if the result is "Cancel" then
+				return
+			end if
+		end if
 		variable tArray as Array
 		put the empty array into tArray	
 		put tElement into tArray[1 formatted as string]

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -759,7 +759,7 @@ public handler OnMouseDown() returns nothing
 	end if
 end handler
 
-public handler OnMouseMove() returns nothing			
+public handler OnMouseMove() returns nothing
 	if scrollDragging() then
 		variable tScrollPositionRatio as Real
 		scrollbarDrag(mViewHeight)
@@ -1511,7 +1511,7 @@ private handler addKey(in pListElt as Integer, in pPath as List, in pLevel as In
 	else
 		variable tArray as Array
 		put the empty array into tArray	
-		put "" into tArray[1 formatted as string]
+		put tElement into tArray[1 formatted as string]
 		put tArray into xArray[pPath[pLevel + 1]]
 		put false into xList[pListElt]["leaf"]
 	end if


### PR DESCRIPTION
Current operation of the tree widget will delete the value stored in a key
if the "+" is clicked to add a new sub-key and it is not already an array.

This change alters the behavior such that when the "+" is clicked, if the current key is not already an array, then a dialog will ask the user for how to proceed.  The options are to `move` the existing value to the new sub-key that is created,`replace` the value with an empty array, or `cancel` the operation.