### PR TITLE
[Dictionary] palindromeFrames to pointer

### DIFF
--- a/docs/dictionary/constant/pi.lcdoc
+++ b/docs/dictionary/constant/pi.lcdoc
@@ -14,7 +14,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-get tan((firstAngle * pi) + secondAngle)
+get tan((tAngleInDegrees * pi/180) + tSecondAngleInRadians)
 
 Description:
 Use the <pi> <constant> in trigonometric <expression|expressions> where

--- a/docs/dictionary/control_st/pass.lcdoc
+++ b/docs/dictionary/control_st/pass.lcdoc
@@ -68,13 +68,13 @@ When a handler executes a <pass> <statement>, the <message> is
 <pass|passed> to the next <object(glossary)> in the <message path>. If
 you use the pass...to top form of the <pass> <control structure>, the
 <message> is <pass|passed> directly to the <engine>, without being
-<pass|passed> through any other <object(glossary)> in the <message
-path>. 
+<pass|passed> through any other <object(glossary)> in the 
+<message path>. 
 
 To halt the current handler without passing the message on through the
 message path, use the <exit> <control structure> instead. To halt the
-current <handler> and return a result, use the <return> <control
-structure> instead.
+current <handler> and return a result, use the <return> 
+<control structure> instead.
 
 >*Important:*  You cannot use the <pass> <command> to pass a <message>
 > that was originally sent with the <send> <command>.

--- a/docs/dictionary/function/param.lcdoc
+++ b/docs/dictionary/function/param.lcdoc
@@ -41,8 +41,7 @@ handler or message handler. For example, the following function assigns
 three parameters, which are multiplied together:
 
     function product firstFactor,secondFactor,thirdFactor
-    return firstFactor * secondFactor * thirdFactor
-
+        return firstFactor * secondFactor * thirdFactor
     end product
 
 
@@ -54,19 +53,17 @@ can use the <param> <function> to use each <parameter> without needing
 to assign it a name:
 
     function product
-    put 1 into total
-    repeat with nextFactor = 1 to the paramCount
-
-    multiply total by param(nextFactor)
-    end repeat
-    return total
-
+        put 1 into total
+        repeat with nextFactor = 1 to the paramCount
+            multiply total by param(nextFactor)
+        end repeat
+        return total
     end product
 
 
 LiveCode evaluates the parameters before passing them. So if you call
 myHandler with the following statement: myHandler 1+1,"A","Hello" &&
-"world" the parameters returned by the <param> <function> are 2<a/>, A,
+"world" the parameters returned by the <param> <function> are 2, A,
 and "Hello World".
 
 References: function (control structure), paramCount (function),

--- a/docs/dictionary/function/params.lcdoc
+++ b/docs/dictionary/function/params.lcdoc
@@ -39,8 +39,7 @@ handler or message handler. For example, the following handler assigns
 three parameters:
 
     on myHandler thisParam,thatParam,theOtherParam
-    answer thisParam & return & thatParam & return & theOtherParam
-
+        answer thisParam & return & thatParam & return & theOtherParam
     end myHandler
 
 
@@ -55,9 +54,8 @@ You can obtain the fourth parameter for use in the handler with the
 <params> <function> :
 
     on myHandler thisParam,thatParam,theOtherParam
-    put item 4 of the params into yetAnotherParam
-    answer yetAnotherParam
-
+        put item 4 of the params into yetAnotherParam
+        answer yetAnotherParam
     end myHandler
 
 
@@ -69,8 +67,7 @@ parameters are enclosed in parentheses. For example, the following
 function handler has three parameters:
 
     function myFunction thisParam,thatParam,theOtherParam
-    return thisParam & return & thatParam & return & theOtherParam
-
+        return thisParam & return & thatParam & return & theOtherParam
     end myFunction
 
 
@@ -78,7 +75,7 @@ If you call "myFunction" with the following statement:
 
     get myFunction("red","green","blue")
 
-the value returned is "myFunction("red","green","blue")".
+the value returned by the <params> function is "myFunction("red","green","blue")".
 
 LiveCode evaluates the parameters before passing them. So if you call
 myHandler with the following statement: myHandler 1+1,"A","Hello" &&

