### PR TITLE
[Dictionary] 'of' to 'pageHeights'

### DIFF
--- a/docs/dictionary/command/open-driver.lcdoc
+++ b/docs/dictionary/command/open-driver.lcdoc
@@ -54,23 +54,23 @@ obtain a list of available <peripheral device|devices> by reading the
 file "/dev/tty".
 
 Description:
-Use the <open driver> <command> to communicate with USB <peripheral
-device|devices>, <peripheral device|devices> attached to a serial port
-other than the modem and printer port, and other <peripheral
-device|peripheral devices>.
+Use the <open driver> <command> to communicate with USB 
+<peripheral device|devices>, <peripheral device|devices> 
+attached to a serial port other than the modem and 
+printer port, and other <peripheral device|peripheral devices>.
 
 If you don't specifyormode, the driver is opened in text mode. (For most
 devices, you should use binary mode.)
 
-Use theform to open the driver for reading. If the driver is opened for
+Use the *read* form to open the driver for reading. If the driver is opened for
 reading, you can use the read from driver <command> to get data from the
 <peripheral device|device>, but you can't send data to it.
 
-Use theorm to open the driver for writing. If the driver is opened for
+Use the *write* form to open the driver for writing. If the driver is opened for
 writing, you can use the <write to driver> <command> to send data to the
 <peripheral device|device> but you can't read from it.
 
-Use theform to open the driver for both reading and writing. If the
+Use the *update* form to open the driver for both reading and writing. If the
 driver is opened for update, you can use both the read from driver and
 <write to driver> <command|commands> to send data to the <peripheral
 device|device> or get data from it.
@@ -84,7 +84,8 @@ device|device> or get data from it.
 > <OS X|OS X systems>.
 
 On Windows systems, the <open driver> <command> is equivalent to the
-<open file> <command> when the <driverName> is <COM1:>, <COM2:>, etc.
+<open file> <command> when the <driverName> is <COMn:|COM1:>, 
+<COMn:|COM2:>, etc.
 
 If the device is a serial port, you can set the serialControlString
 <property> to specify the speed, parity, and other settings. Set the
@@ -96,8 +97,8 @@ The <encoding> parameter was introduced in version 7.0
 References: write to driver (command), open file (command),
 function (control structure), property (glossary), Unix (glossary),
 statement (glossary), command (glossary), peripheral device (glossary),
-OS X (glossary), COM1: (keyword), COM2: (keyword),
-serialControlString (property), recordInput (property)
+OS X (glossary), COMn: (keyword), serialControlString (property), 
+recordInput (property)
 
 Tags: networking
 

--- a/docs/dictionary/command/open-file.lcdoc
+++ b/docs/dictionary/command/open-file.lcdoc
@@ -58,8 +58,8 @@ read-only media.
 
 Description:
 Use the <open file> <command> to create a <file(keyword)> or prepare an
-existing <file(keyword)> for use by the <read from file> or <write to
-file> <command|commands>.
+existing <file(keyword)> for use by the <read from file> or 
+<write to file> <command|commands>.
 
 You can optionally specify either text or binary mode. If you specify
 text mode, when you use the write to file <command> to put data in the
@@ -79,7 +79,7 @@ opened for writing, the write to file <command> replaces the
 <file(glossary)|file's> contents from the starting point to the end of
 the file.
 
->*Important:* : Before opening any file for writing, remember to back up
+>*Important:* Before opening any file for writing, remember to back up
 > the file contents as LiveCode will erase them even if you do not write
 > to the file after opening it.
 
@@ -103,10 +103,10 @@ in the <fileType> <property>.
 Any files you have opened are closed automatically when you quit the
 application. 
 
