### PR TITLE
[Dctionary] read from file to reset

### DIFF
--- a/docs/dictionary/command/read-from-file.lcdoc
+++ b/docs/dictionary/command/read-from-file.lcdoc
@@ -32,7 +32,8 @@ Parameters:
 pathName:
 The pathName specifies the name and location of the file you want to
 read from. It must be the same as the path you used with the open file
-command.>*Important:* The pathName is case-sensitive, even on platforms
+command.
+>*Important:* The pathName is case-sensitive, even on platforms
 where file names are not case-sensitive. It must be exactly the
 same--including the case of characters--as the name you used with the
 open file command. If you specify the name of a serial port on Mac OS or
@@ -118,11 +119,11 @@ The <time> is the time to wait for the read to be completed, in
 <milliseconds>, seconds, or <ticks>.
 
 If you don't specify a <start>, LiveCode begins at the position
-determined by the <seek> <command>, or wherever the last <read from
-file> or <write to file> <command> to that <file> left off, or at the
-first <character>, if the <file> has not been accessed since being
-opened, or at the last <character>, if the <file> was opened in append
-mode. 
+determined by the <seek> <command>, or wherever the last 
+<read from file> or <write to file> <command> to that <file> left off, 
+or at the first <character>, if the <file> has not been accessed since 
+being opened, or at the last <character>, if the <file> was opened in 
+append mode. 
 
 The until <string> form reads data until the specified string is
 encountered. The until end, until EOF, and until empty forms are

--- a/docs/dictionary/command/record-pause.lcdoc
+++ b/docs/dictionary/command/record-pause.lcdoc
@@ -21,8 +21,8 @@ end if
 Description:
 Use the <record pause> command to pause a recording being made. 
 
-The <record pause> command pauses a recording started with the <record
-sound> command.
+The <record pause> command pauses a recording started with the 
+<record sound> command.
 
 The <recording> property remains true while a recording is paused.
 

--- a/docs/dictionary/command/record-resume.lcdoc
+++ b/docs/dictionary/command/record-resume.lcdoc
@@ -22,8 +22,8 @@ Description:
 Use the <record resume> command to resume a recording that has been
 paused. 
 
-The <record resume> command resumes a recording paused with the <record
-pause> command.
+The <record resume> command resumes a recording paused with the 
+<record pause> command.
 
 References: record pause (command), record sound (command),
 stop recording (command), recording (property)

--- a/docs/dictionary/command/record-sound.lcdoc
+++ b/docs/dictionary/command/record-sound.lcdoc
@@ -30,9 +30,9 @@ The result:
 >*Important:*  If the <recordFormat> is set to "movie", the resulting
 > <file> is in the <QuickTime> file format. <QuickTime> files cannot be
 > played as <audio clip|audio clips>. To play such a sound, either
-> create a <player> and set its <filename> <property> to the <file
-> path|path> of the <file> you recorded, or use the play videoclip form
-> of the play <command>.
+> create a <player> and set its <filename> <property> to the 
+> <file path|path> of the <file> you recorded, or use the play videoclip 
+> form of the play <command>.
 
 Description:
 Use the <record sound> <command> to record the user's speech, import
@@ -74,6 +74,7 @@ References: stop recording (command), recordLoudness (function),
 format (function), recordCompressionTypes (function), property (glossary),
 audio clip (glossary), file path (glossary), command (glossary),
 QuickTime (glossary), file (keyword), player (keyword),
+dontUseQT (property), dontUseQTEffects (property),
 filename (property), properties (property), recording (property),
 recordCompression (property), recordSampleSize (property),
 recordChannels (property), recordFormat (property),

--- a/docs/dictionary/command/record-sound.lcdoc
+++ b/docs/dictionary/command/record-sound.lcdoc
@@ -32,7 +32,7 @@ The result:
 > played as <audio clip|audio clips>. To play such a sound, either
 > create a <player> and set its <filename> <property> to the 
 > <file path|path> of the <file> you recorded, or use the play videoclip 
-> form of the play <command>.
+> form of the <play> <command>.
 
 Description:
 Use the <record sound> <command> to record the user's speech, import
