### PR TITLE
[[ Bug 21629 ]] Fix display update on iOS 12

### DIFF
--- a/docs/notes/bugfix-21629.md
+++ b/docs/notes/bugfix-21629.md
@@ -1,0 +1,1 @@
+# Fix display update issues on iOS 12 when not using accelerated rendering

--- a/engine/src/mbliphonegfx.mm
+++ b/engine/src/mbliphonegfx.mm
@@ -484,7 +484,6 @@ bool MCMacDoUpdateRegionCallback(void *p_context, const MCRectangle &p_rect)
 	
 	MCGRegionAddRegion(s_redraw_region, (MCGRegionRef)p_region);
 	MCRegionForEachRect(p_region, MCMacDoUpdateRegionCallback, self);
-	[[self layer] displayIfNeeded];
 }
 
 @end


### PR DESCRIPTION
This patch fixes an issue on iOS 12 where we were calling `displayIfNeeded`
to force the update of the CALayer of the main view. This initiates the
update process for a layer if it is currently marked as needing an update.
This method is documented as generally not needed and the preferred way is
to call `setNeedsDisplay`.

We already call `setNeedsDisplayInRect` on the view so should be able to
let the OS decide when to call `drawRect`. The issue on iOS 12 was that
the CALayer appeared to be redrawing the first image that had been rendered
to it and then in `drawRect` we were drawing only the updated regions over
that. This ofcourse looks very odd after changing cards etc. Why the initial
image is being retained is a mystery and quite likely a bug in iOS 12.