### PR TITLE
[[ Bug 21567 ]] Tree View Widget hilitedElement execution error

### DIFF
--- a/extensions/widgets/treeview/notes/21567.md
+++ b/extensions/widgets/treeview/notes/21567.md
@@ -1,0 +1,1 @@
+# [21567] Prevent error when hilitedElement set to empty

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -83,7 +83,7 @@ use com.livecode.library.widgetutils
 use com.livecode.foreign
 
 metadata author is "LiveCode"
-metadata version is "2.0.2"
+metadata version is "2.0.3"
 metadata title is "Tree View"
 metadata svgicon is "M152.4,249.7c-6.4,0-11.8,4.3-13.5,10.1h-10v-26.7h10c1.7,5.8,7.1,10.1,13.5,10.1c7.8,0,14.1-6.3,14.1-14.1s-6.3-14.1-14.1-14.1c-6.4,0-11.8,4.3-13.5,10.1h-10v-16.1c8.4-1.8,14.8-9.3,14.8-18.3c0-10.4-8.4-18.8-18.8-18.8s-18.8,8.4-18.8,18.8c0,9,6.3,16.5,14.7,18.3v58.8h18c1.7,5.8,7.1,10.1,13.5,10.1c7.8,0,14.1-6.3,14.1-14.1S160.2,249.7,152.4,249.7z M128.7,202h-7.5v-7.5h-7.5V187h7.5v-7.5h7.5v7.5h7.5v7.5h-7.5V202z"
 metadata _ide is "true"
@@ -117,8 +117,9 @@ Description:
 <pPath> is a list of the keys which determine the row to be selected. For example, if tArray is the arrayData
 of the widget, to select a row corresponding to tArray["key1"]["subkey2"]["subsubkey5"], simply execute
 
-
 ``` set the hilitedElement of widget "Array Viewer" to "key1,subkey2,subsubkey5" ```
+
+Setting to an invalid path or to `empty` will unselect the currently selected row.
 **/
 
 property hilitedElement			get getSelectedElement			set setSelectedElement
@@ -1610,15 +1611,21 @@ end handler
 
 // Select the key at the target path
 private handler selectPath(in pPath as List)
+	variable tSelectedElement as optional List
+	put mSelectedElement into tSelectedElement
+
 	// Unselect the existing selection if applicable
 	if mSelectedElement is not nothing and mSelectedElement is not pPath then
 		applyToNode(unselectKey, mSelectedElement, 0, 1, mDataList, mData)
 	end if
 
-	if mSelectedElement is nothing or mSelectedElement is not pPath then
+	if (mSelectedElement is nothing or mSelectedElement is not pPath) \
+			and pPath is not the empty list then
 		if not applyToNode(selectKey, pPath, 0, 1, mDataList, mData) then
 			put nothing into mSelectedElement
 		end if	
+	end if
+	if mSelectedElement is not tSelectedElement then
 		post "hiliteChanged"
 		redraw all
 	end if
@@ -1641,7 +1648,7 @@ end handler
 private handler applyToNode(in pHandler as NodeApply, in pPathToNode as List, in pLevel as Integer, in pStart as Integer, inout xList as List, inout xArray as Array) returns Boolean	
 	if pStart >= the number of elements in xList then
 		return false
-	end if	
+	end if
 
 	variable tKey as String
 	put element pLevel + 1 of pPathToNode into tKey


### PR DESCRIPTION
The following command would generate an error:
`set the hilitedElement of widget 1 to empty`

Input validation was not being performed to handle an empty input.  Fix ensures that the path is not empty before attempting to select a key.  Additionally, adjusted the code to remove an extra hiliteChanged message/redraw all in the situation where nothing was selected and an empty or invalid path was passed as input.

Added a comment to the dictionary entry indicating how to unselect a row.