### PR TITLE
[[ Bug 21623 ]] Fix early window synchronize when taking window

### DIFF
--- a/engine/src/osxstack.cpp
+++ b/engine/src/osxstack.cpp
@@ -137,7 +137,10 @@ void MCStack::applyscroll(void)
 	if (t_new_scroll == m_scroll)
 		return;
 	
-	// Otherwise, set the scroll back to the unmolested version.
+    // dirty the current view
+	dirtyall();
+    
+    // Otherwise, set the scroll back to the unmolested version.
 	rect . height += m_scroll;
 	
 	// Update the scroll value.

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -2120,10 +2120,13 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
 		setparentstack(parentptr);
 	
 	// IM-2014-01-16: [[ StackScale ]] Ensure view has the current stack rect
-	view_setstackviewport(rect);
-	
-	if (window == NULL)
+	// If we have a window then set the viewport after opening to cover lockscreen
+    bool t_had_window = window != NULL;
+	if (!t_had_window)
+    {
+        view_setstackviewport(rect);
 		createwindow();
+    }
 
 	if (substacks != NULL)
 		opened++;
@@ -2131,7 +2134,12 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
 	{
 		MCObject::open();
 	}
-
+    
+    if (t_had_window)
+    {
+        view_setstackviewport(rect);
+    }
+    
 	MCRectangle trect;
 	switch (mode)
 	{


### PR DESCRIPTION
This patch fixes an issue when opening a stack in another stack's
window. The call to `view_setstackviewport` before the stack's opened
value is incremented was causing `view_setgeom` to ignore the screen
lock. Additionally, this patch adds a call to `dirtyall` before stack
scroll is applied. This is allows the region that is to be scrolled
to redraw correctly.