### PR TITLE
[Dictionary] revPreviewVideo to revSetDatabaseDriverPath

### DIFF
--- a/docs/dictionary/command/revPreviewVideo.lcdoc
+++ b/docs/dictionary/command/revPreviewVideo.lcdoc
@@ -27,8 +27,8 @@ Description:
 Use the <revPreviewVideo> <command> to see the image from a video camera
 on the screen.
 
-You must use the revInitializeVideoGrabber <command> to open the <video
-grabber> before you can use the <revPreviewVideo> <command>.
+You must use the revInitializeVideoGrabber <command> to open the 
+<video grabber> before you can use the <revPreviewVideo> <command>.
 
 The <revPreviewVideo> <command> shows the input from the video source in
 the <video grabber|video grabber window>, but does not record it. To
@@ -66,7 +66,8 @@ execute (glossary), Standalone Application Settings (glossary),
 command (glossary), video grabber (glossary),
 standalone application (glossary), QuickTime (glossary),
 LiveCode custom library (glossary), file (keyword),
-Video library (library)
+Video library (library), dontUseQT (property), 
+dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revPrintField.lcdoc
+++ b/docs/dictionary/command/revPrintField.lcdoc
@@ -28,13 +28,7 @@ revPrintField ("field" && 5) -- prints field 5
 
 Parameters:
 fieldDescriptor:
-Any expression that evaluates to a field reference.>*Important:* The
-revPrintField command does not accept direct field references. For
-example, the following statement causes an error message: revPrintField
-field "My Field" -- CAN'T USE THIS FORM Instead, use a form that
-evaluates to a field reference, like this: : revPrintField the name of
-field "My Field" -- use this form instead revPrintField ("field" &&
-quote & "My Field" & quote) -- or this
+Any expression that evaluates to a field reference.
 
 Description:
 Use the <revPrintField> <command> to print the formatted contents of a

--- a/docs/dictionary/command/revPrintReport.lcdoc
+++ b/docs/dictionary/command/revPrintReport.lcdoc
@@ -5,8 +5,8 @@ Type: command
 Syntax: revPrintReport
 
 Summary:
-Prints a report from the <report viewer|report viewers> on the <current
-card>. 
+Prints a report from the <report viewer|report viewers> on the 
+<current card>. 
 
 Introduced: 2.0
 
@@ -29,10 +29,11 @@ up in the <Report Builder>.
 
 When you use the <Report Builder> to create a set of report settings,
 the settings are stored with the card. The <revPrintReport> <command>
-uses the settings specified in the <Report Builder> for the <current
-card> to print the report. If you have never used the <Report Builder>
-with the <current card> (and therefore there are no report settings to
-use), the <revPrintReport> <command> causes a <error|script error>.
+uses the settings specified in the <Report Builder> for the 
+<current card> to print the report. If you have never used the 
+<Report Builder> with the <current card> (and therefore there are no 
+report settings to use), the <revPrintReport> <command> causes a 
+<error|script error>.
 
 The <revPrintReport> <command> is equivalent to clicking "Print Report"
 in the <Report Builder>.

--- a/docs/dictionary/command/revPrintText.lcdoc
+++ b/docs/dictionary/command/revPrintText.lcdoc
@@ -46,13 +46,7 @@ footerText (string):
 If the footerText is empty, no page footer is printed.
 
 fieldTemplate:
-Any expression that evaluates to a field reference.>*Important:* The
-revPrintText command does not accept direct field references for the
-fieldTemplate parameter. For example, the following statement causes an
-error message: revPrintText myText,,,field "Text" -- CAN'T USE THIS FORM
-Instead, use a form that evaluates to a field reference, like this: :
-revPrintText myText,,,the name of field "Text" -- use this form
-revPrintText myText,,,("field" && quote & "Text" & quote) -- or this
+Any expression that evaluates to a field reference.
 
 Description:
 Use the <revPrintText> <command> to print any text from within a
@@ -120,8 +114,8 @@ To show the standard print dialog box, use the revShowPrintDialog
 >*Tip:*  If the <textToPrint> contains tags, the tags are interpreted as
 > text style information. To print tags literally, set the <text> of a
 > <field(keyword)> to the text you want to print, then use the
-> <htmlText> of that <field(keyword)> as the <textToPrint>. Converting
-> to the <htmlText> escapes the tags and allows them to be printed.
+> <HTMLText> of that <field(keyword)> as the <textToPrint>. Converting
+> to the <HTMLText> escapes the tags and allows them to be printed.
 
 >*Important:*  The <revPrintText> <command> is part of the 
 > <Printing library>. To ensure that the <command> works in a 