-You can use the <open file> <command> to open a serial <port> on <Mac
-OS> or <Windows|Windows systems>. On <Mac OS|Mac OS systems>, specify
-either "printer:" or "modem:". On Windows systems, specify either
-"COM1:", "COM2:", or up to "COM9:". Set the serialControlString
+You can use the <open file> <command> to open a serial <port> on 
+<Mac OS> or <Windows|Windows systems>. On <Mac OS|Mac OS systems>, 
+specify either "printer:" or "modem:". On Windows systems, specify
+either "COM1:", "COM2:", or up to "COM9:". Set the serialControlString
 <property> before opening the <port> to specify the baud rate and other
 settings. 
 
@@ -151,13 +151,14 @@ BOM is ignored.
 References: write to file (command), open file (command), put (command),
 constant (command), read from file (command), get (command),
 close file (command), answer file (command), return (constant),
-function (control structure), tempName (function), return (glossary),
-null (glossary), property (glossary), file (glossary), port (glossary),
-command (glossary), Windows (glossary), textDecode (glossary),
-OS X (glossary), type signature (glossary), creator signature (glossary),
-result (glossary), textEncode (glossary), Mac OS (glossary),
-Unix (glossary), ASCII (glossary), characters (keyword), file (keyword),
-URL keyword (keyword), fileType (property), umask (property)
+function (control structure), result (function),  tempName (function), 
+textDecode (function), textEncode (function), return (glossary), 
+null (glossary),  property (glossary), file (glossary), port (glossary), 
+command (glossary), Windows (glossary), textDecode (glossary), 
+OS X (glossary), type signature (glossary), creator signature (glossary), 
+Mac OS (glossary), Unix (glossary), ASCII (glossary), 
+characters (keyword), file (keyword), URL (keyword), fileType (property), 
+umask (property)
 
 Tags: file system
 

--- a/docs/dictionary/command/open-printing-to-pdf.lcdoc
+++ b/docs/dictionary/command/open-printing-to-pdf.lcdoc
@@ -39,20 +39,19 @@ Description:
 Use the <open printing to pdf> <command> to print multiple cards
 directly to a pdf file.
 
-    The open printing to pdf command starts a print loop that outputs
-    directly to a PDF file rather that the currently configured printer.
+The open printing to pdf command starts a print loop that outputs
+directly to a PDF file rather that the currently configured printer.
 
 
 The following handler prints cards that have been collected in a global
 variable: 
 
     on printSomeCards
-    global cardsToPrint
-    open printing to pdf "test.pdf"
-    repeat with x = 1 to the number of lines of cardsToPrint
-
-    print card (line x of cardsToPrint)
-    end repeat
+        global cardsToPrint
+        open printing to pdf "test.pdf"
+        repeat with x = 1 to the number of lines of cardsToPrint
+           print card (line x of cardsToPrint)
+        end repeat
     close printing -- send group of cards to printer
 
     end printSomeCards

--- a/docs/dictionary/command/open-printing.lcdoc
+++ b/docs/dictionary/command/open-printing.lcdoc
@@ -57,14 +57,12 @@ The following handler prints cards that have been collected in a global
 variable: 
 
     on printSomeCards
-    global cardsToPrint
-    open printing with dialog
-    repeat with x = 1 to the number of lines of cardsToPrint
-
-    print card (line x of cardsToPrint)
-    end repeat
-    close printing -- send group of cards to printer
-
+        global cardsToPrint
+        open printing with dialog
+        repeat with x = 1 to the number of lines of cardsToPrint
+            print card (line x of cardsToPrint)
+        end repeat
+        close printing -- send group of cards to printer
     end printSomeCards
 
 

--- a/docs/dictionary/command/open-process.lcdoc
+++ b/docs/dictionary/command/open-process.lcdoc
@@ -142,8 +142,8 @@ BOM is ignored.
 References: kill (command), close process (command),
 read from process (command), write to process (command),
 exit (control structure), screenName (function), command (glossary),
