### PR TITLE
 [Bugfix-21592] Correct typos in revOpenDatabase

### DIFF
--- a/docs/dictionary/function/revOpenDatabase.lcdoc
+++ b/docs/dictionary/function/revOpenDatabase.lcdoc
@@ -114,7 +114,7 @@ cursorType (enum):
 
 
 sqliteOptions (enum):
-A comma delimited list contain one or me of the following (Note that the
+A comma-delimited list containing one or more items listed below (Note 
 order of the items in the options parameter is not important):
 
 -   "extensions": Enable loadable extensions for the connection.

--- a/docs/notes/Bugfix-21592.md
+++ b/docs/notes/Bugfix-21592.md
@@ -1,0 +1,1 @@
+# Corrected several typos in the revOpenDatabase dictionary entry.


### PR DESCRIPTION
Corrected several typos found in the description of the sqliteOptions parameter in the revOpenDatabase entry.