### PR TITLE
[[ Bug 21612 ]] Fix crash when sending touch events to a deleted stack

### DIFF
--- a/docs/notes/bugfix-21612.md
+++ b/docs/notes/bugfix-21612.md
@@ -1,0 +1,1 @@
+# Fix crash sending touch events to a deleted stack

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -555,7 +555,10 @@ static void MCEventQueueDispatchEvent(MCEvent *p_event)
 	{
 #ifdef _MOBILE
 		MCStackHandle t_stack(t_event->touch.stack);
-		handle_touch(t_stack, t_event->touch.phase, t_event->touch.id, t_event->touch.taps, t_event->touch.x, t_event->touch.y);
+        if (t_stack)
+        {
+            handle_touch(t_stack, t_event->touch.phase, t_event->touch.id, t_event->touch.taps, t_event->touch.x, t_event->touch.y);
+        }
 #else
         MCUnreachable();
 #endif


### PR DESCRIPTION
This patch ensures the target stack is valid before attempting calling `handle_touch`
to avoid crashing.