### PR TITLE
[Dictionary] newBackground to ODBC manager

### DIFF
--- a/docs/dictionary/function/numToCodepoint.lcdoc
+++ b/docs/dictionary/function/numToCodepoint.lcdoc
@@ -36,9 +36,8 @@ The <numToCodepoint> function takes the numerical identifier of a
 Unicode character and returns its textual form.
 
 Integers in the range 0x000000 to 0x10FFFF can be used to  identify
-Unicode characters. For example, the space character is 0x20 and A is
-
-0x41. 
+Unicode characters. For example, the space character is 0x20 and A 
+is 0x41. 
 
 
 The <numToCodepoint> function raises an exception if the given integer

--- a/docs/dictionary/keyword/ninth.lcdoc
+++ b/docs/dictionary/keyword/ninth.lcdoc
@@ -20,14 +20,14 @@ Example:
 get first item of ninth line of field "Expressions"
 
 Description:
-Use the <ninth> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <ninth> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <ninth> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 9. It can also be used to designate the
 ninth <chunk> in a <chunk expression>.
 
-The word the is optional when using the <ninth> <keyword>.
+The word "the" is optional when using the <ninth> <keyword>.
 
 References: number (function), object (glossary), keyword (glossary),
 property (glossary), object reference (glossary),
@@ -35,4 +35,3 @@ chunk expression (glossary), chunk (glossary), middle (keyword),
 ninth (keyword), last (keyword), number (property)
 
 Tags: math
-

--- a/docs/dictionary/message/newBackground.lcdoc
+++ b/docs/dictionary/message/newBackground.lcdoc
@@ -33,7 +33,7 @@ A <newGroup> <message> is sent before the <newBackground> <message>.
 
 References: copy (command), group (command), pass (control structure),
 object (glossary), trap (glossary), message (glossary),
-HyperCard (glossary), templateGroup (glossary), message path (glossary),
+HyperCard (glossary), message path (glossary), templateGroup (keyword),
 openBackground (message), newGroup (message), newCard (message),
 script (property)
 

--- a/docs/dictionary/message/newCard.lcdoc
+++ b/docs/dictionary/message/newCard.lcdoc
@@ -37,8 +37,8 @@ prevent the <card> from being created.
 
 References: create card (command), paste (command), copy (command),
 clone (command), pass (control structure), object (glossary),
-trap (glossary), message (glossary), templateCard (glossary),
-tool (glossary), message path (glossary), card (keyword),
+trap (glossary), message (glossary), tool (glossary), 
+message path (glossary), card (keyword), templateCard (keyword),
 newBackground (message), script (property)
 
 Tags: objects

--- a/docs/dictionary/message/newField.lcdoc
+++ b/docs/dictionary/message/newField.lcdoc
@@ -42,8 +42,8 @@ prevent the <field> from being created.
 
 References: copy (command), clone (command), paste (command),
 pass (control structure), object (glossary), trap (glossary),
-templateField (glossary), message (glossary), tool (glossary),
-message path (glossary), field (keyword), script (property)
+message (glossary), tool (glossary), message path (glossary), 
+field (keyword), script (property), templateField (keyword)
 
 Tags: objects
 

--- a/docs/dictionary/message/newPlayer.lcdoc
+++ b/docs/dictionary/message/newPlayer.lcdoc
@@ -42,9 +42,9 @@ prevent the <player> from being created.
 
 References: copy (command), clone (command), paste (command),
 pass (control structure), object (glossary), property (glossary),
-templatePlayer (glossary), variable (glossary), message path (glossary),
-message (glossary), tool (glossary), it (glossary), trap (glossary),
-player (keyword), script (property)
+variable (glossary), message path (glossary), message (glossary), 
+tool (glossary), trap (glossary), it (keyword), player (keyword), 
+templatePlayer (keyword), script (property)
 
 Tags: objects
 

--- a/docs/dictionary/message/newScrollbar.lcdoc
+++ b/docs/dictionary/message/newScrollbar.lcdoc
@@ -35,9 +35,8 @@ prevent the <scrollbar> from being created.
 
 References: copy (command), clone (command), paste (command),
 pass (control structure), object (glossary), trap (glossary),
-message (glossary), templateScrollbar (glossary), tool (glossary),
-message path (glossary), templateScrollbar (keyword), scrollbar (keyword),
-script (property)
+message (glossary), tool (glossary), message path (glossary), 
+templateScrollbar (keyword), scrollbar (keyword), script (property)
 
 Tags: objects
 

