### PR TITLE
[[ Bug 21623 ]] Handle stack scroll in open in window

### DIFF
--- a/docs/notes/bugfix-21623.md
+++ b/docs/notes/bugfix-21623.md
@@ -1,0 +1,1 @@
+# Ensure stack vScroll due to a menubar on Mac is handled correctly when opening a card in an existing window

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -548,7 +548,12 @@ Boolean MCStack::takewindow(MCStack *sptr)
 	flags &= ~(F_TAKE_FLAGS | F_VISIBLE);
 	flags |= sptr->flags & (F_TAKE_FLAGS | F_VISIBLE);
 	decorations = sptr->decorations;
-	rect = sptr->rect;
+    rect = sptr->rect;
+    
+    // sptr has not been closed so may still have a scroll while this stack has been closed
+    // so has had clearscroll called on it so scroll will be 0. applyscroll is called later.
+    rect.height += sptr->getscroll();
+    
 	minwidth = sptr->minwidth;
 	minheight = sptr->minheight;
 	maxwidth = sptr->maxwidth;


### PR DESCRIPTION
This patch ensures that the stack scroll is taken into account when taking
a window from another stack. The stack taking the window is closed and therefore
the scroll is cleared, however, the stack with the target window is not closed
so may have a non-zero `vScroll`. As a result we need to adjust the rect with
the `vScroll` after copying it.