### PR TITLE
[[ Bug 21617 ]] Fix emscripten loading capsule from file

### DIFF
--- a/docs/notes/bugfix-21617.md
+++ b/docs/notes/bugfix-21617.md
@@ -1,0 +1,1 @@
+# Fix failure to load HTML5 standalones when mainstack is greater than 1MB

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -724,7 +724,7 @@ MCDispatch::startup()
 		return IO_ERROR;
 	}
 	
-	if (!MCCapsuleFillFromFile(t_capsule, MCSTR(kMCEmscriptenStartupCapsuleFilename), 4, false))
+	if (!MCCapsuleFillFromFile(t_capsule, MCSTR(kMCEmscriptenStartupCapsuleFilename), 4, true))
 	{
 		MCresult->sets("failed to read startup data file");
 		MCCapsuleClose(t_capsule);


### PR DESCRIPTION
This patch fixes the call to `MCCapsuleFillFromFile` so that the capsule
is not expecting more buckets of data after the file has been loaded. This
was causing standalones to fail to load when greater than 1MB.