-OS X (glossary), textDecode (glossary), Windows (glossary),
-Mac OS (glossary), Unix (glossary), textEncode (glossary),
+OS X (glossary), textDecode (function), Windows (glossary),
+Mac OS (glossary), Unix (glossary), textEncode (keyword),
 background (glossary), process (glossary), characters (keyword),
 hideConsoleWindows (property)
 

--- a/docs/dictionary/command/option.lcdoc
+++ b/docs/dictionary/command/option.lcdoc
@@ -35,8 +35,7 @@ Use the <option> <command> in a <mouseDown> <handler> to display the
 <menu> :
 
     on mouseDown
-    option stack "Help Menu"
-
+        option stack "Help Menu"
     end mouseDown
 
 

--- a/docs/dictionary/function/openFiles.lcdoc
+++ b/docs/dictionary/function/openFiles.lcdoc
@@ -7,8 +7,8 @@ Syntax: the openFiles
 Syntax: openFiles()
 
 Summary:
-<return|Returns> a list of <files> that have been opened with the <open
-file> <command>, but not yet closed with the <close file> <command>.
+<return|Returns> a list of <files> that have been opened with the 
+<open file> <command>, but not yet closed with the <close file> <command>.
 
 Introduced: 1.0
 

--- a/docs/dictionary/keyword/of.lcdoc
+++ b/docs/dictionary/keyword/of.lcdoc
@@ -6,8 +6,8 @@ Syntax: of
 
 Summary:
 Designates the <object(glossary)> a <property> belongs to, or the
-<parameter> of a <function>, or the <string> that contains a <chunk
-expression>. 
+<parameter> of a <function>, or the <string> that contains a 
+<chunk expression>. 
 
 Introduced: 1.0
 

--- a/docs/dictionary/message/openControl.lcdoc
+++ b/docs/dictionary/message/openControl.lcdoc
@@ -6,7 +6,7 @@ Syntax: openControl
 
 Summary:
 Sent to a <group> right after you go to the card that contains it or to
-a <background group> right after going from a card where it was is not
+a <background|background group> right after going from a card where it was is not
 placed on to one where it is.
 
 Associations: group
@@ -28,8 +28,8 @@ Handle the <openControl> message to change a group's objects or perform
 other updates, when a card with the group on is visited.
 
 For groups with their <backgroundBehavior> <property> set to true, the
-<openControl> message is sent immediately after the <openBackground
-message> is sent to the card being opened. For non-background groups, it
+<openControl> message is sent immediately after the <openBackground>
+<message> is sent to the card being opened. For non-background groups, it
 is sent after the <openCard> <message>.
 
 For nested groups, the <openControl> message is sent to the parent group
@@ -38,7 +38,7 @@ passes though each child group in reverse layer order (i.e from highest
 to lowest).
 
 References: preOpenBackground (message), openCard (message),
-openBackground message (message), preOpenControl (message),
+openBackground (message), preOpenControl (message),
 closeControl (message), message (glossary), group (object),
-background group (property), backgroundBehavior (property), property (glossary)
+backgroundBehavior (property), property (glossary), background (glossary)
 

--- a/docs/dictionary/message/openField.lcdoc
+++ b/docs/dictionary/message/openField.lcdoc
@@ -36,10 +36,10 @@ a <handler>, the <focusIn> <message> is sent to it.
 
 References: select (command), select (glossary), handler (glossary),
 lock (glossary), message (glossary), unlock (glossary),
-menuMode (glossary), active control (glossary), combo box (glossary),
-selection (keyword), field (keyword), focusIn (message),
-exitField (message), closeField (message), field (object),
-button (object)
+active control (glossary), combo box (glossary), selection (keyword), 
+field (keyword), focusIn (message), exitField (message), 
+closeField (message), field (object), button (object),
+menuMode (property)
 
 Tags: ui
 