@@ -135,19 +129,19 @@ Changes:
 The fieldTemplate parameter was added in version 2.0.
 
 References: revPrintReport (command), answer printer (command),
-platform (function), LiveCode custom library (glossary),
-application (glossary), standalone application (glossary),
-evaluate (glossary), property (glossary), text (glossary),
-execute (glossary), HTML (glossary), command (glossary),
-object reference (glossary), expression (glossary), main stack (glossary),
-group (glossary), Standalone Application Settings (glossary),
-message (glossary), parameter (glossary), statement (glossary),
-handler (glossary), field (keyword), revPrintField (library),
-Printing library (library), library (library), startup (message),
-openBackground (message), preOpenStack (message), openStack (message),
-preOpenCard (message), field (object), textStyle (property),
-properties (property), HTMLText (property), textFont (property),
-textSize (property)
+revPrintField (command), platform (function), 
+LiveCode custom library (glossary), application (glossary), 
+standalone application (glossary), evaluate (glossary), 
+property (glossary), text (glossary), execute (glossary), HTML (glossary), 
+command (glossary), object reference (glossary), expression (glossary), 
+main stack (glossary), group (glossary), 
+Standalone Application Settings (glossary), message (glossary), 
+parameter (glossary), statement (glossary), handler (glossary), 
+field (keyword), Printing library (library), library (library), 
+startup (message), openBackground (message), preOpenStack (message), 
+openStack (message), preOpenCard (message), field (object), 
+textStyle (property), properties (property), HTMLText (property), 
+textFont (property), textSize (property)
 
 Tags: printing
 

--- a/docs/dictionary/command/revRecordVideo.lcdoc
+++ b/docs/dictionary/command/revRecordVideo.lcdoc
@@ -72,7 +72,8 @@ execute (glossary), AVI (glossary),
 Standalone Application Settings (glossary), QuickTime (glossary),
 standalone application (glossary), video grabber (glossary),
 command (glossary), LiveCode custom library (glossary),
-Video library (library)
+Video library (library), dontUseQT (property), 
+dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revRotatePoly.lcdoc
+++ b/docs/dictionary/command/revRotatePoly.lcdoc
@@ -25,16 +25,10 @@ revRotatePoly the name of graphic 3 of stack "Draw", field "Rotate by"
 Parameters:
 graphicReference:
 Any expression that evaluates to a reference to a graphic whose style
-property is set to "line", "curve", or "polygon" .>*Important:* The
-revRotatePoly command does not accept direct graphic references. For
-example, the following statement causes an error message: revRotatePoly
-graphic "My Graphic" ,45 -- CAN'T USE THIS FORM Instead, use a form that
-evaluates to a graphic reference, like this:
+property is set to "line", "curve", or "polygon" .
 
 angleInDegrees:
 A number, or an expression that evaluates to a number.
-: revRotatePoly the name of graphic "My Graphic",90 -- use this form
-revRotatePoly ("field" && quote & "My Field" & quote),22 -- or this
 
 Description:
 Use the <revRotatePoly> <command> to rotate a line, curve, or irregular

--- a/docs/dictionary/command/revSetCardProfile.lcdoc
+++ b/docs/dictionary/command/revSetCardProfile.lcdoc
@@ -28,9 +28,7 @@ The profileName specifies which profile to use.
 
 stackName:
 The short name of an open stack. If you don't specify a stack, the
-current card of the topStack is changed. >*Note:* Although the
-revSetCardProfile command changes a card, you specify a stack name, not
-a card name.
+current card of the topStack is changed. 
 
 Description:
 Use the <revSetCardProfile> <command> to change <property> settings on a

--- a/docs/dictionary/command/revSetDatabaseDriverPath.lcdoc
+++ b/docs/dictionary/command/revSetDatabaseDriverPath.lcdoc
@@ -5,8 +5,8 @@ Type: command
 Syntax: revSetDatabaseDriverPath <driverFolder>
 
 Summary:
-Specifies where the <Database library> should look for <database
-driver|database drivers>.
+Specifies where the <Database library> should look for 
+<database driver|database drivers>.
 
 Associations: database library
 

--- a/docs/dictionary/function/revQueryDatabase.lcdoc
+++ b/docs/dictionary/function/revQueryDatabase.lcdoc
@@ -49,15 +49,16 @@ that evaluate to variable names), separated by commas. As of version
 example "tInputData[myKey]".
 
 arrayName (array):
-The name of a single array variable whose keys are sequential
-numbers.>*Note:* The variable names or arrayName must be enclosed in
+The name of a single array variable whose keys are 
+sequential numbers.
+>*Note:* The variable names or arrayName must be enclosed in
 quotes; otherwise, the variable's value rather than its name is passed
 to the revQueryDatabase function.
 
 
 Returns:
 The <revQueryDatabase> <function> returns a record set ID which
