### PR TITLE
[[ Bug 21726 ]] Fix crash when using inf in math ops

### DIFF
--- a/docs/notes/bugfix-21726.md
+++ b/docs/notes/bugfix-21726.md
@@ -1,0 +1,1 @@
+# Fix crash when using "inf" in mathematical ops 

--- a/engine/src/exec-math.cpp
+++ b/engine/src/exec-math.cpp
@@ -590,7 +590,7 @@ void MCMathEvalMultiply(MCExecContext& ctxt, real64_t p_left, real64_t p_right, 
 	if (r_result == MCinfinity || MCS_geterrno() != 0)
 	{
 		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_PLUS_RANGE);
+		ctxt.LegacyThrow(EE_MULTIPLY_RANGE);
 		return;
 	}
 }

--- a/engine/src/operator.h
+++ b/engine/src/operator.h
@@ -171,10 +171,10 @@ public:
                 Eval(ctxt, t_left . double_value, t_right . double_value, r_value . double_value);
         }
         
-        if (ctxt . HasError())
-            MCExecTypeRelease(r_value);
-        else
+        if (!ctxt . HasError())
+        {
             r_value . type = t_left . type;
+        }
 
         if (t_left . type == kMCExecValueTypeArrayRef)
             MCValueRelease(t_left . arrayref_value);
@@ -243,12 +243,13 @@ public:
                 Eval(ctxt, t_left . double_value, t_right . double_value, r_value . double_value);
         }
         
-        if (ctxt . HasError())
-            MCExecTypeRelease(r_value);
-        else if (t_left . type == kMCExecValueTypeDouble && t_right . type == kMCExecValueTypeDouble)
-            r_value . type = kMCExecValueTypeDouble;
-        else
-            r_value . type = kMCExecValueTypeArrayRef;
+        if (!ctxt . HasError())
+        {
+            if (t_left . type == kMCExecValueTypeDouble && t_right . type == kMCExecValueTypeDouble)
+                r_value . type = kMCExecValueTypeDouble;
+            else
+                r_value . type = kMCExecValueTypeArrayRef;
+        }
 
         if (t_left . type == kMCExecValueTypeArrayRef)
             MCValueRelease(t_left . valueref_value);

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -304,7 +304,7 @@ on TestAssertBroken pDescription, pExpectTrue, pReasonBroken
    _TestOutput pExpectTrue, pDescription, "TODO", pReasonBroken
 end TestAssertBroken
 
-on TestAssertThrow pDescription, pHandler, pTarget, pErrorCodes, pParam
+function _TestHandlerThrows pHandler, pTarget, pErrorCodes, pParam
    local tError
    try
       dispatch pHandler to pTarget with pParam
@@ -319,9 +319,20 @@ on TestAssertThrow pDescription, pHandler, pTarget, pErrorCodes, pParam
       put tSuccess and __TestErrorMatches(tError, tErrorCode) into tSuccess
       delete the first line of tError
    end repeat
+   return tSuccess
+end _TestHandlerThrows
 
+on TestAssertThrow pDescription, pHandler, pTarget, pErrorCodes, pParam
+   local tSuccess
+   put _TestHandlerThrows(pHandler, pTarget, pErrorCodes, pParam) into tSuccess
    TestAssert pDescription, tSuccess
 end TestAssertThrow
+
+on TestAssertBrokenThrow pDescription, pHandler, pReason, pTarget, pErrorCodes, pParam
+   local tSuccess
+   put _TestHandlerThrows(pHandler, pTarget, pErrorCodes, pParam) into tSuccess
+   TestAssertBroken pDescription, tSuccess, pReason
+end TestAssertBrokenThrow
 
 on TestAssertDoesNotThrow pDescription, pHandler, pTarget, pParam
   local tError

--- a/tests/lcs/core/math/infinity.livecodescript
+++ b/tests/lcs/core/math/infinity.livecodescript
@@ -1,0 +1,56 @@
+script "CoreMathInfinity"
+/*
+Copyright (C) 2018 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+command _TestInfinityDivOperator
+    get inf div 1 is inf
+end _TestInfinityDivOperator
+
+on TestInfinityDivOperator
+    TestAssertBrokenThrow "Infinity is unchanged by div operator", "_TestInfinityDivOperator", "Bug 14316", \
+        the long id of me, "EE_DIV_RANGE"
+end TestInfinityDivOperator
+
+on TestInfinitySubtractOperator
+    TestAssert "Infinity is unchanged by subtract operator", inf - 1 is inf
+end TestInfinitySubtractOperator
+
+on TestInfinityOverOperator
+   TestAssert "Infinity is unchanged by over operator", inf / 2 is inf
+end TestInfinityOverOperator
+
+on TestInfinityAddOperator
+   TestAssert "Infinity is unchanged by add operator", inf + 1 is inf
+end TestInfinityAddOperator
+
+command _TestInfinityMultiplyOperator
+    get inf * 2 is inf
+end _TestInfinityMultiplyOperator
+
+on TestInfinityMultiplyOperator
+    TestAssertBrokenThrow "Infinity is unchanged by multiply operator", "_TestInfinityMultiplyOperator", "Bug 14316", \
+        the long id of me, "EE_MULTIPLY_RANGE"
+end TestInfinityMultiplyOperator
+
+command _TestInfinityPowerOperator
+    get inf ^ 2 is inf
+end _TestInfinityPowerOperator
+
+on TestInfinityPowerOperator
+    TestAssertBrokenThrow "Infinity is unchanged by power operator", "_TestInfinityPowerOperator", "Bug 14316", \
+        the long id of me, "EE_POW_RANGE"
+end TestInfinityPowerOperator


### PR DESCRIPTION
- Fix crash caused by releasing uninitialised exec value
- Add tests for arithmetic ops being identity on `inf`
- Add broken throws test handler for things that throw that shouldn't
- Add broken throws tests for `div`, `*` and `^` when acting on `inf`, which currently throw
- Fix incorrect error message for `*` range error