### PR TITLE
revDatabaseCursors to revDeleteFolder

### DIFF
--- a/docs/dictionary/command/revDeleteFolder.lcdoc
+++ b/docs/dictionary/command/revDeleteFolder.lcdoc
@@ -46,27 +46,28 @@ On Mac OS and OS X systems, the <revDeleteFolder> <command> places the
 > should not rename or move <file|files> and <folder|folders> it didn't
 > create without obtaining explicit confirmation from the user.
 
->*Note:* When included in a <standalone application>, the <Common
-> library> is implemented as a hidden <group> and made available when
-> the <group> receives its first <openBackground> message. During the
-> first part of the <application|application's> startup process, before
-> this <message> is sent, the <revDeleteFolder> <command> is not yet
-> available. This may affect attempts to use this <command> in
-> <startup>, <preOpenStack>, <openStack>, or <preOpenCard>
-> <handler|handlers> in the <main stack>. Once the <application> has
-> finished starting up, the <library> is available and the
-> <revDeleteFolder> <command> can be used in any <handler>.
+>*Note:* When included in a <standalone application>, the 
+> <Common library> is implemented as a hidden <group> and made 
+> available when the <group> receives its first <openBackground> 
+> message. During the first part of the <application|application's> 
+> startup process, before this <message> is sent, the 
+> <revDeleteFolder> <command> is not yet available. This may affect
+> attempts to use this <command> in <startup>, <preOpenStack>, 
+> <openStack>, or <preOpenCard> <handler|handlers> in the 
+> <main stack>. Once the <application> has finished starting up, 
+> the <library> is available and the <revDeleteFolder> <command> 
+> can be used in any <handler>.
 
 References: revCopyFolder (command), create folder (command),
 answer folder (command), delete file (command), revMoveFolder (command),
-function (control structure), folders (function), application (glossary),
-return (glossary), standalone application (glossary), file (glossary),
-shell (glossary), subfolder (glossary), platform (glossary),
-command (glossary), Windows (glossary), main stack (glossary),
-OS X (glossary), AppleScript (glossary), group (glossary),
-result (glossary), Unix (glossary), Mac OS (glossary), folder (glossary),
-message (glossary), handler (glossary), Common library (library),
-library (library), startup (message), openBackground (message),
-preOpenStack (message), openStack (message), preOpenCard (message),
-stack (object)
+function (control structure), folders (function), result (function),
+application (glossary), return (glossary), 
+standalone application (glossary), file (glossary), shell (glossary), 
+subfolder (glossary), platform (glossary), command (glossary), 
+Windows (glossary), main stack (glossary), OS X (glossary), 
+AppleScript (glossary), group (glossary), Unix (glossary), 
+Mac OS (glossary), folder (glossary), message (glossary), 
+handler (glossary), Common library (library), library (library), 
+startup (message), openBackground (message), preOpenStack (message), 
+openStack (message), preOpenCard (message), stack (object)
 

