### PR TITLE
[Bugfix 21494] Correct missing text issue in Round entry

### DIFF
--- a/docs/dictionary/function/round.lcdoc
+++ b/docs/dictionary/function/round.lcdoc
@@ -47,12 +47,12 @@ the <number> up if positive, down if <negative>. (To round off numbers
 without introducing any statistical upward bias, use the <statRound>
 <function> instead.)
 
-A positive <precision> indicates a place to the right of the <decimal
-point>, and a <negative> <precision> indicates a place to the left. For
-example, 1 rounds off to the nearest tenth, 2 rounds off to the nearest
-hundredth, -1 rounds off by ten, and so on. If you don't specify a
-<precision>, zero is used, meaning that the <number> is rounded off to a
-whole number.
+A positive <precision> indicates a place to the right of the 
+<decimal point>, and a <negative> <precision> indicates a place to the 
+left. For example, 1 rounds off to the nearest tenth, 2 rounds off to 
+the nearest hundredth, -1 rounds off by ten, and so on. If you don't 
+specify a <precision>, zero is used, meaning that the <number> is 
+rounded off to a whole number.
 
 >*Note:* The <statRound> <function> is equivalent to
 > <HyperCard|HyperTalk's> "round" <function>.

--- a/docs/notes/bugfix-21494.md
+++ b/docs/notes/bugfix-21494.md
@@ -1,0 +1,1 @@
+# Correct missing text issue in the ROund function dictionary entry.

--- a/docs/notes/bugfix-21494.md
+++ b/docs/notes/bugfix-21494.md
@@ -1,1 +1,1 @@
-# Correct missing text issue in the ROund function dictionary entry.
+# Correct missing text issue in the Round function dictionary entry.


### PR DESCRIPTION
Fixed a link to another entry that was written across two lines, preventing it from displaying correctly.