### PR TITLE
[[ Bug 19670 ]] Fix effective working screenrect on Android

### DIFF
--- a/docs/notes/bugfix-19670.md
+++ b/docs/notes/bugfix-19670.md
@@ -1,0 +1,1 @@
+# Fix effective working screenrect on Android when status bar is hidden

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -1218,8 +1218,8 @@ public class Engine extends View implements EngineApi
 	private Rect getEffectiveWorkarea()
 	{
 		Rect t_workrect = new Rect();
-		getGlobalVisibleRect(t_workrect);
-		return t_workrect;
+        getWindowVisibleDisplayFrame(t_workrect);
+        return t_workrect;
 	}
 
 	public String getEffectiveWorkareaAsString()


### PR DESCRIPTION
This patch fixes the effective working screenrect on Android when
the status bar is hidden. Previously to determine the area not covered
by screen decorations we used `getGlobalVisibleRect`, however this only
took clipping into account and in some cases decorations do not clip the
view.

This patch uses `getWindowVisibleDisplayFrame` which is documented to tell
`you the available area where content can be placed and remain visible to
users.`