### PR TITLE
[Dictionary] pointerFocus to processID

### DIFF
--- a/docs/dictionary/command/post.lcdoc
+++ b/docs/dictionary/command/post.lcdoc
@@ -39,7 +39,7 @@ The value the web server returns is placed in the it <variable>.
 The result:
 If an error occurs, the <result> <function> is set to the error message.
 >*Important:* If a <blocking> operation involving a <URL> (using the
-> <put> <command> to <upload> a <URL>, the <post> c <ommand>, the
+> <put> <command> to <upload> a <URL>, the <post> <command>, the
 > <delete URL> <command>, or a <statement> that gets an <ftp> or <HTTP>
 > <URL>) is going on, no other <blocking> <URL> operation can start
 > until the previous one is finished. If you attempt to use a <URL> in
@@ -80,9 +80,8 @@ password "pass", use the following <statement> :
     put "name" into userName
     put "jdoe@example.com" into userPassword
     put "http://" & userName & ":" & URLEncode(userPassword) \
-
-    & "@www.example.net/index.html" into fileURLToGet
-	get URL fileURLToGet
+        & "@www.example.net/index.html" into fileURLToGet
+    get URL fileURLToGet
 
 
 >*Important:*  The <post> <command> is part of the 
@@ -120,10 +119,12 @@ open socket (command), libURLSetCustomHTTPHeaders (command),
 function (control structure), result (function), URLStatus (function),
 URLEncode (function), libURLFormData (function), URLDecode (function),
 libURLMultipartFormAddPart (function), libURLMultipartFormData (function),
-variable (glossary), ommand (glossary), property (glossary),
-blocking (glossary), web server (glossary), command (glossary),
-expression (glossary), syntax (glossary), server (glossary),
-upload (glossary), statement (glossary), handler (glossary),
-URL (keyword), ftp (keyword), http (keyword), urlProgress (message),
+variable (glossary), command (glossary), 
+Livecode custom library (glossary), property (glossary),
+standalone application (glossary), blocking (glossary), 
+web server (glossary), command (glossary), expression (glossary), 
+syntax (glossary), server (glossary), upload (glossary), 
+statement (glossary), handler (glossary), URL (keyword), ftp (keyword), 
+http (keyword), Internet library (library), urlProgress (message), 
 httpHeaders (property), HTTPProxy (property)
 

--- a/docs/dictionary/function/processID.lcdoc
+++ b/docs/dictionary/function/processID.lcdoc
@@ -7,8 +7,8 @@ Syntax: the processID
 Syntax: processID()
 
 Summary:
-<return|Returns> the <process> ID of LiveCode (or a <standalone
-application>). 
+<return|Returns> the <process> ID of LiveCode (or a 
+<standalone application>). 
 
 Introduced: 1.0
 
@@ -34,8 +34,8 @@ On Unix systems, the <processID> uniquely identifies the <process>
 belonging to the running <application>. Other <process|processes> can
 use the <processID> to address LiveCode.
 
-The <processID> function does not <return> a meaningful value on <Mac
-OS> or <Windows|Windows systems>.
+The <processID> function does not <return> a meaningful value on 
+<Mac OS> or <Windows|Windows systems>.
 
 References: kill (command), return (constant), application (glossary),
 Windows (glossary), standalone application (glossary), return (glossary),

--- a/docs/dictionary/keyword/printercolon.lcdoc
+++ b/docs/dictionary/keyword/printercolon.lcdoc
@@ -5,9 +5,9 @@ Type: keyword
 Syntax: printer:
 
 Summary:
-Used with the <open file>, <read from file>, <write to file>, and <close
-file> <command|commands> to specify the printer <port> on <Mac OS|Mac OS
-systems>. 
+Used with the <open file>, <read from file>, <write to file>, and 
+<close file> <command|commands> to specify the printer <port> on 
+<Mac OS|Mac OS systems>. 
 
 Introduced: 1.0
 

--- a/docs/dictionary/message/preOpenControl.lcdoc
+++ b/docs/dictionary/message/preOpenControl.lcdoc
@@ -6,7 +6,7 @@ Syntax: preOpenControl
 
 Summary:
 Sent to a <group> when you go to the <card> that contains it and to a
-<background group> when going from a card which it is not placed on to
+<group|background group> when going from a card which it is not placed on to
 one where it is.
 
 Associations: group
@@ -45,8 +45,8 @@ The actual navigation is not triggered by the <preOpenControl>
 <message>, so blocking the <message> and not allowing it to pass does
 not prevent the <card(keyword)> with the <group> from opening.
 
-References: dispatch (command), group (command), message (glossary),
+References: dispatch (command), message (glossary),
 card (keyword), preOpenBackground (message),
 openControl (message), preOpenCard (message), card (object),
