### PR TITLE
[[ Bug 21608 ]] Remove second break wait from invoke handler block

### DIFF
--- a/docs/notes/bugfix-21608.md
+++ b/docs/notes/bugfix-21608.md
@@ -1,0 +1,1 @@
+# Fix application lockup when invoking a handler from the browser widget on iOS 12

--- a/libbrowser/src/libbrowser_uiwebview.mm
+++ b/libbrowser/src/libbrowser_uiwebview.mm
@@ -416,9 +416,6 @@ bool MCUIWebViewBrowser::SyncJavaScriptHandlers(NSArray *p_handlers)
 				OnJavaScriptCall([p_handler cStringUsingEncoding: NSUTF8StringEncoding], t_args);
 
 				MCBrowserListRelease(t_args);
-				
-				// IM-2016-09-30: [[ Bug 18406 ]] Wake main thread to process handler call
-				MCBrowserRunloopBreakWait();
 			}
 		};
 	}


### PR DESCRIPTION
This patch removes the call to `MCBrowserRunloopBreakWait` as we are
already using the LCB `post` command which does `MCEngineRunloopBreakWait`.

On iOS 12 this second break wait causes an app lockup that has been hard
to diagnose. Perhaps breaking an `MCFiberDispatch` `pthread_cond_wait` that
should not be broken.