### PR TITLE
[[ Bug 21474 ]] Reset mouse stack after drag and drop

### DIFF
--- a/docs/notes/bugfix-21474.md
+++ b/docs/notes/bugfix-21474.md
@@ -1,0 +1,1 @@
+# Fix unresponsive stack after drag and drop

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1705,7 +1705,7 @@ MCDragAction MCDispatch::wmdragdrop(Window w)
 		dodrop(false);
 
     // The drag operation has ended. Remove the drag board contents.
-	MCmousestackptr = nil;
+    MCmousestackptr = findstackd(w);
     MCdragboard->Clear();
 	m_drag_target = false;
 


### PR DESCRIPTION
This patch resolves an issue where after a drag and drop operation the mouse stack
was being cleared in `wmdragdrop`. This resulted in a seemingly unresponsive stack
as mouse events are guarded by `MCmousestackptr`. As `wmdragdrop` is only called when
a window recieves a drag drop event we can ensure the mouse stack is correct by finding
the stack for the window and setting it to that.