### PR TITLE
[[Bug 20943]][Docs] Explicit RegEx escape examples

### DIFF
--- a/docs/dictionary/function/replaceText.lcdoc
+++ b/docs/dictionary/function/replaceText.lcdoc
@@ -25,6 +25,10 @@ Example:
 put replaceText("colour or color","colou?r","culler")
 -- returns "culler or culler"
 
+Example:
+-- escape RegEx metacharacter using backslash
+put replaceText ( "ABC|DEV" , "\|" , CR )
+
 Parameters:
 stringToChange (string): A container reference or literal value.
 
@@ -56,11 +60,12 @@ need to make a case-insensitive comparison, use "(?i)" at the start of
 the <matchExpression> to make the match case-insensitive.)
 
 >*Note:* A number of characters in regular expressions have special
-> meanings and need to be escaped with back slashes For example period
-> (".") matches any character, so in order to replace period characters
-> with a <regular expression> use "\." . For more information on regular
-> expressions see the Perl documentation at 
-> http://perldoc.perl.org/perlre.html .
+> meanings and these need to be 'escaped' using backslashes ("\"). For example
+> period (".") matches any character, so in order to replace period characters
+> using a <regular expression> use "\.", to replace vertical bar characters ("|")
+> use "\|" and so on.
+> For more information on <regular expressions> see the Perl documentation  
+> at http://perldoc.perl.org/perlre.html .
 
 References: replace (command), filter (command), command (glossary),
 regular expression (glossary), property (glossary), string (keyword),

--- a/docs/notes/bugfix-20943.md
+++ b/docs/notes/bugfix-20943.md
@@ -1,0 +1,1 @@
+# Added explicit RegEx escape character use examples


### PR DESCRIPTION
• Expanded the Note information regarding escape characters needed in regular expressions match string.
• Added an Example script demonstrating the use of an escape character