--- a/docs/dictionary/keyword/pointer.lcdoc
+++ b/docs/dictionary/keyword/pointer.lcdoc
@@ -24,9 +24,9 @@ When using the Pointer tool, the cursor is an arrow. Use this tool to
 select, resize, and move <control(glossary)|controls>.
 
 You cannot edit the objects in stacks whose <cantModify> <property> is
-true or <stacks> which are being displayed as a <palette>, <modeless
-dialog box|modeless dialog>, or <modal dialog box|modal dialog>. Only
-<stacks> displayed as an <editable window> can be edited. (Use the
+true or <stacks> which are being displayed as a <palette>, 
+<modeless dialog box|modeless dialog>, or <modal dialog box|modal dialog>. 
+Only <stacks> displayed as an <editable window> can be edited. (Use the
 <topLevel> <command> to display a <stack> in an <editable window>.)
 
 References: topLevel (command), select (command), palette (command),

--- a/docs/dictionary/message/playStopped.lcdoc
+++ b/docs/dictionary/message/playStopped.lcdoc
@@ -34,8 +34,8 @@ created for it. When the clip is finished, the <playStopped> <message>
 is sent to it.
 
 >*Note:* The <playStopped> <message> is sent when a <card(keyword)>
-> containing the <player(keyword)> closes and when the <player's
-> filename property> is changed. If the <player(object)> is hidden, or
+> containing the <player(keyword)> closes and when the 
+> player's <filename> is changed. If the <player(object)> is hidden, or
 > the movie or sound is not currently running, the message will still be
 > sent. To prevent a playStopped <handler> from being <execute|executed>
 > inappropriately, set the <lockMessages> to true before changing the
@@ -49,8 +49,8 @@ is sent to it.
 References: start (command), play (command), handler (glossary),
 player (glossary), message (glossary), command (glossary),
 execute (glossary), card (keyword), player (keyword),
-playPaused (message), player's filename property (object), card (object),
-player (object), lockMessages (property), filename (property)
+playPaused (message), card (object), player (object), 
+filename (property), lockMessages (property), filename (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/object/player.lcdoc
+++ b/docs/dictionary/object/player.lcdoc
@@ -30,8 +30,8 @@ reduces the memory required by your <stack>, because the movie or sound
 data is only <loaded into memory> when it's being used, rather than
 being <loaded into memory> whenever the <stack file> is open. However,
 it also makes it possible for the movie or sound data to be misplaced
-during distribution, since the <file> is separate from your <stack
-file>. 
+during distribution, since the <file> is separate from your 
+<stack file>. 
 
 A player is contained in a card, group, or background. Players cannot 
 contain other objects.

--- a/docs/dictionary/property/palindromeFrames.lcdoc
+++ b/docs/dictionary/property/palindromeFrames.lcdoc
@@ -24,8 +24,8 @@ By default, the <palindromeFrames> <property> of newly created
 <image(object)|images> is set to false.
 
 Description:
-Use the <palindromeFrames> <property> to change the way an <animated
-GIF> <image> repeats itself.
+Use the <palindromeFrames> <property> to change the way an 
+<animated GIF> <image> repeats itself.
 
 An animated GIF image can be set to loop over and over, instead of
 playing the animation once and then stopping. If the <palindromeFrames>

--- a/docs/dictionary/property/password.lcdoc
+++ b/docs/dictionary/property/password.lcdoc
@@ -36,14 +36,15 @@ empty.
 
 If the <password> <property> of a <stack> is not empty, all the text in
 the <stack> is <encrypt|encrypted> (so that it cannot be read in another
-program, such as a text editor). <script|Scripts>, <custom
-property|custom properties>, text in <field|fields> or <button|buttons>,
-and <object(glossary)> names in a password-protected <stack> are all
-<encrypt|encrypted>. However, you can still open the <stack>, see the
-contents, and get <object(glossary)> <property|properties>.
+program, such as a text editor). <script|Scripts>, 
+<custom property|custom properties>, text in <field|fields> or 
+<button|buttons>, and <object(glossary)> names in a password-protected 
+<stack> are all <encrypt|encrypted>. However, you can still open the 
+<stack>, see the contents, and get <object(glossary)> 
+<property|properties>.
 
-The <password> <property> applies to a <stack>, not to the entire <stack
-file>, so it is possible to have a <stack file> that contains both
+The <password> <property> applies to a <stack>, not to the entire 
+<stack file>, so it is possible to have a <stack file> that contains both
 password-protected and unprotected <stacks>. After setting the password
 the password protection does not take effect until the stack has been
 removed from memory and reloaded.
@@ -85,8 +86,8 @@ otherwise.
 > the <Application Browser> window cannot display properties of a
 > <password> -protected <stack>.) If you want to set a <password> for
 > <stacks> before you release them, the recommended method is to set the