-background group (property), backgroundBehavior (property), property (glossary)
+group (object), backgroundBehavior (property), property (glossary)
 

--- a/docs/dictionary/property/pointerFocus.lcdoc
+++ b/docs/dictionary/property/pointerFocus.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: set the pointerFocus to {true | false}
 
 Summary:
-Specifies whether typed text is sent to the window under the <mouse
-pointer> or to the frontmost window.
+Specifies whether typed text is sent to the window under the 
+<mouse pointer> or to the frontmost window.
 
 Introduced: 1.0
 
@@ -41,10 +41,10 @@ correctly.
 If the application is started from a Unix command line, this property
 can be set to true on startup by using the -pointerfocus option.
 
->*Cross-platform note:*  On <Mac OS>, <OS X>, and <Windows|Windows
-> systems>, setting the <pointerFocus> <property> to false changes
-> window activation in minor ways which are not particularly useful, and
-> has no other effect.
+>*Cross-platform note:*  On <Mac OS>, <OS X>, and 
+> <Windows|Windows systems>, setting the <pointerFocus> <property> 
+> to false changes  window activation in minor ways which are not 
+> particularly useful, and has no other effect.
 
 References: property (glossary), OS X (glossary),
 explicit focus (glossary), active window (glossary), Windows (glossary),

--- a/docs/dictionary/property/printColors.lcdoc
+++ b/docs/dictionary/property/printColors.lcdoc
@@ -34,8 +34,8 @@ monochrome.
 If the <printColors> is false then LiveCode will convert all colors in
 the data to be printed to greyscale before sending to the printer.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), printerFeatures (property),
 printFontTable (property), printCommand (property)

--- a/docs/dictionary/property/printCopies.lcdoc
+++ b/docs/dictionary/property/printCopies.lcdoc
@@ -32,8 +32,8 @@ Use the <printCopies> property to specify a number of copies to print.
 This property will only have an affect if the <printerFeatures> contains
 "copies". 
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), answer printer (command),
 printPageNumber (property), printerFeatures (property),

--- a/docs/dictionary/property/printDuplex.lcdoc
+++ b/docs/dictionary/property/printDuplex.lcdoc
@@ -37,8 +37,8 @@ effect.
 Attempting to set the <printDuplex> to an invalid value results in a
 script execution error.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: print (command), open printing (command),
 printCollate (property), printerFeatures (property)

--- a/docs/dictionary/property/printFontTable.lcdoc
+++ b/docs/dictionary/property/printFontTable.lcdoc
@@ -31,13 +31,13 @@ substitutions for better results.
 Each line of the <printFontTable> corresponds to one screen <font> and
 contains the following <items>, separated by commas:
 
-        * The name of an X11 screen font
-        * The name of the PostScript font to use in its place for
-          printing 
-        * The name of the normal style for that font
-        * The name of the bold style for that font
-        * The name of the italic style for that font
-        * The name of the bold italic style for that font
+* The name of an X11 screen font
+* The name of the PostScript font to use in its place for
+printing 
+* The name of the normal style for that font
+* The name of the bold style for that font
+* The name of the italic style for that font
+* The name of the bold italic style for that font
 
 
 By default, the <printFontTable> <property> uses a mapping between the

--- a/docs/dictionary/property/printPaperOrientation.lcdoc
+++ b/docs/dictionary/property/printPaperOrientation.lcdoc
@@ -21,8 +21,8 @@ Example:
 set the printPaperOrientation to "portrait"
 
 Value (enum):
-The <printPaperOrientation> is one of the following values.The default
-value is determined by the default settings of the current printer
+The <printPaperOrientation> is one of the following values. The default
+value is determined by the default settings of the current printer.
 
 -   portrait: rotated 0 degrees.
 -   landscape: rotated 90 degrees clockwise.
@@ -37,8 +37,8 @@ desired orientation on the page.
 Attempting to set the <printPaperOrientation> to an invalid value will
 result in a script execution error.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 >*Cross-platform note:*  The reverse options are not supported on
 > Windows. When used Windows will revert these options to their

--- a/docs/dictionary/property/printPaperScale.lcdoc
+++ b/docs/dictionary/property/printPaperScale.lcdoc
@@ -31,8 +31,8 @@ Description:
 Use the <printPaperScale> property to apply a final scaling factor to a
 printed page after all other settings have been taken into account.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), answer printer (command)
 

--- a/docs/dictionary/property/printPaperSize.lcdoc
+++ b/docs/dictionary/property/printPaperSize.lcdoc
@@ -30,8 +30,8 @@ Use the <printPaperSize> to determine or set the size of the paper to
 print to. This size is the size of the physical paper before any scaling
 or rotation is applied.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), answer printer (command)
 

