### PR TITLE
[[ Bug 21295 ]] Fix synonym handling of widget properties

### DIFF
--- a/docs/notes/bugfix-21295.md
+++ b/docs/notes/bugfix-21295.md
@@ -1,0 +1,1 @@
+# Fix synonym handling of widget properties

--- a/tests/lcs/core/engine/_widget.lcb
+++ b/tests/lcs/core/engine/_widget.lcb
@@ -4,6 +4,9 @@ private variable mTestMode
 
 property testMode get mTestMode set mTestMode
 
+private variable mAutoHilite
+property autoHilite get mAutoHilite set mAutoHilite
+
 public handler OnSave(out rProperties as Array)
    if mTestMode is "resolve" then
       resolve script object "this stack"

--- a/tests/lcs/core/engine/widget.livecodescript
+++ b/tests/lcs/core/engine/widget.livecodescript
@@ -54,6 +54,7 @@ end TestWidgetBindErrorsDontEscape
 private command _DoTestWidgetScriptObjectAccess pMode
    set the testMode of widget "Test" to pMode
 
+   local tVar
    export widget "Test" to array tVar
 
    TestAssertErrorDialog "no script access allowed for" && pMode, \ 
@@ -115,3 +116,29 @@ on TestWidgetRetainRep
    delete stack "WidgetRetainRepTest"
    delete file tPath
 end TestWidgetRetainRep
+
+on TestWidgetEnginePropertyName
+   create stack "WidgetEnginePropertyNameTest"
+   set the defaultStack to "WidgetEnginePropertyNameTest"
+   
+   create widget "Test" as "com.livecode.lcs_tests.core.widget"
+
+   local tWidget
+   put it into tWidget
+
+   set the autoHilite of tWidget to "test"
+   TestAssert "engine property name round trip", the autoHilite of tWidget is "test"
+
+   TestAssert "engine property is not renamed to first alpha", \
+         "autoHilight" is not among the lines of the customKeys of tWidget
+
+   TestAssertThrow "engine property not implemented throws", \
+         "__TestEnginePropertyNameNotFound", \
+         the long id of me, \
+         "EE_OBJECT_SETNOPROP"
+end TestWidgetEnginePropertyName
+
+on __TestEnginePropertyNameNotFound
+   set the radioBehavior of widget "test" of stack "WidgetEnginePropertyNameTest" to true
+end __TestEnginePropertyNameNotFound
+


### PR DESCRIPTION
This patch fixes synonym handling by finding the property name that the
widget is using rather than the first property name for a particular
property. The patch also handles unimplemented engine properties as an
error as with legacy objects.

While setting unimplemented engine properties as a custom property may
be useful it should be consistent for all objects and is not possible
if the only information is the value of the Properties enum as we would
need the name used in the script.