### PR TITLE
[Bugfix-11792] Add note in docs about copying objects on mobile

### DIFF
--- a/docs/dictionary/command/copy.lcdoc
+++ b/docs/dictionary/command/copy.lcdoc
@@ -69,6 +69,9 @@ the <clipboard> (including text styles).
 > crosses <line> boundaries, the <copy> <command> copies the entire
 > <line> or <line|lines> containing the <chunk>.
 
+>*Note:* Copy operations that result in an object being placed on the 
+> clipboard are not supported on mobile devices.
+
 References: select (command), doMenu (command), undo (command),
 cut (command), paste (command), clone (command), group (command),
 place (command), clipboard (function), copyResource (function),

--- a/docs/notes/bugfix-11792.md
+++ b/docs/notes/bugfix-11792.md
@@ -1,0 +1,1 @@
+# Added note in the documentation for copy that copy operations that result in an object being put on the clipboard are not supported on mobile


### PR DESCRIPTION
Added a note to the copy dictionary entry that copy operations that result in objects being placed on the clipboard are not supported on mobile devices.