### PR TITLE
[[ Is Strictly Equals ]] Implement is strictly equals

### DIFF
--- a/docs/dictionary/operator/is-not-strictly.lcdoc
+++ b/docs/dictionary/operator/is-not-strictly.lcdoc
@@ -2,11 +2,11 @@ Name: is not strictly
 
 Type: operator
 
-Syntax: <value> is not strictly { nothing | a boolean | an integer | a real | a string | a binary string | an array }
+Syntax: <value> is not strictly { nothing | a boolean | an integer | a real | a string | a binary string | an array | <otherValue> }
 
 Summary:
-Evaluates to true if the actual type of <value> is not the specified
-type. 
+Evaluates to true if the actual <value> is not the specified
+type or value. 
 
 Introduced: 8.0
 
@@ -24,15 +24,27 @@ Example:
 (100 is 100) is not strictly a boolean -- evaluates to false
 
 Example:
+"test" is not strictly "TEST" -- evaluates to true
+
+Example:
+1 is not strictly 1.0 -- evaluates to true
+
+Example:
+1 + 0 is not strictly 1.0 + 0 -- evaluates to false
+
+Example:
 the compress of "Hello World!" is not strictly a binary string -- evaluates to false
 
 Parameters:
 value:
 The expression which will be tested for its type.
 
+otherValue:
+The expression which will be compared for its value.
+
 Description:
-Use the <is not strictly> operator to determine what the true type of
-a value is not.  The true type of a value is the representation which
+Use the <is not strictly> operator to determine what the true value is not. 
+The true type of a value is the representation which
 the engine is currently holding for it, without performing any
 implicit type coercion. The true type of a value can be one of the
 following:
@@ -52,6 +64,17 @@ not perform any type coercion. For example, `x not is an integer`
 would return false only when `x` is neither an integer nor a string
 which parses as an integer; whereas `x is not strictly an integer`
 only returns false if `x` is not currently an integer.
+
+When comparing to another value the values are considered to be equal if they
+are the same type and have exactly the same value:
+
+* strings and binary strings must have the same byte values
+* unicode strings are not normalized prior to the comparison
+* numeric strings are compared as strings
+
+Changes:
+Comparison to another value to determine strict value are not equivalent was
+added in LiveCode 9.5
 
 References: is strictly (operator), is a (operator), is not a (operator)
 

--- a/docs/dictionary/operator/is-strictly.lcdoc
+++ b/docs/dictionary/operator/is-strictly.lcdoc
@@ -2,10 +2,10 @@ Name: is strictly
 
 Type: operator
 
-Syntax: <value> is strictly { nothing | a boolean | an integer | a real | a string | a binary string | an array }
+Syntax: <value> is strictly { nothing | a boolean | an integer | a real | a string | a binary string | an array | <otherValue> }
 
 Summary:
-Evaluates to true if the actual type of <value> is the specified type.
+Evaluates to true if the actual <value> is the specified type or value.
 
 Introduced: 8.0
 
@@ -23,17 +23,30 @@ Example:
 (100 is 100) is strictly a boolean -- evaluates to true
 
 Example:
+"test" is strictly "TEST" -- evaluates to false
+
+Example:
+1 is strictly 1.0 -- evaluates to false
+
+Example:
+1 + 0 is strictly 1.0 + 0 -- evaluates to true
+
+Example:
 the compress of "Hello World!" is strictly a binary string -- evaluates to true
 
 Parameters:
 value:
-The expression which will be tested for its type.
+The expression which will be tested for its type or value.
+
+otherValue:
+The expression which will be compared for its value.
 
 Description:
 Use the <is strictly> operator to determine the true type of a
-value. The true type of a value is the representation which the engine
-is currently holding for it, without performing any implicit type
-coercion. The true type of a value can be one of the following:
+value or if it is strictly equal to another value. The true type of a value is
+the representation which the engine is currently holding for it, without
+performing any implicit type coercion. The true type of a value can be one of
+the following:
 
 * nothing: no value, typically seen as <empty>
 * boolean: either true or false, typically seen as the result of a
@@ -44,12 +57,22 @@ coercion. The true type of a value can be one of the following:
 * binary string: a sequence of bytes
 * array: an associative array
 
-
 The <is strictly> operator differs from <is a> in that it does not
 perform any type coercion. For example, `x is an integer` would return
 true if `x` is truly an integer or if it is a string which can be parsed
 as an integer; whereas `x is strictly an integer` only returns true if
 `x` is currently an integer (and not a string).
+
+When comparing to another value the values are considered to be equal if they
+are the same type and have exactly the same value:
+
+* strings and binary strings must have the same byte values
+* unicode strings are not normalized prior to the comparison
+* numeric strings are compared as strings
+
+Changes:
+Comparison to another value to determine strict value equivalence was added in
+LiveCode 9.5
 
 References: is not strictly (operator), is a (operator),
 is not a (operator)