--- a/docs/dictionary/message/optionKeyDown.lcdoc
+++ b/docs/dictionary/message/optionKeyDown.lcdoc
@@ -30,10 +30,10 @@ Handle the <optionKeyDown> <message> if you want to provide <Option key>
 shortcuts, or do something special when the user types an <Option key>
 combination. 
 
-The <optionKeyDown> <message> is sent only when the user types a <key
-combination> that produces a <character>. For example, typing Option-F11
-does not send an <optionKeyDown> <message>, because Option-F11 does not
-produce a <character>.
+The <optionKeyDown> <message> is sent only when the user types a 
+<key combination> that produces a <character>. For example, typing 
+Option-F11 does not send an <optionKeyDown> <message>, because Option-F11 
+does not produce a <character>.
 
 On MacOS 9, some key codes are not sent if the preceding character is
 one that produces an international diacritical. In those cases, the key

--- a/docs/dictionary/message/orientationChanged.lcdoc
+++ b/docs/dictionary/message/orientationChanged.lcdoc
@@ -35,7 +35,7 @@ The <orientationChanged> message is sent before any automatic interface
 rotation takes place thus changes to the orientation lock state and
 allowed set can be made at this point and still have an effect. If you
 wish to perform an action after the interface has been rotated, then
-either do so on receipt of <resizeStack>, or by using a <send in 0
+either do so on receipt of <resizeStack>, or by using a <send|send in 0
 milliseconds(command)> command.
 
 References: mobileSetAllowedOrientations (command),

--- a/docs/dictionary/property/opaque.lcdoc
+++ b/docs/dictionary/property/opaque.lcdoc
@@ -43,11 +43,11 @@ not opaque, regardless of the setting of the <image(object)|image's>
 <opaque> <property>.
 
 >*Tip:*  <graphic(object)|Graphics> whose <ink> <property> is set to
