### PR TITLE
[17751] Correct the loc of option menus triggered by a popup stack

### DIFF
--- a/docs/notes/bugfix-17751.md
+++ b/docs/notes/bugfix-17751.md
@@ -1,0 +1,1 @@
+# Correct the loc of option menus and pulldown menus triggered by a popup stack

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -384,7 +384,7 @@ void MCButton::macopenmenu(void)
 			tmenuy = trect.y+trect.height + 1;
 			break;
 		case WM_CASCADE:
-			trect = MCU_recttoroot(MCmousestackptr, rect);
+			trect = MCU_recttoroot(getstack(), rect);
 			tmenux = trect.x + trect.width + 1;
 			tmenuy = trect.y;
 			break;

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -374,12 +374,12 @@ void MCButton::macopenmenu(void)
 	{
 		case WM_COMBO:
 		case WM_OPTION:
-			trect = MCU_recttoroot(MCmousestackptr, rect);
+			trect = MCU_recttoroot(getstack(), rect);
 			tmenux = trect.x;
 			tmenuy = trect.y;
 			break;
 		case WM_PULLDOWN:
-			trect = MCU_recttoroot(MCmousestackptr, rect);
+			trect = MCU_recttoroot(getstack(), rect);
 			tmenux = trect.x;
 			tmenuy = trect.y+trect.height + 1;
 			break;


### PR DESCRIPTION
Scenario:

Stack A calls `popup stack B` and stack B has (1) an option menu and (2) a pulldown menu button. Previously if you clicked on (1) or (2) in the popped stack B, the menu appeared as if the buttons were on stack A (i.e. relatively to stack A).

This patch ensures that the menus appear relatively to the stack they live in.