### PR TITLE
[[ Bug 21464 ]] Implement mobileSetKeyboardReturnType

### DIFF
--- a/docs/dictionary/command/mobileSetKeyboardReturnKey.lcdoc
+++ b/docs/dictionary/command/mobileSetKeyboardReturnKey.lcdoc
@@ -1,23 +1,27 @@
-Name: iphoneSetKeyboardReturnKey
+Name: mobileSetKeyboardReturnKey
+
+Synonyms: iphoneSetKeyboardReturnKey
 
 Type: command
 
-Syntax: iphoneSetKeyboardReturnKey <returnKey>
+Syntax: mobileSetKeyboardReturnKey <returnKey>
 
 Summary:
 Configures the type of return key displayed on the keyboard.
 
 Introduced: 4.5.3
 
-OS: ios
+Changes: LiveCode 9.5 added support for android
+
+OS: ios, android
 
 Platforms: mobile
 
 Example:
-iphoneSetKeyboardReturnKey "alphabet"
+mobileSetKeyboardReturnKey "alphabet"
 
 Example:
-iphoneSetKeyboardReturnKey "numeric"
+mobileSetKeyboardReturnKey "numeric"
 
 Parameters:
 returnKey (enum):
@@ -25,22 +29,22 @@ Specifies what the return key function is.
 
 -   default: the normal return key
 -   go: the 'Go' return key
--   google: the 'Google' return key
--   join: the 'Join' return key
+-   google: the 'Google' return key (iOS only)
+-   join: the 'Join' return key (iOS only)
 -   next: the 'Next' return key
--   route: the 'Route' return key
+-   route: the 'Route' return key (iOS only)
 -   search: the 'Search' return key
 -   send: the 'Send' return key
--   yahoo: the 'Yahoo' return key
+-   yahoo: the 'Yahoo' return key (iOS only)
 -   done: the 'Done' return key
--   emergency call: the 'emergency call' return key
+-   emergency call: the 'emergency call' return key (iOS only)
 
 
 Description:
-Use the iphoneSetKeyboardReturnKey command to configure the type of
+Use the mobileSetKeyboardReturnKey command to configure the type of
 return key displayed on the keyboard.
 
-The <iphoneSetKeyboardReturnKey> command configures the type of return
+The <mobileSetKeyboardReturnKey> command configures the type of return
 key displayed on the keyboard
 
 The return key type setting takes effect the next time the keyboard is

--- a/docs/dictionary/command/mobileSetKeyboardType.lcdoc
+++ b/docs/dictionary/command/mobileSetKeyboardType.lcdoc
@@ -44,6 +44,6 @@ The keyboard type setting takes affect the next time the keyboard is
 shown. It does not affect the current keyboard, if it is being
 displayed. 
 
-References: iphoneSetKeyboardReturnKey (command),
+References: mobileSetKeyboardReturnKey (command),
 keyboardDeactivated (message), keyboardActivated (message)
 

--- a/docs/dictionary/message/keyboardActivated.lcdoc
+++ b/docs/dictionary/message/keyboardActivated.lcdoc
@@ -25,6 +25,6 @@ display layout to take account of the restricted screen area that is
 available. 
 
 References: mobileSetKeyboardType (command),
-iphoneSetKeyboardReturnKey (command), current card (glossary),
+mobileSetKeyboardReturnKey (command), current card (glossary),
 keyboardDeactivated (message)
 

--- a/docs/dictionary/message/keyboardDeactivated.lcdoc
+++ b/docs/dictionary/message/keyboardDeactivated.lcdoc
@@ -25,6 +25,6 @@ display layout to take account of the restricted screen area that
 becomes available when the keyboard is hidden.
 
 References: mobileSetKeyboardType (command),
-iphoneSetKeyboardReturnKey (command), current card (glossary),
+mobileSetKeyboardReturnKey (command), current card (glossary),
 keyboardActivated (message)
 

