### PR TITLE
[[ TreeView ]] Get/Set Fold State

### DIFF
--- a/extensions/widgets/treeview/notes/feature-fold_state.md
+++ b/extensions/widgets/treeview/notes/feature-fold_state.md
@@ -1,0 +1,18 @@
+# Properties
+
+The tree view widget now has the ability to get and set the fold state.
+
+One property has been added to achieve this option:
+* **foldState**: array
+
+The fold state array is structured as follows:
+
+```
+	[key1]
+		["folded"]
+		["array"]
+			[subkey1]
+				["folded"]
+	[key2]
+		["folded"]
+```

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -110,10 +110,23 @@ Syntax: get the foldState of <widget>
 Summary: The fold state of the array being displayed by the widget
 
 Parameters:
-pFoldState (array): The fold state data.
+pFoldState (array): The fold state data.  See description for details.
 
 Description:
 The foldState is the fold state currently being displayed by the tree view widget.
+
+The fold state array only contains elements of the data array where the
+value is a subarray.  The value for each `folded` key must be a boolean.
+
+```
+	[key1]
+		["folded"]
+		["array"]
+			[subkey1]
+				["folded"]
+	[key2]
+		["folded"]
+```
 **/
 
 property foldState 					get getFoldState 				set setFoldState
@@ -1861,15 +1874,38 @@ private handler applyFoldState(in pLevel as Integer, in pStart as Integer, in pF
 			next repeat
 		end if
 	
-		// If user supplied fold state is invalid
-		if "folded" is not among the keys of pFoldState[tKey] or \
-				not(pFoldState[tKey]["folded"] is a boolean) then
-			next repeat
-		end if
-
 		applyFoldStateKey(tKey, pLevel, pStart, pFoldState[tKey], pArray[tKey], xList)
 	end repeat
 
+end handler
+
+private handler checkFoldState(inout pFoldState as Array) returns Boolean
+	if pFoldState is empty then
+		return true
+	end if
+	
+	variable tKey as String
+	variable tValue as String
+	repeat for each key tKey in pFoldState
+		if not (pFoldState[tKey] is an array) or \
+				"folded" is not among the keys of pFoldState[tKey] then
+			return false
+		end if
+		if not(pFoldState[tKey]["folded"] is a boolean) then
+			put pFoldState[tKey]["folded"] into tValue
+			delete pFoldState[tKey]["folded"]
+			if tValue is "true" then
+				put true into pFoldState[tKey]["folded"]
+			else
+				put false into pFoldState[tKey]["folded"]
+			end if
+		end if
+		if "array" is among the keys of pFoldState[tKey] and \
+				not checkFoldState(pFoldState[tKey]["array"]) then
+			return false
+		end if
+	end repeat
+	return true
 end handler
 
 private handler setRowBackgrounds(in pShowAlternateBackgrounds as Boolean) returns nothing
@@ -1891,6 +1927,9 @@ private handler setArrayData(in pData as Array) returns nothing
 end handler
 
 private handler setFoldState(in pData as Array) returns nothing
+	if not checkFoldState(pData) then
+		throw "Invalid fold state"
+	end if
 	put pData into mFoldState
 	put true into mUpdateDataList
 	redraw all

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -105,6 +105,21 @@ property arrayData 					get getArrayData 				set setArrayData
 metadata arrayData.label is "Array data"
 
 /**
+Syntax: set the foldState of <widget> to <pFoldState>
+Syntax: get the foldState of <widget>
+Summary: The fold state of the array being displayed by the widget
+
+Parameters:
+pFoldState (array): The fold state data.
+
+Description:
+The foldState is the fold state currently being displayed by the tree view widget.
+**/
+
+property foldState 					get getFoldState 				set setFoldState
+metadata foldState.user_visible is "false"
+
+/**
 Syntax: set the hilitedElement of <widget> to <pPath>
 Syntax: get the hilitedElement of <widget>
 
@@ -1361,6 +1376,10 @@ private handler getArrayData() returns Array
 	return mData
 end handler
 
+private handler getFoldState() returns Array
+	return mFoldState
+end handler
+
 -- Sorts numerically, converting strings to numbers where possible
 private handler CompareKeysNumeric(in pLeft as any, in pRight as any) returns Integer
 	variable tLeft as optional any
@@ -1842,6 +1861,12 @@ private handler applyFoldState(in pLevel as Integer, in pStart as Integer, in pF
 			next repeat
 		end if
 	
+		// If user supplied fold state is invalid
+		if "folded" is not among the keys of pFoldState[tKey] or \
+				not(pFoldState[tKey]["folded"] is a boolean) then
+			next repeat
+		end if
+
 		applyFoldStateKey(tKey, pLevel, pStart, pFoldState[tKey], pArray[tKey], xList)
 	end repeat
 
@@ -1861,6 +1886,12 @@ end handler
 // Replace the existing data wholesale with a new array pData
 private handler setArrayData(in pData as Array) returns nothing
 	put pData into mData
+	put true into mUpdateDataList
+	redraw all
+end handler
+
+private handler setFoldState(in pData as Array) returns nothing
+	put pData into mFoldState
 	put true into mUpdateDataList
 	redraw all
 end handler


### PR DESCRIPTION
Add `foldState` property to allow the full fold state to be retrieved
and managed via LCS.  This will allow arbitrary states to be saved and
restored along with the ability to clear the fold state.

Checks were added so that invalid data does not crash the widget.
If the `folded` key is missing for a key in the array, then it is skipped.
If a boolean is not set for the `folded` key value, then the value is
ignored.