### PR TITLE
[[ Bug 21623 ]] Fix height calcuation in takewindow

### DIFF
--- a/engine/src/osxstack.cpp
+++ b/engine/src/osxstack.cpp
@@ -131,7 +131,7 @@ void MCStack::setgeom()
 void MCStack::applyscroll(void)
 {
 	int32_t t_new_scroll;
-	t_new_scroll = getnextscroll();
+	t_new_scroll = getnextscroll(false);
 	
 	// If the scroll isn't changing, do nothing.
 	if (t_new_scroll == m_scroll)

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -723,7 +723,7 @@ public:
 	
 	// MW-2011-09-12: [[ MacScroll ]] The 'next' scroll setting (i.e. what it should be with
 	//   current menubar and such).
-	int32_t getnextscroll(void);
+	int32_t getnextscroll(bool p_ignore_opened);
 	// MW-2011-09-12: [[ MacScroll ]] Return the current scroll setting of the stack.
 	int32_t getscroll(void) const;
 	// MW-2011-09-12: [[ MacScroll ]] Apply any necessary scroll setting, based on current

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -552,7 +552,8 @@ Boolean MCStack::takewindow(MCStack *sptr)
     
     // sptr has not been closed so may still have a scroll while this stack has been closed
     // so has had clearscroll called on it so scroll will be 0. applyscroll is called later.
-    rect.height += sptr->getscroll();
+    rect.height += getnextscroll(true);
+    m_scroll = 0;
     
 	minwidth = sptr->minwidth;
 	minheight = sptr->minheight;
@@ -954,13 +955,13 @@ void MCStack::updatemenubar()
 
 // MW-2011-09-12: [[ MacScroll ]] Compute the scroll as it should be now taking
 //   into account the menubar and such.
-int32_t MCStack::getnextscroll()
+int32_t MCStack::getnextscroll(bool p_ignore_opened)
 {
 #ifdef _MACOSX
 	MCControl *mbptr;
 	if (!(state & CS_EDIT_MENUS) && hasmenubar()
 	        && (mbptr = curcard->getchild(CT_EXPRESSION, MCNameGetString(getmenubar()), CT_GROUP, CT_UNDEFINED)) != NULL
-	        && mbptr->getopened() && mbptr->isvisible())
+	        && (p_ignore_opened || mbptr->getopened()) && mbptr->isvisible())
 	{
 		MCRectangle r = mbptr->getrect();
 		return (r.y + r.height);

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1140,7 +1140,7 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
 
 		// MW-2011-09-12: [[ MacScroll ]] Use 'getnextscroll()' to see if anything needs
 		//   changing on that score.
-		if (oldscroll != getnextscroll())
+		if (oldscroll != getnextscroll(false))
 		{
 			setgeom();
 			updatemenubar();


### PR DESCRIPTION
This patch ensures the height of the stack is set to the height of the target
stack + the scroll of the stack and that `m_scroll` is set to 0. This ensures
that when `applyscroll` is called the stack ends up at the same height as the
target stack.