### PR TITLE
[[Android Browser]] Allow cross-origin requests for "file:" protocol scheme

### DIFF
--- a/docs/notes/bugfix-21595.md
+++ b/docs/notes/bugfix-21595.md
@@ -1,0 +1,1 @@
+# Android API 26: allow opening local files with JavaScript on Android Browser 

--- a/engine/src/java/com/runrev/android/libraries/LibBrowser.java
+++ b/engine/src/java/com/runrev/android/libraries/LibBrowser.java
@@ -358,6 +358,8 @@ class LibBrowserWebView extends WebView
 		
 		setWebChromeClient(m_chrome_client);
 		getSettings().setJavaScriptEnabled(true);
+        getSettings().setAllowFileAccessFromFileURLs(true);
+        getSettings().setAllowUniversalAccessFromFileURLs(true);
 		getSettings().setGeolocationEnabled(true);
 		getSettings().setDomStorageEnabled(true);
 		getSettings().setPluginState(WebSettings.PluginState.ON);

--- a/engine/src/java/com/runrev/android/nativecontrol/BrowserControl.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/BrowserControl.java
@@ -322,6 +322,8 @@ class BrowserControl extends NativeControl
 		};
 		t_view.setWebChromeClient(m_chrome_client);
         t_view.getSettings().setJavaScriptEnabled(true);
+        t_view.getSettings().setAllowFileAccessFromFileURLs(true);
+        t_view.getSettings().setAllowUniversalAccessFromFileURLs(true);
 		t_view.getSettings().setGeolocationEnabled(true);
 		t_view.getSettings().setDomStorageEnabled(true);
         t_view.getSettings().setPluginState(WebSettings.PluginState.ON);


### PR DESCRIPTION
This is not automatically allowed when targetSdkVersion = 26, so we have to explicitly enable these flags.