### PR TITLE
[Bugfix-19231] Correct code example in rawClipboardData

### DIFF
--- a/docs/dictionary/property/rawClipboardData.lcdoc
+++ b/docs/dictionary/property/rawClipboardData.lcdoc
@@ -24,7 +24,7 @@ Example:
 lock the clipboard
 set the rawClipboardData["text/plain;charset=utf-8"] \
       to textEncode("Hello, World!", "UTF-8" ) -- Linux
-set the rawClipboardData["CF_UNICODE"] \
+set the rawClipboardData["CF_UNICODETEXT"] \
       to textEncode("Hello, World!", "UTF-16" ) -- Windows
 set the rawClipboardData["public.utf8-plain-text"] \
       to textEncode("Hello, World!", "UTF-8" ) -- OSX
@@ -76,7 +76,7 @@ encoding.
 
 References: lock clipboard (command), unlock clipboard (command),
 clipboard (function), textEncode (function), textDecode (function),
-clipboard (glossary), clipboardData (property),
+clipboard (glossary), property (glossary), clipboardData (property),
 fullClipboardData (property), rawDragData (property)
 
 Tags: ui, clipboard

--- a/docs/notes/bugfix-19231.md
+++ b/docs/notes/bugfix-19231.md
@@ -1,0 +1,1 @@
+# Correct code example in documentation for rawClipboardData


### PR DESCRIPTION
Changed `CF_UNICODE` to `CF_UNICODETEXT` as indicated to be correct in Windows' list of standard clipboard formats.