### PR TITLE
[[ Bug 21505 ]] Implement matches operator

### DIFF
--- a/docs/dictionary/operator/matches.lcdoc
+++ b/docs/dictionary/operator/matches.lcdoc
@@ -1,0 +1,81 @@
+Name: matches
+
+Type: operator
+
+Syntax: <value> matches { "regex" | "wildcard" } [pattern] <pattern>
+
+Summary:
+Compares a <value> to a <wildcard> pattern or <regular expression>.
+
+Introduced: 9.5
+
+OS: mac, windows, linux, ios, android
+
+Platforms: desktop, server, mobile
+
+Example:
+"foobar" matches wildcard pattern "*b*" -- evaluates to true
+
+Example:
+"Foobar" matches regex pattern "^f.*r$" -- evaluates to false
+
+Example:
+"Foobar" matches regex pattern "(?i)^f.*r$" -- evaluates to true
+
+Parameters:
+value:
+The <value> is a <string> to be compared against the <pattern>
+
+pattern:
+A <regular expression> or <wildcard> pattern to compare to the <value>
+
+Description:
+Use the <matches> <operator> to determine if a <value> conforms to a <wildcard>
+pattern or <regular expression>.
+
+>*Note:* If the <value> is an array it will first be converted into the empty
+> string, thus any array will only match a <regular expression> or <wildcard>
+> pattern that matches an empty string.
+
+If the <regex pattern> form is specified, the <pattern> should
+be formatted as a <regular expression>. There are [many websites](https://www.google.com/search?regex)
+that provide examples and tutorials of RegEx expressions.
+
+If the <wildcard> pattern form is to be used, the <pattern> should
+consist of a string of characters to match, which may be combined with any
+number of the following special characters:
+
+- `*` : Matches zero or more of any character. The pattern `A*C`
+    matches "AC", "ABC", or "ADZXC".
+- `?` : Matches exactly one character. The pattern `A?C` matches
+  "ABC", but not "AC" or "ADZXC".
+- `[chars]` : Matches any one of the characters inside the brackets. The
+  pattern `A[BC]D` matches "ABD" or "ACD", but not "AD" or "ABCD".
+- `[!chars]` : Matches any character which is not one of the characters
+  inside the brackets.
+- `[char-char]` : Matches any character whose unicode codepoint is between
+  the first character and the second character, such as `[a-y]` any character
+  between "a" and "y" but not "z"
+
+You can match instances of special chars as follows:
+
+- `?` with `[?]`
+- `*` with `[*]`
+- `[` with `[[]`
+- `-` with `-`
+- `!` with `!`
+
+For example, the <pattern> `[[]A]*` will match any
+string beginning with `[A]`. Broken down, there is `[[]` which equates
+to an open square bracket `[` followed by `A]*` as the closing square
+bracket is not a special character.
+
+The three bracketed forms can be combined to create more complex
+character classes, for example the <pattern> `[!abcA-C]` matches any
+character which is not a, b or c (upper or lower case)
+
+References: operator (glossary), case-sensitive (glossary), value (glossary),
+string (glossary), expression (glossary), caseSensitive (property),
+regular expression (glossary), wildcard (glossary)
+
+Tags: text processing

--- a/docs/notes/feature-matches.md
+++ b/docs/notes/feature-matches.md
@@ -1,0 +1,12 @@
+# Matches Operator
+
+A new operator `matches` has been implemented to allow checking a value against
+a regular expression or wildcard pattern. For example:
+
+    if "foobar" matches wildcard pattern "*b*" then
+        --
+    end if
+
+    if "foobar" matches regex pattern "^f.*r$" then
+        --
+    end if

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2778,7 +2778,13 @@ enum Exec_errors
     EE_BAD_PERMISSION_NAME,
     
     // {EE-0910} Property: value is not a data
-    EE_PROPERTY_NOTADATA
+    EE_PROPERTY_NOTADATA,
+
+    // {EE-0911} matches: illegal type for right operand
+    EE_MATCHES_BADRIGHT,
+    
+    // {EE-0912} matches: illegal type for left operand
+    EE_MATCHES_BADLEFT,
     
 };
 

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -1214,6 +1214,7 @@ const LT factor_table[] =
         {"maskdata", TT_PROPERTY, P_MASK_DATA},
         {"maskpixmapid", TT_PROPERTY, P_MASK_PIXMAP_ID},
         {"matchchunk", TT_FUNCTION, F_MATCH_CHUNK},
+        {"matches", TT_BINOP, O_MATCHES},
         {"matchtext", TT_FUNCTION, F_MATCH_TEXT},
         {"matrixmultiply", TT_FUNCTION, F_MATRIX_MULTIPLY},
         {"max", TT_FUNCTION, F_MAX},

--- a/engine/src/newobj.cpp
+++ b/engine/src/newobj.cpp
@@ -941,7 +941,9 @@ MCExpression *MCN_new_operator(int2 which)
 		return new MCBeginsWith;
 	case O_ENDS_WITH:
 		return new MCEndsWith;
-	default:
+    case O_MATCHES:
+        return new MCMatches;
+    default:
 		return new MCExpression;
 	}
 }

--- a/engine/src/operator.h
+++ b/engine/src/operator.h
@@ -492,4 +492,13 @@ public:
     virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
 };
 
+class MCMatches : public MCBinaryOperator
+{
+public:
+    virtual Parse_stat parse(MCScriptPoint&, Boolean the);
+    virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
+private:
+    Match_mode m_matchmode;
+};
+
 #endif

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -784,7 +784,8 @@ enum Operators {
     O_OR,
 	O_WRAP,
 	O_BEGINS_WITH,
-	O_ENDS_WITH
+	O_ENDS_WITH,
+    O_MATCHES
 };
 
 // return codes from parsers

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1798,6 +1798,9 @@ enum Parse_errors
     
     // {PE-0584} out of memory
     PE_OUTOFMEMORY,
+
+    // {PE-0585} matches: missing match mode 'regex' or 'wildcard'
+    PE_MATCHES_NOMODE,
 };
 
 extern const char *MCparsingerrors;

--- a/tests/lcs/core/logic/matches.livecodescript
+++ b/tests/lcs/core/logic/matches.livecodescript
@@ -1,0 +1,29 @@
+script "CoreLogicMatches"
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestMatchesWildcard
+	TestAssert "wildcard pattern matches", "foobar" matches wildcard pattern "*b*"
+	TestAssert "wildcard pattern does not match", not ("foobar" matches wildcard pattern "*z*")
+end TestMatchesWildcard
+
+constant kEmailRegex = "^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+
+on TestMatchesRegex
+	TestAssert "regex pattern matches", "support@livecode.com" matches regex pattern kEmailRegex
+	TestAssert "regex pattern does not match", not ("support dot livecode dot com" matches regex pattern kEmailRegex)
+end TestMatchesRegex


### PR DESCRIPTION
This patch implements a new operator `matches` to match a
string to a regex or wildcard pattern.