### PR TITLE
[[ Bug 21527 ]] Include iPadPro splash image in plist file

### DIFF
--- a/docs/notes/bugfix-21527.md
+++ b/docs/notes/bugfix-21527.md
@@ -1,0 +1,1 @@
+# Include iPadPro splash image in plist file

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1707,9 +1707,11 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    if 2 is among the items of tDeviceFamily then      
       if tIPadOrientations contains "Portrait" then
          put "Default-Portrait|Default-Portrait|{768, 1024}|Portrait" & return after tSplashScreens
+         put "Default-iPadProPortrait|Default-iPadProPortrait|{1024, 1366}|Portrait" & return after tSplashScreens
       end if
       if tIPadOrientations contains "Landscape" then
          put "Default-Landscape|Default-Landscape|{768, 1024}|Landscape" & return after tSplashScreens
+         put "Default-iPadProLandscape|Default-iPadProLandscape|{1024, 1366}|Landscape" & return after tSplashScreens
       end if
    end if
    


### PR DESCRIPTION
Adjusted `revCreateMobilePlist` handler to include the iPadPro splash
images in the plist file so that they are recognized by the device.