### PR TITLE
[Bugfix 18359] Add note about non-numeric x-values for hilitedCoordinates

### DIFF
--- a/docs/notes/bugfix-18359.md
+++ b/docs/notes/bugfix-18359.md
@@ -1,0 +1,1 @@
+# Added note to hiliteCoordinates about non-numeric x-values.

--- a/extensions/widgets/graph/graph.lcb
+++ b/extensions/widgets/graph/graph.lcb
@@ -246,7 +246,7 @@ widget will highlight the specified coordinates with a dot and dashed
 horizontal and vertical lines.
 
 >*Note:* If the x-axis values in the graph data are non-numeric,
->then the x-value of the point set must mathc one of those values.
+>then the x-value of the point set must match one of those values.
 
 Related: hilitedCoordinatesColor (property)
 */

--- a/extensions/widgets/graph/graph.lcb
+++ b/extensions/widgets/graph/graph.lcb
@@ -245,6 +245,9 @@ If the <hilitedCoordinates> of the graph widget is not empty, then the
 widget will highlight the specified coordinates with a dot and dashed
 horizontal and vertical lines.
 
+>*Note:* If the x-axis values in the graph data are non-numeric,
+>then the x-value of the point set must mathc one of those values.
+
 Related: hilitedCoordinatesColor (property)
 */
 property hilitedCoordinates get GetHilitedCoordinates set SetHilitedCoordinates


### PR DESCRIPTION
Added note to explain that when setting a point for a graph whose x-values are non-numeric, the x-value for that point must be one used in the graph data.


Note: The above doesn't hold true for y values; non-numeric y values are not accepted and they are immediately changed to 0.