### PR TITLE
[[ Library ]] Try extension when loading module

### DIFF
--- a/libfoundation/src/system-library-emscripten.hpp
+++ b/libfoundation/src/system-library-emscripten.hpp
@@ -58,7 +58,7 @@ public:
         return MCHashPointer(nullptr);
     }
     
-    bool CreateWithNativePath(MCStringRef p_native_path)
+    bool CreateWithNativePath(MCStringRef p_native_path, bool p_has_extension)
     {
         return false;
     }

--- a/libfoundation/src/system-library-ios.hpp
+++ b/libfoundation/src/system-library-ios.hpp
@@ -130,7 +130,7 @@ public:
         return hash_t();
     }
     
-    bool CreateWithNativePath(MCStringRef p_native_path)
+    bool CreateWithNativePath(MCStringRef p_native_path, bool p_has_extension)
     {
         MCAssert(m_type == kNone);
         if (m_static.CreateWithNativePath(p_native_path))

--- a/libfoundation/src/system-library-static.hpp
+++ b/libfoundation/src/system-library-static.hpp
@@ -52,7 +52,7 @@ public:
         return MCHashPointer(m_handle);
     }
     
-    bool CreateWithNativePath(MCStringRef p_native_path)
+    bool CreateWithNativePath(MCStringRef p_native_path, bool p_has_extension)
     {
         for(MCSLibraryStaticInfo *t_info = s_chain;
             t_info != nullptr;
@@ -161,7 +161,7 @@ class __MCSLibraryHandleStatic
         return MCHashPointer(m_handle);
     }
     
-    bool CreateWithNativePath(MCStringRef p_native_path)
+    bool CreateWithNativePath(MCStringRef p_native_path, bool p_has_extension)
     {
         // First process the native path to remove the engine folder prefix
         // and extension - all static libs are compiled in with just the

--- a/libfoundation/src/system-library.cpp
+++ b/libfoundation/src/system-library.cpp
@@ -82,7 +82,26 @@ public:
     bool CreateWithNativePath(MCStringRef p_native_path)
     {
         MCAssert(!IsDefined());
-        return m_handle.CreateWithNativePath(p_native_path);
+        
+        uindex_t t_sep;
+        if (!MCStringLastIndexOfChar(p_native_path,
+                                     '/',
+                                     UINDEX_MAX,
+                                     kMCStringOptionCompareExact,
+                                     t_sep))
+        {
+            t_sep = 0;
+        }
+        
+        uindex_t t_ext;
+        bool t_has_extension =
+                    MCStringFirstIndexOfChar(p_native_path,
+                                        '.',
+                                        t_sep,
+                                        kMCStringOptionCompareExact,
+                                        t_ext);
+        
+        return m_handle.CreateWithNativePath(p_native_path, t_has_extension);
     }
     
     bool CreateWithAddress(void *p_address)

--- a/tests/lcb/vm/interop-objc.lcb
+++ b/tests/lcb/vm/interop-objc.lcb
@@ -558,4 +558,16 @@ public handler TestDelegateRequiredMethod()
                                 "Creating delegate throws error when required protocol method is not mapped")
 end handler
 
+foreign handler AVURLAssetAlloc() returns ObjcRetainedId \
+	binds to "objc:AVFoundation>AVURLAsset.+alloc"
+
+public handler TestBindingToFrameworkWithoutExtension()
+	if not the operating system is in ["mac", "ios"] then
+		skip test "objc framework loads without .framework extension" \
+			because "not implemented on" && the operating system
+		return
+	end if
+	test "objc framework loads without .framework extension" when AVURLAssetAlloc is not nothing
+end handler
+
 end module


### PR DESCRIPTION
This patch moves the extension append and try code from `MCU_library_load` into
the `CreateWithNativePath` implementaton of each `__MCSLibraryHandle` to allow
binding strings to be cross platfor.