-> <password> on the Stacks screen of the <Standalone Application
-> Settings> window.
+> <password> on the Stacks screen of the 
+> <Standalone Application Settings> window.
 
 >**Note:** Setting the <password> of a <stack> is only supported in 
 > *LiveCode Indy* and *LiveCode Business*. In *LiveCode Community* and

--- a/docs/dictionary/property/pixels.lcdoc
+++ b/docs/dictionary/property/pixels.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: pixels
 
 Summary:
-The <pixels> <property> is not implemented and is <reserved
-word|reserved>.
+The <pixels> <property> is not implemented and is 
+<reserved word|reserved>.
 
 Associations: image
 

--- a/docs/glossary/p/PICT.lcdoc
+++ b/docs/glossary/p/PICT.lcdoc
@@ -5,10 +5,10 @@ Synonyms: pict
 Type: glossary
 
 Description:
-PICTure. A picture< forma(glossary)>t developed by Apple Computer and
-usually used on< Mac OS(glossary)> or <OS X|OS X system>s.
+PICTure. A picture <format(glossary)> developed by Apple Computer and
+usually used on <Mac OS(glossary)> or <OS X|OS X systems>.
 
-References: Mac OS (glossary), forma (glossary), OS X (glossary)
+References: Mac OS (glossary), format (glossary), OS X (glossary)
 
 Tags: multimedia
 

--- a/docs/glossary/p/pass-by-reference.lcdoc
+++ b/docs/glossary/p/pass-by-reference.lcdoc
@@ -18,7 +18,7 @@ its name with the <@> character in the called <handler|handler's> first
 line. 
 
 References: handler (glossary), parameter (glossary), variable (glossary),
-local variable (glossary), @ (glossary), call (glossary)
+local variable (glossary), call (glossary), @ (keyword)
 
 Tags: properties
 

--- a/docs/glossary/p/pass.lcdoc
+++ b/docs/glossary/p/pass.lcdoc
@@ -5,8 +5,8 @@ Synonyms: pass, passed, passing
 Type: glossary
 
 Description:
-To relinquish a <message> to the next <object(glossary)> in the <message
-path>. 
+To relinquish a <message> to the next <object(glossary)> in the 
+<message path>. 
 
 Also, to send data from one <handler> to another; to share data between
 <handler|handlers>. 


### PR DESCRIPTION
property/palindromeFrames.lcdoc - Fixed broken link.
function/param.lcdoc - Altered spacing in code examples.
function/params.lcdoc - Altered spacing in code examples. Explained for one example that it is the params function that returns the value given.
control_st/pass.lcdoc - Fixed broken links.
glossary/p/pass.lcdoc - Fixed broken links.
glossary/p/pass-by-reference.lcdoc - Changed type of reference.
property/password.lcdoc - Fixed broken links.
constant/pi.lcdoc - Rewrote code example to fit usual LiveCode conventions and be less confusing in purpose.
glossary/p/PICT.lcdoc - Corrected various spelling mistakes in references.
glossary/p/pixels.lcdoc - Fixed broken link.
object/player.lcdoc - Fixed broken link.
property/filename.lcdoc - Replaced a nonexistent reference.
keyword/pointer.lcdoc - Fixed broken link.