### PR TITLE
[[ BUILD ]] Disable PIE when linking executables on Linux

### DIFF
--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -39,6 +39,15 @@
 			},
 		],
 		[
+			'_type == "executable"',
+			{
+				'ldflags':
+				[
+					'-no-pie',
+				],
+			},
+		],
+		[
 			'server_mode == 0',
 			{
 				'defines':


### PR DESCRIPTION
This option is enabled by default when building on Ubuntu 18.04LTS,
which causes problems when linking against libraries built without PIE
support.