--- a/docs/dictionary/message/newStack.lcdoc
+++ b/docs/dictionary/message/newStack.lcdoc
@@ -36,8 +36,8 @@ The actual creation is not triggered by the <newStack> <message>, so
 prevent the <stack> from being created.
 
 References: create stack (command), pass (control structure),
-object (glossary), trap (glossary), templateStack (glossary),
-current card (glossary), message (glossary), message path (glossary),
+object (glossary), trap (glossary), current card (glossary), 
+message (glossary), message path (glossary), templateStack (keyword),
 deleteStack (message), stack (object), script (property)
 
 Tags: objects

--- a/docs/dictionary/message/nodeChanged.lcdoc
+++ b/docs/dictionary/message/nodeChanged.lcdoc
@@ -47,7 +47,7 @@ bit builds of LiveCode.
 
 References: QuickTime VR (glossary), message (glossary),
 property (glossary), player (keyword), hotspotClicked (message),
-currentNode (property)
+currentNode (property), dontUseQT (property), dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/property/noncontiguousHilites.lcdoc
+++ b/docs/dictionary/property/noncontiguousHilites.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: set the noncontiguousHilites of <field> to {true | false}
 
 Summary:
-Specifies whether the user can <select> non-adjacent <lines> of a <list
-field>. 
+Specifies whether the user can <select> non-adjacent <lines> of a 
+<list field>. 
 
 Associations: field
 
@@ -51,7 +51,7 @@ References: select (command), property (glossary), Unix (glossary),
 list field (glossary), Windows (glossary), behavior (glossary),
 Mac OS (glossary), field (keyword), lines (keyword), field (object),
 hilitedLine (property), listBehavior (property), toggleHilites (property),
-threeDHilite (property), multipleLines (property)
+threeDHilite (property), multipleHilites (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/number.lcdoc
+++ b/docs/dictionary/property/number.lcdoc
@@ -65,7 +65,7 @@ References: move (command), length (function), object (glossary),
 property (glossary), substack (glossary), main stack (glossary),
 file (keyword), ninth (keyword), seconds (keyword), card (keyword),
 control (keyword), integer (keyword), home (keyword),
-nameChanged (message), control (object), stack (object), card (object),
+nameChanged (message), stack (object), card (object),
 substacks (property), layer (property)
 
 Tags: ui

--- a/docs/glossary/o/ODBC-manager.lcdoc
+++ b/docs/glossary/o/ODBC-manager.lcdoc
@@ -5,8 +5,8 @@ Synonyms: odbc manager
 Type: glossary
 
 Description:
-A utility program that manages <database> connections made via <Open
-Database Connectivity (ODBC)|ODBC>.
+A utility program that manages <database> connections made via 
+<Open Database Connectivity|ODBC>.
 
 Typically, you use an ODBC manager program to create one or more
 <DSN|DSNs> with all the information needed to communicate with a
@@ -14,7 +14,7 @@ Typically, you use an ODBC manager program to create one or more
 <revOpenDatabase> <function> to communicate with that <database>.
 
 References: revOpenDatabase (function), DSN (glossary),
-Open Database Connectivity (ODBC) (glossary), database (glossary),
+Open Database Connectivity (glossary), database (glossary),
 function (glossary)
 
 Tags: database


### PR DESCRIPTION
message/newBackground.lcdoc - Changed type of templateGroup in references to keyword.
message/newCard.lcdoc - Changed type of templateCard in references to keyword.
message/newPlayer.lcdoc - Changed type of it and templatePlayer in references to keyword.
message/newScrollbar.lcdoc - Removed reference to templateScrollbar (glossary); doesn’t exist.
message/newStack.lcdoc - Changed type of templateStack in references to keyword.
keyword/ninth.lcdoc - Fixed broken link.
message/nodeChanged.lcdoc - Added references to dontUseQT and dontUseQTEffects so the reader can see this is what the deprecation note is talking about.
property/noncontiguousHilites.lcdoc - Fixed broken link. Changed `multipleLines` to `multipleHilites`.
property/number.lcdoc - Removed non-existent control (object).
function/numToCodepoint.lcdoc - Removed mid-sentence line breaks.
Glossary/o/ODBC-manager.lcdoc - Removed (ODBC) from references to Open Database Connectivity.