### PR TITLE
[[ Bug 21532 ]] Move clear before creation of clipboard item

### DIFF
--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -254,6 +254,10 @@ bool MCClipboard::AddText(MCStringRef p_string)
 
     AutoLock t_lock(this);
     
+    // Clear contents if the clipboard contains external data
+    if (m_clipboard->IsExternalData())
+        Clear();
+    
     // Clear contents to ensure that the clipboard does not end up
     // containing data from different copy events.
     // i.e. the HTML/RTF representation would be left untouched
@@ -273,10 +277,6 @@ bool MCClipboard::AddText(MCStringRef p_string)
 bool MCClipboard::AddTextToItem(MCRawClipboardItem* p_item, MCStringRef p_string)
 {
     AutoLock t_lock(this);
-    
-    // Clear contents if the clipboard contains external data
-    if (m_clipboard->IsExternalData())
-        Clear();
     
     // For each text encoding that the underlying clipboard supports, encode the
     // text and add it.


### PR DESCRIPTION
This patch moves the call to clear the raw clipboard if it has external
data to before the creation of a new item so that any references to the
new item are not cleared from the clipboard.