### PR TITLE
[[ Bug 21532 ]] Remove AutoLock from AddTextToItem

### DIFF
--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -276,8 +276,6 @@ bool MCClipboard::AddText(MCStringRef p_string)
 
 bool MCClipboard::AddTextToItem(MCRawClipboardItem* p_item, MCStringRef p_string)
 {
-    AutoLock t_lock(this);
-    
     // For each text encoding that the underlying clipboard supports, encode the
     // text and add it.
     bool t_success = true;


### PR DESCRIPTION
This patch removes the `AutoLock` from `AddTextToItem` so that there
is no pull and push after the item has been created. `AddTextToItem`
is a convenience method that should be called on a locked clipboard
that has any external data cleared.