@@ -70,7 +70,7 @@ longer supports any <QuickTime> features and setting the <dontUseQT> and
 not include 64 bit support and therefore can not be supported on OS X 64
 bit builds of LiveCode.
 
-References: stop recording (command), recordLoudness (function),
+References: play (command), stop recording (command), recordLoudness (function),
 format (function), recordCompressionTypes (function), property (glossary),
 audio clip (glossary), file path (glossary), command (glossary),
 QuickTime (glossary), file (keyword), player (keyword),

--- a/docs/dictionary/command/remove-script.lcdoc
+++ b/docs/dictionary/command/remove-script.lcdoc
@@ -31,8 +31,8 @@ the <message path>.
 You can remove a script only if it has previously been inserted in the
 message path with the <insert script> <command>. The <remove script>
 <command> does not affect <object|objects> that are normally in the
-<message path> or <script|scripts> that were placed in the <message
-path> with the <start using> <command>.
+<message path> or <script|scripts> that were placed in the 
+<message path> with the <start using> <command>.
 
 References: start using (command), stop using (command),
 insert script (command), backScripts (function), frontScripts (function),

--- a/docs/dictionary/command/reply.lcdoc
+++ b/docs/dictionary/command/reply.lcdoc
@@ -7,8 +7,8 @@ Syntax: reply <string> [with keyword <aeKeyword>]
 Syntax: reply error <string>
 
 Summary:
-<return|Returns> data to an application that sent LiveCode an <Apple
-event>. 
+<return|Returns> data to an application that sent LiveCode an 
+<Apple event>. 
 
 Introduced: 1.0
 
@@ -49,7 +49,7 @@ pieces you want to reply with.
 
 The form
 
-    reply <string> 
+    reply <string> &nbsp;
 
 is equivalent to
 

--- a/docs/dictionary/command/reply.lcdoc
+++ b/docs/dictionary/command/reply.lcdoc
@@ -49,20 +49,20 @@ pieces you want to reply with.
 
 The form
 
-    reply <string> &nbsp;
+    reply string
 
 is equivalent to
 
-    reply <string> with keyword "----"
+    reply string with keyword "----"
 
 
 The form
 
-    reply error <string> 
+    reply error string 
 
 is equivalent to
 
-    reply <string> with keyword "errs"
+    reply string with keyword "errs"
 
 
 For more information about Apple events, see Apple Computer's technical

--- a/docs/dictionary/command/request.lcdoc
+++ b/docs/dictionary/command/request.lcdoc
@@ -53,7 +53,7 @@ the eval <Apple event>.
 
 For more information about Apple events, see Apple Computer's technical
 documentation, Inside Macintosh: Interapplication Communication, located
