### PR TITLE
[[ Bug 20193 ]] Retain mouse focus when taking snapshot

### DIFF
--- a/docs/notes/bugfix-20193.md
+++ b/docs/notes/bugfix-20193.md
@@ -1,0 +1,1 @@
+# Fix import snapshot from rect causing other applications to lose focus on Windows

--- a/engine/src/w32dcs.cpp
+++ b/engine/src/w32dcs.cpp
@@ -880,7 +880,14 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle &r, uint4 window, MCStringRef di
 	MCRectangle t_device_viewport;
 	t_device_viewport = logicaltoscreenrect(t_virtual_viewport);
 
-	HWND hwndsnap = CreateWindowExA(WS_EX_TRANSPARENT | WS_EX_TOPMOST,
+	DWORD t_ex_options = WS_EX_TRANSPARENT | WS_EX_TOPMOST;
+	// use layered if we don't need to select the snapshot area via cursor
+	if (window != 0 || r.x != -32768)
+	{
+		t_ex_options |= WS_EX_LAYERED;
+	}
+
+	HWND hwndsnap = CreateWindowExA(t_ex_options,
 	                               MC_SNAPSHOT_WIN_CLASS_NAME,"", WS_POPUP, t_device_viewport . x, t_device_viewport . y,
 	                               t_device_viewport . width, t_device_viewport . height, invisiblehwnd,
 	                               NULL, MChInst, NULL);


### PR DESCRIPTION
This patch changes the snapshot implementation on windows to use a
`WS_EX_LAYERED` style window so as not to interrupt the mouse focus.