-> <noOp> are transparent, but (unlike <graphic(object)|Graphics> whose
+> `noOp` are transparent, but (unlike <graphic(object)|Graphics> whose
 > <opaque> is set to false) they still intercept mouse clicks within the
 > <graphic(object)|graphic's> outline. To create an invisible hot spot
 > with a non-rectangular shape, use a <curve> or <polygon>
-> <graphic(keyword)> and set its <ink> to <noOp>.
+> <graphic(keyword)> and set its <ink> to `noOp`.
 
 Setting a button's or field's style <property> to "opaque" sets its
 <opaque> to true.
@@ -64,7 +64,7 @@ Setting a button's or field's style <property> to "opaque" sets its
 References: object (glossary), property (glossary), background (glossary),
 appearance (glossary), object (glossary), Mac OS (glossary),
 OS X (glossary), polygon (keyword), opaque (keyword), curve (keyword),
-control (keyword), graphic (keyword), noOp (keyword), image (keyword),
+control (keyword), graphic (keyword), image (keyword),
 button (object), image (object), graphic (object),
 strokeGradient (property), ink (property), showBorder (property),
 properties (property), threeD (property), blendLevel (property),
@@ -72,4 +72,3 @@ backgroundPattern (property), style (property), lookAndFeel (property),
 visible (property), fillRule (property), fillGradient (property)
 
 Tags: ui
-

--- a/docs/dictionary/property/outerglow.lcdoc
+++ b/docs/dictionary/property/outerglow.lcdoc
@@ -32,58 +32,34 @@ properties is by using the Graphic Effects card of the property
 inspector which has full control over each parameter. To control the
 effect by script use the following properties:
 
-outerglow["color"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The color of the glow, in the format
+outerglow["color"] - The color of the glow, in the format 
 red,green,blue where each value is between 0 and 255.
 
-outerglow["blendMode"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;How the glow is blended with objects
+outerglow["blendMode"] - How the glow is blended with objects 
 behind it. This is one of the following values:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- "normal" :
-the glow is laid over the background.
+* "normal": the glow is laid over the background.
+* "multiply": this results in a darkening effect
+* "colorDodge": this results in a lightening effect
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- "multiply"
-: this results in a darkening effect
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-
-"colorDodge" : this results in a lightening effect
-
-outerglow["opacity"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;How opaque the glow is. The value is
+outerglow["opacity"] - How opaque the glow is. The value is
 between 0 (fully transparent) and 255 (fully opaque).
 
-outerglow["filter"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Which algorithm is used to render the
+outerglow["filter"] - Which algorithm is used to render the
 glow. This is one of the following options:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"gaussian" :
-highest quality (and slowest)
+* "gaussian": highest quality (and slowest)
+* "box3pass": high quality.
+* "box2pass": medium quality
+* "box1pass": low quality (and fastest)
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"box3pass" :
-high quality.
+>*Note:* When using the "colorDodge" blend mode, it
+> is recommended that you set the filter mode to "gaussian".
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"box2pass" :
-medium quality
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"box1pass" :
-low quality (and fastest)
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;When using the "colorDodge" blend mode, it
-is recommended that you set the filter mode to "gaussian".
-
-outerglow["size"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The radius of the glow, i.e. how far from
+outerglow["size"] - The radius of the glow, i.e. how far from
 the edge of the object it extends to. This is between 0 and 255.
 
-outerglow["spread"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This controls where the effect begins to
+outerglow["spread"] - This controls where the effect begins to
 blend. This is between 0 and 255.
 
 References: innerShadow (property), innerGlow (property),

--- a/docs/dictionary/property/pageHeights.lcdoc
+++ b/docs/dictionary/property/pageHeights.lcdoc
@@ -32,9 +32,9 @@ full of text.
 
 You can use the <pageHeights> <property> to print the entire contents of
 a <field(keyword)> by printing the <field(keyword)>, setting the
-<field(object)|field's> <scroll> to the first line of the <pageHeights>,
-printing the <field(keyword)> again, setting the <scroll> to the current
-<scroll> plus line 2 of the <pageHeights>, and so on.
+<field(object)|field's> <vScroll> to the first line of the <pageHeights>,
+printing the <field(keyword)> again, setting the <vScroll> to the current
+<vScroll> plus line 2 of the <pageHeights>, and so on.
 
 The computations used by the <pageHeights> <property> assume the
 <field(object)|field's> <borderWidth> <property> is set to zero and its
@@ -43,7 +43,7 @@ The computations used by the <pageHeights> <property> assume the
 References: textHeightSum (function), property (glossary),
 integer (glossary), field (keyword), line (keyword), field (object),
 borderWidth (property), formatForPrinting (property), pixels (property),
-margins (property), scroll (property)
+margins (property), vScroll (property)
 
 Tags: printing
 


### PR DESCRIPTION
keyword/of.lcdoc - Fixed broken link.
property/opaque.lcdoc - Removed noOp as a reference due to a lack of corresponding entry.
command/open-driver.lcdoc - Fixed broken links, replaced instances of `theform` with best guesses for what they ought to say, changed all references to `COM1:` and `COM2:` to `COMn:` instead.
command/open-file.lcdoc - Fixed broken links, changes types of certain references.
command/open-printing.lcdoc - Changed spacing of code example.
command/open-printing-to-pdf.lcdoc - Changed spacing of code example. Removed indents from text that was not code.
command/open-process.lcdoc - Changed types of references to their appropriate ones.
message/openControl.lcdoc - Edited certain references.
message/openField.lcdoc - Changed type of a reference to an appropriate one.
message/openFiles.lcdoc - Fixed broken link.
command/option.lcdoc - Changed spacing of code example.
message/optionKeyDown.lcdoc - Fixed broken link.
message/orientationChanged.lcdoc - Fixed broken link.
property/outerGlow.lcdoc - Changed formatting in line with innerGlow.
property/pageHeights.lcdoc - Changed references to `scroll` to refer to `vScroll` as a guess that it should be this instead; `scroll` doesn’t seem to exist.