-designates the <record set (database cursor)(glossary)> selected by the
+designates the <record set (glossary)> selected by the
 <SQLQuery>. The record set ID is an <integer>.
 
 Description:
@@ -129,7 +130,7 @@ function (control structure), revQueryIsAtStart (function),
 LiveCode custom library (glossary), variable (glossary), element (glossary),
 standalone application (glossary), binary file (glossary),
 array (glossary), prepend (glossary), SQL query (glossary),
-record set (database cursor) (glossary), return value (glossary),
+record set (glossary), return value (glossary),
 record (glossary), Standalone Application Settings (glossary),
 database (glossary), integer (keyword), element (keyword),
 Database library (library)

--- a/docs/dictionary/function/revQueryIsAtEnd.lcdoc
+++ b/docs/dictionary/function/revQueryIsAtEnd.lcdoc
@@ -29,8 +29,8 @@ The number returned by the revQueryDatabase function when the record set
 was created
 
 Returns:
-The <revQueryIsAtEnd> function returns true if the <revMoveToNextRecord
-command> has been called with the cursor pointing to the last record.
+The <revQueryIsAtEnd> function returns true if the <revMoveToNextRecord>
+<command> has been called with the cursor pointing to the last record.
 
 Description:
 Use the <revQueryIsAtEnd> function to stop when you reach the end of a
@@ -39,6 +39,7 @@ record set.
 If the operation is not successful, the <revQueryIsAtEnd> function
 returns an error message that begins with the string "revdberr"
 
-References: revMoveToNextRecord command (command),
-revMoveToNextRecord (command), revQueryIsAtStart (function)
+References: revMoveToNextRecord (command),
+revMoveToNextRecord (command), revQueryIsAtStart (function),
+command (glossary)
 

--- a/docs/dictionary/function/revQueryResult.lcdoc
+++ b/docs/dictionary/function/revQueryResult.lcdoc
@@ -7,8 +7,8 @@ Type: function
 Syntax: revQueryResult(<recordSetID>)
 
 Summary:
-<return|Returns> the most recent error message associated with a <record
-set (database cursor)(glossary)>.
+<return|Returns> the most recent error message associated with a 
+<record set (glossary)>.
 
 Associations: database library
 
@@ -56,7 +56,7 @@ References: revCommitDatabase (command), function (control structure),
 revdb_commit (function), revDatabaseConnectResult (function),
 Standalone Application Settings (glossary),
 standalone application (glossary),
-record set (database cursor) (glossary), return (glossary),
+record set (glossary), return (glossary),
 SQL (glossary), LiveCode custom library (glossary), string (keyword),
 Database library (library)
 

--- a/docs/dictionary/property/revProfile.lcdoc
+++ b/docs/dictionary/property/revProfile.lcdoc
@@ -41,7 +41,7 @@ When you change the value of a property for an object, the value is
 stored in the object's current profile. If you later switch back to that
 profile, the stored values are restored. For example, if you create a
 profile named "Fluffy" for a button, then set the button's
-backgroundColor <property> to "pink", that setting of the
+<backgroundColor> <property> to "pink", that setting of the
 <backgroundColor> <property> is stored with the Fluffy
 <property profile|profile>. If you later set the <button|button's>
 <property profile|profile> to "Fluffy", the pink color is restored.
@@ -64,7 +64,7 @@ cRevGeneral["profile"].)
 
 References: revSetStackFileProfile (command), object (glossary),
 property (glossary), custom property (glossary),
-backgroundColor (glossary), property profile (glossary), button (object),
+property profile (glossary), button (object), backgroundColor (property),
 customPropertySets (property), gRevAutoCreateProfiles (keyword),
 gRevProfileReadOnly (keyword), Profile library (library)
 


### PR DESCRIPTION
command/revPreviewVideo.lcdoc - Fixed broken link. Added references.
command/revPrintField.lcdoc - Removed redundant Important note.
command/revPrintReport.lcdoc - Fixed broken links.
command/revPrintText.lcdoc - Fixed broken links. Fixed incorrect type of reference.
property/revProfile.lcdoc - Fixed incorrect type of reference.
function/revQueryDatabase.lcdoc - Fixed broken link. Fixed formatting of Note. Fixed broken reference.
function/revQueryIsAtEnd.lcodoc - Fixed broken link. Added reference for the link fix.
function/revQueryResult.lcdoc - Fixed broken link.
command/revRecordVideo.lcdoc - Added missing references.
command/revRotatePoly.lcdoc - Removed redundant note.
command/revSetCardProfile.lcdoc - Remove redundant note.
command/revSetDatabaseDriverPath.lcdoc - Fixed broken link.