### PR TITLE
[[ Bug 20027 ]] Ensure UQL is cleard when setting container value

### DIFF
--- a/docs/notes/bugfix-20027.md
+++ b/docs/notes/bugfix-20027.md
@@ -1,0 +1,1 @@
+# Fix value assignment to undeclared variable in matchText

--- a/engine/src/variable.cpp
+++ b/engine/src/variable.cpp
@@ -1104,7 +1104,8 @@ bool MCContainer::remove(MCExecContext& ctxt)
 
 bool MCContainer::set_valueref(MCValueRef p_value)
 {
-	return m_variable -> setvalueref(getpath(), false, p_value);
+    m_variable -> clearuql();
+    return m_variable -> setvalueref(getpath(), false, p_value);
 }
 
 MCValueRef MCContainer::get_valueref()

--- a/tests/lcs/core/execution/uql.livecodescript
+++ b/tests/lcs/core/execution/uql.livecodescript
@@ -1,0 +1,50 @@
+﻿script "CoreExecutionUQL"
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestUQLPut
+	put "foo" into tTest1
+	TestAssert "unquoted literal put into", tTest1 is "foo"
+	put "foo" after tTest2
+	TestAssert "unquoted literal put after", tTest2 is "foo"
+	put "foo" before tTest3
+	TestAssert "unquoted literal put before", tTest3 is "foo"
+end TestUQLPut
+
+on TestUQLValue
+	TestAssert "unquoted literal value", tTest1 is "tTest1"	
+end TestUQLValue
+
+on TestUQLMatchText
+	put "rangeInt={0,3}" into tVar
+	get matchText(tVar,"(.*?)={(.*?)}", tOption, tValue)
+	TestAssert "matchText assigns correct values to UQL", \
+			tOption is "rangeInt" and tValue is "0,3"
+end TestUQLMatchText
+
+on TestUQLBinaryDecode
+	get binaryDecode("h*",sha1Digest("foobar"), tFoobar)
+	TestAssert "binaryDecode assigns correct values to UQL", \
+			tFoobar is "88347d9f426112d19ebe9b36ffc42e1852398287"
+end TestUQLBinaryDecode
+
+on TestUQLQueryRegistry
+	TestSkipIfNot "platform", "win32"
+	get queryRegistry("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ProgramFilesDir", tType)
+	TestAssert "queryRegistry assigns correct values to UQL", \
+			tType is "string"
+end TestUQLQueryRegistry


### PR DESCRIPTION
This patch ensures that undeclared variables are cleared of their UQL
status when their value is set via `MCContainer::set_valueref`.