### PR TITLE
[[ Bug ]] Send keyboard messages after effective rect changes

### DIFF
--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -607,8 +607,7 @@ public class Engine extends View implements EngineApi
 		
 		// HH-2017-01-18: [[ Bug 18058 ]] Fix keyboard not show in landscape orientation
         imm.showSoftInput(this, InputMethodManager.SHOW_FORCED);
-		updateKeyboardVisible(true);
-    }
+	}
 
     public void hideKeyboard()
     {
@@ -620,8 +619,7 @@ public class Engine extends View implements EngineApi
 			imm.restartInput(this);
 		
         imm.hideSoftInputFromWindow(getWindowToken(), 0);
-		updateKeyboardVisible(false);
-    }
+	}
 
 	public void resetKeyboard()
 	{
@@ -1422,23 +1420,6 @@ public class Engine extends View implements EngineApi
 	protected void onSizeChanged(int w, int h, int oldw, int oldh)
 	{
 		// Log.i(TAG, "onSizeChanged({" + w + "x" + h + "}, {" + oldw + ", " + oldh + "})");
-		
-		// status bar height
-		int t_status_bar_height = 0;
-		int t_resource_id = getResources().getIdentifier("status_bar_height", "dimen", "android");
-		if (t_resource_id > 0)
-		{
-			t_status_bar_height = getResources().getDimensionPixelSize(t_resource_id);
-		}
-		
-		// display window size for the app layout
-		Rect t_app_rect = new Rect();
-		getActivity().getWindow().getDecorView().getWindowVisibleDisplayFrame(t_app_rect);
-		
-		// keyboard height equals (screen height - (user app height + status))
-		int t_keyboard_height = getContainer().getRootView().getHeight() - (t_app_rect.height() + t_status_bar_height);
-		
-		updateKeyboardVisible(t_keyboard_height > 0);
 		
 		Rect t_rect;
 		t_rect = null;

--- a/engine/src/java/com/runrev/android/LiveCodeActivity.java
+++ b/engine/src/java/com/runrev/android/LiveCodeActivity.java
@@ -24,6 +24,7 @@ import android.content.res.*;
 import android.widget.*;
 import android.util.*;
 import android.content.pm.PackageManager;
+import android.graphics.*;
 
 // This is the main activity exported by the application. This is
 // split into two parts, a customizable sub-class that gets dynamically
@@ -76,6 +77,32 @@ public class LiveCodeActivity extends Activity
         
         // prevent soft keyboard from resizing our view when shown
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        
+        s_main_layout.getRootView().getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener()
+        {
+            @Override
+            public void onGlobalLayout()
+            {
+                // status bar height
+                int t_status_bar_height = 0;
+                int t_resource_id = getResources().getIdentifier("status_bar_height", "dimen", "android");
+                if (t_resource_id > 0)
+                {
+                    t_status_bar_height = getResources().getDimensionPixelSize(t_resource_id);
+                }
+                
+                // display window size for the app layout
+                Rect t_app_rect = new Rect();
+                getWindow().getDecorView().getWindowVisibleDisplayFrame(t_app_rect);
+                
+                int t_screen_height = s_main_layout.getRootView().getHeight();
+                
+                // keyboard height equals (screen height - (user app height + status))
+                int t_keyboard_height = t_screen_height - (t_app_rect.height() + t_status_bar_height);
+                
+                s_main_view.updateKeyboardVisible(t_keyboard_height > 0);
+            }
+        });
 	}
 
 	@Override


### PR DESCRIPTION
This patch ensures that `keyboardActivated` and `keyboardDeactivated` are sent after
the `effective working screenRect` changes so that any scripts requesting that will
have access to the returned values. This bug appears to have been introduced with the
change to building against api 26.