### PR TITLE
[Dictionary] reset paint to revDatabaseColumnTypes

### DIFF
--- a/docs/dictionary/command/reset-paint.lcdoc
+++ b/docs/dictionary/command/reset-paint.lcdoc
@@ -41,7 +41,7 @@ The <reset paint> <command> assigns the following <property>
 * The polySides <property> is set to 4.
 * The roundEnds <property> is set to false.
 * The slices <property> is set to 16.
-* The spray <property> is set to 31<a/>.
+* The spray <property> is set to 31.
 
 
 References: reset cursors (command), reset (command), revert (command),

--- a/docs/dictionary/command/revBrowserAddJavaScriptHandler.lcdoc
+++ b/docs/dictionary/command/revBrowserAddJavaScriptHandler.lcdoc
@@ -18,13 +18,13 @@ Security: network
 
 Example:
 local tBrowserID
-put revOpenBrowserCef(the windowId \
+put revBrowserOpenCef(the windowId \
       of this stack, "http://www.livecode.com" ) into tBrowserID
 revBrowserAddJavaScriptHandler tBrowserID, "myLiveCodeHandler"
 
 Parameters:
 instanceID:
-the ID of the browser instance returned by the revOpenBrowser function.
+the ID of the browser instance returned by the <revBrowserOpen> function.
 
 handlerName:
 the name of a LiveCode handler in the script of the card / stack
@@ -65,7 +65,7 @@ handler via the registered function:
 References: revBrowserStop (command), revBrowserPrint (command),
 revBrowserSet (command), revBrowserMakeTextBigger (command),
 revBrowserNavigate (command), revBrowserRemoveJavaScriptHandler (command),
-revBrowserClose (command), revBrowserOpenCef (function),
+revBrowserClose (command), revBrowserOpen (function), revBrowserOpenCef (function),
 browserOver (message), browserNewInstance (message),
 browserNewUrlWindow (message), browserDownloadRequest (message),
 browserNavigateCompleteFrame (message)

--- a/docs/dictionary/command/revBrowserAddJavaScriptHandler.lcdoc
+++ b/docs/dictionary/command/revBrowserAddJavaScriptHandler.lcdoc
@@ -44,9 +44,8 @@ any parameters given to the JavaScript function.
 A LiveCode card has the following handler:
 
     on myLiveCodeHandler pID, pArg1, pArg2
-
-    answer "Browser ID" && pID &&
-    "called myLiveCodeHandler with arguments" && pArg1 && "and" && pArg2
+        answer "Browser ID" && pID &&
+        "called myLiveCodeHandler with arguments" && pArg1 && "and" && pArg2
     end myLiveCodeHandler
 
 
@@ -60,8 +59,7 @@ handler via the registered function:
 
 
     if (tIsRevBrowser)
-
-    liveCode.myBrowserHandler(tValue1, tValue2);
+        liveCode.myBrowserHandler(tValue1, tValue2);
 
 
 References: revBrowserStop (command), revBrowserPrint (command),

--- a/docs/dictionary/command/revBrowserSet.lcdoc
+++ b/docs/dictionary/command/revBrowserSet.lcdoc
@@ -116,10 +116,10 @@ will move to that stack.
 For example, to toggle the resizable property of a stack hosting a
 browser use the following code:
 
-revBrowserSet pBrowserId, "windowId", 0
-set the resizable of stack pBrowserStack to pNewResizeableValue
-revBrowserSet pBrowserId, "windowId", the windowId of stack
-pBrowserStack 
+    revBrowserSet pBrowserId, "windowId", 0
+    set the resizable of stack pBrowserStack to pNewResizeableValue
+    revBrowserSet pBrowserId, "windowId", the windowId of stack
+    pBrowserStack 
 
 Cross Platform Caution: Due to a limitation in the current browser
 implementation, the behavior of the scrollbars property is slightly
@@ -129,33 +129,26 @@ revBrowser won't allow you to turn scrollbars back on. The way to work
 around this and create a browser that allows scrollbars to be toggled on
 both platforms is like this:
 
-local sBrowserId
+    local sBrowserId
 
-on browserOpen
-
-    put revBrowserOpen(the windowId \
+    on browserOpen
+        put revBrowserOpen(the windowId \
           of me, http://www.livecode.com) into sBrowserId
+        if the platform is MacOS then
+            send browserDisableScrollbars to me in 1 second
+        else
+            revBrowserSet sBrowserId, scrollbars, false
+        end if
+    end browserOpen
 
-    if the platform is MacOS then
-    send browserDisableScrollbars to me in 1 second
+    on browserDisableScrollbars
+        revBrowserSet sBrowserId, scrollbars, false
+    end browserDisableScrollbars
 
-    else
-    revBrowserSet sBrowserId, scrollbars, false
-
-    end if
-
-end browserOpen
-
-on browserDisableScrollbars
-
-    revBrowserSet sBrowserId, scrollbars, false
-
-end browserDisableScrollbars
-
-on browserToggleScrollbars
-
-    revBrowserSet sBrowserId, scrollbars, (not(revBrowserGet(sBrowserId,
-    scrollbars))) end browserToggleScrollbars
+    on browserToggleScrollbars
+        revBrowserSet sBrowserId, scrollbars, \
+          (not(revBrowserGet(sBrowserId, scrollbars))) 
+    end browserToggleScrollbars
 
 
 >*Note:*  For general information on using the browser library, see the

--- a/docs/dictionary/command/revCacheGeometry.lcdoc
+++ b/docs/dictionary/command/revCacheGeometry.lcdoc
@@ -24,7 +24,7 @@ if the rect of me is not savedRect then revCacheGeometry
 Description:
 Use the <revCacheGeometry> <command> to update the Geometry pane's
 internal settings, after changing the size or position of
-<control(object)|controls> that you have used the Geometry pane to
+<control|controls> that you have used the Geometry pane to
 specify behavior for.
 
 The <revCacheGeometry> <command> rebuilds the Geometry <pane|pane's>
@@ -41,7 +41,7 @@ normally updated automatically.
 Normally, you do not need to use the <revCacheGeometry> <command> at
 all, since LiveCode automatically updates the geometry settings when a
 <control> is moved or resized. However, if you move or resize
-<control(object)|controls> manually or in a <handler>, and the
+<control|controls> manually or in a <handler>, and the
 <resizeControl> or <moveControl> <message> is not sent, you may need to
 use the <revCacheGeometry> <command> to update the baseline positions.
 
@@ -68,7 +68,7 @@ group (glossary), standalone application (glossary), control (glossary),
 pane (glossary), command (glossary), Geometry library (library),
 library (library), moveControl (message), openBackground (message),
 startup (message), preOpenStack (message), openStack (message),
-resizeControl (message), preOpenCard (message), control (object)
+resizeControl (message), preOpenCard (message)
 
 Tags: ui
 

--- a/docs/dictionary/command/revCloseCursor.lcdoc
+++ b/docs/dictionary/command/revCloseCursor.lcdoc
@@ -5,7 +5,7 @@ Type: command
 Syntax: revCloseCursor <recordSetID>
 
 Summary:
-Closes a <record set (database cursor)(glossary)>.
+Closes a <redcord set|record set (database cursor)>.
 
 Associations: database library
 
@@ -32,8 +32,8 @@ The result:
 If the closure is not successful, the result is set to an error message.
 
 Description:
-Use the <revCloseCursor> <command> to clean up after using a <record set
-(database cursor)|record set> in a <database>.
+Use the <revCloseCursor> <command> to clean up after using a 
+<record set> in a <database>.
 
 All open record sets are closed automatically when the database they are
 associated with is closed. However, it is recommended practice to
@@ -53,7 +53,7 @@ revdb_disconnect (function), revQueryDatabase (function),
 revDataFromQuery (function), revdb_closecursor (function),
 Standalone Application Settings (glossary), database (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), command (glossary),
+record set (glossary), command (glossary),
 LiveCode custom library (glossary), Database library (library)
 
 Tags: database

--- a/docs/dictionary/command/revCloseDatabase.lcdoc
+++ b/docs/dictionary/command/revCloseDatabase.lcdoc
@@ -37,9 +37,8 @@ All open databases are closed automatically when the application quits.
 However, it is recommended practice to explicitly close database
 connections when your stack is finished with them.
 
-The <revCloseDatabase> <command> closes all open <record sets (database
-cursors)(glossary)> opened by the <database>, as well as closing the
-<database> itself.
+The <revCloseDatabase> <command> closes all open <record set|record sets> 
+opened by the <database>, as well as closing the <database> itself.
 
 >*Important:*  The <revCloseDatabase> <command> is part of the 
 > <Database library>. To ensure that the <command> works in a 
@@ -56,7 +55,7 @@ revdb_rollback (function), revDatabaseID (function),
 LiveCode custom library (glossary),
 Standalone Application Settings (glossary), database (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), command (glossary),
+record set (glossary), command (glossary),
 string (keyword), Database library (library)
 
 Tags: database

--- a/docs/dictionary/command/revCloseVideoGrabber.lcdoc
+++ b/docs/dictionary/command/revCloseVideoGrabber.lcdoc
@@ -37,8 +37,8 @@ memory it uses, when you're done.
 
 If your application uses video capture, you should execute the
 <revCloseVideoGrabber> <command> either when your application is
-finished using <video capture>, when the <stack> that uses <video
-capture> is closed (in a <closeStack> <handler>), or when your
+finished using <video capture>, when the <stack> that uses 
+<video capture> is closed (in a <closeStack> <handler>), or when your
 application quits (in a <shutdown> <handler>).
 
 If the video grabber was already recording video to a file, the

--- a/docs/dictionary/command/revCopyFile.lcdoc
+++ b/docs/dictionary/command/revCopyFile.lcdoc
@@ -50,8 +50,7 @@ another <folder>.
 You can also copy a file using the put <command>, in a <statement> like
 the following:
 
-    put URL "binfile:/Disk/myfile" into URL
-    "binfile:/Disk/Folder/myfile" 
+    put URL "binfile:/Disk/myfile" into URL "binfile:/Disk/Folder/myfile" 
 
 
 However, the <revCopyFile> <command> provides certain advantages. It
@@ -72,11 +71,11 @@ extremely large <file(function)|files> can be copied.
 > <handler>. 
 
 References: rename (command), answer file (command),
-create alias (command), function (control structure),
+create alias (command), function (control structure), result (function),
 application bundle (glossary), type signature (glossary), Unix (glossary),
 command (glossary), main stack (glossary), folder (glossary),
 file (glossary), return (glossary), group (glossary), message (glossary),
-statement (glossary), result (glossary), Mac OS (glossary),
+statement (glossary), Mac OS (glossary),
 shell (glossary), OS X (glossary), AppleScript (glossary),
 platform (glossary), application (glossary), resource fork (glossary),
 handler (glossary), Windows (glossary), resfile (keyword), file (keyword),
@@ -85,4 +84,3 @@ startup (message), openBackground (message), preOpenStack (message),
 openStack (message), preOpenCard (message)
 
 Tags: file system
-

--- a/docs/dictionary/command/revCopyFolder.lcdoc
+++ b/docs/dictionary/command/revCopyFolder.lcdoc
@@ -47,8 +47,8 @@ including all <file|files>, <subfolder|subfolders>, and their contents.
 The <folder> remains in its original location and the copy is placed in
 the new location.
 
->*Note:* When included in a <standalone application>, the <Common
-> library> is implemented as a hidden <group> and made available when
+>*Note:* When included in a <standalone application>, the <Common library>
+>  is implemented as a hidden <group> and made available when
 > the <group> receives its first <openBackground> message. During the
 > first part of the <application|application's> startup process, before
 > this <message> is sent, the <revCopyFolder> <command> is not yet
@@ -58,8 +58,8 @@ the new location.
 > <application> has finished starting up, the <library> is available and
 > the <revCopyFolder> <command> can be used in any <handler>.
 
->*Note:* To copy a bundle on Mac OS X systems, use the <revCopyFile
-> command> 
+>*Note:* To copy a bundle on Mac OS X systems, use the <revCopyFile>
+> command
 
 >*Note:* On Linux and OS X systems, folder paths can contain the tilde
 > (~) character, referring to the current user's home directory. Using
@@ -67,13 +67,14 @@ the new location.
 > replace the tilde with its literal value (eg /home/userName)
 
 References: create alias (command), revDeleteFolder (command),
-function (control structure), application (glossary), return (glossary),
+revCopyFile (command), function (control structure), result (function)
+application (glossary), return (glossary),
 standalone application (glossary), file (glossary), shell (glossary),
 handler (glossary), platform (glossary), command (glossary),
 Windows (glossary), main stack (glossary), OS X (glossary),
 AppleScript (glossary), group (glossary), result (glossary),
 Unix (glossary), message (glossary), folder (glossary),
 subfolder (glossary), Mac OS (glossary), Common library (library),
-revCopyFile command (library), library (library), startup (message),
+library (library), startup (message),
 openBackground (message), preOpenStack (message), openStack (message)
 

--- a/docs/dictionary/function/revBrowserOpen.lcdoc
+++ b/docs/dictionary/function/revBrowserOpen.lcdoc
@@ -48,9 +48,9 @@ The result:
 If successful this will be an integer browser instance id, if
 unsuccessful, the result will be empty. The browser library functions
 will throw an execution error if they encounter a problem. These can be
-caught by handling the <errorDialog> <message> or by using a <try / catch
-block>. In general there is no need to check the <result>, as nearly all
-the commands and functions put empty into it.
+caught by handling the <errorDialog> <message> or by using a 
+<try|try/catch block>. In general there is no need to check the <result>, 
+as nearly all the commands and functions put empty into it.
 
 Description:
 The <revBrowserOpen> function opens a new browser in the window with the
@@ -72,7 +72,7 @@ and this command now does nothing, but is still included to prevent
 legacy code causing script errors.
 
 There is a sample stack for revBrowser at the following location in the
-LiveCode folder: Resources/Examples/Browser Samper.rev. This stack
+LiveCode folder: Resources/Examples/Browser Sampler.rev. This stack
 demonstrates, with many examples, how to use browser objects in an
 application. 
 
@@ -119,7 +119,7 @@ References: revBrowserStop (command), revBrowserPrint (command),
 revBrowserSet (command), revBrowserMakeTextBigger (command),
 revBrowserNavigate (command), XBrowser_Init (command),
 XBrowser_Focus (command), revBrowserClose (command),
-try / catch block (control structure), result (function),
+try (control structure), result (function),
 browserOver (message), browserNewInstance (message),
 browserNewUrlWindow (message), browserDownloadRequest (message),
 errorDialog (message), message (glossary), browserNavigateCompleteFrame (message)

--- a/docs/dictionary/function/revCurrentRecord.lcdoc
+++ b/docs/dictionary/function/revCurrentRecord.lcdoc
@@ -7,8 +7,8 @@ Type: function
 Syntax: revCurrentRecord(<recordSetID>)
 
 Summary:
-<return|Returns> the number of the current record in a <record set
-(database cursor)(glossary)>.
+<return|Returns> the number of the current record in a 
+<record set>.
 
 Associations: database library
 
@@ -72,6 +72,6 @@ revDatabaseColumnNumbered (function), revdb_movenext (function),
 LiveCode custom library (glossary),
 Standalone Application Settings (glossary), record (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 string (keyword), Database library (library)
 

--- a/docs/dictionary/function/revCurrentRecordIsFirst.lcdoc
+++ b/docs/dictionary/function/revCurrentRecordIsFirst.lcdoc
@@ -6,7 +6,7 @@ Syntax: revCurrentRecordIsFirst(<recordSetID>)
 
 Summary:
 <return|Returns> whether the current <record> is the first <record> in a
-<record set (database cursor)(glossary)>.
+<record set (glossary)>.
 
 Associations: database library
 
@@ -59,7 +59,7 @@ revdb_movelast (function), revQueryIsAtStart (function),
 revdb_movenext (function), LiveCode custom library (glossary),
 record (glossary), Standalone Application Settings (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 string (keyword), Database library (library)
 
 Tags: database

--- a/docs/dictionary/function/revCurrentRecordIsLast.lcdoc
+++ b/docs/dictionary/function/revCurrentRecordIsLast.lcdoc
@@ -6,7 +6,7 @@ Syntax: revCurrentRecordIsLast(<recordSetID>)
 
 Summary:
 <return|Returns> whether the current <record> is the last <record> in a
-<record set (database cursor)(glossary)>.
+<record set (glossary)>.
 
 Associations: database library
 
@@ -59,7 +59,7 @@ revdb_movelast (function), revdb_movenext (function),
 LiveCode custom library (glossary), record (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 string (keyword), Database library (library)
 
 Tags: database

--- a/docs/dictionary/function/revDatabaseColumnCount.lcdoc
+++ b/docs/dictionary/function/revDatabaseColumnCount.lcdoc
@@ -8,7 +8,7 @@ Syntax: revDatabaseColumnCount(<recordSetID>)
 
 Summary:
 <return|Returns> the number of <database field|database fields> in a
-<record set (database cursor)(glossary)>.
+<record set (glossary)>.
 
 Associations: database library
 
@@ -37,8 +37,8 @@ The <revDatabaseColumnCount> <function> returns either positive
 
 Description:
 Use the <revDatabaseColumnCount> <function> to find out how many
-<database field|database fields> you must deal with in a <record set
-(database cursor)(glossary)>.
+<database field|database fields> you must deal with in a 
+<record set (glossary)>.
 
 If the operation is not successful, the <revDatabaseColumnCount>
 <function> returns an error message that begins with the <string>
@@ -67,7 +67,7 @@ revDatabaseColumnNames (function), revDatabaseColumnNumbered (function),
 LiveCode custom library (glossary), database field (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 string (keyword), integer (keyword), Database library (library)
 
 Tags: database

--- a/docs/dictionary/function/revDatabaseColumnLengths.lcdoc
+++ b/docs/dictionary/function/revDatabaseColumnLengths.lcdoc
@@ -7,8 +7,7 @@ Type: function
 Syntax: revDatabaseColumnLengths(<recordSetID>)
 
 Summary:
-<return|Returns> the maximum field sizes in a <record set (database
-cursor)(glossary)>. 
+<return|Returns> the maximum field sizes in a <record set (glossary)>. 
 
 Associations: database library
 
@@ -61,7 +60,7 @@ revDatabaseColumnIsNull (function), revDatabaseColumnNumbered (function),
 LiveCode custom library (glossary),
 Standalone Application Settings (glossary), database field (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 string (keyword), Database library (library)
 
 Tags: database

--- a/docs/dictionary/function/revDatabaseColumnNamed.lcdoc
+++ b/docs/dictionary/function/revDatabaseColumnNamed.lcdoc
@@ -45,8 +45,8 @@ if successful, an error string otherwise.
 
 Description:
 Use the <revDatabaseColumnNamed> <function> to obtain the contents of a
-given <database field>, in the current <record> of the specified <record
-set (database cursor)(glossary)>.
+given <database field>, in the current <record> of the specified 
+<record set (glossary)>.
 
 If you specify a <holderVariable>, the data is placed in that
 <variable>. Otherwise, the data is <return|returned> by the <function>.
@@ -75,7 +75,7 @@ References: function (control structure),
 revDatabaseColumnNames (function), revDatabaseColumnLengths (function),
 revDatabaseColumnNumbered (function), LiveCode custom library (glossary),
 return (glossary), variable (glossary), database (glossary),
-record set (database cursor) (glossary), record (glossary),
+record set (glossary), record (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), database field (glossary),
 string (keyword), Database library (library)

--- a/docs/dictionary/function/revDatabaseColumnNames.lcdoc
+++ b/docs/dictionary/function/revDatabaseColumnNames.lcdoc
@@ -44,9 +44,9 @@ The <revDatabaseColumnNames> <function> returns a list of <database
 field> names, separated by commas.
 
 Description:
-Use the <revDatabaseColumnNames> <function> to find out what <database
-field|database fields> are in the <record set (database cursor)|record
-set> returned by a <SQL query> or what database fields are contained
+Use the <revDatabaseColumnNames> <function> to find out what 
+<database field|database fields> are in the 
+<record set> returned by a <SQL query> or what database fields are contained
 within a certain table.
 
 There are two forms of the revDatabaseColumnNames function. It can
@@ -55,11 +55,11 @@ of version 2.9, the list of columns in a given table.
 
 To get the list of columns in a record set use a form like this:
 
-get revDatabaseColumnNames(tRecordSetId)
+    get revDatabaseColumnNames(tRecordSetId)
 
 To get the list of columns in a given table, use a form like this:
 
-get revDatabaseColumnNames(tConnectionId, "myTable")
+    get revDatabaseColumnNames(tConnectionId, "myTable")
 
 If the operation is not successful, the <revDatabaseColumnNames>
 <function> returns an error message that begins with the <string>
@@ -84,7 +84,7 @@ revDatabaseColumnTypes (function), revDatabaseColumnIsNull (function),
 LiveCode custom library (glossary), database field (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 SQL query (glossary), string (keyword), Database library (library)
 
 Tags: database

--- a/docs/dictionary/function/revDatabaseColumnNumbered.lcdoc
+++ b/docs/dictionary/function/revDatabaseColumnNumbered.lcdoc
@@ -52,7 +52,7 @@ that <variable>.
 Description:
 Use the <revDatabaseColumnNumbered> <function> to obtain the contents of
 a given <database field>, in the current <record> of the specified
-<record set (database cursor)(glossary)>.
+<record set>.
 
 If you specify a <holderVariable>, the data is placed in that
 <variable>. Otherwise, the data is <return|returned> by the <function>.
@@ -84,7 +84,7 @@ revDatabaseColumnCount (function), revCurrentRecord (function),
 revDatabaseColumnNamed (function), revDatabaseColumnLengths (function),
 revDatabaseColumnIsNull (function), LiveCode custom library (glossary),
 return (glossary), variable (glossary),
-record set (database cursor) (glossary), record (glossary),
+record set (glossary), record (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), database field (glossary),
 string (keyword), Database library (library)

--- a/docs/dictionary/function/revDatabaseColumnTypes.lcdoc
+++ b/docs/dictionary/function/revDatabaseColumnTypes.lcdoc
@@ -7,8 +7,7 @@ Type: function
 Syntax: revDatabaseColumnTypes(<recordSetID>)
 
 Summary:
-<return|Returns> the data types of the columns in a <record set
-(database cursor)(glossary)>.
+<return|Returns> the data types of the columns in a <record set>.
 
 Associations: database library
 
@@ -35,8 +34,7 @@ was created.
 
 Returns:
 The <revDatabaseColumnTypes> <function> returns a list of data types,
-one for each <column> in the <record set (database cursor)|record set>,
-separated by commas.
+one for each <column> in the <record set>, separated by commas.
 
 Description:
 Use the <revDatabaseColumnTypes> <function> to find out the data type of
@@ -83,7 +81,7 @@ References: function (control structure),
 revDatabaseColumnNames (function), revDatabaseColumnLengths (function),
 revDatabaseType (function), LiveCode custom library (glossary),
 return (glossary), binary file (glossary),
-record set (database cursor) (glossary),
+record set (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), column (glossary),
 database field (glossary), BLOB (glossary), field (keyword),

--- a/docs/dictionary/keyword/resfile.lcdoc
+++ b/docs/dictionary/keyword/resfile.lcdoc
@@ -22,8 +22,8 @@ put tResForkData into URL "resfile:MyFile"
 
 
 Description:
-Use the <resfile> <keyword> to work with <Mac OS> <resource
-fork|resource forks>.
+Use the <resfile> <keyword> to work with <Mac OS> 
+<resource fork|resource forks>.
 
 On Mac OS systems, files consist of either or both of a <data fork> and
 a <resource fork>. The resource fork contains defined resources such as


### PR DESCRIPTION
command/reset-paint.lcdoc - Removed extraneous HTML.
keyword/resfile.lcdoc - Fixed broken link.
command/revBrowserAddJavaScriptHandler.lcdoc - Reformatted code examples.
function/revBrowserOpen.lcdoc - Fixed broken link and changed associated reference.
command/revBrowserSet.lcdoc - Reformatted code examples.
dictionary/command/revCacheGeometry.lcdoc - Removed all reference to `control (object)` because it doesn’t exist.
command/revCloseCursor.lcdoc - Fixed broken link and changed associated reference.
command/revCloseDatabase.lcdoc - Fixed broken link and changed associated reference.
command/revCloseVideoGrabber.lcdoc - Fixed broken link.
command/revCopyFile.lcdoc - Changed type of result reference.
command/revCopyFolder.lcdoc - Changed type of result reference. Fixed broken link and change one’s associated reference.
function/revCurrentRecord.lcdoc - Fixed broken link and changed associated reference.
function/revCurrentRecordIsFirst.lcdoc - Fixed broken link and changed associated reference.
function/revCurrentRecordIsLast.lcdoc - Fixed broken link and changed associated reference.
function/revDatabaseColumnCount.lcdoc - Fixed broken link and changed associated reference.
function/revDatabaseColumnLengths.lcdoc - Fixed broken link and changed associated reference.
function/revDatabaseColumnNamed.lcdoc - Fixed broken link and changed associated reference.
function/revDatabaseColumnNames.lcdoc - Fixed broken links and changed one’s associated reference.
function/revDatabaseColumnNumbered.lcdoc - Fixed broken link and changed associated reference.
function/revDatabaseColumnTypes.lcdoc - Fixed broken link and changed associated reference.