### PR TITLE
[bugfix-14440] Add note about caseSensitive to offset function entry

### DIFF
--- a/docs/dictionary/function/offset.lcdoc
+++ b/docs/dictionary/function/offset.lcdoc
@@ -56,12 +56,21 @@ specified number of <characters> in the <stringToSearch>. The <value>
 <return|returned> is relative to this starting <point> instead of the
 beginning of the <stringToSearch>.
 
+>*Note:* The <offset> is affected by the <caseSensitive> <property>.
+>By default, this property is set to false, meaning uppercase letters
+>and their lowercase equivalents are treated as the same. For example,
+    offset("A","abcABC") 
+>returns 1 by default, however after setting the <caseSensitive> to 
+>true, it returns 4 instead.
+
+
 References: find (command), sort container (command),
 function (control structure), wordOffset (function),
 itemOffset (function), length (function), lineOffset (function),
 value (function), return (glossary), non-negative (glossary),
-character (keyword), characters (keyword), integer (keyword),
-string (keyword), point (keyword), begins with (operator)
+property (glossary), character (keyword), characters (keyword), 
+integer (keyword), string (keyword), point (keyword), 
+begins with (operator), caseSensitive (property)
 
 Tags: text processing
 

--- a/docs/notes/bugfix-14440.md
+++ b/docs/notes/bugfix-14440.md
@@ -1,0 +1,1 @@
+# Added note in the offset function's documentation about caseSensitive's effect on it.


### PR DESCRIPTION
Added a note to offset's dictionary entry about how the caseSensitive property must be set to true to stop the offset function from treating uppercase and lowercase letters as the same.