### PR TITLE
[[ Bug ]] Ensure result mode is not clobbered by debugger messages

### DIFF
--- a/engine/src/debug.cpp
+++ b/engine/src/debug.cpp
@@ -208,6 +208,8 @@ void MCB_message(MCExecContext &ctxt, MCNameRef mess, MCParameter *p)
 	/* UNCHECKED */ MCVariable::createwithname(MCNAME("MCdebugresult"), MCresult);
 	MCtracereturn = False;
 	MCtraceabort = False;
+    
+    MCExecResultMode t_oldresultmode = MCresultmode;
 
 	Boolean oldcheck;
 	oldcheck = MCcheckstack;
@@ -246,6 +248,8 @@ void MCB_message(MCExecContext &ctxt, MCNameRef mess, MCParameter *p)
 	 MCresult = oldresult;
 	 MCU_restoreprops(sp);
 	 MCexitall = exitall;
+     MCresultmode = t_oldresultmode;
+
 }
 
 void MCB_prepmessage(MCExecContext &ctxt, MCNameRef mess, uint2 line, uint2 pos, uint2 id, MCStringRef p_info)

--- a/tests/lcs/core/engine/_trace.livecodescript
+++ b/tests/lcs/core/engine/_trace.livecodescript
@@ -1,0 +1,21 @@
+script "CoreEngineTrace"
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on trace pHandlerName, pLine
+   set the traceReturn to true
+end trace

--- a/tests/lcs/core/engine/return.livecodescript
+++ b/tests/lcs/core/engine/return.livecodescript
@@ -229,3 +229,21 @@ on TestReturnNested
                   the result is "ReturnValue" and \
                   it is "TheIt"
 end TestReturnNested
+
+on TestMessageMessagesResultMode
+   local tPath
+   put format("%s/../_trace.livecodescript", the filename of me) into tPath
+   start using stack tPath
+   set the traceReturn to true
+   set the traceStack to the long id of me
+   DoReturnValueInCommand "foobar"
+   local tIt, tResult
+   put it into tIt
+   put the result into tResult
+   TestDiagnostic "it" && tIt
+   TestDiagnostic "result" && tResult
+   TestAssert "result mode is not clobbered in messageHandled", tIt is "foobar"
+   set the traceStack to empty
+   stop using stack tPath
+end TestMessageMessagesResultMode
+


### PR DESCRIPTION
This patch ensures that `return for value` and `return for error`
function correctly under the debugger. Previously the call to `MCB_trace`
on the last line of a handler would clobber the result mode set in the
return statement.

(cherry picked from commit fa4ccaa19b327a0ee71f0242f38cc6a64377e5a1)