### PR TITLE
[21681] Ensure start and end date are respected on mobilePickDate

### DIFF
--- a/docs/notes/bugfix-21681.md
+++ b/docs/notes/bugfix-21681.md
@@ -1,0 +1,1 @@
+# Ensure start and end dates are respected on mobilePickDate on Android

--- a/engine/src/java/com/runrev/android/DialogModule.java
+++ b/engine/src/java/com/runrev/android/DialogModule.java
@@ -171,14 +171,14 @@ class DialogModule
                 if (p_with_min)
                 {
                     Method t_setMinDate;
-                    t_setMinDate = t_dialog.getClass().getMethod("setMinDate", new Class[] {Long.TYPE});
+                    t_setMinDate = t_date_picker.getClass().getMethod("setMinDate", new Class[] {Long.TYPE});
                     t_setMinDate.invoke(t_date_picker, new Object[] {p_min * 1000});
                 }
 
                 if (p_with_max)
                 {
                     Method t_setMaxDate;
-                    t_setMaxDate = t_dialog.getClass().getMethod("setMaxDate", new Class[] {Long.TYPE});
+                    t_setMaxDate = t_date_picker.getClass().getMethod("setMaxDate", new Class[] {Long.TYPE});
                     t_setMaxDate.invoke(t_date_picker, new Object[] {p_max * 1000});
                 }
             }


### PR DESCRIPTION
`setMinDate` and `setMaxDate` were called by an incorrect object type (`DatePickerDialog` instead of `DatePicker`) and this resulted in a `java.lang.NoSuchMethodException` to be thrown