### PR TITLE
Ensure "mailto:" works in the browser widget on iOS

### DIFF
--- a/libbrowser/src/libbrowser_uiwebview.mm
+++ b/libbrowser/src/libbrowser_uiwebview.mm
@@ -825,7 +825,7 @@ bool MCUIWebViewBrowser::Init(void)
 	
 	/* UNCHECKED */ MCCStringClone([request.URL.absoluteString cStringUsingEncoding: NSUTF8StringEncoding], t_url);
 	
-	if ([NSURLConnection canHandleRequest: request])
+    if ([NSURLConnection canHandleRequest: request] || MCCStringBeginsWith(t_url, "mailto:") )
 	{
 		if (!t_frame_request)
 			m_instance->OnNavigationBegin(false, t_url);


### PR DESCRIPTION
`canHandleRequest` returns false for requests with the `mailto:` scheme on WebViews, so this patch handles this case separately. Tested on an iPad.