-at http://developer.apple.com/techpubs/mac/IAC/IAC-2.html
+at [Apple's developer site](https://developer.apple.com/library/archive/documentation/mac/IAC/IAC-2.html)
 
 References: send to program (command), function (control structure),
 command (glossary), variable (glossary), Apple Event (glossary),

--- a/docs/dictionary/command/request.lcdoc
+++ b/docs/dictionary/command/request.lcdoc
@@ -53,8 +53,7 @@ the eval <Apple event>.
 
 For more information about Apple events, see Apple Computer's technical
 documentation, Inside Macintosh: Interapplication Communication, located
-at <a
-href="http://developer.apple.com/techpubs/mac/IAC/IAC-2.html">http://developer.apple.com/techpubs/mac/IAC/IAC-2.html</a>. 
+at http://developer.apple.com/techpubs/mac/IAC/IAC-2.html
 
 References: send to program (command), function (control structure),
 command (glossary), variable (glossary), Apple Event (glossary),

--- a/docs/dictionary/command/reset.lcdoc
+++ b/docs/dictionary/command/reset.lcdoc
@@ -29,17 +29,19 @@ Description:
 Use the <reset> <command> to change a <template> <object(glossary)> back
 to its <default|defaults> after you have changed it temporarily.
 
-Change the properties of template objects temporarily to easily create a
-number of objects of that type with the property settings you want.
+Change the <property|properties> of <template> <object|objects> temporarily 
+to easily create a number of <object|objects> of that type with the property 
+settings you want.
 
->*Note:* The LiveCode development environment makes changes to template
-> objects when it creates new objects. This means that objects you
-> create in the development environment may not have the same property
-> settings as objects you create in a standalone application.
+>*Note:* The LiveCode development environment makes changes to <template>
+> <object|objects> when it creates new <object|objects>. This means that 
+> <object|objects> you create in the development environment may not have the 
+> same property settings as <object|objects> you create in a 
+> <standalone application>.
 
 References: reset paint (command), object (glossary), template (glossary),
-default (glossary), command (glossary), return (glossary),
-templateScrollbar (keyword), default (keyword)
+default (glossary), command (glossary), property (glossary), return (glossary),
+standalone application (glossary), templateScrollbar (keyword), default (keyword)
 
 Tags: objects
 

--- a/docs/dictionary/command/reset.lcdoc
+++ b/docs/dictionary/command/reset.lcdoc
@@ -35,7 +35,7 @@ number of objects of that type with the property settings you want.
 >*Note:* The LiveCode development environment makes changes to template
 > objects when it creates new objects. This means that objects you
 > create in the development environment may not have the same property
-> settings as objects you create in a <a/>standalone application.
+> settings as objects you create in a standalone application.
 
 References: reset paint (command), object (glossary), template (glossary),
 default (glossary), command (glossary), return (glossary),

--- a/docs/dictionary/function/recordCompressionTypes.lcdoc
+++ b/docs/dictionary/function/recordCompressionTypes.lcdoc
@@ -27,11 +27,8 @@ Returns (enum):
 The <recordCompressionTypes> <function> <return|returns> a list of
 available audio <codec|codecs>, one per <line>. Each <line> consists of
 two <items> :
-
-        - the codec's name
-
-
--   the codec's four: character identifier
+- the codec's name
+- the codec's four: character identifier
 
 
 Description:

--- a/docs/dictionary/function/recordCompressionTypes.lcdoc
+++ b/docs/dictionary/function/recordCompressionTypes.lcdoc
@@ -28,7 +28,7 @@ The <recordCompressionTypes> <function> <return|returns> a list of
 available audio <codec|codecs>, one per <line>. Each <line> consists of
 two <items> :
 - the codec's name
-- the codec's four: character identifier
+- the codec's four-character identifier
 
 
 Description:

--- a/docs/dictionary/keyword/real4.lcdoc
+++ b/docs/dictionary/keyword/real4.lcdoc
@@ -21,9 +21,10 @@ read from file "image.gif" for 3 real4
 Description:
 Use the <real4> <keyword> to read data from a <binary file>.
 
-If you specify <real4> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each <chunk> read.
+If you specify <real4> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is 
+returned as a series of numbers separated by commas, one for each 
+<chunk> read.
 
 References: read from socket (command), read from process (command),
 write to driver (command), read from file (command), keyword (glossary),

--- a/docs/dictionary/keyword/real8.lcdoc
+++ b/docs/dictionary/keyword/real8.lcdoc
@@ -5,9 +5,9 @@ Type: keyword
 Syntax: real8
 
 Summary:
-Used with the <read from file>, <read from process>, and <read from
-socket> <command|commands> to signify a <chunk> of <binary file|binary
-data> the size of a signed 8- <byte> real.
+Used with the <read from file>, <read from process>, and 
+<read from socket> <command|commands> to signify a <chunk> of 
+<binary file|binary data> the size of a signed 8- <byte> real.
 
 Introduced: 1.0
 
@@ -24,9 +24,10 @@ read from file "Thing.jpg" for 12 real8
 Description:
 Use the <real8> <keyword> to read data from a <binary file>.
 
-If you specify <real8> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each <chunk> read.
+If you specify <real8> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is 
+returned as a series of numbers separated by commas, one for each 
+<chunk> read.
 
 References: read from socket (command), read from process (command),
 write to driver (command), read from file (command), keyword (glossary),

--- a/docs/dictionary/keyword/relative.lcdoc
+++ b/docs/dictionary/keyword/relative.lcdoc
@@ -23,9 +23,9 @@ Example:
 move image "Butterfly" relative 10,-10 - 10 pixels right and up
 
 Description:
-Use the <relative> <keyword> with the <read from file> and <write to
-file> <command|commands> to move within a <file>, or with the <move>
-<command> to move a <control> relative to its current location.
+Use the <relative> <keyword> with the <read from file> and 
+<write to file> <command|commands> to move within a <file>, or with 
+the <move> <command> to move a <control> relative to its current location.
 
 When used with the <seek> <command>, the <relative> <keyword> indicates
 how far to move the current position. If the number is positive, the

--- a/docs/dictionary/message/reloadStack.lcdoc
+++ b/docs/dictionary/message/reloadStack.lcdoc
@@ -35,9 +35,9 @@ second main stack with the same name.
 
 Description:
 Handle the <reloadStack> <message> when you want to prevent a stack from
-being reopened, or moderate conflicts between the names of <main
-stack|main stacks>, or prevent two <main stack|main stacks> with the
-same <name> from being open at one time.
+being reopened, or moderate conflicts between the names of 
+<main stack|main stacks>, or prevent two <main stack|main stacks> with 
+the same <name> from being open at one time.
 
 The opening of the stack is triggered by the <reloadStack> <message>.
 This means that <trap|trapping> the <reloadStack> <message> and not

--- a/docs/dictionary/property/recordFormat.lcdoc
+++ b/docs/dictionary/property/recordFormat.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: set the recordFormat to <fileFormat>
 
 Summary:
-Specifies the file format for sound files recorded with the <record
-sound> <command>.
+Specifies the file format for sound files recorded with the 
+<record sound> <command>.
 
 Introduced: 2.0
 
@@ -24,9 +24,9 @@ The result:
 >*Important:*  If the <recordFormat> is set to "movie", the resulting
 > file is in the <QuickTime> file format. <QuickTime> files cannot be
 > played as <audio clip|audio clips>. To play such a sound, either
-> create a <player> and set its <filename> <property> to the <file
-> path|path> of the <file> you recorded, or use the play videoclip form
-> of the <play> <command>.
+> create a <player> and set its <filename> <property> to the 
+> <file path|path> of the <file> you recorded, or use the play 
+> videoclip form of the <play> <command>.
 
 Value(string): The file format of the created recording.
 

--- a/docs/dictionary/property/recordInput.lcdoc
+++ b/docs/dictionary/property/recordInput.lcdoc
@@ -41,16 +41,17 @@ different <soundSource> is specified, that input device is used instead.
 
 The possible soundSources vary, depending on the QuickTime version
 installed and on the system's hardware configuration. QuickTime 3.0 and
-later supports the following: imic - records from the internal
-microphone emic -records from the external sound input jack cd - records
-from an internal CD player irca - records from an RCA input jack
-
-    tvfm - records from an FM radio tuner
-    idav - records from a DAV analog input port
-    mbay - records from a media-bay device
-    modm - records from the modem
-    zvpc - records from zoom video input
-    none - does not record.
+later supports the following: 
+- imic - records from the internal microphone 
+- emic -records from the external sound input jack 
+- cd - records from an internal CD player 
+- irca - records from an RCA input jack
+- tvfm - records from an FM radio tuner
+- idav - records from a DAV analog input port
+- mbay - records from a media-bay device
+- modm - records from the modem
+- zvpc - records from zoom video input
+- none - does not record.
 
 
 Changes:
@@ -64,5 +65,6 @@ bit builds of LiveCode.
 
 References: open driver (command), record sound (command),
 command (glossary), property (glossary), string (keyword),
+dontUseQT (property), dontUseQTEffects (property), 
 playDestination (property)
 

--- a/docs/dictionary/property/rectangle.lcdoc
+++ b/docs/dictionary/property/rectangle.lcdoc
@@ -38,21 +38,14 @@ The four items of an object's <rectangle> describe the
 <object|object's> left, top, right, and bottom edges:
 
 * The <left> is the number of <pixels> between the left edge of the 
-
 <stack window> and the leftmost pixel of the <object(glossary)>.
-
 * The <top> is the number of <pixels> between the top edge of the 
-
 <stack window> and the topmost pixel of the <object(glossary)>.
-
 * The <right> is the horizontal distance in <pixels> between the left 
-
 edge of the <stack window> and the rightmost pixel of the 
 <object(glossary)>.
-
 * The <bottom> is the vertical distance in <pixels> between the top
-  edge of the <stack window> and the bottommost pixel of the 
-
+edge of the <stack window> and the bottommost pixel of the 
 <object(glossary)>.
 
 >*Note:* The sides of an <object|object's> <rectangle> specify the
@@ -92,10 +85,8 @@ rectangle.
 >*Note:*As of version 6.0 the effective rect property of stacks returns 
 > the rect of the given stack with its decorations and frame taken into 
 > account. The effective rect of a stack can also be set. Here, the
-> rect 
-> of the frame of the stack will be set appropriately before setting
-> the 
-> rect of the stack.
+> rect of the frame of the stack will be set appropriately before setting
+> the rect of the stack.
 
 Changes:
 The use of the effective keyword with the rectangle property was 

--- a/docs/dictionary/property/relayerGroupedControls.lcdoc
+++ b/docs/dictionary/property/relayerGroupedControls.lcdoc
@@ -25,8 +25,8 @@ By default, the <relayerGroupedControls> <property> is set to false.
 
 Description:
 Use the <relayerGroupedControls> <property> to change the <layer> of
-<grouped control|grouped controls> without being in <group-editing
-mode>, or to move <control(object)|controls> out of a <group> by
+<grouped control|grouped controls> without being in 
+<group-editing mode>, or to move <control(object)|controls> out of a <group> by
 changing their <layer>.
 
 The <layer> of a control is its order on the <card>. If two

--- a/docs/dictionary/property/repeatCount.lcdoc
+++ b/docs/dictionary/property/repeatCount.lcdoc
@@ -22,9 +22,9 @@ Value:
 The <repeatCount> of an <image> is an <integer>.
 
 Description:
-Use the <repeatCount> <property> to specify how many times an <animated
-GIF> <image> should repeat when it's displayed, or to stop it from
-repeating. 
+Use the <repeatCount> <property> to specify how many times an 
+<animated GIF> <image> should repeat when it's displayed, or to stop 
+it from repeating. 
 
 If the <repeatCount> is positive, the <image> repeats the specified
 number of times. If the <repeatCount> is <negative>, the <image>

--- a/docs/dictionary/property/repeatRate.lcdoc
+++ b/docs/dictionary/property/repeatRate.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: set the repeatRate to <milliseconds>
 
 Summary:
-Specifies how long a <scrollbar> waits between repeats when the <mouse
-button> is held down.
+Specifies how long a <scrollbar> waits between repeats when the 
+<mouse button> is held down.
 
 Introduced: 1.0
 

--- a/docs/glossary/r/record-set.lcdoc
+++ b/docs/glossary/r/record-set.lcdoc
@@ -15,8 +15,8 @@ Deprecated:
 database cursor
 
 Description:
-In a <database>, the set of <record|records> returned by a <SQL
-query|query>. 
+In a <database>, the set of <record|records> returned by a 
+<SQL query|query>. 
 
 You can use commands in the <Database library> to move among the subset
 of <record|records> that makes up a record set.


### PR DESCRIPTION
command/read-from-file.lcdoc - Fixed broken links.
keyword/real4.lcdoc - Fixed broken link.
keyword/real8.lcdoc - Fixed broken link.
command/record-pause.lcdoc - Fixed broken link.
command/record-resume.lcdoc - Fixed broken link.
command/record-sound.lcdoc - Fixed broken link. Added missing references.
glossary/r/record-set.cldoc - Fixed broken link.
function/recordCompressionTypes.lcdoc - Reformatted list items. 
property/recordFormat.lcdoc - Fixed broken link.
property/recordInput.lcdoc - Reformatted list items. Added missing references.
property/rectangle.lcdoc - Reformatted list items.
property/relayerGroupedControls.lcdoc - Fixed broken link.
message/reloadStack.lcdoc - Fixed broken link.
command/remove-script.lcdoc - Fixed broken link.
property/repeatRate.lcdoc - Fixed broken link.
command/reply.lcdoc - Fixed broken link. Added non-breaking space in hope this would cause the `<string>` before it to be displayed in the same way as the others.
command/request.lcdoc - Removed extraneous html markdown from external link.
command/reset.lcdoc - Removed extraneous html(?).
