### PR TITLE
[[ Bug 21624 ]] Fix blendlevel + disabled button issue for Motif

### DIFF
--- a/docs/notes/bugfix-21624.md
+++ b/docs/notes/bugfix-21624.md
@@ -1,0 +1,1 @@
+# Fix rendering issues in Motif appearance (default for iOS, Android and HTML5) when a button is disabled and has a non-zero blendlevel

--- a/engine/src/buttondraw.cpp
+++ b/engine/src/buttondraw.cpp
@@ -580,9 +580,6 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
                 drawdirectionaltext(dc, rect.x + leftmargin, starty, t_name, m_font);
 			}
 			
-			if (t_use_alpha_layer)
-				dc->end();
-
 			// MW-2012-01-27: [[ Bug 9432 ]] Native GTK handles focus borders itself
 			//   so don't render the win95-style one.
 			if (MClook == LF_WIN95 && !IsNativeGTK() && state & CS_KFOCUSED && !(flags & F_AUTO_ARM) && !white)
@@ -627,6 +624,12 @@ void MCButton::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 
 			}
 		}
+        
+        if (t_use_alpha_layer)
+        {
+            dc->end();
+        }
+        
 		if (flags & F_DISABLED && MClook == LF_MOTIF)
 			dc->setfillstyle(FillSolid, nil, 0 , 0);
 		if (indicator && !(flags & F_SHOW_ICON)


### PR DESCRIPTION
This patch fixes an issue where we begin a layer but do not end it because
the call to `dc->end()` is only called when a label is being shown for the
button. The fix is to move the call out of that code block. It is safe to
do so as the only code after it is for Win 95 appearance.