--- a/docs/dictionary/function/revDataFromQuery.lcdoc
+++ b/docs/dictionary/function/revDataFromQuery.lcdoc
@@ -8,8 +8,8 @@ Syntax: revDataFromQuery([<columnDelim>],[<rowDelim>], <databaseID>, <SQLQuery> 
 
 Summary:
 Gets <record|records> from a <database> according to a <SQL query> and
-places the resulting data in a <variable>, without creating a <record
-set (database cursor)(glossary)>.
+places the resulting data in a <variable>, without creating a 
+<record set>.
 
 Associations: database library
 
@@ -67,18 +67,18 @@ It is convenient to use the <revDataFromQuery> <function>, instead of
 revQueryDatabase, when you want to obtain the data for use but don't
 need to retain a reference to the <record|records> that the data came
 from. The <revDataFromQuery> <function> executes the <SQLQuery>, gets
-the <record|records> found by the <SQL query|query>, closes the <record
-set (database cursor)|record set> created by the <SQL query|query>, and
-returns the data. Important:The <revDataFromQuery> function should not
-be used if any of the data being retrieved is binary, doing so will
-probably produce unexpected results. If you wish to use this function to
-return things like image data, the data should be encoded before being
-stored in the database, this could for example be done with the
-<base64Encode> <function>. Also remember to specify a columDelim and
-<rowDelim> that will not appear in the data. Alternatively, both these
-problems can be avoided by using the <revQueryDatabase> <function> to
-generate a record set, then using <revDatabaseColumnNamed> to retrieve
-each field individually.
+the <record|records> found by the <SQL query|query>, closes the 
+<record set> created by the <SQL query|query>, and returns the data. 
+>*Important*: The <revDataFromQuery> function should not
+> be used if any of the data being retrieved is binary, doing so will
+> probably produce unexpected results. If you wish to use this function to
+> return things like image data, the data should be encoded before being
+> stored in the database, this could for example be done with the
+> <base64Encode> <function>. Also remember to specify a columDelim and
+> <rowDelim> that will not appear in the data. Alternatively, both these
+> problems can be avoided by using the <revQueryDatabase> <function> to
+> generate a record set, then using <revDatabaseColumnNamed> to retrieve
+> each field individually.
 
 The <SQLQuery> may contain one or more placeholders, which are
 sequential numbers <prepend|prepended> by a colon. The
@@ -144,7 +144,7 @@ function (control structure), base64Encode (function), function (glossary),
 revQueryDatabase (function), revDatabaseColumnNamed (function),
 LiveCode custom library (glossary), return (glossary),
 variable (glossary), database (glossary),
-record set (database cursor) (glossary), record (glossary),
+record set (glossary), record (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), SQL query (glossary),
 delimit (glossary), prepend (glossary), string (keyword),

--- a/docs/dictionary/function/revDatabaseCursors.lcdoc
+++ b/docs/dictionary/function/revDatabaseCursors.lcdoc
@@ -7,8 +7,8 @@ Type: function
 Syntax: revDatabaseCursors(<databaseID>)
 
 Summary:
-<return|Returns> the <record set (database cursor)(glossary)> IDs
-associated with a connection to a <database>.
+<return|Returns> the <record set> IDs associated with a connection 
+to a <database>.
 
 Associations: database library
 
@@ -40,9 +40,8 @@ separated by commas.
 
 Description:
 Use the <revDatabaseCursors> <function> to perform an operation on each
-<record set (database cursor)|record set>, or to find out how many
-<record set (database cursor)|record sets> exist on a particular
-<database> connection.
+<record set>, or to find out how many <record set|record sets> exist 
+on a particular <database> connection.
 
 The record set IDs returned are those opened by the specified
 <databaseID>. 
@@ -61,9 +60,9 @@ The revDatabaseCursors synonym was added in version 2.0.
 
 References: revCloseCursor (command), function (control structure),
 Standalone Application Settings (glossary), database (glossary),
-standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
-LiveCode custom library (glossary), Database library (library)
+standalone application (glossary), record set (glossary), 
+return (glossary), LiveCode custom library (glossary), 
+Database library (library)
 
 Tags: database
 

--- a/docs/dictionary/function/revDatabaseID.lcdoc
+++ b/docs/dictionary/function/revDatabaseID.lcdoc
@@ -7,8 +7,8 @@ Type: function
 Syntax: revDatabaseID(<recordSetID>)
 
 Summary:
-<return|Returns> the database ID of the <database> that opened a <record
-set (database cursor)(glossary)>.
+<return|Returns> the database ID of the <database> that opened a 
+<record set>.
 
 Associations: database library
 
@@ -38,7 +38,7 @@ The <revDatabaseID> <function> returns a positive <integer>.
 
 Description:
 Use the <revDatabaseID> <function> to find out which <database> a
-<record set (database cursor)|record set> belongs to.
+<record set> belongs to.
 
 The returned value is the same as the value returned by the
 <revOpenDatabase> <function> when the <database> was first opened.
@@ -61,7 +61,7 @@ The revDatabaseID synonym was added in version 2.0.
 References: revCloseDatabase (command), function (control structure),
 revOpenDatabase (function), Standalone Application Settings (glossary),
 database (glossary), standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 LiveCode custom library (glossary), integer (keyword),
 Database library (library)
 

--- a/docs/dictionary/function/revDatabaseType.lcdoc
+++ b/docs/dictionary/function/revDatabaseType.lcdoc
@@ -53,8 +53,8 @@ perform different operations depending on what kind of database is being
 used. 
 
 You can use the <revDatabaseType> <function> to distinguish between
-different <database> types. For example, you may need to frame a <SQL
-query> differently depending on what type of <database> you are
+different <database> types. For example, you may need to frame a 
+<SQL query> differently depending on what type of <database> you are
 communicating with.
 
 >*Important:*  The <revDatabaseType> <function> is part of the 

--- a/docs/dictionary/function/revdb_closecursor.lcdoc
+++ b/docs/dictionary/function/revdb_closecursor.lcdoc
@@ -33,8 +33,8 @@ The <revdb_closecursor> <function> returns an error message if the
 closure is not successful. Otherwise, it returns empty.
 
 Description:
-Use the <revdb_closecursor> <function> to clean up after using a <record
-set (database cursor)(glossary)>.
+Use the <revdb_closecursor> <function> to clean up after using a 
+<record set>.
 
 Evaluating the <revdb_closecursor> <function> has the same effect as
 <execute|executing> the <revCloseCursor> <command>. The only difference
@@ -52,8 +52,8 @@ is that one is a <function call> and the other is a <command>.
 References: revCloseCursor (command), function (control structure),
 function call (glossary), Standalone Application Settings (glossary),
 command (glossary), standalone application (glossary), execute (glossary),
-record set (database cursor) (glossary),
-LiveCode custom library (glossary), Database library (library)
+record set (glossary), LiveCode custom library (glossary), 
+Database library (library)
 
 Tags: database
 

--- a/docs/dictionary/function/revdb_movefirst.lcdoc
+++ b/docs/dictionary/function/revdb_movefirst.lcdoc
@@ -23,13 +23,12 @@ revdb_movefirst(savedResults)
 Parameters:
 recordSetID:
 The number returned by the revQueryDatabase or revQueryDatabaseBLOB
-function when the record set (database cursor) was created.
+function when the record set was created.
 
 Returns:
 The <revdb_movefirst> <function> returns true if it successfully moved
 to the first <record>, false if it could not move to the first <record>
-because there are no <record|records> in the <record set (database
-cursor)|record set>.
+because there are no <record|records> in the <record set>.
 
 Description:
 Use the <revdb_movefirst> <function> to move around within the selected
@@ -53,7 +52,7 @@ References: revMoveToLastRecord (command), revMoveToFirstRecord (command),
 revMoveToNextRecord (command), function (control structure),
 revCurrentRecord (function), revCurrentRecordIsFirst (function),
 revCurrentRecordIsLast (function), LiveCode custom library (glossary),
-execute (glossary), record set (database cursor) (glossary),
+execute (glossary), record set (glossary),
 record (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), function call (glossary),
 command (glossary), Database library (library)

--- a/docs/dictionary/function/revdb_movelast.lcdoc
+++ b/docs/dictionary/function/revdb_movelast.lcdoc
@@ -23,13 +23,12 @@ revdb_movelast(mySearch)
 Parameters:
 recordSetID:
 The number returned by the revQueryDatabase or revQueryDatabaseBLOB
-function when the record set (database cursor) was created.
+function when the record set was created.
 
 Returns:
 The <revdb_movelast> <function> returns true if it successfully moved to
 the last <record>, false if it could not move to the last <record>
-because there are no <record|records> in the <record set (database
-cursor)|record set>.
+because there are no <record|records> in the <record set>.
 
 Description:
 Use the <revdb_movelast> <function> to move around within the selected
@@ -53,7 +52,7 @@ References: revMoveToLastRecord (command), revMoveToFirstRecord (command),
 revMoveToNextRecord (command), function (control structure),
 revCurrentRecord (function), revCurrentRecordIsFirst (function),
 revCurrentRecordIsLast (function), LiveCode custom library (glossary),
-execute (glossary), record set (database cursor) (glossary),
+execute (glossary), record set (glossary),
 record (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), function call (glossary),
 command (glossary), Database library (library)


### PR DESCRIPTION
function/revDatabaseCursors.lcdoc - Fixed broken links.
function/revDatabaseID.lcdoc - Fixed broken links.
function/revDatabaseType.lcdoc - Fixed broken links.
function/revDataFromQuery.lcdoc - Fixed broken links. Formatted Important note the way they typically are.
function/revdb_closecursor.lcdoc - Fixed broken links.
function/revdb_movefirst.lcdoc - Fixed broken links.
function/revdb_movelast.lcdoc - Fixed broken links.
command/revDeleteFolder.lcdoc - Fixed broken link. Changed type of `result` to appropriate type.