### PR TITLE
[[ Bug 20917 ]] Fix display of <> in markdown

### DIFF
--- a/docs/glossary/u/URL-scheme.lcdoc
+++ b/docs/glossary/u/URL-scheme.lcdoc
@@ -5,9 +5,9 @@ Synonyms: scheme, url scheme
 Type: glossary
 
 Description:
-A type of `<URL>`, specified by the part of the `<URL>` before the "://".
-URL schemes supported by LiveCode include `<http>`, `<ftp>`, `<file>`,
-`<resfile>`, and `<binfile>`.
+A type of <URL(glossary)>, specified by the part of the <URL(glossary)> before the "://".
+<URL(glossary)> schemes supported by LiveCode include <http(keyword)>, <ftp(keyword)>, <file(keyword)>,
+<resfile(keyword)>, and <binfile(keyword)>.
 
 References: URL (glossary), FTP (glossary), file (glossary),
 binfile (keyword), HTTP (glossary), resfile (keyword)

--- a/docs/glossary/u/URL-scheme.lcdoc
+++ b/docs/glossary/u/URL-scheme.lcdoc
@@ -5,9 +5,9 @@ Synonyms: scheme, url scheme
 Type: glossary
 
 Description:
-A type of <URL>, specified by the part of the <URL> before the "://".
-URL schemes supported by LiveCode include <http>, <ftp>, <file>,
-<resfile>, and <binfile>.
+A type of `<URL>`, specified by the part of the `<URL>` before the "://".
+URL schemes supported by LiveCode include `<http>`, `<ftp>`, `<file>`,
+`<resfile>`, and `<binfile>`.
 
 References: URL (glossary), FTP (glossary), file (glossary),
 binfile (keyword), HTTP (glossary), resfile (keyword)

--- a/docs/notes/bugfix-20917.md
+++ b/docs/notes/bugfix-20917.md
@@ -1,0 +1,1 @@
+# Fixed broken links in "URL scheme" entry


### PR DESCRIPTION
I chose to escape the instances of <> with code.