--- a/docs/notes/feature-isstrictlyequal.md
+++ b/docs/notes/feature-isstrictlyequal.md
@@ -1,0 +1,25 @@
+# The `is strictly` and `is not strictly` operators have been enhanced to allow comparison to another value
+
+Use `<value> is [not] strictly <otherValue>` to determine if two values have
+strict value equivalence. Previously `is strictly` could be used to only test if
+the expression evaluated to either a particular type or `nothing`. This
+enhancement allows `is strictly` to also compare exact value equivalence.
+
+When comparing to another value the values are considered to be equal if they
+are the same type and have exactly the same value:
+
+* strings and binary strings must have the same byte values
+* unicode strings are not normalized prior to the comparison
+* numeric strings are compared as strings
+
+For example:
+
+The following evaluates to `true` because strict type of a numeric literal is
+string and the string values differ
+
+    1 is not strictly 1.0
+
+The following evaluates to `true` because the strict type resulting from a
+numeric expression is a number and the number is the same
+
+    1 + 0 is strictly 1.0 + 0

--- a/engine/src/exec-logic.cpp
+++ b/engine/src/exec-logic.cpp
@@ -233,6 +233,42 @@ void MCLogicEvalIsNotEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef 
 	ctxt . Throw();
 }
 
+static bool MCLogicIsStrictlyEqualTo(MCValueRef p_left, MCValueRef p_right)
+{
+    /* Take into account names */
+    MCValueTypeCode t_left_code, t_right_code;
+    t_left_code = MCValueGetTypeCode(p_left);
+    t_right_code = MCValueGetTypeCode(p_right);
+    
+    if (t_left_code != t_right_code)
+    {
+        if (t_left_code == kMCValueTypeCodeName)
+        {
+            p_left = MCNameGetString((MCNameRef)p_left);
+        }
+        else if (t_right_code == kMCValueTypeCodeName)
+        {
+            p_right = MCNameGetString((MCNameRef)p_right);
+        }
+        else
+        {
+            return false;
+        }
+    }
+    
+    return MCValueIsEqualTo(p_left, p_right);
+}
+
+void MCLogicEvalIsStrictlyEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result)
+{
+    r_result = MCLogicIsStrictlyEqualTo(p_left, p_right);
+}
+
+void MCLogicEvalIsNotStrictlyEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result)
+{
+    r_result = !MCLogicIsStrictlyEqualTo(p_left, p_right);
+}
+
 void MCLogicEvalIsGreaterThan(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result)
 {
 	compare_t t_order;

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1810,6 +1810,8 @@ void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, MCHandler *handler, MC
 
 void MCLogicEvalIsEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result);
 void MCLogicEvalIsNotEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result);
+void MCLogicEvalIsStrictlyEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result);
+void MCLogicEvalIsNotStrictlyEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result);
 void MCLogicEvalIsGreaterThan(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result);
 void MCLogicEvalIsGreaterThanOrEqualTo(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result);
 void MCLogicEvalIsLessThan(MCExecContext& ctxt, MCValueRef p_left, MCValueRef p_right, bool& r_result);

--- a/engine/src/operator.cpp
+++ b/engine/src/operator.cpp
@@ -271,45 +271,54 @@ Parse_stat MCIs::parse(MCScriptPoint &sp, Boolean the)
         {
             if (sp.skip_token(SP_VALIDATION, TT_UNDEFINED, TT_UNDEFINED) != PS_NORMAL)
             {
-	            MCperror -> add(PE_ISSTRICTLY_NOAN, sp);
-                return PS_ERROR;
-            }
-            
-            if (sp.skip_token(SP_SORT, TT_UNDEFINED, ST_BINARY) == PS_NORMAL)
-            {
-                if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_STRING) != PS_NORMAL)
-                {
-                    MCperror -> add(PE_ISSTRICTLY_NOSTRING, sp);
-                    return PS_ERROR;
-                }
-                
-                valid = IV_BINARY_STRING;
-            }
-            else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_NOTHING) == PS_NORMAL)
                 valid = IV_UNDEFINED;
