### PR TITLE
[21500] Fix crash when moving a group before calling quit

### DIFF
--- a/docs/notes/bugfix-21500.md
+++ b/docs/notes/bugfix-21500.md
@@ -1,1 +1,1 @@
-# Fix crash when moving a group before calling quit
+# Fix crash when ungrouping a group before calling quit

--- a/docs/notes/bugfix-21500.md
+++ b/docs/notes/bugfix-21500.md
@@ -1,0 +1,1 @@
+# Fix crash when moving a group before calling quit

--- a/engine/src/globals.cpp
+++ b/engine/src/globals.cpp
@@ -1342,6 +1342,7 @@ int X_close(void)
 	while (MCsavegroupptr != NULL)
 	{
 		MCControl *gptr = MCsavegroupptr->remove(MCsavegroupptr);
+        gptr -> removereferences();
 		delete gptr;
 	}
 

--- a/tests/lcs/core/engine/_ungroupandquit.livecodescript
+++ b/tests/lcs/core/engine/_ungroupandquit.livecodescript
@@ -1,0 +1,8 @@
+script "_ungroupandquit"
+on startup
+    create button "one"
+    create button "two"
+    group button "one" and button "two"
+    ungroup the last group
+    quit 0
+end startup

--- a/tests/lcs/core/engine/engine.livecodescript
+++ b/tests/lcs/core/engine/engine.livecodescript
@@ -501,3 +501,19 @@ wait 2 ticks
 TestAssert "the ticks change with time", the ticks - tTime >= 2
 end TestTicks
 
+on TestUngroupAndQuit
+    -- Bug 21500: run a subprocess in which we ungroup a group and
+    -- then quit, to test that it no longer crashes
+   local tStackToRun, tOptions
+   put the effective filename of me into tStackToRun
+   set the itemdelimiter to slash
+   if the environment is not "server" then
+      put "_ungroupandquit.livecodescript" into item -1 of tStackToRun
+      if the environment contains "command line" then
+         put "-ui" into tOptions
+      end if
+   end if
+   TestRunStack tOptions, tStackToRun
+   TestAssert "ungroup does not crash on quit", the result is empty
+end TestUngroupAndQuit
+


### PR DESCRIPTION
This patch fixes an assertion failure in `MCObject::~MCObject()` (`MCAssert(!m_in_id_cache);`) when dragging a group before calling `quit`