### PR TITLE
[21669] Ensure an error is thrown when Map API key is empty

### DIFF
--- a/docs/notes/bugfix-21669.md
+++ b/docs/notes/bugfix-21669.md
@@ -1,0 +1,1 @@
+# Ensure an error is thrown if no Map API key is specified

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -108,7 +108,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    dispatch "revIDEDeployAndroidInitialize" to stack "revDeployLibrary"
    
    -- If we're searching for inclusions, do it here 
-   local tConfirm
+   local tConfirm, tResult
    put true into tConfirm
    if pSettings["inclusions"] is "search" then 
       put false into tConfirm
@@ -122,8 +122,9 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    -- Make sure all dependencies are included
    revSBUpdateForDependencies "android", "armv6", , pSettings
    revSBEnsurePerExtensionSettings "android", pSettings
-   if the result is not empty then
-      return the result
+   put the result into tResult
+   if tResult is not empty then
+      throw tResult
    end if
    
    -- Manually remove built-in implementations from detected script library inclusions


### PR DESCRIPTION
This patch ensures an appropriate error is thrown - in this case:
```
Missing standalone settings for com.livecode.widget.native.map:
	Google Maps V2 API key
Please set on standalone inclusions pane
```