### PR TITLE
[[ Bug ]] Fix extension copy resources

### DIFF
--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2133,6 +2133,12 @@ command revSBUpdateSettingsForExtensions pTarget, @xSettingsA
          repeat for each line tLine in tContents
             local tFileData
             put tResourcesFolder & slash & tLine into tFileData["resolved"]
+
+            -- __EnumerateFolder list folders and we only want to add files
+            if there is a folder tFileData["resolved"] then
+               next repeat
+            end if
+
             put tTargetResourceFolder & slash & tLine into tFileData["name"]
             addToList tFileData, xSettingsA["files_computed"]
          end repeat


### PR DESCRIPTION
When extension resources contained folders they were being as though
they were folders andded to copy files which recurses the entire tree
and adds the folder under the leaf name. This patch will ensure that
only files are added. The patch does come with the caveat that extension
resources will not support empty folders.