### PR TITLE
[11794] Fix crash on iOS in a special case of 'hide this stack with visual ..'

### DIFF
--- a/docs/notes/bugfix-11794.md
+++ b/docs/notes/bugfix-11794.md
@@ -1,0 +1,1 @@
+# Fix crash on iOS when calling `hide this stack with visual .. ` and the stack's name is `with`

--- a/engine/src/mbliphonestack.mm
+++ b/engine/src/mbliphonestack.mm
@@ -272,6 +272,12 @@ extern bool MCGImageToCGImage(MCGImageRef p_src, const MCGIntegerRectangle &p_sr
 // IM-2013-07-18: [[ ResIndependence ]] added scale parameter to support hi-res images
 static bool MCGImageToUIImage(MCGImageRef p_image, bool p_copy, MCGFloat p_scale, UIImage *&r_uiimage)
 {
+   if (p_image == nil)
+    {
+        r_uiimage = nil;
+        return false;
+    }
+    
 	bool t_success = true;
 	
 	CGImageRef t_cg_image = nil;


### PR DESCRIPTION
In `MCStack::effectrect()`, in these lines:

```
snapshotwindow(t_effect_area);
ctxt . snapshot = m_snapshot;
MCIPhoneRunOnMainFiber(effectrect_phase_2, &ctxt);
```

`m_snapshot` is NULL after the call to `snapshotwindow ` (because in `snapshotwindow ` the window is invisible) thus in `effectrect_phase_2`, when `MCGImageToUIImage` is called, `ctxt -> snapshot` is NULL 