### PR TITLE
[Dictionary] revGoToFramePaused to revNumberofRecords

### DIFF
--- a/docs/dictionary/command/revGoToFramePaused.lcdoc
+++ b/docs/dictionary/command/revGoToFramePaused.lcdoc
@@ -52,9 +52,8 @@ revGoToFramePause <command> repeatedly for each frame, using the <send>
 <command> :
 
     on goNextFrame theFrame -- 1 frame every 20th of a second
-    revGoToFramePaused "My Animation",theFrame  
-    send ("goNextFrame" && (theFrame + 1)) to me in 3 ticks
-
+        revGoToFramePaused "My Animation",theFrame  
+        send ("goNextFrame" && (theFrame + 1)) to me in 3 ticks
     end goNextFrame
 
 
@@ -67,14 +66,14 @@ revGoToFramePause <command> repeatedly for each frame, using the <send>
 > library checkbox is checked.
 
 References: revStopAnimation (command), group (command),
-current card (glossary), main stack (glossary), handler (glossary),
-frame (glossary), message (glossary),
+send (command), current card (glossary), main stack (glossary), 
+handler (glossary), frame (glossary), message (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), command (glossary),
 application (glossary), LiveCode custom library (glossary),
-Animation library (library), send (library), library (library),
-startup (message), openBackground (message), preOpenStack (message),
-openStack (message), preOpenCard (message), defaultStack (property)
+Animation library (library), library (library), startup (message), 
+openBackground (message), preOpenStack (message), openStack (message), 
+preOpenCard (message), defaultStack (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revGoURL.lcdoc
+++ b/docs/dictionary/command/revGoURL.lcdoc
@@ -54,7 +54,9 @@ browser, and so on.
 > folder inside the Extensions folder. (This <file> is installed by the
 > Internet Access installer on the 8.0 installation CD.) The <revGoURL>
 > <command> is not supported for <Mac OS> versions before 8.0.
-Important:If the <URL> contains quotes, it is necessary either to
+
+
+>*Important:* If the <URL> contains quotes, it is necessary either to
 <URLEncode> it or to replace the quotes with "%22", or unexpected
 behavior may be experienced.
 
@@ -80,9 +82,8 @@ handler (glossary), message (glossary), group (glossary),
 Mac OS (glossary), standalone application (glossary),
 Apple Event (glossary), command (glossary), browser (glossary),
 URL (keyword), file (keyword), Common library (library),
-launch url command (library), library (library), startup (message),
-openBackground (message), preOpenStack (message), openStack (message),
-stack (object)
+library (library), startup (message), openBackground (message), 
+preOpenStack (message), openStack (message), stack (object)
 
 Tags: networking
 

--- a/docs/dictionary/command/revInitializeVideoGrabber.lcdoc
+++ b/docs/dictionary/command/revInitializeVideoGrabber.lcdoc
@@ -88,7 +88,8 @@ video capture (glossary), Windows (glossary), VFW (glossary),
 Standalone Application Settings (glossary), video grabber (glossary),
 standalone application (glossary), function (glossary),
 command (glossary), LiveCode custom library (glossary), file (keyword),
-Video library (library), properties (property)
+Video library (library), properties (property), dontUseQT (property),
+dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revInitializeVideoGrabber.lcdoc
+++ b/docs/dictionary/command/revInitializeVideoGrabber.lcdoc
@@ -34,20 +34,20 @@ separated by commas: the left, top, right, and bottom edges of the video
 grabber, in absolute (screen) coordinates.
 
 Description:
-Use the <revInitializeVideoGrabber> <command> to start up <video
-capture> capability.
+Use the <revInitializeVideoGrabber> <command> to start up 
+<video capture> capability.
 
 You must use the <revInitializeVideoGrabber> <command> before using any
-of the other <command|commands> and <function|functions> in the <Video
-library>. The <command> does two things:
+of the other <command|commands> and <function|functions> in the 
+<Video library>. The <command> does two things:
 
 * Loads the code necessary for video capture into memory.
 * Opens the video grabber window.
 
 
 >*Note:* The <video grabber> is not a <stack window>, so you can't set
-> its <properties>. To change the size and location of the <video
-> grabber>, use the <revSetVideoGrabberRect> <command>.
+> its <properties>. To change the size and location of the 
+> <video grabber>, use the <revSetVideoGrabberRect> <command>.
 
 Once the video grabber is open, you can use the revVideoGrabDialog
 <command> to specify where the video camera (or other video source) is
@@ -68,8 +68,7 @@ capture>.
 > <LiveCode custom library|custom library> when you create your 
 > <standalone application|standalone>. In the Inclusions pane of the 
 > <Standalone Application Settings> window, make sure the
-> "Video Grabber" 
-> library checkbox is checked.
+> "Video Grabber" library checkbox is checked.
 
 Changes:
 The use of <QuickTime> was deprecated in version 8.1 of LiveCode with

--- a/docs/dictionary/command/revMailUnicode.lcdoc
+++ b/docs/dictionary/command/revMailUnicode.lcdoc
@@ -52,9 +52,9 @@ For some older email programs, it may not be possible to specify a
 <revMailUnicode> command will still work with such programs, but only
 the To: header will be set.
 
->*Note:* When included in a <standalone application>, the <Common
-> library> is implemented as a hidden <group> and made available when
-> the <group> receives its first <openBackground> message. During the
+>*Note:* When included in a <standalone application>, the 
+> <Common library> is implemented as a hidden <group> and made available 
+> when the <group> receives its first <openBackground> message. During the
 > first part of the <application|application's> startup process, before
 > this <message> is sent, the <revMailUnicode> <command> is not yet
 > available. This may affect attempts to use this <command> in

--- a/docs/dictionary/command/revMoveFolder.lcdoc
+++ b/docs/dictionary/command/revMoveFolder.lcdoc
@@ -47,9 +47,9 @@ The <revMoveFolder> <command> moves the entire <folder>, including all
 is removed from its original location and apppears only in the new
 location. 
 
->*Note:* When included in a <standalone application>, the <Common
-> library> is implemented as a hidden <group> and made available when
-> the <group> receives its first <openBackground> message. During the
+>*Note:* When included in a <standalone application>, the 
+> <Common library> is implemented as a hidden <group> and made available 
+> when the <group> receives its first <openBackground> message. During the
 > first part of the <application|application's> startup process, before
 > this <message> is sent, the <revMoveFolder> <command> is not yet
 > available. This may affect attempts to use this <command> in
@@ -60,11 +60,11 @@ location.
 
 References: create alias (command), delete folder (command),
 revDeleteFolder (command), function (control structure),
-application (glossary), return (glossary),
-standalone application (glossary), file (glossary), shell (glossary),
-subfolder (glossary), platform (glossary), command (glossary),
-Windows (glossary), main stack (glossary), OS X (glossary),
-AppleScript (glossary), group (glossary), result (glossary),
+result (function), application (glossary), 
+standalone application (glossary),  file (glossary), 
+shell (glossary), subfolder (glossary), platform (glossary), 
+command (glossary), Windows (glossary), main stack (glossary), 
+OS X (glossary), AppleScript (glossary),  group (glossary), 
 Unix (glossary), message (glossary), folder (glossary), Mac OS (glossary),
 handler (glossary), Common library (library), library (library),
 startup (message), openBackground (message), preOpenStack (message),

--- a/docs/dictionary/command/revMoveToFirstRecord.lcdoc
+++ b/docs/dictionary/command/revMoveToFirstRecord.lcdoc
@@ -5,8 +5,7 @@ Type: command
 Syntax: revMoveToFirstRecord <recordSetID>
 
 Summary:
-Moves to the first <record> of a <record set (database
-cursor)(glossary)>. 
+Moves to the first <record> of a <record set (glossary)>. 
 
 Associations: database library
 
@@ -53,8 +52,7 @@ References: revMoveToNextRecord (command), function (control structure),
 revdb_movefirst (function), revdb_moveprev (function),
 revdb_movelast (function), revDatabaseColumnNumbered (function),
 revdb_movenext (function), Standalone Application Settings (glossary),
-record (glossary), command (glossary),
-record set (database cursor) (glossary),
+record (glossary), command (glossary), record set (glossary), 
 standalone application (glossary), database (glossary),
 LiveCode custom library (glossary), Database library (library)
 

--- a/docs/dictionary/command/revMoveToLastRecord.lcdoc
+++ b/docs/dictionary/command/revMoveToLastRecord.lcdoc
@@ -5,8 +5,7 @@ Type: command
 Syntax: revMoveToLastRecord <recordSetID>
 
 Summary:
-Moves to the last <record> of a <record set (database
-cursor)(glossary)>. 
+Moves to the last <record> of a <record set (glossary)>. 
 
 Associations: database library
 
@@ -53,7 +52,7 @@ revdb_movefirst (function), revdb_moveprev (function),
 revdb_movelast (function), revDatabaseColumnNumbered (function),
 revdb_movenext (function), LiveCode custom library (glossary),
 Standalone Application Settings (glossary), record (glossary),
-command (glossary), record set (database cursor) (glossary),
+command (glossary), record set (glossary), 
 standalone application (glossary), database (glossary), string (keyword),
 Database library (library)
 

--- a/docs/dictionary/command/revMoveToNextRecord.lcdoc
+++ b/docs/dictionary/command/revMoveToNextRecord.lcdoc
@@ -5,8 +5,7 @@ Type: command
 Syntax: revMoveToNextRecord <recordSetID>
 
 Summary:
-Moves to the next <record> in a <record set (database
-cursor)(glossary)>. 
+Moves to the next <record> in a <record set (glossary)>. 
 
 Associations: database library
 
@@ -60,8 +59,7 @@ revQueryIsAtEnd (function), revdb_moveprev (function),
 revCurrentRecord (function), revCurrentRecordIsLast (function),
 revNumberOfRecords (function), revDatabaseColumnNumbered (function),
 revdb_movenext (function), Standalone Application Settings (glossary),
-record (glossary), command (glossary),
-record set (database cursor) (glossary),
+record (glossary), command (glossary), record set (glossary),
 standalone application (glossary), database (glossary),
 LiveCode custom library (glossary), Database library (library)
 

--- a/docs/dictionary/command/revMoveToPreviousRecord.lcdoc
+++ b/docs/dictionary/command/revMoveToPreviousRecord.lcdoc
@@ -5,8 +5,7 @@ Type: command
 Syntax: revMoveToPreviousRecord <recordSetID>
 
 Summary:
-Moves to the previous <record> in a <record set (database
-cursor)(glossary)>. 
+Moves to the previous <record> in a <record set (glossary)>. 
 
 Associations: database library
 
@@ -56,7 +55,7 @@ selected set of <record|records>.
 References: revMoveToNextRecord (command), function (control structure),
 revQueryIsAtStart (function), LiveCode custom library (glossary),
 Standalone Application Settings (glossary), record (glossary),
-command (glossary), record set (database cursor) (glossary),
+command (glossary), record set (glossary),
 standalone application (glossary), database (glossary), string (keyword),
 Database library (library)
 

--- a/docs/dictionary/command/revMoveToRecord.lcdoc
+++ b/docs/dictionary/command/revMoveToRecord.lcdoc
@@ -5,7 +5,9 @@ Type: command
 Syntax: revMoveToRecord <recordSetId>, <recordNumber>
 
 Summary:
-Moves to the specified record in a record set (database cursor).
+Moves to the specified record in a <record set>.
+
+Associations: database library
 
 Introduced: 3.5
 
@@ -61,5 +63,6 @@ command will not be supported. The error
 
 References: revMoveToPreviousRecord (command),
 revMoveToNextRecord (command), result (function),
-function (glossary), revOpenDatabase (function)
+function (glossary), revOpenDatabase (function),
+record set (glossary), Database library (library)
 

--- a/docs/dictionary/function/revIsSpeaking.lcdoc
+++ b/docs/dictionary/function/revIsSpeaking.lcdoc
@@ -26,8 +26,8 @@ Returns (bool):
 The <revIsSpeaking> <function> <return|returns> true or false.
 
 Description:
-Use the <revIsSpeaking> <function> to avoid interrupting a <text to
-speech|speech>. 
+Use the <revIsSpeaking> <function> to avoid interrupting a 
+<text to speech|speech>. 
 
 If you execute the <revSpeak> <command> while the computer is already
 speaking, the first speech is stopped and the second speech begins

--- a/docs/dictionary/function/revLoadedStacks.lcdoc
+++ b/docs/dictionary/function/revLoadedStacks.lcdoc
@@ -5,8 +5,8 @@ Type: function
 Syntax: revLoadedStacks([<whichStacks>])
 
 Summary:
-<return|Returns> a list of the names of all <stacks> that are <loaded
-into memory>.
+<return|Returns> a list of the names of all <stacks> that are 
+<loaded into memory>.
 
 Introduced: 1.0
 
@@ -25,8 +25,10 @@ revLoadedStacks()
 
 Parameters:
 whichStacks:
-One of the following
-: One of the following
+* all
+* application
+* preference
+
 
 Returns:
 The <revLoadedStacks> <function> returns a list of the short names of

--- a/docs/dictionary/function/revNumberOfRecords.lcdoc
+++ b/docs/dictionary/function/revNumberOfRecords.lcdoc
@@ -7,8 +7,7 @@ Type: function
 Syntax: revNumberOfRecords(<recordSetID>)
 
 Summary:
-<return|Returns> the number of records in a <record set (database
-cursor)(glossary)>. 
+<return|Returns> the number of records in a <record set (glossary)>. 
 
 Associations: database library
 
@@ -60,10 +59,10 @@ cursors. If the database does not support this feature, the
 
 References: revMoveToNextRecord (command),
 Standalone Application Settings (glossary), record (glossary),
-standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
-SQL query (glossary), LiveCode custom library (glossary),
-function (glossary), string (keyword), Database library (library)
+standalone application (glossary), record set (glossary), 
+return (glossary), SQL query (glossary), 
+LiveCode custom library (glossary), function (glossary), 
+string (keyword), Database library (library)
 
 Tags: database
 


### PR DESCRIPTION
command/revGoToFramePaused.lcdoc - Formatted code example. Changed type of a reference to something appropriate.
command/revGoURL.lcdoc - Formatted second Important note. Removed reference to non-existent library.
command/revInitializeVideoGrabber.lcdoc - Fixed broken links
function/revIsSpeaking.lcdoc - Fixed broken link.
function/revLoadedStacks.lcdoc - Fixed broken link. Listed accepted parameter values.
command/revMailUnicode.lcdoc - Fixed broken link.
command/revMoveFolder.lcdoc - Fixed broken link. Changed one instance of result (glossary) to result (function) and deleted the other one.
command/revMoveToFirstRecord.lcdoc - Fixed broken link. Fixed reference.
command/revMoveToLastRecord.lcdoc - Fixed broken link. Fixed reference.
command/revMoveToNextRecord.lcdoc - Fixed broken link. Fixed reference.
command/revMoveToPreviousRecord.lcdoc - Fixed broken link. Fixed reference.
command/revMoveToRecord.lcdoc - Added references to Database library and record set, common to similar entries.
command/revNumberofRecords.lcdoc - Fixed broken link. Fixed reference.
