### PR TITLE
[Bugfix-21556] Fix broken link in libraryStack entry

### DIFF
--- a/docs/dictionary/message/libraryStack.lcdoc
+++ b/docs/dictionary/message/libraryStack.lcdoc
@@ -5,8 +5,8 @@ Type: message
 Syntax: libraryStack
 
 Summary:
-Sent to a <stack> when it is placed in the <message path> by the <start
-using> <command>.
+Sent to a <stack> when it is placed in the <message path> by the 
+<start using> <command>.
 
 Associations: stack
 

--- a/docs/notes/bugfix-21556.md
+++ b/docs/notes/bugfix-21556.md
@@ -1,0 +1,1 @@
+# Fixed missing text issue in the libraryStack dictionary entry


### PR DESCRIPTION
Placed a link to `start using` on a single line in order to have it display correctly.