### PR TITLE
[[ Simple Case ]] Add local parameter to toLower & toUpper

### DIFF
--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -388,6 +388,7 @@ class MCSort : public MCStatement
 	Sort_type direction;
 	Sort_type format;
 	MCExpression *by;
+    MCAutoPointer<MCExpression> m_collateoptions;
 public:
 	MCSort()
 	{

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4129,7 +4129,7 @@ void MCInterfaceExecExportObjectToArray(MCExecContext& ctxt, MCObject *p_object,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef p_data, int p_type, Sort_type p_direction, int p_form, MCExpression *p_by, MCStringRef &r_output)
+bool MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef p_data, int p_type, Sort_type p_direction, int p_form, MCExpression *p_by, MCArrayRef p_collateoptions, MCStringRef &r_output)
 {
 	if (MCStringIsEmpty(p_data))
 	{
@@ -4175,7 +4175,7 @@ bool MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef p_data, int p
  	// of an MCAutoStringRefArray.
 	MCAutoArray<MCStringRef> t_sorted;
 	MCStringsExecSort(ctxt, p_direction, (Sort_type)p_form,
-	                  *t_chunks, t_item_count, p_by,
+	                  *t_chunks, t_item_count, p_by, p_collateoptions,
 	                  t_sorted . PtrRef(), t_sorted . SizeRef());
 	
 	// Build the output string
@@ -4204,27 +4204,27 @@ bool MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef p_data, int p
 }
 
 
-void MCInterfaceExecSortCardsOfStack(MCExecContext &ctxt, MCStack *p_target, bool p_ascending, int p_format, MCExpression *p_by, bool p_only_marked)
+void MCInterfaceExecSortCardsOfStack(MCExecContext &ctxt, MCStack *p_target, bool p_ascending, int p_format, MCExpression *p_by, bool p_only_marked, MCArrayRef p_collateoptions)
 {
 	if (p_target == nil)
 		p_target = MCdefaultstackptr;
 
-	if (!p_target->sort(ctxt, p_ascending ? ST_ASCENDING : ST_DESCENDING, (Sort_type)p_format, p_by, p_only_marked))
+	if (!p_target->sort(ctxt, p_ascending ? ST_ASCENDING : ST_DESCENDING, (Sort_type)p_format, p_by, p_only_marked, p_collateoptions))
 		ctxt . LegacyThrow(EE_SORT_CANTSORT);
 }
 
-void MCInterfaceExecSortField(MCExecContext &ctxt, MCObjectPtr p_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by)
+void MCInterfaceExecSortField(MCExecContext &ctxt, MCObjectPtr p_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by, MCArrayRef p_collateoptions)
 {
 	MCField *t_field =(MCField *)p_target . object;
-	if (t_field->sort(ctxt, p_target . part_id, (Chunk_term)p_chunk_type, p_ascending ? ST_ASCENDING : ST_DESCENDING, (Sort_type)p_format, p_by) != ES_NORMAL)
+	if (t_field->sort(ctxt, p_target . part_id, (Chunk_term)p_chunk_type, p_ascending ? ST_ASCENDING : ST_DESCENDING, (Sort_type)p_format, p_by, p_collateoptions) != ES_NORMAL)
 		ctxt . LegacyThrow(EE_SORT_CANTSORT);
 }
 
-void MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef& x_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by)
+void MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef& x_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by, MCArrayRef p_collateoptions)
 {
 	MCAutoStringRef t_sorted_string;
 
-	if (MCInterfaceExecSortContainer(ctxt, x_target, p_chunk_type, p_ascending ? ST_ASCENDING : ST_DESCENDING, p_format, p_by, &t_sorted_string))
+	if (MCInterfaceExecSortContainer(ctxt, x_target, p_chunk_type, p_ascending ? ST_ASCENDING : ST_DESCENDING, p_format, p_by, p_collateoptions, &t_sorted_string))
 	{
         MCValueAssign(x_target, *t_sorted_string);
 		return;

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -2300,41 +2300,6 @@ void MCStringsSortAddItem(MCExecContext &ctxt, MCSortnode *items, uint4 &nitems,
 	nitems++;
 }
 
-void MCStringsExecSortOld(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, MCStringRef *p_strings_array, uindex_t p_count, MCExpression *p_by, MCStringRef*& r_sorted_array, uindex_t& r_sorted_count)
-{
-	// OK-2008-12-11: [[Bug 7503]] - If there are 0 items in the string, don't carry out the search,
-	// this keeps the behavior consistent with previous versions of Revolution.
-	if (p_count < 1)
-	{
-        r_sorted_count = 0;
-        return;
-	}
-    
-	// Now we know the item count, we can allocate an array of MCSortnodes to store them.
-	MCAutoArray<MCSortnode> t_items;
-	t_items.Extend(p_count + 1);
-    uindex_t t_added = 0;
-    
-	// Next, populate the MCSortnodes with all the items to be sorted
-    for (uindex_t i = 0; i < p_count; i++)
-    {
-        MCStringsSortAddItem(ctxt, t_items . Ptr(), t_added, p_form, p_strings_array[i], p_by);
-        t_items[t_added - 1] . data = (void *)p_strings_array[i];
-    }
-
-    MCStringsSort(t_items . Ptr(), t_added, p_dir, p_form, ctxt . GetStringComparisonType());
-
-    MCAutoArray<MCStringRef> t_sorted;
-    
- 	for (uindex_t i = 0; i < t_added; i++)
-    {
-        t_sorted . Push((MCStringRef)t_items[i] . data);
-        MCValueRelease(t_items[i] . svalue);
-    }
-    
-    t_sorted . Take(r_sorted_array, r_sorted_count);
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef bool (*comparator_t)(void *context, uindex_t left, uindex_t right);

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -100,11 +100,23 @@ bool MCStringsSplit(MCStringRef p_string, MCStringRef p_separator, MCStringRef*&
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCStringsEvalToLower(MCExecContext& ctxt, MCStringRef p_string, MCStringRef& r_lower)
+void MCStringsEvalToLower(MCExecContext& ctxt, MCStringRef p_string, MCStringRef p_locale, MCStringRef& r_lower)
 {
+    
+    MCLocaleRef t_locale = nullptr;
+    if (p_locale != nullptr)
+    {
+        if (MCStringIsEmpty(p_locale) ||
+             !MCLocaleCreateWithName(p_locale, t_locale))
+        {
+            ctxt.LegacyThrow(EE_TOLOWER_BADLOCALE);
+            return;
+        }
+    }
+    
 	MCStringRef t_string = nil;
 	if (!MCStringMutableCopy(p_string, t_string) ||
-		!MCStringLowercase(t_string, kMCSystemLocale) ||
+		!MCStringLowercase(t_string, t_locale) ||
 		!MCStringCopyAndRelease(t_string, r_lower))
 	{
 		MCValueRelease(t_string);
@@ -112,11 +124,23 @@ void MCStringsEvalToLower(MCExecContext& ctxt, MCStringRef p_string, MCStringRef
 	}
 }
 
-void MCStringsEvalToUpper(MCExecContext& ctxt, MCStringRef p_string, MCStringRef& r_upper)
+void MCStringsEvalToUpper(MCExecContext& ctxt, MCStringRef p_string, MCStringRef p_locale, MCStringRef& r_upper)
 {
+    
+    MCLocaleRef t_locale = nullptr;
+    if (p_locale != nullptr)
+    {
+        if (MCStringIsEmpty(p_locale) ||
+            !MCLocaleCreateWithName(p_locale, t_locale))
+        {
+            ctxt.LegacyThrow(EE_TOUPPER_BADLOCALE);
+            return;
+        }
+    }
+    
 	MCStringRef t_string = nil;
 	if (!MCStringMutableCopy(p_string, t_string) ||
-		!MCStringUppercase(t_string, kMCSystemLocale) ||
+		!MCStringUppercase(t_string, t_locale) ||
 		!MCStringCopyAndRelease(t_string, r_upper))
 	{
 		MCValueRelease(t_string);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1978,8 +1978,8 @@ void MCFiltersEvalSHA1Digest(MCExecContext& ctxt, MCDataRef p_src, MCDataRef& r_
 
 ///////////
 
-void MCStringsEvalToLower(MCExecContext& ctxt, MCStringRef p_string, MCStringRef& r_lower);
-void MCStringsEvalToUpper(MCExecContext& ctxt, MCStringRef p_string, MCStringRef& r_lower);
+void MCStringsEvalToLower(MCExecContext& ctxt, MCStringRef p_string, MCStringRef p_locale, MCStringRef& r_lower);
+void MCStringsEvalToUpper(MCExecContext& ctxt, MCStringRef p_string, MCStringRef p_locale, MCStringRef& r_lower);
 
 void MCStringsEvalNumToChar(MCExecContext& ctxt, uinteger_t codepoint, MCValueRef& r_character);
 void MCStringsEvalNumToNativeChar(MCExecContext& ctxt, uinteger_t codepoint, MCStringRef& r_character);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2063,7 +2063,7 @@ void MCStringsExecFilterRegexIntoIt(MCExecContext& ctxt, MCStringRef p_source, M
 void MCStringsEvalIsAscii(MCExecContext& ctxt, MCValueRef p_string, bool& r_result);
 void MCStringsEvalIsNotAscii(MCExecContext& ctxt, MCValueRef p_string, bool& r_result);
 
-void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, MCStringRef *p_strings_array, uindex_t p_count, MCExpression *p_by, MCStringRef*& r_sorted_array, uindex_t& r_sorted_count);
+void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, MCStringRef *p_strings_array, uindex_t p_count, MCExpression *p_by, MCArrayRef p_collateoptions, MCStringRef*& r_sorted_array, uindex_t& r_sorted_count);
 
 void MCStringsEvalBidiDirection(MCExecContext& ctxt, MCStringRef p_string, MCStringRef& r_result);
 
@@ -2445,9 +2445,9 @@ void MCInterfaceExecExportImage(MCExecContext& ctxt, MCImage *p_target, int p_fo
 void MCInterfaceExecExportImageToFile(MCExecContext& ctxt, MCImage *p_target, int p_format, MCInterfaceImagePaletteSettings *p_palette, MCImageMetadata* p_metadata, MCStringRef p_filename, MCStringRef p_mask_filename);
 void MCInterfaceExecExportObjectToArray(MCExecContext& ctxt, MCObject *p_container, MCArrayRef& r_array);
 
-void MCInterfaceExecSortCardsOfStack(MCExecContext &ctxt, MCStack *p_target, bool p_ascending, int p_format, MCExpression *p_by, bool p_only_marked);
-void MCInterfaceExecSortField(MCExecContext &ctxt, MCObjectPtr p_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by);
-void MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef& x_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by);
+void MCInterfaceExecSortCardsOfStack(MCExecContext &ctxt, MCStack *p_target, bool p_ascending, int p_format, MCExpression *p_by, bool p_only_marked, MCArrayRef p_collateoptions);
+void MCInterfaceExecSortField(MCExecContext &ctxt, MCObjectPtr p_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by, MCArrayRef p_collateoptions);
+void MCInterfaceExecSortContainer(MCExecContext &ctxt, MCStringRef& x_target, int p_chunk_type, bool p_ascending, int p_format, MCExpression *p_by, MCArrayRef p_collateoptions);
 void MCInterfaceExecReplaceInField(MCExecContext& ctxt, MCStringRef p_pattern, MCStringRef p_replacement, MCObjectChunkPtr& p_container, bool p_preserve_styles);
 
 void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_tool);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2067,6 +2067,9 @@ void MCStringsExecSort(MCExecContext& ctxt, Sort_type p_dir, Sort_type p_form, M
 
 void MCStringsEvalBidiDirection(MCExecContext& ctxt, MCStringRef p_string, MCStringRef& r_result);
 
+void MCStringsParseCollateOptions(MCExecContext& ctxt, MCArrayRef p_options, MCUnicodeCollateOption& r_options, MCLocaleRef& r_locale);
+void MCStringsEvalCollate(MCExecContext& ctxt, MCStringRef p_left, MCStringRef p_right, MCArrayRef p_options, integer_t& r_result);
+
 void MCStringsEvalTextChunkByRange(MCExecContext& ctxt, MCStringRef p_source, Chunk_term p_chunk_type, integer_t p_first, integer_t p_last, bool p_eval_mutable, MCStringRef& x_string);
 void MCStringsEvalTextChunkByExpression(MCExecContext& ctxt, MCStringRef p_source, Chunk_term p_chunk_type, integer_t p_first, bool p_eval_mutable, MCStringRef &x_string);
 void MCStringsEvalTextChunkByOrdinal(MCExecContext& ctxt, MCStringRef p_source, Chunk_term p_chunk_type, Chunk_term p_ordinal_type, bool p_eval_mutable, MCStringRef& x_string);

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2791,6 +2791,9 @@ enum Exec_errors
     
     // {EE-0914} collate: bad options
     EE_COLLATE_BADOPTIONS,
+    
+    // {EE-0915} sort: bad options
+    EE_SORT_BADOPTIONS,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2777,6 +2777,11 @@ enum Exec_errors
     // {EE-0909} android permission: bad permission name
     EE_BAD_PERMISSION_NAME,
     
+    // {EE-0910} toLower: bad locale
+    EE_TOLOWER_BADLOCALE,
+    
+    // {EE-0911} toUpper: bad locale
+    EE_TOUPPER_BADLOCALE,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2782,6 +2782,15 @@ enum Exec_errors
     
     // {EE-0911} toUpper: bad locale
     EE_TOUPPER_BADLOCALE,
+    
+    // {EE-0912} collate: error in first parameter
+    EE_COLLATE_BADLEFT,
+    
+    // {EE-0913} collate: error in second parameter
+    EE_COLLATE_BADRIGHT,
+    
+    // {EE-0914} collate: bad options
+    EE_COLLATE_BADOPTIONS,
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -430,7 +430,7 @@ public:
 	Boolean find(MCExecContext &ctxt, uint4 cardid,
 	             Find_mode mode, MCStringRef, Boolean first);
 	Exec_stat sort(MCExecContext &ctxt, uint4 parid, Chunk_term type,
-	               Sort_type dir, Sort_type form, MCExpression *by);
+	               Sort_type dir, Sort_type form, MCExpression *by, MCArrayRef p_collateoptions);
 	// MW-2012-02-08: [[ Field Indices ]] The 'index' parameter, if non-nil, will contain
 	//   the 1-based index of the returned paragraph (i.e. the one si resides in).
 	MCParagraph *indextoparagraph(MCParagraph *top, findex_t &si, findex_t &ei, findex_t* index = nil);

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -2528,6 +2528,68 @@ MCMessageDigestFunc::eval_ctxt(MCExecContext &ctxt,
 
 ///////////////////////////////////////////////////////////////////////////////
 
+Parse_stat
+MCCollate::parse(MCScriptPoint &sp,
+                           Boolean the)
+{
+    MCExpression *t_params[MAX_EXP];
+    uint2 t_param_count = 0;
+    
+    if (getexps(sp, t_params, t_param_count) != PS_NORMAL ||
+        (t_param_count < 2))
+    {
+        /* Wrong number of parameters or some other probleem */
+        freeexps(t_params, t_param_count);
+        
+        MCperror->add(PE_COLLATE_BADPARAM, sp);
+        return PS_ERROR;
+    }
+    
+    m_left.Reset(t_params[0]);
+    m_right.Reset(t_params[1]);
+    
+    if (t_param_count > 2)
+    {
+        m_options.Reset(t_params[2]);
+    }
+    
+    return PS_NORMAL;
+}
+
+void
+MCCollate::eval_ctxt(MCExecContext &ctxt,
+                               MCExecValue &r_value)
+{
+    MCAutoStringRef t_left;
+    if (!ctxt.EvalExprAsStringRef(m_left.Get(), EE_COLLATE_BADLEFT, &t_left))
+    {
+        return;
+    }
+    
+    MCAutoStringRef t_right;
+    if (!ctxt.EvalExprAsStringRef(m_right.Get(), EE_COLLATE_BADRIGHT, &t_right))
+    {
+        return;
+    }
+    
+    MCAutoArrayRef t_options;
+    if (m_options && !ctxt.EvalExprAsArrayRef(m_options.Get(), EE_COLLATE_BADOPTIONS, &t_options))
+    {
+        return;
+    }
+    
+    integer_t t_value;
+    MCStringsEvalCollate(ctxt, *t_left, *t_right, *t_options, t_value);
+    
+    if (!ctxt.HasError())
+    {
+        r_value.int_value = t_value;
+        r_value.type = kMCExecValueTypeInt;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 #ifdef _TEST
 #include "test.h"
 

--- a/engine/src/funcs.h
+++ b/engine/src/funcs.h
@@ -2393,6 +2393,18 @@ public:
     virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
 };
 
+class MCCollate: public MCFunction
+{
+    MCAutoPointer<MCExpression> m_left;
+    MCAutoPointer<MCExpression> m_right;
+    MCAutoPointer<MCExpression> m_options;
+    
+public:
+    virtual ~MCCollate(void) {};
+    virtual Parse_stat parse(MCScriptPoint &sp, Boolean the);
+    virtual void eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value);
+};
+
 #endif
 
 

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -540,7 +540,8 @@ const LT factor_table[] =
         {"=", TT_BINOP, O_EQ},
         {">", TT_BINOP, O_GT},
         {">=", TT_BINOP, O_GE},
-        {"^", TT_BINOP, O_POW},	
+        {"^", TT_BINOP, O_POW},
+        {"_collate_", TT_FUNCTION, F_COLLATE},
 #ifdef MODE_DEVELOPMENT
 		{"_hscrollbarid", TT_PROPERTY, P_HSCROLLBARID},
 		{"_ideoverride", TT_PROPERTY, P_IDE_OVERRIDE},

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -2092,7 +2092,9 @@ const static LT sort_table[] =
         {"marked", TT_UNDEFINED, ST_MARKED},
         {"numeric", TT_UNDEFINED, ST_NUMERIC},
         {"of", TT_UNDEFINED, ST_OF},
-        {"text", TT_UNDEFINED, ST_TEXT}
+        {"options", TT_UNDEFINED, ST_OPTIONS},
+        {"text", TT_UNDEFINED, ST_TEXT},
+        {"with", TT_UNDEFINED, ST_WITH},
     };
 
 

--- a/engine/src/newobj.cpp
+++ b/engine/src/newobj.cpp
@@ -865,6 +865,8 @@ MCExpression *MCN_new_function(int2 which)
         return new MCNormalizeText;
     case F_CODEPOINT_PROPERTY:
         return new MCCodepointProperty;
+    case F_COLLATE:
+        return new MCCollate;
     default:
 		break;
 	}

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1898,7 +1898,9 @@ enum Sort_type {
     ST_INTERNATIONAL,
     ST_DATETIME,
     ST_ASCENDING,
-    ST_DESCENDING
+    ST_DESCENDING,
+    ST_WITH,
+    ST_OPTIONS
 };
 
 

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -607,6 +607,8 @@ enum Functions {
     F_EVENT_CONTROL_KEY,
     F_EVENT_OPTION_KEY,
     F_EVENT_SHIFT_KEY,
+    
+    F_COLLATE,
 };
 
 /* The HT_MIN and HT_MAX elements of the enum delimit the range of the handler

--- a/engine/src/parseerrors.h
+++ b/engine/src/parseerrors.h
@@ -1796,6 +1796,9 @@ enum Parse_errors
     // {PE-0583} fontLanguage: bad type expression
     PE_FONTLANGUAGE_BADPARAM,
     
+    // {PE-0584} collate: bad parameters
+    PE_COLLATE_BADPARAM,
+    
 };
 
 extern const char *MCparsingerrors;

--- a/engine/src/sellst.cpp
+++ b/engine/src/sellst.cpp
@@ -254,8 +254,8 @@ void MCSellist::sort()
 	while (optr != objects);
 	if (nitems > 1)
 	{
-        extern void MCStringsSort(MCSortnode *p_items, uint4 nitems, Sort_type p_dir, Sort_type p_form, MCStringOptions p_options);
-		MCStringsSort(items.Ptr(), nitems, ST_ASCENDING, ST_NUMERIC, kMCStringOptionCompareExact);
+        extern void MCStringsSort(MCSortnode *p_items, uint4 nitems, Sort_type p_dir, Sort_type p_form, MCStringOptions p_options, MCUnicodeCollateOption p_collateoptions, MCLocaleRef p_locale);
+		MCStringsSort(items.Ptr(), nitems, ST_ASCENDING, ST_NUMERIC, kMCStringOptionCompareExact, kMCUnicodeCollateOptionDefault, nullptr);
 		uint4 i;
 		MCSelnode *newobjects = NULL;
 		for (i = 0 ; i < nitems ; i++)

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -823,7 +823,7 @@ public:
 	void enter();
 	void flip(uint2 count);
 	bool sort(MCExecContext &ctxt, Sort_type dir, Sort_type form,
-	               MCExpression *by, Boolean marked);
+	               MCExpression *by, Boolean marked, MCArrayRef p_collateoptions);
 	void breakstring(MCStringRef, MCStringRef*& dest, uindex_t &nstrings,
 	                 Find_mode fmode);
 	Boolean findone(MCExecContext &ctxt, Find_mode mode, MCStringRef *strings,

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1893,7 +1893,7 @@ void MCStack::flip(uint2 count)
 }
 
 bool MCStack::sort(MCExecContext &ctxt, Sort_type dir, Sort_type form,
-                        MCExpression *by, Boolean marked)
+                        MCExpression *by, Boolean marked, MCArrayRef p_collateoptions)
 {
 	if (by == NULL)
 		return false;
@@ -1908,7 +1908,7 @@ bool MCStack::sort(MCExecContext &ctxt, Sort_type dir, Sort_type form,
 	MCerrorlock++;
     
     extern void MCStringsSortAddItem(MCExecContext &ctxt, MCSortnode *items, uint4 &nitems, int form, MCValueRef p_input, MCExpression *by);
-    extern void MCStringsSort(MCSortnode *p_items, uint4 nitems, Sort_type p_dir, Sort_type p_form, MCStringOptions p_options);
+    extern void MCStringsSort(MCSortnode *p_items, uint4 nitems, Sort_type p_dir, Sort_type p_form, MCStringOptions p_options, MCUnicodeCollateOption p_collateoptions, MCLocaleRef p_locale);
     
 	do
 	{
@@ -1933,7 +1933,15 @@ bool MCStack::sort(MCExecContext &ctxt, Sort_type dir, Sort_type form,
 	while (curcard != cptr);
 	MCerrorlock--;
 	if (nitems > 1)
-		MCStringsSort(items . Ptr(), nitems, dir, form, ctxt . GetStringComparisonType());
+    {
+        MCLocaleRef t_locale_ref = nullptr;
+        MCUnicodeCollateOption t_options = kMCUnicodeCollateOptionDefault;
+        if (form == ST_INTERNATIONAL)
+        {
+            MCStringsParseCollateOptions(ctxt, p_collateoptions, t_options, t_locale_ref);
+        }
+        MCStringsSort(items . Ptr(), nitems, dir, form, ctxt . GetStringComparisonType(), t_options, t_locale_ref);
+    }
 	MCCard *newcards = NULL;
 	uint4 i;
 	for (i = 0 ; i < nitems ; i++)

--- a/libfoundation/include/foundation-unicode.h
+++ b/libfoundation/include/foundation-unicode.h
@@ -330,6 +330,9 @@ bool    MCUnicodeIsNormalisedNFKD(const unichar_t *p_string, uindex_t p_length);
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
+bool MCUnicodeMapString(MCUnicodeProperty p_property, MCLocaleRef p_locale,
+                        const unichar_t *p_in, uindex_t p_in_length,
+                        unichar_t *&r_out, uindex_t &r_out_length);
 
 // Casing options are locale-dependent
 bool    MCUnicodeLowercase(MCLocaleRef,

--- a/libfoundation/src/foundation-unicode.cpp
+++ b/libfoundation/src/foundation-unicode.cpp
@@ -771,121 +771,147 @@ bool MCUnicodeIsNormalisedNKD(const unichar_t *p_string, uindex_t p_length)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool MCUnicodeLowercase(MCLocaleRef p_locale,
-                        const unichar_t *p_in, uindex_t p_in_length,
-                        unichar_t *&r_out, uindex_t &r_out_length)
+bool MCUnicodeMapString(MCUnicodeProperty p_property, MCLocaleRef p_locale,
+                                const unichar_t *p_in, uindex_t p_in_length,
+                                unichar_t *&r_out, uindex_t &r_out_length)
 {
+    MCAutoArray<unichar_t> t_buffer;
+    uindex_t t_out_length;
+    
     // Do the casing using icu::UnicodeString. Note that a locale is required.
     UErrorCode t_error = U_ZERO_ERROR;
     icu::UnicodeString t_input(p_in, p_in_length);
-    t_input.toLower(MCLocaleGetICULocale(p_locale));
+    
+    switch (p_property)
+    {
+        case kMCUnicodePropertyLowercaseMapping:
+        case kMCUnicodePropertyUppercaseMapping:
+        case kMCUnicodePropertyTitlecaseMapping:
+        case kMCUnicodePropertyCaseFolding:
+        {
+            icu::Locale t_locale = nullptr;
+            if (p_locale != nullptr)
+            {
+                t_locale = MCLocaleGetICULocale(p_locale);
+            }
+            
+            switch (p_property)
+            {
+                case kMCUnicodePropertyLowercaseMapping:
+                    t_input.toLower(t_locale);
+                    break;
+                case kMCUnicodePropertyUppercaseMapping:
+                    t_input.toUpper(t_locale);
+                    break;
+                case kMCUnicodePropertyTitlecaseMapping:
+                    t_input.toTitle(nullptr, t_locale);
+                    break;
+                case kMCUnicodePropertyCaseFolding:
+                    t_input.foldCase();
+                    break;
+                default:
+                    MCUnreachableReturn(false);
+            }
+        }
+            break;
+        case kMCUnicodePropertySimpleLowercaseMapping:
+        case kMCUnicodePropertySimpleUppercaseMapping:
+        case kMCUnicodePropertySimpleTitlecaseMapping:
+        case kMCUnicodePropertySimpleCaseFolding:
+        {
+            icu::UnicodeString t_temp;
+            int32_t i = 0;
+            
+            while(i < t_input.length())
+            {
+                t_temp.append(static_cast<UChar32>(MCUnicodeGetCharacterProperty(t_input.char32At(i), p_property)));
+                i = t_input.moveIndex32(i, 1);
+            }
+            
+            t_input.setTo(t_temp);
+            
+        }
+            break;
+        default:
+            MCUnreachableReturn(false);
+    }
+    
+    t_out_length = t_input.length();
     
     // Allocate the output buffer
-    MCAutoArray<unichar_t> t_buffer;
-    if (!t_buffer.New(t_input.length() + 1))
+    if (!t_buffer.New(t_out_length + 1))
         return false;
     
     // Extract the converted characters
-    t_input.extract(t_buffer.Ptr(), t_input.length(), t_error);
+    t_input.extract(t_buffer.Ptr(), t_buffer.Size(), t_error);
     if (U_FAILURE(t_error))
         return false;
     
     // Done
-    t_buffer.Take(r_out, r_out_length);
-    r_out_length--;
+    uindex_t t_size;
+    t_buffer.Take(r_out, t_size);
+    r_out_length = t_out_length;
     r_out[r_out_length] = 0;
     return true;
+}
+
+bool MCUnicodeLowercase(MCLocaleRef p_locale,
+                        const unichar_t *p_in, uindex_t p_in_length,
+                        unichar_t *&r_out, uindex_t &r_out_length)
+{
+    MCUnicodeProperty t_property;
+    if (p_locale != nullptr)
+    {
+        t_property = kMCUnicodePropertyLowercaseMapping;
+    }
+    else
+    {
+        t_property = kMCUnicodePropertySimpleLowercaseMapping;
+    }
+        
+    return MCUnicodeMapString(t_property, p_locale, p_in, p_in_length, r_out, r_out_length);
 }
 
 bool MCUnicodeUppercase(MCLocaleRef p_locale,
                         const unichar_t *p_in, uindex_t p_in_length,
                         unichar_t *&r_out, uindex_t &r_out_length)
 {
-    // Do the casing using icu::UnicodeString. Note that a locale is required.
-    UErrorCode t_error = U_ZERO_ERROR;
-    icu::UnicodeString t_input(p_in, p_in_length);
-    t_input.toUpper(MCLocaleGetICULocale(p_locale));
+    MCUnicodeProperty t_property;
+    if (p_locale != nullptr)
+    {
+        t_property = kMCUnicodePropertyUppercaseMapping;
+    }
+    else
+    {
+        t_property = kMCUnicodePropertySimpleUppercaseMapping;
+    }
     
-    // Allocate the output buffer
-    MCAutoArray<unichar_t> t_buffer;
-    if (!t_buffer.New(t_input.length()))
-        return false;
-    
-    // Extract the converted characters
-    t_input.extract(t_buffer.Ptr(), t_buffer.Size(), t_error);
-    if (U_FAILURE(t_error))
-        return false;
-    
-    // Done
-    t_buffer.Take(r_out, r_out_length);
-    return true;
+    return MCUnicodeMapString(t_property, p_locale, p_in, p_in_length, r_out, r_out_length);
 }
 
 bool MCUnicodeTitlecase(MCLocaleRef p_locale,
                         const unichar_t *p_in, uindex_t p_in_length,
                         unichar_t *&r_out, uindex_t &r_out_length)
 {
-    // The ICU UnicodeString class is convenient for case transformations
-    UErrorCode t_error = U_ZERO_ERROR;
-    icu::UnicodeString t_input(p_in, p_in_length);
-    
-    // By supplying no specific break iterator, the default is used
-    t_input.toTitle(NULL, MCLocaleGetICULocale(p_locale));
-    
-    // Allocate the output buffer
-    MCAutoArray<unichar_t> t_buffer;
-    if (!t_buffer.New(t_input.length()))
-        return false;
-    
-    // Extract the converted characters
-    t_input.extract(t_buffer.Ptr(), t_buffer.Size(), t_error);
-    if (U_FAILURE(t_error))
-        return false;
-    
-    // Done
-    t_buffer.Take(r_out, r_out_length);
-    return true;
-}
-
-static void __MCUnicodeSimpleCaseFold(icu::UnicodeString& p_string)
-{
-    icu::UnicodeString t_temp;
-    int32_t i = 0;
-    
-    while(i < p_string.length())
+    MCUnicodeProperty t_property;
+    if (p_locale != nullptr)
     {
-        t_temp.append(u_toupper(p_string.char32At(i)/*, U_FOLD_CASE_DEFAULT*/));
-        i = p_string.moveIndex32(i, 1);
+        t_property = kMCUnicodePropertyTitlecaseMapping;
+    }
+    else
+    {
+        // requires implementation of word break detection in the simple mapping loop
+        MCUnreachableReturn(false);
     }
     
-    p_string.setTo(t_temp);
+    return MCUnicodeMapString(t_property, p_locale, p_in, p_in_length, r_out, r_out_length);
 }
 
 bool MCUnicodeCaseFold(const unichar_t *p_in, uindex_t p_in_length,
                        unichar_t *&r_out, uindex_t &r_out_length)
 {
-    // The ICU UnicodeString class is convenient for case transformations
-    UErrorCode t_error = U_ZERO_ERROR;
-    icu::UnicodeString t_input(p_in, p_in_length);
-    
-    // Unlike the other case transformations, case folding does not depend on
-    // locale. Its only option is whether to use the special Turkish rules for
-    // casefolding dotless i and dotted l but we don't support this.
-    __MCUnicodeSimpleCaseFold(t_input);
-    
-    // Allocate the output buffer
-    MCAutoArray<unichar_t> t_buffer;
-    if (!t_buffer.New(t_input.length()))
-        return false;
-    
-    // Extract the converted characters
-    t_input.extract(t_buffer.Ptr(), t_buffer.Size(), t_error);
-    if (U_FAILURE(t_error))
-        return false;
-    
-    // Done
-    t_buffer.Take(r_out, r_out_length);
-    return true;
+    // for some reason we don't use kMCUnicodePropertySimpleCaseFolding or kMCUnicodePropertyCaseFolding
+    return MCUnicodeMapString(kMCUnicodePropertySimpleUppercaseMapping, nullptr, p_in, p_in_length, r_out, r_out_length);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/lcs/core/strings/basic.livecodescript
+++ b/tests/lcs/core/strings/basic.livecodescript
@@ -63,6 +63,14 @@ on TestToUpper
   TestAssert "upper of lowercase", toUpper("xy") is "XY"
   TestAssert "upper of uppercase", toUpper("XY") is "XY"
   TestAssert "upper of mixedcase", toUpper("xY") is "XY"
+
+  TestAssert "upper of unicode simple case mapping", toUpper("ßǆ") is "ßǄ"
+  TestAssert "upper of unicode locale case mapping", toUpper("ßǆ","de") is "SSǄ"
+
+  -- workaround case sensitive not being locale aware
+  TestAssert "upper of unicode locale case mapping", \
+      textEncode(toUpper("iǆ","en"),"UTF-8") is textEncode("IǄ","UTF-8") and \
+      textEncode(toUpper("iǆ","tr"),"UTF-8") is textEncode("İǄ","UTF-8")
 end TestToUpper
 
 on TestToLower
@@ -70,6 +78,9 @@ on TestToLower
   TestAssert "lower of lowercase", toLower("xy") is "xy"
   TestAssert "lower of uppercase", toLower("XY") is "xy"
   TestAssert "lower of mixedcase", toLower("xY") is "xy"
+
+  TestAssert "lower of unicode simple case mapping", toLower("İ") is "i"
+  TestAssert "lower of unicode locale case mapping", toLower("IǄ","en") is "iǆ" and toLower("IǄ","tr") is "ıǆ"
 end TestToLower
 
 on TestBeginsWith

--- a/tests/lcs/core/strings/collate.livecodescript
+++ b/tests/lcs/core/strings/collate.livecodescript
@@ -1,0 +1,42 @@
+﻿script "CoreStringsCollate"
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestCollateCaseSensitve
+  set the caseSensitive to true
+  TestAssert "collate case sensitive lowercase", _collate_("xy","XY") is -1
+  TestAssert "collate case sensitive uppercase", _collate_("XY","XY") is 0
+  TestAssert "collate case sensitive mixedcase", _collate_("xY","XY") is -1
+
+  set the caseSensitive to false
+  TestAssert "collate case insensitive lowercase", _collate_("xy","XY") is 0
+  TestAssert "collate case insensitive uppercase", _collate_("XY","XY") is 0
+  TestAssert "collate case insensitive mixedcase", _collate_("xY","XY") is 0
+end TestCollateCaseSensitve
+
+on TestCollateNumeric
+  local tOptions
+  put true into tOptions["numeric"]
+  TestAssert "collate numeric", _collate_("xy9a","xy10b", tOptions) is -1
+end TestCollateNumeric
+
+on TestCollateIgnorePunctuation
+  local tOptions
+  put true into tOptions["ignorepunctuation"]
+  TestAssert "collate ignore punctuation", _collate_("xy..a","xy,b", tOptions) is -1
+end TestCollateIgnorePunctuation
+

--- a/tests/lcs/core/strings/sort.livecodescript
+++ b/tests/lcs/core/strings/sort.livecodescript
@@ -26,3 +26,18 @@ on TestInterface95
    
    TestAssert "test", tContainer is "a,b,c,d,e,f,g,h" 
 end TestInterface95
+
+on TestSortWithOptions
+	local tContainer
+	put "foo1,foo10,foo9a,foo9,bar2" into tContainer
+
+	local tOptions
+	put true into tOptions["numeric"]
+
+	sort items of tContainer international with options tOptions
+	TestAssert "sort international with numeric option", tContainer is "bar2,foo1,foo9,foo9a,foo10" 
+
+	put "foo1,foo10,foo9a,foo9,bar2" into tContainer
+	sort items of tContainer international
+	TestAssert "sort international without numeric option", tContainer is "bar2,foo1,foo10,foo9,foo9a" 
+end TestSortWithOptions


### PR DESCRIPTION
This patch adds a locale parameter to `toLower` and `toUpper` allowing
scripts to specify the locale that should be used for case mapping. If
empty then the simple non-language specific case mapping will be used.

The new parameter is optional and without the parrameter the detected
system locale continues to be used for case mapping.