### PR TITLE
[Bugfix-21406] Add missing keyboard types to mobileSetKeyboardType

### DIFF
--- a/docs/dictionary/command/mobileSetKeyboardType.lcdoc
+++ b/docs/dictionary/command/mobileSetKeyboardType.lcdoc
@@ -25,7 +25,8 @@ Parameters:
 type (enum):
 The type of keyboard to use. One of:
 
--   "default": the alphabetic keyboard
+-   "default": the default keyboard
+-   "alphabet": the alphabetic keyboard
 -   "numeric": the numeric keyboard with punctuation
 -   "url": the url entry keyboard (iOS only)
 -   "number": the number pad keyboard

--- a/docs/dictionary/command/mobileSetKeyboardType.lcdoc
+++ b/docs/dictionary/command/mobileSetKeyboardType.lcdoc
@@ -16,7 +16,7 @@ OS: ios, android
 Platforms: mobile
 
 Example:
-mobileSetKeyboardType "default"
+mobileSetKeyboardType "alphabet"
 
 Example:
 mobileSetKeyboardType "numeric"
@@ -25,13 +25,15 @@ Parameters:
 type (enum):
 The type of keyboard to use. One of:
 
--   "default": the alphabetic keyboard
+-   "default": the default keyboard
+-   "alphabet": the alphabetic keyboard
 -   "numeric": the numeric keyboard with punctuation
 -   "url": the url entry keyboard (iOS only)
 -   "number": the number pad keyboard
 -   "phone": the phone number pad keyboard
 -   "contact": the phone contact pad keyboard (iOS only)
 -   "email": the email keyboard
+-   "decimal": the decimal numeric pad keyboard
 
 
 Description:

--- a/docs/dictionary/command/mobileSetKeyboardType.lcdoc
+++ b/docs/dictionary/command/mobileSetKeyboardType.lcdoc
@@ -16,7 +16,7 @@ OS: ios, android
 Platforms: mobile
 
 Example:
-mobileSetKeyboardType "alphabet"
+mobileSetKeyboardType "default"
 
 Example:
 mobileSetKeyboardType "numeric"
@@ -25,8 +25,7 @@ Parameters:
 type (enum):
 The type of keyboard to use. One of:
 
--   "default": the default keyboard
--   "alphabet": the alphabetic keyboard
+-   "default": the alphabetic keyboard
 -   "numeric": the numeric keyboard with punctuation
 -   "url": the url entry keyboard (iOS only)
 -   "number": the number pad keyboard

--- a/docs/notes/bugfix-21406.md
+++ b/docs/notes/bugfix-21406.md
@@ -1,0 +1,2 @@
+# Added `alphabetic` to the list of keyboard types in the mobileSetKeyboardType entry
+


### PR DESCRIPTION
Added `decimal` and `alphabet` to the mobileSetKeyboardType dictionary entry