-            else if (sp . skip_token(SP_VALIDATION, TT_UNDEFINED, IV_LOGICAL) == PS_NORMAL)
-                valid = IV_LOGICAL;
-            else if (sp . skip_token(SP_VALIDATION, TT_UNDEFINED, IV_ARRAY) == PS_NORMAL)
-                valid = IV_ARRAY;
-            else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_STRING) == PS_NORMAL)
-                valid = IV_STRING;
-            else if (sp . skip_token(SP_VALIDATION, TT_UNDEFINED, IV_INTEGER) == PS_NORMAL)
-                valid = IV_INTEGER;
-            else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_REAL) == PS_NORMAL)
-                valid = IV_REAL;
+                
+                if (form != IT_NOT)
+                    form = IT_STRICTLY_EQUAL;
+                else
+                    form = IT_NOT_STRICTLY_EQUAL;
+            }
             else
             {
-                MCperror -> add(PE_ISSTRICTLY_NOTYPE, sp);
-                return PS_ERROR;
+                if (sp.skip_token(SP_SORT, TT_UNDEFINED, ST_BINARY) == PS_NORMAL)
+                {
+                    if (sp.skip_token(SP_SUGAR, TT_UNDEFINED, SG_STRING) != PS_NORMAL)
+                    {
+                        MCperror -> add(PE_ISSTRICTLY_NOSTRING, sp);
+                        return PS_ERROR;
+                    }
+                    
+                    valid = IV_BINARY_STRING;
+                }
+                else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_NOTHING) == PS_NORMAL)
+                    valid = IV_UNDEFINED;
+                else if (sp . skip_token(SP_VALIDATION, TT_UNDEFINED, IV_LOGICAL) == PS_NORMAL)
+                    valid = IV_LOGICAL;
+                else if (sp . skip_token(SP_VALIDATION, TT_UNDEFINED, IV_ARRAY) == PS_NORMAL)
+                    valid = IV_ARRAY;
+                else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_STRING) == PS_NORMAL)
+                    valid = IV_STRING;
+                else if (sp . skip_token(SP_VALIDATION, TT_UNDEFINED, IV_INTEGER) == PS_NORMAL)
+                    valid = IV_INTEGER;
+                else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_REAL) == PS_NORMAL)
+                    valid = IV_REAL;
+                else
+                {
+                    MCperror -> add(PE_ISSTRICTLY_NOTYPE, sp);
+                    return PS_ERROR;
+                }
             }
         }
-            
-        if (form != IT_NOT)
-            form = IT_STRICTLY;
-        else
-            form = IT_NOT_STRICTLY;
         
-        return PS_BREAK;
+        if (form != IT_STRICTLY_EQUAL && form != IT_NOT_STRICTLY_EQUAL)
+        {
+            if (form != IT_NOT)
+                form = IT_STRICTLY;
+            else
+                form = IT_NOT_STRICTLY;
+            
+            return PS_BREAK;
+        }
     }
 	if (sp.next(type) != PS_NORMAL)
 	{
@@ -832,6 +841,23 @@ void MCIs::eval_ctxt(MCExecContext &ctxt, MCExecValue &r_value)
                 MCGraphicsEvalIsWithin(ctxt, t_point, t_rectangle, t_result);
             else
                 MCGraphicsEvalIsNotWithin(ctxt, t_point, t_rectangle, t_result);
+        }
+        break;
+    case IT_STRICTLY_EQUAL:
+    case IT_NOT_STRICTLY_EQUAL:
+        {
+            MCAutoValueRef t_left, t_right;
+
+            if (!ctxt . EvalExprAsValueRef(left, EE_IS_BADLEFT, &t_left))
+                return;
+            
+            if (!ctxt . EvalExprAsValueRef(right, EE_IS_BADRIGHT, &t_right))
+                return;
+            
+            if (form == IT_STRICTLY_EQUAL)
+                MCLogicEvalIsStrictlyEqualTo(ctxt, *t_left, *t_right, t_result);
+            else
+                MCLogicEvalIsNotStrictlyEqualTo(ctxt, *t_left, *t_right, t_result);
         }
         break;
     default:

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -682,6 +682,8 @@ enum Is_type {
     IT_NOT_AMONG_THE_FULL_DRAGBOARD_DATA,
     IT_STRICTLY,
     IT_NOT_STRICTLY,
+    IT_STRICTLY_EQUAL,
+    IT_NOT_STRICTLY_EQUAL,
 };
 
 enum Is_validation {

--- a/tests/lcs/core/logic/isstrictly.livecodescript
+++ b/tests/lcs/core/logic/isstrictly.livecodescript
@@ -75,3 +75,14 @@ on TestStrictlyArray
 
    __TestIsStrictly tVal, "an array"
 end TestStrictlyArray
+
+on TestStrictlyEquals
+   TestAssert "is strictly string", "test" is strictly "test"
+   TestAssert "is strictly string case sensitive", "test" is not strictly "Test"
+   TestAssert "is strictly numeric strings", 1 is not strictly 1.0
+   TestAssert "is strictly numeric", (1 + 0) is strictly (1.0 + 0)
+   TestAssert "is strictly boolean", (1 is 1) is strictly (1 is 1)
+   TestAssert "is strictly unicode equivalence NFC/NFD", numToCodepoint(0x00e9) is not strictly numToCodepoint(0x0065)&numToCodepoint(0x0301)
+   TestAssert "is strictly unicode equivalence NFC/NFC", numToCodepoint(0x00e9) is strictly normalizeText(numToCodepoint(0x0065)&numToCodepoint(0x0301),"NFC")
+   TestAssert "is strictly name is string", "0" is strictly (0 & "")
+end TestStrictlyEquals


### PR DESCRIPTION
This patch enhances the `is strictly` operator to allow for strict value
equivalence. Previously `is strictly` could be used to only test if the
expression evaluated to either a particular type or nothing. This patch
allows `is strictly` to also compare exact value equivalence.