--- a/docs/notes/bugfix-21464.md
+++ b/docs/notes/bugfix-21464.md
@@ -1,0 +1,4 @@
+# mobileSetKeyboardReturnKey on android
+
+The mobileSetKeyboardReturnKey is now supported on android and the iphoneSetKeyboardReturnKey
+synonym is now deprecated

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -113,6 +113,8 @@ public class Engine extends View implements EngineApi
 	private boolean m_text_editor_visible;
 	private int m_text_editor_mode;
 
+    private int m_default_ime_action;
+    
     private SensorModule m_sensor_module;
     private DialogModule m_dialog_module;
     private NetworkModule m_network_module;
@@ -165,6 +167,8 @@ public class Engine extends View implements EngineApi
 		m_text_editor_mode = 1;
 		m_text_editor_visible = false;
 
+        m_default_ime_action = EditorInfo.IME_FLAG_NO_ENTER_ACTION | EditorInfo.IME_ACTION_DONE;
+        
         // initialise modules
         m_sensor_module = new SensorModule(this);
         m_dialog_module = new DialogModule(this);
@@ -583,13 +587,19 @@ public class Engine extends View implements EngineApi
 				updateComposingText(text);
 				return super.setComposingText(text, newCursorPosition);
 			}
+            @Override
+            public boolean performEditorAction (int editorAction)
+            {
+                handleKey(0, 10);
+                return true;
+            }
         };
         
 		int t_type = getInputType(false);
 		
         outAttrs.actionLabel = null;
 		outAttrs.inputType = t_type;
-        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI | EditorInfo.IME_FLAG_NO_ENTER_ACTION | EditorInfo.IME_ACTION_DONE;
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI | m_default_ime_action;
         
         return t_connection;
     }
@@ -643,6 +653,11 @@ public class Engine extends View implements EngineApi
 		else
 			hideKeyboard();
 	}
+    
+    public void setKeyboardReturnKey(int p_ime_action)
+    {
+        m_default_ime_action = p_ime_action;
+    }
 	
 	public void setTextInputMode(int p_mode)
 	{

--- a/engine/src/mblandroidmisc.cpp
+++ b/engine/src/mblandroidmisc.cpp
@@ -702,9 +702,33 @@ bool MCSystemGetReachabilityTarget(MCStringRef& r_target)
     return false;
 }
 
+static int32_t MCMiscGetAndroidReturnKeyTypeFromMCExecEnum(MCMiscKeyboardReturnKey p_type)
+{
+    switch(p_type)
+    {
+        case kMCMiscKeyboardReturnKeyGo:
+            return 0x2; // IME_ACTION_GO
+        case kMCMiscKeyboardReturnKeyNext:
+            return 0x5; // IME_ACTION_NEXT
+        case kMCMiscKeyboardReturnKeySearch:
+            return 0x3; // IME_ACTION_SEARCH
+        case kMCMiscKeyboardReturnKeySend:
+            return 0x4; // IME_ACTION_SEND
+        case kMCMiscKeyboardReturnKeyDone:
+            return 0x6; // IME_ACTION_DONE
+        case kMCMiscKeyboardReturnKeyDefault:
+            return 0x40000000 | 0x6; // IME_FLAG_NO_ENTER_ACTION | IME_ACTION_DONE
+        default:
+            return 0x0; // IME_ACTION_UNSPECIFIED
+    }
+}
+
 bool MCSystemSetKeyboardReturnKey(intenum_t p_type)
 {
-    return false;
+    int32_t t_type = MCMiscGetAndroidReturnKeyTypeFromMCExecEnum(static_cast<MCMiscKeyboardReturnKey>(p_type));
+    MCAndroidEngineRemoteCall("setKeyboardReturnKey", "vi", nullptr, t_type);
+    
+    return true;
 }
 
 // SN-2014-12-18: [[ Bug 13860 ]] Parameter added in case it's a filename, not raw data, in the DataRef


### PR DESCRIPTION
This patch implements `mobileSetKeyboardReturnType` for android and documents
`iphoneSetKeyboardReturnType` as a synonym.