--- a/docs/dictionary/property/printRanges.lcdoc
+++ b/docs/dictionary/property/printRanges.lcdoc
@@ -47,8 +47,8 @@ printing loop.
 >*Note:* LiveCode automatically handles coalescing overlapping ranges,
 > e.g. 1-10,5-25,23 will result in the range being 1-25.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), answer printer (command),
 printPageNumber (property)

--- a/docs/dictionary/property/printTextSize.lcdoc
+++ b/docs/dictionary/property/printTextSize.lcdoc
@@ -18,7 +18,7 @@ Description:
 In HyperCard, the <printTextSize> <property> specifies the font size of
 printed text. In LiveCode, only <card(object)|cards> can be printed, and
 the size of text on the <card(keyword)> is determined by the <textSize>
-<property> of the <object|objects> that display text..
+<property> of the <object|objects> that display text.
 
 By default, the value of <printTextSize> is 14. A <handler> can set the
 <property>, but the new setting has no effect.

--- a/docs/dictionary/property/printTextStyle.lcdoc
+++ b/docs/dictionary/property/printTextStyle.lcdoc
@@ -18,7 +18,7 @@ Description:
 In HyperCard, the <printTextStyle> <property> specifies the styles of
 printed text. In LiveCode, only <card(object)|cards> can be printed, and
 the style of text on the <card(keyword)> is determined by the
-<textStyle> <property> of <object|objects> that display text..
+<textStyle> <property> of <object|objects> that display text.
 
 By default, the value of <printTextStyle> is plain. A handler can set
 the <property>, but the new setting has no effect.

--- a/docs/dictionary/property/printTitle.lcdoc
+++ b/docs/dictionary/property/printTitle.lcdoc
@@ -26,8 +26,8 @@ Use the <printTitle> property to specify the name of the next print job
 in the system printer queue. If the printTitle is empty at the start of
 a printing loop, the title of the defaultStack will be used.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: print (command), open printing (command),
 printerName (property)

--- a/docs/dictionary/property/printerName.lcdoc
+++ b/docs/dictionary/property/printerName.lcdoc
@@ -43,8 +43,8 @@ be used by LiveCode.
 Setting the <printerName> to empty will reset the printer to the system
 default, and all printer settings to the default for that printer.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), answer printer (command),
 result (function), printTitle (property)

--- a/docs/dictionary/property/printerOutput.lcdoc
+++ b/docs/dictionary/property/printerOutput.lcdoc
@@ -27,7 +27,7 @@ end if
 set the printerOutput to "device"
 
 Value (enum):
-The <printerOutput> can be one of the following values.The default value
+The <printerOutput> can be one of the following values. The default value
 depends on the printer driver
 
   	- Windows Vista uses XPS format.
@@ -53,8 +53,8 @@ of a print job.
 Setting the <printerOutput> to an invalid value will result in a script
 execution error.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), answer printer (command)
 

--- a/docs/dictionary/property/printerSettings.lcdoc
+++ b/docs/dictionary/property/printerSettings.lcdoc
@@ -41,8 +41,8 @@ the current printer.
 Setting the <printerSettings> to empty will reset the printer to the
 system default and all printer settings to the default for the printer.
 
-To have an effect, this property must be set before calling <open
-printing>. 
+To have an effect, this property must be set before calling 
+<open printing>. 
 
 References: open printing (command), answer printer (command)
 


### PR DESCRIPTION
property/pointerFocus.lcdoc - Fixed broken links.
command/post.lcdoc - Added/fixed multiple references. Changed spacing of code example.
message/preOpenControl.lcdoc - Changed references.
property/printColors.lcdoc - Fixed broken link.
property/printCopies.lcdoc - Fixed broken link.
property/printDuplex.lcdoc - Fixed broken link.
property/printFontTable.lcdoc - Changed spacing of list.
keyword/printercolon.lcdoc - Fixed broken link.
property/printerName.lcdoc - Fixed broken link.
property/printerOutput.lcdoc - Fixed broken link.
property/printerSettings.lcdoc - Fixed broken link.
property/printPaperOrientation.lcdoc - Fixed broken link.
property/printPaperScale.lcdoc - Fixed broken link.
property/printPaperSize.lcdoc - Fixed broken link.
property/printRanges.lcdoc - Fixed broken link.
property/printTextSize.lcdoc - Fixed typo.
property/printTextStyle.lcdoc - Fixed typo.
property/printTitle.lcdoc - Fixed typo.
function/processID.lcdoc - Fixed broken links.
